### PR TITLE
Remove passing around video_data inside RGUI.

### DIFF
--- a/frontend/frontend.c
+++ b/frontend/frontend.c
@@ -155,12 +155,12 @@ int main_entry_iterate(signature(), args_type() args)
    }
    else if (g_extern.lifecycle_state & (1ULL << MODE_LOAD_GAME))
    {
-      load_menu_game_prepare(driver.video_data);
+      load_menu_game_prepare();
 
       if (load_menu_game())
       {
          g_extern.lifecycle_state |= (1ULL << MODE_GAME);
-         if (driver.video_poke && driver.video_poke->set_aspect_ratio)
+         if (driver.video_data && driver.video_poke && driver.video_poke->set_aspect_ratio)
             driver.video_poke->set_aspect_ratio(driver.video_data, g_settings.video.aspect_ratio_idx);
       }
       else
@@ -225,7 +225,7 @@ int main_entry_iterate(signature(), args_type() args)
    }
    else if (g_extern.lifecycle_state & (1ULL << MODE_MENU))
    {
-      if (menu_iterate(driver.video_data))
+      if (menu_iterate())
       {
          if (frontend_ctx && frontend_ctx->process_events)
             frontend_ctx->process_events(args);
@@ -260,7 +260,7 @@ void main_exit(args_type() args)
 #ifdef HAVE_MENU
    g_extern.system.shutdown = false;
 
-   menu_free(driver.video_data);
+   menu_free();
 
    if (g_extern.config_save_on_exit && *g_extern.config_path)
    {
@@ -338,7 +338,7 @@ returntype main_entry(signature())
 
 #if defined(HAVE_MENU)
    if (menu_init_enable)
-      menu_init(driver.video_data);
+      menu_init();
 
    if (frontend_ctx && frontend_ctx->process_args)
       frontend_ctx->process_args(argc, argv, args);

--- a/frontend/menu/disp/lakka.c
+++ b/frontend/menu/disp/lakka.c
@@ -199,7 +199,7 @@ static void lakka_render_background(rgui_handle_t *rgui)
          rgui->width - 10, 5, 5, rgui->height - 10, green_filler);
 }
 
-static void lakka_render_messagebox(void *data, void *video_data, const char *message)
+static void lakka_render_messagebox(void *data, const char *message)
 {
    rgui_handle_t *rgui = (rgui_handle_t*)data;
    size_t i;
@@ -351,11 +351,11 @@ void lakka_draw_icon(void *data, GLuint texture, float x, float y, float alpha, 
    gl_set_viewport(gl, gl->win_width, gl->win_height, 0, 0);
 }
 
-static void lakka_render(void *data, void *video_data)
+static void lakka_render(void *data)
 {
    rgui_handle_t *rgui = (rgui_handle_t*)data;
 
-   gl_t *gl = (gl_t*)video_data;
+   gl_t *gl = (gl_t*)driver.video_data;
 
    gl_set_viewport(gl, gl->win_width, gl->win_height, 0, 0);
 
@@ -625,16 +625,16 @@ static void lakka_render(void *data, void *video_data)
       if (!str)
          str = "";
       snprintf(msg, sizeof(msg), "%s\n%s", rgui->keyboard.label, str);
-      lakka_render_messagebox(rgui, video_data, msg);
+      lakka_render_messagebox(rgui, msg);
    }
 }
 
-static void lakka_set_texture(void *data, void *video_data, bool enable)
+static void lakka_set_texture(void *data, bool enable)
 {
    rgui_handle_t *rgui = (rgui_handle_t*)data;
 
-   if (driver.video_poke && driver.video_poke->set_texture_enable)
-      driver.video_poke->set_texture_frame(video_data, menu_framebuf,
+   if (driver.video_data && driver.video_poke && driver.video_poke->set_texture_enable)
+      driver.video_poke->set_texture_frame(driver.video_data, menu_framebuf,
             enable, rgui->width, rgui->height, 1.0f);
 }
 
@@ -653,7 +653,7 @@ static void lakka_init_assets(void *data)
    lakka_set_texture(rgui, true);
 }
 
-static void *lakka_init(void *video_data)
+static void *lakka_init(void)
 {
    uint16_t *framebuf = menu_framebuf;
    size_t framebuf_pitch;

--- a/frontend/menu/disp/rgui.c
+++ b/frontend/menu/disp/rgui.c
@@ -191,7 +191,7 @@ static void rgui_render_background(rgui_handle_t *rgui)
          rgui->width - 10, 5, 5, rgui->height - 10, green_filler);
 }
 
