### PR TITLE
Start to simplify the RPNG interface.

### DIFF
--- a/libretro-common/formats/png/rpng.c
+++ b/libretro-common/formats/png/rpng.c
@@ -769,7 +769,7 @@ bool rpng_load_image_argb_process(uint8_t *inflate_buf,
 }
 
 bool rpng_load_image_argb_init(FILE *file,
-      const char *path, uint32_t **data,
+      uint32_t **data,
       unsigned *width, unsigned *height,
       long *file_len)
 {
@@ -813,8 +813,7 @@ bool rpng_load_image_argb(const char *path, uint32_t **data,
       GOTO_END_ERROR();
    }
 
-   if (!rpng_load_image_argb_init(file, path,
-            data, width, height, &file_len))
+   if (!rpng_load_image_argb_init(file, data, width, height, &file_len))
       GOTO_END_ERROR();
 
    /* feof() apparently isn't triggered after a seek (IEND). */

--- a/libretro-common/formats/png/rpng.c
+++ b/libretro-common/formats/png/rpng.c
@@ -768,7 +768,7 @@ bool rpng_load_image_argb_process(uint8_t *inflate_buf,
    return true;
 }
 
-bool rpng_load_image_argb_init(FILE *file,
+static bool rpng_load_image_argb_init(FILE *file,
       uint32_t **data,
       unsigned *width, unsigned *height,
       long *file_len)


### PR DESCRIPTION
Currently the RPNG functions interact with a `const char *` file path string.  Since RetroArch already has resources for centralizing stable file I/O management, it was desirable to make use of them outside of these functions so that the same code isn't necessarily repeated for better maintenance.

This is only a first step.  Bear with me: still trying to understand the rest. :P