### PR TITLE
Add audio_max_timing_skew setting

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -544,6 +544,10 @@ static const bool rate_control = false;
  * is allowed to adjust input rate. */
 static const float rate_control_delta = 0.005;
 
+/* Maximum timing skew. Defines how much adjust_system_rates
+ * is allowed to adjust input rate. */
+static const float max_timing_skew = 0.05;
+
 /* Default audio volume in dB. (0.0 dB == unity gain). */
 static const float audio_volume = 0.0;
 

--- a/driver.c
+++ b/driver.c
@@ -763,7 +763,7 @@ static void adjust_system_rates(void)
 
    timing_skew = fabs(1.0f - info->fps / g_settings.video.refresh_rate);
 
-   if (timing_skew > 0.05f)
+   if (timing_skew > g_settings.audio.max_timing_skew)
    {
       /* We don't want to adjust pitch too much. If we have extreme cases,
        * just don't readjust at all. */

--- a/general.h
+++ b/general.h
@@ -334,6 +334,7 @@ struct settings
 
       bool rate_control;
       float rate_control_delta;
+      float max_timing_skew;
       float volume; /* dB scale. */
       char resampler[32];
    } audio;

--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -271,6 +271,10 @@
 # Input rate = in_rate * (1.0 +/- audio_rate_control_delta)
 # audio_rate_control_delta = 0.005
 
+# Controls maximum audio timing skew. Defines the maximum change in input rate.
+# Input rate = in_rate * (1.0 +/- max_timing_skew)
+# audio_max_timing_skew = 0.05
+
 # Audio volume. Volume is expressed in dB.
 # 0 dB is normal volume. No gain will be applied.
 # Gain can be controlled in runtime with input_volume_up/input_volume_down.

--- a/settings.c
+++ b/settings.c
@@ -406,6 +406,7 @@ static void config_set_defaults(void)
    g_settings.audio.sync = audio_sync;
    g_settings.audio.rate_control = rate_control;
    g_settings.audio.rate_control_delta = rate_control_delta;
+   g_settings.audio.max_timing_skew = max_timing_skew;
    g_settings.audio.volume = audio_volume;
    g_extern.audio_data.volume_gain = db_to_gain(g_settings.audio.volume);
 
@@ -1012,6 +1013,7 @@ static bool config_load_file(const char *path, bool set_defaults)
    CONFIG_GET_BOOL(audio.sync, "audio_sync");
    CONFIG_GET_BOOL(audio.rate_control, "audio_rate_control");
    CONFIG_GET_FLOAT(audio.rate_control_delta, "audio_rate_control_delta");
+   CONFIG_GET_FLOAT(audio.max_timing_skew, "audio_max_timing_skew");
    CONFIG_GET_FLOAT(audio.volume, "audio_volume");
    CONFIG_GET_STRING(audio.resampler, "audio_resampler");
    g_extern.audio_data.volume_gain = db_to_gain(g_settings.audio.volume);
@@ -1602,6 +1604,8 @@ bool config_save_file(const char *path)
    config_set_bool(conf, "audio_rate_control", g_settings.audio.rate_control);
    config_set_float(conf, "audio_rate_control_delta",
          g_settings.audio.rate_control_delta);
+   config_set_float(conf, "audio_max_timing_skew",
+         g_settings.audio.max_timing_skew);
    config_set_float(conf, "audio_volume", g_settings.audio.volume);
    config_set_string(conf, "video_context_driver", g_settings.video.context_driver);
    config_set_string(conf, "audio_driver", g_settings.audio.driver);

--- a/settings_data.c
+++ b/settings_data.c
@@ -1582,6 +1582,20 @@ int setting_data_get_description(const char *label, char *msg,
             " Input rate is defined as: \n"
             " input rate * (1.0 +/- (rate control delta))");
    }
+   else if (!strcmp(label, "audio_max_timing_skew"))
+   {
+      snprintf(msg, sizeof_msg,
+            " -- Maximum audio timing skew.\n"
+            " \n"
+            "Defines the maximum change in input rate.\n"
+            "You may want to increase this to enable\n"
+            "very large changes in timing, for example\n"
+            "running PAL cores on NTSC displays, at the\n"
+            "cost of inaccurate audio pitch.\n"
+            " \n"
+            " Input rate is defined as: \n"
+            " input rate * (1.0 +/- (max timing skew))");
+   }
    else if (!strcmp(label, "video_filter"))
    {
 #ifdef HAVE_FILTERS_BUILTIN
@@ -2388,6 +2402,8 @@ static void general_read_handler(void *data)
          g_settings.audio.rate_control_delta = *setting->value.fraction;
       }
    }
+   else if (!strcmp(setting->name, "audio_max_timing_skew"))
+      *setting->value.fraction = g_settings.audio.max_timing_skew;
    else if (!strcmp(setting->name, "video_refresh_rate_auto"))
       *setting->value.fraction = g_settings.video.refresh_rate;
    else if (!strcmp(setting->name, "input_player1_joypad_index"))
@@ -2493,6 +2509,8 @@ static void general_write_handler(void *data)
          g_settings.audio.rate_control_delta = *setting->value.fraction;
       }
    }
+   else if (!strcmp(setting->name, "audio_max_timing_skew"))
+      g_settings.audio.max_timing_skew = *setting->value.fraction;
    else if (!strcmp(setting->name, "video_refresh_rate_auto"))
    {
       if (driver.video && driver.video_data)
@@ -4124,6 +4142,25 @@ static bool setting_data_append_list_audio_options(
          0.001,
          true,
          false);
+
+   CONFIG_FLOAT(
+         g_settings.audio.max_timing_skew,
+         "audio_max_timing_skew",
+         "Audio Maximum Timing Skew",
+         max_timing_skew,
+         "%.2f",
+         group_info.name,
+         subgroup_info.name,
+         general_write_handler,
+         general_read_handler);
+   settings_list_current_add_range(
+         list,
+         list_info,
+         0.01,
+         0.5,
+         0.01,
+         true,
+         true);
 
    CONFIG_UINT(
          g_settings.audio.block_frames,


### PR DESCRIPTION
Let users enable very large timing skews if they don't mind
inaccurate audio pitch.
