### PR TITLE
Implement basic keyboard binding in RGUI.

### DIFF
--- a/frontend/menu/disp/rgui.c
+++ b/frontend/menu/disp/rgui.c
@@ -2,7 +2,7 @@
  *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
  *  Copyright (C) 2011-2014 - Daniel De Matteis
  *  Copyright (C) 2012-2014 - Michael Lelli
- * 
+ *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-
  *  ation, either version 3 of the License, or (at your option) any later version.
@@ -230,7 +230,7 @@ static void rgui_render_messagebox(void *data, const char *message)
    unsigned height = FONT_HEIGHT_STRIDE * list->size + 6 + 10;
    int x = (rgui->width - width) / 2;
    int y = (rgui->height - height) / 2;
-   
+
    fill_rect(rgui->frame_buf, rgui->frame_buf_pitch,
          x + 5, y + 5, width - 10, height - 10, gray_filler);
 
@@ -261,7 +261,7 @@ static void rgui_render(void *data)
 {
    rgui_handle_t *rgui = (rgui_handle_t*)data;
 
-   if (rgui->need_refresh && 
+   if (rgui->need_refresh &&
          (g_extern.lifecycle_state & (1ULL << MODE_MENU))
          && !rgui->msg_force)
       return;
@@ -270,7 +270,7 @@ static void rgui_render(void *data)
       rgui->selection_ptr - RGUI_TERM_HEIGHT / 2 : 0;
    size_t end = rgui->selection_ptr + RGUI_TERM_HEIGHT <= rgui->selection_buf->size ?
       rgui->selection_ptr + RGUI_TERM_HEIGHT : rgui->selection_buf->size;
-   
+
    // Do not scroll if all items are visible.
    if (rgui->selection_buf->size <= RGUI_TERM_HEIGHT)
       begin = 0;
@@ -295,7 +295,9 @@ static void rgui_render(void *data)
       snprintf(title, sizeof(title), "DISK APPEND %s", dir);
    else if (menu_type == RGUI_SETTINGS_VIDEO_OPTIONS)
       strlcpy(title, "VIDEO OPTIONS", sizeof(title));
-   else if (menu_type == RGUI_SETTINGS_INPUT_OPTIONS)
+   else if (menu_type == RGUI_SETTINGS_INPUT_OPTIONS ||
+         menu_type == RGUI_SETTINGS_CUSTOM_BIND ||
+         menu_type == RGUI_SETTINGS_CUSTOM_BIND_KEYBOARD)
       strlcpy(title, "INPUT OPTIONS", sizeof(title));
    else if (menu_type == RGUI_SETTINGS_OVERLAY_OPTIONS)
       strlcpy(title, "OVERLAY OPTIONS", sizeof(title));
@@ -322,18 +324,17 @@ static void rgui_render(void *data)
    else if (menu_type == RGUI_SETTINGS_CORE_OPTIONS)
       strlcpy(title, "CORE OPTIONS", sizeof(title));
    else if (menu_type == RGUI_SETTINGS_CORE_INFO)
-      strlcpy(title, "CORE INFO", sizeof(title));		  
+      strlcpy(title, "CORE INFO", sizeof(title));
    else if (menu_type == RGUI_SETTINGS_PRIVACY_OPTIONS)
-      strlcpy(title, "PRIVACY OPTIONS", sizeof(title)); 	  
+      strlcpy(title, "PRIVACY OPTIONS", sizeof(title));
 #ifdef HAVE_SHADER_MANAGER
    else if (menu_type_is(menu_type) == RGUI_SETTINGS_SHADER_OPTIONS)
       snprintf(title, sizeof(title), "SHADER %s", dir);
 #endif
-   else if ((menu_type == RGUI_SETTINGS_INPUT_OPTIONS) ||
-         (menu_type == RGUI_SETTINGS_PATH_OPTIONS) ||
-         (menu_type == RGUI_SETTINGS_OPTIONS) ||
-         (menu_type == RGUI_SETTINGS_CUSTOM_VIEWPORT || menu_type == RGUI_SETTINGS_CUSTOM_VIEWPORT_2) ||
-         menu_type == RGUI_SETTINGS_CUSTOM_BIND ||
+   else if (menu_type == RGUI_SETTINGS_PATH_OPTIONS ||
+         menu_type == RGUI_SETTINGS_OPTIONS ||
+         menu_type == RGUI_SETTINGS_CUSTOM_VIEWPORT ||
+         menu_type == RGUI_SETTINGS_CUSTOM_VIEWPORT_2 ||
          menu_type == RGUI_START_SCREEN ||
          menu_type == RGUI_SETTINGS)
       snprintf(title, sizeof(title), "MENU %s", dir);
@@ -417,7 +418,7 @@ static void rgui_render(void *data)
       char type_str[256];
 
       unsigned w = 19;
-      if (menu_type == RGUI_SETTINGS_INPUT_OPTIONS || menu_type == RGUI_SETTINGS_CUSTOM_BIND)
+      if (menu_type == RGUI_SETTINGS_INPUT_OPTIONS || menu_type == RGUI_SETTINGS_CUSTOM_BIND || menu_type == RGUI_SETTINGS_CUSTOM_BIND_KEYBOARD)
          w = 21;
       else if (menu_type == RGUI_SETTINGS_PATH_OPTIONS)
          w = 24;

--- a/frontend/menu/menu_common.h
+++ b/frontend/menu/menu_common.h
@@ -1,7 +1,7 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
  *  Copyright (C) 2011-2014 - Daniel De Matteis
- * 
+ *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-
  *  ation, either version 3 of the License, or (at your option) any later version.
@@ -249,6 +249,7 @@ typedef enum
    RGUI_SETTINGS_BIND_GRAB_MOUSE_TOGGLE,
    RGUI_SETTINGS_BIND_MENU_TOGGLE,
    RGUI_SETTINGS_CUSTOM_BIND,
+   RGUI_SETTINGS_CUSTOM_BIND_KEYBOARD,
    RGUI_SETTINGS_CUSTOM_BIND_ALL,
    RGUI_SETTINGS_CUSTOM_BIND_DEFAULT_ALL,
    RGUI_SETTINGS_ONSCREEN_KEYBOARD_ENABLE,
@@ -294,9 +295,11 @@ struct rgui_bind_axis_state
    int16_t locked_axes[RGUI_MAX_AXES];
 };
 
+#define RGUI_KEYBOARD_BIND_TIMEOUT_SECONDS 3
 struct rgui_bind_state
 {
    struct retro_keybind *target;
+   int64_t timeout_end; // For keyboard binding.
    unsigned begin;
    unsigned last;
    unsigned player;
@@ -308,6 +311,7 @@ struct rgui_bind_state
 void menu_poll_bind_get_rested_axes(struct rgui_bind_state *state);
 void menu_poll_bind_state(struct rgui_bind_state *state);
 bool menu_poll_find_trigger(struct rgui_bind_state *state, struct rgui_bind_state *new_state);
+bool menu_custom_bind_keyboard_cb(void *data, unsigned code);
 
 #ifdef GEKKO
 enum
@@ -337,12 +341,12 @@ enum
    GX_RESOLUTIONS_448_448,
    GX_RESOLUTIONS_480_448,
    GX_RESOLUTIONS_512_448,
-   GX_RESOLUTIONS_576_448, 
-   GX_RESOLUTIONS_608_448, 
-   GX_RESOLUTIONS_640_448, 
-   GX_RESOLUTIONS_340_464, 
-   GX_RESOLUTIONS_512_464, 
-   GX_RESOLUTIONS_512_472, 
+   GX_RESOLUTIONS_576_448,
+   GX_RESOLUTIONS_608_448,
+   GX_RESOLUTIONS_640_448,
+   GX_RESOLUTIONS_340_464,
+   GX_RESOLUTIONS_512_464,
+   GX_RESOLUTIONS_512_472,
    GX_RESOLUTIONS_384_480,
    GX_RESOLUTIONS_512_480,
    GX_RESOLUTIONS_530_480,

--- a/frontend/menu/menu_input_line_cb.c
+++ b/frontend/menu/menu_input_line_cb.c
@@ -1,7 +1,7 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
  *  Copyright (C) 2011-2014 - Daniel De Matteis
- * 
+ *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-
  *  ation, either version 3 of the License, or (at your option) any later version.

--- a/input/keyboard_line.c
+++ b/input/keyboard_line.c
@@ -1,6 +1,6 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
- * 
+ *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-
  *  ation, either version 3 of the License, or (at your option) any later version.
@@ -98,6 +98,9 @@ const char **input_keyboard_line_get_buffer(const input_keyboard_line_t *state)
 
 static input_keyboard_line_t *g_keyboard_line;
 
+static input_keyboard_press_t g_keyboard_press_cb;
+static void *g_keyboard_press_data;
+
 const char **input_keyboard_start_line(void *userdata, input_keyboard_line_complete_t cb)
 {
    if (g_keyboard_line)
@@ -110,9 +113,29 @@ const char **input_keyboard_start_line(void *userdata, input_keyboard_line_compl
    return input_keyboard_line_get_buffer(g_keyboard_line);
 }
 
+void input_keyboard_wait_keys(void *userdata, input_keyboard_press_t cb)
+{
+   g_keyboard_press_cb = cb;
+   g_keyboard_press_data = userdata;
+   // While waiting for input, we have to block all hotkeys.
+   driver.block_input = true;
+}
+
+void input_keyboard_wait_keys_cancel(void)
+{
+   g_keyboard_press_cb = NULL;
+   g_keyboard_press_data = NULL;
+   driver.block_input = false;
+}
+
 void input_keyboard_event(bool down, unsigned code, uint32_t character, uint16_t mod)
 {
-   if (g_keyboard_line)
+   if (g_keyboard_press_cb)
+   {
+      if (down && code != RETROK_UNKNOWN && !g_keyboard_press_cb(g_keyboard_press_data, code))
+         input_keyboard_wait_keys_cancel();
+   }
+   else if (g_keyboard_line)
    {
       if (input_keyboard_line_event(g_keyboard_line, character))
       {

--- a/input/keyboard_line.h
+++ b/input/keyboard_line.h
@@ -1,6 +1,6 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
- * 
+ *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-
  *  ation, either version 3 of the License, or (at your option) any later version.
@@ -31,6 +31,8 @@ typedef struct input_keyboard_line input_keyboard_line_t;
 // line can be NULL.
 typedef void (*input_keyboard_line_complete_t)(void *userdata, const char *line);
 
+typedef bool (*input_keyboard_press_t)(void *userdata, unsigned code);
+
 input_keyboard_line_t *input_keyboard_line_new(void *userdata,
       input_keyboard_line_complete_t cb);
 
@@ -45,6 +47,11 @@ void input_keyboard_line_free(input_keyboard_line_t *state);
 // This interfaces with the global driver struct and libretro callbacks.
 void input_keyboard_event(bool down, unsigned code, uint32_t character, uint16_t mod);
 const char **input_keyboard_start_line(void *userdata, input_keyboard_line_complete_t cb);
+
+// Wait for keys to be pressed (used for binding keys in RGUI).
+// Callback returns false when all polling is done.
+void input_keyboard_wait_keys(void *userdata, input_keyboard_press_t cb);
+void input_keyboard_wait_keys_cancel(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
I've implemented a basic keyboard binding scheme in RGUI. Still kinda hacky though.

Press RIGHT on binds instead of OK/accept button to bind keyboard. It has a timeout, and if hit, it'll just clear out the bind (can't use a key to cancel because that'd just be treated as a bind :P).

Dunno how to make it clearer, I don't want to add doubled up sets of binds in the menu just to differentiate between things. Maybe a bind mode (keyboard / joypad) is doable, but we'll see.

Binding keyboard stuff from RGUI is obviously not as "safe" as joypad binds. If you end up breaking binds, you might be locked out of RGUI until you cleanup the config manually.

Another caveat, binding the Quit RetroArch button will immediately exit retroarch for obvious reasons. At least the bind is saved properly ...
