### PR TITLE
Preparation for the menu API

### DIFF
--- a/cheats.c
+++ b/cheats.c
@@ -68,12 +68,12 @@ void cheat_manager_apply_cheats(cheat_manager_t *handle)
    if (!handle)
       return;
 
-   pretro_cheat_reset();
+   core.retro_cheat_reset();
 
    for (i = 0; i < handle->size; i++)
    {
       if (handle->cheats[i].state)
-         pretro_cheat_set(idx++, true, handle->cheats[i].code);
+         core.retro_cheat_set(idx++, true, handle->cheats[i].code);
    }
 }
 

--- a/command_event.c
+++ b/command_event.c
@@ -112,12 +112,12 @@ static void event_init_autosave(void)
       const char *path = global->savefiles->elems[i].data;
       unsigned    type = global->savefiles->elems[i].attr.i;
 
-      if (pretro_get_memory_size(type) <= 0)
+      if (core.retro_get_memory_size(type) <= 0)
          continue;
 
       global->autosave.list[i] = autosave_new(path,
-            pretro_get_memory_data(type),
-            pretro_get_memory_size(type),
+            core.retro_get_memory_data(type),
+            core.retro_get_memory_size(type),
             settings->autosave_interval);
 
       if (!global->autosave.list[i])
@@ -513,7 +513,7 @@ static void event_init_controllers(void)
       {
          case RETRO_DEVICE_NONE:
             RARCH_LOG("Disconnecting device from port %u.\n", i + 1);
-            pretro_set_controller_port_device(i, device);
+            core.retro_set_controller_port_device(i, device);
             break;
          case RETRO_DEVICE_JOYPAD:
             break;
@@ -523,7 +523,7 @@ static void event_init_controllers(void)
              * cores needlessly. */
             RARCH_LOG("Connecting %s (ID: %u) to port %u.\n", ident,
                   device, i + 1);
-            pretro_set_controller_port_device(i, device);
+            core.retro_set_controller_port_device(i, device);
             break;
       }
    }
@@ -534,8 +534,8 @@ static void event_deinit_core(bool reinit)
    global_t *global     = global_get_ptr();
    settings_t *settings = config_get_ptr();
 
-   pretro_unload_game();
-   pretro_deinit();
+   core.retro_unload_game();
+   core.retro_deinit();
 
    if (reinit)
       event_command(EVENT_CMD_DRIVERS_DEINIT);
@@ -738,7 +738,7 @@ static bool event_init_core(void)
    /* reset video format to libretro's default */
    video_driver_set_pixel_format(RETRO_PIXEL_FORMAT_0RGB1555);
 
-   pretro_set_environment(rarch_environment_cb);
+   core.retro_set_environment(rarch_environment_cb);
 
    /* auto-remap: apply remap files */
    if(settings->auto_remaps_enable)
@@ -749,7 +749,7 @@ static bool event_init_core(void)
       set_paths_redirect(global->name.base);
 
    rarch_ctl(RARCH_ACTION_STATE_VERIFY_API_VERSION, NULL);
-   pretro_init();
+   core.retro_init();
 
    global->sram.use = (global->inited.core.type == CORE_TYPE_PLAIN) &&
       !global->inited.core.no_content;
@@ -970,7 +970,7 @@ static void event_main_state(unsigned cmd)
    else
       strlcpy(path, global->name.savestate, sizeof(path));
 
