### PR TITLE
Android: Make UI more compliant with 5.0

### DIFF
--- a/android/phoenix/res/layout/coremanager_viewpager.xml
+++ b/android/phoenix/res/layout/coremanager_viewpager.xml
@@ -1,5 +1,14 @@
-<android.support.v4.view.ViewPager 
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v4.view.ViewPager xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/coreviewer_viewPager"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+    android:layout_height="match_parent">
+
+    <android.support.v4.view.PagerTabStrip
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top"
+        android:paddingBottom="10dp"
+        android:paddingTop="10dp" />
+
+</android.support.v4.view.ViewPager>

--- a/android/phoenix/res/layout/preference_viewpager.xml
+++ b/android/phoenix/res/layout/preference_viewpager.xml
@@ -1,5 +1,14 @@
-<android.support.v4.view.ViewPager 
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v4.view.ViewPager xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/viewPager"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+    android:layout_height="match_parent">
+
+    <android.support.v4.view.PagerTabStrip
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top"
+        android:paddingBottom="10dp"
+        android:paddingTop="10dp" />
+
+</android.support.v4.view.ViewPager>

--- a/android/phoenix/src/com/retroarch/browser/coremanager/CoreManagerActivity.java
+++ b/android/phoenix/src/com/retroarch/browser/coremanager/CoreManagerActivity.java
@@ -10,22 +10,15 @@ import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentPagerAdapter;
-import android.support.v4.app.FragmentTransaction;
 import android.support.v4.view.ViewPager;
-import android.support.v7.app.ActionBar;
-import android.support.v7.app.ActionBar.Tab;
-import android.support.v7.app.ActionBar.TabListener;
 import android.support.v7.app.ActionBarActivity;
 
 /**
  * Activity which provides the base for viewing installed cores,
  * as well as the ability to download other cores.
  */
