### PR TITLE
Allow GLES2 app to use GLES3 core

### DIFF
--- a/dynamic.c
+++ b/dynamic.c
@@ -1137,9 +1137,7 @@ bool rarch_environment_cb(unsigned cmd, void *data)
 
 #if (defined(HAVE_OPENGLES2) || defined(HAVE_OPENGLES3))
             case RETRO_HW_CONTEXT_OPENGLES2:
-#ifdef HAVE_OPENGLES3
             case RETRO_HW_CONTEXT_OPENGLES3:
-#endif
                RARCH_LOG("Requesting OpenGLES%u context.\n",
                      cb->context_type == RETRO_HW_CONTEXT_OPENGLES2 ? 2 : 3);
                break;


### PR DESCRIPTION
The Android app is a GLES2 application (it doesn't have HAVE_OPENGLES3 set when it is compiled). However, it is possible to use the GLES2 Android App to launch GLES3 cores, if the phone supports it. This allows cores to set RETRO_HW_CONTEXT_OPENGLES3 and have the Android app respect that, without having to compile the Android app for GLES3.