### PR TITLE
Autoconfigure - Change equals to starts with ident

### DIFF
--- a/input/input_autodetect.c
+++ b/input/input_autodetect.c
@@ -89,8 +89,8 @@ static bool input_try_autoconfigure_joypad_from_conf(config_file_t *conf,
       ret = true;
    }
 
-
-   if (!strcmp(ident, params->name))
+   /* Check for name match - name starts with ident */
+   if (!strncmp(params->name, ident, strlen(ident)))
    {
       BIT32_SET(*match, AUTODETECT_MATCH_IDENT);
       ret = true;


### PR DESCRIPTION
This allows for Bluetooth PS3 controllers (and other bluetooth controllers) to be automatically detected.

In the input_try_autoconfigure_joypad_from_conf function, there is a string comparision between the input's name "params->name" and the configuration's name "ident".  Specifically on Bluetooth controllers, the uuid is appended to the end of the name.  
This enhancement will change the checking for name match from an equals comparision, to a startswith.