### PR TITLE
(dir_list_special.c) Fix content directory scanning

### DIFF
--- a/dir_list_special.c
+++ b/dir_list_special.c
@@ -61,5 +61,5 @@ struct string_list *dir_list_new_special(const char *input_dir, enum dir_list_ty
          return NULL;
    }
 
-   return dir_list_new(dir, exts, include_dirs, false);
+   return dir_list_new(dir, exts, include_dirs, type == DIR_LIST_CORE_INFO);
 }


### PR DESCRIPTION
dir_list_new_special() only considered files that matched the reported
supported extensions and thus users without zip-loading cores could not
successfuly scan a folder full of zip-compressed content.