### PR TITLE
stb.c fixes

### DIFF
--- a/gfx/drivers_font_renderer/stb.c
+++ b/gfx/drivers_font_renderer/stb.c
@@ -18,6 +18,7 @@
 #include <file/file_path.h>
 #include "../../general.h"
 #include "../../file_ops.h"
+#include <ctype.h>
 
 #define STB_TRUETYPE_IMPLEMENTATION
 #define STB_RECT_PACK_IMPLEMENTATION
@@ -63,6 +64,8 @@ static bool font_renderer_stb_create_atlas(stb_font_renderer_t *self,
    stbtt_packedchar   chardata[256];
 
    self->atlas.width  = self->atlas.height = 512;
+
+alloc_atlas:
    self->atlas.buffer = (uint8_t*)calloc(self->atlas.height, self->atlas.width);
 
    if (!self->atlas.buffer)
@@ -87,6 +90,18 @@ static bool font_renderer_stb_create_atlas(stb_font_renderer_t *self,
       g->draw_offset_y  = c->yoff;
       g->width          = c->x1 - c->x0;
       g->height         = c->y1 - c->y0;
+
+      /* make sure important characters fit */
+      if (isprint(i) && !isspace(i) && (!g->width || !g->height))
+      {
+         /* increase atlas by 20% in all directions */
+         self->atlas.width  *= 1.2;
+         self->atlas.height *= 1.2;
+
+         free(self->atlas.buffer);
+         goto alloc_atlas;
+         break;
+      }
    }
 
    return true;

--- a/gfx/drivers_font_renderer/stb.c
+++ b/gfx/drivers_font_renderer/stb.c
@@ -146,7 +146,8 @@ static const char *font_renderer_stb_get_default_font(void)
       "/Library/Fonts/Tahoma.ttf",
 #elif defined(__ANDROID_API__)
       "/system/fonts/DroidSansMono.ttf",
-      "/system/fonts/DroidSansFallback.ttf",
+      "/system/fonts/CutiveMono.ttf",
+      "/system/fonts/DroidSans.ttf",
 #else
       "/usr/share/fonts/TTF/DejaVuSansMono.ttf",
       "/usr/share/fonts/TTF/DejaVuSans.ttf",


### PR DESCRIPTION
This fixes stb_truetype font backend issues in high DPI displays. I did not disable the hack introduced by https://github.com/libretro/RetroArch/commit/a73f91e68a1d4296c5091dc263c335273d705310 because I do not possess such devices and thus can't test it on them. Please do so if the issue is fixed.

700dpi (desktop):
![https://i.imgur.com/7kVgMC9.png](https://i.imgur.com/7kVgMC9.png)