### PR TITLE
Move 'Start Remote RetroPad' for both glui and xmb to match rgui

### DIFF
--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -1626,9 +1626,6 @@ static int mui_list_push(void *data, void *userdata,
          entry.enum_idx      = MENU_ENUM_LABEL_START_VIDEO_PROCESSOR;
          menu_displaylist_ctl(DISPLAYLIST_SETTING_ENUM, &entry);
 
-         entry.enum_idx      = MENU_ENUM_LABEL_START_NET_RETROPAD;
-         menu_displaylist_ctl(DISPLAYLIST_SETTING_ENUM, &entry);
-
 #ifndef HAVE_DYNAMIC
          if (frontend_driver_has_fork())
 #endif
@@ -1665,6 +1662,9 @@ static int mui_list_push(void *data, void *userdata,
 
          entry.enum_idx      = MENU_ENUM_LABEL_SAVE_NEW_CONFIG;
          menu_displaylist_ctl(DISPLAYLIST_SETTING_ENUM, &entry);
+
+         entry.enum_idx      = MENU_ENUM_LABEL_START_NET_RETROPAD;
+         menu_displaylist_ctl(DISPLAYLIST_SETTING_ENUM, &entry); 
 
          entry.enum_idx      = MENU_ENUM_LABEL_HELP_LIST;
          menu_displaylist_ctl(DISPLAYLIST_SETTING_ENUM, &entry);

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -3326,9 +3326,6 @@ static int xmb_list_push(void *data, void *userdata,
          entry.enum_idx      = MENU_ENUM_LABEL_START_VIDEO_PROCESSOR;
          menu_displaylist_ctl(DISPLAYLIST_SETTING_ENUM, &entry);
 
-         entry.enum_idx      = MENU_ENUM_LABEL_START_NET_RETROPAD;
-         menu_displaylist_ctl(DISPLAYLIST_SETTING_ENUM, &entry);
-
 #ifndef HAVE_DYNAMIC
          if (frontend_driver_has_fork())
 #endif
@@ -3359,6 +3356,9 @@ static int xmb_list_push(void *data, void *userdata,
          menu_displaylist_ctl(DISPLAYLIST_SETTING_ENUM, &entry);
 
          entry.enum_idx      = MENU_ENUM_LABEL_SAVE_NEW_CONFIG;
+         menu_displaylist_ctl(DISPLAYLIST_SETTING_ENUM, &entry);
+
+         entry.enum_idx      = MENU_ENUM_LABEL_START_NET_RETROPAD;
          menu_displaylist_ctl(DISPLAYLIST_SETTING_ENUM, &entry);
 
          entry.enum_idx      = MENU_ENUM_LABEL_HELP_LIST;


### PR DESCRIPTION
This moves `Start Remote RetroPad` above `Help` as it was with `rgui` for both `glui` and `xmb`. `Load Core` is a more useful default option, especially for first time users.