### PR TITLE
Revert "Add .project to .gitignore for Eclipse support"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,4 +63,3 @@ apple/RetroArch_iOS.xcodeproj/project.xcworkspace/*
 /python/
 /rsound.h
 .pc
-.project


### PR DESCRIPTION
Possibility this might cause problems with the Android build, and conflicts with local Eclipse installs can be worked around as RA sources can be linked into another Eclipse project.
