### PR TITLE
Ping SDL input driver before linux raw driver.

### DIFF
--- a/input/input_common.c
+++ b/input/input_common.c
@@ -44,11 +44,11 @@ static const rarch_joypad_driver_t *joypad_drivers[] = {
 #ifdef HAVE_DINPUT
    &dinput_joypad,
 #endif
-#if defined(__linux) && !defined(ANDROID)
-   &linuxraw_joypad,
-#endif
 #ifdef HAVE_SDL
    &sdl_joypad,
+#endif
+#if defined(__linux) && !defined(ANDROID)
+   &linuxraw_joypad,
 #endif
 #endif
    NULL,


### PR DESCRIPTION
This fixes the odd behaviour of not being able to configure the joystick with retroarch-joyconfig because always picking up the wrong driver.

Best solution would be a configurable option for input_driver in retroarch-joyconfig as well.
