### PR TITLE
retroarch_logger: Include header stdio.h

### DIFF
--- a/retroarch_logger.h
+++ b/retroarch_logger.h
@@ -18,6 +18,7 @@
 #define __RARCH_LOGGER_H
 
 #include <stdarg.h>
+#include <stdio.h>
 
 #if defined(RARCH_DUMMY_LOG)
 #define LOG_FILE (stderr)


### PR DESCRIPTION
Prior to this, if this file was included in a source file, but stdio.h was not, then a compile error would result, as the log calls internally print to stderr, which is defined within stdio.h
