### PR TITLE
Merge volume_db and audio_volume, save audio_volume

### DIFF
--- a/general.h
+++ b/general.h
@@ -580,7 +580,6 @@ struct global
       double orig_src_ratio;
       size_t driver_buffer_size;
 
-      float volume_db;
       float volume_gain;
    } audio_data;
 

--- a/runloop.c
+++ b/runloop.c
@@ -52,16 +52,16 @@ static void set_volume(float gain)
 {
    char msg[256];
 
-   g_extern.audio_data.volume_db += gain;
-   g_extern.audio_data.volume_db = max(g_extern.audio_data.volume_db, -80.0f);
-   g_extern.audio_data.volume_db = min(g_extern.audio_data.volume_db, 12.0f);
+   g_settings.audio.volume += gain;
+   g_settings.audio.volume = max(g_settings.audio.volume, -80.0f);
+   g_settings.audio.volume = min(g_settings.audio.volume, 12.0f);
 
-   snprintf(msg, sizeof(msg), "Volume: %.1f dB", g_extern.audio_data.volume_db);
+   snprintf(msg, sizeof(msg), "Volume: %.1f dB", g_settings.audio.volume);
    msg_queue_clear(g_extern.msg_queue);
    msg_queue_push(g_extern.msg_queue, msg, 1, 180);
    RARCH_LOG("%s\n", msg);
 
-   g_extern.audio_data.volume_gain = db_to_gain(g_extern.audio_data.volume_db);
+   g_extern.audio_data.volume_gain = db_to_gain(g_settings.audio.volume);
 }
 
 static void check_grab_mouse_toggle(void)

--- a/settings.c
+++ b/settings.c
@@ -402,7 +402,6 @@ static void config_set_defaults(void)
    g_settings.audio.rate_control = rate_control;
    g_settings.audio.rate_control_delta = rate_control_delta;
    g_settings.audio.volume = audio_volume;
-   g_extern.audio_data.volume_db   = g_settings.audio.volume;
    g_extern.audio_data.volume_gain = db_to_gain(g_settings.audio.volume);
 
    g_settings.rewind_enable = rewind_enable;
@@ -991,7 +990,6 @@ static bool config_load_file(const char *path, bool set_defaults)
    CONFIG_GET_FLOAT(audio.rate_control_delta, "audio_rate_control_delta");
    CONFIG_GET_FLOAT(audio.volume, "audio_volume");
    CONFIG_GET_STRING(audio.resampler, "audio_resampler");
-   g_extern.audio_data.volume_db   = g_settings.audio.volume;
    g_extern.audio_data.volume_gain = db_to_gain(g_settings.audio.volume);
 
    CONFIG_GET_STRING(camera.device, "camera_device");
@@ -1575,6 +1573,7 @@ bool config_save_file(const char *path)
    config_set_bool(conf, "audio_rate_control", g_settings.audio.rate_control);
    config_set_float(conf, "audio_rate_control_delta",
          g_settings.audio.rate_control_delta);
+   config_set_float(conf, "audio_volume", g_settings.audio.volume);
    config_set_string(conf, "audio_driver", g_settings.audio.driver);
    config_set_bool(conf, "audio_enable", g_settings.audio.enable);
    config_set_int(conf, "audio_out_rate", g_settings.audio.out_rate);


### PR DESCRIPTION
This prevents unexpected volume changes on RARCH_VOLUME_UP and
RARCH_VOLUME_DOWN, and adds convenience by saving to config file.
