### PR TITLE
(menu) Fix heap overflow

### DIFF
--- a/menu/menu.c
+++ b/menu/menu.c
@@ -20,7 +20,6 @@
 #include "menu_cbs.h"
 #include "menu_display.h"
 #include "menu_hash.h"
-#include "menu_shader.h"
 
 #include "../general.h"
 #include "../frontend/frontend.h"

--- a/menu/menu.h
+++ b/menu/menu.h
@@ -25,23 +25,10 @@
 #include <boolean.h>
 
 #include "menu_driver.h"
+#include "menu_shader.h"
 #include "../driver.h"
 #include "../input/input_driver.h"
 #include "../dynamic.h"
-
-#if defined(HAVE_CG) || defined(HAVE_HLSL) || defined(HAVE_GLSL)
-#ifndef HAVE_SHADER_MANAGER
-#define HAVE_SHADER_MANAGER
-#endif
-#endif
-
-#ifndef GFX_MAX_PARAMETERS
-#define GFX_MAX_PARAMETERS 64
-#endif
-
-#ifndef GFX_MAX_SHADERS
-#define GFX_MAX_SHADERS 16
-#endif
 
 #ifndef MAX_COUNTERS
 #define MAX_COUNTERS 64


### PR DESCRIPTION
Some struct video_shader fields have sizes defined by macros, menu.h and video_shader_parse.h had different values for some of them. This resulted in menu.c allocating a ~120KB struct video_shader while video_shader_parse.c tried to memset() a ~150KB one.

For some reason this was only triggered in 32bit environments.