### PR TITLE
(cores/dynamic_dummy) Do not hardcode "No Core"

### DIFF
--- a/cores/dynamic_dummy.c
+++ b/cores/dynamic_dummy.c
@@ -50,7 +50,7 @@ void libretro_dummy_retro_get_system_info(
       struct retro_system_info *info)
 {
    memset(info, 0, sizeof(*info));
-   info->library_name     = "No Core";
+   info->library_name     = "";
    info->library_version  = "";
    info->need_fullpath    = false;
    info->valid_extensions = ""; /* Nothing. */

--- a/menu/menu_entries.c
+++ b/menu/menu_entries.c
@@ -105,9 +105,9 @@ void menu_entries_get_core_title(char *s, size_t len)
    const char *core_name     = global ? global->menu.info.library_name    : NULL;
    const char *core_version  = global ? global->menu.info.library_version : NULL;
 
-   if (!core_name)
+   if (!core_name || core_name[0] == '\0')
       core_name = global->system.info.library_name;
-   if (!core_name)
+   if (!core_name || core_name[0] == '\0')
       core_name = menu_hash_to_str(MENU_VALUE_NO_CORE);
 
    if (!core_version)


### PR DESCRIPTION
Use an empty string as `library_name` for dynamic dummy.

If the string is empty, display `MENU_VALUE_NO_CORE`.