### PR TITLE
Making netplay-related settings overrides behave consistently

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -1703,6 +1703,7 @@ static bool config_load_file(const char *path, bool set_defaults,
    struct config_path_setting     *path_settings   = NULL;
    char *override_username                         = NULL;
 #ifdef HAVE_NETWORKING
+   bool override_netplay_is_client                 = false;
    char *override_netplay_ip_address               = NULL;
 #endif
    global_t   *global                              = global_get_ptr();
@@ -1768,6 +1769,8 @@ static bool config_load_file(const char *path, bool set_defaults,
       override_username = strdup(settings->username);
 
 #ifdef HAVE_NETWORKING
+   if (retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_NETPLAY_MODE, NULL))
+      override_netplay_is_client = settings->netplay.is_client;
    if (retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_NETPLAY_IP_ADDRESS, NULL))
       override_netplay_ip_address = strdup(settings->netplay.server);
 #endif
@@ -1810,10 +1813,11 @@ static bool config_load_file(const char *path, bool set_defaults,
 
 #ifdef HAVE_NETWORKING
    if (!retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_NETPLAY_MODE, NULL))
+   {
       CONFIG_GET_BOOL_BASE(conf, settings, netplay.is_spectate,
             "netplay_spectator_mode_enable");
-   if (!retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_NETPLAY_MODE, NULL))
       CONFIG_GET_BOOL_BASE(conf, settings, netplay.is_client, "netplay_mode");
+   }
 #endif
 #ifdef HAVE_NETWORKGAMEPAD
    for (i = 0; i < MAX_USERS; i++)
@@ -1956,6 +1960,8 @@ static bool config_load_file(const char *path, bool set_defaults,
    }
 
 #ifdef HAVE_NETWORKING
+   if (retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_NETPLAY_MODE, NULL))
+      settings->netplay.is_client = override_netplay_is_client;
    if (retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_NETPLAY_IP_ADDRESS, NULL))
    {
       strlcpy(settings->netplay.server, override_netplay_ip_address, sizeof(settings->netplay.server));

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -1656,15 +1656,12 @@ void general_write_handler(void *data)
          break;
       case MENU_ENUM_LABEL_NETPLAY_MODE:
 #ifdef HAVE_NETWORKING
-         if (!settings->netplay.is_client)
-            *settings->netplay.server = '\0';
          retroarch_override_setting_set(RARCH_OVERRIDE_SETTING_NETPLAY_MODE, NULL);
 #endif
          break;
       case MENU_ENUM_LABEL_NETPLAY_SPECTATOR_MODE_ENABLE:
 #ifdef HAVE_NETWORKING
-         if (settings->netplay.is_spectate)
-            *settings->netplay.server = '\0';
+         retroarch_override_setting_set(RARCH_OVERRIDE_SETTING_NETPLAY_MODE, NULL);
 #endif
          break;
       case MENU_ENUM_LABEL_NETPLAY_DELAY_FRAMES:

--- a/retroarch.c
+++ b/retroarch.c
@@ -691,15 +691,18 @@ static void retroarch_parse_input(int argc, char *argv[])
 #ifdef HAVE_NETWORKING
          case 'H':
             retroarch_override_setting_set(
-                  RARCH_OVERRIDE_SETTING_NETPLAY_IP_ADDRESS, NULL);
+                  RARCH_OVERRIDE_SETTING_NETPLAY_MODE, NULL);
             netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE, NULL);
             settings->netplay.is_client = false;
             break;
 
          case 'C':
             retroarch_override_setting_set(
+                  RARCH_OVERRIDE_SETTING_NETPLAY_MODE, NULL);
+            retroarch_override_setting_set(
                   RARCH_OVERRIDE_SETTING_NETPLAY_IP_ADDRESS, NULL);
             netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE, NULL);
+            settings->netplay.is_client = true;
             strlcpy(settings->netplay.server, optarg,
                   sizeof(settings->netplay.server));
             break;


### PR DESCRIPTION
Settings overrides for netplay behave a bit inconsistently, since the server hostname setting is conflated with the is_client setting in an unnecessary and confusing way. This cleans that up, so netplay mode and netplay hostname are fully orthogonal overrides.