### PR TITLE
libretro API: VFS discussion (was Multiple system directories)

### DIFF
--- a/dynamic.c
+++ b/dynamic.c
@@ -1608,6 +1608,19 @@ bool rarch_environment_cb(unsigned cmd, void *data)
          break;
       }
 
+      case RETRO_ENVIRONMENT_GET_RESOURCE_DIRECTORY:
+      {
+         const struct retro_resource_path *res = (const struct retro_resource_path*)data;
+
+         const char *system_dir = NULL;
+         if (!rarch_environment_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, (void*)&system_dir) || system_dir == NULL)
+            return false;
+
+         strncpy(res->base_directory, system_dir, res->base_directory_max_len);
+
+         break;
+      }
+
       /* Default */
       default:
          RARCH_LOG("Environ UNSUPPORTED (#%u).\n", cmd);

--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -976,6 +976,22 @@ struct retro_hw_render_context_negotiation_interface
                                             * so it will be used after SET_HW_RENDER, but before the context_reset callback.
                                             */
 
+/* Struct to query for system files among multiple system directories */
+struct retro_resource_path
+{
+   const char *rel_path;
+   char *base_directory;
+   size_t base_directory_max_len;
+};
+
+#define RETRO_ENVIRONMENT_GET_RESOURCE_DIRECTORY 44
+                                           /* struct retro_resource_path * --
+                                            * Interface to acquire resource paths by a relative filename.
+                                            * 'rel_path' should be set to a filename relative to the system directory.
+                                            * 'base_directory' will be set to the base directory containing the resource or the empty string if unknown.
+                                            * 'base_directory_max_len' is the maximum amount of bytes that can be written to base_directory
+                                            */
+
 #define RETRO_MEMDESC_CONST     (1 << 0)   /* The frontend will never change this memory area once retro_load_game has returned. */
 #define RETRO_MEMDESC_BIGENDIAN (1 << 1)   /* The memory area contains big endian data. Default is little endian. */
 #define RETRO_MEMDESC_ALIGN_2   (1 << 16)  /* All memory access in this area is aligned to their own size, or 2, whichever is smaller. */


### PR DESCRIPTION
I'm trying to tackle the copyright-restricted BIOSes issue in Kodi. My solution is to add a second system directory for restricted files. That way, nonrestricted files can be distributed with the libretro core for maximum out-of-the-box compatibility, while still allowing alternative sources for restricted content.

I've added an environment command that retrieves the correct system directory for a specified file. This degrades gracefully in RetroArch, where the original system directory is returned for all files. In the future, RetroArch could add support for multiple system directories to allow the separation of free and restricted content.

I've implemented the new environment command in two cores:

* [Genesis Plus GX](https://github.com/kodi-game/Genesis-Plus-GX/commit/resources)
* [BlueMSX](https://github.com/kodi-game/blueMSX-libretro/commit/resources)

These examples show that core modifications can be minor and constrained to the libretro-specific code.