### PR TITLE
Added an input/action callback in the menu_ctx_driver

### DIFF
--- a/menu/drivers/glui.c
+++ b/menu/drivers/glui.c
@@ -674,4 +674,5 @@ menu_ctx_driver_t menu_ctx_glui = {
    NULL,
    glui_load_wallpaper,
    "glui",
+   NULL,
 };

--- a/menu/drivers/null.c
+++ b/menu/drivers/null.c
@@ -48,4 +48,5 @@ menu_ctx_driver_t menu_ctx_null = {
   NULL, // list_set_selection
   NULL,
   "null",
+  NULL,
 };

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -654,4 +654,5 @@ menu_ctx_driver_t menu_ctx_rgui = {
    NULL,
    NULL,
    "rgui",
+   NULL,
 };

--- a/menu/drivers/rmenu.c
+++ b/menu/drivers/rmenu.c
@@ -329,4 +329,5 @@ menu_ctx_driver_t menu_ctx_rmenu = {
    NULL,
    NULL,
    "rmenu",
+   NULL,
 };

--- a/menu/drivers/rmenu_xui.cpp
+++ b/menu/drivers/rmenu_xui.cpp
@@ -683,4 +683,5 @@ menu_ctx_driver_t menu_ctx_rmenu_xui = {
    rmenu_xui_list_set_selection,
    NULL,
    "rmenu_xui",
+   NULL,
 };

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -1936,4 +1936,5 @@ menu_ctx_driver_t menu_ctx_xmb = {
    NULL,
    xmb_load_wallpaper,
    "xmb",
+   NULL,
 };

--- a/menu/menu_driver.h
+++ b/menu/menu_driver.h
@@ -254,6 +254,7 @@ typedef struct menu_ctx_driver
    void  (*list_set_selection)(file_list_t *list);
    bool  (*load_background)(void *data);
    const char *ident;
+   bool  (*perform_action)(unsigned action);
 } menu_ctx_driver_t;
 
 extern menu_ctx_driver_t menu_ctx_rmenu;

--- a/menu/menu_driver.h
+++ b/menu/menu_driver.h
@@ -254,7 +254,7 @@ typedef struct menu_ctx_driver
    void  (*list_set_selection)(file_list_t *list);
    bool  (*load_background)(void *data);
    const char *ident;
-   bool  (*perform_action)(unsigned action);
+   bool  (*perform_action)(void* data, unsigned action);
 } menu_ctx_driver_t;
 
 extern menu_ctx_driver_t menu_ctx_rmenu;

--- a/menu/menu_input.c
+++ b/menu/menu_input.c
@@ -940,6 +940,14 @@ void menu_input_post_iterate(int *ret, unsigned action)
       *ret |= menu_input_pointer_post_iterate(cbs, &entry, action);
 }
 
+static const menu_ctx_driver_t *menu_ctx_driver_get_ptr(void)
+{
+   driver_t *driver = driver_get_ptr();
+   if (!driver || !driver->menu_ctx)
+      return NULL;
+   return driver->menu_ctx;
+}
+
 unsigned menu_input_frame(retro_input_t input, retro_input_t trigger_input)
 {
    unsigned ret = 0;
@@ -1029,6 +1037,13 @@ unsigned menu_input_frame(retro_input_t input, retro_input_t trigger_input)
 
    if (settings->menu.pointer.enable)
       menu_input_pointer(&ret);
-
-   return ret;
+      
+   if (trigger_input && menu_ctx_driver_get_ptr()->perform_action && menu_ctx_driver_get_ptr()->perform_action(menu->userdata, ret))
+   {
+      return MENU_ACTION_NOOP;
+   }
+   else
+   {
+      return ret;
+   }
 }


### PR DESCRIPTION
Hello,

I noticed that if a menu driver needed to catch inputs (or menu actions) to do specific things, it couldn't. I came with the idea of an "input bypass callback", in the menu context driver.

Now, each time RA gets an input, it :
 - makes it a menu action as usual
 - first asks to the menu driver if it wants to do something special with it (using `perform_action` if implemented)
 - the menu driver catches it, and do whatever it wants with this action, and returns true or false
 - if the return value is true, then RA stops there (it means that the menu already processed the input)
 - if not, it continues with the current default behaviour (refresh entries etc)

It allows menu drivers to do whatever they want with the menu actions, it could lead to more flexible and powerfuls menus (Lakka could use it for example). The current menus are not impacted, and as far as I tested the current behaviour is not impacted since the callback isn't implemented.
