### PR TITLE
fixes game screen sometimes not showing in combination with some shaders

### DIFF
--- a/frontend/menu/disp/glui.c
+++ b/frontend/menu/disp/glui.c
@@ -137,6 +137,7 @@ static void glui_render_background(bool force_transparency)
       glBindTexture(GL_TEXTURE_2D, 0);
    }
 
+   gl->shader->use(gl, GL_SHADER_STOCK_BLEND);
    gl->shader->set_coords(&coords);
    gl->shader->set_mvp(gl, &gl->mvp_no_rot);
 

--- a/frontend/menu/disp/lakka.c
+++ b/frontend/menu/disp/lakka.c
@@ -184,6 +184,7 @@ static void lakka_draw_background(bool force_transparency)
       glBindTexture(GL_TEXTURE_2D, 0);
    }
 
+   gl->shader->use(gl, GL_SHADER_STOCK_BLEND);
    gl->shader->set_coords(&coords);
    gl->shader->set_mvp(gl, &gl->mvp_no_rot);
 

--- a/frontend/menu/disp/xmb.c
+++ b/frontend/menu/disp/xmb.c
@@ -294,6 +294,7 @@ static void xmb_render_background(bool force_transparency)
       glBindTexture(GL_TEXTURE_2D, 0);
    }
 
+   gl->shader->use(gl, GL_SHADER_STOCK_BLEND);
    gl->shader->set_coords(&coords);
    gl->shader->set_mvp(gl, &gl->mvp_no_rot);
 


### PR DESCRIPTION
and menu drivers using GL.
note: this still doesnt fix the game screen not showing when
pause_libretro is set to true.
