### PR TITLE
Add Save Overrides to XMB and GLUI Main Menu

### DIFF
--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -1660,6 +1660,12 @@ static int mui_list_push(void *data, void *userdata,
          entry.enum_idx      = MENU_ENUM_LABEL_SAVE_CURRENT_CONFIG;
          menu_displaylist_ctl(DISPLAYLIST_SETTING_ENUM, &entry);
 
+         entry.enum_idx      = MENU_ENUM_LABEL_SAVE_CURRENT_CONFIG_OVERRIDE_CORE;
+         menu_displaylist_ctl(DISPLAYLIST_SETTING_ENUM, &entry);
+
+         entry.enum_idx      = MENU_ENUM_LABEL_SAVE_CURRENT_CONFIG_OVERRIDE_GAME;
+         menu_displaylist_ctl(DISPLAYLIST_SETTING_ENUM, &entry);
+
          entry.enum_idx      = MENU_ENUM_LABEL_SAVE_NEW_CONFIG;
          menu_displaylist_ctl(DISPLAYLIST_SETTING_ENUM, &entry);
 

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -3355,6 +3355,12 @@ static int xmb_list_push(void *data, void *userdata,
          entry.enum_idx      = MENU_ENUM_LABEL_SAVE_CURRENT_CONFIG;
          menu_displaylist_ctl(DISPLAYLIST_SETTING_ENUM, &entry);
 
+         entry.enum_idx      = MENU_ENUM_LABEL_SAVE_CURRENT_CONFIG_OVERRIDE_CORE;
+         menu_displaylist_ctl(DISPLAYLIST_SETTING_ENUM, &entry);
+
+         entry.enum_idx      = MENU_ENUM_LABEL_SAVE_CURRENT_CONFIG_OVERRIDE_GAME;
+         menu_displaylist_ctl(DISPLAYLIST_SETTING_ENUM, &entry);
+
          entry.enum_idx      = MENU_ENUM_LABEL_SAVE_NEW_CONFIG;
          menu_displaylist_ctl(DISPLAYLIST_SETTING_ENUM, &entry);
 


### PR DESCRIPTION
The new menu options were only showing up in RGUI