### PR TITLE
Add egl debug context option for Android

### DIFF
--- a/gfx/drivers_context/android_ctx.c
+++ b/gfx/drivers_context/android_ctx.c
@@ -105,8 +105,11 @@ static void *android_gfx_ctx_init(void *video_driver)
 #ifdef HAVE_OPENGLES
    EGLint n, major, minor;
    EGLint format;
+   struct retro_hw_render_callback *hwr = video_driver_get_hw_context();
+   bool debug = hwr->debug_context;
    EGLint context_attributes[] = {
       EGL_CONTEXT_CLIENT_VERSION, g_es3 ? 3 : 2,
+      EGL_CONTEXT_FLAGS_KHR, debug ? EGL_CONTEXT_OPENGL_DEBUG_BIT_KHR : 0,
       EGL_NONE
    };
    EGLint attribs[] = {


### PR DESCRIPTION
According to https://www.khronos.org/registry/egl/extensions/KHR/EGL_KHR_create_context.txt

"The default value of EGL_CONTEXT_FLAGS_KHR is zero"

So this should keep it at 0 if debug=false, and set it to EGL_CONTEXT_OPENGL_DEBUG_BIT_KHR if debug=true

Fixes https://github.com/libretro/RetroArch/issues/3910