### PR TITLE
command: Remove core deinitialization on close for non-dynamic targets

### DIFF
--- a/command.c
+++ b/command.c
@@ -1922,7 +1922,9 @@ bool command_event(enum event_command cmd, void *data)
                break;
          }
 
+#ifdef HAVE_DYNAMIC
          command_event(CMD_EVENT_LOAD_CORE_DEINIT, NULL);
+#endif
 
          switch (cmd)
          {


### PR DESCRIPTION
This commit removes core deinitialization for RetroArch versions built statically with cores, such as PS3. Reversing the logic (#ifdef to #ifndef) leaves the core loaded in my environment, and allows me to load new content without reloading a core, as expected. This still needs to be validates on non-dynamic targets.