### PR TITLE
task content: Display OSD loading message prior to loading content

### DIFF
--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -1607,9 +1607,6 @@ static bool task_load_content(content_ctx_info_t *content_info,
    }
 #endif
 
-   if (!content_load(content_info))
-      goto error;
-
    if (launched_from_menu)
    {
       /** Show loading OSD message */
@@ -1621,7 +1618,10 @@ static bool task_load_content(content_ctx_info_t *content_info,
          runloop_msg_queue_push(msg, 2, 1, true);
       }
    }
-   
+
+   if (!content_load(content_info))
+      goto error;
+
    /* Push entry to top of history playlist */
    if (content_is_inited() || content_does_not_need_content())
    {


### PR DESCRIPTION
This actually is a workaround and not a direct fix - when a core fails to load content, it would be beneficial to display a message to the end-user indicating what failed to load, with a string controlled by the actual core (thus providing better details). Prior to this commit, the message would be replaced/flushed right away with a regular "Loading" message, not giving the end-user the opportunity to understand what went wrong. This commit changes the message order so that the error string provided by the core remains on top of the OSD when coming back to the frontend UI.