### PR TITLE
Font refactor

### DIFF
--- a/frontend/drivers/platform_psp.c
+++ b/frontend/drivers/platform_psp.c
@@ -138,6 +138,8 @@ static void frontend_psp_get_environment_settings(int *argc, char *argv[],
          "temp", sizeof(g_defaults.dir.cache));
    fill_pathname_join(g_defaults.dir.overlay, user_path,
          "overlays", sizeof(g_defaults.dir.overlay));
+   fill_pathname_join(g_defaults.dir.thumbnails, user_path,
+         "thumbnails", sizeof(g_defaults.dir.thumbnails));
    strlcpy(g_defaults.dir.content_history,
          user_path, sizeof(g_defaults.dir.content_history));
    fill_pathname_join(g_defaults.path.config, user_path,
@@ -210,8 +212,9 @@ static void frontend_psp_get_environment_settings(int *argc, char *argv[],
    path_mkdir(g_defaults.dir.screenshot);
    path_mkdir(g_defaults.dir.sram);
    path_mkdir(g_defaults.dir.system);
-   /* path_mkdir(g_defaults.dir.thumbnails); */
-
+#ifdef VITA
+   path_mkdir(g_defaults.dir.thumbnails);
+#endif
    /* create cache dir */
    path_mkdir(g_defaults.dir.cache);
 
@@ -466,6 +469,8 @@ static int frontend_psp_parse_drive_list(void *data)
    file_list_t *list = (file_list_t*)data;
 
 #ifdef VITA
+   menu_entries_append_enum(list,
+         "app0:/", "", MSG_UNKNOWN, FILE_TYPE_DIRECTORY, 0, 0);
    menu_entries_append_enum(list,
          "ur0:/", "", MSG_UNKNOWN, FILE_TYPE_DIRECTORY, 0, 0);
    menu_entries_append_enum(list,

--- a/gfx/common/ctr_common.h
+++ b/gfx/common/ctr_common.h
@@ -2,6 +2,7 @@
 #define CTR_COMMON_H__
 
 #include <retro_inline.h>
+#include "../font_driver.h"
 
 #define COLOR_ABGR(r, g, b, a) (((unsigned)(a) << 24) | ((b) << 16) | ((g) << 8) | ((r) << 0))
 
@@ -99,6 +100,8 @@ typedef struct ctr_video
       ctr_vertex_t* current;
       int size;
    }vertex_cache;
+
+   const font_t *osd_font;
 
 } ctr_video_t;
 

--- a/gfx/common/gl_common.h
+++ b/gfx/common/gl_common.h
@@ -148,6 +148,8 @@ typedef struct gl
 #endif
 
    GLuint vao;
+
+   const font_t *osd_font;
 } gl_t;
 
 bool gl_load_luts(const struct video_shader *generic_shader,

--- a/gfx/common/vita2d_common.h
+++ b/gfx/common/vita2d_common.h
@@ -81,6 +81,8 @@ typedef struct vita_video
    bool overlay_enable;
    bool overlay_full_screen;
 #endif
+
+   const font_t *osd_font;
    
 } vita_video_t;
 

--- a/gfx/common/vulkan_common.h
+++ b/gfx/common/vulkan_common.h
@@ -391,6 +391,8 @@ typedef struct vk
    } tracker;
 
    void *filter_chain;
