### PR TITLE
Move 64-bit printf stuff to its own experimental function.

### DIFF
--- a/libretro-db/rmsgpack_dom.c
+++ b/libretro-db/rmsgpack_dom.c
@@ -32,26 +32,12 @@ static void puts_i64(int64_t dec)
     register int i;
 
     decimal = (dec < 0) ? (uint64_t)-dec : (uint64_t)+dec;
-    digits[ 0] = (decimal / 1000000000000000000) % 10;
-    digits[ 1] = (decimal /  100000000000000000) % 10;
-    digits[ 2] = (decimal /   10000000000000000) % 10;
-    digits[ 3] = (decimal /    1000000000000000) % 10;
-    digits[ 4] = (decimal /     100000000000000) % 10;
-    digits[ 5] = (decimal /      10000000000000) % 10;
-    digits[ 6] = (decimal /       1000000000000) % 10;
-    digits[ 7] = (decimal /        100000000000) % 10;
-    digits[ 8] = (decimal /         10000000000) % 10;
-    digits[ 9] = (decimal /          1000000000) % 10;
-    digits[10] = (decimal /           100000000) % 10;
-    digits[11] = (decimal /            10000000) % 10;
-    digits[12] = (decimal /             1000000) % 10;
-    digits[13] = (decimal /              100000) % 10;
-    digits[14] = (decimal /               10000) % 10;
-    digits[15] = (decimal /                1000) % 10;
-    digits[16] = (decimal /                 100) % 10;
-    digits[17] = (decimal /                  10) % 10;
-    digits[18] = (decimal /                   1) % 10;
     digits[19] = '\0';
+    for (i = sizeof(digits) - 2; i >= 0; i--)
+    {
+        digits[i] = decimal % 10;
+        decimal /= 10;
+    }
 
     for (i = 0; i < sizeof(digits) - 1; i++)
         digits[i] += '0';
