### PR TITLE
7z fixes

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1147,6 +1147,7 @@ endif
 ifeq ($(HAVE_COMPRESSION), 1)
    DEFINES += -DHAVE_COMPRESSION
    OBJ += libretro-common/file/archive_file.o \
+          libretro-common/encodings/encoding_crc32.o \
           tasks/task_decompress.o
 endif
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -971,6 +971,8 @@ endif
 
 # Compression/Archive
 
+OBJ += libretro-common/file/archive_file.o
+
 ifeq ($(HAVE_7ZIP),1)
    CFLAGS  += -I./deps/7zip
    HAVE_COMPRESSION = 1
@@ -1143,6 +1145,7 @@ ifeq ($(HAVE_FFMPEG), 1)
    DEFINES += $(AVCODEC_CFLAGS) $(AVFORMAT_CFLAGS) $(AVUTIL_CFLAGS) $(SWSCALE_CFLAGS) $(SWRESAMPLE_CFLAGS)
    DEFINES += -Wno-deprecated-declarations -DHAVE_FFMPEG -Iffmpeg
 endif
+
 
 ifeq ($(HAVE_COMPRESSION), 1)
    DEFINES += -DHAVE_COMPRESSION

--- a/libretro-common/file/archive_file.c
+++ b/libretro-common/file/archive_file.c
@@ -319,11 +319,11 @@ static int file_archive_decompress_data_to_file(
       goto end;
    }
 
-   handle->real_checksum = handle->backend->stream_crc_calculate(
-         0, handle->data, size);
    handle->backend->stream_free(handle->stream);
 
 #if 0
