### PR TITLE
Fix spurious error message in init_movie()

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -1680,18 +1680,19 @@ static void init_movie(void)
             g_extern.bsv.movie_start_path);
 
       msg_queue_clear(g_extern.msg_queue);
-      msg_queue_push(g_extern.msg_queue,
-            g_extern.bsv.movie ? msg : "Failed to start movie record.", 1, 180);
-
       if ((g_extern.bsv.movie = bsv_movie_init(g_extern.bsv.movie_start_path,
                   RARCH_MOVIE_RECORD)))
       {
+         msg_queue_push(g_extern.msg_queue, msg, 1, 180);
          RARCH_LOG("Starting movie record to \"%s\".\n",
                g_extern.bsv.movie_start_path);
          g_settings.rewind_granularity = 1;
       }
       else
+      {
+         msg_queue_push(g_extern.msg_queue, "Failed to start movie record.", 1, 180);
          RARCH_ERR("Failed to start movie record.\n");
+      }
    }
 }
 


### PR DESCRIPTION
g_extern.bsv.movie was checked before bsv_movie_init, resulting
in failure report even if recording succeeded.
