### PR TITLE
Fix volume hotkeys

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -2755,7 +2755,7 @@ static void check_volume(void)
    bool pressed_up   = input_key_pressed_func(RARCH_VOLUME_UP);
    bool pressed_down = input_key_pressed_func(RARCH_VOLUME_DOWN);
 
-   if (!g_extern.audio_active || !pressed_up || !pressed_down)
+   if (!pressed_up && !pressed_down)
       return;
 
    if (pressed_up)


### PR DESCRIPTION
not sure if it breaks something, not sure about the purpose of g_extern.audio_active, I guess !g_extern.audio_active means mute, in that case I guess it should be && instead of || anyway?
