### PR TITLE
(file_extract) Fix invalid read in zlib_parse_file_progress()

### DIFF
--- a/libretro-common/file/file_extract.c
+++ b/libretro-common/file/file_extract.c
@@ -606,10 +606,9 @@ bool zlib_parse_file(const char *file, const char *valid_exts,
 
 int zlib_parse_file_progress(void *data)
 {
-   /* FIXME: this estimate is pretty bad */
+   /* FIXME: this estimate is worse than before */
    zlib_transfer_t *state = (zlib_transfer_t*)data;
-   const uint8_t *offset = state->data + read_le(state->directory + 42, 4);
-   ptrdiff_t delta = offset - state->data - 46 - 22;
+   ptrdiff_t delta = state->directory - state->data;
    return delta * 100 / state->zip_size;
 }
 


### PR DESCRIPTION
Fixes yet another issue in Android.