### PR TITLE
Allow setting --with-bin_dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,13 +167,13 @@ $(OBJDIR)/%.o: %.rc $(HEADERS)
 
 install: $(TARGET)
 	rm -f $(OBJDIR)/git_version.o
-	mkdir -p $(DESTDIR)$(PREFIX)/bin 2>/dev/null || /bin/true
+	mkdir -p $(DESTDIR)$(BIN_DIR)/ 2>/dev/null || /bin/true
 	mkdir -p $(DESTDIR)$(GLOBAL_CONFIG_DIR) 2>/dev/null || /bin/true
 	mkdir -p $(DESTDIR)$(PREFIX)/share/applications 2>/dev/null || /bin/true
 	mkdir -p $(DESTDIR)$(MAN_DIR)/man6 2>/dev/null || /bin/true
 	mkdir -p $(DESTDIR)$(PREFIX)/share/pixmaps 2>/dev/null || /bin/true
-	install -m755 $(TARGET) $(DESTDIR)$(PREFIX)/bin 
-	install -m755 tools/cg2glsl.py $(DESTDIR)$(PREFIX)/bin/retroarch-cg2glsl
+	install -m755 $(TARGET) $(DESTDIR)$(BIN_DIR) 
+	install -m755 tools/cg2glsl.py $(DESTDIR)$(BIN_DIR)/retroarch-cg2glsl
 	install -m644 retroarch.cfg $(DESTDIR)$(GLOBAL_CONFIG_DIR)/retroarch.cfg
 	install -m644 retroarch.desktop $(DESTDIR)$(PREFIX)/share/applications
 	install -m644 docs/retroarch.6 $(DESTDIR)$(MAN_DIR)/man6
@@ -181,8 +181,8 @@ install: $(TARGET)
 	install -m644 media/retroarch.svg $(DESTDIR)$(PREFIX)/share/pixmaps
 
 uninstall:
-	rm -f $(DESTDIR)$(PREFIX)/bin/retroarch
-	rm -f $(DESTDIR)$(PREFIX)/bin/retroarch-cg2glsl
+	rm -f $(DESTDIR)$(BIN_DIR/retroarch
+	rm -f $(DESTDIR)$(BIN_DIR)/retroarch-cg2glsl
 	rm -f $(DESTDIR)$(GLOBAL_CONFIG_DIR)/retroarch.cfg
 	rm -f $(DESTDIR)$(PREFIX)/share/applications/retroarch.desktop
 	rm -f $(DESTDIR)$(MAN_DIR)/man6/retroarch.6

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -130,6 +130,12 @@ fi
    add_define_make libretro "$LIBRETRO"
 }
 
+if [ "$BIN_DIR" ]; then
+   add_define_make BIN_DIR "$BIN_DIR"
+else
+   add_define_make BIN_DIR "${PREFIX}/bin"
+fi
+
 if [ "$MAN_DIR" ]; then
    add_define_make MAN_DIR "$MAN_DIR"
 else

--- a/qb/config.params.sh
+++ b/qb/config.params.sh
@@ -13,6 +13,7 @@ HAVE_LIBUSB=auto           # Libusb HID support
 C89_LIBUSB=no
 HAVE_UDEV=auto             # Udev/Evdev gamepad support
 HAVE_LIBRETRO=             # Libretro library used
+HAVE_BIN_DIR=              # Binary install directory
 HAVE_MAN_DIR=              # Manpage install directory
 HAVE_GLES_LIBS=            # Link flags for custom GLES library
 HAVE_GLES_CFLAGS=          # C-flags for custom GLES library


### PR DESCRIPTION
This allows setting the binary installation directory, for example to `/usr/games` which is standard in Slackware for game binaries.