### PR TITLE
Vulkan: Fix validation errors with OriginalHistory.

### DIFF
--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -350,12 +350,15 @@ struct vk_texture vulkan_create_texture(vk_t *vk,
       case VULKAN_TEXTURE_DYNAMIC:
          retro_assert(!initial && "Dynamic textures must not have initial data.\n");
          info.tiling        = VK_IMAGE_TILING_OPTIMAL;
-         info.usage         = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+         info.usage         = VK_IMAGE_USAGE_SAMPLED_BIT |
+                              VK_IMAGE_USAGE_TRANSFER_DST_BIT |
+                              VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
          info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
          break;
 
       case VULKAN_TEXTURE_STREAMED:
-         info.usage         = VK_IMAGE_USAGE_SAMPLED_BIT;
+         info.usage         = VK_IMAGE_USAGE_SAMPLED_BIT |
+                              VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
          info.tiling        = VK_IMAGE_TILING_LINEAR;
          info.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
          break;

--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -1789,6 +1789,11 @@ static bool vulkan_frame(void *data, const void *frame,
    /* End the render pass. We're done rendering to backbuffer now. */
    vkCmdEndRenderPass(vk->cmd);
 
+   /* End the filter chain frame.
+    * This must happen outside a render pass.
+    */
+   vulkan_filter_chain_end_frame(vk->filter_chain, vk->cmd);
+
    if (vk->readback.pending || vk->readback.streamed)
    {
       /* We cannot safely read back from an image which 

--- a/gfx/drivers_shader/shader_vulkan.h
+++ b/gfx/drivers_shader/shader_vulkan.h
@@ -149,6 +149,8 @@ void vulkan_filter_chain_build_offscreen_passes(vulkan_filter_chain_t *chain,
       VkCommandBuffer cmd, const VkViewport *vp);
 void vulkan_filter_chain_build_viewport_pass(vulkan_filter_chain_t *chain,
       VkCommandBuffer cmd, const VkViewport *vp, const float *mvp);
+void vulkan_filter_chain_end_frame(vulkan_filter_chain_t *chain,
+      VkCommandBuffer cmd);
 
 vulkan_filter_chain_t *vulkan_filter_chain_create_default(
       const struct vulkan_filter_chain_create_info *info,


### PR DESCRIPTION
For some reason, OriginalHistory blit happened inside a render pass.
Also add more TRANSFER_SRC_BIT caps to images as they might have to be
copied to history.