### PR TITLE
do-not-merge-this-yet

### DIFF
--- a/dynamic.c
+++ b/dynamic.c
@@ -455,7 +455,8 @@ void init_libretro_sym(bool dummy)
 
    load_symbols(dummy);
 
-   pretro_set_environment(rarch_environment_cb);
+   //move this to init_core, will need to be tested
+   //pretro_set_environment(rarch_environment_cb);
 }
 
 /**

--- a/retroarch.c
+++ b/retroarch.c
@@ -1886,6 +1886,9 @@ static bool init_core(void)
    driver_t *driver = driver_get_ptr();
    global_t *global = global_get_ptr();
 
+   //needs testing for regressions
+   pretro_set_environment(rarch_environment_cb);
+   
    if (!config_load_override())
       RARCH_ERR("Error loading override files\n");
    if (!config_load_remap())


### PR DESCRIPTION
move pretro_set_environment(rarch_environment_cb); after init_libretro_sym so core_options and libretro_path can be overriden