### PR TITLE
Add safe homebrew flag

### DIFF
--- a/Makefile.griffin
+++ b/Makefile.griffin
@@ -408,7 +408,7 @@ ifneq ($(DEBUG), 1)
 	arm-vita-eabi-strip -g $<
 endif
 	vita-elf-create $< $@
-	vita-make-fself $@ eboot.bin
+	vita-make-fself -s $@ eboot.bin
 
 %.elf32: %.elf
 ifeq ($(platform), xenon360)

--- a/dist-scripts/dist-cores.sh
+++ b/dist-scripts/dist-cores.sh
@@ -210,7 +210,7 @@ for f in `ls -v *_${platform}.${EXT}`; do
       mkdir -p ../pkg/${platform}/${name}_libretro.vpk/vpk/sce_sys/
       mkdir -p ../pkg/${platform}/${name}_libretro.vpk/vpk/sce_sys/livearea
       mkdir -p ../pkg/${platform}/${name}_libretro.vpk/vpk/sce_sys/livearea/contents
-      vita-make-fself ../retroarch_${platform}.velf ../pkg/${platform}/${name}_libretro.vpk/vpk/eboot.bin
+      vita-make-fself -s ../retroarch_${platform}.velf ../pkg/${platform}/${name}_libretro.vpk/vpk/eboot.bin
       vita-mksfoex -s TITLE_ID=RETR${COUNTER_ID} "RetroArch ${name}" ../pkg/${platform}/${name}_libretro.vpk/vpk/sce_sys/param.sfo
       cp ../pkg/${platform}/assets/ICON0.PNG ../pkg/${platform}/${name}_libretro.vpk/vpk/sce_sys/icon0.png
       cp ../pkg/${platform}/assets/livearea/contents/bg.png ../pkg/${platform}/${name}_libretro.vpk/vpk/sce_sys/livearea/contents/bg.png


### PR DESCRIPTION
Added safe homebrew flag as described in https://yifan.lu/2016/08/27/henkaku-update/ to skip warnings when installing the RetroArch vpk files via Molecular/VitaShell.