### PR TITLE
hid: Fix return of potentially uninitialized pointers

### DIFF
--- a/input/drivers_hid/apple_hid.c
+++ b/input/drivers_hid/apple_hid.c
@@ -442,7 +442,7 @@ static void *apple_hid_init(void)
 error:
     if (hid_apple)
         free(hid_apple);
-    return hid_apple;
+    return NULL;
 }
 
 static void apple_hid_free(void *data)

--- a/input/drivers_hid/null_hid.c
+++ b/input/drivers_hid/null_hid.c
@@ -75,17 +75,7 @@ static int16_t null_hid_joypad_axis(void *data, unsigned port, uint32_t joyaxis)
 
 static void *null_hid_init(void)
 {
-   null_hid_t *hid_null = (null_hid_t*)calloc(1, sizeof(*hid_null));
-
-   if (!hid_null)
-      goto error;
-
-   return hid_null;
-
-error:
-   if (hid_null)
-      free(hid_null);
-   return hid_null;
+   return (null_hid_t*)calloc(1, sizeof(null_hid_t));
 }
 
 static void null_hid_free(void *data)


### PR DESCRIPTION
After a pointer is freed it's considered to be a dangling pointer. Returning a dangling pointer is undefined behavior.

Also if those cases were ever hit, they would still pass the initialization null check at the calling code in input_hid_driver.c despite being deallocated.