### PR TITLE
Memory leak-related fixes

### DIFF
--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -529,8 +529,6 @@ bool menu_driver_ctl(enum rarch_menu_ctl_state state, void *data)
          menu_driver_data_own = true;
          break;
       case RARCH_MENU_CTL_UNSET_OWN_DRIVER:
-         if (!content_is_inited())
-            return false;
          menu_driver_data_own = false;
          break;
       case RARCH_MENU_CTL_SET_TEXTURE:

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -3455,7 +3455,7 @@ static bool setting_append_list_input_player_options(
                &settings->input.binds[user][i],
                user + 1,
                user,
-               strdup(name), /* TODO: Find a way to fix these memleaks. */
+               strdup(name),
                strdup(label),
                &defaults[i],
                &group_info,
@@ -6588,6 +6588,7 @@ static bool setting_append_list(
                      general_write_handler,
                      general_read_handler);
                settings_data_list_current_add_flags(list, list_info, SD_FLAG_ADVANCED);
+               settings_data_list_current_add_free_flags(list, list_info, SD_FREE_FLAG_NAME | SD_FREE_FLAG_SHORT);
             }
 
             CONFIG_BOOL(

--- a/menu/menu_setting.h
+++ b/menu/menu_setting.h
@@ -62,6 +62,13 @@ enum setting_flags
    SD_FLAG_ADVANCED       = (1 << 9)
 };
 
+enum settings_free_flags
+{
+   SD_FREE_FLAG_VALUES    = (1 << 0),
+   SD_FREE_FLAG_NAME      = (1 << 1),
+   SD_FREE_FLAG_SHORT     = (1 << 2)
+};
+
 enum menu_setting_ctl_state
 {
    MENU_SETTING_CTL_NONE = 0,
@@ -366,6 +373,11 @@ void menu_settings_list_current_add_range(
       bool enforce_minrange_enable, bool enforce_maxrange_enable);
 
 void settings_data_list_current_add_flags(
+      rarch_setting_t **list,
+      rarch_setting_info_t *list_info,
+      unsigned values);
+
+void settings_data_list_current_add_free_flags(
       rarch_setting_t **list,
       rarch_setting_info_t *list_info,
       unsigned values);


### PR DESCRIPTION
The first commit fixes a memory leak occurring on exit. The menu driver in this case refused to deinitialize, which was due to an ownership flag not properly reset when RetroArch was requested to quit. This flag remained true due to "content not being loaded yet". Even though I don't fully grasp the logic behind why the two were related, I don't believe this check belongs in the menu driver so this PR just removes this check.

The remaining 3 commits introduce the concept of free flags for settings data. When creating a new menu setting, some data is expected to be freed later on, and some special cases were handled for ST_BIND and ST_STRING_OPTIONS, leaving an ST_BOOL setting with a leak. This PR just removes this handling and relies on "free flags" to be set upon setting creation, which are later parsed and automatically free tagged data. The CONFIG_BIND and CONFIG_STRING_OPTIONS functions automatically tag the data to be freed, so there is no extra code required when using these helper functions.