### PR TITLE
Two Android Fixes

### DIFF
--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -278,11 +278,7 @@ static bool android_input_lookup_name(char *buf,
       goto error;
 
    CALL_INT_METHOD(env, *vendorId, device, getVendorId);
-   if (!*vendorId)
-   {
-      RARCH_ERR("Failed to find vendor id for device ID: %d\n", id);
-      goto error;
-   }
+
    RARCH_LOG("device vendor id: %d\n", *vendorId);
 
    getProductId = NULL;
@@ -292,11 +288,7 @@ static bool android_input_lookup_name(char *buf,
 
    *productId = 0;
    CALL_INT_METHOD(env, *productId, device, getProductId);
-   if (!*productId)
-   {
-      RARCH_ERR("Failed to find product id for device ID: %d\n", id);
-      goto error;
-   }
+
    RARCH_LOG("device product id: %d\n", *productId);
 
    return true;

--- a/libretro-common/include/retro_log.h
+++ b/libretro-common/include/retro_log.h
@@ -65,7 +65,7 @@ FILE *rarch_main_log_file(void);
 #define PROGRAM_NAME "N/A"
 #endif
 
-#if defined(RARCH_INTERNAL)
+#if defined(RARCH_INTERNAL) && !defined(ANDROID)
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Fixed linker error due to undefined reference to rarch_main_verbosity, and allow a VID/PID of 0 (which is the case for the built-in buttons when using KitKat on a JXD S7800B and possibly other non-USB input devices).