### PR TITLE
Proposals

### DIFF
--- a/core_info.c
+++ b/core_info.c
@@ -404,10 +404,7 @@ bool core_info_get_display_name(const char *path, char *s, size_t len)
    if (!conf)
       goto error;
 
-   if(display_name)
-      snprintf(s, len,"%s (%s)",core_name, display_name);
-   else
-      snprintf(s, len,"%s",core_name);
+   snprintf(s, len,"%s",display_name);
 
    free(core_name);
 

--- a/core_info.c
+++ b/core_info.c
@@ -380,7 +380,7 @@ bool core_info_list_get_display_name(core_info_list_t *core_info_list,
 bool core_info_get_display_name(const char *path, char *s, size_t len)
 {
    char       *core_name = NULL;
-   char       *system_name = NULL;
+   char       *display_name = NULL;
    config_file_t *conf   = NULL;
 
    if (!path_file_exists(path))
@@ -394,8 +394,8 @@ bool core_info_get_display_name(const char *path, char *s, size_t len)
    config_get_string(conf, "corename",
          &core_name);
 
-   config_get_string(conf, "systemname",
-         &system_name);
+   config_get_string(conf, "display_name",
+         &display_name);
 
    config_file_free(conf);
 
@@ -404,8 +404,8 @@ bool core_info_get_display_name(const char *path, char *s, size_t len)
    if (!conf)
       goto error;
 
-   if(system_name)
-      snprintf(s, len,"%s (%s)",core_name, system_name);
+   if(display_name)
+      snprintf(s, len,"%s (%s)",core_name, display_name);
    else
       snprintf(s, len,"%s",core_name);
 

--- a/core_info.c
+++ b/core_info.c
@@ -380,6 +380,7 @@ bool core_info_list_get_display_name(core_info_list_t *core_info_list,
 bool core_info_get_display_name(const char *path, char *s, size_t len)
 {
    char       *core_name = NULL;
+   char       *system_name = NULL;
    config_file_t *conf   = NULL;
 
    if (!path_file_exists(path))
@@ -393,6 +394,9 @@ bool core_info_get_display_name(const char *path, char *s, size_t len)
    config_get_string(conf, "corename",
          &core_name);
 
+   config_get_string(conf, "systemname",
+         &system_name);
+
    config_file_free(conf);
 
    if (!core_name)
@@ -400,7 +404,10 @@ bool core_info_get_display_name(const char *path, char *s, size_t len)
    if (!conf)
       goto error;
 
-   strlcpy(s, core_name, len);
+   if(system_name)
+      snprintf(s, len,"%s (%s)",core_name, system_name);
+   else
+      snprintf(s, len,"%s",core_name);
 
    free(core_name);
 

--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -643,7 +643,6 @@ static void handle_hotplug(android_input_t *android,
        * We really need to find a way to detect useless input devices
        * like gpio-keys in a general way.
        */
-      *port = 0;
       strlcpy(name_buf, device_name, sizeof(name_buf));
    }
    else if (device_name[0] != '\0')

--- a/input/input_autodetect.c
+++ b/input/input_autodetect.c
@@ -106,7 +106,10 @@ static void input_autoconfigure_joypad_add(
       autoconfig_params_t *params)
 {
    char msg[PATH_MAX_LENGTH] = {0};
+   char buf[PATH_MAX_LENGTH] = {0};
    settings_t      *settings = config_get_ptr();
+
+   config_get_array(conf, "input_display_name", buf, sizeof(buf));
 
    /* This will be the case if input driver is reinitialized.
     * No reason to spam autoconfigure messages every time. */
@@ -120,8 +123,12 @@ static void input_autoconfigure_joypad_add(
    input_autoconfigure_joypad_conf(conf,
          settings->input.autoconf_binds[params->idx]);
 
-   snprintf(msg, sizeof(msg), "Device port #%u (%s) configured.",
-         params->idx, params->name);
+   if (buf[0] != '\0' || strcmp(buf, ""))
+      snprintf(msg, sizeof(msg), "Device %s in port #%u configured as %s",
+            params->name, params->idx, buf);
+   else
+      snprintf(msg, sizeof(msg), "Device %s in port #%u configured",
+            params->name, params->idx);
 
    if (!block_osd_spam)
       rarch_main_msg_queue_push(msg, 0, 60, false);


### PR DESCRIPTION
- The core updater shows the same names (including system name) as the core picker
- Input autodetect would print a display name so the user can know what autoconf matched