### PR TITLE
VS: Enable multi-core compilation for release builds only

### DIFF
--- a/msvc/msvc-2010/RetroArch-msvc2010.vcxproj
+++ b/msvc/msvc-2010/RetroArch-msvc2010.vcxproj
@@ -106,7 +106,6 @@
       <CompileAs>CompileAsCpp</CompileAs>
       <FloatingPointModel>Fast</FloatingPointModel>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
-      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -127,7 +126,6 @@
       <CompileAs>CompileAsCpp</CompileAs>
       <FloatingPointModel>Fast</FloatingPointModel>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
-      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
Was a little overzealous. These should only be enabled on release builds, as debug builds have 'minimal rebuild' on, which will make the compiler ignore /MP.
