### PR TITLE
Add fetching git submodules

### DIFF
--- a/fetch-submodules.sh
+++ b/fetch-submodules.sh
@@ -75,3 +75,5 @@ fetch_git "https://github.com/libretro/common-overlays.git" "media/overlays"
 fetch_git "https://github.com/libretro/retroarch-assets.git" "media/assets"
 fetch_git "https://github.com/libretro/retroarch-joypad-autoconfig.git" "media/autoconfig"
 fetch_git "https://github.com/libretro/libretro-database.git" "media/libretrodb"
+
+git submodule update --init

--- a/fetch-submodules.sh
+++ b/fetch-submodules.sh
@@ -76,4 +76,4 @@ fetch_git "https://github.com/libretro/retroarch-assets.git" "media/assets"
 fetch_git "https://github.com/libretro/retroarch-joypad-autoconfig.git" "media/autoconfig"
 fetch_git "https://github.com/libretro/libretro-database.git" "media/libretrodb"
 
-git submodule update --init
+git submodule update --init --recursive


### PR DESCRIPTION
As discussed in issue #3556 
This automates fetching KhronosGroup/glslang so we don't have to do it manually.