### PR TITLE
Reboot Menu Item

### DIFF
--- a/command_event.c
+++ b/command_event.c
@@ -1311,9 +1311,11 @@ bool event_command(enum event_command cmd)
 #endif
          break;
       case EVENT_CMD_REBOOT:
+#if defined(__linux__) && !defined(ANDROID)
          runloop_msg_queue_push("Rebooting...", 1, 180, true);
          rarch_ctl(RARCH_CTL_FORCE_QUIT, NULL);
          system("shutdown -r now");
+#endif
          break;
       case EVENT_CMD_RESUME:
          rarch_ctl(RARCH_CTL_MENU_RUNNING_FINISHED, NULL);

--- a/command_event.c
+++ b/command_event.c
@@ -1310,6 +1310,11 @@ bool event_command(enum event_command cmd)
          system("shutdown -P now");
 #endif
          break;
+      case EVENT_CMD_REBOOT:
+         runloop_msg_queue_push("Rebooting...", 1, 180, true);
+         rarch_ctl(RARCH_CTL_FORCE_QUIT, NULL);
+         system("shutdown -r now");
+         break;
       case EVENT_CMD_RESUME:
          rarch_ctl(RARCH_CTL_MENU_RUNNING_FINISHED, NULL);
          break;

--- a/command_event.h
+++ b/command_event.h
@@ -121,7 +121,7 @@ enum event_command
    /* Shutdown the OS */
    EVENT_CMD_SHUTDOWN,
    /* Reboot the OS */
-   EVENT_CMD_REBOOT
+   EVENT_CMD_REBOOT,
    /* Resume RetroArch when in menu. */
    EVENT_CMD_RESUME,
    /* Toggles pause. */

--- a/command_event.h
+++ b/command_event.h
@@ -120,6 +120,8 @@ enum event_command
    EVENT_CMD_QUIT_RETROARCH,
    /* Shutdown the OS */
    EVENT_CMD_SHUTDOWN,
