### PR TITLE
Allow pthread support in emscripten

### DIFF
--- a/Makefile.emscripten
+++ b/Makefile.emscripten
@@ -37,7 +37,7 @@ endif
 #if you compile with SDL2 flag add this Emscripten flag "-s USE_SDL=2" to LDFLAGS:
 
 LIBS    := -s USE_SDL=2 -s USE_ZLIB=1
-LDFLAGS := -L. --no-heap-copy -s USE_ZLIB=1 -s TOTAL_MEMORY=$(MEMORY) -s ASYNCIFY=$(ASYNC) -s USE_PTHREADS=$(PTHREAD) \
+LDFLAGS := -L. --no-heap-copy -s USE_ZLIB=1 -s TOTAL_MEMORY=$(MEMORY) -s ASYNCIFY=$(ASYNC) -s USE_PTHREADS=$(PTHREAD) -s PTHREAD_POOL_SIZE=2 \
            -s EXPORTED_FUNCTIONS="['_main', '_malloc', '_cmd_savefiles', '_cmd_save_state', '_cmd_load_state', '_cmd_take_screenshot']" \
            --js-library emscripten/library_rwebaudio.js \
            --js-library emscripten/library_rwebinput.js \

--- a/Makefile.emscripten
+++ b/Makefile.emscripten
@@ -3,9 +3,10 @@ TARGET := retroarch.js
 EOPT = USE_ZLIB=1 USE_SDL=2 # Emscripten specific options
 EOPTS = $(addprefix -s $(EMPTY), $(EOPT)) # Add '-s ' to each option
 
+PTHREAD = 0
 OS = Emscripten
 OBJ :=
-DEFINES := -DRARCH_INTERNAL -DHAVE_OVERLAY -DHAVE_MAIN
+DEFINES := -DRARCH_INTERNAL -DHAVE_OVERLAY -DHAVE_MAIN -s USE_PTHREADS=$(PTHREAD)
 DEFINES += -DHAVE_OPENGL -DHAVE_OPENGLES -DHAVE_OPENGLES2 -DHAVE_EGL -DHAVE_OVERLAY -DHAVE_GLSL -DHAVE_FILTERS_BUILTIN
 
 HAVE_EGL    = 1
@@ -36,7 +37,7 @@ endif
 #if you compile with SDL2 flag add this Emscripten flag "-s USE_SDL=2" to LDFLAGS:
 
 LIBS    := -s USE_SDL=2 -s USE_ZLIB=1
-LDFLAGS := -L. --no-heap-copy -s USE_ZLIB=1 -s TOTAL_MEMORY=$(MEMORY) -s ASYNCIFY=$(ASYNC) \
+LDFLAGS := -L. --no-heap-copy -s USE_ZLIB=1 -s TOTAL_MEMORY=$(MEMORY) -s ASYNCIFY=$(ASYNC) -s USE_PTHREADS=$(PTHREAD) \
            -s EXPORTED_FUNCTIONS="['_main', '_malloc', '_cmd_savefiles', '_cmd_save_state', '_cmd_load_state', '_cmd_take_screenshot']" \
            --js-library emscripten/library_rwebaudio.js \
            --js-library emscripten/library_rwebinput.js \


### PR DESCRIPTION
From the emscripten docs:

Pass the compiler flag -s USE_PTHREADS=1 when compiling any .c/.cpp files, AND when linking to generate the final output .js file.

If a page is built with the -s USE_PTHREADS=1 linker flag, then it will not run backwards compatibly in a non-supporting browser. In order to enable backwards compatibility so that multithreaded pages can run in non-supporting browsers (except with pthread_create() disabled), pass the linker flag -s USE_PTHREADS=2 instead.