### PR TITLE
.gitignore dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,14 @@ DerivedData
 apple/tmp
 apple/modules/*.dylib
 apple/*.mobileprovision
+/Cg/
+/GL/
+/SDL/
+/ffmpeg/
+/freetype2/
+/ft2build.h
+/iconv.h
+/libxml2/
+/phoenix/
+/python/
+/rsound.h


### PR DESCRIPTION
Windows build instructions say to put these in your retroarch directory, where they will clutter up git status.
