### PR TITLE
[Android] Do checking for a valid core name in ModuleWrapper. 

### DIFF
--- a/android/phoenix/src/com/retroarch/browser/ModuleWrapper.java
+++ b/android/phoenix/src/com/retroarch/browser/ModuleWrapper.java
@@ -37,8 +37,11 @@ public final class ModuleWrapper implements IconAdapterItem, Comparable<ModuleWr
 		// Attempt to get the core's info file.
 		// Basically this is dataDir/info/[core name].info
 
-		// So first, since the core name will contain platform specific strings at the end of name, we trim this.
-		final String coreName = file.getName().substring(0, file.getName().lastIndexOf("_android.so"));
+		// So first, since the core name will have a platform-specific identifier at the end of its name, we trim this.
+		// If it turns out we have an invalid core name, simply assign the core name as the full name of the file.
+		final boolean isValidCoreName = (file.getName().lastIndexOf("_android.so") != -1); 
+		final String coreName = (isValidCoreName) ? file.getName().substring(0, file.getName().lastIndexOf("_android.so"))
+												  : file.getName();
 
 		// Now get the directory where all of the info files are kept (dataDir/info)
 		final String infoFileDir  = context.getApplicationInfo().dataDir + File.separator + "info";


### PR DESCRIPTION
Prevents a potential crash when random files are tossed in the cores folder.