-static void rgui_render_messagebox(void *data, void *video_data, const char *message)
+static void rgui_render_messagebox(void *data, const char *message)
 {
    rgui_handle_t *rgui = (rgui_handle_t*)data;
    size_t i;
@@ -258,7 +258,7 @@ static void rgui_render_messagebox(void *data, void *video_data, const char *mes
    string_list_free(list);
 }
 
-static void rgui_render(void *data, void *video_data)
+static void rgui_render(void *data)
 {
    rgui_handle_t *rgui = (rgui_handle_t*)data;
 
@@ -526,7 +526,7 @@ static void rgui_render(void *data, void *video_data)
    else
       message_queue = driver.current_msg;
 
-   rgui_render_messagebox(rgui, video_data, message_queue);
+   rgui_render_messagebox(rgui, message_queue);
 #endif
 
    if (rgui->keyboard.display)
@@ -536,11 +536,11 @@ static void rgui_render(void *data, void *video_data)
       if (!str)
          str = "";
       snprintf(msg, sizeof(msg), "%s\n%s", rgui->keyboard.label, str);
-      rgui_render_messagebox(rgui, video_data, msg);
+      rgui_render_messagebox(rgui, msg);
    }
 }
 
-static void *rgui_init(void *video_data)
+static void *rgui_init(void)
 {
    uint16_t *framebuf = menu_framebuf;
    size_t framebuf_pitch;
@@ -592,12 +592,12 @@ static int rgui_input_postprocess(void *data, uint64_t old_state)
    return ret;
 }
 
-void rgui_set_texture(void *data, void *video_data, bool enable)
+void rgui_set_texture(void *data, bool enable)
 {
    rgui_handle_t *rgui = (rgui_handle_t*)data;
 
-   if (driver.video_poke && driver.video_poke->set_texture_enable)
-      driver.video_poke->set_texture_frame(video_data, menu_framebuf,
+   if (driver.video_data && driver.video_poke && driver.video_poke->set_texture_enable)
+      driver.video_poke->set_texture_frame(driver.video_data, menu_framebuf,
             enable, rgui->width, rgui->height, 1.0f);
 }
 

--- a/frontend/menu/disp/rmenu.c
+++ b/frontend/menu/disp/rmenu.c
@@ -70,7 +70,7 @@ static void rmenu_render_background(rgui_handle_t *rgui)
 {
 }
 
-static void rmenu_render_messagebox(void *data, void *video_data, const char *message)
+static void rmenu_render_messagebox(void *data, const char *message)
 {
    font_params_t font_parms;
 
@@ -107,14 +107,14 @@ static void rmenu_render_messagebox(void *data, void *video_data, const char *me
       font_parms.scale = FONT_SIZE_NORMAL;
       font_parms.color = WHITE;
 
-      if (driver.video_poke && driver.video_poke->set_osd_msg)
-         driver.video_poke->set_osd_msg(video_data, msg, &font_parms);
+      if (driver.video_data && driver.video_poke && driver.video_poke->set_osd_msg)
+         driver.video_poke->set_osd_msg(driver.video_data, msg, &font_parms);
    }
 
    render_normal = false;
 }
 
-static void rmenu_render(void *data, void *video_data)
+static void rmenu_render(void *data)
 {
    if (!render_normal)
    {
@@ -246,8 +246,8 @@ static void rmenu_render(void *data, void *video_data)
    font_parms.scale = FONT_SIZE_NORMAL;
    font_parms.color = WHITE;
 
-   if (driver.video_poke && driver.video_poke->set_osd_msg)
-      driver.video_poke->set_osd_msg(video_data, title_buf, &font_parms);
+   if (driver.video_data && driver.video_poke && driver.video_poke->set_osd_msg)
+      driver.video_poke->set_osd_msg(driver.video_data, title_buf, &font_parms);
 
    char title_msg[64];
    const char *core_name = rgui->info.library_name;
@@ -269,8 +269,8 @@ static void rmenu_render(void *data, void *video_data)
 
    snprintf(title_msg, sizeof(title_msg), "%s - %s %s", PACKAGE_VERSION, core_name, core_version);
 
-   if (driver.video_poke && driver.video_poke->set_osd_msg)
-      driver.video_poke->set_osd_msg(video_data, title_msg, &font_parms);
+   if (driver.video_data && driver.video_poke && driver.video_poke->set_osd_msg)
+      driver.video_poke->set_osd_msg(driver.video_data, title_msg, &font_parms);
 
    size_t i, j;
 
@@ -384,32 +384,32 @@ static void rmenu_render(void *data, void *video_data)
       font_parms.scale = FONT_SIZE_NORMAL;
       font_parms.color = WHITE;
 
-      if (driver.video_poke && driver.video_poke->set_osd_msg)
-         driver.video_poke->set_osd_msg(video_data, message, &font_parms);
+      if (driver.video_data && driver.video_poke && driver.video_poke->set_osd_msg)
+         driver.video_poke->set_osd_msg(driver.video_data, message, &font_parms);
 
       font_parms.x = POSITION_EDGE_CENTER + POSITION_OFFSET;
 
-      if (driver.video_poke && driver.video_poke->set_osd_msg)
-         driver.video_poke->set_osd_msg(video_data, type_str_buf, &font_parms);
+      if (driver.video_data && driver.video_poke && driver.video_poke->set_osd_msg)
+         driver.video_poke->set_osd_msg(driver.video_data, type_str_buf, &font_parms);
    }
 }
 
-void rmenu_set_texture(void *data, void *video_data, bool enable)
+void rmenu_set_texture(void *data, bool enable)
 {
    rgui_handle_t *rgui = (rgui_handle_t*)data;
 
    if (menu_texture_inited)
       return;
 
-   if (driver.video_poke && driver.video_poke->set_texture_enable)
+   if (driver.video_data && driver.video_poke && driver.video_poke->set_texture_enable)
    {
-      driver.video_poke->set_texture_frame(video_data, menu_texture->pixels,
+      driver.video_poke->set_texture_frame(driver.video_data, menu_texture->pixels,
             enable, rgui->width, rgui->height, 1.0f);
       menu_texture_inited = true;
    }
 }
 
-static void rmenu_init_assets(void *data, void *video_data)
+static void rmenu_init_assets(void *data)
 {
    rgui_handle_t *rgui = (rgui_handle_t*)data;
 
@@ -421,14 +421,14 @@ static void rmenu_init_assets(void *data, void *video_data)
    rgui->width = menu_texture->width;
    rgui->height = menu_texture->height;
 
-   rmenu_set_texture(rgui, video_data, true);
+   rmenu_set_texture(rgui, true);
 }
 
-static void *rmenu_init(void *video_data)
+static void *rmenu_init(void)
 {
    rgui_handle_t *rgui = (rgui_handle_t*)calloc(1, sizeof(*rgui));
 
-   rmenu_init_assets(rgui, video_data);
+   rmenu_init_assets(rgui);
 
    return rgui;
 }

--- a/frontend/menu/disp/rmenu_xui.cpp
+++ b/frontend/menu/disp/rmenu_xui.cpp
@@ -149,7 +149,7 @@ HRESULT CRetroArchMain::OnInit(XUIMessageInit * pInitData, BOOL& bHandled)
    return 0;
 }
 
-static void* rmenu_xui_init(void *video_data)
+static void* rmenu_xui_init(void)
 {
    HRESULT hr;
 
@@ -160,7 +160,7 @@ static void* rmenu_xui_init(void *video_data)
       return NULL;
    }
 
-   d3d_video_t *d3d= (d3d_video_t*)video_data;
+   d3d_video_t *d3d= (d3d_video_t*)driver.video_data;
 
    bool hdmenus_allowed = (g_extern.lifecycle_state & (1ULL << MODE_MENU_HD));
 
@@ -227,8 +227,8 @@ static void* rmenu_xui_init(void *video_data)
       return NULL;
    }
 
