### PR TITLE
(BlackBerry) Fix up core_info usage after cleanup.

### DIFF
--- a/blackberry-qnx/bb10/bar-descriptor.xml
+++ b/blackberry-qnx/bb10/bar-descriptor.xml
@@ -69,7 +69,7 @@
     <asset path="../../media/overlays">overlays</asset>
     <asset path="assets">assets</asset>
     <asset path="assets/images/icon.png">icon.png</asset>
-    <asset path="../../ios/modules">modules</asset>
+    <asset path="../../ios/modules">lib</asset>
 
     
     <!-- Bright theme is used for this application. --> 

--- a/blackberry-qnx/bb10/src/RetroArch-Cascades.cpp
+++ b/blackberry-qnx/bb10/src/RetroArch-Cascades.cpp
@@ -87,7 +87,7 @@ RetroArch::RetroArch()
          //Get core DropDown reference to populate it in C++
          coreSelection = mAppPane->findChild<DropDown*>("dropdown_core");
          connect(coreSelection, SIGNAL(selectedValueChanged(QVariant)), this, SLOT(onCoreSelected(QVariant)));
-         core_info_list = get_core_info_list("/app/native/modules/");
+         core_info_list = get_core_info_list(g_settings.libretro);
          populateCores(core_info_list);
 
          Application::instance()->setScene(mAppPane);
@@ -246,7 +246,6 @@ void RetroArch::onCoreSelected(QVariant value)
    coreSelectedIndex = value.toInt();
 
    core.clear();
-   core.append("app/native/lib/");
    core.append(core_info_list->list[coreSelectedIndex].path);
    emit coreChanged(core);
 


### PR DESCRIPTION
Few things broke after the cleanup.
