### PR TITLE
Add analog device to Net RetroPad

### DIFF
--- a/cores/libretro-net-retropad/net_retropad_core.c
+++ b/cores/libretro-net-retropad/net_retropad_core.c
@@ -94,8 +94,19 @@ static struct descriptor joypad = {
    .id_max = RETRO_DEVICE_ID_JOYPAD_R3
 };
 
+static struct descriptor analog = {
+   .device = RETRO_DEVICE_ANALOG,
+   .port_min = 0,
+   .port_max = 0,
+   .index_min = RETRO_DEVICE_INDEX_ANALOG_LEFT,
+   .index_max = RETRO_DEVICE_INDEX_ANALOG_RIGHT,
+   .id_min = RETRO_DEVICE_ID_ANALOG_X,
+   .id_max = RETRO_DEVICE_ID_ANALOG_Y
+};
+
 static struct descriptor *descriptors[] = {
-   &joypad
+   &joypad,
+   &analog
 };
 
 void NETRETROPAD_CORE_PREFIX(retro_init)(void)

--- a/input/input_remote.c
+++ b/input/input_remote.c
@@ -171,6 +171,9 @@ static void input_remote_parse_packet(struct message *msg, unsigned user)
          if (msg->state)
             ol_state->buttons[user] |= 1 << msg->id;
          break;
+      case RETRO_DEVICE_ANALOG:
+         ol_state->analog[msg->index * 2 + msg->id][user] = msg->state;
+         break;
    }
 }
 #endif
@@ -246,7 +249,13 @@ void input_remote_poll(input_remote_t *handle)
             input_remote_parse_packet(&msg, user);
          else if ((ret != -1) || (errno != EAGAIN))
 #endif
+         {
             ol_state->buttons[user] = 0;
+            ol_state->analog[0][user] = 0;
+            ol_state->analog[1][user] = 0;
+            ol_state->analog[2][user] = 0;
+            ol_state->analog[3][user] = 0;
+         }
       }
    }
 }


### PR DESCRIPTION
These commits are untested, as I don't have access to a gamepad. The goal of this PR is to add analog device support to the Net RetroPad core and RetroArch. Once tested, one would still need to update the core's drawing method to reflect analog changes.