### PR TITLE
Fix variable shadowing that makes the previous fix ineffective.

### DIFF
--- a/compat/rxml/rxml.c
+++ b/compat/rxml/rxml.c
@@ -143,8 +143,8 @@ static struct rxml_attrib_node *rxml_parse_attrs(const char *str)
       if (!end || end != (elem + strlen(elem) - 1))
          goto end;
 
-      char *attrib = strdup_range_escape(elem, eq);
-      char *value  = strdup_range_escape(eq + 2, end);
+      attrib = strdup_range_escape(elem, eq);
+      value  = strdup_range_escape(eq + 2, end);
       if (!attrib || !value)
          goto end;
 


### PR DESCRIPTION
The leak seems to only appear if we're out of memory, but that's when leaks matter the most. Future refactoring could also make the leak more likely, so let's zap it before it gets a chance.
