### PR TITLE
Restore generic Mac OS X joypad functionality

### DIFF
--- a/input/connect/joypad_connection.c
+++ b/input/connect/joypad_connection.c
@@ -105,7 +105,7 @@ int32_t pad_connection_pad_init(joypad_connection_t *joyconn,
       }
    }
 
-   return -1;
+   return pad;
 }
 
 void pad_connection_pad_deinit(joypad_connection_t *joyconn, uint32_t pad)


### PR DESCRIPTION
Forward port of the RetroArch 1.0.0.3 generic Mac OS X (HID) joypad handling logic. This patch allows joypads such as the Logitech F310 to be recognized (again) by RetroArch under OSX.