### PR TITLE
Allow cores that do not need content to still start with content if given

### DIFF
--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -1368,13 +1368,15 @@ static bool init_content_file_set_attribs(
       attr.i              |= system->info.need_fullpath << 1;
       attr.i              |= (!content_does_not_need_content())  << 2;
 
-      if (content_does_not_need_content()
+      char *fullpath    = NULL;
+
+      if (!runloop_ctl(RUNLOOP_CTL_GET_CONTENT_PATH, &fullpath)
+            && content_does_not_need_content()
             && settings->set_supports_no_game_enable)
          string_list_append(content, "", attr);
       else
       {
-         char *fullpath    = NULL;
-         if (runloop_ctl(RUNLOOP_CTL_GET_CONTENT_PATH, &fullpath))
+         if(fullpath)
             string_list_append(content, fullpath, attr);
       }
    }


### PR DESCRIPTION
Check if content has been passed to core even if the core does not need content to start.
Only start without content if no content has been passed.

This fixes a problem with cores that are both able to start with or without
content, eg. ScummVM.
