### PR TITLE
(libretro-common) Fix sthread_isself() documentation

### DIFF
--- a/libretro-common/include/rthreads/rthreads.h
+++ b/libretro-common/include/rthreads/rthreads.h
@@ -76,13 +76,8 @@ void sthread_join(sthread_t *thread);
 
 /**
  * sthread_isself:
- * @thread                  : pointer to thread object 
+ * @thread                  : pointer to thread object
  *
- * Join with a terminated thread. Waits for the thread specified by
- * @thread to terminate. If that thread has already terminated, then
- * it will return immediately. The thread specified by @thread must
- * be joinable.
- * 
  * Returns: true (1) if calling thread is the specified thread
  */
 bool sthread_isself(sthread_t *thread);

--- a/libretro-common/rthreads/rthreads.c
+++ b/libretro-common/rthreads/rthreads.c
@@ -207,11 +207,6 @@ void sthread_join(sthread_t *thread)
  * sthread_isself:
  * @thread                  : pointer to thread object
  *
- * Join with a terminated thread. Waits for the thread specified by
- * @thread to terminate. If that thread has already terminated, then
- * it will return immediately. The thread specified by @thread must
- * be joinable.
- *
  * Returns: true (1) if calling thread is the specified thread
  */
 bool sthread_isself(sthread_t *thread)


### PR DESCRIPTION
Old non-brief doc was a copy of sthread_join()