### PR TITLE
Clarifications to Netplay menu and removing obsolete setting

### DIFF
--- a/command.c
+++ b/command.c
@@ -2349,7 +2349,7 @@ bool command_event(enum event_command cmd, void *data)
       case CMD_EVENT_NETPLAY_INIT:
          command_event(CMD_EVENT_NETPLAY_DEINIT, NULL);
 #ifdef HAVE_NETWORKING
-         if (!init_netplay(settings->netplay.is_client,
+         if (!init_netplay(
               settings->netplay.is_spectate, settings->netplay.server,
               settings->netplay.port))
             return false;

--- a/configuration.c
+++ b/configuration.c
@@ -805,7 +805,6 @@ static int populate_settings_bool(settings_t *settings, struct config_bool_setti
 #endif
 #ifdef HAVE_NETWORKING
    SETTING_BOOL("netplay_spectator_mode_enable",&settings->netplay.is_spectate, false, false /* TODO */, false);
-   SETTING_BOOL("netplay_mode",                 &settings->netplay.is_client, false, false /* TODO */, false);
 #endif
    SETTING_BOOL("block_sram_overwrite",         &settings->block_sram_overwrite, true, block_sram_overwrite, false);
    SETTING_BOOL("savestate_auto_index",         &settings->savestate_auto_index, true, savestate_auto_index, false);
@@ -1769,8 +1768,6 @@ static bool config_load_file(const char *path, bool set_defaults,
       override_username = strdup(settings->username);
 
 #ifdef HAVE_NETWORKING
-   if (retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_NETPLAY_MODE, NULL))
-      override_netplay_is_client = settings->netplay.is_client;
    if (retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_NETPLAY_IP_ADDRESS, NULL))
       override_netplay_ip_address = strdup(settings->netplay.server);
 #endif
@@ -1816,7 +1813,6 @@ static bool config_load_file(const char *path, bool set_defaults,
    {
       CONFIG_GET_BOOL_BASE(conf, settings, netplay.is_spectate,
             "netplay_spectator_mode_enable");
-      CONFIG_GET_BOOL_BASE(conf, settings, netplay.is_client, "netplay_mode");
    }
 #endif
 #ifdef HAVE_NETWORKGAMEPAD
@@ -1960,8 +1956,6 @@ static bool config_load_file(const char *path, bool set_defaults,
    }
 
 #ifdef HAVE_NETWORKING
-   if (retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_NETPLAY_MODE, NULL))
-      settings->netplay.is_client = override_netplay_is_client;
    if (retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_NETPLAY_IP_ADDRESS, NULL))
    {
       strlcpy(settings->netplay.server, override_netplay_ip_address, sizeof(settings->netplay.server));

--- a/configuration.h
+++ b/configuration.h
@@ -401,7 +401,6 @@ typedef struct settings
       unsigned port;
       unsigned sync_frames;
       unsigned check_frames;
-      bool is_client;
       bool is_spectate;
       bool swap_input;
    } netplay;

--- a/intl/msg_hash_de.c
+++ b/intl/msg_hash_de.c
@@ -586,11 +586,11 @@ const char *msg_hash_to_str_de(enum msg_hash_enums msg)
          return "Overlay-Verzeichnis";
       case MENU_ENUM_LABEL_VALUE_OSK_OVERLAY_DIRECTORY:
          return "OSK-Overlay-Verzeichnis";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT:
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT: /* TODO: Original string changed */
          return "Tausche Netplay-Eingabe";
       case MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE:
          return "Aktiviere Netplay-Zuschauermodus";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS:
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS: /* TODO: Original string changed */
          return "IP-Addresse für Netplay";
       case MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT:
          return "TCP/UDP-Port für Netplay";

--- a/intl/msg_hash_es.c
+++ b/intl/msg_hash_es.c
@@ -1670,11 +1670,11 @@ const char *msg_hash_to_str_es(enum msg_hash_enums msg)
          return "Carpeta de superposiciones";
       case MENU_ENUM_LABEL_VALUE_OSK_OVERLAY_DIRECTORY:
          return "Carpeta de teclados superpuestos";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT:
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT: /* TODO: Original string changed */
          return "Intercambiar entrada en red";
       case MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE:
          return "Permitir espectadores en red";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS:
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS: /* TODO: Original string changed */
          return "Dirección IP";
       case MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT:
          return "Puerto TCP/UDP para juego en red";

--- a/intl/msg_hash_fr.c
+++ b/intl/msg_hash_fr.c
@@ -403,11 +403,11 @@ const char *msg_hash_to_str_fr(enum msg_hash_enums msg)
          return "Dossier des overlays";
       case MENU_ENUM_LABEL_VALUE_OSK_OVERLAY_DIRECTORY:
          return "Dossier des overlays claviers";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT:
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT: /* TODO: Original string changed */
          return "Inverser les entrées du jeu en réseau";
       case MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE:
          return "Activer le mode spectateur";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS:
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS: /* TODO: Original string changed */
          return "Adresse IP";
       case MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT:
          return "Port TCP/UDP du jeu en réseau";

--- a/intl/msg_hash_it.c
+++ b/intl/msg_hash_it.c
@@ -1411,11 +1411,11 @@ const char *msg_hash_to_str_it(enum msg_hash_enums msg)
          return "Directory Overlay";
       case MENU_ENUM_LABEL_VALUE_OSK_OVERLAY_DIRECTORY:
          return "Directory Overlay OSK";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT:
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT: /* TODO: Original string changed */
          return "Scambia ingressi in rete";
       case MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE:
          return "Abilita spettatore in rete";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS:
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS: /* TODO: Original string changed */
          return "Indirizzo IP";
       case MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT:
          return "Porta TCP/UDP Rete";

--- a/intl/msg_hash_jp.c
+++ b/intl/msg_hash_jp.c
@@ -1639,7 +1639,7 @@ int menu_hash_get_help_jp_enum(enum msg_hash_enums msg, char *s, size_t len)
          break;
       case MENU_ENUM_LABEL_NETPLAY_IP_ADDRESS:
          snprintf(s, len,
-               "The IP address of the host to connect to.");
+               "The address of the host to connect to.");
          break;
       case MENU_ENUM_LABEL_STDIN_CMD_ENABLE:
          snprintf(s, len,
@@ -3666,11 +3666,11 @@ const char *msg_hash_to_str_jp(enum msg_hash_enums msg)
       case MENU_ENUM_LABEL_VALUE_OSK_OVERLAY_DIRECTORY:
          return "OSK Overlay Dir";
       case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT:
-         return "Swap Netplay Input";
+         return "Netplay P2 Uses C1";
       case MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE:
          return "Netplay Spectator Enable";
       case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS:
-         return "IP Address";
+         return "Server Address";
       case MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT:
          return "Netplay TCP/UDP Port";
       case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE:

--- a/intl/msg_hash_nl.c
+++ b/intl/msg_hash_nl.c
@@ -261,11 +261,11 @@ const char *msg_hash_to_str_nl(enum msg_hash_enums msg)
          return "Overlay Map";
       case MENU_ENUM_LABEL_VALUE_OSK_OVERLAY_DIRECTORY:
          return "OSK Overlay Map";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT:
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT: /* TODO: Original string changed */
          return "Swap Netplay Input";
       case MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE:
          return "Netplay Spectator Activeren";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS:
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS: /* TODO: Original string changed */
          return "IP Adres";
       case MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT:
          return "Netplay TCP/UDP Poort";

--- a/intl/msg_hash_pl.c
+++ b/intl/msg_hash_pl.c
@@ -366,11 +366,11 @@ const char *msg_hash_to_str_pl(enum msg_hash_enums msg)
          return "Katalog nak³adek";
       case MENU_ENUM_LABEL_VALUE_OSK_OVERLAY_DIRECTORY:
          return "Katalog klawiatur ekranowych";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT:
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT: /* TODO: Original string changed */
          return "Zamieñ kontrolery w grze sieciowej";
       case MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE:
          return "Tryb obserwatora gry sieciowej";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS:
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS: /* TODO: Original string changed */
          return "Adres IP";
       case MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT:
          return "Port TCP/UDP gry sieciowej";

--- a/intl/msg_hash_pt.c
+++ b/intl/msg_hash_pt.c
@@ -1268,11 +1268,11 @@ const char *msg_hash_to_str_pt(enum msg_hash_enums msg)
          return "Overlays";
       case MENU_ENUM_LABEL_VALUE_OSK_OVERLAY_DIRECTORY:
          return "Overlays de Teclado";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT:
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT: /* TODO: Original string changed */
          return "Trocar Entradas de Netplay";
       case MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE:
          return "Ativar Espectador de Netplay";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS:
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS: /* TODO: Original string changed */
          return "Endereço IP";
       case MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT:
          return "Portas TCP/UDP de Netplay";

--- a/intl/msg_hash_us.c
+++ b/intl/msg_hash_us.c
@@ -1682,7 +1682,7 @@ int menu_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
          break;
       case MENU_ENUM_LABEL_NETPLAY_IP_ADDRESS:
          snprintf(s, len,
-               "The IP address of the host to connect to.");
+               "The address of the host to connect to.");
          break;
       case MENU_ENUM_LABEL_STDIN_CMD_ENABLE:
          snprintf(s, len,
@@ -3784,11 +3784,11 @@ const char *msg_hash_to_str_us(enum msg_hash_enums msg)
       case MENU_ENUM_LABEL_VALUE_OSK_OVERLAY_DIRECTORY:
          return "OSK Overlay Dir";
       case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT:
-         return "Swap Netplay Input";
+         return "Netplay P2 Uses C1";
       case MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE:
          return "Netplay Spectator Enable";
       case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS:
-         return "IP Address";
+         return "Server Address";
       case MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT:
          return "Netplay TCP/UDP Port";
       case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE:

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -3277,26 +3277,15 @@ static int action_ok_netplay_enable_host(const char *path,
    bool netplay_was_on = false;
    settings_t *settings = config_get_ptr();
 
-   netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE, NULL);
+   netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE_SERVER, NULL);
 
    if (netplay_driver_ctl(RARCH_NETPLAY_CTL_IS_DATA_INITED, NULL))
    {
       netplay_was_on = true;
 
-      /* Netplay is already on. Are we in the wrong mode? */
-      if (settings->netplay.is_client)
-      {
-         /* Kill it! */
-         command_event(CMD_EVENT_NETPLAY_DEINIT, NULL);
-      }
-      else
-      {
-         /* We were already hosting! */
-         return generic_action_ok_command(CMD_EVENT_RESUME);
-      }
+      /* Netplay is already on. Kill it. */
+      command_event(CMD_EVENT_NETPLAY_DEINIT, NULL);
    }
