### PR TITLE
Disable netplay when we disconnect from the menu

### DIFF
--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -3451,6 +3451,7 @@ static int action_ok_netplay_disconnect(const char *path,
 {
 #ifdef HAVE_NETWORKING
    netplay_driver_ctl(RARCH_NETPLAY_CTL_DISCONNECT, NULL);
+   netplay_driver_ctl(RARCH_NETPLAY_CTL_DISABLE, NULL);
    return generic_action_ok_command(CMD_EVENT_RESUME);
 
 #else


### PR DESCRIPTION
This just fixes some confusing behavior. Previously if you disconnected then loaded a new game, it would try to reconnect, because it was disconnected but still enabled.
