### PR TITLE
[Android] Disable the preference "Automatically detect audio latency" if the Android device running RetroArch is less than Android 4.1.

### DIFF
--- a/android/phoenix/src/org/retroarch/browser/preferences/fragments/AudioPreferenceFragment.java
+++ b/android/phoenix/src/org/retroarch/browser/preferences/fragments/AudioPreferenceFragment.java
@@ -3,7 +3,9 @@ package org.retroarch.browser.preferences.fragments;
 import org.retroarch.R;
 import org.retroarch.browser.preferences.fragments.util.PreferenceListFragment;
 
+import android.os.Build;
 import android.os.Bundle;
+import android.preference.CheckBoxPreference;
 
 /**
  * A {@link PreferenceListFragment} responsible for handling the audio preferences.
@@ -17,5 +19,13 @@ public final class AudioPreferenceFragment extends PreferenceListFragment
 		
 		// Add audio preferences from the XML.
 		addPreferencesFromResource(R.xml.audio_preferences);
+		
+		// Disable automatic detection of optimal audio latency if a device is below Android 4.1
+		final CheckBoxPreference autoDetectAudioLatency = (CheckBoxPreference) findPreference("audio_latency_auto");
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN)
+		{
+			autoDetectAudioLatency.setChecked(false);
+			autoDetectAudioLatency.setEnabled(false);
+		}
 	}
 }


### PR DESCRIPTION
Auto detection won't work on those below it.