+   /* Reboot the OS */
+   EVENT_CMD_REBOOT
    /* Resume RetroArch when in menu. */
    EVENT_CMD_RESUME,
    /* Toggles pause. */

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -2606,6 +2606,8 @@ static int xmb_list_push(void *data, void *userdata, menu_displaylist_info_t *in
 #endif
          menu_displaylist_parse_settings(menu, info,
                menu_hash_to_str(MENU_LABEL_SHUTDOWN), PARSE_ACTION, false);
+         menu_displaylist_parse_settings(menu, info,
+               menu_hash_to_str(MENU_LABEL_REBOOT), PARSE_ACTION, false);
          info->need_push    = true;
          ret = 0;
          break;

--- a/menu/intl/menu_hash_us.c
+++ b/menu/intl/menu_hash_us.c
@@ -1246,6 +1246,8 @@ const char *menu_hash_to_str_us(uint32_t hash)
          return "Quit RetroArch";
       case MENU_LABEL_VALUE_SHUTDOWN:
          return "Shutdown";
+      case MENU_LABEL_VALUE_REBOOT:
+         return "Reboot":
       case MENU_LABEL_VALUE_HELP:
          return "help";
       case MENU_LABEL_VALUE_SAVE_NEW_CONFIG:

--- a/menu/intl/menu_hash_us.c
+++ b/menu/intl/menu_hash_us.c
@@ -1247,7 +1247,7 @@ const char *menu_hash_to_str_us(uint32_t hash)
       case MENU_LABEL_VALUE_SHUTDOWN:
          return "Shutdown";
       case MENU_LABEL_VALUE_REBOOT:
-         return "Reboot":
+         return "Reboot";
       case MENU_LABEL_VALUE_HELP:
          return "help";
       case MENU_LABEL_VALUE_SAVE_NEW_CONFIG:

--- a/menu/intl/menu_hash_us.c
+++ b/menu/intl/menu_hash_us.c
@@ -572,6 +572,10 @@ static const char *menu_hash_to_str_us_label(uint32_t hash)
          return "settings";
       case MENU_LABEL_QUIT_RETROARCH:
          return "quit_retroarch";
+      case MENU_LABEL_SHUTDOWN:
+         return "shutdown";
+      case MENU_LABEL_REBOOT:
+         return "reboot";
       case MENU_LABEL_HELP:
          return "help";
       case MENU_LABEL_SAVE_NEW_CONFIG:

--- a/menu/intl/menu_hash_us.c
+++ b/menu/intl/menu_hash_us.c
@@ -572,10 +572,12 @@ static const char *menu_hash_to_str_us_label(uint32_t hash)
          return "settings";
       case MENU_LABEL_QUIT_RETROARCH:
          return "quit_retroarch";
+#if defined(HAVE_LAKKA)
       case MENU_LABEL_SHUTDOWN:
          return "shutdown";
       case MENU_LABEL_REBOOT:
          return "reboot";
+#endif
       case MENU_LABEL_HELP:
          return "help";
       case MENU_LABEL_SAVE_NEW_CONFIG:
@@ -1248,10 +1250,12 @@ const char *menu_hash_to_str_us(uint32_t hash)
          return "Settings";
       case MENU_LABEL_VALUE_QUIT_RETROARCH:
          return "Quit RetroArch";
+#if defined(HAVE_LAKKA)
       case MENU_LABEL_VALUE_SHUTDOWN:
          return "Shutdown";
       case MENU_LABEL_VALUE_REBOOT:
          return "Reboot";
+#endif
       case MENU_LABEL_VALUE_HELP:
          return "help";
       case MENU_LABEL_VALUE_SAVE_NEW_CONFIG:

--- a/menu/menu_hash.h
+++ b/menu/menu_hash.h
@@ -689,8 +689,8 @@ extern "C" {
 #define MENU_LABEL_VALUE_QUIT_RETROARCH                                        0x8e7024f2U
 #define MENU_LABEL_SHUTDOWN                                                    0xfc460361U
 #define MENU_LABEL_VALUE_SHUTDOWN                                              0x740b6741U
-#define MENU_LABEL_REBOOT                                                      0xac460361U
-#define MENU_LABEL_VALUE_REBOOT                                                0xa40b6741U
+#define MENU_LABEL_REBOOT                                                      0x1b353023U
+#define MENU_LABEL_VALUE_REBOOT                                                0xcab9e59fU
 #define MENU_LABEL_DEFERRED_VIDEO_FILTER                                       0x966ad201U
 #define MENU_LABEL_DEFERRED_CORE_LIST_SET                                      0xa6d5fdb4U
 #define MENU_LABEL_VALUE_STARTING_DOWNLOAD                                     0x42e10f03U

--- a/menu/menu_hash.h
+++ b/menu/menu_hash.h
@@ -687,10 +687,12 @@ extern "C" {
 #define MENU_LABEL_VALUE_CLOSE_CONTENT                                         0x2b3d9556U
 #define MENU_LABEL_QUIT_RETROARCH                                              0x84b0bc71U
 #define MENU_LABEL_VALUE_QUIT_RETROARCH                                        0x8e7024f2U
-#define MENU_LABEL_SHUTDOWN                                                    0xfc460361U
-#define MENU_LABEL_VALUE_SHUTDOWN                                              0x740b6741U
-#define MENU_LABEL_REBOOT                                                      0x19266b70U
-#define MENU_LABEL_VALUE_REBOOT                                                0xce815750U
+#if defined(HAVE_LAKKA)
+    #define MENU_LABEL_SHUTDOWN                                                    0xfc460361U
+    #define MENU_LABEL_VALUE_SHUTDOWN                                              0x740b6741U
+    #define MENU_LABEL_REBOOT                                                      0x19266b70U
+    #define MENU_LABEL_VALUE_REBOOT                                                0xce815750U
+#endif
 #define MENU_LABEL_DEFERRED_VIDEO_FILTER                                       0x966ad201U
 #define MENU_LABEL_DEFERRED_CORE_LIST_SET                                      0xa6d5fdb4U
 #define MENU_LABEL_VALUE_STARTING_DOWNLOAD                                     0x42e10f03U

--- a/menu/menu_hash.h
+++ b/menu/menu_hash.h
@@ -689,8 +689,8 @@ extern "C" {
 #define MENU_LABEL_VALUE_QUIT_RETROARCH                                        0x8e7024f2U
 #define MENU_LABEL_SHUTDOWN                                                    0xfc460361U
 #define MENU_LABEL_VALUE_SHUTDOWN                                              0x740b6741U
-#define MENU_LABEL_REBOOT                                                      0x1b353023U
-#define MENU_LABEL_VALUE_REBOOT                                                0xcab9e59fU
+#define MENU_LABEL_REBOOT                                                      0x19266b70U
+#define MENU_LABEL_VALUE_REBOOT                                                0xce815750U
 #define MENU_LABEL_DEFERRED_VIDEO_FILTER                                       0x966ad201U
 #define MENU_LABEL_DEFERRED_CORE_LIST_SET                                      0xa6d5fdb4U
 #define MENU_LABEL_VALUE_STARTING_DOWNLOAD                                     0x42e10f03U

--- a/menu/menu_hash.h
+++ b/menu/menu_hash.h
@@ -689,6 +689,8 @@ extern "C" {
 #define MENU_LABEL_VALUE_QUIT_RETROARCH                                        0x8e7024f2U
 #define MENU_LABEL_SHUTDOWN                                                    0xfc460361U
 #define MENU_LABEL_VALUE_SHUTDOWN                                              0x740b6741U
+#define MENU_LABEL_REBOOT                                                      0xac460361U
+#define MENU_LABEL_VALUE_REBOOT                                                0xa40b6741U
 #define MENU_LABEL_DEFERRED_VIDEO_FILTER                                       0x966ad201U
 #define MENU_LABEL_DEFERRED_CORE_LIST_SET                                      0xa6d5fdb4U
 #define MENU_LABEL_VALUE_STARTING_DOWNLOAD                                     0x42e10f03U

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -3413,6 +3413,17 @@ static bool setting_append_list_main_menu_options(
    menu_settings_list_current_add_cmd(list, list_info, EVENT_CMD_SHUTDOWN);
 #endif
 
+#if defined(HAVE_LAKKA)
+   CONFIG_ACTION(
+         list, list_info,
+         menu_hash_to_str(MENU_LABEL_REBOOT),
+         menu_hash_to_str(MENU_LABEL_VALUE_REBOOT),
+         &group_info,
+         &subgroup_info,
+         parent_group);
+   menu_settings_list_current_add_cmd(list, list_info, EVENT_CMD_REBOOT);
+#endif
+
    CONFIG_ACTION(
          list, list_info,
          menu_hash_to_str(MENU_LABEL_INPUT_SETTINGS),


### PR DESCRIPTION
I've added a Reboot Menu Item.
This is useful for Lakka as well as a dual booting.

I was assisted by Kivutar, and relied on his original Shutdown Menu Item PR (https://github.com/libretro/RetroArch/commit/2b376ce3d551fb2b649743d38ba818be5109b3ba)

Thanks. 
