### PR TITLE
task image: Fix memory leak occurring for images loading non-progress…

### DIFF
--- a/tasks/task_image.c
+++ b/tasks/task_image.c
@@ -127,21 +127,17 @@ static int cb_image_menu_generic(nbio_handle_t *nbio)
 {
    unsigned width = 0, height = 0;
    nbio_image_handle_t *image = (nbio_image_handle_t*)nbio->data;
+   int retval;
+
    if (!nbio || !image)
       return -1;
 
-   switch (task_image_process(nbio,
-         &width, &height))
-   {
-      case IMAGE_PROCESS_ERROR:
-      case IMAGE_PROCESS_ERROR_END:
-         return -1;
-      default:
-         break;
-   }
+   retval = task_image_process(nbio, &width, &height);
+   if ((retval == IMAGE_PROCESS_ERROR) || (retval == IMAGE_PROCESS_ERROR_END))
+      return -1;
 
-   image->is_blocking_on_processing         = true;
-   image->is_finished                       = false;
+   image->is_blocking_on_processing         = (retval != IMAGE_PROCESS_END);
+   image->is_finished                       = (retval == IMAGE_PROCESS_END);
 
    return 0;
 }


### PR DESCRIPTION
This commit fixes a nasty leak which was occurring for JPEG and BMP image loading, reproduced easily by selecting a JPEG or BMP wallpaper. The description of the issue and fix is below.

When loading a wallpaper for instance, the process is two-fold (file loading and image loading). The `rarch_task_push_image_load` is the main entry point, which creates a new task, with `rarch_task_file_load_handler` as a handler. When the file is loaded into memory, a callback is executed (in this case leading to `cb_image_menu_generic` eventually calling `task_image_process`), which in turns start decoding the image itself. Data is allocated within all types of format handlers, and this data is is either progressively filled, or filled all at once. The higher-level function knows whether the image is fully decoded or not through the return value of this function (`IMAGE_PROCESS_NEXT` vs `IMAGE_PROCESS_NEXT`). The issue at hand was the fact that the callback of the file load handler (`cb_image_menu_generic`) assumed that the image would not be decoded at once (progressive loading), and setting the image `is_finished` flag to false. This would lead a further iteration through the `rarch_task_image_load_handler` function, meaning both BMP and JPEG handlers would be called another time, allocating memory once again even though this was unneeded - and most importantly, discarding the previously allocating memory which in turn would never be freed.

This commit simply flags the the image as finished if it really is in the file handler callback function, fixing the memory leak.