### PR TITLE
VG backend fixes

### DIFF
--- a/gfx/vg.c
+++ b/gfx/vg.c
@@ -25,11 +25,8 @@
 #include "../general.h"
 #include "../driver.h"
 #include "../performance.h"
-
-#ifdef HAVE_FREETYPE
 #include "fonts/fonts.h"
 #include "../file.h"
-#endif
 
 typedef struct
 {


### PR DESCRIPTION
Fixes for a couple of small issues in the VG backend:
- Removed a reference to a missing struct field
- Removed an ifdef that failed compilation without freetype
