### PR TITLE
Fix delay_frames=0 mode to work with the recent late-loading workaround

### DIFF
--- a/network/netplay/netplay.c
+++ b/network/netplay/netplay.c
@@ -598,7 +598,7 @@ static bool netplay_poll(netplay_t *netplay)
 
    /* WORKAROUND: The only reason poll_input is ignored in the first frame is
     * that some cores can't report state size until after the first frame. */
-   if (netplay->self_frame_count > 0)
+   if (netplay->self_frame_count > 0 || netplay->stall)
    {
       /* Read Netplay input, block if we're configured to stall for input every
        * frame */

--- a/network/netplay/netplay_net.c
+++ b/network/netplay/netplay_net.c
@@ -261,7 +261,10 @@ static void netplay_net_post_frame(netplay_t *netplay)
       serial_info.data_const = netplay->buffer[netplay->replay_ptr].state;
       serial_info.size       = netplay->state_size;
 
-      core_unserialize(&serial_info);
+      if (!core_unserialize(&serial_info))
+      {
+         RARCH_ERR("Netplay savestate loading failed: Prepare for desync!\n");
+      }
 
       while (netplay->replay_frame_count < netplay->self_frame_count)
       {


### PR DESCRIPTION
My recent workaround to push some events later and avoid early-loading crashes broke delay_frames=0, since in delay_frames=0 mode we never proceed to "later", so it would just stall. This fixes that.