### PR TITLE
iOS: Directly synthsize RAMenuItemBasic properties

### DIFF
--- a/apple/iOS/menu.m
+++ b/apple/iOS/menu.m
@@ -134,6 +134,10 @@ static void RunActionSheet(const char* title, const struct string_list* items, U
 /* selected.                                 */
 /*********************************************/
 @implementation RAMenuItemBasic
+@synthesize description;
+@synthesize userdata;
+@synthesize action;
+@synthesize detail;
 
 + (RAMenuItemBasic*)itemWithDescription:(NSString*)description action:(void (^)())action
 {


### PR DESCRIPTION
On iOS, when properties are not explicitly synthesized in their implementation, the compiler will attempt to do something that is called "autosynthesis", which is essentially it synthesizing the properties for you. However the problem with this is that it can trip up the compiler if you have a subclass of a base class that has a property with the same name as one in the base class.

Also consider how properties work. Say we have a property like so:

`@property int someVar;`

This is telling the compiler to make a getter and a setter for a class member variable named someVar which is of type int. So the following functions will be created.
`+(int) someVar()`, which is the getter.
`+(void) setSomeVar:(int) var`, which is the setter.

In this case, RAMenuItemBasic inherits from NSObject, which already has a function named "description", yet we were trying to generate a getter/setter for our own variable named that, which leads to clashing. This is why the property was never being synthesized correctly. Directly declaring the synthesizing calls ourselves fixes this.
