### PR TITLE
iOS: Adds support for Music.app while RetroArch is running

### DIFF
--- a/gfx/drivers_context/cocoa_gl_ctx.m
+++ b/gfx/drivers_context/cocoa_gl_ctx.m
@@ -26,6 +26,7 @@
 #include <AppKit/NSOpenGL.h>
 #elif defined(HAVE_COCOATOUCH)
 #include <GLKit/GLKit.h>
+#import <AVFoundation/AVFoundation.h>
 #endif
 
 #include <retro_assert.h>
@@ -119,6 +120,10 @@ void *glkitview_init(void)
 #if defined(HAVE_COCOATOUCH)
 void cocoagl_bind_game_view_fbo(void)
 {
+   // implicitly initializes your audio session
+   [AVAudioSession *audioSession = [AVAudioSession sharedInstance];
+   [audioSession setCategory: AVAudioSessionCategoryAmbient error: nil];
+   [audioSession setActive:YES error:nil];
    if (g_context)
       [g_view bindDrawable];
 }

--- a/gfx/drivers_context/cocoa_gl_ctx.m
+++ b/gfx/drivers_context/cocoa_gl_ctx.m
@@ -121,7 +121,7 @@ void *glkitview_init(void)
 void cocoagl_bind_game_view_fbo(void)
 {
    // implicitly initializes your audio session
-   [AVAudioSession *audioSession = [AVAudioSession sharedInstance];
+   AVAudioSession *audioSession = [AVAudioSession sharedInstance];
    [audioSession setCategory: AVAudioSessionCategoryAmbient error: nil];
    [audioSession setActive:YES error:nil];
    if (g_context)

--- a/ui/drivers/cocoa/cocoa_common.h
+++ b/ui/drivers/cocoa/cocoa_common.h
@@ -74,6 +74,7 @@ extern apple_frontend_settings_t apple_frontend_settings;
 
 - (void)showGameView;
 - (void)toggleUI;
+- (void)supportOtherAudioSessions;
 
 - (void)refreshSystemConfig;
 - (void)mainMenuPushPop: (bool)pushp;

--- a/ui/drivers/ui_cocoatouch.m
+++ b/ui/drivers/ui_cocoatouch.m
@@ -400,7 +400,6 @@ enum
 {
    NSString *filename = (NSString*)url.path.lastPathComponent;
    NSError     *error = nil;
-  [self supportOtherAudioSessions];
     
    [[NSFileManager defaultManager] moveItemAtPath:[url path] toPath:[self.documentsDirectory stringByAppendingPathComponent:filename] error:&error];
    

--- a/ui/drivers/ui_cocoatouch.m
+++ b/ui/drivers/ui_cocoatouch.m
@@ -27,7 +27,7 @@
 #include "../../input/drivers/cocoa_input.h"
 #include "../../input/drivers_keyboard/keyboard_event_apple.h"
 #include "../../retroarch.h"
-
+#import <AVFoundation/AVFoundation.h>
 #include "../../frontend/frontend.h"
 #include "../../runloop.h"
 
@@ -44,6 +44,10 @@ void apple_rarch_exited(void);
 
 static void rarch_enable_ui(void)
 {
+   AVAudioSession *audioSession = [AVAudioSession sharedInstance];
+   [audioSession setCategory: AVAudioSessionCategoryAmbient error: nil];
+   [audioSession setActive:YES error:nil];
+    
    bool boolean = true;
 
    ui_companion_set_foreground(true);
@@ -62,6 +66,9 @@ static void rarch_disable_ui(void)
    runloop_ctl(RUNLOOP_CTL_SET_PAUSED, &boolean);
    runloop_ctl(RUNLOOP_CTL_SET_IDLE,   &boolean);
    rarch_ctl(RARCH_CTL_MENU_RUNNING_FINISHED, NULL);
+   AVAudioSession *audioSession = [AVAudioSession sharedInstance];
+   [audioSession setCategory: AVAudioSessionCategoryAmbient error: nil];
+   [audioSession setActive:YES error:nil];
 }
 
 static void ui_companion_cocoatouch_event_command(
@@ -314,6 +321,10 @@ enum
 
 + (RetroArch_iOS*)get
 {
+   // implicitly initializes your audio session
+   AVAudioSession *audioSession = [AVAudioSession sharedInstance];
+   [audioSession setCategory: AVAudioSessionCategoryAmbient error: nil];
+   [audioSession setActive:YES error:nil];
    return (RetroArch_iOS*)[[UIApplication sharedApplication] delegate];
 }
 
@@ -325,7 +336,8 @@ enum
     
    if (rarch_main(0, NULL, NULL))
        apple_rarch_exited();
-
+    /* Other background audio check */
+   [self supportOtherAudioSessions];
    /* Setup window */
    self.window      = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
    [self.window makeKeyAndVisible];
@@ -336,6 +348,7 @@ enum
 
    [self refreshSystemConfig];
    [self showGameView];
+   [self supportOtherAudioSessions];
 
    if (rarch_main(0, NULL, NULL))
       apple_rarch_exited();
@@ -352,7 +365,7 @@ enum
 
 - (void)applicationDidEnterBackground:(UIApplication *)application
 {
-    
+    [self supportOtherAudioSessions];
 }
 
 - (void)applicationWillTerminate:(UIApplication *)application
@@ -365,7 +378,8 @@ enum
 - (void)applicationDidBecomeActive:(UIApplication *)application
 {
    settings_t *settings = config_get_ptr();
-    
+   
+   [self supportOtherAudioSessions];
    if (settings->ui.companion_start_on_boot)
       return;
     
@@ -374,6 +388,7 @@ enum
 
 - (void)applicationWillResignActive:(UIApplication *)application
 {
+   [self supportOtherAudioSessions];
    dispatch_async(dispatch_get_main_queue(),
                   ^{
                   ui_companion_cocoatouch_event_command(NULL, EVENT_CMD_MENU_SAVE_CURRENT_CONFIG);
@@ -385,7 +400,8 @@ enum
 {
    NSString *filename = (NSString*)url.path.lastPathComponent;
    NSError     *error = nil;
-
+  [self supportOtherAudioSessions];
+    
    [[NSFileManager defaultManager] moveItemAtPath:[url path] toPath:[self.documentsDirectory stringByAppendingPathComponent:filename] error:&error];
    
    if (error)
@@ -402,6 +418,8 @@ enum
 
 - (void)showGameView
 {
+    // implicitly initializes your audio session
+   [self supportOtherAudioSessions];
    [self popToRootViewControllerAnimated:NO];
    [self setToolbarHidden:true animated:NO];
    [[UIApplication sharedApplication] setStatusBarHidden:true withAnimation:UIStatusBarAnimationNone];
@@ -414,7 +432,7 @@ enum
 
 - (IBAction)showPauseMenu:(id)sender
 {
-   ui_companion_cocoatouch_event_command(NULL, EVENT_CMD_AUDIO_STOP);
+   //ui_companion_cocoatouch_event_command(NULL, EVENT_CMD_AUDIO_STOP);
    rarch_enable_ui();
 
    [[UIApplication sharedApplication] setStatusBarHidden:false withAnimation:UIStatusBarAnimationNone];
@@ -433,6 +451,7 @@ enum
    {
       [self showPauseMenu:self];
    }
+   [self supportOtherAudioSessions];
 }
 
 - (void)refreshSystemConfig
@@ -471,6 +490,14 @@ enum
   }
 }
 
+- (void)supportOtherAudioSessions
+{
+    // implicitly initializes your audio session
+    AVAudioSession *audioSession = [AVAudioSession sharedInstance];
+    [audioSession setCategory: AVAudioSessionCategoryAmbient error: nil];
+    [audioSession setActive:YES error:nil];
+}
+
 - (void)mainMenuRenderMessageBox:(NSString *)msg
 {
   [self.mainmenu renderMessageBox:msg];
@@ -501,6 +528,7 @@ void apple_rarch_exited(void)
     
     if (!ap)
         return;
+    [ap supportOtherAudioSessions];
     [ap showPauseMenu:ap];
 }
 


### PR DESCRIPTION
I added a couple lines of code in the iOS project to allow the Music.app to play while RetroArch is running. Compiled, deployed, and after listening to my jams whilst I Ocarina of Time… I have to say I can’t go back to a version of libretro without it. 

I'm not a Object-C developer, so there could be cleaner ways of doing this in the context of the RetroArch app. It was trial and error getting the audio to stop and start during different actions within RetroArch so once I got a stable listening experience, I didn't modify it much so there may be unnecessary calls that can be safely removed.

I've been using this version for a couple of weeks now and have to say it's stable on my iPhone 6+. Now I can't go back to not having my favorite tunes playing while playing my favorite games.