### PR TITLE
playlist: Fix memory leak due to unallocated playlist entry strings

### DIFF
--- a/playlist.c
+++ b/playlist.c
@@ -182,13 +182,31 @@ void playlist_update(playlist_t *playlist, size_t idx,
       return;
 
    entry            = &playlist->entries[idx];
-   
-   entry->path      = path ?  strdup(path)          : entry->path;
-   entry->label     = label ? strdup(label)         : entry->label;
-   entry->core_path = core_path ? strdup(core_path) : entry->core_path;
-   entry->core_name = core_name ? strdup(core_name) : entry->core_name;
-   entry->db_name   = db_name ? strdup(db_name)     : entry->db_name;
-   entry->crc32     = crc32 ? strdup(crc32)         : entry->crc32;
+
+   if (path && (path != entry->path)) {
+      free(entry->path);
+      entry->path = strdup(path);
+   }
+   if (label && (label != entry->label)) {
+      free(entry->label);
+      entry->label = strdup(label);
+   }
+   if (core_path && (core_path != entry->core_path)) {
+      free(entry->core_path);
+      entry->core_path = strdup(core_path);
+   }
+   if (core_name && (core_name != entry->core_name)) {
+      free(entry->core_name);
+      entry->core_name = strdup(core_name);
+   }
+   if (db_name && (db_name != entry->db_name)) {
+      free(entry->db_name);
+      entry->db_name = strdup(db_name);
+   }
+   if (crc32 && (crc32 != entry->crc32)) {
+      free(entry->crc32);
+      entry->crc32 = strdup(crc32);
+   }
 }
 
 /**


### PR DESCRIPTION
This fixes a memory leak which occurred after the following steps:
- Scan directory
- Go to newly created playlist
- Select game
- Select Run
- Select core

At this point, some strings allocated within `playlist_read_file` were leaking. The reason this happened was due to `playlist_update` being called, overwriting these previously allocated strings without freeing them. These new allocated strings are properly unallocated later on within `playlist_free_entry`. Note: this PR has been updated: a bug was introduced in the previous one due to argument pointers being equal to the pointers within the playlist entry itself, causing the contents of these arguments to be freed as well - this is why this commit adds a check for each argument passed in to make sure this scenario does not happen.