### PR TITLE
Minor performance improvements

### DIFF
--- a/gfx/drivers_font/gl_raster_font.c
+++ b/gfx/drivers_font/gl_raster_font.c
@@ -266,35 +266,38 @@ static void gl_raster_font_render_message(
       const GLfloat color[4], GLfloat pos_x, GLfloat pos_y,
       unsigned text_align)
 {
-    //If the font height is not supported just draw as usual
-    if (!font->font_driver->get_line_height)
-    {
-        gl_raster_font_render_line(font, msg, strlen(msg), scale, color, pos_x, pos_y, text_align);
-        return;
-    }
-    
-    int lines = 0;
-    float line_height = scale * 1/(float)font->font_driver->get_line_height(font->font_data);
-    
-    for (;;)
-    {
-        const char *delim = strchr(msg, '\n');
-        
-        //Draw the line
-        if (delim)
-        {
-            unsigned msg_len = delim - msg;
-            gl_raster_font_render_line(font, msg, msg_len, scale, color, pos_x, pos_y - (float)lines*line_height, text_align);
-            msg += msg_len + 1;
-            lines++;
-        }
-        else
-        {
-            unsigned msg_len = strlen(msg);
-            gl_raster_font_render_line(font, msg, msg_len, scale, color, pos_x, pos_y - (float)lines*line_height, text_align);
-            break;
-        }
-    }
+   if (!msg || !*msg || !font->gl)
+      return;
+
+   //If the font height is not supported just draw as usual
+   if (!font->font_driver->get_line_height)
+   {
+      gl_raster_font_render_line(font, msg, strlen(msg), scale, color, pos_x, pos_y, text_align);
+      return;
+   }
+
+   int lines = 0;
+   float line_height = scale * 1/(float)font->font_driver->get_line_height(font->font_data);
+
+   for (;;)
+   {
+      const char *delim = strchr(msg, '\n');
+
+      //Draw the line
+      if (delim)
+      {
+         unsigned msg_len = delim - msg;
+         gl_raster_font_render_line(font, msg, msg_len, scale, color, pos_x, pos_y - (float)lines*line_height, text_align);
+         msg += msg_len + 1;
+         lines++;
+      }
+      else
+      {
+         unsigned msg_len = strlen(msg);
+         gl_raster_font_render_line(font, msg, msg_len, scale, color, pos_x, pos_y - (float)lines*line_height, text_align);
+         break;
+      }
+   }
 }
 
 static void gl_raster_font_setup_viewport(gl_raster_t *font, bool full_screen)

--- a/libretro-common/file/config_file.c
+++ b/libretro-common/file/config_file.c
@@ -32,6 +32,7 @@
 #include <file/file_path.h>
 #include <retro_miscellaneous.h>
 #include <string/string_list.h>
+#include <rhash.h>
 
 #if !defined(_WIN32) && !defined(__CELLOS_LV2__) && !defined(_XBOX)
 #include <sys/param.h> /* PATH_MAX */
@@ -327,6 +328,7 @@ static bool parse_line(config_file_t *conf,
    }
    key[idx] = '\0';
    list->key = key;
+   list->key_hash = djb2_calculate(key);
 
    list->value = extract_value(line, true);
    if (!list->value)
@@ -526,12 +528,13 @@ void config_file_free(config_file_t *conf)
 
 static const struct config_entry_list *config_get_entry_for_read(config_file_t *conf, const char *key)
 {
-   struct config_entry_list *list;
+   struct config_entry_list *entry;
+   uint32_t hash = djb2_calculate(key);
 
-   for (list = conf->entries; list; list = list->next)
+   for (entry = conf->entries; entry; entry = entry->next)
    {
-      if (strcmp(key, list->key) == 0)
-         return list;
+      if (hash == entry->key_hash && strcmp(key, entry->key) == 0)
+         return entry;
    }
 
    return NULL;

--- a/libretro-common/file/config_file.c
+++ b/libretro-common/file/config_file.c
@@ -526,23 +526,34 @@ void config_file_free(config_file_t *conf)
    free(conf);
 }
 
