### PR TITLE
Fix bug in calculation of blocksize for savestates

### DIFF
--- a/managers/state_manager.c
+++ b/managers/state_manager.c
@@ -315,7 +315,7 @@ static state_manager_t *state_manager_new(size_t state_size, size_t buffer_size)
    if (!state)
       return NULL;
 
-   state->blocksize   = (state_size + sizeof(uint16_t) - 1) & ~sizeof(uint16_t);
+   state->blocksize   = (state_size + sizeof(uint16_t) - 1) & -sizeof(uint16_t);
    /* the compressed data is surrounded by pointers to the other side */
    state->maxcompsize = state_manager_raw_maxsize(state_size) + sizeof(size_t) * 2;
    state->data        = (uint8_t*)malloc(buffer_size);


### PR DESCRIPTION
An issue with the calculation of blocksize for savestates crashes RetroArch in certain cases. Whether or not a crash occurs depends on the indicated state size when calling state_manager_new(). This issue was first discussed here:

https://github.com/libretro/bsnes-libretro/issues/14

Although it was found with MSU-1 hacked SNES games and appeared to become worse with the lag fix, the issue is a general one.

The actual reason for the crash is that the num16s variable in state_manager_raw_compress() gets an incorrect value. This stops the function from terminating when expected and it keeps running, calling the find_same() function which eventually causes a segmentation fault.

With this fix, state->blocksize is now calculated in the same way as the len16 variable in state_manager_raw_alloc(), which makes a lot more sense.

I have tested this fix with and without rewind on in Mega Man X with MSU-1 and the lag fix active. It works fine. I have also tested a few other games (without MSU-1) and they also seem fine. However, I'd appreciate it if others helped out with testing both MSU-1 and non-MSU-1 games.