### PR TITLE
allow using video filters when building with HAVE_FILTERS_BUILTIN

### DIFF
--- a/frontend/drivers/platform_ctr.c
+++ b/frontend/drivers/platform_ctr.c
@@ -75,6 +75,8 @@ static void frontend_ctr_get_environment_settings(int *argc, char *argv[],
          "playlists", sizeof(g_defaults.dir.playlist));
    fill_pathname_join(g_defaults.dir.remap, g_defaults.dir.port,
          "remaps", sizeof(g_defaults.dir.remap));
+   fill_pathname_join(g_defaults.dir.video_filter, g_defaults.dir.port,
+         "filters", sizeof(g_defaults.dir.remap));
    fill_pathname_join(g_defaults.path.config, g_defaults.dir.port,
          "retroarch.cfg", sizeof(g_defaults.path.config));
    

--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -285,7 +285,11 @@ bool video_driver_set_shader(enum rarch_shader_type type,
 static void deinit_video_filter(void)
 {
    rarch_softfilter_free(video_state.filter.filter);
+#ifdef _3DS
+   linearFree(video_state.filter.buffer);
+#else
    free(video_state.filter.buffer);
+#endif
    memset(&video_state.filter, 0, sizeof(video_state.filter));
 }
 
@@ -344,7 +348,11 @@ static void init_video_filter(enum retro_pixel_format colfmt)
       sizeof(uint32_t) : sizeof(uint16_t);
 
    /* TODO: Aligned output. */
+#ifdef _3DS
+   video_state.filter.buffer = linearMemAlign(width * height * video_state.filter.out_bpp, 0x80);
+#else
    video_state.filter.buffer = malloc(width * height * video_state.filter.out_bpp);
+#endif
    if (!video_state.filter.buffer)
       goto error;
 

--- a/gfx/video_filter.c
+++ b/gfx/video_filter.c
@@ -216,6 +216,7 @@ static bool create_softfilter_graph(rarch_softfilter_t *filt,
       return false;
    }
 
+   filt->threads = threads;
    RARCH_LOG("Using %u threads for softfilter.\n", threads);
 
    filt->packets = (struct softfilter_work_packet*)
@@ -231,7 +232,6 @@ static bool create_softfilter_graph(rarch_softfilter_t *filt,
       calloc(threads, sizeof(*filt->thread_data));
    if (!filt->thread_data)
       return false;
-   filt->threads = threads;
 
    for (i = 0; i < threads; i++)
    {

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -4515,7 +4515,6 @@ static bool setting_append_list_video_options(
          EVENT_CMD_VIDEO_APPLY_STATE_CHANGES);
 #endif
 
-#ifndef HAVE_FILTERS_BUILTIN
    CONFIG_PATH(
          settings->video.softfilter_plugin,
          menu_hash_to_str(MENU_LABEL_VIDEO_FILTER),
@@ -4529,7 +4528,6 @@ static bool setting_append_list_video_options(
    menu_settings_list_current_add_values(list, list_info, "filt");
    menu_settings_list_current_add_cmd(list, list_info, EVENT_CMD_REINIT);
    settings_data_list_current_add_flags(list, list_info, SD_FLAG_ALLOW_EMPTY);
-#endif
 
 #ifdef _XBOX1
    CONFIG_UINT(


### PR DESCRIPTION
- also fixes video filters when the HAVE_THREAD build option is disabled.
- fix some issues with the 3DS video drivers when using  video filters.
- this still lacks the ability to generate the built-in video filter list at runtime, so the *.filt files are still needed to select one.