### PR TITLE
Add refresh rate parameter to Android version

### DIFF
--- a/pkg/android/phoenix/src/com/retroarch/browser/retroactivity/RetroActivityFuture.java
+++ b/pkg/android/phoenix/src/com/retroarch/browser/retroactivity/RetroActivityFuture.java
@@ -1,6 +1,8 @@
 package com.retroarch.browser.retroactivity;
 
 import android.view.View;
+import android.view.WindowManager;
+import android.content.Intent;
 
 public final class RetroActivityFuture extends RetroActivityCamera {
 
@@ -25,6 +27,17 @@ public final class RetroActivityFuture extends RetroActivityCamera {
 					| View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
 					| API_SYSTEM_UI_FLAG_FULLSCREEN
 					| API_SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+
+			// Check for REFRESH parameter
+			Intent retro = getIntent();
+			String refresh = retro.getStringExtra("REFRESH");
+
+			// If REFRESH parameter is provided then try to set refreshrate accordingly
+			if(refresh != null) {
+				WindowManager.LayoutParams params = getWindow().getAttributes();
+				params.preferredRefreshRate = Integer.parseInt(refresh);
+				getWindow().setAttributes(params);
+			}
 		}
 	}
 


### PR DESCRIPTION
Adds a "REFRESH" parameter option to the Android version which can be used to specify a
preferred refresh rate for Retroarch to use if the device supports it.

On Android devices that supports different refresh rates, such as the Nvidia Shield, this makes it possible to launch specific cores in refresh rates that fits the original system that is being emulated.

Example of a command that can be used from Advanced Launcher in Kodi to launch the Amstrad CPC core with 50Hz refresh rate:
start --user 0 -a android.intent.action.MAIN -c android.intent.category.LAUNCHER -e ROM "%rom%" -e LIBRETRO /data/data/com.retroarch/cores/cap32_libretro_android.so -e CONFIGFILE /sdcard/Android/data/com.retroarch/files/retroarch.cfg -e IME com.android.inputmethod.latin/.LatinIME -e REFRESH 50 -n com.retroarch/.browser.retroactivity.RetroActivityFuture
