### PR TITLE
lakka: Fix overflow possibilities when copying to icon_dir

### DIFF
--- a/frontend/menu/disp/lakka.c
+++ b/frontend/menu/disp/lakka.c
@@ -63,7 +63,7 @@ float title_margin_top;
 float label_margin_left;
 float label_margin_top;
 int icon_size;
-char icon_dir[3];
+char icon_dir[4];
 float above_subitem_offset;
 float above_item_offset;
 float active_item_factor;


### PR DESCRIPTION
strcpy also copies over the null-terminator as well.

See line 148 for an example of where this would happen.
