### PR TITLE
rbmp encode: Fix memory leak when saving image

### DIFF
--- a/libretro-common/formats/bmp/rbmp_encode.c
+++ b/libretro-common/formats/bmp/rbmp_encode.c
@@ -197,6 +197,8 @@ static void dump_content(RFILE *file, const void *frame,
       }
    }
 
+   /* Free allocated line buffer */
+   free(line);
 }
 
 bool rbmp_save_image(const char *filename, const void *frame,


### PR DESCRIPTION
This is a trivial commit fixing a memory leak occurring when calling rbmp_save_image with certain parameters.