### PR TITLE
For Twinaphex: A suggestion for different handling of special gamepad buttons on Nvidia Android TV

### DIFF
--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -872,7 +872,7 @@ static void handle_hotplug(android_input_data_t *android_data,
       settings->input.autoconf_binds[*port][RARCH_MENU_TOGGLE].joykey = AKEYCODE_BACK;
 
    android_data->pad_states[*port].id = id;
-   android_data->pad_states[android_data->pads_connected].port = *port;
+   android_data->pad_states[*port].port = *port;
    strlcpy(android_data->pad_states[*port].name, name_buf,
          sizeof(android_data->pad_states[*port].name));
 


### PR DESCRIPTION
@Twinaphex:
This is a suggestion for different handling of the special keys that are received on the "Virtual" device on Nvidia Android TV.

I suggest this approach instead of the id_1 and id_2 handling because the Virtual device covers more special buttons than the Nvidia button. The Virtual device also handles remote control keys received through CEC. When using the id_1 and id_2 method these other keys cannot be used because they conflict with the existing button mappings in the "Nvidia Shield Controller.cfg" autoconfig.

I suggest that the Virtual device is instead handled as a separate device with its own autoconfig file "Nvidia Shield Controller Extra.cfg" and that this device is bound to port 0 when a button on the Virtual device is received. In this case the virtual device replaces the controller currently bound to port 0. When a normal button on the controller is pressed the controller will be mapped back to port 0 overwriting the Virtual device. So the mapping on port 0 goes back and forth between "Nvidia Shield Controller" and "Nvidia Shield Controller Extra" depending on the buttons you press.

Using this approach you will be able to map all buttons of a CEC remote in the autoconfig file and use the remote to fully navigate the Retroarch interface and actually play games with it, if you just want to start something quick without fiddling with the gamepad. If the Nvidia button is mapped in this extra autoconfig to the menu_toggle_btn the functionality achieved by the id_1 and id_2 method will remain.

The only side effect of this way of handling the special buttons is that Retroarch will notify that a new controller has been found whenever you switch back and forth between the controller and the virtual device.
