### PR TITLE
(Emscripten) Show/Hide the console with no animation

### DIFF
--- a/pkg/emscripten/proto.html
+++ b/pkg/emscripten/proto.html
@@ -114,7 +114,7 @@
    </div>
    <div class="container">
       <div class="row">
-         <div class="col-sm-12 form-group btn-group text-xs-center p-t-2">
+         <div class="col-sm-10 form-group btn-group text-xs-center p-t-2">
             <div class="btn-group" data-toggle="buttons">
                <label class="btn btn-primary" id="lblLocal" onclick=switchStorage("browser")>
                   <input type="radio" name="options" id="btnLocal" autocomplete="off" checked>
@@ -127,6 +127,11 @@
                   </input>
               </label>
             </div>
+         </div>
+         <div class="col-sm-2 form-group btn-group text-xs-center p-t-2">
+            <button type="button" name="options" id="btnlogs" class="btn btn-info pull-xs-right">
+               <span class="fa fa-list"></span> Log
+            </button>
          </div>
       </div>
       <div class="row">

--- a/pkg/emscripten/proto.js
+++ b/pkg/emscripten/proto.js
@@ -280,6 +280,13 @@ function switchStorage(backend) {
 
 // When the browser has loaded everything.
 $(function() {
+
+  // Hide the logging window and allow the user to show it.
+  $('#output').hide();
+  $('#btnlogs').click(function () {
+    $('#output').slideToggle();
+  });
+
   /**
    * Attempt to disable some default browser keys.
    */

--- a/pkg/emscripten/proto.js
+++ b/pkg/emscripten/proto.js
@@ -284,7 +284,7 @@ $(function() {
   // Hide the logging window and allow the user to show it.
   $('#output').hide();
   $('#btnlogs').click(function () {
-    $('#output').slideToggle();
+    $('#output').toggle();
   });
 
   /**

--- a/pkg/emscripten/proto.js
+++ b/pkg/emscripten/proto.js
@@ -281,8 +281,7 @@ function switchStorage(backend) {
 // When the browser has loaded everything.
 $(function() {
 
-  // Hide the logging window and allow the user to show it.
-  $('#output').hide();
+  // Allow the user to show/hide the log console.
   $('#btnlogs').click(function () {
     $('#output').toggle();
   });


### PR DESCRIPTION
Reverts libretro/RetroArch#3587 and uses http://api.jquery.com/toggle/ rather then the slide animation. Will speed it up.