### PR TITLE
better overall hack for GPIO devices on port 0

### DIFF
--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -618,8 +618,6 @@ static void handle_hotplug(android_input_t *android,
       //For Xperia Play - count similar devices and bind them to the same 'user'
       //port
       //
-      //For nVidia Shield - see above
-      //
       //For TTT HT - keep track of how many of these 'pads' are already
       //connected, and based on that, assign one of them to be User 1 and
       //the other to be User 2.

--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -639,22 +639,15 @@ static void handle_hotplug(android_input_t *android,
       else if (strstr(device_name, "SideWinder"))
          strlcpy(name_buf, "SideWinder Classic", sizeof(name_buf));
    }
-   else if (strstr(device_name, "NVIDIA Corporation NVIDIA Controller v01.01"))
-   {
-      /* Built-in shield contrlleris always user 1. FIXME: This is kinda ugly.
-       * We really need to find a way to detect useless input devices
-       * like gpio-keys in a general way.
-       */
-      *port = 0;
-      strlcpy(name_buf, device_name, sizeof(name_buf));
-   }
+   /* Make sure generic I/O devices are always bound to port one
+    * should be easier to add these instead of one hack per device
+    */
    else if (strstr(device_name, "Amazon Fire TV Remote")
          || strstr(device_name, "Nexus Remote")
          || strstr(device_name, "SHIELD Remote")
          || strstr(device_name, "gpio")
          || strstr(device_name, "Virtual"))
    {
-      /* hack for remote control type devices, set them always to port 0 */
       *port = 0;
        if (strstr(device_name, "Virtual") || (strstr(device_name, "gpio")))
          strlcpy(name_buf, "Generic I/O Device", sizeof(name_buf));
@@ -666,10 +659,8 @@ static void handle_hotplug(android_input_t *android,
                       ||   strstr(android->pad_states[0].name,"SHIELD Remote")
                       ||   strstr(android->pad_states[0].name,"Generic I/O Device")))
    {
-      /* and then when we are binding a new controller in port 1 and one of those remotes
-       * was bound to port 0, bind the device as port 0 too, it causes all the controllers to 
-       * rebind on the first button press but at least the remotes can be used to navigate
-       * the user interface
+      /* then, when binding a new controller in port 1 and one of those remotes
+       * was bound to port 0, overwrite that binding
        */
       *port = 0;
       strlcpy(name_buf, device_name, sizeof(name_buf));

--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -641,7 +641,7 @@ static void handle_hotplug(android_input_t *android,
    }
    else if (strstr(device_name, "NVIDIA Corporation NVIDIA Controller v01.01"))
    {
-      /* Built-in shield controller is always user 1. FIXME: This is kinda ugly.
+      /* Built-in shield contrlleris always user 1. FIXME: This is kinda ugly.
        * We really need to find a way to detect useless input devices
        * like gpio-keys in a general way.
        */
@@ -655,21 +655,6 @@ static void handle_hotplug(android_input_t *android,
       *port = 0;
       strlcpy(name_buf, "Generic I/O Device", sizeof(name_buf));
    }
-   else if (strstr(device_name, "NVIDIA Corporation NVIDIA Controller v01.03") && !strstr(android->pad_states[0].name,"NVIDIA Corporation NVIDIA Controller v01.03"))
-   {
-      /* Shield Controller is user 0 by default. FIXME: This is kinda ugly.
-       * this allows using the NVIDIA button as menu
-       */
-      *port = 0;
-      strlcpy(name_buf, device_name, sizeof(name_buf));
-   }
-   else if (strstr(device_name, "Virtual") || 
-         (strstr(device_name, "gpio") && strstr(android->pad_states[0].name,"NVIDIA Corporation NVIDIA Controller v01.03")))
-   {
-      /* If the shield controller is detected bind the virtual and gpio devices to the same port*/
-      *port = 0;
-      strlcpy(name_buf, "Generic I/O Device", sizeof(name_buf));
-   }
    else if (strstr(device_name, "Amazon Fire TV Remote")
          || strstr(device_name, "Nexus Remote")
          || strstr(device_name, "SHIELD Remote"))
@@ -680,7 +665,8 @@ static void handle_hotplug(android_input_t *android,
    }
    else if ( *port==1 && ( strstr(android->pad_states[0].name,"Amazon Fire TV Remote")
                       ||   strstr(android->pad_states[0].name,"Nexus Remote")
-                      ||   strstr(android->pad_states[0].name,"SHIELD Remote")))
+                      ||   strstr(android->pad_states[0].name,"SHIELD Remote")
+                      ||   strstr(android->pad_states[0].name,"Generic I/O Device")))
    {
       /* and then when we are binding a new controller in port 1 and one of those remotes
        * was bound to port 0, bind the device as port 0 too, it causes all the controllers to 

--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -641,7 +641,7 @@ static void handle_hotplug(android_input_t *android,
    }
    else if (strstr(device_name, "NVIDIA Corporation NVIDIA Controller v01.01"))
    {
-      /* Built-in shield contrlleris always user 1. FIXME: This is kinda ugly.
+      /* Built-in shield controller is always user 1. FIXME: This is kinda ugly.
        * We really need to find a way to detect useless input devices
        * like gpio-keys in a general way.
        */
@@ -652,6 +652,21 @@ static void handle_hotplug(android_input_t *android,
          (strstr(device_name, "gpio") && strstr(android->pad_states[0].name,"NVIDIA Corporation NVIDIA Controller v01.01")))
    {
       /* If built-in shield controller is detected bind the virtual and gpio devices to the same port*/
+      *port = 0;
+      strlcpy(name_buf, "Generic I/O Device", sizeof(name_buf));
+   }
+   else if (strstr(device_name, "NVIDIA Corporation NVIDIA Controller v01.03") && !strstr(android->pad_states[0].name,"NVIDIA Corporation NVIDIA Controller v01.03"))
+   {
+      /* Shield Controller is user 0 by default. FIXME: This is kinda ugly.
+       * this allows using the NVIDIA button as menu
+       */
+      *port = 0;
+      strlcpy(name_buf, device_name, sizeof(name_buf));
+   }
+   else if (strstr(device_name, "Virtual") || 
+         (strstr(device_name, "gpio") && strstr(android->pad_states[0].name,"NVIDIA Corporation NVIDIA Controller v01.03")))
+   {
+      /* If the shield controller is detected bind the virtual and gpio devices to the same port*/
       *port = 0;
       strlcpy(name_buf, "Generic I/O Device", sizeof(name_buf));
    }

--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -648,20 +648,18 @@ static void handle_hotplug(android_input_t *android,
       *port = 0;
       strlcpy(name_buf, device_name, sizeof(name_buf));
    }
-   else if (strstr(device_name, "Virtual") || 
-         (strstr(device_name, "gpio") && strstr(android->pad_states[0].name,"NVIDIA Corporation NVIDIA Controller v01.01")))
-   {
-      /* If built-in shield controller is detected bind the virtual and gpio devices to the same port*/
-      *port = 0;
-      strlcpy(name_buf, "Generic I/O Device", sizeof(name_buf));
-   }
    else if (strstr(device_name, "Amazon Fire TV Remote")
          || strstr(device_name, "Nexus Remote")
-         || strstr(device_name, "SHIELD Remote"))
+         || strstr(device_name, "SHIELD Remote")
+         || strstr(device_name, "gpio")
+         || strstr(device_name, "Virtual"))
    {
       /* hack for remote control type devices, set them always to port 0 */
       *port = 0;
-      strlcpy(name_buf, device_name, sizeof(name_buf));
+       if (strstr(device_name, "Virtual") || (strstr(device_name, "gpio"))
+         strlcpy(name_buf, "Generic I/O Device", sizeof(name_buf));
+      else
+         strlcpy(name_buf, device_name, sizeof(name_buf));
    }
    else if ( *port==1 && ( strstr(android->pad_states[0].name,"Amazon Fire TV Remote")
                       ||   strstr(android->pad_states[0].name,"Nexus Remote")

--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -656,9 +656,9 @@ static void handle_hotplug(android_input_t *android,
    {
       /* hack for remote control type devices, set them always to port 0 */
       *port = 0;
-       if (strstr(device_name, "Virtual") || (strstr(device_name, "gpio"))
+       if (strstr(device_name, "Virtual") || (strstr(device_name, "gpio")))
          strlcpy(name_buf, "Generic I/O Device", sizeof(name_buf));
-      else
+       else
          strlcpy(name_buf, device_name, sizeof(name_buf));
    }
    else if ( *port==1 && ( strstr(android->pad_states[0].name,"Amazon Fire TV Remote")


### PR DESCRIPTION
I think this approach is better, force all the weird input devices to port 0, and make sure the binding is overriden later when binding a proper device.