-
-   settings->netplay.is_client = false;
 
    /* If we haven't yet started, this will load on its own */
    if (!content_is_inited())
@@ -3330,7 +3319,7 @@ static int action_ok_netplay_enable_client(const char *path,
    bool netplay_was_on = false;
    settings_t *settings = config_get_ptr();
 
-   netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE, NULL);
+   netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE_CLIENT, NULL);
 
    if (netplay_driver_ctl(RARCH_NETPLAY_CTL_IS_DATA_INITED, NULL))
    {
@@ -3339,8 +3328,6 @@ static int action_ok_netplay_enable_client(const char *path,
       /* Kill it! */
       command_event(CMD_EVENT_NETPLAY_DEINIT, NULL);
    }
-
-   settings->netplay.is_client = true;
 
    /* We can't do anything without a host specified */
    if (!settings->netplay.server[0])

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -3277,8 +3277,6 @@ static int action_ok_netplay_enable_host(const char *path,
    bool netplay_was_on = false;
    settings_t *settings = config_get_ptr();
 
-   netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE_SERVER, NULL);
-
    if (netplay_driver_ctl(RARCH_NETPLAY_CTL_IS_DATA_INITED, NULL))
    {
       netplay_was_on = true;
@@ -3286,6 +3284,8 @@ static int action_ok_netplay_enable_host(const char *path,
       /* Netplay is already on. Kill it. */
       command_event(CMD_EVENT_NETPLAY_DEINIT, NULL);
    }
+
+   netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE_SERVER, NULL);
 
    /* If we haven't yet started, this will load on its own */
    if (!content_is_inited())
@@ -3319,8 +3319,6 @@ static int action_ok_netplay_enable_client(const char *path,
    bool netplay_was_on = false;
    settings_t *settings = config_get_ptr();
 
-   netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE_CLIENT, NULL);
-
    if (netplay_driver_ctl(RARCH_NETPLAY_CTL_IS_DATA_INITED, NULL))
    {
       netplay_was_on = true;
@@ -3328,6 +3326,8 @@ static int action_ok_netplay_enable_client(const char *path,
       /* Kill it! */
       command_event(CMD_EVENT_NETPLAY_DEINIT, NULL);
    }
+
+   netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE_CLIENT, NULL);
 
    /* We can't do anything without a host specified */
    if (!settings->netplay.server[0])

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -4737,24 +4737,12 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, void *data)
             unsigned count = 0;
 
             if (menu_displaylist_parse_settings_enum(menu, info,
-                  MENU_ENUM_LABEL_NETPLAY_ENABLE,
-                  PARSE_ONLY_BOOL, false) != -1)
-               count++;
-            if (menu_displaylist_parse_settings_enum(menu, info,
-                  MENU_ENUM_LABEL_NETPLAY_CLIENT_SWAP_INPUT,
-                  PARSE_ONLY_BOOL, false) != -1)
-               count++;
-            if (menu_displaylist_parse_settings_enum(menu, info,
                   MENU_ENUM_LABEL_NETPLAY_IP_ADDRESS,
                   PARSE_ONLY_STRING, false) != -1)
                count++;
             if (menu_displaylist_parse_settings_enum(menu, info,
-                  MENU_ENUM_LABEL_NETPLAY_MODE,
-                  PARSE_ONLY_BOOL, false) != -1)
-               count++;
-            if (menu_displaylist_parse_settings_enum(menu, info,
-                  MENU_ENUM_LABEL_NETPLAY_SPECTATOR_MODE_ENABLE,
-                  PARSE_ONLY_BOOL, false) != -1)
+                  MENU_ENUM_LABEL_NETPLAY_TCP_UDP_PORT,
+                  PARSE_ONLY_UINT, false) != -1)
                count++;
             if (menu_displaylist_parse_settings_enum(menu, info,
                   MENU_ENUM_LABEL_NETPLAY_DELAY_FRAMES,
@@ -4765,8 +4753,12 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, void *data)
                   PARSE_ONLY_UINT, false) != -1)
                count++;
             if (menu_displaylist_parse_settings_enum(menu, info,
-                  MENU_ENUM_LABEL_NETPLAY_TCP_UDP_PORT,
-                  PARSE_ONLY_UINT, false) != -1)
+                  MENU_ENUM_LABEL_NETPLAY_SPECTATOR_MODE_ENABLE,
+                  PARSE_ONLY_BOOL, false) != -1)
+               count++;
+            if (menu_displaylist_parse_settings_enum(menu, info,
+                  MENU_ENUM_LABEL_NETPLAY_CLIENT_SWAP_INPUT,
+                  PARSE_ONLY_BOOL, false) != -1)
                count++;
             if (menu_displaylist_parse_settings_enum(menu, info,
                   MENU_ENUM_LABEL_NETWORK_CMD_ENABLE,

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -5778,22 +5778,6 @@ static bool setting_append_list(
 #if defined(HAVE_NETWORK_CMD)
             unsigned user;
 #endif
-            CONFIG_BOOL(
-                  list, list_info,
-                  &settings->netplay.swap_input,
-                  msg_hash_to_str(MENU_ENUM_LABEL_NETPLAY_CLIENT_SWAP_INPUT),
-                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT),
-                  netplay_client_swap_input,
-                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF),
-                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_ON),
-                  &group_info,
-                  &subgroup_info,
-                  parent_group,
-                  general_write_handler,
-                  general_read_handler,
-                  SD_FLAG_NONE);
-            menu_settings_list_current_add_enum_idx(list, list_info, MENU_ENUM_LABEL_NETPLAY_CLIENT_SWAP_INPUT);
-
             CONFIG_STRING(
                   list, list_info,
                   settings->netplay.server,
@@ -5809,37 +5793,20 @@ static bool setting_append_list(
             settings_data_list_current_add_flags(list, list_info, SD_FLAG_ALLOW_INPUT);
             menu_settings_list_current_add_enum_idx(list, list_info, MENU_ENUM_LABEL_NETPLAY_IP_ADDRESS);
 
-            CONFIG_BOOL(
+            CONFIG_UINT(
                   list, list_info,
-                  &settings->netplay.is_client,
-                  msg_hash_to_str(MENU_ENUM_LABEL_NETPLAY_MODE),
-                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NETPLAY_MODE),
-                  false,
-                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF),
-                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_ON),
+                  &settings->netplay.port,
+                  msg_hash_to_str(MENU_ENUM_LABEL_NETPLAY_TCP_UDP_PORT),
+                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT),
+                  RARCH_DEFAULT_PORT,
                   &group_info,
                   &subgroup_info,
                   parent_group,
                   general_write_handler,
