### PR TITLE
Vulkan: Mipmapping, LUT in shader support, Mipmapped FBOs, bugfixes

### DIFF
--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -267,7 +267,7 @@ void vulkan_sync_texture_to_cpu(vk_t *vk, const struct vk_texture *tex)
 
 static unsigned vulkan_num_miplevels(unsigned width, unsigned height)
 {
-   unsigned size = width > height ? width : height;
+   unsigned size = MAX(width, height);
    unsigned levels = 0;
    while (size)
    {
@@ -488,7 +488,7 @@ struct vk_texture vulkan_create_texture(vk_t *vk,
          view.components.a             = VK_COMPONENT_SWIZZLE_A;
       }
       view.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-      view.subresourceRange.levelCount = 1;
+      view.subresourceRange.levelCount = info.mipLevels;
       view.subresourceRange.layerCount = 1;
 
       vkCreateImageView(device, &view, NULL, &tex.view);

--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -1627,6 +1627,7 @@ bool vulkan_context_init(gfx_ctx_vulkan_data_t *vk,
       info.pfnCallback = vulkan_debug_cb;
       vkCreateDebugReportCallbackEXT(vk->context.instance, &info, NULL, &vk->context.debug_callback);
    }
+   RARCH_LOG("[Vulkan]: Enabling Vulkan debug layers.\n");
 #endif
 
    /* Try different API versions if driver has compatible

--- a/gfx/common/vulkan_common.h
+++ b/gfx/common/vulkan_common.h
@@ -173,6 +173,7 @@ struct vk_texture
    enum vk_texture_type type;
    bool default_smooth;
    bool need_manual_cache_management;
+   bool mipmap;
 };
 
 struct vk_buffer
@@ -352,6 +353,8 @@ typedef struct vk
    {
       VkSampler linear;
       VkSampler nearest;
+      VkSampler mipmap_nearest;
+      VkSampler mipmap_linear;
    } samplers;
 
    unsigned last_valid_index;

--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -651,6 +651,8 @@ static bool vulkan_init_default_filter_chain(vk_t *vk)
    info.gpu                   = vk->context->gpu;
    info.memory_properties     = &vk->context->memory_properties;
    info.pipeline_cache        = vk->pipelines.cache;
+   info.queue                 = vk->context->queue;
+   info.command_pool          = vk->swapchain[vk->context->current_swapchain_index].cmd_pool;
    info.max_input_size.width  = vk->tex_w;
    info.max_input_size.height = vk->tex_h;
    info.swapchain.viewport    = vk->vk_vp;
@@ -683,6 +685,8 @@ static bool vulkan_init_filter_chain_preset(vk_t *vk, const char *shader_path)
    info.gpu                   = vk->context->gpu;
    info.memory_properties     = &vk->context->memory_properties;
    info.pipeline_cache        = vk->pipelines.cache;
+   info.queue                 = vk->context->queue;
+   info.command_pool          = vk->swapchain[vk->context->current_swapchain_index].cmd_pool;
    info.max_input_size.width  = vk->tex_w;
    info.max_input_size.height = vk->tex_h;
    info.swapchain.viewport    = vk->vk_vp;

--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -483,16 +483,31 @@ static void vulkan_init_samplers(vk_t *vk)
    vkCreateSampler(vk->context->device,
          &info, NULL, &vk->samplers.nearest);
 
-   info.magFilter               = VK_FILTER_LINEAR;
-   info.minFilter               = VK_FILTER_LINEAR;
+   info.magFilter = VK_FILTER_LINEAR;
+   info.minFilter = VK_FILTER_LINEAR;
    vkCreateSampler(vk->context->device,
          &info, NULL, &vk->samplers.linear);
+
+   info.maxLod     = VK_LOD_CLAMP_NONE;
+   info.magFilter  = VK_FILTER_NEAREST;
+   info.minFilter  = VK_FILTER_NEAREST;
+   info.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+   vkCreateSampler(vk->context->device,
+         &info, NULL, &vk->samplers.mipmap_nearest);
+
+   info.magFilter  = VK_FILTER_LINEAR;
+   info.minFilter  = VK_FILTER_LINEAR;
+   info.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
+   vkCreateSampler(vk->context->device,
+         &info, NULL, &vk->samplers.mipmap_linear);
 }
 
 static void vulkan_deinit_samplers(vk_t *vk)
 {
    vkDestroySampler(vk->context->device, vk->samplers.nearest, NULL);
    vkDestroySampler(vk->context->device, vk->samplers.linear, NULL);
+   vkDestroySampler(vk->context->device, vk->samplers.mipmap_nearest, NULL);
+   vkDestroySampler(vk->context->device, vk->samplers.mipmap_linear, NULL);
 }
 
 static void vulkan_init_buffers(vk_t *vk)
@@ -1749,7 +1764,9 @@ static bool vulkan_frame(void *data, const void *frame,
             quad.texture = optimal;
          }
 
-         quad.sampler = vk->samplers.linear;
+         quad.sampler = optimal->mipmap ?
+            vk->samplers.mipmap_linear : vk->samplers.linear;
+
          quad.mvp     = &vk->mvp_no_rot;
          quad.color.r = 1.0f;
          quad.color.g = 1.0f;
@@ -2137,10 +2154,9 @@ static uintptr_t vulkan_load_texture(void *video_data, void *data,
          image->width, image->height, VK_FORMAT_B8G8R8A8_UNORM,
          image->pixels, NULL, VULKAN_TEXTURE_STATIC);
 
-   /* TODO: Actually add mipmapping support.
-    * Optimal tiling would make sense here as well ... */
    texture->default_smooth =
       filter_type == TEXTURE_FILTER_MIPMAP_LINEAR || filter_type == TEXTURE_FILTER_LINEAR;
+   texture->mipmap = filter_type == TEXTURE_FILTER_MIPMAP_LINEAR;
 
    return (uintptr_t)texture;
 }
@@ -2370,7 +2386,8 @@ static void vulkan_render_overlay(vk_t *vk)
       memset(&call, 0, sizeof(call));
       call.pipeline     = vk->display.pipelines[3]; /* Strip with blend */
       call.texture      = &vk->overlay.images[i];
-      call.sampler      = vk->samplers.linear;
+      call.sampler      = call.texture->mipmap ?
+         vk->samplers.mipmap_linear : vk->samplers.linear;
       call.uniform      = &vk->mvp;
       call.uniform_size = sizeof(vk->mvp);
       call.vbo          = &range;

--- a/gfx/drivers_font/vulkan_raster_font.c
+++ b/gfx/drivers_font/vulkan_raster_font.c
@@ -241,7 +241,7 @@ static void vulkan_raster_font_flush(vulkan_raster_t *font)
    const struct vk_draw_triangles call = {
       font->vk->pipelines.font,
       &font->texture,
-      font->vk->samplers.nearest,
+      font->vk->samplers.mipmap_linear,
       &font->vk->mvp,
       sizeof(font->vk->mvp),
       &font->range,

--- a/gfx/drivers_shader/shader_vulkan.cpp
+++ b/gfx/drivers_shader/shader_vulkan.cpp
@@ -2340,11 +2340,11 @@ static vulkan_filter_chain_address wrap_to_address(gfx_wrap_type type)
    switch (type)
    {
       default:
-      case RARCH_WRAP_BORDER:
-         return VULKAN_FILTER_CHAIN_ADDRESS_CLAMP_TO_BORDER;
-
       case RARCH_WRAP_EDGE:
          return VULKAN_FILTER_CHAIN_ADDRESS_CLAMP_TO_EDGE;
+
+      case RARCH_WRAP_BORDER:
+         return VULKAN_FILTER_CHAIN_ADDRESS_CLAMP_TO_BORDER;
 
       case RARCH_WRAP_REPEAT:
          return VULKAN_FILTER_CHAIN_ADDRESS_REPEAT;
@@ -2622,10 +2622,10 @@ vulkan_filter_chain_t *vulkan_filter_chain_create_from_preset(
             pass->filter == RARCH_FILTER_LINEAR ? VULKAN_FILTER_CHAIN_LINEAR : 
             VULKAN_FILTER_CHAIN_NEAREST;
       }
+      pass_info.address = wrap_to_address(pass->wrap);
 
-      // TODO: Implement configurable mip/address modes.
+      // TODO: Implement configurable mip modes.
       pass_info.mip_filter = VULKAN_FILTER_CHAIN_NEAREST;
-      pass_info.address = VULKAN_FILTER_CHAIN_ADDRESS_CLAMP_TO_EDGE;
 
       bool explicit_format = output.meta.rt_format != SLANG_FORMAT_UNKNOWN;
 

--- a/gfx/drivers_shader/shader_vulkan.cpp
+++ b/gfx/drivers_shader/shader_vulkan.cpp
@@ -2275,8 +2275,6 @@ static unique_ptr<StaticTexture> vulkan_filter_chain_load_lut(VkCommandBuffer cm
    ptr = buffer->map();
    memcpy(ptr, image.pixels, image.width * image.height * sizeof(uint32_t));
    buffer->unmap();
-   image_texture_free(&image);
-   image.pixels = nullptr;
 
    image_layout_transition(cmd, tex,
          VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
@@ -2298,6 +2296,9 @@ static unique_ptr<StaticTexture> vulkan_filter_chain_load_lut(VkCommandBuffer cm
          VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
          VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_SHADER_READ_BIT,
          VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
+
+   image_texture_free(&image);
+   image.pixels = nullptr;
 
    return unique_ptr<StaticTexture>(new StaticTexture(shader->id, info->device,
             tex, view, memory, move(buffer), image.width, image.height));

--- a/gfx/drivers_shader/shader_vulkan.cpp
+++ b/gfx/drivers_shader/shader_vulkan.cpp
@@ -55,8 +55,8 @@ static void image_layout_transition(
    barrier.dstQueueFamilyIndex         = VK_QUEUE_FAMILY_IGNORED;
    barrier.image                       = image;
    barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-   barrier.subresourceRange.levelCount = 1;
-   barrier.subresourceRange.layerCount = 1;
+   barrier.subresourceRange.levelCount = VK_REMAINING_MIP_LEVELS;
+   barrier.subresourceRange.layerCount = VK_REMAINING_ARRAY_LAYERS;
 
    vkCmdPipelineBarrier(cmd,
          src_stages,

--- a/gfx/drivers_shader/shader_vulkan.cpp
+++ b/gfx/drivers_shader/shader_vulkan.cpp
@@ -1898,7 +1898,8 @@ void Pass::build_commands(
    {
       set_uniform_buffer(sets[sync_index], reflection.ubo_binding,
             common->ubo->get_buffer(),
-            ubo_offset, reflection.ubo_size);
+            ubo_offset + sync_index * common->ubo_sync_index_stride,
+            reflection.ubo_size);
    }
 
    // The final pass is always executed inside 

--- a/gfx/drivers_shader/shader_vulkan.h
+++ b/gfx/drivers_shader/shader_vulkan.h
@@ -31,7 +31,18 @@ typedef struct vulkan_filter_chain vulkan_filter_chain_t;
 enum vulkan_filter_chain_filter
 {
    VULKAN_FILTER_CHAIN_LINEAR  = 0,
-   VULKAN_FILTER_CHAIN_NEAREST = 1
+   VULKAN_FILTER_CHAIN_NEAREST = 1,
+   VULKAN_FILTER_CHAIN_COUNT
+};
+
+enum vulkan_filter_chain_address
+{
+   VULKAN_FILTER_CHAIN_ADDRESS_REPEAT = 0,
+   VULKAN_FILTER_CHAIN_ADDRESS_MIRRORED_REPEAT = 1,
+   VULKAN_FILTER_CHAIN_ADDRESS_CLAMP_TO_EDGE = 2,
+   VULKAN_FILTER_CHAIN_ADDRESS_CLAMP_TO_BORDER = 3,
+   VULKAN_FILTER_CHAIN_ADDRESS_MIRROR_CLAMP_TO_EDGE = 4,
+   VULKAN_FILTER_CHAIN_ADDRESS_COUNT
 };
 
 struct vulkan_filter_chain_texture
@@ -65,6 +76,8 @@ struct vulkan_filter_chain_pass_info
 
    /* The filter to use for source in this pass. */
    enum vulkan_filter_chain_filter source_filter;
+   enum vulkan_filter_chain_filter mip_filter;
+   enum vulkan_filter_chain_address address;
 };
 
 struct vulkan_filter_chain_swapchain_info

--- a/gfx/drivers_shader/shader_vulkan.h
+++ b/gfx/drivers_shader/shader_vulkan.h
@@ -78,6 +78,9 @@ struct vulkan_filter_chain_pass_info
    enum vulkan_filter_chain_filter source_filter;
    enum vulkan_filter_chain_filter mip_filter;
    enum vulkan_filter_chain_address address;
+
+   /* Maximum number of mip-levels to use. */
+   unsigned max_levels;
 };
 
 struct vulkan_filter_chain_swapchain_info

--- a/gfx/drivers_shader/shader_vulkan.h
+++ b/gfx/drivers_shader/shader_vulkan.h
@@ -81,6 +81,8 @@ struct vulkan_filter_chain_create_info
    VkPhysicalDevice gpu;
    const VkPhysicalDeviceMemoryProperties *memory_properties;
    VkPipelineCache pipeline_cache;
+   VkQueue queue;
+   VkCommandPool command_pool;
    unsigned num_passes;
 
    VkFormat original_format;

--- a/gfx/drivers_shader/slang_reflection.cpp
+++ b/gfx/drivers_shader/slang_reflection.cpp
@@ -29,6 +29,7 @@ static bool slang_texture_semantic_is_array(slang_texture_semantic sem)
       case SLANG_TEXTURE_SEMANTIC_ORIGINAL_HISTORY:
       case SLANG_TEXTURE_SEMANTIC_PASS_OUTPUT:
       case SLANG_TEXTURE_SEMANTIC_PASS_FEEDBACK:
+      case SLANG_TEXTURE_SEMANTIC_USER:
          return true;
 
       default:
@@ -52,6 +53,7 @@ static const char *texture_semantic_names[] = {
    "OriginalHistory",
    "PassOutput",
    "PassFeedback",
+   "User",
    nullptr
 };
 
@@ -61,6 +63,7 @@ static const char *texture_semantic_uniform_names[] = {
    "OriginalHistorySize",
    "PassOutputSize",
    "PassFeedbackSize",
+   "UserSize",
    nullptr
 };
 

--- a/gfx/drivers_shader/slang_reflection.hpp
+++ b/gfx/drivers_shader/slang_reflection.hpp
@@ -48,6 +48,11 @@ enum slang_texture_semantic
    // Canonical name: "PassFeedback#", e.g. "PassFeedback2".
    SLANG_TEXTURE_SEMANTIC_PASS_FEEDBACK = 4,
 
+   // Inputs from static textures, defined by the user.
+   // There is no canonical name, and the only way to use these semantics are by
+   // remapping.
+   SLANG_TEXTURE_SEMANTIC_USER = 5,
+
    SLANG_NUM_TEXTURE_SEMANTICS,
    SLANG_INVALID_TEXTURE_SEMANTIC = -1
 };

--- a/menu/drivers_display/menu_display_vulkan.c
+++ b/menu/drivers_display/menu_display_vulkan.c
@@ -193,8 +193,9 @@ static void menu_display_vk_draw(void *data)
             vk->display.pipelines[
                to_display_pipeline(draw->prim_type, vk->display.blend)],
                texture,
-               texture->default_smooth 
-                  ? vk->samplers.linear : vk->samplers.nearest,
+               texture->mipmap ?
+                  vk->samplers.mipmap_linear :
+                  (texture->default_smooth ? vk->samplers.linear : vk->samplers.nearest),
                draw->matrix_data
                   ? draw->matrix_data : menu_display_vk_get_default_mvp(),
                sizeof(math_matrix_4x4),


### PR DESCRIPTION
- Implements mipmapping in Vulkan backend which gives smoother textures when downscaling UI elements.
- LUTs are now fully supported in slang shader backend with mipmap, wrapping and filter toggle support.
- FBOs can now be mipmapped, so mipmap_input works.
- Frame count now works properly.
- Optimize filter chain UBO uploads by persistently mapping the buffer.