### PR TITLE
[Gentoo] deps/zlib/ioapi.h define _Z_OF

### DIFF
--- a/deps/zlib/ioapi.h
+++ b/deps/zlib/ioapi.h
@@ -61,6 +61,16 @@
 #endif
 #endif
 
+#ifdef _Z_OF
+#undef OF
+#define OF _Z_OF
+#else
+#ifndef OF
+#define _Z_OF(args) args
+#define OF _Z_OF
+#endif
+#endif
+
 /*
 #ifndef ZPOS64_T
   #ifdef _WIN32


### PR DESCRIPTION
Gentoo has effectively forked zlib some years ago, this means that some things don't work as expected. See: https://bugs.gentoo.org/show_bug.cgi?id=383179

This PR should make it build in gentoo again and hopefully not break vanilla zlib.

Build failure:

```
In file included from decompress/../deps/zlib/unzip.h:55:0,
                 from decompress/zip_support.c:29:
decompress/../deps/zlib/ioapi.h:127:51: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘OF’
 typedef voidpf   (ZCALLBACK *open_file_func)      OF((voidpf opaque, const char* filename, int mode));
                                                   ^
decompress/../deps/zlib/ioapi.h:128:51: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘OF’
 typedef uLong    (ZCALLBACK *read_file_func)      OF((voidpf opaque, voidpf stream, void* buf, uLong size));
                                                   ^
decompress/../deps/zlib/ioapi.h:129:51: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘OF’
 typedef uLong    (ZCALLBACK *write_file_func)     OF((voidpf opaque, voidpf stream, const void* buf, uLong size));
                                                   ^
decompress/../deps/zlib/ioapi.h:130:51: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘OF’
 typedef int      (ZCALLBACK *close_file_func)     OF((voidpf opaque, voidpf stream));
                                                   ^
decompress/../deps/zlib/ioapi.h:131:51: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘OF’
 typedef int      (ZCALLBACK *testerror_file_func) OF((voidpf opaque, voidpf stream));
                                                   ^
decompress/../deps/zlib/ioapi.h:133:51: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘OF’
 typedef long     (ZCALLBACK *tell_file_func)      OF((voidpf opaque, voidpf stream));
                                                   ^
decompress/../deps/zlib/ioapi.h:134:51: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘OF’
 typedef long     (ZCALLBACK *seek_file_func)      OF((voidpf opaque, voidpf stream, uLong offset, int origin));
```