### PR TITLE
EGL_DEPTH_SIZE should be set

### DIFF
--- a/gfx/drivers_context/android_ctx.c
+++ b/gfx/drivers_context/android_ctx.c
@@ -114,6 +114,7 @@ static void *android_gfx_ctx_init(void *video_driver)
       EGL_GREEN_SIZE, 8,
       EGL_RED_SIZE, 8,
       EGL_ALPHA_SIZE, 8,
+      EGL_DEPTH_SIZE, 16,
       EGL_NONE
    };
 #endif


### PR DESCRIPTION
EGL_DEPTH_SIZE needs to be set in order to have an FBO with a depth buffer. Some drivers aren't as strict about this but many are.