### PR TITLE
some more error tracking in common `read_generic_file` function

### DIFF
--- a/file_ops.c
+++ b/file_ops.c
@@ -110,6 +110,8 @@ static bool read_generic_file(const char *path, void **buf, ssize_t *len)
    fseek(file, 0, SEEK_END);
 
    _len     = ftell(file);
+   if (_len < 0)
+      goto error;
 
    rewind(file);
 

--- a/file_ops.c
+++ b/file_ops.c
@@ -107,13 +107,15 @@ static bool read_generic_file(const char *path, void **buf, ssize_t *len)
    if (!file)
       goto error;
 
-   fseek(file, 0, SEEK_END);
+   if (fseek(file, 0, SEEK_END) != 0)
+      goto error;
 
    _len     = ftell(file);
    if (_len < 0)
       goto error;
 
-   rewind(file);
+   if (fseek(file, 0, SEEK_SET) != 0)
+      goto error;
 
    rom_buf = malloc(_len + 1);
 

--- a/file_ops.c
+++ b/file_ops.c
@@ -133,7 +133,9 @@ static bool read_generic_file(const char *path, void **buf, ssize_t *len)
    /* Allow for easy reading of strings to be safe.
     * Will only work with sane character formatting (Unix). */
    ((char*)rom_buf)[_len] = '\0';
-   fclose(file);
+
+   if (fclose(file) != 0)
+      RARCH_WARN("Failed to close file stream.\n");
 
    if (len)
       *len = ret;


### PR DESCRIPTION
When I look through some of the RPNG stuff which does file I/O management on its own, sometimes I see error checking done for things that are already handled within the error checking inside the libretro `read_generic_file` function.  So rather than reinventing this function, I figure if we were trying to re-use it for other functions, it could serve to try to maximize the error handling possibilities.  I added some trivial checks for when standard library functions like `fclose`, `fseek`, or `ftell` could fail.