### PR TITLE
macro for binding menu button

### DIFF
--- a/input/autoconf/builtin.h
+++ b/input/autoconf/builtin.h
@@ -1,6 +1,6 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2013-2014 - pinumbernumber
- *  
+ *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-
  *  ation, either version 3 of the License, or (at your option) any later version.
@@ -19,6 +19,6 @@
 #include "../input_common.h"
 #define DECL_BTN(btn, bind) "input_" #btn "_btn = " #bind "\n"
 #define DECL_AXIS(axis, bind) "input_" #axis "_axis = " #bind "\n"
+#define DECL_MENU(btn) "input_menu_toggle_btn = " #btn "\n"
 
 #endif
-

--- a/input/autoconf/builtin_android.c
+++ b/input/autoconf/builtin_android.c
@@ -1,7 +1,7 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
  *  Copyright (C) 2011-2014 - Daniel De Matteis
- *  
+ *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-
  *  ation, either version 3 of the License, or (at your option) any later version.
@@ -39,7 +39,7 @@ DECL_AXIS(r_x_plus,  +2) \
 DECL_AXIS(r_x_minus, -2) \
 DECL_AXIS(r_y_plus,  -3) \
 DECL_AXIS(r_y_minus, +3) \
-"input_menu_toggle_btn = 108\n"
+DECL_MENU(108)
 
 // TODO
 // Verify if stick works
@@ -58,7 +58,7 @@ DECL_BTN(l, 100) \
 DECL_BTN(l2, 102) \
 DECL_BTN(start, 105) \
 DECL_BTN(select, 110) \
-"input_menu_toggle_btn = 104\n"
+DECL_MENU(104)
 
 // TODO
 // - D-pad - verify if it works
@@ -103,7 +103,7 @@ DECL_BTN(left, 21) \
 DECL_BTN(right, 22) \
 DECL_BTN(l, 102) \
 DECL_BTN(r, 103) \
-"input_menu_toggle_btn = 82\n"
+DECL_MENU(82)
 
 // TODO
 // - Analog sticks - verify if they work
@@ -227,7 +227,7 @@ DECL_AXIS(r_x_plus,  +2) \
 DECL_AXIS(r_x_minus, -2) \
 DECL_AXIS(r_y_plus, +3) \
 DECL_AXIS(r_y_minus, -3) \
-"input_menu_toggle_btn = 82\n"
+DECL_MENU(82)
 
 #define SIDEWINDER_DUAL_STRIKE_DEFAULT_BINDS \
 DECL_BTN(a, 190) \
@@ -246,7 +246,7 @@ DECL_AXIS(r_x_plus,  +0) \
 DECL_AXIS(r_x_minus, -0) \
 DECL_AXIS(r_y_plus, -1) \
 DECL_AXIS(r_y_minus, +1) \
-"input_menu_toggle_btn = 196\n"
+DECL_MENU(196)
 
 #define SIDEWINDER_CLASSIC_DEFAULT_BINDS \
 DECL_BTN(a, 97) \
@@ -367,7 +367,7 @@ DECL_AXIS(r_x_plus,  +2) \
 DECL_AXIS(r_x_minus, -2) \
 DECL_AXIS(r_y_plus, +3) \
 DECL_AXIS(r_y_minus, -3) \
-"input_menu_toggle_btn = 82\n"
+DECL_MENU(82)
 
 #define HUIJIA_DEFAULT_BINDS \
 DECL_BTN(a, 189) \
@@ -565,7 +565,7 @@ const char* const input_builtin_autoconfs[] =
    "input_device = \"SideWinder Classic\" \n"
    "input_driver = \"android\"                    \n"
    SIDEWINDER_CLASSIC_DEFAULT_BINDS,
-   
+
    "input_device = \"MUCH iReadyGo i5\" \n"
    "input_driver = \"android\"                    \n"
    MUCH_IREADYGO_I5_DEFAULT_BINDS


### PR DESCRIPTION
this will clean code --

what about adding a macro like this:

   DECL_AUTOCONF_DEVICE("NVIDIA Shield", "android", SHIELD_DEFAULT_BINDS)

to replace all the:

   "input_device = \"NVIDIA Shield\" \n"
   "input_driver = \"android\"                    \n"
   SHIELD_DEFAULT_BINDS,

since the autoconf files will be edited again and again, I think this is important for them to be as simple as possible
