### PR TITLE
vc_egl_ctx.c: Fix missing fps output

### DIFF
--- a/gfx/drivers_context/vc_egl_ctx.c
+++ b/gfx/drivers_context/vc_egl_ctx.c
@@ -130,7 +130,7 @@ static void gfx_ctx_vc_update_window_title(void *data)
    video_monitor_get_fps(buf, sizeof(buf),
          buf_fps, sizeof(buf_fps));
    if (settings->fps_show)
-      msg_queue_push(buf_fps, 1, 1, false);
+      rarch_main_msg_queue_push(buf_fps, 1, 1, false);
 }
 
 static void gfx_ctx_vc_get_video_size(void *data,


### PR DESCRIPTION
Related to: https://github.com/libretro/RetroArch/issues/2034
It does not segfault but there is no fps output with msg_queue_push(). Just do it like other context drivers.