### PR TITLE
fix a few issues with savestate sorting and system dir

### DIFF
--- a/command_event.c
+++ b/command_event.c
@@ -547,6 +547,7 @@ static void event_deinit_core(bool reinit)
    if(settings->sort_savestates_enable)
       strlcpy(global->savestate_dir,orig_savestate_dir,sizeof(global->savestate_dir));
 
+  /* restore system directory if it was set to <content dir> */
   if(orig_system_dir_empty)
       strlcpy(settings->system_directory,"",sizeof(settings->system_directory));
   

--- a/command_event.c
+++ b/command_event.c
@@ -545,7 +545,10 @@ static void event_deinit_core(bool reinit)
    if(settings->sort_savefiles_enable)
       strlcpy(global->savefile_dir,orig_savefile_dir,sizeof(global->savefile_dir));
    if(settings->sort_savestates_enable)
-      strlcpy(global->savestate_dir,orig_savestate_dir,sizeof(global->savestate_dir)); 
+      strlcpy(global->savestate_dir,orig_savestate_dir,sizeof(global->savestate_dir));
+
+  if(orig_system_dir_empty)
+      strlcpy(settings->system_directory,"",sizeof(settings->system_directory));
   
   /* auto overrides: reload the original config */
    if(global->overrides_active)

--- a/frontend/frontend.c
+++ b/frontend/frontend.c
@@ -47,6 +47,10 @@ void main_exit_save_config(void)
       if (settings->sort_savestates_enable && orig_savestate_dir[0] != '\0')
          strlcpy(global->savestate_dir,orig_savestate_dir,sizeof(global->savestate_dir));
 
+      /* restore system directory if it was set to <content dir> */
+      if(orig_system_dir_empty)
+         strlcpy(settings->system_directory,"",sizeof(settings->system_directory));
+
       /* Save last core-specific config to the default config location,
        * needed on consoles for core switching and reusing last good 
        * config for new cores.

--- a/frontend/frontend.c
+++ b/frontend/frontend.c
@@ -43,9 +43,9 @@ void main_exit_save_config(void)
    {
       /* restore original paths in case per-core organization is enabled */
       if (settings->sort_savefiles_enable && orig_savefile_dir[0] != '\0')
-	     strlcpy(global->savefile_dir,orig_savefile_dir,sizeof(global->savefile_dir));
+         strlcpy(global->savefile_dir,orig_savefile_dir,sizeof(global->savefile_dir));
       if (settings->sort_savestates_enable && orig_savestate_dir[0] != '\0')
-	     strlcpy(global->savestate_dir,orig_savestate_dir,sizeof(global->savestate_dir));
+         strlcpy(global->savestate_dir,orig_savestate_dir,sizeof(global->savestate_dir));
 
       /* Save last core-specific config to the default config location,
        * needed on consoles for core switching and reusing last good 

--- a/retroarch.c
+++ b/retroarch.c
@@ -61,6 +61,7 @@
 
 char orig_savestate_dir[PATH_MAX_LENGTH];
 char orig_savefile_dir[PATH_MAX_LENGTH];
+bool orig_system_dir_empty = false;
 
 /* Descriptive names for options without short variant. Please keep the name in
    sync with the option name. Order does not matter. */
@@ -313,6 +314,8 @@ static void set_special_paths(char **argv, unsigned num_content)
    /* If this is already set,
     * do not overwrite it as this was initialized before in
     * a menu or otherwise. */
+   if (settings->system_directory[0] == '\0')
+      orig_system_dir_empty = true;
    if (!*settings->system_directory)
       fill_pathname_basedir(settings->system_directory, argv[0],
             sizeof(settings->system_directory));
@@ -333,7 +336,7 @@ void set_paths_redirect(const char *path)
          (global_library_name_hash != MENU_VALUE_NO_CORE))
    {
       /* per-core saves: append the library_name to the save location */
-      if (settings->sort_savefiles_enable)
+      if (settings->sort_savefiles_enable && global->savefile_dir[0] != '\0')
       {
          strlcpy(orig_savefile_dir,global->savefile_dir,sizeof(global->savefile_dir));
          fill_pathname_dir(
@@ -344,7 +347,7 @@ void set_paths_redirect(const char *path)
 
          /* If path doesn't exist, try to create it,
           * if everything fails revert to the original path. */
-         if(!path_is_directory(global->savefile_dir))
+         if(!path_is_directory(global->savefile_dir) && global->savestate_dir[0] != '\0')
             if(!path_mkdir(global->savefile_dir))
                strlcpy(global->savefile_dir,
                      orig_savefile_dir,
@@ -428,7 +431,8 @@ void rarch_set_paths(const char *path)
     * as this was initialized before in a menu or otherwise. */
    if (*settings->system_directory)
       return;
-
+   if (settings->system_directory[0] == '\0')
+      orig_system_dir_empty = true;
    fill_pathname_basedir(settings->system_directory, path,
          sizeof(settings->system_directory));
 }

--- a/retroarch.h
+++ b/retroarch.h
@@ -214,6 +214,7 @@ enum rarch_content_type rarch_path_is_media_type(const char *path);
 
 extern char orig_savestate_dir[PATH_MAX_LENGTH];
 extern char orig_savefile_dir[PATH_MAX_LENGTH];
+extern bool orig_system_dir_empty;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
- Savestate / Savefile sorting shouldn't happen even if enabled when save location is <content dir>
- Made sure system dir is restored after loading content when it's set to <content dir>