-                  general_read_handler,
-                  SD_FLAG_NONE);
-            menu_settings_list_current_add_enum_idx(list, list_info, MENU_ENUM_LABEL_NETPLAY_MODE);
-
-            CONFIG_BOOL(
-                  list, list_info,
-                  &settings->netplay.is_spectate,
-                  msg_hash_to_str(MENU_ENUM_LABEL_NETPLAY_SPECTATOR_MODE_ENABLE),
-                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE),
-                  false,
-                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF),
-                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_ON),
-                  &group_info,
-                  &subgroup_info,
-                  parent_group,
-                  general_write_handler,
-                  general_read_handler,
-                  SD_FLAG_NONE);
-            menu_settings_list_current_add_enum_idx(list, list_info, MENU_ENUM_LABEL_NETPLAY_SPECTATOR_MODE_ENABLE);
+                  general_read_handler);
+            menu_settings_list_current_add_range(list, list_info, 0, 65535, 1, true, true);
+            settings_data_list_current_add_flags(list, list_info, SD_FLAG_ALLOW_INPUT);
+            menu_settings_list_current_add_enum_idx(list, list_info, MENU_ENUM_LABEL_NETPLAY_TCP_UDP_PORT);
 
             CONFIG_UINT(
                   list, list_info,
@@ -5871,20 +5838,37 @@ static bool setting_append_list(
             settings_data_list_current_add_flags(list, list_info, SD_FLAG_ADVANCED);
             menu_settings_list_current_add_enum_idx(list, list_info, MENU_ENUM_LABEL_NETPLAY_CHECK_FRAMES);
 
-            CONFIG_UINT(
+            CONFIG_BOOL(
                   list, list_info,
-                  &settings->netplay.port,
-                  msg_hash_to_str(MENU_ENUM_LABEL_NETPLAY_TCP_UDP_PORT),
-                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT),
-                  RARCH_DEFAULT_PORT,
+                  &settings->netplay.is_spectate,
+                  msg_hash_to_str(MENU_ENUM_LABEL_NETPLAY_SPECTATOR_MODE_ENABLE),
+                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE),
+                  false,
+                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF),
+                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_ON),
                   &group_info,
                   &subgroup_info,
                   parent_group,
                   general_write_handler,