-public final class CoreManagerActivity extends ActionBarActivity implements TabListener
+public final class CoreManagerActivity extends ActionBarActivity
 {
-	// ViewPager for the fragments
-	private ViewPager viewPager;
-
 	@Override
 	public void onCreate(Bundle savedInstanceState)
 	{
@@ -33,48 +26,8 @@ public final class CoreManagerActivity extends ActionBarActivity implements TabL
 
 		// Set the ViewPager
 		setContentView(R.layout.coremanager_viewpager);
-		viewPager = (ViewPager) findViewById(R.id.coreviewer_viewPager);
-
-		// Set the ViewPager adapter.
-		final ViewPagerAdapter adapter = new ViewPagerAdapter(getSupportFragmentManager());
-		viewPager.setAdapter(adapter);
-
-		// Initialize the ActionBar.
-		final ActionBar actionBar = getSupportActionBar();
-		actionBar.setNavigationMode(ActionBar.NAVIGATION_MODE_TABS);
-		actionBar.addTab(actionBar.newTab().setText(R.string.installed_cores).setTabListener(this));
-		actionBar.addTab(actionBar.newTab().setText(R.string.downloadable_cores).setTabListener(this));
-
-		// When swiping between different sections, select the corresponding
-		// tab. We can also use ActionBar.Tab#select() to do this if we have
-		// a reference to the Tab.
-		viewPager.setOnPageChangeListener(new ViewPager.SimpleOnPageChangeListener()
-		{
-			@Override
-			public void onPageSelected(int position)
-			{
-				actionBar.setSelectedNavigationItem(position);
-			}
-		});
-	}
-	
-	@Override
-	public void onTabSelected(Tab tab, FragmentTransaction ft)
-	{
-		// Switch to the fragment indicated by the tab's position.
-		viewPager.setCurrentItem(tab.getPosition());
-	}
-
-	@Override
-	public void onTabReselected(Tab tab, FragmentTransaction ft)
-	{
-		// Do nothing. Not used.
-	}
-
-	@Override
-	public void onTabUnselected(Tab tab, FragmentTransaction ft)
-	{
-		// Do nothing. Not used.
+		final ViewPager viewPager = (ViewPager) findViewById(R.id.coreviewer_viewPager);
+		viewPager.setAdapter(new ViewPagerAdapter(getSupportFragmentManager()));
 	}
 
 	@Override
@@ -126,6 +79,11 @@ public final class CoreManagerActivity extends ActionBarActivity implements TabL
 	// Adapter for the core manager ViewPager.
 	private final class ViewPagerAdapter extends FragmentPagerAdapter
 	{
+		private final String[] pageTitles = {
+			getString(R.string.installed_cores),
+			getString(R.string.downloadable_cores)
+		};
+		
 		/**
 		 * Constructor
 		 * 
@@ -161,17 +119,7 @@ public final class CoreManagerActivity extends ActionBarActivity implements TabL
 		@Override
 		public CharSequence getPageTitle(int position)
 		{
-			switch (position)
-			{
-				case 0:
-					return getString(R.string.installed_cores);
-
-				case 1:
-					return getString(R.string.downloadable_cores);
-
-				default: // Should never happen.
-					return null;
-			}
+			return pageTitles[position];
 		}
 	}
 }

--- a/android/phoenix/src/com/retroarch/browser/preferences/PreferenceActivity.java
+++ b/android/phoenix/src/com/retroarch/browser/preferences/PreferenceActivity.java
@@ -7,11 +7,7 @@ import android.preference.PreferenceManager;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentPagerAdapter;
-import android.support.v4.app.FragmentTransaction;
 import android.support.v4.view.ViewPager;
-import android.support.v7.app.ActionBar;
-import android.support.v7.app.ActionBar.Tab;
-import android.support.v7.app.ActionBar.TabListener;
 import android.support.v7.app.ActionBarActivity;
 
 import com.retroarch.R;
@@ -29,11 +25,8 @@ import com.retroarch.browser.preferences.util.UserPreferences;
  * This class can be considered the central activity for the settings, as this class
  * provides the backbone for the {@link ViewPager} that handles all of the fragments being used.
  */
-public final class PreferenceActivity extends ActionBarActivity implements TabListener, OnSharedPreferenceChangeListener
+public final class PreferenceActivity extends ActionBarActivity implements OnSharedPreferenceChangeListener
 {
-	// ViewPager for the fragments.
-	private ViewPager viewPager;
-
 	@Override
 	public void onCreate(Bundle savedInstanceState)
 	{
@@ -41,55 +34,14 @@ public final class PreferenceActivity extends ActionBarActivity implements TabLi
 
 		// Set the ViewPager.
 		setContentView(R.layout.preference_viewpager);
-		viewPager = (ViewPager) findViewById(R.id.viewPager);
 
-		// Initialize the ViewPager adapter.
-		final PreferencesAdapter adapter = new PreferencesAdapter(getSupportFragmentManager());
-		viewPager.setAdapter(adapter);
+		// Initialize the ViewPager.
+		final ViewPager viewPager = (ViewPager) findViewById(R.id.viewPager);
+		viewPager.setAdapter(new PreferencesAdapter(getSupportFragmentManager()));
 
 		// Register the preference change listener.
 		final SharedPreferences sPrefs = PreferenceManager.getDefaultSharedPreferences(this);
 		sPrefs.registerOnSharedPreferenceChangeListener(this);
-
-		// Initialize the ActionBar.
-		final ActionBar actionBar = getSupportActionBar();
-		actionBar.setNavigationMode(ActionBar.NAVIGATION_MODE_TABS);
-		actionBar.addTab(actionBar.newTab().setText(R.string.general_options).setTabListener(this));
-		actionBar.addTab(actionBar.newTab().setText(R.string.audio_options).setTabListener(this));
-		actionBar.addTab(actionBar.newTab().setText(R.string.input_options).setTabListener(this));
-		actionBar.addTab(actionBar.newTab().setText(R.string.video_options).setTabListener(this));
-		actionBar.addTab(actionBar.newTab().setText(R.string.path_options).setTabListener(this));
-
-		// When swiping between different sections, select the corresponding
-		// tab. We can also use ActionBar.Tab#select() to do this if we have
-		// a reference to the Tab.
-		viewPager.setOnPageChangeListener(new ViewPager.SimpleOnPageChangeListener()
-		{
-			@Override
-			public void onPageSelected(int position)
-			{
-				actionBar.setSelectedNavigationItem(position);
-			}
-		} );
-	}
-
-	@Override
-	public void onTabSelected(Tab tab, FragmentTransaction ft)
-	{
-		// Switch to the fragment indicated by the tab's position.
-		viewPager.setCurrentItem(tab.getPosition());
-	}
-
-	@Override
-	public void onTabUnselected(Tab tab, FragmentTransaction ft)
-	{
-		// Do nothing.
-	}
-
-	@Override
-	public void onTabReselected(Tab tab, FragmentTransaction ft)
-	{
-		// Do nothing
 	}
 
 	@Override
@@ -105,6 +57,14 @@ public final class PreferenceActivity extends ActionBarActivity implements TabLi
 	 */
 	private final class PreferencesAdapter extends FragmentPagerAdapter
 	{
+		private final String[] pageTitles = {
+			getString(R.string.general_options),
+			getString(R.string.audio_options),
+			getString(R.string.input_options),
+			getString(R.string.video_options),
+			getString(R.string.path_options)
+		};
+
 		/**
 		 * Constructor
 		 * 
@@ -143,26 +103,7 @@ public final class PreferenceActivity extends ActionBarActivity implements TabLi
 		@Override
 		public CharSequence getPageTitle(int position)
 		{
-			switch (position)
-			{
-				case 0:
-					return getString(R.string.general_options);
-
-				case 1:
-					return getString(R.string.audio_options);
-
-				case 2:
-					return getString(R.string.input_options);
-
-				case 3:
-					return getString(R.string.video_options);
-
-				case 4:
-					return getString(R.string.path_options);
-
-				default: // Should never happen
-					return null;
-			}
+			return pageTitles[position];
 		}
 
 		@Override


### PR DESCRIPTION
On 5.0 the ActionBar method of doing tabs are deprecated. So we use the PagerTabStrip instead.
Should get rid of deprecation warnings when building for Android 5.0.
