### PR TITLE
Change "ALooper_pollAll" call in android_input_poll

### DIFF
--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -1046,7 +1046,7 @@ static void android_input_poll(void *data)
 
    while ((ident =
             ALooper_pollAll((input_driver_ctl(RARCH_INPUT_CTL_KEY_PRESSED, &key))
-               ? -1 : 0,
+               ? -1 : 1,
                NULL, NULL, NULL)) >= 0)
    {
       switch (ident)


### PR DESCRIPTION
The call is changed from a non blocking call into a 1 ms waiting call.

For some reason this allows more input events to be ready in the input queue
for processing making it easier to press multiple gamepad buttons and have it
register within a single frame.

Results have been positive in Golden Axe and Double Dragon. I've not noticed any
performance hits on my units, but please test.
