### PR TITLE
osx: Remove a redundant compile flag

### DIFF
--- a/apple/OSX/OSX/RetroArch_OSX.xcodeproj/project.pbxproj
+++ b/apple/OSX/OSX/RetroArch_OSX.xcodeproj/project.pbxproj
@@ -422,7 +422,6 @@
 					"-D_7ZIP_ST",
 					"-DHAVE_COMPRESSION",
 					"-DHAVE_7ZIP",
-					"-DHAVE_7ZIP",
 					"-DHAVE_LAKKA",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
This is already defined
