### PR TITLE
Remove "This game doesn't feature achievements" message

### DIFF
--- a/cheevos.c
+++ b/cheevos.c
@@ -2149,9 +2149,7 @@ bool cheevos_load(const void *data)
       if (game_id)
          goto found;
    }
-   
-   runloop_msg_queue_push("This game doesn't feature achievements",
-         0, 5 * 60, false);
+
    RARCH_LOG("CHEEVOS this game doesn't feature achievements\n");
    return false;
    


### PR DESCRIPTION
It appears on the vast majority of games, and is rather annoying.