### PR TITLE
improve per-game core options

### DIFF
--- a/dynamic.c
+++ b/dynamic.c
@@ -536,6 +536,7 @@ void uninit_libretro_sym(struct retro_core_t *current_core)
 
    memset(current_core, 0, sizeof(struct retro_core_t));
 
+   runloop_ctl(RUNLOOP_CTL_CORE_OPTIONS_DEINIT, NULL);
    runloop_ctl(RUNLOOP_CTL_SYSTEM_INFO_FREE, NULL);
    camera_driver_ctl(RARCH_CAMERA_CTL_UNSET_ACTIVE, NULL);
    location_driver_ctl(RARCH_LOCATION_CTL_UNSET_ACTIVE, NULL);

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -1329,6 +1329,7 @@ static int action_ok_option_create(const char *path,
 {
    char game_path[PATH_MAX_LENGTH];
    rarch_system_info_t *system            = NULL;
+   config_file_t *conf                    = NULL;
 
    if (!rarch_option_create(game_path, sizeof(game_path)))
    {
@@ -1337,12 +1338,23 @@ static int action_ok_option_create(const char *path,
       return 0;
    }
 
+   conf = config_file_new(game_path);
+
+   if (!conf)
+   {
+      conf = config_file_new(NULL);
+      if (!conf)
+         return false;
+   }
+
    runloop_ctl(RUNLOOP_CTL_SYSTEM_INFO_GET, &system);
 
-   if(core_option_flush_game_specific(system->core_options,
-            game_path))
-      menu_display_msg_queue_push("Core options file saved successfully",
+   if(config_file_write(conf, game_path))
+   {
+      menu_display_msg_queue_push("Core options file created successfully",
             1, 100, true);
+      strlcpy(system->game_options_path, game_path, sizeof(system->game_options_path));
+   }
 
    return 0;
 }

--- a/runloop.c
+++ b/runloop.c
@@ -1093,8 +1093,20 @@ bool runloop_ctl(enum runloop_ctl_state state, void *data)
          if (!runloop_system.core_options)
             return false;
 
-         core_option_flush(runloop_system.core_options);
+         /* check if game options file was just created and flush
+            to that file instead */
+         if(!string_is_empty(runloop_system.game_options_path))
+         {
+            core_option_flush_game_specific(runloop_system.core_options, runloop_system.game_options_path);
+            runloop_system.game_options_path[0] = '\0';
+         }
+         else
+            core_option_flush(runloop_system.core_options);
+
          core_option_free(runloop_system.core_options);
+
+         if (runloop_ctl(RUNLOOP_CTL_IS_GAME_OPTIONS_ACTIVE, NULL))
+            runloop_ctl(RUNLOOP_CTL_UNSET_GAME_OPTIONS_ACTIVE, NULL);
 
          runloop_system.core_options = NULL;
          return true;

--- a/system.h
+++ b/system.h
@@ -33,6 +33,7 @@ extern "C" {
 typedef struct rarch_system_info
 {
    char title_buf[64];
+   char game_options_path[PATH_MAX_LENGTH];
 
    struct retro_system_info info;
 


### PR DESCRIPTION
before:
- it would flush immediately when selecting create core options file, if you selected the option it would keep flushing over and over creating duplicates
- on exit it would flush to the main core options file instead creating inconsistencies

now:
- it will create an empty game options file on selection, if you select again and again it will not flush
- on exit it will flush to the correct options file