### PR TITLE
Fixed invalid regexp for Colin McRae games

### DIFF
--- a/tools/retrolaunch/launch.conf
+++ b/tools/retrolaunch/launch.conf
@@ -68,7 +68,7 @@
 "ps1.Chippoke Ralph no Daibouken (Adventure of Little Ralph)" mednafen-psx dualanalog ;
 "ps1.Chocobo Racing" mednafen-psx dualanalog ;
 "ps1.Chrono Cross*" pcsxr dualanalog ;
-"ps1.Colin Mc[rR]rae*" mednafen-psx dualanalog ;
+"ps1.Colin Mc[rR]ae*" mednafen-psx dualanalog ;
 "ps1.Colony Wars*" mednafen-psx dualanalog ;
 "ps1.Cosmowarrior Rei" mednafen-psx dualanalog ;
 "ps1.Cowboy Bebop" mednafen-psx dualanalog ;


### PR DESCRIPTION
The regexp for Colin McRae games was wrong and wouldn't have matched anything. This PR corrects it.
