### PR TITLE
Fix socket_send_all_blocking to fail on errors not related to blocking

### DIFF
--- a/libretro-common/net/net_socket.c
+++ b/libretro-common/net/net_socket.c
@@ -164,7 +164,7 @@ int socket_send_all_blocking(int fd, const void *data_, size_t size,
             no_signal ? MSG_NOSIGNAL : 0);
       if (ret <= 0)
       {
-         if (!isagain(ret))
+         if (isagain(ret))
             continue;
 
          return false;


### PR DESCRIPTION
Netplay sometimes had some strange behaviors when one side or the other disconnected: Quitting, hanging, doing all sorts of nonsensical things.

Upon digging into the underlying network code I found what seems to be a very odd bug: socket_send_all_blocking continued attempting to send if the socket gave any sort of error *other* than EAGAIN. This means that if the socket reported a disconnection, for instance, the function would just try, try again, fruitlessly, hanging RetroArch.

I reversed the logic so that it only tries again with EAGAIN. I believe that this is the correct logic, and up to the limits of my ability to test it, this change fixed all strange behaviors with Netplay disconnecting.

The only other code that depends on this functionality is net_http.c and its various dependencies, so I would advise testing HTTP code for similar disconnection problems.