### PR TITLE
(XMB) Add a setting to display or hide the core name and core version

### DIFF
--- a/general.h
+++ b/general.h
@@ -205,6 +205,7 @@ struct settings
       bool pause_libretro;
       bool mouse_enable;
       bool timedate_enable;
+      bool core_enable;
       bool throttle;
       char wallpaper[PATH_MAX_LENGTH];
 

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -1034,17 +1034,20 @@ static void xmb_frame(menu_handle_t *menu)
             gl->win_width - xmb->icon.size, xmb->icon.size, 1, 0, 1);
    }
 
-   core_version = g_extern.menu.info.library_version;
+   if (g_settings.menu.core_enable)
+   {
+      core_version = g_extern.menu.info.library_version;
 
-   if (!core_version)
-      core_version = g_extern.system.info.library_version;
-   if (!core_version)
-      core_version = "";
+      if (!core_version)
+         core_version = g_extern.system.info.library_version;
+      if (!core_version)
+         core_version = "";
 
-   snprintf(title_msg, sizeof(title_msg), "%s - %s %s", PACKAGE_VERSION,
-         core_name, core_version);
-   xmb_draw_text(gl, xmb, title_msg, xmb->title.margin.left, 
-         gl->win_height - xmb->title.margin.bottom, 1, 1, 0);
+      snprintf(title_msg, sizeof(title_msg), "%s - %s %s", PACKAGE_VERSION,
+            core_name, core_version);
+      xmb_draw_text(gl, xmb, title_msg, xmb->title.margin.left, 
+            gl->win_height - xmb->title.margin.bottom, 1, 1, 0);
+   }
 
    xmb_draw_icon(gl, xmb, xmb->textures[XMB_TEXTURE_ARROW].id,
          xmb->x + xmb->margin_left + xmb->hspacing - xmb->icon.size / 2.0 + xmb->icon.size,

--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -597,6 +597,9 @@
 # Shows current date and/or time inside menu.
 # menu_timedate_enable = true
 
+# Shows current core inside menu.
+# menu_core_enable = true
+
 # Throttle the menu to ~60 FPS instead of using v-sync. Useful for 120+Hz monitors.
 # menu_throttle = false
 

--- a/settings.c
+++ b/settings.c
@@ -485,6 +485,7 @@ static void config_set_defaults(void)
    g_settings.menu.pause_libretro = true;
    g_settings.menu.mouse_enable = false;
    g_settings.menu.timedate_enable = true;
+   g_settings.menu.core_enable = true;
    g_settings.menu.throttle = false;
    *g_settings.menu.wallpaper = '\0';
    g_settings.menu.navigation.wraparound.horizontal_enable = true;
@@ -1107,6 +1108,7 @@ static bool config_load_file(const char *path, bool set_defaults)
    CONFIG_GET_BOOL(menu.pause_libretro, "menu_pause_libretro");
    CONFIG_GET_BOOL(menu.mouse_enable,   "menu_mouse_enable");
    CONFIG_GET_BOOL(menu.timedate_enable,   "menu_timedate_enable");
+   CONFIG_GET_BOOL(menu.core_enable,   "menu_core_enable");
    CONFIG_GET_BOOL(menu.navigation.wraparound.horizontal_enable, "menu_navigation_wraparound_horizontal_enable");
    CONFIG_GET_BOOL(menu.navigation.wraparound.vertical_enable,   "menu_navigation_wraparound_vertical_enable");
    CONFIG_GET_BOOL(menu.navigation.browser.filter.supported_extensions_enable,   "menu_navigation_browser_filter_supported_extensions_enable");
@@ -1881,6 +1883,7 @@ bool config_save_file(const char *path)
    config_set_bool(conf,"menu_pause_libretro", g_settings.menu.pause_libretro);
    config_set_bool(conf,"menu_mouse_enable", g_settings.menu.mouse_enable);
    config_set_bool(conf,"menu_timedate_enable", g_settings.menu.timedate_enable);
+   config_set_bool(conf,"menu_core_enable", g_settings.menu.core_enable);
    config_set_bool(conf,"menu_throttle", g_settings.menu.throttle);
    config_set_path(conf, "menu_wallpaper", g_settings.menu.wallpaper);
 #endif

--- a/settings_data.c
+++ b/settings_data.c
@@ -5255,6 +5255,18 @@ static bool setting_data_append_list_menu_options(
          general_write_handler,
          general_read_handler);
 
+   CONFIG_BOOL(
+         g_settings.menu.core_enable,
+         "menu_core_enable",
+         "Core enable",
+         true,
+         "OFF",
+         "ON",
+         group_info.name,
+         subgroup_info.name,
+         general_write_handler,
+         general_read_handler);
+
 
    END_SUB_GROUP(list, list_info);
 


### PR DESCRIPTION
Not sure if it's the right way to go, I'm trying to make XMB configurable so it can look like the previous lakka driver.

On the OS the target audience is non technical users, there should be only one way to do one action, so the prefered way to launch a content is by the horizontal menu. So displaying the current selected core, or even having a current selected core loses its meaning.