### PR TITLE
Remove missed Vblank log printout, since it may cause prolonged performance degradation

### DIFF
--- a/gfx/drivers_context/drm_ctx.c
+++ b/gfx/drivers_context/drm_ctx.c
@@ -157,25 +157,25 @@ static void gfx_ctx_drm_check_window(void *data, bool *quit,
 static void drm_flip_handler(int fd, unsigned frame,
       unsigned sec, unsigned usec, void *data)
 {
-   static unsigned first_page_flip;
-   static unsigned last_page_flip;
+   //static unsigned first_page_flip;
+   //static unsigned last_page_flip;
 
    (void)fd;
    (void)sec;
    (void)usec;
 
-   if (!first_page_flip)
-      first_page_flip = frame;
+   //if (!first_page_flip)
+   //   first_page_flip = frame;
 
-   if (last_page_flip)
-   {
-      unsigned missed = frame - last_page_flip - 1;
-      if (missed)
-         RARCH_LOG("[KMS]: Missed %u VBlank(s) (Frame: %u, DRM frame: %u).\n",
-               missed, frame - first_page_flip, frame);
-   }
+   //if (last_page_flip)
+   //{
+   //   unsigned missed = frame - last_page_flip - 1;
+   //   if (missed)
+   //      RARCH_LOG("[KMS]: Missed %u VBlank(s) (Frame: %u, DRM frame: %u).\n",
+   //            missed, frame - first_page_flip, frame);
+   //}
 
-   last_page_flip = frame;
+   //last_page_flip = frame;
    *(bool*)data = false;
 }
 

--- a/gfx/drivers_context/drm_ctx.c
+++ b/gfx/drivers_context/drm_ctx.c
@@ -157,25 +157,28 @@ static void gfx_ctx_drm_check_window(void *data, bool *quit,
 static void drm_flip_handler(int fd, unsigned frame,
       unsigned sec, unsigned usec, void *data)
 {
-   //static unsigned first_page_flip;
-   //static unsigned last_page_flip;
-
    (void)fd;
    (void)sec;
    (void)usec;
+  
+#if 0
+   static unsigned first_page_flip;
+   static unsigned last_page_flip;
 
-   //if (!first_page_flip)
-   //   first_page_flip = frame;
+   if (!first_page_flip)
+      first_page_flip = frame;
 
-   //if (last_page_flip)
-   //{
-   //   unsigned missed = frame - last_page_flip - 1;
-   //   if (missed)
-   //      RARCH_LOG("[KMS]: Missed %u VBlank(s) (Frame: %u, DRM frame: %u).\n",
-   //            missed, frame - first_page_flip, frame);
-   //}
+   if (last_page_flip)
+   {
+      unsigned missed = frame - last_page_flip - 1;
+      if (missed)
+         RARCH_LOG("[KMS]: Missed %u VBlank(s) (Frame: %u, DRM frame: %u).\n",
+               missed, frame - first_page_flip, frame);
+   }
 
-   //last_page_flip = frame;
+   last_page_flip = frame;
+#endif
+
    *(bool*)data = false;
 }
 


### PR DESCRIPTION
As the heading says, this log printout may cause a state of prolonged slowdown, since printing to the terminal is really slow. Imagine the following case:

The system is constantly on the edge of being able to churn out a frame in time for a page flip. A particularly demanding frame causes the system to (legitimately) miss a Vblank. This will cause a printout in the terminal. Console printouts are generally really slow and the time taken to print the message eats right into the time available for rendering the next frame. Since we were already on the edge of rendering each frame on time, the time lost in printing the message causes us to miss the next Vblank as well. Which in turn causes another slow printout, which... etc, etc. I have verified with testing that this is an actual issue.

I have just commented out the logging code, since I do see the value of enabling it during specific performance tests/investigations. You probably have opinions about that, so please let me know if you want me to change it in any way. Either way, the log printout is a bad idea and should not be enabled by default.