### PR TITLE
XMB/Animation optimizations

### DIFF
--- a/gfx/drivers_font/gl_raster_font.c
+++ b/gfx/drivers_font/gl_raster_font.c
@@ -346,7 +346,7 @@ static void gl_raster_font_render_msg(void *data, const char *msg,
    settings_t *settings = config_get_ptr();
    const struct font_params *params = (const struct font_params*)userdata;
 
-   if (!font)
+   if (!font || !msg || !*msg)
       return;
 
    gl = font->gl;

--- a/menu/drivers/glui.c
+++ b/menu/drivers/glui.c
@@ -681,7 +681,7 @@ static void glui_navigation_set(bool scroll)
    }
 
    menu_animation_push(disp->animation, 10, scroll_pos,
-         &menu->scroll_y, EASING_IN_OUT_QUAD, NULL);
+         &menu->scroll_y, EASING_IN_OUT_QUAD, -1, NULL);
 }
 
 static void glui_navigation_clear(bool pending_push)

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -583,7 +583,7 @@ static void xmb_update_boxart(xmb_handle_t *xmb, unsigned i)
 
 static void xmb_selection_pointer_changed(void)
 {
-   unsigned i, current, end;
+   unsigned i, current, end, tag;
    xmb_handle_t    *xmb   = NULL;
    menu_handle_t    *menu = menu_driver_get_ptr();
    menu_display_t   *disp = menu_display_get_ptr();
@@ -602,6 +602,10 @@ static void xmb_selection_pointer_changed(void)
    current = nav->selection_ptr;
    end     = menu_entries_get_end();
 
+   tag = (uintptr_t)menu_list;
+
+   menu_animation_kill_by_tag(disp->animation, tag);
+
    for (i = 0; i < end; i++)
    {
       float iy;
@@ -613,7 +617,7 @@ static void xmb_selection_pointer_changed(void)
       if (!node)
          continue;
 
-      iy = xmb_item_y(xmb, i, current);
+      iy  = xmb_item_y(xmb, i, current);
 
       if (i == current)
       {
@@ -625,13 +629,13 @@ static void xmb_selection_pointer_changed(void)
       }
 
       menu_animation_push(disp->animation,
-            XMB_DELAY, ia, &node->alpha, EASING_IN_OUT_QUAD, NULL);
+            XMB_DELAY, ia, &node->alpha, EASING_IN_OUT_QUAD, tag, NULL);
       menu_animation_push(disp->animation,
-            XMB_DELAY, ia, &node->label_alpha, EASING_IN_OUT_QUAD, NULL);
+            XMB_DELAY, ia, &node->label_alpha, EASING_IN_OUT_QUAD, tag, NULL);
       menu_animation_push(disp->animation,
-            XMB_DELAY, iz, &node->zoom,  EASING_IN_OUT_QUAD, NULL);
+            XMB_DELAY, iz, &node->zoom,  EASING_IN_OUT_QUAD, tag, NULL);
       menu_animation_push(disp->animation,
-            XMB_DELAY, iy, &node->y,     EASING_IN_OUT_QUAD, NULL);
+            XMB_DELAY, iy, &node->y,     EASING_IN_OUT_QUAD, tag, NULL);
    }
 }
 
@@ -661,12 +665,12 @@ static void xmb_list_open_old(xmb_handle_t *xmb,
          ia = 0;
 
       menu_animation_push(disp->animation,
-            XMB_DELAY, ia, &node->alpha, EASING_IN_OUT_QUAD, NULL);
+            XMB_DELAY, ia, &node->alpha, EASING_IN_OUT_QUAD, -1, NULL);
       menu_animation_push(disp->animation,
-            XMB_DELAY, 0, &node->label_alpha, EASING_IN_OUT_QUAD, NULL);
+            XMB_DELAY, 0, &node->label_alpha, EASING_IN_OUT_QUAD, -1, NULL);
       menu_animation_push(disp->animation,
             XMB_DELAY, xmb->icon.size * dir * -2, &node->x,
-            EASING_IN_OUT_QUAD, NULL);
+            EASING_IN_OUT_QUAD, -1, NULL);
    }
 }
 
