### PR TITLE
(command_event.c) Set index to appended disk in event_disk_control_append_image

### DIFF
--- a/command_event.c
+++ b/command_event.c
@@ -257,60 +257,6 @@ static void event_disk_control_set_eject(bool new_state, bool print_log)
 }
 
 /**
- * event_disk_control_append_image:
- * @path                 : Path to disk image. 
- *
- * Appends disk image to disk image list.
- **/
-void event_disk_control_append_image(const char *path)
-{
-   unsigned new_idx;
-   char msg[PATH_MAX_LENGTH]                         = {0};
-   struct retro_game_info info                       = {0};
-   global_t                                  *global = global_get_ptr();
-   rarch_system_info_t                       *sysinfo = rarch_system_info_get_ptr();
-   const struct retro_disk_control_callback *control = 
-      sysinfo ? (const struct retro_disk_control_callback*)&sysinfo->disk_control
-      : NULL;
-
-   if (!control)
-      return;
-
-   event_disk_control_set_eject(true, false);
-
-   control->add_image_index();
-   new_idx = control->get_num_images();
-   if (!new_idx)
-      return;
-   new_idx--;
-
-   info.path = path;
-   control->replace_image_index(new_idx, &info);
-
-   snprintf(msg, sizeof(msg), "%s: ", msg_hash_to_str(MSG_APPENDED_DISK));
-   strlcat(msg, path, sizeof(msg));
-   RARCH_LOG("%s\n", msg);
-   rarch_main_msg_queue_push(msg, 0, 180, true);
-
-   event_command(EVENT_CMD_AUTOSAVE_DEINIT);
-
-   /* TODO: Need to figure out what to do with subsystems case. */
-   if (!*global->subsystem)
-   {
-      /* Update paths for our new image.
-       * If we actually use append_image, we assume that we
-       * started out in a single disk case, and that this way
-       * of doing it makes the most sense. */
-      rarch_set_paths(path);
-      rarch_fill_pathnames();
-   }
-
-   event_command(EVENT_CMD_AUTOSAVE_INIT);
-
-   event_disk_control_set_eject(false, false);
-}
-
-/**
  * event_check_disk_eject:
  * @control              : Handle to disk control handle.
  *
@@ -375,6 +321,60 @@ static void event_disk_control_set_index(unsigned idx)
          RARCH_LOG("%s\n", msg);
       rarch_main_msg_queue_push(msg, 1, 180, true);
    }
+}
+
+/**
+ * event_disk_control_append_image:
+ * @path                 : Path to disk image.
+ *
+ * Appends disk image to disk image list.
+ **/
+void event_disk_control_append_image(const char *path)
+{
+   unsigned new_idx;
+   char msg[PATH_MAX_LENGTH]                         = {0};
+   struct retro_game_info info                       = {0};
+   global_t                                  *global = global_get_ptr();
+   rarch_system_info_t                       *sysinfo = rarch_system_info_get_ptr();
+   const struct retro_disk_control_callback *control =
+      sysinfo ? (const struct retro_disk_control_callback*)&sysinfo->disk_control
+      : NULL;
+
+   if (!control)
+      return;
+
+   event_disk_control_set_eject(true, false);
+
+   control->add_image_index();
+   new_idx = control->get_num_images();
+   if (!new_idx)
+      return;
+   new_idx--;
+
+   info.path = path;
+   control->replace_image_index(new_idx, &info);
+
+   snprintf(msg, sizeof(msg), "%s: ", msg_hash_to_str(MSG_APPENDED_DISK));
+   strlcat(msg, path, sizeof(msg));
+   RARCH_LOG("%s\n", msg);
+   rarch_main_msg_queue_push(msg, 0, 180, true);
+
+   event_command(EVENT_CMD_AUTOSAVE_DEINIT);
+
+   /* TODO: Need to figure out what to do with subsystems case. */
+   if (!*global->subsystem)
+   {
+      /* Update paths for our new image.
+       * If we actually use append_image, we assume that we
+       * started out in a single disk case, and that this way
+       * of doing it makes the most sense. */
+      rarch_set_paths(path);
+      rarch_fill_pathnames();
+   }
+
+   event_command(EVENT_CMD_AUTOSAVE_INIT);
+   event_disk_control_set_index(new_idx);
+   event_disk_control_set_eject(false, false);
 }
 
 /**


### PR DESCRIPTION
Simply added event_disk_control_set_index(new_idx) before eject was set to false. Had to move event_disk_control_append_image beneath event_disk_control_set_index to allow this to compile without 'implicit declaration' errors.

Makes switching disks less annoying since you don't have to go back into the menu to actually set the index to the disk you just appended, since that's what you're wanting to switch to when appending disks most of the time.

I tested this with several PSX games that use disk swapping. A few like Chrono Cross and Metal Gear Solid may need to run 'ejected' for a second or two for the game to register the disk change.