### PR TITLE
Enables keyboard to be mapped to gamepad buttons

### DIFF
--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -976,8 +976,11 @@ static void android_input_poll_input(void *data)
 
                   if (is_keyboard_id(id))
                   {
-                     if (!predispatched) android_input_poll_event_type_keyboard(event, keycode, &handled);
-                     android_input_poll_event_type_key(android_app, event, ANDROID_KEYBOARD_PORT, keycode, source, type_event, &handled);
+                     if (!predispatched)
+                     {
+                        android_input_poll_event_type_keyboard(event, keycode, &handled);
+                        android_input_poll_event_type_key(android_app, event, ANDROID_KEYBOARD_PORT, keycode, source, type_event, &handled);
+                     }
                   }
                   else
                      android_input_poll_event_type_key(android_app,
@@ -1113,8 +1116,6 @@ static int16_t android_input_state(void *data,
       case RETRO_DEVICE_JOYPAD:
          return input_joypad_pressed(android->joypad, port, binds[port], id) ||
                 android_keyboard_port_input_pressed(binds[port],id);
-      case RETRO_DEVICE_KEYBOARD:
-                android_keyboard_port_input_pressed(binds[0],id);
       case RETRO_DEVICE_ANALOG:
          return input_joypad_analog(android->joypad, port, idx, id,
                binds[port]);
@@ -1205,7 +1206,6 @@ static uint64_t android_input_get_capabilities(void *data)
 
    return
       (1 << RETRO_DEVICE_JOYPAD)  |
-      (1 << RETRO_DEVICE_KEYBOARD) |
       (1 << RETRO_DEVICE_POINTER) |
       (1 << RETRO_DEVICE_ANALOG);
 }

--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -977,6 +977,7 @@ static void android_input_poll_input(void *data)
                   if (is_keyboard_id(id))
                   {
                      if (!predispatched) android_input_poll_event_type_keyboard(event, keycode, &handled);
+                     android_input_poll_event_type_key(android_app, event, ANDROID_KEYBOARD_PORT, keycode, source, type_event, &handled);
                   }
                   else
                      android_input_poll_event_type_key(android_app,
@@ -1110,7 +1111,10 @@ static int16_t android_input_state(void *data,
    switch (device)
    {
       case RETRO_DEVICE_JOYPAD:
-         return input_joypad_pressed(android->joypad, port, binds[port], id);
+         return input_joypad_pressed(android->joypad, port, binds[port], id) ||
+                android_keyboard_port_input_pressed(binds[port],id);
+      case RETRO_DEVICE_KEYBOARD:
+                android_keyboard_port_input_pressed(binds[0],id);
       case RETRO_DEVICE_ANALOG:
          return input_joypad_analog(android->joypad, port, idx, id,
                binds[port]);
@@ -1156,6 +1160,9 @@ static bool android_input_key_pressed(void *data, int key)
    android_input_t *android = (android_input_t*)data;
    settings_t *settings     = config_get_ptr();
 
+   if(android_keyboard_port_input_pressed(settings->input.binds[0],key))
+      return true;
+
    if (input_joypad_pressed(android->joypad,
          0, settings->input.binds[0], key))
       return true;
@@ -1198,6 +1205,7 @@ static uint64_t android_input_get_capabilities(void *data)
 
    return
       (1 << RETRO_DEVICE_JOYPAD)  |
+      (1 << RETRO_DEVICE_KEYBOARD) |
       (1 << RETRO_DEVICE_POINTER) |
       (1 << RETRO_DEVICE_ANALOG);
 }

--- a/input/drivers_keyboard/keyboard_event_android.c
+++ b/input/drivers_keyboard/keyboard_event_android.c
@@ -21,7 +21,19 @@
 
 #define MAX_KEYS ((LAST_KEYCODE + 7) / 8)
 
-static uint8_t android_key_state[MAX_PADS][MAX_KEYS];
+// First ports are used to keeping track of gamepad states. Last port is used for keyboard state
+static uint8_t android_key_state[MAX_PADS+1][MAX_KEYS];
+
+bool android_keyboard_port_input_pressed(const struct retro_keybind *binds, unsigned id)
+{
+   if (id < RARCH_BIND_LIST_END)
+   {
+      const struct retro_keybind *bind = &binds[id];
+      unsigned bit = input_keymaps_translate_rk_to_keysym(binds[id].key);
+      return bind->valid && BIT_GET(android_key_state[ANDROID_KEYBOARD_PORT], bit);
+   }
+   return false;
+}
 
 bool android_keyboard_input_pressed(unsigned key)
 {

--- a/input/drivers_keyboard/keyboard_event_android.h
+++ b/input/drivers_keyboard/keyboard_event_android.h
@@ -135,6 +135,10 @@ enum {
 #define MAX_PADS 8
 #endif
 
+#define ANDROID_KEYBOARD_PORT MAX_PADS
+
+bool android_keyboard_port_input_pressed(const struct retro_keybind *binds, unsigned id);
+
 bool android_keyboard_input_pressed(unsigned key);
 
 uint8_t *android_keyboard_state_get(unsigned port);


### PR DESCRIPTION
Added one more android_key_state to "keyboard_event_android.c" which keeps track of the keyboard state.

Added return of keyboard states to "android_input.c" which fixes using keyboard to navigate Retroarch menus and enabled the use of keyboard for gamepad button mappings.

The Android input driver is a bit confusing to follow on these points compared to other input drivers. It seems that joypad states are mixed into "keyboard_event_android.c" when it should be used for keeping track of keyboard states. I've built on top of this and added keyboard states in this pull request, but in the long run joypad states might be better to move out of "keyboard_event_android.c".

I'll look into how this is done in the other drivers and suggest an easier structure at a later point.
