### PR TITLE
working basic implementation of async downloader

### DIFF
--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -746,7 +746,7 @@ static void xmb_update_thumbnail_image(void *data)
 
    if (!xmb)
       return;
-   snprintf(buf, sizeof(buf), "http://bot.libretro.com/.test/%s/%s/%s", 
+   snprintf(buf, sizeof(buf), "http://thumbnails.libretro.com/%s/%s/%s", 
       xmb->title_name, xmb_thumbnails_ident(), 
       path_basename(xmb->thumbnail_file_path));
 


### PR DESCRIPTION
only boxarts available to test in the example location are NES

todo:
- refresh automatically after a download
- don't try downloading for base items (xmb items)
- cache the .index instead of trying to download every file regardless of it's prescence
- make the code sane, this is just a PoC

** do not merge **