### PR TITLE
Allow asyncify for emscripten

### DIFF
--- a/Makefile.emscripten
+++ b/Makefile.emscripten
@@ -6,7 +6,7 @@ EOPTS = $(addprefix -s $(EMPTY), $(EOPT)) # Add '-s ' to each option
 OS = Emscripten
 OBJ :=
 DEFINES := -DRARCH_INTERNAL -DHAVE_OVERLAY -DHAVE_MAIN
-DEFINES += -DHAVE_OPENGL -DHAVE_OPENGLES -DHAVE_OPENGLES2 -DHAVE_EGL -DHAVE_OVERLAY -DHAVE_GLSL -DHAVE_FILTERS_BUILTIN 
+DEFINES += -DHAVE_OPENGL -DHAVE_OPENGLES -DHAVE_OPENGLES2 -DHAVE_EGL -DHAVE_OVERLAY -DHAVE_GLSL -DHAVE_FILTERS_BUILTIN
 
 HAVE_EGL    = 1
 HAVE_OPENGLES = 1
@@ -35,7 +35,7 @@ endif
 #if you compile with SDL2 flag add this Emscripten flag "-s USE_SDL=2" to LDFLAGS:
 
 LIBS    := -s USE_SDL=2 -s USE_ZLIB=1
-LDFLAGS := -L. --no-heap-copy -s USE_ZLIB=1 -s TOTAL_MEMORY=$(MEMORY) -s OUTLINING_LIMIT=50000 \
+LDFLAGS := -L. --no-heap-copy -s USE_ZLIB=1 -s TOTAL_MEMORY=$(MEMORY) -s ASYNCIFY=1 -s FULL_ES2=1 \
            -s EXPORTED_FUNCTIONS="['_main', '_malloc', '_cmd_savefiles', '_cmd_save_state', '_cmd_load_state', '_cmd_take_screenshot']" \
            --js-library emscripten/library_rwebaudio.js \
            --js-library emscripten/library_rwebinput.js \

--- a/Makefile.emscripten
+++ b/Makefile.emscripten
@@ -1,6 +1,6 @@
 TARGET := retroarch.js
 
-EOPT = USE_ZLIB=1 USE_SDL=2 FULL_ES2=1 # Emscripten specific options
+EOPT = USE_ZLIB=1 USE_SDL=2 # Emscripten specific options
 EOPTS = $(addprefix -s $(EMPTY), $(EOPT)) # Add '-s ' to each option
 
 OS = Emscripten
@@ -35,7 +35,7 @@ endif
 #if you compile with SDL2 flag add this Emscripten flag "-s USE_SDL=2" to LDFLAGS:
 
 LIBS    := -s USE_SDL=2 -s USE_ZLIB=1
-LDFLAGS := -L. --no-heap-copy -s USE_ZLIB=1 -s TOTAL_MEMORY=$(MEMORY) -s ASYNCIFY=1 -s FULL_ES2=1 \
+LDFLAGS := -L. --no-heap-copy -s USE_ZLIB=1 -s TOTAL_MEMORY=$(MEMORY) -s ASYNCIFY=1 \
            -s EXPORTED_FUNCTIONS="['_main', '_malloc', '_cmd_savefiles', '_cmd_save_state', '_cmd_load_state', '_cmd_take_screenshot']" \
            --js-library emscripten/library_rwebaudio.js \
            --js-library emscripten/library_rwebinput.js \


### PR DESCRIPTION
Also fixes FULL_ES2

**Please don't merge this until @fr500 has weighed in.**

This fixes asyncify (allows you to use emscripten_yield and such). It also fixes ES2.

With these changes I can get GLupeN64 to work, although there is still something wrong (missing textures), but that might be some kind of incompatibility with GLideN64 and WebGL

I'm not sure what the performance impact of ASYNCIFY might be on cores that don't use it, so this should probably be tested more thoroughly before it is merged, but this should allow cores that rely on libco to be ported to emscripten.