### PR TITLE
Queue and download/extract related fixes

### DIFF
--- a/libretro-common/queues/task_queue.c
+++ b/libretro-common/queues/task_queue.c
@@ -113,6 +113,35 @@ static retro_task_t *task_queue_get(task_queue_t *queue)
    return task;
 }
 
+static void task_queue_remove(task_queue_t *queue, retro_task_t *task)
+{
+   retro_task_t *t;
+
+   /* Remove first element if needed */
+   if (task == queue->front)
+   {
+      queue->front = task->next;
+      task->next = NULL;
+      return;
+   }
+
+   /* Parse queue */
+   t = queue->front;
+   while (t && t->next)
+   {
+      /* Remove task and update queue */
+      if (t->next == task)
+      {
+         t->next = task->next;
+         task->next = NULL;
+         break;
+      }
+
+      /* Update iterator */
+      t = t->next;
+   }
+}
+
 static void retro_task_internal_gather(void)
 {
    retro_task_t *task = NULL;

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -1379,6 +1379,19 @@ static void cb_generic_download(void *task_data,
    fill_pathname_join(output_path, dir_path,
          transf->path, sizeof(output_path));
 
+#ifdef HAVE_ZLIB
+   file_ext = path_get_extension(output_path);
+
+   if (string_is_equal_noncase(file_ext, "zip"))
+   {
+      if (rarch_task_check_decompress(output_path))
+      {
+        err = "Decompression already in progress.";
+        goto finish;
+      }
+   }
+#endif
+
    if (!filestream_write_file(output_path, data->data, data->len))
    {
       err = "Write failed.";
@@ -1386,8 +1399,6 @@ static void cb_generic_download(void *task_data,
    }
 
 #ifdef HAVE_ZLIB
-   file_ext = path_get_extension(output_path);
-
    if (!settings->network.buildbot_auto_extract_archive)
       goto finish;
 

--- a/tasks/task_decompress.c
+++ b/tasks/task_decompress.c
@@ -247,7 +247,6 @@ bool rarch_task_push_decompress(
       retro_task_callback_t cb,
       void *user_data)
 {
-   task_finder_data_t find_data;
    char tmp[PATH_MAX_LENGTH];
    decompress_state_t *s      = NULL;
    retro_task_t *t            = NULL;
@@ -275,10 +274,7 @@ bool rarch_task_push_decompress(
    if (!valid_ext || !valid_ext[0])
       valid_ext   = NULL;
 
-   find_data.func     = rarch_task_decompress_finder;
-   find_data.userdata = (void*)source_file;
-
-   if (task_queue_ctl(TASK_QUEUE_CTL_FIND, &find_data))
+   if (rarch_task_check_decompress(source_file))
    {
       RARCH_LOG("[decompress] File '%s' already being decompressed.\n",
             source_file);

--- a/tasks/task_decompress.c
+++ b/tasks/task_decompress.c
@@ -226,6 +226,18 @@ static bool rarch_task_decompress_finder(
    return string_is_equal(dec->source_file, (const char*)user_data);
 }
 
+bool rarch_task_check_decompress(const char *source_file)
+{
+   task_finder_data_t find_data;
+
+   /* Prepare find parameters */
+   find_data.func = rarch_task_decompress_finder;
+   find_data.userdata = (void *)source_file;
+
+   /* Return whether decompressing is in progress or not */
+   return task_queue_ctl(TASK_QUEUE_CTL_FIND, &find_data);
+}
+
 bool rarch_task_push_decompress(
       const char *source_file,
       const char *target_dir,

--- a/tasks/task_http.c
+++ b/tasks/task_http.c
@@ -45,6 +45,7 @@ typedef struct http_handle
       struct http_connection_t *handle;
       transfer_cb_t  cb;
       char elem1[PATH_MAX_LENGTH];
+      char url[PATH_MAX_LENGTH];
    } connection;
    struct http_t *handle;
    transfer_cb_t  cb;
@@ -192,20 +193,19 @@ task_finished:
 
 static bool rarch_task_http_finder(retro_task_t *task, void *user_data)
 {
-   http_handle_t *http = (http_handle_t*)task->state;
-   const char *handle_url = NULL;
-   if (  !http || !user_data || 
-         !task || task->handler != rarch_task_http_transfer_handler)
-      return false;
-   if (!http->connection.handle)
+   http_handle_t *http;
+
+   if (!task || (task->handler != rarch_task_http_transfer_handler))
       return false;
 
-   handle_url = net_http_connection_url(http->connection.handle);
-
-   if (!handle_url)
+   if (!user_data)
       return false;
 
-   return string_is_equal(handle_url, (const char*)user_data);
+   http = (http_handle_t*)task->state;
+   if (!http)
+      return false;
+
+   return string_is_equal(http->connection.url, (const char*)user_data);
 }
 
 bool rarch_task_push_http_transfer(const char *url, const char *type,
@@ -245,6 +245,8 @@ bool rarch_task_push_http_transfer(const char *url, const char *type,
 
    if (type)
       strlcpy(http->connection.elem1, type, sizeof(http->connection.elem1));
+
+   strlcpy(http->connection.url, url, sizeof(http->connection.url));
 
    http->status            = HTTP_STATUS_CONNECTION_TRANSFER;
    t                       = (retro_task_t*)calloc(1, sizeof(*t));

--- a/tasks/tasks_internal.h
+++ b/tasks/tasks_internal.h
@@ -61,6 +61,8 @@ int detect_ps1_game(const char *track_path, char *game_id);
 
 int detect_psp_game(const char *track_path, char *game_id);
 
+bool rarch_task_check_decompress(const char *source_file);
+
 bool rarch_task_push_decompress(
       const char *source_file,
       const char *target_dir,


### PR DESCRIPTION
The first fix in these commits is in regards to threaded queues. Various parts of the code use a method to find existing running tasks, and when found, decide not to spawn new tasks. The issue is that when a task handler is currently executing, the find method will not be able to find it. This can causes severe crashes as concurrent I/O can occur in some instances. Thanks to this code change, a check was added in order to avoid overwriting a file which was simultaneously being downloaded and extracted.

Another fix in this pull request prevents a file which is currently being downloaded from downloading again. This logic existed in the past, but was relying on a connection handle being valid which in some instances turned out not to be the case. The code was updated to add a "url" structure member and comparing the current downloads using this more reliable member.