### PR TITLE
(Xbox 1) Fixed screen residues from temporary messages appearing in certain viewports

### DIFF
--- a/gfx/fonts/xdk1_xfonts.c
+++ b/gfx/fonts/xdk1_xfonts.c
@@ -27,13 +27,13 @@ void xfonts_render_msg_place(void *data, float x, float y, float scale, const ch
    xdk_d3d_video_t *d3d = (xdk_d3d_video_t*)data;
 
    d3d->d3d_render_device->GetBackBuffer(-1, D3DBACKBUFFER_TYPE_MONO, &d3d->pFrontBuffer);
-   d3d->d3d_render_device->GetBackBuffer(0, D3DBACKBUFFER_TYPE_MONO, &d3d->pBackBuffer);
+   //d3d->d3d_render_device->GetBackBuffer(0, D3DBACKBUFFER_TYPE_MONO, &d3d->pBackBuffer);
 
    wchar_t str[256];
    convert_char_to_wchar(str, msg, sizeof(str));
    d3d->debug_font->TextOut(d3d->pFrontBuffer, str, (unsigned)-1, x, y);
-   d3d->debug_font->TextOut(d3d->pBackBuffer, str, (unsigned)-1, x, y);
+   //d3d->debug_font->TextOut(d3d->pBackBuffer, str, (unsigned)-1, x, y);
 
    d3d->pFrontBuffer->Release();
-   d3d->pBackBuffer->Release();
+   //d3d->pBackBuffer->Release();
 }

--- a/xbox1/xdk_d3d8.cpp
+++ b/xbox1/xdk_d3d8.cpp
@@ -22,7 +22,7 @@
 #include "../driver.h"
 #include "xdk_d3d8.h"
 
-#include "../../gfx/fonts/xdk1_xfonts.h"
+#include "./../gfx/fonts/xdk1_xfonts.h"
 #include "./../gfx/gfx_context.h"
 #include "../general.h"
 #include "../message.h"


### PR DESCRIPTION
(Xbox 1) Fixed screen residues from temporary messages appearing in certain viewports
(Xbox 1) Fixed include typo in xdk_d3d8.cpp
