### PR TITLE
Fix use-after-free

### DIFF
--- a/file_list.c
+++ b/file_list.c
@@ -108,8 +108,11 @@ void file_list_clear(file_list_t *list)
    for (i = 0; i < list->size; i++)
    {
       free(list->list[i].path);
+      list->list[i].path = NULL;
       free(list->list[i].label);
+      list->list[i].label = NULL;
       free(list->list[i].alt);
+      list->list[i].alt = NULL;
    }
 
 #ifdef HAVE_MENU

--- a/frontend/menu/backend/menu_common_backend.c
+++ b/frontend/menu/backend/menu_common_backend.c
@@ -411,12 +411,15 @@ static int menu_settings_iterate(unsigned action)
       file_list_get_at_offset(driver.menu->selection_buf,
             driver.menu->selection_ptr, NULL, &label, &type);
 
-   if (!strcmp(label, "core_list"))
-      dir = g_settings.libretro_directory;
-   else if (!strcmp(label, "configurations"))
-      dir = g_settings.menu_config_directory;
-   else if (!strcmp(label, "disk_image_append"))
-      dir = g_settings.menu_content_directory;
+   if (label)
+   {
+      if (!strcmp(label, "core_list"))
+         dir = g_settings.libretro_directory;
+      else if (!strcmp(label, "configurations"))
+         dir = g_settings.menu_config_directory;
+      else if (!strcmp(label, "disk_image_append"))
+         dir = g_settings.menu_content_directory;
+   }
 
    if (driver.menu->need_refresh && action != MENU_ACTION_MESSAGE)
       action = MENU_ACTION_NOOP;


### PR DESCRIPTION
menu_settings_iterate() would strcmp freed labels after exiting
a submenu.
