### PR TITLE
Fix deadlock due to missing slock_unlock in task threaded find function.

### DIFF
--- a/libretro-common/queues/task_queue.c
+++ b/libretro-common/queues/task_queue.c
@@ -270,16 +270,20 @@ static bool retro_task_threaded_find(
       retro_task_finder_t func, void *user_data)
 {
    retro_task_t *task = NULL;
+   bool result = false;
 
    slock_lock(running_lock);
    for (task = tasks_running.front; task; task = task->next)
    {
       if (func(task, user_data))
-         return true;
+      {
+         result = true;
+         break;
+      }
    }
    slock_unlock(running_lock);
 
-   return false;
+   return result;
 }
 
 static void threaded_worker(void *userdata)

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -1393,8 +1393,12 @@ static void cb_generic_download(void *task_data,
 
    if (string_is_equal_noncase(file_ext, "zip"))
    {
-      rarch_task_push_decompress(output_path, dir_path, NULL, NULL, NULL,
-            cb_decompressed, (void*)(uintptr_t)transf->type_hash);
+      if (!rarch_task_push_decompress(output_path, dir_path, NULL, NULL, NULL,
+            cb_decompressed, (void*)(uintptr_t)transf->type_hash))
+      {
+        err = "Decompression failed.";
+        goto finish;
+      }
    }
 #else
    switch (transf->type_hash)


### PR DESCRIPTION
The original deadlock issue can be reproduced easily (on Linux Debian at least) by going to the Online Updater option and downloading multiple files at once and at a fast pace - this would lead to an instant UI freeze on my system, which is solved by this pull request.

The second commit is a fix to something I noticed while debugging some downloading-related issues. When the rarch_task_push_decompress returns an error, it is not propagated to the higher level - this code change simply adds this check in place.