### PR TITLE
Refactor autoconfig

### DIFF
--- a/input/drivers_joypad/dinput_joypad.c
+++ b/input/drivers_joypad/dinput_joypad.c
@@ -177,6 +177,16 @@ static const char *dinput_joypad_name(unsigned pad)
    return NULL;
 }
 
+static int32_t dinput_joypad_vid(unsigned pad)
+{
+    return g_pads[pad].vid;
+}
+
+static int32_t dinput_joypad_pid(unsigned pad)
+{
+    return g_pads[pad].pid;
+}
+
 static const char *dinput_joypad_friendly_name(unsigned pad)
 {
    if (pad < MAX_USERS)
@@ -263,6 +273,8 @@ static BOOL CALLBACK enum_joypad_cb(const DIDEVICEINSTANCE *inst, void *p)
       strlcpy(params.name, dinput_joypad_name(g_joypad_cnt), sizeof(params.name));
       strlcpy(params.display_name, dinput_joypad_friendly_name(g_joypad_cnt), sizeof(params.driver));
       strlcpy(params.driver, dinput_joypad.ident, sizeof(params.driver));
+      params.vid = dinput_joypad_vid(g_joypad_cnt);
+      params.pid = dinput_joypad_pid(g_joypad_cnt);
       input_config_autoconfigure_joypad(&params);
       RARCH_LOG("DINPUT %s %s %s\n",params.name, params.driver, params.display_name);
    }

--- a/input/drivers_joypad/dinput_joypad.c
+++ b/input/drivers_joypad/dinput_joypad.c
@@ -230,10 +230,10 @@ static BOOL CALLBACK enum_joypad_cb(const DIDEVICEINSTANCE *inst, void *p)
 #endif
 
 
-   g_pads[g_joypad_cnt].vid = inst->guidProduct.Data1 / 0x10000;
-   g_pads[g_joypad_cnt].pid = inst->guidProduct.Data1 % 0x10000;
+   g_pads[g_joypad_cnt].vid = inst->guidProduct.Data1 % 0x10000;
+   g_pads[g_joypad_cnt].pid = inst->guidProduct.Data1 / 0x10000;
 
-   RARCH_LOG("PID: {%04lX} VID:{%04lX}\n", g_pads[g_joypad_cnt].pid, g_pads[g_joypad_cnt].vid);
+   RARCH_LOG("Device #%u PID: {%04lX} VID:{%04lX}\n", g_joypad_cnt, g_pads[g_joypad_cnt].pid, g_pads[g_joypad_cnt].vid);
 
 #ifdef HAVE_XINPUT
 #if 0
@@ -276,7 +276,6 @@ static BOOL CALLBACK enum_joypad_cb(const DIDEVICEINSTANCE *inst, void *p)
       params.vid = dinput_joypad_vid(g_joypad_cnt);
       params.pid = dinput_joypad_pid(g_joypad_cnt);
       input_config_autoconfigure_joypad(&params);
-      RARCH_LOG("DINPUT %s %s %s\n",params.name, params.driver, params.display_name);
    }
 
 enum_iteration_done:

--- a/input/input_autodetect.c
+++ b/input/input_autodetect.c
@@ -23,7 +23,7 @@
 
 #include "../general.h"
 
-enum
+/*enum
 {
    AUTODETECT_MATCH_NONE = 0,
    AUTODETECT_MATCH_VID,
@@ -31,7 +31,7 @@ enum
    AUTODETECT_MATCH_IDENT,
    AUTODETECT_MATCH_DRIVER,
    AUTODETECT_MATCH_NAME
-};
+};*/
 
 static void input_autoconfigure_joypad_conf(config_file_t *conf,
       struct retro_keybind *binds)
