### PR TITLE
Fix vulkan xmb bug.

### DIFF
--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -1371,19 +1371,23 @@ static void xmb_context_reset_horizontal_list(
             sizeof(content_texturepath));
 
       image_texture_load(&ti, texturepath);
-
-      video_driver_texture_unload(&node->icon);
-      video_driver_texture_load(&ti,
-            TEXTURE_FILTER_MIPMAP_LINEAR, &node->icon);
+      
+      if(ti.pixels) {
+        video_driver_texture_unload(&node->icon);
+        video_driver_texture_load(&ti,
+                TEXTURE_FILTER_MIPMAP_LINEAR, &node->icon);
+      }
 
       image_texture_free(&ti);
 
       image_texture_load(&ti, content_texturepath);
-
-      video_driver_texture_unload(&node->content_icon);
-      video_driver_texture_load(&ti,
-            TEXTURE_FILTER_MIPMAP_LINEAR, &node->content_icon);
-
+      
+      if(ti.pixels) {
+        video_driver_texture_unload(&node->content_icon);
+        video_driver_texture_load(&ti,
+                TEXTURE_FILTER_MIPMAP_LINEAR, &node->content_icon);
+      }
+      
       image_texture_free(&ti);
    }
 


### PR DESCRIPTION
The xmb menu driver has a bug that when it cannot find a thumbnail it causes an assert by trying to render an texture with the pixels as a null pointer. This fixes it by not trying to render it, when the texture has pixels as a null pointer. Fixes issue #3225.