### PR TITLE
Allow partial SRAM load

### DIFF
--- a/file.c
+++ b/file.c
@@ -424,8 +424,15 @@ void load_ram_file(const char *path, int type)
 
    void *buf = NULL;
    ssize_t rc = read_file(path, &buf);
-   if (rc > 0 && rc <= (ssize_t)size)
+   if (rc > 0)
+   {
+      if (rc > (ssize_t)size)
+      {
+         RARCH_WARN("SRAM is larger than implementation expects, doing partial load.\n");
+         rc = size;
+      }
       memcpy(data, buf, rc);
+   }
 
    free(buf);
 }


### PR DESCRIPTION
Different cores that emulate the same system may have slightly different
understanding of SRAM, like it currently is for Genesis Plus GX vs
PicoDrive. Currently Genesis Plus GX uses larger padding, which means it
creates larger files. When loading such file for PicoDrive, current
code refuses to load it and this effectively destroys user's save
because new SRAM file is written on PicoDrive's exit.

To fix this, allow partial load (and print a warning).
