### PR TITLE
file_ops: Get rid of unnecessary if statement

### DIFF
--- a/file_ops.c
+++ b/file_ops.c
@@ -120,9 +120,6 @@ static int read_generic_file(const char *path, void **buf, ssize_t *len)
    if ((ret = fread(content_buf, 1, content_buf_size, file)) < content_buf_size)
       RARCH_WARN("Didn't read whole file.\n");
 
-   if (!content_buf)
-      goto error;
-
    *buf    = content_buf;
 
    /* Allow for easy reading of strings to be safe.


### PR DESCRIPTION
fread won't null out the given buffer; nullity is already checked above the fread call.