### PR TITLE
Wait for all user input to be released before re-activating the core

### DIFF
--- a/frontend/frontend.c
+++ b/frontend/frontend.c
@@ -76,6 +76,12 @@ int main(int argc, char *argv[])
       }
       else if (g_extern.lifecycle_mode_state & (1ULL << MODE_GAME))
       {
+         // wait until all user input is released
+         while (0x0 != rgui_input()) {
+             usleep(1000);
+             rarch_input_poll();
+         }
+
          while ((g_extern.is_paused && !g_extern.is_oneshot) ? rarch_main_idle_iterate() : rarch_main_iterate());
          g_extern.lifecycle_mode_state &= ~(1ULL << MODE_GAME);
       }


### PR DESCRIPTION
Wait for all user input to be released before re-activating the core; this prevents undesired button releases (for A,B for example) being passed to the core.

**Please check** for side effects of calling _rgui_input()_ and _rarch_input_poll()_ in that context, I didn't check them.
Also the usleep() call could be tuned to a different value or removed completely - depending on your judgement.
