### PR TITLE
Deleted unneeded header include

### DIFF
--- a/gfx/context/mali_fbdev_ctx.c
+++ b/gfx/context/mali_fbdev_ctx.c
@@ -19,7 +19,6 @@
 #include "../gl_common.h"
 
 #include <EGL/egl.h>
-#include <EGL/fbdev_window.h>
 #include <signal.h>
 
 //Includes and defines for framebuffer size retrieval


### PR DESCRIPTION
Deleted a a non-standard header include, fbdev_window.h, that defined a stryct type, fbdev_window, that's already defined in EGL/eglplatform.h, so there was no need for this extra include.