### PR TITLE
Ignore `apple/iOS/modules/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ apple/RetroArch_iOS.xcodeproj/project.xcworkspace/*
 /media/shaders/
 
 apple/iOS/build/
+apple/iOS/modules/


### PR DESCRIPTION
This adds `apple/iOS/modules/` to the ignore list.