### PR TITLE
Vulkan: Attempt workaround for Ivy Bridge.

### DIFF
--- a/cores/libretro-test-vulkan/libretro-test.c
+++ b/cores/libretro-test-vulkan/libretro-test.c
@@ -178,10 +178,10 @@ static void vulkan_test_render(void)
    update_ubo();
 
    VkCommandBuffer cmd = vk.cmd[vk.index];
-   vkResetCommandPool(vulkan->device, vk.cmd_pool[vk.index], 0);
 
    VkCommandBufferBeginInfo begin_info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };
    begin_info.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+   vkResetCommandBuffer(cmd, 0);
    vkBeginCommandBuffer(cmd, &begin_info);
 
    VkImageMemoryBarrier prepare_rendering = { VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER };
@@ -583,6 +583,7 @@ static void init_command(void)
    VkCommandBufferAllocateInfo info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO };
 
    pool_info.queueFamilyIndex = vulkan->queue_index;
+   pool_info.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
 
    for (unsigned i = 0; i < vk.num_swapchain_images; i++)
    {


### PR DESCRIPTION
Reset command buffer instead of pool.