### PR TITLE
Support for Netplay reconnection

### DIFF
--- a/network/netplay/netplay_private.h
+++ b/network/netplay/netplay_private.h
@@ -87,6 +87,8 @@ struct netplay
    struct retro_callbacks cbs;
    /* TCP connection for state sending, etc. Also used for commands */
    int fd;
+   /* TCP port (if serving) */
+   uint16_t tcp_port;
    /* Which port is governed by netplay (other user)? */
    unsigned port;
    bool has_connection;


### PR DESCRIPTION
In net (normal) server mode, when the client disconnects, the server now returns to listening mode, in anticipation of the client reconnecting. The client is still reduced to quitting and restarting RetroArch in order to reconnect, but at least they'll rejoin the active game since the server remembers the state. The previous behavior was that reconnects simply could never occur, and prior to that, there were no save states over Netplay regardless, so disconnection was pretty catastrophic.

This is phase two of my "make netplay's user interface less garbagey" initiative. Phase three is client live reconnection. Unfortunately, phase three and further all require changes to the menu that are somewhat out of my depth, and phases four and further will require deeper changes to let Netplay activate during normal gameplay (which, bear in mind, involves redirecting most of the polling interfaces that otherwise go straight to the core). Again, if somebody else is interested in making the menu side work, we can work together to make RetroArch's Netplay the killer feature it deserves to be.