### PR TITLE
emscripten: Disable default browser keys

### DIFF
--- a/pkg/emscripten/webplayer.js
+++ b/pkg/emscripten/webplayer.js
@@ -230,5 +230,15 @@ $(function() {
   $.getScript(core + '_libretro.js', function () {
     // Activate the Start RetroArch button.
     $('#btnStart').removeClass('disabled');
+
+    /**
+     * Attempt to disable some default browser keys.
+     */
+    window.addEventListener('keydown', function(e) {
+      // Space key, arrows, and F1.
+      if([32, 37, 38, 39, 40, 112].indexOf(e.keyCode) > -1) {
+        e.preventDefault();
+      }
+    }, false);
   });
 });


### PR DESCRIPTION
This will attempt to disable the default action of some of the browser hotkeys.

Space bar, arrows and F1. These should be used in RetroArch rather then the default browser window.