### PR TITLE
Fix scaling on Retina Macs

### DIFF
--- a/apple/OSX/RetroArch-Info.plist
+++ b/apple/OSX/RetroArch-Info.plist
@@ -43,5 +43,7 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>RApplication</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
 </dict>
 </plist>

--- a/gfx/drivers_context/cocoa_gl_ctx.m
+++ b/gfx/drivers_context/cocoa_gl_ctx.m
@@ -151,6 +151,7 @@ static bool cocoagl_gfx_ctx_init(void *data)
     
 #if defined(HAVE_COCOA)
     CocoaView *g_view = (CocoaView*)nsview_get_ptr();
+	[g_view setWantsBestResolutionOpenGLSurface:YES];
     NSOpenGLPixelFormatAttribute attributes [] = {
         NSOpenGLPFAColorSize, 24,
         NSOpenGLPFADoubleBuffer,
@@ -337,8 +338,10 @@ static void cocoagl_gfx_ctx_get_video_size(void *data, unsigned* width, unsigned
 	
 #if defined(HAVE_COCOA)
    CocoaView *g_view = (CocoaView*)nsview_get_ptr();
-   CGRect cgrect = NSRectToCGRect([g_view frame]);
-   size = CGRectMake(0, 0, CGRectGetWidth(cgrect), CGRectGetHeight(cgrect));
+   NSRect backingBounds = [g_view convertRectToBacking:[g_view bounds]];
+   GLsizei backingPixelWidth = (GLSizei)(backingBounds.size.width),
+		   backingPixelHeight = (GLSizei)(backingBounds.size.height);
+   size = CGRectMake(0, 0, backingPixelWidth, backingPixelHeight);
 #else
    size = g_view.bounds;
 #endif
@@ -383,7 +386,7 @@ static bool cocoagl_gfx_ctx_get_metrics(void *data, enum display_metric_types ty
 #if MAC_OS_X_VERSION_10_6
     float   scale                 = screen.backingScaleFactor;
 #else
-	float   scale                 = 1.0f;
+	float   scale                 = 4.0f;
 #endif
     float   dpi                   = (display_width/ physical_width) * 25.4f * scale;
 #elif defined(HAVE_COCOATOUCH)

--- a/gfx/drivers_context/cocoa_gl_ctx.m
+++ b/gfx/drivers_context/cocoa_gl_ctx.m
@@ -339,8 +339,8 @@ static void cocoagl_gfx_ctx_get_video_size(void *data, unsigned* width, unsigned
 #if defined(HAVE_COCOA)
    CocoaView *g_view = (CocoaView*)nsview_get_ptr();
    NSRect backingBounds = [g_view convertRectToBacking:[g_view bounds]];
-   GLsizei backingPixelWidth = (GLSizei)(backingBounds.size.width),
-		   backingPixelHeight = (GLSizei)(backingBounds.size.height);
+   GLsizei backingPixelWidth = (GLsizei)(backingBounds.size.width),
+		   backingPixelHeight = (GLsizei)(backingBounds.size.height);
    size = CGRectMake(0, 0, backingPixelWidth, backingPixelHeight);
 #else
    size = g_view.bounds;
@@ -386,9 +386,9 @@ static bool cocoagl_gfx_ctx_get_metrics(void *data, enum display_metric_types ty
 #if MAC_OS_X_VERSION_10_6
     float   scale                 = screen.backingScaleFactor;
 #else
-	float   scale                 = 4.0f;
+	float   scale                 = 1.0f;
 #endif
-    float   dpi                   = (display_width/ physical_width) * 25.4f * scale;
+    float   dpi                   = (display_width/ physical_width) * 25.4f * scale * 3.0f;
 #elif defined(HAVE_COCOATOUCH)
     float   scale                 = cocoagl_gfx_ctx_get_native_scale();
     CGRect  screen_rect           = [[UIScreen mainScreen] bounds];

--- a/gfx/drivers_context/cocoa_gl_ctx.m
+++ b/gfx/drivers_context/cocoa_gl_ctx.m
@@ -388,7 +388,7 @@ static bool cocoagl_gfx_ctx_get_metrics(void *data, enum display_metric_types ty
 #else
 	float   scale                 = 1.0f;
 #endif
-    float   dpi                   = (display_width/ physical_width) * 25.4f * scale * 3.0f;
+    float   dpi                   = (display_width/ physical_width) * 25.4f * scale;
 #elif defined(HAVE_COCOATOUCH)
     float   scale                 = cocoagl_gfx_ctx_get_native_scale();
     CGRect  screen_rect           = [[UIScreen mainScreen] bounds];


### PR DESCRIPTION
This gives Macs access to the true context size instead of the half-scaled one, so text looks much nicer. It will negatively impact shader performance, though, since it's getting the actual, giant retina size.