### PR TITLE
Update controller profiles

### DIFF
--- a/android/native/jni/input_android.c
+++ b/android/native/jni/input_android.c
@@ -546,7 +546,7 @@ static void android_input_set_keybinds(void *data, unsigned device,
             strlcpy(g_settings.input.device_names[port], "iDroid x360",
                   sizeof(g_settings.input.device_names[port]));
 
-            android->dpad_emulation[port] = ANALOG_DPAD_NONE;
+            android->dpad_emulation[port] = ANALOG_DPAD_DUALANALOG;
             android->keycode_lut[AKEYCODE_DPAD_UP] |=  ((RETRO_DEVICE_ID_JOYPAD_UP+1)      << shift);
             android->keycode_lut[AKEYCODE_DPAD_DOWN] |=  ((RETRO_DEVICE_ID_JOYPAD_DOWN+1)      << shift);
             android->keycode_lut[AKEYCODE_DPAD_LEFT] |=  ((RETRO_DEVICE_ID_JOYPAD_LEFT+1)      << shift);
@@ -659,7 +659,7 @@ static void android_input_set_keybinds(void *data, unsigned device,
             strlcpy(g_settings.input.device_names[port], "MS Sidewinder",
                   sizeof(g_settings.input.device_names[port]));
 
-            android->dpad_emulation[port] = ANALOG_DPAD_DUALANALOG;
+            android->dpad_emulation[port] = ANALOG_DPAD_LSTICK;
             android->keycode_lut[AKEYCODE_BUTTON_R2] |= ((RETRO_DEVICE_ID_JOYPAD_SELECT+1) << shift);
             android->keycode_lut[AKEYCODE_BUTTON_L2] |= ((RETRO_DEVICE_ID_JOYPAD_START+1) << shift);
             android->keycode_lut[AKEYCODE_BUTTON_11] |= ((RETRO_DEVICE_ID_JOYPAD_L3+1) << shift);


### PR DESCRIPTION
Changed many of them to be marked as dual analog. This information was mostly gathered by doing google image searches and then looking at the results. So it might not be perfect but it should be a good bit better than what we have now. Also changed the default to be DUALANALOG as I figure that's more common (and there's not so much harm in mislabeling as such). 
