### PR TITLE
Added quotes to Keyboard input examples

### DIFF
--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -406,18 +406,18 @@
 #
 # Keyboard input, Joypad and Joyaxis will all obey the "nul" bind, which disables the bind completely, 
 # rather than relying on a default.
-# input_player1_a = x
-# input_player1_b = z
-# input_player1_y = a
-# input_player1_x = s
-# input_player1_start = enter
-# input_player1_select = rshift
-# input_player1_l = q
-# input_player1_r = w
-# input_player1_left = left
-# input_player1_right = right
-# input_player1_up = up
-# input_player1_down = down
+# input_player1_a = "x"
+# input_player1_b = "z"
+# input_player1_y = "a"
+# input_player1_x = "s"
+# input_player1_start = "enter"
+# input_player1_select = "rshift"
+# input_player1_l = "q"
+# input_player1_r = "w"
+# input_player1_left = "left"
+# input_player1_right = "right"
+# input_player1_up = "up"
+# input_player1_down = "down"
 # input_player1_l2 =
 # input_player1_r2 =
 # input_player1_l3 =


### PR DESCRIPTION
The commented-out examples for key mappings like input_player1_a were shown without quotes around the key definitions. This caused some confusion when trying to get this feature to work after uncommenting as they don't work without quotes around the values.