### PR TITLE
Only apply shader parameters immediately in Shader Parameters (Current).

### DIFF
--- a/frontend/menu/backend/menu_common_backend.c
+++ b/frontend/menu/backend/menu_common_backend.c
@@ -954,7 +954,8 @@ static int menu_common_shader_manager_setting_toggle(
 
       param->current = min(max(param->minimum, param->current), param->maximum);
 
-      if (apply_changes)
+      if (apply_changes 
+       && !strcmp(label, "video_shader_parameters"))
          rarch_main_command(RARCH_CMD_SHADERS_APPLY_CHANGES);
    }
    else if ((!strcmp(label, "video_shader_parameters") ||


### PR DESCRIPTION
Fixes Shader Parameters (Menu). This makes it easier to use shader parameters on large multi-pass shaders that take a while to compile (such as CRT Royale), since applying parameter changes immediately makes the shaders recompile now and it can make changing parameters really slow in those cases, but it now saves to preset file immediately as well so it's a good trade-off and you can use menu parameters for those that take a long time to recompile.
