### PR TITLE
(video_shader_parse.h) Increase max parameters to 128

### DIFF
--- a/gfx/video_shader_parse.h
+++ b/gfx/video_shader_parse.h
@@ -39,7 +39,7 @@ extern "C" {
 #endif
 
 #ifndef GFX_MAX_PARAMETERS
-#define GFX_MAX_PARAMETERS 64
+#define GFX_MAX_PARAMETERS 128
 #endif
 
 enum rarch_shader_type


### PR DESCRIPTION
This is mainly for CRT Royale, since it can exceed 64 runtime parameters if other shaders are added to it.