### PR TITLE
Do not attempt xdg-screensaver method if DBus method succeeded

### DIFF
--- a/gfx/common/x11_common.c
+++ b/gfx/common/x11_common.c
@@ -306,9 +306,17 @@ static void x11_suspend_screensaver_xdg_screensaver(Window wnd, bool enable)
 
 void x11_suspend_screensaver(Window wnd, bool enable)
 {
-    x11_suspend_screensaver_xdg_screensaver(wnd, enable);
 #ifdef HAVE_DBUS
     x11_suspend_screensaver_dbus(enable);
+    if (dbus_screensaver_cookie == 0)
+    {
+        // Only attempt xdg-screensaver method if dbus didn't succeed
+#endif
+
+        x11_suspend_screensaver_xdg_screensaver(wnd, enable);
+
+#ifdef HAVE_DBUS
+    }
 #endif
 }
 

--- a/gfx/common/x11_common.c
+++ b/gfx/common/x11_common.c
@@ -309,15 +309,10 @@ void x11_suspend_screensaver(Window wnd, bool enable)
 #ifdef HAVE_DBUS
     x11_suspend_screensaver_dbus(enable);
     if (dbus_screensaver_cookie == 0)
-    {
         // Only attempt xdg-screensaver method if dbus didn't succeed
 #endif
 
         x11_suspend_screensaver_xdg_screensaver(wnd, enable);
-
-#ifdef HAVE_DBUS
-    }
-#endif
 }
 
 static bool get_video_mode(Display *dpy, unsigned width, unsigned height,


### PR DESCRIPTION
As suggested by @hadess, try to inhibit the screensaver via DBus first,
and if we were successful do not run `xdg-screensaver` as it's
unnecessary and may result in undesirable side effects (as it also uses
DBus on Gnome but on a different interface).