### PR TITLE
populate system dir correctly when content dir when it's empty

### DIFF
--- a/dynamic.c
+++ b/dynamic.c
@@ -755,15 +755,20 @@ bool rarch_environment_cb(unsigned cmd, void *data)
          if (settings->system_directory[0] == '\0')
          {
             RARCH_WARN("SYSTEM DIR is empty, assume CONTENT DIR %s\n",global->path.fullpath);
-            fill_pathname_basedir(buf, global->path.fullpath,
-                  sizeof(buf));
+            fill_pathname_basedir(global->dir.systemdir, global->path.fullpath,
+                  sizeof(global->dir.systemdir));
 
+            *(const char**)data = global->dir.systemdir;
+            RARCH_LOG("Environ SYSTEM_DIRECTORY: \"%s\".\n",
+               global->dir.systemdir);
          }
-         *(const char**)data = *settings->system_directory ?
-            settings->system_directory : buf;
-
-         RARCH_LOG("Environ SYSTEM_DIRECTORY: \"%s\".\n",
+         else
+         {
+            *(const char**)data = settings->system_directory;
+            RARCH_LOG("Environ SYSTEM_DIRECTORY: \"%s\".\n",
                settings->system_directory);
+         }
+
          break;
 
       case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY:

--- a/runloop.h
+++ b/runloop.h
@@ -122,6 +122,7 @@ typedef struct global
       /* Used on reentrancy to use a savestate dir. */
       char savefile[PATH_MAX_LENGTH];
       char savestate[PATH_MAX_LENGTH];
+      char systemdir[PATH_MAX_LENGTH];
 #ifdef HAVE_OVERLAY
       char overlay[PATH_MAX_LENGTH];
       char osk_overlay[PATH_MAX_LENGTH];


### PR DESCRIPTION
it now behaves exactly like savefile dir and savestate dir, when the directories are empty it will just use the content dir WITHOUT altering the config value