### PR TITLE
Add an rdb database compiler script

### DIFF
--- a/libretro-db/.gitignore
+++ b/libretro-db/.gitignore
@@ -1,0 +1,4 @@
+libretro-database
+c_converter
+libretrodb_tool
+rmsgpack_test

--- a/libretro-db/Makefile
+++ b/libretro-db/Makefile
@@ -68,3 +68,9 @@ rmsgpack_test: $(RMSGPACK_OBJS)
 
 clean:
 	rm -rf $(TARGETS) $(C_CONVERTER_OBJS) $(RARCHDB_TOOL_OBJS) $(RMSGPACK_OBJS) $(TESTLIB_OBJS) 
+
+libretro-database:
+	@git clone git@github.com:libretro/libretro-database.git
+
+compile: c_converter libretro-database
+	@./c_converter_compiler.sh

--- a/libretro-db/README.md
+++ b/libretro-db/README.md
@@ -66,3 +66,25 @@ Usecase: Search for all games released on October 1995.
 
 `libretrodb_tool <db file> find "{'releasemonth':10,'releaseyear':1995}"`
 
+## Compiling the Database
+
+The [libretro-database](https://github.com/libretro/libretro-database) is a set of compiled assets that RetroArch uses in order to parse game data correctly. This database needs to be compiled in order for RetroArch to read it quickly..
+
+1. Run the following command:
+  ``` bash
+  make compile
+  ```
+
+2. Fork the [libretro-database](https://github.com/libretro/libretro-database) repository to your own organization
+
+3. Push the new database files to your fork:
+  ``` bash
+  cd libretro-database
+  git remote add myremote git@github.com:USERNAME/libretro-database.git
+  git checkout -b update
+  git add -A
+  git commit -m "Update the rdb files"
+  git push myremote update
+  ```
+
+4. Submit a pull request with the new updated database files

--- a/libretro-db/c_converter_compiler.sh
+++ b/libretro-db/c_converter_compiler.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Iterate through each dat file to compile.
+for file in libretro-database/rdb/*.rdb; do
+   # Find the name of the rdb file.
+   name=$(basename --suffix=.rdb "$file")
+
+   # Tell the user which database file we are acting on.
+   echo -e "\033[1m$name\033[0m"
+
+   # Find all related DAT files, and send them over to c_converter.
+   find -name "${name}.dat" -print0 | sort -z | xargs -0 ./c_converter "${file}"
+done


### PR DESCRIPTION
Compiling all the `.rdb` files in one go was a pain, so I created a script to do it for us. Also added some documentation about it.

```
cd libretro-db
make compile
```

For some of them, I'm gettting `missing match key` errors. Know what's missing for them?

```
Bandai - WonderSwan
Parsing dat file './libretro-database/dat/Bandai - WonderSwan.dat'...
Casio - Loopy
Parsing dat file './libretro-database/dat/Casio - Loopy.dat'...
Casio - PV-1000
Parsing dat file './libretro-database/dat/Casio - PV-1000.dat'...
Coleco - ColecoVision
Parsing dat file './libretro-database/dat/Coleco - ColecoVision.dat'...
DOOM
Parsing dat file './libretro-database/metadat/developer/DOOM.dat'...
missing match key './libretro-database/dat/DOOM.dat' in one of the entries
```

Don't merge this yet, as it still may need some review from @Kivutar, @leiradel and others.