### PR TITLE
(BlackBerry) Fix a few overlay issues.

### DIFF
--- a/blackberry-qnx/qnx_input.c
+++ b/blackberry-qnx/qnx_input.c
@@ -535,6 +535,7 @@ static int16_t qnx_input_state(void *data, const struct retro_keybind **retro_ke
                return ((port_device[port]->buttons & retro_keybinds[port][id].joykey) && (port < pads_connected));
             }
          }
+         break;
 #ifdef HAVE_BB10
       case RETRO_DEVICE_ANALOG:
          //Need to return [-0x8000, 0x7fff]


### PR DESCRIPTION
So bad mistake on my part. A missed break in a case statement caused joypad scans to fall through to the touchscreen. Caused bad key presses on unmapped players. The other fixes are due to the bezel on PlayBook/BB10 extending past the screen resolution causing touches to wrap around. Also make sure RETRO_DEVICE_POINTER is handled properly.

Give it a try to make sure it fixes the issues you've seen with MAME and other cores.