-   if (pretro_serialize_size())
+   if (core.retro_serialize_size())
    {
       switch (cmd)
       {
@@ -1115,7 +1115,7 @@ bool event_command(enum event_command cmd)
       case EVENT_CMD_RESET:
          RARCH_LOG("%s.\n", msg_hash_to_str(MSG_RESET));
          rarch_main_msg_queue_push_new(MSG_RESET, 1, 120, true);
-         pretro_reset();
+         core.retro_reset();
 
          /* bSNES since v073r01 resets controllers to JOYPAD
           * after a reset, so just enforce it here. */

--- a/content.c
+++ b/content.c
@@ -150,7 +150,7 @@ bool save_state(const char *path)
 {
    bool ret    = false;
    void *data  = NULL;
-   size_t size = pretro_serialize_size();
+   size_t size = core.retro_serialize_size();
 
    RARCH_LOG("%s: \"%s\".\n",
          msg_hash_to_str(MSG_SAVING_STATE),
@@ -168,7 +168,7 @@ bool save_state(const char *path)
          msg_hash_to_str(MSG_STATE_SIZE),
          (int)size,
          msg_hash_to_str(MSG_BYTES));
-   ret = pretro_serialize(data, size);
+   ret = core.retro_serialize(data, size);
 
    if (ret)
       ret = retro_write_file(path, data, size);
@@ -236,7 +236,7 @@ bool load_state(const char *path)
    }
 
    for (i = 0; i < num_blocks; i++)
-      blocks[i].size = pretro_get_memory_size(blocks[i].type);
+      blocks[i].size = core.retro_get_memory_size(blocks[i].type);
 
    for (i = 0; i < num_blocks; i++)
       if (blocks[i].size)
@@ -247,20 +247,20 @@ bool load_state(const char *path)
    {
       if (blocks[i].data)
       {
-         const void *ptr = pretro_get_memory_data(blocks[i].type);
+         const void *ptr = core.retro_get_memory_data(blocks[i].type);
          if (ptr)
             memcpy(blocks[i].data, ptr, blocks[i].size);
       }
    }
 
-   ret = pretro_unserialize(buf, size);
+   ret = core.retro_unserialize(buf, size);
 
    /* Flush back. */
    for (i = 0; i < num_blocks; i++)
    {
       if (blocks[i].data)
       {
-         void *ptr = pretro_get_memory_data(blocks[i].type);
+         void *ptr = core.retro_get_memory_data(blocks[i].type);
          if (ptr)
             memcpy(ptr, blocks[i].data, blocks[i].size);
       }
@@ -285,8 +285,8 @@ void load_ram_file(const char *path, int type)
    ssize_t rc;
    bool ret    = false;
    void *buf   = NULL;
-   size_t size = pretro_get_memory_size(type);
-   void *data  = pretro_get_memory_data(type);
+   size_t size = core.retro_get_memory_size(type);
+   void *data  = core.retro_get_memory_data(type);
 
    if (size == 0 || !data)
       return;
@@ -326,8 +326,8 @@ void load_ram_file(const char *path, int type)
  */
 void save_ram_file(const char *path, int type)
 {
-   size_t size = pretro_get_memory_size(type);
-   void *data  = pretro_get_memory_data(type);
+   size_t size = core.retro_get_memory_size(type);
+   void *data  = core.retro_get_memory_data(type);
 
    if (!data)
       return;
@@ -508,9 +508,9 @@ static bool load_content(const struct retro_subsystem_info *special,
    }
 
    if (special)
-      ret = pretro_load_game_special(special->id, info, content->size);
+      ret = core.retro_load_game_special(special->id, info, content->size);
    else
-      ret = pretro_load_game(*content->elems[0].data ? info : NULL);
+      ret = core.retro_load_game(*content->elems[0].data ? info : NULL);
 
    if (!ret)
       RARCH_ERR("%s.\n", msg_hash_to_str(MSG_FAILED_TO_LOAD_CONTENT));

--- a/dynamic.c
+++ b/dynamic.c
@@ -42,63 +42,26 @@
 #ifdef HAVE_DYNAMIC
 #define SYMBOL(x) do { \
    function_t func = dylib_proc(lib_handle, #x); \
-   memcpy(&p##x, &func, sizeof(func)); \
-   if (p##x == NULL) { RARCH_ERR("Failed to load symbol: \"%s\"\n", #x); rarch_fail(1, "init_libretro_sym()"); } \
+   memcpy(&core.x, &func, sizeof(func)); \
+   if (core.x == NULL) { RARCH_ERR("Failed to load symbol: \"%s\"\n", #x); rarch_fail(1, "init_libretro_sym()"); } \
 } while (0)
 
 static dylib_t lib_handle;
 #else
-#define SYMBOL(x) p##x = x
+#define SYMBOL(x) core.x = x
 #endif
 
-#define SYMBOL_DUMMY(x) p##x = libretro_dummy_##x
+#define SYMBOL_DUMMY(x) core.x = libretro_dummy_##x
 
 #ifdef HAVE_FFMPEG
-#define SYMBOL_FFMPEG(x) p##x = libretro_ffmpeg_##x
+#define SYMBOL_FFMPEG(x) core.x = libretro_ffmpeg_##x
 #endif
 
 #ifdef HAVE_IMAGEVIEWER
-#define SYMBOL_IMAGEVIEWER(x) p##x = libretro_imageviewer_##x
+#define SYMBOL_IMAGEVIEWER(x) core.x = libretro_imageviewer_##x
 #endif
 
-void (*pretro_init)(void);
-void (*pretro_deinit)(void);
-
-unsigned (*pretro_api_version)(void);
-
-void (*pretro_get_system_info)(struct retro_system_info*);
-void (*pretro_get_system_av_info)(struct retro_system_av_info*);
-
-void (*pretro_set_environment)(retro_environment_t);
-void (*pretro_set_video_refresh)(retro_video_refresh_t);
-void (*pretro_set_audio_sample)(retro_audio_sample_t);
-void (*pretro_set_audio_sample_batch)(retro_audio_sample_batch_t);
-void (*pretro_set_input_poll)(retro_input_poll_t);
-void (*pretro_set_input_state)(retro_input_state_t);
-
-void (*pretro_set_controller_port_device)(unsigned, unsigned);
-
-void (*pretro_reset)(void);
-void (*pretro_run)(void);
-
-size_t (*pretro_serialize_size)(void);
-bool (*pretro_serialize)(void*, size_t);
-bool (*pretro_unserialize)(const void*, size_t);
-
-void (*pretro_cheat_reset)(void);
-void (*pretro_cheat_set)(unsigned, bool, const char*);
-
-bool (*pretro_load_game)(const struct retro_game_info*);
-bool (*pretro_load_game_special)(unsigned,
-      const struct retro_game_info*, size_t);
-
-void (*pretro_unload_game)(void);
-
-unsigned (*pretro_get_region)(void);
-
-void *(*pretro_get_memory_data)(unsigned);
-size_t (*pretro_get_memory_size)(unsigned);
-
+struct retro_core_t core;
 static bool ignore_environment_cb;
 
 #ifdef HAVE_DYNAMIC
@@ -495,7 +458,7 @@ void libretro_get_current_core_pathname(char *name, size_t size)
    if (size == 0)
       return;
 
-   pretro_get_system_info(&info);
+   core.retro_get_system_info(&info);
    id = info.library_name ? info.library_name : 
       msg_hash_to_str(MSG_UNKNOWN);
 
@@ -555,31 +518,31 @@ void uninit_libretro_sym(void)
    lib_handle = NULL;
 #endif
 
-   pretro_init = NULL;
-   pretro_deinit = NULL;
-   pretro_api_version = NULL;
-   pretro_get_system_info = NULL;
-   pretro_get_system_av_info = NULL;
-   pretro_set_environment = NULL;
-   pretro_set_video_refresh = NULL;
-   pretro_set_audio_sample = NULL;
-   pretro_set_audio_sample_batch = NULL;
-   pretro_set_input_poll = NULL;
-   pretro_set_input_state = NULL;
-   pretro_set_controller_port_device = NULL;
-   pretro_reset = NULL;
-   pretro_run = NULL;
-   pretro_serialize_size = NULL;
-   pretro_serialize = NULL;
-   pretro_unserialize = NULL;
-   pretro_cheat_reset = NULL;
-   pretro_cheat_set = NULL;
-   pretro_load_game = NULL;
-   pretro_load_game_special = NULL;
-   pretro_unload_game = NULL;
-   pretro_get_region = NULL;
-   pretro_get_memory_data = NULL;
-   pretro_get_memory_size = NULL;
+   core.retro_init = NULL;
+   core.retro_deinit = NULL;
+   core.retro_api_version = NULL;
+   core.retro_get_system_info = NULL;
+   core.retro_get_system_av_info = NULL;
+   core.retro_set_environment = NULL;
+   core.retro_set_video_refresh = NULL;
+   core.retro_set_audio_sample = NULL;
+   core.retro_set_audio_sample_batch = NULL;
+   core.retro_set_input_poll = NULL;
+   core.retro_set_input_state = NULL;
+   core.retro_set_controller_port_device = NULL;
+   core.retro_reset = NULL;
+   core.retro_run = NULL;
+   core.retro_serialize_size = NULL;
+   core.retro_serialize = NULL;
+   core.retro_unserialize = NULL;
+   core.retro_cheat_reset = NULL;
+   core.retro_cheat_set = NULL;
+   core.retro_load_game = NULL;
+   core.retro_load_game_special = NULL;
+   core.retro_unload_game = NULL;
+   core.retro_get_region = NULL;
+   core.retro_get_memory_data = NULL;
+   core.retro_get_memory_size = NULL;
 
    rarch_system_info_free();
 

--- a/dynamic.h
+++ b/dynamic.h
@@ -125,56 +125,35 @@ const struct retro_controller_description *
  **/
 bool rarch_environment_cb(unsigned cmd, void *data);
 
-extern void (*pretro_init)(void);
+struct retro_core_t {
+   void (*retro_init)(void);
+   void (*retro_deinit)(void);
+   unsigned (*retro_api_version)(void);
+   void (*retro_get_system_info)(struct retro_system_info*);
+   void (*retro_get_system_av_info)(struct retro_system_av_info*);
+   void (*retro_set_environment)(retro_environment_t);
+   void (*retro_set_video_refresh)(retro_video_refresh_t);
+   void (*retro_set_audio_sample)(retro_audio_sample_t);
+   void (*retro_set_audio_sample_batch)(retro_audio_sample_batch_t);
+   void (*retro_set_input_poll)(retro_input_poll_t);
+   void (*retro_set_input_state)(retro_input_state_t);
+   void (*retro_set_controller_port_device)(unsigned, unsigned);
+   void (*retro_reset)(void); 
+   void (*retro_run)(void);
+   size_t (*retro_serialize_size)(void);
+   bool (*retro_serialize)(void*, size_t);
+   bool (*retro_unserialize)(const void*, size_t);
+   void (*retro_cheat_reset)(void);
+   void (*retro_cheat_set)(unsigned, bool, const char*);
+   bool (*retro_load_game)(const struct retro_game_info*);
+   bool (*retro_load_game_special)(unsigned, const struct retro_game_info*, size_t);
+   void (*retro_unload_game)(void);
+   unsigned (*retro_get_region)(void);
+   void *(*retro_get_memory_data)(unsigned);
+   size_t (*retro_get_memory_size)(unsigned);
+};
 
-extern void (*pretro_deinit)(void);
-
-extern unsigned (*pretro_api_version)(void);
-
-extern void (*pretro_get_system_info)(struct retro_system_info*);
-
-extern void (*pretro_get_system_av_info)(struct retro_system_av_info*);
-
-extern void (*pretro_set_environment)(retro_environment_t);
-
-extern void (*pretro_set_video_refresh)(retro_video_refresh_t);
-
-extern void (*pretro_set_audio_sample)(retro_audio_sample_t);
-
-extern void (*pretro_set_audio_sample_batch)(retro_audio_sample_batch_t);
-
-extern void (*pretro_set_input_poll)(retro_input_poll_t);
-
-extern void (*pretro_set_input_state)(retro_input_state_t);
-
-extern void (*pretro_set_controller_port_device)(unsigned, unsigned);
-
-extern void (*pretro_reset)(void); 
-
-extern void (*pretro_run)(void);
-
-extern size_t (*pretro_serialize_size)(void);
-
-extern bool (*pretro_serialize)(void*, size_t);
-
-extern bool (*pretro_unserialize)(const void*, size_t);
-
-extern void (*pretro_cheat_reset)(void);
-
-extern void (*pretro_cheat_set)(unsigned, bool, const char*);
-
-extern bool (*pretro_load_game)(const struct retro_game_info*);
-
-extern bool (*pretro_load_game_special)(unsigned,
-      const struct retro_game_info*, size_t);
-
-extern void (*pretro_unload_game)(void);
-
-extern unsigned (*pretro_get_region)(void);
-
-extern void *(*pretro_get_memory_data)(unsigned);
-
-extern size_t (*pretro_get_memory_size)(unsigned);
+extern struct retro_core_t core;
 
 /**
  * init_libretro_sym:

--- a/gfx/drivers_shader/shader_glsl.c
+++ b/gfx/drivers_shader/shader_glsl.c
@@ -885,7 +885,7 @@ static bool gl_glsl_init(void *data, const char *path)
    {
       struct state_tracker_info info = {0};
 
-      info.wram      = (uint8_t*)pretro_get_memory_data(RETRO_MEMORY_SYSTEM_RAM);
+      info.wram      = (uint8_t*)core.retro_get_memory_data(RETRO_MEMORY_SYSTEM_RAM);
       info.info      = glsl->shader->variable;
       info.info_elem = glsl->shader->variables;
 

--- a/gfx/video_state_python.c
+++ b/gfx/video_state_python.c
@@ -33,7 +33,7 @@ static PyObject* py_read_wram(PyObject *self, PyObject *args)
    unsigned addr;
    size_t   max;
    const uint8_t *data = (const uint8_t*)
-      pretro_get_memory_data(RETRO_MEMORY_SYSTEM_RAM);
+      core.retro_get_memory_data(RETRO_MEMORY_SYSTEM_RAM);
 
    (void)self;
 
@@ -43,7 +43,7 @@ static PyObject* py_read_wram(PyObject *self, PyObject *args)
       return Py_None;
    }
 
-   max = pretro_get_memory_size(RETRO_MEMORY_SYSTEM_RAM);
+   max = core.retro_get_memory_size(RETRO_MEMORY_SYSTEM_RAM);
 
    if (!PyArg_ParseTuple(args, "I", &addr))
       return NULL;
@@ -62,7 +62,7 @@ static PyObject* py_read_vram(PyObject *self, PyObject *args)
    unsigned addr;
    size_t max;
    const uint8_t *data = (const uint8_t*)
-      pretro_get_memory_data(RETRO_MEMORY_VIDEO_RAM);
+      core.retro_get_memory_data(RETRO_MEMORY_VIDEO_RAM);
 
    (void)self;
 
@@ -72,7 +72,7 @@ static PyObject* py_read_vram(PyObject *self, PyObject *args)
       return Py_None;
    }
 
-   max = pretro_get_memory_size(RETRO_MEMORY_VIDEO_RAM);
+   max = core.retro_get_memory_size(RETRO_MEMORY_VIDEO_RAM);
 
    if (!PyArg_ParseTuple(args, "I", &addr))
       return NULL;

--- a/libretro_version_1.c
+++ b/libretro_version_1.c
@@ -258,11 +258,11 @@ void retro_init_libretro_cbs(void *data)
    (void)driver;
    (void)global;
 
-   pretro_set_video_refresh(video_frame);
-   pretro_set_audio_sample(audio_driver_sample);
-   pretro_set_audio_sample_batch(audio_driver_sample_batch);
-   pretro_set_input_state(input_state);
-   pretro_set_input_poll(input_poll);
+   core.retro_set_video_refresh(video_frame);
+   core.retro_set_audio_sample(audio_driver_sample);
+   core.retro_set_audio_sample_batch(audio_driver_sample_batch);
+   core.retro_set_input_state(input_state);
+   core.retro_set_input_poll(input_poll);
 
    retro_set_default_callbacks(cbs);
 
@@ -272,17 +272,17 @@ void retro_init_libretro_cbs(void *data)
 
    if (global->netplay.is_spectate)
    {
-      pretro_set_input_state(
+      core.retro_set_input_state(
             (global->netplay.is_client ?
              input_state_spectate_client : input_state_spectate)
             );
    }
    else
    {
-      pretro_set_video_refresh(video_frame_net);
-      pretro_set_audio_sample(audio_sample_net);
-      pretro_set_audio_sample_batch(audio_sample_batch_net);
-      pretro_set_input_state(input_state_net);
+      core.retro_set_video_refresh(video_frame_net);
+      core.retro_set_audio_sample(audio_sample_net);
+      core.retro_set_audio_sample_batch(audio_sample_batch_net);
+      core.retro_set_input_state(input_state_net);
    }
 #endif
 }
@@ -297,12 +297,12 @@ void retro_set_rewind_callbacks(void)
 {
    if (state_manager_frame_is_reversed())
    {
-      pretro_set_audio_sample(audio_driver_sample_rewind);
-      pretro_set_audio_sample_batch(audio_driver_sample_batch_rewind);
+      core.retro_set_audio_sample(audio_driver_sample_rewind);
+      core.retro_set_audio_sample_batch(audio_driver_sample_batch_rewind);
    }
    else
    {
-      pretro_set_audio_sample(audio_driver_sample);
-      pretro_set_audio_sample_batch(audio_driver_sample_batch);
+      core.retro_set_audio_sample(audio_driver_sample);
+      core.retro_set_audio_sample_batch(audio_driver_sample_batch);
    }
 }

--- a/menu/menu_display.c
+++ b/menu/menu_display.c
@@ -260,7 +260,7 @@ bool menu_display_ctl(enum menu_display_ctl_state state, void *data)
             {
                bool block_libretro_input = driver->block_libretro_input;
                driver->block_libretro_input = true;
-               pretro_run();
+               core.retro_run();
                driver->block_libretro_input = block_libretro_input;
                return true;
             }

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -699,7 +699,7 @@ static int setting_action_start_libretro_device_type(void *data)
    current_device = RETRO_DEVICE_JOYPAD;
 
    settings->input.libretro_device[port] = current_device;
-   pretro_set_controller_port_device(port, current_device);
+   core.retro_set_controller_port_device(port, current_device);
 
    return 0;
 }
@@ -849,7 +849,7 @@ static int setting_action_left_libretro_device_type(
       [(current_idx + types - 1) % types];
 
    settings->input.libretro_device[port] = current_device;
-   pretro_set_controller_port_device(port, current_device);
+   core.retro_set_controller_port_device(port, current_device);
 
    return 0;
 }
@@ -907,7 +907,7 @@ static int setting_action_right_libretro_device_type(
       [(current_idx + 1) % types];
 
    settings->input.libretro_device[port] = current_device;
-   pretro_set_controller_port_device(port, current_device);
+   core.retro_set_controller_port_device(port, current_device);
 
    return 0;
 }

--- a/movie.c
+++ b/movie.c
@@ -91,8 +91,8 @@ static bool init_playback(bsv_movie_t *handle, const char *path)
          return false;
       }
 
-      if (pretro_serialize_size() == state_size)
-         pretro_unserialize(handle->state, state_size);
+      if (core.retro_serialize_size() == state_size)
+         core.retro_unserialize(handle->state, state_size);
       else
          RARCH_WARN("Movie format seems to have a different serializer version. Will most likely fail.\n");
    }
@@ -119,7 +119,7 @@ static bool init_record(bsv_movie_t *handle, const char *path)
     * BSV1 in a HEX editor, big-endian. */
    header[MAGIC_INDEX]      = swap_if_little32(BSV_MAGIC);
    header[CRC_INDEX]        = swap_if_big32(global->content_crc);
-   state_size               = pretro_serialize_size();
+   state_size               = core.retro_serialize_size();
    header[STATE_SIZE_INDEX] = swap_if_big32(state_size);
 
    fwrite(header, 4, sizeof(uint32_t), handle->file);
@@ -133,7 +133,7 @@ static bool init_record(bsv_movie_t *handle, const char *path)
       if (!handle->state)
          return false;
 
-      pretro_serialize(handle->state, state_size);
+      core.retro_serialize(handle->state, state_size);
       fwrite(handle->state, 1, state_size, handle->file);
    }
 
@@ -246,7 +246,7 @@ void bsv_movie_frame_rewind(bsv_movie_t *handle)
          /* If recording, we simply reset
           * the starting point. Nice and easy. */
          fseek(handle->file, 4 * sizeof(uint32_t), SEEK_SET);
-         pretro_serialize(handle->state, handle->state_size);
+         core.retro_serialize(handle->state, handle->state_size);
          fwrite(handle->state, 1, handle->state_size, handle->file);
       }
       else

--- a/retroarch.c
+++ b/retroarch.c
@@ -1092,7 +1092,7 @@ void rarch_init_system_av_info(void)
 {
    struct retro_system_av_info *av_info = video_viewport_get_system_av_info();
 
-   pretro_get_system_av_info(av_info);
+   core.retro_get_system_av_info(av_info);
    event_command(EVENT_CMD_SET_FRAME_LIMIT);
 }
 
@@ -1404,10 +1404,10 @@ bool rarch_ctl(enum rarch_ctl_state state, void *data)
          }
          break;
       case RARCH_ACTION_STATE_VERIFY_API_VERSION:
-         RARCH_LOG("Version of libretro API: %u\n", pretro_api_version());
+         RARCH_LOG("Version of libretro API: %u\n", core.retro_api_version());
          RARCH_LOG("Compiled against API: %u\n",    RETRO_API_VERSION);
 
-         if (pretro_api_version() != RETRO_API_VERSION)
+         if (core.retro_api_version() != RETRO_API_VERSION)
             RARCH_WARN("%s\n", msg_hash_to_str(MSG_LIBRETRO_ABI_BREAK));
          break;
       case RARCH_ACTION_STATE_FILL_PATHNAMES:

--- a/rewind.c
+++ b/rewind.c
@@ -570,7 +570,7 @@ void init_rewind(void)
       return;
    }
 
-   global->rewind.size = pretro_serialize_size();
+   global->rewind.size = core.retro_serialize_size();
 
    if (!global->rewind.size)
    {
@@ -590,7 +590,7 @@ void init_rewind(void)
       RARCH_WARN("%s.\n", msg_hash_to_str(MSG_REWIND_INIT_FAILED));
 
    state_manager_push_where(global->rewind.state, &state);
-   pretro_serialize(state, global->rewind.size);
+   core.retro_serialize(state, global->rewind.size);
    state_manager_push_do(global->rewind.state);
 }
 

--- a/runloop.c
+++ b/runloop.c
@@ -193,7 +193,7 @@ static void check_rewind(settings_t *settings,
 
          rarch_main_msg_queue_push_new(MSG_REWINDING, 0,
                main_is_paused ? 1 : 30, true);
-         pretro_unserialize(buf, global->rewind.size);
+         core.retro_unserialize(buf, global->rewind.size);
 
          if (global->bsv.movie)
             bsv_movie_frame_rewind(global->bsv.movie);
@@ -218,7 +218,7 @@ static void check_rewind(settings_t *settings,
 
          rarch_perf_init(&rewind_serialize, "rewind_serialize");
          retro_perf_start(&rewind_serialize);
-         pretro_serialize(state, global->rewind.size);
+         core.retro_serialize(state, global->rewind.size);
          retro_perf_stop(&rewind_serialize);
 
          state_manager_push_do(global->rewind.state);
@@ -1026,7 +1026,7 @@ int rarch_main_iterate(unsigned *sleep_ms)
       retro_sleep(settings->video.frame_delay);
 
    /* Run libretro for one frame. */
-   pretro_run();
+   core.retro_run();
 
    for (i = 0; i < settings->input.max_users; i++)
    {

--- a/system.c
+++ b/system.c
@@ -66,7 +66,7 @@ void rarch_system_info_init(void)
 {
    rarch_system_info_t *system    = rarch_system_info_get_ptr();
 
-   pretro_get_system_info(&system->info);
+   core.retro_get_system_info(&system->info);
 
    if (!system->info.library_name)
       system->info.library_name = msg_hash_to_str(MSG_UNKNOWN);


### PR DESCRIPTION
@twinaphex this change only swaps the many `petro_*` function pointers for a variable of the new `retro_core_t` type, which is a structure containing all the function pointers.

All accesses via `pretro_*` are now done via `core.retro_*`, and RetroArch seems to work just fine with this change, which doesn't really change much.