### PR TITLE
Vulkan: Implement universal FBO feedback.

### DIFF
--- a/gfx/common/vksym.h
+++ b/gfx/common/vksym.h
@@ -191,6 +191,7 @@ typedef struct vulkan_context_fp
 
    /* Image commands */
    PFN_vkCmdCopyImage                            vkCmdCopyImage;
+   PFN_vkCmdClearColorImage                      vkCmdClearColorImage;
 
    /* Pipeline commands */
    PFN_vkCmdBindPipeline                         vkCmdBindPipeline;

--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -1153,6 +1153,7 @@ static bool vulkan_load_device_symbols(gfx_ctx_vulkan_data_t *vk)
 
    /* Image commands */
    VK_GET_DEVICE_PROC_ADDR(CmdCopyImage);
+   VK_GET_DEVICE_PROC_ADDR(CmdClearColorImage);
 
    /* Vertex input descriptions */
    VK_GET_DEVICE_PROC_ADDR(CmdBindVertexBuffers);

--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -158,6 +158,8 @@ void vulkan_copy_staging_to_dynamic(vk_t *vk, VkCommandBuffer cmd,
          VK_ACCESS_SHADER_READ_BIT,
          VK_PIPELINE_STAGE_TRANSFER_BIT,
          VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
+
+   dynamic->layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 }
 
 #ifdef VULKAN_DEBUG_TEXTURE_ALLOC

--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -584,6 +584,7 @@ static bool vulkan_init_default_filter_chain(vk_t *vk)
    info.swapchain.format      = vk->context->swapchain_format;
    info.swapchain.render_pass = vk->render_pass;
    info.swapchain.num_indices = vk->context->num_swapchain_images;
