### PR TITLE
Fix unimplemented use of getVendorID and getProductID in Android <= 4.3

### DIFF
--- a/frontend/drivers/platform_android.c
+++ b/frontend/drivers/platform_android.c
@@ -448,9 +448,10 @@ static int system_property_get(const char *name, char *value)
    {
       if (fgets(buffer, 128, pipe) != NULL)
       {
-         memcpy(curpos, buffer, strlen(buffer));
-         curpos += strlen(buffer);
-         length += strlen(buffer);
+         int curlen = strlen(buffer);
+         memcpy(curpos, buffer, curlen);
+         curpos += curlen;
+         length += curlen;
       }
    }
    *curpos = '\0';
@@ -501,7 +502,7 @@ static void frontend_android_get_version_sdk(int32_t *sdk)
   if (os_version_str[0])
   {
     int num_read = sscanf(os_version_str, "%d", sdk);
-	(void) num_read;
+    (void) num_read;
   }
 }
 

--- a/gfx/drivers_context/androidegl_ctx.c
+++ b/gfx/drivers_context/androidegl_ctx.c
@@ -22,7 +22,7 @@
 #include <EGL/egl.h>
 
 #include "../../frontend/drivers/platform_android.h"
-#include "../image/image.h"
+#include <formats/image.h>
 
 #include <stdint.h>
 


### PR DESCRIPTION
Similar to PetePriority's pull request to get the sdk version but instead of using __system_property_get (which can't be used if compiled with Android L's NDK), I'm using the results of calling getprop.  I also updated the other usages of __system_property_get to do this.  Given it's been around a dozen years since I've used C, it's always possible bugs lurk in the code being used to do that part but it seems to be working in the bit of testing I've done (emulated and physical Nexus 5's running Lollipop, and an Amazon Fire TV running Fire OS 3.0 / JB 4.2.2).