### PR TITLE
(gl_raster_font) Fixed scaling for newlines

### DIFF
--- a/gfx/drivers_font/gl_raster_font.c
+++ b/gfx/drivers_font/gl_raster_font.c
@@ -360,8 +360,8 @@ static void gl_raster_font_render_message(
       return;
    }
 
-   line_height = scale * 1/ (float)
-      font->font_driver->get_line_height(font->font_data);
+   line_height = 1 / 
+      (scale * (float) font->font_driver->get_line_height(font->font_data));
 
    for (;;)
    {


### PR DESCRIPTION
The `line_height` formula was wrong and leaded to incorrect line spacing when drawing multilines strings with a scale different from 0.

AFAIK nobody uses multiline strings yet it so it won't break anything. The XMB menu seems to be working fine.