### PR TITLE
Auto save state before the emulator freezes

### DIFF
--- a/apple/RetroArch/main.m
+++ b/apple/RetroArch/main.m
@@ -271,7 +271,7 @@ int main(int argc, char *argv[])
 // Prevent game to crash when receiving a call
 - (void)applicationWillResignActive:(UIApplication *)application
 {
-    save_auto_state();
+    rarch_save_auto_state();
 }
 
 // UINavigationControllerDelegate

--- a/general.h
+++ b/general.h
@@ -697,6 +697,7 @@ void rarch_take_screenshot(void);
 
 void rarch_load_state(void);
 void rarch_save_state(void);
+void rarch_save_auto_state(void);
 void rarch_state_slot_increase(void);
 void rarch_state_slot_decrease(void);
 /////////

--- a/retroarch.c
+++ b/retroarch.c
@@ -1854,7 +1854,7 @@ static void load_auto_state(void)
    }
 }
 
-void save_auto_state(void)
+void rarch_save_auto_state(void)
 {
    if (!g_settings.savestate_auto_save)
       return;
@@ -3084,7 +3084,7 @@ void rarch_main_deinit(void)
 #endif
 
    if (!g_extern.libretro_dummy && !g_extern.libretro_no_rom)
-      save_auto_state();
+      rarch_save_auto_state();
 
    pretro_unload_game();
    pretro_deinit();


### PR DESCRIPTION
It's a known issue that when emulator is running on iOS and the device gets a call or the alarm rings the emulator freezes and the only thing you can do is force closing RetroArch and open it again. In this process the game state is not saved and the player loses all the progress.

I tried to fix this bug, but I lacked knowledge. I did a simple workaround to auto save the state when the application will change from active to inactive. Thereby the player's progress is not lost.
