### PR TITLE
[Android] Remove a pointless throws for IOException in ModuleWrapper.

### DIFF
--- a/android/phoenix/src/org/retroarch/browser/CoreSelection.java
+++ b/android/phoenix/src/org/retroarch/browser/CoreSelection.java
@@ -73,13 +73,8 @@ public final class CoreSelection extends ListActivity {
 			}
 
 			// Allow both libretro-core.so and libretro_core.so.
-			if (libName.startsWith("libretro")
-					&& !libName.startsWith("libretroarch")) {
-				try {
-					adapter.add(new ModuleWrapper(this, lib, core_config));
-				} catch (IOException e) {
-					e.printStackTrace();
-				}
+			if (libName.startsWith("libretro") && !libName.startsWith("libretroarch")) {
+				adapter.add(new ModuleWrapper(this, lib, core_config));
 			}
 		}
 

--- a/android/phoenix/src/org/retroarch/browser/ModuleWrapper.java
+++ b/android/phoenix/src/org/retroarch/browser/ModuleWrapper.java
@@ -1,7 +1,6 @@
 package org.retroarch.browser;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.retroarch.browser.preferences.util.ConfigFile;
 
@@ -12,7 +11,7 @@ final class ModuleWrapper implements IconAdapterItem {
 	public final File file;
 	private final ConfigFile config;
 
-	public ModuleWrapper(Context context, File file, ConfigFile config) throws IOException {
+	public ModuleWrapper(Context context, File file, ConfigFile config) {
 		this.file = file;
 		this.config = config;
 	}


### PR DESCRIPTION
There's no way an I/O exception can be thrown in this constructor.
