### PR TITLE
Removing Netplay workarounds in anticipation of quirks API

### DIFF
--- a/network/netplay/netplay_spectate.c
+++ b/network/netplay/netplay_spectate.c
@@ -36,29 +36,6 @@
  **/
 static bool netplay_spectate_pre_frame(netplay_t *netplay)
 {
-   /* WORKAROUND: We initialize the buffer states here as part of a workaround
-    * for cores that can't even core_serialize_size early. */
-   if (netplay->self_frame_count == 0 && netplay->state_size == 0)
-   {
-      unsigned i;
-      retro_ctx_size_info_t info;
-
-      core_serialize_size(&info);
-
-      netplay->state_size = info.size;
-
-      for (i = 0; i < netplay->buffer_size; i++)
-      {
-         netplay->buffer[i].state = calloc(netplay->state_size, 1);
-
-         if (!netplay->buffer[i].state)
-         {
-            netplay->savestates_work = false;
-            netplay->stall_frames = 0;
-         }
-      }
-   }
-
    if (netplay_is_server(netplay))
    {
       fd_set fds;


### PR DESCRIPTION
The Netplay workarounds to avoid serialization early in execution were enough to get mupen64 working, but as my last few PRs can attest to, it broke more than it fixed. In particular it made savestateless cores unreliable, and supporting savestateless cores was a big part of the netplay changes, so that's bad. This eliminates those workarounds.

This removes support for e.g. mupen64, but is in anticipation of the discussed quirks API, which will open the door for mupen64 and virtually all other cores.