### PR TITLE
GCC 4.7 does not have __builtin_bswap16 on all platforms

### DIFF
--- a/libretro-common/include/retro_endianness.h
+++ b/libretro-common/include/retro_endianness.h
@@ -27,7 +27,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#if defined(__llvm__) || (defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__) >= 403)
+#if defined(__llvm__) || (defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__) >= 408)
 #define SWAP16 __builtin_bswap16
 #define SWAP32 __builtin_bswap32
 #elif defined(_MSC_VER)


### PR DESCRIPTION
GCC 4.7 does not have __builtin_bswap16 on all platforms so don't try to use it unless we are on gcc 4.8 or greater

#1793