### PR TITLE
Disable dbus by default

### DIFF
--- a/qb/config.params.sh
+++ b/qb/config.params.sh
@@ -11,6 +11,7 @@ HAVE_SDL2=auto             # SDL2 support (disables SDL 1.x)
 C89_SDL2=no
 HAVE_LIBUSB=auto           # Libusb HID support
 C89_LIBUSB=no
+HAVE_DBUS=no               # dbus support
 HAVE_UDEV=auto             # Udev/Evdev gamepad support
 HAVE_LIBRETRO=             # Libretro library used
 HAVE_ASSETS_DIR=           # Assets install directory


### PR DESCRIPTION
dbus as a dependency is both controversial and completely unnecessary except for a few broken environments. This will make it a configurable option which is off by default so those that actually need it can enable it. Ideally this should of been fixed in those environments rather than RetroArch, but since that probably won't happen lets reduce the dependency count for most people who do not need this instead.

This adds to an earlier PR found here.
https://github.com/libretro/RetroArch/pull/3547