-   if (driver.video_poke && driver.video_poke->set_texture_enable)
-      driver.video_poke->set_texture_frame(video_data, NULL,
+   if (driver.video_data && driver.video_poke && driver.video_poke->set_texture_enable)
+      driver.video_poke->set_texture_frame(driver.video_data, NULL,
             true, 0, 0, 1.0f);
 
    xui_msg_queue = msg_queue_new(16);
@@ -367,19 +367,18 @@ int x, int y, const char *message, bool green)
 {
 }
 
-static void rmenu_xui_render_background(void *data, void *video_data)
+static void rmenu_xui_render_background(void *data)
 {
    (void)data;
-   (void)video_data;
 }
 
-static void rmenu_xui_render_messagebox(void *data, void *video_data, const char *message)
+static void rmenu_xui_render_messagebox(void *data, const char *message)
 {
    msg_queue_clear(xui_msg_queue);
    msg_queue_push(xui_msg_queue, message, 2, 1);
 }
 
-static void rmenu_xui_render(void *data, void *video_data)
+static void rmenu_xui_render(void *data)
 {
    rgui_handle_t *rgui = (rgui_handle_t*)data;
 
@@ -391,7 +390,7 @@ static void rmenu_xui_render(void *data, void *video_data)
    size_t begin = rgui->selection_ptr;
    size_t end = rgui->selection_buf->size;
 
-   rmenu_xui_render_background(rgui, video_data);
+   rmenu_xui_render_background(rgui);
 
    char title[256];
    const char *dir = NULL;
@@ -639,7 +638,7 @@ static void rmenu_xui_render(void *data, void *video_data)
       if (!str)
          str = "";
       snprintf(msg, sizeof(msg), "%s\n%s", rgui->keyboard.label, str);
-      rmenu_xui_render_messagebox(rgui, video_data, msg);
+      rmenu_xui_render_messagebox(rgui, msg);
    }
 }
 

