### PR TITLE
Set base man directory in MAN_DIR and move manpages to man6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,14 +163,14 @@ install: $(TARGET)
 	mkdir -p $(DESTDIR)$(PREFIX)/bin 2>/dev/null || /bin/true
 	mkdir -p $(DESTDIR)$(GLOBAL_CONFIG_DIR) 2>/dev/null || /bin/true
 	mkdir -p $(DESTDIR)$(PREFIX)/share/applications 2>/dev/null || /bin/true
-	mkdir -p $(DESTDIR)$(MAN_DIR) 2>/dev/null || /bin/true
+	mkdir -p $(DESTDIR)$(MAN_DIR)/man1 2>/dev/null || /bin/true
 	mkdir -p $(DESTDIR)$(PREFIX)/share/pixmaps 2>/dev/null || /bin/true
 	install -m755 $(TARGET) $(DESTDIR)$(PREFIX)/bin 
 	install -m755 tools/cg2glsl.py $(DESTDIR)$(PREFIX)/bin/retroarch-cg2glsl
 	install -m644 retroarch.cfg $(DESTDIR)$(GLOBAL_CONFIG_DIR)/retroarch.cfg
 	install -m644 retroarch.desktop $(DESTDIR)$(PREFIX)/share/applications
-	install -m644 docs/retroarch.1 $(DESTDIR)$(MAN_DIR)
-	install -m644 docs/retroarch-cg2glsl.1 $(DESTDIR)$(MAN_DIR)
+	install -m644 docs/retroarch.1 $(DESTDIR)$(MAN_DIR)/man1
+	install -m644 docs/retroarch-cg2glsl.1 $(DESTDIR)$(MAN_DIR)/man1
 	install -m644 media/retroarch.svg $(DESTDIR)$(PREFIX)/share/pixmaps
 
 uninstall:
@@ -178,8 +178,8 @@ uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/retroarch-cg2glsl
 	rm -f $(DESTDIR)$(GLOBAL_CONFIG_DIR)/retroarch.cfg
 	rm -f $(DESTDIR)$(PREFIX)/share/applications/retroarch.desktop
-	rm -f $(DESTDIR)$(MAN_DIR)/retroarch.1
-	rm -f $(DESTDIR)$(MAN_DIR)/retroarch-cg2glsl.1
+	rm -f $(DESTDIR)$(MAN_DIR)/man1/retroarch.1
+	rm -f $(DESTDIR)$(MAN_DIR)/man1/retroarch-cg2glsl.1
 	rm -f $(DESTDIR)$(PREFIX)/share/pixmaps/retroarch.svg
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -163,14 +163,14 @@ install: $(TARGET)
 	mkdir -p $(DESTDIR)$(PREFIX)/bin 2>/dev/null || /bin/true
 	mkdir -p $(DESTDIR)$(GLOBAL_CONFIG_DIR) 2>/dev/null || /bin/true
 	mkdir -p $(DESTDIR)$(PREFIX)/share/applications 2>/dev/null || /bin/true
-	mkdir -p $(DESTDIR)$(MAN_DIR)/man1 2>/dev/null || /bin/true
+	mkdir -p $(DESTDIR)$(MAN_DIR)/man6 2>/dev/null || /bin/true
 	mkdir -p $(DESTDIR)$(PREFIX)/share/pixmaps 2>/dev/null || /bin/true
 	install -m755 $(TARGET) $(DESTDIR)$(PREFIX)/bin 
 	install -m755 tools/cg2glsl.py $(DESTDIR)$(PREFIX)/bin/retroarch-cg2glsl
 	install -m644 retroarch.cfg $(DESTDIR)$(GLOBAL_CONFIG_DIR)/retroarch.cfg
 	install -m644 retroarch.desktop $(DESTDIR)$(PREFIX)/share/applications
-	install -m644 docs/retroarch.1 $(DESTDIR)$(MAN_DIR)/man1
-	install -m644 docs/retroarch-cg2glsl.1 $(DESTDIR)$(MAN_DIR)/man1
+	install -m644 docs/retroarch.6 $(DESTDIR)$(MAN_DIR)/man6
+	install -m644 docs/retroarch-cg2glsl.6 $(DESTDIR)$(MAN_DIR)/man6
 	install -m644 media/retroarch.svg $(DESTDIR)$(PREFIX)/share/pixmaps
 
 uninstall:
