### PR TITLE
[Android] Catch a more specific exception in HistoryWrapper.java.

### DIFF
--- a/android/phoenix/src/org/retroarch/browser/HistoryWrapper.java
+++ b/android/phoenix/src/org/retroarch/browser/HistoryWrapper.java
@@ -20,7 +20,7 @@ public final class HistoryWrapper implements IconAdapterItem {
 		gamePathShort = file.getName();
 		try {
 			gamePathShort = gamePathShort.substring(0, gamePathShort.lastIndexOf('.'));
-		} catch (Exception e) {
+		} catch (IndexOutOfBoundsException e) {
 		}
 	}
 	


### PR DESCRIPTION
The only possible exception that can be thrown here is IndexOutOfBoundsException. It's better to be more explicit in regards to exceptions.
