### PR TITLE
(GLUI) Remove early return in glui_frame()

### DIFF
--- a/menu/drivers/glui.c
+++ b/menu/drivers/glui.c
@@ -396,14 +396,6 @@ static void glui_frame(void)
 
    glui = (glui_handle_t*)menu->userdata;
 
-   if (
-         menu_entries_needs_refresh()
-         && menu_driver_alive() 
-         && !disp->msg_force
-         && !glui->box_message[0]
-      )
-      return;
-
    title[0]     = '\0';
    title_buf[0] = '\0';
    title_msg[0] = '\0';


### PR DESCRIPTION
This is not needed anymore as CPU usage has been greatly reduced by
changes introduced in the last 4-6 weeks.

Fixes #1914 