### PR TITLE
input: Get rid of some if statement conditions

### DIFF
--- a/input/input_autodetect.c
+++ b/input/input_autodetect.c
@@ -160,8 +160,7 @@ void input_config_autoconfigure_joypad(unsigned index,
 
 const struct retro_keybind *input_get_auto_bind(unsigned port, unsigned id)
 {
-   int joy_index = g_settings.input.joypad_map[port];
-   if (joy_index < 0)
-      return NULL;
+   unsigned int joy_index = g_settings.input.joypad_map[port];
+
    return &g_settings.input.autoconf_binds[joy_index][id];
 }

--- a/input/input_common.c
+++ b/input/input_common.c
@@ -148,8 +148,8 @@ bool input_joypad_set_rumble(const rarch_joypad_driver_t *drv,
    if (!drv || !drv->set_rumble)
       return false;
 
-   int joy_index = g_settings.input.joypad_map[port];
-   if (joy_index < 0 || joy_index >= MAX_PLAYERS)
+   unsigned int joy_index = g_settings.input.joypad_map[port];
+   if (joy_index >= MAX_PLAYERS)
       return false;
 
    return drv->set_rumble(joy_index, effect, strength);
@@ -161,8 +161,8 @@ bool input_joypad_pressed(const rarch_joypad_driver_t *drv,
    if (!drv)
       return false;
 
-   int joy_index = g_settings.input.joypad_map[port];
-   if (joy_index < 0 || joy_index >= MAX_PLAYERS)
+   unsigned int joy_index = g_settings.input.joypad_map[port];
+   if (joy_index >= MAX_PLAYERS)
       return false;
 
    /* Auto-binds are per joypad, not per player. */
@@ -195,8 +195,8 @@ int16_t input_joypad_analog(const rarch_joypad_driver_t *drv,
    if (!drv)
       return 0;
 
-   int joy_index = g_settings.input.joypad_map[port];
-   if (joy_index < 0 || joy_index >= MAX_PLAYERS)
+   unsigned int joy_index = g_settings.input.joypad_map[port];
+   if (joy_index >= MAX_PLAYERS)
       return 0;
 
    /* Auto-binds are per joypad, not per player. */


### PR DESCRIPTION
`g_settings.input.joypad_map[port]` returns an unsigned int by default, so just use `unsigned int` over `int` for the corresponding storage variables.
