### PR TITLE
Initialize window name at window creation time (fixes #1521).

### DIFF
--- a/gfx/common/x11_common.c
+++ b/gfx/common/x11_common.c
@@ -152,7 +152,7 @@ void x11_suspend_screensaver(Window wnd)
 
    RARCH_LOG("Suspending screensaver (X11).\n");
 
-   snprintf(cmd, sizeof(cmd), "xdg-screensaver suspend %d", (int)wnd);
+   snprintf(cmd, sizeof(cmd), "xdg-screensaver suspend 0x%x", (int)wnd);
 
    ret = system(cmd);
    if (ret == -1)
@@ -551,8 +551,7 @@ void x11_update_window_title(void *data)
    char buf_fps[128]       = {0};
    settings_t *settings    = config_get_ptr();
 
-   if (video_monitor_get_fps(buf, sizeof(buf),
-            buf_fps, sizeof(buf_fps)))
+   if (video_monitor_get_fps(buf, sizeof(buf), NULL, 0))
       XStoreName(g_x11_dpy, g_x11_win, buf);
    if (settings->fps_show)
       runloop_msg_queue_push(buf_fps, 1, 1, false);

--- a/gfx/drivers_context/x_ctx.c
+++ b/gfx/drivers_context/x_ctx.c
@@ -533,6 +533,7 @@ static bool gfx_ctx_x_set_video_mode(void *data,
    }
 
    x11_set_window_attr(g_x11_dpy, g_x11_win);
+   x11_update_window_title(NULL);
 
    if (fullscreen)
       x11_show_mouse(g_x11_dpy, g_x11_win, false);

--- a/gfx/drivers_context/xegl_ctx.c
+++ b/gfx/drivers_context/xegl_ctx.c
@@ -352,6 +352,7 @@ static bool gfx_ctx_xegl_set_video_mode(void *data,
       goto error;
 
    x11_set_window_attr(g_x11_dpy, g_x11_win);
+   x11_update_window_title(NULL);
 
    if (fullscreen)
       x11_show_mouse(g_x11_dpy, g_x11_win, false);


### PR DESCRIPTION
The protocol error reported in #1521 is caused by two different issues.
First xdg-screensaver fails to parse decimal values for the window id
(https://bugzilla.redhat.com/show_bug.cgi?id=1274931). Using the hex
notation fixes this part.

Second, the script reads the WM_NAME property from the window which is
not yet available at this time. Calling x11_update_window_title() early
ensures the property is set when xdg-screensaver is run.