### PR TITLE
LUT texture filtering improvements, etc.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ OBJ = frontend/frontend.o \
 		conf/config_file.o \
 		screenshot.o \
 		gfx/scaler/scaler.o \
+		gfx/shader_common.o \
 		gfx/shader_parse.o \
 		gfx/scaler/pixconv.o \
 		gfx/scaler/scaler_int.o \

--- a/gfx/shader_common.c
+++ b/gfx/shader_common.c
@@ -1,0 +1,82 @@
+/*  RetroArch - A frontend for libretro.
+ *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
+ * 
+ *  RetroArch is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  RetroArch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with RetroArch.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "shader_common.h"
+#include "../retroarch_logger.h"
+
+#ifdef HAVE_OPENGL
+//  gl_common.c may or may not be a better location for these functions.
+void gl_load_texture_data(GLuint obj, const struct texture_image *img,
+      GLenum wrap, bool linear, bool mipmap)
+{
+   glBindTexture(GL_TEXTURE_2D, obj);
+
+#ifdef HAVE_OPENGLES2
+   GLenum wrap = GL_CLAMP_TO_EDGE;
+#endif
+   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, wrap);
+   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, wrap);
+
+   GLint filter = linear ? (mipmap ? GL_LINEAR_MIPMAP_LINEAR : GL_LINEAR) :
+                           (mipmap ? GL_NEAREST_MIPMAP_NEAREST : GL_NEAREST);
+   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);
+   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter);
+
+#ifndef HAVE_PSGL
+   glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
+#endif
+   glTexImage2D(GL_TEXTURE_2D,
+         0, driver.gfx_use_rgba ? GL_RGBA : RARCH_GL_INTERNAL_FORMAT32, img->width, img->height,
+         0, driver.gfx_use_rgba ? GL_RGBA : RARCH_GL_TEXTURE_TYPE32, RARCH_GL_FORMAT32, img->pixels);
+   if (mipmap)
+   {
+      glGenerateMipmap(GL_TEXTURE_2D);
+   }
+}
+
+bool gl_load_luts(const struct gfx_shader *generic_shader, GLuint *lut_textures)
+{
+   unsigned i;
+   unsigned num_luts = min(generic_shader->luts, GFX_MAX_TEXTURES);
+   if (!generic_shader->luts)
+      return true;
+
+   //  Original shader_glsl.c code only generated one texture handle.  I assume
+   //  it was a bug, but if not, replace num_luts with 1 when GLSL is used.
+   glGenTextures(num_luts, lut_textures);
+   for (i = 0; i < num_luts; i++)
+   {
+      RARCH_LOG("Loading texture image from: \"%s\" ...\n",
+            generic_shader->lut[i].path);
+      struct texture_image img = {0};
+      if (!texture_image_load(generic_shader->lut[i].path, &img))
+      {
+         RARCH_ERR("Failed to load texture image from: \"%s\"\n", generic_shader->lut[i].path);
+         return false;
+      }
+
+      gl_load_texture_data(lut_textures[i], &img,
+            gl_wrap_type_to_enum(generic_shader->lut[i].wrap),
+            generic_shader->lut[i].filter != RARCH_FILTER_NEAREST,
+            generic_shader->lut[i].mipmap);
+      texture_image_free(&img);
+   }
+
+   glBindTexture(GL_TEXTURE_2D, 0);
+   return true;
+}
+#endif // HAVE_OPENGL
+
+

--- a/gfx/shader_common.h
+++ b/gfx/shader_common.h
@@ -56,5 +56,9 @@ struct gl_shader_backend
    enum rarch_shader_type type;
 };
 
+void gl_load_texture_data(GLuint obj, const struct texture_image *img,
+      GLenum wrap, bool linear, bool mipmap);
+bool gl_load_luts(const struct gfx_shader *generic_shader, GLuint *lut_textures);
+
 #endif
 

--- a/gfx/shader_parse.c
+++ b/gfx/shader_parse.c
@@ -80,7 +80,6 @@ static bool shader_parse_pass(config_file_t *conf, struct gfx_shader_pass *pass,
    // Smooth
    char filter_name_buf[64];
    print_buf(filter_name_buf, "filter_linear%u", i);
-
    bool smooth = false;
    if (config_get_bool(conf, filter_name_buf, &smooth))
       pass->filter = smooth ? RARCH_FILTER_LINEAR : RARCH_FILTER_NEAREST;
@@ -244,7 +243,6 @@ static bool shader_parse_textures(config_file_t *conf, struct gfx_shader *shader
 
       char id_filter[64];
       print_buf(id_filter, "%s_linear", id);
-
       bool smooth = false;
       if (config_get_bool(conf, id_filter, &smooth))
          shader->lut[shader->luts].filter = smooth ? RARCH_FILTER_LINEAR : RARCH_FILTER_NEAREST;
@@ -256,6 +254,14 @@ static bool shader_parse_textures(config_file_t *conf, struct gfx_shader *shader
       char wrap_mode[64];
       if (config_get_array(conf, id_wrap, wrap_mode, sizeof(wrap_mode)))
          shader->lut[shader->luts].wrap = wrap_str_to_mode(wrap_mode);
+
+      char id_mipmap[64];
+      print_buf(id_mipmap, "%s_mipmap", id);
+      bool mipmap = false;
+      if (config_get_bool(conf, id_mipmap, &mipmap))
+         shader->lut[shader->luts].mipmap = mipmap;
+      else
+         shader->lut[shader->luts].mipmap = false;
    }
 
    return true;
@@ -1084,11 +1090,14 @@ void gfx_shader_write_conf_cgp(config_file_t *conf, const struct gfx_shader *sha
          if (shader->lut[i].filter != RARCH_FILTER_UNSPEC)
          {
             print_buf(key, "%s_linear", shader->lut[i].id);
-            config_set_bool(conf, key, shader->lut[i].filter != RARCH_FILTER_LINEAR);
+            config_set_bool(conf, key, shader->lut[i].filter == RARCH_FILTER_LINEAR);
          }
 
          print_buf(key, "%s_wrap_mode", shader->lut[i].id);
          config_set_string(conf, key, wrap_mode_to_str(shader->lut[i].wrap));
+
+         print_buf(key, "%s_mipmap", shader->lut[i].id);
+         config_set_bool(conf, key, shader->lut[i].mipmap);
       }
    }
 

--- a/gfx/shader_parse.h
+++ b/gfx/shader_parse.h
@@ -88,6 +88,7 @@ struct gfx_shader_lut
    char path[PATH_MAX];
    enum gfx_filter_type filter;
    enum gfx_wrap_type wrap;
+   bool mipmap;
 };
 
 // This is pretty big, shouldn't be put on the stack.


### PR DESCRIPTION
Hey Squarepusher,
This is the mipmapping support we talked about on IRC.  The first commit message is pretty self-explanatory, but there are two things you might want to glance at just in case I screwed something up:

First, check out line 58 of shader_common.c.  The original LUT loading code for GLSL only generated a single texture handle, whereas the code for Cg generated one for each LUT as expected.  I'm assuming that was just a bug in the GLSL code, so I fixed it in the refactored code, but if there was a good reason for it, the new function will have to be tweaked accordingly.

Second, I eliminated the MAX_LUT_TEXTURES macro from shader_cg.c and used GFX_MAX_TEXTURES in its place, which is what shader_glsl.c used.  I'm assuming MAX_LUT_TEXTURES was just an unnecessary duplicate macro for the same conceptual value, but I wanted to bring it to your attention in case I'm mistaken.
