### PR TITLE
drm GL backend performance fix

### DIFF
--- a/gfx/drivers_context/drm_ctx.c
+++ b/gfx/drivers_context/drm_ctx.c
@@ -215,7 +215,8 @@ static bool gfx_ctx_drm_queue_flip(void)
    fb                = (struct drm_fb*)drm_fb_get_from_bo(g_next_bo);
 
    if (drmModePageFlip(g_drm_fd, g_crtc_id, fb->fb_id,
-         DRM_MODE_PAGE_FLIP_EVENT, &waiting_for_flip) == 0)
+                       DRM_MODE_PAGE_FLIP_EVENT | DRM_MODE_PAGE_FLIP_ASYNC,
+                       &waiting_for_flip) == 0)
       return true;
 
    /* Failed to queue page flip. */

--- a/gfx/drivers_context/drm_ctx.c
+++ b/gfx/drivers_context/drm_ctx.c
@@ -1,7 +1,7 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
  *  Copyright (C) 2011-2016 - Daniel De Matteis
- * 
+ *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-
  *  ation, either version 3 of the License, or (at your option) any later version.
@@ -80,7 +80,7 @@ typedef struct gfx_ctx_drm_data
    unsigned fb_width;
    unsigned fb_height;
 
-   bool core_hw_context_enable; 
+   bool core_hw_context_enable;
 } gfx_ctx_drm_data_t;
 
 struct drm_fb
@@ -185,7 +185,7 @@ static bool gfx_ctx_drm_wait_flip(bool block)
 
    if (!waiting_for_flip)
       return false;
-   
+
    if (block)
       timeout = -1;
 
@@ -203,7 +203,7 @@ static bool gfx_ctx_drm_wait_flip(bool block)
    /* This buffer is not on-screen anymore. Release it to GBM. */
    gbm_surface_release_buffer(g_gbm_surface, g_bo);
    /* This buffer is being shown now. */
-   g_bo = g_next_bo; 
+   g_bo = g_next_bo;
 
    return false;
 }
@@ -217,7 +217,7 @@ static bool gfx_ctx_drm_queue_flip(void)
    if (drmModePageFlip(g_drm_fd, g_crtc_id, fb->fb_id,
          DRM_MODE_PAGE_FLIP_EVENT, &waiting_for_flip) == 0)
       return true;
-   
+
    /* Failed to queue page flip. */
    return false;
 }
@@ -240,7 +240,7 @@ static void gfx_ctx_drm_swap_buffers(void *data)
          break;
    }
 
-   /* I guess we have to wait for flip to have taken 
+   /* I guess we have to wait for flip to have taken
     * place before another flip can be queued up.
     *
     * If true, we are still waiting for a flip
@@ -255,7 +255,7 @@ static void gfx_ctx_drm_swap_buffers(void *data)
          gbm_surface_has_free_buffers(g_gbm_surface))
       return;
 
-   gfx_ctx_drm_wait_flip(true);  
+   gfx_ctx_drm_wait_flip(true);
 }
 
 static bool gfx_ctx_drm_set_resize(void *data,
@@ -397,7 +397,7 @@ nextgpu:
 
    drm_setup(fd);
 
-   /* First mode is assumed to be the "optimal" 
+   /* First mode is assumed to be the "optimal"
     * one for get_video_size() purposes. */
    drm->fb_width    = g_drm_connector->modes[0].hdisplay;
    drm->fb_height   = g_drm_connector->modes[0].vdisplay;
