### PR TITLE
Removed specific viWidth for 16:9 mode, not needed anymore

### DIFF
--- a/gfx/gx/gx_gfx.c
+++ b/gfx/gx/gx_gfx.c
@@ -127,8 +127,6 @@ void gx_set_video_mode(void *data, unsigned fbWidth, unsigned lines)
    viWidth    = g_settings.video.viwidth;
 #if defined(HW_RVL)
 #if 0
-   if (CONF_GetAspectRatio() == CONF_ASPECT_16_9)
-      viWidth = 704;
 #endif
 
    progressive = CONF_GetProgressiveScan() > 0 && VIDEO_HaveComponentCable();


### PR DESCRIPTION
I just noticed this mistake, on my fork it was commented out but it's not needed at all and not removing it might prevent using the config viwidth when Wii is set to widescreen.
