### PR TITLE
[Android] Minor simplification in ShaderActivity.java

### DIFF
--- a/android/phoenix/src/org/retroarch/browser/diractivities/ShaderActivity.java
+++ b/android/phoenix/src/org/retroarch/browser/diractivities/ShaderActivity.java
@@ -7,7 +7,7 @@ import android.os.Bundle;
 public final class ShaderActivity extends DirectoryActivity {
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
-		File shaderDir = new File(getBaseContext().getApplicationInfo().dataDir, "shaders_glsl");
+		File shaderDir = new File(getApplicationInfo().dataDir, "shaders_glsl");
 		if (shaderDir.exists())
 			super.setStartDirectory(shaderDir.getAbsolutePath());
 		


### PR DESCRIPTION
No need to get the base context in ShaderActivity.java for getting application info. Since ShaderActivity.java is (obviously) an Activity. It can act as it's own Context.
