### PR TITLE
Load roms from external app - #3

### DIFF
--- a/android/phoenix/src/org/retroarch/browser/MainMenuActivity.java
+++ b/android/phoenix/src/org/retroarch/browser/MainMenuActivity.java
@@ -93,9 +93,7 @@ public class MainMenuActivity extends PreferenceActivity {
 			if (null==savedInstanceState || !savedInstanceState.getBoolean("romexec"))
 				loadRomExternal(startedByIntent.getStringExtra("ROM"),
 						startedByIntent.getStringExtra("LIBRETRO"));
-			else
-				super.onBackPressed();
-			// return;
+			else finish();
 		}
 
 	}


### PR DESCRIPTION
Used Activity Lifecycle instead of SharedPreferences to fix the back button issues. 

Thanks TheMaister for the directions. 
