### PR TITLE
Fix build when OpenGL and GLES are disabled

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -455,20 +455,20 @@ ifeq ($(HAVE_PARPORT), 1)
    OBJ += input/drivers_joypad/parport_joypad.o
 endif
 
-OBJ += gfx/video_context_driver.o \
-		 gfx/drivers_context/gfx_null_ctx.o
-
 # Video
 #
 ifeq ($(HAVE_OPENGL), 1)
+
    DEFINES += -DHAVE_OPENGL -DHAVE_GLSL
    OBJ += gfx/drivers/gl.o \
-			 gfx/drivers/gl_common.o \
-			 gfx/drivers_font/gl_raster_font.o \
-			 libretro-common/gfx/math/matrix_4x4.o \
-			 gfx/video_state_tracker.o \
-			 gfx/video_texture.o \
-			 libretro-common/glsym/rglgen.o
+			gfx/video_context_driver.o \
+			gfx/drivers_context/gfx_null_ctx.o \
+			gfx/drivers/gl_common.o \
+			gfx/drivers_font/gl_raster_font.o \
+			libretro-common/gfx/math/matrix_4x4.o \
+			gfx/video_state_tracker.o \
+			gfx/video_texture.o \
+			libretro-common/glsym/rglgen.o
 
    ifeq ($(HAVE_KMS), 1)
       OBJ += gfx/drivers_context/drm_egl_ctx.o

--- a/menu/menu_display.c
+++ b/menu/menu_display.c
@@ -86,16 +86,18 @@ bool menu_display_init(menu_handle_t *menu)
 
 float menu_display_get_dpi(menu_handle_t *menu)
 {
-   float dpi;
+   float dpi = menu_dpi_override_value;
    settings_t *settings = config_get_ptr();
 
    if (!menu || !settings)
-      return menu_dpi_override_value;
+      return dpi;
 
-   if (   settings->menu.dpi.override_enable ||
-         !gfx_ctx_get_metrics(DISPLAY_METRIC_DPI, &dpi)
-      )
-      return settings->menu.dpi.override_value;
+   if (settings->menu.dpi.override_enable)
+      dpi = settings->menu.dpi.override_value;
+#if defined(HAVE_OPENGL) || defined(HAVE_GLES)
+   else if (!gfx_ctx_get_metrics(DISPLAY_METRIC_DPI, &dpi))
+      dpi = menu_dpi_override_value;
+#endif
 
    return dpi;
 }

--- a/menu/menu_entries_cbs_deferred_push.c
+++ b/menu/menu_entries_cbs_deferred_push.c
@@ -411,6 +411,7 @@ static int deferred_push_system_information(void *data, void *userdata,
          }
       }
 
+#if defined(HAVE_OPENGL) || defined(HAVE_GLES)
       tmp_string = gfx_ctx_get_ident();
 
       snprintf(tmp, sizeof(tmp), "Video context driver: %s",
@@ -444,6 +445,8 @@ static int deferred_push_system_information(void *data, void *userdata,
                   MENU_SETTINGS_CORE_INFO_NONE, 0);
          }
       }
+#endif
+
    }
 
    {


### PR DESCRIPTION
Possible fix for #1601 and #1658.
I couldn't find any issues on my system but please review `menu_display_get_dpi()` to see if it's ok, I initialized the `dpi` variable to `menu_dpi_override_value` to avoid an uninitialized variable usage warning.