@@ -48,14 +48,14 @@ static void input_autoconfigure_joypad_conf(config_file_t *conf,
 }
 
 static int input_try_autoconfigure_joypad_from_conf(config_file_t *conf,
-      autoconfig_params_t *params, unsigned *match)
+      autoconfig_params_t *params)
 {
    char ident[PATH_MAX_LENGTH]        = {0};
-   char ident_idx[PATH_MAX_LENGTH]    = {0};
+   //char ident_idx[PATH_MAX_LENGTH]    = {0};
    char input_driver[PATH_MAX_LENGTH] = {0};
    int                      input_vid = 0;
    int                      input_pid = 0;
-   int                            ret = 0;
+   int                            score = 0;
 
    if (!conf)
       return false;
@@ -67,11 +67,7 @@ static int input_try_autoconfigure_joypad_from_conf(config_file_t *conf,
    config_get_int  (conf, "input_vendor_id", &input_vid);
    config_get_int  (conf, "input_product_id", &input_pid);
 
-   snprintf(ident_idx,
-         sizeof(ident_idx), "%s_p%u", ident, params->idx);
-
-   /* If Vendor ID and Product ID matches, we've found our
-    * entry. */
+   /* Check for VID/PID */
    if (     (params->vid == input_vid)
          && (params->pid == input_pid)
          && params->vid != 0
@@ -79,37 +75,26 @@ static int input_try_autoconfigure_joypad_from_conf(config_file_t *conf,
          && input_vid   != 0
          && input_pid   != 0)
    {
-      BIT32_SET(*match, AUTODETECT_MATCH_VID);
-      BIT32_SET(*match, AUTODETECT_MATCH_PID);
-      ret = 1;
-   }
-
-   /* Check for name match. */
-   if (!strcmp(ident_idx, params->name))
-   {
-      BIT32_SET(*match, AUTODETECT_MATCH_NAME);
-      ret = 1;
-   }
-
-   /* Check for name match - name starts with ident */
-   if (ident[0] != '\0' && !strncmp(params->name, ident, strlen(ident)))
-   {
-      BIT32_SET(*match, AUTODETECT_MATCH_IDENT);
-      ret = 2;
-      if (!strcmp(params->driver, input_driver))
-          BIT32_SET(*match, AUTODETECT_MATCH_DRIVER);
+      score += 3;
+      RARCH_LOG("Autoconf: VID/PID match score=%d\n", score);
    }
 
    /* Check for name match */
    if (!strcmp(ident, params->name))
    {
-      BIT32_SET(*match, AUTODETECT_MATCH_IDENT);
-      ret = 1;
-      if (!strcmp(params->driver, input_driver))
-          BIT32_SET(*match, AUTODETECT_MATCH_DRIVER);
+      score += 2;
+      RARCH_LOG("Autoconf: exact name match score=%d\n", score);
    }
-
-   return ret;
+   else
+   {
+      if (ident[0] != '\0' && !strncmp(params->name, ident, strlen(ident)))
+      {
+         score += 1;
+         RARCH_LOG("Autoconf: partial name match score=%d\n", score);
+      }
+   }
+   RARCH_LOG("Autoconf: configuration score=%d\n", score);
+   return score;
 }
 
 static void input_autoconfigure_joypad_add(
@@ -143,13 +128,12 @@ static int input_autoconfigure_joypad_from_conf(
       config_file_t *conf, autoconfig_params_t *params)
 {
    int ret = 0;
-   uint32_t match = 0;
 
    if (!conf)
       return false;
 
    ret = input_try_autoconfigure_joypad_from_conf(conf,
-         params, &match);
+         params);
 
    if (ret)
       input_autoconfigure_joypad_add(conf, params);
@@ -171,15 +155,26 @@ static bool input_autoconfigure_joypad_from_conf_dir(
    if (!list)
       return false;
 
+   int current_best = 0;
+   int index = 0;
+
+   config_file_t *conf;
+
    for (i = 0; i < list->size; i++)
    {
-      config_file_t *conf = config_file_new(list->elems[i].data);
-      ret = input_autoconfigure_joypad_from_conf(conf, params);
-
-	  if (ret == 1)
-		  break;
-
+      conf = config_file_new(list->elems[i].data);
+      ret = input_try_autoconfigure_joypad_from_conf(conf, params);
+      if(ret > current_best)
+      {
+          index = i;
+          current_best = ret;
+      }
+      config_file_free(conf);
    }
+
+   conf = config_file_new(list->elems[index].data);
+   input_autoconfigure_joypad_add(conf, params);
+   config_file_free(conf);
 
    string_list_free(list);
 

--- a/input/input_autodetect.c
+++ b/input/input_autodetect.c
@@ -148,15 +148,15 @@ static bool input_autoconfigure_joypad_from_conf_dir(
 {
    size_t i;
    int ret = 0;
+   int index = 0;
+   int current_best = 0;
+
    settings_t *settings = config_get_ptr();
    struct string_list *list = settings ? dir_list_new(
          settings->input.autoconfig_dir, "cfg", false) : NULL;
 
    if (!list)
       return false;
-
-   int current_best = 0;
-   int index = 0;
 
    config_file_t *conf;
 
@@ -172,9 +172,14 @@ static bool input_autoconfigure_joypad_from_conf_dir(
       config_file_free(conf);
    }
 
-   conf = config_file_new(list->elems[index].data);
-   input_autoconfigure_joypad_add(conf, params);
-   config_file_free(conf);
+   if(index)
+   {
+      conf = config_file_new(list->elems[index].data);
+      input_autoconfigure_joypad_add(conf, params);
+      config_file_free(conf);
+   }
+   else
+       ret = 0;
 
    string_list_free(list);
 

--- a/input/input_autodetect.c
+++ b/input/input_autodetect.c
@@ -158,11 +158,20 @@ static bool input_autoconfigure_joypad_from_conf_dir(
    fill_pathname_join(path,settings->input.autoconfig_dir,settings->input.driver,sizeof(path));
 
    struct string_list *list = settings ? dir_list_new(
-         path, "cfg", false) : NULL;
+         settings->input.autoconfig_dir, "cfg", false) : NULL;
 
-   if (!list)
+   if (!list || !list->size)
+   {
+      fill_pathname_join(path,settings->input.autoconfig_dir,settings->input.driver,sizeof(path));
+
+      list = settings ? dir_list_new(
+            path, "cfg", false) : NULL;
+   }
+
+   if(!list)
       return false;
 
+   RARCH_LOG("Autoconfig: %d profiles found\n", list->size);
    config_file_t *conf;
 
    for (i = 0; i < list->size; i++)

--- a/input/input_autodetect.c
+++ b/input/input_autodetect.c
@@ -76,21 +76,21 @@ static int input_try_autoconfigure_joypad_from_conf(config_file_t *conf,
          && input_pid   != 0)
    {
       score += 3;
-      RARCH_LOG("Autoconf: VID/PID match score=%d\n", score);
+      //RARCH_LOG("Autoconf: VID/PID match score=%d\n", score);
    }
 
    /* Check for name match */
    if (!strcmp(ident, params->name))
    {
       score += 2;
-      RARCH_LOG("Autoconf: exact name match score=%d\n", score);
+      //RARCH_LOG("Autoconf: exact name match score=%d\n", score);
    }
    else
    {
       if (ident[0] != '\0' && !strncmp(params->name, ident, strlen(ident)))
       {
          score += 1;
-         RARCH_LOG("Autoconf: partial name match score=%d\n", score);
+         //RARCH_LOG("Autoconf: partial name match score=%d\n", score);
       }
    }
    RARCH_LOG("Autoconf: configuration score=%d\n", score);
@@ -174,6 +174,7 @@ static bool input_autoconfigure_joypad_from_conf_dir(
 
    if(index)
    {
+      RARCH_LOG("Autoconf: best configuration score=%d\n", current_best);
       conf = config_file_new(list->elems[index].data);
       input_autoconfigure_joypad_add(conf, params);
       config_file_free(conf);

--- a/input/input_autodetect.c
+++ b/input/input_autodetect.c
@@ -20,6 +20,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <ctype.h>
+#include <file/file_path.h>
 
 #include "../general.h"
 
@@ -152,8 +153,12 @@ static bool input_autoconfigure_joypad_from_conf_dir(
    int current_best = 0;
 
    settings_t *settings = config_get_ptr();
+
+   char path[PATH_MAX_LENGTH] = {0};
+   fill_pathname_join(path,settings->input.autoconfig_dir,settings->input.driver,sizeof(path));
+
    struct string_list *list = settings ? dir_list_new(
-         settings->input.autoconfig_dir, "cfg", false) : NULL;
+         path, "cfg", false) : NULL;
 
    if (!list)
       return false;

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -1358,19 +1358,8 @@ static int action_ok_download_generic(const char *path,
    else if (!strcmp(type_msg, "cb_update_assets"))
       path = "assets.zip";
    else if (!strcmp(type_msg, "cb_update_autoconfig_profiles"))
-   {
-#ifdef ANDROID
-      path = "autoconf_android.zip";
-#elif defined(__QNX__)
-      path = "autoconf_qnx.zip";
-#elif defined(HAVE_UDEV)
-      path = "autoconf_udev.zip";
-#elif defined(HAVE_XINPUT2)
-      path = "autoconf_xinput.zip";
-#else
       path = "autoconf.zip";
-#endif
-   }
+
 #ifdef HAVE_HID
    else if (!strcmp(type_msg, "cb_update_autoconfig_profiles_hid"))
       path = "autoconf_hid.zip";


### PR DESCRIPTION
- Now it uses a points system, where VID/PID adds 3, exact name adds 2, and inexact name adds 1, it will pick the best config of the bunch
- Add VID/PID detection to dinput
- Make autoconf look into autoconfdir/inputdrivername