### PR TITLE
Fix segfault on invalid graphics context driver

### DIFF
--- a/gfx/gfx_context.c
+++ b/gfx/gfx_context.c
@@ -77,7 +77,7 @@ const gfx_ctx_driver_t *gfx_ctx_find_driver(const char *ident)
    unsigned i;
    for (i = 0; i < ARRAY_SIZE(gfx_ctx_drivers); i++)
    {
-      if (strcmp(gfx_ctx_drivers[i]->ident, ident) == 0)
+      if (gfx_ctx_drivers[i] && strcmp(gfx_ctx_drivers[i]->ident, ident) == 0)
          return gfx_ctx_drivers[i];
    }
 


### PR DESCRIPTION
Last element of gfx_ctx_drivers[] is NULL, don't dereference it.
