### PR TITLE
Various changes

### DIFF
--- a/command_event.c
+++ b/command_event.c
@@ -1,6 +1,6 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2011-2015 - Daniel De Matteis
- * 
+ *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-
  *  ation, either version 3 of the License, or (at your option) any later version.
@@ -225,7 +225,7 @@ static void event_disk_control_set_eject(bool new_state, bool print_log)
    char msg[PATH_MAX_LENGTH] = {0};
    bool error                = false;
    rarch_system_info_t *info = rarch_system_info_get_ptr();
-   const struct retro_disk_control_callback *control = 
+   const struct retro_disk_control_callback *control =
       info ? (const struct retro_disk_control_callback*)&info->disk_control : NULL;
 
    if (!control || !control->get_num_images)
@@ -283,7 +283,7 @@ static void event_disk_control_set_index(unsigned idx)
    unsigned num_disks;
    char msg[PATH_MAX_LENGTH] = {0};
    rarch_system_info_t                      *info    = rarch_system_info_get_ptr();
-   const struct retro_disk_control_callback *control = 
+   const struct retro_disk_control_callback *control =
       info ? (const struct retro_disk_control_callback*)&info->disk_control : NULL;
    bool error = false;
 
@@ -549,14 +549,6 @@ static void event_deinit_core(bool reinit)
    if (reinit)
       event_command(EVENT_CMD_DRIVERS_DEINIT);
 
