### PR TITLE
(Menu) Use float for icon coordinates, makes animations look smoother

### DIFF
--- a/menu/drivers_display/menu_display_d3d.cpp
+++ b/menu/drivers_display/menu_display_d3d.cpp
@@ -102,7 +102,7 @@ static void menu_display_d3d_blend_end(void)
 }
 
 static void menu_display_d3d_draw(
-      unsigned x, unsigned y,
+      float x, float y,
       unsigned width, unsigned height,
       struct gfx_coords *coords,
       void *matrix_data,

--- a/menu/drivers_display/menu_display_gl.c
+++ b/menu/drivers_display/menu_display_gl.c
@@ -92,7 +92,7 @@ static void menu_display_gl_blend_end(void)
 }
 
 static void menu_display_gl_draw(
-      unsigned x, unsigned y,
+      float x, float y,
       unsigned width, unsigned height,
       struct gfx_coords *coords,
       void *matrix_data,

--- a/menu/drivers_display/menu_display_null.c
+++ b/menu/drivers_display/menu_display_null.c
@@ -40,7 +40,7 @@ static void menu_display_null_blend_end(void)
 }
 
 static void menu_display_null_draw(
-      unsigned x, unsigned y,
+      float x, float y,
       unsigned width, unsigned height,
       struct gfx_coords *coords,
       void *matrix_data,

--- a/menu/menu_display.c
+++ b/menu/menu_display.c
@@ -603,7 +603,7 @@ void menu_display_texture_unload(uintptr_t *id)
    menu_disp->texture_unload(id);
 }
 
-void menu_display_draw(unsigned x, unsigned y,
+void menu_display_draw(float x, float y,
       unsigned width, unsigned height,
       struct gfx_coords *coords,
       void *matrix_data, 

--- a/menu/menu_display.h
+++ b/menu/menu_display.h
@@ -78,7 +78,7 @@ enum menu_display_driver_type
 
 typedef struct menu_display_ctx_driver
 {
-   void (*draw)(unsigned x, unsigned y,
+   void (*draw)(float x, float y,
       unsigned width, unsigned height,
       struct gfx_coords *coords,
       void *matrix_data, 
@@ -141,7 +141,7 @@ void menu_display_msg_queue_push(const char *msg, unsigned prio, unsigned durati
 
 bool menu_display_driver_init_first(void);
 
-void menu_display_draw(unsigned x, unsigned y,
+void menu_display_draw(float x, float y,
       unsigned width, unsigned height,
       struct gfx_coords *coords,
       void *matrix_data, 


### PR DESCRIPTION
Fixes the image overlap bug for me, tested on iPhone.