### PR TITLE
Task retrieval mechanism

### DIFF
--- a/libretro-common/include/queues/task_queue.h
+++ b/libretro-common/include/queues/task_queue.h
@@ -56,6 +56,14 @@ enum task_queue_ctl_state
     */
    TASK_QUEUE_CTL_FIND,
 
+   /**
+    * Calls func for every running task when handler
+    * parameter matches task handler, allowing the
+    * list parameter to be filled with user-defined
+    * data.
+    */
+   TASK_QUEUE_CTL_RETRIEVE,
+
    /* Blocks until all tasks have finished.
     * This must only be called from the main thread. */
    TASK_QUEUE_CTL_WAIT,
@@ -98,6 +106,8 @@ typedef void (*retro_task_handler_t)(retro_task_t *task);
 
 typedef bool (*retro_task_finder_t)(retro_task_t *task,
       void *userdata);
+
+typedef bool (*retro_task_retriever_t)(retro_task_t *task, void *data);
 
 typedef struct
 {
@@ -149,9 +159,27 @@ typedef struct task_finder_data
    void *userdata;
 } task_finder_data_t;
 
+typedef struct task_retriever_info
+{
+   struct task_retriever_info *next;
+   void *data;
+} task_retriever_info_t;
+
+typedef struct task_retriever_data
+{
+   retro_task_handler_t handler;
+   size_t element_size;
+   retro_task_retriever_t func;
+   task_retriever_info_t *list;
+} task_retriever_data_t;
+
 void task_queue_push_progress(retro_task_t *task);
 
 bool task_queue_ctl(enum task_queue_ctl_state state, void *data);
+
+void *task_queue_retriever_info_next(task_retriever_info_t **link);
+
+void task_queue_retriever_info_free(task_retriever_info_t *list);
 
 void task_queue_cancel_task(void *task);
 

--- a/tasks/tasks_internal.h
+++ b/tasks/tasks_internal.h
@@ -38,15 +38,12 @@ typedef struct http_transfer_info
 {
    char url[PATH_MAX_LENGTH];
    int progress;
-   struct http_transfer_info *next;
 } http_transfer_info_t;
 
 void *rarch_task_push_http_transfer(const char *url, const char *type,
       retro_task_callback_t cb, void *userdata);
 
-http_transfer_info_t *http_task_get_transfer_list(void);
-
-void http_task_free_transfer_list(http_transfer_info_t *list);
+task_retriever_info_t *http_task_get_transfer_list(void);
 #endif
 
 bool rarch_task_push_image_load(const char *fullpath, const char *type,


### PR DESCRIPTION
The first commit in this PR implement the ability to retrieve running tasks based on a task handler. The user of this function provides a callback function and the size of the element that the callback function is supposed to fill. The next commit simply updates the previous HTTP transfer list retrieval method to use this new mechanism.

Follow these steps to use this mechanism (example given with existing HTTP transfer retrieval):
1) Define the structure of the individual element you want to fill:
```c
typedef struct http_transfer_info
{
   char url[PATH_MAX_LENGTH];
   int progress;
} http_transfer_info_t;
```

2) Create the retriever callback function used to fill this structure (passed in as a void * and cast immediately to the structure defined previously):
```c
static bool rarch_task_http_retriever(retro_task_t *task, void *data)
{
   http_handle_t *http;
   http_transfer_info_t *info = data;

   /* Extract HTTP handle and return already if invalid */
   http = (http_handle_t *)task->state;
   if (!http)
      return false;

   /* Fill HTTP info link */
   strlcpy(info->url, http->connection.url, sizeof(info->url));
   info->progress = task->progress;
   return true;
}
```

3) Fill retriever data and invoke task retrieval method (the list is available within retrieve_data.list after the task_queue_ctl call):
```c
...
   task_retriever_data_t retrieve_data;

   /* Fill retrieve data */
   retrieve_data.handler = rarch_task_http_transfer_handler;
   retrieve_data.element_size = sizeof(http_transfer_info_t);
   retrieve_data.func = rarch_task_http_retriever;

   /* Build list of current HTTP transfers and return it */
   task_queue_ctl(TASK_QUEUE_CTL_RETRIEVE, &retrieve_data);
...
```

4) Parse and free list (the code below was tested right after pushing a new HTTP transfer from menu_cbs_ok.c):
```c
...
   task_retriever_info_t *list = http_task_get_transfer_list();
   task_retriever_info_t *link = list;
   http_transfer_info_t *info;
   while ((info = task_queue_retriever_info_next(&link)))
      printf("Downloading %s... (%d)\n", info->url, info->progress);
   task_queue_retriever_info_free(list);
...
```

The functions allowing to parse and free data are generic (independent of the data type). While it would in theory be possible to retrieve any kind of task from anywhere in the code, the task handlers (used as a filter for this mechanism) is in all instances I've seen declared statically within task-specific files - this is the reason why each specific file would currently still need to add a new high-level retrieval function, such as `http_task_get_transfer_list`.