### PR TITLE
Get rid of global->netplay

### DIFF
--- a/audio/audio_driver.c
+++ b/audio/audio_driver.c
@@ -32,6 +32,10 @@
 #include "../record/record_driver.h"
 #include "audio_thread_wrapper.h"
 
+#ifdef HAVE_NETWORKING
+#include "network/netplay/netplay.h"
+#endif
+
 #include "../command.h"
 #include "../driver.h"
 #include "../configuration.h"
@@ -855,8 +859,7 @@ bool audio_driver_set_callback(const void *data)
 {
    const struct retro_audio_callback *cb = (const struct retro_audio_callback*)data;
 #ifdef HAVE_NETWORKING
-   global_t *global = global_get_ptr();
-   if (global->netplay.enable)
+   if (netplay_driver_ctl(RARCH_NETPLAY_CTL_IS_ENABLED, NULL))
       return false;
 #endif
 

--- a/command.c
+++ b/command.c
@@ -1209,7 +1209,7 @@ static void command_event_load_auto_state(void)
    global_t   *global   = global_get_ptr();
 
 #ifdef HAVE_NETWORKING
-   if (global->netplay.enable && !global->netplay.is_spectate)
+   if (netplay_driver_ctl(RARCH_NETPLAY_CTL_IS_ENABLED, NULL) && !settings->netplay.is_spectate)
       return;
 #endif
 
@@ -1312,8 +1312,7 @@ static bool event_init_content(void)
    if (content_does_not_need_content())
    {
 #ifdef HAVE_NETWORKING
-      global_t   *global = global_get_ptr();
-      if (global->netplay.enable)
+      if (netplay_driver_ctl(RARCH_NETPLAY_CTL_IS_ENABLED, NULL))
          RARCH_ERR("sorry, unimplemented: cores that don't demand content cannot participate in netplay\n");
 #endif
       return true;
@@ -2351,7 +2350,9 @@ bool command_event(enum event_command cmd, void *data)
       case CMD_EVENT_NETPLAY_INIT:
          command_event(CMD_EVENT_NETPLAY_DEINIT, NULL);
 #ifdef HAVE_NETWORKING
-         if (!init_netplay())
+         if (!init_netplay(settings->netplay.is_client,
+              settings->netplay.is_spectate, settings->netplay.server,
+              settings->netplay.port))
             return false;
 #endif
          break;

--- a/configuration.c
+++ b/configuration.c
@@ -587,7 +587,7 @@ static int populate_settings_path(settings_t *settings, struct config_path_setti
    SETTING_PATH("core_updater_buildbot_url", settings->network.buildbot_url, false, NULL, true);
    SETTING_PATH("core_updater_buildbot_assets_url", settings->network.buildbot_assets_url, false, NULL, true);
 #ifdef HAVE_NETWORKING
-   SETTING_PATH("netplay_ip_address",       global->netplay.server, false, NULL, true);
+   SETTING_PATH("netplay_ip_address",       settings->netplay.server, false, NULL, true);
 #endif
    SETTING_PATH("recording_output_directory",
          global->record.output_dir, false, NULL, true);
@@ -702,7 +702,7 @@ static int populate_settings_bool(settings_t *settings, struct config_bool_setti
    SETTING_BOOL("input_remap_binds_enable",      &settings->input.remap_binds_enable, true, true, false);
    SETTING_BOOL("back_as_menu_toggle_enable",    &settings->input.back_as_menu_toggle_enable, true, true, false);
    SETTING_BOOL("all_users_control_menu",        &settings->input.all_users_control_menu, true, all_users_control_menu, false);
-   SETTING_BOOL("netplay_client_swap_input",     &settings->input.netplay_client_swap_input, true, netplay_client_swap_input, false);
+   SETTING_BOOL("netplay_client_swap_input",     &settings->netplay.swap_input, true, netplay_client_swap_input, false);
    SETTING_BOOL("input_descriptor_label_show",   &settings->input.input_descriptor_label_show, true, input_descriptor_label_show, false);
    SETTING_BOOL("input_descriptor_hide_unbound", &settings->input.input_descriptor_hide_unbound, true, input_descriptor_hide_unbound, false);
    SETTING_BOOL("load_dummy_on_core_shutdown",   &settings->load_dummy_on_core_shutdown, true, load_dummy_on_core_shutdown, false);
@@ -802,8 +802,8 @@ static int populate_settings_bool(settings_t *settings, struct config_bool_setti
    SETTING_BOOL("network_remote_enable",        &settings->network_remote_enable, false, false /* TODO */, false);
 #endif
 #ifdef HAVE_NETWORKING
-   SETTING_BOOL("netplay_spectator_mode_enable",&global->netplay.is_spectate, false, false /* TODO */, false);
-   SETTING_BOOL("netplay_mode",                 &global->netplay.is_client, false, false /* TODO */, false);
+   SETTING_BOOL("netplay_spectator_mode_enable",&settings->netplay.is_spectate, false, false /* TODO */, false);
+   SETTING_BOOL("netplay_mode",                 &settings->netplay.is_client, false, false /* TODO */, false);
 #endif
    SETTING_BOOL("block_sram_overwrite",         &settings->block_sram_overwrite, true, block_sram_overwrite, false);
    SETTING_BOOL("savestate_auto_index",         &settings->savestate_auto_index, true, savestate_auto_index, false);
@@ -932,9 +932,9 @@ static int populate_settings_int(settings_t *settings, struct config_int_setting
    SETTING_INT("aspect_ratio_index",           &settings->video.aspect_ratio_idx, true, aspect_ratio_idx, false);
    SETTING_INT("state_slot",                   (unsigned*)&settings->state_slot, false, 0 /* TODO */, false);
 #ifdef HAVE_NETWORKING
-   SETTING_INT("netplay_ip_port",              &global->netplay.port, false, 0 /* TODO */, false);
-   SETTING_INT("netplay_delay_frames",         &global->netplay.sync_frames, true, 16, false);
-   SETTING_INT("netplay_check_frames",         &global->netplay.check_frames, false, 0, false);
+   SETTING_INT("netplay_ip_port",              &settings->netplay.port, false, 0 /* TODO */, false);
+   SETTING_INT("netplay_delay_frames",         &settings->netplay.sync_frames, true, 16, false);
+   SETTING_INT("netplay_check_frames",         &settings->netplay.check_frames, false, 0, false);
 #endif
 #ifdef HAVE_LANGEXTRA
    SETTING_INT("user_language",                &settings->user_language, true, RETRO_LANGUAGE_ENGLISH, false);
@@ -1770,7 +1770,7 @@ static bool config_load_file(const char *path, bool set_defaults,
 
 #ifdef HAVE_NETWORKING
    if (retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_NETPLAY_IP_ADDRESS, NULL))
-      override_netplay_ip_address = strdup(global->netplay.server);
+      override_netplay_ip_address = strdup(settings->netplay.server);
 #endif
 
    /* Boolean settings */
@@ -1811,10 +1811,10 @@ static bool config_load_file(const char *path, bool set_defaults,
 
 #ifdef HAVE_NETWORKING
    if (!retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_NETPLAY_MODE, NULL))
-      CONFIG_GET_BOOL_BASE(conf, global, netplay.is_spectate,
+      CONFIG_GET_BOOL_BASE(conf, settings, netplay.is_spectate,
             "netplay_spectator_mode_enable");
    if (!retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_NETPLAY_MODE, NULL))
-      CONFIG_GET_BOOL_BASE(conf, global, netplay.is_client, "netplay_mode");
+      CONFIG_GET_BOOL_BASE(conf, settings, netplay.is_client, "netplay_mode");
 #endif
 #ifdef HAVE_NETWORKGAMEPAD
    for (i = 0; i < MAX_USERS; i++)
@@ -1861,11 +1861,11 @@ static bool config_load_file(const char *path, bool set_defaults,
 
 #ifdef HAVE_NETWORKING
    if (!retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_NETPLAY_DELAY_FRAMES, NULL))
-      CONFIG_GET_INT_BASE(conf, global, netplay.sync_frames, "netplay_delay_frames");
+      CONFIG_GET_INT_BASE(conf, settings, netplay.sync_frames, "netplay_delay_frames");
    if (!retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_NETPLAY_CHECK_FRAMES, NULL))
-      CONFIG_GET_INT_BASE(conf, global, netplay.check_frames, "netplay_check_frames");
+      CONFIG_GET_INT_BASE(conf, settings, netplay.check_frames, "netplay_check_frames");
    if (!retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_NETPLAY_IP_PORT, NULL))
-      CONFIG_GET_INT_BASE(conf, global, netplay.port, "netplay_ip_port");
+      CONFIG_GET_INT_BASE(conf, settings, netplay.port, "netplay_ip_port");
 #endif
    for (i = 0; i < MAX_USERS; i++)
    {
@@ -1959,7 +1959,7 @@ static bool config_load_file(const char *path, bool set_defaults,
 #ifdef HAVE_NETWORKING
    if (retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_NETPLAY_IP_ADDRESS, NULL))
    {
-      strlcpy(global->netplay.server, override_netplay_ip_address, sizeof(global->netplay.server));
+      strlcpy(settings->netplay.server, override_netplay_ip_address, sizeof(settings->netplay.server));
       free(override_netplay_ip_address);
    }
 #endif
@@ -2288,13 +2288,6 @@ bool config_load_override(void)
       return false;
 
    /* Re-load the configuration with any overrides that might have been found */
-#ifdef HAVE_NETWORKING
-   if (global && global->netplay.enable)
-   {
-      RARCH_WARN("[overrides] can't use overrides in conjunction with netplay, disabling overrides.\n");
-      return false;
-   }
-#endif
 
    /* Store the libretro_path we're using since it will be 
     * overwritten by the override when reloading. */

--- a/configuration.h
+++ b/configuration.h
@@ -277,7 +277,6 @@ typedef struct settings
       unsigned device[MAX_USERS];
       unsigned device_name_index[MAX_USERS];
       bool autodetect_enable;
-      bool netplay_client_swap_input;
 
       unsigned turbo_period;
       unsigned turbo_duty_cycle;
@@ -394,6 +393,19 @@ typedef struct settings
       char menu_config[PATH_MAX_LENGTH];
       char menu_content[PATH_MAX_LENGTH];
    } directory;
+
+#ifdef HAVE_NETWORKING
+   struct
+   {
+      char server[PATH_MAX_LENGTH];
+      unsigned port;
+      unsigned sync_frames;
+      unsigned check_frames;
+      bool is_client;
+      bool is_spectate;
+      bool swap_input;
+   } netplay;
+#endif
 
    unsigned content_history_size;
 

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -3275,16 +3275,16 @@ static int action_ok_netplay_enable_host(const char *path,
 {
 #ifdef HAVE_NETWORKING
    bool netplay_was_on = false;
-   global_t *global  = global_get_ptr();
+   settings_t *settings = config_get_ptr();
 
-   global->netplay.enable = true;
+   netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE, NULL);
 
    if (netplay_driver_ctl(RARCH_NETPLAY_CTL_IS_DATA_INITED, NULL))
    {
       netplay_was_on = true;
 
       /* Netplay is already on. Are we in the wrong mode? */
-      if (global->netplay.is_client)
+      if (settings->netplay.is_client)
       {
          /* Kill it! */
          command_event(CMD_EVENT_NETPLAY_DEINIT, NULL);
@@ -3296,8 +3296,7 @@ static int action_ok_netplay_enable_host(const char *path,
       }
    }
 
-   global->netplay.is_client = false;
-   global->netplay.server[0] = '\0';
+   settings->netplay.is_client = false;
 
    /* If we haven't yet started, this will load on its own */
    if (!content_is_inited())
@@ -3329,9 +3328,9 @@ static int action_ok_netplay_enable_client(const char *path,
 {
 #ifdef HAVE_NETWORKING
    bool netplay_was_on = false;
-   global_t *global  = global_get_ptr();
+   settings_t *settings = config_get_ptr();
 
-   global->netplay.enable = true;
+   netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE, NULL);
 
    if (netplay_driver_ctl(RARCH_NETPLAY_CTL_IS_DATA_INITED, NULL))
    {
@@ -3341,10 +3340,10 @@ static int action_ok_netplay_enable_client(const char *path,
       command_event(CMD_EVENT_NETPLAY_DEINIT, NULL);
    }
 
-   global->netplay.is_client = true;
+   settings->netplay.is_client = true;
 
    /* We can't do anything without a host specified */
-   if (!global->netplay.server[0])
+   if (!settings->netplay.server[0])
    {
       runloop_msg_queue_push(
             "Please specify the Netplay server's IP address or hostname.",

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -1656,21 +1656,21 @@ void general_write_handler(void *data)
          break;
       case MENU_ENUM_LABEL_NETPLAY_MODE:
 #ifdef HAVE_NETWORKING
-         if (!global->netplay.is_client)
-            *global->netplay.server = '\0';
+         if (!settings->netplay.is_client)
+            *settings->netplay.server = '\0';
          retroarch_override_setting_set(RARCH_OVERRIDE_SETTING_NETPLAY_MODE, NULL);
 #endif
          break;
       case MENU_ENUM_LABEL_NETPLAY_SPECTATOR_MODE_ENABLE:
 #ifdef HAVE_NETWORKING
-         if (global->netplay.is_spectate)
-            *global->netplay.server = '\0';
+         if (settings->netplay.is_spectate)
+            *settings->netplay.server = '\0';
 #endif
          break;
       case MENU_ENUM_LABEL_NETPLAY_DELAY_FRAMES:
 #ifdef HAVE_NETWORKING
          {
-            bool val = (global->netplay.sync_frames > 0);
+            bool val = (settings->netplay.sync_frames > 0);
             
             if (val)
                retroarch_override_setting_set(RARCH_OVERRIDE_SETTING_NETPLAY_DELAY_FRAMES, NULL);
@@ -1682,7 +1682,7 @@ void general_write_handler(void *data)
       case MENU_ENUM_LABEL_NETPLAY_CHECK_FRAMES:
 #ifdef HAVE_NETWORKING
          {
-            bool val = (global->netplay.check_frames > 0);
+            bool val = (settings->netplay.check_frames > 0);
 
             if (val)
                retroarch_override_setting_set(RARCH_OVERRIDE_SETTING_NETPLAY_CHECK_FRAMES, NULL);
@@ -5783,24 +5783,7 @@ static bool setting_append_list(
 #endif
             CONFIG_BOOL(
                   list, list_info,
-                  &global->netplay.enable,
-                  msg_hash_to_str(MENU_ENUM_LABEL_NETPLAY_ENABLE),
-                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE),
-                  false,
-                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF),
-                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_ON),
-                  &group_info,
-                  &subgroup_info,
-                  parent_group,
-                  general_write_handler,
-                  general_read_handler,
-                  SD_FLAG_NONE
-                  );
-            menu_settings_list_current_add_enum_idx(list, list_info, MENU_ENUM_LABEL_NETPLAY_ENABLE);
-
-            CONFIG_BOOL(
-                  list, list_info,
-                  &settings->input.netplay_client_swap_input,
+                  &settings->netplay.swap_input,
                   msg_hash_to_str(MENU_ENUM_LABEL_NETPLAY_CLIENT_SWAP_INPUT),
                   msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT),
                   netplay_client_swap_input,
@@ -5816,8 +5799,8 @@ static bool setting_append_list(
 
             CONFIG_STRING(
                   list, list_info,
-                  global->netplay.server,
-                  sizeof(global->netplay.server),
+                  settings->netplay.server,
+                  sizeof(settings->netplay.server),
                   msg_hash_to_str(MENU_ENUM_LABEL_NETPLAY_IP_ADDRESS),
                   msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS),
                   "",
@@ -5831,7 +5814,7 @@ static bool setting_append_list(
 
             CONFIG_BOOL(
                   list, list_info,
-                  &global->netplay.is_client,
+                  &settings->netplay.is_client,
                   msg_hash_to_str(MENU_ENUM_LABEL_NETPLAY_MODE),
                   msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NETPLAY_MODE),
                   false,
@@ -5847,7 +5830,7 @@ static bool setting_append_list(
 
             CONFIG_BOOL(
                   list, list_info,
-                  &global->netplay.is_spectate,
+                  &settings->netplay.is_spectate,
                   msg_hash_to_str(MENU_ENUM_LABEL_NETPLAY_SPECTATOR_MODE_ENABLE),
                   msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE),
                   false,
@@ -5863,7 +5846,7 @@ static bool setting_append_list(
 
             CONFIG_UINT(
                   list, list_info,
-                  &global->netplay.sync_frames,
+                  &settings->netplay.sync_frames,
                   msg_hash_to_str(MENU_ENUM_LABEL_NETPLAY_DELAY_FRAMES),
                   msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NETPLAY_DELAY_FRAMES),
                   0,
@@ -5878,7 +5861,7 @@ static bool setting_append_list(
 
             CONFIG_UINT(
                   list, list_info,
-                  &global->netplay.check_frames,
+                  &settings->netplay.check_frames,
                   msg_hash_to_str(MENU_ENUM_LABEL_NETPLAY_CHECK_FRAMES),
                   msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NETPLAY_CHECK_FRAMES),
                   0,
@@ -5893,7 +5876,7 @@ static bool setting_append_list(
 
             CONFIG_UINT(
                   list, list_info,
-                  &global->netplay.port,
+                  &settings->netplay.port,
                   msg_hash_to_str(MENU_ENUM_LABEL_NETPLAY_TCP_UDP_PORT),
                   msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT),
                   RARCH_DEFAULT_PORT,

--- a/network/netplay/netplay.h
+++ b/network/netplay/netplay.h
@@ -35,6 +35,9 @@ enum rarch_netplay_ctl_state
    RARCH_NETPLAY_CTL_FULLSCREEN_TOGGLE,
    RARCH_NETPLAY_CTL_POST_FRAME,
    RARCH_NETPLAY_CTL_PRE_FRAME,
+   RARCH_NETPLAY_CTL_ENABLE,
+   RARCH_NETPLAY_CTL_DISABLE,
+   RARCH_NETPLAY_CTL_IS_ENABLED,
    RARCH_NETPLAY_CTL_IS_DATA_INITED,
    RARCH_NETPLAY_CTL_PAUSE,
    RARCH_NETPLAY_CTL_UNPAUSE,
@@ -206,7 +209,11 @@ void netplay_load_savestate(netplay_t *netplay, retro_ctx_serialize_info_t *seri
 bool netplay_disconnect(netplay_t *netplay);
 
 /**
- * init_netplay:
+ * init_netplay
+ * @is_client            : true if starting Netplay as client
+ * @is_spectate          : true if running in spectate mode
+ * @server               : server address to connect to (client only)
+ * @port                 : TCP port to host on/connect to
  *
  * Initializes netplay.
  *
@@ -214,7 +221,8 @@ bool netplay_disconnect(netplay_t *netplay);
  *
  * Returns: true (1) if successful, otherwise false (0).
  **/
-bool init_netplay(void);
+bool init_netplay(bool is_client, bool is_spectate, const char *server,
+                  unsigned port);
 
 void deinit_netplay(void);
 

--- a/paths.c
+++ b/paths.c
@@ -380,11 +380,11 @@ void path_init_savefile(void)
    bool should_sram_be_used = rarch_ctl(RARCH_CTL_IS_SRAM_USED, NULL) 
       && !rarch_ctl(RARCH_CTL_IS_SRAM_SAVE_DISABLED, NULL);
 #ifdef HAVE_NETWORKING
-   global_t *global         = global_get_ptr();
+   settings_t *settings = config_get_ptr();
 
    should_sram_be_used = should_sram_be_used &&
       (!netplay_driver_ctl(RARCH_NETPLAY_CTL_IS_DATA_INITED, NULL)
-       || !global->netplay.is_client);
+       || !settings->netplay.is_client);
 #endif
 
    if (should_sram_be_used)

--- a/retroarch.c
+++ b/retroarch.c
@@ -57,6 +57,10 @@
 #include "menu/menu_driver.h"
 #endif
 
+#ifdef HAVE_NETWORKING
+#include "network/netplay/netplay.h"
+#endif
+
 #include "config.features.h"
 #include "content.h"
 #include "core_type.h"
@@ -688,20 +692,20 @@ static void retroarch_parse_input(int argc, char *argv[])
          case 'H':
             retroarch_override_setting_set(
                   RARCH_OVERRIDE_SETTING_NETPLAY_IP_ADDRESS, NULL);
-            global->netplay.enable = true;
-            *global->netplay.server = '\0';
+            netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE, NULL);
+            settings->netplay.is_client = false;
             break;
 
          case 'C':
             retroarch_override_setting_set(
                   RARCH_OVERRIDE_SETTING_NETPLAY_IP_ADDRESS, NULL);
-            global->netplay.enable = true;
-            strlcpy(global->netplay.server, optarg,
-                  sizeof(global->netplay.server));
+            netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE, NULL);
+            strlcpy(settings->netplay.server, optarg,
+                  sizeof(settings->netplay.server));
             break;
 
          case 'F':
-            global->netplay.sync_frames = strtol(optarg, NULL, 0);
+            settings->netplay.sync_frames = strtol(optarg, NULL, 0);
             retroarch_override_setting_set(
                   RARCH_OVERRIDE_SETTING_NETPLAY_DELAY_FRAMES, NULL);
             break;
@@ -709,19 +713,19 @@ static void retroarch_parse_input(int argc, char *argv[])
          case RA_OPT_CHECK_FRAMES:
             retroarch_override_setting_set(
                   RARCH_OVERRIDE_SETTING_NETPLAY_CHECK_FRAMES, NULL);
-            global->netplay.check_frames = strtoul(optarg, NULL, 0);
+            settings->netplay.check_frames = strtoul(optarg, NULL, 0);
             break;
 
          case RA_OPT_PORT:
             retroarch_override_setting_set(
                   RARCH_OVERRIDE_SETTING_NETPLAY_IP_PORT, NULL);
-            global->netplay.port = strtoul(optarg, NULL, 0);
+            settings->netplay.port = strtoul(optarg, NULL, 0);
             break;
 
          case RA_OPT_SPECTATE:
             retroarch_override_setting_set(
                   RARCH_OVERRIDE_SETTING_NETPLAY_MODE, NULL);
-            global->netplay.is_spectate = true;
+            settings->netplay.is_spectate = true;
             break;
 
 #if defined(HAVE_NETWORK_CMD)

--- a/runloop.c
+++ b/runloop.c
@@ -682,11 +682,9 @@ bool runloop_ctl(enum runloop_ctl_state state, void *data)
             const struct retro_frame_time_callback *info =
                (const struct retro_frame_time_callback*)data;
 #ifdef HAVE_NETWORKING
-            global_t *global = global_get_ptr();
-
             /* retro_run() will be called in very strange and
              * mysterious ways, have to disable it. */
-            if (global && global->netplay.enable)
+            if (netplay_driver_ctl(RARCH_NETPLAY_CTL_IS_ENABLED, NULL))
                return false;
 #endif
             runloop_frame_time = *info;

--- a/runloop.h
+++ b/runloop.h
@@ -148,20 +148,6 @@ typedef struct global
       char remapfile[PATH_MAX_LENGTH];
    } name;
 
-#ifdef HAVE_NETWORKING
-   /* Netplay. */
-   struct
-   {
-      char server[PATH_MAX_LENGTH];
-      bool enable;
-      bool is_client;
-      bool is_spectate;
-      unsigned sync_frames;
-      unsigned check_frames;
-      unsigned port;
-   } netplay;
-#endif
-
    /* Recording. */
    struct
    {


### PR DESCRIPTION
Moved settings values into settings->netplay, and global->netplay.enable is moved into netplay itself, and is no longer a configuration value whatsoever, as that conflicts with the behavior of the netplay menu.

There are some of these that perhaps shouldn't be settings anymore, in particular is_client, but this at least gets rid of the global component and makes the settings behave like settings.