### PR TITLE
Android: Use apply instead of commit for applying SharedPreference changes

### DIFF
--- a/android/phoenix/src/com/retroarch/browser/DisplayRefreshRateTest.java
+++ b/android/phoenix/src/com/retroarch/browser/DisplayRefreshRateTest.java
@@ -45,7 +45,7 @@ public final class DisplayRefreshRateTest extends Activity {
 			SharedPreferences prefs = UserPreferences.getPreferences(DisplayRefreshRateTest.this);
 			SharedPreferences.Editor edit = prefs.edit();
 			edit.putString("video_refresh_rate", Double.toString(fps));
-			edit.commit();
+			edit.apply();
 		}
 
 		@Override

--- a/android/phoenix/src/com/retroarch/browser/dirfragment/DirectoryFragment.java
+++ b/android/phoenix/src/com/retroarch/browser/dirfragment/DirectoryFragment.java
@@ -252,7 +252,7 @@ public class DirectoryFragment extends DialogFragment
 			SharedPreferences settings = UserPreferences.getPreferences(getActivity());
 			SharedPreferences.Editor editor = settings.edit();
 			editor.putString(pathSettingKey, path);
-			editor.commit();
+			editor.apply();
 		}
 
 		if (onClosedListener != null)

--- a/android/phoenix/src/com/retroarch/browser/mainmenu/MainMenuActivity.java
+++ b/android/phoenix/src/com/retroarch/browser/mainmenu/MainMenuActivity.java
@@ -45,7 +45,7 @@ public final class MainMenuActivity extends FragmentActivity
 		SharedPreferences.Editor edit = prefs.edit();
 		edit.putString("libretro_path", core_path);
 		edit.putString("libretro_name", core_name);
-		edit.commit();
+		edit.apply();
 
 		// Set the title section to contain the name of the selected core.
 		setCoreTitle(core_name);

--- a/android/phoenix/src/com/retroarch/browser/mainmenu/MainMenuFragment.java
+++ b/android/phoenix/src/com/retroarch/browser/mainmenu/MainMenuFragment.java
@@ -78,7 +78,7 @@ public final class MainMenuFragment extends PreferenceListFragment implements On
 		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(ctx);
 		if (!prefs.getBoolean("first_time_refreshrate_calculate", false))
 		{
-			prefs.edit().putBoolean("first_time_refreshrate_calculate", true).commit();
+			prefs.edit().putBoolean("first_time_refreshrate_calculate", true).apply();
 
 			AlertDialog.Builder alert = new AlertDialog.Builder(ctx)
 						.setTitle(R.string.welcome_to_retroarch)

--- a/android/phoenix/src/com/retroarch/browser/preferences/fragments/VideoPreferenceFragment.java
+++ b/android/phoenix/src/com/retroarch/browser/preferences/fragments/VideoPreferenceFragment.java
@@ -48,7 +48,7 @@ public final class VideoPreferenceFragment extends PreferenceListFragment implem
 			final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
 			final SharedPreferences.Editor edit = prefs.edit();
 			edit.putString("video_refresh_rate", Double.toString(rate));
-			edit.commit();
+			edit.apply();
 
 			Toast.makeText(getActivity(), String.format(getString(R.string.using_os_reported_refresh_rate), rate), Toast.LENGTH_LONG).show();
 		}

--- a/android/phoenix/src/com/retroarch/browser/preferences/util/UserPreferences.java
+++ b/android/phoenix/src/com/retroarch/browser/preferences/util/UserPreferences.java
@@ -141,7 +141,7 @@ public final class UserPreferences
 		readbackBool(config, edit, "savefile_directory_enable"); // Ignored by RetroArch
 		readbackBool(config, edit, "savestate_directory_enable"); // Ignored by RetroArch
 
-		edit.commit();
+		edit.apply();
 	}
 
 	/**

--- a/android/phoenix/src/com/retroarch/browser/retroactivity/RetroActivityCamera.java
+++ b/android/phoenix/src/com/retroarch/browser/retroactivity/RetroActivityCamera.java
@@ -162,7 +162,7 @@ public class RetroActivityCamera extends RetroActivityCommon
 		SharedPreferences prefs = UserPreferences.getPreferences(this);
 		SharedPreferences.Editor edit = prefs.edit();
 		edit.putBoolean("CAMERA_UPDATES_ON", false);
-		edit.commit();
+		edit.apply();
 
 		camera_service_running = false;
 
@@ -176,7 +176,7 @@ public class RetroActivityCamera extends RetroActivityCommon
 		SharedPreferences prefs = UserPreferences.getPreferences(this);
 		SharedPreferences.Editor edit = prefs.edit();
 		edit.putBoolean("CAMERA_UPDATES_ON", camera_service_running);
-		edit.commit();
+		edit.apply();
 		
 		onCameraStop();
 		super.onPause();
@@ -203,7 +203,7 @@ public class RetroActivityCamera extends RetroActivityCommon
 		else // Otherwise, turn off camera updates
 		{
 			edit.putBoolean("CAMERA_UPDATES_ON", false);
-			edit.commit();
+			edit.apply();
 			camera_service_running = false;
 		}
 		super.onResume();

--- a/android/phoenix/src/com/retroarch/browser/retroactivity/RetroActivityLocation.java
+++ b/android/phoenix/src/com/retroarch/browser/retroactivity/RetroActivityLocation.java
@@ -276,7 +276,7 @@ implements ConnectionCallbacks, OnConnectionFailedListener, LocationListener
 		SharedPreferences prefs = UserPreferences.getPreferences(this);
 		SharedPreferences.Editor edit = prefs.edit();
 		edit.putBoolean("LOCATION_UPDATES_ON", mUpdatesRequested);
-		edit.commit();
+		edit.apply();
 
 		super.onPause();
 	}
@@ -300,7 +300,7 @@ implements ConnectionCallbacks, OnConnectionFailedListener, LocationListener
 		else // Otherwise, turn off location updates
 		{
 			edit.putBoolean("LOCATION_UPDATES_ON", false);
-			edit.commit();
+			edit.apply();
 			location_service_running = false;
 		}
 


### PR DESCRIPTION
This will apply changes asynchronously, so it gets rid of some blocking IO.
It probably doesn't matter, but is considered good practice.
