### PR TITLE
(GLUI) Turn y into an int in glui_render_menu_list

### DIFF
--- a/menu/drivers/glui.c
+++ b/menu/drivers/glui.c
@@ -297,10 +297,9 @@ static void glui_render_menu_list(glui_handle_t *glui,
       char message[PATH_MAX_LENGTH],
            entry_title_buf[PATH_MAX_LENGTH], type_str_buf[PATH_MAX_LENGTH];
       bool entry_selected;
-      unsigned y = menu->header_height - menu->scroll_y + (glui->line_height * i);
-      int max_visible_entries = ((y + glui->line_height));
+      int y = menu->header_height - menu->scroll_y + (glui->line_height * i);
 
-      if (y > height || (max_visible_entries < 0))
+      if (y > height || ((y + (int)glui->line_height) < 0))
          continue;
 
       entry_selected = menu_entry_is_currently_selected(i);


### PR DESCRIPTION
In large screens y can be negative