### PR TITLE
Set delay_frames to 16 by default

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -933,7 +933,7 @@ static int populate_settings_int(settings_t *settings, struct config_int_setting
    SETTING_INT("state_slot",                   (unsigned*)&settings->state_slot, false, 0 /* TODO */, false);
 #ifdef HAVE_NETWORKING
    SETTING_INT("netplay_ip_port",              &global->netplay.port, false, 0 /* TODO */, false);
-   SETTING_INT("netplay_delay_frames",         &global->netplay.sync_frames, false, 16, false);
+   SETTING_INT("netplay_delay_frames",         &global->netplay.sync_frames, true, 16, false);
    SETTING_INT("netplay_check_frames",         &global->netplay.check_frames, false, 0, false);
 #endif
 #ifdef HAVE_LANGEXTRA


### PR DESCRIPTION
delay_frames should default to a value that works well on the Internet. delay_frames=0 only works well on LAN.