### PR TITLE
command: Fix possible null dereference in rarch_cmd_free

### DIFF
--- a/command.c
+++ b/command.c
@@ -161,7 +161,7 @@ error:
 void rarch_cmd_free(rarch_cmd_t *handle)
 {
 #if defined(HAVE_NETWORK_CMD) && defined(HAVE_NETPLAY)
-   if (handle->net_fd >= 0)
+   if (handle && handle->net_fd >= 0)
       close(handle->net_fd);
 #endif
 


### PR DESCRIPTION
Free called on null pointers is OK, but if it's ever null and it hits this conditional, it will be a null pointer dereference.
