### PR TITLE
Add uniform lookup for menu shaders.

### DIFF
--- a/gfx/drivers_shader/shader_glsl.c
+++ b/gfx/drivers_shader/shader_glsl.c
@@ -911,6 +911,8 @@ static void *gl_glsl_init(void *data, const char *path)
          VIDEO_SHADER_MENU,
          &glsl->prg[VIDEO_SHADER_MENU],
          &shader_prog_info);
+   gl_glsl_find_uniforms(glsl, 0, glsl->prg[VIDEO_SHADER_MENU].id,
+         &glsl->uniforms[VIDEO_SHADER_MENU]);
 
    shader_prog_info.vertex   = stock_vertex_xmb_simple;
    shader_prog_info.fragment = stock_fragment_xmb_simple;
@@ -920,6 +922,8 @@ static void *gl_glsl_init(void *data, const char *path)
          VIDEO_SHADER_MENU_SEC,
          &glsl->prg[VIDEO_SHADER_MENU_SEC],
          &shader_prog_info);
+   gl_glsl_find_uniforms(glsl, 0, glsl->prg[VIDEO_SHADER_MENU_SEC].id,
+         &glsl->uniforms[VIDEO_SHADER_MENU_SEC]);
 
    gl_glsl_reset_attrib(glsl);
 

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -2391,9 +2391,9 @@ static void xmb_init_ribbon(xmb_handle_t * xmb)
    }
 
    coords.color         = dummy;
-   coords.vertex        = dummy;
+   coords.vertex        = ribbon_verts;
    coords.tex_coord     = dummy;
-   coords.lut_tex_coord = ribbon_verts;
+   coords.lut_tex_coord = dummy;
    coords.vertices      = XMB_RIBBON_VERTICES;
 
    gfx_coord_array_append(ca, &coords, XMB_RIBBON_VERTICES);


### PR DESCRIPTION
This fixes the mix-up of parameter assignments for the XMB ribbon shader
which was caused by all 4 uniform locations set to 0.