### PR TITLE
(android_input.c) Fix usage of signed/unsigned

### DIFF
--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -579,7 +579,7 @@ static int android_input_get_id_index_from_name(android_input_data_t *android_da
 }
 
 static void handle_hotplug(android_input_data_t *android_data,
-      struct android_app *android_app, unsigned *port, unsigned id,
+      struct android_app *android_app, int *port, int id,
       int source)
 {
    char device_name[256]        = {0};
@@ -818,7 +818,7 @@ static void android_input_poll_input(void *data)
 
          if (port < 0)
             handle_hotplug(android_data, android_app,
-                  &android_data->pads_connected, id, source);
+                  &port, id, source);
 
          switch (type_event)
          {


### PR DESCRIPTION
This caused a segmentation fault in android_keyboard_state_get()