### PR TITLE
WIP: Fixes #2026 Screensaver suspend on Linux via Dbus

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -612,6 +612,11 @@ ifeq ($(HAVE_XKBCOMMON), 1)
    LIBS += $(XKBCOMMON_LIBS)
 endif
 
+ifeq ($(HAVE_DBUS), 1)
+	LIBS += $(DBUS_LIBS)
+	CFLAGS += $(DBUS_CFLAGS)
+endif
+
 ifeq ($(HAVE_UDEV), 1)
    DEFINES += $(UDEV_CFLAGS)
    LIBS += $(UDEV_LIBS)

--- a/gfx/common/x11_common.h
+++ b/gfx/common/x11_common.h
@@ -44,10 +44,6 @@ void x11_save_last_used_monitor(Window win);
 void x11_show_mouse(Display *dpy, Window win, bool state);
 void x11_windowed_fullscreen(Display *dpy, Window win);
 void x11_suspend_screensaver(Window win, bool enable);
-void x11_suspend_screensaver_xdg_screensaver(Window win, bool enable);
-#ifdef HAVE_DBUS
-void x11_suspend_screensaver_dbus(bool enable);
-#endif
 bool x11_enter_fullscreen(Display *dpy, unsigned width,
       unsigned height, XF86VidModeModeInfo *desktop_mode);
 

--- a/gfx/common/x11_common.h
+++ b/gfx/common/x11_common.h
@@ -44,6 +44,10 @@ void x11_save_last_used_monitor(Window win);
 void x11_show_mouse(Display *dpy, Window win, bool state);
 void x11_windowed_fullscreen(Display *dpy, Window win);
 void x11_suspend_screensaver(Window win, bool enable);
+void x11_suspend_screensaver_xdg_screensaver(Window win, bool enable);
+#ifdef HAVE_DBUS
+void x11_suspend_screensaver_dbus(bool enable);
+#endif
 bool x11_enter_fullscreen(Display *dpy, unsigned width,
       unsigned height, XF86VidModeModeInfo *desktop_mode);
 

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -382,6 +382,7 @@ check_pkgconf XCB xcb
 check_pkgconf WAYLAND wayland-egl
 
 check_pkgconf XKBCOMMON xkbcommon 0.3.2
+check_pkgconf DBUS dbus-1
 check_pkgconf XEXT xext
 check_pkgconf XF86VM xxf86vm
 check_pkgconf XINERAMA xinerama


### PR DESCRIPTION
One some systems (tested with Gnome 3 on Arch Linux) the current method
of using `xdg-screensaver` to suspend the screensaver does not work.
Instead, using DBus to issue an `Inhibit` request is recommended.

The request returns a cookie that needs to be re-used to un-inhibit the
screensaver later. Additionally if the DBus connection is closed the
current inhibition is discarded. Thus, the DBus connection needs to stay
connected for the duration of the screenshot inhibition.

The code is heavily inspired from the [SDL 2.x
code](http://hg.libsdl.org/SDL/file/default/src/core/linux/SDL_dbus.c#l172).
I didn't call the SDL 2 code though since this it to fix the issue with
the GL driver, and I assume one would want to have screensaver inhibited
even when SDL 2 is not available (but GL is).

I've set "WIP" because:
* I haven't done C in a long time so my code is probably not great
* There's a dependency on DBus which I don't know is acceptable or
not
* I've put my code where I could to check it works, but `x11_common` may
not be the best place
* The code need and "init" and "deinit" kind of method as it needs to
initialise the DBus connection, and on deinit close it properly. I've
used `x11_connect` and `x11_window_destroy` but they don't sound like
the best choices.
* I'm a bit unclear as to what happens when "suspend screensaver" is
ticked on/off in the menu. This doesn't seem to call
`x11_suspend_screensaver` everytime, so I'm not sure if there's a hook
somewhere (as disabling screensaver suspend in the menu should cause a
DBus unhinibit request to be sent).
* Should I just call the SDL 2.x code (meaning that the GL driver would
depend on SDL 2.x at runtime)?

So, first of all are you ok with the approach, and if yes I'd gladly get
feedback about the code, how to architecture it and the best place to
put it.

Thanks!