### PR TITLE
Screenshot with gamename

### DIFF
--- a/libretro-common/file/file_path.c
+++ b/libretro-common/file/file_path.c
@@ -439,13 +439,13 @@ void fill_dated_filename(char *out_filename,
 void fill_str_dated_filename(char *out_filename,
       const char *in_str, const char *ext, size_t size)
 {
-   char format[PATH_MAX_LENGTH] = {0};
+   char format[256] = {0};
    time_t cur_time;
    time(&cur_time);
 
-   snprintf(format, sizeof(format),
-         "%s-%%y%%m%%d-%%H%%M%%S.", in_str);
-   strftime(out_filename, size, format, localtime(&cur_time));
+   strncpy(out_filename, in_str, size);
+   strftime(format, sizeof(format), "-%y%m%d-%H%M%S.", localtime(&cur_time));
+   strlcat(out_filename, format, size);
    strlcat(out_filename, ext, size);
 }
 

--- a/libretro-common/file/file_path.c
+++ b/libretro-common/file/file_path.c
@@ -415,8 +415,7 @@ void fill_pathname_parent_dir(char *out_dir,
 void fill_dated_filename(char *out_filename,
       const char *ext, size_t size)
 {
-   time_t cur_time;
-   time(&cur_time);
+   time_t cur_time = time(NULL);
 
    strftime(out_filename, size,
          "RetroArch-%m%d-%H%M%S.", localtime(&cur_time));
@@ -440,11 +439,10 @@ void fill_str_dated_filename(char *out_filename,
       const char *in_str, const char *ext, size_t size)
 {
    char format[256] = {0};
-   time_t cur_time;
-   time(&cur_time);
+   time_t cur_time = time(NULL);
 
-   strncpy(out_filename, in_str, size);
    strftime(format, sizeof(format), "-%y%m%d-%H%M%S.", localtime(&cur_time));
+   strlcpy(out_filename, in_str, size);
    strlcat(out_filename, format, size);
    strlcat(out_filename, ext, size);
 }

--- a/libretro-common/file/file_path.c
+++ b/libretro-common/file/file_path.c
@@ -424,6 +424,32 @@ void fill_dated_filename(char *out_filename,
 }
 
 /**
+ * fill_str_dated_filename:
+ * @out_filename       : output filename
+ * @in_str             : input string
+ * @ext                : extension of output filename
+ * @size               : buffer size of output filename
+ *
+ * Creates a 'dated' filename prefixed by the string @in_str, and
+ * concatenates extension (@ext) to it.
+ *
+ * E.g.:
+ * out_filename = "RetroArch-{year}{month}{day}-{Hour}{Minute}{Second}.{@ext}"
+ **/
+void fill_str_dated_filename(char *out_filename,
+      const char *in_str, const char *ext, size_t size)
+{
+   char format[PATH_MAX_LENGTH] = {0};
+   time_t cur_time;
+   time(&cur_time);
+
+   snprintf(format, sizeof(format),
+         "%s-%%y%%m%%d-%%H%%M%%S.", in_str);
+   strftime(out_filename, size, format, localtime(&cur_time));
+   strlcat(out_filename, ext, size);
+}
+
+/**
  * path_basedir:
  * @path               : path
  *

--- a/libretro-common/include/file/file_path.h
+++ b/libretro-common/include/file/file_path.h
@@ -195,6 +195,22 @@ void fill_dated_filename(char *out_filename,
       const char *ext, size_t size);
 
 /**
+ * fill_str_dated_filename:
+ * @out_filename       : output filename
+ * @in_str             : input string
+ * @ext                : extension of output filename
+ * @size               : buffer size of output filename
+ *
+ * Creates a 'dated' filename prefixed by the string @in_str, and
+ * concatenates extension (@ext) to it.
+ *
+ * E.g.:
+ * out_filename = "RetroArch-{year}{month}{day}-{Hour}{Minute}{Second}.{@ext}"
+ **/
+void fill_str_dated_filename(char *out_filename,
+      const char *in_str, const char *ext, size_t size);
+
+/**
  * fill_pathname_noext:
  * @out_path           : output path
  * @in_path            : input  path

--- a/tasks/task_screenshot.c
+++ b/tasks/task_screenshot.c
@@ -78,14 +78,14 @@ static bool screenshot_dump(
 
    if (settings->auto_screenshot_filename)
    {
-      fill_dated_filename(shotname, IMG_EXT, sizeof(shotname));
-      fill_pathname_join(filename, folder, shotname, sizeof(filename));
+      fill_str_dated_filename(shotname, path_basename(global_name_base),
+            IMG_EXT, sizeof(shotname));
    }
    else
    {
       snprintf(shotname, sizeof(shotname),"%s.png", path_basename(global_name_base));
-      fill_pathname_join(filename, folder, shotname, sizeof(filename));
    }
+   fill_pathname_join(filename, folder, shotname, sizeof(filename));
 
 #ifdef _XBOX1
    d3d_video_t *d3d = (d3d_video_t*)video_driver_get_ptr(true);


### PR DESCRIPTION
I would like to take screenshots named "Game Name-yymmdd-hhmmss.png" and I saw [in this forum post](http://libretro.com/forums/showthread.php?t=2112&p=18926&viewfull=1#post18926) that the hunterk and his libretro fellows agree with this filename scheme.

What I did here:
1. created the `fill_str_dated_filename()` function in the `libretro-common/file/file_path.c`. It's pretty similar to the `fill_dated_filename()`, but it requires a string to prefix the timestamp (BTW: the timestamp is "yymmdd-hhmmss", eg: "160821-082115").
2. added the function prototype in `libretro-common/include/file/file_path.h`
3. changed the `tasks/task_screenshot.c` to call the `fill_str_dated_filename()` instead of `fill_dated_filename()` and pass the game name to prefix the timestamp.

Tested here with ROMs with some "strange" characters and it worked really fine (just like the savestates do). Example: a screenshot from the NES `Mike Tyson's Punch-Out!! (USA).zip` became `Mike Tyson's Punch-Out!! (USA)-160819-073423.png`.