### PR TITLE
Sane default path for thumbnails [on linux].

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -807,6 +807,9 @@ static void config_set_defaults(void)
    if (*g_defaults.dir.wallpapers)
       strlcpy(settings->dynamic_wallpapers_directory,
             g_defaults.dir.wallpapers, sizeof(settings->dynamic_wallpapers_directory));
+   if (*g_defaults.dir.thumbnails)
+      strlcpy(settings->thumbnails_directory,
+            g_defaults.dir.thumbnails, sizeof(settings->thumbnails_directory));
    if (*g_defaults.dir.remap)
       strlcpy(settings->input_remapping_directory,
             g_defaults.dir.remap, sizeof(settings->input_remapping_directory));

--- a/content.c
+++ b/content.c
@@ -734,6 +734,8 @@ static void check_defaults_dirs(void)
       check_defaults_dir_create_dir(g_defaults.dir.cursor);
    if (*g_defaults.dir.cheats)
       check_defaults_dir_create_dir(g_defaults.dir.cheats);
+   if (*g_defaults.dir.thumbnails)
+      check_defaults_dir_create_dir(g_defaults.dir.thumbnails);
 }
 
 void content_push_to_history_playlist(bool do_push,

--- a/defaults.h
+++ b/defaults.h
@@ -50,6 +50,7 @@ struct defaults
       char remap[PATH_MAX_LENGTH];
       char cache[PATH_MAX_LENGTH];
       char wallpapers[PATH_MAX_LENGTH];
+      char thumbnails[PATH_MAX_LENGTH];
       char database[PATH_MAX_LENGTH];
       char cursor[PATH_MAX_LENGTH];
       char cheats[PATH_MAX_LENGTH];

--- a/frontend/drivers/platform_linux.c
+++ b/frontend/drivers/platform_linux.c
@@ -1837,6 +1837,8 @@ static void frontend_linux_get_env(int *argc,
                   app_dir, "remaps", sizeof(g_defaults.dir.remap));
             fill_pathname_join(g_defaults.dir.wallpapers,
                   app_dir, "wallpapers", sizeof(g_defaults.dir.wallpapers));
+            fill_pathname_join(g_defaults.dir.thumbnails,
+                  app_dir, "thumbnails", sizeof(g_defaults.dir.thumbnails));
             if(*downloads_dir && test_permissions(downloads_dir))
             {
                fill_pathname_join(g_defaults.dir.core_assets,
@@ -2008,6 +2010,8 @@ static void frontend_linux_get_env(int *argc,
          "downloads", sizeof(g_defaults.dir.core_assets));
    fill_pathname_join(g_defaults.dir.screenshot, base_path,
          "screenshots", sizeof(g_defaults.dir.screenshot));
+   fill_pathname_join(g_defaults.dir.thumbnails, base_path,
+         "thumbnails", sizeof(g_defaults.dir.thumbnails));
 #endif
 }
 


### PR DESCRIPTION
Related to #2893. Works in a clean config