### PR TITLE
Android: Disallow explicit instantiation of utility classes

### DIFF
--- a/android/phoenix/src/com/retroarch/browser/NativeInterface.java
+++ b/android/phoenix/src/com/retroarch/browser/NativeInterface.java
@@ -3,10 +3,16 @@ package com.retroarch.browser;
 /**
  * Helper class which calls into JNI for various tasks.
  */
-public final class NativeInterface {
-
-	static {
+public final class NativeInterface
+{
+	static
+	{
 		System.loadLibrary("retroarch-jni");
+	}
+
+	// Disallow explicit instantiation.
+	private NativeInterface()
+	{
 	}
 
 	public static native boolean extractArchiveTo(String archive,

--- a/android/phoenix/src/com/retroarch/browser/preferences/util/UserPreferences.java
+++ b/android/phoenix/src/com/retroarch/browser/preferences/util/UserPreferences.java
@@ -26,6 +26,11 @@ public final class UserPreferences
 	// Logging tag.
 	private static final String TAG = "UserPreferences";
 
+	// Disallow explicit instantiation.
+	private UserPreferences()
+	{
+	}
+
 	/**
 	 * Retrieves the path to the default location of the libretro config.
 	 * 


### PR DESCRIPTION
It doesn't make sense to allow instantiation of classes that are only composed of static members.
