### PR TITLE
make GLX context current when managing font textures with threaded video

### DIFF
--- a/gfx/drivers_context/android_ctx.c
+++ b/gfx/drivers_context/android_ctx.c
@@ -625,4 +625,5 @@ const gfx_ctx_driver_t gfx_ctx_android = {
 #else
    NULL
 #endif
+   ,NULL
 };

--- a/gfx/drivers_context/khr_display_ctx.c
+++ b/gfx/drivers_context/khr_display_ctx.c
@@ -258,5 +258,6 @@ const gfx_ctx_driver_t gfx_ctx_khr_display = {
    gfx_ctx_khr_display_set_flags,
    NULL, 
    gfx_ctx_khr_display_get_context_data,
+   NULL
 };
 

--- a/gfx/drivers_context/wayland_ctx.c
+++ b/gfx/drivers_context/wayland_ctx.c
@@ -1177,4 +1177,5 @@ const gfx_ctx_driver_t gfx_ctx_wayland = {
 #else
    NULL
 #endif
+   ,NULL
 };

--- a/gfx/drivers_context/wgl_ctx.cpp
+++ b/gfx/drivers_context/wgl_ctx.cpp
@@ -705,5 +705,6 @@ const gfx_ctx_driver_t gfx_ctx_wgl = {
 #else
    NULL,
 #endif
+   NULL
 };
 

--- a/gfx/video_context_driver.c
+++ b/gfx/video_context_driver.c
@@ -328,6 +328,14 @@ bool video_context_driver_bind_hw_render(bool *enable)
    return true;
 }
 
+void video_context_driver_make_current(bool release)
+{
+   if (!current_video_context || !current_video_context->make_current)
+      return;
+
+   current_video_context->make_current(release);
+}
+
 bool video_context_driver_set(const gfx_ctx_driver_t *data)
 {
    if (!data)

--- a/gfx/video_context_driver.h
+++ b/gfx/video_context_driver.h
@@ -163,6 +163,10 @@ typedef struct gfx_ctx_driver
     * This is mostly relevant for graphics APIs such as Vulkan
     * which do not have global context state. */
    void *(*get_context_data)(void *data);
+
+   /* Optional. Makes driver context (only GLX right now)
+    * active for this thread. */
+   void (*make_current)(bool release);
 } gfx_ctx_driver_t;
 
 typedef struct gfx_ctx_flags
@@ -279,6 +283,8 @@ bool video_context_driver_get_video_output_prev(void);
 bool video_context_driver_get_video_output_next(void);
 
 bool video_context_driver_bind_hw_render(bool *enable);
+
+void video_context_driver_make_current(bool restore);
 
 bool video_context_driver_set(const gfx_ctx_driver_t *data);
 


### PR DESCRIPTION
This fixes a crash on startup when running RetroArch under optirun on Linux with the XMB or GLUI menu drivers and threaded video enabled. glDeleteTextures() would segfault because the thread it is run under is not the current one for the GLX context.