### PR TITLE
Vulkan: Fix wrong error handling for missing file.

### DIFF
--- a/gfx/drivers_shader/glslang_util.cpp
+++ b/gfx/drivers_shader/glslang_util.cpp
@@ -35,7 +35,7 @@ static bool read_shader_file(const char *path, vector<string> *output)
    struct string_list *list = NULL;
    char include_path[PATH_MAX];
 
-   if (filestream_read_file(path, (void**)&buf, &len) < 0)
+   if (!filestream_read_file(path, (void**)&buf, &len))
    {
       RARCH_ERR("Failed to open shader file: \"%s\".\n", path);
       return false;


### PR DESCRIPTION
Apparently 0/1 is returned instead of 0/-1.