### PR TITLE
Added '\n' support for gl_raster_font

### DIFF
--- a/gfx/drivers_font/gl_raster_font.c
+++ b/gfx/drivers_font/gl_raster_font.c
@@ -262,15 +262,12 @@ static void gl_raster_font_render_line(
    }
 }
 
-//TODO Support scale
-//TODO Line height
-//TODO Adapt this to all drivers
 static void gl_raster_font_render_message(
       gl_raster_t *font, const char *msg, GLfloat scale,
       const GLfloat color[4], GLfloat pos_x, GLfloat pos_y,
       unsigned text_align)
 {
-    //If the font height is not supported just draw like as usual
+    //If the font height is not supported just draw as usual
     if (!font->font_driver->get_line_height)
     {
         gl_raster_font_render_line(font, msg, scale, color, pos_x, pos_y, text_align);

--- a/gfx/drivers_font_renderer/bitmapfont.c
+++ b/gfx/drivers_font_renderer/bitmapfont.c
@@ -128,6 +128,16 @@ static const char *font_renderer_bmp_get_default_font(void)
    return "";
 }
 
+static int font_renderer_bmp_get_line_height(void* data)
+{
+    bm_renderer_t *handle = (bm_renderer_t*)data;
+    
+    if (!handle)
+      return FONT_HEIGHT;
+      
+    return FONT_HEIGHT * handle->scale_factor;
+}
+
 font_renderer_driver_t bitmap_font_renderer = {
    font_renderer_bmp_init,
    font_renderer_bmp_get_atlas,
@@ -135,5 +145,6 @@ font_renderer_driver_t bitmap_font_renderer = {
    font_renderer_bmp_free,
    font_renderer_bmp_get_default_font,
    "bitmap",
+   font_renderer_bmp_get_line_height,
 };
 

--- a/gfx/drivers_font_renderer/coretext.c
+++ b/gfx/drivers_font_renderer/coretext.c
@@ -293,4 +293,5 @@ font_renderer_driver_t coretext_font_renderer = {
   font_renderer_ct_free,
   font_renderer_ct_get_default_font,
   "coretext",
+  NULL, /*get_line_height*/
 };

--- a/gfx/drivers_font_renderer/freetype.c
+++ b/gfx/drivers_font_renderer/freetype.c
@@ -226,6 +226,15 @@ static const char *font_renderer_ft_get_default_font(void)
    return NULL;
 }
 
+static int font_renderer_ft_get_line_height(void* data)
+{
+    ft_font_renderer_t *handle = (ft_font_renderer_t*)data;
+    if (!handle)
+      return 0;
+      
+    return handle->face->size->metrics->height;
+}
+
 font_renderer_driver_t freetype_font_renderer = {
    font_renderer_ft_init,
    font_renderer_ft_get_atlas,
@@ -233,4 +242,5 @@ font_renderer_driver_t freetype_font_renderer = {
    font_renderer_ft_free,
    font_renderer_ft_get_default_font,
    "freetype",
+   NULL, /*get_line_height*/
 };

--- a/gfx/drivers_font_renderer/freetype.c
+++ b/gfx/drivers_font_renderer/freetype.c
@@ -232,7 +232,7 @@ static int font_renderer_ft_get_line_height(void* data)
     if (!handle)
       return 0;
       
-    return handle->face->size->metrics->height;
+    return handle->face->size->metrics.height/64;
 }
 
 font_renderer_driver_t freetype_font_renderer = {
@@ -242,5 +242,5 @@ font_renderer_driver_t freetype_font_renderer = {
    font_renderer_ft_free,
    font_renderer_ft_get_default_font,
    "freetype",
-   NULL, /*get_line_height*/
+   font_renderer_ft_get_line_height,
 };

--- a/gfx/font_renderer_driver.h
+++ b/gfx/font_renderer_driver.h
@@ -94,6 +94,8 @@ typedef struct font_renderer_driver
    const char *(*get_default_font)(void);
 
    const char *ident;
+   
+   int (*get_line_height)(void* data);
 } font_renderer_driver_t;
 
 extern font_renderer_driver_t freetype_font_renderer;


### PR DESCRIPTION
I added the support for the `\n` character in `gl_raster_font driver`. I created a new function in the font renderer driver called `get_line_height` which returns the height of a line for the current font : for the bitmap font it's `FONT_HEIGHT` multiplied by the scale factor, and for Freetype it's the line height in the face metrics.

Now, `gl_raster` checks if the font renderer driver provides a line height ; if it does, then it splits the message using `strtok` and draws it line by line. It works for all the alignment types and support the scale. If the font renderer doesn't have any line height callback (like `coretext`, I couldn't test it so I didn't write one), it draws the whole message like usual.

The `get_message_width` function is not altered, it just returns the whole width regardless of the `\n` characters.