### PR TITLE
Consistently use HAVE_NEON to include NEON-specific fragments.

### DIFF
--- a/audio/audio_utils.c
+++ b/audio/audio_utils.c
@@ -218,7 +218,7 @@ void audio_convert_float_to_s16_altivec(int16_t *out,
    }
    audio_convert_float_to_s16_C(out, in, samples_in);
 }
-#elif defined(__ARM_NEON__)
+#elif defined(HAVE_NEON)
 /* Avoid potential hard-float/soft-float ABI issues. */
 void audio_convert_s16_float_asm(float *out, const int16_t *in,
       size_t samples, const float *gain);
@@ -429,7 +429,7 @@ void audio_convert_init_simd(void)
    unsigned cpu = audio_convert_get_cpu_features();
 
    (void)cpu;
-#if defined(__ARM_NEON__) 
+#if defined(HAVE_NEON)
    audio_convert_s16_to_float_arm = cpu & RETRO_SIMD_NEON ?
       audio_convert_s16_to_float_neon : audio_convert_s16_to_float_C;
    audio_convert_float_to_s16_arm = cpu & RETRO_SIMD_NEON ?

--- a/audio/audio_utils.h
+++ b/audio/audio_utils.h
@@ -93,7 +93,7 @@ void audio_convert_s16_to_float_altivec(float *out,
 void audio_convert_float_to_s16_altivec(int16_t *out,
       const float *in, size_t samples);
 
-#elif defined(__ARM_NEON__)
+#elif defined(HAVE_NEON)
 #define audio_convert_s16_to_float audio_convert_s16_to_float_arm
 #define audio_convert_float_to_s16 audio_convert_float_to_s16_arm
 

--- a/audio/drivers_resampler/cc_resampler.c
+++ b/audio/drivers_resampler/cc_resampler.c
@@ -380,7 +380,7 @@ static void resampler_CC_upsample(void *re_, struct resampler_data *data)
 }
 
 
-#elif defined (__ARM_NEON__)
+#elif defined (HAVE_NEON)
 
 #define CC_RESAMPLER_IDENT "NEON"
 

--- a/audio/drivers_resampler/sinc.c
+++ b/audio/drivers_resampler/sinc.c
@@ -393,7 +393,7 @@ static void process_sinc(rarch_sinc_resampler_t *resamp, float *out_buffer)
    /* movehl { X, R, X, L } == { X, R, X, R } */
    _mm_store_ss(out_buffer + 1, _mm_movehl_ps(sum, sum));
 }
-#elif defined(__ARM_NEON__)
+#elif defined(HAVE_NEON)
 
 #if SINC_COEFF_LERP
 #error "NEON asm does not support SINC lerp."
@@ -498,7 +498,7 @@ static void *resampler_sinc_new(const struct resampler_config *config,
    }
 
    /* Be SIMD-friendly. */
-#if (defined(__AVX__) && ENABLE_AVX) || defined(__ARM_NEON__)
+#if (defined(__AVX__) && ENABLE_AVX) || defined(HAVE_NEON)
    re->taps = (re->taps + 7) & ~7;
 #else
    re->taps = (re->taps + 3) & ~3;
@@ -522,7 +522,7 @@ static void *resampler_sinc_new(const struct resampler_config *config,
    init_sinc_table(re, cutoff, re->phase_table,
          1 << PHASE_BITS, re->taps, SINC_COEFF_LERP);
 
-#if defined(__ARM_NEON__)
+#if defined(HAVE_NEON)
    process_sinc_func = mask & RESAMPLER_SIMD_NEON 
       ? process_sinc_neon : process_sinc_C;
 #endif

--- a/performance.c
+++ b/performance.c
@@ -323,7 +323,7 @@ static uint64_t xgetbv_x86(uint32_t idx)
 }
 #endif
 
-#if defined(__ARM_NEON__)
+#if defined(HAVE_NEON)
 static void arm_enable_runfast_mode(void)
 {
    /* RunFast mode. Enables flush-to-zero and some 
@@ -486,7 +486,7 @@ uint64_t rarch_get_cpu_features(void)
    uint64_t cpu_flags = android_getCpuFeatures();
    (void)cpu_flags;
 
-#ifdef __ARM_NEON__
+#ifdef HAVE_NEON
    if (cpu_flags & ANDROID_CPU_ARM_FEATURE_NEON)
    {
       cpu |= RETRO_SIMD_NEON;
@@ -494,7 +494,7 @@ uint64_t rarch_get_cpu_features(void)
    }
 #endif
 
-#elif defined(__ARM_NEON__)
+#elif defined(HAVE_NEON)
    cpu |= RETRO_SIMD_NEON;
    arm_enable_runfast_mode();
 #elif defined(__ALTIVEC__)


### PR DESCRIPTION
While GCC only defines __ARM_NEON__ when NEON is explicitly requested,
Clang provides it for all CPUs known/expected to have NEON.