### PR TITLE
(XMB) Fix buffer overflow

### DIFF
--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -1535,8 +1535,8 @@ static void xmb_draw_cursor(xmb_handle_t *xmb,
 static void xmb_render(void *data)
 {
    float delta_time, dt;
-   size_t selection;
-   unsigned i, end, height  = 0;
+   size_t i, selection;
+   unsigned end, height  = 0;
    settings_t   *settings   = config_get_ptr();
    xmb_handle_t *xmb        = (xmb_handle_t*)data;
 


### PR DESCRIPTION
It was introduced by 3df4101 . MENU_ENTRIES_CTL_START_GET and
MENU_ENTRIES_CTL_START_GET access size_t-sized data, but an
unsigned was passed.