### PR TITLE
Apply deferred settings before freeing settings list

### DIFF
--- a/frontend/menu/backend/menu_common_backend.c
+++ b/frontend/menu/backend/menu_common_backend.c
@@ -219,6 +219,7 @@ static int menu_settings_iterate(unsigned action,
          break;
 
       case MENU_ACTION_CANCEL:
+         apply_deferred_settings();
          menu_entries_pop_list(driver.menu->menu_stack);
          break;
       case MENU_ACTION_SELECT:


### PR DESCRIPTION
Deferred settings were getting lost on exiting the settings menu.
