### PR TITLE
Netplay savestate loading frontend changes

### DIFF
--- a/command.c
+++ b/command.c
@@ -1713,6 +1713,10 @@ static void command_event_load_state(const char *path, char *s, size_t len)
       return;
    }
 
+#ifdef HAVE_NETPLAY
+   netplay_driver_ctl(RARCH_NETPLAY_CTL_LOAD_SAVESTATE, NULL);
+#endif
+
    if (settings->state_slot < 0)
       snprintf(s, len, "%s #-1 (auto).",
             msg_hash_to_str(MSG_LOADED_STATE_FROM_SLOT));
@@ -1739,6 +1743,10 @@ static void command_event_undo_load_state(char *s, size_t len)
             "RAM");
       return;
    }
+
+#ifdef HAVE_NETPLAY
+   netplay_driver_ctl(RARCH_NETPLAY_CTL_LOAD_SAVESTATE, NULL);
+#endif
 
    strlcpy(s,
          msg_hash_to_str(MSG_UNDID_LOAD_STATE), len);

--- a/network/netplay/netplay.h
+++ b/network/netplay/netplay.h
@@ -187,7 +187,7 @@ void netplay_frontend_paused(netplay_t *netplay, bool paused);
 /**
  * netplay_load_savestate
  * @netplay              : pointer to netplay object
- * @serial_info          : the savestate being loaded
+ * @serial_info          : the savestate being loaded, NULL means "load it yourself"
  * @save                 : whether to save the provided serial_info into the frame buffer
  *
  * Inform Netplay of a savestate load and send it to the other side


### PR DESCRIPTION
Support for the frontend to inform Netplay when a savestate has been loaded, so Netplay can in turn inform the peer. This is the companion piece to my previous submission of the Netplay side of this. All the changes are now associated with the savestate loading commands in comand.c instead of the tasks in task_save_state.c.