### PR TITLE
Fix Mac build on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,21 @@
+machine:
+  environment:
+    XCODE_PROJECT: apple/RetroArch_OSX.xcodeproj
+    XCODE_SCHEME: RetroArch_OSX
+
+dependencies:
+  post:
+    - ./fetch-submodules.sh
+    - echo 'Installing Cg'
+    - curl http://developer.download.nvidia.com/cg/Cg_3.1/Cg-3.1_April2012.dmg > Cg.dmg
+    - hdiutil mount Cg.dmg
+    - cp /Volumes/Cg-3.1.0013/Cg-3.1.0013.app/Contents/Resources/Installer\ Items/NVIDIA_Cg.tgz /tmp
+    - cd /tmp && tar -zxvf NVIDIA_Cg.tgz
+    - sudo cp -r /tmp/Library/Frameworks/Cg.framework /Library/Frameworks
 test:
   override:
     - xcodebuild -target RetroArch_OSX -configuration Debug -project apple/RetroArch_OSX.xcodeproj
     - xcodebuild -target RetroArch_OSX -configuration Release -project apple/RetroArch_OSX.xcodeproj
+    - rm -rf ./apple/build/Release/RetroArch_OSX.app.dSYM
+    - cd ./apple/build && zip -r build.zip Debug Release
+    - cp -R ./apple/build/build.zip $CIRCLE_ARTIFACTS

--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -45,7 +45,7 @@ check_lib()	#$1 = HAVE_$1	$2 = lib	$3 = function in lib	$4 = extralibs $5 = head
 		exit 1
 	}
 
-	/bin/true
+	true
 }
 
 check_lib_cxx()	#$1 = HAVE_$1	$2 = lib	$3 = function in lib	$4 = extralibs	$5 = critical error message [checked only if non-empty]
@@ -73,7 +73,7 @@ check_lib_cxx()	#$1 = HAVE_$1	$2 = lib	$3 = function in lib	$4 = extralibs	$5 = 
 	
 	}
 
-	/bin/true
+	true
 }
 
 check_code_c()


### PR DESCRIPTION
With these changes, this will actually build on CircleCI.
- submodules are fetched
- Nvidia "Cg" is installed
- Build output saved to artifacts (good place to save nightly builds, but we can also add a buildbot-upload step later too)
- The "true" command has a different path on Mac, and anyway it should be in the `$PATH` on either platform so it doesn't need an explicit path.