### PR TITLE
Somewhat fixing support for savestateless cores

### DIFF
--- a/network/netplay/netplay_net.c
+++ b/network/netplay/netplay_net.c
@@ -61,8 +61,7 @@ static bool netplay_net_pre_frame(netplay_t *netplay)
 {
    retro_ctx_serialize_info_t serial_info;
 
-   if (netplay_delta_frame_ready(netplay, &netplay->buffer[netplay->self_ptr], netplay->self_frame_count) &&
-       netplay->self_frame_count > 0 /* Frame 0 may not yet be ready for serialization */)
+   if (netplay_delta_frame_ready(netplay, &netplay->buffer[netplay->self_ptr], netplay->self_frame_count))
    {
       serial_info.data_const = NULL;
       serial_info.data = netplay->buffer[netplay->self_ptr].state;
@@ -206,7 +205,11 @@ static void netplay_net_post_frame(netplay_t *netplay)
 
    /* Only relevant if we're connected */
    if (!netplay->has_connection)
+   {
+      netplay->read_frame_count = netplay->other_frame_count = netplay->self_frame_count;
+      netplay->read_ptr = netplay->other_ptr = netplay->self_ptr;
       return;
+   }
 
    if (!netplay->force_rewind)
    {


### PR DESCRIPTION
Without early saves we couldn't properly detect savestateless cores. We still can't, really, but we can at least EVENTUALLY detect this condition. netplay_net has been fixed to do so.

This is a very partial fix, and savestateless cores were only partially broken. Currently, we'll allow a few frames to pass before stalling the core, so whether the client and host stay in sync depends on how they respond to input after that point. Without a savestates quirk interface, there's no better way to handle this case.