-                  general_read_handler);
-            menu_settings_list_current_add_range(list, list_info, 1, 99999, 1, true, true);
-            settings_data_list_current_add_flags(list, list_info, SD_FLAG_ALLOW_INPUT);
-            menu_settings_list_current_add_enum_idx(list, list_info, MENU_ENUM_LABEL_NETPLAY_TCP_UDP_PORT);
+                  general_read_handler,
+                  SD_FLAG_NONE);
+            menu_settings_list_current_add_enum_idx(list, list_info, MENU_ENUM_LABEL_NETPLAY_SPECTATOR_MODE_ENABLE);
+
+            CONFIG_BOOL(
+                  list, list_info,
+                  &settings->netplay.swap_input,
+                  msg_hash_to_str(MENU_ENUM_LABEL_NETPLAY_CLIENT_SWAP_INPUT),
+                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT),
+                  netplay_client_swap_input,
+                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF),
+                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_ON),
+                  &group_info,
+                  &subgroup_info,
+                  parent_group,
+                  general_write_handler,
+                  general_read_handler,
+                  SD_FLAG_NONE);
+            menu_settings_list_current_add_enum_idx(list, list_info, MENU_ENUM_LABEL_NETPLAY_CLIENT_SWAP_INPUT);
 
             END_SUB_GROUP(list, list_info, parent_group);
 

