### PR TITLE
exynos_gfx: fix error handling of fd open

### DIFF
--- a/gfx/drivers/exynos_gfx.c
+++ b/gfx/drivers/exynos_gfx.c
@@ -181,7 +181,7 @@ static int get_device_index(void)
     snprintf(buf, sizeof(buf), "/dev/dri/card%d", index);
 
     fd = open(buf, O_RDWR);
-    if (fd == -1) break;
+    if (fd < 0) break;
 
     ver = drmGetVersion(fd);
 
@@ -599,7 +599,7 @@ static int exynos_open(struct exynos_data *pdata)
   }
 
   fd = open(buf, O_RDWR);
-  if (fd == -1)
+  if (fd < 0)
   {
     RARCH_ERR("video_exynos: can't open drm device\n");
     return -1;


### PR DESCRIPTION
Opening an fd can fail for multiple reasons, we would
just error out on EPERM. Handle the other cases as well.