### PR TITLE
Fix ugly task popup

### DIFF
--- a/libretro-common/queues/task_queue.c
+++ b/libretro-common/queues/task_queue.c
@@ -84,7 +84,7 @@ static void task_queue_push_progress(retro_task_t *task)
       {
          if (task->error)
             task_queue_msg_push(1, 60, true, "%s: %s",
-               "Task failed\n", task->title);
+               "Task failed", task->title);
          else
             task_queue_msg_push(1, 60, true, "100%%: %s", task->title);
       }


### PR DESCRIPTION
Fix the task popup that will pop outside of the box with this settings.

video_font_size = "16"
video_message_pos_x = "0.01"
video_message_pos_y = "0.01"