### PR TITLE
add basic drag and drop to win32 gui

### DIFF
--- a/tasks/tasks_internal.h
+++ b/tasks/tasks_internal.h
@@ -26,6 +26,11 @@
 #include "../core_type.h"
 #include "../runloop.h"
 
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum content_mode_load
 {
    CONTENT_MODE_LOAD_NONE = 0,
@@ -129,5 +134,10 @@ void task_file_load_handler(retro_task_t *task);
 bool take_screenshot(void);
 bool dump_to_file_desperate(const void *data,
       size_t size, unsigned type);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
adds basic drag and drop to win32 gui.
needs to be extended to autodetect cores to make it more seamless though.