### PR TITLE
make android defaults smarter

### DIFF
--- a/android/phoenix/src/com/retroarch/browser/mainmenu/MainMenuFragment.java
+++ b/android/phoenix/src/com/retroarch/browser/mainmenu/MainMenuFragment.java
@@ -23,6 +23,7 @@ import android.provider.Settings;
 import android.util.Log;
 import android.widget.Toast;
 import android.os.Environment;
+import android.content.Context;
 
 import com.retroarch.R;
 import com.retroarch.browser.NativeInterface;
@@ -222,5 +223,10 @@ public final class MainMenuFragment extends PreferenceListFragment implements On
 		retro.putExtra("SDCARD", Environment.getExternalStorageDirectory().getAbsolutePath());
 		retro.putExtra("DOWNLOADS", Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).getAbsolutePath());
 		retro.putExtra("SCREENSHOTS", Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES).getAbsolutePath());
+        String external = Environment.getExternalStorageDirectory().getAbsolutePath() + "/Android/data/com.retroarch/files";
+        retro.putExtra("EXTERNAL", external);
 	}
 }
+
+
+

--- a/frontend/drivers/platform_android.c
+++ b/frontend/drivers/platform_android.c
@@ -791,10 +791,20 @@ static void frontend_android_get_environment_settings(int *argc,
                 case SDCARD_EXT_DIR_WRITABLE:
                    fill_pathname_join(g_defaults.sram_dir,
                         app_dir, "saves", sizeof(g_defaults.sram_dir));
+                   path_mkdir(g_defaults.sram_dir);
+
+                   fill_pathname_join(g_defaults.savestate_dir,
+                        app_dir, "saves", sizeof(g_defaults.savestate_dir));
+                   path_mkdir(g_defaults.savestate_dir);
                    break;
                 case SDCARD_NOT_WRITABLE:
                    fill_pathname_join(g_defaults.sram_dir,
                         app_dir, "saves", sizeof(g_defaults.sram_dir));
+                   path_mkdir(g_defaults.sram_dir);
+
+                   fill_pathname_join(g_defaults.savestate_dir,
+                        app_dir, "saves", sizeof(g_defaults.savestate_dir));
+                   path_mkdir(g_defaults.savestate_dir);
                    break;
                 case SDCARD_ROOT_WRITABLE:
                 default:

--- a/frontend/drivers/platform_android.c
+++ b/frontend/drivers/platform_android.c
@@ -774,6 +774,7 @@ static void frontend_android_get_environment_settings(int *argc,
             {
                fill_pathname_join(g_defaults.core_assets_dir,
                      app_dir, "downloads", sizeof(g_defaults.core_assets_dir));
+               path_mkdir(g_defaults.core_assets_dir);
             }
             if(*screenshot_dir && test_permissions(screenshot_dir))
             {
@@ -784,6 +785,7 @@ static void frontend_android_get_environment_settings(int *argc,
             {
                fill_pathname_join(g_defaults.screenshot_dir,
                      app_dir, "screenshots", sizeof(g_defaults.screenshot_dir));
+               path_mkdir(g_defaults.screenshot_dir);
             }
 
             switch (perms)


### PR DESCRIPTION
for saves, states and system dir:
- if sdcard root is writable use <content dir> by default
- else, if sdcard root is not writable but the externalFiles dir of the sdcard is use that by default (sdcard/Android/data/com.retroarch/saves) 
- else if no sdcard path is writable use app dir

for downloads and pictures, test if the sdcard paths are writtable and otherwise revert to appdir