### PR TITLE
(CTR/3DS) allow access for more RAM.

### DIFF
--- a/Makefile.ctr
+++ b/Makefile.ctr
@@ -20,6 +20,9 @@ APP_CIA_RSF       = ctr/tools/template-cia.rsf
 APP_3DS_RSF       = ctr/tools/template-3ds.rsf
 
 
+O3DS_80MB_APPMEM = 0
+
+
 ifeq ($(BIG_STACK),1)
 CTR_STACK_SIZE        = 0x400000
 else
@@ -28,6 +31,15 @@ endif
 CTR_LINEAR_HEAP_SIZE  = 0x600000
 
 include ctr/Makefile.cores
+
+
+ifeq ($(O3DS_80MB_APPMEM), 1)
+APP_SYSTEM_MODE     = 3
+else
+APP_SYSTEM_MODE     = 0
+endif
+
+APP_SYSTEM_MODE_EXT = 6
 
 
 OBJS :=
@@ -394,7 +406,9 @@ $(TARGET)_stripped.elf: $(TARGET).elf
 	$(STRIP) $@
 
 $(TARGET).cia: $(TARGET)_stripped.elf $(TARGET).bnr $(TARGET).icn $(APP_CIA_RSF)
-	$(MAKEROM) -f cia -o $@ -rsf $(APP_CIA_RSF) -target t -exefslogo -elf $(TARGET)_stripped.elf -icon $(TARGET).icn -banner $(TARGET).bnr -DAPP_TITLE="$(APP_TITLE)" -DAPP_PRODUCT_CODE="$(APP_PRODUCT_CODE)" -DAPP_UNIQUE_ID=$(APP_UNIQUE_ID)
+	$(MAKEROM) -f cia -o $@ -rsf $(APP_CIA_RSF) -target t -exefslogo -elf $(TARGET)_stripped.elf -icon $(TARGET).icn\
+              -banner $(TARGET).bnr -DAPP_TITLE="$(APP_TITLE)" -DAPP_PRODUCT_CODE="$(APP_PRODUCT_CODE)" -DAPP_UNIQUE_ID=$(APP_UNIQUE_ID)\
+              -DAPP_SYSTEM_MODE=$(APP_SYSTEM_MODE) -DAPP_SYSTEM_MODE_EXT=$(APP_SYSTEM_MODE_EXT)
 
 clean:
 	rm -f $(OBJS)

--- a/ctr/Makefile.cores
+++ b/ctr/Makefile.cores
@@ -159,6 +159,7 @@ else ifeq ($(LIBRETRO), fb_alpha_neo)
 	APP_ICON          = ctr/fb_alpha_neo.png
 	#APP_BANNER        = ctr/libretro_banner.png
 	#APP_AUDIO         = ctr/silent.wav
+   O3DS_80MB_APPMEM  = 1
 
 else ifeq ($(LIBRETRO), fb_alpha_cps1)
 	APP_TITLE         = Final Burn Alpha - CPS-1
@@ -179,6 +180,7 @@ else ifeq ($(LIBRETRO), fb_alpha_cps2)
 	APP_ICON          = ctr/fb_alpha_cps2.png
 	#APP_BANNER        = ctr/libretro_banner.png
 	#APP_AUDIO         = ctr/silent.wav
+   O3DS_80MB_APPMEM  = 1
 
 else ifeq ($(LIBRETRO), catsfc_plus)
 	APP_TITLE         = CATSFC Plus Libretro

--- a/ctr/Makefile.cores
+++ b/ctr/Makefile.cores
@@ -159,7 +159,7 @@ else ifeq ($(LIBRETRO), fb_alpha_neo)
 	APP_ICON          = ctr/fb_alpha_neo.png
 	#APP_BANNER        = ctr/libretro_banner.png
 	#APP_AUDIO         = ctr/silent.wav
-   O3DS_80MB_APPMEM  = 1
+	O3DS_80MB_APPMEM  = 1
 
 else ifeq ($(LIBRETRO), fb_alpha_cps1)
 	APP_TITLE         = Final Burn Alpha - CPS-1
@@ -180,7 +180,7 @@ else ifeq ($(LIBRETRO), fb_alpha_cps2)
 	APP_ICON          = ctr/fb_alpha_cps2.png
 	#APP_BANNER        = ctr/libretro_banner.png
 	#APP_AUDIO         = ctr/silent.wav
-   O3DS_80MB_APPMEM  = 1
+	O3DS_80MB_APPMEM  = 1
 
 else ifeq ($(LIBRETRO), catsfc_plus)
 	APP_TITLE         = CATSFC Plus Libretro

--- a/ctr/tools/template-cia.rsf
+++ b/ctr/tools/template-cia.rsf
@@ -92,6 +92,8 @@ AccessControlInfo:
   MaxCpu                        : 0x9E # Default
   CpuSpeed                      : 804mhz
   EnableL2Cache                 : true
+  SystemMode                    : $(APP_SYSTEM_MODE)
+  SystemModeExt                 : $(APP_SYSTEM_MODE_EXT)
   
   DisableDebug                  : false
   EnableForceDebug              : false

--- a/frontend/drivers/platform_ctr.c
+++ b/frontend/drivers/platform_ctr.c
@@ -43,6 +43,8 @@ void wait_for_input(void);
 
 #define DEBUG_HOLD() do{printf("%s@%s:%d.\n",__FUNCTION__, __FILE__, __LINE__);fflush(stdout);wait_for_input();}while(0)
 
+#define CTR_APPMEMALLOC_PTR ((u32*)0x1FF80040)
+
 #ifndef CTR_STACK_SIZE
 #define CTR_STACK_SIZE         0x100000
 #endif
@@ -68,10 +70,11 @@ void __libc_fini_array(void);
 void __system_allocateHeaps() {
 	u32 tmp=0;
    int64_t mem_used;
+   u32 app_memory = *CTR_APPMEMALLOC_PTR;
    svcGetSystemInfo(&mem_used, 0, 1);
 
    __linear_heap_size_local = CTR_LINEAR_HEAP_SIZE;
-   __heap_size_local        = (0x4000000 - mem_used - __linear_heap_size_local - 0x1000) & 0xFFFFF000;
+   __heap_size_local        = (app_memory - mem_used - __linear_heap_size_local - 0x10000) & 0xFFFFF000;
 
 	// Allocate the application heap
 	__heapBase = 0x08000000;


### PR DESCRIPTION
124MB are used by default for n3DS.
80MB can be used on o3DS with a build option.
.cia builds only.