### PR TITLE
retroarch_logger: Append the calling function name to the log message.

### DIFF
--- a/frontend/menu/disp/rgui.c
+++ b/frontend/menu/disp/rgui.c
@@ -152,7 +152,7 @@ static bool init_font(menu_handle_t *menu, const uint8_t *font_bmp_buf)
 
    if (!font)
    {
-      RARCH_ERR("Font memory allocation failed in %s", __FUNCTION__);
+      RARCH_ERR("Font memory allocation failed.\n");
       return false;
    }
 

--- a/gfx/gl.c
+++ b/gfx/gl.c
@@ -207,7 +207,7 @@ static bool gl_shader_init(gl_t *gl)
 
    if (!gl)
    {
-      RARCH_ERR("Invalid GL instance passed to %s", __FUNCTION__);
+      RARCH_ERR("Invalid GL instance passed.\n");
       return false;
    }
 

--- a/gfx/state_tracker.c
+++ b/gfx/state_tracker.c
@@ -88,7 +88,7 @@ state_tracker_t* state_tracker_init(const struct state_tracker_info *info)
 
    if (!tracker->info)
    {
-      RARCH_ERR("%s: Allocation of state tracker info failed.", __FUNCTION__);
+      RARCH_ERR("Allocation of state tracker info failed.\n");
       free(tracker);
       return NULL;
    }

--- a/message_queue.c
+++ b/message_queue.c
@@ -75,7 +75,7 @@ void msg_queue_push(msg_queue_t *queue, const char *msg,
       calloc(1, sizeof(struct queue_elem));
    if (!new_elem)
    {
-      RARCH_ERR("New element allocation failed in %s", __FUNCTION__);
+      RARCH_ERR("New element allocation failed.\n");
       return;
    }
 

--- a/retroarch_logger.h
+++ b/retroarch_logger.h
@@ -51,14 +51,16 @@
 #define RARCH_LOG(...) do { \
       if (RARCH_LOG_VERBOSE) \
       { \
-         fprintf(LOG_FILE, "RetroArch: " __VA_ARGS__); \
+         fprintf(LOG_FILE, "RetroArch: %s: ", __FUNCTION__); \
+         fprintf(LOG_FILE, __VA_ARGS__); \
          fflush(LOG_FILE); \
       } \
    } while (0)
 #define RARCH_LOG_V(tag, fmt, vp) do { \
       if (RARCH_LOG_VERBOSE) \
       { \
-         fprintf(LOG_FILE, "RetroArch: " tag); \
+         fprintf(LOG_FILE, "RetroArch: %s: " __FUNCTION__); \
+         fprintf(LOG_FILE, tag);\
          vfprintf(LOG_FILE, fmt, vp); \
          fflush(LOG_FILE); \
       } \
@@ -68,24 +70,28 @@
 #ifndef RARCH_LOG_OUTPUT
 #undef RARCH_LOG_OUTPUT_V
 #define RARCH_LOG_OUTPUT(...) do { \
-         fprintf(LOG_FILE, __VA_ARGS__); \
-         fflush(LOG_FILE); \
+      fprintf(LOG_FILE, "%s: ", __FUNCTION__); \
+      fprintf(LOG_FILE, __VA_ARGS__); \
+      fflush(LOG_FILE); \
    } while (0)
 #define RARCH_LOG_OUTPUT_V(tag, fmt, vp) do { \
-         fprintf(LOG_FILE, "RetroArch: " tag); \
-         vfprintf(LOG_FILE, fmt, vp); \
-         fflush(LOG_FILE); \
+      fprintf(LOG_FILE, "RetroArch: %s: ", __FUNCTION__); \
+      fprintf(LOG_FILE, tag); \
+      vfprintf(LOG_FILE, fmt, vp); \
+      fflush(LOG_FILE); \
    } while (0)
 #endif
 
 #ifndef RARCH_ERR
 #undef RARCH_ERR_V
 #define RARCH_ERR(...) do { \
-      fprintf(LOG_FILE, "RetroArch [ERROR] :: " __VA_ARGS__); \
+      fprintf(LOG_FILE, "RetroArch [ERROR] :: %s :: ", __FUNCTION__); \
+      fprintf(LOG_FILE, __VA_ARGS__); \
       fflush(LOG_FILE); \
    } while (0)
 #define RARCH_ERR_V(tag, fmt, vp) do { \
-      fprintf(LOG_FILE, "RetroArch [ERROR] :: " tag); \
+      fprintf(LOG_FILE, "RetroArch [ERROR] :: %s :: ", __FUNCTION__); \
+      fprintf(LOG_FILE, tag); \
       vfprintf(LOG_FILE, fmt, vp); \
       fflush(LOG_FILE); \
    } while (0)
