### PR TITLE
(GX) Refactor of the Wii USB HID support. Now it's working!

### DIFF
--- a/griffin/griffin.c
+++ b/griffin/griffin.c
@@ -416,6 +416,11 @@ INPUT (HID)
 #include "../input/connect/connect_ps4.c"
 #include "../input/connect/connect_wii.c"
 #include "../input/connect/connect_wiiupro.c"
+#ifdef HAVE_WIIUSB_HID
+#include "../input/connect/connect_snesusb.c"
+#include "../input/connect/connect_nesusb.c"
+#include "../input/connect/connect_wiiugca.c"
+#endif
 #endif
 
 /*============================================================

--- a/input/connect/connect_nesusb.c
+++ b/input/connect/connect_nesusb.c
@@ -1,0 +1,146 @@
+/*  RetroArch - A frontend for libretro.
+ *  Copyright (C) 2013-2014 - Jason Fetters
+ *  Copyright (C) 2011-2016 - Daniel De Matteis
+ *
+ *  RetroArch is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  RetroArch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with RetroArch.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include <boolean.h>
+#include "joypad_connection.h"
+
+struct hidpad_nesusb_data
+{
+   struct pad_connection* connection;
+   uint8_t data[64];
+   uint32_t slot;
+   uint64_t buttons;
+};
+
+static void* hidpad_nesusb_init(void *data, uint32_t slot, send_control_t ptr)
+{
+   struct pad_connection* connection = (struct pad_connection*)data;
+   struct hidpad_nesusb_data* device    = (struct hidpad_nesusb_data*)
+      calloc(1, sizeof(struct hidpad_nesusb_data));
+
+   if (!device)
+      return NULL;
+
+   if (!connection)
+   {
+      free(device);
+      return NULL;
+   }
+
+   device->connection   = connection;
+   device->slot         = slot;
+
+   return device;
+}
+
+static void hidpad_nesusb_deinit(void *data)
+{
+   struct hidpad_nesusb_data *device = (struct hidpad_nesusb_data*)data;
+
+   if (device)
+      free(device);
+}
+
+static uint64_t hidpad_nesusb_get_buttons(void *data)
+{
+   struct hidpad_nesusb_data *device = (struct hidpad_nesusb_data*)data;
+   if (!device)
+      return 0;
+   return device->buttons;
+}
+
+static int16_t hidpad_nesusb_get_axis(void *data, unsigned axis)
+{
+   int val;
+   struct hidpad_nesusb_data *device = (struct hidpad_nesusb_data*)data;
+
+   if (!device || axis >= 2)
+      return 0;
+
+   val = device->data[4 + axis];
+   val = (val << 8) - 0x8000;
+
+   return (abs(val) > 0x1000) ? val : 0;
+}
+
+static void hidpad_nesusb_packet_handler(void *data, uint8_t *packet, uint16_t size)
+{
+   uint32_t i, pressed_keys;
+   static const uint32_t button_mapping[17] =
+   {
+      NO_BTN,
+      NO_BTN,
+      NO_BTN,
+      NO_BTN,
+      RETRO_DEVICE_ID_JOYPAD_SELECT,
+      RETRO_DEVICE_ID_JOYPAD_START,
+      NO_BTN,
+      NO_BTN,
+      NO_BTN,
+      NO_BTN,
+      NO_BTN,
+      NO_BTN,
+      RETRO_DEVICE_ID_JOYPAD_B,
+      RETRO_DEVICE_ID_JOYPAD_A,
+      NO_BTN,
+      NO_BTN,
+      16, /* HOME BUTTON when pressing SELECT+START */
+   };
+   struct hidpad_nesusb_data *device = (struct hidpad_nesusb_data*)data;
+
+   if (!device)
+      return;
+
+   memcpy(device->data, packet, size);
+
+   device->buttons = 0;
+
+   pressed_keys  = device->data[7] | (device->data[6] << 8) |
+                (((device->data[7] & 0x30) == 0x30) ? (1 << 16) : 0);  /* SELECT+START=HOME */
+
+   for (i = 0; i < 17; i ++)
+      if (button_mapping[i] != NO_BTN)
+         device->buttons |= (pressed_keys & (1 << i)) ? (UINT64_C(1) << button_mapping[i]) : 0;
+}
+
+static void hidpad_nesusb_set_rumble(void *data,
+      enum retro_rumble_effect effect, uint16_t strength)
+{
+	(void)data;
+	(void)effect;
+   (void)strength;
+}
+
+const char * hidpad_nesusb_get_name(void *data)
+{
+	(void)data;
+	/* For now we return a single static name */
+	return "Generic NES USB Controller";
+}
+
+pad_connection_interface_t pad_connection_nesusb = {
+   hidpad_nesusb_init,
+   hidpad_nesusb_deinit,
+   hidpad_nesusb_packet_handler,
+   hidpad_nesusb_set_rumble,
+   hidpad_nesusb_get_buttons,
+   hidpad_nesusb_get_axis,
+   hidpad_nesusb_get_name,
+};

