### PR TITLE
List all special keys in sample configuration file.

### DIFF
--- a/pandora/retroarch/retroarch.cfg
+++ b/pandora/retroarch/retroarch.cfg
@@ -183,7 +183,18 @@ audio_driver = alsa
 # Defines axis threshold. Possible values are [0.0, 1.0]
 # input_axis_threshold = 0.5
 
-# Keyboard input. Will recognize normal keypresses and special keys like "left", "right", and so on.
+# Keyboard input. Will recognize letters ("a" to "z") and the following special keys (where "kp_"
+# is for keypad keys):
+#
+#   left, right, up, down, enter, kp_enter, tab, insert, del, end, home,
+#   rshift, shift, ctrl, alt, space, escape, add, subtract, kp_plus, kp_minus,
+#   f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12,
+#   num0, num1, num2, num3, num4, num5, num6, num7, num8, num9, pageup, pagedown,
+#   keypad0, keypad1, keypad2, keypad3, keypad4, keypad5, keypad6, keypad7, keypad8, keypad9,
+#   period, capslock, numlock, backspace, multiply, divide, print_screen, scroll_lock,
+#   tilde, backquote, pause, quote, comma, minus, slash, semicolon, equals, leftbracket,
+#   backslash, rightbracket, kp_period, kp_equals, rctrl, ralt
+#
 # Keyboard input, Joypad and Joyaxis will all obey the "nul" bind, which disables the bind completely, 
 # rather than relying on a default.
 # On Pandora, the included mappings below match the gpio-keys

--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -285,7 +285,18 @@
 # input_libretro_device_p7 =
 # input_libretro_device_p8 =
 
-# Keyboard input. Will recognize normal keypresses and special keys like "left", "right", and so on.
+# Keyboard input. Will recognize letters ("a" to "z") and the following special keys (where "kp_"
+# is for keypad keys):
+#
+#   left, right, up, down, enter, kp_enter, tab, insert, del, end, home,
+#   rshift, shift, ctrl, alt, space, escape, add, subtract, kp_plus, kp_minus,
+#   f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12,
+#   num0, num1, num2, num3, num4, num5, num6, num7, num8, num9, pageup, pagedown,
+#   keypad0, keypad1, keypad2, keypad3, keypad4, keypad5, keypad6, keypad7, keypad8, keypad9,
+#   period, capslock, numlock, backspace, multiply, divide, print_screen, scroll_lock,
+#   tilde, backquote, pause, quote, comma, minus, slash, semicolon, equals, leftbracket,
+#   backslash, rightbracket, kp_period, kp_equals, rctrl, ralt
+#
 # Keyboard input, Joypad and Joyaxis will all obey the "nul" bind, which disables the bind completely, 
 # rather than relying on a default.
 # input_player1_a = x


### PR DESCRIPTION
It's not at all clear that, for example, the key
for the digit 5 should be "num5" and not simply "5".
List all keys for clarity.
