### PR TITLE
Improve per-game/per-config overrides

### DIFF
--- a/configuration.h
+++ b/configuration.h
@@ -400,6 +400,8 @@ const char *config_get_default_menu(void);
  */
 void config_load(void);
 
+bool config_append_specific();
+
 /**
  * config_save_keybinds_file:
  * @path            : Path that shall be written to.

--- a/retroarch.c
+++ b/retroarch.c
@@ -199,7 +199,7 @@ static void print_help(void)
    puts("\t-S/--savestate: Path to use for save states. If not selected, *.state will be assumed.");
    puts("\t-c/--config: Path for config file." RARCH_DEFAULT_CONF_PATH_STR);
    puts("\t--appendconfig: Extra config files are loaded in, and take priority over config selected in -c (or default).");
-   puts("\t\tMultiple configs are delimited by ','.");
+   puts("\t\tMultiple configs are delimited by '|'.");
 #ifdef HAVE_DYNAMIC
    puts("\t-L/--libretro: Path to libretro implementation. Overrides any config setting.");
 #endif
@@ -1875,7 +1875,6 @@ static bool init_content(void)
       RARCH_LOG("Skipping SRAM load.\n");
 
    load_auto_state();
-
    rarch_main_command(RARCH_CMD_BSV_MOVIE_INIT);
    rarch_main_command(RARCH_CMD_NETPLAY_INIT);
 
@@ -1886,6 +1885,8 @@ static bool init_core(void)
 {
    driver_t *driver = driver_get_ptr();
    global_t *global = global_get_ptr();
+
+   config_append_specific();
 
    verify_api_version();
    pretro_init();


### PR DESCRIPTION
An additional limitation I failed to mention in the commit, any changes done before loading the game/core won't affect the new loaded game. This happens because changes to the config are written on exit only, maybe we should write changes before loading content?