### PR TITLE
Load external rom - #2

### DIFF
--- a/android/phoenix/src/org/retroarch/browser/MainMenuActivity.java
+++ b/android/phoenix/src/org/retroarch/browser/MainMenuActivity.java
@@ -36,12 +36,6 @@ public class MainMenuActivity extends PreferenceActivity {
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
-		Intent startedByIntent = getIntent();
-		if (null != startedByIntent.getStringExtra("ROM")
-				&& null != startedByIntent.getStringExtra("LIBRETRO")) {
-			loadRomExternal(startedByIntent.getStringExtra("ROM"),
-					startedByIntent.getStringExtra("LIBRETRO"));
-		}
 		instance = this;
 		addPreferencesFromResource(R.xml.prefs);
 		PreferenceManager.setDefaultValues(this, R.xml.prefs, false);
@@ -90,6 +84,18 @@ public class MainMenuActivity extends PreferenceActivity {
 			libretro_path = MainMenuActivity.getInstance().getApplicationInfo().nativeLibraryDir;
 			libretro_name = "No core";
 			setCoreTitle("No core");
+		}
+		Intent startedByIntent = getIntent();
+		if (null != startedByIntent.getStringExtra("ROM")
+				&& null != startedByIntent.getStringExtra("LIBRETRO")) {
+			if (prefs.getInt("loadRomExternal", 0) == 0) {
+				loadRomExternal(startedByIntent.getStringExtra("ROM"),
+						startedByIntent.getStringExtra("LIBRETRO"));
+				prefs.edit().putInt("loadRomExternal", 1).commit();
+			} else{
+				prefs.edit().putInt("loadRomExternal", 0).commit();
+				super.onBackPressed();
+			}
 		}
 	}
 


### PR DESCRIPTION
My previous commit caused RetroArch to crash when back button was pressed, so I fixed the issue.
Another problem came out, if back was pressed the rom was reloaded, so I added a value in sharedpreferences to be checked, to make retroarch understand if it has to move back to the caller application or load a rom.

However, if the back behavior is set to show menu instead of quit, the value isn't updated and the fix doesn't work. 
A full fix would require to update the value from native code on quit from retroarch menu.