+
+   const font_t *osd_font;
 } vk_t;
 
 uint32_t vulkan_find_memory_type(

--- a/gfx/drivers/ctr_gfx.c
+++ b/gfx/drivers/ctr_gfx.c
@@ -433,13 +433,7 @@ static void* ctr_init(const video_info_t* video,
    driver_ctl(RARCH_DRIVER_CTL_SET_REFRESH_RATE, &refresh_rate);
    aptHook(&ctr->lcd_aptHook, ctr_lcd_aptHook, ctr);
 
-   if (!font_driver_init_first(NULL, NULL, ctr, *settings->path.font
-          ? settings->path.font : NULL, settings->video.font_size, false,
-          FONT_DRIVER_RENDER_CTR))
-   {
-      RARCH_ERR("Font: Failed to initialize font renderer.\n");
-        return false;
-   }
+   font_set_api(FONT_DRIVER_RENDER_CTR);
 
    ctr->msg_rendering_enabled = false;
    ctr->menu_texture_frame_enable = false;

--- a/gfx/drivers/ctr_gfx.c
+++ b/gfx/drivers/ctr_gfx.c
@@ -757,7 +757,7 @@ static bool ctr_frame(void* data, const void* frame,
 
    }
 
-   if (font_driver_has_render_msg() && msg)
+   if (msg)
       font_driver_render_msg(NULL, msg, NULL);
 
 //   font_driver_render_msg(NULL, "TEST: 123 ABC àüî", NULL);

--- a/gfx/drivers/ctr_gfx.c
+++ b/gfx/drivers/ctr_gfx.c
@@ -1099,7 +1099,7 @@ static void ctr_set_osd_msg(void *data, const char *msg,
    ctr_video_t* ctr = (ctr_video_t*)data;
 
    if (ctr && ctr->msg_rendering_enabled)
-      font_driver_render_msg(font, msg, params);
+      font_render_full(font, msg, params);
 }
 
 

--- a/gfx/drivers/ctr_gfx.c
+++ b/gfx/drivers/ctr_gfx.c
@@ -434,6 +434,8 @@ static void* ctr_init(const video_info_t* video,
    aptHook(&ctr->lcd_aptHook, ctr_lcd_aptHook, ctr);
 
    font_set_api(FONT_DRIVER_RENDER_CTR);
+   ctr->osd_font = font_load(*settings->path.font ? settings->path.font : NULL,
+                        settings->video.font_size);
 
    ctr->msg_rendering_enabled = false;
    ctr->menu_texture_frame_enable = false;
@@ -758,9 +760,9 @@ static bool ctr_frame(void* data, const void* frame,
    }
 
    if (msg)
-      font_driver_render_msg(NULL, msg, NULL);
+      font_render_full(ctr->osd_font, msg, NULL);
 
-//   font_driver_render_msg(NULL, "TEST: 123 ABC àüî", NULL);
+//   font_render_full(ctr->osd_font, "TEST: 123 ABC àüî", NULL);
 
 
 
@@ -859,6 +861,8 @@ static void ctr_free(void* data)
 
    if (!ctr)
       return;
+
+   font_unref(ctr->osd_font);
 
    aptUnhook(&ctr->lcd_aptHook);
    gspSetEventCallback(GSPGPU_EVENT_VBlank0, NULL, NULL, true);

--- a/gfx/drivers/d3d.cpp
+++ b/gfx/drivers/d3d.cpp
@@ -1182,6 +1182,8 @@ static void *d3d_init(const video_info_t *info,
    video_input_ctl(RARCH_INPUT_CTL_SET_OWN_DRIVER, NULL);
 #endif
 
+   font_set_api(FONT_DRIVER_RENDER_DIRECT3D_API);
+
    return d3d;
 
 error:
@@ -1516,7 +1518,7 @@ static bool d3d_frame(void *data, const void *frame,
       return false;
    }
 
-   if (font_driver_has_render_msg() && msg)
+   if (msg)
    {
       struct font_params font_parms = {0};
 #ifdef _XBOX
@@ -1531,7 +1533,7 @@ static bool d3d_frame(void *data, const void *frame,
       font_parms.y                  = msg_height;
       font_parms.scale              = 21;
 #endif
-      font_driver_render_msg(NULL, msg, &font_parms);
+      font_render_full(d3d->osd_font, true, msg, &font_parms);
    }
 
 #ifdef HAVE_MENU

--- a/gfx/drivers/d3d.cpp
+++ b/gfx/drivers/d3d.cpp
@@ -487,7 +487,7 @@ static void d3d_deinitialize(d3d_video_t *d3d)
    if (!d3d)
       return;
 
-   font_driver_free(NULL);
+   font_unref(d3d->osd_font);
    d3d_deinit_chain(d3d);
 }
 
@@ -815,13 +815,10 @@ static bool d3d_initialize(d3d_video_t *d3d, const video_info_t *info)
    strlcpy(settings->path.font, "game:\\media\\Arial_12.xpr",
          sizeof(settings->path.font));
 #endif
-   if (!font_driver_init_first(NULL, NULL,
-            d3d, settings->path.font, 0, false,
-            FONT_DRIVER_RENDER_DIRECT3D_API))
-   {
-      RARCH_ERR("[D3D]: Failed to initialize font renderer.\n");
-      return false;
-   }
+
+   font_set_api(FONT_DRIVER_RENDER_DIRECT3D_API);
+   d3d->osd_font = font_load(*settings->path.font ? settings->path.font : NULL,
+                           settings->video.font_size);
 
    return true;
 }
@@ -969,7 +966,7 @@ static void d3d_set_osd_msg(void *data, const char *msg,
    if (d3d->renderchain_driver->set_font_rect && params)
       d3d->renderchain_driver->set_font_rect(d3d, params);
 
-   font_driver_render_msg(NULL, msg, params);
+   font_render_full(d3d->osd_font, msg, params);
 }
 
 /* Delay constructor due to lack of exceptions. */
@@ -1181,8 +1178,6 @@ static void *d3d_init(const video_info_t *info,
    video_driver_set_own_driver();
    video_input_ctl(RARCH_INPUT_CTL_SET_OWN_DRIVER, NULL);
 #endif
-
-   font_set_api(FONT_DRIVER_RENDER_DIRECT3D_API);
 
    return d3d;
 
@@ -1533,7 +1528,7 @@ static bool d3d_frame(void *data, const void *frame,
       font_parms.y                  = msg_height;
       font_parms.scale              = 21;
 #endif
-      font_render_full(d3d->osd_font, true, msg, &font_parms);
+      font_render_full(d3d->osd_font, msg, &font_parms);
    }
 
 #ifdef HAVE_MENU

--- a/gfx/drivers/d3d.h
+++ b/gfx/drivers/d3d.h
@@ -107,6 +107,7 @@ typedef struct d3d_video
 
    RECT font_rect;
    RECT font_rect_shifted;
+   const font_t *osd_font;
 
 #ifdef HAVE_OVERLAY
    bool overlays_enabled;

--- a/gfx/drivers/exynos_gfx.c
+++ b/gfx/drivers/exynos_gfx.c
@@ -1021,7 +1021,7 @@ struct exynos_video
    struct exynos_data *data;
 
    void *font;
-   const font_renderer_driver_t *font_driver;
+   const font_backend_t *font_driver;
    uint16_t font_color; /* ARGB4444 */
 
    unsigned bytes_per_pixel;

--- a/gfx/drivers/omap_gfx.c
+++ b/gfx/drivers/omap_gfx.c
@@ -788,7 +788,7 @@ typedef struct omap_video
    omapfb_data_t *omap;
 
    void *font;
-   const font_renderer_driver_t *font_driver;
+   const font_backend_t *font_driver;
    uint8_t font_rgb[4];
 
    unsigned bytes_per_pixel;

--- a/gfx/drivers/sdl2_gfx.c
+++ b/gfx/drivers/sdl2_gfx.c
@@ -61,13 +61,12 @@ typedef struct _sdl2_video
 
    sdl2_tex_t frame;
    sdl2_tex_t menu;
-   sdl2_tex_t font;
+   sdl2_tex_t font_tex;
 
    bool gl;
    bool quitting;
 
-   void *font_data;
-   const font_backend_t *font_driver;
+   const font_t *font;
    uint8_t font_r;
    uint8_t font_g;
    uint8_t font_b;
@@ -105,8 +104,7 @@ static void sdl2_init_font(sdl2_video_t *vid, const char *font_path,
    if (!settings->video.font_enable)
       return;
 
-   if (!font_renderer_create_default((const void**)&vid->font_driver, &vid->font_data,
-                                    *font_path ? font_path : NULL, font_size))
+   if ((vid->font = font_load(*font_path ? font_path : NULL, font_size)) == NULL)
    {
       RARCH_WARN("[SDL]: Could not initialize fonts.\n");
       return;
@@ -124,7 +122,7 @@ static void sdl2_init_font(sdl2_video_t *vid, const char *font_path,
    vid->font_g = g;
    vid->font_b = b;
 
-   atlas = vid->font_driver->get_atlas(vid->font_data);
+   atlas = font_get_atlas(vid->font);
 
    tmp = SDL_CreateRGBSurfaceFrom(atlas->buffer, atlas->width,
          atlas->height, 8, atlas->width,
@@ -141,15 +139,15 @@ static void sdl2_init_font(sdl2_video_t *vid, const char *font_path,
    SDL_SetSurfacePalette(tmp, pal);
    SDL_SetColorKey(tmp, SDL_TRUE, 0);
 
-   vid->font.tex  = SDL_CreateTextureFromSurface(vid->renderer, tmp);
+   vid->font_tex.tex  = SDL_CreateTextureFromSurface(vid->renderer, tmp);
 
-   if (vid->font.tex)
+   if (vid->font_tex.tex)
    {
-      vid->font.w      = atlas->width;
-      vid->font.h      = atlas->height;
-      vid->font.active = true;
+      vid->font_tex.w      = atlas->width;
+      vid->font_tex.h      = atlas->height;
+      vid->font_tex.active = true;
 
-      SDL_SetTextureBlendMode(vid->font.tex, SDL_BLENDMODE_ADD);
+      SDL_SetTextureBlendMode(vid->font_tex.tex, SDL_BLENDMODE_ADD);
    }
    else
       RARCH_WARN("[SDL]: Failed to initialize font texture: %s\n", SDL_GetError());
@@ -165,7 +163,7 @@ static void sdl2_render_msg(sdl2_video_t *vid, const char *msg)
    unsigned height = vid->vp.height;
    settings_t *settings = config_get_ptr();
 
-   if (!vid->font_data)
+   if (!vid->font)
       return;
 
    x       = settings->video.msg_pos_x * width;
@@ -173,17 +171,13 @@ static void sdl2_render_msg(sdl2_video_t *vid, const char *msg)
    delta_x = 0;
    delta_y = 0;
 
-   SDL_SetTextureColorMod(vid->font.tex, vid->font_r, vid->font_g, vid->font_b);
+   SDL_SetTextureColorMod(vid->font_tex.tex, vid->font_r, vid->font_g, vid->font_b);
 
    for (; *msg; msg++)
    {
       SDL_Rect src_rect, dst_rect;
       int off_x, off_y, tex_x, tex_y;
-      const struct font_glyph *gly = 
-         vid->font_driver->get_glyph(vid->font_data, (uint8_t)*msg);
-
-      if (!gly)
-         gly = vid->font_driver->get_glyph(vid->font_data, '?');
+      const struct font_glyph *gly = font_get_glyph(vid->font, (uint8_t)*msg);
 
       if (!gly)
          continue;
@@ -203,7 +197,7 @@ static void sdl2_render_msg(sdl2_video_t *vid, const char *msg)
       dst_rect.w = (int)gly->width;
       dst_rect.h = (int)gly->height;
 
-      SDL_RenderCopyEx(vid->renderer, vid->font.tex,
+      SDL_RenderCopyEx(vid->renderer, vid->font_tex.tex,
             &src_rect, &dst_rect, 0, NULL, SDL_FLIP_NONE);
 
       delta_x += gly->advance_x;
@@ -601,8 +595,8 @@ static void sdl2_gfx_free(void *data)
 
    SDL_QuitSubSystem(SDL_INIT_VIDEO);
 
-   if (vid->font_data)
-      vid->font_driver->free(vid->font_data);
+   if (vid->font)
+      font_unref(vid->font);
 
    free(vid);
 }

--- a/gfx/drivers/sdl2_gfx.c
+++ b/gfx/drivers/sdl2_gfx.c
@@ -67,7 +67,7 @@ typedef struct _sdl2_video
    bool quitting;
 
    void *font_data;
-   const font_renderer_driver_t *font_driver;
+   const font_backend_t *font_driver;
    uint8_t font_r;
    uint8_t font_g;
    uint8_t font_b;

--- a/gfx/drivers/sdl_gfx.c
+++ b/gfx/drivers/sdl_gfx.c
@@ -55,7 +55,7 @@ typedef struct sdl_video
    bool quitting;
 
    void *font;
-   const font_renderer_driver_t *font_driver;
+   const font_backend_t *font_driver;
    uint8_t font_r;
    uint8_t font_g;
    uint8_t font_b;

--- a/gfx/drivers/sdl_gfx.c
+++ b/gfx/drivers/sdl_gfx.c
@@ -54,8 +54,7 @@ typedef struct sdl_video
    SDL_Surface *screen;
    bool quitting;
 
-   void *font;
-   const font_backend_t *font_driver;
+   const font_t *font;
    uint8_t font_r;
    uint8_t font_g;
    uint8_t font_b;
@@ -77,7 +76,7 @@ static void sdl_gfx_free(void *data)
    SDL_QuitSubSystem(SDL_INIT_VIDEO);
 
    if (vid->font)
-      vid->font_driver->free(vid->font);
+      font_unref(vid->font);
 
    scaler_ctx_gen_reset(&vid->scaler);
    scaler_ctx_gen_reset(&vid->menu.scaler);
@@ -93,9 +92,7 @@ static void sdl_init_font(sdl_video_t *vid, const char *font_path, unsigned font
    if (!settings->video.font_enable)
       return;
 
-   if (!font_renderer_create_default((const void**)&vid->font_driver, &vid->font,
-            *settings->path.font ? settings->path.font : NULL,
-            settings->video.font_size))
+   if ((vid->font = font_load(*font_path ? font_path : NULL, font_size)) == NULL)
    {
       RARCH_LOG("[SDL]: Could not initialize fonts.\n");
       return;
@@ -125,7 +122,7 @@ static void sdl_render_msg(sdl_video_t *vid, SDL_Surface *buffer,
    if (!vid->font)
       return;
 
-   atlas = vid->font_driver->get_atlas(vid->font);
+   atlas = font_get_atlas(vid->font);
 
    msg_base_x = settings->video.msg_pos_x * width;
    msg_base_y = (1.0f - settings->video.msg_pos_y) * height;
@@ -140,7 +137,7 @@ static void sdl_render_msg(sdl_video_t *vid, SDL_Surface *buffer,
       int base_x, base_y, max_width, max_height;
       uint32_t *out      = NULL;
       const uint8_t *src = NULL;
-      const struct font_glyph *glyph = vid->font_driver->get_glyph(vid->font, (uint8_t)*msg);
+      const struct font_glyph *glyph = font_get_glyph(vid->font, (uint8_t)*msg);
       if (!glyph)
          continue;
 

--- a/gfx/drivers/sunxi_gfx.c
+++ b/gfx/drivers/sunxi_gfx.c
@@ -504,7 +504,7 @@ struct sunxi_page
 struct sunxi_video
 {
    void *font;
-   const font_renderer_driver_t *font_driver;
+   const font_backend_t *font_driver;
 
    uint8_t font_rgb[4];
 

--- a/gfx/drivers/vg.c
+++ b/gfx/drivers/vg.c
@@ -63,7 +63,7 @@ typedef struct
    uint32_t mFontHeight;
    VGFont mFont;
    void *mFontRenderer;
-   const font_renderer_driver_t *font_driver;
+   const font_backend_t *font_driver;
    bool mFontsOn;
    VGuint mMsgLength;
    VGuint mGlyphIndices[1024];

--- a/gfx/drivers/vita2d_gfx.c
+++ b/gfx/drivers/vita2d_gfx.c
@@ -99,13 +99,8 @@ static void *vita2d_gfx_init(const video_info_t *video,
 #ifdef HAVE_OVERLAY
    vita->overlay_enable     = false;
 #endif
-   if (!font_driver_init_first(NULL, NULL, vita, *settings->path.font 
-          ? settings->path.font : NULL, settings->video.font_size, false,
-          FONT_DRIVER_RENDER_VITA2D))
-   {
-      RARCH_ERR("Font: Failed to initialize font renderer.\n");
-        return false;
-   }
+
+   font_set_api(FONT_DRIVER_RENDER_VITA2D);
    return vita;
 }
 

--- a/gfx/drivers/vita2d_gfx.c
+++ b/gfx/drivers/vita2d_gfx.c
@@ -101,6 +101,8 @@ static void *vita2d_gfx_init(const video_info_t *video,
 #endif
 
    font_set_api(FONT_DRIVER_RENDER_VITA2D);
+   vita->osd_font = font_load(*settings->path.font ? settings->path.font : NULL,
+                        settings->video.font_size);
    return vita;
 }
 
@@ -254,7 +256,7 @@ static bool vita2d_gfx_frame(void *data, const void *frame,
    
    
    if(!string_is_empty(msg))
-     font_driver_render_msg(NULL, msg, NULL);
+     font_render_full(vita->osd_font, msg, NULL);
    
    vita2d_end_drawing();
    vita2d_swap_buffers();
@@ -316,7 +318,7 @@ static void vita2d_gfx_free(void *data)
       vita->texture = NULL;
    }
 
-   font_driver_free(NULL);
+   font_unref(vita->osd_font);
 
    RARCH_LOG("vita2d_gfx_free() done\n");
 }
@@ -734,8 +736,8 @@ static void vita_unload_texture(void *data, uintptr_t handle)
 static void vita_set_osd_msg(void *data, const char *msg,
       const struct font_params *params, void *font)
 {
-   (void)data;
-   font_driver_render_msg(font, msg, params);
+  vita_video_t *vita = (vita_video_t*)data;
+   font_render_full(vita->osd_font, msg, params);
 }
 
 static bool vita_get_current_sw_framebuffer(void *data,

--- a/gfx/drivers/xvideo.c
+++ b/gfx/drivers/xvideo.c
@@ -60,8 +60,7 @@ typedef struct xv
    uint8_t *utable;
    uint8_t *vtable;
 
-   void *font;
-   const font_backend_t *font_driver;
+   const font_t *font;
 
    unsigned luma_index[2];
    unsigned chroma_u_index;
@@ -130,9 +129,7 @@ static void xv_init_font(xv_t *xv, const char *font_path, unsigned font_size)
    if (!settings->video.font_enable)
       return;
 
-   if (font_renderer_create_default((const void**)&xv->font_driver, 
-            &xv->font, *settings->path.font 
-            ? settings->path.font : NULL, settings->video.font_size))
+   if ((xv->font = font_load(*font_path ? font_path : NULL, font_size)) == NULL)
    {
       int r, g, b;
       r = settings->video.msg_color_r * 255;
@@ -676,7 +673,7 @@ static void xv_render_msg(xv_t *xv, const char *msg,
    if (!xv->font)
       return;
 
-   atlas          = xv->font_driver->get_atlas(xv->font);
+   atlas          = font_get_atlas(xv->font);
 
    msg_base_x     = settings->video.msg_pos_x * width;
    msg_base_y     = height * (1.0f - settings->video.msg_pos_y);
@@ -694,8 +691,7 @@ static void xv_render_msg(xv_t *xv, const char *msg,
       int base_x, base_y, glyph_width, glyph_height, max_width, max_height;
       const uint8_t *src             = NULL;
       uint8_t *out                   = NULL;
-      const struct font_glyph *glyph = 
-         xv->font_driver->get_glyph(xv->font, (uint8_t)*msg);
+      const struct font_glyph *glyph = font_get_glyph(xv->font, (uint8_t)*msg);
 
       if (!glyph)
          continue;
@@ -856,7 +852,7 @@ static void xv_free(void *data)
    free(xv->vtable);
 
    if (xv->font)
-      xv->font_driver->free(xv->font);
+      font_unref(xv->font);
 
    free(xv);
 }

--- a/gfx/drivers/xvideo.c
+++ b/gfx/drivers/xvideo.c
@@ -61,7 +61,7 @@ typedef struct xv
    uint8_t *vtable;
 
    void *font;
-   const font_renderer_driver_t *font_driver;
+   const font_backend_t *font_driver;
 
    unsigned luma_index[2];
    unsigned chroma_u_index;

--- a/gfx/drivers_font/ctr_font.c
+++ b/gfx/drivers_font/ctr_font.c
@@ -39,7 +39,7 @@ typedef struct
 {
    ctr_texture_t texture;
    ctr_scale_vector_t scale_vector;
-   const font_renderer_driver_t* font_driver;
+   const font_backend_t* font_driver;
    void* font_data;
 } ctr_font_t;
 

--- a/gfx/drivers_font/ctr_font.c
+++ b/gfx/drivers_font/ctr_font.c
@@ -52,7 +52,7 @@ static void* ctr_font_init_font(void* data, const font_t* font)
    if (!self)
       return NULL;
 
-   self->font = font_ref(font);
+   self->font = font;
 
    atlas = font_get_atlas(font);
 
@@ -94,10 +94,8 @@ static void ctr_font_free_font(void* data)
    if (!self)
       return;
 
-   font_unref(self->font);
-
 #ifdef FONT_TEXTURE_IN_VRAM
-   vramFree(font->texture.data);
+   vramFree(self->texture.data);
 #else
    linearFree(self->texture.data);
 #endif

--- a/gfx/drivers_font/ctr_font.c
+++ b/gfx/drivers_font/ctr_font.c
@@ -52,8 +52,7 @@ static void* ctr_font_init_font(void* data, const font_t* font)
    if (!self)
       return NULL;
 
-   self->font = font;
-   font_ref(font);
+   self->font = font_ref(font);
 
    atlas = font_get_atlas(font);
 

--- a/gfx/drivers_font/ctr_font.c
+++ b/gfx/drivers_font/ctr_font.c
@@ -39,38 +39,32 @@ typedef struct
 {
    ctr_texture_t texture;
    ctr_scale_vector_t scale_vector;
-   const font_backend_t* font_driver;
+   const font_t* font;
    void* font_data;
 } ctr_font_t;
 
-static void* ctr_font_init_font(void* data, const char* font_path, float font_size)
+static void* ctr_font_init_font(void* data, const font_t* font)
 {
    const struct font_atlas* atlas = NULL;
-   ctr_font_t* font = (ctr_font_t*)calloc(1, sizeof(*font));
+   ctr_font_t* self= (ctr_font_t*)calloc(1, sizeof(*self));
    ctr_video_t* ctr = (ctr_video_t*)data;
 
-   if (!font)
+   if (!self)
       return NULL;
 
-   font_size = 10;
-   if (!font_renderer_create_default((const void**)&font->font_driver,
-                                     &font->font_data, font_path, font_size))
-   {
-      RARCH_WARN("Couldn't initialize font renderer.\n");
-      free(font);
-      return NULL;
-   }
+   self->font = font;
+   font_ref(font);
 
-   atlas = font->font_driver->get_atlas(font->font_data);
+   atlas = font_get_atlas(font);
 
-   font->texture.width = next_pow2(atlas->width);
-   font->texture.height = next_pow2(atlas->height);
+   self->texture.width = next_pow2(atlas->width);
+   self->texture.height = next_pow2(atlas->height);
 #if FONT_TEXTURE_IN_VRAM
    font->texture.data = vramAlloc(font->texture.width * font->texture.height);
    uint8_t* tmp = linearAlloc(font->texture.width * font->texture.height);
 #else
-   font->texture.data = linearAlloc(font->texture.width * font->texture.height);
-   uint8_t* tmp = font->texture.data;
+   self->texture.data = linearAlloc(self->texture.width * self->texture.height);
+   uint8_t* tmp = self->texture.data;
 #endif
 
    int i, j;
@@ -80,7 +74,7 @@ static void* ctr_font_init_font(void* data, const char* font_path, float font_si
       for (i = 0; (i < atlas->width) && (i < font->texture.width); i++)
          tmp[ctrgu_swizzle_coords(i, j, font->texture.width)] = src[i + j * atlas->width];
 
-   GSPGPU_FlushDataCache(tmp, font->texture.width * font->texture.height);
+   GSPGPU_FlushDataCache(tmp, self->texture.width * self->texture.height);
 
 #if FONT_TEXTURE_IN_VRAM
    ctrGuCopyImage(true, tmp, font->texture.width >> 2, font->texture.height, CTRGU_RGBA8, true,
@@ -89,38 +83,37 @@ static void* ctr_font_init_font(void* data, const char* font_path, float font_si
    linearFree(tmp);
 #endif
 
-   ctr_set_scale_vector(&font->scale_vector, 400, 240, font->texture.width, font->texture.height);
+   ctr_set_scale_vector(&self->scale_vector, 400, 240, self->texture.width, self->texture.height);
 
-   return font;
+   return self;
 }
 
 static void ctr_font_free_font(void* data)
 {
-   ctr_font_t* font = (ctr_font_t*)data;
+   ctr_font_t* self = (ctr_font_t*)data;
 
-   if (!font)
+   if (!self)
       return;
 
-   if (font->font_driver && font->font_data)
-      font->font_driver->free(font->font_data);
+   font_unref(self->font);
 
 #ifdef FONT_TEXTURE_IN_VRAM
    vramFree(font->texture.data);
 #else
-   linearFree(font->texture.data);
+   linearFree(self->texture.data);
 #endif
-   free(font);
+   free(self);
 }
 
 static int ctr_font_get_message_width(void* data, const char* msg,
                                       unsigned msg_len, float scale)
 {
-   ctr_font_t* font = (ctr_font_t*)data;
+   ctr_font_t* self = (ctr_font_t*)data;
 
    unsigned i;
    int delta_x = 0;
 
-   if (!font)
+   if (!self)
       return 0;
 
    for (i = 0; i < msg_len; i++)
@@ -132,23 +125,17 @@ static int ctr_font_get_message_width(void* data, const char* msg,
       if (skip > 1)
          i += skip - 1;
 
-      const struct font_glyph* glyph =
-         font->font_driver->get_glyph(font->font_data, code);
+      const struct font_glyph* glyph = font_get_glyph(self->font, code);
 
-      if (!glyph) /* Do something smarter here ... */
-         glyph = font->font_driver->get_glyph(font->font_data, '?');
-
-      if (!glyph)
-         continue;
-
-      delta_x += glyph->advance_x;
+      if (glyph)
+         delta_x += glyph->advance_x;
    }
 
    return delta_x * scale;
 }
 
 static void ctr_font_render_line(
-   ctr_font_t* font, const char* msg, unsigned msg_len,
+   ctr_font_t* self, const char* msg, unsigned msg_len,
    float scale, const unsigned int color, float pos_x,
    float pos_y, unsigned text_align)
 {
@@ -169,11 +156,11 @@ static void ctr_font_render_line(
    switch (text_align)
    {
    case TEXT_ALIGN_RIGHT:
-      x -= ctr_font_get_message_width(font, msg, msg_len, scale);
+      x -= ctr_font_get_message_width(self, msg, msg_len, scale);
       break;
 
    case TEXT_ALIGN_CENTER:
-      x -= ctr_font_get_message_width(font, msg, msg_len, scale) / 2;
+      x -= ctr_font_get_message_width(self, msg, msg_len, scale) / 2;
       break;
    }
 
@@ -192,11 +179,7 @@ static void ctr_font_render_line(
       if (skip > 1)
          i += skip - 1;
 
-      const struct font_glyph* glyph =
-         font->font_driver->get_glyph(font->font_data, code);
-
-      if (!glyph) /* Do something smarter here ... */
-         glyph = font->font_driver->get_glyph(font->font_data, '?');
+      const struct font_glyph* glyph = font_get_glyph(self->font, code);
 
       if (!glyph)
          continue;
@@ -226,7 +209,7 @@ static void ctr_font_render_line(
    if (v == ctr->vertex_cache.current)
       return;
 
-   ctrGuSetVertexShaderFloatUniform(0, (float*)&font->scale_vector, 1);
+   ctrGuSetVertexShaderFloatUniform(0, (float*)&self->scale_vector, 1);
    GSPGPU_FlushDataCache(ctr->vertex_cache.current, (v - ctr->vertex_cache.current) * sizeof(ctr_vertex_t));
    ctrGuSetAttributeBuffers(2,
                             VIRT_TO_PHYS(ctr->vertex_cache.current),
@@ -244,7 +227,7 @@ static void ctr_font_render_line(
 //   printf("%s\n", msg);
 //   DEBUG_VAR(color);
 //   GPU_SetTexEnv(0, GPU_TEXTURE0, GPU_TEXTURE0, 0, GPU_TEVOPERANDS(GPU_TEVOP_RGB_SRC_R, 0, 0), GPU_REPLACE, GPU_REPLACE, 0);
-   ctrGuSetTexture(GPU_TEXUNIT0, VIRT_TO_PHYS(font->texture.data), font->texture.width, font->texture.height,
+   ctrGuSetTexture(GPU_TEXUNIT0, VIRT_TO_PHYS(self->texture.data), self->texture.width, self->texture.height,
                    GPU_TEXTURE_MAG_FILTER(GPU_NEAREST)  | GPU_TEXTURE_MIN_FILTER(GPU_NEAREST) |
                    GPU_TEXTURE_WRAP_S(GPU_CLAMP_TO_EDGE) | GPU_TEXTURE_WRAP_T(GPU_CLAMP_TO_EDGE),
                    GPU_L8);
@@ -292,7 +275,7 @@ static void ctr_font_render_line(
 }
 
 static void ctr_font_render_message(
-   ctr_font_t* font, const char* msg, float scale,
+   ctr_font_t* self, const char* msg, float scale,
    const unsigned int color, float pos_x, float pos_y,
    unsigned text_align)
 {
@@ -303,14 +286,14 @@ static void ctr_font_render_message(
       return;
 
    /* If the font height is not supported just draw as usual */
-   if (!font->font_driver->get_line_height)
+   if (font_get_line_height(self->font) <= 0)
    {
-      ctr_font_render_line(font, msg, strlen(msg),
+      ctr_font_render_line(self, msg, strlen(msg),
                            scale, color, pos_x, pos_y, text_align);
       return;
    }
 
-   line_height = scale / font->font_driver->get_line_height(font->font_data);
+   line_height = scale / font_get_line_height(self->font);
 
    for (;;)
    {
@@ -320,7 +303,7 @@ static void ctr_font_render_message(
       if (delim)
       {
          unsigned msg_len = delim - msg;
-         ctr_font_render_line(font, msg, msg_len,
+         ctr_font_render_line(self, msg, msg_len,
                               scale, color, pos_x, pos_y - (float)lines * line_height,
                               text_align);
          msg += msg_len + 1;
@@ -329,7 +312,7 @@ static void ctr_font_render_message(
       else
       {
          unsigned msg_len = strlen(msg);
-         ctr_font_render_line(font, msg, msg_len,
+         ctr_font_render_line(self, msg, msg_len,
                               scale, color, pos_x, pos_y - (float)lines * line_height,
                               text_align);
          break;
@@ -417,15 +400,12 @@ static void ctr_font_render_msg(void* data, const char* msg,
 static const struct font_glyph* ctr_font_get_glyph(
    void* data, uint32_t code)
 {
-   ctr_font_t* font = (ctr_font_t*)data;
+   ctr_font_t* self = (ctr_font_t*)data;
 
-   if (!font || !font->font_driver)
+   if (!self)
       return NULL;
 
-   if (!font->font_driver->ident)
-      return NULL;
-
-   return font->font_driver->get_glyph((void*)font->font_driver, code);
+   return font_get_glyph(self->font, code);
 }
 
 static void ctr_font_flush_block(void* data)

--- a/gfx/drivers_font/ctr_font.c
+++ b/gfx/drivers_font/ctr_font.c
@@ -69,9 +69,9 @@ static void* ctr_font_init_font(void* data, const font_t* font)
    int i, j;
    const uint8_t*     src = atlas->buffer;
 
-   for (j = 0; (j < atlas->height) && (j < font->texture.height); j++)
-      for (i = 0; (i < atlas->width) && (i < font->texture.width); i++)
-         tmp[ctrgu_swizzle_coords(i, j, font->texture.width)] = src[i + j * atlas->width];
+   for (j = 0; (j < atlas->height) && (j < self->texture.height); j++)
+      for (i = 0; (i < atlas->width) && (i < self->texture.width); i++)
+         tmp[ctrgu_swizzle_coords(i, j, self->texture.width)] = src[i + j * atlas->width];
 
    GSPGPU_FlushDataCache(tmp, self->texture.width * self->texture.height);
 

--- a/gfx/drivers_font/d3d_w32_font.cpp
+++ b/gfx/drivers_font/d3d_w32_font.cpp
@@ -34,13 +34,13 @@ typedef struct
 } d3dfonts_t;
 
 static void *d3dfonts_w32_init_font(void *video_data,
-      const char *font_path, float font_size)
+      const font_t *font)
 {
    uint32_t r, g, b;
    d3dfonts_t *d3dfonts = NULL;
    settings_t *settings = config_get_ptr();
    D3DXFONT_DESC desc = {
-      (int)(font_size), 0, 400, 0,
+      (int)(font_get_size(font)), 0, 400, 0,
       false, DEFAULT_CHARSET,
       OUT_TT_PRECIS,
       CLIP_DEFAULT_PRECIS,
@@ -52,8 +52,6 @@ static void *d3dfonts_w32_init_font(void *video_data,
 
    if (!d3dfonts)
       return NULL;
-
-   (void)font_path;
 
    r               = (settings->video.msg_color_r * 255);
    g               = (settings->video.msg_color_g * 255);

--- a/gfx/drivers_font/gl_raster_font.c
+++ b/gfx/drivers_font/gl_raster_font.c
@@ -49,15 +49,14 @@ typedef struct
    GLuint tex;
    unsigned tex_width, tex_height;
 
-   const font_backend_t *font_driver;
-   void *font_data;
+   const font_t *font;
 
    video_font_raster_block_t *block;
 } gl_raster_t;
 
 static void gl_raster_font_free_font(void *data);
 
-static bool gl_raster_font_upload_atlas(gl_raster_t *font,
+static bool gl_raster_font_upload_atlas(
       const struct font_atlas *atlas,
       unsigned width, unsigned height)
 {
@@ -145,70 +144,62 @@ static bool gl_raster_font_upload_atlas(gl_raster_t *font,
 }
 
 static void *gl_raster_font_init_font(void *data,
-      const char *font_path, float font_size)
+      const font_t *font)
 {
    const struct font_atlas *atlas = NULL;
-   gl_raster_t   *font = (gl_raster_t*)calloc(1, sizeof(*font));
+   gl_raster_t   *self = (gl_raster_t*)calloc(1, sizeof(*self));
    settings_t *settings = config_get_ptr();
 
-   if (!font)
+   if (!self)
       return NULL;
 
-   font->gl = (gl_t*)data;
-
-   if (!font_renderer_create_default((const void**)&font->font_driver,
-            &font->font_data, font_path, font_size))
-   {
-      RARCH_WARN("Couldn't initialize font renderer.\n");
-      free(font);
-      return NULL;
-   }
+   self->gl = (gl_t*)data;
+   self->font = font;
 
    if (settings->video.threaded)
       video_context_driver_make_current(false);
 
-   glGenTextures(1, &font->tex);
-   glBindTexture(GL_TEXTURE_2D, font->tex);
+   glGenTextures(1, &self->tex);
+   glBindTexture(GL_TEXTURE_2D, self->tex);
    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 
-   atlas            = font->font_driver->get_atlas(font->font_data);
-   font->tex_width  = next_pow2(atlas->width);
-   font->tex_height = next_pow2(atlas->height);
+   atlas            = font_get_atlas(self->font);
+   self->tex_width  = next_pow2(atlas->width);
+   self->tex_height = next_pow2(atlas->height);
 
-   if (!gl_raster_font_upload_atlas(font, atlas,
-            font->tex_width, font->tex_height))
+   if (!gl_raster_font_upload_atlas(atlas, self->tex_width, self->tex_height))
       goto error;
 
-   glBindTexture(GL_TEXTURE_2D, font->gl->texture[font->gl->tex_index]);
+   glBindTexture(GL_TEXTURE_2D, self->gl->texture[self->gl->tex_index]);
 
-   return font;
+   return self;
 
 error:
-   gl_raster_font_free_font(font);
-   font = NULL;
+   gl_raster_font_free_font(self);
+   self = NULL;
 
    return NULL;
 }
 
 static void gl_raster_font_free_font(void *data)
 {
-   gl_raster_t *font = (gl_raster_t*)data;
+   gl_raster_t *self = (gl_raster_t*)data;
    settings_t *settings    = config_get_ptr();
-   if (!font)
+
+   if (!self)
       return;
 
-   if (font->font_driver && font->font_data)
-      font->font_driver->free(font->font_data);
+   font_unref(self->font);
 
    if (settings->video.threaded)
       video_context_driver_make_current(true);
 
-   glDeleteTextures(1, &font->tex);
+   glDeleteTextures(1, &self->tex);
 
-   free(font);
+   free(self);
 }
 
 static int gl_get_message_width(void *data, const char *msg,
@@ -217,15 +208,9 @@ static int gl_get_message_width(void *data, const char *msg,
    unsigned i;
    int delta_x       = 0;
    unsigned msg_len  = MIN(msg_len_full, MAX_MSG_LEN_CHUNK);
-   gl_raster_t *font = (gl_raster_t*)data;
+   gl_raster_t *self = (gl_raster_t*)data;
 
-   if (!font)
-      return 0;
-
-   if (
-            !font->font_driver
-         || !font->font_driver->get_glyph
-         || !font->font_data )
+   if (!self)
       return 0;
 
    while (msg_len_full)
@@ -240,14 +225,10 @@ static int gl_get_message_width(void *data, const char *msg,
          if (skip > 1)
             i += skip - 1;
 
-         glyph = font->font_driver->get_glyph(font->font_data, code);
+         glyph = font_get_glyph(self->font, code);
 
-         if (!glyph) /* Do something smarter here ... */
-            glyph = font->font_driver->get_glyph(font->font_data, '?');
-         if (!glyph)
-            continue;
-
-         delta_x += glyph->advance_x;
+         if (glyph)
+            delta_x += glyph->advance_x;
       }
 
       msg_len_full -= msg_len;
@@ -277,7 +258,7 @@ static void gl_raster_font_draw_vertices(gl_t *gl, const video_coords_t *coords)
 }
 
 static void gl_raster_font_render_line(
-      gl_raster_t *font, const char *msg, unsigned msg_len_full,
+      gl_raster_t *self, const char *msg, unsigned msg_len_full,
       GLfloat scale, const GLfloat color[4], GLfloat pos_x,
       GLfloat pos_y, unsigned text_align)
 {
@@ -289,7 +270,7 @@ static void gl_raster_font_render_line(
    GLfloat font_vertex[2 * 6 * MAX_MSG_LEN_CHUNK];
    GLfloat font_color[4 * 6 * MAX_MSG_LEN_CHUNK];
    GLfloat font_lut_tex_coord[2 * 6 * MAX_MSG_LEN_CHUNK];
-   gl_t *gl       = font ? font->gl : NULL;
+   gl_t *gl       = self ? self->gl : NULL;
 
    if (!gl)
       return;
@@ -304,17 +285,17 @@ static void gl_raster_font_render_line(
    switch (text_align)
    {
       case TEXT_ALIGN_RIGHT:
-         x -= gl_get_message_width(font, msg, msg_len_full, scale);
+         x -= gl_get_message_width(self, msg, msg_len_full, scale);
          break;
       case TEXT_ALIGN_CENTER:
-         x -= gl_get_message_width(font, msg, msg_len_full, scale) / 2.0;
+         x -= gl_get_message_width(self, msg, msg_len_full, scale) / 2.0;
          break;
    }
 
-   inv_tex_size_x = 1.0f / font->tex_width;
-   inv_tex_size_y = 1.0f / font->tex_height;
-   inv_win_width  = 1.0f / font->gl->vp.width;
-   inv_win_height = 1.0f / font->gl->vp.height;
+   inv_tex_size_x = 1.0f / self->tex_width;
+   inv_tex_size_y = 1.0f / self->tex_height;
+   inv_win_width  = 1.0f / self->gl->vp.width;
+   inv_win_height = 1.0f / self->gl->vp.height;
 
    while (msg_len_full)
    {
@@ -334,10 +315,8 @@ static void gl_raster_font_render_line(
                break;
          }
 
-         glyph = font->font_driver->get_glyph(font->font_data, code);
+         glyph = font_get_glyph(self->font, code);
 
-         if (!glyph) /* Do something smarter here ... */
-            glyph = font->font_driver->get_glyph(font->font_data, '?');
          if (!glyph)
             continue;
 
@@ -366,8 +345,8 @@ static void gl_raster_font_render_line(
       coords.vertices      = 6 * msg_len;
       coords.lut_tex_coord = font_lut_tex_coord;
 
-      if (font->block)
-         video_coord_array_append(&font->block->carr, &coords, coords.vertices);
+      if (self->block)
+         video_coord_array_append(&self->block->carr, &coords, coords.vertices);
       else
          gl_raster_font_draw_vertices(gl, &coords);
 
@@ -378,32 +357,29 @@ static void gl_raster_font_render_line(
 }
 
 static void gl_raster_font_render_message(
-      gl_raster_t *font, const char *msg, GLfloat scale,
+      gl_raster_t *self, const char *msg, GLfloat scale,
       const GLfloat color[4], GLfloat pos_x, GLfloat pos_y,
       unsigned text_align)
 {
    int lines = 0;
    float line_height;
 
-   if (!font)
+   if (!self)
       return;
 
-   if (     string_is_empty(msg)
-         || !font->gl
-         || !font->font_data
-         || !font->font_driver)
+   if (string_is_empty(msg))
       return;
 
    /* If the font height is not supported just draw as usual */
-   if (!font->font_driver->get_line_height)
+   if (font_get_line_height(self->font) <= 0)
    {
-      gl_raster_font_render_line(font, msg, strlen(msg),
+      gl_raster_font_render_line(self, msg, strlen(msg),
             scale, color, pos_x, pos_y, text_align);
       return;
    }
 
    line_height = 1 /
-      (scale * (float) font->font_driver->get_line_height(font->font_data));
+      (scale * (float) font_get_line_height(self->font));
 
    for (;;)
    {
@@ -413,7 +389,7 @@ static void gl_raster_font_render_message(
       if (delim)
       {
          unsigned msg_len = delim - msg;
-         gl_raster_font_render_line(font,
+         gl_raster_font_render_line(self,
                msg, msg_len, scale, color, pos_x,
                pos_y - (float)lines*line_height, text_align);
          msg += msg_len + 1;
@@ -422,14 +398,14 @@ static void gl_raster_font_render_message(
       else
       {
          unsigned msg_len = strlen(msg);
-         gl_raster_font_render_line(font, msg, msg_len, scale, color, pos_x,
+         gl_raster_font_render_line(self, msg, msg_len, scale, color, pos_x,
                pos_y - (float)lines*line_height, text_align);
          break;
       }
    }
 }
 
-static void gl_raster_font_setup_viewport(gl_raster_t *font, bool full_screen)
+static void gl_raster_font_setup_viewport(gl_raster_t *self, bool full_screen)
 {
    video_shader_ctx_info_t shader_info;
    unsigned width, height;
@@ -442,7 +418,7 @@ static void gl_raster_font_setup_viewport(gl_raster_t *font, bool full_screen)
    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
    glBlendEquation(GL_FUNC_ADD);
 
-   glBindTexture(GL_TEXTURE_2D, font->tex);
+   glBindTexture(GL_TEXTURE_2D, self->tex);
 
    shader_info.data       = NULL;
    shader_info.idx        = VIDEO_SHADER_STOCK_BLEND;
@@ -472,14 +448,14 @@ static void gl_raster_font_render_msg(void *data, const char *msg,
    bool full_screen;
    enum text_alignment text_align;
    gl_t *gl = NULL;
-   gl_raster_t *font = (gl_raster_t*)data;
+   gl_raster_t *self = (gl_raster_t*)data;
    settings_t *settings = config_get_ptr();
    const struct font_params *params = (const struct font_params*)userdata;
 
-   if (!font || string_is_empty(msg))
+   if (!self || string_is_empty(msg))
       return;
 
-   gl = font->gl;
+   gl = self->gl;
 
    if (!gl)
       return;
@@ -524,10 +500,10 @@ static void gl_raster_font_render_msg(void *data, const char *msg,
       drop_alpha = 1.0f;
    }
 
-   if (font && font->block)
-      font->block->fullscreen = full_screen;
+   if (self && self->block)
+      self->block->fullscreen = full_screen;
    else
-      gl_raster_font_setup_viewport(font, full_screen);
+      gl_raster_font_setup_viewport(self, full_screen);
 
    if (drop_x || drop_y)
    {
@@ -536,52 +512,51 @@ static void gl_raster_font_render_msg(void *data, const char *msg,
       color_dark[2] = color[2] * drop_mod;
       color_dark[3] = color[3] * drop_alpha;
 
-      gl_raster_font_render_message(font, msg, scale, color_dark,
+      gl_raster_font_render_message(self, msg, scale, color_dark,
             x + scale * drop_x / gl->vp.width, y +
             scale * drop_y / gl->vp.height, text_align);
    }
 
-   gl_raster_font_render_message(font, msg, scale, color, x, y, text_align);
+   gl_raster_font_render_message(self, msg, scale, color, x, y, text_align);
 
-   if (!font->block)
+   if (!self->block)
       gl_raster_font_restore_viewport(gl, false);
 }
 
 static const struct font_glyph *gl_raster_font_get_glyph(
       void *data, uint32_t code)
 {
-   gl_raster_t *font = (gl_raster_t*)data;
+   gl_raster_t *self = (gl_raster_t*)data;
 
-   if (!font || !font->font_driver)
+   if (!self)
       return NULL;
-   if (!font->font_driver->ident)
-       return NULL;
-   return font->font_driver->get_glyph((void*)font->font_driver, code);
+
+   return font_get_glyph(self->font, code);
 }
 
 static void gl_raster_font_flush_block(void *data)
 {
-   gl_raster_t       *font       = (gl_raster_t*)data;
-   video_font_raster_block_t *block = font ? font->block : NULL;
+   gl_raster_t       *self       = (gl_raster_t*)data;
+   video_font_raster_block_t *block = self ? self->block : NULL;
 
-   if (!font || !block || !block->carr.coords.vertices)
+   if (!self || !block || !block->carr.coords.vertices)
       return;
 
-   gl_raster_font_setup_viewport(font, block->fullscreen);
-   gl_raster_font_draw_vertices(font->gl, (video_coords_t*)&block->carr.coords);
-   gl_raster_font_restore_viewport(font->gl, block->fullscreen);
+   gl_raster_font_setup_viewport(self, block->fullscreen);
+   gl_raster_font_draw_vertices(self->gl, (video_coords_t*)&block->carr.coords);
+   gl_raster_font_restore_viewport(self->gl, block->fullscreen);
 }
 
 static void gl_raster_font_bind_block(void *data, void *userdata)
 {
-   gl_raster_t              *font = (gl_raster_t*)data;
+   gl_raster_t              *self   = (gl_raster_t*)data;
    video_font_raster_block_t *block = (video_font_raster_block_t*)userdata;
 
-   if (font)
-      font->block = block;
+   if (self)
+      self->block = block;
 }
 
-font_renderer_t gl_raster_font = {
+font_renderer_t gl_font_renderer = {
    gl_raster_font_init_font,
    gl_raster_font_free_font,
    gl_raster_font_render_msg,

--- a/gfx/drivers_font/gl_raster_font.c
+++ b/gfx/drivers_font/gl_raster_font.c
@@ -154,9 +154,7 @@ static void *gl_raster_font_init_font(void *data,
       return NULL;
 
    self->gl = (gl_t*)data;
-   self->font = font;
-
-   font_ref(self->font);
+   self->font = font_ref(font);
 
    if (settings->video.threaded)
       video_context_driver_make_current(false);

--- a/gfx/drivers_font/gl_raster_font.c
+++ b/gfx/drivers_font/gl_raster_font.c
@@ -156,6 +156,8 @@ static void *gl_raster_font_init_font(void *data,
    self->gl = (gl_t*)data;
    self->font = font;
 
+   font_ref(self->font);
+
    if (settings->video.threaded)
       video_context_driver_make_current(false);
 

--- a/gfx/drivers_font/gl_raster_font.c
+++ b/gfx/drivers_font/gl_raster_font.c
@@ -49,7 +49,7 @@ typedef struct
    GLuint tex;
    unsigned tex_width, tex_height;
 
-   const font_renderer_driver_t *font_driver;
+   const font_backend_t *font_driver;
    void *font_data;
 
    video_font_raster_block_t *block;

--- a/gfx/drivers_font/gl_raster_font.c
+++ b/gfx/drivers_font/gl_raster_font.c
@@ -154,7 +154,7 @@ static void *gl_raster_font_init_font(void *data,
       return NULL;
 
    self->gl = (gl_t*)data;
-   self->font = font_ref(font);
+   self->font = font;
 
    if (settings->video.threaded)
       video_context_driver_make_current(false);
@@ -191,8 +191,6 @@ static void gl_raster_font_free_font(void *data)
 
    if (!self)
       return;
-
-   font_unref(self->font);
 
    if (settings->video.threaded)
       video_context_driver_make_current(true);

--- a/gfx/drivers_font/ps_libdbgfont.c
+++ b/gfx/drivers_font/ps_libdbgfont.c
@@ -31,14 +31,13 @@
 
 #include "../font_driver.h"
 
-static void *libdbg_font_init_font(void *gl_data, const char *font_path, float font_size)
+static void *libdbg_font_init_font(void *gl_data, const font_t *font)
 {
    unsigned width, height;
 
    video_driver_get_size(&width, &height);
 
-   (void)font_path;
-   (void)font_size;
+   (void)font;
    (void)width;
    (void)height;
 

--- a/gfx/drivers_font/vita2d_font.c
+++ b/gfx/drivers_font/vita2d_font.c
@@ -37,7 +37,7 @@ static void *vita2d_font_init_font(void *gl_data, const font_t *font)
    if (!self)
       return NULL;
 
-   self->font = font_ref(font);
+   self->font = font;
 
    atlas = font_get_atlas(self->font);
 
@@ -70,9 +70,7 @@ static void vita2d_font_free_font(void *data)
     if (!self)
        return;
 
-    font_unref(self->font);
-
-	 //vita2d_wait_rendering_done();
+	 vita2d_wait_rendering_done();
    vita2d_free_texture(self->texture);
 
    free(self);

--- a/gfx/drivers_font/vita2d_font.c
+++ b/gfx/drivers_font/vita2d_font.c
@@ -23,103 +23,93 @@
 typedef struct
 {
    vita2d_texture *texture;
-   const font_backend_t *font_driver;
-   void *font_data;
+   const font_t *font;
 
 } vita_font_t;
 
 
-static void *vita2d_font_init_font(void *gl_data, const char *font_path, float font_size)
+static void *vita2d_font_init_font(void *gl_data, const font_t *font)
 {
-	 unsigned int stride, pitch, j, k;
+   unsigned int stride, pitch, j, k;
    const struct font_atlas *atlas = NULL;
-	 vita_font_t *font = (vita_font_t*)calloc(1, sizeof(*font));
+   vita_font_t *self = (vita_font_t*)calloc(1, sizeof(*self));
 
-	 if (!font)
-	 	 return NULL;
+   if (!self)
+      return NULL;
 
-	 if (!font_renderer_create_default((const void**)&font->font_driver,
-	 				 &font->font_data, font_path, font_size))
-	 {
-	 	 RARCH_WARN("Couldn't initialize font renderer.\n");
-	 	 free(font);
-	 	 return NULL;
-	 }
+   self->font = font;
+   font_ref(font);
 
-	 atlas = font->font_driver->get_atlas(font->font_data);
+   atlas = font_get_atlas(self->font);
 
-	 font->texture = vita2d_create_empty_texture_format(atlas->width,atlas->height,SCE_GXM_TEXTURE_FORMAT_U8_R111);
+   self->texture = vita2d_create_empty_texture_format(atlas->width,atlas->height,SCE_GXM_TEXTURE_FORMAT_U8_R111);
 
-	 if (!font->texture) {
- 		free(font);
- 		return NULL;
- 	 }
+   if (!self->texture) {
+      font_unref(self->font);
+      free(self);
+      return NULL;
+   }
 
-	 vita2d_texture_set_filters(font->texture,
- 				   SCE_GXM_TEXTURE_FILTER_POINT,
- 				   SCE_GXM_TEXTURE_FILTER_LINEAR);
+   vita2d_texture_set_filters(self->texture,
+      SCE_GXM_TEXTURE_FILTER_POINT,
+      SCE_GXM_TEXTURE_FILTER_LINEAR);
 
-	 stride = vita2d_texture_get_stride(font->texture);
-   uint8_t             *tex32 = vita2d_texture_get_datap(font->texture);
+   stride = vita2d_texture_get_stride(self->texture);
+   uint8_t             *tex32 = vita2d_texture_get_datap(self->texture);
    const uint8_t     *frame32 = atlas->buffer;
    pitch = atlas->width;
    for (j = 0; j < atlas->height; j++)
       for (k = 0; k < atlas->width; k++)
          tex32[k + j*stride] = frame32[k + j*pitch];
 
-   return font;
+   return self;
 }
 
 static void vita2d_font_free_font(void *data)
 {
-	 vita_font_t *font = (vita_font_t*)data;
-	 if (!font)
-			return;
+    vita_font_t *self= (vita_font_t*)data;
+    if (!self)
+       return;
 
-	 if (font->font_driver && font->font_data)
-			font->font_driver->free(font->font_data);
+    font_unref(self->font);
 
 	 //vita2d_wait_rendering_done();
-   vita2d_free_texture(font->texture);
+   vita2d_free_texture(self->texture);
 
-	 free(font);
+   free(self);
 }
 
 static int vita2d_font_get_message_width(void *data, const char *msg,
       unsigned msg_len, float scale)
 {
-	 vita_font_t *font = (vita_font_t*)data;
+   vita_font_t *self = (vita_font_t*)data;
 
-	 unsigned i;
-	 int delta_x = 0;
+   unsigned i;
+   int delta_x = 0;
 
-	 if (!font)
-			return 0;
+   if (!self)
+      return 0;
 
-	 for (i = 0; i < msg_len; i++)
-	 {
+   for (i = 0; i < msg_len; i++)
+   {
       const char *msg_tmp            = &msg[i];
       unsigned code                  = utf8_walk(&msg_tmp);
       unsigned skip                  = msg_tmp - &msg[i];
 
       if (skip > 1)
          i += skip - 1;
-         
-			const struct font_glyph *glyph =
-				 font->font_driver->get_glyph(font->font_data, code);
-			if (!glyph) /* Do something smarter here ... */
-				 glyph = font->font_driver->get_glyph(font->font_data, '?');
-			if (!glyph)
-				 continue;
 
-			delta_x += glyph->advance_x;
-	 }
+      const struct font_glyph *glyph = font_get_glyph(self->font, code);
 
-	 return delta_x * scale;
+      if (glyph)
+         delta_x += glyph->advance_x;
+   }
+
+   return delta_x * scale;
 }
 
 static void vita2d_font_render_line(
-      vita_font_t *font, const char *msg, unsigned msg_len,
+      vita_font_t *self, const char *msg, unsigned msg_len,
       float scale, const unsigned int color, float pos_x,
       float pos_y, unsigned text_align)
 {
@@ -138,10 +128,10 @@ static void vita2d_font_render_line(
    switch (text_align)
    {
       case TEXT_ALIGN_RIGHT:
-         x -= vita2d_font_get_message_width(font, msg, msg_len, scale);
+         x -= vita2d_font_get_message_width(self, msg, msg_len, scale);
          break;
       case TEXT_ALIGN_CENTER:
-         x -= vita2d_font_get_message_width(font, msg, msg_len, scale) / 2;
+         x -= vita2d_font_get_message_width(self, msg, msg_len, scale) / 2;
          break;
    }
 
@@ -155,11 +145,8 @@ static void vita2d_font_render_line(
       if (skip > 1)
          i += skip - 1;
          
-      const struct font_glyph *glyph =
-         font->font_driver->get_glyph(font->font_data, code);
+      const struct font_glyph *glyph = font_get_glyph(self->font, code);
 
-      if (!glyph) /* Do something smarter here ... */
-         glyph = font->font_driver->get_glyph(font->font_data, '?');
       if (!glyph)
          continue;
 
@@ -170,7 +157,7 @@ static void vita2d_font_render_line(
       width  = glyph->width;
       height = glyph->height;
 
-			vita2d_draw_texture_tint_part_scale(font->texture,
+         vita2d_draw_texture_tint_part_scale(self->texture,
 				x + off_x + delta_x * scale,
 				y + off_y + delta_y * scale,
 				tex_x, tex_y, width, height,
@@ -184,7 +171,7 @@ static void vita2d_font_render_line(
 }
 
 static void vita2d_font_render_message(
-      vita_font_t *font, const char *msg, float scale,
+      vita_font_t *self, const char *msg, float scale,
       const unsigned int color, float pos_x, float pos_y,
       unsigned text_align)
 {
@@ -195,14 +182,14 @@ static void vita2d_font_render_message(
       return;
 
    /* If the font height is not supported just draw as usual */
-   if (!font->font_driver->get_line_height)
+   if (font_get_line_height(self->font) <= 0)
    {
-      vita2d_font_render_line(font, msg, strlen(msg),
+      vita2d_font_render_line(self, msg, strlen(msg),
             scale, color, pos_x, pos_y, text_align);
       return;
    }
 
-   line_height = scale / font->font_driver->get_line_height(font->font_data);
+   line_height = scale / font_get_line_height(self->font);
 
    for (;;)
    {
@@ -212,7 +199,7 @@ static void vita2d_font_render_message(
       if (delim)
       {
          unsigned msg_len = delim - msg;
-         vita2d_font_render_line(font, msg, msg_len,
+         vita2d_font_render_line(self, msg, msg_len,
                scale, color, pos_x, pos_y - (float)lines * line_height,
                text_align);
          msg += msg_len + 1;
@@ -221,7 +208,7 @@ static void vita2d_font_render_message(
       else
       {
          unsigned msg_len = strlen(msg);
-         vita2d_font_render_line(font, msg, msg_len,
+         vita2d_font_render_line(self, msg, msg_len,
                scale, color, pos_x, pos_y - (float)lines * line_height,
                text_align);
          break;
@@ -306,13 +293,11 @@ static void vita2d_font_render_msg(void *data, const char *msg,
 static const struct font_glyph *vita2d_font_get_glyph(
       void *data, uint32_t code)
 {
-   vita_font_t *font = (vita_font_t*)data;
+   vita_font_t *self = (vita_font_t*)data;
 
-   if (!font || !font->font_driver)
+   if (!self)
       return NULL;
-   if (!font->font_driver->ident)
-       return NULL;
-   return font->font_driver->get_glyph((void*)font->font_driver, code);
+   return font_get_glyph(self->font, code);
 }
 
 static void vita2d_font_flush_block(void *data)

--- a/gfx/drivers_font/vita2d_font.c
+++ b/gfx/drivers_font/vita2d_font.c
@@ -37,8 +37,7 @@ static void *vita2d_font_init_font(void *gl_data, const font_t *font)
    if (!self)
       return NULL;
 
-   self->font = font;
-   font_ref(font);
+   self->font = font_ref(font);
 
    atlas = font_get_atlas(self->font);
 

--- a/gfx/drivers_font/vita2d_font.c
+++ b/gfx/drivers_font/vita2d_font.c
@@ -23,7 +23,7 @@
 typedef struct
 {
    vita2d_texture *texture;
-   const font_renderer_driver_t *font_driver;
+   const font_backend_t *font_driver;
    void *font_data;
 
 } vita_font_t;

--- a/gfx/drivers_font/vulkan_raster_font.c
+++ b/gfx/drivers_font/vulkan_raster_font.c
@@ -55,9 +55,7 @@ static void *vulkan_raster_font_init_font(void *data,
       return NULL;
 
    self->vk = (vk_t*)data;
-   self->font = font;
-
-   font_ref(self->font);
+   self->font = font_ref(font);
 
    atlas = font_get_atlas(self->font);
    self->texture = vulkan_create_texture(self->vk, NULL,

--- a/gfx/drivers_font/vulkan_raster_font.c
+++ b/gfx/drivers_font/vulkan_raster_font.c
@@ -27,8 +27,7 @@ typedef struct
 {
    vk_t *vk;
    struct vk_texture texture;
-   const font_backend_t *font_driver;
-   void *font_data;
+   const font_t *font;
 
    struct vk_vertex *pv;
    struct vk_buffer_range range;
@@ -38,10 +37,10 @@ typedef struct
 static void vulkan_raster_font_free_font(void *data);
 
 static void *vulkan_raster_font_init_font(void *data,
-      const char *font_path, float font_size)
+      const font_t *font)
 {
    const struct font_atlas *atlas = NULL;
-   vulkan_raster_t *font = (vulkan_raster_t*)calloc(1, sizeof(*font));
+   vulkan_raster_t *self = (vulkan_raster_t*)calloc(1, sizeof(*self));
 
 #if 0
    VkComponentMapping swizzle = {
@@ -52,71 +51,59 @@ static void *vulkan_raster_font_init_font(void *data,
    };
 #endif
 
-   if (!font)
+   if (!self)
       return NULL;
 
-   font->vk = (vk_t*)data;
+   self->vk = (vk_t*)data;
+   self->font = font;
 
-   if (!font_renderer_create_default((const void**)&font->font_driver,
-            &font->font_data, font_path, font_size))
-   {
-      RARCH_WARN("Couldn't initialize font renderer.\n");
-      free(font);
-      return NULL;
-   }
-
-   atlas = font->font_driver->get_atlas(font->font_data);
-   font->texture = vulkan_create_texture(font->vk, NULL,
+   atlas = font_get_atlas(self->font);
+   self->texture = vulkan_create_texture(self->vk, NULL,
          atlas->width, atlas->height, VK_FORMAT_R8_UNORM, atlas->buffer,
          NULL /*&swizzle*/, VULKAN_TEXTURE_STATIC);
 
-   return font;
+   return self;
 }
 
 static void vulkan_raster_font_free_font(void *data)
 {
-   vulkan_raster_t *font = (vulkan_raster_t*)data;
-   if (!font)
+   vulkan_raster_t *self = (vulkan_raster_t*)data;
+   if (!self)
       return;
 
-   if (font->font_driver && font->font_data)
-      font->font_driver->free(font->font_data);
+   font_unref(self->font);
 
-   vkQueueWaitIdle(font->vk->context->queue);
+   vkQueueWaitIdle(self->vk->context->queue);
    vulkan_destroy_texture( 
-         font->vk->context->device, &font->texture);
+         self->vk->context->device, &self->texture);
 
-   free(font);
+   free(self);
 }
 
 static int vulkan_get_message_width(void *data, const char *msg,
       unsigned msg_len, float scale)
 {
-   vulkan_raster_t *font = (vulkan_raster_t*)data;
+   vulkan_raster_t *self = (vulkan_raster_t*)data;
       
    unsigned i;
    int delta_x = 0;
 
-   if (!font)
+   if (!self)
       return 0;
 
    for (i = 0; i < msg_len; i++)
    {
-      const struct font_glyph *glyph = 
-         font->font_driver->get_glyph(font->font_data, (uint8_t)msg[i]);
-      if (!glyph) /* Do something smarter here ... */
-         glyph = font->font_driver->get_glyph(font->font_data, '?');
-      if (!glyph)
-         continue;
+      const struct font_glyph *glyph = font_get_glyph(self->font, (uint8_t)msg[i]);
 
-      delta_x += glyph->advance_x;
+      if (glyph)
+         delta_x += glyph->advance_x;
    }
 
    return delta_x * scale;
 }
 
 static void vulkan_raster_font_render_line(
-      vulkan_raster_t *font, const char *msg, unsigned msg_len,
+      vulkan_raster_t *self, const char *msg, unsigned msg_len,
       float scale, const float color[4], float pos_x,
       float pos_y, unsigned text_align)
 {
@@ -124,7 +111,7 @@ static void vulkan_raster_font_render_line(
    float inv_tex_size_x, inv_tex_size_y, inv_win_width, inv_win_height;
    unsigned i;
    struct vk_color vk_color;
-   vk_t *vk = font ? font->vk : NULL;
+   vk_t *vk = self ? self->vk : NULL;
 
    if (!vk)
       return;
@@ -142,26 +129,23 @@ static void vulkan_raster_font_render_line(
    switch (text_align)
    {
       case TEXT_ALIGN_RIGHT:
-         x -= vulkan_get_message_width(font, msg, msg_len, scale);
+         x -= vulkan_get_message_width(self, msg, msg_len, scale);
          break;
       case TEXT_ALIGN_CENTER:
-         x -= vulkan_get_message_width(font, msg, msg_len, scale) / 2;
+         x -= vulkan_get_message_width(self, msg, msg_len, scale) / 2;
          break;
    }
 
-   inv_tex_size_x = 1.0f / font->texture.width;
-   inv_tex_size_y = 1.0f / font->texture.height;
-   inv_win_width  = 1.0f / font->vk->vp.width;
-   inv_win_height = 1.0f / font->vk->vp.height;
+   inv_tex_size_x = 1.0f / self->texture.width;
+   inv_tex_size_y = 1.0f / self->texture.height;
+   inv_win_width  = 1.0f / self->vk->vp.width;
+   inv_win_height = 1.0f / self->vk->vp.height;
 
    for (i = 0; i < msg_len; i++)
    {
       int off_x, off_y, tex_x, tex_y, width, height;
-      const struct font_glyph *glyph =
-         font->font_driver->get_glyph(font->font_data, (uint8_t)msg[i]);
+      const struct font_glyph *glyph = font_get_glyph(self->font, (uint8_t)msg[i]);
 
-      if (!glyph) /* Do something smarter here ... */
-         glyph = font->font_driver->get_glyph(font->font_data, '?');
       if (!glyph)
          continue;
 
@@ -172,7 +156,7 @@ static void vulkan_raster_font_render_line(
       width  = glyph->width;
       height = glyph->height;
 
-      vulkan_write_quad_vbo(font->pv + font->vertices,
+      vulkan_write_quad_vbo(self->pv + self->vertices,
             (x + off_x + delta_x * scale) * inv_win_width,
             (y + off_y + delta_y * scale) * inv_win_height,
             width * scale * inv_win_width,
@@ -182,7 +166,7 @@ static void vulkan_raster_font_render_line(
             width * inv_tex_size_x,
             height * inv_tex_size_y,
             &vk_color);
-      font->vertices += 6;
+      self->vertices += 6;
 
       delta_x += glyph->advance_x;
       delta_y += glyph->advance_y;
@@ -190,25 +174,25 @@ static void vulkan_raster_font_render_line(
 }
 
 static void vulkan_raster_font_render_message(
-      vulkan_raster_t *font, const char *msg, float scale,
+      vulkan_raster_t *self, const char *msg, float scale,
       const float color[4], float pos_x, float pos_y,
       unsigned text_align)
 {
    int lines = 0;
    float line_height;
 
-   if (!msg || !*msg || !font->vk)
+   if (!msg || !*msg || !self->vk)
       return;
 
    /* If the font height is not supported just draw as usual */
-   if (!font->font_driver->get_line_height)
+   if (font_get_line_height(self->font) <= 0)
    {
-      vulkan_raster_font_render_line(font, msg, strlen(msg),
+      vulkan_raster_font_render_line(self, msg, strlen(msg),
             scale, color, pos_x, pos_y, text_align);
       return;
    }
 
-   line_height = scale / font->font_driver->get_line_height(font->font_data);
+   line_height = scale / font_get_line_height(self->font);
 
    for (;;)
    {
@@ -218,7 +202,7 @@ static void vulkan_raster_font_render_message(
       if (delim)
       {
          unsigned msg_len = delim - msg;
-         vulkan_raster_font_render_line(font, msg, msg_len,
+         vulkan_raster_font_render_line(self, msg, msg_len,
                scale, color, pos_x, pos_y - (float)lines * line_height,
                text_align);
          msg += msg_len + 1;
@@ -227,7 +211,7 @@ static void vulkan_raster_font_render_message(
       else
       {
          unsigned msg_len = strlen(msg);
-         vulkan_raster_font_render_line(font, msg, msg_len,
+         vulkan_raster_font_render_line(self, msg, msg_len,
                scale, color, pos_x, pos_y - (float)lines * line_height,
                text_align);
          break;
@@ -243,19 +227,19 @@ static void vulkan_raster_font_setup_viewport(
    video_driver_set_viewport(width, height, full_screen, false);
 }
 
-static void vulkan_raster_font_flush(vulkan_raster_t *font)
+static void vulkan_raster_font_flush(vulkan_raster_t *self)
 {
    const struct vk_draw_triangles call = {
-      font->vk->pipelines.font,
-      &font->texture,
-      font->vk->samplers.mipmap_linear,
-      &font->vk->mvp,
-      sizeof(font->vk->mvp),
-      &font->range,
-      font->vertices,
+      self->vk->pipelines.font,
+      &self->texture,
+      self->vk->samplers.mipmap_linear,
+      &self->vk->mvp,
+      sizeof(self->vk->mvp),
+      &self->range,
+      self->vertices,
    };
 
-   vulkan_draw_triangles(font->vk, &call);
+   vulkan_draw_triangles(self->vk, &call);
 }
 
 static void vulkan_raster_font_render_msg(void *data, const char *msg,
@@ -268,14 +252,14 @@ static void vulkan_raster_font_render_msg(void *data, const char *msg,
    unsigned max_glyphs;
    enum text_alignment text_align;
    vk_t *vk                         = NULL;
-   vulkan_raster_t *font            = (vulkan_raster_t*)data;
+   vulkan_raster_t *self            = (vulkan_raster_t*)data;
    settings_t *settings             = config_get_ptr();
    const struct font_params *params = (const struct font_params*)userdata;
 
-   if (!font || !msg || !*msg)
+   if (!self || !msg || !*msg)
       return;
 
-   vk = font->vk;
+   vk = self->vk;
 
    if (params)
    {
@@ -317,18 +301,18 @@ static void vulkan_raster_font_render_msg(void *data, const char *msg,
       drop_alpha = 1.0f;
    }
 
-   vulkan_raster_font_setup_viewport(font, full_screen);
+   vulkan_raster_font_setup_viewport(self, full_screen);
 
    max_glyphs = strlen(msg);
    if (drop_x || drop_y)
       max_glyphs *= 2;
 
-   if (!vulkan_buffer_chain_alloc(font->vk->context, &font->vk->chain->vbo,
-         6 * sizeof(struct vk_vertex) * max_glyphs, &font->range))
+   if (!vulkan_buffer_chain_alloc(self->vk->context, &self->vk->chain->vbo,
+         6 * sizeof(struct vk_vertex) * max_glyphs, &self->range))
       return;
 
-   font->vertices = 0;
-   font->pv = (struct vk_vertex*)font->range.data;
+   self->vertices = 0;
+   self->pv = (struct vk_vertex*)self->range.data;
 
    if (drop_x || drop_y)
    {
@@ -337,26 +321,25 @@ static void vulkan_raster_font_render_msg(void *data, const char *msg,
       color_dark[2] = color[2] * drop_mod;
       color_dark[3] = color[3] * drop_alpha;
 
-      vulkan_raster_font_render_message(font, msg, scale, color_dark,
+      vulkan_raster_font_render_message(self, msg, scale, color_dark,
             x + scale * drop_x / vk->vp.width, y + 
             scale * drop_y / vk->vp.height, text_align);
    }
 
-   vulkan_raster_font_render_message(font, msg, scale,
+   vulkan_raster_font_render_message(self, msg, scale,
          color, x, y, text_align);
-   vulkan_raster_font_flush(font);
+   vulkan_raster_font_flush(self);
 }
 
 static const struct font_glyph *vulkan_raster_font_get_glyph(
       void *data, uint32_t code)
 {
-   vulkan_raster_t *font = (vulkan_raster_t*)data;
+   vulkan_raster_t *self = (vulkan_raster_t*)data;
 
-   if (!font || !font->font_driver)
+   if (!self)
       return NULL;
-   if (!font->font_driver->ident)
-       return NULL;
-   return font->font_driver->get_glyph((void*)font->font_driver, code);
+
+   return font_get_glyph(self->font, code);
 }
 
 static void vulkan_raster_font_flush_block(void *data)
@@ -369,7 +352,7 @@ static void vulkan_raster_font_bind_block(void *data, void *userdata)
    (void)data;
 }
 
-font_renderer_t vulkan_raster_font = {
+font_renderer_t vulkan_font_renderer = {
    vulkan_raster_font_init_font,
    vulkan_raster_font_free_font,
    vulkan_raster_font_render_msg,

--- a/gfx/drivers_font/vulkan_raster_font.c
+++ b/gfx/drivers_font/vulkan_raster_font.c
@@ -57,6 +57,8 @@ static void *vulkan_raster_font_init_font(void *data,
    self->vk = (vk_t*)data;
    self->font = font;
 
+   font_ref(self->font);
+
    atlas = font_get_atlas(self->font);
    self->texture = vulkan_create_texture(self->vk, NULL,
          atlas->width, atlas->height, VK_FORMAT_R8_UNORM, atlas->buffer,

--- a/gfx/drivers_font/vulkan_raster_font.c
+++ b/gfx/drivers_font/vulkan_raster_font.c
@@ -27,7 +27,7 @@ typedef struct
 {
    vk_t *vk;
    struct vk_texture texture;
-   const font_renderer_driver_t *font_driver;
+   const font_backend_t *font_driver;
    void *font_data;
 
    struct vk_vertex *pv;

--- a/gfx/drivers_font/xdk1_xfonts.c
+++ b/gfx/drivers_font/xdk1_xfonts.c
@@ -31,15 +31,14 @@ typedef struct
 } xfonts_t;
 
 static void *xfonts_init_font(void *video_data,
-      const char *font_path, float font_size)
+      const font_t *font)
 {
    xfonts_t *xfont = (xfonts_t*)calloc(1, sizeof(*xfont));
 
    if (!xfont)
       return NULL;
 
-   (void)font_path;
-   (void)font_size;
+   (void)font;
 
    xfont->d3d = (d3d_video_t*)video_data;
 

--- a/gfx/drivers_font_renderer/bitmapfont.c
+++ b/gfx/drivers_font_renderer/bitmapfont.c
@@ -88,6 +88,10 @@ static void *font_renderer_bmp_init(const char *font_path, float font_size)
 
    (void)font_path;
 
+#ifdef _3DS
+   font_size = 10;
+#endif
+
    handle->scale_factor = (unsigned)roundf(font_size / FONT_HEIGHT);
    if (!handle->scale_factor)
       handle->scale_factor = 1;

--- a/gfx/drivers_font_renderer/bitmapfont.c
+++ b/gfx/drivers_font_renderer/bitmapfont.c
@@ -140,7 +140,7 @@ static int font_renderer_bmp_get_line_height(void* data)
     return FONT_HEIGHT * handle->scale_factor;
 }
 
-font_renderer_driver_t bitmap_font_renderer = {
+font_backend_t bitmap_font_backend = {
    font_renderer_bmp_init,
    font_renderer_bmp_get_atlas,
    font_renderer_bmp_get_glyph,

--- a/gfx/drivers_font_renderer/coretext.c
+++ b/gfx/drivers_font_renderer/coretext.c
@@ -306,7 +306,7 @@ static const char *font_renderer_ct_get_default_font(void)
   return default_font;
 }
 
-font_renderer_driver_t coretext_font_renderer = {
+font_backend_t coretext_font_backend = {
   font_renderer_ct_init,
   font_renderer_ct_get_atlas,
   font_renderer_ct_get_glyph,

--- a/gfx/drivers_font_renderer/freetype.c
+++ b/gfx/drivers_font_renderer/freetype.c
@@ -240,7 +240,7 @@ static int font_renderer_ft_get_line_height(void* data)
    return handle->face->size->metrics.height/64;
 }
 
-font_renderer_driver_t freetype_font_renderer = {
+font_backend_t freetype_font_backend = {
    font_renderer_ft_init,
    font_renderer_ft_get_atlas,
    font_renderer_ft_get_glyph,

--- a/gfx/drivers_font_renderer/stb.c
+++ b/gfx/drivers_font_renderer/stb.c
@@ -227,7 +227,7 @@ static int font_renderer_stb_get_line_height(void* data)
     return handle->line_height;
 }
 
-font_renderer_driver_t stb_font_renderer = {
+font_backend_t stb_font_backend = {
    font_renderer_stb_init,
    font_renderer_stb_get_atlas,
    font_renderer_stb_get_glyph,

--- a/gfx/font_driver.c
+++ b/gfx/font_driver.c
@@ -416,8 +416,11 @@ static font_t *create_font_instance(const char *filename, float size)
       const char *path = filename;
       void *data;
 
-      if (!path || !*path)
+      if (!path)
          path = (*backend)->get_default_font();
+
+      if (!path)
+         continue;
 
       data = (*backend)->init(path, size);
 

--- a/gfx/font_driver.c
+++ b/gfx/font_driver.c
@@ -94,14 +94,13 @@ static const font_renderer_t *d3d_font_backends[] = {
 
 static bool d3d_font_init_first(
       const void **font_driver, void **font_handle,
-      void *video_data, const char *font_path, float font_size)
+      void *video_data, const font_t *font)
 {
    unsigned i;
 
    for (i = 0; i < ARRAY_SIZE(d3d_font_backends); i++)
    {
-      void *data = d3d_font_backends[i]->init(
-            video_data, font_path, font_size);
+      void *data = d3d_font_backends[i]->init(video_data, font);
 
       if (!data)
          continue;

--- a/gfx/font_driver.c
+++ b/gfx/font_driver.c
@@ -336,7 +336,13 @@ bool font_driver_init_first(
       : (void**)&font_osd_data;
 
    /* FIXME: check PSP, PS3(LIBDBG), Vita and D3D. */
-   const font_t *font = font_load(font_path, font_size);
+   const font_t *font;
+
+#ifdef _3DS
+   font_size = 10;
+#endif
+
+   font = font_load(font_path, font_size);
 
    if (!font)
       return false;

--- a/gfx/font_driver.c
+++ b/gfx/font_driver.c
@@ -471,17 +471,17 @@ const font_t *font_load(const char *filename, float size)
 /* XXX: ref and unref might have concurrency issues */
 const font_t *font_ref(const font_t *font)
 {
-   font_t *f = (font_t*)font;
+   font_t *f = (font_t*)font; /* yes */
 
    if (f->ref >= 0)
       f->ref++;
 
-   return f;
+   return font;
 }
 
-void font_unref(const font_t *font)
+const font_t *font_unref(const font_t *font)
 {
-   font_t *f = (font_t*)font;
+   font_t *f = (font_t*)font; /* YES */
 
    if (--f->ref <= 0)
    {
@@ -503,7 +503,11 @@ void font_unref(const font_t *font)
       f->backend->free(f->backend_data);
       free(font->filename);
       free(f);
+
+      f = NULL;
    }
+
+   return f;
 }
 
 const char *font_get_filename(const font_t *font)

--- a/gfx/font_driver.c
+++ b/gfx/font_driver.c
@@ -339,10 +339,6 @@ bool font_driver_init_first(
    const font_t *font;
    bool result = false;
 
-#ifdef _3DS
-   font_size = 10;
-#endif
-
    /* TODO: font_load() and font_unref() should be handled by the caller */
    font = font_load(font_path, font_size);
 

--- a/gfx/font_driver.c
+++ b/gfx/font_driver.c
@@ -42,9 +42,8 @@ static const font_backend_t *font_backends[] = {
    NULL
 };
 
-static const font_renderer_t *font_osd_driver;
-
-static void *font_osd_data;
+static const font_renderer_t *font_osd_driver = NULL;
+static void *font_osd_data = NULL;
 
 int font_renderer_create_default(const void **data, void **handle,
       const char *font_path, unsigned font_size)
@@ -235,6 +234,21 @@ static bool font_init_first(
       void *video_data, const font_t *font,
       enum font_driver_render_api api)
 {
+
+   if (font_osd_driver)
+   {
+      void *data = font_osd_driver->init(video_data, font);
+
+      if (data)
+      {
+         *font_driver = font_osd_driver;
+         *font_handle = data;
+         return true;
+      }
+
+      RARCH_WARN("[font] Failed to reuse renderer.\n");
+   }
+
    switch (api)
    {
 #ifdef HAVE_D3D

--- a/gfx/font_driver.c
+++ b/gfx/font_driver.c
@@ -335,6 +335,7 @@ bool font_driver_init_first(
    void **new_font_handle        = font_handle ? font_handle 
       : (void**)&font_osd_data;
 
+   /* FIXME: check PSP, PS3(LIBDBG), Vita and D3D. */
    const font_t *font = font_load(font_path, font_size);
 
    if (!font)
@@ -442,14 +443,23 @@ const font_t *font_load(const char *filename, float size)
 #if 0 /* disabled until all relevant files are updated */
    font = find_font_instance(djb2_calculate(filename ? filename : ""), size);
 
-   if (!font)
+   if (font)
+      font_ref(font);
+   else
 #endif
       font = create_font_instance(filename, size);
 
-   if (font)
-      font->ref++;
-
    return font;
+}
+
+const font_t *font_ref(const font_t *font)
+{
+   font_t *f = (font_t*)font;
+
+   if (f->ref >= 0)
+      f->ref++;
+
+   return f;
 }
 
 void font_unref(const font_t *font)
@@ -492,7 +502,7 @@ const struct font_glyph *font_get_glyph(const font_t *font, uint32_t codepoint)
 {
    const struct font_glyph *glyph = font->backend->get_glyph(font->backend_data, codepoint);
 
-   if (!glyph)
+   if (!glyph) /* Do something smarter here ... */
       glyph = font->backend->get_glyph(font->backend_data, '?');
 
    return glyph;

--- a/gfx/font_driver.c
+++ b/gfx/font_driver.c
@@ -182,14 +182,14 @@ static const font_renderer_t *vita2d_font_backends[] = {
 
 static bool vita2d_font_init_first(
       const void **font_driver, void **font_handle,
-      void *video_data, const char *font_path, float font_size)
+      void *video_data, const font_t *font)
 {
    unsigned i;
 
    for (i = 0; vita2d_font_backends[i]; i++)
    {
       void *data = vita2d_font_backends[i]->init(
-            video_data, font_path, font_size);
+            video_data, font);
 
       if (!data)
          continue;

--- a/gfx/font_driver.c
+++ b/gfx/font_driver.c
@@ -399,7 +399,7 @@ static fcache_t *fcache_push(const font_t *font,
 
       for (entry = g_fcache; entry < end; ++entry)
       {
-         if (!entry->font)
+         if (!entry->renderer)
          {
             reuse = true;
             break;

--- a/gfx/font_driver.c
+++ b/gfx/font_driver.c
@@ -24,17 +24,17 @@
 #include "../config.h"
 #endif
 
-static const font_renderer_driver_t *font_backends[] = {
+static const font_backend_t *font_backends[] = {
 #ifdef HAVE_FREETYPE
-   &freetype_font_renderer,
+   &freetype_font_backend,
 #endif
 #if defined(__APPLE__) && defined(HAVE_CORETEXT)
-   &coretext_font_renderer,
+   &coretext_font_backend,
 #endif
 #ifdef HAVE_STB_FONT
-   &stb_font_renderer,
+   &stb_font_backend,
 #endif
-   &bitmap_font_renderer,
+   &bitmap_font_backend,
    NULL
 };
 
@@ -47,8 +47,8 @@ int font_renderer_create_default(const void **data, void **handle,
 {
 
    unsigned i;
-   const font_renderer_driver_t **drv = 
-      (const font_renderer_driver_t**)data;
+   const font_backend_t **drv = 
+      (const font_backend_t**)data;
 
    for (i = 0; font_backends[i]; i++)
    {

--- a/gfx/font_driver.c
+++ b/gfx/font_driver.c
@@ -210,14 +210,13 @@ static const font_renderer_t *ctr_font_backends[] = {
 
 static bool ctr_font_init_first(
       const void **font_driver, void **font_handle,
-      void *video_data, const char *font_path, float font_size)
+      void *video_data, const font_t *font)
 {
    unsigned i;
 
    for (i = 0; ctr_font_backends[i]; i++)
    {
-      void *data = ctr_font_backends[i]->init(
-            video_data, font_path, font_size);
+      void *data = ctr_font_backends[i]->init(video_data, font);
 
       if (!data)
          continue;

--- a/gfx/font_driver.c
+++ b/gfx/font_driver.c
@@ -361,6 +361,7 @@ struct font_t {
    const font_backend_t *backend;
    void                 *backend_data;
 
+   char *filename;
    unsigned hash; /* filename hash */
    float    size;
 
@@ -394,6 +395,7 @@ static font_t *create_font_instance(const char *filename, float size)
       return NULL;
    }
 
+   font->filename = strdup(filename ? filename : "");
    font->hash = djb2_calculate(filename ? filename : "");
    font->size = size;
 
@@ -429,6 +431,7 @@ static font_t *create_font_instance(const char *filename, float size)
    {
       RARCH_ERR("[font] Failed to load %s (size=%.2f): no working backend\n",
                 filename, size);
+      free(font->filename);
       free(font);
       font = NULL;
    }
@@ -484,8 +487,14 @@ void font_unref(const font_t *font)
       }
 #endif
       f->backend->free(f->backend_data);
+      free(font->filename);
       free(f);
    }
+}
+
+const char *font_get_filename(const font_t *font)
+{
+   return font->filename;
 }
 
 float font_get_size(const font_t *font)

--- a/gfx/font_driver.c
+++ b/gfx/font_driver.c
@@ -607,7 +607,9 @@ void font_invalidate_caches(void)
 
       for (entry = g_fcache; entry < end; ++entry)
       {
-         entry->renderer->free(entry->data);
+         if (entry->data)
+            entry->renderer->free(entry->data);
+
          entry->renderer = NULL;
          entry->data     = NULL;
       }

--- a/gfx/font_driver.c
+++ b/gfx/font_driver.c
@@ -149,19 +149,19 @@ static bool gl_font_init_first(
 
 #ifdef HAVE_VULKAN
 static const font_renderer_t *vulkan_font_backends[] = {
-   &vulkan_raster_font,
+   &vulkan_font_renderer,
    NULL,
 };
 
 static bool vulkan_font_init_first(
       const void **font_driver, void **font_handle,
-      void *video_data, const char *font_path, float font_size)
+      void *video_data, const font_t *font)
 {
    unsigned i;
 
    for (i = 0; vulkan_font_backends[i]; i++)
    {
-      void *data = vulkan_font_backends[i]->init(video_data, font_path, font_size);
+      void *data = vulkan_font_backends[i]->init(video_data, font);
 
       if (!data)
          continue;
@@ -477,6 +477,11 @@ void font_unref(const font_t *font)
       f->backend->free(f->backend_data);
       free(f);
    }
+}
+
+float font_get_size(const font_t *font)
+{
+   return font->size;
 }
 
 const struct font_atlas *font_get_atlas(const font_t *font)

--- a/gfx/font_driver.c
+++ b/gfx/font_driver.c
@@ -438,7 +438,7 @@ static font_t *create_font_instance(const char *filename, float size)
       font->next = g_fonts;
       g_fonts = font;
 #endif
-      font->ref = 0;
+      font->ref = 1;
    }
    else
    {

--- a/gfx/font_driver.h
+++ b/gfx/font_driver.h
@@ -163,6 +163,13 @@ bool font_driver_init_first(const void **font_driver, void **font_handle,
 const font_t *font_load(const char *filename, float size);
 
 /**
+ * @brief Increments the font refcount
+ * @param font
+ * @return the font itself
+ */
+const font_t *font_ref(const font_t *font);
+
+/**
  * @brief Decrements the font refcount and/or deallocates it
  * @param font
  */

--- a/gfx/font_driver.h
+++ b/gfx/font_driver.h
@@ -175,6 +175,7 @@ const font_t *font_ref(const font_t *font);
  */
 void font_unref(const font_t *font);
 
+const char *font_get_filename(const font_t *font);
 float font_get_size(const font_t *font);
 const struct font_atlas *font_get_atlas(const font_t *font);
 const struct font_glyph *font_get_glyph(const font_t *font, uint32_t codepoint);

--- a/gfx/font_driver.h
+++ b/gfx/font_driver.h
@@ -75,7 +75,7 @@ struct font_atlas
    unsigned height;
 };
 
-struct font_params
+typedef struct font_params
 {
    float x;
    float y;
@@ -91,7 +91,7 @@ struct font_params
    uint32_t color;
    bool full_screen;
    enum text_alignment text_align;
-};
+} font_params_t;
 
 /** Don't free() it. Use font_load() and font_unref() to manage. */
 typedef struct font_t font_t;
@@ -189,6 +189,19 @@ float font_get_size(const font_t *font);
 const struct font_atlas *font_get_atlas(const font_t *font);
 const struct font_glyph *font_get_glyph(const font_t *font, uint32_t codepoint);
 int font_get_line_height(const font_t *font);
+int font_width(const font_t *font, bool video_thread, const char *text, unsigned len, float scale);
+
+void font_set_api(enum font_driver_render_api api);
+
+/**
+ * @brief Render text on the screen
+ * @param font
+ * @param video_thread whether the caller is in the video thread
+ * @param text
+ * @param params
+ */
+void font_render_full(const font_t *font, bool video_thread, const char *text, const font_params_t *params);
+void font_render(const font_t *font, bool video_thread, const char *text, float x, float y, enum text_alignment align, uint32_t color);
 
 extern font_renderer_t gl_font_renderer;
 extern font_renderer_t libdbg_font;

--- a/gfx/font_driver.h
+++ b/gfx/font_driver.h
@@ -168,6 +168,7 @@ const font_t *font_load(const char *filename, float size);
  */
 void font_unref(const font_t *font);
 
+float font_get_size(const font_t *font);
 const struct font_atlas *font_get_atlas(const font_t *font);
 const struct font_glyph *font_get_glyph(const font_t *font, uint32_t codepoint);
 int font_get_line_height(const font_t *font);
@@ -179,7 +180,7 @@ extern font_renderer_t d3d_xdk1_font;
 extern font_renderer_t d3d_win32_font;
 extern font_renderer_t vita2d_vita_font;
 extern font_renderer_t ctr_font;
-extern font_renderer_t vulkan_raster_font;
+extern font_renderer_t vulkan_font_renderer;
 
 extern font_backend_t stb_font_backend;
 extern font_backend_t freetype_font_backend;

--- a/gfx/font_driver.h
+++ b/gfx/font_driver.h
@@ -108,7 +108,7 @@ typedef struct font_renderer
    int (*get_message_width)(void *data, const char *msg, unsigned msg_len_full, float scale);
 } font_renderer_t;
 
-typedef struct font_renderer_driver
+typedef struct
 {
    void *(*init)(const char *font_path, float font_size);
 
@@ -124,7 +124,7 @@ typedef struct font_renderer_driver
    const char *ident;
    
    int (*get_line_height)(void* data);
-} font_renderer_driver_t;
+} font_backend_t;
 
 /* font_path can be NULL for default font. */
 int font_renderer_create_default(const void **driver,
@@ -155,10 +155,10 @@ extern font_renderer_t vita2d_vita_font;
 extern font_renderer_t ctr_font;
 extern font_renderer_t vulkan_raster_font;
 
-extern font_renderer_driver_t stb_font_renderer;
-extern font_renderer_driver_t freetype_font_renderer;
-extern font_renderer_driver_t coretext_font_renderer;
-extern font_renderer_driver_t bitmap_font_renderer;
+extern font_backend_t stb_font_backend;
+extern font_backend_t freetype_font_backend;
+extern font_backend_t coretext_font_backend;
+extern font_backend_t bitmap_font_backend;
 
 RETRO_END_DECLS
 

--- a/gfx/font_driver.h
+++ b/gfx/font_driver.h
@@ -98,7 +98,7 @@ typedef struct font_t font_t;
 
 typedef struct
 {
-   void *(*init)(void *data, const char *font_path, float font_size);
+   void *(*init)(void *data, const font_t *font);
    void (*free)(void *data);
    void (*render_msg)(void *data, const char *msg,
          const void *params);
@@ -172,7 +172,7 @@ const struct font_atlas *font_get_atlas(const font_t *font);
 const struct font_glyph *font_get_glyph(const font_t *font, uint32_t codepoint);
 int font_get_line_height(const font_t *font);
 
-extern font_renderer_t gl_raster_font;
+extern font_renderer_t gl_font_renderer;
 extern font_renderer_t libdbg_font;
 extern font_renderer_t d3d_xbox360_font;
 extern font_renderer_t d3d_xdk1_font;

--- a/gfx/font_driver.h
+++ b/gfx/font_driver.h
@@ -133,23 +133,6 @@ typedef struct
 int font_renderer_create_default(const void **driver,
       void **handle, const char *font_path, unsigned font_size);
       
-bool font_driver_has_render_msg(void);
-
-void font_driver_render_msg(void *data, const char *msg, const struct font_params *params);
-
-void font_driver_bind_block(void *font_data, void *block);
-
-int font_driver_get_message_width(void *data, const char *msg, unsigned len, float scale);
-
-void font_driver_flush(void *data);
-
-void font_driver_free(void *data);
-
-bool font_driver_init_first(const void **font_driver, void **font_handle,
-      void *data, const char *font_path, float font_size,
-      bool threading_hint, enum font_driver_render_api api);
-
-
 /**
  * @brief Loads a font file
  *
@@ -189,9 +172,17 @@ float font_get_size(const font_t *font);
 const struct font_atlas *font_get_atlas(const font_t *font);
 const struct font_glyph *font_get_glyph(const font_t *font, uint32_t codepoint);
 int font_get_line_height(const font_t *font);
-int font_width(const font_t *font, bool video_thread, const char *text, unsigned len, float scale);
-
+int font_width(const font_t *font, const char *text, unsigned len, float scale);
 void font_set_api(enum font_driver_render_api api);
+
+
+/**
+ * @brief Instructs
+ * @param font
+ * @param queue
+ */
+void font_bind_block(const font_t *font, void *block);
+void font_flush(const font_t *font);
 
 /**
  * @brief Render text on the screen
@@ -200,8 +191,18 @@ void font_set_api(enum font_driver_render_api api);
  * @param text
  * @param params
  */
-void font_render_full(const font_t *font, bool video_thread, const char *text, const font_params_t *params);
-void font_render(const font_t *font, bool video_thread, const char *text, float x, float y, enum text_alignment align, uint32_t color);
+void font_render_full(const font_t *font, const char *text, const font_params_t *params);
+void font_render(const font_t *font, const char *text, float x, float y, enum text_alignment align, uint32_t color);
+
+
+
+/**
+ * @brief Invalidates font caches
+ *
+ * This function should be called before video contexts or drivers get
+ * deinitialized or destroyed.
+ */
+void font_invalidate_caches(void);
 
 extern font_renderer_t gl_font_renderer;
 extern font_renderer_t libdbg_font;

--- a/gfx/font_driver.h
+++ b/gfx/font_driver.h
@@ -93,7 +93,10 @@ struct font_params
    enum text_alignment text_align;
 };
 
-typedef struct font_renderer
+/** Don't free() it. Use font_load() and font_unref() to manage. */
+typedef struct font_t font_t;
+
+typedef struct
 {
    void *(*init)(void *data, const char *font_path, float font_size);
    void (*free)(void *data);
@@ -145,6 +148,29 @@ void font_driver_free(void *data);
 bool font_driver_init_first(const void **font_driver, void **font_handle,
       void *data, const char *font_path, float font_size,
       bool threading_hint, enum font_driver_render_api api);
+
+
+/**
+ * @brief Loads a font file
+ *
+ * The returned pointer must be freed using font_unref().
+ *
+ * @param filename
+ * @param size
+ * @return pointer to a font_t structure
+ * @see font_unref()
+ */
+const font_t *font_load(const char *filename, float size);
+
+/**
+ * @brief Decrements the font refcount and/or deallocates it
+ * @param font
+ */
+void font_unref(const font_t *font);
+
+const struct font_atlas *font_get_atlas(const font_t *font);
+const struct font_glyph *font_get_glyph(const font_t *font, uint32_t codepoint);
+int font_get_line_height(const font_t *font);
 
 extern font_renderer_t gl_raster_font;
 extern font_renderer_t libdbg_font;

--- a/gfx/font_driver.h
+++ b/gfx/font_driver.h
@@ -164,6 +164,13 @@ const font_t *font_load(const char *filename, float size);
 
 /**
  * @brief Increments the font refcount
+ *
+ * Use this function if you want to tie the font lifetime to a certain piece of
+ * code's lifetime e.g. a menu driver or a font renderer.
+ *
+ * All font_ref() calls must have a matching font_unref() call otherwise the
+ * program leaks.
+ *
  * @param font
  * @return the font itself
  */
@@ -171,9 +178,11 @@ const font_t *font_ref(const font_t *font);
 
 /**
  * @brief Decrements the font refcount and/or deallocates it
+ *
  * @param font
+ * @return the font itself or NULL
  */
-void font_unref(const font_t *font);
+const font_t *font_unref(const font_t *font);
 
 const char *font_get_filename(const font_t *font);
 float font_get_size(const font_t *font);

--- a/gfx/video_context_driver.c
+++ b/gfx/video_context_driver.c
@@ -397,6 +397,8 @@ bool video_context_driver_has_windowed(void)
 
 void video_context_driver_free(void)
 {
+   font_invalidate_caches();
+
    if (current_video_context->destroy)
       current_video_context->destroy(video_context_data);
    current_video_context = NULL;

--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -1558,6 +1558,7 @@ void video_driver_destroy_data(void)
 
 void video_driver_deinit(void)
 {
+   font_invalidate_caches();
    uninit_video_input();
    video_driver_lock_free();
    video_driver_data = NULL;

--- a/gfx/video_thread_wrapper.c
+++ b/gfx/video_thread_wrapper.c
@@ -140,8 +140,7 @@ struct thread_packet
          const void **font_driver;
          void **font_handle;
          void *video_data;
-         const char *font_path;
-         float font_size;
+         const font_t *font;
          bool return_value;
          enum font_driver_render_api api;
       } font_init;
@@ -535,8 +534,7 @@ static bool video_thread_handle_packet(
                   (pkt.data.font_init.font_driver,
                      pkt.data.font_init.font_handle,
                      pkt.data.font_init.video_data,
-                     pkt.data.font_init.font_path,
-                     pkt.data.font_init.font_size,
+                     pkt.data.font_init.font,
                      pkt.data.font_init.api);
          video_thread_reply(thr, &pkt);
          break;
@@ -1395,7 +1393,7 @@ static void video_thread_send_and_wait(thread_video_t *thr,
 }
 
 bool video_thread_font_init(const void **font_driver, void **font_handle,
-      void *data, const char *font_path, float font_size,
+      void *data, const font_t *font,
       enum font_driver_render_api api, custom_font_command_method_t func)
 {
    thread_packet_t pkt;
@@ -1409,8 +1407,7 @@ bool video_thread_font_init(const void **font_driver, void **font_handle,
    pkt.data.font_init.font_driver = font_driver;
    pkt.data.font_init.font_handle = font_handle;
    pkt.data.font_init.video_data  = data;
-   pkt.data.font_init.font_path   = font_path;
-   pkt.data.font_init.font_size   = font_size;
+   pkt.data.font_init.font        = font;
    pkt.data.font_init.api         = api;
 
    video_thread_send_and_wait(thr, &pkt);

--- a/gfx/video_thread_wrapper.h
+++ b/gfx/video_thread_wrapper.h
@@ -29,8 +29,8 @@ RETRO_BEGIN_DECLS
 typedef int (*custom_command_method_t)(void*);
 
 typedef bool (*custom_font_command_method_t)(const void **font_driver,
-      void **font_handle, void *video_data, const char *font_path,
-      float font_size, enum font_driver_render_api api);
+      void **font_handle, void *video_data, const font_t *font,
+      enum font_driver_render_api api);
 
 typedef struct thread_packet thread_packet_t;
 
@@ -71,12 +71,10 @@ void *video_thread_get_ptr(const video_driver_t **drv);
 
 const char *video_thread_get_ident(void);
 
-bool video_thread_font_init(
-      const void **font_driver,
+bool video_thread_font_init(const void **font_driver,
       void **font_handle,
       void *data,
-      const char *font_path,
-      float font_size,
+      const font_t *font,
       enum font_driver_render_api api,
       custom_font_command_method_t func);
 

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -2066,16 +2066,13 @@ static int generic_action_ok_network(const char *path,
 
    url_path[0] = '\0';
 
-   menu_entries_ctl(MENU_ENTRIES_CTL_SET_REFRESH, &refresh);
-
-   if (string_is_empty(settings->network.buildbot_url))
-      return menu_cbs_exit();
-
-   command_event(CMD_EVENT_NETWORK_INIT, NULL);
-
    switch (enum_idx)
    {
       case MENU_ENUM_LABEL_CB_CORE_CONTENT_DIRS_LIST:
+
+         if (string_is_empty(settings->network.buildbot_assets_url))
+            return menu_cbs_exit();
+
          fill_pathname_join(url_path, settings->network.buildbot_assets_url,
                "cores/.index-dirs", sizeof(url_path));
          url_label = msg_hash_to_str(enum_idx);
@@ -2092,6 +2089,10 @@ static int generic_action_ok_network(const char *path,
          suppress_msg = true;
          break;
       case MENU_ENUM_LABEL_CB_CORE_UPDATER_LIST:
+
+         if (string_is_empty(settings->network.buildbot_url))
+            return menu_cbs_exit();
+
          fill_pathname_join(url_path, settings->network.buildbot_url,
                file_path_str(FILE_PATH_INDEX_EXTENDED_URL), sizeof(url_path));
          url_label = msg_hash_to_str(enum_idx);
@@ -2123,6 +2124,10 @@ static int generic_action_ok_network(const char *path,
       default:
          break;
    }
+   
+   menu_entries_ctl(MENU_ENTRIES_CTL_SET_REFRESH, &refresh);
+
+   command_event(CMD_EVENT_NETWORK_INIT, NULL);
 
    transf           = (menu_file_transfer_t*)calloc(1, sizeof(*transf));
    strlcpy(transf->path, url_path, sizeof(transf->path));

--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -1116,6 +1116,8 @@ static void mui_frame(void *data)
    );
 
    font_flush(mui->font);
+   font_bind_block(mui->font, NULL);
+
    menu_animation_ctl(MENU_ANIMATION_CTL_SET_ACTIVE, NULL);
 
    /* header */

--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -120,6 +120,8 @@ typedef struct mui_handle
 
    video_font_raster_block_t list_block;
    float scroll_y;
+
+   const font_t *font;
 } mui_handle_t;
 
 static void hex32_to_rgba_normalized(uint32_t hex, float* rgba, float alpha)
@@ -248,7 +250,8 @@ static void mui_draw_tab(mui_handle_t *mui,
          &tab_color[0]);
 }
 
-static void mui_draw_text(float x, float y, unsigned width, unsigned height,
+static void mui_draw_text(mui_handle_t *mui,
+      float x, float y, unsigned width, unsigned height,
       const char *msg, uint32_t color, enum text_alignment text_align)
 {
    int font_size;
@@ -266,7 +269,7 @@ static void mui_draw_text(float x, float y, unsigned width, unsigned height,
    params.full_screen = true;
    params.text_align  = text_align;
 
-   menu_display_draw_text(msg, width, height, &params);
+   menu_display_draw_text(mui->font, msg, width, height, &params);
 }
 
 static void mui_render_quad(mui_handle_t *mui,
@@ -391,7 +394,6 @@ static void mui_render_messagebox(mui_handle_t *mui,
    int x, y, line_height, longest = 0, longest_width = 0;
    struct string_list *list = (struct string_list*)
       string_split(message, "\n");
-   void *fb_buf;
 
    if (!list)
       return;
@@ -405,8 +407,6 @@ static void mui_render_messagebox(mui_handle_t *mui,
    x = width  / 2;
    y = height / 2 - (list->size-1) * line_height / 2;
 
-   fb_buf = menu_display_get_font_buffer();
-
    /* find the longest line width */
    for (i = 0; i < list->size; i++)
    {
@@ -415,7 +415,7 @@ static void mui_render_messagebox(mui_handle_t *mui,
       if (len > longest)
       {
          longest = len;
-         longest_width = font_driver_get_message_width(fb_buf, msg, len, 1);
+         longest_width = font_width(mui->font, msg, len, 1);
       }
    }
 
@@ -435,7 +435,7 @@ static void mui_render_messagebox(mui_handle_t *mui,
    {
       const char *msg = list->elems[i].data;
       if (msg)
-         mui_draw_text(x - longest_width/2.0, y + i * line_height,
+         mui_draw_text(mui, x - longest_width/2.0, y + i * line_height,
                width, height,
                msg, font_color, TEXT_ALIGN_LEFT);
    }
@@ -562,7 +562,7 @@ static void mui_render_label_value(mui_handle_t *mui,
 
    menu_animation_ctl(MENU_ANIMATION_CTL_TICKER, &ticker);
 
-   mui_draw_text(mui->margin, y + mui->line_height / 2,
+   mui_draw_text(mui, mui->margin, y + mui->line_height / 2,
          width, height, label_str, color, TEXT_ALIGN_LEFT);
 
    if (string_is_equal(value, "disabled") || string_is_equal(value, "off"))
@@ -621,7 +621,7 @@ static void mui_render_label_value(mui_handle_t *mui,
    }
 
    if (do_draw_text)
-      mui_draw_text(width - mui->margin,
+      mui_draw_text(mui, width - mui->margin,
             y + mui->line_height / 2,
             width, height, value_str, color, TEXT_ALIGN_RIGHT);
 
@@ -1104,7 +1104,7 @@ static void mui_frame(void *data)
       &highlighted_entry_color[0]
    );
 
-   menu_display_font_bind_block(&mui->list_block);
+   font_bind_block(mui->font, &mui->list_block);
 
    mui_render_menu_list(
       mui, 
@@ -1115,7 +1115,7 @@ static void mui_frame(void *data)
       &active_tab_marker_color[0]
    );
 
-   menu_display_font_flush_block();
+   font_flush(mui->font);
    menu_animation_ctl(MENU_ANIMATION_CTL_SET_ACTIVE, NULL);
 
    /* header */
@@ -1204,7 +1204,7 @@ static void mui_frame(void *data)
       strlcpy(title_buf, title_buf_msg_tmp, sizeof(title_buf));
    }
 
-   mui_draw_text(title_margin, header_height / 2, width, height,
+   mui_draw_text(mui, title_margin, header_height / 2, width, height,
          title_buf, font_header_color, TEXT_ALIGN_LEFT);
 
    mui_draw_scrollbar(mui, width, height, &grey_bg[0]);
@@ -1241,7 +1241,6 @@ static void mui_frame(void *data)
 
 static void mui_layout(mui_handle_t *mui)
 {
-   void *fb_buf;
    float scale_factor;
    int new_font_size;
    unsigned width, height, new_header_height;
@@ -1272,18 +1271,12 @@ static void mui_layout(mui_handle_t *mui)
    /* we assume the average glyph aspect ratio is close to 3:4 */
    mui->glyph_width = new_font_size * 3/4;
 
-   menu_display_font(APPLICATION_SPECIAL_DIRECTORY_ASSETS_MATERIALUI_FONT);
+   mui->font = menu_display_font(APPLICATION_SPECIAL_DIRECTORY_ASSETS_MATERIALUI_FONT);
 
-   fb_buf = menu_display_get_font_buffer();
+   unsigned m_width = font_width(mui->font, "a", 1, 1);
 
-   if (fb_buf) /* calculate a more realistic ticker_limit */
-   {
-      unsigned m_width = 
-         font_driver_get_message_width(fb_buf, "a", 1, 1);
-
-      if (m_width)
-         mui->glyph_width = m_width;
-   }
+   if (m_width)
+      mui->glyph_width = m_width;
 }
 
 static void *mui_init(void **userdata)
@@ -1325,8 +1318,8 @@ static void mui_free(void *data)
       return;
 
    video_coord_array_free(&mui->list_block.carr);
-
-   font_driver_bind_block(NULL, NULL);
+   font_bind_block(mui->font, NULL);
+   font_unref(mui->font);
 }
 
 static void mui_context_bg_destroy(mui_handle_t *mui)
@@ -1348,8 +1341,6 @@ static void mui_context_destroy(void *data)
 
    for (i = 0; i < MUI_TEXTURE_LAST; i++)
       video_driver_texture_unload(&mui->textures.list[i]);
-
-   menu_display_font_main_deinit();
 
    mui_context_bg_destroy(mui);
 }

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -281,6 +281,8 @@ typedef struct xmb_handle
 
    unsigned tabs[8];
    unsigned system_tab_end;
+
+   const font_t *font;
 } xmb_handle_t;
 
 float gradient_dark_purple[16] = {
@@ -666,7 +668,10 @@ static void xmb_draw_text(xmb_handle_t *xmb,
       params.drop_alpha  = 0.35f;
    }
 
-   menu_display_draw_text(str, width, height, &params);
+   menu_display_draw_text(xmb->font, str, width, height, &params);
+
+   /* FIXME: why is this needed? */
+   menu_display_blend_begin();
 }
 
 static void xmb_messagebox(void *data, const char *message)
@@ -686,7 +691,6 @@ static void xmb_render_messagebox_internal(
    unsigned i;
    unsigned width, height;
    struct string_list *list = NULL;
-   void *fb_buf;
 
    if (!xmb)
       return;
@@ -705,8 +709,6 @@ static void xmb_render_messagebox_internal(
    x = width  / 2;
    y = height / 2 - (list->size-1) * font_size / 2;
 
-   fb_buf = menu_display_get_font_buffer();
-
    /* find the longest line width */
    for (i = 0; i < list->size; i++)
    {
@@ -715,7 +717,7 @@ static void xmb_render_messagebox_internal(
       if (len > longest)
       {
          longest = len;
-         longest_width = font_driver_get_message_width(fb_buf, msg, len, 1);
+         longest_width = font_width(xmb->font, msg, len, 1);
       }
    }
 
@@ -2185,7 +2187,7 @@ static void xmb_frame(void *data)
 
    video_driver_get_size(&width, &height);
 
-   menu_display_font_bind_block(&xmb->raster_block);
+   font_bind_block(xmb->font, &xmb->raster_block);
 
    xmb->raster_block.carr.coords.vertices = 0;
 
@@ -2380,7 +2382,7 @@ static void xmb_frame(void *data)
          width,
          height);
 
-   menu_display_font_flush_block();
+   font_flush(xmb->font);
 
    if (menu_input_dialog_get_display_kb())
    {
@@ -2703,7 +2705,7 @@ static void *xmb_init(void **userdata)
    menu_display_allocate_white_texture();
 
    xmb_init_horizontal_list(xmb);
-   menu_display_font(APPLICATION_SPECIAL_DIRECTORY_ASSETS_XMB_FONT);
+//   xmb->font = menu_display_font2(APPLICATION_SPECIAL_DIRECTORY_ASSETS_XMB_FONT);
    xmb_init_ribbon(xmb);
 
    return menu;
@@ -2747,7 +2749,8 @@ static void xmb_free(void *data)
       video_coord_array_free(&xmb->raster_block.carr);
    }
 
-   font_driver_bind_block(NULL, NULL);
+   font_bind_block(xmb->font, NULL);
+   font_unref(xmb->font);
 
 }
 
@@ -2963,7 +2966,7 @@ static void xmb_context_reset(void *data)
          APPLICATION_SPECIAL_DIRECTORY_ASSETS_XMB_ICONS);
 
    xmb_layout(xmb);
-   menu_display_font(APPLICATION_SPECIAL_DIRECTORY_ASSETS_XMB_FONT);
+   xmb->font = menu_display_font(APPLICATION_SPECIAL_DIRECTORY_ASSETS_XMB_FONT);
    xmb_context_reset_textures(xmb, iconpath);
    xmb_context_reset_background(iconpath);
    xmb_context_reset_horizontal_list(xmb);
@@ -3255,8 +3258,6 @@ static void xmb_context_destroy(void *data)
 
    xmb_context_destroy_horizontal_list(xmb);
    xmb_context_bg_destroy(xmb);
-
-   menu_display_font_main_deinit();
 }
 
 static void xmb_toggle(void *userdata, bool menu_on)

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -671,7 +671,7 @@ static void xmb_draw_text(xmb_handle_t *xmb,
    menu_display_draw_text(xmb->font, str, width, height, &params);
 
    /* FIXME: why is this needed? */
-   menu_display_blend_begin();
+   /* menu_display_blend_begin(); */
 }
 
 static void xmb_messagebox(void *data, const char *message)
@@ -2383,6 +2383,7 @@ static void xmb_frame(void *data)
          height);
 
    font_flush(xmb->font);
+   font_bind_block(xmb->font, NULL);
 
    if (menu_input_dialog_get_display_kb())
    {

--- a/menu/drivers_display/menu_display_ctr.c
+++ b/menu/drivers_display/menu_display_ctr.c
@@ -171,14 +171,6 @@ static void menu_display_ctr_clear_color(menu_display_ctx_clearcolor_t *clearcol
 //   ctr_clear_screen();
 }
 
-static bool menu_display_ctr_font_init_first(
-      void **font_handle, void *video_data,
-      const char *font_path, float font_size)
-{
-   return font_driver_init_first(NULL, font_handle, video_data,
-         font_path, font_size, true, FONT_DRIVER_RENDER_CTR);
-}
-
 menu_display_ctx_driver_t menu_display_ctx_ctr = {
    menu_display_ctr_draw,
    menu_display_ctr_draw_pipeline,
@@ -190,7 +182,7 @@ menu_display_ctx_driver_t menu_display_ctx_ctr = {
    menu_display_ctr_get_default_mvp,
    menu_display_ctr_get_default_vertices,
    menu_display_ctr_get_default_tex_coords,
-   menu_display_ctr_font_init_first,
+   NULL,
    MENU_VIDEO_DRIVER_CTR,
    "menu_display_ctr",
 };

--- a/menu/drivers_display/menu_display_d3d.cpp
+++ b/menu/drivers_display/menu_display_d3d.cpp
@@ -249,14 +249,6 @@ static void menu_display_d3d_clear_color(menu_display_ctx_clearcolor_t *clearcol
    d3d_clear(d3d->dev, 0, NULL, D3DCLEAR_TARGET, clear_color, 0, 0);
 }
 
-static bool menu_display_d3d_font_init_first(
-      void **font_handle, void *video_data,
-      const char *font_path, float font_size)
-{
-   return font_driver_init_first(NULL, font_handle, video_data,
-         font_path, font_size, true, FONT_DRIVER_RENDER_DIRECT3D_API);
-}
-
 menu_display_ctx_driver_t menu_display_ctx_d3d = {
    menu_display_d3d_draw,
    menu_display_d3d_draw_pipeline,
@@ -268,7 +260,7 @@ menu_display_ctx_driver_t menu_display_ctx_d3d = {
    menu_display_d3d_get_default_mvp,
    menu_display_d3d_get_default_vertices,
    menu_display_d3d_get_default_tex_coords,
-   menu_display_d3d_font_init_first,
+   NULL,
    MENU_VIDEO_DRIVER_DIRECT3D,
    "menu_display_d3d",
 };

--- a/menu/drivers_display/menu_display_gl.c
+++ b/menu/drivers_display/menu_display_gl.c
@@ -213,14 +213,6 @@ static void menu_display_gl_clear_color(menu_display_ctx_clearcolor_t *clearcolo
    glClear(GL_COLOR_BUFFER_BIT);
 }
 
-static bool menu_display_gl_font_init_first(
-      void **font_handle, void *video_data,
-      const char *font_path, float font_size)
-{
-   return font_driver_init_first(NULL, font_handle, video_data,
-         font_path, font_size, true, FONT_DRIVER_RENDER_OPENGL_API);
-}
-
 menu_display_ctx_driver_t menu_display_ctx_gl = {
    menu_display_gl_draw,
    menu_display_gl_draw_pipeline,
@@ -232,7 +224,7 @@ menu_display_ctx_driver_t menu_display_ctx_gl = {
    menu_display_gl_get_default_mvp,
    menu_display_gl_get_default_vertices,
    menu_display_gl_get_default_tex_coords,
-   menu_display_gl_font_init_first,
+   NULL,
    MENU_VIDEO_DRIVER_OPENGL,
    "menu_display_gl",
 };

--- a/menu/drivers_display/menu_display_vita2d.c
+++ b/menu/drivers_display/menu_display_vita2d.c
@@ -221,14 +221,6 @@ static void menu_display_vita2d_clear_color(menu_display_ctx_clearcolor_t *clear
    vita2d_clear_screen();
 }
 
-static bool menu_display_vita2d_font_init_first(
-      void **font_handle, void *video_data,
-      const char *font_path, float font_size)
-{
-   return font_driver_init_first(NULL, font_handle, video_data,
-         font_path, font_size, true, FONT_DRIVER_RENDER_VITA2D);
-}
-
 menu_display_ctx_driver_t menu_display_ctx_vita2d = {
    menu_display_vita2d_draw,
    menu_display_vita2d_draw_pipeline,
@@ -240,7 +232,7 @@ menu_display_ctx_driver_t menu_display_ctx_vita2d = {
    menu_display_vita2d_get_default_mvp,
    menu_display_vita2d_get_default_vertices,
    menu_display_vita2d_get_default_tex_coords,
-   menu_display_vita2d_font_init_first,
+   NULL,
    MENU_VIDEO_DRIVER_VITA2D,
    "menu_display_vita2d",
 };

--- a/menu/drivers_display/menu_display_vulkan.c
+++ b/menu/drivers_display/menu_display_vulkan.c
@@ -251,14 +251,6 @@ static void menu_display_vk_blend_end(void)
    vk->display.blend = false;
 }
 
-static bool menu_display_vk_font_init_first(
-      void **font_handle, void *video_data, const char *font_path,
-      float font_size)
-{
-   return font_driver_init_first(NULL, font_handle, video_data,
-         font_path, font_size, true, FONT_DRIVER_RENDER_VULKAN_API);
-}
-
 menu_display_ctx_driver_t menu_display_ctx_vulkan = {
    menu_display_vk_draw,
    menu_display_vk_draw_pipeline,
@@ -270,7 +262,7 @@ menu_display_ctx_driver_t menu_display_ctx_vulkan = {
    menu_display_vk_get_default_mvp,
    menu_display_vk_get_default_vertices,
    menu_display_vk_get_default_tex_coords,
-   menu_display_vk_font_init_first,
+   NULL,
    MENU_VIDEO_DRIVER_VULKAN,
    "menu_display_vulkan",
 };

--- a/menu/menu_display.h
+++ b/menu/menu_display.h
@@ -181,11 +181,6 @@ void menu_display_toggle_set_reason(enum menu_toggle_reason reason);
 void menu_display_blend_begin(void);
 void menu_display_blend_end(void);
 
-void menu_display_font_main_deinit(void);
-bool menu_display_font_main_init(menu_display_ctx_font_t *font);
-void menu_display_font_bind_block(void *block);
-bool menu_display_font_flush_block(void);
-
 void menu_display_framebuffer_deinit(void);
 
 void menu_display_deinit(void);
@@ -193,8 +188,6 @@ bool menu_display_init(void);
 
 void menu_display_coords_array_reset(void);
 video_coord_array_t *menu_display_get_coords_array(void);
-void *menu_display_get_font_buffer(void);
-void menu_display_set_font_buffer(void *buffer);
 const uint8_t *menu_display_get_font_framebuffer(void);
 void menu_display_set_font_framebuffer(const uint8_t *buffer);
 bool menu_display_libretro_running(void);
@@ -254,14 +247,14 @@ void menu_display_draw_cursor(
       float *color, float cursor_size, uintptr_t texture,
       float x, float y, unsigned width, unsigned height);
 
-void menu_display_draw_text(const char *msg, int width, int height,
+void menu_display_draw_text(const font_t *font, const char *msg, int width, int height,
       struct font_params *params);
 
 bool menu_display_shader_pipeline_active(void);
 
 void menu_display_set_alpha(float *color, float alpha_value);
 
-bool menu_display_font(enum application_special_type type);
+const font_t *menu_display_font(enum application_special_type type);
 
 void menu_display_reset_textures_list(const char *texture_path, const char *iconpath,
       uintptr_t *item);

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -2914,11 +2914,13 @@ static int menu_displaylist_parse_options(
          MENU_ENUM_LABEL_THUMBNAILS_UPDATER_LIST,
          MENU_SETTING_ACTION, 0, 0);
 #else
+#if !defined(VITA)
    menu_entries_append_enum(info->list,
          msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CORE_UPDATER_LIST),
          msg_hash_to_str(MENU_ENUM_LABEL_CORE_UPDATER_LIST),
          MENU_ENUM_LABEL_CORE_UPDATER_LIST,
          MENU_SETTING_ACTION, 0, 0);
+#endif
 
    menu_entries_append_enum(info->list,
          msg_hash_to_str(MENU_ENUM_LABEL_VALUE_THUMBNAILS_UPDATER_LIST),
@@ -2926,11 +2928,13 @@ static int menu_displaylist_parse_options(
          MENU_ENUM_LABEL_THUMBNAILS_UPDATER_LIST,
          MENU_SETTING_ACTION, 0, 0);
 
+#if !defined(VITA)
    menu_entries_append_enum(info->list,
          msg_hash_to_str(MENU_ENUM_LABEL_VALUE_UPDATE_CORE_INFO_FILES),
          msg_hash_to_str(MENU_ENUM_LABEL_UPDATE_CORE_INFO_FILES),
          MENU_ENUM_LABEL_UPDATE_CORE_INFO_FILES,
          MENU_SETTING_ACTION, 0, 0);
+#endif
 
 #ifdef HAVE_UPDATE_ASSETS
    menu_entries_append_enum(info->list,
@@ -2953,11 +2957,13 @@ static int menu_displaylist_parse_options(
          MENU_SETTING_ACTION, 0, 0);
 
 #ifdef HAVE_LIBRETRODB
+#if !defined(VITA)
    menu_entries_append_enum(info->list,
          msg_hash_to_str(MENU_ENUM_LABEL_VALUE_UPDATE_DATABASES),
          msg_hash_to_str(MENU_ENUM_LABEL_UPDATE_DATABASES),
          MENU_ENUM_LABEL_UPDATE_DATABASES,
          MENU_SETTING_ACTION, 0, 0);
+#endif
 #endif
 
    menu_entries_append_enum(info->list,


### PR DESCRIPTION
I did this because I was really annoyed at some font code I saw. I still am annoyed, particularly with the font renderers (GL in particular). There's still lots of room for improvement here.

What this does:

* Enables/eases the use of multiple fonts by the menu and video drivers.
* Encapsulates font backend, renderer and metadata into font_t and it's functions.
* Lazily initializes gfx-specific data (saves video resources if the font is loaded but never used).
* Allows basic font metadata to persist across video context resets (no more reloading+parsing from slow media).
* Makes sure there is only one instance of each font file-size pair (saves memory).

What this doesn't do but I wish it did:

* Gets rid of nasty viewport side effects in the OpenGL renderer (this has caused multiple bugs overtime).

I have not tested all platforms, but GL (Linux and Windows) and Vulkan (Linux) work. A few days (many commits) ago some people confirmed it was working in PS3 and 3DS but I cannot confirm if it still works there.

@Kivutar Twinaphex said you might be interested in this.