### PR TITLE
cg2glsl: Write uniform declarations for fragment shaders.

### DIFF
--- a/tools/cg2glsl.py
+++ b/tools/cg2glsl.py
@@ -405,6 +405,8 @@ def fix_samplers(log_prefix, ref_index, source):
         source.insert(ref_index, sampler)
     if struct_texunit0:
         source.insert(ref_index, 'uniform sampler2D Texture;')
+    for uniform in uniforms:
+        source.insert(ref_index, 'uniform COMPAT_PRECISION vec2 ' + uniform + ';')
     for index, line in enumerate(source):
         for orig, new in translations:
             log(log_prefix, 'Translation:', orig, '->', new)


### PR DESCRIPTION
Formerly, the fragment shader conversion pass did not write required uniform
declarations. This resulted in use of undefined symbols in some cases. In turn
conversion of some shaders to GLSL were broken.

This fixes conversion of some shaders, most prominently the hq shaders.