### PR TITLE
Android: Fixes for iPega PG-9017 support

### DIFF
--- a/android/native/jni/input_android.c
+++ b/android/native/jni/input_android.c
@@ -326,6 +326,8 @@ static void android_input_set_keybinds(void *data, unsigned device,
       // NOTE - we have to add '1' to the bit mask because
       // RETRO_DEVICE_ID_JOYPAD_B is 0
 
+      RARCH_LOG("Detecting keybinds. Device %u port %u id %u keybind_action %u\n", device, port, id, keybind_action);
+
       switch (device)
       {
          case DEVICE_LOGITECH_RUMBLEPAD2:
@@ -1224,14 +1226,14 @@ static void android_input_set_keybinds(void *data, unsigned device,
             keycode_lut[AKEYCODE_BUTTON_START] |= ((RETRO_DEVICE_ID_JOYPAD_START+1) << shift);
             break;
          case DEVICE_BROADCOM_BLUETOOTH_HID:
+            RARCH_LOG("Bluetooth HID\n");
             if ((g_settings.input.icade_count +1) < 4)
             {
                g_settings.input.device[port] = device;
-               strlcpy(g_settings.input.device_names[port], "Broadcom Bluetooth HID",
-                     sizeof(g_settings.input.device_names[port]));
                g_settings.input.icade_count++;
+               RARCH_LOG("Using icade profile %u\n", g_settings.input.icade_count - 1);
 
-               switch(g_settings.input.icade_profile[g_settings.input.icade_count])
+               switch(g_settings.input.icade_profile[g_settings.input.icade_count - 1])  /* was just incremented... */
                {
                   case ICADE_PROFILE_RED_SAMURAI:
                      /* TODO: unsure about Select button here */
@@ -1242,6 +1244,8 @@ static void android_input_set_keybinds(void *data, unsigned device,
                       * RStick Right: 40 */
 
                      /* Red Samurai */
+                     strlcpy(g_settings.input.device_names[port], "Red Samurai",
+                        sizeof(g_settings.input.device_names[port]));
                      keycode_lut[AKEYCODE_W]   |= ((RETRO_DEVICE_ID_JOYPAD_UP+1)    << shift);
                      keycode_lut[AKEYCODE_S] |= ((RETRO_DEVICE_ID_JOYPAD_DOWN+1)    << shift);
                      keycode_lut[AKEYCODE_A] |= ((RETRO_DEVICE_ID_JOYPAD_LEFT+1)    << shift);
@@ -1266,17 +1270,28 @@ static void android_input_set_keybinds(void *data, unsigned device,
                      keycode_lut[AKEYCODE_4] |=  ((RETRO_DEVICE_ID_JOYPAD_X+1)      << shift);
                      break;
                   case ICADE_PROFILE_IPEGA_PG9017:
+                     strlcpy(g_settings.input.device_names[port], "iPega PG-9017",
+                        sizeof(g_settings.input.device_names[port]));
                      /* Todo: diagonals - patchy? */
-                     keycode_lut[AKEYCODE_BUTTON_1] |=  ((RETRO_DEVICE_ID_JOYPAD_Y+1)      << shift);
-                     keycode_lut[AKEYCODE_BUTTON_2] |=  ((RETRO_DEVICE_ID_JOYPAD_X+1)      << shift);
-                     keycode_lut[AKEYCODE_BUTTON_3] |=  ((RETRO_DEVICE_ID_JOYPAD_B+1)      << shift);
-                     keycode_lut[AKEYCODE_BUTTON_4] |=  ((RETRO_DEVICE_ID_JOYPAD_A+1)      << shift);
-                     keycode_lut[AKEYCODE_BUTTON_5] |=  ((RETRO_DEVICE_ID_JOYPAD_L+1)      << shift);
-                     keycode_lut[AKEYCODE_BUTTON_6] |=  ((RETRO_DEVICE_ID_JOYPAD_R+1)      << shift);
-                     keycode_lut[AKEYCODE_BUTTON_9] |=  ((RETRO_DEVICE_ID_JOYPAD_SELECT+1)      << shift);
-                     keycode_lut[AKEYCODE_BUTTON_10] |=  ((RETRO_DEVICE_ID_JOYPAD_START+1)      << shift);
+                     /* This maps to SNES layout, not button labels on gamepad -- SNES layout has A to the right of B */
+                     keycode_lut[AKEYCODE_BUTTON_1]  |= ((RETRO_DEVICE_ID_JOYPAD_Y+1)      << shift); /* Button labeled X on gamepad */
+                     keycode_lut[AKEYCODE_BUTTON_2]  |= ((RETRO_DEVICE_ID_JOYPAD_B+1)      << shift); /* Button labeled A on gamepad */
+                     keycode_lut[AKEYCODE_BUTTON_3]  |= ((RETRO_DEVICE_ID_JOYPAD_A+1)      << shift); /* Button labeled B on gamepad */
+                     keycode_lut[AKEYCODE_BUTTON_4]  |= ((RETRO_DEVICE_ID_JOYPAD_X+1)      << shift); /* Button labeled Y on gamepad */
+                     keycode_lut[AKEYCODE_BUTTON_5]  |= ((RETRO_DEVICE_ID_JOYPAD_L+1)      << shift);
+                     keycode_lut[AKEYCODE_BUTTON_6]  |= ((RETRO_DEVICE_ID_JOYPAD_R+1)      << shift);
+                     keycode_lut[AKEYCODE_BUTTON_9]  |= ((RETRO_DEVICE_ID_JOYPAD_SELECT+1) << shift);
+                     keycode_lut[AKEYCODE_BUTTON_10] |= ((RETRO_DEVICE_ID_JOYPAD_START+1)  << shift);
+                     /* These don't work, the dpad seems to send motion events instead of button events, so they get processed by
+                        engine_handle_dpad_getaxisvalue() but it gets values of 0 for all axes... */
+                     keycode_lut[AKEYCODE_DPAD_UP]   |= ((RETRO_DEVICE_ID_JOYPAD_UP+1)     << shift);
+                     keycode_lut[AKEYCODE_DPAD_DOWN] |= ((RETRO_DEVICE_ID_JOYPAD_DOWN+1)   << shift);
+                     keycode_lut[AKEYCODE_DPAD_LEFT] |= ((RETRO_DEVICE_ID_JOYPAD_LEFT+1)   << shift);
+                     keycode_lut[AKEYCODE_DPAD_RIGHT]|= ((RETRO_DEVICE_ID_JOYPAD_RIGHT+1)  << shift);
                      break;
                   case ICADE_PROFILE_GAMESTOP_WIRELESS:
+                     strlcpy(g_settings.input.device_names[port], "Gamestop Wireless",
+                        sizeof(g_settings.input.device_names[port]));
                      keycode_lut[AKEYCODE_W] |=  ((RETRO_DEVICE_ID_JOYPAD_UP+1)      << shift);
                      keycode_lut[AKEYCODE_S] |=  ((RETRO_DEVICE_ID_JOYPAD_DOWN+1)      << shift);
                      keycode_lut[AKEYCODE_A] |=  ((RETRO_DEVICE_ID_JOYPAD_LEFT+1)      << shift);

--- a/android/phoenix/res/xml/prefs.xml
+++ b/android/phoenix/res/xml/prefs.xml
@@ -189,25 +189,25 @@
             <ListPreference
                 android:entries="@array/icade_profiles"
                 android:entryValues="@array/icade_profiles_values"
-                android:key="input_autodetect_icade_profile_pad0"
+                android:key="input_autodetect_icade_profile_pad1"
                 android:summary="Select the iCade profile to use for controller 1."
                 android:title="iCade profile Pad 1" />
             <ListPreference
                 android:entries="@array/icade_profiles"
                 android:entryValues="@array/icade_profiles_values"
-                android:key="input_autodetect_icade_profile_pad1"
+                android:key="input_autodetect_icade_profile_pad2"
                 android:summary="Select the iCade profile to use for controller 2."
                 android:title="iCade profile Pad 2" />
             <ListPreference
                 android:entries="@array/icade_profiles"
                 android:entryValues="@array/icade_profiles_values"
-                android:key="input_autodetect_icade_profile_pad2"
+                android:key="input_autodetect_icade_profile_pad3"
                 android:summary="Select the iCade profile to use for controller 3."
                 android:title="iCade profile Pad 3" />
             <ListPreference
                 android:entries="@array/icade_profiles"
                 android:entryValues="@array/icade_profiles_values"
-                android:key="input_autodetect_icade_profile_pad3"
+                android:key="input_autodetect_icade_profile_pad4"
                 android:summary="Select the iCade profile to use for controller 4."
                 android:title="iCade profile Pad 4" />
         </PreferenceCategory>


### PR DESCRIPTION
Hello,

Some small fixes to improve autodetection of iPega PG-9017 bluetooth controller in RetroArch Android.

This comes with a small question: In general, I think most bluetooth controllers look similar to a SNES controller. When autodetecting them, do you generally assign buttons in the SNES layout? For example, look at this screenshot:

http://img.dxcdn.com/productimages/sku_172963_9.jpg

You will see the iPega has the X button to the left of Y, and A to the left of B. This is the opposite of SNES layout. In my change, I have made sure that the physical buttons are laid out like in the SNES, so the button labeled X on the iPega is actually mapped to the Y button input in RetroArch, so that the SNES emulator sees it as the Y button. I think that's what you did for other controllers too.

But what happens for example with the Genesis emulators? If you treat every controller as having an SNES layout, where do the Genesis A, B and C buttons fall on an SNES controller?

It's a minor thing, and I've tried a Genesis game or two and it seems A=SNES_Y, B=SNES_B and C=SNES_A, which is logical and comfortable, but I just wanted to make sure that was the intention and that it works for all controllers.

Back to my change. I fixed two small bugs that affected the selection of iCade profiles when a device called "Broadcom Bluetooth HID" was detected. There were two separate off-by-one errors that meant that to use the iPega on the first detected pad, iCade profile for pad 3 had to be set to iPega! :-)

I also fixed the button assignments as mentioned above to match the SNES physical layout. And I added some logging and an accurate controller name when detecting generic "iCade profile" controllers, so we know a bit more what's going on.

With those fixed, I can use my iPega by setting iCade profile for pad 1 to "iPega PG-9017". The last thing that doesn't work is the d-pad, I mention that in a comment in my code change. I don't know how to fix that, because when I turn on input debugging, I see that the d-pad seems to be sending motion events (it goes in the `if (type_event == AINPUT_EVENT_TYPE_MOTION)` branch) but with an axis value of 0 for every axis. No button events are sent, whether using the autodetection or a custom mapping. I don't understand that at all, because in other emulators on Android (for example SNESdroid) I can do custom mapping, set the values for the dpad buttons, and they work fine. Note that even in RetroArch, the dpad works well when in the ROM selection interface, just not when in a libretro core. That kind of hints to some setting being changed when the libretro core is loaded, leading to the dpad sending motion events instead of button press events? Or the Android API converting the dpad's button events to motion events behind our back before sending the events to our app? I don't know enough about how Android interfaces with the controller to know what that might be. But it's a major bummer!

Last thing: Actually I think it may be more accurate to change the term "iCade profile" to "generic bluetooth controller profile", because iCade is used for other things (among others, the iPega has an iCade-specific mode) and using the term iCade there might lead to some confusion (users thinking they need to use the iPega in iCade mode, which is not the case). But I'll leave that open for discussion, it can be modified later if you agree to change the term.

So here are the changes, let me know if you have any comments or want me to change anything.

`android/native/jni/input_android.c`:
- Fixed off-by-one when using g_settings.input.icade_count to index in array of icade profiles. It has just been incremented...
- Added setting actual device names instead of generic "Broadcom Bluetooth HID" so the libretro menu shows it. Also added a bit of logging when detecting generic devices and selecting an icade profile.
- Fixed some wrong button assignments for iPega controller.
- Added a note about the dpad buttons not working, it's the next thing I want to fix.

`android/phoenix/res/xml/prefs.xml`:
- Fixed key names for icade profiles, input_autodetect_icade_profile_pad0 does not exist in the config as given in the root settings.c file, they start at 1.
