### PR TITLE
[Android] Extract assets (overlays/shaders) to user-accessible location

### DIFF
--- a/android/phoenix/src/org/retroarch/browser/MainMenuActivity.java
+++ b/android/phoenix/src/org/retroarch/browser/MainMenuActivity.java
@@ -121,10 +121,11 @@ public final class MainMenuActivity extends PreferenceActivity {
 	private void extractAssetsThread() {
 		try {
 			String dataDir = getApplicationInfo().dataDir;
+			String userDataDir = getExternalFilesDir(null).getAbsolutePath();
 
 			String apk = getApplicationInfo().sourceDir;
 			Log.i(TAG, "Extracting RetroArch assets from: " + apk + " ...");
-			boolean success = NativeInterface.extractArchiveTo(apk, "assets", dataDir);
+			boolean success = NativeInterface.extractArchiveTo(apk, "assets", userDataDir);
 			if (!success) {
 				throw new IOException("Failed to extract assets ...");
 			}

--- a/android/phoenix/src/org/retroarch/browser/diractivities/OverlayActivity.java
+++ b/android/phoenix/src/org/retroarch/browser/diractivities/OverlayActivity.java
@@ -7,7 +7,7 @@ import android.os.Bundle;
 public final class OverlayActivity extends DirectoryActivity {
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
-		File overlayDir = new File(getApplicationInfo().dataDir, "overlays");
+		File overlayDir = new File(getExternalFilesDir(null), "overlays");
 		if (overlayDir.exists())
 			super.setStartDirectory(overlayDir.getAbsolutePath());
 		

--- a/android/phoenix/src/org/retroarch/browser/diractivities/ShaderActivity.java
+++ b/android/phoenix/src/org/retroarch/browser/diractivities/ShaderActivity.java
@@ -7,7 +7,7 @@ import android.os.Bundle;
 public final class ShaderActivity extends DirectoryActivity {
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
-		File shaderDir = new File(getApplicationInfo().dataDir, "shaders_glsl");
+		File shaderDir = new File(getExternalFilesDir(null), "shaders_glsl");
 		if (shaderDir.exists())
 			super.setStartDirectory(shaderDir.getAbsolutePath());
 		

--- a/android/phoenix/src/org/retroarch/browser/preferences/util/UserPreferences.java
+++ b/android/phoenix/src/org/retroarch/browser/preferences/util/UserPreferences.java
@@ -178,6 +178,7 @@ public final class UserPreferences
 
 		// Native library and data directories.
 		final String dataDir = ctx.getApplicationInfo().dataDir;
+		final String userDataDir = ctx.getExternalFilesDir(null).getAbsolutePath();
 		final String nativeLibraryDir = ctx.getApplicationInfo().nativeLibraryDir;
 
 		final SharedPreferences prefs = getPreferences(ctx);
@@ -277,7 +278,7 @@ public final class UserPreferences
 		config.setBoolean("input_overlay_enable", useOverlay); // Not used by RetroArch directly.
 		if (useOverlay)
 		{
-			String overlayPath = prefs.getString("input_overlay", dataDir + "/overlays/snes-landscape.cfg");
+			String overlayPath = prefs.getString("input_overlay", userDataDir + "/overlays/snes-landscape.cfg");
 			config.setString("input_overlay", overlayPath);
 			config.setDouble("input_overlay_opacity", prefs.getFloat("input_overlay_opacity", 1.0f));
 		}


### PR DESCRIPTION
Currently, assets are extracted to a /data/data/org.retroarch/ which is
not accessible from Phoenix or RGUI.  This revision changes the asset
location to the standard Android location for user accessible data.
