### PR TITLE
(Android) restrict abi targets

### DIFF
--- a/android/phoenix/jni/Application.mk
+++ b/android/phoenix/jni/Application.mk
@@ -3,4 +3,4 @@ ifeq ($(GLES),3)
 else
    APP_PLATFORM := android-9
 endif
-APP_ABI := all
+APP_ABI := armeabi-v7a mips x86


### PR DESCRIPTION
This fixes a build error I get with the latest android NDK (r10) complaining about an unsupported architecture (armeabi, maybe it was retired). Also, libretro-build-android-mk.sh only builds the cores for armeabi-v7a, mips and x86 anyway so there is no point in building the app for other architectures.
