### PR TITLE
(CTR/3DS) add ir:rst to ServiceAccessControl, needed by the n3DS HID

### DIFF
--- a/ctr/tools/template-cia.rsf
+++ b/ctr/tools/template-cia.rsf
@@ -200,6 +200,7 @@ AccessControlInfo:
    - ldr:ro
    - ir:USER
    - ir:u
+   - ir:rst
    - csnd:SND
   
    


### PR DESCRIPTION
hardware.