### PR TITLE
(griffin.c) Fix build when freetype2 support is enabled

### DIFF
--- a/gfx/fonts/fonts.c
+++ b/gfx/fonts/fonts.c
@@ -24,13 +24,16 @@ static const font_renderer_driver_t *font_backends[] = {
 #ifdef HAVE_FREETYPE
    &ft_font_renderer,
 #endif
+#if !defined(DONT_HAVE_BITMAPFONTS)
    &bitmap_font_renderer,
+#endif
+   NULL
 };
 
 bool font_renderer_create_default(const font_renderer_driver_t **driver, void **handle)
 {
    unsigned i;
-   for (i = 0; i < ARRAY_SIZE(font_backends); i++)
+   for (i = 0; font_backends[i]; i++)
    {
       const char *font_path = *g_settings.video.font_path ? g_settings.video.font_path : NULL;
       if (!font_path)

--- a/griffin/griffin.c
+++ b/griffin/griffin.c
@@ -247,13 +247,17 @@ FONTS
 
 #if defined(HAVE_OPENGL) || defined(HAVE_D3D8) || defined(HAVE_D3D9)
 
+#if defined(HAVE_FREETYPE) || !defined(DONT_HAVE_BITMAPFONTS)
+#include "../gfx/fonts/fonts.c"
+
 #if defined(HAVE_FREETYPE)
 #include "../gfx/fonts/freetype.c"
 #endif
 
 #if !defined(DONT_HAVE_BITMAPFONTS)
-#include "../gfx/fonts/fonts.c"
 #include "../gfx/fonts/bitmapfont.c"
+#endif
+
 #endif
 
 #ifdef HAVE_OPENGL


### PR DESCRIPTION
This commit fixes build issues for frontends that wish to use freetype2 or that do not want to use the built-in bitmap font:
- Having `HAVE_FREETYPE` without `DONT_HAVE_BITMAPFONT` makes griffin.c include both freetype.c and bitmapfont.c resulting in a redefinition of `struct font_renderer` (freetype.c:25 and bitmapfont.c:24).
- Having both `HAVE_FREETYPE` and `DONT_HAVE_BITMAPFONT` resulted in linkage problems because in this case griffin.c does not include fonts.c and thus `font_renderer_create_default()`  implementation is missing. If fonts.c is included, the linker complains about undefined reference to `bitmap_font_renderer` in fonts.c:27.
