### PR TITLE
(Wii) Simple fix for Wiimote not reconnecting on reloads

### DIFF
--- a/input/drivers_joypad/gx_input_joypad.c
+++ b/input/drivers_joypad/gx_input_joypad.c
@@ -632,8 +632,9 @@ static void gx_joypad_destroy(void)
 #endif
 
 #ifdef HW_RVL
-      WPAD_Flush(i);
-      WPADDisconnect(i);
+   // Commenting this out fixes the Wii remote not reconnecting after core load, exit, etc.
+   //   WPAD_Flush(i);
+   //   WPADDisconnect(i);
 #endif
    }
 }


### PR DESCRIPTION
I don't really know how it works but removing this did the trick on my tests. Just in case, I left it commented out instead.