### PR TITLE
Reimplemented savestate task informing Netplay

### DIFF
--- a/tasks/task_save.c
+++ b/tasks/task_save.c
@@ -38,6 +38,10 @@
 #include "../core.h"
 #endif
 
+#ifdef HAVE_NETWORKING
+#include "network/netplay/netplay.h"
+#endif
+
 #include "../core.h"
 #include "../file_path_special.h"
 #include "../configuration.h"
@@ -430,6 +434,12 @@ bool content_undo_load_state(void)
    content_save_state("RAM", false);
 
    ret                    = core_unserialize(&serial_info);
+
+#if HAVE_NETWORKING
+   /* If Netplay is running, inform it */
+   if (netplay_driver_ctl(RARCH_NETPLAY_CTL_IS_DATA_INITED, NULL))
+      netplay_driver_ctl(RARCH_NETPLAY_CTL_LOAD_SAVESTATE, &serial_info);
+#endif
 
    /* Clean up the temporary copy */
    free(temp_data);
@@ -877,6 +887,12 @@ static void content_load_state_cb(void *task_data,
    content_save_state("RAM", false);
 
    ret                    = core_unserialize(&serial_info);
+
+#if HAVE_NETWORKING
+   /* If Netplay is running, inform it */
+   if (netplay_driver_ctl(RARCH_NETPLAY_CTL_IS_DATA_INITED, NULL))
+      netplay_driver_ctl(RARCH_NETPLAY_CTL_LOAD_SAVESTATE, &serial_info);
+#endif
 
     /* Flush back. */
    for (i = 0; i < num_blocks; i++)


### PR DESCRIPTION
The recent changes to make savestates a task broke informing Netplay peers that a state has been loaded. Actually, it removed it entirely. This adds it back, in what I believe (on advise from bparker) to be the correct location.