### PR TITLE
(Menu) No more core_info manipulation on the menu driver side. Instead, ...

### DIFF
--- a/menu/drivers/glui.c
+++ b/menu/drivers/glui.c
@@ -453,23 +453,6 @@ static void glui_frame(void)
    gl_set_viewport(gl, gl->win_width, gl->win_height, false, false);
 }
 
-static void glui_init_core_info(void *data)
-{
-   (void)data;
-
-   core_info_list_free(g_extern.core_info);
-   g_extern.core_info = NULL;
-
-   if (*g_settings.libretro_directory)
-      g_extern.core_info = core_info_list_new(g_settings.libretro_directory);
-}
-
-static void glui_update_core_info(void *data)
-{
-   (void)data;
-   menu_update_libretro_info(&g_extern.menu.info);
-}
-
 static void *glui_init(void)
 {
    menu_handle_t *menu;
@@ -496,8 +479,6 @@ static void *glui_init(void)
    glui     = (glui_handle_t*)menu->userdata;
    glui->bg = 0;
 
-   glui_init_core_info(menu);
-
    return menu;
 error:
    if (menu)
@@ -514,10 +495,6 @@ static void glui_free(void *data)
 
    if (menu->userdata)
       free(menu->userdata);
-
-   if (g_extern.core_info)
-      core_info_list_free(g_extern.core_info);
-   g_extern.core_info = NULL;
 }
 
 static GLuint glui_png_texture_load_(const char * file_name)
@@ -673,8 +650,6 @@ menu_ctx_driver_t menu_ctx_glui = {
    NULL,
    NULL,
    NULL,
-   glui_init_core_info,
-   glui_update_core_info,
    glui_entry_iterate,
    "glui",
 };

--- a/menu/drivers/ios.c
+++ b/menu/drivers/ios.c
@@ -89,13 +89,6 @@ static void ios_free(void *data)
    free(menu);
 }
 
-
-static void ios_update_core_info(void *data)
-{
-   (void)data;
-   menu_update_libretro_info(&g_extern.menu.info);
-}
-
 menu_ctx_driver_t menu_ctx_ios = {
   NULL, // set_texture
   NULL, // render_messagebox
@@ -122,8 +115,6 @@ menu_ctx_driver_t menu_ctx_ios = {
   NULL, // list_clear
   NULL, // list_cache
   NULL, // list_set_selection
-  NULL, // init_core_info
-  ios_update_core_info,  // ios_update_core_info
   ios_entry_iterate,
   "ios",
 };

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -648,12 +648,6 @@ static void rgui_navigation_ascend_alphabet(void *data, size_t *unused)
    rgui_navigation_set(data, true);
 }
 
