### PR TITLE
(Menu) performance improvement

### DIFF
--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -536,7 +536,9 @@ void init_video(void)
    g_extern.frame_cache.pitch = 8;
    g_extern.frame_cache.data = &dummy_pixels;
 
+#if defined(PSP)
    if (driver.video_poke && driver.video_poke->set_texture_frame)
       driver.video_poke->set_texture_frame(driver.video_data,
                &dummy_pixels, false, 1, 1, 1.0f);
+#endif
 }


### PR DESCRIPTION
This dummy pixel thing was a workaround for a PSP specific bug, iirc. Commenting it results in a small performance improvement noticeable on weak hardware like RPi and BPi. Please check with @ToadKing before mergin it, he wanted to come with its own fix but it was some month ago.