### PR TITLE
(qb) Add header argument to check_lib

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -14,6 +14,7 @@ DYLIB=-ldl;
 CLIB=-lc
 PTHREADLIB=-lpthread
 SOCKETLIB=-lc
+SOCKETHEADER=
 
 if [ "$OS" = 'BSD' ]; then
    DYLIB=-lc;
@@ -24,6 +25,7 @@ elif [ "$OS" = 'Haiku' ]; then
    SOCKETLIB=-lnetwork
 elif [ "$OS" = 'Win32' ]; then
    SOCKETLIB=-lws2_32
+   SOCKETHEADER="#include <winsock2.h>"
    DYLIB=
 fi
 
@@ -133,7 +135,8 @@ else
    check_lib DYLIB "$DYLIB" dlopen
 fi
 
-check_lib NETPLAY "$SOCKETLIB" socket
+check_lib NETPLAY "$SOCKETLIB" socket "" "$SOCKETHEADER"
+
 if [ "$HAVE_NETPLAY" = 'yes' ]; then
    HAVE_GETADDRINFO=auto
    check_lib GETADDRINFO "$SOCKETLIB" getaddrinfo

--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -19,13 +19,17 @@ add_include_dirs()
 add_library_dirs()
 {	while [ "$1" ]; do LIBRARY_DIRS="$LIBRARY_DIRS -L$1"; shift; done;}
 
-check_lib()	#$1 = HAVE_$1	$2 = lib	$3 = function in lib	$4 = extralibs
+check_lib()	#$1 = HAVE_$1	$2 = lib	$3 = function in lib	$4 = extralibs $5 = headers
 {	tmpval="$(eval echo \$HAVE_$1)"
 	[ "$tmpval" = 'no' ] && return 0
 
 	if [ "$3" ]; then
 		ECHOBUF="Checking function $3 in ${2% }"
-		echo "void $3(void); int main(void) { $3(); return 0; }" > $TEMP_C
+		if [ "$5" ]; then
+			printf "$5\nint main(void) { void *p = (void*)$3; return 0; }" > $TEMP_C
+		else
+			echo "void $3(void); int main(void) { $3(); return 0; }" > $TEMP_C
+		fi
 	else
 		ECHOBUF="Checking existence of ${2% }"
 		echo "int main(void) { return 0; }" > $TEMP_C


### PR DESCRIPTION
Fixes "socket() in -lws2_32" check when compiling to Win32 in a Win64 environment.
