### PR TITLE
retroarch: Fix core type detection when cores are excplicitely set

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -1658,8 +1658,9 @@ void retroarch_set_current_core_type(enum rarch_core_type type, bool explicitly_
    {
       current_core_explicitly_set = true;
       explicit_current_core_type  = type;
+      current_core_type           = type;
    }
-   else
+   else if (!current_core_explicitly_set)
       current_core_type          = type;
 }
 


### PR DESCRIPTION
This commit fixes an issue occurring when attempting to start the net retropad core from the main menu - this would always fail unless another core was previously loaded. The issue was that the core loading process would check the core type before accepting to continue loading, and in this first instance, the core type would always be "dummy". In the second case, the core type was set to "plain", which actually was due to luck as the -L option being appended to `argv` when calling `retroarch_main_init` was overwriting the core type. This fix changes the `retroarch_set_current_core_type` function to save the core type when explicitly set as well, and at the same refuse setting another core type if one was explicitly set beforehand.