### PR TITLE
Reset player flip state when we lose Netplay connection

### DIFF
--- a/network/netplay/netplay.c
+++ b/network/netplay/netplay.c
@@ -77,7 +77,11 @@ static void hangup(netplay_t *netplay)
       }
 
       netplay->has_connection = false;
+
+      /* Reset things that will behave oddly if we get a new connection */
       netplay->remote_paused = false;
+      netplay->flip = false;
+      netplay->flip_frame = 0;
 
    }
 }


### PR DESCRIPTION
With the new netplay reconnection feature, if the server had flipped players and then lost connection, it would connect with players flipped, but the client would expect unflipped, so they'd go out of sync. This fixes that bug.