@@ -704,11 +708,11 @@ static void xmb_list_open_new(xmb_handle_t *xmb,
          ia = xmb->item.active.alpha;
 
       menu_animation_push(disp->animation,
-            XMB_DELAY, ia, &node->alpha,  EASING_IN_OUT_QUAD, NULL);
+            XMB_DELAY, ia, &node->alpha,  EASING_IN_OUT_QUAD, -1, NULL);
       menu_animation_push(disp->animation,
-            XMB_DELAY, ia, &node->label_alpha,  EASING_IN_OUT_QUAD, NULL);
+            XMB_DELAY, ia, &node->label_alpha,  EASING_IN_OUT_QUAD, -1, NULL);
       menu_animation_push(disp->animation,
-            XMB_DELAY, 0, &node->x, EASING_IN_OUT_QUAD, NULL);
+            XMB_DELAY, 0, &node->x, EASING_IN_OUT_QUAD, -1, NULL);
    }
 
    xmb->old_depth = xmb->depth;
@@ -752,11 +756,11 @@ static void xmb_push_animations(xmb_node_t *node, float ia, float ix)
       return;
 
    menu_animation_push(disp->animation,
-         XMB_DELAY, ia, &node->alpha,  EASING_IN_OUT_QUAD, NULL);
+         XMB_DELAY, ia, &node->alpha,  EASING_IN_OUT_QUAD, -1, NULL);
    menu_animation_push(disp->animation,
-         XMB_DELAY, ia, &node->label_alpha,  EASING_IN_OUT_QUAD, NULL);
+         XMB_DELAY, ia, &node->label_alpha,  EASING_IN_OUT_QUAD, -1, NULL);
    menu_animation_push(disp->animation,
-         XMB_DELAY, ix, &node->x, EASING_IN_OUT_QUAD, NULL);
+         XMB_DELAY, ix, &node->x, EASING_IN_OUT_QUAD, -1, NULL);
 }
 
 static void xmb_list_switch_old(xmb_handle_t *xmb,
@@ -869,9 +873,9 @@ static void xmb_list_switch_horizontal_list(xmb_handle_t *xmb, menu_handle_t *me
       }
 
       menu_animation_push(menu->display.animation,
-            XMB_DELAY, ia, &node->alpha, EASING_IN_OUT_QUAD, NULL);
+            XMB_DELAY, ia, &node->alpha, EASING_IN_OUT_QUAD, -1, NULL);
       menu_animation_push(menu->display.animation,
-            XMB_DELAY, iz, &node->zoom, EASING_IN_OUT_QUAD, NULL);
+            XMB_DELAY, iz, &node->zoom, EASING_IN_OUT_QUAD, -1, NULL);
    }
 }
 
@@ -896,7 +900,7 @@ static void xmb_list_switch(xmb_handle_t *xmb)
 
    menu_animation_push(disp->animation, XMB_DELAY,
          xmb->icon.spacing.horizontal * -(float)xmb->categories.selection_ptr,
-         &xmb->categories.x_pos, EASING_IN_OUT_QUAD, NULL);
+         &xmb->categories.x_pos, EASING_IN_OUT_QUAD, -1, NULL);
 
    dir = -1;
    if (xmb->categories.selection_ptr > xmb->categories.selection_ptr_old)
@@ -934,7 +938,7 @@ static void xmb_list_open_horizontal_list(xmb_handle_t *xmb, menu_handle_t *menu
          ia = xmb->categories.passive.alpha;
 
       menu_animation_push(menu->display.animation, XMB_DELAY, ia,
-            &node->alpha, EASING_IN_OUT_QUAD, NULL);
+            &node->alpha, EASING_IN_OUT_QUAD, -1, NULL);
    }
 }
 
