### PR TITLE
Change ALooper_pollAll in android_input_poll from a non blocking call…

### DIFF
--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -1044,7 +1044,7 @@ static void android_input_poll(void *data)
 
    while ((ident =
             ALooper_pollAll((input_driver_ctl(RARCH_INPUT_CTL_KEY_PRESSED, &key))
-               ? -1 : 0,
+               ? -1 : 1,
                NULL, NULL, NULL)) >= 0)
    {
       switch (ident)


### PR DESCRIPTION
… into a 1 ms

blocking call. For some reason this allows more input events to queue up in the
input queue for processing making it easier to press multiple gamepad buttons and
have it register within a single frame.