### PR TITLE
Serial Scanning Removal for disk CRC scanning.

### DIFF
--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -112,6 +112,32 @@ static int task_database_iterate_start(database_info_handle_t *db,
    return 0;
 }
 
+static int iso_get_serial(database_state_handle_t *db_state,
+      database_info_handle_t *db, const char *name, char* serial)
+{
+   int rv;
+   int32_t offset = 0;
+   const char* system_name = NULL;
+
+   if ((rv = detect_system(name, offset, &system_name)) < 0)
+      return rv;
+
+   if (string_is_equal(system_name, "psp"))
+   {
+      if (detect_psp_game(name, serial) == 0)
+         return 0;
+      RARCH_LOG("%s '%s'\n", msg_hash_to_str(MSG_FOUND_DISK_LABEL), serial);
+   }
+   else if (string_is_equal(system_name, "ps1"))
+   {
+      if (detect_ps1_game(name, serial) == 0)
+         return 0;
+      RARCH_LOG("%s '%s'\n", msg_hash_to_str(MSG_FOUND_DISK_LABEL), serial);
+   }
+
+   return 0;
+} 
+
 static bool file_get_crc(database_state_handle_t *db_state,
       const char *name, uint32_t *crc)
 {
@@ -155,6 +181,11 @@ static int task_database_iterate_playlist(
 #else
          break;
 #endif
+	 case FILE_TYPE_ISO:
+         db_state->serial[0] = '\0';
+         iso_get_serial(db_state, db, name, db_state->serial);
+         db->type = DATABASE_TYPE_SERIAL_LOOKUP;
+         break;
       case FILE_TYPE_LUTRO:
          db->type = DATABASE_TYPE_ITERATE_LUTRO;
          break;

--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -112,53 +112,6 @@ static int task_database_iterate_start(database_info_handle_t *db,
    return 0;
 }
 
-static int iso_get_serial(database_state_handle_t *db_state,
-      database_info_handle_t *db, const char *name, char* serial)
-{
-   int rv;
-   int32_t offset = 0;
-   const char* system_name = NULL;
-
-   if ((rv = detect_system(name, offset, &system_name)) < 0)
-      return rv;
-
-   if (string_is_equal(system_name, "psp"))
-   {
-      if (detect_psp_game(name, serial) == 0)
-         return 0;
-      RARCH_LOG("%s '%s'\n", msg_hash_to_str(MSG_FOUND_DISK_LABEL), serial);
-   }
-   else if (string_is_equal(system_name, "ps1"))
-   {
-      if (detect_ps1_game(name, serial) == 0)
-         return 0;
-      RARCH_LOG("%s '%s'\n", msg_hash_to_str(MSG_FOUND_DISK_LABEL), serial);
-   }
-
-   return 0;
-}
-
-static int cue_get_serial(database_state_handle_t *db_state,
-      database_info_handle_t *db, const char *name, char* serial)
-{
-   int32_t offset                   = 0;
-   char track_path[PATH_MAX_LENGTH] = {0};
-   int rv                           = find_first_data_track(name,
-         &offset, track_path, PATH_MAX_LENGTH);
-    
-   if (rv < 0)
-   {
-      RARCH_LOG("%s: %s\n",
-            msg_hash_to_str(MSG_COULD_NOT_FIND_VALID_DATA_TRACK),
-            strerror(-rv));
-      return rv;
-   }
-
-   RARCH_LOG("%s\n", msg_hash_to_str(MSG_READING_FIRST_DATA_TRACK));
-
-   return iso_get_serial(db_state, db, track_path, serial);
-}
-
 static bool file_get_crc(database_state_handle_t *db_state,
       const char *name, uint32_t *crc)
 {
@@ -202,16 +155,6 @@ static int task_database_iterate_playlist(
 #else
          break;
 #endif
-      case FILE_TYPE_CUE:
-         db_state->serial[0] = '\0';
-         cue_get_serial(db_state, db, name, db_state->serial);
-         db->type = DATABASE_TYPE_SERIAL_LOOKUP;
-         break;
-      case FILE_TYPE_ISO:
-         db_state->serial[0] = '\0';
-         iso_get_serial(db_state, db, name, db_state->serial);
-         db->type = DATABASE_TYPE_SERIAL_LOOKUP;
-         break;
       case FILE_TYPE_LUTRO:
          db->type = DATABASE_TYPE_ITERATE_LUTRO;
          break;

--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -112,32 +112,6 @@ static int task_database_iterate_start(database_info_handle_t *db,
    return 0;
 }
 
-static int iso_get_serial(database_state_handle_t *db_state,
-      database_info_handle_t *db, const char *name, char* serial)
-{
-   int rv;
-   int32_t offset = 0;
-   const char* system_name = NULL;
-
-   if ((rv = detect_system(name, offset, &system_name)) < 0)
-      return rv;
-
-   if (string_is_equal(system_name, "psp"))
-   {
-      if (detect_psp_game(name, serial) == 0)
-         return 0;
-      RARCH_LOG("%s '%s'\n", msg_hash_to_str(MSG_FOUND_DISK_LABEL), serial);
-   }
-   else if (string_is_equal(system_name, "ps1"))
-   {
-      if (detect_ps1_game(name, serial) == 0)
-         return 0;
-      RARCH_LOG("%s '%s'\n", msg_hash_to_str(MSG_FOUND_DISK_LABEL), serial);
-   }
-
-   return 0;
-} 
-
 static bool file_get_crc(database_state_handle_t *db_state,
       const char *name, uint32_t *crc)
 {
@@ -181,11 +155,6 @@ static int task_database_iterate_playlist(
 #else
          break;
 #endif
-	 case FILE_TYPE_ISO:
-         db_state->serial[0] = '\0';
-         iso_get_serial(db_state, db, name, db_state->serial);
-         db->type = DATABASE_TYPE_SERIAL_LOOKUP;
-         break;
       case FILE_TYPE_LUTRO:
          db->type = DATABASE_TYPE_ITERATE_LUTRO;
          break;


### PR DESCRIPTION
Removed the ISO and CUE serial scanning to prevent a conflict that will occur when the [disk CRC scanning](https://github.com/libretro/libretro-database/pull/251) is merged.
