### PR TITLE
fix compilation with --disable-threads

### DIFF
--- a/tasks/task_overlay.c
+++ b/tasks/task_overlay.c
@@ -89,7 +89,7 @@ void rarch_main_data_overlay_iterate(bool is_thread, void *data)
          break;
    }
 
-end:
+end: ;
 #ifdef HAVE_THREADS
    if (is_thread)
       slock_unlock(runloop->overlay_lock);


### PR DESCRIPTION
fixes this error

tasks/task_overlay.c: In function ‘rarch_main_data_overlay_iterate’:
tasks/task_overlay.c:92:1: error: label at end of compound statement

there might be a cleaner/different way of solving this.