### PR TITLE
fix overlays on iphone 6+ (hopefully)

### DIFF
--- a/apple/common/apple_gfx_context.c.inl
+++ b/apple/common/apple_gfx_context.c.inl
@@ -241,8 +241,8 @@ static void apple_gfx_ctx_get_video_size(void *data, unsigned* width, unsigned* 
 #endif
    }
 
-   *width  = CGRectGetWidth(size)  * screen.scale;
-   *height = CGRectGetHeight(size) * screen.scale;
+   *width  = CGRectGetWidth(size)  * screen.nativeScale;
+   *height = CGRectGetHeight(size) * screen.nativeScale;
 }
 
 static void apple_gfx_ctx_update_window_title(void *data)


### PR DESCRIPTION
what maddox was working on, based on this:
http://stackoverflow.com/questions/25853519/gklview-not-scaling-correctly-with-ios7-app-running-in-ios8-iphone-6-plus-simula