### PR TITLE
(gl_raster_font) Fixed the alignment support for line by line drawing

### DIFF
--- a/gfx/drivers_font/gl_raster_font.c
+++ b/gfx/drivers_font/gl_raster_font.c
@@ -128,14 +128,13 @@ static void gl_raster_font_free_font(void *data)
    free(font);
 }
 
-static int gl_get_message_width(void *data, const char *msg, float scale)
+static int gl_get_message_width(void *data, const char *msg, unsigned msg_len_full, float scale)
 {
    gl_raster_t *font = (gl_raster_t*)data;
    if (!font)
       return 0;
       
    unsigned i;
-   unsigned msg_len_full   = strlen(msg);
    unsigned msg_len        = min(msg_len_full, MAX_MSG_LEN_CHUNK);
    int      delta_x        = 0;
 
@@ -200,10 +199,10 @@ static void gl_raster_font_render_line(
    switch (text_align)
    {
       case TEXT_ALIGN_RIGHT:
-         x -= gl_get_message_width(font, msg, scale);
+         x -= gl_get_message_width(font, msg, msg_len_full, scale);
          break;
       case TEXT_ALIGN_CENTER:
-         x -= gl_get_message_width(font, msg, scale) / 2.0;
+         x -= gl_get_message_width(font, msg, msg_len_full, scale) / 2.0;
          break;
    }
 

--- a/gfx/font_renderer_driver.c
+++ b/gfx/font_renderer_driver.c
@@ -40,7 +40,7 @@ int font_renderer_get_message_width(const char *msg, float scale)
     if (!font_driver || !font_driver->get_message_width)
        return 0;
        
-    return font_driver->get_message_width(driver->font_osd_data, msg, scale);
+    return font_driver->get_message_width(driver->font_osd_data, msg, strlen(msg), scale);
 }
 
 bool font_renderer_create_default(

--- a/gfx/font_renderer_driver.h
+++ b/gfx/font_renderer_driver.h
@@ -71,7 +71,7 @@ typedef struct font_renderer
    void (*bind_block)(void *data, void *block);
    void (*flush)(void *data);
    
-   int (*get_message_width)(void *data, const char *msg, float scale);
+   int (*get_message_width)(void *data, const char *msg, unsigned msg_len_full, float scale);
 } font_renderer_t;
 
 extern font_renderer_t gl_raster_font;


### PR DESCRIPTION
Each line was drawn using the full message's length so the alignment was broken. I fixed it by adding the message length to `get_message_width` so every line has its own length for `get_message_width`. Finally, we can now have the width of one single line by using `strlen` and `strchr`. 