### PR TITLE
Fix support for Logitech F310 pad on windows

### DIFF
--- a/input/dinput.c
+++ b/input/dinput.c
@@ -417,6 +417,7 @@ static const char* const XINPUT_PAD_NAMES[] =
    "Controller (Xbox 360 Wireless Receiver for Windows)",
    "Controller (Xbox wireless receiver for windows)",
    "Controller (XBOX360 GAMEPAD)",
+   "MadCatz GamePad",
    NULL
 };
 


### PR DESCRIPTION
See the Logitech F310 as a 360 pad.
