### PR TITLE
(task_http) Don't use 100% CPU in threaded mode

### DIFF
--- a/libretro-common/queues/task_queue.c
+++ b/libretro-common/queues/task_queue.c
@@ -454,10 +454,6 @@ static void threaded_worker(void *userdata)
          task_queue_put(&tasks_finished, task);
          slock_unlock(finished_lock);
       }
-
-#if 0
-      retro_sleep(10);
-#endif
    }
 }
 

--- a/tasks/task_http.c
+++ b/tasks/task_http.c
@@ -119,6 +119,10 @@ static int task_http_iterate_transfer(retro_task_t *task)
    http_handle_t *http  = (http_handle_t*)task->state;
    size_t pos  = 0, tot = 0;
 
+   /* FIXME: This wouldn't be needed if we could wait for a timeout */
+   if (task_queue_ctl(TASK_QUEUE_CTL_IS_THREADED, NULL))
+      retro_sleep(1);
+
    if (!net_http_update(http->handle, &pos, &tot))
    {
       task->progress = (tot == 0) ? -1 : (signed)(pos * 100 / tot);


### PR DESCRIPTION
This task is network bound and the HTTP functions use non-blocking I/O,
so task_http_iterate_transfer() returns "too fast" and the worker thread
gets no rest.