### PR TITLE
Improve cheat menu + wording 

### DIFF
--- a/intl/msg_hash_us.c
+++ b/intl/msg_hash_us.c
@@ -625,7 +625,7 @@ int menu_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
          {
             /* Work around C89 limitations */
             char u[501];
-            const char * t = 
+            const char * t =
                   "RetroArch relies on an unique form of\n"
                   "audio/video synchronization where it needs to be\n"
                   "calibrated against the refresh rate of your\n"
@@ -4171,9 +4171,9 @@ const char *msg_hash_to_str_us(enum msg_hash_enums msg)
       case MENU_ENUM_LABEL_VALUE_CHEAT_FILE:
          return "Cheat File";
       case MENU_ENUM_LABEL_VALUE_CHEAT_FILE_LOAD:
-         return "Cheat File Load";
+         return "Load Cheat File";
       case MENU_ENUM_LABEL_VALUE_CHEAT_FILE_SAVE_AS:
-         return "Cheat File Save As";
+         return "Save Cheat File As";
       case MENU_ENUM_LABEL_VALUE_CORE_COUNTERS:
          return "Core Counters";
       case MENU_ENUM_LABEL_VALUE_TAKE_SCREENSHOT:

--- a/managers/cheat_manager.c
+++ b/managers/cheat_manager.c
@@ -1,7 +1,7 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
  *  Copyright (C) 2011-2016 - Daniel De Matteis
- * 
+ *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-
  *  ation, either version 3 of the License, or (at your option) any later version.
@@ -97,7 +97,9 @@ void cheat_manager_apply_cheats(void)
          core_set_cheat(&cheat_info);
       }
    }
-   
+    runloop_msg_queue_push("Applying cheat changes.", 1, 180, true);
+    RARCH_LOG("Applying cheat changes.\n");
+
 #ifdef HAVE_CHEEVOS
    data_bool = idx != 0;
    cheevos_apply_cheats(&data_bool);
@@ -137,7 +139,7 @@ bool cheat_manager_save(const char *path)
          path, sizeof(buf));
 
    fill_pathname_noext(cheats_file, buf, ".cht", sizeof(cheats_file));
-   
+
    conf = config_file_new(cheats_file);
 
    if (!conf)
@@ -340,7 +342,7 @@ void cheat_manager_update(cheat_manager_t *handle, unsigned handle_idx)
 
    snprintf(msg, sizeof(msg), "Cheat: #%u [%s]: %s",
          handle_idx, handle->cheats[handle_idx].state ? "ON" : "OFF",
-         (handle->cheats[handle_idx].desc) ? 
+         (handle->cheats[handle_idx].desc) ?
          (handle->cheats[handle_idx].desc) : (handle->cheats[handle_idx].code)
          );
    runloop_msg_queue_push(msg, 1, 180, true);

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -2722,19 +2722,19 @@ static int menu_displaylist_parse_load_content_settings(
             MENU_ENUM_LABEL_SHADER_OPTIONS,
             MENU_SETTING_ACTION, 0, 0);
 #endif
-      
+
       menu_entries_append_enum(info->list,
             msg_hash_to_str(MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG_OVERRIDE_CORE),
             msg_hash_to_str(MENU_ENUM_LABEL_SAVE_CURRENT_CONFIG_OVERRIDE_CORE),
             MENU_ENUM_LABEL_SAVE_CURRENT_CONFIG_OVERRIDE_CORE,
             MENU_SETTING_ACTION, 0, 0);
-      
+
       menu_entries_append_enum(info->list,
             msg_hash_to_str(MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG_OVERRIDE_GAME),
             msg_hash_to_str(MENU_ENUM_LABEL_SAVE_CURRENT_CONFIG_OVERRIDE_GAME),
             MENU_ENUM_LABEL_SAVE_CURRENT_CONFIG_OVERRIDE_GAME,
             MENU_SETTING_ACTION, 0, 0);
-      
+
 #ifdef HAVE_CHEEVOS
       if(settings->cheevos.enable)
          menu_entries_append_enum(info->list,
@@ -3039,6 +3039,11 @@ static int menu_displaylist_parse_options_cheats(
       return -1;
 
    menu_entries_append_enum(info->list,
+         msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_APPLY_CHANGES),
+         msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_APPLY_CHANGES),
+         MENU_ENUM_LABEL_CHEAT_APPLY_CHANGES,
+         MENU_SETTING_ACTION, 0, 0);
+   menu_entries_append_enum(info->list,
          msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_FILE_LOAD),
          msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_FILE_LOAD),
          MENU_ENUM_LABEL_CHEAT_FILE_LOAD,
@@ -3053,11 +3058,6 @@ static int menu_displaylist_parse_options_cheats(
          msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_NUM_PASSES),
          MENU_ENUM_LABEL_CHEAT_NUM_PASSES,
          0, 0, 0);
-   menu_entries_append_enum(info->list,
-         msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_APPLY_CHANGES),
-         msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_APPLY_CHANGES),
-         MENU_ENUM_LABEL_CHEAT_APPLY_CHANGES,
-         MENU_SETTING_ACTION, 0, 0);
 
    for (i = 0; i < cheat_manager_get_size(); i++)
    {


### PR DESCRIPTION
First commit. (Perfect)
* Rename Cheat File Load --> Load Cheat File. (Human)
* Rename Cheat File Save As --> Save Cheat Code As. (Human)
* Rearrange options for better setup flow (imo) as Apply Cheat Changes comes between a changeable numbered list of cheats and Cheat Passes (number). This would be similar to options under Shader.

Second commit. (English Only)
* Add notification + logging for "Applying cheat changes." -- English only.

I don't have experience with programming. I tried to add support for all languages and couldn't pull it off. This may serve as a base to start implementing support for notifications.

More cheat improvements / suggestions can be found here. https://github.com/libretro/RetroArch/issues/3748