-static void rgui_update_core_info(void *data)
-{
-   (void)data;
-   menu_update_libretro_info(&g_extern.menu.info);
-}
-
 static void rgui_populate_entries(void *data, const char *path,
       const char *label, unsigned k)
 {
@@ -686,8 +680,6 @@ menu_ctx_driver_t menu_ctx_rgui = {
    NULL,
    NULL,
    NULL,
-   NULL,
-   rgui_update_core_info,
    rgui_entry_iterate,
    "rgui",
 };

--- a/menu/drivers/rmenu.c
+++ b/menu/drivers/rmenu.c
@@ -367,12 +367,6 @@ static void rmenu_free(void *data)
 {
 }
 
-static void rmenu_update_core_info(void *data)
-{
-   (void)data;
-   menu_update_libretro_info(&g_extern.menu.info);
-}
-
 menu_ctx_driver_t menu_ctx_rmenu = {
    rmenu_set_texture,
    rmenu_render_messagebox,
@@ -399,8 +393,6 @@ menu_ctx_driver_t menu_ctx_rmenu = {
    NULL,
    NULL,
    NULL,
-   NULL,
-   rmenu_update_core_info,
    rmenu_entry_iterate,
    "rmenu",
 };

--- a/menu/drivers/rmenu_xui.cpp
+++ b/menu/drivers/rmenu_xui.cpp
@@ -688,12 +688,6 @@ static void rmenu_xui_list_set_selection(void *data)
       XuiListSetCurSel(m_menulist, file_list_get_directory_ptr(list));
 }
 
-static void rmenu_xui_update_core_info(void *data)
-{
-   (void)data;
-   menu_update_libretro_info(&g_extern.menu.info);
-}
-
 menu_ctx_driver_t menu_ctx_rmenu_xui = {
    NULL,
    rmenu_xui_render_messagebox,
@@ -719,8 +713,6 @@ menu_ctx_driver_t menu_ctx_rmenu_xui = {
    rmenu_xui_list_clear,
    NULL,
    rmenu_xui_list_set_selection,
-   NULL,
-   rmenu_xui_update_core_info,
    rmenu_xui_entry_iterate,
    "rmenu_xui",
 };

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -1039,7 +1039,7 @@ static void xmb_draw_items(file_list_t *list, file_list_t *stack,
 
 static void xmb_frame(void)
 {
-   int i;
+   int i, depth;
    char title_msg[PATH_MAX_LENGTH], timedate[PATH_MAX_LENGTH];
    const char *core_name = NULL;
    const char *core_version = NULL;
@@ -1095,11 +1095,14 @@ static void xmb_frame(void)
          xmb->margin_top + xmb->icon_size/2.0 + xmb->vspacing * xmb->active_item_factor,
          xmb->arrow_alpha, 0, 1);
 
+   depth = file_list_get_size(driver.menu->menu_list->menu_stack);
+
    xmb_draw_items(
          xmb->selection_buf_old,
          xmb->menu_stack_old,
          xmb->selection_ptr_old,
-         xmb->cat_selection_ptr_old);
+         depth > 1 ? driver.menu->cat_selection_ptr :
+                     xmb->cat_selection_ptr_old);
    xmb_draw_items(
          driver.menu->menu_list->selection_buf,
          driver.menu->menu_list->menu_stack,

--- a/menu/menu.c
+++ b/menu/menu.c
@@ -65,6 +65,8 @@ void menu_update_libretro_info(struct retro_system_info *info)
    g_extern.core_info = NULL;
    if (*g_settings.libretro_directory)
       g_extern.core_info = core_info_list_new(g_settings.libretro_directory);
+   if (driver.menu_ctx && driver.menu_ctx->context_reset)
+      driver.menu_ctx->context_reset(driver.menu);
 
    rarch_update_system_info(info, NULL);
 }
@@ -147,9 +149,7 @@ bool menu_load_content(void)
       return false;
    }
 
-   if (driver.menu && driver.menu_ctx
-         && driver.menu_ctx->update_core_info)
-      driver.menu_ctx->update_core_info(driver.menu);
+   menu_update_libretro_info(&g_extern.menu.info);
 
    menu_shader_manager_init(driver.menu);
 
@@ -176,6 +176,8 @@ void *menu_init(const void *data)
    if (!menu_ctx)
       return NULL;
 
+   menu_update_libretro_info(&g_extern.menu.info);
+
    if (!(menu = (menu_handle_t*)menu_ctx->init()))
       return NULL;
 
@@ -191,8 +193,6 @@ void *menu_init(const void *data)
 #endif
    menu->push_start_screen = g_settings.menu_show_start_screen;
    g_settings.menu_show_start_screen = false;
-
-   menu_update_libretro_info(&g_extern.menu.info);
 
    menu_shader_manager_init(menu);
 

--- a/menu/menu_driver.h
+++ b/menu/menu_driver.h
@@ -201,8 +201,6 @@ typedef struct menu_ctx_driver
    void  (*list_clear)(void *);
    void  (*list_cache)(bool, unsigned);
    void  (*list_set_selection)(void *);
-   void  (*init_core_info)(void *);
-   void  (*update_core_info)(void *);
    int   (*entry_iterate)(unsigned);
    const char *ident;
 } menu_ctx_driver_t;

--- a/retroarch.c
+++ b/retroarch.c
@@ -2762,15 +2762,8 @@ bool rarch_main_command(unsigned cmd)
       case RARCH_CMD_CORE_INFO_INIT:
          rarch_main_command(RARCH_CMD_CORE_INFO_DEINIT);
 
-         if (*g_settings.libretro_directory &&
-               !g_extern.core_info)
-         {
+         if (*g_settings.libretro_directory && !g_extern.core_info)
             g_extern.core_info = core_info_list_new(g_settings.libretro_directory);
-#ifdef HAVE_MENU
-            if (driver.menu_ctx && driver.menu_ctx->init_core_info)
-               driver.menu_ctx->init_core_info(driver.menu);
-#endif
-         }
          break;
       case RARCH_CMD_CORE_DEINIT:
          deinit_core();


### PR DESCRIPTION
...we ensure that core_info is inited before menu init, and call context reset after core info update.

This removes a lot of useless code. However, I'm not sure to understand why g_extern.menu.info was updated by the update_core_info callback in glui.c, rgui.c and ios.c. So I made sure that this g_extern.menu.info updated by another mean.