### PR TITLE
Fix an uninitialized variable warning on OSX

### DIFF
--- a/apple/OSX/platform.m
+++ b/apple/OSX/platform.m
@@ -315,6 +315,9 @@ static char** waiting_argv;
       case 3:
          cmd = RARCH_CMD_SAVE_STATE;
          break;
+      default:
+         cmd = RARCH_CMD_NONE;
+         break;
    }
 
    rarch_main_command(cmd);


### PR DESCRIPTION
Might not happen, but it gets rid of an analysis warning.
