### PR TITLE
Fix GL_DEBUG on GLES3

### DIFF
--- a/gfx/drivers/gl.c
+++ b/gfx/drivers/gl.c
@@ -1975,7 +1975,7 @@ static const gfx_ctx_driver_t *gl_get_context(gl_t *gl)
 }
 
 #ifdef GL_DEBUG
-#ifdef HAVE_OPENGLES2
+#ifdef HAVE_OPENGLES
 #define DEBUG_CALLBACK_TYPE GL_APIENTRY
 
 #define GL_DEBUG_SOURCE_API GL_DEBUG_SOURCE_API_KHR
@@ -2088,7 +2088,7 @@ static void gl_begin_debug(gl_t *gl)
 {
    if (gl_check_capability(GL_CAPS_DEBUG))
    {
-#ifdef HAVE_OPENGLES2
+#ifdef HAVE_OPENGLES
       glDebugMessageCallbackKHR(gl_debug_cb, gl);
       glDebugMessageControlKHR(GL_DONT_CARE, GL_DONT_CARE, GL_DONT_CARE, 0, NULL, GL_TRUE);
       glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS_KHR);


### PR DESCRIPTION
These ifdef's apply GLES3 as well, not just GLES2