### PR TITLE
playlist: Fix erroneous return value.

### DIFF
--- a/playlist.c
+++ b/playlist.c
@@ -199,7 +199,7 @@ static bool content_playlist_read_file(
       if (file)
          fclose(file);
 
-      return true;
+      return false;
    }
 
    for (playlist->size = 0; playlist->size < playlist->cap; )


### PR DESCRIPTION
This should actually be false, since it failed to read the playlist file in this case.
