### PR TITLE
Netplay in core

### DIFF
--- a/core_impl.c
+++ b/core_impl.c
@@ -283,6 +283,11 @@ bool core_unserialize(retro_ctx_serialize_info_t *info)
       return false;
    if (!core.retro_unserialize(info->data_const, info->size))
       return false;
+
+#if HAVE_NETWORKING
+   netplay_driver_ctl(RARCH_NETPLAY_CTL_LOAD_SAVESTATE, info);
+#endif
+
    return true;
 }
 

--- a/core_impl.c
+++ b/core_impl.c
@@ -368,6 +368,14 @@ bool core_unload_game(void)
 
 bool core_run(void)
 {
+#ifdef HAVE_NETWORKING
+   if (!netplay_driver_ctl(RARCH_NETPLAY_CTL_PRE_FRAME, NULL))
+   {
+      /* Paused due to Netplay */
+      return true;
+   }
+#endif
+
    switch (core_poll_type)
    {
       case POLL_TYPE_EARLY:
@@ -384,6 +392,11 @@ bool core_run(void)
       core.retro_run();
    if (core_poll_type == POLL_TYPE_LATE && !core_input_polled)
       input_poll();
+
+#ifdef HAVE_NETWORKING
+   netplay_driver_ctl(RARCH_NETPLAY_CTL_POST_FRAME, NULL);
+#endif
+
    return true;
 }
 

--- a/runloop.c
+++ b/runloop.c
@@ -1330,16 +1330,6 @@ int runloop_iterate(unsigned *sleep_ms)
 
    autosave_lock();
 
-#ifdef HAVE_NETWORKING
-   if (!netplay_driver_ctl(RARCH_NETPLAY_CTL_PRE_FRAME, NULL))
-   {
-      /* Paused due to Netplay */
-      core_poll();
-      *sleep_ms = 10;
-      return 1;
-   }
-#endif
-
    if (bsv_movie_ctl(BSV_MOVIE_CTL_IS_INITED, NULL))
       bsv_movie_ctl(BSV_MOVIE_CTL_SET_FRAME_START, NULL);
 
@@ -1378,10 +1368,6 @@ int runloop_iterate(unsigned *sleep_ms)
 
    if (bsv_movie_ctl(BSV_MOVIE_CTL_IS_INITED, NULL))
       bsv_movie_ctl(BSV_MOVIE_CTL_SET_FRAME_END, NULL);
-
-#ifdef HAVE_NETWORKING
-   netplay_driver_ctl(RARCH_NETPLAY_CTL_POST_FRAME, NULL);
-#endif
 
    autosave_unlock();
 

--- a/tasks/task_save.c
+++ b/tasks/task_save.c
@@ -440,12 +440,6 @@ bool content_undo_load_state(void)
 
    ret                    = core_unserialize(&serial_info);
 
-#if HAVE_NETWORKING
-   /* If Netplay is running, inform it */
-   if (netplay_driver_ctl(RARCH_NETPLAY_CTL_IS_DATA_INITED, NULL))
-      netplay_driver_ctl(RARCH_NETPLAY_CTL_LOAD_SAVESTATE, &serial_info);
-#endif
-
    /* Clean up the temporary copy */
    free(temp_data);
    temp_data              = NULL;
@@ -901,12 +895,6 @@ static void content_load_state_cb(void *task_data,
    content_save_state("RAM", false);
 
    ret                    = core_unserialize(&serial_info);
-
-#if HAVE_NETWORKING
-   /* If Netplay is running, inform it */
-   if (netplay_driver_ctl(RARCH_NETPLAY_CTL_IS_DATA_INITED, NULL))
-      netplay_driver_ctl(RARCH_NETPLAY_CTL_LOAD_SAVESTATE, &serial_info);
-#endif
 
     /* Flush back. */
    for (i = 0; i < num_blocks; i++)


### PR DESCRIPTION
This pushes the netplay callbacks deeper into the core, instead of the runloop, so that alternate code paths can't accidentally forget to inform netplay. Modifies core_run and core_unserialize to inform netplay, and netplay_driver_ctl to make sure netplay doesn't recurse into itself when it uses these functions. This fixes the bug identified thusfar in issue #3729, as well as slightly simplifying the savestate loading hotkey code, as it no longer duplicates the netplay call.

I'm not sure if you WANT netplay deeper in the core. If you'd prefer a different fix, I can spew more netplay calls in other places to make sure everybody always informs netplay.