### PR TITLE
(Emscripten) Bind to the console when logging

### DIFF
--- a/pkg/emscripten/proto.html
+++ b/pkg/emscripten/proto.html
@@ -129,16 +129,6 @@
             </div>
          </div>
       </div>
-      <div class="row">
-         <div class="col-sm-12 form-group btn-group text-xs-center p-t-2">
-            <div class="card">
-                <div class="view overlay hm-white-slight" align="center">
-                     <textarea id="output" rows="15"></textarea>
-                </div>
-            </div>
-
-         </div>
-      </div>
    </div>
    <div align="center">
       <p>For now, we recommend you use <a href="https://www.google.com/chrome/">Google Chrome</a> for the best possible performance.</p>

--- a/pkg/emscripten/proto.js
+++ b/pkg/emscripten/proto.js
@@ -239,9 +239,9 @@ var Module =
   arguments: ["-v", "--menu"],
   preRun: [],
   postRun: [],
-  // Print both stdout and stderr to the browser console.
-  print: console.log,
-  printErr: console.log,
+  // Log both stdout and stderr with the browser's console object.
+  print: console.log.bind(console),
+  printErr: console.log.bind(console),
   canvas: document.getElementById('canvas'),
   totalDependencies: 0,
   monitorRunDependencies: function(left) 

--- a/pkg/emscripten/proto.js
+++ b/pkg/emscripten/proto.js
@@ -239,25 +239,9 @@ var Module =
   arguments: ["-v", "--menu"],
   preRun: [],
   postRun: [],
-  print: (function() 
-  {
-     var element = document.getElementById('output');
-     element.value = ''; // clear browser cache
-     return function(text) 
-     {
-        text = Array.prototype.slice.call(arguments).join(' ');
-        element.value += text + "\n";
-        element.scrollTop = 99999; // focus on bottom
-     };
-  })(),
-
-  printErr: function(text)
-  {
-     var text = Array.prototype.slice.call(arguments).join(' ');
-     var element = document.getElementById('output');
-     element.value += text + "\n";
-     element.scrollTop = 99999; // focus on bottom
-  },
+  // Print both stdout and stderr to the browser console.
+  print: console.log,
+  printErr: console.log,
   canvas: document.getElementById('canvas'),
   totalDependencies: 0,
   monitorRunDependencies: function(left) 


### PR DESCRIPTION
This fixes Firefox's use of the console. The `this` object was changing when calling `console.log` through emscripten. Needed to [`.bind()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind) it instead so that `this` stays as `console`.

Tested in both Firefox and Chrome. Seems to run a lot faster now that it's not doing the DOM changes.