### PR TITLE
Fix overlap of source and destination buffers in snprintf call

### DIFF
--- a/command.c
+++ b/command.c
@@ -1586,7 +1586,7 @@ static void command_event_save_state(const char *path,
       strlcpy(buf, path, sizeof(buf));
       snprintf(buf, sizeof(buf), "%s", path);
       path_remove_extension(buf);
-      snprintf(buf, sizeof(buf), "%s.last", buf);
+      strlcat(buf, ".last", sizeof(buf));
 
       if (!content_rename_state(path, buf))
       {


### PR DESCRIPTION
command_event_save_state was failing on my machine because of undefined behavior of snprintf function when source and destination buffers overlap.

http://linux.die.net/man/3/snprintf:
> C99 and POSIX.1-2001 specify that the results are undefined if a call to sprintf(), snprintf(), vsprintf(), or vsnprintf() would cause copying to take place between objects that overlap (e.g., if the target string array and one of the supplied input arguments refer to the same buffer). See NOTES. 

PR #3098 reworks this part of the code, but until it's merged, this should be fixed.