### PR TITLE
Give sRGB FBO's priority over float FBO's:

### DIFF
--- a/gfx/gl.c
+++ b/gfx/gl.c
@@ -521,32 +521,33 @@ static void gl_create_fbo_textures(void *data)
             RARCH_ERR("Floating-point FBO was requested, but is not supported. Falling back to UNORM.\n");
       }
 
-#ifndef HAVE_OPENGLES2
-      if (fp_fbo && gl->has_fp_fbo)
+      if (srgb_fbo && gl->has_srgb_fbo)
       {
-         RARCH_LOG("FBO pass #%d is floating-point.\n", i);
-         glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA32F,
-               gl->fbo_rect[i].width, gl->fbo_rect[i].height,
-               0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+         RARCH_LOG("FBO pass #%d is sRGB.\n", i);
+#ifdef HAVE_OPENGLES2
+         glTexImage2D(GL_TEXTURE_2D,
+               0, GL_SRGB_ALPHA_EXT,
+               gl->fbo_rect[i].width, gl->fbo_rect[i].height, 0,
+               GL_SRGB_ALPHA_EXT, GL_UNSIGNED_BYTE, NULL);
+#else
+         glTexImage2D(GL_TEXTURE_2D,
+               0, GL_SRGB8_ALPHA8,
+               gl->fbo_rect[i].width, gl->fbo_rect[i].height, 0,
+               GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+#endif
       }
       else
-#endif
       {
-         if (srgb_fbo && gl->has_srgb_fbo)
+#ifndef HAVE_OPENGLES2
+         if (fp_fbo && gl->has_fp_fbo)
          {
-#ifdef HAVE_OPENGLES2
-            glTexImage2D(GL_TEXTURE_2D,
-                  0, GL_SRGB_ALPHA_EXT,
-                  gl->fbo_rect[i].width, gl->fbo_rect[i].height, 0,
-                  GL_SRGB_ALPHA_EXT, GL_UNSIGNED_BYTE, NULL);
-#else
-            glTexImage2D(GL_TEXTURE_2D,
-                  0, GL_SRGB8_ALPHA8,
-                  gl->fbo_rect[i].width, gl->fbo_rect[i].height, 0,
-                  GL_RGBA, GL_UNSIGNED_BYTE, NULL);
-#endif
+            RARCH_LOG("FBO pass #%d is floating-point.\n", i);
+            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA32F,
+                  gl->fbo_rect[i].width, gl->fbo_rect[i].height,
+                  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
          }
          else
+#endif
          {
 #ifdef HAVE_OPENGLES2
             glTexImage2D(GL_TEXTURE_2D,

--- a/gfx/shader_common.c
+++ b/gfx/shader_common.c
@@ -32,10 +32,11 @@ void gl_load_texture_data(GLuint obj, const struct texture_image *img,
    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, wrap);
    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, wrap);
 
-   GLint filter = linear ? (mipmap ? GL_LINEAR_MIPMAP_LINEAR : GL_LINEAR) :
-                           (mipmap ? GL_NEAREST_MIPMAP_NEAREST : GL_NEAREST);
-   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);
-   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter);
+   GLint mag_filter = linear? GL_LINEAR : GL_NEAREST;
+   GLint min_filter = linear ? (mipmap ? GL_LINEAR_MIPMAP_LINEAR : GL_LINEAR) :
+                               (mipmap ? GL_NEAREST_MIPMAP_NEAREST : GL_NEAREST);
+   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, mag_filter);
+   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, min_filter);
 
 #ifndef HAVE_PSGL
    glPixelStorei(GL_UNPACK_ALIGNMENT, 4);


### PR DESCRIPTION
Both pass through linear RGB similarly, but sRGB should be faster.
If both are enabled, the .cgp author won't need float32-only features like
packing multiple values.  This also makes testing/usage priority the same.
Add sRGB FBO logging to mirror float FBO logging.
Make LUT mipmapping consistent with FBO's (ignore it for magnification.)