--- a/frontend/menu/menu_common.h
+++ b/frontend/menu/menu_common.h
@@ -405,9 +405,9 @@ typedef struct
 
 extern rgui_handle_t *rgui;
 
-void menu_init(void *data);
-bool menu_iterate(void *data);
-void menu_free(void *data);
+void menu_init(void);
+bool menu_iterate(void);
+void menu_free(void);
 
 #ifdef HAVE_SHADER_MANAGER
 void shader_manager_init(void *data);
@@ -422,7 +422,7 @@ void menu_ticker_line(char *buf, size_t len, unsigned tick, const char *str, boo
 
 void menu_init_core_info(void *data);
 
-void load_menu_game_prepare(void *video_data);
+void load_menu_game_prepare(void);
 void load_menu_game_prepare_dummy(void);
 bool load_menu_game(void);
 void load_menu_game_history(unsigned game_index);
@@ -435,8 +435,8 @@ bool menu_replace_config(const char *path);
 
 bool menu_save_new_config(void);
 
-int menu_settings_toggle_setting(void *data, void *video_data, unsigned setting, unsigned action, unsigned menu_type);
-int menu_set_settings(void *data, void *video_data, unsigned setting, unsigned action);
+int menu_settings_toggle_setting(void *data, unsigned setting, unsigned action, unsigned menu_type);
+int menu_set_settings(void *data, unsigned setting, unsigned action);
 void menu_set_settings_label(char *type_str, size_t type_str_size, unsigned *w, unsigned type);
 
 void menu_populate_entries(void *data, unsigned menu_type);

--- a/frontend/menu/menu_context.c
+++ b/frontend/menu/menu_context.c
@@ -83,7 +83,7 @@ void find_next_menu_driver(void)
       RARCH_WARN("Couldn't find any next menu driver (current one: \"%s\").\n", g_settings.menu.driver);
 }
 
-bool menu_ctx_init_first(const menu_ctx_driver_t **driver, void **data, void *video_data)
+bool menu_ctx_init_first(const menu_ctx_driver_t **driver, void **data)
 {
    unsigned i;
    rgui_handle_t **handle = (rgui_handle_t**)data;
@@ -93,7 +93,7 @@ bool menu_ctx_init_first(const menu_ctx_driver_t **driver, void **data, void *vi
 
    for (i = 0; menu_ctx_drivers[i]; i++)
    {
-      void *h = menu_ctx_drivers[i]->init(video_data);
+      void *h = menu_ctx_drivers[i]->init();
       if (h)
       {
          *driver = menu_ctx_drivers[i];

--- a/frontend/menu/menu_context.h
+++ b/frontend/menu/menu_context.h
@@ -26,12 +26,12 @@
 
 typedef struct menu_ctx_driver
 {
-   void  (*set_texture)(void*, void*, bool);
-   void  (*render_messagebox)(void*, void*, const char*);
-   void  (*render)(void*, void*);
-   void* (*init)(void*);
+   void  (*set_texture)(void*, bool);
+   void  (*render_messagebox)(void*, const char*);
+   void  (*render)(void*);
+   void* (*init)(void);
    void  (*free)(void*);
-   void  (*init_assets)(void*, void*);
+   void  (*init_assets)(void*);
    void  (*free_assets)(void*);
    void  (*populate_entries)(void*, unsigned);
    void  (*iterate)(void*, unsigned);
@@ -47,7 +47,7 @@ extern const menu_ctx_driver_t menu_ctx_rgui;
 extern const menu_ctx_driver_t menu_ctx_lakka;
 
 const menu_ctx_driver_t *menu_ctx_find_driver(const char *ident); // Finds driver with ident. Does not initialize.
-bool menu_ctx_init_first(const menu_ctx_driver_t **driver, void **handle, void *video_data); // Finds first suitable driver and initializes.
+bool menu_ctx_init_first(const menu_ctx_driver_t **driver, void **handle); // Finds first suitable driver and initializes.
 void find_prev_menu_driver(void);
 void find_next_menu_driver(void);
 


### PR DESCRIPTION
Makes very little sense to add cruft to the interface
when it also risks using an invalidated video_data ...

Also adds some additional checks for driver.video_data.