+   info.original_format       = vk->tex_fmt;
 
    vk->filter_chain           = vulkan_filter_chain_create_default(
          &info,
@@ -614,6 +615,7 @@ static bool vulkan_init_filter_chain_preset(vk_t *vk, const char *shader_path)
    info.swapchain.format      = vk->context->swapchain_format;
    info.swapchain.render_pass = vk->render_pass;
    info.swapchain.num_indices = vk->context->num_swapchain_images;
+   info.original_format       = vk->tex_fmt;
 
    vk->filter_chain           = vulkan_filter_chain_create_from_preset(
          &info, shader_path,
@@ -1495,6 +1497,7 @@ static bool vulkan_frame(void *data, const void *frame,
             return false;
          }
 
+         input.image        = vk->hw.image->create_info.image;
          input.view         = vk->hw.image->image_view;
          input.layout       = vk->hw.image->image_layout;
 
@@ -1520,6 +1523,7 @@ static bool vulkan_frame(void *data, const void *frame,
          else
             vulkan_transition_texture(vk, tex);
 
+         input.image  = tex->image;
          input.view   = tex->view;
          input.layout = tex->layout;
          input.width  = tex->width;

--- a/gfx/drivers_shader/shader_vulkan.cpp
+++ b/gfx/drivers_shader/shader_vulkan.cpp
@@ -569,8 +569,6 @@ bool vulkan_filter_chain::init_history()
    original_history.clear();
    common.original_history.clear();
 
-   require_clear = false;
-
    size_t required_images = 0;
    for (auto &pass : passes)
    {
@@ -640,6 +638,7 @@ bool vulkan_filter_chain::init_feedback()
    }
 
    common.framebuffer_feedback.resize(passes.size() - 1);
+   require_clear = true;
    return true;
 }
 
@@ -656,9 +655,9 @@ bool vulkan_filter_chain::init()
          return false;
    }
 
+   require_clear = false;
    if (!init_history())
       return false;
-
    if (!init_feedback())
       return false;
 
@@ -1462,13 +1461,13 @@ void Pass::build_commands(
          { original.texture.width, original.texture.height },
          { source.texture.width, source.texture.height });
 
-   if (     size.width  != current_framebuffer_size.width 
-         || size.height != current_framebuffer_size.height)
+   if (framebuffer &&
+         (size.width  != framebuffer->get_size().width ||
+          size.height != framebuffer->get_size().height))
    {
-      if (framebuffer)
-         framebuffer->set_size(disposer, size);
-      current_framebuffer_size = size;
+      framebuffer->set_size(disposer, size);
    }
+   current_framebuffer_size = size;
 
    if (reflection.ubo_stage_mask)
    {

--- a/gfx/drivers_shader/shader_vulkan.cpp
+++ b/gfx/drivers_shader/shader_vulkan.cpp
@@ -32,13 +32,13 @@ using namespace std;
 static void image_layout_transition(
       VkCommandBuffer cmd, VkImage image,
       VkImageLayout old_layout, VkImageLayout new_layout,
-      VkAccessFlags srcAccess, VkAccessFlags dstAccess,
-      VkPipelineStageFlags srcStages, VkPipelineStageFlags dstStages)
+      VkAccessFlags src_access, VkAccessFlags dst_access,
+      VkPipelineStageFlags src_stages, VkPipelineStageFlags dst_stages)
 {
    VkImageMemoryBarrier barrier = { VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER };
 
-   barrier.srcAccessMask               = srcAccess;
-   barrier.dstAccessMask               = dstAccess;
+   barrier.srcAccessMask               = src_access;
+   barrier.dstAccessMask               = dst_access;
    barrier.oldLayout                   = old_layout;
    barrier.newLayout                   = new_layout;
    barrier.srcQueueFamilyIndex         = VK_QUEUE_FAMILY_IGNORED;
@@ -49,8 +49,8 @@ static void image_layout_transition(
    barrier.subresourceRange.layerCount = 1;
 
    VKFUNC(vkCmdPipelineBarrier)(cmd,
-         srcStages,
-         dstStages,
+         src_stages,
+         dst_stages,
          false,
          0, nullptr,
          0, nullptr,

--- a/gfx/drivers_shader/shader_vulkan.cpp
+++ b/gfx/drivers_shader/shader_vulkan.cpp
@@ -561,7 +561,10 @@ bool vulkan_filter_chain::init_history()
    }
 
    if (required_images < 2)
+   {
+      RARCH_LOG("[Vulkan filter chain]: Not using frame history.\n");
       return true;
+   }
 
    // We don't need to store array element #0, since it's aliased with the actual original.
    required_images--;
@@ -586,6 +589,8 @@ bool vulkan_filter_chain::init_history()
 
       common.original_history.push_back(source);
    }
+
+   RARCH_LOG("[Vulkan filter chain]: Using history of %u frames.\n", required_images);
 
    // On first frame, we need to clear the textures to a known state, but we need
    // a command buffer for that, so just defer to first frame.
@@ -617,10 +622,16 @@ bool vulkan_filter_chain::init_feedback()
 
       if (use_feedback && !passes[i]->init_feedback())
          return false;
+
+      if (use_feedback)
+         RARCH_LOG("[Vulkan filter chain]: Using framebuffer feedback for pass #%u.\n", i);
    }
 
    if (!use_feedbacks)
+   {
+      RARCH_LOG("[Vulkan filter chain]: Not using framebuffer feedback.\n");
       return true;
+   }
 
    common.framebuffer_feedback.resize(passes.size() - 1);
    return true;

--- a/gfx/drivers_shader/shader_vulkan.h
+++ b/gfx/drivers_shader/shader_vulkan.h
@@ -37,6 +37,7 @@ enum vulkan_filter_chain_filter
 
 struct vulkan_filter_chain_texture
 {
+   VkImage image;
    VkImageView view;
    VkImageLayout layout;
    unsigned width;
@@ -82,6 +83,7 @@ struct vulkan_filter_chain_create_info
    VkPipelineCache pipeline_cache;
    unsigned num_passes;
 
+   VkFormat original_format;
    struct
    {
       unsigned width, height;

--- a/gfx/drivers_shader/slang_reflection.cpp
+++ b/gfx/drivers_shader/slang_reflection.cpp
@@ -22,14 +22,46 @@
 using namespace std;
 using namespace spir2cross;
 
+static bool slang_texture_semantic_is_array(slang_texture_semantic sem)
+{
+   switch (sem)
+   {
+      case SLANG_TEXTURE_SEMANTIC_ORIGINAL_HISTORY:
+      case SLANG_TEXTURE_SEMANTIC_PASS_OUTPUT:
+      case SLANG_TEXTURE_SEMANTIC_PASS_FEEDBACK:
+         return true;
+
+      default:
+         return false;
+   }
+}
+
+slang_reflection::slang_reflection()
+{
+   for (unsigned i = 0; i < SLANG_NUM_TEXTURE_SEMANTICS; i++)
+   {
+      semantic_textures[i].resize(
+            slang_texture_semantic_is_array(static_cast<slang_texture_semantic>(i))
+            ? 0 : 1);
+   }
+}
+
 static const char *texture_semantic_names[] = {
    "Original",
    "Source",
+   "OriginalHistory",
+   "PassOutput",
+   "PassFeedback",
+   nullptr
 };
 
 static const char *texture_semantic_uniform_names[] = {
    "OriginalSize",
    "SourceSize",
+   "OriginalHistorySize",
+   "PassOutputSize",
+   "PassFeedbackSize",
+   nullptr
 };
 
 static const char *semantic_uniform_names[] = {
@@ -38,28 +70,45 @@ static const char *semantic_uniform_names[] = {
    "FinalViewportSize",
 };
 
-static slang_texture_semantic slang_name_to_texture_semantic(const string &name)
+static slang_texture_semantic slang_name_to_texture_semantic_array(const string &name, const char **names,
+      unsigned *index)
 {
    unsigned i = 0;
-   for (auto n : texture_semantic_names)
+   while (*names)
    {
-      if (name == n)
-         return static_cast<slang_texture_semantic>(i);
+      auto n = *names;
+      auto semantic = static_cast<slang_texture_semantic>(i);
+      if (slang_texture_semantic_is_array(semantic))
+      {
+         size_t baselen = strlen(n);
+         int cmp = strncmp(n, name.c_str(), baselen);
+
+         if (cmp == 0)
+         {
+            *index = strtoul(name.c_str() + baselen, nullptr, 0);
+            return semantic;
+         }
+      }
+      else if (name == n)
+      {
+         *index = 0;
+         return semantic;
+      }
+
       i++;
+      names++;
    }
    return SLANG_INVALID_TEXTURE_SEMANTIC;
 }
 
-static slang_texture_semantic slang_uniform_name_to_texture_semantic(const string &name)
+static slang_texture_semantic slang_name_to_texture_semantic(const string &name, unsigned *index)
 {
-   unsigned i = 0;
-   for (auto n : texture_semantic_uniform_names)
-   {
-      if (name == n)
-         return static_cast<slang_texture_semantic>(i);
-      i++;
-   }
-   return SLANG_INVALID_TEXTURE_SEMANTIC;
+   return slang_name_to_texture_semantic_array(name, texture_semantic_names, index);
+}
+
+static slang_texture_semantic slang_uniform_name_to_texture_semantic(const string &name, unsigned *index)
+{
+   return slang_name_to_texture_semantic_array(name, texture_semantic_uniform_names, index);
 }
 
 static slang_semantic slang_uniform_name_to_semantic(const string &name)
@@ -75,50 +124,64 @@ static slang_semantic slang_uniform_name_to_semantic(const string &name)
    return SLANG_INVALID_SEMANTIC;
 }
 
-static bool set_ubo_texture_offset(slang_reflection *reflection, slang_texture_semantic semantic,
+template <typename T>
+static void resize_minimum(T &vec, unsigned minimum)
+{
+   if (vec.size() < minimum)
+      vec.resize(minimum);
+}
+
+static bool set_ubo_texture_offset(slang_reflection *reflection,
+      slang_texture_semantic semantic, unsigned index,
       size_t offset)
 {
-   if (reflection->semantic_texture_ubo_mask & (1u << semantic))
+   resize_minimum(reflection->semantic_textures[semantic], index + 1);
+   auto &sem = reflection->semantic_textures[semantic][index];
+
+   if (sem.uniform)
    {
-      if (reflection->semantic_textures[semantic].ubo_offset != offset)
+      if (sem.ubo_offset != offset)
       {
-         RARCH_ERR("[slang]: Vertex and fragment have different offsets for same semantic %s (%u vs. %u).\n",
+         RARCH_ERR("[slang]: Vertex and fragment have different offsets for same semantic %s #%u (%u vs. %u).\n",
                texture_semantic_uniform_names[semantic],
-               unsigned(reflection->semantic_textures[semantic].ubo_offset),
+               index,
+               unsigned(sem.ubo_offset),
                unsigned(offset));
          return false;
       }
    }
-   reflection->semantic_texture_ubo_mask |= 1u << semantic;
-   reflection->semantic_textures[semantic].ubo_offset = offset;
+   sem.uniform = true;
+   sem.ubo_offset = offset;
    return true;
 }
 
 static bool set_ubo_offset(slang_reflection *reflection, slang_semantic semantic,
       size_t offset, unsigned num_components)
 {
-   if (reflection->semantic_ubo_mask & (1u << semantic))
+   auto &sem = reflection->semantics[semantic];
+
+   if (sem.uniform)
    {
-      if (reflection->semantics[semantic].ubo_offset != offset)
+      if (sem.ubo_offset != offset)
       {
          RARCH_ERR("[slang]: Vertex and fragment have different offsets for same semantic %s (%u vs. %u).\n",
                semantic_uniform_names[semantic],
-               unsigned(reflection->semantics[semantic].ubo_offset),
+               unsigned(sem.ubo_offset),
                unsigned(offset));
          return false;
       }
 
-      if (reflection->semantics[semantic].num_components != num_components)
+      if (sem.num_components != num_components)
       {
          RARCH_ERR("[slang]: Vertex and fragment have different components for same semantic %s (%u vs. %u).\n",
                semantic_uniform_names[semantic],
-               unsigned(reflection->semantics[semantic].num_components),
+               unsigned(sem.num_components),
                unsigned(num_components));
       }
    }
-   reflection->semantic_ubo_mask |= 1u << semantic;
-   reflection->semantics[semantic].ubo_offset = offset;
-   reflection->semantics[semantic].num_components = num_components;
+   sem.uniform = true;
+   sem.ubo_offset = offset;
+   sem.num_components = num_components;
    return true;
 }
 
@@ -157,8 +220,10 @@ static bool add_active_buffer_ranges(const Compiler &compiler, const Resource &r
    {
       auto &name = compiler.get_member_name(resource.type_id, range.index);
       auto &type = compiler.get_type(compiler.get_type(resource.type_id).member_types[range.index]);
-      slang_semantic sem = slang_uniform_name_to_semantic(name);
-      slang_texture_semantic tex_sem = slang_uniform_name_to_texture_semantic(name);
+
+      unsigned tex_sem_index = 0;
+      auto sem = slang_uniform_name_to_semantic(name);
+      auto tex_sem = slang_uniform_name_to_texture_semantic(name, &tex_sem_index);
 
       if (sem != SLANG_INVALID_SEMANTIC)
       {
@@ -179,7 +244,7 @@ static bool add_active_buffer_ranges(const Compiler &compiler, const Resource &r
             return false;
          }
 
-         if (!set_ubo_texture_offset(reflection, tex_sem, range.offset))
+         if (!set_ubo_texture_offset(reflection, tex_sem, tex_sem_index, range.offset))
             return false;
       }
       else
@@ -346,7 +411,8 @@ static bool slang_reflect(const Compiler &vertex_compiler, const Compiler &fragm
       }
       binding_mask |= 1 << binding;
 
-      slang_texture_semantic index = slang_name_to_texture_semantic(texture.name);
+      unsigned array_index = 0;
+      slang_texture_semantic index = slang_name_to_texture_semantic(texture.name, &array_index);
       
       if (index == SLANG_INVALID_TEXTURE_SEMANTIC)
       {
@@ -354,17 +420,25 @@ static bool slang_reflect(const Compiler &vertex_compiler, const Compiler &fragm
          return false;
       }
 
-      auto &semantic = reflection->semantic_textures[index];
+      resize_minimum(reflection->semantic_textures[index], array_index + 1);
+      auto &semantic = reflection->semantic_textures[index][array_index];
       semantic.binding = binding;
       semantic.stage_mask = SLANG_STAGE_FRAGMENT_MASK;
-      reflection->semantic_texture_mask |= 1 << index;
+      semantic.texture = true;
    }
 
    RARCH_LOG("[slang]: Reflection\n");
    RARCH_LOG("[slang]:   Textures:\n");
    for (unsigned i = 0; i < SLANG_NUM_TEXTURE_SEMANTICS; i++)
-      if (reflection->semantic_texture_mask & (1u << i))
-         RARCH_LOG("[slang]:      %s\n", texture_semantic_names[i]);
+   {
+      unsigned index = 0;
+      for (auto &sem : reflection->semantic_textures[i])
+      {
+         if (sem.texture)
+            RARCH_LOG("[slang]:      %s (#%u)\n", texture_semantic_names[i], index);
+         index++;
+      }
+   }
 
    RARCH_LOG("[slang]:\n");
    RARCH_LOG("[slang]:   Uniforms (Vertex: %s, Fragment: %s):\n",
@@ -372,7 +446,7 @@ static bool slang_reflect(const Compiler &vertex_compiler, const Compiler &fragm
          reflection->ubo_stage_mask & SLANG_STAGE_FRAGMENT_MASK ? "yes": "no");
    for (unsigned i = 0; i < SLANG_NUM_SEMANTICS; i++)
    {
-      if (reflection->semantic_ubo_mask & (1u << i))
+      if (reflection->semantics[i].uniform)
       {
          RARCH_LOG("[slang]:      %s (Offset: %u)\n", semantic_uniform_names[i],
                unsigned(reflection->semantics[i].ubo_offset));
@@ -381,10 +455,16 @@ static bool slang_reflect(const Compiler &vertex_compiler, const Compiler &fragm
 
    for (unsigned i = 0; i < SLANG_NUM_TEXTURE_SEMANTICS; i++)
    {
-      if (reflection->semantic_texture_ubo_mask & (1u << i))
+      unsigned index = 0;
+      for (auto &sem : reflection->semantic_textures[i])
       {
-         RARCH_LOG("[slang]:      %s (Offset: %u)\n", texture_semantic_uniform_names[i],
-               unsigned(reflection->semantic_textures[i].ubo_offset));
+         if (sem.uniform)
+         {
+            RARCH_LOG("[slang]:      %s (#%u) (Offset: %u)\n", texture_semantic_uniform_names[i],
+                  index,
+                  unsigned(sem.ubo_offset));
+         }
+         index++;
       }
    }
 

--- a/gfx/drivers_shader/slang_reflection.hpp
+++ b/gfx/drivers_shader/slang_reflection.hpp
@@ -22,8 +22,30 @@
 // Textures with built-in meaning.
 enum slang_texture_semantic
 {
+   // The input texture to the filter chain.
+   // Canonical name: "Original".
    SLANG_TEXTURE_SEMANTIC_ORIGINAL = 0,
+
+   // The output from pass N - 1 if executing pass N, or ORIGINAL
+   // if pass #0 is executed.
+   // Canonical name: "Source".
    SLANG_TEXTURE_SEMANTIC_SOURCE = 1,
+
+   // The original inputs with a history back in time.
+   // Canonical name: "OriginalHistory#", e.g. "OriginalHistory2" <- Two frames back.
+   // "OriginalHistory0" is an alias for SEMANTIC_ORIGINAL.
+   // Size name: "OriginalHistorySize#".
+   SLANG_TEXTURE_SEMANTIC_ORIGINAL_HISTORY = 2,
+
+   // The output from pass #N, where pass #0 is the first pass.
+   // Canonical name: "PassOutput#", e.g. "PassOutput3".
+   // Size name: "PassOutputSize#".
+   SLANG_TEXTURE_SEMANTIC_PASS_OUTPUT = 3,
+
+   // The output from pass #N, one frame ago where pass #0 is the first pass.
+   // It is not valid to use the pass feedback from a pass which is not offscreen.
+   // Canonical name: "PassFeedback#", e.g. "PassFeedback2".
+   SLANG_TEXTURE_SEMANTIC_PASS_FEEDBACK = 4,
 
    SLANG_NUM_TEXTURE_SEMANTICS,
    SLANG_INVALID_TEXTURE_SEMANTIC = -1
@@ -44,6 +66,8 @@ enum slang_stage
    SLANG_STAGE_VERTEX_MASK = 1 << 0,
    SLANG_STAGE_FRAGMENT_MASK = 1 << 1
 };
+
+// Vulkan minimum limit.
 #define SLANG_NUM_BINDINGS 16
 
 struct slang_texture_semantic_meta
@@ -51,27 +75,28 @@ struct slang_texture_semantic_meta
    size_t ubo_offset = 0;
    unsigned binding = 0;
    uint32_t stage_mask = 0;
+
+   bool texture = false;
+   bool uniform = false;
 };
 
 struct slang_semantic_meta
 {
    size_t ubo_offset = 0;
    unsigned num_components = 0;
+   bool uniform = false;
 };
 
 struct slang_reflection
 {
-   slang_reflection() = default;
+   slang_reflection();
 
    size_t ubo_size = 0;
    unsigned ubo_binding = 0;
    uint32_t ubo_stage_mask = 0;
 
-   slang_texture_semantic_meta semantic_textures[SLANG_NUM_TEXTURE_SEMANTICS];
+   std::vector<slang_texture_semantic_meta> semantic_textures[SLANG_NUM_TEXTURE_SEMANTICS];
    slang_semantic_meta semantics[SLANG_NUM_SEMANTICS];
-   uint32_t semantic_texture_mask = 0;
-   uint32_t semantic_texture_ubo_mask = 0;
-   uint32_t semantic_ubo_mask = 0;
 };
 
 bool slang_reflect_spirv(const std::vector<uint32_t> &vertex,


### PR DESCRIPTION
This implements feedback for any FBO as well as arbitrary history.
With this, we can build highly complex filter chains which surpass the old shader format.

Also fixes a small bug with optimal textures where wrong image layout was used (should only affect AMD)