### PR TITLE
tcc doesn't support -MMD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,12 @@ ifeq ($(shell $(CC) -v 2>&1 | grep -c "clang"),1)
    DEFINES +=  -Wno-invalid-source-encoding
 endif
 
+ifeq ($(shell $(CC) -v 2>&1 | grep -c "tcc"),1)
+   MD = -MD
+else
+   MD = -MMD
+endif
+
 HEADERS = $(wildcard */*/*.h) $(wildcard */*.h) $(wildcard *.h)
 
 ifeq ($(MISSING_DECLS), 1)
@@ -133,7 +139,7 @@ retroarch: $(RARCH_OBJ)
 $(OBJDIR)/%.o: %.c config.h config.mk
 	@mkdir -p $(dir $@)
 	@$(if $(Q), $(shell echo echo CC $<),)
-	$(Q)$(CC) $(CPPFLAGS) $(CFLAGS) $(DEFINES) -MMD -c -o $@ $<
+	$(Q)$(CC) $(CPPFLAGS) $(CFLAGS) $(DEFINES) $(MD) -c -o $@ $<
 
 $(OBJDIR)/%.o: %.cpp config.h config.mk
 	@mkdir -p $(dir $@)


### PR DESCRIPTION
This will add basic support for the tinycc compiler which does not support `-MMD`, but does for `-MD`.  It will still fail on the linking stage, but this could make it easier to eventually fix it. At worst this should just add extra lines to the Makefile...

This has been tested with the tcc mob branch.
http://repo.or.cz/tinycc.git

Tinycc is a very small and fast compiler which might be useful for RA on systems which do not have something like gcc or clang. It apparently even works on systems like windows.

Here is are the current issues that remain, I have not investigated how much should be fixed in tcc or RA yet.
http://pastebin.com/cvJCxVLy