### PR TITLE
Only call glUniformMatrix4fv if needed

### DIFF
--- a/gfx/drivers_shader/shader_glsl.c
+++ b/gfx/drivers_shader/shader_glsl.c
@@ -1256,6 +1256,7 @@ static void gl_glsl_set_params(void *data, void *shader_data,
 
 static bool gl_glsl_set_mvp(void *data, void *shader_data, const math_matrix_4x4 *mat)
 {
+   static float current_mat_data[GFX_MAX_SHADERS];
    int loc;
    glsl_shader_data_t *glsl = (glsl_shader_data_t*)shader_data;
 
@@ -1265,9 +1266,12 @@ static bool gl_glsl_set_mvp(void *data, void *shader_data, const math_matrix_4x4
       goto fallback;
 
    loc = glsl->uniforms[glsl->active_idx].mvp;
-   if (loc >= 0)
-      glUniformMatrix4fv(loc, 1, GL_FALSE, mat->data);
-
+   if (loc >= 0) {
+      if (*mat->data != current_mat_data[loc]) {
+         glUniformMatrix4fv(loc, 1, GL_FALSE, mat->data);
+         current_mat_data[loc] = *mat->data;
+      }
+   }
    return true;
 
 fallback:


### PR DESCRIPTION
Right now, glUniformMatrix4fv is called every frame. It really only needs to be called if something has changed, so that's what this does.

Someone with some GL experience should probably look this over before it is merged. I tested it with shaders and everything seems to be fine though.