### PR TITLE
Use setting_data_get_string_representation + fix a bug

### DIFF
--- a/frontend/menu/disp/lakka.c
+++ b/frontend/menu/disp/lakka.c
@@ -755,43 +755,20 @@ void lakka_init_settings(void)
                item->num_subitems++;
 
                item->subitems = (menu_subitem_t*)
-                  realloc(item->subitems, item->num_subitems * sizeof(menu_subitem_t));
+                  realloc(item->subitems, 
+                     item->num_subitems * sizeof(menu_subitem_t));
 
                menu_subitem_t *subitem = (menu_subitem_t*)&item->subitems[kk];
 
-               strlcpy(subitem->name, setting.short_description, sizeof(subitem->name));
+               strlcpy(subitem->name, setting.short_description, 
+                     sizeof(subitem->name));
                subitem->alpha = kk ? 1.0 : 0.5;
                subitem->zoom = kk ? i_active_zoom : i_passive_zoom;
                subitem->y = kk ? vspacing * (kk + under_item_offset)
                   : vspacing * active_item_factor;
 
-               if (setting.type == ST_BOOL)
-               {
-                  if (setting.value.boolean)
-                     strlcpy(subitem->value, "ON", sizeof(subitem->value));
-                  else
-                     strlcpy(subitem->value, "OFF", sizeof(subitem->value));
-               }
-               else if (setting.type == ST_INT)
-               {
-                  sprintf(subitem->value, "%d", *setting.value.integer);
-               }
-               else if (setting.type == ST_UINT)
-               {
-                  sprintf(subitem->value, "%u", *setting.value.unsigned_integer);
-               }
-               else if (setting.type == ST_FLOAT)
-               {
-                  sprintf(subitem->value, "%f", *setting.value.fraction);
-               }
-               else if (setting.type == ST_STRING || setting.type == ST_PATH || setting.type == ST_DIR)
-               {
-                  sprintf(subitem->value, "%s", setting.value.string);
-               }
-               else
-               {
-                  strlcpy(subitem->value, "tbd", sizeof(subitem->value));
-               }
+               setting_data_get_string_representation(&setting, subitem->value,
+                     sizeof(subitem->value));
 
                kk++;
             }

--- a/settings_data.c
+++ b/settings_data.c
@@ -603,11 +603,15 @@ void setting_data_get_string_representation(rarch_setting_t* setting,
             snprintf(buf, sizeof_buf, "[KB:%s] [JS:%s] [AX:%s]", key_name, button_name, axis_name);
 #else
 #ifdef HAVE_MENU
-            const struct retro_keybind* bind = (const struct retro_keybind*)
-               &setting->value.keybind[driver.menu->current_pad];
-            const struct retro_keybind* auto_bind = (const struct retro_keybind*)
-               input_get_auto_bind(driver.menu->current_pad, bind->id);
-            input_get_bind_string(buf, bind, auto_bind, sizeof_buf);
+            if (driver.menu != NULL)
+            {
+               const struct retro_keybind* bind = (const struct retro_keybind*)
+                  &setting->value.keybind[driver.menu->current_pad];
+               const struct retro_keybind* auto_bind = 
+                  (const struct retro_keybind*)
+                  input_get_auto_bind(driver.menu->current_pad, bind->id);
+               input_get_bind_string(buf, bind, auto_bind, sizeof_buf);
+            }
 #endif
 #endif
          }


### PR DESCRIPTION
There was a segfault because driver.menu is not set in case of lakka (and I don't understand why, as lakka_init is returning menu) so added a check of driver.menu in settings_data.c. I hope this check does not break something elsewhere.
