### PR TITLE
Fix ScummVM in the menu to match the DAT

### DIFF
--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -313,9 +313,18 @@ static int database_info_list_iterate_found_match(
 
    if(!playlist_entry_exists(playlist, entry_path_str, db_crc))
    {
+      // For the playlist item name, use the game's
+      // description if it's less then 60 characters
+      // long. Otherwise, just use the name.
+      char* name;
+      if (strlen(db_info_entry->description) <= 60)
+         name = db_info_entry->description;
+      else
+         name = db_info_entry->name;
+
+      // Add the item to the playlist.
       playlist_push(playlist, entry_path_str,
-            // Use the game's description, instead of its name.
-            db_info_entry->description,
+            name,
             file_path_str(FILE_PATH_DETECT),
             file_path_str(FILE_PATH_DETECT),
             db_crc, db_playlist_base_str);

--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -314,7 +314,8 @@ static int database_info_list_iterate_found_match(
    if(!playlist_entry_exists(playlist, entry_path_str, db_crc))
    {
       playlist_push(playlist, entry_path_str,
-            db_info_entry->name,
+            // Use the game's description, instead of its name.
+            db_info_entry->description,
             file_path_str(FILE_PATH_DETECT),
             file_path_str(FILE_PATH_DETECT),
             db_crc, db_playlist_base_str);

--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -313,11 +313,10 @@ static int database_info_list_iterate_found_match(
 
    if(!playlist_entry_exists(playlist, entry_path_str, db_crc))
    {
-      // For the playlist item name, use the game's
-      // description if it's less then 60 characters
-      // long. Otherwise, just use the name.
+      // For ScummVM, use the game description, for every
+      // other system, use the DAT's game name.
       char* name;
-      if (strlen(db_info_entry->description) <= 60)
+      if (strcmp(db_playlist_base_str, "ScummVM.lpl") == 0)
          name = db_info_entry->description;
       else
          name = db_info_entry->name;


### PR DESCRIPTION
The game's description is usually more human-friendly than the given rom name. You can see  this happen in https://github.com/libretro/libretro-database/pull/221 . Doesn't affect any of the other DATs we have, as the key is mirrored.

![scummvm](https://cloud.githubusercontent.com/assets/25086/16829860/54491a12-4969-11e6-8b04-2bbd083a2892.png)
![scummvm2](https://cloud.githubusercontent.com/assets/25086/16829861/544bccb2-4969-11e6-95dd-bcbbca966487.png)

... With this change, it ends up being correct....

![scummvm3](https://cloud.githubusercontent.com/assets/25086/16829895/903bf2ec-4969-11e6-805b-6e80ae2f6e0d.png)
