### PR TITLE
Make Core Provided the default aspect ratio.

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -498,7 +498,7 @@ static unsigned aspect_ratio_idx = ASPECT_RATIO_CORE;
 #elif defined(RARCH_CONSOLE)
 static unsigned aspect_ratio_idx = ASPECT_RATIO_4_3;
 #else
-static unsigned aspect_ratio_idx = ASPECT_RATIO_CONFIG;
+static unsigned aspect_ratio_idx = ASPECT_RATIO_CORE;
 #endif
 
 /* Save configuration file on exit. */


### PR DESCRIPTION
Core Provided should be the default aspect ratio because "Config" seems to not have sane behavior across platforms, i.e. it's like core provided on laptop for mGBA (which is 3:2), for example, but it's 4:3 on android.

I really didn't understand all the talk in irc