### PR TITLE
(gl) Remove context switch calls from set_osd_msg

### DIFF
--- a/gfx/drivers/gl.c
+++ b/gfx/drivers/gl.c
@@ -3148,11 +3148,7 @@ static void gl_set_osd_msg(void *data, const char *msg,
       font = driver->font_osd_data;
 
    if (driver->font_osd_driver && font)
-   {
-      context_bind_hw_render(gl, false);
       font_driver->render_msg(font, msg, params);
-      context_bind_hw_render(gl, true);
-   }
 }
 
 static void gl_show_mouse(void *data, bool state)


### PR DESCRIPTION
It's not needed because this function is always called from the
frontend/menu context. The video driver handles SET_MESSAGE
environment call in the frame() function (msg argument).