### PR TITLE
Added check to make sure ident was not an empty string.

### DIFF
--- a/input/input_autodetect.c
+++ b/input/input_autodetect.c
@@ -90,7 +90,7 @@ static bool input_try_autoconfigure_joypad_from_conf(config_file_t *conf,
    }
 
    /* Check for name match - name starts with ident */
-   if (!strncmp(params->name, ident, strlen(ident)))
+   if (ident[0] != '\0' && !strncmp(params->name, ident, strlen(ident)))
    {
       BIT32_SET(*match, AUTODETECT_MATCH_IDENT);
       ret = true;


### PR DESCRIPTION
Added check to make sure ident was not an empty string.

This commit is to fix a bug related to having a autoconfig.cfg file without an ident.
Currently, there are none in the repository that fit this condition, which is why the bug was never triggered in testing. 

This checks to make sure the ident loaded from the config file actually has a value associated with it.
Without this check, the if() statement will always return true, because an empty string is always within another string.