### PR TITLE
Vulkan: Make glslang shaders debuggable.

### DIFF
--- a/gfx/drivers_shader/slang_reflection.cpp
+++ b/gfx/drivers_shader/slang_reflection.cpp
@@ -289,7 +289,6 @@ static bool add_active_buffer_ranges(const Compiler &compiler, const Resource &r
       }
       else
       {
-         // TODO: Handle invalid semantics as user defined.
          RARCH_ERR("[slang]: Unknown semantic found.\n");
          return false;
       }


### PR DESCRIPTION
Properly handle file names, includes, etc to make
error reports somewhat more sane.