### PR TITLE
Suppress screensaver only if requested by user settings.

### DIFF
--- a/gfx/common/x11_common.c
+++ b/gfx/common/x11_common.c
@@ -141,11 +141,14 @@ void x11_set_window_attr(Display *dpy, Window win)
    x11_set_window_class(dpy, win);
 }
 
-void x11_suspend_screensaver(Window wnd)
+void x11_suspend_screensaver(Window wnd, bool enable)
 {
    int ret;
    char cmd[64] = {0};
    static bool screensaver_na = false;
+
+   if (!enable)
+       return;
 
    if (screensaver_na)
       return;

--- a/gfx/common/x11_common.h
+++ b/gfx/common/x11_common.h
@@ -43,7 +43,7 @@ extern unsigned g_x11_screen;
 void x11_save_last_used_monitor(Window win);
 void x11_show_mouse(Display *dpy, Window win, bool state);
 void x11_windowed_fullscreen(Display *dpy, Window win);
-void x11_suspend_screensaver(Window win);
+void x11_suspend_screensaver(Window win, bool enable);
 bool x11_enter_fullscreen(Display *dpy, unsigned width,
       unsigned height, XF86VidModeModeInfo *desktop_mode);
 

--- a/gfx/drivers/sdl2_gfx.c
+++ b/gfx/drivers/sdl2_gfx.c
@@ -569,7 +569,7 @@ static bool sdl2_gfx_suppress_screensaver(void *data, bool enable)
    if (video_driver_display_type_get() == RARCH_DISPLAY_X11)
    {
 #ifdef HAVE_X11
-      x11_suspend_screensaver(video_driver_window_get());
+      x11_suspend_screensaver(video_driver_window_get(), enable);
 #endif
       return true;
    }

--- a/gfx/drivers/sdl_gfx.c
+++ b/gfx/drivers/sdl_gfx.c
@@ -401,7 +401,7 @@ static bool sdl_gfx_suppress_screensaver(void *data, bool enable)
 #ifdef HAVE_X11
    if (video_driver_display_type_get() == RARCH_DISPLAY_X11)
    {
-      x11_suspend_screensaver(video_driver_window_get());
+      x11_suspend_screensaver(video_driver_window_get(), enable);
       return true;
    }
 #endif

--- a/gfx/drivers/xvideo.c
+++ b/gfx/drivers/xvideo.c
@@ -806,10 +806,12 @@ static bool xv_frame(void *data, const void *frame, unsigned width,
 
 static bool xv_suppress_screensaver(void *data, bool enable)
 {
+   (void)data;
+
    if (video_driver_display_type_get() != RARCH_DISPLAY_X11)
       return false;
 
-   x11_suspend_screensaver(video_driver_window_get());
+   x11_suspend_screensaver(video_driver_window_get(), enable);
    return true;
 }
 

--- a/gfx/drivers_context/x_ctx.c
+++ b/gfx/drivers_context/x_ctx.c
@@ -765,10 +765,12 @@ static void gfx_ctx_x_input_driver(void *data,
 
 static bool gfx_ctx_x_suppress_screensaver(void *data, bool enable)
 {
+   (void)data;
+
    if (video_driver_display_type_get() != RARCH_DISPLAY_X11)
       return false;
 
-   x11_suspend_screensaver(video_driver_window_get());
+   x11_suspend_screensaver(video_driver_window_get(), enable);
 
    return true;
 }

--- a/gfx/drivers_context/xegl_ctx.c
+++ b/gfx/drivers_context/xegl_ctx.c
@@ -444,12 +444,11 @@ static bool gfx_ctx_xegl_has_focus(void *data)
 static bool gfx_ctx_xegl_suppress_screensaver(void *data, bool enable)
 {
    (void)data;
-   (void)enable;
 
    if (video_driver_display_type_get() != RARCH_DISPLAY_X11)
       return false;
 
-   x11_suspend_screensaver(video_driver_window_get());
+   x11_suspend_screensaver(video_driver_window_get(), enable);
 
    return true;
 }


### PR DESCRIPTION
The X11 handler `x11_suspend_screensaver()` now respects the `enable` settings value.