### PR TITLE
 Fix getDefaultConfigPath not correctly looking up external and internal data directories

### DIFF
--- a/android/phoenix/src/com/retroarch/browser/preferences/util/UserPreferences.java
+++ b/android/phoenix/src/com/retroarch/browser/preferences/util/UserPreferences.java
@@ -31,9 +31,9 @@ public final class UserPreferences
 
 	/**
 	 * Retrieves the path to the default location of the libretro config.
-	 *
+	 * 
 	 * @param ctx the current {@link Context}
-	 *
+	 * 
 	 * @return the path to the default location of the libretro config.
 	 */
 	public static String getDefaultConfigPath(Context ctx)
@@ -116,7 +116,7 @@ public final class UserPreferences
 	/**
 	 * Re-reads the configuration file into the {@link SharedPreferences}
 	 * instance that contains all of the settings for the front-end.
-	 *
+	 * 
 	 * @param ctx the current {@link Context}.
 	 */
 	public static void readbackConfigFile(Context ctx)
@@ -125,7 +125,7 @@ public final class UserPreferences
 		ConfigFile config = new ConfigFile(path);
 
 		Log.i(TAG, "Config readback from: " + path);
-
+		
 		SharedPreferences prefs = getPreferences(ctx);
 		SharedPreferences.Editor edit = prefs.edit();
 
@@ -168,7 +168,7 @@ public final class UserPreferences
 	/**
 	 * Updates the libretro configuration file
 	 * with new values if settings have changed.
-	 *
+	 * 
 	 * @param ctx the current {@link Context}.
 	 */
 	public static void updateConfigFile(Context ctx)
@@ -182,7 +182,7 @@ public final class UserPreferences
 		final String coreDir = dataDir + "/cores/";
 
 		final SharedPreferences prefs = getPreferences(ctx);
-
+		
 		config.setString("libretro_path", prefs.getString("libretro_path", coreDir));
 		config.setString("libretro_directory", coreDir);
 		config.setString("rgui_browser_directory", prefs.getString("rgui_browser_directory", ""));
@@ -244,15 +244,15 @@ public final class UserPreferences
 
 		if (prefs.getBoolean("savefile_directory_enable", false))
 		{
-			config.setString("savefile_directory", prefs.getString("savefile_directory", ""));
+		   config.setString("savefile_directory", prefs.getString("savefile_directory", ""));
 		}
 		if (prefs.getBoolean("savestate_directory_enable", false))
 		{
-			config.setString("savestate_directory", prefs.getString("savestate_directory", ""));
+		   config.setString("savestate_directory", prefs.getString("savestate_directory", ""));
 		}
 		if (prefs.getBoolean("system_directory_enable", false))
 		{
-			config.setString("system_directory", prefs.getString("system_directory", ""));
+		   config.setString("system_directory", prefs.getString("system_directory", ""));
 		}
 
 		config.setBoolean("video_font_enable", prefs.getBoolean("video_font_enable", true));
@@ -262,11 +262,11 @@ public final class UserPreferences
 		for (int i = 1; i <= 4; i++)
 		{
 			final String[] btns =
-					{
-							"up", "down", "left", "right",
-							"a", "b", "x", "y", "start", "select",
-							"l", "r", "l2", "r2", "l3", "r3"
-					};
+			{ 
+				"up", "down", "left", "right",
+				"a", "b", "x", "y", "start", "select",
+				"l", "r", "l2", "r2", "l3", "r3"
+			};
 
 			for (String b : btns)
 			{
@@ -323,20 +323,20 @@ public final class UserPreferences
 	*/
 
 	/**
-	 private static void readbackInt(ConfigFile cfg, SharedPreferences.Editor edit, String key)
-	 {
-	 if (cfg.keyExists(key))
-	 edit.putInt(key, cfg.getInt(key));
-	 else
-	 edit.remove(key);
-	 }
-	 */
+	private static void readbackInt(ConfigFile cfg, SharedPreferences.Editor edit, String key)
+	{
+		if (cfg.keyExists(key))
+			edit.putInt(key, cfg.getInt(key));
+		else
+			edit.remove(key);
+	}
+	*/
 
 	/**
 	 * Sanitizes a libretro core path.
-	 *
+	 * 
 	 * @param path The path to the libretro core.
-	 *
+	 * 
 	 * @return the sanitized libretro path.
 	 */
 	private static String sanitizeLibretroPath(String path)
@@ -352,9 +352,9 @@ public final class UserPreferences
 
 	/**
 	 * Gets a {@link SharedPreferences} instance containing current settings.
-	 *
+	 * 
 	 * @param ctx the current {@link Context}.
-	 *
+	 * 
 	 * @return A SharedPreference instance containing current settings.
 	 */
 	public static SharedPreferences getPreferences(Context ctx)
@@ -364,9 +364,9 @@ public final class UserPreferences
 
 	/**
 	 * Gets the optimal sampling rate for low-latency audio playback.
-	 *
+	 * 
 	 * @param ctx the current {@link Context}.
-	 *
+	 * 
 	 * @return the optimal sampling rate for low-latency audio playback in Hz.
 	 */
 	@TargetApi(17)
@@ -380,9 +380,9 @@ public final class UserPreferences
 
 	/**
 	 * Gets the optimal buffer size for low-latency audio playback.
-	 *
+	 * 
 	 * @param ctx the current {@link Context}.
-	 *
+	 * 
 	 * @return the optimal output buffer size in decimal PCM frames.
 	 */
 	@TargetApi(17)
@@ -403,9 +403,9 @@ public final class UserPreferences
 	 * <p>
 	 * On other devices, it simply returns the regular optimal sampling rate
 	 * as returned by the hardware.
-	 *
+	 * 
 	 * @param ctx The current {@link Context}.
-	 *
+	 * 
 	 * @return the optimal audio sampling rate in Hz.
 	 */
 	private static int getOptimalSamplingRate(Context ctx)
@@ -422,7 +422,7 @@ public final class UserPreferences
 
 	/**
 	 * Retrieves the CPU info, as provided by /proc/cpuinfo.
-	 *
+	 * 
 	 * @return the CPU info.
 	 */
 	public static String readCPUInfo()


### PR DESCRIPTION
getDefaultConfigPath was not correctly looking up internal and external storage dirs. Instead, it returned a wrong path (/data/data/com.retroarch/ instead of /data/data/com.retroarch/files) and also defaulted to private internal storage.

With this patch, it first checks whether external storage is available. If not, it uses the private storage in /data/data/com.retroarch/files and configuration changes should now be persistent.
If external storage is present, it will save the configuration files in /sdcard/emulated/legacy/Android/data/com.retroarch/files, where the configuration is user accesible, even if the device is not rooted.