### PR TITLE
retroarch: Fix savefile directory memory leak

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -405,19 +405,9 @@ static void retroarch_set_special_paths(char **argv, unsigned num_content)
 
 const char *retroarch_get_current_savefile_dir(void)
 {
-   char* ret        = NULL;
-   
-   if (!string_is_empty(current_savefile_dir))
-      ret = current_savefile_dir;
-   else
-   {
-      global_t *global = global_get_ptr();
-      ret = strdup(global->name.base);
-      path_basedir(ret);
-   }
+   char *ret = current_savefile_dir;
 
-   RARCH_LOG("Environ SAVE_DIRECTORY: \"%s\".\n",
-         ret);
+   RARCH_LOG("Environ SAVE_DIRECTORY: \"%s\".\n", ret);
 
    return ret;
 }
@@ -515,6 +505,15 @@ static void retroarch_set_paths_redirect(const char *path)
             }
          }
       }
+   }
+
+   /* Set savefile directory if empty based on content directory */
+   if (string_is_empty(current_savefile_dir))
+   {
+      global_t *global = global_get_ptr();
+      strlcpy(current_savefile_dir, global->name.base,
+         sizeof(current_savefile_dir));
+      path_basedir(current_savefile_dir);
    }
 
    if(path_is_directory(current_savefile_dir))


### PR DESCRIPTION
The savefile directory is filled in `retroarch_set_paths_redirect`, and later on, when the core requests it, it gets strdup'ed from the content directory if empty in `retroarch_get_current_savefile_dir`. Rather than doing this, `retroarch_set_paths_redirect` was updated to fill  `current_savefile_dir` with the content directory as a last resort, and `retroarch_get_current_savefile_dir` was modified to return `current_savefile_dir` as is. This commit now implies that the implementations should not free this string anymore.