+   handle->real_checksum = handle->backend->stream_crc_calculate(
+         0, handle->data, size);
    if (handle->real_checksum != checksum)
    {
       /* File CRC difers from archive CRC. */
@@ -668,16 +668,10 @@ struct string_list *file_archive_file_list_new(const char *path,
       const char* ext)
 {
 #ifdef HAVE_COMPRESSION
-   const char* file_ext = path_get_extension(path);
+   bool compressed = path_is_compressed_file(path);
 
-#ifdef HAVE_7ZIP
-   if (string_is_equal_noncase(file_ext, "7z"))
+   if (compressed)
       return file_archive_get_file_list(path, ext);
-#endif
-#ifdef HAVE_ZLIB
-   if (string_is_equal_noncase(file_ext, "zip"))
-      return file_archive_get_file_list(path, ext);
-#endif
 #endif
    return NULL;
 }

--- a/libretro-common/file/archive_file_7z.c
+++ b/libretro-common/file/archive_file_7z.c
@@ -101,11 +101,9 @@ static int sevenzip_file_read(
    allocTempImp.Alloc   = SzAllocTemp;
    allocTempImp.Free    = SzFreeTemp;
 
+   /* Could not open 7zip archive? */
    if (InFile_Open(&archiveStream.file, path))
-   {
-      //RARCH_ERR("Could not open %s as 7z archive\n.", path);
       return -1;
-   }
 
    FileInStream_CreateVTable(&archiveStream);
    LookToRead_CreateVTable(&lookStream, False);
@@ -212,13 +210,10 @@ static int sevenzip_file_read(
 
       if (!(file_found && res == SZ_OK))
       {
-         /* Error handling */
-         /*if (!file_found)
-            RARCH_ERR("%s: %s in %s.\n",
-                  msg_hash_to_str(MSG_FILE_NOT_FOUND),
-                  needle, path);*/
-
-         //RARCH_ERR("Failed to open compressed file inside 7zip archive.\n");
+         /* Error handling
+          *
+          * Failed to open compressed file inside 7zip archive.
+          */
 
          outsize    = -1;
       }
@@ -271,19 +266,18 @@ static int sevenzip_stream_decompress_data_to_file_iterate(void *data)
 static int sevenzip_parse_file_init(file_archive_transfer_t *state,
       const char *file)
 {
+   struct sevenzip_context_t *sevenzip_context = NULL;
    if (state->archive_size < SEVENZIP_MAGIC_LEN)
       return -1;
 
    if (memcmp(state->data, SEVENZIP_MAGIC, SEVENZIP_MAGIC_LEN) != 0)
       return -1;
 
-   struct sevenzip_context_t *sevenzip_context = sevenzip_stream_new();
+   sevenzip_context = sevenzip_stream_new();
 
+   /* could not open 7zip archive? */
    if (InFile_Open(&sevenzip_context->archiveStream.file, file))
-   {
-      //RARCH_ERR("Could not open as 7zip archive: %s.\n",path);
       return -1;
-   }
 
    FileInStream_CreateVTable(&sevenzip_context->archiveStream);
    LookToRead_CreateVTable(&sevenzip_context->lookStream, False);
@@ -292,7 +286,8 @@ static int sevenzip_parse_file_init(file_archive_transfer_t *state,
    CrcGenerateTable();
    SzArEx_Init(&sevenzip_context->db);
 
-   SzArEx_Open(&sevenzip_context->db, &sevenzip_context->lookStream.s, &sevenzip_context->allocImp, &sevenzip_context->allocTempImp);
+   SzArEx_Open(&sevenzip_context->db, &sevenzip_context->lookStream.s,
+         &sevenzip_context->allocImp, &sevenzip_context->allocTempImp);
 
    state->stream = sevenzip_context;
 
@@ -315,15 +310,14 @@ static int sevenzip_parse_file_iterate_step_internal(
 
       if (len < PATH_MAX_LENGTH && !file->IsDir)
       {
+         SRes res                     = SZ_ERROR_FAIL;
          char infile[PATH_MAX_LENGTH] = {0};
-         uint16_t *temp = (uint16_t*)malloc(len * sizeof(uint16_t));
+         uint16_t *temp               = (uint16_t*)malloc(len * sizeof(uint16_t));
 
          if (!temp)
             return -1;
 
          SzArEx_GetFileNameUtf16(&sevenzip_context->db, sevenzip_context->index, temp);
-
-         SRes res = SZ_ERROR_FAIL;
 
          if (temp)
          {
@@ -358,6 +352,7 @@ static int sevenzip_parse_file_iterate_step(file_archive_transfer_t *state,
    uint32_t csize       = 0;
    unsigned cmode       = 0;
    unsigned payload     = 0;
+   struct sevenzip_context_t *sevenzip_context = NULL;
    char filename[PATH_MAX_LENGTH] = {0};
    int ret = sevenzip_parse_file_iterate_step_internal(state, filename,
          &cdata, &cmode, &size, &csize,
@@ -370,8 +365,7 @@ static int sevenzip_parse_file_iterate_step(file_archive_transfer_t *state,
             csize, size, checksum, userdata))
       return 0;
 
-   struct sevenzip_context_t *sevenzip_context =
-         (struct sevenzip_context_t*)state->stream;
+   sevenzip_context = (struct sevenzip_context_t*)state->stream;
 
    sevenzip_context->index += payload;
 

--- a/libretro-common/file/archive_file_7z.c
+++ b/libretro-common/file/archive_file_7z.c
@@ -273,7 +273,7 @@ static int sevenzip_parse_file_init(file_archive_transfer_t *state,
    if (memcmp(state->data, SEVENZIP_MAGIC, SEVENZIP_MAGIC_LEN) != 0)
       return -1;
 
-   sevenzip_context = sevenzip_stream_new();
+   sevenzip_context = (struct sevenzip_context_t*)sevenzip_stream_new();
 
    /* could not open 7zip archive? */
    if (InFile_Open(&sevenzip_context->archiveStream.file, file))

--- a/libretro-common/file/archive_file_7z.c
+++ b/libretro-common/file/archive_file_7z.c
@@ -26,6 +26,7 @@
 #include <streams/file_stream.h>
 #include <retro_miscellaneous.h>
 #include <encodings/utf.h>
+#include <encodings/crc32.h>
 #include <string/stdstring.h>
 #include <lists/string_list.h>
 #include <file/file_path.h>
@@ -334,7 +335,7 @@ static int sevenzip_parse_file_iterate_step_internal(
          if (res != SZ_OK)
             return -1;
 
-         strlcpy(filename, infile, sizeof(infile));
+         strlcpy(filename, infile, PATH_MAX_LENGTH);
 
          *cmode = ARCHIVE_MODE_COMPRESSED;
          *checksum = file->Crc;
@@ -380,7 +381,7 @@ static int sevenzip_parse_file_iterate_step(file_archive_transfer_t *state,
 static uint32_t sevenzip_stream_crc32_calculate(uint32_t crc,
       const uint8_t *data, size_t length)
 {
-   return CrcUpdate(crc, data, length);
+   return encoding_crc32(crc, data, length);
 }
 
 const struct file_archive_file_backend sevenzip_backend = {

--- a/libretro-common/file/archive_file_zlib.c
+++ b/libretro-common/file/archive_file_zlib.c
@@ -239,11 +239,9 @@ static bool zip_file_decompressed_handle(
          handle->data, size);
 
    if (handle->real_checksum != crc32)
-   {
-      //RARCH_ERR("%s\n", msg_hash_to_str(MSG_INFLATED_CHECKSUM_DID_NOT_MATCH_CRC32));
       goto error;
-   }
 #endif
+
    if (handle->stream)
       free(handle->stream);
 
@@ -257,8 +255,8 @@ error:
 
    handle->stream = NULL;
    handle->data   = NULL;
-#endif
    return false;
+#endif
 }
 
 /* Extract the relative path (needle) from a
@@ -280,7 +278,9 @@ static int zip_file_decompressed(
    if (name[strlen(name) - 1] == '/' || name[strlen(name) - 1] == '\\')
       return 1;
 
-   //RARCH_LOG("[deflate] Path: %s, CRC32: 0x%x\n", name, crc32);
+#if 0
+   RARCH_LOG("[deflate] Path: %s, CRC32: 0x%x\n", name, crc32);
+#endif
 
    if (strstr(name, st->needle))
    {
@@ -416,23 +416,23 @@ static int zip_parse_file_iterate_step_internal(
    if (signature != CENTRAL_FILE_HEADER_SIGNATURE)
       return 0;
 
-   *cmode         = read_le(state->directory + 10, 2); // compression mode, 0 = store, 8 = deflate
-   *checksum      = read_le(state->directory + 16, 4); // CRC32
-   *csize         = read_le(state->directory + 20, 4); // compressed size
-   *size          = read_le(state->directory + 24, 4); // uncompressed size
+   *cmode         = read_le(state->directory + 10, 2); /* compression mode, 0 = store, 8 = deflate */
+   *checksum      = read_le(state->directory + 16, 4); /* CRC32 */
+   *csize         = read_le(state->directory + 20, 4); /* compressed size */
+   *size          = read_le(state->directory + 24, 4); /* uncompressed size */
 
-   namelength     = read_le(state->directory + 28, 2); // file name length
-   extralength    = read_le(state->directory + 30, 2); // extra field length
-   commentlength  = read_le(state->directory + 32, 2); // file comment length
+   namelength     = read_le(state->directory + 28, 2); /* file name length */
+   extralength    = read_le(state->directory + 30, 2); /* extra field length */
+   commentlength  = read_le(state->directory + 32, 2); /* file comment length */
 
    if (namelength >= PATH_MAX_LENGTH)
       return -1;
 
-   memcpy(filename, state->directory + 46, namelength); // file name
+   memcpy(filename, state->directory + 46, namelength); /* file name */
 
-   offset         = read_le(state->directory + 42, 4); // relative offset of local file header
-   offsetNL       = read_le(state->data + offset + 26, 2); // file name length
-   offsetEL       = read_le(state->data + offset + 28, 2); // extra field length
+   offset         = read_le(state->directory + 42, 4); /* relative offset of local file header */
+   offsetNL       = read_le(state->data + offset + 26, 2); /* file name length */
+   offsetEL       = read_le(state->data + offset + 28, 2); /* extra field length */
 
    *cdata         = state->data + offset + 30 + offsetNL + offsetEL;
 

--- a/libretro-common/file/archive_file_zlib.c
+++ b/libretro-common/file/archive_file_zlib.c
@@ -27,6 +27,7 @@
 #include <streams/file_stream.h>
 #include <string.h>
 #include <retro_miscellaneous.h>
+#include <encodings/crc32.h>
 
 #ifndef CENTRAL_FILE_HEADER_SIGNATURE
 #define CENTRAL_FILE_HEADER_SIGNATURE 0x02014b50
@@ -204,7 +205,7 @@ static void zlib_stream_compress_init(void *data, int level)
 static uint32_t zlib_stream_crc32_calculate(uint32_t crc,
       const uint8_t *data, size_t length)
 {
-   return crc32(crc, data, length);
+   return encoding_crc32(crc, data, length);
 }
 
 struct decomp_state
@@ -233,7 +234,7 @@ static bool zip_file_decompressed_handle(
       ret = handle->backend->stream_decompress_data_to_file_iterate(
             handle->stream);
    }while(ret == 0);
-
+#if 0
    handle->real_checksum = handle->backend->stream_crc_calculate(0,
          handle->data, size);
 
@@ -242,12 +243,12 @@ static bool zip_file_decompressed_handle(
       //RARCH_ERR("%s\n", msg_hash_to_str(MSG_INFLATED_CHECKSUM_DID_NOT_MATCH_CRC32));
       goto error;
    }
-
+#endif
    if (handle->stream)
       free(handle->stream);
 
    return true;
-
+#if 0
 error:
    if (handle->stream)
       free(handle->stream);
@@ -256,7 +257,7 @@ error:
 
    handle->stream = NULL;
    handle->data   = NULL;
-
+#endif
    return false;
 }
 

--- a/libretro-common/include/lists/string_list.h
+++ b/libretro-common/include/lists/string_list.h
@@ -44,7 +44,7 @@ struct string_list_elem
    union string_list_elem_attr attr;
 };
 
-struct __attribute__ ((aligned(1))) string_list
+struct string_list
 {
    struct string_list_elem *elems;
    size_t size;

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -421,12 +421,14 @@ static bool read_content_file(unsigned i, const char *path, void **buf,
       file_archive_get_file_backend(path);
 
    if (stream_backend)
+   {
       stream_info.crc = stream_backend->stream_crc_calculate(
             stream_info.a, stream_info.b, stream_info.c);
 
-   *content_crc_ptr = stream_info.crc;
+      *content_crc_ptr = stream_info.crc;
 
-   RARCH_LOG("CRC32: 0x%x .\n", (unsigned)*content_crc_ptr);
+      RARCH_LOG("CRC32: 0x%x .\n", (unsigned)*content_crc_ptr);
+   }
 #endif
    *buf = ret_buf;
 

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -715,8 +715,10 @@ static bool init_content_file_extract(
 
    for (i = 0; i < content->size; i++)
    {
-      bool compressed       = NULL;
-      const char *valid_ext = system->info.valid_extensions;
+      char temp_content[PATH_MAX_LENGTH] = {0};
+      char new_path[PATH_MAX_LENGTH]     = {0};
+      bool compressed                    = NULL;
+      const char *valid_ext              = system->info.valid_extensions;
 
       /* Block extract check. */
       if (content->elems[i].attr.i & 1)
@@ -729,9 +731,6 @@ static bool init_content_file_extract(
 
       if (!compressed)
          continue;
-
-      char new_path[PATH_MAX_LENGTH]     = {0};
-      char temp_content[PATH_MAX_LENGTH] = {0};
 
       strlcpy(temp_content, content->elems[i].data,
             sizeof(temp_content));


### PR DESCRIPTION
- use the detected stream backend's crc32 function
- remove zlib/7zip ifdef from archive_file.c, task_content.c and task_database.c
- don't re-compute CRC from one stored in archive
