### PR TITLE
rxml.c: Get rid of a free called on a null pointer

### DIFF
--- a/compat/rxml/rxml.c
+++ b/compat/rxml/rxml.c
@@ -247,7 +247,6 @@ static struct rxml_node *rxml_parse_node(const char **ptr_)
 
       if (!closing_tag)
       {
-         free(closing_tag);
          goto error;
       }
 


### PR DESCRIPTION
Would equate to a NOP, but it's still a good idea to take it out.
