### PR TITLE
File check bug fix with 7z and zip files

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -1486,6 +1486,8 @@ void rarch_playlist_load_content(void *data, unsigned idx)
 {
    const char *path             = NULL;
    const char *core_path        = NULL;
+   char *path_check		= NULL;
+   char *path_tolower		= NULL;
    content_playlist_t *playlist = (content_playlist_t*)data;
    menu_handle_t *menu          = menu_driver_get_ptr();
    settings_t  *settings        = config_get_ptr();
@@ -1496,14 +1498,34 @@ void rarch_playlist_load_content(void *data, unsigned idx)
    content_playlist_get_index(playlist,
          idx, &path, NULL, &core_path, NULL, NULL, NULL);
 
-   RFILE *fp = retro_fopen(path, RFILE_MODE_READ, -1);
+   path_tolower = strdup(path);
+   for (int i = 0; i < strlen(path_tolower); ++i)
+   {
+      path_tolower[i] = tolower(path_tolower[i]);
+   }
+   
+   if (strstr(path_tolower, ".zip"))
+   {
+      *(strstr(path_tolower, ".zip") + 4) = '\0';
+   }
+   else if (strstr(path_tolower, ".7z"))
+   {
+      *(strstr(path_tolower, ".7z") + 3) = '\0';
+   }
+
+   path_check = (char *)calloc(strlen(path_tolower) + 1, sizeof(char));
+   strncpy(path_check, path, strlen(path_tolower));
+
+   RFILE *fp = retro_fopen(path_check, RFILE_MODE_READ, -1);
    if (!fp)
    {
       rarch_main_msg_queue_push("File could not be loaded.\n", 1, 100, true);
-      RARCH_LOG("File at %s failed to load.\n", path);
+      RARCH_LOG("File at %s failed to load.\n", path_check);
       return;
    }
    retro_fclose(fp);
+   free(path_tolower);
+   free(path_check);
 
    strlcpy(settings->libretro, core_path, sizeof(settings->libretro));
 

--- a/retroarch.c
+++ b/retroarch.c
@@ -1488,6 +1488,7 @@ void rarch_playlist_load_content(void *data, unsigned idx)
    const char *core_path        = NULL;
    char *path_check		= NULL;
    char *path_tolower		= NULL;
+   RFILE *fp			= NULL;
    content_playlist_t *playlist = (content_playlist_t*)data;
    menu_handle_t *menu          = menu_driver_get_ptr();
    settings_t  *settings        = config_get_ptr();
@@ -1516,7 +1517,7 @@ void rarch_playlist_load_content(void *data, unsigned idx)
    path_check = (char *)calloc(strlen(path_tolower) + 1, sizeof(char));
    strncpy(path_check, path, strlen(path_tolower));
 
-   RFILE *fp = retro_fopen(path_check, RFILE_MODE_READ, -1);
+   fp = retro_fopen(path_check, RFILE_MODE_READ, -1);
    if (!fp)
    {
       rarch_main_msg_queue_push("File could not be loaded.\n", 1, 100, true);

--- a/retroarch.c
+++ b/retroarch.c
@@ -1486,7 +1486,7 @@ void rarch_playlist_load_content(void *data, unsigned idx)
 {
    const char *path             = NULL;
    const char *core_path        = NULL;
-   char *path_check		= NULL;
+   char *path_check             = NULL;
    char *path_tolower           = NULL;
    RFILE *fp                    = NULL;
    content_playlist_t *playlist = (content_playlist_t*)data;

--- a/retroarch.c
+++ b/retroarch.c
@@ -1507,11 +1507,11 @@ void rarch_playlist_load_content(void *data, unsigned idx)
    
    if (strstr(path_tolower, ".zip"))
    {
-      *(strstr(path_tolower, ".zip") + 4) = '\0';
+      strstr(path_tolower, ".zip")[4] = '\0';
    }
    else if (strstr(path_tolower, ".7z"))
    {
-      *(strstr(path_tolower, ".7z") + 3) = '\0';
+      *(strstr(path_tolower, ".7z")[3] = '\0';
    }
 
    path_check = (char *)calloc(strlen(path_tolower) + 1, sizeof(char));

--- a/retroarch.c
+++ b/retroarch.c
@@ -1487,8 +1487,8 @@ void rarch_playlist_load_content(void *data, unsigned idx)
    const char *path             = NULL;
    const char *core_path        = NULL;
    char *path_check		= NULL;
-   char *path_tolower		= NULL;
-   RFILE *fp			= NULL;
+   char *path_tolower           = NULL;
+   RFILE *fp                    = NULL;
    content_playlist_t *playlist = (content_playlist_t*)data;
    menu_handle_t *menu          = menu_driver_get_ptr();
    settings_t  *settings        = config_get_ptr();


### PR DESCRIPTION
@fr500 mentioned a bug with zip and 7z files, where it tries to load for ex.: ...\Final Fantasy (Japan).zip#Final Fantasy (Japan).wsc

This is my bugfix.