### PR TITLE
This memset should probably be done only for dynamic cores/builds.

### DIFF
--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -678,8 +678,8 @@ bool menu_driver_ctl(enum rarch_menu_ctl_state state, void *data)
       case RARCH_MENU_CTL_SYSTEM_INFO_DEINIT:
 #ifdef HAVE_DYNAMIC
          libretro_free_system_info(&menu_driver_system);
-#endif
          memset(&menu_driver_system, 0, sizeof(struct retro_system_info));
+#endif
          break;
       case RARCH_MENU_CTL_RENDER_MESSAGEBOX:
          if (driver->render_messagebox)


### PR DESCRIPTION
If it's not in the ifdef, it breaks statically-linked platforms like 3DS with a "No Core" string instead of the actual emulator name, and acts as if it can't load any games.

Fixes/helps https://github.com/libretro/RetroArch/issues/2579.

@twinaphex, what was your intention here? Was it meant to be in the ifdef?