### PR TITLE
check_block_hotkey(): Add RARCH_ENABLE_HOTKEY check of first autoconf_bi...

### DIFF
--- a/runloop.c
+++ b/runloop.c
@@ -536,6 +536,8 @@ static void check_block_hotkey(bool enable_hotkey)
    bool use_hotkey_enable;
    static const struct retro_keybind *bind = 
       &g_settings.input.binds[0][RARCH_ENABLE_HOTKEY];
+   static const struct retro_keybind *autoconf_bind = 
+      &g_settings.input.autoconf_binds[0][RARCH_ENABLE_HOTKEY];
 
    /* Don't block the check to RARCH_ENABLE_HOTKEY
     * unless we're really supposed to. */
@@ -544,7 +546,10 @@ static void check_block_hotkey(bool enable_hotkey)
    // If we haven't bound anything to this, always allow hotkeys.
    use_hotkey_enable = bind->key != RETROK_UNKNOWN ||
       bind->joykey != NO_BTN ||
-      bind->joyaxis != AXIS_NONE;
+      bind->joyaxis != AXIS_NONE ||
+      autoconf_bind->key != RETROK_UNKNOWN ||
+      autoconf_bind->joykey != NO_BTN ||
+      autoconf_bind->joyaxis != AXIS_NONE;;
 
    driver.block_hotkey = driver.block_input ||
       (use_hotkey_enable && !enable_hotkey);


### PR DESCRIPTION
...nd

If there is no RARCH_ENABLE_HOTKEY set in retroarch.cfg RARCH_ENABLE_HOTKEY set in a autoconf file is not respected. The new solution only checks the first autoconf input device.

https://github.com/libretro/RetroArch/issues/1310