### PR TITLE
(BlackBerry) Get input overlay to show when booting to RGUI

### DIFF
--- a/driver.c
+++ b/driver.c
@@ -285,6 +285,15 @@ void global_init_drivers(void)
    driver.video->start(); // Statically starts video driver. Sets driver.video_data.
 #endif
    driver.input_data = driver.input->init();
+
+#ifdef HAVE_OVERLAY
+   if (*g_settings.input.overlay)
+   {
+      driver.overlay = input_overlay_new(g_settings.input.overlay);
+      if (!driver.overlay)
+	     RARCH_ERR("Failed to load overlay.\n");
+   }
+#endif
 }
 
 void global_uninit_drivers(void)

--- a/frontend/frontend_bbqnx.c
+++ b/frontend/frontend_bbqnx.c
@@ -28,6 +28,9 @@ int rarch_main(int argc, char *argv[])
 
    rarch_main_clear_state();
 
+   strcpy(g_extern.config_path,"app/native/retroarch.cfg");
+   strcpy(g_settings.libretro,"app/native/lib");
+
    config_load();
    global_init_drivers();
 


### PR DESCRIPTION
You still need to hard code the overlay path in retroarch.cfg. This should let you choose a core, a rom and boot it up. The overlay covers parts of RGUI which makes it hard to navigate sometimes. Might have to change the aspect ratio or width.
