### PR TITLE
Fix build on Raspberry Pi (3)

### DIFF
--- a/gfx/drivers/vg.c
+++ b/gfx/drivers/vg.c
@@ -35,6 +35,7 @@
 #include "../../content.h"
 #include "../../runloop.h"
 #include "../../verbosity.h"
+#include "../../configuration.h"
 
 typedef struct
 {


### PR DESCRIPTION
Fixes this build error: http://pastebin.com/nBMjcrRB

I'm not sure why it's suddenly trying to build the vg driver as it looks like this error would have happened before. Maybe some build rule has changed recently. Anyway, this builds now!