@@ -94,11 +100,13 @@
 #ifndef RARCH_WARN
 #undef RARCH_WARN_V
 #define RARCH_WARN(...) do { \
-      fprintf(LOG_FILE, "RetroArch [WARN] :: " __VA_ARGS__); \
+      fprintf(LOG_FILE, "RetroArch [WARN] :: %s :: ", __FUNCTION__); \
+      fprintf(LOG_FILE, __VA_ARGS__); \
       fflush(LOG_FILE); \
    } while (0)
 #define RARCH_WARN_V(tag, fmt, vp) do { \
-      fprintf(LOG_FILE, "RetroArch [WARN] :: " tag); \
+      fprintf(LOG_FILE, "RetroArch [WARN] :: %s :: ", __FUNCTION__); \
+      fprintf(LOG_FILE, tag); \
       vfprintf(LOG_FILE, fmt, vp); \
       fflush(LOG_FILE); \
    } while (0)

--- a/settings_data.c
+++ b/settings_data.c
@@ -43,13 +43,13 @@ static void get_input_config_prefix(char *buf, size_t sizeof_buf,
 {
    if (!buf)
    {
-      RARCH_ERR("Null buffer passed to %s", __FUNCTION__);
+      RARCH_ERR("Null buffer passed.\n");
       return;
    }
 
    if (!setting)
    {
-      RARCH_ERR("Null setting passed to %s", __FUNCTION__);
+      RARCH_ERR("Null setting passed.\n");
       return;
    }
 
@@ -64,13 +64,13 @@ static void get_input_config_key(char *buf, size_t sizeof_buf,
 
    if (!buf)
    {
-      RARCH_ERR("Null buffer passed to %s", __FUNCTION__);
+      RARCH_ERR("Null buffer passed.\n");
       return;
    }
 
    if (!setting)
    {
-      RARCH_ERR("Null setting passed to %s", __FUNCTION__);
+      RARCH_ERR("Null setting passed.\n");
       return;
    }
 
@@ -89,13 +89,13 @@ static void get_key_name(char *buf, size_t sizeof_buf,
 
    if (!buf)
    {
-      RARCH_ERR("Null buffer passed to %s", __FUNCTION__);
+      RARCH_ERR("Null buffer passed.\n");
       return;
    }
 
    if (!setting)
    {
-      RARCH_ERR("Null setting passed to %s", __FUNCTION__);
+      RARCH_ERR("Null setting passed.\n");
       return;
    }
 
@@ -120,13 +120,13 @@ static void get_button_name(char *buf, size_t sizeof_buf,
 {
    if (!buf)
    {
-      RARCH_ERR("Null buffer passed to %s", __FUNCTION__);
+      RARCH_ERR("Null buffer passed.\n");
       return;
    }
 
    if (!setting)
    {
-      RARCH_ERR("Null setting passed to %s", __FUNCTION__);
+      RARCH_ERR("Null setting passed.\n");
       return;
    }
 
@@ -144,13 +144,13 @@ static void get_axis_name(char *buf, size_t sizeof_buf,
 
    if (!buf)
    {
-      RARCH_ERR("Null buffer passed to %s", __FUNCTION__);
+      RARCH_ERR("Null buffer passed.\n");
       return;
    }
 
    if (!setting)
    {
-      RARCH_ERR("Null setting passed to %s", __FUNCTION__);
+      RARCH_ERR("Null setting passed.\n");
       return;
    }
 
@@ -166,7 +166,7 @@ void setting_data_reset_setting(const rarch_setting_t* setting)
 {
    if (!setting)
    {
-      RARCH_ERR("Null setting passed to %s", __FUNCTION__);
+      RARCH_ERR("Null setting passed.\n");
       return;
    }
 
@@ -531,7 +531,7 @@ static void menu_common_setting_set_label_st_bool(rarch_setting_t *setting,
 {
    if (!setting)
    {
-      RARCH_ERR("Null setting passed to %s", __FUNCTION__);
+      RARCH_ERR("Null setting passed.\n");
       return;
    }
 
@@ -555,7 +555,7 @@ static void menu_common_setting_set_label_st_uint(rarch_setting_t *setting,
 {
    if (!setting)
    {
-      RARCH_ERR("Null setting passed to %s", __FUNCTION__);
+      RARCH_ERR("Null setting passed.\n");
       return;
    }
 
@@ -629,7 +629,7 @@ static void menu_common_setting_set_label_st_float(rarch_setting_t *setting,
 {
    if (!setting)
    {
-      RARCH_ERR("Null setting passed to %s", __FUNCTION__);
+      RARCH_ERR("Null setting passed.\n");
       return;
    }
 


### PR DESCRIPTION
Makes tracing back a little easier.
