### PR TITLE
(XMB) Load boxarts from subfolders named after the system name in no-…

### DIFF
--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -534,7 +534,12 @@ static void xmb_update_boxart_path(xmb_handle_t *xmb, unsigned i)
    menu_entry_get(&entry, 0, i, NULL, true);
 
    fill_pathname_join(xmb->boxart_file_path, settings->boxarts_directory,
+         xmb->title_name, sizeof(xmb->boxart_file_path));
+   fill_pathname_join(xmb->boxart_file_path, xmb->boxart_file_path,
+         "Named_Snaps", sizeof(xmb->boxart_file_path));
+   fill_pathname_join(xmb->boxart_file_path, xmb->boxart_file_path,
          entry.path, sizeof(xmb->boxart_file_path));
+
    strlcat(xmb->boxart_file_path, ".png", sizeof(xmb->boxart_file_path));
 }
 


### PR DESCRIPTION
…intro. Start following the convention of no-intro-screenshot-reloaded to get title screenshots, or in game screenshots, and we will add boxarts by ourselves later.