### PR TITLE
only save config when menu_show_start_screen is enabled if config_save_on_exit is also enabled

### DIFF
--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -182,7 +182,8 @@ static bool menu_init(menu_handle_t *menu_data)
    {
       menu_dialog_push_pending(true, MENU_DIALOG_WELCOME);
       settings->menu_show_start_screen   = false;
-      command_event(CMD_EVENT_MENU_SAVE_CURRENT_CONFIG, NULL);
+      if (settings->config_save_on_exit)
+         command_event(CMD_EVENT_MENU_SAVE_CURRENT_CONFIG, NULL);
    }
 
    if (      settings->bundle_assets_extract_enable


### PR DESCRIPTION
this is needed after https://github.com/libretro/RetroArch/issues/3605 otherwise it will always save if rgui_show_start_screen is true.