### PR TITLE
image texture: Add length argument to image_transfer_process

### DIFF
--- a/libretro-common/formats/image_texture.c
+++ b/libretro-common/formats/image_texture.c
@@ -160,6 +160,7 @@ static bool image_texture_internal_gx_convert_texture32(
 static bool image_texture_load_internal(
       enum image_type_enum type,
       void *ptr,
+      size_t len,
       struct texture_image *out_img,
       unsigned a_shift, unsigned r_shift,
       unsigned g_shift, unsigned b_shift)
@@ -184,7 +185,7 @@ static bool image_texture_load_internal(
    do
    {
       ret = image_transfer_process(img, type,
-            (uint32_t**)&out_img->pixels, 0, &out_img->width,
+            (uint32_t**)&out_img->pixels, len, &out_img->width,
             &out_img->height);
    }while(ret == IMAGE_PROCESS_NEXT);
 
@@ -299,7 +300,7 @@ bool image_texture_load(struct texture_image *out_img,
 
       if (image_texture_load_internal(
                image_texture_convert_fmt_to_type(fmt),
-               ptr,out_img,
+               ptr, file_len, out_img,
                a_shift, r_shift, g_shift, b_shift))
          goto success;
    }


### PR DESCRIPTION
After going deep within the rjpeg image loading code, it turns out that the issue when loading images in the imageviewer libretro core (without having `HAVE_STB_IMAGE` defined) was due to a buffer size not properly propagated throughout internal API calls. This commit simply adds a length parameter to the `image_transfer_process` call, which fixes BMP and JPEG loading.