### PR TITLE
Allow disabling downloading assets in the online updater

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -2962,11 +2962,13 @@ static int menu_displaylist_parse_options(
          MENU_ENUM_LABEL_UPDATE_CORE_INFO_FILES,
          MENU_SETTING_ACTION, 0, 0);
 
+#ifdef HAVE_UPDATE_ASSETS
    menu_entries_append_enum(info->list,
          msg_hash_to_str(MENU_ENUM_LABEL_VALUE_UPDATE_ASSETS),
          msg_hash_to_str(MENU_ENUM_LABEL_UPDATE_ASSETS),
          MENU_ENUM_LABEL_UPDATE_ASSETS,
          MENU_SETTING_ACTION, 0, 0);
+#endif
 
    menu_entries_append_enum(info->list,
          msg_hash_to_str(MENU_ENUM_LABEL_VALUE_UPDATE_AUTOCONFIG_PROFILES),

--- a/qb/config.params.sh
+++ b/qb/config.params.sh
@@ -71,6 +71,7 @@ HAVE_SSE=no                # x86 SSE optimizations (SSE, SSE2)
 HAVE_FLOATHARD=no          # Force hard float ABI (for ARM)
 HAVE_FLOATSOFTFP=no        # Force soft float ABI (for ARM)
 HAVE_7ZIP=yes              # Compile in 7z support
+HAVE_UPDATE_ASSETS=yes     # Disable downloading assets with online updater
 HAVE_PRESERVE_DYLIB=no     # Enable dlclose() for Valgrind support
 HAVE_PARPORT=auto          # Parallel port joypad support
 HAVE_IMAGEVIEWER=yes       # Built-in image viewer support.


### PR DESCRIPTION
As xmb is now the default menu driver including the assets with RetroArch is useful for it to work out of the box, but including it in the RetroArch repo is not the best idea. So this problem falls on downstream package maintainers where its useful to specify the assets directory to a non-writable system directory when installed on a distro like Slackware. 

So the downloading the assets with the online updater may not necessarily work and this commit will optionally hide it for when RetroArch is installed with the assets. Downloading the assets with the online updater will be on by default and only disabled if `--disable-update_assets` is used during compile time.

This was inspired after reading issue https://github.com/libretro/RetroArch/issues/3433.

Edit: Clarity