@@ -460,7 +460,7 @@ static EGLint *gfx_ctx_drm_egl_fill_attribs(
             *attr++ = drm->egl.minor;
 
             /* Technically, we don't have core/compat until 3.2.
-             * Version 3.1 is either compat or not depending 
+             * Version 3.1 is either compat or not depending
              * on GL_ARB_compatibility. */
             if (version >= 3002)
             {
@@ -482,7 +482,7 @@ static EGLint *gfx_ctx_drm_egl_fill_attribs(
       case GFX_CTX_OPENGL_ES_API:
 #ifdef HAVE_OPENGLES
          *attr++ = EGL_CONTEXT_CLIENT_VERSION;
-         *attr++ = drm->egl.major 
+         *attr++ = drm->egl.major
             ? (EGLint)drm->egl.major : 2;
 #ifdef EGL_KHR_create_context
          if (drm->egl.minor > 0)
@@ -586,7 +586,7 @@ static bool gfx_ctx_drm_egl_set_video_mode(gfx_ctx_drm_data_t *drm)
          attr            = gfx_ctx_drm_egl_fill_attribs(drm, egl_attribs);
          egl_attribs_ptr = &egl_attribs[0];
 
-         if (!egl_create_context(&drm->egl, (attr != egl_attribs_ptr) 
+         if (!egl_create_context(&drm->egl, (attr != egl_attribs_ptr)
                   ? egl_attribs_ptr : NULL))
             goto error;
 
@@ -627,23 +627,23 @@ static bool gfx_ctx_drm_set_video_mode(void *data,
 
    frontend_driver_install_signal_handler();
 
-   /* If we use black frame insertion, 
-    * we fake a 60 Hz monitor for 120 Hz one, 
+   /* If we use black frame insertion,
+    * we fake a 60 Hz monitor for 120 Hz one,
     * etc, so try to match that. */
-   refresh_mod = settings->video.black_frame_insertion 
+   refresh_mod = settings->video.black_frame_insertion
       ? 0.5f : 1.0f;
 
    /* Find desired video mode, and use that.
-    * If not fullscreen, we get desired windowed size, 
+    * If not fullscreen, we get desired windowed size,
     * which is not appropriate. */
    if ((width == 0 && height == 0) || !fullscreen)
       g_drm_mode = &g_drm_connector->modes[0];
    else
    {
-      /* Try to match settings->video.refresh_rate 
+      /* Try to match settings->video.refresh_rate
        * as closely as possible.
        *
-       * Lower resolutions tend to have multiple supported 
+       * Lower resolutions tend to have multiple supported
        * refresh rates as well.
        */
       float minimum_fps_diff = 0.0f;
@@ -652,7 +652,7 @@ static bool gfx_ctx_drm_set_video_mode(void *data,
       for (i = 0; i < g_drm_connector->count_modes; i++)
       {
          float diff;
-         if (width != g_drm_connector->modes[i].hdisplay || 
+         if (width != g_drm_connector->modes[i].hdisplay ||
                height != g_drm_connector->modes[i].vdisplay)
             continue;
 

--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -32,10 +32,10 @@
 # This option is mandatory.
 
 # Path to a libretro implementation.
-# libretro_path = "/path/to/libretro.so"
+# libretro_path = "/home/anholt/src/rpi2/RetroArch/nestopia_libretro.so"
 
 # A directory for where to search for libretro core implementations.
-# libretro_directory =
+libretro_directory ="/home/anholt/src/rpi2/RetroArch/nestopia_libretro.so"
 
 # A directory for where to search for libretro core information.
 # libretro_info_path =
@@ -47,7 +47,7 @@
 # libretro_log_level = 0
 
 # Enable or disable verbosity level of frontend.
-# log_verbosity = false
+log_verbosity = true
 
 # If this option is enabled, every content file loaded in RetroArch will be
 # automatically added to a history list.
@@ -131,7 +131,7 @@
 #### Video
 
 # Video driver to use. "gl", "xvideo", "sdl"
-# video_driver = "gl"
+video_driver = "gl"
 
 # Which context implementation to use.
 # Possible ones for desktop are: glx, x-egl, kms-egl, sdl-gl, wgl.
@@ -162,9 +162,9 @@
 # Video vsync.
 # video_vsync = true
 
-# Max amount of swapchain images. 
+# Max amount of swapchain images.
 # Single buffering = 1, Double buffering = 2, 3 = Triple buffering
-# video_max_swapchain_images = 3
+ video_max_swapchain_images = 2
 
 # Forcibly disable sRGB FBO support. Some Intel OpenGL drivers on Windows
 # have video problems with sRGB FBO support enabled.
@@ -217,7 +217,7 @@
 
 # Forces cropping of overscanned frames.
 # Exact behavior of this option is implementation specific.
-# video_crop_overscan = true 
+# video_crop_overscan = true
 
 # Path to shader. Shader can be either Cg, CGP (Cg preset) or GLSL, GLSLP (GLSL preset)
 # video_shader = "/path/to/shader.{cg,cgp,glsl,glslp}"
@@ -237,7 +237,7 @@
 
 # Path to a font used for rendering messages. This path must be defined to enable fonts.
 # Do note that the _full_ path of the font is necessary!
-# video_font_path = 
+# video_font_path =
 
 # Size of the font rendered.
 # video_font_size = 32
@@ -245,7 +245,7 @@
 # Enable usage of OSD messages.
 # video_font_enable = true
 
-# Offset for where messages will be placed on screen. Values are in range 0.0 to 1.0 for both x and y values. 
+# Offset for where messages will be placed on screen. Values are in range 0.0 to 1.0 for both x and y values.
 # [0.0, 0.0] maps to the lower left corner of the screen.
 # video_message_pos_x = 0.05
 # video_message_pos_y = 0.05
@@ -284,7 +284,7 @@
 # audio_resampler =
 
 # Audio driver backend. Depending on configuration possible candidates are: alsa, pulse, oss, jack, rsound, roar, openal, sdl, xaudio.
-# audio_driver =
+audio_driver = null
 
 # Override the default audio device the audio_driver uses. This is driver dependant. E.g. ALSA wants a PCM device, OSS wants a path (e.g. /dev/dsp), Jack wants portnames (e.g. system:playback1,system:playback_2), and so on ...
 # audio_device =
@@ -339,7 +339,7 @@
 
 #### OSK (Onscreen Keyboard) Overlay
 
-# Defines a directory where onscreen keyboard overlays are 
+# Defines a directory where onscreen keyboard overlays are
 # kept for easy access.
 # osk_overlay_directory =
 
@@ -400,9 +400,9 @@
 #     requested.
 # 2 : Late   - Input polling is performed on first call to retro_input_state
 #     per frame
-# 
+#
 # Setting it to 0 or 2 can result in less latency depending on
-# your configuration. 
+# your configuration.
 #
 # When netplay is enabled, the default polling behavior (1) will
 # be used regardless of the value set here.
@@ -453,7 +453,7 @@
 #   tilde, backquote, pause, quote, comma, minus, slash, semicolon, equals, leftbracket,
 #   backslash, rightbracket, kp_period, kp_equals, rctrl, ralt
 #
-# Keyboard input, Joypad and Joyaxis will all obey the "nul" bind, which disables the bind completely, 
+# Keyboard input, Joypad and Joyaxis will all obey the "nul" bind, which disables the bind completely,
 # rather than relying on a default.
 # input_player1_a = "x"
 # input_player1_b = "z"
@@ -498,7 +498,7 @@
 
 # Input device buttons.
 # Figure these out by using RetroArch-Phoenix or retroarch-joyconfig.
-# You can use joypad hats with hnxx, where n is the hat, and xx is a string representing direction. 
+# You can use joypad hats with hnxx, where n is the hat, and xx is a string representing direction.
 # E.g. "h0up"
 # input_player1_a_btn =
 # input_player1_b_btn =
@@ -526,8 +526,8 @@
 # menu_scroll_down_btn =
 # menu_scroll_up_btn   =
 
-# Axis for RetroArch D-Pad. 
-# Needs to be either '+' or '-' in the first character signaling either positive or negative direction of the axis, then the axis number. 
+# Axis for RetroArch D-Pad.
+# Needs to be either '+' or '-' in the first character signaling either positive or negative direction of the axis, then the axis number.
 # Do note that every other input option has the corresponding _btn and _axis binds as well; they are omitted here for clarity.
 # input_player1_left_axis =
 # input_player1_right_axis =
@@ -566,7 +566,7 @@
 # Hold for fast-forward. Releasing button disables fast-forward.
 # input_hold_fast_forward = l
 
-# Key to exit RetroArch cleanly. 
+# Key to exit RetroArch cleanly.
 # Killing it in any hard way (SIGKILL, etc) will terminate RetroArch without saving RAM, etc.
 # On Unix-likes, SIGINT/SIGTERM allows a clean deinitialization.
 # input_exit_emulator = escape
@@ -650,7 +650,7 @@
 
 #### Menu
 
-# Menu driver to use. "rgui", "lakka", etc. 
+# Menu driver to use. "rgui", "lakka", etc.
 # menu_driver = "rgui"
 
 # If disabled, the libretro core will keep running in the background when we
@@ -727,7 +727,7 @@
 # netplay_client_swap_input = false
 
 # The username of the person running RetroArch. This will be used for playing online, for instance.
-# netplay_nickname = 
+# netplay_nickname =
 
 # The amount of delay frames to use for netplay. Increasing this value will increase
 # performance, but introduce more latency.
@@ -741,7 +741,7 @@
 # netplay_spectator_mode_enable = false
 
 # The IP Address of the host to connect to.
-# netplay_ip_address = 
+# netplay_ip_address =
 
 # The port of the host IP Address. Can be either a TCP or UDP port.
 # netplay_ip_port = 55435
@@ -808,5 +808,3 @@
 # stdin_cmd_enable = false
 
 #### Bundle extraction
-
-


### PR DESCRIPTION
A Raspberry Pi user submitted a bug report to me about performance of the open source graphics driver with RetroArch (https://github.com/anholt/linux/issues/57) with max swapchain of 2, but the first thing I found looks like a bug in RetroArch's drm_ctx.c.

This is very lightly tested -- just watching the vblank missed complaints during the splash screen of an NES game I had laying around, using a nightly nestopia_libretro.so.

The real problem, I think, is that we immediately block on the flip completion after swap, to make the back buffer go idle.  However, I think it will be a long time until the next gl_frame(), causing us to miss the vblank.  I'm assuming nobody's going to be drawing to the default framebuffer until gl_frame(), so we could just block on completion at that point.  Is there a reasonable way to hook that up?
