### PR TITLE
Some clean-up and consistency, no actual code changes

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -1661,7 +1661,7 @@ bool config_load_override(void)
    }
 
    //early return in case a library isn't loaded
-   if(!global->system.info.library_name || !strcmp(global->system.info.library_name,"No Core"))
+   if (!global->system.info.library_name || !strcmp(global->system.info.library_name,"No Core"))
    {
       RARCH_LOG("No library loaded, not using overrides.\n");
       return true;
@@ -1723,25 +1723,22 @@ bool config_load_override(void)
    /* Append game-specific */
    if (new_conf)
    {
-      if(should_append)
+      if (should_append)
       {
           strlcat(global->append_config_path, "|", sizeof(global->append_config_path));
           strlcat(global->append_config_path, game_path, sizeof(global->append_config_path));
       }
       else
           strlcpy(global->append_config_path, game_path, sizeof(global->append_config_path));
-      RARCH_LOG("Game-specific configuration found at %s. Appending.\n", game_path);
 
+      RARCH_LOG("Game-specific configuration found at %s. Appending.\n", game_path);
       should_append = true;
    }
    else
       RARCH_LOG("No game-specific configuration found at %s.\n", game_path);
 
-   if(should_append)
-   {
-      if(!config_load_file(global->config_path, false))
-          return false;
-   }
+   if (should_append && !config_load_file(global->config_path, false))
+      return false;
 
    return true;   /* only means no errors were caught */
 }

--- a/configuration.c
+++ b/configuration.c
@@ -1654,18 +1654,18 @@ bool config_load_override(void)
    global_t *global = global_get_ptr();      /* global pointer                                             */
    settings_t *settings = config_get_ptr();  /* config pointer                                             */
 
+   if (!global || !settings )
+   {
+      RARCH_ERR("Could not obtain global pointer or configuration file pointer to retrieve path of retroarch.cfg.\n");
+      return false;
+   }
+
    //early return in case a library isn't loaded
    if(!global->system.info.library_name || !strcmp(global->system.info.library_name,"No Core"))
       return true;
 
    RARCH_LOG("Game name: %s\n",global->basename);
    RARCH_LOG("Core name: %s\n",global->system.info.library_name);
-
-   if (!global || !settings )
-   {
-      RARCH_ERR("Could not obtain global pointer or configuration file pointer to retrieve path of retroarch.cfg.\n");
-      return false;
-   }
 
    /* Config directory: config_directory. */
    if (settings->menu_config_directory)   /* Try RGUI path setting first */

--- a/configuration.c
+++ b/configuration.c
@@ -1662,7 +1662,10 @@ bool config_load_override(void)
 
    //early return in case a library isn't loaded
    if(!global->system.info.library_name || !strcmp(global->system.info.library_name,"No Core"))
+   {
+      RARCH_LOG("No library loaded, not using overrides.\n");
       return true;
+   }
 
    RARCH_LOG("Game name: %s\n",global->basename);
    RARCH_LOG("Core name: %s\n",global->system.info.library_name);


### PR DESCRIPTION
If we do test for !global at all we should do it before using its members. Added some white space to make the collaborated function more consistent with the rest of the code base.