### PR TITLE
Add option for menu linear filter

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -479,6 +479,7 @@ static void config_set_defaults(void)
    settings->menu.xmb_alpha_factor   = xmb_alpha_factor;
    settings->menu.xmb_font[0]        = '\0';
    settings->menu.throttle_framerate = true;
+   settings->menu.linear_filter      = true;
 #endif
 
    settings->history_list_enable         = def_history_list_enable;
@@ -1317,6 +1318,8 @@ static bool config_load_file(const char *path, bool set_defaults)
 
    CONFIG_GET_BOOL_BASE(conf, settings, menu.throttle_framerate,
          "menu_throttle_framerate");
+   CONFIG_GET_BOOL_BASE(conf, settings, menu.linear_filter,
+         "menu_linear_filter");
    CONFIG_GET_BOOL_BASE(conf, settings, menu.dpi.override_enable,
          "dpi_override_enable");
    CONFIG_GET_INT_BASE (conf, settings, menu.dpi.override_value,
@@ -2615,6 +2618,7 @@ bool config_save_file(const char *path)
 #endif
 
    config_set_bool(conf, "menu_throttle_framerate", settings->menu.throttle_framerate);
+   config_set_bool(conf, "menu_linear_filter", settings->menu.linear_filter);
    config_set_bool(conf, "dpi_override_enable", settings->menu.dpi.override_enable);
    config_set_int (conf, "dpi_override_value", settings->menu.dpi.override_value);
    config_set_string(conf,"menu_driver", settings->menu.driver);

--- a/configuration.h
+++ b/configuration.h
@@ -168,6 +168,7 @@ typedef struct settings
       unsigned xmb_alpha_factor;
       char xmb_font[PATH_MAX_LENGTH];
       bool throttle_framerate;
+      bool linear_filter;
    } menu;
 #endif
 

--- a/gfx/drivers/gl.c
+++ b/gfx/drivers/gl.c
@@ -3642,6 +3642,7 @@ static void gl_set_texture_frame(void *data,
       const void *frame, bool rgb32, unsigned width, unsigned height,
       float alpha)
 {
+   settings_t *settings            = config_get_ptr();
    unsigned base_size = rgb32 ? sizeof(uint32_t) : sizeof(uint16_t);
    gl_t *gl = (gl_t*)data;
    if (!gl)
@@ -3649,12 +3650,14 @@ static void gl_set_texture_frame(void *data,
 
    context_bind_hw_render(gl, false);
 
+   enum texture_filter_type menu_filter = settings->menu.linear_filter ? TEXTURE_FILTER_LINEAR : TEXTURE_FILTER_NEAREST;
+
    if (!gl->menu_texture)
       glGenTextures(1, &gl->menu_texture);
 
 
    gl_load_texture_data(gl->menu_texture,
-         RARCH_WRAP_EDGE, TEXTURE_FILTER_LINEAR,
+         RARCH_WRAP_EDGE, menu_filter,
          video_pixel_get_alignment(width * base_size),
          width, height, frame,
          base_size);

--- a/menu/intl/menu_hash_us.c
+++ b/menu/intl/menu_hash_us.c
@@ -26,6 +26,8 @@ static const char *menu_hash_to_str_us_label(uint32_t hash)
 {
    switch (hash)
    {
+      case MENU_LABEL_MENU_LINEAR_FILTER:
+         return "menu_linear_filter";
       case MENU_LABEL_MENU_THROTTLE_FRAMERATE:
          return "menu_throttle_framerate";
       case MENU_LABEL_START_CORE:
@@ -730,6 +732,8 @@ const char *menu_hash_to_str_us(uint32_t hash)
 
    switch (hash)
    {
+      case MENU_LABEL_VALUE_MENU_LINEAR_FILTER:
+         return "Menu Linear Filter";
       case MENU_LABEL_VALUE_MENU_THROTTLE_FRAMERATE:
          return "Throttle Menu Framerate";
       case MENU_LABEL_VALUE_CHEEVOS_TEST_UNOFFICIAL:

--- a/menu/menu_hash.h
+++ b/menu/menu_hash.h
@@ -22,6 +22,9 @@
 extern "C" {
 #endif
 
+#define MENU_LABEL_MENU_LINEAR_FILTER                                          0x5fe9128cU
+#define MENU_LABEL_VALUE_MENU_LINEAR_FILTER                                    0x192de208U
+
 #define MENU_LABEL_MENU_THROTTLE_FRAMERATE                                     0x9a8681c5U
 #define MENU_LABEL_VALUE_MENU_THROTTLE_FRAMERATE                               0x285bb667U
 

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -5747,6 +5747,21 @@ static bool setting_append_list_menu_options(
          parent_group,
          general_write_handler,
          general_read_handler);
+
+   CONFIG_BOOL(
+         list, list_info,
+         &settings->menu.linear_filter,
+         menu_hash_to_str(MENU_LABEL_MENU_LINEAR_FILTER),
+         menu_hash_to_str(MENU_LABEL_VALUE_MENU_LINEAR_FILTER),
+         true,
+         menu_hash_to_str(MENU_VALUE_OFF),
+         menu_hash_to_str(MENU_VALUE_ON),
+         &group_info,
+         &subgroup_info,
+         parent_group,
+         general_write_handler,
+         general_read_handler);
+
 #ifdef RARCH_MOBILE
    /* We don't want mobile users being able to switch this off. */
    (*list)[list_info->index - 1].action_left   = NULL;


### PR DESCRIPTION
This allows the linear filter applied to the menu to be disabled. This is mainly to allow RGUI or any other rasterized 2D menu driver to be scaled with the nearest filter. 

This is for the GL driver only for now, I didn't see an easy way to do this for D3D.

https://a.pomf.cat/jcyvbi.png