### PR TITLE
Context driver improvements

### DIFF
--- a/gfx/common/egl_common.h
+++ b/gfx/common/egl_common.h
@@ -29,16 +29,44 @@
 extern "C" {
 #endif
 
-extern volatile sig_atomic_t g_egl_quit;
+/* Put this structure as the first member of egl-based contexts
+ * like this:
+ *    typedef struct
+ *    {
+ *       egl_ctx_data_t egl;
+ *       int member0;
+ *       char member1;
+ *     ....
+ *    } my_ctx_data_t;
+ *
+ * You can call egl functions passing the data pointer you receive
+ * or using &ctx_data->egl. It's up to you.
+ */
+typedef struct
+{
+   EGLContext ctx;
+   EGLContext hw_ctx;
+   EGLSurface surf;
+   EGLDisplay dpy;
+   EGLConfig config;
+   unsigned interval;
 
-extern EGLContext g_egl_ctx;
-extern EGLContext g_egl_hw_ctx;
-extern EGLSurface g_egl_surf;
-extern EGLDisplay g_egl_dpy;
-extern EGLConfig g_egl_config;
-extern enum gfx_ctx_api g_egl_api;
+   unsigned major;
+   unsigned minor;
+   enum gfx_ctx_api api;
+
+   /* egl "private" */
+   bool use_hw_ctx;
+} egl_ctx_data_t;
+
+extern volatile sig_atomic_t g_egl_quit;
 extern bool g_egl_inited;
-extern unsigned g_interval;
+
+/* bind_api is called before init so we need these, please
+ * try no to use them outside of bind_api() and init() */
+extern enum gfx_ctx_api g_egl_api;
+extern unsigned g_egl_major;
+extern unsigned g_egl_minor;
 
 void egl_report_error(void);
 
@@ -56,17 +84,17 @@ void egl_get_video_size(void *data, unsigned *width, unsigned *height);
 
 void egl_install_sighandlers(void);
 
-bool egl_init_context(NativeDisplayType display,
+bool egl_init_context(void *data, NativeDisplayType display,
       EGLint *major, EGLint *minor,
      EGLint *n, const EGLint *attrib_ptr);
 
-bool egl_create_context(EGLint *egl_attribs);
+bool egl_create_context(void *data, EGLint *egl_attribs);
 
-bool egl_create_surface(NativeWindowType native_window);
+bool egl_create_surface(void *data, NativeWindowType native_window);
 
-bool egl_get_native_visual_id(EGLint *value);
+bool egl_get_native_visual_id(void *data, EGLint *value);
 
-bool egl_has_config(void);
+bool egl_has_config(void *data);
 
 #ifdef __cplusplus
 }

--- a/gfx/drivers/gl.c
+++ b/gfx/drivers/gl.c
@@ -108,7 +108,7 @@ static const GLfloat white_color[] = {
 static INLINE void context_bind_hw_render(gl_t *gl, bool enable)
 {
    if (gl && gl->shared_context_use)
-      gfx_ctx_bind_hw_render(gl, enable);
+      gfx_ctx_bind_hw_render(enable);
 }
 
 static INLINE bool gl_query_extension(gl_t *gl, const char *ext)
@@ -851,7 +851,7 @@ static void gl_set_viewport(void *data, unsigned viewport_width,
 
    video_driver_get_size(&width, &height);
 
-   gfx_ctx_translate_aspect(gl, &device_aspect,
+   gfx_ctx_translate_aspect(&device_aspect,
          viewport_width, viewport_height);
 
    if (settings->video.scale_integer && !force_full)
@@ -951,7 +951,7 @@ static void gl_set_rotation(void *data, unsigned rotation)
 static void gl_set_video_mode(void *data, unsigned width, unsigned height,
       bool fullscreen)
 {
-   gfx_ctx_set_video_mode(data, width, height, fullscreen);
+   gfx_ctx_set_video_mode(width, height, fullscreen);
 }
 
 #ifdef HAVE_FBO
@@ -1680,7 +1680,7 @@ static bool gl_frame(void *data, const void *frame,
    {
       gl->should_resize = false;
 
-      gfx_ctx_set_resize(gl, width, height);
+      gfx_ctx_set_resize(width, height);
 
 #ifdef HAVE_FBO
       if (gl->fbo_inited)
@@ -1809,7 +1809,7 @@ static bool gl_frame(void *data, const void *frame,
       gl_render_overlay(gl);
 #endif
 
-   gfx_ctx_update_window_title(gl);
+   gfx_ctx_update_window_title();
 
    retro_perf_stop(&frame_run);
 
@@ -1856,11 +1856,11 @@ static bool gl_frame(void *data, const void *frame,
          && !input_driver_ctl(RARCH_INPUT_CTL_IS_NONBLOCK_STATE, NULL)
          && !is_slowmotion && !is_paused)
    {
-      gfx_ctx_swap_buffers(gl);
+      gfx_ctx_swap_buffers();
       glClear(GL_COLOR_BUFFER_BIT);
    }
 
-   gfx_ctx_swap_buffers(gl);
+   gfx_ctx_swap_buffers();
 
 #ifdef HAVE_GL_SYNC
    if (settings->video.hard_sync && gl->have_sync)
@@ -1987,7 +1987,7 @@ static void gl_free(void *data)
    }
 #endif
 
-   gfx_ctx_free(gl);
+   gfx_ctx_free();
 
    free(gl->empty_buf);
    free(gl->conv_buffer);
@@ -2005,7 +2005,7 @@ static void gl_set_nonblock_state(void *data, bool state)
    RARCH_LOG("[GL]: VSync => %s\n", state ? "off" : "on");
 
    context_bind_hw_render(gl, false);
-   gfx_ctx_swap_interval(gl, 
+   gfx_ctx_swap_interval(
          state ? 0 : settings->video.swap_interval);
    context_bind_hw_render(gl, true);
 }
@@ -2467,10 +2467,10 @@ static void *gl_init(const video_info_t *video, const input_driver_t **input, vo
 
    RARCH_LOG("Found GL context: %s\n", ctx_driver->ident);
 
-   gfx_ctx_get_video_size(gl, &gl->full_x, &gl->full_y);
+   gfx_ctx_get_video_size(&gl->full_x, &gl->full_y);
    RARCH_LOG("Detecting screen resolution %ux%u.\n", gl->full_x, gl->full_y);
 
-   gfx_ctx_swap_interval(gl, 
+   gfx_ctx_swap_interval(
          video->vsync ? settings->video.swap_interval : 0);
 
    win_width  = video->width;
@@ -2482,7 +2482,7 @@ static void *gl_init(const video_info_t *video, const input_driver_t **input, vo
       win_height = gl->full_y;
    }
 
-   if (!gfx_ctx_set_video_mode(gl, win_width, win_height, video->fullscreen))
+   if (!gfx_ctx_set_video_mode(win_width, win_height, video->fullscreen))
       goto error;
 
    /* Clear out potential error flags in case we use cached context. */
@@ -2513,7 +2513,7 @@ static void *gl_init(const video_info_t *video, const input_driver_t **input, vo
    gl->fullscreen = video->fullscreen;
    
    /* Get real known video size, which might have been altered by context. */
-   gfx_ctx_get_video_size(gl, &temp_width, &temp_height);
+   gfx_ctx_get_video_size(&temp_width, &temp_height);
 
    if (temp_width != 0 && temp_height != 0)
       video_driver_set_size(&temp_width, &temp_height);
@@ -2641,7 +2641,7 @@ static void *gl_init(const video_info_t *video, const input_driver_t **input, vo
       goto error;
 #endif
 
-   gfx_ctx_input_driver(gl, input, input_data);
+   gfx_ctx_input_driver(input, input_data);
    
    if (settings->video.font_enable)
    {
@@ -2677,7 +2677,7 @@ static bool gl_alive(void *data)
    /* Needed because some context drivers don't track their sizes */
    video_driver_get_size(&temp_width, &temp_height);
 
-   if (gfx_ctx_check_window(data, &quit,
+   if (gfx_ctx_check_window(&quit,
             &resize, &temp_width, &temp_height))
    {
       if (quit)
@@ -2696,17 +2696,17 @@ static bool gl_alive(void *data)
 
 static bool gl_focus(void *data)
 {
-   return gfx_ctx_focus(data);
+   return gfx_ctx_focus();
 }
 
 static bool gl_suppress_screensaver(void *data, bool enable)
 {
-   return gfx_ctx_suppress_screensaver(data, enable);
+   return gfx_ctx_suppress_screensaver(enable);
 }
 
 static bool gl_has_windowed(void *data)
 {
-   return gfx_ctx_has_windowed(data);
+   return gfx_ctx_has_windowed();
 }
 
 static void gl_update_tex_filter_frame(gl_t *gl)
@@ -3189,7 +3189,7 @@ static void gl_overlay_enable(void *data, bool state)
    gl->overlay_enable = state;
 
    if (gl->fullscreen)
-      gfx_ctx_show_mouse(gl, state);
+      gfx_ctx_show_mouse(state);
 }
 
 static void gl_overlay_full_screen(void *data, bool enable)
@@ -3381,7 +3381,7 @@ static void gl_set_osd_msg(void *data, const char *msg,
 
 static void gl_show_mouse(void *data, bool state)
 {
-   gfx_ctx_show_mouse(data, state);
+   gfx_ctx_show_mouse(state);
 }
 
 static struct video_shader *gl_get_current_shader(void *data)
@@ -3393,17 +3393,17 @@ static struct video_shader *gl_get_current_shader(void *data)
 static void gl_get_video_output_size(void *data,
       unsigned *width, unsigned *height)
 {
-   gfx_ctx_get_video_output_size(data, width, height);
+   gfx_ctx_get_video_output_size(width, height);
 }
 
 static void gl_get_video_output_prev(void *data)
 {
-   gfx_ctx_get_video_output_prev(data);
+   gfx_ctx_get_video_output_prev();
 }
 
 static void gl_get_video_output_next(void *data)
 {
-   gfx_ctx_get_video_output_next(data);
+   gfx_ctx_get_video_output_next();
 }
 
 static const video_poke_interface_t gl_poke_interface = {

--- a/gfx/drivers_context/bbqnx_ctx.c
+++ b/gfx/drivers_context/bbqnx_ctx.c
@@ -47,7 +47,7 @@ static void gfx_ctx_qnx_destroy(void *data)
    g_resize      = false;
 }
 
-static bool gfx_ctx_qnx_init(void *data)
+static void *gfx_ctx_qnx_init(void *video_driver)
 {
    EGLint n;
    EGLint major, minor;
@@ -214,14 +214,14 @@ static bool gfx_ctx_qnx_init(void *data)
    if (!egl_create_surface(screen_win))
       goto error;
 
-   return true;
+   return "egl";
 
 error:
    RARCH_ERR("EGL error: %d.\n", eglGetError());
-   gfx_ctx_qnx_destroy(data);
+   gfx_ctx_qnx_destroy(video_driver);
 screen_error:
    screen_stop_events(screen_ctx);
-   return false;
+   return NULL;
 }
 
 static void gfx_ctx_qnx_check_window(void *data, bool *quit,

--- a/gfx/drivers_context/bbqnx_ctx.c
+++ b/gfx/drivers_context/bbqnx_ctx.c
@@ -34,17 +34,21 @@
 
 #define WINDOW_BUFFERS 2
 
-static bool g_resize;
-
 screen_context_t screen_ctx;
-screen_window_t screen_win;
-static screen_display_t screen_disp;
+
+typedef struct {
+    screen_window_t screen_win;
+    screen_display_t screen_disp;
+    bool resize;
+} qnx_ctx_data_t;
 
 static void gfx_ctx_qnx_destroy(void *data)
 {
+   qnx_ctx_data_t *qnx = (qnx_ctx_data_t*)data;
    egl_destroy(data);
 
-   g_resize      = false;
+   qnx->resize      = false;
+   free(data);
 }
 
 static void *gfx_ctx_qnx_init(void *video_driver)
@@ -65,6 +69,10 @@ static void *gfx_ctx_qnx_init(void *video_driver)
    };
    int angle, size[2];
    int usage, format = SCREEN_FORMAT_RGBX8888;
+   qnx_ctx_data_t *qnx = (qnx_ctx_data_t*)calloc(1, sizeof(*qnx));
+
+   if (!qnx)
+       goto screen_error;
 
    /* Create a screen context that will be used to 
     * create an EGL surface to receive libscreen events */
@@ -101,41 +109,41 @@ static void *gfx_ctx_qnx_init(void *video_driver)
       goto error;
    }
 
-   if (!egl_init_context(EGL_DEFAULT_DISPLAY, &major, &minor,
+   if (!egl_init_context(qnx, EGL_DEFAULT_DISPLAY, &major, &minor,
             &n, attribs))
    {
       egl_report_error();
       goto error;
    }
 
-   if (!egl_create_context(context_attributes))
+   if (!egl_create_context(qnx, context_attributes))
    {
       egl_report_error();
       goto error;
    }
 
-   if(!screen_win)
+   if(!qnx->screen_win)
    {
-      if (screen_create_window(&screen_win, screen_ctx))
+      if (screen_create_window(&qnx->screen_win, screen_ctx))
       {
-	     RARCH_ERR("screen_create_window failed:.\n");
+             RARCH_ERR("screen_create_window failed:.\n");
 	     goto error;
       }
    }
 
-   if (screen_set_window_property_iv(screen_win, SCREEN_PROPERTY_FORMAT, &format))
+   if (screen_set_window_property_iv(qnx->screen_win, SCREEN_PROPERTY_FORMAT, &format))
    {
       RARCH_ERR("screen_set_window_property_iv [SCREEN_PROPERTY_FORMAT] failed.\n");
       goto error;
    }
 
-   if (screen_set_window_property_iv(screen_win, SCREEN_PROPERTY_USAGE, &usage))
+   if (screen_set_window_property_iv(qnx->screen_win, SCREEN_PROPERTY_USAGE, &usage))
    {
       RARCH_ERR("screen_set_window_property_iv [SCREEN_PROPERTY_USAGE] failed.\n");
       goto error;
    }
 
-   if (screen_get_window_property_pv(screen_win, SCREEN_PROPERTY_DISPLAY, (void **)&screen_disp))
+   if (screen_get_window_property_pv(qnx->screen_win, SCREEN_PROPERTY_DISPLAY, (void **)&qnx->screen_disp))
    {
       RARCH_ERR("screen_get_window_property_pv [SCREEN_PROPERTY_DISPLAY] failed.\n");
       goto error;
@@ -143,7 +151,7 @@ static void *gfx_ctx_qnx_init(void *video_driver)
 
    int screen_resolution[2];
 
-   if (screen_get_display_property_iv(screen_disp, SCREEN_PROPERTY_SIZE, screen_resolution))
+   if (screen_get_display_property_iv(qnx->screen_disp, SCREEN_PROPERTY_SIZE, screen_resolution))
    {
       RARCH_ERR("screen_get_window_property_iv [SCREEN_PROPERTY_SIZE] failed.\n");
       goto error;
@@ -153,13 +161,13 @@ static void *gfx_ctx_qnx_init(void *video_driver)
    angle = atoi(getenv("ORIENTATION"));
 
    screen_display_mode_t screen_mode;
-   if (screen_get_display_property_pv(screen_disp, SCREEN_PROPERTY_MODE, (void**)&screen_mode))
+   if (screen_get_display_property_pv(qnx->screen_disp, SCREEN_PROPERTY_MODE, (void**)&screen_mode))
    {
       RARCH_ERR("screen_get_display_property_pv [SCREEN_PROPERTY_MODE] failed.\n");
       goto error;
    }
 
-   if (screen_get_window_property_iv(screen_win, SCREEN_PROPERTY_BUFFER_SIZE, size))
+   if (screen_get_window_property_iv(qnx->screen_win, SCREEN_PROPERTY_BUFFER_SIZE, size))
    {
       RARCH_ERR("screen_get_window_property_iv [SCREEN_PROPERTY_BUFFER_SIZE] failed.\n");
       goto error;
@@ -192,26 +200,26 @@ static void *gfx_ctx_qnx_init(void *video_driver)
    }
 
 
-   if (screen_set_window_property_iv(screen_win, SCREEN_PROPERTY_BUFFER_SIZE, buffer_size))
+   if (screen_set_window_property_iv(qnx->screen_win, SCREEN_PROPERTY_BUFFER_SIZE, buffer_size))
    {
       RARCH_ERR("screen_set_window_property_iv [SCREEN_PROPERTY_BUFFER_SIZE] failed.\n");
       goto error;
    }
 
-   if (screen_set_window_property_iv(screen_win, SCREEN_PROPERTY_ROTATION, &angle))
+   if (screen_set_window_property_iv(qnx->screen_win, SCREEN_PROPERTY_ROTATION, &angle))
    {
       RARCH_ERR("screen_set_window_property_iv [SCREEN_PROPERTY_ROTATION] failed.\n");
       goto error;
    }
 #endif
 
-   if (screen_create_window_buffers(screen_win, WINDOW_BUFFERS))
+   if (screen_create_window_buffers(qnx->screen_win, WINDOW_BUFFERS))
    {
       RARCH_ERR("screen_create_window_buffers failed.\n");
       goto error;
    }
 
-   if (!egl_create_surface(screen_win))
+   if (!egl_create_surface(qnx->screen_win))
       goto error;
 
    return "egl";

--- a/gfx/drivers_context/cgl_ctx.c
+++ b/gfx/drivers_context/cgl_ctx.c
@@ -304,7 +304,7 @@ static CGSSurfaceID attach_gl_context_to_window(CGLContextObj glCtx,
     return sid;
 }
 
-static bool gfx_ctx_cgl_init(void *data)
+static void *gfx_ctx_cgl_init(void *video_driver)
 {
    CGError err;
    gfx_ctx_cgl_data_t *cgl = (gfx_ctx_cgl_data_t*)calloc(1, sizeof(gfx_ctx_cgl_data_t));
@@ -333,12 +333,12 @@ static bool gfx_ctx_cgl_init(void *data)
 
    gfx_ctx_data_set(cgl);
 
-   return true;
+   return cgl;
 
 error:
    gfx_ctx_cgl_destroy(cgl);
 
-   return false;
+   return NULL;
 }
 
 const gfx_ctx_driver_t gfx_ctx_cgl = {

--- a/gfx/drivers_context/cocoa_gl_ctx.m
+++ b/gfx/drivers_context/cocoa_gl_ctx.m
@@ -148,9 +148,9 @@ void cocoagl_gfx_ctx_update(void)
 #endif
 }
 
-static bool cocoagl_gfx_ctx_init(void *data)
+static void *cocoagl_gfx_ctx_init(void *video_driver)
 {
-   (void)data;
+   (void)video_driver;
     
 #if defined(HAVE_COCOA)
     CocoaView *g_view = (CocoaView*)nsview_get_ptr();
@@ -196,7 +196,7 @@ static bool cocoagl_gfx_ctx_init(void *data)
     [g_context makeCurrentContext];
    // Make sure the view was created
    [CocoaView get];
-   return true;
+   return "cocoa";
 }
 
 static void cocoagl_gfx_ctx_destroy(void *data)

--- a/gfx/drivers_context/d3d_ctx.cpp
+++ b/gfx/drivers_context/d3d_ctx.cpp
@@ -159,13 +159,13 @@ static bool gfx_ctx_d3d_bind_api(void *data,
 #endif
 }
 
-static bool gfx_ctx_d3d_init(void *data)
+static void *gfx_ctx_d3d_init(void *video_driver)
 {
-   (void)data;
+   (void)video_driver;
 
    win32_monitor_init();
 
-   return true;
+   return "d3d";
 }
 
 static void gfx_ctx_d3d_destroy(void *data)

--- a/gfx/drivers_context/emscriptenegl_ctx.c
+++ b/gfx/drivers_context/emscriptenegl_ctx.c
@@ -101,7 +101,7 @@ static void gfx_ctx_emscripten_get_video_size(void *data,
 
 static void gfx_ctx_emscripten_destroy(void *data);
 
-static bool gfx_ctx_emscripten_init(void *data)
+static void *gfx_ctx_emscripten_init(void *video_driver)
 {
    EGLint width, height, n, major, minor;
    static const EGLint attribute_list[] =
@@ -119,12 +119,12 @@ static bool gfx_ctx_emscripten_init(void *data)
       EGL_NONE
    };
 
-   (void)data;
+   (void)video_driver;
 
    if (g_egl_inited)
    {
       RARCH_LOG("[EMSCRIPTEN/EGL]: Attempted to re-initialize driver.\n");
-      return true;
+      return (void*)"emscripten";
    }
 
    if (!egl_init_context(EGL_DEFAULT_DISPLAY, &major, &minor,
@@ -149,11 +149,11 @@ static bool gfx_ctx_emscripten_init(void *data)
    g_fb_height = height;
    RARCH_LOG("[EMSCRIPTEN/EGL]: Dimensions: %ux%u\n", width, height);
 
-   return true;
+   return (void*)"emscripten";
 
 error:
-   gfx_ctx_emscripten_destroy(data);
-   return false;
+   gfx_ctx_emscripten_destroy(video_driver);
+   return NULL;
 }
 
 static bool gfx_ctx_emscripten_set_video_mode(void *data,

--- a/gfx/drivers_context/gfx_null_ctx.c
+++ b/gfx/drivers_context/gfx_null_ctx.c
@@ -125,11 +125,11 @@ static void gfx_ctx_null_bind_hw_render(void *data, bool enable)
    (void)enable;
 }
 
-static bool gfx_ctx_null_init(void *data)
+static void *gfx_ctx_null_init(void *video_driver)
 {
-   (void)data;
+   (void)video_driver;
 
-   return true;
+   return (void*)"null";
 }
 
 const gfx_ctx_driver_t gfx_ctx_null = {

--- a/gfx/drivers_context/glx_ctx.c
+++ b/gfx/drivers_context/glx_ctx.c
@@ -116,8 +116,7 @@ static void ctx_glx_destroy_resources(gfx_ctx_glx_data_t *glx)
 
 static void gfx_ctx_glx_destroy(void *data)
 {
-   gfx_ctx_glx_data_t *glx = (gfx_ctx_glx_data_t*)
-      gfx_ctx_data_get_ptr();
+   gfx_ctx_glx_data_t *glx = (gfx_ctx_glx_data_t*)data;
 
    if (!glx)
       return;
@@ -125,13 +124,12 @@ static void gfx_ctx_glx_destroy(void *data)
    (void)data;
 
    ctx_glx_destroy_resources(glx);
-   gfx_ctx_free_data();
+   free(data);
 }
 
 static void gfx_ctx_glx_swap_interval(void *data, unsigned interval)
 {
-   gfx_ctx_glx_data_t *glx = (gfx_ctx_glx_data_t*)
-      gfx_ctx_data_get_ptr();
+   gfx_ctx_glx_data_t *glx = (gfx_ctx_glx_data_t*)data;
 
    glx->g_interval = interval;
 
@@ -156,8 +154,7 @@ static void gfx_ctx_glx_swap_interval(void *data, unsigned interval)
 
 static void gfx_ctx_glx_swap_buffers(void *data)
 {
-   gfx_ctx_glx_data_t *glx = (gfx_ctx_glx_data_t*)
-      gfx_ctx_data_get_ptr();
+   gfx_ctx_glx_data_t *glx = (gfx_ctx_glx_data_t*)data;
 
    if (glx->g_is_double)
       glXSwapBuffers(g_x11_dpy, glx->g_glx_win);
@@ -171,7 +168,7 @@ static void gfx_ctx_glx_set_resize(void *data,
    (void)height;
 }
 
-static bool gfx_ctx_glx_init(void *data)
+static void *gfx_ctx_glx_init(void *data)
 {
    static const int visual_attribs[] = {
       GLX_X_RENDERABLE     , True,
@@ -241,9 +238,7 @@ static bool gfx_ctx_glx_init(void *data)
    glx->g_fbc = fbcs[0];
    XFree(fbcs);
 
-   gfx_ctx_data_set(glx);
-
-   return true;
+   return glx;
 
 error:
    ctx_glx_destroy_resources(glx);
@@ -252,7 +247,7 @@ error:
       free(glx);
    g_x11_screen = 0;
 
-   return false;
+   return NULL;
 }
 
 static bool gfx_ctx_glx_set_video_mode(void *data,
@@ -266,8 +261,7 @@ static bool gfx_ctx_glx_set_video_mode(void *data,
    XSetWindowAttributes swa = {0};
    int (*old_handler)(Display*, XErrorEvent*) = NULL;
    settings_t *settings    = config_get_ptr();
-   gfx_ctx_glx_data_t *glx = (gfx_ctx_glx_data_t*)
-      gfx_ctx_data_get_ptr();
+   gfx_ctx_glx_data_t *glx = (gfx_ctx_glx_data_t*)data;
 
    x11_install_sighandlers();
 
@@ -555,8 +549,7 @@ static void gfx_ctx_glx_show_mouse(void *data, bool state)
 
 static void gfx_ctx_glx_bind_hw_render(void *data, bool enable)
 {
-   gfx_ctx_glx_data_t *glx = (gfx_ctx_glx_data_t*)
-      gfx_ctx_data_get_ptr();
+   gfx_ctx_glx_data_t *glx = (gfx_ctx_glx_data_t*)data;
 
    if (!glx)
       return;

--- a/gfx/drivers_context/mali_fbdev_ctx.c
+++ b/gfx/drivers_context/mali_fbdev_ctx.c
@@ -61,7 +61,7 @@ static void gfx_ctx_mali_fbdev_get_video_size(void *data,
    *height = g_height;
 }
 
-static bool gfx_ctx_mali_fbdev_init(void *data)
+static void *gfx_ctx_mali_fbdev_init(void *video_driver)
 {
    EGLint n;
    EGLint major, minor;
@@ -88,12 +88,12 @@ static bool gfx_ctx_mali_fbdev_init(void *data)
       goto error;
    }
 
-   return true;
+   return (void*)"mali";
 
 error:
    RARCH_ERR("[Mali fbdev]: EGL error: %d.\n", eglGetError());
-   gfx_ctx_mali_fbdev_destroy(data);
-   return false;
+   gfx_ctx_mali_fbdev_destroy(video_driver);
+   return NULL;
 }
 
 static void gfx_ctx_mali_fbdev_check_window(void *data, bool *quit,

--- a/gfx/drivers_context/ps3_ctx.c
+++ b/gfx/drivers_context/ps3_ctx.c
@@ -207,10 +207,7 @@ static void gfx_ctx_ps3_update_window_title(void *data)
 static void gfx_ctx_ps3_get_video_size(void *data,
       unsigned *width, unsigned *height)
 {
-   gfx_ctx_ps3_data_t *ps3 = (gfx_ctx_ps3_data_t*)
-      gfx_ctx_data_get_ptr();
-
-   (void)data;
+   gfx_ctx_ps3_data_t *ps3 = (gfx_ctx_ps3_data_t*)data;
 
 #if defined(HAVE_PSGL)
    if (ps3)
@@ -218,7 +215,7 @@ static void gfx_ctx_ps3_get_video_size(void *data,
 #endif
 }
 
-static bool gfx_ctx_ps3_init(void *data)
+static void *gfx_ctx_ps3_init(void *video_driver)
 {
 #ifdef HAVE_PSGL
    PSGLdeviceParameters params;
@@ -228,11 +225,11 @@ static bool gfx_ctx_ps3_init(void *data)
    gfx_ctx_ps3_data_t *ps3 = (gfx_ctx_ps3_data_t*)
       calloc(1, sizeof(gfx_ctx_ps3_data_t));
 
-   (void)data;
+   (void)video_driver;
    (void)global;
 
    if (!ps3)
-      return false;
+      return NULL;
 
 #if defined(HAVE_PSGL)
    options.enable         = PSGL_INIT_MAX_SPUS | PSGL_INIT_INITIALIZE_SPUS;
@@ -291,9 +288,7 @@ static bool gfx_ctx_ps3_init(void *data)
 
    gfx_ctx_ps3_get_available_resolutions();
 
-   gfx_ctx_data_set(ps3);
-
-   return true;
+   return ps3;
 }
 
 static bool gfx_ctx_ps3_set_video_mode(void *data,
@@ -326,10 +321,7 @@ static void gfx_ctx_ps3_destroy_resources(gfx_ctx_ps3_data_t *ps3)
 
 static void gfx_ctx_ps3_destroy(void *data)
 {
-   gfx_ctx_ps3_data_t *ps3 = (gfx_ctx_ps3_data_t*)
-      gfx_ctx_data_get_ptr();
-
-   (void)data;
+   gfx_ctx_ps3_data_t *ps3 = (gfx_ctx_ps3_data_t*)data;
 
    if (!ps3)
       return;

--- a/gfx/drivers_context/vc_egl_ctx.c
+++ b/gfx/drivers_context/vc_egl_ctx.c
@@ -131,7 +131,7 @@ static void gfx_ctx_vc_get_video_size(void *data,
 
 static void gfx_ctx_vc_destroy(void *data);
 
-static bool gfx_ctx_vc_init(void *data)
+static void *gfx_ctx_vc_init(void *video_driver)
 {
    VC_DISPMANX_ALPHA_T alpha;
    EGLint n, major, minor;
@@ -164,7 +164,7 @@ static bool gfx_ctx_vc_init(void *data)
    if (g_egl_inited)
    {
       RARCH_ERR("[VC/EGL]: Attempted to re-initialize driver.\n");
-      return false;
+      return (void*)"vc";
    }
 
    bcm_host_init();
@@ -262,11 +262,11 @@ static bool gfx_ctx_vc_init(void *data)
    if (!egl_create_surface(&nativewindow))
       goto error;
 
-   return true;
+   return (void*)"vc";
 
 error:
-   gfx_ctx_vc_destroy(data);
-   return false;
+   gfx_ctx_vc_destroy(video_driver);
+   return NULL;
 }
 
 static bool gfx_ctx_vc_set_video_mode(void *data,

--- a/gfx/drivers_context/vivante_fbdev_ctx.c
+++ b/gfx/drivers_context/vivante_fbdev_ctx.c
@@ -32,7 +32,7 @@ static void gfx_ctx_vivante_destroy(void *data)
    g_resize       = false;
 }
 
-static bool gfx_ctx_vivante_init(void *data)
+static void *gfx_ctx_vivante_init(void *video_driver)
 {
    EGLint n;
    EGLint major, minor;
@@ -50,7 +50,7 @@ static bool gfx_ctx_vivante_init(void *data)
       EGL_NONE
    };
 
-   (void)data;
+   (void)video_driver;
 
    egl_install_sighandlers();
 
@@ -61,12 +61,12 @@ static bool gfx_ctx_vivante_init(void *data)
       goto error;
    }
 
-   return true;
+   return (void*)"vivante";
 
 error:
    RARCH_ERR("[Vivante fbdev]: EGL error: %d.\n", eglGetError());
-   gfx_ctx_vivante_destroy(data);
-   return false;
+   gfx_ctx_vivante_destroy(video_driver);
+   return NULL;
 }
 
 static void gfx_ctx_vivante_check_window(void *data, bool *quit,

--- a/gfx/drivers_context/wayland_ctx.c
+++ b/gfx/drivers_context/wayland_ctx.c
@@ -28,25 +28,21 @@
 
 typedef struct gfx_ctx_wayland_data
 {
-   bool g_resize;
-   int g_fd;
-   unsigned g_width;
-   unsigned g_height;
-   struct wl_display *g_dpy;
-   struct wl_registry *g_registry;
-   struct wl_compositor *g_compositor;
-   struct wl_surface *g_surface;
-   struct wl_shell_surface *g_shell_surf;
-   struct wl_shell *g_shell;
-   struct wl_egl_window *g_win;
-   struct wl_keyboard *g_wl_keyboard;
-   struct wl_pointer  *g_wl_pointer;
+   egl_ctx_data_t egl;
+   bool resize;
+   int fd;
+   unsigned width;
+   unsigned height;
+   struct wl_display *dpy;
+   struct wl_registry *registry;
+   struct wl_compositor *compositor;
+   struct wl_surface *surface;
+   struct wl_shell_surface *shell_surf;
+   struct wl_shell *shell;
+   struct wl_egl_window *win;
+   struct wl_keyboard *wl_keyboard;
+   struct wl_pointer  *wl_pointer;
 } gfx_ctx_wayland_data_t;
-
-
-static unsigned g_major;
-static unsigned g_minor;
-
 
 #ifndef EGL_OPENGL_ES3_BIT_KHR
 #define EGL_OPENGL_ES3_BIT_KHR 0x0040
@@ -70,11 +66,11 @@ static void shell_surface_handle_configure(void *data,
    (void)shell_surface;
    (void)edges;
 
-   wl->g_width = width;
-   wl->g_height = height;
+   wl->width = width;
+   wl->height = height;
 
    RARCH_LOG("[Wayland/EGL]: Surface configure: %u x %u.\n",
-         wl->g_width, wl->g_height);
+         wl->width, wl->height);
 }
 
 static void shell_surface_handle_popup_done(void *data,
@@ -99,9 +95,9 @@ static void registry_handle_global(void *data, struct wl_registry *reg,
    (void)version;
 
    if (!strcmp(interface, "wl_compositor"))
-      wl->g_compositor = (struct wl_compositor*)wl_registry_bind(reg, id, &wl_compositor_interface, 1);
+      wl->compositor = (struct wl_compositor*)wl_registry_bind(reg, id, &wl_compositor_interface, 1);
    else if (!strcmp(interface, "wl_shell"))
-      wl->g_shell = (struct wl_shell*)wl_registry_bind(reg, id, &wl_shell_interface, 1);
+      wl->shell = (struct wl_shell*)wl_registry_bind(reg, id, &wl_shell_interface, 1);
 }
 
 static void registry_handle_global_remove(void *data,
@@ -127,37 +123,37 @@ static void gfx_ctx_wl_destroy_resources(gfx_ctx_wayland_data_t *wl)
    if (!wl)
       return;
 
-   egl_destroy(NULL);
+   egl_destroy(wl);
 
-   if (wl->g_win)
-      wl_egl_window_destroy(wl->g_win);
-   if (wl->g_shell)
-      wl_shell_destroy(wl->g_shell);
-   if (wl->g_compositor)
-      wl_compositor_destroy(wl->g_compositor);
-   if (wl->g_registry)
-      wl_registry_destroy(wl->g_registry);
-   if (wl->g_shell_surf)
-      wl_shell_surface_destroy(wl->g_shell_surf);
-   if (wl->g_surface)
-      wl_surface_destroy(wl->g_surface);
+   if (wl->win)
+      wl_egl_window_destroy(wl->win);
+   if (wl->shell)
+      wl_shell_destroy(wl->shell);
+   if (wl->compositor)
+      wl_compositor_destroy(wl->compositor);
+   if (wl->registry)
+      wl_registry_destroy(wl->registry);
+   if (wl->shell_surf)
+      wl_shell_surface_destroy(wl->shell_surf);
+   if (wl->surface)
+      wl_surface_destroy(wl->surface);
 
-   if (wl->g_dpy)
+   if (wl->dpy)
    {
-      wl_display_flush(wl->g_dpy);
-      wl_display_disconnect(wl->g_dpy);
+      wl_display_flush(wl->dpy);
+      wl_display_disconnect(wl->dpy);
    }
 
-   wl->g_win        = NULL;
-   wl->g_shell      = NULL;
-   wl->g_compositor = NULL;
-   wl->g_registry   = NULL;
-   wl->g_dpy        = NULL;
-   wl->g_shell_surf = NULL;
-   wl->g_surface    = NULL;
+   wl->win        = NULL;
+   wl->shell      = NULL;
+   wl->compositor = NULL;
+   wl->registry   = NULL;
+   wl->dpy        = NULL;
+   wl->shell_surf = NULL;
+   wl->surface    = NULL;
 
-   wl->g_width  = 0;
-   wl->g_height = 0;
+   wl->width  = 0;
+   wl->height = 0;
 }
 
 static void flush_wayland_fd(void)
@@ -166,24 +162,24 @@ static void flush_wayland_fd(void)
    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)
       gfx_ctx_data_get_ptr();
 
-   wl_display_dispatch_pending(wl->g_dpy);
-   wl_display_flush(wl->g_dpy);
+   wl_display_dispatch_pending(wl->dpy);
+   wl_display_flush(wl->dpy);
 
-   fd.fd = wl->g_fd;
+   fd.fd = wl->fd;
    fd.events = POLLIN | POLLOUT | POLLERR | POLLHUP;
 
    if (poll(&fd, 1, 0) > 0)
    {
       if (fd.revents & (POLLERR | POLLHUP))
       {
-         close(wl->g_fd);
+         close(wl->fd);
          g_egl_quit = true;
       }
 
       if (fd.revents & POLLIN)
-         wl_display_dispatch(wl->g_dpy);
+         wl_display_dispatch(wl->dpy);
       if (fd.revents & POLLOUT)
-         wl_display_flush(wl->g_dpy);
+         wl_display_flush(wl->dpy);
    }
 }
 
@@ -216,7 +212,7 @@ static void gfx_ctx_wl_set_resize(void *data, unsigned width, unsigned height)
 {
    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
 
-   wl_egl_window_resize(wl->g_win, width, height, 0, 0);
+   wl_egl_window_resize(wl->win, width, height, 0, 0);
 }
 
 static void gfx_ctx_wl_update_window_title(void *data)
@@ -228,7 +224,7 @@ static void gfx_ctx_wl_update_window_title(void *data)
 
    if (video_monitor_get_fps(buf, sizeof(buf),  
             buf_fps, sizeof(buf_fps)))
-      wl_shell_surface_set_title(wl->g_shell_surf, buf);
+      wl_shell_surface_set_title(wl->shell_surf, buf);
 
    if (settings->fps_show)
       runloop_msg_queue_push(buf_fps, 1, 1, false);
@@ -239,8 +235,8 @@ static void gfx_ctx_wl_get_video_size(void *data,
 {
    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
 
-   *width  = wl->g_width;
-   *height = wl->g_height;
+   *width  = wl->width;
+   *height = wl->height;
 }
 
 #define DEFAULT_WINDOWED_WIDTH 640
@@ -293,14 +289,14 @@ static void *gfx_ctx_wl_init(void *video_driver)
    if (!wl)
       return NULL;
 
-   switch (g_egl_api)
+   switch (wl->egl.api)
    {
       case GFX_CTX_OPENGL_API:
          attrib_ptr = egl_attribs_gl;
          break;
       case GFX_CTX_OPENGL_ES_API:
 #ifdef EGL_KHR_create_context
-         if (g_major >= 3)
+         if (g_egl_major >= 3)
             attrib_ptr = egl_attribs_gles3;
          else
 #endif
@@ -315,39 +311,40 @@ static void *gfx_ctx_wl_init(void *video_driver)
 
    g_egl_quit = 0;
 
-   wl->g_dpy = wl_display_connect(NULL);
-   if (!wl->g_dpy)
+   wl->dpy = wl_display_connect(NULL);
+   if (!wl->dpy)
    {
       RARCH_ERR("Failed to connect to Wayland server.\n");
       goto error;
    }
 
-   wl->g_registry = wl_display_get_registry(wl->g_dpy);
-   wl_registry_add_listener(wl->g_registry, &registry_listener, NULL);
-   wl_display_dispatch(wl->g_dpy);
+   wl->registry = wl_display_get_registry(wl->dpy);
+   wl_registry_add_listener(wl->registry, &registry_listener, wl);
+   wl_display_dispatch(wl->dpy);
+   wl_display_roundtrip(wl->dpy);
 
-   if (!wl->g_compositor)
+   if (!wl->compositor)
    {
       RARCH_ERR("Failed to create compositor.\n");
       goto error;
    }
 
-   if (!wl->g_shell)
+   if (!wl->shell)
    {
       RARCH_ERR("Failed to create shell.\n");
       goto error;
    }
 
-   wl->g_fd = wl_display_get_fd(wl->g_dpy);
+   wl->fd = wl_display_get_fd(wl->dpy);
 
-   if (!egl_init_context((EGLNativeDisplayType)wl->g_dpy,
+   if (!egl_init_context(wl, (EGLNativeDisplayType)wl->dpy,
             &major, &minor, &n, attrib_ptr))
    {
       egl_report_error();
       goto error;
    }
 
-   if (n == 0 || !egl_has_config())
+   if (n == 0 || !egl_has_config(wl))
       goto error;
 
    return wl;
@@ -361,14 +358,14 @@ error:
    return NULL;
 }
 
-static EGLint *egl_fill_attribs(EGLint *attr)
+static EGLint *egl_fill_attribs(gfx_ctx_wayland_data_t *wl, EGLint *attr)
 {
-   switch (g_egl_api)
+   switch (wl->egl.api)
    {
 #ifdef EGL_KHR_create_context
       case GFX_CTX_OPENGL_API:
       {
-         unsigned version = g_major * 1000 + g_minor;
+         unsigned version = wl->egl.major * 1000 + wl->egl.minor;
          bool core = version >= 3001;
 #ifdef GL_DEBUG
          bool debug = true;
@@ -381,9 +378,9 @@ static EGLint *egl_fill_attribs(EGLint *attr)
          if (core)
          {
             *attr++ = EGL_CONTEXT_MAJOR_VERSION_KHR;
-            *attr++ = g_major;
+            *attr++ = wl->egl.major;
             *attr++ = EGL_CONTEXT_MINOR_VERSION_KHR;
-            *attr++ = g_minor;
+            *attr++ = wl->egl.minor;
             /* Technically, we don't have core/compat until 3.2.
              * Version 3.1 is either compat or not depending on GL_ARB_compatibility. */
             if (version >= 3002)
@@ -405,12 +402,12 @@ static EGLint *egl_fill_attribs(EGLint *attr)
 
       case GFX_CTX_OPENGL_ES_API:
          *attr++ = EGL_CONTEXT_CLIENT_VERSION; /* Same as EGL_CONTEXT_MAJOR_VERSION */
-         *attr++ = g_major ? (EGLint)g_major : 2;
+         *attr++ = wl->egl.major ? (EGLint)wl->egl.major : 2;
 #ifdef EGL_KHR_create_context
-         if (g_minor > 0)
+         if (wl->egl.minor > 0)
          {
             *attr++ = EGL_CONTEXT_MINOR_VERSION_KHR;
-            *attr++ = g_minor;
+            *attr++ = wl->egl.minor;
          }
 #endif
          break;
@@ -445,33 +442,33 @@ static bool gfx_ctx_wl_set_video_mode(void *data,
 
    egl_install_sighandlers();
 
-   attr = egl_fill_attribs(egl_attribs);
+   attr = egl_fill_attribs(wl, egl_attribs);
 
-   wl->g_width = width ? width : DEFAULT_WINDOWED_WIDTH;
-   wl->g_height = height ? height : DEFAULT_WINDOWED_HEIGHT;
+   wl->width = width ? width : DEFAULT_WINDOWED_WIDTH;
+   wl->height = height ? height : DEFAULT_WINDOWED_HEIGHT;
 
-   wl->g_surface = wl_compositor_create_surface(wl->g_compositor);
-   wl->g_win = wl_egl_window_create(wl->g_surface, wl->g_width, wl->g_height);
-   wl->g_shell_surf = wl_shell_get_shell_surface(wl->g_shell, wl->g_surface);
+   wl->surface = wl_compositor_create_surface(wl->compositor);
+   wl->win = wl_egl_window_create(wl->surface, wl->width, wl->height);
+   wl->shell_surf = wl_shell_get_shell_surface(wl->shell, wl->surface);
 
-   wl_shell_surface_add_listener(wl->g_shell_surf, &shell_surface_listener, NULL);
-   wl_shell_surface_set_toplevel(wl->g_shell_surf);
-   wl_shell_surface_set_class(wl->g_shell_surf, "RetroArch");
-   wl_shell_surface_set_title(wl->g_shell_surf, "RetroArch");
+   wl_shell_surface_add_listener(wl->shell_surf, &shell_surface_listener, NULL);
+   wl_shell_surface_set_toplevel(wl->shell_surf);
+   wl_shell_surface_set_class(wl->shell_surf, "RetroArch");
+   wl_shell_surface_set_title(wl->shell_surf, "RetroArch");
 
-   if (!egl_create_context((attr != egl_attribs) ? egl_attribs : NULL))
+   if (!egl_create_context(wl, (attr != egl_attribs) ? egl_attribs : NULL))
    {
       egl_report_error();
       goto error;
    }
 
-   if (!egl_create_surface((EGLNativeWindowType)wl->g_win))
+   if (!egl_create_surface(wl, (EGLNativeWindowType)wl->win))
       goto error;
 
-   egl_set_swap_interval(data, g_interval);
+   egl_set_swap_interval(wl, wl->egl.interval);
 
    if (fullscreen)
-      wl_shell_surface_set_fullscreen(wl->g_shell_surf, WL_SHELL_SURFACE_FULLSCREEN_METHOD_DEFAULT, 0, NULL);
+      wl_shell_surface_set_fullscreen(wl->shell_surf, WL_SHELL_SURFACE_FULLSCREEN_METHOD_DEFAULT, 0, NULL);
 
    flush_wayland_fd();
    return true;
@@ -513,14 +510,12 @@ static bool gfx_ctx_wl_has_windowed(void *data)
    return true;
 }
 
-static bool gfx_ctx_wl_bind_api(void *data,
+static bool gfx_ctx_wl_bind_api(void *video_driver,
       enum gfx_ctx_api api, unsigned major, unsigned minor)
 {
-   (void)data;
-
-   g_major   = major;
-   g_minor   = minor;
-   g_egl_api = api;
+   g_egl_major = major;
+   g_egl_minor = minor;
+   g_egl_api   = api;
 
    switch (api)
    {
@@ -660,25 +655,25 @@ struct wl_seat *seat, unsigned caps)
 {
    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
 
-   if ((caps & WL_SEAT_CAPABILITY_KEYBOARD) && !wl->g_wl_keyboard)
+   if ((caps & WL_SEAT_CAPABILITY_KEYBOARD) && !wl->wl_keyboard)
    {
-      wl->g_wl_keyboard = wl_seat_get_keyboard(seat);
-      wl_keyboard_add_listener(wl->g_wl_keyboard, &keyboard_listener, NULL);
+      wl->wl_keyboard = wl_seat_get_keyboard(seat);
+      wl_keyboard_add_listener(wl->wl_keyboard, &keyboard_listener, NULL);
    }
-   else if (!(caps & WL_SEAT_CAPABILITY_KEYBOARD) && wl->g_wl_keyboard)
+   else if (!(caps & WL_SEAT_CAPABILITY_KEYBOARD) && wl->wl_keyboard)
    {
-      wl_keyboard_destroy(wl->g_wl_keyboard);
-      wl->g_wl_keyboard = NULL;
+      wl_keyboard_destroy(wl->wl_keyboard);
+      wl->wl_keyboard = NULL;
    }
-   if ((caps & WL_SEAT_CAPABILITY_POINTER) && !wl->g_wl_pointer)
+   if ((caps & WL_SEAT_CAPABILITY_POINTER) && !wl->wl_pointer)
    {
-      wl->g_wl_pointer = wl_seat_get_pointer(seat);
-      wl_pointer_add_listener(wl->g_wl_pointer, &pointer_listener, NULL);
+      wl->wl_pointer = wl_seat_get_pointer(seat);
+      wl_pointer_add_listener(wl->wl_pointer, &pointer_listener, NULL);
    }
-   else if (!(caps & WL_SEAT_CAPABILITY_POINTER) && wl->g_wl_pointer)
+   else if (!(caps & WL_SEAT_CAPABILITY_POINTER) && wl->wl_pointer)
    {
-      wl_pointer_destroy(wl->g_wl_pointer);
-      wl->g_wl_pointer = NULL;
+      wl_pointer_destroy(wl->wl_pointer);
+      wl->wl_pointer = NULL;
    }
 }
 

--- a/gfx/drivers_context/wgl_ctx.cpp
+++ b/gfx/drivers_context/wgl_ctx.cpp
@@ -295,23 +295,23 @@ static void gfx_ctx_wgl_get_video_size(void *data, unsigned *width, unsigned *he
    }
 }
 
-static bool gfx_ctx_wgl_init(void *data)
+static void *gfx_ctx_wgl_init(void *video_driver)
 {
    WNDCLASSEX wndclass = {0};
 
-   (void)data;
+   (void)video_driver;
 
    if (g_inited)
-      return false;
+      return NULL;
 
    win32_window_reset();
    win32_monitor_init();
 
    wndclass.lpfnWndProc   = WndProcGL;
    if (!win32_window_init(&wndclass, true, NULL))
-	   return false;
+           return NULL;
 
-   return true;
+   return (void*)"wgl";
 }
 
 static void gfx_ctx_wgl_destroy(void *data)

--- a/gfx/drivers_context/xegl_ctx.c
+++ b/gfx/drivers_context/xegl_ctx.c
@@ -81,7 +81,7 @@ EGL_BLUE_SIZE,       1, \
 EGL_ALPHA_SIZE,      0, \
 EGL_DEPTH_SIZE,      0
 
-static bool gfx_ctx_xegl_init(void *data)
+static void *gfx_ctx_xegl_init(void *video_driver)
 {
    static const EGLint egl_attribs_gl[] = {
       XEGL_ATTRIBS_BASE,
@@ -114,7 +114,7 @@ static bool gfx_ctx_xegl_init(void *data)
    EGLint n;
 
    if (g_egl_inited)
-      return false;
+      return NULL;
 
    XInitThreads();
 
@@ -151,11 +151,11 @@ static bool gfx_ctx_xegl_init(void *data)
    if (n == 0 || !egl_has_config())
       goto error;
 
-   return true;
+   return (void*)"xegl";
 
 error:
-   gfx_ctx_xegl_destroy(data);
-   return false;
+   gfx_ctx_xegl_destroy(video_driver);
+   return NULL;
 }
 
 static EGLint *xegl_fill_attribs(EGLint *attr)

--- a/gfx/drivers_context/xegl_ctx.c
+++ b/gfx/drivers_context/xegl_ctx.c
@@ -27,11 +27,11 @@
 #define EGL_OPENGL_ES3_BIT_KHR 0x0040
 #endif
 
-static XF86VidModeModeInfo g_desktop_mode;
-static bool g_should_reset_mode;
-
-static unsigned g_major;
-static unsigned g_minor;
+typedef struct {
+   egl_ctx_data_t egl;
+   XF86VidModeModeInfo desktop_mode;
+   bool should_reset_mode;
+} xegl_ctx_data_t;
 
 static int egl_nul_handler(Display *dpy, XErrorEvent *event)
 {
@@ -42,6 +42,8 @@ static int egl_nul_handler(Display *dpy, XErrorEvent *event)
 
 static void gfx_ctx_xegl_destroy(void *data)
 {
+   xegl_ctx_data_t *xegl = (xegl_ctx_data_t*)data;
+
    x11_input_ctx_destroy();
    egl_destroy(data);
 
@@ -54,11 +56,13 @@ static void gfx_ctx_xegl_destroy(void *data)
 
    x11_colormap_destroy();
 
-   if (g_should_reset_mode)
+   if (xegl->should_reset_mode)
    {
-      x11_exit_fullscreen(g_x11_dpy, &g_desktop_mode);
-      g_should_reset_mode = false;
+      x11_exit_fullscreen(g_x11_dpy, &xegl->desktop_mode);
+      xegl->should_reset_mode = false;
    }
+
+   free(data);
 
    /* Do not close g_x11_dpy. We'll keep one for the entire application 
     * lifecycle to work-around nVidia EGL limitations.
@@ -112,20 +116,26 @@ static void *gfx_ctx_xegl_init(void *video_driver)
    const EGLint *attrib_ptr;
    EGLint major, minor;
    EGLint n;
+   xegl_ctx_data_t *xegl;
+
 
    if (g_egl_inited)
       return NULL;
 
    XInitThreads();
 
-   switch (g_egl_api)
+   xegl = (xegl_ctx_data_t*)calloc(1, sizeof(xegl_ctx_data_t));
+   if (!xegl)
+      return NULL;
+
+   switch (xegl->egl.api)
    {
       case GFX_CTX_OPENGL_API:
          attrib_ptr = egl_attribs_gl;
          break;
       case GFX_CTX_OPENGL_ES_API:
 #ifdef EGL_KHR_create_context
-         if (g_major >= 3)
+         if (xegl->egl.major >= 3)
             attrib_ptr = egl_attribs_gles3;
          else
 #endif
@@ -141,33 +151,33 @@ static void *gfx_ctx_xegl_init(void *video_driver)
    if (!x11_connect())
       goto error;
 
-   if (!egl_init_context((EGLNativeDisplayType)g_x11_dpy,
+   if (!egl_init_context(xegl, (EGLNativeDisplayType)g_x11_dpy,
             &major, &minor, &n, attrib_ptr))
    {
       egl_report_error();
       goto error;
    }
 
-   if (n == 0 || !egl_has_config())
+   if (n == 0 || !egl_has_config(xegl))
       goto error;
 
-   return (void*)"xegl";
+   return xegl;
 
 error:
-   gfx_ctx_xegl_destroy(video_driver);
+   gfx_ctx_xegl_destroy(xegl);
    return NULL;
 }
 
-static EGLint *xegl_fill_attribs(EGLint *attr)
+static EGLint *xegl_fill_attribs(xegl_ctx_data_t *xegl, EGLint *attr)
 {
-   switch (g_egl_api)
+   switch (xegl->egl.api)
    {
 #ifdef EGL_KHR_create_context
       case GFX_CTX_OPENGL_API:
          {
             const struct retro_hw_render_callback *hw_render =
                (const struct retro_hw_render_callback*)video_driver_callback();
-            unsigned version = g_major * 1000 + g_minor;
+            unsigned version = xegl->egl.major * 1000 + xegl->egl.minor;
             bool core        = version >= 3001;
 #ifdef GL_DEBUG
             bool debug = true;
@@ -178,9 +188,9 @@ static EGLint *xegl_fill_attribs(EGLint *attr)
             if (core)
             {
                *attr++ = EGL_CONTEXT_MAJOR_VERSION_KHR;
-               *attr++ = g_major;
+               *attr++ = xegl->egl.major;
                *attr++ = EGL_CONTEXT_MINOR_VERSION_KHR;
-               *attr++ = g_minor;
+               *attr++ = xegl->egl.minor;
 
                /* Technically, we don't have core/compat until 3.2.
                 * Version 3.1 is either compat or not depending 
@@ -206,12 +216,12 @@ static EGLint *xegl_fill_attribs(EGLint *attr)
       case GFX_CTX_OPENGL_ES_API:
          /* Same as EGL_CONTEXT_MAJOR_VERSION. */
          *attr++ = EGL_CONTEXT_CLIENT_VERSION;
-         *attr++ = g_major ? (EGLint)g_major : 2;
+         *attr++ = xegl->egl.major ? (EGLint)xegl->egl.major : 2;
 #ifdef EGL_KHR_create_context
-         if (g_minor > 0)
+         if (xegl->egl.minor > 0)
          {
             *attr++ = EGL_CONTEXT_MINOR_VERSION_KHR;
-            *attr++ = g_minor;
+            *attr++ = xegl->egl.minor;
          }
 #endif
          break;
@@ -240,6 +250,7 @@ static bool gfx_ctx_xegl_set_video_mode(void *data,
    XSetWindowAttributes swa = {0};
    XVisualInfo *vi = NULL;
    settings_t *settings = config_get_ptr();
+   xegl_ctx_data_t *xegl = (xegl_ctx_data_t*)data;
 
    int (*old_handler)(Display*, XErrorEvent*) = NULL;
 
@@ -248,9 +259,9 @@ static bool gfx_ctx_xegl_set_video_mode(void *data,
    windowed_full = settings->video.windowed_fullscreen;
 
    attr = egl_attribs;
-   attr = xegl_fill_attribs(attr);
+   attr = xegl_fill_attribs(xegl, attr);
 
-   if (!egl_get_native_visual_id(&vid))
+   if (!egl_get_native_visual_id(xegl, &vid))
       goto error;
 
    temp.visualid = vid;
@@ -266,9 +277,9 @@ static bool gfx_ctx_xegl_set_video_mode(void *data,
 
    if (fullscreen && !windowed_full)
    {
-      if (x11_enter_fullscreen(g_x11_dpy, width, height, &g_desktop_mode))
+      if (x11_enter_fullscreen(g_x11_dpy, width, height, &xegl->desktop_mode))
       {
-         g_should_reset_mode = true;
+         xegl->should_reset_mode = true;
          true_full = true;
       }
       else
@@ -306,13 +317,13 @@ static bool gfx_ctx_xegl_set_video_mode(void *data,
          CWBorderPixel | CWColormap | CWEventMask | (true_full ? CWOverrideRedirect : 0), &swa);
    XSetWindowBackground(g_x11_dpy, g_x11_win, 0);
 
-   if (!egl_create_context((attr != egl_attribs) ? egl_attribs : NULL))
+   if (!egl_create_context(xegl, (attr != egl_attribs) ? egl_attribs : NULL))
    {
       egl_report_error();
       goto error;
    }
 
-   if (!egl_create_surface((EGLNativeWindowType)g_x11_win))
+   if (!egl_create_surface(xegl, (EGLNativeWindowType)g_x11_win))
       goto error;
 
    x11_set_window_attr(g_x11_dpy, g_x11_win);
@@ -356,7 +367,7 @@ static bool gfx_ctx_xegl_set_video_mode(void *data,
    x11_event_queue_check(&event);
    x11_install_quit_atom();
 
-   egl_set_swap_interval(data, g_interval);
+   egl_set_swap_interval(xegl, xegl->egl.interval);
 
    /* This can blow up on some drivers. It's not fatal, 
     * so override errors for this call.
@@ -367,7 +378,7 @@ static bool gfx_ctx_xegl_set_video_mode(void *data,
    XSetErrorHandler(old_handler);
 
    XFree(vi);
-   g_egl_inited    = true;
+   g_egl_inited = true;
 
    if (!x11_input_ctx_new(true_full))
       goto error;
@@ -423,13 +434,11 @@ static bool gfx_ctx_xegl_has_windowed(void *data)
    return true;
 }
 
-static bool gfx_ctx_xegl_bind_api(void *data,
+static bool gfx_ctx_xegl_bind_api(void *video_driver,
    enum gfx_ctx_api api, unsigned major, unsigned minor)
 {
-   (void)data;
-
-   g_major   = major;
-   g_minor   = minor;
+   g_egl_major  = major;
+   g_egl_minor  = minor;
    g_egl_api = api;
 
    switch (api)

--- a/gfx/video_context_driver.c
+++ b/gfx/video_context_driver.c
@@ -103,6 +103,7 @@ void gfx_ctx_free(void)
    if (current_video_context->destroy)
       current_video_context->destroy(video_context_data);
    current_video_context = NULL;
+   video_context_data    = NULL;
 }
 
 const char *gfx_ctx_get_ident(void)

--- a/gfx/video_context_driver.c
+++ b/gfx/video_context_driver.c
@@ -98,24 +98,10 @@ void gfx_ctx_destroy(const gfx_ctx_driver_t *ctx_driver)
    current_video_context = NULL;
 }
 
-void gfx_ctx_data_set(void *ptr)
-{
-   if (!ptr)
-      return;
-   video_context_data = ptr;
-}
-
-void gfx_ctx_free_data(void)
-{
-   if (video_context_data)
-      free(video_context_data);
-   video_context_data = NULL;
-}
-
-void gfx_ctx_free(void *data)
+void gfx_ctx_free(void)
 {
    if (current_video_context->destroy)
-      current_video_context->destroy(data);
+      current_video_context->destroy(video_context_data);
    current_video_context = NULL;
 }
 
@@ -128,78 +114,78 @@ const char *gfx_ctx_get_ident(void)
    return ctx->ident;
 }
 
-void gfx_ctx_update_window_title(void *data)
+void gfx_ctx_update_window_title(void)
 {
    if (current_video_context->update_window_title)
-      current_video_context->update_window_title(data);
+      current_video_context->update_window_title(video_context_data);
 }
 
-void gfx_ctx_get_video_output_size(void *data,
+void gfx_ctx_get_video_output_size(
       unsigned *width, unsigned *height)
 {
    const gfx_ctx_driver_t *ctx = current_video_context;
 
    if (ctx->get_video_output_size)
-      ctx->get_video_output_size(data, width, height);
+      ctx->get_video_output_size(video_context_data, width, height);
 }
 
-bool gfx_ctx_get_video_output_prev(void *data)
+bool gfx_ctx_get_video_output_prev(void)
 {
    if (current_video_context->get_video_output_prev)
    {
-      current_video_context->get_video_output_prev(data);
+      current_video_context->get_video_output_prev(video_context_data);
       return true;
    }
 
    return false;
 }
 
-bool gfx_ctx_get_video_output_next(void *data)
+bool gfx_ctx_get_video_output_next(void)
 {
    if (current_video_context->get_video_output_next)
    {
-      current_video_context->get_video_output_next(data);
+      current_video_context->get_video_output_next(video_context_data);
       return true;
    }
 
    return false;
 }
 
-void gfx_ctx_swap_buffers(void *data)
+void gfx_ctx_swap_buffers(void)
 {
    if (!current_video_context)
       return;
    if (current_video_context->swap_buffers)
-      current_video_context->swap_buffers(data);
+      current_video_context->swap_buffers(video_context_data);
 }
 
-void gfx_ctx_bind_hw_render(void *data, bool enable)
+void gfx_ctx_bind_hw_render(bool enable)
 {
    if (current_video_context->bind_hw_render)
-      current_video_context->bind_hw_render(data, enable);
+      current_video_context->bind_hw_render(video_context_data, enable);
 }
 
-bool gfx_ctx_focus(void *data)
+bool gfx_ctx_focus(void)
 {
-   if (data && current_video_context->has_focus)
-      return current_video_context->has_focus(data);
+   if (video_context_data && current_video_context->has_focus)
+      return current_video_context->has_focus(video_context_data);
    return false;
 }
 
-bool gfx_ctx_set_video_mode(void *data,
+bool gfx_ctx_set_video_mode(
       unsigned width, unsigned height,
       bool fullscreen)
 {
    if (current_video_context->set_video_mode)
-      return current_video_context->set_video_mode(data, width, height, fullscreen);
+      return current_video_context->set_video_mode(video_context_data, width, height, fullscreen);
    return false;
 }
 
-void gfx_ctx_translate_aspect(void *data, float *aspect,
+void gfx_ctx_translate_aspect(float *aspect,
       unsigned width, unsigned height)
 {
    if (current_video_context->translate_aspect)
-      *aspect = current_video_context->translate_aspect(data, width, height);
+      *aspect = current_video_context->translate_aspect(video_context_data, width, height);
 }
 
 bool gfx_ctx_get_metrics(enum display_metric_types type, float *value)
@@ -234,64 +220,64 @@ retro_proc_address_t gfx_ctx_get_proc_address(const char *sym)
    return current_video_context->get_proc_address(sym);
 }
 
-void gfx_ctx_show_mouse(void *data, bool state)
+void gfx_ctx_show_mouse(bool state)
 {
-   if (data && current_video_context->show_mouse)
-      current_video_context->show_mouse(data, state);
+   if (video_context_data && current_video_context->show_mouse)
+      current_video_context->show_mouse(video_context_data, state);
 }
 
-bool gfx_ctx_has_windowed(void *data)
+bool gfx_ctx_has_windowed(void)
 {
-   if (data)
-      return current_video_context->has_windowed(data);
+   if (video_context_data)
+      return current_video_context->has_windowed(video_context_data);
    return true;
 }
 
-bool gfx_ctx_check_window(void *data, bool *quit, bool *resize,
+bool gfx_ctx_check_window(bool *quit, bool *resize,
       unsigned *width, unsigned *height)
 {
    uint64_t       *frame_count;
    
    video_driver_ctl(RARCH_DISPLAY_CTL_GET_FRAME_COUNT, &frame_count);
 
-   if (!data)
+   if (!video_context_data)
       return false;
    
-   current_video_context->check_window(data, quit, resize, width, height, (unsigned int)*frame_count);
+   current_video_context->check_window(video_context_data, quit, resize, width, height, (unsigned int)*frame_count);
 
    return true;
 }
 
-bool gfx_ctx_suppress_screensaver(void *data, bool enable)
+bool gfx_ctx_suppress_screensaver(bool enable)
 {
-   if (data && current_video_context)
-      return current_video_context->suppress_screensaver(data, enable);
+   if (video_context_data && current_video_context)
+      return current_video_context->suppress_screensaver(video_context_data, enable);
    return false;
 }
 
-void gfx_ctx_get_video_size(void *data,
+void gfx_ctx_get_video_size(
       unsigned *width, unsigned *height)
 {
-   current_video_context->get_video_size(data, width, height);
+   current_video_context->get_video_size(video_context_data, width, height);
 }
 
-void gfx_ctx_swap_interval(void *data, unsigned interval)
+void gfx_ctx_swap_interval(unsigned interval)
 {
    if (current_video_context)
-      current_video_context->swap_interval(data, interval);
+      current_video_context->swap_interval(video_context_data, interval);
 }
 
-void gfx_ctx_set_resize(void *data, unsigned width, unsigned height)
+void gfx_ctx_set_resize(unsigned width, unsigned height)
 {
    if (current_video_context)
-      current_video_context->set_resize(data, width, height);
+      current_video_context->set_resize(video_context_data, width, height);
 }
 
-void gfx_ctx_input_driver(void *data,
+void gfx_ctx_input_driver(
       const input_driver_t **input, void **input_data)
 {
    if (current_video_context)
-      current_video_context->input_driver(data, input, input_data);
+      current_video_context->input_driver(video_context_data, input, input_data);
 }
 
 /**
@@ -375,15 +361,16 @@ static const gfx_ctx_driver_t *gfx_ctx_init(void *data,
 
    if (ctx->bind_api(data, api, major, minor))
    {
-      bool initialized = ctx->init(data);
+      void *ctx_data = ctx->init(data);
 
-      if (!initialized)
+      if (!ctx_data)
          return NULL;
 
       if (ctx->bind_hw_render)
-         ctx->bind_hw_render(data,
+         ctx->bind_hw_render(ctx_data,
                settings->video.shared_context && hw_render_ctx);
 
+      video_context_data = ctx_data;
       return ctx;
    }
 

--- a/gfx/video_context_driver.h
+++ b/gfx/video_context_driver.h
@@ -64,7 +64,7 @@ typedef struct gfx_ctx_driver
    void (*destroy)(void *data);
 
    /* Which API to bind to. */
-   bool (*bind_api)(void *data, enum gfx_ctx_api,
+   bool (*bind_api)(void *video_driver, enum gfx_ctx_api,
          unsigned major, unsigned minor);
 
    /* Sets the swap interval. */

--- a/gfx/video_context_driver.h
+++ b/gfx/video_context_driver.h
@@ -53,17 +53,14 @@ enum display_metric_types
 
 typedef void (*gfx_ctx_proc_t)(void);
 
-/* The opaque void* argument should be the overlying driver data 
- * (e.g. gl_t for OpenGL contexts).
- *
- * This will allow us in the future to have separate contexts 
- * to separate gl_t structs (if needed).
- *
- * For now, this is only relevant for D3D. */
-
 typedef struct gfx_ctx_driver
 {
-   bool (*init)(void *data);
+   /* The opaque pointer is the underlying video driver data (e.g. gl_t for
+    * OpenGL contexts). Although not advised, the context driver is allowed
+    * to hold a pointer to it as the context never outlives the video driver.
+    *
+    * The context driver is responsible for it's own data.*/
+   void* (*init)(void *video_driver);
    void (*destroy)(void *data);
 
    /* Which API to bind to. */
@@ -203,16 +200,15 @@ void find_prev_gfx_context_driver(void);
 
 bool gfx_ctx_get_metrics(enum display_metric_types type, float *value);
 
-void gfx_ctx_translate_aspect(void *data, float *aspect,
+void gfx_ctx_translate_aspect(float *aspect,
       unsigned width, unsigned height);
 
-bool gfx_ctx_set_video_mode(void *data,
-      unsigned width, unsigned height,
+bool gfx_ctx_set_video_mode(unsigned width, unsigned height,
       bool fullscreen);
 
-void gfx_ctx_swap_buffers(void *data);
+void gfx_ctx_swap_buffers(void);
 
-bool gfx_ctx_focus(void *data);
+bool gfx_ctx_focus(void);
 
 bool gfx_ctx_image_buffer_init(void *data, const video_info_t *info);
 
@@ -220,46 +216,41 @@ bool gfx_ctx_image_buffer_write(void *data, const void *frame,
       unsigned width, unsigned height, unsigned pitch, bool rgb32,
       unsigned index, void **image_handle);
 
-void gfx_ctx_show_mouse(void *data, bool state);
+void gfx_ctx_show_mouse(bool state);
 
-bool gfx_ctx_has_windowed(void *data);
+bool gfx_ctx_has_windowed(void);
 
-bool gfx_ctx_check_window(void *data, bool *quit, bool *resize,
+bool gfx_ctx_check_window(bool *quit, bool *resize,
       unsigned *width, unsigned *height);
 
-bool gfx_ctx_suppress_screensaver(void *data, bool enable);
+bool gfx_ctx_suppress_screensaver(bool enable);
 
-void gfx_ctx_update_window_title(void *data);
+void gfx_ctx_update_window_title(void);
 
-void gfx_ctx_get_video_size(void *data, unsigned *width, unsigned *height);
+void gfx_ctx_get_video_size(unsigned *width, unsigned *height);
 
-void gfx_ctx_set_resize(void *data, unsigned width, unsigned height);
+void gfx_ctx_set_resize(unsigned width, unsigned height);
 
-void gfx_ctx_swap_interval(void *data, unsigned interval);
+void gfx_ctx_swap_interval(unsigned interval);
 
-void gfx_ctx_bind_hw_render(void *data, bool enable);
+void gfx_ctx_bind_hw_render(bool enable);
 
-void gfx_ctx_get_video_output_size(void *data,
-      unsigned *width, unsigned *height);
+void gfx_ctx_get_video_output_size(unsigned *width, unsigned *height);
 
-bool gfx_ctx_get_video_output_prev(void *data);
+bool gfx_ctx_get_video_output_prev(void);
 
-bool gfx_ctx_get_video_output_next(void *data);
+bool gfx_ctx_get_video_output_next(void);
 
 const char *gfx_ctx_get_ident(void);
 
-void gfx_ctx_free(void *data);
+void gfx_ctx_free(void);
 
-void gfx_ctx_input_driver(void *data,
-      const input_driver_t **input, void **input_data);
+void gfx_ctx_input_driver(
+        const input_driver_t **input, void **input_data);
 
 retro_proc_address_t gfx_ctx_get_proc_address(const char *sym);
 
 void *gfx_ctx_data_get_ptr(void);
-
-void gfx_ctx_data_set(void *ptr);
-
-void gfx_ctx_free_data(void);
 
 void gfx_ctx_set(const gfx_ctx_driver_t *ctx_driver);
 

--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -797,7 +797,7 @@ bool video_driver_set_video_mode(unsigned width,
       return true;
    }
 
-   return gfx_ctx_set_video_mode(gfx_ctx_data_get_ptr(), width, height, fullscreen);
+   return gfx_ctx_set_video_mode(width, height, fullscreen);
 }
 
 bool video_driver_get_video_output_size(unsigned *width, unsigned *height)
@@ -1485,7 +1485,7 @@ bool video_driver_ctl(enum rarch_display_ctl_state state, void *data)
             video_driver_poke->get_video_output_next(video_driver_data);
             return true;
          }
-         return gfx_ctx_get_video_output_next(gfx_ctx_data_get_ptr());
+         return gfx_ctx_get_video_output_next();
       case RARCH_DISPLAY_CTL_GET_PREV_VIDEO_OUT:
          if (!video_driver_poke)
             return false;
@@ -1495,7 +1495,7 @@ bool video_driver_ctl(enum rarch_display_ctl_state state, void *data)
             video_driver_poke->get_video_output_prev(video_driver_data);
             return true;
          }
-         return gfx_ctx_get_video_output_next(gfx_ctx_data_get_ptr());
+         return gfx_ctx_get_video_output_next();
       case RARCH_DISPLAY_CTL_INIT:
          return init_video();
       case RARCH_DISPLAY_CTL_DESTROY_DATA:


### PR DESCRIPTION
- Makes better use of the void*data pointer passed to most context calls
- Move egl context globals into egl_ctx_data_t which can be embedded in other structures just fine.

See androidegl_ctx.c diff for the most simple case.
See xegl_ctx.c diff for an advanced example of usage.