### PR TITLE
(XMB) Move the savestate and loadstate entries on top of the contextual ...

### DIFF
--- a/menu/menu_entries_cbs.c
+++ b/menu/menu_entries_cbs.c
@@ -3444,6 +3444,8 @@ static int deferred_push_content_actions(void *data, void *userdata,
          !strcmp(driver.menu->deferred_path, g_extern.fullpath))
    {
       menu_list_push(list, "Resume", "file_load_or_resume", MENU_SETTING_ACTION_RUN, 0);
+      menu_list_push(list, "Save State", "savestate", MENU_SETTING_ACTION_SAVESTATE, 0);
+      menu_list_push(list, "Load State", "loadstate", MENU_SETTING_ACTION_LOADSTATE, 0);
       menu_list_push(list, "Core Informations", "core_information", MENU_SETTING_ACTION_CORE_INFORMATION, 0);
       menu_list_push(list, "Core Options", "core_options", MENU_SETTING_ACTION_CORE_OPTIONS, 0);
       if (g_extern.has_set_input_descriptors)
@@ -3451,8 +3453,6 @@ static int deferred_push_content_actions(void *data, void *userdata,
       menu_list_push(list, "Core Cheat Options", "core_cheat_options", MENU_SETTING_ACTION_CORE_CHEAT_OPTIONS, 0);
       if ( !g_extern.libretro_dummy && g_extern.system.disk_control.get_num_images)
          menu_list_push(list, "Core Disk Options", "disk_options", MENU_SETTING_ACTION_CORE_DISK_OPTIONS, 0);
-      menu_list_push(list, "Save State", "savestate", MENU_SETTING_ACTION_SAVESTATE, 0);
-      menu_list_push(list, "Load State", "loadstate", MENU_SETTING_ACTION_LOADSTATE, 0);
       menu_list_push(list, "Take Screenshot", "take_screenshot", MENU_SETTING_ACTION_SCREENSHOT, 0);
       menu_list_push(list, "Reset", "restart_content", MENU_SETTING_ACTION_RESET, 0);
    }


### PR DESCRIPTION
...menu

Those actions are the most often used in this menu, so they should be directly accessible.