### PR TITLE
(string_list.c) Initialize data after realloc()ing the list

### DIFF
--- a/libretro-common/string/string_list.c
+++ b/libretro-common/string/string_list.c
@@ -66,6 +66,9 @@ static bool string_list_capacity(struct string_list *list, size_t cap)
    if (!new_data)
       return false;
 
+   if (cap > list->cap)
+      memset(&new_data[list->cap], 0, sizeof(*new_data) * (cap - list->cap));
+
    list->elems = new_data;
    list->cap   = cap;
    return true;


### PR DESCRIPTION
Fixes directory scan crash reported by Earnestly: http://ix.io/juK