### PR TITLE
Don't serialize frame 0 in netplay, as the core may not yet be ready

### DIFF
--- a/network/netplay/netplay_net.c
+++ b/network/netplay/netplay_net.c
@@ -59,7 +59,8 @@ static bool netplay_net_pre_frame(netplay_t *netplay)
 {
    retro_ctx_serialize_info_t serial_info;
 
-   if (netplay_delta_frame_ready(netplay, &netplay->buffer[netplay->self_ptr], netplay->self_frame_count))
+   if (netplay_delta_frame_ready(netplay, &netplay->buffer[netplay->self_ptr], netplay->self_frame_count) &&
+       netplay->self_frame_count > 0 /* Frame 0 may not yet be ready for serialization */)
    {
       serial_info.data_const = NULL;
       serial_info.data = netplay->buffer[netplay->self_ptr].state;


### PR DESCRIPTION
Fixes (mostly) netplay with e.g. mupen64, which segfaults if you try to serialize frame 0. We never rewind to frame 0 regardless, since the first frame of input is always ignored, so this simply avoids some segfaults without affecting behavior at all.