### PR TITLE
(Lakka) Disable buildbot updaters

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -2394,8 +2394,12 @@ static int menu_displaylist_parse_options(
          menu_hash_to_str(MENU_LABEL_VALUE_UPDATE_LAKKA),
          menu_hash_to_str(MENU_LABEL_UPDATE_LAKKA),
          MENU_SETTING_ACTION, 0, 0);
-#endif
 
+   menu_entries_add(info->list,
+         menu_hash_to_str(MENU_LABEL_VALUE_THUMBNAILS_UPDATER_LIST),
+         menu_hash_to_str(MENU_LABEL_THUMBNAILS_UPDATER_LIST),
+         MENU_SETTING_ACTION, 0, 0);
+#else
    menu_entries_add(info->list,
          menu_hash_to_str(MENU_LABEL_VALUE_CORE_UPDATER_LIST),
          menu_hash_to_str(MENU_LABEL_CORE_UPDATER_LIST),
@@ -2450,6 +2454,8 @@ static int menu_displaylist_parse_options(
          menu_hash_to_str(MENU_LABEL_VALUE_UPDATE_GLSL_SHADERS),
          menu_hash_to_str(MENU_LABEL_UPDATE_GLSL_SHADERS),
          MENU_SETTING_ACTION, 0, 0);
+#endif
+
 #endif
 
 #else


### PR DESCRIPTION
Keeping two concurrent update systems causes a lot of bugs. Especially in our case where the buildbot stuff overrides the system stuff. Users don't get how to use both updaters properly. They end up using outdated cores or joyconfigs, or even assets. Using the Lakka updater in our case is a better solution, because it ensures version compatibility between all the components. I will do an additional effort to keep all the libretro packages up to date in Lakka.