### PR TITLE
(Emscripten) Fix BrowserFS casing

### DIFF
--- a/pkg/emscripten/proto.js
+++ b/pkg/emscripten/proto.js
@@ -6,6 +6,7 @@
 var dropbox = false;
 var client = new Dropbox.Client({ key: "il6e10mfd7pgf8r" });
 var XFS;
+var BrowserFS = browserfs;
 
 var showError = function(error) {
   switch (error.status) {

--- a/pkg/emscripten/webplayer.js
+++ b/pkg/emscripten/webplayer.js
@@ -5,6 +5,7 @@
  */
 var dropbox = false;
 var client = new Dropbox.Client({ key: "il6e10mfd7pgf8r" });
+var BrowserFS = browserfs;
 
 var showError = function(error) {
   switch (error.status) {


### PR DESCRIPTION
BrowserifyCDN exports the name of the module as what you asked for. In this case, it exports `browserfs`, not `BrowserFS`.