### PR TITLE
xmb: Fix memory leak due to horizontal list not being freed properly

### DIFF
--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -1423,7 +1423,7 @@ static void xmb_refresh_horizontal_list(xmb_handle_t *xmb)
 
    xmb_context_destroy_horizontal_list(xmb);
    if (xmb->horizontal_list)
-      free(xmb->horizontal_list);
+      file_list_free(xmb->horizontal_list);
    xmb->horizontal_list = NULL;
 
    menu_driver_ctl(RARCH_MENU_CTL_SET_PREVENT_POPULATE, NULL);
@@ -2586,7 +2586,7 @@ error:
          free(xmb->selection_buf_old);
       xmb->selection_buf_old = NULL;
       if (xmb->horizontal_list)
-         free(xmb->horizontal_list);
+         file_list_free(xmb->horizontal_list);
       xmb->horizontal_list = NULL;
    }
    return NULL;


### PR DESCRIPTION
The `horizontal_list` allocated from `xmb_init` is a data structure containing embedded pointers which are in turn allocated as well. A few pieces of code were simply calling `free` on this list without using the custom `file_list_free` method which properly takes care of deleting this embedded data - this commit fixes this.