### PR TITLE
XBOX1 D3D8 driver fixes

### DIFF
--- a/msvc/RetroArch-Xbox1/RetroArch-Xbox1.vcproj
+++ b/msvc/RetroArch-Xbox1/RetroArch-Xbox1.vcproj
@@ -172,7 +172,13 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="3"
+				GlobalOptimizations="TRUE"
+				InlineFunctionExpansion="2"
+				EnableIntrinsicFunctions="TRUE"
+				ImproveFloatingPointConsistency="TRUE"
+				FavorSizeOrSpeed="1"
 				OmitFramePointers="TRUE"
+				EnableFiberSafeOptimizations="TRUE"
 				OptimizeForProcessor="2"
 				AdditionalIncludeDirectories="&quot;$(SolutionDir)\msvc-stdint&quot;;&quot;$(SolutionDir)\msvc-71&quot;"
 				PreprocessorDefinitions="NDEBUG;_XBOX;_XBOX1;RARCH_CONSOLE;HAVE_XINPUT_XBOX1;PACKAGE_VERSION=\&quot;0.9.6\&quot;;__STDC_CONSTANT_MACROS;HAVE_ZLIB;HAVE_GRIFFIN;inline=_inline;HAVE_RARCH_MAIN_WRAP;HAVE_LIBRETRO_MANAGEMENT;HAVE_RARCH_EXEC;HAVE_DEFAULT_RETROPAD_INPUT;HAVE_CONFIGFILE;HAVE_VID_CONTEXT;HAVE_DSOUND;HAVE_D3D8"

--- a/xbox1/xdk_d3d8.h
+++ b/xbox1/xdk_d3d8.h
@@ -14,8 +14,8 @@
  *  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _XDK360_VIDEO_H
-#define _XDK360_VIDEO_H
+#ifndef _XDK_VIDEO_H
+#define _XDK_VIDEO_H
 
 #include <stdint.h>
 
@@ -77,7 +77,10 @@ typedef struct xdk_d3d_video
    LPDIRECT3DDEVICE_PTR d3d_render_device;
    LPDIRECT3DVERTEXBUFFER_PTR vertex_buf;
    LPDIRECT3DTEXTURE_PTR lpTexture;
+   D3DTexture lpTexture_ot_as16srgb;
+   LPDIRECT3DTEXTURE_PTR lpTexture_ot;
    D3DPRESENT_PARAMETERS d3dpp;
+   LPDIRECT3DSURFACE_PTR lpSurface;
 } xdk_d3d_video_t;
 
 #endif


### PR DESCRIPTION
Fixed: Garbled output which was caused by missing and faulty D3D formats …
Fixed: Minor speedup for Release build, see project properties-> C/C++ ->Optimization
Fixed: Texture scaling issue, at least it displays full screen now, it may still need some work though
