### PR TITLE
fixed segfault when osd message rendering was disabled

### DIFF
--- a/gfx/drivers/gl.c
+++ b/gfx/drivers/gl.c
@@ -1806,7 +1806,7 @@ static bool gl_frame(void *data, const void *frame,
    }
 #endif
 
-   if (msg)
+   if (font_driver_has_render_msg() && msg)
       font_driver_render_msg(NULL, msg, NULL);
 
 #ifdef HAVE_OVERLAY


### PR DESCRIPTION
GL driver was trying to render message even if osd message rendering is disabled, which ultimately caused a segfault in gfx/font_driver.c, line 213.
Now the GL driver evaluates font_driver_has_render_msg() before trying to render a message, so the segfault doesn't happen.