### PR TITLE
corrected a switch case, makes ngc build (and probably others) boot up again

### DIFF
--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -1842,10 +1842,11 @@ bool task_push_content_load_default(
    /* Fork core? */
    switch (mode)
    {
-      case 0:
-      default:
+	  case CONTENT_MODE_LOAD_NOTHING_WITH_NEW_CORE_FROM_MENU:
          if (!frontend_driver_set_fork(FRONTEND_FORK_CORE))
             return false;
+         break;
+      default:
          break;
    }
 #endif


### PR DESCRIPTION
this was the original behavior in the code which was changed during a code move and broke the ngc build and probably others, now it behaves as it did originally again.