### PR TITLE
Fix typo

### DIFF
--- a/audio/dsound.c
+++ b/audio/dsound.c
@@ -260,7 +260,7 @@ static void dsound_free(void *data)
          IDirectSoundBuffer_Release(ds->dsb);
       }
 
-      if (ds)
+      if (ds->ds)
          IDirectSound_Release(ds->ds);
 
       if (ds->event)


### PR DESCRIPTION
Fix checking for wrong pointer. It's an understandable mistake, but still a mistake.
