### PR TITLE
(CTR/3DS) no longer need stripped ELF files.

### DIFF
--- a/Makefile.ctr
+++ b/Makefile.ctr
@@ -383,18 +383,13 @@ $(TARGET).bnr: $(APP_BANNER) $(APP_AUDIO)
 $(TARGET).icn: $(APP_ICON)
 	$(BANNERTOOL) makesmdh -s "$(APP_TITLE)" -l "$(APP_TITLE)" -p "$(APP_AUTHOR)" -i $(APP_ICON) -o $@
 
-$(TARGET)_stripped.elf: $(TARGET).elf
-	cp $(TARGET).elf $@
-	$(STRIP) $@
-
-$(TARGET).cia: $(TARGET)_stripped.elf $(TARGET).bnr $(TARGET).icn
-	$(MAKEROM) -f cia -o $@ -rsf $(APP_CIA_RSF) -target t -exefslogo -elf $(TARGET)_stripped.elf -icon $(TARGET).icn -banner $(TARGET).bnr -DAPP_TITLE="$(APP_TITLE)" -DAPP_PRODUCT_CODE="$(APP_PRODUCT_CODE)" -DAPP_UNIQUE_ID=$(APP_UNIQUE_ID)
+$(TARGET).cia: $(TARGET).elf $(TARGET).bnr $(TARGET).icn
+	$(MAKEROM) -f cia -o $@ -rsf $(APP_CIA_RSF) -target t -exefslogo -elf $(TARGET).elf -icon $(TARGET).icn -banner $(TARGET).bnr -DAPP_TITLE="$(APP_TITLE)" -DAPP_PRODUCT_CODE="$(APP_PRODUCT_CODE)" -DAPP_UNIQUE_ID=$(APP_UNIQUE_ID)
 
 clean:
 	rm -f $(OBJS)
 	rm -f $(TARGET).3dsx
 	rm -f $(TARGET).elf
-	rm -f $(TARGET)_stripped.elf
 	rm -f $(TARGET).cia
 	rm -f $(TARGET).bnr
 	rm -f $(TARGET).icn


### PR DESCRIPTION
Recent builds of makerom support unstripped ELFs. See https://github.com/profi200/Project_CTR/commit/4d530c5d70c369d2dc1685226454478c50d00906