### PR TITLE
Disable JOYPAD_X search box

### DIFF
--- a/menu/menu_input.c
+++ b/menu/menu_input.c
@@ -517,8 +517,8 @@ unsigned menu_input_frame(retro_input_t input, retro_input_t trigger_input)
       return MENU_ACTION_CANCEL;
    if (trigger_input & (1ULL << RETRO_DEVICE_ID_JOYPAD_A))
       return MENU_ACTION_OK;
-   if (trigger_input & (1ULL << RETRO_DEVICE_ID_JOYPAD_X))
-      return MENU_ACTION_SEARCH;
+//   if (trigger_input & (1ULL << RETRO_DEVICE_ID_JOYPAD_X))
+//      return MENU_ACTION_SEARCH;
    if (trigger_input & (1ULL << RETRO_DEVICE_ID_JOYPAD_Y))
       return MENU_ACTION_TEST;
    if (trigger_input & (1ULL << RETRO_DEVICE_ID_JOYPAD_START))


### PR DESCRIPTION
It is not possible to close the search box if you have a joypad only system. It is not even possible to close the search box if a keyboard is connected and there is no input_enable_hotkey="nul" input_enable_hotkey_btn="some button". Only a restart works. So disable MENU_ACTION_SEARCH until there is a timeout for menu_input_search_start().

https://github.com/libretro/RetroArch/issues/1432
https://github.com/libretro/RetroArch/issues/1428

