### PR TITLE
Fix unimplemented use of getVendorID and getProductID in Android <= 4.3

### DIFF
--- a/frontend/drivers/platform_android.c
+++ b/frontend/drivers/platform_android.c
@@ -461,6 +461,16 @@ void frontend_android_get_version(int32_t *major, int32_t *minor, int32_t *bugfi
    }
 }
 
+void frontend_android_get_version_sdk(int32_t *sdk)
+{
+  char os_version_str[PROP_VALUE_MAX];
+  __system_property_get("ro.build.version.sdk", os_version_str);
+
+  *sdk = 0;
+  if (os_version_str[0])
+    int num_read = sscanf(os_version_str, "%d", sdk);
+}
+
 static bool device_is_xperia_play(const char *name)
 {
    if (

--- a/frontend/drivers/platform_android.c
+++ b/frontend/drivers/platform_android.c
@@ -468,7 +468,9 @@ void frontend_android_get_version_sdk(int32_t *sdk)
 
   *sdk = 0;
   if (os_version_str[0])
+  {
     int num_read = sscanf(os_version_str, "%d", sdk);
+  }
 }
 
 static bool device_is_xperia_play(const char *name)

--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -90,7 +90,7 @@ typedef struct android_input
    const rarch_joypad_driver_t *joypad;
 } android_input_t;
 
-void frontend_android_get_version(int32_t *major, int32_t *minor, int32_t *bugfix);
+void frontent_android_get_version_sdk(int32_t *sdk);
 
 bool (*engine_lookup_name)(char *buf,
       int *vendorId, int *productId, size_t size, int id);
@@ -297,7 +297,7 @@ error:
 
 static void *android_input_init(void)
 {
-   int32_t major, minor, bugfix;
+   int32_t sdk;
    android_input_t *android = (android_input_t*)calloc(1, sizeof(*android));
 
    if (!android)
@@ -306,11 +306,11 @@ static void *android_input_init(void)
    android->pads_connected = 0;
    android->joypad = input_joypad_init_driver(g_settings.input.joypad_driver);
 
-   frontend_android_get_version(&major, &minor, &bugfix);
+   frontent_android_get_version_sdk(&sdk);
 
    engine_lookup_name = android_input_lookup_name_post_gingerbread;
 
-   if (major == 2 && minor == 3)
+   if (sdk <= 18)
       engine_lookup_name = android_input_lookup_name_gingerbread;
 
    return android;

--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -90,7 +90,7 @@ typedef struct android_input
    const rarch_joypad_driver_t *joypad;
 } android_input_t;
 
-void frontent_android_get_version_sdk(int32_t *sdk);
+void frontend_android_get_version_sdk(int32_t *sdk);
 
 bool (*engine_lookup_name)(char *buf,
       int *vendorId, int *productId, size_t size, int id);
@@ -306,7 +306,7 @@ static void *android_input_init(void)
    android->pads_connected = 0;
    android->joypad = input_joypad_init_driver(g_settings.input.joypad_driver);
 
-   frontent_android_get_version_sdk(&sdk);
+   frontend_android_get_version_sdk(&sdk);
 
    engine_lookup_name = android_input_lookup_name_post_gingerbread;
 


### PR DESCRIPTION
getVendorId() and getProductId() have only been added to android.view.InputDevice at API level 19 (KitKat). Therefore, I use the gingerbread code for the input lookup in case the API level is smaller than 19.

I changed the way the version lookup is done by getting the API level instead of parsing the version string.
I used the deprecated field 'ro.build.version.sdk' instead of the recommended 'ro.build.version.sdk_int' because I am unfamiliar with the __system_property_get call. Please let me know of a proper way to do this and I will happily implement it.

This is my first pull request (ever). I'm happy about criticism, so feel free to let me know if I did something wrong.