### PR TITLE
Revert "Fix overlap of source and destination buffers in snprintf call"

### DIFF
--- a/command.c
+++ b/command.c
@@ -1586,7 +1586,7 @@ static void command_event_save_state(const char *path,
       strlcpy(buf, path, sizeof(buf));
       snprintf(buf, sizeof(buf), "%s", path);
       path_remove_extension(buf);
-      strlcat(buf, ".last", sizeof(buf));
+      snprintf(buf, sizeof(buf), "%s.last", buf);
 
       if (!content_rename_state(path, buf))
       {


### PR DESCRIPTION
Reverts libretro/RetroArch#3126