### PR TITLE
task http: Add support for retrieving list of active transfers

### DIFF
--- a/tasks/tasks_internal.h
+++ b/tasks/tasks_internal.h
@@ -34,8 +34,19 @@ typedef struct {
     size_t len;
 } http_transfer_data_t;
 
+typedef struct http_transfer_info
+{
+   char url[PATH_MAX_LENGTH];
+   int progress;
+   struct http_transfer_info *next;
+} http_transfer_info_t;
+
 bool rarch_task_push_http_transfer(const char *url, const char *type,
       retro_task_callback_t cb, void *userdata);
+
+http_transfer_info_t *http_task_get_transfer_list();
+
+void http_task_free_transfer_list(http_transfer_info_t *list);
 #endif
 
 bool rarch_task_push_image_load(const char *fullpath, const char *type,


### PR DESCRIPTION
This commit adds support for retrieving the list of current active HTTP transfers, giving the ability to check downloads and their progress. There are two methods involved in this process:
- http_task_get_transfer_list() which retrieves the list of active transfers
- http_task_free_transfer_list() which frees the list priorly retrieved

The list returned is a basic linked list containing elements of type http_transfer_info_t:
typedef struct http_transfer_info
{
   char url[PATH_MAX_LENGTH];
   int progress;
   struct http_transfer_info *next;
} http_transfer_info_t;

Here's a code excerpt demonstrating how to use these functions:
...
http_transfer_info_t *downloads;
http_transfer_info_t *info;

/* Retrieve list of active HTTP transfers */
downloads = http_task_get_transfer_list();

/* Print information */
for (info = downloads; info != NULL; info = info->next)
   printf("Downloading %s... (%d)\n", info->url, info->progress);

/* Free transfer list elements */
http_task_free_transfer_list(downloads);
...

Note 1:
The transfer progress is directly copied from the HTTP task progress, meaning it can be equal to -1 if the task has not been started yet.

Note 2:
These methods retrieve all HTTP requests, and therefore may need to be updated in the future in order to separate downloads from other HTTP requests.