--- a/input/connect/connect_ps4.c
+++ b/input/connect/connect_ps4.c
@@ -264,4 +264,5 @@ pad_connection_interface_t pad_connection_ps4 = {
    hidpad_ps4_set_rumble,
    hidpad_ps4_get_buttons,
    hidpad_ps4_get_axis,
+   NULL,
 };

--- a/input/connect/connect_snesusb.c
+++ b/input/connect/connect_snesusb.c
@@ -1,0 +1,146 @@
+/*  RetroArch - A frontend for libretro.
+ *  Copyright (C) 2013-2014 - Jason Fetters
+ *  Copyright (C) 2011-2016 - Daniel De Matteis
+ *
+ *  RetroArch is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  RetroArch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with RetroArch.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include <boolean.h>
+#include "joypad_connection.h"
+
+struct hidpad_snesusb_data
+{
+   struct pad_connection* connection;
+   uint8_t data[64];
+   uint32_t slot;
+   uint64_t buttons;
+};
+
+static void* hidpad_snesusb_init(void *data, uint32_t slot, send_control_t ptr)
+{
+   struct pad_connection* connection = (struct pad_connection*)data;
+   struct hidpad_snesusb_data* device    = (struct hidpad_snesusb_data*)
+      calloc(1, sizeof(struct hidpad_snesusb_data));
+
+   if (!device)
+      return NULL;
+
+   if (!connection)
+   {
+      free(device);
+      return NULL;
+   }
+
+   device->connection   = connection;
+   device->slot         = slot;
+
+   return device;
+}
+
+static void hidpad_snesusb_deinit(void *data)
+{
+   struct hidpad_snesusb_data *device = (struct hidpad_snesusb_data*)data;
+
+   if (device)
+      free(device);
+}
+
+static uint64_t hidpad_snesusb_get_buttons(void *data)
+{
+   struct hidpad_snesusb_data *device = (struct hidpad_snesusb_data*)data;
+   if (!device)
+      return 0;
+   return device->buttons;
+}
+
+static int16_t hidpad_snesusb_get_axis(void *data, unsigned axis)
+{
+   int val;
+   struct hidpad_snesusb_data *device = (struct hidpad_snesusb_data*)data;
+
+   if (!device || axis >= 2)
+      return 0;
+
+   val = device->data[1 + axis];
+   val = (val << 8) - 0x8000;
+
+   return (abs(val) > 0x1000) ? val : 0;
+}
+
+static void hidpad_snesusb_packet_handler(void *data, uint8_t *packet, uint16_t size)
+{
+   uint32_t i, pressed_keys;
+   static const uint32_t button_mapping[17] =
+   {
+      RETRO_DEVICE_ID_JOYPAD_L,
+      RETRO_DEVICE_ID_JOYPAD_R,
+      NO_BTN,
+      NO_BTN,
+      RETRO_DEVICE_ID_JOYPAD_SELECT,
+      RETRO_DEVICE_ID_JOYPAD_START,
+      NO_BTN,
+      NO_BTN,
+      NO_BTN,
+      NO_BTN,
+      NO_BTN,
+      NO_BTN,
+      RETRO_DEVICE_ID_JOYPAD_X,
+      RETRO_DEVICE_ID_JOYPAD_A,
+      RETRO_DEVICE_ID_JOYPAD_B,
+      RETRO_DEVICE_ID_JOYPAD_Y,
+      16, /* HOME BUTTON when pressing SELECT+START */
+   };
+   struct hidpad_snesusb_data *device = (struct hidpad_snesusb_data*)data;
+
+   if (!device)
+      return;
+
+   memcpy(device->data, packet, size);
+
+   device->buttons = 0;
+
+   pressed_keys  = device->data[7] | (device->data[6] << 8) |
+                (((device->data[7] & 0x30) == 0x30) ? (1 << 16) : 0);  /* SELECT+START = MENU TOGGLE */
+
+   for (i = 0; i < 17; i ++)
+      if (button_mapping[i] != NO_BTN)
+         device->buttons |= (pressed_keys & (1 << i)) ? (UINT64_C(1) << button_mapping[i]) : 0;
+}
+
+static void hidpad_snesusb_set_rumble(void *data,
+      enum retro_rumble_effect effect, uint16_t strength)
+{
+	(void)data;
+	(void)effect;
+   (void)strength;
+}
+
+const char * hidpad_snesusb_get_name(void *data)
+{
+	(void)data;
+	/* For now we return a single static name */
+	return "Generic SNES USB Controller";
+}
+
+pad_connection_interface_t pad_connection_snesusb = {
+   hidpad_snesusb_init,
+   hidpad_snesusb_deinit,
+   hidpad_snesusb_packet_handler,
+   hidpad_snesusb_set_rumble,
+   hidpad_snesusb_get_buttons,
+   hidpad_snesusb_get_axis,
+   hidpad_snesusb_get_name,
+};

