### PR TITLE
corrected core info removal

### DIFF
--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -425,8 +425,13 @@ bool menu_driver_ctl(enum rarch_menu_ctl_state state, void *data)
          }
          break;
       case RARCH_MENU_CTL_SYSTEM_INFO_DEINIT:
-         libretro_free_system_info(&menu_driver_system);
-         memset(&menu_driver_system, 0, sizeof(struct retro_system_info));
+#ifndef HAVE_DYNAMIC
+         if (frontend_driver_has_fork())
+#endif
+         {
+            libretro_free_system_info(&menu_driver_system);
+            memset(&menu_driver_system, 0, sizeof(struct retro_system_info));
+         }
          break;
       case RARCH_MENU_CTL_RENDER_MESSAGEBOX:
          if (menu_driver_ctx->render_messagebox)


### PR DESCRIPTION
this was changed pretty much right after 1.3.3 came out and was not quite right, it should be now though.