--- a/network/netplay/netplay.h
+++ b/network/netplay/netplay.h
@@ -35,7 +35,8 @@ enum rarch_netplay_ctl_state
    RARCH_NETPLAY_CTL_FULLSCREEN_TOGGLE,
    RARCH_NETPLAY_CTL_POST_FRAME,
    RARCH_NETPLAY_CTL_PRE_FRAME,
-   RARCH_NETPLAY_CTL_ENABLE,
+   RARCH_NETPLAY_CTL_ENABLE_SERVER,
+   RARCH_NETPLAY_CTL_ENABLE_CLIENT,
    RARCH_NETPLAY_CTL_DISABLE,
    RARCH_NETPLAY_CTL_IS_ENABLED,
    RARCH_NETPLAY_CTL_IS_DATA_INITED,
@@ -210,7 +211,6 @@ bool netplay_disconnect(netplay_t *netplay);
 
 /**
  * init_netplay
- * @is_client            : true if starting Netplay as client
  * @is_spectate          : true if running in spectate mode
  * @server               : server address to connect to (client only)
  * @port                 : TCP port to host on/connect to
@@ -221,8 +221,7 @@ bool netplay_disconnect(netplay_t *netplay);
  *
  * Returns: true (1) if successful, otherwise false (0).
  **/
