### PR TITLE
Allow the menu to run immediately again if there is input

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -3261,7 +3261,8 @@ int rarch_main_iterate(void)
       if (!menu_iterate(input, old_input, trigger_input))
          rarch_main_set_state(RARCH_ACTION_STATE_MENU_RUNNING_FINISHED);
 
-      ret = 1;
+      if ( ! input )
+        ret = 1;
       goto success;
    }
 #endif


### PR DESCRIPTION
This corresponds to when the user is holding down a button. Run loops
are typically edge triggered and not level triggered, so we only see
the changes, thus we don't get continually woken up when the level
stays at HIGH.