--- a/input/connect/connect_wii.c
+++ b/input/connect/connect_wii.c
@@ -724,4 +724,5 @@ pad_connection_interface_t pad_connection_wii = {
    hidpad_wii_set_rumble,
    hidpad_wii_get_buttons,
    hidpad_wii_get_axis,
+   NULL,
 };

--- a/input/connect/connect_wiiugca.c
+++ b/input/connect/connect_wiiugca.c
@@ -1,0 +1,148 @@
+/*  RetroArch - A frontend for libretro.
+ *  Copyright (C) 2013-2014 - Jason Fetters
+ *  Copyright (C) 2011-2016 - Daniel De Matteis
+ *
+ *  RetroArch is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  RetroArch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with RetroArch.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include <boolean.h>
+#include "joypad_connection.h"
+
+struct hidpad_wiiugca_data
+{
+   struct pad_connection* connection;
+   send_control_t send_control;
+   uint8_t data[64];
+   uint32_t slot;
+   uint64_t buttons;
+};
+
+static void* hidpad_wiiugca_init(void *data, uint32_t slot, send_control_t ptr)
+{
+   static uint8_t magic_data[]         = {0x01, 0x13}; /* Special command to enable reading */
+   struct pad_connection* connection   = (struct pad_connection*)data;
+   struct hidpad_wiiugca_data* device  = (struct hidpad_wiiugca_data*)
+      calloc(1, sizeof(struct hidpad_wiiugca_data));
+
+   if (!device)
+      return NULL;
+
+   if (!connection)
+   {
+      free(device);
+      return NULL;
+   }
+
+   device->connection   = connection;
+   device->slot         = slot;
+   device->send_control = ptr;
+   device->send_control(device->connection, magic_data, sizeof(magic_data));
+
+   return device;
+}
+
+static void hidpad_wiiugca_deinit(void *data)
+{
+   struct hidpad_wiiugca_data *device = (struct hidpad_wiiugca_data*)data;
+
+   if (device)
+      free(device);
+}
+
+static uint64_t hidpad_wiiugca_get_buttons(void *data)
+{
+   struct hidpad_wiiugca_data *device = (struct hidpad_wiiugca_data*)data;
+   if (!device)
+      return 0;
+   return device->buttons;
+}
+
+static int16_t hidpad_wiiugca_get_axis(void *data, unsigned axis)
+{
+   int val;
+   struct hidpad_wiiugca_data *device = (struct hidpad_wiiugca_data*)data;
+
+   if (!device || axis >= 4)
+      return 0;
+
+   val = device->data[5 + axis];
+
+   if (axis % 2) /* the Y axis is inverted */
+      val = 0x8000 - (val << 8);
+   else
+      val = (val << 8) - 0x8000;
+
+   return (abs(val) > 0x1000) ? val : 0;
+}
+
+static void hidpad_wiiugca_packet_handler(void *data, uint8_t *packet, uint16_t size)
+{
+   uint32_t i, pressed_keys;
+   static const uint32_t button_mapping[12] =
+   {
+      RETRO_DEVICE_ID_JOYPAD_A,
+      RETRO_DEVICE_ID_JOYPAD_B,
+      RETRO_DEVICE_ID_JOYPAD_X,
+      RETRO_DEVICE_ID_JOYPAD_Y,
+      RETRO_DEVICE_ID_JOYPAD_LEFT,
+      RETRO_DEVICE_ID_JOYPAD_RIGHT,
+      RETRO_DEVICE_ID_JOYPAD_DOWN,
+      RETRO_DEVICE_ID_JOYPAD_UP,
+      RETRO_DEVICE_ID_JOYPAD_START,
+      RETRO_DEVICE_ID_JOYPAD_SELECT,
+      RETRO_DEVICE_ID_JOYPAD_R,
+      RETRO_DEVICE_ID_JOYPAD_L,
+   };
+   struct hidpad_wiiugca_data *device = (struct hidpad_wiiugca_data*)data;
+
+   if (!device)
+      return;
+
+   memcpy(device->data, packet, size);
+
+   device->buttons = 0;
+
+   pressed_keys = device->data[3] | (device->data[4] << 8);
+
+   for (i = 0; i < 12; i ++)
+      device->buttons |= (pressed_keys & (1 << i)) ?
+         (1 << button_mapping[i]) : 0;
+}
+
+static void hidpad_wiiugca_set_rumble(void *data,
+      enum retro_rumble_effect effect, uint16_t strength)
+{
+	(void)data;
+	(void)effect;
+   (void)strength;
+}
+
+const char * hidpad_wiiugca_get_name(void *data)
+{
+	(void)data;
+	/* For now we return a single static name */
+	return "Wii U GC Controller Adapter";
+}
+
+pad_connection_interface_t pad_connection_wiiugca = {
+   hidpad_wiiugca_init,
+   hidpad_wiiugca_deinit,
+   hidpad_wiiugca_packet_handler,
+   hidpad_wiiugca_set_rumble,
+   hidpad_wiiugca_get_buttons,
+   hidpad_wiiugca_get_axis,
+   hidpad_wiiugca_get_name,
+};

