### PR TITLE
(gl_raster_font) Reduce the size of the font atlas textures

### DIFF
--- a/gfx/drivers_font/gl_raster_font.c
+++ b/gfx/drivers_font/gl_raster_font.c
@@ -60,7 +60,12 @@ static bool gl_raster_font_upload_atlas(gl_raster_t *font,
    uint8_t       *tmp = NULL;
 
 #ifndef HAVE_OPENGLES
-   if (font->gl->core_context)
+   struct retro_hw_render_callback *cb = video_driver_callback();
+   bool modern = font->gl->core_context ||
+         (cb->context_type == RETRO_HW_CONTEXT_OPENGL &&
+          cb->version_major >= 3);
+
+   if (modern)
    {
       GLint swizzle[] = { GL_ONE, GL_ONE, GL_ONE, GL_RED };
       glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, swizzle);

--- a/gfx/drivers_font/gl_raster_font.c
+++ b/gfx/drivers_font/gl_raster_font.c
@@ -60,13 +60,19 @@ static bool gl_raster_font_upload_atlas(gl_raster_t *font,
    uint8_t       *tmp = NULL;
    struct retro_hw_render_callback *cb = video_driver_callback();
    bool ancient = false; /* add a check here if needed */
-
-#ifndef HAVE_OPENGLES
    bool modern = font->gl->core_context ||
          (cb->context_type == RETRO_HW_CONTEXT_OPENGL &&
           cb->version_major >= 3);
 
-   if (modern)
+   if (ancient)
+   {
+      gl_internal = gl_format = GL_RGBA;
+      ncomponents = 4;
+   }
+#ifdef HAVE_OPENGLES
+   (void)modern;
+#else
+   else if (modern)
    {
       GLint swizzle[] = { GL_ONE, GL_ONE, GL_ONE, GL_RED };
       glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, swizzle);
@@ -75,13 +81,7 @@ static bool gl_raster_font_upload_atlas(gl_raster_t *font,
       gl_format   = GL_RED;
       ncomponents = 1;
    }
-   else
 #endif
-   if (ancient)
-   {
-      gl_internal = gl_format = GL_RGBA;
-      ncomponents = 4;
-   }
 
    tmp = (uint8_t*)calloc(height, width * ncomponents);
 


### PR DESCRIPTION
This reduces the atlas texture depth from 32bpp to 16bpp or 8bpp when possible. The old 32bpp code is there but will remain "dead code" until there's a platform/configuration that sets `ancient=true` in `gl_raster_font_upload_atlas()`

The 16bpp path uses GL_LUMINANCE_ALPHA which seems to be available since OpenGL 1.0. PSGL is OpenGL ES 1.0 compliant so, at least in theory, it should support this format.
The 8bpp path uses GL_R8 which was introduced in OpenGL 3.0.