### PR TITLE
Install assets better

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,17 +181,17 @@ install: $(TARGET)
 	install -m644 media/retroarch.svg $(DESTDIR)$(PREFIX)/share/pixmaps
 	@if test -d media/assets; then \
 		echo "Installing media assets..."; \
-		mkdir -p $(DESTDIR)$(PREFIX)/share/retroarch; \
-		mkdir -p $(DESTDIR)$(PREFIX)/share/retroarch/assets; \
-		mkdir -p $(DESTDIR)$(PREFIX)/share/retroarch/assets/xmb; \
-		mkdir -p $(DESTDIR)$(PREFIX)/share/retroarch/assets/glui; \
-		cp -r media/assets/xmb/  $(DESTDIR)$(PREFIX)/share/retroarch/assets; \
-		cp -r media/assets/glui/ $(DESTDIR)$(PREFIX)/share/retroarch/assets; \
+		mkdir -p $(DESTDIR)$(ASSETS_DIR)/retroarch; \
+		mkdir -p $(DESTDIR)$(ASSETS_DIR)/share/retroarch/assets; \
+		mkdir -p $(DESTDIR)$(ASSETS_DIR)/share/retroarch/assets/xmb; \
+		mkdir -p $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/glui; \
+		cp -r media/assets/xmb/  $(DESTDIR)$(ASSETS_DIR)/retroarch/assets; \
+		cp -r media/assets/glui/ $(DESTDIR)$(ASSETS_DIR)/retroarch/assets; \
 		echo "Removing unneeded source image files.."; \
-		rm -rf $(DESTDIR)$(PREFIX)/share/retroarch/assets/xmb/flatui/src; \
-		rm -rf $(DESTDIR)$(PREFIX)/share/retroarch/assets/xmb/monochrome/src; \
-		rm -rf $(DESTDIR)$(PREFIX)/share/retroarch/assets/xmb/retroactive/src; \
-		rm -rf $(DESTDIR)$(PREFIX)/share/retroarch/assets/xmb/retroactive_marked/src; \
+		rm -rf $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb/flatui/src; \
+		rm -rf $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb/monochrome/src; \
+		rm -rf $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb/retroactive/src; \
+		rm -rf $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb/retroactive_marked/src; \
 		echo "Asset copying done."; \
 	fi
 
@@ -203,7 +203,7 @@ uninstall:
 	rm -f $(DESTDIR)$(MAN_DIR)/man6/retroarch.6
 	rm -f $(DESTDIR)$(MAN_DIR)/man6/retroarch-cg2glsl.6
 	rm -f $(DESTDIR)$(PREFIX)/share/pixmaps/retroarch.svg
-	rm -rf $(DESTDIR)$(PREFIX)/share/retroarch/assets
+	rm -rf $(DESTDIR)$(ASSETS_DIR)/retroarch/assets
 
 clean:
 	rm -rf $(OBJDIR)

--- a/Makefile
+++ b/Makefile
@@ -181,17 +181,17 @@ install: $(TARGET)
 	install -m644 media/retroarch.svg $(DESTDIR)$(PREFIX)/share/pixmaps
 	@if test -d media/assets; then \
 		echo "Installing media assets..."; \
-		mkdir -p $(DESTDIR)$(PREFIX)/share/applications/retroarch; \
-		mkdir -p $(DESTDIR)$(PREFIX)/share/applications/retroarch/assets; \
-		mkdir -p $(DESTDIR)$(PREFIX)/share/applications/retroarch/assets/xmb; \
-		mkdir -p $(DESTDIR)$(PREFIX)/share/applications/retroarch/assets/glui; \
-		cp -r media/assets/xmb/  $(DESTDIR)$(PREFIX)/share/applications/retroarch/assets; \
-		cp -r media/assets/glui/ $(DESTDIR)$(PREFIX)/share/applications/retroarch/assets; \
+		mkdir -p $(DESTDIR)$(PREFIX)/share/retroarch; \
+		mkdir -p $(DESTDIR)$(PREFIX)/share/retroarch/assets; \
+		mkdir -p $(DESTDIR)$(PREFIX)/share/retroarch/assets/xmb; \
+		mkdir -p $(DESTDIR)$(PREFIX)/share/retroarch/assets/glui; \
+		cp -r media/assets/xmb/  $(DESTDIR)$(PREFIX)/share/retroarch/assets; \
+		cp -r media/assets/glui/ $(DESTDIR)$(PREFIX)/share/retroarch/assets; \
 		echo "Removing unneeded source image files.."; \
