### PR TITLE
fix DECL_AUTOCONF_DEVICE macro

### DIFF
--- a/input/autoconf/builtin.h
+++ b/input/autoconf/builtin.h
@@ -20,6 +20,6 @@
 #define DECL_BTN(btn, bind) "input_" #btn "_btn = " #bind "\n"
 #define DECL_AXIS(axis, bind) "input_" #axis "_axis = " #bind "\n"
 #define DECL_MENU(btn) "input_menu_toggle_btn = " #btn "\n"
-#define DECL_AUTOCONF_DEVICE(device, driver, binds) "input_device = \"" #device "\" \ninput_driver = \"" #driver "\"                    \n" #binds
+#define DECL_AUTOCONF_DEVICE(device, driver, binds) "input_device = \"" #device "\" \ninput_driver = \"" #driver "\"                    \n" binds
 
 #endif


### PR DESCRIPTION
This fixes input device auto-configuration (which was broken by c5c6223d3f9d727939135dd6512b932cb29cd2f6). One shouldn't use string literal replacement for `binds`, which is a macro its self, not a string.
