### PR TITLE
Added scale support for get_message_width on gl_raster_font

### DIFF
--- a/gfx/drivers_font/gl_raster_font.c
+++ b/gfx/drivers_font/gl_raster_font.c
@@ -126,7 +126,7 @@ static void gl_raster_font_free_font(void *data)
    free(font);
 }
 
-static int get_message_width(gl_raster_t *font, const char *msg)
+static int get_message_width(gl_raster_t *font, const char *msg, float scale)
 {
    unsigned i;
    unsigned msg_len_full   = strlen(msg);
@@ -152,7 +152,7 @@ static int get_message_width(gl_raster_t *font, const char *msg)
       msg_len       = min(msg_len_full, MAX_MSG_LEN_CHUNK);
    }
 
-   return delta_x;
+   return delta_x * scale;
 }
 
 static void gl_raster_font_draw_vertices(gl_t *gl, const gl_coords_t *coords)
@@ -194,10 +194,10 @@ static void gl_raster_font_render_message(
    switch (text_align)
    {
       case TEXT_ALIGN_RIGHT:
-         x -= get_message_width(font, msg);
+         x -= get_message_width(font, msg, scale);
          break;
       case TEXT_ALIGN_CENTER:
-         x -= get_message_width(font, msg) / 2.0;
+         x -= get_message_width(font, msg, scale) / 2.0;
          break;
    }
 


### PR DESCRIPTION
Now, the get_message_width function takes an additional parameter `scale`. This final width is then multiplied using this parameter.

This fixes the text alignment issue I've had when the scale wasn't set to 1 (the text was scaled but not its position when aligning).

This fixes issue #1691