### PR TITLE
fix dispmanx compile (dispmanx_gfx_get_frame_count)

### DIFF
--- a/gfx/drivers/dispmanx_gfx.c
+++ b/gfx/drivers/dispmanx_gfx.c
@@ -598,7 +598,7 @@ static uint64_t dispmanx_gfx_get_frame_count(void *data)
 }
 
 static const video_poke_interface_t dispmanx_poke_interface = {
-   dispmanx_get_frame_count,
+   dispmanx_gfx_get_frame_count,
    NULL, /* set_video_mode */
    NULL, /* set_filtering */
    NULL, /* get_video_output_size */


### PR DESCRIPTION
line 601 looking for dispmanx_get_frame_count
the correct name is dispmanx_gfx_get_frame_count (from line 592)