### PR TITLE
(3DS) fixes argv corruption when started from the homebrew launcher

### DIFF
--- a/ctr/3dsx_custom.specs
+++ b/ctr/3dsx_custom.specs
@@ -1,7 +1,7 @@
 %rename link                old_link
 
 *link:
-%(old_link) -T 3dsx.ld%s -d --emit-relocs --use-blx
+%(old_link) -T 3dsx.ld%s -d --emit-relocs --use-blx --gc-sections
 
 *startfile:
 ctr/3dsx_custom_crt0%O%s crti%O%s crtbegin%O%s

--- a/ctr/3dsx_custom_crt0.s
+++ b/ctr/3dsx_custom_crt0.s
@@ -30,6 +30,7 @@ __system_runflags:
 startup:
 	@ Save return address
 	mov r4, lr
+   bics sp, sp, #7
 
 	@ Clear the BSS section
 	ldr r0, =__bss_start__
@@ -39,7 +40,6 @@ startup:
 
 	@ System initialization
 	mov r0, r4
-	and r4, sp, #7
 	bl initSystem
 
 	@ Set up argc/argv arguments for main()
@@ -50,8 +50,6 @@ startup:
 
 	@ Jump to user code
 	ldr r3, =main
-	cmp r4, #0
-	ldrne r3, =ctr_request_update
 	ldr lr, =__ctru_exit
 	bx  r3
 

--- a/ctr/3dsx_custom_crt0.s
+++ b/ctr/3dsx_custom_crt0.s
@@ -30,7 +30,7 @@ __system_runflags:
 startup:
 	@ Save return address
 	mov r4, lr
-   bics sp, sp, #7
+	bics sp, sp, #7
 
 	@ Clear the BSS section
 	ldr r0, =__bss_start__

--- a/ctr/ctr_system.c
+++ b/ctr/ctr_system.c
@@ -195,23 +195,6 @@ void __attribute__((noreturn)) __ctru_exit(int rc)
    __libctru_exit(rc);
 }
 
-int ctr_request_update(void)
-{
-   gfxInit(GSP_BGR8_OES,GSP_RGB565_OES,false);
-   gfxSet3D(false);
-   consoleInit(GFX_BOTTOM, NULL);
-
-   printf("\n\nunsupported version\n\n");
-   printf("Please update your payload\n");
-
-   wait_for_input();
-
-   gfxExit();
-
-   return 0;
-}
-
-
 typedef union{
    struct
    {
@@ -263,10 +246,6 @@ void wait_for_input(void)
    }
 }
 
-int usleep (useconds_t us)
-{
-   svcSleepThread((int64_t)us * 1000);
-}
 
 long sysconf(int name)
 {

--- a/frontend/drivers/platform_ctr.c
+++ b/frontend/drivers/platform_ctr.c
@@ -16,7 +16,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <string.h>
-
+#include <ctype.h>
 #include <boolean.h>
 
 #include <3ds.h>
@@ -89,7 +89,8 @@ static void frontend_ctr_get_environment_settings(int *argc, char *argv[],
       *argc = 0;
       while (i)
       {
-         if(argv[i] && argv[i][0])
+         if(argv[i] && isalnum(argv[i][0])
+            && strncmp(argv[i], "3dslink:/", 9))
          {
             argv[1] = argv[i];
             argv[2] = NULL;


### PR DESCRIPTION
- add more heuristics to try to clean up the corrupted argv when using the homebrew launcher.
- force align the stack pointer to 8 bytes.
- add --gc-sections to the link specs