-   /* per-core saves: restore the original path so the config is not affected */
-   if(settings->sort_savefiles_enable)
-      strlcpy(global->dir.savefile, orig_savefile_dir,
-            sizeof(global->dir.savefile));
-   if(settings->sort_savestates_enable)
-      strlcpy(global->dir.savestate, orig_savestate_dir,
-            sizeof(global->dir.savestate));
-
   /* auto overrides: reload the original config */
    if(global->overrides_active)
    {
@@ -696,7 +688,7 @@ static bool event_init_content(void)
 
    /* No content to be loaded for dummy core,
     * just successfully exit. */
-   if (global->inited.core.type == CORE_TYPE_DUMMY) 
+   if (global->inited.core.type == CORE_TYPE_DUMMY)
       return true;
 
    if (!global->inited.core.no_content)
@@ -727,21 +719,13 @@ static bool event_init_core(void)
    driver_t *driver     = driver_get_ptr();
    settings_t *settings = config_get_ptr();
 
-   /* per-core saves: save the original path */
-   if(orig_savefile_dir[0] == '\0')
-      strlcpy(orig_savefile_dir, global->dir.savefile,
-            sizeof(orig_savefile_dir));
-   if(orig_savestate_dir[0] == '\0')
-      strlcpy(orig_savestate_dir, global->dir.savestate,
-            sizeof(orig_savestate_dir));
-
    /* auto overrides: apply overrides */
    if(settings->auto_overrides_enable)
    {
       if (config_load_override())
          global->overrides_active = true;
       else
-         global->overrides_active = false; 
+         global->overrides_active = false;
    }
 
    /* reset video format to libretro's default */
@@ -754,7 +738,7 @@ static bool event_init_core(void)
       config_load_remap();
 
    /* per-core saves: reset redirection paths */
-   if((settings->sort_savestates_enable || settings->sort_savefiles_enable) && !global->inited.core.no_content) 
+   if((settings->sort_savestates_enable || settings->sort_savefiles_enable) && !global->inited.core.no_content)
       set_paths_redirect(global->name.base);
 
    rarch_ctl(RARCH_ACTION_STATE_VERIFY_API_VERSION, NULL);
@@ -779,7 +763,7 @@ static bool event_save_auto_state(void)
    settings_t *settings = config_get_ptr();
    global_t   *global   = global_get_ptr();
 
-   if (!settings->savestate_auto_save || 
+   if (!settings->savestate_auto_save ||
          (global->inited.core.type == CORE_TYPE_DUMMY) ||
        global->inited.core.no_content)
        return false;
@@ -1090,7 +1074,7 @@ bool event_command(enum event_command cmd)
 #endif
          break;
       case EVENT_CMD_LOAD_STATE:
-         /* Immutable - disallow savestate load when 
+         /* Immutable - disallow savestate load when
           * we absolutely cannot change game state. */
          if (global->bsv.movie)
             return false;
@@ -1175,7 +1159,7 @@ bool event_command(enum event_command cmd)
          {
             const struct retro_hw_render_callback *hw_render =
                (const struct retro_hw_render_callback*)video_driver_callback();
-            const input_driver_t *input     = driver ? 
+            const input_driver_t *input     = driver ?
                (const input_driver_t*)driver->input : NULL;
 
             driver->video_cache_context     = hw_render->cache_context;
@@ -1611,7 +1595,7 @@ bool event_command(enum event_command cmd)
          if (!video_driver_has_windowed())
             return false;
 
-         /* If we go fullscreen we drop all drivers and 
+         /* If we go fullscreen we drop all drivers and
           * reinitialize to be safe. */
          settings->video.fullscreen = !settings->video.fullscreen;
          event_command(EVENT_CMD_REINIT);
@@ -1657,7 +1641,7 @@ bool event_command(enum event_command cmd)
       case EVENT_CMD_DISK_EJECT_TOGGLE:
          if (system && system->disk_control.get_num_images)
          {
-            const struct retro_disk_control_callback *control = 
+            const struct retro_disk_control_callback *control =
                (const struct retro_disk_control_callback*)
                &system->disk_control;
 
@@ -1672,7 +1656,7 @@ bool event_command(enum event_command cmd)
       case EVENT_CMD_DISK_NEXT:
          if (system && system->disk_control.get_num_images)
          {
-            const struct retro_disk_control_callback *control = 
+            const struct retro_disk_control_callback *control =
                (const struct retro_disk_control_callback*)
                &system->disk_control;
 
@@ -1692,7 +1676,7 @@ bool event_command(enum event_command cmd)
       case EVENT_CMD_DISK_PREV:
          if (system && system->disk_control.get_num_images)
          {
-            const struct retro_disk_control_callback *control = 
+            const struct retro_disk_control_callback *control =
                (const struct retro_disk_control_callback*)
                &system->disk_control;
 

--- a/config.def.h
+++ b/config.def.h
@@ -750,9 +750,9 @@ static char buildbot_server_url[] = "";
 static char buildbot_server_url[] = "http://buildbot.libretro.com/nightly/ios/latest/";
 #elif defined(OSX)
 #if defined(__x86_64__)
-static char buildbot_server_url[] = "http://buildbot.libretro.com/nightly/osx-x86_64/latest/";
+static char buildbot_server_url[] = "http://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/";
 #elif defined(__i386__) || defined(__i486__) || defined(__i686__)
-static char buildbot_server_url[] = "http://buildbot.libretro.com/nightly/osx-i386/latest/";
+static char buildbot_server_url[] = "http://bot.libretro.com/nightly/apple/osx/x86/latest/";
 #else
 static char buildbot_server_url[] = "http://buildbot.libretro.com/nightly/osx-ppc/latest/";
 #endif
@@ -875,4 +875,3 @@ static const struct retro_keybind retro_keybinds_rest[] = {
 #endif
 
 #endif
-

--- a/dynamic.c
+++ b/dynamic.c
@@ -88,13 +88,13 @@ static bool environ_cb_get_system_info(unsigned cmd, void *data)
  * @load_no_content              : If true, core should be able to auto-start
  *                                 without any content loaded.
  *
- * Sets environment callback in order to get statically known 
+ * Sets environment callback in order to get statically known
  * information from it.
  *
  * Fetched via environment callbacks instead of
  * retro_get_system_info(), as this info is part of extensions.
  *
- * Should only be called once right after core load to 
+ * Should only be called once right after core load to
  * avoid overwriting the "real" environ callback.
  *
  * For statically linked cores, pass retro_set_environment as argument.
@@ -120,7 +120,7 @@ static dylib_t libretro_get_system_info_lib(const char *path,
 {
    dylib_t lib = dylib_load(path);
    void (*proc)(struct retro_system_info*);
-   
+
    if (!lib)
       return NULL;
 
@@ -246,7 +246,7 @@ libretro_find_controller_description(
 /**
  * load_symbols:
  * @type                        : Type of core to be loaded.
- *                                If CORE_TYPE_DUMMY, will 
+ *                                If CORE_TYPE_DUMMY, will
  *                                load dummy symbols.
  *
  * Setup libretro callback symbols.
@@ -277,8 +277,8 @@ static void load_symbols(enum rarch_core_type type)
                rarch_fail(1, "init_libretro_sym()");
             }
 
-            /* Need to use absolute path for this setting. It can be 
-             * saved to content history, and a relative path would 
+            /* Need to use absolute path for this setting. It can be
+             * saved to content history, and a relative path would
              * break in that scenario. */
             path_resolve_realpath(settings->libretro,
                   sizeof(settings->libretro));
@@ -459,7 +459,7 @@ void libretro_get_current_core_pathname(char *name, size_t size)
       return;
 
    core.retro_get_system_info(&info);
-   id = info.library_name ? info.library_name : 
+   id = info.library_name ? info.library_name :
       msg_hash_to_str(MSG_UNKNOWN);
 
    if (!id || strlen(id) >= size)
@@ -484,7 +484,7 @@ void libretro_get_current_core_pathname(char *name, size_t size)
 /**
  * init_libretro_sym:
  * @type                        : Type of core to be loaded.
- *                                If CORE_TYPE_DUMMY, will 
+ *                                If CORE_TYPE_DUMMY, will
  *                                load dummy symbols.
  *
  * Initializes libretro symbols and
@@ -725,10 +725,10 @@ bool rarch_environment_cb(unsigned cmd, void *data)
          break;
 
       case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY:
-         *(const char**)data = *global->dir.savefile ?
-            global->dir.savefile : NULL;
+         *(const char**)data = *current_savefile_dir ?
+            current_savefile_dir : NULL;
          RARCH_LOG("Environ SAVE_DIRECTORY: \"%s\".\n",
-               global->dir.savefile);
+               current_savefile_dir);
          break;
 
       case RETRO_ENVIRONMENT_GET_USERNAME:
@@ -746,7 +746,7 @@ bool rarch_environment_cb(unsigned cmd, void *data)
 
       case RETRO_ENVIRONMENT_SET_PIXEL_FORMAT:
       {
-         enum retro_pixel_format pix_fmt = 
+         enum retro_pixel_format pix_fmt =
             *(const enum retro_pixel_format*)data;
 
          switch (pix_fmt)
@@ -860,7 +860,7 @@ bool rarch_environment_cb(unsigned cmd, void *data)
 
       case RETRO_ENVIRONMENT_SET_KEYBOARD_CALLBACK:
       {
-         const struct retro_keyboard_callback *info = 
+         const struct retro_keyboard_callback *info =
             (const struct retro_keyboard_callback*)data;
 
          RARCH_LOG("Environ SET_KEYBOARD_CALLBACK.\n");
@@ -871,7 +871,7 @@ bool rarch_environment_cb(unsigned cmd, void *data)
 
       case RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE:
          RARCH_LOG("Environ SET_DISK_CONTROL_INTERFACE.\n");
-         system->disk_control = 
+         system->disk_control =
             *(const struct retro_disk_control_callback*)data;
          break;
 
@@ -879,7 +879,7 @@ bool rarch_environment_cb(unsigned cmd, void *data)
       case RETRO_ENVIRONMENT_SET_HW_RENDER | RETRO_ENVIRONMENT_EXPERIMENTAL:
       {
          struct retro_hw_render_callback *hw_render = video_driver_callback();
-         struct retro_hw_render_callback *cb = 
+         struct retro_hw_render_callback *cb =
             (struct retro_hw_render_callback*)data;
 
          RARCH_LOG("Environ SET_HW_RENDER.\n");
@@ -966,13 +966,13 @@ bool rarch_environment_cb(unsigned cmd, void *data)
          break;
       }
 
-      /* FIXME - PS3 audio driver needs to be fixed so that threaded 
-       * audio works correctly (audio is already on a thread for PS3 
+      /* FIXME - PS3 audio driver needs to be fixed so that threaded
+       * audio works correctly (audio is already on a thread for PS3
        * audio driver so that's probably the problem) */
 #if defined(HAVE_THREADS) && !defined(__CELLOS_LV2__)
       case RETRO_ENVIRONMENT_SET_AUDIO_CALLBACK:
       {
-         const struct retro_audio_callback *info = 
+         const struct retro_audio_callback *info =
             (const struct retro_audio_callback*)data;
          RARCH_LOG("Environ SET_AUDIO_CALLBACK.\n");
 
@@ -991,13 +991,13 @@ bool rarch_environment_cb(unsigned cmd, void *data)
 
       case RETRO_ENVIRONMENT_SET_FRAME_TIME_CALLBACK:
       {
-         const struct retro_frame_time_callback *info = 
+         const struct retro_frame_time_callback *info =
             (const struct retro_frame_time_callback*)data;
 
          RARCH_LOG("Environ SET_FRAME_TIME_CALLBACK.\n");
 
 #ifdef HAVE_NETPLAY
-         /* retro_run() will be called in very strange and 
+         /* retro_run() will be called in very strange and
           * mysterious ways, have to disable it. */
          if (global->netplay.enable)
             return false;
@@ -1009,7 +1009,7 @@ bool rarch_environment_cb(unsigned cmd, void *data)
 
       case RETRO_ENVIRONMENT_GET_RUMBLE_INTERFACE:
       {
-         struct retro_rumble_interface *iface = 
+         struct retro_rumble_interface *iface =
             (struct retro_rumble_interface*)data;
 
          RARCH_LOG("Environ GET_RUMBLE_INTERFACE.\n");
@@ -1032,7 +1032,7 @@ bool rarch_environment_cb(unsigned cmd, void *data)
 
       case RETRO_ENVIRONMENT_GET_SENSOR_INTERFACE:
       {
-         struct retro_sensor_interface *iface = 
+         struct retro_sensor_interface *iface =
             (struct retro_sensor_interface*)data;
 
          RARCH_LOG("Environ GET_SENSOR_INTERFACE.\n");
@@ -1114,7 +1114,7 @@ bool rarch_environment_cb(unsigned cmd, void *data)
       case RETRO_ENVIRONMENT_SET_SUBSYSTEM_INFO:
       {
          unsigned i, j;
-         const struct retro_subsystem_info *info = 
+         const struct retro_subsystem_info *info =
             (const struct retro_subsystem_info*)data;
 
          RARCH_LOG("Environ SET_SUBSYSTEM_INFO.\n");
@@ -1149,7 +1149,7 @@ bool rarch_environment_cb(unsigned cmd, void *data)
       case RETRO_ENVIRONMENT_SET_CONTROLLER_INFO:
       {
          unsigned i, j;
-         const struct retro_controller_info *info = 
+         const struct retro_controller_info *info =
             (const struct retro_controller_info*)data;
 
          RARCH_LOG("Environ SET_CONTROLLER_INFO.\n");
@@ -1177,9 +1177,9 @@ bool rarch_environment_cb(unsigned cmd, void *data)
       case RETRO_ENVIRONMENT_SET_GEOMETRY:
       {
          struct retro_system_av_info *av_info = video_viewport_get_system_av_info();
-         const struct retro_game_geometry *in_geom = 
+         const struct retro_game_geometry *in_geom =
             (const struct retro_game_geometry*)data;
-         struct retro_game_geometry *geom = av_info ? 
+         struct retro_game_geometry *geom = av_info ?
             (struct retro_game_geometry*)&av_info->geometry : NULL;
 
          if (!geom)
@@ -1199,10 +1199,10 @@ bool rarch_environment_cb(unsigned cmd, void *data)
             RARCH_LOG("SET_GEOMETRY: %ux%u, aspect: %.3f.\n",
                   geom->base_width, geom->base_height, geom->aspect_ratio);
 
-            /* Forces recomputation of aspect ratios if 
+            /* Forces recomputation of aspect ratios if
              * using core-dependent aspect ratios. */
             event_command(EVENT_CMD_VIDEO_SET_ASPECT_RATIO);
-            
+
             /* TODO: Figure out what to do, if anything, with recording. */
          }
          break;
@@ -1253,4 +1253,3 @@ bool rarch_environment_cb(unsigned cmd, void *data)
 
    return true;
 }
-

--- a/frontend/frontend.c
+++ b/frontend/frontend.c
@@ -41,14 +41,6 @@ void main_exit_save_config(void)
 
    if (settings->config_save_on_exit && *global->path.config)
    {
-      /* restore original paths in case per-core organization is enabled */
-      if (settings->sort_savefiles_enable && orig_savefile_dir[0] != '\0')
-         strlcpy(global->dir.savefile, orig_savefile_dir,
-               sizeof(global->dir.savefile));
-      if (settings->sort_savestates_enable && orig_savestate_dir[0] != '\0')
-         strlcpy(global->dir.savestate, orig_savestate_dir,
-               sizeof(global->dir.savestate));
-
       /* Save last core-specific config to the default config location,
        * needed on consoles for core switching and reusing last good
        * config for new cores.

--- a/retroarch.c
+++ b/retroarch.c
@@ -54,8 +54,9 @@
 #include "menu/menu_hash.h"
 #endif
 
-char orig_savestate_dir[PATH_MAX_LENGTH];
-char orig_savefile_dir[PATH_MAX_LENGTH];
+char current_savestate_dir[PATH_MAX_LENGTH];
+char current_savefile_dir[PATH_MAX_LENGTH];
+
 
 /* Descriptive names for options without short variant. Please keep the name in
    sync with the option name. Order does not matter. */
@@ -333,62 +334,66 @@ void set_paths_redirect(const char *path)
       /* per-core saves: append the library_name to the save location */
       if (settings->sort_savefiles_enable && global->dir.savefile[0] != '\0')
       {
-         strlcpy(orig_savefile_dir,global->dir.savefile,
-               sizeof(orig_savefile_dir));
-         fill_pathname_dir(
-               global->dir.savefile,
+         fill_pathname_join(
+               current_savefile_dir,
                global->dir.savefile,
                info->info.library_name,
                sizeof(global->dir.savefile));
 
          /* If path doesn't exist, try to create it,
           * if everything fails revert to the original path. */
-         if(!path_is_directory(global->dir.savefile) && global->dir.savefile[0] != '\0')
+         if(!path_is_directory(current_savefile_dir) && current_savefile_dir[0] != '\0')
          {
-            path_mkdir(global->dir.savefile);
-            if(!path_is_directory(global->dir.savefile))
+            path_mkdir(current_savefile_dir);
+            if(!path_is_directory(current_savefile_dir))
             {
-               RARCH_LOG("Reverting savefile directory to %s\n", orig_savefile_dir);
-               strlcpy(global->dir.savefile,
-                     orig_savefile_dir,
-                     sizeof(global->dir.savefile));
+               RARCH_LOG("Reverting savefile directory to %s\n", global->dir.savefile);
+               strlcpy(current_savefile_dir,
+                     global->dir.savefile,
+                     sizeof(current_savefile_dir));
             }
          }
       }
+      else
+         strlcpy(current_savefile_dir,
+               global->dir.savefile,
+               sizeof(current_savefile_dir));
 
       /* per-core states: append the library_name to the save location */
       if (settings->sort_savestates_enable && global->dir.savestate[0] != '\0')
       {
-         strlcpy(orig_savestate_dir,
-               global->dir.savestate,
-               sizeof(orig_savestate_dir));
-         fill_pathname_dir(global->dir.savestate,
+         fill_pathname_join(
+               current_savestate_dir,
                global->dir.savestate,
                info->info.library_name,
                sizeof(global->dir.savestate));
 
          /* If path doesn't exist, try to create it.
           * If everything fails, revert to the original path. */
-         if(!path_is_directory(global->dir.savestate) && global->dir.savestate[0] != '\0')
+         if(!path_is_directory(current_savestate_dir) && current_savestate_dir[0] != '\0')
          {
-            path_mkdir(global->dir.savestate);
-            if(!path_is_directory(global->dir.savestate))
+            path_mkdir(current_savestate_dir);
+            if(!path_is_directory(current_savestate_dir))
             {
-               RARCH_LOG("Reverting savestate directory to %s\n", orig_savestate_dir);
-               strlcpy(global->dir.savestate,
-                     orig_savestate_dir,
-                     sizeof(global->dir.savestate));
+               RARCH_LOG("Reverting savestate directory to %s\n", global->dir.savestate);
+               strlcpy(current_savestate_dir,
+                     global->dir.savestate,
+                     sizeof(current_savestate_dir));
             }
          }
       }
+      else
+         strlcpy(current_savestate_dir,
+               global->dir.savestate,
+               sizeof(current_savestate_dir));
    }
 
-   if(path_is_directory(global->dir.savefile))
-      strlcpy(global->name.savefile, global->dir.savefile,
+   if(path_is_directory(current_savefile_dir))
+      strlcpy(global->name.savefile, current_savefile_dir,
             sizeof(global->name.savefile));
 
-   if(path_is_directory(global->dir.savestate))
-      strlcpy(global->name.savestate, global->dir.savestate,
+   if(path_is_directory(current_savestate_dir))
+      strlcpy(global->name.savestate, current_savestate_dir,
             sizeof(global->name.savestate));
 
    if (path_is_directory(global->name.savefile))
@@ -789,7 +794,7 @@ static void parse_input(int argc, char *argv[])
             FreeConsole();
 #endif
             break;
-         
+
          case RA_OPT_MENU:
             global->inited.core.type        = CORE_TYPE_DUMMY;
             break;
@@ -1057,7 +1062,7 @@ void rarch_main_alloc(void)
 /**
  * rarch_main_new:
  *
- * Will teardown drivers and clears all 
+ * Will teardown drivers and clears all
  * internal state of the program.
  * If @inited is true, will initialize all
  * drivers again after teardown.
@@ -1099,7 +1104,7 @@ void rarch_init_system_av_info(void)
 /**
  * rarch_main_init:
  * @argc                 : Count of (commandline) arguments.
- * @argv                 : (Commandline) arguments. 
+ * @argv                 : (Commandline) arguments.
  *
  * Initializes the program.
  *
@@ -1512,7 +1517,7 @@ void rarch_playlist_load_content(void *data, unsigned idx)
  *
  * Gets deferred core.
  *
- * Returns: 0 if there are multiple deferred cores and a 
+ * Returns: 0 if there are multiple deferred cores and a
  * selection needs to be made from a list, otherwise
  * returns -1 and fills in @s with path to core.
  **/

--- a/retroarch.h
+++ b/retroarch.h
@@ -1,7 +1,7 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
  *  Copyright (C) 2011-2015 - Daniel De Matteis
- * 
+ *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-
  *  ation, either version 3 of the License, or (at your option) any later version.
@@ -89,7 +89,7 @@ enum rarch_ctl_state
       /* Validates CPU features for given processor architecture.
        *
        * Make sure we haven't compiled for something we cannot run.
-       * Ideally, code would get swapped out depending on CPU support, 
+       * Ideally, code would get swapped out depending on CPU support,
        * but this will do for now. */
    RARCH_ACTION_STATE_VALIDATE_CPU_FEATURES,
 
@@ -135,7 +135,7 @@ bool rarch_ctl(enum rarch_ctl_state state, void *data);
 /**
  * rarch_main_init:
  * @argc                 : Count of (commandline) arguments.
- * @argv                 : (Commandline) arguments. 
+ * @argv                 : (Commandline) arguments.
  *
  * Initializes RetroArch.
  *
@@ -183,7 +183,7 @@ void rarch_playlist_load_content(void *data, unsigned index);
  *
  * Gets deferred core.
  *
- * Returns: 0 if there are multiple deferred cores and a 
+ * Returns: 0 if there are multiple deferred cores and a
  * selection needs to be made from a list, otherwise
  * returns -1 and fills in @s with path to core.
  **/
@@ -207,8 +207,8 @@ int rarch_info_get_capabilities(enum rarch_capabilities type, char *s, size_t le
 
 enum rarch_content_type rarch_path_is_media_type(const char *path);
 
-extern char orig_savestate_dir[PATH_MAX_LENGTH];
-extern char orig_savefile_dir[PATH_MAX_LENGTH];
+extern char current_savestate_dir[PATH_MAX_LENGTH];
+extern char current_savefile_dir[PATH_MAX_LENGTH];
 extern bool orig_system_dir_empty;
 
 #ifdef __cplusplus


### PR DESCRIPTION
- Refactor save sorting
This option used to actually change the savefile directory which would often lead to a change in the config file when loading some cores (2048 for instance), now the settings are never touched so there is no need to reset keep track of the original location or reset the path after closing content.

- Change the OSX buildbot URL to the actual URL
The older url should still work (via server redirects) but I made sure we use the true URL from now on