### PR TITLE
Making netplay disable when it deinits

### DIFF
--- a/network/netplay/netplay.c
+++ b/network/netplay/netplay.c
@@ -1427,6 +1427,7 @@ void deinit_netplay(void)
    if (netplay_data)
       netplay_free(netplay_data);
    netplay_data = NULL;
+   netplay_enabled = false;
 }
 
 /**


### PR DESCRIPTION
Fixing a behavioral quirk reported by radius. This makes loading a new core/content not automatically reconnect to the same (probably wrong) netplay server or automatically restart hosting.