### PR TITLE
Add include_compressed param to dir_list_new.

### DIFF
--- a/audio/audio_dsp_filter.c
+++ b/audio/audio_dsp_filter.c
@@ -242,7 +242,7 @@ rarch_dsp_filter_t *rarch_dsp_filter_new(
 #if !defined(HAVE_FILTERS_BUILTIN) && defined(HAVE_DYLIB)
    fill_pathname_basedir(basedir, filter_config, sizeof(basedir));
 
-   plugs = dir_list_new(basedir, EXT_EXECUTABLES, false);
+   plugs = dir_list_new(basedir, EXT_EXECUTABLES, false, false);
    if (!plugs)
       goto error;
 #endif

--- a/dir_list_special.c
+++ b/dir_list_special.c
@@ -25,7 +25,7 @@ struct string_list *dir_list_new_special(const char *input_dir, enum dir_list_ty
    const char *exts  = NULL;
    bool include_dirs = false;
 
-   global_t                *global = global_get_ptr();
+   global_t     *global = global_get_ptr();
    settings_t *settings = config_get_ptr();
 
    (void)input_dir;
@@ -58,5 +58,5 @@ struct string_list *dir_list_new_special(const char *input_dir, enum dir_list_ty
          return NULL;
    }
 
-   return dir_list_new(dir, exts, include_dirs);
+   return dir_list_new(dir, exts, include_dirs, false);
 }

--- a/frontend/frontend_salamander.c
+++ b/frontend/frontend_salamander.c
@@ -42,7 +42,7 @@ static void find_first_libretro_core(char *first_file,
    RARCH_LOG("Searching for valid libretro implementation in: \"%s\".\n",
          dir);
 
-   list = dir_list_new(dir, ext, false);
+   list = dir_list_new(dir, ext, false, false);
    if (!list)
    {
       RARCH_ERR("Couldn't read directory. Cannot infer default libretro core.\n");

--- a/gfx/drivers_context/drm_egl_ctx.c
+++ b/gfx/drivers_context/drm_egl_ctx.c
@@ -444,7 +444,7 @@ static bool gfx_ctx_drm_egl_init(void *data)
       return false;
 
    drm->g_drm_fd   = -1;
-   gpu_descriptors = dir_list_new("/dev/dri", NULL, false);
+   gpu_descriptors = dir_list_new("/dev/dri", NULL, false, false);
 
 nextgpu:
    free_drm_resources(drm);

--- a/gfx/video_filter.c
+++ b/gfx/video_filter.c
@@ -396,7 +396,7 @@ rarch_softfilter_t *rarch_softfilter_new(const char *filter_config,
 #if defined(HAVE_DYLIB)
    fill_pathname_basedir(basedir, filter_config, sizeof(basedir));
 
-   plugs = dir_list_new(basedir, EXT_EXECUTABLES, false);
+   plugs = dir_list_new(basedir, EXT_EXECUTABLES, false, false);
    if (!plugs)
    {
       RARCH_ERR("[SoftFilter]: Could not build up string list...\n");

--- a/input/input_autodetect.c
+++ b/input/input_autodetect.c
@@ -199,10 +199,10 @@ static bool input_autoconfigure_joypad_from_conf_dir(
          sizeof(path));
 
    if (settings)
-      list = dir_list_new(path, "cfg", false);
+      list = dir_list_new(path, "cfg", false, false);
 
    if (!list || !list->size)
-      list = dir_list_new(settings->input.autoconfig_dir, "cfg", false);
+      list = dir_list_new(settings->input.autoconfig_dir, "cfg", false, false);
 
    if(!list)
       return false;

--- a/libretro-common/file/dir_list.c
+++ b/libretro-common/file/dir_list.c
@@ -129,13 +129,14 @@ static bool dirent_is_directory(const char *path,
 
 /**
  * parse_dir_entry:
- * @name         : name of the directory listing entry.
- * @file_path    : file path of the directory listing entry.
- * @is_dir       : is the directory listing a directory?
- * @include_dirs : include directories as part of the finished directory listing?
- * @list         : pointer to directory listing.
- * @ext_list     : pointer to allowed file extensions listing.
- * @file_ext     : file extension of the directory listing entry.
+ * @name               : name of the directory listing entry.
+ * @file_path          : file path of the directory listing entry.
+ * @is_dir             : is the directory listing a directory?
+ * @include_dirs       : include directories as part of the finished directory listing?
+ * @include_compressed : Include compressed files, even if not part of ext_list.
+ * @list               : pointer to directory listing.
+ * @ext_list           : pointer to allowed file extensions listing.
+ * @file_ext           : file extension of the directory listing entry.
  *
  * Parses a directory listing.
  *
@@ -143,7 +144,7 @@ static bool dirent_is_directory(const char *path,
  * continue to the next entry in the directory listing.
  **/
 static int parse_dir_entry(const char *name, char *file_path,
-      bool is_dir, bool include_dirs,
+      bool is_dir, bool include_dirs, bool include_compressed,
       struct string_list *list, struct string_list *ext_list,
       const char *file_ext)
 {
@@ -167,6 +168,9 @@ static int parse_dir_entry(const char *name, char *file_path,
       return 1;
 
    if (!is_compressed_file && !is_dir && ext_list && !supported_by_core)
+      return 1;
+
+   if (!include_compressed && !supported_by_core)
       return 1;
 
    if (is_dir)
@@ -195,6 +199,7 @@ static int parse_dir_entry(const char *name, char *file_path,
  * @dir          : directory path.
  * @ext          : allowed extensions of file directory entries to include.
  * @include_dirs : include directories as part of the finished directory listing?
+ * @strict_ext   : Only include files which match ext. Do not try to match compressed files, etc.
  *
  * Create a directory listing.
  *
@@ -202,7 +207,7 @@ static int parse_dir_entry(const char *name, char *file_path,
  * NULL in case of error. Has to be freed manually.
  **/
 struct string_list *dir_list_new(const char *dir,
-      const char *ext, bool include_dirs)
+      const char *ext, bool include_dirs, bool include_compressed)
 {
 #ifdef _WIN32
    WIN32_FIND_DATA ffd;
@@ -241,14 +246,14 @@ struct string_list *dir_list_new(const char *dir,
       fill_pathname_join(file_path, dir, name, sizeof(file_path));
 
       ret = parse_dir_entry(name, file_path, is_dir,
-            include_dirs, list, ext_list, file_ext);
+            include_dirs, include_compressed, list, ext_list, file_ext);
 
       if (ret == -1)
          goto error;
 
       if (ret == 1)
          continue;
-   }while (FindNextFile(hFind, &ffd) != 0);
+   } while (FindNextFile(hFind, &ffd) != 0);
 
    FindClose(hFind);
    string_list_free(ext_list);
@@ -275,7 +280,7 @@ error:
       is_dir = dirent_is_directory(file_path, entry);
 
       ret = parse_dir_entry(name, file_path, is_dir,
-            include_dirs, list, ext_list, file_ext);
+            include_dirs, include_compressed, list, ext_list, file_ext);
 
       if (ret == -1)
          goto error;
@@ -290,7 +295,6 @@ error:
    return list;
 
 error:
-
    if (directory)
       closedir(directory);
 

--- a/libretro-common/file/dir_list.c
+++ b/libretro-common/file/dir_list.c
@@ -196,10 +196,10 @@ static int parse_dir_entry(const char *name, char *file_path,
 
 /**
  * dir_list_new:
- * @dir          : directory path.
- * @ext          : allowed extensions of file directory entries to include.
- * @include_dirs : include directories as part of the finished directory listing?
- * @strict_ext   : Only include files which match ext. Do not try to match compressed files, etc.
+ * @dir                : directory path.
+ * @ext                : allowed extensions of file directory entries to include.
+ * @include_dirs       : include directories as part of the finished directory listing?
+ * @include_compressed : Only include files which match ext. Do not try to match compressed files, etc.
  *
  * Create a directory listing.
  *

--- a/libretro-common/file/dir_list_obj.m
+++ b/libretro-common/file/dir_list_obj.m
@@ -105,13 +105,14 @@ static bool dirent_is_directory(const char *path)
 
 /**
  * parse_dir_entry:
- * @name         : name of the directory listing entry.
- * @file_path    : file path of the directory listing entry.
- * @is_dir       : is the directory listing a directory?
- * @include_dirs : include directories as part of the finished directory listing?
- * @list         : pointer to directory listing.
- * @ext_list     : pointer to allowed file extensions listing.
- * @file_ext     : file extension of the directory listing entry.
+ * @name               : name of the directory listing entry.
+ * @file_path          : file path of the directory listing entry.
+ * @is_dir             : is the directory listing a directory?
+ * @include_dirs       : include directories as part of the finished directory listing?
+ * @include_compressed : include compressed files, even when not part of ext_list.
+ * @list               : pointer to directory listing.
+ * @ext_list           : pointer to allowed file extensions listing.
+ * @file_ext           : file extension of the directory listing entry.
  *
  * Parses a directory listing.
  *
@@ -119,7 +120,7 @@ static bool dirent_is_directory(const char *path)
  * continue to the next entry in the directory listing.
  **/
 static int parse_dir_entry(const char *name, char *file_path,
-      bool is_dir, bool include_dirs,
+      bool is_dir, bool include_dirs, bool include_compressed,
       struct string_list *list, struct string_list *ext_list,
       const char *file_ext)
 {
@@ -145,6 +146,9 @@ static int parse_dir_entry(const char *name, char *file_path,
    if (!is_compressed_file && !is_dir && ext_list && !supported_by_core)
       return 1;
 
+   if (!include_compressed && !supported_by_core)
+      return 1;
+
    if (is_dir)
       attr.i = RARCH_DIRECTORY;
    if (is_compressed_file)
@@ -168,9 +172,10 @@ static int parse_dir_entry(const char *name, char *file_path,
 
 /**
  * dir_list_new:
- * @dir          : directory path.
- * @ext          : allowed extensions of file directory entries to include.
- * @include_dirs : include directories as part of the finished directory listing?
+ * @dir                : directory path.
+ * @ext                : allowed extensions of file directory entries to include.
+ * @include_dirs       : include directories as part of the finished directory listing?
+ * @include_compressed : Include compressed files, even if not part of ext.
  *
  * Create a directory listing.
  *
@@ -178,7 +183,7 @@ static int parse_dir_entry(const char *name, char *file_path,
  * NULL in case of error. Has to be freed manually.
  **/
 struct string_list *dir_list_new(const char *dir,
-      const char *ext, bool include_dirs)
+      const char *ext, bool include_dirs, bool include_compressed)
 {
    NSArray *entries = NULL;
    char path_buf[PATH_MAX_LENGTH] = {0};
@@ -207,7 +212,7 @@ struct string_list *dir_list_new(const char *dir,
       is_dir = dirent_is_directory(file_path);
 
       ret = parse_dir_entry([name UTF8String], file_path, is_dir,
-            include_dirs, list, ext_list, file_ext);
+            include_dirs, include_compressed, list, ext_list, file_ext);
 
       if (ret == -1)
          goto error;

--- a/libretro-common/include/file/dir_list.h
+++ b/libretro-common/include/file/dir_list.h
@@ -31,9 +31,10 @@ extern "C" {
 
 /**
  * dir_list_new:
- * @dir          : directory path.
- * @ext          : allowed extensions of file directory entries to include.
- * @include_dirs : include directories as part of the finished directory listing?
+ * @dir                : directory path.
+ * @ext                : allowed extensions of file directory entries to include.
+ * @include_dirs       : include directories as part of the finished directory listing?
+ * @include_compressed : include compressed files, even when not part of ext.
  *
  * Create a directory listing.
  *
@@ -41,7 +42,7 @@ extern "C" {
  * NULL in case of error. Has to be freed manually.
  **/
 struct string_list *dir_list_new(const char *dir, const char *ext,
-      bool include_dirs);
+      bool include_dirs, bool include_compressed);
 
 /**
  * dir_list_sort:

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -2118,7 +2118,7 @@ static int menu_displaylist_parse_generic(menu_displaylist_info_t *info, bool *n
    else
       str_list = dir_list_new(info->path,
             filter_ext ? info->exts : NULL,
-            true);
+            true, true);
 
    if (hash_label == MENU_LABEL_SCAN_DIRECTORY)
       menu_list_push(info->list,


### PR DESCRIPTION
Do not try to load in compressed archives unless we expect them.
Fixes hang in input autodetect where it tried to parse a zip file as an
archive.