### PR TITLE
Fix crashing in the core manager for devices on Android 2.3.x.

### DIFF
--- a/android/phoenix/AndroidManifest.xml
+++ b/android/phoenix/AndroidManifest.xml
@@ -27,7 +27,6 @@
             </intent-filter>
         </activity>
         <activity android:name="com.retroarch.browser.FileWrapper"/>
-        <activity android:name="com.retroarch.browser.RetroTVMode"/>
 
         <activity android:name="com.retroarch.browser.preferences.PreferenceActivity" android:theme="@style/Theme.AppCompat" />
         <activity android:name="com.retroarch.browser.coremanager.CoreManagerActivity" android:theme="@style/Theme.AppCompat"/>

--- a/android/phoenix/res/layout/coremanager_listview.xml
+++ b/android/phoenix/res/layout/coremanager_listview.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ListView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:background="?android:attr/activatedBackgroundIndicator"
     android:choiceMode="singleChoice"
     android:id="@android:id/list"
     android:layout_width="match_parent"


### PR DESCRIPTION
Also remove a now non-existent activity reference from the AndroidManifest.
