### PR TITLE
Add --enable-preserve_dylib configure option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -490,6 +490,10 @@ ifeq ($(HAVE_7ZIP),1)
    JOYCONFIG_OBJ += $(7ZOBJ)
 endif
 
+ifeq ($(HAVE_PRESERVE_DYLIB),1)
+   DEFINES += -DNO_DLCLOSE
+endif
+
 ifneq ($(V),1)
    Q := @
 endif

--- a/dynamic.c
+++ b/dynamic.c
@@ -451,7 +451,9 @@ void dylib_close(dylib_t lib)
 #ifdef _WIN32
    FreeLibrary((HMODULE)lib);
 #else
+#ifndef NO_DLCLOSE
    dlclose(lib);
+#endif
 #endif
 }
 #endif

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -52,6 +52,11 @@ if [ "$HAVE_7ZIP" = "yes" ]; then
    add_include_dirs ./decompress/7zip/
 fi
 
+if [ "$HAVE_PRESERVE_DYLIB" = "yes" ]; then
+   echo "Disabling dlclose() of shared objects for Valgrind support."
+   add_define_make HAVE_PRESERVE_DYLIB "1"
+fi
+
 if [ "$HAVE_FLOATHARD" = "yes" ]; then
    CFLAGS="$CFLAGS -mfloat-abi=hard"
    CXXFLAGS="$CXXFLAGS -mfloat-abi=hard"

--- a/qb/config.params.sh
+++ b/qb/config.params.sh
@@ -45,3 +45,4 @@ HAVE_SSE=no             # Forcefully enable x86 SSE optimizations (SSE, SSE2)
 HAVE_FLOATHARD=no       # Force hard float ABI (for ARM)
 HAVE_FLOATSOFTFP=no     # Force soft float ABI (for ARM)
 HAVE_7ZIP=yes           # Compile in 7z support
+HAVE_PRESERVE_DYLIB=no  # Disable dlclose() for Valgrind support


### PR DESCRIPTION
Valgrind requires shared objects to be kept open for meaningful
debug information. Add configure option to disable dlclose() in
dylib_close().

Renamed option following discussion on IRC.
