### PR TITLE
(Android) Implement immersive mode on Kitkat

### DIFF
--- a/android/phoenix/AndroidManifest.xml
+++ b/android/phoenix/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <uses-feature android:glEsVersion="0x00020000" />
     <uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
     <uses-sdk
-        android:minSdkVersion="9"
+        android:minSdkVersion="11"
         android:targetSdkVersion="19" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>

--- a/android/phoenix/src/com/retroarch/browser/retroactivity/RetroActivityFuture.java
+++ b/android/phoenix/src/com/retroarch/browser/retroactivity/RetroActivityFuture.java
@@ -1,5 +1,31 @@
 package com.retroarch.browser.retroactivity;
 
-public final class RetroActivityFuture extends RetroActivityCamera
-{
+import android.view.View;
+
+public final class RetroActivityFuture extends RetroActivityCamera {
+
+	@Override
+	public void onResume() {
+		super.onResume();
+
+		if (android.os.Build.VERSION.SDK_INT >= 19) {
+			// Immersive mode
+
+			// Constants from API > 14
+			final int API_SYSTEM_UI_FLAG_LAYOUT_STABLE = 0x00000100;
+			final int API_SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION = 0x00000200;
+			final int API_SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN = 0x00000400;
+			final int API_SYSTEM_UI_FLAG_FULLSCREEN = 0x00000004;
+			final int API_SYSTEM_UI_FLAG_IMMERSIVE_STICKY = 0x00001000;
+
+			View thisView = getWindow().getDecorView();
+			thisView.setSystemUiVisibility(API_SYSTEM_UI_FLAG_LAYOUT_STABLE
+					| API_SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+					| API_SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+					| View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+					| API_SYSTEM_UI_FLAG_FULLSCREEN
+					| API_SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+		}
+	}
+
 }


### PR DESCRIPTION
Kitkat has a new fullscreen mode "immersive". It can make the app truly full screen

http://developer.android.com/training/system-ui/immersive.html

The code I take from XBMC https://github.com/xbmc/xbmc/pull/3712

Only enable in game-playing screen. The patch maybe dirty and need to review, at least, it work fine on my Nexus 4(Google official ROM without root).  

Here is a screenshot 

![screenshot_2014-03-17-00-47-08](https://f.cloud.github.com/assets/330812/2436767/a10f3c78-addf-11e3-9221-aabada77dc11.jpg)
