### PR TITLE
Vulkan: Allocate correct number of descriptors.

### DIFF
--- a/cores/libretro-test-vulkan/libretro-test.c
+++ b/cores/libretro-test-vulkan/libretro-test.c
@@ -341,8 +341,8 @@ static void init_descriptor(void)
    binding.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
    binding.pImmutableSamplers = NULL;
 
-   static const VkDescriptorPoolSize pool_sizes[1] = {
-      { VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1 },
+   const VkDescriptorPoolSize pool_sizes[1] = {
+      { VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, vk.num_swapchain_images },
    };
 
    VkDescriptorSetLayoutCreateInfo set_layout_info = { VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO };

--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -454,8 +454,8 @@ static void vulkan_init_descriptor_pool(vk_t *vk)
    VkDescriptorPoolCreateInfo pool_info            = { 
       VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO };
    static const VkDescriptorPoolSize pool_sizes[2] = {
-      { VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1 },
-      { VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1 },
+      { VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, VULKAN_DESCRIPTOR_MANAGER_BLOCK_SETS },
+      { VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VULKAN_DESCRIPTOR_MANAGER_BLOCK_SETS },
    };
 
    for (i = 0; i < vk->num_swapchain_images; i++)

--- a/gfx/drivers_shader/shader_vulkan.cpp
+++ b/gfx/drivers_shader/shader_vulkan.cpp
@@ -693,9 +693,9 @@ bool Pass::init_pipeline_layout()
          VK_SHADER_STAGE_FRAGMENT_BIT,
          nullptr });
 
-   desc_counts.push_back({ VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1 });
-   desc_counts.push_back({ VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1 });
-   desc_counts.push_back({ VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1 });
+   desc_counts.push_back({ VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, num_sync_indices });
+   desc_counts.push_back({ VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, num_sync_indices });
+   desc_counts.push_back({ VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, num_sync_indices });
 
    VkDescriptorSetLayoutCreateInfo set_layout_info = { 
       VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO };


### PR DESCRIPTION
Have to allocate for entire pool, not per set.