### PR TITLE
More GX gamma changes

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -131,8 +131,10 @@ enum
    RECORD_NULL
 };
 
-#ifdef GEKKO
+#if defined(HW_RVL)
 #define MAX_GAMMA_SETTING 30
+#elif defined(GEKKO)
+#define MAX_GAMMA_SETTING 2
 #else
 #define MAX_GAMMA_SETTING 1
 #endif

--- a/gfx/drivers/gx_gfx.c
+++ b/gfx/drivers/gx_gfx.c
@@ -864,10 +864,13 @@ static void gx_resize(void *data)
 
 #ifdef HW_RVL
    VIDEO_SetTrapFilter(global->console.softfilter_enable);
-#endif
    int gamma = global->console.screen.gamma_correction;
    if(gamma == 0) gamma = 10; //default 1.0 gamma value
    VIDEO_SetGamma(gamma);
+#else
+	int gamma = global->console.screen.gamma_correction;
+	GX_SetDispCopyGamma(MAX(0,MIN(2,gamma)));
+#endif
 
    /* Ignore this for custom resolutions */
    if (gx->keep_aspect && gx_mode.efbHeight >= 192)

--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -1207,7 +1207,7 @@ void video_driver_menu_settings(void **list_data, void *list_info_data,
          general_write_handler,
          general_read_handler);
 #endif
-#if defined(HW_RVL) || defined(_XBOX360)
+#if defined(GEKKO) || defined(_XBOX360)
    CONFIG_UINT(
          list, list_info,
          &global->console.screen.gamma_correction,


### PR DESCRIPTION
sorry for having this small messup, noticed it a little too late in my last pull request.
(GX) only apply better gamma setting to wii and use old setting on ngc
(GX) show gamma setting in the video options on ngc, was hidden before