### PR TITLE
Netplay Nouveau

### DIFF
--- a/network/netplay/README
+++ b/network/netplay/README
@@ -1,0 +1,52 @@
+How Netplay works (as documented by somebody who didn't write it):
+
+Note that this documentation is all for (the poorly-named) “net” mode, which is
+the normal mode, and not “spectator” mode, which has its own whole host of
+problems.
+
+Netplay in RetroArch works by expecting input to come delayed from the network,
+then rewinding and re-playing with the delayed input to get a consistent state.
+So long as both sides agree on which frame is which, it should be impossible
+for them to become de-synced, since each input event always happens at the
+correct frame.
+
+Within the state buffers, there are three locations: self, other and read. Self
+is where the emulator believes itself to be, which inevitably will be ahead of
+what it's read from the peer. Other is where it was most recently in perfect
+sync: i.e., other has been read and actioned. Read is where it's read up to,
+which can be slightly ahead of other since it can't always immediately act upon
+new data. In general, other ≤ read ≤ self. If read > self, logically it should
+try to catch up, but that logic currently doesn't seem to exist (?)
+
+In terms of the implementation, Netplay is in effect an input buffer and some
+pre- and post-frame behaviors.
+
+Pre-frame, it serializes the core's state, polls for input from the other side,
+and if input has not been received for the other side up to the current frame
+(which it shouldn't be), “simulates” the other side's input up to the current
+frame. The simulation is simply assuming that the input state hasn't changed.
+Each frame's local serialized state and simulated or real input goes into the
+frame buffers. Frame buffers that are simulated are marked as such.
+
+Post-frame, it checks whether it's read more than it's actioned, i.e. if read >
+other. If so, it rewinds to other and runs the core in replay mode with the
+real data up to read, then sets other = read.
+
+When in Netplay mode, the callback for receiving input is replaced by
+input_state_net. It is the role of input_state_net to combine the true local
+input (whether live or replay) with the remote input (whether true or
+simulated).
+
+In the previous implementation, there was seemingly nothing to prevent the self
+frame from advancing past the other frame in the ring buffer, causing local
+input from one time to be mixed with remote input from another. The new
+implementation uses a not-at-all-better strategy of simply refusing local input
+if it steps past remote input.
+
+Some thoughts about "frame counts": The frame counters act like indexes into a
+0-indexed array; i.e., they refer to the first unactioned frame. With
+self_frame_count it's slightly more complicated, since there are two relevant
+actions: Reading the data and emulating with the data. The frame count is only
+incremented after the latter, but the nature of the emulation assures that the
+current frame's input will always be read before it's actioned (or at least, we
+should certainly hope so!)

--- a/network/netplay/README
+++ b/network/netplay/README
@@ -11,8 +11,8 @@ Furthermore, if the core supports serialization (save states), Netplay allows
 for latency and clock drift, providing both host and client with a smooth
 experience.
 
-Note that this documentation is all for (the poorly-named) “net” mode, which is
-the normal mode, and not “spectator” mode, which has its own whole host of
+Note that this documentation is all for (the poorly-named) "net" mode, which is
+the normal mode, and not "spectator" mode, which has its own whole host of
 problems.
 
 Netplay in RetroArch works by expecting input to come delayed from the network,

--- a/network/netplay/README
+++ b/network/netplay/README
@@ -1,4 +1,15 @@
-How Netplay works (as documented by somebody who didn't write it):
+This is RetroArch's Netplay code. RetroArch Netplay allows a second player to
+be connected via the Internet, rather than local at the same computer. Netplay
+in RetroArch is guaranteed* to work with perfect synchronization given a few
+minor constraints:
+
+(1) The core is deterministic,
+(2) The only input devices the core interacts with are the joypad and analog sticks, and
+(3) Both the core and the loaded content are identical on host and client.
+
+Furthermore, if the core supports serialization (save states), Netplay allows
+for latency and clock drift, providing both host and client with a smooth
+experience.
 
 Note that this documentation is all for (the poorly-named) “net” mode, which is
 the normal mode, and not “spectator” mode, which has its own whole host of
@@ -10,43 +21,61 @@ So long as both sides agree on which frame is which, it should be impossible
 for them to become de-synced, since each input event always happens at the
 correct frame.
 
-Within the state buffers, there are three locations: self, other and read. Self
-is where the emulator believes itself to be, which inevitably will be ahead of
-what it's read from the peer. Other is where it was most recently in perfect
-sync: i.e., other has been read and actioned. Read is where it's read up to,
-which can be slightly ahead of other since it can't always immediately act upon
-new data. In general, other ≤ read ≤ self. If read > self, logically it should
-try to catch up, but that logic currently doesn't seem to exist (?)
+In terms of the implementation, Netplay is in effect a state buffer
+(implemented as a ring of buffers) and some pre- and post-frame behaviors.
 
-In terms of the implementation, Netplay is in effect an input buffer and some
-pre- and post-frame behaviors.
+Within the state buffers, there are three locations: self, other and read. Each
+refers to a frame, and a state buffer corresponding to that frame. The state
+buffer contains the savestate for the frame, and the input from both the local
+and remote players.
 
-Pre-frame, it serializes the core's state, polls for input from the other side,
-and if input has not been received for the other side up to the current frame
-(which it shouldn't be), “simulates” the other side's input up to the current
-frame. The simulation is simply assuming that the input state hasn't changed.
-Each frame's local serialized state and simulated or real input goes into the
-frame buffers. Frame buffers that are simulated are marked as such.
+Self is where the emulator believes itself to be, which may be ahead or behind
+of what it's read from the peer. Generally speaking, self progresses at 1 frame
+per frame, except when the network stalls, described later.
+
+Other is where it was most recently in perfect sync: i.e., other-1 is the last
+frame from which both local and remote input have been actioned. As such, other
+is always less than or equal to both self and read. Since the state buffer is a
+ring, other is the first frame that it's unsafe to overwrite.
+
+Read is where it's read up to, which can be slightly ahead of other since it
+can't always immediately act upon new data.
+
+In general, other ≤ read and other ≤ self. In all likelyhood, read ≤ self, but
+it is both possible and supported for the remote host to get ahead of the local
+host.
+
+Pre-frame, Netplay serializes the core's state, polls for local input, and
+polls for input from the other side. If the input from the other side is too
+far behind, it stalls to allow the other side to catch up. To assure that this
+stalling does not block the UI thread, it is implemented by rewinding the
+thread every frame until data is ready.
+
+If input has not been received for the other side up to the current frame (the
+usual case), the remote input is simulated in a simplistic manner.  Each
+frame's local serialized state and simulated or real input goes into the frame
+buffers.
+
+During the frame of execution, when the core requests input, it receives the
+input from the thread buffer, both local and real or simulated remote.
 
 Post-frame, it checks whether it's read more than it's actioned, i.e. if read >
-other. If so, it rewinds to other and runs the core in replay mode with the
-real data up to read, then sets other = read.
+other. If so, it rewinds to other (by loading the serialized state there) and
+runs the core in replay mode with the real data up to read, then sets other =
+read.
 
 When in Netplay mode, the callback for receiving input is replaced by
 input_state_net. It is the role of input_state_net to combine the true local
 input (whether live or replay) with the remote input (whether true or
 simulated).
 
-In the previous implementation, there was seemingly nothing to prevent the self
-frame from advancing past the other frame in the ring buffer, causing local
-input from one time to be mixed with remote input from another. The new
-implementation uses a not-at-all-better strategy of simply refusing local input
-if it steps past remote input.
-
 Some thoughts about "frame counts": The frame counters act like indexes into a
-0-indexed array; i.e., they refer to the first unactioned frame. With
-self_frame_count it's slightly more complicated, since there are two relevant
-actions: Reading the data and emulating with the data. The frame count is only
-incremented after the latter, but the nature of the emulation assures that the
-current frame's input will always be read before it's actioned (or at least, we
-should certainly hope so!)
+0-indexed array; i.e., they refer to the first unactioned frame. So, when
+read_frame_count is 23, we've read 23 frames, but the last frame we read is
+frame 22. With self_frame_count it's slightly more complicated, since there are
+two relevant actions: Reading the data and emulating with the data. The frame
+count is only incremented after the latter, so there is a period of time during
+which we've actually read self_frame_count+1 frames of local input.
+
+
+* Guarantee not actually a guarantee.

--- a/network/netplay/netplay.c
+++ b/network/netplay/netplay.c
@@ -1,6 +1,7 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
  *  Copyright (C) 2011-2016 - Daniel De Matteis
+ *  Copyright (C)      2016 - Gregor Richards
  *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-

--- a/network/netplay/netplay.c
+++ b/network/netplay/netplay.c
@@ -378,7 +378,7 @@ static void simulate_input(netplay_t *netplay)
          sizeof(netplay->buffer[prev].real_input_state));
 }
 
-#define MAX_STALL_TIME_USEC 10000000
+#define MAX_STALL_TIME_USEC (10*1000*1000)
 
 /**
  * netplay_poll:
@@ -521,7 +521,9 @@ static int16_t netplay_input_state(netplay_t *netplay,
          curr_input_state = netplay->buffer[ptr].real_input_state;
       }
       else
+      {
          curr_input_state = netplay->buffer[ptr].simulated_input_state;
+      }
    }
 
    switch (device)

--- a/network/netplay/netplay.c
+++ b/network/netplay/netplay.c
@@ -386,6 +386,9 @@ static int poll_input(netplay_t *netplay, bool block)
 
       RARCH_LOG("Network is stalling at frame %u, count %u of %d ...\n",
             netplay->self_frame_count, netplay->timeout_cnt, MAX_RETRIES);
+
+      if (netplay->timeout_cnt >= MAX_RETRIES)
+         return -1;
    } while (had_input || (block && (netplay->read_frame_count <= netplay->self_frame_count)));
 
    return 0;

--- a/network/netplay/netplay.c
+++ b/network/netplay/netplay.c
@@ -625,9 +625,13 @@ static int init_tcp_connection(const struct addrinfo *res,
 {
    bool ret = true;
    int fd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
-   int flag = 1;
 
-   setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(int));
+#if defined(IPPROTO_TCP) && defined(TCP_NODELAY)
+   {
+      int flag = 1;
+      setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(int));
+   }
+#endif
 
    if (fd < 0)
    {

--- a/network/netplay/netplay.c
+++ b/network/netplay/netplay.c
@@ -378,9 +378,6 @@ static void simulate_input(netplay_t *netplay)
    memcpy(netplay->buffer[ptr].simulated_input_state,
          netplay->buffer[prev].real_input_state,
          sizeof(netplay->buffer[prev].real_input_state));
-
-   netplay->buffer[ptr].have_remote = false;
-   netplay->buffer[ptr].used_real = false;
 }
 
 #define MAX_STALL_TIME_USEC 10000000
@@ -416,7 +413,8 @@ static bool netplay_poll(netplay_t *netplay)
       return false;
    }
 
-   if (netplay->read_frame_count <= netplay->self_frame_count)
+   /* Simulate the input if we don't have real input */
+   if (!netplay->buffer[PREV_PTR(netplay->self_ptr)].have_remote)
       simulate_input(netplay);
 
    /* Consider stalling */

--- a/network/netplay/netplay.c
+++ b/network/netplay/netplay.c
@@ -105,7 +105,6 @@ static bool get_self_input_state(netplay_t *netplay)
    if (ptr->have_local)
    {
       /* We've already read this frame! */
-      netplay->self_ptr = NEXT_PTR(netplay->self_ptr);
       return true;
    }
 
@@ -167,7 +166,6 @@ static bool get_self_input_state(netplay_t *netplay)
 
    memcpy(ptr->self_state, state, sizeof(state));
    ptr->have_local = true;
-   netplay->self_ptr = NEXT_PTR(netplay->self_ptr);
    return true;
 }
 
@@ -372,7 +370,7 @@ static int poll_input(netplay_t *netplay, bool block)
 /* TODO: Somewhat better prediction. :P */
 static void simulate_input(netplay_t *netplay)
 {
-   size_t ptr  = PREV_PTR(netplay->self_ptr);
+   size_t ptr  = netplay->self_ptr;
    size_t prev = PREV_PTR(netplay->read_ptr);
 
    memcpy(netplay->buffer[ptr].simulated_input_state,
@@ -414,7 +412,7 @@ static bool netplay_poll(netplay_t *netplay)
    }
 
    /* Simulate the input if we don't have real input */
-   if (!netplay->buffer[PREV_PTR(netplay->self_ptr)].have_remote)
+   if (!netplay->buffer[netplay->self_ptr].have_remote)
       simulate_input(netplay);
 
    /* Consider stalling */
@@ -511,7 +509,7 @@ static int16_t netplay_input_state(netplay_t *netplay,
       unsigned idx, unsigned id)
 {
    size_t ptr = netplay->is_replay ? 
-      netplay->replay_ptr : PREV_PTR(netplay->self_ptr);
+      netplay->replay_ptr : netplay->self_ptr;
 
    const uint32_t *curr_input_state = netplay->buffer[ptr].self_state;
 

--- a/network/netplay/netplay.c
+++ b/network/netplay/netplay.c
@@ -549,7 +549,7 @@ static bool netplay_poll(netplay_t *netplay)
 
    /* Read Netplay input, block if we're configured to stall for input every
     * frame */
-   res = poll_input(netplay, netplay->stall_frames == 0);
+   res = poll_input(netplay, (netplay->stall_frames == 0) && (netplay->read_frame_count <= netplay->self_frame_count));
    if (res == -1)
    {
       netplay->has_connection = false;
@@ -587,10 +587,8 @@ static bool netplay_poll(netplay_t *netplay)
    }
 #endif
 
-   if (netplay->read_frame_count < netplay->self_frame_count)
+   if (netplay->read_frame_count <= netplay->self_frame_count)
       simulate_input(netplay);
-   /*else
-      netplay->buffer[PREV_PTR(netplay->self_ptr)].used_real = true;*/
 
    /* Consider stalling */
    switch (netplay->stall) {
@@ -677,7 +675,10 @@ static int16_t netplay_input_state(netplay_t *netplay,
    if (netplay->port == (netplay_flip_port(netplay, port) ? 1 : 0))
    {
       if (netplay->buffer[ptr].have_remote)
+      {
+         netplay->buffer[ptr].used_real = true;
          curr_input_state = netplay->buffer[ptr].real_input_state;
+      }
       else
          curr_input_state = netplay->buffer[ptr].simulated_input_state;
    }

--- a/network/netplay/netplay.c
+++ b/network/netplay/netplay.c
@@ -310,7 +310,7 @@ static bool netplay_get_cmd(netplay_t *netplay)
          }
 
          /* The data's good! */
-         netplay->buffer[netplay->read_ptr].is_simulated = false;
+         netplay->buffer[netplay->read_ptr].have_remote = true;
          memcpy(netplay->buffer[netplay->read_ptr].real_input_state, buffer + 1, sizeof(buffer) - sizeof(uint32_t));
          netplay->read_ptr = NEXT_PTR(netplay->read_ptr);
          netplay->read_frame_count++;
@@ -498,7 +498,7 @@ static void simulate_input(netplay_t *netplay)
          netplay->buffer[prev].real_input_state,
          sizeof(netplay->buffer[prev].real_input_state));
 
-   netplay->buffer[ptr].is_simulated = true;
+   netplay->buffer[ptr].have_remote = false;
    netplay->buffer[ptr].used_real = false;
 }
 
@@ -529,7 +529,7 @@ static bool netplay_poll(netplay_t *netplay)
    if (netplay->self_frame_count == 0)
    {
       netplay->buffer[0].used_real        = true;
-      netplay->buffer[0].is_simulated     = false;
+      netplay->buffer[0].have_remote      = true;
 
       memset(netplay->buffer[0].real_input_state,
             0, sizeof(netplay->buffer[0].real_input_state));
@@ -667,10 +667,10 @@ static int16_t netplay_input_state(netplay_t *netplay,
 
    if (netplay->port == (netplay_flip_port(netplay, port) ? 1 : 0))
    {
-      if (netplay->buffer[ptr].is_simulated)
-         curr_input_state = netplay->buffer[ptr].simulated_input_state;
-      else
+      if (netplay->buffer[ptr].have_remote)
          curr_input_state = netplay->buffer[ptr].real_input_state;
+      else
+         curr_input_state = netplay->buffer[ptr].simulated_input_state;
    }
 
    switch (device)

--- a/network/netplay/netplay.c
+++ b/network/netplay/netplay.c
@@ -217,9 +217,12 @@ static bool netplay_get_cmd(netplay_t *netplay)
    switch (cmd)
    {
       case NETPLAY_CMD_ACK:
-      case NETPLAY_CMD_NAK:
          /* Why are we even bothering? */
          return true;
+
+      case NETPLAY_CMD_NAK:
+         /* Disconnect now! */
+         return false;
 
       case NETPLAY_CMD_INPUT:
          {
@@ -243,8 +246,7 @@ static bool netplay_get_cmd(netplay_t *netplay)
 
             if (buffer[0] != netplay->read_frame_count)
             {
-               /* FIXME: Except on the first (null) frame, this should be
-                * impossible, so maybe just disconnect? */
+               /* Out of order = out of luck */
                return netplay_cmd_nak(netplay);
             }
 

--- a/network/netplay/netplay.c
+++ b/network/netplay/netplay.c
@@ -464,14 +464,14 @@ void video_frame_net(const void *data, unsigned width,
 void audio_sample_net(int16_t left, int16_t right)
 {
    netplay_t *netplay = (netplay_t*)netplay_data;
-   if (!netplay_should_skip(netplay))
+   if (!netplay_should_skip(netplay) && !netplay->stall)
       netplay->cbs.sample_cb(left, right);
 }
 
 size_t audio_sample_batch_net(const int16_t *data, size_t frames)
 {
    netplay_t *netplay = (netplay_t*)netplay_data;
-   if (!netplay_should_skip(netplay))
+   if (!netplay_should_skip(netplay) && !netplay->stall)
       return netplay->cbs.sample_batch_cb(data, frames);
    return frames;
 }

--- a/network/netplay/netplay.h
+++ b/network/netplay/netplay.h
@@ -40,7 +40,7 @@ enum rarch_netplay_ctl_state
 
 enum netplay_cmd
 {
-   /* Miscellaneous commands */
+   /* Basic commands */
 
    /* Acknowlegement response */
    NETPLAY_CMD_ACK            = 0x0000, 
@@ -48,23 +48,28 @@ enum netplay_cmd
    /* Failed acknowlegement response */
    NETPLAY_CMD_NAK            = 0x0001, 
 
+   /* Input data */
+   NETPLAY_CMD_INPUT          = 0x0002,
+
+   /* Misc. commands */
+
    /* Swap inputs between player 1 and player 2 */
-   NETPLAY_CMD_FLIP_PLAYERS   = 0x0002,
+   NETPLAY_CMD_FLIP_PLAYERS   = 0x0003,
 
    /* Toggle spectate/join mode */
-   NETPLAY_CMD_SPECTATE       = 0x0003, 
+   NETPLAY_CMD_SPECTATE       = 0x0004, 
 
    /* Gracefully disconnects from host */
-   NETPLAY_CMD_DISCONNECT     = 0x0004, 
+   NETPLAY_CMD_DISCONNECT     = 0x0005, 
 
    /* Sends multiple config requests over, 
     * See enum netplay_cmd_cfg */
-   NETPLAY_CMD_CFG            = 0x0005, 
+   NETPLAY_CMD_CFG            = 0x0006, 
 
    /* CMD_CFG streamlines sending multiple
       configurations. This acknowledges
       each one individually */
-   NETPLAY_CMD_CFG_ACK        = 0x0006, 
+   NETPLAY_CMD_CFG_ACK        = 0x0007, 
 
    /* Loading and synchronization */
 

--- a/network/netplay/netplay_common.c
+++ b/network/netplay/netplay_common.c
@@ -1,6 +1,7 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
  *  Copyright (C) 2011-2016 - Daniel De Matteis
+ *  Copyright (C)      2016 - Gregor Richards
  *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-

--- a/network/netplay/netplay_common.c
+++ b/network/netplay/netplay_common.c
@@ -347,13 +347,16 @@ bool netplay_is_spectate(netplay_t* netplay)
 
 bool netplay_delta_frame_ready(netplay_t *netplay, struct delta_frame *delta, uint32_t frame)
 {
+    void *remember_state;
     if (delta->frame == frame) return true;
     if (netplay->other_frame_count <= delta->frame)
     {
         /* We haven't even replayed this frame yet, so we can't overwrite it! */
         return false;
     }
+    remember_state = delta->state;
     memset(delta, 0, sizeof(struct delta_frame));
     delta->frame = frame;
+    delta->state = remember_state;
     return true;
 }

--- a/network/netplay/netplay_common.c
+++ b/network/netplay/netplay_common.c
@@ -199,6 +199,8 @@ uint32_t netplay_impl_magic(void)
    for (i = 0; i < len; i++)
       res ^= ver[i] << ((i & 0xf) + 16);
 
+   res ^= NETPLAY_PROTOCOL_VERSION << 24;
+
    return res;
 }
 
@@ -341,4 +343,17 @@ bool netplay_is_spectate(netplay_t* netplay)
    if (!netplay)
       return false;
    return netplay->spectate.enabled;
+}
+
+bool netplay_delta_frame_ready(netplay_t *netplay, struct delta_frame *delta, uint32_t frame)
+{
+    if (delta->frame == frame) return true;
+    if (netplay->other_frame_count <= delta->frame)
+    {
+        /* We haven't even replayed this frame yet, so we can't overwrite it! */
+        return false;
+    }
+    memset(delta, 0, sizeof(struct delta_frame));
+    delta->frame = frame;
+    return true;
 }

--- a/network/netplay/netplay_common.c
+++ b/network/netplay/netplay_common.c
@@ -348,14 +348,18 @@ bool netplay_is_spectate(netplay_t* netplay)
 bool netplay_delta_frame_ready(netplay_t *netplay, struct delta_frame *delta, uint32_t frame)
 {
     void *remember_state;
-    if (delta->frame == frame) return true;
-    if (netplay->other_frame_count <= delta->frame)
+    if (delta->used)
     {
-        /* We haven't even replayed this frame yet, so we can't overwrite it! */
-        return false;
+        if (delta->frame == frame) return true;
+        if (netplay->other_frame_count <= delta->frame)
+        {
+           /* We haven't even replayed this frame yet, so we can't overwrite it! */
+           return false;
+        }
     }
     remember_state = delta->state;
     memset(delta, 0, sizeof(struct delta_frame));
+    delta->used = true;
     delta->frame = frame;
     delta->state = remember_state;
     return true;

--- a/network/netplay/netplay_common.c
+++ b/network/netplay/netplay_common.c
@@ -79,7 +79,7 @@ uint32_t *netplay_bsv_header_generate(size_t *size, uint32_t magic)
    uint32_t *header, bsv_header[4] = {0};
 
    core_serialize_size(&info);
-   
+
    serialize_size = info.size;
    header_size    = sizeof(bsv_header) + serialize_size;
    *size          = header_size;
@@ -177,9 +177,9 @@ uint32_t netplay_impl_magic(void)
    core_api_version(&api_info);
 
    api                                 = api_info.version;
-   
+
    runloop_ctl(RUNLOOP_CTL_SYSTEM_INFO_GET, &info);
-   
+
    if (info)
       lib = info->info.library_name;
 
@@ -217,7 +217,7 @@ bool netplay_send_info(netplay_t *netplay)
 
    core_get_memory(&mem_info);
    content_get_crc(&content_crc_ptr);
-   
+
    header[0] = htonl(*content_crc_ptr);
    header[1] = htonl(netplay_impl_magic());
    header[2] = htonl(mem_info.size);
@@ -347,20 +347,20 @@ bool netplay_is_spectate(netplay_t* netplay)
 
 bool netplay_delta_frame_ready(netplay_t *netplay, struct delta_frame *delta, uint32_t frame)
 {
-    void *remember_state;
-    if (delta->used)
-    {
-        if (delta->frame == frame) return true;
-        if (netplay->other_frame_count <= delta->frame)
-        {
-           /* We haven't even replayed this frame yet, so we can't overwrite it! */
-           return false;
-        }
-    }
-    remember_state = delta->state;
-    memset(delta, 0, sizeof(struct delta_frame));
-    delta->used = true;
-    delta->frame = frame;
-    delta->state = remember_state;
-    return true;
+   void *remember_state;
+   if (delta->used)
+   {
+      if (delta->frame == frame) return true;
+      if (netplay->other_frame_count <= delta->frame)
+      {
+         /* We haven't even replayed this frame yet, so we can't overwrite it! */
+         return false;
+      }
+   }
+   remember_state = delta->state;
+   memset(delta, 0, sizeof(struct delta_frame));
+   delta->used = true;
+   delta->frame = frame;
+   delta->state = remember_state;
+   return true;
 }

--- a/network/netplay/netplay_net.c
+++ b/network/netplay/netplay_net.c
@@ -1,6 +1,7 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
  *  Copyright (C) 2011-2016 - Daniel De Matteis
+ *  Copyright (C)      2016 - Gregor Richards
  *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-

--- a/network/netplay/netplay_net.c
+++ b/network/netplay/netplay_net.c
@@ -63,12 +63,6 @@ static void netplay_net_post_frame(netplay_t *netplay)
 {
    netplay->self_frame_count++;
 
-#if 0
-   /* Nothing to do... */
-   if (netplay->other_frame_count == netplay->read_frame_count)
-      return;
-#endif
-
    /* Skip ahead if we predicted correctly.
     * Skip until our simulation failed. */
    while (netplay->other_frame_count < netplay->read_frame_count)
@@ -133,47 +127,6 @@ static void netplay_net_post_frame(netplay_t *netplay)
       netplay->other_frame_count = netplay->read_frame_count;
       netplay->is_replay = false;
    }
-
-#if 0
-   /* And if the other side has gotten too far ahead of /us/, skip to catch up
-    * FIXME: Make this configurable */
-   if (netplay->read_frame_count > netplay->self_frame_count + 10 ||
-       netplay->must_fast_forward)
-   {
-       /* "replay" into the future */
-       netplay->is_replay = true;
-       netplay->replay_ptr = netplay->self_ptr;
-       netplay->replay_frame_count = netplay->self_frame_count;
-
-       /* just assume input doesn't change for the intervening frames */
-       while (netplay->replay_frame_count < netplay->read_frame_count)
-       {
-           size_t cur = netplay->replay_ptr;
-           size_t prev = PREV_PTR(cur);
-
-           memcpy(netplay->buffer[cur].self_state, netplay->buffer[prev].self_state,
-                sizeof(netplay->buffer[prev].self_state));
-
-#if defined(HAVE_THREADS)
-         autosave_lock();
-#endif
-         core_run();
-#if defined(HAVE_THREADS)
-         autosave_unlock();
-#endif
-
-         netplay->replay_ptr = NEXT_PTR(cur);
-         netplay->replay_frame_count++;
-       }
-
-       /* at this point, other = read = self */
-       netplay->self_ptr = netplay->replay_ptr;
-       netplay->self_frame_count = netplay->replay_frame_count;
-       netplay->other_ptr = netplay->read_ptr;
-       netplay->other_frame_count = netplay->read_frame_count;
-       netplay->is_replay = false;
-   }
-#endif
 
    /* If we're supposed to stall, rewind */
    if (netplay->stall)

--- a/network/netplay/netplay_net.c
+++ b/network/netplay/netplay_net.c
@@ -166,6 +166,20 @@ static void netplay_net_post_frame(netplay_t *netplay)
    }
 #endif
 
+   /* If we're supposed to stall, rewind */
+   if (netplay->stall)
+   {
+      retro_ctx_serialize_info_t serial_info;
+
+      netplay->self_ptr = PREV_PTR(netplay->self_ptr);
+      netplay->self_frame_count--;
+
+      serial_info.data       = NULL;
+      serial_info.data_const = netplay->buffer[netplay->self_ptr].state;
+      serial_info.size       = netplay->state_size;
+
+      core_unserialize(&serial_info);
+   }
 }
 static bool netplay_net_init_buffers(netplay_t *netplay)
 {

--- a/network/netplay/netplay_net.c
+++ b/network/netplay/netplay_net.c
@@ -35,16 +35,16 @@ static void netplay_net_pre_frame(netplay_t *netplay)
 
    if (netplay_delta_frame_ready(netplay, &netplay->buffer[netplay->self_ptr], netplay->self_frame_count))
    {
-       serial_info.data_const = NULL;
-       serial_info.data = netplay->buffer[netplay->self_ptr].state;
-       serial_info.size = netplay->state_size;
+      serial_info.data_const = NULL;
+      serial_info.data = netplay->buffer[netplay->self_ptr].state;
+      serial_info.size = netplay->state_size;
 
-       if (!core_serialize(&serial_info))
-       {
-           /* If the core can't serialize properly, we must stall for the
-            * remote input on EVERY frame, because we can't recover */
-           netplay->stall_frames = 0;
-       }
+      if (!core_serialize(&serial_info))
+      {
+         /* If the core can't serialize properly, we must stall for the
+          * remote input on EVERY frame, because we can't recover */
+         netplay->stall_frames = 0;
+      }
    }
 
    netplay->can_poll = true;
@@ -118,9 +118,9 @@ static void netplay_net_post_frame(netplay_t *netplay)
       /* For the remainder of the frames up to the read count, we can use the real data */
       while (netplay->replay_frame_count < netplay->read_frame_count)
       {
-          retro_assert(netplay->buffer[netplay->replay_ptr].have_remote);
-          netplay->replay_ptr = NEXT_PTR(netplay->replay_ptr);
-          netplay->replay_frame_count++;
+         retro_assert(netplay->buffer[netplay->replay_ptr].have_remote);
+         netplay->replay_ptr = NEXT_PTR(netplay->replay_ptr);
+         netplay->replay_frame_count++;
       }
 
       netplay->other_ptr = netplay->read_ptr;
@@ -153,7 +153,7 @@ static bool netplay_net_init_buffers(netplay_t *netplay)
 
    netplay->buffer = (struct delta_frame*)calloc(netplay->buffer_size,
          sizeof(*netplay->buffer));
-   
+
    if (!netplay->buffer)
       return false;
 

--- a/network/netplay/netplay_net.c
+++ b/network/netplay/netplay_net.c
@@ -62,6 +62,7 @@ static void netplay_net_pre_frame(netplay_t *netplay)
  **/
 static void netplay_net_post_frame(netplay_t *netplay)
 {
+   netplay->self_ptr = NEXT_PTR(netplay->self_ptr);
    netplay->self_frame_count++;
 
    /* Only relevant if we're connected */

--- a/network/netplay/netplay_net.c
+++ b/network/netplay/netplay_net.c
@@ -64,6 +64,10 @@ static void netplay_net_post_frame(netplay_t *netplay)
 {
    netplay->self_frame_count++;
 
+   /* Only relevant if we're connected */
+   if (!netplay->has_connection)
+      return;
+
    /* Skip ahead if we predicted correctly.
     * Skip until our simulation failed. */
    while (netplay->other_frame_count < netplay->read_frame_count)

--- a/network/netplay/netplay_net.c
+++ b/network/netplay/netplay_net.c
@@ -114,7 +114,6 @@ static void netplay_net_post_frame(netplay_t *netplay)
       /* For the remainder of the frames up to the read count, we can use the real data */
       while (netplay->replay_frame_count < netplay->read_frame_count)
       {
-          netplay->buffer[netplay->replay_ptr].is_simulated = false;
           netplay->buffer[netplay->replay_ptr].used_real = true;
           netplay->replay_ptr = NEXT_PTR(netplay->replay_ptr);
           netplay->replay_frame_count++;
@@ -205,8 +204,6 @@ static bool netplay_net_init_buffers(netplay_t *netplay)
 
       if (!netplay->buffer[i].state)
          return false;
-
-      netplay->buffer[i].is_simulated = true;
    }
 
    return true;

--- a/network/netplay/netplay_net.c
+++ b/network/netplay/netplay_net.c
@@ -15,8 +15,11 @@
  */
 
 #include <compat/strl.h>
+#include <stdio.h>
 
 #include "netplay_private.h"
+
+#include "retro_assert.h"
 
 #include "../../autosave.h"
 
@@ -95,7 +98,7 @@ static void netplay_net_post_frame(netplay_t *netplay)
          serial_info.data       = NULL;
          serial_info.data_const = netplay->buffer[netplay->replay_ptr].state;
          serial_info.size       = netplay->state_size;
-   
+
          core_unserialize(&serial_info);
       }
 
@@ -121,7 +124,7 @@ static void netplay_net_post_frame(netplay_t *netplay)
       /* For the remainder of the frames up to the read count, we can use the real data */
       while (netplay->replay_frame_count < netplay->read_frame_count)
       {
-          /*netplay->buffer[netplay->replay_ptr].used_real = true;*/
+          retro_assert(netplay->buffer[netplay->replay_ptr].have_remote);
           netplay->replay_ptr = NEXT_PTR(netplay->replay_ptr);
           netplay->replay_frame_count++;
       }

--- a/network/netplay/netplay_net.c
+++ b/network/netplay/netplay_net.c
@@ -127,7 +127,9 @@ static void netplay_net_post_frame(netplay_t *netplay)
       {
          netplay->other_ptr = netplay->read_ptr;
          netplay->other_frame_count = netplay->read_frame_count;
-      } else {
+      }
+      else
+      {
          netplay->other_ptr = netplay->self_ptr;
          netplay->other_frame_count = netplay->self_frame_count;
       }

--- a/network/netplay/netplay_private.h
+++ b/network/netplay/netplay_private.h
@@ -30,10 +30,9 @@
 #define HAVE_IPV6
 #endif
 
-#define UDP_FRAME_PACKETS     16
-#define UDP_WORDS_PER_FRAME   4 /* Allows us to send 128 bits worth of state per frame. */
-#define MAX_SPECTATORS        16
-#define RARCH_DEFAULT_PORT    55435
+#define WORDS_PER_FRAME 4 /* Allows us to send 128 bits worth of state per frame. */
+#define MAX_SPECTATORS 16
+#define RARCH_DEFAULT_PORT 55435
 
 #define NETPLAY_PROTOCOL_VERSION 1
 
@@ -46,9 +45,9 @@ struct delta_frame
 
    void *state;
 
-   uint32_t real_input_state[UDP_WORDS_PER_FRAME - 1];
-   uint32_t simulated_input_state[UDP_WORDS_PER_FRAME - 1];
-   uint32_t self_state[UDP_WORDS_PER_FRAME - 1];
+   uint32_t real_input_state[WORDS_PER_FRAME - 1];
+   uint32_t simulated_input_state[WORDS_PER_FRAME - 1];
+   uint32_t self_state[WORDS_PER_FRAME - 1];
 
    bool have_local;
    bool is_simulated;
@@ -98,9 +97,8 @@ struct netplay
    /* If we end up having to drop remote frame data because it's ahead of us, fast-forward is URGENT */
    bool must_fast_forward;
 
-   /* To compat UDP packet loss we also send 
-    * old data along with the packets. */
-   uint32_t packet_buffer[UDP_FRAME_PACKETS * UDP_WORDS_PER_FRAME];
+   /* A buffer for outgoing input packets. */
+   uint32_t packet_buffer[2 + WORDS_PER_FRAME];
    uint32_t self_frame_count;
    uint32_t read_frame_count;
    uint32_t other_frame_count;

--- a/network/netplay/netplay_private.h
+++ b/network/netplay/netplay_private.h
@@ -41,6 +41,7 @@
 
 struct delta_frame
 {
+   bool used; /* a bit derpy, but this is how we know if the delta's been used at all */
    uint32_t frame;
 
    void *state;
@@ -143,6 +144,7 @@ struct netplay
    uint32_t pause_frame;
 
    /* And stalling */
+   uint32_t stall_frames;
    int stall;
 
    struct netplay_callbacks* net_cbs;

--- a/network/netplay/netplay_private.h
+++ b/network/netplay/netplay_private.h
@@ -20,6 +20,7 @@
 #include "netplay.h"
 
 #include <net/net_compat.h>
+#include <features/features_cpu.h>
 #include <retro_endianness.h>
 
 #include "../../core.h"
@@ -144,6 +145,7 @@ struct netplay
    /* And stalling */
    uint32_t stall_frames;
    int stall;
+   retro_time_t stall_time;
 
    struct netplay_callbacks* net_cbs;
 };

--- a/network/netplay/netplay_private.h
+++ b/network/netplay/netplay_private.h
@@ -49,8 +49,13 @@ struct delta_frame
    uint32_t simulated_input_state[WORDS_PER_FRAME - 1];
    uint32_t self_state[WORDS_PER_FRAME - 1];
 
+   /* Have we read local input? */
    bool have_local;
+
+   /* Badly named: This is !have_real(_remote) */
    bool is_simulated;
+
+   /* Is the current state as of self_frame_count using the real data? */
    bool used_real;
 };
 
@@ -58,6 +63,12 @@ struct netplay_callbacks {
    void (*pre_frame) (netplay_t *netplay);
    void (*post_frame)(netplay_t *netplay);
    bool (*info_cb)   (netplay_t *netplay, unsigned frames);
+};
+
+enum rarch_netplay_stall_reasons
+{
+    RARCH_NETPLAY_STALL_NONE = 0,
+    RARCH_NETPLAY_STALL_RUNNING_FAST
 };
 
 struct netplay
@@ -130,6 +141,9 @@ struct netplay
     */
    bool pause;
    uint32_t pause_frame;
+
+   /* And stalling */
+   int stall;
 
    struct netplay_callbacks* net_cbs;
 };

--- a/network/netplay/netplay_private.h
+++ b/network/netplay/netplay_private.h
@@ -81,8 +81,6 @@ struct netplay
    struct retro_callbacks cbs;
    /* TCP connection for state sending, etc. Also used for commands */
    int fd;
-   /* UDP connection for game state updates. */
-   int udp_fd;
    /* Which port is governed by netplay (other user)? */
    unsigned port;
    bool has_connection;

--- a/network/netplay/netplay_private.h
+++ b/network/netplay/netplay_private.h
@@ -52,10 +52,10 @@ struct delta_frame
    /* Have we read local input? */
    bool have_local;
 
-   /* Badly named: This is !have_real(_remote) */
-   bool is_simulated;
+   /* Have we read the real remote input? */
+   bool have_remote;
 
-   /* Is the current state as of self_frame_count using the real data? */
+   /* Is the current state as of self_frame_count using the real remote data? */
    bool used_real;
 };
 


### PR DESCRIPTION
This is my near-total overhaul of Netplay. I think we're all aware of the fact that RetroArch's Netplay is great in theory but buggy in practice. I've fixed it.

This PR is not all of the changes I intend to make to Netplay. I'm submitting it now because Netplay Nouveau is now feature-complete with respect to the Netplay it replaces, just with fewer bugs. Also included is a small README describing how Netplay is implemented, in place of the "here there be dragons" sign that was there before.

A summary of my changes:

- Most of the bugs in the previous implementation had to do with the three heads on the ring buffer of frame info walking past each other in unexpected/incorrect ways. I hardened the ring buffer to be able to check for all such wrong steps. Theoretically the checkability is no longer necessary since I've fixed the relevant bugs, but it doesn't do any harm.
- The previous implementation used UDP for the actual frame data, but the very nature of this application demands reliable delivery, so it resent every frame's data 16 times to combat drops. It was also effectively written in such a way that in-order delivery was also mandatory. Basically, minor network hiccups could cause major desyncs. Because both reliable and in-order delivery were (and continue to be) mandatory, and because reimplementing ⅔ of TCP on top of UDP is a fool's errand, I switched the whole protocol to TCP-only.
- I've removed all limits on the size of the frame buffer, i.e., the number of delay frames. Perhaps there should be some sanity-based limit in the future, but for now, if you're willing to let you and your peer drift by a minute (3600 frames), you're totally free to do that. This was actually a consequence of removing UDP, as the limit was an artificial component of how it implemented UDP "reliability".
- Unless your delay frames is set to 0 (i.e., serialization-free netplay), stalling is implemented by repeating the same frame over and over, rather than blocking. This has the disadvantage of wasting the core's time redoing the same frame, but the advantage of not blocking the UI. As I plan future changes to make the UI usable during Netplay, not blocking the UI is valuable.

Introduced bug:
- Both in the previous and current implementation, the only way it assures that flipping inputs is done at the same time on both sides is by making it happen sufficiently far in the future (32 frames in the future, as it happens). While that was probably (?) always (?) sufficient in the previous implementation, since you can now set arbitrarily large delay/drift frames, it's technically quite possible for one client to be 10 seconds ahead of the other, let alone 32 frames. Thus, flipping can cause a desync. I didn't bother to make the logic better because I intend to overhaul all frame-timing-specific behavior to use forced rewinds, which will make the whole point moot.

Unfixed bug:
- Spectator mode doesn't work. After spending an hour trying to figure out why it ever worked in the first place, I thought to try it in master. Turns out, it didn't work there. I don't know what happened between 1.0.0.2 (last version I used spectator mode in) and now, but spectator mode is totally whomped, and continues to be so.

If you're curious about some of the future changes I intend to make, see the wiki associated with my fork of retroarch.