### PR TITLE
ifdef the retina stuff for backward compatibility

### DIFF
--- a/gfx/drivers_context/cocoa_gl_ctx.m
+++ b/gfx/drivers_context/cocoa_gl_ctx.m
@@ -338,10 +338,15 @@ static void cocoagl_gfx_ctx_get_video_size(void *data, unsigned* width, unsigned
 	
 #if defined(HAVE_COCOA)
    CocoaView *g_view = (CocoaView*)nsview_get_ptr();
-   NSRect backingBounds = [g_view convertRectToBacking:[g_view bounds]];
-   GLsizei backingPixelWidth = (GLsizei)(backingBounds.size.width),
-		   backingPixelHeight = (GLsizei)(backingBounds.size.height);
-   size = CGRectMake(0, 0, backingPixelWidth, backingPixelHeight);
+   #if MAC_OS_X_VERSION_10_7
+      NSRect backingBounds = [g_view convertRectToBacking:[g_view bounds]];
+      GLsizei backingPixelWidth = (GLsizei)(backingBounds.size.width),
+		      backingPixelHeight = (GLsizei)(backingBounds.size.height);
+      size = CGRectMake(0, 0, backingPixelWidth, backingPixelHeight);
+   #else
+      CGRect cgrect = NSRectToCGRect([g_view frame]);
+      size = CGRectMake(0, 0, CGRectGetWidth(cgrect), CGRectGetHeight(cgrect));
+   #endif
 #else
    size = g_view.bounds;
 #endif


### PR DESCRIPTION
I think all of the high-dpi stuff was added in 10.7, so this should revert it back to the old code on anything older than that.