### PR TITLE
Silence warning with GL_DEBUG=1

### DIFF
--- a/cores/libretro-ffmpeg/fft/fft.cpp
+++ b/cores/libretro-ffmpeg/fft/fft.cpp
@@ -17,7 +17,7 @@
 #include <glm/gtc/type_ptr.hpp>
 using namespace glm;
 
-#define GL_DEBUG 0
+#undef GL_DEBUG
 #if GL_DEBUG
 #define GL_CHECK_ERROR() do { \
    if (glGetError() != GL_NO_ERROR) \


### PR DESCRIPTION
Please make sure I am not doing something stupid before merging.

This should silence the following warning with `GL_DEBUG=1` and gcc-5.4.0.
```
cores/libretro-ffmpeg/fft/fft.cpp:20:0: warning: "GL_DEBUG" redefined
 #define GL_DEBUG 0
 ^
<command-line>:0:0: note: this is the location of the previous definition
```