### PR TITLE
improve autodetection of input gamepads

### DIFF
--- a/tools/retroarch-joyconfig.c
+++ b/tools/retroarch-joyconfig.c
@@ -46,6 +46,8 @@ static char *g_out_path = NULL;
 static char *g_auto_path = NULL;
 static char *g_driver = NULL;
 static unsigned g_meta_level = 0;
+static int g_input_vid = 0;
+static int g_input_pid = 0;
 
 bool rarch_main_verbosity(void)
 {
@@ -141,10 +143,19 @@ static void get_binds(config_file_t *conf, config_file_t *auto_conf,
    const char *joypad_name = input_joypad_name(driver, joypad);
    fprintf(stderr, "Using joypad: %s\n", joypad_name ? joypad_name : "Unknown");
 
-   if (joypad_name && auto_conf)
+   if (auto_conf)
    {
-      config_set_string(auto_conf, "input_device", joypad_name);
-      config_set_string(auto_conf, "input_driver", driver->ident);
+      if (joypad_name)
+      {
+         config_set_string(auto_conf, "input_device", joypad_name);
+         config_set_string(auto_conf, "input_driver", driver->ident);
+      }
+      
+      if (g_input_vid != 0 && g_input_pid != 0)
+      {
+         config_set_int(auto_conf, "input_vendor_id", g_input_vid);
+         config_set_int(auto_conf, "input_product_id", g_input_pid);
+      }
    }
 
    int16_t initial_axes[MAX_AXES] = {0};
@@ -450,7 +461,8 @@ static void parse_input(int argc, char *argv[])
 
 void input_config_autoconfigure_joypad(autoconfig_params_t *params)
 {
-   (void)params;
+   g_input_vid = params->vid;
+   g_input_pid = params->pid;
 }
 
 // Need SDL_main on OSX.


### PR DESCRIPTION
In my case always another configuration did win, the VID nor the PID was taken in account, previously the first one which matched was taken (in my case the name was the same :-()

Now: we try to find the perfect match (VID and PID match) if there is no perfect match the last soft match (name is the same) is used.

Additionally in the retroarch-joyconfig VID and PID is added to the config file, if in autoconf mode