### PR TITLE
Override improvements #3

### DIFF
--- a/command_event.c
+++ b/command_event.c
@@ -449,7 +449,7 @@ static void event_init_controllers(void)
       {
          /* If we're trying to connect a completely unknown device,
           * revert back to JOYPAD. */
-         
+
          if (device != RETRO_DEVICE_JOYPAD && device != RETRO_DEVICE_NONE)
          {
             /* Do not fix settings->input.libretro_device[i],
@@ -484,18 +484,20 @@ static void event_init_controllers(void)
 static void event_deinit_core(bool reinit)
 {
    global_t *global = global_get_ptr();
-   
+   settings_t *settings = config_get_ptr();
+
    pretro_unload_game();
    pretro_deinit();
 
    if (reinit)
       event_command(EVENT_CMD_DRIVERS_DEINIT);
-    
+
    if(global->overrides_active)
    {
       config_unload_override();
       global->overrides_active = false;
    }
+
    pretro_set_environment(rarch_environment_cb);
    uninit_libretro_sym();
 }
@@ -530,7 +532,7 @@ static bool event_load_save_files(void)
    for (i = 0; i < global->savefiles->size; i++)
       load_ram_file(global->savefiles->elems[i].data,
             global->savefiles->elems[i].attr.i);
-    
+
    return true;
 }
 
@@ -656,6 +658,9 @@ static bool event_init_core(void)
    driver_t *driver     = driver_get_ptr();
    settings_t *settings = config_get_ptr();
 
+   strlcpy(orig_savefile_dir,global->savefile_dir,sizeof(orig_savefile_dir));
+   strlcpy(orig_savestate_dir,global->savestate_dir,sizeof(orig_savestate_dir));
+
    if(settings->auto_overrides_enable)
    {
       if (config_load_override())
@@ -664,7 +669,7 @@ static bool event_init_core(void)
          global->overrides_active = false; 
    }
 
-   pretro_set_environment(rarch_environment_cb);  
+   pretro_set_environment(rarch_environment_cb);
 
    if(settings->auto_remaps_enable)
       config_load_remap();
@@ -683,6 +688,11 @@ static bool event_init_core(void)
 
    retro_init_libretro_cbs(&driver->retro_ctx);
    rarch_init_system_av_info();
+
+   if(settings->sort_savefiles_enable)
+	   strlcpy(global->savefile_dir,orig_savefile_dir,sizeof(global->savefile_dir));
+   if(settings->sort_savestates_enable)
+	   strlcpy(global->savestate_dir,orig_savestate_dir,sizeof(global->savestate_dir)); 
 
    return true;
 }
@@ -704,7 +714,7 @@ static bool event_save_auto_state(void)
    ret = save_state(savestate_name_auto);
    RARCH_LOG("Auto save state to \"%s\" %s.\n", savestate_name_auto, ret ?
          "succeeded" : "failed");
-    
+
    return true;
 }
 

--- a/command_event.c
+++ b/command_event.c
@@ -690,9 +690,9 @@ static bool event_init_core(void)
    rarch_init_system_av_info();
 
    if(settings->sort_savefiles_enable)
-	   strlcpy(global->savefile_dir,orig_savefile_dir,sizeof(global->savefile_dir));
+      strlcpy(global->savefile_dir,orig_savefile_dir,sizeof(global->savefile_dir));
    if(settings->sort_savestates_enable)
-	   strlcpy(global->savestate_dir,orig_savestate_dir,sizeof(global->savestate_dir)); 
+      strlcpy(global->savestate_dir,orig_savestate_dir,sizeof(global->savestate_dir)); 
 
    return true;
 }

--- a/command_event.c
+++ b/command_event.c
@@ -665,9 +665,12 @@ static bool event_init_core(void)
    }
 
    pretro_set_environment(rarch_environment_cb);  
-  
+
    if(settings->auto_remaps_enable)
       config_load_remap();
+
+   if(settings->sort_savestates_enable || settings->sort_savefiles_enable)
+      set_paths_redirect(global->basename);
 
    rarch_verify_api_version();
    pretro_init();

--- a/command_event.c
+++ b/command_event.c
@@ -492,6 +492,7 @@ static void event_deinit_core(bool reinit)
    if (reinit)
       event_command(EVENT_CMD_DRIVERS_DEINIT);
 
+   /* auto overrides: reload the original config */
    if(global->overrides_active)
    {
       config_unload_override();
@@ -658,9 +659,11 @@ static bool event_init_core(void)
    driver_t *driver     = driver_get_ptr();
    settings_t *settings = config_get_ptr();
 
+   /* per-core saves: save the original path */
    strlcpy(orig_savefile_dir,global->savefile_dir,sizeof(orig_savefile_dir));
    strlcpy(orig_savestate_dir,global->savestate_dir,sizeof(orig_savestate_dir));
 
+   /* auto overrides: apply overrides */
    if(settings->auto_overrides_enable)
    {
       if (config_load_override())
@@ -671,9 +674,11 @@ static bool event_init_core(void)
 
    pretro_set_environment(rarch_environment_cb);
 
+   /* auto-remap: apply remap files */
    if(settings->auto_remaps_enable)
       config_load_remap();
 
+   /* per-core saves: reset redirection paths */
    if(settings->sort_savestates_enable || settings->sort_savefiles_enable)
       set_paths_redirect(global->basename);
 
@@ -689,6 +694,7 @@ static bool event_init_core(void)
    retro_init_libretro_cbs(&driver->retro_ctx);
    rarch_init_system_av_info();
 
+   /* per-core saves: restore the original path so the config is not affected */
    if(settings->sort_savefiles_enable)
       strlcpy(global->savefile_dir,orig_savefile_dir,sizeof(global->savefile_dir));
    if(settings->sort_savestates_enable)

--- a/config.def.h
+++ b/config.def.h
@@ -494,6 +494,9 @@ static bool default_core_specific_config = false;
 static bool default_auto_overrides_enable = false;
 static bool default_auto_remaps_enable = false;
 
+static bool default_sort_savefiles_enable = false;
+static bool default_sort_savestates_enable = false;
+
 static unsigned default_menu_btn_ok          = RETRO_DEVICE_ID_JOYPAD_A;
 static unsigned default_menu_btn_cancel      = RETRO_DEVICE_ID_JOYPAD_B;
 static unsigned default_menu_btn_search      = RETRO_DEVICE_ID_JOYPAD_X;

--- a/configuration.c
+++ b/configuration.c
@@ -1669,6 +1669,11 @@ static void config_load_core_specific(void)
 
    if (settings->core_specific_config)
    {
+
+	  // Toggle has_save_path to false so it resets
+	  global->has_set_save_path = false;
+	  global->has_set_state_path = false;
+
       char tmp[PATH_MAX_LENGTH];
       strlcpy(tmp, settings->libretro, sizeof(tmp));
       RARCH_LOG("Loading core-specific config from: %s.\n",
@@ -1683,6 +1688,10 @@ static void config_load_core_specific(void)
 
       /* This must be true for core specific configs. */
       settings->core_specific_config = true;
+
+	  // Reset save paths
+	  global->has_set_save_path = true;
+	  global->has_set_state_path = true;
    }
 }
 
@@ -1812,13 +1821,22 @@ bool config_load_override(void)
 #endif
 
       char buf[PATH_MAX_LENGTH];
-      //Store the libretro_path we're using since it will be overwritten by the override when reloading
+      // Store the libretro_path we're using since it will be overwritten by the override when reloading
       strlcpy(buf,settings->libretro,sizeof(buf));
+
+	  // Toggle has_save_path to false so it resets
+	   global->has_set_save_path = false;
+	   global->has_set_state_path = false;
+
       if (config_load_file(global->config_path, false))
       {		  
-         //Restore the libretro_path we're using since it will be overwritten by the override when reloading
+         // Restore the libretro_path we're using since it will be overwritten by the override when reloading
          strlcpy(settings->libretro,buf,sizeof(settings->libretro));
          rarch_main_msg_queue_push("Configuration override loaded", 1, 100, true);
+
+		 // Reset save paths
+	     global->has_set_save_path = true;
+	     global->has_set_state_path = true;
          return true;
       }
    }
@@ -1842,9 +1860,19 @@ bool config_load_override(void)
       return false;
 
    *global->append_config_path = '\0';
+   
+   	// Toggle has_save_path to false so it resets
+	global->has_set_save_path = false;
+	global->has_set_state_path = false;
+   
    if (config_load_file(global->config_path, false))
    {
        RARCH_LOG("Configuration overrides unloaded, original configuration reset\n");
+       	   
+	   // Reset save paths	   
+	   global->has_set_save_path = true;
+	   global->has_set_state_path = true;
+
        return true;
    }
    else

--- a/configuration.c
+++ b/configuration.c
@@ -689,6 +689,9 @@ static void config_set_defaults(void)
    settings->auto_overrides_enable = default_auto_overrides_enable;
    settings->auto_remaps_enable = default_auto_remaps_enable;
 
+   settings->sort_savefiles_enable = default_sort_savefiles_enable;
+   settings->sort_savestates_enable = default_sort_savestates_enable;
+
    settings->menu_ok_btn          = default_menu_btn_ok;
    settings->menu_cancel_btn      = default_menu_btn_cancel;
    settings->menu_search_btn      = default_menu_btn_search;
@@ -1620,6 +1623,9 @@ static bool config_load_file(const char *path, bool set_defaults)
    CONFIG_GET_BOOL_BASE(conf, settings, auto_overrides_enable, "auto_overrides_enable");
    CONFIG_GET_BOOL_BASE(conf, settings, auto_remaps_enable, "auto_remaps_enable");
 
+   CONFIG_GET_BOOL_BASE(conf, settings, sort_savefiles_enable, "sort_savefiles_enable");
+   CONFIG_GET_BOOL_BASE(conf, settings, sort_savestates_enable, "sort_savestates_enable");
+
    CONFIG_GET_INT_BASE(conf, settings, menu_ok_btn,          "menu_ok_btn");
    CONFIG_GET_INT_BASE(conf, settings, menu_cancel_btn,      "menu_cancel_btn");
    CONFIG_GET_INT_BASE(conf, settings, menu_search_btn,      "menu_search_btn");
@@ -1817,7 +1823,7 @@ bool config_load_override(void)
       {
          RARCH_WARN("Can't use overrides in conjunction with netplay, disabling overrides\n");
          return false;
-      }   	   
+      }
 #endif
 
       char buf[PATH_MAX_LENGTH];
@@ -1829,7 +1835,7 @@ bool config_load_override(void)
 	   global->has_set_state_path = false;
 
       if (config_load_file(global->config_path, false))
-      {		  
+      {
          // Restore the libretro_path we're using since it will be overwritten by the override when reloading
          strlcpy(settings->libretro,buf,sizeof(settings->libretro));
          rarch_main_msg_queue_push("Configuration override loaded", 1, 100, true);
@@ -1860,16 +1866,16 @@ bool config_load_override(void)
       return false;
 
    *global->append_config_path = '\0';
-   
+
    	// Toggle has_save_path to false so it resets
 	global->has_set_save_path = false;
 	global->has_set_state_path = false;
-   
+
    if (config_load_file(global->config_path, false))
    {
        RARCH_LOG("Configuration overrides unloaded, original configuration reset\n");
-       	   
-	   // Reset save paths	   
+
+	   // Reset save paths
 	   global->has_set_save_path = true;
 	   global->has_set_state_path = true;
 
@@ -2535,6 +2541,10 @@ bool config_save_file(const char *path)
          settings->auto_overrides_enable);
    config_set_bool(conf, "auto_remaps_enable",
          settings->auto_remaps_enable);
+   config_set_bool(conf, "sort_savefiles_enable",
+         settings->sort_savefiles_enable);
+   config_set_bool(conf, "sort_savestates_enable",
+         settings->sort_savestates_enable);
    config_set_int(conf, "libretro_log_level", settings->libretro_log_level);
    config_set_bool(conf, "log_verbosity", global->verbosity);
    config_set_bool(conf, "perfcnt_enable", global->perfcnt_enable);

--- a/configuration.h
+++ b/configuration.h
@@ -33,7 +33,7 @@ extern "C" {
 
 typedef struct settings
 {
-   struct 
+   struct
    {
       char driver[32];
       char context_driver[32];
@@ -105,7 +105,7 @@ typedef struct settings
    } ui;
 
 #ifdef HAVE_MENU
-   struct 
+   struct
    {
       char driver[32];
       bool pause_libretro;
@@ -322,6 +322,9 @@ typedef struct settings
    bool core_specific_config;
    bool auto_overrides_enable;
    bool auto_remaps_enable;
+
+   bool sort_savefiles_enable;
+   bool sort_savestates_enable;
 
    unsigned menu_ok_btn;
    unsigned menu_cancel_btn;

--- a/retroarch.c
+++ b/retroarch.c
@@ -334,13 +334,13 @@ void set_paths_redirect(const char *path)
    if(global->system.info.library_name && strcmp(global->system.info.library_name,"No Core") && settings->sort_savefiles_enable)
    {
       strlcpy(orig_savefile_dir,global->savefile_dir,sizeof(global->savefile_dir));
-	  fill_pathname_dir(global->savefile_dir,global->savefile_dir,global->system.info.library_name,sizeof(global->savefile_dir));
+      fill_pathname_dir(global->savefile_dir,global->savefile_dir,global->system.info.library_name,sizeof(global->savefile_dir));
    }
 
    if (global->system.info.library_name && strcmp(global->system.info.library_name,"No Core") && settings->sort_savestates_enable)
    {
       strlcpy(orig_savestate_dir,global->savestate_dir,sizeof(global->savestate_dir));
-	  fill_pathname_dir(global->savestate_dir,global->savestate_dir,global->system.info.library_name,sizeof(global->savestate_dir));
+      fill_pathname_dir(global->savestate_dir,global->savestate_dir,global->system.info.library_name,sizeof(global->savestate_dir));
    }
 
    if(path_is_directory(global->savefile_dir))

--- a/retroarch.c
+++ b/retroarch.c
@@ -331,16 +331,28 @@ void set_paths_redirect(const char *path)
    global_t   *global   = global_get_ptr();
    settings_t *settings = config_get_ptr();
 
+   /* per-core saves: append the library_name to the save location */
    if(global->system.info.library_name && strcmp(global->system.info.library_name,"No Core") && settings->sort_savefiles_enable)
    {
       strlcpy(orig_savefile_dir,global->savefile_dir,sizeof(global->savefile_dir));
       fill_pathname_dir(global->savefile_dir,global->savefile_dir,global->system.info.library_name,sizeof(global->savefile_dir));
+
+	  // if path doesn't exist try to create it, if everything fails revert to the original path
+	  if(!path_is_directory(global->savefile_dir))
+         if(!path_mkdir(global->savefile_dir))
+            strlcpy(global->savefile_dir,orig_savefile_dir,sizeof(global->savefile_dir));
    }
 
+   /* per-core states: append the library_name to the save location */
    if (global->system.info.library_name && strcmp(global->system.info.library_name,"No Core") && settings->sort_savestates_enable)
    {
       strlcpy(orig_savestate_dir,global->savestate_dir,sizeof(global->savestate_dir));
       fill_pathname_dir(global->savestate_dir,global->savestate_dir,global->system.info.library_name,sizeof(global->savestate_dir));
+
+	  // if path doesn't exist try to create it, if everything fails revert to the original path
+	  if(!path_is_directory(global->savestate_dir))
+         if(!path_mkdir(global->savestate_dir))
+            strlcpy(global->savestate_dir,orig_savestate_dir,sizeof(global->savestate_dir));
    }
 
    if(path_is_directory(global->savefile_dir))

--- a/retroarch.c
+++ b/retroarch.c
@@ -344,10 +344,10 @@ void set_paths_redirect(const char *path)
    }
 
    if(path_is_directory(global->savefile_dir))
-	   strlcpy(global->savefile_name,global->savefile_dir,sizeof(global->savefile_dir));
+      strlcpy(global->savefile_name,global->savefile_dir,sizeof(global->savefile_dir));
 
    if(path_is_directory(global->savestate_dir))
-	   strlcpy(global->savestate_name,global->savestate_dir,sizeof(global->savestate_dir));
+      strlcpy(global->savestate_name,global->savestate_dir,sizeof(global->savestate_dir));
 
    if (path_is_directory(global->savefile_name))
    {

--- a/retroarch.c
+++ b/retroarch.c
@@ -331,19 +331,16 @@ void set_paths_redirect(const char *path)
    global_t   *global   = global_get_ptr();
    settings_t *settings = config_get_ptr();
 
-   char orig_savestate_dir[PATH_MAX_LENGTH] = "";
-   char orig_savefile_dir[PATH_MAX_LENGTH] = "";
-
-   if (global->system.info.library_name && strcmp(global->system.info.library_name,"No Core") && settings->sort_savefiles_enable)
+   if(global->system.info.library_name && strcmp(global->system.info.library_name,"No Core") && settings->sort_savefiles_enable)
    {
-	   strlcpy(orig_savefile_dir,global->savefile_dir,sizeof(global->savefile_dir));
-	   fill_pathname_dir(global->savefile_dir,global->savefile_dir,global->system.info.library_name,sizeof(global->savefile_dir));
+	      strlcpy(orig_savefile_dir,global->savefile_dir,sizeof(global->savefile_dir));
+	      fill_pathname_dir(global->savefile_dir,global->savefile_dir,global->system.info.library_name,sizeof(global->savefile_dir));
    }
 
    if (global->system.info.library_name && strcmp(global->system.info.library_name,"No Core") && settings->sort_savestates_enable)
    {
-       strlcpy(orig_savestate_dir,global->savestate_dir,sizeof(global->savestate_dir));
-	   fill_pathname_dir(global->savestate_dir,global->savestate_dir,global->system.info.library_name,sizeof(global->savestate_dir));
+          strlcpy(orig_savestate_dir,global->savestate_dir,sizeof(global->savestate_dir));
+	      fill_pathname_dir(global->savestate_dir,global->savestate_dir,global->system.info.library_name,sizeof(global->savestate_dir));
    }
 
    if(path_is_directory(global->savefile_dir))
@@ -372,13 +369,6 @@ void set_paths_redirect(const char *path)
             ".state", sizeof(global->cheatfile_name));
       RARCH_LOG("Redirecting cheat file to \"%s\".\n", global->cheatfile_name);
    }
-
-   if(global->system.info.library_name && strcmp(global->system.info.library_name,"No Core") && settings->sort_savefiles_enable)
-	   strlcpy(global->savefile_dir,orig_savefile_dir,sizeof(global->savefile_dir));
-
-   if(global->system.info.library_name && strcmp(global->system.info.library_name,"No Core") && settings->sort_savestates_enable)
-	   strlcpy(global->savestate_dir,orig_savestate_dir,sizeof(global->savestate_dir));
-
 }
 
 void rarch_set_paths(const char *path)
@@ -1180,7 +1170,7 @@ int rarch_main_init(int argc, char *argv[])
 #if defined(GEKKO) && defined(HW_RVL)
    {
       settings_t *settings = config_get_ptr();
-       
+
       if (settings)
       {
          event_command(EVENT_CMD_VIDEO_SET_ASPECT_RATIO);

--- a/retroarch.c
+++ b/retroarch.c
@@ -333,14 +333,14 @@ void set_paths_redirect(const char *path)
 
    if(global->system.info.library_name && strcmp(global->system.info.library_name,"No Core") && settings->sort_savefiles_enable)
    {
-	      strlcpy(orig_savefile_dir,global->savefile_dir,sizeof(global->savefile_dir));
-	      fill_pathname_dir(global->savefile_dir,global->savefile_dir,global->system.info.library_name,sizeof(global->savefile_dir));
+      strlcpy(orig_savefile_dir,global->savefile_dir,sizeof(global->savefile_dir));
+	  fill_pathname_dir(global->savefile_dir,global->savefile_dir,global->system.info.library_name,sizeof(global->savefile_dir));
    }
 
    if (global->system.info.library_name && strcmp(global->system.info.library_name,"No Core") && settings->sort_savestates_enable)
    {
-          strlcpy(orig_savestate_dir,global->savestate_dir,sizeof(global->savestate_dir));
-	      fill_pathname_dir(global->savestate_dir,global->savestate_dir,global->system.info.library_name,sizeof(global->savestate_dir));
+      strlcpy(orig_savestate_dir,global->savestate_dir,sizeof(global->savestate_dir));
+	  fill_pathname_dir(global->savestate_dir,global->savestate_dir,global->system.info.library_name,sizeof(global->savestate_dir));
    }
 
    if(path_is_directory(global->savefile_dir))

--- a/retroarch.c
+++ b/retroarch.c
@@ -330,13 +330,20 @@ static void set_paths_redirect(const char *path)
 {
    global_t   *global   = global_get_ptr();
 
+   
+   if(path_is_directory(global->savefile_dir))
+	   strlcpy(global->savefile_name,global->savefile_dir,sizeof(global->savefile_dir));
+
+   if(path_is_directory(global->savestate_dir))
+	   strlcpy(global->savestate_name,global->savestate_dir,sizeof(global->savestate_dir));
+    
    if (path_is_directory(global->savefile_name))
    {
       fill_pathname_dir(global->savefile_name, global->basename,
             ".srm", sizeof(global->savefile_name));
       RARCH_LOG("Redirecting save file to \"%s\".\n", global->savefile_name);
    }
-
+   
    if (path_is_directory(global->savestate_name))
    {
       fill_pathname_dir(global->savestate_name, global->basename,

--- a/retroarch.c
+++ b/retroarch.c
@@ -330,13 +330,12 @@ static void set_paths_redirect(const char *path)
 {
    global_t   *global   = global_get_ptr();
 
-   
    if(path_is_directory(global->savefile_dir))
 	   strlcpy(global->savefile_name,global->savefile_dir,sizeof(global->savefile_dir));
 
    if(path_is_directory(global->savestate_dir))
 	   strlcpy(global->savestate_name,global->savestate_dir,sizeof(global->savestate_dir));
-    
+
    if (path_is_directory(global->savefile_name))
    {
       fill_pathname_dir(global->savefile_name, global->basename,

--- a/retroarch.c
+++ b/retroarch.c
@@ -356,7 +356,7 @@ void set_paths_redirect(const char *path)
    {
       fill_pathname_dir(global->savefile_name, global->basename,
             ".srm", sizeof(global->savefile_name));
-      RARCH_LOG("%s \nRedirecting save file to \"%s\".\n", orig_savefile_dir,global->savefile_name);
+      RARCH_LOG("Redirecting save file to \"%s\".\n", global->savefile_name);
    }
 
    if (path_is_directory(global->savestate_name))

--- a/retroarch.h
+++ b/retroarch.h
@@ -167,6 +167,8 @@ void rarch_init_system_av_info(void);
 
 void rarch_set_paths(const char *path);
 
+void set_paths_redirect(const char *path);
+
 /**
  * rarch_print_compiler:
  *

--- a/retroarch.h
+++ b/retroarch.h
@@ -176,6 +176,9 @@ void set_paths_redirect(const char *path);
  **/
 void rarch_print_compiler(char *str, size_t sizeof_str);
 
+char orig_savestate_dir[PATH_MAX_LENGTH];
+char orig_savefile_dir[PATH_MAX_LENGTH];
+
 #ifdef __cplusplus
 }
 #endif

--- a/settings.c
+++ b/settings.c
@@ -3682,6 +3682,30 @@ static bool setting_append_list_general_options(
          general_write_handler,
          general_read_handler);
 
+   CONFIG_BOOL(
+         settings->sort_savefiles_enable,
+         "sort_savefiles_enable",
+         "Sort Saves In Folders",
+         default_sort_savefiles_enable,
+         "OFF",
+         "ON",
+         group_info.name,
+         subgroup_info.name,
+         general_write_handler,
+         general_read_handler);
+
+   CONFIG_BOOL(
+         settings->sort_savestates_enable,
+         "sort_savestates_enable",
+         "Sort Saves States In Folders",
+         default_sort_savestates_enable,
+         "OFF",
+         "ON",
+         group_info.name,
+         subgroup_info.name,
+         general_write_handler,
+         general_read_handler);
+
    END_SUB_GROUP(list, list_info);
 
    START_SUB_GROUP(list, list_info, "Logging", group_info.name, subgroup_info);


### PR DESCRIPTION
Allow save dir and state dir to be overriden
This should be safe to merge now, most cases have been tested and it shouldn't affect anything for users that don't use the option.

Also I added an option to allow savefiles and savestates to be sorted in folders inside the main save directory.This is independent from overrides or per-core configs and should work in combination with those too. All of these are disabled by default.