### PR TITLE
Extends Android keyboard functionality to allow for more than one keyboard

### DIFF
--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -965,8 +965,10 @@ static void android_input_poll_input(void *data)
                {
                   int keycode = AKeyEvent_getKeyCode(event);
 
-                  if (is_keyboard_id(id) && !predispatched)
-                     android_input_poll_event_type_keyboard(event, keycode, &handled);
+                  if (is_keyboard_id(id))
+                  {
+                     if (!predispatched) android_input_poll_event_type_keyboard(event, keycode, &handled);
+                  }
                   else
                      android_input_poll_event_type_key(android_app,
                         event, port, keycode, source, type_event, &handled);


### PR DESCRIPTION
Renamed id_1 and id_2 to pad_id1 and pad_id2
Renamed id_3 to kbd_id and change it to an array of keyboard ids

Implement function is_keyboard_id(int id) which checks if an id is mapped as a keyboard

This solves a problem with phone buttons, such as volume buttons, being detected as
keyboards and blocking a real keyboard from being mapped afterwards.