@@ -66,30 +52,15 @@ static void puts_i64(int64_t dec)
 
 static void puts_u64(uint64_t decimal)
 {
-    char digits[20 + 1]; /* max i64:  18,446,744,073,709,551,616 */
+    char digits[20 + 1]; /* max u64:  18,446,744,073,709,551,616 */
     register int i;
 
-    digits[ 0] = (decimal / 10000000000000000000) % 10;
-    digits[ 1] = (decimal /  1000000000000000000) % 10;
-    digits[ 2] = (decimal /   100000000000000000) % 10;
-    digits[ 3] = (decimal /    10000000000000000) % 10;
-    digits[ 4] = (decimal /     1000000000000000) % 10;
-    digits[ 5] = (decimal /      100000000000000) % 10;
-    digits[ 6] = (decimal /       10000000000000) % 10;
-    digits[ 7] = (decimal /        1000000000000) % 10;
-    digits[ 8] = (decimal /         100000000000) % 10;
-    digits[ 9] = (decimal /          10000000000) % 10;
-    digits[10] = (decimal /           1000000000) % 10;
-    digits[11] = (decimal /            100000000) % 10;
-    digits[12] = (decimal /             10000000) % 10;
-    digits[13] = (decimal /              1000000) % 10;
-    digits[14] = (decimal /               100000) % 10;
-    digits[15] = (decimal /                10000) % 10;
-    digits[16] = (decimal /                 1000) % 10;
-    digits[17] = (decimal /                  100) % 10;
-    digits[18] = (decimal /                   10) % 10;
-    digits[19] = (decimal /                    1) % 10;
     digits[20] = '\0';
+    for (i = sizeof(digits) - 2; i >= 0; i--)
+    {
+        digits[i] = decimal % 10;
+        decimal /= 10;
+    }
 
     for (i = 0; i < sizeof(digits) - 1; i++)
         digits[i] += '0';

--- a/libretro-db/rmsgpack_dom.c
+++ b/libretro-db/rmsgpack_dom.c
@@ -25,6 +25,81 @@ static struct rmsgpack_dom_value *dom_reader_state_pop(
 	return v;
 }
 
+static void puts_i64(int64_t dec)
+{
+    signed char digits[19 + 1]; /* max i64:  9,223,372,036,854,775,807 */
+    uint64_t decimal;
+    register int i;
+
+    decimal = (dec < 0) ? (uint64_t)-dec : (uint64_t)+dec;
+    digits[ 0] = (decimal / 1000000000000000000) % 10;
+    digits[ 1] = (decimal /  100000000000000000) % 10;
+    digits[ 2] = (decimal /   10000000000000000) % 10;
+    digits[ 3] = (decimal /    1000000000000000) % 10;
+    digits[ 4] = (decimal /     100000000000000) % 10;
+    digits[ 5] = (decimal /      10000000000000) % 10;
+    digits[ 6] = (decimal /       1000000000000) % 10;
+    digits[ 7] = (decimal /        100000000000) % 10;
+    digits[ 8] = (decimal /         10000000000) % 10;
+    digits[ 9] = (decimal /          1000000000) % 10;
+    digits[10] = (decimal /           100000000) % 10;
+    digits[11] = (decimal /            10000000) % 10;
+    digits[12] = (decimal /             1000000) % 10;
+    digits[13] = (decimal /              100000) % 10;
+    digits[14] = (decimal /               10000) % 10;
+    digits[15] = (decimal /                1000) % 10;
+    digits[16] = (decimal /                 100) % 10;
+    digits[17] = (decimal /                  10) % 10;
+    digits[18] = (decimal /                   1) % 10;
+    digits[19] = '\0';
+
+    for (i = 0; i < sizeof(digits) - 1; i++)
+        digits[i] += '0';
+    for (i = 0; i < sizeof(digits) - 2; i++)
+        if (digits[i] != '0')
+            break; /* Don't print leading zeros to the console. */
+
+    if (dec < 0)
+        putchar('-');
+    fputs((char *)&digits[i], stdout);
+}
+
+static void puts_u64(uint64_t decimal)
+{
+    char digits[20 + 1]; /* max i64:  18,446,744,073,709,551,616 */
+    register int i;
+
+    digits[ 0] = (decimal / 10000000000000000000) % 10;
+    digits[ 1] = (decimal /  1000000000000000000) % 10;
+    digits[ 2] = (decimal /   100000000000000000) % 10;
+    digits[ 3] = (decimal /    10000000000000000) % 10;
+    digits[ 4] = (decimal /     1000000000000000) % 10;
+    digits[ 5] = (decimal /      100000000000000) % 10;
+    digits[ 6] = (decimal /       10000000000000) % 10;
+    digits[ 7] = (decimal /        1000000000000) % 10;
+    digits[ 8] = (decimal /         100000000000) % 10;
+    digits[ 9] = (decimal /          10000000000) % 10;
+    digits[10] = (decimal /           1000000000) % 10;
+    digits[11] = (decimal /            100000000) % 10;
+    digits[12] = (decimal /             10000000) % 10;
+    digits[13] = (decimal /              1000000) % 10;
+    digits[14] = (decimal /               100000) % 10;
+    digits[15] = (decimal /                10000) % 10;
+    digits[16] = (decimal /                 1000) % 10;
+    digits[17] = (decimal /                  100) % 10;
+    digits[18] = (decimal /                   10) % 10;
+    digits[19] = (decimal /                    1) % 10;
+    digits[20] = '\0';
+
+    for (i = 0; i < sizeof(digits) - 1; i++)
+        digits[i] += '0';
+    for (i = 0; i < sizeof(digits) - 2; i++)
+        if (digits[i] != '0')
+            break; /* Don't print leading zeros to the console. */
+
+    fputs(&digits[i], stdout);
+}
+
 static int dom_reader_state_push(struct dom_reader_state *s,
       struct rmsgpack_dom_value *v)
 {
@@ -295,18 +370,10 @@ void rmsgpack_dom_value_print(struct rmsgpack_dom_value *obj)
             printf("false");
          break;
       case RDT_INT:
-#ifdef _WIN32
-         printf("%I64d", (signed long long)obj->int_);
-#else
-         printf("%lld", (signed long long)obj->int_);
-#endif
+         puts_i64(obj -> int_);
          break;
       case RDT_UINT:
-#ifdef _WIN32
-         printf("%I64u", (unsigned long long)obj->uint_);
-#else
-         printf("%llu",  (unsigned long long)obj->uint_);
-#endif
+         puts_u64(obj -> uint_);
          break;
       case RDT_STRING:
          printf("\"%s\"", obj->string.buff);


### PR DESCRIPTION
As unlikely as it is that the segmentation fault is coming from something done with `printf` on 64-bit numbers, we'll make room for debugging anyway.  Besides, this **portably** solves the problem of how to do said prints of 64-bit integers on implementations that lack a complete set of C99 features and extensions or decline to implement them (for example the #ifdef for _WIN32).