-static const struct config_entry_list *config_get_entry_for_read(config_file_t *conf, const char *key)
+static struct config_entry_list *config_get_entry(const config_file_t *conf,
+      const char *key, struct config_entry_list **prev)
 {
    struct config_entry_list *entry;
+   struct config_entry_lsit *previous;
+
    uint32_t hash = djb2_calculate(key);
+
+   if (prev)
+      previous = *prev;
 
    for (entry = conf->entries; entry; entry = entry->next)
    {
       if (hash == entry->key_hash && strcmp(key, entry->key) == 0)
          return entry;
+
+      previous = entry;
    }
+
+   if (*prev)
+      *prev = previous;
 
    return NULL;
 }
 
 bool config_get_double(config_file_t *conf, const char *key, double *in)
 {
-   const struct config_entry_list *entry = config_get_entry_for_read(conf, key);
+   const struct config_entry_list *entry = config_get_entry(conf, key, NULL);
 
    if (entry)
       *in = strtod(entry->value, NULL);
@@ -552,7 +563,7 @@ bool config_get_double(config_file_t *conf, const char *key, double *in)
 
 bool config_get_float(config_file_t *conf, const char *key, float *in)
 {
-   const struct config_entry_list *entry = config_get_entry_for_read(conf, key);
+   const struct config_entry_list *entry = config_get_entry(conf, key, NULL);
 
    if (entry)
    {
@@ -565,7 +576,7 @@ bool config_get_float(config_file_t *conf, const char *key, float *in)
 
 bool config_get_int(config_file_t *conf, const char *key, int *in)
 {
-   const struct config_entry_list *entry = config_get_entry_for_read(conf, key);
+   const struct config_entry_list *entry = config_get_entry(conf, key, NULL);
    errno = 0;
 
    if (entry)
@@ -581,7 +592,7 @@ bool config_get_int(config_file_t *conf, const char *key, int *in)
 
 bool config_get_uint64(config_file_t *conf, const char *key, uint64_t *in)
 {
-   const struct config_entry_list *entry = config_get_entry_for_read(conf, key);
+   const struct config_entry_list *entry = config_get_entry(conf, key, NULL);
    errno = 0;
 
    if (entry)
@@ -597,7 +608,7 @@ bool config_get_uint64(config_file_t *conf, const char *key, uint64_t *in)
 
 bool config_get_uint(config_file_t *conf, const char *key, unsigned *in)
 {
-   const struct config_entry_list *entry = config_get_entry_for_read(conf, key);
+   const struct config_entry_list *entry = config_get_entry(conf, key, NULL);
    errno = 0;
 
    if (entry)
@@ -613,7 +624,7 @@ bool config_get_uint(config_file_t *conf, const char *key, unsigned *in)
 
 bool config_get_hex(config_file_t *conf, const char *key, unsigned *in)
 {
-   const struct config_entry_list *entry = config_get_entry_for_read(conf, key);
+   const struct config_entry_list *entry = config_get_entry(conf, key, NULL);
    errno = 0;
 
    if (entry)
@@ -629,7 +640,7 @@ bool config_get_hex(config_file_t *conf, const char *key, unsigned *in)
 
 bool config_get_char(config_file_t *conf, const char *key, char *in)
 {
-   const struct config_entry_list *entry = config_get_entry_for_read(conf, key);
+   const struct config_entry_list *entry = config_get_entry(conf, key, NULL);
 
    if (entry)
    {
@@ -644,7 +655,7 @@ bool config_get_char(config_file_t *conf, const char *key, char *in)
 
 bool config_get_string(config_file_t *conf, const char *key, char **str)
 {
-   const struct config_entry_list *entry = config_get_entry_for_read(conf, key);
+   const struct config_entry_list *entry = config_get_entry(conf, key, NULL);
 
    if (entry)
       *str = strdup(entry->value);
@@ -655,7 +666,7 @@ bool config_get_string(config_file_t *conf, const char *key, char **str)
 bool config_get_array(config_file_t *conf, const char *key,
       char *buf, size_t size)
 {
-   const struct config_entry_list *entry = config_get_entry_for_read(conf, key);
+   const struct config_entry_list *entry = config_get_entry(conf, key, NULL);
 
    if (entry)
       return strlcpy(buf, entry->value, size) < size;
@@ -669,7 +680,7 @@ bool config_get_path(config_file_t *conf, const char *key,
 #if defined(RARCH_CONSOLE)
    return config_get_array(conf, key, buf, size);
 #else
-   const struct config_entry_list *entry = config_get_entry_for_read(conf, key);
+   const struct config_entry_list *entry = config_get_entry(conf, key, NULL);
 
    if (entry)
       fill_pathname_expand_special(buf, entry->value, size);
@@ -680,7 +691,7 @@ bool config_get_path(config_file_t *conf, const char *key,
 
 bool config_get_bool(config_file_t *conf, const char *key, bool *in)
 {
-   const struct config_entry_list *entry = config_get_entry_for_read(conf, key);
+   const struct config_entry_list *entry = config_get_entry(conf, key, NULL);
 
    if (entry)
    {

--- a/libretro-common/include/file/config_file.h
+++ b/libretro-common/include/file/config_file.h
@@ -40,6 +40,8 @@ struct config_entry_list
    bool readonly;
    char *key;
    char *value;
+   uint32_t key_hash;
+
    struct config_entry_list *next;
 };
 

--- a/retroarch.c
+++ b/retroarch.c
@@ -477,7 +477,7 @@ static void parse_input(int argc, char *argv[])
       { "size",         1, &val, RA_OPT_SIZE },
       { "verbose",      0, NULL, 'v' },
       { "config",       1, NULL, 'c' },
-      { "appendconfig", 1, &val, 'C' },
+      { "appendconfig", 1, &val, RA_OPT_APPENDCONFIG },
       { "nodevice",     1, NULL, 'N' },
       { "dualanalog",   1, NULL, 'A' },
       { "device",       1, NULL, 'd' },

--- a/tools/retroarch-joyconfig-griffin.c
+++ b/tools/retroarch-joyconfig-griffin.c
@@ -49,6 +49,7 @@
 #include "../libretro-common/queues/fifo_buffer.c"
 #include "../libretro-common/file/config_file.c"
 #include "../libretro-common/file/file_path.c"
+#include "../libretro-common/hash/rhash.c"
 #include "../file_path_special.c"
 #include "../libretro-common/string/string_list.c"
 #include "../libretro-common/compat/compat.c"


### PR DESCRIPTION
This speeds up in-memory config I/O and avoid calls to `gl_raster_font_render_line()` when the message is empty.