@@ -968,18 +972,18 @@ static void xmb_list_open(xmb_handle_t *xmb)
       case 1:
          menu_animation_push(disp->animation,
                XMB_DELAY, xmb->icon.size * -(xmb->depth*2-2),
-               &xmb->x, EASING_IN_OUT_QUAD, NULL);
+               &xmb->x, EASING_IN_OUT_QUAD, -1, NULL);
          menu_animation_push(disp->animation,
                XMB_DELAY, 0, &xmb->textures.arrow.alpha,
-               EASING_IN_OUT_QUAD, NULL);
+               EASING_IN_OUT_QUAD, -1, NULL);
          break;
       case 2:
          menu_animation_push(disp->animation,
                XMB_DELAY, xmb->icon.size * -(xmb->depth*2-2),
-               &xmb->x, EASING_IN_OUT_QUAD, NULL);
+               &xmb->x, EASING_IN_OUT_QUAD, -1, NULL);
          menu_animation_push(disp->animation,
                XMB_DELAY, 1, &xmb->textures.arrow.alpha,
-               EASING_IN_OUT_QUAD, NULL);
+               EASING_IN_OUT_QUAD, -1, NULL);
          break;
    }
 
@@ -2334,7 +2338,7 @@ static void xmb_toggle(bool menu_on)
    }
 
    menu_animation_push(disp->animation, XMB_DELAY, 1.0f,
-         &xmb->alpha, EASING_IN_OUT_QUAD, NULL);
+         &xmb->alpha, EASING_IN_OUT_QUAD, -1, NULL);
 
    xmb->prevent_populate = !menu_entries_needs_refresh();
 

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -690,13 +690,17 @@ static void xmb_list_open_old(xmb_handle_t *xmb,
 static void xmb_list_open_new(xmb_handle_t *xmb,
       file_list_t *list, int dir, size_t current)
 {
-   unsigned i;
+   unsigned i, height;
+   int threshold = xmb->icon.size * 10;
    menu_display_t *disp = menu_display_get_ptr();
    size_t           end = file_list_get_size(list);
+
+   video_driver_get_size(NULL, &height);
 
    for (i = 0; i < end; i++)
    {
       float ia;
+      float real_y;
       xmb_node_t *node = (xmb_node_t*)
          menu_list_get_userdata_at_offset(list, i);
 
@@ -713,6 +717,8 @@ static void xmb_list_open_new(xmb_handle_t *xmb,
       node->y = xmb_item_y(xmb, i, current);
       node->zoom = xmb->categories.passive.zoom;
 
+      real_y = node->y + + xmb->margins.screen.top;
+
       if (i == current)
          node->zoom = xmb->categories.active.zoom;
 
@@ -720,12 +726,20 @@ static void xmb_list_open_new(xmb_handle_t *xmb,
       if (i == current)
          ia = xmb->item.active.alpha;
 
-      menu_animation_push(disp->animation,
-            XMB_DELAY, ia, &node->alpha,  EASING_IN_OUT_QUAD, -1, NULL);
-      menu_animation_push(disp->animation,
-            XMB_DELAY, ia, &node->label_alpha,  EASING_IN_OUT_QUAD, -1, NULL);
-      menu_animation_push(disp->animation,
-            XMB_DELAY, 0, &node->x, EASING_IN_OUT_QUAD, -1, NULL);
+      if (real_y < -threshold || real_y > height+threshold)
+      {
+         node->alpha = node->label_alpha = ia;
+         node->x = 0;
+      }
+      else
+      {
+         menu_animation_push(disp->animation,
+               XMB_DELAY, ia, &node->alpha,  EASING_IN_OUT_QUAD, -1, NULL);
+         menu_animation_push(disp->animation,
+               XMB_DELAY, ia, &node->label_alpha,  EASING_IN_OUT_QUAD, -1, NULL);
+         menu_animation_push(disp->animation,
+               XMB_DELAY, 0, &node->x, EASING_IN_OUT_QUAD, -1, NULL);
+      }
    }
 
    xmb->old_depth = xmb->depth;

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -655,7 +655,8 @@ static void xmb_selection_pointer_changed(void)
 static void xmb_list_open_old(xmb_handle_t *xmb,
       file_list_t *list, int dir, size_t current)
 {
-   unsigned i;
+   unsigned i, height = 0;
+   int threshold = xmb->icon.size * 10;
    size_t           end = 0;
    menu_display_t *disp = menu_display_get_ptr();
 
@@ -664,9 +665,12 @@ static void xmb_list_open_old(xmb_handle_t *xmb,
 
    end = file_list_get_size(list);
 
+   video_driver_get_size(NULL, &height);
+
    for (i = 0; i < end; i++)
    {
       float ia = 0;
+      float real_y;
       xmb_node_t *node = (xmb_node_t*)menu_list_get_userdata_at_offset(list, i);
 
       if (!node)
@@ -677,13 +681,24 @@ static void xmb_list_open_old(xmb_handle_t *xmb,
       if (dir == -1)
          ia = 0;
 
-      menu_animation_push(disp->animation,
-            XMB_DELAY, ia, &node->alpha, EASING_IN_OUT_QUAD, -1, NULL);
-      menu_animation_push(disp->animation,
-            XMB_DELAY, 0, &node->label_alpha, EASING_IN_OUT_QUAD, -1, NULL);
-      menu_animation_push(disp->animation,
-            XMB_DELAY, xmb->icon.size * dir * -2, &node->x,
-            EASING_IN_OUT_QUAD, -1, NULL);
+      real_y = node->y + + xmb->margins.screen.top;
+
+      if (real_y < -threshold || real_y > height+threshold)
+      {
+         node->alpha = ia;
+         node->label_alpha = 0;
+         node->x = xmb->icon.size * dir * -2;
+      }
+      else
+      {
+         menu_animation_push(disp->animation,
+               XMB_DELAY, ia, &node->alpha, EASING_IN_OUT_QUAD, -1, NULL);
+         menu_animation_push(disp->animation,
+               XMB_DELAY, 0, &node->label_alpha, EASING_IN_OUT_QUAD, -1, NULL);
+         menu_animation_push(disp->animation,
+               XMB_DELAY, xmb->icon.size * dir * -2, &node->x,
+               EASING_IN_OUT_QUAD, -1, NULL);
+      }
    }
 }
 

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -688,7 +688,7 @@ static void xmb_list_open_old(xmb_handle_t *xmb,
       if (dir == -1)
          ia = 0;
 
-      real_y = node->y + + xmb->margins.screen.top;
+      real_y = node->y + xmb->margins.screen.top;
 
       if (real_y < -threshold || real_y > height+threshold)
       {
@@ -739,7 +739,7 @@ static void xmb_list_open_new(xmb_handle_t *xmb,
       node->y = xmb_item_y(xmb, i, current);
       node->zoom = xmb->categories.passive.zoom;
 
-      real_y = node->y + + xmb->margins.screen.top;
+      real_y = node->y + xmb->margins.screen.top;
 
       if (i == current)
          node->zoom = xmb->categories.active.zoom;

--- a/menu/menu_animation.c
+++ b/menu/menu_animation.c
@@ -293,7 +293,7 @@ void menu_animation_kill_by_subject(menu_animation_t *animation,
       {
          if (animation->list[i].subject == sub[j])
          {
-            animation->list[i].alive   = 0;
+            animation->list[i].alive   = false;
             animation->list[i].subject = NULL;
 
             if (i < animation->first_dead)
@@ -302,6 +302,26 @@ void menu_animation_kill_by_subject(menu_animation_t *animation,
             killed++;
             break;
          }
+      }
+   }
+}
+
+void menu_animation_kill_by_tag(menu_animation_t *anim, unsigned tag)
+{
+   unsigned i;
+
+   if (tag == -1)
+      return;
+
+   for (i = 0; i < anim->size; ++i)
+   {
+      if (anim->list[i].tag == tag)
+      {
+         anim->list[i].alive   = false;
+         anim->list[i].subject = NULL;
+
+         if (i < anim->first_dead)
+            anim->first_dead = i;
       }
    }
 }
@@ -327,25 +347,24 @@ static void menu_animation_push_internal(menu_animation_t *anim, const struct tw
    *target = *t;
 }
 
-bool menu_animation_push(
-      menu_animation_t *anim,
+bool menu_animation_push(menu_animation_t *anim,
       float duration,
-      float target_value,
-      float* subject,
+      float target_value, float* subject,
       enum menu_animation_easing_type easing_enum,
-      tween_cb cb)
+      unsigned tag, tween_cb cb)
 {
    struct tween t;
 
    if (!subject)
       return false;
 
-   t.alive         = 1;
+   t.alive         = true;
    t.duration      = duration;
    t.running_since = 0;
    t.initial_value = *subject;
    t.target_value  = target_value;
    t.subject       = subject;
+   t.tag           = tag;
    t.cb            = cb;
 
    switch (easing_enum)
@@ -491,7 +510,7 @@ static int menu_animation_iterate(
    if (tween->running_since >= tween->duration)
    {
       *tween->subject = tween->target_value;
-      tween->alive    = 0;
+      tween->alive    = false;
 
       if (idx < anim->first_dead)
          anim->first_dead = idx;

--- a/menu/menu_animation.h
+++ b/menu/menu_animation.h
@@ -51,6 +51,7 @@ typedef struct menu_animation
 
    size_t capacity;
    size_t size;
+   size_t first_dead;
    bool is_active;
 
    /* Delta timing */

--- a/menu/menu_animation.h
+++ b/menu/menu_animation.h
@@ -35,12 +35,13 @@ typedef void  (*tween_cb) (void);
 
 struct tween
 {
-   int    alive;
+   bool   alive;
    float  duration;
    float  running_since;
    float  initial_value;
    float  target_value;
    float* subject;
+   unsigned tag;
    easingFunc easing;
    tween_cb cb;
 };
@@ -119,11 +120,15 @@ void menu_animation_kill_by_subject(
       size_t count,
       const void *subjects);
 
+void menu_animation_kill_by_tag(menu_animation_t *anim, unsigned tag);
+
+/* Use -1 for untagged */
 bool menu_animation_push(
       menu_animation_t *animation,
       float duration,
       float target_value, float* subject,
-      enum menu_animation_easing_type easing_enum, tween_cb cb);
+      enum menu_animation_easing_type easing_enum,
+      unsigned tag, tween_cb cb);
 
 bool menu_animation_update(
       menu_animation_t *animation,

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -1935,6 +1935,7 @@ int menu_displaylist_push_list(menu_displaylist_info_t *info, unsigned type)
          ret = menu_displaylist_parse_load_core_list(info);
 
          need_push    = true;
+         need_refresh = true;
          break;
       case DISPLAYLIST_OPTIONS:
          menu_list_clear(info->list);
@@ -2179,6 +2180,7 @@ int menu_displaylist_push_list(menu_displaylist_info_t *info, unsigned type)
          menu_list_clear(info->list);
          menu_displaylist_parse_system_info(info);
          need_push    = true;
+         need_refresh = true;
          break;
       case DISPLAYLIST_CORES_SUPPORTED:
       case DISPLAYLIST_CORES_COLLECTION_SUPPORTED:


### PR DESCRIPTION
- Reduces the number of reallocations in menu_animation.c by reusing dead slots when possible
- Reduces the number of active animations while navigating lists with ↓ and ↑.
- Reduces the number of active animations when opening lists (up to 250x less at 2x window scale when opening mame's database).
- Reduces xmb_render() overhead.
- Prevents viewport/pipeline changes when attempting to render an empty/null message
- Fixes R/L scrolling in System Information and Load Content