-bool init_netplay(bool is_client, bool is_spectate, const char *server,
-                  unsigned port);
+bool init_netplay(bool is_spectate, const char *server, unsigned port);
 
 void deinit_netplay(void);
 

--- a/paths.c
+++ b/paths.c
@@ -378,13 +378,6 @@ void path_init_savefile(void)
 {
    bool should_sram_be_used = rarch_ctl(RARCH_CTL_IS_SRAM_USED, NULL) 
       && !rarch_ctl(RARCH_CTL_IS_SRAM_SAVE_DISABLED, NULL);
-#ifdef HAVE_NETWORKING
-   settings_t *settings = config_get_ptr();
-
-   should_sram_be_used = should_sram_be_used &&
-      (!netplay_driver_ctl(RARCH_NETPLAY_CTL_IS_DATA_INITED, NULL)
-       || !settings->netplay.is_client);
-#endif
 
    if (should_sram_be_used)
       rarch_ctl(RARCH_CTL_SET_SRAM_ENABLE_FORCE, NULL);

--- a/retroarch.c
+++ b/retroarch.c
@@ -692,8 +692,7 @@ static void retroarch_parse_input(int argc, char *argv[])
          case 'H':
             retroarch_override_setting_set(
                   RARCH_OVERRIDE_SETTING_NETPLAY_MODE, NULL);
-            netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE, NULL);
-            settings->netplay.is_client = false;
+            netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE_SERVER, NULL);
             break;
 
          case 'C':
@@ -701,8 +700,7 @@ static void retroarch_parse_input(int argc, char *argv[])
                   RARCH_OVERRIDE_SETTING_NETPLAY_MODE, NULL);
             retroarch_override_setting_set(
                   RARCH_OVERRIDE_SETTING_NETPLAY_IP_ADDRESS, NULL);
-            netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE, NULL);
-            settings->netplay.is_client = true;
+            netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE_CLIENT, NULL);
             strlcpy(settings->netplay.server, optarg,
                   sizeof(settings->netplay.server));
             break;


### PR DESCRIPTION
This commit:
 * Reorders the Netplay settings menu to put more useful options at the
   top.
 * Renames the swap_input setting from "Swap Netplay Input", which is
   meaningless and confusing, to "Netplay P2 Uses C1", which is oddly
   truncated but at least true.
 * Removes the is_client setting altogether, as that's no longer how
   client vs. server mode is determined (each are separate options when
   enabling Netplay)

Hopefully the last time I touch the netplay menu for a while. It's pretty well perfect at this point.