### PR TITLE
3DS: Fix compilation for great-refactor.

### DIFF
--- a/frontend/drivers/platform_ctr.c
+++ b/frontend/drivers/platform_ctr.c
@@ -151,7 +151,7 @@ static void frontend_ctr_deinit(void *data)
       svcCloseHandle(lcd_handle);
    }
 
-   exitCfgu();
+   cfguExit();
    ndspExit();
    csndExit();   
    gfxExit();
@@ -244,7 +244,7 @@ static void frontend_ctr_init(void *data)
    ctr_check_dspfirm();
    if(ndspInit() != 0)
       *dsp_audio_driver = audio_null;
-   initCfgu();
+   cfguInit();
 #endif
 }
 


### PR DESCRIPTION
exitCfgu/initCfgu changed to cfguInit/cfguExit.
https://github.com/smealum/ctrulib/commit/2797540a3dabf262be9701300631685e0de1696c