### PR TITLE
Specify EGL_DEPTH_SIZE for emscripten

### DIFF
--- a/gfx/drivers_context/emscriptenegl_ctx.c
+++ b/gfx/drivers_context/emscriptenegl_ctx.c
@@ -139,6 +139,7 @@ static void *gfx_ctx_emscripten_init(void *video_driver)
       EGL_GREEN_SIZE, 8,
       EGL_BLUE_SIZE, 8,
       EGL_ALPHA_SIZE, 8,
+      EGL_DEPTH_SIZE, 16,
       EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
       EGL_NONE
    };


### PR DESCRIPTION
Some drivers require it to provide a depth buffer.