--- a/input/connect/connect_wiiupro.c
+++ b/input/connect/connect_wiiupro.c
@@ -242,4 +242,5 @@ pad_connection_interface_t pad_connection_wiiupro = {
    hidpad_wiiupro_set_rumble,
    hidpad_wiiupro_get_buttons,
    hidpad_wiiupro_get_axis,
+   NULL,
 };

--- a/input/connect/joypad_connection.c
+++ b/input/connect/joypad_connection.c
@@ -81,7 +81,12 @@ int32_t pad_connection_pad_init(joypad_connection_t *joyconn,
       { "Nintendo RVL-CNT-01-UC",      1406,  816,    &pad_connection_wiiupro },
       { "Wireless Controller",         1356,  1476,   &pad_connection_ps4 },
       { "PLAYSTATION(R)3 Controller",  1356,  616,    &pad_connection_ps3 },
-      { "PLAYSTATION(R)3 Controller",   787,  8406,   &pad_connection_ps3 },
+      { "PLAYSTATION(R)3 Controller",  787,   8406,   &pad_connection_ps3 },
+#ifdef HAVE_WIIUSB_HID
+      { "Generic SNES USB Controller", 2079,  58369,  &pad_connection_snesusb },
+      { "Generic NES USB Controller",  121,   17,     &pad_connection_nesusb },
+      { "Wii U GC Controller Adapter", 1406,  823,    &pad_connection_wiiugca },
+#endif
       { 0, 0}
    };
    joypad_connection_t *s = NULL;
