### PR TITLE
Quick Xinput performance fix

### DIFF
--- a/input/dinput.c
+++ b/input/dinput.c
@@ -562,7 +562,7 @@ static void dinput_joypad_poll(void)
    {
       struct dinput_joypad *pad = &g_pads[i];
 
-      if (pad->joypad)
+      if ((pad->joypad) && (g_xbox_pad_indexes[i] == -1))
       {
          memset(&pad->joy_state, 0, sizeof(pad->joy_state));
 

--- a/input/winxinput_joypad.c
+++ b/input/winxinput_joypad.c
@@ -315,7 +315,7 @@ static void winxinput_joypad_poll(void)
 {
    for (unsigned i = 0; i < 4; ++i)
       if (g_winxinput_states[i].connected)
-         if (g_XInputGetStateEx(i, &(g_winxinput_states[i].xstate)) == ERROR_DEVICE_NOT_CONNECTED)
+         if (g_XInputGetStateEx(i, &(g_winxinput_states[i].xstate)) != ERROR_SUCCESS)
             g_winxinput_states[i].connected = false;
          
    dinput_joypad.poll();


### PR DESCRIPTION
Sorry, my XInput driver has a performance issue- calling XInputGetState on a disconnected controller is very expensive. This fixes that and also stops dinput from re-polling an XInput pad.
