### PR TITLE
Add start+select to the list of gamepad combos

### DIFF
--- a/menu/cbs/menu_cbs_get_value.c
+++ b/menu/cbs/menu_cbs_get_value.c
@@ -761,6 +761,9 @@ static void menu_action_setting_disp_set_label_menu_toggle_gamepad_combo(
          break;
       case 2:
          snprintf(s, len, "%s", "L3 + R3");
+	 break;
+      case 3:
+         snprintf(s, len, "%s", "Start + Select");
          break;
    }
 }

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -5788,7 +5788,7 @@ static bool setting_append_list(
                   parent_group,
                   general_write_handler,
                   general_read_handler);
-            menu_settings_list_current_add_range(list, list_info, 0, 2, 1, true, true);
+            menu_settings_list_current_add_range(list, list_info, 0, 3, 1, true, true);
             menu_settings_list_current_add_enum_idx(list, list_info, MENU_ENUM_LABEL_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO);
 
             CONFIG_BOOL(

--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -614,7 +614,7 @@
 # input_menu_toggle = f1
 
 # RetroPad button combination to toggle menu
-# 0 = none, 1 = L + R + Y + D-Pad Down, 2 = L3 + R3
+# 0 = none, 1 = L + R + Y + D-Pad Down, 2 = L3 + R3, 3 = Start + Select
 # input_menu_toggle_gamepad_combo = 0
 
 # Toggles mouse grab. When mouse is grabbed, RetroArch hides the mouse,

--- a/runloop.c
+++ b/runloop.c
@@ -330,6 +330,11 @@ static bool runloop_cmd_get_state_menu_toggle_button_combo(
             return false;
          if (!BIT64_GET(input.state, RETRO_DEVICE_ID_JOYPAD_R3))
             return false;
+      case 3:
+         if (!BIT64_GET(input.state, RETRO_DEVICE_ID_JOYPAD_START))
+            return false;
+         if (!BIT64_GET(input.state, RETRO_DEVICE_ID_JOYPAD_SELECT))
+            return false;
          break;
    }
 


### PR DESCRIPTION
Can be useful for the 8bitdo Zero, or for Gamegirl.