### PR TITLE
Add EditorConfig support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# EditorConfig: http://EditorConfig.org
+
+# Top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+# 3 space indentation
+[*.{c,h,js,css,html}]
+indent_style = space
+indent_size = 3
+
+# Tab indentation
+[Makefile*]
+indent_style = tab


### PR DESCRIPTION
[EditorConfig](http://editorconfig.org/) will automatically configure text editors and IDEs to RetroArch's coding standards. Helps keeps things to the 3-space tabbing.