### PR TITLE
Change binary name for DEBUG builds on windows only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,9 @@ endif
 retroarch: $(RARCH_OBJ)
 	@$(if $(Q), $(shell echo echo LD $@),)
 ifeq ($(DEBUG), 1)
+   ifeq ($(findstring Win32,$(OS)),)
 		$(Q)$(LINK) -o $@_debug $(RARCH_OBJ) $(LIBS) $(LDFLAGS) $(LIBRARY_DIRS)
+endif
 else	
 		$(Q)$(LINK) -o $@ $(RARCH_OBJ) $(LIBS) $(LDFLAGS) $(LIBRARY_DIRS)
 endif


### PR DESCRIPTION
Changing the name to `retroarch-debug` is not at all useful on linux and broke the `make install` target. This should make the name change for windows only for which it was requested for.