### PR TITLE
(Android) Fix regression in Xperia Play controls

### DIFF
--- a/android/native/jni/input_autodetect.c
+++ b/android/native/jni/input_autodetect.c
@@ -231,7 +231,7 @@ void input_autodetect_setup (void *data, char *msg, size_t sizeof_msg, unsigned 
          snprintf(name_buf, sizeof(name_buf), "ccpcreations WiiUse");
       }
 
-      if (source == AINPUT_SOURCE_KEYBOARD)
+      if (source == AINPUT_SOURCE_KEYBOARD && device != DEVICE_XPERIA_PLAY)
          device = DEVICE_KEYBOARD_RETROPAD;
 
       if (driver.input->set_keybinds)


### PR DESCRIPTION
Regression introduced in commit
4fa8d0f3c6f9c37c30a4628da81023606c91f9e2

Confirmed working on Xperia Play R800x (US Verizon model), stock
firmware, Gingerbread 2.3.3, no OTA updates, not rooted.
