### PR TITLE
nulllocation: Remove nulllocation_t.

### DIFF
--- a/location/nulllocation.c
+++ b/location/nulllocation.c
@@ -16,10 +16,6 @@
 
 #include "../driver.h"
 
-typedef struct null_location
-{
-} nulllocation_t;
-
 static void *null_location_init(void)
 {
    return NULL;


### PR DESCRIPTION
This is technically not even allowed (empty struct) according to the C standard, but is a GNU-specific extension.
