### PR TITLE
Vulkan: Fix lots of dubious barrier usage and add initial SPIR-V shader reflection

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "deps/glslang/glslang"]
 	path = deps/glslang/glslang
 	url = git://github.com/KhronosGroup/glslang.git
+[submodule "deps/spir2cross"]
+	path = deps/spir2cross
+	url = git://github.com/ARM-software/spir2cross

--- a/Makefile.common
+++ b/Makefile.common
@@ -749,25 +749,30 @@ ifeq ($(HAVE_VULKAN), 1)
 		$(wildcard deps/glslang/glslang/glslang/MachineIndependent/preprocessor/*.cpp) \
 		$(wildcard deps/glslang/glslang/glslang/OSDependent/$(GLSLANG_PLATFORM)/*.cpp)
 
+	SPIR2CROSS_SOURCES := deps/spir2cross/spir2cross.cpp
+
 	DEFINES += \
 			  -Ideps/glslang/glslang/glslang/OSDependent/$(GLSLANG_PLATFORM) \
 			  -Ideps/glslang/glslang \
 			  -Ideps/glslang/glslang/glslang/MachineIndependent \
 			  -Ideps/glslang/glslang/glslang/Public \
 			  -Ideps/glslang/glslang/SPIRV \
-			  -Ideps/glslang
+			  -Ideps/glslang \
+			  -Ideps/spir2cross
 
 	CXXFLAGS += -Wno-switch -Wno-sign-compare -fno-strict-aliasing -Wno-maybe-uninitialized -Wno-reorder -I./gfx/include/vulkan
    CFLAGS  += -I./gfx/include/vulkan
 
 	GLSLANG_OBJ := $(GLSLANG_SOURCES:.cpp=.o)
+	SPIR2CROSS_OBJ := $(SPIR2CROSS_SOURCES:.cpp=.o)
 
 	OBJ += gfx/drivers/vulkan.o \
 			 gfx/common/vulkan_common.o \
 			 gfx/drivers_font/vulkan_raster_font.o \
 			 gfx/drivers_shader/shader_vulkan.o \
 			 gfx/drivers_shader/glslang_util.o \
-			 $(GLSLANG_OBJ)
+			 $(GLSLANG_OBJ) \
+			 $(SPIR2CROSS_OBJ)
 	ifeq ($(HAVE_MENU_COMMON), 1)
 		OBJ += menu/drivers_display/menu_display_vulkan.o
 	endif

--- a/Makefile.common
+++ b/Makefile.common
@@ -771,6 +771,7 @@ ifeq ($(HAVE_VULKAN), 1)
 			 gfx/drivers_font/vulkan_raster_font.o \
 			 gfx/drivers_shader/shader_vulkan.o \
 			 gfx/drivers_shader/glslang_util.o \
+			 gfx/drivers_shader/slang_reflection.o \
 			 $(GLSLANG_OBJ) \
 			 $(SPIR2CROSS_OBJ)
 	ifeq ($(HAVE_MENU_COMMON), 1)

--- a/cores/libretro-test-vulkan/libretro-test.c
+++ b/cores/libretro-test-vulkan/libretro-test.c
@@ -186,7 +186,7 @@ static void vulkan_test_render(void)
 
    VkImageMemoryBarrier prepare_rendering = { VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER };
    prepare_rendering.srcAccessMask = 0;
-   prepare_rendering.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+   prepare_rendering.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
    prepare_rendering.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
    prepare_rendering.newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
    prepare_rendering.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
@@ -704,7 +704,7 @@ static void context_destroy(void)
 static bool retro_init_hw_context(void)
 {
    hw_render.context_type = RETRO_HW_CONTEXT_VULKAN;
-   hw_render.version_major = VK_API_VERSION;
+   hw_render.version_major = VK_MAKE_VERSION(1, 0, 6);
    hw_render.version_minor = 0;
    hw_render.context_reset = context_reset;
    hw_render.context_destroy = context_destroy;

--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -444,8 +444,8 @@ struct vk_texture vulkan_create_texture(vk_t *vk,
 
       vulkan_image_layout_transition(vk, staging, tmp.image,
             VK_IMAGE_LAYOUT_PREINITIALIZED, VK_IMAGE_LAYOUT_GENERAL,
-            VK_ACCESS_HOST_WRITE_BIT, VK_ACCESS_TRANSFER_READ_BIT,
-            VK_PIPELINE_STAGE_HOST_BIT,
+            0, VK_ACCESS_TRANSFER_READ_BIT,
+            VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
             VK_PIPELINE_STAGE_TRANSFER_BIT);
 
       vulkan_image_layout_transition(vk, staging, tex.image,
@@ -565,16 +565,16 @@ void vulkan_transition_texture(vk_t *vk, struct vk_texture *texture)
       case VULKAN_TEXTURE_STREAMED:
          vulkan_image_layout_transition(vk, vk->cmd, texture->image,
                texture->layout, VK_IMAGE_LAYOUT_GENERAL,
-               VK_ACCESS_HOST_WRITE_BIT, VK_ACCESS_SHADER_READ_BIT,
-               VK_PIPELINE_STAGE_HOST_BIT,
+               0, VK_ACCESS_SHADER_READ_BIT,
+               VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
                VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
          break;
 
       case VULKAN_TEXTURE_STAGING:
          vulkan_image_layout_transition(vk, vk->cmd, texture->image,
                texture->layout, VK_IMAGE_LAYOUT_GENERAL,
-               VK_ACCESS_HOST_WRITE_BIT, VK_ACCESS_TRANSFER_READ_BIT,
-               VK_PIPELINE_STAGE_HOST_BIT,
+               0, VK_ACCESS_TRANSFER_READ_BIT,
+               VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
                VK_PIPELINE_STAGE_TRANSFER_BIT);
          break;
 

--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -1262,7 +1262,7 @@ bool vulkan_context_init(gfx_ctx_vulkan_data_t *vk,
    app.applicationVersion            = 0;
    app.pEngineName                   = "RetroArch";
    app.engineVersion                 = 0;
-   app.apiVersion                    = VK_MAKE_VERSION(1, 0, 2);
+   app.apiVersion                    = VK_MAKE_VERSION(1, 0, 6);
 
    info.pApplicationInfo             = &app;
    info.enabledExtensionCount        = ARRAY_SIZE(instance_extensions);

--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -1351,7 +1351,7 @@ static void vulkan_readback(vk_t *vk)
          VK_PIPELINE_STAGE_HOST_BIT);
 }
 
-static void vulkan_flush_vertex_caches(vk_t *vk)
+static void vulkan_flush_caches(vk_t *vk)
 {
    VkMemoryBarrier barrier = { VK_STRUCTURE_TYPE_MEMORY_BARRIER };
    barrier.srcAccessMask = VK_ACCESS_HOST_WRITE_BIT;
@@ -1359,7 +1359,9 @@ static void vulkan_flush_vertex_caches(vk_t *vk)
 
    VKFUNC(vkCmdPipelineBarrier)(vk->cmd,
          VK_PIPELINE_STAGE_HOST_BIT,
-         VK_PIPELINE_STAGE_VERTEX_INPUT_BIT | VK_PIPELINE_STAGE_VERTEX_SHADER_BIT,
+         VK_PIPELINE_STAGE_VERTEX_INPUT_BIT |
+         VK_PIPELINE_STAGE_VERTEX_SHADER_BIT |
+         VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
          false,
          1, &barrier,
          0, NULL, 0, NULL);
@@ -1421,7 +1423,7 @@ static bool vulkan_frame(void *data, const void *frame,
 
    memset(&vk->tracker, 0, sizeof(vk->tracker));
 
-   vulkan_flush_vertex_caches(vk);
+   vulkan_flush_caches(vk);
 
    /* Upload texture */
    retro_perf_start(&copy_frame);

--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -978,6 +978,7 @@ static void *vulkan_init(const video_info_t *video,
    vk->tex_fmt           = video->rgb32 
       ? VK_FORMAT_B8G8R8A8_UNORM : VK_FORMAT_R5G6B5_UNORM_PACK16;
    vk->keep_aspect       = video->force_aspect;
+   RARCH_LOG("[Vulkan]: Using %s format.\n", video->rgb32 ? "BGRA8888" : "RGB565");
 
    /* Set the viewport to fix recording, since it needs to know
     * the viewport sizes before we start running. */

--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -1335,7 +1335,7 @@ static void vulkan_readback(vk_t *vk)
          VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_GENERAL,
          0, VK_ACCESS_TRANSFER_WRITE_BIT,
          VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-         VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
+         VK_PIPELINE_STAGE_TRANSFER_BIT);
 
    VKFUNC(vkCmdCopyImage)(vk->cmd, vk->chain->backbuffer.image,
          VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
@@ -1527,12 +1527,12 @@ static bool vulkan_frame(void *data, const void *frame,
    rp_info.clearValueCount          = 1;
    rp_info.pClearValues             = &clear_value;
 
-   /* Prepare backbuffer for rendering */
+   /* Prepare backbuffer for rendering. We don't use WSI semaphores here. */
    vulkan_image_layout_transition(vk, vk->cmd, chain->backbuffer.image,
          VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-         0, VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+         0, VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_COLOR_ATTACHMENT_READ_BIT,
          VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-         VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
+         VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
 
    /* Begin render pass and set up viewport */
    VKFUNC(vkCmdBeginRenderPass)(vk->cmd, &rp_info, VK_SUBPASS_CONTENTS_INLINE);
@@ -1613,10 +1613,10 @@ static bool vulkan_frame(void *data, const void *frame,
             chain->backbuffer.image,
             VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
             VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
-            VK_ACCESS_TRANSFER_READ_BIT,
-            VK_ACCESS_MEMORY_READ_BIT,
+            0,
+            0,
             VK_PIPELINE_STAGE_TRANSFER_BIT,
-            VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
+            VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
 
       vk->readback.pending = false;
    }
@@ -1628,9 +1628,9 @@ static bool vulkan_frame(void *data, const void *frame,
             VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
             VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
             VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
-            VK_ACCESS_MEMORY_READ_BIT,
+            0,
             VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT,
-            VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
+            VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
    }
 
    retro_perf_start(&end_cmd);

--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -1354,11 +1354,11 @@ static void vulkan_readback(vk_t *vk)
 static void vulkan_flush_caches(vk_t *vk)
 {
    VkMemoryBarrier barrier = { VK_STRUCTURE_TYPE_MEMORY_BARRIER };
-   barrier.srcAccessMask = VK_ACCESS_HOST_WRITE_BIT;
+   barrier.srcAccessMask = 0;
    barrier.dstAccessMask = VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT | VK_ACCESS_UNIFORM_READ_BIT;
 
    VKFUNC(vkCmdPipelineBarrier)(vk->cmd,
-         VK_PIPELINE_STAGE_HOST_BIT,
+         VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
          VK_PIPELINE_STAGE_VERTEX_INPUT_BIT |
          VK_PIPELINE_STAGE_VERTEX_SHADER_BIT |
          VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,

--- a/gfx/drivers_shader/shader_vulkan.cpp
+++ b/gfx/drivers_shader/shader_vulkan.cpp
@@ -1074,9 +1074,9 @@ void Pass::build_commands(
             framebuffer->get_image(),
             VK_IMAGE_LAYOUT_UNDEFINED,
             VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-            VK_ACCESS_SHADER_READ_BIT,
-            VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
-            VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+            0,
+            VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+            VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT,
             VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
 
       VkRenderPassBeginInfo rp_info = { 

--- a/gfx/drivers_shader/shader_vulkan.cpp
+++ b/gfx/drivers_shader/shader_vulkan.cpp
@@ -25,8 +25,10 @@
 #include "../drivers/vulkan_shaders/opaque.frag.inc"
 #include "../video_shader_driver.h"
 #include "../../verbosity.h"
+#include "spir2cross.hpp"
 
 using namespace std;
+using namespace spir2cross;
 
 static uint32_t find_memory_type(
       const VkPhysicalDeviceMemoryProperties &mem_props,

--- a/gfx/drivers_shader/slang_reflection.cpp
+++ b/gfx/drivers_shader/slang_reflection.cpp
@@ -1,0 +1,242 @@
+/*  RetroArch - A frontend for libretro.
+ *  Copyright (C) 2010-2016 - Hans-Kristian Arntzen
+ * 
+ *  RetroArch is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  RetroArch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with RetroArch.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "spir2cross.hpp"
+#include "slang_reflection.hpp"
+#include <vector>
+#include <stdio.h>
+#include "../../verbosity.h"
+
+using namespace std;
+using namespace spir2cross;
+
+static slang_texture_semantic slang_name_to_semantic(const string &name)
+{
+   if (name == "Original")
+      return SLANG_TEXTURE_SEMANTIC_ORIGINAL;
+   else if (name == "Source")
+      return SLANG_TEXTURE_SEMANTIC_SOURCE;
+   else
+      return SLANG_TEXTURE_INVALID_SEMANTIC;
+}
+
+static bool find_uniform_offset(const Compiler &compiler, const Resource &resource, const char *name,
+      size_t *offset, unsigned *member_index)
+{
+   auto &type = compiler.get_type(resource.type_id);
+   size_t num_members = type.member_types.size();
+   for (size_t i = 0; i < num_members; i++)
+   {
+      if (compiler.get_member_name(resource.type_id, i) == name)
+      {
+         *offset = compiler.get_member_decoration(resource.type_id, i, spv::DecorationOffset);
+         *member_index = i;
+         return true;
+      }
+   }
+   return false;
+}
+
+static bool slang_reflect(const Compiler &vertex_compiler, const Compiler &fragment_compiler,
+      const ShaderResources &vertex, const ShaderResources &fragment,
+      slang_reflection *reflection)
+{
+   unsigned member_index = 0;
+
+   // Validate use of unexpected types.
+   if (
+         !vertex.sampled_images.empty() ||
+         !vertex.storage_buffers.empty() ||
+         !vertex.subpass_inputs.empty() ||
+         !vertex.storage_images.empty() ||
+         !vertex.atomic_counters.empty() ||
+         !vertex.push_constant_buffers.empty() ||
+         !fragment.storage_buffers.empty() ||
+         !fragment.subpass_inputs.empty() ||
+         !fragment.storage_images.empty() ||
+         !fragment.atomic_counters.empty() ||
+         !fragment.push_constant_buffers.empty())
+   {
+      RARCH_ERR("Invalid resource type detected.\n");
+      return false;
+   }
+
+   // Validate vertex input.
+   if (vertex.stage_inputs.size() != 2)
+   {
+      RARCH_ERR("Vertex must have two attributes.\n");
+      return false;
+   }
+
+   uint32_t location_mask = 0;
+   for (auto &input : vertex.stage_inputs)
+      location_mask |= 1 << vertex_compiler.get_decoration(input.id, spv::DecorationLocation);
+
+   if (location_mask != 0x3)
+   {
+      RARCH_ERR("The two vertex attributes do not use location = 0 and location = 1.\n");
+      return false;
+   }
+
+   // Validate the single uniform buffer.
+   if (vertex.uniform_buffers.size() != 1)
+   {
+      RARCH_ERR("Vertex must use exactly one uniform buffer.\n");
+      return false;
+   }
+
+   if (fragment.uniform_buffers.size() > 1)
+   {
+      RARCH_ERR("Fragment must use zero or one uniform buffer.\n");
+      return false;
+   }
+
+   if (vertex_compiler.get_decoration(vertex.uniform_buffers[0].id, spv::DecorationDescriptorSet) != 0)
+   {
+      RARCH_ERR("Resources must use descriptor set #0.\n");
+      return false;
+   }
+
+   if (!fragment.uniform_buffers.empty() &&
+         fragment_compiler.get_decoration(fragment.uniform_buffers[0].id, spv::DecorationDescriptorSet) != 0)
+   {
+      RARCH_ERR("Resources must use descriptor set #0.\n");
+      return false;
+   }
+
+   unsigned ubo_binding = vertex_compiler.get_decoration(vertex.uniform_buffers[0].id,
+         spv::DecorationBinding);
+   if (!fragment.uniform_buffers.empty() &&
+         ubo_binding != fragment_compiler.get_decoration(fragment.uniform_buffers[0].id, spv::DecorationBinding))
+   {
+      RARCH_ERR("Vertex and fragment uniform buffer must have same binding.\n");
+      return false;
+   }
+
+   if (ubo_binding >= SLANG_NUM_BINDINGS)
+   {
+      RARCH_ERR("Binding %u is out of range.\n", ubo_binding);
+      return false;
+   }
+
+   reflection->ubo_stage_mask = SLANG_STAGE_VERTEX_MASK;
+   reflection->ubo_size = vertex_compiler.get_declared_struct_size(
+         vertex_compiler.get_type(vertex.uniform_buffers[0].type_id));
+
+   if (!fragment.uniform_buffers.empty())
+   {
+      reflection->ubo_stage_mask |= SLANG_STAGE_FRAGMENT_MASK;
+      reflection->ubo_size = max(reflection->ubo_size,
+            fragment_compiler.get_declared_struct_size(fragment_compiler.get_type(fragment.uniform_buffers[0].type_id)));
+   }
+
+   if (!find_uniform_offset(vertex_compiler, vertex.uniform_buffers[0], "MVP", &reflection->mvp_offset, &member_index))
+   {
+      RARCH_ERR("Could not find offset for MVP matrix.\n");
+      return false;
+   }
+
+   uint32_t binding_mask = 1 << ubo_binding;
+
+   // On to textures.
+   for (auto &texture : fragment.sampled_images)
+   {
+      unsigned set = fragment_compiler.get_decoration(texture.id, spv::DecorationDescriptorSet);
+      unsigned binding = fragment_compiler.get_decoration(texture.id, spv::DecorationBinding);
+
+      if (set != 0)
+      {
+         RARCH_ERR("Resources must use descriptor set #0.\n");
+         return false;
+      }
+
+      if (binding >= SLANG_NUM_BINDINGS)
+      {
+         RARCH_ERR("Binding %u is out of range.\n", ubo_binding);
+         return false;
+      }
+
+      if (binding_mask & (1 << binding))
+      {
+         RARCH_ERR("Binding %u is already in use.\n", binding);
+         return false;
+      }
+      binding_mask |= 1 << binding;
+
+      slang_texture_semantic index = slang_name_to_semantic(texture.name); 
+      
+      if (index == SLANG_TEXTURE_INVALID_SEMANTIC)
+      {
+         RARCH_ERR("Non-semantic textures not supported.\n");
+         return false;
+      }
+
+      auto &semantic = reflection->semantic_textures[index];
+      semantic.binding = binding;
+      semantic.stage_mask = SLANG_STAGE_FRAGMENT_MASK;
+      reflection->semantic_texture_mask |= 1 << index;
+
+      // TODO: Do we want to expose Size uniforms if no stage is using the texture?
+      char uniform_name[128];
+      snprintf(uniform_name, sizeof(uniform_name), "%sSize", texture.name.c_str());
+      if (find_uniform_offset(fragment_compiler, fragment.uniform_buffers[0], uniform_name,
+               &semantic.ubo_offset, &member_index))
+      {
+         auto &type = fragment_compiler.get_type(
+               fragment_compiler.get_type(fragment.uniform_buffers[0].type_id).member_types[member_index]);
+
+         // Verify that the type is a vec4 to avoid any nasty surprises later.
+         bool is_vec4 = type.basetype == SPIRType::Float && type.array.empty() && type.vecsize == 4 && type.columns == 1;
+         if (!is_vec4)
+         {
+            RARCH_ERR("Semantic uniform is not vec4.\n");
+            return false;
+         }
+
+         reflection->semantic_texture_ubo_mask |= 1 << index;
+      }
+   }
+
+   return true;
+}
+
+bool slang_reflect_spirv(const std::vector<uint32_t> &vertex,
+      const std::vector<uint32_t> &fragment,
+      slang_reflection *reflection)
+{
+   try
+   {
+      Compiler vertex_compiler(vertex);
+      Compiler fragment_compiler(fragment);
+      auto vertex_resources = vertex_compiler.get_shader_resources();
+      auto fragment_resources = fragment_compiler.get_shader_resources();
+
+      if (!slang_reflect(vertex_compiler, fragment_compiler,
+               vertex_resources, fragment_resources,
+               reflection))
+      {
+         RARCH_ERR("Failed to reflect SPIR-V. Resource usage is inconsistent with expectations.\n");
+         return false;
+      }
+
+      return true;
+   }
+   catch (const std::exception &e)
+   {
+      RARCH_ERR("spir2cross threw exception: %s.\n", e.what());
+      return false;
+   }
+}
+

--- a/gfx/drivers_shader/slang_reflection.hpp
+++ b/gfx/drivers_shader/slang_reflection.hpp
@@ -1,0 +1,64 @@
+/*  RetroArch - A frontend for libretro.
+ *  Copyright (C) 2010-2016 - Hans-Kristian Arntzen
+ * 
+ *  RetroArch is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  RetroArch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with RetroArch.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SLANG_REFLECTION_HPP
+#define SLANG_REFLECTION_HPP
+
+#include <string>
+#include <stdint.h>
+
+// Textures with built-in meaning.
+enum slang_texture_semantic
+{
+   SLANG_TEXTURE_SEMANTIC_ORIGINAL = 0,
+   SLANG_TEXTURE_SEMANTIC_SOURCE = 1,
+   SLANG_TEXTURE_SEMANTIC_OUTPUT = 2,
+
+   SLANG_TEXTURE_NUM_SEMANTICS,
+   SLANG_TEXTURE_INVALID_SEMANTIC = -1
+};
+
+enum slang_stage
+{
+   SLANG_STAGE_VERTEX_MASK = 1 << 0,
+   SLANG_STAGE_FRAGMENT_MASK = 1 << 1
+};
+#define SLANG_NUM_BINDINGS 16
+
+struct slang_texture_semantic_meta
+{
+   size_t ubo_offset = 0;
+   unsigned binding = 0;
+   uint32_t stage_mask = 0;
+};
+
+struct slang_reflection
+{
+   size_t ubo_size = 0;
+   size_t mvp_offset = 0;
+   unsigned ubo_binding = 0;
+   uint32_t ubo_stage_mask = 0;
+
+   slang_texture_semantic_meta semantic_textures[SLANG_TEXTURE_NUM_SEMANTICS];
+   uint32_t semantic_texture_mask = 0;
+   uint32_t semantic_texture_ubo_mask = 0;
+};
+
+bool slang_reflect_spirv(const std::vector<uint32_t> &vertex,
+      const std::vector<uint32_t> &fragment,
+      slang_reflection *reflection);
+
+#endif
+


### PR DESCRIPTION
This adds spir2cross which lets us reflect SPIR-V binaries which in turn allows continuing the Vulkan shader backend to be more feature complete.

Also adds basic #include support in slang shaders which was previously missing from GLSL backends.

Tested on nVidia and Mesa.

Tightened up barrier usage to reflect current understanding from https://github.com/KhronosGroup/Vulkan-Docs/issues/128.