### PR TITLE
use menu_set_navigation after a keyboard search instead of modifying

### DIFF
--- a/frontend/menu/menu_input_line_cb.c
+++ b/frontend/menu/menu_input_line_cb.c
@@ -62,9 +62,11 @@ static void menu_key_end_line(void *data)
 static void menu_search_callback(void *userdata, const char *str)
 {
    menu_handle_t *menu = (menu_handle_t*)userdata;
+   size_t index;
 
-   if (str && *str)
-      file_list_search(menu->selection_buf, str, &menu->selection_ptr);
+   if (str && *str && file_list_search(menu->selection_buf, str, &index))
+         menu_set_navigation(menu, index);
+
    menu_key_end_line(menu);
 }
 


### PR DESCRIPTION
menu->selection_ptr directly.
