### PR TITLE
(Android) Build fix [7rtype]

### DIFF
--- a/android/phoenix/jni/Android.mk
+++ b/android/phoenix/jni/Android.mk
@@ -7,7 +7,7 @@ LOCAL_CFLAGS += -std=gnu99 -Wall -DHAVE_LOGGER -DRARCH_DUMMY_LOG -DHAVE_ZLIB -DH
 LOCAL_LDLIBS := -llog -lz
 LOCAL_SRC_FILES := apk-extract/apk-extract.c $(RARCH_DIR)/file_extract.c $(RARCH_DIR)/libretro-sdk/file/file_path.c $(RARCH_DIR)/file_ops.c $(RARCH_DIR)/libretro-sdk/string/string_list.c $(RARCH_DIR)/libretro-sdk/compat/compat.c
 
-LOCAL_C_INCLUDES := $(RARCH_DIR)/libretro-sdk/include/
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/$(RARCH_DIR)/libretro-sdk/include/
 
 include $(BUILD_SHARED_LIBRARY)
 
@@ -64,7 +64,7 @@ LOCAL_CFLAGS += -DHAVE_7ZIP
 LOCAL_CFLAGS += -O2
 
 LOCAL_LDLIBS	:= -L$(SYSROOT)/usr/lib -landroid -lEGL $(GLES_LIB) $(LOGGER_LDLIBS) -ldl
-LOCAL_C_INCLUDES := $(RARCH_DIR)/libretro-sdk/include/
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/$(RARCH_DIR)/libretro-sdk/include/
 
 LOCAL_CFLAGS += -DHAVE_SL
 LOCAL_LDLIBS += -lOpenSLES -lz


### PR DESCRIPTION
Rtype's build fix for Android due to ant/ndk not seeing the include files in libretro-sdk.
