### PR TITLE
query: Fix arguments memory leak

### DIFF
--- a/libretro-db/query.c
+++ b/libretro-db/query.c
@@ -413,6 +413,8 @@ static void query_argument_free(struct argument *arg)
 
    for (i = 0; i < arg->a.invocation.argc; i++)
       query_argument_free(&arg->a.invocation.argv[i]);
+
+   free((void*)arg->a.invocation.argv);
 }
 
 static struct buffer query_parse_integer(struct buffer buff,


### PR DESCRIPTION
This is a simple fix to an issue caused by `query_argument_free` not freeing all previously allocated data.