-		rm -rf $(DESTDIR)$(PREFIX)/share/applications/retroarch/assets/xmb/flatui/src; \
-		rm -rf $(DESTDIR)$(PREFIX)/share/applications/retroarch/assets/xmb/monochrome/src; \
-		rm -rf $(DESTDIR)$(PREFIX)/share/applications/retroarch/assets/xmb/retroactive/src; \
-		rm -rf $(DESTDIR)$(PREFIX)/share/applications/retroarch/assets/xmb/retroactive_marked/src; \
+		rm -rf $(DESTDIR)$(PREFIX)/share/retroarch/assets/xmb/flatui/src; \
+		rm -rf $(DESTDIR)$(PREFIX)/share/retroarch/assets/xmb/monochrome/src; \
+		rm -rf $(DESTDIR)$(PREFIX)/share/retroarch/assets/xmb/retroactive/src; \
+		rm -rf $(DESTDIR)$(PREFIX)/share/retroarch/assets/xmb/retroactive_marked/src; \
 		echo "Asset copying done."; \
 	fi
 
@@ -203,6 +203,7 @@ uninstall:
 	rm -f $(DESTDIR)$(MAN_DIR)/man6/retroarch.6
 	rm -f $(DESTDIR)$(MAN_DIR)/man6/retroarch-cg2glsl.6
 	rm -f $(DESTDIR)$(PREFIX)/share/pixmaps/retroarch.svg
+	rm -rf $(DESTDIR)$(PREFIX)/share/retroarch/assets
 
 clean:
 	rm -rf $(OBJDIR)

--- a/frontend/drivers/platform_linux.c
+++ b/frontend/drivers/platform_linux.c
@@ -1711,11 +1711,17 @@ static void frontend_linux_get_env(int *argc,
    fill_pathname_join(g_defaults.dir.autoconfig, base_path,
          "autoconfig", sizeof(g_defaults.dir.autoconfig));
 
-   if (path_is_directory("/usr/local/share/applications/retroarch/assets"))
-      fill_pathname_join(g_defaults.dir.assets, "/usr/local/share/applications/retroarch",
+   if (path_is_directory("/usr/local/share/retroarch/assets"))
+      fill_pathname_join(g_defaults.dir.assets, "/usr/local/share/retroarch",
             "assets", sizeof(g_defaults.dir.assets));
-   else if (path_is_directory("/usr/share/applications/retroarch/assets"))
-      fill_pathname_join(g_defaults.dir.assets, "/usr/share/applications/retroarch",
+   else if (path_is_directory("/usr/share/retroarch/assets"))
+      fill_pathname_join(g_defaults.dir.assets, "/usr/share/retroarch",
+            "assets", sizeof(g_defaults.dir.assets));
+   else if (path_is_directory("/usr/local/share/games/retroarch/assets"))
+      fill_pathname_join(g_defaults.dir.assets, "/usr/local/share/games/retroarch",
+            "assets", sizeof(g_defaults.dir.assets));
+   else if (path_is_directory("/usr/share/games/retroarch/assets"))
+      fill_pathname_join(g_defaults.dir.assets, "/usr/share/games/retroarch",
             "assets", sizeof(g_defaults.dir.assets));
    else
       fill_pathname_join(g_defaults.dir.assets, base_path,

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -131,7 +131,6 @@ fi
 }
 
 if [ "$ASSETS_DIR" ]; then
-
    add_define_make ASSETS_DIR "$ASSETS_DIR"
 else
    add_define_make ASSETS_DIR "${PREFIX}/share"

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -130,6 +130,13 @@ fi
    add_define_make libretro "$LIBRETRO"
 }
 
+if [ "$ASSETS_DIR" ]; then
+
+   add_define_make ASSETS_DIR "$ASSETS_DIR"
+else
+   add_define_make ASSETS_DIR "${PREFIX}/share"
+fi
+
 if [ "$BIN_DIR" ]; then
    add_define_make BIN_DIR "$BIN_DIR"
 else

--- a/qb/config.params.sh
+++ b/qb/config.params.sh
@@ -13,6 +13,7 @@ HAVE_LIBUSB=auto           # Libusb HID support
 C89_LIBUSB=no
 HAVE_UDEV=auto             # Udev/Evdev gamepad support
 HAVE_LIBRETRO=             # Libretro library used
+HAVE_ASSETS_DIR=           # Assets install directory
 HAVE_BIN_DIR=              # Binary install directory
 HAVE_MAN_DIR=              # Manpage install directory
 HAVE_GLES_LIBS=            # Link flags for custom GLES library


### PR DESCRIPTION
`share/applications` is for desktop files in slackware, this should not be the default location so this will install them in just `share`. It will also allow setting the assets install directory with a configuration option via `--with-assets_dir` as well as allow uninstalling them if `make uninstall` is used.

Lastly this adds a few more potential places to look for assets before defaulting to the user directory, such as `/usr/local/share/games/retroarch/assets` and `/usr/share/games/retroarch/assets`.