### PR TITLE
connect_ps4: Fix a condition check in hidpad_ps4_check_dpad

### DIFF
--- a/input/connect/connect_ps4.c
+++ b/input/connect/connect_ps4.c
@@ -141,7 +141,7 @@ static bool hidpad_ps4_check_dpad(struct ps4 *rpt, unsigned id)
         case RETRO_DEVICE_ID_JOYPAD_RIGHT:
             return rpt->btn.dpad == DPAD_UP_RIGHT || rpt->btn.dpad == DPAD_RIGHT || rpt->btn.dpad == DPAD_RIGHT_DOWN;
         case RETRO_DEVICE_ID_JOYPAD_DOWN:
-            return rpt->btn.dpad == DPAD_RIGHT_DOWN | rpt->btn.dpad == DPAD_DOWN || rpt->btn.dpad == DPAD_DOWN_LEFT;
+            return rpt->btn.dpad == DPAD_RIGHT_DOWN || rpt->btn.dpad == DPAD_DOWN || rpt->btn.dpad == DPAD_DOWN_LEFT;
         case RETRO_DEVICE_ID_JOYPAD_LEFT:
             return rpt->btn.dpad == DPAD_DOWN_LEFT || rpt->btn.dpad == DPAD_LEFT || rpt->btn.dpad == DPAD_LEFT_UP;
     }


### PR DESCRIPTION
Accidental bitwise OR. Doubt it matters in the long run, but for the sake of consistency, it may as well be corrected.