### PR TITLE
implemented the RETRO_ENVIRONMENT_SET_MEMORY_MAPS callback

### DIFF
--- a/dynamic.c
+++ b/dynamic.c
@@ -1213,6 +1213,42 @@ bool rarch_environment_cb(unsigned cmd, void *data)
          system->ports.size = i;
          break;
       }
+      
+      case RETRO_ENVIRONMENT_SET_MEMORY_MAPS:
+      {
+         unsigned i;
+         const struct retro_memory_map *mmaps =
+            (const struct retro_memory_map*)data;
+         
+         RARCH_LOG("Environ SET_MEMORY_MAPS.\n");
+         RARCH_LOG("   flags    ptr              offset   start    select   disconn  len      addrspace\n");
+         
+         for (i = 0; i < mmaps->num_descriptors; i++)
+         {
+            const struct retro_memory_descriptor *desc =
+               &mmaps->descriptors[i];
+            
+            RARCH_LOG("Memory map: %u\n", i + 1);
+            RARCH_LOG("   %08X %p %08X %08X %08X %08X %08X %s\n",
+               desc->flags, desc->ptr, desc->offset, desc->start,
+               desc->select, desc->disconnect, desc->len,
+               desc->addrspace ? desc->addrspace : "");
+         }
+         
+         free((void*)system->mmaps.descriptors);
+         system->mmaps.num_descriptors = 0;
+         
+         system->mmaps.descriptors = (struct retro_memory_descriptor*)
+            calloc(mmaps->num_descriptors, sizeof(*system->mmaps.descriptors));
+         
+         if (!system->mmaps.descriptors)
+            return false;
+         
+         memcpy((void*)system->mmaps.descriptors, mmaps->descriptors,
+            mmaps->num_descriptors * sizeof(*system->mmaps.descriptors));
+         system->mmaps.num_descriptors = mmaps->num_descriptors;
+         break;
+      }
 
       case RETRO_ENVIRONMENT_SET_GEOMETRY:
       {

--- a/dynamic.c
+++ b/dynamic.c
@@ -624,22 +624,22 @@ static void rarch_log_libretro(enum retro_log_level level,
 
 static size_t add_bits_down(size_t n)
 {
-	 n |= n >>  1;
-	 n |= n >>  2;
-	 n |= n >>  4;
-	 n |= n >>  8;
-	 n |= n >> 16;
+   n |= n >>  1;
+   n |= n >>  2;
+   n |= n >>  4;
+   n |= n >>  8;
+   n |= n >> 16;
    
    /* double shift to avoid warnings on 32bit (it's dead code, but compilers suck) */
-	 if (sizeof(size_t) > 4)
+   if (sizeof(size_t) > 4)
       n |= n >> 16 >> 16;
    
-	 return n;
+   return n;
 }
 
 static size_t inflate(size_t addr, size_t mask)
 {
- 	 while (mask)
+    while (mask)
    {
       size_t tmp = (mask - 1) & ~mask;
       /* to put in an 1 bit instead, OR in tmp+1 */

--- a/dynamic.c
+++ b/dynamic.c
@@ -1221,16 +1221,45 @@ bool rarch_environment_cb(unsigned cmd, void *data)
             (const struct retro_memory_map*)data;
          
          RARCH_LOG("Environ SET_MEMORY_MAPS.\n");
-         RARCH_LOG("   flags    ptr              offset   start    select   disconn  len      addrspace\n");
+         
+         if (sizeof(void *) == 8)
+            RARCH_LOG("    flags  ptr              offset   start    select   disconn  len      addrspace\n");
+         else
+            RARCH_LOG("    flags  ptr          offset   start    select   disconn  len      addrspace\n");
          
          for (i = 0; i < mmaps->num_descriptors; i++)
          {
             const struct retro_memory_descriptor *desc =
                &mmaps->descriptors[i];
+            char flags[7];
+            
+            flags[0] = 'M';
+            if ((desc->flags & RETRO_MEMDESC_MINSIZE_8) == RETRO_MEMDESC_MINSIZE_8)
+               flags[1] = '8';
+            else if ((desc->flags & RETRO_MEMDESC_MINSIZE_4) == RETRO_MEMDESC_MINSIZE_4)
+               flags[1] = '4';
+            else if ((desc->flags & RETRO_MEMDESC_MINSIZE_2) == RETRO_MEMDESC_MINSIZE_2)
+               flags[1] = '2';
+            else
+               flags[1] = '1';
+            
+            flags[2] = 'A';
+            if ((desc->flags & RETRO_MEMDESC_ALIGN_8) == RETRO_MEMDESC_ALIGN_8)
+               flags[3] = '8';
+            else if ((desc->flags & RETRO_MEMDESC_ALIGN_4) == RETRO_MEMDESC_ALIGN_4)
+               flags[3] = '4';
+            else if ((desc->flags & RETRO_MEMDESC_ALIGN_2) == RETRO_MEMDESC_ALIGN_2)
+               flags[3] = '2';
+            else
+               flags[3] = '1';
+            
+            flags[4] = (desc->flags & RETRO_MEMDESC_BIGENDIAN) ? 'B' : 'b';
+            flags[5] = (desc->flags & RETRO_MEMDESC_CONST) ? 'C' : 'c';
+            flags[6] = 0;
             
             RARCH_LOG("Memory map: %u\n", i + 1);
-            RARCH_LOG("   %08X %p %08X %08X %08X %08X %08X %s\n",
-               desc->flags, desc->ptr, desc->offset, desc->start,
+            RARCH_LOG("    %s %p %08X %08X %08X %08X %08X %s\n",
+               flags, desc->ptr, desc->offset, desc->start,
                desc->select, desc->disconnect, desc->len,
                desc->addrspace ? desc->addrspace : "");
          }

--- a/runloop.c
+++ b/runloop.c
@@ -717,13 +717,20 @@ bool runloop_ctl(enum runloop_ctl_state state, void *data)
          if (runloop_system.subsystem.data)
             free(runloop_system.subsystem.data);
          runloop_system.subsystem.data = NULL;
+         runloop_system.subsystem.size = 0;
+         
          if (runloop_system.ports.data)
             free(runloop_system.ports.data);
-         runloop_system.subsystem.size = 0;
-         runloop_system.ports.data     = NULL;
-         runloop_system.ports.size     = 0;
-         runloop_key_event             = NULL;
-         runloop_frontend_key_event    = NULL;
+         runloop_system.ports.data = NULL;
+         runloop_system.ports.size = 0;
+         
+         if (runloop_system.mmaps.descriptors)
+            free((void *)runloop_system.mmaps.descriptors);
+         runloop_system.mmaps.descriptors     = NULL;
+         runloop_system.mmaps.num_descriptors = 0;
+         
+         runloop_key_event          = NULL;
+         runloop_frontend_key_event = NULL;
 
          audio_driver_unset_callback();
          memset(&runloop_system, 0, sizeof(rarch_system_info_t));

--- a/system.h
+++ b/system.h
@@ -54,6 +54,8 @@ typedef struct rarch_system_info
       struct retro_controller_info *data;
       unsigned size;
    } ports;
+   
+   struct retro_memory_map mmaps;
 } rarch_system_info_t;
 
 #ifdef __cplusplus


### PR DESCRIPTION
And I've found where the data must be freed in `runloop.c`.