### PR TITLE
(BlackBerry) Fix PlayBook crash

### DIFF
--- a/driver.c
+++ b/driver.c
@@ -320,7 +320,7 @@ void global_uninit_drivers(void)
 {
    if (driver.video_data)
    {
-#if defined(RARCH_CONSOLE) || defined(__BLACKBERRY_QNX__)
+#ifdef RARCH_CONSOLE
       driver.video->stop();
 #endif
       driver.video_data = NULL;

--- a/frontend/frontend_bbqnx.c
+++ b/frontend/frontend_bbqnx.c
@@ -34,7 +34,8 @@ int rarch_main(int argc, char *argv[])
    strlcpy(g_settings.libretro, "app/native/lib", sizeof(g_settings.libretro));
 
    config_load();
-   global_init_drivers();
+   init_drivers_pre();
+   init_drivers();
 
    g_extern.verbose = true;
 
@@ -55,7 +56,7 @@ int rarch_main(int argc, char *argv[])
 	     if (g_extern.main_is_init)
 	        rarch_main_deinit();
 	     else
-	        global_uninit_drivers();
+	        uninit_drivers();
 
 	     struct rarch_main_wrap args = {0};
 


### PR DESCRIPTION
You'll probably want to take a look at the changes. It looks like the crash was caused by a couple different things. The main one was that on PB, it doesn't look like you can create another surface without destroying the first (EGL_BAD_ALLOC). We created one for RGUI at the start, then recreated it for the core. Once I called uninit, then I couldn't reinit EGL anymore. Not releasing the EGL thread fixed that on the PB. That was my first commit here, but it caused BB10 to crash while setting up the core (a side effect of calling uninit I think). I tried to mimic how a core is launched when setting up RGUI as that always seemed to work, by using init_drivers rather than global_init_drivers. It's working on both now, though let me know if this isn't the best way.
