### PR TITLE
(ffmpeg_core.c) passing a format string without the arguments to log_cb

### DIFF
--- a/cores/libretro-ffmpeg/ffmpeg_core.c
+++ b/cores/libretro-ffmpeg/ffmpeg_core.c
@@ -181,9 +181,14 @@ static struct
 #ifdef HAVE_SSA
 static void ass_msg_cb(int level, const char *fmt, va_list args, void *data)
 {
+   char buffer[4096];
    (void)data;
+
    if (level < 6)
-      log_cb(RETRO_LOG_INFO, fmt);
+   {
+      vsnprintf(buffer, sizeof(buffer), fmt, args);
+      log_cb(RETRO_LOG_INFO, "%s\n", buffer);
+   }
 }
 #endif
 


### PR DESCRIPTION
can result in a crash.