### PR TITLE
(Emscripten) Remove unneeded Font Awesome JS file

### DIFF
--- a/pkg/emscripten/proto.html
+++ b/pkg/emscripten/proto.html
@@ -15,10 +15,7 @@
    <link rel="shortcut icon" href="media/icon_dark.ico" />
    
 </head>
-<body>
-   
-   <script src="https://use.fontawesome.com/bb20806e1e.js"></script>
-   
+<body>   
    <!--Navbar-->
    <nav class="navbar navbar-dark bg-primary">
 
@@ -150,7 +147,6 @@
    <script src="//cdnjs.cloudflare.com/ajax/libs/tether/1.3.4/js/tether.min.js"></script>
    <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0-alpha.3/js/bootstrap.min.js"></script>
    <script src="//cdnjs.cloudflare.com/ajax/libs/dropbox.js/0.10.2/dropbox.min.js"></script>
-   <script src="https://use.fontawesome.com/bb20806e1e.js"></script>
    <script src="analytics.js"></script>
    <script src="//wzrd.in/standalone/browserfs@0.6.1"></script>
    <script src="proto.js"></script>


### PR DESCRIPTION
We don't need the JavaScript files for Font Awesome, since we're using [Bootstrap's CDN for Font Awesome](https://www.bootstrapcdn.com/fontawesome/).