@@ -178,8 +178,8 @@ uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/retroarch-cg2glsl
 	rm -f $(DESTDIR)$(GLOBAL_CONFIG_DIR)/retroarch.cfg
 	rm -f $(DESTDIR)$(PREFIX)/share/applications/retroarch.desktop
-	rm -f $(DESTDIR)$(MAN_DIR)/man1/retroarch.1
-	rm -f $(DESTDIR)$(MAN_DIR)/man1/retroarch-cg2glsl.1
+	rm -f $(DESTDIR)$(MAN_DIR)/man6/retroarch.6
+	rm -f $(DESTDIR)$(MAN_DIR)/man6/retroarch-cg2glsl.6
 	rm -f $(DESTDIR)$(PREFIX)/share/pixmaps/retroarch.svg
 
 clean:

--- a/docs/retroarch-cg2glsl.6
+++ b/docs/retroarch-cg2glsl.6
@@ -1,6 +1,6 @@
-.\" retroarch-cg2glsl.1
+.\" retroarch-cg2glsl.6
 
-.TH "RETROARCH-CG2GLSL" "1" "July 10, 2014" "RETROARCH-CG2GLSL" "System Manager's Manual: retroarch-cg2glsl"
+.TH "RETROARCH-CG2GLSL" "6" "July 10, 2014" "RETROARCH-CG2GLSL" "System Manager's Manual: retroarch-cg2glsl"
 
 .SH "NAME"
 

--- a/docs/retroarch-joyconfig.6
+++ b/docs/retroarch-joyconfig.6
@@ -1,6 +1,6 @@
-.\" retroarch-joyconfig.1:
+.\" retroarch-joyconfig.6:
 
-.TH  "RETROARCH-JOYCONFIG" "1" "October 1, 2011" "RETROARCH-JOYCONFIG" "System Manager's Manual: retroarch-joyconfig"
+.TH  "RETROARCH-JOYCONFIG" "6" "October 1, 2011" "RETROARCH-JOYCONFIG" "System Manager's Manual: retroarch-joyconfig"
 
 .SH NAME
 
@@ -78,6 +78,6 @@ Adds a timeout of N seconds to each bind. If timed out, the bind will not be use
 Prints help message.
 
 .SH "SEE ALSO"
-\fBretroarch\fR(1)
+\fBretroarch\fR(6)
 
 .\"

--- a/docs/retroarch.6
+++ b/docs/retroarch.6
@@ -1,6 +1,6 @@
-.\" retroarch.1:
+.\" retroarch.6:
 
-.TH  "RETROARCH" "1" "November 1, 2011" "RETROARCH" "System Manager's Manual: retroarch"
+.TH  "RETROARCH" "6" "November 1, 2011" "RETROARCH" "System Manager's Manual: retroarch"
 
 .SH NAME
 
@@ -235,4 +235,4 @@ Disables all kinds of content patching.
 Detach from the current console. This is currently only relevant for Microsoft Windows.
 
 .SH "SEE ALSO"
-\fBretroarch-joyconfig\fR(1)
+\fBretroarch-joyconfig\fR(6)

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -133,7 +133,7 @@ fi
 if [ "$MAN_DIR" ]; then
    add_define_make MAN_DIR "$MAN_DIR"
 else
-   add_define_make MAN_DIR "${PREFIX}/share/man/man1"
+   add_define_make MAN_DIR "${PREFIX}/share/man"
 fi
 
 if [ "$OS" = 'Win32' ]; then


### PR DESCRIPTION
This is split into two commits, the first sets the base man directory to `man1` since should not have to be set with `--with-man_dir` as the same standards should apply across different unix systems. The only thing that does differ in some operating systems is `usr/share/man`, for examples its `usr/man` in Slackware.

The second commit moves the manpages from `man1` to `man6` and updates the specific man pages accordingly to follow the man section standards according to `man man`.
```
MANUAL SECTIONS
       The standard sections of the manual include:

       1      User Commands
       2      System Calls
       3      C Library Functions
       4      Devices and Special Files
       5      File Formats and Conventions
       6      Games et. Al.
       7      Miscellanea
       8      System Administration tools and Deamons

       Distributions customize the manual section to their specifics,  which  often
       include additional sections.
```