### PR TITLE
input: add sanity check for analog dpad mode

### DIFF
--- a/input/input_common.c
+++ b/input/input_common.c
@@ -457,12 +457,28 @@ void input_push_analog_dpad(struct retro_keybind *binds, unsigned mode)
    switch (mode)
    {
       case ANALOG_DPAD_LSTICK:
-         j = RARCH_ANALOG_LEFT_X_PLUS + 3;
-         inherit_joyaxis = true;
+         /* check if analog left is defined.   *
+          * if plus and minus are equal abort. */
+         if (!((binds[RARCH_ANALOG_LEFT_X_PLUS].joyaxis == 
+               binds[RARCH_ANALOG_LEFT_X_MINUS].joyaxis) || 
+               (binds[RARCH_ANALOG_LEFT_Y_PLUS].joyaxis == 
+               binds[RARCH_ANALOG_LEFT_Y_MINUS].joyaxis)))
+         {
+            j = RARCH_ANALOG_LEFT_X_PLUS + 3;
+            inherit_joyaxis = true;
+         }
          break;
       case ANALOG_DPAD_RSTICK:
-         j = RARCH_ANALOG_RIGHT_X_PLUS + 3;
-         inherit_joyaxis = true;
+         /* check if analog right is defined.  *
+          * if plus and minus are equal abort. */
+         if (!((binds[RARCH_ANALOG_RIGHT_X_PLUS].joyaxis == 
+               binds[RARCH_ANALOG_RIGHT_X_MINUS].joyaxis) || 
+               (binds[RARCH_ANALOG_RIGHT_Y_PLUS].joyaxis == 
+               binds[RARCH_ANALOG_RIGHT_Y_MINUS].joyaxis)))
+         {          
+            j = RARCH_ANALOG_RIGHT_X_PLUS + 3;
+            inherit_joyaxis = true;
+         }
          break;
    }
 


### PR DESCRIPTION
Don't remap dpad joyaxis if analog joyaxis values are not valid. Joyaxis values are not valid if up and down or left and right are equal.

-Fix for https://github.com/libretro/RetroArch/issues/1780. If no analog left or right is configured (retroarch.cfg, autoconf) default analog joyaxis values are "-1".
-Make this wish https://github.com/libretro/RetroArch/issues/609 obsolete.