### PR TITLE
Vulkan: Add proc address query functions to HW interface.

### DIFF
--- a/cores/libretro-test-vulkan/Makefile
+++ b/cores/libretro-test-vulkan/Makefile
@@ -30,12 +30,10 @@ ifeq ($(platform), unix)
    TARGET := $(TARGET_NAME)_libretro.so
    fpic := -fPIC
    SHARED := -shared -Wl,--version-script=link.T -Wl,--no-undefined
-   VULKAN_LIB := -lvulkan
 else
    CC = gcc
    TARGET := $(TARGET_NAME)_libretro.dll
    SHARED := -shared -static-libgcc -static-libstdc++ -s -Wl,--version-script=link.T -Wl,--no-undefined
-   VULKAN_LIB := -lvulkan
    CFLAGS += -I..
 endif
 
@@ -48,12 +46,11 @@ endif
 CFLAGS += -std=gnu99
 OBJECTS := libretro-test.o
 CFLAGS += -Wall -pedantic $(fpic)
-LIBS += $(VULKAN_LIB)
 
 all: $(TARGET)
 
 $(TARGET): $(OBJECTS)
-	$(CC) $(fpic) $(SHARED) $(INCLUDES) -o $@ $(OBJECTS) $(LIBS) -lm $(EXTRA_VULKAN_LIBS)
+	$(CC) $(fpic) $(SHARED) $(INCLUDES) -o $@ $(OBJECTS) $(LIBS) -lm
 
 %.o: %.c
 	$(CC) -I../../libretro-common/include $(CFLAGS) -c -o $@ $<

--- a/gfx/common/vksym.h
+++ b/gfx/common/vksym.h
@@ -29,8 +29,6 @@
 
 #define VKFUNC(sym) (vkcfp.sym)
 
-#define VK_PROTOTYPES
-
 #ifdef HAVE_WAYLAND
 #define VK_USE_PLATFORM_WAYLAND_KHR
 #endif

--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -874,6 +874,9 @@ static void vulkan_init_hw_render(vk_t *vk)
    iface->set_command_buffers = vulkan_set_command_buffers;
    iface->lock_queue          = vulkan_lock_queue;
    iface->unlock_queue        = vulkan_unlock_queue;
+
+   iface->get_device_proc_addr   = VKFUNC(vkGetDeviceProcAddr);
+   iface->get_instance_proc_addr = VKFUNC(vkGetInstanceProcAddr);
 }
 
 static void vulkan_init_readback(vk_t *vk)

--- a/libretro_vulkan.h
+++ b/libretro_vulkan.h
@@ -26,7 +26,7 @@
 #include "libretro.h"
 #include <vulkan/vulkan.h>
 
-#define RETRO_HW_RENDER_INTERFACE_VULKAN_VERSION 1
+#define RETRO_HW_RENDER_INTERFACE_VULKAN_VERSION 2
 
 struct retro_vulkan_image
 {
@@ -82,6 +82,11 @@ struct retro_hw_render_interface_vulkan
    VkPhysicalDevice gpu;
    /* The logical device used. */
    VkDevice device;
+
+   /* Allows a core to fetch all its needed symbols without having to link
+    * against the loader itself. */
+   PFN_vkGetDeviceProcAddr get_device_proc_addr;
+   PFN_vkGetInstanceProcAddr get_instance_proc_addr;
 
    /* The queue the core must use to submit data.
     * This queue and index must remain constant throughout the lifetime


### PR DESCRIPTION
Allows cores to avoid linking directly against any extra library.
Update HW interface version to 2 to signal ABI change.

Note that the interface is still experimental and can change at any time.