### PR TITLE
Fix nasty breakage when joypad index >= MAX_PLAYERS.

### DIFF
--- a/input/input_autodetect.c
+++ b/input/input_autodetect.c
@@ -161,6 +161,9 @@ void input_config_autoconfigure_joypad(unsigned idx,
 
 const struct retro_keybind *input_get_auto_bind(unsigned port, unsigned id)
 {
-   unsigned int joy_idx = g_settings.input.joypad_map[port];
-   return &g_settings.input.autoconf_binds[joy_idx][id];
+   unsigned joy_idx = g_settings.input.joypad_map[port];
+   if (joy_idx < MAX_PLAYERS)
+      return &g_settings.input.autoconf_binds[joy_idx][id];
+   else
+      return NULL;
 }

--- a/input/input_common.c
+++ b/input/input_common.c
@@ -38,7 +38,7 @@ bool input_joypad_set_rumble(const rarch_joypad_driver_t *drv,
    if (!drv || !drv->set_rumble)
       return false;
 
-   unsigned int joy_idx = g_settings.input.joypad_map[port];
+   unsigned joy_idx = g_settings.input.joypad_map[port];
    if (joy_idx >= MAX_PLAYERS)
       return false;
 
@@ -51,7 +51,7 @@ static bool input_joypad_is_pressed(
       const struct retro_keybind *binds,
       unsigned key)
 {
-   unsigned int joy_idx = g_settings.input.joypad_map[port];
+   unsigned joy_idx = g_settings.input.joypad_map[port];
    if (joy_idx >= MAX_PLAYERS)
       return false;
 
@@ -98,7 +98,7 @@ int16_t input_joypad_analog(const rarch_joypad_driver_t *drv,
    if (!drv)
       return 0;
 
-   unsigned int joy_idx = g_settings.input.joypad_map[port];
+   unsigned joy_idx = g_settings.input.joypad_map[port];
    if (joy_idx >= MAX_PLAYERS)
       return 0;
 

--- a/settings_data.c
+++ b/settings_data.c
@@ -567,16 +567,12 @@ static int setting_data_bool_action_toggle_savestates(void *data, unsigned actio
 
 static int setting_data_action_start_bind_device(void *data)
 {
-   unsigned *p = NULL;
    rarch_setting_t *setting = (rarch_setting_t*)data;
 
    if (!setting)
       return -1;
 
-   p = (unsigned*)&g_settings.input.joypad_map[setting->index_offset];
-
-   (*p) = setting->index_offset;
-
+   g_settings.input.joypad_map[setting->index_offset] = setting->index_offset;
    return 0;
 }
 
@@ -588,12 +584,14 @@ static int setting_data_action_toggle_bind_device(void *data, unsigned action)
    if (!setting)
       return -1;
 
-   p = (unsigned*)&g_settings.input.joypad_map[setting->index_offset];
+   p = &g_settings.input.joypad_map[setting->index_offset];
 
    switch (action)
    {
       case MENU_ACTION_LEFT:
-         if ((*p) > 0)
+         if ((*p) >= MAX_PLAYERS)
+            *p = MAX_PLAYERS - 1;
+         else if ((*p) > 0)
             (*p)--;
          break;
       case MENU_ACTION_RIGHT:


### PR DESCRIPTION
No bounds checking and joypad index is apparently now unsigned so old
"disabled" values in config will now overflow instead ...
