### PR TITLE
Memory leak fix

### DIFF
--- a/libretro-common/include/queues/task_queue.h
+++ b/libretro-common/include/queues/task_queue.h
@@ -123,6 +123,10 @@ struct retro_task
    /* always called from the main loop */
    retro_task_callback_t callback;
 
+   /* task cleanup handler to free allocated resources, will
+    * be called immediately after running the main callback */
+   retro_task_handler_t cleanup;
+
    /* set to true by the handler to signal 
     * the task has finished executing. */
    bool finished;

--- a/libretro-common/queues/task_queue.c
+++ b/libretro-common/queues/task_queue.c
@@ -126,6 +126,9 @@ static void retro_task_internal_gather(void)
       if (task->callback)
          task->callback(task->task_data, task->user_data, task->error);
 
+      if (task->cleanup)
+          task->cleanup(task);
+
       if (task->error)
          free(task->error);
 

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -728,48 +728,6 @@ static void xmb_update_thumbnail_path(void *data, unsigned i)
 #endif
 }
 
-static void xmb_context_bg_destroy(xmb_handle_t *xmb)
-{
-    if (!xmb)
-        return;
-    video_driver_texture_unload(&xmb->textures.bg);
-    video_driver_texture_unload(&menu_display_white_texture);
-}
-
-static bool xmb_load_image(void *userdata, void *data, enum menu_image_type type)
-{
-    xmb_handle_t *xmb = (xmb_handle_t*)userdata;
-    
-    if (!xmb || !data)
-        return false;
-    
-    switch (type)
-    {
-        case MENU_IMAGE_NONE:
-            break;
-        case MENU_IMAGE_WALLPAPER:
-            xmb_context_bg_destroy(xmb);
-            video_driver_texture_unload(&xmb->textures.bg);
-            video_driver_texture_load(data,
-                                      TEXTURE_FILTER_MIPMAP_LINEAR,
-                                      &xmb->textures.bg);
-            menu_display_allocate_white_texture();
-            break;
-        case MENU_IMAGE_THUMBNAIL:
-        {
-            struct texture_image *img = (struct texture_image*)data;
-            xmb->thumbnail_height = xmb->thumbnail_width
-            * (float)img->height / (float)img->width;
-            video_driver_texture_unload(&xmb->thumbnail);
-            video_driver_texture_load(data,
-                                      TEXTURE_FILTER_MIPMAP_LINEAR, &xmb->thumbnail);
-        }
-            break;
-    }
-    
-    return true;
-}
-
 static void xmb_update_thumbnail_image(void *data)
 {
    xmb_handle_t *xmb = (xmb_handle_t*)data;
@@ -777,12 +735,8 @@ static void xmb_update_thumbnail_image(void *data)
       return;
 
    if (path_file_exists(xmb->thumbnail_file_path))
-   {
-      struct texture_image ti = {0};
-      image_texture_load(&ti, xmb->thumbnail_file_path);
-      xmb_load_image(xmb, &ti, MENU_IMAGE_THUMBNAIL);
-      image_texture_free(&ti);
-   }
+      rarch_task_push_image_load(xmb->thumbnail_file_path, "cb_menu_thumbnail",
+            menu_display_handle_thumbnail_upload, NULL);
    else if (xmb->depth == 1)
       xmb->thumbnail = 0;
 }
@@ -2660,6 +2614,48 @@ static void xmb_free(void *data)
 
    font_driver_bind_block(NULL, NULL);
 
+}
+
+static void xmb_context_bg_destroy(xmb_handle_t *xmb)
+{
+   if (!xmb)
+      return;
+   video_driver_texture_unload(&xmb->textures.bg);
+   video_driver_texture_unload(&menu_display_white_texture);
+}
+
+static bool xmb_load_image(void *userdata, void *data, enum menu_image_type type)
+{
+   xmb_handle_t *xmb = (xmb_handle_t*)userdata;
+
+   if (!xmb || !data)
+      return false;
+
+   switch (type)
+   {
+      case MENU_IMAGE_NONE:
+         break;
+      case MENU_IMAGE_WALLPAPER:
+         xmb_context_bg_destroy(xmb);
+         video_driver_texture_unload(&xmb->textures.bg);
+         video_driver_texture_load(data,
+               TEXTURE_FILTER_MIPMAP_LINEAR,
+               &xmb->textures.bg);
+         menu_display_allocate_white_texture();
+         break;
+      case MENU_IMAGE_THUMBNAIL:
+         {
+            struct texture_image *img = (struct texture_image*)data;
+            xmb->thumbnail_height = xmb->thumbnail_width
+               * (float)img->height / (float)img->width;
+            video_driver_texture_unload(&xmb->thumbnail);
+            video_driver_texture_load(data,
+                  TEXTURE_FILTER_MIPMAP_LINEAR, &xmb->thumbnail);
+         }
+         break;
+   }
+
+   return true;
 }
 
 static const char *xmb_texture_path(unsigned id)

--- a/tasks/task_file_transfer.c
+++ b/tasks/task_file_transfer.c
@@ -90,27 +90,17 @@ void rarch_task_file_load_handler(retro_task_t *task)
       case IMAGE_TYPE_TGA:
       case IMAGE_TYPE_BMP:
          if (!rarch_task_image_load_handler(task))
-            goto task_finished;
+            task->finished = true;
          break;
       case 0:
          if (nbio->is_finished)
-            goto task_finished;
+            task->finished = true;
          break;
    }
 
    if (task->cancelled)
    {
       task->error = strdup("Task canceled.");
-      goto task_finished;
+      task->finished = true;
    }
-
-   return;
-
-task_finished:
-   task->finished = true;
-
-   nbio_free(nbio->handle);
-   nbio->handle      = NULL;
-   nbio->is_finished = false;
-   free(nbio);
 }

--- a/tasks/task_image.c
+++ b/tasks/task_image.c
@@ -383,6 +383,7 @@ bool rarch_task_push_image_load(const char *fullpath,
 
    t->state     = nbio;
    t->handler   = rarch_task_file_load_handler;
+   t->cleanup   = rarch_task_image_load_free;
    t->callback  = cb;
    t->user_data = user_data;
 


### PR DESCRIPTION
* Enable loading thumbnails via the task system again
* Add cleanup handler to the task so the image-task can free allocated resources
* Change allocation order to retain the pointers for the cleanup call