### PR TITLE
http tasks can now be cancelled

### DIFF
--- a/libretro-common/include/queues/task_queue.h
+++ b/libretro-common/include/queues/task_queue.h
@@ -82,8 +82,13 @@ enum task_queue_ctl_state
 
    TASK_QUEUE_CTL_UNSET_THREADED,
 
-   TASK_QUEUE_CTL_IS_THREADED
-};
+   TASK_QUEUE_CTL_IS_THREADED,
+   
+   /**
+    * Signals a task to end without waiting for
+    * it to complete. */
+   TASK_QUEUE_CTL_CANCEL,
+ };
 
 typedef struct retro_task retro_task_t;
 typedef void (*retro_task_callback_t)(void *task_data,
@@ -147,6 +152,8 @@ typedef struct task_finder_data
 void task_queue_push_progress(retro_task_t *task);
 
 bool task_queue_ctl(enum task_queue_ctl_state state, void *data);
+
+void task_queue_cancel_task(void *task);
 
 RETRO_END_DECLS
 

--- a/tasks/task_http.c
+++ b/tasks/task_http.c
@@ -127,6 +127,9 @@ static void rarch_task_http_transfer_handler(retro_task_t *task)
    http_handle_t *http = (http_handle_t*)task->state;
    http_transfer_data_t *data;
 
+   if (task->cancelled)
+      goto task_finished;
+
    switch (http->status)
    {
       case HTTP_STATUS_CONNECTION_TRANSFER_PARSE:
@@ -148,7 +151,7 @@ static void rarch_task_http_transfer_handler(retro_task_t *task)
          break;
    }
 
-   if (task->cancelled || http->error)
+   if (http->error)
       goto task_finished;
 
    return;
@@ -251,7 +254,7 @@ static bool rarch_task_http_retriever(retro_task_t *task, void *user_data)
    return false;
 }
 
-bool rarch_task_push_http_transfer(const char *url, const char *type,
+void *rarch_task_push_http_transfer(const char *url, const char *type,
       retro_task_callback_t cb, void *user_data)
 {
    char tmp[PATH_MAX_LENGTH];
@@ -261,7 +264,7 @@ bool rarch_task_push_http_transfer(const char *url, const char *type,
    http_handle_t *http            = NULL;
 
    if (string_is_empty(url))
-      return false;
+      return NULL;
 
    find_data.func     = rarch_task_http_finder;
    find_data.userdata = (void*)url;
@@ -270,13 +273,13 @@ bool rarch_task_push_http_transfer(const char *url, const char *type,
    if (task_queue_ctl(TASK_QUEUE_CTL_FIND, &find_data))
    {
       RARCH_LOG("[http] '%s'' is already being downloaded.\n", url);
-      return false;
+      return NULL;
    }
 
    conn = net_http_connection_new(url);
 
    if (!conn)
-      return false;
+      return NULL;
 
    http                    = (http_handle_t*)calloc(1, sizeof(*http));
 
@@ -310,7 +313,7 @@ bool rarch_task_push_http_transfer(const char *url, const char *type,
 
    task_queue_ctl(TASK_QUEUE_CTL_PUSH, t);
 
-   return true;
+   return t;
 
 error:
    if (conn)
@@ -320,7 +323,7 @@ error:
    if (http)
       free(http);
 
-   return false;
+   return NULL;
 }
 
 http_transfer_info_t *http_task_get_transfer_list()

--- a/tasks/tasks_internal.h
+++ b/tasks/tasks_internal.h
@@ -41,7 +41,7 @@ typedef struct http_transfer_info
    struct http_transfer_info *next;
 } http_transfer_info_t;
 
-bool rarch_task_push_http_transfer(const char *url, const char *type,
+void *rarch_task_push_http_transfer(const char *url, const char *type,
       retro_task_callback_t cb, void *userdata);
 
 http_transfer_info_t *http_task_get_transfer_list();


### PR DESCRIPTION
Tested on Windows only, but no platform-specific code was changed.