### PR TITLE
(Font) Added get_message_width in font_renderer_t

### DIFF
--- a/gfx/drivers_font/d3d_w32_font.cpp
+++ b/gfx/drivers_font/d3d_w32_font.cpp
@@ -118,4 +118,5 @@ font_renderer_t d3d_win32_font = {
    NULL,                      /* get_glyph */
    NULL,                      /* bind_block */
    NULL,                      /* flush */
+   NULL                       /* get_message_width */
 };

--- a/gfx/drivers_font/gl_raster_font.c
+++ b/gfx/drivers_font/gl_raster_font.c
@@ -126,8 +126,12 @@ static void gl_raster_font_free_font(void *data)
    free(font);
 }
 
-static int get_message_width(gl_raster_t *font, const char *msg, float scale)
+static int gl_get_message_width(void *data, const char *msg, float scale)
 {
+   gl_raster_t *font = (gl_raster_t*)data;
+   if (!font)
+      return 0;
+      
    unsigned i;
    unsigned msg_len_full   = strlen(msg);
    unsigned msg_len        = min(msg_len_full, MAX_MSG_LEN_CHUNK);
@@ -194,10 +198,10 @@ static void gl_raster_font_render_message(
    switch (text_align)
    {
       case TEXT_ALIGN_RIGHT:
-         x -= get_message_width(font, msg, scale);
+         x -= gl_get_message_width(font, msg, scale);
          break;
       case TEXT_ALIGN_CENTER:
-         x -= get_message_width(font, msg, scale) / 2.0;
+         x -= gl_get_message_width(font, msg, scale) / 2.0;
          break;
    }
 
@@ -408,5 +412,5 @@ font_renderer_t gl_raster_font = {
    gl_raster_font_get_glyph,
    gl_raster_font_bind_block,
    gl_raster_font_flush_block,
-   NULL                         /* get_message_width */
+   gl_get_message_width
 };

--- a/gfx/drivers_font/gl_raster_font.c
+++ b/gfx/drivers_font/gl_raster_font.c
@@ -407,5 +407,6 @@ font_renderer_t gl_raster_font = {
    "GL raster",
    gl_raster_font_get_glyph,
    gl_raster_font_bind_block,
-   gl_raster_font_flush_block
+   gl_raster_font_flush_block,
+   NULL                         /* get_message_width */
 };

--- a/gfx/drivers_font/ps_libdbgfont.c
+++ b/gfx/drivers_font/ps_libdbgfont.c
@@ -104,5 +104,6 @@ font_renderer_t libdbg_font = {
    "libdbgfont",
    NULL,                      /* get_glyph */
    NULL,                      /* bind_block */
-   NULL,                      /* flush */
+   NULL,                      /* flush */,
+   NULL,                      /* get_message_width */
 };

--- a/gfx/drivers_font/xdk1_xfonts.c
+++ b/gfx/drivers_font/xdk1_xfonts.c
@@ -92,4 +92,5 @@ font_renderer_t d3d_xdk1_font = {
    NULL,                      /* get_glyph */
    NULL,                      /* bind_block */
    NULL,                      /* flush */
+   NULL                       /* get_message_width */
 };

--- a/gfx/drivers_font/xdk360_fonts.c
+++ b/gfx/drivers_font/xdk360_fonts.c
@@ -497,4 +497,5 @@ font_renderer_t d3d_xbox360_font = {
    NULL,                      /* get_glyph */
    NULL,                      /* bind_block */
    NULL,                      /* flush */
+   NULL                       /* get_message_width */
 };

--- a/gfx/font_renderer_driver.c
+++ b/gfx/font_renderer_driver.c
@@ -32,6 +32,17 @@ static const font_renderer_driver_t *font_backends[] = {
    NULL
 };
 
+int font_renderer_get_message_width(const char *msg, float scale)
+{
+    driver_t *driver                        = driver_get_ptr();  
+    const struct font_renderer *font_driver = driver ? driver->font_osd_driver : NULL;
+    
+    if (!font_driver || !font_driver->get_message_width)
+       return 0;
+       
+    return font_driver->get_message_width(driver->font_osd_data, msg, scale);
+}
+
 bool font_renderer_create_default(
       const font_renderer_driver_t **drv, void **handle,
       const char *font_path, unsigned font_size)

--- a/gfx/font_renderer_driver.h
+++ b/gfx/font_renderer_driver.h
@@ -103,6 +103,8 @@ extern font_renderer_driver_t bitmap_font_renderer;
 /* font_path can be NULL for default font. */
 bool font_renderer_create_default(const font_renderer_driver_t **driver,
       void **handle, const char *font_path, unsigned font_size);
+      
+int font_renderer_get_message_width(const char *msg, float scale);
 
 #ifdef __cplusplus
 }

--- a/gfx/font_renderer_driver.h
+++ b/gfx/font_renderer_driver.h
@@ -70,6 +70,8 @@ typedef struct font_renderer
    const struct font_glyph *(*get_glyph)(void *data, uint32_t code);
    void (*bind_block)(void *data, void *block);
    void (*flush)(void *data);
+   
+   int (*get_message_width)(void *data, const char *msg, float scale);
 } font_renderer_t;
 
 extern font_renderer_t gl_raster_font;


### PR DESCRIPTION
I thought that a menu driver could need to get a message on-screen width, for example to draw several strings horizontally on a same line. It just has to include `font_renderer_driver.h` to use the function.

I added the function in `font_renderer_t` and only implemented it in `gl_raster_font` (it's set to `NULL` on the others, and so returns 0 when used). The function in `font_renderer_driver.h` is only there to create a shortcut so we can use it more directly, like we have with other drivers.

I don't know if I placed the stuff at the right place tho, I tried to match as much as possible with how the drivers works, but it looks right to me.