### PR TITLE
(Makefile) Fix non desktop GL builds

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -469,9 +469,23 @@ ifeq ($(HAVE_PARPORT), 1)
 endif
 
 # Video
-#
-ifeq ($(HAVE_OPENGL), 1)
+ifeq ($(HAVE_GL_CONTEXT),)
+   HAVE_GL_CONTEXT=0
 
+   ifeq ($(HAVE_OPENGL), 1)
+      HAVE_GL_CONTEXT=1
+   endif
+
+   ifeq ($(HAVE_GLES), 1)
+      HAVE_GL_CONTEXT=1
+   endif
+
+   ifeq ($(HAVE_GLES3), 1)
+      HAVE_GL_CONTEXT=1
+   endif
+endif
+
+ifeq ($(HAVE_GL_CONTEXT), 1)
    DEFINES += -DHAVE_OPENGL -DHAVE_GLSL
    OBJ += gfx/drivers/gl.o \
 			gfx/video_context_driver.o \
@@ -563,7 +577,7 @@ ifeq ($(HAVE_SDL), 1)
 			 input/drivers_joypad/sdl_joypad.o \
 			 audio/drivers/sdl_audio.o
 
-   ifeq ($(HAVE_OPENGL), 1)
+   ifeq ($(HAVE_GL_CONTEXT), 1)
      OBJ += gfx/drivers_context/sdl_gl_ctx.o
    endif
 
@@ -578,7 +592,7 @@ ifeq ($(HAVE_SDL2), 1)
 			 input/drivers_joypad/sdl_joypad.o \
 			 audio/drivers/sdl_audio.o
 
-   ifeq ($(HAVE_OPENGL), 1)
+   ifeq ($(HAVE_GL_CONTEXT), 1)
      OBJ += gfx/drivers_context/sdl_gl_ctx.o
    endif
 


### PR DESCRIPTION
This fixes undefined references to video context functions when using `./configure --enable-gles`