### PR TITLE
(CTR/3DS) improve memory management.

### DIFF
--- a/Makefile.ctr
+++ b/Makefile.ctr
@@ -18,10 +18,9 @@ APP_AUDIO         = ctr/silent.wav
 APP_CIA_RSF       = ctr/tools/template-cia.rsf
 APP_3DS_RSF       = ctr/tools/template-3ds.rsf
 
-CTR_STACK_SIZE   = 0x100000
-CTR_HEAP_SIZE    = 0x3400000
-CTR_PROG_MEMSIZE = 0x500000
 
+CTR_STACK_SIZE        = 0x100000
+CTR_LINEAR_HEAP_SIZE  = 0x600000
 
 include ctr/Makefile.cores
 
@@ -275,14 +274,9 @@ ifneq ($(CTR_STACK_SIZE),)
    CFLAGS += -DCTR_STACK_SIZE=$(CTR_STACK_SIZE)
 endif
 
-ifneq ($(CTR_HEAP_SIZE),)
-   CFLAGS += -DCTR_HEAP_SIZE=$(CTR_HEAP_SIZE)
+ifneq ($(CTR_LINEAR_HEAP_SIZE),)
+   CFLAGS += -DCTR_LINEAR_HEAP_SIZE=$(CTR_LINEAR_HEAP_SIZE)
 endif
-
-ifneq ($(CTR_PROG_MEMSIZE),)
-   CFLAGS += -DCTR_PROG_MEMSIZE=$(CTR_PROG_MEMSIZE)
-endif
-
 
 CFLAGS += -I. -Ideps/zlib -Ideps/7zip -Ilibretro-common/include
 

--- a/frontend/drivers/platform_ctr.c
+++ b/frontend/drivers/platform_ctr.c
@@ -43,22 +43,11 @@ void wait_for_input(void);
 #define DEBUG_HOLD() do{printf("%s@%s:%d.\n",__FUNCTION__, __FILE__, __LINE__);fflush(stdout);wait_for_input();}while(0)
 
 #ifndef CTR_STACK_SIZE
-#define CTR_STACK_SIZE        0x100000
+#define CTR_STACK_SIZE         0x100000
 #endif
 
-#ifndef CTR_HEAP_SIZE
-#define CTR_HEAP_SIZE         0x3000000
-#endif
-
-#ifndef CTR_PROG_MEMSIZE
-#define CTR_PROG_MEMSIZE      0x800000
-#endif
-
-#define CTR_MEMORY_MAX        0x04000000
-
-
-#if CTR_MEMORY_MAX < (CTR_PROG_MEMSIZE + CTR_HEAP_SIZE + CTR_STACK_SIZE)
-#error
+#ifndef CTR_LINEAR_HEAP_SIZE
+#define CTR_LINEAR_HEAP_SIZE   0x600000
 #endif
 
 int __stacksize__ = CTR_STACK_SIZE;
@@ -77,9 +66,11 @@ void __libc_fini_array(void);
 
 void __system_allocateHeaps() {
 	u32 tmp=0;
+   int64_t mem_used;
+   svcGetSystemInfo(&mem_used, 0, 1);
 
-   __heap_size_local = CTR_HEAP_SIZE;
-   __linear_heap_size_local = CTR_MEMORY_MAX - (CTR_PROG_MEMSIZE + CTR_HEAP_SIZE + CTR_STACK_SIZE);
+   __linear_heap_size_local = CTR_LINEAR_HEAP_SIZE;
+   __heap_size_local        = (0x4000000 - mem_used - __linear_heap_size_local - 0x1000) & 0xFFFFF000;
 
 	// Allocate the application heap
 	__heapBase = 0x08000000;


### PR DESCRIPTION
only stacksize and linear heap size need to be specified now.
regular heap size will be determined automatically.