@@ -91,7 +96,7 @@ int32_t pad_connection_pad_init(joypad_connection_t *joyconn,
       return -1;
 
    s = &joyconn[pad];
-       
+
    if (s)
    {
       unsigned i;
@@ -177,6 +182,8 @@ void pad_connection_destroy(joypad_connection_t *joyconn)
 
    for (i = 0; i < MAX_USERS; i ++)
       pad_connection_pad_deinit(&joyconn[i], i);
+
+   free(joyconn);
 }
 
 bool pad_connection_rumble(joypad_connection_t *joyconn,
@@ -189,4 +196,11 @@ bool pad_connection_rumble(joypad_connection_t *joyconn,
 
    joyconn->iface->set_rumble(joyconn->data, effect, strength);
    return true;
+}
+
+const char* pad_connection_get_name(joypad_connection_t *joyconn, unsigned pad)
+{
+   if (!joyconn->iface || !joyconn->iface->get_name)
+      return NULL;
+   return joyconn->iface->get_name(joyconn->data);
 }

--- a/input/connect/joypad_connection.h
+++ b/input/connect/joypad_connection.h
@@ -1,7 +1,7 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2013-2014 - Jason Fetters
  *  Copyright (C) 2011-2016 - Daniel De Matteis
- * 
+ *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-
  *  ation, either version 3 of the License, or (at your option) any later version.
@@ -33,13 +33,14 @@ struct joypad_connection
 
 typedef struct pad_connection_interface
 {
-   void*    (*init)(void *data, uint32_t slot, send_control_t ptr);
-   void     (*deinit)(void* device);
-   void     (*packet_handler)(void* device, uint8_t *packet, uint16_t size);
-   void     (*set_rumble)(void* device, enum retro_rumble_effect effect,
-         uint16_t strength);
-   uint64_t (*get_buttons)(void *data);
-   int16_t  (*get_axis)(void *data, unsigned axis);
+   void*    	(*init)(void *data, uint32_t slot, send_control_t ptr);
+   void     	(*deinit)(void* device);
+   void     	(*packet_handler)(void* device, uint8_t *packet, uint16_t size);
+   void     	(*set_rumble)(void* device, enum retro_rumble_effect effect,
+					uint16_t strength);
+   uint64_t 	(*get_buttons)(void *data);
+   int16_t  	(*get_axis)(void *data, unsigned axis);
+   const char*	(*get_name)(void *data);
 } pad_connection_interface_t;
 
 typedef struct joypad_connection joypad_connection_t;
@@ -48,6 +49,11 @@ extern pad_connection_interface_t pad_connection_wii;
 extern pad_connection_interface_t pad_connection_wiiupro;
 extern pad_connection_interface_t pad_connection_ps3;
 extern pad_connection_interface_t pad_connection_ps4;
+#ifdef HAVE_WIIUSB_HID
+extern pad_connection_interface_t pad_connection_snesusb;
+extern pad_connection_interface_t pad_connection_nesusb;
+extern pad_connection_interface_t pad_connection_wiiugca;
+#endif
 
 int32_t pad_connection_pad_init(joypad_connection_t *joyconn,
    const char* name, uint16_t vid, uint16_t pid,
@@ -79,5 +85,8 @@ int pad_connection_find_vacant_pad(joypad_connection_t *joyconn);
 
 bool pad_connection_rumble(joypad_connection_t *s,
    unsigned pad, enum retro_rumble_effect effect, uint16_t strength);
+
+const char* pad_connection_get_name(joypad_connection_t *joyconn,
+   unsigned idx);
 
 #endif


### PR DESCRIPTION
In order to have a controller working you need:
1) Have a matching HID autoconfig file in autoconfig/hid for your controller.
2) Create a "connect" driver for the pad in "input/connect" folder (source code of RA).
3) Once you are in RA, change the joystick driver to HID and restart.
4) You may be now able to use you USB HID compatible pad in RA.

I included some "connect" drivers as an example. It also need to include them for compilation.