### PR TITLE
Add yet another third-party pad to xinput detection

### DIFF
--- a/input/dinput.c
+++ b/input/dinput.c
@@ -426,6 +426,8 @@ static const char* const XINPUT_PAD_NAMES[] =
    "Controller (Xbox wireless receiver for windows)",
    "Controller (XBOX360 GAMEPAD)",
    "MadCatz GamePad",
+   "MadCatz GamePad (Controller)",
+   "Controller (MadCatz GamePad)",
    NULL
 };
 


### PR DESCRIPTION
I really need to find a more generic way to do this sometime.
