### PR TITLE
Sort all msg_hash_{LANG}.c 

### DIFF
--- a/intl/msg_hash_chs.c
+++ b/intl/msg_hash_chs.c
@@ -1866,156 +1866,484 @@ static const char *menu_hash_to_str_chs_label_enum(enum msg_hash_enums msg)
 
    switch (msg)
    {
-      case MENU_ENUM_SUBLABEL_VIDEO_THREADED:
-         return "以延迟和视频撕裂为代价换取高性能，当且仅当能达到全速模拟时使用。";
-      case MENU_ENUM_SUBLABEL_VIDEO_HARD_SYNC:
-         return "强制同步CPU和GPU，以性能为代价换取低延迟。";
-      case MENU_ENUM_SUBLABEL_MENU_SETTINGS:
-         return "调整菜单屏幕相关的设置。";
-      case MSG_CONNECTION_SLOT:
-         return "Connection slot";
-      case MSG_WAITING_FOR_CLIENT:
-         return "Waiting for client ...";
-      case MSG_CONNECTING_TO_NETPLAY_HOST:
-         return "Connecting to netplay host";
-      case MSG_GOT_CONNECTION_FROM:
-         return "Got connection from";
-      case MSG_AUTODETECT:
-         return "自动检测";
-      case MSG_SUCCEEDED:
-         return "已成功";
-      case MSG_FAILED:
-         return "已失败";
-      case MSG_UNKNOWN_NETPLAY_COMMAND_RECEIVED:
-         return "Unknown netplay command received";
-      case MSG_NETPLAY_USERS_HAS_FLIPPED:
-         return "Netplay users has flipped";
-      case MSG_FILE_ALREADY_EXISTS_SAVING_TO_BACKUP_BUFFER:
-         return "File already exists. Saving to backup buffer";
-      case MSG_AUTOLOADING_SAVESTATE_FROM:
-         return "Auto-loading savestate from";
-      case MSG_CONNECTING_TO_PORT:
-         return "Connecting to port";
-      case MSG_SETTING_DISK_IN_TRAY:
-         return "Setting disk in tray";
-      case MSG_AUDIO_VOLUME:
-         return "Audio volume";
-      case MSG_FAILED_TO_SET_DISK:
-         return "Failed to set disk";
-      case MSG_FAILED_TO_START_AUDIO_DRIVER:
-         return "failed_to_start_audio_driver";
-      case MSG_FOUND_LAST_STATE_SLOT:
-         return "found_last_state_slot";
-      case MSG_DEVICE_CONFIGURED_IN_PORT:
-         return "configured in port";
-      case MSG_DEVICE_NOT_CONFIGURED:
-         return "not configured";
-      case MSG_DEVICE_DISCONNECTED_FROM_PORT:
-        return "Device disconnected from port";
-      case MSG_CONNECT_DEVICE_FROM_A_VALID_PORT:
-         return "connect_device_from_a_valid_port";
-      case MSG_DISCONNECT_DEVICE_FROM_A_VALID_PORT:
-         return "disconnect_device_from_a_valid_port";
-      case MSG_DISCONNECTING_DEVICE_FROM_PORT:
-         return "disconnecting_device_from_port";
-      case MSG_BRINGING_UP_COMMAND_INTERFACE_ON_PORT:
-         return "bringing_up_command_interface_at_port";
-      case MENU_ENUM_LABEL_VIDEO_MAX_SWAPCHAIN_IMAGES:
-         return "video_max_swapchain_images";
-      case MENU_ENUM_LABEL_CORE_SETTINGS:
-         return "core_settings";
-      case MENU_ENUM_LABEL_CB_MENU_WALLPAPER:
-         return "cb_menu_wallpaper";
-      case MENU_ENUM_LABEL_CB_MENU_THUMBNAIL:
-         return "cb_menu_thumbnail";
-      case MENU_ENUM_LABEL_CB_LAKKA_LIST:
-         return "cb_lakka_list";
-      case MENU_ENUM_LABEL_CB_THUMBNAILS_UPDATER_LIST:
-         return "cb_thumbnails_updater_list";
-      case MENU_ENUM_LABEL_CB_CORE_UPDATER_LIST:
-         return "cb_core_updater_list";
-      case MENU_ENUM_LABEL_CB_CORE_CONTENT_LIST:
-         return "cb_core_content_list";
+      case MENU_ENUM_LABEL_ACCOUNTS_CHEEVOS_USERNAME:
+         return "accounts_cheevos_username";
+      case MENU_ENUM_LABEL_ACCOUNTS_LIST:
+         return "accounts_list";
+      case MENU_ENUM_LABEL_ACCOUNTS_RETRO_ACHIEVEMENTS:
+         return "retro_achievements";
+      case MENU_ENUM_LABEL_ACHIEVEMENT_LIST:
+         return "achievement_list";
+      case MENU_ENUM_LABEL_ADD_CONTENT_LIST:
+         return "add_content";
+      case MENU_ENUM_LABEL_ADD_TAB:
+         return "add_tab";
+      case MENU_ENUM_LABEL_ARCHIVE_MODE:
+         return "archive_mode";
+      case MENU_ENUM_LABEL_ASSETS_DIRECTORY:
+         return "assets_directory";
+      case MENU_ENUM_LABEL_AUDIO_BLOCK_FRAMES:
+         return "audio_block_frames";
+      case MENU_ENUM_LABEL_AUDIO_DEVICE:
+         return "audio_device";
+      case MENU_ENUM_LABEL_AUDIO_DRIVER:
+         return "audio_driver";
+      case MENU_ENUM_LABEL_AUDIO_DSP_PLUGIN:
+         return "audio_dsp_plugin";
+      case MENU_ENUM_LABEL_AUDIO_ENABLE:
+         return "audio_enable";
+      case MENU_ENUM_LABEL_AUDIO_FILTER_DIR:
+         return "audio_filter_dir";
+      case MENU_ENUM_LABEL_AUDIO_LATENCY:
+         return "audio_latency";
+      case MENU_ENUM_LABEL_AUDIO_MAX_TIMING_SKEW:
+         return "audio_max_timing_skew";
+      case MENU_ENUM_LABEL_AUDIO_MUTE:
+         return "audio_mute_enable";
+      case MENU_ENUM_LABEL_AUDIO_OUTPUT_RATE:
+         return "audio_output_rate";
+      case MENU_ENUM_LABEL_AUDIO_RATE_CONTROL_DELTA:
+         return "audio_rate_control_delta";
+      case MENU_ENUM_LABEL_AUDIO_RESAMPLER_DRIVER:
+         return "audio_resampler_driver";
+      case MENU_ENUM_LABEL_AUDIO_SETTINGS:
+         return "audio_settings";
+      case MENU_ENUM_LABEL_AUDIO_SYNC:
+         return "audio_sync";
+      case MENU_ENUM_LABEL_AUDIO_VOLUME:
+         return "audio_volume";
+      case MENU_ENUM_LABEL_AUTOSAVE_INTERVAL:
+         return "autosave_interval";
+      case MENU_ENUM_LABEL_AUTO_OVERRIDES_ENABLE:
+         return "auto_overrides_enable";
+      case MENU_ENUM_LABEL_AUTO_REMAPS_ENABLE:
+         return "auto_remaps_enable";
+      case MENU_ENUM_LABEL_AUTO_SHADERS_ENABLE:
+         return "auto_shaders_enable";
+      case MENU_ENUM_LABEL_BLOCK_SRAM_OVERWRITE:
+         return "block_sram_overwrite";
+      case MENU_ENUM_LABEL_BLUETOOTH_ENABLE:
+         return "bluetooth_enable";
+      case MENU_ENUM_LABEL_BUILDBOT_ASSETS_URL:
+         return "buildbot_assets_url";
+      case MENU_ENUM_LABEL_CACHE_DIRECTORY:
+         return "cache_directory";
+      case MENU_ENUM_LABEL_CAMERA_ALLOW:
+         return "camera_allow";
+      case MENU_ENUM_LABEL_CAMERA_DRIVER:
+         return "camera_driver";
       case MENU_ENUM_LABEL_CB_CORE_CONTENT_DIRS_LIST:
          return "cb_core_content_dirs_list";
+      case MENU_ENUM_LABEL_CB_CORE_CONTENT_DOWNLOAD:
+         return "cb_core_content_download";
+      case MENU_ENUM_LABEL_CB_CORE_CONTENT_LIST:
+         return "cb_core_content_list";
       case MENU_ENUM_LABEL_CB_CORE_THUMBNAILS_DOWNLOAD:
          return "cb_core_thumbnails_download";
       case MENU_ENUM_LABEL_CB_CORE_UPDATER_DOWNLOAD:
          return "cb_core_updater_download";
-      case MENU_ENUM_LABEL_CB_UPDATE_CHEATS:
-         return "cb_update_cheats";
-      case MENU_ENUM_LABEL_CB_UPDATE_OVERLAYS:
-         return "cb_update_overlays";
-      case MENU_ENUM_LABEL_CB_UPDATE_DATABASES:
-         return "cb_update_databases";
-      case MENU_ENUM_LABEL_CB_UPDATE_SHADERS_GLSL:
-         return "cb_update_shaders_glsl";
-      case MENU_ENUM_LABEL_CB_UPDATE_SHADERS_CG:
-         return "cb_update_shaders_cg";
-      case MENU_ENUM_LABEL_CB_UPDATE_CORE_INFO_FILES:
-         return "cb_update_core_info_files";
-      case MENU_ENUM_LABEL_CB_CORE_CONTENT_DOWNLOAD:
-         return "cb_core_content_download";
+      case MENU_ENUM_LABEL_CB_CORE_UPDATER_LIST:
+         return "cb_core_updater_list";
+      case MENU_ENUM_LABEL_CB_DOWNLOAD_URL:
+         return "cb_download_url";
       case MENU_ENUM_LABEL_CB_LAKKA_DOWNLOAD:
          return "cb_lakka_download";
+      case MENU_ENUM_LABEL_CB_LAKKA_LIST:
+         return "cb_lakka_list";
+      case MENU_ENUM_LABEL_CB_MENU_THUMBNAIL:
+         return "cb_menu_thumbnail";
+      case MENU_ENUM_LABEL_CB_MENU_WALLPAPER:
+         return "cb_menu_wallpaper";
+      case MENU_ENUM_LABEL_CB_THUMBNAILS_UPDATER_DOWNLOAD:
+         return "cb_thumbnails_updater_download";
+      case MENU_ENUM_LABEL_CB_THUMBNAILS_UPDATER_LIST:
+         return "cb_thumbnails_updater_list";
       case MENU_ENUM_LABEL_CB_UPDATE_ASSETS:
          return "cb_update_assets";
       case MENU_ENUM_LABEL_CB_UPDATE_AUTOCONFIG_PROFILES:
          return "cb_update_autoconfig_profiles";
-      case MENU_ENUM_LABEL_CB_THUMBNAILS_UPDATER_DOWNLOAD:
-         return "cb_thumbnails_updater_download";
+      case MENU_ENUM_LABEL_CB_UPDATE_CHEATS:
+         return "cb_update_cheats";
+      case MENU_ENUM_LABEL_CB_UPDATE_CORE_INFO_FILES:
+         return "cb_update_core_info_files";
+      case MENU_ENUM_LABEL_CB_UPDATE_DATABASES:
+         return "cb_update_databases";
+      case MENU_ENUM_LABEL_CB_UPDATE_OVERLAYS:
+         return "cb_update_overlays";
+      case MENU_ENUM_LABEL_CB_UPDATE_SHADERS_CG:
+         return "cb_update_shaders_cg";
+      case MENU_ENUM_LABEL_CB_UPDATE_SHADERS_GLSL:
+         return "cb_update_shaders_glsl";
+      case MENU_ENUM_LABEL_CHEAT_APPLY_CHANGES:
+         return "cheat_apply_changes";
+      case MENU_ENUM_LABEL_CHEAT_DATABASE_PATH:
+         return "cheat_database_path";
+      case MENU_ENUM_LABEL_CHEAT_FILE_LOAD:
+         return "cheat_file_load";
+      case MENU_ENUM_LABEL_CHEAT_FILE_SAVE_AS:
+         return "cheat_file_save_as";
+      case MENU_ENUM_LABEL_CHEAT_NUM_PASSES:
+         return "cheat_num_passes";
+      case MENU_ENUM_LABEL_CHEEVOS_DESCRIPTION:
+         return "cheevos_description";
+      case MENU_ENUM_LABEL_CHEEVOS_ENABLE:
+         return "cheevos_enable";
+      case MENU_ENUM_LABEL_CHEEVOS_HARDCORE_MODE_ENABLE:
+         return "cheevos_hardcore_mode_enable";
+      case MENU_ENUM_LABEL_CHEEVOS_LOCKED_ACHIEVEMENTS:
+         return "cheevos_locked_achievements";
+      case MENU_ENUM_LABEL_CHEEVOS_LOCKED_ENTRY:
+         return "cheevos_locked_entry";
+      case MENU_ENUM_LABEL_CHEEVOS_PASSWORD:
+         return "cheevos_password";
+      case MENU_ENUM_LABEL_CHEEVOS_TEST_UNOFFICIAL:
+         return "cheevos_test_unofficial";
+      case MENU_ENUM_LABEL_CHEEVOS_UNLOCKED_ACHIEVEMENTS:
+         return "cheevos_unlocked_achievements";
+      case MENU_ENUM_LABEL_CHEEVOS_UNLOCKED_ENTRY:
+         return "cheevos_unlocked_entry";
+      case MENU_ENUM_LABEL_CHEEVOS_USERNAME:
+         return "cheevos_username";
+      case MENU_ENUM_LABEL_CLOSE_CONTENT:
+         return "unload_core";
+      case MENU_ENUM_LABEL_COLLECTION:
+         return "collection";
+      case MENU_ENUM_LABEL_CONFIGURATIONS:
+         return "configurations";
+      case MENU_ENUM_LABEL_CONFIGURATION_SETTINGS:
+         return "configuration_settings";
+      case MENU_ENUM_LABEL_CONFIG_SAVE_ON_EXIT:
+         return "config_save_on_exit";
+      case MENU_ENUM_LABEL_CONFIRM_ON_EXIT:
+         return "confirm_on_exit";
+      case MENU_ENUM_LABEL_CONNECT_WIFI:
+         return "connect_wifi";
       case MENU_ENUM_LABEL_CONTENT_ACTIONS:
          return "content_actions";
+      case MENU_ENUM_LABEL_CONTENT_COLLECTION_LIST:
+         return "select_from_collection";
+      case MENU_ENUM_LABEL_CONTENT_DATABASE_DIRECTORY:
+         return "content_database_path";
+      case MENU_ENUM_LABEL_CONTENT_HISTORY_SIZE:
+         return "content_history_size";
+      case MENU_ENUM_LABEL_CONTENT_SETTINGS:
+         return "quick_menu";
+      case MENU_ENUM_LABEL_CORE_ASSETS_DIRECTORY:
+         return "core_assets_directory";
+      case MENU_ENUM_LABEL_CORE_CHEAT_OPTIONS:
+         return "core_cheat_options";
+      case MENU_ENUM_LABEL_CORE_COUNTERS:
+         return "core_counters";
+      case MENU_ENUM_LABEL_CORE_ENABLE:
+         return "menu_core_enable";
+      case MENU_ENUM_LABEL_CORE_INFORMATION:
+         return "core_information";
+      case MENU_ENUM_LABEL_CORE_INFO_ENTRY:
+         return "core_info_entry";
+      case MENU_ENUM_LABEL_CORE_INPUT_REMAPPING_OPTIONS:
+         return "core_input_remapping_options";
+      case MENU_ENUM_LABEL_CORE_LIST:
+         return "load_core";
+      case MENU_ENUM_LABEL_CORE_OPTIONS:
+         return "core_options";
+      case MENU_ENUM_LABEL_CORE_OPTION_ENTRY:
+         return "core_option_entry";
+      case MENU_ENUM_LABEL_CORE_SETTINGS:
+         return "core_settings";
+      case MENU_ENUM_LABEL_CORE_SET_SUPPORTS_NO_CONTENT_ENABLE:
+         return "core_set_supports_no_content_enable";
+      case MENU_ENUM_LABEL_CORE_SPECIFIC_CONFIG:
+         return "core_specific_config";
+      case MENU_ENUM_LABEL_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
+         return "core_updater_auto_extract_archive";
+      case MENU_ENUM_LABEL_CORE_UPDATER_BUILDBOT_URL:
+         return "core_updater_buildbot_url";
+      case MENU_ENUM_LABEL_CORE_UPDATER_LIST:
+         return "core_updater_list";
       case MENU_ENUM_LABEL_CPU_ARCHITECTURE:
          return "system_information_cpu_architecture";
       case MENU_ENUM_LABEL_CPU_CORES:
          return "system_information_cpu_cores";
-      case MENU_ENUM_LABEL_NO_ITEMS:
-         return "no_items";
-      case MENU_ENUM_LABEL_NO_PLAYLISTS:
-         return "no_playlists";
-      case MENU_ENUM_LABEL_NO_HISTORY_AVAILABLE:
-         return "no_history";
-      case MENU_ENUM_LABEL_NO_SHADER_PARAMETERS:
-         return "no_shader_parameters.";
-      case MENU_ENUM_LABEL_SETTINGS_TAB:
-         return "settings_tab";
+      case MENU_ENUM_LABEL_CURSOR_DIRECTORY:
+         return "cursor_directory";
+      case MENU_ENUM_LABEL_CURSOR_MANAGER_LIST:
+         return "cursor_manager_list";
+      case MENU_ENUM_LABEL_CUSTOM_BIND:
+         return "custom_bind";
+      case MENU_ENUM_LABEL_CUSTOM_BIND_ALL:
+         return "custom_bind_all";
+      case MENU_ENUM_LABEL_CUSTOM_RATIO:
+         return "custom_ratio";
+      case MENU_ENUM_LABEL_DATABASE_MANAGER_LIST:
+         return "database_manager_list";
+      case MENU_ENUM_LABEL_DEFERRED_ACCOUNTS_CHEEVOS_LIST:
+         return "deferred_accounts_cheevos_list";
+      case MENU_ENUM_LABEL_DEFERRED_ACCOUNTS_LIST:
+         return "deferred_accounts_list";
+      case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_ACTION:
+         return "deferred_archive_action";
+      case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_ACTION_DETECT_CORE:
+         return "deferred_archive_action_detect_core";
+      case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_OPEN:
+         return "deferred_archive_open";
+      case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_OPEN_DETECT_CORE:
+         return "deferred_archive_open_detect_core";
+      case MENU_ENUM_LABEL_DEFERRED_AUDIO_SETTINGS_LIST:
+         return "deferred_audio_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_CONFIGURATION_SETTINGS_LIST:
+         return "deferred_configuration_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_CORE_CONTENT_DIRS_LIST:
+         return "deferred_core_content_dirs_list";
+      case MENU_ENUM_LABEL_DEFERRED_CORE_CONTENT_DIRS_SUBDIR_LIST:
+         return "deferred_core_content_dirs_subdir_list";
+      case MENU_ENUM_LABEL_DEFERRED_CORE_CONTENT_LIST:
+         return "deferred_core_content_list";
+      case MENU_ENUM_LABEL_DEFERRED_CORE_LIST:
+         return "deferred_core_list";
+      case MENU_ENUM_LABEL_DEFERRED_CORE_LIST_SET:
+         return "deferred_core_list_set";
+      case MENU_ENUM_LABEL_DEFERRED_CORE_SETTINGS_LIST:
+         return "deferred_core_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_CORE_UPDATER_LIST:
+         return "core_updater";
+      case MENU_ENUM_LABEL_DEFERRED_CURSOR_MANAGER_LIST:
+         return "deferred_cursor_manager_list";
+      case MENU_ENUM_LABEL_DEFERRED_DATABASE_MANAGER_LIST:
+         return "deferred_database_manager_list";
+      case MENU_ENUM_LABEL_DEFERRED_DIRECTORY_SETTINGS_LIST:
+         return "deferred_directory_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_DRIVER_SETTINGS_LIST:
+         return "deferred_driver_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_FRAME_THROTTLE_SETTINGS_LIST:
+         return "deferred_frame_throttle_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_INPUT_HOTKEY_BINDS_LIST:
+         return "deferred_input_hotkey_binds";
+      case MENU_ENUM_LABEL_DEFERRED_INPUT_SETTINGS_LIST:
+         return "deferred_input_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_LAKKA_LIST:
+         return "deferred_lakka_list";
+      case MENU_ENUM_LABEL_DEFERRED_LAKKA_SERVICES_LIST:
+         return "deferred_lakka_services_list";
+      case MENU_ENUM_LABEL_DEFERRED_LOGGING_SETTINGS_LIST:
+         return "deferred_logging_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_MENU_FILE_BROWSER_SETTINGS_LIST:
+         return "deferred_menu_file_browser_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_MENU_SETTINGS_LIST:
+         return "deferred_menu_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_NETWORK_SETTINGS_LIST:
+         return "deferred_network_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_ONSCREEN_DISPLAY_SETTINGS_LIST:
+         return "deferred_onscreen_display_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_ONSCREEN_OVERLAY_SETTINGS_LIST:
+         return "deferred_onscreen_overlay_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_PLAYLIST_SETTINGS_LIST:
+         return "deferred_playlist_settings";
+      case MENU_ENUM_LABEL_DEFERRED_PRIVACY_SETTINGS_LIST:
+         return "deferred_privacy_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_RDB_ENTRY_DETAIL:
+         return "deferred_rdb_entry_detail";
+      case MENU_ENUM_LABEL_DEFERRED_RECORDING_SETTINGS_LIST:
+         return "deferred_recording_settings";
+      case MENU_ENUM_LABEL_DEFERRED_RETRO_ACHIEVEMENTS_SETTINGS_LIST:
+         return "deferred_retro_achievements_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_REWIND_SETTINGS_LIST:
+         return "deferred_rewind_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_SAVING_SETTINGS_LIST:
+         return "deferred_saving_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_THUMBNAILS_UPDATER_LIST:
+         return "deferred_thumbnails_updater_list";
+      case MENU_ENUM_LABEL_DEFERRED_UPDATER_SETTINGS_LIST:
+         return "deferred_updater_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_USER_BINDS_LIST:
+         return "deferred_user_binds_list";
+      case MENU_ENUM_LABEL_DEFERRED_USER_INTERFACE_SETTINGS_LIST:
+         return "deferred_user_interface_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_USER_SETTINGS_LIST:
+         return "deferred_user_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_VIDEO_FILTER:
+         return "deferred_video_filter";
+      case MENU_ENUM_LABEL_DEFERRED_VIDEO_SETTINGS_LIST:
+         return "deferred_video_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_WIFI_SETTINGS_LIST:
+         return "deferred_wifi_settings_list";
+      case MENU_ENUM_LABEL_DELETE_ENTRY:
+         return "delete_entry";
+      case MENU_ENUM_LABEL_DETECT_CORE_LIST:
+         return "detect_core_list";
+      case MENU_ENUM_LABEL_DIRECTORY_SETTINGS:
+         return "directory_settings";
+      case MENU_ENUM_LABEL_DISK_CYCLE_TRAY_STATUS:
+         return "disk_cycle_tray_status";
+      case MENU_ENUM_LABEL_DISK_IMAGE_APPEND:
+         return "disk_image_append";
+      case MENU_ENUM_LABEL_DISK_OPTIONS:
+         return "core_disk_options";
+      case MENU_ENUM_LABEL_DOWNLOADED_FILE_DETECT_CORE_LIST:
+         return "downloaded_file_detect_core_list";
+      case MENU_ENUM_LABEL_DOWNLOAD_CORE_CONTENT:
+         return "download_core_content";
+      case MENU_ENUM_LABEL_DOWNLOAD_CORE_CONTENT_DIRS:
+         return "download_core_content_dirs";
+      case MENU_ENUM_LABEL_DPI_OVERRIDE_ENABLE:
+         return "dpi_override_enable";
+      case MENU_ENUM_LABEL_DPI_OVERRIDE_VALUE:
+         return "dpi_override_value";
+      case MENU_ENUM_LABEL_DRIVER_SETTINGS:
+         return "driver_settings";
+      case MENU_ENUM_LABEL_DUMMY_ON_CORE_SHUTDOWN:
+         return "dummy_on_core_shutdown";
+      case MENU_ENUM_LABEL_DYNAMIC_WALLPAPER:
+         return "menu_dynamic_wallpaper_enable";
+      case MENU_ENUM_LABEL_DYNAMIC_WALLPAPERS_DIRECTORY:
+         return "dynamic_wallpapers_directory";
+      case MENU_ENUM_LABEL_ENTRY_HOVER_COLOR:
+         return "menu_entry_hover_color";
+      case MENU_ENUM_LABEL_ENTRY_NORMAL_COLOR:
+         return "menu_entry_normal_color";
+      case MENU_ENUM_LABEL_FASTFORWARD_RATIO:
+         return "fastforward_ratio";
+      case MENU_ENUM_LABEL_FILE_BROWSER_CORE:
+         return "file_browser_core";
+      case MENU_ENUM_LABEL_FILE_BROWSER_CORE_DETECTED:
+         return "file_browser_core_detected";
+      case MENU_ENUM_LABEL_FILE_BROWSER_CORE_SELECT_FROM_COLLECTION:
+         return "file_browser_core_select_from_collection";
+      case MENU_ENUM_LABEL_FILE_BROWSER_DIRECTORY:
+         return "file_browser_directory";
+      case MENU_ENUM_LABEL_FILE_BROWSER_IMAGE:
+         return "file_browser_image";
+      case MENU_ENUM_LABEL_FILE_BROWSER_IMAGE_OPEN_WITH_VIEWER:
+         return "file_browser_image_open_with_viewer";
+      case MENU_ENUM_LABEL_FILE_BROWSER_MOVIE_OPEN:
+         return "file_browser_movie_open";
+      case MENU_ENUM_LABEL_FILE_BROWSER_MUSIC_OPEN:
+         return "file_browser_music_open";
+      case MENU_ENUM_LABEL_FILE_BROWSER_PLAIN_FILE:
+         return "file_browser_plain_file";
+      case MENU_ENUM_LABEL_FILE_BROWSER_REMAP:
+         return "file_browser_remap";
+      case MENU_ENUM_LABEL_FILE_BROWSER_SHADER:
+         return "file_browser_shader";
+      case MENU_ENUM_LABEL_FILE_BROWSER_SHADER_PRESET:
+         return "file_browser_shader_preset";
+      case MENU_ENUM_LABEL_FPS_SHOW:
+         return "fps_show";
+      case MENU_ENUM_LABEL_FRAME_THROTTLE_ENABLE:
+         return "fastforward_ratio_throttle_enable";
+      case MENU_ENUM_LABEL_FRAME_THROTTLE_SETTINGS:
+         return "frame_throttle_settings";
+      case MENU_ENUM_LABEL_FRONTEND_COUNTERS:
+         return "frontend_counters";
+      case MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS:
+         return "game_specific_options";
+      case MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS_CREATE:
+         return "game_specific_options_create";
+      case MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS_IN_USE:
+         return "game_specific_options_in_use";
+      case MENU_ENUM_LABEL_HELP:
+         return "help";
+      case MENU_ENUM_LABEL_HELP_AUDIO_VIDEO_TROUBLESHOOTING:
+         return "help_audio_video_troubleshooting";
+      case MENU_ENUM_LABEL_HELP_CHANGE_VIRTUAL_GAMEPAD:
+         return "help_change_virtual_gamepad";
+      case MENU_ENUM_LABEL_HELP_CONTROLS:
+         return "help_controls";
+      case MENU_ENUM_LABEL_HELP_LIST:
+         return "help_list";
+      case MENU_ENUM_LABEL_HELP_LOADING_CONTENT:
+         return "help_loading_content";
+      case MENU_ENUM_LABEL_HELP_SCANNING_CONTENT:
+         return "help_scanning_content";
+      case MENU_ENUM_LABEL_HELP_WHAT_IS_A_CORE:
+         return "help_what_is_a_core";
+      case MENU_ENUM_LABEL_HISTORY_LIST_ENABLE:
+         return "history_list_enable";
       case MENU_ENUM_LABEL_HISTORY_TAB:
          return "history_tab";
-      case MENU_ENUM_LABEL_ADD_TAB:
-         return "add_tab";
-      case MENU_ENUM_LABEL_PLAYLISTS_TAB:
-         return "playlists_tab";
-      case MENU_ENUM_LABEL_MUSIC_TAB:
-         return "music_tab";
-      case MENU_ENUM_LABEL_VIDEO_TAB:
-         return "video_tab";
-      case MENU_ENUM_LABEL_IMAGES_TAB:
-         return "images_tab";
       case MENU_ENUM_LABEL_HORIZONTAL_MENU:
          return "horizontal_menu";
-      case MENU_ENUM_LABEL_PARENT_DIRECTORY:
-         return "parent_directory";
-      case MENU_ENUM_LABEL_INPUT_PLAYER_ANALOG_DPAD_MODE:
-         return "input_player%u_analog_dpad_mode";
+      case MENU_ENUM_LABEL_IMAGES_TAB:
+         return "images_tab";
+      case MENU_ENUM_LABEL_INFORMATION:
+         return "information";
+      case MENU_ENUM_LABEL_INFORMATION_LIST:
+         return "information_list";
+      case MENU_ENUM_LABEL_INFO_SCREEN:
+         return "info_screen";
+      case MENU_ENUM_LABEL_INPUT_ALL_USERS_CONTROL_MENU:
+         return "all_users_control_menu";
+      case MENU_ENUM_LABEL_INPUT_AUTODETECT_ENABLE:
+         return "input_autodetect_enable";
+      case MENU_ENUM_LABEL_INPUT_AXIS_THRESHOLD:
+         return "input_axis_threshold";
+      case MENU_ENUM_LABEL_INPUT_BACK_AS_MENU_ENUM_TOGGLE_ENABLE:
+         return "back_as_menu_toggle_enable";
+      case MENU_ENUM_LABEL_INPUT_BIND_MODE:
+         return "input_bind_mode";
+      case MENU_ENUM_LABEL_INPUT_BIND_TIMEOUT:
+         return "input_bind_timeout";
+      case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_HIDE_UNBOUND:
+         return "input_descriptor_hide_unbound";
+      case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_LABEL_SHOW:
+         return "input_descriptor_label_show";
+      case MENU_ENUM_LABEL_INPUT_DRIVER:
+         return "input_driver";
+      case MENU_ENUM_LABEL_INPUT_DUTY_CYCLE:
+         return "input_duty_cycle";
+      case MENU_ENUM_LABEL_INPUT_HOTKEY_BINDS:
+         return "input_hotkey_binds";
+      case MENU_ENUM_LABEL_INPUT_HOTKEY_BINDS_BEGIN:
+         return "input_hotkey_binds_begin";
+      case MENU_ENUM_LABEL_INPUT_ICADE_ENABLE:
+         return "input_icade_enable";
+      case MENU_ENUM_LABEL_INPUT_KEYBOARD_GAMEPAD_MAPPING_TYPE:
+         return "keyboard_gamepad_mapping_type";
       case MENU_ENUM_LABEL_INPUT_LIBRETRO_DEVICE:
          return "input_libretro_device_p%u";
-      case MENU_ENUM_LABEL_RUN:
-         return "collection";
-      case MENU_ENUM_LABEL_PLAYLIST_COLLECTION_ENTRY:
-         return "playlist_collection_entry";
-      case MENU_ENUM_LABEL_CHEEVOS_LOCKED_ENTRY:
-         return "cheevos_locked_entry";
-      case MENU_ENUM_LABEL_CHEEVOS_UNLOCKED_ENTRY:
-         return "cheevos_unlocked_entry";
-      case MENU_ENUM_LABEL_CORE_INFO_ENTRY:
-         return "core_info_entry";
-      case MENU_ENUM_LABEL_NETWORK_INFO_ENTRY:
-         return "network_info_entry";
-      case MENU_ENUM_LABEL_PLAYLIST_ENTRY:
-         return "playlist_entry";
-      case MENU_ENUM_LABEL_SYSTEM_INFO_ENTRY:
-         return "system_info_entry";
+      case MENU_ENUM_LABEL_INPUT_MAX_USERS:
+         return "input_max_users";
+      case MENU_ENUM_LABEL_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
+         return "input_menu_toggle_gamepad_combo";
+      case MENU_ENUM_LABEL_INPUT_OSK_OVERLAY_ENABLE:
+         return "input_osk_overlay_enable";
+      case MENU_ENUM_LABEL_INPUT_OVERLAY_ENABLE:
+         return "input_overlay_enable";
+      case MENU_ENUM_LABEL_INPUT_OVERLAY_HIDE_IN_MENU:
+         return "overlay_hide_in_menu";
+      case MENU_ENUM_LABEL_INPUT_PLAYER_ANALOG_DPAD_MODE:
+         return "input_player%u_analog_dpad_mode";
+      case MENU_ENUM_LABEL_INPUT_POLL_TYPE_BEHAVIOR:
+         return "input_poll_type_behavior";
+      case MENU_ENUM_LABEL_INPUT_PREFER_FRONT_TOUCH:
+         return "input_prefer_front_touch";
+      case MENU_ENUM_LABEL_INPUT_REMAPPING_DIRECTORY:
+         return "input_remapping_directory";
+      case MENU_ENUM_LABEL_INPUT_REMAP_BINDS_ENABLE:
+         return "input_remap_binds_enable";
+      case MENU_ENUM_LABEL_INPUT_SETTINGS:
+         return "input_settings";
+      case MENU_ENUM_LABEL_INPUT_SETTINGS_BEGIN:
+         return "input_settings_begin";
+      case MENU_ENUM_LABEL_INPUT_SMALL_KEYBOARD_ENABLE:
+         return "input_small_keyboard_enable";
+      case MENU_ENUM_LABEL_INPUT_TOUCH_ENABLE:
+         return "input_touch_enable";
+      case MENU_ENUM_LABEL_INPUT_TURBO_PERIOD:
+         return "input_turbo_period";
+      case MENU_ENUM_LABEL_INPUT_USER_10_BINDS:
+         return "10_input_binds_list";
+      case MENU_ENUM_LABEL_INPUT_USER_11_BINDS:
+         return "11_input_binds_list";
+      case MENU_ENUM_LABEL_INPUT_USER_12_BINDS:
+         return "12_input_binds_list";
+      case MENU_ENUM_LABEL_INPUT_USER_13_BINDS:
+         return "13_input_binds_list";
+      case MENU_ENUM_LABEL_INPUT_USER_14_BINDS:
+         return "14_input_binds_list";
+      case MENU_ENUM_LABEL_INPUT_USER_15_BINDS:
+         return "15_input_binds_list";
+      case MENU_ENUM_LABEL_INPUT_USER_16_BINDS:
+         return "16_input_binds_list";
       case MENU_ENUM_LABEL_INPUT_USER_1_BINDS:
          return "1_input_binds_list";
       case MENU_ENUM_LABEL_INPUT_USER_2_BINDS:
@@ -2034,954 +2362,626 @@ static const char *menu_hash_to_str_chs_label_enum(enum msg_hash_enums msg)
          return "8_input_binds_list";
       case MENU_ENUM_LABEL_INPUT_USER_9_BINDS:
          return "9_input_binds_list";
-      case MENU_ENUM_LABEL_INPUT_USER_10_BINDS:
-         return "10_input_binds_list";
-      case MENU_ENUM_LABEL_INPUT_USER_11_BINDS:
-         return "11_input_binds_list";
-      case MENU_ENUM_LABEL_INPUT_USER_12_BINDS:
-         return "12_input_binds_list";
-      case MENU_ENUM_LABEL_INPUT_USER_13_BINDS:
-         return "13_input_binds_list";
-      case MENU_ENUM_LABEL_INPUT_USER_14_BINDS:
-         return "14_input_binds_list";
-      case MENU_ENUM_LABEL_INPUT_USER_15_BINDS:
-         return "15_input_binds_list";
-      case MENU_ENUM_LABEL_INPUT_USER_16_BINDS:
-         return "16_input_binds_list";
-      case MENU_ENUM_LABEL_VIDEO_VIEWPORT_CUSTOM_X:
-         return "video_viewport_custom_x";
-      case MENU_ENUM_LABEL_VIDEO_VIEWPORT_CUSTOM_Y:
-         return "video_viewport_custom_y";
-      case MENU_ENUM_LABEL_VIDEO_VIEWPORT_CUSTOM_WIDTH:
-         return "video_viewport_custom_width";
-      case MENU_ENUM_LABEL_VIDEO_VIEWPORT_CUSTOM_HEIGHT:
-         return "video_viewport_custom_height";
-      case MENU_ENUM_LABEL_NO_CORES_AVAILABLE:
-         return "no_cores_available";
-      case MENU_ENUM_LABEL_NO_CORE_OPTIONS_AVAILABLE:
-         return "no_core_options_available";
-      case MENU_ENUM_LABEL_NO_CORE_INFORMATION_AVAILABLE:
-         return "no_core_information_available";
-      case MENU_ENUM_LABEL_CORE_OPTION_ENTRY:
-         return "core_option_entry";
-      case MENU_ENUM_LABEL_URL_ENTRY:
-         return "url_entry";
-      case MENU_ENUM_LABEL_NO_PERFORMANCE_COUNTERS:
-         return "no_performance_counters";
-      case MENU_ENUM_LABEL_NO_ENTRIES_TO_DISPLAY:
-         return "no_entries_to_display";
-      case MENU_ENUM_LABEL_NO_ACHIEVEMENTS_TO_DISPLAY:
-         return "no_achievements_to_display";
-      case MENU_ENUM_LABEL_CHEEVOS_UNLOCKED_ACHIEVEMENTS:
-         return "cheevos_unlocked_achievements";
-      case MENU_ENUM_LABEL_CHEEVOS_LOCKED_ACHIEVEMENTS:
-         return "cheevos_locked_achievements";
+      case MENU_ENUM_LABEL_JOYPAD_AUTOCONFIG_DIR:
+         return "joypad_autoconfig_dir";
+      case MENU_ENUM_LABEL_JOYPAD_DRIVER:
+         return "input_joypad_driver";
+      case MENU_ENUM_LABEL_KEYBOARD_OVERLAY_PRESET:
+         return "input_osk_overlay";
+      case MENU_ENUM_LABEL_LAKKA_SERVICES:
+         return "lakka_services";
+      case MENU_ENUM_LABEL_LIBRETRO_DIR_PATH:
+         return "libretro_dir_path";
+      case MENU_ENUM_LABEL_LIBRETRO_INFO_PATH:
+         return "libretro_info_path";
+      case MENU_ENUM_LABEL_LIBRETRO_LOG_LEVEL:
+         return "libretro_log_level";
+      case MENU_ENUM_LABEL_LOAD_ARCHIVE:
+         return "load_archive";
+      case MENU_ENUM_LABEL_LOAD_ARCHIVE_DETECT_CORE:
+         return "load_archive_detect_core";
+      case MENU_ENUM_LABEL_LOAD_CONTENT:
+         return "load_content_default";
+      case MENU_ENUM_LABEL_LOAD_CONTENT_HISTORY:
+         return "load_recent";
+      case MENU_ENUM_LABEL_LOAD_CONTENT_LIST:
+         return "load_content";
+      case MENU_ENUM_LABEL_LOAD_STATE:
+         return "loadstate";
+      case MENU_ENUM_LABEL_LOCATION_ALLOW:
+         return "location_allow";
+      case MENU_ENUM_LABEL_LOCATION_DRIVER:
+         return "location_driver";
+      case MENU_ENUM_LABEL_LOGGING_SETTINGS:
+         return "logging_settings";
+      case MENU_ENUM_LABEL_LOG_VERBOSITY:
+         return "log_verbosity";
       case MENU_ENUM_LABEL_MAIN_MENU:
          return "main_menu";
-      case MENU_ENUM_LABEL_MENU_LINEAR_FILTER:
-         return "menu_linear_filter";
+      case MENU_ENUM_LABEL_MANAGEMENT:
+         return "database_settings";
+      case MENU_ENUM_LABEL_MATERIALUI_MENU_COLOR_THEME:
+         return "materialui_menu_color_theme";
+      case MENU_ENUM_LABEL_MATERIALUI_MENU_FOOTER_OPACITY:
+         return "materialui_menu_footer_opacity";
+      case MENU_ENUM_LABEL_MATERIALUI_MENU_HEADER_OPACITY:
+         return "materialui_menu_header_opacity";
+      case MENU_ENUM_LABEL_MENU_DRIVER:
+         return "menu_driver";
       case MENU_ENUM_LABEL_MENU_ENUM_THROTTLE_FRAMERATE:
          return "menu_throttle_framerate";
-      case MENU_ENUM_LABEL_START_CORE:
-         return "start_core";
-      case MENU_ENUM_LABEL_CHEEVOS_HARDCORE_MODE_ENABLE:
-         return "cheevos_hardcore_mode_enable";
-      case MENU_ENUM_LABEL_CHEEVOS_TEST_UNOFFICIAL:
-         return "cheevos_test_unofficial";
-      case MENU_ENUM_LABEL_CHEEVOS_ENABLE:
-         return "cheevos_enable";
-      case MENU_ENUM_LABEL_INPUT_TOUCH_ENABLE:
-         return "input_touch_enable";
-      case MENU_ENUM_LABEL_INPUT_PREFER_FRONT_TOUCH:
-         return "input_prefer_front_touch";
-      case MENU_ENUM_LABEL_INPUT_ICADE_ENABLE:
-         return "input_icade_enable";
-      case MENU_ENUM_LABEL_INPUT_KEYBOARD_GAMEPAD_MAPPING_TYPE:
-         return "keyboard_gamepad_mapping_type";
-      case MENU_ENUM_LABEL_INPUT_SMALL_KEYBOARD_ENABLE:
-         return "input_small_keyboard_enable";
+      case MENU_ENUM_LABEL_MENU_FILE_BROWSER_SETTINGS:
+         return "menu_file_browser_settings";
+      case MENU_ENUM_LABEL_MENU_LINEAR_FILTER:
+         return "menu_linear_filter";
+      case MENU_ENUM_LABEL_MENU_SETTINGS:
+         return "menu_settings";
+      case MENU_ENUM_LABEL_MENU_WALLPAPER:
+         return "menu_wallpaper";
+      case MENU_ENUM_LABEL_MENU_WALLPAPER_OPACITY:
+         return "menu_wallpaper_opacity";
+      case MENU_ENUM_LABEL_MOUSE_ENABLE:
+         return "menu_mouse_enable";
+      case MENU_ENUM_LABEL_MUSIC_TAB:
+         return "music_tab";
+      case MENU_ENUM_LABEL_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
+         return "menu_navigation_browser_filter_supported_extensions_enable";
+      case MENU_ENUM_LABEL_NAVIGATION_WRAPAROUND:
+         return "menu_navigation_wraparound_enable";
+      case MENU_ENUM_LABEL_NETPLAY:
+         return "netplay";
+      case MENU_ENUM_LABEL_NETPLAY_CHECK_FRAMES:
+         return "netplay_check_frames";
+      case MENU_ENUM_LABEL_NETPLAY_CLIENT_SWAP_INPUT:
+         return "netplay_client_swap_input";
+      case MENU_ENUM_LABEL_NETPLAY_DELAY_FRAMES:
+         return "netplay_delay_frames";
+      case MENU_ENUM_LABEL_NETPLAY_DISCONNECT:
+         return "menu_netplay_disconnect";
+      case MENU_ENUM_LABEL_NETPLAY_ENABLE:
+         return "netplay_enable";
+      case MENU_ENUM_LABEL_NETPLAY_ENABLE_CLIENT:
+         return "menu_netplay_enable_client";
+      case MENU_ENUM_LABEL_NETPLAY_ENABLE_HOST:
+         return "menu_netplay_enable_host";
+      case MENU_ENUM_LABEL_NETPLAY_IP_ADDRESS:
+         return "netplay_ip_address";
+      case MENU_ENUM_LABEL_NETPLAY_MODE:
+         return "netplay_mode";
+      case MENU_ENUM_LABEL_NETPLAY_NICKNAME:
+         return "netplay_nickname";
+      case MENU_ENUM_LABEL_NETPLAY_SETTINGS:
+         return "menu_netplay_settings";
+      case MENU_ENUM_LABEL_NETPLAY_SPECTATOR_MODE_ENABLE:
+         return "netplay_spectator_mode_enable";
+      case MENU_ENUM_LABEL_NETPLAY_TCP_UDP_PORT:
+         return "netplay_tcp_udp_port";
+      case MENU_ENUM_LABEL_NETWORK_CMD_ENABLE:
+         return "network_cmd_enable";
+      case MENU_ENUM_LABEL_NETWORK_CMD_PORT:
+         return "network_cmd_port";
+      case MENU_ENUM_LABEL_NETWORK_INFORMATION:
+         return "network_information";
+      case MENU_ENUM_LABEL_NETWORK_INFO_ENTRY:
+         return "network_info_entry";
+      case MENU_ENUM_LABEL_NETWORK_REMOTE_ENABLE:
+         return "network_remote_enable";
+      case MENU_ENUM_LABEL_NETWORK_REMOTE_PORT:
+         return "network_remote_base_port";
+      case MENU_ENUM_LABEL_NETWORK_REMOTE_USER_1_ENABLE:
+         return "network_remote_user_1_enable";
+      case MENU_ENUM_LABEL_NETWORK_REMOTE_USER_LAST_ENABLE:
+         return "network_remote_user_last_enable";
+      case MENU_ENUM_LABEL_NETWORK_SETTINGS:
+         return "network_settings";
+      case MENU_ENUM_LABEL_NO_ACHIEVEMENTS_TO_DISPLAY:
+         return "no_achievements_to_display";
+      case MENU_ENUM_LABEL_NO_CORES_AVAILABLE:
+         return "no_cores_available";
+      case MENU_ENUM_LABEL_NO_CORE_INFORMATION_AVAILABLE:
+         return "no_core_information_available";
+      case MENU_ENUM_LABEL_NO_CORE_OPTIONS_AVAILABLE:
+         return "no_core_options_available";
+      case MENU_ENUM_LABEL_NO_ENTRIES_TO_DISPLAY:
+         return "no_entries_to_display";
+      case MENU_ENUM_LABEL_NO_HISTORY_AVAILABLE:
+         return "no_history";
+      case MENU_ENUM_LABEL_NO_ITEMS:
+         return "no_items";
+      case MENU_ENUM_LABEL_NO_PERFORMANCE_COUNTERS:
+         return "no_performance_counters";
+      case MENU_ENUM_LABEL_NO_PLAYLISTS:
+         return "no_playlists";
+      case MENU_ENUM_LABEL_NO_PLAYLIST_ENTRIES_AVAILABLE:
+         return "no_playlist_entries_available";
+      case MENU_ENUM_LABEL_NO_SETTINGS_FOUND:
+         return "menu_label_no_settings_found";
+      case MENU_ENUM_LABEL_NO_SHADER_PARAMETERS:
+         return "no_shader_parameters.";
+      case MENU_ENUM_LABEL_ONLINE_UPDATER:
+         return "online_updater";
+      case MENU_ENUM_LABEL_ONSCREEN_DISPLAY_SETTINGS:
+         return "onscreen_display_settings";
+      case MENU_ENUM_LABEL_ONSCREEN_OVERLAY_SETTINGS:
+         return "onscreen_overlay_settings";
+      case MENU_ENUM_LABEL_OPEN_ARCHIVE:
+         return "open_archive";
+      case MENU_ENUM_LABEL_OPEN_ARCHIVE_DETECT_CORE:
+         return "open_archive_detect_core";
+      case MENU_ENUM_LABEL_OSK_OVERLAY_DIRECTORY:
+         return "osk_overlay_directory";
+      case MENU_ENUM_LABEL_OVERLAY_AUTOLOAD_PREFERRED:
+         return "overlay_autoload_preferred";
+      case MENU_ENUM_LABEL_OVERLAY_DIRECTORY:
+         return "overlay_directory";
+      case MENU_ENUM_LABEL_OVERLAY_OPACITY:
+         return "input_overlay_opacity";
+      case MENU_ENUM_LABEL_OVERLAY_PRESET:
+         return "input_overlay";
+      case MENU_ENUM_LABEL_OVERLAY_SCALE:
+         return "input_overlay_scale";
+      case MENU_ENUM_LABEL_PAL60_ENABLE:
+         return "pal60_enable";
+      case MENU_ENUM_LABEL_PARENT_DIRECTORY:
+         return "parent_directory";
+      case MENU_ENUM_LABEL_PAUSE_LIBRETRO:
+         return "menu_pause_libretro";
+      case MENU_ENUM_LABEL_PAUSE_NONACTIVE:
+         return "pause_nonactive";
+      case MENU_ENUM_LABEL_PERFCNT_ENABLE:
+         return "perfcnt_enable";
+      case MENU_ENUM_LABEL_PLAYLISTS_TAB:
+         return "playlists_tab";
+      case MENU_ENUM_LABEL_PLAYLIST_COLLECTION_ENTRY:
+         return "playlist_collection_entry";
+      case MENU_ENUM_LABEL_PLAYLIST_DIRECTORY:
+         return "playlist_directory";
+      case MENU_ENUM_LABEL_PLAYLIST_ENTRY:
+         return "playlist_entry";
+      case MENU_ENUM_LABEL_PLAYLIST_SETTINGS:
+         return "playlist_settings";
+      case MENU_ENUM_LABEL_PLAYLIST_SETTINGS_BEGIN:
+         return "playlist_settings_begin";
+      case MENU_ENUM_LABEL_POINTER_ENABLE:
+         return "menu_pointer_enable";
+      case MENU_ENUM_LABEL_PRIVACY_SETTINGS:
+         return "privacy_settings";
+      case MENU_ENUM_LABEL_QUIT_RETROARCH:
+         return "quit_retroarch";
+      case MENU_ENUM_LABEL_RDB_ENTRY:
+         return "rdb_entry";
+      case MENU_ENUM_LABEL_RDB_ENTRY_ANALOG:
+         return "rdb_entry_analog";
+      case MENU_ENUM_LABEL_RDB_ENTRY_BBFC_RATING:
+         return "rdb_entry_bbfc_rating";
+      case MENU_ENUM_LABEL_RDB_ENTRY_CERO_RATING:
+         return "rdb_entry_cero_rating";
+      case MENU_ENUM_LABEL_RDB_ENTRY_CRC32:
+         return "rdb_entry_crc32";
+      case MENU_ENUM_LABEL_RDB_ENTRY_DESCRIPTION:
+         return "rdb_entry_description";
+      case MENU_ENUM_LABEL_RDB_ENTRY_DEVELOPER:
+         return "rdb_entry_developer";
+      case MENU_ENUM_LABEL_RDB_ENTRY_EDGE_MAGAZINE_ISSUE:
+         return "rdb_entry_edge_magazine_issue";
+      case MENU_ENUM_LABEL_RDB_ENTRY_EDGE_MAGAZINE_RATING:
+         return "rdb_entry_edge_magazine_rating";
+      case MENU_ENUM_LABEL_RDB_ENTRY_EDGE_MAGAZINE_REVIEW:
+         return "rdb_entry_edge_magazine_review";
+      case MENU_ENUM_LABEL_RDB_ENTRY_ELSPA_RATING:
+         return "rdb_entry_elspa_rating";
+      case MENU_ENUM_LABEL_RDB_ENTRY_ENHANCEMENT_HW:
+         return "rdb_entry_enhancement_hw";
+      case MENU_ENUM_LABEL_RDB_ENTRY_ESRB_RATING:
+         return "rdb_entry_esrb_rating";
+      case MENU_ENUM_LABEL_RDB_ENTRY_FAMITSU_MAGAZINE_RATING:
+         return "rdb_entry_famitsu_magazine_rating";
+      case MENU_ENUM_LABEL_RDB_ENTRY_FRANCHISE:
+         return "rdb_entry_franchise";
+      case MENU_ENUM_LABEL_RDB_ENTRY_GENRE:
+         return "rdb_entry_genre";
+      case MENU_ENUM_LABEL_RDB_ENTRY_MAX_USERS:
+         return "rdb_entry_max_users";
+      case MENU_ENUM_LABEL_RDB_ENTRY_MD5:
+         return "rdb_entry_md5";
+      case MENU_ENUM_LABEL_RDB_ENTRY_NAME:
+         return "rdb_entry_name";
+      case MENU_ENUM_LABEL_RDB_ENTRY_ORIGIN:
+         return "rdb_entry_origin";
+      case MENU_ENUM_LABEL_RDB_ENTRY_PEGI_RATING:
+         return "rdb_entry_pegi_rating";
+      case MENU_ENUM_LABEL_RDB_ENTRY_PUBLISHER:
+         return "rdb_entry_publisher";
+      case MENU_ENUM_LABEL_RDB_ENTRY_RELEASE_MONTH:
+         return "rdb_entry_releasemonth";
+      case MENU_ENUM_LABEL_RDB_ENTRY_RELEASE_YEAR:
+         return "rdb_entry_releaseyear";
+      case MENU_ENUM_LABEL_RDB_ENTRY_SERIAL:
+         return "rdb_entry_serial";
+      case MENU_ENUM_LABEL_RDB_ENTRY_SHA1:
+         return "rdb_entry_sha1";
+      case MENU_ENUM_LABEL_RDB_ENTRY_START_CONTENT:
+         return "rdb_entry_start_content";
+      case MENU_ENUM_LABEL_RDB_ENTRY_TGDB_RATING:
+         return "rdb_entry_tgdb_rating";
+      case MENU_ENUM_LABEL_REBOOT:
+         return "reboot";
+      case MENU_ENUM_LABEL_RECORDING_CONFIG_DIRECTORY:
+         return "recording_config_directory";
+      case MENU_ENUM_LABEL_RECORDING_OUTPUT_DIRECTORY:
+         return "recording_output_directory";
+      case MENU_ENUM_LABEL_RECORDING_SETTINGS:
+         return "recording_settings";
+      case MENU_ENUM_LABEL_RECORD_CONFIG:
+         return "record_config";
+      case MENU_ENUM_LABEL_RECORD_DRIVER:
+         return "record_driver";
+      case MENU_ENUM_LABEL_RECORD_ENABLE:
+         return "record_enable";
+      case MENU_ENUM_LABEL_RECORD_PATH:
+         return "record_path";
+      case MENU_ENUM_LABEL_RECORD_USE_OUTPUT_DIRECTORY:
+         return "record_use_output_directory";
+      case MENU_ENUM_LABEL_REMAP_FILE_LOAD:
+         return "remap_file_load";
+      case MENU_ENUM_LABEL_REMAP_FILE_SAVE_CORE:
+         return "remap_file_save_core";
+      case MENU_ENUM_LABEL_REMAP_FILE_SAVE_GAME:
+         return "remap_file_save_game";
+      case MENU_ENUM_LABEL_RESTART_CONTENT:
+         return "restart_content";
+      case MENU_ENUM_LABEL_RESTART_RETROARCH:
+         return "restart_retroarch";
+      case MENU_ENUM_LABEL_RESUME_CONTENT:
+         return "resume_content";
+      case MENU_ENUM_LABEL_RETRO_ACHIEVEMENTS_SETTINGS:
+         return "retro_achievements_settings";
+      case MENU_ENUM_LABEL_REWIND_ENABLE:
+         return "rewind_enable";
+      case MENU_ENUM_LABEL_REWIND_GRANULARITY:
+         return "rewind_granularity";
+      case MENU_ENUM_LABEL_REWIND_SETTINGS:
+         return "rewind_settings";
+      case MENU_ENUM_LABEL_RGUI_BROWSER_DIRECTORY:
+         return "rgui_browser_directory";
+      case MENU_ENUM_LABEL_RGUI_CONFIG_DIRECTORY:
+         return "rgui_config_directory";
+      case MENU_ENUM_LABEL_RGUI_SHOW_START_SCREEN:
+         return "rgui_show_start_screen";
+      case MENU_ENUM_LABEL_RUN:
+         return "collection";
+      case MENU_ENUM_LABEL_SAMBA_ENABLE:
+         return "samba_enable";
+      case MENU_ENUM_LABEL_SAVEFILE_DIRECTORY:
+         return "savefile_directory";
+      case MENU_ENUM_LABEL_SAVESTATE_AUTO_INDEX:
+         return "savestate_auto_index";
+      case MENU_ENUM_LABEL_SAVESTATE_AUTO_LOAD:
+         return "savestate_auto_load";
+      case MENU_ENUM_LABEL_SAVESTATE_AUTO_SAVE:
+         return "savestate_auto_save";
+      case MENU_ENUM_LABEL_SAVESTATE_DIRECTORY:
+         return "savestate_directory";
       case MENU_ENUM_LABEL_SAVE_CURRENT_CONFIG:
          return "save_current_config";
       case MENU_ENUM_LABEL_SAVE_CURRENT_CONFIG_OVERRIDE_CORE:
          return "save_current_config_override_core";
       case MENU_ENUM_LABEL_SAVE_CURRENT_CONFIG_OVERRIDE_GAME:
          return "save_current_config_override_game";
-      case MENU_ENUM_LABEL_STATE_SLOT:
-         return "state_slot";
-      case MENU_ENUM_LABEL_CHEEVOS_USERNAME:
-         return "cheevos_username";
-      case MENU_ENUM_LABEL_CHEEVOS_PASSWORD:
-         return "cheevos_password";
-      case MENU_ENUM_LABEL_ACCOUNTS_CHEEVOS_USERNAME:
-         return "accounts_cheevos_username";
-      case MENU_ENUM_LABEL_ACCOUNTS_RETRO_ACHIEVEMENTS:
-         return "retro_achievements";
-      case MENU_ENUM_LABEL_DEFERRED_ACCOUNTS_CHEEVOS_LIST:
-         return "deferred_accounts_cheevos_list";
-      case MENU_ENUM_LABEL_DEFERRED_USER_BINDS_LIST:
-         return "deferred_user_binds_list";
-      case MENU_ENUM_LABEL_DEFERRED_ACCOUNTS_LIST:
-         return "deferred_accounts_list";
-      case MENU_ENUM_LABEL_DEFERRED_INPUT_SETTINGS_LIST:
-         return "deferred_input_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_DRIVER_SETTINGS_LIST:
-         return "deferred_driver_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_AUDIO_SETTINGS_LIST:
-         return "deferred_audio_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_CORE_SETTINGS_LIST:
-         return "deferred_core_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_VIDEO_SETTINGS_LIST:
-         return "deferred_video_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_CONFIGURATION_SETTINGS_LIST:
-         return "deferred_configuration_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_SAVING_SETTINGS_LIST:
-         return "deferred_saving_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_LOGGING_SETTINGS_LIST:
-         return "deferred_logging_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_FRAME_THROTTLE_SETTINGS_LIST:
-         return "deferred_frame_throttle_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_REWIND_SETTINGS_LIST:
-         return "deferred_rewind_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_ONSCREEN_DISPLAY_SETTINGS_LIST:
-         return "deferred_onscreen_display_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_ONSCREEN_OVERLAY_SETTINGS_LIST:
-         return "deferred_onscreen_overlay_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_MENU_SETTINGS_LIST:
-         return "deferred_menu_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_USER_INTERFACE_SETTINGS_LIST:
-         return "deferred_user_interface_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_MENU_FILE_BROWSER_SETTINGS_LIST:
-         return "deferred_menu_file_browser_settings_list";
-      case MENU_ENUM_LABEL_FILE_BROWSER_DIRECTORY:
-         return "file_browser_directory";
-      case MENU_ENUM_LABEL_FILE_BROWSER_PLAIN_FILE:
-         return "file_browser_plain_file";
-      case MENU_ENUM_LABEL_FILE_BROWSER_REMAP:
-         return "file_browser_remap";
-      case MENU_ENUM_LABEL_FILE_BROWSER_SHADER:
-         return "file_browser_shader";
-      case MENU_ENUM_LABEL_FILE_BROWSER_SHADER_PRESET:
-         return "file_browser_shader_preset";
-      case MENU_ENUM_LABEL_FILE_BROWSER_CORE:
-         return "file_browser_core";
-      case MENU_ENUM_LABEL_FILE_BROWSER_CORE_SELECT_FROM_COLLECTION:
-         return "file_browser_core_select_from_collection";
-      case MENU_ENUM_LABEL_FILE_BROWSER_MUSIC_OPEN:
-         return "file_browser_music_open";
-      case MENU_ENUM_LABEL_FILE_BROWSER_MOVIE_OPEN:
-         return "file_browser_movie_open";
-      case MENU_ENUM_LABEL_FILE_BROWSER_IMAGE_OPEN_WITH_VIEWER:
-         return "file_browser_image_open_with_viewer";
-      case MENU_ENUM_LABEL_FILE_BROWSER_IMAGE:
-         return "file_browser_image";
-      case MENU_ENUM_LABEL_FILE_BROWSER_CORE_DETECTED:
-         return "file_browser_core_detected";
-      case MENU_ENUM_LABEL_DEFERRED_RETRO_ACHIEVEMENTS_SETTINGS_LIST:
-         return "deferred_retro_achievements_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_UPDATER_SETTINGS_LIST:
-         return "deferred_updater_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_WIFI_SETTINGS_LIST:
-         return "deferred_wifi_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_NETWORK_SETTINGS_LIST:
-         return "deferred_network_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_LAKKA_SERVICES_LIST:
-         return "deferred_lakka_services_list";
-      case MENU_ENUM_LABEL_DEFERRED_USER_SETTINGS_LIST:
-         return "deferred_user_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_DIRECTORY_SETTINGS_LIST:
-         return "deferred_directory_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_PRIVACY_SETTINGS_LIST:
-         return "deferred_privacy_settings_list";
-      case MENU_ENUM_LABEL_ACCOUNTS_LIST:
-         return "accounts_list";
-      case MENU_ENUM_LABEL_DEFERRED_INPUT_HOTKEY_BINDS_LIST:
-         return "deferred_input_hotkey_binds";
-      case MENU_ENUM_LABEL_INPUT_HOTKEY_BINDS:
-         return "input_hotkey_binds";
-      case MENU_ENUM_LABEL_INPUT_HOTKEY_BINDS_BEGIN:
-         return "input_hotkey_binds_begin";
-      case MENU_ENUM_LABEL_INPUT_SETTINGS_BEGIN:
-         return "input_settings_begin";
-      case MENU_ENUM_LABEL_PLAYLIST_SETTINGS_BEGIN:
-         return "playlist_settings_begin";
-      case MENU_ENUM_LABEL_RECORDING_SETTINGS:
-         return "recording_settings";
-      case MENU_ENUM_LABEL_PLAYLIST_SETTINGS:
-         return "playlist_settings";
-      case MENU_ENUM_LABEL_DEFERRED_RECORDING_SETTINGS_LIST:
-         return "deferred_recording_settings";
-      case MENU_ENUM_LABEL_DEFERRED_PLAYLIST_SETTINGS_LIST:
-         return "deferred_playlist_settings";
-      case MENU_ENUM_LABEL_INPUT_SETTINGS:
-         return "input_settings";
-      case MENU_ENUM_LABEL_DRIVER_SETTINGS:
-         return "driver_settings";
-      case MENU_ENUM_LABEL_VIDEO_SETTINGS:
-         return "video_settings";
-      case MENU_ENUM_LABEL_CONFIGURATION_SETTINGS:
-         return "configuration_settings";
+      case MENU_ENUM_LABEL_SAVE_NEW_CONFIG:
+         return "save_new_config";
+      case MENU_ENUM_LABEL_SAVE_STATE:
+         return "savestate";
       case MENU_ENUM_LABEL_SAVING_SETTINGS:
          return "saving_settings";
-      case MENU_ENUM_LABEL_LOGGING_SETTINGS:
-         return "logging_settings";
-      case MENU_ENUM_LABEL_FRAME_THROTTLE_SETTINGS:
-         return "frame_throttle_settings";
-      case MENU_ENUM_LABEL_REWIND_SETTINGS:
-         return "rewind_settings";
-      case MENU_ENUM_LABEL_ONSCREEN_DISPLAY_SETTINGS:
-         return "onscreen_display_settings";
-      case MENU_ENUM_LABEL_ONSCREEN_OVERLAY_SETTINGS:
-         return "onscreen_overlay_settings";
-      case MENU_ENUM_LABEL_AUDIO_SETTINGS:
-         return "audio_settings";
-      case MENU_ENUM_LABEL_MENU_SETTINGS:
-         return "menu_settings";
-      case MENU_ENUM_LABEL_USER_INTERFACE_SETTINGS:
-         return "user_interface_settings";
-      case MENU_ENUM_LABEL_MENU_FILE_BROWSER_SETTINGS:
-         return "menu_file_browser_settings";
-      case MENU_ENUM_LABEL_RETRO_ACHIEVEMENTS_SETTINGS:
-         return "retro_achievements_settings";
-      case MENU_ENUM_LABEL_UPDATER_SETTINGS:
-         return "updater_settings";
-      case MENU_ENUM_LABEL_NETWORK_SETTINGS:
-         return "network_settings";
-      case MENU_ENUM_LABEL_WIFI_SETTINGS:
-         return "wifi_settings";
-      case MENU_ENUM_LABEL_USER_SETTINGS:
-         return "user_settings";
-      case MENU_ENUM_LABEL_LAKKA_SERVICES:
-         return "lakka_services";
-      case MENU_ENUM_LABEL_DIRECTORY_SETTINGS:
-         return "directory_settings";
-      case MENU_ENUM_LABEL_PRIVACY_SETTINGS:
-         return "privacy_settings";
-      case MENU_ENUM_LABEL_HELP_SCANNING_CONTENT:
-         return "help_scanning_content";
-      case MENU_ENUM_LABEL_CHEEVOS_DESCRIPTION:
-         return "cheevos_description";
-      case MENU_ENUM_LABEL_HELP_AUDIO_VIDEO_TROUBLESHOOTING:
-         return "help_audio_video_troubleshooting";
-      case MENU_ENUM_LABEL_HELP_CHANGE_VIRTUAL_GAMEPAD:
-         return "help_change_virtual_gamepad";
-      case MENU_ENUM_LABEL_HELP_WHAT_IS_A_CORE:
-         return "help_what_is_a_core";
-      case MENU_ENUM_LABEL_HELP_LOADING_CONTENT:
-         return "help_loading_content";
-      case MENU_ENUM_LABEL_HELP_LIST:
-         return "help_list";
-      case MENU_ENUM_LABEL_HELP_CONTROLS:
-         return "help_controls";
-      case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_OPEN_DETECT_CORE:
-         return "deferred_archive_open_detect_core";
-      case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_OPEN:
-         return "deferred_archive_open";
-      case MENU_ENUM_LABEL_LOAD_ARCHIVE_DETECT_CORE:
-         return "load_archive_detect_core";
-      case MENU_ENUM_LABEL_LOAD_ARCHIVE:
-         return "load_archive";
-      case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_ACTION_DETECT_CORE:
-         return "deferred_archive_action_detect_core";
-      case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_ACTION:
-         return "deferred_archive_action";
-      case MENU_ENUM_LABEL_OPEN_ARCHIVE_DETECT_CORE:
-         return "open_archive_detect_core";
-      case MENU_ENUM_LABEL_OPEN_ARCHIVE:
-         return "open_archive";
-      case MENU_ENUM_LABEL_INPUT_BACK_AS_MENU_ENUM_TOGGLE_ENABLE:
-         return "back_as_menu_toggle_enable";
-      case MENU_ENUM_LABEL_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
-         return "input_menu_toggle_gamepad_combo";
-      case MENU_ENUM_LABEL_INPUT_ALL_USERS_CONTROL_MENU:
-         return "all_users_control_menu";
-      case MENU_ENUM_LABEL_INPUT_OVERLAY_HIDE_IN_MENU:
-         return "overlay_hide_in_menu";
-      case MENU_ENUM_LABEL_NO_PLAYLIST_ENTRIES_AVAILABLE:
-         return "no_playlist_entries_available";
-      case MENU_ENUM_LABEL_DOWNLOADED_FILE_DETECT_CORE_LIST:
-         return "downloaded_file_detect_core_list";
-      case MENU_ENUM_LABEL_UPDATE_CORE_INFO_FILES:
-         return "update_core_info_files";
-      case MENU_ENUM_LABEL_DEFERRED_CORE_CONTENT_LIST:
-         return "deferred_core_content_list";
-      case MENU_ENUM_LABEL_DEFERRED_CORE_CONTENT_DIRS_LIST:
-         return "deferred_core_content_dirs_list";
-      case MENU_ENUM_LABEL_DEFERRED_CORE_CONTENT_DIRS_SUBDIR_LIST:
-         return "deferred_core_content_dirs_subdir_list";
-      case MENU_ENUM_LABEL_DEFERRED_LAKKA_LIST:
-         return "deferred_lakka_list";
-      case MENU_ENUM_LABEL_DOWNLOAD_CORE_CONTENT:
-         return "download_core_content";
-      case MENU_ENUM_LABEL_DOWNLOAD_CORE_CONTENT_DIRS:
-         return "download_core_content_dirs";
-      case MENU_ENUM_LABEL_CB_DOWNLOAD_URL:
-         return "cb_download_url";
-      case MENU_ENUM_LABEL_SCAN_THIS_DIRECTORY:
-         return "scan_this_directory";
-      case MENU_ENUM_LABEL_SCAN_FILE:
-         return "scan_file";
       case MENU_ENUM_LABEL_SCAN_DIRECTORY:
          return "scan_directory";
-      case MENU_ENUM_LABEL_ADD_CONTENT_LIST:
-         return "add_content";
-      case MENU_ENUM_LABEL_CONNECT_WIFI:
-         return "connect_wifi";
-      case MENU_ENUM_LABEL_OVERLAY_AUTOLOAD_PREFERRED:
-         return "overlay_autoload_preferred";
-      case MENU_ENUM_LABEL_INFORMATION:
-         return "information";
-      case MENU_ENUM_LABEL_INFORMATION_LIST:
-         return "information_list";
-      case MENU_ENUM_LABEL_USE_BUILTIN_PLAYER:
-         return "use_builtin_player";
-      case MENU_ENUM_LABEL_CONTENT_SETTINGS:
-         return "quick_menu";
-      case MENU_ENUM_LABEL_LOAD_CONTENT_LIST:
-         return "load_content";
-      case MENU_ENUM_LABEL_NO_SETTINGS_FOUND:
-         return "menu_label_no_settings_found";
+      case MENU_ENUM_LABEL_SCAN_FILE:
+         return "scan_file";
+      case MENU_ENUM_LABEL_SCAN_THIS_DIRECTORY:
+         return "scan_this_directory";
+      case MENU_ENUM_LABEL_SCREENSHOT_DIRECTORY:
+         return "screenshot_directory";
+      case MENU_ENUM_LABEL_SCREEN_RESOLUTION:
+         return "screen_resolution";
+      case MENU_ENUM_LABEL_SETTINGS:
+         return "settings";
+      case MENU_ENUM_LABEL_SETTINGS_TAB:
+         return "settings_tab";
+      case MENU_ENUM_LABEL_SHADER_APPLY_CHANGES:
+         return "shader_apply_changes";
+      case MENU_ENUM_LABEL_SHADER_OPTIONS:
+         return "shader_options";
+      case MENU_ENUM_LABEL_SHADER_PARAMETERS_ENTRY:
+         return "shader_parameters_entry";
+      case MENU_ENUM_LABEL_SHOW_ADVANCED_SETTINGS:
+         return "menu_show_advanced_settings";
+      case MENU_ENUM_LABEL_SHOW_HIDDEN_FILES:
+         return "show_hidden_files";
+      case MENU_ENUM_LABEL_SHUTDOWN:
+         return "shutdown";
+      case MENU_ENUM_LABEL_SLOWMOTION_RATIO:
+         return "slowmotion_ratio";
+      case MENU_ENUM_LABEL_SORT_SAVEFILES_ENABLE:
+         return "sort_savefiles_enable";
+      case MENU_ENUM_LABEL_SORT_SAVESTATES_ENABLE:
+         return "sort_savestates_enable";
+      case MENU_ENUM_LABEL_SSH_ENABLE:
+         return "ssh_enable";
+      case MENU_ENUM_LABEL_START_CORE:
+         return "start_core";
+      case MENU_ENUM_LABEL_START_NET_RETROPAD:
+         return "menu_start_net_retropad";
+      case MENU_ENUM_LABEL_START_VIDEO_PROCESSOR:
+         return "menu_start_video_processor";
+      case MENU_ENUM_LABEL_STATE_SLOT:
+         return "state_slot";
+      case MENU_ENUM_LABEL_STDIN_CMD_ENABLE:
+         return "stdin_commands";
+      case MENU_ENUM_LABEL_SUSPEND_SCREENSAVER_ENABLE:
+         return "suspend_screensaver_enable";
       case MENU_ENUM_LABEL_SYSTEM_BGM_ENABLE:
          return "system_bgm_enable";
-      case MENU_ENUM_LABEL_AUDIO_BLOCK_FRAMES:
-         return "audio_block_frames";
-      case MENU_ENUM_LABEL_INPUT_BIND_MODE:
-         return "input_bind_mode";
-      case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_LABEL_SHOW:
-         return "input_descriptor_label_show";
-      case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_HIDE_UNBOUND:
-         return "input_descriptor_hide_unbound";
+      case MENU_ENUM_LABEL_SYSTEM_DIRECTORY:
+         return "system_directory";
+      case MENU_ENUM_LABEL_SYSTEM_INFORMATION:
+         return "system_information";
+      case MENU_ENUM_LABEL_SYSTEM_INFO_ENTRY:
+         return "system_info_entry";
+      case MENU_ENUM_LABEL_TAKE_SCREENSHOT:
+         return "take_screenshot";
+      case MENU_ENUM_LABEL_THREADED_DATA_RUNLOOP_ENABLE:
+         return "threaded_data_runloop_enable";
+      case MENU_ENUM_LABEL_THUMBNAILS:
+         return "thumbnails";
+      case MENU_ENUM_LABEL_THUMBNAILS_DIRECTORY:
+         return "thumbnails_directory";
+      case MENU_ENUM_LABEL_THUMBNAILS_UPDATER_LIST:
+         return "thumbnails_updater_list";
+      case MENU_ENUM_LABEL_TIMEDATE_ENABLE:
+         return "menu_timedate_enable";
+      case MENU_ENUM_LABEL_TITLE_COLOR:
+         return "menu_title_color";
+      case MENU_ENUM_LABEL_UI_COMPANION_ENABLE:
+         return "ui_companion_enable";
+      case MENU_ENUM_LABEL_UI_COMPANION_START_ON_BOOT:
+         return "ui_companion_start_on_boot";
+      case MENU_ENUM_LABEL_UI_MENUBAR_ENABLE:
+         return "ui_menubar_enable";
+      case MENU_ENUM_LABEL_UNDO_LOAD_STATE:
+         return "undoloadstate";
+      case MENU_ENUM_LABEL_UNDO_SAVE_STATE:
+         return "undosavestate";
+      case MENU_ENUM_LABEL_UPDATER_SETTINGS:
+         return "updater_settings";
+      case MENU_ENUM_LABEL_UPDATE_ASSETS:
+         return "update_assets";
+      case MENU_ENUM_LABEL_UPDATE_AUTOCONFIG_PROFILES:
+         return "update_autoconfig_profiles";
+      case MENU_ENUM_LABEL_UPDATE_CG_SHADERS:
+         return "update_cg_shaders";
+      case MENU_ENUM_LABEL_UPDATE_CHEATS:
+         return "update_cheats";
+      case MENU_ENUM_LABEL_UPDATE_CORE_INFO_FILES:
+         return "update_core_info_files";
+      case MENU_ENUM_LABEL_UPDATE_DATABASES:
+         return "update_databases";
+      case MENU_ENUM_LABEL_UPDATE_GLSL_SHADERS:
+         return "update_glsl_shaders";
+      case MENU_ENUM_LABEL_UPDATE_LAKKA:
+         return "update_lakka";
+      case MENU_ENUM_LABEL_UPDATE_OVERLAYS:
+         return "update_overlays";
+      case MENU_ENUM_LABEL_UPDATE_SLANG_SHADERS:
+         return "update_slang_shaders";
+      case MENU_ENUM_LABEL_URL_ENTRY:
+         return "url_entry";
+      case MENU_ENUM_LABEL_USER_INTERFACE_SETTINGS:
+         return "user_interface_settings";
+      case MENU_ENUM_LABEL_USER_LANGUAGE:
+         return "user_language";
+      case MENU_ENUM_LABEL_USER_SETTINGS:
+         return "user_settings";
+      case MENU_ENUM_LABEL_USE_BUILTIN_IMAGE_VIEWER:
+         return "use_builtin_image_viewer";
+      case MENU_ENUM_LABEL_USE_BUILTIN_PLAYER:
+         return "use_builtin_player";
+      case MENU_ENUM_LABEL_USE_THIS_DIRECTORY:
+         return "use_this_directory";
+      case MENU_ENUM_LABEL_VIDEO_ALLOW_ROTATE:
+         return "video_allow_rotate";
+      case MENU_ENUM_LABEL_VIDEO_ASPECT_RATIO_AUTO:
+         return "video_aspect_ratio_auto";
+      case MENU_ENUM_LABEL_VIDEO_ASPECT_RATIO_INDEX:
+         return "aspect_ratio_index";
+      case MENU_ENUM_LABEL_VIDEO_BLACK_FRAME_INSERTION:
+         return "video_black_frame_insertion";
+      case MENU_ENUM_LABEL_VIDEO_CROP_OVERSCAN:
+         return "video_crop_overscan";
+      case MENU_ENUM_LABEL_VIDEO_DISABLE_COMPOSITION:
+         return "video_disable_composition";
+      case MENU_ENUM_LABEL_VIDEO_DRIVER:
+         return "video_driver";
+      case MENU_ENUM_LABEL_VIDEO_FILTER:
+         return "video_filter";
+      case MENU_ENUM_LABEL_VIDEO_FILTER_DIR:
+         return "video_filter_dir";
+      case MENU_ENUM_LABEL_VIDEO_FILTER_FLICKER:
+         return "video_filter_flicker";
       case MENU_ENUM_LABEL_VIDEO_FONT_ENABLE:
          return "video_font_enable";
       case MENU_ENUM_LABEL_VIDEO_FONT_PATH:
          return "video_font_path";
       case MENU_ENUM_LABEL_VIDEO_FONT_SIZE:
          return "video_font_size";
+      case MENU_ENUM_LABEL_VIDEO_FORCE_ASPECT:
+         return "video_force_aspect";
+      case MENU_ENUM_LABEL_VIDEO_FORCE_SRGB_DISABLE:
+         return "video_force_srgb_disable";
+      case MENU_ENUM_LABEL_VIDEO_FRAME_DELAY:
+         return "video_frame_delay";
+      case MENU_ENUM_LABEL_VIDEO_FULLSCREEN:
+         return "video_fullscreen";
+      case MENU_ENUM_LABEL_VIDEO_GAMMA:
+         return "video_gamma";
+      case MENU_ENUM_LABEL_VIDEO_GPU_RECORD:
+         return "video_gpu_record";
+      case MENU_ENUM_LABEL_VIDEO_GPU_SCREENSHOT:
+         return "video_gpu_screenshot";
+      case MENU_ENUM_LABEL_VIDEO_HARD_SYNC:
+         return "video_hard_sync";
+      case MENU_ENUM_LABEL_VIDEO_HARD_SYNC_FRAMES:
+         return "video_hard_sync_frames";
+      case MENU_ENUM_LABEL_VIDEO_MAX_SWAPCHAIN_IMAGES:
+         return "video_max_swapchain_images";
       case MENU_ENUM_LABEL_VIDEO_MESSAGE_POS_X:
          return "video_message_pos_x";
       case MENU_ENUM_LABEL_VIDEO_MESSAGE_POS_Y:
          return "video_message_pos_y";
-      case MENU_ENUM_LABEL_VIDEO_SOFT_FILTER:
-         return "soft_filter";
-      case MENU_ENUM_LABEL_VIDEO_FILTER_FLICKER:
-         return "video_filter_flicker";
-      case MENU_ENUM_LABEL_INPUT_REMAPPING_DIRECTORY:
-         return "input_remapping_directory";
-      case MENU_ENUM_LABEL_JOYPAD_AUTOCONFIG_DIR:
-         return "joypad_autoconfig_dir";
-      case MENU_ENUM_LABEL_RECORDING_CONFIG_DIRECTORY:
-         return "recording_config_directory";
-      case MENU_ENUM_LABEL_RECORDING_OUTPUT_DIRECTORY:
-         return "recording_output_directory";
-      case MENU_ENUM_LABEL_SCREENSHOT_DIRECTORY:
-         return "screenshot_directory";
-      case MENU_ENUM_LABEL_PLAYLIST_DIRECTORY:
-         return "playlist_directory";
-      case MENU_ENUM_LABEL_SAVEFILE_DIRECTORY:
-         return "savefile_directory";
-      case MENU_ENUM_LABEL_SAVESTATE_DIRECTORY:
-         return "savestate_directory";
-      case MENU_ENUM_LABEL_STDIN_CMD_ENABLE:
-         return "stdin_commands";
-      case MENU_ENUM_LABEL_NETWORK_REMOTE_ENABLE:
-         return "network_remote_enable";
-      case MENU_ENUM_LABEL_NETWORK_REMOTE_USER_1_ENABLE:
-         return "network_remote_user_1_enable";
-      case MENU_ENUM_LABEL_NETWORK_REMOTE_USER_LAST_ENABLE:
-         return "network_remote_user_last_enable";
-      case MENU_ENUM_LABEL_NETWORK_REMOTE_PORT:
-         return "network_remote_base_port";
-      case MENU_ENUM_LABEL_VIDEO_DRIVER:
-         return "video_driver";
-      case MENU_ENUM_LABEL_RECORD_ENABLE:
-         return "record_enable";
-      case MENU_ENUM_LABEL_VIDEO_GPU_RECORD:
-         return "video_gpu_record";
-      case MENU_ENUM_LABEL_RECORD_PATH:
-         return "record_path";
-      case MENU_ENUM_LABEL_RECORD_USE_OUTPUT_DIRECTORY:
-         return "record_use_output_directory";
-      case MENU_ENUM_LABEL_RECORD_CONFIG:
-         return "record_config";
+      case MENU_ENUM_LABEL_VIDEO_MONITOR_INDEX:
+         return "video_monitor_index";
       case MENU_ENUM_LABEL_VIDEO_POST_FILTER_RECORD:
          return "video_post_filter_record";
-      case MENU_ENUM_LABEL_CORE_ASSETS_DIRECTORY:
-         return "core_assets_directory";
-      case MENU_ENUM_LABEL_ASSETS_DIRECTORY:
-         return "assets_directory";
-      case MENU_ENUM_LABEL_DYNAMIC_WALLPAPERS_DIRECTORY:
-         return "dynamic_wallpapers_directory";
-      case MENU_ENUM_LABEL_THUMBNAILS_DIRECTORY:
-         return "thumbnails_directory";
-      case MENU_ENUM_LABEL_RGUI_BROWSER_DIRECTORY:
-         return "rgui_browser_directory";
-      case MENU_ENUM_LABEL_RGUI_CONFIG_DIRECTORY:
-         return "rgui_config_directory";
-      case MENU_ENUM_LABEL_LIBRETRO_INFO_PATH:
-         return "libretro_info_path";
-      case MENU_ENUM_LABEL_LIBRETRO_DIR_PATH:
-         return "libretro_dir_path";
-      case MENU_ENUM_LABEL_CURSOR_DIRECTORY:
-         return "cursor_directory";
-      case MENU_ENUM_LABEL_CONTENT_DATABASE_DIRECTORY:
-         return "content_database_path";
-      case MENU_ENUM_LABEL_SYSTEM_DIRECTORY:
-         return "system_directory";
-      case MENU_ENUM_LABEL_CACHE_DIRECTORY:
-         return "cache_directory";
-      case MENU_ENUM_LABEL_CHEAT_DATABASE_PATH:
-         return "cheat_database_path";
-      case MENU_ENUM_LABEL_AUDIO_FILTER_DIR:
-         return "audio_filter_dir";
-      case MENU_ENUM_LABEL_VIDEO_FILTER_DIR:
-         return "video_filter_dir";
-      case MENU_ENUM_LABEL_VIDEO_SHADER_DIR:
-         return "video_shader_dir";
-      case MENU_ENUM_LABEL_OVERLAY_DIRECTORY:
-         return "overlay_directory";
-      case MENU_ENUM_LABEL_OSK_OVERLAY_DIRECTORY:
-         return "osk_overlay_directory";
-      case MENU_ENUM_LABEL_NETPLAY_CLIENT_SWAP_INPUT:
-         return "netplay_client_swap_input";
-      case MENU_ENUM_LABEL_NETPLAY_SPECTATOR_MODE_ENABLE:
-         return "netplay_spectator_mode_enable";
-      case MENU_ENUM_LABEL_NETPLAY_IP_ADDRESS:
-         return "netplay_ip_address";
-      case MENU_ENUM_LABEL_NETPLAY_TCP_UDP_PORT:
-         return "netplay_tcp_udp_port";
-      case MENU_ENUM_LABEL_NETPLAY_ENABLE:
-         return "netplay_enable";
-      case MENU_ENUM_LABEL_SSH_ENABLE:
-         return "ssh_enable";
-      case MENU_ENUM_LABEL_SAMBA_ENABLE:
-         return "samba_enable";
-      case MENU_ENUM_LABEL_BLUETOOTH_ENABLE:
-         return "bluetooth_enable";
-      case MENU_ENUM_LABEL_NETPLAY_DELAY_FRAMES:
-         return "netplay_delay_frames";
-      case MENU_ENUM_LABEL_NETPLAY_CHECK_FRAMES:
-         return "netplay_check_frames";
-      case MENU_ENUM_LABEL_NETPLAY_MODE:
-         return "netplay_mode";
-      case MENU_ENUM_LABEL_RGUI_SHOW_START_SCREEN:
-         return "rgui_show_start_screen";
-      case MENU_ENUM_LABEL_TITLE_COLOR:
-         return "menu_title_color";
-      case MENU_ENUM_LABEL_ENTRY_HOVER_COLOR:
-         return "menu_entry_hover_color";
-      case MENU_ENUM_LABEL_TIMEDATE_ENABLE:
-         return "menu_timedate_enable";
-      case MENU_ENUM_LABEL_THREADED_DATA_RUNLOOP_ENABLE:
-         return "threaded_data_runloop_enable";
-      case MENU_ENUM_LABEL_ENTRY_NORMAL_COLOR:
-         return "menu_entry_normal_color";
-      case MENU_ENUM_LABEL_SHOW_ADVANCED_SETTINGS:
-         return "menu_show_advanced_settings";
-      case MENU_ENUM_LABEL_MOUSE_ENABLE:
-         return "menu_mouse_enable";
-      case MENU_ENUM_LABEL_POINTER_ENABLE:
-         return "menu_pointer_enable";
-      case MENU_ENUM_LABEL_CORE_ENABLE:
-         return "menu_core_enable";
-      case MENU_ENUM_LABEL_NETPLAY_ENABLE_HOST:
-         return "menu_netplay_enable_host";
-      case MENU_ENUM_LABEL_NETPLAY_ENABLE_CLIENT:
-         return "menu_netplay_enable_client";
-      case MENU_ENUM_LABEL_NETPLAY_DISCONNECT:
-         return "menu_netplay_disconnect";
-      case MENU_ENUM_LABEL_NETPLAY_SETTINGS:
-         return "menu_netplay_settings";
-      case MENU_ENUM_LABEL_DPI_OVERRIDE_ENABLE:
-         return "dpi_override_enable";
-      case MENU_ENUM_LABEL_DPI_OVERRIDE_VALUE:
-         return "dpi_override_value";
-      case MENU_ENUM_LABEL_XMB_FONT:
-         return "xmb_font";
-      case MENU_ENUM_LABEL_XMB_THEME:
-         return "xmb_theme";
-      case MENU_ENUM_LABEL_XMB_MENU_COLOR_THEME:
-         return "xmb_menu_color_theme";
-      case MENU_ENUM_LABEL_MATERIALUI_MENU_COLOR_THEME:
-         return "materialui_menu_color_theme";
-      case MENU_ENUM_LABEL_MATERIALUI_MENU_HEADER_OPACITY:
-         return "materialui_menu_header_opacity";
-      case MENU_ENUM_LABEL_MATERIALUI_MENU_FOOTER_OPACITY:
-         return "materialui_menu_footer_opacity";
-      case MENU_ENUM_LABEL_XMB_SHADOWS_ENABLE:
-         return "xmb_shadows_enable";
-      case MENU_ENUM_LABEL_XMB_SHOW_SETTINGS:
-         return "xmb_show_settings";
-      case MENU_ENUM_LABEL_XMB_SHOW_IMAGES:
-         return "xmb_show_images";
-      case MENU_ENUM_LABEL_XMB_SHOW_MUSIC:
-         return "xmb_show_music";
-      case MENU_ENUM_LABEL_XMB_SHOW_VIDEO:
-         return "xmb_show_video";
-      case MENU_ENUM_LABEL_XMB_SHOW_HISTORY:
-         return "xmb_show_history";
-      case MENU_ENUM_LABEL_XMB_RIBBON_ENABLE:
-         return "xmb_ribbon_enable";
-      case MENU_ENUM_LABEL_XMB_SCALE_FACTOR:
-         return "xmb_scale_factor";
-      case MENU_ENUM_LABEL_XMB_ALPHA_FACTOR:
-         return "xmb_alpha_factor";
-      case MENU_ENUM_LABEL_SUSPEND_SCREENSAVER_ENABLE:
-         return "suspend_screensaver_enable";
-      case MENU_ENUM_LABEL_VIDEO_DISABLE_COMPOSITION:
-         return "video_disable_composition";
-      case MENU_ENUM_LABEL_PAUSE_NONACTIVE:
-         return "pause_nonactive";
-      case MENU_ENUM_LABEL_UI_COMPANION_START_ON_BOOT:
-         return "ui_companion_start_on_boot";
-      case MENU_ENUM_LABEL_UI_COMPANION_ENABLE:
-         return "ui_companion_enable";
-      case MENU_ENUM_LABEL_UI_MENUBAR_ENABLE:
-         return "ui_menubar_enable";
-      case MENU_ENUM_LABEL_ARCHIVE_MODE:
-         return "archive_mode";
-      case MENU_ENUM_LABEL_NETWORK_CMD_ENABLE:
-         return "network_cmd_enable";
-      case MENU_ENUM_LABEL_NETWORK_CMD_PORT:
-         return "network_cmd_port";
-      case MENU_ENUM_LABEL_HISTORY_LIST_ENABLE:
-         return "history_list_enable";
-      case MENU_ENUM_LABEL_CONTENT_HISTORY_SIZE:
-         return "content_history_size";
-      case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE_AUTO:
-         return "video_refresh_rate_auto";
-      case MENU_ENUM_LABEL_DUMMY_ON_CORE_SHUTDOWN:
-         return "dummy_on_core_shutdown";
-      case MENU_ENUM_LABEL_CORE_SET_SUPPORTS_NO_CONTENT_ENABLE:
-         return "core_set_supports_no_content_enable";
-      case MENU_ENUM_LABEL_FRAME_THROTTLE_ENABLE:
-         return "fastforward_ratio_throttle_enable";
-      case MENU_ENUM_LABEL_FASTFORWARD_RATIO:
-         return "fastforward_ratio";
-      case MENU_ENUM_LABEL_AUTO_REMAPS_ENABLE:
-         return "auto_remaps_enable";
-      case MENU_ENUM_LABEL_AUTO_SHADERS_ENABLE:
-         return "auto_shaders_enable";
-      case MENU_ENUM_LABEL_SLOWMOTION_RATIO:
-         return "slowmotion_ratio";
-      case MENU_ENUM_LABEL_CORE_SPECIFIC_CONFIG:
-         return "core_specific_config";
-      case MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS:
-         return "game_specific_options";
-      case MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS_CREATE:
-         return "game_specific_options_create";
-      case MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS_IN_USE:
-         return "game_specific_options_in_use";
-      case MENU_ENUM_LABEL_AUTO_OVERRIDES_ENABLE:
-         return "auto_overrides_enable";
-      case MENU_ENUM_LABEL_CONFIG_SAVE_ON_EXIT:
-         return "config_save_on_exit";
-      case MENU_ENUM_LABEL_CONFIRM_ON_EXIT:
-         return "confirm_on_exit";
-      case MENU_ENUM_LABEL_SHOW_HIDDEN_FILES:
-         return "show_hidden_files";
-      case MENU_ENUM_LABEL_VIDEO_SMOOTH:
-         return "video_smooth";
-      case MENU_ENUM_LABEL_VIDEO_GAMMA:
-         return "video_gamma";
-      case MENU_ENUM_LABEL_VIDEO_ALLOW_ROTATE:
-         return "video_allow_rotate";
-      case MENU_ENUM_LABEL_VIDEO_HARD_SYNC:
-         return "video_hard_sync";
-      case MENU_ENUM_LABEL_VIDEO_SWAP_INTERVAL:
-         return "video_swap_interval";
-      case MENU_ENUM_LABEL_VIDEO_VSYNC:
-         return "video_vsync";
-      case MENU_ENUM_LABEL_VIDEO_THREADED:
-         return "video_threaded";
-      case MENU_ENUM_LABEL_VIDEO_ROTATION:
-         return "video_rotation";
-      case MENU_ENUM_LABEL_VIDEO_GPU_SCREENSHOT:
-         return "video_gpu_screenshot";
-      case MENU_ENUM_LABEL_VIDEO_CROP_OVERSCAN:
-         return "video_crop_overscan";
-      case MENU_ENUM_LABEL_VIDEO_ASPECT_RATIO_INDEX:
-         return "aspect_ratio_index";
-      case MENU_ENUM_LABEL_VIDEO_ASPECT_RATIO_AUTO:
-         return "video_aspect_ratio_auto";
-      case MENU_ENUM_LABEL_VIDEO_FORCE_ASPECT:
-         return "video_force_aspect";
       case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE:
          return "video_refresh_rate";
-      case MENU_ENUM_LABEL_VIDEO_FORCE_SRGB_DISABLE:
-         return "video_force_srgb_disable";
-      case MENU_ENUM_LABEL_VIDEO_WINDOWED_FULLSCREEN:
-         return "video_windowed_fullscreen";
-      case MENU_ENUM_LABEL_PAL60_ENABLE:
-         return "pal60_enable";
-      case MENU_ENUM_LABEL_VIDEO_VFILTER:
-         return "video_vfilter";
-      case MENU_ENUM_LABEL_VIDEO_VI_WIDTH:
-         return "video_vi_width";
-      case MENU_ENUM_LABEL_VIDEO_BLACK_FRAME_INSERTION:
-         return "video_black_frame_insertion";
-      case MENU_ENUM_LABEL_VIDEO_HARD_SYNC_FRAMES:
-         return "video_hard_sync_frames";
-      case MENU_ENUM_LABEL_SORT_SAVEFILES_ENABLE:
-         return "sort_savefiles_enable";
-      case MENU_ENUM_LABEL_SORT_SAVESTATES_ENABLE:
-         return "sort_savestates_enable";
-      case MENU_ENUM_LABEL_VIDEO_FULLSCREEN:
-         return "video_fullscreen";
-      case MENU_ENUM_LABEL_PERFCNT_ENABLE:
-         return "perfcnt_enable";
+      case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE_AUTO:
+         return "video_refresh_rate_auto";
+      case MENU_ENUM_LABEL_VIDEO_ROTATION:
+         return "video_rotation";
       case MENU_ENUM_LABEL_VIDEO_SCALE:
          return "video_scale";
       case MENU_ENUM_LABEL_VIDEO_SCALE_INTEGER:
          return "video_scale_integer";
-      case MENU_ENUM_LABEL_LIBRETRO_LOG_LEVEL:
-         return "libretro_log_level";
-      case MENU_ENUM_LABEL_LOG_VERBOSITY:
-         return "log_verbosity";
-      case MENU_ENUM_LABEL_SAVESTATE_AUTO_SAVE:
-         return "savestate_auto_save";
-      case MENU_ENUM_LABEL_SAVESTATE_AUTO_LOAD:
-         return "savestate_auto_load";
-      case MENU_ENUM_LABEL_SAVESTATE_AUTO_INDEX:
-         return "savestate_auto_index";
-      case MENU_ENUM_LABEL_AUTOSAVE_INTERVAL:
-         return "autosave_interval";
-      case MENU_ENUM_LABEL_BLOCK_SRAM_OVERWRITE:
-         return "block_sram_overwrite";
-      case MENU_ENUM_LABEL_VIDEO_SHARED_CONTEXT:
-         return "video_shared_context";
-      case MENU_ENUM_LABEL_RESTART_RETROARCH:
-         return "restart_retroarch";
-      case MENU_ENUM_LABEL_NETPLAY_NICKNAME:
-         return "netplay_nickname";
-      case MENU_ENUM_LABEL_USER_LANGUAGE:
-         return "user_language";
-      case MENU_ENUM_LABEL_CAMERA_ALLOW:
-         return "camera_allow";
-      case MENU_ENUM_LABEL_LOCATION_ALLOW:
-         return "location_allow";
-      case MENU_ENUM_LABEL_PAUSE_LIBRETRO:
-         return "menu_pause_libretro";
-      case MENU_ENUM_LABEL_INPUT_OSK_OVERLAY_ENABLE:
-         return "input_osk_overlay_enable";
-      case MENU_ENUM_LABEL_INPUT_OVERLAY_ENABLE:
-         return "input_overlay_enable";
-      case MENU_ENUM_LABEL_VIDEO_MONITOR_INDEX:
-         return "video_monitor_index";
-      case MENU_ENUM_LABEL_VIDEO_FRAME_DELAY:
-         return "video_frame_delay";
-      case MENU_ENUM_LABEL_INPUT_DUTY_CYCLE:
-         return "input_duty_cycle";
-      case MENU_ENUM_LABEL_INPUT_TURBO_PERIOD:
-         return "input_turbo_period";
-      case MENU_ENUM_LABEL_INPUT_BIND_TIMEOUT:
-         return "input_bind_timeout";
-      case MENU_ENUM_LABEL_INPUT_AXIS_THRESHOLD:
-         return "input_axis_threshold";
-      case MENU_ENUM_LABEL_INPUT_REMAP_BINDS_ENABLE:
-         return "input_remap_binds_enable";
-      case MENU_ENUM_LABEL_INPUT_MAX_USERS:
-         return "input_max_users";
-      case MENU_ENUM_LABEL_INPUT_AUTODETECT_ENABLE:
-         return "input_autodetect_enable";
-      case MENU_ENUM_LABEL_AUDIO_OUTPUT_RATE:
-         return "audio_output_rate";
-      case MENU_ENUM_LABEL_AUDIO_MAX_TIMING_SKEW:
-         return "audio_max_timing_skew";
-      case MENU_ENUM_LABEL_CHEAT_APPLY_CHANGES:
-         return "cheat_apply_changes";
-      case MENU_ENUM_LABEL_REMAP_FILE_SAVE_CORE:
-         return "remap_file_save_core";
-      case MENU_ENUM_LABEL_REMAP_FILE_SAVE_GAME:
-         return "remap_file_save_game";
-      case MENU_ENUM_LABEL_CHEAT_NUM_PASSES:
-         return "cheat_num_passes";
-      case MENU_ENUM_LABEL_SHADER_APPLY_CHANGES:
-         return "shader_apply_changes";
-      case MENU_ENUM_LABEL_COLLECTION:
-         return "collection";
-      case MENU_ENUM_LABEL_REWIND_ENABLE:
-         return "rewind_enable";
-      case MENU_ENUM_LABEL_CONTENT_COLLECTION_LIST:
-         return "select_from_collection";
-      case MENU_ENUM_LABEL_DETECT_CORE_LIST:
-         return "detect_core_list";
-      case MENU_ENUM_LABEL_LOAD_CONTENT_HISTORY:
-         return "load_recent";
-      case MENU_ENUM_LABEL_AUDIO_ENABLE:
-         return "audio_enable";
-      case MENU_ENUM_LABEL_FPS_SHOW:
-         return "fps_show";
-      case MENU_ENUM_LABEL_AUDIO_MUTE:
-         return "audio_mute_enable";
-      case MENU_ENUM_LABEL_VIDEO_SHADER_PASS:
-         return "video_shader_pass";
-      case MENU_ENUM_LABEL_AUDIO_VOLUME:
-         return "audio_volume";
-      case MENU_ENUM_LABEL_AUDIO_SYNC:
-         return "audio_sync";
-      case MENU_ENUM_LABEL_AUDIO_RATE_CONTROL_DELTA:
-         return "audio_rate_control_delta";
+      case MENU_ENUM_LABEL_VIDEO_SETTINGS:
+         return "video_settings";
+      case MENU_ENUM_LABEL_VIDEO_SHADER_DIR:
+         return "video_shader_dir";
       case MENU_ENUM_LABEL_VIDEO_SHADER_FILTER_PASS:
          return "video_shader_filter_pass";
-      case MENU_ENUM_LABEL_VIDEO_SHADER_SCALE_PASS:
-         return "video_shader_scale_pass";
       case MENU_ENUM_LABEL_VIDEO_SHADER_NUM_PASSES:
          return "video_shader_num_passes";
-      case MENU_ENUM_LABEL_SHADER_PARAMETERS_ENTRY:
-         return "shader_parameters_entry";
-      case MENU_ENUM_LABEL_RDB_ENTRY:
-         return "rdb_entry";
-      case MENU_ENUM_LABEL_RDB_ENTRY_DESCRIPTION:
-         return "rdb_entry_description";
-      case MENU_ENUM_LABEL_RDB_ENTRY_GENRE:
-         return "rdb_entry_genre";
-      case MENU_ENUM_LABEL_RDB_ENTRY_ORIGIN:
-         return "rdb_entry_origin";
-      case MENU_ENUM_LABEL_RDB_ENTRY_PUBLISHER:
-         return "rdb_entry_publisher";
-      case MENU_ENUM_LABEL_RDB_ENTRY_DEVELOPER:
-         return "rdb_entry_developer";
-      case MENU_ENUM_LABEL_RDB_ENTRY_FRANCHISE:
-         return "rdb_entry_franchise";
-      case MENU_ENUM_LABEL_RDB_ENTRY_MAX_USERS:
-         return "rdb_entry_max_users";
-      case MENU_ENUM_LABEL_RDB_ENTRY_NAME:
-         return "rdb_entry_name";
-      case MENU_ENUM_LABEL_RDB_ENTRY_EDGE_MAGAZINE_RATING:
-         return "rdb_entry_edge_magazine_rating";
-      case MENU_ENUM_LABEL_RDB_ENTRY_EDGE_MAGAZINE_REVIEW:
-         return "rdb_entry_edge_magazine_review";
-      case MENU_ENUM_LABEL_RDB_ENTRY_FAMITSU_MAGAZINE_RATING:
-         return "rdb_entry_famitsu_magazine_rating";
-      case MENU_ENUM_LABEL_RDB_ENTRY_TGDB_RATING:
-         return "rdb_entry_tgdb_rating";
-      case MENU_ENUM_LABEL_RDB_ENTRY_EDGE_MAGAZINE_ISSUE:
-         return "rdb_entry_edge_magazine_issue";
-      case MENU_ENUM_LABEL_RDB_ENTRY_RELEASE_MONTH:
-         return "rdb_entry_releasemonth";
-      case MENU_ENUM_LABEL_RDB_ENTRY_RELEASE_YEAR:
-         return "rdb_entry_releaseyear";
-      case MENU_ENUM_LABEL_RDB_ENTRY_ENHANCEMENT_HW:
-         return "rdb_entry_enhancement_hw";
-      case MENU_ENUM_LABEL_RDB_ENTRY_SHA1:
-         return "rdb_entry_sha1";
-      case MENU_ENUM_LABEL_RDB_ENTRY_CRC32:
-         return "rdb_entry_crc32";
-      case MENU_ENUM_LABEL_RDB_ENTRY_MD5:
-         return "rdb_entry_md5";
-      case MENU_ENUM_LABEL_RDB_ENTRY_BBFC_RATING:
-         return "rdb_entry_bbfc_rating";
-      case MENU_ENUM_LABEL_RDB_ENTRY_ESRB_RATING:
-         return "rdb_entry_esrb_rating";
-      case MENU_ENUM_LABEL_RDB_ENTRY_ELSPA_RATING:
-         return "rdb_entry_elspa_rating";
-      case MENU_ENUM_LABEL_RDB_ENTRY_PEGI_RATING:
-         return "rdb_entry_pegi_rating";
-      case MENU_ENUM_LABEL_RDB_ENTRY_CERO_RATING:
-         return "rdb_entry_cero_rating";
-      case MENU_ENUM_LABEL_RDB_ENTRY_ANALOG:
-         return "rdb_entry_analog";
-      case MENU_ENUM_LABEL_RDB_ENTRY_SERIAL:
-         return "rdb_entry_serial";
-      case MENU_ENUM_LABEL_CONFIGURATIONS:
-         return "configurations";
-      case MENU_ENUM_LABEL_REWIND_GRANULARITY:
-         return "rewind_granularity";
-      case MENU_ENUM_LABEL_REMAP_FILE_LOAD:
-         return "remap_file_load";
-      case MENU_ENUM_LABEL_CUSTOM_RATIO:
-         return "custom_ratio";
-      case MENU_ENUM_LABEL_USE_THIS_DIRECTORY:
-         return "use_this_directory";
-      case MENU_ENUM_LABEL_RDB_ENTRY_START_CONTENT:
-         return "rdb_entry_start_content";
-      case MENU_ENUM_LABEL_CUSTOM_BIND:
-         return "custom_bind";
-      case MENU_ENUM_LABEL_CUSTOM_BIND_ALL:
-         return "custom_bind_all";
-      case MENU_ENUM_LABEL_DISK_OPTIONS:
-         return "core_disk_options";
-      case MENU_ENUM_LABEL_CORE_CHEAT_OPTIONS:
-         return "core_cheat_options";
-      case MENU_ENUM_LABEL_CORE_OPTIONS:
-         return "core_options";
-      case MENU_ENUM_LABEL_DATABASE_MANAGER_LIST:
-         return "database_manager_list";
-      case MENU_ENUM_LABEL_DEFERRED_DATABASE_MANAGER_LIST:
-         return "deferred_database_manager_list";
-      case MENU_ENUM_LABEL_CURSOR_MANAGER_LIST:
-         return "cursor_manager_list";
-      case MENU_ENUM_LABEL_DEFERRED_CURSOR_MANAGER_LIST:
-         return "deferred_cursor_manager_list";
-      case MENU_ENUM_LABEL_CHEAT_FILE_LOAD:
-         return "cheat_file_load";
-      case MENU_ENUM_LABEL_CHEAT_FILE_SAVE_AS:
-         return "cheat_file_save_as";
-      case MENU_ENUM_LABEL_DEFERRED_RDB_ENTRY_DETAIL:
-         return "deferred_rdb_entry_detail";
-      case MENU_ENUM_LABEL_FRONTEND_COUNTERS:
-         return "frontend_counters";
-      case MENU_ENUM_LABEL_CORE_COUNTERS:
-         return "core_counters";
-      case MENU_ENUM_LABEL_DISK_CYCLE_TRAY_STATUS:
-         return "disk_cycle_tray_status";
-      case MENU_ENUM_LABEL_DISK_IMAGE_APPEND:
-         return "disk_image_append";
-      case MENU_ENUM_LABEL_DEFERRED_CORE_LIST:
-         return "deferred_core_list";
-      case MENU_ENUM_LABEL_DEFERRED_CORE_LIST_SET:
-         return "deferred_core_list_set";
-      case MENU_ENUM_LABEL_INFO_SCREEN:
-         return "info_screen";
-      case MENU_ENUM_LABEL_SETTINGS:
-         return "settings";
-      case MENU_ENUM_LABEL_QUIT_RETROARCH:
-         return "quit_retroarch";
-      case MENU_ENUM_LABEL_SHUTDOWN:
-         return "shutdown";
-      case MENU_ENUM_LABEL_REBOOT:
-         return "reboot";
-      case MENU_ENUM_LABEL_HELP:
-         return "help";
-      case MENU_ENUM_LABEL_SAVE_NEW_CONFIG:
-         return "save_new_config";
-      case MENU_ENUM_LABEL_RESTART_CONTENT:
-         return "restart_content";
-      case MENU_ENUM_LABEL_TAKE_SCREENSHOT:
-         return "take_screenshot";
-      case MENU_ENUM_LABEL_DELETE_ENTRY:
-         return "delete_entry";
-      case MENU_ENUM_LABEL_CORE_UPDATER_LIST:
-         return "core_updater_list";
-      case MENU_ENUM_LABEL_START_VIDEO_PROCESSOR:
-         return "menu_start_video_processor";
-      case MENU_ENUM_LABEL_START_NET_RETROPAD:
-         return "menu_start_net_retropad";
-      case MENU_ENUM_LABEL_THUMBNAILS_UPDATER_LIST:
-         return "thumbnails_updater_list";
-      case MENU_ENUM_LABEL_CORE_UPDATER_BUILDBOT_URL:
-         return "core_updater_buildbot_url";
-      case MENU_ENUM_LABEL_BUILDBOT_ASSETS_URL:
-         return "buildbot_assets_url";
-      case MENU_ENUM_LABEL_NAVIGATION_WRAPAROUND:
-         return "menu_navigation_wraparound_enable";
-      case MENU_ENUM_LABEL_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
-         return "menu_navigation_browser_filter_supported_extensions_enable";
-      case MENU_ENUM_LABEL_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
-         return "core_updater_auto_extract_archive";
-      case MENU_ENUM_LABEL_ACHIEVEMENT_LIST:
-         return "achievement_list";
-      case MENU_ENUM_LABEL_SYSTEM_INFORMATION:
-         return "system_information";
-      case MENU_ENUM_LABEL_NETWORK_INFORMATION:
-         return "network_information";
-      case MENU_ENUM_LABEL_ONLINE_UPDATER:
-         return "online_updater";
-      case MENU_ENUM_LABEL_NETPLAY:
-         return "netplay";
-      case MENU_ENUM_LABEL_CORE_INFORMATION:
-         return "core_information";
-      case MENU_ENUM_LABEL_CORE_LIST:
-         return "load_core";
-      case MENU_ENUM_LABEL_LOAD_CONTENT:
-         return "load_content_default";
-      case MENU_ENUM_LABEL_CLOSE_CONTENT:
-         return "unload_core";
-      case MENU_ENUM_LABEL_MANAGEMENT:
-         return "database_settings";
-      case MENU_ENUM_LABEL_SAVE_STATE:
-         return "savestate";
-      case MENU_ENUM_LABEL_LOAD_STATE:
-         return "loadstate";
-      case MENU_ENUM_LABEL_UNDO_LOAD_STATE:
-         return "undoloadstate";
-      case MENU_ENUM_LABEL_UNDO_SAVE_STATE:
-         return "undosavestate";
-      case MENU_ENUM_LABEL_RESUME_CONTENT:
-         return "resume_content";
-      case MENU_ENUM_LABEL_INPUT_DRIVER:
-         return "input_driver";
-      case MENU_ENUM_LABEL_AUDIO_DRIVER:
-         return "audio_driver";
-      case MENU_ENUM_LABEL_JOYPAD_DRIVER:
-         return "input_joypad_driver";
-      case MENU_ENUM_LABEL_AUDIO_RESAMPLER_DRIVER:
-         return "audio_resampler_driver";
-      case MENU_ENUM_LABEL_RECORD_DRIVER:
-         return "record_driver";
-      case MENU_ENUM_LABEL_MENU_DRIVER:
-         return "menu_driver";
-      case MENU_ENUM_LABEL_CAMERA_DRIVER:
-         return "camera_driver";
-      case MENU_ENUM_LABEL_WIFI_DRIVER:
-         return "wifi_driver";
-      case MENU_ENUM_LABEL_LOCATION_DRIVER:
-         return "location_driver";
-      case MENU_ENUM_LABEL_OVERLAY_SCALE:
-         return "input_overlay_scale";
-      case MENU_ENUM_LABEL_OVERLAY_PRESET:
-         return "input_overlay";
-      case MENU_ENUM_LABEL_KEYBOARD_OVERLAY_PRESET:
-         return "input_osk_overlay";
-      case MENU_ENUM_LABEL_AUDIO_DEVICE:
-         return "audio_device";
-      case MENU_ENUM_LABEL_AUDIO_LATENCY:
-         return "audio_latency";
-      case MENU_ENUM_LABEL_OVERLAY_OPACITY:
-         return "input_overlay_opacity";
-      case MENU_ENUM_LABEL_MENU_WALLPAPER:
-         return "menu_wallpaper";
-      case MENU_ENUM_LABEL_DYNAMIC_WALLPAPER:
-         return "menu_dynamic_wallpaper_enable";
-      case MENU_ENUM_LABEL_THUMBNAILS:
-         return "thumbnails";
-      case MENU_ENUM_LABEL_CORE_INPUT_REMAPPING_OPTIONS:
-         return "core_input_remapping_options";
-      case MENU_ENUM_LABEL_SHADER_OPTIONS:
-         return "shader_options";
       case MENU_ENUM_LABEL_VIDEO_SHADER_PARAMETERS:
          return "video_shader_parameters";
+      case MENU_ENUM_LABEL_VIDEO_SHADER_PASS:
+         return "video_shader_pass";
+      case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET:
+         return "video_shader_preset";
       case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_PARAMETERS:
          return "video_shader_preset_parameters";
       case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_SAVE_AS:
          return "video_shader_preset_save_as";
-      case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET:
-         return "video_shader_preset";
-      case MENU_ENUM_LABEL_VIDEO_FILTER:
-         return "video_filter";
-      case MENU_ENUM_LABEL_DEFERRED_VIDEO_FILTER:
-         return "deferred_video_filter";
-      case MENU_ENUM_LABEL_DEFERRED_CORE_UPDATER_LIST:
-         return "core_updater";
-      case MENU_ENUM_LABEL_DEFERRED_THUMBNAILS_UPDATER_LIST:
-         return "deferred_thumbnails_updater_list";
-      case MENU_ENUM_LABEL_AUDIO_DSP_PLUGIN:
-         return "audio_dsp_plugin";
-      case MENU_ENUM_LABEL_UPDATE_ASSETS:
-         return "update_assets";
-      case MENU_ENUM_LABEL_UPDATE_LAKKA:
-         return "update_lakka";
-      case MENU_ENUM_LABEL_UPDATE_CHEATS:
-         return "update_cheats";
-      case MENU_ENUM_LABEL_UPDATE_AUTOCONFIG_PROFILES:
-         return "update_autoconfig_profiles";
-      case MENU_ENUM_LABEL_UPDATE_DATABASES:
-         return "update_databases";
-      case MENU_ENUM_LABEL_UPDATE_OVERLAYS:
-         return "update_overlays";
-      case MENU_ENUM_LABEL_UPDATE_CG_SHADERS:
-         return "update_cg_shaders";
-      case MENU_ENUM_LABEL_UPDATE_GLSL_SHADERS:
-         return "update_glsl_shaders";
-      case MENU_ENUM_LABEL_UPDATE_SLANG_SHADERS:
-         return "update_slang_shaders";
-      case MENU_ENUM_LABEL_SCREEN_RESOLUTION:
-         return "screen_resolution";
-      case MENU_ENUM_LABEL_USE_BUILTIN_IMAGE_VIEWER:
-         return "use_builtin_image_viewer";
-      case MENU_ENUM_LABEL_INPUT_POLL_TYPE_BEHAVIOR:
-         return "input_poll_type_behavior";
-      case MENU_ENUM_LABEL_MENU_WALLPAPER_OPACITY:
-         return "menu_wallpaper_opacity";
+      case MENU_ENUM_LABEL_VIDEO_SHADER_SCALE_PASS:
+         return "video_shader_scale_pass";
+      case MENU_ENUM_LABEL_VIDEO_SHARED_CONTEXT:
+         return "video_shared_context";
+      case MENU_ENUM_LABEL_VIDEO_SMOOTH:
+         return "video_smooth";
+      case MENU_ENUM_LABEL_VIDEO_SOFT_FILTER:
+         return "soft_filter";
+      case MENU_ENUM_LABEL_VIDEO_SWAP_INTERVAL:
+         return "video_swap_interval";
+      case MENU_ENUM_LABEL_VIDEO_TAB:
+         return "video_tab";
+      case MENU_ENUM_LABEL_VIDEO_THREADED:
+         return "video_threaded";
+      case MENU_ENUM_LABEL_VIDEO_VFILTER:
+         return "video_vfilter";
+      case MENU_ENUM_LABEL_VIDEO_VIEWPORT_CUSTOM_HEIGHT:
+         return "video_viewport_custom_height";
+      case MENU_ENUM_LABEL_VIDEO_VIEWPORT_CUSTOM_WIDTH:
+         return "video_viewport_custom_width";
+      case MENU_ENUM_LABEL_VIDEO_VIEWPORT_CUSTOM_X:
+         return "video_viewport_custom_x";
+      case MENU_ENUM_LABEL_VIDEO_VIEWPORT_CUSTOM_Y:
+         return "video_viewport_custom_y";
+      case MENU_ENUM_LABEL_VIDEO_VI_WIDTH:
+         return "video_vi_width";
+      case MENU_ENUM_LABEL_VIDEO_VSYNC:
+         return "video_vsync";
+      case MENU_ENUM_LABEL_VIDEO_WINDOWED_FULLSCREEN:
+         return "video_windowed_fullscreen";
+      case MENU_ENUM_LABEL_WIFI_DRIVER:
+         return "wifi_driver";
+      case MENU_ENUM_LABEL_WIFI_SETTINGS:
+         return "wifi_settings";
+      case MENU_ENUM_LABEL_XMB_ALPHA_FACTOR:
+         return "xmb_alpha_factor";
+      case MENU_ENUM_LABEL_XMB_FONT:
+         return "xmb_font";
+      case MENU_ENUM_LABEL_XMB_MENU_COLOR_THEME:
+         return "xmb_menu_color_theme";
+      case MENU_ENUM_LABEL_XMB_RIBBON_ENABLE:
+         return "xmb_ribbon_enable";
+      case MENU_ENUM_LABEL_XMB_SCALE_FACTOR:
+         return "xmb_scale_factor";
+      case MENU_ENUM_LABEL_XMB_SHADOWS_ENABLE:
+         return "xmb_shadows_enable";
+      case MENU_ENUM_LABEL_XMB_SHOW_HISTORY:
+         return "xmb_show_history";
+      case MENU_ENUM_LABEL_XMB_SHOW_IMAGES:
+         return "xmb_show_images";
+      case MENU_ENUM_LABEL_XMB_SHOW_MUSIC:
+         return "xmb_show_music";
+      case MENU_ENUM_LABEL_XMB_SHOW_SETTINGS:
+         return "xmb_show_settings";
+      case MENU_ENUM_LABEL_XMB_SHOW_VIDEO:
+         return "xmb_show_video";
+      case MENU_ENUM_LABEL_XMB_THEME:
+         return "xmb_theme";
+      case MENU_ENUM_SUBLABEL_MENU_SETTINGS:
+         return "调整菜单屏幕相关的设置。";
+      case MENU_ENUM_SUBLABEL_VIDEO_HARD_SYNC:
+         return "强制同步CPU和GPU，以性能为代价换取低延迟。";
+      case MENU_ENUM_SUBLABEL_VIDEO_THREADED:
+         return "以延迟和视频撕裂为代价换取高性能，当且仅当能达到全速模拟时使用。";
+      case MSG_AUDIO_VOLUME:
+         return "Audio volume";
+      case MSG_AUTODETECT:
+         return "自动检测";
+      case MSG_AUTOLOADING_SAVESTATE_FROM:
+         return "Auto-loading savestate from";
+      case MSG_BRINGING_UP_COMMAND_INTERFACE_ON_PORT:
+         return "bringing_up_command_interface_at_port";
+      case MSG_CONNECTING_TO_NETPLAY_HOST:
+         return "Connecting to netplay host";
+      case MSG_CONNECTING_TO_PORT:
+         return "Connecting to port";
+      case MSG_CONNECTION_SLOT:
+         return "Connection slot";
+      case MSG_CONNECT_DEVICE_FROM_A_VALID_PORT:
+         return "connect_device_from_a_valid_port";
+      case MSG_DEVICE_CONFIGURED_IN_PORT:
+         return "configured in port";
+      case MSG_DEVICE_DISCONNECTED_FROM_PORT:
+        return "Device disconnected from port";
+      case MSG_DEVICE_NOT_CONFIGURED:
+         return "not configured";
+      case MSG_DISCONNECTING_DEVICE_FROM_PORT:
+         return "disconnecting_device_from_port";
+      case MSG_DISCONNECT_DEVICE_FROM_A_VALID_PORT:
+         return "disconnect_device_from_a_valid_port";
+      case MSG_FAILED:
+         return "已失败";
+      case MSG_FAILED_TO_SET_DISK:
+         return "Failed to set disk";
+      case MSG_FAILED_TO_START_AUDIO_DRIVER:
+         return "failed_to_start_audio_driver";
+      case MSG_FILE_ALREADY_EXISTS_SAVING_TO_BACKUP_BUFFER:
+         return "File already exists. Saving to backup buffer";
+      case MSG_FOUND_LAST_STATE_SLOT:
+         return "found_last_state_slot";
+      case MSG_GOT_CONNECTION_FROM:
+         return "Got connection from";
+      case MSG_NETPLAY_USERS_HAS_FLIPPED:
+         return "Netplay users has flipped";
+      case MSG_SETTING_DISK_IN_TRAY:
+         return "Setting disk in tray";
+      case MSG_SUCCEEDED:
+         return "已成功";
+      case MSG_UNKNOWN_NETPLAY_COMMAND_RECEIVED:
+         return "Unknown netplay command received";
+      case MSG_WAITING_FOR_CLIENT:
+         return "Waiting for client ...";
       default:
          break;
    }
@@ -3001,1788 +3001,1788 @@ const char *msg_hash_to_str_chs(enum msg_hash_enums msg)
 
    switch (msg)
    {
-      case MENU_ENUM_SUBLABEL_CONFIG_SAVE_ON_EXIT:
-         return "程序将在退出时保存修改到配置文件。";
-      case MENU_ENUM_SUBLABEL_VIDEO_HARD_SYNC_FRAMES:
-         return "设置当开启“强制GPU同步”时CPU可以预先GPU多少帧。";
-      case MENU_ENUM_SUBLABEL_VIDEO_REFRESH_RATE_AUTO:
-         return "估算的显示器刷新率(Hz)。";
-      case MENU_ENUM_SUBLABEL_VIDEO_MONITOR_INDEX:
-         return "选择将要使用哪一个显示器。";
-      case MENU_ENUM_SUBLABEL_LOG_VERBOSITY:
-         return "启用或禁止向控制台打印日志。";
-      case MENU_ENUM_SUBLABEL_SHOW_HIDDEN_FILES:
-         return "在文件浏览器中显示隐藏的文件或文件夹。";
-      case MENU_ENUM_SUBLABEL_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
-         return "控制器用来切出菜单的组合键。";
-      case MENU_ENUM_SUBLABEL_CPU_CORES:
-         return "CPU拥有的核心总数。";
-      case MENU_ENUM_SUBLABEL_VIDEO_BLACK_FRAME_INSERTION:
-         return "在帧与帧之间插入黑色的中间帧，通常用于消除在120Hz刷新率的显示器上运行60Hz的游戏内容带来的鬼影。";
-      case MENU_ENUM_SUBLABEL_VIDEO_FRAME_DELAY:
-         return "以增加画面卡顿的风险换取低延时，在垂直同步后增加时延(毫秒)。";
-      case MENU_ENUM_SUBLABEL_ADD_CONTENT_LIST:
-         return "下载且/或者扫描游戏内容，并将其加入你的收藏中。";
-      case MENU_ENUM_SUBLABEL_NETPLAY:
-         return "加入或者开启一个在线多人游戏的会话。";
-      case MENU_ENUM_SUBLABEL_FPS_SHOW:
-         return "在屏幕上显示当前每秒的帧率。";
-      case MENU_ENUM_SUBLABEL_VIDEO_SETTINGS:
-         return "调整视频输出的选项。";
-      case MENU_ENUM_SUBLABEL_AUDIO_SETTINGS:
-         return "调整音频输出的选项。";
-      case MENU_ENUM_SUBLABEL_INPUT_SETTINGS:
-         return "调整游戏控制器、键盘和鼠标的设置。";
-      case MENU_ENUM_SUBLABEL_WIFI_SETTINGS:
-         return "扫描无线网络并且建立连接。";
-      case MENU_ENUM_SUBLABEL_SERVICES_SETTINGS:
-         return "管理操作系统层级的服务。";
-      case MENU_ENUM_SUBLABEL_SSH_ENABLE:
-         return "启用或者禁止远程终端访问(SSH)。";
-      case MENU_ENUM_SUBLABEL_SAMBA_ENABLE:
-         return "启用或者禁止网络文件夹共享(SAMBA)。";
-      case MENU_ENUM_SUBLABEL_BLUETOOTH_ENABLE:
-         return "启用或者禁止蓝牙。";
-      case MENU_ENUM_SUBLABEL_USER_LANGUAGE:
-         return "设置用户界面的语言。";
-      case MENU_ENUM_SUBLABEL_SUSPEND_SCREENSAVER_ENABLE:
-         return "阻止系统激活屏幕保护程序。";
-      case MENU_ENUM_SUBLABEL_VIDEO_MAX_SWAPCHAIN_IMAGES:
-         return "强制显示驱动程序使用特定的缓冲模式。";
-      case MENU_ENUM_SUBLABEL_ONLINE_UPDATER:
-         return "下载并更新RetroArch的附加插件和组件。";
-      case MENU_ENUM_SUBLABEL_INPUT_USER_BINDS:
-         return "配置该用户的控制选项。";
-      case MENU_ENUM_SUBLABEL_INPUT_HOTKEY_BINDS:
-         return "配置热键选项。";
-      case MSG_VALUE_SHUTTING_DOWN:
-         return "正在关机……";
-      case MSG_VALUE_REBOOTING:
-         return "正在重启……";
-      case MSG_FAILED_TO_START_AUDIO_DRIVER:
-         return "音频驱动启动失败，将在无音频模式下继续启动。";
-      case MSG_FOUND_LAST_STATE_SLOT:
-         return "Found last state slot";
-      case MSG_VALUE_CONNECT_DEVICE_FROM_A_VALID_PORT:
-         return "Connect device from a valid port.";
-      case MSG_DISCONNECT_DEVICE_FROM_A_VALID_PORT:
-         return "Disconnect device from a valid port.";
-      case MSG_VALUE_DISCONNECTING_DEVICE_FROM_PORT:
-         return "Disconnecting device from port";
-      case MSG_BRINGING_UP_COMMAND_INTERFACE_ON_PORT:
-         return "Bringing up command interface on port";
-      case MSG_LOADING_HISTORY_FILE:
-         return "Loading history file";
-      case MENU_ENUM_LABEL_VALUE_SHADER_PIPELINE_RIBBON_SIMPLIFIED:
-         return "Ribbon (简化)";
-      case MENU_ENUM_LABEL_VALUE_SHADER_PIPELINE_RIBBON:
-         return "Ribbon";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_FOOTER_OPACITY:
-         return "底部不透明度";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_HEADER_OPACITY:
-         return "顶部不透明度";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_BLUE:
-         return "蓝色";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_BLUE_GREY:
-         return "蓝灰色";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_RED:
-         return "红色";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_YELLOW:
-         return "黄色";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_NVIDIA_SHIELD:
-         return "NV SHIELD";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_GREEN:
-         return "绿色";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_DARK_BLUE:
-         return "深蓝色";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_PLAIN:
-         return "朴素";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_LEGACY_RED:
-         return "传统红";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_DARK_PURPLE:
-         return "深紫色";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_MIDNIGHT_BLUE:
-         return "蓝黑色";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_GOLDEN:
-         return "金色";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_ELECTRIC_BLUE:
-         return "铁蓝色";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_APPLE_GREEN:
-         return "苹果绿";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_UNDERSEA:
-         return "海底";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_VOLCANIC_RED:
-         return "火山红";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_DARK:
-         return "深色";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_UNLOCKED_ENTRY:
-         return "未锁定";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_LOCKED_ENTRY:
-         return "锁定";
-      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR_LATE:
-         return "稍晚";
-      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR_NORMAL:
-         return "正常";
-      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR_EARLY:
-         return "较早";
-      case MSG_INTERNAL_MEMORY:
-         return "内部存储";
-      case MSG_EXTERNAL_APPLICATION_DIR:
-         return "外部应用程序目录";
-      case MSG_APPLICATION_DIR:
-         return "应用程序目录";
-      case MSG_PROGRAM:
-         return "RetroArch";
-      case MSG_LIBRETRO_FRONTEND:
-         return "为libretro而设计的前端";
-      case MSG_LOADING:
-         return "正在加载";
-      case MSG_GAME_SPECIFIC_CORE_OPTIONS_FOUND_AT:
-         return "Per-Game Options: game-specific core options found at";
-      case MSG_RESTORING_DEFAULT_SHADER_PRESET_TO:
-         return "Shaders: restoring default shader preset to";
-      case  MSG_SORRY_UNIMPLEMENTED_CORES_DONT_DEMAND_CONTENT_NETPLAY:
-         return "Sorry, unimplemented: cores that don't demand content cannot participate in netplay.";
-      case MSG_FOUND_AUTO_SAVESTATE_IN:
-         return "Found auto savestate in";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_REMOTE_PORT:
-         return "网络远端基本端口";
-      case MSG_OVERRIDES_SAVED_SUCCESSFULLY:
-         return "Overrides saved successfully.";
-      case MSG_AUTOCONFIG_FILE_SAVED_SUCCESSFULLY:
-         return "Autoconfig file saved successfully.";
-      case MSG_OVERRIDES_ERROR_SAVING:
-         return "Error saving overrides.";
-      case MSG_AUTOCONFIG_FILE_ERROR_SAVING:
-         return "Error saving autoconf file.";
-      case MSG_DOWNLOAD_FAILED:
-         return "下载失败";
-      case MSG_INPUT_CHEAT:
-         return "输入金手指";
-      case MSG_DECOMPRESSION_ALREADY_IN_PROGRESS:
-         return "解压缩已在进行中。";
-      case MSG_DECOMPRESSION_FAILED:
-         return "解压缩失败。";
-      case MSG_CORE_OPTIONS_FILE_CREATED_SUCCESSFULLY:
-         return "Core options file created successfully.";
-      case MSG_FAILED_TO_CREATE_THE_DIRECTORY:
-         return "创建目录失败。";
-      case MSG_FAILED_TO_EXTRACT_CONTENT_FROM_COMPRESSED_FILE:
-         return "Failed to extract content from compressed file";
-      case MSG_FILE_NOT_FOUND:
-         return "未找到文件";
-      case MSG_ERROR_SAVING_CORE_OPTIONS_FILE:
-         return "Error saving core options file.";
-      case MSG_FAILED_TO_ALLOCATE_MEMORY_FOR_PATCHED_CONTENT:
-         return "Failed to allocate memory for patched content...";
-      case MSG_DID_NOT_FIND_A_VALID_CONTENT_PATCH:
-         return "Did not find a valid content patch.";
-      case MSG_SEVERAL_PATCHES_ARE_EXPLICITLY_DEFINED:
-         return "Several patches are explicitly defined, ignoring all...";
-      case MSG_REMAP_FILE_SAVED_SUCCESSFULLY:
-         return "Remap file saved successfully.";
-      case MSG_SHADER_PRESET_SAVED_SUCCESSFULLY:
-         return "Shader preset saved successfully.";
-      case MSG_ERROR_SAVING_REMAP_FILE:
-         return "Error saving remap file.";
-      case MSG_ERROR_SAVING_SHADER_PRESET:
-         return "Error saving shader preset.";
-      case MSG_INPUT_CHEAT_FILENAME:
-         return "Cheat Filename";
-      case MSG_INPUT_PRESET_FILENAME:
-         return "Preset Filename";
-      case MSG_DISK_EJECTED:
-         return "Ejected";
-      case MSG_DISK_CLOSED:
-         return "Closed";
-      case MSG_VERSION_OF_LIBRETRO_API:
-         return "Version of libretro API";
-      case MSG_COMPILED_AGAINST_API:
-         return "Compiled against API";
-      case MSG_FAILED_TO_LOAD:
-         return "无法加载";
-      case MSG_CONNECTED_TO:
-         return "Connected to";
-      case MSG_FAILED_TO_ACCEPT_INCOMING_SPECTATOR:
-         return "Failed to accept incoming spectator.";
-      case MSG_FAILED_TO_GET_NICKNAME_FROM_CLIENT:
-         return "Failed to get nickname from client.";
-      case MSG_FAILED_TO_SEND_NICKNAME_TO_CLIENT:
-         return "Failed to send nickname to client.";
-      case MSG_USING_CORE_NAME_FOR_NEW_CONFIG:
-         return "Using core name for new config.";
-      case MSG_CANNOT_INFER_NEW_CONFIG_PATH:
-         return "Cannot infer new config path. Use current time.";
-      case MSG_NO_STATE_HAS_BEEN_LOADED_YET:
-         return "No state has been loaded yet.";
-      case MSG_NO_SAVE_STATE_HAS_BEEN_OVERWRITTEN_YET:
-         return "No save state has been overwritten yet.";
-      case MSG_RESTORED_OLD_SAVE_STATE:
-         return "Restored old save state.";
-      case MSG_SAVED_NEW_CONFIG_TO:
-         return "已保存新配置到";
-      case MSG_FAILED_SAVING_CONFIG_TO:
-         return "无法保存配置到";
-      case MSG_FAILED_TO_RECEIVE_NICKNAME_SIZE_FROM_HOST:
-         return "Failed to receive nickname size from host.";
-      case MSG_FAILED_TO_RECEIVE_NICKNAME:
-         return "Failed to receive nickname.";
-      case MSG_FAILED_TO_RECEIVE_NICKNAME_FROM_HOST:
-         return "Failed to receive nickname from host.";
-      case MSG_FAILED_TO_SEND_NICKNAME_SIZE:
-         return "Failed to send nickname size.";
-      case MSG_FAILED_TO_SEND_SRAM_DATA_TO_CLIENT:
-         return "Failed to send SRAM data to client.";
-      case MSG_FAILED_TO_RECEIVE_HEADER_FROM_CLIENT:
-         return "Failed to receive header from client.";
-      case MSG_FAILED_TO_RECEIVE_SRAM_DATA_FROM_HOST:
-         return "Failed to receive SRAM data from host.";
-      case MSG_CONTENT_CRC32S_DIFFER:
-         return "Content CRC32s differ. Cannot use different games.";
-      case MSG_FAILED_TO_SEND_NICKNAME:
-         return "Failed to send nickname.";
-      case MSG_FAILED_TO_SEND_NICKNAME_TO_HOST:
-         return "Failed to send nickname to host.";
-      case MSG_INVALID_NICKNAME_SIZE:
-         return "Invalid nickname size.";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ANALOG:
-         return "支持摇杆输入";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_SERIAL:
-         return "系列";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_COOP:
-         return "多人游戏支持";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ENHANCEMENT_HW:
-         return "增强硬件";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ELSPA_RATING:
-         return "ELSPA 分级";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RUMBLE:
-         return "震动支持";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_PEGI_RATING:
-         return "PEGI 分级";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_EDGE_MAGAZINE_ISSUE:
-         return "Edge Magazine Issue";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_BBFC_RATING:
-         return "BBFC 分级";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ESRB_RATING:
-         return "ESRB 分级";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_CERO_RATING:
-         return "CERO 分级";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MAX_SWAPCHAIN_IMAGES:
-         return "最大交换链图像数";
-      case MSG_ERROR_LIBRETRO_CORE_REQUIRES_CONTENT:
-         return "Libretro core requires content, but nothing was provided.";
-      case MSG_CONTENT_LOADING_SKIPPED_IMPLEMENTATION_WILL_DO_IT:
-         return "Content loading skipped. Implementation will load it on its own.";
-      case MSG_ERROR_LIBRETRO_CORE_REQUIRES_SPECIAL_CONTENT:
-         return "Libretro core requires special content, but none were provided.";
-      case MSG_REVERTING_SAVEFILE_DIRECTORY_TO:
-         return "Reverting savefile directory to";
-      case MSG_REVERTING_SAVESTATE_DIRECTORY_TO:
-         return "Reverting savestate directory to";
-      case MSG_COULD_NOT_READ_MOVIE_HEADER:
-         return "Could not read movie header.";
-      case MSG_FAILED_TO_OPEN_LIBRETRO_CORE:
-         return "Failed to open libretro core";
-      case MSG_COULD_NOT_FIND_ANY_NEXT_DRIVER:
-         return "Could not find any next driver";
-      case MSG_MOVIE_FORMAT_DIFFERENT_SERIALIZER_VERSION:
-         return "Movie format seems to have a different serializer version. Will most likely fail.";
-      case MSG_CRC32_CHECKSUM_MISMATCH:
-         return "CRC32 checksum mismatch between content file and saved content checksum in replay file header; replay highly likely to desync on playback.";
-      case MSG_INFLATED_CHECKSUM_DID_NOT_MATCH_CRC32:
-         return "Inflated checksum did not match CRC32.";
-      case MSG_ERROR_PARSING_ARGUMENTS:
-         return "Error parsing arguments.";
-      case MSG_ERROR:
-         return "Error";
-      case MSG_FOUND_DISK_LABEL:
-         return "Found disk label";
-      case MSG_READING_FIRST_DATA_TRACK:
-         return "Reading first data track...";
-      case MSG_FOUND_FIRST_DATA_TRACK_ON_FILE:
-         return "Found first data track on file";
-      case MSG_COULD_NOT_FIND_VALID_DATA_TRACK:
-         return "Could not find valid data track";
-      case MSG_COMPARING_WITH_KNOWN_MAGIC_NUMBERS:
-         return "Comparing with known magic numbers...";
-      case MSG_COULD_NOT_FIND_COMPATIBLE_SYSTEM:
-         return "Could not find compatible system.";
-      case MSG_COULD_NOT_OPEN_DATA_TRACK:
-         return "could not open data track";
-      case MSG_MEMORY:
-         return "内存";
-      case MSG_FRAMES:
-         return "帧";
-      case MSG_IN_BYTES:
-         return "(字节)";
-      case MSG_IN_MEGABYTES:
-         return "(兆字节)";
-      case MSG_IN_GIGABYTES:
-         return "(吉字节)";
-      case MSG_INTERFACE:
-         return "接口";
-      case MSG_FAILED_TO_PATCH:
-         return "补丁应用失败";
-      case MSG_FATAL_ERROR_RECEIVED_IN:
-         return "Fatal error received in";
-      case MSG_MOVIE_RECORD_STOPPED:
-         return "Stopping movie record.";
-      case MSG_MOVIE_PLAYBACK_ENDED:
-         return "Movie playback ended.";
-      case MSG_AUTOSAVE_FAILED:
-         return "Could not initialize autosave.";
-      case MSG_NETPLAY_FAILED_MOVIE_PLAYBACK_HAS_STARTED:
-         return "Movie playback has started. Cannot start netplay.";
-      case MSG_NETPLAY_FAILED:
-         return "Failed to initialize netplay.";
-      case MSG_LIBRETRO_ABI_BREAK:
-         return "is compiled against a different version of libretro than this libretro implementation.";
-      case MSG_REWIND_INIT_FAILED_THREADED_AUDIO:
-         return "Implementation uses threaded audio. Cannot use rewind.";
-      case MSG_REWIND_INIT_FAILED:
-         return "Failed to initialize rewind buffer. Rewinding will be disabled.";
-      case MSG_REWIND_INIT:
-         return "Initializing rewind buffer with size";
-      case MSG_CUSTOM_TIMING_GIVEN:
-         return "Custom timing given";
-      case MSG_VIEWPORT_SIZE_CALCULATION_FAILED:
-         return "Viewport size calculation failed! Will continue using raw data. This will probably not work right ...";
-      case MSG_HW_RENDERED_MUST_USE_POSTSHADED_RECORDING:
-         return "Libretro core is hardware rendered. Must use post-shaded recording as well.";
-      case MSG_RECORDING_TO:
-         return "Recording to";
-      case MSG_DETECTED_VIEWPORT_OF:
-         return "Detected viewport of";
-      case MSG_TAKING_SCREENSHOT:
-         return "Taking screenshot.";
-      case MSG_FAILED_TO_TAKE_SCREENSHOT:
-         return "Failed to take screenshot.";
-      case MSG_FAILED_TO_START_RECORDING:
-         return "Failed to start recording.";
-      case MSG_RECORDING_TERMINATED_DUE_TO_RESIZE:
-         return "Recording terminated due to resize.";
-      case MSG_USING_LIBRETRO_DUMMY_CORE_RECORDING_SKIPPED:
-         return "Using libretro dummy core. Skipping recording.";
-      case MSG_UNKNOWN:
-         return "Unknown";
-      case MSG_COULD_NOT_READ_STATE_FROM_MOVIE:
-         return "Could not read state from movie.";
-      case MSG_MOVIE_FILE_IS_NOT_A_VALID_BSV1_FILE:
-         return "Movie file is not a valid BSV1 file.";
-      case MSG_LOADING_CONTENT_FILE:
-         return "Loading content file";
-      case MSG_RECEIVED:
-         return "received";
-      case MSG_UNRECOGNIZED_COMMAND:
-         return "Unrecognized command";
-      case MSG_SENDING_COMMAND:
-         return "Sending command";
-      case MSG_GOT_INVALID_DISK_INDEX:
-         return "Got invalid disk index.";
-      case MSG_FAILED_TO_REMOVE_DISK_FROM_TRAY:
-         return "Failed to remove disk from tray.";
-      case MSG_REMOVED_DISK_FROM_TRAY:
-         return "Removed disk from tray.";
-      case MSG_VIRTUAL_DISK_TRAY:
-         return "virtual disk tray.";
-      case MSG_FAILED_TO:
-         return "Failed to";
-      case MSG_TO:
-         return "to";
-      case MSG_SAVING_RAM_TYPE:
-         return "Saving RAM type";
-      case MSG_UNDOING_SAVE_STATE:
-         return "Undoing save state";
-      case MSG_SAVING_STATE:
-         return "Saving state";
-      case MSG_LOADING_STATE:
-         return "Loading state";
-      case MSG_FAILED_TO_LOAD_MOVIE_FILE:
-         return "Failed to load movie file";
-      case MSG_FAILED_TO_LOAD_CONTENT:
-         return "Failed to load content";
-      case MSG_COULD_NOT_READ_CONTENT_FILE:
-         return "Could not read content file";
-      case MSG_GRAB_MOUSE_STATE:
-         return "Grab mouse state";
-      case MSG_PAUSED:
-         return "暂停。";
-      case MSG_UNPAUSED:
-         return "取消暂停。";
-      case MSG_FAILED_TO_LOAD_OVERLAY:
-         return "Failed to load overlay.";
-      case MSG_FAILED_TO_UNMUTE_AUDIO:
-         return "Failed to unmute audio.";
-      case MSG_AUDIO_MUTED:
-         return "静音。";
-      case MSG_AUDIO_UNMUTED:
-         return "取消静音。";
-      case MSG_RESET:
-         return "重置";
-      case MSG_AUTO_SAVE_STATE_TO:
-         return "自动保存状态至";
-      case MSG_FAILED_TO_LOAD_STATE:
-         return "Failed to load state from";
-      case MSG_FAILED_TO_SAVE_STATE_TO:
-         return "Failed to save state to";
-      case MSG_FAILED_TO_UNDO_LOAD_STATE:
-         return "Failed to undo load state.";
-      case MSG_FAILED_TO_UNDO_SAVE_STATE:
-         return "Failed to undo save state.";
-      case MSG_FAILED_TO_SAVE_SRAM:
-         return "Failed to save SRAM";
-      case MSG_STATE_SIZE:
-         return "State size";
-      case MSG_FOUND_SHADER:
-         return "Found shader";
-      case MSG_SRAM_WILL_NOT_BE_SAVED:
-         return "SRAM will not be saved.";
-      case MSG_BLOCKING_SRAM_OVERWRITE:
-         return "Blocking SRAM Overwrite";
-      case MSG_CORE_DOES_NOT_SUPPORT_SAVESTATES:
-         return "核心不支持保存状态。";
-      case MSG_SAVED_STATE_TO_SLOT:
-         return "保存状态至槽";
-      case MSG_SAVED_SUCCESSFULLY_TO:
-         return "成功保存至";
-      case MSG_BYTES:
-         return "bytes";
-      case MSG_CONFIG_DIRECTORY_NOT_SET:
-         return "Config directory not set. Cannot save new config.";
-      case MSG_SKIPPING_SRAM_LOAD:
-         return "Skipping SRAM load.";
-      case MSG_APPENDED_DISK:
-         return "Appended disk";
-      case MSG_STARTING_MOVIE_PLAYBACK:
-         return "Starting movie playback.";
-      case MSG_FAILED_TO_REMOVE_TEMPORARY_FILE:
-         return "Failed to remove temporary file";
-      case MSG_REMOVING_TEMPORARY_CONTENT_FILE:
-         return "Removing temporary content file";
-      case MSG_LOADED_STATE_FROM_SLOT:
-         return "加载状态从槽";
-      case MSG_SCANNING_OF_DIRECTORY_FINISHED:
-         return "已完成对文件夹的扫描";
-      case MSG_SCANNING:
-         return "扫描中";
-      case MSG_REDIRECTING_CHEATFILE_TO:
-         return "Redirecting cheat file to";
-      case MSG_REDIRECTING_SAVEFILE_TO:
-         return "Redirecting save file to";
-      case MSG_REDIRECTING_SAVESTATE_TO:
-         return "Redirecting savestate to";
-      case MSG_SHADER:
-         return "Shader";
-      case MSG_APPLYING_SHADER:
-         return "Applying shader";
-      case MSG_FAILED_TO_APPLY_SHADER:
-         return "Failed to apply shader.";
-      case MSG_STARTING_MOVIE_RECORD_TO:
-         return "Starting movie record to";
-      case MSG_FAILED_TO_START_MOVIE_RECORD:
-         return "Failed to start movie record.";
-      case MSG_STATE_SLOT:
-         return "状态存档槽";
-      case MSG_RESTARTING_RECORDING_DUE_TO_DRIVER_REINIT:
-         return "Restarting recording due to driver reinit.";
-      case MSG_SLOW_MOTION:
-         return "慢动作。";
-      case MSG_SLOW_MOTION_REWIND:
-         return "慢动作回溯。";
-      case MSG_REWINDING:
-         return "正在回溯。";
-      case MSG_REWIND_REACHED_END:
-         return "Reached end of rewind buffer.";
-      case MSG_CHEEVOS_HARDCORE_MODE_ENABLE:
-         return "Hardcore Mode Enabled: savestate & rewind were disabled.";
-      case MSG_DOWNLOADING:
-         return "正在下载";
-      case MSG_EXTRACTING:
-         return "正在解压";
-      case MSG_EXTRACTING_FILE:
-         return "解压文件";
-      case MSG_NO_CONTENT_STARTING_DUMMY_CORE:
-         return "No content, starting dummy core.";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_EDGE_MAGAZINE_RATING:
-         return "Edge Magazine Rating";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_EDGE_MAGAZINE_REVIEW:
-         return "Edge Magazine Review";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_FAMITSU_MAGAZINE_RATING:
-         return "Famitsu Magazine Rating";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_TGDB_RATING:
-         return "TGDB Rating";
-      case MENU_ENUM_LABEL_VALUE_CPU_ARCHITECTURE:
-         return "CPU架构:";
-      case MENU_ENUM_LABEL_VALUE_CPU_CORES:
-         return "CPU核心:";
-      case MENU_ENUM_LABEL_VALUE_INTERNAL_STORAGE_STATUS:
-         return "内部存储状态";
-      case MENU_ENUM_LABEL_VALUE_PARENT_DIRECTORY:
-         return "上一级目录";
-      case MENU_ENUM_LABEL_VALUE_MORE:
-         return "...";
-      case MENU_ENUM_LABEL_VALUE_RUN:
-         return "运行";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_X:
-         return "自定义视口X";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_Y:
-         return "自定义视口Y";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_WIDTH:
-         return "自定义视口宽度";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_HEIGHT:
-         return "自定义视口高度";
-      case MENU_ENUM_LABEL_VALUE_NO_ENTRIES_TO_DISPLAY:
-         return "没有可显示的条目。";
-      case MENU_ENUM_LABEL_VALUE_NO_ACHIEVEMENTS_TO_DISPLAY:
-         return "没有可显示的成就。";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_UNLOCKED_ACHIEVEMENTS:
-         return "未解锁的成就:";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_LOCKED_ACHIEVEMENTS:
-         return "已解锁的成就:";
-      case MENU_ENUM_LABEL_VALUE_START_VIDEO_PROCESSOR:
-         return "启动视频处理";
-      case MENU_ENUM_LABEL_VALUE_START_NET_RETROPAD:
-         return "启动远程的RetroPad";
-      case MENU_ENUM_LABEL_VALUE_THUMBNAILS_UPDATER_LIST:
-         return "缩略图更新程序";
-      case MENU_ENUM_LABEL_VALUE_MENU_LINEAR_FILTER:
-         return "菜单线性过滤";
-      case MENU_ENUM_LABEL_VALUE_MENU_ENUM_THROTTLE_FRAMERATE:
-         return "限制菜单帧率";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_HARDCORE_MODE_ENABLE:
-         return "专家模式";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_TEST_UNOFFICIAL:
-         return "非官方测试";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_SETTINGS:
-         return "Retro 成就";
-      case MENU_ENUM_LABEL_VALUE_INPUT_TOUCH_ENABLE:
-         return "启用触摸";
-      case MENU_ENUM_LABEL_VALUE_INPUT_PREFER_FRONT_TOUCH:
-         return "优先前置触摸";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ICADE_ENABLE:
-         return "键盘控制器映射启用";
-      case MENU_ENUM_LABEL_VALUE_INPUT_KEYBOARD_GAMEPAD_MAPPING_TYPE:
-         return "键盘控制器映射类型";
-      case MENU_ENUM_LABEL_VALUE_INPUT_SMALL_KEYBOARD_ENABLE:
-         return "启用小键盘";
-      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG_OVERRIDE_CORE:
-         return "保存核心覆写";
-      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG_OVERRIDE_GAME:
-         return "保存游戏覆写";
-      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG:
-         return "保存当前配置";
-      case MENU_ENUM_LABEL_VALUE_STATE_SLOT:
-         return "状态存储槽";
+      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_PASSWORD:
+         return "密码";
       case MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_SETTINGS:
          return "Accounts Cheevos";
       case MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_USERNAME:
          return "用户名";
-      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_PASSWORD:
-         return "密码";
-      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_RETRO_ACHIEVEMENTS:
-         return "Retro 成就";
-      case MENU_ENUM_LABEL_VALUE_RETRO_ACHIEVEMENTS_SETTINGS:
-         return "Retro 成就";
       case MENU_ENUM_LABEL_VALUE_ACCOUNTS_LIST:
          return "账户";
       case MENU_ENUM_LABEL_VALUE_ACCOUNTS_LIST_END:
          return "账户列表终端";
-      case MENU_ENUM_LABEL_VALUE_HELP_SCANNING_CONTENT:
-         return "扫描游戏内容";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_DESCRIPTION:
-         return "描述";
-      case MENU_ENUM_LABEL_VALUE_HELP_AUDIO_VIDEO_TROUBLESHOOTING:
-         return "音频/视频故障排除";
-      case MENU_ENUM_LABEL_VALUE_HELP_CHANGE_VIRTUAL_GAMEPAD:
-         return "变更虚拟游戏控制器覆层";
-      case MENU_ENUM_LABEL_VALUE_HELP_WHAT_IS_A_CORE:
-         return "什么是“核心”？";
-      case MENU_ENUM_LABEL_VALUE_HELP_LOADING_CONTENT:
-         return "加载游戏内容";
-      case MENU_ENUM_LABEL_VALUE_HELP_LIST:
-         return "帮助";
-      case MENU_ENUM_LABEL_VALUE_HELP_CONTROLS:
-         return "基本菜单控制";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS:
-         return "基本菜单控制";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_SCROLL_UP:
-         return "向上滚动";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_CONFIRM:
-         return "确认";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_BACK:
-         return "返回";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_START:
-         return "默认值";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_INFO:
-         return "信息";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_TOGGLE_MENU:
-         return "切换菜单";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_QUIT:
-         return "退出";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_TOGGLE_KEYBOARD:
-         return "切换键盘";
-      case MENU_ENUM_LABEL_VALUE_OPEN_ARCHIVE:
-         return "以文件夹形式打开压缩包";
-      case MENU_ENUM_LABEL_VALUE_LOAD_ARCHIVE:
-         return "使用核心加载压缩包";
-      case MENU_ENUM_LABEL_VALUE_INPUT_BACK_AS_MENU_ENUM_TOGGLE_ENABLE:
-         return "将返回作为菜单切出键";
-      case MENU_ENUM_LABEL_VALUE_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
-         return "游戏控制器菜单切出组合键";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ALL_USERS_CONTROL_MENU:
-         return "所有用户都能控制菜单";
-      case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_HIDE_IN_MENU:
-         return "在菜单中隐藏覆层";
-      case MENU_ENUM_LABEL_VALUE_LANG_POLISH:
-         return "波兰语";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_AUTOLOAD_PREFERRED:
-         return "自动加载最佳的覆层";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_CORE_INFO_FILES:
-         return "更新核心信息文件";
-      case MENU_ENUM_LABEL_VALUE_DOWNLOAD_CORE_CONTENT:
-         return "下载游戏内容";
-      case MENU_ENUM_LABEL_VALUE_DOWNLOAD_CORE:
-         return "下载核心……";
-      case MENU_ENUM_LABEL_VALUE_SCAN_THIS_DIRECTORY:
-         return "<扫描当前目录>";
-      case MENU_ENUM_LABEL_VALUE_SCAN_FILE:
-         return "扫描文件";
-      case MENU_ENUM_LABEL_VALUE_SCAN_DIRECTORY:
-         return "扫描文件夹";
+      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_RETRO_ACHIEVEMENTS:
+         return "Retro 成就";
+      case MENU_ENUM_LABEL_VALUE_ACHIEVEMENT_LIST:
+         return "成就列表";
       case MENU_ENUM_LABEL_VALUE_ADD_CONTENT_LIST:
          return "添加游戏内容";
-      case MENU_ENUM_LABEL_VALUE_INFORMATION:
-         return "信息";
-      case MENU_ENUM_LABEL_VALUE_INFORMATION_LIST:
-         return "信息";
-      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_PLAYER:
-         return "使用内建媒体播放器";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_SETTINGS:
-         return "快捷菜单";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_CRC32:
-         return "CRC32";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_MD5:
-         return "MD5";
-      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_LIST:
-         return "载入游戏内容";
-      case MENU_ENUM_LABEL_VALUE_ASK_ARCHIVE:
-         return "询问";
-      case MENU_ENUM_LABEL_VALUE_PRIVACY_SETTINGS:
-         return "隐私";
-      case MENU_ENUM_LABEL_VALUE_MUSIC_TAB:
-         return "音乐";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_TAB:
-         return "视频";
-      case MENU_ENUM_LABEL_VALUE_IMAGES_TAB:
-         return "图像";
-      case MENU_ENUM_LABEL_VALUE_HORIZONTAL_MENU:
-         return "水平化菜单";
-      case MENU_ENUM_LABEL_VALUE_SETTINGS_TAB:
-         return "设置";
-      case MENU_ENUM_LABEL_VALUE_HISTORY_TAB:
-         return "历史";
       case MENU_ENUM_LABEL_VALUE_ADD_TAB:
          return "导入游戏内容";
-      case MENU_ENUM_LABEL_VALUE_PLAYLISTS_TAB:
-         return "游戏列表";
-      case MENU_ENUM_LABEL_VALUE_NO_SETTINGS_FOUND:
-         return "没有找到设置。";
-      case MENU_ENUM_LABEL_VALUE_NO_PERFORMANCE_COUNTERS:
-         return "没有性能计数器。";
-      case MENU_ENUM_LABEL_VALUE_DRIVER_SETTINGS:
-         return "驱动";
-      case MENU_ENUM_LABEL_VALUE_CONFIGURATION_SETTINGS:
-         return "配置";
-      case MENU_ENUM_LABEL_VALUE_CORE_SETTINGS:
-         return "核心";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SETTINGS:
-         return "视频";
-      case MENU_ENUM_LABEL_VALUE_LOGGING_SETTINGS:
-         return "日志";
-      case MENU_ENUM_LABEL_VALUE_SAVING_SETTINGS:
-         return "存档";
-      case MENU_ENUM_LABEL_VALUE_REWIND_SETTINGS:
-         return "回溯";
-      case MENU_ENUM_LABEL_VALUE_SHADER:
-         return "Shader";
-      case MENU_ENUM_LABEL_VALUE_CHEAT:
-         return "金手指";
-      case MENU_ENUM_LABEL_VALUE_USER:
-         return "用户";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_BGM_ENABLE:
-         return "启用系统背景音乐";
-      case MENU_ENUM_LABEL_VALUE_RETROPAD:
-         return "RetroPad";
-      case MENU_ENUM_LABEL_VALUE_RETROKEYBOARD:
-         return "RetroKeyboard";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_BLOCK_FRAMES:
-         return "Block Frames";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_LABEL_SHOW:
-         return "显示输入描述标签";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_HIDE_UNBOUND:
-         return "隐藏未绑定的核心输入描述";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_ENABLE:
-         return "显示屏显消息(OSD)";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_PATH:
-         return "屏显消息(OSD)字体";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_SIZE:
-         return "屏显消息(OSD)大小";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_X:
-         return "屏显消息(OSD)X轴位置";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_Y:
-         return "屏显消息(OSD)Y轴位置";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SOFT_FILTER:
-         return "启用软件过滤器";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_FLICKER:
-         return "闪烁过滤器";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_CONTENT:
-         return "<游戏内容目录>";
-      case MENU_ENUM_LABEL_VALUE_UNKNOWN:
-         return "未知";
-      case MENU_ENUM_LABEL_VALUE_DONT_CARE:
-         return "不关心";
-      case MENU_ENUM_LABEL_VALUE_LINEAR:
-         return "线性";
-      case MENU_ENUM_LABEL_VALUE_NEAREST:
-         return "最近";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_DEFAULT:
-         return "<默认>";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NONE:
-         return "<无>";
-      case MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE:
-         return "N/A";
-      case MENU_ENUM_LABEL_VALUE_DATABASE_SELECTION:
-         return "选择数据库";
-      case MENU_ENUM_LABEL_VALUE_CORE_ASSETS_DIR:
-         return "核心资源目录";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_DIR:
-         return "游戏内容目录";
-      case MENU_ENUM_LABEL_VALUE_INPUT_REMAPPING_DIRECTORY:
-         return "输入重映射目录";
-      case MENU_ENUM_LABEL_VALUE_JOYPAD_AUTOCONFIG_DIR:
-         return "输入设备自动配置目录";
-      case MENU_ENUM_LABEL_VALUE_RECORDING_CONFIG_DIRECTORY:
-         return "录像配置目录";
-      case MENU_ENUM_LABEL_VALUE_RECORDING_OUTPUT_DIRECTORY:
-         return "录像输出目录";
-      case MENU_ENUM_LABEL_VALUE_SCREENSHOT_DIRECTORY:
-         return "屏幕截图目录";
-      case MENU_ENUM_LABEL_VALUE_PLAYLIST_DIRECTORY:
-         return "游戏列表目录";
-      case MENU_ENUM_LABEL_VALUE_SAVEFILE_DIRECTORY:
-         return "存档文件目录";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_DIRECTORY:
-         return "状态存储目录";
-      case MENU_ENUM_LABEL_VALUE_STDIN_CMD_ENABLE:
-         return "标准输入流命令";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_REMOTE_ENABLE:
-         return "网络游戏控制器";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_DRIVER:
-         return "视频驱动";
-      case MENU_ENUM_LABEL_VALUE_RECORD_ENABLE:
-         return "启用录像";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_RECORD:
-         return "启用GPU录像";
-      case MENU_ENUM_LABEL_VALUE_RECORD_PATH:
-         return "输出文件";
-      case MENU_ENUM_LABEL_VALUE_RECORD_USE_OUTPUT_DIRECTORY:
-         return "使用输出目录";
-      case MENU_ENUM_LABEL_VALUE_RECORD_CONFIG:
-         return "录像配置";
-      case MENU_ENUM_LABEL_VALUE_CONFIG:
-         return "配置";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_POST_FILTER_RECORD:
-         return "启用录像后期滤镜";
-      case MENU_ENUM_LABEL_VALUE_CORE_ASSETS_DIRECTORY:
-         return "下载目录";
-      case MENU_ENUM_LABEL_VALUE_ASSETS_DIRECTORY:
-         return "资源目录";
-      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPERS_DIRECTORY:
-         return "动态壁纸目录";
-      case MENU_ENUM_LABEL_VALUE_THUMBNAILS_DIRECTORY:
-         return "缩略图目录";
-      case MENU_ENUM_LABEL_VALUE_RGUI_BROWSER_DIRECTORY:
-         return "文件浏览器目录";
-      case MENU_ENUM_LABEL_VALUE_RGUI_CONFIG_DIRECTORY:
-         return "配置目录";
-      case MENU_ENUM_LABEL_VALUE_LIBRETRO_INFO_PATH:
-         return "核心信息目录";
-      case MENU_ENUM_LABEL_VALUE_LIBRETRO_DIR_PATH:
-         return "核心目录";
-      case MENU_ENUM_LABEL_VALUE_CURSOR_DIRECTORY:
-         return "指针目录";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_DATABASE_DIRECTORY:
-         return "游戏内容数据库目录";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_DIRECTORY:
-         return "系统/BIOS目录";
-      case MENU_ENUM_LABEL_VALUE_CHEAT_DATABASE_PATH:
-         return "金手指文件目录";
-      case MENU_ENUM_LABEL_VALUE_CACHE_DIRECTORY:
-         return "缓存目录";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_FILTER_DIR:
-         return "音频过滤器目录";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_DIR:
-         return "视频Shader目录";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_DIR:
-         return "视频滤镜目录";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_DIRECTORY:
-         return "覆层目录";
-      case MENU_ENUM_LABEL_VALUE_OSK_OVERLAY_DIRECTORY:
-         return "OSK覆层目录";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT:
-         return "在线玩家P2使用C1";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE:
-         return "启用在线游戏旁观者";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS:
-         return "服务器地址";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT:
-         return "在线游戏TCP/UDP端口";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE:
-         return "启用在线游戏";
-      case MENU_ENUM_LABEL_VALUE_SSH_ENABLE:
-         return "启用SSH远程终端服务";
-      case MENU_ENUM_LABEL_VALUE_SAMBA_ENABLE:
-         return "启用SAMBA文件共享服务";
-      case MENU_ENUM_LABEL_VALUE_BLUETOOTH_ENABLE:
-         return "启用蓝牙服务";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_DELAY_FRAMES:
-         return "在线游戏延迟帧数";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_CHECK_FRAMES:
-         return "在线游戏检查帧数";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_MODE:
-         return "启用在线游戏客户端";
-      case MENU_ENUM_LABEL_VALUE_RGUI_SHOW_START_SCREEN:
-         return "显示开始屏幕";
-      case MENU_ENUM_LABEL_VALUE_TITLE_COLOR:
-         return "菜单标题颜色";
-      case MENU_ENUM_LABEL_VALUE_ENTRY_HOVER_COLOR:
-         return "菜单项悬停颜色";
-      case MENU_ENUM_LABEL_VALUE_TIMEDATE_ENABLE:
-         return "显示时间日期";
-      case MENU_ENUM_LABEL_VALUE_THREADED_DATA_RUNLOOP_ENABLE:
-         return "启用多线程数据执行循环";
-      case MENU_ENUM_LABEL_VALUE_ENTRY_NORMAL_COLOR:
-         return "菜单项正常颜色";
-      case MENU_ENUM_LABEL_VALUE_SHOW_ADVANCED_SETTINGS:
-         return "显示高级设置";
-      case MENU_ENUM_LABEL_VALUE_MOUSE_ENABLE:
-         return "鼠标支持";
-      case MENU_ENUM_LABEL_VALUE_POINTER_ENABLE:
-         return "触摸支持";
-      case MENU_ENUM_LABEL_VALUE_CORE_ENABLE:
-         return "显示核心名称";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE_HOST:
-         return "作为游戏主机";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE_CLIENT:
-         return "连接到游戏主机";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_DISCONNECT:
-         return "断开连接";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_SETTINGS:
-         return "在线游戏设置";
-      case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_ENABLE:
-         return "启用DPI覆盖";
-      case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_VALUE:
-         return "DPI覆盖";
-      case MENU_ENUM_LABEL_VALUE_XMB_SCALE_FACTOR:
-         return "菜单缩放因子";
-      case MENU_ENUM_LABEL_VALUE_XMB_ALPHA_FACTOR:
-         return "菜单透明度因子";
-      case MENU_ENUM_LABEL_VALUE_XMB_FONT:
-         return "菜单字体";
-      case MENU_ENUM_LABEL_VALUE_XMB_THEME:
-         return "菜单图标主题";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME:
-         return "菜单颜色主题";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME:
-         return "菜单颜色主题";
-      case MENU_ENUM_LABEL_VALUE_XMB_SHADOWS_ENABLE:
-         return "启用图标阴影";
-      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_SETTINGS:
-         return "显示设置页";
-      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_IMAGES:
-         return "显示图像页";
-      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_MUSIC:
-         return "显示音乐页";
-      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_VIDEO:
-         return "显示视频页";
-      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_HISTORY:
-         return "显示历史页";
-      case MENU_ENUM_LABEL_VALUE_XMB_RIBBON_ENABLE:
-         return "菜单Shader管线";
-      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_MONOCHROME:
-         return "Monochrome";
-      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_MONOCHROME_JAGGED:
-         return "Monochrome Jagged";
-      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_FLATUI:
-         return "FlatUI";
-      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_RETROACTIVE:
-         return "RetroActive";
-      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_PIXEL:
-         return "Pixel";
-      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_CUSTOM:
-         return "自定义";
-      case MENU_ENUM_LABEL_VALUE_SUSPEND_SCREENSAVER_ENABLE:
-         return "暂停屏保程序";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_DISABLE_COMPOSITION:
-         return "禁用桌面元素";
-      case MENU_ENUM_LABEL_VALUE_PAUSE_NONACTIVE:
-         return "禁止后台运行";
-      case MENU_ENUM_LABEL_VALUE_UI_COMPANION_START_ON_BOOT:
-         return "UI Companion Start On Boot";
-      case MENU_ENUM_LABEL_VALUE_UI_COMPANION_ENABLE:
-         return "UI Companion Enable";
-      case MENU_ENUM_LABEL_VALUE_UI_MENUBAR_ENABLE:
-         return "Menubar";
       case MENU_ENUM_LABEL_VALUE_ARCHIVE_MODE:
          return "Archive File Association Action";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_ENABLE:
-         return "网络命令";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_PORT:
-         return "网络命令端口";
-      case MENU_ENUM_LABEL_VALUE_HISTORY_LIST_ENABLE:
-         return "启用历史记录";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_HISTORY_SIZE:
-         return "历史记录数量";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE_AUTO:
-         return "估算的显示器帧率";
-      case MENU_ENUM_LABEL_VALUE_DUMMY_ON_CORE_SHUTDOWN:
-         return "Dummy On Core Shutdown";
-      case MENU_ENUM_LABEL_VALUE_CORE_SET_SUPPORTS_NO_CONTENT_ENABLE:
-         return "自动启动一个核心";
-      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_ENABLE:
-         return "限制最大运行速度";
-      case MENU_ENUM_LABEL_VALUE_FASTFORWARD_RATIO:
-         return "最大运行速度";
+      case MENU_ENUM_LABEL_VALUE_ASK_ARCHIVE:
+         return "询问";
+      case MENU_ENUM_LABEL_VALUE_ASSETS_DIRECTORY:
+         return "资源目录";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_BLOCK_FRAMES:
+         return "Block Frames";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_DEVICE:
+         return "音频设备";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_DRIVER:
+         return "音频驱动";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_DSP_PLUGIN:
+         return "音频DSP插件";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_ENABLE:
+         return "启用音频";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_FILTER_DIR:
+         return "音频过滤器目录";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_LATENCY:
+         return "音频时延(ms)";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_MAX_TIMING_SKEW:
+         return "音频最大采样间隔";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_MUTE:
+         return "音频静音";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_OUTPUT_RATE:
+         return "音频输出码率(KHz)";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_RATE_CONTROL_DELTA:
+         return "音频码率控制间隔";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_RESAMPLER_DRIVER:
+         return "音频重采样驱动";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_SETTINGS:
+         return "音频";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_SYNC:
+         return "启用音频同步";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_VOLUME:
+         return "音频音量级别(dB)";
+      case MENU_ENUM_LABEL_VALUE_AUTOSAVE_INTERVAL:
+         return "SaveRAM自动保存间隔";
+      case MENU_ENUM_LABEL_VALUE_AUTO_OVERRIDES_ENABLE:
+         return "自动加载覆写文件";
       case MENU_ENUM_LABEL_VALUE_AUTO_REMAPS_ENABLE:
          return "自动加载重映射文件";
       case MENU_ENUM_LABEL_VALUE_AUTO_SHADERS_ENABLE:
          return "自动加载Shader预设";
-      case MENU_ENUM_LABEL_VALUE_SLOWMOTION_RATIO:
-         return "慢动作倍率";
-      case MENU_ENUM_LABEL_VALUE_CORE_SPECIFIC_CONFIG:
-         return "单核心配置";
-      case MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS:
-         return "自动加载游戏内容特定的核心选项";
-      case MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS_CREATE:
-         return "创建游戏选项文件";
-      case MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS_IN_USE:
-         return "游戏选项文件";
-      case MENU_ENUM_LABEL_VALUE_AUTO_OVERRIDES_ENABLE:
-         return "自动加载覆写文件";
-      case MENU_ENUM_LABEL_VALUE_CONFIG_SAVE_ON_EXIT:
-         return "退出时保存配置";
-      case MENU_ENUM_LABEL_VALUE_CONFIRM_ON_EXIT:
-         return "退出时进行询问";
-      case MENU_ENUM_LABEL_VALUE_SHOW_HIDDEN_FILES:
-         return "显示隐藏的文件和文件夹";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SMOOTH:
-         return "硬件双线性过滤";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_GAMMA:
-         return "视频Gamma";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ALLOW_ROTATE:
-         return "允许旋转";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC:
-         return "强制GPU同步";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SWAP_INTERVAL:
-         return "垂直同步交换间隔";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VSYNC:
-         return "垂直同步";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_THREADED:
-         return "多线程渲染";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ROTATION:
-         return "旋转";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_SCREENSHOT:
-         return "启用GPU截屏";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_CROP_OVERSCAN:
-         return "Crop Overscan (Reload)";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_INDEX:
-         return "视口比例选项";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_AUTO:
-         return "自动选择视口比例";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_ASPECT:
-         return "强制视口比例";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE:
-         return "刷新率";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_SRGB_DISABLE:
-         return "强制禁止sRGB帧缓冲";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_WINDOWED_FULLSCREEN:
-         return "无边框窗口全屏模式";
-      case MENU_ENUM_LABEL_VALUE_PAL60_ENABLE:
-         return "使用PAL60模式";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VFILTER:
-         return "Deflicker";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VI_WIDTH:
-         return "Set VI Screen Width";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_BLACK_FRAME_INSERTION:
-         return "黑色帧补间";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC_FRAMES:
-         return "强制GPU同步帧数";
-      case MENU_ENUM_LABEL_VALUE_SORT_SAVEFILES_ENABLE:
-         return "排序文件夹中的存档";
-      case MENU_ENUM_LABEL_VALUE_SORT_SAVESTATES_ENABLE:
-         return "排序文件夹中的状态存储";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FULLSCREEN:
-         return "使用全屏模式";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE:
-         return "窗口缩放量";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE_INTEGER:
-         return "整数化缩放量";
-      case MENU_ENUM_LABEL_VALUE_PERFCNT_ENABLE:
-         return "性能计数器";
-      case MENU_ENUM_LABEL_VALUE_LIBRETRO_LOG_LEVEL:
-         return "核心日志级别";
-      case MENU_ENUM_LABEL_VALUE_LOG_VERBOSITY:
-         return "完整日志记录";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_LOAD:
-         return "自动加载状态";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_INDEX:
-         return "自动索引保存状态";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_SAVE:
-         return "自动保存状态";
-      case MENU_ENUM_LABEL_VALUE_AUTOSAVE_INTERVAL:
-         return "SaveRAM自动保存间隔";
+      case MENU_ENUM_LABEL_VALUE_BACK:
+         return "返回";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_BACK:
+         return "返回";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_CONFIRM:
+         return "确认";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_INFO:
+         return "信息";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_QUIT:
+         return "退出";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_SCROLL_DOWN:
+         return "向下滚动";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_SCROLL_UP:
+         return "向上滚动";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_START:
+         return "开始";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_TOGGLE_KEYBOARD:
+         return "切换键盘";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_TOGGLE_MENU:
+         return "切换菜单";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS:
+         return "基本菜单控制";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_BACK:
+         return "返回";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_CONFIRM:
+         return "确认";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_INFO:
+         return "信息";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_QUIT:
+         return "退出";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_SCROLL_UP:
+         return "向上滚动";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_START:
+         return "默认值";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_TOGGLE_KEYBOARD:
+         return "切换键盘";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_TOGGLE_MENU:
+         return "切换菜单";
       case MENU_ENUM_LABEL_VALUE_BLOCK_SRAM_OVERWRITE:
          return "加载保存状态时不覆盖SaveRAM";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHARED_CONTEXT:
-         return "启用硬件共享上下文";
-      case MENU_ENUM_LABEL_VALUE_RESTART_RETROARCH:
-         return "重启 RetroArch";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_NICKNAME:
-         return "用户名";
-      case MENU_ENUM_LABEL_VALUE_USER_LANGUAGE:
-         return "语言";
+      case MENU_ENUM_LABEL_VALUE_BLUETOOTH_ENABLE:
+         return "启用蓝牙服务";
+      case MENU_ENUM_LABEL_VALUE_BUILDBOT_ASSETS_URL:
+         return "构建机器人资源URL";
+      case MENU_ENUM_LABEL_VALUE_CACHE_DIRECTORY:
+         return "缓存目录";
       case MENU_ENUM_LABEL_VALUE_CAMERA_ALLOW:
          return "允许使用相机";
-      case MENU_ENUM_LABEL_VALUE_LOCATION_ALLOW:
-         return "允许使用位置";
-      case MENU_ENUM_LABEL_VALUE_PAUSE_LIBRETRO:
-         return "当菜单激活时暂停";
-      case MENU_ENUM_LABEL_VALUE_INPUT_OSK_OVERLAY_ENABLE:
-         return "显示键盘覆层";
-      case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_ENABLE:
-         return "显示覆层";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MONITOR_INDEX:
-         return "显示器索引";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FRAME_DELAY:
-         return "帧延时";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DUTY_CYCLE:
-         return "Turbo占空比";
-      case MENU_ENUM_LABEL_VALUE_INPUT_TURBO_PERIOD:
-         return "Turbo区间";
-      case MENU_ENUM_LABEL_VALUE_INPUT_BIND_TIMEOUT:
-         return "绑定超时时间";
-      case MENU_ENUM_LABEL_VALUE_INPUT_AXIS_THRESHOLD:
-         return "输入轴阈值";
-      case MENU_ENUM_LABEL_VALUE_INPUT_REMAP_BINDS_ENABLE:
-         return "启用绑定重映射";
-      case MENU_ENUM_LABEL_VALUE_INPUT_MAX_USERS:
-         return "最大用户数";
-      case MENU_ENUM_LABEL_VALUE_INPUT_AUTODETECT_ENABLE:
-         return "启用自动配置";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_OUTPUT_RATE:
-         return "音频输出码率(KHz)";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_MAX_TIMING_SKEW:
-         return "音频最大采样间隔";
-      case MENU_ENUM_LABEL_VALUE_CHEAT_NUM_PASSES:
-         return "Cheat Passes";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_CORE:
-         return "保存核心重映射文件";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_GAME:
-         return "保存游戏重映射文件";
+      case MENU_ENUM_LABEL_VALUE_CAMERA_DRIVER:
+         return "相机驱动";
+      case MENU_ENUM_LABEL_VALUE_CHEAT:
+         return "金手指";
       case MENU_ENUM_LABEL_VALUE_CHEAT_APPLY_CHANGES:
          return "应用金手指修改";
-      case MENU_ENUM_LABEL_VALUE_SHADER_APPLY_CHANGES:
-         return "应用Shader修改";
-      case MENU_ENUM_LABEL_VALUE_REWIND_ENABLE:
-         return "启用回溯";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_COLLECTION_LIST:
-         return "收藏";
-      case MENU_ENUM_LABEL_VALUE_DETECT_CORE_LIST:
-         return "选择文件并探测核心";
-      case MENU_ENUM_LABEL_VALUE_DOWNLOADED_FILE_DETECT_CORE_LIST:
-         return "下载目录";
-      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_HISTORY:
-         return "加载最近的游戏内容";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_ENABLE:
-         return "启用音频";
-      case MENU_ENUM_LABEL_VALUE_FPS_SHOW:
-         return "显示帧率";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_MUTE:
-         return "音频静音";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_VOLUME:
-         return "音频音量级别(dB)";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_SYNC:
-         return "启用音频同步";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_RATE_CONTROL_DELTA:
-         return "音频码率控制间隔";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_NUM_PASSES:
-         return "Shader渲染遍数";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_SHA1:
-         return "SHA1";
-      case MENU_ENUM_LABEL_VALUE_CONFIGURATIONS:
-         return "加载配置";
-      case MENU_ENUM_LABEL_VALUE_REWIND_GRANULARITY:
-         return "回溯粒度";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_LOAD:
-         return "加载重映射文件";
-      case MENU_ENUM_LABEL_VALUE_CUSTOM_RATIO:
-         return "自定义比率";
-      case MENU_ENUM_LABEL_VALUE_USE_THIS_DIRECTORY:
-         return "<使用当前目录>";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_START_CONTENT:
-         return "启动游戏内容";
-      case MENU_ENUM_LABEL_VALUE_DISK_OPTIONS:
-         return "光盘控制";
-      case MENU_ENUM_LABEL_VALUE_CORE_OPTIONS:
-         return "选项";
-      case MENU_ENUM_LABEL_VALUE_CORE_CHEAT_OPTIONS:
-         return "金手指";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE:
-         return "重映射文件";
+      case MENU_ENUM_LABEL_VALUE_CHEAT_DATABASE_PATH:
+         return "金手指文件目录";
       case MENU_ENUM_LABEL_VALUE_CHEAT_FILE:
          return "金手指文件";
       case MENU_ENUM_LABEL_VALUE_CHEAT_FILE_LOAD:
          return "加载金手指文件";
       case MENU_ENUM_LABEL_VALUE_CHEAT_FILE_SAVE_AS:
          return "另存为金手指文件";
-      case MENU_ENUM_LABEL_VALUE_CORE_COUNTERS:
-         return "核心计数器";
-      case MENU_ENUM_LABEL_VALUE_TAKE_SCREENSHOT:
-         return "截取屏幕";
-      case MENU_ENUM_LABEL_VALUE_DELETE_ENTRY:
-         return "移除";
-      case MENU_ENUM_LABEL_VALUE_RESUME:
-         return "继续";
-      case MENU_ENUM_LABEL_VALUE_DISK_INDEX:
-         return "光盘索引";
-      case MENU_ENUM_LABEL_VALUE_FRONTEND_COUNTERS:
-         return "前端计数器";
-      case MENU_ENUM_LABEL_VALUE_DISK_IMAGE_APPEND:
-         return "追加光盘镜像";
-      case MENU_ENUM_LABEL_VALUE_DISK_CYCLE_TRAY_STATUS:
-         return "Disk Cycle Tray Status";
-      case MENU_ENUM_LABEL_VALUE_NO_PLAYLIST_ENTRIES_AVAILABLE:
-         return "没有可用的游戏列表项目。";
-      case MENU_ENUM_LABEL_VALUE_NO_HISTORY_AVAILABLE:
-         return "没有可用的历史记录。";
-      case MENU_ENUM_LABEL_VALUE_NO_CORE_INFORMATION_AVAILABLE:
-         return "没有可用的核心信息。";
-      case MENU_ENUM_LABEL_VALUE_NO_CORE_OPTIONS_AVAILABLE:
-         return "没有可用的核心选项。";
-      case MENU_ENUM_LABEL_VALUE_NO_CORES_AVAILABLE:
-         return "没有可用的核心。";
-      case MENU_ENUM_LABEL_VALUE_NO_CORE:
-         return "没有核心";
-      case MENU_ENUM_LABEL_VALUE_DATABASE_MANAGER:
-         return "数据库管理器";
-      case MENU_ENUM_LABEL_VALUE_CURSOR_MANAGER:
-         return "光标管理器";
-      case MENU_ENUM_LABEL_VALUE_MAIN_MENU:
-         return "主菜单";
-      case MENU_ENUM_LABEL_VALUE_SETTINGS:
-         return "设置";
-      case MENU_ENUM_LABEL_VALUE_QUIT_RETROARCH:
-         return "退出 RetroArch";
-      case MENU_ENUM_LABEL_VALUE_SHUTDOWN:
-         return "关机";
-      case MENU_ENUM_LABEL_VALUE_REBOOT:
-         return "重启";
-      case MENU_ENUM_LABEL_VALUE_HELP:
-         return "帮助";
-      case MENU_ENUM_LABEL_VALUE_SAVE_NEW_CONFIG:
-         return "保存新配置";
-      case MENU_ENUM_LABEL_VALUE_RESTART_CONTENT:
-         return "重启";
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_LIST:
-         return "核心更新程序";
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_BUILDBOT_URL:
-         return "构建机器人核心URL";
-      case MENU_ENUM_LABEL_VALUE_BUILDBOT_ASSETS_URL:
-         return "构建机器人资源URL";
-      case MENU_ENUM_LABEL_VALUE_NAVIGATION_WRAPAROUND:
-         return "环绕式导航";
-      case MENU_ENUM_LABEL_VALUE_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
-         return "过滤未知扩展名";
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
-         return "自动解压下载的档案";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFORMATION:
-         return "系统信息";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_INFORMATION:
-         return "网络信息";
-      case MENU_ENUM_LABEL_VALUE_ACHIEVEMENT_LIST:
-         return "成就列表";
-      case MENU_ENUM_LABEL_VALUE_ONLINE_UPDATER:
-         return "在线更新器";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY:
-         return "在线游戏";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFORMATION:
-         return "核心信息";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NOT_FOUND:
-         return "没有找到文件夹。";
-      case MENU_ENUM_LABEL_VALUE_NO_ITEMS:
-         return "没有条目。";
-      case MENU_ENUM_LABEL_VALUE_NO_PLAYLISTS:
-         return "没有游戏列表。";
-      case MENU_ENUM_LABEL_VALUE_CORE_LIST:
-         return "加载核心";
-      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT:
-         return "选择文件";
+      case MENU_ENUM_LABEL_VALUE_CHEAT_NUM_PASSES:
+         return "Cheat Passes";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_DESCRIPTION:
+         return "描述";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_HARDCORE_MODE_ENABLE:
+         return "专家模式";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_LOCKED_ACHIEVEMENTS:
+         return "已解锁的成就:";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_LOCKED_ENTRY:
+         return "锁定";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_SETTINGS:
+         return "Retro 成就";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_TEST_UNOFFICIAL:
+         return "非官方测试";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_UNLOCKED_ACHIEVEMENTS:
+         return "未解锁的成就:";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_UNLOCKED_ENTRY:
+         return "未锁定";
       case MENU_ENUM_LABEL_VALUE_CLOSE_CONTENT:
          return "关闭";
-      case MENU_ENUM_LABEL_VALUE_MANAGEMENT:
-         return "数据库设置";
-      case MENU_ENUM_LABEL_VALUE_SAVE_STATE:
-         return "保存状态";
-      case MENU_ENUM_LABEL_VALUE_LOAD_STATE:
-         return "加载状态";
-      case MENU_ENUM_LABEL_VALUE_UNDO_LOAD_STATE:
-         return "撤销加载状态";
-      case MENU_ENUM_LABEL_VALUE_UNDO_SAVE_STATE:
-         return "撤销保存状态";
-      case MSG_UNDID_LOAD_STATE:
-         return "已撤销加载状态。";
-      case MENU_ENUM_LABEL_VALUE_RESUME_CONTENT:
-         return "继续";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DRIVER:
-         return "输入驱动";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_DRIVER:
-         return "音频驱动";
-      case MENU_ENUM_LABEL_VALUE_JOYPAD_DRIVER:
-         return "手柄驱动";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_RESAMPLER_DRIVER:
-         return "音频重采样驱动";
-      case MENU_ENUM_LABEL_VALUE_RECORD_DRIVER:
-         return "录像驱动";
-      case MENU_ENUM_LABEL_VALUE_MENU_DRIVER:
-         return "菜单驱动";
-      case MENU_ENUM_LABEL_VALUE_CAMERA_DRIVER:
-         return "相机驱动";
-      case MENU_ENUM_LABEL_VALUE_WIFI_DRIVER:
-         return "Wi-Fi驱动";
-      case MENU_ENUM_LABEL_VALUE_LOCATION_DRIVER:
-         return "定位驱动";
-      case MENU_ENUM_LABEL_VALUE_UNABLE_TO_READ_COMPRESSED_FILE:
-         return "无法读取压缩的文件。";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_SCALE:
-         return "覆层缩放比例";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_PRESET:
-         return "覆层预设";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_LATENCY:
-         return "音频时延(ms)";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_DEVICE:
-         return "音频设备";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY:
-         return "覆层";
-      case MENU_ENUM_LABEL_VALUE_KEYBOARD_OVERLAY_PRESET:
-         return "键盘覆层预设";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_OPACITY:
-         return "覆层不透明度";
-      case MENU_ENUM_LABEL_VALUE_MENU_WALLPAPER:
-         return "菜单壁纸";
-      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPER:
-         return "动态壁纸";
-      case MENU_ENUM_LABEL_VALUE_THUMBNAILS:
-         return "缩略图";
-      case MENU_ENUM_LABEL_VALUE_CORE_INPUT_REMAPPING_OPTIONS:
-         return "控制";
-      case MENU_ENUM_LABEL_VALUE_SHADER_OPTIONS:
-         return "Shader效果";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PARAMETERS:
-         return "预览Shader参数";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_PARAMETERS:
-         return "菜单Shader参数";
-      case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_TWO:
-         return "Shader预设";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_AS:
-         return "保存Shader预设为";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_CORE:
-         return "保存核心预设";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_GAME:
-         return "保存游戏预设";
-      case MENU_ENUM_LABEL_VALUE_NO_SHADER_PARAMETERS:
-         return "没有Shader参数.";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET:
-         return "加载Shader预设";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER:
-         return "视频滤镜";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_DSP_PLUGIN:
-         return "音频DSP插件";
-      case MENU_ENUM_LABEL_VALUE_SECONDS:
-         return "秒";
-      case MENU_ENUM_LABEL_VALUE_OFF:
-         return "关";
-      case MENU_ENUM_LABEL_VALUE_ON:
-         return "开";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_ASSETS:
-         return "更新资源";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_LAKKA:
-         return "更新 Lakka";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_CHEATS:
-         return "更新金手指";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_AUTOCONFIG_PROFILES:
-         return "更新自动配置档案";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_DATABASES:
-         return "更新数据库";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_OVERLAYS:
-         return "更新覆层";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_CG_SHADERS:
-         return "更新CG Shader效果文件";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_GLSL_SHADERS:
-         return "更新GLSL Shader效果文件";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_SLANG_SHADERS:
-         return "更新Slang Shader效果文件";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NAME:
-         return "核心名称";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_LABEL:
-         return "核心标签";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_NAME:
-         return "系统名称";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_MANUFACTURER:
-         return "系统制造商";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CATEGORIES:
-         return "分类";
+      case MENU_ENUM_LABEL_VALUE_CONFIG:
+         return "配置";
+      case MENU_ENUM_LABEL_VALUE_CONFIGURATIONS:
+         return "加载配置";
+      case MENU_ENUM_LABEL_VALUE_CONFIGURATION_SETTINGS:
+         return "配置";
+      case MENU_ENUM_LABEL_VALUE_CONFIG_SAVE_ON_EXIT:
+         return "退出时保存配置";
+      case MENU_ENUM_LABEL_VALUE_CONFIRM_ON_EXIT:
+         return "退出时进行询问";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_COLLECTION_LIST:
+         return "收藏";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_DATABASE_DIRECTORY:
+         return "游戏内容数据库目录";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_DIR:
+         return "游戏内容目录";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_HISTORY_SIZE:
+         return "历史记录数量";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_SETTINGS:
+         return "快捷菜单";
+      case MENU_ENUM_LABEL_VALUE_CORE_ASSETS_DIR:
+         return "核心资源目录";
+      case MENU_ENUM_LABEL_VALUE_CORE_ASSETS_DIRECTORY:
+         return "下载目录";
+      case MENU_ENUM_LABEL_VALUE_CORE_CHEAT_OPTIONS:
+         return "金手指";
+      case MENU_ENUM_LABEL_VALUE_CORE_COUNTERS:
+         return "核心计数器";
+      case MENU_ENUM_LABEL_VALUE_CORE_ENABLE:
+         return "显示核心名称";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFORMATION:
+         return "核心信息";
       case MENU_ENUM_LABEL_VALUE_CORE_INFO_AUTHORS:
          return "作者";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_PERMISSIONS:
-         return "许可";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_LICENSES:
-         return "许可证";
-      case MENU_ENUM_LABEL_VALUE_SUPPORTED_CORES:
-         return "支持的核心";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SUPPORTED_EXTENSIONS:
-         return "支持的扩展";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_FIRMWARE:
-         return "固件";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CATEGORIES:
+         return "分类";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_LABEL:
+         return "核心标签";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NAME:
+         return "核心名称";
       case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NOTES:
          return "核心说明";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_BUILD_DATE:
-         return "编译日期";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GIT_VERSION:
-         return "Git版本";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CPU_FEATURES:
-         return "CPU特性";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_IDENTIFIER:
-         return "前端标识";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_NAME:
-         return "前端名称";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_OS:
-         return "前端操作系统";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RETRORATING_LEVEL:
-         return "RetroRating 等级";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE:
-         return "电源";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_NO_SOURCE:
-         return "没有电源";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGING:
-         return "充电中";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGED:
-         return "已充满电";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_DISCHARGING:
-         return "放电中";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VIDEO_CONTEXT_DRIVER:
-         return "视频上下文驱动";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_WIDTH:
-         return "显示器度量宽度(mm)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_HEIGHT:
-         return "显示器度量高度(mm)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_DPI:
-         return "显示器度量DPI";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBRETRODB_SUPPORT:
-         return "LibretroDB 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OVERLAY_SUPPORT:
-         return "覆层支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COMMAND_IFACE_SUPPORT:
-         return "控制台支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETWORK_REMOTE_SUPPORT:
-         return "网络控制器支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETWORK_COMMAND_IFACE_SUPPORT:
-         return "网络控制台支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COCOA_SUPPORT:
-         return "Cocoa 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RPNG_SUPPORT:
-         return "PNG 支持 (RPNG)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RJPEG_SUPPORT:
-         return "JPEG 支持 (RJPEG)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RBMP_SUPPORT:
-         return "BMP 支持 (RBMP)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RTGA_SUPPORT:
-         return "TGA 支持 (RTGA)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_SUPPORT:
-         return "SDL1.2 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL2_SUPPORT:
-         return "SDL2 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VULKAN_SUPPORT:
-         return "Vulkan 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGL_SUPPORT:
-         return "OpenGL 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGLES_SUPPORT:
-         return "OpenGL ES 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_THREADING_SUPPORT:
-         return "多线程支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_KMS_SUPPORT:
-         return "KMS/EGL 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_UDEV_SUPPORT:
-         return "Udev 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENVG_SUPPORT:
-         return "OpenVG 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_EGL_SUPPORT:
-         return "EGL 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_X11_SUPPORT:
-         return "X11 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_WAYLAND_SUPPORT:
-         return "Wayland 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XVIDEO_SUPPORT:
-         return "XVideo 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ALSA_SUPPORT:
-         return "ALSA 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OSS_SUPPORT:
-         return "OSS 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENAL_SUPPORT:
-         return "OpenAL 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENSL_SUPPORT:
-         return "OpenSL 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RSOUND_SUPPORT:
-         return "RSound 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ROARAUDIO_SUPPORT:
-         return "RoarAudio 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_JACK_SUPPORT:
-         return "JACK 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PULSEAUDIO_SUPPORT:
-         return "PulseAudio 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DSOUND_SUPPORT:
-         return "DirectSound 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XAUDIO2_SUPPORT:
-         return "XAudio2 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ZLIB_SUPPORT:
-         return "Zlib 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_7ZIP_SUPPORT:
-         return "7zip 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DYLIB_SUPPORT:
-         return "动态链接库支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CG_SUPPORT:
-         return "Cg 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GLSL_SUPPORT:
-         return "GLSL 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SLANG_SUPPORT:
-         return "Slang 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_HLSL_SUPPORT:
-         return "HLSL 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBXML2_SUPPORT:
-         return "libxml2 XML解析支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_IMAGE_SUPPORT:
-         return "SDL 图像支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FBO_SUPPORT:
-         return "OpenGL/Direct3D 渲染至纹理 (多渲染批次Shader) 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DYNAMIC_SUPPORT:
-         return "运行时动态加载libretro库";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FFMPEG_SUPPORT:
-         return "FFmpeg 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CORETEXT_SUPPORT:
-         return "CoreText 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FREETYPE_SUPPORT:
-         return "FreeType 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETPLAY_SUPPORT:
-         return "Netplay (点对点) 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PYTHON_SUPPORT:
-         return "Python (Shader中脚本支持) 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_V4L2_SUPPORT:
-         return "Video4Linux2 支持";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBUSB_SUPPORT:
-         return "Libusb 支持";
-      case MENU_ENUM_LABEL_VALUE_YES:
-         return "是";
-      case MENU_ENUM_LABEL_VALUE_NO:
-         return "否";
-      case MENU_ENUM_LABEL_VALUE_BACK:
-         return "返回";
-      case MSG_FAILED_TO_BIND_SOCKET:
-         return "Failed to bind socket.";
-      case MENU_ENUM_LABEL_VALUE_SCREEN_RESOLUTION:
-         return "屏幕分辨率";
-      case MENU_ENUM_LABEL_VALUE_DISABLED:
-         return "禁用";
-      case MENU_ENUM_LABEL_VALUE_PORT:
-         return "端口";
-      case MENU_ENUM_LABEL_VALUE_NONE:
-         return "无";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DEVELOPER:
-         return "开发者";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_PUBLISHER:
-         return "出版方";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DESCRIPTION:
-         return "描述";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_GENRE:
-         return "类型";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_NAME:
-         return "名称";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ORIGIN:
-         return "起源";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_FRANCHISE:
-         return "经销商";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_MONTH:
-         return "发售月份";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_YEAR:
-         return "发售年份";
-      case MENU_ENUM_LABEL_VALUE_TRUE:
-         return "真";
-      case MENU_ENUM_LABEL_VALUE_FALSE:
-         return "假";
-      case MENU_ENUM_LABEL_VALUE_MISSING:
-         return "丢失";
-      case MENU_ENUM_LABEL_VALUE_PRESENT:
-         return "现在";
-      case MENU_ENUM_LABEL_VALUE_OPTIONAL:
-         return "任意";
-      case MENU_ENUM_LABEL_VALUE_REQUIRED:
-         return "必须";
-      case MENU_ENUM_LABEL_VALUE_STATUS:
-         return "状态";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_SETTINGS:
-         return "音频";
-      case MENU_ENUM_LABEL_VALUE_INPUT_SETTINGS:
-         return "输入";
-      case MENU_ENUM_LABEL_VALUE_ONSCREEN_DISPLAY_SETTINGS:
-         return "屏幕显示";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_SETTINGS:
-         return "屏幕覆层";
-      case MENU_ENUM_LABEL_VALUE_ONSCREEN_OVERLAY_SETTINGS:
-         return "屏幕覆层";
-      case MENU_ENUM_LABEL_VALUE_MENU_SETTINGS:
-         return "菜单";
-      case MENU_ENUM_LABEL_VALUE_MULTIMEDIA_SETTINGS:
-         return "多媒体";
-      case MENU_ENUM_LABEL_VALUE_USER_INTERFACE_SETTINGS:
-         return "用户界面";
-      case MENU_ENUM_LABEL_VALUE_MENU_FILE_BROWSER_SETTINGS:
-         return "菜单文件浏览器";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_FIRMWARE:
+         return "固件";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_LICENSES:
+         return "许可证";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_PERMISSIONS:
+         return "许可";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SUPPORTED_EXTENSIONS:
+         return "支持的扩展";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_MANUFACTURER:
+         return "系统制造商";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_NAME:
+         return "系统名称";
+      case MENU_ENUM_LABEL_VALUE_CORE_INPUT_REMAPPING_OPTIONS:
+         return "控制";
+      case MENU_ENUM_LABEL_VALUE_CORE_LIST:
+         return "加载核心";
+      case MENU_ENUM_LABEL_VALUE_CORE_OPTIONS:
+         return "选项";
+      case MENU_ENUM_LABEL_VALUE_CORE_SETTINGS:
+         return "核心";
+      case MENU_ENUM_LABEL_VALUE_CORE_SET_SUPPORTS_NO_CONTENT_ENABLE:
+         return "自动启动一个核心";
+      case MENU_ENUM_LABEL_VALUE_CORE_SPECIFIC_CONFIG:
+         return "单核心配置";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
+         return "自动解压下载的档案";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_BUILDBOT_URL:
+         return "构建机器人核心URL";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_LIST:
+         return "核心更新程序";
       case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_SETTINGS:
          return "更新程序";
-      case MENU_ENUM_LABEL_VALUE_UPDATER_SETTINGS:
-         return "更新程序";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_SETTINGS:
-         return "网络";
-      case MENU_ENUM_LABEL_VALUE_WIFI_SETTINGS:
-         return "Wi-Fi";
-      case MENU_ENUM_LABEL_VALUE_LAKKA_SERVICES:
-         return "Lakka 服务";
-      case MENU_ENUM_LABEL_VALUE_PLAYLIST_SETTINGS:
-         return "游戏列表";
-      case MENU_ENUM_LABEL_VALUE_USER_SETTINGS:
-         return "用户";
+      case MENU_ENUM_LABEL_VALUE_CPU_ARCHITECTURE:
+         return "CPU架构:";
+      case MENU_ENUM_LABEL_VALUE_CPU_CORES:
+         return "CPU核心:";
+      case MENU_ENUM_LABEL_VALUE_CURSOR_DIRECTORY:
+         return "指针目录";
+      case MENU_ENUM_LABEL_VALUE_CURSOR_MANAGER:
+         return "光标管理器";
+      case MENU_ENUM_LABEL_VALUE_CUSTOM_RATIO:
+         return "自定义比率";
+      case MENU_ENUM_LABEL_VALUE_DATABASE_MANAGER:
+         return "数据库管理器";
+      case MENU_ENUM_LABEL_VALUE_DATABASE_SELECTION:
+         return "选择数据库";
+      case MENU_ENUM_LABEL_VALUE_DELETE_ENTRY:
+         return "移除";
+      case MENU_ENUM_LABEL_VALUE_DETECT_CORE_LIST:
+         return "选择文件并探测核心";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_CONTENT:
+         return "<游戏内容目录>";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_DEFAULT:
+         return "<默认>";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NONE:
+         return "<无>";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NOT_FOUND:
+         return "没有找到文件夹。";
       case MENU_ENUM_LABEL_VALUE_DIRECTORY_SETTINGS:
          return "目录";
-      case MENU_ENUM_LABEL_VALUE_RECORDING_SETTINGS:
-         return "录像";
-      case MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE:
-         return "没有可用的信息。";
-      case MENU_ENUM_LABEL_VALUE_INPUT_USER_BINDS:
-         return "输入用户 %u 的绑定";
-      case MENU_ENUM_LABEL_VALUE_LANG_ENGLISH:
-         return "英语";
-      case MENU_ENUM_LABEL_VALUE_LANG_JAPANESE:
-         return "日语";
-      case MENU_ENUM_LABEL_VALUE_LANG_FRENCH:
-         return "法语";
-      case MENU_ENUM_LABEL_VALUE_LANG_SPANISH:
-         return "西班牙语";
-      case MENU_ENUM_LABEL_VALUE_LANG_GERMAN:
-         return "德语";
-      case MENU_ENUM_LABEL_VALUE_LANG_ITALIAN:
-         return "意大利语";
-      case MENU_ENUM_LABEL_VALUE_LANG_DUTCH:
-         return "荷兰语";
-      case MENU_ENUM_LABEL_VALUE_LANG_PORTUGUESE:
-         return "葡萄牙语";
-      case MENU_ENUM_LABEL_VALUE_LANG_RUSSIAN:
-         return "俄语";
-      case MENU_ENUM_LABEL_VALUE_LANG_KOREAN:
-         return "韩语";
-      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_TRADITIONAL:
-         return "繁体中文";
-      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_SIMPLIFIED:
-         return "简体中文";
-      case MENU_ENUM_LABEL_VALUE_LANG_ESPERANTO:
-         return "世界语";
-      case MENU_ENUM_LABEL_VALUE_LANG_VIETNAMESE:
-         return "越南语";
-      case MENU_ENUM_LABEL_VALUE_LEFT_ANALOG:
-         return "左侧摇杆";
-      case MENU_ENUM_LABEL_VALUE_RIGHT_ANALOG:
-         return "右侧摇杆";
-      case MENU_ENUM_LABEL_VALUE_INPUT_HOTKEY_BINDS:
-         return "输入热键绑定";
-      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_SETTINGS:
-         return "帧率限制";
-      case MENU_ENUM_LABEL_VALUE_SEARCH:
-         return "搜索：";
-      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_IMAGE_VIEWER:
-         return "使用内建的图像浏览器";
+      case MENU_ENUM_LABEL_VALUE_DISABLED:
+         return "禁用";
+      case MENU_ENUM_LABEL_VALUE_DISK_CYCLE_TRAY_STATUS:
+         return "Disk Cycle Tray Status";
+      case MENU_ENUM_LABEL_VALUE_DISK_IMAGE_APPEND:
+         return "追加光盘镜像";
+      case MENU_ENUM_LABEL_VALUE_DISK_INDEX:
+         return "光盘索引";
+      case MENU_ENUM_LABEL_VALUE_DISK_OPTIONS:
+         return "光盘控制";
+      case MENU_ENUM_LABEL_VALUE_DONT_CARE:
+         return "不关心";
+      case MENU_ENUM_LABEL_VALUE_DOWNLOADED_FILE_DETECT_CORE_LIST:
+         return "下载目录";
+      case MENU_ENUM_LABEL_VALUE_DOWNLOAD_CORE:
+         return "下载核心……";
+      case MENU_ENUM_LABEL_VALUE_DOWNLOAD_CORE_CONTENT:
+         return "下载游戏内容";
+      case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_ENABLE:
+         return "启用DPI覆盖";
+      case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_VALUE:
+         return "DPI覆盖";
+      case MENU_ENUM_LABEL_VALUE_DRIVER_SETTINGS:
+         return "驱动";
+      case MENU_ENUM_LABEL_VALUE_DUMMY_ON_CORE_SHUTDOWN:
+         return "Dummy On Core Shutdown";
+      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPER:
+         return "动态壁纸";
+      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPERS_DIRECTORY:
+         return "动态壁纸目录";
       case MENU_ENUM_LABEL_VALUE_ENABLE:
          return "启用";
-      case MENU_ENUM_LABEL_VALUE_START_CORE:
-         return "启动核心";
-      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR:
-         return "轮询类型行为";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_SCROLL_UP:
-         return "向上滚动";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_SCROLL_DOWN:
-         return "向下滚动";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_CONFIRM:
-         return "确认";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_BACK:
-         return "返回";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_START:
-         return "开始";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_INFO:
+      case MENU_ENUM_LABEL_VALUE_ENTRY_HOVER_COLOR:
+         return "菜单项悬停颜色";
+      case MENU_ENUM_LABEL_VALUE_ENTRY_NORMAL_COLOR:
+         return "菜单项正常颜色";
+      case MENU_ENUM_LABEL_VALUE_FALSE:
+         return "假";
+      case MENU_ENUM_LABEL_VALUE_FASTFORWARD_RATIO:
+         return "最大运行速度";
+      case MENU_ENUM_LABEL_VALUE_FPS_SHOW:
+         return "显示帧率";
+      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_ENABLE:
+         return "限制最大运行速度";
+      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_SETTINGS:
+         return "帧率限制";
+      case MENU_ENUM_LABEL_VALUE_FRONTEND_COUNTERS:
+         return "前端计数器";
+      case MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS:
+         return "自动加载游戏内容特定的核心选项";
+      case MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS_CREATE:
+         return "创建游戏选项文件";
+      case MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS_IN_USE:
+         return "游戏选项文件";
+      case MENU_ENUM_LABEL_VALUE_HELP:
+         return "帮助";
+      case MENU_ENUM_LABEL_VALUE_HELP_AUDIO_VIDEO_TROUBLESHOOTING:
+         return "音频/视频故障排除";
+      case MENU_ENUM_LABEL_VALUE_HELP_CHANGE_VIRTUAL_GAMEPAD:
+         return "变更虚拟游戏控制器覆层";
+      case MENU_ENUM_LABEL_VALUE_HELP_CONTROLS:
+         return "基本菜单控制";
+      case MENU_ENUM_LABEL_VALUE_HELP_LIST:
+         return "帮助";
+      case MENU_ENUM_LABEL_VALUE_HELP_LOADING_CONTENT:
+         return "加载游戏内容";
+      case MENU_ENUM_LABEL_VALUE_HELP_SCANNING_CONTENT:
+         return "扫描游戏内容";
+      case MENU_ENUM_LABEL_VALUE_HELP_WHAT_IS_A_CORE:
+         return "什么是“核心”？";
+      case MENU_ENUM_LABEL_VALUE_HISTORY_LIST_ENABLE:
+         return "启用历史记录";
+      case MENU_ENUM_LABEL_VALUE_HISTORY_TAB:
+         return "历史";
+      case MENU_ENUM_LABEL_VALUE_HORIZONTAL_MENU:
+         return "水平化菜单";
+      case MENU_ENUM_LABEL_VALUE_IMAGES_TAB:
+         return "图像";
+      case MENU_ENUM_LABEL_VALUE_INFORMATION:
          return "信息";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_TOGGLE_MENU:
-         return "切换菜单";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_QUIT:
-         return "退出";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_TOGGLE_KEYBOARD:
-         return "切换键盘";
-      case MENU_ENUM_LABEL_VALUE_THUMBNAIL_MODE_SCREENSHOTS:
-         return "截屏";
-      case MENU_ENUM_LABEL_VALUE_THUMBNAIL_MODE_TITLE_SCREENS:
-         return "标题画面";
-      case MENU_ENUM_LABEL_VALUE_THUMBNAIL_MODE_BOXARTS:
-         return "Boxarts";
-      case MENU_ENUM_LABEL_VALUE_MENU_WALLPAPER_OPACITY:
-         return "壁纸不透明度";
+      case MENU_ENUM_LABEL_VALUE_INFORMATION_LIST:
+         return "信息";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ADC_TYPE:
+         return "手柄输入转数字选项";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ALL_USERS_CONTROL_MENU:
+         return "所有用户都能控制菜单";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_X:
+         return "左摇杆X";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_X_MINUS:
+         return "左摇杆X- (左)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_X_PLUS:
+         return "左摇杆X+ (右)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_Y:
+         return "左摇杆Y";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_Y_MINUS:
+         return "左摇杆Y- (上)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_Y_PLUS:
+         return "左摇杆Y+ (下)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_X:
+         return "右摇杆X";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_X_MINUS:
+         return "右摇杆X- (左)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_X_PLUS:
+         return "右摇杆X+ (右)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_Y:
+         return "右摇杆Y";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_Y_MINUS:
+         return "右摇杆Y- (上)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_Y_PLUS:
+         return "右摇杆Y+ (下)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_AUTODETECT_ENABLE:
+         return "启用自动配置";
+      case MENU_ENUM_LABEL_VALUE_INPUT_AXIS_THRESHOLD:
+         return "输入轴阈值";
+      case MENU_ENUM_LABEL_VALUE_INPUT_BACK_AS_MENU_ENUM_TOGGLE_ENABLE:
+         return "将返回作为菜单切出键";
+      case MENU_ENUM_LABEL_VALUE_INPUT_BIND_ALL:
+         return "绑定全部";
+      case MENU_ENUM_LABEL_VALUE_INPUT_BIND_DEFAULT_ALL:
+         return "绑定全部至默认值";
+      case MENU_ENUM_LABEL_VALUE_INPUT_BIND_TIMEOUT:
+         return "绑定超时时间";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_HIDE_UNBOUND:
+         return "隐藏未绑定的核心输入描述";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_LABEL_SHOW:
+         return "显示输入描述标签";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DEVICE_INDEX:
+         return "设备索引";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DEVICE_TYPE:
+         return "设备类型";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DRIVER:
+         return "输入驱动";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DUTY_CYCLE:
+         return "Turbo占空比";
+      case MENU_ENUM_LABEL_VALUE_INPUT_HOTKEY_BINDS:
+         return "输入热键绑定";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ICADE_ENABLE:
+         return "键盘控制器映射启用";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_A:
+         return "A键(右侧)";
       case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_B:
          return "B键(下方)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_Y:
-         return "Y键(左侧)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_DOWN:
+         return "下十字键";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_L2:
+         return "L2键(触发)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_L3:
+         return "L3键(拇指)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_L:
+         return "L键(手柄肩部)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_LEFT:
+         return "左十字键";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_R2:
+         return "R2键(触发)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_R3:
+         return "R3键(拇指)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_R:
+         return "R键(手柄肩部)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_RIGHT:
+         return "右十字键";
       case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_SELECT:
          return "选择键";
       case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_START:
          return "开始键";
       case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_UP:
          return "上十字键";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_DOWN:
-         return "下十字键";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_LEFT:
-         return "左十字键";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_RIGHT:
-         return "右十字键";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_A:
-         return "A键(右侧)";
       case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_X:
          return "X键(上方)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_L:
-         return "L键(手柄肩部)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_R:
-         return "R键(手柄肩部)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_L2:
-         return "L2键(触发)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_R2:
-         return "R2键(触发)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_L3:
-         return "L3键(拇指)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_R3:
-         return "R3键(拇指)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_X:
-         return "左摇杆X";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_Y:
-         return "左摇杆Y";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_X:
-         return "右摇杆X";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_Y:
-         return "右摇杆Y";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_X_PLUS:
-         return "左摇杆X+ (右)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_X_MINUS:
-         return "左摇杆X- (左)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_Y_PLUS:
-         return "左摇杆Y+ (下)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_Y_MINUS:
-         return "左摇杆Y- (上)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_X_PLUS:
-         return "右摇杆X+ (右)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_X_MINUS:
-         return "右摇杆X- (左)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_Y_PLUS:
-         return "右摇杆Y+ (下)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_Y_MINUS:
-         return "右摇杆Y- (上)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_TURBO_ENABLE:
-         return "TURBO开关";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_FAST_FORWARD_KEY:
-         return "快进切换";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_FAST_FORWARD_HOLD_KEY:
-         return "快进保持";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_LOAD_STATE_KEY:
-         return "加载状态";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_SAVE_STATE_KEY:
-         return "保存状态";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_FULLSCREEN_TOGGLE_KEY:
-         return "切换全屏幕";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_QUIT_KEY:
-         return "退出 RetroArch";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_STATE_SLOT_PLUS:
-         return "存档槽 +";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_STATE_SLOT_MINUS:
-         return "存档槽 -";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_REWIND:
-         return "回溯";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_MOVIE_RECORD_TOGGLE:
-         return "视频录制开关";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_PAUSE_TOGGLE:
-         return "切换暂停";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_FRAMEADVANCE:
-         return "帧提前量";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_RESET:
-         return "重置游戏";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_SHADER_NEXT:
-         return "下一个Shader";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_SHADER_PREV:
-         return "上一个Shader";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_CHEAT_INDEX_PLUS:
-         return "金手指索引 +";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_Y:
+         return "Y键(左侧)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_KEYBOARD_GAMEPAD_MAPPING_TYPE:
+         return "键盘控制器映射类型";
+      case MENU_ENUM_LABEL_VALUE_INPUT_MAX_USERS:
+         return "最大用户数";
+      case MENU_ENUM_LABEL_VALUE_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
+         return "游戏控制器菜单切出组合键";
       case MENU_ENUM_LABEL_VALUE_INPUT_META_CHEAT_INDEX_MINUS:
          return "金手指索引 -";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_CHEAT_INDEX_PLUS:
+         return "金手指索引 +";
       case MENU_ENUM_LABEL_VALUE_INPUT_META_CHEAT_TOGGLE:
          return "金手指开关";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_SCREENSHOT:
-         return "屏幕截图";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_MUTE:
-         return "静音开关";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_OSK:
-         return "切换屏幕键盘";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_NETPLAY_FLIP:
-         return "Netplay flip users";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_SLOWMOTION:
-         return "慢动作";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_ENABLE_HOTKEY:
-         return "启用热键";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_VOLUME_UP:
-         return "音量 +";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_VOLUME_DOWN:
-         return "音量 -";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_OVERLAY_NEXT:
-         return "下一个覆层";
       case MENU_ENUM_LABEL_VALUE_INPUT_META_DISK_EJECT_TOGGLE:
          return "光驱出仓切换";
       case MENU_ENUM_LABEL_VALUE_INPUT_META_DISK_NEXT:
          return "下一张光盘";
       case MENU_ENUM_LABEL_VALUE_INPUT_META_DISK_PREV:
          return "上一张光盘";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_ENABLE_HOTKEY:
+         return "启用热键";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_FAST_FORWARD_HOLD_KEY:
+         return "快进保持";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_FAST_FORWARD_KEY:
+         return "快进切换";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_FRAMEADVANCE:
+         return "帧提前量";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_FULLSCREEN_TOGGLE_KEY:
+         return "切换全屏幕";
       case MENU_ENUM_LABEL_VALUE_INPUT_META_GRAB_MOUSE_TOGGLE:
          return "鼠标捕获开关";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_LOAD_STATE_KEY:
+         return "加载状态";
       case MENU_ENUM_LABEL_VALUE_INPUT_META_MENU_TOGGLE:
          return "切换菜单";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DEVICE_INDEX:
-         return "设备索引";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DEVICE_TYPE:
-         return "设备类型";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ADC_TYPE:
-         return "手柄输入转数字选项";
-      case MENU_ENUM_LABEL_VALUE_INPUT_BIND_ALL:
-         return "绑定全部";
-      case MENU_ENUM_LABEL_VALUE_INPUT_BIND_DEFAULT_ALL:
-         return "绑定全部至默认值";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_MOVIE_RECORD_TOGGLE:
+         return "视频录制开关";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_MUTE:
+         return "静音开关";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_NETPLAY_FLIP:
+         return "Netplay flip users";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_OSK:
+         return "切换屏幕键盘";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_OVERLAY_NEXT:
+         return "下一个覆层";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_PAUSE_TOGGLE:
+         return "切换暂停";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_QUIT_KEY:
+         return "退出 RetroArch";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_RESET:
+         return "重置游戏";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_REWIND:
+         return "回溯";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_SAVE_STATE_KEY:
+         return "保存状态";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_SCREENSHOT:
+         return "屏幕截图";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_SHADER_NEXT:
+         return "下一个Shader";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_SHADER_PREV:
+         return "上一个Shader";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_SLOWMOTION:
+         return "慢动作";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_STATE_SLOT_MINUS:
+         return "存档槽 -";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_STATE_SLOT_PLUS:
+         return "存档槽 +";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_VOLUME_DOWN:
+         return "音量 -";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_VOLUME_UP:
+         return "音量 +";
+      case MENU_ENUM_LABEL_VALUE_INPUT_OSK_OVERLAY_ENABLE:
+         return "显示键盘覆层";
+      case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_ENABLE:
+         return "显示覆层";
+      case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_HIDE_IN_MENU:
+         return "在菜单中隐藏覆层";
+      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR:
+         return "轮询类型行为";
+      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR_EARLY:
+         return "较早";
+      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR_LATE:
+         return "稍晚";
+      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR_NORMAL:
+         return "正常";
+      case MENU_ENUM_LABEL_VALUE_INPUT_PREFER_FRONT_TOUCH:
+         return "优先前置触摸";
+      case MENU_ENUM_LABEL_VALUE_INPUT_REMAPPING_DIRECTORY:
+         return "输入重映射目录";
+      case MENU_ENUM_LABEL_VALUE_INPUT_REMAP_BINDS_ENABLE:
+         return "启用绑定重映射";
       case MENU_ENUM_LABEL_VALUE_INPUT_SAVE_AUTOCONFIG:
          return "保存自动设置";
+      case MENU_ENUM_LABEL_VALUE_INPUT_SETTINGS:
+         return "输入";
+      case MENU_ENUM_LABEL_VALUE_INPUT_SMALL_KEYBOARD_ENABLE:
+         return "启用小键盘";
+      case MENU_ENUM_LABEL_VALUE_INPUT_TOUCH_ENABLE:
+         return "启用触摸";
+      case MENU_ENUM_LABEL_VALUE_INPUT_TURBO_ENABLE:
+         return "TURBO开关";
+      case MENU_ENUM_LABEL_VALUE_INPUT_TURBO_PERIOD:
+         return "Turbo区间";
+      case MENU_ENUM_LABEL_VALUE_INPUT_USER_BINDS:
+         return "输入用户 %u 的绑定";
+      case MENU_ENUM_LABEL_VALUE_INTERNAL_STORAGE_STATUS:
+         return "内部存储状态";
+      case MENU_ENUM_LABEL_VALUE_JOYPAD_AUTOCONFIG_DIR:
+         return "输入设备自动配置目录";
+      case MENU_ENUM_LABEL_VALUE_JOYPAD_DRIVER:
+         return "手柄驱动";
+      case MENU_ENUM_LABEL_VALUE_KEYBOARD_OVERLAY_PRESET:
+         return "键盘覆层预设";
+      case MENU_ENUM_LABEL_VALUE_LAKKA_SERVICES:
+         return "Lakka 服务";
+      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_SIMPLIFIED:
+         return "简体中文";
+      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_TRADITIONAL:
+         return "繁体中文";
+      case MENU_ENUM_LABEL_VALUE_LANG_DUTCH:
+         return "荷兰语";
+      case MENU_ENUM_LABEL_VALUE_LANG_ENGLISH:
+         return "英语";
+      case MENU_ENUM_LABEL_VALUE_LANG_ESPERANTO:
+         return "世界语";
+      case MENU_ENUM_LABEL_VALUE_LANG_FRENCH:
+         return "法语";
+      case MENU_ENUM_LABEL_VALUE_LANG_GERMAN:
+         return "德语";
+      case MENU_ENUM_LABEL_VALUE_LANG_ITALIAN:
+         return "意大利语";
+      case MENU_ENUM_LABEL_VALUE_LANG_JAPANESE:
+         return "日语";
+      case MENU_ENUM_LABEL_VALUE_LANG_KOREAN:
+         return "韩语";
+      case MENU_ENUM_LABEL_VALUE_LANG_POLISH:
+         return "波兰语";
+      case MENU_ENUM_LABEL_VALUE_LANG_PORTUGUESE:
+         return "葡萄牙语";
+      case MENU_ENUM_LABEL_VALUE_LANG_RUSSIAN:
+         return "俄语";
+      case MENU_ENUM_LABEL_VALUE_LANG_SPANISH:
+         return "西班牙语";
+      case MENU_ENUM_LABEL_VALUE_LANG_VIETNAMESE:
+         return "越南语";
+      case MENU_ENUM_LABEL_VALUE_LEFT_ANALOG:
+         return "左侧摇杆";
+      case MENU_ENUM_LABEL_VALUE_LIBRETRO_DIR_PATH:
+         return "核心目录";
+      case MENU_ENUM_LABEL_VALUE_LIBRETRO_INFO_PATH:
+         return "核心信息目录";
+      case MENU_ENUM_LABEL_VALUE_LIBRETRO_LOG_LEVEL:
+         return "核心日志级别";
+      case MENU_ENUM_LABEL_VALUE_LINEAR:
+         return "线性";
+      case MENU_ENUM_LABEL_VALUE_LOAD_ARCHIVE:
+         return "使用核心加载压缩包";
+      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT:
+         return "选择文件";
+      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_HISTORY:
+         return "加载最近的游戏内容";
+      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_LIST:
+         return "载入游戏内容";
+      case MENU_ENUM_LABEL_VALUE_LOAD_STATE:
+         return "加载状态";
+      case MENU_ENUM_LABEL_VALUE_LOCATION_ALLOW:
+         return "允许使用位置";
+      case MENU_ENUM_LABEL_VALUE_LOCATION_DRIVER:
+         return "定位驱动";
+      case MENU_ENUM_LABEL_VALUE_LOGGING_SETTINGS:
+         return "日志";
+      case MENU_ENUM_LABEL_VALUE_LOG_VERBOSITY:
+         return "完整日志记录";
+      case MENU_ENUM_LABEL_VALUE_MAIN_MENU:
+         return "主菜单";
+      case MENU_ENUM_LABEL_VALUE_MANAGEMENT:
+         return "数据库设置";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME:
+         return "菜单颜色主题";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_BLUE:
+         return "蓝色";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_BLUE_GREY:
+         return "蓝灰色";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_DARK_BLUE:
+         return "深蓝色";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_GREEN:
+         return "绿色";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_NVIDIA_SHIELD:
+         return "NV SHIELD";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_RED:
+         return "红色";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_YELLOW:
+         return "黄色";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_FOOTER_OPACITY:
+         return "底部不透明度";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_HEADER_OPACITY:
+         return "顶部不透明度";
+      case MENU_ENUM_LABEL_VALUE_MENU_DRIVER:
+         return "菜单驱动";
+      case MENU_ENUM_LABEL_VALUE_MENU_ENUM_THROTTLE_FRAMERATE:
+         return "限制菜单帧率";
+      case MENU_ENUM_LABEL_VALUE_MENU_FILE_BROWSER_SETTINGS:
+         return "菜单文件浏览器";
+      case MENU_ENUM_LABEL_VALUE_MENU_LINEAR_FILTER:
+         return "菜单线性过滤";
+      case MENU_ENUM_LABEL_VALUE_MENU_SETTINGS:
+         return "菜单";
+      case MENU_ENUM_LABEL_VALUE_MENU_WALLPAPER:
+         return "菜单壁纸";
+      case MENU_ENUM_LABEL_VALUE_MENU_WALLPAPER_OPACITY:
+         return "壁纸不透明度";
+      case MENU_ENUM_LABEL_VALUE_MISSING:
+         return "丢失";
+      case MENU_ENUM_LABEL_VALUE_MORE:
+         return "...";
+      case MENU_ENUM_LABEL_VALUE_MOUSE_ENABLE:
+         return "鼠标支持";
+      case MENU_ENUM_LABEL_VALUE_MULTIMEDIA_SETTINGS:
+         return "多媒体";
+      case MENU_ENUM_LABEL_VALUE_MUSIC_TAB:
+         return "音乐";
+      case MENU_ENUM_LABEL_VALUE_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
+         return "过滤未知扩展名";
+      case MENU_ENUM_LABEL_VALUE_NAVIGATION_WRAPAROUND:
+         return "环绕式导航";
+      case MENU_ENUM_LABEL_VALUE_NEAREST:
+         return "最近";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY:
+         return "在线游戏";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_CHECK_FRAMES:
+         return "在线游戏检查帧数";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT:
+         return "在线玩家P2使用C1";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_DELAY_FRAMES:
+         return "在线游戏延迟帧数";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_DISCONNECT:
+         return "断开连接";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE:
+         return "启用在线游戏";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE_CLIENT:
+         return "连接到游戏主机";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE_HOST:
+         return "作为游戏主机";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS:
+         return "服务器地址";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_MODE:
+         return "启用在线游戏客户端";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_NICKNAME:
+         return "用户名";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_SETTINGS:
+         return "在线游戏设置";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE:
+         return "启用在线游戏旁观者";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT:
+         return "在线游戏TCP/UDP端口";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_ENABLE:
+         return "网络命令";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_PORT:
+         return "网络命令端口";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_INFORMATION:
+         return "网络信息";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_REMOTE_ENABLE:
+         return "网络游戏控制器";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_REMOTE_PORT:
+         return "网络远端基本端口";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_SETTINGS:
+         return "网络";
+      case MENU_ENUM_LABEL_VALUE_NO:
+         return "否";
+      case MENU_ENUM_LABEL_VALUE_NONE:
+         return "无";
+      case MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE:
+         return "N/A";
+      case MENU_ENUM_LABEL_VALUE_NO_ACHIEVEMENTS_TO_DISPLAY:
+         return "没有可显示的成就。";
+      case MENU_ENUM_LABEL_VALUE_NO_CORE:
+         return "没有核心";
+      case MENU_ENUM_LABEL_VALUE_NO_CORES_AVAILABLE:
+         return "没有可用的核心。";
+      case MENU_ENUM_LABEL_VALUE_NO_CORE_INFORMATION_AVAILABLE:
+         return "没有可用的核心信息。";
+      case MENU_ENUM_LABEL_VALUE_NO_CORE_OPTIONS_AVAILABLE:
+         return "没有可用的核心选项。";
+      case MENU_ENUM_LABEL_VALUE_NO_ENTRIES_TO_DISPLAY:
+         return "没有可显示的条目。";
+      case MENU_ENUM_LABEL_VALUE_NO_HISTORY_AVAILABLE:
+         return "没有可用的历史记录。";
+      case MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE:
+         return "没有可用的信息。";
+      case MENU_ENUM_LABEL_VALUE_NO_ITEMS:
+         return "没有条目。";
+      case MENU_ENUM_LABEL_VALUE_NO_PERFORMANCE_COUNTERS:
+         return "没有性能计数器。";
+      case MENU_ENUM_LABEL_VALUE_NO_PLAYLISTS:
+         return "没有游戏列表。";
+      case MENU_ENUM_LABEL_VALUE_NO_PLAYLIST_ENTRIES_AVAILABLE:
+         return "没有可用的游戏列表项目。";
+      case MENU_ENUM_LABEL_VALUE_NO_SETTINGS_FOUND:
+         return "没有找到设置。";
+      case MENU_ENUM_LABEL_VALUE_NO_SHADER_PARAMETERS:
+         return "没有Shader参数.";
+      case MENU_ENUM_LABEL_VALUE_OFF:
+         return "关";
+      case MENU_ENUM_LABEL_VALUE_ON:
+         return "开";
+      case MENU_ENUM_LABEL_VALUE_ONLINE_UPDATER:
+         return "在线更新器";
+      case MENU_ENUM_LABEL_VALUE_ONSCREEN_DISPLAY_SETTINGS:
+         return "屏幕显示";
+      case MENU_ENUM_LABEL_VALUE_ONSCREEN_OVERLAY_SETTINGS:
+         return "屏幕覆层";
+      case MENU_ENUM_LABEL_VALUE_OPEN_ARCHIVE:
+         return "以文件夹形式打开压缩包";
+      case MENU_ENUM_LABEL_VALUE_OPTIONAL:
+         return "任意";
+      case MENU_ENUM_LABEL_VALUE_OSK_OVERLAY_DIRECTORY:
+         return "OSK覆层目录";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY:
+         return "覆层";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_AUTOLOAD_PREFERRED:
+         return "自动加载最佳的覆层";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_DIRECTORY:
+         return "覆层目录";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_OPACITY:
+         return "覆层不透明度";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_PRESET:
+         return "覆层预设";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_SCALE:
+         return "覆层缩放比例";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_SETTINGS:
+         return "屏幕覆层";
+      case MENU_ENUM_LABEL_VALUE_PAL60_ENABLE:
+         return "使用PAL60模式";
+      case MENU_ENUM_LABEL_VALUE_PARENT_DIRECTORY:
+         return "上一级目录";
+      case MENU_ENUM_LABEL_VALUE_PAUSE_LIBRETRO:
+         return "当菜单激活时暂停";
+      case MENU_ENUM_LABEL_VALUE_PAUSE_NONACTIVE:
+         return "禁止后台运行";
+      case MENU_ENUM_LABEL_VALUE_PERFCNT_ENABLE:
+         return "性能计数器";
+      case MENU_ENUM_LABEL_VALUE_PLAYLISTS_TAB:
+         return "游戏列表";
+      case MENU_ENUM_LABEL_VALUE_PLAYLIST_DIRECTORY:
+         return "游戏列表目录";
+      case MENU_ENUM_LABEL_VALUE_PLAYLIST_SETTINGS:
+         return "游戏列表";
+      case MENU_ENUM_LABEL_VALUE_POINTER_ENABLE:
+         return "触摸支持";
+      case MENU_ENUM_LABEL_VALUE_PORT:
+         return "端口";
+      case MENU_ENUM_LABEL_VALUE_PRESENT:
+         return "现在";
+      case MENU_ENUM_LABEL_VALUE_PRIVACY_SETTINGS:
+         return "隐私";
+      case MENU_ENUM_LABEL_VALUE_QUIT_RETROARCH:
+         return "退出 RetroArch";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ANALOG:
+         return "支持摇杆输入";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_BBFC_RATING:
+         return "BBFC 分级";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_CERO_RATING:
+         return "CERO 分级";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_COOP:
+         return "多人游戏支持";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_CRC32:
+         return "CRC32";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DESCRIPTION:
+         return "描述";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DEVELOPER:
+         return "开发者";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_EDGE_MAGAZINE_ISSUE:
+         return "Edge Magazine Issue";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_EDGE_MAGAZINE_RATING:
+         return "Edge Magazine Rating";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_EDGE_MAGAZINE_REVIEW:
+         return "Edge Magazine Review";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ELSPA_RATING:
+         return "ELSPA 分级";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ENHANCEMENT_HW:
+         return "增强硬件";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ESRB_RATING:
+         return "ESRB 分级";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_FAMITSU_MAGAZINE_RATING:
+         return "Famitsu Magazine Rating";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_FRANCHISE:
+         return "经销商";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_GENRE:
+         return "类型";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_MD5:
+         return "MD5";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_NAME:
+         return "名称";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ORIGIN:
+         return "起源";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_PEGI_RATING:
+         return "PEGI 分级";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_PUBLISHER:
+         return "出版方";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_MONTH:
+         return "发售月份";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_YEAR:
+         return "发售年份";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RUMBLE:
+         return "震动支持";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_SERIAL:
+         return "系列";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_SHA1:
+         return "SHA1";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_START_CONTENT:
+         return "启动游戏内容";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_TGDB_RATING:
+         return "TGDB Rating";
+      case MENU_ENUM_LABEL_VALUE_REBOOT:
+         return "重启";
+      case MENU_ENUM_LABEL_VALUE_RECORDING_CONFIG_DIRECTORY:
+         return "录像配置目录";
+      case MENU_ENUM_LABEL_VALUE_RECORDING_OUTPUT_DIRECTORY:
+         return "录像输出目录";
+      case MENU_ENUM_LABEL_VALUE_RECORDING_SETTINGS:
+         return "录像";
+      case MENU_ENUM_LABEL_VALUE_RECORD_CONFIG:
+         return "录像配置";
+      case MENU_ENUM_LABEL_VALUE_RECORD_DRIVER:
+         return "录像驱动";
+      case MENU_ENUM_LABEL_VALUE_RECORD_ENABLE:
+         return "启用录像";
+      case MENU_ENUM_LABEL_VALUE_RECORD_PATH:
+         return "输出文件";
+      case MENU_ENUM_LABEL_VALUE_RECORD_USE_OUTPUT_DIRECTORY:
+         return "使用输出目录";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE:
+         return "重映射文件";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_LOAD:
+         return "加载重映射文件";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_CORE:
+         return "保存核心重映射文件";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_GAME:
+         return "保存游戏重映射文件";
+      case MENU_ENUM_LABEL_VALUE_REQUIRED:
+         return "必须";
+      case MENU_ENUM_LABEL_VALUE_RESTART_CONTENT:
+         return "重启";
+      case MENU_ENUM_LABEL_VALUE_RESTART_RETROARCH:
+         return "重启 RetroArch";
+      case MENU_ENUM_LABEL_VALUE_RESUME:
+         return "继续";
+      case MENU_ENUM_LABEL_VALUE_RESUME_CONTENT:
+         return "继续";
+      case MENU_ENUM_LABEL_VALUE_RETROKEYBOARD:
+         return "RetroKeyboard";
+      case MENU_ENUM_LABEL_VALUE_RETROPAD:
+         return "RetroPad";
+      case MENU_ENUM_LABEL_VALUE_RETRO_ACHIEVEMENTS_SETTINGS:
+         return "Retro 成就";
+      case MENU_ENUM_LABEL_VALUE_REWIND_ENABLE:
+         return "启用回溯";
+      case MENU_ENUM_LABEL_VALUE_REWIND_GRANULARITY:
+         return "回溯粒度";
+      case MENU_ENUM_LABEL_VALUE_REWIND_SETTINGS:
+         return "回溯";
+      case MENU_ENUM_LABEL_VALUE_RGUI_BROWSER_DIRECTORY:
+         return "文件浏览器目录";
+      case MENU_ENUM_LABEL_VALUE_RGUI_CONFIG_DIRECTORY:
+         return "配置目录";
+      case MENU_ENUM_LABEL_VALUE_RGUI_SHOW_START_SCREEN:
+         return "显示开始屏幕";
+      case MENU_ENUM_LABEL_VALUE_RIGHT_ANALOG:
+         return "右侧摇杆";
+      case MENU_ENUM_LABEL_VALUE_RUN:
+         return "运行";
+      case MENU_ENUM_LABEL_VALUE_SAMBA_ENABLE:
+         return "启用SAMBA文件共享服务";
+      case MENU_ENUM_LABEL_VALUE_SAVEFILE_DIRECTORY:
+         return "存档文件目录";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_INDEX:
+         return "自动索引保存状态";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_LOAD:
+         return "自动加载状态";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_SAVE:
+         return "自动保存状态";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_DIRECTORY:
+         return "状态存储目录";
+      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG:
+         return "保存当前配置";
+      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG_OVERRIDE_CORE:
+         return "保存核心覆写";
+      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG_OVERRIDE_GAME:
+         return "保存游戏覆写";
+      case MENU_ENUM_LABEL_VALUE_SAVE_NEW_CONFIG:
+         return "保存新配置";
+      case MENU_ENUM_LABEL_VALUE_SAVE_STATE:
+         return "保存状态";
+      case MENU_ENUM_LABEL_VALUE_SAVING_SETTINGS:
+         return "存档";
+      case MENU_ENUM_LABEL_VALUE_SCAN_DIRECTORY:
+         return "扫描文件夹";
+      case MENU_ENUM_LABEL_VALUE_SCAN_FILE:
+         return "扫描文件";
+      case MENU_ENUM_LABEL_VALUE_SCAN_THIS_DIRECTORY:
+         return "<扫描当前目录>";
+      case MENU_ENUM_LABEL_VALUE_SCREENSHOT_DIRECTORY:
+         return "屏幕截图目录";
+      case MENU_ENUM_LABEL_VALUE_SCREEN_RESOLUTION:
+         return "屏幕分辨率";
+      case MENU_ENUM_LABEL_VALUE_SEARCH:
+         return "搜索：";
+      case MENU_ENUM_LABEL_VALUE_SECONDS:
+         return "秒";
+      case MENU_ENUM_LABEL_VALUE_SETTINGS:
+         return "设置";
+      case MENU_ENUM_LABEL_VALUE_SETTINGS_TAB:
+         return "设置";
+      case MENU_ENUM_LABEL_VALUE_SHADER:
+         return "Shader";
+      case MENU_ENUM_LABEL_VALUE_SHADER_APPLY_CHANGES:
+         return "应用Shader修改";
+      case MENU_ENUM_LABEL_VALUE_SHADER_OPTIONS:
+         return "Shader效果";
+      case MENU_ENUM_LABEL_VALUE_SHADER_PIPELINE_RIBBON:
+         return "Ribbon";
+      case MENU_ENUM_LABEL_VALUE_SHADER_PIPELINE_RIBBON_SIMPLIFIED:
+         return "Ribbon (简化)";
+      case MENU_ENUM_LABEL_VALUE_SHOW_ADVANCED_SETTINGS:
+         return "显示高级设置";
+      case MENU_ENUM_LABEL_VALUE_SHOW_HIDDEN_FILES:
+         return "显示隐藏的文件和文件夹";
+      case MENU_ENUM_LABEL_VALUE_SHUTDOWN:
+         return "关机";
+      case MENU_ENUM_LABEL_VALUE_SLOWMOTION_RATIO:
+         return "慢动作倍率";
+      case MENU_ENUM_LABEL_VALUE_SORT_SAVEFILES_ENABLE:
+         return "排序文件夹中的存档";
+      case MENU_ENUM_LABEL_VALUE_SORT_SAVESTATES_ENABLE:
+         return "排序文件夹中的状态存储";
+      case MENU_ENUM_LABEL_VALUE_SSH_ENABLE:
+         return "启用SSH远程终端服务";
+      case MENU_ENUM_LABEL_VALUE_START_CORE:
+         return "启动核心";
+      case MENU_ENUM_LABEL_VALUE_START_NET_RETROPAD:
+         return "启动远程的RetroPad";
+      case MENU_ENUM_LABEL_VALUE_START_VIDEO_PROCESSOR:
+         return "启动视频处理";
+      case MENU_ENUM_LABEL_VALUE_STATE_SLOT:
+         return "状态存储槽";
+      case MENU_ENUM_LABEL_VALUE_STATUS:
+         return "状态";
+      case MENU_ENUM_LABEL_VALUE_STDIN_CMD_ENABLE:
+         return "标准输入流命令";
+      case MENU_ENUM_LABEL_VALUE_SUPPORTED_CORES:
+         return "支持的核心";
+      case MENU_ENUM_LABEL_VALUE_SUSPEND_SCREENSAVER_ENABLE:
+         return "暂停屏保程序";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_BGM_ENABLE:
+         return "启用系统背景音乐";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_DIRECTORY:
+         return "系统/BIOS目录";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFORMATION:
+         return "系统信息";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_7ZIP_SUPPORT:
+         return "7zip 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ALSA_SUPPORT:
+         return "ALSA 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_BUILD_DATE:
+         return "编译日期";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CG_SUPPORT:
+         return "Cg 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COCOA_SUPPORT:
+         return "Cocoa 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COMMAND_IFACE_SUPPORT:
+         return "控制台支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CORETEXT_SUPPORT:
+         return "CoreText 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CPU_FEATURES:
+         return "CPU特性";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_DPI:
+         return "显示器度量DPI";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_HEIGHT:
+         return "显示器度量高度(mm)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_WIDTH:
+         return "显示器度量宽度(mm)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DSOUND_SUPPORT:
+         return "DirectSound 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DYLIB_SUPPORT:
+         return "动态链接库支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DYNAMIC_SUPPORT:
+         return "运行时动态加载libretro库";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_EGL_SUPPORT:
+         return "EGL 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FBO_SUPPORT:
+         return "OpenGL/Direct3D 渲染至纹理 (多渲染批次Shader) 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FFMPEG_SUPPORT:
+         return "FFmpeg 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FREETYPE_SUPPORT:
+         return "FreeType 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_IDENTIFIER:
+         return "前端标识";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_NAME:
+         return "前端名称";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_OS:
+         return "前端操作系统";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GIT_VERSION:
+         return "Git版本";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GLSL_SUPPORT:
+         return "GLSL 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_HLSL_SUPPORT:
+         return "HLSL 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_JACK_SUPPORT:
+         return "JACK 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_KMS_SUPPORT:
+         return "KMS/EGL 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBRETRODB_SUPPORT:
+         return "LibretroDB 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBUSB_SUPPORT:
+         return "Libusb 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBXML2_SUPPORT:
+         return "libxml2 XML解析支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETPLAY_SUPPORT:
+         return "Netplay (点对点) 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETWORK_COMMAND_IFACE_SUPPORT:
+         return "网络控制台支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETWORK_REMOTE_SUPPORT:
+         return "网络控制器支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENAL_SUPPORT:
+         return "OpenAL 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGLES_SUPPORT:
+         return "OpenGL ES 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGL_SUPPORT:
+         return "OpenGL 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENSL_SUPPORT:
+         return "OpenSL 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENVG_SUPPORT:
+         return "OpenVG 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OSS_SUPPORT:
+         return "OSS 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OVERLAY_SUPPORT:
+         return "覆层支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE:
+         return "电源";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGED:
+         return "已充满电";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGING:
+         return "充电中";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_DISCHARGING:
+         return "放电中";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_NO_SOURCE:
+         return "没有电源";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PULSEAUDIO_SUPPORT:
+         return "PulseAudio 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PYTHON_SUPPORT:
+         return "Python (Shader中脚本支持) 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RBMP_SUPPORT:
+         return "BMP 支持 (RBMP)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RETRORATING_LEVEL:
+         return "RetroRating 等级";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RJPEG_SUPPORT:
+         return "JPEG 支持 (RJPEG)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ROARAUDIO_SUPPORT:
+         return "RoarAudio 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RPNG_SUPPORT:
+         return "PNG 支持 (RPNG)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RSOUND_SUPPORT:
+         return "RSound 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RTGA_SUPPORT:
+         return "TGA 支持 (RTGA)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL2_SUPPORT:
+         return "SDL2 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_IMAGE_SUPPORT:
+         return "SDL 图像支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_SUPPORT:
+         return "SDL1.2 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SLANG_SUPPORT:
+         return "Slang 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_THREADING_SUPPORT:
+         return "多线程支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_UDEV_SUPPORT:
+         return "Udev 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_V4L2_SUPPORT:
+         return "Video4Linux2 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VIDEO_CONTEXT_DRIVER:
+         return "视频上下文驱动";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VULKAN_SUPPORT:
+         return "Vulkan 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_WAYLAND_SUPPORT:
+         return "Wayland 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_X11_SUPPORT:
+         return "X11 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XAUDIO2_SUPPORT:
+         return "XAudio2 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XVIDEO_SUPPORT:
+         return "XVideo 支持";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ZLIB_SUPPORT:
+         return "Zlib 支持";
+      case MENU_ENUM_LABEL_VALUE_TAKE_SCREENSHOT:
+         return "截取屏幕";
+      case MENU_ENUM_LABEL_VALUE_THREADED_DATA_RUNLOOP_ENABLE:
+         return "启用多线程数据执行循环";
+      case MENU_ENUM_LABEL_VALUE_THUMBNAILS:
+         return "缩略图";
+      case MENU_ENUM_LABEL_VALUE_THUMBNAILS_DIRECTORY:
+         return "缩略图目录";
+      case MENU_ENUM_LABEL_VALUE_THUMBNAILS_UPDATER_LIST:
+         return "缩略图更新程序";
+      case MENU_ENUM_LABEL_VALUE_THUMBNAIL_MODE_BOXARTS:
+         return "Boxarts";
+      case MENU_ENUM_LABEL_VALUE_THUMBNAIL_MODE_SCREENSHOTS:
+         return "截屏";
+      case MENU_ENUM_LABEL_VALUE_THUMBNAIL_MODE_TITLE_SCREENS:
+         return "标题画面";
+      case MENU_ENUM_LABEL_VALUE_TIMEDATE_ENABLE:
+         return "显示时间日期";
+      case MENU_ENUM_LABEL_VALUE_TITLE_COLOR:
+         return "菜单标题颜色";
+      case MENU_ENUM_LABEL_VALUE_TRUE:
+         return "真";
+      case MENU_ENUM_LABEL_VALUE_UI_COMPANION_ENABLE:
+         return "UI Companion Enable";
+      case MENU_ENUM_LABEL_VALUE_UI_COMPANION_START_ON_BOOT:
+         return "UI Companion Start On Boot";
+      case MENU_ENUM_LABEL_VALUE_UI_MENUBAR_ENABLE:
+         return "Menubar";
+      case MENU_ENUM_LABEL_VALUE_UNABLE_TO_READ_COMPRESSED_FILE:
+         return "无法读取压缩的文件。";
+      case MENU_ENUM_LABEL_VALUE_UNDO_LOAD_STATE:
+         return "撤销加载状态";
+      case MENU_ENUM_LABEL_VALUE_UNDO_SAVE_STATE:
+         return "撤销保存状态";
+      case MENU_ENUM_LABEL_VALUE_UNKNOWN:
+         return "未知";
+      case MENU_ENUM_LABEL_VALUE_UPDATER_SETTINGS:
+         return "更新程序";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_ASSETS:
+         return "更新资源";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_AUTOCONFIG_PROFILES:
+         return "更新自动配置档案";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_CG_SHADERS:
+         return "更新CG Shader效果文件";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_CHEATS:
+         return "更新金手指";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_CORE_INFO_FILES:
+         return "更新核心信息文件";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_DATABASES:
+         return "更新数据库";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_GLSL_SHADERS:
+         return "更新GLSL Shader效果文件";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_LAKKA:
+         return "更新 Lakka";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_OVERLAYS:
+         return "更新覆层";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_SLANG_SHADERS:
+         return "更新Slang Shader效果文件";
+      case MENU_ENUM_LABEL_VALUE_USER:
+         return "用户";
+      case MENU_ENUM_LABEL_VALUE_USER_INTERFACE_SETTINGS:
+         return "用户界面";
+      case MENU_ENUM_LABEL_VALUE_USER_LANGUAGE:
+         return "语言";
+      case MENU_ENUM_LABEL_VALUE_USER_SETTINGS:
+         return "用户";
+      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_IMAGE_VIEWER:
+         return "使用内建的图像浏览器";
+      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_PLAYER:
+         return "使用内建媒体播放器";
+      case MENU_ENUM_LABEL_VALUE_USE_THIS_DIRECTORY:
+         return "<使用当前目录>";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ALLOW_ROTATE:
+         return "允许旋转";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_AUTO:
+         return "自动选择视口比例";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_INDEX:
+         return "视口比例选项";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_BLACK_FRAME_INSERTION:
+         return "黑色帧补间";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_CROP_OVERSCAN:
+         return "Crop Overscan (Reload)";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_DISABLE_COMPOSITION:
+         return "禁用桌面元素";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_DRIVER:
+         return "视频驱动";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER:
+         return "视频滤镜";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_DIR:
+         return "视频滤镜目录";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_FLICKER:
+         return "闪烁过滤器";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_ENABLE:
+         return "显示屏显消息(OSD)";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_PATH:
+         return "屏显消息(OSD)字体";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_SIZE:
+         return "屏显消息(OSD)大小";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_ASPECT:
+         return "强制视口比例";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_SRGB_DISABLE:
+         return "强制禁止sRGB帧缓冲";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FRAME_DELAY:
+         return "帧延时";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FULLSCREEN:
+         return "使用全屏模式";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_GAMMA:
+         return "视频Gamma";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_RECORD:
+         return "启用GPU录像";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_SCREENSHOT:
+         return "启用GPU截屏";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC:
+         return "强制GPU同步";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC_FRAMES:
+         return "强制GPU同步帧数";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MAX_SWAPCHAIN_IMAGES:
+         return "最大交换链图像数";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_X:
+         return "屏显消息(OSD)X轴位置";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_Y:
+         return "屏显消息(OSD)Y轴位置";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MONITOR_INDEX:
+         return "显示器索引";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_POST_FILTER_RECORD:
+         return "启用录像后期滤镜";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE:
+         return "刷新率";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE_AUTO:
+         return "估算的显示器帧率";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ROTATION:
+         return "旋转";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE:
+         return "窗口缩放量";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE_INTEGER:
+         return "整数化缩放量";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SETTINGS:
+         return "视频";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_DIR:
+         return "视频Shader目录";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_NUM_PASSES:
+         return "Shader渲染遍数";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PARAMETERS:
+         return "预览Shader参数";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET:
+         return "加载Shader预设";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_PARAMETERS:
+         return "菜单Shader参数";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_AS:
+         return "保存Shader预设为";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_CORE:
+         return "保存核心预设";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_GAME:
+         return "保存游戏预设";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHARED_CONTEXT:
+         return "启用硬件共享上下文";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SMOOTH:
+         return "硬件双线性过滤";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SOFT_FILTER:
+         return "启用软件过滤器";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SWAP_INTERVAL:
+         return "垂直同步交换间隔";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_TAB:
+         return "视频";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_THREADED:
+         return "多线程渲染";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VFILTER:
+         return "Deflicker";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_HEIGHT:
+         return "自定义视口高度";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_WIDTH:
+         return "自定义视口宽度";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_X:
+         return "自定义视口X";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_Y:
+         return "自定义视口Y";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VI_WIDTH:
+         return "Set VI Screen Width";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VSYNC:
+         return "垂直同步";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_WINDOWED_FULLSCREEN:
+         return "无边框窗口全屏模式";
+      case MENU_ENUM_LABEL_VALUE_WIFI_DRIVER:
+         return "Wi-Fi驱动";
+      case MENU_ENUM_LABEL_VALUE_WIFI_SETTINGS:
+         return "Wi-Fi";
+      case MENU_ENUM_LABEL_VALUE_XMB_ALPHA_FACTOR:
+         return "菜单透明度因子";
+      case MENU_ENUM_LABEL_VALUE_XMB_FONT:
+         return "菜单字体";
+      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_CUSTOM:
+         return "自定义";
+      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_FLATUI:
+         return "FlatUI";
+      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_MONOCHROME:
+         return "Monochrome";
+      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_MONOCHROME_JAGGED:
+         return "Monochrome Jagged";
+      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_PIXEL:
+         return "Pixel";
+      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_RETROACTIVE:
+         return "RetroActive";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME:
+         return "菜单颜色主题";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_APPLE_GREEN:
+         return "苹果绿";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_DARK:
+         return "深色";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_DARK_PURPLE:
+         return "深紫色";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_ELECTRIC_BLUE:
+         return "铁蓝色";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_GOLDEN:
+         return "金色";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_LEGACY_RED:
+         return "传统红";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_MIDNIGHT_BLUE:
+         return "蓝黑色";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_PLAIN:
+         return "朴素";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_UNDERSEA:
+         return "海底";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_VOLCANIC_RED:
+         return "火山红";
+      case MENU_ENUM_LABEL_VALUE_XMB_RIBBON_ENABLE:
+         return "菜单Shader管线";
+      case MENU_ENUM_LABEL_VALUE_XMB_SCALE_FACTOR:
+         return "菜单缩放因子";
+      case MENU_ENUM_LABEL_VALUE_XMB_SHADOWS_ENABLE:
+         return "启用图标阴影";
+      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_HISTORY:
+         return "显示历史页";
+      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_IMAGES:
+         return "显示图像页";
+      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_MUSIC:
+         return "显示音乐页";
+      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_SETTINGS:
+         return "显示设置页";
+      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_VIDEO:
+         return "显示视频页";
+      case MENU_ENUM_LABEL_VALUE_XMB_THEME:
+         return "菜单图标主题";
+      case MENU_ENUM_LABEL_VALUE_YES:
+         return "是";
+      case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_TWO:
+         return "Shader预设";
+      case MENU_ENUM_SUBLABEL_ADD_CONTENT_LIST:
+         return "下载且/或者扫描游戏内容，并将其加入你的收藏中。";
+      case MENU_ENUM_SUBLABEL_AUDIO_SETTINGS:
+         return "调整音频输出的选项。";
+      case MENU_ENUM_SUBLABEL_BLUETOOTH_ENABLE:
+         return "启用或者禁止蓝牙。";
+      case MENU_ENUM_SUBLABEL_CONFIG_SAVE_ON_EXIT:
+         return "程序将在退出时保存修改到配置文件。";
+      case MENU_ENUM_SUBLABEL_CPU_CORES:
+         return "CPU拥有的核心总数。";
+      case MENU_ENUM_SUBLABEL_FPS_SHOW:
+         return "在屏幕上显示当前每秒的帧率。";
+      case MENU_ENUM_SUBLABEL_INPUT_HOTKEY_BINDS:
+         return "配置热键选项。";
+      case MENU_ENUM_SUBLABEL_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
+         return "控制器用来切出菜单的组合键。";
+      case MENU_ENUM_SUBLABEL_INPUT_SETTINGS:
+         return "调整游戏控制器、键盘和鼠标的设置。";
+      case MENU_ENUM_SUBLABEL_INPUT_USER_BINDS:
+         return "配置该用户的控制选项。";
+      case MENU_ENUM_SUBLABEL_LOG_VERBOSITY:
+         return "启用或禁止向控制台打印日志。";
+      case MENU_ENUM_SUBLABEL_NETPLAY:
+         return "加入或者开启一个在线多人游戏的会话。";
+      case MENU_ENUM_SUBLABEL_ONLINE_UPDATER:
+         return "下载并更新RetroArch的附加插件和组件。";
+      case MENU_ENUM_SUBLABEL_SAMBA_ENABLE:
+         return "启用或者禁止网络文件夹共享(SAMBA)。";
+      case MENU_ENUM_SUBLABEL_SERVICES_SETTINGS:
+         return "管理操作系统层级的服务。";
+      case MENU_ENUM_SUBLABEL_SHOW_HIDDEN_FILES:
+         return "在文件浏览器中显示隐藏的文件或文件夹。";
+      case MENU_ENUM_SUBLABEL_SSH_ENABLE:
+         return "启用或者禁止远程终端访问(SSH)。";
+      case MENU_ENUM_SUBLABEL_SUSPEND_SCREENSAVER_ENABLE:
+         return "阻止系统激活屏幕保护程序。";
+      case MENU_ENUM_SUBLABEL_USER_LANGUAGE:
+         return "设置用户界面的语言。";
+      case MENU_ENUM_SUBLABEL_VIDEO_BLACK_FRAME_INSERTION:
+         return "在帧与帧之间插入黑色的中间帧，通常用于消除在120Hz刷新率的显示器上运行60Hz的游戏内容带来的鬼影。";
+      case MENU_ENUM_SUBLABEL_VIDEO_FRAME_DELAY:
+         return "以增加画面卡顿的风险换取低延时，在垂直同步后增加时延(毫秒)。";
+      case MENU_ENUM_SUBLABEL_VIDEO_HARD_SYNC_FRAMES:
+         return "设置当开启“强制GPU同步”时CPU可以预先GPU多少帧。";
+      case MENU_ENUM_SUBLABEL_VIDEO_MAX_SWAPCHAIN_IMAGES:
+         return "强制显示驱动程序使用特定的缓冲模式。";
+      case MENU_ENUM_SUBLABEL_VIDEO_MONITOR_INDEX:
+         return "选择将要使用哪一个显示器。";
+      case MENU_ENUM_SUBLABEL_VIDEO_REFRESH_RATE_AUTO:
+         return "估算的显示器刷新率(Hz)。";
+      case MENU_ENUM_SUBLABEL_VIDEO_SETTINGS:
+         return "调整视频输出的选项。";
+      case MENU_ENUM_SUBLABEL_WIFI_SETTINGS:
+         return "扫描无线网络并且建立连接。";
+      case MSG_APPENDED_DISK:
+         return "Appended disk";
+      case MSG_APPLICATION_DIR:
+         return "应用程序目录";
+      case MSG_APPLYING_SHADER:
+         return "Applying shader";
+      case MSG_AUDIO_MUTED:
+         return "静音。";
+      case MSG_AUDIO_UNMUTED:
+         return "取消静音。";
+      case MSG_AUTOCONFIG_FILE_ERROR_SAVING:
+         return "Error saving autoconf file.";
+      case MSG_AUTOCONFIG_FILE_SAVED_SUCCESSFULLY:
+         return "Autoconfig file saved successfully.";
+      case MSG_AUTOSAVE_FAILED:
+         return "Could not initialize autosave.";
+      case MSG_AUTO_SAVE_STATE_TO:
+         return "自动保存状态至";
+      case MSG_BLOCKING_SRAM_OVERWRITE:
+         return "Blocking SRAM Overwrite";
+      case MSG_BRINGING_UP_COMMAND_INTERFACE_ON_PORT:
+         return "Bringing up command interface on port";
+      case MSG_BYTES:
+         return "bytes";
+      case MSG_CANNOT_INFER_NEW_CONFIG_PATH:
+         return "Cannot infer new config path. Use current time.";
+      case MSG_CHEEVOS_HARDCORE_MODE_ENABLE:
+         return "Hardcore Mode Enabled: savestate & rewind were disabled.";
+      case MSG_COMPARING_WITH_KNOWN_MAGIC_NUMBERS:
+         return "Comparing with known magic numbers...";
+      case MSG_COMPILED_AGAINST_API:
+         return "Compiled against API";
+      case MSG_CONFIG_DIRECTORY_NOT_SET:
+         return "Config directory not set. Cannot save new config.";
+      case MSG_CONNECTED_TO:
+         return "Connected to";
+      case MSG_CONTENT_CRC32S_DIFFER:
+         return "Content CRC32s differ. Cannot use different games.";
+      case MSG_CONTENT_LOADING_SKIPPED_IMPLEMENTATION_WILL_DO_IT:
+         return "Content loading skipped. Implementation will load it on its own.";
+      case MSG_CORE_DOES_NOT_SUPPORT_SAVESTATES:
+         return "核心不支持保存状态。";
+      case MSG_CORE_OPTIONS_FILE_CREATED_SUCCESSFULLY:
+         return "Core options file created successfully.";
+      case MSG_COULD_NOT_FIND_ANY_NEXT_DRIVER:
+         return "Could not find any next driver";
+      case MSG_COULD_NOT_FIND_COMPATIBLE_SYSTEM:
+         return "Could not find compatible system.";
+      case MSG_COULD_NOT_FIND_VALID_DATA_TRACK:
+         return "Could not find valid data track";
+      case MSG_COULD_NOT_OPEN_DATA_TRACK:
+         return "could not open data track";
+      case MSG_COULD_NOT_READ_CONTENT_FILE:
+         return "Could not read content file";
+      case MSG_COULD_NOT_READ_MOVIE_HEADER:
+         return "Could not read movie header.";
+      case MSG_COULD_NOT_READ_STATE_FROM_MOVIE:
+         return "Could not read state from movie.";
+      case MSG_CRC32_CHECKSUM_MISMATCH:
+         return "CRC32 checksum mismatch between content file and saved content checksum in replay file header; replay highly likely to desync on playback.";
+      case MSG_CUSTOM_TIMING_GIVEN:
+         return "Custom timing given";
+      case MSG_DECOMPRESSION_ALREADY_IN_PROGRESS:
+         return "解压缩已在进行中。";
+      case MSG_DECOMPRESSION_FAILED:
+         return "解压缩失败。";
+      case MSG_DETECTED_VIEWPORT_OF:
+         return "Detected viewport of";
+      case MSG_DID_NOT_FIND_A_VALID_CONTENT_PATCH:
+         return "Did not find a valid content patch.";
+      case MSG_DISCONNECT_DEVICE_FROM_A_VALID_PORT:
+         return "Disconnect device from a valid port.";
+      case MSG_DISK_CLOSED:
+         return "Closed";
+      case MSG_DISK_EJECTED:
+         return "Ejected";
+      case MSG_DOWNLOADING:
+         return "正在下载";
+      case MSG_DOWNLOAD_FAILED:
+         return "下载失败";
+      case MSG_ERROR:
+         return "Error";
+      case MSG_ERROR_LIBRETRO_CORE_REQUIRES_CONTENT:
+         return "Libretro core requires content, but nothing was provided.";
+      case MSG_ERROR_LIBRETRO_CORE_REQUIRES_SPECIAL_CONTENT:
+         return "Libretro core requires special content, but none were provided.";
+      case MSG_ERROR_PARSING_ARGUMENTS:
+         return "Error parsing arguments.";
+      case MSG_ERROR_SAVING_CORE_OPTIONS_FILE:
+         return "Error saving core options file.";
+      case MSG_ERROR_SAVING_REMAP_FILE:
+         return "Error saving remap file.";
+      case MSG_ERROR_SAVING_SHADER_PRESET:
+         return "Error saving shader preset.";
+      case MSG_EXTERNAL_APPLICATION_DIR:
+         return "外部应用程序目录";
+      case MSG_EXTRACTING:
+         return "正在解压";
+      case MSG_EXTRACTING_FILE:
+         return "解压文件";
+      case MSG_FAILED_SAVING_CONFIG_TO:
+         return "无法保存配置到";
+      case MSG_FAILED_TO:
+         return "Failed to";
+      case MSG_FAILED_TO_ACCEPT_INCOMING_SPECTATOR:
+         return "Failed to accept incoming spectator.";
+      case MSG_FAILED_TO_ALLOCATE_MEMORY_FOR_PATCHED_CONTENT:
+         return "Failed to allocate memory for patched content...";
+      case MSG_FAILED_TO_APPLY_SHADER:
+         return "Failed to apply shader.";
+      case MSG_FAILED_TO_BIND_SOCKET:
+         return "Failed to bind socket.";
+      case MSG_FAILED_TO_CREATE_THE_DIRECTORY:
+         return "创建目录失败。";
+      case MSG_FAILED_TO_EXTRACT_CONTENT_FROM_COMPRESSED_FILE:
+         return "Failed to extract content from compressed file";
+      case MSG_FAILED_TO_GET_NICKNAME_FROM_CLIENT:
+         return "Failed to get nickname from client.";
+      case MSG_FAILED_TO_LOAD:
+         return "无法加载";
+      case MSG_FAILED_TO_LOAD_CONTENT:
+         return "Failed to load content";
+      case MSG_FAILED_TO_LOAD_MOVIE_FILE:
+         return "Failed to load movie file";
+      case MSG_FAILED_TO_LOAD_OVERLAY:
+         return "Failed to load overlay.";
+      case MSG_FAILED_TO_LOAD_STATE:
+         return "Failed to load state from";
+      case MSG_FAILED_TO_OPEN_LIBRETRO_CORE:
+         return "Failed to open libretro core";
+      case MSG_FAILED_TO_PATCH:
+         return "补丁应用失败";
+      case MSG_FAILED_TO_RECEIVE_HEADER_FROM_CLIENT:
+         return "Failed to receive header from client.";
+      case MSG_FAILED_TO_RECEIVE_NICKNAME:
+         return "Failed to receive nickname.";
+      case MSG_FAILED_TO_RECEIVE_NICKNAME_FROM_HOST:
+         return "Failed to receive nickname from host.";
+      case MSG_FAILED_TO_RECEIVE_NICKNAME_SIZE_FROM_HOST:
+         return "Failed to receive nickname size from host.";
+      case MSG_FAILED_TO_RECEIVE_SRAM_DATA_FROM_HOST:
+         return "Failed to receive SRAM data from host.";
+      case MSG_FAILED_TO_REMOVE_DISK_FROM_TRAY:
+         return "Failed to remove disk from tray.";
+      case MSG_FAILED_TO_REMOVE_TEMPORARY_FILE:
+         return "Failed to remove temporary file";
+      case MSG_FAILED_TO_SAVE_SRAM:
+         return "Failed to save SRAM";
+      case MSG_FAILED_TO_SAVE_STATE_TO:
+         return "Failed to save state to";
+      case MSG_FAILED_TO_SEND_NICKNAME:
+         return "Failed to send nickname.";
+      case MSG_FAILED_TO_SEND_NICKNAME_SIZE:
+         return "Failed to send nickname size.";
+      case MSG_FAILED_TO_SEND_NICKNAME_TO_CLIENT:
+         return "Failed to send nickname to client.";
+      case MSG_FAILED_TO_SEND_NICKNAME_TO_HOST:
+         return "Failed to send nickname to host.";
+      case MSG_FAILED_TO_SEND_SRAM_DATA_TO_CLIENT:
+         return "Failed to send SRAM data to client.";
+      case MSG_FAILED_TO_START_AUDIO_DRIVER:
+         return "音频驱动启动失败，将在无音频模式下继续启动。";
+      case MSG_FAILED_TO_START_MOVIE_RECORD:
+         return "Failed to start movie record.";
+      case MSG_FAILED_TO_START_RECORDING:
+         return "Failed to start recording.";
+      case MSG_FAILED_TO_TAKE_SCREENSHOT:
+         return "Failed to take screenshot.";
+      case MSG_FAILED_TO_UNDO_LOAD_STATE:
+         return "Failed to undo load state.";
+      case MSG_FAILED_TO_UNDO_SAVE_STATE:
+         return "Failed to undo save state.";
+      case MSG_FAILED_TO_UNMUTE_AUDIO:
+         return "Failed to unmute audio.";
+      case MSG_FATAL_ERROR_RECEIVED_IN:
+         return "Fatal error received in";
+      case MSG_FILE_NOT_FOUND:
+         return "未找到文件";
+      case MSG_FOUND_AUTO_SAVESTATE_IN:
+         return "Found auto savestate in";
+      case MSG_FOUND_DISK_LABEL:
+         return "Found disk label";
+      case MSG_FOUND_FIRST_DATA_TRACK_ON_FILE:
+         return "Found first data track on file";
+      case MSG_FOUND_LAST_STATE_SLOT:
+         return "Found last state slot";
+      case MSG_FOUND_SHADER:
+         return "Found shader";
+      case MSG_FRAMES:
+         return "帧";
+      case MSG_GAME_SPECIFIC_CORE_OPTIONS_FOUND_AT:
+         return "Per-Game Options: game-specific core options found at";
+      case MSG_GOT_INVALID_DISK_INDEX:
+         return "Got invalid disk index.";
+      case MSG_GRAB_MOUSE_STATE:
+         return "Grab mouse state";
+      case MSG_HW_RENDERED_MUST_USE_POSTSHADED_RECORDING:
+         return "Libretro core is hardware rendered. Must use post-shaded recording as well.";
+      case MSG_INFLATED_CHECKSUM_DID_NOT_MATCH_CRC32:
+         return "Inflated checksum did not match CRC32.";
+      case MSG_INPUT_CHEAT:
+         return "输入金手指";
+      case MSG_INPUT_CHEAT_FILENAME:
+         return "Cheat Filename";
+      case MSG_INPUT_PRESET_FILENAME:
+         return "Preset Filename";
+      case MSG_INTERFACE:
+         return "接口";
+      case MSG_INTERNAL_MEMORY:
+         return "内部存储";
+      case MSG_INVALID_NICKNAME_SIZE:
+         return "Invalid nickname size.";
+      case MSG_IN_BYTES:
+         return "(字节)";
+      case MSG_IN_GIGABYTES:
+         return "(吉字节)";
+      case MSG_IN_MEGABYTES:
+         return "(兆字节)";
+      case MSG_LIBRETRO_ABI_BREAK:
+         return "is compiled against a different version of libretro than this libretro implementation.";
+      case MSG_LIBRETRO_FRONTEND:
+         return "为libretro而设计的前端";
+      case MSG_LOADED_STATE_FROM_SLOT:
+         return "加载状态从槽";
+      case MSG_LOADING:
+         return "正在加载";
+      case MSG_LOADING_CONTENT_FILE:
+         return "Loading content file";
+      case MSG_LOADING_HISTORY_FILE:
+         return "Loading history file";
+      case MSG_LOADING_STATE:
+         return "Loading state";
+      case MSG_MEMORY:
+         return "内存";
+      case MSG_MOVIE_FILE_IS_NOT_A_VALID_BSV1_FILE:
+         return "Movie file is not a valid BSV1 file.";
+      case MSG_MOVIE_FORMAT_DIFFERENT_SERIALIZER_VERSION:
+         return "Movie format seems to have a different serializer version. Will most likely fail.";
+      case MSG_MOVIE_PLAYBACK_ENDED:
+         return "Movie playback ended.";
+      case MSG_MOVIE_RECORD_STOPPED:
+         return "Stopping movie record.";
+      case MSG_NETPLAY_FAILED:
+         return "Failed to initialize netplay.";
+      case MSG_NETPLAY_FAILED_MOVIE_PLAYBACK_HAS_STARTED:
+         return "Movie playback has started. Cannot start netplay.";
+      case MSG_NO_CONTENT_STARTING_DUMMY_CORE:
+         return "No content, starting dummy core.";
+      case MSG_NO_SAVE_STATE_HAS_BEEN_OVERWRITTEN_YET:
+         return "No save state has been overwritten yet.";
+      case MSG_NO_STATE_HAS_BEEN_LOADED_YET:
+         return "No state has been loaded yet.";
+      case MSG_OVERRIDES_ERROR_SAVING:
+         return "Error saving overrides.";
+      case MSG_OVERRIDES_SAVED_SUCCESSFULLY:
+         return "Overrides saved successfully.";
+      case MSG_PAUSED:
+         return "暂停。";
+      case MSG_PROGRAM:
+         return "RetroArch";
+      case MSG_READING_FIRST_DATA_TRACK:
+         return "Reading first data track...";
+      case MSG_RECEIVED:
+         return "received";
+      case MSG_RECORDING_TERMINATED_DUE_TO_RESIZE:
+         return "Recording terminated due to resize.";
+      case MSG_RECORDING_TO:
+         return "Recording to";
+      case MSG_REDIRECTING_CHEATFILE_TO:
+         return "Redirecting cheat file to";
+      case MSG_REDIRECTING_SAVEFILE_TO:
+         return "Redirecting save file to";
+      case MSG_REDIRECTING_SAVESTATE_TO:
+         return "Redirecting savestate to";
+      case MSG_REMAP_FILE_SAVED_SUCCESSFULLY:
+         return "Remap file saved successfully.";
+      case MSG_REMOVED_DISK_FROM_TRAY:
+         return "Removed disk from tray.";
+      case MSG_REMOVING_TEMPORARY_CONTENT_FILE:
+         return "Removing temporary content file";
+      case MSG_RESET:
+         return "重置";
+      case MSG_RESTARTING_RECORDING_DUE_TO_DRIVER_REINIT:
+         return "Restarting recording due to driver reinit.";
+      case MSG_RESTORED_OLD_SAVE_STATE:
+         return "Restored old save state.";
+      case MSG_RESTORING_DEFAULT_SHADER_PRESET_TO:
+         return "Shaders: restoring default shader preset to";
+      case MSG_REVERTING_SAVEFILE_DIRECTORY_TO:
+         return "Reverting savefile directory to";
+      case MSG_REVERTING_SAVESTATE_DIRECTORY_TO:
+         return "Reverting savestate directory to";
+      case MSG_REWINDING:
+         return "正在回溯。";
+      case MSG_REWIND_INIT:
+         return "Initializing rewind buffer with size";
+      case MSG_REWIND_INIT_FAILED:
+         return "Failed to initialize rewind buffer. Rewinding will be disabled.";
+      case MSG_REWIND_INIT_FAILED_THREADED_AUDIO:
+         return "Implementation uses threaded audio. Cannot use rewind.";
+      case MSG_REWIND_REACHED_END:
+         return "Reached end of rewind buffer.";
+      case MSG_SAVED_NEW_CONFIG_TO:
+         return "已保存新配置到";
+      case MSG_SAVED_STATE_TO_SLOT:
+         return "保存状态至槽";
+      case MSG_SAVED_SUCCESSFULLY_TO:
+         return "成功保存至";
+      case MSG_SAVING_RAM_TYPE:
+         return "Saving RAM type";
+      case MSG_SAVING_STATE:
+         return "Saving state";
+      case MSG_SCANNING:
+         return "扫描中";
+      case MSG_SCANNING_OF_DIRECTORY_FINISHED:
+         return "已完成对文件夹的扫描";
+      case MSG_SENDING_COMMAND:
+         return "Sending command";
+      case MSG_SEVERAL_PATCHES_ARE_EXPLICITLY_DEFINED:
+         return "Several patches are explicitly defined, ignoring all...";
+      case MSG_SHADER:
+         return "Shader";
+      case MSG_SHADER_PRESET_SAVED_SUCCESSFULLY:
+         return "Shader preset saved successfully.";
+      case MSG_SKIPPING_SRAM_LOAD:
+         return "Skipping SRAM load.";
+      case MSG_SLOW_MOTION:
+         return "慢动作。";
+      case MSG_SLOW_MOTION_REWIND:
+         return "慢动作回溯。";
+      case MSG_SORRY_UNIMPLEMENTED_CORES_DONT_DEMAND_CONTENT_NETPLAY:
+         return "Sorry, unimplemented: cores that don't demand content cannot participate in netplay.";
+      case MSG_SRAM_WILL_NOT_BE_SAVED:
+         return "SRAM will not be saved.";
+      case MSG_STARTING_MOVIE_PLAYBACK:
+         return "Starting movie playback.";
+      case MSG_STARTING_MOVIE_RECORD_TO:
+         return "Starting movie record to";
+      case MSG_STATE_SIZE:
+         return "State size";
+      case MSG_STATE_SLOT:
+         return "状态存档槽";
+      case MSG_TAKING_SCREENSHOT:
+         return "Taking screenshot.";
+      case MSG_TO:
+         return "to";
+      case MSG_UNDID_LOAD_STATE:
+         return "已撤销加载状态。";
+      case MSG_UNDOING_SAVE_STATE:
+         return "Undoing save state";
+      case MSG_UNKNOWN:
+         return "Unknown";
+      case MSG_UNPAUSED:
+         return "取消暂停。";
+      case MSG_UNRECOGNIZED_COMMAND:
+         return "Unrecognized command";
+      case MSG_USING_CORE_NAME_FOR_NEW_CONFIG:
+         return "Using core name for new config.";
+      case MSG_USING_LIBRETRO_DUMMY_CORE_RECORDING_SKIPPED:
+         return "Using libretro dummy core. Skipping recording.";
+      case MSG_VALUE_CONNECT_DEVICE_FROM_A_VALID_PORT:
+         return "Connect device from a valid port.";
+      case MSG_VALUE_DISCONNECTING_DEVICE_FROM_PORT:
+         return "Disconnecting device from port";
+      case MSG_VALUE_REBOOTING:
+         return "正在重启……";
+      case MSG_VALUE_SHUTTING_DOWN:
+         return "正在关机……";
+      case MSG_VERSION_OF_LIBRETRO_API:
+         return "Version of libretro API";
+      case MSG_VIEWPORT_SIZE_CALCULATION_FAILED:
+         return "Viewport size calculation failed! Will continue using raw data. This will probably not work right ...";
+      case MSG_VIRTUAL_DISK_TRAY:
+         return "virtual disk tray.";
       default:
 #if 0
          RARCH_LOG("Unimplemented: [%d]\n", msg);

--- a/intl/msg_hash_de.c
+++ b/intl/msg_hash_de.c
@@ -428,860 +428,860 @@ const char *msg_hash_to_str_de(enum msg_hash_enums msg)
 {
    switch (msg)
    {
-      case MENU_ENUM_LABEL_VALUE_INFORMATION_LIST:
-         return "Information";
-      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_PLAYER:
-         return "Verwende integrierten Player"; /* FIXME/UPDATE */
-      case MENU_ENUM_LABEL_VALUE_CONTENT_SETTINGS:
-         return "Content-Einstellungen"; /* FIXME */
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_CRC32:
-         return "CRC32";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_MD5:
-         return "MD5";
-      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_LIST:
-         return "Lade Content";
-      case MENU_ENUM_LABEL_VALUE_LOAD_ARCHIVE:
-         return "Lade Archiv";
-      case MENU_ENUM_LABEL_VALUE_OPEN_ARCHIVE:
-         return "Öffne Archiv";
-      case MENU_ENUM_LABEL_VALUE_ASK_ARCHIVE:
-         return "Nachfragen";
-      case MENU_ENUM_LABEL_VALUE_PRIVACY_SETTINGS:
-         return "Privatsphäre-Einstellungen";
-      case MENU_ENUM_LABEL_VALUE_HORIZONTAL_MENU: /* Don't change. Breaks everything. (Would be: "Horizontales Menu") */
-         return "Horizontal Menu";
-      case MENU_ENUM_LABEL_VALUE_NO_SETTINGS_FOUND:
-         return "Keine Einstellungen gefunden.";
-      case MENU_ENUM_LABEL_VALUE_NO_PERFORMANCE_COUNTERS:
-         return "Keine Leistungszähler.";
-      case MENU_ENUM_LABEL_VALUE_DRIVER_SETTINGS:
-         return "Treiber-Einstellungen";
-      case MENU_ENUM_LABEL_VALUE_CONFIGURATION_SETTINGS:
-         return "Konfigurations-Einstellungen";
-      case MENU_ENUM_LABEL_VALUE_CORE_SETTINGS:
-         return "Core-Einstellungen";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SETTINGS:
-         return "Video-Einstellungen";
-      case MENU_ENUM_LABEL_VALUE_LOGGING_SETTINGS:
-         return "Logging-Einstellungen";
-      case MENU_ENUM_LABEL_VALUE_SAVING_SETTINGS:
-         return "Spielstand-Einstellungen";
-      case MENU_ENUM_LABEL_VALUE_REWIND_SETTINGS:
-         return "Zurückspul-Einstellungen";
-      case MENU_ENUM_LABEL_VALUE_SHADER:
-         return "Shader";
-      case MENU_ENUM_LABEL_VALUE_CHEAT:
-         return "Cheat";
-      case MENU_ENUM_LABEL_VALUE_USER:
-         return "Benutzer";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_BGM_ENABLE:
-         return "Aktiviere System-BGM";
-      case MENU_ENUM_LABEL_VALUE_RETROPAD:
-         return "RetroPad";
-      case MENU_ENUM_LABEL_VALUE_RETROKEYBOARD:
-         return "RetroKeyboard";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_BLOCK_FRAMES:
-         return "Warte auf Audio-Frames";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_LABEL_SHOW: /* TODO/FIXME */
-         return "Zeige Core-Eingabe-Beschriftungen";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_HIDE_UNBOUND:
-         return "Verstecke nicht zugewiesene Core-Eingabe-Beschriftungen";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_ENABLE:
-         return "Zeige OSD-Nachrichten";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_PATH:
-         return "Schriftart der OSD-Nachrichten";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_SIZE:
-         return "Schriftgröße der OSD-Nachrichten";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_X:
-         return "X-Position der OSD-Nachrichten";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_Y:
-         return "Y-Position der OSD-Nachrichten";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SOFT_FILTER:
-         return "Aktiviere Soft-Filter";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_FLICKER:
-         return "Aktiviere Flacker-Filter";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_CONTENT:
-         return "<Content-Verz.>";
-      case MENU_ENUM_LABEL_VALUE_UNKNOWN:
-         return "Unbekannt";
-      case MENU_ENUM_LABEL_VALUE_DONT_CARE:
-         return "Mir egal";
-      case MENU_ENUM_LABEL_VALUE_LINEAR:
-         return "Linear";
-      case MENU_ENUM_LABEL_VALUE_NEAREST:
-         return "Nächster";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_DEFAULT:
-         return "<Voreinstellung>";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NONE:
-         return "<Keins>";
-      case MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE:
-         return "Nicht verfügbar";
-      case MENU_ENUM_LABEL_VALUE_INPUT_REMAPPING_DIRECTORY: /* UPDATE/FIXME */
-         return "Eingabebelegungs-Verzeichnis";
-      case MENU_ENUM_LABEL_VALUE_JOYPAD_AUTOCONFIG_DIR:
-         return "Eingabegerät-Autoconfig-Verzeichnis";
-      case MENU_ENUM_LABEL_VALUE_RECORDING_CONFIG_DIRECTORY:
-         return "Aufnahme-Konfigurationsverzeichnis";
-      case MENU_ENUM_LABEL_VALUE_RECORDING_OUTPUT_DIRECTORY:
-         return "Aufnahme-Ausgabeverzeichnis";
-      case MENU_ENUM_LABEL_VALUE_SCREENSHOT_DIRECTORY:
-         return "Bildschirmfoto-Verzeichnis";
-      case MENU_ENUM_LABEL_VALUE_PLAYLIST_DIRECTORY:
-         return "Wiedergabelisten-Verzeichnis";
-      case MENU_ENUM_LABEL_VALUE_SAVEFILE_DIRECTORY:
-         return "Spielstand-Verzeichnis";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_DIRECTORY:
-         return "Savestate-Verzeichnis";
-      case MENU_ENUM_LABEL_VALUE_STDIN_CMD_ENABLE:
-         return "stdin-Befehle";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_DRIVER:
-         return "Grafiktreiber";
-      case MENU_ENUM_LABEL_VALUE_RECORD_ENABLE:
-         return "Aktiviere Aufnahmefunktion";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_RECORD:
-         return "Aktiviere GPU-Aufnahmefunktion";
-      case MENU_ENUM_LABEL_VALUE_RECORD_PATH: /* FIXME/UPDATE */
-         return "Aufnahmepfad";
-      case MENU_ENUM_LABEL_VALUE_RECORD_USE_OUTPUT_DIRECTORY:
-         return "Verwende Aufnahme-Ausgabeverzeichnis";
-      case MENU_ENUM_LABEL_VALUE_RECORD_CONFIG:
-         return "Aufnahme-Konfiguration";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_POST_FILTER_RECORD:
-         return "Aktiviere Aufnahme von Post-Filtern";
-      case MENU_ENUM_LABEL_VALUE_CORE_ASSETS_DIRECTORY:
-         return "Core-Assets-Verzeichnis"; /* FIXME/UPDATE */
-      case MENU_ENUM_LABEL_VALUE_ASSETS_DIRECTORY:
-         return "Assets-Verzeichnis";
-      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPERS_DIRECTORY:
-         return "Dynamische-Bildschirmhintergründe-Verzeichnis";
-      case MENU_ENUM_LABEL_VALUE_RGUI_BROWSER_DIRECTORY:
-         return "Browser-Directory";
-      case MENU_ENUM_LABEL_VALUE_RGUI_CONFIG_DIRECTORY:
-         return "Konfigurations-Verzeichnis";
-      case MENU_ENUM_LABEL_VALUE_LIBRETRO_INFO_PATH:
-         return "Core-Info-Verzeichnis";
-      case MENU_ENUM_LABEL_VALUE_LIBRETRO_DIR_PATH:
-         return "Core-Verzeichnis";
-      case MENU_ENUM_LABEL_VALUE_CURSOR_DIRECTORY:
-         return "Cursor-Verzeichnis";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_DATABASE_DIRECTORY:
-         return "Content-Datenbankverzeichnis";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_DIRECTORY:
-         return "System/BIOS-Verzeichnis";
-      case MENU_ENUM_LABEL_VALUE_CHEAT_DATABASE_PATH:
-         return "Cheat-Datei-Verzeichnis";
-      case MENU_ENUM_LABEL_VALUE_CACHE_DIRECTORY: /* FIXME/UPDATE */
-         return "Entpack-Verzeichnis";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_FILTER_DIR:
-         return "Audio-Filter-Verzeichnis";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_DIR:
-         return "Grafikshader-Verzeichnis";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_DIR:
-         return "Grafikfilter-Verzeichnis";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_DIRECTORY:
-         return "Overlay-Verzeichnis";
-      case MENU_ENUM_LABEL_VALUE_OSK_OVERLAY_DIRECTORY:
-         return "OSK-Overlay-Verzeichnis";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT: /* TODO: Original string changed */
-         return "Tausche Netplay-Eingabe";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE:
-         return "Aktiviere Netplay-Zuschauermodus";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS: /* TODO: Original string changed */
-         return "IP-Addresse für Netplay";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT:
-         return "TCP/UDP-Port für Netplay";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE:
-         return "Aktiviere Netplay";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_DELAY_FRAMES:
-         return "Verzögere Netplay-Frames";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_MODE:
-         return "Aktiviere Netplay-Client";
-      case MENU_ENUM_LABEL_VALUE_RGUI_SHOW_START_SCREEN:
-         return "Zeige Startbildschirm";
-      case MENU_ENUM_LABEL_VALUE_TITLE_COLOR:
-         return "Menü-Titel-Farbe";
-      case MENU_ENUM_LABEL_VALUE_ENTRY_HOVER_COLOR:
-         return "Hover-Farbe für Menü-Einträge";
-      case MENU_ENUM_LABEL_VALUE_TIMEDATE_ENABLE:
-         return "Zeige Uhrzeit / Datum";
-      case MENU_ENUM_LABEL_VALUE_THREADED_DATA_RUNLOOP_ENABLE:
-         return "Threaded Data Runloop";
-      case MENU_ENUM_LABEL_VALUE_ENTRY_NORMAL_COLOR:
-         return "Normale Farbe für Menü-Einträge";
-      case MENU_ENUM_LABEL_VALUE_SHOW_ADVANCED_SETTINGS:
-         return "Zeige erweitere Einstellungen";
-      case MENU_ENUM_LABEL_VALUE_COLLAPSE_SUBGROUPS_ENABLE:
-         return "Untergruppen einklappen";
-      case MENU_ENUM_LABEL_VALUE_MOUSE_ENABLE:
-         return "Maus-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_POINTER_ENABLE:
-         return "Touch-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_CORE_ENABLE:
-         return "Zeige Core-Namen";
-      case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_ENABLE:
-         return "Aktiviere DPI-Override";
-      case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_VALUE:
-         return "DPI-Override";
-      case MENU_ENUM_LABEL_VALUE_SUSPEND_SCREENSAVER_ENABLE:
-         return "Bildschirmschoner aussetzen";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_DISABLE_COMPOSITION:
-         return "Deaktiviere Desktop-Komposition";
-      case MENU_ENUM_LABEL_VALUE_PAUSE_NONACTIVE:
-         return "Nicht im Hintergrund laufen";
-      case MENU_ENUM_LABEL_VALUE_UI_COMPANION_START_ON_BOOT:
-         return "UI-Companion beim Hochfahren starten";
-      case MENU_ENUM_LABEL_VALUE_UI_MENUBAR_ENABLE:
-         return "Menüleiste";
+      case MENU_ENUM_LABEL_SETTINGS:
+         return "Einstellungen";
+      case MENU_ENUM_LABEL_SHUTDOWN:
+         return "Ausschalten";
+      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_PASSWORD:
+         return "Passwort";
+      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_USERNAME:
+         return "Benutzername";
+      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_LIST:
+         return "Konten";
+      case MENU_ENUM_LABEL_VALUE_ADD_TAB:
+         return "Hinzufügen";
       case MENU_ENUM_LABEL_VALUE_ARCHIVE_MODE:
          return "Verknüpfte Aktion bei Archivdateien";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_ENABLE:
-         return "Netzwerk-Befehle";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_PORT:
-         return "Port für Netzwerk-Befehle";
-      case MENU_ENUM_LABEL_VALUE_HISTORY_LIST_ENABLE:
-         return "Aktiviere Verlaufsliste";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_HISTORY_SIZE:
-         return "Länge der Verlaufsliste";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE_AUTO:
-         return "Geschätzte Bildwiederholrate";
-      case MENU_ENUM_LABEL_VALUE_DUMMY_ON_CORE_SHUTDOWN:
-         return "Dummy bei Core-Abschaltung";
-      case MENU_ENUM_LABEL_VALUE_CORE_SET_SUPPORTS_NO_CONTENT_ENABLE: /* TODO/FIXME */
-         return "Cores nicht automatisch starten";
-      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_ENABLE:
-         return "Begrenze maximale Ausführungsgeschwindigkeit";
-      case MENU_ENUM_LABEL_VALUE_FASTFORWARD_RATIO:
-         return "Maximale Ausführungsgeschwindigkeit";
-      case MENU_ENUM_LABEL_VALUE_AUTO_REMAPS_ENABLE:
-         return "Lade Remap-Dateien automatisch";
-      case MENU_ENUM_LABEL_VALUE_SLOWMOTION_RATIO:
-         return "Zeitlupen-Verhältnis";
-      case MENU_ENUM_LABEL_VALUE_CORE_SPECIFIC_CONFIG:
-         return "Core-Spezifische Konfiguration";
-      case MENU_ENUM_LABEL_VALUE_AUTO_OVERRIDES_ENABLE:
-         return "Lade Override-Dateien automatisch";
-      case MENU_ENUM_LABEL_VALUE_CONFIG_SAVE_ON_EXIT:
-         return "Speichere Konfiguration beim Beenden";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SMOOTH:
-         return "Bilineare Filterung (HW)";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_GAMMA:
-         return "Gamma";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ALLOW_ROTATE:
-         return "Erlaube Bildrotation";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC:
-         return "Synchronisiere GPU und CPU";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SWAP_INTERVAL:
-         return "VSync-Intervall";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VSYNC:
-         return "Vertikale Synchronisation (VSync)";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_THREADED:
-         return "Threaded Video";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ROTATION:
-         return "Rotation";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_SCREENSHOT:
-         return "Aktiviere GPU-Bildschirmfotos";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_CROP_OVERSCAN:
-         return "Bildränder (Overscan) zuschneiden (Neustart erforderlich)";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_INDEX:
-         return "Bildseitenverhältnis-Index";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_AUTO:
-         return "Automatisches Bildseitenverhältnis";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_ASPECT:
-         return "Erzwinge Bildseitenverhältnis";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE:
-         return "Bildwiederholrate";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_SRGB_DISABLE:
-         return "Erzwinge Deaktivierung des sRGB FBO";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_WINDOWED_FULLSCREEN:
-         return "Unechter Vollbild-Modus (Windowed Fullscreen)";
-      case MENU_ENUM_LABEL_VALUE_PAL60_ENABLE:
-         return "Verwende PAL60-Modus";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VFILTER:
-         return "Bild entflackern";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VI_WIDTH:
-         return "Kalibriere VI-Bildbreite";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_BLACK_FRAME_INSERTION:
-         return "Setze schwarze Frames ein";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC_FRAMES:
-         return "Synchronisiere Frames fest mit GPU";
-      case MENU_ENUM_LABEL_VALUE_SORT_SAVEFILES_ENABLE:
-         return "Sortiere Speicherdaten per Ordner";
-      case MENU_ENUM_LABEL_VALUE_SORT_SAVESTATES_ENABLE:
-         return "Sortiere Save States per Ordner";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FULLSCREEN:
-         return "Verwende Vollbildmodus";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE:
-         return "Fenterskalierung";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE_INTEGER:
-         return "Ganzzahlige Bildskalierung";
-      case MENU_ENUM_LABEL_VALUE_PERFCNT_ENABLE:
-         return "Leistungsindikatoren";
-      case MENU_ENUM_LABEL_VALUE_LIBRETRO_LOG_LEVEL:
-         return "Core-Logging-Stufe";
-      case MENU_ENUM_LABEL_VALUE_LOG_VERBOSITY:
-         return "Log-Ausführlichkeit";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_LOAD:
-         return "Automatisches Laden von Save States";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_INDEX:
-         return "Automatische Indexierung von Save States";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_SAVE:
-         return "Automatische Save States";
-      case MENU_ENUM_LABEL_VALUE_AUTOSAVE_INTERVAL:
-         return "Autospeicherungsintervall";
-      case MENU_ENUM_LABEL_VALUE_BLOCK_SRAM_OVERWRITE:
-         return "Blockiere SRAM-Überschreibung";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHARED_CONTEXT:
-         return "HW-Shared-Context aktivieren";
-      case MENU_ENUM_LABEL_VALUE_RESTART_RETROARCH:
-         return "Starte RetroArch neu";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_NICKNAME:
-         return "Benutzername";
-      case MENU_ENUM_LABEL_VALUE_USER_LANGUAGE:
-         return "Sprache";
-      case MENU_ENUM_LABEL_VALUE_CAMERA_ALLOW:
-         return "Erlaube Kamera-Zugriff";
-      case MENU_ENUM_LABEL_VALUE_LOCATION_ALLOW:
-         return "Erlaube Standort-Lokalisierung";
-      case MENU_ENUM_LABEL_VALUE_PAUSE_LIBRETRO:
-         return "Pausiere, wenn das Menü aktiv ist";
-      case MENU_ENUM_LABEL_VALUE_INPUT_OSK_OVERLAY_ENABLE:
-         return "Zeige Tastatur-Overlay";
-      case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_ENABLE:
-         return "Aktiviere Overlay";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MONITOR_INDEX:
-         return "Monitor-Index";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FRAME_DELAY:
-         return "Bildverzögerung";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DUTY_CYCLE:
-         return "Auslastungsgrad";
-      case MENU_ENUM_LABEL_VALUE_INPUT_TURBO_PERIOD:
-         return "Turbo-Dauer";
-      case MENU_ENUM_LABEL_VALUE_INPUT_AXIS_THRESHOLD:
-         return "Schwellwert der Eingabe-Achsen";
-      case MENU_ENUM_LABEL_VALUE_INPUT_REMAP_BINDS_ENABLE:
-         return "Bind-Remapping aktivieren";
-      case MENU_ENUM_LABEL_VALUE_INPUT_MAX_USERS:
-         return "Maximale Benutzerzahl";
-      case MENU_ENUM_LABEL_VALUE_INPUT_AUTODETECT_ENABLE:
-         return "Automatische Konfiguration aktivieren";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_OUTPUT_RATE:
-         return "Audio-Frequenzrate (kHz)";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_MAX_TIMING_SKEW:
-         return "Maximaler Audioversatz";
-      case MENU_ENUM_LABEL_VALUE_CHEAT_NUM_PASSES:
-         return "Cheat-Durchgänge";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_CORE:
-         return "Speichere Core-Remap-Datei";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_GAME:
-         return "Speichere Spiel-Remap-Datei";
-      case MENU_ENUM_LABEL_VALUE_CHEAT_APPLY_CHANGES:
-         return "Änderungen übernehmen";
-      case MENU_ENUM_LABEL_VALUE_SHADER_APPLY_CHANGES:
-         return "Änderungen übernehmen";
-      case MENU_ENUM_LABEL_VALUE_REWIND_ENABLE:
-         return "Zurückspulen (Rewind) aktivieren";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_COLLECTION_LIST:
-         return "Lade Content (Sammlung)";  /* FIXME/TODO - rewrite */
-      case MENU_ENUM_LABEL_VALUE_DETECT_CORE_LIST:
-         return "Lade Content (Core erkennen)";  /* FIXME */
-      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_HISTORY:
-         return "Lade Content (Verlauf)"; /* FIXME/UPDATE */
+      case MENU_ENUM_LABEL_VALUE_ASK_ARCHIVE:
+         return "Nachfragen";
+      case MENU_ENUM_LABEL_VALUE_ASSETS_DIRECTORY:
+         return "Assets-Verzeichnis";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_BLOCK_FRAMES:
+         return "Warte auf Audio-Frames";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_DEVICE:
+         return "Soundkarte";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_DRIVER:
+         return "Audio-Treiber";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_DSP_PLUGIN:
+         return "Audio-DSP-Plugin";
       case MENU_ENUM_LABEL_VALUE_AUDIO_ENABLE:
          return "Aktiviere Audio";
-      case MENU_ENUM_LABEL_VALUE_FPS_SHOW:
-         return "Zeige Framerate";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_FILTER_DIR:
+         return "Audio-Filter-Verzeichnis";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_LATENCY:
+         return "Audiolatenz (ms)";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_MAX_TIMING_SKEW:
+         return "Maximaler Audioversatz";
       case MENU_ENUM_LABEL_VALUE_AUDIO_MUTE:
          return "Stumm";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_VOLUME:
-         return "Lautstärke (dB)";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_SYNC:
-         return "Synchronisiere Audio";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_OUTPUT_RATE:
+         return "Audio-Frequenzrate (kHz)";
       case MENU_ENUM_LABEL_VALUE_AUDIO_RATE_CONTROL_DELTA:
          return "Audio Rate Control Delta";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_NUM_PASSES:
-         return "Shader-Durchgänge";  /* FIXME */
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_SHA1:
-         return "SHA1";
-      case MENU_ENUM_LABEL_VALUE_CONFIGURATIONS:
-         return "Lade Konfigurationsdatei"; /* FIXME/UPDATE */
-      case MENU_ENUM_LABEL_VALUE_REWIND_GRANULARITY:
-         return "Genauigkeit des Zurückspulens (Rewind)";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_LOAD:
-         return "Lade Remap-Datei";
-      case MENU_ENUM_LABEL_VALUE_CUSTOM_RATIO:
-         return "Benutzerdefiniertes Verhältnis";
-      case MENU_ENUM_LABEL_VALUE_USE_THIS_DIRECTORY:
-         return "<Diesen Ordner verwenden>";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_START_CONTENT:
-         return "Starte Content";
-      case MENU_ENUM_LABEL_VALUE_DISK_OPTIONS: /* UPDATE/FIXME */
-         return "Datenträger-Optionen";
-      case MENU_ENUM_LABEL_VALUE_CORE_OPTIONS:
-         return "Optionen";
-      case MENU_ENUM_LABEL_VALUE_CORE_CHEAT_OPTIONS:
-         return "Cheats";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_RESAMPLER_DRIVER:
+         return "Audio-Resampler-Treiber";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_SETTINGS:
+         return "Audio-Einstellungen";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_SYNC:
+         return "Synchronisiere Audio";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_VOLUME:
+         return "Lautstärke (dB)";
+      case MENU_ENUM_LABEL_VALUE_AUTOSAVE_INTERVAL:
+         return "Autospeicherungsintervall";
+      case MENU_ENUM_LABEL_VALUE_AUTO_OVERRIDES_ENABLE:
+         return "Lade Override-Dateien automatisch";
+      case MENU_ENUM_LABEL_VALUE_AUTO_REMAPS_ENABLE:
+         return "Lade Remap-Dateien automatisch";
+      case MENU_ENUM_LABEL_VALUE_BACK:
+         return "ZURÜCK";
+      case MENU_ENUM_LABEL_VALUE_BLOCK_SRAM_OVERWRITE:
+         return "Blockiere SRAM-Überschreibung";
+      case MENU_ENUM_LABEL_VALUE_BUILDBOT_ASSETS_URL:
+         return "Buildbot-Assets-URL";
+      case MENU_ENUM_LABEL_VALUE_CACHE_DIRECTORY: /* FIXME/UPDATE */
+         return "Entpack-Verzeichnis";
+      case MENU_ENUM_LABEL_VALUE_CAMERA_ALLOW:
+         return "Erlaube Kamera-Zugriff";
+      case MENU_ENUM_LABEL_VALUE_CAMERA_DRIVER:
+         return "Kamera-Treiber";
+      case MENU_ENUM_LABEL_VALUE_CHEAT:
+         return "Cheat";
+      case MENU_ENUM_LABEL_VALUE_CHEAT_APPLY_CHANGES:
+         return "Änderungen übernehmen";
+      case MENU_ENUM_LABEL_VALUE_CHEAT_DATABASE_PATH:
+         return "Cheat-Datei-Verzeichnis";
       case MENU_ENUM_LABEL_VALUE_CHEAT_FILE_LOAD:
          return "Lade Cheat-Datei";
       case MENU_ENUM_LABEL_VALUE_CHEAT_FILE_SAVE_AS:
          return "Speichere Cheat-Datei unter...";
+      case MENU_ENUM_LABEL_VALUE_CHEAT_NUM_PASSES:
+         return "Cheat-Durchgänge";
+      case MENU_ENUM_LABEL_VALUE_CLOSE_CONTENT:
+         return "Schließe";
+      case MENU_ENUM_LABEL_VALUE_COLLAPSE_SUBGROUPS_ENABLE:
+         return "Untergruppen einklappen";
+      case MENU_ENUM_LABEL_VALUE_CONFIGURATIONS:
+         return "Lade Konfigurationsdatei"; /* FIXME/UPDATE */
+      case MENU_ENUM_LABEL_VALUE_CONFIGURATION_SETTINGS:
+         return "Konfigurations-Einstellungen";
+      case MENU_ENUM_LABEL_VALUE_CONFIG_SAVE_ON_EXIT:
+         return "Speichere Konfiguration beim Beenden";
+      case MENU_ENUM_LABEL_VALUE_CONFIRM_ON_EXIT:
+         return "Zum Beenden Nachfragen";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_COLLECTION_LIST:
+         return "Lade Content (Sammlung)";  /* FIXME/TODO - rewrite */
+      case MENU_ENUM_LABEL_VALUE_CONTENT_DATABASE_DIRECTORY:
+         return "Content-Datenbankverzeichnis";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_HISTORY_SIZE:
+         return "Länge der Verlaufsliste";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_SETTINGS:
+         return "Content-Einstellungen"; /* FIXME */
+      case MENU_ENUM_LABEL_VALUE_CORE_ASSETS_DIRECTORY:
+         return "Core-Assets-Verzeichnis"; /* FIXME/UPDATE */
+      case MENU_ENUM_LABEL_VALUE_CORE_CHEAT_OPTIONS:
+         return "Cheats";
       case MENU_ENUM_LABEL_VALUE_CORE_COUNTERS:
          return "Core-Zähler";
-      case MENU_ENUM_LABEL_VALUE_TAKE_SCREENSHOT:
-         return "Bildschirmfoto";
-      case MENU_ENUM_LABEL_VALUE_RESUME:
-         return "Fortsetzen";
-      case MENU_ENUM_LABEL_VALUE_DISK_INDEX:
-         return "Datenträger-Nummer";
-      case MENU_ENUM_LABEL_VALUE_FRONTEND_COUNTERS:
-         return "Frontendzähler";
-      case MENU_ENUM_LABEL_VALUE_DISK_IMAGE_APPEND:
-         return "Füge Datenträgerabbild hinzu";
+      case MENU_ENUM_LABEL_VALUE_CORE_ENABLE:
+         return "Zeige Core-Namen";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFORMATION:
+         return "Core-Informationen";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_AUTHORS:
+         return "Autoren";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CATEGORIES:
+         return "Kategorien";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_LABEL:
+         return "Core-Beschriftung";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NAME:
+         return "Core-Name";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NOTES:
+         return "Core-Hinweise";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_FIRMWARE:
+         return "Firmware";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_LICENSES:
+         return "Lizenz(en)";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_PERMISSIONS:
+         return "Berechtigungen";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SUPPORTED_EXTENSIONS:
+         return "Unterstütze Erweiterungen";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_MANUFACTURER:
+         return "System-Hersteller";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_NAME:
+         return "System-Name";
+      case MENU_ENUM_LABEL_VALUE_CORE_INPUT_REMAPPING_OPTIONS: /* UPDATE/FIXME */
+         return "Core-Input-Optionen";
+      case MENU_ENUM_LABEL_VALUE_CORE_LIST:
+         return "Lade Core";
+      case MENU_ENUM_LABEL_VALUE_CORE_OPTIONS:
+         return "Optionen";
+      case MENU_ENUM_LABEL_VALUE_CORE_SETTINGS:
+         return "Core-Einstellungen";
+      case MENU_ENUM_LABEL_VALUE_CORE_SET_SUPPORTS_NO_CONTENT_ENABLE: /* TODO/FIXME */
+         return "Cores nicht automatisch starten";
+      case MENU_ENUM_LABEL_VALUE_CORE_SPECIFIC_CONFIG:
+         return "Core-Spezifische Konfiguration";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
+         return "Heruntergeladene Archive automatisch entpacken";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_BUILDBOT_URL:
+         return "Buildbot-Cores-URL";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_LIST:
+         return "Core-Updater";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_SETTINGS:
+         return "Core-Updater-Einstellungen"; /* UPDATE/FIXME */
+      case MENU_ENUM_LABEL_VALUE_CURSOR_DIRECTORY:
+         return "Cursor-Verzeichnis";
+      case MENU_ENUM_LABEL_VALUE_CURSOR_MANAGER:
+         return "Cursormanager";
+      case MENU_ENUM_LABEL_VALUE_CUSTOM_RATIO:
+         return "Benutzerdefiniertes Verhältnis";
+      case MENU_ENUM_LABEL_VALUE_DATABASE_MANAGER:
+         return "Datenbankmanager";
+      case MENU_ENUM_LABEL_VALUE_DELETE_ENTRY:
+         return "Von der Playlist löschen";
+      case MENU_ENUM_LABEL_VALUE_DETECT_CORE_LIST:
+         return "Lade Content (Core erkennen)";  /* FIXME */
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_CONTENT:
+         return "<Content-Verz.>";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_DEFAULT:
+         return "<Voreinstellung>";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NONE:
+         return "<Keins>";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NOT_FOUND:
+         return "Ordner nicht gefunden.";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_SETTINGS:
+         return "Verzeichnis-Einstellungen";
+      case MENU_ENUM_LABEL_VALUE_DISABLED:
+         return "Deaktiviert";
       case MENU_ENUM_LABEL_VALUE_DISK_CYCLE_TRAY_STATUS:
          return "Datenträgerstatus";
-      case MENU_ENUM_LABEL_VALUE_NO_PLAYLIST_ENTRIES_AVAILABLE:
-         return "Keine Wiedergabelisten-Eintrage verfügbar.";
+      case MENU_ENUM_LABEL_VALUE_DISK_IMAGE_APPEND:
+         return "Füge Datenträgerabbild hinzu";
+      case MENU_ENUM_LABEL_VALUE_DISK_INDEX:
+         return "Datenträger-Nummer";
+      case MENU_ENUM_LABEL_VALUE_DISK_OPTIONS: /* UPDATE/FIXME */
+         return "Datenträger-Optionen";
+      case MENU_ENUM_LABEL_VALUE_DONT_CARE:
+         return "Mir egal";
+      case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_ENABLE:
+         return "Aktiviere DPI-Override";
+      case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_VALUE:
+         return "DPI-Override";
+      case MENU_ENUM_LABEL_VALUE_DRIVER_SETTINGS:
+         return "Treiber-Einstellungen";
+      case MENU_ENUM_LABEL_VALUE_DUMMY_ON_CORE_SHUTDOWN:
+         return "Dummy bei Core-Abschaltung";
+      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPER:
+         return "Dynamischer Hintergrund";
+      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPERS_DIRECTORY:
+         return "Dynamische-Bildschirmhintergründe-Verzeichnis";
+      case MENU_ENUM_LABEL_VALUE_ENTRY_HOVER_COLOR:
+         return "Hover-Farbe für Menü-Einträge";
+      case MENU_ENUM_LABEL_VALUE_ENTRY_NORMAL_COLOR:
+         return "Normale Farbe für Menü-Einträge";
+      case MENU_ENUM_LABEL_VALUE_FALSE:
+         return "False";
+      case MENU_ENUM_LABEL_VALUE_FASTFORWARD_RATIO:
+         return "Maximale Ausführungsgeschwindigkeit";
+      case MENU_ENUM_LABEL_VALUE_FPS_SHOW:
+         return "Zeige Framerate";
+      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_ENABLE:
+         return "Begrenze maximale Ausführungsgeschwindigkeit";
+      case MENU_ENUM_LABEL_VALUE_FRONTEND_COUNTERS:
+         return "Frontendzähler";
+      case MENU_ENUM_LABEL_VALUE_HELP:
+         return "Hilfe";
+      case MENU_ENUM_LABEL_VALUE_HISTORY_LIST_ENABLE:
+         return "Aktiviere Verlaufsliste";
+      case MENU_ENUM_LABEL_VALUE_HISTORY_TAB:
+         return "Verlauf";
+      case MENU_ENUM_LABEL_VALUE_HORIZONTAL_MENU: /* Don't change. Breaks everything. (Would be: "Horizontales Menu") */
+         return "Horizontal Menu";
+      case MENU_ENUM_LABEL_VALUE_IMAGES_TAB:
+         return "Bilder";
+      case MENU_ENUM_LABEL_VALUE_INFORMATION_LIST:
+         return "Information";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ALL_USERS_CONTROL_MENU:
+         return "Jeder nutze kann Menü Steuern";
+      case MENU_ENUM_LABEL_VALUE_INPUT_AUTODETECT_ENABLE:
+         return "Automatische Konfiguration aktivieren";
+      case MENU_ENUM_LABEL_VALUE_INPUT_AXIS_THRESHOLD:
+         return "Schwellwert der Eingabe-Achsen";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_HIDE_UNBOUND:
+         return "Verstecke nicht zugewiesene Core-Eingabe-Beschriftungen";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_LABEL_SHOW: /* TODO/FIXME */
+         return "Zeige Core-Eingabe-Beschriftungen";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DRIVER:
+         return "Eingabe-Treiber";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DUTY_CYCLE:
+         return "Auslastungsgrad";
+      case MENU_ENUM_LABEL_VALUE_INPUT_MAX_USERS:
+         return "Maximale Benutzerzahl";
+      case MENU_ENUM_LABEL_VALUE_INPUT_OSK_OVERLAY_ENABLE:
+         return "Zeige Tastatur-Overlay";
+      case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_ENABLE:
+         return "Aktiviere Overlay";
+      case MENU_ENUM_LABEL_VALUE_INPUT_REMAPPING_DIRECTORY: /* UPDATE/FIXME */
+         return "Eingabebelegungs-Verzeichnis";
+      case MENU_ENUM_LABEL_VALUE_INPUT_REMAP_BINDS_ENABLE:
+         return "Bind-Remapping aktivieren";
+      case MENU_ENUM_LABEL_VALUE_INPUT_SETTINGS:
+         return "Eingabe-Einstellungen";
+      case MENU_ENUM_LABEL_VALUE_INPUT_TURBO_PERIOD:
+         return "Turbo-Dauer";
+      case MENU_ENUM_LABEL_VALUE_INPUT_USER_BINDS:
+         return "Spieler %u Tastenbelegung";
+      case MENU_ENUM_LABEL_VALUE_JOYPAD_AUTOCONFIG_DIR:
+         return "Eingabegerät-Autoconfig-Verzeichnis";
+      case MENU_ENUM_LABEL_VALUE_JOYPAD_DRIVER:
+         return "Joypad-Treiber";
+      case MENU_ENUM_LABEL_VALUE_KEYBOARD_OVERLAY_PRESET:
+         return "Tastatur-Overlay-Voreinstellung";
+      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_SIMPLIFIED:
+         return "Chinesisch (Vereinfacht)";
+      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_TRADITIONAL:
+         return "Chinesisch (Traditionell)";
+      case MENU_ENUM_LABEL_VALUE_LANG_DUTCH:
+         return "Niederländisch";
+      case MENU_ENUM_LABEL_VALUE_LANG_ENGLISH:
+         return "Englisch";
+      case MENU_ENUM_LABEL_VALUE_LANG_ESPERANTO:
+         return "Esperanto";
+      case MENU_ENUM_LABEL_VALUE_LANG_FRENCH:
+         return "Französisch";
+      case MENU_ENUM_LABEL_VALUE_LANG_GERMAN:
+         return "Deutsch";
+      case MENU_ENUM_LABEL_VALUE_LANG_ITALIAN:
+         return "Italienisch";
+      case MENU_ENUM_LABEL_VALUE_LANG_JAPANESE:
+         return "Japanisch";
+      case MENU_ENUM_LABEL_VALUE_LANG_KOREAN:
+         return "Koreanisch";
+      case MENU_ENUM_LABEL_VALUE_LANG_PORTUGUESE:
+         return "Portugiesisch";
+      case MENU_ENUM_LABEL_VALUE_LANG_RUSSIAN:
+         return "Russisch";
+      case MENU_ENUM_LABEL_VALUE_LANG_SPANISH:
+         return "Spanisch";
+      case MENU_ENUM_LABEL_VALUE_LEFT_ANALOG:
+         return "Linker Analogstick";
+      case MENU_ENUM_LABEL_VALUE_LIBRETRO_DIR_PATH:
+         return "Core-Verzeichnis";
+      case MENU_ENUM_LABEL_VALUE_LIBRETRO_INFO_PATH:
+         return "Core-Info-Verzeichnis";
+      case MENU_ENUM_LABEL_VALUE_LIBRETRO_LOG_LEVEL:
+         return "Core-Logging-Stufe";
+      case MENU_ENUM_LABEL_VALUE_LINEAR:
+         return "Linear";
+      case MENU_ENUM_LABEL_VALUE_LOAD_ARCHIVE:
+         return "Lade Archiv";
+      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT:
+         return "Lade Content"; /* FIXME */
+      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_HISTORY:
+         return "Lade Content (Verlauf)"; /* FIXME/UPDATE */
+      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_LIST:
+         return "Lade Content";
+      case MENU_ENUM_LABEL_VALUE_LOAD_STATE:
+         return "Lade Savestate";
+      case MENU_ENUM_LABEL_VALUE_LOCATION_ALLOW:
+         return "Erlaube Standort-Lokalisierung";
+      case MENU_ENUM_LABEL_VALUE_LOCATION_DRIVER:
+         return "Standort-Treiber";
+      case MENU_ENUM_LABEL_VALUE_LOGGING_SETTINGS:
+         return "Logging-Einstellungen";
+      case MENU_ENUM_LABEL_VALUE_LOG_VERBOSITY:
+         return "Log-Ausführlichkeit";
+      case MENU_ENUM_LABEL_VALUE_MAIN_MENU:
+         return "Hauptmenü";
+      case MENU_ENUM_LABEL_VALUE_MANAGEMENT:
+         return "Datenbank-Einstellungen";
+      case MENU_ENUM_LABEL_VALUE_MENU_DRIVER:
+         return "Menü-Treiber";
+      case MENU_ENUM_LABEL_VALUE_MENU_FILE_BROWSER_SETTINGS:
+         return "Menü-Dateibrowser-Einstellungen";
+      case MENU_ENUM_LABEL_VALUE_MENU_SETTINGS:
+         return "Menü-Einstellungen";
+      case MENU_ENUM_LABEL_VALUE_MENU_WALLPAPER:
+         return "Menühintergrund";
+      case MENU_ENUM_LABEL_VALUE_MISSING:
+         return "Fehlt";
+      case MENU_ENUM_LABEL_VALUE_MOUSE_ENABLE:
+         return "Maus-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_MULTIMEDIA_SETTINGS:
+         return "Media-Player-Einstellungen"; /* UPDATE/FIXME */
+      case MENU_ENUM_LABEL_VALUE_MUSIC_TAB:
+         return "Musik";
+      case MENU_ENUM_LABEL_VALUE_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
+         return "Bekannte Dateiendungen filtern"; /* TODO/FIXME - rewrite */
+      case MENU_ENUM_LABEL_VALUE_NAVIGATION_WRAPAROUND:
+         return "Navigation umbrechen";
+      case MENU_ENUM_LABEL_VALUE_NEAREST:
+         return "Nächster";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT: /* TODO: Original string changed */
+         return "Tausche Netplay-Eingabe";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_DELAY_FRAMES:
+         return "Verzögere Netplay-Frames";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE:
+         return "Aktiviere Netplay";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS: /* TODO: Original string changed */
+         return "IP-Addresse für Netplay";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_MODE:
+         return "Aktiviere Netplay-Client";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_NICKNAME:
+         return "Benutzername";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE:
+         return "Aktiviere Netplay-Zuschauermodus";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT:
+         return "TCP/UDP-Port für Netplay";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_ENABLE:
+         return "Netzwerk-Befehle";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_PORT:
+         return "Port für Netzwerk-Befehle";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_SETTINGS:
+         return "Netzwerk-Einstellungen";
+      case MENU_ENUM_LABEL_VALUE_NO:
+         return "Nein";
+      case MENU_ENUM_LABEL_VALUE_NONE:
+         return "Keins";
+      case MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE:
+         return "Nicht verfügbar";
+      case MENU_ENUM_LABEL_VALUE_NO_CORE:
+         return "Kein Core";
+      case MENU_ENUM_LABEL_VALUE_NO_CORES_AVAILABLE:
+         return "Kein Core verfügbar.";
       case MENU_ENUM_LABEL_VALUE_NO_CORE_INFORMATION_AVAILABLE:
          return "Keine Core-Informationen verfügbar.";
       case MENU_ENUM_LABEL_VALUE_NO_CORE_OPTIONS_AVAILABLE:
          return "Keine Core-Optionen verfügbar.";
-      case MENU_ENUM_LABEL_VALUE_NO_CORES_AVAILABLE:
-         return "Kein Core verfügbar.";
-      case MENU_ENUM_LABEL_VALUE_NO_CORE:
-         return "Kein Core";
-      case MENU_ENUM_LABEL_VALUE_DATABASE_MANAGER:
-         return "Datenbankmanager";
-      case MENU_ENUM_LABEL_VALUE_CURSOR_MANAGER:
-         return "Cursormanager";
-      case MENU_ENUM_LABEL_VALUE_MAIN_MENU:
-         return "Hauptmenü";
-      case MENU_ENUM_LABEL_VALUE_SETTINGS:
-         return "Einstellungen";
-      case MENU_ENUM_LABEL_VALUE_QUIT_RETROARCH:
-         return "RetroArch beenden";
-      case MENU_ENUM_LABEL_VALUE_HELP:
-         return "Hilfe";
-      case MENU_ENUM_LABEL_VALUE_SAVE_NEW_CONFIG:
-         return "Speichere neue Konfiguration";
-      case MENU_ENUM_LABEL_VALUE_RESTART_CONTENT:
-         return "Starte neu";
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_LIST:
-         return "Core-Updater";
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_BUILDBOT_URL:
-         return "Buildbot-Cores-URL";
-      case MENU_ENUM_LABEL_VALUE_BUILDBOT_ASSETS_URL:
-         return "Buildbot-Assets-URL";
-      case MENU_ENUM_LABEL_VALUE_NAVIGATION_WRAPAROUND:
-         return "Navigation umbrechen";
-      case MENU_ENUM_LABEL_VALUE_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
-         return "Bekannte Dateiendungen filtern"; /* TODO/FIXME - rewrite */
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
-         return "Heruntergeladene Archive automatisch entpacken";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFORMATION:
-         return "Systeminformationen";
-      case MENU_ENUM_LABEL_VALUE_ONLINE_UPDATER:
-         return "Online-Aktualisierungen";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFORMATION:
-         return "Core-Informationen";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NOT_FOUND:
-         return "Ordner nicht gefunden.";
+      case MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE:
+         return "Keine Informationen verfügbar.";
       case MENU_ENUM_LABEL_VALUE_NO_ITEMS:
          return "Keine Einträge.";
-      case MENU_ENUM_LABEL_VALUE_CORE_LIST:
-         return "Lade Core";
-      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT:
-         return "Lade Content"; /* FIXME */
-      case MENU_ENUM_LABEL_VALUE_CLOSE_CONTENT:
-         return "Schließe";
-      case MENU_ENUM_LABEL_VALUE_MANAGEMENT:
-         return "Datenbank-Einstellungen";
-      case MENU_ENUM_LABEL_VALUE_SAVE_STATE:
-         return "Speichere Savestate";
-      case MENU_ENUM_LABEL_VALUE_LOAD_STATE:
-         return "Lade Savestate";
-      case MENU_ENUM_LABEL_VALUE_RESUME_CONTENT:
-         return "Fortsetzen";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DRIVER:
-         return "Eingabe-Treiber";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_DRIVER:
-         return "Audio-Treiber";
-      case MENU_ENUM_LABEL_VALUE_JOYPAD_DRIVER:
-         return "Joypad-Treiber";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_RESAMPLER_DRIVER:
-         return "Audio-Resampler-Treiber";
-      case MENU_ENUM_LABEL_VALUE_RECORD_DRIVER:
-         return "Aufnahme-Treiber";
-      case MENU_ENUM_LABEL_VALUE_MENU_DRIVER:
-         return "Menü-Treiber";
-      case MENU_ENUM_LABEL_VALUE_CAMERA_DRIVER:
-         return "Kamera-Treiber";
-      case MENU_ENUM_LABEL_VALUE_LOCATION_DRIVER:
-         return "Standort-Treiber";
-      case MENU_ENUM_LABEL_VALUE_UNABLE_TO_READ_COMPRESSED_FILE:
-         return "Komprimiertes Archiv kann nicht gelesen werden.";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_SCALE:
-         return "Overlay-Skalierung";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_PRESET:
-         return "Overlay-Voreinstellung";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_LATENCY:
-         return "Audiolatenz (ms)";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_DEVICE:
-         return "Soundkarte";
-      case MENU_ENUM_LABEL_VALUE_KEYBOARD_OVERLAY_PRESET:
-         return "Tastatur-Overlay-Voreinstellung";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_OPACITY:
-         return "Overlay-Transparenz";
-      case MENU_ENUM_LABEL_VALUE_MENU_WALLPAPER:
-         return "Menühintergrund";
-      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPER:
-         return "Dynamischer Hintergrund";
-      case MENU_ENUM_LABEL_VALUE_CORE_INPUT_REMAPPING_OPTIONS: /* UPDATE/FIXME */
-         return "Core-Input-Optionen";
-      case MENU_ENUM_LABEL_VALUE_SHADER_OPTIONS:
-         return "Shaders";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PARAMETERS:
-         return "Momentane Shaderparameter"; /* FIXME/UPDATE */
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_PARAMETERS:
-         return "Menü Shaderparameter (Menü)";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_AS:
-         return "Speichere Shader-Voreinstellung unter...";
+      case MENU_ENUM_LABEL_VALUE_NO_PERFORMANCE_COUNTERS:
+         return "Keine Leistungszähler.";
+      case MENU_ENUM_LABEL_VALUE_NO_PLAYLIST_ENTRIES_AVAILABLE:
+         return "Keine Wiedergabelisten-Eintrage verfügbar.";
+      case MENU_ENUM_LABEL_VALUE_NO_SETTINGS_FOUND:
+         return "Keine Einstellungen gefunden.";
       case MENU_ENUM_LABEL_VALUE_NO_SHADER_PARAMETERS:
          return "Keine Shaderparameter";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET:
-         return "Lade Shader-Voreinstellung";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER:
-         return "Videofilter";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_DSP_PLUGIN:
-         return "Audio-DSP-Plugin";
-      case MENU_ENUM_LABEL_VALUE_SECONDS:
-         return "Sekunden";
       case MENU_ENUM_LABEL_VALUE_OFF: /* Don't change. Needed for XMB atm. (Would be: "AN") */
          return "OFF";
       case MENU_ENUM_LABEL_VALUE_ON: /* Don't change. Needed for XMB atm. (Would be: "AUS") */
          return "ON";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_ASSETS:
-         return "Aktualisiere Assets";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_CHEATS:
-         return "Aktualisiere Cheats";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_AUTOCONFIG_PROFILES:
-         return "Aktualisiere Autoconfig-Profile";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_DATABASES:
-         return "Aktualisiere Datenbanken";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_OVERLAYS:
-         return "Aktualisiere Overlays";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_CG_SHADERS:
-         return "Aktualisiere CG-Shader";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_GLSL_SHADERS:
-         return "Aktualisiere GLSL-Shader";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NAME:
-         return "Core-Name";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_LABEL:
-         return "Core-Beschriftung";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_NAME:
-         return "System-Name";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_MANUFACTURER:
-         return "System-Hersteller";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CATEGORIES:
-         return "Kategorien";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_AUTHORS:
-         return "Autoren";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_PERMISSIONS:
-         return "Berechtigungen";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_LICENSES:
-         return "Lizenz(en)";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SUPPORTED_EXTENSIONS:
-         return "Unterstütze Erweiterungen";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_FIRMWARE:
-         return "Firmware";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NOTES:
-         return "Core-Hinweise";
+      case MENU_ENUM_LABEL_VALUE_ONLINE_UPDATER:
+         return "Online-Aktualisierungen";
+      case MENU_ENUM_LABEL_VALUE_ONSCREEN_DISPLAY_SETTINGS:
+         return "OSD-Einstellungen";
+      case MENU_ENUM_LABEL_VALUE_OPEN_ARCHIVE:
+         return "Öffne Archiv";
+      case MENU_ENUM_LABEL_VALUE_OPTIONAL:
+         return "Optional";
+      case MENU_ENUM_LABEL_VALUE_OSK_OVERLAY_DIRECTORY:
+         return "OSK-Overlay-Verzeichnis";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_DIRECTORY:
+         return "Overlay-Verzeichnis";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_OPACITY:
+         return "Overlay-Transparenz";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_PRESET:
+         return "Overlay-Voreinstellung";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_SCALE:
+         return "Overlay-Skalierung";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_SETTINGS:
+         return "Overlay-Einstellungen";
+      case MENU_ENUM_LABEL_VALUE_PAL60_ENABLE:
+         return "Verwende PAL60-Modus";
+      case MENU_ENUM_LABEL_VALUE_PAUSE_LIBRETRO:
+         return "Pausiere, wenn das Menü aktiv ist";
+      case MENU_ENUM_LABEL_VALUE_PAUSE_NONACTIVE:
+         return "Nicht im Hintergrund laufen";
+      case MENU_ENUM_LABEL_VALUE_PERFCNT_ENABLE:
+         return "Leistungsindikatoren";
+      case MENU_ENUM_LABEL_VALUE_PLAYLIST_DIRECTORY:
+         return "Wiedergabelisten-Verzeichnis";
+      case MENU_ENUM_LABEL_VALUE_PLAYLIST_SETTINGS:
+         return "Wiedergabelisten-Einstellungen";
+      case MENU_ENUM_LABEL_VALUE_POINTER_ENABLE:
+         return "Touch-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_PORT:
+         return "Port";
+      case MENU_ENUM_LABEL_VALUE_PRESENT:
+         return "Vorhanden";
+      case MENU_ENUM_LABEL_VALUE_PRIVACY_SETTINGS:
+         return "Privatsphäre-Einstellungen";
+      case MENU_ENUM_LABEL_VALUE_QUIT_RETROARCH:
+         return "RetroArch beenden";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_CRC32:
+         return "CRC32";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DESCRIPTION:
+         return "Beschreibung";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DEVELOPER:
+         return "Entwickler";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_FRANCHISE:
+         return "Franchise";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_MD5:
+         return "MD5";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_NAME:
+         return "Name";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ORIGIN:
+         return "Herkunft";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_PUBLISHER:
+         return "Publisher";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_MONTH:
+         return "Veröffentlichungsmonat";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_YEAR:
+         return "Veröffentlichungsjahr";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_SHA1:
+         return "SHA1";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_START_CONTENT:
+         return "Starte Content";
+      case MENU_ENUM_LABEL_VALUE_REBOOT:
+         return "Neustart";
+      case MENU_ENUM_LABEL_VALUE_RECORDING_CONFIG_DIRECTORY:
+         return "Aufnahme-Konfigurationsverzeichnis";
+      case MENU_ENUM_LABEL_VALUE_RECORDING_OUTPUT_DIRECTORY:
+         return "Aufnahme-Ausgabeverzeichnis";
+      case MENU_ENUM_LABEL_VALUE_RECORDING_SETTINGS:
+         return "Aufnahme-Einstellungen";
+      case MENU_ENUM_LABEL_VALUE_RECORD_CONFIG:
+         return "Aufnahme-Konfiguration";
+      case MENU_ENUM_LABEL_VALUE_RECORD_DRIVER:
+         return "Aufnahme-Treiber";
+      case MENU_ENUM_LABEL_VALUE_RECORD_ENABLE:
+         return "Aktiviere Aufnahmefunktion";
+      case MENU_ENUM_LABEL_VALUE_RECORD_PATH: /* FIXME/UPDATE */
+         return "Aufnahmepfad";
+      case MENU_ENUM_LABEL_VALUE_RECORD_USE_OUTPUT_DIRECTORY:
+         return "Verwende Aufnahme-Ausgabeverzeichnis";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_LOAD:
+         return "Lade Remap-Datei";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_CORE:
+         return "Speichere Core-Remap-Datei";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_GAME:
+         return "Speichere Spiel-Remap-Datei";
+      case MENU_ENUM_LABEL_VALUE_REQUIRED:
+         return "Notwendig";
+      case MENU_ENUM_LABEL_VALUE_RESTART_CONTENT:
+         return "Starte neu";
+      case MENU_ENUM_LABEL_VALUE_RESTART_RETROARCH:
+         return "Starte RetroArch neu";
+      case MENU_ENUM_LABEL_VALUE_RESUME:
+         return "Fortsetzen";
+      case MENU_ENUM_LABEL_VALUE_RESUME_CONTENT:
+         return "Fortsetzen";
+      case MENU_ENUM_LABEL_VALUE_RETROKEYBOARD:
+         return "RetroKeyboard";
+      case MENU_ENUM_LABEL_VALUE_RETROPAD:
+         return "RetroPad";
+      case MENU_ENUM_LABEL_VALUE_REWIND_ENABLE:
+         return "Zurückspulen (Rewind) aktivieren";
+      case MENU_ENUM_LABEL_VALUE_REWIND_GRANULARITY:
+         return "Genauigkeit des Zurückspulens (Rewind)";
+      case MENU_ENUM_LABEL_VALUE_REWIND_SETTINGS:
+         return "Zurückspul-Einstellungen";
+      case MENU_ENUM_LABEL_VALUE_RGUI_BROWSER_DIRECTORY:
+         return "Browser-Directory";
+      case MENU_ENUM_LABEL_VALUE_RGUI_CONFIG_DIRECTORY:
+         return "Konfigurations-Verzeichnis";
+      case MENU_ENUM_LABEL_VALUE_RGUI_SHOW_START_SCREEN:
+         return "Zeige Startbildschirm";
+      case MENU_ENUM_LABEL_VALUE_RIGHT_ANALOG:
+         return "Rechter Analogstick";
+      case MENU_ENUM_LABEL_VALUE_RUN:
+         return "Start";
+      case MENU_ENUM_LABEL_VALUE_SAVEFILE_DIRECTORY:
+         return "Spielstand-Verzeichnis";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_INDEX:
+         return "Automatische Indexierung von Save States";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_LOAD:
+         return "Automatisches Laden von Save States";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_SAVE:
+         return "Automatische Save States";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_DIRECTORY:
+         return "Savestate-Verzeichnis";
+      case MENU_ENUM_LABEL_VALUE_SAVE_NEW_CONFIG:
+         return "Speichere neue Konfiguration";
+      case MENU_ENUM_LABEL_VALUE_SAVE_STATE:
+         return "Speichere Savestate";
+      case MENU_ENUM_LABEL_VALUE_SAVING_SETTINGS:
+         return "Spielstand-Einstellungen";
+      case MENU_ENUM_LABEL_VALUE_SCAN_DIRECTORY:
+         return "Durchsuche Verzeichnis";
+      case MENU_ENUM_LABEL_VALUE_SCAN_FILE:
+         return "Durchsuche Datei";
+      case MENU_ENUM_LABEL_VALUE_SCAN_THIS_DIRECTORY:
+         return "<- Durchsuche ->";
+      case MENU_ENUM_LABEL_VALUE_SCREENSHOT_DIRECTORY:
+         return "Bildschirmfoto-Verzeichnis";
+      case MENU_ENUM_LABEL_VALUE_SCREEN_RESOLUTION:
+         return "Bildschirmauflösung";
+      case MENU_ENUM_LABEL_VALUE_SECONDS:
+         return "Sekunden";
+      case MENU_ENUM_LABEL_VALUE_SETTINGS:
+         return "Einstellungen";
+      case MENU_ENUM_LABEL_VALUE_SHADER:
+         return "Shader";
+      case MENU_ENUM_LABEL_VALUE_SHADER_APPLY_CHANGES:
+         return "Änderungen übernehmen";
+      case MENU_ENUM_LABEL_VALUE_SHADER_OPTIONS:
+         return "Shaders";
+      case MENU_ENUM_LABEL_VALUE_SHOW_ADVANCED_SETTINGS:
+         return "Zeige erweitere Einstellungen";
+      case MENU_ENUM_LABEL_VALUE_SHOW_HIDDEN_FILES:
+         return "Zeige versteckte Ordner und Dateien";
+      case MENU_ENUM_LABEL_VALUE_SLOWMOTION_RATIO:
+         return "Zeitlupen-Verhältnis";
+      case MENU_ENUM_LABEL_VALUE_SORT_SAVEFILES_ENABLE:
+         return "Sortiere Speicherdaten per Ordner";
+      case MENU_ENUM_LABEL_VALUE_SORT_SAVESTATES_ENABLE:
+         return "Sortiere Save States per Ordner";
+      case MENU_ENUM_LABEL_VALUE_STATUS:
+         return "Status";
+      case MENU_ENUM_LABEL_VALUE_STDIN_CMD_ENABLE:
+         return "stdin-Befehle";
+      case MENU_ENUM_LABEL_VALUE_SUSPEND_SCREENSAVER_ENABLE:
+         return "Bildschirmschoner aussetzen";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_BGM_ENABLE:
+         return "Aktiviere System-BGM";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_DIRECTORY:
+         return "System/BIOS-Verzeichnis";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFORMATION:
+         return "Systeminformationen";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_7ZIP_SUPPORT:
+         return "7zip-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ALSA_SUPPORT:
+         return "ALSA-Unterstützung";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_BUILD_DATE:
          return "Build-Datum";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GIT_VERSION:
-         return "Git-Version";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CG_SUPPORT:
+         return "Cg-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COCOA_SUPPORT:
+         return "Cocoa-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COMMAND_IFACE_SUPPORT:
+         return "Befehlsinterface-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CORETEXT_SUPPORT:
+         return "CoreText-Unterstützung";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CPU_FEATURES:
          return "CPU-Eigenschaften";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_DPI:
+         return "Bildschirm-DPI";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_HEIGHT:
+         return "Bildschirmhöhe (mm)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_WIDTH:
+         return "Bildschirmbreite (mm)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DSOUND_SUPPORT:
+         return "DirectSound-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DYLIB_SUPPORT:
+         return "Dynamic-Library-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_EGL_SUPPORT:
+         return "EGL-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FBO_SUPPORT:
+         return "Unterstützung für OpenGL/Direct3D Render-to-Texture (Multi-Pass Shader)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FFMPEG_SUPPORT:
+         return "FFmpeg-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FREETYPE_SUPPORT:
+         return "FreeType-Unterstützung";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_IDENTIFIER:
          return "Frontend-Kennung";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_NAME:
          return "Frontend-Name";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_OS:
          return "Frontend-Betriebssystem";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RETRORATING_LEVEL:
-         return "RetroRating-Stufe";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE:
-         return "Energiequelle";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_NO_SOURCE:
-         return "Keine Quelle";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGING:
-         return "Lädt";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGED:
-         return "Geladen";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_DISCHARGING:
-         return "Entlädt";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VIDEO_CONTEXT_DRIVER:
-         return "Video-Context-Treiber";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_WIDTH:
-         return "Bildschirmbreite (mm)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_HEIGHT:
-         return "Bildschirmhöhe (mm)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_DPI:
-         return "Bildschirm-DPI";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBRETRODB_SUPPORT:
-         return "LibretroDB-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OVERLAY_SUPPORT:
-         return "Overlay-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COMMAND_IFACE_SUPPORT:
-         return "Befehlsinterface-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETWORK_COMMAND_IFACE_SUPPORT:
-         return "Netzwerk-Befehlsinterface-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COCOA_SUPPORT:
-         return "Cocoa-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RPNG_SUPPORT:
-         return "PNG-Unterstützung (RPNG)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_SUPPORT:
-         return "SDL1.2-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL2_SUPPORT:
-         return "SDL2-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGL_SUPPORT:
-         return "OpenGL-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGLES_SUPPORT:
-         return "OpenGL-ES-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_THREADING_SUPPORT:
-         return "Threading-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_KMS_SUPPORT:
-         return "KMS/EGL-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_UDEV_SUPPORT:
-         return "Udev-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENVG_SUPPORT:
-         return "OpenVG-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_EGL_SUPPORT:
-         return "EGL-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_X11_SUPPORT:
-         return "X11-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_WAYLAND_SUPPORT:
-         return "Wayland-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XVIDEO_SUPPORT:
-         return "XVideo-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ALSA_SUPPORT:
-         return "ALSA-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OSS_SUPPORT:
-         return "OSS-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENAL_SUPPORT:
-         return "OpenAL-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENSL_SUPPORT:
-         return "OpenSL-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RSOUND_SUPPORT:
-         return "RSound-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ROARAUDIO_SUPPORT:
-         return "RoarAudio-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_JACK_SUPPORT:
-         return "JACK-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PULSEAUDIO_SUPPORT:
-         return "PulseAudio-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DSOUND_SUPPORT:
-         return "DirectSound-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XAUDIO2_SUPPORT:
-         return "XAudio2-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ZLIB_SUPPORT:
-         return "Zlib-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_7ZIP_SUPPORT:
-         return "7zip-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DYLIB_SUPPORT:
-         return "Dynamic-Library-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CG_SUPPORT:
-         return "Cg-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GIT_VERSION:
+         return "Git-Version";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GLSL_SUPPORT:
          return "GLSL-Unterstützung";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_HLSL_SUPPORT:
          return "HLSL-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBXML2_SUPPORT:
-         return "Libxml2-XML-Parsing-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_IMAGE_SUPPORT:
-         return "SDL-Image-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FBO_SUPPORT:
-         return "Unterstützung für OpenGL/Direct3D Render-to-Texture (Multi-Pass Shader)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FFMPEG_SUPPORT:
-         return "FFmpeg-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CORETEXT_SUPPORT:
-         return "CoreText-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FREETYPE_SUPPORT:
-         return "FreeType-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETPLAY_SUPPORT:
-         return "Netplay-Unterstützung (Peer-to-Peer)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PYTHON_SUPPORT:
-         return "Python-Unterstützung (Script-Unterstützung in Shadern)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_V4L2_SUPPORT:
-         return "Video4Linux2-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_JACK_SUPPORT:
+         return "JACK-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_KMS_SUPPORT:
+         return "KMS/EGL-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBRETRODB_SUPPORT:
+         return "LibretroDB-Unterstützung";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBUSB_SUPPORT:
          return "Libusb-Unterstützung";
-      case MENU_ENUM_LABEL_VALUE_YES:
-         return "Ja";
-      case MENU_ENUM_LABEL_VALUE_NO:
-         return "Nein";
-      case MENU_ENUM_LABEL_VALUE_BACK:
-         return "ZURÜCK";
-      case MENU_ENUM_LABEL_VALUE_SCREEN_RESOLUTION:
-         return "Bildschirmauflösung";
-      case MENU_ENUM_LABEL_VALUE_DISABLED:
-         return "Deaktiviert";
-      case MENU_ENUM_LABEL_VALUE_PORT:
-         return "Port";
-      case MENU_ENUM_LABEL_VALUE_NONE:
-         return "Keins";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DEVELOPER:
-         return "Entwickler";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_PUBLISHER:
-         return "Publisher";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DESCRIPTION:
-         return "Beschreibung";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_NAME:
-         return "Name";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ORIGIN:
-         return "Herkunft";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_FRANCHISE:
-         return "Franchise";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_MONTH:
-         return "Veröffentlichungsmonat";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_YEAR:
-         return "Veröffentlichungsjahr";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBXML2_SUPPORT:
+         return "Libxml2-XML-Parsing-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETPLAY_SUPPORT:
+         return "Netplay-Unterstützung (Peer-to-Peer)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETWORK_COMMAND_IFACE_SUPPORT:
+         return "Netzwerk-Befehlsinterface-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENAL_SUPPORT:
+         return "OpenAL-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGLES_SUPPORT:
+         return "OpenGL-ES-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGL_SUPPORT:
+         return "OpenGL-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENSL_SUPPORT:
+         return "OpenSL-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENVG_SUPPORT:
+         return "OpenVG-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OSS_SUPPORT:
+         return "OSS-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OVERLAY_SUPPORT:
+         return "Overlay-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE:
+         return "Energiequelle";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGED:
+         return "Geladen";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGING:
+         return "Lädt";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_DISCHARGING:
+         return "Entlädt";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_NO_SOURCE:
+         return "Keine Quelle";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PULSEAUDIO_SUPPORT:
+         return "PulseAudio-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PYTHON_SUPPORT:
+         return "Python-Unterstützung (Script-Unterstützung in Shadern)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RETRORATING_LEVEL:
+         return "RetroRating-Stufe";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ROARAUDIO_SUPPORT:
+         return "RoarAudio-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RPNG_SUPPORT:
+         return "PNG-Unterstützung (RPNG)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RSOUND_SUPPORT:
+         return "RSound-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL2_SUPPORT:
+         return "SDL2-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_IMAGE_SUPPORT:
+         return "SDL-Image-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_SUPPORT:
+         return "SDL1.2-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_THREADING_SUPPORT:
+         return "Threading-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_UDEV_SUPPORT:
+         return "Udev-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_V4L2_SUPPORT:
+         return "Video4Linux2-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VIDEO_CONTEXT_DRIVER:
+         return "Video-Context-Treiber";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_WAYLAND_SUPPORT:
+         return "Wayland-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_X11_SUPPORT:
+         return "X11-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XAUDIO2_SUPPORT:
+         return "XAudio2-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XVIDEO_SUPPORT:
+         return "XVideo-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ZLIB_SUPPORT:
+         return "Zlib-Unterstützung";
+      case MENU_ENUM_LABEL_VALUE_TAKE_SCREENSHOT:
+         return "Bildschirmfoto";
+      case MENU_ENUM_LABEL_VALUE_THREADED_DATA_RUNLOOP_ENABLE:
+         return "Threaded Data Runloop";
+      case MENU_ENUM_LABEL_VALUE_TIMEDATE_ENABLE:
+         return "Zeige Uhrzeit / Datum";
+      case MENU_ENUM_LABEL_VALUE_TITLE_COLOR:
+         return "Menü-Titel-Farbe";
       case MENU_ENUM_LABEL_VALUE_TRUE:
          return "True";
-      case MENU_ENUM_LABEL_VALUE_FALSE:
-         return "False";
-      case MENU_ENUM_LABEL_VALUE_MISSING:
-         return "Fehlt";
-      case MENU_ENUM_LABEL_VALUE_PRESENT:
-         return "Vorhanden";
-      case MENU_ENUM_LABEL_VALUE_OPTIONAL:
-         return "Optional";
-      case MENU_ENUM_LABEL_VALUE_REQUIRED:
-         return "Notwendig";
-      case MENU_ENUM_LABEL_VALUE_STATUS:
-         return "Status";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_SETTINGS:
-         return "Audio-Einstellungen";
-      case MENU_ENUM_LABEL_VALUE_INPUT_SETTINGS:
-         return "Eingabe-Einstellungen";
-      case MENU_ENUM_LABEL_VALUE_ONSCREEN_DISPLAY_SETTINGS:
-         return "OSD-Einstellungen";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_SETTINGS:
-         return "Overlay-Einstellungen";
-      case MENU_ENUM_LABEL_VALUE_MENU_SETTINGS:
-         return "Menü-Einstellungen";
-      case MENU_ENUM_LABEL_VALUE_MULTIMEDIA_SETTINGS:
-         return "Media-Player-Einstellungen"; /* UPDATE/FIXME */
+      case MENU_ENUM_LABEL_VALUE_UI_COMPANION_START_ON_BOOT:
+         return "UI-Companion beim Hochfahren starten";
+      case MENU_ENUM_LABEL_VALUE_UI_MENUBAR_ENABLE:
+         return "Menüleiste";
+      case MENU_ENUM_LABEL_VALUE_UNABLE_TO_READ_COMPRESSED_FILE:
+         return "Komprimiertes Archiv kann nicht gelesen werden.";
+      case MENU_ENUM_LABEL_VALUE_UNKNOWN:
+         return "Unbekannt";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_ASSETS:
+         return "Aktualisiere Assets";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_AUTOCONFIG_PROFILES:
+         return "Aktualisiere Autoconfig-Profile";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_CG_SHADERS:
+         return "Aktualisiere CG-Shader";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_CHEATS:
+         return "Aktualisiere Cheats";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_DATABASES:
+         return "Aktualisiere Datenbanken";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_GLSL_SHADERS:
+         return "Aktualisiere GLSL-Shader";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_OVERLAYS:
+         return "Aktualisiere Overlays";
+      case MENU_ENUM_LABEL_VALUE_USER:
+         return "Benutzer";
       case MENU_ENUM_LABEL_VALUE_USER_INTERFACE_SETTINGS:
          return "Benutzeroberflächen-Einstellungen";
-      case MENU_ENUM_LABEL_VALUE_MENU_FILE_BROWSER_SETTINGS:
-         return "Menü-Dateibrowser-Einstellungen";
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_SETTINGS:
-         return "Core-Updater-Einstellungen"; /* UPDATE/FIXME */
-      case MENU_ENUM_LABEL_VALUE_NETWORK_SETTINGS:
-         return "Netzwerk-Einstellungen";
-      case MENU_ENUM_LABEL_VALUE_PLAYLIST_SETTINGS:
-         return "Wiedergabelisten-Einstellungen";
+      case MENU_ENUM_LABEL_VALUE_USER_LANGUAGE:
+         return "Sprache";
       case MENU_ENUM_LABEL_VALUE_USER_SETTINGS:
          return "Benutzer-Einstellungen";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_SETTINGS:
-         return "Verzeichnis-Einstellungen";
-      case MENU_ENUM_LABEL_VALUE_RECORDING_SETTINGS:
-         return "Aufnahme-Einstellungen";
-      case MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE:
-         return "Keine Informationen verfügbar.";
-      case MENU_ENUM_LABEL_VALUE_INPUT_USER_BINDS:
-         return "Spieler %u Tastenbelegung";
-      case MENU_ENUM_LABEL_VALUE_LANG_ENGLISH:
-         return "Englisch";
-      case MENU_ENUM_LABEL_VALUE_LANG_JAPANESE:
-         return "Japanisch";
-      case MENU_ENUM_LABEL_VALUE_LANG_FRENCH:
-         return "Französisch";
-      case MENU_ENUM_LABEL_VALUE_LANG_SPANISH:
-         return "Spanisch";
-      case MENU_ENUM_LABEL_VALUE_LANG_GERMAN:
-         return "Deutsch";
-      case MENU_ENUM_LABEL_VALUE_LANG_ITALIAN:
-         return "Italienisch";
-      case MENU_ENUM_LABEL_VALUE_LANG_DUTCH:
-         return "Niederländisch";
-      case MENU_ENUM_LABEL_VALUE_LANG_PORTUGUESE:
-         return "Portugiesisch";
-      case MENU_ENUM_LABEL_VALUE_LANG_RUSSIAN:
-         return "Russisch";
-      case MENU_ENUM_LABEL_VALUE_LANG_KOREAN:
-         return "Koreanisch";
-      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_TRADITIONAL:
-         return "Chinesisch (Traditionell)";
-      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_SIMPLIFIED:
-         return "Chinesisch (Vereinfacht)";
-      case MENU_ENUM_LABEL_VALUE_LANG_ESPERANTO:
-         return "Esperanto";
-      case MENU_ENUM_LABEL_VALUE_LEFT_ANALOG:
-         return "Linker Analogstick";
-      case MENU_ENUM_LABEL_VALUE_RIGHT_ANALOG:
-         return "Rechter Analogstick";
-      case MENU_ENUM_LABEL_VALUE_DELETE_ENTRY:
-         return "Von der Playlist löschen";
-      case MENU_ENUM_LABEL_VALUE_RUN:
-         return "Start";
-      case MENU_ENUM_LABEL_SETTINGS:
-         return "Einstellungen";
-      case MENU_ENUM_LABEL_VALUE_HISTORY_TAB:
-         return "Verlauf";
-      case MENU_ENUM_LABEL_VALUE_ADD_TAB:
-         return "Hinzufügen";
+      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_PLAYER:
+         return "Verwende integrierten Player"; /* FIXME/UPDATE */
+      case MENU_ENUM_LABEL_VALUE_USE_THIS_DIRECTORY:
+         return "<Diesen Ordner verwenden>";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ALLOW_ROTATE:
+         return "Erlaube Bildrotation";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_AUTO:
+         return "Automatisches Bildseitenverhältnis";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_INDEX:
+         return "Bildseitenverhältnis-Index";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_BLACK_FRAME_INSERTION:
+         return "Setze schwarze Frames ein";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_CROP_OVERSCAN:
+         return "Bildränder (Overscan) zuschneiden (Neustart erforderlich)";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_DISABLE_COMPOSITION:
+         return "Deaktiviere Desktop-Komposition";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_DRIVER:
+         return "Grafiktreiber";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER:
+         return "Videofilter";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_DIR:
+         return "Grafikfilter-Verzeichnis";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_FLICKER:
+         return "Aktiviere Flacker-Filter";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_ENABLE:
+         return "Zeige OSD-Nachrichten";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_PATH:
+         return "Schriftart der OSD-Nachrichten";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_SIZE:
+         return "Schriftgröße der OSD-Nachrichten";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_ASPECT:
+         return "Erzwinge Bildseitenverhältnis";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_SRGB_DISABLE:
+         return "Erzwinge Deaktivierung des sRGB FBO";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FRAME_DELAY:
+         return "Bildverzögerung";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FULLSCREEN:
+         return "Verwende Vollbildmodus";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_GAMMA:
+         return "Gamma";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_RECORD:
+         return "Aktiviere GPU-Aufnahmefunktion";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_SCREENSHOT:
+         return "Aktiviere GPU-Bildschirmfotos";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC:
+         return "Synchronisiere GPU und CPU";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC_FRAMES:
+         return "Synchronisiere Frames fest mit GPU";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_X:
+         return "X-Position der OSD-Nachrichten";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_Y:
+         return "Y-Position der OSD-Nachrichten";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MONITOR_INDEX:
+         return "Monitor-Index";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_POST_FILTER_RECORD:
+         return "Aktiviere Aufnahme von Post-Filtern";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE:
+         return "Bildwiederholrate";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE_AUTO:
+         return "Geschätzte Bildwiederholrate";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ROTATION:
+         return "Rotation";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE:
+         return "Fenterskalierung";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE_INTEGER:
+         return "Ganzzahlige Bildskalierung";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SETTINGS:
+         return "Video-Einstellungen";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_DIR:
+         return "Grafikshader-Verzeichnis";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_NUM_PASSES:
+         return "Shader-Durchgänge";  /* FIXME */
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PARAMETERS:
+         return "Momentane Shaderparameter"; /* FIXME/UPDATE */
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET:
+         return "Lade Shader-Voreinstellung";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_PARAMETERS:
+         return "Menü Shaderparameter (Menü)";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_AS:
+         return "Speichere Shader-Voreinstellung unter...";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHARED_CONTEXT:
+         return "HW-Shared-Context aktivieren";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SMOOTH:
+         return "Bilineare Filterung (HW)";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SOFT_FILTER:
+         return "Aktiviere Soft-Filter";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SWAP_INTERVAL:
+         return "VSync-Intervall";
       case MENU_ENUM_LABEL_VALUE_VIDEO_TAB:
          return "Videos";
-      case MENU_ENUM_LABEL_VALUE_IMAGES_TAB:
-         return "Bilder";
-      case MENU_ENUM_LABEL_VALUE_MUSIC_TAB:
-         return "Musik";
-      case MENU_ENUM_LABEL_VALUE_XMB_SHADOWS_ENABLE:
-         return "Icon Schatten";
-      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_SETTINGS:
-         return "Zeige Einstellungen";
-      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_IMAGES:
-         return "Zeige Bilder";
-      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_MUSIC:
-         return "Zeige Musik";
-      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_VIDEO:
-         return "Zeige Videos";
-      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_HISTORY:
-         return "Zeige Verlauf";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_THREADED:
+         return "Threaded Video";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VFILTER:
+         return "Bild entflackern";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_HEIGHT:
+         return "Bildchirmauflösung Höhe";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_WIDTH:
+         return "Bildchirmauflösung Breite";
       case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_X:
          return "Bildchirmauflösung X";
       case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_Y:
          return "Bildchirmauflösung Y";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_WIDTH:
-         return "Bildchirmauflösung Breite";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_HEIGHT:
-         return "Bildchirmauflösung Höhe";
-      case MENU_ENUM_LABEL_VALUE_SCAN_THIS_DIRECTORY:
-         return "<- Durchsuche ->";
-      case MENU_ENUM_LABEL_VALUE_SCAN_FILE:
-         return "Durchsuche Datei";
-      case MENU_ENUM_LABEL_VALUE_SCAN_DIRECTORY:
-         return "Durchsuche Verzeichnis";
-      case MENU_ENUM_LABEL_VALUE_REBOOT:
-         return "Neustart";
-      case MENU_ENUM_LABEL_SHUTDOWN:
-         return "Ausschalten";
-      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_USERNAME:
-         return "Benutzername";
-      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_PASSWORD:
-         return "Passwort";
-      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_LIST:
-         return "Konten";
-      case MENU_ENUM_LABEL_VALUE_CONFIRM_ON_EXIT:
-         return "Zum Beenden Nachfragen";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ALL_USERS_CONTROL_MENU:
-         return "Jeder nutze kann Menü Steuern";
-      case MENU_ENUM_LABEL_VALUE_SHOW_HIDDEN_FILES:
-         return "Zeige versteckte Ordner und Dateien";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VI_WIDTH:
+         return "Kalibriere VI-Bildbreite";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VSYNC:
+         return "Vertikale Synchronisation (VSync)";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_WINDOWED_FULLSCREEN:
+         return "Unechter Vollbild-Modus (Windowed Fullscreen)";
       case MENU_ENUM_LABEL_VALUE_WIFI_DRIVER:
          return "Wlan-Treiber";
       case MENU_ENUM_LABEL_VALUE_WIFI_SETTINGS:
          return "Wlan";
+      case MENU_ENUM_LABEL_VALUE_XMB_SHADOWS_ENABLE:
+         return "Icon Schatten";
+      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_HISTORY:
+         return "Zeige Verlauf";
+      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_IMAGES:
+         return "Zeige Bilder";
+      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_MUSIC:
+         return "Zeige Musik";
+      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_SETTINGS:
+         return "Zeige Einstellungen";
+      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_VIDEO:
+         return "Zeige Videos";
+      case MENU_ENUM_LABEL_VALUE_YES:
+         return "Ja";
       default:
          break;
    }

--- a/intl/msg_hash_es.c
+++ b/intl/msg_hash_es.c
@@ -918,7 +918,7 @@ int menu_hash_get_help_es_enum(enum msg_hash_enums msg, char *s, size_t len)
                "que se vaya a utilizar.\n");
          break;
       case MENU_ENUM_LABEL_VIDEO_FULLSCREEN:
-         snprintf(s, len, 
+         snprintf(s, len,
                 "Activa o desactiva el modo \n"
                 "en pantalla completa.");
          break;
@@ -1017,7 +1017,7 @@ int menu_hash_get_help_es_enum(enum msg_hash_enums msg, char *s, size_t len)
                "Los valores posibles son [0.0, 1.0].");
          break;
       case MENU_ENUM_LABEL_INPUT_TURBO_PERIOD:
-         snprintf(s, len, 
+         snprintf(s, len,
                "Período de turbo.\n"
                " \n"
                "Describe la velocidad con la que se \n"
@@ -1229,280 +1229,280 @@ const char *msg_hash_to_str_es(enum msg_hash_enums msg)
 {
    switch (msg)
    {
-      case MSG_PROGRAM:
-         return "RetroArch";
-      case MSG_MOVIE_RECORD_STOPPED:
-         return "Deteniendo grabación de vídeo.";
-      case MSG_MOVIE_PLAYBACK_ENDED:
-         return "Reproducción detenida.";
-      case MSG_AUTOSAVE_FAILED:
-         return "No se ha podido iniciar el autoguardado.";
-      case MSG_NETPLAY_FAILED_MOVIE_PLAYBACK_HAS_STARTED:
-         return "Se ha iniciado una reproducción. No se puede ejecutar el juego en red.";
-      case MSG_NETPLAY_FAILED:
-         return "Error al iniciar el juego en red.";
-      case MSG_LIBRETRO_ABI_BREAK:
-         return "se ha compilado con una versión distinta a esta implementación de libretro.";
-      case MSG_REWIND_INIT_FAILED_THREADED_AUDIO:
-         return "La implementación utiliza sonido multinúcleo. No se puede utilizar el rebobinado.";
-      case MSG_REWIND_INIT_FAILED:
-         return "Error al iniciar el búfer de rebobinado. Rebobinado desactivado.";
-      case MSG_REWIND_INIT:
-         return "Iniciando búfer de rebobinado, tamaño:";
-      case MSG_CUSTOM_TIMING_GIVEN:
-         return "Se ha indicado un ritmo personalizado";
-      case MSG_VIEWPORT_SIZE_CALCULATION_FAILED:
-         return "¡Error al calcular el tamaño de ventana! Se utilizarán datos en bruto. Probablemente esto no acabe bien...";
-      case MSG_HW_RENDERED_MUST_USE_POSTSHADED_RECORDING:
-         return "El núcleo Libretro se renderiza por hardware. Es necesario utilizar la grabación post-shaders.";
-      case MSG_RECORDING_TO:
-         return "Grabando a";
-      case MSG_DETECTED_VIEWPORT_OF:
-         return "Ventana detectada:";
-      case MSG_TAKING_SCREENSHOT:
-         return "Capturando pantalla.";
-      case MSG_FAILED_TO_TAKE_SCREENSHOT:
-         return "Error al capturar pantalla.";
-      case MSG_FAILED_TO_START_RECORDING:
-         return "Error al comenzar a grabar.";
-      case MSG_RECORDING_TERMINATED_DUE_TO_RESIZE:
-         return "Grabación terminada por cambio de tamaño.";
-      case MSG_USING_LIBRETRO_DUMMY_CORE_RECORDING_SKIPPED:
-         return "Se está utilizando el núcleo dummy de libretro. Anulando grabación.";
-      case MSG_UNKNOWN:
-         return "Desconocido";
-      case MSG_LOADING_CONTENT_FILE:
-         return "Cargando archivo de contenido";
-      case MSG_RECEIVED:
-         return "recibido";
-      case MSG_UNRECOGNIZED_COMMAND:
-         return "Comando no reconocido";
-      case MSG_SENDING_COMMAND:
-         return "Enviando comando";
-      case MSG_GOT_INVALID_DISK_INDEX:
-         return "Se ha obtenido un índice de disco no válido.";
-      case MSG_FAILED_TO_REMOVE_DISK_FROM_TRAY:
-         return "Error al extraer el disco de la bandeja.";
-      case MSG_REMOVED_DISK_FROM_TRAY:
-         return "Se ha retirado el disco de la bandeja.";
-      case MSG_VIRTUAL_DISK_TRAY:
-         return "bandeja de disco virtual.";
-      case MSG_FAILED_TO:
-         return "Error:";
-      case MSG_TO:
-         return "a";
-      case MSG_SAVING_RAM_TYPE:
-         return "Guardando tipo de RAM";
-      case MSG_SAVING_STATE:
-         return "Guardando rápidamente";
-      case MSG_LOADING_STATE:
-         return "Cargando rápidamente";
-      case MSG_FAILED_TO_LOAD_MOVIE_FILE:
-         return "Error al cargar el archivo de película";
-      case MSG_FAILED_TO_LOAD_CONTENT:
-         return "Error al cargar el contenido";
-      case MSG_COULD_NOT_READ_CONTENT_FILE:
-         return "No se ha podido leer el archivo de contenido";
-      case MSG_GRAB_MOUSE_STATE:
-         return "Capturar estado de ratón";
-      case MSG_PAUSED:
-         return "En pausa.";
-      case MSG_UNPAUSED:
-         return "Sin pausa.";
-      case MSG_FAILED_TO_LOAD_OVERLAY:
-         return "Error al cargar sobreimposición.";
-      case MSG_FAILED_TO_UNMUTE_AUDIO:
-         return "Error al recuperar el sonido.";
+      case MENU_ENUM_LABEL_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
+         return "Combo para alternar mando con menú";
+      case MENU_ENUM_LABEL_MENU_THROTTLE_FRAMERATE:
+         return "Acelerar velocidad del menú";
+      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_PASSWORD:
+         return "Contraseña";
+      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_SETTINGS:
+         return "Cuenta Cheevos";
+      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_USERNAME:
+         return "Usuario";
+      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_LIST:
+         return "Cuentas";
+      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_LIST_END:
+         return "Enlace a lista de cuentas";
+      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_RETRO_ACHIEVEMENTS:
+         return "Retrologros";
+      case MENU_ENUM_LABEL_VALUE_ADD_CONTENT_LIST:
+         return "Añadir contenido";
+      case MENU_ENUM_LABEL_VALUE_ASK_ARCHIVE:
+         return "Preguntar";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS:
+         return "Controles básicos del menú";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_BACK:
+         return "Retroceder";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_CONFIRM:
+         return "Confirmar/Aceptar";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_INFO:
+         return "Información";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_QUIT:
+         return "Abandonar";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_SCROLL_DOWN:
+         return "Desplazar hacia abajo";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_SCROLL_UP:
+         return "Desplazar hacia arriba";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_START:
+         return "Valores predeterminados";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_TOGGLE_KEYBOARD:
+         return "Alternar teclado";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_TOGGLE_MENU:
+         return "Alternar menú";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_DESCRIPTION:
+         return "Descripción";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_HARDCORE_MODE_ENABLE:
+         return "Modo Extremo";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_SETTINGS:
+         return "Retrologros";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_TEST_UNOFFICIAL:
+         return "Probar versión no oficial";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_SETTINGS:
+         return "Menú rápido";
+      case MENU_ENUM_LABEL_VALUE_DOWNLOAD_CORE_CONTENT:
+         return "Descargar contenido";
+      case MENU_ENUM_LABEL_VALUE_HELP_AUDIO_VIDEO_TROUBLESHOOTING:
+         return "Solucionar problemas de vídeo/sonido";
+      case MENU_ENUM_LABEL_VALUE_HELP_CHANGE_VIRTUAL_GAMEPAD:
+         return "Cambiar el mando virtual superpuesto";
+      case MENU_ENUM_LABEL_VALUE_HELP_CONTROLS:
+         return "Controles básicos del menú";
+      case MENU_ENUM_LABEL_VALUE_HELP_LIST:
+         return "Ayuda";
+      case MENU_ENUM_LABEL_VALUE_HELP_LOADING_CONTENT:
+         return "Cargando contenidos";
+      case MENU_ENUM_LABEL_VALUE_HELP_SCANNING_CONTENT:
+         return "Buscar contenido";
+      case MENU_ENUM_LABEL_VALUE_HELP_WHAT_IS_A_CORE:
+         return "¿Qué es un núcleo?";
+      case MENU_ENUM_LABEL_VALUE_INFORMATION_LIST:
+         return "Información";
+      case MENU_ENUM_LABEL_VALUE_INPUT_BACK_AS_MENU_ENUM_TOGGLE_ENABLE:
+         return "Permitir alternar Back como menú";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ICADE_ENABLE:
+         return "Activar asignar mando al teclado";
+      case MENU_ENUM_LABEL_VALUE_INPUT_KEYBOARD_GAMEPAD_MAPPING_TYPE:
+         return "Tipo de asignación de mando para teclado";
+      case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_HIDE_IN_MENU:
+         return "Ocultar superposición en el menú";
+      case MENU_ENUM_LABEL_VALUE_INPUT_SMALL_KEYBOARD_ENABLE:
+         return "Activar miniteclado";
+      case MENU_ENUM_LABEL_VALUE_LANG_POLISH:
+         return "Polaco";
+      case MENU_ENUM_LABEL_VALUE_LOAD_ARCHIVE:
+         return "Cargar archivo con un núcleo";
+      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_LIST:
+         return "Cargar contenido";
+      case MENU_ENUM_LABEL_VALUE_MENU_LINEAR_FILTER:
+         return "Filtro lineal del menú";
+      case MENU_ENUM_LABEL_VALUE_OPEN_ARCHIVE:
+         return "Abrir archivo como una carpeta";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_AUTOLOAD_PREFERRED:
+         return "Cargar superposición preferida automáticamente";
+      case MENU_ENUM_LABEL_VALUE_PRIVACY_SETTINGS:
+         return "Privacidad";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_CRC32:
+         return "CRC32";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_MD5:
+         return "MD5";
+      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG:
+         return "Guardar configuración actual";
+      case MENU_ENUM_LABEL_VALUE_SCAN_DIRECTORY:
+         return "Escanear carpeta";
+      case MENU_ENUM_LABEL_VALUE_SCAN_FILE:
+         return "Escanear archivo";
+      case MENU_ENUM_LABEL_VALUE_SCAN_THIS_DIRECTORY:
+         return "(Escanear esta carpeta)";
+      case MENU_ENUM_LABEL_VALUE_STATE_SLOT:
+         return "Ranura de guardado";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_CORE_INFO_FILES:
+         return "Actualizar archivos de información de núcleos";
+      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_PLAYER:
+         return "Usar reproductor de medios integrado";
+      case MSG_APPENDED_DISK:
+         return "Disco incorporado";
+      case MSG_APPLYING_SHADER:
+         return "Aplicando shader";
       case MSG_AUDIO_MUTED:
          return "Sonido silenciado.";
       case MSG_AUDIO_UNMUTED:
          return "Sonido recuperado.";
-      case MSG_RESET:
-         return "Reiniciar";
-      case MSG_FAILED_TO_LOAD_STATE:
-         return "Error al cargar rápidamente desde";
-      case MSG_FAILED_TO_SAVE_STATE_TO:
-         return "Error al guardar rápidamente a";
-      case MSG_FAILED_TO_SAVE_SRAM:
-         return "Error al guardar la SRAM";
-      case MSG_STATE_SIZE:
-         return "Tamaño de guardado rápido";
-      case MSG_FOUND_SHADER:
-         return "Shader encontrado";
-      case MSG_SRAM_WILL_NOT_BE_SAVED:
-         return "No se guardará la SRAM.";
+      case MSG_AUTOSAVE_FAILED:
+         return "No se ha podido iniciar el autoguardado.";
       case MSG_BLOCKING_SRAM_OVERWRITE:
          return "Bloqueando sobrescritura de SRAM";
-      case MSG_CORE_DOES_NOT_SUPPORT_SAVESTATES:
-         return "El núcleo no es compatible con los guardados rápidos.";
-      case MSG_SAVED_STATE_TO_SLOT:
-         return "Guardando rápidamente a la ranura";
-      case MSG_SAVED_SUCCESSFULLY_TO:
-         return "Partida guardada en";
       case MSG_BYTES:
          return "bytes";
+      case MSG_CHEEVOS_HARDCORE_MODE_ENABLE:
+         return "Modo Extremo Activado: guardar estado y reboninar se han desactivado.";
       case MSG_CONFIG_DIRECTORY_NOT_SET:
          return "No se ha asignado la carpeta de configuración. No se puede guardar la nueva configuración.";
-      case MSG_SKIPPING_SRAM_LOAD:
-         return "Omitiendo carga de SRAM.";
-      case MSG_APPENDED_DISK:
-         return "Disco incorporado";
-      case MSG_STARTING_MOVIE_PLAYBACK:
-         return "Iniciando reproducción.";
+      case MSG_CORE_DOES_NOT_SUPPORT_SAVESTATES:
+         return "El núcleo no es compatible con los guardados rápidos.";
+      case MSG_COULD_NOT_READ_CONTENT_FILE:
+         return "No se ha podido leer el archivo de contenido";
+      case MSG_CUSTOM_TIMING_GIVEN:
+         return "Se ha indicado un ritmo personalizado";
+      case MSG_DETECTED_VIEWPORT_OF:
+         return "Ventana detectada:";
+      case MSG_DOWNLOADING:
+        return "Descargando";
+      case MSG_EXTRACTING:
+        return "Extrayendo";
+      case MSG_FAILED_TO:
+         return "Error:";
+      case MSG_FAILED_TO_APPLY_SHADER:
+         return "Error al aplicar shader.";
+      case MSG_FAILED_TO_LOAD_CONTENT:
+         return "Error al cargar el contenido";
+      case MSG_FAILED_TO_LOAD_MOVIE_FILE:
+         return "Error al cargar el archivo de película";
+      case MSG_FAILED_TO_LOAD_OVERLAY:
+         return "Error al cargar sobreimposición.";
+      case MSG_FAILED_TO_LOAD_STATE:
+         return "Error al cargar rápidamente desde";
+      case MSG_FAILED_TO_REMOVE_DISK_FROM_TRAY:
+         return "Error al extraer el disco de la bandeja.";
       case MSG_FAILED_TO_REMOVE_TEMPORARY_FILE:
          return "Error al borrar el archivo temporal";
-      case MSG_REMOVING_TEMPORARY_CONTENT_FILE:
-         return "Borrando archivo temporal de contenido";
+      case MSG_FAILED_TO_SAVE_SRAM:
+         return "Error al guardar la SRAM";
+      case MSG_FAILED_TO_SAVE_STATE_TO:
+         return "Error al guardar rápidamente a";
+      case MSG_FAILED_TO_START_MOVIE_RECORD:
+         return "Error al iniciar la grabación.";
+      case MSG_FAILED_TO_START_RECORDING:
+         return "Error al comenzar a grabar.";
+      case MSG_FAILED_TO_TAKE_SCREENSHOT:
+         return "Error al capturar pantalla.";
+      case MSG_FAILED_TO_UNMUTE_AUDIO:
+         return "Error al recuperar el sonido.";
+      case MSG_FOUND_SHADER:
+         return "Shader encontrado";
+      case MSG_GOT_INVALID_DISK_INDEX:
+         return "Se ha obtenido un índice de disco no válido.";
+      case MSG_GRAB_MOUSE_STATE:
+         return "Capturar estado de ratón";
+      case MSG_HW_RENDERED_MUST_USE_POSTSHADED_RECORDING:
+         return "El núcleo Libretro se renderiza por hardware. Es necesario utilizar la grabación post-shaders.";
+      case MSG_LIBRETRO_ABI_BREAK:
+         return "se ha compilado con una versión distinta a esta implementación de libretro.";
       case MSG_LOADED_STATE_FROM_SLOT:
          return "Carga rápida desde la ranura";
-      case MSG_SCANNING_OF_DIRECTORY_FINISHED:
-         return "Escaneado de carpetas terminado";
-      case MSG_SCANNING:
-         return "Escaneando";
+      case MSG_LOADING_CONTENT_FILE:
+         return "Cargando archivo de contenido";
+      case MSG_LOADING_STATE:
+         return "Cargando rápidamente";
+      case MSG_MOVIE_PLAYBACK_ENDED:
+         return "Reproducción detenida.";
+      case MSG_MOVIE_RECORD_STOPPED:
+         return "Deteniendo grabación de vídeo.";
+      case MSG_NETPLAY_FAILED:
+         return "Error al iniciar el juego en red.";
+      case MSG_NETPLAY_FAILED_MOVIE_PLAYBACK_HAS_STARTED:
+         return "Se ha iniciado una reproducción. No se puede ejecutar el juego en red.";
+      case MSG_PAUSED:
+         return "En pausa.";
+      case MSG_PROGRAM:
+         return "RetroArch";
+      case MSG_RECEIVED:
+         return "recibido";
+      case MSG_RECORDING_TERMINATED_DUE_TO_RESIZE:
+         return "Grabación terminada por cambio de tamaño.";
+      case MSG_RECORDING_TO:
+         return "Grabando a";
       case MSG_REDIRECTING_CHEATFILE_TO:
          return "Redirigiendo archivo de trucos a";
       case MSG_REDIRECTING_SAVEFILE_TO:
          return "Redirigiendo partida guardada a";
       case MSG_REDIRECTING_SAVESTATE_TO:
          return "Redirigiendo guardado rápido a";
-      case MSG_SHADER:
-         return "Shader";
-      case MSG_APPLYING_SHADER:
-         return "Aplicando shader";
-      case MSG_FAILED_TO_APPLY_SHADER:
-         return "Error al aplicar shader.";
-      case MSG_STARTING_MOVIE_RECORD_TO:
-         return "Iniciando grabación en";
-      case MSG_FAILED_TO_START_MOVIE_RECORD:
-         return "Error al iniciar la grabación.";
-      case MSG_STATE_SLOT:
-         return "Ranura de guardado rápido";
+      case MSG_REMOVED_DISK_FROM_TRAY:
+         return "Se ha retirado el disco de la bandeja.";
+      case MSG_REMOVING_TEMPORARY_CONTENT_FILE:
+         return "Borrando archivo temporal de contenido";
+      case MSG_RESET:
+         return "Reiniciar";
       case MSG_RESTARTING_RECORDING_DUE_TO_DRIVER_REINIT:
          return "Reiniciando grabación debido al reinicio de un controlador.";
+      case MSG_REWINDING:
+         return "Rebobinando.";
+      case MSG_REWIND_INIT:
+         return "Iniciando búfer de rebobinado, tamaño:";
+      case MSG_REWIND_INIT_FAILED:
+         return "Error al iniciar el búfer de rebobinado. Rebobinado desactivado.";
+      case MSG_REWIND_INIT_FAILED_THREADED_AUDIO:
+         return "La implementación utiliza sonido multinúcleo. No se puede utilizar el rebobinado.";
+      case MSG_REWIND_REACHED_END:
+         return "Se ha llegado al final del búfer de rebobinado.";
+      case MSG_SAVED_STATE_TO_SLOT:
+         return "Guardando rápidamente a la ranura";
+      case MSG_SAVED_SUCCESSFULLY_TO:
+         return "Partida guardada en";
+      case MSG_SAVING_RAM_TYPE:
+         return "Guardando tipo de RAM";
+      case MSG_SAVING_STATE:
+         return "Guardando rápidamente";
+      case MSG_SCANNING:
+         return "Escaneando";
+      case MSG_SCANNING_OF_DIRECTORY_FINISHED:
+         return "Escaneado de carpetas terminado";
+      case MSG_SENDING_COMMAND:
+         return "Enviando comando";
+      case MSG_SHADER:
+         return "Shader";
+      case MSG_SKIPPING_SRAM_LOAD:
+         return "Omitiendo carga de SRAM.";
       case MSG_SLOW_MOTION:
          return "Cámara lenta.";
       case MSG_SLOW_MOTION_REWIND:
          return "Rebobinar cámara lenta.";
-      case MSG_REWINDING:
-         return "Rebobinando.";
-      case MSG_REWIND_REACHED_END:
-         return "Se ha llegado al final del búfer de rebobinado.";
-      case MSG_CHEEVOS_HARDCORE_MODE_ENABLE:
-         return "Modo Extremo Activado: guardar estado y reboninar se han desactivado.";
-      case MSG_DOWNLOADING:
-        return "Descargando";
-      case MSG_EXTRACTING:
-        return "Extrayendo";
-      case MENU_ENUM_LABEL_VALUE_MENU_LINEAR_FILTER:
-         return "Filtro lineal del menú";
-      case MENU_ENUM_LABEL_MENU_THROTTLE_FRAMERATE:
-         return "Acelerar velocidad del menú";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_TEST_UNOFFICIAL:
-         return "Probar versión no oficial";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_SETTINGS:
-         return "Retrologros";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ICADE_ENABLE:
-         return "Activar asignar mando al teclado";
-      case MENU_ENUM_LABEL_VALUE_INPUT_KEYBOARD_GAMEPAD_MAPPING_TYPE:
-         return "Tipo de asignación de mando para teclado";
-      case MENU_ENUM_LABEL_VALUE_INPUT_SMALL_KEYBOARD_ENABLE:
-         return "Activar miniteclado";
-      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG:
-         return "Guardar configuración actual";
-      case MENU_ENUM_LABEL_VALUE_STATE_SLOT:
-         return "Ranura de guardado";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_HARDCORE_MODE_ENABLE:
-         return "Modo Extremo";
-      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_SETTINGS:
-         return "Cuenta Cheevos";
-      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_USERNAME:
-         return "Usuario";
-      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_PASSWORD:
-         return "Contraseña";
-      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_RETRO_ACHIEVEMENTS:
-         return "Retrologros";
-      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_LIST:
-         return "Cuentas";
-      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_LIST_END:
-         return "Enlace a lista de cuentas";
-      case MENU_ENUM_LABEL_VALUE_HELP_SCANNING_CONTENT:
-         return "Buscar contenido";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_DESCRIPTION:
-         return "Descripción";
-      case MENU_ENUM_LABEL_VALUE_HELP_AUDIO_VIDEO_TROUBLESHOOTING:
-         return "Solucionar problemas de vídeo/sonido";
-      case MENU_ENUM_LABEL_VALUE_HELP_CHANGE_VIRTUAL_GAMEPAD:
-         return "Cambiar el mando virtual superpuesto";
-      case MENU_ENUM_LABEL_VALUE_HELP_WHAT_IS_A_CORE:
-         return "¿Qué es un núcleo?";
-      case MENU_ENUM_LABEL_VALUE_HELP_LOADING_CONTENT:
-         return "Cargando contenidos";
-      case MENU_ENUM_LABEL_VALUE_HELP_LIST:
-         return "Ayuda";
-      case MENU_ENUM_LABEL_VALUE_HELP_CONTROLS:
-         return "Controles básicos del menú";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS:
-         return "Controles básicos del menú";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_SCROLL_UP:
-         return "Desplazar hacia arriba";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_SCROLL_DOWN:
-         return "Desplazar hacia abajo";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_CONFIRM:
-         return "Confirmar/Aceptar";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_BACK:
-         return "Retroceder";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_START:
-         return "Valores predeterminados";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_INFO:
-         return "Información";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_TOGGLE_MENU:
-         return "Alternar menú";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_QUIT:
-         return "Abandonar";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_TOGGLE_KEYBOARD:
-         return "Alternar teclado";
-      case MENU_ENUM_LABEL_VALUE_OPEN_ARCHIVE:
-         return "Abrir archivo como una carpeta";
-      case MENU_ENUM_LABEL_VALUE_LOAD_ARCHIVE:
-         return "Cargar archivo con un núcleo";
-      case MENU_ENUM_LABEL_VALUE_INPUT_BACK_AS_MENU_ENUM_TOGGLE_ENABLE:
-         return "Permitir alternar Back como menú";
-      case MENU_ENUM_LABEL_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
-         return "Combo para alternar mando con menú";
-      case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_HIDE_IN_MENU:
-         return "Ocultar superposición en el menú";
-      case MENU_ENUM_LABEL_VALUE_LANG_POLISH:
-         return "Polaco";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_AUTOLOAD_PREFERRED:
-         return "Cargar superposición preferida automáticamente";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_CORE_INFO_FILES:
-         return "Actualizar archivos de información de núcleos";
-      case MENU_ENUM_LABEL_VALUE_DOWNLOAD_CORE_CONTENT:
-         return "Descargar contenido";
-      case MENU_ENUM_LABEL_VALUE_SCAN_THIS_DIRECTORY:
-         return "(Escanear esta carpeta)";
-      case MENU_ENUM_LABEL_VALUE_SCAN_FILE:
-         return "Escanear archivo";
-      case MENU_ENUM_LABEL_VALUE_SCAN_DIRECTORY:
-         return "Escanear carpeta";
-      case MENU_ENUM_LABEL_VALUE_ADD_CONTENT_LIST:
-         return "Añadir contenido";
-      case MENU_ENUM_LABEL_VALUE_INFORMATION_LIST:
-         return "Información";
-      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_PLAYER:
-         return "Usar reproductor de medios integrado";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_SETTINGS:
-         return "Menú rápido";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_CRC32:
-         return "CRC32";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_MD5:
-         return "MD5";
-      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_LIST:
-         return "Cargar contenido";
-      case MENU_ENUM_LABEL_VALUE_ASK_ARCHIVE:
-         return "Preguntar";
-      case MENU_ENUM_LABEL_VALUE_PRIVACY_SETTINGS:
-         return "Privacidad";
+      case MSG_SRAM_WILL_NOT_BE_SAVED:
+         return "No se guardará la SRAM.";
+      case MSG_STARTING_MOVIE_PLAYBACK:
+         return "Iniciando reproducción.";
+      case MSG_STARTING_MOVIE_RECORD_TO:
+         return "Iniciando grabación en";
+      case MSG_STATE_SIZE:
+         return "Tamaño de guardado rápido";
+      case MSG_STATE_SLOT:
+         return "Ranura de guardado rápido";
+      case MSG_TAKING_SCREENSHOT:
+         return "Capturando pantalla.";
+      case MSG_TO:
+         return "a";
+      case MSG_UNKNOWN:
+         return "Desconocido";
+      case MSG_UNPAUSED:
+         return "Sin pausa.";
+      case MSG_UNRECOGNIZED_COMMAND:
+         return "Comando no reconocido";
+      case MSG_USING_LIBRETRO_DUMMY_CORE_RECORDING_SKIPPED:
+         return "Se está utilizando el núcleo dummy de libretro. Anulando grabación.";
+      case MSG_VIEWPORT_SIZE_CALCULATION_FAILED:
+         return "¡Error al calcular el tamaño de ventana! Se utilizarán datos en bruto. Probablemente esto no acabe bien...";
+      case MSG_VIRTUAL_DISK_TRAY:
+         return "bandeja de disco virtual.";
 #if 0
       case MENU_ENUM_LABEL_VALUE_HORIZONTAL_MENU: /* Don't change. Breaks everything. (Would be: "Menú horizontal") */
          return "Horizontal Menu";
@@ -1516,822 +1516,822 @@ const char *msg_hash_to_str_es(enum msg_hash_enums msg)
       case MENU_ENUM_LABEL_VALUE_PLAYLISTS_TAB:
          return "Pestaña de listas de reproducción";
 #endif
-      case MENU_ENUM_LABEL_VALUE_NO_SETTINGS_FOUND:
-         return "No se ha encontrado una configuración.";
-      case MENU_ENUM_LABEL_VALUE_NO_PERFORMANCE_COUNTERS:
-         return "No hay contadores de rendimiento.";
-      case MENU_ENUM_LABEL_VALUE_DRIVER_SETTINGS:
-         return "Controlador";
-      case MENU_ENUM_LABEL_VALUE_CONFIGURATION_SETTINGS:
-         return "Configuración";
-      case MENU_ENUM_LABEL_VALUE_CORE_SETTINGS:
-         return "Núcleo";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SETTINGS:
-         return "Vídeo";
-      case MENU_ENUM_LABEL_VALUE_LOGGING_SETTINGS:
-         return "Registros";
-      case MENU_ENUM_LABEL_VALUE_SAVING_SETTINGS:
-         return "Guardado";
-      case MENU_ENUM_LABEL_VALUE_REWIND_SETTINGS:
-         return "Rebobinado";
-      case MENU_ENUM_LABEL_VALUE_SHADER:
-         return "Shader";
-      case MENU_ENUM_LABEL_VALUE_CHEAT:
-         return "Truco";
-      case MENU_ENUM_LABEL_VALUE_USER:
-         return "Usuario";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_BGM_ENABLE:
-         return "Activar música del sistema";
-      case MENU_ENUM_LABEL_VALUE_RETROPAD:
-         return "RetroPad";
-      case MENU_ENUM_LABEL_VALUE_RETROKEYBOARD:
-         return "RetroKeyboard";
+      case MENU_ENUM_LABEL_VALUE_ACHIEVEMENT_LIST:
+         return "Lista de logros";
+      case MENU_ENUM_LABEL_VALUE_ARCHIVE_MODE:
+         return "Acción para asociar tipos de archivo";
+      case MENU_ENUM_LABEL_VALUE_ASSETS_DIRECTORY:
+         return "Carpeta de recursos";
       case MENU_ENUM_LABEL_VALUE_AUDIO_BLOCK_FRAMES:
          return "Bloquear fotogramas";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_LABEL_SHOW:
-         return "Mostrar etiquetas de descripción de la entrada";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_HIDE_UNBOUND:
-         return "Ocultar descripciones sin asignar de la entrada del núcleo";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_ENABLE:
-         return "Mostrar mensajes en pantalla";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_PATH:
-         return "Fuente de mensajes en pantalla";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_SIZE:
-         return "Tamaño de mensajes en pantalla";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_X:
-         return "Posición X de mensajes en pantalla";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_Y:
-         return "Posición Y de mensajes en pantalla";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SOFT_FILTER:
-         return "Activar filtros por software";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_FLICKER:
-         return "Filtro de parpadeo";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_DEVICE:
+         return "Controlador de sonido";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_DRIVER:
+         return "Controlador de sonido";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_DSP_PLUGIN:
+         return "Plugin DSP de sonido";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_ENABLE:
+         return "Activar sonido";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_FILTER_DIR:
+         return "Carpeta de filtros de sonido";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_LATENCY:
+         return "Retraso de sonido (ms)";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_MAX_TIMING_SKEW:
+         return "Variación máxima de sincronía de sonido";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_MUTE:
+         return "Silenciar sonido";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_OUTPUT_RATE:
+         return "Frecuencia de sonido (KHz)";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_RATE_CONTROL_DELTA:
+         return "Delta de control de frecuencia de sonido";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_RESAMPLER_DRIVER:
+         return "Controlador de muestreo de sonido";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_SETTINGS:
+         return "Sonido";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_SYNC:
+         return "Activar sincronía de sonido";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_VOLUME:
+         return "Volumen de sonido (dB)";
+      case MENU_ENUM_LABEL_VALUE_AUTOSAVE_INTERVAL:
+         return "Intervalo de autoguardados de SaveRAM";
+      case MENU_ENUM_LABEL_VALUE_AUTO_OVERRIDES_ENABLE:
+         return "Cargar autom. archivos de anulación";
+      case MENU_ENUM_LABEL_VALUE_AUTO_REMAPS_ENABLE:
+         return "Cargar autom. archivos de reasignación";
+      case MENU_ENUM_LABEL_VALUE_BACK:
+         return "BACK";
+      case MENU_ENUM_LABEL_VALUE_BLOCK_SRAM_OVERWRITE:
+         return "No sobrescribir SaveRAM al cargar un guardado rápido";
+      case MENU_ENUM_LABEL_VALUE_BUILDBOT_ASSETS_URL:
+         return "URL de recursos de Buildbot";
+      case MENU_ENUM_LABEL_VALUE_CACHE_DIRECTORY:
+         return "Carpeta de caché";
+      case MENU_ENUM_LABEL_VALUE_CAMERA_ALLOW:
+         return "Permitir cámara";
+      case MENU_ENUM_LABEL_VALUE_CAMERA_DRIVER:
+         return "Controlador de cámara";
+      case MENU_ENUM_LABEL_VALUE_CHEAT:
+         return "Truco";
+      case MENU_ENUM_LABEL_VALUE_CHEAT_APPLY_CHANGES:
+         return "Aplicar cambios en trucos";
+      case MENU_ENUM_LABEL_VALUE_CHEAT_DATABASE_PATH:
+         return "Carpeta de archivos de trucos";
+      case MENU_ENUM_LABEL_VALUE_CHEAT_FILE_LOAD:
+         return "Cargar archivo de trucos";
+      case MENU_ENUM_LABEL_VALUE_CHEAT_FILE_SAVE_AS:
+         return "Guardar archivo de trucos como...";
+      case MENU_ENUM_LABEL_VALUE_CHEAT_NUM_PASSES:
+         return "Pasadas de trucos";
+      case MENU_ENUM_LABEL_VALUE_CLOSE_CONTENT:
+         return "Cerrar";
+      case MENU_ENUM_LABEL_VALUE_CONFIGURATIONS:
+         return "Cargar configuración";
+      case MENU_ENUM_LABEL_VALUE_CONFIGURATION_SETTINGS:
+         return "Configuración";
+      case MENU_ENUM_LABEL_VALUE_CONFIG_SAVE_ON_EXIT:
+         return "Guardar configuración al salir";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_COLLECTION_LIST:
+         return "Seleccionar de una colección";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_DATABASE_DIRECTORY:
+         return "Carpeta de bases de datos de contenidos";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_HISTORY_SIZE:
+         return "Tamaño del historial";
+      case MENU_ENUM_LABEL_VALUE_CORE_ASSETS_DIRECTORY:
+         return "Carpeta de descargas";
+      case MENU_ENUM_LABEL_VALUE_CORE_CHEAT_OPTIONS: /* UPDATE/FIXME */
+         return "Opciones de trucos del núcleo";
+      case MENU_ENUM_LABEL_VALUE_CORE_COUNTERS:
+         return "Contadores del núcleo";
+      case MENU_ENUM_LABEL_VALUE_CORE_ENABLE:
+         return "Mostrar nombre del núcleo";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFORMATION:
+         return "Información del núcleo";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_AUTHORS:
+         return "Autores";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CATEGORIES:
+         return "Categorías";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_LABEL:
+         return "Etiqueta del núcleo";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NAME:
+         return "Nombre del núcleo";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NOTES:
+         return "Notas del núcleo";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_FIRMWARE:
+         return "Firmware";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_LICENSES:
+         return "Licencia(s)";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_PERMISSIONS:
+         return "Permisos";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SUPPORTED_EXTENSIONS:
+         return "Extensiones compatibles";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_MANUFACTURER:
+         return "Fabricante del sistema";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_NAME:
+         return "Nombre del sistema";
+      case MENU_ENUM_LABEL_VALUE_CORE_INPUT_REMAPPING_OPTIONS:
+         return "Opciones de entrada del núcleo";
+      case MENU_ENUM_LABEL_VALUE_CORE_LIST:
+         return "Cargar núcleo";
+      case MENU_ENUM_LABEL_VALUE_CORE_OPTIONS:
+         return "Opciones";
+      case MENU_ENUM_LABEL_VALUE_CORE_SETTINGS:
+         return "Núcleo";
+      case MENU_ENUM_LABEL_VALUE_CORE_SET_SUPPORTS_NO_CONTENT_ENABLE: /* TODO/FIXME */
+         return "No ejecutar automáticamente";
+      case MENU_ENUM_LABEL_VALUE_CORE_SPECIFIC_CONFIG:
+         return "Configuración por núcleo";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
+         return "Extraer automáticamente el archivo descargado";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_BUILDBOT_URL:
+         return "URL de núcleos de Buildbot";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_LIST:
+         return "Actualizador de núcleos";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_SETTINGS:
+         return "Actualizador";
+      case MENU_ENUM_LABEL_VALUE_CURSOR_DIRECTORY:
+         return "Carpeta de cursores";
+      case MENU_ENUM_LABEL_VALUE_CURSOR_MANAGER:
+         return "Gestor de cursores";
+      case MENU_ENUM_LABEL_VALUE_CUSTOM_RATIO:
+         return "Proporción personalizada";
+      case MENU_ENUM_LABEL_VALUE_DATABASE_MANAGER:
+         return "Gestor de bases de datos";
+      case MENU_ENUM_LABEL_VALUE_DETECT_CORE_LIST:
+         return "Seleccionar archivo y detectar núcleo";
       case MENU_ENUM_LABEL_VALUE_DIRECTORY_CONTENT:
          return "(Carpeta de contenido)";
-      case MENU_ENUM_LABEL_VALUE_UNKNOWN:
-         return "Desconocido";
-      case MENU_ENUM_LABEL_VALUE_DONT_CARE:
-         return "No importa";
-      case MENU_ENUM_LABEL_VALUE_LINEAR:
-         return "Lineal";
-      case MENU_ENUM_LABEL_VALUE_NEAREST:
-         return "Más cercano";
       case MENU_ENUM_LABEL_VALUE_DIRECTORY_DEFAULT:
          return "(Predeterminada)";
       case MENU_ENUM_LABEL_VALUE_DIRECTORY_NONE:
          return "(Ninguna)";
-      case MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE:
-         return "No disponible";
-      case MENU_ENUM_LABEL_VALUE_INPUT_REMAPPING_DIRECTORY:
-         return "Carpeta de reasignación de entrada";
-      case MENU_ENUM_LABEL_VALUE_JOYPAD_AUTOCONFIG_DIR:
-         return "Carpeta de autoconfiguración de dispositivo de entrada";
-      case MENU_ENUM_LABEL_VALUE_RECORDING_CONFIG_DIRECTORY:
-         return "Carpeta de configuración de grabación";
-      case MENU_ENUM_LABEL_VALUE_RECORDING_OUTPUT_DIRECTORY:
-         return "Carpeta de salida de grabación";
-      case MENU_ENUM_LABEL_VALUE_SCREENSHOT_DIRECTORY:
-         return "Carpeta de capturas de pantalla";
-      case MENU_ENUM_LABEL_VALUE_PLAYLIST_DIRECTORY:
-         return "Carpeta de listas de reproducción";
-      case MENU_ENUM_LABEL_VALUE_SAVEFILE_DIRECTORY:
-         return "Carpeta de partidas guardadas";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_DIRECTORY:
-         return "Carpeta de guardados rápidos";
-      case MENU_ENUM_LABEL_VALUE_STDIN_CMD_ENABLE:
-         return "Comandos stdin";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_REMOTE_ENABLE:
-         return "Mando en red";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_DRIVER:
-         return "Controlador de vídeo";
-      case MENU_ENUM_LABEL_VALUE_RECORD_ENABLE:
-         return "Activar grabación";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_RECORD:
-         return "Activar grabación de GPU";
-      case MENU_ENUM_LABEL_VALUE_RECORD_PATH:
-         return "Carpeta de salida";
-      case MENU_ENUM_LABEL_VALUE_RECORD_USE_OUTPUT_DIRECTORY:
-         return "Usar carpeta de salida";
-      case MENU_ENUM_LABEL_VALUE_RECORD_CONFIG:
-         return "Configuración de grabación";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_POST_FILTER_RECORD:
-         return "Activar grabación con filtros";
-      case MENU_ENUM_LABEL_VALUE_CORE_ASSETS_DIRECTORY:
-         return "Carpeta de descargas";
-      case MENU_ENUM_LABEL_VALUE_ASSETS_DIRECTORY:
-         return "Carpeta de recursos";
-      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPERS_DIRECTORY:
-         return "Carpeta de fondos de pantalla dinámicos";
-      case MENU_ENUM_LABEL_VALUE_RGUI_BROWSER_DIRECTORY:
-         return "Carpeta del navegador de archivos";
-      case MENU_ENUM_LABEL_VALUE_RGUI_CONFIG_DIRECTORY:
-         return "Carpeta de configuración";
-      case MENU_ENUM_LABEL_VALUE_LIBRETRO_INFO_PATH:
-         return "Carpeta de información del núcleo";
-      case MENU_ENUM_LABEL_VALUE_LIBRETRO_DIR_PATH:
-         return "Carpeta de núcleos";
-      case MENU_ENUM_LABEL_VALUE_CURSOR_DIRECTORY:
-         return "Carpeta de cursores";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_DATABASE_DIRECTORY:
-         return "Carpeta de bases de datos de contenidos";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_DIRECTORY:
-         return "Carpeta de sistema/BIOS";
-      case MENU_ENUM_LABEL_VALUE_CHEAT_DATABASE_PATH:
-         return "Carpeta de archivos de trucos";
-      case MENU_ENUM_LABEL_VALUE_CACHE_DIRECTORY:
-         return "Carpeta de caché";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_FILTER_DIR:
-         return "Carpeta de filtros de sonido";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_DIR:
-         return "Carpeta de shaders de vídeo";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_DIR:
-         return "Carpeta de filtros de vídeo";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_DIRECTORY:
-         return "Carpeta de superposiciones";
-      case MENU_ENUM_LABEL_VALUE_OSK_OVERLAY_DIRECTORY:
-         return "Carpeta de teclados superpuestos";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT: /* TODO: Original string changed */
-         return "Intercambiar entrada en red";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE:
-         return "Permitir espectadores en red";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS: /* TODO: Original string changed */
-         return "Dirección IP";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT:
-         return "Puerto TCP/UDP para juego en red";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE:
-         return "Activar juego en red";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_DELAY_FRAMES:
-         return "Retraso de fotogramas en red";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_MODE:
-         return "Activar cliente en red";
-      case MENU_ENUM_LABEL_VALUE_RGUI_SHOW_START_SCREEN:
-         return "Mostrar pantalla de inicio";
-      case MENU_ENUM_LABEL_VALUE_TITLE_COLOR:
-         return "Color de títulos del menú";
-      case MENU_ENUM_LABEL_VALUE_ENTRY_HOVER_COLOR:
-         return "Color de entrada resaltada del menú";
-      case MENU_ENUM_LABEL_VALUE_TIMEDATE_ENABLE:
-         return "Mostrar fecha y hora";
-      case MENU_ENUM_LABEL_VALUE_THREADED_DATA_RUNLOOP_ENABLE:
-         return "Buclar datos hilados";
-      case MENU_ENUM_LABEL_VALUE_ENTRY_NORMAL_COLOR:
-         return "Color de entrada normal del menú";
-      case MENU_ENUM_LABEL_VALUE_SHOW_ADVANCED_SETTINGS:
-         return "Mostrar ajustes avanzados";
-      case MENU_ENUM_LABEL_VALUE_MOUSE_ENABLE:
-         return "Soporte para teclado";
-      case MENU_ENUM_LABEL_VALUE_POINTER_ENABLE:
-         return "Soporte táctil";
-      case MENU_ENUM_LABEL_VALUE_CORE_ENABLE:
-         return "Mostrar nombre del núcleo";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NOT_FOUND:
+         return "No se ha encontrado la carpeta.";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_SETTINGS:
+         return "Carpeta";
+      case MENU_ENUM_LABEL_VALUE_DISABLED:
+         return "Desactivado";
+      case MENU_ENUM_LABEL_VALUE_DISK_CYCLE_TRAY_STATUS:
+         return "Estado de la bandeja del disco";
+      case MENU_ENUM_LABEL_VALUE_DISK_IMAGE_APPEND:
+         return "Asignar imagen de disco";
+      case MENU_ENUM_LABEL_VALUE_DISK_INDEX:
+         return "Índice del disco";
+      case MENU_ENUM_LABEL_VALUE_DISK_OPTIONS: /* UPDATE/FIXME */
+         return "Opciones del disco del núcleo";
+      case MENU_ENUM_LABEL_VALUE_DONT_CARE:
+         return "No importa";
+      case MENU_ENUM_LABEL_VALUE_DOWNLOADED_FILE_DETECT_CORE_LIST: /* TODO/FIXME - rewrite */
+         return "Seleccionar archivo descargado y detectar núcleo";
       case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_ENABLE:
          return "Activar anulación de PPP";
       case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_VALUE:
          return "Anular PPP";
-      case MENU_ENUM_LABEL_VALUE_XMB_SCALE_FACTOR:
-         return "Escala del XMB";
-      case MENU_ENUM_LABEL_VALUE_XMB_ALPHA_FACTOR:
-         return "Transparencia del XMB";
-      case MENU_ENUM_LABEL_VALUE_XMB_FONT:
-         return "Fuente del XMB";
-      case MENU_ENUM_LABEL_VALUE_SUSPEND_SCREENSAVER_ENABLE:
-         return "Suspender salvapantallas";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_DISABLE_COMPOSITION:
-         return "Desactivar composición de escritorio";
-      case MENU_ENUM_LABEL_VALUE_PAUSE_NONACTIVE:
-         return "Detenerse en segundo plano";
-      case MENU_ENUM_LABEL_VALUE_UI_COMPANION_START_ON_BOOT:
-         return "Ejecutar al inicio la IU ayudante";
-      case MENU_ENUM_LABEL_VALUE_UI_COMPANION_ENABLE:
-         return "Activar IU ayudante";
-      case MENU_ENUM_LABEL_VALUE_UI_MENUBAR_ENABLE:
-         return "Barra de menús";
-      case MENU_ENUM_LABEL_VALUE_ARCHIVE_MODE:
-         return "Acción para asociar tipos de archivo";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_ENABLE:
-         return "Comandos de red";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_PORT:
-         return "Puerto de comandos de red";
-      case MENU_ENUM_LABEL_VALUE_HISTORY_LIST_ENABLE:
-         return "Activar historial";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_HISTORY_SIZE:
-         return "Tamaño del historial";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE_AUTO:
-         return "Frecuencia estimada del monitor";
+      case MENU_ENUM_LABEL_VALUE_DRIVER_SETTINGS:
+         return "Controlador";
       case MENU_ENUM_LABEL_VALUE_DUMMY_ON_CORE_SHUTDOWN:
          return "Anular al cerrar núcleo";
-      case MENU_ENUM_LABEL_VALUE_CORE_SET_SUPPORTS_NO_CONTENT_ENABLE: /* TODO/FIXME */
-         return "No ejecutar automáticamente";
-      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_ENABLE:
-         return "Limitar velocidad máxima de ejecución";
+      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPER:
+         return "Fondo de pantalla dinámico";
+      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPERS_DIRECTORY:
+         return "Carpeta de fondos de pantalla dinámicos";
+      case MENU_ENUM_LABEL_VALUE_ENABLE:
+         return "Activar";
+      case MENU_ENUM_LABEL_VALUE_ENTRY_HOVER_COLOR:
+         return "Color de entrada resaltada del menú";
+      case MENU_ENUM_LABEL_VALUE_ENTRY_NORMAL_COLOR:
+         return "Color de entrada normal del menú";
+      case MENU_ENUM_LABEL_VALUE_FALSE:
+         return "Desactivado";
       case MENU_ENUM_LABEL_VALUE_FASTFORWARD_RATIO:
          return "Velocidad máxima de ejecución";
-      case MENU_ENUM_LABEL_VALUE_AUTO_REMAPS_ENABLE:
-         return "Cargar autom. archivos de reasignación";
-      case MENU_ENUM_LABEL_VALUE_SLOWMOTION_RATIO:
-         return "Cantidad de velocidad reducida";
-      case MENU_ENUM_LABEL_VALUE_CORE_SPECIFIC_CONFIG:
-         return "Configuración por núcleo";
+      case MENU_ENUM_LABEL_VALUE_FPS_SHOW:
+         return "Mostrar velocidad de fotogramas";
+      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_ENABLE:
+         return "Limitar velocidad máxima de ejecución";
+      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_SETTINGS:
+         return "Aumento de fotogramas";
+      case MENU_ENUM_LABEL_VALUE_FRONTEND_COUNTERS:
+         return "Contadores del frontend";
       case MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS:
          return "Usar opciones de núcleo para cada juego si existen";
       case MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS_CREATE:
          return "Crear archivo de opciones del juego";
       case MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS_IN_USE:
          return "Archivo de opciones del juego";
-      case MENU_ENUM_LABEL_VALUE_AUTO_OVERRIDES_ENABLE:
-         return "Cargar autom. archivos de anulación";
-      case MENU_ENUM_LABEL_VALUE_CONFIG_SAVE_ON_EXIT:
-         return "Guardar configuración al salir";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SMOOTH:
-         return "Filtrado bilineal por hardware";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_GAMMA:
-         return "Gamma de vídeo";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ALLOW_ROTATE:
-         return "Permitir rotación";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC:
-         return "Sincronía estricta de GPU";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SWAP_INTERVAL:
-         return "Intervalo de alternado de VSync";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VSYNC:
-         return "VSync/Sincronía vertical";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_THREADED:
-         return "Vídeo por hilos";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ROTATION:
-         return "Rotación";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_SCREENSHOT:
-         return "Permitir capturas de pantalla de GPU";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_CROP_OVERSCAN:
-         return "Recortar Overscan (Reinicio)";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_INDEX:
-         return "Índice de proporción de aspecto";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_AUTO:
-         return "Proporción de aspecto automática";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_ASPECT:
-         return "Forzar proporción de aspecto";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE:
-         return "Frecuencia de actualización";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_SRGB_DISABLE:
-         return "Forzar anulación del FBO sRGB";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_WINDOWED_FULLSCREEN:
-         return "Pantalla completa en ventana";
-      case MENU_ENUM_LABEL_VALUE_PAL60_ENABLE:
-         return "Usar modo PAL60";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VFILTER:
-         return "Filtro contra parpadeos";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VI_WIDTH:
-         return "Asignar ancho de interfaz visual";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_BLACK_FRAME_INSERTION:
-         return "Insertar fotogramas negros";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC_FRAMES:
-         return "Fotogramas a sincronizar estrictamente";
-      case MENU_ENUM_LABEL_VALUE_SORT_SAVEFILES_ENABLE:
-         return "Ordenar partidas guardadas por carpetas";
-      case MENU_ENUM_LABEL_VALUE_SORT_SAVESTATES_ENABLE:
-         return "Ordenar guardados rápidos por carpetas";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FULLSCREEN:
-         return "Pantalla completa";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE:
-         return "Escala de ventana";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE_INTEGER:
-         return "Escala integral";
-      case MENU_ENUM_LABEL_VALUE_PERFCNT_ENABLE:
-         return "Contadores de rendimiento";
-      case MENU_ENUM_LABEL_VALUE_LIBRETRO_LOG_LEVEL:
-         return "Nivel de registro del núcleo";
-      case MENU_ENUM_LABEL_VALUE_LOG_VERBOSITY:
-         return "Verbosidad del registro";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_LOAD:
-         return "Cargar guardado rápido automáticamente";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_INDEX:
-         return "Indizar automáticamente guardados rápidos";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_SAVE:
-         return "Guardado rápido automático";
-      case MENU_ENUM_LABEL_VALUE_AUTOSAVE_INTERVAL:
-         return "Intervalo de autoguardados de SaveRAM";
-      case MENU_ENUM_LABEL_VALUE_BLOCK_SRAM_OVERWRITE:
-         return "No sobrescribir SaveRAM al cargar un guardado rápido";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHARED_CONTEXT:
-         return "Activar contexto compartido por HW";
-      case MENU_ENUM_LABEL_VALUE_RESTART_RETROARCH:
-         return "Reiniciar RetroArch";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_NICKNAME:
-         return "Nombre de usuario";
-      case MENU_ENUM_LABEL_VALUE_USER_LANGUAGE:
-         return "Idioma";
-      case MENU_ENUM_LABEL_VALUE_CAMERA_ALLOW:
-         return "Permitir cámara";
-      case MENU_ENUM_LABEL_VALUE_LOCATION_ALLOW:
-         return "Permitir ubicación";
-      case MENU_ENUM_LABEL_VALUE_PAUSE_LIBRETRO:
-         return "Pausar al activar el menú";
+      case MENU_ENUM_LABEL_VALUE_HELP:
+         return "Ayuda";
+      case MENU_ENUM_LABEL_VALUE_HISTORY_LIST_ENABLE:
+         return "Activar historial";
+      case MENU_ENUM_LABEL_VALUE_INPUT_AUTODETECT_ENABLE:
+         return "Activar autoconfiguración";
+      case MENU_ENUM_LABEL_VALUE_INPUT_AXIS_THRESHOLD:
+         return "Margen de ejes de entrada";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_HIDE_UNBOUND:
+         return "Ocultar descripciones sin asignar de la entrada del núcleo";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_LABEL_SHOW:
+         return "Mostrar etiquetas de descripción de la entrada";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DRIVER:
+         return "Controlador de entrada";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DUTY_CYCLE:
+         return "Ciclo de trabajo";
+      case MENU_ENUM_LABEL_VALUE_INPUT_HOTKEY_BINDS:
+         return "Asignaciones de teclas rápidas";
+      case MENU_ENUM_LABEL_VALUE_INPUT_MAX_USERS:
+         return "Número máximo de usuarios";
       case MENU_ENUM_LABEL_VALUE_INPUT_OSK_OVERLAY_ENABLE:
          return "Mostrar teclado superpuesto";
       case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_ENABLE:
          return "Mostrar superposición";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MONITOR_INDEX:
-         return "Índice del monitor";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FRAME_DELAY:
-         return "Retraso de fotogramas";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DUTY_CYCLE:
-         return "Ciclo de trabajo";
-      case MENU_ENUM_LABEL_VALUE_INPUT_TURBO_PERIOD:
-         return "Período de turbo";
-      case MENU_ENUM_LABEL_VALUE_INPUT_AXIS_THRESHOLD:
-         return "Margen de ejes de entrada";
+      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR:
+         return "Tipo de retardo";
+      case MENU_ENUM_LABEL_VALUE_INPUT_REMAPPING_DIRECTORY:
+         return "Carpeta de reasignación de entrada";
       case MENU_ENUM_LABEL_VALUE_INPUT_REMAP_BINDS_ENABLE:
          return "Permitir reasignar controles";
-      case MENU_ENUM_LABEL_VALUE_INPUT_MAX_USERS:
-         return "Número máximo de usuarios";
-      case MENU_ENUM_LABEL_VALUE_INPUT_AUTODETECT_ENABLE:
-         return "Activar autoconfiguración";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_OUTPUT_RATE:
-         return "Frecuencia de sonido (KHz)";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_MAX_TIMING_SKEW:
-         return "Variación máxima de sincronía de sonido";
-      case MENU_ENUM_LABEL_VALUE_CHEAT_NUM_PASSES:
-         return "Pasadas de trucos";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_CORE:
-         return "Guardar archivo de reasignación del núcleo";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_GAME:
-         return "Guardar archivo de reasignación del juego";
-      case MENU_ENUM_LABEL_VALUE_CHEAT_APPLY_CHANGES:
-         return "Aplicar cambios en trucos";
-      case MENU_ENUM_LABEL_VALUE_SHADER_APPLY_CHANGES:
-         return "Aplicar cambios en shaders";
-      case MENU_ENUM_LABEL_VALUE_REWIND_ENABLE:
-         return "Activar rebobinado";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_COLLECTION_LIST:
-         return "Seleccionar de una colección";
-      case MENU_ENUM_LABEL_VALUE_DETECT_CORE_LIST:
-         return "Seleccionar archivo y detectar núcleo";
-      case MENU_ENUM_LABEL_VALUE_DOWNLOADED_FILE_DETECT_CORE_LIST: /* TODO/FIXME - rewrite */
-         return "Seleccionar archivo descargado y detectar núcleo";
+      case MENU_ENUM_LABEL_VALUE_INPUT_SETTINGS:
+         return "Entrada";
+      case MENU_ENUM_LABEL_VALUE_INPUT_TURBO_PERIOD:
+         return "Período de turbo";
+      case MENU_ENUM_LABEL_VALUE_INPUT_USER_BINDS:
+         return "Asignaciones de entrada del usuario %u";
+      case MENU_ENUM_LABEL_VALUE_JOYPAD_AUTOCONFIG_DIR:
+         return "Carpeta de autoconfiguración de dispositivo de entrada";
+      case MENU_ENUM_LABEL_VALUE_JOYPAD_DRIVER:
+         return "Controlador de joypad";
+      case MENU_ENUM_LABEL_VALUE_KEYBOARD_OVERLAY_PRESET:
+         return "Preajuste de teclado superpuesto";
+      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_SIMPLIFIED:
+         return "Chino (Simplificado)";
+      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_TRADITIONAL:
+         return "Chino (Tradicional)";
+      case MENU_ENUM_LABEL_VALUE_LANG_DUTCH:
+         return "Holandés";
+      case MENU_ENUM_LABEL_VALUE_LANG_ENGLISH:
+         return "Inglés";
+      case MENU_ENUM_LABEL_VALUE_LANG_ESPERANTO:
+         return "Esperanto";
+      case MENU_ENUM_LABEL_VALUE_LANG_FRENCH:
+         return "Francés";
+      case MENU_ENUM_LABEL_VALUE_LANG_GERMAN:
+         return "Alemán";
+      case MENU_ENUM_LABEL_VALUE_LANG_ITALIAN:
+         return "Italiano";
+      case MENU_ENUM_LABEL_VALUE_LANG_JAPANESE:
+         return "Japonés";
+      case MENU_ENUM_LABEL_VALUE_LANG_KOREAN:
+         return "Coreano";
+      case MENU_ENUM_LABEL_VALUE_LANG_PORTUGUESE:
+         return "Portugués";
+      case MENU_ENUM_LABEL_VALUE_LANG_RUSSIAN:
+         return "Ruso";
+      case MENU_ENUM_LABEL_VALUE_LANG_SPANISH:
+         return "Español";
+      case MENU_ENUM_LABEL_VALUE_LEFT_ANALOG:
+         return "Analógico izquierdo";
+      case MENU_ENUM_LABEL_VALUE_LIBRETRO_DIR_PATH:
+         return "Carpeta de núcleos";
+      case MENU_ENUM_LABEL_VALUE_LIBRETRO_INFO_PATH:
+         return "Carpeta de información del núcleo";
+      case MENU_ENUM_LABEL_VALUE_LIBRETRO_LOG_LEVEL:
+         return "Nivel de registro del núcleo";
+      case MENU_ENUM_LABEL_VALUE_LINEAR:
+         return "Lineal";
+      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT:
+         return "Seleccionar archivo";
       case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_HISTORY:
          return "Cargar archivos recientes";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_ENABLE:
-         return "Activar sonido";
-      case MENU_ENUM_LABEL_VALUE_FPS_SHOW:
-         return "Mostrar velocidad de fotogramas";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_MUTE:
-         return "Silenciar sonido";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_VOLUME:
-         return "Volumen de sonido (dB)";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_SYNC:
-         return "Activar sincronía de sonido";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_RATE_CONTROL_DELTA:
-         return "Delta de control de frecuencia de sonido";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_NUM_PASSES:
-         return "Pasadas del shader";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_SHA1:
-         return "SHA1";
-      case MENU_ENUM_LABEL_VALUE_CONFIGURATIONS:
-         return "Cargar configuración";
-      case MENU_ENUM_LABEL_VALUE_REWIND_GRANULARITY:
-         return "Nivel de detalle del rebobinado";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_LOAD:
-         return "Cargar archivo de reasignación";
-      case MENU_ENUM_LABEL_VALUE_CUSTOM_RATIO:
-         return "Proporción personalizada";
-      case MENU_ENUM_LABEL_VALUE_USE_THIS_DIRECTORY:
-         return "(Usar esta carpeta)";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_START_CONTENT:
-         return "Ejecutar contenido";
-      case MENU_ENUM_LABEL_VALUE_DISK_OPTIONS: /* UPDATE/FIXME */
-         return "Opciones del disco del núcleo";
-      case MENU_ENUM_LABEL_VALUE_CORE_OPTIONS:
-         return "Opciones";
-      case MENU_ENUM_LABEL_VALUE_CORE_CHEAT_OPTIONS: /* UPDATE/FIXME */
-         return "Opciones de trucos del núcleo";
-      case MENU_ENUM_LABEL_VALUE_CHEAT_FILE_LOAD:
-         return "Cargar archivo de trucos";
-      case MENU_ENUM_LABEL_VALUE_CHEAT_FILE_SAVE_AS:
-         return "Guardar archivo de trucos como...";
-      case MENU_ENUM_LABEL_VALUE_CORE_COUNTERS:
-         return "Contadores del núcleo";
-      case MENU_ENUM_LABEL_VALUE_TAKE_SCREENSHOT:
-         return "Capturar pantalla";
-      case MENU_ENUM_LABEL_VALUE_RESUME:
-         return "Reanudar";
-      case MENU_ENUM_LABEL_VALUE_DISK_INDEX:
-         return "Índice del disco";
-      case MENU_ENUM_LABEL_VALUE_FRONTEND_COUNTERS:
-         return "Contadores del frontend";
-      case MENU_ENUM_LABEL_VALUE_DISK_IMAGE_APPEND:
-         return "Asignar imagen de disco";
-      case MENU_ENUM_LABEL_VALUE_DISK_CYCLE_TRAY_STATUS:
-         return "Estado de la bandeja del disco";
-      case MENU_ENUM_LABEL_VALUE_NO_PLAYLIST_ENTRIES_AVAILABLE:
-         return "No hay listas de reproducción.";
+      case MENU_ENUM_LABEL_VALUE_LOAD_STATE:
+         return "Carga rápida";
+      case MENU_ENUM_LABEL_VALUE_LOCATION_ALLOW:
+         return "Permitir ubicación";
+      case MENU_ENUM_LABEL_VALUE_LOCATION_DRIVER:
+         return "Controlador de ubicación";
+      case MENU_ENUM_LABEL_VALUE_LOGGING_SETTINGS:
+         return "Registros";
+      case MENU_ENUM_LABEL_VALUE_LOG_VERBOSITY:
+         return "Verbosidad del registro";
+      case MENU_ENUM_LABEL_VALUE_MAIN_MENU:
+         return "Menú principal";
+      case MENU_ENUM_LABEL_VALUE_MANAGEMENT:
+         return "Ajustes de bases de datos";
+      case MENU_ENUM_LABEL_VALUE_MENU_DRIVER:
+         return "Controlador de menú";
+      case MENU_ENUM_LABEL_VALUE_MENU_FILE_BROWSER_SETTINGS:
+         return "Navegador de archivos del menú";
+      case MENU_ENUM_LABEL_VALUE_MENU_SETTINGS:
+         return "Menú";
+      case MENU_ENUM_LABEL_VALUE_MENU_WALLPAPER:
+         return "Fondo del menú";
+      case MENU_ENUM_LABEL_VALUE_MISSING:
+         return "Desaparecido";
+      case MENU_ENUM_LABEL_VALUE_MOUSE_ENABLE:
+         return "Soporte para teclado";
+      case MENU_ENUM_LABEL_VALUE_MULTIMEDIA_SETTINGS:
+         return "Multimedia";
+      case MENU_ENUM_LABEL_VALUE_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
+         return "Filtrar por extensiones compatibles"; /* TODO/FIXME - rewrite */
+      case MENU_ENUM_LABEL_VALUE_NAVIGATION_WRAPAROUND:
+         return "Seguir navegación";
+      case MENU_ENUM_LABEL_VALUE_NEAREST:
+         return "Más cercano";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT: /* TODO: Original string changed */
+         return "Intercambiar entrada en red";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_DELAY_FRAMES:
+         return "Retraso de fotogramas en red";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE:
+         return "Activar juego en red";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS: /* TODO: Original string changed */
+         return "Dirección IP";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_MODE:
+         return "Activar cliente en red";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_NICKNAME:
+         return "Nombre de usuario";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE:
+         return "Permitir espectadores en red";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT:
+         return "Puerto TCP/UDP para juego en red";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_ENABLE:
+         return "Comandos de red";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_PORT:
+         return "Puerto de comandos de red";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_REMOTE_ENABLE:
+         return "Mando en red";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_SETTINGS:
+         return "Red";
+      case MENU_ENUM_LABEL_VALUE_NO:
+         return "No";
+      case MENU_ENUM_LABEL_VALUE_NONE:
+         return "Ninguno";
+      case MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE:
+         return "No disponible";
+      case MENU_ENUM_LABEL_VALUE_NO_CORE:
+         return "Sin núcleo";
+      case MENU_ENUM_LABEL_VALUE_NO_CORES_AVAILABLE:
+         return "No hay núcleos.";
       case MENU_ENUM_LABEL_VALUE_NO_CORE_INFORMATION_AVAILABLE:
          return "No hay información del núcleo.";
       case MENU_ENUM_LABEL_VALUE_NO_CORE_OPTIONS_AVAILABLE:
          return "No hay opciones del núcleo.";
-      case MENU_ENUM_LABEL_VALUE_NO_CORES_AVAILABLE:
-         return "No hay núcleos.";
-      case MENU_ENUM_LABEL_VALUE_NO_CORE:
-         return "Sin núcleo";
-      case MENU_ENUM_LABEL_VALUE_DATABASE_MANAGER:
-         return "Gestor de bases de datos";
-      case MENU_ENUM_LABEL_VALUE_CURSOR_MANAGER:
-         return "Gestor de cursores";
-      case MENU_ENUM_LABEL_VALUE_MAIN_MENU:
-         return "Menú principal"; 
-      case MENU_ENUM_LABEL_VALUE_SETTINGS:
-         return "Ajustes";
-      case MENU_ENUM_LABEL_VALUE_QUIT_RETROARCH:
-         return "Abandonar RetroArch";
-      case MENU_ENUM_LABEL_VALUE_SHUTDOWN:
-         return "Apagar";
-      case MENU_ENUM_LABEL_VALUE_REBOOT:
-         return "Reiniciar";
-      case MENU_ENUM_LABEL_VALUE_HELP:
-         return "Ayuda";
-      case MENU_ENUM_LABEL_VALUE_SAVE_NEW_CONFIG:
-         return "Guardar configuración nueva";
-      case MENU_ENUM_LABEL_VALUE_RESTART_CONTENT:
-         return "Reiniciar";
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_LIST:
-         return "Actualizador de núcleos";
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_BUILDBOT_URL:
-         return "URL de núcleos de Buildbot";
-      case MENU_ENUM_LABEL_VALUE_BUILDBOT_ASSETS_URL:
-         return "URL de recursos de Buildbot";
-      case MENU_ENUM_LABEL_VALUE_NAVIGATION_WRAPAROUND:
-         return "Seguir navegación";
-      case MENU_ENUM_LABEL_VALUE_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
-         return "Filtrar por extensiones compatibles"; /* TODO/FIXME - rewrite */
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
-         return "Extraer automáticamente el archivo descargado";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFORMATION:
-         return "Información del sistema";
-      case MENU_ENUM_LABEL_VALUE_ACHIEVEMENT_LIST:
-         return "Lista de logros";
-      case MENU_ENUM_LABEL_VALUE_ONLINE_UPDATER:
-         return "Actualizador en línea";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFORMATION:
-         return "Información del núcleo";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NOT_FOUND:
-         return "No se ha encontrado la carpeta.";
+      case MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE:
+         return "No hay información disponible.";
       case MENU_ENUM_LABEL_VALUE_NO_ITEMS:
          return "No hay elementos.";
-      case MENU_ENUM_LABEL_VALUE_CORE_LIST:
-         return "Cargar núcleo";
-      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT:
-         return "Seleccionar archivo";
-      case MENU_ENUM_LABEL_VALUE_CLOSE_CONTENT:
-         return "Cerrar";
-      case MENU_ENUM_LABEL_VALUE_MANAGEMENT:
-         return "Ajustes de bases de datos";
-      case MENU_ENUM_LABEL_VALUE_SAVE_STATE:
-         return "Guardado rápido";
-      case MENU_ENUM_LABEL_VALUE_LOAD_STATE:
-         return "Carga rápida";
-      case MENU_ENUM_LABEL_VALUE_RESUME_CONTENT:
-         return "Reanudar";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DRIVER:
-         return "Controlador de entrada";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_DRIVER:
-         return "Controlador de sonido";
-      case MENU_ENUM_LABEL_VALUE_JOYPAD_DRIVER:
-         return "Controlador de joypad";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_RESAMPLER_DRIVER:
-         return "Controlador de muestreo de sonido";
-      case MENU_ENUM_LABEL_VALUE_RECORD_DRIVER:
-         return "Controlador de grabación";
-      case MENU_ENUM_LABEL_VALUE_MENU_DRIVER:
-         return "Controlador de menú";
-      case MENU_ENUM_LABEL_VALUE_CAMERA_DRIVER:
-         return "Controlador de cámara";
-      case MENU_ENUM_LABEL_VALUE_LOCATION_DRIVER:
-         return "Controlador de ubicación";
-      case MENU_ENUM_LABEL_VALUE_UNABLE_TO_READ_COMPRESSED_FILE:
-         return "No se ha podido leer el archivo comprimido.";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_SCALE:
-         return "Escala de superposición";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_PRESET:
-         return "Preajuste de superposición";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_LATENCY:
-         return "Retraso de sonido (ms)";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_DEVICE:
-         return "Controlador de sonido";
-      case MENU_ENUM_LABEL_VALUE_KEYBOARD_OVERLAY_PRESET:
-         return "Preajuste de teclado superpuesto";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_OPACITY:
-         return "Opacidad de la superposición";
-      case MENU_ENUM_LABEL_VALUE_MENU_WALLPAPER:
-         return "Fondo del menú";
-      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPER:
-         return "Fondo de pantalla dinámico";
-      case MENU_ENUM_LABEL_VALUE_CORE_INPUT_REMAPPING_OPTIONS:
-         return "Opciones de entrada del núcleo";
-      case MENU_ENUM_LABEL_VALUE_SHADER_OPTIONS:
-         return "Opciones de shaders";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PARAMETERS:
-         return "Previsualizar parámetros de shaders";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_PARAMETERS:
-         return "Parámetros de shaders del menú";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_AS:
-         return "Guardar preajuste de shaders como...";
+      case MENU_ENUM_LABEL_VALUE_NO_PERFORMANCE_COUNTERS:
+         return "No hay contadores de rendimiento.";
+      case MENU_ENUM_LABEL_VALUE_NO_PLAYLIST_ENTRIES_AVAILABLE:
+         return "No hay listas de reproducción.";
+      case MENU_ENUM_LABEL_VALUE_NO_SETTINGS_FOUND:
+         return "No se ha encontrado una configuración.";
       case MENU_ENUM_LABEL_VALUE_NO_SHADER_PARAMETERS:
          return "No hay parámetros de shaders.";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET:
-         return "Cargar preajuste de shaders";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER:
-         return "Filtro de vídeo";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_DSP_PLUGIN:
-         return "Plugin DSP de sonido";
-      case MENU_ENUM_LABEL_VALUE_SECONDS:
-         return "segundos";
       case MENU_ENUM_LABEL_VALUE_OFF: /* Not changed. Would be "SÍ" */
          return "OFF";
       case MENU_ENUM_LABEL_VALUE_ON: /* Not changed. Would be "NO" */
          return "ON";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_ASSETS:
-         return "Actualizar recursos";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_LAKKA:
-         return "Actualizar Lakka";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_CHEATS:
-         return "Actualizar trucos";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_AUTOCONFIG_PROFILES:
-         return "Actualizar perfiles de autoconfiguración";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_DATABASES:
-         return "Actualizar bases de datos";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_OVERLAYS:
-         return "Actualizar superposiciones";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_CG_SHADERS:
-         return "Actualizar shaders Cg";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_GLSL_SHADERS:
-         return "Actualizar shaders GLSL";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NAME:
-         return "Nombre del núcleo";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_LABEL:
-         return "Etiqueta del núcleo";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_NAME:
-         return "Nombre del sistema";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_MANUFACTURER:
-         return "Fabricante del sistema";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CATEGORIES:
-         return "Categorías";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_AUTHORS:
-         return "Autores";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_PERMISSIONS:
-         return "Permisos";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_LICENSES:
-         return "Licencia(s)";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SUPPORTED_EXTENSIONS:
-         return "Extensiones compatibles";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_FIRMWARE:
-         return "Firmware";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NOTES:
-         return "Notas del núcleo";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_BUILD_DATE:
-         return "Fecha de compilación";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GIT_VERSION:
-         return "Versión de Git";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CPU_FEATURES:
-         return "Características de CPU";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_IDENTIFIER:
-         return "Identificador del frontend";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_NAME:
-         return "Nombre del frontend";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_OS:
-         return "S.O. del frontend";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RETRORATING_LEVEL:
-         return "Nivel de RetroRating";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE:
-         return "Fuente de alimentación";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_NO_SOURCE:
-         return "No hay una fuente";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGING:
-         return "Cargando";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGED:
-         return "Cargada";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_DISCHARGING:
-         return "Descargando";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VIDEO_CONTEXT_DRIVER:
-         return "Controlador de contexto de vídeo";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_WIDTH:
-         return "Mostrar ancho métrico (mm)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_HEIGHT:
-         return "Mostrar alto métrico (mm)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_DPI:
-         return "Mostrar PPP métricos";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBRETRODB_SUPPORT:
-         return "Soporte de LibretroDB";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OVERLAY_SUPPORT:
-         return "Soporte de superposiciones";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COMMAND_IFACE_SUPPORT:
-         return "Soporte de interfaz de comandos";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETWORK_REMOTE_SUPPORT:
-         return "Soporte de mando en red";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETWORK_COMMAND_IFACE_SUPPORT:
-         return "Soporte de interfaz de comandos en red";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COCOA_SUPPORT:
-         return "Soporte de Cocoa";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RPNG_SUPPORT:
-         return "Soporte de PNG (RPNG)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_SUPPORT:
-         return "Soporte de SDL1.2";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL2_SUPPORT:
-         return "Soporte de SDL2";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VULKAN_SUPPORT:
-         return "Soporte Vulkan";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGL_SUPPORT:
-         return "Soporte de OpenGL";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGLES_SUPPORT:
-         return "Soporte de OpenGL ES";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_THREADING_SUPPORT:
-         return "Soporte de hilos";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_KMS_SUPPORT:
-         return "Soporte de KMS/EGL";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_UDEV_SUPPORT:
-         return "Soporte de Udev";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENVG_SUPPORT:
-         return "Soporte de OpenVG";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_EGL_SUPPORT:
-         return "Soporte de EGL";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_X11_SUPPORT:
-         return "Soporte de X11";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_WAYLAND_SUPPORT:
-         return "Soporte de Wayland";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XVIDEO_SUPPORT:
-         return "Soporte de XVideo";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ALSA_SUPPORT:
-         return "Soporte de ALSA";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OSS_SUPPORT:
-         return "Soporte de OSS";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENAL_SUPPORT:
-         return "Soporte de OpenAL";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENSL_SUPPORT:
-         return "Soporte de OpenSL";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RSOUND_SUPPORT:
-         return "Soporte de RSound";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ROARAUDIO_SUPPORT:
-         return "Soporte de RoarAudio";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_JACK_SUPPORT:
-         return "Soporte de JACK";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PULSEAUDIO_SUPPORT:
-         return "Soporte de PulseAudio";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DSOUND_SUPPORT:
-         return "Soporte de DirectSound";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XAUDIO2_SUPPORT:
-         return "Soporte de XAudio2";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ZLIB_SUPPORT:
-         return "Soporte de Zlib";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_7ZIP_SUPPORT:
-         return "Soporte de 7zip";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DYLIB_SUPPORT:
-         return "Soporte de librerías dinámicas";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CG_SUPPORT:
-         return "Soporte de Cg";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GLSL_SUPPORT:
-         return "Soporte de GLSL";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_HLSL_SUPPORT:
-         return "Soporte de HLSL";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBXML2_SUPPORT:
-         return "Soporte de parseo XML libxml2";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_IMAGE_SUPPORT:
-         return "Soporte de imágenes SDL";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FBO_SUPPORT:
-         return "Soporte de render-to-texture OpenGL/Direct3D (shaders multipasos)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DYNAMIC_SUPPORT:
-         return "Carga dinámica en tiempo real de librería libretro";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FFMPEG_SUPPORT:
-         return "Soporte de FFmpeg";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CORETEXT_SUPPORT:
-         return "Soporte de CoreText";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FREETYPE_SUPPORT:
-         return "Soporte de FreeType";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETPLAY_SUPPORT:
-         return "Soporte de juego en red (peer-to-peer)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PYTHON_SUPPORT:
-         return "Soporte de Python (soporte de scripts para shaders)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_V4L2_SUPPORT:
-         return "Soporte de Video4Linux2";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBUSB_SUPPORT:
-         return "Soporte de Libusb";
-      case MENU_ENUM_LABEL_VALUE_YES:
-         return "Sí";
-      case MENU_ENUM_LABEL_VALUE_NO:
-         return "No";
-      case MENU_ENUM_LABEL_VALUE_BACK:
-         return "BACK";
-      case MENU_ENUM_LABEL_VALUE_SCREEN_RESOLUTION:
-         return "Resolución de pantalla";
-      case MENU_ENUM_LABEL_VALUE_DISABLED:
-         return "Desactivado";
+      case MENU_ENUM_LABEL_VALUE_ONLINE_UPDATER:
+         return "Actualizador en línea";
+      case MENU_ENUM_LABEL_VALUE_ONSCREEN_DISPLAY_SETTINGS:
+         return "Textos en pantalla (OSD)";
+      case MENU_ENUM_LABEL_VALUE_OPTIONAL:
+         return "Opcional";
+      case MENU_ENUM_LABEL_VALUE_OSK_OVERLAY_DIRECTORY:
+         return "Carpeta de teclados superpuestos";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_DIRECTORY:
+         return "Carpeta de superposiciones";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_OPACITY:
+         return "Opacidad de la superposición";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_PRESET:
+         return "Preajuste de superposición";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_SCALE:
+         return "Escala de superposición";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_SETTINGS:
+         return "Superposición";
+      case MENU_ENUM_LABEL_VALUE_PAL60_ENABLE:
+         return "Usar modo PAL60";
+      case MENU_ENUM_LABEL_VALUE_PAUSE_LIBRETRO:
+         return "Pausar al activar el menú";
+      case MENU_ENUM_LABEL_VALUE_PAUSE_NONACTIVE:
+         return "Detenerse en segundo plano";
+      case MENU_ENUM_LABEL_VALUE_PERFCNT_ENABLE:
+         return "Contadores de rendimiento";
+      case MENU_ENUM_LABEL_VALUE_PLAYLIST_DIRECTORY:
+         return "Carpeta de listas de reproducción";
+      case MENU_ENUM_LABEL_VALUE_PLAYLIST_SETTINGS:
+         return "Lista de reproducción";
+      case MENU_ENUM_LABEL_VALUE_POINTER_ENABLE:
+         return "Soporte táctil";
       case MENU_ENUM_LABEL_VALUE_PORT:
          return "Puerto";
-      case MENU_ENUM_LABEL_VALUE_NONE:
-         return "Ninguno";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DEVELOPER:
-         return "Desarrollador";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_PUBLISHER:
-         return "Distribuidora";
+      case MENU_ENUM_LABEL_VALUE_PRESENT:
+         return "Presente";
+      case MENU_ENUM_LABEL_VALUE_QUIT_RETROARCH:
+         return "Abandonar RetroArch";
       case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DESCRIPTION:
          return "Descripción";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DEVELOPER:
+         return "Desarrollador";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_FRANCHISE:
+         return "Franquicia";
       case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_GENRE:
          return "Género";
       case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_NAME:
          return "Nombre";
       case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ORIGIN:
          return "Origen";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_FRANCHISE:
-         return "Franquicia";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_PUBLISHER:
+         return "Distribuidora";
       case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_MONTH:
          return "Mes de lanzamiento";
       case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_YEAR:
          return "Año de lanzamiento";
-      case MENU_ENUM_LABEL_VALUE_TRUE:
-         return "Activado";
-      case MENU_ENUM_LABEL_VALUE_FALSE:
-         return "Desactivado";
-      case MENU_ENUM_LABEL_VALUE_MISSING:
-         return "Desaparecido";
-      case MENU_ENUM_LABEL_VALUE_PRESENT:
-         return "Presente";
-      case MENU_ENUM_LABEL_VALUE_OPTIONAL:
-         return "Opcional";
-      case MENU_ENUM_LABEL_VALUE_REQUIRED:
-         return "Necesario";
-      case MENU_ENUM_LABEL_VALUE_STATUS:
-         return "Estado";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_SETTINGS:
-         return "Sonido";
-      case MENU_ENUM_LABEL_VALUE_INPUT_SETTINGS:
-         return "Entrada";
-      case MENU_ENUM_LABEL_VALUE_ONSCREEN_DISPLAY_SETTINGS:
-         return "Textos en pantalla (OSD)";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_SETTINGS:
-         return "Superposición";
-      case MENU_ENUM_LABEL_VALUE_MENU_SETTINGS:
-         return "Menú";
-      case MENU_ENUM_LABEL_VALUE_MULTIMEDIA_SETTINGS:
-         return "Multimedia";
-      case MENU_ENUM_LABEL_VALUE_USER_INTERFACE_SETTINGS:
-         return "Interfaz de usuario";
-      case MENU_ENUM_LABEL_VALUE_MENU_FILE_BROWSER_SETTINGS:
-         return "Navegador de archivos del menú";
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_SETTINGS:
-         return "Actualizador";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_SETTINGS:
-         return "Red";
-      case MENU_ENUM_LABEL_VALUE_PLAYLIST_SETTINGS:
-         return "Lista de reproducción";
-      case MENU_ENUM_LABEL_VALUE_USER_SETTINGS:
-         return "Usuario";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_SETTINGS:
-         return "Carpeta";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_SHA1:
+         return "SHA1";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_START_CONTENT:
+         return "Ejecutar contenido";
+      case MENU_ENUM_LABEL_VALUE_REBOOT:
+         return "Reiniciar";
+      case MENU_ENUM_LABEL_VALUE_RECORDING_CONFIG_DIRECTORY:
+         return "Carpeta de configuración de grabación";
+      case MENU_ENUM_LABEL_VALUE_RECORDING_OUTPUT_DIRECTORY:
+         return "Carpeta de salida de grabación";
       case MENU_ENUM_LABEL_VALUE_RECORDING_SETTINGS:
          return "Grabación";
-      case MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE:
-         return "No hay información disponible.";
-      case MENU_ENUM_LABEL_VALUE_INPUT_USER_BINDS:
-         return "Asignaciones de entrada del usuario %u";
-      case MENU_ENUM_LABEL_VALUE_LANG_ENGLISH:
-         return "Inglés";
-      case MENU_ENUM_LABEL_VALUE_LANG_JAPANESE:
-         return "Japonés";
-      case MENU_ENUM_LABEL_VALUE_LANG_FRENCH:
-         return "Francés";
-      case MENU_ENUM_LABEL_VALUE_LANG_SPANISH:
-         return "Español";
-      case MENU_ENUM_LABEL_VALUE_LANG_GERMAN:
-         return "Alemán";
-      case MENU_ENUM_LABEL_VALUE_LANG_ITALIAN:
-         return "Italiano";
-      case MENU_ENUM_LABEL_VALUE_LANG_DUTCH:
-         return "Holandés";
-      case MENU_ENUM_LABEL_VALUE_LANG_PORTUGUESE:
-         return "Portugués";
-      case MENU_ENUM_LABEL_VALUE_LANG_RUSSIAN:
-         return "Ruso";
-      case MENU_ENUM_LABEL_VALUE_LANG_KOREAN:
-         return "Coreano";
-      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_TRADITIONAL:
-         return "Chino (Tradicional)";
-      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_SIMPLIFIED:
-         return "Chino (Simplificado)";
-      case MENU_ENUM_LABEL_VALUE_LANG_ESPERANTO:
-         return "Esperanto";
-      case MENU_ENUM_LABEL_VALUE_LEFT_ANALOG:
-         return "Analógico izquierdo";
+      case MENU_ENUM_LABEL_VALUE_RECORD_CONFIG:
+         return "Configuración de grabación";
+      case MENU_ENUM_LABEL_VALUE_RECORD_DRIVER:
+         return "Controlador de grabación";
+      case MENU_ENUM_LABEL_VALUE_RECORD_ENABLE:
+         return "Activar grabación";
+      case MENU_ENUM_LABEL_VALUE_RECORD_PATH:
+         return "Carpeta de salida";
+      case MENU_ENUM_LABEL_VALUE_RECORD_USE_OUTPUT_DIRECTORY:
+         return "Usar carpeta de salida";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_LOAD:
+         return "Cargar archivo de reasignación";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_CORE:
+         return "Guardar archivo de reasignación del núcleo";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_GAME:
+         return "Guardar archivo de reasignación del juego";
+      case MENU_ENUM_LABEL_VALUE_REQUIRED:
+         return "Necesario";
+      case MENU_ENUM_LABEL_VALUE_RESTART_CONTENT:
+         return "Reiniciar";
+      case MENU_ENUM_LABEL_VALUE_RESTART_RETROARCH:
+         return "Reiniciar RetroArch";
+      case MENU_ENUM_LABEL_VALUE_RESUME:
+         return "Reanudar";
+      case MENU_ENUM_LABEL_VALUE_RESUME_CONTENT:
+         return "Reanudar";
+      case MENU_ENUM_LABEL_VALUE_RETROKEYBOARD:
+         return "RetroKeyboard";
+      case MENU_ENUM_LABEL_VALUE_RETROPAD:
+         return "RetroPad";
+      case MENU_ENUM_LABEL_VALUE_REWIND_ENABLE:
+         return "Activar rebobinado";
+      case MENU_ENUM_LABEL_VALUE_REWIND_GRANULARITY:
+         return "Nivel de detalle del rebobinado";
+      case MENU_ENUM_LABEL_VALUE_REWIND_SETTINGS:
+         return "Rebobinado";
+      case MENU_ENUM_LABEL_VALUE_RGUI_BROWSER_DIRECTORY:
+         return "Carpeta del navegador de archivos";
+      case MENU_ENUM_LABEL_VALUE_RGUI_CONFIG_DIRECTORY:
+         return "Carpeta de configuración";
+      case MENU_ENUM_LABEL_VALUE_RGUI_SHOW_START_SCREEN:
+         return "Mostrar pantalla de inicio";
       case MENU_ENUM_LABEL_VALUE_RIGHT_ANALOG:
          return "Analógico derecho";
-      case MENU_ENUM_LABEL_VALUE_INPUT_HOTKEY_BINDS:
-         return "Asignaciones de teclas rápidas";
-      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_SETTINGS:
-         return "Aumento de fotogramas";
+      case MENU_ENUM_LABEL_VALUE_SAVEFILE_DIRECTORY:
+         return "Carpeta de partidas guardadas";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_INDEX:
+         return "Indizar automáticamente guardados rápidos";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_LOAD:
+         return "Cargar guardado rápido automáticamente";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_SAVE:
+         return "Guardado rápido automático";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_DIRECTORY:
+         return "Carpeta de guardados rápidos";
+      case MENU_ENUM_LABEL_VALUE_SAVE_NEW_CONFIG:
+         return "Guardar configuración nueva";
+      case MENU_ENUM_LABEL_VALUE_SAVE_STATE:
+         return "Guardado rápido";
+      case MENU_ENUM_LABEL_VALUE_SAVING_SETTINGS:
+         return "Guardado";
+      case MENU_ENUM_LABEL_VALUE_SCREENSHOT_DIRECTORY:
+         return "Carpeta de capturas de pantalla";
+      case MENU_ENUM_LABEL_VALUE_SCREEN_RESOLUTION:
+         return "Resolución de pantalla";
       case MENU_ENUM_LABEL_VALUE_SEARCH:
          return "Buscar:";
-      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_IMAGE_VIEWER:
-         return "Usar visualizador de imágenes integrado";
-      case MENU_ENUM_LABEL_VALUE_ENABLE:
-         return "Activar";
+      case MENU_ENUM_LABEL_VALUE_SECONDS:
+         return "segundos";
+      case MENU_ENUM_LABEL_VALUE_SETTINGS:
+         return "Ajustes";
+      case MENU_ENUM_LABEL_VALUE_SHADER:
+         return "Shader";
+      case MENU_ENUM_LABEL_VALUE_SHADER_APPLY_CHANGES:
+         return "Aplicar cambios en shaders";
+      case MENU_ENUM_LABEL_VALUE_SHADER_OPTIONS:
+         return "Opciones de shaders";
+      case MENU_ENUM_LABEL_VALUE_SHOW_ADVANCED_SETTINGS:
+         return "Mostrar ajustes avanzados";
+      case MENU_ENUM_LABEL_VALUE_SHUTDOWN:
+         return "Apagar";
+      case MENU_ENUM_LABEL_VALUE_SLOWMOTION_RATIO:
+         return "Cantidad de velocidad reducida";
+      case MENU_ENUM_LABEL_VALUE_SORT_SAVEFILES_ENABLE:
+         return "Ordenar partidas guardadas por carpetas";
+      case MENU_ENUM_LABEL_VALUE_SORT_SAVESTATES_ENABLE:
+         return "Ordenar guardados rápidos por carpetas";
       case MENU_ENUM_LABEL_VALUE_START_CORE:
          return "Iniciar núcleo";
-      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR:
-         return "Tipo de retardo";
+      case MENU_ENUM_LABEL_VALUE_STATUS:
+         return "Estado";
+      case MENU_ENUM_LABEL_VALUE_STDIN_CMD_ENABLE:
+         return "Comandos stdin";
+      case MENU_ENUM_LABEL_VALUE_SUSPEND_SCREENSAVER_ENABLE:
+         return "Suspender salvapantallas";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_BGM_ENABLE:
+         return "Activar música del sistema";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_DIRECTORY:
+         return "Carpeta de sistema/BIOS";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFORMATION:
+         return "Información del sistema";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_7ZIP_SUPPORT:
+         return "Soporte de 7zip";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ALSA_SUPPORT:
+         return "Soporte de ALSA";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_BUILD_DATE:
+         return "Fecha de compilación";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CG_SUPPORT:
+         return "Soporte de Cg";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COCOA_SUPPORT:
+         return "Soporte de Cocoa";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COMMAND_IFACE_SUPPORT:
+         return "Soporte de interfaz de comandos";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CORETEXT_SUPPORT:
+         return "Soporte de CoreText";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CPU_FEATURES:
+         return "Características de CPU";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_DPI:
+         return "Mostrar PPP métricos";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_HEIGHT:
+         return "Mostrar alto métrico (mm)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_WIDTH:
+         return "Mostrar ancho métrico (mm)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DSOUND_SUPPORT:
+         return "Soporte de DirectSound";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DYLIB_SUPPORT:
+         return "Soporte de librerías dinámicas";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DYNAMIC_SUPPORT:
+         return "Carga dinámica en tiempo real de librería libretro";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_EGL_SUPPORT:
+         return "Soporte de EGL";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FBO_SUPPORT:
+         return "Soporte de render-to-texture OpenGL/Direct3D (shaders multipasos)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FFMPEG_SUPPORT:
+         return "Soporte de FFmpeg";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FREETYPE_SUPPORT:
+         return "Soporte de FreeType";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_IDENTIFIER:
+         return "Identificador del frontend";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_NAME:
+         return "Nombre del frontend";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_OS:
+         return "S.O. del frontend";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GIT_VERSION:
+         return "Versión de Git";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GLSL_SUPPORT:
+         return "Soporte de GLSL";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_HLSL_SUPPORT:
+         return "Soporte de HLSL";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_JACK_SUPPORT:
+         return "Soporte de JACK";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_KMS_SUPPORT:
+         return "Soporte de KMS/EGL";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBRETRODB_SUPPORT:
+         return "Soporte de LibretroDB";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBUSB_SUPPORT:
+         return "Soporte de Libusb";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBXML2_SUPPORT:
+         return "Soporte de parseo XML libxml2";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETPLAY_SUPPORT:
+         return "Soporte de juego en red (peer-to-peer)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETWORK_COMMAND_IFACE_SUPPORT:
+         return "Soporte de interfaz de comandos en red";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETWORK_REMOTE_SUPPORT:
+         return "Soporte de mando en red";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENAL_SUPPORT:
+         return "Soporte de OpenAL";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGLES_SUPPORT:
+         return "Soporte de OpenGL ES";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGL_SUPPORT:
+         return "Soporte de OpenGL";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENSL_SUPPORT:
+         return "Soporte de OpenSL";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENVG_SUPPORT:
+         return "Soporte de OpenVG";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OSS_SUPPORT:
+         return "Soporte de OSS";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OVERLAY_SUPPORT:
+         return "Soporte de superposiciones";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE:
+         return "Fuente de alimentación";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGED:
+         return "Cargada";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGING:
+         return "Cargando";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_DISCHARGING:
+         return "Descargando";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_NO_SOURCE:
+         return "No hay una fuente";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PULSEAUDIO_SUPPORT:
+         return "Soporte de PulseAudio";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PYTHON_SUPPORT:
+         return "Soporte de Python (soporte de scripts para shaders)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RETRORATING_LEVEL:
+         return "Nivel de RetroRating";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ROARAUDIO_SUPPORT:
+         return "Soporte de RoarAudio";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RPNG_SUPPORT:
+         return "Soporte de PNG (RPNG)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RSOUND_SUPPORT:
+         return "Soporte de RSound";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL2_SUPPORT:
+         return "Soporte de SDL2";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_IMAGE_SUPPORT:
+         return "Soporte de imágenes SDL";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_SUPPORT:
+         return "Soporte de SDL1.2";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_THREADING_SUPPORT:
+         return "Soporte de hilos";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_UDEV_SUPPORT:
+         return "Soporte de Udev";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_V4L2_SUPPORT:
+         return "Soporte de Video4Linux2";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VIDEO_CONTEXT_DRIVER:
+         return "Controlador de contexto de vídeo";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VULKAN_SUPPORT:
+         return "Soporte Vulkan";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_WAYLAND_SUPPORT:
+         return "Soporte de Wayland";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_X11_SUPPORT:
+         return "Soporte de X11";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XAUDIO2_SUPPORT:
+         return "Soporte de XAudio2";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XVIDEO_SUPPORT:
+         return "Soporte de XVideo";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ZLIB_SUPPORT:
+         return "Soporte de Zlib";
+      case MENU_ENUM_LABEL_VALUE_TAKE_SCREENSHOT:
+         return "Capturar pantalla";
+      case MENU_ENUM_LABEL_VALUE_THREADED_DATA_RUNLOOP_ENABLE:
+         return "Buclar datos hilados";
+      case MENU_ENUM_LABEL_VALUE_TIMEDATE_ENABLE:
+         return "Mostrar fecha y hora";
+      case MENU_ENUM_LABEL_VALUE_TITLE_COLOR:
+         return "Color de títulos del menú";
+      case MENU_ENUM_LABEL_VALUE_TRUE:
+         return "Activado";
+      case MENU_ENUM_LABEL_VALUE_UI_COMPANION_ENABLE:
+         return "Activar IU ayudante";
+      case MENU_ENUM_LABEL_VALUE_UI_COMPANION_START_ON_BOOT:
+         return "Ejecutar al inicio la IU ayudante";
+      case MENU_ENUM_LABEL_VALUE_UI_MENUBAR_ENABLE:
+         return "Barra de menús";
+      case MENU_ENUM_LABEL_VALUE_UNABLE_TO_READ_COMPRESSED_FILE:
+         return "No se ha podido leer el archivo comprimido.";
+      case MENU_ENUM_LABEL_VALUE_UNKNOWN:
+         return "Desconocido";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_ASSETS:
+         return "Actualizar recursos";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_AUTOCONFIG_PROFILES:
+         return "Actualizar perfiles de autoconfiguración";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_CG_SHADERS:
+         return "Actualizar shaders Cg";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_CHEATS:
+         return "Actualizar trucos";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_DATABASES:
+         return "Actualizar bases de datos";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_GLSL_SHADERS:
+         return "Actualizar shaders GLSL";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_LAKKA:
+         return "Actualizar Lakka";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_OVERLAYS:
+         return "Actualizar superposiciones";
+      case MENU_ENUM_LABEL_VALUE_USER:
+         return "Usuario";
+      case MENU_ENUM_LABEL_VALUE_USER_INTERFACE_SETTINGS:
+         return "Interfaz de usuario";
+      case MENU_ENUM_LABEL_VALUE_USER_LANGUAGE:
+         return "Idioma";
+      case MENU_ENUM_LABEL_VALUE_USER_SETTINGS:
+         return "Usuario";
+      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_IMAGE_VIEWER:
+         return "Usar visualizador de imágenes integrado";
+      case MENU_ENUM_LABEL_VALUE_USE_THIS_DIRECTORY:
+         return "(Usar esta carpeta)";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ALLOW_ROTATE:
+         return "Permitir rotación";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_AUTO:
+         return "Proporción de aspecto automática";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_INDEX:
+         return "Índice de proporción de aspecto";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_BLACK_FRAME_INSERTION:
+         return "Insertar fotogramas negros";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_CROP_OVERSCAN:
+         return "Recortar Overscan (Reinicio)";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_DISABLE_COMPOSITION:
+         return "Desactivar composición de escritorio";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_DRIVER:
+         return "Controlador de vídeo";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER:
+         return "Filtro de vídeo";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_DIR:
+         return "Carpeta de filtros de vídeo";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_FLICKER:
+         return "Filtro de parpadeo";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_ENABLE:
+         return "Mostrar mensajes en pantalla";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_PATH:
+         return "Fuente de mensajes en pantalla";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_SIZE:
+         return "Tamaño de mensajes en pantalla";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_ASPECT:
+         return "Forzar proporción de aspecto";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_SRGB_DISABLE:
+         return "Forzar anulación del FBO sRGB";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FRAME_DELAY:
+         return "Retraso de fotogramas";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FULLSCREEN:
+         return "Pantalla completa";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_GAMMA:
+         return "Gamma de vídeo";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_RECORD:
+         return "Activar grabación de GPU";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_SCREENSHOT:
+         return "Permitir capturas de pantalla de GPU";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC:
+         return "Sincronía estricta de GPU";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC_FRAMES:
+         return "Fotogramas a sincronizar estrictamente";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_X:
+         return "Posición X de mensajes en pantalla";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_Y:
+         return "Posición Y de mensajes en pantalla";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MONITOR_INDEX:
+         return "Índice del monitor";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_POST_FILTER_RECORD:
+         return "Activar grabación con filtros";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE:
+         return "Frecuencia de actualización";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE_AUTO:
+         return "Frecuencia estimada del monitor";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ROTATION:
+         return "Rotación";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE:
+         return "Escala de ventana";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE_INTEGER:
+         return "Escala integral";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SETTINGS:
+         return "Vídeo";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_DIR:
+         return "Carpeta de shaders de vídeo";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_NUM_PASSES:
+         return "Pasadas del shader";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PARAMETERS:
+         return "Previsualizar parámetros de shaders";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET:
+         return "Cargar preajuste de shaders";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_PARAMETERS:
+         return "Parámetros de shaders del menú";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_AS:
+         return "Guardar preajuste de shaders como...";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHARED_CONTEXT:
+         return "Activar contexto compartido por HW";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SMOOTH:
+         return "Filtrado bilineal por hardware";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SOFT_FILTER:
+         return "Activar filtros por software";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SWAP_INTERVAL:
+         return "Intervalo de alternado de VSync";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_THREADED:
+         return "Vídeo por hilos";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VFILTER:
+         return "Filtro contra parpadeos";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VI_WIDTH:
+         return "Asignar ancho de interfaz visual";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VSYNC:
+         return "VSync/Sincronía vertical";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_WINDOWED_FULLSCREEN:
+         return "Pantalla completa en ventana";
+      case MENU_ENUM_LABEL_VALUE_XMB_ALPHA_FACTOR:
+         return "Transparencia del XMB";
+      case MENU_ENUM_LABEL_VALUE_XMB_FONT:
+         return "Fuente del XMB";
+      case MENU_ENUM_LABEL_VALUE_XMB_SCALE_FACTOR:
+         return "Escala del XMB";
+      case MENU_ENUM_LABEL_VALUE_YES:
+         return "Sí";
       default:
          break;
    }

--- a/intl/msg_hash_fr.c
+++ b/intl/msg_hash_fr.c
@@ -56,1031 +56,1030 @@ const char *msg_hash_to_str_fr(enum msg_hash_enums msg)
 {
    switch (msg)
    {
-      case MSG_PROGRAM:
-         return "RetroArch";
-      case MSG_MOVIE_RECORD_STOPPED:
-         return "Arrêt de l'enregistrement vidéo.";
-      case MSG_MOVIE_PLAYBACK_ENDED:
-         return "Fin de la lecture vidéo";
-      case MSG_AUTOSAVE_FAILED:
-         return "Impossible d'activer l'enregistrement automatique.";
-      case MSG_NETPLAY_FAILED_MOVIE_PLAYBACK_HAS_STARTED:
-         return "Lecture en cours. Impossible d'activer le jeu en réseau.";
-      case MSG_NETPLAY_FAILED:
-         return "Échec de l'initialisation du jeu en réseau";
-      case MSG_LIBRETRO_ABI_BREAK:
-         return "est compilé avec une version différente de la bibliothèque libretro actuelle.";
-      case MSG_REWIND_INIT_FAILED_THREADED_AUDIO:
-         return "L'implémentation utilise audio thread. Impossible d'activer le retour rapide.";
-      case MSG_REWIND_INIT_FAILED:
-         return "Échec de l'initialisation du tampon pour le retour rapide. Cette fonctionnalité sera désactivée.";
-      case MSG_REWIND_INIT:
-         return "Initialisation du tampon pour le retour rapide avec une taille";
-      case MSG_CUSTOM_TIMING_GIVEN:
-         return "Temps personnalisé attribué";
-      case MSG_VIEWPORT_SIZE_CALCULATION_FAILED:
-         return "Échec du calcul de la taille du visuel ! Utilisation des données brutes. Cela ne fonctionnera probablement pas bien ...";
-      case MSG_HW_RENDERED_MUST_USE_POSTSHADED_RECORDING:
-         return "Le core Libretro utilise le rendu matériel. Obligation d'utiliser également l'enregistrement post-shaded.";
-      case MSG_RECORDING_TO:
-         return "Enregistrement vers";
-      case MSG_DETECTED_VIEWPORT_OF:
-         return "Détection du visuel";
-      case MSG_TAKING_SCREENSHOT:
-         return "Réalisation d'une copie d'écran.";
-      case MSG_FAILED_TO_TAKE_SCREENSHOT:
-         return "Échec de la copie d'écran.";
-      case MSG_FAILED_TO_START_RECORDING:
-         return "Échec de l'activation de l'enregistrement.";
-      case MSG_RECORDING_TERMINATED_DUE_TO_RESIZE:
-         return "Enregistrement interrompu à cause du redimensionnement.";
-      case MSG_USING_LIBRETRO_DUMMY_CORE_RECORDING_SKIPPED:
-         return "Utilisation d'un core libretro simple. Ignore l'enregistrement.";
-      case MSG_UNKNOWN:
-         return "Inconnu";
-      case MSG_LOADING_CONTENT_FILE:
-         return "Chargement du contenu";
-      case MSG_RECEIVED:
-         return "Reçu";
-      case MSG_UNRECOGNIZED_COMMAND:
-         return "Commande non reconnue";
-      case MSG_SENDING_COMMAND:
-         return "Envoi commande";
-      case MSG_GOT_INVALID_DISK_INDEX:
-         return "Index du disque invalide.";
-      case MSG_FAILED_TO_REMOVE_DISK_FROM_TRAY:
-         return "Impossible d'éjecter le disque du lecteur.";
-      case MSG_REMOVED_DISK_FROM_TRAY:
-         return "Éjection du disque du lecteur.";
-      case MSG_VIRTUAL_DISK_TRAY:
-         return "Lecteur de disque virtuel.";
-      case MSG_FAILED_TO:
-         return "Échec de";
-      case MSG_TO:
-         return "de";
-      case MSG_SAVING_RAM_TYPE:
-         return "Sauvegarde du type de RAM";
-      case MSG_SAVING_STATE:
-         return "Sauvegarde savestate";
-      case MSG_LOADING_STATE:
-         return "Chargement savestate";
-      case MSG_FAILED_TO_LOAD_MOVIE_FILE:
-         return "Échec du chargement du fichier vidéo";
-      case MSG_FAILED_TO_LOAD_CONTENT:
-         return "Échec du chargement du fichier";
-      case MSG_COULD_NOT_READ_CONTENT_FILE:
-         return "Impossible de lire le contenu du fichier";
-      case MSG_GRAB_MOUSE_STATE:
-         return "Capture la souris";
-      case MSG_PAUSED:
-         return "Pause.";
-      case MSG_UNPAUSED:
-         return "Relancé.";
-      case MSG_FAILED_TO_LOAD_OVERLAY:
-         return "Impossible de charger l'overlay.";
-      case MSG_FAILED_TO_UNMUTE_AUDIO:
-         return "Impossible de remettre le son.";
-      case MSG_AUDIO_MUTED:
-         return "Son coupé.";
-      case MSG_AUDIO_UNMUTED:
-         return "Remise du son.";
-      case MSG_RESET:
-         return "Reset";
-      case MSG_FAILED_TO_LOAD_STATE:
-         return "Impossible de charger la savestate à partir de";
-      case MSG_FAILED_TO_SAVE_STATE_TO:
-         return "Impossible de sauvegarder la savestate vers";
-      case MSG_FAILED_TO_UNDO_LOAD_STATE:
-         return "Aucun savestate de retour arrière trouvé";
-      case MSG_FAILED_TO_UNDO_SAVE_STATE:
-         return "Impossible de sauvegarder les informations de savestate de retour arrière";
-      case MSG_FAILED_TO_SAVE_SRAM:
-         return "Impossible de sauvegarder la SRAM";
-      case MSG_STATE_SIZE:
-         return "Taille savestate";
-      case MSG_FOUND_SHADER:
-         return "Shader trouvé";
-      case MSG_SRAM_WILL_NOT_BE_SAVED:
-         return "SRAM ne sera pas sauvegardée.";
-      case MSG_BLOCKING_SRAM_OVERWRITE:
-         return "Bloque l'écrasement de la SRAM";
-      case MSG_CORE_DOES_NOT_SUPPORT_SAVESTATES:
-         return "Le core ne supporte pas les savestates.";
-      case MSG_SAVED_STATE_TO_SLOT:
-         return "Savestate vers slot";
-      case MSG_SAVED_SUCCESSFULLY_TO:
-         return "Sauvegarde réussie vers";
-      case MSG_BYTES:
-         return "octets";
-      case MSG_CONFIG_DIRECTORY_NOT_SET:
-         return "Répertoire de configuration non défini. Impossible de sauvegarder le nouveau fichier.";
-      case MSG_SKIPPING_SRAM_LOAD:
-         return "Ignore le chargement de la SRAM.";
-      case MSG_APPENDED_DISK:
-         return "Disque fusionné";
-      case MSG_STARTING_MOVIE_PLAYBACK:
-         return "Démarrage de la lecture vidéo.";
-      case MSG_FAILED_TO_REMOVE_TEMPORARY_FILE:
-         return "Impossible de supprimer le fichier temporaire";
-      case MSG_REMOVING_TEMPORARY_CONTENT_FILE:
-         return "Suppression du fichier temporaire";
-      case MSG_LOADED_STATE_FROM_SLOT:
-         return "Chargement du savestate à partir du slot";
-      case MSG_SCANNING_OF_DIRECTORY_FINISHED:
-         return "Analyse des dossiers terminée";
-      case MSG_SCANNING:
-         return "Analyse";
-      case MSG_REDIRECTING_CHEATFILE_TO:
-         return "Redirection du fichier triche vers";
-      case MSG_REDIRECTING_SAVEFILE_TO:
-         return "Redirection de la sauvegarde vers";
-      case MSG_REDIRECTING_SAVESTATE_TO:
-         return "Redirection de la savestate vers";
-      case MSG_SHADER:
-         return "Shader";
-      case MSG_APPLYING_SHADER:
-         return "Application du shader";
-      case MSG_FAILED_TO_APPLY_SHADER:
-         return "Impossible d'appliquer le shader.";
-      case MSG_STARTING_MOVIE_RECORD_TO:
-         return "Démarrage de l'enregistrement vidéo vers";
-      case MSG_FAILED_TO_START_MOVIE_RECORD:
-         return "Impossible de démarrer l'enregistrement vidéo.";
-      case MSG_STATE_SLOT:
-         return "State slot";
-      case MSG_RESTARTING_RECORDING_DUE_TO_DRIVER_REINIT:
-         return "Redémarrage de l'enregistrement à cause de la réinitialisation du pilote.";
-      case MSG_SLOW_MOTION:
-         return "Ralenti.";
-      case MSG_SLOW_MOTION_REWIND:
-         return "Rembobinage ralenti.";
-      case MSG_REWINDING:
-         return "Rembobinage.";
-      case MSG_REWIND_REACHED_END:
-         return "Atteinte de la fin du tampon de rembobinage.";
-      case MSG_CHEEVOS_HARDCORE_MODE_ENABLE:
-         return "Mode matériel activé : savestate et rembobinage sont désactivés.";
-      case MSG_DOWNLOADING:
-         return "Téléchargement";
-      case MSG_EXTRACTING:
-         return "Extraction";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_AUTOLOAD_PREFERRED:
-         return "Charger l'overlay préféré automatiquement";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_CORE_INFO_FILES:
-         return "Mettre à jour les informations des coeurs";
-      case MENU_ENUM_LABEL_VALUE_DOWNLOAD_CORE_CONTENT:
-         return "Télécharger du contenu";
-      case MENU_ENUM_LABEL_VALUE_SCAN_THIS_DIRECTORY:
-         return "<Scanner ce dossier>";
-      case MENU_ENUM_LABEL_VALUE_SCAN_FILE:
-         return "Scanner un fichier";
-      case MENU_ENUM_LABEL_VALUE_SCAN_DIRECTORY:
-         return "Scanner un dossier";
-      case MENU_ENUM_LABEL_VALUE_ADD_CONTENT_LIST:
-         return "Ajouter du contenu";
-      case MENU_ENUM_LABEL_VALUE_INFORMATION_LIST:
-         return "Informations";
-      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_PLAYER:
-         return "Utiliser le lecteur vidéo embarqué";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_SETTINGS:
-         return "Menu rapide";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_CRC32:
-         return "CRC32";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_MD5:
-         return "MD5";
-      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_LIST:
-         return "Charger du contenu";
-      case MENU_ENUM_LABEL_VALUE_LOAD_ARCHIVE:
-         return "Charger l'archive";
-      case MENU_ENUM_LABEL_VALUE_OPEN_ARCHIVE:
-         return "Ouvrir l'archive";
-      case MENU_ENUM_LABEL_VALUE_ASK_ARCHIVE:
-         return "Demander";
-      case MENU_ENUM_LABEL_VALUE_PRIVACY_SETTINGS:
-         return "Confidentialité";
-      case MENU_ENUM_LABEL_VALUE_HORIZONTAL_MENU:
-         return "Horizontal Menu";
-      case MENU_ENUM_LABEL_VALUE_NO_SETTINGS_FOUND:
-         return "Pas de réglages trouvés.";
-      case MENU_ENUM_LABEL_VALUE_NO_PERFORMANCE_COUNTERS:
-         return "Pas de compteurs de performance.";
-      case MENU_ENUM_LABEL_VALUE_DRIVER_SETTINGS:
-         return "Pilotes";
-      case MENU_ENUM_LABEL_VALUE_CONFIGURATION_SETTINGS:
-         return "Configurations";
-      case MENU_ENUM_LABEL_VALUE_CORE_SETTINGS:
-         return "Coeurs";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SETTINGS:
-         return "Vidéo";
-      case MENU_ENUM_LABEL_VALUE_LOGGING_SETTINGS:
-         return "Journaux";
-      case MENU_ENUM_LABEL_VALUE_SAVING_SETTINGS:
-         return "Sauvegardes";
-      case MENU_ENUM_LABEL_VALUE_REWIND_SETTINGS:
-         return "Rembobinage";
-      case MENU_ENUM_LABEL_VALUE_SHADER:
-         return "Shader";
-      case MENU_ENUM_LABEL_VALUE_CHEAT:
-         return "Triche";
-      case MENU_ENUM_LABEL_VALUE_USER:
-         return "Utilisateur";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_BGM_ENABLE:
-         return "Musique du système activée";
-      case MENU_ENUM_LABEL_VALUE_RETROPAD:
-         return "RetroPad";
-      case MENU_ENUM_LABEL_VALUE_RETROKEYBOARD:
-         return "RetroKeyboard";
       case MENU_ENUM_LABEL_AUDIO_BLOCK_FRAMES:
          return "audio_block_frames";
+      case MENU_ENUM_LABEL_CONTENT_HISTORY_SIZE:
+         return "Taille de l'historique";
+      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_LIST:
+         return "Comptes en ligne";
+      case MENU_ENUM_LABEL_VALUE_ADD_CONTENT_LIST:
+         return "Ajouter du contenu";
+      case MENU_ENUM_LABEL_VALUE_ADD_TAB:
+         return "Scanner";
+      case MENU_ENUM_LABEL_VALUE_ARCHIVE_MODE:
+         return "Mode d'ouverture des archives";
+      case MENU_ENUM_LABEL_VALUE_ASK_ARCHIVE:
+         return "Demander";
+      case MENU_ENUM_LABEL_VALUE_ASSETS_DIRECTORY:
+         return "Dossier des assets";
       case MENU_ENUM_LABEL_VALUE_AUDIO_BLOCK_FRAMES:
          return "Block Frames";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_LABEL_SHOW: /* FIXME/UPDATE */
-         return "Afficher les remaps du coeur";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_HIDE_UNBOUND:
-         return "Cacher les remaps non mappés des coeurs";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_ENABLE:
-         return "Afficher les messages d'info";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_PATH:
-         return "Police des messages d'info";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_SIZE:
-         return "Taille du texte des messages";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_X:
-         return "Position X";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_Y:
-         return "Position Y";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SOFT_FILTER:
-         return "Filtre doux activé";
-      case MENU_ENUM_LABEL_VIDEO_FILTER_FLICKER:
-         return "video_filter_flicker";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_FLICKER:
-         return "Filtre anti-scintillement";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_DEVICE:
+         return "Carte son";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_DRIVER:
+         return "Pilote audio";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_DSP_PLUGIN:
+         return "Module DSP";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_ENABLE:
+         return "Activer le son";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_FILTER_DIR:
+         return "Dossier des filtres audio";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_LATENCY:
+         return "Latence audio (ms)";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_MAX_TIMING_SKEW:
+         return "Limite max de l'ajustement";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_MUTE:
+         return "Muet";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_OUTPUT_RATE:
+         return "Fréquence de sortie (KHz)";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_RATE_CONTROL_DELTA:
+         return "Delta du taux de contrôle";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_RESAMPLER_DRIVER:
+         return "Pilote de ré-échantillonage audio";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_SETTINGS:
+         return "Audio";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_SYNC:
+         return "Synchroniser le son";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_VOLUME:
+         return "Volume sonnore (dB)";
+      case MENU_ENUM_LABEL_VALUE_AUTOSAVE_INTERVAL:
+         return "Intervale de sauvegarde SaveRAM";
+      case MENU_ENUM_LABEL_VALUE_AUTO_OVERRIDES_ENABLE:
+         return "Charger les fichiers d'override automatiquement";
+      case MENU_ENUM_LABEL_VALUE_AUTO_REMAPS_ENABLE:
+         return "Charger les fichiers remaps automatiquement";
+      case MENU_ENUM_LABEL_VALUE_BACK:
+         return "Retour";
+      case MENU_ENUM_LABEL_VALUE_BLOCK_SRAM_OVERWRITE:
+         return "Ne pas écraser la SaveRAM en chargeant la savestate";
+      case MENU_ENUM_LABEL_VALUE_BUILDBOT_ASSETS_URL:
+         return "URL du buildbot des assets";
+      case MENU_ENUM_LABEL_VALUE_CACHE_DIRECTORY: /* FIXME/UPDATE */
+         return "Dossier d'extraction";
+      case MENU_ENUM_LABEL_VALUE_CAMERA_ALLOW:
+         return "Autoriser la caméra";
+      case MENU_ENUM_LABEL_VALUE_CAMERA_DRIVER:
+         return "Pilote de caméra";
+      case MENU_ENUM_LABEL_VALUE_CHEAT:
+         return "Triche";
+      case MENU_ENUM_LABEL_VALUE_CHEAT_APPLY_CHANGES:
+         return "Appliquer les changements";
+      case MENU_ENUM_LABEL_VALUE_CHEAT_DATABASE_PATH:
+         return "Dossier des fichiers de triche";
+      case MENU_ENUM_LABEL_VALUE_CHEAT_NUM_PASSES:
+         return "Nombre de passages";
+      case MENU_ENUM_LABEL_VALUE_CLOSE_CONTENT:
+         return "Quitter";
+      case MENU_ENUM_LABEL_VALUE_COLLAPSE_SUBGROUPS_ENABLE:
+         return "Fusionner les sous-groupes";
+      case MENU_ENUM_LABEL_VALUE_CONFIGURATIONS:
+         return "Charger une configuration";
+      case MENU_ENUM_LABEL_VALUE_CONFIGURATION_SETTINGS:
+         return "Configurations";
+      case MENU_ENUM_LABEL_VALUE_CONFIG_SAVE_ON_EXIT:
+         return "Sauver la config en quittant";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_COLLECTION_LIST:
+         return "Collections";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_DATABASE_DIRECTORY:
+         return "Dossier des bases de données de contenus";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_HISTORY_SIZE:
+         return "Taille de l'historique";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_SETTINGS:
+         return "Menu rapide";
+      case MENU_ENUM_LABEL_VALUE_CORE_ASSETS_DIRECTORY:
+         return "Dossier des téléchargements";
+      case MENU_ENUM_LABEL_VALUE_CORE_CHEAT_OPTIONS:
+         return "Triche";
+      case MENU_ENUM_LABEL_VALUE_CORE_ENABLE:
+         return "Afficher le coeur actuel";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFORMATION:
+         return "Informations sur le coeur";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_AUTHORS:
+         return "Auteurs";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CATEGORIES:
+         return "Catégories";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_LABEL:
+         return "Label";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NAME:
+         return "Nom";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NOTES:
+         return "Notes";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_FIRMWARE:
+         return "Firmware";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_LICENSES:
+         return "Licence(s)";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_PERMISSIONS:
+         return "Permissions";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SUPPORTED_EXTENSIONS:
+         return "Extensions supportées";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_MANUFACTURER:
+         return "Fabricant du système";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_NAME:
+         return "Système";
+      case MENU_ENUM_LABEL_VALUE_CORE_INPUT_REMAPPING_OPTIONS:
+         return "Remap d'entrées";
+      case MENU_ENUM_LABEL_VALUE_CORE_LIST:
+         return "Charger un coeur";
+      case MENU_ENUM_LABEL_VALUE_CORE_OPTIONS:
+         return "Options";
+      case MENU_ENUM_LABEL_VALUE_CORE_SETTINGS:
+         return "Coeurs";
+      case MENU_ENUM_LABEL_VALUE_CORE_SET_SUPPORTS_NO_CONTENT_ENABLE: /* TODO/FIXME */
+         return "Ne pas démarrer de coeur automatiquement";
+      case MENU_ENUM_LABEL_VALUE_CORE_SPECIFIC_CONFIG:
+         return "Avoir une configuration par-coeur";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
+         return "Extraire automatiquement";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_BUILDBOT_URL:
+         return "URL du buildbot des coeurs";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_LIST:
+         return "Mise à jour des coeurs";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_SETTINGS:
+         return "Mises à jour";
+      case MENU_ENUM_LABEL_VALUE_CURSOR_DIRECTORY:
+         return "Dossier des curseurs";
+      case MENU_ENUM_LABEL_VALUE_CURSOR_MANAGER:
+         return "Gestion des curseurs";
+      case MENU_ENUM_LABEL_VALUE_CUSTOM_RATIO:
+         return "Forcer une résolution";
+      case MENU_ENUM_LABEL_VALUE_DATABASE_MANAGER:
+         return "Gestion de la base de données";
+      case MENU_ENUM_LABEL_VALUE_DETECT_CORE_LIST:
+         return "Via les fichiers (détecter le coeur)";
       case MENU_ENUM_LABEL_VALUE_DIRECTORY_CONTENT:
          return "<Dossier de contenu>";
-      case MENU_ENUM_LABEL_VALUE_UNKNOWN:
-         return "Inconnu";
-      case MENU_ENUM_LABEL_VALUE_DONT_CARE:
-         return "Peu importe";
-      case MENU_ENUM_LABEL_VALUE_LINEAR:
-         return "Linéaire";
-      case MENU_ENUM_LABEL_VALUE_NEAREST:
-         return "Au plus proche";
       case MENU_ENUM_LABEL_VALUE_DIRECTORY_DEFAULT:
          return "<Par défaut>";
       case MENU_ENUM_LABEL_VALUE_DIRECTORY_NONE:
          return "<Aucun>";
-      case MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE:
-         return "Indisponible";
-      case MENU_ENUM_LABEL_VALUE_INPUT_REMAPPING_DIRECTORY:
-         return "Dossier de remaps d'entrées";
-      case MENU_ENUM_LABEL_VALUE_JOYPAD_AUTOCONFIG_DIR:
-         return "Dossier des autoconfigs d'entrées";
-      case MENU_ENUM_LABEL_VALUE_RECORDING_CONFIG_DIRECTORY:
-         return "Dossier des réglages de capture vidéo";
-      case MENU_ENUM_LABEL_VALUE_RECORDING_OUTPUT_DIRECTORY:
-         return "Dossier d'enregistrement des vidéos";
-      case MENU_ENUM_LABEL_VALUE_SCREENSHOT_DIRECTORY:
-         return "Dossier des captures d'écran";
-      case MENU_ENUM_LABEL_VALUE_PLAYLIST_DIRECTORY:
-         return "Dossier des playlists";
-      case MENU_ENUM_LABEL_VALUE_SAVEFILE_DIRECTORY:
-         return "Dossier des sauvegardes";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_DIRECTORY:
-         return "Dossier des sauvegardes rapides";
-      case MENU_ENUM_LABEL_VALUE_STDIN_CMD_ENABLE:
-         return "Commandes stdin";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_DRIVER:
-         return "Pilote vidéo";
-      case MENU_ENUM_LABEL_VALUE_RECORD_ENABLE:
-         return "Autoriser les captures vidéo";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_RECORD:
-         return "Captures vidéo via le GPU";
-      case MENU_ENUM_LABEL_VALUE_RECORD_PATH: /* FIXME/UPDATE */
-         return "Chemin de l'enregistrement";
-      case MENU_ENUM_LABEL_VALUE_RECORD_USE_OUTPUT_DIRECTORY:
-         return "Utiliser le dossier d'enregistrement";
-      case MENU_ENUM_LABEL_VALUE_RECORD_CONFIG:
-         return "Configuration de capture";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_POST_FILTER_RECORD:
-         return "Activer les filtres de traitement";
-      case MENU_ENUM_LABEL_VALUE_CORE_ASSETS_DIRECTORY:
-         return "Dossier des téléchargements";
-      case MENU_ENUM_LABEL_VALUE_ASSETS_DIRECTORY:
-         return "Dossier des assets";
-      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPERS_DIRECTORY:
-         return "Dossier des fonds d'écran dynamiques";
-      case MENU_ENUM_LABEL_VALUE_THUMBNAILS_DIRECTORY:
-         return "Dossier des vignettes";
-      case MENU_ENUM_LABEL_VALUE_RGUI_BROWSER_DIRECTORY:
-         return "Dossier racine de navigation";
-      case MENU_ENUM_LABEL_VALUE_RGUI_CONFIG_DIRECTORY:
-         return "Dossier des fichiers de configuration";
-      case MENU_ENUM_LABEL_VALUE_LIBRETRO_INFO_PATH:
-         return "Dossier des informations des coeurs";
-      case MENU_ENUM_LABEL_VALUE_LIBRETRO_DIR_PATH:
-         return "Dossier des coeurs";
-      case MENU_ENUM_LABEL_VALUE_CURSOR_DIRECTORY:
-         return "Dossier des curseurs";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_DATABASE_DIRECTORY:
-         return "Dossier des bases de données de contenus";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_DIRECTORY:
-         return "Dossier système/BIOS";
-      case MENU_ENUM_LABEL_VALUE_CHEAT_DATABASE_PATH:
-         return "Dossier des fichiers de triche";
-      case MENU_ENUM_LABEL_VALUE_CACHE_DIRECTORY: /* FIXME/UPDATE */
-         return "Dossier d'extraction";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_FILTER_DIR:
-         return "Dossier des filtres audio";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_DIR:
-         return "Dossier des shaders vidéo";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_DIR:
-         return "Dossier des filtres vidéo";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_DIRECTORY:
-         return "Dossier des overlays";
-      case MENU_ENUM_LABEL_VALUE_OSK_OVERLAY_DIRECTORY:
-         return "Dossier des overlays claviers";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT: /* TODO: Original string changed */
-         return "Inverser les entrées du jeu en réseau";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE:
-         return "Activer le mode spectateur";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS: /* TODO: Original string changed */
-         return "Adresse IP";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT:
-         return "Port TCP/UDP du jeu en réseau";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE:
-         return "Autoriser le jeu en réseau";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_DELAY_FRAMES:
-         return "Netplay Delay Frames";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_MODE:
-         return "Activer le mode client";
-      case MENU_ENUM_LABEL_VALUE_RGUI_SHOW_START_SCREEN:
-         return "Afficher l'écran de d'aide";
-      case MENU_ENUM_LABEL_VALUE_TITLE_COLOR:
-         return "Couleur du titre du menu";
-      case MENU_ENUM_LABEL_VALUE_ENTRY_HOVER_COLOR:
-         return "Couleur de l'entrée active";
-      case MENU_ENUM_LABEL_VALUE_TIMEDATE_ENABLE:
-         return "Afficher la date et l'heure";
-      case MENU_ENUM_LABEL_VALUE_THREADED_DATA_RUNLOOP_ENABLE:
-         return "Boucle de données threadée";
-      case MENU_ENUM_LABEL_VALUE_ENTRY_NORMAL_COLOR:
-         return "Couleur des entrées du menu";
-      case MENU_ENUM_LABEL_VALUE_SHOW_ADVANCED_SETTINGS:
-         return "Afficher les réglages avancés";
-      case MENU_ENUM_LABEL_VALUE_COLLAPSE_SUBGROUPS_ENABLE:
-         return "Fusionner les sous-groupes";
-      case MENU_ENUM_LABEL_VALUE_MOUSE_ENABLE:
-         return "Support de la souris";
-      case MENU_ENUM_LABEL_VALUE_POINTER_ENABLE:
-         return "Support du tactile";
-      case MENU_ENUM_LABEL_VALUE_CORE_ENABLE:
-         return "Afficher le coeur actuel";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NOT_FOUND:
+         return "Dossier non trouvé.";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_SETTINGS:
+         return "Dossiers";
+      case MENU_ENUM_LABEL_VALUE_DISABLED:
+         return "Désactivé";
+      case MENU_ENUM_LABEL_VALUE_DISK_CYCLE_TRAY_STATUS:
+         return "État du lecteur de disque";
+      case MENU_ENUM_LABEL_VALUE_DISK_IMAGE_APPEND:
+         return "Ajouter une image de disque";
+      case MENU_ENUM_LABEL_VALUE_DISK_INDEX:
+         return "Numéro du disque";
+      case MENU_ENUM_LABEL_VALUE_DISK_OPTIONS:
+         return "Disques";
+      case MENU_ENUM_LABEL_VALUE_DONT_CARE:
+         return "Peu importe";
+      case MENU_ENUM_LABEL_VALUE_DOWNLOADED_FILE_DETECT_CORE_LIST: /* FIXME/TODO - rewrite */
+         return "Via les téléchargements (détecter le coeur)";
+      case MENU_ENUM_LABEL_VALUE_DOWNLOAD_CORE_CONTENT:
+         return "Télécharger du contenu";
       case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_ENABLE:
          return "Personnaliser le DPI";
       case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_VALUE:
          return "Valeur du DPI personnalisé";
-      case MENU_ENUM_LABEL_VALUE_SUSPEND_SCREENSAVER_ENABLE:
-         return "Désactiver l'économiseur d'écran";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_DISABLE_COMPOSITION:
-         return "Désactiver le compositeur du bureau";
-      case MENU_ENUM_LABEL_VALUE_PAUSE_NONACTIVE:
-         return "Ne pas fonctionner en arrière-plan";
-      case MENU_ENUM_LABEL_VALUE_UI_COMPANION_START_ON_BOOT:
-         return "UI Companion Start On Boot";
-      case MENU_ENUM_LABEL_VALUE_UI_MENUBAR_ENABLE:
-         return "Menubar";
-      case MENU_ENUM_LABEL_VALUE_ARCHIVE_MODE:
-         return "Mode d'ouverture des archives";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_ENABLE:
-         return "Commandes réseau";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_PORT:
-         return "Port des commandes réseau";
-      case MENU_ENUM_LABEL_VALUE_HISTORY_LIST_ENABLE:
-         return "Afficher l'historique";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_HISTORY_SIZE:
-         return "Taille de l'historique";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE_AUTO:
-         return "Fréquence estimée de l'écran";
+      case MENU_ENUM_LABEL_VALUE_DRIVER_SETTINGS:
+         return "Pilotes";
       case MENU_ENUM_LABEL_VALUE_DUMMY_ON_CORE_SHUTDOWN:
          return "Utiliser un faux coeur lorsqu'il n'y en a pas";
-      case MENU_ENUM_LABEL_VALUE_CORE_SET_SUPPORTS_NO_CONTENT_ENABLE: /* TODO/FIXME */
-         return "Ne pas démarrer de coeur automatiquement";
-      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_ENABLE:
-         return "Limiter la vitesse d'exécution";
+      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPER:
+         return "Fond d'écran dynamique";
+      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPERS_DIRECTORY:
+         return "Dossier des fonds d'écran dynamiques";
+      case MENU_ENUM_LABEL_VALUE_ENTRY_HOVER_COLOR:
+         return "Couleur de l'entrée active";
+      case MENU_ENUM_LABEL_VALUE_ENTRY_NORMAL_COLOR:
+         return "Couleur des entrées du menu";
+      case MENU_ENUM_LABEL_VALUE_FALSE:
+         return "Faux";
       case MENU_ENUM_LABEL_VALUE_FASTFORWARD_RATIO:
          return "Vitesse de l'avance rapide";
-      case MENU_ENUM_LABEL_VALUE_AUTO_REMAPS_ENABLE:
-         return "Charger les fichiers remaps automatiquement";
-      case MENU_ENUM_LABEL_VALUE_SLOWMOTION_RATIO:
-         return "Taux de ralentissement";
-      case MENU_ENUM_LABEL_VALUE_CORE_SPECIFIC_CONFIG:
-         return "Avoir une configuration par-coeur";
+      case MENU_ENUM_LABEL_VALUE_FPS_SHOW:
+         return "Afficher le FPS";
+      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_ENABLE:
+         return "Limiter la vitesse d'exécution";
+      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_SETTINGS:
+         return "Vitesse d'affichage";
+      case MENU_ENUM_LABEL_VALUE_FRONTEND_COUNTERS:
+         return "Compteurs du Frontend";
       case MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS:
          return "Options du coeur par-jeu";
-      case MENU_ENUM_LABEL_VALUE_AUTO_OVERRIDES_ENABLE:
-         return "Charger les fichiers d'override automatiquement";
-      case MENU_ENUM_LABEL_VALUE_CONFIG_SAVE_ON_EXIT:
-         return "Sauver la config en quittant";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SMOOTH:
-         return "Filtre bilinéaire (HW)";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_GAMMA:
-         return "Gamma";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ALLOW_ROTATE:
-         return "Autoriser la rotation";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC:
-         return "Synchroniser le GPU au CPU";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SWAP_INTERVAL:
-         return "Intervale de synchronisation verticale";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VSYNC:
-         return "Synchronisation verticale";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_THREADED:
-         return "Threader l'affichage";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ROTATION:
-         return "Rotation";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_SCREENSHOT:
-         return "Activer les captures d'écran GPU";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_CROP_OVERSCAN:
-         return "Tronquer l'overscan (Reload)";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_INDEX:
-         return "Rapport d'aspect";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_AUTO:
-         return "Format d'image automatique";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_ASPECT:
-         return "Forcer le format d'image";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE:
-         return "Fréquence de rafraichissement";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_SRGB_DISABLE:
-         return "Désactiver sRGB FBO";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_WINDOWED_FULLSCREEN:
-         return "Mode plein écran fenêtré";
-      case MENU_ENUM_LABEL_VALUE_PAL60_ENABLE:
-         return "Utiliser le mode PAL60";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VFILTER:
-         return "Deflicker"; /* TODO */
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VI_WIDTH:
-         return "Set VI Screen Width"; /* TODO */
-      case MENU_ENUM_LABEL_VALUE_VIDEO_BLACK_FRAME_INSERTION:
-         return "Insérer des frames noires";
-      case MENU_ENUM_LABEL_VALUE_SORT_SAVEFILES_ENABLE:
-         return "Classer les sauvegardes par dossier";
-      case MENU_ENUM_LABEL_VALUE_SORT_SAVESTATES_ENABLE:
-         return "Classer les savestates par dossier";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FULLSCREEN:
-         return "Plein écran";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE:
-         return "Zoom (en fenêtre)";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE_INTEGER:
-         return "Aligner aux pixels de l'écran";
-      case MENU_ENUM_LABEL_VALUE_PERFCNT_ENABLE:
-         return "Compteurs de performance";
-      case MENU_ENUM_LABEL_VALUE_LIBRETRO_LOG_LEVEL:
-         return "Verbosité des journaux des coeurs";
-      case MENU_ENUM_LABEL_VALUE_LOG_VERBOSITY:
-         return "Verbosité des journaux";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_LOAD:
-         return "Charger automatiquement les savestates";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_INDEX:
-         return "Indexer automatiquement les savestates";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_SAVE:
-         return "Sauvegarde automatique";
-      case MENU_ENUM_LABEL_VALUE_AUTOSAVE_INTERVAL:
-         return "Intervale de sauvegarde SaveRAM";
-      case MENU_ENUM_LABEL_VALUE_BLOCK_SRAM_OVERWRITE:
-         return "Ne pas écraser la SaveRAM en chargeant la savestate";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHARED_CONTEXT:
-         return "Partager le contexte matériel";
-      case MENU_ENUM_LABEL_VALUE_RESTART_RETROARCH:
-         return "Redémarrer RetroArch";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_NICKNAME:
-         return "Nom d'utilisateur";
-      case MENU_ENUM_LABEL_VALUE_USER_LANGUAGE:
-         return "Langage";
-      case MENU_ENUM_LABEL_VALUE_CAMERA_ALLOW:
-         return "Autoriser la caméra";
-      case MENU_ENUM_LABEL_VALUE_LOCATION_ALLOW:
-         return "Autoriser la localisation";
-      case MENU_ENUM_LABEL_VALUE_PAUSE_LIBRETRO:
-         return "Pauser le contenu quand le menu est activé";
+      case MENU_ENUM_LABEL_VALUE_HELP:
+         return "Aide";
+      case MENU_ENUM_LABEL_VALUE_HELP_LIST:
+         return "Aide";
+      case MENU_ENUM_LABEL_VALUE_HISTORY_LIST_ENABLE:
+         return "Afficher l'historique";
+      case MENU_ENUM_LABEL_VALUE_HISTORY_TAB:
+         return "Historique";
+      case MENU_ENUM_LABEL_VALUE_HORIZONTAL_MENU:
+         return "Horizontal Menu";
+      case MENU_ENUM_LABEL_VALUE_INFORMATION_LIST:
+         return "Informations";
+      case MENU_ENUM_LABEL_VALUE_INPUT_AUTODETECT_ENABLE:
+         return "Activer l'autoconfiguration";
+      case MENU_ENUM_LABEL_VALUE_INPUT_AXIS_THRESHOLD:
+         return "Seuil des axes";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_HIDE_UNBOUND:
+         return "Cacher les remaps non mappés des coeurs";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_LABEL_SHOW: /* FIXME/UPDATE */
+         return "Afficher les remaps du coeur";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DRIVER:
+         return "Pilote des entrées";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DUTY_CYCLE:
+         return "Rapport de cycle";
+      case MENU_ENUM_LABEL_VALUE_INPUT_HOTKEY_BINDS:
+         return "Racourcis d'entrées";
+      case MENU_ENUM_LABEL_VALUE_INPUT_MAX_USERS:
+         return "Nombre d'utilisateurs";
       case MENU_ENUM_LABEL_VALUE_INPUT_OSK_OVERLAY_ENABLE:
          return "Afficher l'overlay clavier";
       case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_ENABLE:
          return "Activer les overlays";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MONITOR_INDEX:
-         return "Écran";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FRAME_DELAY:
-         return "Délayer les frames";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DUTY_CYCLE:
-         return "Rapport de cycle";
-      case MENU_ENUM_LABEL_VALUE_INPUT_TURBO_PERIOD:
-         return "Délai du turbo";
-      case MENU_ENUM_LABEL_VALUE_INPUT_AXIS_THRESHOLD:
-         return "Seuil des axes";
+      case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_HIDE_IN_MENU:
+         return "Cacher l'overlay dans le menu";
+      case MENU_ENUM_LABEL_VALUE_INPUT_REMAPPING_DIRECTORY:
+         return "Dossier de remaps d'entrées";
       case MENU_ENUM_LABEL_VALUE_INPUT_REMAP_BINDS_ENABLE:
          return "Autoriser le remapping des entrées";
-      case MENU_ENUM_LABEL_VALUE_INPUT_MAX_USERS:
-         return "Nombre d'utilisateurs";
-      case MENU_ENUM_LABEL_VALUE_INPUT_AUTODETECT_ENABLE:
-         return "Activer l'autoconfiguration";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_OUTPUT_RATE:
-         return "Fréquence de sortie (KHz)";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_MAX_TIMING_SKEW:
-         return "Limite max de l'ajustement";
-      case MENU_ENUM_LABEL_VALUE_CHEAT_NUM_PASSES:
-         return "Nombre de passages";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_CORE:
-         return "Charger un fichier remaps de coeur";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_GAME:
-         return "Charger un fichier remap de contenu";
-      case MENU_ENUM_LABEL_VALUE_CHEAT_APPLY_CHANGES:
-         return "Appliquer les changements";
-      case MENU_ENUM_LABEL_VALUE_SHADER_APPLY_CHANGES:
-         return "Appliquer les changements";
-      case MENU_ENUM_LABEL_VALUE_REWIND_ENABLE:
-         return "Activer le rembobinage";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_COLLECTION_LIST:
-         return "Collections";
-      case MENU_ENUM_LABEL_VALUE_DETECT_CORE_LIST:
-         return "Via les fichiers (détecter le coeur)";
-      case MENU_ENUM_LABEL_VALUE_DOWNLOADED_FILE_DETECT_CORE_LIST: /* FIXME/TODO - rewrite */
-         return "Via les téléchargements (détecter le coeur)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_SETTINGS:
+         return "Entrées";
+      case MENU_ENUM_LABEL_VALUE_INPUT_TURBO_PERIOD:
+         return "Délai du turbo";
+      case MENU_ENUM_LABEL_VALUE_INPUT_USER_BINDS:
+         return "Entrées utilisateur %u";
+      case MENU_ENUM_LABEL_VALUE_JOYPAD_AUTOCONFIG_DIR:
+         return "Dossier des autoconfigs d'entrées";
+      case MENU_ENUM_LABEL_VALUE_JOYPAD_DRIVER:
+         return "Pilote des manettes";
+      case MENU_ENUM_LABEL_VALUE_KEYBOARD_OVERLAY_PRESET:
+         return "Préréglages d'overlay clavier";
+      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_SIMPLIFIED:
+         return "Chinois (Simplifié)";
+      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_TRADITIONAL:
+         return "Chinois (Traditionnel)";
+      case MENU_ENUM_LABEL_VALUE_LANG_DUTCH:
+         return "Néerlandais";
+      case MENU_ENUM_LABEL_VALUE_LANG_ENGLISH:
+         return "Anglais";
+      case MENU_ENUM_LABEL_VALUE_LANG_ESPERANTO:
+         return "Esperanto";
+      case MENU_ENUM_LABEL_VALUE_LANG_FRENCH:
+         return "Français";
+      case MENU_ENUM_LABEL_VALUE_LANG_GERMAN:
+         return "Allemand";
+      case MENU_ENUM_LABEL_VALUE_LANG_ITALIAN:
+         return "Italien";
+      case MENU_ENUM_LABEL_VALUE_LANG_JAPANESE:
+         return "Japonais";
+      case MENU_ENUM_LABEL_VALUE_LANG_KOREAN:
+         return "Coréen";
+      case MENU_ENUM_LABEL_VALUE_LANG_PORTUGUESE:
+         return "Portuguais";
+      case MENU_ENUM_LABEL_VALUE_LANG_RUSSIAN:
+         return "Russe";
+      case MENU_ENUM_LABEL_VALUE_LANG_SPANISH:
+         return "Espagnol";
+      case MENU_ENUM_LABEL_VALUE_LEFT_ANALOG:
+         return "Stick analogique gauche";
+      case MENU_ENUM_LABEL_VALUE_LIBRETRO_DIR_PATH:
+         return "Dossier des coeurs";
+      case MENU_ENUM_LABEL_VALUE_LIBRETRO_INFO_PATH:
+         return "Dossier des informations des coeurs";
+      case MENU_ENUM_LABEL_VALUE_LIBRETRO_LOG_LEVEL:
+         return "Verbosité des journaux des coeurs";
+      case MENU_ENUM_LABEL_VALUE_LINEAR:
+         return "Linéaire";
+      case MENU_ENUM_LABEL_VALUE_LOAD_ARCHIVE:
+         return "Charger l'archive";
+      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT:
+         return "Via les fichiers";
       case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_HISTORY:
          return "Récemment ouvert";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_ENABLE:
-         return "Activer le son";
-      case MENU_ENUM_LABEL_VALUE_FPS_SHOW:
-         return "Afficher le FPS";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_MUTE:
-         return "Muet";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_VOLUME:
-         return "Volume sonnore (dB)";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_SYNC:
-         return "Synchroniser le son";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_RATE_CONTROL_DELTA:
-         return "Delta du taux de contrôle";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_NUM_PASSES:
-         return "Nombre de passages";
-      case MENU_ENUM_LABEL_VALUE_CONFIGURATIONS:
-         return "Charger une configuration";
-      case MENU_ENUM_LABEL_VALUE_REWIND_GRANULARITY:
-         return "Précision du rembobinage";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_LOAD:
-         return "Charger un fichier de remap";
-      case MENU_ENUM_LABEL_VALUE_CUSTOM_RATIO:
-         return "Forcer une résolution";
-      case MENU_ENUM_LABEL_VALUE_USE_THIS_DIRECTORY:
-         return "<Choisir ce dossier>";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_START_CONTENT:
-         return "Exécuter le contenu";
-      case MENU_ENUM_LABEL_VALUE_DISK_OPTIONS:
-         return "Disques";
-      case MENU_ENUM_LABEL_VALUE_CORE_OPTIONS:
-         return "Options";
-      case MENU_ENUM_LABEL_VALUE_CORE_CHEAT_OPTIONS:
-         return "Triche";
-      case MENU_ENUM_LABEL_VALUE_TAKE_SCREENSHOT:
-         return "Capturer l écran";
-      case MENU_ENUM_LABEL_VALUE_RESUME:
-         return "Reprendre";
-      case MENU_ENUM_LABEL_VALUE_DISK_INDEX:
-         return "Numéro du disque";
-      case MENU_ENUM_LABEL_VALUE_FRONTEND_COUNTERS:
-         return "Compteurs du Frontend";
-      case MENU_ENUM_LABEL_VALUE_DISK_IMAGE_APPEND:
-         return "Ajouter une image de disque";
-      case MENU_ENUM_LABEL_VALUE_DISK_CYCLE_TRAY_STATUS:
-         return "État du lecteur de disque";
-      case MENU_ENUM_LABEL_VALUE_NO_PLAYLIST_ENTRIES_AVAILABLE:
-         return "Playlist vide.";
+      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_LIST:
+         return "Charger du contenu";
+      case MENU_ENUM_LABEL_VALUE_LOAD_STATE:
+         return "Charger une savestate";
+      case MENU_ENUM_LABEL_VALUE_LOCATION_ALLOW:
+         return "Autoriser la localisation";
+      case MENU_ENUM_LABEL_VALUE_LOCATION_DRIVER:
+         return "Pilote de localisation";
+      case MENU_ENUM_LABEL_VALUE_LOGGING_SETTINGS:
+         return "Journaux";
+      case MENU_ENUM_LABEL_VALUE_LOG_VERBOSITY:
+         return "Verbosité des journaux";
+      case MENU_ENUM_LABEL_VALUE_MAIN_MENU:
+         return "Menu principal";
+      case MENU_ENUM_LABEL_VALUE_MANAGEMENT:
+         return "Gestion avancée";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME:
+         return "Dégradé de font d'écran";
+      case MENU_ENUM_LABEL_VALUE_MENU_DRIVER:
+         return "Pilote de menu";
+      case MENU_ENUM_LABEL_VALUE_MENU_FILE_BROWSER_SETTINGS:
+         return "Navigateur de fichiers";
+      case MENU_ENUM_LABEL_VALUE_MENU_LINEAR_FILTER:
+         return "Filtre linéaire";
+      case MENU_ENUM_LABEL_VALUE_MENU_SETTINGS:
+         return "Menu";
+      case MENU_ENUM_LABEL_VALUE_MENU_WALLPAPER:
+         return "Fond d'écran";
+      case MENU_ENUM_LABEL_VALUE_MISSING:
+         return "Manquant";
+      case MENU_ENUM_LABEL_VALUE_MOUSE_ENABLE:
+         return "Support de la souris";
+      case MENU_ENUM_LABEL_VALUE_MULTIMEDIA_SETTINGS:
+         return "Multimédia";
+      case MENU_ENUM_LABEL_VALUE_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
+         return "Filtrer par extentions supportées"; /* TODO/FIXME - rewrite */
+      case MENU_ENUM_LABEL_VALUE_NAVIGATION_WRAPAROUND:
+         return "Saut-retour";
+      case MENU_ENUM_LABEL_VALUE_NEAREST:
+         return "Au plus proche";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT: /* TODO: Original string changed */
+         return "Inverser les entrées du jeu en réseau";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_DELAY_FRAMES:
+         return "Netplay Delay Frames";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE:
+         return "Autoriser le jeu en réseau";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS: /* TODO: Original string changed */
+         return "Adresse IP";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_MODE:
+         return "Activer le mode client";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_NICKNAME:
+         return "Nom d'utilisateur";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE:
+         return "Activer le mode spectateur";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT:
+         return "Port TCP/UDP du jeu en réseau";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_ENABLE:
+         return "Commandes réseau";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_PORT:
+         return "Port des commandes réseau";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_REMOTE_ENABLE:
+         return "Manette réseau";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_SETTINGS:
+         return "Réseau";
+      case MENU_ENUM_LABEL_VALUE_NO:
+         return "Non";
+      case MENU_ENUM_LABEL_VALUE_NONE:
+         return "Aucun";
+      case MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE:
+         return "Indisponible";
+      case MENU_ENUM_LABEL_VALUE_NO_CORE:
+         return "Aucun coeur";
+      case MENU_ENUM_LABEL_VALUE_NO_CORES_AVAILABLE:
+         return "Aucun coeur disponible.";
       case MENU_ENUM_LABEL_VALUE_NO_CORE_INFORMATION_AVAILABLE:
          return "Pas d'informations disponibles.";
       case MENU_ENUM_LABEL_VALUE_NO_CORE_OPTIONS_AVAILABLE:
          return "Pas d'options disponibles.";
-      case MENU_ENUM_LABEL_VALUE_NO_CORES_AVAILABLE:
-         return "Aucun coeur disponible.";
-      case MENU_ENUM_LABEL_VALUE_NO_CORE:
-         return "Aucun coeur";
-      case MENU_ENUM_LABEL_VALUE_DATABASE_MANAGER:
-         return "Gestion de la base de données";
-      case MENU_ENUM_LABEL_VALUE_CURSOR_MANAGER:
-         return "Gestion des curseurs";
-      case MENU_ENUM_LABEL_VALUE_MAIN_MENU:
-         return "Menu principal";
-      case MENU_ENUM_LABEL_VALUE_SETTINGS:
-         return "Réglages";
-      case MENU_ENUM_LABEL_VALUE_QUIT_RETROARCH:
-         return "Quitter RetroArch";
-      case MENU_ENUM_LABEL_VALUE_SHUTDOWN:
-         return "Éteindre";
-      case MENU_ENUM_LABEL_VALUE_HELP:
-         return "Aide";
-      case MENU_ENUM_LABEL_VALUE_SAVE_NEW_CONFIG:
-         return "Sauvegarder la configuration";
-      case MENU_ENUM_LABEL_VALUE_RESTART_CONTENT:
-         return "Redémarrer le contenu";
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_LIST:
-         return "Mise à jour des coeurs";
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_BUILDBOT_URL:
-         return "URL du buildbot des coeurs";
-      case MENU_ENUM_LABEL_VALUE_BUILDBOT_ASSETS_URL:
-         return "URL du buildbot des assets";
-      case MENU_ENUM_LABEL_VALUE_NAVIGATION_WRAPAROUND:
-         return "Saut-retour";
-      case MENU_ENUM_LABEL_VALUE_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
-         return "Filtrer par extentions supportées"; /* TODO/FIXME - rewrite */
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
-         return "Extraire automatiquement";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFORMATION:
-         return "Informations du système";
-      case MENU_ENUM_LABEL_VALUE_ONLINE_UPDATER:
-         return "Mises à jour";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFORMATION:
-         return "Informations sur le coeur";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NOT_FOUND:
-         return "Dossier non trouvé.";
+      case MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE:
+         return "Pas d'informations disponibles.";
       case MENU_ENUM_LABEL_VALUE_NO_ITEMS:
          return "Vide.";
-      case MENU_ENUM_LABEL_VALUE_CORE_LIST:
-         return "Charger un coeur";
-      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT:
-         return "Via les fichiers";
-      case MENU_ENUM_LABEL_VALUE_CLOSE_CONTENT:
-         return "Quitter";
-      case MENU_ENUM_LABEL_VALUE_MANAGEMENT:
-         return "Gestion avancée";
-      case MENU_ENUM_LABEL_VALUE_SAVE_STATE:
-         return "Sauvegarder une savestate";
-      case MENU_ENUM_LABEL_VALUE_LOAD_STATE:
-         return "Charger une savestate";
-      case MENU_ENUM_LABEL_VALUE_RESUME_CONTENT:
-         return "Reprendre";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DRIVER:
-         return "Pilote des entrées";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_DRIVER:
-         return "Pilote audio";
-      case MENU_ENUM_LABEL_VALUE_JOYPAD_DRIVER:
-         return "Pilote des manettes";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_RESAMPLER_DRIVER:
-         return "Pilote de ré-échantillonage audio";
-      case MENU_ENUM_LABEL_VALUE_RECORD_DRIVER:
-         return "Pilote de capture vidéo";
-      case MENU_ENUM_LABEL_VALUE_MENU_DRIVER:
-         return "Pilote de menu";
-      case MENU_ENUM_LABEL_VALUE_CAMERA_DRIVER:
-         return "Pilote de caméra";
-      case MENU_ENUM_LABEL_VALUE_LOCATION_DRIVER:
-         return "Pilote de localisation";
-      case MENU_ENUM_LABEL_VALUE_UNABLE_TO_READ_COMPRESSED_FILE:
-         return "Impossible de lire l'archive.";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_SCALE:
-         return "Zoom de l'overlay";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_PRESET:
-         return "Préréglages de l'overlay";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_LATENCY:
-         return "Latence audio (ms)";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_DEVICE:
-         return "Carte son";
-      case MENU_ENUM_LABEL_VALUE_KEYBOARD_OVERLAY_PRESET:
-         return "Préréglages d'overlay clavier";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_OPACITY:
-         return "Transparence de l'overlay";
-      case MENU_ENUM_LABEL_VALUE_MENU_WALLPAPER:
-         return "Fond d'écran";
-      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPER:
-         return "Fond d'écran dynamique";
-      case MENU_ENUM_LABEL_VALUE_THUMBNAILS:
-         return "Vignettes";
-      case MENU_ENUM_LABEL_VALUE_CORE_INPUT_REMAPPING_OPTIONS:
-         return "Remap d'entrées";
-      case MENU_ENUM_LABEL_VALUE_SHADER_OPTIONS:
-         return "Shaders";
+      case MENU_ENUM_LABEL_VALUE_NO_PERFORMANCE_COUNTERS:
+         return "Pas de compteurs de performance.";
+      case MENU_ENUM_LABEL_VALUE_NO_PLAYLIST_ENTRIES_AVAILABLE:
+         return "Playlist vide.";
+      case MENU_ENUM_LABEL_VALUE_NO_SETTINGS_FOUND:
+         return "Pas de réglages trouvés.";
       case MENU_ENUM_LABEL_VALUE_NO_SHADER_PARAMETERS:
          return "Aucun paramètres.";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER:
-         return "Filtre vidéo";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_DSP_PLUGIN:
-         return "Module DSP";
       case MENU_ENUM_LABEL_VALUE_OFF:
          return "OFF";
       case MENU_ENUM_LABEL_VALUE_ON:
          return "ON";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_ASSETS:
-         return "Mettre à jour les assets";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_CHEATS:
-         return "Mettre à jour les codes de triche";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_AUTOCONFIG_PROFILES:
-         return "Mettre à jour les profils d'autoconfiguration";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_DATABASES:
-         return "Mettre à jour les bases de données";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_OVERLAYS:
-         return "Mettre à jour les overlays";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_CG_SHADERS:
-         return "Mettre à jour les shaders CG";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_GLSL_SHADERS:
-         return "Mettre à jour les shaders GLSL";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NAME:
+      case MENU_ENUM_LABEL_VALUE_ONLINE_UPDATER:
+         return "Mises à jour";
+      case MENU_ENUM_LABEL_VALUE_ONSCREEN_DISPLAY_SETTINGS:
+         return "Messages d'info";
+      case MENU_ENUM_LABEL_VALUE_OPEN_ARCHIVE:
+         return "Ouvrir l'archive";
+      case MENU_ENUM_LABEL_VALUE_OPTIONAL:
+         return "Optionnel";
+      case MENU_ENUM_LABEL_VALUE_OSK_OVERLAY_DIRECTORY:
+         return "Dossier des overlays claviers";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_AUTOLOAD_PREFERRED:
+         return "Charger l'overlay préféré automatiquement";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_DIRECTORY:
+         return "Dossier des overlays";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_OPACITY:
+         return "Transparence de l'overlay";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_PRESET:
+         return "Préréglages de l'overlay";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_SCALE:
+         return "Zoom de l'overlay";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_SETTINGS:
+         return "Overlays";
+      case MENU_ENUM_LABEL_VALUE_PAL60_ENABLE:
+         return "Utiliser le mode PAL60";
+      case MENU_ENUM_LABEL_VALUE_PAUSE_LIBRETRO:
+         return "Pauser le contenu quand le menu est activé";
+      case MENU_ENUM_LABEL_VALUE_PAUSE_NONACTIVE:
+         return "Ne pas fonctionner en arrière-plan";
+      case MENU_ENUM_LABEL_VALUE_PERFCNT_ENABLE:
+         return "Compteurs de performance";
+      case MENU_ENUM_LABEL_VALUE_PLAYLIST_DIRECTORY:
+         return "Dossier des playlists";
+      case MENU_ENUM_LABEL_VALUE_PLAYLIST_SETTINGS:
+         return "Playlists";
+      case MENU_ENUM_LABEL_VALUE_POINTER_ENABLE:
+         return "Support du tactile";
+      case MENU_ENUM_LABEL_VALUE_PORT:
+         return "Port";
+      case MENU_ENUM_LABEL_VALUE_PRESENT:
+         return "Présent";
+      case MENU_ENUM_LABEL_VALUE_PRIVACY_SETTINGS:
+         return "Confidentialité";
+      case MENU_ENUM_LABEL_VALUE_QUIT_RETROARCH:
+         return "Quitter RetroArch";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_CRC32:
+         return "CRC32";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DESCRIPTION:
+         return "Description";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DEVELOPER:
+         return "Développeur";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_FRANCHISE:
+         return "Franchise";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_MD5:
+         return "MD5";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_NAME:
          return "Nom";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_LABEL:
-         return "Label";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_NAME:
-         return "Système";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_MANUFACTURER:
-         return "Fabricant du système";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CATEGORIES:
-         return "Catégories";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_AUTHORS:
-         return "Auteurs";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_PERMISSIONS:
-         return "Permissions";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_LICENSES:
-         return "Licence(s)";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SUPPORTED_EXTENSIONS:
-         return "Extensions supportées";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_FIRMWARE:
-         return "Firmware";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NOTES:
-         return "Notes";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ORIGIN:
+         return "Origine";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_PUBLISHER:
+         return "Éditeur";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_MONTH:
+         return "Mois de sortie";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_YEAR:
+         return "Année de sortie";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_START_CONTENT:
+         return "Exécuter le contenu";
+      case MENU_ENUM_LABEL_VALUE_RECORDING_CONFIG_DIRECTORY:
+         return "Dossier des réglages de capture vidéo";
+      case MENU_ENUM_LABEL_VALUE_RECORDING_OUTPUT_DIRECTORY:
+         return "Dossier d'enregistrement des vidéos";
+      case MENU_ENUM_LABEL_VALUE_RECORDING_SETTINGS:
+         return "Capture video";
+      case MENU_ENUM_LABEL_VALUE_RECORD_CONFIG:
+         return "Configuration de capture";
+      case MENU_ENUM_LABEL_VALUE_RECORD_DRIVER:
+         return "Pilote de capture vidéo";
+      case MENU_ENUM_LABEL_VALUE_RECORD_ENABLE:
+         return "Autoriser les captures vidéo";
+      case MENU_ENUM_LABEL_VALUE_RECORD_PATH: /* FIXME/UPDATE */
+         return "Chemin de l'enregistrement";
+      case MENU_ENUM_LABEL_VALUE_RECORD_USE_OUTPUT_DIRECTORY:
+         return "Utiliser le dossier d'enregistrement";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_LOAD:
+         return "Charger un fichier de remap";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_CORE:
+         return "Charger un fichier remaps de coeur";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_GAME:
+         return "Charger un fichier remap de contenu";
+      case MENU_ENUM_LABEL_VALUE_REQUIRED:
+         return "Requis";
+      case MENU_ENUM_LABEL_VALUE_RESTART_CONTENT:
+         return "Redémarrer le contenu";
+      case MENU_ENUM_LABEL_VALUE_RESTART_RETROARCH:
+         return "Redémarrer RetroArch";
+      case MENU_ENUM_LABEL_VALUE_RESUME:
+         return "Reprendre";
+      case MENU_ENUM_LABEL_VALUE_RESUME_CONTENT:
+         return "Reprendre";
+      case MENU_ENUM_LABEL_VALUE_RETROKEYBOARD:
+         return "RetroKeyboard";
+      case MENU_ENUM_LABEL_VALUE_RETROPAD:
+         return "RetroPad";
+      case MENU_ENUM_LABEL_VALUE_REWIND_ENABLE:
+         return "Activer le rembobinage";
+      case MENU_ENUM_LABEL_VALUE_REWIND_GRANULARITY:
+         return "Précision du rembobinage";
+      case MENU_ENUM_LABEL_VALUE_REWIND_SETTINGS:
+         return "Rembobinage";
+      case MENU_ENUM_LABEL_VALUE_RGUI_BROWSER_DIRECTORY:
+         return "Dossier racine de navigation";
+      case MENU_ENUM_LABEL_VALUE_RGUI_CONFIG_DIRECTORY:
+         return "Dossier des fichiers de configuration";
+      case MENU_ENUM_LABEL_VALUE_RGUI_SHOW_START_SCREEN:
+         return "Afficher l'écran de d'aide";
+      case MENU_ENUM_LABEL_VALUE_RIGHT_ANALOG:
+         return "Stick analogique droite";
+      case MENU_ENUM_LABEL_VALUE_RUN:
+         return "Lancer";
+      case MENU_ENUM_LABEL_VALUE_SAVEFILE_DIRECTORY:
+         return "Dossier des sauvegardes";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_INDEX:
+         return "Indexer automatiquement les savestates";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_LOAD:
+         return "Charger automatiquement les savestates";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_SAVE:
+         return "Sauvegarde automatique";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_DIRECTORY:
+         return "Dossier des sauvegardes rapides";
+      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG:
+         return "Sauvegarder la configuration actuelle";
+      case MENU_ENUM_LABEL_VALUE_SAVE_NEW_CONFIG:
+         return "Sauvegarder la configuration";
+      case MENU_ENUM_LABEL_VALUE_SAVE_STATE:
+         return "Sauvegarder une savestate";
+      case MENU_ENUM_LABEL_VALUE_SAVING_SETTINGS:
+         return "Sauvegardes";
+      case MENU_ENUM_LABEL_VALUE_SCAN_DIRECTORY:
+         return "Scanner un dossier";
+      case MENU_ENUM_LABEL_VALUE_SCAN_FILE:
+         return "Scanner un fichier";
+      case MENU_ENUM_LABEL_VALUE_SCAN_THIS_DIRECTORY:
+         return "<Scanner ce dossier>";
+      case MENU_ENUM_LABEL_VALUE_SCREENSHOT_DIRECTORY:
+         return "Dossier des captures d'écran";
+      case MENU_ENUM_LABEL_VALUE_SCREEN_RESOLUTION:
+         return "Résolution d'écran";
+      case MENU_ENUM_LABEL_VALUE_SEARCH:
+         return "Recherche :";
+      case MENU_ENUM_LABEL_VALUE_SETTINGS:
+         return "Réglages";
+      case MENU_ENUM_LABEL_VALUE_SETTINGS_TAB:
+         return "Réglages";
+      case MENU_ENUM_LABEL_VALUE_SHADER:
+         return "Shader";
+      case MENU_ENUM_LABEL_VALUE_SHADER_APPLY_CHANGES:
+         return "Appliquer les changements";
+      case MENU_ENUM_LABEL_VALUE_SHADER_OPTIONS:
+         return "Shaders";
+      case MENU_ENUM_LABEL_VALUE_SHOW_ADVANCED_SETTINGS:
+         return "Afficher les réglages avancés";
+      case MENU_ENUM_LABEL_VALUE_SHUTDOWN:
+         return "Éteindre";
+      case MENU_ENUM_LABEL_VALUE_SLOWMOTION_RATIO:
+         return "Taux de ralentissement";
+      case MENU_ENUM_LABEL_VALUE_SORT_SAVEFILES_ENABLE:
+         return "Classer les sauvegardes par dossier";
+      case MENU_ENUM_LABEL_VALUE_SORT_SAVESTATES_ENABLE:
+         return "Classer les savestates par dossier";
+      case MENU_ENUM_LABEL_VALUE_START_CORE:
+         return "Démarrer le coeur";
+      case MENU_ENUM_LABEL_VALUE_START_NET_RETROPAD:
+         return "Mode manette à distance";
+      case MENU_ENUM_LABEL_VALUE_STATE_SLOT:
+         return "Slot de savestate";
+      case MENU_ENUM_LABEL_VALUE_STATUS:
+         return "Statut";
+      case MENU_ENUM_LABEL_VALUE_STDIN_CMD_ENABLE:
+         return "Commandes stdin";
+      case MENU_ENUM_LABEL_VALUE_SUSPEND_SCREENSAVER_ENABLE:
+         return "Désactiver l'économiseur d'écran";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_BGM_ENABLE:
+         return "Musique du système activée";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_DIRECTORY:
+         return "Dossier système/BIOS";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFORMATION:
+         return "Informations du système";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_7ZIP_SUPPORT:
+         return "Support de 7zip";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ALSA_SUPPORT:
+         return "Support d'ALSA";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_BUILD_DATE:
          return "Date de build";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GIT_VERSION:
-         return "Version git";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CG_SUPPORT:
+         return "Support de CG";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COCOA_SUPPORT:
+         return "Support de Cocoa";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COMMAND_IFACE_SUPPORT:
+         return "Support de l'interface de commandes";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CORETEXT_SUPPORT:
+         return "Support de CoreText";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CPU_FEATURES:
          return "Fonctionnalités du CPU";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_DPI:
+         return "DPI de l'écran";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_HEIGHT:
+         return "Hauteur d'écran (mm)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_WIDTH:
+         return "Largeur d'écran (mm)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DSOUND_SUPPORT:
+         return "Support de DirectSoundt";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DYLIB_SUPPORT:
+         return "Support des bibliothèques dynamiques";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_EGL_SUPPORT:
+         return "Support d'EGL";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FBO_SUPPORT:
+         return "Support d'OpenGL/Direct3D render-to-texture (shaders multi-passages)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FFMPEG_SUPPORT:
+         return "Support de FFmpeg";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FREETYPE_SUPPORT:
+         return "Support de FreeType";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_IDENTIFIER:
          return "Identifiant frontend";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_NAME:
          return "Nom du frontend";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_OS:
          return "OS du frontend";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RETRORATING_LEVEL:
-         return "Niveau RetroRating";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE:
-         return "Alimentation";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_NO_SOURCE:
-         return "Non alimenté";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGING:
-         return "En chargement";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGED:
-         return "Chargé";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_DISCHARGING:
-         return "Déchargé";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VIDEO_CONTEXT_DRIVER:
-         return "Pilote du contexte vidéo";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_WIDTH:
-         return "Largeur d'écran (mm)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_HEIGHT:
-         return "Hauteur d'écran (mm)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_DPI:
-         return "DPI de l'écran";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBRETRODB_SUPPORT:
-         return "Support de libretroDB";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OVERLAY_SUPPORT:
-         return "Support des overlays";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COMMAND_IFACE_SUPPORT:
-         return "Support de l'interface de commandes";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETWORK_COMMAND_IFACE_SUPPORT:
-         return "Support des commandes réseau";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COCOA_SUPPORT:
-         return "Support de Cocoa";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RPNG_SUPPORT:
-         return "Support des PNGs (RPNG)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_SUPPORT:
-         return "Support de SDL1.2";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL2_SUPPORT:
-         return "Support de SDL2";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGL_SUPPORT:
-         return "Support d'OpenGL";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGLES_SUPPORT:
-         return "Support d'OpenGL ES";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_THREADING_SUPPORT:
-         return "Support du threading";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_KMS_SUPPORT:
-         return "Support de KMS/EGL";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_UDEV_SUPPORT:
-         return "Support de udev";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENVG_SUPPORT:
-         return "Support d'OpenVG";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_EGL_SUPPORT:
-         return "Support d'EGL";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_X11_SUPPORT:
-         return "Support de X11";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_WAYLAND_SUPPORT:
-         return "Support de Wayland";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XVIDEO_SUPPORT:
-         return "Support de XVideo";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ALSA_SUPPORT:
-         return "Support d'ALSA";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OSS_SUPPORT:
-         return "Support d'OSS";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENAL_SUPPORT:
-         return "Support d'OpenAL";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENSL_SUPPORT:
-         return "Support d'OpenSL";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RSOUND_SUPPORT:
-         return "Support de RSound";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ROARAUDIO_SUPPORT:
-         return "Support de RoarAudio";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_JACK_SUPPORT:
-         return "Support de JACK";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PULSEAUDIO_SUPPORT:
-         return "Support de PulseAudio";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DSOUND_SUPPORT:
-         return "Support de DirectSoundt";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XAUDIO2_SUPPORT:
-         return "Support de XAudio2";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ZLIB_SUPPORT:
-         return "Support de Zlib";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_7ZIP_SUPPORT:
-         return "Support de 7zip";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DYLIB_SUPPORT:
-         return "Support des bibliothèques dynamiques";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CG_SUPPORT:
-         return "Support de CG";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GIT_VERSION:
+         return "Version git";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GLSL_SUPPORT:
          return "Support de GLSL";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_HLSL_SUPPORT:
          return "Support de HLSL";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBXML2_SUPPORT:
-         return "Support du parser XML libxml2";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_IMAGE_SUPPORT:
-         return "Support de SDL_Image";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FBO_SUPPORT:
-         return "Support d'OpenGL/Direct3D render-to-texture (shaders multi-passages)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FFMPEG_SUPPORT:
-         return "Support de FFmpeg";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CORETEXT_SUPPORT:
-         return "Support de CoreText";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FREETYPE_SUPPORT:
-         return "Support de FreeType";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETPLAY_SUPPORT:
-         return "Support du jeu en réseau";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PYTHON_SUPPORT:
-         return "Support de Python (scripting des shaders)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_V4L2_SUPPORT:
-         return "Support de Video4Linux2";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_JACK_SUPPORT:
+         return "Support de JACK";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_KMS_SUPPORT:
+         return "Support de KMS/EGL";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBRETRODB_SUPPORT:
+         return "Support de libretroDB";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBUSB_SUPPORT:
          return "Support de libusb";
-      case MENU_ENUM_LABEL_VALUE_YES:
-         return "Oui";
-      case MENU_ENUM_LABEL_VALUE_NO:
-         return "Non";
-      case MENU_ENUM_LABEL_VALUE_BACK:
-         return "Retour";
-      case MENU_ENUM_LABEL_VALUE_SCREEN_RESOLUTION:
-         return "Résolution d'écran";
-      case MENU_ENUM_LABEL_VALUE_DISABLED:
-         return "Désactivé";
-      case MENU_ENUM_LABEL_VALUE_PORT:
-         return "Port";
-      case MENU_ENUM_LABEL_VALUE_NONE:
-         return "Aucun";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DEVELOPER:
-         return "Développeur";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_PUBLISHER:
-         return "Éditeur";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DESCRIPTION:
-         return "Description";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_NAME:
-         return "Nom";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ORIGIN:
-         return "Origine";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_FRANCHISE:
-         return "Franchise";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_MONTH:
-         return "Mois de sortie";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_YEAR:
-         return "Année de sortie";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBXML2_SUPPORT:
+         return "Support du parser XML libxml2";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETPLAY_SUPPORT:
+         return "Support du jeu en réseau";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETWORK_COMMAND_IFACE_SUPPORT:
+         return "Support des commandes réseau";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENAL_SUPPORT:
+         return "Support d'OpenAL";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGLES_SUPPORT:
+         return "Support d'OpenGL ES";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGL_SUPPORT:
+         return "Support d'OpenGL";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENSL_SUPPORT:
+         return "Support d'OpenSL";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENVG_SUPPORT:
+         return "Support d'OpenVG";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OSS_SUPPORT:
+         return "Support d'OSS";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OVERLAY_SUPPORT:
+         return "Support des overlays";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE:
+         return "Alimentation";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGED:
+         return "Chargé";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGING:
+         return "En chargement";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_DISCHARGING:
+         return "Déchargé";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_NO_SOURCE:
+         return "Non alimenté";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PULSEAUDIO_SUPPORT:
+         return "Support de PulseAudio";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PYTHON_SUPPORT:
+         return "Support de Python (scripting des shaders)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RETRORATING_LEVEL:
+         return "Niveau RetroRating";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ROARAUDIO_SUPPORT:
+         return "Support de RoarAudio";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RPNG_SUPPORT:
+         return "Support des PNGs (RPNG)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RSOUND_SUPPORT:
+         return "Support de RSound";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL2_SUPPORT:
+         return "Support de SDL2";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_IMAGE_SUPPORT:
+         return "Support de SDL_Image";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_SUPPORT:
+         return "Support de SDL1.2";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_THREADING_SUPPORT:
+         return "Support du threading";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_UDEV_SUPPORT:
+         return "Support de udev";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_V4L2_SUPPORT:
+         return "Support de Video4Linux2";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VIDEO_CONTEXT_DRIVER:
+         return "Pilote du contexte vidéo";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_WAYLAND_SUPPORT:
+         return "Support de Wayland";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_X11_SUPPORT:
+         return "Support de X11";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XAUDIO2_SUPPORT:
+         return "Support de XAudio2";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XVIDEO_SUPPORT:
+         return "Support de XVideo";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ZLIB_SUPPORT:
+         return "Support de Zlib";
+      case MENU_ENUM_LABEL_VALUE_TAKE_SCREENSHOT:
+         return "Capturer l écran";
+      case MENU_ENUM_LABEL_VALUE_THREADED_DATA_RUNLOOP_ENABLE:
+         return "Boucle de données threadée";
+      case MENU_ENUM_LABEL_VALUE_THUMBNAILS:
+         return "Vignettes";
+      case MENU_ENUM_LABEL_VALUE_THUMBNAILS_DIRECTORY:
+         return "Dossier des vignettes";
+      case MENU_ENUM_LABEL_VALUE_TIMEDATE_ENABLE:
+         return "Afficher la date et l'heure";
+      case MENU_ENUM_LABEL_VALUE_TITLE_COLOR:
+         return "Couleur du titre du menu";
       case MENU_ENUM_LABEL_VALUE_TRUE:
          return "Vrai";
-      case MENU_ENUM_LABEL_VALUE_FALSE:
-         return "Faux";
-      case MENU_ENUM_LABEL_VALUE_MISSING:
-         return "Manquant";
-      case MENU_ENUM_LABEL_VALUE_PRESENT:
-         return "Présent";
-      case MENU_ENUM_LABEL_VALUE_OPTIONAL:
-         return "Optionnel";
-      case MENU_ENUM_LABEL_VALUE_REQUIRED:
-         return "Requis";
-      case MENU_ENUM_LABEL_VALUE_STATUS:
-         return "Statut";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_SETTINGS:
-         return "Audio";
-      case MENU_ENUM_LABEL_VALUE_INPUT_SETTINGS:
-         return "Entrées";
-      case MENU_ENUM_LABEL_VALUE_ONSCREEN_DISPLAY_SETTINGS:
-         return "Messages d'info";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_SETTINGS:
-         return "Overlays";
-      case MENU_ENUM_LABEL_VALUE_MENU_SETTINGS:
-         return "Menu";
-      case MENU_ENUM_LABEL_VALUE_MULTIMEDIA_SETTINGS:
-         return "Multimédia";
-      case MENU_ENUM_LABEL_VALUE_USER_INTERFACE_SETTINGS:
-         return "Interface graphique";
-      case MENU_ENUM_LABEL_VALUE_MENU_FILE_BROWSER_SETTINGS:
-         return "Navigateur de fichiers";
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_SETTINGS:
-         return "Mises à jour";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_SETTINGS:
-         return "Réseau";
-      case MENU_ENUM_LABEL_VALUE_PLAYLIST_SETTINGS:
-         return "Playlists";
-      case MENU_ENUM_LABEL_VALUE_USER_SETTINGS:
-         return "Utilisateur";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_SETTINGS:
-         return "Dossiers";
-      case MENU_ENUM_LABEL_VALUE_RECORDING_SETTINGS:
-         return "Capture video";
-      case MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE:
-         return "Pas d'informations disponibles.";
-      case MENU_ENUM_LABEL_VALUE_INPUT_USER_BINDS:
-         return "Entrées utilisateur %u";
-      case MENU_ENUM_LABEL_VALUE_LANG_ENGLISH:
-         return "Anglais";
-      case MENU_ENUM_LABEL_VALUE_LANG_JAPANESE:
-         return "Japonais";
-      case MENU_ENUM_LABEL_VALUE_LANG_FRENCH:
-         return "Français";
-      case MENU_ENUM_LABEL_VALUE_LANG_SPANISH:
-         return "Espagnol";
-      case MENU_ENUM_LABEL_VALUE_LANG_GERMAN:
-         return "Allemand";
-      case MENU_ENUM_LABEL_VALUE_LANG_ITALIAN:
-         return "Italien";
-      case MENU_ENUM_LABEL_VALUE_LANG_DUTCH:
-         return "Néerlandais";
-      case MENU_ENUM_LABEL_VALUE_LANG_PORTUGUESE:
-         return "Portuguais";
-      case MENU_ENUM_LABEL_VALUE_LANG_RUSSIAN:
-         return "Russe";
-      case MENU_ENUM_LABEL_VALUE_LANG_KOREAN:
-         return "Coréen";
-      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_TRADITIONAL:
-         return "Chinois (Traditionnel)";
-      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_SIMPLIFIED:
-         return "Chinois (Simplifié)";
-      case MENU_ENUM_LABEL_VALUE_LANG_ESPERANTO:
-         return "Esperanto";
-      case MENU_ENUM_LABEL_VALUE_LEFT_ANALOG:
-         return "Stick analogique gauche";
-      case MENU_ENUM_LABEL_VALUE_RIGHT_ANALOG:
-         return "Stick analogique droite";
-      case MENU_ENUM_LABEL_VALUE_INPUT_HOTKEY_BINDS:
-         return "Racourcis d'entrées";
-      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_SETTINGS:
-         return "Vitesse d'affichage";
-      case MENU_ENUM_LABEL_VALUE_SEARCH:
-         return "Recherche :";
-      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_IMAGE_VIEWER:
-         return "Utiliser le lecteur d'image embarqué";
-      case MENU_ENUM_LABEL_VALUE_HELP_LIST:
-         return "Aide";
-      case MENU_ENUM_LABEL_VALUE_START_CORE:
-         return "Démarrer le coeur";
-      case MENU_ENUM_LABEL_VALUE_START_NET_RETROPAD:
-         return "Mode manette à distance";
-      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG:
-         return "Sauvegarder la configuration actuelle";
-      case MENU_ENUM_LABEL_VALUE_SETTINGS_TAB:
-         return "Réglages";
-      case MENU_ENUM_LABEL_VALUE_HISTORY_TAB:
-         return "Historique";
-      case MENU_ENUM_LABEL_VALUE_ADD_TAB:
-         return "Scanner";
-      case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_HIDE_IN_MENU:
-         return "Cacher l'overlay dans le menu";
-      case MENU_ENUM_LABEL_CONTENT_HISTORY_SIZE:
-         return "Taille de l'historique";
-      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_LIST:
-         return "Comptes en ligne";
-      case MENU_ENUM_LABEL_VALUE_MENU_LINEAR_FILTER:
-         return "Filtre linéaire";
-      case MENU_ENUM_LABEL_VALUE_XMB_SCALE_FACTOR:
-         return "XMB : Zoom";
-      case MENU_ENUM_LABEL_VALUE_XMB_ALPHA_FACTOR:
-         return "XMB : Transparence";
-      case MENU_ENUM_LABEL_VALUE_XMB_FONT:
-         return "XMB : Police";
-      case MENU_ENUM_LABEL_VALUE_XMB_THEME:
-         return "XMB : Theme";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME:
-         return "Dégradé de font d'écran";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME:
-         return "Dégradé de font d'écran";
-      case MENU_ENUM_LABEL_VALUE_XMB_SHADOWS_ENABLE:
-         return "Ombres pour les icones";
-      case MENU_ENUM_LABEL_VALUE_XMB_RIBBON_ENABLE:
-         return "Font d'écran animé";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_REMOTE_ENABLE:
-         return "Manette réseau";
-      case MENU_ENUM_LABEL_VALUE_RUN:
-         return "Lancer";
-      case MENU_ENUM_LABEL_VALUE_STATE_SLOT:
-         return "Slot de savestate";
-
+      case MENU_ENUM_LABEL_VALUE_UI_COMPANION_START_ON_BOOT:
+         return "UI Companion Start On Boot";
+      case MENU_ENUM_LABEL_VALUE_UI_MENUBAR_ENABLE:
+         return "Menubar";
+      case MENU_ENUM_LABEL_VALUE_UNABLE_TO_READ_COMPRESSED_FILE:
+         return "Impossible de lire l'archive.";
       case MENU_ENUM_LABEL_VALUE_UNDO_LOAD_STATE:
          return "Annuler charger une savestate";
       case MENU_ENUM_LABEL_VALUE_UNDO_SAVE_STATE:
          return "Annuler sauvegarder une savestate";
+      case MENU_ENUM_LABEL_VALUE_UNKNOWN:
+         return "Inconnu";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_ASSETS:
+         return "Mettre à jour les assets";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_AUTOCONFIG_PROFILES:
+         return "Mettre à jour les profils d'autoconfiguration";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_CG_SHADERS:
+         return "Mettre à jour les shaders CG";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_CHEATS:
+         return "Mettre à jour les codes de triche";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_CORE_INFO_FILES:
+         return "Mettre à jour les informations des coeurs";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_DATABASES:
+         return "Mettre à jour les bases de données";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_GLSL_SHADERS:
+         return "Mettre à jour les shaders GLSL";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_OVERLAYS:
+         return "Mettre à jour les overlays";
+      case MENU_ENUM_LABEL_VALUE_USER:
+         return "Utilisateur";
+      case MENU_ENUM_LABEL_VALUE_USER_INTERFACE_SETTINGS:
+         return "Interface graphique";
+      case MENU_ENUM_LABEL_VALUE_USER_LANGUAGE:
+         return "Langage";
+      case MENU_ENUM_LABEL_VALUE_USER_SETTINGS:
+         return "Utilisateur";
+      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_IMAGE_VIEWER:
+         return "Utiliser le lecteur d'image embarqué";
+      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_PLAYER:
+         return "Utiliser le lecteur vidéo embarqué";
+      case MENU_ENUM_LABEL_VALUE_USE_THIS_DIRECTORY:
+         return "<Choisir ce dossier>";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ALLOW_ROTATE:
+         return "Autoriser la rotation";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_AUTO:
+         return "Format d'image automatique";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_INDEX:
+         return "Rapport d'aspect";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_BLACK_FRAME_INSERTION:
+         return "Insérer des frames noires";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_CROP_OVERSCAN:
+         return "Tronquer l'overscan (Reload)";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_DISABLE_COMPOSITION:
+         return "Désactiver le compositeur du bureau";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_DRIVER:
+         return "Pilote vidéo";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER:
+         return "Filtre vidéo";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_DIR:
+         return "Dossier des filtres vidéo";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_FLICKER:
+         return "Filtre anti-scintillement";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_ENABLE:
+         return "Afficher les messages d'info";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_PATH:
+         return "Police des messages d'info";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_SIZE:
+         return "Taille du texte des messages";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_ASPECT:
+         return "Forcer le format d'image";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_SRGB_DISABLE:
+         return "Désactiver sRGB FBO";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FRAME_DELAY:
+         return "Délayer les frames";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FULLSCREEN:
+         return "Plein écran";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_GAMMA:
+         return "Gamma";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_RECORD:
+         return "Captures vidéo via le GPU";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_SCREENSHOT:
+         return "Activer les captures d'écran GPU";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC:
+         return "Synchroniser le GPU au CPU";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_X:
+         return "Position X";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_Y:
+         return "Position Y";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MONITOR_INDEX:
+         return "Écran";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_POST_FILTER_RECORD:
+         return "Activer les filtres de traitement";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE:
+         return "Fréquence de rafraichissement";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE_AUTO:
+         return "Fréquence estimée de l'écran";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ROTATION:
+         return "Rotation";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE:
+         return "Zoom (en fenêtre)";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE_INTEGER:
+         return "Aligner aux pixels de l'écran";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SETTINGS:
+         return "Vidéo";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_DIR:
+         return "Dossier des shaders vidéo";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_NUM_PASSES:
+         return "Nombre de passages";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHARED_CONTEXT:
+         return "Partager le contexte matériel";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SMOOTH:
+         return "Filtre bilinéaire (HW)";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SOFT_FILTER:
+         return "Filtre doux activé";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SWAP_INTERVAL:
+         return "Intervale de synchronisation verticale";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_THREADED:
+         return "Threader l'affichage";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VFILTER:
+         return "Deflicker"; /* TODO */
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VI_WIDTH:
+         return "Set VI Screen Width"; /* TODO */
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VSYNC:
+         return "Synchronisation verticale";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_WINDOWED_FULLSCREEN:
+         return "Mode plein écran fenêtré";
+      case MENU_ENUM_LABEL_VALUE_XMB_ALPHA_FACTOR:
+         return "XMB : Transparence";
+      case MENU_ENUM_LABEL_VALUE_XMB_FONT:
+         return "XMB : Police";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME:
+         return "Dégradé de font d'écran";
+      case MENU_ENUM_LABEL_VALUE_XMB_RIBBON_ENABLE:
+         return "Font d'écran animé";
+      case MENU_ENUM_LABEL_VALUE_XMB_SCALE_FACTOR:
+         return "XMB : Zoom";
+      case MENU_ENUM_LABEL_VALUE_XMB_SHADOWS_ENABLE:
+         return "Ombres pour les icones";
+      case MENU_ENUM_LABEL_VALUE_XMB_THEME:
+         return "XMB : Theme";
+      case MENU_ENUM_LABEL_VALUE_YES:
+         return "Oui";
+      case MENU_ENUM_LABEL_VIDEO_FILTER_FLICKER:
+         return "video_filter_flicker";
+      case MSG_APPENDED_DISK:
+         return "Disque fusionné";
+      case MSG_APPLYING_SHADER:
+         return "Application du shader";
+      case MSG_AUDIO_MUTED:
+         return "Son coupé.";
+      case MSG_AUDIO_UNMUTED:
+         return "Remise du son.";
+      case MSG_AUTOSAVE_FAILED:
+         return "Impossible d'activer l'enregistrement automatique.";
+      case MSG_BLOCKING_SRAM_OVERWRITE:
+         return "Bloque l'écrasement de la SRAM";
+      case MSG_BYTES:
+         return "octets";
+      case MSG_CHEEVOS_HARDCORE_MODE_ENABLE:
+         return "Mode matériel activé : savestate et rembobinage sont désactivés.";
+      case MSG_CONFIG_DIRECTORY_NOT_SET:
+         return "Répertoire de configuration non défini. Impossible de sauvegarder le nouveau fichier.";
+      case MSG_CORE_DOES_NOT_SUPPORT_SAVESTATES:
+         return "Le core ne supporte pas les savestates.";
+      case MSG_COULD_NOT_READ_CONTENT_FILE:
+         return "Impossible de lire le contenu du fichier";
+      case MSG_CUSTOM_TIMING_GIVEN:
+         return "Temps personnalisé attribué";
+      case MSG_DETECTED_VIEWPORT_OF:
+         return "Détection du visuel";
+      case MSG_DOWNLOADING:
+         return "Téléchargement";
+      case MSG_EXTRACTING:
+         return "Extraction";
+      case MSG_FAILED_TO:
+         return "Échec de";
+      case MSG_FAILED_TO_APPLY_SHADER:
+         return "Impossible d'appliquer le shader.";
+      case MSG_FAILED_TO_LOAD_CONTENT:
+         return "Échec du chargement du fichier";
+      case MSG_FAILED_TO_LOAD_MOVIE_FILE:
+         return "Échec du chargement du fichier vidéo";
+      case MSG_FAILED_TO_LOAD_OVERLAY:
+         return "Impossible de charger l'overlay.";
+      case MSG_FAILED_TO_LOAD_STATE:
+         return "Impossible de charger la savestate à partir de";
+      case MSG_FAILED_TO_REMOVE_DISK_FROM_TRAY:
+         return "Impossible d'éjecter le disque du lecteur.";
+      case MSG_FAILED_TO_REMOVE_TEMPORARY_FILE:
+         return "Impossible de supprimer le fichier temporaire";
+      case MSG_FAILED_TO_SAVE_SRAM:
+         return "Impossible de sauvegarder la SRAM";
+      case MSG_FAILED_TO_SAVE_STATE_TO:
+         return "Impossible de sauvegarder la savestate vers";
+      case MSG_FAILED_TO_START_MOVIE_RECORD:
+         return "Impossible de démarrer l'enregistrement vidéo.";
+      case MSG_FAILED_TO_START_RECORDING:
+         return "Échec de l'activation de l'enregistrement.";
+      case MSG_FAILED_TO_TAKE_SCREENSHOT:
+         return "Échec de la copie d'écran.";
+      case MSG_FAILED_TO_UNDO_LOAD_STATE:
+         return "Aucun savestate de retour arrière trouvé";
+      case MSG_FAILED_TO_UNDO_SAVE_STATE:
+         return "Impossible de sauvegarder les informations de savestate de retour arrière";
+      case MSG_FAILED_TO_UNMUTE_AUDIO:
+         return "Impossible de remettre le son.";
+      case MSG_FOUND_SHADER:
+         return "Shader trouvé";
+      case MSG_GOT_INVALID_DISK_INDEX:
+         return "Index du disque invalide.";
+      case MSG_GRAB_MOUSE_STATE:
+         return "Capture la souris";
+      case MSG_HW_RENDERED_MUST_USE_POSTSHADED_RECORDING:
+         return "Le core Libretro utilise le rendu matériel. Obligation d'utiliser également l'enregistrement post-shaded.";
+      case MSG_LIBRETRO_ABI_BREAK:
+         return "est compilé avec une version différente de la bibliothèque libretro actuelle.";
+      case MSG_LOADED_STATE_FROM_SLOT:
+         return "Chargement du savestate à partir du slot";
+      case MSG_LOADING_CONTENT_FILE:
+         return "Chargement du contenu";
+      case MSG_LOADING_STATE:
+         return "Chargement savestate";
+      case MSG_MOVIE_PLAYBACK_ENDED:
+         return "Fin de la lecture vidéo";
+      case MSG_MOVIE_RECORD_STOPPED:
+         return "Arrêt de l'enregistrement vidéo.";
+      case MSG_NETPLAY_FAILED:
+         return "Échec de l'initialisation du jeu en réseau";
+      case MSG_NETPLAY_FAILED_MOVIE_PLAYBACK_HAS_STARTED:
+         return "Lecture en cours. Impossible d'activer le jeu en réseau.";
+      case MSG_PAUSED:
+         return "Pause.";
+      case MSG_PROGRAM:
+         return "RetroArch";
+      case MSG_RECEIVED:
+         return "Reçu";
+      case MSG_RECORDING_TERMINATED_DUE_TO_RESIZE:
+         return "Enregistrement interrompu à cause du redimensionnement.";
+      case MSG_RECORDING_TO:
+         return "Enregistrement vers";
+      case MSG_REDIRECTING_CHEATFILE_TO:
+         return "Redirection du fichier triche vers";
+      case MSG_REDIRECTING_SAVEFILE_TO:
+         return "Redirection de la sauvegarde vers";
+      case MSG_REDIRECTING_SAVESTATE_TO:
+         return "Redirection de la savestate vers";
+      case MSG_REMOVED_DISK_FROM_TRAY:
+         return "Éjection du disque du lecteur.";
+      case MSG_REMOVING_TEMPORARY_CONTENT_FILE:
+         return "Suppression du fichier temporaire";
+      case MSG_RESET:
+         return "Reset";
+      case MSG_RESTARTING_RECORDING_DUE_TO_DRIVER_REINIT:
+         return "Redémarrage de l'enregistrement à cause de la réinitialisation du pilote.";
+      case MSG_REWINDING:
+         return "Rembobinage.";
+      case MSG_REWIND_INIT:
+         return "Initialisation du tampon pour le retour rapide avec une taille";
+      case MSG_REWIND_INIT_FAILED:
+         return "Échec de l'initialisation du tampon pour le retour rapide. Cette fonctionnalité sera désactivée.";
+      case MSG_REWIND_INIT_FAILED_THREADED_AUDIO:
+         return "L'implémentation utilise audio thread. Impossible d'activer le retour rapide.";
+      case MSG_REWIND_REACHED_END:
+         return "Atteinte de la fin du tampon de rembobinage.";
+      case MSG_SAVED_STATE_TO_SLOT:
+         return "Savestate vers slot";
+      case MSG_SAVED_SUCCESSFULLY_TO:
+         return "Sauvegarde réussie vers";
+      case MSG_SAVING_RAM_TYPE:
+         return "Sauvegarde du type de RAM";
+      case MSG_SAVING_STATE:
+         return "Sauvegarde savestate";
+      case MSG_SCANNING:
+         return "Analyse";
+      case MSG_SCANNING_OF_DIRECTORY_FINISHED:
+         return "Analyse des dossiers terminée";
+      case MSG_SENDING_COMMAND:
+         return "Envoi commande";
+      case MSG_SHADER:
+         return "Shader";
+      case MSG_SKIPPING_SRAM_LOAD:
+         return "Ignore le chargement de la SRAM.";
+      case MSG_SLOW_MOTION:
+         return "Ralenti.";
+      case MSG_SLOW_MOTION_REWIND:
+         return "Rembobinage ralenti.";
+      case MSG_SRAM_WILL_NOT_BE_SAVED:
+         return "SRAM ne sera pas sauvegardée.";
+      case MSG_STARTING_MOVIE_PLAYBACK:
+         return "Démarrage de la lecture vidéo.";
+      case MSG_STARTING_MOVIE_RECORD_TO:
+         return "Démarrage de l'enregistrement vidéo vers";
+      case MSG_STATE_SIZE:
+         return "Taille savestate";
+      case MSG_STATE_SLOT:
+         return "State slot";
+      case MSG_TAKING_SCREENSHOT:
+         return "Réalisation d'une copie d'écran.";
+      case MSG_TO:
+         return "de";
+      case MSG_UNKNOWN:
+         return "Inconnu";
+      case MSG_UNPAUSED:
+         return "Relancé.";
+      case MSG_UNRECOGNIZED_COMMAND:
+         return "Commande non reconnue";
+      case MSG_USING_LIBRETRO_DUMMY_CORE_RECORDING_SKIPPED:
+         return "Utilisation d'un core libretro simple. Ignore l'enregistrement.";
+      case MSG_VIEWPORT_SIZE_CALCULATION_FAILED:
+         return "Échec du calcul de la taille du visuel ! Utilisation des données brutes. Cela ne fonctionnera probablement pas bien ...";
+      case MSG_VIRTUAL_DISK_TRAY:
+         return "Lecteur de disque virtuel.";
       default:
          break;
    }

--- a/intl/msg_hash_it.c
+++ b/intl/msg_hash_it.c
@@ -63,7 +63,7 @@ int menu_hash_get_help_it_enum(enum msg_hash_enums msg, char *s, size_t len)
             char u[501];
             char t[501];
 
-            strlcpy(t, 
+            strlcpy(t,
                   "RetroArch si basa su una forma unica di\n"
                   "sincronizzazione audio/video che necessita essere\n"
                   "calibrata rispetto alla frequenza di aggiornamento\n"
@@ -901,7 +901,7 @@ int menu_hash_get_help_it_enum(enum msg_hash_enums msg, char *s, size_t len)
                " Possible values are [0.0, 1.0].");
          break;
       case MENU_ENUM_LABEL_INPUT_TURBO_PERIOD:
-         snprintf(s, len, 
+         snprintf(s, len,
                "Turbo period.\n"
                " \n"
                "Describes speed of which turbo-enabled\n"
@@ -1099,134 +1099,134 @@ const char *msg_hash_to_str_it(enum msg_hash_enums msg)
 {
    switch (msg)
    {
-      case MENU_ENUM_LABEL_VALUE_NO_ENTRIES_TO_DISPLAY:
-         return "Nessuna voce da mostrare.";
-      case MENU_ENUM_LABEL_VALUE_NO_ACHIEVEMENTS_TO_DISPLAY:
-         return "Nessun obiettivo da mostrare.";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_UNLOCKED_ACHIEVEMENTS:
-         return "Obiettivi sbloccati:";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_LOCKED_ACHIEVEMENTS:
-         return "Obiettivi bloccati:";
-      case MENU_ENUM_LABEL_VALUE_START_VIDEO_PROCESSOR:
-         return "Avvia processore video";
-      case MENU_ENUM_LABEL_VALUE_START_NET_RETROPAD:
-         return "Avvia Retropad remoto";
-      case MENU_ENUM_LABEL_VALUE_THUMBNAILS_UPDATER_LIST:
-         return "Aggiorna miniature";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_HARDCORE_MODE_ENABLE:
-         return "Modalità Hardcore";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_TEST_UNOFFICIAL:
-         return "Prova non ufficiali";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_SETTINGS:
-         return "Retro Obiettivi";
-	  case MENU_ENUM_LABEL_VALUE_PARENT_DIRECTORY:
-         return "Directory precedente";
+	  case MENU_ENUM_LABEL_VALUE_CHEEVOS_DESCRIPTION:
+         return "Descrizione";
+	  case MENU_ENUM_LABEL_VALUE_INPUT_ALL_USERS_CONTROL_MENU:
+         return "Menù di controllo per tutti gli utenti";
 	  case MENU_ENUM_LABEL_VALUE_INPUT_ICADE_ENABLE:
          return "Abilita mappatura gamepad tastiera";
-      case MENU_ENUM_LABEL_VALUE_INPUT_KEYBOARD_GAMEPAD_MAPPING_TYPE:
-         return "Tipologia di mappatura gamepad tastiera";
-      case MENU_ENUM_LABEL_VALUE_INPUT_SMALL_KEYBOARD_ENABLE:
-         return "Abilita tastiera ridotta";
+	  case MENU_ENUM_LABEL_VALUE_PARENT_DIRECTORY:
+         return "Directory precedente";
 	  case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG_OVERRIDE_CORE:
          return "Salva override del core";
-      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG_OVERRIDE_GAME:
-         return "Salva override di gioco";
-      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG:
-         return "Salva configurazione attuale";
-      case MENU_ENUM_LABEL_VALUE_STATE_SLOT:
-         return "Slot di stato";
+      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_PASSWORD:
+         return "Password";
       case MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_SETTINGS:
          return "Obiettivi dell'account";
       case MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_USERNAME:
          return "Nome utente";
-      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_PASSWORD:
-         return "Password";
-      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_RETRO_ACHIEVEMENTS:
-         return "Retro Obiettivi";
       case MENU_ENUM_LABEL_VALUE_ACCOUNTS_LIST:
          return "Account";
       case MENU_ENUM_LABEL_VALUE_ACCOUNTS_LIST_END:
          return "Lista degli account";
-      case MENU_ENUM_LABEL_VALUE_HELP_SCANNING_CONTENT:
-         return "Scansiona per contenuto";
-	  case MENU_ENUM_LABEL_VALUE_CHEEVOS_DESCRIPTION:
-         return "Descrizione";
+      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_RETRO_ACHIEVEMENTS:
+         return "Retro Obiettivi";
+      case MENU_ENUM_LABEL_VALUE_ADD_CONTENT_LIST:
+         return "Aggiungi Contenuto";
+      case MENU_ENUM_LABEL_VALUE_ASK_ARCHIVE:
+         return "Chiedi";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS:
+         return "Menù di base dei controlli";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_BACK:
+         return "Indietro";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_CONFIRM:
+         return "Conferma/OK";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_INFO:
+         return "Info";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_QUIT:
+         return "Esci";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_SCROLL_DOWN:
+         return "Scorri verso il basso";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_SCROLL_UP:
+         return "Scorri verso l'alto";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_START:
+         return "Predefinito";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_TOGGLE_KEYBOARD:
+         return "Tastiera a comparsa";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_TOGGLE_MENU:
+         return "Menù a comparsa";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_HARDCORE_MODE_ENABLE:
+         return "Modalità Hardcore";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_LOCKED_ACHIEVEMENTS:
+         return "Obiettivi bloccati:";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_SETTINGS:
+         return "Retro Obiettivi";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_TEST_UNOFFICIAL:
+         return "Prova non ufficiali";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_UNLOCKED_ACHIEVEMENTS:
+         return "Obiettivi sbloccati:";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_SETTINGS:
+         return "Menù rapido";
+      case MENU_ENUM_LABEL_VALUE_DOWNLOAD_CORE_CONTENT:
+         return "Scarica contenuto";
       case MENU_ENUM_LABEL_VALUE_HELP_AUDIO_VIDEO_TROUBLESHOOTING:
          return "Problemi Audio/Video";
       case MENU_ENUM_LABEL_VALUE_HELP_CHANGE_VIRTUAL_GAMEPAD:
          return "Cambia i settaggi del gamepad virtuale";
-      case MENU_ENUM_LABEL_VALUE_HELP_WHAT_IS_A_CORE:
-         return "Che cosa è un core?";
-      case MENU_ENUM_LABEL_VALUE_HELP_LOADING_CONTENT:
-         return "Carica Contenuto";
-      case MENU_ENUM_LABEL_VALUE_HELP_LIST:
-         return "Aiuto";
       case MENU_ENUM_LABEL_VALUE_HELP_CONTROLS:
          return "Menù di base dei controlli";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS:
-         return "Menù di base dei controlli";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_SCROLL_UP:
-         return "Scorri verso l'alto";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_SCROLL_DOWN:
-         return "Scorri verso il basso";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_CONFIRM:
-         return "Conferma/OK";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_BACK:
-         return "Indietro";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_START:
-         return "Predefinito";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_INFO:
-         return "Info";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_TOGGLE_MENU:
-         return "Menù a comparsa";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_QUIT:
-         return "Esci";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_TOGGLE_KEYBOARD:
-         return "Tastiera a comparsa";
-      case MENU_ENUM_LABEL_VALUE_OPEN_ARCHIVE:
-         return "Apri archivio come cartella";
-      case MENU_ENUM_LABEL_VALUE_LOAD_ARCHIVE:
-         return "Carica archivio con il core";
-      case MENU_ENUM_LABEL_VALUE_INPUT_BACK_AS_MENU_TOGGLE_ENABLE:
-         return "Indietro quando il menù a comparsa è abilitato";
-      case MENU_ENUM_LABEL_VALUE_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
-         return "Combo gamepad per il menù a comparsa";
-	  case MENU_ENUM_LABEL_VALUE_INPUT_ALL_USERS_CONTROL_MENU:
-         return "Menù di controllo per tutti gli utenti";
-      case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_HIDE_IN_MENU:
-         return "Nascondi overlay nel menù";
-      case MENU_ENUM_LABEL_VALUE_LANG_POLISH:
-         return "Polacco";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_AUTOLOAD_PREFERRED:
-         return "Autocarica overlay preferito";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_CORE_INFO_FILES:
-         return "Aggiorna le info dei core";
-      case MENU_ENUM_LABEL_VALUE_DOWNLOAD_CORE_CONTENT:
-         return "Scarica contenuto";
-      case MENU_ENUM_LABEL_VALUE_SCAN_THIS_DIRECTORY:
-         return "<Scansiona questa directory>";
-      case MENU_ENUM_LABEL_VALUE_SCAN_FILE:
-         return "Scansiona file";
-      case MENU_ENUM_LABEL_VALUE_SCAN_DIRECTORY:
-         return "Scansiona directory";
-      case MENU_ENUM_LABEL_VALUE_ADD_CONTENT_LIST:
-         return "Aggiungi Contenuto";
+      case MENU_ENUM_LABEL_VALUE_HELP_LIST:
+         return "Aiuto";
+      case MENU_ENUM_LABEL_VALUE_HELP_LOADING_CONTENT:
+         return "Carica Contenuto";
+      case MENU_ENUM_LABEL_VALUE_HELP_SCANNING_CONTENT:
+         return "Scansiona per contenuto";
+      case MENU_ENUM_LABEL_VALUE_HELP_WHAT_IS_A_CORE:
+         return "Che cosa è un core?";
       case MENU_ENUM_LABEL_VALUE_INFORMATION_LIST:
          return "Informazioni";
-      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_PLAYER:
-         return "Usa Media Player interno";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_SETTINGS:
-         return "Menù rapido";
+      case MENU_ENUM_LABEL_VALUE_INPUT_BACK_AS_MENU_TOGGLE_ENABLE:
+         return "Indietro quando il menù a comparsa è abilitato";
+      case MENU_ENUM_LABEL_VALUE_INPUT_KEYBOARD_GAMEPAD_MAPPING_TYPE:
+         return "Tipologia di mappatura gamepad tastiera";
+      case MENU_ENUM_LABEL_VALUE_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
+         return "Combo gamepad per il menù a comparsa";
+      case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_HIDE_IN_MENU:
+         return "Nascondi overlay nel menù";
+      case MENU_ENUM_LABEL_VALUE_INPUT_SMALL_KEYBOARD_ENABLE:
+         return "Abilita tastiera ridotta";
+      case MENU_ENUM_LABEL_VALUE_LANG_POLISH:
+         return "Polacco";
+      case MENU_ENUM_LABEL_VALUE_LOAD_ARCHIVE:
+         return "Carica archivio con il core";
+      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_LIST:
+         return "Carica Contenuto";
+      case MENU_ENUM_LABEL_VALUE_NO_ACHIEVEMENTS_TO_DISPLAY:
+         return "Nessun obiettivo da mostrare.";
+      case MENU_ENUM_LABEL_VALUE_NO_ENTRIES_TO_DISPLAY:
+         return "Nessuna voce da mostrare.";
+      case MENU_ENUM_LABEL_VALUE_OPEN_ARCHIVE:
+         return "Apri archivio come cartella";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_AUTOLOAD_PREFERRED:
+         return "Autocarica overlay preferito";
+      case MENU_ENUM_LABEL_VALUE_PRIVACY_SETTINGS:
+         return "Privacy";
       case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_CRC32:
          return "CRC32";
       case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_MD5:
          return "MD5";
-      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_LIST:
-         return "Carica Contenuto";
-      case MENU_ENUM_LABEL_VALUE_ASK_ARCHIVE:
-         return "Chiedi";
-      case MENU_ENUM_LABEL_VALUE_PRIVACY_SETTINGS:
-         return "Privacy";
+      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG:
+         return "Salva configurazione attuale";
+      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG_OVERRIDE_GAME:
+         return "Salva override di gioco";
+      case MENU_ENUM_LABEL_VALUE_SCAN_DIRECTORY:
+         return "Scansiona directory";
+      case MENU_ENUM_LABEL_VALUE_SCAN_FILE:
+         return "Scansiona file";
+      case MENU_ENUM_LABEL_VALUE_SCAN_THIS_DIRECTORY:
+         return "<Scansiona questa directory>";
+      case MENU_ENUM_LABEL_VALUE_START_NET_RETROPAD:
+         return "Avvia Retropad remoto";
+      case MENU_ENUM_LABEL_VALUE_START_VIDEO_PROCESSOR:
+         return "Avvia processore video";
+      case MENU_ENUM_LABEL_VALUE_STATE_SLOT:
+         return "Slot di stato";
+      case MENU_ENUM_LABEL_VALUE_THUMBNAILS_UPDATER_LIST:
+         return "Aggiorna miniature";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_CORE_INFO_FILES:
+         return "Aggiorna le info dei core";
+      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_PLAYER:
+         return "Usa Media Player interno";
 #if 0
       case MENU_ENUM_LABEL_VALUE_HORIZONTAL_MENU:
          return "Menú orizzontale";
@@ -1721,7 +1721,7 @@ const char *msg_hash_to_str_it(enum msg_hash_enums msg)
       case MENU_ENUM_LABEL_VALUE_CURSOR_MANAGER:
          return "Gestore cursori";
       case MENU_ENUM_LABEL_VALUE_MAIN_MENU:
-         return "Menú principale"; 
+         return "Menú principale";
       case MENU_ENUM_LABEL_VALUE_SETTINGS:
          return "Settaggi";
       case MENU_ENUM_LABEL_VALUE_QUIT_RETROARCH:
@@ -1927,13 +1927,13 @@ const char *msg_hash_to_str_it(enum msg_hash_enums msg)
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RBMP_SUPPORT:
          return "Supporto BMP (RBMP)";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RTGA_SUPPORT:
-	 return "Supporto RTGA (RTGA)";
+         return "Supporto RTGA (RTGA)";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_SUPPORT:
          return "Supporto SDL1.2";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL2_SUPPORT:
          return "Supporto SDL2";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VULKAN_SUPPORT:
-	 return "Supporto Vulkan";
+         return "Supporto Vulkan";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGL_SUPPORT:
          return "Supporto OpenGL";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGLES_SUPPORT:

--- a/intl/msg_hash_jp.c
+++ b/intl/msg_hash_jp.c
@@ -1896,156 +1896,484 @@ static const char *menu_hash_to_str_jp_label_enum(enum msg_hash_enums msg)
 
    switch (msg)
    {
-      case MENU_ENUM_SUBLABEL_VIDEO_THREADED:
-         return "パフォーマンスを改良するけど、ビデオの遅延と途切れが増す。フルスピードを取得しない時だけで使用する。";
-      case MENU_ENUM_SUBLABEL_VIDEO_HARD_SYNC:
-         return "CPUとGPUを強制に同期する。遅延が減るけどパフォーマンスも減る。";
-      case MENU_ENUM_SUBLABEL_MENU_SETTINGS:
-         return "メニューの外観関係の設定を変更する。";
-      case MSG_CONNECTION_SLOT:
-         return "Connection slot";
-      case MSG_WAITING_FOR_CLIENT:
-         return "Waiting for client ...";
-      case MSG_CONNECTING_TO_NETPLAY_HOST:
-         return "Connecting to netplay host";
-      case MSG_GOT_CONNECTION_FROM:
-         return "Got connection from";
-      case MSG_AUTODETECT:
-         return "Autodetect";
-      case MSG_SUCCEEDED:
-         return "succeeded";
-      case MSG_FAILED:
-         return "failed";
-      case MSG_UNKNOWN_NETPLAY_COMMAND_RECEIVED:
-         return "Unknown netplay command received";
-      case MSG_NETPLAY_USERS_HAS_FLIPPED:
-         return "Netplay users has flipped";
-      case MSG_FILE_ALREADY_EXISTS_SAVING_TO_BACKUP_BUFFER:
-         return "File already exists. Saving to backup buffer";
-      case MSG_AUTOLOADING_SAVESTATE_FROM:
-         return "Auto-loading savestate from";
-      case MSG_CONNECTING_TO_PORT:
-         return "Connecting to port";
-      case MSG_SETTING_DISK_IN_TRAY:
-         return "Setting disk in tray";
-      case MSG_AUDIO_VOLUME:
-         return "Audio volume";
-      case MSG_FAILED_TO_SET_DISK:
-         return "Failed to set disk";
-      case MSG_FAILED_TO_START_AUDIO_DRIVER:
-         return "failed_to_start_audio_driver";
-      case MSG_FOUND_LAST_STATE_SLOT:
-         return "found_last_state_slot";
-      case MSG_DEVICE_CONFIGURED_IN_PORT:
-         return "configured in port";
-      case MSG_DEVICE_NOT_CONFIGURED:
-         return "not configured";
-      case MSG_DEVICE_DISCONNECTED_FROM_PORT:
-        return "Device disconnected from port";
-      case MSG_CONNECT_DEVICE_FROM_A_VALID_PORT:
-         return "connect_device_from_a_valid_port";
-      case MSG_DISCONNECT_DEVICE_FROM_A_VALID_PORT:
-         return "disconnect_device_from_a_valid_port";
-      case MSG_DISCONNECTING_DEVICE_FROM_PORT:
-         return "disconnecting_device_from_port";
-      case MSG_BRINGING_UP_COMMAND_INTERFACE_ON_PORT:
-         return "bringing_up_command_interface_at_port";
-      case MENU_ENUM_LABEL_VIDEO_MAX_SWAPCHAIN_IMAGES:
-         return "video_max_swapchain_images";
-      case MENU_ENUM_LABEL_CORE_SETTINGS:
-         return "core_settings";
-      case MENU_ENUM_LABEL_CB_MENU_WALLPAPER:
-         return "cb_menu_wallpaper";
-      case MENU_ENUM_LABEL_CB_MENU_THUMBNAIL:
-         return "cb_menu_thumbnail";
-      case MENU_ENUM_LABEL_CB_LAKKA_LIST:
-         return "cb_lakka_list";
-      case MENU_ENUM_LABEL_CB_THUMBNAILS_UPDATER_LIST:
-         return "cb_thumbnails_updater_list";
-      case MENU_ENUM_LABEL_CB_CORE_UPDATER_LIST:
-         return "cb_core_updater_list";
-      case MENU_ENUM_LABEL_CB_CORE_CONTENT_LIST:
-         return "cb_core_content_list";
+      case MENU_ENUM_LABEL_ACCOUNTS_CHEEVOS_USERNAME:
+         return "accounts_cheevos_username";
+      case MENU_ENUM_LABEL_ACCOUNTS_LIST:
+         return "accounts_list";
+      case MENU_ENUM_LABEL_ACCOUNTS_RETRO_ACHIEVEMENTS:
+         return "retro_achievements";
+      case MENU_ENUM_LABEL_ACHIEVEMENT_LIST:
+         return "achievement_list";
+      case MENU_ENUM_LABEL_ADD_CONTENT_LIST:
+         return "add_content";
+      case MENU_ENUM_LABEL_ADD_TAB:
+         return "add_tab";
+      case MENU_ENUM_LABEL_ARCHIVE_MODE:
+         return "archive_mode";
+      case MENU_ENUM_LABEL_ASSETS_DIRECTORY:
+         return "assets_directory";
+      case MENU_ENUM_LABEL_AUDIO_BLOCK_FRAMES:
+         return "audio_block_frames";
+      case MENU_ENUM_LABEL_AUDIO_DEVICE:
+         return "audio_device";
+      case MENU_ENUM_LABEL_AUDIO_DRIVER:
+         return "audio_driver";
+      case MENU_ENUM_LABEL_AUDIO_DSP_PLUGIN:
+         return "audio_dsp_plugin";
+      case MENU_ENUM_LABEL_AUDIO_ENABLE:
+         return "audio_enable";
+      case MENU_ENUM_LABEL_AUDIO_FILTER_DIR:
+         return "audio_filter_dir";
+      case MENU_ENUM_LABEL_AUDIO_LATENCY:
+         return "audio_latency";
+      case MENU_ENUM_LABEL_AUDIO_MAX_TIMING_SKEW:
+         return "audio_max_timing_skew";
+      case MENU_ENUM_LABEL_AUDIO_MUTE:
+         return "audio_mute_enable";
+      case MENU_ENUM_LABEL_AUDIO_OUTPUT_RATE:
+         return "audio_output_rate";
+      case MENU_ENUM_LABEL_AUDIO_RATE_CONTROL_DELTA:
+         return "audio_rate_control_delta";
+      case MENU_ENUM_LABEL_AUDIO_RESAMPLER_DRIVER:
+         return "audio_resampler_driver";
+      case MENU_ENUM_LABEL_AUDIO_SETTINGS:
+         return "audio_settings";
+      case MENU_ENUM_LABEL_AUDIO_SYNC:
+         return "audio_sync";
+      case MENU_ENUM_LABEL_AUDIO_VOLUME:
+         return "audio_volume";
+      case MENU_ENUM_LABEL_AUTOSAVE_INTERVAL:
+         return "autosave_interval";
+      case MENU_ENUM_LABEL_AUTO_OVERRIDES_ENABLE:
+         return "auto_overrides_enable";
+      case MENU_ENUM_LABEL_AUTO_REMAPS_ENABLE:
+         return "auto_remaps_enable";
+      case MENU_ENUM_LABEL_AUTO_SHADERS_ENABLE:
+         return "auto_shaders_enable";
+      case MENU_ENUM_LABEL_BLOCK_SRAM_OVERWRITE:
+         return "block_sram_overwrite";
+      case MENU_ENUM_LABEL_BLUETOOTH_ENABLE:
+         return "bluetooth_enable";
+      case MENU_ENUM_LABEL_BUILDBOT_ASSETS_URL:
+         return "buildbot_assets_url";
+      case MENU_ENUM_LABEL_CACHE_DIRECTORY:
+         return "cache_directory";
+      case MENU_ENUM_LABEL_CAMERA_ALLOW:
+         return "camera_allow";
+      case MENU_ENUM_LABEL_CAMERA_DRIVER:
+         return "camera_driver";
       case MENU_ENUM_LABEL_CB_CORE_CONTENT_DIRS_LIST:
          return "cb_core_content_dirs_list";
+      case MENU_ENUM_LABEL_CB_CORE_CONTENT_DOWNLOAD:
+         return "cb_core_content_download";
+      case MENU_ENUM_LABEL_CB_CORE_CONTENT_LIST:
+         return "cb_core_content_list";
       case MENU_ENUM_LABEL_CB_CORE_THUMBNAILS_DOWNLOAD:
          return "cb_core_thumbnails_download";
       case MENU_ENUM_LABEL_CB_CORE_UPDATER_DOWNLOAD:
          return "cb_core_updater_download";
-      case MENU_ENUM_LABEL_CB_UPDATE_CHEATS:
-         return "cb_update_cheats";
-      case MENU_ENUM_LABEL_CB_UPDATE_OVERLAYS:
-         return "cb_update_overlays";
-      case MENU_ENUM_LABEL_CB_UPDATE_DATABASES:
-         return "cb_update_databases";
-      case MENU_ENUM_LABEL_CB_UPDATE_SHADERS_GLSL:
-         return "cb_update_shaders_glsl";
-      case MENU_ENUM_LABEL_CB_UPDATE_SHADERS_CG:
-         return "cb_update_shaders_cg";
-      case MENU_ENUM_LABEL_CB_UPDATE_CORE_INFO_FILES:
-         return "cb_update_core_info_files";
-      case MENU_ENUM_LABEL_CB_CORE_CONTENT_DOWNLOAD:
-         return "cb_core_content_download";
+      case MENU_ENUM_LABEL_CB_CORE_UPDATER_LIST:
+         return "cb_core_updater_list";
+      case MENU_ENUM_LABEL_CB_DOWNLOAD_URL:
+         return "cb_download_url";
       case MENU_ENUM_LABEL_CB_LAKKA_DOWNLOAD:
          return "cb_lakka_download";
+      case MENU_ENUM_LABEL_CB_LAKKA_LIST:
+         return "cb_lakka_list";
+      case MENU_ENUM_LABEL_CB_MENU_THUMBNAIL:
+         return "cb_menu_thumbnail";
+      case MENU_ENUM_LABEL_CB_MENU_WALLPAPER:
+         return "cb_menu_wallpaper";
+      case MENU_ENUM_LABEL_CB_THUMBNAILS_UPDATER_DOWNLOAD:
+         return "cb_thumbnails_updater_download";
+      case MENU_ENUM_LABEL_CB_THUMBNAILS_UPDATER_LIST:
+         return "cb_thumbnails_updater_list";
       case MENU_ENUM_LABEL_CB_UPDATE_ASSETS:
          return "cb_update_assets";
       case MENU_ENUM_LABEL_CB_UPDATE_AUTOCONFIG_PROFILES:
          return "cb_update_autoconfig_profiles";
-      case MENU_ENUM_LABEL_CB_THUMBNAILS_UPDATER_DOWNLOAD:
-         return "cb_thumbnails_updater_download";
+      case MENU_ENUM_LABEL_CB_UPDATE_CHEATS:
+         return "cb_update_cheats";
+      case MENU_ENUM_LABEL_CB_UPDATE_CORE_INFO_FILES:
+         return "cb_update_core_info_files";
+      case MENU_ENUM_LABEL_CB_UPDATE_DATABASES:
+         return "cb_update_databases";
+      case MENU_ENUM_LABEL_CB_UPDATE_OVERLAYS:
+         return "cb_update_overlays";
+      case MENU_ENUM_LABEL_CB_UPDATE_SHADERS_CG:
+         return "cb_update_shaders_cg";
+      case MENU_ENUM_LABEL_CB_UPDATE_SHADERS_GLSL:
+         return "cb_update_shaders_glsl";
+      case MENU_ENUM_LABEL_CHEAT_APPLY_CHANGES:
+         return "cheat_apply_changes";
+      case MENU_ENUM_LABEL_CHEAT_DATABASE_PATH:
+         return "cheat_database_path";
+      case MENU_ENUM_LABEL_CHEAT_FILE_LOAD:
+         return "cheat_file_load";
+      case MENU_ENUM_LABEL_CHEAT_FILE_SAVE_AS:
+         return "cheat_file_save_as";
+      case MENU_ENUM_LABEL_CHEAT_NUM_PASSES:
+         return "cheat_num_passes";
+      case MENU_ENUM_LABEL_CHEEVOS_DESCRIPTION:
+         return "cheevos_description";
+      case MENU_ENUM_LABEL_CHEEVOS_ENABLE:
+         return "cheevos_enable";
+      case MENU_ENUM_LABEL_CHEEVOS_HARDCORE_MODE_ENABLE:
+         return "cheevos_hardcore_mode_enable";
+      case MENU_ENUM_LABEL_CHEEVOS_LOCKED_ACHIEVEMENTS:
+         return "cheevos_locked_achievements";
+      case MENU_ENUM_LABEL_CHEEVOS_LOCKED_ENTRY:
+         return "cheevos_locked_entry";
+      case MENU_ENUM_LABEL_CHEEVOS_PASSWORD:
+         return "cheevos_password";
+      case MENU_ENUM_LABEL_CHEEVOS_TEST_UNOFFICIAL:
+         return "cheevos_test_unofficial";
+      case MENU_ENUM_LABEL_CHEEVOS_UNLOCKED_ACHIEVEMENTS:
+         return "cheevos_unlocked_achievements";
+      case MENU_ENUM_LABEL_CHEEVOS_UNLOCKED_ENTRY:
+         return "cheevos_unlocked_entry";
+      case MENU_ENUM_LABEL_CHEEVOS_USERNAME:
+         return "cheevos_username";
+      case MENU_ENUM_LABEL_CLOSE_CONTENT:
+         return "unload_core";
+      case MENU_ENUM_LABEL_COLLECTION:
+         return "collection";
+      case MENU_ENUM_LABEL_CONFIGURATIONS:
+         return "configurations";
+      case MENU_ENUM_LABEL_CONFIGURATION_SETTINGS:
+         return "configuration_settings";
+      case MENU_ENUM_LABEL_CONFIG_SAVE_ON_EXIT:
+         return "config_save_on_exit";
+      case MENU_ENUM_LABEL_CONFIRM_ON_EXIT:
+         return "confirm_on_exit";
+      case MENU_ENUM_LABEL_CONNECT_WIFI:
+         return "connect_wifi";
       case MENU_ENUM_LABEL_CONTENT_ACTIONS:
          return "content_actions";
+      case MENU_ENUM_LABEL_CONTENT_COLLECTION_LIST:
+         return "select_from_collection";
+      case MENU_ENUM_LABEL_CONTENT_DATABASE_DIRECTORY:
+         return "content_database_path";
+      case MENU_ENUM_LABEL_CONTENT_HISTORY_SIZE:
+         return "content_history_size";
+      case MENU_ENUM_LABEL_CONTENT_SETTINGS:
+         return "quick_menu";
+      case MENU_ENUM_LABEL_CORE_ASSETS_DIRECTORY:
+         return "core_assets_directory";
+      case MENU_ENUM_LABEL_CORE_CHEAT_OPTIONS:
+         return "core_cheat_options";
+      case MENU_ENUM_LABEL_CORE_COUNTERS:
+         return "core_counters";
+      case MENU_ENUM_LABEL_CORE_ENABLE:
+         return "menu_core_enable";
+      case MENU_ENUM_LABEL_CORE_INFORMATION:
+         return "core_information";
+      case MENU_ENUM_LABEL_CORE_INFO_ENTRY:
+         return "core_info_entry";
+      case MENU_ENUM_LABEL_CORE_INPUT_REMAPPING_OPTIONS:
+         return "core_input_remapping_options";
+      case MENU_ENUM_LABEL_CORE_LIST:
+         return "load_core";
+      case MENU_ENUM_LABEL_CORE_OPTIONS:
+         return "core_options";
+      case MENU_ENUM_LABEL_CORE_OPTION_ENTRY:
+         return "core_option_entry";
+      case MENU_ENUM_LABEL_CORE_SETTINGS:
+         return "core_settings";
+      case MENU_ENUM_LABEL_CORE_SET_SUPPORTS_NO_CONTENT_ENABLE:
+         return "core_set_supports_no_content_enable";
+      case MENU_ENUM_LABEL_CORE_SPECIFIC_CONFIG:
+         return "core_specific_config";
+      case MENU_ENUM_LABEL_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
+         return "core_updater_auto_extract_archive";
+      case MENU_ENUM_LABEL_CORE_UPDATER_BUILDBOT_URL:
+         return "core_updater_buildbot_url";
+      case MENU_ENUM_LABEL_CORE_UPDATER_LIST:
+         return "core_updater_list";
       case MENU_ENUM_LABEL_CPU_ARCHITECTURE:
          return "system_information_cpu_architecture";
       case MENU_ENUM_LABEL_CPU_CORES:
          return "system_information_cpu_cores";
-      case MENU_ENUM_LABEL_NO_ITEMS:
-         return "no_items";
-      case MENU_ENUM_LABEL_NO_PLAYLISTS:
-         return "no_playlists";
-      case MENU_ENUM_LABEL_NO_HISTORY_AVAILABLE:
-         return "no_history";
-      case MENU_ENUM_LABEL_NO_SHADER_PARAMETERS:
-         return "no_shader_parameters.";
-      case MENU_ENUM_LABEL_SETTINGS_TAB:
-         return "settings_tab";
+      case MENU_ENUM_LABEL_CURSOR_DIRECTORY:
+         return "cursor_directory";
+      case MENU_ENUM_LABEL_CURSOR_MANAGER_LIST:
+         return "cursor_manager_list";
+      case MENU_ENUM_LABEL_CUSTOM_BIND:
+         return "custom_bind";
+      case MENU_ENUM_LABEL_CUSTOM_BIND_ALL:
+         return "custom_bind_all";
+      case MENU_ENUM_LABEL_CUSTOM_RATIO:
+         return "custom_ratio";
+      case MENU_ENUM_LABEL_DATABASE_MANAGER_LIST:
+         return "database_manager_list";
+      case MENU_ENUM_LABEL_DEFERRED_ACCOUNTS_CHEEVOS_LIST:
+         return "deferred_accounts_cheevos_list";
+      case MENU_ENUM_LABEL_DEFERRED_ACCOUNTS_LIST:
+         return "deferred_accounts_list";
+      case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_ACTION:
+         return "deferred_archive_action";
+      case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_ACTION_DETECT_CORE:
+         return "deferred_archive_action_detect_core";
+      case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_OPEN:
+         return "deferred_archive_open";
+      case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_OPEN_DETECT_CORE:
+         return "deferred_archive_open_detect_core";
+      case MENU_ENUM_LABEL_DEFERRED_AUDIO_SETTINGS_LIST:
+         return "deferred_audio_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_CONFIGURATION_SETTINGS_LIST:
+         return "deferred_configuration_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_CORE_CONTENT_DIRS_LIST:
+         return "deferred_core_content_dirs_list";
+      case MENU_ENUM_LABEL_DEFERRED_CORE_CONTENT_DIRS_SUBDIR_LIST:
+         return "deferred_core_content_dirs_subdir_list";
+      case MENU_ENUM_LABEL_DEFERRED_CORE_CONTENT_LIST:
+         return "deferred_core_content_list";
+      case MENU_ENUM_LABEL_DEFERRED_CORE_LIST:
+         return "deferred_core_list";
+      case MENU_ENUM_LABEL_DEFERRED_CORE_LIST_SET:
+         return "deferred_core_list_set";
+      case MENU_ENUM_LABEL_DEFERRED_CORE_SETTINGS_LIST:
+         return "deferred_core_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_CORE_UPDATER_LIST:
+         return "core_updater";
+      case MENU_ENUM_LABEL_DEFERRED_CURSOR_MANAGER_LIST:
+         return "deferred_cursor_manager_list";
+      case MENU_ENUM_LABEL_DEFERRED_DATABASE_MANAGER_LIST:
+         return "deferred_database_manager_list";
+      case MENU_ENUM_LABEL_DEFERRED_DIRECTORY_SETTINGS_LIST:
+         return "deferred_directory_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_DRIVER_SETTINGS_LIST:
+         return "deferred_driver_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_FRAME_THROTTLE_SETTINGS_LIST:
+         return "deferred_frame_throttle_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_INPUT_HOTKEY_BINDS_LIST:
+         return "deferred_input_hotkey_binds";
+      case MENU_ENUM_LABEL_DEFERRED_INPUT_SETTINGS_LIST:
+         return "deferred_input_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_LAKKA_LIST:
+         return "deferred_lakka_list";
+      case MENU_ENUM_LABEL_DEFERRED_LAKKA_SERVICES_LIST:
+         return "deferred_lakka_services_list";
+      case MENU_ENUM_LABEL_DEFERRED_LOGGING_SETTINGS_LIST:
+         return "deferred_logging_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_MENU_FILE_BROWSER_SETTINGS_LIST:
+         return "deferred_menu_file_browser_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_MENU_SETTINGS_LIST:
+         return "deferred_menu_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_NETWORK_SETTINGS_LIST:
+         return "deferred_network_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_ONSCREEN_DISPLAY_SETTINGS_LIST:
+         return "deferred_onscreen_display_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_ONSCREEN_OVERLAY_SETTINGS_LIST:
+         return "deferred_onscreen_overlay_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_PLAYLIST_SETTINGS_LIST:
+         return "deferred_playlist_settings";
+      case MENU_ENUM_LABEL_DEFERRED_PRIVACY_SETTINGS_LIST:
+         return "deferred_privacy_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_RDB_ENTRY_DETAIL:
+         return "deferred_rdb_entry_detail";
+      case MENU_ENUM_LABEL_DEFERRED_RECORDING_SETTINGS_LIST:
+         return "deferred_recording_settings";
+      case MENU_ENUM_LABEL_DEFERRED_RETRO_ACHIEVEMENTS_SETTINGS_LIST:
+         return "deferred_retro_achievements_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_REWIND_SETTINGS_LIST:
+         return "deferred_rewind_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_SAVING_SETTINGS_LIST:
+         return "deferred_saving_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_THUMBNAILS_UPDATER_LIST:
+         return "deferred_thumbnails_updater_list";
+      case MENU_ENUM_LABEL_DEFERRED_UPDATER_SETTINGS_LIST:
+         return "deferred_updater_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_USER_BINDS_LIST:
+         return "deferred_user_binds_list";
+      case MENU_ENUM_LABEL_DEFERRED_USER_INTERFACE_SETTINGS_LIST:
+         return "deferred_user_interface_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_USER_SETTINGS_LIST:
+         return "deferred_user_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_VIDEO_FILTER:
+         return "deferred_video_filter";
+      case MENU_ENUM_LABEL_DEFERRED_VIDEO_SETTINGS_LIST:
+         return "deferred_video_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_WIFI_SETTINGS_LIST:
+         return "deferred_wifi_settings_list";
+      case MENU_ENUM_LABEL_DELETE_ENTRY:
+         return "delete_entry";
+      case MENU_ENUM_LABEL_DETECT_CORE_LIST:
+         return "detect_core_list";
+      case MENU_ENUM_LABEL_DIRECTORY_SETTINGS:
+         return "directory_settings";
+      case MENU_ENUM_LABEL_DISK_CYCLE_TRAY_STATUS:
+         return "disk_cycle_tray_status";
+      case MENU_ENUM_LABEL_DISK_IMAGE_APPEND:
+         return "disk_image_append";
+      case MENU_ENUM_LABEL_DISK_OPTIONS:
+         return "core_disk_options";
+      case MENU_ENUM_LABEL_DOWNLOADED_FILE_DETECT_CORE_LIST:
+         return "downloaded_file_detect_core_list";
+      case MENU_ENUM_LABEL_DOWNLOAD_CORE_CONTENT:
+         return "download_core_content";
+      case MENU_ENUM_LABEL_DOWNLOAD_CORE_CONTENT_DIRS:
+         return "download_core_content_dirs";
+      case MENU_ENUM_LABEL_DPI_OVERRIDE_ENABLE:
+         return "dpi_override_enable";
+      case MENU_ENUM_LABEL_DPI_OVERRIDE_VALUE:
+         return "dpi_override_value";
+      case MENU_ENUM_LABEL_DRIVER_SETTINGS:
+         return "driver_settings";
+      case MENU_ENUM_LABEL_DUMMY_ON_CORE_SHUTDOWN:
+         return "dummy_on_core_shutdown";
+      case MENU_ENUM_LABEL_DYNAMIC_WALLPAPER:
+         return "menu_dynamic_wallpaper_enable";
+      case MENU_ENUM_LABEL_DYNAMIC_WALLPAPERS_DIRECTORY:
+         return "dynamic_wallpapers_directory";
+      case MENU_ENUM_LABEL_ENTRY_HOVER_COLOR:
+         return "menu_entry_hover_color";
+      case MENU_ENUM_LABEL_ENTRY_NORMAL_COLOR:
+         return "menu_entry_normal_color";
+      case MENU_ENUM_LABEL_FASTFORWARD_RATIO:
+         return "fastforward_ratio";
+      case MENU_ENUM_LABEL_FILE_BROWSER_CORE:
+         return "file_browser_core";
+      case MENU_ENUM_LABEL_FILE_BROWSER_CORE_DETECTED:
+         return "file_browser_core_detected";
+      case MENU_ENUM_LABEL_FILE_BROWSER_CORE_SELECT_FROM_COLLECTION:
+         return "file_browser_core_select_from_collection";
+      case MENU_ENUM_LABEL_FILE_BROWSER_DIRECTORY:
+         return "file_browser_directory";
+      case MENU_ENUM_LABEL_FILE_BROWSER_IMAGE:
+         return "file_browser_image";
+      case MENU_ENUM_LABEL_FILE_BROWSER_IMAGE_OPEN_WITH_VIEWER:
+         return "file_browser_image_open_with_viewer";
+      case MENU_ENUM_LABEL_FILE_BROWSER_MOVIE_OPEN:
+         return "file_browser_movie_open";
+      case MENU_ENUM_LABEL_FILE_BROWSER_MUSIC_OPEN:
+         return "file_browser_music_open";
+      case MENU_ENUM_LABEL_FILE_BROWSER_PLAIN_FILE:
+         return "file_browser_plain_file";
+      case MENU_ENUM_LABEL_FILE_BROWSER_REMAP:
+         return "file_browser_remap";
+      case MENU_ENUM_LABEL_FILE_BROWSER_SHADER:
+         return "file_browser_shader";
+      case MENU_ENUM_LABEL_FILE_BROWSER_SHADER_PRESET:
+         return "file_browser_shader_preset";
+      case MENU_ENUM_LABEL_FPS_SHOW:
+         return "fps_show";
+      case MENU_ENUM_LABEL_FRAME_THROTTLE_ENABLE:
+         return "fastforward_ratio_throttle_enable";
+      case MENU_ENUM_LABEL_FRAME_THROTTLE_SETTINGS:
+         return "frame_throttle_settings";
+      case MENU_ENUM_LABEL_FRONTEND_COUNTERS:
+         return "frontend_counters";
+      case MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS:
+         return "game_specific_options";
+      case MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS_CREATE:
+         return "game_specific_options_create";
+      case MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS_IN_USE:
+         return "game_specific_options_in_use";
+      case MENU_ENUM_LABEL_HELP:
+         return "help";
+      case MENU_ENUM_LABEL_HELP_AUDIO_VIDEO_TROUBLESHOOTING:
+         return "help_audio_video_troubleshooting";
+      case MENU_ENUM_LABEL_HELP_CHANGE_VIRTUAL_GAMEPAD:
+         return "help_change_virtual_gamepad";
+      case MENU_ENUM_LABEL_HELP_CONTROLS:
+         return "help_controls";
+      case MENU_ENUM_LABEL_HELP_LIST:
+         return "help_list";
+      case MENU_ENUM_LABEL_HELP_LOADING_CONTENT:
+         return "help_loading_content";
+      case MENU_ENUM_LABEL_HELP_SCANNING_CONTENT:
+         return "help_scanning_content";
+      case MENU_ENUM_LABEL_HELP_WHAT_IS_A_CORE:
+         return "help_what_is_a_core";
+      case MENU_ENUM_LABEL_HISTORY_LIST_ENABLE:
+         return "history_list_enable";
       case MENU_ENUM_LABEL_HISTORY_TAB:
          return "history_tab";
-      case MENU_ENUM_LABEL_ADD_TAB:
-         return "add_tab";
-      case MENU_ENUM_LABEL_PLAYLISTS_TAB:
-         return "playlists_tab";
-      case MENU_ENUM_LABEL_MUSIC_TAB:
-         return "music_tab";
-      case MENU_ENUM_LABEL_VIDEO_TAB:
-         return "video_tab";
-      case MENU_ENUM_LABEL_IMAGES_TAB:
-         return "images_tab";
       case MENU_ENUM_LABEL_HORIZONTAL_MENU:
          return "horizontal_menu";
-      case MENU_ENUM_LABEL_PARENT_DIRECTORY:
-         return "parent_directory";
-      case MENU_ENUM_LABEL_INPUT_PLAYER_ANALOG_DPAD_MODE:
-         return "input_player%u_analog_dpad_mode";
+      case MENU_ENUM_LABEL_IMAGES_TAB:
+         return "images_tab";
+      case MENU_ENUM_LABEL_INFORMATION:
+         return "information";
+      case MENU_ENUM_LABEL_INFORMATION_LIST:
+         return "information_list";
+      case MENU_ENUM_LABEL_INFO_SCREEN:
+         return "info_screen";
+      case MENU_ENUM_LABEL_INPUT_ALL_USERS_CONTROL_MENU:
+         return "all_users_control_menu";
+      case MENU_ENUM_LABEL_INPUT_AUTODETECT_ENABLE:
+         return "input_autodetect_enable";
+      case MENU_ENUM_LABEL_INPUT_AXIS_THRESHOLD:
+         return "input_axis_threshold";
+      case MENU_ENUM_LABEL_INPUT_BACK_AS_MENU_ENUM_TOGGLE_ENABLE:
+         return "back_as_menu_toggle_enable";
+      case MENU_ENUM_LABEL_INPUT_BIND_MODE:
+         return "input_bind_mode";
+      case MENU_ENUM_LABEL_INPUT_BIND_TIMEOUT:
+         return "input_bind_timeout";
+      case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_HIDE_UNBOUND:
+         return "input_descriptor_hide_unbound";
+      case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_LABEL_SHOW:
+         return "input_descriptor_label_show";
+      case MENU_ENUM_LABEL_INPUT_DRIVER:
+         return "input_driver";
+      case MENU_ENUM_LABEL_INPUT_DUTY_CYCLE:
+         return "input_duty_cycle";
+      case MENU_ENUM_LABEL_INPUT_HOTKEY_BINDS:
+         return "input_hotkey_binds";
+      case MENU_ENUM_LABEL_INPUT_HOTKEY_BINDS_BEGIN:
+         return "input_hotkey_binds_begin";
+      case MENU_ENUM_LABEL_INPUT_ICADE_ENABLE:
+         return "input_icade_enable";
+      case MENU_ENUM_LABEL_INPUT_KEYBOARD_GAMEPAD_MAPPING_TYPE:
+         return "keyboard_gamepad_mapping_type";
       case MENU_ENUM_LABEL_INPUT_LIBRETRO_DEVICE:
          return "input_libretro_device_p%u";
-      case MENU_ENUM_LABEL_RUN:
-         return "collection";
-      case MENU_ENUM_LABEL_PLAYLIST_COLLECTION_ENTRY:
-         return "playlist_collection_entry";
-      case MENU_ENUM_LABEL_CHEEVOS_LOCKED_ENTRY:
-         return "cheevos_locked_entry";
-      case MENU_ENUM_LABEL_CHEEVOS_UNLOCKED_ENTRY:
-         return "cheevos_unlocked_entry";
-      case MENU_ENUM_LABEL_CORE_INFO_ENTRY:
-         return "core_info_entry";
-      case MENU_ENUM_LABEL_NETWORK_INFO_ENTRY:
-         return "network_info_entry";
-      case MENU_ENUM_LABEL_PLAYLIST_ENTRY:
-         return "playlist_entry";
-      case MENU_ENUM_LABEL_SYSTEM_INFO_ENTRY:
-         return "system_info_entry";
+      case MENU_ENUM_LABEL_INPUT_MAX_USERS:
+         return "input_max_users";
+      case MENU_ENUM_LABEL_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
+         return "input_menu_toggle_gamepad_combo";
+      case MENU_ENUM_LABEL_INPUT_OSK_OVERLAY_ENABLE:
+         return "input_osk_overlay_enable";
+      case MENU_ENUM_LABEL_INPUT_OVERLAY_ENABLE:
+         return "input_overlay_enable";
+      case MENU_ENUM_LABEL_INPUT_OVERLAY_HIDE_IN_MENU:
+         return "overlay_hide_in_menu";
+      case MENU_ENUM_LABEL_INPUT_PLAYER_ANALOG_DPAD_MODE:
+         return "input_player%u_analog_dpad_mode";
+      case MENU_ENUM_LABEL_INPUT_POLL_TYPE_BEHAVIOR:
+         return "input_poll_type_behavior";
+      case MENU_ENUM_LABEL_INPUT_PREFER_FRONT_TOUCH:
+         return "input_prefer_front_touch";
+      case MENU_ENUM_LABEL_INPUT_REMAPPING_DIRECTORY:
+         return "input_remapping_directory";
+      case MENU_ENUM_LABEL_INPUT_REMAP_BINDS_ENABLE:
+         return "input_remap_binds_enable";
+      case MENU_ENUM_LABEL_INPUT_SETTINGS:
+         return "input_settings";
+      case MENU_ENUM_LABEL_INPUT_SETTINGS_BEGIN:
+         return "input_settings_begin";
+      case MENU_ENUM_LABEL_INPUT_SMALL_KEYBOARD_ENABLE:
+         return "input_small_keyboard_enable";
+      case MENU_ENUM_LABEL_INPUT_TOUCH_ENABLE:
+         return "input_touch_enable";
+      case MENU_ENUM_LABEL_INPUT_TURBO_PERIOD:
+         return "input_turbo_period";
+      case MENU_ENUM_LABEL_INPUT_USER_10_BINDS:
+         return "10_input_binds_list";
+      case MENU_ENUM_LABEL_INPUT_USER_11_BINDS:
+         return "11_input_binds_list";
+      case MENU_ENUM_LABEL_INPUT_USER_12_BINDS:
+         return "12_input_binds_list";
+      case MENU_ENUM_LABEL_INPUT_USER_13_BINDS:
+         return "13_input_binds_list";
+      case MENU_ENUM_LABEL_INPUT_USER_14_BINDS:
+         return "14_input_binds_list";
+      case MENU_ENUM_LABEL_INPUT_USER_15_BINDS:
+         return "15_input_binds_list";
+      case MENU_ENUM_LABEL_INPUT_USER_16_BINDS:
+         return "16_input_binds_list";
       case MENU_ENUM_LABEL_INPUT_USER_1_BINDS:
          return "1_input_binds_list";
       case MENU_ENUM_LABEL_INPUT_USER_2_BINDS:
@@ -2064,954 +2392,626 @@ static const char *menu_hash_to_str_jp_label_enum(enum msg_hash_enums msg)
          return "8_input_binds_list";
       case MENU_ENUM_LABEL_INPUT_USER_9_BINDS:
          return "9_input_binds_list";
-      case MENU_ENUM_LABEL_INPUT_USER_10_BINDS:
-         return "10_input_binds_list";
-      case MENU_ENUM_LABEL_INPUT_USER_11_BINDS:
-         return "11_input_binds_list";
-      case MENU_ENUM_LABEL_INPUT_USER_12_BINDS:
-         return "12_input_binds_list";
-      case MENU_ENUM_LABEL_INPUT_USER_13_BINDS:
-         return "13_input_binds_list";
-      case MENU_ENUM_LABEL_INPUT_USER_14_BINDS:
-         return "14_input_binds_list";
-      case MENU_ENUM_LABEL_INPUT_USER_15_BINDS:
-         return "15_input_binds_list";
-      case MENU_ENUM_LABEL_INPUT_USER_16_BINDS:
-         return "16_input_binds_list";
-      case MENU_ENUM_LABEL_VIDEO_VIEWPORT_CUSTOM_X:
-         return "video_viewport_custom_x";
-      case MENU_ENUM_LABEL_VIDEO_VIEWPORT_CUSTOM_Y:
-         return "video_viewport_custom_y";
-      case MENU_ENUM_LABEL_VIDEO_VIEWPORT_CUSTOM_WIDTH:
-         return "video_viewport_custom_width";
-      case MENU_ENUM_LABEL_VIDEO_VIEWPORT_CUSTOM_HEIGHT:
-         return "video_viewport_custom_height";
-      case MENU_ENUM_LABEL_NO_CORES_AVAILABLE:
-         return "no_cores_available";
-      case MENU_ENUM_LABEL_NO_CORE_OPTIONS_AVAILABLE:
-         return "no_core_options_available";
-      case MENU_ENUM_LABEL_NO_CORE_INFORMATION_AVAILABLE:
-         return "no_core_information_available";
-      case MENU_ENUM_LABEL_CORE_OPTION_ENTRY:
-         return "core_option_entry";
-      case MENU_ENUM_LABEL_URL_ENTRY:
-         return "url_entry";
-      case MENU_ENUM_LABEL_NO_PERFORMANCE_COUNTERS:
-         return "no_performance_counters";
-      case MENU_ENUM_LABEL_NO_ENTRIES_TO_DISPLAY:
-         return "no_entries_to_display";
-      case MENU_ENUM_LABEL_NO_ACHIEVEMENTS_TO_DISPLAY:
-         return "no_achievements_to_display";
-      case MENU_ENUM_LABEL_CHEEVOS_UNLOCKED_ACHIEVEMENTS:
-         return "cheevos_unlocked_achievements";
-      case MENU_ENUM_LABEL_CHEEVOS_LOCKED_ACHIEVEMENTS:
-         return "cheevos_locked_achievements";
+      case MENU_ENUM_LABEL_JOYPAD_AUTOCONFIG_DIR:
+         return "joypad_autoconfig_dir";
+      case MENU_ENUM_LABEL_JOYPAD_DRIVER:
+         return "input_joypad_driver";
+      case MENU_ENUM_LABEL_KEYBOARD_OVERLAY_PRESET:
+         return "input_osk_overlay";
+      case MENU_ENUM_LABEL_LAKKA_SERVICES:
+         return "lakka_services";
+      case MENU_ENUM_LABEL_LIBRETRO_DIR_PATH:
+         return "libretro_dir_path";
+      case MENU_ENUM_LABEL_LIBRETRO_INFO_PATH:
+         return "libretro_info_path";
+      case MENU_ENUM_LABEL_LIBRETRO_LOG_LEVEL:
+         return "libretro_log_level";
+      case MENU_ENUM_LABEL_LOAD_ARCHIVE:
+         return "load_archive";
+      case MENU_ENUM_LABEL_LOAD_ARCHIVE_DETECT_CORE:
+         return "load_archive_detect_core";
+      case MENU_ENUM_LABEL_LOAD_CONTENT:
+         return "load_content_default";
+      case MENU_ENUM_LABEL_LOAD_CONTENT_HISTORY:
+         return "load_recent";
+      case MENU_ENUM_LABEL_LOAD_CONTENT_LIST:
+         return "load_content";
+      case MENU_ENUM_LABEL_LOAD_STATE:
+         return "loadstate";
+      case MENU_ENUM_LABEL_LOCATION_ALLOW:
+         return "location_allow";
+      case MENU_ENUM_LABEL_LOCATION_DRIVER:
+         return "location_driver";
+      case MENU_ENUM_LABEL_LOGGING_SETTINGS:
+         return "logging_settings";
+      case MENU_ENUM_LABEL_LOG_VERBOSITY:
+         return "log_verbosity";
       case MENU_ENUM_LABEL_MAIN_MENU:
          return "main_menu";
-      case MENU_ENUM_LABEL_MENU_LINEAR_FILTER:
-         return "menu_linear_filter";
+      case MENU_ENUM_LABEL_MANAGEMENT:
+         return "database_settings";
+      case MENU_ENUM_LABEL_MATERIALUI_MENU_COLOR_THEME:
+         return "materialui_menu_color_theme";
+      case MENU_ENUM_LABEL_MATERIALUI_MENU_FOOTER_OPACITY:
+         return "materialui_menu_footer_opacity";
+      case MENU_ENUM_LABEL_MATERIALUI_MENU_HEADER_OPACITY:
+         return "materialui_menu_header_opacity";
+      case MENU_ENUM_LABEL_MENU_DRIVER:
+         return "menu_driver";
       case MENU_ENUM_LABEL_MENU_ENUM_THROTTLE_FRAMERATE:
          return "menu_throttle_framerate";
-      case MENU_ENUM_LABEL_START_CORE:
-         return "start_core";
-      case MENU_ENUM_LABEL_CHEEVOS_HARDCORE_MODE_ENABLE:
-         return "cheevos_hardcore_mode_enable";
-      case MENU_ENUM_LABEL_CHEEVOS_TEST_UNOFFICIAL:
-         return "cheevos_test_unofficial";
-      case MENU_ENUM_LABEL_CHEEVOS_ENABLE:
-         return "cheevos_enable";
-      case MENU_ENUM_LABEL_INPUT_TOUCH_ENABLE:
-         return "input_touch_enable";
-      case MENU_ENUM_LABEL_INPUT_PREFER_FRONT_TOUCH:
-         return "input_prefer_front_touch";
-      case MENU_ENUM_LABEL_INPUT_ICADE_ENABLE:
-         return "input_icade_enable";
-      case MENU_ENUM_LABEL_INPUT_KEYBOARD_GAMEPAD_MAPPING_TYPE:
-         return "keyboard_gamepad_mapping_type";
-      case MENU_ENUM_LABEL_INPUT_SMALL_KEYBOARD_ENABLE:
-         return "input_small_keyboard_enable";
+      case MENU_ENUM_LABEL_MENU_FILE_BROWSER_SETTINGS:
+         return "menu_file_browser_settings";
+      case MENU_ENUM_LABEL_MENU_LINEAR_FILTER:
+         return "menu_linear_filter";
+      case MENU_ENUM_LABEL_MENU_SETTINGS:
+         return "menu_settings";
+      case MENU_ENUM_LABEL_MENU_WALLPAPER:
+         return "menu_wallpaper";
+      case MENU_ENUM_LABEL_MENU_WALLPAPER_OPACITY:
+         return "menu_wallpaper_opacity";
+      case MENU_ENUM_LABEL_MOUSE_ENABLE:
+         return "menu_mouse_enable";
+      case MENU_ENUM_LABEL_MUSIC_TAB:
+         return "music_tab";
+      case MENU_ENUM_LABEL_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
+         return "menu_navigation_browser_filter_supported_extensions_enable";
+      case MENU_ENUM_LABEL_NAVIGATION_WRAPAROUND:
+         return "menu_navigation_wraparound_enable";
+      case MENU_ENUM_LABEL_NETPLAY:
+         return "netplay";
+      case MENU_ENUM_LABEL_NETPLAY_CHECK_FRAMES:
+         return "netplay_check_frames";
+      case MENU_ENUM_LABEL_NETPLAY_CLIENT_SWAP_INPUT:
+         return "netplay_client_swap_input";
+      case MENU_ENUM_LABEL_NETPLAY_DELAY_FRAMES:
+         return "netplay_delay_frames";
+      case MENU_ENUM_LABEL_NETPLAY_DISCONNECT:
+         return "menu_netplay_disconnect";
+      case MENU_ENUM_LABEL_NETPLAY_ENABLE:
+         return "netplay_enable";
+      case MENU_ENUM_LABEL_NETPLAY_ENABLE_CLIENT:
+         return "menu_netplay_enable_client";
+      case MENU_ENUM_LABEL_NETPLAY_ENABLE_HOST:
+         return "menu_netplay_enable_host";
+      case MENU_ENUM_LABEL_NETPLAY_IP_ADDRESS:
+         return "netplay_ip_address";
+      case MENU_ENUM_LABEL_NETPLAY_MODE:
+         return "netplay_mode";
+      case MENU_ENUM_LABEL_NETPLAY_NICKNAME:
+         return "netplay_nickname";
+      case MENU_ENUM_LABEL_NETPLAY_SETTINGS:
+         return "menu_netplay_settings";
+      case MENU_ENUM_LABEL_NETPLAY_SPECTATOR_MODE_ENABLE:
+         return "netplay_spectator_mode_enable";
+      case MENU_ENUM_LABEL_NETPLAY_TCP_UDP_PORT:
+         return "netplay_tcp_udp_port";
+      case MENU_ENUM_LABEL_NETWORK_CMD_ENABLE:
+         return "network_cmd_enable";
+      case MENU_ENUM_LABEL_NETWORK_CMD_PORT:
+         return "network_cmd_port";
+      case MENU_ENUM_LABEL_NETWORK_INFORMATION:
+         return "network_information";
+      case MENU_ENUM_LABEL_NETWORK_INFO_ENTRY:
+         return "network_info_entry";
+      case MENU_ENUM_LABEL_NETWORK_REMOTE_ENABLE:
+         return "network_remote_enable";
+      case MENU_ENUM_LABEL_NETWORK_REMOTE_PORT:
+         return "network_remote_base_port";
+      case MENU_ENUM_LABEL_NETWORK_REMOTE_USER_1_ENABLE:
+         return "network_remote_user_1_enable";
+      case MENU_ENUM_LABEL_NETWORK_REMOTE_USER_LAST_ENABLE:
+         return "network_remote_user_last_enable";
+      case MENU_ENUM_LABEL_NETWORK_SETTINGS:
+         return "network_settings";
+      case MENU_ENUM_LABEL_NO_ACHIEVEMENTS_TO_DISPLAY:
+         return "no_achievements_to_display";
+      case MENU_ENUM_LABEL_NO_CORES_AVAILABLE:
+         return "no_cores_available";
+      case MENU_ENUM_LABEL_NO_CORE_INFORMATION_AVAILABLE:
+         return "no_core_information_available";
+      case MENU_ENUM_LABEL_NO_CORE_OPTIONS_AVAILABLE:
+         return "no_core_options_available";
+      case MENU_ENUM_LABEL_NO_ENTRIES_TO_DISPLAY:
+         return "no_entries_to_display";
+      case MENU_ENUM_LABEL_NO_HISTORY_AVAILABLE:
+         return "no_history";
+      case MENU_ENUM_LABEL_NO_ITEMS:
+         return "no_items";
+      case MENU_ENUM_LABEL_NO_PERFORMANCE_COUNTERS:
+         return "no_performance_counters";
+      case MENU_ENUM_LABEL_NO_PLAYLISTS:
+         return "no_playlists";
+      case MENU_ENUM_LABEL_NO_PLAYLIST_ENTRIES_AVAILABLE:
+         return "no_playlist_entries_available";
+      case MENU_ENUM_LABEL_NO_SETTINGS_FOUND:
+         return "menu_label_no_settings_found";
+      case MENU_ENUM_LABEL_NO_SHADER_PARAMETERS:
+         return "no_shader_parameters.";
+      case MENU_ENUM_LABEL_ONLINE_UPDATER:
+         return "online_updater";
+      case MENU_ENUM_LABEL_ONSCREEN_DISPLAY_SETTINGS:
+         return "onscreen_display_settings";
+      case MENU_ENUM_LABEL_ONSCREEN_OVERLAY_SETTINGS:
+         return "onscreen_overlay_settings";
+      case MENU_ENUM_LABEL_OPEN_ARCHIVE:
+         return "open_archive";
+      case MENU_ENUM_LABEL_OPEN_ARCHIVE_DETECT_CORE:
+         return "open_archive_detect_core";
+      case MENU_ENUM_LABEL_OSK_OVERLAY_DIRECTORY:
+         return "osk_overlay_directory";
+      case MENU_ENUM_LABEL_OVERLAY_AUTOLOAD_PREFERRED:
+         return "overlay_autoload_preferred";
+      case MENU_ENUM_LABEL_OVERLAY_DIRECTORY:
+         return "overlay_directory";
+      case MENU_ENUM_LABEL_OVERLAY_OPACITY:
+         return "input_overlay_opacity";
+      case MENU_ENUM_LABEL_OVERLAY_PRESET:
+         return "input_overlay";
+      case MENU_ENUM_LABEL_OVERLAY_SCALE:
+         return "input_overlay_scale";
+      case MENU_ENUM_LABEL_PAL60_ENABLE:
+         return "pal60_enable";
+      case MENU_ENUM_LABEL_PARENT_DIRECTORY:
+         return "parent_directory";
+      case MENU_ENUM_LABEL_PAUSE_LIBRETRO:
+         return "menu_pause_libretro";
+      case MENU_ENUM_LABEL_PAUSE_NONACTIVE:
+         return "pause_nonactive";
+      case MENU_ENUM_LABEL_PERFCNT_ENABLE:
+         return "perfcnt_enable";
+      case MENU_ENUM_LABEL_PLAYLISTS_TAB:
+         return "playlists_tab";
+      case MENU_ENUM_LABEL_PLAYLIST_COLLECTION_ENTRY:
+         return "playlist_collection_entry";
+      case MENU_ENUM_LABEL_PLAYLIST_DIRECTORY:
+         return "playlist_directory";
+      case MENU_ENUM_LABEL_PLAYLIST_ENTRY:
+         return "playlist_entry";
+      case MENU_ENUM_LABEL_PLAYLIST_SETTINGS:
+         return "playlist_settings";
+      case MENU_ENUM_LABEL_PLAYLIST_SETTINGS_BEGIN:
+         return "playlist_settings_begin";
+      case MENU_ENUM_LABEL_POINTER_ENABLE:
+         return "menu_pointer_enable";
+      case MENU_ENUM_LABEL_PRIVACY_SETTINGS:
+         return "privacy_settings";
+      case MENU_ENUM_LABEL_QUIT_RETROARCH:
+         return "quit_retroarch";
+      case MENU_ENUM_LABEL_RDB_ENTRY:
+         return "rdb_entry";
+      case MENU_ENUM_LABEL_RDB_ENTRY_ANALOG:
+         return "rdb_entry_analog";
+      case MENU_ENUM_LABEL_RDB_ENTRY_BBFC_RATING:
+         return "rdb_entry_bbfc_rating";
+      case MENU_ENUM_LABEL_RDB_ENTRY_CERO_RATING:
+         return "rdb_entry_cero_rating";
+      case MENU_ENUM_LABEL_RDB_ENTRY_CRC32:
+         return "rdb_entry_crc32";
+      case MENU_ENUM_LABEL_RDB_ENTRY_DESCRIPTION:
+         return "rdb_entry_description";
+      case MENU_ENUM_LABEL_RDB_ENTRY_DEVELOPER:
+         return "rdb_entry_developer";
+      case MENU_ENUM_LABEL_RDB_ENTRY_EDGE_MAGAZINE_ISSUE:
+         return "rdb_entry_edge_magazine_issue";
+      case MENU_ENUM_LABEL_RDB_ENTRY_EDGE_MAGAZINE_RATING:
+         return "rdb_entry_edge_magazine_rating";
+      case MENU_ENUM_LABEL_RDB_ENTRY_EDGE_MAGAZINE_REVIEW:
+         return "rdb_entry_edge_magazine_review";
+      case MENU_ENUM_LABEL_RDB_ENTRY_ELSPA_RATING:
+         return "rdb_entry_elspa_rating";
+      case MENU_ENUM_LABEL_RDB_ENTRY_ENHANCEMENT_HW:
+         return "rdb_entry_enhancement_hw";
+      case MENU_ENUM_LABEL_RDB_ENTRY_ESRB_RATING:
+         return "rdb_entry_esrb_rating";
+      case MENU_ENUM_LABEL_RDB_ENTRY_FAMITSU_MAGAZINE_RATING:
+         return "rdb_entry_famitsu_magazine_rating";
+      case MENU_ENUM_LABEL_RDB_ENTRY_FRANCHISE:
+         return "rdb_entry_franchise";
+      case MENU_ENUM_LABEL_RDB_ENTRY_GENRE:
+         return "rdb_entry_genre";
+      case MENU_ENUM_LABEL_RDB_ENTRY_MAX_USERS:
+         return "rdb_entry_max_users";
+      case MENU_ENUM_LABEL_RDB_ENTRY_MD5:
+         return "rdb_entry_md5";
+      case MENU_ENUM_LABEL_RDB_ENTRY_NAME:
+         return "rdb_entry_name";
+      case MENU_ENUM_LABEL_RDB_ENTRY_ORIGIN:
+         return "rdb_entry_origin";
+      case MENU_ENUM_LABEL_RDB_ENTRY_PEGI_RATING:
+         return "rdb_entry_pegi_rating";
+      case MENU_ENUM_LABEL_RDB_ENTRY_PUBLISHER:
+         return "rdb_entry_publisher";
+      case MENU_ENUM_LABEL_RDB_ENTRY_RELEASE_MONTH:
+         return "rdb_entry_releasemonth";
+      case MENU_ENUM_LABEL_RDB_ENTRY_RELEASE_YEAR:
+         return "rdb_entry_releaseyear";
+      case MENU_ENUM_LABEL_RDB_ENTRY_SERIAL:
+         return "rdb_entry_serial";
+      case MENU_ENUM_LABEL_RDB_ENTRY_SHA1:
+         return "rdb_entry_sha1";
+      case MENU_ENUM_LABEL_RDB_ENTRY_START_CONTENT:
+         return "rdb_entry_start_content";
+      case MENU_ENUM_LABEL_RDB_ENTRY_TGDB_RATING:
+         return "rdb_entry_tgdb_rating";
+      case MENU_ENUM_LABEL_REBOOT:
+         return "reboot";
+      case MENU_ENUM_LABEL_RECORDING_CONFIG_DIRECTORY:
+         return "recording_config_directory";
+      case MENU_ENUM_LABEL_RECORDING_OUTPUT_DIRECTORY:
+         return "recording_output_directory";
+      case MENU_ENUM_LABEL_RECORDING_SETTINGS:
+         return "recording_settings";
+      case MENU_ENUM_LABEL_RECORD_CONFIG:
+         return "record_config";
+      case MENU_ENUM_LABEL_RECORD_DRIVER:
+         return "record_driver";
+      case MENU_ENUM_LABEL_RECORD_ENABLE:
+         return "record_enable";
+      case MENU_ENUM_LABEL_RECORD_PATH:
+         return "record_path";
+      case MENU_ENUM_LABEL_RECORD_USE_OUTPUT_DIRECTORY:
+         return "record_use_output_directory";
+      case MENU_ENUM_LABEL_REMAP_FILE_LOAD:
+         return "remap_file_load";
+      case MENU_ENUM_LABEL_REMAP_FILE_SAVE_CORE:
+         return "remap_file_save_core";
+      case MENU_ENUM_LABEL_REMAP_FILE_SAVE_GAME:
+         return "remap_file_save_game";
+      case MENU_ENUM_LABEL_RESTART_CONTENT:
+         return "restart_content";
+      case MENU_ENUM_LABEL_RESTART_RETROARCH:
+         return "restart_retroarch";
+      case MENU_ENUM_LABEL_RESUME_CONTENT:
+         return "resume_content";
+      case MENU_ENUM_LABEL_RETRO_ACHIEVEMENTS_SETTINGS:
+         return "retro_achievements_settings";
+      case MENU_ENUM_LABEL_REWIND_ENABLE:
+         return "rewind_enable";
+      case MENU_ENUM_LABEL_REWIND_GRANULARITY:
+         return "rewind_granularity";
+      case MENU_ENUM_LABEL_REWIND_SETTINGS:
+         return "rewind_settings";
+      case MENU_ENUM_LABEL_RGUI_BROWSER_DIRECTORY:
+         return "rgui_browser_directory";
+      case MENU_ENUM_LABEL_RGUI_CONFIG_DIRECTORY:
+         return "rgui_config_directory";
+      case MENU_ENUM_LABEL_RGUI_SHOW_START_SCREEN:
+         return "rgui_show_start_screen";
+      case MENU_ENUM_LABEL_RUN:
+         return "collection";
+      case MENU_ENUM_LABEL_SAMBA_ENABLE:
+         return "samba_enable";
+      case MENU_ENUM_LABEL_SAVEFILE_DIRECTORY:
+         return "savefile_directory";
+      case MENU_ENUM_LABEL_SAVESTATE_AUTO_INDEX:
+         return "savestate_auto_index";
+      case MENU_ENUM_LABEL_SAVESTATE_AUTO_LOAD:
+         return "savestate_auto_load";
+      case MENU_ENUM_LABEL_SAVESTATE_AUTO_SAVE:
+         return "savestate_auto_save";
+      case MENU_ENUM_LABEL_SAVESTATE_DIRECTORY:
+         return "savestate_directory";
       case MENU_ENUM_LABEL_SAVE_CURRENT_CONFIG:
          return "save_current_config";
       case MENU_ENUM_LABEL_SAVE_CURRENT_CONFIG_OVERRIDE_CORE:
          return "save_current_config_override_core";
       case MENU_ENUM_LABEL_SAVE_CURRENT_CONFIG_OVERRIDE_GAME:
          return "save_current_config_override_game";
-      case MENU_ENUM_LABEL_STATE_SLOT:
-         return "state_slot";
-      case MENU_ENUM_LABEL_CHEEVOS_USERNAME:
-         return "cheevos_username";
-      case MENU_ENUM_LABEL_CHEEVOS_PASSWORD:
-         return "cheevos_password";
-      case MENU_ENUM_LABEL_ACCOUNTS_CHEEVOS_USERNAME:
-         return "accounts_cheevos_username";
-      case MENU_ENUM_LABEL_ACCOUNTS_RETRO_ACHIEVEMENTS:
-         return "retro_achievements";
-      case MENU_ENUM_LABEL_DEFERRED_ACCOUNTS_CHEEVOS_LIST:
-         return "deferred_accounts_cheevos_list";
-      case MENU_ENUM_LABEL_DEFERRED_USER_BINDS_LIST:
-         return "deferred_user_binds_list";
-      case MENU_ENUM_LABEL_DEFERRED_ACCOUNTS_LIST:
-         return "deferred_accounts_list";
-      case MENU_ENUM_LABEL_DEFERRED_INPUT_SETTINGS_LIST:
-         return "deferred_input_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_DRIVER_SETTINGS_LIST:
-         return "deferred_driver_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_AUDIO_SETTINGS_LIST:
-         return "deferred_audio_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_CORE_SETTINGS_LIST:
-         return "deferred_core_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_VIDEO_SETTINGS_LIST:
-         return "deferred_video_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_CONFIGURATION_SETTINGS_LIST:
-         return "deferred_configuration_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_SAVING_SETTINGS_LIST:
-         return "deferred_saving_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_LOGGING_SETTINGS_LIST:
-         return "deferred_logging_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_FRAME_THROTTLE_SETTINGS_LIST:
-         return "deferred_frame_throttle_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_REWIND_SETTINGS_LIST:
-         return "deferred_rewind_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_ONSCREEN_DISPLAY_SETTINGS_LIST:
-         return "deferred_onscreen_display_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_ONSCREEN_OVERLAY_SETTINGS_LIST:
-         return "deferred_onscreen_overlay_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_MENU_SETTINGS_LIST:
-         return "deferred_menu_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_USER_INTERFACE_SETTINGS_LIST:
-         return "deferred_user_interface_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_MENU_FILE_BROWSER_SETTINGS_LIST:
-         return "deferred_menu_file_browser_settings_list";
-      case MENU_ENUM_LABEL_FILE_BROWSER_DIRECTORY:
-         return "file_browser_directory";
-      case MENU_ENUM_LABEL_FILE_BROWSER_PLAIN_FILE:
-         return "file_browser_plain_file";
-      case MENU_ENUM_LABEL_FILE_BROWSER_REMAP:
-         return "file_browser_remap";
-      case MENU_ENUM_LABEL_FILE_BROWSER_SHADER:
-         return "file_browser_shader";
-      case MENU_ENUM_LABEL_FILE_BROWSER_SHADER_PRESET:
-         return "file_browser_shader_preset";
-      case MENU_ENUM_LABEL_FILE_BROWSER_CORE:
-         return "file_browser_core";
-      case MENU_ENUM_LABEL_FILE_BROWSER_CORE_SELECT_FROM_COLLECTION:
-         return "file_browser_core_select_from_collection";
-      case MENU_ENUM_LABEL_FILE_BROWSER_MUSIC_OPEN:
-         return "file_browser_music_open";
-      case MENU_ENUM_LABEL_FILE_BROWSER_MOVIE_OPEN:
-         return "file_browser_movie_open";
-      case MENU_ENUM_LABEL_FILE_BROWSER_IMAGE_OPEN_WITH_VIEWER:
-         return "file_browser_image_open_with_viewer";
-      case MENU_ENUM_LABEL_FILE_BROWSER_IMAGE:
-         return "file_browser_image";
-      case MENU_ENUM_LABEL_FILE_BROWSER_CORE_DETECTED:
-         return "file_browser_core_detected";
-      case MENU_ENUM_LABEL_DEFERRED_RETRO_ACHIEVEMENTS_SETTINGS_LIST:
-         return "deferred_retro_achievements_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_UPDATER_SETTINGS_LIST:
-         return "deferred_updater_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_WIFI_SETTINGS_LIST:
-         return "deferred_wifi_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_NETWORK_SETTINGS_LIST:
-         return "deferred_network_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_LAKKA_SERVICES_LIST:
-         return "deferred_lakka_services_list";
-      case MENU_ENUM_LABEL_DEFERRED_USER_SETTINGS_LIST:
-         return "deferred_user_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_DIRECTORY_SETTINGS_LIST:
-         return "deferred_directory_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_PRIVACY_SETTINGS_LIST:
-         return "deferred_privacy_settings_list";
-      case MENU_ENUM_LABEL_ACCOUNTS_LIST:
-         return "accounts_list";
-      case MENU_ENUM_LABEL_DEFERRED_INPUT_HOTKEY_BINDS_LIST:
-         return "deferred_input_hotkey_binds";
-      case MENU_ENUM_LABEL_INPUT_HOTKEY_BINDS:
-         return "input_hotkey_binds";
-      case MENU_ENUM_LABEL_INPUT_HOTKEY_BINDS_BEGIN:
-         return "input_hotkey_binds_begin";
-      case MENU_ENUM_LABEL_INPUT_SETTINGS_BEGIN:
-         return "input_settings_begin";
-      case MENU_ENUM_LABEL_PLAYLIST_SETTINGS_BEGIN:
-         return "playlist_settings_begin";
-      case MENU_ENUM_LABEL_RECORDING_SETTINGS:
-         return "recording_settings";
-      case MENU_ENUM_LABEL_PLAYLIST_SETTINGS:
-         return "playlist_settings";
-      case MENU_ENUM_LABEL_DEFERRED_RECORDING_SETTINGS_LIST:
-         return "deferred_recording_settings";
-      case MENU_ENUM_LABEL_DEFERRED_PLAYLIST_SETTINGS_LIST:
-         return "deferred_playlist_settings";
-      case MENU_ENUM_LABEL_INPUT_SETTINGS:
-         return "input_settings";
-      case MENU_ENUM_LABEL_DRIVER_SETTINGS:
-         return "driver_settings";
-      case MENU_ENUM_LABEL_VIDEO_SETTINGS:
-         return "video_settings";
-      case MENU_ENUM_LABEL_CONFIGURATION_SETTINGS:
-         return "configuration_settings";
+      case MENU_ENUM_LABEL_SAVE_NEW_CONFIG:
+         return "save_new_config";
+      case MENU_ENUM_LABEL_SAVE_STATE:
+         return "savestate";
       case MENU_ENUM_LABEL_SAVING_SETTINGS:
          return "saving_settings";
-      case MENU_ENUM_LABEL_LOGGING_SETTINGS:
-         return "logging_settings";
-      case MENU_ENUM_LABEL_FRAME_THROTTLE_SETTINGS:
-         return "frame_throttle_settings";
-      case MENU_ENUM_LABEL_REWIND_SETTINGS:
-         return "rewind_settings";
-      case MENU_ENUM_LABEL_ONSCREEN_DISPLAY_SETTINGS:
-         return "onscreen_display_settings";
-      case MENU_ENUM_LABEL_ONSCREEN_OVERLAY_SETTINGS:
-         return "onscreen_overlay_settings";
-      case MENU_ENUM_LABEL_AUDIO_SETTINGS:
-         return "audio_settings";
-      case MENU_ENUM_LABEL_MENU_SETTINGS:
-         return "menu_settings";
-      case MENU_ENUM_LABEL_USER_INTERFACE_SETTINGS:
-         return "user_interface_settings";
-      case MENU_ENUM_LABEL_MENU_FILE_BROWSER_SETTINGS:
-         return "menu_file_browser_settings";
-      case MENU_ENUM_LABEL_RETRO_ACHIEVEMENTS_SETTINGS:
-         return "retro_achievements_settings";
-      case MENU_ENUM_LABEL_UPDATER_SETTINGS:
-         return "updater_settings";
-      case MENU_ENUM_LABEL_NETWORK_SETTINGS:
-         return "network_settings";
-      case MENU_ENUM_LABEL_WIFI_SETTINGS:
-         return "wifi_settings";
-      case MENU_ENUM_LABEL_USER_SETTINGS:
-         return "user_settings";
-      case MENU_ENUM_LABEL_LAKKA_SERVICES:
-         return "lakka_services";
-      case MENU_ENUM_LABEL_DIRECTORY_SETTINGS:
-         return "directory_settings";
-      case MENU_ENUM_LABEL_PRIVACY_SETTINGS:
-         return "privacy_settings";
-      case MENU_ENUM_LABEL_HELP_SCANNING_CONTENT:
-         return "help_scanning_content";
-      case MENU_ENUM_LABEL_CHEEVOS_DESCRIPTION:
-         return "cheevos_description";
-      case MENU_ENUM_LABEL_HELP_AUDIO_VIDEO_TROUBLESHOOTING:
-         return "help_audio_video_troubleshooting";
-      case MENU_ENUM_LABEL_HELP_CHANGE_VIRTUAL_GAMEPAD:
-         return "help_change_virtual_gamepad";
-      case MENU_ENUM_LABEL_HELP_WHAT_IS_A_CORE:
-         return "help_what_is_a_core";
-      case MENU_ENUM_LABEL_HELP_LOADING_CONTENT:
-         return "help_loading_content";
-      case MENU_ENUM_LABEL_HELP_LIST:
-         return "help_list";
-      case MENU_ENUM_LABEL_HELP_CONTROLS:
-         return "help_controls";
-      case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_OPEN_DETECT_CORE:
-         return "deferred_archive_open_detect_core";
-      case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_OPEN:
-         return "deferred_archive_open";
-      case MENU_ENUM_LABEL_LOAD_ARCHIVE_DETECT_CORE:
-         return "load_archive_detect_core";
-      case MENU_ENUM_LABEL_LOAD_ARCHIVE:
-         return "load_archive";
-      case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_ACTION_DETECT_CORE:
-         return "deferred_archive_action_detect_core";
-      case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_ACTION:
-         return "deferred_archive_action";
-      case MENU_ENUM_LABEL_OPEN_ARCHIVE_DETECT_CORE:
-         return "open_archive_detect_core";
-      case MENU_ENUM_LABEL_OPEN_ARCHIVE:
-         return "open_archive";
-      case MENU_ENUM_LABEL_INPUT_BACK_AS_MENU_ENUM_TOGGLE_ENABLE:
-         return "back_as_menu_toggle_enable";
-      case MENU_ENUM_LABEL_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
-         return "input_menu_toggle_gamepad_combo";
-      case MENU_ENUM_LABEL_INPUT_ALL_USERS_CONTROL_MENU:
-         return "all_users_control_menu";
-      case MENU_ENUM_LABEL_INPUT_OVERLAY_HIDE_IN_MENU:
-         return "overlay_hide_in_menu";
-      case MENU_ENUM_LABEL_NO_PLAYLIST_ENTRIES_AVAILABLE:
-         return "no_playlist_entries_available";
-      case MENU_ENUM_LABEL_DOWNLOADED_FILE_DETECT_CORE_LIST:
-         return "downloaded_file_detect_core_list";
-      case MENU_ENUM_LABEL_UPDATE_CORE_INFO_FILES:
-         return "update_core_info_files";
-      case MENU_ENUM_LABEL_DEFERRED_CORE_CONTENT_LIST:
-         return "deferred_core_content_list";
-      case MENU_ENUM_LABEL_DEFERRED_CORE_CONTENT_DIRS_LIST:
-         return "deferred_core_content_dirs_list";
-      case MENU_ENUM_LABEL_DEFERRED_CORE_CONTENT_DIRS_SUBDIR_LIST:
-         return "deferred_core_content_dirs_subdir_list";
-      case MENU_ENUM_LABEL_DEFERRED_LAKKA_LIST:
-         return "deferred_lakka_list";
-      case MENU_ENUM_LABEL_DOWNLOAD_CORE_CONTENT:
-         return "download_core_content";
-      case MENU_ENUM_LABEL_DOWNLOAD_CORE_CONTENT_DIRS:
-         return "download_core_content_dirs";
-      case MENU_ENUM_LABEL_CB_DOWNLOAD_URL:
-         return "cb_download_url";
-      case MENU_ENUM_LABEL_SCAN_THIS_DIRECTORY:
-         return "scan_this_directory";
-      case MENU_ENUM_LABEL_SCAN_FILE:
-         return "scan_file";
       case MENU_ENUM_LABEL_SCAN_DIRECTORY:
          return "scan_directory";
-      case MENU_ENUM_LABEL_ADD_CONTENT_LIST:
-         return "add_content";
-      case MENU_ENUM_LABEL_CONNECT_WIFI:
-         return "connect_wifi";
-      case MENU_ENUM_LABEL_OVERLAY_AUTOLOAD_PREFERRED:
-         return "overlay_autoload_preferred";
-      case MENU_ENUM_LABEL_INFORMATION:
-         return "information";
-      case MENU_ENUM_LABEL_INFORMATION_LIST:
-         return "information_list";
-      case MENU_ENUM_LABEL_USE_BUILTIN_PLAYER:
-         return "use_builtin_player";
-      case MENU_ENUM_LABEL_CONTENT_SETTINGS:
-         return "quick_menu";
-      case MENU_ENUM_LABEL_LOAD_CONTENT_LIST:
-         return "load_content";
-      case MENU_ENUM_LABEL_NO_SETTINGS_FOUND:
-         return "menu_label_no_settings_found";
+      case MENU_ENUM_LABEL_SCAN_FILE:
+         return "scan_file";
+      case MENU_ENUM_LABEL_SCAN_THIS_DIRECTORY:
+         return "scan_this_directory";
+      case MENU_ENUM_LABEL_SCREENSHOT_DIRECTORY:
+         return "screenshot_directory";
+      case MENU_ENUM_LABEL_SCREEN_RESOLUTION:
+         return "screen_resolution";
+      case MENU_ENUM_LABEL_SETTINGS:
+         return "settings";
+      case MENU_ENUM_LABEL_SETTINGS_TAB:
+         return "settings_tab";
+      case MENU_ENUM_LABEL_SHADER_APPLY_CHANGES:
+         return "shader_apply_changes";
+      case MENU_ENUM_LABEL_SHADER_OPTIONS:
+         return "shader_options";
+      case MENU_ENUM_LABEL_SHADER_PARAMETERS_ENTRY:
+         return "shader_parameters_entry";
+      case MENU_ENUM_LABEL_SHOW_ADVANCED_SETTINGS:
+         return "menu_show_advanced_settings";
+      case MENU_ENUM_LABEL_SHOW_HIDDEN_FILES:
+         return "show_hidden_files";
+      case MENU_ENUM_LABEL_SHUTDOWN:
+         return "shutdown";
+      case MENU_ENUM_LABEL_SLOWMOTION_RATIO:
+         return "slowmotion_ratio";
+      case MENU_ENUM_LABEL_SORT_SAVEFILES_ENABLE:
+         return "sort_savefiles_enable";
+      case MENU_ENUM_LABEL_SORT_SAVESTATES_ENABLE:
+         return "sort_savestates_enable";
+      case MENU_ENUM_LABEL_SSH_ENABLE:
+         return "ssh_enable";
+      case MENU_ENUM_LABEL_START_CORE:
+         return "start_core";
+      case MENU_ENUM_LABEL_START_NET_RETROPAD:
+         return "menu_start_net_retropad";
+      case MENU_ENUM_LABEL_START_VIDEO_PROCESSOR:
+         return "menu_start_video_processor";
+      case MENU_ENUM_LABEL_STATE_SLOT:
+         return "state_slot";
+      case MENU_ENUM_LABEL_STDIN_CMD_ENABLE:
+         return "stdin_commands";
+      case MENU_ENUM_LABEL_SUSPEND_SCREENSAVER_ENABLE:
+         return "suspend_screensaver_enable";
       case MENU_ENUM_LABEL_SYSTEM_BGM_ENABLE:
          return "system_bgm_enable";
-      case MENU_ENUM_LABEL_AUDIO_BLOCK_FRAMES:
-         return "audio_block_frames";
-      case MENU_ENUM_LABEL_INPUT_BIND_MODE:
-         return "input_bind_mode";
-      case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_LABEL_SHOW:
-         return "input_descriptor_label_show";
-      case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_HIDE_UNBOUND:
-         return "input_descriptor_hide_unbound";
+      case MENU_ENUM_LABEL_SYSTEM_DIRECTORY:
+         return "system_directory";
+      case MENU_ENUM_LABEL_SYSTEM_INFORMATION:
+         return "system_information";
+      case MENU_ENUM_LABEL_SYSTEM_INFO_ENTRY:
+         return "system_info_entry";
+      case MENU_ENUM_LABEL_TAKE_SCREENSHOT:
+         return "take_screenshot";
+      case MENU_ENUM_LABEL_THREADED_DATA_RUNLOOP_ENABLE:
+         return "threaded_data_runloop_enable";
+      case MENU_ENUM_LABEL_THUMBNAILS:
+         return "thumbnails";
+      case MENU_ENUM_LABEL_THUMBNAILS_DIRECTORY:
+         return "thumbnails_directory";
+      case MENU_ENUM_LABEL_THUMBNAILS_UPDATER_LIST:
+         return "thumbnails_updater_list";
+      case MENU_ENUM_LABEL_TIMEDATE_ENABLE:
+         return "menu_timedate_enable";
+      case MENU_ENUM_LABEL_TITLE_COLOR:
+         return "menu_title_color";
+      case MENU_ENUM_LABEL_UI_COMPANION_ENABLE:
+         return "ui_companion_enable";
+      case MENU_ENUM_LABEL_UI_COMPANION_START_ON_BOOT:
+         return "ui_companion_start_on_boot";
+      case MENU_ENUM_LABEL_UI_MENUBAR_ENABLE:
+         return "ui_menubar_enable";
+      case MENU_ENUM_LABEL_UNDO_LOAD_STATE:
+         return "undoloadstate";
+      case MENU_ENUM_LABEL_UNDO_SAVE_STATE:
+         return "undosavestate";
+      case MENU_ENUM_LABEL_UPDATER_SETTINGS:
+         return "updater_settings";
+      case MENU_ENUM_LABEL_UPDATE_ASSETS:
+         return "update_assets";
+      case MENU_ENUM_LABEL_UPDATE_AUTOCONFIG_PROFILES:
+         return "update_autoconfig_profiles";
+      case MENU_ENUM_LABEL_UPDATE_CG_SHADERS:
+         return "update_cg_shaders";
+      case MENU_ENUM_LABEL_UPDATE_CHEATS:
+         return "update_cheats";
+      case MENU_ENUM_LABEL_UPDATE_CORE_INFO_FILES:
+         return "update_core_info_files";
+      case MENU_ENUM_LABEL_UPDATE_DATABASES:
+         return "update_databases";
+      case MENU_ENUM_LABEL_UPDATE_GLSL_SHADERS:
+         return "update_glsl_shaders";
+      case MENU_ENUM_LABEL_UPDATE_LAKKA:
+         return "update_lakka";
+      case MENU_ENUM_LABEL_UPDATE_OVERLAYS:
+         return "update_overlays";
+      case MENU_ENUM_LABEL_UPDATE_SLANG_SHADERS:
+         return "update_slang_shaders";
+      case MENU_ENUM_LABEL_URL_ENTRY:
+         return "url_entry";
+      case MENU_ENUM_LABEL_USER_INTERFACE_SETTINGS:
+         return "user_interface_settings";
+      case MENU_ENUM_LABEL_USER_LANGUAGE:
+         return "user_language";
+      case MENU_ENUM_LABEL_USER_SETTINGS:
+         return "user_settings";
+      case MENU_ENUM_LABEL_USE_BUILTIN_IMAGE_VIEWER:
+         return "use_builtin_image_viewer";
+      case MENU_ENUM_LABEL_USE_BUILTIN_PLAYER:
+         return "use_builtin_player";
+      case MENU_ENUM_LABEL_USE_THIS_DIRECTORY:
+         return "use_this_directory";
+      case MENU_ENUM_LABEL_VIDEO_ALLOW_ROTATE:
+         return "video_allow_rotate";
+      case MENU_ENUM_LABEL_VIDEO_ASPECT_RATIO_AUTO:
+         return "video_aspect_ratio_auto";
+      case MENU_ENUM_LABEL_VIDEO_ASPECT_RATIO_INDEX:
+         return "aspect_ratio_index";
+      case MENU_ENUM_LABEL_VIDEO_BLACK_FRAME_INSERTION:
+         return "video_black_frame_insertion";
+      case MENU_ENUM_LABEL_VIDEO_CROP_OVERSCAN:
+         return "video_crop_overscan";
+      case MENU_ENUM_LABEL_VIDEO_DISABLE_COMPOSITION:
+         return "video_disable_composition";
+      case MENU_ENUM_LABEL_VIDEO_DRIVER:
+         return "video_driver";
+      case MENU_ENUM_LABEL_VIDEO_FILTER:
+         return "video_filter";
+      case MENU_ENUM_LABEL_VIDEO_FILTER_DIR:
+         return "video_filter_dir";
+      case MENU_ENUM_LABEL_VIDEO_FILTER_FLICKER:
+         return "video_filter_flicker";
       case MENU_ENUM_LABEL_VIDEO_FONT_ENABLE:
          return "video_font_enable";
       case MENU_ENUM_LABEL_VIDEO_FONT_PATH:
          return "video_font_path";
       case MENU_ENUM_LABEL_VIDEO_FONT_SIZE:
          return "video_font_size";
+      case MENU_ENUM_LABEL_VIDEO_FORCE_ASPECT:
+         return "video_force_aspect";
+      case MENU_ENUM_LABEL_VIDEO_FORCE_SRGB_DISABLE:
+         return "video_force_srgb_disable";
+      case MENU_ENUM_LABEL_VIDEO_FRAME_DELAY:
+         return "video_frame_delay";
+      case MENU_ENUM_LABEL_VIDEO_FULLSCREEN:
+         return "video_fullscreen";
+      case MENU_ENUM_LABEL_VIDEO_GAMMA:
+         return "video_gamma";
+      case MENU_ENUM_LABEL_VIDEO_GPU_RECORD:
+         return "video_gpu_record";
+      case MENU_ENUM_LABEL_VIDEO_GPU_SCREENSHOT:
+         return "video_gpu_screenshot";
+      case MENU_ENUM_LABEL_VIDEO_HARD_SYNC:
+         return "video_hard_sync";
+      case MENU_ENUM_LABEL_VIDEO_HARD_SYNC_FRAMES:
+         return "video_hard_sync_frames";
+      case MENU_ENUM_LABEL_VIDEO_MAX_SWAPCHAIN_IMAGES:
+         return "video_max_swapchain_images";
       case MENU_ENUM_LABEL_VIDEO_MESSAGE_POS_X:
          return "video_message_pos_x";
       case MENU_ENUM_LABEL_VIDEO_MESSAGE_POS_Y:
          return "video_message_pos_y";
-      case MENU_ENUM_LABEL_VIDEO_SOFT_FILTER:
-         return "soft_filter";
-      case MENU_ENUM_LABEL_VIDEO_FILTER_FLICKER:
-         return "video_filter_flicker";
-      case MENU_ENUM_LABEL_INPUT_REMAPPING_DIRECTORY:
-         return "input_remapping_directory";
-      case MENU_ENUM_LABEL_JOYPAD_AUTOCONFIG_DIR:
-         return "joypad_autoconfig_dir";
-      case MENU_ENUM_LABEL_RECORDING_CONFIG_DIRECTORY:
-         return "recording_config_directory";
-      case MENU_ENUM_LABEL_RECORDING_OUTPUT_DIRECTORY:
-         return "recording_output_directory";
-      case MENU_ENUM_LABEL_SCREENSHOT_DIRECTORY:
-         return "screenshot_directory";
-      case MENU_ENUM_LABEL_PLAYLIST_DIRECTORY:
-         return "playlist_directory";
-      case MENU_ENUM_LABEL_SAVEFILE_DIRECTORY:
-         return "savefile_directory";
-      case MENU_ENUM_LABEL_SAVESTATE_DIRECTORY:
-         return "savestate_directory";
-      case MENU_ENUM_LABEL_STDIN_CMD_ENABLE:
-         return "stdin_commands";
-      case MENU_ENUM_LABEL_NETWORK_REMOTE_ENABLE:
-         return "network_remote_enable";
-      case MENU_ENUM_LABEL_NETWORK_REMOTE_USER_1_ENABLE:
-         return "network_remote_user_1_enable";
-      case MENU_ENUM_LABEL_NETWORK_REMOTE_USER_LAST_ENABLE:
-         return "network_remote_user_last_enable";
-      case MENU_ENUM_LABEL_NETWORK_REMOTE_PORT:
-         return "network_remote_base_port";
-      case MENU_ENUM_LABEL_VIDEO_DRIVER:
-         return "video_driver";
-      case MENU_ENUM_LABEL_RECORD_ENABLE:
-         return "record_enable";
-      case MENU_ENUM_LABEL_VIDEO_GPU_RECORD:
-         return "video_gpu_record";
-      case MENU_ENUM_LABEL_RECORD_PATH:
-         return "record_path";
-      case MENU_ENUM_LABEL_RECORD_USE_OUTPUT_DIRECTORY:
-         return "record_use_output_directory";
-      case MENU_ENUM_LABEL_RECORD_CONFIG:
-         return "record_config";
+      case MENU_ENUM_LABEL_VIDEO_MONITOR_INDEX:
+         return "video_monitor_index";
       case MENU_ENUM_LABEL_VIDEO_POST_FILTER_RECORD:
          return "video_post_filter_record";
-      case MENU_ENUM_LABEL_CORE_ASSETS_DIRECTORY:
-         return "core_assets_directory";
-      case MENU_ENUM_LABEL_ASSETS_DIRECTORY:
-         return "assets_directory";
-      case MENU_ENUM_LABEL_DYNAMIC_WALLPAPERS_DIRECTORY:
-         return "dynamic_wallpapers_directory";
-      case MENU_ENUM_LABEL_THUMBNAILS_DIRECTORY:
-         return "thumbnails_directory";
-      case MENU_ENUM_LABEL_RGUI_BROWSER_DIRECTORY:
-         return "rgui_browser_directory";
-      case MENU_ENUM_LABEL_RGUI_CONFIG_DIRECTORY:
-         return "rgui_config_directory";
-      case MENU_ENUM_LABEL_LIBRETRO_INFO_PATH:
-         return "libretro_info_path";
-      case MENU_ENUM_LABEL_LIBRETRO_DIR_PATH:
-         return "libretro_dir_path";
-      case MENU_ENUM_LABEL_CURSOR_DIRECTORY:
-         return "cursor_directory";
-      case MENU_ENUM_LABEL_CONTENT_DATABASE_DIRECTORY:
-         return "content_database_path";
-      case MENU_ENUM_LABEL_SYSTEM_DIRECTORY:
-         return "system_directory";
-      case MENU_ENUM_LABEL_CACHE_DIRECTORY:
-         return "cache_directory";
-      case MENU_ENUM_LABEL_CHEAT_DATABASE_PATH:
-         return "cheat_database_path";
-      case MENU_ENUM_LABEL_AUDIO_FILTER_DIR:
-         return "audio_filter_dir";
-      case MENU_ENUM_LABEL_VIDEO_FILTER_DIR:
-         return "video_filter_dir";
-      case MENU_ENUM_LABEL_VIDEO_SHADER_DIR:
-         return "video_shader_dir";
-      case MENU_ENUM_LABEL_OVERLAY_DIRECTORY:
-         return "overlay_directory";
-      case MENU_ENUM_LABEL_OSK_OVERLAY_DIRECTORY:
-         return "osk_overlay_directory";
-      case MENU_ENUM_LABEL_NETPLAY_CLIENT_SWAP_INPUT:
-         return "netplay_client_swap_input";
-      case MENU_ENUM_LABEL_NETPLAY_SPECTATOR_MODE_ENABLE:
-         return "netplay_spectator_mode_enable";
-      case MENU_ENUM_LABEL_NETPLAY_IP_ADDRESS:
-         return "netplay_ip_address";
-      case MENU_ENUM_LABEL_NETPLAY_TCP_UDP_PORT:
-         return "netplay_tcp_udp_port";
-      case MENU_ENUM_LABEL_NETPLAY_ENABLE:
-         return "netplay_enable";
-      case MENU_ENUM_LABEL_SSH_ENABLE:
-         return "ssh_enable";
-      case MENU_ENUM_LABEL_SAMBA_ENABLE:
-         return "samba_enable";
-      case MENU_ENUM_LABEL_BLUETOOTH_ENABLE:
-         return "bluetooth_enable";
-      case MENU_ENUM_LABEL_NETPLAY_DELAY_FRAMES:
-         return "netplay_delay_frames";
-      case MENU_ENUM_LABEL_NETPLAY_CHECK_FRAMES:
-         return "netplay_check_frames";
-      case MENU_ENUM_LABEL_NETPLAY_MODE:
-         return "netplay_mode";
-      case MENU_ENUM_LABEL_RGUI_SHOW_START_SCREEN:
-         return "rgui_show_start_screen";
-      case MENU_ENUM_LABEL_TITLE_COLOR:
-         return "menu_title_color";
-      case MENU_ENUM_LABEL_ENTRY_HOVER_COLOR:
-         return "menu_entry_hover_color";
-      case MENU_ENUM_LABEL_TIMEDATE_ENABLE:
-         return "menu_timedate_enable";
-      case MENU_ENUM_LABEL_THREADED_DATA_RUNLOOP_ENABLE:
-         return "threaded_data_runloop_enable";
-      case MENU_ENUM_LABEL_ENTRY_NORMAL_COLOR:
-         return "menu_entry_normal_color";
-      case MENU_ENUM_LABEL_SHOW_ADVANCED_SETTINGS:
-         return "menu_show_advanced_settings";
-      case MENU_ENUM_LABEL_MOUSE_ENABLE:
-         return "menu_mouse_enable";
-      case MENU_ENUM_LABEL_POINTER_ENABLE:
-         return "menu_pointer_enable";
-      case MENU_ENUM_LABEL_CORE_ENABLE:
-         return "menu_core_enable";
-      case MENU_ENUM_LABEL_NETPLAY_ENABLE_HOST:
-         return "menu_netplay_enable_host";
-      case MENU_ENUM_LABEL_NETPLAY_ENABLE_CLIENT:
-         return "menu_netplay_enable_client";
-      case MENU_ENUM_LABEL_NETPLAY_DISCONNECT:
-         return "menu_netplay_disconnect";
-      case MENU_ENUM_LABEL_NETPLAY_SETTINGS:
-         return "menu_netplay_settings";
-      case MENU_ENUM_LABEL_DPI_OVERRIDE_ENABLE:
-         return "dpi_override_enable";
-      case MENU_ENUM_LABEL_DPI_OVERRIDE_VALUE:
-         return "dpi_override_value";
-      case MENU_ENUM_LABEL_XMB_FONT:
-         return "xmb_font";
-      case MENU_ENUM_LABEL_XMB_THEME:
-         return "xmb_theme";
-      case MENU_ENUM_LABEL_XMB_MENU_COLOR_THEME:
-         return "xmb_menu_color_theme";
-      case MENU_ENUM_LABEL_MATERIALUI_MENU_COLOR_THEME:
-         return "materialui_menu_color_theme";
-      case MENU_ENUM_LABEL_MATERIALUI_MENU_HEADER_OPACITY:
-         return "materialui_menu_header_opacity";
-      case MENU_ENUM_LABEL_MATERIALUI_MENU_FOOTER_OPACITY:
-         return "materialui_menu_footer_opacity";
-      case MENU_ENUM_LABEL_XMB_SHADOWS_ENABLE:
-         return "xmb_shadows_enable";
-      case MENU_ENUM_LABEL_XMB_SHOW_SETTINGS:
-         return "xmb_show_settings";
-      case MENU_ENUM_LABEL_XMB_SHOW_IMAGES:
-         return "xmb_show_images";
-      case MENU_ENUM_LABEL_XMB_SHOW_MUSIC:
-         return "xmb_show_music";
-      case MENU_ENUM_LABEL_XMB_SHOW_VIDEO:
-         return "xmb_show_video";
-      case MENU_ENUM_LABEL_XMB_SHOW_HISTORY:
-         return "xmb_show_history";
-      case MENU_ENUM_LABEL_XMB_RIBBON_ENABLE:
-         return "xmb_ribbon_enable";
-      case MENU_ENUM_LABEL_XMB_SCALE_FACTOR:
-         return "xmb_scale_factor";
-      case MENU_ENUM_LABEL_XMB_ALPHA_FACTOR:
-         return "xmb_alpha_factor";
-      case MENU_ENUM_LABEL_SUSPEND_SCREENSAVER_ENABLE:
-         return "suspend_screensaver_enable";
-      case MENU_ENUM_LABEL_VIDEO_DISABLE_COMPOSITION:
-         return "video_disable_composition";
-      case MENU_ENUM_LABEL_PAUSE_NONACTIVE:
-         return "pause_nonactive";
-      case MENU_ENUM_LABEL_UI_COMPANION_START_ON_BOOT:
-         return "ui_companion_start_on_boot";
-      case MENU_ENUM_LABEL_UI_COMPANION_ENABLE:
-         return "ui_companion_enable";
-      case MENU_ENUM_LABEL_UI_MENUBAR_ENABLE:
-         return "ui_menubar_enable";
-      case MENU_ENUM_LABEL_ARCHIVE_MODE:
-         return "archive_mode";
-      case MENU_ENUM_LABEL_NETWORK_CMD_ENABLE:
-         return "network_cmd_enable";
-      case MENU_ENUM_LABEL_NETWORK_CMD_PORT:
-         return "network_cmd_port";
-      case MENU_ENUM_LABEL_HISTORY_LIST_ENABLE:
-         return "history_list_enable";
-      case MENU_ENUM_LABEL_CONTENT_HISTORY_SIZE:
-         return "content_history_size";
-      case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE_AUTO:
-         return "video_refresh_rate_auto";
-      case MENU_ENUM_LABEL_DUMMY_ON_CORE_SHUTDOWN:
-         return "dummy_on_core_shutdown";
-      case MENU_ENUM_LABEL_CORE_SET_SUPPORTS_NO_CONTENT_ENABLE:
-         return "core_set_supports_no_content_enable";
-      case MENU_ENUM_LABEL_FRAME_THROTTLE_ENABLE:
-         return "fastforward_ratio_throttle_enable";
-      case MENU_ENUM_LABEL_FASTFORWARD_RATIO:
-         return "fastforward_ratio";
-      case MENU_ENUM_LABEL_AUTO_REMAPS_ENABLE:
-         return "auto_remaps_enable";
-      case MENU_ENUM_LABEL_AUTO_SHADERS_ENABLE:
-         return "auto_shaders_enable";
-      case MENU_ENUM_LABEL_SLOWMOTION_RATIO:
-         return "slowmotion_ratio";
-      case MENU_ENUM_LABEL_CORE_SPECIFIC_CONFIG:
-         return "core_specific_config";
-      case MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS:
-         return "game_specific_options";
-      case MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS_CREATE:
-         return "game_specific_options_create";
-      case MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS_IN_USE:
-         return "game_specific_options_in_use";
-      case MENU_ENUM_LABEL_AUTO_OVERRIDES_ENABLE:
-         return "auto_overrides_enable";
-      case MENU_ENUM_LABEL_CONFIG_SAVE_ON_EXIT:
-         return "config_save_on_exit";
-      case MENU_ENUM_LABEL_CONFIRM_ON_EXIT:
-         return "confirm_on_exit";
-      case MENU_ENUM_LABEL_SHOW_HIDDEN_FILES:
-         return "show_hidden_files";
-      case MENU_ENUM_LABEL_VIDEO_SMOOTH:
-         return "video_smooth";
-      case MENU_ENUM_LABEL_VIDEO_GAMMA:
-         return "video_gamma";
-      case MENU_ENUM_LABEL_VIDEO_ALLOW_ROTATE:
-         return "video_allow_rotate";
-      case MENU_ENUM_LABEL_VIDEO_HARD_SYNC:
-         return "video_hard_sync";
-      case MENU_ENUM_LABEL_VIDEO_SWAP_INTERVAL:
-         return "video_swap_interval";
-      case MENU_ENUM_LABEL_VIDEO_VSYNC:
-         return "video_vsync";
-      case MENU_ENUM_LABEL_VIDEO_THREADED:
-         return "video_threaded";
-      case MENU_ENUM_LABEL_VIDEO_ROTATION:
-         return "video_rotation";
-      case MENU_ENUM_LABEL_VIDEO_GPU_SCREENSHOT:
-         return "video_gpu_screenshot";
-      case MENU_ENUM_LABEL_VIDEO_CROP_OVERSCAN:
-         return "video_crop_overscan";
-      case MENU_ENUM_LABEL_VIDEO_ASPECT_RATIO_INDEX:
-         return "aspect_ratio_index";
-      case MENU_ENUM_LABEL_VIDEO_ASPECT_RATIO_AUTO:
-         return "video_aspect_ratio_auto";
-      case MENU_ENUM_LABEL_VIDEO_FORCE_ASPECT:
-         return "video_force_aspect";
       case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE:
          return "video_refresh_rate";
-      case MENU_ENUM_LABEL_VIDEO_FORCE_SRGB_DISABLE:
-         return "video_force_srgb_disable";
-      case MENU_ENUM_LABEL_VIDEO_WINDOWED_FULLSCREEN:
-         return "video_windowed_fullscreen";
-      case MENU_ENUM_LABEL_PAL60_ENABLE:
-         return "pal60_enable";
-      case MENU_ENUM_LABEL_VIDEO_VFILTER:
-         return "video_vfilter";
-      case MENU_ENUM_LABEL_VIDEO_VI_WIDTH:
-         return "video_vi_width";
-      case MENU_ENUM_LABEL_VIDEO_BLACK_FRAME_INSERTION:
-         return "video_black_frame_insertion";
-      case MENU_ENUM_LABEL_VIDEO_HARD_SYNC_FRAMES:
-         return "video_hard_sync_frames";
-      case MENU_ENUM_LABEL_SORT_SAVEFILES_ENABLE:
-         return "sort_savefiles_enable";
-      case MENU_ENUM_LABEL_SORT_SAVESTATES_ENABLE:
-         return "sort_savestates_enable";
-      case MENU_ENUM_LABEL_VIDEO_FULLSCREEN:
-         return "video_fullscreen";
-      case MENU_ENUM_LABEL_PERFCNT_ENABLE:
-         return "perfcnt_enable";
+      case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE_AUTO:
+         return "video_refresh_rate_auto";
+      case MENU_ENUM_LABEL_VIDEO_ROTATION:
+         return "video_rotation";
       case MENU_ENUM_LABEL_VIDEO_SCALE:
          return "video_scale";
       case MENU_ENUM_LABEL_VIDEO_SCALE_INTEGER:
          return "video_scale_integer";
-      case MENU_ENUM_LABEL_LIBRETRO_LOG_LEVEL:
-         return "libretro_log_level";
-      case MENU_ENUM_LABEL_LOG_VERBOSITY:
-         return "log_verbosity";
-      case MENU_ENUM_LABEL_SAVESTATE_AUTO_SAVE:
-         return "savestate_auto_save";
-      case MENU_ENUM_LABEL_SAVESTATE_AUTO_LOAD:
-         return "savestate_auto_load";
-      case MENU_ENUM_LABEL_SAVESTATE_AUTO_INDEX:
-         return "savestate_auto_index";
-      case MENU_ENUM_LABEL_AUTOSAVE_INTERVAL:
-         return "autosave_interval";
-      case MENU_ENUM_LABEL_BLOCK_SRAM_OVERWRITE:
-         return "block_sram_overwrite";
-      case MENU_ENUM_LABEL_VIDEO_SHARED_CONTEXT:
-         return "video_shared_context";
-      case MENU_ENUM_LABEL_RESTART_RETROARCH:
-         return "restart_retroarch";
-      case MENU_ENUM_LABEL_NETPLAY_NICKNAME:
-         return "netplay_nickname";
-      case MENU_ENUM_LABEL_USER_LANGUAGE:
-         return "user_language";
-      case MENU_ENUM_LABEL_CAMERA_ALLOW:
-         return "camera_allow";
-      case MENU_ENUM_LABEL_LOCATION_ALLOW:
-         return "location_allow";
-      case MENU_ENUM_LABEL_PAUSE_LIBRETRO:
-         return "menu_pause_libretro";
-      case MENU_ENUM_LABEL_INPUT_OSK_OVERLAY_ENABLE:
-         return "input_osk_overlay_enable";
-      case MENU_ENUM_LABEL_INPUT_OVERLAY_ENABLE:
-         return "input_overlay_enable";
-      case MENU_ENUM_LABEL_VIDEO_MONITOR_INDEX:
-         return "video_monitor_index";
-      case MENU_ENUM_LABEL_VIDEO_FRAME_DELAY:
-         return "video_frame_delay";
-      case MENU_ENUM_LABEL_INPUT_DUTY_CYCLE:
-         return "input_duty_cycle";
-      case MENU_ENUM_LABEL_INPUT_TURBO_PERIOD:
-         return "input_turbo_period";
-      case MENU_ENUM_LABEL_INPUT_BIND_TIMEOUT:
-         return "input_bind_timeout";
-      case MENU_ENUM_LABEL_INPUT_AXIS_THRESHOLD:
-         return "input_axis_threshold";
-      case MENU_ENUM_LABEL_INPUT_REMAP_BINDS_ENABLE:
-         return "input_remap_binds_enable";
-      case MENU_ENUM_LABEL_INPUT_MAX_USERS:
-         return "input_max_users";
-      case MENU_ENUM_LABEL_INPUT_AUTODETECT_ENABLE:
-         return "input_autodetect_enable";
-      case MENU_ENUM_LABEL_AUDIO_OUTPUT_RATE:
-         return "audio_output_rate";
-      case MENU_ENUM_LABEL_AUDIO_MAX_TIMING_SKEW:
-         return "audio_max_timing_skew";
-      case MENU_ENUM_LABEL_CHEAT_APPLY_CHANGES:
-         return "cheat_apply_changes";
-      case MENU_ENUM_LABEL_REMAP_FILE_SAVE_CORE:
-         return "remap_file_save_core";
-      case MENU_ENUM_LABEL_REMAP_FILE_SAVE_GAME:
-         return "remap_file_save_game";
-      case MENU_ENUM_LABEL_CHEAT_NUM_PASSES:
-         return "cheat_num_passes";
-      case MENU_ENUM_LABEL_SHADER_APPLY_CHANGES:
-         return "shader_apply_changes";
-      case MENU_ENUM_LABEL_COLLECTION:
-         return "collection";
-      case MENU_ENUM_LABEL_REWIND_ENABLE:
-         return "rewind_enable";
-      case MENU_ENUM_LABEL_CONTENT_COLLECTION_LIST:
-         return "select_from_collection";
-      case MENU_ENUM_LABEL_DETECT_CORE_LIST:
-         return "detect_core_list";
-      case MENU_ENUM_LABEL_LOAD_CONTENT_HISTORY:
-         return "load_recent";
-      case MENU_ENUM_LABEL_AUDIO_ENABLE:
-         return "audio_enable";
-      case MENU_ENUM_LABEL_FPS_SHOW:
-         return "fps_show";
-      case MENU_ENUM_LABEL_AUDIO_MUTE:
-         return "audio_mute_enable";
-      case MENU_ENUM_LABEL_VIDEO_SHADER_PASS:
-         return "video_shader_pass";
-      case MENU_ENUM_LABEL_AUDIO_VOLUME:
-         return "audio_volume";
-      case MENU_ENUM_LABEL_AUDIO_SYNC:
-         return "audio_sync";
-      case MENU_ENUM_LABEL_AUDIO_RATE_CONTROL_DELTA:
-         return "audio_rate_control_delta";
+      case MENU_ENUM_LABEL_VIDEO_SETTINGS:
+         return "video_settings";
+      case MENU_ENUM_LABEL_VIDEO_SHADER_DIR:
+         return "video_shader_dir";
       case MENU_ENUM_LABEL_VIDEO_SHADER_FILTER_PASS:
          return "video_shader_filter_pass";
-      case MENU_ENUM_LABEL_VIDEO_SHADER_SCALE_PASS:
-         return "video_shader_scale_pass";
       case MENU_ENUM_LABEL_VIDEO_SHADER_NUM_PASSES:
          return "video_shader_num_passes";
-      case MENU_ENUM_LABEL_SHADER_PARAMETERS_ENTRY:
-         return "shader_parameters_entry";
-      case MENU_ENUM_LABEL_RDB_ENTRY:
-         return "rdb_entry";
-      case MENU_ENUM_LABEL_RDB_ENTRY_DESCRIPTION:
-         return "rdb_entry_description";
-      case MENU_ENUM_LABEL_RDB_ENTRY_GENRE:
-         return "rdb_entry_genre";
-      case MENU_ENUM_LABEL_RDB_ENTRY_ORIGIN:
-         return "rdb_entry_origin";
-      case MENU_ENUM_LABEL_RDB_ENTRY_PUBLISHER:
-         return "rdb_entry_publisher";
-      case MENU_ENUM_LABEL_RDB_ENTRY_DEVELOPER:
-         return "rdb_entry_developer";
-      case MENU_ENUM_LABEL_RDB_ENTRY_FRANCHISE:
-         return "rdb_entry_franchise";
-      case MENU_ENUM_LABEL_RDB_ENTRY_MAX_USERS:
-         return "rdb_entry_max_users";
-      case MENU_ENUM_LABEL_RDB_ENTRY_NAME:
-         return "rdb_entry_name";
-      case MENU_ENUM_LABEL_RDB_ENTRY_EDGE_MAGAZINE_RATING:
-         return "rdb_entry_edge_magazine_rating";
-      case MENU_ENUM_LABEL_RDB_ENTRY_EDGE_MAGAZINE_REVIEW:
-         return "rdb_entry_edge_magazine_review";
-      case MENU_ENUM_LABEL_RDB_ENTRY_FAMITSU_MAGAZINE_RATING:
-         return "rdb_entry_famitsu_magazine_rating";
-      case MENU_ENUM_LABEL_RDB_ENTRY_TGDB_RATING:
-         return "rdb_entry_tgdb_rating";
-      case MENU_ENUM_LABEL_RDB_ENTRY_EDGE_MAGAZINE_ISSUE:
-         return "rdb_entry_edge_magazine_issue";
-      case MENU_ENUM_LABEL_RDB_ENTRY_RELEASE_MONTH:
-         return "rdb_entry_releasemonth";
-      case MENU_ENUM_LABEL_RDB_ENTRY_RELEASE_YEAR:
-         return "rdb_entry_releaseyear";
-      case MENU_ENUM_LABEL_RDB_ENTRY_ENHANCEMENT_HW:
-         return "rdb_entry_enhancement_hw";
-      case MENU_ENUM_LABEL_RDB_ENTRY_SHA1:
-         return "rdb_entry_sha1";
-      case MENU_ENUM_LABEL_RDB_ENTRY_CRC32:
-         return "rdb_entry_crc32";
-      case MENU_ENUM_LABEL_RDB_ENTRY_MD5:
-         return "rdb_entry_md5";
-      case MENU_ENUM_LABEL_RDB_ENTRY_BBFC_RATING:
-         return "rdb_entry_bbfc_rating";
-      case MENU_ENUM_LABEL_RDB_ENTRY_ESRB_RATING:
-         return "rdb_entry_esrb_rating";
-      case MENU_ENUM_LABEL_RDB_ENTRY_ELSPA_RATING:
-         return "rdb_entry_elspa_rating";
-      case MENU_ENUM_LABEL_RDB_ENTRY_PEGI_RATING:
-         return "rdb_entry_pegi_rating";
-      case MENU_ENUM_LABEL_RDB_ENTRY_CERO_RATING:
-         return "rdb_entry_cero_rating";
-      case MENU_ENUM_LABEL_RDB_ENTRY_ANALOG:
-         return "rdb_entry_analog";
-      case MENU_ENUM_LABEL_RDB_ENTRY_SERIAL:
-         return "rdb_entry_serial";
-      case MENU_ENUM_LABEL_CONFIGURATIONS:
-         return "configurations";
-      case MENU_ENUM_LABEL_REWIND_GRANULARITY:
-         return "rewind_granularity";
-      case MENU_ENUM_LABEL_REMAP_FILE_LOAD:
-         return "remap_file_load";
-      case MENU_ENUM_LABEL_CUSTOM_RATIO:
-         return "custom_ratio";
-      case MENU_ENUM_LABEL_USE_THIS_DIRECTORY:
-         return "use_this_directory";
-      case MENU_ENUM_LABEL_RDB_ENTRY_START_CONTENT:
-         return "rdb_entry_start_content";
-      case MENU_ENUM_LABEL_CUSTOM_BIND:
-         return "custom_bind";
-      case MENU_ENUM_LABEL_CUSTOM_BIND_ALL:
-         return "custom_bind_all";
-      case MENU_ENUM_LABEL_DISK_OPTIONS:
-         return "core_disk_options";
-      case MENU_ENUM_LABEL_CORE_CHEAT_OPTIONS:
-         return "core_cheat_options";
-      case MENU_ENUM_LABEL_CORE_OPTIONS:
-         return "core_options";
-      case MENU_ENUM_LABEL_DATABASE_MANAGER_LIST:
-         return "database_manager_list";
-      case MENU_ENUM_LABEL_DEFERRED_DATABASE_MANAGER_LIST:
-         return "deferred_database_manager_list";
-      case MENU_ENUM_LABEL_CURSOR_MANAGER_LIST:
-         return "cursor_manager_list";
-      case MENU_ENUM_LABEL_DEFERRED_CURSOR_MANAGER_LIST:
-         return "deferred_cursor_manager_list";
-      case MENU_ENUM_LABEL_CHEAT_FILE_LOAD:
-         return "cheat_file_load";
-      case MENU_ENUM_LABEL_CHEAT_FILE_SAVE_AS:
-         return "cheat_file_save_as";
-      case MENU_ENUM_LABEL_DEFERRED_RDB_ENTRY_DETAIL:
-         return "deferred_rdb_entry_detail";
-      case MENU_ENUM_LABEL_FRONTEND_COUNTERS:
-         return "frontend_counters";
-      case MENU_ENUM_LABEL_CORE_COUNTERS:
-         return "core_counters";
-      case MENU_ENUM_LABEL_DISK_CYCLE_TRAY_STATUS:
-         return "disk_cycle_tray_status";
-      case MENU_ENUM_LABEL_DISK_IMAGE_APPEND:
-         return "disk_image_append";
-      case MENU_ENUM_LABEL_DEFERRED_CORE_LIST:
-         return "deferred_core_list";
-      case MENU_ENUM_LABEL_DEFERRED_CORE_LIST_SET:
-         return "deferred_core_list_set";
-      case MENU_ENUM_LABEL_INFO_SCREEN:
-         return "info_screen";
-      case MENU_ENUM_LABEL_SETTINGS:
-         return "settings";
-      case MENU_ENUM_LABEL_QUIT_RETROARCH:
-         return "quit_retroarch";
-      case MENU_ENUM_LABEL_SHUTDOWN:
-         return "shutdown";
-      case MENU_ENUM_LABEL_REBOOT:
-         return "reboot";
-      case MENU_ENUM_LABEL_HELP:
-         return "help";
-      case MENU_ENUM_LABEL_SAVE_NEW_CONFIG:
-         return "save_new_config";
-      case MENU_ENUM_LABEL_RESTART_CONTENT:
-         return "restart_content";
-      case MENU_ENUM_LABEL_TAKE_SCREENSHOT:
-         return "take_screenshot";
-      case MENU_ENUM_LABEL_DELETE_ENTRY:
-         return "delete_entry";
-      case MENU_ENUM_LABEL_CORE_UPDATER_LIST:
-         return "core_updater_list";
-      case MENU_ENUM_LABEL_START_VIDEO_PROCESSOR:
-         return "menu_start_video_processor";
-      case MENU_ENUM_LABEL_START_NET_RETROPAD:
-         return "menu_start_net_retropad";
-      case MENU_ENUM_LABEL_THUMBNAILS_UPDATER_LIST:
-         return "thumbnails_updater_list";
-      case MENU_ENUM_LABEL_CORE_UPDATER_BUILDBOT_URL:
-         return "core_updater_buildbot_url";
-      case MENU_ENUM_LABEL_BUILDBOT_ASSETS_URL:
-         return "buildbot_assets_url";
-      case MENU_ENUM_LABEL_NAVIGATION_WRAPAROUND:
-         return "menu_navigation_wraparound_enable";
-      case MENU_ENUM_LABEL_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
-         return "menu_navigation_browser_filter_supported_extensions_enable";
-      case MENU_ENUM_LABEL_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
-         return "core_updater_auto_extract_archive";
-      case MENU_ENUM_LABEL_ACHIEVEMENT_LIST:
-         return "achievement_list";
-      case MENU_ENUM_LABEL_SYSTEM_INFORMATION:
-         return "system_information";
-      case MENU_ENUM_LABEL_NETWORK_INFORMATION:
-         return "network_information";
-      case MENU_ENUM_LABEL_ONLINE_UPDATER:
-         return "online_updater";
-      case MENU_ENUM_LABEL_NETPLAY:
-         return "netplay";
-      case MENU_ENUM_LABEL_CORE_INFORMATION:
-         return "core_information";
-      case MENU_ENUM_LABEL_CORE_LIST:
-         return "load_core";
-      case MENU_ENUM_LABEL_LOAD_CONTENT:
-         return "load_content_default";
-      case MENU_ENUM_LABEL_CLOSE_CONTENT:
-         return "unload_core";
-      case MENU_ENUM_LABEL_MANAGEMENT:
-         return "database_settings";
-      case MENU_ENUM_LABEL_SAVE_STATE:
-         return "savestate";
-      case MENU_ENUM_LABEL_LOAD_STATE:
-         return "loadstate";
-      case MENU_ENUM_LABEL_UNDO_LOAD_STATE:
-         return "undoloadstate";
-      case MENU_ENUM_LABEL_UNDO_SAVE_STATE:
-         return "undosavestate";
-      case MENU_ENUM_LABEL_RESUME_CONTENT:
-         return "resume_content";
-      case MENU_ENUM_LABEL_INPUT_DRIVER:
-         return "input_driver";
-      case MENU_ENUM_LABEL_AUDIO_DRIVER:
-         return "audio_driver";
-      case MENU_ENUM_LABEL_JOYPAD_DRIVER:
-         return "input_joypad_driver";
-      case MENU_ENUM_LABEL_AUDIO_RESAMPLER_DRIVER:
-         return "audio_resampler_driver";
-      case MENU_ENUM_LABEL_RECORD_DRIVER:
-         return "record_driver";
-      case MENU_ENUM_LABEL_MENU_DRIVER:
-         return "menu_driver";
-      case MENU_ENUM_LABEL_CAMERA_DRIVER:
-         return "camera_driver";
-      case MENU_ENUM_LABEL_WIFI_DRIVER:
-         return "wifi_driver";
-      case MENU_ENUM_LABEL_LOCATION_DRIVER:
-         return "location_driver";
-      case MENU_ENUM_LABEL_OVERLAY_SCALE:
-         return "input_overlay_scale";
-      case MENU_ENUM_LABEL_OVERLAY_PRESET:
-         return "input_overlay";
-      case MENU_ENUM_LABEL_KEYBOARD_OVERLAY_PRESET:
-         return "input_osk_overlay";
-      case MENU_ENUM_LABEL_AUDIO_DEVICE:
-         return "audio_device";
-      case MENU_ENUM_LABEL_AUDIO_LATENCY:
-         return "audio_latency";
-      case MENU_ENUM_LABEL_OVERLAY_OPACITY:
-         return "input_overlay_opacity";
-      case MENU_ENUM_LABEL_MENU_WALLPAPER:
-         return "menu_wallpaper";
-      case MENU_ENUM_LABEL_DYNAMIC_WALLPAPER:
-         return "menu_dynamic_wallpaper_enable";
-      case MENU_ENUM_LABEL_THUMBNAILS:
-         return "thumbnails";
-      case MENU_ENUM_LABEL_CORE_INPUT_REMAPPING_OPTIONS:
-         return "core_input_remapping_options";
-      case MENU_ENUM_LABEL_SHADER_OPTIONS:
-         return "shader_options";
       case MENU_ENUM_LABEL_VIDEO_SHADER_PARAMETERS:
          return "video_shader_parameters";
+      case MENU_ENUM_LABEL_VIDEO_SHADER_PASS:
+         return "video_shader_pass";
+      case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET:
+         return "video_shader_preset";
       case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_PARAMETERS:
          return "video_shader_preset_parameters";
       case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_SAVE_AS:
          return "video_shader_preset_save_as";
-      case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET:
-         return "video_shader_preset";
-      case MENU_ENUM_LABEL_VIDEO_FILTER:
-         return "video_filter";
-      case MENU_ENUM_LABEL_DEFERRED_VIDEO_FILTER:
-         return "deferred_video_filter";
-      case MENU_ENUM_LABEL_DEFERRED_CORE_UPDATER_LIST:
-         return "core_updater";
-      case MENU_ENUM_LABEL_DEFERRED_THUMBNAILS_UPDATER_LIST:
-         return "deferred_thumbnails_updater_list";
-      case MENU_ENUM_LABEL_AUDIO_DSP_PLUGIN:
-         return "audio_dsp_plugin";
-      case MENU_ENUM_LABEL_UPDATE_ASSETS:
-         return "update_assets";
-      case MENU_ENUM_LABEL_UPDATE_LAKKA:
-         return "update_lakka";
-      case MENU_ENUM_LABEL_UPDATE_CHEATS:
-         return "update_cheats";
-      case MENU_ENUM_LABEL_UPDATE_AUTOCONFIG_PROFILES:
-         return "update_autoconfig_profiles";
-      case MENU_ENUM_LABEL_UPDATE_DATABASES:
-         return "update_databases";
-      case MENU_ENUM_LABEL_UPDATE_OVERLAYS:
-         return "update_overlays";
-      case MENU_ENUM_LABEL_UPDATE_CG_SHADERS:
-         return "update_cg_shaders";
-      case MENU_ENUM_LABEL_UPDATE_GLSL_SHADERS:
-         return "update_glsl_shaders";
-      case MENU_ENUM_LABEL_UPDATE_SLANG_SHADERS:
-         return "update_slang_shaders";
-      case MENU_ENUM_LABEL_SCREEN_RESOLUTION:
-         return "screen_resolution";
-      case MENU_ENUM_LABEL_USE_BUILTIN_IMAGE_VIEWER:
-         return "use_builtin_image_viewer";
-      case MENU_ENUM_LABEL_INPUT_POLL_TYPE_BEHAVIOR:
-         return "input_poll_type_behavior";
-      case MENU_ENUM_LABEL_MENU_WALLPAPER_OPACITY:
-         return "menu_wallpaper_opacity";
+      case MENU_ENUM_LABEL_VIDEO_SHADER_SCALE_PASS:
+         return "video_shader_scale_pass";
+      case MENU_ENUM_LABEL_VIDEO_SHARED_CONTEXT:
+         return "video_shared_context";
+      case MENU_ENUM_LABEL_VIDEO_SMOOTH:
+         return "video_smooth";
+      case MENU_ENUM_LABEL_VIDEO_SOFT_FILTER:
+         return "soft_filter";
+      case MENU_ENUM_LABEL_VIDEO_SWAP_INTERVAL:
+         return "video_swap_interval";
+      case MENU_ENUM_LABEL_VIDEO_TAB:
+         return "video_tab";
+      case MENU_ENUM_LABEL_VIDEO_THREADED:
+         return "video_threaded";
+      case MENU_ENUM_LABEL_VIDEO_VFILTER:
+         return "video_vfilter";
+      case MENU_ENUM_LABEL_VIDEO_VIEWPORT_CUSTOM_HEIGHT:
+         return "video_viewport_custom_height";
+      case MENU_ENUM_LABEL_VIDEO_VIEWPORT_CUSTOM_WIDTH:
+         return "video_viewport_custom_width";
+      case MENU_ENUM_LABEL_VIDEO_VIEWPORT_CUSTOM_X:
+         return "video_viewport_custom_x";
+      case MENU_ENUM_LABEL_VIDEO_VIEWPORT_CUSTOM_Y:
+         return "video_viewport_custom_y";
+      case MENU_ENUM_LABEL_VIDEO_VI_WIDTH:
+         return "video_vi_width";
+      case MENU_ENUM_LABEL_VIDEO_VSYNC:
+         return "video_vsync";
+      case MENU_ENUM_LABEL_VIDEO_WINDOWED_FULLSCREEN:
+         return "video_windowed_fullscreen";
+      case MENU_ENUM_LABEL_WIFI_DRIVER:
+         return "wifi_driver";
+      case MENU_ENUM_LABEL_WIFI_SETTINGS:
+         return "wifi_settings";
+      case MENU_ENUM_LABEL_XMB_ALPHA_FACTOR:
+         return "xmb_alpha_factor";
+      case MENU_ENUM_LABEL_XMB_FONT:
+         return "xmb_font";
+      case MENU_ENUM_LABEL_XMB_MENU_COLOR_THEME:
+         return "xmb_menu_color_theme";
+      case MENU_ENUM_LABEL_XMB_RIBBON_ENABLE:
+         return "xmb_ribbon_enable";
+      case MENU_ENUM_LABEL_XMB_SCALE_FACTOR:
+         return "xmb_scale_factor";
+      case MENU_ENUM_LABEL_XMB_SHADOWS_ENABLE:
+         return "xmb_shadows_enable";
+      case MENU_ENUM_LABEL_XMB_SHOW_HISTORY:
+         return "xmb_show_history";
+      case MENU_ENUM_LABEL_XMB_SHOW_IMAGES:
+         return "xmb_show_images";
+      case MENU_ENUM_LABEL_XMB_SHOW_MUSIC:
+         return "xmb_show_music";
+      case MENU_ENUM_LABEL_XMB_SHOW_SETTINGS:
+         return "xmb_show_settings";
+      case MENU_ENUM_LABEL_XMB_SHOW_VIDEO:
+         return "xmb_show_video";
+      case MENU_ENUM_LABEL_XMB_THEME:
+         return "xmb_theme";
+      case MENU_ENUM_SUBLABEL_MENU_SETTINGS:
+         return "メニューの外観関係の設定を変更する。";
+      case MENU_ENUM_SUBLABEL_VIDEO_HARD_SYNC:
+         return "CPUとGPUを強制に同期する。遅延が減るけどパフォーマンスも減る。";
+      case MENU_ENUM_SUBLABEL_VIDEO_THREADED:
+         return "パフォーマンスを改良するけど、ビデオの遅延と途切れが増す。フルスピードを取得しない時だけで使用する。";
+      case MSG_AUDIO_VOLUME:
+         return "Audio volume";
+      case MSG_AUTODETECT:
+         return "Autodetect";
+      case MSG_AUTOLOADING_SAVESTATE_FROM:
+         return "Auto-loading savestate from";
+      case MSG_BRINGING_UP_COMMAND_INTERFACE_ON_PORT:
+         return "bringing_up_command_interface_at_port";
+      case MSG_CONNECTING_TO_NETPLAY_HOST:
+         return "Connecting to netplay host";
+      case MSG_CONNECTING_TO_PORT:
+         return "Connecting to port";
+      case MSG_CONNECTION_SLOT:
+         return "Connection slot";
+      case MSG_CONNECT_DEVICE_FROM_A_VALID_PORT:
+         return "connect_device_from_a_valid_port";
+      case MSG_DEVICE_CONFIGURED_IN_PORT:
+         return "configured in port";
+      case MSG_DEVICE_DISCONNECTED_FROM_PORT:
+        return "Device disconnected from port";
+      case MSG_DEVICE_NOT_CONFIGURED:
+         return "not configured";
+      case MSG_DISCONNECTING_DEVICE_FROM_PORT:
+         return "disconnecting_device_from_port";
+      case MSG_DISCONNECT_DEVICE_FROM_A_VALID_PORT:
+         return "disconnect_device_from_a_valid_port";
+      case MSG_FAILED:
+         return "failed";
+      case MSG_FAILED_TO_SET_DISK:
+         return "Failed to set disk";
+      case MSG_FAILED_TO_START_AUDIO_DRIVER:
+         return "failed_to_start_audio_driver";
+      case MSG_FILE_ALREADY_EXISTS_SAVING_TO_BACKUP_BUFFER:
+         return "File already exists. Saving to backup buffer";
+      case MSG_FOUND_LAST_STATE_SLOT:
+         return "found_last_state_slot";
+      case MSG_GOT_CONNECTION_FROM:
+         return "Got connection from";
+      case MSG_NETPLAY_USERS_HAS_FLIPPED:
+         return "Netplay users has flipped";
+      case MSG_SETTING_DISK_IN_TRAY:
+         return "Setting disk in tray";
+      case MSG_SUCCEEDED:
+         return "succeeded";
+      case MSG_UNKNOWN_NETPLAY_COMMAND_RECEIVED:
+         return "Unknown netplay command received";
+      case MSG_WAITING_FOR_CLIENT:
+         return "Waiting for client ...";
       default:
          break;
    }
@@ -3031,1790 +3031,1790 @@ const char *msg_hash_to_str_jp(enum msg_hash_enums msg)
 
    switch (msg)
    {
-      case MENU_ENUM_SUBLABEL_CONFIG_SAVE_ON_EXIT:
-         return "終了時に設定を自動的に保存する。";
-      case MENU_ENUM_SUBLABEL_VIDEO_HARD_SYNC_FRAMES:
-         return "CPUが「強制GPU同期」を使用時にGPUからの最高のフレーム前進を選択する。";
-      case MENU_ENUM_SUBLABEL_VIDEO_REFRESH_RATE_AUTO:
-         return "モニターの正確な推定のモニターリフレッシュレート";
-      case MENU_ENUM_SUBLABEL_VIDEO_MONITOR_INDEX:
-         return "希望するモニターを選択する。";
-      case MENU_ENUM_SUBLABEL_LOG_VERBOSITY:
-         return "端末にログすることを有効と無効。";
-      case MENU_ENUM_SUBLABEL_SHOW_HIDDEN_FILES:
-         return "ファイルブラウザーの中に隠しファイルとフォルダを表示する。";
-      case MENU_ENUM_SUBLABEL_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
-         return "メニューに切り替えるゲームパッドのボタンコンボ";
-      case MENU_ENUM_SUBLABEL_CPU_CORES:
-         return "CPUのコア数";
-      case MENU_ENUM_SUBLABEL_VIDEO_BLACK_FRAME_INSERTION:
-         return "フレームの間で黒フレームを挿入する。60Hzコンテンツを120Hzモニターでやることを役に立つ。";
-      case MENU_ENUM_SUBLABEL_VIDEO_FRAME_DELAY:
-         return "遅延が減るけどビデオ途切れの危険率が増す。";
-      case MENU_ENUM_SUBLABEL_ADD_CONTENT_LIST:
-         return "コンテンツをスキャンしてデータベースに入れる。";
-      case MENU_ENUM_SUBLABEL_NETPLAY:
-         return "ネットプレイのセッションを参加やホストする。";
-      case MENU_ENUM_SUBLABEL_FPS_SHOW:
-         return "画面で現在のフレームレートを表示する。";
-      case MENU_ENUM_SUBLABEL_VIDEO_SETTINGS:
-         return "ビデオ出力の設定を変える。";
-      case MENU_ENUM_SUBLABEL_AUDIO_SETTINGS:
-         return "オーディオ出力の設定を変更する。";
-      case MENU_ENUM_SUBLABEL_INPUT_SETTINGS:
-         return "ゲームパッド、キーボード、マウスの設定を変更する。";
-      case MENU_ENUM_SUBLABEL_WIFI_SETTINGS:
-         return "無線ネットワークを検索して接続する。";
-      case MENU_ENUM_SUBLABEL_SERVICES_SETTINGS:
-         return "OS関係のサービスを管理する。";
-      case MENU_ENUM_SUBLABEL_SSH_ENABLE:
-         return "SSHでのアクセスを有効する。";
-      case MENU_ENUM_SUBLABEL_SAMBA_ENABLE:
-         return "フォルダのネットワーク共有を有効する。";
-      case MENU_ENUM_SUBLABEL_BLUETOOTH_ENABLE:
-         return "Bluetoothを有効する。";
-      case MENU_ENUM_SUBLABEL_USER_LANGUAGE:
-         return "インタフェースの言語を変更する。";
-      case MENU_ENUM_SUBLABEL_SUSPEND_SCREENSAVER_ENABLE:
-         return "システムのスクリーンセーバーをアクティブになることを予防する。";
-      case MENU_ENUM_SUBLABEL_VIDEO_MAX_SWAPCHAIN_IMAGES:
-         return "指定するバッファーモードをビデオドライバに伝える。";
-      case MENU_ENUM_SUBLABEL_ONLINE_UPDATER:
-         return "RetroArchにアドオン、コンポーネント、コンテンツをダウンロードする。";
-      case MENU_ENUM_SUBLABEL_INPUT_USER_BINDS:
-         return "このユーザーの入力設定を変更する。";
-      case MENU_ENUM_SUBLABEL_INPUT_HOTKEY_BINDS:
-         return "ホットキー設定を変更する。";
-      case MSG_VALUE_SHUTTING_DOWN:
-         return "シャットダウンしています。。。";
-      case MSG_VALUE_REBOOTING:
-         return "再起動しています。。。";
-      case MSG_FAILED_TO_START_AUDIO_DRIVER:
-         return "Failed to start audio driver. Will continue without audio.";
-      case MSG_FOUND_LAST_STATE_SLOT:
-         return "Found last state slot";
-      case MSG_VALUE_CONNECT_DEVICE_FROM_A_VALID_PORT:
-         return "Connect device from a valid port.";
-      case MSG_DISCONNECT_DEVICE_FROM_A_VALID_PORT:
-         return "Disconnect device from a valid port.";
-      case MSG_VALUE_DISCONNECTING_DEVICE_FROM_PORT:
-         return "Disconnecting device from port";
-      case MSG_BRINGING_UP_COMMAND_INTERFACE_ON_PORT:
-         return "Bringing up command interface on port";
-      case MSG_LOADING_HISTORY_FILE:
-         return "Loading history file";
-      case MENU_ENUM_LABEL_VALUE_SHADER_PIPELINE_RIBBON_SIMPLIFIED:
-         return "リボン (単純)";
-      case MENU_ENUM_LABEL_VALUE_SHADER_PIPELINE_RIBBON:
-         return "リボン";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_FOOTER_OPACITY:
-         return "Footer Opacity";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_HEADER_OPACITY:
-         return "Header Opacity";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_BLUE:
-         return "青";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_BLUE_GREY:
-         return "ブルーグレイ";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_RED:
-         return "赤";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_YELLOW:
-         return "黄色";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_NVIDIA_SHIELD:
-         return "SHIELD";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_GREEN:
-         return "緑";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_DARK_BLUE:
-         return "ダークブルー";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_PLAIN:
-         return "プレーン";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_LEGACY_RED:
-         return "レガシーレッド";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_DARK_PURPLE:
-         return "ぶどう色";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_MIDNIGHT_BLUE:
-         return "ミッドナイトブルー";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_GOLDEN:
-         return "ゴールデン";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_ELECTRIC_BLUE:
-         return "電子ブルー";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_APPLE_GREEN:
-         return "りんご緑";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_UNDERSEA:
-         return "海底";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_VOLCANIC_RED:
-         return "火山レッド";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_DARK:
-         return "ダーク";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_UNLOCKED_ENTRY:
-         return "アンロックされている";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_LOCKED_ENTRY:
-         return "ロックされている";
-      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR_LATE:
-         return "遅い";
-      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR_NORMAL:
-         return "普通";
-      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR_EARLY:
-         return "早い";
-      case MSG_INTERNAL_MEMORY:
-         return "内部メモリ";
-      case MSG_EXTERNAL_APPLICATION_DIR:
-         return "外部アプリフォルダ";
-      case MSG_APPLICATION_DIR:
-         return "アプリフォルダ";
-      case MSG_PROGRAM:
-         return "RetroArch";
-      case MSG_LIBRETRO_FRONTEND:
-         return "libretroのフロントエンド";
-      case MSG_LOADING:
-         return "ロード中";
-      case MSG_GAME_SPECIFIC_CORE_OPTIONS_FOUND_AT:
-         return "Per-Game Options: game-specific core options found at";
-      case MSG_RESTORING_DEFAULT_SHADER_PRESET_TO:
-         return "Shaders: restoring default shader preset to";
-      case  MSG_SORRY_UNIMPLEMENTED_CORES_DONT_DEMAND_CONTENT_NETPLAY:
-         return "Sorry, unimplemented: cores that don't demand content cannot participate in netplay.";
-      case MSG_FOUND_AUTO_SAVESTATE_IN:
-         return "Found auto savestate in";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_REMOTE_PORT:
-         return "Network Remote Base Port";
-      case MSG_OVERRIDES_SAVED_SUCCESSFULLY:
-         return "Overrides saved successfully.";
-      case MSG_AUTOCONFIG_FILE_SAVED_SUCCESSFULLY:
-         return "Autoconfig file saved successfully.";
-      case MSG_OVERRIDES_ERROR_SAVING:
-         return "Error saving overrides.";
-      case MSG_AUTOCONFIG_FILE_ERROR_SAVING:
-         return "Error saving autoconf file.";
-      case MSG_DOWNLOAD_FAILED:
-         return "Download failed";
-      case MSG_INPUT_CHEAT:
-         return "Input Cheat";
-      case MSG_DECOMPRESSION_ALREADY_IN_PROGRESS:
-         return "Decompression already in progress.";
-      case MSG_DECOMPRESSION_FAILED:
-         return "Decompression failed.";
-      case MSG_CORE_OPTIONS_FILE_CREATED_SUCCESSFULLY:
-         return "Core options file created successfully.";
-      case MSG_FAILED_TO_CREATE_THE_DIRECTORY:
-         return "Failed to create the directory.";
-      case MSG_FAILED_TO_EXTRACT_CONTENT_FROM_COMPRESSED_FILE:
-         return "Failed to extract content from compressed file";
-      case MSG_FILE_NOT_FOUND:
-         return "File not found";
-      case MSG_ERROR_SAVING_CORE_OPTIONS_FILE:
-         return "Error saving core options file.";
-      case MSG_FAILED_TO_ALLOCATE_MEMORY_FOR_PATCHED_CONTENT:
-         return "Failed to allocate memory for patched content...";
-      case MSG_DID_NOT_FIND_A_VALID_CONTENT_PATCH:
-         return "Did not find a valid content patch.";
-      case MSG_SEVERAL_PATCHES_ARE_EXPLICITLY_DEFINED:
-         return "Several patches are explicitly defined, ignoring all...";
-      case MSG_REMAP_FILE_SAVED_SUCCESSFULLY:
-         return "Remap file saved successfully.";
-      case MSG_SHADER_PRESET_SAVED_SUCCESSFULLY:
-         return "Shader preset saved successfully.";
-      case MSG_ERROR_SAVING_REMAP_FILE:
-         return "Error saving remap file.";
-      case MSG_ERROR_SAVING_SHADER_PRESET:
-         return "Error saving shader preset.";
-      case MSG_INPUT_CHEAT_FILENAME:
-         return "Cheat Filename";
-      case MSG_INPUT_PRESET_FILENAME:
-         return "Preset Filename";
-      case MSG_DISK_EJECTED:
-         return "Ejected";
-      case MSG_DISK_CLOSED:
-         return "Closed";
-      case MSG_VERSION_OF_LIBRETRO_API:
-         return "Version of libretro API";
-      case MSG_COMPILED_AGAINST_API:
-         return "Compiled against API";
-      case MSG_FAILED_TO_LOAD:
-         return "Failed to load";
-      case MSG_CONNECTED_TO:
-         return "Connected to";
-      case MSG_FAILED_TO_ACCEPT_INCOMING_SPECTATOR:
-         return "Failed to accept incoming spectator.";
-      case MSG_FAILED_TO_GET_NICKNAME_FROM_CLIENT:
-         return "Failed to get nickname from client.";
-      case MSG_FAILED_TO_SEND_NICKNAME_TO_CLIENT:
-         return "Failed to send nickname to client.";
-      case MSG_USING_CORE_NAME_FOR_NEW_CONFIG:
-         return "Using core name for new config.";
-      case MSG_CANNOT_INFER_NEW_CONFIG_PATH:
-         return "Cannot infer new config path. Use current time.";
-      case MSG_NO_STATE_HAS_BEEN_LOADED_YET:
-         return "No state has been loaded yet.";
-      case MSG_NO_SAVE_STATE_HAS_BEEN_OVERWRITTEN_YET:
-         return "No save state has been overwritten yet.";
-      case MSG_RESTORED_OLD_SAVE_STATE:
-         return "Restored old save state.";
-      case MSG_SAVED_NEW_CONFIG_TO:
-         return "Saved new config to";
-      case MSG_FAILED_SAVING_CONFIG_TO:
-         return "Failed saving config to";
-      case MSG_FAILED_TO_RECEIVE_NICKNAME_SIZE_FROM_HOST:
-         return "Failed to receive nickname size from host.";
-      case MSG_FAILED_TO_RECEIVE_NICKNAME:
-         return "Failed to receive nickname.";
-      case MSG_FAILED_TO_RECEIVE_NICKNAME_FROM_HOST:
-         return "Failed to receive nickname from host.";
-      case MSG_FAILED_TO_SEND_NICKNAME_SIZE:
-         return "Failed to send nickname size.";
-      case MSG_FAILED_TO_SEND_SRAM_DATA_TO_CLIENT:
-         return "Failed to send SRAM data to client.";
-      case MSG_FAILED_TO_RECEIVE_HEADER_FROM_CLIENT:
-         return "Failed to receive header from client.";
-      case MSG_FAILED_TO_RECEIVE_SRAM_DATA_FROM_HOST:
-         return "Failed to receive SRAM data from host.";
-      case MSG_CONTENT_CRC32S_DIFFER:
-         return "Content CRC32s differ. Cannot use different games.";
-      case MSG_FAILED_TO_SEND_NICKNAME:
-         return "Failed to send nickname.";
-      case MSG_FAILED_TO_SEND_NICKNAME_TO_HOST:
-         return "Failed to send nickname to host.";
-      case MSG_INVALID_NICKNAME_SIZE:
-         return "Invalid nickname size.";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ANALOG:
-         return "Analog supported";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_SERIAL:
-         return "Serial";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_COOP:
-         return "Co-op supported";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ENHANCEMENT_HW:
-         return "Enhancement Hardware";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ELSPA_RATING:
-         return "ELSPA Rating";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RUMBLE:
-         return "Rumble supported";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_PEGI_RATING:
-         return "PEGI Rating";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_EDGE_MAGAZINE_ISSUE:
-         return "Edge Magazine Issue";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_BBFC_RATING:
-         return "BBFC Rating";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ESRB_RATING:
-         return "ESRB Rating";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_CERO_RATING:
-         return "CERO Rating";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MAX_SWAPCHAIN_IMAGES:
-         return "最高のスワップチェーンイメージ";
-      case MSG_ERROR_LIBRETRO_CORE_REQUIRES_CONTENT:
-         return "Libretro core requires content, but nothing was provided.";
-      case MSG_CONTENT_LOADING_SKIPPED_IMPLEMENTATION_WILL_DO_IT:
-         return "Content loading skipped. Implementation will load it on its own.";
-      case MSG_ERROR_LIBRETRO_CORE_REQUIRES_SPECIAL_CONTENT:
-         return "Libretro core requires special content, but none were provided.";
-      case MSG_REVERTING_SAVEFILE_DIRECTORY_TO:
-         return "Reverting savefile directory to";
-      case MSG_REVERTING_SAVESTATE_DIRECTORY_TO:
-         return "Reverting savestate directory to";
-      case MSG_COULD_NOT_READ_MOVIE_HEADER:
-         return "Could not read movie header.";
-      case MSG_FAILED_TO_OPEN_LIBRETRO_CORE:
-         return "Failed to open libretro core";
-      case MSG_COULD_NOT_FIND_ANY_NEXT_DRIVER:
-         return "Could not find any next driver";
-      case MSG_MOVIE_FORMAT_DIFFERENT_SERIALIZER_VERSION:
-         return "Movie format seems to have a different serializer version. Will most likely fail.";
-      case MSG_CRC32_CHECKSUM_MISMATCH:
-         return "CRC32 checksum mismatch between content file and saved content checksum in replay file header; replay highly likely to desync on playback.";
-      case MSG_INFLATED_CHECKSUM_DID_NOT_MATCH_CRC32:
-         return "Inflated checksum did not match CRC32.";
-      case MSG_ERROR_PARSING_ARGUMENTS:
-         return "Error parsing arguments.";
-      case MSG_ERROR:
-         return "Error";
-      case MSG_FOUND_DISK_LABEL:
-         return "Found disk label";
-      case MSG_READING_FIRST_DATA_TRACK:
-         return "Reading first data track...";
-      case MSG_FOUND_FIRST_DATA_TRACK_ON_FILE:
-         return "Found first data track on file";
-      case MSG_COULD_NOT_FIND_VALID_DATA_TRACK:
-         return "Could not find valid data track";
-      case MSG_COMPARING_WITH_KNOWN_MAGIC_NUMBERS:
-         return "Comparing with known magic numbers...";
-      case MSG_COULD_NOT_FIND_COMPATIBLE_SYSTEM:
-         return "Could not find compatible system.";
-      case MSG_COULD_NOT_OPEN_DATA_TRACK:
-         return "could not open data track";
-      case MSG_MEMORY:
-         return "メモリ";
-      case MSG_FRAMES:
-         return "フレーム";
-      case MSG_IN_BYTES:
-         return "(バイトで)";
-      case MSG_IN_MEGABYTES:
-         return "(メガバイトで)";
-      case MSG_IN_GIGABYTES:
-         return "(ギガバイトで)";
-      case MSG_INTERFACE:
-         return "インターフェース";
-      case MSG_FAILED_TO_PATCH:
-         return "パッチに失敗しました";
-      case MSG_FATAL_ERROR_RECEIVED_IN:
-         return "Fatal error received in";
-      case MSG_MOVIE_RECORD_STOPPED:
-         return "Stopping movie record.";
-      case MSG_MOVIE_PLAYBACK_ENDED:
-         return "Movie playback ended.";
-      case MSG_AUTOSAVE_FAILED:
-         return "Could not initialize autosave.";
-      case MSG_NETPLAY_FAILED_MOVIE_PLAYBACK_HAS_STARTED:
-         return "Movie playback has started. Cannot start netplay.";
-      case MSG_NETPLAY_FAILED:
-         return "Failed to initialize netplay.";
-      case MSG_LIBRETRO_ABI_BREAK:
-         return "is compiled against a different version of libretro than this libretro implementation.";
-      case MSG_REWIND_INIT_FAILED_THREADED_AUDIO:
-         return "Implementation uses threaded audio. Cannot use rewind.";
-      case MSG_REWIND_INIT_FAILED:
-         return "Failed to initialize rewind buffer. Rewinding will be disabled.";
-      case MSG_REWIND_INIT:
-         return "Initializing rewind buffer with size";
-      case MSG_CUSTOM_TIMING_GIVEN:
-         return "Custom timing given";
-      case MSG_VIEWPORT_SIZE_CALCULATION_FAILED:
-         return "Viewport size calculation failed! Will continue using raw data. This will probably not work right ...";
-      case MSG_HW_RENDERED_MUST_USE_POSTSHADED_RECORDING:
-         return "Libretro core is hardware rendered. Must use post-shaded recording as well.";
-      case MSG_RECORDING_TO:
-         return "Recording to";
-      case MSG_DETECTED_VIEWPORT_OF:
-         return "Detected viewport of";
-      case MSG_TAKING_SCREENSHOT:
-         return "Taking screenshot.";
-      case MSG_FAILED_TO_TAKE_SCREENSHOT:
-         return "Failed to take screenshot.";
-      case MSG_FAILED_TO_START_RECORDING:
-         return "Failed to start recording.";
-      case MSG_RECORDING_TERMINATED_DUE_TO_RESIZE:
-         return "Recording terminated due to resize.";
-      case MSG_USING_LIBRETRO_DUMMY_CORE_RECORDING_SKIPPED:
-         return "Using libretro dummy core. Skipping recording.";
-      case MSG_UNKNOWN:
-         return "Unknown";
-      case MSG_COULD_NOT_READ_STATE_FROM_MOVIE:
-         return "Could not read state from movie.";
-      case MSG_MOVIE_FILE_IS_NOT_A_VALID_BSV1_FILE:
-         return "Movie file is not a valid BSV1 file.";
-      case MSG_LOADING_CONTENT_FILE:
-         return "Loading content file";
-      case MSG_RECEIVED:
-         return "received";
-      case MSG_UNRECOGNIZED_COMMAND:
-         return "Unrecognized command";
-      case MSG_SENDING_COMMAND:
-         return "Sending command";
-      case MSG_GOT_INVALID_DISK_INDEX:
-         return "Got invalid disk index.";
-      case MSG_FAILED_TO_REMOVE_DISK_FROM_TRAY:
-         return "Failed to remove disk from tray.";
-      case MSG_REMOVED_DISK_FROM_TRAY:
-         return "Removed disk from tray.";
-      case MSG_VIRTUAL_DISK_TRAY:
-         return "virtual disk tray.";
-      case MSG_FAILED_TO:
-         return "Failed to";
-      case MSG_TO:
-         return "to";
-      case MSG_SAVING_RAM_TYPE:
-         return "Saving RAM type";
-      case MSG_UNDOING_SAVE_STATE:
-         return "Undoing save state";
-      case MSG_SAVING_STATE:
-         return "Saving state";
-      case MSG_LOADING_STATE:
-         return "Loading state";
-      case MSG_FAILED_TO_LOAD_MOVIE_FILE:
-         return "Failed to load movie file";
-      case MSG_FAILED_TO_LOAD_CONTENT:
-         return "Failed to load content";
-      case MSG_COULD_NOT_READ_CONTENT_FILE:
-         return "Could not read content file";
-      case MSG_GRAB_MOUSE_STATE:
-         return "Grab mouse state";
-      case MSG_PAUSED:
-         return "Paused.";
-      case MSG_UNPAUSED:
-         return "Unpaused.";
-      case MSG_FAILED_TO_LOAD_OVERLAY:
-         return "Failed to load overlay.";
-      case MSG_FAILED_TO_UNMUTE_AUDIO:
-         return "Failed to unmute audio.";
-      case MSG_AUDIO_MUTED:
-         return "Audio muted.";
-      case MSG_AUDIO_UNMUTED:
-         return "Audio unmuted.";
-      case MSG_RESET:
-         return "Reset";
-      case MSG_AUTO_SAVE_STATE_TO:
-         return "Auto save state to";
-      case MSG_FAILED_TO_LOAD_STATE:
-         return "Failed to load state from";
-      case MSG_FAILED_TO_SAVE_STATE_TO:
-         return "Failed to save state to";
-      case MSG_FAILED_TO_UNDO_LOAD_STATE:
-         return "Failed to undo load state.";
-      case MSG_FAILED_TO_UNDO_SAVE_STATE:
-         return "Failed to undo save state.";
-      case MSG_FAILED_TO_SAVE_SRAM:
-         return "Failed to save SRAM";
-      case MSG_STATE_SIZE:
-         return "State size";
-      case MSG_FOUND_SHADER:
-         return "Found shader";
-      case MSG_SRAM_WILL_NOT_BE_SAVED:
-         return "SRAM will not be saved.";
-      case MSG_BLOCKING_SRAM_OVERWRITE:
-         return "Blocking SRAM Overwrite";
-      case MSG_CORE_DOES_NOT_SUPPORT_SAVESTATES:
-         return "Core does not support save states.";
-      case MSG_SAVED_STATE_TO_SLOT:
-         return "Saved state to slot";
-      case MSG_SAVED_SUCCESSFULLY_TO:
-         return "Saved successfully to";
-      case MSG_BYTES:
-         return "bytes";
-      case MSG_CONFIG_DIRECTORY_NOT_SET:
-         return "Config directory not set. Cannot save new config.";
-      case MSG_SKIPPING_SRAM_LOAD:
-         return "Skipping SRAM load.";
-      case MSG_APPENDED_DISK:
-         return "Appended disk";
-      case MSG_STARTING_MOVIE_PLAYBACK:
-         return "Starting movie playback.";
-      case MSG_FAILED_TO_REMOVE_TEMPORARY_FILE:
-         return "Failed to remove temporary file";
-      case MSG_REMOVING_TEMPORARY_CONTENT_FILE:
-         return "Removing temporary content file";
-      case MSG_LOADED_STATE_FROM_SLOT:
-         return "Loaded state from slot";
-      case MSG_SCANNING_OF_DIRECTORY_FINISHED:
-         return "Scanning of directory finished";
-      case MSG_SCANNING:
-         return "スキャン中";
-      case MSG_REDIRECTING_CHEATFILE_TO:
-         return "Redirecting cheat file to";
-      case MSG_REDIRECTING_SAVEFILE_TO:
-         return "Redirecting save file to";
-      case MSG_REDIRECTING_SAVESTATE_TO:
-         return "Redirecting savestate to";
-      case MSG_APPLYING_CHEAT:
-         return "Applying cheat changes.";
-      case MSG_SHADER:
-         return "シェーダー";
-      case MSG_APPLYING_SHADER:
-         return "Applying shader";
-      case MSG_FAILED_TO_APPLY_SHADER:
-         return "Failed to apply shader.";
-      case MSG_STARTING_MOVIE_RECORD_TO:
-         return "Starting movie record to";
-      case MSG_FAILED_TO_START_MOVIE_RECORD:
-         return "Failed to start movie record.";
-      case MSG_STATE_SLOT:
-         return "保存状態のスロット";
-      case MSG_RESTARTING_RECORDING_DUE_TO_DRIVER_REINIT:
-         return "Restarting recording due to driver reinit.";
-      case MSG_SLOW_MOTION:
-         return "スローモーション。";
-      case MSG_SLOW_MOTION_REWIND:
-         return "スローモーション巻き戻し。";
-      case MSG_REWINDING:
-         return "巻き戻しています。";
-      case MSG_REWIND_REACHED_END:
-         return "Reached end of rewind buffer.";
-      case MSG_CHEEVOS_HARDCORE_MODE_ENABLE:
-         return "Hardcore Mode Enabled: savestate & rewind were disabled.";
-      case MSG_DOWNLOADING:
-         return "ダウンロード中";
-      case MSG_EXTRACTING:
-         return "解凍中";
-      case MSG_EXTRACTING_FILE:
-         return "ファイルを解凍中";
-      case MSG_NO_CONTENT_STARTING_DUMMY_CORE:
-         return "No content, starting dummy core.";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_EDGE_MAGAZINE_RATING:
-         return "Edge Magazine Rating";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_EDGE_MAGAZINE_REVIEW:
-         return "Edge Magazine Review";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_FAMITSU_MAGAZINE_RATING:
-         return "Famitsu Magazine Rating";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_TGDB_RATING:
-         return "TGDB Rating";
-      case MENU_ENUM_LABEL_VALUE_CPU_ARCHITECTURE:
-         return "CPUアーキテクチャ:";
-      case MENU_ENUM_LABEL_VALUE_CPU_CORES:
-         return "CPUコア数:";
-      case MENU_ENUM_LABEL_VALUE_INTERNAL_STORAGE_STATUS:
-         return "Internal storage status";
-      case MENU_ENUM_LABEL_VALUE_PARENT_DIRECTORY:
-         return "親ディレクトリー";
-      case MENU_ENUM_LABEL_VALUE_MORE:
-         return "...";
-      case MENU_ENUM_LABEL_VALUE_RUN:
-         return "実行";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_X:
-         return "カスタムのビューポートのX";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_Y:
-         return "カスタムのビューポートのY";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_WIDTH:
-         return "カスタムのビューポートの横幅";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_HEIGHT:
-         return "カスタムのビューポートの縦幅";
-      case MENU_ENUM_LABEL_VALUE_NO_ENTRIES_TO_DISPLAY:
-         return "No entries to display.";
-      case MENU_ENUM_LABEL_VALUE_NO_ACHIEVEMENTS_TO_DISPLAY:
-         return "No achievements to display.";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_UNLOCKED_ACHIEVEMENTS:
-         return "Unlocked Achievements:";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_LOCKED_ACHIEVEMENTS:
-         return "Locked Achievements:";
-      case MENU_ENUM_LABEL_VALUE_START_VIDEO_PROCESSOR:
-         return "ビデオプロセッサをスタート";
-      case MENU_ENUM_LABEL_VALUE_START_NET_RETROPAD:
-         return "リモートレトロパッドをスタート";
-      case MENU_ENUM_LABEL_VALUE_THUMBNAILS_UPDATER_LIST:
-         return "サムネイルのアップデーター";
-      case MENU_ENUM_LABEL_VALUE_MENU_LINEAR_FILTER:
-         return "メニューのリニアフィルター";
-      case MENU_ENUM_LABEL_VALUE_MENU_ENUM_THROTTLE_FRAMERATE:
-         return "メニューのフレームレートを減速";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_HARDCORE_MODE_ENABLE:
-         return "ハードコアモード";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_TEST_UNOFFICIAL:
-         return "非公式をテスト";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_SETTINGS:
-         return "レトロ";
-      case MENU_ENUM_LABEL_VALUE_INPUT_TOUCH_ENABLE:
-         return "タッチを有効";
-      case MENU_ENUM_LABEL_VALUE_INPUT_PREFER_FRONT_TOUCH:
-         return "Prefer Front Touch";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ICADE_ENABLE:
-         return "Keyboard Gamepad Mapping Enable";
-      case MENU_ENUM_LABEL_VALUE_INPUT_KEYBOARD_GAMEPAD_MAPPING_TYPE:
-         return "Keyboard Gamepad Mapping Type";
-      case MENU_ENUM_LABEL_VALUE_INPUT_SMALL_KEYBOARD_ENABLE:
-         return "Small Keyboard Enable";
-      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG_OVERRIDE_CORE:
-         return "コアの優先を保存";
-      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG_OVERRIDE_GAME:
-         return "ゲームの優先を保存";
-      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG:
-         return "現在の設定を保存";
-      case MENU_ENUM_LABEL_VALUE_STATE_SLOT:
-         return "保存状態のスロット";
+      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_PASSWORD:
+         return "パスワード";
       case MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_SETTINGS:
          return "Accounts Cheevos";
       case MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_USERNAME:
          return "ユーザー名";
-      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_PASSWORD:
-         return "パスワード";
-      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_RETRO_ACHIEVEMENTS:
-         return "Retro Achievements";
-      case MENU_ENUM_LABEL_VALUE_RETRO_ACHIEVEMENTS_SETTINGS:
-         return "Retro Achievements";
       case MENU_ENUM_LABEL_VALUE_ACCOUNTS_LIST:
          return "アカウント";
       case MENU_ENUM_LABEL_VALUE_ACCOUNTS_LIST_END:
          return "Accounts List Endpoint";
-      case MENU_ENUM_LABEL_VALUE_HELP_SCANNING_CONTENT:
-         return "Scanning For Content";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_DESCRIPTION:
-         return "Description";
-      case MENU_ENUM_LABEL_VALUE_HELP_AUDIO_VIDEO_TROUBLESHOOTING:
-         return "Audio/Video Troubleshooting";
-      case MENU_ENUM_LABEL_VALUE_HELP_CHANGE_VIRTUAL_GAMEPAD:
-         return "Changing Virtual Gamepad Overlay";
-      case MENU_ENUM_LABEL_VALUE_HELP_WHAT_IS_A_CORE:
-         return "What Is A Core?";
-      case MENU_ENUM_LABEL_VALUE_HELP_LOADING_CONTENT:
-         return "Loading Content";
-      case MENU_ENUM_LABEL_VALUE_HELP_LIST:
-         return "ヘルプ";
-      case MENU_ENUM_LABEL_VALUE_HELP_CONTROLS:
-         return "Basic Menu Controls";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS:
-         return "Basic menu controls";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_SCROLL_UP:
-         return "Scroll Up";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_CONFIRM:
-         return "確認/了承";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_BACK:
-         return "前";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_START:
-         return "デフォルト";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_INFO:
-         return "情報";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_TOGGLE_MENU:
-         return "メニューに切り替え";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_QUIT:
-         return "終了";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_TOGGLE_KEYBOARD:
-         return "キーボードに切り替え";
-      case MENU_ENUM_LABEL_VALUE_OPEN_ARCHIVE:
-         return "フォルダでアーカイブを開く";
-      case MENU_ENUM_LABEL_VALUE_LOAD_ARCHIVE:
-         return "コアでアーカイブをロード";
-      case MENU_ENUM_LABEL_VALUE_INPUT_BACK_AS_MENU_ENUM_TOGGLE_ENABLE:
-         return "Back As Menu Toggle Enable";
-      case MENU_ENUM_LABEL_VALUE_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
-         return "ゲームパッドのメニュー切り替えコンボ";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ALL_USERS_CONTROL_MENU:
-         return "すべてのユーザーがメニューを操作できる";
-      case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_HIDE_IN_MENU:
-         return "メニューにオーバーレイを隠す";
-      case MENU_ENUM_LABEL_VALUE_LANG_POLISH:
-         return "ポーランド語";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_AUTOLOAD_PREFERRED:
-         return "優先オーバーレイを自動ロード";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_CORE_INFO_FILES:
-         return "コアの情報ファイルをアップデート";
-      case MENU_ENUM_LABEL_VALUE_DOWNLOAD_CORE_CONTENT:
-         return "コンテンツをダウンロード";
-      case MENU_ENUM_LABEL_VALUE_DOWNLOAD_CORE:
-         return "コアをダウンロード...";
-      case MENU_ENUM_LABEL_VALUE_SCAN_THIS_DIRECTORY:
-         return "<このフォルダをスキャン>";
-      case MENU_ENUM_LABEL_VALUE_SCAN_FILE:
-         return "ファイルをスキャン";
-      case MENU_ENUM_LABEL_VALUE_SCAN_DIRECTORY:
-         return "フォルダをスキャン";
+      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_RETRO_ACHIEVEMENTS:
+         return "Retro Achievements";
+      case MENU_ENUM_LABEL_VALUE_ACHIEVEMENT_LIST:
+         return "Achievement List";
       case MENU_ENUM_LABEL_VALUE_ADD_CONTENT_LIST:
          return "コンテンツをスキャン";
-      case MENU_ENUM_LABEL_VALUE_INFORMATION:
-         return "情報";
-      case MENU_ENUM_LABEL_VALUE_INFORMATION_LIST:
-         return "情報";
-      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_PLAYER:
-         return "Use Builtin Media Player";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_SETTINGS:
-         return "クイックメニュー";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_CRC32:
-         return "CRC32";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_MD5:
-         return "MD5";
-      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_LIST:
-         return "コンテンツをロード";
-      case MENU_ENUM_LABEL_VALUE_ASK_ARCHIVE:
-         return "Ask";
-      case MENU_ENUM_LABEL_VALUE_PRIVACY_SETTINGS:
-         return "プライバシー";
-      case MENU_ENUM_LABEL_VALUE_MUSIC_TAB:
-         return "音楽";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_TAB:
-         return "ビデオ";
-      case MENU_ENUM_LABEL_VALUE_IMAGES_TAB:
-         return "画像";
-      case MENU_ENUM_LABEL_VALUE_HORIZONTAL_MENU:
-         return "Horizontal Menu";
-      case MENU_ENUM_LABEL_VALUE_SETTINGS_TAB:
-         return "設定";
-      case MENU_ENUM_LABEL_VALUE_HISTORY_TAB:
-         return "履歴";
       case MENU_ENUM_LABEL_VALUE_ADD_TAB:
          return "コンテンツをインポート";
-      case MENU_ENUM_LABEL_VALUE_PLAYLISTS_TAB:
-         return "プレイリスト";
-      case MENU_ENUM_LABEL_VALUE_NO_SETTINGS_FOUND:
-         return "設定が見つかりませんでした。";
-      case MENU_ENUM_LABEL_VALUE_NO_PERFORMANCE_COUNTERS:
-         return "No performance counters.";
-      case MENU_ENUM_LABEL_VALUE_DRIVER_SETTINGS:
-         return "ドライバ";
-      case MENU_ENUM_LABEL_VALUE_CONFIGURATION_SETTINGS:
-         return "設定";
-      case MENU_ENUM_LABEL_VALUE_CORE_SETTINGS:
-         return "コア";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SETTINGS:
-         return "ビデオ";
-      case MENU_ENUM_LABEL_VALUE_LOGGING_SETTINGS:
-         return "ログ";
-      case MENU_ENUM_LABEL_VALUE_SAVING_SETTINGS:
-         return "保存";
-      case MENU_ENUM_LABEL_VALUE_REWIND_SETTINGS:
-         return "巻き戻し";
-      case MENU_ENUM_LABEL_VALUE_SHADER:
-         return "シェーダー";
-      case MENU_ENUM_LABEL_VALUE_CHEAT:
-         return "チート";
-      case MENU_ENUM_LABEL_VALUE_USER:
-         return "ユーザー";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_BGM_ENABLE:
-         return "System BGM Enable";
-      case MENU_ENUM_LABEL_VALUE_RETROPAD:
-         return "レトロパッド";
-      case MENU_ENUM_LABEL_VALUE_RETROKEYBOARD:
-         return "RetroKeyboard";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_BLOCK_FRAMES:
-         return "Block Frames";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_LABEL_SHOW:
-         return "入力の識別子ラベルを表示";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_HIDE_UNBOUND:
-         return "未定義のコア入力の識別子を隠す";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_ENABLE:
-         return "OSDメッセージを表示";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_PATH:
-         return "OSDメッセージのフォント";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_SIZE:
-         return "OSDメッセージのサイズ";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_X:
-         return "OSDメッセージのX位置";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_Y:
-         return "OSDメッセージのY位置";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SOFT_FILTER:
-         return "Soft Filter Enable";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_FLICKER:
-         return "Flicker filter";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_CONTENT:
-         return "<Content dir>";
-      case MENU_ENUM_LABEL_VALUE_UNKNOWN:
-         return "Unknown";
-      case MENU_ENUM_LABEL_VALUE_DONT_CARE:
-         return "Don't care";
-      case MENU_ENUM_LABEL_VALUE_LINEAR:
-         return "Linear";
-      case MENU_ENUM_LABEL_VALUE_NEAREST:
-         return "Nearest";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_DEFAULT:
-         return "<Default>";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NONE:
-         return "<None>";
-      case MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE:
-         return "N/A";
-      case MENU_ENUM_LABEL_VALUE_DATABASE_SELECTION:
-         return "Database Selection";
-      case MENU_ENUM_LABEL_VALUE_CORE_ASSETS_DIR:
-         return "コアの資産ディレクトリー";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_DIR:
-         return "コンテンツのディレクトリー";
-      case MENU_ENUM_LABEL_VALUE_INPUT_REMAPPING_DIRECTORY:
-         return "入力リマップのディレクトリー";
-      case MENU_ENUM_LABEL_VALUE_JOYPAD_AUTOCONFIG_DIR:
-         return "入力デバイスの自動設定ディレクトリー";
-      case MENU_ENUM_LABEL_VALUE_RECORDING_CONFIG_DIRECTORY:
-         return "録画設定のディレクトリー";
-      case MENU_ENUM_LABEL_VALUE_RECORDING_OUTPUT_DIRECTORY:
-         return "録画の出力ディレクトリー";
-      case MENU_ENUM_LABEL_VALUE_SCREENSHOT_DIRECTORY:
-         return "スクリーンショットのディレクトリー";
-      case MENU_ENUM_LABEL_VALUE_PLAYLIST_DIRECTORY:
-         return "プレイリストのディレクトリー";
-      case MENU_ENUM_LABEL_VALUE_SAVEFILE_DIRECTORY:
-         return "セーブファイルのディレクトリー";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_DIRECTORY:
-         return "保存状態のディレクトリー";
-      case MENU_ENUM_LABEL_VALUE_STDIN_CMD_ENABLE:
-         return "stdinコマンド";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_REMOTE_ENABLE:
-         return "ネットワークゲームパッド";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_DRIVER:
-         return "ビデオのドライバ";
-      case MENU_ENUM_LABEL_VALUE_RECORD_ENABLE:
-         return "録画を有効";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_RECORD:
-         return "GPUの録画を有効";
-      case MENU_ENUM_LABEL_VALUE_RECORD_PATH:
-         return "出力ファイル";
-      case MENU_ENUM_LABEL_VALUE_RECORD_USE_OUTPUT_DIRECTORY:
-         return "出力ディレクトリーを使用";
-      case MENU_ENUM_LABEL_VALUE_RECORD_CONFIG:
-         return "録画設定ファイル";
-      case MENU_ENUM_LABEL_VALUE_CONFIG:
-         return "Config";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_POST_FILTER_RECORD:
-         return "事後フィルターの録画を有効";
-      case MENU_ENUM_LABEL_VALUE_CORE_ASSETS_DIRECTORY:
-         return "ダウンロードのディレクトリー";
-      case MENU_ENUM_LABEL_VALUE_ASSETS_DIRECTORY:
-         return "資産のディレクトリー";
-      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPERS_DIRECTORY:
-         return "ダイナミック壁紙のディレクトリー";
-      case MENU_ENUM_LABEL_VALUE_THUMBNAILS_DIRECTORY:
-         return "サムネイルのディレクトリー";
-      case MENU_ENUM_LABEL_VALUE_RGUI_BROWSER_DIRECTORY:
-         return "ファイルブラウザーのディレクトリー";
-      case MENU_ENUM_LABEL_VALUE_RGUI_CONFIG_DIRECTORY:
-         return "設定のディレクトリー";
-      case MENU_ENUM_LABEL_VALUE_LIBRETRO_INFO_PATH:
-         return "コア情報のディレクトリー";
-      case MENU_ENUM_LABEL_VALUE_LIBRETRO_DIR_PATH:
-         return "コアのディレクトリー";
-      case MENU_ENUM_LABEL_VALUE_CURSOR_DIRECTORY:
-         return "カーソルのディレクトリー";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_DATABASE_DIRECTORY:
-         return "コンテンツデータベースのディレクトリー";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_DIRECTORY:
-         return "システム/BIOSのディレクトリー";
-      case MENU_ENUM_LABEL_VALUE_CHEAT_DATABASE_PATH:
-         return "チートファイルのディレクトリー";
-      case MENU_ENUM_LABEL_VALUE_CACHE_DIRECTORY:
-         return "キャッシュのディレクトリー";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_FILTER_DIR:
-         return "オーディオフィルターのディレクトリー";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_DIR:
-         return "ビデオシェーダーのディレクトリー";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_DIR:
-         return "ビデオフィルターのディレクトリー";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_DIRECTORY:
-         return "オーバーレイのディレクトリー";
-      case MENU_ENUM_LABEL_VALUE_OSK_OVERLAY_DIRECTORY:
-         return "OSKオーバーレイのディレクトリー";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT:
-         return "ネットプレイのP2がC1を使用";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE:
-         return "ネットプレイの観覧者を有効";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS:
-         return "サーバーのアドレス";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT:
-         return "ネットプレイのTCP/UDPポート";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE:
-         return "ネットプレイを有効";
-      case MENU_ENUM_LABEL_VALUE_SSH_ENABLE:
-         return "SSHを有効";
-      case MENU_ENUM_LABEL_VALUE_SAMBA_ENABLE:
-         return "SAMBAを有効";
-      case MENU_ENUM_LABEL_VALUE_BLUETOOTH_ENABLE:
-         return "Bluetoothを有効";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_DELAY_FRAMES:
-         return "ネットプレイの延期フレーム";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_CHECK_FRAMES:
-         return "ネットプレイのチェックフレーム";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_MODE:
-         return "ネットプレイのクライアントを有効";
-      case MENU_ENUM_LABEL_VALUE_RGUI_SHOW_START_SCREEN:
-         return "スタート画面を表示";
-      case MENU_ENUM_LABEL_VALUE_TITLE_COLOR:
-         return "Menu title color";
-      case MENU_ENUM_LABEL_VALUE_ENTRY_HOVER_COLOR:
-         return "Menu entry hover color";
-      case MENU_ENUM_LABEL_VALUE_TIMEDATE_ENABLE:
-         return "日付と時刻を表示";
-      case MENU_ENUM_LABEL_VALUE_THREADED_DATA_RUNLOOP_ENABLE:
-         return "データループをスレッド化";
-      case MENU_ENUM_LABEL_VALUE_ENTRY_NORMAL_COLOR:
-         return "Menu entry normal color";
-      case MENU_ENUM_LABEL_VALUE_SHOW_ADVANCED_SETTINGS:
-         return "詳細設定を表示";
-      case MENU_ENUM_LABEL_VALUE_MOUSE_ENABLE:
-         return "マウス対応";
-      case MENU_ENUM_LABEL_VALUE_POINTER_ENABLE:
-         return "タッチ対応";
-      case MENU_ENUM_LABEL_VALUE_CORE_ENABLE:
-         return "コアの名前を表示";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE_HOST:
-         return "ホストする";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE_CLIENT:
-         return "ネットプレイサーバーに接続";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_DISCONNECT:
-         return "切断";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_SETTINGS:
-         return "ネットプレイ設定";
-      case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_ENABLE:
-         return "DPI Override Enable";
-      case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_VALUE:
-         return "DPI Override";
-      case MENU_ENUM_LABEL_VALUE_XMB_SCALE_FACTOR:
-         return "メニューの倍率";
-      case MENU_ENUM_LABEL_VALUE_XMB_ALPHA_FACTOR:
-         return "メニューの透明性";
-      case MENU_ENUM_LABEL_VALUE_XMB_FONT:
-         return "メニューのフォント";
-      case MENU_ENUM_LABEL_VALUE_XMB_THEME:
-         return "メニューのアイコンテーマ";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME:
-         return "メニューの色テーマ";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME:
-         return "メニューの色テーマ";
-      case MENU_ENUM_LABEL_VALUE_XMB_SHADOWS_ENABLE:
-         return "アイコンの影を有効";
-      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_SETTINGS:
-         return "設定タブを表示";
-      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_IMAGES:
-         return "画像タブを表示";
-      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_MUSIC:
-         return "音楽タブを表示";
-      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_VIDEO:
-         return "ビデオタブを表示";
-      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_HISTORY:
-         return "履歴タブを表示";
-      case MENU_ENUM_LABEL_VALUE_XMB_RIBBON_ENABLE:
-         return "メニューのシェーダーパイプライン";
-      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_MONOCHROME:
-         return "モノクローム";
-      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_MONOCHROME_JAGGED:
-         return "モノクロームぎざぎざ";
-      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_FLATUI:
-         return "フラットUI";
-      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_RETROACTIVE:
-         return "レトロアクティブ";
-      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_PIXEL:
-         return "ピクセル";
-      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_CUSTOM:
-         return "カスタム";
-      case MENU_ENUM_LABEL_VALUE_SUSPEND_SCREENSAVER_ENABLE:
-         return "スクリーンセーバーをサスペンド";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_DISABLE_COMPOSITION:
-         return "デスクトップのコンポジットを無効";
-      case MENU_ENUM_LABEL_VALUE_PAUSE_NONACTIVE:
-         return "バックグラウンドで実行しない";
-      case MENU_ENUM_LABEL_VALUE_UI_COMPANION_START_ON_BOOT:
-         return "UI Companion Start On Boot";
-      case MENU_ENUM_LABEL_VALUE_UI_COMPANION_ENABLE:
-         return "UI Companion Enable";
-      case MENU_ENUM_LABEL_VALUE_UI_MENUBAR_ENABLE:
-         return "メニューバー";
       case MENU_ENUM_LABEL_VALUE_ARCHIVE_MODE:
          return "Archive File Association Action";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_ENABLE:
-         return "ネットワークコマンドを有効";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_PORT:
-         return "ネットワークコマンドのポート";
-      case MENU_ENUM_LABEL_VALUE_HISTORY_LIST_ENABLE:
-         return "履歴リストを有効";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_HISTORY_SIZE:
-         return "履歴リストのサイズ";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE_AUTO:
-         return "モニタの予想フレームレート";
-      case MENU_ENUM_LABEL_VALUE_DUMMY_ON_CORE_SHUTDOWN:
-         return "コアをシャットダウンでダミー";
-      case MENU_ENUM_LABEL_VALUE_CORE_SET_SUPPORTS_NO_CONTENT_ENABLE:
-         return "自動的にコアをスタート";
-      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_ENABLE:
-         return "フレームの減速度";
-      case MENU_ENUM_LABEL_VALUE_FASTFORWARD_RATIO:
-         return "早送り比";
+      case MENU_ENUM_LABEL_VALUE_ASK_ARCHIVE:
+         return "Ask";
+      case MENU_ENUM_LABEL_VALUE_ASSETS_DIRECTORY:
+         return "資産のディレクトリー";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_BLOCK_FRAMES:
+         return "Block Frames";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_DEVICE:
+         return "オーディオのデバイス";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_DRIVER:
+         return "オーディオのドライバ";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_DSP_PLUGIN:
+         return "オーディオのDSPプラグイン";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_ENABLE:
+         return "オーディオを有効";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_FILTER_DIR:
+         return "オーディオフィルターのディレクトリー";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_LATENCY:
+         return "オーディオの遅延 (ms)";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_MAX_TIMING_SKEW:
+         return "オーディオの最高タイミングスキュー";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_MUTE:
+         return "オーディオの消音";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_OUTPUT_RATE:
+         return "オーディオの出力レート(KHz)";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_RATE_CONTROL_DELTA:
+         return "オーディオのレートコントロールデルタ";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_RESAMPLER_DRIVER:
+         return "オーディをリサンプルのドライバ";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_SETTINGS:
+         return "オーディオ";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_SYNC:
+         return "オーディオの同期を有効";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_VOLUME:
+         return "オーディオの音量 (dB)";
+      case MENU_ENUM_LABEL_VALUE_AUTOSAVE_INTERVAL:
+         return "セーブRAMの自動保存期間";
+      case MENU_ENUM_LABEL_VALUE_AUTO_OVERRIDES_ENABLE:
+         return "オーバーライドファイルを自動的にロード";
       case MENU_ENUM_LABEL_VALUE_AUTO_REMAPS_ENABLE:
          return "リマップファイルを自動的にロード";
       case MENU_ENUM_LABEL_VALUE_AUTO_SHADERS_ENABLE:
          return "Load Shader Presets Automatically";
-      case MENU_ENUM_LABEL_VALUE_SLOWMOTION_RATIO:
-         return "スローモーション比";
-      case MENU_ENUM_LABEL_VALUE_CORE_SPECIFIC_CONFIG:
-         return "コア特定の設定";
-      case MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS:
-         return "コンテンツ特定のコア設定を自動的にロード";
-      case MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS_CREATE:
-         return "Create game-options file";
-      case MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS_IN_USE:
-         return "Game-options file";
-      case MENU_ENUM_LABEL_VALUE_AUTO_OVERRIDES_ENABLE:
-         return "オーバーライドファイルを自動的にロード";
-      case MENU_ENUM_LABEL_VALUE_CONFIG_SAVE_ON_EXIT:
-         return "終了前に設定を自動保存";
-      case MENU_ENUM_LABEL_VALUE_CONFIRM_ON_EXIT:
-         return "終了前に確認";
-      case MENU_ENUM_LABEL_VALUE_SHOW_HIDDEN_FILES:
-         return "隠しファイルとフォルダを表示";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SMOOTH:
-         return "ハードウェアのバイリニアフィルター";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_GAMMA:
-         return "ビデオのガンマ";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ALLOW_ROTATE:
-         return "回転を許す";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC:
-         return "強制GPU同期";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SWAP_INTERVAL:
-         return "VSYNCのスワップ期間";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VSYNC:
-         return "VSYNC";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_THREADED:
-         return "スレッドされているビデオ";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ROTATION:
-         return "回転";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_SCREENSHOT:
-         return "GPUスクリーンショットを有効";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_CROP_OVERSCAN:
-         return "オーバースキャンをクロップ (再起動が必要)";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_INDEX:
-         return "アスペクト比のインデックス";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_AUTO:
-         return "自動アスペクト比";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_ASPECT:
-         return "アスペクト比を強制";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE:
-         return "リフレッシュレート";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_SRGB_DISABLE:
-         return "sRGB FBOを強制無効";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_WINDOWED_FULLSCREEN:
-         return "ウィンドウのフルスクリーンモード";
-      case MENU_ENUM_LABEL_VALUE_PAL60_ENABLE:
-         return "Use PAL60 Mode";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VFILTER:
-         return "Deflicker";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VI_WIDTH:
-         return "Set VI Screen Width";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_BLACK_FRAME_INSERTION:
-         return "黒いフレームを挿入";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC_FRAMES:
-         return "強制GPU同期フレーム";
-      case MENU_ENUM_LABEL_VALUE_SORT_SAVEFILES_ENABLE:
-         return "フォルダでセーブを並び替え";
-      case MENU_ENUM_LABEL_VALUE_SORT_SAVESTATES_ENABLE:
-         return "フォルダで保存状態を並び替え";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FULLSCREEN:
-         return "フルスクリーンモード";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE:
-         return "ウィンドウのスケール";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE_INTEGER:
-         return "整数スケール";
-      case MENU_ENUM_LABEL_VALUE_PERFCNT_ENABLE:
-         return "パフォーマンスカウンター";
-      case MENU_ENUM_LABEL_VALUE_LIBRETRO_LOG_LEVEL:
-         return "コアのログ出力レベル";
-      case MENU_ENUM_LABEL_VALUE_LOG_VERBOSITY:
-         return "ログの出力レベル";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_LOAD:
-         return "自動的に保存状態をロード";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_INDEX:
-         return "保存状態の自動インデックス";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_SAVE:
-         return "自動的に状態を保存";
-      case MENU_ENUM_LABEL_VALUE_AUTOSAVE_INTERVAL:
-         return "セーブRAMの自動保存期間";
+      case MENU_ENUM_LABEL_VALUE_BACK:
+         return "戻る";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_BACK:
+         return "戻る";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_CONFIRM:
+         return "確認";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_INFO:
+         return "情報";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_QUIT:
+         return "終了";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_SCROLL_DOWN:
+         return "下にスクロール";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_SCROLL_UP:
+         return "上にスクロール";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_START:
+         return "スタート";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_TOGGLE_KEYBOARD:
+         return "キーボードに切り替え";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_TOGGLE_MENU:
+         return "メニューに切り替え";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS:
+         return "Basic menu controls";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_BACK:
+         return "前";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_CONFIRM:
+         return "確認/了承";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_INFO:
+         return "情報";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_QUIT:
+         return "終了";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_SCROLL_UP:
+         return "Scroll Up";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_START:
+         return "デフォルト";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_TOGGLE_KEYBOARD:
+         return "キーボードに切り替え";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_TOGGLE_MENU:
+         return "メニューに切り替え";
       case MENU_ENUM_LABEL_VALUE_BLOCK_SRAM_OVERWRITE:
          return "保存状態をロード時にセーブRAMを置き換えない";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHARED_CONTEXT:
-         return "ハードウェアの共有コンテキストを有効";
-      case MENU_ENUM_LABEL_VALUE_RESTART_RETROARCH:
-         return "RetroArchを再起動";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_NICKNAME:
-         return "ユーザー名";
-      case MENU_ENUM_LABEL_VALUE_USER_LANGUAGE:
-         return "言語";
+      case MENU_ENUM_LABEL_VALUE_BLUETOOTH_ENABLE:
+         return "Bluetoothを有効";
+      case MENU_ENUM_LABEL_VALUE_BUILDBOT_ASSETS_URL:
+         return "Buildbotの資産URL";
+      case MENU_ENUM_LABEL_VALUE_CACHE_DIRECTORY:
+         return "キャッシュのディレクトリー";
       case MENU_ENUM_LABEL_VALUE_CAMERA_ALLOW:
          return "カメラを許す";
-      case MENU_ENUM_LABEL_VALUE_LOCATION_ALLOW:
-         return "ロケーションを許す";
-      case MENU_ENUM_LABEL_VALUE_PAUSE_LIBRETRO:
-         return "メニューが表示時に一時停止";
-      case MENU_ENUM_LABEL_VALUE_INPUT_OSK_OVERLAY_ENABLE:
-         return "キーボードオーバーレイを表示";
-      case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_ENABLE:
-         return "ディスプレイのオーバーレイ";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MONITOR_INDEX:
-         return "モニタのインデックス";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FRAME_DELAY:
-         return "フレームの遅れ";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DUTY_CYCLE:
-         return "デューティー比";
-      case MENU_ENUM_LABEL_VALUE_INPUT_TURBO_PERIOD:
-         return "ターボの期間";
-      case MENU_ENUM_LABEL_VALUE_INPUT_BIND_TIMEOUT:
-         return "バインドのタイムアウト";
-      case MENU_ENUM_LABEL_VALUE_INPUT_AXIS_THRESHOLD:
-         return "入力軸のしきい値";
-      case MENU_ENUM_LABEL_VALUE_INPUT_REMAP_BINDS_ENABLE:
-         return "リマップバインドを有効";
-      case MENU_ENUM_LABEL_VALUE_INPUT_MAX_USERS:
-         return "最高のユーザー数";
-      case MENU_ENUM_LABEL_VALUE_INPUT_AUTODETECT_ENABLE:
-         return "自動コンフィグを有効";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_OUTPUT_RATE:
-         return "オーディオの出力レート(KHz)";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_MAX_TIMING_SKEW:
-         return "オーディオの最高タイミングスキュー";
-      case MENU_ENUM_LABEL_VALUE_CHEAT_NUM_PASSES:
-         return "チートのパス";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_CORE:
-         return "コアリマップファイルを保存";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_GAME:
-         return "ゲームリマップファイルを保存";
+      case MENU_ENUM_LABEL_VALUE_CAMERA_DRIVER:
+         return "カメラのドライバ";
+      case MENU_ENUM_LABEL_VALUE_CHEAT:
+         return "チート";
       case MENU_ENUM_LABEL_VALUE_CHEAT_APPLY_CHANGES:
          return "チートの変更点を適用";
-      case MENU_ENUM_LABEL_VALUE_SHADER_APPLY_CHANGES:
-         return "シェーダーの変更点を適用";
-      case MENU_ENUM_LABEL_VALUE_REWIND_ENABLE:
-         return "巻き戻しを有効";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_COLLECTION_LIST:
-         return "コレクション";
-      case MENU_ENUM_LABEL_VALUE_DETECT_CORE_LIST:
-         return "ファイルを選択とコア検出";
-      case MENU_ENUM_LABEL_VALUE_DOWNLOADED_FILE_DETECT_CORE_LIST:
-         return "ダウンロードのディレクトリー";
-      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_HISTORY:
-         return "最近のものをロード";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_ENABLE:
-         return "オーディオを有効";
-      case MENU_ENUM_LABEL_VALUE_FPS_SHOW:
-         return "フレームレートを表示";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_MUTE:
-         return "オーディオの消音";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_VOLUME:
-         return "オーディオの音量 (dB)";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_SYNC:
-         return "オーディオの同期を有効";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_RATE_CONTROL_DELTA:
-         return "オーディオのレートコントロールデルタ";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_NUM_PASSES:
-         return "シェーダーのパス数";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_SHA1:
-         return "SHA1";
-      case MENU_ENUM_LABEL_VALUE_CONFIGURATIONS:
-         return "設定をロード";
-      case MENU_ENUM_LABEL_VALUE_REWIND_GRANULARITY:
-         return "巻き戻しの粒状度";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_LOAD:
-         return "リマップファイルをロード";
-      case MENU_ENUM_LABEL_VALUE_CUSTOM_RATIO:
-         return "カスタム比";
-      case MENU_ENUM_LABEL_VALUE_USE_THIS_DIRECTORY:
-         return "<このフォルダを使用>";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_START_CONTENT:
-         return "コンテンツをスタート";
-      case MENU_ENUM_LABEL_VALUE_DISK_OPTIONS:
-         return "ディスク設定";
-      case MENU_ENUM_LABEL_VALUE_CORE_OPTIONS:
-         return "オプション";
-      case MENU_ENUM_LABEL_VALUE_CORE_CHEAT_OPTIONS:
-         return "チート";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE:
-         return "リマップファイル";
+      case MENU_ENUM_LABEL_VALUE_CHEAT_DATABASE_PATH:
+         return "チートファイルのディレクトリー";
       case MENU_ENUM_LABEL_VALUE_CHEAT_FILE:
          return "チートファイル";
       case MENU_ENUM_LABEL_VALUE_CHEAT_FILE_LOAD:
          return "チートファイルをロード";
       case MENU_ENUM_LABEL_VALUE_CHEAT_FILE_SAVE_AS:
          return "チートファイルを名前を付けて保存";
-      case MENU_ENUM_LABEL_VALUE_CORE_COUNTERS:
-         return "Core Counters";
-      case MENU_ENUM_LABEL_VALUE_TAKE_SCREENSHOT:
-         return "スクリーンショットを撮る";
-      case MENU_ENUM_LABEL_VALUE_DELETE_ENTRY:
-         return "削除";
-      case MENU_ENUM_LABEL_VALUE_RESUME:
-         return "再開";
-      case MENU_ENUM_LABEL_VALUE_DISK_INDEX:
-         return "Disk Index";
-      case MENU_ENUM_LABEL_VALUE_FRONTEND_COUNTERS:
-         return "Frontend Counters";
-      case MENU_ENUM_LABEL_VALUE_DISK_IMAGE_APPEND:
-         return "Disk Image Append";
-      case MENU_ENUM_LABEL_VALUE_DISK_CYCLE_TRAY_STATUS:
-         return "Disk Cycle Tray Status";
-      case MENU_ENUM_LABEL_VALUE_NO_PLAYLIST_ENTRIES_AVAILABLE:
-         return "プレイリストのエントリーはありません。";
-      case MENU_ENUM_LABEL_VALUE_NO_HISTORY_AVAILABLE:
-         return "履歴はありません。";
-      case MENU_ENUM_LABEL_VALUE_NO_CORE_INFORMATION_AVAILABLE:
-         return "コア情報はありません。";
-      case MENU_ENUM_LABEL_VALUE_NO_CORE_OPTIONS_AVAILABLE:
-         return "コア設定はありません。";
-      case MENU_ENUM_LABEL_VALUE_NO_CORES_AVAILABLE:
-         return "コアはありません。";
-      case MENU_ENUM_LABEL_VALUE_NO_CORE:
-         return "コアはありません";
-      case MENU_ENUM_LABEL_VALUE_DATABASE_MANAGER:
-         return "データーベースマネージャー";
-      case MENU_ENUM_LABEL_VALUE_CURSOR_MANAGER:
-         return "カーソルマネージャー";
-      case MENU_ENUM_LABEL_VALUE_MAIN_MENU:
-         return "メインメニュー";
-      case MENU_ENUM_LABEL_VALUE_SETTINGS:
-         return "設定";
-      case MENU_ENUM_LABEL_VALUE_QUIT_RETROARCH:
-         return "終了";
-      case MENU_ENUM_LABEL_VALUE_SHUTDOWN:
-         return "シャットダウン";
-      case MENU_ENUM_LABEL_VALUE_REBOOT:
-         return "再起動";
-      case MENU_ENUM_LABEL_VALUE_HELP:
-         return "ヘルプ";
-      case MENU_ENUM_LABEL_VALUE_SAVE_NEW_CONFIG:
-         return "新しい設定を保存";
-      case MENU_ENUM_LABEL_VALUE_RESTART_CONTENT:
-         return "コンテンツを再起動";
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_LIST:
-         return "コアのアップデーター";
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_BUILDBOT_URL:
-         return "BuildbotのコアURL";
-      case MENU_ENUM_LABEL_VALUE_BUILDBOT_ASSETS_URL:
-         return "Buildbotの資産URL";
-      case MENU_ENUM_LABEL_VALUE_NAVIGATION_WRAPAROUND:
-         return "ナビゲーションの回り込み";
-      case MENU_ENUM_LABEL_VALUE_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
-         return "不明な拡張子を隠す";
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
-         return "ダウンロードしたアーカイブを自動解凍";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFORMATION:
-         return "システム情報";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_INFORMATION:
-         return "ネットワーク情報";
-      case MENU_ENUM_LABEL_VALUE_ACHIEVEMENT_LIST:
-         return "Achievement List";
-      case MENU_ENUM_LABEL_VALUE_ONLINE_UPDATER:
-         return "オンラインアップデーター";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY:
-         return "ネットプレイ";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFORMATION:
-         return "コアの情報";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NOT_FOUND:
-         return "そのようなフォルダはありません。";
-      case MENU_ENUM_LABEL_VALUE_NO_ITEMS:
-         return "アイテムが見つかりません。";
-      case MENU_ENUM_LABEL_VALUE_NO_PLAYLISTS:
-         return "プレイリストが見つかりません。";
-      case MENU_ENUM_LABEL_VALUE_CORE_LIST:
-         return "コアをロード";
-      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT:
-         return "ファイル選択";
+      case MENU_ENUM_LABEL_VALUE_CHEAT_NUM_PASSES:
+         return "チートのパス";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_DESCRIPTION:
+         return "Description";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_HARDCORE_MODE_ENABLE:
+         return "ハードコアモード";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_LOCKED_ACHIEVEMENTS:
+         return "Locked Achievements:";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_LOCKED_ENTRY:
+         return "ロックされている";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_SETTINGS:
+         return "レトロ";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_TEST_UNOFFICIAL:
+         return "非公式をテスト";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_UNLOCKED_ACHIEVEMENTS:
+         return "Unlocked Achievements:";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_UNLOCKED_ENTRY:
+         return "アンロックされている";
       case MENU_ENUM_LABEL_VALUE_CLOSE_CONTENT:
          return "閉じる";
-      case MENU_ENUM_LABEL_VALUE_MANAGEMENT:
-         return "データベースの設定";
-      case MENU_ENUM_LABEL_VALUE_SAVE_STATE:
-         return "状態保存";
-      case MENU_ENUM_LABEL_VALUE_LOAD_STATE:
-         return "保存状態をロード";
-      case MENU_ENUM_LABEL_VALUE_UNDO_LOAD_STATE:
-         return "保存状態のロードを前に戻す";
-      case MENU_ENUM_LABEL_VALUE_UNDO_SAVE_STATE:
-         return "状態の保存を前に戻す";
-      case MSG_UNDID_LOAD_STATE:
-         return "保存状態のロードを前に戻した。";
-      case MENU_ENUM_LABEL_VALUE_RESUME_CONTENT:
-         return "再開";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DRIVER:
-         return "入力のドライバ";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_DRIVER:
-         return "オーディオのドライバ";
-      case MENU_ENUM_LABEL_VALUE_JOYPAD_DRIVER:
-         return "ジョイパッドのドライバ";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_RESAMPLER_DRIVER:
-         return "オーディをリサンプルのドライバ";
-      case MENU_ENUM_LABEL_VALUE_RECORD_DRIVER:
-         return "録画のドライバ";
-      case MENU_ENUM_LABEL_VALUE_MENU_DRIVER:
-         return "メニューのドライバ";
-      case MENU_ENUM_LABEL_VALUE_CAMERA_DRIVER:
-         return "カメラのドライバ";
-      case MENU_ENUM_LABEL_VALUE_WIFI_DRIVER:
-         return "Wi-Fiのドライバ";
-      case MENU_ENUM_LABEL_VALUE_LOCATION_DRIVER:
-         return "ロケーションのドライバ";
-      case MENU_ENUM_LABEL_VALUE_UNABLE_TO_READ_COMPRESSED_FILE:
-         return "圧縮ファイルの読み込みは失敗しました。";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_SCALE:
-         return "オーバーレイのスケール";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_PRESET:
-         return "オーバーレイのプリセット";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_LATENCY:
-         return "オーディオの遅延 (ms)";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_DEVICE:
-         return "オーディオのデバイス";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY:
-         return "オーバーレイ";
-      case MENU_ENUM_LABEL_VALUE_KEYBOARD_OVERLAY_PRESET:
-         return "キーボードのオーバーレイプリセット";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_OPACITY:
-         return "オーバーレイの不透明性";
-      case MENU_ENUM_LABEL_VALUE_MENU_WALLPAPER:
-         return "メニューの壁紙";
-      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPER:
-         return "ダイナミック壁紙";
-      case MENU_ENUM_LABEL_VALUE_THUMBNAILS:
-         return "サムネイル";
-      case MENU_ENUM_LABEL_VALUE_CORE_INPUT_REMAPPING_OPTIONS:
-         return "コントロール";
-      case MENU_ENUM_LABEL_VALUE_SHADER_OPTIONS:
-         return "シェーダー";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PARAMETERS:
-         return "シェーダーのパラメータをプレビュー";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_PARAMETERS:
-         return "メニューのシェーダーパラメータ";
-      case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_TWO:
-         return "シェーダーのプリセット";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_AS:
-         return "シェーダーのプリセットを名前を付けて保存";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_CORE:
-         return "コアのプリセットを保存";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_GAME:
-         return "ゲームのプリセットを保存";
-      case MENU_ENUM_LABEL_VALUE_NO_SHADER_PARAMETERS:
-         return "シェーダーのパラメータはありません。";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET:
-         return "シェーダーのプリセットをロード";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER:
-         return "ビデオのフィルター";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_DSP_PLUGIN:
-         return "オーディオのDSPプラグイン";
-      case MENU_ENUM_LABEL_VALUE_SECONDS:
-         return "秒";
-      case MENU_ENUM_LABEL_VALUE_OFF:
-         return "OFF";
-      case MENU_ENUM_LABEL_VALUE_ON:
-         return "ON";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_ASSETS:
-         return "資産をアップデート";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_LAKKA:
-         return "Lakkaをアップデート";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_CHEATS:
-         return "チーとをアップデート";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_AUTOCONFIG_PROFILES:
-         return "自動コンフィグプロファイルをアップデート";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_DATABASES:
-         return "データベースをアップデート";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_OVERLAYS:
-         return "オーバーレイをアップデート";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_CG_SHADERS:
-         return "Cgシェーダーをアップデート";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_GLSL_SHADERS:
-         return "GLSLシェーダーをアップデート";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_SLANG_SHADERS:
-         return "Slangシェーダーをアップデート";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NAME:
-         return "コアの名前";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_LABEL:
-         return "コアのラベル";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_NAME:
-         return "システム名";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_MANUFACTURER:
-         return "システムのメーカー";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CATEGORIES:
-         return "カテゴリー";
+      case MENU_ENUM_LABEL_VALUE_CONFIG:
+         return "Config";
+      case MENU_ENUM_LABEL_VALUE_CONFIGURATIONS:
+         return "設定をロード";
+      case MENU_ENUM_LABEL_VALUE_CONFIGURATION_SETTINGS:
+         return "設定";
+      case MENU_ENUM_LABEL_VALUE_CONFIG_SAVE_ON_EXIT:
+         return "終了前に設定を自動保存";
+      case MENU_ENUM_LABEL_VALUE_CONFIRM_ON_EXIT:
+         return "終了前に確認";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_COLLECTION_LIST:
+         return "コレクション";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_DATABASE_DIRECTORY:
+         return "コンテンツデータベースのディレクトリー";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_DIR:
+         return "コンテンツのディレクトリー";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_HISTORY_SIZE:
+         return "履歴リストのサイズ";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_SETTINGS:
+         return "クイックメニュー";
+      case MENU_ENUM_LABEL_VALUE_CORE_ASSETS_DIR:
+         return "コアの資産ディレクトリー";
+      case MENU_ENUM_LABEL_VALUE_CORE_ASSETS_DIRECTORY:
+         return "ダウンロードのディレクトリー";
+      case MENU_ENUM_LABEL_VALUE_CORE_CHEAT_OPTIONS:
+         return "チート";
+      case MENU_ENUM_LABEL_VALUE_CORE_COUNTERS:
+         return "Core Counters";
+      case MENU_ENUM_LABEL_VALUE_CORE_ENABLE:
+         return "コアの名前を表示";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFORMATION:
+         return "コアの情報";
       case MENU_ENUM_LABEL_VALUE_CORE_INFO_AUTHORS:
          return "作家";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_PERMISSIONS:
-         return "許可";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_LICENSES:
-         return "ライセンス";
-      case MENU_ENUM_LABEL_VALUE_SUPPORTED_CORES:
-         return "対応するコア";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SUPPORTED_EXTENSIONS:
-         return "対応する拡張子";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_FIRMWARE:
-         return "ファームウェア";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CATEGORIES:
+         return "カテゴリー";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_LABEL:
+         return "コアのラベル";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NAME:
+         return "コアの名前";
       case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NOTES:
          return "コアのメモ";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_BUILD_DATE:
-         return "ビルド日付";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GIT_VERSION:
-         return "Gitバージョン";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CPU_FEATURES:
-         return "CPU機能";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_IDENTIFIER:
-         return "フロントエンド識別名";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_NAME:
-         return "フロントエンド名";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_OS:
-         return "フロントエンドOS";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RETRORATING_LEVEL:
-         return "RetroRating level";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE:
-         return "パワーソース";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_NO_SOURCE:
-         return "ソースはありません";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGING:
-         return "充電中";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGED:
-         return "充電完了";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_DISCHARGING:
-         return "放電";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VIDEO_CONTEXT_DRIVER:
-         return "ビデオのコンテクストドライバ";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_WIDTH:
-         return "ディスプレイの軽量横幅 (mm)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_HEIGHT:
-         return "ディスプレイの軽量縦幅 (mm)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_DPI:
-         return "ディスプレイの軽量DPI";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBRETRODB_SUPPORT:
-         return "LibretroDB対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OVERLAY_SUPPORT:
-         return "オーバーレイ対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COMMAND_IFACE_SUPPORT:
-         return "コマンドインターフェース対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETWORK_REMOTE_SUPPORT:
-         return "ネットワークゲームパッド対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETWORK_COMMAND_IFACE_SUPPORT:
-         return "ネットワークコマンドインターフェース対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COCOA_SUPPORT:
-         return "Cocoa対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RPNG_SUPPORT:
-         return "PNG対応 (RPNG)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RJPEG_SUPPORT:
-         return "JPEG対応 (RJPEG)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RBMP_SUPPORT:
-         return "BMP対応 (RBMP)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RTGA_SUPPORT:
-         return "TGA対応 (RTGA)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_SUPPORT:
-         return "SDL1.2対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL2_SUPPORT:
-         return "SDL2対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VULKAN_SUPPORT:
-         return "Vulkan対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGL_SUPPORT:
-         return "OpenGL対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGLES_SUPPORT:
-         return "OpenGL ES対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_THREADING_SUPPORT:
-         return "スレッド対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_KMS_SUPPORT:
-         return "KMS/EGL対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_UDEV_SUPPORT:
-         return "Udev対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENVG_SUPPORT:
-         return "OpenVG対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_EGL_SUPPORT:
-         return "EGL対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_X11_SUPPORT:
-         return "X11対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_WAYLAND_SUPPORT:
-         return "Wayland対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XVIDEO_SUPPORT:
-         return "XVideo対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ALSA_SUPPORT:
-         return "ALSA対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OSS_SUPPORT:
-         return "OSS対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENAL_SUPPORT:
-         return "OpenAL対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENSL_SUPPORT:
-         return "OpenSL対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RSOUND_SUPPORT:
-         return "RSound対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ROARAUDIO_SUPPORT:
-         return "RoarAudio対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_JACK_SUPPORT:
-         return "JACK対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PULSEAUDIO_SUPPORT:
-         return "PulseAudio対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DSOUND_SUPPORT:
-         return "DirectSound対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XAUDIO2_SUPPORT:
-         return "XAudio2対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ZLIB_SUPPORT:
-         return "Zlib対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_7ZIP_SUPPORT:
-         return "7zip対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DYLIB_SUPPORT:
-         return "ダイナミックライブラリー対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CG_SUPPORT:
-         return "Cg対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GLSL_SUPPORT:
-         return "GLSL対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SLANG_SUPPORT:
-         return "Slang対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_HLSL_SUPPORT:
-         return "HLSL対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBXML2_SUPPORT:
-         return "libxml2 XMLパース対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_IMAGE_SUPPORT:
-         return "SDLイメージ対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FBO_SUPPORT:
-         return "OpenGL/Direct3Dテクスチャーにレンダリング (マルチパスシェーダー)対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DYNAMIC_SUPPORT:
-         return "ダイナミックlibretroライブラリーのランタイム時にロード対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FFMPEG_SUPPORT:
-         return "FFmpeg対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CORETEXT_SUPPORT:
-         return "CoreText対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FREETYPE_SUPPORT:
-         return "FreeType対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETPLAY_SUPPORT:
-         return "ネットプレイ(ピアツーピア)対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PYTHON_SUPPORT:
-         return "Python(シェーダーにスクリプト)対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_V4L2_SUPPORT:
-         return "Video4Linux2対応";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBUSB_SUPPORT:
-         return "Libusb対応";
-      case MENU_ENUM_LABEL_VALUE_YES:
-         return "はい";
-      case MENU_ENUM_LABEL_VALUE_NO:
-         return "いいえ";
-      case MENU_ENUM_LABEL_VALUE_BACK:
-         return "戻る";
-      case MSG_FAILED_TO_BIND_SOCKET:
-         return "Failed to bind socket.";
-      case MENU_ENUM_LABEL_VALUE_SCREEN_RESOLUTION:
-         return "スクリーン解像度";
-      case MENU_ENUM_LABEL_VALUE_DISABLED:
-         return "無効";
-      case MENU_ENUM_LABEL_VALUE_PORT:
-         return "ポート";
-      case MENU_ENUM_LABEL_VALUE_NONE:
-         return "無し";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DEVELOPER:
-         return "開発者";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_PUBLISHER:
-         return "出版社";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DESCRIPTION:
-         return "記述";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_GENRE:
-         return "ジャンル";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_NAME:
-         return "名前";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ORIGIN:
-         return "元";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_FRANCHISE:
-         return "フランチャイズ";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_MONTH:
-         return "発売月";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_YEAR:
-         return "発売年";
-      case MENU_ENUM_LABEL_VALUE_TRUE:
-         return "真";
-      case MENU_ENUM_LABEL_VALUE_FALSE:
-         return "偽";
-      case MENU_ENUM_LABEL_VALUE_MISSING:
-         return "欠測";
-      case MENU_ENUM_LABEL_VALUE_PRESENT:
-         return "現在";
-      case MENU_ENUM_LABEL_VALUE_OPTIONAL:
-         return "任意";
-      case MENU_ENUM_LABEL_VALUE_REQUIRED:
-         return "必要";
-      case MENU_ENUM_LABEL_VALUE_STATUS:
-         return "ステータス";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_SETTINGS:
-         return "オーディオ";
-      case MENU_ENUM_LABEL_VALUE_INPUT_SETTINGS:
-         return "入力";
-      case MENU_ENUM_LABEL_VALUE_ONSCREEN_DISPLAY_SETTINGS:
-         return "OSDディスプレイ";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_SETTINGS:
-         return "OSDオーバーレイ";
-      case MENU_ENUM_LABEL_VALUE_ONSCREEN_OVERLAY_SETTINGS:
-         return "OSDオーバーレイ";
-      case MENU_ENUM_LABEL_VALUE_MENU_SETTINGS:
-         return "メニュー";
-      case MENU_ENUM_LABEL_VALUE_MULTIMEDIA_SETTINGS:
-         return "マルチメディア";
-      case MENU_ENUM_LABEL_VALUE_USER_INTERFACE_SETTINGS:
-         return "ユーザーインターフェース";
-      case MENU_ENUM_LABEL_VALUE_MENU_FILE_BROWSER_SETTINGS:
-         return "メニューファイルブラウザー";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_FIRMWARE:
+         return "ファームウェア";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_LICENSES:
+         return "ライセンス";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_PERMISSIONS:
+         return "許可";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SUPPORTED_EXTENSIONS:
+         return "対応する拡張子";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_MANUFACTURER:
+         return "システムのメーカー";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_NAME:
+         return "システム名";
+      case MENU_ENUM_LABEL_VALUE_CORE_INPUT_REMAPPING_OPTIONS:
+         return "コントロール";
+      case MENU_ENUM_LABEL_VALUE_CORE_LIST:
+         return "コアをロード";
+      case MENU_ENUM_LABEL_VALUE_CORE_OPTIONS:
+         return "オプション";
+      case MENU_ENUM_LABEL_VALUE_CORE_SETTINGS:
+         return "コア";
+      case MENU_ENUM_LABEL_VALUE_CORE_SET_SUPPORTS_NO_CONTENT_ENABLE:
+         return "自動的にコアをスタート";
+      case MENU_ENUM_LABEL_VALUE_CORE_SPECIFIC_CONFIG:
+         return "コア特定の設定";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
+         return "ダウンロードしたアーカイブを自動解凍";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_BUILDBOT_URL:
+         return "BuildbotのコアURL";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_LIST:
+         return "コアのアップデーター";
       case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_SETTINGS:
          return "アップデーター";
-      case MENU_ENUM_LABEL_VALUE_UPDATER_SETTINGS:
-         return "アップデーター";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_SETTINGS:
-         return "ネットワーク";
-      case MENU_ENUM_LABEL_VALUE_WIFI_SETTINGS:
-         return "Wi-Fi";
-      case MENU_ENUM_LABEL_VALUE_LAKKA_SERVICES:
-         return "Lakkaのサービス";
-      case MENU_ENUM_LABEL_VALUE_PLAYLIST_SETTINGS:
-         return "プレイリスト";
-      case MENU_ENUM_LABEL_VALUE_USER_SETTINGS:
-         return "ユーザー";
+      case MENU_ENUM_LABEL_VALUE_CPU_ARCHITECTURE:
+         return "CPUアーキテクチャ:";
+      case MENU_ENUM_LABEL_VALUE_CPU_CORES:
+         return "CPUコア数:";
+      case MENU_ENUM_LABEL_VALUE_CURSOR_DIRECTORY:
+         return "カーソルのディレクトリー";
+      case MENU_ENUM_LABEL_VALUE_CURSOR_MANAGER:
+         return "カーソルマネージャー";
+      case MENU_ENUM_LABEL_VALUE_CUSTOM_RATIO:
+         return "カスタム比";
+      case MENU_ENUM_LABEL_VALUE_DATABASE_MANAGER:
+         return "データーベースマネージャー";
+      case MENU_ENUM_LABEL_VALUE_DATABASE_SELECTION:
+         return "Database Selection";
+      case MENU_ENUM_LABEL_VALUE_DELETE_ENTRY:
+         return "削除";
+      case MENU_ENUM_LABEL_VALUE_DETECT_CORE_LIST:
+         return "ファイルを選択とコア検出";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_CONTENT:
+         return "<Content dir>";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_DEFAULT:
+         return "<Default>";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NONE:
+         return "<None>";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NOT_FOUND:
+         return "そのようなフォルダはありません。";
       case MENU_ENUM_LABEL_VALUE_DIRECTORY_SETTINGS:
          return "ディレクトリ";
-      case MENU_ENUM_LABEL_VALUE_RECORDING_SETTINGS:
-         return "録画";
-      case MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE:
-         return "情報はありません。";
-      case MENU_ENUM_LABEL_VALUE_INPUT_USER_BINDS:
-         return "入力ユーザー%uのバインド";
-      case MENU_ENUM_LABEL_VALUE_LANG_ENGLISH:
-         return "英語";
-      case MENU_ENUM_LABEL_VALUE_LANG_JAPANESE:
-         return "日本語";
-      case MENU_ENUM_LABEL_VALUE_LANG_FRENCH:
-         return "フランス語";
-      case MENU_ENUM_LABEL_VALUE_LANG_SPANISH:
-         return "スペイン語";
-      case MENU_ENUM_LABEL_VALUE_LANG_GERMAN:
-         return "ドイツ語";
-      case MENU_ENUM_LABEL_VALUE_LANG_ITALIAN:
-         return "イタリア語";
-      case MENU_ENUM_LABEL_VALUE_LANG_DUTCH:
-         return "オランダ語";
-      case MENU_ENUM_LABEL_VALUE_LANG_PORTUGUESE:
-         return "ポルトガル語";
-      case MENU_ENUM_LABEL_VALUE_LANG_RUSSIAN:
-         return "ロシア語";
-      case MENU_ENUM_LABEL_VALUE_LANG_KOREAN:
-         return "韓国語";
-      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_TRADITIONAL:
-         return "中国語 (繁体)";
-      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_SIMPLIFIED:
-         return "中国語 (簡体)";
-      case MENU_ENUM_LABEL_VALUE_LANG_ESPERANTO:
-         return "エスペラント";
-      case MENU_ENUM_LABEL_VALUE_LANG_VIETNAMESE:
-         return "ベトナム語";
-      case MENU_ENUM_LABEL_VALUE_LEFT_ANALOG:
-         return "左のアナログ";
-      case MENU_ENUM_LABEL_VALUE_RIGHT_ANALOG:
-         return "右のアナログ";
-      case MENU_ENUM_LABEL_VALUE_INPUT_HOTKEY_BINDS:
-         return "入力のホットキーバインド";
-      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_SETTINGS:
-         return "フレームの減速度";
-      case MENU_ENUM_LABEL_VALUE_SEARCH:
-         return "検索:";
-      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_IMAGE_VIEWER:
-         return "Use Builtin Image Viewer";
+      case MENU_ENUM_LABEL_VALUE_DISABLED:
+         return "無効";
+      case MENU_ENUM_LABEL_VALUE_DISK_CYCLE_TRAY_STATUS:
+         return "Disk Cycle Tray Status";
+      case MENU_ENUM_LABEL_VALUE_DISK_IMAGE_APPEND:
+         return "Disk Image Append";
+      case MENU_ENUM_LABEL_VALUE_DISK_INDEX:
+         return "Disk Index";
+      case MENU_ENUM_LABEL_VALUE_DISK_OPTIONS:
+         return "ディスク設定";
+      case MENU_ENUM_LABEL_VALUE_DONT_CARE:
+         return "Don't care";
+      case MENU_ENUM_LABEL_VALUE_DOWNLOADED_FILE_DETECT_CORE_LIST:
+         return "ダウンロードのディレクトリー";
+      case MENU_ENUM_LABEL_VALUE_DOWNLOAD_CORE:
+         return "コアをダウンロード...";
+      case MENU_ENUM_LABEL_VALUE_DOWNLOAD_CORE_CONTENT:
+         return "コンテンツをダウンロード";
+      case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_ENABLE:
+         return "DPI Override Enable";
+      case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_VALUE:
+         return "DPI Override";
+      case MENU_ENUM_LABEL_VALUE_DRIVER_SETTINGS:
+         return "ドライバ";
+      case MENU_ENUM_LABEL_VALUE_DUMMY_ON_CORE_SHUTDOWN:
+         return "コアをシャットダウンでダミー";
+      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPER:
+         return "ダイナミック壁紙";
+      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPERS_DIRECTORY:
+         return "ダイナミック壁紙のディレクトリー";
       case MENU_ENUM_LABEL_VALUE_ENABLE:
          return "有効";
-      case MENU_ENUM_LABEL_VALUE_START_CORE:
-         return "コアをスタート";
-      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR:
-         return "ポールタイプの行動";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_SCROLL_UP:
-         return "上にスクロール";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_SCROLL_DOWN:
-         return "下にスクロール";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_CONFIRM:
-         return "確認";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_BACK:
-         return "戻る";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_START:
-         return "スタート";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_INFO:
+      case MENU_ENUM_LABEL_VALUE_ENTRY_HOVER_COLOR:
+         return "Menu entry hover color";
+      case MENU_ENUM_LABEL_VALUE_ENTRY_NORMAL_COLOR:
+         return "Menu entry normal color";
+      case MENU_ENUM_LABEL_VALUE_FALSE:
+         return "偽";
+      case MENU_ENUM_LABEL_VALUE_FASTFORWARD_RATIO:
+         return "早送り比";
+      case MENU_ENUM_LABEL_VALUE_FPS_SHOW:
+         return "フレームレートを表示";
+      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_ENABLE:
+         return "フレームの減速度";
+      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_SETTINGS:
+         return "フレームの減速度";
+      case MENU_ENUM_LABEL_VALUE_FRONTEND_COUNTERS:
+         return "Frontend Counters";
+      case MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS:
+         return "コンテンツ特定のコア設定を自動的にロード";
+      case MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS_CREATE:
+         return "Create game-options file";
+      case MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS_IN_USE:
+         return "Game-options file";
+      case MENU_ENUM_LABEL_VALUE_HELP:
+         return "ヘルプ";
+      case MENU_ENUM_LABEL_VALUE_HELP_AUDIO_VIDEO_TROUBLESHOOTING:
+         return "Audio/Video Troubleshooting";
+      case MENU_ENUM_LABEL_VALUE_HELP_CHANGE_VIRTUAL_GAMEPAD:
+         return "Changing Virtual Gamepad Overlay";
+      case MENU_ENUM_LABEL_VALUE_HELP_CONTROLS:
+         return "Basic Menu Controls";
+      case MENU_ENUM_LABEL_VALUE_HELP_LIST:
+         return "ヘルプ";
+      case MENU_ENUM_LABEL_VALUE_HELP_LOADING_CONTENT:
+         return "Loading Content";
+      case MENU_ENUM_LABEL_VALUE_HELP_SCANNING_CONTENT:
+         return "Scanning For Content";
+      case MENU_ENUM_LABEL_VALUE_HELP_WHAT_IS_A_CORE:
+         return "What Is A Core?";
+      case MENU_ENUM_LABEL_VALUE_HISTORY_LIST_ENABLE:
+         return "履歴リストを有効";
+      case MENU_ENUM_LABEL_VALUE_HISTORY_TAB:
+         return "履歴";
+      case MENU_ENUM_LABEL_VALUE_HORIZONTAL_MENU:
+         return "Horizontal Menu";
+      case MENU_ENUM_LABEL_VALUE_IMAGES_TAB:
+         return "画像";
+      case MENU_ENUM_LABEL_VALUE_INFORMATION:
          return "情報";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_TOGGLE_MENU:
-         return "メニューに切り替え";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_QUIT:
-         return "終了";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_TOGGLE_KEYBOARD:
-         return "キーボードに切り替え";
-      case MENU_ENUM_LABEL_VALUE_THUMBNAIL_MODE_SCREENSHOTS:
-         return "スクリーンショット";
-      case MENU_ENUM_LABEL_VALUE_THUMBNAIL_MODE_TITLE_SCREENS:
-         return "Title Screens";
-      case MENU_ENUM_LABEL_VALUE_THUMBNAIL_MODE_BOXARTS:
-         return "Boxarts";
-      case MENU_ENUM_LABEL_VALUE_MENU_WALLPAPER_OPACITY:
-         return "壁紙の不透明性";
+      case MENU_ENUM_LABEL_VALUE_INFORMATION_LIST:
+         return "情報";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ADC_TYPE:
+         return "アナログのデジタル化のタイプ";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ALL_USERS_CONTROL_MENU:
+         return "すべてのユーザーがメニューを操作できる";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_X:
+         return "左アナログX";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_X_MINUS:
+         return "左アナログX- (左)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_X_PLUS:
+         return "左アナログX+ (右)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_Y:
+         return "左アナログY";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_Y_MINUS:
+         return "左アナログY- (上)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_Y_PLUS:
+         return "左アナログY+ (下)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_X:
+         return "右アナログX";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_X_MINUS:
+         return "右アナログX- (左)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_X_PLUS:
+         return "右アナログX+ (右)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_Y:
+         return "右アナログY";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_Y_MINUS:
+         return "右アナログY- (上)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_Y_PLUS:
+         return "右アナログY+ (下)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_AUTODETECT_ENABLE:
+         return "自動コンフィグを有効";
+      case MENU_ENUM_LABEL_VALUE_INPUT_AXIS_THRESHOLD:
+         return "入力軸のしきい値";
+      case MENU_ENUM_LABEL_VALUE_INPUT_BACK_AS_MENU_ENUM_TOGGLE_ENABLE:
+         return "Back As Menu Toggle Enable";
+      case MENU_ENUM_LABEL_VALUE_INPUT_BIND_ALL:
+         return "全てをバインド";
+      case MENU_ENUM_LABEL_VALUE_INPUT_BIND_DEFAULT_ALL:
+         return "全てのバインドを初期化";
+      case MENU_ENUM_LABEL_VALUE_INPUT_BIND_TIMEOUT:
+         return "バインドのタイムアウト";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_HIDE_UNBOUND:
+         return "未定義のコア入力の識別子を隠す";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_LABEL_SHOW:
+         return "入力の識別子ラベルを表示";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DEVICE_INDEX:
+         return "デバイスインデックス";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DEVICE_TYPE:
+         return "デバイスタイプ";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DRIVER:
+         return "入力のドライバ";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DUTY_CYCLE:
+         return "デューティー比";
+      case MENU_ENUM_LABEL_VALUE_INPUT_HOTKEY_BINDS:
+         return "入力のホットキーバインド";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ICADE_ENABLE:
+         return "Keyboard Gamepad Mapping Enable";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_A:
+         return "Aボタン(右)";
       case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_B:
          return "Bボタン(下)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_Y:
-         return "Yボタン(左)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_DOWN:
+         return "下 (十字キー)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_L2:
+         return "L2ボタン(トリガー)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_L3:
+         return "L3ボタン(親指)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_L:
+         return "Lボタン(上面)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_LEFT:
+         return "左 (十字キー)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_R2:
+         return "R2ボタン(トリガー)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_R3:
+         return "R3ボタン(親指)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_R:
+         return "Rボタン(上面)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_RIGHT:
+         return "右 (十字キー)";
       case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_SELECT:
          return "選択ボタン";
       case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_START:
          return "スタートボタン";
       case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_UP:
          return "上 (十字キー)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_DOWN:
-         return "下 (十字キー)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_LEFT:
-         return "左 (十字キー)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_RIGHT:
-         return "右 (十字キー)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_A:
-         return "Aボタン(右)";
       case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_X:
          return "Xボタン(上面)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_L:
-         return "Lボタン(上面)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_R:
-         return "Rボタン(上面)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_L2:
-         return "L2ボタン(トリガー)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_R2:
-         return "R2ボタン(トリガー)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_L3:
-         return "L3ボタン(親指)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_R3:
-         return "R3ボタン(親指)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_X:
-         return "左アナログX";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_Y:
-         return "左アナログY";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_X:
-         return "右アナログX";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_Y:
-         return "右アナログY";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_X_PLUS:
-         return "左アナログX+ (右)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_X_MINUS:
-         return "左アナログX- (左)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_Y_PLUS:
-         return "左アナログY+ (下)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_Y_MINUS:
-         return "左アナログY- (上)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_X_PLUS:
-         return "右アナログX+ (右)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_X_MINUS:
-         return "右アナログX- (左)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_Y_PLUS:
-         return "右アナログY+ (下)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_Y_MINUS:
-         return "右アナログY- (上)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_TURBO_ENABLE:
-         return "ターボ有効";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_FAST_FORWARD_KEY:
-         return "早送りに切り替え";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_FAST_FORWARD_HOLD_KEY:
-         return "ホールドで早送";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_LOAD_STATE_KEY:
-         return "保存状態をロード";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_SAVE_STATE_KEY:
-         return "状態保存";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_FULLSCREEN_TOGGLE_KEY:
-         return "フルスクリーンに切り替え";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_QUIT_KEY:
-         return "RetroArchを終了";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_STATE_SLOT_PLUS:
-         return "次の状態スロット";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_STATE_SLOT_MINUS:
-         return "前の状態スロット";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_REWIND:
-         return "巻き戻し";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_MOVIE_RECORD_TOGGLE:
-         return "録画";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_PAUSE_TOGGLE:
-         return "一時停止";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_FRAMEADVANCE:
-         return "コマ送り";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_RESET:
-         return "リセット";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_SHADER_NEXT:
-         return "次のシェーダー";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_SHADER_PREV:
-         return "前のシェーダー";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_CHEAT_INDEX_PLUS:
-         return "次のチートインデックス";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_Y:
+         return "Yボタン(左)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_KEYBOARD_GAMEPAD_MAPPING_TYPE:
+         return "Keyboard Gamepad Mapping Type";
+      case MENU_ENUM_LABEL_VALUE_INPUT_MAX_USERS:
+         return "最高のユーザー数";
+      case MENU_ENUM_LABEL_VALUE_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
+         return "ゲームパッドのメニュー切り替えコンボ";
       case MENU_ENUM_LABEL_VALUE_INPUT_META_CHEAT_INDEX_MINUS:
          return "前のチートインデックス";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_CHEAT_INDEX_PLUS:
+         return "次のチートインデックス";
       case MENU_ENUM_LABEL_VALUE_INPUT_META_CHEAT_TOGGLE:
          return "チートを切り替";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_SCREENSHOT:
-         return "スクリーンショット";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_MUTE:
-         return "消音";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_OSK:
-         return "ソフトウェアキーボードを切りがえ";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_NETPLAY_FLIP:
-         return "ネットプレイのユーザ交換";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_SLOWMOTION:
-         return "スローモーション";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_ENABLE_HOTKEY:
-         return "ホットキーを有効";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_VOLUME_UP:
-         return "音量を増す";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_VOLUME_DOWN:
-         return "音量を減る";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_OVERLAY_NEXT:
-         return "次のオーバーレイ";
       case MENU_ENUM_LABEL_VALUE_INPUT_META_DISK_EJECT_TOGGLE:
          return "ディスクを取り出し";
       case MENU_ENUM_LABEL_VALUE_INPUT_META_DISK_NEXT:
          return "次のディスクに切り替え";
       case MENU_ENUM_LABEL_VALUE_INPUT_META_DISK_PREV:
          return "前のディスクに切り替え";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_ENABLE_HOTKEY:
+         return "ホットキーを有効";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_FAST_FORWARD_HOLD_KEY:
+         return "ホールドで早送";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_FAST_FORWARD_KEY:
+         return "早送りに切り替え";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_FRAMEADVANCE:
+         return "コマ送り";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_FULLSCREEN_TOGGLE_KEY:
+         return "フルスクリーンに切り替え";
       case MENU_ENUM_LABEL_VALUE_INPUT_META_GRAB_MOUSE_TOGGLE:
          return "マウスグラブを切り替え";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_LOAD_STATE_KEY:
+         return "保存状態をロード";
       case MENU_ENUM_LABEL_VALUE_INPUT_META_MENU_TOGGLE:
          return "メニューに切り替え";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DEVICE_INDEX:
-         return "デバイスインデックス";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DEVICE_TYPE:
-         return "デバイスタイプ";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ADC_TYPE:
-         return "アナログのデジタル化のタイプ";
-      case MENU_ENUM_LABEL_VALUE_INPUT_BIND_ALL:
-         return "全てをバインド";
-      case MENU_ENUM_LABEL_VALUE_INPUT_BIND_DEFAULT_ALL:
-         return "全てのバインドを初期化";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_MOVIE_RECORD_TOGGLE:
+         return "録画";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_MUTE:
+         return "消音";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_NETPLAY_FLIP:
+         return "ネットプレイのユーザ交換";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_OSK:
+         return "ソフトウェアキーボードを切りがえ";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_OVERLAY_NEXT:
+         return "次のオーバーレイ";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_PAUSE_TOGGLE:
+         return "一時停止";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_QUIT_KEY:
+         return "RetroArchを終了";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_RESET:
+         return "リセット";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_REWIND:
+         return "巻き戻し";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_SAVE_STATE_KEY:
+         return "状態保存";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_SCREENSHOT:
+         return "スクリーンショット";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_SHADER_NEXT:
+         return "次のシェーダー";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_SHADER_PREV:
+         return "前のシェーダー";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_SLOWMOTION:
+         return "スローモーション";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_STATE_SLOT_MINUS:
+         return "前の状態スロット";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_STATE_SLOT_PLUS:
+         return "次の状態スロット";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_VOLUME_DOWN:
+         return "音量を減る";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_VOLUME_UP:
+         return "音量を増す";
+      case MENU_ENUM_LABEL_VALUE_INPUT_OSK_OVERLAY_ENABLE:
+         return "キーボードオーバーレイを表示";
+      case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_ENABLE:
+         return "ディスプレイのオーバーレイ";
+      case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_HIDE_IN_MENU:
+         return "メニューにオーバーレイを隠す";
+      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR:
+         return "ポールタイプの行動";
+      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR_EARLY:
+         return "早い";
+      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR_LATE:
+         return "遅い";
+      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR_NORMAL:
+         return "普通";
+      case MENU_ENUM_LABEL_VALUE_INPUT_PREFER_FRONT_TOUCH:
+         return "Prefer Front Touch";
+      case MENU_ENUM_LABEL_VALUE_INPUT_REMAPPING_DIRECTORY:
+         return "入力リマップのディレクトリー";
+      case MENU_ENUM_LABEL_VALUE_INPUT_REMAP_BINDS_ENABLE:
+         return "リマップバインドを有効";
       case MENU_ENUM_LABEL_VALUE_INPUT_SAVE_AUTOCONFIG:
          return "自動設定を保存";
+      case MENU_ENUM_LABEL_VALUE_INPUT_SETTINGS:
+         return "入力";
+      case MENU_ENUM_LABEL_VALUE_INPUT_SMALL_KEYBOARD_ENABLE:
+         return "Small Keyboard Enable";
+      case MENU_ENUM_LABEL_VALUE_INPUT_TOUCH_ENABLE:
+         return "タッチを有効";
+      case MENU_ENUM_LABEL_VALUE_INPUT_TURBO_ENABLE:
+         return "ターボ有効";
+      case MENU_ENUM_LABEL_VALUE_INPUT_TURBO_PERIOD:
+         return "ターボの期間";
+      case MENU_ENUM_LABEL_VALUE_INPUT_USER_BINDS:
+         return "入力ユーザー%uのバインド";
+      case MENU_ENUM_LABEL_VALUE_INTERNAL_STORAGE_STATUS:
+         return "Internal storage status";
+      case MENU_ENUM_LABEL_VALUE_JOYPAD_AUTOCONFIG_DIR:
+         return "入力デバイスの自動設定ディレクトリー";
+      case MENU_ENUM_LABEL_VALUE_JOYPAD_DRIVER:
+         return "ジョイパッドのドライバ";
+      case MENU_ENUM_LABEL_VALUE_KEYBOARD_OVERLAY_PRESET:
+         return "キーボードのオーバーレイプリセット";
+      case MENU_ENUM_LABEL_VALUE_LAKKA_SERVICES:
+         return "Lakkaのサービス";
+      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_SIMPLIFIED:
+         return "中国語 (簡体)";
+      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_TRADITIONAL:
+         return "中国語 (繁体)";
+      case MENU_ENUM_LABEL_VALUE_LANG_DUTCH:
+         return "オランダ語";
+      case MENU_ENUM_LABEL_VALUE_LANG_ENGLISH:
+         return "英語";
+      case MENU_ENUM_LABEL_VALUE_LANG_ESPERANTO:
+         return "エスペラント";
+      case MENU_ENUM_LABEL_VALUE_LANG_FRENCH:
+         return "フランス語";
+      case MENU_ENUM_LABEL_VALUE_LANG_GERMAN:
+         return "ドイツ語";
+      case MENU_ENUM_LABEL_VALUE_LANG_ITALIAN:
+         return "イタリア語";
+      case MENU_ENUM_LABEL_VALUE_LANG_JAPANESE:
+         return "日本語";
+      case MENU_ENUM_LABEL_VALUE_LANG_KOREAN:
+         return "韓国語";
+      case MENU_ENUM_LABEL_VALUE_LANG_POLISH:
+         return "ポーランド語";
+      case MENU_ENUM_LABEL_VALUE_LANG_PORTUGUESE:
+         return "ポルトガル語";
+      case MENU_ENUM_LABEL_VALUE_LANG_RUSSIAN:
+         return "ロシア語";
+      case MENU_ENUM_LABEL_VALUE_LANG_SPANISH:
+         return "スペイン語";
+      case MENU_ENUM_LABEL_VALUE_LANG_VIETNAMESE:
+         return "ベトナム語";
+      case MENU_ENUM_LABEL_VALUE_LEFT_ANALOG:
+         return "左のアナログ";
+      case MENU_ENUM_LABEL_VALUE_LIBRETRO_DIR_PATH:
+         return "コアのディレクトリー";
+      case MENU_ENUM_LABEL_VALUE_LIBRETRO_INFO_PATH:
+         return "コア情報のディレクトリー";
+      case MENU_ENUM_LABEL_VALUE_LIBRETRO_LOG_LEVEL:
+         return "コアのログ出力レベル";
+      case MENU_ENUM_LABEL_VALUE_LINEAR:
+         return "Linear";
+      case MENU_ENUM_LABEL_VALUE_LOAD_ARCHIVE:
+         return "コアでアーカイブをロード";
+      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT:
+         return "ファイル選択";
+      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_HISTORY:
+         return "最近のものをロード";
+      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_LIST:
+         return "コンテンツをロード";
+      case MENU_ENUM_LABEL_VALUE_LOAD_STATE:
+         return "保存状態をロード";
+      case MENU_ENUM_LABEL_VALUE_LOCATION_ALLOW:
+         return "ロケーションを許す";
+      case MENU_ENUM_LABEL_VALUE_LOCATION_DRIVER:
+         return "ロケーションのドライバ";
+      case MENU_ENUM_LABEL_VALUE_LOGGING_SETTINGS:
+         return "ログ";
+      case MENU_ENUM_LABEL_VALUE_LOG_VERBOSITY:
+         return "ログの出力レベル";
+      case MENU_ENUM_LABEL_VALUE_MAIN_MENU:
+         return "メインメニュー";
+      case MENU_ENUM_LABEL_VALUE_MANAGEMENT:
+         return "データベースの設定";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME:
+         return "メニューの色テーマ";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_BLUE:
+         return "青";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_BLUE_GREY:
+         return "ブルーグレイ";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_DARK_BLUE:
+         return "ダークブルー";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_GREEN:
+         return "緑";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_NVIDIA_SHIELD:
+         return "SHIELD";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_RED:
+         return "赤";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_YELLOW:
+         return "黄色";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_FOOTER_OPACITY:
+         return "Footer Opacity";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_HEADER_OPACITY:
+         return "Header Opacity";
+      case MENU_ENUM_LABEL_VALUE_MENU_DRIVER:
+         return "メニューのドライバ";
+      case MENU_ENUM_LABEL_VALUE_MENU_ENUM_THROTTLE_FRAMERATE:
+         return "メニューのフレームレートを減速";
+      case MENU_ENUM_LABEL_VALUE_MENU_FILE_BROWSER_SETTINGS:
+         return "メニューファイルブラウザー";
+      case MENU_ENUM_LABEL_VALUE_MENU_LINEAR_FILTER:
+         return "メニューのリニアフィルター";
+      case MENU_ENUM_LABEL_VALUE_MENU_SETTINGS:
+         return "メニュー";
+      case MENU_ENUM_LABEL_VALUE_MENU_WALLPAPER:
+         return "メニューの壁紙";
+      case MENU_ENUM_LABEL_VALUE_MENU_WALLPAPER_OPACITY:
+         return "壁紙の不透明性";
+      case MENU_ENUM_LABEL_VALUE_MISSING:
+         return "欠測";
+      case MENU_ENUM_LABEL_VALUE_MORE:
+         return "...";
+      case MENU_ENUM_LABEL_VALUE_MOUSE_ENABLE:
+         return "マウス対応";
+      case MENU_ENUM_LABEL_VALUE_MULTIMEDIA_SETTINGS:
+         return "マルチメディア";
+      case MENU_ENUM_LABEL_VALUE_MUSIC_TAB:
+         return "音楽";
+      case MENU_ENUM_LABEL_VALUE_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
+         return "不明な拡張子を隠す";
+      case MENU_ENUM_LABEL_VALUE_NAVIGATION_WRAPAROUND:
+         return "ナビゲーションの回り込み";
+      case MENU_ENUM_LABEL_VALUE_NEAREST:
+         return "Nearest";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY:
+         return "ネットプレイ";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_CHECK_FRAMES:
+         return "ネットプレイのチェックフレーム";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT:
+         return "ネットプレイのP2がC1を使用";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_DELAY_FRAMES:
+         return "ネットプレイの延期フレーム";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_DISCONNECT:
+         return "切断";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE:
+         return "ネットプレイを有効";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE_CLIENT:
+         return "ネットプレイサーバーに接続";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE_HOST:
+         return "ホストする";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS:
+         return "サーバーのアドレス";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_MODE:
+         return "ネットプレイのクライアントを有効";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_NICKNAME:
+         return "ユーザー名";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_SETTINGS:
+         return "ネットプレイ設定";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE:
+         return "ネットプレイの観覧者を有効";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT:
+         return "ネットプレイのTCP/UDPポート";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_ENABLE:
+         return "ネットワークコマンドを有効";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_PORT:
+         return "ネットワークコマンドのポート";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_INFORMATION:
+         return "ネットワーク情報";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_REMOTE_ENABLE:
+         return "ネットワークゲームパッド";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_REMOTE_PORT:
+         return "Network Remote Base Port";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_SETTINGS:
+         return "ネットワーク";
+      case MENU_ENUM_LABEL_VALUE_NO:
+         return "いいえ";
+      case MENU_ENUM_LABEL_VALUE_NONE:
+         return "無し";
+      case MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE:
+         return "N/A";
+      case MENU_ENUM_LABEL_VALUE_NO_ACHIEVEMENTS_TO_DISPLAY:
+         return "No achievements to display.";
+      case MENU_ENUM_LABEL_VALUE_NO_CORE:
+         return "コアはありません";
+      case MENU_ENUM_LABEL_VALUE_NO_CORES_AVAILABLE:
+         return "コアはありません。";
+      case MENU_ENUM_LABEL_VALUE_NO_CORE_INFORMATION_AVAILABLE:
+         return "コア情報はありません。";
+      case MENU_ENUM_LABEL_VALUE_NO_CORE_OPTIONS_AVAILABLE:
+         return "コア設定はありません。";
+      case MENU_ENUM_LABEL_VALUE_NO_ENTRIES_TO_DISPLAY:
+         return "No entries to display.";
+      case MENU_ENUM_LABEL_VALUE_NO_HISTORY_AVAILABLE:
+         return "履歴はありません。";
+      case MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE:
+         return "情報はありません。";
+      case MENU_ENUM_LABEL_VALUE_NO_ITEMS:
+         return "アイテムが見つかりません。";
+      case MENU_ENUM_LABEL_VALUE_NO_PERFORMANCE_COUNTERS:
+         return "No performance counters.";
+      case MENU_ENUM_LABEL_VALUE_NO_PLAYLISTS:
+         return "プレイリストが見つかりません。";
+      case MENU_ENUM_LABEL_VALUE_NO_PLAYLIST_ENTRIES_AVAILABLE:
+         return "プレイリストのエントリーはありません。";
+      case MENU_ENUM_LABEL_VALUE_NO_SETTINGS_FOUND:
+         return "設定が見つかりませんでした。";
+      case MENU_ENUM_LABEL_VALUE_NO_SHADER_PARAMETERS:
+         return "シェーダーのパラメータはありません。";
+      case MENU_ENUM_LABEL_VALUE_OFF:
+         return "OFF";
+      case MENU_ENUM_LABEL_VALUE_ON:
+         return "ON";
+      case MENU_ENUM_LABEL_VALUE_ONLINE_UPDATER:
+         return "オンラインアップデーター";
+      case MENU_ENUM_LABEL_VALUE_ONSCREEN_DISPLAY_SETTINGS:
+         return "OSDディスプレイ";
+      case MENU_ENUM_LABEL_VALUE_ONSCREEN_OVERLAY_SETTINGS:
+         return "OSDオーバーレイ";
+      case MENU_ENUM_LABEL_VALUE_OPEN_ARCHIVE:
+         return "フォルダでアーカイブを開く";
+      case MENU_ENUM_LABEL_VALUE_OPTIONAL:
+         return "任意";
+      case MENU_ENUM_LABEL_VALUE_OSK_OVERLAY_DIRECTORY:
+         return "OSKオーバーレイのディレクトリー";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY:
+         return "オーバーレイ";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_AUTOLOAD_PREFERRED:
+         return "優先オーバーレイを自動ロード";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_DIRECTORY:
+         return "オーバーレイのディレクトリー";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_OPACITY:
+         return "オーバーレイの不透明性";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_PRESET:
+         return "オーバーレイのプリセット";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_SCALE:
+         return "オーバーレイのスケール";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_SETTINGS:
+         return "OSDオーバーレイ";
+      case MENU_ENUM_LABEL_VALUE_PAL60_ENABLE:
+         return "Use PAL60 Mode";
+      case MENU_ENUM_LABEL_VALUE_PARENT_DIRECTORY:
+         return "親ディレクトリー";
+      case MENU_ENUM_LABEL_VALUE_PAUSE_LIBRETRO:
+         return "メニューが表示時に一時停止";
+      case MENU_ENUM_LABEL_VALUE_PAUSE_NONACTIVE:
+         return "バックグラウンドで実行しない";
+      case MENU_ENUM_LABEL_VALUE_PERFCNT_ENABLE:
+         return "パフォーマンスカウンター";
+      case MENU_ENUM_LABEL_VALUE_PLAYLISTS_TAB:
+         return "プレイリスト";
+      case MENU_ENUM_LABEL_VALUE_PLAYLIST_DIRECTORY:
+         return "プレイリストのディレクトリー";
+      case MENU_ENUM_LABEL_VALUE_PLAYLIST_SETTINGS:
+         return "プレイリスト";
+      case MENU_ENUM_LABEL_VALUE_POINTER_ENABLE:
+         return "タッチ対応";
+      case MENU_ENUM_LABEL_VALUE_PORT:
+         return "ポート";
+      case MENU_ENUM_LABEL_VALUE_PRESENT:
+         return "現在";
+      case MENU_ENUM_LABEL_VALUE_PRIVACY_SETTINGS:
+         return "プライバシー";
+      case MENU_ENUM_LABEL_VALUE_QUIT_RETROARCH:
+         return "終了";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ANALOG:
+         return "Analog supported";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_BBFC_RATING:
+         return "BBFC Rating";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_CERO_RATING:
+         return "CERO Rating";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_COOP:
+         return "Co-op supported";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_CRC32:
+         return "CRC32";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DESCRIPTION:
+         return "記述";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DEVELOPER:
+         return "開発者";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_EDGE_MAGAZINE_ISSUE:
+         return "Edge Magazine Issue";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_EDGE_MAGAZINE_RATING:
+         return "Edge Magazine Rating";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_EDGE_MAGAZINE_REVIEW:
+         return "Edge Magazine Review";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ELSPA_RATING:
+         return "ELSPA Rating";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ENHANCEMENT_HW:
+         return "Enhancement Hardware";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ESRB_RATING:
+         return "ESRB Rating";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_FAMITSU_MAGAZINE_RATING:
+         return "Famitsu Magazine Rating";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_FRANCHISE:
+         return "フランチャイズ";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_GENRE:
+         return "ジャンル";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_MD5:
+         return "MD5";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_NAME:
+         return "名前";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ORIGIN:
+         return "元";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_PEGI_RATING:
+         return "PEGI Rating";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_PUBLISHER:
+         return "出版社";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_MONTH:
+         return "発売月";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_YEAR:
+         return "発売年";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RUMBLE:
+         return "Rumble supported";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_SERIAL:
+         return "Serial";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_SHA1:
+         return "SHA1";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_START_CONTENT:
+         return "コンテンツをスタート";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_TGDB_RATING:
+         return "TGDB Rating";
+      case MENU_ENUM_LABEL_VALUE_REBOOT:
+         return "再起動";
+      case MENU_ENUM_LABEL_VALUE_RECORDING_CONFIG_DIRECTORY:
+         return "録画設定のディレクトリー";
+      case MENU_ENUM_LABEL_VALUE_RECORDING_OUTPUT_DIRECTORY:
+         return "録画の出力ディレクトリー";
+      case MENU_ENUM_LABEL_VALUE_RECORDING_SETTINGS:
+         return "録画";
+      case MENU_ENUM_LABEL_VALUE_RECORD_CONFIG:
+         return "録画設定ファイル";
+      case MENU_ENUM_LABEL_VALUE_RECORD_DRIVER:
+         return "録画のドライバ";
+      case MENU_ENUM_LABEL_VALUE_RECORD_ENABLE:
+         return "録画を有効";
+      case MENU_ENUM_LABEL_VALUE_RECORD_PATH:
+         return "出力ファイル";
+      case MENU_ENUM_LABEL_VALUE_RECORD_USE_OUTPUT_DIRECTORY:
+         return "出力ディレクトリーを使用";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE:
+         return "リマップファイル";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_LOAD:
+         return "リマップファイルをロード";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_CORE:
+         return "コアリマップファイルを保存";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_GAME:
+         return "ゲームリマップファイルを保存";
+      case MENU_ENUM_LABEL_VALUE_REQUIRED:
+         return "必要";
+      case MENU_ENUM_LABEL_VALUE_RESTART_CONTENT:
+         return "コンテンツを再起動";
+      case MENU_ENUM_LABEL_VALUE_RESTART_RETROARCH:
+         return "RetroArchを再起動";
+      case MENU_ENUM_LABEL_VALUE_RESUME:
+         return "再開";
+      case MENU_ENUM_LABEL_VALUE_RESUME_CONTENT:
+         return "再開";
+      case MENU_ENUM_LABEL_VALUE_RETROKEYBOARD:
+         return "RetroKeyboard";
+      case MENU_ENUM_LABEL_VALUE_RETROPAD:
+         return "レトロパッド";
+      case MENU_ENUM_LABEL_VALUE_RETRO_ACHIEVEMENTS_SETTINGS:
+         return "Retro Achievements";
+      case MENU_ENUM_LABEL_VALUE_REWIND_ENABLE:
+         return "巻き戻しを有効";
+      case MENU_ENUM_LABEL_VALUE_REWIND_GRANULARITY:
+         return "巻き戻しの粒状度";
+      case MENU_ENUM_LABEL_VALUE_REWIND_SETTINGS:
+         return "巻き戻し";
+      case MENU_ENUM_LABEL_VALUE_RGUI_BROWSER_DIRECTORY:
+         return "ファイルブラウザーのディレクトリー";
+      case MENU_ENUM_LABEL_VALUE_RGUI_CONFIG_DIRECTORY:
+         return "設定のディレクトリー";
+      case MENU_ENUM_LABEL_VALUE_RGUI_SHOW_START_SCREEN:
+         return "スタート画面を表示";
+      case MENU_ENUM_LABEL_VALUE_RIGHT_ANALOG:
+         return "右のアナログ";
+      case MENU_ENUM_LABEL_VALUE_RUN:
+         return "実行";
+      case MENU_ENUM_LABEL_VALUE_SAMBA_ENABLE:
+         return "SAMBAを有効";
+      case MENU_ENUM_LABEL_VALUE_SAVEFILE_DIRECTORY:
+         return "セーブファイルのディレクトリー";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_INDEX:
+         return "保存状態の自動インデックス";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_LOAD:
+         return "自動的に保存状態をロード";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_SAVE:
+         return "自動的に状態を保存";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_DIRECTORY:
+         return "保存状態のディレクトリー";
+      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG:
+         return "現在の設定を保存";
+      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG_OVERRIDE_CORE:
+         return "コアの優先を保存";
+      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG_OVERRIDE_GAME:
+         return "ゲームの優先を保存";
+      case MENU_ENUM_LABEL_VALUE_SAVE_NEW_CONFIG:
+         return "新しい設定を保存";
+      case MENU_ENUM_LABEL_VALUE_SAVE_STATE:
+         return "状態保存";
+      case MENU_ENUM_LABEL_VALUE_SAVING_SETTINGS:
+         return "保存";
+      case MENU_ENUM_LABEL_VALUE_SCAN_DIRECTORY:
+         return "フォルダをスキャン";
+      case MENU_ENUM_LABEL_VALUE_SCAN_FILE:
+         return "ファイルをスキャン";
+      case MENU_ENUM_LABEL_VALUE_SCAN_THIS_DIRECTORY:
+         return "<このフォルダをスキャン>";
+      case MENU_ENUM_LABEL_VALUE_SCREENSHOT_DIRECTORY:
+         return "スクリーンショットのディレクトリー";
+      case MENU_ENUM_LABEL_VALUE_SCREEN_RESOLUTION:
+         return "スクリーン解像度";
+      case MENU_ENUM_LABEL_VALUE_SEARCH:
+         return "検索:";
+      case MENU_ENUM_LABEL_VALUE_SECONDS:
+         return "秒";
+      case MENU_ENUM_LABEL_VALUE_SETTINGS:
+         return "設定";
+      case MENU_ENUM_LABEL_VALUE_SETTINGS_TAB:
+         return "設定";
+      case MENU_ENUM_LABEL_VALUE_SHADER:
+         return "シェーダー";
+      case MENU_ENUM_LABEL_VALUE_SHADER_APPLY_CHANGES:
+         return "シェーダーの変更点を適用";
+      case MENU_ENUM_LABEL_VALUE_SHADER_OPTIONS:
+         return "シェーダー";
+      case MENU_ENUM_LABEL_VALUE_SHADER_PIPELINE_RIBBON:
+         return "リボン";
+      case MENU_ENUM_LABEL_VALUE_SHADER_PIPELINE_RIBBON_SIMPLIFIED:
+         return "リボン (単純)";
+      case MENU_ENUM_LABEL_VALUE_SHOW_ADVANCED_SETTINGS:
+         return "詳細設定を表示";
+      case MENU_ENUM_LABEL_VALUE_SHOW_HIDDEN_FILES:
+         return "隠しファイルとフォルダを表示";
+      case MENU_ENUM_LABEL_VALUE_SHUTDOWN:
+         return "シャットダウン";
+      case MENU_ENUM_LABEL_VALUE_SLOWMOTION_RATIO:
+         return "スローモーション比";
+      case MENU_ENUM_LABEL_VALUE_SORT_SAVEFILES_ENABLE:
+         return "フォルダでセーブを並び替え";
+      case MENU_ENUM_LABEL_VALUE_SORT_SAVESTATES_ENABLE:
+         return "フォルダで保存状態を並び替え";
+      case MENU_ENUM_LABEL_VALUE_SSH_ENABLE:
+         return "SSHを有効";
+      case MENU_ENUM_LABEL_VALUE_START_CORE:
+         return "コアをスタート";
+      case MENU_ENUM_LABEL_VALUE_START_NET_RETROPAD:
+         return "リモートレトロパッドをスタート";
+      case MENU_ENUM_LABEL_VALUE_START_VIDEO_PROCESSOR:
+         return "ビデオプロセッサをスタート";
+      case MENU_ENUM_LABEL_VALUE_STATE_SLOT:
+         return "保存状態のスロット";
+      case MENU_ENUM_LABEL_VALUE_STATUS:
+         return "ステータス";
+      case MENU_ENUM_LABEL_VALUE_STDIN_CMD_ENABLE:
+         return "stdinコマンド";
+      case MENU_ENUM_LABEL_VALUE_SUPPORTED_CORES:
+         return "対応するコア";
+      case MENU_ENUM_LABEL_VALUE_SUSPEND_SCREENSAVER_ENABLE:
+         return "スクリーンセーバーをサスペンド";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_BGM_ENABLE:
+         return "System BGM Enable";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_DIRECTORY:
+         return "システム/BIOSのディレクトリー";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFORMATION:
+         return "システム情報";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_7ZIP_SUPPORT:
+         return "7zip対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ALSA_SUPPORT:
+         return "ALSA対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_BUILD_DATE:
+         return "ビルド日付";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CG_SUPPORT:
+         return "Cg対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COCOA_SUPPORT:
+         return "Cocoa対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COMMAND_IFACE_SUPPORT:
+         return "コマンドインターフェース対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CORETEXT_SUPPORT:
+         return "CoreText対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CPU_FEATURES:
+         return "CPU機能";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_DPI:
+         return "ディスプレイの軽量DPI";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_HEIGHT:
+         return "ディスプレイの軽量縦幅 (mm)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_WIDTH:
+         return "ディスプレイの軽量横幅 (mm)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DSOUND_SUPPORT:
+         return "DirectSound対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DYLIB_SUPPORT:
+         return "ダイナミックライブラリー対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DYNAMIC_SUPPORT:
+         return "ダイナミックlibretroライブラリーのランタイム時にロード対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_EGL_SUPPORT:
+         return "EGL対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FBO_SUPPORT:
+         return "OpenGL/Direct3Dテクスチャーにレンダリング (マルチパスシェーダー)対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FFMPEG_SUPPORT:
+         return "FFmpeg対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FREETYPE_SUPPORT:
+         return "FreeType対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_IDENTIFIER:
+         return "フロントエンド識別名";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_NAME:
+         return "フロントエンド名";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_OS:
+         return "フロントエンドOS";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GIT_VERSION:
+         return "Gitバージョン";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GLSL_SUPPORT:
+         return "GLSL対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_HLSL_SUPPORT:
+         return "HLSL対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_JACK_SUPPORT:
+         return "JACK対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_KMS_SUPPORT:
+         return "KMS/EGL対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBRETRODB_SUPPORT:
+         return "LibretroDB対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBUSB_SUPPORT:
+         return "Libusb対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBXML2_SUPPORT:
+         return "libxml2 XMLパース対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETPLAY_SUPPORT:
+         return "ネットプレイ(ピアツーピア)対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETWORK_COMMAND_IFACE_SUPPORT:
+         return "ネットワークコマンドインターフェース対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETWORK_REMOTE_SUPPORT:
+         return "ネットワークゲームパッド対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENAL_SUPPORT:
+         return "OpenAL対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGLES_SUPPORT:
+         return "OpenGL ES対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGL_SUPPORT:
+         return "OpenGL対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENSL_SUPPORT:
+         return "OpenSL対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENVG_SUPPORT:
+         return "OpenVG対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OSS_SUPPORT:
+         return "OSS対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OVERLAY_SUPPORT:
+         return "オーバーレイ対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE:
+         return "パワーソース";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGED:
+         return "充電完了";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGING:
+         return "充電中";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_DISCHARGING:
+         return "放電";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_NO_SOURCE:
+         return "ソースはありません";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PULSEAUDIO_SUPPORT:
+         return "PulseAudio対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PYTHON_SUPPORT:
+         return "Python(シェーダーにスクリプト)対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RBMP_SUPPORT:
+         return "BMP対応 (RBMP)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RETRORATING_LEVEL:
+         return "RetroRating level";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RJPEG_SUPPORT:
+         return "JPEG対応 (RJPEG)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ROARAUDIO_SUPPORT:
+         return "RoarAudio対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RPNG_SUPPORT:
+         return "PNG対応 (RPNG)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RSOUND_SUPPORT:
+         return "RSound対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RTGA_SUPPORT:
+         return "TGA対応 (RTGA)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL2_SUPPORT:
+         return "SDL2対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_IMAGE_SUPPORT:
+         return "SDLイメージ対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_SUPPORT:
+         return "SDL1.2対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SLANG_SUPPORT:
+         return "Slang対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_THREADING_SUPPORT:
+         return "スレッド対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_UDEV_SUPPORT:
+         return "Udev対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_V4L2_SUPPORT:
+         return "Video4Linux2対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VIDEO_CONTEXT_DRIVER:
+         return "ビデオのコンテクストドライバ";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VULKAN_SUPPORT:
+         return "Vulkan対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_WAYLAND_SUPPORT:
+         return "Wayland対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_X11_SUPPORT:
+         return "X11対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XAUDIO2_SUPPORT:
+         return "XAudio2対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XVIDEO_SUPPORT:
+         return "XVideo対応";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ZLIB_SUPPORT:
+         return "Zlib対応";
+      case MENU_ENUM_LABEL_VALUE_TAKE_SCREENSHOT:
+         return "スクリーンショットを撮る";
+      case MENU_ENUM_LABEL_VALUE_THREADED_DATA_RUNLOOP_ENABLE:
+         return "データループをスレッド化";
+      case MENU_ENUM_LABEL_VALUE_THUMBNAILS:
+         return "サムネイル";
+      case MENU_ENUM_LABEL_VALUE_THUMBNAILS_DIRECTORY:
+         return "サムネイルのディレクトリー";
+      case MENU_ENUM_LABEL_VALUE_THUMBNAILS_UPDATER_LIST:
+         return "サムネイルのアップデーター";
+      case MENU_ENUM_LABEL_VALUE_THUMBNAIL_MODE_BOXARTS:
+         return "Boxarts";
+      case MENU_ENUM_LABEL_VALUE_THUMBNAIL_MODE_SCREENSHOTS:
+         return "スクリーンショット";
+      case MENU_ENUM_LABEL_VALUE_THUMBNAIL_MODE_TITLE_SCREENS:
+         return "Title Screens";
+      case MENU_ENUM_LABEL_VALUE_TIMEDATE_ENABLE:
+         return "日付と時刻を表示";
+      case MENU_ENUM_LABEL_VALUE_TITLE_COLOR:
+         return "Menu title color";
+      case MENU_ENUM_LABEL_VALUE_TRUE:
+         return "真";
+      case MENU_ENUM_LABEL_VALUE_UI_COMPANION_ENABLE:
+         return "UI Companion Enable";
+      case MENU_ENUM_LABEL_VALUE_UI_COMPANION_START_ON_BOOT:
+         return "UI Companion Start On Boot";
+      case MENU_ENUM_LABEL_VALUE_UI_MENUBAR_ENABLE:
+         return "メニューバー";
+      case MENU_ENUM_LABEL_VALUE_UNABLE_TO_READ_COMPRESSED_FILE:
+         return "圧縮ファイルの読み込みは失敗しました。";
+      case MENU_ENUM_LABEL_VALUE_UNDO_LOAD_STATE:
+         return "保存状態のロードを前に戻す";
+      case MENU_ENUM_LABEL_VALUE_UNDO_SAVE_STATE:
+         return "状態の保存を前に戻す";
+      case MENU_ENUM_LABEL_VALUE_UNKNOWN:
+         return "Unknown";
+      case MENU_ENUM_LABEL_VALUE_UPDATER_SETTINGS:
+         return "アップデーター";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_ASSETS:
+         return "資産をアップデート";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_AUTOCONFIG_PROFILES:
+         return "自動コンフィグプロファイルをアップデート";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_CG_SHADERS:
+         return "Cgシェーダーをアップデート";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_CHEATS:
+         return "チーとをアップデート";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_CORE_INFO_FILES:
+         return "コアの情報ファイルをアップデート";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_DATABASES:
+         return "データベースをアップデート";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_GLSL_SHADERS:
+         return "GLSLシェーダーをアップデート";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_LAKKA:
+         return "Lakkaをアップデート";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_OVERLAYS:
+         return "オーバーレイをアップデート";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_SLANG_SHADERS:
+         return "Slangシェーダーをアップデート";
+      case MENU_ENUM_LABEL_VALUE_USER:
+         return "ユーザー";
+      case MENU_ENUM_LABEL_VALUE_USER_INTERFACE_SETTINGS:
+         return "ユーザーインターフェース";
+      case MENU_ENUM_LABEL_VALUE_USER_LANGUAGE:
+         return "言語";
+      case MENU_ENUM_LABEL_VALUE_USER_SETTINGS:
+         return "ユーザー";
+      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_IMAGE_VIEWER:
+         return "Use Builtin Image Viewer";
+      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_PLAYER:
+         return "Use Builtin Media Player";
+      case MENU_ENUM_LABEL_VALUE_USE_THIS_DIRECTORY:
+         return "<このフォルダを使用>";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ALLOW_ROTATE:
+         return "回転を許す";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_AUTO:
+         return "自動アスペクト比";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_INDEX:
+         return "アスペクト比のインデックス";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_BLACK_FRAME_INSERTION:
+         return "黒いフレームを挿入";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_CROP_OVERSCAN:
+         return "オーバースキャンをクロップ (再起動が必要)";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_DISABLE_COMPOSITION:
+         return "デスクトップのコンポジットを無効";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_DRIVER:
+         return "ビデオのドライバ";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER:
+         return "ビデオのフィルター";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_DIR:
+         return "ビデオフィルターのディレクトリー";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_FLICKER:
+         return "Flicker filter";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_ENABLE:
+         return "OSDメッセージを表示";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_PATH:
+         return "OSDメッセージのフォント";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_SIZE:
+         return "OSDメッセージのサイズ";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_ASPECT:
+         return "アスペクト比を強制";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_SRGB_DISABLE:
+         return "sRGB FBOを強制無効";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FRAME_DELAY:
+         return "フレームの遅れ";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FULLSCREEN:
+         return "フルスクリーンモード";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_GAMMA:
+         return "ビデオのガンマ";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_RECORD:
+         return "GPUの録画を有効";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_SCREENSHOT:
+         return "GPUスクリーンショットを有効";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC:
+         return "強制GPU同期";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC_FRAMES:
+         return "強制GPU同期フレーム";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MAX_SWAPCHAIN_IMAGES:
+         return "最高のスワップチェーンイメージ";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_X:
+         return "OSDメッセージのX位置";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_Y:
+         return "OSDメッセージのY位置";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MONITOR_INDEX:
+         return "モニタのインデックス";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_POST_FILTER_RECORD:
+         return "事後フィルターの録画を有効";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE:
+         return "リフレッシュレート";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE_AUTO:
+         return "モニタの予想フレームレート";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ROTATION:
+         return "回転";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE:
+         return "ウィンドウのスケール";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE_INTEGER:
+         return "整数スケール";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SETTINGS:
+         return "ビデオ";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_DIR:
+         return "ビデオシェーダーのディレクトリー";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_NUM_PASSES:
+         return "シェーダーのパス数";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PARAMETERS:
+         return "シェーダーのパラメータをプレビュー";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET:
+         return "シェーダーのプリセットをロード";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_PARAMETERS:
+         return "メニューのシェーダーパラメータ";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_AS:
+         return "シェーダーのプリセットを名前を付けて保存";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_CORE:
+         return "コアのプリセットを保存";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_GAME:
+         return "ゲームのプリセットを保存";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHARED_CONTEXT:
+         return "ハードウェアの共有コンテキストを有効";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SMOOTH:
+         return "ハードウェアのバイリニアフィルター";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SOFT_FILTER:
+         return "Soft Filter Enable";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SWAP_INTERVAL:
+         return "VSYNCのスワップ期間";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_TAB:
+         return "ビデオ";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_THREADED:
+         return "スレッドされているビデオ";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VFILTER:
+         return "Deflicker";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_HEIGHT:
+         return "カスタムのビューポートの縦幅";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_WIDTH:
+         return "カスタムのビューポートの横幅";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_X:
+         return "カスタムのビューポートのX";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_Y:
+         return "カスタムのビューポートのY";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VI_WIDTH:
+         return "Set VI Screen Width";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VSYNC:
+         return "VSYNC";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_WINDOWED_FULLSCREEN:
+         return "ウィンドウのフルスクリーンモード";
+      case MENU_ENUM_LABEL_VALUE_WIFI_DRIVER:
+         return "Wi-Fiのドライバ";
+      case MENU_ENUM_LABEL_VALUE_WIFI_SETTINGS:
+         return "Wi-Fi";
+      case MENU_ENUM_LABEL_VALUE_XMB_ALPHA_FACTOR:
+         return "メニューの透明性";
+      case MENU_ENUM_LABEL_VALUE_XMB_FONT:
+         return "メニューのフォント";
+      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_CUSTOM:
+         return "カスタム";
+      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_FLATUI:
+         return "フラットUI";
+      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_MONOCHROME:
+         return "モノクローム";
+      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_MONOCHROME_JAGGED:
+         return "モノクロームぎざぎざ";
+      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_PIXEL:
+         return "ピクセル";
+      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_RETROACTIVE:
+         return "レトロアクティブ";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME:
+         return "メニューの色テーマ";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_APPLE_GREEN:
+         return "りんご緑";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_DARK:
+         return "ダーク";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_DARK_PURPLE:
+         return "ぶどう色";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_ELECTRIC_BLUE:
+         return "電子ブルー";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_GOLDEN:
+         return "ゴールデン";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_LEGACY_RED:
+         return "レガシーレッド";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_MIDNIGHT_BLUE:
+         return "ミッドナイトブルー";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_PLAIN:
+         return "プレーン";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_UNDERSEA:
+         return "海底";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_VOLCANIC_RED:
+         return "火山レッド";
+      case MENU_ENUM_LABEL_VALUE_XMB_RIBBON_ENABLE:
+         return "メニューのシェーダーパイプライン";
+      case MENU_ENUM_LABEL_VALUE_XMB_SCALE_FACTOR:
+         return "メニューの倍率";
+      case MENU_ENUM_LABEL_VALUE_XMB_SHADOWS_ENABLE:
+         return "アイコンの影を有効";
+      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_HISTORY:
+         return "履歴タブを表示";
+      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_IMAGES:
+         return "画像タブを表示";
+      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_MUSIC:
+         return "音楽タブを表示";
+      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_SETTINGS:
+         return "設定タブを表示";
+      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_VIDEO:
+         return "ビデオタブを表示";
+      case MENU_ENUM_LABEL_VALUE_XMB_THEME:
+         return "メニューのアイコンテーマ";
+      case MENU_ENUM_LABEL_VALUE_YES:
+         return "はい";
+      case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_TWO:
+         return "シェーダーのプリセット";
+      case MENU_ENUM_SUBLABEL_ADD_CONTENT_LIST:
+         return "コンテンツをスキャンしてデータベースに入れる。";
+      case MENU_ENUM_SUBLABEL_AUDIO_SETTINGS:
+         return "オーディオ出力の設定を変更する。";
+      case MENU_ENUM_SUBLABEL_BLUETOOTH_ENABLE:
+         return "Bluetoothを有効する。";
+      case MENU_ENUM_SUBLABEL_CONFIG_SAVE_ON_EXIT:
+         return "終了時に設定を自動的に保存する。";
+      case MENU_ENUM_SUBLABEL_CPU_CORES:
+         return "CPUのコア数";
+      case MENU_ENUM_SUBLABEL_FPS_SHOW:
+         return "画面で現在のフレームレートを表示する。";
+      case MENU_ENUM_SUBLABEL_INPUT_HOTKEY_BINDS:
+         return "ホットキー設定を変更する。";
+      case MENU_ENUM_SUBLABEL_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
+         return "メニューに切り替えるゲームパッドのボタンコンボ";
+      case MENU_ENUM_SUBLABEL_INPUT_SETTINGS:
+         return "ゲームパッド、キーボード、マウスの設定を変更する。";
+      case MENU_ENUM_SUBLABEL_INPUT_USER_BINDS:
+         return "このユーザーの入力設定を変更する。";
+      case MENU_ENUM_SUBLABEL_LOG_VERBOSITY:
+         return "端末にログすることを有効と無効。";
+      case MENU_ENUM_SUBLABEL_NETPLAY:
+         return "ネットプレイのセッションを参加やホストする。";
+      case MENU_ENUM_SUBLABEL_ONLINE_UPDATER:
+         return "RetroArchにアドオン、コンポーネント、コンテンツをダウンロードする。";
+      case MENU_ENUM_SUBLABEL_SAMBA_ENABLE:
+         return "フォルダのネットワーク共有を有効する。";
+      case MENU_ENUM_SUBLABEL_SERVICES_SETTINGS:
+         return "OS関係のサービスを管理する。";
+      case MENU_ENUM_SUBLABEL_SHOW_HIDDEN_FILES:
+         return "ファイルブラウザーの中に隠しファイルとフォルダを表示する。";
+      case MENU_ENUM_SUBLABEL_SSH_ENABLE:
+         return "SSHでのアクセスを有効する。";
+      case MENU_ENUM_SUBLABEL_SUSPEND_SCREENSAVER_ENABLE:
+         return "システムのスクリーンセーバーをアクティブになることを予防する。";
+      case MENU_ENUM_SUBLABEL_USER_LANGUAGE:
+         return "インタフェースの言語を変更する。";
+      case MENU_ENUM_SUBLABEL_VIDEO_BLACK_FRAME_INSERTION:
+         return "フレームの間で黒フレームを挿入する。60Hzコンテンツを120Hzモニターでやることを役に立つ。";
+      case MENU_ENUM_SUBLABEL_VIDEO_FRAME_DELAY:
+         return "遅延が減るけどビデオ途切れの危険率が増す。";
+      case MENU_ENUM_SUBLABEL_VIDEO_HARD_SYNC_FRAMES:
+         return "CPUが「強制GPU同期」を使用時にGPUからの最高のフレーム前進を選択する。";
+      case MENU_ENUM_SUBLABEL_VIDEO_MAX_SWAPCHAIN_IMAGES:
+         return "指定するバッファーモードをビデオドライバに伝える。";
+      case MENU_ENUM_SUBLABEL_VIDEO_MONITOR_INDEX:
+         return "希望するモニターを選択する。";
+      case MENU_ENUM_SUBLABEL_VIDEO_REFRESH_RATE_AUTO:
+         return "モニターの正確な推定のモニターリフレッシュレート";
+      case MENU_ENUM_SUBLABEL_VIDEO_SETTINGS:
+         return "ビデオ出力の設定を変える。";
+      case MENU_ENUM_SUBLABEL_WIFI_SETTINGS:
+         return "無線ネットワークを検索して接続する。";
+      case MSG_APPENDED_DISK:
+         return "Appended disk";
+      case MSG_APPLICATION_DIR:
+         return "アプリフォルダ";
+      case MSG_APPLYING_CHEAT:
+         return "Applying cheat changes.";
+      case MSG_APPLYING_SHADER:
+         return "Applying shader";
+      case MSG_AUDIO_MUTED:
+         return "Audio muted.";
+      case MSG_AUDIO_UNMUTED:
+         return "Audio unmuted.";
+      case MSG_AUTOCONFIG_FILE_ERROR_SAVING:
+         return "Error saving autoconf file.";
+      case MSG_AUTOCONFIG_FILE_SAVED_SUCCESSFULLY:
+         return "Autoconfig file saved successfully.";
+      case MSG_AUTOSAVE_FAILED:
+         return "Could not initialize autosave.";
+      case MSG_AUTO_SAVE_STATE_TO:
+         return "Auto save state to";
+      case MSG_BLOCKING_SRAM_OVERWRITE:
+         return "Blocking SRAM Overwrite";
+      case MSG_BRINGING_UP_COMMAND_INTERFACE_ON_PORT:
+         return "Bringing up command interface on port";
+      case MSG_BYTES:
+         return "bytes";
+      case MSG_CANNOT_INFER_NEW_CONFIG_PATH:
+         return "Cannot infer new config path. Use current time.";
+      case MSG_CHEEVOS_HARDCORE_MODE_ENABLE:
+         return "Hardcore Mode Enabled: savestate & rewind were disabled.";
+      case MSG_COMPARING_WITH_KNOWN_MAGIC_NUMBERS:
+         return "Comparing with known magic numbers...";
+      case MSG_COMPILED_AGAINST_API:
+         return "Compiled against API";
+      case MSG_CONFIG_DIRECTORY_NOT_SET:
+         return "Config directory not set. Cannot save new config.";
+      case MSG_CONNECTED_TO:
+         return "Connected to";
+      case MSG_CONTENT_CRC32S_DIFFER:
+         return "Content CRC32s differ. Cannot use different games.";
+      case MSG_CONTENT_LOADING_SKIPPED_IMPLEMENTATION_WILL_DO_IT:
+         return "Content loading skipped. Implementation will load it on its own.";
+      case MSG_CORE_DOES_NOT_SUPPORT_SAVESTATES:
+         return "Core does not support save states.";
+      case MSG_CORE_OPTIONS_FILE_CREATED_SUCCESSFULLY:
+         return "Core options file created successfully.";
+      case MSG_COULD_NOT_FIND_ANY_NEXT_DRIVER:
+         return "Could not find any next driver";
+      case MSG_COULD_NOT_FIND_COMPATIBLE_SYSTEM:
+         return "Could not find compatible system.";
+      case MSG_COULD_NOT_FIND_VALID_DATA_TRACK:
+         return "Could not find valid data track";
+      case MSG_COULD_NOT_OPEN_DATA_TRACK:
+         return "could not open data track";
+      case MSG_COULD_NOT_READ_CONTENT_FILE:
+         return "Could not read content file";
+      case MSG_COULD_NOT_READ_MOVIE_HEADER:
+         return "Could not read movie header.";
+      case MSG_COULD_NOT_READ_STATE_FROM_MOVIE:
+         return "Could not read state from movie.";
+      case MSG_CRC32_CHECKSUM_MISMATCH:
+         return "CRC32 checksum mismatch between content file and saved content checksum in replay file header; replay highly likely to desync on playback.";
+      case MSG_CUSTOM_TIMING_GIVEN:
+         return "Custom timing given";
+      case MSG_DECOMPRESSION_ALREADY_IN_PROGRESS:
+         return "Decompression already in progress.";
+      case MSG_DECOMPRESSION_FAILED:
+         return "Decompression failed.";
+      case MSG_DETECTED_VIEWPORT_OF:
+         return "Detected viewport of";
+      case MSG_DID_NOT_FIND_A_VALID_CONTENT_PATCH:
+         return "Did not find a valid content patch.";
+      case MSG_DISCONNECT_DEVICE_FROM_A_VALID_PORT:
+         return "Disconnect device from a valid port.";
+      case MSG_DISK_CLOSED:
+         return "Closed";
+      case MSG_DISK_EJECTED:
+         return "Ejected";
+      case MSG_DOWNLOADING:
+         return "ダウンロード中";
+      case MSG_DOWNLOAD_FAILED:
+         return "Download failed";
+      case MSG_ERROR:
+         return "Error";
+      case MSG_ERROR_LIBRETRO_CORE_REQUIRES_CONTENT:
+         return "Libretro core requires content, but nothing was provided.";
+      case MSG_ERROR_LIBRETRO_CORE_REQUIRES_SPECIAL_CONTENT:
+         return "Libretro core requires special content, but none were provided.";
+      case MSG_ERROR_PARSING_ARGUMENTS:
+         return "Error parsing arguments.";
+      case MSG_ERROR_SAVING_CORE_OPTIONS_FILE:
+         return "Error saving core options file.";
+      case MSG_ERROR_SAVING_REMAP_FILE:
+         return "Error saving remap file.";
+      case MSG_ERROR_SAVING_SHADER_PRESET:
+         return "Error saving shader preset.";
+      case MSG_EXTERNAL_APPLICATION_DIR:
+         return "外部アプリフォルダ";
+      case MSG_EXTRACTING:
+         return "解凍中";
+      case MSG_EXTRACTING_FILE:
+         return "ファイルを解凍中";
+      case MSG_FAILED_SAVING_CONFIG_TO:
+         return "Failed saving config to";
+      case MSG_FAILED_TO:
+         return "Failed to";
+      case MSG_FAILED_TO_ACCEPT_INCOMING_SPECTATOR:
+         return "Failed to accept incoming spectator.";
+      case MSG_FAILED_TO_ALLOCATE_MEMORY_FOR_PATCHED_CONTENT:
+         return "Failed to allocate memory for patched content...";
+      case MSG_FAILED_TO_APPLY_SHADER:
+         return "Failed to apply shader.";
+      case MSG_FAILED_TO_BIND_SOCKET:
+         return "Failed to bind socket.";
+      case MSG_FAILED_TO_CREATE_THE_DIRECTORY:
+         return "Failed to create the directory.";
+      case MSG_FAILED_TO_EXTRACT_CONTENT_FROM_COMPRESSED_FILE:
+         return "Failed to extract content from compressed file";
+      case MSG_FAILED_TO_GET_NICKNAME_FROM_CLIENT:
+         return "Failed to get nickname from client.";
+      case MSG_FAILED_TO_LOAD:
+         return "Failed to load";
+      case MSG_FAILED_TO_LOAD_CONTENT:
+         return "Failed to load content";
+      case MSG_FAILED_TO_LOAD_MOVIE_FILE:
+         return "Failed to load movie file";
+      case MSG_FAILED_TO_LOAD_OVERLAY:
+         return "Failed to load overlay.";
+      case MSG_FAILED_TO_LOAD_STATE:
+         return "Failed to load state from";
+      case MSG_FAILED_TO_OPEN_LIBRETRO_CORE:
+         return "Failed to open libretro core";
+      case MSG_FAILED_TO_PATCH:
+         return "パッチに失敗しました";
+      case MSG_FAILED_TO_RECEIVE_HEADER_FROM_CLIENT:
+         return "Failed to receive header from client.";
+      case MSG_FAILED_TO_RECEIVE_NICKNAME:
+         return "Failed to receive nickname.";
+      case MSG_FAILED_TO_RECEIVE_NICKNAME_FROM_HOST:
+         return "Failed to receive nickname from host.";
+      case MSG_FAILED_TO_RECEIVE_NICKNAME_SIZE_FROM_HOST:
+         return "Failed to receive nickname size from host.";
+      case MSG_FAILED_TO_RECEIVE_SRAM_DATA_FROM_HOST:
+         return "Failed to receive SRAM data from host.";
+      case MSG_FAILED_TO_REMOVE_DISK_FROM_TRAY:
+         return "Failed to remove disk from tray.";
+      case MSG_FAILED_TO_REMOVE_TEMPORARY_FILE:
+         return "Failed to remove temporary file";
+      case MSG_FAILED_TO_SAVE_SRAM:
+         return "Failed to save SRAM";
+      case MSG_FAILED_TO_SAVE_STATE_TO:
+         return "Failed to save state to";
+      case MSG_FAILED_TO_SEND_NICKNAME:
+         return "Failed to send nickname.";
+      case MSG_FAILED_TO_SEND_NICKNAME_SIZE:
+         return "Failed to send nickname size.";
+      case MSG_FAILED_TO_SEND_NICKNAME_TO_CLIENT:
+         return "Failed to send nickname to client.";
+      case MSG_FAILED_TO_SEND_NICKNAME_TO_HOST:
+         return "Failed to send nickname to host.";
+      case MSG_FAILED_TO_SEND_SRAM_DATA_TO_CLIENT:
+         return "Failed to send SRAM data to client.";
+      case MSG_FAILED_TO_START_AUDIO_DRIVER:
+         return "Failed to start audio driver. Will continue without audio.";
+      case MSG_FAILED_TO_START_MOVIE_RECORD:
+         return "Failed to start movie record.";
+      case MSG_FAILED_TO_START_RECORDING:
+         return "Failed to start recording.";
+      case MSG_FAILED_TO_TAKE_SCREENSHOT:
+         return "Failed to take screenshot.";
+      case MSG_FAILED_TO_UNDO_LOAD_STATE:
+         return "Failed to undo load state.";
+      case MSG_FAILED_TO_UNDO_SAVE_STATE:
+         return "Failed to undo save state.";
+      case MSG_FAILED_TO_UNMUTE_AUDIO:
+         return "Failed to unmute audio.";
+      case MSG_FATAL_ERROR_RECEIVED_IN:
+         return "Fatal error received in";
+      case MSG_FILE_NOT_FOUND:
+         return "File not found";
+      case MSG_FOUND_AUTO_SAVESTATE_IN:
+         return "Found auto savestate in";
+      case MSG_FOUND_DISK_LABEL:
+         return "Found disk label";
+      case MSG_FOUND_FIRST_DATA_TRACK_ON_FILE:
+         return "Found first data track on file";
+      case MSG_FOUND_LAST_STATE_SLOT:
+         return "Found last state slot";
+      case MSG_FOUND_SHADER:
+         return "Found shader";
+      case MSG_FRAMES:
+         return "フレーム";
+      case MSG_GAME_SPECIFIC_CORE_OPTIONS_FOUND_AT:
+         return "Per-Game Options: game-specific core options found at";
+      case MSG_GOT_INVALID_DISK_INDEX:
+         return "Got invalid disk index.";
+      case MSG_GRAB_MOUSE_STATE:
+         return "Grab mouse state";
+      case MSG_HW_RENDERED_MUST_USE_POSTSHADED_RECORDING:
+         return "Libretro core is hardware rendered. Must use post-shaded recording as well.";
+      case MSG_INFLATED_CHECKSUM_DID_NOT_MATCH_CRC32:
+         return "Inflated checksum did not match CRC32.";
+      case MSG_INPUT_CHEAT:
+         return "Input Cheat";
+      case MSG_INPUT_CHEAT_FILENAME:
+         return "Cheat Filename";
+      case MSG_INPUT_PRESET_FILENAME:
+         return "Preset Filename";
+      case MSG_INTERFACE:
+         return "インターフェース";
+      case MSG_INTERNAL_MEMORY:
+         return "内部メモリ";
+      case MSG_INVALID_NICKNAME_SIZE:
+         return "Invalid nickname size.";
+      case MSG_IN_BYTES:
+         return "(バイトで)";
+      case MSG_IN_GIGABYTES:
+         return "(ギガバイトで)";
+      case MSG_IN_MEGABYTES:
+         return "(メガバイトで)";
+      case MSG_LIBRETRO_ABI_BREAK:
+         return "is compiled against a different version of libretro than this libretro implementation.";
+      case MSG_LIBRETRO_FRONTEND:
+         return "libretroのフロントエンド";
+      case MSG_LOADED_STATE_FROM_SLOT:
+         return "Loaded state from slot";
+      case MSG_LOADING:
+         return "ロード中";
+      case MSG_LOADING_CONTENT_FILE:
+         return "Loading content file";
+      case MSG_LOADING_HISTORY_FILE:
+         return "Loading history file";
+      case MSG_LOADING_STATE:
+         return "Loading state";
+      case MSG_MEMORY:
+         return "メモリ";
+      case MSG_MOVIE_FILE_IS_NOT_A_VALID_BSV1_FILE:
+         return "Movie file is not a valid BSV1 file.";
+      case MSG_MOVIE_FORMAT_DIFFERENT_SERIALIZER_VERSION:
+         return "Movie format seems to have a different serializer version. Will most likely fail.";
+      case MSG_MOVIE_PLAYBACK_ENDED:
+         return "Movie playback ended.";
+      case MSG_MOVIE_RECORD_STOPPED:
+         return "Stopping movie record.";
+      case MSG_NETPLAY_FAILED:
+         return "Failed to initialize netplay.";
+      case MSG_NETPLAY_FAILED_MOVIE_PLAYBACK_HAS_STARTED:
+         return "Movie playback has started. Cannot start netplay.";
+      case MSG_NO_CONTENT_STARTING_DUMMY_CORE:
+         return "No content, starting dummy core.";
+      case MSG_NO_SAVE_STATE_HAS_BEEN_OVERWRITTEN_YET:
+         return "No save state has been overwritten yet.";
+      case MSG_NO_STATE_HAS_BEEN_LOADED_YET:
+         return "No state has been loaded yet.";
+      case MSG_OVERRIDES_ERROR_SAVING:
+         return "Error saving overrides.";
+      case MSG_OVERRIDES_SAVED_SUCCESSFULLY:
+         return "Overrides saved successfully.";
+      case MSG_PAUSED:
+         return "Paused.";
+      case MSG_PROGRAM:
+         return "RetroArch";
+      case MSG_READING_FIRST_DATA_TRACK:
+         return "Reading first data track...";
+      case MSG_RECEIVED:
+         return "received";
+      case MSG_RECORDING_TERMINATED_DUE_TO_RESIZE:
+         return "Recording terminated due to resize.";
+      case MSG_RECORDING_TO:
+         return "Recording to";
+      case MSG_REDIRECTING_CHEATFILE_TO:
+         return "Redirecting cheat file to";
+      case MSG_REDIRECTING_SAVEFILE_TO:
+         return "Redirecting save file to";
+      case MSG_REDIRECTING_SAVESTATE_TO:
+         return "Redirecting savestate to";
+      case MSG_REMAP_FILE_SAVED_SUCCESSFULLY:
+         return "Remap file saved successfully.";
+      case MSG_REMOVED_DISK_FROM_TRAY:
+         return "Removed disk from tray.";
+      case MSG_REMOVING_TEMPORARY_CONTENT_FILE:
+         return "Removing temporary content file";
+      case MSG_RESET:
+         return "Reset";
+      case MSG_RESTARTING_RECORDING_DUE_TO_DRIVER_REINIT:
+         return "Restarting recording due to driver reinit.";
+      case MSG_RESTORED_OLD_SAVE_STATE:
+         return "Restored old save state.";
+      case MSG_RESTORING_DEFAULT_SHADER_PRESET_TO:
+         return "Shaders: restoring default shader preset to";
+      case MSG_REVERTING_SAVEFILE_DIRECTORY_TO:
+         return "Reverting savefile directory to";
+      case MSG_REVERTING_SAVESTATE_DIRECTORY_TO:
+         return "Reverting savestate directory to";
+      case MSG_REWINDING:
+         return "巻き戻しています。";
+      case MSG_REWIND_INIT:
+         return "Initializing rewind buffer with size";
+      case MSG_REWIND_INIT_FAILED:
+         return "Failed to initialize rewind buffer. Rewinding will be disabled.";
+      case MSG_REWIND_INIT_FAILED_THREADED_AUDIO:
+         return "Implementation uses threaded audio. Cannot use rewind.";
+      case MSG_REWIND_REACHED_END:
+         return "Reached end of rewind buffer.";
+      case MSG_SAVED_NEW_CONFIG_TO:
+         return "Saved new config to";
+      case MSG_SAVED_STATE_TO_SLOT:
+         return "Saved state to slot";
+      case MSG_SAVED_SUCCESSFULLY_TO:
+         return "Saved successfully to";
+      case MSG_SAVING_RAM_TYPE:
+         return "Saving RAM type";
+      case MSG_SAVING_STATE:
+         return "Saving state";
+      case MSG_SCANNING:
+         return "スキャン中";
+      case MSG_SCANNING_OF_DIRECTORY_FINISHED:
+         return "Scanning of directory finished";
+      case MSG_SENDING_COMMAND:
+         return "Sending command";
+      case MSG_SEVERAL_PATCHES_ARE_EXPLICITLY_DEFINED:
+         return "Several patches are explicitly defined, ignoring all...";
+      case MSG_SHADER:
+         return "シェーダー";
+      case MSG_SHADER_PRESET_SAVED_SUCCESSFULLY:
+         return "Shader preset saved successfully.";
+      case MSG_SKIPPING_SRAM_LOAD:
+         return "Skipping SRAM load.";
+      case MSG_SLOW_MOTION:
+         return "スローモーション。";
+      case MSG_SLOW_MOTION_REWIND:
+         return "スローモーション巻き戻し。";
+      case MSG_SORRY_UNIMPLEMENTED_CORES_DONT_DEMAND_CONTENT_NETPLAY:
+         return "Sorry, unimplemented: cores that don't demand content cannot participate in netplay.";
+      case MSG_SRAM_WILL_NOT_BE_SAVED:
+         return "SRAM will not be saved.";
+      case MSG_STARTING_MOVIE_PLAYBACK:
+         return "Starting movie playback.";
+      case MSG_STARTING_MOVIE_RECORD_TO:
+         return "Starting movie record to";
+      case MSG_STATE_SIZE:
+         return "State size";
+      case MSG_STATE_SLOT:
+         return "保存状態のスロット";
+      case MSG_TAKING_SCREENSHOT:
+         return "Taking screenshot.";
+      case MSG_TO:
+         return "to";
+      case MSG_UNDID_LOAD_STATE:
+         return "保存状態のロードを前に戻した。";
+      case MSG_UNDOING_SAVE_STATE:
+         return "Undoing save state";
+      case MSG_UNKNOWN:
+         return "Unknown";
+      case MSG_UNPAUSED:
+         return "Unpaused.";
+      case MSG_UNRECOGNIZED_COMMAND:
+         return "Unrecognized command";
+      case MSG_USING_CORE_NAME_FOR_NEW_CONFIG:
+         return "Using core name for new config.";
+      case MSG_USING_LIBRETRO_DUMMY_CORE_RECORDING_SKIPPED:
+         return "Using libretro dummy core. Skipping recording.";
+      case MSG_VALUE_CONNECT_DEVICE_FROM_A_VALID_PORT:
+         return "Connect device from a valid port.";
+      case MSG_VALUE_DISCONNECTING_DEVICE_FROM_PORT:
+         return "Disconnecting device from port";
+      case MSG_VALUE_REBOOTING:
+         return "再起動しています。。。";
+      case MSG_VALUE_SHUTTING_DOWN:
+         return "シャットダウンしています。。。";
+      case MSG_VERSION_OF_LIBRETRO_API:
+         return "Version of libretro API";
+      case MSG_VIEWPORT_SIZE_CALCULATION_FAILED:
+         return "Viewport size calculation failed! Will continue using raw data. This will probably not work right ...";
+      case MSG_VIRTUAL_DISK_TRAY:
+         return "virtual disk tray.";
       default:
 #if 0
          RARCH_LOG("Unimplemented: [%d]\n", msg);

--- a/intl/msg_hash_nl.c
+++ b/intl/msg_hash_nl.c
@@ -45,876 +45,876 @@ const char *msg_hash_to_str_nl(enum msg_hash_enums msg)
 {
    switch (msg)
    {
-      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG:
-         return "Huidige configuratie opslaan";
-      case MENU_ENUM_LABEL_VALUE_HELP_SCANNING_CONTENT:
-         return "Scannen naar Content";
-      case MENU_ENUM_LABEL_VALUE_HELP_AUDIO_VIDEO_TROUBLESHOOTING:
-         return "Audio/Video Raadpleging";
-      case MENU_ENUM_LABEL_VALUE_HELP_CHANGE_VIRTUAL_GAMEPAD:
-         return "Virtuele Gamepad Overlay Veranderen";
-      case MENU_ENUM_LABEL_VALUE_HELP_WHAT_IS_A_CORE:
-         return "Wat is een Core?";
-      case MENU_ENUM_LABEL_VALUE_HELP_LOADING_CONTENT:
-         return "Hoe Laad je Content?";
-      case MENU_ENUM_LABEL_VALUE_HELP_LIST:
-         return "Help";
-      case MENU_ENUM_LABEL_VALUE_HELP_CONTROLS:
-         return "Basis Menu Besturing";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS:
-         return "Basis menu besturing";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_SCROLL_UP:
-         return "Omhoog Scrollen";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_SCROLL_DOWN:
-         return "Omlaag Scrollen";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_CONFIRM:
-         return "Bevestigen/OK";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_BACK:
-         return "Terug";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_START:
-         return "Reset";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_INFO:
-         return "Info";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_TOGGLE_MENU:
-         return "Menu Schakelaar";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_QUIT:
-         return "Afsluiten";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_TOGGLE_KEYBOARD:
-         return "Keyboard Toggle";
-      case MENU_ENUM_LABEL_VALUE_OPEN_ARCHIVE:
-         return "Open Archief als map";
-      case MENU_ENUM_LABEL_VALUE_LOAD_ARCHIVE:
-         return "Open Archief met Core";
-      case MENU_ENUM_LABEL_VALUE_INPUT_BACK_AS_MENU_TOGGLE_ENABLE:
-         return "Terug als Menu Schakelaar";
-      case MENU_ENUM_LABEL_VALUE_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
-         return "Menu Schakelaar Gamepad Combo";
-      case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_HIDE_IN_MENU:
-         return "Verberg Overlay In Menu";
-      case MENU_ENUM_LABEL_VALUE_LANG_POLISH:
-         return "Pools";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_AUTOLOAD_PREFERRED:
-         return "Laad geprefeerd overlay autom.";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_CORE_INFO_FILES:
-         return "Update Core Info Bestanden";
-      case MENU_ENUM_LABEL_VALUE_DOWNLOAD_CORE_CONTENT:
-         return "Download Inhoud";
-      case MENU_ENUM_LABEL_VALUE_SCAN_THIS_DIRECTORY:
-         return "<Scan Deze Map>";
-      case MENU_ENUM_LABEL_VALUE_SCAN_FILE:
-         return "Scan een Bestand";
-      case MENU_ENUM_LABEL_VALUE_SCAN_DIRECTORY:
-         return "Scan een Map";
       case MENU_ENUM_LABEL_VALUE_ADD_CONTENT_LIST:
          return "Content toevoegen";
-      case MENU_ENUM_LABEL_VALUE_INFORMATION_LIST:
-         return "Informatie";
-      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_PLAYER:
-         return "Gebruik Ingebouwde Media Speler";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_SETTINGS:
-         return "Snelmenu";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_CRC32:
-         return "CRC32";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_MD5:
-         return "MD5";
-      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_LIST:
-         return "Laad Inhoud";
-      case MENU_ENUM_LABEL_VALUE_ASK_ARCHIVE:
-         return "Keuze";
-      case MENU_ENUM_LABEL_VALUE_PRIVACY_SETTINGS:
-         return "Privacy";
-      case MENU_ENUM_LABEL_VALUE_HORIZONTAL_MENU:
-         return "Horizontal Menu";
-      case MENU_ENUM_LABEL_VALUE_SETTINGS_TAB:
-         return "Instellingen";
-      case MENU_ENUM_LABEL_VALUE_MUSIC_TAB:
-         return "Muziek";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_TAB:
-         return "Video";
-      case MENU_ENUM_LABEL_VALUE_IMAGES_TAB:
-         return "Afbeeldingen";
-      case MENU_ENUM_LABEL_VALUE_PLAYLISTS_TAB:
-         return "Afspeellijsten";
-      case MENU_ENUM_LABEL_VALUE_HISTORY_TAB:
-         return "Geschiedenis";
       case MENU_ENUM_LABEL_VALUE_ADD_TAB:
          return "Importeer inhoud";
-      case MENU_ENUM_LABEL_VALUE_NO_SETTINGS_FOUND:
-         return "Geen instellingen gevonden.";
-      case MENU_ENUM_LABEL_VALUE_NO_PERFORMANCE_COUNTERS:
-         return "Geen prestatie tellers.";
-      case MENU_ENUM_LABEL_VALUE_DRIVER_SETTINGS:
-         return "Driver";
-      case MENU_ENUM_LABEL_VALUE_CONFIGURATION_SETTINGS:
-         return "Configuratie";
-      case MENU_ENUM_LABEL_VALUE_CORE_SETTINGS:
-         return "Core";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SETTINGS:
-         return "Video";
-      case MENU_ENUM_LABEL_VALUE_LOGGING_SETTINGS:
-         return "Logging";
-      case MENU_ENUM_LABEL_VALUE_SAVING_SETTINGS:
-         return "Saving";
-      case MENU_ENUM_LABEL_VALUE_REWIND_SETTINGS:
-         return "Rewind";
-      case MENU_ENUM_LABEL_VALUE_SHADER:
-         return "Shader";
-      case MENU_ENUM_LABEL_VALUE_CHEAT:
-         return "Cheat";
-      case MENU_ENUM_LABEL_VALUE_USER:
-         return "Gebruiker";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_BGM_ENABLE:
-         return "Systeem BGM";
-      case MENU_ENUM_LABEL_VALUE_RETROPAD:
-         return "RetroPad";
-      case MENU_ENUM_LABEL_VALUE_RETROKEYBOARD:
-         return "RetroKeyboard";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_BLOCK_FRAMES:
-         return "Block Frames";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_LABEL_SHOW:
-         return "Descriptie Labels Weergeven";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_HIDE_UNBOUND:
-         return "Verbergen Niet-gemapte Core Input Descripties";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_ENABLE:
-         return "OSD Berichten Weergeven";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_PATH:
-         return "OSD Berichten Font";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_SIZE:
-         return "OSD Berichten Grootte";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_X:
-         return "OSD Berichten X-as positie";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_Y:
-         return "OSD Berichten Y-as positie";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SOFT_FILTER:
-         return "Soft Filter";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_FLICKER:
-         return "Flicker filter";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_CONTENT:
-         return "<Content dir>";
-      case MENU_ENUM_LABEL_VALUE_UNKNOWN:
-         return "Onbekend";
-      case MENU_ENUM_LABEL_VALUE_DONT_CARE:
-         return "Onbelangrijk";
-      case MENU_ENUM_LABEL_VALUE_LINEAR:
-         return "Linear";
-      case MENU_ENUM_LABEL_VALUE_NEAREST:
-         return "Nearest";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_DEFAULT:
-         return "<Standaard>";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NONE:
-         return "<Niets>";
-      case MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE:
-         return "N.v.t";
-      case MENU_ENUM_LABEL_VALUE_INPUT_REMAPPING_DIRECTORY:
-         return "Invoer Remapping Map";
-      case MENU_ENUM_LABEL_VALUE_JOYPAD_AUTOCONFIG_DIR:
-         return "Invoerapparaten Autoconfig Map";
-      case MENU_ENUM_LABEL_VALUE_RECORDING_CONFIG_DIRECTORY:
-         return "Opname Config Map";
-      case MENU_ENUM_LABEL_VALUE_RECORDING_OUTPUT_DIRECTORY:
-         return "Opname Uitvoer Map";
-      case MENU_ENUM_LABEL_VALUE_SCREENSHOT_DIRECTORY:
-         return "Screenshot Map";
-      case MENU_ENUM_LABEL_VALUE_PLAYLIST_DIRECTORY:
-         return "Afspeellijsten Map";
-      case MENU_ENUM_LABEL_VALUE_SAVEFILE_DIRECTORY:
-         return "Savebestand Map";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_DIRECTORY:
-         return "Savestate Map";
-      case MENU_ENUM_LABEL_VALUE_STDIN_CMD_ENABLE:
-         return "stdin Commandos";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_DRIVER:
-         return "Video Driver";
-      case MENU_ENUM_LABEL_VALUE_RECORD_ENABLE:
-         return "Opname";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_RECORD:
-         return "GPU Opname";
-      case MENU_ENUM_LABEL_VALUE_RECORD_PATH:
-         return "Uitvoer Bestand";
-      case MENU_ENUM_LABEL_VALUE_RECORD_USE_OUTPUT_DIRECTORY:
-         return "Gebruik uitvoer map";
-      case MENU_ENUM_LABEL_VALUE_RECORD_CONFIG:
-         return "Opname Configuratie";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_POST_FILTER_RECORD:
-         return "Post filter opname activeren";
-      case MENU_ENUM_LABEL_VALUE_CORE_ASSETS_DIRECTORY:
-         return "Downloads Map";
-      case MENU_ENUM_LABEL_VALUE_ASSETS_DIRECTORY:
-         return "Assets Map";
-      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPERS_DIRECTORY:
-         return "Dynamische Wallpapers Map";
-      case MENU_ENUM_LABEL_VALUE_RGUI_BROWSER_DIRECTORY:
-         return "Bestandsbeheer Map";
-      case MENU_ENUM_LABEL_VALUE_RGUI_CONFIG_DIRECTORY:
-         return "Config Map";
-      case MENU_ENUM_LABEL_VALUE_LIBRETRO_INFO_PATH:
-         return "Core Info Map";
-      case MENU_ENUM_LABEL_VALUE_LIBRETRO_DIR_PATH:
-         return "Core Map";
-      case MENU_ENUM_LABEL_VALUE_CURSOR_DIRECTORY:
-         return "Cursor Map";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_DATABASE_DIRECTORY:
-         return "Content Database Map";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_DIRECTORY:
-         return "Systeem/BIOS Map";
-      case MENU_ENUM_LABEL_VALUE_CHEAT_DATABASE_PATH:
-         return "Cheat Bestand Map";
-      case MENU_ENUM_LABEL_VALUE_CACHE_DIRECTORY:
-         return "Cache Map";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_FILTER_DIR:
-         return "Audio Filter Map";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_DIR:
-         return "Video Shader Map";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_DIR:
-         return "Video Filter Map";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_DIRECTORY:
-         return "Overlay Map";
-      case MENU_ENUM_LABEL_VALUE_OSK_OVERLAY_DIRECTORY:
-         return "OSK Overlay Map";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT: /* TODO: Original string changed */
-         return "Swap Netplay Input";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE:
-         return "Netplay Spectator Activeren";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS: /* TODO: Original string changed */
-         return "IP Adres";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT:
-         return "Netplay TCP/UDP Poort";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE:
-         return "Netplay Activeren";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_DELAY_FRAMES:
-         return "Netplay Vertraging Frames";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_MODE:
-         return "Netplay Client Activeren";
-      case MENU_ENUM_LABEL_VALUE_RGUI_SHOW_START_SCREEN:
-         return "Start Scherm Weergeven";
-      case MENU_ENUM_LABEL_VALUE_TITLE_COLOR:
-         return "Menu titel kleur";
-      case MENU_ENUM_LABEL_VALUE_ENTRY_HOVER_COLOR:
-         return "Menu entry hover kleur";
-      case MENU_ENUM_LABEL_VALUE_TIMEDATE_ENABLE:
-         return "Tijd/datum weergeven";
-      case MENU_ENUM_LABEL_VALUE_THREADED_DATA_RUNLOOP_ENABLE:
-         return "Threaded data runloop";
-      case MENU_ENUM_LABEL_VALUE_ENTRY_NORMAL_COLOR:
-         return "Menu entry normale kleur";
-      case MENU_ENUM_LABEL_VALUE_SHOW_ADVANCED_SETTINGS:
-         return "Geavanceerde instellingen weergeven";
-      case MENU_ENUM_LABEL_VALUE_MOUSE_ENABLE:
-         return "Muis Ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_POINTER_ENABLE:
-         return "Touch Ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_CORE_ENABLE:
-         return "Core naam weergeven";
-      case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_ENABLE:
-         return "DPI Override activeren";
-      case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_VALUE:
-         return "DPI Override";
-      case MENU_ENUM_LABEL_VALUE_SUSPEND_SCREENSAVER_ENABLE:
-         return "Onderbreek Screensaver";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_DISABLE_COMPOSITION:
-         return "Desktop Compositie deactiveren";
-      case MENU_ENUM_LABEL_VALUE_PAUSE_NONACTIVE:
-         return "Laat niet in achtergrond draaien";
-      case MENU_ENUM_LABEL_VALUE_UI_COMPANION_START_ON_BOOT:
-         return "UI Companion Start Tijdens Boot";
-      case MENU_ENUM_LABEL_VALUE_UI_MENUBAR_ENABLE:
-         return "Menubalk";
       case MENU_ENUM_LABEL_VALUE_ARCHIVE_MODE:
          return "Archief Bestand Associatie";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_ENABLE:
-         return "Netwerk Commandos";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_PORT:
-         return "Netwerk Commandos Poort";
-      case MENU_ENUM_LABEL_VALUE_HISTORY_LIST_ENABLE:
-         return "Geschiedenislijst Activeren";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_HISTORY_SIZE:
-         return "Geschiedenislijst grootte";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE_AUTO:
-         return "Geschatte Monitor Framerate";
-      case MENU_ENUM_LABEL_VALUE_DUMMY_ON_CORE_SHUTDOWN:
-         return "Dummy Tijdens Core Shutdown";
-      case MENU_ENUM_LABEL_VALUE_CORE_SET_SUPPORTS_NO_CONTENT_ENABLE:
-         return "Automatisch core opstarten";
-      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_ENABLE:
-         return "Beperk Maximale Afspeelsnelheid";
-      case MENU_ENUM_LABEL_VALUE_FASTFORWARD_RATIO:
-         return "Maximale Afspeelsnelheid";
-      case MENU_ENUM_LABEL_VALUE_AUTO_REMAPS_ENABLE:
-         return "Laad Remap Bestanden Automatisch";
-      case MENU_ENUM_LABEL_VALUE_SLOWMOTION_RATIO:
-         return "Slow-Motion Ratio";
-      case MENU_ENUM_LABEL_VALUE_CORE_SPECIFIC_CONFIG:
-         return "Configuratie Per-Core";
-      case MENU_ENUM_LABEL_VALUE_AUTO_OVERRIDES_ENABLE:
-         return "Laad Override Bestanden Automatisch";
-      case MENU_ENUM_LABEL_VALUE_CONFIG_SAVE_ON_EXIT:
-         return "Configuratie Opslaan Tijdens Afsluiten";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SMOOTH:
-         return "Hardware Bilinear Filtering";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_GAMMA:
-         return "Video Gamma";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ALLOW_ROTATE:
-         return "Rotatie toestaan";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC:
-         return "Harde GPU Synchronisatie";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SWAP_INTERVAL:
-         return "VSync Swap Interval";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VSYNC:
-         return "VSync";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_THREADED:
-         return "Threaded Video";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ROTATION:
-         return "Rotatie";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_SCREENSHOT:
-         return "GPU Screenshot Activeren";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_CROP_OVERSCAN:
-         return "Overscan Afsnijden (Herladen vereist)";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_INDEX:
-         return "Beeldverhouding Index";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_AUTO:
-         return "Auto Beeldverhouding";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_ASPECT:
-         return "Forceer beeldverhouding";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE:
-         return "Refresh Rate";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_SRGB_DISABLE:
-         return "Handmatig sRGB FBO deactiveren";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_WINDOWED_FULLSCREEN:
-         return "Windowed Fullscreen Mode"; /* TODO/FIXME */
-      case MENU_ENUM_LABEL_VALUE_PAL60_ENABLE:
-         return "PAL60 Mode Activeren";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VFILTER:
-         return "Deflicker"; /* TODO/FIXME */
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VI_WIDTH:
-         return "VI Scherm Breedte Instellen";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_BLACK_FRAME_INSERTION:
-         return "Zwarte Frame Injectie";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC_FRAMES:
-         return "Harde GPU Sync Frames";
-      case MENU_ENUM_LABEL_VALUE_SORT_SAVEFILES_ENABLE:
-         return "Saves Sorteren In Map";
-      case MENU_ENUM_LABEL_VALUE_SORT_SAVESTATES_ENABLE:
-         return "Savestates Sorteren In Map";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FULLSCREEN:
-         return "Gebruik Fullscreen Mode";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE:
-         return "Windowed Schalering";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE_INTEGER:
-         return "Gehele schalering";
-      case MENU_ENUM_LABEL_VALUE_PERFCNT_ENABLE:
-         return "Prestatie Teller";
-      case MENU_ENUM_LABEL_VALUE_LIBRETRO_LOG_LEVEL:
-         return "Core Logging Niveau";
-      case MENU_ENUM_LABEL_VALUE_LOG_VERBOSITY:
-         return "Logging Uitgebreidheid";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_LOAD:
-         return "Automatisch State Loaden";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_INDEX:
-         return "Save State Automatische Index";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_SAVE:
-         return "Automatisch State Saven";
-      case MENU_ENUM_LABEL_VALUE_AUTOSAVE_INTERVAL:
-         return "SaveRAM Autosave Interval";
-      case MENU_ENUM_LABEL_VALUE_BLOCK_SRAM_OVERWRITE:
-         return "SaveRAM niet overschrijven tijdens laden van savestate";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHARED_CONTEXT:
-         return "HW Shared Context Activeren";
-      case MENU_ENUM_LABEL_VALUE_RESTART_RETROARCH:
-         return "RetroArch Opnieuw Opstarten";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_NICKNAME:
-         return "Gebruikersnaam";
-      case MENU_ENUM_LABEL_VALUE_USER_LANGUAGE:
-         return "Taal";
-      case MENU_ENUM_LABEL_VALUE_CAMERA_ALLOW:
-         return "Camera Toestaan";
-      case MENU_ENUM_LABEL_VALUE_LOCATION_ALLOW:
-         return "Locatie Toestaan";
-      case MENU_ENUM_LABEL_VALUE_PAUSE_LIBRETRO:
-         return "Pauseer als menu op voorgrond is";
-      case MENU_ENUM_LABEL_VALUE_INPUT_OSK_OVERLAY_ENABLE:
-         return "Toetsenbord Overlay Weergeven";
-      case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_ENABLE:
-         return "Overlay Weergeven";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MONITOR_INDEX:
-         return "Monitor Index";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FRAME_DELAY:
-         return "Frame Delay"; /* TODO/FIXME */
-      case MENU_ENUM_LABEL_VALUE_INPUT_DUTY_CYCLE:
-         return "Duty Cycle"; /* TODO/FIXME */
-      case MENU_ENUM_LABEL_VALUE_INPUT_TURBO_PERIOD:
-         return "Turbo Period"; /* TODO/FIXME */
-      case MENU_ENUM_LABEL_VALUE_INPUT_AXIS_THRESHOLD:
-         return "Invoer As Threshold"; /* TODO/FIXME */
-      case MENU_ENUM_LABEL_VALUE_INPUT_REMAP_BINDS_ENABLE:
-         return "Remap Binds Activeren";
-      case MENU_ENUM_LABEL_VALUE_INPUT_MAX_USERS:
-         return "Maximaal aantal gebruikers";
-      case MENU_ENUM_LABEL_VALUE_INPUT_AUTODETECT_ENABLE:
-         return "Autoconfiguratie Activeren";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_OUTPUT_RATE:
-         return "Audio Uitvoer Frequentie (KHz)";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_MAX_TIMING_SKEW:
-         return "Audio Maximale Timing Onevenredigheid";
-      case MENU_ENUM_LABEL_VALUE_CHEAT_NUM_PASSES:
-         return "Cheat Passes";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_CORE:
-         return "Core Remap Bestand Opslaan";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_GAME:
-         return "Game Remap Bestand Opslaan";
-      case MENU_ENUM_LABEL_VALUE_CHEAT_APPLY_CHANGES:
-         return "Cheat Instellingen Toepassen";
-      case MENU_ENUM_LABEL_VALUE_SHADER_APPLY_CHANGES:
-         return "Shader Instellingen Toepassen";
-      case MENU_ENUM_LABEL_VALUE_REWIND_ENABLE:
-         return "Rewind Activeren";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_COLLECTION_LIST:
-         return "Verzameling";
-      case MENU_ENUM_LABEL_VALUE_DETECT_CORE_LIST:
-         return "Selecteer bestand en detecteer Core";
-      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_HISTORY:
-         return "Laad Recent";
+      case MENU_ENUM_LABEL_VALUE_ASK_ARCHIVE:
+         return "Keuze";
+      case MENU_ENUM_LABEL_VALUE_ASSETS_DIRECTORY:
+         return "Assets Map";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_BLOCK_FRAMES:
+         return "Block Frames";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_DEVICE:
+         return "Audio Apparaat";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_DRIVER:
+         return "Audio Driver";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_DSP_PLUGIN:
+         return "Audio DSP Plugin";
       case MENU_ENUM_LABEL_VALUE_AUDIO_ENABLE:
          return "Audio Activeren";
-      case MENU_ENUM_LABEL_VALUE_FPS_SHOW:
-         return "Framerate Weergeven";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_FILTER_DIR:
+         return "Audio Filter Map";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_LATENCY:
+         return "Audio Latentie (ms)";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_MAX_TIMING_SKEW:
+         return "Audio Maximale Timing Onevenredigheid";
       case MENU_ENUM_LABEL_VALUE_AUDIO_MUTE:
          return "Audio Mute"; /* TODO/FIXME */
-      case MENU_ENUM_LABEL_VALUE_AUDIO_VOLUME:
-         return "Audio Uitgangsniveau (dB)";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_SYNC:
-         return "Audio Synchronizatie Activeren";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_OUTPUT_RATE:
+         return "Audio Uitvoer Frequentie (KHz)";
       case MENU_ENUM_LABEL_VALUE_AUDIO_RATE_CONTROL_DELTA:
          return "Audio Rate Control Delta"; /* TODO/FIXME */
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_NUM_PASSES:
-         return "Shader Passes"; /* TODO/FIXME */
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_SHA1:
-         return "SHA1";
-      case MENU_ENUM_LABEL_VALUE_CONFIGURATIONS:
-         return "Laad Configuratie";
-      case MENU_ENUM_LABEL_VALUE_REWIND_GRANULARITY:
-         return "Rewind Granulariteit";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_LOAD:
-         return "Laad Remap Bestand";
-      case MENU_ENUM_LABEL_VALUE_CUSTOM_RATIO:
-         return "Handmatige beeldverhouding";
-      case MENU_ENUM_LABEL_VALUE_USE_THIS_DIRECTORY:
-         return "<Deze directory gebruiken>";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_START_CONTENT:
-         return "Content Opstarten";
-      case MENU_ENUM_LABEL_VALUE_DISK_OPTIONS:
-         return "Disk Beheer";
-      case MENU_ENUM_LABEL_VALUE_CORE_OPTIONS:
-         return "Opties";
-      case MENU_ENUM_LABEL_VALUE_CORE_CHEAT_OPTIONS:
-         return "Cheats";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_RESAMPLER_DRIVER:
+         return "Audio Resampler Driver";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_SETTINGS:
+         return "Geluid";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_SYNC:
+         return "Audio Synchronizatie Activeren";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_VOLUME:
+         return "Audio Uitgangsniveau (dB)";
+      case MENU_ENUM_LABEL_VALUE_AUTOSAVE_INTERVAL:
+         return "SaveRAM Autosave Interval";
+      case MENU_ENUM_LABEL_VALUE_AUTO_OVERRIDES_ENABLE:
+         return "Laad Override Bestanden Automatisch";
+      case MENU_ENUM_LABEL_VALUE_AUTO_REMAPS_ENABLE:
+         return "Laad Remap Bestanden Automatisch";
+      case MENU_ENUM_LABEL_VALUE_BACK:
+         return "TERUG";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS:
+         return "Basis menu besturing";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_BACK:
+         return "Terug";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_CONFIRM:
+         return "Bevestigen/OK";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_INFO:
+         return "Info";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_QUIT:
+         return "Afsluiten";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_SCROLL_DOWN:
+         return "Omlaag Scrollen";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_SCROLL_UP:
+         return "Omhoog Scrollen";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_START:
+         return "Reset";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_TOGGLE_KEYBOARD:
+         return "Keyboard Toggle";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_TOGGLE_MENU:
+         return "Menu Schakelaar";
+      case MENU_ENUM_LABEL_VALUE_BLOCK_SRAM_OVERWRITE:
+         return "SaveRAM niet overschrijven tijdens laden van savestate";
+      case MENU_ENUM_LABEL_VALUE_BUILDBOT_ASSETS_URL:
+         return "Buildbot Assets URL";
+      case MENU_ENUM_LABEL_VALUE_CACHE_DIRECTORY:
+         return "Cache Map";
+      case MENU_ENUM_LABEL_VALUE_CAMERA_ALLOW:
+         return "Camera Toestaan";
+      case MENU_ENUM_LABEL_VALUE_CAMERA_DRIVER:
+         return "Camera Driver";
+      case MENU_ENUM_LABEL_VALUE_CHEAT:
+         return "Cheat";
+      case MENU_ENUM_LABEL_VALUE_CHEAT_APPLY_CHANGES:
+         return "Cheat Instellingen Toepassen";
+      case MENU_ENUM_LABEL_VALUE_CHEAT_DATABASE_PATH:
+         return "Cheat Bestand Map";
       case MENU_ENUM_LABEL_VALUE_CHEAT_FILE_LOAD:
          return "Cheat Bestand Laden";
       case MENU_ENUM_LABEL_VALUE_CHEAT_FILE_SAVE_AS:
          return "Cheat Bestand Opslaan Als";
+      case MENU_ENUM_LABEL_VALUE_CHEAT_NUM_PASSES:
+         return "Cheat Passes";
+      case MENU_ENUM_LABEL_VALUE_CLOSE_CONTENT:
+         return "Afsluiten";
+      case MENU_ENUM_LABEL_VALUE_CONFIGURATIONS:
+         return "Laad Configuratie";
+      case MENU_ENUM_LABEL_VALUE_CONFIGURATION_SETTINGS:
+         return "Configuratie";
+      case MENU_ENUM_LABEL_VALUE_CONFIG_SAVE_ON_EXIT:
+         return "Configuratie Opslaan Tijdens Afsluiten";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_COLLECTION_LIST:
+         return "Verzameling";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_DATABASE_DIRECTORY:
+         return "Content Database Map";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_HISTORY_SIZE:
+         return "Geschiedenislijst grootte";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_SETTINGS:
+         return "Snelmenu";
+      case MENU_ENUM_LABEL_VALUE_CORE_ASSETS_DIRECTORY:
+         return "Downloads Map";
+      case MENU_ENUM_LABEL_VALUE_CORE_CHEAT_OPTIONS:
+         return "Cheats";
       case MENU_ENUM_LABEL_VALUE_CORE_COUNTERS:
          return "Core Prestatie Tellers";
-      case MENU_ENUM_LABEL_VALUE_TAKE_SCREENSHOT:
-         return "Schermafdruk";
+      case MENU_ENUM_LABEL_VALUE_CORE_ENABLE:
+         return "Core naam weergeven";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFORMATION:
+         return "Core Informatie";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_AUTHORS:
+         return "Auteur(s)";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CATEGORIES:
+         return "Categories"; /* TODO/FIXME - need accented characters here */
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_LABEL:
+         return "Core label";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NAME:
+         return "Core naam";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NOTES:
+         return "Core opmerkingen";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_FIRMWARE:
+         return "Firmware";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_LICENSES:
+         return "Licentie(s)";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_PERMISSIONS:
+         return "Permissies";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SUPPORTED_EXTENSIONS:
+         return "Ondersteunde extensies";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_MANUFACTURER:
+         return "Systeem fabrikant";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_NAME:
+         return "Systeem naam";
+      case MENU_ENUM_LABEL_VALUE_CORE_INPUT_REMAPPING_OPTIONS:
+         return "Besturing";
+      case MENU_ENUM_LABEL_VALUE_CORE_LIST:
+         return "Laad Core";
+      case MENU_ENUM_LABEL_VALUE_CORE_OPTIONS:
+         return "Opties";
+      case MENU_ENUM_LABEL_VALUE_CORE_SETTINGS:
+         return "Core";
+      case MENU_ENUM_LABEL_VALUE_CORE_SET_SUPPORTS_NO_CONTENT_ENABLE:
+         return "Automatisch core opstarten";
+      case MENU_ENUM_LABEL_VALUE_CORE_SPECIFIC_CONFIG:
+         return "Configuratie Per-Core";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
+         return "Automatisch uitpakken van gedownloade archieven";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_BUILDBOT_URL:
+         return "Buildbot Cores URL";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_LIST:
+         return "Core Updater";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_SETTINGS:
+         return "Updater";
+      case MENU_ENUM_LABEL_VALUE_CURSOR_DIRECTORY:
+         return "Cursor Map";
+      case MENU_ENUM_LABEL_VALUE_CURSOR_MANAGER:
+         return "Cursorbeheer";
+      case MENU_ENUM_LABEL_VALUE_CUSTOM_RATIO:
+         return "Handmatige beeldverhouding";
+      case MENU_ENUM_LABEL_VALUE_DATABASE_MANAGER:
+         return "Databasebeheer";
       case MENU_ENUM_LABEL_VALUE_DELETE_ENTRY:
          return "Verwijderen";
-      case MENU_ENUM_LABEL_VALUE_RESUME:
-         return "Hervatten";
-      case MENU_ENUM_LABEL_VALUE_DISK_INDEX:
-         return "Disk Index";
-      case MENU_ENUM_LABEL_VALUE_FRONTEND_COUNTERS:
-         return "Frontend Prestatie Tellers";
-      case MENU_ENUM_LABEL_VALUE_DISK_IMAGE_APPEND:
-         return "Disk Image Toevoegen";
+      case MENU_ENUM_LABEL_VALUE_DETECT_CORE_LIST:
+         return "Selecteer bestand en detecteer Core";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_CONTENT:
+         return "<Content dir>";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_DEFAULT:
+         return "<Standaard>";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NONE:
+         return "<Niets>";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NOT_FOUND:
+         return "Directory niet gevonden.";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_SETTINGS:
+         return "Mappen";
+      case MENU_ENUM_LABEL_VALUE_DISABLED:
+         return "Uitgeschakeld";
       case MENU_ENUM_LABEL_VALUE_DISK_CYCLE_TRAY_STATUS:
          return "Disk Cycle Tray Status"; /* TODO/FIXME */
-      case MENU_ENUM_LABEL_VALUE_NO_PLAYLIST_ENTRIES_AVAILABLE:
-         return "Geen afspeellijst items beschikbaar.";
+      case MENU_ENUM_LABEL_VALUE_DISK_IMAGE_APPEND:
+         return "Disk Image Toevoegen";
+      case MENU_ENUM_LABEL_VALUE_DISK_INDEX:
+         return "Disk Index";
+      case MENU_ENUM_LABEL_VALUE_DISK_OPTIONS:
+         return "Disk Beheer";
+      case MENU_ENUM_LABEL_VALUE_DONT_CARE:
+         return "Onbelangrijk";
+      case MENU_ENUM_LABEL_VALUE_DOWNLOAD_CORE_CONTENT:
+         return "Download Inhoud";
+      case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_ENABLE:
+         return "DPI Override activeren";
+      case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_VALUE:
+         return "DPI Override";
+      case MENU_ENUM_LABEL_VALUE_DRIVER_SETTINGS:
+         return "Driver";
+      case MENU_ENUM_LABEL_VALUE_DUMMY_ON_CORE_SHUTDOWN:
+         return "Dummy Tijdens Core Shutdown";
+      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPER:
+         return "Dynamic Wallpaper";
+      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPERS_DIRECTORY:
+         return "Dynamische Wallpapers Map";
+      case MENU_ENUM_LABEL_VALUE_ENTRY_HOVER_COLOR:
+         return "Menu entry hover kleur";
+      case MENU_ENUM_LABEL_VALUE_ENTRY_NORMAL_COLOR:
+         return "Menu entry normale kleur";
+      case MENU_ENUM_LABEL_VALUE_FALSE:
+         return "Niet waar";
+      case MENU_ENUM_LABEL_VALUE_FASTFORWARD_RATIO:
+         return "Maximale Afspeelsnelheid";
+      case MENU_ENUM_LABEL_VALUE_FPS_SHOW:
+         return "Framerate Weergeven";
+      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_ENABLE:
+         return "Beperk Maximale Afspeelsnelheid";
+      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_SETTINGS:
+         return "Frame Throttle";
+      case MENU_ENUM_LABEL_VALUE_FRONTEND_COUNTERS:
+         return "Frontend Prestatie Tellers";
+      case MENU_ENUM_LABEL_VALUE_HELP:
+         return "Help";
+      case MENU_ENUM_LABEL_VALUE_HELP_AUDIO_VIDEO_TROUBLESHOOTING:
+         return "Audio/Video Raadpleging";
+      case MENU_ENUM_LABEL_VALUE_HELP_CHANGE_VIRTUAL_GAMEPAD:
+         return "Virtuele Gamepad Overlay Veranderen";
+      case MENU_ENUM_LABEL_VALUE_HELP_CONTROLS:
+         return "Basis Menu Besturing";
+      case MENU_ENUM_LABEL_VALUE_HELP_LIST:
+         return "Help";
+      case MENU_ENUM_LABEL_VALUE_HELP_LOADING_CONTENT:
+         return "Hoe Laad je Content?";
+      case MENU_ENUM_LABEL_VALUE_HELP_SCANNING_CONTENT:
+         return "Scannen naar Content";
+      case MENU_ENUM_LABEL_VALUE_HELP_WHAT_IS_A_CORE:
+         return "Wat is een Core?";
+      case MENU_ENUM_LABEL_VALUE_HISTORY_LIST_ENABLE:
+         return "Geschiedenislijst Activeren";
+      case MENU_ENUM_LABEL_VALUE_HISTORY_TAB:
+         return "Geschiedenis";
+      case MENU_ENUM_LABEL_VALUE_HORIZONTAL_MENU:
+         return "Horizontal Menu";
+      case MENU_ENUM_LABEL_VALUE_IMAGES_TAB:
+         return "Afbeeldingen";
+      case MENU_ENUM_LABEL_VALUE_INFORMATION_LIST:
+         return "Informatie";
+      case MENU_ENUM_LABEL_VALUE_INPUT_AUTODETECT_ENABLE:
+         return "Autoconfiguratie Activeren";
+      case MENU_ENUM_LABEL_VALUE_INPUT_AXIS_THRESHOLD:
+         return "Invoer As Threshold"; /* TODO/FIXME */
+      case MENU_ENUM_LABEL_VALUE_INPUT_BACK_AS_MENU_TOGGLE_ENABLE:
+         return "Terug als Menu Schakelaar";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_HIDE_UNBOUND:
+         return "Verbergen Niet-gemapte Core Input Descripties";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_LABEL_SHOW:
+         return "Descriptie Labels Weergeven";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DRIVER:
+         return "Input Driver";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DUTY_CYCLE:
+         return "Duty Cycle"; /* TODO/FIXME */
+      case MENU_ENUM_LABEL_VALUE_INPUT_HOTKEY_BINDS:
+         return "Invoer Hotkey Binds";
+      case MENU_ENUM_LABEL_VALUE_INPUT_MAX_USERS:
+         return "Maximaal aantal gebruikers";
+      case MENU_ENUM_LABEL_VALUE_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
+         return "Menu Schakelaar Gamepad Combo";
+      case MENU_ENUM_LABEL_VALUE_INPUT_OSK_OVERLAY_ENABLE:
+         return "Toetsenbord Overlay Weergeven";
+      case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_ENABLE:
+         return "Overlay Weergeven";
+      case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_HIDE_IN_MENU:
+         return "Verberg Overlay In Menu";
+      case MENU_ENUM_LABEL_VALUE_INPUT_REMAPPING_DIRECTORY:
+         return "Invoer Remapping Map";
+      case MENU_ENUM_LABEL_VALUE_INPUT_REMAP_BINDS_ENABLE:
+         return "Remap Binds Activeren";
+      case MENU_ENUM_LABEL_VALUE_INPUT_SETTINGS:
+         return "Invoer";
+      case MENU_ENUM_LABEL_VALUE_INPUT_TURBO_PERIOD:
+         return "Turbo Period"; /* TODO/FIXME */
+      case MENU_ENUM_LABEL_VALUE_INPUT_USER_BINDS:
+         return "Invoer Gebruiker %u Binds";
+      case MENU_ENUM_LABEL_VALUE_JOYPAD_AUTOCONFIG_DIR:
+         return "Invoerapparaten Autoconfig Map";
+      case MENU_ENUM_LABEL_VALUE_JOYPAD_DRIVER:
+         return "Joypad Driver";
+      case MENU_ENUM_LABEL_VALUE_KEYBOARD_OVERLAY_PRESET:
+         return "Toetsenbord Overlay Preset";
+      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_SIMPLIFIED:
+         return "Chinees (Gesimplificeerd)";
+      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_TRADITIONAL:
+         return "Chinees (Traditioneel)";
+      case MENU_ENUM_LABEL_VALUE_LANG_DUTCH:
+         return "Nederlands";
+      case MENU_ENUM_LABEL_VALUE_LANG_ENGLISH:
+         return "Engels";
+      case MENU_ENUM_LABEL_VALUE_LANG_ESPERANTO:
+         return "Esperanto";
+      case MENU_ENUM_LABEL_VALUE_LANG_FRENCH:
+         return "Frans";
+      case MENU_ENUM_LABEL_VALUE_LANG_GERMAN:
+         return "Duits";
+      case MENU_ENUM_LABEL_VALUE_LANG_ITALIAN:
+         return "Italiaans";
+      case MENU_ENUM_LABEL_VALUE_LANG_JAPANESE:
+         return "Japans";
+      case MENU_ENUM_LABEL_VALUE_LANG_KOREAN:
+         return "Koreaans";
+      case MENU_ENUM_LABEL_VALUE_LANG_POLISH:
+         return "Pools";
+      case MENU_ENUM_LABEL_VALUE_LANG_PORTUGUESE:
+         return "Portugees";
+      case MENU_ENUM_LABEL_VALUE_LANG_RUSSIAN:
+         return "Russisch";
+      case MENU_ENUM_LABEL_VALUE_LANG_SPANISH:
+         return "Spaans";
+      case MENU_ENUM_LABEL_VALUE_LEFT_ANALOG:
+         return "Linkse Analog";
+      case MENU_ENUM_LABEL_VALUE_LIBRETRO_DIR_PATH:
+         return "Core Map";
+      case MENU_ENUM_LABEL_VALUE_LIBRETRO_INFO_PATH:
+         return "Core Info Map";
+      case MENU_ENUM_LABEL_VALUE_LIBRETRO_LOG_LEVEL:
+         return "Core Logging Niveau";
+      case MENU_ENUM_LABEL_VALUE_LINEAR:
+         return "Linear";
+      case MENU_ENUM_LABEL_VALUE_LOAD_ARCHIVE:
+         return "Open Archief met Core";
+      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT:
+         return "Selecteer bestand";
+      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_HISTORY:
+         return "Laad Recent";
+      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_LIST:
+         return "Laad Inhoud";
+      case MENU_ENUM_LABEL_VALUE_LOAD_STATE:
+         return "Laad State";
+      case MENU_ENUM_LABEL_VALUE_LOCATION_ALLOW:
+         return "Locatie Toestaan";
+      case MENU_ENUM_LABEL_VALUE_LOCATION_DRIVER:
+         return "Locatie Driver";
+      case MENU_ENUM_LABEL_VALUE_LOGGING_SETTINGS:
+         return "Logging";
+      case MENU_ENUM_LABEL_VALUE_LOG_VERBOSITY:
+         return "Logging Uitgebreidheid";
+      case MENU_ENUM_LABEL_VALUE_MAIN_MENU:
+         return "Hoofdmenu";
+      case MENU_ENUM_LABEL_VALUE_MANAGEMENT:
+         return "Database";
+      case MENU_ENUM_LABEL_VALUE_MENU_DRIVER:
+         return "Menu Driver";
+      case MENU_ENUM_LABEL_VALUE_MENU_FILE_BROWSER_SETTINGS:
+         return "Menu Bestandsbeheer";
+      case MENU_ENUM_LABEL_VALUE_MENU_SETTINGS:
+         return "Menu";
+      case MENU_ENUM_LABEL_VALUE_MENU_WALLPAPER:
+         return "Menu Wallpaper";
+      case MENU_ENUM_LABEL_VALUE_MISSING:
+         return "Ontbrekend";
+      case MENU_ENUM_LABEL_VALUE_MOUSE_ENABLE:
+         return "Muis Ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_MULTIMEDIA_SETTINGS:
+         return "Multimedia";
+      case MENU_ENUM_LABEL_VALUE_MUSIC_TAB:
+         return "Muziek";
+      case MENU_ENUM_LABEL_VALUE_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
+         return "Filtreer onbekende extensies";
+      case MENU_ENUM_LABEL_VALUE_NAVIGATION_WRAPAROUND:
+         return "Navigatie Wrap-Around";
+      case MENU_ENUM_LABEL_VALUE_NEAREST:
+         return "Nearest";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT: /* TODO: Original string changed */
+         return "Swap Netplay Input";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_DELAY_FRAMES:
+         return "Netplay Vertraging Frames";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE:
+         return "Netplay Activeren";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS: /* TODO: Original string changed */
+         return "IP Adres";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_MODE:
+         return "Netplay Client Activeren";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_NICKNAME:
+         return "Gebruikersnaam";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE:
+         return "Netplay Spectator Activeren";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT:
+         return "Netplay TCP/UDP Poort";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_ENABLE:
+         return "Netwerk Commandos";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_PORT:
+         return "Netwerk Commandos Poort";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_SETTINGS:
+         return "Netwerk";
+      case MENU_ENUM_LABEL_VALUE_NO:
+         return "Nee";
+      case MENU_ENUM_LABEL_VALUE_NONE:
+         return "Geen";
+      case MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE:
+         return "N.v.t";
+      case MENU_ENUM_LABEL_VALUE_NO_CORE:
+         return "Geen core";
+      case MENU_ENUM_LABEL_VALUE_NO_CORES_AVAILABLE:
+         return "Geen cores beschikbaar.";
       case MENU_ENUM_LABEL_VALUE_NO_CORE_INFORMATION_AVAILABLE:
          return "Geen core informatie beschikbaar.";
       case MENU_ENUM_LABEL_VALUE_NO_CORE_OPTIONS_AVAILABLE:
          return "Geen core opties beschikbaar.";
-      case MENU_ENUM_LABEL_VALUE_NO_CORES_AVAILABLE:
-         return "Geen cores beschikbaar.";
-      case MENU_ENUM_LABEL_VALUE_NO_CORE:
-         return "Geen core";
-      case MENU_ENUM_LABEL_VALUE_DATABASE_MANAGER:
-         return "Databasebeheer";
-      case MENU_ENUM_LABEL_VALUE_CURSOR_MANAGER:
-         return "Cursorbeheer";
-      case MENU_ENUM_LABEL_VALUE_MAIN_MENU:
-         return "Hoofdmenu";
-      case MENU_ENUM_LABEL_VALUE_SETTINGS:
-         return "Instellingen";
-      case MENU_ENUM_LABEL_VALUE_QUIT_RETROARCH:
-         return "RetroArch Afsluiten";
-      case MENU_ENUM_LABEL_VALUE_HELP:
-         return "Help";
-      case MENU_ENUM_LABEL_VALUE_SAVE_NEW_CONFIG:
-         return "Nieuwe configuratie opslaan";
-      case MENU_ENUM_LABEL_VALUE_RESTART_CONTENT:
-         return "Herstart";
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_LIST:
-         return "Core Updater";
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_BUILDBOT_URL:
-         return "Buildbot Cores URL";
-      case MENU_ENUM_LABEL_VALUE_BUILDBOT_ASSETS_URL:
-         return "Buildbot Assets URL";
-      case MENU_ENUM_LABEL_VALUE_NAVIGATION_WRAPAROUND:
-         return "Navigatie Wrap-Around";
-      case MENU_ENUM_LABEL_VALUE_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
-         return "Filtreer onbekende extensies";
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
-         return "Automatisch uitpakken van gedownloade archieven";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFORMATION:
-         return "Systeem Informatie";
-      case MENU_ENUM_LABEL_VALUE_ONLINE_UPDATER:
-         return "Online Updater";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFORMATION:
-         return "Core Informatie";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NOT_FOUND:
-         return "Directory niet gevonden.";
+      case MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE:
+         return "Informatie is niet beschikbaar.";
       case MENU_ENUM_LABEL_VALUE_NO_ITEMS:
          return "Geen items.";
-      case MENU_ENUM_LABEL_VALUE_CORE_LIST:
-         return "Laad Core";
-      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT:
-         return "Selecteer bestand";
-      case MENU_ENUM_LABEL_VALUE_CLOSE_CONTENT:
-         return "Afsluiten";
-      case MENU_ENUM_LABEL_VALUE_MANAGEMENT:
-         return "Database";
-      case MENU_ENUM_LABEL_VALUE_SAVE_STATE:
-         return "Save State";
-      case MENU_ENUM_LABEL_VALUE_LOAD_STATE:
-         return "Laad State";
-      case MENU_ENUM_LABEL_VALUE_RESUME_CONTENT:
-         return "Hervatten";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DRIVER:
-         return "Input Driver";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_DRIVER:
-         return "Audio Driver";
-      case MENU_ENUM_LABEL_VALUE_JOYPAD_DRIVER:
-         return "Joypad Driver";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_RESAMPLER_DRIVER:
-         return "Audio Resampler Driver";
-      case MENU_ENUM_LABEL_VALUE_RECORD_DRIVER:
-         return "Opname Driver";
-      case MENU_ENUM_LABEL_VALUE_MENU_DRIVER:
-         return "Menu Driver";
-      case MENU_ENUM_LABEL_VALUE_CAMERA_DRIVER:
-         return "Camera Driver";
-      case MENU_ENUM_LABEL_VALUE_LOCATION_DRIVER:
-         return "Locatie Driver";
-      case MENU_ENUM_LABEL_VALUE_UNABLE_TO_READ_COMPRESSED_FILE:
-         return "Fout opgetreden tijdens lezen van gecomprimeerd bestand.";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_SCALE:
-         return "Overlay Schalering";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_PRESET:
-         return "Overlay Preset";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_LATENCY:
-         return "Audio Latentie (ms)";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_DEVICE:
-         return "Audio Apparaat";
-      case MENU_ENUM_LABEL_VALUE_KEYBOARD_OVERLAY_PRESET:
-         return "Toetsenbord Overlay Preset";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_OPACITY:
-         return "Overlay Transparentie";
-      case MENU_ENUM_LABEL_VALUE_MENU_WALLPAPER:
-         return "Menu Wallpaper";
-      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPER:
-         return "Dynamic Wallpaper";
-      case MENU_ENUM_LABEL_VALUE_CORE_INPUT_REMAPPING_OPTIONS:
-         return "Besturing";
-      case MENU_ENUM_LABEL_VALUE_SHADER_OPTIONS:
-         return "Shaders";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PARAMETERS:
-         return "Voorbeeldweergave Shader Parameters";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_PARAMETERS:
-         return "Menu Shader Parameters";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_AS:
-         return "Shader Preset Opslaan Als";
+      case MENU_ENUM_LABEL_VALUE_NO_PERFORMANCE_COUNTERS:
+         return "Geen prestatie tellers.";
+      case MENU_ENUM_LABEL_VALUE_NO_PLAYLIST_ENTRIES_AVAILABLE:
+         return "Geen afspeellijst items beschikbaar.";
+      case MENU_ENUM_LABEL_VALUE_NO_SETTINGS_FOUND:
+         return "Geen instellingen gevonden.";
       case MENU_ENUM_LABEL_VALUE_NO_SHADER_PARAMETERS:
          return "Geen shader parameters.";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET:
-         return "Laad Shader Preset";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER:
-         return "Video Filter";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_DSP_PLUGIN:
-         return "Audio DSP Plugin";
-      case MENU_ENUM_LABEL_VALUE_SECONDS:
-         return "secondes";
       case MENU_ENUM_LABEL_VALUE_OFF:
          return "OFF";
       case MENU_ENUM_LABEL_VALUE_ON:
          return "ON";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_ASSETS:
-         return "Update Assets";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_CHEATS:
-         return "Update Cheats";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_AUTOCONFIG_PROFILES:
-         return "Update Autoconfiguratie Profielen";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_DATABASES:
-         return "Update Databases";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_OVERLAYS:
-         return "Update Overlays";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_CG_SHADERS:
-         return "Update Cg Shaders";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_GLSL_SHADERS:
-         return "Update GLSL Shaders";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NAME:
-         return "Core naam";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_LABEL:
-         return "Core label";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_NAME:
-         return "Systeem naam";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_MANUFACTURER:
-         return "Systeem fabrikant";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CATEGORIES:
-         return "Categories"; /* TODO/FIXME - need accented characters here */
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_AUTHORS:
-         return "Auteur(s)";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_PERMISSIONS:
-         return "Permissies";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_LICENSES:
-         return "Licentie(s)";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SUPPORTED_EXTENSIONS:
-         return "Ondersteunde extensies";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_FIRMWARE:
-         return "Firmware";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NOTES:
-         return "Core opmerkingen";
+      case MENU_ENUM_LABEL_VALUE_ONLINE_UPDATER:
+         return "Online Updater";
+      case MENU_ENUM_LABEL_VALUE_ONSCREEN_DISPLAY_SETTINGS:
+         return "Onscreen Weergave";
+      case MENU_ENUM_LABEL_VALUE_OPEN_ARCHIVE:
+         return "Open Archief als map";
+      case MENU_ENUM_LABEL_VALUE_OPTIONAL:
+         return "Optioneel";
+      case MENU_ENUM_LABEL_VALUE_OSK_OVERLAY_DIRECTORY:
+         return "OSK Overlay Map";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_AUTOLOAD_PREFERRED:
+         return "Laad geprefeerd overlay autom.";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_DIRECTORY:
+         return "Overlay Map";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_OPACITY:
+         return "Overlay Transparentie";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_PRESET:
+         return "Overlay Preset";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_SCALE:
+         return "Overlay Schalering";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_SETTINGS:
+         return "Onscreen Overlay";
+      case MENU_ENUM_LABEL_VALUE_PAL60_ENABLE:
+         return "PAL60 Mode Activeren";
+      case MENU_ENUM_LABEL_VALUE_PAUSE_LIBRETRO:
+         return "Pauseer als menu op voorgrond is";
+      case MENU_ENUM_LABEL_VALUE_PAUSE_NONACTIVE:
+         return "Laat niet in achtergrond draaien";
+      case MENU_ENUM_LABEL_VALUE_PERFCNT_ENABLE:
+         return "Prestatie Teller";
+      case MENU_ENUM_LABEL_VALUE_PLAYLISTS_TAB:
+         return "Afspeellijsten";
+      case MENU_ENUM_LABEL_VALUE_PLAYLIST_DIRECTORY:
+         return "Afspeellijsten Map";
+      case MENU_ENUM_LABEL_VALUE_PLAYLIST_SETTINGS:
+         return "Playlist";
+      case MENU_ENUM_LABEL_VALUE_POINTER_ENABLE:
+         return "Touch Ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_PORT:
+         return "Poort";
+      case MENU_ENUM_LABEL_VALUE_PRESENT:
+         return "Aanwezig";
+      case MENU_ENUM_LABEL_VALUE_PRIVACY_SETTINGS:
+         return "Privacy";
+      case MENU_ENUM_LABEL_VALUE_QUIT_RETROARCH:
+         return "RetroArch Afsluiten";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_CRC32:
+         return "CRC32";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DESCRIPTION:
+         return "Omschrijving";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DEVELOPER:
+         return "Ontwikkelaar";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_FRANCHISE:
+         return "Franchise";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_MD5:
+         return "MD5";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_NAME:
+         return "Naam";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ORIGIN:
+         return "Afkomst";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_PUBLISHER:
+         return "Uitgever";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_MONTH:
+         return "Release datum maand";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_YEAR:
+         return "Release datum jaar";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_SHA1:
+         return "SHA1";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_START_CONTENT:
+         return "Content Opstarten";
+      case MENU_ENUM_LABEL_VALUE_RECORDING_CONFIG_DIRECTORY:
+         return "Opname Config Map";
+      case MENU_ENUM_LABEL_VALUE_RECORDING_OUTPUT_DIRECTORY:
+         return "Opname Uitvoer Map";
+      case MENU_ENUM_LABEL_VALUE_RECORDING_SETTINGS:
+         return "Opname";
+      case MENU_ENUM_LABEL_VALUE_RECORD_CONFIG:
+         return "Opname Configuratie";
+      case MENU_ENUM_LABEL_VALUE_RECORD_DRIVER:
+         return "Opname Driver";
+      case MENU_ENUM_LABEL_VALUE_RECORD_ENABLE:
+         return "Opname";
+      case MENU_ENUM_LABEL_VALUE_RECORD_PATH:
+         return "Uitvoer Bestand";
+      case MENU_ENUM_LABEL_VALUE_RECORD_USE_OUTPUT_DIRECTORY:
+         return "Gebruik uitvoer map";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_LOAD:
+         return "Laad Remap Bestand";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_CORE:
+         return "Core Remap Bestand Opslaan";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_GAME:
+         return "Game Remap Bestand Opslaan";
+      case MENU_ENUM_LABEL_VALUE_REQUIRED:
+         return "Vereist";
+      case MENU_ENUM_LABEL_VALUE_RESTART_CONTENT:
+         return "Herstart";
+      case MENU_ENUM_LABEL_VALUE_RESTART_RETROARCH:
+         return "RetroArch Opnieuw Opstarten";
+      case MENU_ENUM_LABEL_VALUE_RESUME:
+         return "Hervatten";
+      case MENU_ENUM_LABEL_VALUE_RESUME_CONTENT:
+         return "Hervatten";
+      case MENU_ENUM_LABEL_VALUE_RETROKEYBOARD:
+         return "RetroKeyboard";
+      case MENU_ENUM_LABEL_VALUE_RETROPAD:
+         return "RetroPad";
+      case MENU_ENUM_LABEL_VALUE_REWIND_ENABLE:
+         return "Rewind Activeren";
+      case MENU_ENUM_LABEL_VALUE_REWIND_GRANULARITY:
+         return "Rewind Granulariteit";
+      case MENU_ENUM_LABEL_VALUE_REWIND_SETTINGS:
+         return "Rewind";
+      case MENU_ENUM_LABEL_VALUE_RGUI_BROWSER_DIRECTORY:
+         return "Bestandsbeheer Map";
+      case MENU_ENUM_LABEL_VALUE_RGUI_CONFIG_DIRECTORY:
+         return "Config Map";
+      case MENU_ENUM_LABEL_VALUE_RGUI_SHOW_START_SCREEN:
+         return "Start Scherm Weergeven";
+      case MENU_ENUM_LABEL_VALUE_RIGHT_ANALOG:
+         return "Rechtse Analog";
+      case MENU_ENUM_LABEL_VALUE_SAVEFILE_DIRECTORY:
+         return "Savebestand Map";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_INDEX:
+         return "Save State Automatische Index";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_LOAD:
+         return "Automatisch State Loaden";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_SAVE:
+         return "Automatisch State Saven";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_DIRECTORY:
+         return "Savestate Map";
+      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG:
+         return "Huidige configuratie opslaan";
+      case MENU_ENUM_LABEL_VALUE_SAVE_NEW_CONFIG:
+         return "Nieuwe configuratie opslaan";
+      case MENU_ENUM_LABEL_VALUE_SAVE_STATE:
+         return "Save State";
+      case MENU_ENUM_LABEL_VALUE_SAVING_SETTINGS:
+         return "Saving";
+      case MENU_ENUM_LABEL_VALUE_SCAN_DIRECTORY:
+         return "Scan een Map";
+      case MENU_ENUM_LABEL_VALUE_SCAN_FILE:
+         return "Scan een Bestand";
+      case MENU_ENUM_LABEL_VALUE_SCAN_THIS_DIRECTORY:
+         return "<Scan Deze Map>";
+      case MENU_ENUM_LABEL_VALUE_SCREENSHOT_DIRECTORY:
+         return "Screenshot Map";
+      case MENU_ENUM_LABEL_VALUE_SCREEN_RESOLUTION:
+         return "Scherm Resolutie";
+      case MENU_ENUM_LABEL_VALUE_SEARCH:
+         return "Zoeken:";
+      case MENU_ENUM_LABEL_VALUE_SECONDS:
+         return "secondes";
+      case MENU_ENUM_LABEL_VALUE_SETTINGS:
+         return "Instellingen";
+      case MENU_ENUM_LABEL_VALUE_SETTINGS_TAB:
+         return "Instellingen";
+      case MENU_ENUM_LABEL_VALUE_SHADER:
+         return "Shader";
+      case MENU_ENUM_LABEL_VALUE_SHADER_APPLY_CHANGES:
+         return "Shader Instellingen Toepassen";
+      case MENU_ENUM_LABEL_VALUE_SHADER_OPTIONS:
+         return "Shaders";
+      case MENU_ENUM_LABEL_VALUE_SHOW_ADVANCED_SETTINGS:
+         return "Geavanceerde instellingen weergeven";
+      case MENU_ENUM_LABEL_VALUE_SLOWMOTION_RATIO:
+         return "Slow-Motion Ratio";
+      case MENU_ENUM_LABEL_VALUE_SORT_SAVEFILES_ENABLE:
+         return "Saves Sorteren In Map";
+      case MENU_ENUM_LABEL_VALUE_SORT_SAVESTATES_ENABLE:
+         return "Savestates Sorteren In Map";
+      case MENU_ENUM_LABEL_VALUE_STATUS:
+         return "Status";
+      case MENU_ENUM_LABEL_VALUE_STDIN_CMD_ENABLE:
+         return "stdin Commandos";
+      case MENU_ENUM_LABEL_VALUE_SUSPEND_SCREENSAVER_ENABLE:
+         return "Onderbreek Screensaver";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_BGM_ENABLE:
+         return "Systeem BGM";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_DIRECTORY:
+         return "Systeem/BIOS Map";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFORMATION:
+         return "Systeem Informatie";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_7ZIP_SUPPORT:
+         return "7zip ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ALSA_SUPPORT:
+         return "ALSA ondersteuning";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_BUILD_DATE:
          return "Build datum";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GIT_VERSION:
-         return "Git versie";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CG_SUPPORT:
+         return "Cg ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COCOA_SUPPORT:
+         return "Cocoa ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COMMAND_IFACE_SUPPORT:
+         return "Command interface ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CORETEXT_SUPPORT:
+         return "CoreText ondersteuning";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CPU_FEATURES:
          return "CPU Features";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_DPI:
+         return "Display metric DPI";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_HEIGHT:
+         return "Display metric hoogte (mm)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_WIDTH:
+         return "Display metric breedte (mm)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DSOUND_SUPPORT:
+         return "DirectSound ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DYLIB_SUPPORT:
+         return "Dynamic library ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_EGL_SUPPORT:
+         return "EGL ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FBO_SUPPORT:
+         return "OpenGL/Direct3D render-to-texture (multi-pass shaders) ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FFMPEG_SUPPORT:
+         return "FFmpeg ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FREETYPE_SUPPORT:
+         return "FreeType ondersteuning";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_IDENTIFIER:
          return "Frontend identificatie";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_NAME:
          return "Frontend naam";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_OS:
          return "Frontend OS";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RETRORATING_LEVEL:
-         return "RetroRating level";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE:
-         return "Energie bron";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_NO_SOURCE:
-         return "Geen bron";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGING:
-         return "Opladen";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGED:
-         return "Charged";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_DISCHARGING:
-         return "Discharging";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VIDEO_CONTEXT_DRIVER:
-         return "Video context driver";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_WIDTH:
-         return "Display metric breedte (mm)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_HEIGHT:
-         return "Display metric hoogte (mm)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_DPI:
-         return "Display metric DPI";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBRETRODB_SUPPORT:
-         return "LibretroDB ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OVERLAY_SUPPORT:
-         return "Overlay ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COMMAND_IFACE_SUPPORT:
-         return "Command interface ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETWORK_COMMAND_IFACE_SUPPORT:
-         return "Network Command interface ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COCOA_SUPPORT:
-         return "Cocoa ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RPNG_SUPPORT:
-         return "PNG ondersteuning (RPNG)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_SUPPORT:
-         return "SDL1.2 ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL2_SUPPORT:
-         return "SDL2 ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGL_SUPPORT:
-         return "OpenGL ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGLES_SUPPORT:
-         return "OpenGL ES ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_THREADING_SUPPORT:
-         return "Threading ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_KMS_SUPPORT:
-         return "KMS/EGL ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_UDEV_SUPPORT:
-         return "Udev ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENVG_SUPPORT:
-         return "OpenVG ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_EGL_SUPPORT:
-         return "EGL ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_X11_SUPPORT:
-         return "X11 ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_WAYLAND_SUPPORT:
-         return "Wayland ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XVIDEO_SUPPORT:
-         return "XVideo ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ALSA_SUPPORT:
-         return "ALSA ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OSS_SUPPORT:
-         return "OSS ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENAL_SUPPORT:
-         return "OpenAL ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENSL_SUPPORT:
-         return "OpenSL ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RSOUND_SUPPORT:
-         return "RSound ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ROARAUDIO_SUPPORT:
-         return "RoarAudio ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_JACK_SUPPORT:
-         return "JACK ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PULSEAUDIO_SUPPORT:
-         return "PulseAudio ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DSOUND_SUPPORT:
-         return "DirectSound ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XAUDIO2_SUPPORT:
-         return "XAudio2 ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ZLIB_SUPPORT:
-         return "Zlib ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_7ZIP_SUPPORT:
-         return "7zip ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DYLIB_SUPPORT:
-         return "Dynamic library ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CG_SUPPORT:
-         return "Cg ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GIT_VERSION:
+         return "Git versie";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GLSL_SUPPORT:
          return "GLSL ondersteuning";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_HLSL_SUPPORT:
          return "HLSL ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBXML2_SUPPORT:
-         return "libxml2 XML parsing ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_IMAGE_SUPPORT:
-         return "SDL afbeeldingen ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FBO_SUPPORT:
-         return "OpenGL/Direct3D render-to-texture (multi-pass shaders) ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FFMPEG_SUPPORT:
-         return "FFmpeg ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CORETEXT_SUPPORT:
-         return "CoreText ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FREETYPE_SUPPORT:
-         return "FreeType ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETPLAY_SUPPORT:
-         return "Netplay (peer-to-peer) ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PYTHON_SUPPORT:
-         return "Python (script ondersteuning in shaders) ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_V4L2_SUPPORT:
-         return "Video4Linux2 ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_JACK_SUPPORT:
+         return "JACK ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_KMS_SUPPORT:
+         return "KMS/EGL ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBRETRODB_SUPPORT:
+         return "LibretroDB ondersteuning";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBUSB_SUPPORT:
          return "Libusb ondersteuning";
-      case MENU_ENUM_LABEL_VALUE_YES:
-         return "Ja";
-      case MENU_ENUM_LABEL_VALUE_NO:
-         return "Nee";
-      case MENU_ENUM_LABEL_VALUE_SCREEN_RESOLUTION:
-         return "Scherm Resolutie";
-      case MENU_ENUM_LABEL_VALUE_BACK:
-         return "TERUG";
-      case MENU_ENUM_LABEL_VALUE_DISABLED:
-         return "Uitgeschakeld";
-      case MENU_ENUM_LABEL_VALUE_PORT:
-         return "Poort";
-      case MENU_ENUM_LABEL_VALUE_NONE:
-         return "Geen";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DEVELOPER:
-         return "Ontwikkelaar";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_PUBLISHER:
-         return "Uitgever";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DESCRIPTION:
-         return "Omschrijving";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_NAME:
-         return "Naam";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ORIGIN:
-         return "Afkomst";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_FRANCHISE:
-         return "Franchise";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_MONTH:
-         return "Release datum maand";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_YEAR:
-         return "Release datum jaar";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBXML2_SUPPORT:
+         return "libxml2 XML parsing ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETPLAY_SUPPORT:
+         return "Netplay (peer-to-peer) ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETWORK_COMMAND_IFACE_SUPPORT:
+         return "Network Command interface ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENAL_SUPPORT:
+         return "OpenAL ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGLES_SUPPORT:
+         return "OpenGL ES ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGL_SUPPORT:
+         return "OpenGL ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENSL_SUPPORT:
+         return "OpenSL ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENVG_SUPPORT:
+         return "OpenVG ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OSS_SUPPORT:
+         return "OSS ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OVERLAY_SUPPORT:
+         return "Overlay ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE:
+         return "Energie bron";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGED:
+         return "Charged";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGING:
+         return "Opladen";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_DISCHARGING:
+         return "Discharging";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_NO_SOURCE:
+         return "Geen bron";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PULSEAUDIO_SUPPORT:
+         return "PulseAudio ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PYTHON_SUPPORT:
+         return "Python (script ondersteuning in shaders) ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RETRORATING_LEVEL:
+         return "RetroRating level";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ROARAUDIO_SUPPORT:
+         return "RoarAudio ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RPNG_SUPPORT:
+         return "PNG ondersteuning (RPNG)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RSOUND_SUPPORT:
+         return "RSound ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL2_SUPPORT:
+         return "SDL2 ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_IMAGE_SUPPORT:
+         return "SDL afbeeldingen ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_SUPPORT:
+         return "SDL1.2 ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_THREADING_SUPPORT:
+         return "Threading ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_UDEV_SUPPORT:
+         return "Udev ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_V4L2_SUPPORT:
+         return "Video4Linux2 ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VIDEO_CONTEXT_DRIVER:
+         return "Video context driver";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_WAYLAND_SUPPORT:
+         return "Wayland ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_X11_SUPPORT:
+         return "X11 ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XAUDIO2_SUPPORT:
+         return "XAudio2 ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XVIDEO_SUPPORT:
+         return "XVideo ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ZLIB_SUPPORT:
+         return "Zlib ondersteuning";
+      case MENU_ENUM_LABEL_VALUE_TAKE_SCREENSHOT:
+         return "Schermafdruk";
+      case MENU_ENUM_LABEL_VALUE_THREADED_DATA_RUNLOOP_ENABLE:
+         return "Threaded data runloop";
+      case MENU_ENUM_LABEL_VALUE_TIMEDATE_ENABLE:
+         return "Tijd/datum weergeven";
+      case MENU_ENUM_LABEL_VALUE_TITLE_COLOR:
+         return "Menu titel kleur";
       case MENU_ENUM_LABEL_VALUE_TRUE:
          return "Waar";
-      case MENU_ENUM_LABEL_VALUE_FALSE:
-         return "Niet waar";
-      case MENU_ENUM_LABEL_VALUE_MISSING:
-         return "Ontbrekend";
-      case MENU_ENUM_LABEL_VALUE_PRESENT:
-         return "Aanwezig";
-      case MENU_ENUM_LABEL_VALUE_OPTIONAL:
-         return "Optioneel";
-      case MENU_ENUM_LABEL_VALUE_REQUIRED:
-         return "Vereist";
-      case MENU_ENUM_LABEL_VALUE_STATUS:
-         return "Status";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_SETTINGS:
-         return "Geluid";
-      case MENU_ENUM_LABEL_VALUE_INPUT_SETTINGS:
-         return "Invoer";
-      case MENU_ENUM_LABEL_VALUE_ONSCREEN_DISPLAY_SETTINGS:
-         return "Onscreen Weergave";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_SETTINGS:
-         return "Onscreen Overlay";
-      case MENU_ENUM_LABEL_VALUE_MENU_SETTINGS:
-         return "Menu";
-      case MENU_ENUM_LABEL_VALUE_MULTIMEDIA_SETTINGS:
-         return "Multimedia";
+      case MENU_ENUM_LABEL_VALUE_UI_COMPANION_START_ON_BOOT:
+         return "UI Companion Start Tijdens Boot";
+      case MENU_ENUM_LABEL_VALUE_UI_MENUBAR_ENABLE:
+         return "Menubalk";
+      case MENU_ENUM_LABEL_VALUE_UNABLE_TO_READ_COMPRESSED_FILE:
+         return "Fout opgetreden tijdens lezen van gecomprimeerd bestand.";
+      case MENU_ENUM_LABEL_VALUE_UNKNOWN:
+         return "Onbekend";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_ASSETS:
+         return "Update Assets";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_AUTOCONFIG_PROFILES:
+         return "Update Autoconfiguratie Profielen";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_CG_SHADERS:
+         return "Update Cg Shaders";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_CHEATS:
+         return "Update Cheats";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_CORE_INFO_FILES:
+         return "Update Core Info Bestanden";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_DATABASES:
+         return "Update Databases";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_GLSL_SHADERS:
+         return "Update GLSL Shaders";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_OVERLAYS:
+         return "Update Overlays";
+      case MENU_ENUM_LABEL_VALUE_USER:
+         return "Gebruiker";
       case MENU_ENUM_LABEL_VALUE_USER_INTERFACE_SETTINGS:
          return "Gebruikersinterface";
-      case MENU_ENUM_LABEL_VALUE_MENU_FILE_BROWSER_SETTINGS:
-         return "Menu Bestandsbeheer";
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_SETTINGS:
-         return "Updater";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_SETTINGS:
-         return "Netwerk";
-      case MENU_ENUM_LABEL_VALUE_PLAYLIST_SETTINGS:
-         return "Playlist";
+      case MENU_ENUM_LABEL_VALUE_USER_LANGUAGE:
+         return "Taal";
       case MENU_ENUM_LABEL_VALUE_USER_SETTINGS:
          return "Gebruiker";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_SETTINGS:
-         return "Mappen";
-      case MENU_ENUM_LABEL_VALUE_RECORDING_SETTINGS:
-         return "Opname";
-      case MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE:
-         return "Informatie is niet beschikbaar.";
-      case MENU_ENUM_LABEL_VALUE_INPUT_USER_BINDS:
-         return "Invoer Gebruiker %u Binds";
-      case MENU_ENUM_LABEL_VALUE_LANG_ENGLISH:
-         return "Engels";
-      case MENU_ENUM_LABEL_VALUE_LANG_JAPANESE:
-         return "Japans";
-      case MENU_ENUM_LABEL_VALUE_LANG_FRENCH:
-         return "Frans";
-      case MENU_ENUM_LABEL_VALUE_LANG_SPANISH:
-         return "Spaans";
-      case MENU_ENUM_LABEL_VALUE_LANG_GERMAN:
-         return "Duits";
-      case MENU_ENUM_LABEL_VALUE_LANG_ITALIAN:
-         return "Italiaans";
-      case MENU_ENUM_LABEL_VALUE_LANG_DUTCH:
-         return "Nederlands";
-      case MENU_ENUM_LABEL_VALUE_LANG_PORTUGUESE:
-         return "Portugees";
-      case MENU_ENUM_LABEL_VALUE_LANG_RUSSIAN:
-         return "Russisch";
-      case MENU_ENUM_LABEL_VALUE_LANG_KOREAN:
-         return "Koreaans";
-      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_TRADITIONAL:
-         return "Chinees (Traditioneel)";
-      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_SIMPLIFIED:
-         return "Chinees (Gesimplificeerd)";
-      case MENU_ENUM_LABEL_VALUE_LANG_ESPERANTO:
-         return "Esperanto";
-      case MENU_ENUM_LABEL_VALUE_LEFT_ANALOG:
-         return "Linkse Analog";
-      case MENU_ENUM_LABEL_VALUE_RIGHT_ANALOG:
-         return "Rechtse Analog";
-      case MENU_ENUM_LABEL_VALUE_INPUT_HOTKEY_BINDS:
-         return "Invoer Hotkey Binds";
-      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_SETTINGS:
-         return "Frame Throttle";
-      case MENU_ENUM_LABEL_VALUE_SEARCH:
-         return "Zoeken:";
+      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_PLAYER:
+         return "Gebruik Ingebouwde Media Speler";
+      case MENU_ENUM_LABEL_VALUE_USE_THIS_DIRECTORY:
+         return "<Deze directory gebruiken>";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ALLOW_ROTATE:
+         return "Rotatie toestaan";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_AUTO:
+         return "Auto Beeldverhouding";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_INDEX:
+         return "Beeldverhouding Index";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_BLACK_FRAME_INSERTION:
+         return "Zwarte Frame Injectie";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_CROP_OVERSCAN:
+         return "Overscan Afsnijden (Herladen vereist)";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_DISABLE_COMPOSITION:
+         return "Desktop Compositie deactiveren";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_DRIVER:
+         return "Video Driver";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER:
+         return "Video Filter";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_DIR:
+         return "Video Filter Map";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_FLICKER:
+         return "Flicker filter";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_ENABLE:
+         return "OSD Berichten Weergeven";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_PATH:
+         return "OSD Berichten Font";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_SIZE:
+         return "OSD Berichten Grootte";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_ASPECT:
+         return "Forceer beeldverhouding";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_SRGB_DISABLE:
+         return "Handmatig sRGB FBO deactiveren";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FRAME_DELAY:
+         return "Frame Delay"; /* TODO/FIXME */
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FULLSCREEN:
+         return "Gebruik Fullscreen Mode";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_GAMMA:
+         return "Video Gamma";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_RECORD:
+         return "GPU Opname";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_SCREENSHOT:
+         return "GPU Screenshot Activeren";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC:
+         return "Harde GPU Synchronisatie";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC_FRAMES:
+         return "Harde GPU Sync Frames";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_X:
+         return "OSD Berichten X-as positie";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_Y:
+         return "OSD Berichten Y-as positie";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MONITOR_INDEX:
+         return "Monitor Index";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_POST_FILTER_RECORD:
+         return "Post filter opname activeren";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE:
+         return "Refresh Rate";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE_AUTO:
+         return "Geschatte Monitor Framerate";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ROTATION:
+         return "Rotatie";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE:
+         return "Windowed Schalering";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE_INTEGER:
+         return "Gehele schalering";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SETTINGS:
+         return "Video";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_DIR:
+         return "Video Shader Map";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_NUM_PASSES:
+         return "Shader Passes"; /* TODO/FIXME */
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PARAMETERS:
+         return "Voorbeeldweergave Shader Parameters";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET:
+         return "Laad Shader Preset";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_PARAMETERS:
+         return "Menu Shader Parameters";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_AS:
+         return "Shader Preset Opslaan Als";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHARED_CONTEXT:
+         return "HW Shared Context Activeren";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SMOOTH:
+         return "Hardware Bilinear Filtering";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SOFT_FILTER:
+         return "Soft Filter";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SWAP_INTERVAL:
+         return "VSync Swap Interval";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_TAB:
+         return "Video";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_THREADED:
+         return "Threaded Video";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VFILTER:
+         return "Deflicker"; /* TODO/FIXME */
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VI_WIDTH:
+         return "VI Scherm Breedte Instellen";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VSYNC:
+         return "VSync";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_WINDOWED_FULLSCREEN:
+         return "Windowed Fullscreen Mode"; /* TODO/FIXME */
+      case MENU_ENUM_LABEL_VALUE_YES:
+         return "Ja";
       default:
          break;
    }

--- a/intl/msg_hash_pl.c
+++ b/intl/msg_hash_pl.c
@@ -36,981 +36,980 @@ const char *msg_hash_to_str_pl(enum msg_hash_enums msg)
 {
    switch (msg)
    {
-      case MSG_PROGRAM:
-         return "RetroArch";
-      case MSG_MOVIE_RECORD_STOPPED:
-         return "Zatrzymano nagrywanie filmu.";
-      case MSG_MOVIE_PLAYBACK_ENDED:
-         return "Zakończono odtwarzanie filmu.";
-      case MSG_AUTOSAVE_FAILED:
-         return "Nie udało się zainicjalizować automatycznego zapisu.";
-      case MSG_NETPLAY_FAILED_MOVIE_PLAYBACK_HAS_STARTED:
-         return "Odtwarzanie filmu w toku. Nie można rozpocząć gry sieciowej.";
-      case MSG_NETPLAY_FAILED:
-         return "Nie udało się zainicjalizować gry sieciowej.";
-      case MSG_LIBRETRO_ABI_BREAK:
-         return "został skompilowany dla innej wersji libretro, różnej od obecnie używanej.";
-      case MSG_REWIND_INIT_FAILED_THREADED_AUDIO:
-         return "Implementacja używa osobnego wątku do przetwarzania dźwięku. Przewijanie nie jest możliwe.";
-      case MSG_REWIND_INIT_FAILED:
-         return "Nie udało się zainicjalizować bufora przewijania. Przewijanie zostanie wyłączone.";
-      case MSG_REWIND_INIT:
-         return "Inicjalizowanie bufora przewijania o rozmiarze";
-      case MSG_CUSTOM_TIMING_GIVEN:
-         return "Wprowadzono niestandardowy timing";
-      case MSG_VIEWPORT_SIZE_CALCULATION_FAILED:
-         return "Obliczanie rozmiaru viewportu nie powiodło się! Kontynuowanie z użyciem surowych danych. Prawdopodobnie nie będzie to działało poprawnie...";
-      case MSG_HW_RENDERED_MUST_USE_POSTSHADED_RECORDING:
-         return "Ten rdzeń libretro używa renderowania sprzętowego. Konieczne jest użycie nagrywania wraz z zaaplikowanymi shaderami.";
-      case MSG_RECORDING_TO:
-         return "Nagrywanie do";
-      case MSG_DETECTED_VIEWPORT_OF:
-         return "Wykrywanie viewportu";
-      case MSG_TAKING_SCREENSHOT:
-         return "Zapisywanie zrzutu.";
-      case MSG_FAILED_TO_TAKE_SCREENSHOT:
-         return "Nie udało się zapisać zrzutu.";
-      case MSG_FAILED_TO_START_RECORDING:
-         return "Nie udało się rozpocząć nagrywania.";
-      case MSG_RECORDING_TERMINATED_DUE_TO_RESIZE:
-         return "Przerwano nagrywanie z powodu zmiany rozmiaru.";
-      case MSG_USING_LIBRETRO_DUMMY_CORE_RECORDING_SKIPPED:
-         return "Atrapa rdzenia w użyciu. Pomijanie nagrywania.";
-      case MSG_UNKNOWN:
-         return "Nieznane";
-      case MSG_LOADING_CONTENT_FILE:
-         return "Wczytywanie pliku treści";
-      case MSG_RECEIVED:
-         return "otrzymano";
-      case MSG_UNRECOGNIZED_COMMAND:
-         return "Nieznana komenda";
-      case MSG_SENDING_COMMAND:
-         return "Wysyłanie komendy";
-      case MSG_GOT_INVALID_DISK_INDEX:
-         return "Otrzymano nieprawidłowy indeks dysku.";
-      case MSG_FAILED_TO_REMOVE_DISK_FROM_TRAY:
-         return "Nie udało się usunąć dysku z tacki.";
-      case MSG_REMOVED_DISK_FROM_TRAY:
-         return "Usunięto dysk z tacki.";
-      case MSG_VIRTUAL_DISK_TRAY:
-         return "wirtualna tacka."; /* this is funny */
-      case MSG_FAILED_TO:
-         return "Nie udało się";
-      case MSG_TO:
-         return "do";
-      case MSG_SAVING_RAM_TYPE:
-         return "Zapisywanie typu RAM";
-      case MSG_SAVING_STATE:
-         return "Zapisywanie stanu";
-      case MSG_LOADING_STATE:
-         return "Wczytywanie stanu";
-      case MSG_FAILED_TO_LOAD_MOVIE_FILE:
-         return "Nie udało się wczytać pliku filmu";
-      case MSG_FAILED_TO_LOAD_CONTENT:
-         return "Nie udało się wczytać treści";
-      case MSG_COULD_NOT_READ_CONTENT_FILE:
-         return "Nie udało się odczytać pliku treści";
-      case MSG_GRAB_MOUSE_STATE:
-         return "Grab mouse state";
-      case MSG_PAUSED:
-         return "Wstrzymano.";
-      case MSG_UNPAUSED:
-         return "Wznowiono.";
-      case MSG_FAILED_TO_LOAD_OVERLAY:
-         return "Nie udało się wczytać nakładki.";
-      case MSG_FAILED_TO_UNMUTE_AUDIO:
-         return "Nie udało się przywrócić dźwięku.";
-      case MSG_AUDIO_MUTED:
-         return "Wyciszono dźwięk.";
-      case MSG_AUDIO_UNMUTED:
-         return "Przywrócono dźwięk.";
-      case MSG_RESET:
-         return "Reset";
-      case MSG_FAILED_TO_LOAD_STATE:
-         return "Nie udało się wczytać stanu z";
-      case MSG_FAILED_TO_SAVE_STATE_TO:
-         return "Nie udało się zapisać stanu do";
-      case MSG_FAILED_TO_SAVE_SRAM:
-         return "Nie udało się zapisać SRAM";
-      case MSG_STATE_SIZE:
-         return "Rozmiar stanu";
-      case MSG_FOUND_SHADER:
-         return "Znaleziono shader";
-      case MSG_SRAM_WILL_NOT_BE_SAVED:
-         return "SRAM nie zostanie zapisany.";
-      case MSG_BLOCKING_SRAM_OVERWRITE:
-         return "Blokowanie nadpisania SRAM";
-      case MSG_CORE_DOES_NOT_SUPPORT_SAVESTATES:
-         return "Rdzeń nie wspiera zapisów stanu.";
-      case MSG_SAVED_STATE_TO_SLOT:
-         return "Zapisano stan w slocie";
-      case MSG_SAVED_SUCCESSFULLY_TO:
-         return "Pomyślnie zapisano do";
-      case MSG_BYTES:
-         return "bajtów";
-      case MSG_CONFIG_DIRECTORY_NOT_SET:
-         return "Nie ustawiono katalogu konfiguracji. Nie można zapisać nowej konfiguracji.";
-      case MSG_SKIPPING_SRAM_LOAD:
-         return "Pomijanie wczytywania SRAM.";
-      case MSG_APPENDED_DISK:
-         return "Dopisano do dysku";
-      case MSG_STARTING_MOVIE_PLAYBACK:
-         return "Rozpoczynanie odtwarzania filmu.";
-      case MSG_FAILED_TO_REMOVE_TEMPORARY_FILE:
-         return "Nie udało się usunąć pliku tymczasowego";
-      case MSG_REMOVING_TEMPORARY_CONTENT_FILE:
-         return "Usuwanie tymczasowego pliku treści";
-      case MSG_LOADED_STATE_FROM_SLOT:
-         return "Wczytano stan ze slotu";
-      case MSG_SCANNING_OF_DIRECTORY_FINISHED:
-         return "Zakończono skanowanie katalogu";
-      case MSG_SCANNING:
-         return "Skanowanie";
-      case MSG_REDIRECTING_CHEATFILE_TO:
-         return "Przekierowywanie pliku cheatów do";
-      case MSG_REDIRECTING_SAVEFILE_TO:
-         return "Przekierowywanie pliku zapisu do";
-      case MSG_REDIRECTING_SAVESTATE_TO:
-         return "Przekierowywanie zapisu stanu do";
-/* TODO */
-      case MSG_APPLYING_CHEAT:
-         return "Applying cheat changes.";
-      case MSG_SHADER:
-         return "Shader";
-      case MSG_APPLYING_SHADER:
-         return "Aplikowanie shadera";
-      case MSG_FAILED_TO_APPLY_SHADER:
-         return "Nie udało się zaaplikować shadera.";
-      case MSG_STARTING_MOVIE_RECORD_TO:
-         return "Rozpoczynanie zapisu filmu do";
-      case MSG_FAILED_TO_START_MOVIE_RECORD:
-         return "Nie udało się rozpocząć nagrywania filmu.";
-      case MSG_STATE_SLOT:
-         return "Slot zapisu";
-      case MSG_RESTARTING_RECORDING_DUE_TO_DRIVER_REINIT:
-         return "Ponowne rozpoczęcie nagrywania z powodu reinicjalizacji kontrolera.";
-      case MSG_SLOW_MOTION:
-         return "Spowolnione tempo.";
-      case MSG_SLOW_MOTION_REWIND:
-         return "Przewijanie w spowolnionym tempie.";
-      case MSG_REWINDING:
-         return "Przewijanie.";
-      case MSG_REWIND_REACHED_END:
-         return "W buforze przewijania nie ma więcej danych.";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_AUTOLOAD_PREFERRED:
-         return "Automatycznie wczytaj preferowaną nakładkę";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_CORE_INFO_FILES:
-         return "Aktualizuj pliki informacji o rdzeniach";
-      case MENU_ENUM_LABEL_VALUE_DOWNLOAD_CORE_CONTENT:
-         return "Pobierz treści";
-      case MENU_ENUM_LABEL_VALUE_SCAN_THIS_DIRECTORY:
-         return "<Przeszukaj ten katalog>";
-      case MENU_ENUM_LABEL_VALUE_SCAN_FILE:
-         return "Skanuj plik";
-      case MENU_ENUM_LABEL_VALUE_SCAN_DIRECTORY:
-         return "Przeszukaj katalog";
       case MENU_ENUM_LABEL_VALUE_ADD_CONTENT_LIST:
          return "Dodaj treść";
-      case MENU_ENUM_LABEL_VALUE_INFORMATION_LIST:
-         return "Informacje";
-      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_PLAYER:
-         return "Użyj wbudowanego odtwarzacza mediów";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_SETTINGS:
-         return "Szybkie menu";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_CRC32:
-         return "CRC32";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_MD5:
-         return "MD5";
-      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_LIST:
-         return "Wczytaj treść";
-      case MENU_ENUM_LABEL_VALUE_LOAD_ARCHIVE:
-         return "Wczytaj archiwum";
-      case MENU_ENUM_LABEL_VALUE_OPEN_ARCHIVE:
-         return "Otwórz archiwum";
-      case MENU_ENUM_LABEL_VALUE_ASK_ARCHIVE:
-         return "Pytaj";
-      case MENU_ENUM_LABEL_VALUE_PRIVACY_SETTINGS:
-         return "Ustawienia prywatności";
-      case MENU_ENUM_LABEL_VALUE_HORIZONTAL_MENU: /* Don't change. Breaks everything. (Would be: "Menu poziome") */
-         return "Horizontal Menu";
-      case MENU_ENUM_LABEL_VALUE_NO_SETTINGS_FOUND:
-         return "Nie znaleziono ustawień.";
-      case MENU_ENUM_LABEL_VALUE_NO_PERFORMANCE_COUNTERS:
-         return "Brak liczników wydajności.";
-      case MENU_ENUM_LABEL_VALUE_DRIVER_SETTINGS:
-         return "Ustawienia kontrolerów";
-      case MENU_ENUM_LABEL_VALUE_CONFIGURATION_SETTINGS:
-         return "Ustawienia konfiguracji";
-      case MENU_ENUM_LABEL_VALUE_CORE_SETTINGS:
-         return "Ustawienia rdzenia";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SETTINGS:
-         return "Ustawienia wideo";
-      case MENU_ENUM_LABEL_VALUE_LOGGING_SETTINGS:
-         return "Ustawienia logowania";
-      case MENU_ENUM_LABEL_VALUE_SAVING_SETTINGS:
-         return "Ustawienia zapisywania";
-      case MENU_ENUM_LABEL_VALUE_REWIND_SETTINGS:
-         return "Ustawienia przewijania";
-      case MENU_ENUM_LABEL_VALUE_SHADER:
-         return "Shader";
-      case MENU_ENUM_LABEL_VALUE_CHEAT:
-         return "Cheat";
-      case MENU_ENUM_LABEL_VALUE_USER:
-         return "Użytkownik";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_BGM_ENABLE:
-         return "Włącz BGM systemu";
-      case MENU_ENUM_LABEL_VALUE_RETROPAD:
-         return "RetroPad";
-      case MENU_ENUM_LABEL_VALUE_RETROKEYBOARD:
-         return "RetroKeyboard";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_BLOCK_FRAMES:
-         return "Block Frames";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_LABEL_SHOW:
-         return "Wyświetl opisy przycisków dla tego rdzenia"; /* UPDATE/FIXME */
-      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_HIDE_UNBOUND:
-         return "Ukryj nieprzypisane przyciski";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_ENABLE:
-         return "Wyświetlaj wiadomości OSD";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_PATH:
-         return "Czcionka wiadomości OSD";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_SIZE:
-         return "Rozmiar wiadomości OSD";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_X:
-         return "Współrzędna X dla wiadomości OSD";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_Y:
-         return "Współrzędna Y dla wiadomości OSD";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SOFT_FILTER:
-         return "Włącz filtr programowy";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_FLICKER:
-         return "Filtr migotania";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_CONTENT:
-         return "<Katalog treści>";
-      case MENU_ENUM_LABEL_VALUE_UNKNOWN:
-         return "Nieznane";
-      case MENU_ENUM_LABEL_VALUE_DONT_CARE:
-         return "Bez znaczenia";
-      case MENU_ENUM_LABEL_VALUE_LINEAR:
-         return "Liniowe";
-      case MENU_ENUM_LABEL_VALUE_NEAREST:
-         return "Najbliższe";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_DEFAULT:
-         return "<Domyślny>";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NONE:
-         return "<Żaden>";
-      case MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE:
-         return "B/D";
-      case MENU_ENUM_LABEL_VALUE_INPUT_REMAPPING_DIRECTORY:
-         return "Katalog plików remapowania";
-      case MENU_ENUM_LABEL_VALUE_JOYPAD_AUTOCONFIG_DIR:
-         return "Katalog autokonfiguracji kontrolerów gier";
-      case MENU_ENUM_LABEL_VALUE_RECORDING_CONFIG_DIRECTORY:
-         return "Katalog konfiguracji nagrywania";
-      case MENU_ENUM_LABEL_VALUE_RECORDING_OUTPUT_DIRECTORY:
-         return "Katalog wyjściowy nagrywania";
-      case MENU_ENUM_LABEL_VALUE_SCREENSHOT_DIRECTORY:
-         return "Katalog zrzutów";
-      case MENU_ENUM_LABEL_VALUE_PLAYLIST_DIRECTORY:
-         return "Katalog historii";
-      case MENU_ENUM_LABEL_VALUE_SAVEFILE_DIRECTORY:
-         return "Katalog zapisów treści";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_DIRECTORY:
-         return "Katalog zapisanych stanów";
-      case MENU_ENUM_LABEL_VALUE_STDIN_CMD_ENABLE:
-         return "Komendy stdin";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_DRIVER:
-         return "Kontroler wideo";
-      case MENU_ENUM_LABEL_VALUE_RECORD_ENABLE:
-         return "Włącz nagrywanie";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_RECORD:
-         return "Włącz nagrywanie z użyciem GPU";
-      case MENU_ENUM_LABEL_VALUE_RECORD_PATH: /* FIXME/UPDATE */
-         return "Ścieżka nagrywania";
-      case MENU_ENUM_LABEL_VALUE_RECORD_USE_OUTPUT_DIRECTORY:
-         return "Używaj katalogu wyjściowego nagrywania";
-      case MENU_ENUM_LABEL_VALUE_RECORD_CONFIG:
-         return "Konfiguracja nagrywania";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_POST_FILTER_RECORD:
-         return "Nagrywaj wraz z zaaplikowanymi filtrami";
-      case MENU_ENUM_LABEL_VALUE_CORE_ASSETS_DIRECTORY:
-         return "Katalog pobranych";
-      case MENU_ENUM_LABEL_VALUE_ASSETS_DIRECTORY:
-         return "Katalog assetów";
-      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPERS_DIRECTORY:
-         return "Katalog dynamicznych tapet";
-      case MENU_ENUM_LABEL_VALUE_RGUI_BROWSER_DIRECTORY:
-         return "Katalog przeglądarki";
-      case MENU_ENUM_LABEL_VALUE_RGUI_CONFIG_DIRECTORY:
-         return "Katalog zapisanych konfiguracji";
-      case MENU_ENUM_LABEL_VALUE_LIBRETRO_INFO_PATH:
-         return "Katalog informacji o rdzeniach";
-      case MENU_ENUM_LABEL_VALUE_LIBRETRO_DIR_PATH:
-         return "Katalog rdzeni";
-      case MENU_ENUM_LABEL_VALUE_CURSOR_DIRECTORY:
-         return "Katalog z kursorami";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_DATABASE_DIRECTORY:
-         return "Katalog bazy danych treści";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_DIRECTORY:
-         return "Katalog systemu";
-      case MENU_ENUM_LABEL_VALUE_CHEAT_DATABASE_PATH:
-         return "Katalog z plikami cheatów";
-      case MENU_ENUM_LABEL_VALUE_CACHE_DIRECTORY: /* UPDATE/FIXME */
-         return "Katalog do wypakowywania archiwów";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_FILTER_DIR:
-         return "Katalog filtrów audio";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_DIR:
-         return "Katalog shaderów";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_DIR:
-         return "Katalog filtrów wideo";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_DIRECTORY:
-         return "Katalog nakładek";
-      case MENU_ENUM_LABEL_VALUE_OSK_OVERLAY_DIRECTORY:
-         return "Katalog klawiatur ekranowych";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT: /* TODO: Original string changed */
-         return "Zamień kontrolery w grze sieciowej";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE:
-         return "Tryb obserwatora gry sieciowej";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS: /* TODO: Original string changed */
-         return "Adres IP";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT:
-         return "Port TCP/UDP gry sieciowej";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE:
-         return "Włącz grę sieciową";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_DELAY_FRAMES:
-         return "Opóxnione klatki w grze sieciowej";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_MODE:
-         return "Tryb klienta gry sieciowej";
-      case MENU_ENUM_LABEL_VALUE_RGUI_SHOW_START_SCREEN:
-         return "Pokazuj ekran startowy";
-      case MENU_ENUM_LABEL_VALUE_TITLE_COLOR:
-         return "Kolor tytułu menu";
-      case MENU_ENUM_LABEL_VALUE_ENTRY_HOVER_COLOR:
-         return "Kolor zaznaczonego elementu menu";
-      case MENU_ENUM_LABEL_VALUE_TIMEDATE_ENABLE:
-         return "Wyświetl czas/datę";
-      case MENU_ENUM_LABEL_VALUE_THREADED_DATA_RUNLOOP_ENABLE:
-         return "Osobny wątek odbierania danych";
-      case MENU_ENUM_LABEL_VALUE_ENTRY_NORMAL_COLOR:
-         return "Zwykły kolor elementu menu";
-      case MENU_ENUM_LABEL_VALUE_SHOW_ADVANCED_SETTINGS:
-         return "Pokaż zaawansowane ustawienia";
-      case MENU_ENUM_LABEL_VALUE_MOUSE_ENABLE:
-         return "Obsługa myszy";
-      case MENU_ENUM_LABEL_VALUE_POINTER_ENABLE:
-         return "Obsługa dotyku";
-      case MENU_ENUM_LABEL_VALUE_CORE_ENABLE:
-         return "Wyświetlaj nazwę rdzenia";
-      case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_ENABLE:
-         return "Pomiń wykryte DPI";
-      case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_VALUE:
-         return "Własne DPI";
-      case MENU_ENUM_LABEL_VALUE_SUSPEND_SCREENSAVER_ENABLE:
-         return "Wstrzymaj wygaszacz";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_DISABLE_COMPOSITION:
-         return "Wyłącz efekty kompozycji pulpitu";
-      case MENU_ENUM_LABEL_VALUE_PAUSE_NONACTIVE:
-         return "Wstrzymaj gdy w tle";
-      case MENU_ENUM_LABEL_VALUE_UI_COMPANION_START_ON_BOOT:
-         return "UI Companion Start On Boot";
-      case MENU_ENUM_LABEL_VALUE_UI_MENUBAR_ENABLE:
-         return "Pasek menu";
       case MENU_ENUM_LABEL_VALUE_ARCHIVE_MODE:
          return "Archive File Association Action";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_ENABLE:
-         return "Komendy sieciowe";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_PORT:
-         return "Port dla komend sieciowych";
-      case MENU_ENUM_LABEL_VALUE_HISTORY_LIST_ENABLE:
-         return "Włącz historię treści";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_HISTORY_SIZE:
-         return "Rozmiar historii treści";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE_AUTO:
-         return "Szacowana częstotliwość odświeżania monitora";
-      case MENU_ENUM_LABEL_VALUE_DUMMY_ON_CORE_SHUTDOWN:
-         return "Atrapa rdzenia przy zatrzymaniu rdzenia";
-      case MENU_ENUM_LABEL_VALUE_CORE_SET_SUPPORTS_NO_CONTENT_ENABLE: /* TODO/FIXME */
-         return "Nie uruchamiaj rdzenia automatycznie";
-      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_ENABLE:
-         return "Limituj maksymalną szybkość działania";
-      case MENU_ENUM_LABEL_VALUE_FASTFORWARD_RATIO:
-         return "Maksymalna szybkość działania";
-      case MENU_ENUM_LABEL_VALUE_AUTO_REMAPS_ENABLE:
-         return "Automatycznie wczytuj pliki remapowania";
-      case MENU_ENUM_LABEL_VALUE_SLOWMOTION_RATIO:
-         return "Współczynnik spowolnienia";
-      case MENU_ENUM_LABEL_VALUE_CORE_SPECIFIC_CONFIG:
-         return "Osobna konfiguracja dla każdego rdzenia";
-      case MENU_ENUM_LABEL_VALUE_AUTO_OVERRIDES_ENABLE:
-         return "Load Override Files Automatically"; /* this one's rather complicated */
-      case MENU_ENUM_LABEL_VALUE_CONFIG_SAVE_ON_EXIT:
-         return "Zapisz konfigurację przy wyjściu";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SMOOTH:
-         return "Sprzętowe filtrowanie dwuliniowe";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_GAMMA:
-         return "Gamma wideo";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ALLOW_ROTATE:
-         return "Zezwól na obrót";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC:
-         return "Ścisła synchronizacja GPU";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SWAP_INTERVAL:
-         return "VSync Swap Interval";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VSYNC:
-         return "Synchronizacja pionowa";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_THREADED:
-         return "Osobny wątek wideo";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ROTATION:
-         return "Obrót";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_SCREENSHOT:
-         return "Wykonuj zrzuty ekranu z wykorzystaniem GPU";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_CROP_OVERSCAN:
-         return "Wytnij overscan (restart)";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_INDEX:
-         return "Indeks współczynnika proporcji";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_AUTO:
-         return "Auto współczynnik proporcji";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_ASPECT:
-         return "Wymuś współczynnik proporcji";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE:
-         return "Częstotliwość odświeżania";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_SRGB_DISABLE:
-         return "Wymuś wyłączenie sRGB FBO";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_WINDOWED_FULLSCREEN:
-         return "Tryb pełnego ekranu w oknie";
-      case MENU_ENUM_LABEL_VALUE_PAL60_ENABLE:
-         return "Użyj trybu PAL60";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VFILTER:
-         return "Redukcja migotania";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VI_WIDTH:
-         return "Set VI Screen Width";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_BLACK_FRAME_INSERTION:
-         return "Wstawiaj czarne klatki";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC_FRAMES:
-         return "Hard GPU Sync Frames";
-      case MENU_ENUM_LABEL_VALUE_SORT_SAVEFILES_ENABLE:
-         return "Sortuj zapisy w folderach";
-      case MENU_ENUM_LABEL_VALUE_SORT_SAVESTATES_ENABLE:
-         return "Sortuj zapisane stany w folderach";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FULLSCREEN:
-         return "Pełny ekran";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE:
-         return "Skala w oknie";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE_INTEGER:
-         return "Skaluj w liczbach całkowitych";
-      case MENU_ENUM_LABEL_VALUE_PERFCNT_ENABLE:
-         return "Liczniki wydajności";
-      case MENU_ENUM_LABEL_VALUE_LIBRETRO_LOG_LEVEL:
-         return "Poziom logowania rdzenia";
-      case MENU_ENUM_LABEL_VALUE_LOG_VERBOSITY:
-         return "Szczegółowość logowania";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_LOAD:
-         return "Automatyczne wczytywanie stanu";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_INDEX:
-         return "Indeks automatycznie zapisywanego stanu";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_SAVE:
-         return "Automatyczny zapis stanu";
-      case MENU_ENUM_LABEL_VALUE_AUTOSAVE_INTERVAL:
-         return "Częstotliwość automatycznego zapisu SaveRAM";
-      case MENU_ENUM_LABEL_VALUE_BLOCK_SRAM_OVERWRITE:
-         return "Nie nadpisuj SaveRAM przy wczytywaniu stanu";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHARED_CONTEXT:
-         return "HW Shared Context Enable";
-      case MENU_ENUM_LABEL_VALUE_RESTART_RETROARCH:
-         return "Uruchom ponownie RetroArch";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_NICKNAME:
-         return "Nazwa użytkownika";
-      case MENU_ENUM_LABEL_VALUE_USER_LANGUAGE:
-         return "Język";
-      case MENU_ENUM_LABEL_VALUE_CAMERA_ALLOW:
-         return "Zezwalaj na dostęp do kamerki";
-      case MENU_ENUM_LABEL_VALUE_LOCATION_ALLOW:
-         return "Zezwalaj na dostęp do lokalizacji";
-      case MENU_ENUM_LABEL_VALUE_PAUSE_LIBRETRO:
-         return "Pauzuj przy wejściu do menu";
-      case MENU_ENUM_LABEL_VALUE_INPUT_OSK_OVERLAY_ENABLE:
-         return "Wyświetlaj klawiaturę ekranową";
-      case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_ENABLE:
-         return "Wyświetlaj nakładkę";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MONITOR_INDEX:
-         return "Indeks monitora";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FRAME_DELAY:
-         return "Opóźnienie klatek";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DUTY_CYCLE:
-         return "Cykl zmian";
-      case MENU_ENUM_LABEL_VALUE_INPUT_TURBO_PERIOD:
-         return "Okres turbo";
-      case MENU_ENUM_LABEL_VALUE_INPUT_AXIS_THRESHOLD:
-         return "Próg osi";
-      case MENU_ENUM_LABEL_VALUE_INPUT_REMAP_BINDS_ENABLE:
-         return "Włącz remapowanie bindów";
-      case MENU_ENUM_LABEL_VALUE_INPUT_MAX_USERS:
-         return "Maksymalna liczba użytkowników";
-      case MENU_ENUM_LABEL_VALUE_INPUT_AUTODETECT_ENABLE:
-         return "Włącz autokonfigurację";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_OUTPUT_RATE:
-         return "Częstotliwość próbkowania dźwięku (KHz)";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_MAX_TIMING_SKEW:
-         return "Audio Maximum Timing Skew";
-      case MENU_ENUM_LABEL_VALUE_CHEAT_NUM_PASSES:
-         return "Liczba przebiegów cheatów";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_CORE:
-         return "Zapisz plik remapowania dla rdzenia";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_GAME:
-         return "Zapisz plik remapowania dla gry";
-      case MENU_ENUM_LABEL_VALUE_CHEAT_APPLY_CHANGES:
-         return "Zastosuj zmiany cheatów";
-      case MENU_ENUM_LABEL_VALUE_SHADER_APPLY_CHANGES:
-         return "Zastosuj zmiany shaderów";
-      case MENU_ENUM_LABEL_VALUE_REWIND_ENABLE:
-         return "Włącz przewijanie";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_COLLECTION_LIST:
-         return "Kolekcji";
-      case MENU_ENUM_LABEL_VALUE_DETECT_CORE_LIST:
-         return "Wybierz plik i dopasuj rdzeń";
-      case MENU_ENUM_LABEL_VALUE_DOWNLOADED_FILE_DETECT_CORE_LIST:
-         return "Wybierz pobrany plik i dopasuj rdzeń"; /* TODO/FIXME - rewrite */
-      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_HISTORY:
-         return "Wczytaj z ostatnio używanych";
+      case MENU_ENUM_LABEL_VALUE_ASK_ARCHIVE:
+         return "Pytaj";
+      case MENU_ENUM_LABEL_VALUE_ASSETS_DIRECTORY:
+         return "Katalog assetów";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_BLOCK_FRAMES:
+         return "Block Frames";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_DEVICE:
+         return "Urządzenie audio";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_DRIVER:
+         return "Kontroler dźwięku";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_DSP_PLUGIN:
+         return "Wtyczki audio DSP";
       case MENU_ENUM_LABEL_VALUE_AUDIO_ENABLE:
          return "Włącz dźwięk";
-      case MENU_ENUM_LABEL_VALUE_FPS_SHOW:
-         return "Wyświetlaj FPS";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_FILTER_DIR:
+         return "Katalog filtrów audio";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_LATENCY:
+         return "Opóźnienie dźwięku (ms)";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_MAX_TIMING_SKEW:
+         return "Audio Maximum Timing Skew";
       case MENU_ENUM_LABEL_VALUE_AUDIO_MUTE:
          return "Wycisz dźwięk";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_VOLUME:
-         return "Poziom głośności (dB)";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_SYNC:
-         return "Włącz synchronizację dźwięku";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_OUTPUT_RATE:
+         return "Częstotliwość próbkowania dźwięku (KHz)";
       case MENU_ENUM_LABEL_VALUE_AUDIO_RATE_CONTROL_DELTA:
          return "Audio Rate Control Delta";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_NUM_PASSES:
-         return "Liczba przebiegów shadera";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_SHA1:
-         return "SHA1";
-      case MENU_ENUM_LABEL_VALUE_CONFIGURATIONS:
-         return "Wczytaj konfigurację";
-      case MENU_ENUM_LABEL_VALUE_REWIND_GRANULARITY:
-         return "Płynność przewijania";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_LOAD:
-         return "Wczytaj plik remapowania";
-      case MENU_ENUM_LABEL_VALUE_CUSTOM_RATIO:
-         return "Włąsny współczynnik";
-      case MENU_ENUM_LABEL_VALUE_USE_THIS_DIRECTORY:
-         return "<Użyj tego katalogu>";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_START_CONTENT:
-         return "Uruchom treść";
-      case MENU_ENUM_LABEL_VALUE_DISK_OPTIONS:
-         return "Opcje dysku rdzenia";
-      case MENU_ENUM_LABEL_VALUE_CORE_OPTIONS:
-         return "Opcje";
-      case MENU_ENUM_LABEL_VALUE_CORE_CHEAT_OPTIONS:
-         return "Opcje cheatów rdzenia";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_RESAMPLER_DRIVER:
+         return "Kontroler resamplera dźwięku";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_SETTINGS:
+         return "Ustawienia dźwięku";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_SYNC:
+         return "Włącz synchronizację dźwięku";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_VOLUME:
+         return "Poziom głośności (dB)";
+      case MENU_ENUM_LABEL_VALUE_AUTOSAVE_INTERVAL:
+         return "Częstotliwość automatycznego zapisu SaveRAM";
+      case MENU_ENUM_LABEL_VALUE_AUTO_OVERRIDES_ENABLE:
+         return "Load Override Files Automatically"; /* this one's rather complicated */
+      case MENU_ENUM_LABEL_VALUE_AUTO_REMAPS_ENABLE:
+         return "Automatycznie wczytuj pliki remapowania";
+      case MENU_ENUM_LABEL_VALUE_BACK:
+         return "WSTECZ";
+      case MENU_ENUM_LABEL_VALUE_BLOCK_SRAM_OVERWRITE:
+         return "Nie nadpisuj SaveRAM przy wczytywaniu stanu";
+      case MENU_ENUM_LABEL_VALUE_BUILDBOT_ASSETS_URL:
+         return "URL assetów buildbota";
+      case MENU_ENUM_LABEL_VALUE_CACHE_DIRECTORY: /* UPDATE/FIXME */
+         return "Katalog do wypakowywania archiwów";
+      case MENU_ENUM_LABEL_VALUE_CAMERA_ALLOW:
+         return "Zezwalaj na dostęp do kamerki";
+      case MENU_ENUM_LABEL_VALUE_CAMERA_DRIVER:
+         return "Kontroler kamerki";
+      case MENU_ENUM_LABEL_VALUE_CHEAT:
+         return "Cheat";
+      case MENU_ENUM_LABEL_VALUE_CHEAT_APPLY_CHANGES:
+         return "Zastosuj zmiany cheatów";
+      case MENU_ENUM_LABEL_VALUE_CHEAT_DATABASE_PATH:
+         return "Katalog z plikami cheatów";
       case MENU_ENUM_LABEL_VALUE_CHEAT_FILE_LOAD:
          return "Wczytaj plik z cheatami";
       case MENU_ENUM_LABEL_VALUE_CHEAT_FILE_SAVE_AS:
          return "Zapisz plik z cheatami jako";
+      case MENU_ENUM_LABEL_VALUE_CHEAT_NUM_PASSES:
+         return "Liczba przebiegów cheatów";
+      case MENU_ENUM_LABEL_VALUE_CLOSE_CONTENT:
+         return "Zamknij";
+      case MENU_ENUM_LABEL_VALUE_CONFIGURATIONS:
+         return "Wczytaj konfigurację";
+      case MENU_ENUM_LABEL_VALUE_CONFIGURATION_SETTINGS:
+         return "Ustawienia konfiguracji";
+      case MENU_ENUM_LABEL_VALUE_CONFIG_SAVE_ON_EXIT:
+         return "Zapisz konfigurację przy wyjściu";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_COLLECTION_LIST:
+         return "Kolekcji";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_DATABASE_DIRECTORY:
+         return "Katalog bazy danych treści";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_HISTORY_SIZE:
+         return "Rozmiar historii treści";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_SETTINGS:
+         return "Szybkie menu";
+      case MENU_ENUM_LABEL_VALUE_CORE_ASSETS_DIRECTORY:
+         return "Katalog pobranych";
+      case MENU_ENUM_LABEL_VALUE_CORE_CHEAT_OPTIONS:
+         return "Opcje cheatów rdzenia";
       case MENU_ENUM_LABEL_VALUE_CORE_COUNTERS:
          return "Liczniki rdzenia";
-      case MENU_ENUM_LABEL_VALUE_TAKE_SCREENSHOT:
-         return "Zapisz zrzut";
-      case MENU_ENUM_LABEL_VALUE_RESUME:
-         return "Wznów";
-      case MENU_ENUM_LABEL_VALUE_DISK_INDEX:
-         return "Indeks dysku";
-      case MENU_ENUM_LABEL_VALUE_FRONTEND_COUNTERS:
-         return "Liczniki frontendu";
-      case MENU_ENUM_LABEL_VALUE_DISK_IMAGE_APPEND:
-         return "Dopisz do obrazu dysku";
+      case MENU_ENUM_LABEL_VALUE_CORE_ENABLE:
+         return "Wyświetlaj nazwę rdzenia";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFORMATION:
+         return "Informacje o rdzeniu";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_AUTHORS:
+         return "Autorzy";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CATEGORIES:
+         return "Kategorie";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_LABEL:
+         return "Oznaczenie rdzenia";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NAME:
+         return "Nazwa rdzenia";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NOTES:
+         return "Dodatkowe informacje o rdzeniu";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_FIRMWARE:
+         return "Firmware";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_LICENSES:
+         return "Licencja(-e)";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_PERMISSIONS:
+         return "Zezwolenia";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SUPPORTED_EXTENSIONS:
+         return "Wspierane rozszerzenia";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_MANUFACTURER:
+         return "Producent systemu";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_NAME:
+         return "Nazwa systemu";
+      case MENU_ENUM_LABEL_VALUE_CORE_INPUT_REMAPPING_OPTIONS:
+         return "Opcje remapowania kontrolera rdzenia"; /* this is quite bad */
+      case MENU_ENUM_LABEL_VALUE_CORE_LIST:
+         return "Wczytaj rdzeń";
+      case MENU_ENUM_LABEL_VALUE_CORE_OPTIONS:
+         return "Opcje";
+      case MENU_ENUM_LABEL_VALUE_CORE_SETTINGS:
+         return "Ustawienia rdzenia";
+      case MENU_ENUM_LABEL_VALUE_CORE_SET_SUPPORTS_NO_CONTENT_ENABLE: /* TODO/FIXME */
+         return "Nie uruchamiaj rdzenia automatycznie";
+      case MENU_ENUM_LABEL_VALUE_CORE_SPECIFIC_CONFIG:
+         return "Osobna konfiguracja dla każdego rdzenia";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
+         return "Automatycznie wypakowuj pobierane archiwa";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_BUILDBOT_URL:
+         return "URL rdzeni buildbota";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_LIST:
+         return "Aktualizator rdzeni";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_SETTINGS:
+         return "Ustawienia aktualizatora";
+      case MENU_ENUM_LABEL_VALUE_CURSOR_DIRECTORY:
+         return "Katalog z kursorami";
+      case MENU_ENUM_LABEL_VALUE_CURSOR_MANAGER:
+         return "Menedżer kursorów";
+      case MENU_ENUM_LABEL_VALUE_CUSTOM_RATIO:
+         return "Włąsny współczynnik";
+      case MENU_ENUM_LABEL_VALUE_DATABASE_MANAGER:
+         return "Menedżer bazy danych";
+      case MENU_ENUM_LABEL_VALUE_DETECT_CORE_LIST:
+         return "Wybierz plik i dopasuj rdzeń";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_CONTENT:
+         return "<Katalog treści>";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_DEFAULT:
+         return "<Domyślny>";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NONE:
+         return "<Żaden>";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NOT_FOUND:
+         return "Nie znaleziono katalogu.";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_SETTINGS:
+         return "Ustawienia katalogów";
+      case MENU_ENUM_LABEL_VALUE_DISABLED:
+         return "Wyłączone";
       case MENU_ENUM_LABEL_VALUE_DISK_CYCLE_TRAY_STATUS:
          return "Disk Cycle Tray Status";
-      case MENU_ENUM_LABEL_VALUE_NO_PLAYLIST_ENTRIES_AVAILABLE:
-         return "Brak wpisów w playliście.";
+      case MENU_ENUM_LABEL_VALUE_DISK_IMAGE_APPEND:
+         return "Dopisz do obrazu dysku";
+      case MENU_ENUM_LABEL_VALUE_DISK_INDEX:
+         return "Indeks dysku";
+      case MENU_ENUM_LABEL_VALUE_DISK_OPTIONS:
+         return "Opcje dysku rdzenia";
+      case MENU_ENUM_LABEL_VALUE_DONT_CARE:
+         return "Bez znaczenia";
+      case MENU_ENUM_LABEL_VALUE_DOWNLOADED_FILE_DETECT_CORE_LIST:
+         return "Wybierz pobrany plik i dopasuj rdzeń"; /* TODO/FIXME - rewrite */
+      case MENU_ENUM_LABEL_VALUE_DOWNLOAD_CORE_CONTENT:
+         return "Pobierz treści";
+      case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_ENABLE:
+         return "Pomiń wykryte DPI";
+      case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_VALUE:
+         return "Własne DPI";
+      case MENU_ENUM_LABEL_VALUE_DRIVER_SETTINGS:
+         return "Ustawienia kontrolerów";
+      case MENU_ENUM_LABEL_VALUE_DUMMY_ON_CORE_SHUTDOWN:
+         return "Atrapa rdzenia przy zatrzymaniu rdzenia";
+      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPER:
+         return "Dynamiczna tapeta";
+      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPERS_DIRECTORY:
+         return "Katalog dynamicznych tapet";
+      case MENU_ENUM_LABEL_VALUE_ENTRY_HOVER_COLOR:
+         return "Kolor zaznaczonego elementu menu";
+      case MENU_ENUM_LABEL_VALUE_ENTRY_NORMAL_COLOR:
+         return "Zwykły kolor elementu menu";
+      case MENU_ENUM_LABEL_VALUE_FALSE:
+         return "Fałsz";
+      case MENU_ENUM_LABEL_VALUE_FASTFORWARD_RATIO:
+         return "Maksymalna szybkość działania";
+      case MENU_ENUM_LABEL_VALUE_FPS_SHOW:
+         return "Wyświetlaj FPS";
+      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_ENABLE:
+         return "Limituj maksymalną szybkość działania";
+      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_SETTINGS:
+         return "Frame Throttle Settings";
+      case MENU_ENUM_LABEL_VALUE_FRONTEND_COUNTERS:
+         return "Liczniki frontendu";
+      case MENU_ENUM_LABEL_VALUE_HELP:
+         return "Pooc";
+      case MENU_ENUM_LABEL_VALUE_HISTORY_LIST_ENABLE:
+         return "Włącz historię treści";
+      case MENU_ENUM_LABEL_VALUE_HORIZONTAL_MENU: /* Don't change. Breaks everything. (Would be: "Menu poziome") */
+         return "Horizontal Menu";
+      case MENU_ENUM_LABEL_VALUE_INFORMATION_LIST:
+         return "Informacje";
+      case MENU_ENUM_LABEL_VALUE_INPUT_AUTODETECT_ENABLE:
+         return "Włącz autokonfigurację";
+      case MENU_ENUM_LABEL_VALUE_INPUT_AXIS_THRESHOLD:
+         return "Próg osi";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_HIDE_UNBOUND:
+         return "Ukryj nieprzypisane przyciski";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_LABEL_SHOW:
+         return "Wyświetl opisy przycisków dla tego rdzenia"; /* UPDATE/FIXME */
+      case MENU_ENUM_LABEL_VALUE_INPUT_DRIVER:
+         return "Kontroler wejścia";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DUTY_CYCLE:
+         return "Cykl zmian";
+      case MENU_ENUM_LABEL_VALUE_INPUT_HOTKEY_BINDS:
+         return "Input Hotkey Binds";
+      case MENU_ENUM_LABEL_VALUE_INPUT_MAX_USERS:
+         return "Maksymalna liczba użytkowników";
+      case MENU_ENUM_LABEL_VALUE_INPUT_OSK_OVERLAY_ENABLE:
+         return "Wyświetlaj klawiaturę ekranową";
+      case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_ENABLE:
+         return "Wyświetlaj nakładkę";
+      case MENU_ENUM_LABEL_VALUE_INPUT_REMAPPING_DIRECTORY:
+         return "Katalog plików remapowania";
+      case MENU_ENUM_LABEL_VALUE_INPUT_REMAP_BINDS_ENABLE:
+         return "Włącz remapowanie bindów";
+      case MENU_ENUM_LABEL_VALUE_INPUT_SETTINGS:
+         return "Ustawienia wprowadzania";
+      case MENU_ENUM_LABEL_VALUE_INPUT_TURBO_PERIOD:
+         return "Okres turbo";
+      case MENU_ENUM_LABEL_VALUE_INPUT_USER_BINDS:
+         return "Wprowadź bindy dla użytkownika %u";
+      case MENU_ENUM_LABEL_VALUE_JOYPAD_AUTOCONFIG_DIR:
+         return "Katalog autokonfiguracji kontrolerów gier";
+      case MENU_ENUM_LABEL_VALUE_JOYPAD_DRIVER:
+         return "Kontroler gamepadów";
+      case MENU_ENUM_LABEL_VALUE_KEYBOARD_OVERLAY_PRESET:
+         return "Preset klawiatury ekranowej";
+      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_SIMPLIFIED:
+         return "chińśki (Uproszczony)";
+      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_TRADITIONAL:
+         return "chiński (Tradycyjny)";
+      case MENU_ENUM_LABEL_VALUE_LANG_DUTCH:
+         return "duński";
+      case MENU_ENUM_LABEL_VALUE_LANG_ENGLISH:
+         return "angielski";
+      case MENU_ENUM_LABEL_VALUE_LANG_ESPERANTO:
+         return "esperanto";
+      case MENU_ENUM_LABEL_VALUE_LANG_FRENCH:
+         return "francuski";
+      case MENU_ENUM_LABEL_VALUE_LANG_GERMAN:
+         return "niemiecki";
+      case MENU_ENUM_LABEL_VALUE_LANG_ITALIAN:
+         return "włoski";
+      case MENU_ENUM_LABEL_VALUE_LANG_JAPANESE:
+         return "japoński";
+      case MENU_ENUM_LABEL_VALUE_LANG_KOREAN:
+         return "koreański";
+      case MENU_ENUM_LABEL_VALUE_LANG_PORTUGUESE:
+         return "portugalski";
+      case MENU_ENUM_LABEL_VALUE_LANG_RUSSIAN:
+         return "rosyjski";
+      case MENU_ENUM_LABEL_VALUE_LANG_SPANISH:
+         return "hiszpański";
+      case MENU_ENUM_LABEL_VALUE_LEFT_ANALOG:
+         return "Lewy analog";
+      case MENU_ENUM_LABEL_VALUE_LIBRETRO_DIR_PATH:
+         return "Katalog rdzeni";
+      case MENU_ENUM_LABEL_VALUE_LIBRETRO_INFO_PATH:
+         return "Katalog informacji o rdzeniach";
+      case MENU_ENUM_LABEL_VALUE_LIBRETRO_LOG_LEVEL:
+         return "Poziom logowania rdzenia";
+      case MENU_ENUM_LABEL_VALUE_LINEAR:
+         return "Liniowe";
+      case MENU_ENUM_LABEL_VALUE_LOAD_ARCHIVE:
+         return "Wczytaj archiwum";
+      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT:
+         return "Wybierz plik";
+      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_HISTORY:
+         return "Wczytaj z ostatnio używanych";
+      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_LIST:
+         return "Wczytaj treść";
+      case MENU_ENUM_LABEL_VALUE_LOAD_STATE:
+         return "Wczytaj stan";
+      case MENU_ENUM_LABEL_VALUE_LOCATION_ALLOW:
+         return "Zezwalaj na dostęp do lokalizacji";
+      case MENU_ENUM_LABEL_VALUE_LOCATION_DRIVER:
+         return "Kontroler lokalizacji";
+      case MENU_ENUM_LABEL_VALUE_LOGGING_SETTINGS:
+         return "Ustawienia logowania";
+      case MENU_ENUM_LABEL_VALUE_LOG_VERBOSITY:
+         return "Szczegółowość logowania";
+      case MENU_ENUM_LABEL_VALUE_MAIN_MENU:
+         return "Menu główne";
+      case MENU_ENUM_LABEL_VALUE_MANAGEMENT:
+         return "Ustawienia bazy danych";
+      case MENU_ENUM_LABEL_VALUE_MENU_DRIVER:
+         return "Kontroler menu";
+      case MENU_ENUM_LABEL_VALUE_MENU_FILE_BROWSER_SETTINGS:
+         return "Menu File Browser Settings";
+      case MENU_ENUM_LABEL_VALUE_MENU_SETTINGS:
+         return "Ustawienia menu";
+      case MENU_ENUM_LABEL_VALUE_MENU_WALLPAPER:
+         return "Tapeta menu";
+      case MENU_ENUM_LABEL_VALUE_MISSING:
+         return "Brak";
+      case MENU_ENUM_LABEL_VALUE_MOUSE_ENABLE:
+         return "Obsługa myszy";
+      case MENU_ENUM_LABEL_VALUE_MULTIMEDIA_SETTINGS:
+         return "Ustawienia multimediów";
+      case MENU_ENUM_LABEL_VALUE_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
+         return "Filtruj według wspieranych rozszerzeń"; /* TODO/FIXME - rewrite */
+      case MENU_ENUM_LABEL_VALUE_NAVIGATION_WRAPAROUND:
+         return "Zawijanie nawigacji";
+      case MENU_ENUM_LABEL_VALUE_NEAREST:
+         return "Najbliższe";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT: /* TODO: Original string changed */
+         return "Zamień kontrolery w grze sieciowej";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_DELAY_FRAMES:
+         return "Opóxnione klatki w grze sieciowej";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE:
+         return "Włącz grę sieciową";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS: /* TODO: Original string changed */
+         return "Adres IP";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_MODE:
+         return "Tryb klienta gry sieciowej";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_NICKNAME:
+         return "Nazwa użytkownika";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE:
+         return "Tryb obserwatora gry sieciowej";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT:
+         return "Port TCP/UDP gry sieciowej";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_ENABLE:
+         return "Komendy sieciowe";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_PORT:
+         return "Port dla komend sieciowych";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_SETTINGS:
+         return "Ustawienia sieci";
+      case MENU_ENUM_LABEL_VALUE_NO:
+         return "Nie";
+      case MENU_ENUM_LABEL_VALUE_NONE:
+         return "Żaden";
+      case MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE:
+         return "B/D";
+      case MENU_ENUM_LABEL_VALUE_NO_CORE:
+         return "Brak rdzenia";
+      case MENU_ENUM_LABEL_VALUE_NO_CORES_AVAILABLE:
+         return "Brak dostępnych rdzeni.";
       case MENU_ENUM_LABEL_VALUE_NO_CORE_INFORMATION_AVAILABLE:
          return "Brak informacji o rdzeniu.";
       case MENU_ENUM_LABEL_VALUE_NO_CORE_OPTIONS_AVAILABLE:
          return "Brak dostępnych opcji rdzenia.";
-      case MENU_ENUM_LABEL_VALUE_NO_CORES_AVAILABLE:
-         return "Brak dostępnych rdzeni.";
-      case MENU_ENUM_LABEL_VALUE_NO_CORE:
-         return "Brak rdzenia";
-      case MENU_ENUM_LABEL_VALUE_DATABASE_MANAGER:
-         return "Menedżer bazy danych";
-      case MENU_ENUM_LABEL_VALUE_CURSOR_MANAGER:
-         return "Menedżer kursorów";
-      case MENU_ENUM_LABEL_VALUE_MAIN_MENU:
-         return "Menu główne";
-      case MENU_ENUM_LABEL_VALUE_SETTINGS:
-         return "Ustawienia";
-      case MENU_ENUM_LABEL_VALUE_QUIT_RETROARCH:
-         return "Opuść RetroArch";
-      case MENU_ENUM_LABEL_VALUE_HELP:
-         return "Pooc";
-      case MENU_ENUM_LABEL_VALUE_SAVE_NEW_CONFIG:
-         return "Zapisz nową konfigurację";
-      case MENU_ENUM_LABEL_VALUE_RESTART_CONTENT:
-         return "Restartuj";
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_LIST:
-         return "Aktualizator rdzeni";
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_BUILDBOT_URL:
-         return "URL rdzeni buildbota";
-      case MENU_ENUM_LABEL_VALUE_BUILDBOT_ASSETS_URL:
-         return "URL assetów buildbota";
-      case MENU_ENUM_LABEL_VALUE_NAVIGATION_WRAPAROUND:
-         return "Zawijanie nawigacji";
-      case MENU_ENUM_LABEL_VALUE_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
-         return "Filtruj według wspieranych rozszerzeń"; /* TODO/FIXME - rewrite */
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
-         return "Automatycznie wypakowuj pobierane archiwa";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFORMATION:
-         return "Informacje o systemie";
-      case MENU_ENUM_LABEL_VALUE_ONLINE_UPDATER:
-         return "Aktualizator sieciowy";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFORMATION:
-         return "Informacje o rdzeniu";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NOT_FOUND:
-         return "Nie znaleziono katalogu.";
+      case MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE:
+         return "Brak dostępnych informacji.";
       case MENU_ENUM_LABEL_VALUE_NO_ITEMS:
          return "Brak elementów.";
-      case MENU_ENUM_LABEL_VALUE_CORE_LIST:
-         return "Wczytaj rdzeń";
-      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT:
-         return "Wybierz plik";
-      case MENU_ENUM_LABEL_VALUE_CLOSE_CONTENT:
-         return "Zamknij";
-      case MENU_ENUM_LABEL_VALUE_MANAGEMENT:
-         return "Ustawienia bazy danych";
-      case MENU_ENUM_LABEL_VALUE_SAVE_STATE:
-         return "Zapisz stan";
-      case MENU_ENUM_LABEL_VALUE_LOAD_STATE:
-         return "Wczytaj stan";
-      case MENU_ENUM_LABEL_VALUE_RESUME_CONTENT:
-         return "Wznów";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DRIVER:
-         return "Kontroler wejścia";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_DRIVER:
-         return "Kontroler dźwięku";
-      case MENU_ENUM_LABEL_VALUE_JOYPAD_DRIVER:
-         return "Kontroler gamepadów";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_RESAMPLER_DRIVER:
-         return "Kontroler resamplera dźwięku";
-      case MENU_ENUM_LABEL_VALUE_RECORD_DRIVER:
-         return "Kontroler nagrywania";
-      case MENU_ENUM_LABEL_VALUE_MENU_DRIVER:
-         return "Kontroler menu";
-      case MENU_ENUM_LABEL_VALUE_CAMERA_DRIVER:
-         return "Kontroler kamerki";
-      case MENU_ENUM_LABEL_VALUE_LOCATION_DRIVER:
-         return "Kontroler lokalizacji";
-      case MENU_ENUM_LABEL_VALUE_UNABLE_TO_READ_COMPRESSED_FILE:
-         return "Nie udało się odczytać skompresowanego pliku.";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_SCALE:
-         return "Skala nakładki";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_PRESET:
-         return "Preset nakładki";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_LATENCY:
-         return "Opóźnienie dźwięku (ms)";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_DEVICE:
-         return "Urządzenie audio";
-      case MENU_ENUM_LABEL_VALUE_KEYBOARD_OVERLAY_PRESET:
-         return "Preset klawiatury ekranowej";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_OPACITY:
-         return "Nieprzeźroczystość nakładki";
-      case MENU_ENUM_LABEL_VALUE_MENU_WALLPAPER:
-         return "Tapeta menu";
-      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPER:
-         return "Dynamiczna tapeta";
-      case MENU_ENUM_LABEL_VALUE_CORE_INPUT_REMAPPING_OPTIONS:
-         return "Opcje remapowania kontrolera rdzenia"; /* this is quite bad */
-      case MENU_ENUM_LABEL_VALUE_SHADER_OPTIONS:
-         return "Opcje shadera";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PARAMETERS:
-         return "Podgląd parametrów shadera";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_PARAMETERS:
-         return "Parametry shadera menu";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_AS:
-         return "Zapisz preset shadera jako";
+      case MENU_ENUM_LABEL_VALUE_NO_PERFORMANCE_COUNTERS:
+         return "Brak liczników wydajności.";
+      case MENU_ENUM_LABEL_VALUE_NO_PLAYLIST_ENTRIES_AVAILABLE:
+         return "Brak wpisów w playliście.";
+      case MENU_ENUM_LABEL_VALUE_NO_SETTINGS_FOUND:
+         return "Nie znaleziono ustawień.";
       case MENU_ENUM_LABEL_VALUE_NO_SHADER_PARAMETERS:
          return "Brak parametrów shadera.";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET:
-         return "Wczytaj preset shaderów";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER:
-         return "Filtr obrazu";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_DSP_PLUGIN:
-         return "Wtyczki audio DSP";
-      case MENU_ENUM_LABEL_VALUE_SECONDS:
-         return "sekund";
-      case MENU_ENUM_LABEL_VALUE_ON: /* Don't change. Needed for XMB atm. (Would be: "WŁĄCZONE") */
-         return "ON";
       case MENU_ENUM_LABEL_VALUE_OFF: /* Don't change. Needed for XMB atm. (Would be: "WYŁĄCZONE") */
          return "OFF";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_ASSETS:
-         return "Aktualizuj assety";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_CHEATS:
-         return "Aktualizuj cheaty";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_AUTOCONFIG_PROFILES:
-         return "Aktualizuj profile autokonfiguracji";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_DATABASES:
-         return "Aktualizuj bazy danych";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_OVERLAYS:
-         return "Aktualizuj nakładki graficzne";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_CG_SHADERS:
-         return "Aktualizuj shadery Cg";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_GLSL_SHADERS:
-         return "Aktualizuj shadery GLSL";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NAME:
-         return "Nazwa rdzenia";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_LABEL:
-         return "Oznaczenie rdzenia";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_NAME:
-         return "Nazwa systemu";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_MANUFACTURER:
-         return "Producent systemu";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CATEGORIES:
-         return "Kategorie";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_AUTHORS:
-         return "Autorzy";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_PERMISSIONS:
-         return "Zezwolenia";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_LICENSES:
-         return "Licencja(-e)";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SUPPORTED_EXTENSIONS:
-         return "Wspierane rozszerzenia";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_FIRMWARE:
-         return "Firmware";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NOTES:
-         return "Dodatkowe informacje o rdzeniu";
+      case MENU_ENUM_LABEL_VALUE_ON: /* Don't change. Needed for XMB atm. (Would be: "WŁĄCZONE") */
+         return "ON";
+      case MENU_ENUM_LABEL_VALUE_ONLINE_UPDATER:
+         return "Aktualizator sieciowy";
+      case MENU_ENUM_LABEL_VALUE_ONSCREEN_DISPLAY_SETTINGS:
+         return "Ustawienia OSD";
+      case MENU_ENUM_LABEL_VALUE_OPEN_ARCHIVE:
+         return "Otwórz archiwum";
+      case MENU_ENUM_LABEL_VALUE_OPTIONAL:
+         return "Opcjonalny";
+      case MENU_ENUM_LABEL_VALUE_OSK_OVERLAY_DIRECTORY:
+         return "Katalog klawiatur ekranowych";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_AUTOLOAD_PREFERRED:
+         return "Automatycznie wczytaj preferowaną nakładkę";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_DIRECTORY:
+         return "Katalog nakładek";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_OPACITY:
+         return "Nieprzeźroczystość nakładki";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_PRESET:
+         return "Preset nakładki";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_SCALE:
+         return "Skala nakładki";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_SETTINGS:
+         return "Ustawienia przycisków ekranowych";
+      case MENU_ENUM_LABEL_VALUE_PAL60_ENABLE:
+         return "Użyj trybu PAL60";
+      case MENU_ENUM_LABEL_VALUE_PAUSE_LIBRETRO:
+         return "Pauzuj przy wejściu do menu";
+      case MENU_ENUM_LABEL_VALUE_PAUSE_NONACTIVE:
+         return "Wstrzymaj gdy w tle";
+      case MENU_ENUM_LABEL_VALUE_PERFCNT_ENABLE:
+         return "Liczniki wydajności";
+      case MENU_ENUM_LABEL_VALUE_PLAYLIST_DIRECTORY:
+         return "Katalog historii";
+      case MENU_ENUM_LABEL_VALUE_PLAYLIST_SETTINGS:
+         return "Ustawienia playlisty";
+      case MENU_ENUM_LABEL_VALUE_POINTER_ENABLE:
+         return "Obsługa dotyku";
+      case MENU_ENUM_LABEL_VALUE_PORT:
+         return "Port";
+      case MENU_ENUM_LABEL_VALUE_PRESENT:
+         return "Obecny";
+      case MENU_ENUM_LABEL_VALUE_PRIVACY_SETTINGS:
+         return "Ustawienia prywatności";
+      case MENU_ENUM_LABEL_VALUE_QUIT_RETROARCH:
+         return "Opuść RetroArch";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_CRC32:
+         return "CRC32";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DESCRIPTION:
+         return "Opis";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DEVELOPER:
+         return "Deweloper";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_FRANCHISE:
+         return "Franczyza";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_MD5:
+         return "MD5";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_NAME:
+         return "Nazwa";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ORIGIN:
+         return "Pochodzenie";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_PUBLISHER:
+         return "Wydawca";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_MONTH:
+         return "Miesiąc wydania";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_YEAR:
+         return "Rok wydania";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_SHA1:
+         return "SHA1";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_START_CONTENT:
+         return "Uruchom treść";
+      case MENU_ENUM_LABEL_VALUE_RECORDING_CONFIG_DIRECTORY:
+         return "Katalog konfiguracji nagrywania";
+      case MENU_ENUM_LABEL_VALUE_RECORDING_OUTPUT_DIRECTORY:
+         return "Katalog wyjściowy nagrywania";
+      case MENU_ENUM_LABEL_VALUE_RECORDING_SETTINGS:
+         return "Ustawienia nagrywania";
+      case MENU_ENUM_LABEL_VALUE_RECORD_CONFIG:
+         return "Konfiguracja nagrywania";
+      case MENU_ENUM_LABEL_VALUE_RECORD_DRIVER:
+         return "Kontroler nagrywania";
+      case MENU_ENUM_LABEL_VALUE_RECORD_ENABLE:
+         return "Włącz nagrywanie";
+      case MENU_ENUM_LABEL_VALUE_RECORD_PATH: /* FIXME/UPDATE */
+         return "Ścieżka nagrywania";
+      case MENU_ENUM_LABEL_VALUE_RECORD_USE_OUTPUT_DIRECTORY:
+         return "Używaj katalogu wyjściowego nagrywania";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_LOAD:
+         return "Wczytaj plik remapowania";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_CORE:
+         return "Zapisz plik remapowania dla rdzenia";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_GAME:
+         return "Zapisz plik remapowania dla gry";
+      case MENU_ENUM_LABEL_VALUE_REQUIRED:
+         return "Wymagany";
+      case MENU_ENUM_LABEL_VALUE_RESTART_CONTENT:
+         return "Restartuj";
+      case MENU_ENUM_LABEL_VALUE_RESTART_RETROARCH:
+         return "Uruchom ponownie RetroArch";
+      case MENU_ENUM_LABEL_VALUE_RESUME:
+         return "Wznów";
+      case MENU_ENUM_LABEL_VALUE_RESUME_CONTENT:
+         return "Wznów";
+      case MENU_ENUM_LABEL_VALUE_RETROKEYBOARD:
+         return "RetroKeyboard";
+      case MENU_ENUM_LABEL_VALUE_RETROPAD:
+         return "RetroPad";
+      case MENU_ENUM_LABEL_VALUE_REWIND_ENABLE:
+         return "Włącz przewijanie";
+      case MENU_ENUM_LABEL_VALUE_REWIND_GRANULARITY:
+         return "Płynność przewijania";
+      case MENU_ENUM_LABEL_VALUE_REWIND_SETTINGS:
+         return "Ustawienia przewijania";
+      case MENU_ENUM_LABEL_VALUE_RGUI_BROWSER_DIRECTORY:
+         return "Katalog przeglądarki";
+      case MENU_ENUM_LABEL_VALUE_RGUI_CONFIG_DIRECTORY:
+         return "Katalog zapisanych konfiguracji";
+      case MENU_ENUM_LABEL_VALUE_RGUI_SHOW_START_SCREEN:
+         return "Pokazuj ekran startowy";
+      case MENU_ENUM_LABEL_VALUE_RIGHT_ANALOG:
+         return "Prawy analog";
+      case MENU_ENUM_LABEL_VALUE_SAVEFILE_DIRECTORY:
+         return "Katalog zapisów treści";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_INDEX:
+         return "Indeks automatycznie zapisywanego stanu";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_LOAD:
+         return "Automatyczne wczytywanie stanu";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_SAVE:
+         return "Automatyczny zapis stanu";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_DIRECTORY:
+         return "Katalog zapisanych stanów";
+      case MENU_ENUM_LABEL_VALUE_SAVE_NEW_CONFIG:
+         return "Zapisz nową konfigurację";
+      case MENU_ENUM_LABEL_VALUE_SAVE_STATE:
+         return "Zapisz stan";
+      case MENU_ENUM_LABEL_VALUE_SAVING_SETTINGS:
+         return "Ustawienia zapisywania";
+      case MENU_ENUM_LABEL_VALUE_SCAN_DIRECTORY:
+         return "Przeszukaj katalog";
+      case MENU_ENUM_LABEL_VALUE_SCAN_FILE:
+         return "Skanuj plik";
+      case MENU_ENUM_LABEL_VALUE_SCAN_THIS_DIRECTORY:
+         return "<Przeszukaj ten katalog>";
+      case MENU_ENUM_LABEL_VALUE_SCREENSHOT_DIRECTORY:
+         return "Katalog zrzutów";
+      case MENU_ENUM_LABEL_VALUE_SCREEN_RESOLUTION:
+         return "Rozdzielczość ekranu";
+      case MENU_ENUM_LABEL_VALUE_SEARCH:
+         return "Szukaj:";
+      case MENU_ENUM_LABEL_VALUE_SECONDS:
+         return "sekund";
+      case MENU_ENUM_LABEL_VALUE_SETTINGS:
+         return "Ustawienia";
+      case MENU_ENUM_LABEL_VALUE_SHADER:
+         return "Shader";
+      case MENU_ENUM_LABEL_VALUE_SHADER_APPLY_CHANGES:
+         return "Zastosuj zmiany shaderów";
+      case MENU_ENUM_LABEL_VALUE_SHADER_OPTIONS:
+         return "Opcje shadera";
+      case MENU_ENUM_LABEL_VALUE_SHOW_ADVANCED_SETTINGS:
+         return "Pokaż zaawansowane ustawienia";
+      case MENU_ENUM_LABEL_VALUE_SLOWMOTION_RATIO:
+         return "Współczynnik spowolnienia";
+      case MENU_ENUM_LABEL_VALUE_SORT_SAVEFILES_ENABLE:
+         return "Sortuj zapisy w folderach";
+      case MENU_ENUM_LABEL_VALUE_SORT_SAVESTATES_ENABLE:
+         return "Sortuj zapisane stany w folderach";
+      case MENU_ENUM_LABEL_VALUE_STATUS:
+         return "Status";
+      case MENU_ENUM_LABEL_VALUE_STDIN_CMD_ENABLE:
+         return "Komendy stdin";
+      case MENU_ENUM_LABEL_VALUE_SUSPEND_SCREENSAVER_ENABLE:
+         return "Wstrzymaj wygaszacz";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_BGM_ENABLE:
+         return "Włącz BGM systemu";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_DIRECTORY:
+         return "Katalog systemu";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFORMATION:
+         return "Informacje o systemie";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_7ZIP_SUPPORT:
+         return "Wsparcie 7zip";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ALSA_SUPPORT:
+         return "Wsparcie ALSA";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_BUILD_DATE:
          return "Data kompilacji";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GIT_VERSION:
-         return "Wersja git";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CG_SUPPORT:
+         return "Wsparcie Cg";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COCOA_SUPPORT:
+         return "Wsparcie Cocoa";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COMMAND_IFACE_SUPPORT:
+         return "Wsparcie interfejsu wiersza poleceń";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CORETEXT_SUPPORT:
+         return "Wsparcie CoreText";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CPU_FEATURES:
          return "Właściwości CPU";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_DPI:
+         return "Metryczne DPI wyświetlacza";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_HEIGHT:
+         return "Metryczna wysokość wyświetlacza (mm)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_WIDTH:
+         return "Metryczna szerokość wyświetlacza (mm)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DSOUND_SUPPORT:
+         return "Wsparcie DirectSound";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DYLIB_SUPPORT:
+         return "Wsparcie bibliotek dynamicznych";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_EGL_SUPPORT:
+         return "Wsparcie EGL";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FBO_SUPPORT:
+         return "Wsparcie renderowania do tekstury w OpenGL/Direct3D (wielokrotne przebiegi shaderów)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FFMPEG_SUPPORT:
+         return "Wsparcie FFmpeg";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FREETYPE_SUPPORT:
+         return "Wsparcie FreeType";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_IDENTIFIER:
          return "Identyfikator frontendu";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_NAME:
          return "Nazwa frontendu";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_OS:
          return "System operacyjny hosta:";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RETRORATING_LEVEL:
-         return "Poziom RetroRating";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE:
-         return "Źródło zasilania";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_NO_SOURCE:
-         return "Brak źródła";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGING:
-         return "Ładowanie";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGED:
-         return "Naładowano";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_DISCHARGING:
-         return "Na baterii";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VIDEO_CONTEXT_DRIVER:
-         return "Kontroler wideo";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_WIDTH:
-         return "Metryczna szerokość wyświetlacza (mm)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_HEIGHT:
-         return "Metryczna wysokość wyświetlacza (mm)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_DPI:
-         return "Metryczne DPI wyświetlacza";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBRETRODB_SUPPORT:
-         return "Wsparcie LibretroDB";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OVERLAY_SUPPORT:
-         return "Wsparcie nakładek graficznych";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COMMAND_IFACE_SUPPORT:
-         return "Wsparcie interfejsu wiersza poleceń";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETWORK_COMMAND_IFACE_SUPPORT:
-         return "Wsparcie interfejsu komend sieciowych";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COCOA_SUPPORT:
-         return "Wsparcie Cocoa";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RPNG_SUPPORT:
-         return "Wsparcie PNG (RPNG)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_SUPPORT:
-         return "Wsparcie SDL1.2";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL2_SUPPORT:
-         return "Wsparcie SDL2";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGL_SUPPORT:
-         return "Wsparcie OpenGL";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGLES_SUPPORT:
-         return "Wsparcie OpenGL ES";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_THREADING_SUPPORT:
-         return "Wsparcie wielu wątków";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_KMS_SUPPORT:
-         return "Wsparcie KMS/EGL";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_UDEV_SUPPORT:
-         return "Wsparcie Udev";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENVG_SUPPORT:
-         return "Wsparcie OpenVG";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_EGL_SUPPORT:
-         return "Wsparcie EGL";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_X11_SUPPORT:
-         return "Wsparcie X11";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_WAYLAND_SUPPORT:
-         return "Wsparcie Wayland";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XVIDEO_SUPPORT:
-         return "Wsparcie XVideo";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ALSA_SUPPORT:
-         return "Wsparcie ALSA";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OSS_SUPPORT:
-         return "Wsparcie OSS";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENAL_SUPPORT:
-         return "Wsparcie OpenAL";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENSL_SUPPORT:
-         return "Wsparcie OpenSL";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RSOUND_SUPPORT:
-         return "Wsparcie RSound";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ROARAUDIO_SUPPORT:
-         return "Wsparcie RoarAudio";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_JACK_SUPPORT:
-         return "Wsparcie JACK";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PULSEAUDIO_SUPPORT:
-         return "Wsparcie PulseAudio";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DSOUND_SUPPORT:
-         return "Wsparcie DirectSound";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XAUDIO2_SUPPORT:
-         return "Wsparcie XAudio2";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ZLIB_SUPPORT:
-         return "Wsparcie Zlib";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_7ZIP_SUPPORT:
-         return "Wsparcie 7zip";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DYLIB_SUPPORT:
-         return "Wsparcie bibliotek dynamicznych";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CG_SUPPORT:
-         return "Wsparcie Cg";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GIT_VERSION:
+         return "Wersja git";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GLSL_SUPPORT:
          return "Wsparcie GLSL";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_HLSL_SUPPORT:
          return "Wsparcie HLSL";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBXML2_SUPPORT:
-         return "Wsparcie parsowania XML libxml2";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_IMAGE_SUPPORT:
-         return "Wsparcie SDL image";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FBO_SUPPORT:
-         return "Wsparcie renderowania do tekstury w OpenGL/Direct3D (wielokrotne przebiegi shaderów)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FFMPEG_SUPPORT:
-         return "Wsparcie FFmpeg";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CORETEXT_SUPPORT:
-         return "Wsparcie CoreText";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FREETYPE_SUPPORT:
-         return "Wsparcie FreeType";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETPLAY_SUPPORT:
-         return "Wsparcie Netplay (peer-to-peer)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PYTHON_SUPPORT:
-         return "Wsparcie Pythona (skrypty w shaderach)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_V4L2_SUPPORT:
-         return "Wsparcie Video4Linux2";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_JACK_SUPPORT:
+         return "Wsparcie JACK";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_KMS_SUPPORT:
+         return "Wsparcie KMS/EGL";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBRETRODB_SUPPORT:
+         return "Wsparcie LibretroDB";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBUSB_SUPPORT:
          return "Wsparcie libusb";
-      case MENU_ENUM_LABEL_VALUE_YES:
-         return "Tak";
-      case MENU_ENUM_LABEL_VALUE_NO:
-         return "Nie";
-      case MENU_ENUM_LABEL_VALUE_BACK:
-         return "WSTECZ";
-      case MENU_ENUM_LABEL_VALUE_SCREEN_RESOLUTION:
-         return "Rozdzielczość ekranu";
-      case MENU_ENUM_LABEL_VALUE_DISABLED:
-         return "Wyłączone";
-      case MENU_ENUM_LABEL_VALUE_PORT:
-         return "Port";
-      case MENU_ENUM_LABEL_VALUE_NONE:
-         return "Żaden";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DEVELOPER:
-         return "Deweloper";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_PUBLISHER:
-         return "Wydawca";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DESCRIPTION:
-         return "Opis";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_NAME:
-         return "Nazwa";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ORIGIN:
-         return "Pochodzenie";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_FRANCHISE:
-         return "Franczyza";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_MONTH:
-         return "Miesiąc wydania";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_YEAR:
-         return "Rok wydania";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBXML2_SUPPORT:
+         return "Wsparcie parsowania XML libxml2";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETPLAY_SUPPORT:
+         return "Wsparcie Netplay (peer-to-peer)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETWORK_COMMAND_IFACE_SUPPORT:
+         return "Wsparcie interfejsu komend sieciowych";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENAL_SUPPORT:
+         return "Wsparcie OpenAL";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGLES_SUPPORT:
+         return "Wsparcie OpenGL ES";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGL_SUPPORT:
+         return "Wsparcie OpenGL";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENSL_SUPPORT:
+         return "Wsparcie OpenSL";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENVG_SUPPORT:
+         return "Wsparcie OpenVG";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OSS_SUPPORT:
+         return "Wsparcie OSS";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OVERLAY_SUPPORT:
+         return "Wsparcie nakładek graficznych";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE:
+         return "Źródło zasilania";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGED:
+         return "Naładowano";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGING:
+         return "Ładowanie";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_DISCHARGING:
+         return "Na baterii";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_NO_SOURCE:
+         return "Brak źródła";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PULSEAUDIO_SUPPORT:
+         return "Wsparcie PulseAudio";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PYTHON_SUPPORT:
+         return "Wsparcie Pythona (skrypty w shaderach)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RETRORATING_LEVEL:
+         return "Poziom RetroRating";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ROARAUDIO_SUPPORT:
+         return "Wsparcie RoarAudio";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RPNG_SUPPORT:
+         return "Wsparcie PNG (RPNG)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RSOUND_SUPPORT:
+         return "Wsparcie RSound";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL2_SUPPORT:
+         return "Wsparcie SDL2";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_IMAGE_SUPPORT:
+         return "Wsparcie SDL image";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_SUPPORT:
+         return "Wsparcie SDL1.2";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_THREADING_SUPPORT:
+         return "Wsparcie wielu wątków";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_UDEV_SUPPORT:
+         return "Wsparcie Udev";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_V4L2_SUPPORT:
+         return "Wsparcie Video4Linux2";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VIDEO_CONTEXT_DRIVER:
+         return "Kontroler wideo";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_WAYLAND_SUPPORT:
+         return "Wsparcie Wayland";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_X11_SUPPORT:
+         return "Wsparcie X11";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XAUDIO2_SUPPORT:
+         return "Wsparcie XAudio2";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XVIDEO_SUPPORT:
+         return "Wsparcie XVideo";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ZLIB_SUPPORT:
+         return "Wsparcie Zlib";
+      case MENU_ENUM_LABEL_VALUE_TAKE_SCREENSHOT:
+         return "Zapisz zrzut";
+      case MENU_ENUM_LABEL_VALUE_THREADED_DATA_RUNLOOP_ENABLE:
+         return "Osobny wątek odbierania danych";
+      case MENU_ENUM_LABEL_VALUE_TIMEDATE_ENABLE:
+         return "Wyświetl czas/datę";
+      case MENU_ENUM_LABEL_VALUE_TITLE_COLOR:
+         return "Kolor tytułu menu";
       case MENU_ENUM_LABEL_VALUE_TRUE:
          return "Prawda";
-      case MENU_ENUM_LABEL_VALUE_FALSE:
-         return "Fałsz";
-      case MENU_ENUM_LABEL_VALUE_MISSING:
-         return "Brak";
-      case MENU_ENUM_LABEL_VALUE_PRESENT:
-         return "Obecny";
-      case MENU_ENUM_LABEL_VALUE_OPTIONAL:
-         return "Opcjonalny";
-      case MENU_ENUM_LABEL_VALUE_REQUIRED:
-         return "Wymagany";
-      case MENU_ENUM_LABEL_VALUE_STATUS:
-         return "Status";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_SETTINGS:
-         return "Ustawienia dźwięku";
-      case MENU_ENUM_LABEL_VALUE_INPUT_SETTINGS:
-         return "Ustawienia wprowadzania";
-      case MENU_ENUM_LABEL_VALUE_ONSCREEN_DISPLAY_SETTINGS:
-         return "Ustawienia OSD";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_SETTINGS:
-         return "Ustawienia przycisków ekranowych";
-      case MENU_ENUM_LABEL_VALUE_MENU_SETTINGS:
-         return "Ustawienia menu";
-      case MENU_ENUM_LABEL_VALUE_MULTIMEDIA_SETTINGS:
-         return "Ustawienia multimediów";
+      case MENU_ENUM_LABEL_VALUE_UI_COMPANION_START_ON_BOOT:
+         return "UI Companion Start On Boot";
+      case MENU_ENUM_LABEL_VALUE_UI_MENUBAR_ENABLE:
+         return "Pasek menu";
+      case MENU_ENUM_LABEL_VALUE_UNABLE_TO_READ_COMPRESSED_FILE:
+         return "Nie udało się odczytać skompresowanego pliku.";
+      case MENU_ENUM_LABEL_VALUE_UNKNOWN:
+         return "Nieznane";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_ASSETS:
+         return "Aktualizuj assety";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_AUTOCONFIG_PROFILES:
+         return "Aktualizuj profile autokonfiguracji";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_CG_SHADERS:
+         return "Aktualizuj shadery Cg";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_CHEATS:
+         return "Aktualizuj cheaty";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_CORE_INFO_FILES:
+         return "Aktualizuj pliki informacji o rdzeniach";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_DATABASES:
+         return "Aktualizuj bazy danych";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_GLSL_SHADERS:
+         return "Aktualizuj shadery GLSL";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_OVERLAYS:
+         return "Aktualizuj nakładki graficzne";
+      case MENU_ENUM_LABEL_VALUE_USER:
+         return "Użytkownik";
       case MENU_ENUM_LABEL_VALUE_USER_INTERFACE_SETTINGS:
          return "Ustawienia interfejsu użytkownika";
-      case MENU_ENUM_LABEL_VALUE_MENU_FILE_BROWSER_SETTINGS:
-         return "Menu File Browser Settings";
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_SETTINGS:
-         return "Ustawienia aktualizatora";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_SETTINGS:
-         return "Ustawienia sieci";
-      case MENU_ENUM_LABEL_VALUE_PLAYLIST_SETTINGS:
-         return "Ustawienia playlisty";
+      case MENU_ENUM_LABEL_VALUE_USER_LANGUAGE:
+         return "Język";
       case MENU_ENUM_LABEL_VALUE_USER_SETTINGS:
          return "Ustawienia użytkownika";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_SETTINGS:
-         return "Ustawienia katalogów";
-      case MENU_ENUM_LABEL_VALUE_RECORDING_SETTINGS:
-         return "Ustawienia nagrywania";
-      case MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE:
-         return "Brak dostępnych informacji.";
-      case MENU_ENUM_LABEL_VALUE_INPUT_USER_BINDS:
-         return "Wprowadź bindy dla użytkownika %u";
-      case MENU_ENUM_LABEL_VALUE_LANG_ENGLISH:
-         return "angielski";
-      case MENU_ENUM_LABEL_VALUE_LANG_JAPANESE:
-         return "japoński";
-      case MENU_ENUM_LABEL_VALUE_LANG_FRENCH:
-         return "francuski";
-      case MENU_ENUM_LABEL_VALUE_LANG_SPANISH:
-         return "hiszpański";
-      case MENU_ENUM_LABEL_VALUE_LANG_GERMAN:
-         return "niemiecki";
-      case MENU_ENUM_LABEL_VALUE_LANG_ITALIAN:
-         return "włoski";
-      case MENU_ENUM_LABEL_VALUE_LANG_DUTCH:
-         return "duński";
-      case MENU_ENUM_LABEL_VALUE_LANG_PORTUGUESE:
-         return "portugalski";
-      case MENU_ENUM_LABEL_VALUE_LANG_RUSSIAN:
-         return "rosyjski";
-      case MENU_ENUM_LABEL_VALUE_LANG_KOREAN:
-         return "koreański";
-      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_TRADITIONAL:
-         return "chiński (Tradycyjny)";
-      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_SIMPLIFIED:
-         return "chińśki (Uproszczony)";
-      case MENU_ENUM_LABEL_VALUE_LANG_ESPERANTO:
-         return "esperanto";
-      case MENU_ENUM_LABEL_VALUE_LEFT_ANALOG:
-         return "Lewy analog";
-      case MENU_ENUM_LABEL_VALUE_RIGHT_ANALOG:
-         return "Prawy analog";
-      case MENU_ENUM_LABEL_VALUE_INPUT_HOTKEY_BINDS:
-         return "Input Hotkey Binds";
-      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_SETTINGS:
-         return "Frame Throttle Settings";
-      case MENU_ENUM_LABEL_VALUE_SEARCH:
-         return "Szukaj:";
       case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_IMAGE_VIEWER:
          return "Użyj wbudowanej przeglądarki obrazów";
+      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_PLAYER:
+         return "Użyj wbudowanego odtwarzacza mediów";
+      case MENU_ENUM_LABEL_VALUE_USE_THIS_DIRECTORY:
+         return "<Użyj tego katalogu>";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ALLOW_ROTATE:
+         return "Zezwól na obrót";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_AUTO:
+         return "Auto współczynnik proporcji";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_INDEX:
+         return "Indeks współczynnika proporcji";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_BLACK_FRAME_INSERTION:
+         return "Wstawiaj czarne klatki";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_CROP_OVERSCAN:
+         return "Wytnij overscan (restart)";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_DISABLE_COMPOSITION:
+         return "Wyłącz efekty kompozycji pulpitu";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_DRIVER:
+         return "Kontroler wideo";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER:
+         return "Filtr obrazu";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_DIR:
+         return "Katalog filtrów wideo";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_FLICKER:
+         return "Filtr migotania";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_ENABLE:
+         return "Wyświetlaj wiadomości OSD";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_PATH:
+         return "Czcionka wiadomości OSD";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_SIZE:
+         return "Rozmiar wiadomości OSD";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_ASPECT:
+         return "Wymuś współczynnik proporcji";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_SRGB_DISABLE:
+         return "Wymuś wyłączenie sRGB FBO";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FRAME_DELAY:
+         return "Opóźnienie klatek";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FULLSCREEN:
+         return "Pełny ekran";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_GAMMA:
+         return "Gamma wideo";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_RECORD:
+         return "Włącz nagrywanie z użyciem GPU";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_SCREENSHOT:
+         return "Wykonuj zrzuty ekranu z wykorzystaniem GPU";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC:
+         return "Ścisła synchronizacja GPU";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC_FRAMES:
+         return "Hard GPU Sync Frames";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_X:
+         return "Współrzędna X dla wiadomości OSD";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_Y:
+         return "Współrzędna Y dla wiadomości OSD";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MONITOR_INDEX:
+         return "Indeks monitora";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_POST_FILTER_RECORD:
+         return "Nagrywaj wraz z zaaplikowanymi filtrami";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE:
+         return "Częstotliwość odświeżania";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE_AUTO:
+         return "Szacowana częstotliwość odświeżania monitora";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ROTATION:
+         return "Obrót";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE:
+         return "Skala w oknie";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE_INTEGER:
+         return "Skaluj w liczbach całkowitych";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SETTINGS:
+         return "Ustawienia wideo";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_DIR:
+         return "Katalog shaderów";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_NUM_PASSES:
+         return "Liczba przebiegów shadera";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PARAMETERS:
+         return "Podgląd parametrów shadera";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET:
+         return "Wczytaj preset shaderów";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_PARAMETERS:
+         return "Parametry shadera menu";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_AS:
+         return "Zapisz preset shadera jako";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHARED_CONTEXT:
+         return "HW Shared Context Enable";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SMOOTH:
+         return "Sprzętowe filtrowanie dwuliniowe";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SOFT_FILTER:
+         return "Włącz filtr programowy";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SWAP_INTERVAL:
+         return "VSync Swap Interval";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_THREADED:
+         return "Osobny wątek wideo";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VFILTER:
+         return "Redukcja migotania";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VI_WIDTH:
+         return "Set VI Screen Width";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VSYNC:
+         return "Synchronizacja pionowa";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_WINDOWED_FULLSCREEN:
+         return "Tryb pełnego ekranu w oknie";
+      case MENU_ENUM_LABEL_VALUE_YES:
+         return "Tak";
+      case MSG_APPENDED_DISK:
+         return "Dopisano do dysku";
+      case MSG_APPLYING_CHEAT:
+         return "Applying cheat changes.";
+      case MSG_APPLYING_SHADER:
+         return "Aplikowanie shadera";
+      case MSG_AUDIO_MUTED:
+         return "Wyciszono dźwięk.";
+      case MSG_AUDIO_UNMUTED:
+         return "Przywrócono dźwięk.";
+      case MSG_AUTOSAVE_FAILED:
+         return "Nie udało się zainicjalizować automatycznego zapisu.";
+      case MSG_BLOCKING_SRAM_OVERWRITE:
+         return "Blokowanie nadpisania SRAM";
+      case MSG_BYTES:
+         return "bajtów";
+      case MSG_CONFIG_DIRECTORY_NOT_SET:
+         return "Nie ustawiono katalogu konfiguracji. Nie można zapisać nowej konfiguracji.";
+      case MSG_CORE_DOES_NOT_SUPPORT_SAVESTATES:
+         return "Rdzeń nie wspiera zapisów stanu.";
+      case MSG_COULD_NOT_READ_CONTENT_FILE:
+         return "Nie udało się odczytać pliku treści";
+      case MSG_CUSTOM_TIMING_GIVEN:
+         return "Wprowadzono niestandardowy timing";
+      case MSG_DETECTED_VIEWPORT_OF:
+         return "Wykrywanie viewportu";
+      case MSG_FAILED_TO:
+         return "Nie udało się";
+      case MSG_FAILED_TO_APPLY_SHADER:
+         return "Nie udało się zaaplikować shadera.";
+      case MSG_FAILED_TO_LOAD_CONTENT:
+         return "Nie udało się wczytać treści";
+      case MSG_FAILED_TO_LOAD_MOVIE_FILE:
+         return "Nie udało się wczytać pliku filmu";
+      case MSG_FAILED_TO_LOAD_OVERLAY:
+         return "Nie udało się wczytać nakładki.";
+      case MSG_FAILED_TO_LOAD_STATE:
+         return "Nie udało się wczytać stanu z";
+      case MSG_FAILED_TO_REMOVE_DISK_FROM_TRAY:
+         return "Nie udało się usunąć dysku z tacki.";
+      case MSG_FAILED_TO_REMOVE_TEMPORARY_FILE:
+         return "Nie udało się usunąć pliku tymczasowego";
+      case MSG_FAILED_TO_SAVE_SRAM:
+         return "Nie udało się zapisać SRAM";
+      case MSG_FAILED_TO_SAVE_STATE_TO:
+         return "Nie udało się zapisać stanu do";
+      case MSG_FAILED_TO_START_MOVIE_RECORD:
+         return "Nie udało się rozpocząć nagrywania filmu.";
+      case MSG_FAILED_TO_START_RECORDING:
+         return "Nie udało się rozpocząć nagrywania.";
+      case MSG_FAILED_TO_TAKE_SCREENSHOT:
+         return "Nie udało się zapisać zrzutu.";
+      case MSG_FAILED_TO_UNMUTE_AUDIO:
+         return "Nie udało się przywrócić dźwięku.";
+      case MSG_FOUND_SHADER:
+         return "Znaleziono shader";
+      case MSG_GOT_INVALID_DISK_INDEX:
+         return "Otrzymano nieprawidłowy indeks dysku.";
+      case MSG_GRAB_MOUSE_STATE:
+         return "Grab mouse state";
+      case MSG_HW_RENDERED_MUST_USE_POSTSHADED_RECORDING:
+         return "Ten rdzeń libretro używa renderowania sprzętowego. Konieczne jest użycie nagrywania wraz z zaaplikowanymi shaderami.";
+      case MSG_LIBRETRO_ABI_BREAK:
+         return "został skompilowany dla innej wersji libretro, różnej od obecnie używanej.";
+      case MSG_LOADED_STATE_FROM_SLOT:
+         return "Wczytano stan ze slotu";
+      case MSG_LOADING_CONTENT_FILE:
+         return "Wczytywanie pliku treści";
+      case MSG_LOADING_STATE:
+         return "Wczytywanie stanu";
+      case MSG_MOVIE_PLAYBACK_ENDED:
+         return "Zakończono odtwarzanie filmu.";
+      case MSG_MOVIE_RECORD_STOPPED:
+         return "Zatrzymano nagrywanie filmu.";
+      case MSG_NETPLAY_FAILED:
+         return "Nie udało się zainicjalizować gry sieciowej.";
+      case MSG_NETPLAY_FAILED_MOVIE_PLAYBACK_HAS_STARTED:
+         return "Odtwarzanie filmu w toku. Nie można rozpocząć gry sieciowej.";
+      case MSG_PAUSED:
+         return "Wstrzymano.";
+      case MSG_PROGRAM:
+         return "RetroArch";
+      case MSG_RECEIVED:
+         return "otrzymano";
+      case MSG_RECORDING_TERMINATED_DUE_TO_RESIZE:
+         return "Przerwano nagrywanie z powodu zmiany rozmiaru.";
+      case MSG_RECORDING_TO:
+         return "Nagrywanie do";
+      case MSG_REDIRECTING_CHEATFILE_TO:
+         return "Przekierowywanie pliku cheatów do";
+      case MSG_REDIRECTING_SAVEFILE_TO:
+         return "Przekierowywanie pliku zapisu do";
+      case MSG_REDIRECTING_SAVESTATE_TO:
+         return "Przekierowywanie zapisu stanu do"; /* TODO */
+      case MSG_REMOVED_DISK_FROM_TRAY:
+         return "Usunięto dysk z tacki.";
+      case MSG_REMOVING_TEMPORARY_CONTENT_FILE:
+         return "Usuwanie tymczasowego pliku treści";
+      case MSG_RESET:
+         return "Reset";
+      case MSG_RESTARTING_RECORDING_DUE_TO_DRIVER_REINIT:
+         return "Ponowne rozpoczęcie nagrywania z powodu reinicjalizacji kontrolera.";
+      case MSG_REWINDING:
+         return "Przewijanie.";
+      case MSG_REWIND_INIT:
+         return "Inicjalizowanie bufora przewijania o rozmiarze";
+      case MSG_REWIND_INIT_FAILED:
+         return "Nie udało się zainicjalizować bufora przewijania. Przewijanie zostanie wyłączone.";
+      case MSG_REWIND_INIT_FAILED_THREADED_AUDIO:
+         return "Implementacja używa osobnego wątku do przetwarzania dźwięku. Przewijanie nie jest możliwe.";
+      case MSG_REWIND_REACHED_END:
+         return "W buforze przewijania nie ma więcej danych.";
+      case MSG_SAVED_STATE_TO_SLOT:
+         return "Zapisano stan w slocie";
+      case MSG_SAVED_SUCCESSFULLY_TO:
+         return "Pomyślnie zapisano do";
+      case MSG_SAVING_RAM_TYPE:
+         return "Zapisywanie typu RAM";
+      case MSG_SAVING_STATE:
+         return "Zapisywanie stanu";
+      case MSG_SCANNING:
+         return "Skanowanie";
+      case MSG_SCANNING_OF_DIRECTORY_FINISHED:
+         return "Zakończono skanowanie katalogu";
+      case MSG_SENDING_COMMAND:
+         return "Wysyłanie komendy";
+      case MSG_SHADER:
+         return "Shader";
+      case MSG_SKIPPING_SRAM_LOAD:
+         return "Pomijanie wczytywania SRAM.";
+      case MSG_SLOW_MOTION:
+         return "Spowolnione tempo.";
+      case MSG_SLOW_MOTION_REWIND:
+         return "Przewijanie w spowolnionym tempie.";
+      case MSG_SRAM_WILL_NOT_BE_SAVED:
+         return "SRAM nie zostanie zapisany.";
+      case MSG_STARTING_MOVIE_PLAYBACK:
+         return "Rozpoczynanie odtwarzania filmu.";
+      case MSG_STARTING_MOVIE_RECORD_TO:
+         return "Rozpoczynanie zapisu filmu do";
+      case MSG_STATE_SIZE:
+         return "Rozmiar stanu";
+      case MSG_STATE_SLOT:
+         return "Slot zapisu";
+      case MSG_TAKING_SCREENSHOT:
+         return "Zapisywanie zrzutu.";
+      case MSG_TO:
+         return "do";
+      case MSG_UNKNOWN:
+         return "Nieznane";
+      case MSG_UNPAUSED:
+         return "Wznowiono.";
+      case MSG_UNRECOGNIZED_COMMAND:
+         return "Nieznana komenda";
+      case MSG_USING_LIBRETRO_DUMMY_CORE_RECORDING_SKIPPED:
+         return "Atrapa rdzenia w użyciu. Pomijanie nagrywania.";
+      case MSG_VIEWPORT_SIZE_CALCULATION_FAILED:
+         return "Obliczanie rozmiaru viewportu nie powiodło się! Kontynuowanie z użyciem surowych danych. Prawdopodobnie nie będzie to działało poprawnie...";
+      case MSG_VIRTUAL_DISK_TRAY:
+         return "wirtualna tacka."; /* this is funny */
       default:
          break;
    }

--- a/intl/msg_hash_pt.c
+++ b/intl/msg_hash_pt.c
@@ -976,935 +976,934 @@ const char *msg_hash_to_str_pt(enum msg_hash_enums msg)
 {
    switch (msg)
    {
-      case MSG_UNKNOWN:
-         return "Desconhecido";
-      case MSG_RECEIVED:
-         return "recebido";
-      case MSG_UNRECOGNIZED_COMMAND:
-         return "Comando desconhecido";
-      case MSG_SENDING_COMMAND:
-         return "Enviando comando";
-      case MSG_GOT_INVALID_DISK_INDEX:
-         return "Índice de disco inválido.";
-      case MSG_FAILED_TO_REMOVE_DISK_FROM_TRAY:
-         return "Falha ao remover disco da bandeja.";
-      case MSG_REMOVED_DISK_FROM_TRAY:
-         return "Disco removido da bandeja.";
-      case MSG_VIRTUAL_DISK_TRAY:
-         return "bandeja de disco virtual.";
-      case MSG_FAILED_TO:
-         return "Falha ao";
-      case MSG_TO:
-         return "para";
-      case MSG_SAVING_RAM_TYPE:
-         return "Salvando tipo de RAM";
-      case MSG_SAVING_STATE:
-         return "Salvando estado";
-      case MSG_LOADING_STATE:
-         return "Carregando estado";
-      case MSG_FAILED_TO_LOAD_MOVIE_FILE:
-         return "Falha ao carregar vídeo";
-      case MSG_FAILED_TO_LOAD_CONTENT:
-         return "Falha ao carregar conteúdo";
-      case MSG_COULD_NOT_READ_CONTENT_FILE:
-         return "Incapaz de ler arquivo de conteúdo";
-      case MSG_GRAB_MOUSE_STATE:
-         return "Obter estado do mouse";
-      case MSG_PAUSED:
-         return "Pausado.";
-      case MSG_UNPAUSED:
-         return "Despausado.";
-      case MSG_FAILED_TO_LOAD_OVERLAY:
-         return "Falha ao carregar overlay.";
-      case MSG_FAILED_TO_UNMUTE_AUDIO:
-         return "Falha ao desativar mudo.";
-      case MSG_AUDIO_MUTED:
-         return "Áudio mudo.";
-      case MSG_AUDIO_UNMUTED:
-         return "Áudio normal.";
-      case MSG_RESET:
-         return "Reiniciar";
-      case MSG_FAILED_TO_LOAD_STATE:
-         return "Falha ao carregar estado de";
-      case MSG_FAILED_TO_SAVE_STATE_TO:
-         return "Falha ao salvar estado em";
-      case MSG_FAILED_TO_SAVE_SRAM:
-         return "Falha ao salvar SRAM";
-      case MSG_STATE_SIZE:
-         return "Tamanho do estado";
-      case MSG_BLOCKING_SRAM_OVERWRITE:
-         return "Bloqueando Sobrescrição de SRAM";
-      case MSG_CORE_DOES_NOT_SUPPORT_SAVESTATES:
-         return "O core não suporta savestates.";
-      case MSG_SAVED_STATE_TO_SLOT:
-         return "Estado salvo no slot";
-      case MSG_SAVED_SUCCESSFULLY_TO:
-         return "Salvo com sucesso em";
-      case MSG_BYTES:
-         return "bytes";
-      case MSG_CONFIG_DIRECTORY_NOT_SET:
-         return "Diretório de configurações não definido. Incapaz de salvar.";
-      case MSG_SKIPPING_SRAM_LOAD:
-         return "Ignorando carregamento de SRAM.";
-      case MSG_APPENDED_DISK:
-         return "Disco anexado";
-      case MSG_STARTING_MOVIE_PLAYBACK:
-         return "Iniciando reprodução de vídeo.";
-      case MSG_FAILED_TO_REMOVE_TEMPORARY_FILE:
-         return "Falha ao remover arquivo temporário";
-      case MSG_REMOVING_TEMPORARY_CONTENT_FILE:
-         return "Removendo conteúdo temporário";
-      case MSG_LOADED_STATE_FROM_SLOT:
-         return "Estado carregado do slot";
-      case MSG_SCANNING_OF_DIRECTORY_FINISHED:
-         return "Exame de diretório concluído";
-      case MSG_SCANNING:
-         return "Examinando";
-      case MSG_REDIRECTING_CHEATFILE_TO:
-         return "Redirecionando cheat para";
-      case MSG_REDIRECTING_SAVEFILE_TO:
-         return "Redirecionando save para";
-      case MSG_REDIRECTING_SAVESTATE_TO:
-         return "Redirecionando savestate para";
-/* TODO */
-      case MSG_APPLYING_CHEAT:
-         return "Applying cheat changes.";
-      case MSG_SHADER:
-         return "Shader";
-      case MSG_APPLYING_SHADER:
-         return "Aplicando shader";
-      case MSG_FAILED_TO_APPLY_SHADER:
-         return "Falha ao aplicar shader.";
-      case MSG_STARTING_MOVIE_RECORD_TO:
-         return "Iniciando gravação de vídeo em";
-      case MSG_FAILED_TO_START_MOVIE_RECORD:
-         return "Falha ao iniciar gravação de vídeo.";
-      case MSG_STATE_SLOT:
-         return "Slot de estado";
-      case MSG_RESTARTING_RECORDING_DUE_TO_DRIVER_REINIT:
-         return "Reiniciando gravação devido a reinício de driver.";
-      case MSG_SLOW_MOTION:
-         return "Câmera lenta.";
-      case MSG_SLOW_MOTION_REWIND:
-         return "Retrocesso em câmera lenta.";
-      case MSG_REWINDING:
-         return "Retrocedendo.";
-      case MSG_REWIND_REACHED_END:
-         return "Final do buffer de retrocesso atingido.";
-      case MSG_DOWNLOADING:
-         return "Baixando";
-      case MSG_EXTRACTING:
-         return "Extraindo";
-      case MENU_ENUM_LABEL_VALUE_START_NET_RETROPAD:
-         return "Iniciar RetroPad Remoto";
-      case MENU_ENUM_LABEL_VALUE_SCAN_THIS_DIRECTORY:
-         return "<Escanear este Diretório>";
-      case MENU_ENUM_LABEL_VALUE_SCAN_FILE:
-         return "Escanear Arquivo";
-      case MENU_ENUM_LABEL_VALUE_SCAN_DIRECTORY:
-         return "Escanear Diretório";
-      case MENU_ENUM_LABEL_VALUE_START_CORE:
-         return "Iniciar Core";
-      case MENU_ENUM_LABEL_VALUE_INFORMATION_LIST:
-         return "Informação";
-      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_PLAYER:
-         return "Usar Player Interno"; /* TODO/FIXME */
-      case MENU_ENUM_LABEL_VALUE_CONTENT_SETTINGS:
-         return "Menu Rápido";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_CRC32:
-         return "CRC32";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_MD5:
-         return "MD5";
-      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_LIST:
-         return "Carregar Conteúdo";
-      case MENU_ENUM_LABEL_VALUE_LOAD_ARCHIVE:
-         return "Carregar Arquivo";
-      case MENU_ENUM_LABEL_VALUE_OPEN_ARCHIVE:
-         return "Abrir Arquivo";
-      case MENU_ENUM_LABEL_VALUE_ASK_ARCHIVE:
-         return "Ask";
-      case MENU_ENUM_LABEL_VALUE_PRIVACY_SETTINGS:
-         return "Configurações de Privacidade";
-      case MENU_ENUM_LABEL_VALUE_HORIZONTAL_MENU:
-         return "Horizontal Menu"; /* FIXME - don't edit this yet. */
-      case MENU_ENUM_LABEL_VALUE_NO_SETTINGS_FOUND:
-         return "Nenhuma definição encontrada.";
-      case MENU_ENUM_LABEL_VALUE_NO_PERFORMANCE_COUNTERS:
-         return "Nenhum medidor de desempenho.";
-      case MENU_ENUM_LABEL_VALUE_DRIVER_SETTINGS:
-         return "Drivers";
-      case MENU_ENUM_LABEL_VALUE_CONFIGURATION_SETTINGS:
-         return "Configurações";
-      case MENU_ENUM_LABEL_VALUE_CORE_SETTINGS:
-         return "Core";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SETTINGS:
-         return "Vídeo";
-      case MENU_ENUM_LABEL_VALUE_LOGGING_SETTINGS:
-         return "Registro de Dados";
-      case MENU_ENUM_LABEL_VALUE_SAVING_SETTINGS:
-         return "Saves";
-      case MENU_ENUM_LABEL_VALUE_REWIND_SETTINGS:
-         return "Retrocesso";
-      case MENU_ENUM_LABEL_VALUE_SHADER:
-         return "Shader";
-      case MENU_ENUM_LABEL_VALUE_CHEAT:
-         return "Cheat";
-      case MENU_ENUM_LABEL_VALUE_USER:
-         return "Usuário";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_BGM_ENABLE:
-         return "Ativar Sistema BGM";
-      case MENU_ENUM_LABEL_VALUE_RETROPAD:
-         return "RetroPad";
-      case MENU_ENUM_LABEL_VALUE_RETROKEYBOARD:
-         return "RetroTeclado";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_BLOCK_FRAMES:
-         return "Quadros de Blocos de Áudio";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_LABEL_SHOW:
-         return "Mostrar Rótulos de Entradas de Core";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_HIDE_UNBOUND:
-         return "Esconder Descritores de Entradas sem Uso";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_ENABLE:
-         return "Mostrar Mensagem de Tela";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_PATH:
-         return "Fonte da Mensagem de Tela";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_SIZE:
-         return "Tamanho da Mensagem de Tela";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_X:
-         return "Posição X da Mensagem de Tela";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_Y:
-         return "Posição Y da Mensagem de Tela";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SOFT_FILTER:
-         return "Ativar Filtro de Suavização";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_FLICKER:
-         return "Filtro de Cintilação";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_CONTENT:
-         return "<Diretório de Conteúdo>";
-      case MENU_ENUM_LABEL_VALUE_UNKNOWN:
-         return "Desconhecido";
-      case MENU_ENUM_LABEL_VALUE_DONT_CARE:
-         return "Tanto faz";
-      case MENU_ENUM_LABEL_VALUE_LINEAR:
-         return "Linear";
-      case MENU_ENUM_LABEL_VALUE_NEAREST:
-         return "Nearest";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_DEFAULT:
-         return "<Padrão>";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NONE:
-         return "<Nenhum>";
-      case MENU_ENUM_LABEL_VALUE_INPUT_REMAPPING_DIRECTORY:
-         return "Remapeamentos de Controladores";
-      case MENU_ENUM_LABEL_VALUE_JOYPAD_AUTOCONFIG_DIR:
-         return "Autoconfigurações de Dispositivos de Entrada";
-      case MENU_ENUM_LABEL_VALUE_RECORDING_CONFIG_DIRECTORY:
-         return "Configurações de Gravações";
-      case MENU_ENUM_LABEL_VALUE_RECORDING_OUTPUT_DIRECTORY:
-         return "Gravações";
-      case MENU_ENUM_LABEL_VALUE_SCREENSHOT_DIRECTORY:
-         return "Capturas de Telas";
-      case MENU_ENUM_LABEL_VALUE_PLAYLIST_DIRECTORY:
-         return "Históricos";
-      case MENU_ENUM_LABEL_VALUE_SAVEFILE_DIRECTORY:
-         return "Saves";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_DIRECTORY:
-         return "Savestates";
-      case MENU_ENUM_LABEL_VALUE_STDIN_CMD_ENABLE:
-         return "Comandos stdin";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_DRIVER:
-         return "Driver de Vídeo";
-      case MENU_ENUM_LABEL_VALUE_RECORD_ENABLE:
-         return "Ativar Gravação";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_RECORD:
-         return "Ativar Gravação por GPU";
-      case MENU_ENUM_LABEL_VALUE_RECORD_PATH: /* FIXME/UPDATE */
-         return "Caminho da Gravação";
-      case MENU_ENUM_LABEL_VALUE_RECORD_USE_OUTPUT_DIRECTORY:
-         return "Diretório de Saída";
-      case MENU_ENUM_LABEL_VALUE_RECORD_CONFIG:
-         return "Configurações de Gravação";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_POST_FILTER_RECORD:
-         return "Ativar Filtro Pós-Gravação";
-      case MENU_ENUM_LABEL_VALUE_CORE_ASSETS_DIRECTORY:
-         return "Recursos (Assets) de Cores"; /* FIXME/UPDATE */
-      case MENU_ENUM_LABEL_VALUE_ASSETS_DIRECTORY:
-         return "Recursos (Assets)";
-      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPERS_DIRECTORY:
-         return "Papéis de Parede Dinâmicos";
-      case MENU_ENUM_LABEL_VALUE_RGUI_BROWSER_DIRECTORY:
-         return "Navegação";
-      case MENU_ENUM_LABEL_VALUE_RGUI_CONFIG_DIRECTORY:
-         return "Configurações";
-      case MENU_ENUM_LABEL_VALUE_LIBRETRO_INFO_PATH:
-         return "Informações de Cores";
-      case MENU_ENUM_LABEL_VALUE_LIBRETRO_DIR_PATH:
-         return "Cores";
-      case MENU_ENUM_LABEL_VALUE_CURSOR_DIRECTORY:
-         return "Cursores";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_DATABASE_DIRECTORY:
-         return "Databases de Conteúdo";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_DIRECTORY:
-         return "System/BIOS";
-      case MENU_ENUM_LABEL_VALUE_CHEAT_DATABASE_PATH:
-         return "Cheats";
-      case MENU_ENUM_LABEL_VALUE_CACHE_DIRECTORY: /* UPDATE/FIXME */
-         return "Descompactação";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_FILTER_DIR:
-         return "Filtros de Áudio";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_DIR:
-         return "Shaders";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_DIR:
-         return "Filtros de Vídeo";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_DIRECTORY:
-         return "Overlays";
-      case MENU_ENUM_LABEL_VALUE_OSK_OVERLAY_DIRECTORY:
-         return "Overlays de Teclado";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT: /* TODO: Original string changed */
-         return "Trocar Entradas de Netplay";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE:
-         return "Ativar Espectador de Netplay";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS: /* TODO: Original string changed */
-         return "Endereço IP";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT:
-         return "Portas TCP/UDP de Netplay";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE:
-         return "Ativar Netplay";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_DELAY_FRAMES:
-         return "Quadros de Retardo de Netplay";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_MODE:
-         return "Ativar Cliente de Netplay";
-      case MENU_ENUM_LABEL_VALUE_RGUI_SHOW_START_SCREEN:
-         return "Mostrar Tela de Início";
-      case MENU_ENUM_LABEL_VALUE_TITLE_COLOR:
-         return "Cor do Menu Título";
-      case MENU_ENUM_LABEL_VALUE_ENTRY_HOVER_COLOR:
-         return "Cor de Realce do Menu Inicial";
-      case MENU_ENUM_LABEL_VALUE_TIMEDATE_ENABLE:
-         return "Mostrar Hora / Data";
-      case MENU_ENUM_LABEL_VALUE_THREADED_DATA_RUNLOOP_ENABLE:
-         return "Ativar Runloop de Threads de Dados";
-      case MENU_ENUM_LABEL_VALUE_ENTRY_NORMAL_COLOR:
-         return "Cor do Menu Inicial";
-      case MENU_ENUM_LABEL_VALUE_SHOW_ADVANCED_SETTINGS:
-         return "Mostrar Configurações Avançadas";
-      case MENU_ENUM_LABEL_VALUE_MOUSE_ENABLE:
-         return "Suporte a Mouse";
-      case MENU_ENUM_LABEL_VALUE_POINTER_ENABLE:
-         return "Suporte a Touch";
-      case MENU_ENUM_LABEL_VALUE_CORE_ENABLE:
-         return "Mostrar Nome dos Cores";
-      case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_ENABLE:
-         return "Ativar Sobreposição de DPI";
-      case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_VALUE:
-         return "Sobreposição de DPI";
-      case MENU_ENUM_LABEL_VALUE_SUSPEND_SCREENSAVER_ENABLE:
-         return "Suspender Proteção de Tela";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_DISABLE_COMPOSITION:
-         return "Desativar Desktop Composition";
-      case MENU_ENUM_LABEL_VALUE_PAUSE_NONACTIVE:
-         return "Não Rodar em Background";
-      case MENU_ENUM_LABEL_VALUE_UI_COMPANION_START_ON_BOOT:
-         return "Ativar UI Companion ao Iniciar";
-      case MENU_ENUM_LABEL_VALUE_UI_MENUBAR_ENABLE:
-         return "Barra de Menu (Dica)";
       case MENU_ENUM_LABEL_VALUE_ARCHIVE_MODE:
          return "Ação para Arquivos Compactados";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_ENABLE:
-         return "Comandos de Rede";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_PORT:
-         return "Porta para Comandos de Rede";
-      case MENU_ENUM_LABEL_VALUE_HISTORY_LIST_ENABLE:
-         return "Ativar Lista de Histórico";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_HISTORY_SIZE:
-         return "Tamanho da Lista de Histórico";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE_AUTO:
-         return "Taxa de Atualização de Quadros Estimada";
-      case MENU_ENUM_LABEL_VALUE_DUMMY_ON_CORE_SHUTDOWN:
-         return "Desligar Core Dummy On";
-      case MENU_ENUM_LABEL_VALUE_CORE_SET_SUPPORTS_NO_CONTENT_ENABLE: /* TODO/FIXME */
-         return "Não Iniciar Cores Automaticamente";
-      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_ENABLE:
-         return "Limitar Velocidade Máxima de Execução";
-      case MENU_ENUM_LABEL_VALUE_FASTFORWARD_RATIO:
-         return "Velocidade Máxima de Execução";
-      case MENU_ENUM_LABEL_VALUE_AUTO_REMAPS_ENABLE:
-         return "Carregar Automaticamente Arquivos Remapeados";
-      case MENU_ENUM_LABEL_VALUE_SLOWMOTION_RATIO:
-         return "Taxa de Câmera Lenta";
-      case MENU_ENUM_LABEL_VALUE_CORE_SPECIFIC_CONFIG:
-         return "Configuração por Core";
-      case MENU_ENUM_LABEL_VALUE_AUTO_OVERRIDES_ENABLE:
-         return "Carregar Automaticamente Arquivos de Sobreposição";
-      case MENU_ENUM_LABEL_VALUE_CONFIG_SAVE_ON_EXIT:
-         return "Salvar Configuração ao Sair";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SMOOTH:
-         return "Filtragem Bilinear por Hardware";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_GAMMA:
-         return "Gamma de Vídeo";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ALLOW_ROTATE:
-         return "Permitir Rotação";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC:
-         return "Sincronizar GPU com CPU";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SWAP_INTERVAL:
-         return "Intervalo de Permuta do Sincronismo Vertical";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VSYNC:
-         return "Sincronismo Vertical";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_THREADED:
-         return "Vídeo em Threads";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ROTATION:
-         return "Rotação";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_SCREENSHOT:
-         return "Ativar Captura de Tela via GPU";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_CROP_OVERSCAN:
-         return "Descartar Overscan (Recarregue)";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_INDEX:
-         return "Índice de Relações de Aspecto";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_AUTO:
-         return "Relação de Aspecto Automática";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_ASPECT:
-         return "Forçar Relação de Aspecto";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE:
-         return "Taxa de Atualização de Tela";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_SRGB_DISABLE:
-         return "Forcar Desativação de sRGB FBO";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_WINDOWED_FULLSCREEN:
-         return "Modo Tela Cheia em Janela";
-      case MENU_ENUM_LABEL_VALUE_PAL60_ENABLE:
-         return "Usar Modo PAL60";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VFILTER:
-         return "Eliminar Cintilação";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VI_WIDTH:
-         return "Definir Largura de Tela VI";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_BLACK_FRAME_INSERTION:
-         return "Inserção de Quadro Negro";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC_FRAMES:
-         return "Quadros de Sincronização entre GPU e CPU";
-      case MENU_ENUM_LABEL_VALUE_SORT_SAVEFILES_ENABLE:
-         return "Ordenar Saves em Pastas";
-      case MENU_ENUM_LABEL_VALUE_SORT_SAVESTATES_ENABLE:
-         return "Ordenar Savestates em Pastas";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FULLSCREEN:
-         return "Usar Modo Tela Cheia";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE:
-         return "Variar Escala em Janela";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE_INTEGER:
-         return "Escala em Degraus Inteiros";
-      case MENU_ENUM_LABEL_VALUE_PERFCNT_ENABLE:
-         return "Contadores de Desempenho";
-      case MENU_ENUM_LABEL_VALUE_LIBRETRO_LOG_LEVEL:
-         return "Nível de Registro de Core";
-      case MENU_ENUM_LABEL_VALUE_LOG_VERBOSITY:
-         return "Detalhamento de Registro";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_LOAD:
-         return "Carregar Savestate Automaticamente";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_INDEX:
-         return "Índice Automático de Savestates";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_SAVE:
-         return "Savestate Automático";
-      case MENU_ENUM_LABEL_VALUE_AUTOSAVE_INTERVAL:
-         return "Intervalo de Gravação Automática de SaveRAM";
-      case MENU_ENUM_LABEL_VALUE_BLOCK_SRAM_OVERWRITE:
-         return "Não Sobrescrever SaveRAM ao Carregar Savestate";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHARED_CONTEXT:
-         return "Ativar Contexto Compartilhado de Hardware";
-      case MENU_ENUM_LABEL_VALUE_RESTART_RETROARCH:
-         return "Reiniciar RetroArch";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_NICKNAME:
-         return "Nome de Usuário";
-      case MENU_ENUM_LABEL_VALUE_USER_LANGUAGE:
-         return "Idioma";
-      case MENU_ENUM_LABEL_VALUE_CAMERA_ALLOW:
-         return "Autorizar Câmera";
-      case MENU_ENUM_LABEL_VALUE_LOCATION_ALLOW:
-         return "Autorizar Localização";
-      case MENU_ENUM_LABEL_VALUE_PAUSE_LIBRETRO:
-         return "Pausar Quando o Menu for Ativado";
-      case MENU_ENUM_LABEL_VALUE_INPUT_OSK_OVERLAY_ENABLE:
-         return "Mostrar Overlay de Teclado";
-      case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_ENABLE:
-         return "Mostrar Overlay";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MONITOR_INDEX:
-         return "Índice de Monitores";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FRAME_DELAY:
-         return "Retardo de Quadro";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DUTY_CYCLE:
-         return "Ciclo de Trabalho";
-      case MENU_ENUM_LABEL_VALUE_INPUT_TURBO_PERIOD:
-         return "Período de Turbo";
-      case MENU_ENUM_LABEL_VALUE_INPUT_AXIS_THRESHOLD:
-         return "Limiar de Eixo do Controlador";
-      case MENU_ENUM_LABEL_VALUE_INPUT_REMAP_BINDS_ENABLE:
-         return "Ativar Remapeamentos";
-      case MENU_ENUM_LABEL_VALUE_INPUT_MAX_USERS:
-         return "Usuários Máximos";
-      case MENU_ENUM_LABEL_VALUE_INPUT_AUTODETECT_ENABLE:
-         return "Ativar Autoconfiguração";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_OUTPUT_RATE:
-         return "Taxa de Amostragem de Áudio (KHz)";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_MAX_TIMING_SKEW:
-         return "Distorção Máxima de Sincronização de Áudio";
-      case MENU_ENUM_LABEL_VALUE_CHEAT_NUM_PASSES:
-         return "Códigos de Cheat";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_CORE:
-         return "Salvar Remapeamento de Core";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_GAME:
-         return "Salvar Remapeamento de Jogo";
-      case MENU_ENUM_LABEL_VALUE_CHEAT_APPLY_CHANGES:
-         return "Aplicar Alterações de Cheats";
-      case MENU_ENUM_LABEL_VALUE_SHADER_APPLY_CHANGES:
-         return "Aplicar Alterações de Shaders";
-      case MENU_ENUM_LABEL_VALUE_REWIND_ENABLE:
-         return "Ativar Retrocesso";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_COLLECTION_LIST:
-         return "Coleção";
-      case MENU_ENUM_LABEL_VALUE_DETECT_CORE_LIST:
-         return "Selecionar Arquivo e Detectar Core";
-      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_HISTORY:
-         return "Selecionar do Histórico";
+      case MENU_ENUM_LABEL_VALUE_ASK_ARCHIVE:
+         return "Ask";
+      case MENU_ENUM_LABEL_VALUE_ASSETS_DIRECTORY:
+         return "Recursos (Assets)";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_BLOCK_FRAMES:
+         return "Quadros de Blocos de Áudio";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_DEVICE:
+         return "Dispositivo de Áudio";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_DRIVER:
+         return "Driver de Áudio";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_DSP_PLUGIN:
+         return "Plugin de DSP de Áudio";
       case MENU_ENUM_LABEL_VALUE_AUDIO_ENABLE:
          return "Ativar Áudio";
-      case MENU_ENUM_LABEL_VALUE_FPS_SHOW:
-         return "Mostrar Taxa de Quadros";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_FILTER_DIR:
+         return "Filtros de Áudio";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_LATENCY:
+         return "Latência de Áudio (ms)";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_MAX_TIMING_SKEW:
+         return "Distorção Máxima de Sincronização de Áudio";
       case MENU_ENUM_LABEL_VALUE_AUDIO_MUTE:
          return "Silenciar Áudio";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_VOLUME:
-         return "Volume de Áudio (dB)";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_SYNC:
-         return "Ativar Sincronismo de Áudio";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_OUTPUT_RATE:
+         return "Taxa de Amostragem de Áudio (KHz)";
       case MENU_ENUM_LABEL_VALUE_AUDIO_RATE_CONTROL_DELTA:
          return "Variação Máxima de Taxa de Áudio";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_NUM_PASSES:
-         return "Número de Shaders";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_SHA1:
-         return "SHA1";
-      case MENU_ENUM_LABEL_VALUE_CONFIGURATIONS:
-         return "Carregar Configuração";
-      case MENU_ENUM_LABEL_VALUE_REWIND_GRANULARITY:
-         return "Granularidade do Retrocesso";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_LOAD:
-         return "Carregar Remapeamento";
-      case MENU_ENUM_LABEL_VALUE_CUSTOM_RATIO:
-         return "Relação de Aspecto Personalizada";
-      case MENU_ENUM_LABEL_VALUE_USE_THIS_DIRECTORY:
-         return "<Usar este diretório>";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_START_CONTENT:
-         return "Iniciar Conteúdo";
-      case MENU_ENUM_LABEL_VALUE_DISK_OPTIONS:    /* UPDATE/FIXME */
-         return "Opções de Disco do Core";
-      case MENU_ENUM_LABEL_VALUE_CORE_OPTIONS:
-         return "Opções";
-      case MENU_ENUM_LABEL_VALUE_CORE_CHEAT_OPTIONS:
+      case MENU_ENUM_LABEL_VALUE_AUDIO_RESAMPLER_DRIVER:
+         return "Driver do Amostrador de Áudio";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_SETTINGS:
+         return "Áudio";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_SYNC:
+         return "Ativar Sincronismo de Áudio";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_VOLUME:
+         return "Volume de Áudio (dB)";
+      case MENU_ENUM_LABEL_VALUE_AUTOSAVE_INTERVAL:
+         return "Intervalo de Gravação Automática de SaveRAM";
+      case MENU_ENUM_LABEL_VALUE_AUTO_OVERRIDES_ENABLE:
+         return "Carregar Automaticamente Arquivos de Sobreposição";
+      case MENU_ENUM_LABEL_VALUE_AUTO_REMAPS_ENABLE:
+         return "Carregar Automaticamente Arquivos Remapeados";
+      case MENU_ENUM_LABEL_VALUE_BACK:
+         return "VOLTAR";
+      case MENU_ENUM_LABEL_VALUE_BLOCK_SRAM_OVERWRITE:
+         return "Não Sobrescrever SaveRAM ao Carregar Savestate";
+      case MENU_ENUM_LABEL_VALUE_BUILDBOT_ASSETS_URL:
+         return "URL Buildbot de Recursos (Assets)";
+      case MENU_ENUM_LABEL_VALUE_CACHE_DIRECTORY:
+         /* UPDATE/FIXME */ return "Descompactação";
+      case MENU_ENUM_LABEL_VALUE_CAMERA_ALLOW:
+         return "Autorizar Câmera";
+      case MENU_ENUM_LABEL_VALUE_CAMERA_DRIVER:
+         return "Driver de Câmera";
+      case MENU_ENUM_LABEL_VALUE_CHEAT:
+         return "Cheat";
+      case MENU_ENUM_LABEL_VALUE_CHEAT_APPLY_CHANGES:
+         return "Aplicar Alterações de Cheats";
+      case MENU_ENUM_LABEL_VALUE_CHEAT_DATABASE_PATH:
          return "Cheats";
       case MENU_ENUM_LABEL_VALUE_CHEAT_FILE_LOAD:
          return "Carregar Cheat";
       case MENU_ENUM_LABEL_VALUE_CHEAT_FILE_SAVE_AS:
          return "Salvar Cheat Como";
+      case MENU_ENUM_LABEL_VALUE_CHEAT_NUM_PASSES:
+         return "Códigos de Cheat";
+      case MENU_ENUM_LABEL_VALUE_CLOSE_CONTENT:
+         return "Fechar";
+      case MENU_ENUM_LABEL_VALUE_CONFIGURATIONS:
+         return "Carregar Configuração";
+      case MENU_ENUM_LABEL_VALUE_CONFIGURATION_SETTINGS:
+         return "Configurações";
+      case MENU_ENUM_LABEL_VALUE_CONFIG_SAVE_ON_EXIT:
+         return "Salvar Configuração ao Sair";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_COLLECTION_LIST:
+         return "Coleção";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_DATABASE_DIRECTORY:
+         return "Databases de Conteúdo";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_HISTORY_SIZE:
+         return "Tamanho da Lista de Histórico";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_SETTINGS:
+         return "Menu Rápido";
+      case MENU_ENUM_LABEL_VALUE_CORE_ASSETS_DIRECTORY:
+         return "Recursos (Assets) de Cores"; /* FIXME/UPDATE */
+      case MENU_ENUM_LABEL_VALUE_CORE_CHEAT_OPTIONS:
+         return "Cheats";
       case MENU_ENUM_LABEL_VALUE_CORE_COUNTERS:
          return "Contadores de Core";
-      case MENU_ENUM_LABEL_VALUE_TAKE_SCREENSHOT:
-         return "Capturar Tela";
-      case MENU_ENUM_LABEL_VALUE_RESUME:
-         return "Retomar";
-      case MENU_ENUM_LABEL_VALUE_DISK_INDEX:
-         return "Índice de Discos";
-      case MENU_ENUM_LABEL_VALUE_FRONTEND_COUNTERS:
-         return "Contadores do Frontend";
-      case MENU_ENUM_LABEL_VALUE_DISK_IMAGE_APPEND:
-         return "Anexar Imagem de Disco";
+      case MENU_ENUM_LABEL_VALUE_CORE_ENABLE:
+         return "Mostrar Nome dos Cores";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFORMATION:
+         return "Informação de Core";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_AUTHORS:
+         return "Autores";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CATEGORIES:
+         return "Categorias";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_LABEL:
+         return "Rótulo do core";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NAME:
+         return "Nome do core";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NOTES:
+         return "Notas do core";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_FIRMWARE:
+         return "Firmware";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_LICENSES:
+         return "Licença(s)";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_PERMISSIONS:
+         return "Permissões";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SUPPORTED_EXTENSIONS:
+         return "Extensões suportadas";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_MANUFACTURER:
+         return "Fabricante do sistema";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_NAME:
+         return "Nome do sistema";
+      case MENU_ENUM_LABEL_VALUE_CORE_INPUT_REMAPPING_OPTIONS: /* UPDATE/FIXME */
+         return "Opções de Remapeamento de Controlador de Core";
+      case MENU_ENUM_LABEL_VALUE_CORE_LIST:
+         return "Carregar Core";
+      case MENU_ENUM_LABEL_VALUE_CORE_OPTIONS:
+         return "Opções";
+      case MENU_ENUM_LABEL_VALUE_CORE_SETTINGS:
+         return "Core";
+      case MENU_ENUM_LABEL_VALUE_CORE_SET_SUPPORTS_NO_CONTENT_ENABLE: /* TODO/FIXME */
+         return "Não Iniciar Cores Automaticamente";
+      case MENU_ENUM_LABEL_VALUE_CORE_SPECIFIC_CONFIG:
+         return "Configuração por Core";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
+         return "Autoextrair Arquivos Baixados";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_BUILDBOT_URL:
+         return "URL Buildbot de Cores";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_LIST:
+         return "Atualização de Cores";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_SETTINGS:
+         return "Atualização de Core"; /* UPDATE/FIXME */
+      case MENU_ENUM_LABEL_VALUE_CURSOR_DIRECTORY:
+         return "Cursores";
+      case MENU_ENUM_LABEL_VALUE_CURSOR_MANAGER:
+         return "Gerenciador de Cursores";
+      case MENU_ENUM_LABEL_VALUE_CUSTOM_RATIO:
+         return "Relação de Aspecto Personalizada";
+      case MENU_ENUM_LABEL_VALUE_DATABASE_MANAGER:
+         return "Gerenciador de Databases";
+      case MENU_ENUM_LABEL_VALUE_DETECT_CORE_LIST:
+         return "Selecionar Arquivo e Detectar Core";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_CONTENT:
+         return "<Diretório de Conteúdo>";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_DEFAULT:
+         return "<Padrão>";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NONE:
+         return "<Nenhum>";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NOT_FOUND:
+         return "Diretório não encontrado.";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_SETTINGS:
+         return "Diretórios";
+      case MENU_ENUM_LABEL_VALUE_DISABLED:
+         return "Desativado";
       case MENU_ENUM_LABEL_VALUE_DISK_CYCLE_TRAY_STATUS:
          return "Estado do Drive de Disco";
-      case MENU_ENUM_LABEL_VALUE_NO_PLAYLIST_ENTRIES_AVAILABLE:
-         return "Histórico vazio.";
+      case MENU_ENUM_LABEL_VALUE_DISK_IMAGE_APPEND:
+         return "Anexar Imagem de Disco";
+      case MENU_ENUM_LABEL_VALUE_DISK_INDEX:
+         return "Índice de Discos";
+      case MENU_ENUM_LABEL_VALUE_DISK_OPTIONS:    /* UPDATE/FIXME */
+         return "Opções de Disco do Core";
+      case MENU_ENUM_LABEL_VALUE_DONT_CARE:
+         return "Tanto faz";
+      case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_ENABLE:
+         return "Ativar Sobreposição de DPI";
+      case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_VALUE:
+         return "Sobreposição de DPI";
+      case MENU_ENUM_LABEL_VALUE_DRIVER_SETTINGS:
+         return "Drivers";
+      case MENU_ENUM_LABEL_VALUE_DUMMY_ON_CORE_SHUTDOWN:
+         return "Desligar Core Dummy On";
+      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPER:
+         return "Papel de Parede Dinâmico";
+      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPERS_DIRECTORY:
+         return "Papéis de Parede Dinâmicos";
+      case MENU_ENUM_LABEL_VALUE_ENTRY_HOVER_COLOR:
+         return "Cor de Realce do Menu Inicial";
+      case MENU_ENUM_LABEL_VALUE_ENTRY_NORMAL_COLOR:
+         return "Cor do Menu Inicial";
+      case MENU_ENUM_LABEL_VALUE_FALSE:
+         return "Falso";
+      case MENU_ENUM_LABEL_VALUE_FASTFORWARD_RATIO:
+         return "Velocidade Máxima de Execução";
+      case MENU_ENUM_LABEL_VALUE_FPS_SHOW:
+         return "Mostrar Taxa de Quadros";
+      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_ENABLE:
+         return "Limitar Velocidade Máxima de Execução";
+      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_SETTINGS:
+         return "Definições do Limitador de Quadros";
+      case MENU_ENUM_LABEL_VALUE_FRONTEND_COUNTERS:
+         return "Contadores do Frontend";
+      case MENU_ENUM_LABEL_VALUE_HELP:
+         return "Ajuda";
+      case MENU_ENUM_LABEL_VALUE_HISTORY_LIST_ENABLE:
+         return "Ativar Lista de Histórico";
+      case MENU_ENUM_LABEL_VALUE_HORIZONTAL_MENU:
+         return "Horizontal Menu"; /* FIXME - don't edit this yet. */
+      case MENU_ENUM_LABEL_VALUE_INFORMATION_LIST:
+         return "Informação";
+      case MENU_ENUM_LABEL_VALUE_INPUT_AUTODETECT_ENABLE:
+         return "Ativar Autoconfiguração";
+      case MENU_ENUM_LABEL_VALUE_INPUT_AXIS_THRESHOLD:
+         return "Limiar de Eixo do Controlador";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_HIDE_UNBOUND:
+         return "Esconder Descritores de Entradas sem Uso";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_LABEL_SHOW:
+         return "Mostrar Rótulos de Entradas de Core";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DRIVER:
+         return "Driver de Controlador";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DUTY_CYCLE:
+         return "Ciclo de Trabalho";
+      case MENU_ENUM_LABEL_VALUE_INPUT_HOTKEY_BINDS:
+         return "Associação de Teclas de Atalho";
+      case MENU_ENUM_LABEL_VALUE_INPUT_MAX_USERS:
+         return "Usuários Máximos";
+      case MENU_ENUM_LABEL_VALUE_INPUT_OSK_OVERLAY_ENABLE:
+         return "Mostrar Overlay de Teclado";
+      case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_ENABLE:
+         return "Mostrar Overlay";
+      case MENU_ENUM_LABEL_VALUE_INPUT_REMAPPING_DIRECTORY:
+         return "Remapeamentos de Controladores";
+      case MENU_ENUM_LABEL_VALUE_INPUT_REMAP_BINDS_ENABLE:
+         return "Ativar Remapeamentos";
+      case MENU_ENUM_LABEL_VALUE_INPUT_SETTINGS:
+         return "Entradas";
+      case MENU_ENUM_LABEL_VALUE_INPUT_TURBO_PERIOD:
+         return "Período de Turbo";
+      case MENU_ENUM_LABEL_VALUE_INPUT_USER_BINDS:
+         return "Usuário %u";
+      case MENU_ENUM_LABEL_VALUE_JOYPAD_AUTOCONFIG_DIR:
+         return "Autoconfigurações de Dispositivos de Entrada";
+      case MENU_ENUM_LABEL_VALUE_JOYPAD_DRIVER:
+         return "Driver de Joypad";
+      case MENU_ENUM_LABEL_VALUE_KEYBOARD_OVERLAY_PRESET:
+         return "Predefinições de Overlay de Teclado";
+      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_SIMPLIFIED:
+         return "Chinês (Simplificado)";
+      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_TRADITIONAL:
+         return "Chinês (Tradicional)";
+      case MENU_ENUM_LABEL_VALUE_LANG_DUTCH:
+         return "Holandês";
+      case MENU_ENUM_LABEL_VALUE_LANG_ENGLISH:
+         return "Inglês";
+      case MENU_ENUM_LABEL_VALUE_LANG_ESPERANTO:
+         return "Esperanto";
+      case MENU_ENUM_LABEL_VALUE_LANG_FRENCH:
+         return "Francês";
+      case MENU_ENUM_LABEL_VALUE_LANG_GERMAN:
+         return "Alemão";
+      case MENU_ENUM_LABEL_VALUE_LANG_ITALIAN:
+         return "Italiano";
+      case MENU_ENUM_LABEL_VALUE_LANG_JAPANESE:
+         return "Japonês";
+      case MENU_ENUM_LABEL_VALUE_LANG_KOREAN:
+         return "Coreano";
+      case MENU_ENUM_LABEL_VALUE_LANG_PORTUGUESE:
+         return "Português";
+      case MENU_ENUM_LABEL_VALUE_LANG_RUSSIAN:
+         return "Russo";
+      case MENU_ENUM_LABEL_VALUE_LANG_SPANISH:
+         return "Espanhol";
+      case MENU_ENUM_LABEL_VALUE_LEFT_ANALOG:
+         return "Analógico Esquerdo";
+      case MENU_ENUM_LABEL_VALUE_LIBRETRO_DIR_PATH:
+         return "Cores";
+      case MENU_ENUM_LABEL_VALUE_LIBRETRO_INFO_PATH:
+         return "Informações de Cores";
+      case MENU_ENUM_LABEL_VALUE_LIBRETRO_LOG_LEVEL:
+         return "Nível de Registro de Core";
+      case MENU_ENUM_LABEL_VALUE_LINEAR:
+         return "Linear";
+      case MENU_ENUM_LABEL_VALUE_LOAD_ARCHIVE:
+         return "Carregar Arquivo";
+      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT:
+         return "Selecionar Arquivo";
+      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_HISTORY:
+         return "Selecionar do Histórico";
+      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_LIST:
+         return "Carregar Conteúdo";
+      case MENU_ENUM_LABEL_VALUE_LOAD_STATE:
+         return "Carregar Savestate";
+      case MENU_ENUM_LABEL_VALUE_LOCATION_ALLOW:
+         return "Autorizar Localização";
+      case MENU_ENUM_LABEL_VALUE_LOCATION_DRIVER:
+         return "Driver de Localização";
+      case MENU_ENUM_LABEL_VALUE_LOGGING_SETTINGS:
+         return "Registro de Dados";
+      case MENU_ENUM_LABEL_VALUE_LOG_VERBOSITY:
+         return "Detalhamento de Registro";
+      case MENU_ENUM_LABEL_VALUE_MAIN_MENU: /* TODO/FIXME - translate */
+         return "Main Menu";
+      case MENU_ENUM_LABEL_VALUE_MANAGEMENT:
+         return "Databases";
+      case MENU_ENUM_LABEL_VALUE_MENU_DRIVER:
+         return "Driver de Menu";
+      case MENU_ENUM_LABEL_VALUE_MENU_FILE_BROWSER_SETTINGS:
+         return "Menu de Navegação";
+      case MENU_ENUM_LABEL_VALUE_MENU_SETTINGS:
+         return "Menu";
+      case MENU_ENUM_LABEL_VALUE_MENU_WALLPAPER:
+         return "Papel de Parede do Menu";
+      case MENU_ENUM_LABEL_VALUE_MISSING:
+         return "Faltando";
+      case MENU_ENUM_LABEL_VALUE_MOUSE_ENABLE:
+         return "Suporte a Mouse";
+      case MENU_ENUM_LABEL_VALUE_MULTIMEDIA_SETTINGS:
+         return "Reprodução de Mídia"; /* UPDATE/FIXME */
+      case MENU_ENUM_LABEL_VALUE_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
+         return "Filtrar por Extensões Suportadas"; /* TODO/FIXME - rewrite */
+      case MENU_ENUM_LABEL_VALUE_NAVIGATION_WRAPAROUND:
+         return "Navegação Circular";
+      case MENU_ENUM_LABEL_VALUE_NEAREST:
+         return "Nearest";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT: /* TODO: Original string changed */
+         return "Trocar Entradas de Netplay";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_DELAY_FRAMES:
+         return "Quadros de Retardo de Netplay";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE:
+         return "Ativar Netplay";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS: /* TODO: Original string changed */
+         return "Endereço IP";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_MODE:
+         return "Ativar Cliente de Netplay";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_NICKNAME:
+         return "Nome de Usuário";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE:
+         return "Ativar Espectador de Netplay";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT:
+         return "Portas TCP/UDP de Netplay";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_ENABLE:
+         return "Comandos de Rede";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_PORT:
+         return "Porta para Comandos de Rede";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_SETTINGS:
+         return "Rede";
+      case MENU_ENUM_LABEL_VALUE_NO:
+         return "Não";
+      case MENU_ENUM_LABEL_VALUE_NONE:
+         return "Nenhum";
+      case MENU_ENUM_LABEL_VALUE_NO_CORE:
+         return "Nenhum Core";
+      case MENU_ENUM_LABEL_VALUE_NO_CORES_AVAILABLE:
+         return "Nenhum core disponível.";
       case MENU_ENUM_LABEL_VALUE_NO_CORE_INFORMATION_AVAILABLE:
          return "Nenhuma informação de core disponível.";
       case MENU_ENUM_LABEL_VALUE_NO_CORE_OPTIONS_AVAILABLE:
          return "Nenhuma opção de core disponível.";
-      case MENU_ENUM_LABEL_VALUE_NO_CORES_AVAILABLE:
-         return "Nenhum core disponível.";
-      case MENU_ENUM_LABEL_VALUE_NO_CORE:
-         return "Nenhum Core";
-      case MENU_ENUM_LABEL_VALUE_DATABASE_MANAGER:
-         return "Gerenciador de Databases";
-      case MENU_ENUM_LABEL_VALUE_CURSOR_MANAGER:
-         return "Gerenciador de Cursores";
-      case MENU_ENUM_LABEL_VALUE_MAIN_MENU: /* TODO/FIXME - translate */
-         return "Main Menu";
-      case MENU_ENUM_LABEL_VALUE_SETTINGS:
-         return "Definições";
-      case MENU_ENUM_LABEL_VALUE_QUIT_RETROARCH:
-         return "Sair do RetroArch";
-      case MENU_ENUM_LABEL_VALUE_SHUTDOWN:
-         return "Desligar";
-      case MENU_ENUM_LABEL_VALUE_REBOOT:
-         return "Reiniciar";
-      case MENU_ENUM_LABEL_VALUE_HELP:
-         return "Ajuda";
-      case MENU_ENUM_LABEL_VALUE_SAVE_NEW_CONFIG:
-         return "Salvar Nova Configuração";
-      case MENU_ENUM_LABEL_VALUE_RESTART_CONTENT:
-         return "Reiniciar";
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_LIST:
-         return "Atualização de Cores";
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_BUILDBOT_URL:
-         return "URL Buildbot de Cores";
-      case MENU_ENUM_LABEL_VALUE_BUILDBOT_ASSETS_URL:
-         return "URL Buildbot de Recursos (Assets)";
-      case MENU_ENUM_LABEL_VALUE_NAVIGATION_WRAPAROUND:
-         return "Navegação Circular";
-      case MENU_ENUM_LABEL_VALUE_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
-         return "Filtrar por Extensões Suportadas"; /* TODO/FIXME - rewrite */
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
-         return "Autoextrair Arquivos Baixados";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFORMATION:
-         return "Informação de Sistema";
-      case MENU_ENUM_LABEL_VALUE_ONLINE_UPDATER:
-         return "Atualização Online";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFORMATION:
-         return "Informação de Core";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NOT_FOUND:
-         return "Diretório não encontrado.";
+      case MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE:
+         return "Nenhuma informação disponível.";
       case MENU_ENUM_LABEL_VALUE_NO_ITEMS:
          return "Nenhum item.";
-      case MENU_ENUM_LABEL_VALUE_CORE_LIST:
-         return "Carregar Core";
-      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT:
-         return "Selecionar Arquivo";
-      case MENU_ENUM_LABEL_VALUE_CLOSE_CONTENT:
-         return "Fechar";
-      case MENU_ENUM_LABEL_VALUE_MANAGEMENT:
-         return "Databases";
-      case MENU_ENUM_LABEL_VALUE_SAVE_STATE:
-         return "Salvar Savestate";
-      case MENU_ENUM_LABEL_VALUE_LOAD_STATE:
-         return "Carregar Savestate";
-      case MENU_ENUM_LABEL_VALUE_RESUME_CONTENT:
-         return "Retomar";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DRIVER:
-         return "Driver de Controlador";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_DRIVER:
-         return "Driver de Áudio";
-      case MENU_ENUM_LABEL_VALUE_JOYPAD_DRIVER:
-         return "Driver de Joypad";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_RESAMPLER_DRIVER:
-         return "Driver do Amostrador de Áudio";
-      case MENU_ENUM_LABEL_VALUE_RECORD_DRIVER:
-         return "Driver de Gravação";
-      case MENU_ENUM_LABEL_VALUE_MENU_DRIVER:
-         return "Driver de Menu";
-      case MENU_ENUM_LABEL_VALUE_CAMERA_DRIVER:
-         return "Driver de Câmera";
-      case MENU_ENUM_LABEL_VALUE_LOCATION_DRIVER:
-         return "Driver de Localização";
-      case MENU_ENUM_LABEL_VALUE_UNABLE_TO_READ_COMPRESSED_FILE:
-         return "Incapaz de ler arquivo compactado.";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_SCALE:
-         return "Interpolação de Overlay";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_PRESET:
-         return "Predefinições de Overlay";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_LATENCY:
-         return "Latência de Áudio (ms)";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_DEVICE:
-         return "Dispositivo de Áudio";
-      case MENU_ENUM_LABEL_VALUE_KEYBOARD_OVERLAY_PRESET:
-         return "Predefinições de Overlay de Teclado";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_OPACITY:
-         return "Opacidade de Overlay";
-      case MENU_ENUM_LABEL_VALUE_MENU_WALLPAPER:
-         return "Papel de Parede do Menu";
-      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPER:
-         return "Papel de Parede Dinâmico";
-      case MENU_ENUM_LABEL_VALUE_CORE_INPUT_REMAPPING_OPTIONS: /* UPDATE/FIXME */
-         return "Opções de Remapeamento de Controlador de Core";
-      case MENU_ENUM_LABEL_VALUE_SHADER_OPTIONS:
-         return "Shaders";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PARAMETERS:
-         return "Parâmetros de Shader em Uso";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_PARAMETERS:
-         return "Menu de Parâmetros de Shader";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_AS:
-         return "Salvar Predefinições de Shader Como";
+      case MENU_ENUM_LABEL_VALUE_NO_PERFORMANCE_COUNTERS:
+         return "Nenhum medidor de desempenho.";
+      case MENU_ENUM_LABEL_VALUE_NO_PLAYLIST_ENTRIES_AVAILABLE:
+         return "Histórico vazio.";
+      case MENU_ENUM_LABEL_VALUE_NO_SETTINGS_FOUND:
+         return "Nenhuma definição encontrada.";
       case MENU_ENUM_LABEL_VALUE_NO_SHADER_PARAMETERS:
          return "Nenhum parâmetro de shader disponível.";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET:
-         return "Carregar Predefinições de Shader";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER:
-         return "Filtro de Vídeo";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_DSP_PLUGIN:
-         return "Plugin de DSP de Áudio";
-      case MENU_ENUM_LABEL_VALUE_SECONDS:
-         return "segundos";
       case MENU_ENUM_LABEL_VALUE_OFF:
          return "OFF";
       case MENU_ENUM_LABEL_VALUE_ON:
          return "ON";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_ASSETS:
-         return "Atualizar Recursos (Assets)";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_CHEATS:
-         return "Atualizar Cheats";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_AUTOCONFIG_PROFILES:
-         return "Atualizar Perfis de Autoconfiguração";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_DATABASES:
-         return "Atualizar Databases";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_OVERLAYS:
-         return "Atualizar Overlays";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_CG_SHADERS:
-         return "Atualizar Shaders Cg";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_GLSL_SHADERS:
-         return "Atualizar Shaders GLSL";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NAME:
-         return "Nome do core";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_LABEL:
-         return "Rótulo do core";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_NAME:
-         return "Nome do sistema";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_MANUFACTURER:
-         return "Fabricante do sistema";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CATEGORIES:
-         return "Categorias";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_AUTHORS:
-         return "Autores";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_PERMISSIONS:
-         return "Permissões";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_LICENSES:
-         return "Licença(s)";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SUPPORTED_EXTENSIONS:
-         return "Extensões suportadas";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_FIRMWARE:
-         return "Firmware";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NOTES:
-         return "Notas do core";
+      case MENU_ENUM_LABEL_VALUE_ONLINE_UPDATER:
+         return "Atualização Online";
+      case MENU_ENUM_LABEL_VALUE_ONSCREEN_DISPLAY_SETTINGS:
+         return "Informações de Tela";
+      case MENU_ENUM_LABEL_VALUE_OPEN_ARCHIVE:
+         return "Abrir Arquivo";
+      case MENU_ENUM_LABEL_VALUE_OPTIONAL:
+         return "Opcional";
+      case MENU_ENUM_LABEL_VALUE_OSK_OVERLAY_DIRECTORY:
+         return "Overlays de Teclado";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_DIRECTORY:
+         return "Overlays";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_OPACITY:
+         return "Opacidade de Overlay";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_PRESET:
+         return "Predefinições de Overlay";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_SCALE:
+         return "Interpolação de Overlay";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_SETTINGS:
+         return "Overlay em Tela";
+      case MENU_ENUM_LABEL_VALUE_PAL60_ENABLE:
+         return "Usar Modo PAL60";
+      case MENU_ENUM_LABEL_VALUE_PAUSE_LIBRETRO:
+         return "Pausar Quando o Menu for Ativado";
+      case MENU_ENUM_LABEL_VALUE_PAUSE_NONACTIVE:
+         return "Não Rodar em Background";
+      case MENU_ENUM_LABEL_VALUE_PERFCNT_ENABLE:
+         return "Contadores de Desempenho";
+      case MENU_ENUM_LABEL_VALUE_PLAYLIST_DIRECTORY:
+         return "Históricos";
+      case MENU_ENUM_LABEL_VALUE_PLAYLIST_SETTINGS:
+         return "Histórico";
+      case MENU_ENUM_LABEL_VALUE_POINTER_ENABLE:
+         return "Suporte a Touch";
+      case MENU_ENUM_LABEL_VALUE_PORT:
+         return "Porta";
+      case MENU_ENUM_LABEL_VALUE_PRESENT:
+         return "Presente";
+      case MENU_ENUM_LABEL_VALUE_PRIVACY_SETTINGS:
+         return "Configurações de Privacidade";
+      case MENU_ENUM_LABEL_VALUE_QUIT_RETROARCH:
+         return "Sair do RetroArch";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_CRC32:
+         return "CRC32";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DESCRIPTION:
+         return "Descrição";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DEVELOPER:
+         return "Desenvolvedor";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_FRANCHISE:
+         return "Franquia";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_MD5:
+         return "MD5";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_NAME:
+         return "Nome";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ORIGIN:
+         return "Origem";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_PUBLISHER:
+         return "Editora";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_MONTH:
+         return "Mês de Lançamento";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_YEAR:
+         return "Ano de Lançamento";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_SHA1:
+         return "SHA1";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_START_CONTENT:
+         return "Iniciar Conteúdo";
+      case MENU_ENUM_LABEL_VALUE_REBOOT:
+         return "Reiniciar";
+      case MENU_ENUM_LABEL_VALUE_RECORDING_CONFIG_DIRECTORY:
+         return "Configurações de Gravações";
+      case MENU_ENUM_LABEL_VALUE_RECORDING_OUTPUT_DIRECTORY:
+         return "Gravações";
+      case MENU_ENUM_LABEL_VALUE_RECORDING_SETTINGS:
+         return "Gravação";
+      case MENU_ENUM_LABEL_VALUE_RECORD_CONFIG:
+         return "Configurações de Gravação";
+      case MENU_ENUM_LABEL_VALUE_RECORD_DRIVER:
+         return "Driver de Gravação";
+      case MENU_ENUM_LABEL_VALUE_RECORD_ENABLE:
+         return "Ativar Gravação";
+      case MENU_ENUM_LABEL_VALUE_RECORD_PATH: /* FIXME/UPDATE */
+         return "Caminho da Gravação";
+      case MENU_ENUM_LABEL_VALUE_RECORD_USE_OUTPUT_DIRECTORY:
+         return "Diretório de Saída";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_LOAD:
+         return "Carregar Remapeamento";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_CORE:
+         return "Salvar Remapeamento de Core";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_GAME:
+         return "Salvar Remapeamento de Jogo";
+      case MENU_ENUM_LABEL_VALUE_REQUIRED:
+         return "Obrigatório";
+      case MENU_ENUM_LABEL_VALUE_RESTART_CONTENT:
+         return "Reiniciar";
+      case MENU_ENUM_LABEL_VALUE_RESTART_RETROARCH:
+         return "Reiniciar RetroArch";
+      case MENU_ENUM_LABEL_VALUE_RESUME:
+         return "Retomar";
+      case MENU_ENUM_LABEL_VALUE_RESUME_CONTENT:
+         return "Retomar";
+      case MENU_ENUM_LABEL_VALUE_RETROKEYBOARD:
+         return "RetroTeclado";
+      case MENU_ENUM_LABEL_VALUE_RETROPAD:
+         return "RetroPad";
+      case MENU_ENUM_LABEL_VALUE_REWIND_ENABLE:
+         return "Ativar Retrocesso";
+      case MENU_ENUM_LABEL_VALUE_REWIND_GRANULARITY:
+         return "Granularidade do Retrocesso";
+      case MENU_ENUM_LABEL_VALUE_REWIND_SETTINGS:
+         return "Retrocesso";
+      case MENU_ENUM_LABEL_VALUE_RGUI_BROWSER_DIRECTORY:
+         return "Navegação";
+      case MENU_ENUM_LABEL_VALUE_RGUI_CONFIG_DIRECTORY:
+         return "Configurações";
+      case MENU_ENUM_LABEL_VALUE_RGUI_SHOW_START_SCREEN:
+         return "Mostrar Tela de Início";
+      case MENU_ENUM_LABEL_VALUE_RIGHT_ANALOG:
+         return "Analógico Direito";
+      case MENU_ENUM_LABEL_VALUE_SAVEFILE_DIRECTORY:
+         return "Saves";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_INDEX:
+         return "Índice Automático de Savestates";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_LOAD:
+         return "Carregar Savestate Automaticamente";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_SAVE:
+         return "Savestate Automático";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_DIRECTORY:
+         return "Savestates";
+      case MENU_ENUM_LABEL_VALUE_SAVE_NEW_CONFIG:
+         return "Salvar Nova Configuração";
+      case MENU_ENUM_LABEL_VALUE_SAVE_STATE:
+         return "Salvar Savestate";
+      case MENU_ENUM_LABEL_VALUE_SAVING_SETTINGS:
+         return "Saves";
+      case MENU_ENUM_LABEL_VALUE_SCAN_DIRECTORY:
+         return "Escanear Diretório";
+      case MENU_ENUM_LABEL_VALUE_SCAN_FILE:
+         return "Escanear Arquivo";
+      case MENU_ENUM_LABEL_VALUE_SCAN_THIS_DIRECTORY:
+         return "<Escanear este Diretório>";
+      case MENU_ENUM_LABEL_VALUE_SCREENSHOT_DIRECTORY:
+         return "Capturas de Telas";
+      case MENU_ENUM_LABEL_VALUE_SCREEN_RESOLUTION:
+         return "Resolução de Tela";
+      case MENU_ENUM_LABEL_VALUE_SEARCH:
+         return "Busca:";
+      case MENU_ENUM_LABEL_VALUE_SECONDS:
+         return "segundos";
+      case MENU_ENUM_LABEL_VALUE_SETTINGS:
+         return "Definições";
+      case MENU_ENUM_LABEL_VALUE_SHADER:
+         return "Shader";
+      case MENU_ENUM_LABEL_VALUE_SHADER_APPLY_CHANGES:
+         return "Aplicar Alterações de Shaders";
+      case MENU_ENUM_LABEL_VALUE_SHADER_OPTIONS:
+         return "Shaders";
+      case MENU_ENUM_LABEL_VALUE_SHOW_ADVANCED_SETTINGS:
+         return "Mostrar Configurações Avançadas";
+      case MENU_ENUM_LABEL_VALUE_SHUTDOWN:
+         return "Desligar";
+      case MENU_ENUM_LABEL_VALUE_SLOWMOTION_RATIO:
+         return "Taxa de Câmera Lenta";
+      case MENU_ENUM_LABEL_VALUE_SORT_SAVEFILES_ENABLE:
+         return "Ordenar Saves em Pastas";
+      case MENU_ENUM_LABEL_VALUE_SORT_SAVESTATES_ENABLE:
+         return "Ordenar Savestates em Pastas";
+      case MENU_ENUM_LABEL_VALUE_START_CORE:
+         return "Iniciar Core";
+      case MENU_ENUM_LABEL_VALUE_START_NET_RETROPAD:
+         return "Iniciar RetroPad Remoto";
+      case MENU_ENUM_LABEL_VALUE_STATUS:
+         return "Status";
+      case MENU_ENUM_LABEL_VALUE_STDIN_CMD_ENABLE:
+         return "Comandos stdin";
+      case MENU_ENUM_LABEL_VALUE_SUSPEND_SCREENSAVER_ENABLE:
+         return "Suspender Proteção de Tela";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_BGM_ENABLE:
+         return "Ativar Sistema BGM";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_DIRECTORY:
+         return "System/BIOS";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFORMATION:
+         return "Informação de Sistema";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_7ZIP_SUPPORT:
+         return "Suporte a 7zip";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ALSA_SUPPORT:
+         return "Suporte a ALSA";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_BUILD_DATE:
          return "Data do build";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GIT_VERSION:
-         return "Versão do git";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CG_SUPPORT:
+         return "Suporte a Cg";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COCOA_SUPPORT:
+         return "Suporte a Cocoa";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COMMAND_IFACE_SUPPORT:
+         return "Suporte a interface de comandos";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CORETEXT_SUPPORT:
+         return "Suporte a CoreText";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CPU_FEATURES:
          return "Atributos da CPU";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_DPI:
+         return "Mostrar DPI";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_HEIGHT:
+         return "Mostrar altura (mm)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_WIDTH:
+         return "Mostrar largura (mm)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DSOUND_SUPPORT:
+         return "Suporte a DirectSound";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DYLIB_SUPPORT:
+         return "Suporte a bibliotecas dinâmicas";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_EGL_SUPPORT:
+         return "Suporte a EGL";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FBO_SUPPORT:
+         return "Suporte a OpenGL/Direct3D render-to-texture (multi-pass shaders)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FFMPEG_SUPPORT:
+         return "Suporte a FFmpeg";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FREETYPE_SUPPORT:
+         return "Suporte a FreeType";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_IDENTIFIER:
          return "Indentificador do frontend";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_NAME:
          return "Nome do frontend";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_OS:
          return "OS do frontend";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RETRORATING_LEVEL:
-         return "Nível de RetroRating";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE:
-         return "Fonte de energia";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_NO_SOURCE:
-         return "Nenhuma fonte";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGING:
-         return "Carregando";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGED:
-         return "Carregado";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_DISCHARGING:
-         return "Descarregando";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VIDEO_CONTEXT_DRIVER:
-         return "Driver de contexto de vídeo";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_WIDTH:
-         return "Mostrar largura (mm)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_HEIGHT:
-         return "Mostrar altura (mm)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_DPI:
-         return "Mostrar DPI";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBRETRODB_SUPPORT:
-         return "Suporte a LibretroDB";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OVERLAY_SUPPORT:
-         return "Suporte a Overlay";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COMMAND_IFACE_SUPPORT:
-         return "Suporte a interface de comandos";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETWORK_COMMAND_IFACE_SUPPORT:
-         return "Suporte a interface de comandos de rede";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COCOA_SUPPORT:
-         return "Suporte a Cocoa";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RPNG_SUPPORT:
-         return "Suporte a PNG (RPNG)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_SUPPORT:
-         return "Suporte a SDL1.2";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL2_SUPPORT:
-         return "Suporte a SDL2";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGL_SUPPORT:
-         return "Suporte a OpenGL";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGLES_SUPPORT:
-         return "Suporte a OpenGL ES";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_THREADING_SUPPORT:
-         return "Suporte a Threading";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_KMS_SUPPORT:
-         return "Suporte a KMS/EGL";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_UDEV_SUPPORT:
-         return "Suporte a Udev";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENVG_SUPPORT:
-         return "Suporte a OpenVG";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_EGL_SUPPORT:
-         return "Suporte a EGL";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_X11_SUPPORT:
-         return "Suporte a X11";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_WAYLAND_SUPPORT:
-         return "Suporte a Wayland";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XVIDEO_SUPPORT:
-         return "Suporte a XVideo";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ALSA_SUPPORT:
-         return "Suporte a ALSA";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OSS_SUPPORT:
-         return "Suporte a OSS";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENAL_SUPPORT:
-         return "Suporte a OpenAL";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENSL_SUPPORT:
-         return "Suporte a OpenSL";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RSOUND_SUPPORT:
-         return "Suporte a RSound";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ROARAUDIO_SUPPORT:
-         return "Suporte a RoarAudio";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_JACK_SUPPORT:
-         return "Suporte a JACK";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PULSEAUDIO_SUPPORT:
-         return "Suporte a PulseAudio";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DSOUND_SUPPORT:
-         return "Suporte a DirectSound";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XAUDIO2_SUPPORT:
-         return "Suporte a XAudio2";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ZLIB_SUPPORT:
-         return "Suporte a Zlib";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_7ZIP_SUPPORT:
-         return "Suporte a 7zip";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DYLIB_SUPPORT:
-         return "Suporte a bibliotecas dinâmicas";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CG_SUPPORT:
-         return "Suporte a Cg";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GIT_VERSION:
+         return "Versão do git";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GLSL_SUPPORT:
          return "Suporte a GLSL";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_HLSL_SUPPORT:
          return "Suporte a HLSL";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBXML2_SUPPORT:
-         return "Suporte a análise XML libxml2";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_IMAGE_SUPPORT:
-         return "Suporte a imagem SDL";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FBO_SUPPORT:
-         return "Suporte a OpenGL/Direct3D render-to-texture (multi-pass shaders)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FFMPEG_SUPPORT:
-         return "Suporte a FFmpeg";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CORETEXT_SUPPORT:
-         return "Suporte a CoreText";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FREETYPE_SUPPORT:
-         return "Suporte a FreeType";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETPLAY_SUPPORT:
-         return "Suporte a Netplay (peer-to-peer)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PYTHON_SUPPORT:
-         return "Suporte a Python (script em shaders)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_V4L2_SUPPORT:
-         return "Suporte a Video4Linux2";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_JACK_SUPPORT:
+         return "Suporte a JACK";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_KMS_SUPPORT:
+         return "Suporte a KMS/EGL";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBRETRODB_SUPPORT:
+         return "Suporte a LibretroDB";
       case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBUSB_SUPPORT:
          return "Suporte a Libusb";
-      case MENU_ENUM_LABEL_VALUE_YES:
-         return "Sim";
-      case MENU_ENUM_LABEL_VALUE_NO:
-         return "Não";
-      case MENU_ENUM_LABEL_VALUE_BACK:
-         return "VOLTAR";
-      case MENU_ENUM_LABEL_VALUE_SCREEN_RESOLUTION:
-         return "Resolução de Tela";
-      case MENU_ENUM_LABEL_VALUE_DISABLED:
-         return "Desativado";
-      case MENU_ENUM_LABEL_VALUE_PORT:
-         return "Porta";
-      case MENU_ENUM_LABEL_VALUE_NONE:
-         return "Nenhum";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DEVELOPER:
-         return "Desenvolvedor";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_PUBLISHER:
-         return "Editora";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DESCRIPTION:
-         return "Descrição";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_NAME:
-         return "Nome";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ORIGIN:
-         return "Origem";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_FRANCHISE:
-         return "Franquia";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_MONTH:
-         return "Mês de Lançamento";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_YEAR:
-         return "Ano de Lançamento";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBXML2_SUPPORT:
+         return "Suporte a análise XML libxml2";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETPLAY_SUPPORT:
+         return "Suporte a Netplay (peer-to-peer)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETWORK_COMMAND_IFACE_SUPPORT:
+         return "Suporte a interface de comandos de rede";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENAL_SUPPORT:
+         return "Suporte a OpenAL";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGLES_SUPPORT:
+         return "Suporte a OpenGL ES";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGL_SUPPORT:
+         return "Suporte a OpenGL";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENSL_SUPPORT:
+         return "Suporte a OpenSL";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENVG_SUPPORT:
+         return "Suporte a OpenVG";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OSS_SUPPORT:
+         return "Suporte a OSS";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OVERLAY_SUPPORT:
+         return "Suporte a Overlay";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE:
+         return "Fonte de energia";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGED:
+         return "Carregado";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGING:
+         return "Carregando";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_DISCHARGING:
+         return "Descarregando";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_NO_SOURCE:
+         return "Nenhuma fonte";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PULSEAUDIO_SUPPORT:
+         return "Suporte a PulseAudio";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PYTHON_SUPPORT:
+         return "Suporte a Python (script em shaders)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RETRORATING_LEVEL:
+         return "Nível de RetroRating";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ROARAUDIO_SUPPORT:
+         return "Suporte a RoarAudio";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RPNG_SUPPORT:
+         return "Suporte a PNG (RPNG)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RSOUND_SUPPORT:
+         return "Suporte a RSound";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL2_SUPPORT:
+         return "Suporte a SDL2";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_IMAGE_SUPPORT:
+         return "Suporte a imagem SDL";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_SUPPORT:
+         return "Suporte a SDL1.2";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_THREADING_SUPPORT:
+         return "Suporte a Threading";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_UDEV_SUPPORT:
+         return "Suporte a Udev";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_V4L2_SUPPORT:
+         return "Suporte a Video4Linux2";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VIDEO_CONTEXT_DRIVER:
+         return "Driver de contexto de vídeo";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_WAYLAND_SUPPORT:
+         return "Suporte a Wayland";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_X11_SUPPORT:
+         return "Suporte a X11";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XAUDIO2_SUPPORT:
+         return "Suporte a XAudio2";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XVIDEO_SUPPORT:
+         return "Suporte a XVideo";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ZLIB_SUPPORT:
+         return "Suporte a Zlib";
+      case MENU_ENUM_LABEL_VALUE_TAKE_SCREENSHOT:
+         return "Capturar Tela";
+      case MENU_ENUM_LABEL_VALUE_THREADED_DATA_RUNLOOP_ENABLE:
+         return "Ativar Runloop de Threads de Dados";
+      case MENU_ENUM_LABEL_VALUE_TIMEDATE_ENABLE:
+         return "Mostrar Hora / Data";
+      case MENU_ENUM_LABEL_VALUE_TITLE_COLOR:
+         return "Cor do Menu Título";
       case MENU_ENUM_LABEL_VALUE_TRUE:
          return "Verdadeiro";
-      case MENU_ENUM_LABEL_VALUE_FALSE:
-         return "Falso";
-      case MENU_ENUM_LABEL_VALUE_MISSING:
-         return "Faltando";
-      case MENU_ENUM_LABEL_VALUE_PRESENT:
-         return "Presente";
-      case MENU_ENUM_LABEL_VALUE_OPTIONAL:
-         return "Opcional";
-      case MENU_ENUM_LABEL_VALUE_REQUIRED:
-         return "Obrigatório";
-      case MENU_ENUM_LABEL_VALUE_STATUS:
-         return "Status";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_SETTINGS:
-         return "Áudio";
-      case MENU_ENUM_LABEL_VALUE_INPUT_SETTINGS:
-         return "Entradas";
-      case MENU_ENUM_LABEL_VALUE_ONSCREEN_DISPLAY_SETTINGS:
-         return "Informações de Tela";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_SETTINGS:
-         return "Overlay em Tela";
-      case MENU_ENUM_LABEL_VALUE_MENU_SETTINGS:
-         return "Menu";
-      case MENU_ENUM_LABEL_VALUE_MULTIMEDIA_SETTINGS:
-         return "Reprodução de Mídia"; /* UPDATE/FIXME */
+      case MENU_ENUM_LABEL_VALUE_UI_COMPANION_START_ON_BOOT:
+         return "Ativar UI Companion ao Iniciar";
+      case MENU_ENUM_LABEL_VALUE_UI_MENUBAR_ENABLE:
+         return "Barra de Menu (Dica)";
+      case MENU_ENUM_LABEL_VALUE_UNABLE_TO_READ_COMPRESSED_FILE:
+         return "Incapaz de ler arquivo compactado.";
+      case MENU_ENUM_LABEL_VALUE_UNKNOWN:
+         return "Desconhecido";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_ASSETS:
+         return "Atualizar Recursos (Assets)";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_AUTOCONFIG_PROFILES:
+         return "Atualizar Perfis de Autoconfiguração";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_CG_SHADERS:
+         return "Atualizar Shaders Cg";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_CHEATS:
+         return "Atualizar Cheats";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_DATABASES:
+         return "Atualizar Databases";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_GLSL_SHADERS:
+         return "Atualizar Shaders GLSL";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_OVERLAYS:
+         return "Atualizar Overlays";
+      case MENU_ENUM_LABEL_VALUE_USER:
+         return "Usuário";
       case MENU_ENUM_LABEL_VALUE_USER_INTERFACE_SETTINGS:
          return "Interface de Usuário";
-      case MENU_ENUM_LABEL_VALUE_MENU_FILE_BROWSER_SETTINGS:
-         return "Menu de Navegação";
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_SETTINGS:
-         return "Atualização de Core"; /* UPDATE/FIXME */
-      case MENU_ENUM_LABEL_VALUE_NETWORK_SETTINGS:
-         return "Rede";
-      case MENU_ENUM_LABEL_VALUE_PLAYLIST_SETTINGS:
-         return "Histórico";
+      case MENU_ENUM_LABEL_VALUE_USER_LANGUAGE:
+         return "Idioma";
       case MENU_ENUM_LABEL_VALUE_USER_SETTINGS:
          return "Usuário";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_SETTINGS:
-         return "Diretórios";
-      case MENU_ENUM_LABEL_VALUE_RECORDING_SETTINGS:
-         return "Gravação";
-      case MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE:
-         return "Nenhuma informação disponível.";
-      case MENU_ENUM_LABEL_VALUE_INPUT_USER_BINDS:
-         return "Usuário %u";
-      case MENU_ENUM_LABEL_VALUE_LANG_ENGLISH:
-         return "Inglês";
-      case MENU_ENUM_LABEL_VALUE_LANG_JAPANESE:
-         return "Japonês";
-      case MENU_ENUM_LABEL_VALUE_LANG_FRENCH:
-         return "Francês";
-      case MENU_ENUM_LABEL_VALUE_LANG_SPANISH:
-         return "Espanhol";
-      case MENU_ENUM_LABEL_VALUE_LANG_GERMAN:
-         return "Alemão";
-      case MENU_ENUM_LABEL_VALUE_LANG_ITALIAN:
-         return "Italiano";
-      case MENU_ENUM_LABEL_VALUE_LANG_DUTCH:
-         return "Holandês";
-      case MENU_ENUM_LABEL_VALUE_LANG_PORTUGUESE:
-         return "Português";
-      case MENU_ENUM_LABEL_VALUE_LANG_RUSSIAN:
-         return "Russo";
-      case MENU_ENUM_LABEL_VALUE_LANG_KOREAN:
-         return "Coreano";
-      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_TRADITIONAL:
-         return "Chinês (Tradicional)";
-      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_SIMPLIFIED:
-         return "Chinês (Simplificado)";
-      case MENU_ENUM_LABEL_VALUE_LANG_ESPERANTO:
-         return "Esperanto";
-      case MENU_ENUM_LABEL_VALUE_LEFT_ANALOG:
-         return "Analógico Esquerdo";
-      case MENU_ENUM_LABEL_VALUE_RIGHT_ANALOG:
-         return "Analógico Direito";
-      case MENU_ENUM_LABEL_VALUE_INPUT_HOTKEY_BINDS:
-         return "Associação de Teclas de Atalho";
-      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_SETTINGS:
-         return "Definições do Limitador de Quadros";
-      case MENU_ENUM_LABEL_VALUE_SEARCH:
-         return "Busca:";
       case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_IMAGE_VIEWER:
          return "Usar Visualizador de Imagens Interno";
+      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_PLAYER:
+         return "Usar Player Interno"; /* TODO/FIXME */
+      case MENU_ENUM_LABEL_VALUE_USE_THIS_DIRECTORY:
+         return "<Usar este diretório>";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ALLOW_ROTATE:
+         return "Permitir Rotação";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_AUTO:
+         return "Relação de Aspecto Automática";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_INDEX:
+         return "Índice de Relações de Aspecto";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_BLACK_FRAME_INSERTION:
+         return "Inserção de Quadro Negro";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_CROP_OVERSCAN:
+         return "Descartar Overscan (Recarregue)";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_DISABLE_COMPOSITION:
+         return "Desativar Desktop Composition";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_DRIVER:
+         return "Driver de Vídeo";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER:
+         return "Filtro de Vídeo";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_DIR:
+         return "Filtros de Vídeo";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_FLICKER:
+         return "Filtro de Cintilação";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_ENABLE:
+         return "Mostrar Mensagem de Tela";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_PATH:
+         return "Fonte da Mensagem de Tela";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_SIZE:
+         return "Tamanho da Mensagem de Tela";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_ASPECT:
+         return "Forçar Relação de Aspecto";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_SRGB_DISABLE:
+         return "Forcar Desativação de sRGB FBO";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FRAME_DELAY:
+         return "Retardo de Quadro";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FULLSCREEN:
+         return "Usar Modo Tela Cheia";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_GAMMA:
+         return "Gamma de Vídeo";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_RECORD:
+         return "Ativar Gravação por GPU";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_SCREENSHOT:
+         return "Ativar Captura de Tela via GPU";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC:
+         return "Sincronizar GPU com CPU";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC_FRAMES:
+         return "Quadros de Sincronização entre GPU e CPU";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_X:
+         return "Posição X da Mensagem de Tela";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_Y:
+         return "Posição Y da Mensagem de Tela";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MONITOR_INDEX:
+         return "Índice de Monitores";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_POST_FILTER_RECORD:
+         return "Ativar Filtro Pós-Gravação";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE:
+         return "Taxa de Atualização de Tela";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE_AUTO:
+         return "Taxa de Atualização de Quadros Estimada";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ROTATION:
+         return "Rotação";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE:
+         return "Variar Escala em Janela";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE_INTEGER:
+         return "Escala em Degraus Inteiros";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SETTINGS:
+         return "Vídeo";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_DIR:
+         return "Shaders";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_NUM_PASSES:
+         return "Número de Shaders";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PARAMETERS:
+         return "Parâmetros de Shader em Uso";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET:
+         return "Carregar Predefinições de Shader";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_PARAMETERS:
+         return "Menu de Parâmetros de Shader";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_AS:
+         return "Salvar Predefinições de Shader Como";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHARED_CONTEXT:
+         return "Ativar Contexto Compartilhado de Hardware";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SMOOTH:
+         return "Filtragem Bilinear por Hardware";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SOFT_FILTER:
+         return "Ativar Filtro de Suavização";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SWAP_INTERVAL:
+         return "Intervalo de Permuta do Sincronismo Vertical";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_THREADED:
+         return "Vídeo em Threads";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VFILTER:
+         return "Eliminar Cintilação";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VI_WIDTH:
+         return "Definir Largura de Tela VI";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VSYNC:
+         return "Sincronismo Vertical";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_WINDOWED_FULLSCREEN:
+         return "Modo Tela Cheia em Janela";
+      case MENU_ENUM_LABEL_VALUE_YES:
+         return "Sim";
+      case MSG_APPENDED_DISK:
+         return "Disco anexado";
+      case MSG_APPLYING_CHEAT:
+         return "Applying cheat changes.";
+      case MSG_APPLYING_SHADER:
+         return "Aplicando shader";
+      case MSG_AUDIO_MUTED:
+         return "Áudio mudo.";
+      case MSG_AUDIO_UNMUTED:
+         return "Áudio normal.";
+      case MSG_BLOCKING_SRAM_OVERWRITE:
+         return "Bloqueando Sobrescrição de SRAM";
+      case MSG_BYTES:
+         return "bytes";
+      case MSG_CONFIG_DIRECTORY_NOT_SET:
+         return "Diretório de configurações não definido. Incapaz de salvar.";
+      case MSG_CORE_DOES_NOT_SUPPORT_SAVESTATES:
+         return "O core não suporta savestates.";
+      case MSG_COULD_NOT_READ_CONTENT_FILE:
+         return "Incapaz de ler arquivo de conteúdo";
+      case MSG_DOWNLOADING:
+         return "Baixando";
+      case MSG_EXTRACTING:
+         return "Extraindo";
+      case MSG_FAILED_TO:
+         return "Falha ao";
+      case MSG_FAILED_TO_APPLY_SHADER:
+         return "Falha ao aplicar shader.";
+      case MSG_FAILED_TO_LOAD_CONTENT:
+         return "Falha ao carregar conteúdo";
+      case MSG_FAILED_TO_LOAD_MOVIE_FILE:
+         return "Falha ao carregar vídeo";
+      case MSG_FAILED_TO_LOAD_OVERLAY:
+         return "Falha ao carregar overlay.";
+      case MSG_FAILED_TO_LOAD_STATE:
+         return "Falha ao carregar estado de";
+      case MSG_FAILED_TO_REMOVE_DISK_FROM_TRAY:
+         return "Falha ao remover disco da bandeja.";
+      case MSG_FAILED_TO_REMOVE_TEMPORARY_FILE:
+         return "Falha ao remover arquivo temporário";
+      case MSG_FAILED_TO_SAVE_SRAM:
+         return "Falha ao salvar SRAM";
+      case MSG_FAILED_TO_SAVE_STATE_TO:
+         return "Falha ao salvar estado em";
+      case MSG_FAILED_TO_START_MOVIE_RECORD:
+         return "Falha ao iniciar gravação de vídeo.";
+      case MSG_FAILED_TO_UNMUTE_AUDIO:
+         return "Falha ao desativar mudo.";
+      case MSG_GOT_INVALID_DISK_INDEX:
+         return "Índice de disco inválido.";
+      case MSG_GRAB_MOUSE_STATE:
+         return "Obter estado do mouse";
+      case MSG_LOADED_STATE_FROM_SLOT:
+         return "Estado carregado do slot";
+      case MSG_LOADING_STATE:
+         return "Carregando estado";
+      case MSG_PAUSED:
+         return "Pausado.";
+      case MSG_RECEIVED:
+         return "recebido";
+      case MSG_REDIRECTING_CHEATFILE_TO:
+         return "Redirecionando cheat para";
+      case MSG_REDIRECTING_SAVEFILE_TO:
+         return "Redirecionando save para";
+      case MSG_REDIRECTING_SAVESTATE_TO:
+         return "Redirecionando savestate para"; /* TODO */
+      case MSG_REMOVED_DISK_FROM_TRAY:
+         return "Disco removido da bandeja.";
+      case MSG_REMOVING_TEMPORARY_CONTENT_FILE:
+         return "Removendo conteúdo temporário";
+      case MSG_RESET:
+         return "Reiniciar";
+      case MSG_RESTARTING_RECORDING_DUE_TO_DRIVER_REINIT:
+         return "Reiniciando gravação devido a reinício de driver.";
+      case MSG_REWINDING:
+         return "Retrocedendo.";
+      case MSG_REWIND_REACHED_END:
+         return "Final do buffer de retrocesso atingido.";
+      case MSG_SAVED_STATE_TO_SLOT:
+         return "Estado salvo no slot";
+      case MSG_SAVED_SUCCESSFULLY_TO:
+         return "Salvo com sucesso em";
+      case MSG_SAVING_RAM_TYPE:
+         return "Salvando tipo de RAM";
+      case MSG_SAVING_STATE:
+         return "Salvando estado";
+      case MSG_SCANNING:
+         return "Examinando";
+      case MSG_SCANNING_OF_DIRECTORY_FINISHED:
+         return "Exame de diretório concluído";
+      case MSG_SENDING_COMMAND:
+         return "Enviando comando";
+      case MSG_SHADER:
+         return "Shader";
+      case MSG_SKIPPING_SRAM_LOAD:
+         return "Ignorando carregamento de SRAM.";
+      case MSG_SLOW_MOTION:
+         return "Câmera lenta.";
+      case MSG_SLOW_MOTION_REWIND:
+         return "Retrocesso em câmera lenta.";
+      case MSG_STARTING_MOVIE_PLAYBACK:
+         return "Iniciando reprodução de vídeo.";
+      case MSG_STARTING_MOVIE_RECORD_TO:
+         return "Iniciando gravação de vídeo em";
+      case MSG_STATE_SIZE:
+         return "Tamanho do estado";
+      case MSG_STATE_SLOT:
+         return "Slot de estado";
+      case MSG_TO:
+         return "para";
+      case MSG_UNKNOWN:
+         return "Desconhecido";
+      case MSG_UNPAUSED:
+         return "Despausado.";
+      case MSG_UNRECOGNIZED_COMMAND:
+         return "Comando desconhecido";
+      case MSG_VIRTUAL_DISK_TRAY:
+         return "bandeja de disco virtual.";
       default:
          break;
    }

--- a/intl/msg_hash_ru.c
+++ b/intl/msg_hash_ru.c
@@ -20,169 +20,169 @@ const char *msg_hash_to_str_ru(enum msg_hash_enums msg)
 {
    switch (msg)
    {
-      case MSG_PROGRAM:
-         return "RetroArch";
-      case MSG_MOVIE_RECORD_STOPPED:
-         return "Запись остановлена.";
-      case MSG_MOVIE_PLAYBACK_ENDED:
-         return "Достигнут конец записи.";
-      case MSG_AUTOSAVE_FAILED:
-         return "Ошибка автосохранения.";
-      case MSG_NETPLAY_FAILED_MOVIE_PLAYBACK_HAS_STARTED:
-         return "Воспроизведение записи. Невозможно начать сетевую игру.";
-      case MSG_NETPLAY_FAILED:
-         return "Ошибка запуска сетевой игры.";
-      case MSG_LIBRETRO_ABI_BREAK:
-         return "скомпилировано для другой версии libretro.";
-      case MSG_REWIND_INIT_FAILED_THREADED_AUDIO:
-         return "Ядро использует многопоточный звук. Перемотка невозможна.";
-      case MSG_REWIND_INIT_FAILED:
-         return "Ошибка создания буфера перемотки. Перемотка будет отключена.";
-      case MSG_REWIND_INIT:
-         return "Инициализация буфера перемотки с размером";
-      case MSG_CUSTOM_TIMING_GIVEN:
-         return "Задано ручное значение тайминга.";
-      case MSG_VIEWPORT_SIZE_CALCULATION_FAILED:
-         return "Ошибка расчёта размеров окна проекции. Будут использованы необработанные данные. Возможны ошибки.";
-      case MSG_HW_RENDERED_MUST_USE_POSTSHADED_RECORDING:
-         return "Ядро использует аппаратный рендеринг. Включите запись с GPU.";
-      case MSG_RECORDING_TO:
-         return "Запись в";
-      case MSG_DETECTED_VIEWPORT_OF:
-         return "Обнаружено окно проекции";
-      case MSG_TAKING_SCREENSHOT:
-         return "Скриншот сохранён.";
-      case MSG_FAILED_TO_TAKE_SCREENSHOT:
-         return "Невозможно создать скриншот.";
-      case MSG_FAILED_TO_START_RECORDING:
-         return "Невозможно начать запись.";
-      case MSG_RECORDING_TERMINATED_DUE_TO_RESIZE:
-         return "Размеры окна были изменены. Запись остановлена.";
-      case MSG_USING_LIBRETRO_DUMMY_CORE_RECORDING_SKIPPED:
-         return "Используется фиктивное ядро. Запись не производится.";
-      case MSG_UNKNOWN:
-         return "Неизвестно.";
-      case MSG_LOADING_CONTENT_FILE:
-         return "Загружен файл контента";
-      case MSG_RECEIVED:
-         return "получено";
-      case MSG_UNRECOGNIZED_COMMAND:
-         return "Неизвестная команда";
-      case MSG_SENDING_COMMAND:
-         return "Отправка команды";
-      case MSG_GOT_INVALID_DISK_INDEX:
-         return "Задан неверный номер диска.";
-      case MSG_FAILED_TO_REMOVE_DISK_FROM_TRAY:
-         return "Невозможно извлечь диск.";
-      case MSG_REMOVED_DISK_FROM_TRAY:
-         return "Диск извлечён.";
-      case MSG_VIRTUAL_DISK_TRAY:
-         return "виртуальный лоток cd-привода";
-      case MSG_FAILED_TO:
-         return "Ошибка";
-      case MSG_TO:
-         return "в";
-      case MSG_SAVING_RAM_TYPE:
-         return "Запись RAM";
-      case MSG_SAVING_STATE:
-         return "Сохранено";
-      case MSG_LOADING_STATE:
-         return "Загружено сохранение";
-      case MSG_FAILED_TO_LOAD_MOVIE_FILE:
-         return "Не удалось загрузить файл записи.";
-      case MSG_FAILED_TO_LOAD_CONTENT:
-         return "Не удалось загрузить контент";
-      case MSG_COULD_NOT_READ_CONTENT_FILE:
-         return "Не удалось прочитать файл контента";
-      case MSG_GRAB_MOUSE_STATE:
-         return "Режим перехвата мыши";
-      case MSG_PAUSED:
-         return "Пауза вкл.";
-      case MSG_UNPAUSED:
-         return "Пауза откл.";
-      case MSG_FAILED_TO_LOAD_OVERLAY:
-         return "Ошибка загрузки оверлея.";
-      case MSG_FAILED_TO_UNMUTE_AUDIO:
-         return "Не удалось включить звук.";
+      case MSG_APPENDED_DISK:
+         return "Вставлен диск";
+/* TODO */
+      case MSG_APPLYING_CHEAT:
+         return "Applying cheat changes.";
+      case MSG_APPLYING_SHADER:
+         return "Применён шейдер";
       case MSG_AUDIO_MUTED:
          return "Звук откл.";
       case MSG_AUDIO_UNMUTED:
          return "Звук вкл.";
-      case MSG_RESET:
-         return "Сброс";
-      case MSG_FAILED_TO_LOAD_STATE:
-         return "Ошибка загрузки сохранения из";
-      case MSG_FAILED_TO_SAVE_STATE_TO:
-         return "Ошибка записи сохранения в";
-      case MSG_FAILED_TO_SAVE_SRAM:
-         return "Ошибка сохранения SRAM";
-      case MSG_STATE_SIZE:
-         return "Размер сохранения";
-      case MSG_FOUND_SHADER:
-         return "Обнаружен шейдер";
-      case MSG_SRAM_WILL_NOT_BE_SAVED:
-         return "Невозможно сохранить SRAM.";
+      case MSG_AUTOSAVE_FAILED:
+         return "Ошибка автосохранения.";
       case MSG_BLOCKING_SRAM_OVERWRITE:
          return "Перезапись SRAM запрещена.";
-      case MSG_CORE_DOES_NOT_SUPPORT_SAVESTATES:
-         return "Ядро не поддерживает быстрые сохранения.";
-      case MSG_SAVED_STATE_TO_SLOT:
-         return "Сохранено в слот";
-      case MSG_SAVED_SUCCESSFULLY_TO:
-         return "Успешно сохранено в";
       case MSG_BYTES:
          return "байт";
       case MSG_CONFIG_DIRECTORY_NOT_SET:
          return "Не задана папка хранения настроек. Невозможно сохранить конфигурацию.";
-      case MSG_SKIPPING_SRAM_LOAD:
-         return "Пропуск загрузки SRAM.";
-      case MSG_APPENDED_DISK:
-         return "Вставлен диск";
-      case MSG_STARTING_MOVIE_PLAYBACK:
-         return "Воспроизведение записи.";
-      case MSG_FAILED_TO_REMOVE_TEMPORARY_FILE:
-         return "Ошибка удаления временного файла.";
-      case MSG_REMOVING_TEMPORARY_CONTENT_FILE:
-         return "Удалён временный файл контента";
-      case MSG_LOADED_STATE_FROM_SLOT:
-         return "Загружено сохранение из слота";
+      case MSG_CORE_DOES_NOT_SUPPORT_SAVESTATES:
+         return "Ядро не поддерживает быстрые сохранения.";
+      case MSG_COULD_NOT_READ_CONTENT_FILE:
+         return "Не удалось прочитать файл контента";
+      case MSG_CUSTOM_TIMING_GIVEN:
+         return "Задано ручное значение тайминга.";
+      case MSG_DETECTED_VIEWPORT_OF:
+         return "Обнаружено окно проекции";
       case MSG_DOWNLOADING:
          return "Прогресс загрузки";
-      case MSG_SCANNING_OF_DIRECTORY_FINISHED:
-         return "Сканирование папки завершено";
-      case MSG_SCANNING:
-         return "Сканирование";
+      case MSG_FAILED_TO:
+         return "Ошибка";
+      case MSG_FAILED_TO_APPLY_SHADER:
+         return "Не удалось применить шейдер";
+      case MSG_FAILED_TO_LOAD_CONTENT:
+         return "Не удалось загрузить контент";
+      case MSG_FAILED_TO_LOAD_MOVIE_FILE:
+         return "Не удалось загрузить файл записи.";
+      case MSG_FAILED_TO_LOAD_OVERLAY:
+         return "Ошибка загрузки оверлея.";
+      case MSG_FAILED_TO_LOAD_STATE:
+         return "Ошибка загрузки сохранения из";
+      case MSG_FAILED_TO_REMOVE_DISK_FROM_TRAY:
+         return "Невозможно извлечь диск.";
+      case MSG_FAILED_TO_REMOVE_TEMPORARY_FILE:
+         return "Ошибка удаления временного файла.";
+      case MSG_FAILED_TO_SAVE_SRAM:
+         return "Ошибка сохранения SRAM";
+      case MSG_FAILED_TO_SAVE_STATE_TO:
+         return "Ошибка записи сохранения в";
+      case MSG_FAILED_TO_START_MOVIE_RECORD:
+         return "Невозможно начать запись видео.";
+      case MSG_FAILED_TO_START_RECORDING:
+         return "Невозможно начать запись.";
+      case MSG_FAILED_TO_TAKE_SCREENSHOT:
+         return "Невозможно создать скриншот.";
+      case MSG_FAILED_TO_UNMUTE_AUDIO:
+         return "Не удалось включить звук.";
+      case MSG_FOUND_SHADER:
+         return "Обнаружен шейдер";
+      case MSG_GOT_INVALID_DISK_INDEX:
+         return "Задан неверный номер диска.";
+      case MSG_GRAB_MOUSE_STATE:
+         return "Режим перехвата мыши";
+      case MSG_HW_RENDERED_MUST_USE_POSTSHADED_RECORDING:
+         return "Ядро использует аппаратный рендеринг. Включите запись с GPU.";
+      case MSG_LIBRETRO_ABI_BREAK:
+         return "скомпилировано для другой версии libretro.";
+      case MSG_LOADED_STATE_FROM_SLOT:
+         return "Загружено сохранение из слота";
+      case MSG_LOADING_CONTENT_FILE:
+         return "Загружен файл контента";
+      case MSG_LOADING_STATE:
+         return "Загружено сохранение";
+      case MSG_MOVIE_PLAYBACK_ENDED:
+         return "Достигнут конец записи.";
+      case MSG_MOVIE_RECORD_STOPPED:
+         return "Запись остановлена.";
+      case MSG_NETPLAY_FAILED:
+         return "Ошибка запуска сетевой игры.";
+      case MSG_NETPLAY_FAILED_MOVIE_PLAYBACK_HAS_STARTED:
+         return "Воспроизведение записи. Невозможно начать сетевую игру.";
+      case MSG_PAUSED:
+         return "Пауза вкл.";
+      case MSG_PROGRAM:
+         return "RetroArch";
+      case MSG_RECEIVED:
+         return "получено";
+      case MSG_RECORDING_TERMINATED_DUE_TO_RESIZE:
+         return "Размеры окна были изменены. Запись остановлена.";
+      case MSG_RECORDING_TO:
+         return "Запись в";
       case MSG_REDIRECTING_CHEATFILE_TO:
          return "Файл с чит-кодами перенаправлен в";
       case MSG_REDIRECTING_SAVEFILE_TO:
          return "Файл карты памяти перенаправлен в";
       case MSG_REDIRECTING_SAVESTATE_TO:
          return "Файл сохранения перенаправлен в";
-/* TODO */
-      case MSG_APPLYING_CHEAT:
-         return "Applying cheat changes.";
-      case MSG_SHADER:
-         return "Шейдер";
-      case MSG_APPLYING_SHADER:
-         return "Применён шейдер";
-      case MSG_FAILED_TO_APPLY_SHADER:
-         return "Не удалось применить шейдер";
-      case MSG_STARTING_MOVIE_RECORD_TO:
-         return "Запись видео в";
-      case MSG_FAILED_TO_START_MOVIE_RECORD:
-         return "Невозможно начать запись видео.";
-      case MSG_STATE_SLOT:
-         return "Слот сохранения";
+      case MSG_REMOVED_DISK_FROM_TRAY:
+         return "Диск извлечён.";
+      case MSG_REMOVING_TEMPORARY_CONTENT_FILE:
+         return "Удалён временный файл контента";
+      case MSG_RESET:
+         return "Сброс";
       case MSG_RESTARTING_RECORDING_DUE_TO_DRIVER_REINIT:
          return "Реинициализация драйвера. Запись перезапущена.";
+      case MSG_REWINDING:
+         return "Перемотка.";
+      case MSG_REWIND_INIT:
+         return "Инициализация буфера перемотки с размером";
+      case MSG_REWIND_INIT_FAILED:
+         return "Ошибка создания буфера перемотки. Перемотка будет отключена.";
+      case MSG_REWIND_INIT_FAILED_THREADED_AUDIO:
+         return "Ядро использует многопоточный звук. Перемотка невозможна.";
+      case MSG_REWIND_REACHED_END:
+         return "Достигнут предел буфера перемотки.";
+      case MSG_SAVED_STATE_TO_SLOT:
+         return "Сохранено в слот";
+      case MSG_SAVED_SUCCESSFULLY_TO:
+         return "Успешно сохранено в";
+      case MSG_SAVING_RAM_TYPE:
+         return "Запись RAM";
+      case MSG_SAVING_STATE:
+         return "Сохранено";
+      case MSG_SCANNING:
+         return "Сканирование";
+      case MSG_SCANNING_OF_DIRECTORY_FINISHED:
+         return "Сканирование папки завершено";
+      case MSG_SENDING_COMMAND:
+         return "Отправка команды";
+      case MSG_SHADER:
+         return "Шейдер";
+      case MSG_SKIPPING_SRAM_LOAD:
+         return "Пропуск загрузки SRAM.";
       case MSG_SLOW_MOTION:
          return "Замедление.";
       case MSG_SLOW_MOTION_REWIND:
          return "Замедленная перемотка.";
-      case MSG_REWINDING:
-         return "Перемотка.";
-      case MSG_REWIND_REACHED_END:
-         return "Достигнут предел буфера перемотки.";
+      case MSG_SRAM_WILL_NOT_BE_SAVED:
+         return "Невозможно сохранить SRAM.";
+      case MSG_STARTING_MOVIE_PLAYBACK:
+         return "Воспроизведение записи.";
+      case MSG_STARTING_MOVIE_RECORD_TO:
+         return "Запись видео в";
+      case MSG_STATE_SIZE:
+         return "Размер сохранения";
+      case MSG_STATE_SLOT:
+         return "Слот сохранения";
+      case MSG_TAKING_SCREENSHOT:
+         return "Скриншот сохранён.";
+      case MSG_TO:
+         return "в";
+      case MSG_UNKNOWN:
+         return "Неизвестно.";
+      case MSG_UNPAUSED:
+         return "Пауза откл.";
+      case MSG_UNRECOGNIZED_COMMAND:
+         return "Неизвестная команда";
+      case MSG_USING_LIBRETRO_DUMMY_CORE_RECORDING_SKIPPED:
+         return "Используется фиктивное ядро. Запись не производится.";
+      case MSG_VIEWPORT_SIZE_CALCULATION_FAILED:
+         return "Ошибка расчёта размеров окна проекции. Будут использованы необработанные данные. Возможны ошибки.";
+      case MSG_VIRTUAL_DISK_TRAY:
+         return "виртуальный лоток cd-привода";
       default:
          break;
    }

--- a/intl/msg_hash_us.c
+++ b/intl/msg_hash_us.c
@@ -1898,156 +1898,482 @@ static const char *menu_hash_to_str_us_label_enum(enum msg_hash_enums msg)
 
    switch (msg)
    {
-      case MENU_ENUM_SUBLABEL_VIDEO_THREADED:
-         return "Improves performance at the cost of latency and more video stuttering. Use only if you cannot obtain full speed otherwise.";
-      case MENU_ENUM_SUBLABEL_VIDEO_HARD_SYNC:
-         return "Hard-synchronize the CPU and GPU. Reduces latency at the cost of performance.";
-      case MENU_ENUM_SUBLABEL_MENU_SETTINGS:
-         return "Adjusts settings related to the appearance of the menu screen.";
-      case MSG_CONNECTION_SLOT:
-         return "Connection slot";
-      case MSG_WAITING_FOR_CLIENT:
-         return "Waiting for client ...";
-      case MSG_CONNECTING_TO_NETPLAY_HOST:
-         return "Connecting to netplay host";
-      case MSG_GOT_CONNECTION_FROM:
-         return "Got connection from";
-      case MSG_AUTODETECT:
-         return "Autodetect";
-      case MSG_SUCCEEDED:
-         return "succeeded";
-      case MSG_FAILED:
-         return "failed";
-      case MSG_UNKNOWN_NETPLAY_COMMAND_RECEIVED:
-         return "Unknown netplay command received";
-      case MSG_NETPLAY_USERS_HAS_FLIPPED:
-         return "Netplay users has flipped";
-      case MSG_FILE_ALREADY_EXISTS_SAVING_TO_BACKUP_BUFFER:
-         return "File already exists. Saving to backup buffer";
-      case MSG_AUTOLOADING_SAVESTATE_FROM:
-         return "Auto-loading savestate from";
-      case MSG_CONNECTING_TO_PORT:
-         return "Connecting to port";
-      case MSG_SETTING_DISK_IN_TRAY:
-         return "Setting disk in tray";
-      case MSG_AUDIO_VOLUME:
-         return "Audio volume";
-      case MSG_FAILED_TO_SET_DISK:
-         return "Failed to set disk";
-      case MSG_FAILED_TO_START_AUDIO_DRIVER:
-         return "failed_to_start_audio_driver";
-      case MSG_FOUND_LAST_STATE_SLOT:
-         return "found_last_state_slot";
-      case MSG_DEVICE_CONFIGURED_IN_PORT:
-         return "configured in port";
-      case MSG_DEVICE_NOT_CONFIGURED:
-         return "not configured";
-      case MSG_DEVICE_DISCONNECTED_FROM_PORT:
-        return "Device disconnected from port";
-      case MSG_CONNECT_DEVICE_FROM_A_VALID_PORT:
-         return "connect_device_from_a_valid_port";
-      case MSG_DISCONNECT_DEVICE_FROM_A_VALID_PORT:
-         return "disconnect_device_from_a_valid_port";
-      case MSG_DISCONNECTING_DEVICE_FROM_PORT:
-         return "disconnecting_device_from_port";
-      case MSG_BRINGING_UP_COMMAND_INTERFACE_ON_PORT:
-         return "bringing_up_command_interface_at_port";
-      case MENU_ENUM_LABEL_VIDEO_MAX_SWAPCHAIN_IMAGES:
-         return "video_max_swapchain_images";
-      case MENU_ENUM_LABEL_CORE_SETTINGS:
-         return "core_settings";
-      case MENU_ENUM_LABEL_CB_MENU_WALLPAPER:
-         return "cb_menu_wallpaper";
-      case MENU_ENUM_LABEL_CB_MENU_THUMBNAIL:
-         return "cb_menu_thumbnail";
-      case MENU_ENUM_LABEL_CB_LAKKA_LIST:
-         return "cb_lakka_list";
-      case MENU_ENUM_LABEL_CB_THUMBNAILS_UPDATER_LIST:
-         return "cb_thumbnails_updater_list";
-      case MENU_ENUM_LABEL_CB_CORE_UPDATER_LIST:
-         return "cb_core_updater_list";
-      case MENU_ENUM_LABEL_CB_CORE_CONTENT_LIST:
-         return "cb_core_content_list";
+      case MENU_ENUM_LABEL_ACCOUNTS_CHEEVOS_USERNAME:
+         return "accounts_cheevos_username";
+      case MENU_ENUM_LABEL_ACCOUNTS_LIST:
+         return "accounts_list";
+      case MENU_ENUM_LABEL_ACCOUNTS_RETRO_ACHIEVEMENTS:
+         return "retro_achievements";
+      case MENU_ENUM_LABEL_ACHIEVEMENT_LIST:
+         return "achievement_list";
+      case MENU_ENUM_LABEL_ADD_CONTENT_LIST:
+         return "add_content";
+      case MENU_ENUM_LABEL_ADD_TAB:
+         return "add_tab";
+      case MENU_ENUM_LABEL_ARCHIVE_MODE:
+         return "archive_mode";
+      case MENU_ENUM_LABEL_ASSETS_DIRECTORY:
+         return "assets_directory";
+      case MENU_ENUM_LABEL_AUDIO_BLOCK_FRAMES:
+         return "audio_block_frames";
+      case MENU_ENUM_LABEL_AUDIO_DEVICE:
+         return "audio_device";
+      case MENU_ENUM_LABEL_AUDIO_DRIVER:
+         return "audio_driver";
+      case MENU_ENUM_LABEL_AUDIO_DSP_PLUGIN:
+         return "audio_dsp_plugin";
+      case MENU_ENUM_LABEL_AUDIO_ENABLE:
+         return "audio_enable";
+      case MENU_ENUM_LABEL_AUDIO_FILTER_DIR:
+         return "audio_filter_dir";
+      case MENU_ENUM_LABEL_AUDIO_LATENCY:
+         return "audio_latency";
+      case MENU_ENUM_LABEL_AUDIO_MAX_TIMING_SKEW:
+         return "audio_max_timing_skew";
+      case MENU_ENUM_LABEL_AUDIO_MUTE:
+         return "audio_mute_enable";
+      case MENU_ENUM_LABEL_AUDIO_OUTPUT_RATE:
+         return "audio_output_rate";
+      case MENU_ENUM_LABEL_AUDIO_RATE_CONTROL_DELTA:
+         return "audio_rate_control_delta";
+      case MENU_ENUM_LABEL_AUDIO_RESAMPLER_DRIVER:
+         return "audio_resampler_driver";
+      case MENU_ENUM_LABEL_AUDIO_SETTINGS:
+         return "audio_settings";
+      case MENU_ENUM_LABEL_AUDIO_SYNC:
+         return "audio_sync";
+      case MENU_ENUM_LABEL_AUDIO_VOLUME:
+         return "audio_volume";
+      case MENU_ENUM_LABEL_AUTOSAVE_INTERVAL:
+         return "autosave_interval";
+      case MENU_ENUM_LABEL_AUTO_OVERRIDES_ENABLE:
+         return "auto_overrides_enable";
+      case MENU_ENUM_LABEL_AUTO_REMAPS_ENABLE:
+         return "auto_remaps_enable";
+      case MENU_ENUM_LABEL_AUTO_SHADERS_ENABLE:
+         return "auto_shaders_enable";
+      case MENU_ENUM_LABEL_BLOCK_SRAM_OVERWRITE:
+         return "block_sram_overwrite";
+      case MENU_ENUM_LABEL_BLUETOOTH_ENABLE:
+         return "bluetooth_enable";
+      case MENU_ENUM_LABEL_BUILDBOT_ASSETS_URL:
+         return "buildbot_assets_url";
+      case MENU_ENUM_LABEL_CACHE_DIRECTORY:
+         return "cache_directory";
+      case MENU_ENUM_LABEL_CAMERA_ALLOW:
+         return "camera_allow";
+      case MENU_ENUM_LABEL_CAMERA_DRIVER:
+         return "camera_driver";
       case MENU_ENUM_LABEL_CB_CORE_CONTENT_DIRS_LIST:
          return "cb_core_content_dirs_list";
+      case MENU_ENUM_LABEL_CB_CORE_CONTENT_DOWNLOAD:
+         return "cb_core_content_download";
+      case MENU_ENUM_LABEL_CB_CORE_CONTENT_LIST:
+         return "cb_core_content_list";
       case MENU_ENUM_LABEL_CB_CORE_THUMBNAILS_DOWNLOAD:
          return "cb_core_thumbnails_download";
       case MENU_ENUM_LABEL_CB_CORE_UPDATER_DOWNLOAD:
          return "cb_core_updater_download";
-      case MENU_ENUM_LABEL_CB_UPDATE_CHEATS:
-         return "cb_update_cheats";
-      case MENU_ENUM_LABEL_CB_UPDATE_OVERLAYS:
-         return "cb_update_overlays";
-      case MENU_ENUM_LABEL_CB_UPDATE_DATABASES:
-         return "cb_update_databases";
-      case MENU_ENUM_LABEL_CB_UPDATE_SHADERS_GLSL:
-         return "cb_update_shaders_glsl";
-      case MENU_ENUM_LABEL_CB_UPDATE_SHADERS_CG:
-         return "cb_update_shaders_cg";
-      case MENU_ENUM_LABEL_CB_UPDATE_CORE_INFO_FILES:
-         return "cb_update_core_info_files";
-      case MENU_ENUM_LABEL_CB_CORE_CONTENT_DOWNLOAD:
-         return "cb_core_content_download";
+      case MENU_ENUM_LABEL_CB_CORE_UPDATER_LIST:
+         return "cb_core_updater_list";
+      case MENU_ENUM_LABEL_CB_DOWNLOAD_URL:
+         return "cb_download_url";
       case MENU_ENUM_LABEL_CB_LAKKA_DOWNLOAD:
          return "cb_lakka_download";
+      case MENU_ENUM_LABEL_CB_LAKKA_LIST:
+         return "cb_lakka_list";
+      case MENU_ENUM_LABEL_CB_MENU_THUMBNAIL:
+         return "cb_menu_thumbnail";
+      case MENU_ENUM_LABEL_CB_MENU_WALLPAPER:
+         return "cb_menu_wallpaper";
+      case MENU_ENUM_LABEL_CB_THUMBNAILS_UPDATER_DOWNLOAD:
+         return "cb_thumbnails_updater_download";
+      case MENU_ENUM_LABEL_CB_THUMBNAILS_UPDATER_LIST:
+         return "cb_thumbnails_updater_list";
       case MENU_ENUM_LABEL_CB_UPDATE_ASSETS:
          return "cb_update_assets";
       case MENU_ENUM_LABEL_CB_UPDATE_AUTOCONFIG_PROFILES:
          return "cb_update_autoconfig_profiles";
-      case MENU_ENUM_LABEL_CB_THUMBNAILS_UPDATER_DOWNLOAD:
-         return "cb_thumbnails_updater_download";
+      case MENU_ENUM_LABEL_CB_UPDATE_CHEATS:
+         return "cb_update_cheats";
+      case MENU_ENUM_LABEL_CB_UPDATE_CORE_INFO_FILES:
+         return "cb_update_core_info_files";
+      case MENU_ENUM_LABEL_CB_UPDATE_DATABASES:
+         return "cb_update_databases";
+      case MENU_ENUM_LABEL_CB_UPDATE_OVERLAYS:
+         return "cb_update_overlays";
+      case MENU_ENUM_LABEL_CB_UPDATE_SHADERS_CG:
+         return "cb_update_shaders_cg";
+      case MENU_ENUM_LABEL_CB_UPDATE_SHADERS_GLSL:
+         return "cb_update_shaders_glsl";
+      case MENU_ENUM_LABEL_CHEAT_APPLY_CHANGES:
+         return "cheat_apply_changes";
+      case MENU_ENUM_LABEL_CHEAT_DATABASE_PATH:
+         return "cheat_database_path";
+      case MENU_ENUM_LABEL_CHEAT_FILE_LOAD:
+         return "cheat_file_load";
+      case MENU_ENUM_LABEL_CHEAT_FILE_SAVE_AS:
+         return "cheat_file_save_as";
+      case MENU_ENUM_LABEL_CHEAT_NUM_PASSES:
+         return "cheat_num_passes";
+      case MENU_ENUM_LABEL_CHEEVOS_DESCRIPTION:
+         return "cheevos_description";
+      case MENU_ENUM_LABEL_CHEEVOS_ENABLE:
+         return "cheevos_enable";
+      case MENU_ENUM_LABEL_CHEEVOS_HARDCORE_MODE_ENABLE:
+         return "cheevos_hardcore_mode_enable";
+      case MENU_ENUM_LABEL_CHEEVOS_LOCKED_ACHIEVEMENTS:
+         return "cheevos_locked_achievements";
+      case MENU_ENUM_LABEL_CHEEVOS_LOCKED_ENTRY:
+         return "cheevos_locked_entry";
+      case MENU_ENUM_LABEL_CHEEVOS_PASSWORD:
+         return "cheevos_password";
+      case MENU_ENUM_LABEL_CHEEVOS_TEST_UNOFFICIAL:
+         return "cheevos_test_unofficial";
+      case MENU_ENUM_LABEL_CHEEVOS_UNLOCKED_ACHIEVEMENTS:
+         return "cheevos_unlocked_achievements";
+      case MENU_ENUM_LABEL_CHEEVOS_UNLOCKED_ENTRY:
+         return "cheevos_unlocked_entry";
+      case MENU_ENUM_LABEL_CHEEVOS_USERNAME:
+         return "cheevos_username";
+      case MENU_ENUM_LABEL_CLOSE_CONTENT:
+         return "unload_core";
+      case MENU_ENUM_LABEL_COLLECTION:
+         return "collection";
+      case MENU_ENUM_LABEL_CONFIGURATIONS:
+         return "configurations";
+      case MENU_ENUM_LABEL_CONFIGURATION_SETTINGS:
+         return "configuration_settings";
+      case MENU_ENUM_LABEL_CONFIG_SAVE_ON_EXIT:
+         return "config_save_on_exit";
+      case MENU_ENUM_LABEL_CONNECT_WIFI:
+         return "connect_wifi";
       case MENU_ENUM_LABEL_CONTENT_ACTIONS:
          return "content_actions";
+      case MENU_ENUM_LABEL_CONTENT_COLLECTION_LIST:
+         return "select_from_collection";
+      case MENU_ENUM_LABEL_CONTENT_DATABASE_DIRECTORY:
+         return "content_database_path";
+      case MENU_ENUM_LABEL_CONTENT_HISTORY_SIZE:
+         return "content_history_size";
+      case MENU_ENUM_LABEL_CONTENT_SETTINGS:
+         return "quick_menu";
+      case MENU_ENUM_LABEL_CORE_ASSETS_DIRECTORY:
+         return "core_assets_directory";
+      case MENU_ENUM_LABEL_CORE_CHEAT_OPTIONS:
+         return "core_cheat_options";
+      case MENU_ENUM_LABEL_CORE_COUNTERS:
+         return "core_counters";
+      case MENU_ENUM_LABEL_CORE_ENABLE:
+         return "menu_core_enable";
+      case MENU_ENUM_LABEL_CORE_INFORMATION:
+         return "core_information";
+      case MENU_ENUM_LABEL_CORE_INFO_ENTRY:
+         return "core_info_entry";
+      case MENU_ENUM_LABEL_CORE_INPUT_REMAPPING_OPTIONS:
+         return "core_input_remapping_options";
+      case MENU_ENUM_LABEL_CORE_LIST:
+         return "load_core";
+      case MENU_ENUM_LABEL_CORE_OPTIONS:
+         return "core_options";
+      case MENU_ENUM_LABEL_CORE_OPTION_ENTRY:
+         return "core_option_entry";
+      case MENU_ENUM_LABEL_CORE_SETTINGS:
+         return "core_settings";
+      case MENU_ENUM_LABEL_CORE_SET_SUPPORTS_NO_CONTENT_ENABLE:
+         return "core_set_supports_no_content_enable";
+      case MENU_ENUM_LABEL_CORE_SPECIFIC_CONFIG:
+         return "core_specific_config";
+      case MENU_ENUM_LABEL_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
+         return "core_updater_auto_extract_archive";
+      case MENU_ENUM_LABEL_CORE_UPDATER_BUILDBOT_URL:
+         return "core_updater_buildbot_url";
+      case MENU_ENUM_LABEL_CORE_UPDATER_LIST:
+         return "core_updater_list";
       case MENU_ENUM_LABEL_CPU_ARCHITECTURE:
          return "system_information_cpu_architecture";
       case MENU_ENUM_LABEL_CPU_CORES:
          return "system_information_cpu_cores";
-      case MENU_ENUM_LABEL_NO_ITEMS:
-         return "no_items";
-      case MENU_ENUM_LABEL_NO_PLAYLISTS:
-         return "no_playlists";
-      case MENU_ENUM_LABEL_NO_HISTORY_AVAILABLE:
-         return "no_history";
-      case MENU_ENUM_LABEL_NO_SHADER_PARAMETERS:
-         return "no_shader_parameters.";
-      case MENU_ENUM_LABEL_SETTINGS_TAB:
-         return "settings_tab";
+      case MENU_ENUM_LABEL_CURSOR_DIRECTORY:
+         return "cursor_directory";
+      case MENU_ENUM_LABEL_CURSOR_MANAGER_LIST:
+         return "cursor_manager_list";
+      case MENU_ENUM_LABEL_CUSTOM_BIND:
+         return "custom_bind";
+      case MENU_ENUM_LABEL_CUSTOM_BIND_ALL:
+         return "custom_bind_all";
+      case MENU_ENUM_LABEL_CUSTOM_RATIO:
+         return "custom_ratio";
+      case MENU_ENUM_LABEL_DATABASE_MANAGER_LIST:
+         return "database_manager_list";
+      case MENU_ENUM_LABEL_DEFERRED_ACCOUNTS_CHEEVOS_LIST:
+         return "deferred_accounts_cheevos_list";
+      case MENU_ENUM_LABEL_DEFERRED_ACCOUNTS_LIST:
+         return "deferred_accounts_list";
+      case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_ACTION:
+         return "deferred_archive_action";
+      case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_ACTION_DETECT_CORE:
+         return "deferred_archive_action_detect_core";
+      case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_OPEN:
+         return "deferred_archive_open";
+      case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_OPEN_DETECT_CORE:
+         return "deferred_archive_open_detect_core";
+      case MENU_ENUM_LABEL_DEFERRED_AUDIO_SETTINGS_LIST:
+         return "deferred_audio_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_CONFIGURATION_SETTINGS_LIST:
+         return "deferred_configuration_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_CORE_CONTENT_DIRS_LIST:
+         return "deferred_core_content_dirs_list";
+      case MENU_ENUM_LABEL_DEFERRED_CORE_CONTENT_DIRS_SUBDIR_LIST:
+         return "deferred_core_content_dirs_subdir_list";
+      case MENU_ENUM_LABEL_DEFERRED_CORE_CONTENT_LIST:
+         return "deferred_core_content_list";
+      case MENU_ENUM_LABEL_DEFERRED_CORE_LIST:
+         return "deferred_core_list";
+      case MENU_ENUM_LABEL_DEFERRED_CORE_LIST_SET:
+         return "deferred_core_list_set";
+      case MENU_ENUM_LABEL_DEFERRED_CORE_SETTINGS_LIST:
+         return "deferred_core_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_CORE_UPDATER_LIST:
+         return "core_updater";
+      case MENU_ENUM_LABEL_DEFERRED_CURSOR_MANAGER_LIST:
+         return "deferred_cursor_manager_list";
+      case MENU_ENUM_LABEL_DEFERRED_DATABASE_MANAGER_LIST:
+         return "deferred_database_manager_list";
+      case MENU_ENUM_LABEL_DEFERRED_DIRECTORY_SETTINGS_LIST:
+         return "deferred_directory_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_DRIVER_SETTINGS_LIST:
+         return "deferred_driver_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_FRAME_THROTTLE_SETTINGS_LIST:
+         return "deferred_frame_throttle_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_INPUT_HOTKEY_BINDS_LIST:
+         return "deferred_input_hotkey_binds";
+      case MENU_ENUM_LABEL_DEFERRED_INPUT_SETTINGS_LIST:
+         return "deferred_input_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_LAKKA_LIST:
+         return "deferred_lakka_list";
+      case MENU_ENUM_LABEL_DEFERRED_LAKKA_SERVICES_LIST:
+         return "deferred_lakka_services_list";
+      case MENU_ENUM_LABEL_DEFERRED_LOGGING_SETTINGS_LIST:
+         return "deferred_logging_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_MENU_FILE_BROWSER_SETTINGS_LIST:
+         return "deferred_menu_file_browser_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_MENU_SETTINGS_LIST:
+         return "deferred_menu_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_NETWORK_SETTINGS_LIST:
+         return "deferred_network_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_ONSCREEN_DISPLAY_SETTINGS_LIST:
+         return "deferred_onscreen_display_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_ONSCREEN_OVERLAY_SETTINGS_LIST:
+         return "deferred_onscreen_overlay_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_PLAYLIST_SETTINGS_LIST:
+         return "deferred_playlist_settings";
+      case MENU_ENUM_LABEL_DEFERRED_PRIVACY_SETTINGS_LIST:
+         return "deferred_privacy_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_RDB_ENTRY_DETAIL:
+         return "deferred_rdb_entry_detail";
+      case MENU_ENUM_LABEL_DEFERRED_RECORDING_SETTINGS_LIST:
+         return "deferred_recording_settings";
+      case MENU_ENUM_LABEL_DEFERRED_RETRO_ACHIEVEMENTS_SETTINGS_LIST:
+         return "deferred_retro_achievements_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_REWIND_SETTINGS_LIST:
+         return "deferred_rewind_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_SAVING_SETTINGS_LIST:
+         return "deferred_saving_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_THUMBNAILS_UPDATER_LIST:
+         return "deferred_thumbnails_updater_list";
+      case MENU_ENUM_LABEL_DEFERRED_UPDATER_SETTINGS_LIST:
+         return "deferred_updater_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_USER_BINDS_LIST:
+         return "deferred_user_binds_list";
+      case MENU_ENUM_LABEL_DEFERRED_USER_INTERFACE_SETTINGS_LIST:
+         return "deferred_user_interface_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_USER_SETTINGS_LIST:
+         return "deferred_user_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_VIDEO_FILTER:
+         return "deferred_video_filter";
+      case MENU_ENUM_LABEL_DEFERRED_VIDEO_SETTINGS_LIST:
+         return "deferred_video_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_WIFI_SETTINGS_LIST:
+         return "deferred_wifi_settings_list";
+      case MENU_ENUM_LABEL_DELETE_ENTRY:
+         return "delete_entry";
+      case MENU_ENUM_LABEL_DETECT_CORE_LIST:
+         return "detect_core_list";
+      case MENU_ENUM_LABEL_DIRECTORY_SETTINGS:
+         return "directory_settings";
+      case MENU_ENUM_LABEL_DISK_CYCLE_TRAY_STATUS:
+         return "disk_cycle_tray_status";
+      case MENU_ENUM_LABEL_DISK_IMAGE_APPEND:
+         return "disk_image_append";
+      case MENU_ENUM_LABEL_DISK_OPTIONS:
+         return "core_disk_options";
+      case MENU_ENUM_LABEL_DOWNLOADED_FILE_DETECT_CORE_LIST:
+         return "downloaded_file_detect_core_list";
+      case MENU_ENUM_LABEL_DOWNLOAD_CORE_CONTENT:
+         return "download_core_content";
+      case MENU_ENUM_LABEL_DOWNLOAD_CORE_CONTENT_DIRS:
+         return "download_core_content_dirs";
+      case MENU_ENUM_LABEL_DPI_OVERRIDE_ENABLE:
+         return "dpi_override_enable";
+      case MENU_ENUM_LABEL_DPI_OVERRIDE_VALUE:
+         return "dpi_override_value";
+      case MENU_ENUM_LABEL_DRIVER_SETTINGS:
+         return "driver_settings";
+      case MENU_ENUM_LABEL_DUMMY_ON_CORE_SHUTDOWN:
+         return "dummy_on_core_shutdown";
+      case MENU_ENUM_LABEL_DYNAMIC_WALLPAPER:
+         return "menu_dynamic_wallpaper_enable";
+      case MENU_ENUM_LABEL_DYNAMIC_WALLPAPERS_DIRECTORY:
+         return "dynamic_wallpapers_directory";
+      case MENU_ENUM_LABEL_ENTRY_HOVER_COLOR:
+         return "menu_entry_hover_color";
+      case MENU_ENUM_LABEL_ENTRY_NORMAL_COLOR:
+         return "menu_entry_normal_color";
+      case MENU_ENUM_LABEL_FASTFORWARD_RATIO:
+         return "fastforward_ratio";
+      case MENU_ENUM_LABEL_FILE_BROWSER_CORE:
+         return "file_browser_core";
+      case MENU_ENUM_LABEL_FILE_BROWSER_CORE_DETECTED:
+         return "file_browser_core_detected";
+      case MENU_ENUM_LABEL_FILE_BROWSER_CORE_SELECT_FROM_COLLECTION:
+         return "file_browser_core_select_from_collection";
+      case MENU_ENUM_LABEL_FILE_BROWSER_DIRECTORY:
+         return "file_browser_directory";
+      case MENU_ENUM_LABEL_FILE_BROWSER_IMAGE:
+         return "file_browser_image";
+      case MENU_ENUM_LABEL_FILE_BROWSER_IMAGE_OPEN_WITH_VIEWER:
+         return "file_browser_image_open_with_viewer";
+      case MENU_ENUM_LABEL_FILE_BROWSER_MOVIE_OPEN:
+         return "file_browser_movie_open";
+      case MENU_ENUM_LABEL_FILE_BROWSER_MUSIC_OPEN:
+         return "file_browser_music_open";
+      case MENU_ENUM_LABEL_FILE_BROWSER_PLAIN_FILE:
+         return "file_browser_plain_file";
+      case MENU_ENUM_LABEL_FILE_BROWSER_REMAP:
+         return "file_browser_remap";
+      case MENU_ENUM_LABEL_FILE_BROWSER_SHADER:
+         return "file_browser_shader";
+      case MENU_ENUM_LABEL_FILE_BROWSER_SHADER_PRESET:
+         return "file_browser_shader_preset";
+      case MENU_ENUM_LABEL_FPS_SHOW:
+         return "fps_show";
+      case MENU_ENUM_LABEL_FRAME_THROTTLE_ENABLE:
+         return "fastforward_ratio_throttle_enable";
+      case MENU_ENUM_LABEL_FRAME_THROTTLE_SETTINGS:
+         return "frame_throttle_settings";
+      case MENU_ENUM_LABEL_FRONTEND_COUNTERS:
+         return "frontend_counters";
+      case MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS:
+         return "game_specific_options";
+      case MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS_CREATE:
+         return "game_specific_options_create";
+      case MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS_IN_USE:
+         return "game_specific_options_in_use";
+      case MENU_ENUM_LABEL_HELP:
+         return "help";
+      case MENU_ENUM_LABEL_HELP_AUDIO_VIDEO_TROUBLESHOOTING:
+         return "help_audio_video_troubleshooting";
+      case MENU_ENUM_LABEL_HELP_CHANGE_VIRTUAL_GAMEPAD:
+         return "help_change_virtual_gamepad";
+      case MENU_ENUM_LABEL_HELP_CONTROLS:
+         return "help_controls";
+      case MENU_ENUM_LABEL_HELP_LIST:
+         return "help_list";
+      case MENU_ENUM_LABEL_HELP_LOADING_CONTENT:
+         return "help_loading_content";
+      case MENU_ENUM_LABEL_HELP_SCANNING_CONTENT:
+         return "help_scanning_content";
+      case MENU_ENUM_LABEL_HELP_WHAT_IS_A_CORE:
+         return "help_what_is_a_core";
+      case MENU_ENUM_LABEL_HISTORY_LIST_ENABLE:
+         return "history_list_enable";
       case MENU_ENUM_LABEL_HISTORY_TAB:
          return "history_tab";
-      case MENU_ENUM_LABEL_ADD_TAB:
-         return "add_tab";
-      case MENU_ENUM_LABEL_PLAYLISTS_TAB:
-         return "playlists_tab";
-      case MENU_ENUM_LABEL_MUSIC_TAB:
-         return "music_tab";
-      case MENU_ENUM_LABEL_VIDEO_TAB:
-         return "video_tab";
-      case MENU_ENUM_LABEL_IMAGES_TAB:
-         return "images_tab";
       case MENU_ENUM_LABEL_HORIZONTAL_MENU:
          return "horizontal_menu";
-      case MENU_ENUM_LABEL_PARENT_DIRECTORY:
-         return "parent_directory";
-      case MENU_ENUM_LABEL_INPUT_PLAYER_ANALOG_DPAD_MODE:
-         return "input_player%u_analog_dpad_mode";
+      case MENU_ENUM_LABEL_IMAGES_TAB:
+         return "images_tab";
+      case MENU_ENUM_LABEL_INFORMATION:
+         return "information";
+      case MENU_ENUM_LABEL_INFORMATION_LIST:
+         return "information_list";
+      case MENU_ENUM_LABEL_INFO_SCREEN:
+         return "info_screen";
+      case MENU_ENUM_LABEL_INPUT_ALL_USERS_CONTROL_MENU:
+         return "all_users_control_menu";
+      case MENU_ENUM_LABEL_INPUT_AUTODETECT_ENABLE:
+         return "input_autodetect_enable";
+      case MENU_ENUM_LABEL_INPUT_AXIS_THRESHOLD:
+         return "input_axis_threshold";
+      case MENU_ENUM_LABEL_INPUT_BACK_AS_MENU_ENUM_TOGGLE_ENABLE:
+         return "back_as_menu_toggle_enable";
+      case MENU_ENUM_LABEL_INPUT_BIND_MODE:
+         return "input_bind_mode";
+      case MENU_ENUM_LABEL_INPUT_BIND_TIMEOUT:
+         return "input_bind_timeout";
+      case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_HIDE_UNBOUND:
+         return "input_descriptor_hide_unbound";
+      case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_LABEL_SHOW:
+         return "input_descriptor_label_show";
+      case MENU_ENUM_LABEL_INPUT_DRIVER:
+         return "input_driver";
+      case MENU_ENUM_LABEL_INPUT_DUTY_CYCLE:
+         return "input_duty_cycle";
+      case MENU_ENUM_LABEL_INPUT_HOTKEY_BINDS:
+         return "input_hotkey_binds";
+      case MENU_ENUM_LABEL_INPUT_HOTKEY_BINDS_BEGIN:
+         return "input_hotkey_binds_begin";
+      case MENU_ENUM_LABEL_INPUT_ICADE_ENABLE:
+         return "input_icade_enable";
+      case MENU_ENUM_LABEL_INPUT_KEYBOARD_GAMEPAD_MAPPING_TYPE:
+         return "keyboard_gamepad_mapping_type";
       case MENU_ENUM_LABEL_INPUT_LIBRETRO_DEVICE:
          return "input_libretro_device_p%u";
-      case MENU_ENUM_LABEL_RUN:
-         return "collection";
-      case MENU_ENUM_LABEL_PLAYLIST_COLLECTION_ENTRY:
-         return "playlist_collection_entry";
-      case MENU_ENUM_LABEL_CHEEVOS_LOCKED_ENTRY:
-         return "cheevos_locked_entry";
-      case MENU_ENUM_LABEL_CHEEVOS_UNLOCKED_ENTRY:
-         return "cheevos_unlocked_entry";
-      case MENU_ENUM_LABEL_CORE_INFO_ENTRY:
-         return "core_info_entry";
-      case MENU_ENUM_LABEL_NETWORK_INFO_ENTRY:
-         return "network_info_entry";
-      case MENU_ENUM_LABEL_PLAYLIST_ENTRY:
-         return "playlist_entry";
-      case MENU_ENUM_LABEL_SYSTEM_INFO_ENTRY:
-         return "system_info_entry";
+      case MENU_ENUM_LABEL_INPUT_MAX_USERS:
+         return "input_max_users";
+      case MENU_ENUM_LABEL_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
+         return "input_menu_toggle_gamepad_combo";
+      case MENU_ENUM_LABEL_INPUT_OSK_OVERLAY_ENABLE:
+         return "input_osk_overlay_enable";
+      case MENU_ENUM_LABEL_INPUT_OVERLAY_ENABLE:
+         return "input_overlay_enable";
+      case MENU_ENUM_LABEL_INPUT_OVERLAY_HIDE_IN_MENU:
+         return "overlay_hide_in_menu";
+      case MENU_ENUM_LABEL_INPUT_PLAYER_ANALOG_DPAD_MODE:
+         return "input_player%u_analog_dpad_mode";
+      case MENU_ENUM_LABEL_INPUT_POLL_TYPE_BEHAVIOR:
+         return "input_poll_type_behavior";
+      case MENU_ENUM_LABEL_INPUT_PREFER_FRONT_TOUCH:
+         return "input_prefer_front_touch";
+      case MENU_ENUM_LABEL_INPUT_REMAPPING_DIRECTORY:
+         return "input_remapping_directory";
+      case MENU_ENUM_LABEL_INPUT_REMAP_BINDS_ENABLE:
+         return "input_remap_binds_enable";
+      case MENU_ENUM_LABEL_INPUT_SETTINGS:
+         return "input_settings";
+      case MENU_ENUM_LABEL_INPUT_SETTINGS_BEGIN:
+         return "input_settings_begin";
+      case MENU_ENUM_LABEL_INPUT_SMALL_KEYBOARD_ENABLE:
+         return "input_small_keyboard_enable";
+      case MENU_ENUM_LABEL_INPUT_TOUCH_ENABLE:
+         return "input_touch_enable";
+      case MENU_ENUM_LABEL_INPUT_TURBO_PERIOD:
+         return "input_turbo_period";
+      case MENU_ENUM_LABEL_INPUT_USER_10_BINDS:
+         return "10_input_binds_list";
+      case MENU_ENUM_LABEL_INPUT_USER_11_BINDS:
+         return "11_input_binds_list";
+      case MENU_ENUM_LABEL_INPUT_USER_12_BINDS:
+         return "12_input_binds_list";
+      case MENU_ENUM_LABEL_INPUT_USER_13_BINDS:
+         return "13_input_binds_list";
+      case MENU_ENUM_LABEL_INPUT_USER_14_BINDS:
+         return "14_input_binds_list";
+      case MENU_ENUM_LABEL_INPUT_USER_15_BINDS:
+         return "15_input_binds_list";
+      case MENU_ENUM_LABEL_INPUT_USER_16_BINDS:
+         return "16_input_binds_list";
       case MENU_ENUM_LABEL_INPUT_USER_1_BINDS:
          return "1_input_binds_list";
       case MENU_ENUM_LABEL_INPUT_USER_2_BINDS:
@@ -2066,952 +2392,626 @@ static const char *menu_hash_to_str_us_label_enum(enum msg_hash_enums msg)
          return "8_input_binds_list";
       case MENU_ENUM_LABEL_INPUT_USER_9_BINDS:
          return "9_input_binds_list";
-      case MENU_ENUM_LABEL_INPUT_USER_10_BINDS:
-         return "10_input_binds_list";
-      case MENU_ENUM_LABEL_INPUT_USER_11_BINDS:
-         return "11_input_binds_list";
-      case MENU_ENUM_LABEL_INPUT_USER_12_BINDS:
-         return "12_input_binds_list";
-      case MENU_ENUM_LABEL_INPUT_USER_13_BINDS:
-         return "13_input_binds_list";
-      case MENU_ENUM_LABEL_INPUT_USER_14_BINDS:
-         return "14_input_binds_list";
-      case MENU_ENUM_LABEL_INPUT_USER_15_BINDS:
-         return "15_input_binds_list";
-      case MENU_ENUM_LABEL_INPUT_USER_16_BINDS:
-         return "16_input_binds_list";
-      case MENU_ENUM_LABEL_VIDEO_VIEWPORT_CUSTOM_X:
-         return "video_viewport_custom_x";
-      case MENU_ENUM_LABEL_VIDEO_VIEWPORT_CUSTOM_Y:
-         return "video_viewport_custom_y";
-      case MENU_ENUM_LABEL_VIDEO_VIEWPORT_CUSTOM_WIDTH:
-         return "video_viewport_custom_width";
-      case MENU_ENUM_LABEL_VIDEO_VIEWPORT_CUSTOM_HEIGHT:
-         return "video_viewport_custom_height";
-      case MENU_ENUM_LABEL_NO_CORES_AVAILABLE:
-         return "no_cores_available";
-      case MENU_ENUM_LABEL_NO_CORE_OPTIONS_AVAILABLE:
-         return "no_core_options_available";
-      case MENU_ENUM_LABEL_NO_CORE_INFORMATION_AVAILABLE:
-         return "no_core_information_available";
-      case MENU_ENUM_LABEL_CORE_OPTION_ENTRY:
-         return "core_option_entry";
-      case MENU_ENUM_LABEL_URL_ENTRY:
-         return "url_entry";
-      case MENU_ENUM_LABEL_NO_PERFORMANCE_COUNTERS:
-         return "no_performance_counters";
-      case MENU_ENUM_LABEL_NO_ENTRIES_TO_DISPLAY:
-         return "no_entries_to_display";
-      case MENU_ENUM_LABEL_NO_ACHIEVEMENTS_TO_DISPLAY:
-         return "no_achievements_to_display";
-      case MENU_ENUM_LABEL_CHEEVOS_UNLOCKED_ACHIEVEMENTS:
-         return "cheevos_unlocked_achievements";
-      case MENU_ENUM_LABEL_CHEEVOS_LOCKED_ACHIEVEMENTS:
-         return "cheevos_locked_achievements";
+      case MENU_ENUM_LABEL_JOYPAD_AUTOCONFIG_DIR:
+         return "joypad_autoconfig_dir";
+      case MENU_ENUM_LABEL_JOYPAD_DRIVER:
+         return "input_joypad_driver";
+      case MENU_ENUM_LABEL_KEYBOARD_OVERLAY_PRESET:
+         return "input_osk_overlay";
+      case MENU_ENUM_LABEL_LAKKA_SERVICES:
+         return "lakka_services";
+      case MENU_ENUM_LABEL_LIBRETRO_DIR_PATH:
+         return "libretro_dir_path";
+      case MENU_ENUM_LABEL_LIBRETRO_INFO_PATH:
+         return "libretro_info_path";
+      case MENU_ENUM_LABEL_LIBRETRO_LOG_LEVEL:
+         return "libretro_log_level";
+      case MENU_ENUM_LABEL_LOAD_ARCHIVE:
+         return "load_archive";
+      case MENU_ENUM_LABEL_LOAD_ARCHIVE_DETECT_CORE:
+         return "load_archive_detect_core";
+      case MENU_ENUM_LABEL_LOAD_CONTENT:
+         return "load_content_default";
+      case MENU_ENUM_LABEL_LOAD_CONTENT_HISTORY:
+         return "load_recent";
+      case MENU_ENUM_LABEL_LOAD_CONTENT_LIST:
+         return "load_content";
+      case MENU_ENUM_LABEL_LOAD_STATE:
+         return "loadstate";
+      case MENU_ENUM_LABEL_LOCATION_ALLOW:
+         return "location_allow";
+      case MENU_ENUM_LABEL_LOCATION_DRIVER:
+         return "location_driver";
+      case MENU_ENUM_LABEL_LOGGING_SETTINGS:
+         return "logging_settings";
+      case MENU_ENUM_LABEL_LOG_VERBOSITY:
+         return "log_verbosity";
       case MENU_ENUM_LABEL_MAIN_MENU:
          return "main_menu";
-      case MENU_ENUM_LABEL_MENU_LINEAR_FILTER:
-         return "menu_linear_filter";
+      case MENU_ENUM_LABEL_MANAGEMENT:
+         return "database_settings";
+      case MENU_ENUM_LABEL_MATERIALUI_MENU_COLOR_THEME:
+         return "materialui_menu_color_theme";
+      case MENU_ENUM_LABEL_MATERIALUI_MENU_FOOTER_OPACITY:
+         return "materialui_menu_footer_opacity";
+      case MENU_ENUM_LABEL_MATERIALUI_MENU_HEADER_OPACITY:
+         return "materialui_menu_header_opacity";
+      case MENU_ENUM_LABEL_MENU_DRIVER:
+         return "menu_driver";
       case MENU_ENUM_LABEL_MENU_ENUM_THROTTLE_FRAMERATE:
          return "menu_throttle_framerate";
-      case MENU_ENUM_LABEL_START_CORE:
-         return "start_core";
-      case MENU_ENUM_LABEL_CHEEVOS_HARDCORE_MODE_ENABLE:
-         return "cheevos_hardcore_mode_enable";
-      case MENU_ENUM_LABEL_CHEEVOS_TEST_UNOFFICIAL:
-         return "cheevos_test_unofficial";
-      case MENU_ENUM_LABEL_CHEEVOS_ENABLE:
-         return "cheevos_enable";
-      case MENU_ENUM_LABEL_INPUT_TOUCH_ENABLE:
-         return "input_touch_enable";
-      case MENU_ENUM_LABEL_INPUT_PREFER_FRONT_TOUCH:
-         return "input_prefer_front_touch";
-      case MENU_ENUM_LABEL_INPUT_ICADE_ENABLE:
-         return "input_icade_enable";
-      case MENU_ENUM_LABEL_INPUT_KEYBOARD_GAMEPAD_MAPPING_TYPE:
-         return "keyboard_gamepad_mapping_type";
-      case MENU_ENUM_LABEL_INPUT_SMALL_KEYBOARD_ENABLE:
-         return "input_small_keyboard_enable";
+      case MENU_ENUM_LABEL_MENU_FILE_BROWSER_SETTINGS:
+         return "menu_file_browser_settings";
+      case MENU_ENUM_LABEL_MENU_LINEAR_FILTER:
+         return "menu_linear_filter";
+      case MENU_ENUM_LABEL_MENU_SETTINGS:
+         return "menu_settings";
+      case MENU_ENUM_LABEL_MENU_WALLPAPER:
+         return "menu_wallpaper";
+      case MENU_ENUM_LABEL_MENU_WALLPAPER_OPACITY:
+         return "menu_wallpaper_opacity";
+      case MENU_ENUM_LABEL_MOUSE_ENABLE:
+         return "menu_mouse_enable";
+      case MENU_ENUM_LABEL_MUSIC_TAB:
+         return "music_tab";
+      case MENU_ENUM_LABEL_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
+         return "menu_navigation_browser_filter_supported_extensions_enable";
+      case MENU_ENUM_LABEL_NAVIGATION_WRAPAROUND:
+         return "menu_navigation_wraparound_enable";
+      case MENU_ENUM_LABEL_NETPLAY:
+         return "netplay";
+      case MENU_ENUM_LABEL_NETPLAY_CHECK_FRAMES:
+         return "netplay_check_frames";
+      case MENU_ENUM_LABEL_NETPLAY_CLIENT_SWAP_INPUT:
+         return "netplay_client_swap_input";
+      case MENU_ENUM_LABEL_NETPLAY_DELAY_FRAMES:
+         return "netplay_delay_frames";
+      case MENU_ENUM_LABEL_NETPLAY_DISCONNECT:
+         return "menu_netplay_disconnect";
+      case MENU_ENUM_LABEL_NETPLAY_ENABLE:
+         return "netplay_enable";
+      case MENU_ENUM_LABEL_NETPLAY_ENABLE_CLIENT:
+         return "menu_netplay_enable_client";
+      case MENU_ENUM_LABEL_NETPLAY_ENABLE_HOST:
+         return "menu_netplay_enable_host";
+      case MENU_ENUM_LABEL_NETPLAY_IP_ADDRESS:
+         return "netplay_ip_address";
+      case MENU_ENUM_LABEL_NETPLAY_MODE:
+         return "netplay_mode";
+      case MENU_ENUM_LABEL_NETPLAY_NICKNAME:
+         return "netplay_nickname";
+      case MENU_ENUM_LABEL_NETPLAY_SETTINGS:
+         return "menu_netplay_settings";
+      case MENU_ENUM_LABEL_NETPLAY_SPECTATOR_MODE_ENABLE:
+         return "netplay_spectator_mode_enable";
+      case MENU_ENUM_LABEL_NETPLAY_TCP_UDP_PORT:
+         return "netplay_tcp_udp_port";
+      case MENU_ENUM_LABEL_NETWORK_CMD_ENABLE:
+         return "network_cmd_enable";
+      case MENU_ENUM_LABEL_NETWORK_CMD_PORT:
+         return "network_cmd_port";
+      case MENU_ENUM_LABEL_NETWORK_INFORMATION:
+         return "network_information";
+      case MENU_ENUM_LABEL_NETWORK_INFO_ENTRY:
+         return "network_info_entry";
+      case MENU_ENUM_LABEL_NETWORK_REMOTE_ENABLE:
+         return "network_remote_enable";
+      case MENU_ENUM_LABEL_NETWORK_REMOTE_PORT:
+         return "network_remote_base_port";
+      case MENU_ENUM_LABEL_NETWORK_REMOTE_USER_1_ENABLE:
+         return "network_remote_user_1_enable";
+      case MENU_ENUM_LABEL_NETWORK_REMOTE_USER_LAST_ENABLE:
+         return "network_remote_user_last_enable";
+      case MENU_ENUM_LABEL_NETWORK_SETTINGS:
+         return "network_settings";
+      case MENU_ENUM_LABEL_NO_ACHIEVEMENTS_TO_DISPLAY:
+         return "no_achievements_to_display";
+      case MENU_ENUM_LABEL_NO_CORES_AVAILABLE:
+         return "no_cores_available";
+      case MENU_ENUM_LABEL_NO_CORE_INFORMATION_AVAILABLE:
+         return "no_core_information_available";
+      case MENU_ENUM_LABEL_NO_CORE_OPTIONS_AVAILABLE:
+         return "no_core_options_available";
+      case MENU_ENUM_LABEL_NO_ENTRIES_TO_DISPLAY:
+         return "no_entries_to_display";
+      case MENU_ENUM_LABEL_NO_HISTORY_AVAILABLE:
+         return "no_history";
+      case MENU_ENUM_LABEL_NO_ITEMS:
+         return "no_items";
+      case MENU_ENUM_LABEL_NO_PERFORMANCE_COUNTERS:
+         return "no_performance_counters";
+      case MENU_ENUM_LABEL_NO_PLAYLISTS:
+         return "no_playlists";
+      case MENU_ENUM_LABEL_NO_PLAYLIST_ENTRIES_AVAILABLE:
+         return "no_playlist_entries_available";
+      case MENU_ENUM_LABEL_NO_SETTINGS_FOUND:
+         return "menu_label_no_settings_found";
+      case MENU_ENUM_LABEL_NO_SHADER_PARAMETERS:
+         return "no_shader_parameters.";
+      case MENU_ENUM_LABEL_ONLINE_UPDATER:
+         return "online_updater";
+      case MENU_ENUM_LABEL_ONSCREEN_DISPLAY_SETTINGS:
+         return "onscreen_display_settings";
+      case MENU_ENUM_LABEL_ONSCREEN_OVERLAY_SETTINGS:
+         return "onscreen_overlay_settings";
+      case MENU_ENUM_LABEL_OPEN_ARCHIVE:
+         return "open_archive";
+      case MENU_ENUM_LABEL_OPEN_ARCHIVE_DETECT_CORE:
+         return "open_archive_detect_core";
+      case MENU_ENUM_LABEL_OSK_OVERLAY_DIRECTORY:
+         return "osk_overlay_directory";
+      case MENU_ENUM_LABEL_OVERLAY_AUTOLOAD_PREFERRED:
+         return "overlay_autoload_preferred";
+      case MENU_ENUM_LABEL_OVERLAY_DIRECTORY:
+         return "overlay_directory";
+      case MENU_ENUM_LABEL_OVERLAY_OPACITY:
+         return "input_overlay_opacity";
+      case MENU_ENUM_LABEL_OVERLAY_PRESET:
+         return "input_overlay";
+      case MENU_ENUM_LABEL_OVERLAY_SCALE:
+         return "input_overlay_scale";
+      case MENU_ENUM_LABEL_PAL60_ENABLE:
+         return "pal60_enable";
+      case MENU_ENUM_LABEL_PARENT_DIRECTORY:
+         return "parent_directory";
+      case MENU_ENUM_LABEL_PAUSE_LIBRETRO:
+         return "menu_pause_libretro";
+      case MENU_ENUM_LABEL_PAUSE_NONACTIVE:
+         return "pause_nonactive";
+      case MENU_ENUM_LABEL_PERFCNT_ENABLE:
+         return "perfcnt_enable";
+      case MENU_ENUM_LABEL_PLAYLISTS_TAB:
+         return "playlists_tab";
+      case MENU_ENUM_LABEL_PLAYLIST_COLLECTION_ENTRY:
+         return "playlist_collection_entry";
+      case MENU_ENUM_LABEL_PLAYLIST_DIRECTORY:
+         return "playlist_directory";
+      case MENU_ENUM_LABEL_PLAYLIST_ENTRY:
+         return "playlist_entry";
+      case MENU_ENUM_LABEL_PLAYLIST_SETTINGS:
+         return "playlist_settings";
+      case MENU_ENUM_LABEL_PLAYLIST_SETTINGS_BEGIN:
+         return "playlist_settings_begin";
+      case MENU_ENUM_LABEL_POINTER_ENABLE:
+         return "menu_pointer_enable";
+      case MENU_ENUM_LABEL_PRIVACY_SETTINGS:
+         return "privacy_settings";
+      case MENU_ENUM_LABEL_QUIT_RETROARCH:
+         return "quit_retroarch";
+      case MENU_ENUM_LABEL_RDB_ENTRY:
+         return "rdb_entry";
+      case MENU_ENUM_LABEL_RDB_ENTRY_ANALOG:
+         return "rdb_entry_analog";
+      case MENU_ENUM_LABEL_RDB_ENTRY_BBFC_RATING:
+         return "rdb_entry_bbfc_rating";
+      case MENU_ENUM_LABEL_RDB_ENTRY_CERO_RATING:
+         return "rdb_entry_cero_rating";
+      case MENU_ENUM_LABEL_RDB_ENTRY_CRC32:
+         return "rdb_entry_crc32";
+      case MENU_ENUM_LABEL_RDB_ENTRY_DESCRIPTION:
+         return "rdb_entry_description";
+      case MENU_ENUM_LABEL_RDB_ENTRY_DEVELOPER:
+         return "rdb_entry_developer";
+      case MENU_ENUM_LABEL_RDB_ENTRY_EDGE_MAGAZINE_ISSUE:
+         return "rdb_entry_edge_magazine_issue";
+      case MENU_ENUM_LABEL_RDB_ENTRY_EDGE_MAGAZINE_RATING:
+         return "rdb_entry_edge_magazine_rating";
+      case MENU_ENUM_LABEL_RDB_ENTRY_EDGE_MAGAZINE_REVIEW:
+         return "rdb_entry_edge_magazine_review";
+      case MENU_ENUM_LABEL_RDB_ENTRY_ELSPA_RATING:
+         return "rdb_entry_elspa_rating";
+      case MENU_ENUM_LABEL_RDB_ENTRY_ENHANCEMENT_HW:
+         return "rdb_entry_enhancement_hw";
+      case MENU_ENUM_LABEL_RDB_ENTRY_ESRB_RATING:
+         return "rdb_entry_esrb_rating";
+      case MENU_ENUM_LABEL_RDB_ENTRY_FAMITSU_MAGAZINE_RATING:
+         return "rdb_entry_famitsu_magazine_rating";
+      case MENU_ENUM_LABEL_RDB_ENTRY_FRANCHISE:
+         return "rdb_entry_franchise";
+      case MENU_ENUM_LABEL_RDB_ENTRY_GENRE:
+         return "rdb_entry_genre";
+      case MENU_ENUM_LABEL_RDB_ENTRY_MAX_USERS:
+         return "rdb_entry_max_users";
+      case MENU_ENUM_LABEL_RDB_ENTRY_MD5:
+         return "rdb_entry_md5";
+      case MENU_ENUM_LABEL_RDB_ENTRY_NAME:
+         return "rdb_entry_name";
+      case MENU_ENUM_LABEL_RDB_ENTRY_ORIGIN:
+         return "rdb_entry_origin";
+      case MENU_ENUM_LABEL_RDB_ENTRY_PEGI_RATING:
+         return "rdb_entry_pegi_rating";
+      case MENU_ENUM_LABEL_RDB_ENTRY_PUBLISHER:
+         return "rdb_entry_publisher";
+      case MENU_ENUM_LABEL_RDB_ENTRY_RELEASE_MONTH:
+         return "rdb_entry_releasemonth";
+      case MENU_ENUM_LABEL_RDB_ENTRY_RELEASE_YEAR:
+         return "rdb_entry_releaseyear";
+      case MENU_ENUM_LABEL_RDB_ENTRY_SERIAL:
+         return "rdb_entry_serial";
+      case MENU_ENUM_LABEL_RDB_ENTRY_SHA1:
+         return "rdb_entry_sha1";
+      case MENU_ENUM_LABEL_RDB_ENTRY_START_CONTENT:
+         return "rdb_entry_start_content";
+      case MENU_ENUM_LABEL_RDB_ENTRY_TGDB_RATING:
+         return "rdb_entry_tgdb_rating";
+      case MENU_ENUM_LABEL_REBOOT:
+         return "reboot";
+      case MENU_ENUM_LABEL_RECORDING_CONFIG_DIRECTORY:
+         return "recording_config_directory";
+      case MENU_ENUM_LABEL_RECORDING_OUTPUT_DIRECTORY:
+         return "recording_output_directory";
+      case MENU_ENUM_LABEL_RECORDING_SETTINGS:
+         return "recording_settings";
+      case MENU_ENUM_LABEL_RECORD_CONFIG:
+         return "record_config";
+      case MENU_ENUM_LABEL_RECORD_DRIVER:
+         return "record_driver";
+      case MENU_ENUM_LABEL_RECORD_ENABLE:
+         return "record_enable";
+      case MENU_ENUM_LABEL_RECORD_PATH:
+         return "record_path";
+      case MENU_ENUM_LABEL_RECORD_USE_OUTPUT_DIRECTORY:
+         return "record_use_output_directory";
+      case MENU_ENUM_LABEL_REMAP_FILE_LOAD:
+         return "remap_file_load";
+      case MENU_ENUM_LABEL_REMAP_FILE_SAVE_CORE:
+         return "remap_file_save_core";
+      case MENU_ENUM_LABEL_REMAP_FILE_SAVE_GAME:
+         return "remap_file_save_game";
+      case MENU_ENUM_LABEL_RESTART_CONTENT:
+         return "restart_content";
+      case MENU_ENUM_LABEL_RESTART_RETROARCH:
+         return "restart_retroarch";
+      case MENU_ENUM_LABEL_RESUME_CONTENT:
+         return "resume_content";
+      case MENU_ENUM_LABEL_RETRO_ACHIEVEMENTS_SETTINGS:
+         return "retro_achievements_settings";
+      case MENU_ENUM_LABEL_REWIND_ENABLE:
+         return "rewind_enable";
+      case MENU_ENUM_LABEL_REWIND_GRANULARITY:
+         return "rewind_granularity";
+      case MENU_ENUM_LABEL_REWIND_SETTINGS:
+         return "rewind_settings";
+      case MENU_ENUM_LABEL_RGUI_BROWSER_DIRECTORY:
+         return "rgui_browser_directory";
+      case MENU_ENUM_LABEL_RGUI_CONFIG_DIRECTORY:
+         return "rgui_config_directory";
+      case MENU_ENUM_LABEL_RGUI_SHOW_START_SCREEN:
+         return "rgui_show_start_screen";
+      case MENU_ENUM_LABEL_RUN:
+         return "collection";
+      case MENU_ENUM_LABEL_SAMBA_ENABLE:
+         return "samba_enable";
+      case MENU_ENUM_LABEL_SAVEFILE_DIRECTORY:
+         return "savefile_directory";
+      case MENU_ENUM_LABEL_SAVESTATE_AUTO_INDEX:
+         return "savestate_auto_index";
+      case MENU_ENUM_LABEL_SAVESTATE_AUTO_LOAD:
+         return "savestate_auto_load";
+      case MENU_ENUM_LABEL_SAVESTATE_AUTO_SAVE:
+         return "savestate_auto_save";
+      case MENU_ENUM_LABEL_SAVESTATE_DIRECTORY:
+         return "savestate_directory";
       case MENU_ENUM_LABEL_SAVE_CURRENT_CONFIG:
          return "save_current_config";
       case MENU_ENUM_LABEL_SAVE_CURRENT_CONFIG_OVERRIDE_CORE:
          return "save_current_config_override_core";
       case MENU_ENUM_LABEL_SAVE_CURRENT_CONFIG_OVERRIDE_GAME:
          return "save_current_config_override_game";
-      case MENU_ENUM_LABEL_STATE_SLOT:
-         return "state_slot";
-      case MENU_ENUM_LABEL_CHEEVOS_USERNAME:
-         return "cheevos_username";
-      case MENU_ENUM_LABEL_CHEEVOS_PASSWORD:
-         return "cheevos_password";
-      case MENU_ENUM_LABEL_ACCOUNTS_CHEEVOS_USERNAME:
-         return "accounts_cheevos_username";
-      case MENU_ENUM_LABEL_ACCOUNTS_RETRO_ACHIEVEMENTS:
-         return "retro_achievements";
-      case MENU_ENUM_LABEL_DEFERRED_ACCOUNTS_CHEEVOS_LIST:
-         return "deferred_accounts_cheevos_list";
-      case MENU_ENUM_LABEL_DEFERRED_USER_BINDS_LIST:
-         return "deferred_user_binds_list";
-      case MENU_ENUM_LABEL_DEFERRED_ACCOUNTS_LIST:
-         return "deferred_accounts_list";
-      case MENU_ENUM_LABEL_DEFERRED_INPUT_SETTINGS_LIST:
-         return "deferred_input_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_DRIVER_SETTINGS_LIST:
-         return "deferred_driver_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_AUDIO_SETTINGS_LIST:
-         return "deferred_audio_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_CORE_SETTINGS_LIST:
-         return "deferred_core_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_VIDEO_SETTINGS_LIST:
-         return "deferred_video_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_CONFIGURATION_SETTINGS_LIST:
-         return "deferred_configuration_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_SAVING_SETTINGS_LIST:
-         return "deferred_saving_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_LOGGING_SETTINGS_LIST:
-         return "deferred_logging_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_FRAME_THROTTLE_SETTINGS_LIST:
-         return "deferred_frame_throttle_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_REWIND_SETTINGS_LIST:
-         return "deferred_rewind_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_ONSCREEN_DISPLAY_SETTINGS_LIST:
-         return "deferred_onscreen_display_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_ONSCREEN_OVERLAY_SETTINGS_LIST:
-         return "deferred_onscreen_overlay_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_MENU_SETTINGS_LIST:
-         return "deferred_menu_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_USER_INTERFACE_SETTINGS_LIST:
-         return "deferred_user_interface_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_MENU_FILE_BROWSER_SETTINGS_LIST:
-         return "deferred_menu_file_browser_settings_list";
-      case MENU_ENUM_LABEL_FILE_BROWSER_DIRECTORY:
-         return "file_browser_directory";
-      case MENU_ENUM_LABEL_FILE_BROWSER_PLAIN_FILE:
-         return "file_browser_plain_file";
-      case MENU_ENUM_LABEL_FILE_BROWSER_REMAP:
-         return "file_browser_remap";
-      case MENU_ENUM_LABEL_FILE_BROWSER_SHADER:
-         return "file_browser_shader";
-      case MENU_ENUM_LABEL_FILE_BROWSER_SHADER_PRESET:
-         return "file_browser_shader_preset";
-      case MENU_ENUM_LABEL_FILE_BROWSER_CORE:
-         return "file_browser_core";
-      case MENU_ENUM_LABEL_FILE_BROWSER_CORE_SELECT_FROM_COLLECTION:
-         return "file_browser_core_select_from_collection";
-      case MENU_ENUM_LABEL_FILE_BROWSER_MUSIC_OPEN:
-         return "file_browser_music_open";
-      case MENU_ENUM_LABEL_FILE_BROWSER_MOVIE_OPEN:
-         return "file_browser_movie_open";
-      case MENU_ENUM_LABEL_FILE_BROWSER_IMAGE_OPEN_WITH_VIEWER:
-         return "file_browser_image_open_with_viewer";
-      case MENU_ENUM_LABEL_FILE_BROWSER_IMAGE:
-         return "file_browser_image";
-      case MENU_ENUM_LABEL_FILE_BROWSER_CORE_DETECTED:
-         return "file_browser_core_detected";
-      case MENU_ENUM_LABEL_DEFERRED_RETRO_ACHIEVEMENTS_SETTINGS_LIST:
-         return "deferred_retro_achievements_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_UPDATER_SETTINGS_LIST:
-         return "deferred_updater_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_WIFI_SETTINGS_LIST:
-         return "deferred_wifi_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_NETWORK_SETTINGS_LIST:
-         return "deferred_network_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_LAKKA_SERVICES_LIST:
-         return "deferred_lakka_services_list";
-      case MENU_ENUM_LABEL_DEFERRED_USER_SETTINGS_LIST:
-         return "deferred_user_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_DIRECTORY_SETTINGS_LIST:
-         return "deferred_directory_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_PRIVACY_SETTINGS_LIST:
-         return "deferred_privacy_settings_list";
-      case MENU_ENUM_LABEL_ACCOUNTS_LIST:
-         return "accounts_list";
-      case MENU_ENUM_LABEL_DEFERRED_INPUT_HOTKEY_BINDS_LIST:
-         return "deferred_input_hotkey_binds";
-      case MENU_ENUM_LABEL_INPUT_HOTKEY_BINDS:
-         return "input_hotkey_binds";
-      case MENU_ENUM_LABEL_INPUT_HOTKEY_BINDS_BEGIN:
-         return "input_hotkey_binds_begin";
-      case MENU_ENUM_LABEL_INPUT_SETTINGS_BEGIN:
-         return "input_settings_begin";
-      case MENU_ENUM_LABEL_PLAYLIST_SETTINGS_BEGIN:
-         return "playlist_settings_begin";
-      case MENU_ENUM_LABEL_RECORDING_SETTINGS:
-         return "recording_settings";
-      case MENU_ENUM_LABEL_PLAYLIST_SETTINGS:
-         return "playlist_settings";
-      case MENU_ENUM_LABEL_DEFERRED_RECORDING_SETTINGS_LIST:
-         return "deferred_recording_settings";
-      case MENU_ENUM_LABEL_DEFERRED_PLAYLIST_SETTINGS_LIST:
-         return "deferred_playlist_settings";
-      case MENU_ENUM_LABEL_INPUT_SETTINGS:
-         return "input_settings";
-      case MENU_ENUM_LABEL_DRIVER_SETTINGS:
-         return "driver_settings";
-      case MENU_ENUM_LABEL_VIDEO_SETTINGS:
-         return "video_settings";
-      case MENU_ENUM_LABEL_CONFIGURATION_SETTINGS:
-         return "configuration_settings";
+      case MENU_ENUM_LABEL_SAVE_NEW_CONFIG:
+         return "save_new_config";
+      case MENU_ENUM_LABEL_SAVE_STATE:
+         return "savestate";
       case MENU_ENUM_LABEL_SAVING_SETTINGS:
          return "saving_settings";
-      case MENU_ENUM_LABEL_LOGGING_SETTINGS:
-         return "logging_settings";
-      case MENU_ENUM_LABEL_FRAME_THROTTLE_SETTINGS:
-         return "frame_throttle_settings";
-      case MENU_ENUM_LABEL_REWIND_SETTINGS:
-         return "rewind_settings";
-      case MENU_ENUM_LABEL_ONSCREEN_DISPLAY_SETTINGS:
-         return "onscreen_display_settings";
-      case MENU_ENUM_LABEL_ONSCREEN_OVERLAY_SETTINGS:
-         return "onscreen_overlay_settings";
-      case MENU_ENUM_LABEL_AUDIO_SETTINGS:
-         return "audio_settings";
-      case MENU_ENUM_LABEL_MENU_SETTINGS:
-         return "menu_settings";
-      case MENU_ENUM_LABEL_USER_INTERFACE_SETTINGS:
-         return "user_interface_settings";
-      case MENU_ENUM_LABEL_MENU_FILE_BROWSER_SETTINGS:
-         return "menu_file_browser_settings";
-      case MENU_ENUM_LABEL_RETRO_ACHIEVEMENTS_SETTINGS:
-         return "retro_achievements_settings";
-      case MENU_ENUM_LABEL_UPDATER_SETTINGS:
-         return "updater_settings";
-      case MENU_ENUM_LABEL_NETWORK_SETTINGS:
-         return "network_settings";
-      case MENU_ENUM_LABEL_WIFI_SETTINGS:
-         return "wifi_settings";
-      case MENU_ENUM_LABEL_USER_SETTINGS:
-         return "user_settings";
-      case MENU_ENUM_LABEL_LAKKA_SERVICES:
-         return "lakka_services";
-      case MENU_ENUM_LABEL_DIRECTORY_SETTINGS:
-         return "directory_settings";
-      case MENU_ENUM_LABEL_PRIVACY_SETTINGS:
-         return "privacy_settings";
-      case MENU_ENUM_LABEL_HELP_SCANNING_CONTENT:
-         return "help_scanning_content";
-      case MENU_ENUM_LABEL_CHEEVOS_DESCRIPTION:
-         return "cheevos_description";
-      case MENU_ENUM_LABEL_HELP_AUDIO_VIDEO_TROUBLESHOOTING:
-         return "help_audio_video_troubleshooting";
-      case MENU_ENUM_LABEL_HELP_CHANGE_VIRTUAL_GAMEPAD:
-         return "help_change_virtual_gamepad";
-      case MENU_ENUM_LABEL_HELP_WHAT_IS_A_CORE:
-         return "help_what_is_a_core";
-      case MENU_ENUM_LABEL_HELP_LOADING_CONTENT:
-         return "help_loading_content";
-      case MENU_ENUM_LABEL_HELP_LIST:
-         return "help_list";
-      case MENU_ENUM_LABEL_HELP_CONTROLS:
-         return "help_controls";
-      case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_OPEN_DETECT_CORE:
-         return "deferred_archive_open_detect_core";
-      case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_OPEN:
-         return "deferred_archive_open";
-      case MENU_ENUM_LABEL_LOAD_ARCHIVE_DETECT_CORE:
-         return "load_archive_detect_core";
-      case MENU_ENUM_LABEL_LOAD_ARCHIVE:
-         return "load_archive";
-      case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_ACTION_DETECT_CORE:
-         return "deferred_archive_action_detect_core";
-      case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_ACTION:
-         return "deferred_archive_action";
-      case MENU_ENUM_LABEL_OPEN_ARCHIVE_DETECT_CORE:
-         return "open_archive_detect_core";
-      case MENU_ENUM_LABEL_OPEN_ARCHIVE:
-         return "open_archive";
-      case MENU_ENUM_LABEL_INPUT_BACK_AS_MENU_ENUM_TOGGLE_ENABLE:
-         return "back_as_menu_toggle_enable";
-      case MENU_ENUM_LABEL_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
-         return "input_menu_toggle_gamepad_combo";
-      case MENU_ENUM_LABEL_INPUT_ALL_USERS_CONTROL_MENU:
-         return "all_users_control_menu";
-      case MENU_ENUM_LABEL_INPUT_OVERLAY_HIDE_IN_MENU:
-         return "overlay_hide_in_menu";
-      case MENU_ENUM_LABEL_NO_PLAYLIST_ENTRIES_AVAILABLE:
-         return "no_playlist_entries_available";
-      case MENU_ENUM_LABEL_DOWNLOADED_FILE_DETECT_CORE_LIST:
-         return "downloaded_file_detect_core_list";
-      case MENU_ENUM_LABEL_UPDATE_CORE_INFO_FILES:
-         return "update_core_info_files";
-      case MENU_ENUM_LABEL_DEFERRED_CORE_CONTENT_LIST:
-         return "deferred_core_content_list";
-      case MENU_ENUM_LABEL_DEFERRED_CORE_CONTENT_DIRS_LIST:
-         return "deferred_core_content_dirs_list";
-      case MENU_ENUM_LABEL_DEFERRED_CORE_CONTENT_DIRS_SUBDIR_LIST:
-         return "deferred_core_content_dirs_subdir_list";
-      case MENU_ENUM_LABEL_DEFERRED_LAKKA_LIST:
-         return "deferred_lakka_list";
-      case MENU_ENUM_LABEL_DOWNLOAD_CORE_CONTENT:
-         return "download_core_content";
-      case MENU_ENUM_LABEL_DOWNLOAD_CORE_CONTENT_DIRS:
-         return "download_core_content_dirs";
-      case MENU_ENUM_LABEL_CB_DOWNLOAD_URL:
-         return "cb_download_url";
-      case MENU_ENUM_LABEL_SCAN_THIS_DIRECTORY:
-         return "scan_this_directory";
-      case MENU_ENUM_LABEL_SCAN_FILE:
-         return "scan_file";
       case MENU_ENUM_LABEL_SCAN_DIRECTORY:
          return "scan_directory";
-      case MENU_ENUM_LABEL_ADD_CONTENT_LIST:
-         return "add_content";
-      case MENU_ENUM_LABEL_CONNECT_WIFI:
-         return "connect_wifi";
-      case MENU_ENUM_LABEL_OVERLAY_AUTOLOAD_PREFERRED:
-         return "overlay_autoload_preferred";
-      case MENU_ENUM_LABEL_INFORMATION:
-         return "information";
-      case MENU_ENUM_LABEL_INFORMATION_LIST:
-         return "information_list";
-      case MENU_ENUM_LABEL_USE_BUILTIN_PLAYER:
-         return "use_builtin_player";
-      case MENU_ENUM_LABEL_CONTENT_SETTINGS:
-         return "quick_menu";
-      case MENU_ENUM_LABEL_LOAD_CONTENT_LIST:
-         return "load_content";
-      case MENU_ENUM_LABEL_NO_SETTINGS_FOUND:
-         return "menu_label_no_settings_found";
+      case MENU_ENUM_LABEL_SCAN_FILE:
+         return "scan_file";
+      case MENU_ENUM_LABEL_SCAN_THIS_DIRECTORY:
+         return "scan_this_directory";
+      case MENU_ENUM_LABEL_SCREENSHOT_DIRECTORY:
+         return "screenshot_directory";
+      case MENU_ENUM_LABEL_SCREEN_RESOLUTION:
+         return "screen_resolution";
+      case MENU_ENUM_LABEL_SETTINGS:
+         return "settings";
+      case MENU_ENUM_LABEL_SETTINGS_TAB:
+         return "settings_tab";
+      case MENU_ENUM_LABEL_SHADER_APPLY_CHANGES:
+         return "shader_apply_changes";
+      case MENU_ENUM_LABEL_SHADER_OPTIONS:
+         return "shader_options";
+      case MENU_ENUM_LABEL_SHADER_PARAMETERS_ENTRY:
+         return "shader_parameters_entry";
+      case MENU_ENUM_LABEL_SHOW_ADVANCED_SETTINGS:
+         return "menu_show_advanced_settings";
+      case MENU_ENUM_LABEL_SHOW_HIDDEN_FILES:
+         return "show_hidden_files";
+      case MENU_ENUM_LABEL_SHUTDOWN:
+         return "shutdown";
+      case MENU_ENUM_LABEL_SLOWMOTION_RATIO:
+         return "slowmotion_ratio";
+      case MENU_ENUM_LABEL_SORT_SAVEFILES_ENABLE:
+         return "sort_savefiles_enable";
+      case MENU_ENUM_LABEL_SORT_SAVESTATES_ENABLE:
+         return "sort_savestates_enable";
+      case MENU_ENUM_LABEL_SSH_ENABLE:
+         return "ssh_enable";
+      case MENU_ENUM_LABEL_START_CORE:
+         return "start_core";
+      case MENU_ENUM_LABEL_START_NET_RETROPAD:
+         return "menu_start_net_retropad";
+      case MENU_ENUM_LABEL_START_VIDEO_PROCESSOR:
+         return "menu_start_video_processor";
+      case MENU_ENUM_LABEL_STATE_SLOT:
+         return "state_slot";
+      case MENU_ENUM_LABEL_STDIN_CMD_ENABLE:
+         return "stdin_commands";
+      case MENU_ENUM_LABEL_SUSPEND_SCREENSAVER_ENABLE:
+         return "suspend_screensaver_enable";
       case MENU_ENUM_LABEL_SYSTEM_BGM_ENABLE:
          return "system_bgm_enable";
-      case MENU_ENUM_LABEL_AUDIO_BLOCK_FRAMES:
-         return "audio_block_frames";
-      case MENU_ENUM_LABEL_INPUT_BIND_MODE:
-         return "input_bind_mode";
-      case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_LABEL_SHOW:
-         return "input_descriptor_label_show";
-      case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_HIDE_UNBOUND:
-         return "input_descriptor_hide_unbound";
+      case MENU_ENUM_LABEL_SYSTEM_DIRECTORY:
+         return "system_directory";
+      case MENU_ENUM_LABEL_SYSTEM_INFORMATION:
+         return "system_information";
+      case MENU_ENUM_LABEL_SYSTEM_INFO_ENTRY:
+         return "system_info_entry";
+      case MENU_ENUM_LABEL_TAKE_SCREENSHOT:
+         return "take_screenshot";
+      case MENU_ENUM_LABEL_THREADED_DATA_RUNLOOP_ENABLE:
+         return "threaded_data_runloop_enable";
+      case MENU_ENUM_LABEL_THUMBNAILS:
+         return "thumbnails";
+      case MENU_ENUM_LABEL_THUMBNAILS_DIRECTORY:
+         return "thumbnails_directory";
+      case MENU_ENUM_LABEL_THUMBNAILS_UPDATER_LIST:
+         return "thumbnails_updater_list";
+      case MENU_ENUM_LABEL_TIMEDATE_ENABLE:
+         return "menu_timedate_enable";
+      case MENU_ENUM_LABEL_TITLE_COLOR:
+         return "menu_title_color";
+      case MENU_ENUM_LABEL_UI_COMPANION_ENABLE:
+         return "ui_companion_enable";
+      case MENU_ENUM_LABEL_UI_COMPANION_START_ON_BOOT:
+         return "ui_companion_start_on_boot";
+      case MENU_ENUM_LABEL_UI_MENUBAR_ENABLE:
+         return "ui_menubar_enable";
+      case MENU_ENUM_LABEL_UNDO_LOAD_STATE:
+         return "undoloadstate";
+      case MENU_ENUM_LABEL_UNDO_SAVE_STATE:
+         return "undosavestate";
+      case MENU_ENUM_LABEL_UPDATER_SETTINGS:
+         return "updater_settings";
+      case MENU_ENUM_LABEL_UPDATE_ASSETS:
+         return "update_assets";
+      case MENU_ENUM_LABEL_UPDATE_AUTOCONFIG_PROFILES:
+         return "update_autoconfig_profiles";
+      case MENU_ENUM_LABEL_UPDATE_CG_SHADERS:
+         return "update_cg_shaders";
+      case MENU_ENUM_LABEL_UPDATE_CHEATS:
+         return "update_cheats";
+      case MENU_ENUM_LABEL_UPDATE_CORE_INFO_FILES:
+         return "update_core_info_files";
+      case MENU_ENUM_LABEL_UPDATE_DATABASES:
+         return "update_databases";
+      case MENU_ENUM_LABEL_UPDATE_GLSL_SHADERS:
+         return "update_glsl_shaders";
+      case MENU_ENUM_LABEL_UPDATE_LAKKA:
+         return "update_lakka";
+      case MENU_ENUM_LABEL_UPDATE_OVERLAYS:
+         return "update_overlays";
+      case MENU_ENUM_LABEL_UPDATE_SLANG_SHADERS:
+         return "update_slang_shaders";
+      case MENU_ENUM_LABEL_URL_ENTRY:
+         return "url_entry";
+      case MENU_ENUM_LABEL_USER_INTERFACE_SETTINGS:
+         return "user_interface_settings";
+      case MENU_ENUM_LABEL_USER_LANGUAGE:
+         return "user_language";
+      case MENU_ENUM_LABEL_USER_SETTINGS:
+         return "user_settings";
+      case MENU_ENUM_LABEL_USE_BUILTIN_IMAGE_VIEWER:
+         return "use_builtin_image_viewer";
+      case MENU_ENUM_LABEL_USE_BUILTIN_PLAYER:
+         return "use_builtin_player";
+      case MENU_ENUM_LABEL_USE_THIS_DIRECTORY:
+         return "use_this_directory";
+      case MENU_ENUM_LABEL_VIDEO_ALLOW_ROTATE:
+         return "video_allow_rotate";
+      case MENU_ENUM_LABEL_VIDEO_ASPECT_RATIO_AUTO:
+         return "video_aspect_ratio_auto";
+      case MENU_ENUM_LABEL_VIDEO_ASPECT_RATIO_INDEX:
+         return "aspect_ratio_index";
+      case MENU_ENUM_LABEL_VIDEO_BLACK_FRAME_INSERTION:
+         return "video_black_frame_insertion";
+      case MENU_ENUM_LABEL_VIDEO_CROP_OVERSCAN:
+         return "video_crop_overscan";
+      case MENU_ENUM_LABEL_VIDEO_DISABLE_COMPOSITION:
+         return "video_disable_composition";
+      case MENU_ENUM_LABEL_VIDEO_DRIVER:
+         return "video_driver";
+      case MENU_ENUM_LABEL_VIDEO_FILTER:
+         return "video_filter";
+      case MENU_ENUM_LABEL_VIDEO_FILTER_DIR:
+         return "video_filter_dir";
+      case MENU_ENUM_LABEL_VIDEO_FILTER_FLICKER:
+         return "video_filter_flicker";
       case MENU_ENUM_LABEL_VIDEO_FONT_ENABLE:
          return "video_font_enable";
       case MENU_ENUM_LABEL_VIDEO_FONT_PATH:
          return "video_font_path";
       case MENU_ENUM_LABEL_VIDEO_FONT_SIZE:
          return "video_font_size";
+      case MENU_ENUM_LABEL_VIDEO_FORCE_ASPECT:
+         return "video_force_aspect";
+      case MENU_ENUM_LABEL_VIDEO_FORCE_SRGB_DISABLE:
+         return "video_force_srgb_disable";
+      case MENU_ENUM_LABEL_VIDEO_FRAME_DELAY:
+         return "video_frame_delay";
+      case MENU_ENUM_LABEL_VIDEO_FULLSCREEN:
+         return "video_fullscreen";
+      case MENU_ENUM_LABEL_VIDEO_GAMMA:
+         return "video_gamma";
+      case MENU_ENUM_LABEL_VIDEO_GPU_RECORD:
+         return "video_gpu_record";
+      case MENU_ENUM_LABEL_VIDEO_GPU_SCREENSHOT:
+         return "video_gpu_screenshot";
+      case MENU_ENUM_LABEL_VIDEO_HARD_SYNC:
+         return "video_hard_sync";
+      case MENU_ENUM_LABEL_VIDEO_HARD_SYNC_FRAMES:
+         return "video_hard_sync_frames";
+      case MENU_ENUM_LABEL_VIDEO_MAX_SWAPCHAIN_IMAGES:
+         return "video_max_swapchain_images";
       case MENU_ENUM_LABEL_VIDEO_MESSAGE_POS_X:
          return "video_message_pos_x";
       case MENU_ENUM_LABEL_VIDEO_MESSAGE_POS_Y:
          return "video_message_pos_y";
-      case MENU_ENUM_LABEL_VIDEO_SOFT_FILTER:
-         return "soft_filter";
-      case MENU_ENUM_LABEL_VIDEO_FILTER_FLICKER:
-         return "video_filter_flicker";
-      case MENU_ENUM_LABEL_INPUT_REMAPPING_DIRECTORY:
-         return "input_remapping_directory";
-      case MENU_ENUM_LABEL_JOYPAD_AUTOCONFIG_DIR:
-         return "joypad_autoconfig_dir";
-      case MENU_ENUM_LABEL_RECORDING_CONFIG_DIRECTORY:
-         return "recording_config_directory";
-      case MENU_ENUM_LABEL_RECORDING_OUTPUT_DIRECTORY:
-         return "recording_output_directory";
-      case MENU_ENUM_LABEL_SCREENSHOT_DIRECTORY:
-         return "screenshot_directory";
-      case MENU_ENUM_LABEL_PLAYLIST_DIRECTORY:
-         return "playlist_directory";
-      case MENU_ENUM_LABEL_SAVEFILE_DIRECTORY:
-         return "savefile_directory";
-      case MENU_ENUM_LABEL_SAVESTATE_DIRECTORY:
-         return "savestate_directory";
-      case MENU_ENUM_LABEL_STDIN_CMD_ENABLE:
-         return "stdin_commands";
-      case MENU_ENUM_LABEL_NETWORK_REMOTE_ENABLE:
-         return "network_remote_enable";
-      case MENU_ENUM_LABEL_NETWORK_REMOTE_USER_1_ENABLE:
-         return "network_remote_user_1_enable";
-      case MENU_ENUM_LABEL_NETWORK_REMOTE_USER_LAST_ENABLE:
-         return "network_remote_user_last_enable";
-      case MENU_ENUM_LABEL_NETWORK_REMOTE_PORT:
-         return "network_remote_base_port";
-      case MENU_ENUM_LABEL_VIDEO_DRIVER:
-         return "video_driver";
-      case MENU_ENUM_LABEL_RECORD_ENABLE:
-         return "record_enable";
-      case MENU_ENUM_LABEL_VIDEO_GPU_RECORD:
-         return "video_gpu_record";
-      case MENU_ENUM_LABEL_RECORD_PATH:
-         return "record_path";
-      case MENU_ENUM_LABEL_RECORD_USE_OUTPUT_DIRECTORY:
-         return "record_use_output_directory";
-      case MENU_ENUM_LABEL_RECORD_CONFIG:
-         return "record_config";
+      case MENU_ENUM_LABEL_VIDEO_MONITOR_INDEX:
+         return "video_monitor_index";
       case MENU_ENUM_LABEL_VIDEO_POST_FILTER_RECORD:
          return "video_post_filter_record";
-      case MENU_ENUM_LABEL_CORE_ASSETS_DIRECTORY:
-         return "core_assets_directory";
-      case MENU_ENUM_LABEL_ASSETS_DIRECTORY:
-         return "assets_directory";
-      case MENU_ENUM_LABEL_DYNAMIC_WALLPAPERS_DIRECTORY:
-         return "dynamic_wallpapers_directory";
-      case MENU_ENUM_LABEL_THUMBNAILS_DIRECTORY:
-         return "thumbnails_directory";
-      case MENU_ENUM_LABEL_RGUI_BROWSER_DIRECTORY:
-         return "rgui_browser_directory";
-      case MENU_ENUM_LABEL_RGUI_CONFIG_DIRECTORY:
-         return "rgui_config_directory";
-      case MENU_ENUM_LABEL_LIBRETRO_INFO_PATH:
-         return "libretro_info_path";
-      case MENU_ENUM_LABEL_LIBRETRO_DIR_PATH:
-         return "libretro_dir_path";
-      case MENU_ENUM_LABEL_CURSOR_DIRECTORY:
-         return "cursor_directory";
-      case MENU_ENUM_LABEL_CONTENT_DATABASE_DIRECTORY:
-         return "content_database_path";
-      case MENU_ENUM_LABEL_SYSTEM_DIRECTORY:
-         return "system_directory";
-      case MENU_ENUM_LABEL_CACHE_DIRECTORY:
-         return "cache_directory";
-      case MENU_ENUM_LABEL_CHEAT_DATABASE_PATH:
-         return "cheat_database_path";
-      case MENU_ENUM_LABEL_AUDIO_FILTER_DIR:
-         return "audio_filter_dir";
-      case MENU_ENUM_LABEL_VIDEO_FILTER_DIR:
-         return "video_filter_dir";
-      case MENU_ENUM_LABEL_VIDEO_SHADER_DIR:
-         return "video_shader_dir";
-      case MENU_ENUM_LABEL_OVERLAY_DIRECTORY:
-         return "overlay_directory";
-      case MENU_ENUM_LABEL_OSK_OVERLAY_DIRECTORY:
-         return "osk_overlay_directory";
-      case MENU_ENUM_LABEL_NETPLAY_CLIENT_SWAP_INPUT:
-         return "netplay_client_swap_input";
-      case MENU_ENUM_LABEL_NETPLAY_SPECTATOR_MODE_ENABLE:
-         return "netplay_spectator_mode_enable";
-      case MENU_ENUM_LABEL_NETPLAY_IP_ADDRESS:
-         return "netplay_ip_address";
-      case MENU_ENUM_LABEL_NETPLAY_TCP_UDP_PORT:
-         return "netplay_tcp_udp_port";
-      case MENU_ENUM_LABEL_NETPLAY_ENABLE:
-         return "netplay_enable";
-      case MENU_ENUM_LABEL_SSH_ENABLE:
-         return "ssh_enable";
-      case MENU_ENUM_LABEL_SAMBA_ENABLE:
-         return "samba_enable";
-      case MENU_ENUM_LABEL_BLUETOOTH_ENABLE:
-         return "bluetooth_enable";
-      case MENU_ENUM_LABEL_NETPLAY_DELAY_FRAMES:
-         return "netplay_delay_frames";
-      case MENU_ENUM_LABEL_NETPLAY_CHECK_FRAMES:
-         return "netplay_check_frames";
-      case MENU_ENUM_LABEL_NETPLAY_MODE:
-         return "netplay_mode";
-      case MENU_ENUM_LABEL_RGUI_SHOW_START_SCREEN:
-         return "rgui_show_start_screen";
-      case MENU_ENUM_LABEL_TITLE_COLOR:
-         return "menu_title_color";
-      case MENU_ENUM_LABEL_ENTRY_HOVER_COLOR:
-         return "menu_entry_hover_color";
-      case MENU_ENUM_LABEL_TIMEDATE_ENABLE:
-         return "menu_timedate_enable";
-      case MENU_ENUM_LABEL_THREADED_DATA_RUNLOOP_ENABLE:
-         return "threaded_data_runloop_enable";
-      case MENU_ENUM_LABEL_ENTRY_NORMAL_COLOR:
-         return "menu_entry_normal_color";
-      case MENU_ENUM_LABEL_SHOW_ADVANCED_SETTINGS:
-         return "menu_show_advanced_settings";
-      case MENU_ENUM_LABEL_MOUSE_ENABLE:
-         return "menu_mouse_enable";
-      case MENU_ENUM_LABEL_POINTER_ENABLE:
-         return "menu_pointer_enable";
-      case MENU_ENUM_LABEL_CORE_ENABLE:
-         return "menu_core_enable";
-      case MENU_ENUM_LABEL_NETPLAY_ENABLE_HOST:
-         return "menu_netplay_enable_host";
-      case MENU_ENUM_LABEL_NETPLAY_ENABLE_CLIENT:
-         return "menu_netplay_enable_client";
-      case MENU_ENUM_LABEL_NETPLAY_DISCONNECT:
-         return "menu_netplay_disconnect";
-      case MENU_ENUM_LABEL_NETPLAY_SETTINGS:
-         return "menu_netplay_settings";
-      case MENU_ENUM_LABEL_DPI_OVERRIDE_ENABLE:
-         return "dpi_override_enable";
-      case MENU_ENUM_LABEL_DPI_OVERRIDE_VALUE:
-         return "dpi_override_value";
-      case MENU_ENUM_LABEL_XMB_FONT:
-         return "xmb_font";
-      case MENU_ENUM_LABEL_XMB_THEME:
-         return "xmb_theme";
-      case MENU_ENUM_LABEL_XMB_MENU_COLOR_THEME:
-         return "xmb_menu_color_theme";
-      case MENU_ENUM_LABEL_MATERIALUI_MENU_COLOR_THEME:
-         return "materialui_menu_color_theme";
-      case MENU_ENUM_LABEL_MATERIALUI_MENU_HEADER_OPACITY:
-         return "materialui_menu_header_opacity";
-      case MENU_ENUM_LABEL_MATERIALUI_MENU_FOOTER_OPACITY:
-         return "materialui_menu_footer_opacity";
-      case MENU_ENUM_LABEL_XMB_SHADOWS_ENABLE:
-         return "xmb_shadows_enable";
-      case MENU_ENUM_LABEL_XMB_SHOW_SETTINGS:
-         return "xmb_show_settings";
-      case MENU_ENUM_LABEL_XMB_SHOW_IMAGES:
-         return "xmb_show_images";
-      case MENU_ENUM_LABEL_XMB_SHOW_MUSIC:
-         return "xmb_show_music";
-      case MENU_ENUM_LABEL_XMB_SHOW_VIDEO:
-         return "xmb_show_video";
-      case MENU_ENUM_LABEL_XMB_SHOW_HISTORY:
-         return "xmb_show_history";
-      case MENU_ENUM_LABEL_XMB_RIBBON_ENABLE:
-         return "xmb_ribbon_enable";
-      case MENU_ENUM_LABEL_XMB_SCALE_FACTOR:
-         return "xmb_scale_factor";
-      case MENU_ENUM_LABEL_XMB_ALPHA_FACTOR:
-         return "xmb_alpha_factor";
-      case MENU_ENUM_LABEL_SUSPEND_SCREENSAVER_ENABLE:
-         return "suspend_screensaver_enable";
-      case MENU_ENUM_LABEL_VIDEO_DISABLE_COMPOSITION:
-         return "video_disable_composition";
-      case MENU_ENUM_LABEL_PAUSE_NONACTIVE:
-         return "pause_nonactive";
-      case MENU_ENUM_LABEL_UI_COMPANION_START_ON_BOOT:
-         return "ui_companion_start_on_boot";
-      case MENU_ENUM_LABEL_UI_COMPANION_ENABLE:
-         return "ui_companion_enable";
-      case MENU_ENUM_LABEL_UI_MENUBAR_ENABLE:
-         return "ui_menubar_enable";
-      case MENU_ENUM_LABEL_ARCHIVE_MODE:
-         return "archive_mode";
-      case MENU_ENUM_LABEL_NETWORK_CMD_ENABLE:
-         return "network_cmd_enable";
-      case MENU_ENUM_LABEL_NETWORK_CMD_PORT:
-         return "network_cmd_port";
-      case MENU_ENUM_LABEL_HISTORY_LIST_ENABLE:
-         return "history_list_enable";
-      case MENU_ENUM_LABEL_CONTENT_HISTORY_SIZE:
-         return "content_history_size";
-      case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE_AUTO:
-         return "video_refresh_rate_auto";
-      case MENU_ENUM_LABEL_DUMMY_ON_CORE_SHUTDOWN:
-         return "dummy_on_core_shutdown";
-      case MENU_ENUM_LABEL_CORE_SET_SUPPORTS_NO_CONTENT_ENABLE:
-         return "core_set_supports_no_content_enable";
-      case MENU_ENUM_LABEL_FRAME_THROTTLE_ENABLE:
-         return "fastforward_ratio_throttle_enable";
-      case MENU_ENUM_LABEL_FASTFORWARD_RATIO:
-         return "fastforward_ratio";
-      case MENU_ENUM_LABEL_AUTO_REMAPS_ENABLE:
-         return "auto_remaps_enable";
-      case MENU_ENUM_LABEL_AUTO_SHADERS_ENABLE:
-         return "auto_shaders_enable";
-      case MENU_ENUM_LABEL_SLOWMOTION_RATIO:
-         return "slowmotion_ratio";
-      case MENU_ENUM_LABEL_CORE_SPECIFIC_CONFIG:
-         return "core_specific_config";
-      case MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS:
-         return "game_specific_options";
-      case MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS_CREATE:
-         return "game_specific_options_create";
-      case MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS_IN_USE:
-         return "game_specific_options_in_use";
-      case MENU_ENUM_LABEL_AUTO_OVERRIDES_ENABLE:
-         return "auto_overrides_enable";
-      case MENU_ENUM_LABEL_CONFIG_SAVE_ON_EXIT:
-         return "config_save_on_exit";
-      case MENU_ENUM_LABEL_SHOW_HIDDEN_FILES:
-         return "show_hidden_files";
-      case MENU_ENUM_LABEL_VIDEO_SMOOTH:
-         return "video_smooth";
-      case MENU_ENUM_LABEL_VIDEO_GAMMA:
-         return "video_gamma";
-      case MENU_ENUM_LABEL_VIDEO_ALLOW_ROTATE:
-         return "video_allow_rotate";
-      case MENU_ENUM_LABEL_VIDEO_HARD_SYNC:
-         return "video_hard_sync";
-      case MENU_ENUM_LABEL_VIDEO_SWAP_INTERVAL:
-         return "video_swap_interval";
-      case MENU_ENUM_LABEL_VIDEO_VSYNC:
-         return "video_vsync";
-      case MENU_ENUM_LABEL_VIDEO_THREADED:
-         return "video_threaded";
-      case MENU_ENUM_LABEL_VIDEO_ROTATION:
-         return "video_rotation";
-      case MENU_ENUM_LABEL_VIDEO_GPU_SCREENSHOT:
-         return "video_gpu_screenshot";
-      case MENU_ENUM_LABEL_VIDEO_CROP_OVERSCAN:
-         return "video_crop_overscan";
-      case MENU_ENUM_LABEL_VIDEO_ASPECT_RATIO_INDEX:
-         return "aspect_ratio_index";
-      case MENU_ENUM_LABEL_VIDEO_ASPECT_RATIO_AUTO:
-         return "video_aspect_ratio_auto";
-      case MENU_ENUM_LABEL_VIDEO_FORCE_ASPECT:
-         return "video_force_aspect";
       case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE:
          return "video_refresh_rate";
-      case MENU_ENUM_LABEL_VIDEO_FORCE_SRGB_DISABLE:
-         return "video_force_srgb_disable";
-      case MENU_ENUM_LABEL_VIDEO_WINDOWED_FULLSCREEN:
-         return "video_windowed_fullscreen";
-      case MENU_ENUM_LABEL_PAL60_ENABLE:
-         return "pal60_enable";
-      case MENU_ENUM_LABEL_VIDEO_VFILTER:
-         return "video_vfilter";
-      case MENU_ENUM_LABEL_VIDEO_VI_WIDTH:
-         return "video_vi_width";
-      case MENU_ENUM_LABEL_VIDEO_BLACK_FRAME_INSERTION:
-         return "video_black_frame_insertion";
-      case MENU_ENUM_LABEL_VIDEO_HARD_SYNC_FRAMES:
-         return "video_hard_sync_frames";
-      case MENU_ENUM_LABEL_SORT_SAVEFILES_ENABLE:
-         return "sort_savefiles_enable";
-      case MENU_ENUM_LABEL_SORT_SAVESTATES_ENABLE:
-         return "sort_savestates_enable";
-      case MENU_ENUM_LABEL_VIDEO_FULLSCREEN:
-         return "video_fullscreen";
-      case MENU_ENUM_LABEL_PERFCNT_ENABLE:
-         return "perfcnt_enable";
+      case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE_AUTO:
+         return "video_refresh_rate_auto";
+      case MENU_ENUM_LABEL_VIDEO_ROTATION:
+         return "video_rotation";
       case MENU_ENUM_LABEL_VIDEO_SCALE:
          return "video_scale";
       case MENU_ENUM_LABEL_VIDEO_SCALE_INTEGER:
          return "video_scale_integer";
-      case MENU_ENUM_LABEL_LIBRETRO_LOG_LEVEL:
-         return "libretro_log_level";
-      case MENU_ENUM_LABEL_LOG_VERBOSITY:
-         return "log_verbosity";
-      case MENU_ENUM_LABEL_SAVESTATE_AUTO_SAVE:
-         return "savestate_auto_save";
-      case MENU_ENUM_LABEL_SAVESTATE_AUTO_LOAD:
-         return "savestate_auto_load";
-      case MENU_ENUM_LABEL_SAVESTATE_AUTO_INDEX:
-         return "savestate_auto_index";
-      case MENU_ENUM_LABEL_AUTOSAVE_INTERVAL:
-         return "autosave_interval";
-      case MENU_ENUM_LABEL_BLOCK_SRAM_OVERWRITE:
-         return "block_sram_overwrite";
-      case MENU_ENUM_LABEL_VIDEO_SHARED_CONTEXT:
-         return "video_shared_context";
-      case MENU_ENUM_LABEL_RESTART_RETROARCH:
-         return "restart_retroarch";
-      case MENU_ENUM_LABEL_NETPLAY_NICKNAME:
-         return "netplay_nickname";
-      case MENU_ENUM_LABEL_USER_LANGUAGE:
-         return "user_language";
-      case MENU_ENUM_LABEL_CAMERA_ALLOW:
-         return "camera_allow";
-      case MENU_ENUM_LABEL_LOCATION_ALLOW:
-         return "location_allow";
-      case MENU_ENUM_LABEL_PAUSE_LIBRETRO:
-         return "menu_pause_libretro";
-      case MENU_ENUM_LABEL_INPUT_OSK_OVERLAY_ENABLE:
-         return "input_osk_overlay_enable";
-      case MENU_ENUM_LABEL_INPUT_OVERLAY_ENABLE:
-         return "input_overlay_enable";
-      case MENU_ENUM_LABEL_VIDEO_MONITOR_INDEX:
-         return "video_monitor_index";
-      case MENU_ENUM_LABEL_VIDEO_FRAME_DELAY:
-         return "video_frame_delay";
-      case MENU_ENUM_LABEL_INPUT_DUTY_CYCLE:
-         return "input_duty_cycle";
-      case MENU_ENUM_LABEL_INPUT_TURBO_PERIOD:
-         return "input_turbo_period";
-      case MENU_ENUM_LABEL_INPUT_BIND_TIMEOUT:
-         return "input_bind_timeout";
-      case MENU_ENUM_LABEL_INPUT_AXIS_THRESHOLD:
-         return "input_axis_threshold";
-      case MENU_ENUM_LABEL_INPUT_REMAP_BINDS_ENABLE:
-         return "input_remap_binds_enable";
-      case MENU_ENUM_LABEL_INPUT_MAX_USERS:
-         return "input_max_users";
-      case MENU_ENUM_LABEL_INPUT_AUTODETECT_ENABLE:
-         return "input_autodetect_enable";
-      case MENU_ENUM_LABEL_AUDIO_OUTPUT_RATE:
-         return "audio_output_rate";
-      case MENU_ENUM_LABEL_AUDIO_MAX_TIMING_SKEW:
-         return "audio_max_timing_skew";
-      case MENU_ENUM_LABEL_CHEAT_APPLY_CHANGES:
-         return "cheat_apply_changes";
-      case MENU_ENUM_LABEL_REMAP_FILE_SAVE_CORE:
-         return "remap_file_save_core";
-      case MENU_ENUM_LABEL_REMAP_FILE_SAVE_GAME:
-         return "remap_file_save_game";
-      case MENU_ENUM_LABEL_CHEAT_NUM_PASSES:
-         return "cheat_num_passes";
-      case MENU_ENUM_LABEL_SHADER_APPLY_CHANGES:
-         return "shader_apply_changes";
-      case MENU_ENUM_LABEL_COLLECTION:
-         return "collection";
-      case MENU_ENUM_LABEL_REWIND_ENABLE:
-         return "rewind_enable";
-      case MENU_ENUM_LABEL_CONTENT_COLLECTION_LIST:
-         return "select_from_collection";
-      case MENU_ENUM_LABEL_DETECT_CORE_LIST:
-         return "detect_core_list";
-      case MENU_ENUM_LABEL_LOAD_CONTENT_HISTORY:
-         return "load_recent";
-      case MENU_ENUM_LABEL_AUDIO_ENABLE:
-         return "audio_enable";
-      case MENU_ENUM_LABEL_FPS_SHOW:
-         return "fps_show";
-      case MENU_ENUM_LABEL_AUDIO_MUTE:
-         return "audio_mute_enable";
-      case MENU_ENUM_LABEL_VIDEO_SHADER_PASS:
-         return "video_shader_pass";
-      case MENU_ENUM_LABEL_AUDIO_VOLUME:
-         return "audio_volume";
-      case MENU_ENUM_LABEL_AUDIO_SYNC:
-         return "audio_sync";
-      case MENU_ENUM_LABEL_AUDIO_RATE_CONTROL_DELTA:
-         return "audio_rate_control_delta";
+      case MENU_ENUM_LABEL_VIDEO_SETTINGS:
+         return "video_settings";
+      case MENU_ENUM_LABEL_VIDEO_SHADER_DIR:
+         return "video_shader_dir";
       case MENU_ENUM_LABEL_VIDEO_SHADER_FILTER_PASS:
          return "video_shader_filter_pass";
-      case MENU_ENUM_LABEL_VIDEO_SHADER_SCALE_PASS:
-         return "video_shader_scale_pass";
       case MENU_ENUM_LABEL_VIDEO_SHADER_NUM_PASSES:
          return "video_shader_num_passes";
-      case MENU_ENUM_LABEL_SHADER_PARAMETERS_ENTRY:
-         return "shader_parameters_entry";
-      case MENU_ENUM_LABEL_RDB_ENTRY:
-         return "rdb_entry";
-      case MENU_ENUM_LABEL_RDB_ENTRY_DESCRIPTION:
-         return "rdb_entry_description";
-      case MENU_ENUM_LABEL_RDB_ENTRY_GENRE:
-         return "rdb_entry_genre";
-      case MENU_ENUM_LABEL_RDB_ENTRY_ORIGIN:
-         return "rdb_entry_origin";
-      case MENU_ENUM_LABEL_RDB_ENTRY_PUBLISHER:
-         return "rdb_entry_publisher";
-      case MENU_ENUM_LABEL_RDB_ENTRY_DEVELOPER:
-         return "rdb_entry_developer";
-      case MENU_ENUM_LABEL_RDB_ENTRY_FRANCHISE:
-         return "rdb_entry_franchise";
-      case MENU_ENUM_LABEL_RDB_ENTRY_MAX_USERS:
-         return "rdb_entry_max_users";
-      case MENU_ENUM_LABEL_RDB_ENTRY_NAME:
-         return "rdb_entry_name";
-      case MENU_ENUM_LABEL_RDB_ENTRY_EDGE_MAGAZINE_RATING:
-         return "rdb_entry_edge_magazine_rating";
-      case MENU_ENUM_LABEL_RDB_ENTRY_EDGE_MAGAZINE_REVIEW:
-         return "rdb_entry_edge_magazine_review";
-      case MENU_ENUM_LABEL_RDB_ENTRY_FAMITSU_MAGAZINE_RATING:
-         return "rdb_entry_famitsu_magazine_rating";
-      case MENU_ENUM_LABEL_RDB_ENTRY_TGDB_RATING:
-         return "rdb_entry_tgdb_rating";
-      case MENU_ENUM_LABEL_RDB_ENTRY_EDGE_MAGAZINE_ISSUE:
-         return "rdb_entry_edge_magazine_issue";
-      case MENU_ENUM_LABEL_RDB_ENTRY_RELEASE_MONTH:
-         return "rdb_entry_releasemonth";
-      case MENU_ENUM_LABEL_RDB_ENTRY_RELEASE_YEAR:
-         return "rdb_entry_releaseyear";
-      case MENU_ENUM_LABEL_RDB_ENTRY_ENHANCEMENT_HW:
-         return "rdb_entry_enhancement_hw";
-      case MENU_ENUM_LABEL_RDB_ENTRY_SHA1:
-         return "rdb_entry_sha1";
-      case MENU_ENUM_LABEL_RDB_ENTRY_CRC32:
-         return "rdb_entry_crc32";
-      case MENU_ENUM_LABEL_RDB_ENTRY_MD5:
-         return "rdb_entry_md5";
-      case MENU_ENUM_LABEL_RDB_ENTRY_BBFC_RATING:
-         return "rdb_entry_bbfc_rating";
-      case MENU_ENUM_LABEL_RDB_ENTRY_ESRB_RATING:
-         return "rdb_entry_esrb_rating";
-      case MENU_ENUM_LABEL_RDB_ENTRY_ELSPA_RATING:
-         return "rdb_entry_elspa_rating";
-      case MENU_ENUM_LABEL_RDB_ENTRY_PEGI_RATING:
-         return "rdb_entry_pegi_rating";
-      case MENU_ENUM_LABEL_RDB_ENTRY_CERO_RATING:
-         return "rdb_entry_cero_rating";
-      case MENU_ENUM_LABEL_RDB_ENTRY_ANALOG:
-         return "rdb_entry_analog";
-      case MENU_ENUM_LABEL_RDB_ENTRY_SERIAL:
-         return "rdb_entry_serial";
-      case MENU_ENUM_LABEL_CONFIGURATIONS:
-         return "configurations";
-      case MENU_ENUM_LABEL_REWIND_GRANULARITY:
-         return "rewind_granularity";
-      case MENU_ENUM_LABEL_REMAP_FILE_LOAD:
-         return "remap_file_load";
-      case MENU_ENUM_LABEL_CUSTOM_RATIO:
-         return "custom_ratio";
-      case MENU_ENUM_LABEL_USE_THIS_DIRECTORY:
-         return "use_this_directory";
-      case MENU_ENUM_LABEL_RDB_ENTRY_START_CONTENT:
-         return "rdb_entry_start_content";
-      case MENU_ENUM_LABEL_CUSTOM_BIND:
-         return "custom_bind";
-      case MENU_ENUM_LABEL_CUSTOM_BIND_ALL:
-         return "custom_bind_all";
-      case MENU_ENUM_LABEL_DISK_OPTIONS:
-         return "core_disk_options";
-      case MENU_ENUM_LABEL_CORE_CHEAT_OPTIONS:
-         return "core_cheat_options";
-      case MENU_ENUM_LABEL_CORE_OPTIONS:
-         return "core_options";
-      case MENU_ENUM_LABEL_DATABASE_MANAGER_LIST:
-         return "database_manager_list";
-      case MENU_ENUM_LABEL_DEFERRED_DATABASE_MANAGER_LIST:
-         return "deferred_database_manager_list";
-      case MENU_ENUM_LABEL_CURSOR_MANAGER_LIST:
-         return "cursor_manager_list";
-      case MENU_ENUM_LABEL_DEFERRED_CURSOR_MANAGER_LIST:
-         return "deferred_cursor_manager_list";
-      case MENU_ENUM_LABEL_CHEAT_FILE_LOAD:
-         return "cheat_file_load";
-      case MENU_ENUM_LABEL_CHEAT_FILE_SAVE_AS:
-         return "cheat_file_save_as";
-      case MENU_ENUM_LABEL_DEFERRED_RDB_ENTRY_DETAIL:
-         return "deferred_rdb_entry_detail";
-      case MENU_ENUM_LABEL_FRONTEND_COUNTERS:
-         return "frontend_counters";
-      case MENU_ENUM_LABEL_CORE_COUNTERS:
-         return "core_counters";
-      case MENU_ENUM_LABEL_DISK_CYCLE_TRAY_STATUS:
-         return "disk_cycle_tray_status";
-      case MENU_ENUM_LABEL_DISK_IMAGE_APPEND:
-         return "disk_image_append";
-      case MENU_ENUM_LABEL_DEFERRED_CORE_LIST:
-         return "deferred_core_list";
-      case MENU_ENUM_LABEL_DEFERRED_CORE_LIST_SET:
-         return "deferred_core_list_set";
-      case MENU_ENUM_LABEL_INFO_SCREEN:
-         return "info_screen";
-      case MENU_ENUM_LABEL_SETTINGS:
-         return "settings";
-      case MENU_ENUM_LABEL_QUIT_RETROARCH:
-         return "quit_retroarch";
-      case MENU_ENUM_LABEL_SHUTDOWN:
-         return "shutdown";
-      case MENU_ENUM_LABEL_REBOOT:
-         return "reboot";
-      case MENU_ENUM_LABEL_HELP:
-         return "help";
-      case MENU_ENUM_LABEL_SAVE_NEW_CONFIG:
-         return "save_new_config";
-      case MENU_ENUM_LABEL_RESTART_CONTENT:
-         return "restart_content";
-      case MENU_ENUM_LABEL_TAKE_SCREENSHOT:
-         return "take_screenshot";
-      case MENU_ENUM_LABEL_DELETE_ENTRY:
-         return "delete_entry";
-      case MENU_ENUM_LABEL_CORE_UPDATER_LIST:
-         return "core_updater_list";
-      case MENU_ENUM_LABEL_START_VIDEO_PROCESSOR:
-         return "menu_start_video_processor";
-      case MENU_ENUM_LABEL_START_NET_RETROPAD:
-         return "menu_start_net_retropad";
-      case MENU_ENUM_LABEL_THUMBNAILS_UPDATER_LIST:
-         return "thumbnails_updater_list";
-      case MENU_ENUM_LABEL_CORE_UPDATER_BUILDBOT_URL:
-         return "core_updater_buildbot_url";
-      case MENU_ENUM_LABEL_BUILDBOT_ASSETS_URL:
-         return "buildbot_assets_url";
-      case MENU_ENUM_LABEL_NAVIGATION_WRAPAROUND:
-         return "menu_navigation_wraparound_enable";
-      case MENU_ENUM_LABEL_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
-         return "menu_navigation_browser_filter_supported_extensions_enable";
-      case MENU_ENUM_LABEL_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
-         return "core_updater_auto_extract_archive";
-      case MENU_ENUM_LABEL_ACHIEVEMENT_LIST:
-         return "achievement_list";
-      case MENU_ENUM_LABEL_SYSTEM_INFORMATION:
-         return "system_information";
-      case MENU_ENUM_LABEL_NETWORK_INFORMATION:
-         return "network_information";
-      case MENU_ENUM_LABEL_ONLINE_UPDATER:
-         return "online_updater";
-      case MENU_ENUM_LABEL_NETPLAY:
-         return "netplay";
-      case MENU_ENUM_LABEL_CORE_INFORMATION:
-         return "core_information";
-      case MENU_ENUM_LABEL_CORE_LIST:
-         return "load_core";
-      case MENU_ENUM_LABEL_LOAD_CONTENT:
-         return "load_content_default";
-      case MENU_ENUM_LABEL_CLOSE_CONTENT:
-         return "unload_core";
-      case MENU_ENUM_LABEL_MANAGEMENT:
-         return "database_settings";
-      case MENU_ENUM_LABEL_SAVE_STATE:
-         return "savestate";
-      case MENU_ENUM_LABEL_LOAD_STATE:
-         return "loadstate";
-      case MENU_ENUM_LABEL_UNDO_LOAD_STATE:
-         return "undoloadstate";
-      case MENU_ENUM_LABEL_UNDO_SAVE_STATE:
-         return "undosavestate";
-      case MENU_ENUM_LABEL_RESUME_CONTENT:
-         return "resume_content";
-      case MENU_ENUM_LABEL_INPUT_DRIVER:
-         return "input_driver";
-      case MENU_ENUM_LABEL_AUDIO_DRIVER:
-         return "audio_driver";
-      case MENU_ENUM_LABEL_JOYPAD_DRIVER:
-         return "input_joypad_driver";
-      case MENU_ENUM_LABEL_AUDIO_RESAMPLER_DRIVER:
-         return "audio_resampler_driver";
-      case MENU_ENUM_LABEL_RECORD_DRIVER:
-         return "record_driver";
-      case MENU_ENUM_LABEL_MENU_DRIVER:
-         return "menu_driver";
-      case MENU_ENUM_LABEL_CAMERA_DRIVER:
-         return "camera_driver";
-      case MENU_ENUM_LABEL_WIFI_DRIVER:
-         return "wifi_driver";
-      case MENU_ENUM_LABEL_LOCATION_DRIVER:
-         return "location_driver";
-      case MENU_ENUM_LABEL_OVERLAY_SCALE:
-         return "input_overlay_scale";
-      case MENU_ENUM_LABEL_OVERLAY_PRESET:
-         return "input_overlay";
-      case MENU_ENUM_LABEL_KEYBOARD_OVERLAY_PRESET:
-         return "input_osk_overlay";
-      case MENU_ENUM_LABEL_AUDIO_DEVICE:
-         return "audio_device";
-      case MENU_ENUM_LABEL_AUDIO_LATENCY:
-         return "audio_latency";
-      case MENU_ENUM_LABEL_OVERLAY_OPACITY:
-         return "input_overlay_opacity";
-      case MENU_ENUM_LABEL_MENU_WALLPAPER:
-         return "menu_wallpaper";
-      case MENU_ENUM_LABEL_DYNAMIC_WALLPAPER:
-         return "menu_dynamic_wallpaper_enable";
-      case MENU_ENUM_LABEL_THUMBNAILS:
-         return "thumbnails";
-      case MENU_ENUM_LABEL_CORE_INPUT_REMAPPING_OPTIONS:
-         return "core_input_remapping_options";
-      case MENU_ENUM_LABEL_SHADER_OPTIONS:
-         return "shader_options";
       case MENU_ENUM_LABEL_VIDEO_SHADER_PARAMETERS:
          return "video_shader_parameters";
+      case MENU_ENUM_LABEL_VIDEO_SHADER_PASS:
+         return "video_shader_pass";
+      case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET:
+         return "video_shader_preset";
       case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_PARAMETERS:
          return "video_shader_preset_parameters";
       case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_SAVE_AS:
          return "video_shader_preset_save_as";
-      case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET:
-         return "video_shader_preset";
-      case MENU_ENUM_LABEL_VIDEO_FILTER:
-         return "video_filter";
-      case MENU_ENUM_LABEL_DEFERRED_VIDEO_FILTER:
-         return "deferred_video_filter";
-      case MENU_ENUM_LABEL_DEFERRED_CORE_UPDATER_LIST:
-         return "core_updater";
-      case MENU_ENUM_LABEL_DEFERRED_THUMBNAILS_UPDATER_LIST:
-         return "deferred_thumbnails_updater_list";
-      case MENU_ENUM_LABEL_AUDIO_DSP_PLUGIN:
-         return "audio_dsp_plugin";
-      case MENU_ENUM_LABEL_UPDATE_ASSETS:
-         return "update_assets";
-      case MENU_ENUM_LABEL_UPDATE_LAKKA:
-         return "update_lakka";
-      case MENU_ENUM_LABEL_UPDATE_CHEATS:
-         return "update_cheats";
-      case MENU_ENUM_LABEL_UPDATE_AUTOCONFIG_PROFILES:
-         return "update_autoconfig_profiles";
-      case MENU_ENUM_LABEL_UPDATE_DATABASES:
-         return "update_databases";
-      case MENU_ENUM_LABEL_UPDATE_OVERLAYS:
-         return "update_overlays";
-      case MENU_ENUM_LABEL_UPDATE_CG_SHADERS:
-         return "update_cg_shaders";
-      case MENU_ENUM_LABEL_UPDATE_GLSL_SHADERS:
-         return "update_glsl_shaders";
-      case MENU_ENUM_LABEL_UPDATE_SLANG_SHADERS:
-         return "update_slang_shaders";
-      case MENU_ENUM_LABEL_SCREEN_RESOLUTION:
-         return "screen_resolution";
-      case MENU_ENUM_LABEL_USE_BUILTIN_IMAGE_VIEWER:
-         return "use_builtin_image_viewer";
-      case MENU_ENUM_LABEL_INPUT_POLL_TYPE_BEHAVIOR:
-         return "input_poll_type_behavior";
-      case MENU_ENUM_LABEL_MENU_WALLPAPER_OPACITY:
-         return "menu_wallpaper_opacity";
+      case MENU_ENUM_LABEL_VIDEO_SHADER_SCALE_PASS:
+         return "video_shader_scale_pass";
+      case MENU_ENUM_LABEL_VIDEO_SHARED_CONTEXT:
+         return "video_shared_context";
+      case MENU_ENUM_LABEL_VIDEO_SMOOTH:
+         return "video_smooth";
+      case MENU_ENUM_LABEL_VIDEO_SOFT_FILTER:
+         return "soft_filter";
+      case MENU_ENUM_LABEL_VIDEO_SWAP_INTERVAL:
+         return "video_swap_interval";
+      case MENU_ENUM_LABEL_VIDEO_TAB:
+         return "video_tab";
+      case MENU_ENUM_LABEL_VIDEO_THREADED:
+         return "video_threaded";
+      case MENU_ENUM_LABEL_VIDEO_VFILTER:
+         return "video_vfilter";
+      case MENU_ENUM_LABEL_VIDEO_VIEWPORT_CUSTOM_HEIGHT:
+         return "video_viewport_custom_height";
+      case MENU_ENUM_LABEL_VIDEO_VIEWPORT_CUSTOM_WIDTH:
+         return "video_viewport_custom_width";
+      case MENU_ENUM_LABEL_VIDEO_VIEWPORT_CUSTOM_X:
+         return "video_viewport_custom_x";
+      case MENU_ENUM_LABEL_VIDEO_VIEWPORT_CUSTOM_Y:
+         return "video_viewport_custom_y";
+      case MENU_ENUM_LABEL_VIDEO_VI_WIDTH:
+         return "video_vi_width";
+      case MENU_ENUM_LABEL_VIDEO_VSYNC:
+         return "video_vsync";
+      case MENU_ENUM_LABEL_VIDEO_WINDOWED_FULLSCREEN:
+         return "video_windowed_fullscreen";
+      case MENU_ENUM_LABEL_WIFI_DRIVER:
+         return "wifi_driver";
+      case MENU_ENUM_LABEL_WIFI_SETTINGS:
+         return "wifi_settings";
+      case MENU_ENUM_LABEL_XMB_ALPHA_FACTOR:
+         return "xmb_alpha_factor";
+      case MENU_ENUM_LABEL_XMB_FONT:
+         return "xmb_font";
+      case MENU_ENUM_LABEL_XMB_MENU_COLOR_THEME:
+         return "xmb_menu_color_theme";
+      case MENU_ENUM_LABEL_XMB_RIBBON_ENABLE:
+         return "xmb_ribbon_enable";
+      case MENU_ENUM_LABEL_XMB_SCALE_FACTOR:
+         return "xmb_scale_factor";
+      case MENU_ENUM_LABEL_XMB_SHADOWS_ENABLE:
+         return "xmb_shadows_enable";
+      case MENU_ENUM_LABEL_XMB_SHOW_HISTORY:
+         return "xmb_show_history";
+      case MENU_ENUM_LABEL_XMB_SHOW_IMAGES:
+         return "xmb_show_images";
+      case MENU_ENUM_LABEL_XMB_SHOW_MUSIC:
+         return "xmb_show_music";
+      case MENU_ENUM_LABEL_XMB_SHOW_SETTINGS:
+         return "xmb_show_settings";
+      case MENU_ENUM_LABEL_XMB_SHOW_VIDEO:
+         return "xmb_show_video";
+      case MENU_ENUM_LABEL_XMB_THEME:
+         return "xmb_theme";
+      case MENU_ENUM_SUBLABEL_MENU_SETTINGS:
+         return "Adjusts settings related to the appearance of the menu screen.";
+      case MENU_ENUM_SUBLABEL_VIDEO_HARD_SYNC:
+         return "Hard-synchronize the CPU and GPU. Reduces latency at the cost of performance.";
+      case MENU_ENUM_SUBLABEL_VIDEO_THREADED:
+         return "Improves performance at the cost of latency and more video stuttering. Use only if you cannot obtain full speed otherwise.";
+      case MSG_AUDIO_VOLUME:
+         return "Audio volume";
+      case MSG_AUTODETECT:
+         return "Autodetect";
+      case MSG_AUTOLOADING_SAVESTATE_FROM:
+         return "Auto-loading savestate from";
+      case MSG_BRINGING_UP_COMMAND_INTERFACE_ON_PORT:
+         return "bringing_up_command_interface_at_port";
+      case MSG_CONNECTING_TO_NETPLAY_HOST:
+         return "Connecting to netplay host";
+      case MSG_CONNECTING_TO_PORT:
+         return "Connecting to port";
+      case MSG_CONNECTION_SLOT:
+         return "Connection slot";
+      case MSG_CONNECT_DEVICE_FROM_A_VALID_PORT:
+         return "connect_device_from_a_valid_port";
+      case MSG_DEVICE_CONFIGURED_IN_PORT:
+         return "configured in port";
+      case MSG_DEVICE_DISCONNECTED_FROM_PORT:
+        return "Device disconnected from port";
+      case MSG_DEVICE_NOT_CONFIGURED:
+         return "not configured";
+      case MSG_DISCONNECTING_DEVICE_FROM_PORT:
+         return "disconnecting_device_from_port";
+      case MSG_DISCONNECT_DEVICE_FROM_A_VALID_PORT:
+         return "disconnect_device_from_a_valid_port";
+      case MSG_FAILED:
+         return "failed";
+      case MSG_FAILED_TO_SET_DISK:
+         return "Failed to set disk";
+      case MSG_FAILED_TO_START_AUDIO_DRIVER:
+         return "failed_to_start_audio_driver";
+      case MSG_FILE_ALREADY_EXISTS_SAVING_TO_BACKUP_BUFFER:
+         return "File already exists. Saving to backup buffer";
+      case MSG_FOUND_LAST_STATE_SLOT:
+         return "found_last_state_slot";
+      case MSG_GOT_CONNECTION_FROM:
+         return "Got connection from";
+      case MSG_NETPLAY_USERS_HAS_FLIPPED:
+         return "Netplay users has flipped";
+      case MSG_SETTING_DISK_IN_TRAY:
+         return "Setting disk in tray";
+      case MSG_SUCCEEDED:
+         return "succeeded";
+      case MSG_UNKNOWN_NETPLAY_COMMAND_RECEIVED:
+         return "Unknown netplay command received";
+      case MSG_WAITING_FOR_CLIENT:
+         return "Waiting for client ...";
       default:
          break;
    }
@@ -3031,1792 +3031,1792 @@ const char *msg_hash_to_str_us(enum msg_hash_enums msg)
 
    switch (msg)
    {
-      case MENU_ENUM_SUBLABEL_CONFIG_SAVE_ON_EXIT:
-         return "Saves changes to configuration file on exit.";
-      case MENU_ENUM_SUBLABEL_VIDEO_HARD_SYNC_FRAMES:
-         return "Sets how many frames the CPU can run ahead of the GPU when using 'Hard GPU Sync'.";
-      case MENU_ENUM_SUBLABEL_VIDEO_REFRESH_RATE_AUTO:
-         return "The accurate estimated refresh rate of the monitor in Hz.";
-      case MENU_ENUM_SUBLABEL_VIDEO_MONITOR_INDEX:
-         return "Selects which display monitor to use.";
-      case MENU_ENUM_SUBLABEL_LOG_VERBOSITY:
-         return "Enable or disable logging to the terminal.";
-      case MENU_ENUM_SUBLABEL_SHOW_HIDDEN_FILES:
-         return "Show hidden files/directories inside the file browser.";
-      case MENU_ENUM_SUBLABEL_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
-         return "Gamepad button combination to toggle menu.";
-      case MENU_ENUM_SUBLABEL_CPU_CORES:
-         return "Amount of cores that the CPU has.";
-      case MENU_ENUM_SUBLABEL_VIDEO_BLACK_FRAME_INSERTION:
-         return "Inserts a black frame inbetween frames. Useful for users of 120 Hz monitors who want to play 60 Hz material with eliminated ghosting.";
-      case MENU_ENUM_SUBLABEL_VIDEO_FRAME_DELAY:
-         return "Reduces latency at the cost of higher risk of video stuttering. Adds a delay after V-Sync (in ms).";
-      case MENU_ENUM_SUBLABEL_ADD_CONTENT_LIST:
-         return "Scan contents and add to the database.";
-      case MENU_ENUM_SUBLABEL_NETPLAY:
-         return "Join or host a netplay session.";
-      case MENU_ENUM_SUBLABEL_FPS_SHOW:
-         return "Displays the current framerate per second onscreen.";
-      case MENU_ENUM_SUBLABEL_VIDEO_SETTINGS:
-         return "Adjusts settings for video output.";
-      case MENU_ENUM_SUBLABEL_AUDIO_SETTINGS:
-         return "Adjusts settings for audio output.";
-      case MENU_ENUM_SUBLABEL_INPUT_SETTINGS:
-         return "Adjusts settings for joypads, keyboard and mouse.";
-      case MENU_ENUM_SUBLABEL_WIFI_SETTINGS:
-         return "Scans for wireless networks and establishes connection.";
-      case MENU_ENUM_SUBLABEL_SERVICES_SETTINGS:
-         return "Manage operating system level services.";
-      case MENU_ENUM_SUBLABEL_SSH_ENABLE:
-         return "Enable or disable remote command line access.";
-      case MENU_ENUM_SUBLABEL_SAMBA_ENABLE:
-         return "Enable or disable network sharing of your folders.";
-      case MENU_ENUM_SUBLABEL_BLUETOOTH_ENABLE:
-         return "Enable or disable bluetooth.";
-      case MENU_ENUM_SUBLABEL_USER_LANGUAGE:
-         return "Sets the language of the interface.";
-      case MENU_ENUM_SUBLABEL_SUSPEND_SCREENSAVER_ENABLE:
-         return "Prevents your system's screensaver from becoming active.";
-      case MENU_ENUM_SUBLABEL_VIDEO_MAX_SWAPCHAIN_IMAGES:
-         return "Tells the video driver to explicitly use a specified buffering mode.";
-      case MENU_ENUM_SUBLABEL_ONLINE_UPDATER:
-         return "Download add-ons, components and contents for RetroArch.";
-      case MENU_ENUM_SUBLABEL_INPUT_USER_BINDS:
-         return "Configure controls for this user.";
-      case MENU_ENUM_SUBLABEL_INPUT_HOTKEY_BINDS:
-         return "Configure hotkey settings.";
-      case MSG_VALUE_SHUTTING_DOWN:
-         return "Shutting down...";
-      case MSG_VALUE_REBOOTING:
-         return "Rebooting...";
-      case MSG_FAILED_TO_START_AUDIO_DRIVER:
-         return "Failed to start audio driver. Will continue without audio.";
-      case MSG_FOUND_LAST_STATE_SLOT:
-         return "Found last state slot";
-      case MSG_VALUE_CONNECT_DEVICE_FROM_A_VALID_PORT:
-         return "Connect device from a valid port.";
-      case MSG_DISCONNECT_DEVICE_FROM_A_VALID_PORT:
-         return "Disconnect device from a valid port.";
-      case MSG_VALUE_DISCONNECTING_DEVICE_FROM_PORT:
-         return "Disconnecting device from port";
-      case MSG_BRINGING_UP_COMMAND_INTERFACE_ON_PORT:
-         return "Bringing up command interface on port";
-      case MSG_LOADING_HISTORY_FILE:
-         return "Loading history file";
-      case MENU_ENUM_LABEL_VALUE_SHADER_PIPELINE_RIBBON_SIMPLIFIED:
-         return "Ribbon (simplified)";
-      case MENU_ENUM_LABEL_VALUE_SHADER_PIPELINE_RIBBON:
-         return "Ribbon";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_FOOTER_OPACITY:
-         return "Footer Opacity";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_HEADER_OPACITY:
-         return "Header Opacity";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_BLUE:
-         return "Blue";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_BLUE_GREY:
-         return "Blue Grey";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_RED:
-         return "Red";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_YELLOW:
-         return "Yellow";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_NVIDIA_SHIELD:
-         return "Shield";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_GREEN:
-         return "Green";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_DARK_BLUE:
-         return "Dark Blue";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_PLAIN:
-         return "Plain";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_LEGACY_RED:
-         return "Legacy Red";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_DARK_PURPLE:
-         return "Dark Purple";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_MIDNIGHT_BLUE:
-         return "Midnight Blue";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_GOLDEN:
-         return "Golden";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_ELECTRIC_BLUE:
-         return "Electric Blue";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_APPLE_GREEN:
-         return "Apple Green";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_UNDERSEA:
-         return "Undersea";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_VOLCANIC_RED:
-         return "Volcanic Red";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_DARK:
-         return "Dark";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_UNLOCKED_ENTRY:
-         return "Unlocked";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_LOCKED_ENTRY:
-         return "Locked";
-      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR_LATE:
-         return "Late";
-      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR_NORMAL:
-         return "Normal";
-      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR_EARLY:
-         return "Early";
-      case MSG_INTERNAL_MEMORY:
-         return "Internal Memory";
-      case MSG_EXTERNAL_APPLICATION_DIR:
-         return "External Application Dir";
-      case MSG_APPLICATION_DIR:
-         return "Application Dir";
-      case MSG_PROGRAM:
-         return "RetroArch";
-      case MSG_LIBRETRO_FRONTEND:
-         return "Frontend for libretro";
-      case MSG_LOADING:
-         return "Loading";
-      case MSG_GAME_SPECIFIC_CORE_OPTIONS_FOUND_AT:
-         return "Per-Game Options: game-specific core options found at";
-      case MSG_RESTORING_DEFAULT_SHADER_PRESET_TO:
-         return "Shaders: restoring default shader preset to";
       case  MSG_SORRY_UNIMPLEMENTED_CORES_DONT_DEMAND_CONTENT_NETPLAY:
          return "Sorry, unimplemented: cores that don't demand content cannot participate in netplay.";
-      case MSG_FOUND_AUTO_SAVESTATE_IN:
-         return "Found auto savestate in";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_REMOTE_PORT:
-         return "Network Remote Base Port";
-      case MSG_OVERRIDES_SAVED_SUCCESSFULLY:
-         return "Overrides saved successfully.";
-      case MSG_AUTOCONFIG_FILE_SAVED_SUCCESSFULLY:
-         return "Autoconfig file saved successfully.";
-      case MSG_OVERRIDES_ERROR_SAVING:
-         return "Error saving overrides.";
-      case MSG_AUTOCONFIG_FILE_ERROR_SAVING:
-         return "Error saving autoconf file.";
-      case MSG_DOWNLOAD_FAILED:
-         return "Download failed";
-      case MSG_INPUT_CHEAT:
-         return "Input Cheat";
-      case MSG_DECOMPRESSION_ALREADY_IN_PROGRESS:
-         return "Decompression already in progress.";
-      case MSG_DECOMPRESSION_FAILED:
-         return "Decompression failed.";
-      case MSG_CORE_OPTIONS_FILE_CREATED_SUCCESSFULLY:
-         return "Core options file created successfully.";
-      case MSG_FAILED_TO_CREATE_THE_DIRECTORY:
-         return "Failed to create the directory.";
-      case MSG_FAILED_TO_EXTRACT_CONTENT_FROM_COMPRESSED_FILE:
-         return "Failed to extract content from compressed file";
-      case MSG_FILE_NOT_FOUND:
-         return "File not found";
-      case MSG_ERROR_SAVING_CORE_OPTIONS_FILE:
-         return "Error saving core options file.";
-      case MSG_FAILED_TO_ALLOCATE_MEMORY_FOR_PATCHED_CONTENT:
-         return "Failed to allocate memory for patched content...";
-      case MSG_DID_NOT_FIND_A_VALID_CONTENT_PATCH:
-         return "Did not find a valid content patch.";
-      case MSG_SEVERAL_PATCHES_ARE_EXPLICITLY_DEFINED:
-         return "Several patches are explicitly defined, ignoring all...";
-      case MSG_REMAP_FILE_SAVED_SUCCESSFULLY:
-         return "Remap file saved successfully.";
-      case MSG_SHADER_PRESET_SAVED_SUCCESSFULLY:
-         return "Shader preset saved successfully.";
-      case MSG_ERROR_SAVING_REMAP_FILE:
-         return "Error saving remap file.";
-      case MSG_ERROR_SAVING_SHADER_PRESET:
-         return "Error saving shader preset.";
-      case MSG_INPUT_CHEAT_FILENAME:
-         return "Cheat Filename";
-      case MSG_INPUT_PRESET_FILENAME:
-         return "Preset Filename";
-      case MSG_DISK_EJECTED:
-         return "Ejected";
-      case MSG_DISK_CLOSED:
-         return "Closed";
-      case MSG_VERSION_OF_LIBRETRO_API:
-         return "Version of libretro API";
-      case MSG_COMPILED_AGAINST_API:
-         return "Compiled against API";
-      case MSG_FAILED_TO_LOAD:
-         return "Failed to load";
-      case MSG_CONNECTED_TO:
-         return "Connected to";
-      case MSG_FAILED_TO_ACCEPT_INCOMING_SPECTATOR:
-         return "Failed to accept incoming spectator.";
-      case MSG_FAILED_TO_GET_NICKNAME_FROM_CLIENT:
-         return "Failed to get nickname from client.";
-      case MSG_FAILED_TO_SEND_NICKNAME_TO_CLIENT:
-         return "Failed to send nickname to client.";
-      case MSG_USING_CORE_NAME_FOR_NEW_CONFIG:
-         return "Using core name for new config.";
-      case MSG_CANNOT_INFER_NEW_CONFIG_PATH:
-         return "Cannot infer new config path. Use current time.";
-      case MSG_NO_STATE_HAS_BEEN_LOADED_YET:
-         return "No state has been loaded yet.";
-      case MSG_NO_SAVE_STATE_HAS_BEEN_OVERWRITTEN_YET:
-         return "No save state has been overwritten yet.";
-      case MSG_RESTORED_OLD_SAVE_STATE:
-         return "Restored old save state.";
-      case MSG_SAVED_NEW_CONFIG_TO:
-         return "Saved new config to";
-      case MSG_FAILED_SAVING_CONFIG_TO:
-         return "Failed saving config to";
-      case MSG_FAILED_TO_RECEIVE_NICKNAME_SIZE_FROM_HOST:
-         return "Failed to receive nickname size from host.";
-      case MSG_FAILED_TO_RECEIVE_NICKNAME:
-         return "Failed to receive nickname.";
-      case MSG_FAILED_TO_RECEIVE_NICKNAME_FROM_HOST:
-         return "Failed to receive nickname from host.";
-      case MSG_FAILED_TO_SEND_NICKNAME_SIZE:
-         return "Failed to send nickname size.";
-      case MSG_FAILED_TO_SEND_SRAM_DATA_TO_CLIENT:
-         return "Failed to send SRAM data to client.";
-      case MSG_FAILED_TO_RECEIVE_HEADER_FROM_CLIENT:
-         return "Failed to receive header from client.";
-      case MSG_FAILED_TO_RECEIVE_SRAM_DATA_FROM_HOST:
-         return "Failed to receive SRAM data from host.";
-      case MSG_CONTENT_CRC32S_DIFFER:
-         return "Content CRC32s differ. Cannot use different games.";
-      case MSG_FAILED_TO_SEND_NICKNAME:
-         return "Failed to send nickname.";
-      case MSG_FAILED_TO_SEND_NICKNAME_TO_HOST:
-         return "Failed to send nickname to host.";
-      case MSG_INVALID_NICKNAME_SIZE:
-         return "Invalid nickname size.";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ANALOG:
-         return "Analog supported";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_SERIAL:
-         return "Serial";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_COOP:
-         return "Co-op supported";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ENHANCEMENT_HW:
-         return "Enhancement Hardware";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ELSPA_RATING:
-         return "ELSPA Rating";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RUMBLE:
-         return "Rumble supported";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_PEGI_RATING:
-         return "PEGI Rating";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_EDGE_MAGAZINE_ISSUE:
-         return "Edge Magazine Issue";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_BBFC_RATING:
-         return "BBFC Rating";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ESRB_RATING:
-         return "ESRB Rating";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_CERO_RATING:
-         return "CERO Rating";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MAX_SWAPCHAIN_IMAGES:
-         return "Max swapchain images";
-      case MSG_ERROR_LIBRETRO_CORE_REQUIRES_CONTENT:
-         return "Libretro core requires content, but nothing was provided.";
-      case MSG_CONTENT_LOADING_SKIPPED_IMPLEMENTATION_WILL_DO_IT:
-         return "Content loading skipped. Implementation will load it on its own.";
-      case MSG_ERROR_LIBRETRO_CORE_REQUIRES_SPECIAL_CONTENT:
-         return "Libretro core requires special content, but none were provided.";
-      case MSG_REVERTING_SAVEFILE_DIRECTORY_TO:
-         return "Reverting savefile directory to";
-      case MSG_REVERTING_SAVESTATE_DIRECTORY_TO:
-         return "Reverting savestate directory to";
-      case MSG_COULD_NOT_READ_MOVIE_HEADER:
-         return "Could not read movie header.";
-      case MSG_FAILED_TO_OPEN_LIBRETRO_CORE:
-         return "Failed to open libretro core";
-      case MSG_COULD_NOT_FIND_ANY_NEXT_DRIVER:
-         return "Could not find any next driver";
-      case MSG_MOVIE_FORMAT_DIFFERENT_SERIALIZER_VERSION:
-         return "Movie format seems to have a different serializer version. Will most likely fail.";
-      case MSG_CRC32_CHECKSUM_MISMATCH:
-         return "CRC32 checksum mismatch between content file and saved content checksum in replay file header; replay highly likely to desync on playback.";
-      case MSG_INFLATED_CHECKSUM_DID_NOT_MATCH_CRC32:
-         return "Inflated checksum did not match CRC32.";
-      case MSG_ERROR_PARSING_ARGUMENTS:
-         return "Error parsing arguments.";
-      case MSG_ERROR:
-         return "Error";
-      case MSG_FOUND_DISK_LABEL:
-         return "Found disk label";
-      case MSG_READING_FIRST_DATA_TRACK:
-         return "Reading first data track...";
-      case MSG_FOUND_FIRST_DATA_TRACK_ON_FILE:
-         return "Found first data track on file";
-      case MSG_COULD_NOT_FIND_VALID_DATA_TRACK:
-         return "Could not find valid data track";
-      case MSG_COMPARING_WITH_KNOWN_MAGIC_NUMBERS:
-         return "Comparing with known magic numbers...";
-      case MSG_COULD_NOT_FIND_COMPATIBLE_SYSTEM:
-         return "Could not find compatible system.";
-      case MSG_COULD_NOT_OPEN_DATA_TRACK:
-         return "could not open data track";
-      case MSG_MEMORY:
-         return "Memory";
-      case MSG_FRAMES:
-         return "Frames";
-      case MSG_IN_BYTES:
-         return "in bytes";
-      case MSG_IN_MEGABYTES:
-         return "in megabytes";
-      case MSG_IN_GIGABYTES:
-         return "in gigabytes";
-      case MSG_INTERFACE:
-         return "Interface";
-      case MSG_FAILED_TO_PATCH:
-         return "Failed to patch";
-      case MSG_FATAL_ERROR_RECEIVED_IN:
-         return "Fatal error received in";
-      case MSG_MOVIE_RECORD_STOPPED:
-         return "Stopping movie record.";
-      case MSG_MOVIE_PLAYBACK_ENDED:
-         return "Movie playback ended.";
-      case MSG_AUTOSAVE_FAILED:
-         return "Could not initialize autosave.";
-      case MSG_NETPLAY_FAILED_MOVIE_PLAYBACK_HAS_STARTED:
-         return "Movie playback has started. Cannot start netplay.";
-      case MSG_NETPLAY_FAILED:
-         return "Failed to initialize netplay.";
-      case MSG_LIBRETRO_ABI_BREAK:
-         return "is compiled against a different version of libretro than this libretro implementation.";
-      case MSG_REWIND_INIT_FAILED_THREADED_AUDIO:
-         return "Implementation uses threaded audio. Cannot use rewind.";
-      case MSG_REWIND_INIT_FAILED:
-         return "Failed to initialize rewind buffer. Rewinding will be disabled.";
-      case MSG_REWIND_INIT:
-         return "Initializing rewind buffer with size";
-      case MSG_CUSTOM_TIMING_GIVEN:
-         return "Custom timing given";
-      case MSG_VIEWPORT_SIZE_CALCULATION_FAILED:
-         return "Viewport size calculation failed! Will continue using raw data. This will probably not work right ...";
-      case MSG_HW_RENDERED_MUST_USE_POSTSHADED_RECORDING:
-         return "Libretro core is hardware rendered. Must use post-shaded recording as well.";
-      case MSG_RECORDING_TO:
-         return "Recording to";
-      case MSG_DETECTED_VIEWPORT_OF:
-         return "Detected viewport of";
-      case MSG_TAKING_SCREENSHOT:
-         return "Taking screenshot.";
-      case MSG_FAILED_TO_TAKE_SCREENSHOT:
-         return "Failed to take screenshot.";
-      case MSG_FAILED_TO_START_RECORDING:
-         return "Failed to start recording.";
-      case MSG_RECORDING_TERMINATED_DUE_TO_RESIZE:
-         return "Recording terminated due to resize.";
-      case MSG_USING_LIBRETRO_DUMMY_CORE_RECORDING_SKIPPED:
-         return "Using libretro dummy core. Skipping recording.";
-      case MSG_UNKNOWN:
-         return "Unknown";
-      case MSG_COULD_NOT_READ_STATE_FROM_MOVIE:
-         return "Could not read state from movie.";
-      case MSG_MOVIE_FILE_IS_NOT_A_VALID_BSV1_FILE:
-         return "Movie file is not a valid BSV1 file.";
-      case MSG_LOADING_CONTENT_FILE:
-         return "Loading content file";
-      case MSG_RECEIVED:
-         return "received";
-      case MSG_UNRECOGNIZED_COMMAND:
-         return "Unrecognized command";
-      case MSG_SENDING_COMMAND:
-         return "Sending command";
-      case MSG_GOT_INVALID_DISK_INDEX:
-         return "Got invalid disk index.";
-      case MSG_FAILED_TO_REMOVE_DISK_FROM_TRAY:
-         return "Failed to remove disk from tray.";
-      case MSG_REMOVED_DISK_FROM_TRAY:
-         return "Removed disk from tray.";
-      case MSG_VIRTUAL_DISK_TRAY:
-         return "virtual disk tray.";
-      case MSG_FAILED_TO:
-         return "Failed to";
-      case MSG_TO:
-         return "to";
-      case MSG_SAVING_RAM_TYPE:
-         return "Saving RAM type";
-      case MSG_UNDOING_SAVE_STATE:
-         return "Undoing save state";
-      case MSG_SAVING_STATE:
-         return "Saving state";
-      case MSG_LOADING_STATE:
-         return "Loading state";
-      case MSG_FAILED_TO_LOAD_MOVIE_FILE:
-         return "Failed to load movie file";
-      case MSG_FAILED_TO_LOAD_CONTENT:
-         return "Failed to load content";
-      case MSG_COULD_NOT_READ_CONTENT_FILE:
-         return "Could not read content file";
-      case MSG_GRAB_MOUSE_STATE:
-         return "Grab mouse state";
-      case MSG_PAUSED:
-         return "Paused.";
-      case MSG_UNPAUSED:
-         return "Unpaused.";
-      case MSG_FAILED_TO_LOAD_OVERLAY:
-         return "Failed to load overlay.";
-      case MSG_FAILED_TO_UNMUTE_AUDIO:
-         return "Failed to unmute audio.";
-      case MSG_AUDIO_MUTED:
-         return "Audio muted.";
-      case MSG_AUDIO_UNMUTED:
-         return "Audio unmuted.";
-      case MSG_RESET:
-         return "Reset";
-      case MSG_AUTO_SAVE_STATE_TO:
-         return "Auto save state to";
-      case MSG_FAILED_TO_LOAD_STATE:
-         return "Failed to load state from";
-      case MSG_FAILED_TO_SAVE_STATE_TO:
-         return "Failed to save state to";
-      case MSG_FAILED_TO_UNDO_LOAD_STATE:
-         return "Failed to undo load state.";
-      case MSG_FAILED_TO_UNDO_SAVE_STATE:
-         return "Failed to undo save state.";
-      case MSG_FAILED_TO_SAVE_SRAM:
-         return "Failed to save SRAM";
-      case MSG_STATE_SIZE:
-         return "State size";
-      case MSG_FOUND_SHADER:
-         return "Found shader";
-      case MSG_SRAM_WILL_NOT_BE_SAVED:
-         return "SRAM will not be saved.";
-      case MSG_BLOCKING_SRAM_OVERWRITE:
-         return "Blocking SRAM Overwrite";
-      case MSG_CORE_DOES_NOT_SUPPORT_SAVESTATES:
-         return "Core does not support save states.";
-      case MSG_SAVED_STATE_TO_SLOT:
-         return "Saved state to slot";
-      case MSG_SAVED_SUCCESSFULLY_TO:
-         return "Saved successfully to";
-      case MSG_BYTES:
-         return "bytes";
-      case MSG_CONFIG_DIRECTORY_NOT_SET:
-         return "Config directory not set. Cannot save new config.";
-      case MSG_SKIPPING_SRAM_LOAD:
-         return "Skipping SRAM load.";
-      case MSG_APPENDED_DISK:
-         return "Appended disk";
-      case MSG_STARTING_MOVIE_PLAYBACK:
-         return "Starting movie playback.";
-      case MSG_FAILED_TO_REMOVE_TEMPORARY_FILE:
-         return "Failed to remove temporary file";
-      case MSG_REMOVING_TEMPORARY_CONTENT_FILE:
-         return "Removing temporary content file";
-      case MSG_LOADED_STATE_FROM_SLOT:
-         return "Loaded state from slot";
-      case MSG_SCANNING_OF_DIRECTORY_FINISHED:
-         return "Scanning of directory finished";
-      case MSG_SCANNING:
-         return "Scanning";
-      case MSG_REDIRECTING_CHEATFILE_TO:
-         return "Redirecting cheat file to";
-      case MSG_REDIRECTING_SAVEFILE_TO:
-         return "Redirecting save file to";
-      case MSG_REDIRECTING_SAVESTATE_TO:
-         return "Redirecting savestate to";
-      case MSG_APPLYING_CHEAT:
-         return "Applying cheat changes.";
-      case MSG_SHADER:
-         return "Shader";
-      case MSG_APPLYING_SHADER:
-         return "Applying shader";
-      case MSG_FAILED_TO_APPLY_SHADER:
-         return "Failed to apply shader.";
-      case MSG_STARTING_MOVIE_RECORD_TO:
-         return "Starting movie record to";
-      case MSG_FAILED_TO_START_MOVIE_RECORD:
-         return "Failed to start movie record.";
-      case MSG_STATE_SLOT:
-         return "State slot";
-      case MSG_RESTARTING_RECORDING_DUE_TO_DRIVER_REINIT:
-         return "Restarting recording due to driver reinit.";
-      case MSG_SLOW_MOTION:
-         return "Slow motion.";
-      case MSG_SLOW_MOTION_REWIND:
-         return "Slow motion rewind.";
-      case MSG_REWINDING:
-         return "Rewinding.";
-      case MSG_REWIND_REACHED_END:
-         return "Reached end of rewind buffer.";
-      case MSG_CHEEVOS_HARDCORE_MODE_ENABLE:
-         return "Hardcore Mode Enabled: savestate & rewind were disabled.";
-      case MSG_DOWNLOADING:
-         return "Downloading";
-      case MSG_EXTRACTING:
-         return "Extracting";
-      case MSG_EXTRACTING_FILE:
-         return "Extracting file";
-      case MSG_NO_CONTENT_STARTING_DUMMY_CORE:
-         return "No content, starting dummy core.";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_EDGE_MAGAZINE_RATING:
-         return "Edge Magazine Rating";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_EDGE_MAGAZINE_REVIEW:
-         return "Edge Magazine Review";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_FAMITSU_MAGAZINE_RATING:
-         return "Famitsu Magazine Rating";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_TGDB_RATING:
-         return "TGDB Rating";
-      case MENU_ENUM_LABEL_VALUE_CPU_ARCHITECTURE:
-         return "CPU Architecture:";
-      case MENU_ENUM_LABEL_VALUE_CPU_CORES:
-         return "CPU Cores:";
-      case MENU_ENUM_LABEL_VALUE_INTERNAL_STORAGE_STATUS:
-         return "Internal storage status";
-      case MENU_ENUM_LABEL_VALUE_PARENT_DIRECTORY:
-         return "Parent directory";
-      case MENU_ENUM_LABEL_VALUE_MORE:
-         return "...";
-      case MENU_ENUM_LABEL_VALUE_RUN:
-         return "Run";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_X:
-         return "Custom Viewport X";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_Y:
-         return "Custom Viewport Y";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_WIDTH:
-         return "Custom Viewport Width";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_HEIGHT:
-         return "Custom Viewport Height";
-      case MENU_ENUM_LABEL_VALUE_NO_ENTRIES_TO_DISPLAY:
-         return "No entries to display.";
-      case MENU_ENUM_LABEL_VALUE_NO_ACHIEVEMENTS_TO_DISPLAY:
-         return "No achievements to display.";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_UNLOCKED_ACHIEVEMENTS:
-         return "Unlocked Achievements:";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_LOCKED_ACHIEVEMENTS:
-         return "Locked Achievements:";
-      case MENU_ENUM_LABEL_VALUE_START_VIDEO_PROCESSOR:
-         return "Start Video Processor";
-      case MENU_ENUM_LABEL_VALUE_START_NET_RETROPAD:
-         return "Start Remote RetroPad";
-      case MENU_ENUM_LABEL_VALUE_THUMBNAILS_UPDATER_LIST:
-         return "Thumbnails Updater";
-      case MENU_ENUM_LABEL_VALUE_MENU_LINEAR_FILTER:
-         return "Menu Linear Filter";
-      case MENU_ENUM_LABEL_VALUE_MENU_ENUM_THROTTLE_FRAMERATE:
-         return "Throttle Menu Framerate";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_HARDCORE_MODE_ENABLE:
-         return "Hardcore Mode";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_TEST_UNOFFICIAL:
-         return "Test unofficial";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_SETTINGS:
-         return "Retro Achievements";
-      case MENU_ENUM_LABEL_VALUE_INPUT_TOUCH_ENABLE:
-         return "Touch Enable";
-      case MENU_ENUM_LABEL_VALUE_INPUT_PREFER_FRONT_TOUCH:
-         return "Prefer Front Touch";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ICADE_ENABLE:
-         return "Keyboard Gamepad Mapping Enable";
-      case MENU_ENUM_LABEL_VALUE_INPUT_KEYBOARD_GAMEPAD_MAPPING_TYPE:
-         return "Keyboard Gamepad Mapping Type";
-      case MENU_ENUM_LABEL_VALUE_INPUT_SMALL_KEYBOARD_ENABLE:
-         return "Small Keyboard Enable";
-      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG_OVERRIDE_CORE:
-         return "Save Core Overrides";
-      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG_OVERRIDE_GAME:
-         return "Save Game Overrides";
-      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG:
-         return "Save Current Config";
-      case MENU_ENUM_LABEL_VALUE_STATE_SLOT:
-         return "State Slot";
+      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_PASSWORD:
+         return "Password";
       case MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_SETTINGS:
          return "Accounts Cheevos";
       case MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_USERNAME:
          return "Username";
-      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_PASSWORD:
-         return "Password";
-      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_RETRO_ACHIEVEMENTS:
-         return "Retro Achievements";
-      case MENU_ENUM_LABEL_VALUE_RETRO_ACHIEVEMENTS_SETTINGS:
-         return "Retro Achievements";
       case MENU_ENUM_LABEL_VALUE_ACCOUNTS_LIST:
          return "Accounts";
       case MENU_ENUM_LABEL_VALUE_ACCOUNTS_LIST_END:
          return "Accounts List Endpoint";
-      case MENU_ENUM_LABEL_VALUE_HELP_SCANNING_CONTENT:
-         return "Scanning For Content";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_DESCRIPTION:
-         return "Description";
-      case MENU_ENUM_LABEL_VALUE_HELP_AUDIO_VIDEO_TROUBLESHOOTING:
-         return "Audio/Video Troubleshooting";
-      case MENU_ENUM_LABEL_VALUE_HELP_CHANGE_VIRTUAL_GAMEPAD:
-         return "Changing Virtual Gamepad Overlay";
-      case MENU_ENUM_LABEL_VALUE_HELP_WHAT_IS_A_CORE:
-         return "What Is A Core?";
-      case MENU_ENUM_LABEL_VALUE_HELP_LOADING_CONTENT:
-         return "Loading Content";
-      case MENU_ENUM_LABEL_VALUE_HELP_LIST:
-         return "Help";
-      case MENU_ENUM_LABEL_VALUE_HELP_CONTROLS:
-         return "Basic Menu Controls";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS:
-         return "Basic menu controls";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_SCROLL_UP:
-         return "Scroll Up";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_CONFIRM:
-         return "Confirm/OK";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_BACK:
-         return "Back";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_START:
-         return "Defaults";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_INFO:
-         return "Info";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_TOGGLE_MENU:
-         return "Toggle Menu";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_QUIT:
-         return "Quit";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_TOGGLE_KEYBOARD:
-         return "Toggle Keyboard";
-      case MENU_ENUM_LABEL_VALUE_OPEN_ARCHIVE:
-         return "Open Archive As Folder";
-      case MENU_ENUM_LABEL_VALUE_LOAD_ARCHIVE:
-         return "Load Archive With Core";
-      case MENU_ENUM_LABEL_VALUE_INPUT_BACK_AS_MENU_ENUM_TOGGLE_ENABLE:
-         return "Back As Menu Toggle Enable";
-      case MENU_ENUM_LABEL_VALUE_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
-         return "Menu Toggle Gamepad Combo";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ALL_USERS_CONTROL_MENU:
-         return "All Users Control Menu";
-      case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_HIDE_IN_MENU:
-         return "Hide Overlay In Menu";
-      case MENU_ENUM_LABEL_VALUE_LANG_POLISH:
-         return "Polish";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_AUTOLOAD_PREFERRED:
-         return "Autoload Preferred Overlay";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_CORE_INFO_FILES:
-         return "Update Core Info Files";
-      case MENU_ENUM_LABEL_VALUE_DOWNLOAD_CORE_CONTENT:
-         return "Content Downloader";
-      case MENU_ENUM_LABEL_VALUE_DOWNLOAD_CORE:
-         return "Download Core...";
-      case MENU_ENUM_LABEL_VALUE_SCAN_THIS_DIRECTORY:
-         return "<Scan This Directory>";
-      case MENU_ENUM_LABEL_VALUE_SCAN_FILE:
-         return "Scan File";
-      case MENU_ENUM_LABEL_VALUE_SCAN_DIRECTORY:
-         return "Scan Directory";
+      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_RETRO_ACHIEVEMENTS:
+         return "Retro Achievements";
+      case MENU_ENUM_LABEL_VALUE_ACHIEVEMENT_LIST:
+         return "Achievement List";
       case MENU_ENUM_LABEL_VALUE_ADD_CONTENT_LIST:
          return "Scan Content";
-      case MENU_ENUM_LABEL_VALUE_INFORMATION:
-         return "Information";
-      case MENU_ENUM_LABEL_VALUE_INFORMATION_LIST:
-         return "Information";
-      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_PLAYER:
-         return "Use Builtin Media Player";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_SETTINGS:
-         return "Quick Menu";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_CRC32:
-         return "CRC32";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_MD5:
-         return "MD5";
-      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_LIST:
-         return "Load Content";
-      case MENU_ENUM_LABEL_VALUE_ASK_ARCHIVE:
-         return "Ask";
-      case MENU_ENUM_LABEL_VALUE_PRIVACY_SETTINGS:
-         return "Privacy";
-      case MENU_ENUM_LABEL_VALUE_MUSIC_TAB:
-         return "Music";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_TAB:
-         return "Video";
-      case MENU_ENUM_LABEL_VALUE_IMAGES_TAB:
-         return "Images";
-      case MENU_ENUM_LABEL_VALUE_HORIZONTAL_MENU:
-         return "Horizontal Menu";
-      case MENU_ENUM_LABEL_VALUE_SETTINGS_TAB:
-         return "Settings";
-      case MENU_ENUM_LABEL_VALUE_HISTORY_TAB:
-         return "History";
       case MENU_ENUM_LABEL_VALUE_ADD_TAB:
          return "Import content";
-      case MENU_ENUM_LABEL_VALUE_PLAYLISTS_TAB:
-         return "Playlists";
-      case MENU_ENUM_LABEL_VALUE_NO_SETTINGS_FOUND:
-         return "No settings found.";
-      case MENU_ENUM_LABEL_VALUE_NO_PERFORMANCE_COUNTERS:
-         return "No performance counters.";
-      case MENU_ENUM_LABEL_VALUE_DRIVER_SETTINGS:
-         return "Driver";
-      case MENU_ENUM_LABEL_VALUE_CONFIGURATION_SETTINGS:
-         return "Configuration";
-      case MENU_ENUM_LABEL_VALUE_CORE_SETTINGS:
-         return "Core";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SETTINGS:
-         return "Video";
-      case MENU_ENUM_LABEL_VALUE_LOGGING_SETTINGS:
-         return "Logging";
-      case MENU_ENUM_LABEL_VALUE_SAVING_SETTINGS:
-         return "Saving";
-      case MENU_ENUM_LABEL_VALUE_REWIND_SETTINGS:
-         return "Rewind";
-      case MENU_ENUM_LABEL_VALUE_SHADER:
-         return "Shader";
-      case MENU_ENUM_LABEL_VALUE_CHEAT:
-         return "Cheat";
-      case MENU_ENUM_LABEL_VALUE_USER:
-         return "User";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_BGM_ENABLE:
-         return "System BGM Enable";
-      case MENU_ENUM_LABEL_VALUE_RETROPAD:
-         return "RetroPad";
-      case MENU_ENUM_LABEL_VALUE_RETROKEYBOARD:
-         return "RetroKeyboard";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_BLOCK_FRAMES:
-         return "Block Frames";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_LABEL_SHOW:
-         return "Display Input Descriptor Labels";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_HIDE_UNBOUND:
-         return "Hide Unbound Core Input Descriptors";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_ENABLE:
-         return "Display OSD Message";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_PATH:
-         return "OSD Message Font";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_SIZE:
-         return "OSD Message Size";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_X:
-         return "OSD Message X Position";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_Y:
-         return "OSD Message Y Position";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SOFT_FILTER:
-         return "Soft Filter Enable";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_FLICKER:
-         return "Flicker filter";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_CONTENT:
-         return "<Content dir>";
-      case MENU_ENUM_LABEL_VALUE_UNKNOWN:
-         return "Unknown";
-      case MENU_ENUM_LABEL_VALUE_DONT_CARE:
-         return "Don't care";
-      case MENU_ENUM_LABEL_VALUE_LINEAR:
-         return "Linear";
-      case MENU_ENUM_LABEL_VALUE_NEAREST:
-         return "Nearest";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_DEFAULT:
-         return "<Default>";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NONE:
-         return "<None>";
-      case MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE:
-         return "N/A";
-      case MENU_ENUM_LABEL_VALUE_DATABASE_SELECTION:
-         return "Database Selection";
-      case MENU_ENUM_LABEL_VALUE_CORE_ASSETS_DIR:
-         return "Core Assets Dir";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_DIR:
-         return "Content Dir";
-      case MENU_ENUM_LABEL_VALUE_INPUT_REMAPPING_DIRECTORY:
-         return "Input Remapping Dir";
-      case MENU_ENUM_LABEL_VALUE_JOYPAD_AUTOCONFIG_DIR:
-         return "Input Device Autoconfig Dir";
-      case MENU_ENUM_LABEL_VALUE_RECORDING_CONFIG_DIRECTORY:
-         return "Recording Config Dir";
-      case MENU_ENUM_LABEL_VALUE_RECORDING_OUTPUT_DIRECTORY:
-         return "Recording Output Dir";
-      case MENU_ENUM_LABEL_VALUE_SCREENSHOT_DIRECTORY:
-         return "Screenshot Dir";
-      case MENU_ENUM_LABEL_VALUE_PLAYLIST_DIRECTORY:
-         return "Playlist Dir";
-      case MENU_ENUM_LABEL_VALUE_SAVEFILE_DIRECTORY:
-         return "Savefile Dir";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_DIRECTORY:
-         return "Savestate Dir";
-      case MENU_ENUM_LABEL_VALUE_STDIN_CMD_ENABLE:
-         return "stdin Commands";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_REMOTE_ENABLE:
-         return "Network Gamepad";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_DRIVER:
-         return "Video Driver";
-      case MENU_ENUM_LABEL_VALUE_RECORD_ENABLE:
-         return "Record Enable";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_RECORD:
-         return "GPU Record Enable";
-      case MENU_ENUM_LABEL_VALUE_RECORD_PATH:
-         return "Output File";
-      case MENU_ENUM_LABEL_VALUE_RECORD_USE_OUTPUT_DIRECTORY:
-         return "Use Output Dir";
-      case MENU_ENUM_LABEL_VALUE_RECORD_CONFIG:
-         return "Record Config";
-      case MENU_ENUM_LABEL_VALUE_CONFIG:
-         return "Config";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_POST_FILTER_RECORD:
-         return "Post filter record Enable";
-      case MENU_ENUM_LABEL_VALUE_CORE_ASSETS_DIRECTORY:
-         return "Downloads Dir";
-      case MENU_ENUM_LABEL_VALUE_ASSETS_DIRECTORY:
-         return "Assets Dir";
-      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPERS_DIRECTORY:
-         return "Dynamic Wallpapers Dir";
-      case MENU_ENUM_LABEL_VALUE_THUMBNAILS_DIRECTORY:
-         return "Thumbnails Dir";
-      case MENU_ENUM_LABEL_VALUE_RGUI_BROWSER_DIRECTORY:
-         return "File Browser Dir";
-      case MENU_ENUM_LABEL_VALUE_RGUI_CONFIG_DIRECTORY:
-         return "Config Dir";
-      case MENU_ENUM_LABEL_VALUE_LIBRETRO_INFO_PATH:
-         return "Core Info Dir";
-      case MENU_ENUM_LABEL_VALUE_LIBRETRO_DIR_PATH:
-         return "Core Dir";
-      case MENU_ENUM_LABEL_VALUE_CURSOR_DIRECTORY:
-         return "Cursor Dir";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_DATABASE_DIRECTORY:
-         return "Content Database Dir";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_DIRECTORY:
-         return "System/BIOS Dir";
-      case MENU_ENUM_LABEL_VALUE_CHEAT_DATABASE_PATH:
-         return "Cheat File Dir";
-      case MENU_ENUM_LABEL_VALUE_CACHE_DIRECTORY:
-         return "Cache Dir";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_FILTER_DIR:
-         return "Audio Filter Dir";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_DIR:
-         return "Video Shader Dir";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_DIR:
-         return "Video Filter Dir";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_DIRECTORY:
-         return "Overlay Dir";
-      case MENU_ENUM_LABEL_VALUE_OSK_OVERLAY_DIRECTORY:
-         return "OSK Overlay Dir";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT:
-         return "Netplay P2 Uses C1";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE:
-         return "Netplay Spectator Enable";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS:
-         return "Server Address";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT:
-         return "Netplay TCP/UDP Port";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE:
-         return "Netplay Enable";
-      case MENU_ENUM_LABEL_VALUE_SSH_ENABLE:
-         return "SSH Enable";
-      case MENU_ENUM_LABEL_VALUE_SAMBA_ENABLE:
-         return "SAMBA Enable";
-      case MENU_ENUM_LABEL_VALUE_BLUETOOTH_ENABLE:
-         return "Bluetooth Enable";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_DELAY_FRAMES:
-         return "Netplay Delay Frames";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_CHECK_FRAMES:
-         return "Netplay Check Frames";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_MODE:
-         return "Netplay Client Enable";
-      case MENU_ENUM_LABEL_VALUE_RGUI_SHOW_START_SCREEN:
-         return "Show Start Screen";
-      case MENU_ENUM_LABEL_VALUE_TITLE_COLOR:
-         return "Menu title color";
-      case MENU_ENUM_LABEL_VALUE_ENTRY_HOVER_COLOR:
-         return "Menu entry hover color";
-      case MENU_ENUM_LABEL_VALUE_TIMEDATE_ENABLE:
-         return "Display time / date";
-      case MENU_ENUM_LABEL_VALUE_THREADED_DATA_RUNLOOP_ENABLE:
-         return "Threaded data runloop";
-      case MENU_ENUM_LABEL_VALUE_ENTRY_NORMAL_COLOR:
-         return "Menu entry normal color";
-      case MENU_ENUM_LABEL_VALUE_SHOW_ADVANCED_SETTINGS:
-         return "Show Advanced Settings";
-      case MENU_ENUM_LABEL_VALUE_MOUSE_ENABLE:
-         return "Mouse Support";
-      case MENU_ENUM_LABEL_VALUE_POINTER_ENABLE:
-         return "Touch Support";
-      case MENU_ENUM_LABEL_VALUE_CORE_ENABLE:
-         return "Display core name";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE_HOST:
-         return "Start hosting";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE_CLIENT:
-         return "Connect to Netplay host";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_DISCONNECT:
-         return "Disconnect";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_SETTINGS:
-         return "Netplay settings";
-      case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_ENABLE:
-         return "DPI Override Enable";
-      case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_VALUE:
-         return "DPI Override";
-      case MENU_ENUM_LABEL_VALUE_XMB_SCALE_FACTOR:
-         return "Menu Scale Factor";
-      case MENU_ENUM_LABEL_VALUE_XMB_ALPHA_FACTOR:
-         return "Menu Alpha Factor";
-      case MENU_ENUM_LABEL_VALUE_XMB_FONT:
-         return "Menu Font";
-      case MENU_ENUM_LABEL_VALUE_XMB_THEME:
-         return "Menu Icon Theme";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME:
-         return "Menu Color Theme";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME:
-         return "Menu Color Theme";
-      case MENU_ENUM_LABEL_VALUE_XMB_SHADOWS_ENABLE:
-         return "Icon Shadows Enable";
-      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_SETTINGS:
-         return "Show Settings Tab";
-      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_IMAGES:
-         return "Show Images Tab";
-      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_MUSIC:
-         return "Show Music Tab";
-      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_VIDEO:
-         return "Show Video Tab";
-      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_HISTORY:
-         return "Show History Tab";
-      case MENU_ENUM_LABEL_VALUE_XMB_RIBBON_ENABLE:
-         return "Menu Shader Pipeline";
-      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_MONOCHROME:
-         return "Monochrome";
-      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_MONOCHROME_JAGGED:
-         return "Monochrome Jagged";
-      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_FLATUI:
-         return "FlatUI";
-      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_RETROACTIVE:
-         return "RetroActive";
-      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_NEOACTIVE:
-         return "NeoActive";
-      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_PIXEL:
-         return "Pixel";
-      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_CUSTOM:
-         return "Custom";
-      case MENU_ENUM_LABEL_VALUE_SUSPEND_SCREENSAVER_ENABLE:
-         return "Suspend Screensaver";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_DISABLE_COMPOSITION:
-         return "Disable Desktop Composition";
-      case MENU_ENUM_LABEL_VALUE_PAUSE_NONACTIVE:
-         return "Don't run in background";
-      case MENU_ENUM_LABEL_VALUE_UI_COMPANION_START_ON_BOOT:
-         return "UI Companion Start On Boot";
-      case MENU_ENUM_LABEL_VALUE_UI_COMPANION_ENABLE:
-         return "UI Companion Enable";
-      case MENU_ENUM_LABEL_VALUE_UI_MENUBAR_ENABLE:
-         return "Menubar";
       case MENU_ENUM_LABEL_VALUE_ARCHIVE_MODE:
          return "Archive File Association Action";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_ENABLE:
-         return "Network Commands";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_PORT:
-         return "Network Command Port";
-      case MENU_ENUM_LABEL_VALUE_HISTORY_LIST_ENABLE:
-         return "History List Enable";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_HISTORY_SIZE:
-         return "History List Size";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE_AUTO:
-         return "Estimated Monitor Framerate";
-      case MENU_ENUM_LABEL_VALUE_DUMMY_ON_CORE_SHUTDOWN:
-         return "Dummy On Core Shutdown";
-      case MENU_ENUM_LABEL_VALUE_CORE_SET_SUPPORTS_NO_CONTENT_ENABLE:
-         return "Automatically start a core";
-      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_ENABLE:
-         return "Limit Maximum Run Speed";
-      case MENU_ENUM_LABEL_VALUE_FASTFORWARD_RATIO:
-         return "Maximum Run Speed";
+      case MENU_ENUM_LABEL_VALUE_ASK_ARCHIVE:
+         return "Ask";
+      case MENU_ENUM_LABEL_VALUE_ASSETS_DIRECTORY:
+         return "Assets Dir";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_BLOCK_FRAMES:
+         return "Block Frames";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_DEVICE:
+         return "Audio Device";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_DRIVER:
+         return "Audio Driver";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_DSP_PLUGIN:
+         return "Audio DSP Plugin";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_ENABLE:
+         return "Audio Enable";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_FILTER_DIR:
+         return "Audio Filter Dir";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_LATENCY:
+         return "Audio Latency (ms)";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_MAX_TIMING_SKEW:
+         return "Audio Maximum Timing Skew";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_MUTE:
+         return "Audio Mute";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_OUTPUT_RATE:
+         return "Audio Output Rate (KHz)";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_RATE_CONTROL_DELTA:
+         return "Audio Rate Control Delta";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_RESAMPLER_DRIVER:
+         return "Audio Resampler Driver";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_SETTINGS:
+         return "Audio";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_SYNC:
+         return "Audio Sync Enable";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_VOLUME:
+         return "Audio Volume Level (dB)";
+      case MENU_ENUM_LABEL_VALUE_AUTOSAVE_INTERVAL:
+         return "SaveRAM Autosave Interval";
+      case MENU_ENUM_LABEL_VALUE_AUTO_OVERRIDES_ENABLE:
+         return "Load Override Files Automatically";
       case MENU_ENUM_LABEL_VALUE_AUTO_REMAPS_ENABLE:
          return "Load Remap Files Automatically";
       case MENU_ENUM_LABEL_VALUE_AUTO_SHADERS_ENABLE:
          return "Load Shader Presets Automatically";
-      case MENU_ENUM_LABEL_VALUE_SLOWMOTION_RATIO:
-         return "Slow-Motion Ratio";
-      case MENU_ENUM_LABEL_VALUE_CORE_SPECIFIC_CONFIG:
-         return "Configuration Per-Core";
-      case MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS:
-         return "Load Content-specific core options automatically";
-      case MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS_CREATE:
-         return "Create game-options file";
-      case MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS_IN_USE:
-         return "Game-options file";
-      case MENU_ENUM_LABEL_VALUE_AUTO_OVERRIDES_ENABLE:
-         return "Load Override Files Automatically";
-      case MENU_ENUM_LABEL_VALUE_CONFIG_SAVE_ON_EXIT:
-         return "Save Configuration On Exit";
-      case MENU_ENUM_LABEL_VALUE_CONFIRM_ON_EXIT:
-         return "Ask For Confirmation On Exit";
-      case MENU_ENUM_LABEL_VALUE_SHOW_HIDDEN_FILES:
-         return "Show Hidden Files and Folders";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SMOOTH:
-         return "HW Bilinear Filtering";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_GAMMA:
-         return "Video Gamma";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ALLOW_ROTATE:
-         return "Allow rotation";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC:
-         return "Hard GPU Sync";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SWAP_INTERVAL:
-         return "VSync Swap Interval";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VSYNC:
-         return "VSync";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_THREADED:
-         return "Threaded Video";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ROTATION:
-         return "Rotation";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_SCREENSHOT:
-         return "GPU Screenshot Enable";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_CROP_OVERSCAN:
-         return "Crop Overscan (Reload)";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_INDEX:
-         return "Aspect Ratio Index";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_AUTO:
-         return "Auto Aspect Ratio";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_ASPECT:
-         return "Force aspect ratio";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE:
-         return "Refresh Rate";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_SRGB_DISABLE:
-         return "Force-disable sRGB FBO";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_WINDOWED_FULLSCREEN:
-         return "Windowed Fullscreen Mode";
-      case MENU_ENUM_LABEL_VALUE_PAL60_ENABLE:
-         return "Use PAL60 Mode";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VFILTER:
-         return "Deflicker";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VI_WIDTH:
-         return "Set VI Screen Width";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_BLACK_FRAME_INSERTION:
-         return "Black Frame Insertion";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC_FRAMES:
-         return "Hard GPU Sync Frames";
-      case MENU_ENUM_LABEL_VALUE_SORT_SAVEFILES_ENABLE:
-         return "Sort Saves In Folders";
-      case MENU_ENUM_LABEL_VALUE_SORT_SAVESTATES_ENABLE:
-         return "Sort Savestates In Folders";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FULLSCREEN:
-         return "Use Fullscreen Mode";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE:
-         return "Windowed Scale";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE_INTEGER:
-         return "Integer Scale";
-      case MENU_ENUM_LABEL_VALUE_PERFCNT_ENABLE:
-         return "Performance Counters";
-      case MENU_ENUM_LABEL_VALUE_LIBRETRO_LOG_LEVEL:
-         return "Core Logging Level";
-      case MENU_ENUM_LABEL_VALUE_LOG_VERBOSITY:
-         return "Logging Verbosity";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_LOAD:
-         return "Auto Load State";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_INDEX:
-         return "Save State Auto Index";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_SAVE:
-         return "Auto Save State";
-      case MENU_ENUM_LABEL_VALUE_AUTOSAVE_INTERVAL:
-         return "SaveRAM Autosave Interval";
+      case MENU_ENUM_LABEL_VALUE_BACK:
+         return "BACK";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_BACK:
+         return "Back";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_CONFIRM:
+         return "Confirm";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_INFO:
+         return "Info";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_QUIT:
+         return "Quit";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_SCROLL_DOWN:
+         return "Scroll Down";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_SCROLL_UP:
+         return "Scroll Up";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_START:
+         return "Start";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_TOGGLE_KEYBOARD:
+         return "Toggle Keyboard";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_TOGGLE_MENU:
+         return "Toggle Menu";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS:
+         return "Basic menu controls";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_BACK:
+         return "Back";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_CONFIRM:
+         return "Confirm/OK";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_INFO:
+         return "Info";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_QUIT:
+         return "Quit";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_SCROLL_UP:
+         return "Scroll Up";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_START:
+         return "Defaults";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_TOGGLE_KEYBOARD:
+         return "Toggle Keyboard";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_TOGGLE_MENU:
+         return "Toggle Menu";
       case MENU_ENUM_LABEL_VALUE_BLOCK_SRAM_OVERWRITE:
          return "Don't overwrite SaveRAM on loading savestate";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHARED_CONTEXT:
-         return "HW Shared Context Enable";
-      case MENU_ENUM_LABEL_VALUE_RESTART_RETROARCH:
-         return "Restart RetroArch";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_NICKNAME:
-         return "Username";
-      case MENU_ENUM_LABEL_VALUE_USER_LANGUAGE:
-         return "Language";
+      case MENU_ENUM_LABEL_VALUE_BLUETOOTH_ENABLE:
+         return "Bluetooth Enable";
+      case MENU_ENUM_LABEL_VALUE_BUILDBOT_ASSETS_URL:
+         return "Buildbot Assets URL";
+      case MENU_ENUM_LABEL_VALUE_CACHE_DIRECTORY:
+         return "Cache Dir";
       case MENU_ENUM_LABEL_VALUE_CAMERA_ALLOW:
          return "Allow Camera";
-      case MENU_ENUM_LABEL_VALUE_LOCATION_ALLOW:
-         return "Allow Location";
-      case MENU_ENUM_LABEL_VALUE_PAUSE_LIBRETRO:
-         return "Pause when menu activated";
-      case MENU_ENUM_LABEL_VALUE_INPUT_OSK_OVERLAY_ENABLE:
-         return "Display Keyboard Overlay";
-      case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_ENABLE:
-         return "Display Overlay";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MONITOR_INDEX:
-         return "Monitor Index";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FRAME_DELAY:
-         return "Frame Delay";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DUTY_CYCLE:
-         return "Duty Cycle";
-      case MENU_ENUM_LABEL_VALUE_INPUT_TURBO_PERIOD:
-         return "Turbo Period";
-      case MENU_ENUM_LABEL_VALUE_INPUT_BIND_TIMEOUT:
-         return "Bind Timeout";
-      case MENU_ENUM_LABEL_VALUE_INPUT_AXIS_THRESHOLD:
-         return "Input Axis Threshold";
-      case MENU_ENUM_LABEL_VALUE_INPUT_REMAP_BINDS_ENABLE:
-         return "Remap Binds Enable";
-      case MENU_ENUM_LABEL_VALUE_INPUT_MAX_USERS:
-         return "Max Users";
-      case MENU_ENUM_LABEL_VALUE_INPUT_AUTODETECT_ENABLE:
-         return "Autoconfig Enable";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_OUTPUT_RATE:
-         return "Audio Output Rate (KHz)";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_MAX_TIMING_SKEW:
-         return "Audio Maximum Timing Skew";
-      case MENU_ENUM_LABEL_VALUE_CHEAT_NUM_PASSES:
-         return "Cheat Passes";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_CORE:
-         return "Save Core Remap File";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_GAME:
-         return "Save Game Remap File";
+      case MENU_ENUM_LABEL_VALUE_CAMERA_DRIVER:
+         return "Camera Driver";
+      case MENU_ENUM_LABEL_VALUE_CHEAT:
+         return "Cheat";
       case MENU_ENUM_LABEL_VALUE_CHEAT_APPLY_CHANGES:
          return "Apply Cheat Changes";
-      case MENU_ENUM_LABEL_VALUE_SHADER_APPLY_CHANGES:
-         return "Apply Shader Changes";
-      case MENU_ENUM_LABEL_VALUE_REWIND_ENABLE:
-         return "Rewind Enable";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_COLLECTION_LIST:
-         return "Collections";
-      case MENU_ENUM_LABEL_VALUE_DETECT_CORE_LIST:
-         return "Select File And Detect Core";
-      case MENU_ENUM_LABEL_VALUE_DOWNLOADED_FILE_DETECT_CORE_LIST:
-         return "Downloads Dir";
-      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_HISTORY:
-         return "Load Recent";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_ENABLE:
-         return "Audio Enable";
-      case MENU_ENUM_LABEL_VALUE_FPS_SHOW:
-         return "Display Framerate";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_MUTE:
-         return "Audio Mute";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_VOLUME:
-         return "Audio Volume Level (dB)";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_SYNC:
-         return "Audio Sync Enable";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_RATE_CONTROL_DELTA:
-         return "Audio Rate Control Delta";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_NUM_PASSES:
-         return "Shader Passes";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_SHA1:
-         return "SHA1";
-      case MENU_ENUM_LABEL_VALUE_CONFIGURATIONS:
-         return "Load Configuration";
-      case MENU_ENUM_LABEL_VALUE_REWIND_GRANULARITY:
-         return "Rewind Granularity";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_LOAD:
-         return "Load Remap File";
-      case MENU_ENUM_LABEL_VALUE_CUSTOM_RATIO:
-         return "Custom Ratio";
-      case MENU_ENUM_LABEL_VALUE_USE_THIS_DIRECTORY:
-         return "<Use this directory>";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_START_CONTENT:
-         return "Start Content";
-      case MENU_ENUM_LABEL_VALUE_DISK_OPTIONS:
-         return "Disk Control";
-      case MENU_ENUM_LABEL_VALUE_CORE_OPTIONS:
-         return "Options";
-      case MENU_ENUM_LABEL_VALUE_CORE_CHEAT_OPTIONS:
-         return "Cheats";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE:
-         return "Remap File";
+      case MENU_ENUM_LABEL_VALUE_CHEAT_DATABASE_PATH:
+         return "Cheat File Dir";
       case MENU_ENUM_LABEL_VALUE_CHEAT_FILE:
          return "Cheat File";
       case MENU_ENUM_LABEL_VALUE_CHEAT_FILE_LOAD:
          return "Load Cheat File";
       case MENU_ENUM_LABEL_VALUE_CHEAT_FILE_SAVE_AS:
          return "Save Cheat File As";
-      case MENU_ENUM_LABEL_VALUE_CORE_COUNTERS:
-         return "Core Counters";
-      case MENU_ENUM_LABEL_VALUE_TAKE_SCREENSHOT:
-         return "Take Screenshot";
-      case MENU_ENUM_LABEL_VALUE_DELETE_ENTRY:
-         return "Remove";
-      case MENU_ENUM_LABEL_VALUE_RESUME:
-         return "Resume";
-      case MENU_ENUM_LABEL_VALUE_DISK_INDEX:
-         return "Disk Index";
-      case MENU_ENUM_LABEL_VALUE_FRONTEND_COUNTERS:
-         return "Frontend Counters";
-      case MENU_ENUM_LABEL_VALUE_DISK_IMAGE_APPEND:
-         return "Disk Image Append";
-      case MENU_ENUM_LABEL_VALUE_DISK_CYCLE_TRAY_STATUS:
-         return "Disk Cycle Tray Status";
-      case MENU_ENUM_LABEL_VALUE_NO_PLAYLIST_ENTRIES_AVAILABLE:
-         return "No playlist entries available.";
-      case MENU_ENUM_LABEL_VALUE_NO_HISTORY_AVAILABLE:
-         return "No history available.";
-      case MENU_ENUM_LABEL_VALUE_NO_CORE_INFORMATION_AVAILABLE:
-         return "No core information available.";
-      case MENU_ENUM_LABEL_VALUE_NO_CORE_OPTIONS_AVAILABLE:
-         return "No core options available.";
-      case MENU_ENUM_LABEL_VALUE_NO_CORES_AVAILABLE:
-         return "No cores available.";
-      case MENU_ENUM_LABEL_VALUE_NO_CORE:
-         return "No Core";
-      case MENU_ENUM_LABEL_VALUE_DATABASE_MANAGER:
-         return "Database Manager";
-      case MENU_ENUM_LABEL_VALUE_CURSOR_MANAGER:
-         return "Cursor Manager";
-      case MENU_ENUM_LABEL_VALUE_MAIN_MENU:
-         return "Main Menu";
-      case MENU_ENUM_LABEL_VALUE_SETTINGS:
-         return "Settings";
-      case MENU_ENUM_LABEL_VALUE_QUIT_RETROARCH:
-         return "Quit RetroArch";
-      case MENU_ENUM_LABEL_VALUE_SHUTDOWN:
-         return "Shutdown";
-      case MENU_ENUM_LABEL_VALUE_REBOOT:
-         return "Reboot";
-      case MENU_ENUM_LABEL_VALUE_HELP:
-         return "help";
-      case MENU_ENUM_LABEL_VALUE_SAVE_NEW_CONFIG:
-         return "Save New Config";
-      case MENU_ENUM_LABEL_VALUE_RESTART_CONTENT:
-         return "Restart";
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_LIST:
-         return "Core Updater";
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_BUILDBOT_URL:
-         return "Buildbot Cores URL";
-      case MENU_ENUM_LABEL_VALUE_BUILDBOT_ASSETS_URL:
-         return "Buildbot Assets URL";
-      case MENU_ENUM_LABEL_VALUE_NAVIGATION_WRAPAROUND:
-         return "Navigation Wrap-Around";
-      case MENU_ENUM_LABEL_VALUE_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
-         return "Filter unknown extensions";
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
-         return "Automatically extract downloaded archive";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFORMATION:
-         return "System Information";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_INFORMATION:
-         return "Network Information";
-      case MENU_ENUM_LABEL_VALUE_ACHIEVEMENT_LIST:
-         return "Achievement List";
-      case MENU_ENUM_LABEL_VALUE_ONLINE_UPDATER:
-         return "Online Updater";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY:
-         return "Netplay";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFORMATION:
-         return "Core Information";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NOT_FOUND:
-         return "Directory not found.";
-      case MENU_ENUM_LABEL_VALUE_NO_ITEMS:
-         return "No items.";
-      case MENU_ENUM_LABEL_VALUE_NO_PLAYLISTS:
-         return "No playlists.";
-      case MENU_ENUM_LABEL_VALUE_CORE_LIST:
-         return "Load Core";
-      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT:
-         return "Select File";
+      case MENU_ENUM_LABEL_VALUE_CHEAT_NUM_PASSES:
+         return "Cheat Passes";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_DESCRIPTION:
+         return "Description";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_HARDCORE_MODE_ENABLE:
+         return "Hardcore Mode";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_LOCKED_ACHIEVEMENTS:
+         return "Locked Achievements:";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_LOCKED_ENTRY:
+         return "Locked";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_SETTINGS:
+         return "Retro Achievements";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_TEST_UNOFFICIAL:
+         return "Test unofficial";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_UNLOCKED_ACHIEVEMENTS:
+         return "Unlocked Achievements:";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_UNLOCKED_ENTRY:
+         return "Unlocked";
       case MENU_ENUM_LABEL_VALUE_CLOSE_CONTENT:
          return "Close";
-      case MENU_ENUM_LABEL_VALUE_MANAGEMENT:
-         return "Database Settings";
-      case MENU_ENUM_LABEL_VALUE_SAVE_STATE:
-         return "Save State";
-      case MENU_ENUM_LABEL_VALUE_LOAD_STATE:
-         return "Load State";
-      case MENU_ENUM_LABEL_VALUE_UNDO_LOAD_STATE:
-         return "Undo Load State";
-      case MENU_ENUM_LABEL_VALUE_UNDO_SAVE_STATE:
-         return "Undo Save State";
-      case MSG_UNDID_LOAD_STATE:
-         return "Undid load state.";
-      case MENU_ENUM_LABEL_VALUE_RESUME_CONTENT:
-         return "Resume";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DRIVER:
-         return "Input Driver";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_DRIVER:
-         return "Audio Driver";
-      case MENU_ENUM_LABEL_VALUE_JOYPAD_DRIVER:
-         return "Joypad Driver";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_RESAMPLER_DRIVER:
-         return "Audio Resampler Driver";
-      case MENU_ENUM_LABEL_VALUE_RECORD_DRIVER:
-         return "Record Driver";
-      case MENU_ENUM_LABEL_VALUE_MENU_DRIVER:
-         return "Menu Driver";
-      case MENU_ENUM_LABEL_VALUE_CAMERA_DRIVER:
-         return "Camera Driver";
-      case MENU_ENUM_LABEL_VALUE_WIFI_DRIVER:
-         return "Wi-Fi Driver";
-      case MENU_ENUM_LABEL_VALUE_LOCATION_DRIVER:
-         return "Location Driver";
-      case MENU_ENUM_LABEL_VALUE_UNABLE_TO_READ_COMPRESSED_FILE:
-         return "Unable to read compressed file.";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_SCALE:
-         return "Overlay Scale";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_PRESET:
-         return "Overlay Preset";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_LATENCY:
-         return "Audio Latency (ms)";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_DEVICE:
-         return "Audio Device";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY:
-         return "Overlay";
-      case MENU_ENUM_LABEL_VALUE_KEYBOARD_OVERLAY_PRESET:
-         return "Keyboard Overlay Preset";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_OPACITY:
-         return "Overlay Opacity";
-      case MENU_ENUM_LABEL_VALUE_MENU_WALLPAPER:
-         return "Menu Wallpaper";
-      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPER:
-         return "Dynamic Wallpaper";
-      case MENU_ENUM_LABEL_VALUE_THUMBNAILS:
-         return "Thumbnails";
-      case MENU_ENUM_LABEL_VALUE_CORE_INPUT_REMAPPING_OPTIONS:
-         return "Controls";
-      case MENU_ENUM_LABEL_VALUE_SHADER_OPTIONS:
-         return "Shaders";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PARAMETERS:
-         return "Preview Shader Parameters";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_PARAMETERS:
-         return "Menu Shader Parameters";
-      case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_TWO:
-         return "Shader Preset";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_AS:
-         return "Save Shader Preset As";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_CORE:
-         return "Save Core Preset";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_GAME:
-         return "Save Game Preset";
-      case MENU_ENUM_LABEL_VALUE_NO_SHADER_PARAMETERS:
-         return "No shader parameters.";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET:
-         return "Load Shader Preset";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER:
-         return "Video Filter";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_DSP_PLUGIN:
-         return "Audio DSP Plugin";
-      case MENU_ENUM_LABEL_VALUE_SECONDS:
-         return "seconds";
-      case MENU_ENUM_LABEL_VALUE_OFF:
-         return "OFF";
-      case MENU_ENUM_LABEL_VALUE_ON:
-         return "ON";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_ASSETS:
-         return "Update Assets";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_LAKKA:
-         return "Update Lakka";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_CHEATS:
-         return "Update Cheats";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_AUTOCONFIG_PROFILES:
-         return "Update Autoconfig Profiles";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_DATABASES:
-         return "Update Databases";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_OVERLAYS:
-         return "Update Overlays";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_CG_SHADERS:
-         return "Update Cg Shaders";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_GLSL_SHADERS:
-         return "Update GLSL Shaders";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_SLANG_SHADERS:
-         return "Update Slang Shaders";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NAME:
-         return "Core name";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_LABEL:
-         return "Core label";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_NAME:
-         return "System name";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_MANUFACTURER:
-         return "System manufacturer";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CATEGORIES:
-         return "Categories";
+      case MENU_ENUM_LABEL_VALUE_CONFIG:
+         return "Config";
+      case MENU_ENUM_LABEL_VALUE_CONFIGURATIONS:
+         return "Load Configuration";
+      case MENU_ENUM_LABEL_VALUE_CONFIGURATION_SETTINGS:
+         return "Configuration";
+      case MENU_ENUM_LABEL_VALUE_CONFIG_SAVE_ON_EXIT:
+         return "Save Configuration On Exit";
+      case MENU_ENUM_LABEL_VALUE_CONFIRM_ON_EXIT:
+         return "Ask For Confirmation On Exit";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_COLLECTION_LIST:
+         return "Collections";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_DATABASE_DIRECTORY:
+         return "Content Database Dir";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_DIR:
+         return "Content Dir";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_HISTORY_SIZE:
+         return "History List Size";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_SETTINGS:
+         return "Quick Menu";
+      case MENU_ENUM_LABEL_VALUE_CORE_ASSETS_DIR:
+         return "Core Assets Dir";
+      case MENU_ENUM_LABEL_VALUE_CORE_ASSETS_DIRECTORY:
+         return "Downloads Dir";
+      case MENU_ENUM_LABEL_VALUE_CORE_CHEAT_OPTIONS:
+         return "Cheats";
+      case MENU_ENUM_LABEL_VALUE_CORE_COUNTERS:
+         return "Core Counters";
+      case MENU_ENUM_LABEL_VALUE_CORE_ENABLE:
+         return "Display core name";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFORMATION:
+         return "Core Information";
       case MENU_ENUM_LABEL_VALUE_CORE_INFO_AUTHORS:
          return "Authors";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_PERMISSIONS:
-         return "Permissions";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_LICENSES:
-         return "License(s)";
-      case MENU_ENUM_LABEL_VALUE_SUPPORTED_CORES:
-         return "Supported cores";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SUPPORTED_EXTENSIONS:
-         return "Supported extensions";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_FIRMWARE:
-         return "Firmware";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CATEGORIES:
+         return "Categories";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_LABEL:
+         return "Core label";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NAME:
+         return "Core name";
       case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NOTES:
          return "Core notes";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_BUILD_DATE:
-         return "Build date";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GIT_VERSION:
-         return "Git version";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CPU_FEATURES:
-         return "CPU Features";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_IDENTIFIER:
-         return "Frontend identifier";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_NAME:
-         return "Frontend name";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_OS:
-         return "Frontend OS";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RETRORATING_LEVEL:
-         return "RetroRating level";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE:
-         return "Power source";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_NO_SOURCE:
-         return "No source";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGING:
-         return "Charging";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGED:
-         return "Charged";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_DISCHARGING:
-         return "Discharging";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VIDEO_CONTEXT_DRIVER:
-         return "Video context driver";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_WIDTH:
-         return "Display metric width (mm)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_HEIGHT:
-         return "Display metric height (mm)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_DPI:
-         return "Display metric DPI";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBRETRODB_SUPPORT:
-         return "LibretroDB support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OVERLAY_SUPPORT:
-         return "Overlay support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COMMAND_IFACE_SUPPORT:
-         return "Command interface support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETWORK_REMOTE_SUPPORT:
-         return "Network Gamepad support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETWORK_COMMAND_IFACE_SUPPORT:
-         return "Network Command interface support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COCOA_SUPPORT:
-         return "Cocoa support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RPNG_SUPPORT:
-         return "PNG support (RPNG)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RJPEG_SUPPORT:
-         return "JPEG support (RJPEG)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RBMP_SUPPORT:
-         return "BMP support (RBMP)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RTGA_SUPPORT:
-         return "TGA support (RTGA)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_SUPPORT:
-         return "SDL1.2 support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL2_SUPPORT:
-         return "SDL2 support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VULKAN_SUPPORT:
-         return "Vulkan support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGL_SUPPORT:
-         return "OpenGL support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGLES_SUPPORT:
-         return "OpenGL ES support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_THREADING_SUPPORT:
-         return "Threading support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_KMS_SUPPORT:
-         return "KMS/EGL support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_UDEV_SUPPORT:
-         return "Udev support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENVG_SUPPORT:
-         return "OpenVG support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_EGL_SUPPORT:
-         return "EGL support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_X11_SUPPORT:
-         return "X11 support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_WAYLAND_SUPPORT:
-         return "Wayland support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XVIDEO_SUPPORT:
-         return "XVideo support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ALSA_SUPPORT:
-         return "ALSA support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OSS_SUPPORT:
-         return "OSS support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENAL_SUPPORT:
-         return "OpenAL support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENSL_SUPPORT:
-         return "OpenSL support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RSOUND_SUPPORT:
-         return "RSound support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ROARAUDIO_SUPPORT:
-         return "RoarAudio support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_JACK_SUPPORT:
-         return "JACK support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PULSEAUDIO_SUPPORT:
-         return "PulseAudio support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DSOUND_SUPPORT:
-         return "DirectSound support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XAUDIO2_SUPPORT:
-         return "XAudio2 support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ZLIB_SUPPORT:
-         return "Zlib support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_7ZIP_SUPPORT:
-         return "7zip support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DYLIB_SUPPORT:
-         return "Dynamic library support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CG_SUPPORT:
-         return "Cg support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GLSL_SUPPORT:
-         return "GLSL support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SLANG_SUPPORT:
-         return "Slang support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_HLSL_SUPPORT:
-         return "HLSL support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBXML2_SUPPORT:
-         return "libxml2 XML parsing support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_IMAGE_SUPPORT:
-         return "SDL image support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FBO_SUPPORT:
-         return "OpenGL/Direct3D render-to-texture (multi-pass shaders) support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DYNAMIC_SUPPORT:
-         return "Dynamic run-time loading of libretro library";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FFMPEG_SUPPORT:
-         return "FFmpeg support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CORETEXT_SUPPORT:
-         return "CoreText support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FREETYPE_SUPPORT:
-         return "FreeType support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETPLAY_SUPPORT:
-         return "Netplay (peer-to-peer) support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PYTHON_SUPPORT:
-         return "Python (script support in shaders) support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_V4L2_SUPPORT:
-         return "Video4Linux2 support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBUSB_SUPPORT:
-         return "Libusb support";
-      case MENU_ENUM_LABEL_VALUE_YES:
-         return "Yes";
-      case MENU_ENUM_LABEL_VALUE_NO:
-         return "No";
-      case MENU_ENUM_LABEL_VALUE_BACK:
-         return "BACK";
-      case MSG_FAILED_TO_BIND_SOCKET:
-         return "Failed to bind socket.";
-      case MENU_ENUM_LABEL_VALUE_SCREEN_RESOLUTION:
-         return "Screen Resolution";
-      case MENU_ENUM_LABEL_VALUE_DISABLED:
-         return "Disabled";
-      case MENU_ENUM_LABEL_VALUE_PORT:
-         return "Port";
-      case MENU_ENUM_LABEL_VALUE_NONE:
-         return "None";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DEVELOPER:
-         return "Developer";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_PUBLISHER:
-         return "Publisher";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DESCRIPTION:
-         return "Description";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_GENRE:
-         return "Genre";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_NAME:
-         return "Name";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ORIGIN:
-         return "Origin";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_FRANCHISE:
-         return "Franchise";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_MONTH:
-         return "Releasedate Month";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_YEAR:
-         return "Releasedate Year";
-      case MENU_ENUM_LABEL_VALUE_TRUE:
-         return "True";
-      case MENU_ENUM_LABEL_VALUE_FALSE:
-         return "False";
-      case MENU_ENUM_LABEL_VALUE_MISSING:
-         return "Missing";
-      case MENU_ENUM_LABEL_VALUE_PRESENT:
-         return "Present";
-      case MENU_ENUM_LABEL_VALUE_OPTIONAL:
-         return "Optional";
-      case MENU_ENUM_LABEL_VALUE_REQUIRED:
-         return "Required";
-      case MENU_ENUM_LABEL_VALUE_STATUS:
-         return "Status";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_SETTINGS:
-         return "Audio";
-      case MENU_ENUM_LABEL_VALUE_INPUT_SETTINGS:
-         return "Input";
-      case MENU_ENUM_LABEL_VALUE_ONSCREEN_DISPLAY_SETTINGS:
-         return "Onscreen Display";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_SETTINGS:
-         return "Onscreen Overlay";
-      case MENU_ENUM_LABEL_VALUE_ONSCREEN_OVERLAY_SETTINGS:
-         return "Onscreen Overlay";
-      case MENU_ENUM_LABEL_VALUE_MENU_SETTINGS:
-         return "Menu";
-      case MENU_ENUM_LABEL_VALUE_MULTIMEDIA_SETTINGS:
-         return "Multimedia";
-      case MENU_ENUM_LABEL_VALUE_USER_INTERFACE_SETTINGS:
-         return "User Interface";
-      case MENU_ENUM_LABEL_VALUE_MENU_FILE_BROWSER_SETTINGS:
-         return "Menu File Browser";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_FIRMWARE:
+         return "Firmware";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_LICENSES:
+         return "License(s)";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_PERMISSIONS:
+         return "Permissions";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SUPPORTED_EXTENSIONS:
+         return "Supported extensions";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_MANUFACTURER:
+         return "System manufacturer";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_NAME:
+         return "System name";
+      case MENU_ENUM_LABEL_VALUE_CORE_INPUT_REMAPPING_OPTIONS:
+         return "Controls";
+      case MENU_ENUM_LABEL_VALUE_CORE_LIST:
+         return "Load Core";
+      case MENU_ENUM_LABEL_VALUE_CORE_OPTIONS:
+         return "Options";
+      case MENU_ENUM_LABEL_VALUE_CORE_SETTINGS:
+         return "Core";
+      case MENU_ENUM_LABEL_VALUE_CORE_SET_SUPPORTS_NO_CONTENT_ENABLE:
+         return "Automatically start a core";
+      case MENU_ENUM_LABEL_VALUE_CORE_SPECIFIC_CONFIG:
+         return "Configuration Per-Core";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
+         return "Automatically extract downloaded archive";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_BUILDBOT_URL:
+         return "Buildbot Cores URL";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_LIST:
+         return "Core Updater";
       case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_SETTINGS:
          return "Updater";
-      case MENU_ENUM_LABEL_VALUE_UPDATER_SETTINGS:
-         return "Updater";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_SETTINGS:
-         return "Network";
-      case MENU_ENUM_LABEL_VALUE_WIFI_SETTINGS:
-         return "Wi-Fi";
-      case MENU_ENUM_LABEL_VALUE_LAKKA_SERVICES:
-         return "Lakka Services";
-      case MENU_ENUM_LABEL_VALUE_PLAYLIST_SETTINGS:
-         return "Playlists";
-      case MENU_ENUM_LABEL_VALUE_USER_SETTINGS:
-         return "User";
+      case MENU_ENUM_LABEL_VALUE_CPU_ARCHITECTURE:
+         return "CPU Architecture:";
+      case MENU_ENUM_LABEL_VALUE_CPU_CORES:
+         return "CPU Cores:";
+      case MENU_ENUM_LABEL_VALUE_CURSOR_DIRECTORY:
+         return "Cursor Dir";
+      case MENU_ENUM_LABEL_VALUE_CURSOR_MANAGER:
+         return "Cursor Manager";
+      case MENU_ENUM_LABEL_VALUE_CUSTOM_RATIO:
+         return "Custom Ratio";
+      case MENU_ENUM_LABEL_VALUE_DATABASE_MANAGER:
+         return "Database Manager";
+      case MENU_ENUM_LABEL_VALUE_DATABASE_SELECTION:
+         return "Database Selection";
+      case MENU_ENUM_LABEL_VALUE_DELETE_ENTRY:
+         return "Remove";
+      case MENU_ENUM_LABEL_VALUE_DETECT_CORE_LIST:
+         return "Select File And Detect Core";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_CONTENT:
+         return "<Content dir>";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_DEFAULT:
+         return "<Default>";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NONE:
+         return "<None>";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NOT_FOUND:
+         return "Directory not found.";
       case MENU_ENUM_LABEL_VALUE_DIRECTORY_SETTINGS:
          return "Directory";
-      case MENU_ENUM_LABEL_VALUE_RECORDING_SETTINGS:
-         return "Recording";
-      case MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE:
-         return "No information is available.";
-      case MENU_ENUM_LABEL_VALUE_INPUT_USER_BINDS:
-         return "Input User %u Binds";
-      case MENU_ENUM_LABEL_VALUE_LANG_ENGLISH:
-         return "English";
-      case MENU_ENUM_LABEL_VALUE_LANG_JAPANESE:
-         return "Japanese";
-      case MENU_ENUM_LABEL_VALUE_LANG_FRENCH:
-         return "French";
-      case MENU_ENUM_LABEL_VALUE_LANG_SPANISH:
-         return "Spanish";
-      case MENU_ENUM_LABEL_VALUE_LANG_GERMAN:
-         return "German";
-      case MENU_ENUM_LABEL_VALUE_LANG_ITALIAN:
-         return "Italian";
-      case MENU_ENUM_LABEL_VALUE_LANG_DUTCH:
-         return "Dutch";
-      case MENU_ENUM_LABEL_VALUE_LANG_PORTUGUESE:
-         return "Portuguese";
-      case MENU_ENUM_LABEL_VALUE_LANG_RUSSIAN:
-         return "Russian";
-      case MENU_ENUM_LABEL_VALUE_LANG_KOREAN:
-         return "Korean";
-      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_TRADITIONAL:
-         return "Chinese (Traditional)";
-      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_SIMPLIFIED:
-         return "Chinese (Simplified)";
-      case MENU_ENUM_LABEL_VALUE_LANG_ESPERANTO:
-         return "Esperanto";
-      case MENU_ENUM_LABEL_VALUE_LANG_VIETNAMESE:
-         return "Vietnamese";
-      case MENU_ENUM_LABEL_VALUE_LEFT_ANALOG:
-         return "Left Analog";
-      case MENU_ENUM_LABEL_VALUE_RIGHT_ANALOG:
-         return "Right Analog";
-      case MENU_ENUM_LABEL_VALUE_INPUT_HOTKEY_BINDS:
-         return "Input Hotkey Binds";
-      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_SETTINGS:
-         return "Frame Throttle";
-      case MENU_ENUM_LABEL_VALUE_SEARCH:
-         return "Search:";
-      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_IMAGE_VIEWER:
-         return "Use Builtin Image Viewer";
+      case MENU_ENUM_LABEL_VALUE_DISABLED:
+         return "Disabled";
+      case MENU_ENUM_LABEL_VALUE_DISK_CYCLE_TRAY_STATUS:
+         return "Disk Cycle Tray Status";
+      case MENU_ENUM_LABEL_VALUE_DISK_IMAGE_APPEND:
+         return "Disk Image Append";
+      case MENU_ENUM_LABEL_VALUE_DISK_INDEX:
+         return "Disk Index";
+      case MENU_ENUM_LABEL_VALUE_DISK_OPTIONS:
+         return "Disk Control";
+      case MENU_ENUM_LABEL_VALUE_DONT_CARE:
+         return "Don't care";
+      case MENU_ENUM_LABEL_VALUE_DOWNLOADED_FILE_DETECT_CORE_LIST:
+         return "Downloads Dir";
+      case MENU_ENUM_LABEL_VALUE_DOWNLOAD_CORE:
+         return "Download Core...";
+      case MENU_ENUM_LABEL_VALUE_DOWNLOAD_CORE_CONTENT:
+         return "Content Downloader";
+      case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_ENABLE:
+         return "DPI Override Enable";
+      case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_VALUE:
+         return "DPI Override";
+      case MENU_ENUM_LABEL_VALUE_DRIVER_SETTINGS:
+         return "Driver";
+      case MENU_ENUM_LABEL_VALUE_DUMMY_ON_CORE_SHUTDOWN:
+         return "Dummy On Core Shutdown";
+      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPER:
+         return "Dynamic Wallpaper";
+      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPERS_DIRECTORY:
+         return "Dynamic Wallpapers Dir";
       case MENU_ENUM_LABEL_VALUE_ENABLE:
          return "Enable";
-      case MENU_ENUM_LABEL_VALUE_START_CORE:
-         return "Start Core";
-      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR:
-         return "Poll Type Behavior";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_SCROLL_UP:
-         return "Scroll Up";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_SCROLL_DOWN:
-         return "Scroll Down";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_CONFIRM:
-         return "Confirm";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_BACK:
-         return "Back";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_START:
-         return "Start";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_INFO:
-         return "Info";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_TOGGLE_MENU:
-         return "Toggle Menu";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_QUIT:
-         return "Quit";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_TOGGLE_KEYBOARD:
-         return "Toggle Keyboard";
-      case MENU_ENUM_LABEL_VALUE_THUMBNAIL_MODE_SCREENSHOTS:
-         return "Screenshots";
-      case MENU_ENUM_LABEL_VALUE_THUMBNAIL_MODE_TITLE_SCREENS:
-         return "Title Screens";
-      case MENU_ENUM_LABEL_VALUE_THUMBNAIL_MODE_BOXARTS:
-         return "Boxarts";
-      case MENU_ENUM_LABEL_VALUE_MENU_WALLPAPER_OPACITY:
-         return "Wallpaper opacity";
+      case MENU_ENUM_LABEL_VALUE_ENTRY_HOVER_COLOR:
+         return "Menu entry hover color";
+      case MENU_ENUM_LABEL_VALUE_ENTRY_NORMAL_COLOR:
+         return "Menu entry normal color";
+      case MENU_ENUM_LABEL_VALUE_FALSE:
+         return "False";
+      case MENU_ENUM_LABEL_VALUE_FASTFORWARD_RATIO:
+         return "Maximum Run Speed";
+      case MENU_ENUM_LABEL_VALUE_FPS_SHOW:
+         return "Display Framerate";
+      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_ENABLE:
+         return "Limit Maximum Run Speed";
+      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_SETTINGS:
+         return "Frame Throttle";
+      case MENU_ENUM_LABEL_VALUE_FRONTEND_COUNTERS:
+         return "Frontend Counters";
+      case MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS:
+         return "Load Content-specific core options automatically";
+      case MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS_CREATE:
+         return "Create game-options file";
+      case MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS_IN_USE:
+         return "Game-options file";
+      case MENU_ENUM_LABEL_VALUE_HELP:
+         return "help";
+      case MENU_ENUM_LABEL_VALUE_HELP_AUDIO_VIDEO_TROUBLESHOOTING:
+         return "Audio/Video Troubleshooting";
+      case MENU_ENUM_LABEL_VALUE_HELP_CHANGE_VIRTUAL_GAMEPAD:
+         return "Changing Virtual Gamepad Overlay";
+      case MENU_ENUM_LABEL_VALUE_HELP_CONTROLS:
+         return "Basic Menu Controls";
+      case MENU_ENUM_LABEL_VALUE_HELP_LIST:
+         return "Help";
+      case MENU_ENUM_LABEL_VALUE_HELP_LOADING_CONTENT:
+         return "Loading Content";
+      case MENU_ENUM_LABEL_VALUE_HELP_SCANNING_CONTENT:
+         return "Scanning For Content";
+      case MENU_ENUM_LABEL_VALUE_HELP_WHAT_IS_A_CORE:
+         return "What Is A Core?";
+      case MENU_ENUM_LABEL_VALUE_HISTORY_LIST_ENABLE:
+         return "History List Enable";
+      case MENU_ENUM_LABEL_VALUE_HISTORY_TAB:
+         return "History";
+      case MENU_ENUM_LABEL_VALUE_HORIZONTAL_MENU:
+         return "Horizontal Menu";
+      case MENU_ENUM_LABEL_VALUE_IMAGES_TAB:
+         return "Images";
+      case MENU_ENUM_LABEL_VALUE_INFORMATION:
+         return "Information";
+      case MENU_ENUM_LABEL_VALUE_INFORMATION_LIST:
+         return "Information";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ADC_TYPE:
+         return "Analog To Digital Type";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ALL_USERS_CONTROL_MENU:
+         return "All Users Control Menu";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_X:
+         return "Left Analog X";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_X_MINUS:
+         return "Left analog X- (left)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_X_PLUS:
+         return "Left analog X+ (right)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_Y:
+         return "Left Analog Y";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_Y_MINUS:
+         return "Left analog Y- (up)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_Y_PLUS:
+         return "Left analog Y+ (down)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_X:
+         return "Right Analog X";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_X_MINUS:
+         return "Right analog X- (left)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_X_PLUS:
+         return "Right analog X+ (right)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_Y:
+         return "Right Analog Y";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_Y_MINUS:
+         return "Right analog Y- (up)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_Y_PLUS:
+         return "Right analog Y+ (down)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_AUTODETECT_ENABLE:
+         return "Autoconfig Enable";
+      case MENU_ENUM_LABEL_VALUE_INPUT_AXIS_THRESHOLD:
+         return "Input Axis Threshold";
+      case MENU_ENUM_LABEL_VALUE_INPUT_BACK_AS_MENU_ENUM_TOGGLE_ENABLE:
+         return "Back As Menu Toggle Enable";
+      case MENU_ENUM_LABEL_VALUE_INPUT_BIND_ALL:
+         return "Bind All";
+      case MENU_ENUM_LABEL_VALUE_INPUT_BIND_DEFAULT_ALL:
+         return "Bind Default All";
+      case MENU_ENUM_LABEL_VALUE_INPUT_BIND_TIMEOUT:
+         return "Bind Timeout";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_HIDE_UNBOUND:
+         return "Hide Unbound Core Input Descriptors";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_LABEL_SHOW:
+         return "Display Input Descriptor Labels";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DEVICE_INDEX:
+         return "Device Index";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DEVICE_TYPE:
+         return "Device Type";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DRIVER:
+         return "Input Driver";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DUTY_CYCLE:
+         return "Duty Cycle";
+      case MENU_ENUM_LABEL_VALUE_INPUT_HOTKEY_BINDS:
+         return "Input Hotkey Binds";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ICADE_ENABLE:
+         return "Keyboard Gamepad Mapping Enable";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_A:
+         return "A button (right)";
       case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_B:
          return "B button (down)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_Y:
-         return "Y button (left)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_DOWN:
+         return "Down D-pad";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_L2:
+         return "L2 button (trigger)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_L3:
+         return "L3 button (thumb)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_L:
+         return "L button (shoulder)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_LEFT:
+         return "Left D-pad";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_R2:
+         return "R2 button (trigger)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_R3:
+         return "R3 button (thumb)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_R:
+         return "R button (shoulder)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_RIGHT:
+         return "Right D-pad";
       case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_SELECT:
          return "Select button";
       case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_START:
          return "Start button";
       case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_UP:
          return "Up D-pad";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_DOWN:
-         return "Down D-pad";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_LEFT:
-         return "Left D-pad";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_RIGHT:
-         return "Right D-pad";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_A:
-         return "A button (right)";
       case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_X:
          return "X button (top)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_L:
-         return "L button (shoulder)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_R:
-         return "R button (shoulder)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_L2:
-         return "L2 button (trigger)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_R2:
-         return "R2 button (trigger)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_L3:
-         return "L3 button (thumb)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_R3:
-         return "R3 button (thumb)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_X:
-         return "Left Analog X";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_Y:
-         return "Left Analog Y";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_X:
-         return "Right Analog X";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_Y:
-         return "Right Analog Y";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_X_PLUS:
-         return "Left analog X+ (right)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_X_MINUS:
-         return "Left analog X- (left)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_Y_PLUS:
-         return "Left analog Y+ (down)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_Y_MINUS:
-         return "Left analog Y- (up)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_X_PLUS:
-         return "Right analog X+ (right)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_X_MINUS:
-         return "Right analog X- (left)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_Y_PLUS:
-         return "Right analog Y+ (down)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_Y_MINUS:
-         return "Right analog Y- (up)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_TURBO_ENABLE:
-         return "Turbo enable";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_FAST_FORWARD_KEY:
-         return "Fast forward toggle";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_FAST_FORWARD_HOLD_KEY:
-         return "Fast forward hold";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_LOAD_STATE_KEY:
-         return "Load state";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_SAVE_STATE_KEY:
-         return "Save state";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_FULLSCREEN_TOGGLE_KEY:
-         return "Fullscreen toggle";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_QUIT_KEY:
-         return "Quit RetroArch";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_STATE_SLOT_PLUS:
-         return "Savestate slot +";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_STATE_SLOT_MINUS:
-         return "Savestate slot -";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_REWIND:
-         return "Rewind";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_MOVIE_RECORD_TOGGLE:
-         return "Movie record toggle";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_PAUSE_TOGGLE:
-         return "Pause toggle";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_FRAMEADVANCE:
-         return "Frameadvance";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_RESET:
-         return "Reset game";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_SHADER_NEXT:
-         return "Next shader";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_SHADER_PREV:
-         return "Previous shader";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_CHEAT_INDEX_PLUS:
-         return "Cheat index +";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_Y:
+         return "Y button (left)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_KEYBOARD_GAMEPAD_MAPPING_TYPE:
+         return "Keyboard Gamepad Mapping Type";
+      case MENU_ENUM_LABEL_VALUE_INPUT_MAX_USERS:
+         return "Max Users";
+      case MENU_ENUM_LABEL_VALUE_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
+         return "Menu Toggle Gamepad Combo";
       case MENU_ENUM_LABEL_VALUE_INPUT_META_CHEAT_INDEX_MINUS:
          return "Cheat index -";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_CHEAT_INDEX_PLUS:
+         return "Cheat index +";
       case MENU_ENUM_LABEL_VALUE_INPUT_META_CHEAT_TOGGLE:
          return "Cheat toggle";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_SCREENSHOT:
-         return "Take screenshot";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_MUTE:
-         return "Audio mute toggle";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_OSK:
-         return "On-screen keyboard toggle";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_NETPLAY_FLIP:
-         return "Netplay flip users";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_SLOWMOTION:
-         return "Slow motion";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_ENABLE_HOTKEY:
-         return "Enable hotkeys";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_VOLUME_UP:
-         return "Volume +";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_VOLUME_DOWN:
-         return "Volume -";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_OVERLAY_NEXT:
-         return "Overlay next";
       case MENU_ENUM_LABEL_VALUE_INPUT_META_DISK_EJECT_TOGGLE:
          return "Disk eject toggle";
       case MENU_ENUM_LABEL_VALUE_INPUT_META_DISK_NEXT:
          return "Disk next";
       case MENU_ENUM_LABEL_VALUE_INPUT_META_DISK_PREV:
          return "Disk prev";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_ENABLE_HOTKEY:
+         return "Enable hotkeys";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_FAST_FORWARD_HOLD_KEY:
+         return "Fast forward hold";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_FAST_FORWARD_KEY:
+         return "Fast forward toggle";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_FRAMEADVANCE:
+         return "Frameadvance";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_FULLSCREEN_TOGGLE_KEY:
+         return "Fullscreen toggle";
       case MENU_ENUM_LABEL_VALUE_INPUT_META_GRAB_MOUSE_TOGGLE:
          return "Grab mouse toggle";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_LOAD_STATE_KEY:
+         return "Load state";
       case MENU_ENUM_LABEL_VALUE_INPUT_META_MENU_TOGGLE:
          return "Menu toggle";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DEVICE_INDEX:
-         return "Device Index";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DEVICE_TYPE:
-         return "Device Type";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ADC_TYPE:
-         return "Analog To Digital Type";
-      case MENU_ENUM_LABEL_VALUE_INPUT_BIND_ALL:
-         return "Bind All";
-      case MENU_ENUM_LABEL_VALUE_INPUT_BIND_DEFAULT_ALL:
-         return "Bind Default All";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_MOVIE_RECORD_TOGGLE:
+         return "Movie record toggle";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_MUTE:
+         return "Audio mute toggle";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_NETPLAY_FLIP:
+         return "Netplay flip users";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_OSK:
+         return "On-screen keyboard toggle";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_OVERLAY_NEXT:
+         return "Overlay next";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_PAUSE_TOGGLE:
+         return "Pause toggle";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_QUIT_KEY:
+         return "Quit RetroArch";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_RESET:
+         return "Reset game";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_REWIND:
+         return "Rewind";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_SAVE_STATE_KEY:
+         return "Save state";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_SCREENSHOT:
+         return "Take screenshot";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_SHADER_NEXT:
+         return "Next shader";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_SHADER_PREV:
+         return "Previous shader";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_SLOWMOTION:
+         return "Slow motion";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_STATE_SLOT_MINUS:
+         return "Savestate slot -";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_STATE_SLOT_PLUS:
+         return "Savestate slot +";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_VOLUME_DOWN:
+         return "Volume -";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_VOLUME_UP:
+         return "Volume +";
+      case MENU_ENUM_LABEL_VALUE_INPUT_OSK_OVERLAY_ENABLE:
+         return "Display Keyboard Overlay";
+      case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_ENABLE:
+         return "Display Overlay";
+      case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_HIDE_IN_MENU:
+         return "Hide Overlay In Menu";
+      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR:
+         return "Poll Type Behavior";
+      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR_EARLY:
+         return "Early";
+      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR_LATE:
+         return "Late";
+      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR_NORMAL:
+         return "Normal";
+      case MENU_ENUM_LABEL_VALUE_INPUT_PREFER_FRONT_TOUCH:
+         return "Prefer Front Touch";
+      case MENU_ENUM_LABEL_VALUE_INPUT_REMAPPING_DIRECTORY:
+         return "Input Remapping Dir";
+      case MENU_ENUM_LABEL_VALUE_INPUT_REMAP_BINDS_ENABLE:
+         return "Remap Binds Enable";
       case MENU_ENUM_LABEL_VALUE_INPUT_SAVE_AUTOCONFIG:
          return "Save Autoconfig";
+      case MENU_ENUM_LABEL_VALUE_INPUT_SETTINGS:
+         return "Input";
+      case MENU_ENUM_LABEL_VALUE_INPUT_SMALL_KEYBOARD_ENABLE:
+         return "Small Keyboard Enable";
+      case MENU_ENUM_LABEL_VALUE_INPUT_TOUCH_ENABLE:
+         return "Touch Enable";
+      case MENU_ENUM_LABEL_VALUE_INPUT_TURBO_ENABLE:
+         return "Turbo enable";
+      case MENU_ENUM_LABEL_VALUE_INPUT_TURBO_PERIOD:
+         return "Turbo Period";
+      case MENU_ENUM_LABEL_VALUE_INPUT_USER_BINDS:
+         return "Input User %u Binds";
+      case MENU_ENUM_LABEL_VALUE_INTERNAL_STORAGE_STATUS:
+         return "Internal storage status";
+      case MENU_ENUM_LABEL_VALUE_JOYPAD_AUTOCONFIG_DIR:
+         return "Input Device Autoconfig Dir";
+      case MENU_ENUM_LABEL_VALUE_JOYPAD_DRIVER:
+         return "Joypad Driver";
+      case MENU_ENUM_LABEL_VALUE_KEYBOARD_OVERLAY_PRESET:
+         return "Keyboard Overlay Preset";
+      case MENU_ENUM_LABEL_VALUE_LAKKA_SERVICES:
+         return "Lakka Services";
+      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_SIMPLIFIED:
+         return "Chinese (Simplified)";
+      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_TRADITIONAL:
+         return "Chinese (Traditional)";
+      case MENU_ENUM_LABEL_VALUE_LANG_DUTCH:
+         return "Dutch";
+      case MENU_ENUM_LABEL_VALUE_LANG_ENGLISH:
+         return "English";
+      case MENU_ENUM_LABEL_VALUE_LANG_ESPERANTO:
+         return "Esperanto";
+      case MENU_ENUM_LABEL_VALUE_LANG_FRENCH:
+         return "French";
+      case MENU_ENUM_LABEL_VALUE_LANG_GERMAN:
+         return "German";
+      case MENU_ENUM_LABEL_VALUE_LANG_ITALIAN:
+         return "Italian";
+      case MENU_ENUM_LABEL_VALUE_LANG_JAPANESE:
+         return "Japanese";
+      case MENU_ENUM_LABEL_VALUE_LANG_KOREAN:
+         return "Korean";
+      case MENU_ENUM_LABEL_VALUE_LANG_POLISH:
+         return "Polish";
+      case MENU_ENUM_LABEL_VALUE_LANG_PORTUGUESE:
+         return "Portuguese";
+      case MENU_ENUM_LABEL_VALUE_LANG_RUSSIAN:
+         return "Russian";
+      case MENU_ENUM_LABEL_VALUE_LANG_SPANISH:
+         return "Spanish";
+      case MENU_ENUM_LABEL_VALUE_LANG_VIETNAMESE:
+         return "Vietnamese";
+      case MENU_ENUM_LABEL_VALUE_LEFT_ANALOG:
+         return "Left Analog";
+      case MENU_ENUM_LABEL_VALUE_LIBRETRO_DIR_PATH:
+         return "Core Dir";
+      case MENU_ENUM_LABEL_VALUE_LIBRETRO_INFO_PATH:
+         return "Core Info Dir";
+      case MENU_ENUM_LABEL_VALUE_LIBRETRO_LOG_LEVEL:
+         return "Core Logging Level";
+      case MENU_ENUM_LABEL_VALUE_LINEAR:
+         return "Linear";
+      case MENU_ENUM_LABEL_VALUE_LOAD_ARCHIVE:
+         return "Load Archive With Core";
+      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT:
+         return "Select File";
+      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_HISTORY:
+         return "Load Recent";
+      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_LIST:
+         return "Load Content";
+      case MENU_ENUM_LABEL_VALUE_LOAD_STATE:
+         return "Load State";
+      case MENU_ENUM_LABEL_VALUE_LOCATION_ALLOW:
+         return "Allow Location";
+      case MENU_ENUM_LABEL_VALUE_LOCATION_DRIVER:
+         return "Location Driver";
+      case MENU_ENUM_LABEL_VALUE_LOGGING_SETTINGS:
+         return "Logging";
+      case MENU_ENUM_LABEL_VALUE_LOG_VERBOSITY:
+         return "Logging Verbosity";
+      case MENU_ENUM_LABEL_VALUE_MAIN_MENU:
+         return "Main Menu";
+      case MENU_ENUM_LABEL_VALUE_MANAGEMENT:
+         return "Database Settings";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME:
+         return "Menu Color Theme";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_BLUE:
+         return "Blue";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_BLUE_GREY:
+         return "Blue Grey";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_DARK_BLUE:
+         return "Dark Blue";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_GREEN:
+         return "Green";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_NVIDIA_SHIELD:
+         return "Shield";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_RED:
+         return "Red";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_YELLOW:
+         return "Yellow";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_FOOTER_OPACITY:
+         return "Footer Opacity";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_HEADER_OPACITY:
+         return "Header Opacity";
+      case MENU_ENUM_LABEL_VALUE_MENU_DRIVER:
+         return "Menu Driver";
+      case MENU_ENUM_LABEL_VALUE_MENU_ENUM_THROTTLE_FRAMERATE:
+         return "Throttle Menu Framerate";
+      case MENU_ENUM_LABEL_VALUE_MENU_FILE_BROWSER_SETTINGS:
+         return "Menu File Browser";
+      case MENU_ENUM_LABEL_VALUE_MENU_LINEAR_FILTER:
+         return "Menu Linear Filter";
+      case MENU_ENUM_LABEL_VALUE_MENU_SETTINGS:
+         return "Menu";
+      case MENU_ENUM_LABEL_VALUE_MENU_WALLPAPER:
+         return "Menu Wallpaper";
+      case MENU_ENUM_LABEL_VALUE_MENU_WALLPAPER_OPACITY:
+         return "Wallpaper opacity";
+      case MENU_ENUM_LABEL_VALUE_MISSING:
+         return "Missing";
+      case MENU_ENUM_LABEL_VALUE_MORE:
+         return "...";
+      case MENU_ENUM_LABEL_VALUE_MOUSE_ENABLE:
+         return "Mouse Support";
+      case MENU_ENUM_LABEL_VALUE_MULTIMEDIA_SETTINGS:
+         return "Multimedia";
+      case MENU_ENUM_LABEL_VALUE_MUSIC_TAB:
+         return "Music";
+      case MENU_ENUM_LABEL_VALUE_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
+         return "Filter unknown extensions";
+      case MENU_ENUM_LABEL_VALUE_NAVIGATION_WRAPAROUND:
+         return "Navigation Wrap-Around";
+      case MENU_ENUM_LABEL_VALUE_NEAREST:
+         return "Nearest";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY:
+         return "Netplay";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_CHECK_FRAMES:
+         return "Netplay Check Frames";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT:
+         return "Netplay P2 Uses C1";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_DELAY_FRAMES:
+         return "Netplay Delay Frames";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_DISCONNECT:
+         return "Disconnect";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE:
+         return "Netplay Enable";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE_CLIENT:
+         return "Connect to Netplay host";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE_HOST:
+         return "Start hosting";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS:
+         return "Server Address";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_MODE:
+         return "Netplay Client Enable";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_NICKNAME:
+         return "Username";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_SETTINGS:
+         return "Netplay settings";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE:
+         return "Netplay Spectator Enable";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT:
+         return "Netplay TCP/UDP Port";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_ENABLE:
+         return "Network Commands";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_PORT:
+         return "Network Command Port";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_INFORMATION:
+         return "Network Information";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_REMOTE_ENABLE:
+         return "Network Gamepad";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_REMOTE_PORT:
+         return "Network Remote Base Port";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_SETTINGS:
+         return "Network";
+      case MENU_ENUM_LABEL_VALUE_NO:
+         return "No";
+      case MENU_ENUM_LABEL_VALUE_NONE:
+         return "None";
+      case MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE:
+         return "N/A";
+      case MENU_ENUM_LABEL_VALUE_NO_ACHIEVEMENTS_TO_DISPLAY:
+         return "No achievements to display.";
+      case MENU_ENUM_LABEL_VALUE_NO_CORE:
+         return "No Core";
+      case MENU_ENUM_LABEL_VALUE_NO_CORES_AVAILABLE:
+         return "No cores available.";
+      case MENU_ENUM_LABEL_VALUE_NO_CORE_INFORMATION_AVAILABLE:
+         return "No core information available.";
+      case MENU_ENUM_LABEL_VALUE_NO_CORE_OPTIONS_AVAILABLE:
+         return "No core options available.";
+      case MENU_ENUM_LABEL_VALUE_NO_ENTRIES_TO_DISPLAY:
+         return "No entries to display.";
+      case MENU_ENUM_LABEL_VALUE_NO_HISTORY_AVAILABLE:
+         return "No history available.";
+      case MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE:
+         return "No information is available.";
+      case MENU_ENUM_LABEL_VALUE_NO_ITEMS:
+         return "No items.";
+      case MENU_ENUM_LABEL_VALUE_NO_PERFORMANCE_COUNTERS:
+         return "No performance counters.";
+      case MENU_ENUM_LABEL_VALUE_NO_PLAYLISTS:
+         return "No playlists.";
+      case MENU_ENUM_LABEL_VALUE_NO_PLAYLIST_ENTRIES_AVAILABLE:
+         return "No playlist entries available.";
+      case MENU_ENUM_LABEL_VALUE_NO_SETTINGS_FOUND:
+         return "No settings found.";
+      case MENU_ENUM_LABEL_VALUE_NO_SHADER_PARAMETERS:
+         return "No shader parameters.";
+      case MENU_ENUM_LABEL_VALUE_OFF:
+         return "OFF";
+      case MENU_ENUM_LABEL_VALUE_ON:
+         return "ON";
+      case MENU_ENUM_LABEL_VALUE_ONLINE_UPDATER:
+         return "Online Updater";
+      case MENU_ENUM_LABEL_VALUE_ONSCREEN_DISPLAY_SETTINGS:
+         return "Onscreen Display";
+      case MENU_ENUM_LABEL_VALUE_ONSCREEN_OVERLAY_SETTINGS:
+         return "Onscreen Overlay";
+      case MENU_ENUM_LABEL_VALUE_OPEN_ARCHIVE:
+         return "Open Archive As Folder";
+      case MENU_ENUM_LABEL_VALUE_OPTIONAL:
+         return "Optional";
+      case MENU_ENUM_LABEL_VALUE_OSK_OVERLAY_DIRECTORY:
+         return "OSK Overlay Dir";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY:
+         return "Overlay";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_AUTOLOAD_PREFERRED:
+         return "Autoload Preferred Overlay";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_DIRECTORY:
+         return "Overlay Dir";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_OPACITY:
+         return "Overlay Opacity";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_PRESET:
+         return "Overlay Preset";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_SCALE:
+         return "Overlay Scale";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_SETTINGS:
+         return "Onscreen Overlay";
+      case MENU_ENUM_LABEL_VALUE_PAL60_ENABLE:
+         return "Use PAL60 Mode";
+      case MENU_ENUM_LABEL_VALUE_PARENT_DIRECTORY:
+         return "Parent directory";
+      case MENU_ENUM_LABEL_VALUE_PAUSE_LIBRETRO:
+         return "Pause when menu activated";
+      case MENU_ENUM_LABEL_VALUE_PAUSE_NONACTIVE:
+         return "Don't run in background";
+      case MENU_ENUM_LABEL_VALUE_PERFCNT_ENABLE:
+         return "Performance Counters";
+      case MENU_ENUM_LABEL_VALUE_PLAYLISTS_TAB:
+         return "Playlists";
+      case MENU_ENUM_LABEL_VALUE_PLAYLIST_DIRECTORY:
+         return "Playlist Dir";
+      case MENU_ENUM_LABEL_VALUE_PLAYLIST_SETTINGS:
+         return "Playlists";
+      case MENU_ENUM_LABEL_VALUE_POINTER_ENABLE:
+         return "Touch Support";
+      case MENU_ENUM_LABEL_VALUE_PORT:
+         return "Port";
+      case MENU_ENUM_LABEL_VALUE_PRESENT:
+         return "Present";
+      case MENU_ENUM_LABEL_VALUE_PRIVACY_SETTINGS:
+         return "Privacy";
+      case MENU_ENUM_LABEL_VALUE_QUIT_RETROARCH:
+         return "Quit RetroArch";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ANALOG:
+         return "Analog supported";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_BBFC_RATING:
+         return "BBFC Rating";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_CERO_RATING:
+         return "CERO Rating";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_COOP:
+         return "Co-op supported";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_CRC32:
+         return "CRC32";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DESCRIPTION:
+         return "Description";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DEVELOPER:
+         return "Developer";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_EDGE_MAGAZINE_ISSUE:
+         return "Edge Magazine Issue";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_EDGE_MAGAZINE_RATING:
+         return "Edge Magazine Rating";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_EDGE_MAGAZINE_REVIEW:
+         return "Edge Magazine Review";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ELSPA_RATING:
+         return "ELSPA Rating";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ENHANCEMENT_HW:
+         return "Enhancement Hardware";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ESRB_RATING:
+         return "ESRB Rating";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_FAMITSU_MAGAZINE_RATING:
+         return "Famitsu Magazine Rating";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_FRANCHISE:
+         return "Franchise";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_GENRE:
+         return "Genre";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_MD5:
+         return "MD5";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_NAME:
+         return "Name";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ORIGIN:
+         return "Origin";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_PEGI_RATING:
+         return "PEGI Rating";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_PUBLISHER:
+         return "Publisher";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_MONTH:
+         return "Releasedate Month";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_YEAR:
+         return "Releasedate Year";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RUMBLE:
+         return "Rumble supported";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_SERIAL:
+         return "Serial";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_SHA1:
+         return "SHA1";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_START_CONTENT:
+         return "Start Content";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_TGDB_RATING:
+         return "TGDB Rating";
+      case MENU_ENUM_LABEL_VALUE_REBOOT:
+         return "Reboot";
+      case MENU_ENUM_LABEL_VALUE_RECORDING_CONFIG_DIRECTORY:
+         return "Recording Config Dir";
+      case MENU_ENUM_LABEL_VALUE_RECORDING_OUTPUT_DIRECTORY:
+         return "Recording Output Dir";
+      case MENU_ENUM_LABEL_VALUE_RECORDING_SETTINGS:
+         return "Recording";
+      case MENU_ENUM_LABEL_VALUE_RECORD_CONFIG:
+         return "Record Config";
+      case MENU_ENUM_LABEL_VALUE_RECORD_DRIVER:
+         return "Record Driver";
+      case MENU_ENUM_LABEL_VALUE_RECORD_ENABLE:
+         return "Record Enable";
+      case MENU_ENUM_LABEL_VALUE_RECORD_PATH:
+         return "Output File";
+      case MENU_ENUM_LABEL_VALUE_RECORD_USE_OUTPUT_DIRECTORY:
+         return "Use Output Dir";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE:
+         return "Remap File";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_LOAD:
+         return "Load Remap File";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_CORE:
+         return "Save Core Remap File";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_GAME:
+         return "Save Game Remap File";
+      case MENU_ENUM_LABEL_VALUE_REQUIRED:
+         return "Required";
+      case MENU_ENUM_LABEL_VALUE_RESTART_CONTENT:
+         return "Restart";
+      case MENU_ENUM_LABEL_VALUE_RESTART_RETROARCH:
+         return "Restart RetroArch";
+      case MENU_ENUM_LABEL_VALUE_RESUME:
+         return "Resume";
+      case MENU_ENUM_LABEL_VALUE_RESUME_CONTENT:
+         return "Resume";
+      case MENU_ENUM_LABEL_VALUE_RETROKEYBOARD:
+         return "RetroKeyboard";
+      case MENU_ENUM_LABEL_VALUE_RETROPAD:
+         return "RetroPad";
+      case MENU_ENUM_LABEL_VALUE_RETRO_ACHIEVEMENTS_SETTINGS:
+         return "Retro Achievements";
+      case MENU_ENUM_LABEL_VALUE_REWIND_ENABLE:
+         return "Rewind Enable";
+      case MENU_ENUM_LABEL_VALUE_REWIND_GRANULARITY:
+         return "Rewind Granularity";
+      case MENU_ENUM_LABEL_VALUE_REWIND_SETTINGS:
+         return "Rewind";
+      case MENU_ENUM_LABEL_VALUE_RGUI_BROWSER_DIRECTORY:
+         return "File Browser Dir";
+      case MENU_ENUM_LABEL_VALUE_RGUI_CONFIG_DIRECTORY:
+         return "Config Dir";
+      case MENU_ENUM_LABEL_VALUE_RGUI_SHOW_START_SCREEN:
+         return "Show Start Screen";
+      case MENU_ENUM_LABEL_VALUE_RIGHT_ANALOG:
+         return "Right Analog";
+      case MENU_ENUM_LABEL_VALUE_RUN:
+         return "Run";
+      case MENU_ENUM_LABEL_VALUE_SAMBA_ENABLE:
+         return "SAMBA Enable";
+      case MENU_ENUM_LABEL_VALUE_SAVEFILE_DIRECTORY:
+         return "Savefile Dir";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_INDEX:
+         return "Save State Auto Index";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_LOAD:
+         return "Auto Load State";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_SAVE:
+         return "Auto Save State";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_DIRECTORY:
+         return "Savestate Dir";
+      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG:
+         return "Save Current Config";
+      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG_OVERRIDE_CORE:
+         return "Save Core Overrides";
+      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG_OVERRIDE_GAME:
+         return "Save Game Overrides";
+      case MENU_ENUM_LABEL_VALUE_SAVE_NEW_CONFIG:
+         return "Save New Config";
+      case MENU_ENUM_LABEL_VALUE_SAVE_STATE:
+         return "Save State";
+      case MENU_ENUM_LABEL_VALUE_SAVING_SETTINGS:
+         return "Saving";
+      case MENU_ENUM_LABEL_VALUE_SCAN_DIRECTORY:
+         return "Scan Directory";
+      case MENU_ENUM_LABEL_VALUE_SCAN_FILE:
+         return "Scan File";
+      case MENU_ENUM_LABEL_VALUE_SCAN_THIS_DIRECTORY:
+         return "<Scan This Directory>";
+      case MENU_ENUM_LABEL_VALUE_SCREENSHOT_DIRECTORY:
+         return "Screenshot Dir";
+      case MENU_ENUM_LABEL_VALUE_SCREEN_RESOLUTION:
+         return "Screen Resolution";
+      case MENU_ENUM_LABEL_VALUE_SEARCH:
+         return "Search:";
+      case MENU_ENUM_LABEL_VALUE_SECONDS:
+         return "seconds";
+      case MENU_ENUM_LABEL_VALUE_SETTINGS:
+         return "Settings";
+      case MENU_ENUM_LABEL_VALUE_SETTINGS_TAB:
+         return "Settings";
+      case MENU_ENUM_LABEL_VALUE_SHADER:
+         return "Shader";
+      case MENU_ENUM_LABEL_VALUE_SHADER_APPLY_CHANGES:
+         return "Apply Shader Changes";
+      case MENU_ENUM_LABEL_VALUE_SHADER_OPTIONS:
+         return "Shaders";
+      case MENU_ENUM_LABEL_VALUE_SHADER_PIPELINE_RIBBON:
+         return "Ribbon";
+      case MENU_ENUM_LABEL_VALUE_SHADER_PIPELINE_RIBBON_SIMPLIFIED:
+         return "Ribbon (simplified)";
+      case MENU_ENUM_LABEL_VALUE_SHOW_ADVANCED_SETTINGS:
+         return "Show Advanced Settings";
+      case MENU_ENUM_LABEL_VALUE_SHOW_HIDDEN_FILES:
+         return "Show Hidden Files and Folders";
+      case MENU_ENUM_LABEL_VALUE_SHUTDOWN:
+         return "Shutdown";
+      case MENU_ENUM_LABEL_VALUE_SLOWMOTION_RATIO:
+         return "Slow-Motion Ratio";
+      case MENU_ENUM_LABEL_VALUE_SORT_SAVEFILES_ENABLE:
+         return "Sort Saves In Folders";
+      case MENU_ENUM_LABEL_VALUE_SORT_SAVESTATES_ENABLE:
+         return "Sort Savestates In Folders";
+      case MENU_ENUM_LABEL_VALUE_SSH_ENABLE:
+         return "SSH Enable";
+      case MENU_ENUM_LABEL_VALUE_START_CORE:
+         return "Start Core";
+      case MENU_ENUM_LABEL_VALUE_START_NET_RETROPAD:
+         return "Start Remote RetroPad";
+      case MENU_ENUM_LABEL_VALUE_START_VIDEO_PROCESSOR:
+         return "Start Video Processor";
+      case MENU_ENUM_LABEL_VALUE_STATE_SLOT:
+         return "State Slot";
+      case MENU_ENUM_LABEL_VALUE_STATUS:
+         return "Status";
+      case MENU_ENUM_LABEL_VALUE_STDIN_CMD_ENABLE:
+         return "stdin Commands";
+      case MENU_ENUM_LABEL_VALUE_SUPPORTED_CORES:
+         return "Supported cores";
+      case MENU_ENUM_LABEL_VALUE_SUSPEND_SCREENSAVER_ENABLE:
+         return "Suspend Screensaver";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_BGM_ENABLE:
+         return "System BGM Enable";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_DIRECTORY:
+         return "System/BIOS Dir";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFORMATION:
+         return "System Information";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_7ZIP_SUPPORT:
+         return "7zip support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ALSA_SUPPORT:
+         return "ALSA support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_BUILD_DATE:
+         return "Build date";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CG_SUPPORT:
+         return "Cg support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COCOA_SUPPORT:
+         return "Cocoa support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COMMAND_IFACE_SUPPORT:
+         return "Command interface support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CORETEXT_SUPPORT:
+         return "CoreText support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CPU_FEATURES:
+         return "CPU Features";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_DPI:
+         return "Display metric DPI";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_HEIGHT:
+         return "Display metric height (mm)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_WIDTH:
+         return "Display metric width (mm)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DSOUND_SUPPORT:
+         return "DirectSound support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DYLIB_SUPPORT:
+         return "Dynamic library support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DYNAMIC_SUPPORT:
+         return "Dynamic run-time loading of libretro library";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_EGL_SUPPORT:
+         return "EGL support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FBO_SUPPORT:
+         return "OpenGL/Direct3D render-to-texture (multi-pass shaders) support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FFMPEG_SUPPORT:
+         return "FFmpeg support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FREETYPE_SUPPORT:
+         return "FreeType support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_IDENTIFIER:
+         return "Frontend identifier";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_NAME:
+         return "Frontend name";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_OS:
+         return "Frontend OS";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GIT_VERSION:
+         return "Git version";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GLSL_SUPPORT:
+         return "GLSL support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_HLSL_SUPPORT:
+         return "HLSL support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_JACK_SUPPORT:
+         return "JACK support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_KMS_SUPPORT:
+         return "KMS/EGL support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBRETRODB_SUPPORT:
+         return "LibretroDB support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBUSB_SUPPORT:
+         return "Libusb support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBXML2_SUPPORT:
+         return "libxml2 XML parsing support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETPLAY_SUPPORT:
+         return "Netplay (peer-to-peer) support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETWORK_COMMAND_IFACE_SUPPORT:
+         return "Network Command interface support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETWORK_REMOTE_SUPPORT:
+         return "Network Gamepad support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENAL_SUPPORT:
+         return "OpenAL support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGLES_SUPPORT:
+         return "OpenGL ES support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGL_SUPPORT:
+         return "OpenGL support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENSL_SUPPORT:
+         return "OpenSL support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENVG_SUPPORT:
+         return "OpenVG support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OSS_SUPPORT:
+         return "OSS support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OVERLAY_SUPPORT:
+         return "Overlay support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE:
+         return "Power source";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGED:
+         return "Charged";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGING:
+         return "Charging";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_DISCHARGING:
+         return "Discharging";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_NO_SOURCE:
+         return "No source";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PULSEAUDIO_SUPPORT:
+         return "PulseAudio support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PYTHON_SUPPORT:
+         return "Python (script support in shaders) support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RBMP_SUPPORT:
+         return "BMP support (RBMP)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RETRORATING_LEVEL:
+         return "RetroRating level";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RJPEG_SUPPORT:
+         return "JPEG support (RJPEG)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ROARAUDIO_SUPPORT:
+         return "RoarAudio support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RPNG_SUPPORT:
+         return "PNG support (RPNG)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RSOUND_SUPPORT:
+         return "RSound support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RTGA_SUPPORT:
+         return "TGA support (RTGA)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL2_SUPPORT:
+         return "SDL2 support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_IMAGE_SUPPORT:
+         return "SDL image support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_SUPPORT:
+         return "SDL1.2 support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SLANG_SUPPORT:
+         return "Slang support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_THREADING_SUPPORT:
+         return "Threading support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_UDEV_SUPPORT:
+         return "Udev support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_V4L2_SUPPORT:
+         return "Video4Linux2 support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VIDEO_CONTEXT_DRIVER:
+         return "Video context driver";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VULKAN_SUPPORT:
+         return "Vulkan support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_WAYLAND_SUPPORT:
+         return "Wayland support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_X11_SUPPORT:
+         return "X11 support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XAUDIO2_SUPPORT:
+         return "XAudio2 support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XVIDEO_SUPPORT:
+         return "XVideo support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ZLIB_SUPPORT:
+         return "Zlib support";
+      case MENU_ENUM_LABEL_VALUE_TAKE_SCREENSHOT:
+         return "Take Screenshot";
+      case MENU_ENUM_LABEL_VALUE_THREADED_DATA_RUNLOOP_ENABLE:
+         return "Threaded data runloop";
+      case MENU_ENUM_LABEL_VALUE_THUMBNAILS:
+         return "Thumbnails";
+      case MENU_ENUM_LABEL_VALUE_THUMBNAILS_DIRECTORY:
+         return "Thumbnails Dir";
+      case MENU_ENUM_LABEL_VALUE_THUMBNAILS_UPDATER_LIST:
+         return "Thumbnails Updater";
+      case MENU_ENUM_LABEL_VALUE_THUMBNAIL_MODE_BOXARTS:
+         return "Boxarts";
+      case MENU_ENUM_LABEL_VALUE_THUMBNAIL_MODE_SCREENSHOTS:
+         return "Screenshots";
+      case MENU_ENUM_LABEL_VALUE_THUMBNAIL_MODE_TITLE_SCREENS:
+         return "Title Screens";
+      case MENU_ENUM_LABEL_VALUE_TIMEDATE_ENABLE:
+         return "Display time / date";
+      case MENU_ENUM_LABEL_VALUE_TITLE_COLOR:
+         return "Menu title color";
+      case MENU_ENUM_LABEL_VALUE_TRUE:
+         return "True";
+      case MENU_ENUM_LABEL_VALUE_UI_COMPANION_ENABLE:
+         return "UI Companion Enable";
+      case MENU_ENUM_LABEL_VALUE_UI_COMPANION_START_ON_BOOT:
+         return "UI Companion Start On Boot";
+      case MENU_ENUM_LABEL_VALUE_UI_MENUBAR_ENABLE:
+         return "Menubar";
+      case MENU_ENUM_LABEL_VALUE_UNABLE_TO_READ_COMPRESSED_FILE:
+         return "Unable to read compressed file.";
+      case MENU_ENUM_LABEL_VALUE_UNDO_LOAD_STATE:
+         return "Undo Load State";
+      case MENU_ENUM_LABEL_VALUE_UNDO_SAVE_STATE:
+         return "Undo Save State";
+      case MENU_ENUM_LABEL_VALUE_UNKNOWN:
+         return "Unknown";
+      case MENU_ENUM_LABEL_VALUE_UPDATER_SETTINGS:
+         return "Updater";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_ASSETS:
+         return "Update Assets";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_AUTOCONFIG_PROFILES:
+         return "Update Autoconfig Profiles";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_CG_SHADERS:
+         return "Update Cg Shaders";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_CHEATS:
+         return "Update Cheats";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_CORE_INFO_FILES:
+         return "Update Core Info Files";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_DATABASES:
+         return "Update Databases";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_GLSL_SHADERS:
+         return "Update GLSL Shaders";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_LAKKA:
+         return "Update Lakka";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_OVERLAYS:
+         return "Update Overlays";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_SLANG_SHADERS:
+         return "Update Slang Shaders";
+      case MENU_ENUM_LABEL_VALUE_USER:
+         return "User";
+      case MENU_ENUM_LABEL_VALUE_USER_INTERFACE_SETTINGS:
+         return "User Interface";
+      case MENU_ENUM_LABEL_VALUE_USER_LANGUAGE:
+         return "Language";
+      case MENU_ENUM_LABEL_VALUE_USER_SETTINGS:
+         return "User";
+      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_IMAGE_VIEWER:
+         return "Use Builtin Image Viewer";
+      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_PLAYER:
+         return "Use Builtin Media Player";
+      case MENU_ENUM_LABEL_VALUE_USE_THIS_DIRECTORY:
+         return "<Use this directory>";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ALLOW_ROTATE:
+         return "Allow rotation";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_AUTO:
+         return "Auto Aspect Ratio";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_INDEX:
+         return "Aspect Ratio Index";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_BLACK_FRAME_INSERTION:
+         return "Black Frame Insertion";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_CROP_OVERSCAN:
+         return "Crop Overscan (Reload)";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_DISABLE_COMPOSITION:
+         return "Disable Desktop Composition";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_DRIVER:
+         return "Video Driver";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER:
+         return "Video Filter";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_DIR:
+         return "Video Filter Dir";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_FLICKER:
+         return "Flicker filter";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_ENABLE:
+         return "Display OSD Message";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_PATH:
+         return "OSD Message Font";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_SIZE:
+         return "OSD Message Size";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_ASPECT:
+         return "Force aspect ratio";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_SRGB_DISABLE:
+         return "Force-disable sRGB FBO";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FRAME_DELAY:
+         return "Frame Delay";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FULLSCREEN:
+         return "Use Fullscreen Mode";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_GAMMA:
+         return "Video Gamma";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_RECORD:
+         return "GPU Record Enable";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_SCREENSHOT:
+         return "GPU Screenshot Enable";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC:
+         return "Hard GPU Sync";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC_FRAMES:
+         return "Hard GPU Sync Frames";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MAX_SWAPCHAIN_IMAGES:
+         return "Max swapchain images";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_X:
+         return "OSD Message X Position";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_Y:
+         return "OSD Message Y Position";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MONITOR_INDEX:
+         return "Monitor Index";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_POST_FILTER_RECORD:
+         return "Post filter record Enable";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE:
+         return "Refresh Rate";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE_AUTO:
+         return "Estimated Monitor Framerate";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ROTATION:
+         return "Rotation";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE:
+         return "Windowed Scale";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE_INTEGER:
+         return "Integer Scale";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SETTINGS:
+         return "Video";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_DIR:
+         return "Video Shader Dir";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_NUM_PASSES:
+         return "Shader Passes";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PARAMETERS:
+         return "Preview Shader Parameters";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET:
+         return "Load Shader Preset";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_PARAMETERS:
+         return "Menu Shader Parameters";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_AS:
+         return "Save Shader Preset As";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_CORE:
+         return "Save Core Preset";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_GAME:
+         return "Save Game Preset";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHARED_CONTEXT:
+         return "HW Shared Context Enable";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SMOOTH:
+         return "HW Bilinear Filtering";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SOFT_FILTER:
+         return "Soft Filter Enable";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SWAP_INTERVAL:
+         return "VSync Swap Interval";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_TAB:
+         return "Video";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_THREADED:
+         return "Threaded Video";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VFILTER:
+         return "Deflicker";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_HEIGHT:
+         return "Custom Viewport Height";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_WIDTH:
+         return "Custom Viewport Width";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_X:
+         return "Custom Viewport X";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_Y:
+         return "Custom Viewport Y";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VI_WIDTH:
+         return "Set VI Screen Width";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VSYNC:
+         return "VSync";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_WINDOWED_FULLSCREEN:
+         return "Windowed Fullscreen Mode";
+      case MENU_ENUM_LABEL_VALUE_WIFI_DRIVER:
+         return "Wi-Fi Driver";
+      case MENU_ENUM_LABEL_VALUE_WIFI_SETTINGS:
+         return "Wi-Fi";
+      case MENU_ENUM_LABEL_VALUE_XMB_ALPHA_FACTOR:
+         return "Menu Alpha Factor";
+      case MENU_ENUM_LABEL_VALUE_XMB_FONT:
+         return "Menu Font";
+      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_CUSTOM:
+         return "Custom";
+      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_FLATUI:
+         return "FlatUI";
+      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_MONOCHROME:
+         return "Monochrome";
+      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_MONOCHROME_JAGGED:
+         return "Monochrome Jagged";
+      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_NEOACTIVE:
+         return "NeoActive";
+      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_PIXEL:
+         return "Pixel";
+      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_RETROACTIVE:
+         return "RetroActive";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME:
+         return "Menu Color Theme";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_APPLE_GREEN:
+         return "Apple Green";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_DARK:
+         return "Dark";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_DARK_PURPLE:
+         return "Dark Purple";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_ELECTRIC_BLUE:
+         return "Electric Blue";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_GOLDEN:
+         return "Golden";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_LEGACY_RED:
+         return "Legacy Red";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_MIDNIGHT_BLUE:
+         return "Midnight Blue";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_PLAIN:
+         return "Plain";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_UNDERSEA:
+         return "Undersea";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_VOLCANIC_RED:
+         return "Volcanic Red";
+      case MENU_ENUM_LABEL_VALUE_XMB_RIBBON_ENABLE:
+         return "Menu Shader Pipeline";
+      case MENU_ENUM_LABEL_VALUE_XMB_SCALE_FACTOR:
+         return "Menu Scale Factor";
+      case MENU_ENUM_LABEL_VALUE_XMB_SHADOWS_ENABLE:
+         return "Icon Shadows Enable";
+      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_HISTORY:
+         return "Show History Tab";
+      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_IMAGES:
+         return "Show Images Tab";
+      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_MUSIC:
+         return "Show Music Tab";
+      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_SETTINGS:
+         return "Show Settings Tab";
+      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_VIDEO:
+         return "Show Video Tab";
+      case MENU_ENUM_LABEL_VALUE_XMB_THEME:
+         return "Menu Icon Theme";
+      case MENU_ENUM_LABEL_VALUE_YES:
+         return "Yes";
+      case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_TWO:
+         return "Shader Preset";
+      case MENU_ENUM_SUBLABEL_ADD_CONTENT_LIST:
+         return "Scan contents and add to the database.";
+      case MENU_ENUM_SUBLABEL_AUDIO_SETTINGS:
+         return "Adjusts settings for audio output.";
+      case MENU_ENUM_SUBLABEL_BLUETOOTH_ENABLE:
+         return "Enable or disable bluetooth.";
+      case MENU_ENUM_SUBLABEL_CONFIG_SAVE_ON_EXIT:
+         return "Saves changes to configuration file on exit.";
+      case MENU_ENUM_SUBLABEL_CPU_CORES:
+         return "Amount of cores that the CPU has.";
+      case MENU_ENUM_SUBLABEL_FPS_SHOW:
+         return "Displays the current framerate per second onscreen.";
+      case MENU_ENUM_SUBLABEL_INPUT_HOTKEY_BINDS:
+         return "Configure hotkey settings.";
+      case MENU_ENUM_SUBLABEL_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
+         return "Gamepad button combination to toggle menu.";
+      case MENU_ENUM_SUBLABEL_INPUT_SETTINGS:
+         return "Adjusts settings for joypads, keyboard and mouse.";
+      case MENU_ENUM_SUBLABEL_INPUT_USER_BINDS:
+         return "Configure controls for this user.";
+      case MENU_ENUM_SUBLABEL_LOG_VERBOSITY:
+         return "Enable or disable logging to the terminal.";
+      case MENU_ENUM_SUBLABEL_NETPLAY:
+         return "Join or host a netplay session.";
+      case MENU_ENUM_SUBLABEL_ONLINE_UPDATER:
+         return "Download add-ons, components and contents for RetroArch.";
+      case MENU_ENUM_SUBLABEL_SAMBA_ENABLE:
+         return "Enable or disable network sharing of your folders.";
+      case MENU_ENUM_SUBLABEL_SERVICES_SETTINGS:
+         return "Manage operating system level services.";
+      case MENU_ENUM_SUBLABEL_SHOW_HIDDEN_FILES:
+         return "Show hidden files/directories inside the file browser.";
+      case MENU_ENUM_SUBLABEL_SSH_ENABLE:
+         return "Enable or disable remote command line access.";
+      case MENU_ENUM_SUBLABEL_SUSPEND_SCREENSAVER_ENABLE:
+         return "Prevents your system's screensaver from becoming active.";
+      case MENU_ENUM_SUBLABEL_USER_LANGUAGE:
+         return "Sets the language of the interface.";
+      case MENU_ENUM_SUBLABEL_VIDEO_BLACK_FRAME_INSERTION:
+         return "Inserts a black frame inbetween frames. Useful for users of 120 Hz monitors who want to play 60 Hz material with eliminated ghosting.";
+      case MENU_ENUM_SUBLABEL_VIDEO_FRAME_DELAY:
+         return "Reduces latency at the cost of higher risk of video stuttering. Adds a delay after V-Sync (in ms).";
+      case MENU_ENUM_SUBLABEL_VIDEO_HARD_SYNC_FRAMES:
+         return "Sets how many frames the CPU can run ahead of the GPU when using 'Hard GPU Sync'.";
+      case MENU_ENUM_SUBLABEL_VIDEO_MAX_SWAPCHAIN_IMAGES:
+         return "Tells the video driver to explicitly use a specified buffering mode.";
+      case MENU_ENUM_SUBLABEL_VIDEO_MONITOR_INDEX:
+         return "Selects which display monitor to use.";
+      case MENU_ENUM_SUBLABEL_VIDEO_REFRESH_RATE_AUTO:
+         return "The accurate estimated refresh rate of the monitor in Hz.";
+      case MENU_ENUM_SUBLABEL_VIDEO_SETTINGS:
+         return "Adjusts settings for video output.";
+      case MENU_ENUM_SUBLABEL_WIFI_SETTINGS:
+         return "Scans for wireless networks and establishes connection.";
+      case MSG_APPENDED_DISK:
+         return "Appended disk";
+      case MSG_APPLICATION_DIR:
+         return "Application Dir";
+      case MSG_APPLYING_CHEAT:
+         return "Applying cheat changes.";
+      case MSG_APPLYING_SHADER:
+         return "Applying shader";
+      case MSG_AUDIO_MUTED:
+         return "Audio muted.";
+      case MSG_AUDIO_UNMUTED:
+         return "Audio unmuted.";
+      case MSG_AUTOCONFIG_FILE_ERROR_SAVING:
+         return "Error saving autoconf file.";
+      case MSG_AUTOCONFIG_FILE_SAVED_SUCCESSFULLY:
+         return "Autoconfig file saved successfully.";
+      case MSG_AUTOSAVE_FAILED:
+         return "Could not initialize autosave.";
+      case MSG_AUTO_SAVE_STATE_TO:
+         return "Auto save state to";
+      case MSG_BLOCKING_SRAM_OVERWRITE:
+         return "Blocking SRAM Overwrite";
+      case MSG_BRINGING_UP_COMMAND_INTERFACE_ON_PORT:
+         return "Bringing up command interface on port";
+      case MSG_BYTES:
+         return "bytes";
+      case MSG_CANNOT_INFER_NEW_CONFIG_PATH:
+         return "Cannot infer new config path. Use current time.";
+      case MSG_CHEEVOS_HARDCORE_MODE_ENABLE:
+         return "Hardcore Mode Enabled: savestate & rewind were disabled.";
+      case MSG_COMPARING_WITH_KNOWN_MAGIC_NUMBERS:
+         return "Comparing with known magic numbers...";
+      case MSG_COMPILED_AGAINST_API:
+         return "Compiled against API";
+      case MSG_CONFIG_DIRECTORY_NOT_SET:
+         return "Config directory not set. Cannot save new config.";
+      case MSG_CONNECTED_TO:
+         return "Connected to";
+      case MSG_CONTENT_CRC32S_DIFFER:
+         return "Content CRC32s differ. Cannot use different games.";
+      case MSG_CONTENT_LOADING_SKIPPED_IMPLEMENTATION_WILL_DO_IT:
+         return "Content loading skipped. Implementation will load it on its own.";
+      case MSG_CORE_DOES_NOT_SUPPORT_SAVESTATES:
+         return "Core does not support save states.";
+      case MSG_CORE_OPTIONS_FILE_CREATED_SUCCESSFULLY:
+         return "Core options file created successfully.";
+      case MSG_COULD_NOT_FIND_ANY_NEXT_DRIVER:
+         return "Could not find any next driver";
+      case MSG_COULD_NOT_FIND_COMPATIBLE_SYSTEM:
+         return "Could not find compatible system.";
+      case MSG_COULD_NOT_FIND_VALID_DATA_TRACK:
+         return "Could not find valid data track";
+      case MSG_COULD_NOT_OPEN_DATA_TRACK:
+         return "could not open data track";
+      case MSG_COULD_NOT_READ_CONTENT_FILE:
+         return "Could not read content file";
+      case MSG_COULD_NOT_READ_MOVIE_HEADER:
+         return "Could not read movie header.";
+      case MSG_COULD_NOT_READ_STATE_FROM_MOVIE:
+         return "Could not read state from movie.";
+      case MSG_CRC32_CHECKSUM_MISMATCH:
+         return "CRC32 checksum mismatch between content file and saved content checksum in replay file header; replay highly likely to desync on playback.";
+      case MSG_CUSTOM_TIMING_GIVEN:
+         return "Custom timing given";
+      case MSG_DECOMPRESSION_ALREADY_IN_PROGRESS:
+         return "Decompression already in progress.";
+      case MSG_DECOMPRESSION_FAILED:
+         return "Decompression failed.";
+      case MSG_DETECTED_VIEWPORT_OF:
+         return "Detected viewport of";
+      case MSG_DID_NOT_FIND_A_VALID_CONTENT_PATCH:
+         return "Did not find a valid content patch.";
+      case MSG_DISCONNECT_DEVICE_FROM_A_VALID_PORT:
+         return "Disconnect device from a valid port.";
+      case MSG_DISK_CLOSED:
+         return "Closed";
+      case MSG_DISK_EJECTED:
+         return "Ejected";
+      case MSG_DOWNLOADING:
+         return "Downloading";
+      case MSG_DOWNLOAD_FAILED:
+         return "Download failed";
+      case MSG_ERROR:
+         return "Error";
+      case MSG_ERROR_LIBRETRO_CORE_REQUIRES_CONTENT:
+         return "Libretro core requires content, but nothing was provided.";
+      case MSG_ERROR_LIBRETRO_CORE_REQUIRES_SPECIAL_CONTENT:
+         return "Libretro core requires special content, but none were provided.";
+      case MSG_ERROR_PARSING_ARGUMENTS:
+         return "Error parsing arguments.";
+      case MSG_ERROR_SAVING_CORE_OPTIONS_FILE:
+         return "Error saving core options file.";
+      case MSG_ERROR_SAVING_REMAP_FILE:
+         return "Error saving remap file.";
+      case MSG_ERROR_SAVING_SHADER_PRESET:
+         return "Error saving shader preset.";
+      case MSG_EXTERNAL_APPLICATION_DIR:
+         return "External Application Dir";
+      case MSG_EXTRACTING:
+         return "Extracting";
+      case MSG_EXTRACTING_FILE:
+         return "Extracting file";
+      case MSG_FAILED_SAVING_CONFIG_TO:
+         return "Failed saving config to";
+      case MSG_FAILED_TO:
+         return "Failed to";
+      case MSG_FAILED_TO_ACCEPT_INCOMING_SPECTATOR:
+         return "Failed to accept incoming spectator.";
+      case MSG_FAILED_TO_ALLOCATE_MEMORY_FOR_PATCHED_CONTENT:
+         return "Failed to allocate memory for patched content...";
+      case MSG_FAILED_TO_APPLY_SHADER:
+         return "Failed to apply shader.";
+      case MSG_FAILED_TO_BIND_SOCKET:
+         return "Failed to bind socket.";
+      case MSG_FAILED_TO_CREATE_THE_DIRECTORY:
+         return "Failed to create the directory.";
+      case MSG_FAILED_TO_EXTRACT_CONTENT_FROM_COMPRESSED_FILE:
+         return "Failed to extract content from compressed file";
+      case MSG_FAILED_TO_GET_NICKNAME_FROM_CLIENT:
+         return "Failed to get nickname from client.";
+      case MSG_FAILED_TO_LOAD:
+         return "Failed to load";
+      case MSG_FAILED_TO_LOAD_CONTENT:
+         return "Failed to load content";
+      case MSG_FAILED_TO_LOAD_MOVIE_FILE:
+         return "Failed to load movie file";
+      case MSG_FAILED_TO_LOAD_OVERLAY:
+         return "Failed to load overlay.";
+      case MSG_FAILED_TO_LOAD_STATE:
+         return "Failed to load state from";
+      case MSG_FAILED_TO_OPEN_LIBRETRO_CORE:
+         return "Failed to open libretro core";
+      case MSG_FAILED_TO_PATCH:
+         return "Failed to patch";
+      case MSG_FAILED_TO_RECEIVE_HEADER_FROM_CLIENT:
+         return "Failed to receive header from client.";
+      case MSG_FAILED_TO_RECEIVE_NICKNAME:
+         return "Failed to receive nickname.";
+      case MSG_FAILED_TO_RECEIVE_NICKNAME_FROM_HOST:
+         return "Failed to receive nickname from host.";
+      case MSG_FAILED_TO_RECEIVE_NICKNAME_SIZE_FROM_HOST:
+         return "Failed to receive nickname size from host.";
+      case MSG_FAILED_TO_RECEIVE_SRAM_DATA_FROM_HOST:
+         return "Failed to receive SRAM data from host.";
+      case MSG_FAILED_TO_REMOVE_DISK_FROM_TRAY:
+         return "Failed to remove disk from tray.";
+      case MSG_FAILED_TO_REMOVE_TEMPORARY_FILE:
+         return "Failed to remove temporary file";
+      case MSG_FAILED_TO_SAVE_SRAM:
+         return "Failed to save SRAM";
+      case MSG_FAILED_TO_SAVE_STATE_TO:
+         return "Failed to save state to";
+      case MSG_FAILED_TO_SEND_NICKNAME:
+         return "Failed to send nickname.";
+      case MSG_FAILED_TO_SEND_NICKNAME_SIZE:
+         return "Failed to send nickname size.";
+      case MSG_FAILED_TO_SEND_NICKNAME_TO_CLIENT:
+         return "Failed to send nickname to client.";
+      case MSG_FAILED_TO_SEND_NICKNAME_TO_HOST:
+         return "Failed to send nickname to host.";
+      case MSG_FAILED_TO_SEND_SRAM_DATA_TO_CLIENT:
+         return "Failed to send SRAM data to client.";
+      case MSG_FAILED_TO_START_AUDIO_DRIVER:
+         return "Failed to start audio driver. Will continue without audio.";
+      case MSG_FAILED_TO_START_MOVIE_RECORD:
+         return "Failed to start movie record.";
+      case MSG_FAILED_TO_START_RECORDING:
+         return "Failed to start recording.";
+      case MSG_FAILED_TO_TAKE_SCREENSHOT:
+         return "Failed to take screenshot.";
+      case MSG_FAILED_TO_UNDO_LOAD_STATE:
+         return "Failed to undo load state.";
+      case MSG_FAILED_TO_UNDO_SAVE_STATE:
+         return "Failed to undo save state.";
+      case MSG_FAILED_TO_UNMUTE_AUDIO:
+         return "Failed to unmute audio.";
+      case MSG_FATAL_ERROR_RECEIVED_IN:
+         return "Fatal error received in";
+      case MSG_FILE_NOT_FOUND:
+         return "File not found";
+      case MSG_FOUND_AUTO_SAVESTATE_IN:
+         return "Found auto savestate in";
+      case MSG_FOUND_DISK_LABEL:
+         return "Found disk label";
+      case MSG_FOUND_FIRST_DATA_TRACK_ON_FILE:
+         return "Found first data track on file";
+      case MSG_FOUND_LAST_STATE_SLOT:
+         return "Found last state slot";
+      case MSG_FOUND_SHADER:
+         return "Found shader";
+      case MSG_FRAMES:
+         return "Frames";
+      case MSG_GAME_SPECIFIC_CORE_OPTIONS_FOUND_AT:
+         return "Per-Game Options: game-specific core options found at";
+      case MSG_GOT_INVALID_DISK_INDEX:
+         return "Got invalid disk index.";
+      case MSG_GRAB_MOUSE_STATE:
+         return "Grab mouse state";
+      case MSG_HW_RENDERED_MUST_USE_POSTSHADED_RECORDING:
+         return "Libretro core is hardware rendered. Must use post-shaded recording as well.";
+      case MSG_INFLATED_CHECKSUM_DID_NOT_MATCH_CRC32:
+         return "Inflated checksum did not match CRC32.";
+      case MSG_INPUT_CHEAT:
+         return "Input Cheat";
+      case MSG_INPUT_CHEAT_FILENAME:
+         return "Cheat Filename";
+      case MSG_INPUT_PRESET_FILENAME:
+         return "Preset Filename";
+      case MSG_INTERFACE:
+         return "Interface";
+      case MSG_INTERNAL_MEMORY:
+         return "Internal Memory";
+      case MSG_INVALID_NICKNAME_SIZE:
+         return "Invalid nickname size.";
+      case MSG_IN_BYTES:
+         return "in bytes";
+      case MSG_IN_GIGABYTES:
+         return "in gigabytes";
+      case MSG_IN_MEGABYTES:
+         return "in megabytes";
+      case MSG_LIBRETRO_ABI_BREAK:
+         return "is compiled against a different version of libretro than this libretro implementation.";
+      case MSG_LIBRETRO_FRONTEND:
+         return "Frontend for libretro";
+      case MSG_LOADED_STATE_FROM_SLOT:
+         return "Loaded state from slot";
+      case MSG_LOADING:
+         return "Loading";
+      case MSG_LOADING_CONTENT_FILE:
+         return "Loading content file";
+      case MSG_LOADING_HISTORY_FILE:
+         return "Loading history file";
+      case MSG_LOADING_STATE:
+         return "Loading state";
+      case MSG_MEMORY:
+         return "Memory";
+      case MSG_MOVIE_FILE_IS_NOT_A_VALID_BSV1_FILE:
+         return "Movie file is not a valid BSV1 file.";
+      case MSG_MOVIE_FORMAT_DIFFERENT_SERIALIZER_VERSION:
+         return "Movie format seems to have a different serializer version. Will most likely fail.";
+      case MSG_MOVIE_PLAYBACK_ENDED:
+         return "Movie playback ended.";
+      case MSG_MOVIE_RECORD_STOPPED:
+         return "Stopping movie record.";
+      case MSG_NETPLAY_FAILED:
+         return "Failed to initialize netplay.";
+      case MSG_NETPLAY_FAILED_MOVIE_PLAYBACK_HAS_STARTED:
+         return "Movie playback has started. Cannot start netplay.";
+      case MSG_NO_CONTENT_STARTING_DUMMY_CORE:
+         return "No content, starting dummy core.";
+      case MSG_NO_SAVE_STATE_HAS_BEEN_OVERWRITTEN_YET:
+         return "No save state has been overwritten yet.";
+      case MSG_NO_STATE_HAS_BEEN_LOADED_YET:
+         return "No state has been loaded yet.";
+      case MSG_OVERRIDES_ERROR_SAVING:
+         return "Error saving overrides.";
+      case MSG_OVERRIDES_SAVED_SUCCESSFULLY:
+         return "Overrides saved successfully.";
+      case MSG_PAUSED:
+         return "Paused.";
+      case MSG_PROGRAM:
+         return "RetroArch";
+      case MSG_READING_FIRST_DATA_TRACK:
+         return "Reading first data track...";
+      case MSG_RECEIVED:
+         return "received";
+      case MSG_RECORDING_TERMINATED_DUE_TO_RESIZE:
+         return "Recording terminated due to resize.";
+      case MSG_RECORDING_TO:
+         return "Recording to";
+      case MSG_REDIRECTING_CHEATFILE_TO:
+         return "Redirecting cheat file to";
+      case MSG_REDIRECTING_SAVEFILE_TO:
+         return "Redirecting save file to";
+      case MSG_REDIRECTING_SAVESTATE_TO:
+         return "Redirecting savestate to";
+      case MSG_REMAP_FILE_SAVED_SUCCESSFULLY:
+         return "Remap file saved successfully.";
+      case MSG_REMOVED_DISK_FROM_TRAY:
+         return "Removed disk from tray.";
+      case MSG_REMOVING_TEMPORARY_CONTENT_FILE:
+         return "Removing temporary content file";
+      case MSG_RESET:
+         return "Reset";
+      case MSG_RESTARTING_RECORDING_DUE_TO_DRIVER_REINIT:
+         return "Restarting recording due to driver reinit.";
+      case MSG_RESTORED_OLD_SAVE_STATE:
+         return "Restored old save state.";
+      case MSG_RESTORING_DEFAULT_SHADER_PRESET_TO:
+         return "Shaders: restoring default shader preset to";
+      case MSG_REVERTING_SAVEFILE_DIRECTORY_TO:
+         return "Reverting savefile directory to";
+      case MSG_REVERTING_SAVESTATE_DIRECTORY_TO:
+         return "Reverting savestate directory to";
+      case MSG_REWINDING:
+         return "Rewinding.";
+      case MSG_REWIND_INIT:
+         return "Initializing rewind buffer with size";
+      case MSG_REWIND_INIT_FAILED:
+         return "Failed to initialize rewind buffer. Rewinding will be disabled.";
+      case MSG_REWIND_INIT_FAILED_THREADED_AUDIO:
+         return "Implementation uses threaded audio. Cannot use rewind.";
+      case MSG_REWIND_REACHED_END:
+         return "Reached end of rewind buffer.";
+      case MSG_SAVED_NEW_CONFIG_TO:
+         return "Saved new config to";
+      case MSG_SAVED_STATE_TO_SLOT:
+         return "Saved state to slot";
+      case MSG_SAVED_SUCCESSFULLY_TO:
+         return "Saved successfully to";
+      case MSG_SAVING_RAM_TYPE:
+         return "Saving RAM type";
+      case MSG_SAVING_STATE:
+         return "Saving state";
+      case MSG_SCANNING:
+         return "Scanning";
+      case MSG_SCANNING_OF_DIRECTORY_FINISHED:
+         return "Scanning of directory finished";
+      case MSG_SENDING_COMMAND:
+         return "Sending command";
+      case MSG_SEVERAL_PATCHES_ARE_EXPLICITLY_DEFINED:
+         return "Several patches are explicitly defined, ignoring all...";
+      case MSG_SHADER:
+         return "Shader";
+      case MSG_SHADER_PRESET_SAVED_SUCCESSFULLY:
+         return "Shader preset saved successfully.";
+      case MSG_SKIPPING_SRAM_LOAD:
+         return "Skipping SRAM load.";
+      case MSG_SLOW_MOTION:
+         return "Slow motion.";
+      case MSG_SLOW_MOTION_REWIND:
+         return "Slow motion rewind.";
+      case MSG_SRAM_WILL_NOT_BE_SAVED:
+         return "SRAM will not be saved.";
+      case MSG_STARTING_MOVIE_PLAYBACK:
+         return "Starting movie playback.";
+      case MSG_STARTING_MOVIE_RECORD_TO:
+         return "Starting movie record to";
+      case MSG_STATE_SIZE:
+         return "State size";
+      case MSG_STATE_SLOT:
+         return "State slot";
+      case MSG_TAKING_SCREENSHOT:
+         return "Taking screenshot.";
+      case MSG_TO:
+         return "to";
+      case MSG_UNDID_LOAD_STATE:
+         return "Undid load state.";
+      case MSG_UNDOING_SAVE_STATE:
+         return "Undoing save state";
+      case MSG_UNKNOWN:
+         return "Unknown";
+      case MSG_UNPAUSED:
+         return "Unpaused.";
+      case MSG_UNRECOGNIZED_COMMAND:
+         return "Unrecognized command";
+      case MSG_USING_CORE_NAME_FOR_NEW_CONFIG:
+         return "Using core name for new config.";
+      case MSG_USING_LIBRETRO_DUMMY_CORE_RECORDING_SKIPPED:
+         return "Using libretro dummy core. Skipping recording.";
+      case MSG_VALUE_CONNECT_DEVICE_FROM_A_VALID_PORT:
+         return "Connect device from a valid port.";
+      case MSG_VALUE_DISCONNECTING_DEVICE_FROM_PORT:
+         return "Disconnecting device from port";
+      case MSG_VALUE_REBOOTING:
+         return "Rebooting...";
+      case MSG_VALUE_SHUTTING_DOWN:
+         return "Shutting down...";
+      case MSG_VERSION_OF_LIBRETRO_API:
+         return "Version of libretro API";
+      case MSG_VIEWPORT_SIZE_CALCULATION_FAILED:
+         return "Viewport size calculation failed! Will continue using raw data. This will probably not work right ...";
+      case MSG_VIRTUAL_DISK_TRAY:
+         return "virtual disk tray.";
       default:
 #if 0
          RARCH_LOG("Unimplemented: [%d]\n", msg);

--- a/intl/msg_hash_vn.c
+++ b/intl/msg_hash_vn.c
@@ -1898,156 +1898,484 @@ static const char *menu_hash_to_str_vn_label_enum(enum msg_hash_enums msg)
 
    switch (msg)
    {
-      case MENU_ENUM_SUBLABEL_VIDEO_THREADED:
-         return "Improves performance at the cost of latency and more video stuttering. Use only if you cannot obtain full speed otherwise.";
-      case MENU_ENUM_SUBLABEL_VIDEO_HARD_SYNC:
-         return "Hard-synchronize the CPU and GPU. Reduces latency at the cost of performance.";
-      case MENU_ENUM_SUBLABEL_MENU_SETTINGS:
-         return "Điều chỉnh thiết lập related to the appearance of the menu screen.";
-      case MSG_CONNECTION_SLOT:
-         return "Khe kết nối";
-      case MSG_WAITING_FOR_CLIENT:
-         return "Đang đợi máy khách  ...";
-      case MSG_CONNECTING_TO_NETPLAY_HOST:
-         return "Đang kết nối vào máy chủ netplay";
-      case MSG_GOT_CONNECTION_FROM:
-         return "Được kết nối từ";
-      case MSG_AUTODETECT:
-         return "Tự động phát hiện";
-      case MSG_SUCCEEDED:
-         return "Đã thành công";
-      case MSG_FAILED:
-         return "Bị Lỗi";
-      case MSG_UNKNOWN_NETPLAY_COMMAND_RECEIVED:
-         return "Netplay không biết lệnh nhận được";
-      case MSG_NETPLAY_USERS_HAS_FLIPPED:
-         return "Người dùng Netplay đã flipped";
-      case MSG_FILE_ALREADY_EXISTS_SAVING_TO_BACKUP_BUFFER:
-         return "Ttệp đã tồn tại. Đang lưu vào backup buffer";
-      case MSG_AUTOLOADING_SAVESTATE_FROM:
-         return "Đang tự đông tải savestate từ";
-      case MSG_CONNECTING_TO_PORT:
-         return "Đang kết nối vào port";
-      case MSG_SETTING_DISK_IN_TRAY:
-         return "Setting disk in tray";
-      case MSG_AUDIO_VOLUME:
-         return "Âm lượng âm thanh";
-      case MSG_FAILED_TO_SET_DISK:
-         return "Failed to set disk";
-      case MSG_FAILED_TO_START_AUDIO_DRIVER:
-         return "failed_to_start_audio_driver";
-      case MSG_FOUND_LAST_STATE_SLOT:
-         return "found_last_state_slot";
-      case MSG_DEVICE_CONFIGURED_IN_PORT:
-         return "configured in port";
-      case MSG_DEVICE_NOT_CONFIGURED:
-         return "not configured";
-      case MSG_DEVICE_DISCONNECTED_FROM_PORT:
-        return "Device disconnected from port";
-      case MSG_CONNECT_DEVICE_FROM_A_VALID_PORT:
-         return "connect_device_from_a_valid_port";
-      case MSG_DISCONNECT_DEVICE_FROM_A_VALID_PORT:
-         return "disconnect_device_from_a_valid_port";
-      case MSG_DISCONNECTING_DEVICE_FROM_PORT:
-         return "disconnecting_device_from_port";
-      case MSG_BRINGING_UP_COMMAND_INTERFACE_ON_PORT:
-         return "bringing_up_command_interface_at_port";
-      case MENU_ENUM_LABEL_VIDEO_MAX_SWAPCHAIN_IMAGES:
-         return "video_max_swapchain_images";
-      case MENU_ENUM_LABEL_CORE_SETTINGS:
-         return "core_settings";
-      case MENU_ENUM_LABEL_CB_MENU_WALLPAPER:
-         return "cb_menu_wallpaper";
-      case MENU_ENUM_LABEL_CB_MENU_THUMBNAIL:
-         return "cb_menu_thumbnail";
-      case MENU_ENUM_LABEL_CB_LAKKA_LIST:
-         return "cb_lakka_list";
-      case MENU_ENUM_LABEL_CB_THUMBNAILS_UPDATER_LIST:
-         return "cb_thumbnails_updater_list";
-      case MENU_ENUM_LABEL_CB_CORE_UPDATER_LIST:
-         return "cb_core_updater_list";
-      case MENU_ENUM_LABEL_CB_CORE_CONTENT_LIST:
-         return "cb_core_content_list";
+      case MENU_ENUM_LABEL_ACCOUNTS_CHEEVOS_USERNAME:
+         return "accounts_cheevos_username";
+      case MENU_ENUM_LABEL_ACCOUNTS_LIST:
+         return "accounts_list";
+      case MENU_ENUM_LABEL_ACCOUNTS_RETRO_ACHIEVEMENTS:
+         return "retro_achievements";
+      case MENU_ENUM_LABEL_ACHIEVEMENT_LIST:
+         return "achievement_list";
+      case MENU_ENUM_LABEL_ADD_CONTENT_LIST:
+         return "add_content";
+      case MENU_ENUM_LABEL_ADD_TAB:
+         return "add_tab";
+      case MENU_ENUM_LABEL_ARCHIVE_MODE:
+         return "archive_mode";
+      case MENU_ENUM_LABEL_ASSETS_DIRECTORY:
+         return "assets_directory";
+      case MENU_ENUM_LABEL_AUDIO_BLOCK_FRAMES:
+         return "audio_block_frames";
+      case MENU_ENUM_LABEL_AUDIO_DEVICE:
+         return "audio_device";
+      case MENU_ENUM_LABEL_AUDIO_DRIVER:
+         return "audio_driver";
+      case MENU_ENUM_LABEL_AUDIO_DSP_PLUGIN:
+         return "audio_dsp_plugin";
+      case MENU_ENUM_LABEL_AUDIO_ENABLE:
+         return "audio_enable";
+      case MENU_ENUM_LABEL_AUDIO_FILTER_DIR:
+         return "audio_filter_dir";
+      case MENU_ENUM_LABEL_AUDIO_LATENCY:
+         return "audio_latency";
+      case MENU_ENUM_LABEL_AUDIO_MAX_TIMING_SKEW:
+         return "audio_max_timing_skew";
+      case MENU_ENUM_LABEL_AUDIO_MUTE:
+         return "audio_mute_enable";
+      case MENU_ENUM_LABEL_AUDIO_OUTPUT_RATE:
+         return "audio_output_rate";
+      case MENU_ENUM_LABEL_AUDIO_RATE_CONTROL_DELTA:
+         return "audio_rate_control_delta";
+      case MENU_ENUM_LABEL_AUDIO_RESAMPLER_DRIVER:
+         return "audio_resampler_driver";
+      case MENU_ENUM_LABEL_AUDIO_SETTINGS:
+         return "audio_settings";
+      case MENU_ENUM_LABEL_AUDIO_SYNC:
+         return "audio_sync";
+      case MENU_ENUM_LABEL_AUDIO_VOLUME:
+         return "audio_volume";
+      case MENU_ENUM_LABEL_AUTOSAVE_INTERVAL:
+         return "autosave_interval";
+      case MENU_ENUM_LABEL_AUTO_OVERRIDES_ENABLE:
+         return "auto_overrides_enable";
+      case MENU_ENUM_LABEL_AUTO_REMAPS_ENABLE:
+         return "auto_remaps_enable";
+      case MENU_ENUM_LABEL_AUTO_SHADERS_ENABLE:
+         return "auto_shaders_enable";
+      case MENU_ENUM_LABEL_BLOCK_SRAM_OVERWRITE:
+         return "block_sram_overwrite";
+      case MENU_ENUM_LABEL_BLUETOOTH_ENABLE:
+         return "bluetooth_enable";
+      case MENU_ENUM_LABEL_BUILDBOT_ASSETS_URL:
+         return "buildbot_assets_url";
+      case MENU_ENUM_LABEL_CACHE_DIRECTORY:
+         return "cache_directory";
+      case MENU_ENUM_LABEL_CAMERA_ALLOW:
+         return "camera_allow";
+      case MENU_ENUM_LABEL_CAMERA_DRIVER:
+         return "camera_driver";
       case MENU_ENUM_LABEL_CB_CORE_CONTENT_DIRS_LIST:
          return "cb_core_content_dirs_list";
+      case MENU_ENUM_LABEL_CB_CORE_CONTENT_DOWNLOAD:
+         return "cb_core_content_download";
+      case MENU_ENUM_LABEL_CB_CORE_CONTENT_LIST:
+         return "cb_core_content_list";
       case MENU_ENUM_LABEL_CB_CORE_THUMBNAILS_DOWNLOAD:
          return "cb_core_thumbnails_download";
       case MENU_ENUM_LABEL_CB_CORE_UPDATER_DOWNLOAD:
          return "cb_core_updater_download";
-      case MENU_ENUM_LABEL_CB_UPDATE_CHEATS:
-         return "cb_update_cheats";
-      case MENU_ENUM_LABEL_CB_UPDATE_OVERLAYS:
-         return "cb_update_overlays";
-      case MENU_ENUM_LABEL_CB_UPDATE_DATABASES:
-         return "cb_update_databases";
-      case MENU_ENUM_LABEL_CB_UPDATE_SHADERS_GLSL:
-         return "cb_update_shaders_glsl";
-      case MENU_ENUM_LABEL_CB_UPDATE_SHADERS_CG:
-         return "cb_update_shaders_cg";
-      case MENU_ENUM_LABEL_CB_UPDATE_CORE_INFO_FILES:
-         return "cb_update_core_info_files";
-      case MENU_ENUM_LABEL_CB_CORE_CONTENT_DOWNLOAD:
-         return "cb_core_content_download";
+      case MENU_ENUM_LABEL_CB_CORE_UPDATER_LIST:
+         return "cb_core_updater_list";
+      case MENU_ENUM_LABEL_CB_DOWNLOAD_URL:
+         return "cb_download_url";
       case MENU_ENUM_LABEL_CB_LAKKA_DOWNLOAD:
          return "cb_lakka_download";
+      case MENU_ENUM_LABEL_CB_LAKKA_LIST:
+         return "cb_lakka_list";
+      case MENU_ENUM_LABEL_CB_MENU_THUMBNAIL:
+         return "cb_menu_thumbnail";
+      case MENU_ENUM_LABEL_CB_MENU_WALLPAPER:
+         return "cb_menu_wallpaper";
+      case MENU_ENUM_LABEL_CB_THUMBNAILS_UPDATER_DOWNLOAD:
+         return "cb_thumbnails_updater_download";
+      case MENU_ENUM_LABEL_CB_THUMBNAILS_UPDATER_LIST:
+         return "cb_thumbnails_updater_list";
       case MENU_ENUM_LABEL_CB_UPDATE_ASSETS:
          return "cb_update_assets";
       case MENU_ENUM_LABEL_CB_UPDATE_AUTOCONFIG_PROFILES:
          return "cb_update_autoconfig_profiles";
-      case MENU_ENUM_LABEL_CB_THUMBNAILS_UPDATER_DOWNLOAD:
-         return "cb_thumbnails_updater_download";
+      case MENU_ENUM_LABEL_CB_UPDATE_CHEATS:
+         return "cb_update_cheats";
+      case MENU_ENUM_LABEL_CB_UPDATE_CORE_INFO_FILES:
+         return "cb_update_core_info_files";
+      case MENU_ENUM_LABEL_CB_UPDATE_DATABASES:
+         return "cb_update_databases";
+      case MENU_ENUM_LABEL_CB_UPDATE_OVERLAYS:
+         return "cb_update_overlays";
+      case MENU_ENUM_LABEL_CB_UPDATE_SHADERS_CG:
+         return "cb_update_shaders_cg";
+      case MENU_ENUM_LABEL_CB_UPDATE_SHADERS_GLSL:
+         return "cb_update_shaders_glsl";
+      case MENU_ENUM_LABEL_CHEAT_APPLY_CHANGES:
+         return "cheat_apply_changes";
+      case MENU_ENUM_LABEL_CHEAT_DATABASE_PATH:
+         return "cheat_database_path";
+      case MENU_ENUM_LABEL_CHEAT_FILE_LOAD:
+         return "cheat_file_load";
+      case MENU_ENUM_LABEL_CHEAT_FILE_SAVE_AS:
+         return "cheat_file_save_as";
+      case MENU_ENUM_LABEL_CHEAT_NUM_PASSES:
+         return "cheat_num_passes";
+      case MENU_ENUM_LABEL_CHEEVOS_DESCRIPTION:
+         return "cheevos_description";
+      case MENU_ENUM_LABEL_CHEEVOS_ENABLE:
+         return "cheevos_enable";
+      case MENU_ENUM_LABEL_CHEEVOS_HARDCORE_MODE_ENABLE:
+         return "cheevos_hardcore_mode_enable";
+      case MENU_ENUM_LABEL_CHEEVOS_LOCKED_ACHIEVEMENTS:
+         return "cheevos_locked_achievements";
+      case MENU_ENUM_LABEL_CHEEVOS_LOCKED_ENTRY:
+         return "cheevos_locked_entry";
+      case MENU_ENUM_LABEL_CHEEVOS_PASSWORD:
+         return "cheevos_password";
+      case MENU_ENUM_LABEL_CHEEVOS_TEST_UNOFFICIAL:
+         return "cheevos_test_unofficial";
+      case MENU_ENUM_LABEL_CHEEVOS_UNLOCKED_ACHIEVEMENTS:
+         return "cheevos_unlocked_achievements";
+      case MENU_ENUM_LABEL_CHEEVOS_UNLOCKED_ENTRY:
+         return "cheevos_unlocked_entry";
+      case MENU_ENUM_LABEL_CHEEVOS_USERNAME:
+         return "cheevos_username";
+      case MENU_ENUM_LABEL_CLOSE_CONTENT:
+         return "unload_core";
+      case MENU_ENUM_LABEL_COLLECTION:
+         return "collection";
+      case MENU_ENUM_LABEL_CONFIGURATIONS:
+         return "configurations";
+      case MENU_ENUM_LABEL_CONFIGURATION_SETTINGS:
+         return "configuration_settings";
+      case MENU_ENUM_LABEL_CONFIG_SAVE_ON_EXIT:
+         return "config_save_on_exit";
+      case MENU_ENUM_LABEL_CONFIRM_ON_EXIT:
+         return "confirm_on_exit";
+      case MENU_ENUM_LABEL_CONNECT_WIFI:
+         return "connect_wifi";
       case MENU_ENUM_LABEL_CONTENT_ACTIONS:
          return "content_actions";
+      case MENU_ENUM_LABEL_CONTENT_COLLECTION_LIST:
+         return "select_from_collection";
+      case MENU_ENUM_LABEL_CONTENT_DATABASE_DIRECTORY:
+         return "content_database_path";
+      case MENU_ENUM_LABEL_CONTENT_HISTORY_SIZE:
+         return "content_history_size";
+      case MENU_ENUM_LABEL_CONTENT_SETTINGS:
+         return "quick_menu";
+      case MENU_ENUM_LABEL_CORE_ASSETS_DIRECTORY:
+         return "core_assets_directory";
+      case MENU_ENUM_LABEL_CORE_CHEAT_OPTIONS:
+         return "core_cheat_options";
+      case MENU_ENUM_LABEL_CORE_COUNTERS:
+         return "core_counters";
+      case MENU_ENUM_LABEL_CORE_ENABLE:
+         return "menu_core_enable";
+      case MENU_ENUM_LABEL_CORE_INFORMATION:
+         return "core_information";
+      case MENU_ENUM_LABEL_CORE_INFO_ENTRY:
+         return "core_info_entry";
+      case MENU_ENUM_LABEL_CORE_INPUT_REMAPPING_OPTIONS:
+         return "core_input_remapping_options";
+      case MENU_ENUM_LABEL_CORE_LIST:
+         return "load_core";
+      case MENU_ENUM_LABEL_CORE_OPTIONS:
+         return "core_options";
+      case MENU_ENUM_LABEL_CORE_OPTION_ENTRY:
+         return "core_option_entry";
+      case MENU_ENUM_LABEL_CORE_SETTINGS:
+         return "core_settings";
+      case MENU_ENUM_LABEL_CORE_SET_SUPPORTS_NO_CONTENT_ENABLE:
+         return "core_set_supports_no_content_enable";
+      case MENU_ENUM_LABEL_CORE_SPECIFIC_CONFIG:
+         return "core_specific_config";
+      case MENU_ENUM_LABEL_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
+         return "core_updater_auto_extract_archive";
+      case MENU_ENUM_LABEL_CORE_UPDATER_BUILDBOT_URL:
+         return "core_updater_buildbot_url";
+      case MENU_ENUM_LABEL_CORE_UPDATER_LIST:
+         return "core_updater_list";
       case MENU_ENUM_LABEL_CPU_ARCHITECTURE:
          return "system_information_cpu_architecture";
       case MENU_ENUM_LABEL_CPU_CORES:
          return "system_information_cpu_cores";
-      case MENU_ENUM_LABEL_NO_ITEMS:
-         return "no_items";
-      case MENU_ENUM_LABEL_NO_PLAYLISTS:
-         return "no_playlists";
-      case MENU_ENUM_LABEL_NO_HISTORY_AVAILABLE:
-         return "no_history";
-      case MENU_ENUM_LABEL_NO_SHADER_PARAMETERS:
-         return "no_shader_parameters.";
-      case MENU_ENUM_LABEL_SETTINGS_TAB:
-         return "settings_tab";
+      case MENU_ENUM_LABEL_CURSOR_DIRECTORY:
+         return "cursor_directory";
+      case MENU_ENUM_LABEL_CURSOR_MANAGER_LIST:
+         return "cursor_manager_list";
+      case MENU_ENUM_LABEL_CUSTOM_BIND:
+         return "custom_bind";
+      case MENU_ENUM_LABEL_CUSTOM_BIND_ALL:
+         return "custom_bind_all";
+      case MENU_ENUM_LABEL_CUSTOM_RATIO:
+         return "custom_ratio";
+      case MENU_ENUM_LABEL_DATABASE_MANAGER_LIST:
+         return "database_manager_list";
+      case MENU_ENUM_LABEL_DEFERRED_ACCOUNTS_CHEEVOS_LIST:
+         return "deferred_accounts_cheevos_list";
+      case MENU_ENUM_LABEL_DEFERRED_ACCOUNTS_LIST:
+         return "deferred_accounts_list";
+      case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_ACTION:
+         return "deferred_archive_action";
+      case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_ACTION_DETECT_CORE:
+         return "deferred_archive_action_detect_core";
+      case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_OPEN:
+         return "deferred_archive_open";
+      case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_OPEN_DETECT_CORE:
+         return "deferred_archive_open_detect_core";
+      case MENU_ENUM_LABEL_DEFERRED_AUDIO_SETTINGS_LIST:
+         return "deferred_audio_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_CONFIGURATION_SETTINGS_LIST:
+         return "deferred_configuration_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_CORE_CONTENT_DIRS_LIST:
+         return "deferred_core_content_dirs_list";
+      case MENU_ENUM_LABEL_DEFERRED_CORE_CONTENT_DIRS_SUBDIR_LIST:
+         return "deferred_core_content_dirs_subdir_list";
+      case MENU_ENUM_LABEL_DEFERRED_CORE_CONTENT_LIST:
+         return "deferred_core_content_list";
+      case MENU_ENUM_LABEL_DEFERRED_CORE_LIST:
+         return "deferred_core_list";
+      case MENU_ENUM_LABEL_DEFERRED_CORE_LIST_SET:
+         return "deferred_core_list_set";
+      case MENU_ENUM_LABEL_DEFERRED_CORE_SETTINGS_LIST:
+         return "deferred_core_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_CORE_UPDATER_LIST:
+         return "core_updater";
+      case MENU_ENUM_LABEL_DEFERRED_CURSOR_MANAGER_LIST:
+         return "deferred_cursor_manager_list";
+      case MENU_ENUM_LABEL_DEFERRED_DATABASE_MANAGER_LIST:
+         return "deferred_database_manager_list";
+      case MENU_ENUM_LABEL_DEFERRED_DIRECTORY_SETTINGS_LIST:
+         return "deferred_directory_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_DRIVER_SETTINGS_LIST:
+         return "deferred_driver_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_FRAME_THROTTLE_SETTINGS_LIST:
+         return "deferred_frame_throttle_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_INPUT_HOTKEY_BINDS_LIST:
+         return "deferred_input_hotkey_binds";
+      case MENU_ENUM_LABEL_DEFERRED_INPUT_SETTINGS_LIST:
+         return "deferred_input_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_LAKKA_LIST:
+         return "deferred_lakka_list";
+      case MENU_ENUM_LABEL_DEFERRED_LAKKA_SERVICES_LIST:
+         return "deferred_lakka_services_list";
+      case MENU_ENUM_LABEL_DEFERRED_LOGGING_SETTINGS_LIST:
+         return "deferred_logging_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_MENU_FILE_BROWSER_SETTINGS_LIST:
+         return "deferred_menu_file_browser_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_MENU_SETTINGS_LIST:
+         return "deferred_menu_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_NETWORK_SETTINGS_LIST:
+         return "deferred_network_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_ONSCREEN_DISPLAY_SETTINGS_LIST:
+         return "deferred_onscreen_display_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_ONSCREEN_OVERLAY_SETTINGS_LIST:
+         return "deferred_onscreen_overlay_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_PLAYLIST_SETTINGS_LIST:
+         return "deferred_playlist_settings";
+      case MENU_ENUM_LABEL_DEFERRED_PRIVACY_SETTINGS_LIST:
+         return "deferred_privacy_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_RDB_ENTRY_DETAIL:
+         return "deferred_rdb_entry_detail";
+      case MENU_ENUM_LABEL_DEFERRED_RECORDING_SETTINGS_LIST:
+         return "deferred_recording_settings";
+      case MENU_ENUM_LABEL_DEFERRED_RETRO_ACHIEVEMENTS_SETTINGS_LIST:
+         return "deferred_retro_achievements_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_REWIND_SETTINGS_LIST:
+         return "deferred_rewind_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_SAVING_SETTINGS_LIST:
+         return "deferred_saving_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_THUMBNAILS_UPDATER_LIST:
+         return "deferred_thumbnails_updater_list";
+      case MENU_ENUM_LABEL_DEFERRED_UPDATER_SETTINGS_LIST:
+         return "deferred_updater_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_USER_BINDS_LIST:
+         return "deferred_user_binds_list";
+      case MENU_ENUM_LABEL_DEFERRED_USER_INTERFACE_SETTINGS_LIST:
+         return "deferred_user_interface_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_USER_SETTINGS_LIST:
+         return "deferred_user_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_VIDEO_FILTER:
+         return "deferred_video_filter";
+      case MENU_ENUM_LABEL_DEFERRED_VIDEO_SETTINGS_LIST:
+         return "deferred_video_settings_list";
+      case MENU_ENUM_LABEL_DEFERRED_WIFI_SETTINGS_LIST:
+         return "deferred_wifi_settings_list";
+      case MENU_ENUM_LABEL_DELETE_ENTRY:
+         return "delete_entry";
+      case MENU_ENUM_LABEL_DETECT_CORE_LIST:
+         return "detect_core_list";
+      case MENU_ENUM_LABEL_DIRECTORY_SETTINGS:
+         return "directory_settings";
+      case MENU_ENUM_LABEL_DISK_CYCLE_TRAY_STATUS:
+         return "disk_cycle_tray_status";
+      case MENU_ENUM_LABEL_DISK_IMAGE_APPEND:
+         return "disk_image_append";
+      case MENU_ENUM_LABEL_DISK_OPTIONS:
+         return "core_disk_options";
+      case MENU_ENUM_LABEL_DOWNLOADED_FILE_DETECT_CORE_LIST:
+         return "downloaded_file_detect_core_list";
+      case MENU_ENUM_LABEL_DOWNLOAD_CORE_CONTENT:
+         return "download_core_content";
+      case MENU_ENUM_LABEL_DOWNLOAD_CORE_CONTENT_DIRS:
+         return "download_core_content_dirs";
+      case MENU_ENUM_LABEL_DPI_OVERRIDE_ENABLE:
+         return "dpi_override_enable";
+      case MENU_ENUM_LABEL_DPI_OVERRIDE_VALUE:
+         return "dpi_override_value";
+      case MENU_ENUM_LABEL_DRIVER_SETTINGS:
+         return "driver_settings";
+      case MENU_ENUM_LABEL_DUMMY_ON_CORE_SHUTDOWN:
+         return "dummy_on_core_shutdown";
+      case MENU_ENUM_LABEL_DYNAMIC_WALLPAPER:
+         return "menu_dynamic_wallpaper_enable";
+      case MENU_ENUM_LABEL_DYNAMIC_WALLPAPERS_DIRECTORY:
+         return "dynamic_wallpapers_directory";
+      case MENU_ENUM_LABEL_ENTRY_HOVER_COLOR:
+         return "menu_entry_hover_color";
+      case MENU_ENUM_LABEL_ENTRY_NORMAL_COLOR:
+         return "menu_entry_normal_color";
+      case MENU_ENUM_LABEL_FASTFORWARD_RATIO:
+         return "fastforward_ratio";
+      case MENU_ENUM_LABEL_FILE_BROWSER_CORE:
+         return "file_browser_core";
+      case MENU_ENUM_LABEL_FILE_BROWSER_CORE_DETECTED:
+         return "file_browser_core_detected";
+      case MENU_ENUM_LABEL_FILE_BROWSER_CORE_SELECT_FROM_COLLECTION:
+         return "file_browser_core_select_from_collection";
+      case MENU_ENUM_LABEL_FILE_BROWSER_DIRECTORY:
+         return "file_browser_directory";
+      case MENU_ENUM_LABEL_FILE_BROWSER_IMAGE:
+         return "file_browser_image";
+      case MENU_ENUM_LABEL_FILE_BROWSER_IMAGE_OPEN_WITH_VIEWER:
+         return "file_browser_image_open_with_viewer";
+      case MENU_ENUM_LABEL_FILE_BROWSER_MOVIE_OPEN:
+         return "file_browser_movie_open";
+      case MENU_ENUM_LABEL_FILE_BROWSER_MUSIC_OPEN:
+         return "file_browser_music_open";
+      case MENU_ENUM_LABEL_FILE_BROWSER_PLAIN_FILE:
+         return "file_browser_plain_file";
+      case MENU_ENUM_LABEL_FILE_BROWSER_REMAP:
+         return "file_browser_remap";
+      case MENU_ENUM_LABEL_FILE_BROWSER_SHADER:
+         return "file_browser_shader";
+      case MENU_ENUM_LABEL_FILE_BROWSER_SHADER_PRESET:
+         return "file_browser_shader_preset";
+      case MENU_ENUM_LABEL_FPS_SHOW:
+         return "fps_show";
+      case MENU_ENUM_LABEL_FRAME_THROTTLE_ENABLE:
+         return "fastforward_ratio_throttle_enable";
+      case MENU_ENUM_LABEL_FRAME_THROTTLE_SETTINGS:
+         return "frame_throttle_settings";
+      case MENU_ENUM_LABEL_FRONTEND_COUNTERS:
+         return "frontend_counters";
+      case MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS:
+         return "game_specific_options";
+      case MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS_CREATE:
+         return "game_specific_options_create";
+      case MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS_IN_USE:
+         return "game_specific_options_in_use";
+      case MENU_ENUM_LABEL_HELP:
+         return "help";
+      case MENU_ENUM_LABEL_HELP_AUDIO_VIDEO_TROUBLESHOOTING:
+         return "help_audio_video_troubleshooting";
+      case MENU_ENUM_LABEL_HELP_CHANGE_VIRTUAL_GAMEPAD:
+         return "help_change_virtual_gamepad";
+      case MENU_ENUM_LABEL_HELP_CONTROLS:
+         return "help_controls";
+      case MENU_ENUM_LABEL_HELP_LIST:
+         return "help_list";
+      case MENU_ENUM_LABEL_HELP_LOADING_CONTENT:
+         return "help_loading_content";
+      case MENU_ENUM_LABEL_HELP_SCANNING_CONTENT:
+         return "help_scanning_content";
+      case MENU_ENUM_LABEL_HELP_WHAT_IS_A_CORE:
+         return "help_what_is_a_core";
+      case MENU_ENUM_LABEL_HISTORY_LIST_ENABLE:
+         return "history_list_enable";
       case MENU_ENUM_LABEL_HISTORY_TAB:
          return "history_tab";
-      case MENU_ENUM_LABEL_ADD_TAB:
-         return "add_tab";
-      case MENU_ENUM_LABEL_PLAYLISTS_TAB:
-         return "playlists_tab";
-      case MENU_ENUM_LABEL_MUSIC_TAB:
-         return "music_tab";
-      case MENU_ENUM_LABEL_VIDEO_TAB:
-         return "video_tab";
-      case MENU_ENUM_LABEL_IMAGES_TAB:
-         return "images_tab";
       case MENU_ENUM_LABEL_HORIZONTAL_MENU:
          return "horizontal_menu";
-      case MENU_ENUM_LABEL_PARENT_DIRECTORY:
-         return "parent_directory";
-      case MENU_ENUM_LABEL_INPUT_PLAYER_ANALOG_DPAD_MODE:
-         return "input_player%u_analog_dpad_mode";
+      case MENU_ENUM_LABEL_IMAGES_TAB:
+         return "images_tab";
+      case MENU_ENUM_LABEL_INFORMATION:
+         return "information";
+      case MENU_ENUM_LABEL_INFORMATION_LIST:
+         return "information_list";
+      case MENU_ENUM_LABEL_INFO_SCREEN:
+         return "info_screen";
+      case MENU_ENUM_LABEL_INPUT_ALL_USERS_CONTROL_MENU:
+         return "all_users_control_menu";
+      case MENU_ENUM_LABEL_INPUT_AUTODETECT_ENABLE:
+         return "input_autodetect_enable";
+      case MENU_ENUM_LABEL_INPUT_AXIS_THRESHOLD:
+         return "input_axis_threshold";
+      case MENU_ENUM_LABEL_INPUT_BACK_AS_MENU_ENUM_TOGGLE_ENABLE:
+         return "back_as_menu_toggle_enable";
+      case MENU_ENUM_LABEL_INPUT_BIND_MODE:
+         return "input_bind_mode";
+      case MENU_ENUM_LABEL_INPUT_BIND_TIMEOUT:
+         return "input_bind_timeout";
+      case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_HIDE_UNBOUND:
+         return "input_descriptor_hide_unbound";
+      case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_LABEL_SHOW:
+         return "input_descriptor_label_show";
+      case MENU_ENUM_LABEL_INPUT_DRIVER:
+         return "input_driver";
+      case MENU_ENUM_LABEL_INPUT_DUTY_CYCLE:
+         return "input_duty_cycle";
+      case MENU_ENUM_LABEL_INPUT_HOTKEY_BINDS:
+         return "input_hotkey_binds";
+      case MENU_ENUM_LABEL_INPUT_HOTKEY_BINDS_BEGIN:
+         return "input_hotkey_binds_begin";
+      case MENU_ENUM_LABEL_INPUT_ICADE_ENABLE:
+         return "input_icade_enable";
+      case MENU_ENUM_LABEL_INPUT_KEYBOARD_GAMEPAD_MAPPING_TYPE:
+         return "keyboard_gamepad_mapping_type";
       case MENU_ENUM_LABEL_INPUT_LIBRETRO_DEVICE:
          return "input_libretro_device_p%u";
-      case MENU_ENUM_LABEL_RUN:
-         return "collection";
-      case MENU_ENUM_LABEL_PLAYLIST_COLLECTION_ENTRY:
-         return "playlist_collection_entry";
-      case MENU_ENUM_LABEL_CHEEVOS_LOCKED_ENTRY:
-         return "cheevos_locked_entry";
-      case MENU_ENUM_LABEL_CHEEVOS_UNLOCKED_ENTRY:
-         return "cheevos_unlocked_entry";
-      case MENU_ENUM_LABEL_CORE_INFO_ENTRY:
-         return "core_info_entry";
-      case MENU_ENUM_LABEL_NETWORK_INFO_ENTRY:
-         return "network_info_entry";
-      case MENU_ENUM_LABEL_PLAYLIST_ENTRY:
-         return "playlist_entry";
-      case MENU_ENUM_LABEL_SYSTEM_INFO_ENTRY:
-         return "system_info_entry";
+      case MENU_ENUM_LABEL_INPUT_MAX_USERS:
+         return "input_max_users";
+      case MENU_ENUM_LABEL_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
+         return "input_menu_toggle_gamepad_combo";
+      case MENU_ENUM_LABEL_INPUT_OSK_OVERLAY_ENABLE:
+         return "input_osk_overlay_enable";
+      case MENU_ENUM_LABEL_INPUT_OVERLAY_ENABLE:
+         return "input_overlay_enable";
+      case MENU_ENUM_LABEL_INPUT_OVERLAY_HIDE_IN_MENU:
+         return "overlay_hide_in_menu";
+      case MENU_ENUM_LABEL_INPUT_PLAYER_ANALOG_DPAD_MODE:
+         return "input_player%u_analog_dpad_mode";
+      case MENU_ENUM_LABEL_INPUT_POLL_TYPE_BEHAVIOR:
+         return "input_poll_type_behavior";
+      case MENU_ENUM_LABEL_INPUT_PREFER_FRONT_TOUCH:
+         return "input_prefer_front_touch";
+      case MENU_ENUM_LABEL_INPUT_REMAPPING_DIRECTORY:
+         return "input_remapping_directory";
+      case MENU_ENUM_LABEL_INPUT_REMAP_BINDS_ENABLE:
+         return "input_remap_binds_enable";
+      case MENU_ENUM_LABEL_INPUT_SETTINGS:
+         return "input_settings";
+      case MENU_ENUM_LABEL_INPUT_SETTINGS_BEGIN:
+         return "input_settings_begin";
+      case MENU_ENUM_LABEL_INPUT_SMALL_KEYBOARD_ENABLE:
+         return "input_small_keyboard_enable";
+      case MENU_ENUM_LABEL_INPUT_TOUCH_ENABLE:
+         return "input_touch_enable";
+      case MENU_ENUM_LABEL_INPUT_TURBO_PERIOD:
+         return "input_turbo_period";
+      case MENU_ENUM_LABEL_INPUT_USER_10_BINDS:
+         return "10_input_binds_list";
+      case MENU_ENUM_LABEL_INPUT_USER_11_BINDS:
+         return "11_input_binds_list";
+      case MENU_ENUM_LABEL_INPUT_USER_12_BINDS:
+         return "12_input_binds_list";
+      case MENU_ENUM_LABEL_INPUT_USER_13_BINDS:
+         return "13_input_binds_list";
+      case MENU_ENUM_LABEL_INPUT_USER_14_BINDS:
+         return "14_input_binds_list";
+      case MENU_ENUM_LABEL_INPUT_USER_15_BINDS:
+         return "15_input_binds_list";
+      case MENU_ENUM_LABEL_INPUT_USER_16_BINDS:
+         return "16_input_binds_list";
       case MENU_ENUM_LABEL_INPUT_USER_1_BINDS:
          return "1_input_binds_list";
       case MENU_ENUM_LABEL_INPUT_USER_2_BINDS:
@@ -2066,954 +2394,626 @@ static const char *menu_hash_to_str_vn_label_enum(enum msg_hash_enums msg)
          return "8_input_binds_list";
       case MENU_ENUM_LABEL_INPUT_USER_9_BINDS:
          return "9_input_binds_list";
-      case MENU_ENUM_LABEL_INPUT_USER_10_BINDS:
-         return "10_input_binds_list";
-      case MENU_ENUM_LABEL_INPUT_USER_11_BINDS:
-         return "11_input_binds_list";
-      case MENU_ENUM_LABEL_INPUT_USER_12_BINDS:
-         return "12_input_binds_list";
-      case MENU_ENUM_LABEL_INPUT_USER_13_BINDS:
-         return "13_input_binds_list";
-      case MENU_ENUM_LABEL_INPUT_USER_14_BINDS:
-         return "14_input_binds_list";
-      case MENU_ENUM_LABEL_INPUT_USER_15_BINDS:
-         return "15_input_binds_list";
-      case MENU_ENUM_LABEL_INPUT_USER_16_BINDS:
-         return "16_input_binds_list";
-      case MENU_ENUM_LABEL_VIDEO_VIEWPORT_CUSTOM_X:
-         return "video_viewport_custom_x";
-      case MENU_ENUM_LABEL_VIDEO_VIEWPORT_CUSTOM_Y:
-         return "video_viewport_custom_y";
-      case MENU_ENUM_LABEL_VIDEO_VIEWPORT_CUSTOM_WIDTH:
-         return "video_viewport_custom_width";
-      case MENU_ENUM_LABEL_VIDEO_VIEWPORT_CUSTOM_HEIGHT:
-         return "video_viewport_custom_height";
-      case MENU_ENUM_LABEL_NO_CORES_AVAILABLE:
-         return "no_cores_available";
-      case MENU_ENUM_LABEL_NO_CORE_OPTIONS_AVAILABLE:
-         return "no_core_options_available";
-      case MENU_ENUM_LABEL_NO_CORE_INFORMATION_AVAILABLE:
-         return "no_core_information_available";
-      case MENU_ENUM_LABEL_CORE_OPTION_ENTRY:
-         return "core_option_entry";
-      case MENU_ENUM_LABEL_URL_ENTRY:
-         return "url_entry";
-      case MENU_ENUM_LABEL_NO_PERFORMANCE_COUNTERS:
-         return "no_performance_counters";
-      case MENU_ENUM_LABEL_NO_ENTRIES_TO_DISPLAY:
-         return "no_entries_to_display";
-      case MENU_ENUM_LABEL_NO_ACHIEVEMENTS_TO_DISPLAY:
-         return "no_achievements_to_display";
-      case MENU_ENUM_LABEL_CHEEVOS_UNLOCKED_ACHIEVEMENTS:
-         return "cheevos_unlocked_achievements";
-      case MENU_ENUM_LABEL_CHEEVOS_LOCKED_ACHIEVEMENTS:
-         return "cheevos_locked_achievements";
+      case MENU_ENUM_LABEL_JOYPAD_AUTOCONFIG_DIR:
+         return "joypad_autoconfig_dir";
+      case MENU_ENUM_LABEL_JOYPAD_DRIVER:
+         return "input_joypad_driver";
+      case MENU_ENUM_LABEL_KEYBOARD_OVERLAY_PRESET:
+         return "input_osk_overlay";
+      case MENU_ENUM_LABEL_LAKKA_SERVICES:
+         return "lakka_services";
+      case MENU_ENUM_LABEL_LIBRETRO_DIR_PATH:
+         return "libretro_dir_path";
+      case MENU_ENUM_LABEL_LIBRETRO_INFO_PATH:
+         return "libretro_info_path";
+      case MENU_ENUM_LABEL_LIBRETRO_LOG_LEVEL:
+         return "libretro_log_level";
+      case MENU_ENUM_LABEL_LOAD_ARCHIVE:
+         return "load_archive";
+      case MENU_ENUM_LABEL_LOAD_ARCHIVE_DETECT_CORE:
+         return "load_archive_detect_core";
+      case MENU_ENUM_LABEL_LOAD_CONTENT:
+         return "load_content_default";
+      case MENU_ENUM_LABEL_LOAD_CONTENT_HISTORY:
+         return "load_recent";
+      case MENU_ENUM_LABEL_LOAD_CONTENT_LIST:
+         return "load_content";
+      case MENU_ENUM_LABEL_LOAD_STATE:
+         return "loadstate";
+      case MENU_ENUM_LABEL_LOCATION_ALLOW:
+         return "location_allow";
+      case MENU_ENUM_LABEL_LOCATION_DRIVER:
+         return "location_driver";
+      case MENU_ENUM_LABEL_LOGGING_SETTINGS:
+         return "logging_settings";
+      case MENU_ENUM_LABEL_LOG_VERBOSITY:
+         return "log_verbosity";
       case MENU_ENUM_LABEL_MAIN_MENU:
          return "main_menu";
-      case MENU_ENUM_LABEL_MENU_LINEAR_FILTER:
-         return "menu_linear_filter";
+      case MENU_ENUM_LABEL_MANAGEMENT:
+         return "database_settings";
+      case MENU_ENUM_LABEL_MATERIALUI_MENU_COLOR_THEME:
+         return "materialui_menu_color_theme";
+      case MENU_ENUM_LABEL_MATERIALUI_MENU_FOOTER_OPACITY:
+         return "materialui_menu_footer_opacity";
+      case MENU_ENUM_LABEL_MATERIALUI_MENU_HEADER_OPACITY:
+         return "materialui_menu_header_opacity";
+      case MENU_ENUM_LABEL_MENU_DRIVER:
+         return "menu_driver";
       case MENU_ENUM_LABEL_MENU_ENUM_THROTTLE_FRAMERATE:
          return "menu_throttle_framerate";
-      case MENU_ENUM_LABEL_START_CORE:
-         return "start_core";
-      case MENU_ENUM_LABEL_CHEEVOS_HARDCORE_MODE_ENABLE:
-         return "cheevos_hardcore_mode_enable";
-      case MENU_ENUM_LABEL_CHEEVOS_TEST_UNOFFICIAL:
-         return "cheevos_test_unofficial";
-      case MENU_ENUM_LABEL_CHEEVOS_ENABLE:
-         return "cheevos_enable";
-      case MENU_ENUM_LABEL_INPUT_TOUCH_ENABLE:
-         return "input_touch_enable";
-      case MENU_ENUM_LABEL_INPUT_PREFER_FRONT_TOUCH:
-         return "input_prefer_front_touch";
-      case MENU_ENUM_LABEL_INPUT_ICADE_ENABLE:
-         return "input_icade_enable";
-      case MENU_ENUM_LABEL_INPUT_KEYBOARD_GAMEPAD_MAPPING_TYPE:
-         return "keyboard_gamepad_mapping_type";
-      case MENU_ENUM_LABEL_INPUT_SMALL_KEYBOARD_ENABLE:
-         return "input_small_keyboard_enable";
+      case MENU_ENUM_LABEL_MENU_FILE_BROWSER_SETTINGS:
+         return "menu_file_browser_settings";
+      case MENU_ENUM_LABEL_MENU_LINEAR_FILTER:
+         return "menu_linear_filter";
+      case MENU_ENUM_LABEL_MENU_SETTINGS:
+         return "menu_settings";
+      case MENU_ENUM_LABEL_MENU_WALLPAPER:
+         return "menu_wallpaper";
+      case MENU_ENUM_LABEL_MENU_WALLPAPER_OPACITY:
+         return "menu_wallpaper_opacity";
+      case MENU_ENUM_LABEL_MOUSE_ENABLE:
+         return "menu_mouse_enable";
+      case MENU_ENUM_LABEL_MUSIC_TAB:
+         return "music_tab";
+      case MENU_ENUM_LABEL_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
+         return "menu_navigation_browser_filter_supported_extensions_enable";
+      case MENU_ENUM_LABEL_NAVIGATION_WRAPAROUND:
+         return "menu_navigation_wraparound_enable";
+      case MENU_ENUM_LABEL_NETPLAY:
+         return "netplay";
+      case MENU_ENUM_LABEL_NETPLAY_CHECK_FRAMES:
+         return "netplay_check_frames";
+      case MENU_ENUM_LABEL_NETPLAY_CLIENT_SWAP_INPUT:
+         return "netplay_client_swap_input";
+      case MENU_ENUM_LABEL_NETPLAY_DELAY_FRAMES:
+         return "netplay_delay_frames";
+      case MENU_ENUM_LABEL_NETPLAY_DISCONNECT:
+         return "menu_netplay_disconnect";
+      case MENU_ENUM_LABEL_NETPLAY_ENABLE:
+         return "netplay_enable";
+      case MENU_ENUM_LABEL_NETPLAY_ENABLE_CLIENT:
+         return "menu_netplay_enable_client";
+      case MENU_ENUM_LABEL_NETPLAY_ENABLE_HOST:
+         return "menu_netplay_enable_host";
+      case MENU_ENUM_LABEL_NETPLAY_IP_ADDRESS:
+         return "netplay_ip_address";
+      case MENU_ENUM_LABEL_NETPLAY_MODE:
+         return "netplay_mode";
+      case MENU_ENUM_LABEL_NETPLAY_NICKNAME:
+         return "netplay_nickname";
+      case MENU_ENUM_LABEL_NETPLAY_SETTINGS:
+         return "menu_netplay_settings";
+      case MENU_ENUM_LABEL_NETPLAY_SPECTATOR_MODE_ENABLE:
+         return "netplay_spectator_mode_enable";
+      case MENU_ENUM_LABEL_NETPLAY_TCP_UDP_PORT:
+         return "netplay_tcp_udp_port";
+      case MENU_ENUM_LABEL_NETWORK_CMD_ENABLE:
+         return "network_cmd_enable";
+      case MENU_ENUM_LABEL_NETWORK_CMD_PORT:
+         return "network_cmd_port";
+      case MENU_ENUM_LABEL_NETWORK_INFORMATION:
+         return "network_information";
+      case MENU_ENUM_LABEL_NETWORK_INFO_ENTRY:
+         return "network_info_entry";
+      case MENU_ENUM_LABEL_NETWORK_REMOTE_ENABLE:
+         return "network_remote_enable";
+      case MENU_ENUM_LABEL_NETWORK_REMOTE_PORT:
+         return "network_remote_base_port";
+      case MENU_ENUM_LABEL_NETWORK_REMOTE_USER_1_ENABLE:
+         return "network_remote_user_1_enable";
+      case MENU_ENUM_LABEL_NETWORK_REMOTE_USER_LAST_ENABLE:
+         return "network_remote_user_last_enable";
+      case MENU_ENUM_LABEL_NETWORK_SETTINGS:
+         return "network_settings";
+      case MENU_ENUM_LABEL_NO_ACHIEVEMENTS_TO_DISPLAY:
+         return "no_achievements_to_display";
+      case MENU_ENUM_LABEL_NO_CORES_AVAILABLE:
+         return "no_cores_available";
+      case MENU_ENUM_LABEL_NO_CORE_INFORMATION_AVAILABLE:
+         return "no_core_information_available";
+      case MENU_ENUM_LABEL_NO_CORE_OPTIONS_AVAILABLE:
+         return "no_core_options_available";
+      case MENU_ENUM_LABEL_NO_ENTRIES_TO_DISPLAY:
+         return "no_entries_to_display";
+      case MENU_ENUM_LABEL_NO_HISTORY_AVAILABLE:
+         return "no_history";
+      case MENU_ENUM_LABEL_NO_ITEMS:
+         return "no_items";
+      case MENU_ENUM_LABEL_NO_PERFORMANCE_COUNTERS:
+         return "no_performance_counters";
+      case MENU_ENUM_LABEL_NO_PLAYLISTS:
+         return "no_playlists";
+      case MENU_ENUM_LABEL_NO_PLAYLIST_ENTRIES_AVAILABLE:
+         return "no_playlist_entries_available";
+      case MENU_ENUM_LABEL_NO_SETTINGS_FOUND:
+         return "menu_label_no_settings_found";
+      case MENU_ENUM_LABEL_NO_SHADER_PARAMETERS:
+         return "no_shader_parameters.";
+      case MENU_ENUM_LABEL_ONLINE_UPDATER:
+         return "online_updater";
+      case MENU_ENUM_LABEL_ONSCREEN_DISPLAY_SETTINGS:
+         return "onscreen_display_settings";
+      case MENU_ENUM_LABEL_ONSCREEN_OVERLAY_SETTINGS:
+         return "onscreen_overlay_settings";
+      case MENU_ENUM_LABEL_OPEN_ARCHIVE:
+         return "open_archive";
+      case MENU_ENUM_LABEL_OPEN_ARCHIVE_DETECT_CORE:
+         return "open_archive_detect_core";
+      case MENU_ENUM_LABEL_OSK_OVERLAY_DIRECTORY:
+         return "osk_overlay_directory";
+      case MENU_ENUM_LABEL_OVERLAY_AUTOLOAD_PREFERRED:
+         return "overlay_autoload_preferred";
+      case MENU_ENUM_LABEL_OVERLAY_DIRECTORY:
+         return "overlay_directory";
+      case MENU_ENUM_LABEL_OVERLAY_OPACITY:
+         return "input_overlay_opacity";
+      case MENU_ENUM_LABEL_OVERLAY_PRESET:
+         return "input_overlay";
+      case MENU_ENUM_LABEL_OVERLAY_SCALE:
+         return "input_overlay_scale";
+      case MENU_ENUM_LABEL_PAL60_ENABLE:
+         return "pal60_enable";
+      case MENU_ENUM_LABEL_PARENT_DIRECTORY:
+         return "parent_directory";
+      case MENU_ENUM_LABEL_PAUSE_LIBRETRO:
+         return "menu_pause_libretro";
+      case MENU_ENUM_LABEL_PAUSE_NONACTIVE:
+         return "pause_nonactive";
+      case MENU_ENUM_LABEL_PERFCNT_ENABLE:
+         return "perfcnt_enable";
+      case MENU_ENUM_LABEL_PLAYLISTS_TAB:
+         return "playlists_tab";
+      case MENU_ENUM_LABEL_PLAYLIST_COLLECTION_ENTRY:
+         return "playlist_collection_entry";
+      case MENU_ENUM_LABEL_PLAYLIST_DIRECTORY:
+         return "playlist_directory";
+      case MENU_ENUM_LABEL_PLAYLIST_ENTRY:
+         return "playlist_entry";
+      case MENU_ENUM_LABEL_PLAYLIST_SETTINGS:
+         return "playlist_settings";
+      case MENU_ENUM_LABEL_PLAYLIST_SETTINGS_BEGIN:
+         return "playlist_settings_begin";
+      case MENU_ENUM_LABEL_POINTER_ENABLE:
+         return "menu_pointer_enable";
+      case MENU_ENUM_LABEL_PRIVACY_SETTINGS:
+         return "privacy_settings";
+      case MENU_ENUM_LABEL_QUIT_RETROARCH:
+         return "quit_retroarch";
+      case MENU_ENUM_LABEL_RDB_ENTRY:
+         return "rdb_entry";
+      case MENU_ENUM_LABEL_RDB_ENTRY_ANALOG:
+         return "rdb_entry_analog";
+      case MENU_ENUM_LABEL_RDB_ENTRY_BBFC_RATING:
+         return "rdb_entry_bbfc_rating";
+      case MENU_ENUM_LABEL_RDB_ENTRY_CERO_RATING:
+         return "rdb_entry_cero_rating";
+      case MENU_ENUM_LABEL_RDB_ENTRY_CRC32:
+         return "rdb_entry_crc32";
+      case MENU_ENUM_LABEL_RDB_ENTRY_DESCRIPTION:
+         return "rdb_entry_description";
+      case MENU_ENUM_LABEL_RDB_ENTRY_DEVELOPER:
+         return "rdb_entry_developer";
+      case MENU_ENUM_LABEL_RDB_ENTRY_EDGE_MAGAZINE_ISSUE:
+         return "rdb_entry_edge_magazine_issue";
+      case MENU_ENUM_LABEL_RDB_ENTRY_EDGE_MAGAZINE_RATING:
+         return "rdb_entry_edge_magazine_rating";
+      case MENU_ENUM_LABEL_RDB_ENTRY_EDGE_MAGAZINE_REVIEW:
+         return "rdb_entry_edge_magazine_review";
+      case MENU_ENUM_LABEL_RDB_ENTRY_ELSPA_RATING:
+         return "rdb_entry_elspa_rating";
+      case MENU_ENUM_LABEL_RDB_ENTRY_ENHANCEMENT_HW:
+         return "rdb_entry_enhancement_hw";
+      case MENU_ENUM_LABEL_RDB_ENTRY_ESRB_RATING:
+         return "rdb_entry_esrb_rating";
+      case MENU_ENUM_LABEL_RDB_ENTRY_FAMITSU_MAGAZINE_RATING:
+         return "rdb_entry_famitsu_magazine_rating";
+      case MENU_ENUM_LABEL_RDB_ENTRY_FRANCHISE:
+         return "rdb_entry_franchise";
+      case MENU_ENUM_LABEL_RDB_ENTRY_GENRE:
+         return "rdb_entry_genre";
+      case MENU_ENUM_LABEL_RDB_ENTRY_MAX_USERS:
+         return "rdb_entry_max_users";
+      case MENU_ENUM_LABEL_RDB_ENTRY_MD5:
+         return "rdb_entry_md5";
+      case MENU_ENUM_LABEL_RDB_ENTRY_NAME:
+         return "rdb_entry_name";
+      case MENU_ENUM_LABEL_RDB_ENTRY_ORIGIN:
+         return "rdb_entry_origin";
+      case MENU_ENUM_LABEL_RDB_ENTRY_PEGI_RATING:
+         return "rdb_entry_pegi_rating";
+      case MENU_ENUM_LABEL_RDB_ENTRY_PUBLISHER:
+         return "rdb_entry_publisher";
+      case MENU_ENUM_LABEL_RDB_ENTRY_RELEASE_MONTH:
+         return "rdb_entry_releasemonth";
+      case MENU_ENUM_LABEL_RDB_ENTRY_RELEASE_YEAR:
+         return "rdb_entry_releaseyear";
+      case MENU_ENUM_LABEL_RDB_ENTRY_SERIAL:
+         return "rdb_entry_serial";
+      case MENU_ENUM_LABEL_RDB_ENTRY_SHA1:
+         return "rdb_entry_sha1";
+      case MENU_ENUM_LABEL_RDB_ENTRY_START_CONTENT:
+         return "rdb_entry_start_content";
+      case MENU_ENUM_LABEL_RDB_ENTRY_TGDB_RATING:
+         return "rdb_entry_tgdb_rating";
+      case MENU_ENUM_LABEL_REBOOT:
+         return "reboot";
+      case MENU_ENUM_LABEL_RECORDING_CONFIG_DIRECTORY:
+         return "recording_config_directory";
+      case MENU_ENUM_LABEL_RECORDING_OUTPUT_DIRECTORY:
+         return "recording_output_directory";
+      case MENU_ENUM_LABEL_RECORDING_SETTINGS:
+         return "recording_settings";
+      case MENU_ENUM_LABEL_RECORD_CONFIG:
+         return "record_config";
+      case MENU_ENUM_LABEL_RECORD_DRIVER:
+         return "record_driver";
+      case MENU_ENUM_LABEL_RECORD_ENABLE:
+         return "record_enable";
+      case MENU_ENUM_LABEL_RECORD_PATH:
+         return "record_path";
+      case MENU_ENUM_LABEL_RECORD_USE_OUTPUT_DIRECTORY:
+         return "record_use_output_directory";
+      case MENU_ENUM_LABEL_REMAP_FILE_LOAD:
+         return "remap_file_load";
+      case MENU_ENUM_LABEL_REMAP_FILE_SAVE_CORE:
+         return "remap_file_save_core";
+      case MENU_ENUM_LABEL_REMAP_FILE_SAVE_GAME:
+         return "remap_file_save_game";
+      case MENU_ENUM_LABEL_RESTART_CONTENT:
+         return "restart_content";
+      case MENU_ENUM_LABEL_RESTART_RETROARCH:
+         return "restart_retroarch";
+      case MENU_ENUM_LABEL_RESUME_CONTENT:
+         return "resume_content";
+      case MENU_ENUM_LABEL_RETRO_ACHIEVEMENTS_SETTINGS:
+         return "retro_achievements_settings";
+      case MENU_ENUM_LABEL_REWIND_ENABLE:
+         return "rewind_enable";
+      case MENU_ENUM_LABEL_REWIND_GRANULARITY:
+         return "rewind_granularity";
+      case MENU_ENUM_LABEL_REWIND_SETTINGS:
+         return "rewind_settings";
+      case MENU_ENUM_LABEL_RGUI_BROWSER_DIRECTORY:
+         return "rgui_browser_directory";
+      case MENU_ENUM_LABEL_RGUI_CONFIG_DIRECTORY:
+         return "rgui_config_directory";
+      case MENU_ENUM_LABEL_RGUI_SHOW_START_SCREEN:
+         return "rgui_show_start_screen";
+      case MENU_ENUM_LABEL_RUN:
+         return "collection";
+      case MENU_ENUM_LABEL_SAMBA_ENABLE:
+         return "samba_enable";
+      case MENU_ENUM_LABEL_SAVEFILE_DIRECTORY:
+         return "savefile_directory";
+      case MENU_ENUM_LABEL_SAVESTATE_AUTO_INDEX:
+         return "savestate_auto_index";
+      case MENU_ENUM_LABEL_SAVESTATE_AUTO_LOAD:
+         return "savestate_auto_load";
+      case MENU_ENUM_LABEL_SAVESTATE_AUTO_SAVE:
+         return "savestate_auto_save";
+      case MENU_ENUM_LABEL_SAVESTATE_DIRECTORY:
+         return "savestate_directory";
       case MENU_ENUM_LABEL_SAVE_CURRENT_CONFIG:
          return "save_current_config";
       case MENU_ENUM_LABEL_SAVE_CURRENT_CONFIG_OVERRIDE_CORE:
          return "save_current_config_override_core";
       case MENU_ENUM_LABEL_SAVE_CURRENT_CONFIG_OVERRIDE_GAME:
          return "save_current_config_override_game";
-      case MENU_ENUM_LABEL_STATE_SLOT:
-         return "state_slot";
-      case MENU_ENUM_LABEL_CHEEVOS_USERNAME:
-         return "cheevos_username";
-      case MENU_ENUM_LABEL_CHEEVOS_PASSWORD:
-         return "cheevos_password";
-      case MENU_ENUM_LABEL_ACCOUNTS_CHEEVOS_USERNAME:
-         return "accounts_cheevos_username";
-      case MENU_ENUM_LABEL_ACCOUNTS_RETRO_ACHIEVEMENTS:
-         return "retro_achievements";
-      case MENU_ENUM_LABEL_DEFERRED_ACCOUNTS_CHEEVOS_LIST:
-         return "deferred_accounts_cheevos_list";
-      case MENU_ENUM_LABEL_DEFERRED_USER_BINDS_LIST:
-         return "deferred_user_binds_list";
-      case MENU_ENUM_LABEL_DEFERRED_ACCOUNTS_LIST:
-         return "deferred_accounts_list";
-      case MENU_ENUM_LABEL_DEFERRED_INPUT_SETTINGS_LIST:
-         return "deferred_input_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_DRIVER_SETTINGS_LIST:
-         return "deferred_driver_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_AUDIO_SETTINGS_LIST:
-         return "deferred_audio_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_CORE_SETTINGS_LIST:
-         return "deferred_core_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_VIDEO_SETTINGS_LIST:
-         return "deferred_video_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_CONFIGURATION_SETTINGS_LIST:
-         return "deferred_configuration_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_SAVING_SETTINGS_LIST:
-         return "deferred_saving_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_LOGGING_SETTINGS_LIST:
-         return "deferred_logging_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_FRAME_THROTTLE_SETTINGS_LIST:
-         return "deferred_frame_throttle_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_REWIND_SETTINGS_LIST:
-         return "deferred_rewind_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_ONSCREEN_DISPLAY_SETTINGS_LIST:
-         return "deferred_onscreen_display_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_ONSCREEN_OVERLAY_SETTINGS_LIST:
-         return "deferred_onscreen_overlay_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_MENU_SETTINGS_LIST:
-         return "deferred_menu_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_USER_INTERFACE_SETTINGS_LIST:
-         return "deferred_user_interface_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_MENU_FILE_BROWSER_SETTINGS_LIST:
-         return "deferred_menu_file_browser_settings_list";
-      case MENU_ENUM_LABEL_FILE_BROWSER_DIRECTORY:
-         return "file_browser_directory";
-      case MENU_ENUM_LABEL_FILE_BROWSER_PLAIN_FILE:
-         return "file_browser_plain_file";
-      case MENU_ENUM_LABEL_FILE_BROWSER_REMAP:
-         return "file_browser_remap";
-      case MENU_ENUM_LABEL_FILE_BROWSER_SHADER:
-         return "file_browser_shader";
-      case MENU_ENUM_LABEL_FILE_BROWSER_SHADER_PRESET:
-         return "file_browser_shader_preset";
-      case MENU_ENUM_LABEL_FILE_BROWSER_CORE:
-         return "file_browser_core";
-      case MENU_ENUM_LABEL_FILE_BROWSER_CORE_SELECT_FROM_COLLECTION:
-         return "file_browser_core_select_from_collection";
-      case MENU_ENUM_LABEL_FILE_BROWSER_MUSIC_OPEN:
-         return "file_browser_music_open";
-      case MENU_ENUM_LABEL_FILE_BROWSER_MOVIE_OPEN:
-         return "file_browser_movie_open";
-      case MENU_ENUM_LABEL_FILE_BROWSER_IMAGE_OPEN_WITH_VIEWER:
-         return "file_browser_image_open_with_viewer";
-      case MENU_ENUM_LABEL_FILE_BROWSER_IMAGE:
-         return "file_browser_image";
-      case MENU_ENUM_LABEL_FILE_BROWSER_CORE_DETECTED:
-         return "file_browser_core_detected";
-      case MENU_ENUM_LABEL_DEFERRED_RETRO_ACHIEVEMENTS_SETTINGS_LIST:
-         return "deferred_retro_achievements_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_UPDATER_SETTINGS_LIST:
-         return "deferred_updater_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_WIFI_SETTINGS_LIST:
-         return "deferred_wifi_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_NETWORK_SETTINGS_LIST:
-         return "deferred_network_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_LAKKA_SERVICES_LIST:
-         return "deferred_lakka_services_list";
-      case MENU_ENUM_LABEL_DEFERRED_USER_SETTINGS_LIST:
-         return "deferred_user_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_DIRECTORY_SETTINGS_LIST:
-         return "deferred_directory_settings_list";
-      case MENU_ENUM_LABEL_DEFERRED_PRIVACY_SETTINGS_LIST:
-         return "deferred_privacy_settings_list";
-      case MENU_ENUM_LABEL_ACCOUNTS_LIST:
-         return "accounts_list";
-      case MENU_ENUM_LABEL_DEFERRED_INPUT_HOTKEY_BINDS_LIST:
-         return "deferred_input_hotkey_binds";
-      case MENU_ENUM_LABEL_INPUT_HOTKEY_BINDS:
-         return "input_hotkey_binds";
-      case MENU_ENUM_LABEL_INPUT_HOTKEY_BINDS_BEGIN:
-         return "input_hotkey_binds_begin";
-      case MENU_ENUM_LABEL_INPUT_SETTINGS_BEGIN:
-         return "input_settings_begin";
-      case MENU_ENUM_LABEL_PLAYLIST_SETTINGS_BEGIN:
-         return "playlist_settings_begin";
-      case MENU_ENUM_LABEL_RECORDING_SETTINGS:
-         return "recording_settings";
-      case MENU_ENUM_LABEL_PLAYLIST_SETTINGS:
-         return "playlist_settings";
-      case MENU_ENUM_LABEL_DEFERRED_RECORDING_SETTINGS_LIST:
-         return "deferred_recording_settings";
-      case MENU_ENUM_LABEL_DEFERRED_PLAYLIST_SETTINGS_LIST:
-         return "deferred_playlist_settings";
-      case MENU_ENUM_LABEL_INPUT_SETTINGS:
-         return "input_settings";
-      case MENU_ENUM_LABEL_DRIVER_SETTINGS:
-         return "driver_settings";
-      case MENU_ENUM_LABEL_VIDEO_SETTINGS:
-         return "video_settings";
-      case MENU_ENUM_LABEL_CONFIGURATION_SETTINGS:
-         return "configuration_settings";
+      case MENU_ENUM_LABEL_SAVE_NEW_CONFIG:
+         return "save_new_config";
+      case MENU_ENUM_LABEL_SAVE_STATE:
+         return "savestate";
       case MENU_ENUM_LABEL_SAVING_SETTINGS:
          return "saving_settings";
-      case MENU_ENUM_LABEL_LOGGING_SETTINGS:
-         return "logging_settings";
-      case MENU_ENUM_LABEL_FRAME_THROTTLE_SETTINGS:
-         return "frame_throttle_settings";
-      case MENU_ENUM_LABEL_REWIND_SETTINGS:
-         return "rewind_settings";
-      case MENU_ENUM_LABEL_ONSCREEN_DISPLAY_SETTINGS:
-         return "onscreen_display_settings";
-      case MENU_ENUM_LABEL_ONSCREEN_OVERLAY_SETTINGS:
-         return "onscreen_overlay_settings";
-      case MENU_ENUM_LABEL_AUDIO_SETTINGS:
-         return "audio_settings";
-      case MENU_ENUM_LABEL_MENU_SETTINGS:
-         return "menu_settings";
-      case MENU_ENUM_LABEL_USER_INTERFACE_SETTINGS:
-         return "user_interface_settings";
-      case MENU_ENUM_LABEL_MENU_FILE_BROWSER_SETTINGS:
-         return "menu_file_browser_settings";
-      case MENU_ENUM_LABEL_RETRO_ACHIEVEMENTS_SETTINGS:
-         return "retro_achievements_settings";
-      case MENU_ENUM_LABEL_UPDATER_SETTINGS:
-         return "updater_settings";
-      case MENU_ENUM_LABEL_NETWORK_SETTINGS:
-         return "network_settings";
-      case MENU_ENUM_LABEL_WIFI_SETTINGS:
-         return "wifi_settings";
-      case MENU_ENUM_LABEL_USER_SETTINGS:
-         return "user_settings";
-      case MENU_ENUM_LABEL_LAKKA_SERVICES:
-         return "lakka_services";
-      case MENU_ENUM_LABEL_DIRECTORY_SETTINGS:
-         return "directory_settings";
-      case MENU_ENUM_LABEL_PRIVACY_SETTINGS:
-         return "privacy_settings";
-      case MENU_ENUM_LABEL_HELP_SCANNING_CONTENT:
-         return "help_scanning_content";
-      case MENU_ENUM_LABEL_CHEEVOS_DESCRIPTION:
-         return "cheevos_description";
-      case MENU_ENUM_LABEL_HELP_AUDIO_VIDEO_TROUBLESHOOTING:
-         return "help_audio_video_troubleshooting";
-      case MENU_ENUM_LABEL_HELP_CHANGE_VIRTUAL_GAMEPAD:
-         return "help_change_virtual_gamepad";
-      case MENU_ENUM_LABEL_HELP_WHAT_IS_A_CORE:
-         return "help_what_is_a_core";
-      case MENU_ENUM_LABEL_HELP_LOADING_CONTENT:
-         return "help_loading_content";
-      case MENU_ENUM_LABEL_HELP_LIST:
-         return "help_list";
-      case MENU_ENUM_LABEL_HELP_CONTROLS:
-         return "help_controls";
-      case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_OPEN_DETECT_CORE:
-         return "deferred_archive_open_detect_core";
-      case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_OPEN:
-         return "deferred_archive_open";
-      case MENU_ENUM_LABEL_LOAD_ARCHIVE_DETECT_CORE:
-         return "load_archive_detect_core";
-      case MENU_ENUM_LABEL_LOAD_ARCHIVE:
-         return "load_archive";
-      case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_ACTION_DETECT_CORE:
-         return "deferred_archive_action_detect_core";
-      case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_ACTION:
-         return "deferred_archive_action";
-      case MENU_ENUM_LABEL_OPEN_ARCHIVE_DETECT_CORE:
-         return "open_archive_detect_core";
-      case MENU_ENUM_LABEL_OPEN_ARCHIVE:
-         return "open_archive";
-      case MENU_ENUM_LABEL_INPUT_BACK_AS_MENU_ENUM_TOGGLE_ENABLE:
-         return "back_as_menu_toggle_enable";
-      case MENU_ENUM_LABEL_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
-         return "input_menu_toggle_gamepad_combo";
-      case MENU_ENUM_LABEL_INPUT_ALL_USERS_CONTROL_MENU:
-         return "all_users_control_menu";
-      case MENU_ENUM_LABEL_INPUT_OVERLAY_HIDE_IN_MENU:
-         return "overlay_hide_in_menu";
-      case MENU_ENUM_LABEL_NO_PLAYLIST_ENTRIES_AVAILABLE:
-         return "no_playlist_entries_available";
-      case MENU_ENUM_LABEL_DOWNLOADED_FILE_DETECT_CORE_LIST:
-         return "downloaded_file_detect_core_list";
-      case MENU_ENUM_LABEL_UPDATE_CORE_INFO_FILES:
-         return "update_core_info_files";
-      case MENU_ENUM_LABEL_DEFERRED_CORE_CONTENT_LIST:
-         return "deferred_core_content_list";
-      case MENU_ENUM_LABEL_DEFERRED_CORE_CONTENT_DIRS_LIST:
-         return "deferred_core_content_dirs_list";
-      case MENU_ENUM_LABEL_DEFERRED_CORE_CONTENT_DIRS_SUBDIR_LIST:
-         return "deferred_core_content_dirs_subdir_list";
-      case MENU_ENUM_LABEL_DEFERRED_LAKKA_LIST:
-         return "deferred_lakka_list";
-      case MENU_ENUM_LABEL_DOWNLOAD_CORE_CONTENT:
-         return "download_core_content";
-      case MENU_ENUM_LABEL_DOWNLOAD_CORE_CONTENT_DIRS:
-         return "download_core_content_dirs";
-      case MENU_ENUM_LABEL_CB_DOWNLOAD_URL:
-         return "cb_download_url";
-      case MENU_ENUM_LABEL_SCAN_THIS_DIRECTORY:
-         return "scan_this_directory";
-      case MENU_ENUM_LABEL_SCAN_FILE:
-         return "scan_file";
       case MENU_ENUM_LABEL_SCAN_DIRECTORY:
          return "scan_directory";
-      case MENU_ENUM_LABEL_ADD_CONTENT_LIST:
-         return "add_content";
-      case MENU_ENUM_LABEL_CONNECT_WIFI:
-         return "connect_wifi";
-      case MENU_ENUM_LABEL_OVERLAY_AUTOLOAD_PREFERRED:
-         return "overlay_autoload_preferred";
-      case MENU_ENUM_LABEL_INFORMATION:
-         return "information";
-      case MENU_ENUM_LABEL_INFORMATION_LIST:
-         return "information_list";
-      case MENU_ENUM_LABEL_USE_BUILTIN_PLAYER:
-         return "use_builtin_player";
-      case MENU_ENUM_LABEL_CONTENT_SETTINGS:
-         return "quick_menu";
-      case MENU_ENUM_LABEL_LOAD_CONTENT_LIST:
-         return "load_content";
-      case MENU_ENUM_LABEL_NO_SETTINGS_FOUND:
-         return "menu_label_no_settings_found";
+      case MENU_ENUM_LABEL_SCAN_FILE:
+         return "scan_file";
+      case MENU_ENUM_LABEL_SCAN_THIS_DIRECTORY:
+         return "scan_this_directory";
+      case MENU_ENUM_LABEL_SCREENSHOT_DIRECTORY:
+         return "screenshot_directory";
+      case MENU_ENUM_LABEL_SCREEN_RESOLUTION:
+         return "screen_resolution";
+      case MENU_ENUM_LABEL_SETTINGS:
+         return "settings";
+      case MENU_ENUM_LABEL_SETTINGS_TAB:
+         return "settings_tab";
+      case MENU_ENUM_LABEL_SHADER_APPLY_CHANGES:
+         return "shader_apply_changes";
+      case MENU_ENUM_LABEL_SHADER_OPTIONS:
+         return "shader_options";
+      case MENU_ENUM_LABEL_SHADER_PARAMETERS_ENTRY:
+         return "shader_parameters_entry";
+      case MENU_ENUM_LABEL_SHOW_ADVANCED_SETTINGS:
+         return "menu_show_advanced_settings";
+      case MENU_ENUM_LABEL_SHOW_HIDDEN_FILES:
+         return "show_hidden_files";
+      case MENU_ENUM_LABEL_SHUTDOWN:
+         return "shutdown";
+      case MENU_ENUM_LABEL_SLOWMOTION_RATIO:
+         return "slowmotion_ratio";
+      case MENU_ENUM_LABEL_SORT_SAVEFILES_ENABLE:
+         return "sort_savefiles_enable";
+      case MENU_ENUM_LABEL_SORT_SAVESTATES_ENABLE:
+         return "sort_savestates_enable";
+      case MENU_ENUM_LABEL_SSH_ENABLE:
+         return "ssh_enable";
+      case MENU_ENUM_LABEL_START_CORE:
+         return "start_core";
+      case MENU_ENUM_LABEL_START_NET_RETROPAD:
+         return "menu_start_net_retropad";
+      case MENU_ENUM_LABEL_START_VIDEO_PROCESSOR:
+         return "menu_start_video_processor";
+      case MENU_ENUM_LABEL_STATE_SLOT:
+         return "state_slot";
+      case MENU_ENUM_LABEL_STDIN_CMD_ENABLE:
+         return "stdin_commands";
+      case MENU_ENUM_LABEL_SUSPEND_SCREENSAVER_ENABLE:
+         return "suspend_screensaver_enable";
       case MENU_ENUM_LABEL_SYSTEM_BGM_ENABLE:
          return "system_bgm_enable";
-      case MENU_ENUM_LABEL_AUDIO_BLOCK_FRAMES:
-         return "audio_block_frames";
-      case MENU_ENUM_LABEL_INPUT_BIND_MODE:
-         return "input_bind_mode";
-      case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_LABEL_SHOW:
-         return "input_descriptor_label_show";
-      case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_HIDE_UNBOUND:
-         return "input_descriptor_hide_unbound";
+      case MENU_ENUM_LABEL_SYSTEM_DIRECTORY:
+         return "system_directory";
+      case MENU_ENUM_LABEL_SYSTEM_INFORMATION:
+         return "system_information";
+      case MENU_ENUM_LABEL_SYSTEM_INFO_ENTRY:
+         return "system_info_entry";
+      case MENU_ENUM_LABEL_TAKE_SCREENSHOT:
+         return "take_screenshot";
+      case MENU_ENUM_LABEL_THREADED_DATA_RUNLOOP_ENABLE:
+         return "threaded_data_runloop_enable";
+      case MENU_ENUM_LABEL_THUMBNAILS:
+         return "thumbnails";
+      case MENU_ENUM_LABEL_THUMBNAILS_DIRECTORY:
+         return "thumbnails_directory";
+      case MENU_ENUM_LABEL_THUMBNAILS_UPDATER_LIST:
+         return "thumbnails_updater_list";
+      case MENU_ENUM_LABEL_TIMEDATE_ENABLE:
+         return "menu_timedate_enable";
+      case MENU_ENUM_LABEL_TITLE_COLOR:
+         return "menu_title_color";
+      case MENU_ENUM_LABEL_UI_COMPANION_ENABLE:
+         return "ui_companion_enable";
+      case MENU_ENUM_LABEL_UI_COMPANION_START_ON_BOOT:
+         return "ui_companion_start_on_boot";
+      case MENU_ENUM_LABEL_UI_MENUBAR_ENABLE:
+         return "ui_menubar_enable";
+      case MENU_ENUM_LABEL_UNDO_LOAD_STATE:
+         return "undoloadstate";
+      case MENU_ENUM_LABEL_UNDO_SAVE_STATE:
+         return "undosavestate";
+      case MENU_ENUM_LABEL_UPDATER_SETTINGS:
+         return "updater_settings";
+      case MENU_ENUM_LABEL_UPDATE_ASSETS:
+         return "update_assets";
+      case MENU_ENUM_LABEL_UPDATE_AUTOCONFIG_PROFILES:
+         return "update_autoconfig_profiles";
+      case MENU_ENUM_LABEL_UPDATE_CG_SHADERS:
+         return "update_cg_shaders";
+      case MENU_ENUM_LABEL_UPDATE_CHEATS:
+         return "update_cheats";
+      case MENU_ENUM_LABEL_UPDATE_CORE_INFO_FILES:
+         return "update_core_info_files";
+      case MENU_ENUM_LABEL_UPDATE_DATABASES:
+         return "update_databases";
+      case MENU_ENUM_LABEL_UPDATE_GLSL_SHADERS:
+         return "update_glsl_shaders";
+      case MENU_ENUM_LABEL_UPDATE_LAKKA:
+         return "update_lakka";
+      case MENU_ENUM_LABEL_UPDATE_OVERLAYS:
+         return "update_overlays";
+      case MENU_ENUM_LABEL_UPDATE_SLANG_SHADERS:
+         return "update_slang_shaders";
+      case MENU_ENUM_LABEL_URL_ENTRY:
+         return "url_entry";
+      case MENU_ENUM_LABEL_USER_INTERFACE_SETTINGS:
+         return "user_interface_settings";
+      case MENU_ENUM_LABEL_USER_LANGUAGE:
+         return "user_language";
+      case MENU_ENUM_LABEL_USER_SETTINGS:
+         return "user_settings";
+      case MENU_ENUM_LABEL_USE_BUILTIN_IMAGE_VIEWER:
+         return "use_builtin_image_viewer";
+      case MENU_ENUM_LABEL_USE_BUILTIN_PLAYER:
+         return "use_builtin_player";
+      case MENU_ENUM_LABEL_USE_THIS_DIRECTORY:
+         return "use_this_directory";
+      case MENU_ENUM_LABEL_VIDEO_ALLOW_ROTATE:
+         return "video_allow_rotate";
+      case MENU_ENUM_LABEL_VIDEO_ASPECT_RATIO_AUTO:
+         return "video_aspect_ratio_auto";
+      case MENU_ENUM_LABEL_VIDEO_ASPECT_RATIO_INDEX:
+         return "aspect_ratio_index";
+      case MENU_ENUM_LABEL_VIDEO_BLACK_FRAME_INSERTION:
+         return "video_black_frame_insertion";
+      case MENU_ENUM_LABEL_VIDEO_CROP_OVERSCAN:
+         return "video_crop_overscan";
+      case MENU_ENUM_LABEL_VIDEO_DISABLE_COMPOSITION:
+         return "video_disable_composition";
+      case MENU_ENUM_LABEL_VIDEO_DRIVER:
+         return "video_driver";
+      case MENU_ENUM_LABEL_VIDEO_FILTER:
+         return "video_filter";
+      case MENU_ENUM_LABEL_VIDEO_FILTER_DIR:
+         return "video_filter_dir";
+      case MENU_ENUM_LABEL_VIDEO_FILTER_FLICKER:
+         return "video_filter_flicker";
       case MENU_ENUM_LABEL_VIDEO_FONT_ENABLE:
          return "video_font_enable";
       case MENU_ENUM_LABEL_VIDEO_FONT_PATH:
          return "video_font_path";
       case MENU_ENUM_LABEL_VIDEO_FONT_SIZE:
          return "video_font_size";
+      case MENU_ENUM_LABEL_VIDEO_FORCE_ASPECT:
+         return "video_force_aspect";
+      case MENU_ENUM_LABEL_VIDEO_FORCE_SRGB_DISABLE:
+         return "video_force_srgb_disable";
+      case MENU_ENUM_LABEL_VIDEO_FRAME_DELAY:
+         return "video_frame_delay";
+      case MENU_ENUM_LABEL_VIDEO_FULLSCREEN:
+         return "video_fullscreen";
+      case MENU_ENUM_LABEL_VIDEO_GAMMA:
+         return "video_gamma";
+      case MENU_ENUM_LABEL_VIDEO_GPU_RECORD:
+         return "video_gpu_record";
+      case MENU_ENUM_LABEL_VIDEO_GPU_SCREENSHOT:
+         return "video_gpu_screenshot";
+      case MENU_ENUM_LABEL_VIDEO_HARD_SYNC:
+         return "video_hard_sync";
+      case MENU_ENUM_LABEL_VIDEO_HARD_SYNC_FRAMES:
+         return "video_hard_sync_frames";
+      case MENU_ENUM_LABEL_VIDEO_MAX_SWAPCHAIN_IMAGES:
+         return "video_max_swapchain_images";
       case MENU_ENUM_LABEL_VIDEO_MESSAGE_POS_X:
          return "video_message_pos_x";
       case MENU_ENUM_LABEL_VIDEO_MESSAGE_POS_Y:
          return "video_message_pos_y";
-      case MENU_ENUM_LABEL_VIDEO_SOFT_FILTER:
-         return "soft_filter";
-      case MENU_ENUM_LABEL_VIDEO_FILTER_FLICKER:
-         return "video_filter_flicker";
-      case MENU_ENUM_LABEL_INPUT_REMAPPING_DIRECTORY:
-         return "input_remapping_directory";
-      case MENU_ENUM_LABEL_JOYPAD_AUTOCONFIG_DIR:
-         return "joypad_autoconfig_dir";
-      case MENU_ENUM_LABEL_RECORDING_CONFIG_DIRECTORY:
-         return "recording_config_directory";
-      case MENU_ENUM_LABEL_RECORDING_OUTPUT_DIRECTORY:
-         return "recording_output_directory";
-      case MENU_ENUM_LABEL_SCREENSHOT_DIRECTORY:
-         return "screenshot_directory";
-      case MENU_ENUM_LABEL_PLAYLIST_DIRECTORY:
-         return "playlist_directory";
-      case MENU_ENUM_LABEL_SAVEFILE_DIRECTORY:
-         return "savefile_directory";
-      case MENU_ENUM_LABEL_SAVESTATE_DIRECTORY:
-         return "savestate_directory";
-      case MENU_ENUM_LABEL_STDIN_CMD_ENABLE:
-         return "stdin_commands";
-      case MENU_ENUM_LABEL_NETWORK_REMOTE_ENABLE:
-         return "network_remote_enable";
-      case MENU_ENUM_LABEL_NETWORK_REMOTE_USER_1_ENABLE:
-         return "network_remote_user_1_enable";
-      case MENU_ENUM_LABEL_NETWORK_REMOTE_USER_LAST_ENABLE:
-         return "network_remote_user_last_enable";
-      case MENU_ENUM_LABEL_NETWORK_REMOTE_PORT:
-         return "network_remote_base_port";
-      case MENU_ENUM_LABEL_VIDEO_DRIVER:
-         return "video_driver";
-      case MENU_ENUM_LABEL_RECORD_ENABLE:
-         return "record_enable";
-      case MENU_ENUM_LABEL_VIDEO_GPU_RECORD:
-         return "video_gpu_record";
-      case MENU_ENUM_LABEL_RECORD_PATH:
-         return "record_path";
-      case MENU_ENUM_LABEL_RECORD_USE_OUTPUT_DIRECTORY:
-         return "record_use_output_directory";
-      case MENU_ENUM_LABEL_RECORD_CONFIG:
-         return "record_config";
+      case MENU_ENUM_LABEL_VIDEO_MONITOR_INDEX:
+         return "video_monitor_index";
       case MENU_ENUM_LABEL_VIDEO_POST_FILTER_RECORD:
          return "video_post_filter_record";
-      case MENU_ENUM_LABEL_CORE_ASSETS_DIRECTORY:
-         return "core_assets_directory";
-      case MENU_ENUM_LABEL_ASSETS_DIRECTORY:
-         return "assets_directory";
-      case MENU_ENUM_LABEL_DYNAMIC_WALLPAPERS_DIRECTORY:
-         return "dynamic_wallpapers_directory";
-      case MENU_ENUM_LABEL_THUMBNAILS_DIRECTORY:
-         return "thumbnails_directory";
-      case MENU_ENUM_LABEL_RGUI_BROWSER_DIRECTORY:
-         return "rgui_browser_directory";
-      case MENU_ENUM_LABEL_RGUI_CONFIG_DIRECTORY:
-         return "rgui_config_directory";
-      case MENU_ENUM_LABEL_LIBRETRO_INFO_PATH:
-         return "libretro_info_path";
-      case MENU_ENUM_LABEL_LIBRETRO_DIR_PATH:
-         return "libretro_dir_path";
-      case MENU_ENUM_LABEL_CURSOR_DIRECTORY:
-         return "cursor_directory";
-      case MENU_ENUM_LABEL_CONTENT_DATABASE_DIRECTORY:
-         return "content_database_path";
-      case MENU_ENUM_LABEL_SYSTEM_DIRECTORY:
-         return "system_directory";
-      case MENU_ENUM_LABEL_CACHE_DIRECTORY:
-         return "cache_directory";
-      case MENU_ENUM_LABEL_CHEAT_DATABASE_PATH:
-         return "cheat_database_path";
-      case MENU_ENUM_LABEL_AUDIO_FILTER_DIR:
-         return "audio_filter_dir";
-      case MENU_ENUM_LABEL_VIDEO_FILTER_DIR:
-         return "video_filter_dir";
-      case MENU_ENUM_LABEL_VIDEO_SHADER_DIR:
-         return "video_shader_dir";
-      case MENU_ENUM_LABEL_OVERLAY_DIRECTORY:
-         return "overlay_directory";
-      case MENU_ENUM_LABEL_OSK_OVERLAY_DIRECTORY:
-         return "osk_overlay_directory";
-      case MENU_ENUM_LABEL_NETPLAY_CLIENT_SWAP_INPUT:
-         return "netplay_client_swap_input";
-      case MENU_ENUM_LABEL_NETPLAY_SPECTATOR_MODE_ENABLE:
-         return "netplay_spectator_mode_enable";
-      case MENU_ENUM_LABEL_NETPLAY_IP_ADDRESS:
-         return "netplay_ip_address";
-      case MENU_ENUM_LABEL_NETPLAY_TCP_UDP_PORT:
-         return "netplay_tcp_udp_port";
-      case MENU_ENUM_LABEL_NETPLAY_ENABLE:
-         return "netplay_enable";
-      case MENU_ENUM_LABEL_SSH_ENABLE:
-         return "ssh_enable";
-      case MENU_ENUM_LABEL_SAMBA_ENABLE:
-         return "samba_enable";
-      case MENU_ENUM_LABEL_BLUETOOTH_ENABLE:
-         return "bluetooth_enable";
-      case MENU_ENUM_LABEL_NETPLAY_DELAY_FRAMES:
-         return "netplay_delay_frames";
-      case MENU_ENUM_LABEL_NETPLAY_CHECK_FRAMES:
-         return "netplay_check_frames";
-      case MENU_ENUM_LABEL_NETPLAY_MODE:
-         return "netplay_mode";
-      case MENU_ENUM_LABEL_RGUI_SHOW_START_SCREEN:
-         return "rgui_show_start_screen";
-      case MENU_ENUM_LABEL_TITLE_COLOR:
-         return "menu_title_color";
-      case MENU_ENUM_LABEL_ENTRY_HOVER_COLOR:
-         return "menu_entry_hover_color";
-      case MENU_ENUM_LABEL_TIMEDATE_ENABLE:
-         return "menu_timedate_enable";
-      case MENU_ENUM_LABEL_THREADED_DATA_RUNLOOP_ENABLE:
-         return "threaded_data_runloop_enable";
-      case MENU_ENUM_LABEL_ENTRY_NORMAL_COLOR:
-         return "menu_entry_normal_color";
-      case MENU_ENUM_LABEL_SHOW_ADVANCED_SETTINGS:
-         return "menu_show_advanced_settings";
-      case MENU_ENUM_LABEL_MOUSE_ENABLE:
-         return "menu_mouse_enable";
-      case MENU_ENUM_LABEL_POINTER_ENABLE:
-         return "menu_pointer_enable";
-      case MENU_ENUM_LABEL_CORE_ENABLE:
-         return "menu_core_enable";
-      case MENU_ENUM_LABEL_NETPLAY_ENABLE_HOST:
-         return "menu_netplay_enable_host";
-      case MENU_ENUM_LABEL_NETPLAY_ENABLE_CLIENT:
-         return "menu_netplay_enable_client";
-      case MENU_ENUM_LABEL_NETPLAY_DISCONNECT:
-         return "menu_netplay_disconnect";
-      case MENU_ENUM_LABEL_NETPLAY_SETTINGS:
-         return "menu_netplay_settings";
-      case MENU_ENUM_LABEL_DPI_OVERRIDE_ENABLE:
-         return "dpi_override_enable";
-      case MENU_ENUM_LABEL_DPI_OVERRIDE_VALUE:
-         return "dpi_override_value";
-      case MENU_ENUM_LABEL_XMB_FONT:
-         return "xmb_font";
-      case MENU_ENUM_LABEL_XMB_THEME:
-         return "xmb_theme";
-      case MENU_ENUM_LABEL_XMB_MENU_COLOR_THEME:
-         return "xmb_menu_color_theme";
-      case MENU_ENUM_LABEL_MATERIALUI_MENU_COLOR_THEME:
-         return "materialui_menu_color_theme";
-      case MENU_ENUM_LABEL_MATERIALUI_MENU_HEADER_OPACITY:
-         return "materialui_menu_header_opacity";
-      case MENU_ENUM_LABEL_MATERIALUI_MENU_FOOTER_OPACITY:
-         return "materialui_menu_footer_opacity";
-      case MENU_ENUM_LABEL_XMB_SHADOWS_ENABLE:
-         return "xmb_shadows_enable";
-      case MENU_ENUM_LABEL_XMB_SHOW_SETTINGS:
-         return "xmb_show_settings";
-      case MENU_ENUM_LABEL_XMB_SHOW_IMAGES:
-         return "xmb_show_images";
-      case MENU_ENUM_LABEL_XMB_SHOW_MUSIC:
-         return "xmb_show_music";
-      case MENU_ENUM_LABEL_XMB_SHOW_VIDEO:
-         return "xmb_show_video";
-      case MENU_ENUM_LABEL_XMB_SHOW_HISTORY:
-         return "xmb_show_history";
-      case MENU_ENUM_LABEL_XMB_RIBBON_ENABLE:
-         return "xmb_ribbon_enable";
-      case MENU_ENUM_LABEL_XMB_SCALE_FACTOR:
-         return "xmb_scale_factor";
-      case MENU_ENUM_LABEL_XMB_ALPHA_FACTOR:
-         return "xmb_alpha_factor";
-      case MENU_ENUM_LABEL_SUSPEND_SCREENSAVER_ENABLE:
-         return "suspend_screensaver_enable";
-      case MENU_ENUM_LABEL_VIDEO_DISABLE_COMPOSITION:
-         return "video_disable_composition";
-      case MENU_ENUM_LABEL_PAUSE_NONACTIVE:
-         return "pause_nonactive";
-      case MENU_ENUM_LABEL_UI_COMPANION_START_ON_BOOT:
-         return "ui_companion_start_on_boot";
-      case MENU_ENUM_LABEL_UI_COMPANION_ENABLE:
-         return "ui_companion_enable";
-      case MENU_ENUM_LABEL_UI_MENUBAR_ENABLE:
-         return "ui_menubar_enable";
-      case MENU_ENUM_LABEL_ARCHIVE_MODE:
-         return "archive_mode";
-      case MENU_ENUM_LABEL_NETWORK_CMD_ENABLE:
-         return "network_cmd_enable";
-      case MENU_ENUM_LABEL_NETWORK_CMD_PORT:
-         return "network_cmd_port";
-      case MENU_ENUM_LABEL_HISTORY_LIST_ENABLE:
-         return "history_list_enable";
-      case MENU_ENUM_LABEL_CONTENT_HISTORY_SIZE:
-         return "content_history_size";
-      case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE_AUTO:
-         return "video_refresh_rate_auto";
-      case MENU_ENUM_LABEL_DUMMY_ON_CORE_SHUTDOWN:
-         return "dummy_on_core_shutdown";
-      case MENU_ENUM_LABEL_CORE_SET_SUPPORTS_NO_CONTENT_ENABLE:
-         return "core_set_supports_no_content_enable";
-      case MENU_ENUM_LABEL_FRAME_THROTTLE_ENABLE:
-         return "fastforward_ratio_throttle_enable";
-      case MENU_ENUM_LABEL_FASTFORWARD_RATIO:
-         return "fastforward_ratio";
-      case MENU_ENUM_LABEL_AUTO_REMAPS_ENABLE:
-         return "auto_remaps_enable";
-      case MENU_ENUM_LABEL_AUTO_SHADERS_ENABLE:
-         return "auto_shaders_enable";
-      case MENU_ENUM_LABEL_SLOWMOTION_RATIO:
-         return "slowmotion_ratio";
-      case MENU_ENUM_LABEL_CORE_SPECIFIC_CONFIG:
-         return "core_specific_config";
-      case MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS:
-         return "game_specific_options";
-      case MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS_CREATE:
-         return "game_specific_options_create";
-      case MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS_IN_USE:
-         return "game_specific_options_in_use";
-      case MENU_ENUM_LABEL_AUTO_OVERRIDES_ENABLE:
-         return "auto_overrides_enable";
-      case MENU_ENUM_LABEL_CONFIG_SAVE_ON_EXIT:
-         return "config_save_on_exit";
-      case MENU_ENUM_LABEL_CONFIRM_ON_EXIT:
-         return "confirm_on_exit";
-      case MENU_ENUM_LABEL_SHOW_HIDDEN_FILES:
-         return "show_hidden_files";
-      case MENU_ENUM_LABEL_VIDEO_SMOOTH:
-         return "video_smooth";
-      case MENU_ENUM_LABEL_VIDEO_GAMMA:
-         return "video_gamma";
-      case MENU_ENUM_LABEL_VIDEO_ALLOW_ROTATE:
-         return "video_allow_rotate";
-      case MENU_ENUM_LABEL_VIDEO_HARD_SYNC:
-         return "video_hard_sync";
-      case MENU_ENUM_LABEL_VIDEO_SWAP_INTERVAL:
-         return "video_swap_interval";
-      case MENU_ENUM_LABEL_VIDEO_VSYNC:
-         return "video_vsync";
-      case MENU_ENUM_LABEL_VIDEO_THREADED:
-         return "video_threaded";
-      case MENU_ENUM_LABEL_VIDEO_ROTATION:
-         return "video_rotation";
-      case MENU_ENUM_LABEL_VIDEO_GPU_SCREENSHOT:
-         return "video_gpu_screenshot";
-      case MENU_ENUM_LABEL_VIDEO_CROP_OVERSCAN:
-         return "video_crop_overscan";
-      case MENU_ENUM_LABEL_VIDEO_ASPECT_RATIO_INDEX:
-         return "aspect_ratio_index";
-      case MENU_ENUM_LABEL_VIDEO_ASPECT_RATIO_AUTO:
-         return "video_aspect_ratio_auto";
-      case MENU_ENUM_LABEL_VIDEO_FORCE_ASPECT:
-         return "video_force_aspect";
       case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE:
          return "video_refresh_rate";
-      case MENU_ENUM_LABEL_VIDEO_FORCE_SRGB_DISABLE:
-         return "video_force_srgb_disable";
-      case MENU_ENUM_LABEL_VIDEO_WINDOWED_FULLSCREEN:
-         return "video_windowed_fullscreen";
-      case MENU_ENUM_LABEL_PAL60_ENABLE:
-         return "pal60_enable";
-      case MENU_ENUM_LABEL_VIDEO_VFILTER:
-         return "video_vfilter";
-      case MENU_ENUM_LABEL_VIDEO_VI_WIDTH:
-         return "video_vi_width";
-      case MENU_ENUM_LABEL_VIDEO_BLACK_FRAME_INSERTION:
-         return "video_black_frame_insertion";
-      case MENU_ENUM_LABEL_VIDEO_HARD_SYNC_FRAMES:
-         return "video_hard_sync_frames";
-      case MENU_ENUM_LABEL_SORT_SAVEFILES_ENABLE:
-         return "sort_savefiles_enable";
-      case MENU_ENUM_LABEL_SORT_SAVESTATES_ENABLE:
-         return "sort_savestates_enable";
-      case MENU_ENUM_LABEL_VIDEO_FULLSCREEN:
-         return "video_fullscreen";
-      case MENU_ENUM_LABEL_PERFCNT_ENABLE:
-         return "perfcnt_enable";
+      case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE_AUTO:
+         return "video_refresh_rate_auto";
+      case MENU_ENUM_LABEL_VIDEO_ROTATION:
+         return "video_rotation";
       case MENU_ENUM_LABEL_VIDEO_SCALE:
          return "video_scale";
       case MENU_ENUM_LABEL_VIDEO_SCALE_INTEGER:
          return "video_scale_integer";
-      case MENU_ENUM_LABEL_LIBRETRO_LOG_LEVEL:
-         return "libretro_log_level";
-      case MENU_ENUM_LABEL_LOG_VERBOSITY:
-         return "log_verbosity";
-      case MENU_ENUM_LABEL_SAVESTATE_AUTO_SAVE:
-         return "savestate_auto_save";
-      case MENU_ENUM_LABEL_SAVESTATE_AUTO_LOAD:
-         return "savestate_auto_load";
-      case MENU_ENUM_LABEL_SAVESTATE_AUTO_INDEX:
-         return "savestate_auto_index";
-      case MENU_ENUM_LABEL_AUTOSAVE_INTERVAL:
-         return "autosave_interval";
-      case MENU_ENUM_LABEL_BLOCK_SRAM_OVERWRITE:
-         return "block_sram_overwrite";
-      case MENU_ENUM_LABEL_VIDEO_SHARED_CONTEXT:
-         return "video_shared_context";
-      case MENU_ENUM_LABEL_RESTART_RETROARCH:
-         return "restart_retroarch";
-      case MENU_ENUM_LABEL_NETPLAY_NICKNAME:
-         return "netplay_nickname";
-      case MENU_ENUM_LABEL_USER_LANGUAGE:
-         return "user_language";
-      case MENU_ENUM_LABEL_CAMERA_ALLOW:
-         return "camera_allow";
-      case MENU_ENUM_LABEL_LOCATION_ALLOW:
-         return "location_allow";
-      case MENU_ENUM_LABEL_PAUSE_LIBRETRO:
-         return "menu_pause_libretro";
-      case MENU_ENUM_LABEL_INPUT_OSK_OVERLAY_ENABLE:
-         return "input_osk_overlay_enable";
-      case MENU_ENUM_LABEL_INPUT_OVERLAY_ENABLE:
-         return "input_overlay_enable";
-      case MENU_ENUM_LABEL_VIDEO_MONITOR_INDEX:
-         return "video_monitor_index";
-      case MENU_ENUM_LABEL_VIDEO_FRAME_DELAY:
-         return "video_frame_delay";
-      case MENU_ENUM_LABEL_INPUT_DUTY_CYCLE:
-         return "input_duty_cycle";
-      case MENU_ENUM_LABEL_INPUT_TURBO_PERIOD:
-         return "input_turbo_period";
-      case MENU_ENUM_LABEL_INPUT_BIND_TIMEOUT:
-         return "input_bind_timeout";
-      case MENU_ENUM_LABEL_INPUT_AXIS_THRESHOLD:
-         return "input_axis_threshold";
-      case MENU_ENUM_LABEL_INPUT_REMAP_BINDS_ENABLE:
-         return "input_remap_binds_enable";
-      case MENU_ENUM_LABEL_INPUT_MAX_USERS:
-         return "input_max_users";
-      case MENU_ENUM_LABEL_INPUT_AUTODETECT_ENABLE:
-         return "input_autodetect_enable";
-      case MENU_ENUM_LABEL_AUDIO_OUTPUT_RATE:
-         return "audio_output_rate";
-      case MENU_ENUM_LABEL_AUDIO_MAX_TIMING_SKEW:
-         return "audio_max_timing_skew";
-      case MENU_ENUM_LABEL_CHEAT_APPLY_CHANGES:
-         return "cheat_apply_changes";
-      case MENU_ENUM_LABEL_REMAP_FILE_SAVE_CORE:
-         return "remap_file_save_core";
-      case MENU_ENUM_LABEL_REMAP_FILE_SAVE_GAME:
-         return "remap_file_save_game";
-      case MENU_ENUM_LABEL_CHEAT_NUM_PASSES:
-         return "cheat_num_passes";
-      case MENU_ENUM_LABEL_SHADER_APPLY_CHANGES:
-         return "shader_apply_changes";
-      case MENU_ENUM_LABEL_COLLECTION:
-         return "collection";
-      case MENU_ENUM_LABEL_REWIND_ENABLE:
-         return "rewind_enable";
-      case MENU_ENUM_LABEL_CONTENT_COLLECTION_LIST:
-         return "select_from_collection";
-      case MENU_ENUM_LABEL_DETECT_CORE_LIST:
-         return "detect_core_list";
-      case MENU_ENUM_LABEL_LOAD_CONTENT_HISTORY:
-         return "load_recent";
-      case MENU_ENUM_LABEL_AUDIO_ENABLE:
-         return "audio_enable";
-      case MENU_ENUM_LABEL_FPS_SHOW:
-         return "fps_show";
-      case MENU_ENUM_LABEL_AUDIO_MUTE:
-         return "audio_mute_enable";
-      case MENU_ENUM_LABEL_VIDEO_SHADER_PASS:
-         return "video_shader_pass";
-      case MENU_ENUM_LABEL_AUDIO_VOLUME:
-         return "audio_volume";
-      case MENU_ENUM_LABEL_AUDIO_SYNC:
-         return "audio_sync";
-      case MENU_ENUM_LABEL_AUDIO_RATE_CONTROL_DELTA:
-         return "audio_rate_control_delta";
+      case MENU_ENUM_LABEL_VIDEO_SETTINGS:
+         return "video_settings";
+      case MENU_ENUM_LABEL_VIDEO_SHADER_DIR:
+         return "video_shader_dir";
       case MENU_ENUM_LABEL_VIDEO_SHADER_FILTER_PASS:
          return "video_shader_filter_pass";
-      case MENU_ENUM_LABEL_VIDEO_SHADER_SCALE_PASS:
-         return "video_shader_scale_pass";
       case MENU_ENUM_LABEL_VIDEO_SHADER_NUM_PASSES:
          return "video_shader_num_passes";
-      case MENU_ENUM_LABEL_SHADER_PARAMETERS_ENTRY:
-         return "shader_parameters_entry";
-      case MENU_ENUM_LABEL_RDB_ENTRY:
-         return "rdb_entry";
-      case MENU_ENUM_LABEL_RDB_ENTRY_DESCRIPTION:
-         return "rdb_entry_description";
-      case MENU_ENUM_LABEL_RDB_ENTRY_GENRE:
-         return "rdb_entry_genre";
-      case MENU_ENUM_LABEL_RDB_ENTRY_ORIGIN:
-         return "rdb_entry_origin";
-      case MENU_ENUM_LABEL_RDB_ENTRY_PUBLISHER:
-         return "rdb_entry_publisher";
-      case MENU_ENUM_LABEL_RDB_ENTRY_DEVELOPER:
-         return "rdb_entry_developer";
-      case MENU_ENUM_LABEL_RDB_ENTRY_FRANCHISE:
-         return "rdb_entry_franchise";
-      case MENU_ENUM_LABEL_RDB_ENTRY_MAX_USERS:
-         return "rdb_entry_max_users";
-      case MENU_ENUM_LABEL_RDB_ENTRY_NAME:
-         return "rdb_entry_name";
-      case MENU_ENUM_LABEL_RDB_ENTRY_EDGE_MAGAZINE_RATING:
-         return "rdb_entry_edge_magazine_rating";
-      case MENU_ENUM_LABEL_RDB_ENTRY_EDGE_MAGAZINE_REVIEW:
-         return "rdb_entry_edge_magazine_review";
-      case MENU_ENUM_LABEL_RDB_ENTRY_FAMITSU_MAGAZINE_RATING:
-         return "rdb_entry_famitsu_magazine_rating";
-      case MENU_ENUM_LABEL_RDB_ENTRY_TGDB_RATING:
-         return "rdb_entry_tgdb_rating";
-      case MENU_ENUM_LABEL_RDB_ENTRY_EDGE_MAGAZINE_ISSUE:
-         return "rdb_entry_edge_magazine_issue";
-      case MENU_ENUM_LABEL_RDB_ENTRY_RELEASE_MONTH:
-         return "rdb_entry_releasemonth";
-      case MENU_ENUM_LABEL_RDB_ENTRY_RELEASE_YEAR:
-         return "rdb_entry_releaseyear";
-      case MENU_ENUM_LABEL_RDB_ENTRY_ENHANCEMENT_HW:
-         return "rdb_entry_enhancement_hw";
-      case MENU_ENUM_LABEL_RDB_ENTRY_SHA1:
-         return "rdb_entry_sha1";
-      case MENU_ENUM_LABEL_RDB_ENTRY_CRC32:
-         return "rdb_entry_crc32";
-      case MENU_ENUM_LABEL_RDB_ENTRY_MD5:
-         return "rdb_entry_md5";
-      case MENU_ENUM_LABEL_RDB_ENTRY_BBFC_RATING:
-         return "rdb_entry_bbfc_rating";
-      case MENU_ENUM_LABEL_RDB_ENTRY_ESRB_RATING:
-         return "rdb_entry_esrb_rating";
-      case MENU_ENUM_LABEL_RDB_ENTRY_ELSPA_RATING:
-         return "rdb_entry_elspa_rating";
-      case MENU_ENUM_LABEL_RDB_ENTRY_PEGI_RATING:
-         return "rdb_entry_pegi_rating";
-      case MENU_ENUM_LABEL_RDB_ENTRY_CERO_RATING:
-         return "rdb_entry_cero_rating";
-      case MENU_ENUM_LABEL_RDB_ENTRY_ANALOG:
-         return "rdb_entry_analog";
-      case MENU_ENUM_LABEL_RDB_ENTRY_SERIAL:
-         return "rdb_entry_serial";
-      case MENU_ENUM_LABEL_CONFIGURATIONS:
-         return "configurations";
-      case MENU_ENUM_LABEL_REWIND_GRANULARITY:
-         return "rewind_granularity";
-      case MENU_ENUM_LABEL_REMAP_FILE_LOAD:
-         return "remap_file_load";
-      case MENU_ENUM_LABEL_CUSTOM_RATIO:
-         return "custom_ratio";
-      case MENU_ENUM_LABEL_USE_THIS_DIRECTORY:
-         return "use_this_directory";
-      case MENU_ENUM_LABEL_RDB_ENTRY_START_CONTENT:
-         return "rdb_entry_start_content";
-      case MENU_ENUM_LABEL_CUSTOM_BIND:
-         return "custom_bind";
-      case MENU_ENUM_LABEL_CUSTOM_BIND_ALL:
-         return "custom_bind_all";
-      case MENU_ENUM_LABEL_DISK_OPTIONS:
-         return "core_disk_options";
-      case MENU_ENUM_LABEL_CORE_CHEAT_OPTIONS:
-         return "core_cheat_options";
-      case MENU_ENUM_LABEL_CORE_OPTIONS:
-         return "core_options";
-      case MENU_ENUM_LABEL_DATABASE_MANAGER_LIST:
-         return "database_manager_list";
-      case MENU_ENUM_LABEL_DEFERRED_DATABASE_MANAGER_LIST:
-         return "deferred_database_manager_list";
-      case MENU_ENUM_LABEL_CURSOR_MANAGER_LIST:
-         return "cursor_manager_list";
-      case MENU_ENUM_LABEL_DEFERRED_CURSOR_MANAGER_LIST:
-         return "deferred_cursor_manager_list";
-      case MENU_ENUM_LABEL_CHEAT_FILE_LOAD:
-         return "cheat_file_load";
-      case MENU_ENUM_LABEL_CHEAT_FILE_SAVE_AS:
-         return "cheat_file_save_as";
-      case MENU_ENUM_LABEL_DEFERRED_RDB_ENTRY_DETAIL:
-         return "deferred_rdb_entry_detail";
-      case MENU_ENUM_LABEL_FRONTEND_COUNTERS:
-         return "frontend_counters";
-      case MENU_ENUM_LABEL_CORE_COUNTERS:
-         return "core_counters";
-      case MENU_ENUM_LABEL_DISK_CYCLE_TRAY_STATUS:
-         return "disk_cycle_tray_status";
-      case MENU_ENUM_LABEL_DISK_IMAGE_APPEND:
-         return "disk_image_append";
-      case MENU_ENUM_LABEL_DEFERRED_CORE_LIST:
-         return "deferred_core_list";
-      case MENU_ENUM_LABEL_DEFERRED_CORE_LIST_SET:
-         return "deferred_core_list_set";
-      case MENU_ENUM_LABEL_INFO_SCREEN:
-         return "info_screen";
-      case MENU_ENUM_LABEL_SETTINGS:
-         return "settings";
-      case MENU_ENUM_LABEL_QUIT_RETROARCH:
-         return "quit_retroarch";
-      case MENU_ENUM_LABEL_SHUTDOWN:
-         return "shutdown";
-      case MENU_ENUM_LABEL_REBOOT:
-         return "reboot";
-      case MENU_ENUM_LABEL_HELP:
-         return "help";
-      case MENU_ENUM_LABEL_SAVE_NEW_CONFIG:
-         return "save_new_config";
-      case MENU_ENUM_LABEL_RESTART_CONTENT:
-         return "restart_content";
-      case MENU_ENUM_LABEL_TAKE_SCREENSHOT:
-         return "take_screenshot";
-      case MENU_ENUM_LABEL_DELETE_ENTRY:
-         return "delete_entry";
-      case MENU_ENUM_LABEL_CORE_UPDATER_LIST:
-         return "core_updater_list";
-      case MENU_ENUM_LABEL_START_VIDEO_PROCESSOR:
-         return "menu_start_video_processor";
-      case MENU_ENUM_LABEL_START_NET_RETROPAD:
-         return "menu_start_net_retropad";
-      case MENU_ENUM_LABEL_THUMBNAILS_UPDATER_LIST:
-         return "thumbnails_updater_list";
-      case MENU_ENUM_LABEL_CORE_UPDATER_BUILDBOT_URL:
-         return "core_updater_buildbot_url";
-      case MENU_ENUM_LABEL_BUILDBOT_ASSETS_URL:
-         return "buildbot_assets_url";
-      case MENU_ENUM_LABEL_NAVIGATION_WRAPAROUND:
-         return "menu_navigation_wraparound_enable";
-      case MENU_ENUM_LABEL_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
-         return "menu_navigation_browser_filter_supported_extensions_enable";
-      case MENU_ENUM_LABEL_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
-         return "core_updater_auto_extract_archive";
-      case MENU_ENUM_LABEL_ACHIEVEMENT_LIST:
-         return "achievement_list";
-      case MENU_ENUM_LABEL_SYSTEM_INFORMATION:
-         return "system_information";
-      case MENU_ENUM_LABEL_NETWORK_INFORMATION:
-         return "network_information";
-      case MENU_ENUM_LABEL_ONLINE_UPDATER:
-         return "online_updater";
-      case MENU_ENUM_LABEL_NETPLAY:
-         return "netplay";
-      case MENU_ENUM_LABEL_CORE_INFORMATION:
-         return "core_information";
-      case MENU_ENUM_LABEL_CORE_LIST:
-         return "load_core";
-      case MENU_ENUM_LABEL_LOAD_CONTENT:
-         return "load_content_default";
-      case MENU_ENUM_LABEL_CLOSE_CONTENT:
-         return "unload_core";
-      case MENU_ENUM_LABEL_MANAGEMENT:
-         return "database_settings";
-      case MENU_ENUM_LABEL_SAVE_STATE:
-         return "savestate";
-      case MENU_ENUM_LABEL_LOAD_STATE:
-         return "loadstate";
-      case MENU_ENUM_LABEL_UNDO_LOAD_STATE:
-         return "undoloadstate";
-      case MENU_ENUM_LABEL_UNDO_SAVE_STATE:
-         return "undosavestate";
-      case MENU_ENUM_LABEL_RESUME_CONTENT:
-         return "resume_content";
-      case MENU_ENUM_LABEL_INPUT_DRIVER:
-         return "input_driver";
-      case MENU_ENUM_LABEL_AUDIO_DRIVER:
-         return "audio_driver";
-      case MENU_ENUM_LABEL_JOYPAD_DRIVER:
-         return "input_joypad_driver";
-      case MENU_ENUM_LABEL_AUDIO_RESAMPLER_DRIVER:
-         return "audio_resampler_driver";
-      case MENU_ENUM_LABEL_RECORD_DRIVER:
-         return "record_driver";
-      case MENU_ENUM_LABEL_MENU_DRIVER:
-         return "menu_driver";
-      case MENU_ENUM_LABEL_CAMERA_DRIVER:
-         return "camera_driver";
-      case MENU_ENUM_LABEL_WIFI_DRIVER:
-         return "wifi_driver";
-      case MENU_ENUM_LABEL_LOCATION_DRIVER:
-         return "location_driver";
-      case MENU_ENUM_LABEL_OVERLAY_SCALE:
-         return "input_overlay_scale";
-      case MENU_ENUM_LABEL_OVERLAY_PRESET:
-         return "input_overlay";
-      case MENU_ENUM_LABEL_KEYBOARD_OVERLAY_PRESET:
-         return "input_osk_overlay";
-      case MENU_ENUM_LABEL_AUDIO_DEVICE:
-         return "audio_device";
-      case MENU_ENUM_LABEL_AUDIO_LATENCY:
-         return "audio_latency";
-      case MENU_ENUM_LABEL_OVERLAY_OPACITY:
-         return "input_overlay_opacity";
-      case MENU_ENUM_LABEL_MENU_WALLPAPER:
-         return "menu_wallpaper";
-      case MENU_ENUM_LABEL_DYNAMIC_WALLPAPER:
-         return "menu_dynamic_wallpaper_enable";
-      case MENU_ENUM_LABEL_THUMBNAILS:
-         return "thumbnails";
-      case MENU_ENUM_LABEL_CORE_INPUT_REMAPPING_OPTIONS:
-         return "core_input_remapping_options";
-      case MENU_ENUM_LABEL_SHADER_OPTIONS:
-         return "shader_options";
       case MENU_ENUM_LABEL_VIDEO_SHADER_PARAMETERS:
          return "video_shader_parameters";
+      case MENU_ENUM_LABEL_VIDEO_SHADER_PASS:
+         return "video_shader_pass";
+      case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET:
+         return "video_shader_preset";
       case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_PARAMETERS:
          return "video_shader_preset_parameters";
       case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_SAVE_AS:
          return "video_shader_preset_save_as";
-      case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET:
-         return "video_shader_preset";
-      case MENU_ENUM_LABEL_VIDEO_FILTER:
-         return "video_filter";
-      case MENU_ENUM_LABEL_DEFERRED_VIDEO_FILTER:
-         return "deferred_video_filter";
-      case MENU_ENUM_LABEL_DEFERRED_CORE_UPDATER_LIST:
-         return "core_updater";
-      case MENU_ENUM_LABEL_DEFERRED_THUMBNAILS_UPDATER_LIST:
-         return "deferred_thumbnails_updater_list";
-      case MENU_ENUM_LABEL_AUDIO_DSP_PLUGIN:
-         return "audio_dsp_plugin";
-      case MENU_ENUM_LABEL_UPDATE_ASSETS:
-         return "update_assets";
-      case MENU_ENUM_LABEL_UPDATE_LAKKA:
-         return "update_lakka";
-      case MENU_ENUM_LABEL_UPDATE_CHEATS:
-         return "update_cheats";
-      case MENU_ENUM_LABEL_UPDATE_AUTOCONFIG_PROFILES:
-         return "update_autoconfig_profiles";
-      case MENU_ENUM_LABEL_UPDATE_DATABASES:
-         return "update_databases";
-      case MENU_ENUM_LABEL_UPDATE_OVERLAYS:
-         return "update_overlays";
-      case MENU_ENUM_LABEL_UPDATE_CG_SHADERS:
-         return "update_cg_shaders";
-      case MENU_ENUM_LABEL_UPDATE_GLSL_SHADERS:
-         return "update_glsl_shaders";
-      case MENU_ENUM_LABEL_UPDATE_SLANG_SHADERS:
-         return "update_slang_shaders";
-      case MENU_ENUM_LABEL_SCREEN_RESOLUTION:
-         return "screen_resolution";
-      case MENU_ENUM_LABEL_USE_BUILTIN_IMAGE_VIEWER:
-         return "use_builtin_image_viewer";
-      case MENU_ENUM_LABEL_INPUT_POLL_TYPE_BEHAVIOR:
-         return "input_poll_type_behavior";
-      case MENU_ENUM_LABEL_MENU_WALLPAPER_OPACITY:
-         return "menu_wallpaper_opacity";
+      case MENU_ENUM_LABEL_VIDEO_SHADER_SCALE_PASS:
+         return "video_shader_scale_pass";
+      case MENU_ENUM_LABEL_VIDEO_SHARED_CONTEXT:
+         return "video_shared_context";
+      case MENU_ENUM_LABEL_VIDEO_SMOOTH:
+         return "video_smooth";
+      case MENU_ENUM_LABEL_VIDEO_SOFT_FILTER:
+         return "soft_filter";
+      case MENU_ENUM_LABEL_VIDEO_SWAP_INTERVAL:
+         return "video_swap_interval";
+      case MENU_ENUM_LABEL_VIDEO_TAB:
+         return "video_tab";
+      case MENU_ENUM_LABEL_VIDEO_THREADED:
+         return "video_threaded";
+      case MENU_ENUM_LABEL_VIDEO_VFILTER:
+         return "video_vfilter";
+      case MENU_ENUM_LABEL_VIDEO_VIEWPORT_CUSTOM_HEIGHT:
+         return "video_viewport_custom_height";
+      case MENU_ENUM_LABEL_VIDEO_VIEWPORT_CUSTOM_WIDTH:
+         return "video_viewport_custom_width";
+      case MENU_ENUM_LABEL_VIDEO_VIEWPORT_CUSTOM_X:
+         return "video_viewport_custom_x";
+      case MENU_ENUM_LABEL_VIDEO_VIEWPORT_CUSTOM_Y:
+         return "video_viewport_custom_y";
+      case MENU_ENUM_LABEL_VIDEO_VI_WIDTH:
+         return "video_vi_width";
+      case MENU_ENUM_LABEL_VIDEO_VSYNC:
+         return "video_vsync";
+      case MENU_ENUM_LABEL_VIDEO_WINDOWED_FULLSCREEN:
+         return "video_windowed_fullscreen";
+      case MENU_ENUM_LABEL_WIFI_DRIVER:
+         return "wifi_driver";
+      case MENU_ENUM_LABEL_WIFI_SETTINGS:
+         return "wifi_settings";
+      case MENU_ENUM_LABEL_XMB_ALPHA_FACTOR:
+         return "xmb_alpha_factor";
+      case MENU_ENUM_LABEL_XMB_FONT:
+         return "xmb_font";
+      case MENU_ENUM_LABEL_XMB_MENU_COLOR_THEME:
+         return "xmb_menu_color_theme";
+      case MENU_ENUM_LABEL_XMB_RIBBON_ENABLE:
+         return "xmb_ribbon_enable";
+      case MENU_ENUM_LABEL_XMB_SCALE_FACTOR:
+         return "xmb_scale_factor";
+      case MENU_ENUM_LABEL_XMB_SHADOWS_ENABLE:
+         return "xmb_shadows_enable";
+      case MENU_ENUM_LABEL_XMB_SHOW_HISTORY:
+         return "xmb_show_history";
+      case MENU_ENUM_LABEL_XMB_SHOW_IMAGES:
+         return "xmb_show_images";
+      case MENU_ENUM_LABEL_XMB_SHOW_MUSIC:
+         return "xmb_show_music";
+      case MENU_ENUM_LABEL_XMB_SHOW_SETTINGS:
+         return "xmb_show_settings";
+      case MENU_ENUM_LABEL_XMB_SHOW_VIDEO:
+         return "xmb_show_video";
+      case MENU_ENUM_LABEL_XMB_THEME:
+         return "xmb_theme";
+      case MENU_ENUM_SUBLABEL_MENU_SETTINGS:
+         return "Điều chỉnh thiết lập related to the appearance of the menu screen.";
+      case MENU_ENUM_SUBLABEL_VIDEO_HARD_SYNC:
+         return "Hard-synchronize the CPU and GPU. Reduces latency at the cost of performance.";
+      case MENU_ENUM_SUBLABEL_VIDEO_THREADED:
+         return "Improves performance at the cost of latency and more video stuttering. Use only if you cannot obtain full speed otherwise.";
+      case MSG_AUDIO_VOLUME:
+         return "Âm lượng âm thanh";
+      case MSG_AUTODETECT:
+         return "Tự động phát hiện";
+      case MSG_AUTOLOADING_SAVESTATE_FROM:
+         return "Đang tự đông tải savestate từ";
+      case MSG_BRINGING_UP_COMMAND_INTERFACE_ON_PORT:
+         return "bringing_up_command_interface_at_port";
+      case MSG_CONNECTING_TO_NETPLAY_HOST:
+         return "Đang kết nối vào máy chủ netplay";
+      case MSG_CONNECTING_TO_PORT:
+         return "Đang kết nối vào port";
+      case MSG_CONNECTION_SLOT:
+         return "Khe kết nối";
+      case MSG_CONNECT_DEVICE_FROM_A_VALID_PORT:
+         return "connect_device_from_a_valid_port";
+      case MSG_DEVICE_CONFIGURED_IN_PORT:
+         return "configured in port";
+      case MSG_DEVICE_DISCONNECTED_FROM_PORT:
+        return "Device disconnected from port";
+      case MSG_DEVICE_NOT_CONFIGURED:
+         return "not configured";
+      case MSG_DISCONNECTING_DEVICE_FROM_PORT:
+         return "disconnecting_device_from_port";
+      case MSG_DISCONNECT_DEVICE_FROM_A_VALID_PORT:
+         return "disconnect_device_from_a_valid_port";
+      case MSG_FAILED:
+         return "Bị Lỗi";
+      case MSG_FAILED_TO_SET_DISK:
+         return "Failed to set disk";
+      case MSG_FAILED_TO_START_AUDIO_DRIVER:
+         return "failed_to_start_audio_driver";
+      case MSG_FILE_ALREADY_EXISTS_SAVING_TO_BACKUP_BUFFER:
+         return "Ttệp đã tồn tại. Đang lưu vào backup buffer";
+      case MSG_FOUND_LAST_STATE_SLOT:
+         return "found_last_state_slot";
+      case MSG_GOT_CONNECTION_FROM:
+         return "Được kết nối từ";
+      case MSG_NETPLAY_USERS_HAS_FLIPPED:
+         return "Người dùng Netplay đã flipped";
+      case MSG_SETTING_DISK_IN_TRAY:
+         return "Setting disk in tray";
+      case MSG_SUCCEEDED:
+         return "Đã thành công";
+      case MSG_UNKNOWN_NETPLAY_COMMAND_RECEIVED:
+         return "Netplay không biết lệnh nhận được";
+      case MSG_WAITING_FOR_CLIENT:
+         return "Đang đợi máy khách  ...";
       default:
          break;
    }
@@ -3033,1790 +3033,1790 @@ const char *msg_hash_to_str_vn(enum msg_hash_enums msg)
 
    switch (msg)
    {
-      case MENU_ENUM_SUBLABEL_CONFIG_SAVE_ON_EXIT:
-         return "Lưu cấu hình khi thoát retroarch.";
-      case MENU_ENUM_SUBLABEL_VIDEO_HARD_SYNC_FRAMES:
-         return "Sets how many frames the CPU can run ahead of the GPU when using 'Hard GPU Sync'.";
-      case MENU_ENUM_SUBLABEL_VIDEO_REFRESH_RATE_AUTO:
-         return "The accurate estimated refresh rate of the monitor in Hz.";
-      case MENU_ENUM_SUBLABEL_VIDEO_MONITOR_INDEX:
-         return "Chọn màn hình hiển thị để sử dụng.";
-      case MENU_ENUM_SUBLABEL_LOG_VERBOSITY:
-         return "Enable or disable logging to the terminal.";
-      case MENU_ENUM_SUBLABEL_SHOW_HIDDEN_FILES:
-         return "Hiện ra tập tin và thư mục ẩn trong trình duyệt tập tin.";
-      case MENU_ENUM_SUBLABEL_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
-         return "Kết hợp nút Gamepad để vào menu bật/tắt.";
-      case MENU_ENUM_SUBLABEL_CPU_CORES:
-         return "Số lượng lõi của CPU.";
-      case MENU_ENUM_SUBLABEL_VIDEO_BLACK_FRAME_INSERTION:
-         return "Inserts a black frame inbetween frames. Useful for users of 120 Hz monitors who want to play 60 Hz material with eliminated ghosting.";
-      case MENU_ENUM_SUBLABEL_VIDEO_FRAME_DELAY:
-         return "Reduces latency at the cost of higher risk of video stuttering. Adds a delay after V-Sync (in ms).";
-      case MENU_ENUM_SUBLABEL_ADD_CONTENT_LIST:
-         return "Tải/quét nội dung và thêm vào bộ sưu tập.";
-      case MENU_ENUM_SUBLABEL_NETPLAY:
-         return "Tham gia hoặc làm máy chủ cho netplay.";
-      case MENU_ENUM_SUBLABEL_FPS_SHOW:
-         return "Hiển thị tốc độ khung hình/giây trên màn hình.";
-      case MENU_ENUM_SUBLABEL_VIDEO_SETTINGS:
-         return "Điều chỉnh thiết lập cho video ra.";
-      case MENU_ENUM_SUBLABEL_AUDIO_SETTINGS:
-         return "Điều chỉnh thiết lập cho âm thanh ra.";
-      case MENU_ENUM_SUBLABEL_INPUT_SETTINGS:
-         return "Điều chỉnh thiết lập cho joypads, bàn phím và chuột.";
-      case MENU_ENUM_SUBLABEL_WIFI_SETTINGS:
-         return "Tìm mạng không dây và thiết lập kết nối.";
-      case MENU_ENUM_SUBLABEL_SERVICES_SETTINGS:
-         return "Quản lý dịch vụ của hệ điều hành.";
-      case MENU_ENUM_SUBLABEL_SSH_ENABLE:
-         return "Bật/tắt giao thức SSH.";
-      case MENU_ENUM_SUBLABEL_SAMBA_ENABLE:
-         return "Bật/tắt chia sẻ thư mục trên mạng.";
-      case MENU_ENUM_SUBLABEL_BLUETOOTH_ENABLE:
-         return "Bật/tắt bluetooth.";
-      case MENU_ENUM_SUBLABEL_USER_LANGUAGE:
-         return "Thiết lập ngôn ngữ của giao diện .";
-      case MENU_ENUM_SUBLABEL_SUSPEND_SCREENSAVER_ENABLE:
-         return "Chặn tính năng screensaver (màn hình chờ).";
-      case MENU_ENUM_SUBLABEL_VIDEO_MAX_SWAPCHAIN_IMAGES:
-         return "Tells the video driver to explicitly use a specified buffering mode.";
-      case MENU_ENUM_SUBLABEL_ONLINE_UPDATER:
-         return "Tải/cập nhật tiện ích và thành phần của RetroArch.";
-      case MENU_ENUM_SUBLABEL_INPUT_USER_BINDS:
-         return "Đặt cấu hình điều khiển cho người dùng này.";
-      case MENU_ENUM_SUBLABEL_INPUT_HOTKEY_BINDS:
-         return "Đặt cấu hình thiết lập của hotkey.";
-      case MSG_VALUE_SHUTTING_DOWN:
-         return "Đang tắt máy...";
-      case MSG_VALUE_REBOOTING:
-         return "Đang khởi động lại...";
-      case MSG_FAILED_TO_START_AUDIO_DRIVER:
-         return "Bị lỗi khi chạy chương trình điều khiển âm thanh. Sẽ tiếp tục chạy và bỏ âm thanh.";
-      case MSG_FOUND_LAST_STATE_SLOT:
-         return "Tiềm thấy state slot xài lần trước";
-      case MSG_VALUE_CONNECT_DEVICE_FROM_A_VALID_PORT:
-         return "Kết nối thiết bị từ cổng hợp lệ.";
-      case MSG_DISCONNECT_DEVICE_FROM_A_VALID_PORT:
-         return "Ngắt kết nối thiết bị từ cổng hợp lệ.";
-      case MSG_VALUE_DISCONNECTING_DEVICE_FROM_PORT:
-         return "Đang ngắt kết nối thiết bị từ cổng";
-      case MSG_BRINGING_UP_COMMAND_INTERFACE_ON_PORT:
-         return "Đang đưa lên lệnh giao diện trên cổng";
-      case MSG_LOADING_HISTORY_FILE:
-         return "Đang nạp tập tin lịch sử";
-      case MENU_ENUM_LABEL_VALUE_SHADER_PIPELINE_RIBBON_SIMPLIFIED:
-         return "Ribbon (simplified)";
-      case MENU_ENUM_LABEL_VALUE_SHADER_PIPELINE_RIBBON:
-         return "Ribbon";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_FOOTER_OPACITY:
-         return "Footer Opacity";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_HEADER_OPACITY:
-         return "Header Opacity";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_BLUE:
-         return "Blue";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_BLUE_GREY:
-         return "Blue Grey";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_RED:
-         return "Red";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_YELLOW:
-         return "Yellow";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_NVIDIA_SHIELD:
-         return "Shield";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_GREEN:
-         return "Green";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_DARK_BLUE:
-         return "Dark Blue";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_PLAIN:
-         return "Plain";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_LEGACY_RED:
-         return "Legacy Red";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_DARK_PURPLE:
-         return "Dark Purple";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_MIDNIGHT_BLUE:
-         return "Midnight Blue";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_GOLDEN:
-         return "Golden";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_ELECTRIC_BLUE:
-         return "Electric Blue";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_APPLE_GREEN:
-         return "Apple Green";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_UNDERSEA:
-         return "Undersea";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_VOLCANIC_RED:
-         return "Volcanic Red";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_DARK:
-         return "Dark";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_UNLOCKED_ENTRY:
-         return "Unlocked";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_LOCKED_ENTRY:
-         return "Locked";
-      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR_LATE:
-         return "Late";
-      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR_NORMAL:
-         return "Normal";
-      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR_EARLY:
-         return "Early";
-      case MSG_INTERNAL_MEMORY:
-         return "Internal Memory";
-      case MSG_EXTERNAL_APPLICATION_DIR:
-         return "External Application Dir";
-      case MSG_APPLICATION_DIR:
-         return "Application Dir";
-      case MSG_PROGRAM:
-         return "RetroArch";
-      case MSG_LIBRETRO_FRONTEND:
-         return "Frontend for libretro";
-      case MSG_LOADING:
-         return "Đang tải";
-      case MSG_GAME_SPECIFIC_CORE_OPTIONS_FOUND_AT:
-         return "Per-Game Options: game-specific core options found at";
-      case MSG_RESTORING_DEFAULT_SHADER_PRESET_TO:
-         return "Shaders: restoring default shader preset to";
-      case  MSG_SORRY_UNIMPLEMENTED_CORES_DONT_DEMAND_CONTENT_NETPLAY:
-         return "Sorry, unimplemented: cores that don't demand content cannot participate in netplay.";
-      case MSG_FOUND_AUTO_SAVESTATE_IN:
-         return "Tìm thấy savestate tự đông trong";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_REMOTE_PORT:
-         return "Network Remote Base Port";
-      case MSG_OVERRIDES_SAVED_SUCCESSFULLY:
-         return "Overrides saved successfully.";
-      case MSG_AUTOCONFIG_FILE_SAVED_SUCCESSFULLY:
-         return "Tập tin Autoconfig đã lưu thành công.";
-      case MSG_OVERRIDES_ERROR_SAVING:
-         return "Error saving overrides.";
-      case MSG_AUTOCONFIG_FILE_ERROR_SAVING:
-         return "Tập tin Autoconfig bị lỗi khi lưu.";
-      case MSG_DOWNLOAD_FAILED:
-         return "Download failed";
-      case MSG_INPUT_CHEAT:
-         return "Input Cheat";
-      case MSG_DECOMPRESSION_ALREADY_IN_PROGRESS:
-         return "Decompression already in progress.";
-      case MSG_DECOMPRESSION_FAILED:
-         return "Decompression failed.";
-      case MSG_CORE_OPTIONS_FILE_CREATED_SUCCESSFULLY:
-         return "Core options file created successfully.";
-      case MSG_FAILED_TO_CREATE_THE_DIRECTORY:
-         return "Failed to create the directory.";
-      case MSG_FAILED_TO_EXTRACT_CONTENT_FROM_COMPRESSED_FILE:
-         return "Failed to extract content from compressed file";
-      case MSG_FILE_NOT_FOUND:
-         return "Không tìm thấy tệp";
-      case MSG_ERROR_SAVING_CORE_OPTIONS_FILE:
-         return "Error saving core options file.";
-      case MSG_FAILED_TO_ALLOCATE_MEMORY_FOR_PATCHED_CONTENT:
-         return "Failed to allocate memory for patched content...";
-      case MSG_DID_NOT_FIND_A_VALID_CONTENT_PATCH:
-         return "Did not find a valid content patch.";
-      case MSG_SEVERAL_PATCHES_ARE_EXPLICITLY_DEFINED:
-         return "Several patches are explicitly defined, ignoring all...";
-      case MSG_REMAP_FILE_SAVED_SUCCESSFULLY:
-         return "Remap file saved successfully.";
-      case MSG_SHADER_PRESET_SAVED_SUCCESSFULLY:
-         return "Shader preset saved successfully.";
-      case MSG_ERROR_SAVING_REMAP_FILE:
-         return "Error saving remap file.";
-      case MSG_ERROR_SAVING_SHADER_PRESET:
-         return "Error saving shader preset.";
-      case MSG_INPUT_CHEAT_FILENAME:
-         return "Cheat Filename";
-      case MSG_INPUT_PRESET_FILENAME:
-         return "Preset Filename";
-      case MSG_DISK_EJECTED:
-         return "Ejected";
-      case MSG_DISK_CLOSED:
-         return "Closed";
-      case MSG_VERSION_OF_LIBRETRO_API:
-         return "Phiên bản của libretro API";
-      case MSG_COMPILED_AGAINST_API:
-         return "Compiled against API";
-      case MSG_FAILED_TO_LOAD:
-         return "Bị lỗi khi tải";
-      case MSG_CONNECTED_TO:
-         return "Connected to";
-      case MSG_FAILED_TO_ACCEPT_INCOMING_SPECTATOR:
-         return "Failed to accept incoming spectator.";
-      case MSG_FAILED_TO_GET_NICKNAME_FROM_CLIENT:
-         return "Failed to get nickname from client.";
-      case MSG_FAILED_TO_SEND_NICKNAME_TO_CLIENT:
-         return "Failed to send nickname to client.";
-      case MSG_USING_CORE_NAME_FOR_NEW_CONFIG:
-         return "Using core name for new config.";
-      case MSG_CANNOT_INFER_NEW_CONFIG_PATH:
-         return "Cannot infer new config path. Use current time.";
-      case MSG_NO_STATE_HAS_BEEN_LOADED_YET:
-         return "No state has been loaded yet.";
-      case MSG_NO_SAVE_STATE_HAS_BEEN_OVERWRITTEN_YET:
-         return "No save state has been overwritten yet.";
-      case MSG_RESTORED_OLD_SAVE_STATE:
-         return "Restored old save state.";
-      case MSG_SAVED_NEW_CONFIG_TO:
-         return "Saved new config to";
-      case MSG_FAILED_SAVING_CONFIG_TO:
-         return "Failed saving config to";
-      case MSG_FAILED_TO_RECEIVE_NICKNAME_SIZE_FROM_HOST:
-         return "Failed to receive nickname size from host.";
-      case MSG_FAILED_TO_RECEIVE_NICKNAME:
-         return "Failed to receive nickname.";
-      case MSG_FAILED_TO_RECEIVE_NICKNAME_FROM_HOST:
-         return "Failed to receive nickname from host.";
-      case MSG_FAILED_TO_SEND_NICKNAME_SIZE:
-         return "Failed to send nickname size.";
-      case MSG_FAILED_TO_SEND_SRAM_DATA_TO_CLIENT:
-         return "Failed to send SRAM data to client.";
-      case MSG_FAILED_TO_RECEIVE_HEADER_FROM_CLIENT:
-         return "Failed to receive header from client.";
-      case MSG_FAILED_TO_RECEIVE_SRAM_DATA_FROM_HOST:
-         return "Failed to receive SRAM data from host.";
-      case MSG_CONTENT_CRC32S_DIFFER:
-         return "Content CRC32s differ. Cannot use different games.";
-      case MSG_FAILED_TO_SEND_NICKNAME:
-         return "Failed to send nickname.";
-      case MSG_FAILED_TO_SEND_NICKNAME_TO_HOST:
-         return "Failed to send nickname to host.";
-      case MSG_INVALID_NICKNAME_SIZE:
-         return "Invalid nickname size.";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ANALOG:
-         return "Analog supported";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_SERIAL:
-         return "Serial";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_COOP:
-         return "Co-op supported";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ENHANCEMENT_HW:
-         return "Enhancement Hardware";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ELSPA_RATING:
-         return "ELSPA Rating";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RUMBLE:
-         return "Rumble supported";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_PEGI_RATING:
-         return "PEGI Rating";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_EDGE_MAGAZINE_ISSUE:
-         return "Edge Magazine Issue";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_BBFC_RATING:
-         return "BBFC Rating";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ESRB_RATING:
-         return "ESRB Rating";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_CERO_RATING:
-         return "CERO Rating";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MAX_SWAPCHAIN_IMAGES:
-         return "Max swapchain images";
-      case MSG_ERROR_LIBRETRO_CORE_REQUIRES_CONTENT:
-         return "Libretro core requires content, but nothing was provided.";
-      case MSG_CONTENT_LOADING_SKIPPED_IMPLEMENTATION_WILL_DO_IT:
-         return "Content loading skipped. Implementation will tải it on its own.";
-      case MSG_ERROR_LIBRETRO_CORE_REQUIRES_SPECIAL_CONTENT:
-         return "Libretro core requires special content, but none were provided.";
-      case MSG_REVERTING_SAVEFILE_DIRECTORY_TO:
-         return "Reverting savefile directory to";
-      case MSG_REVERTING_SAVESTATE_DIRECTORY_TO:
-         return "Reverting savestate directory to";
-      case MSG_COULD_NOT_READ_MOVIE_HEADER:
-         return "Could not read movie header.";
-      case MSG_FAILED_TO_OPEN_LIBRETRO_CORE:
-         return "Failed to open libretro core";
-      case MSG_COULD_NOT_FIND_ANY_NEXT_DRIVER:
-         return "Could not find any next driver";
-      case MSG_MOVIE_FORMAT_DIFFERENT_SERIALIZER_VERSION:
-         return "Movie format seems to have a different serializer version. Will most likely fail.";
-      case MSG_CRC32_CHECKSUM_MISMATCH:
-         return "CRC32 checksum mismatch between content file and saved content checksum in replay file header; replay highly likely to desync on playback.";
-      case MSG_INFLATED_CHECKSUM_DID_NOT_MATCH_CRC32:
-         return "Inflated checksum did not match CRC32.";
-      case MSG_ERROR_PARSING_ARGUMENTS:
-         return "Error parsing arguments.";
-      case MSG_ERROR:
-         return "Error";
-      case MSG_FOUND_DISK_LABEL:
-         return "Found disk label";
-      case MSG_READING_FIRST_DATA_TRACK:
-         return "Reading first data track...";
-      case MSG_FOUND_FIRST_DATA_TRACK_ON_FILE:
-         return "Found first data track on file";
-      case MSG_COULD_NOT_FIND_VALID_DATA_TRACK:
-         return "Could not find valid data track";
-      case MSG_COMPARING_WITH_KNOWN_MAGIC_NUMBERS:
-         return "Comparing with known magic numbers...";
-      case MSG_COULD_NOT_FIND_COMPATIBLE_SYSTEM:
-         return "Could not find compatible system.";
-      case MSG_COULD_NOT_OPEN_DATA_TRACK:
-         return "could not open data track";
-      case MSG_MEMORY:
-         return "Memory";
-      case MSG_FRAMES:
-         return "Frames";
-      case MSG_IN_BYTES:
-         return "in bytes";
-      case MSG_IN_MEGABYTES:
-         return "in megabytes";
-      case MSG_IN_GIGABYTES:
-         return "in gigabytes";
-      case MSG_INTERFACE:
-         return "Interface";
-      case MSG_FAILED_TO_PATCH:
-         return "Failed to patch";
-      case MSG_FATAL_ERROR_RECEIVED_IN:
-         return "Fatal error received in";
-      case MSG_MOVIE_RECORD_STOPPED:
-         return "Stopping movie record.";
-      case MSG_MOVIE_PLAYBACK_ENDED:
-         return "Movie playback ended.";
-      case MSG_AUTOSAVE_FAILED:
-         return "Could not initialize autosave.";
-      case MSG_NETPLAY_FAILED_MOVIE_PLAYBACK_HAS_STARTED:
-         return "Movie playback has started. Cannot start netplay.";
-      case MSG_NETPLAY_FAILED:
-         return "Failed to initialize netplay.";
-      case MSG_LIBRETRO_ABI_BREAK:
-         return "is compiled against a different version of libretro than this libretro implementation.";
-      case MSG_REWIND_INIT_FAILED_THREADED_AUDIO:
-         return "Implementation uses threaded audio. Cannot use rewind.";
-      case MSG_REWIND_INIT_FAILED:
-         return "Failed to initialize rewind buffer. Rewinding will be disabled.";
-      case MSG_REWIND_INIT:
-         return "Initializing rewind buffer with size";
-      case MSG_CUSTOM_TIMING_GIVEN:
-         return "Custom timing given";
-      case MSG_VIEWPORT_SIZE_CALCULATION_FAILED:
-         return "Viewport size calculation failed! Will continue using raw data. This will probably not work right ...";
-      case MSG_HW_RENDERED_MUST_USE_POSTSHADED_RECORDING:
-         return "Libretro core is hardware rendered. Must use post-shaded recording as well.";
-      case MSG_RECORDING_TO:
-         return "Recording to";
-      case MSG_DETECTED_VIEWPORT_OF:
-         return "Detected viewport of";
-      case MSG_TAKING_SCREENSHOT:
-         return "Taking screenshot.";
-      case MSG_FAILED_TO_TAKE_SCREENSHOT:
-         return "Bị lỗi khi chụp ảnh màn hình.";
-      case MSG_FAILED_TO_START_RECORDING:
-         return "Failed to start recording.";
-      case MSG_RECORDING_TERMINATED_DUE_TO_RESIZE:
-         return "Recording terminated due to resize.";
-      case MSG_USING_LIBRETRO_DUMMY_CORE_RECORDING_SKIPPED:
-         return "Using libretro dummy core. Skipping recording.";
-      case MSG_UNKNOWN:
-         return "Unknown";
-      case MSG_COULD_NOT_READ_STATE_FROM_MOVIE:
-         return "Could not read state from movie.";
-      case MSG_MOVIE_FILE_IS_NOT_A_VALID_BSV1_FILE:
-         return "Movie file is not a valid BSV1 file.";
-      case MSG_LOADING_CONTENT_FILE:
-         return "Loading content file";
-      case MSG_RECEIVED:
-         return "received";
-      case MSG_UNRECOGNIZED_COMMAND:
-         return "Unrecognized command";
-      case MSG_SENDING_COMMAND:
-         return "Sending command";
-      case MSG_GOT_INVALID_DISK_INDEX:
-         return "Got invalid disk index.";
-      case MSG_FAILED_TO_REMOVE_DISK_FROM_TRAY:
-         return "Failed to remove disk from tray.";
-      case MSG_REMOVED_DISK_FROM_TRAY:
-         return "Removed disk from tray.";
-      case MSG_VIRTUAL_DISK_TRAY:
-         return "virtual disk tray.";
-      case MSG_FAILED_TO:
-         return "Failed to";
-      case MSG_TO:
-         return "to";
-      case MSG_SAVING_RAM_TYPE:
-         return "Saving RAM type";
-      case MSG_UNDOING_SAVE_STATE:
-         return "Undoing save state";
-      case MSG_SAVING_STATE:
-         return "Saving state";
-      case MSG_LOADING_STATE:
-         return "Đang tải state";
-      case MSG_FAILED_TO_LOAD_MOVIE_FILE:
-         return "Failed to tải movie file";
-      case MSG_FAILED_TO_LOAD_CONTENT:
-         return "Failed to tải content";
-      case MSG_COULD_NOT_READ_CONTENT_FILE:
-         return "Could not read content file";
-      case MSG_GRAB_MOUSE_STATE:
-         return "Grab mouse state";
-      case MSG_PAUSED:
-         return "Paused.";
-      case MSG_UNPAUSED:
-         return "Unpaused.";
-      case MSG_FAILED_TO_LOAD_OVERLAY:
-         return "Failed to tải overlay.";
-      case MSG_FAILED_TO_UNMUTE_AUDIO:
-         return "Failed to unmute audio.";
-      case MSG_AUDIO_MUTED:
-         return "Audio muted.";
-      case MSG_AUDIO_UNMUTED:
-         return "Audio unmuted.";
-      case MSG_RESET:
-         return "Reset";
-      case MSG_AUTO_SAVE_STATE_TO:
-         return "Auto save state to";
-      case MSG_FAILED_TO_LOAD_STATE:
-         return "Failed to tải state from";
-      case MSG_FAILED_TO_SAVE_STATE_TO:
-         return "Failed to save state to";
-      case MSG_FAILED_TO_UNDO_LOAD_STATE:
-         return "Failed to undo tải state.";
-      case MSG_FAILED_TO_UNDO_SAVE_STATE:
-         return "Failed to undo save state.";
-      case MSG_FAILED_TO_SAVE_SRAM:
-         return "Failed to save SRAM";
-      case MSG_STATE_SIZE:
-         return "State size";
-      case MSG_FOUND_SHADER:
-         return "Found shader";
-      case MSG_SRAM_WILL_NOT_BE_SAVED:
-         return "SRAM will not be saved.";
-      case MSG_BLOCKING_SRAM_OVERWRITE:
-         return "Blocking SRAM Overwrite";
-      case MSG_CORE_DOES_NOT_SUPPORT_SAVESTATES:
-         return "Core does not support save states.";
-      case MSG_SAVED_STATE_TO_SLOT:
-         return "Saved state to slot";
-      case MSG_SAVED_SUCCESSFULLY_TO:
-         return "Saved successfully to";
-      case MSG_BYTES:
-         return "bytes";
-      case MSG_CONFIG_DIRECTORY_NOT_SET:
-         return "Config directory not set. Cannot save new config.";
-      case MSG_SKIPPING_SRAM_LOAD:
-         return "Skipping SRAM tải.";
-      case MSG_APPENDED_DISK:
-         return "Appended disk";
-      case MSG_STARTING_MOVIE_PLAYBACK:
-         return "Starting movie playback.";
-      case MSG_FAILED_TO_REMOVE_TEMPORARY_FILE:
-         return "Failed to remove temporary file";
-      case MSG_REMOVING_TEMPORARY_CONTENT_FILE:
-         return "Removing temporary content file";
-      case MSG_LOADED_STATE_FROM_SLOT:
-         return "Loaded state from slot";
-      case MSG_SCANNING_OF_DIRECTORY_FINISHED:
-         return "Scanning of directory finished";
-      case MSG_SCANNING:
-         return "Scanning";
-      case MSG_REDIRECTING_CHEATFILE_TO:
-         return "Redirecting cheat file to";
-      case MSG_REDIRECTING_SAVEFILE_TO:
-         return "Redirecting save file to";
-      case MSG_REDIRECTING_SAVESTATE_TO:
-         return "Redirecting savestate to";
-      case MSG_APPLYING_CHEAT:
-         return "Applying cheat changes.";
 	  case MSG_SHADER:
          return "Shader";
-      case MSG_APPLYING_SHADER:
-         return "Applying shader";
-      case MSG_FAILED_TO_APPLY_SHADER:
-         return "Failed to apply shader.";
-      case MSG_STARTING_MOVIE_RECORD_TO:
-         return "Starting movie record to";
-      case MSG_FAILED_TO_START_MOVIE_RECORD:
-         return "Failed to start movie record.";
-      case MSG_STATE_SLOT:
-         return "State slot";
-      case MSG_RESTARTING_RECORDING_DUE_TO_DRIVER_REINIT:
-         return "Restarting recording due to driver reinit.";
-      case MSG_SLOW_MOTION:
-         return "Slow motion.";
-      case MSG_SLOW_MOTION_REWIND:
-         return "Slow motion rewind.";
-      case MSG_REWINDING:
-         return "Rewinding.";
-      case MSG_REWIND_REACHED_END:
-         return "Reached end of rewind buffer.";
-      case MSG_CHEEVOS_HARDCORE_MODE_ENABLE:
-         return "Hardcore Mode Enabled: savestate & rewind were disabled.";
-      case MSG_DOWNLOADING:
-         return "Downloading";
-      case MSG_EXTRACTING:
-         return "Extracting";
-      case MSG_EXTRACTING_FILE:
-         return "Extracting file";
-      case MSG_NO_CONTENT_STARTING_DUMMY_CORE:
-         return "No content, starting dummy core.";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_EDGE_MAGAZINE_RATING:
-         return "Edge Magazine Rating";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_EDGE_MAGAZINE_REVIEW:
-         return "Edge Magazine Review";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_FAMITSU_MAGAZINE_RATING:
-         return "Famitsu Magazine Rating";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_TGDB_RATING:
-         return "TGDB Rating";
-      case MENU_ENUM_LABEL_VALUE_CPU_ARCHITECTURE:
-         return "CPU Architecture:";
-      case MENU_ENUM_LABEL_VALUE_CPU_CORES:
-         return "CPU Cores:";
-      case MENU_ENUM_LABEL_VALUE_INTERNAL_STORAGE_STATUS:
-         return "Internal storage status";
-      case MENU_ENUM_LABEL_VALUE_PARENT_DIRECTORY:
-         return "Parent directory";
-      case MENU_ENUM_LABEL_VALUE_MORE:
-         return "...";
-      case MENU_ENUM_LABEL_VALUE_RUN:
-         return "Run";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_X:
-         return "Custom Viewport X";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_Y:
-         return "Custom Viewport Y";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_WIDTH:
-         return "Custom Viewport Width";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_HEIGHT:
-         return "Custom Viewport Height";
-      case MENU_ENUM_LABEL_VALUE_NO_ENTRIES_TO_DISPLAY:
-         return "No entries to display.";
-      case MENU_ENUM_LABEL_VALUE_NO_ACHIEVEMENTS_TO_DISPLAY:
-         return "No achievements to display.";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_UNLOCKED_ACHIEVEMENTS:
-         return "Unlocked Achievements:";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_LOCKED_ACHIEVEMENTS:
-         return "Locked Achievements:";
-      case MENU_ENUM_LABEL_VALUE_START_VIDEO_PROCESSOR:
-         return "Start Video Processor";
-      case MENU_ENUM_LABEL_VALUE_START_NET_RETROPAD:
-         return "Start Remote RetroPad";
-      case MENU_ENUM_LABEL_VALUE_THUMBNAILS_UPDATER_LIST:
-         return "Thumbnails Updater";
-      case MENU_ENUM_LABEL_VALUE_MENU_LINEAR_FILTER:
-         return "Menu Linear Filter";
-      case MENU_ENUM_LABEL_VALUE_MENU_ENUM_THROTTLE_FRAMERATE:
-         return "Throttle Menu Framerate";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_HARDCORE_MODE_ENABLE:
-         return "Hardcore Mode";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_TEST_UNOFFICIAL:
-         return "Test unofficial";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_SETTINGS:
-         return "Retro Achievements";
-      case MENU_ENUM_LABEL_VALUE_INPUT_TOUCH_ENABLE:
-         return "Touch Enable";
-      case MENU_ENUM_LABEL_VALUE_INPUT_PREFER_FRONT_TOUCH:
-         return "Prefer Front Touch";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ICADE_ENABLE:
-         return "Keyboard Gamepad Mapping Enable";
-      case MENU_ENUM_LABEL_VALUE_INPUT_KEYBOARD_GAMEPAD_MAPPING_TYPE:
-         return "Keyboard Gamepad Mapping Type";
-      case MENU_ENUM_LABEL_VALUE_INPUT_SMALL_KEYBOARD_ENABLE:
-         return "Small Keyboard Enable";
-      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG_OVERRIDE_CORE:
-         return "Save Core Overrides";
-      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG_OVERRIDE_GAME:
-         return "Save Game Overrides";
-      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG:
-         return "Save Current Config";
-      case MENU_ENUM_LABEL_VALUE_STATE_SLOT:
-         return "State Slot";
+      case  MSG_SORRY_UNIMPLEMENTED_CORES_DONT_DEMAND_CONTENT_NETPLAY:
+         return "Sorry, unimplemented: cores that don't demand content cannot participate in netplay.";
+      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_PASSWORD:
+         return "Password";
       case MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_SETTINGS:
          return "Accounts Cheevos";
       case MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_USERNAME:
          return "Username";
-      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_PASSWORD:
-         return "Password";
-      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_RETRO_ACHIEVEMENTS:
-         return "Retro Achievements";
-      case MENU_ENUM_LABEL_VALUE_RETRO_ACHIEVEMENTS_SETTINGS:
-         return "Retro Achievements";
       case MENU_ENUM_LABEL_VALUE_ACCOUNTS_LIST:
          return "Accounts";
       case MENU_ENUM_LABEL_VALUE_ACCOUNTS_LIST_END:
          return "Accounts List Endpoint";
-      case MENU_ENUM_LABEL_VALUE_HELP_SCANNING_CONTENT:
-         return "Scanning For Content";
-      case MENU_ENUM_LABEL_VALUE_CHEEVOS_DESCRIPTION:
-         return "Description";
-      case MENU_ENUM_LABEL_VALUE_HELP_AUDIO_VIDEO_TROUBLESHOOTING:
-         return "Audio/Video Troubleshooting";
-      case MENU_ENUM_LABEL_VALUE_HELP_CHANGE_VIRTUAL_GAMEPAD:
-         return "Changing Virtual Gamepad Overlay";
-      case MENU_ENUM_LABEL_VALUE_HELP_WHAT_IS_A_CORE:
-         return "What Is A Core?";
-      case MENU_ENUM_LABEL_VALUE_HELP_LOADING_CONTENT:
-         return "Đang tải Content";
-      case MENU_ENUM_LABEL_VALUE_HELP_LIST:
-         return "Help";
-      case MENU_ENUM_LABEL_VALUE_HELP_CONTROLS:
-         return "Basic Menu Controls";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS:
-         return "Basic menu controls";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_SCROLL_UP:
-         return "Scroll Up";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_CONFIRM:
-         return "Confirm/OK";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_BACK:
-         return "Back";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_START:
-         return "Defaults";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_INFO:
-         return "Info";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_TOGGLE_MENU:
-         return "Toggle Menu";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_QUIT:
-         return "Quit";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_TOGGLE_KEYBOARD:
-         return "Toggle Keyboard";
-      case MENU_ENUM_LABEL_VALUE_OPEN_ARCHIVE:
-         return "Open Archive As Folder";
-      case MENU_ENUM_LABEL_VALUE_LOAD_ARCHIVE:
-         return "Tải Archive With Core";
-      case MENU_ENUM_LABEL_VALUE_INPUT_BACK_AS_MENU_ENUM_TOGGLE_ENABLE:
-         return "Back As Menu Toggle Enable";
-      case MENU_ENUM_LABEL_VALUE_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
-         return "Menu Toggle Gamepad Combo";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ALL_USERS_CONTROL_MENU:
-         return "All Users Control Menu";
-      case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_HIDE_IN_MENU:
-         return "Hide Overlay In Menu";
-      case MENU_ENUM_LABEL_VALUE_LANG_POLISH:
-         return "Polish";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_AUTOLOAD_PREFERRED:
-         return "Tự động tải Preferred Overlay";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_CORE_INFO_FILES:
-         return "Cập nhật Core Info Files";
-      case MENU_ENUM_LABEL_VALUE_DOWNLOAD_CORE_CONTENT:
-         return "Download Content";
-      case MENU_ENUM_LABEL_VALUE_DOWNLOAD_CORE:
-         return "Download Core...";
-      case MENU_ENUM_LABEL_VALUE_SCAN_THIS_DIRECTORY:
-         return "<Scan This Directory>";
-      case MENU_ENUM_LABEL_VALUE_SCAN_FILE:
-         return "Scan File";
-      case MENU_ENUM_LABEL_VALUE_SCAN_DIRECTORY:
-         return "Scan Directory";
+      case MENU_ENUM_LABEL_VALUE_ACCOUNTS_RETRO_ACHIEVEMENTS:
+         return "Retro Achievements";
+      case MENU_ENUM_LABEL_VALUE_ACHIEVEMENT_LIST:
+         return "Achievement List";
       case MENU_ENUM_LABEL_VALUE_ADD_CONTENT_LIST:
          return "Add Content";
-      case MENU_ENUM_LABEL_VALUE_INFORMATION:
-         return "Information";
-      case MENU_ENUM_LABEL_VALUE_INFORMATION_LIST:
-         return "Information";
-      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_PLAYER:
-         return "Use Builtin Media Player";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_SETTINGS:
-         return "Quick Menu";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_CRC32:
-         return "CRC32";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_MD5:
-         return "MD5";
-      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_LIST:
-         return "Tải Content";
-      case MENU_ENUM_LABEL_VALUE_ASK_ARCHIVE:
-         return "Ask";
-      case MENU_ENUM_LABEL_VALUE_PRIVACY_SETTINGS:
-         return "Privacy";
-      case MENU_ENUM_LABEL_VALUE_MUSIC_TAB:
-         return "Music";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_TAB:
-         return "Video";
-      case MENU_ENUM_LABEL_VALUE_IMAGES_TAB:
-         return "Images";
-      case MENU_ENUM_LABEL_VALUE_HORIZONTAL_MENU:
-         return "Horizontal Menu";
-      case MENU_ENUM_LABEL_VALUE_SETTINGS_TAB:
-         return "Thiết lập";
-      case MENU_ENUM_LABEL_VALUE_HISTORY_TAB:
-         return "History";
       case MENU_ENUM_LABEL_VALUE_ADD_TAB:
          return "Import content";
-      case MENU_ENUM_LABEL_VALUE_PLAYLISTS_TAB:
-         return "Playlists";
-      case MENU_ENUM_LABEL_VALUE_NO_SETTINGS_FOUND:
-         return "No thiết lập found.";
-      case MENU_ENUM_LABEL_VALUE_NO_PERFORMANCE_COUNTERS:
-         return "No performance counters.";
-      case MENU_ENUM_LABEL_VALUE_DRIVER_SETTINGS:
-         return "Driver";
-      case MENU_ENUM_LABEL_VALUE_CONFIGURATION_SETTINGS:
-         return "Configuration";
-      case MENU_ENUM_LABEL_VALUE_CORE_SETTINGS:
-         return "Core";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SETTINGS:
-         return "Video";
-      case MENU_ENUM_LABEL_VALUE_LOGGING_SETTINGS:
-         return "Logging";
-      case MENU_ENUM_LABEL_VALUE_SAVING_SETTINGS:
-         return "Saving";
-      case MENU_ENUM_LABEL_VALUE_REWIND_SETTINGS:
-         return "Rewind";
-      case MENU_ENUM_LABEL_VALUE_SHADER:
-         return "Shader";
-      case MENU_ENUM_LABEL_VALUE_CHEAT:
-         return "Cheat";
-      case MENU_ENUM_LABEL_VALUE_USER:
-         return "User";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_BGM_ENABLE:
-         return "System BGM Enable";
-      case MENU_ENUM_LABEL_VALUE_RETROPAD:
-         return "RetroPad";
-      case MENU_ENUM_LABEL_VALUE_RETROKEYBOARD:
-         return "RetroKeyboard";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_BLOCK_FRAMES:
-         return "Block Frames";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_LABEL_SHOW:
-         return "Display Input Descriptor Labels";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_HIDE_UNBOUND:
-         return "Hide Unbound Core Input Descriptors";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_ENABLE:
-         return "Display OSD Message";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_PATH:
-         return "OSD Message Font";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_SIZE:
-         return "OSD Message Size";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_X:
-         return "OSD Message X Position";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_Y:
-         return "OSD Message Y Position";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SOFT_FILTER:
-         return "Soft Filter Enable";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_FLICKER:
-         return "Flicker filter";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_CONTENT:
-         return "<Content dir>";
-      case MENU_ENUM_LABEL_VALUE_UNKNOWN:
-         return "Unknown";
-      case MENU_ENUM_LABEL_VALUE_DONT_CARE:
-         return "Don't care";
-      case MENU_ENUM_LABEL_VALUE_LINEAR:
-         return "Linear";
-      case MENU_ENUM_LABEL_VALUE_NEAREST:
-         return "Nearest";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_DEFAULT:
-         return "<Default>";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NONE:
-         return "<None>";
-      case MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE:
-         return "N/A";
-      case MENU_ENUM_LABEL_VALUE_DATABASE_SELECTION:
-         return "Database Selection";
-      case MENU_ENUM_LABEL_VALUE_CORE_ASSETS_DIR:
-         return "Core Assets Dir";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_DIR:
-         return "Content Dir";
-      case MENU_ENUM_LABEL_VALUE_INPUT_REMAPPING_DIRECTORY:
-         return "Input Remapping Dir";
-      case MENU_ENUM_LABEL_VALUE_JOYPAD_AUTOCONFIG_DIR:
-         return "Input Device Autoconfig Dir";
-      case MENU_ENUM_LABEL_VALUE_RECORDING_CONFIG_DIRECTORY:
-         return "Recording Config Dir";
-      case MENU_ENUM_LABEL_VALUE_RECORDING_OUTPUT_DIRECTORY:
-         return "Recording Output Dir";
-      case MENU_ENUM_LABEL_VALUE_SCREENSHOT_DIRECTORY:
-         return "Screenshot Dir";
-      case MENU_ENUM_LABEL_VALUE_PLAYLIST_DIRECTORY:
-         return "Playlist Dir";
-      case MENU_ENUM_LABEL_VALUE_SAVEFILE_DIRECTORY:
-         return "Savefile Dir";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_DIRECTORY:
-         return "Savestate Dir";
-      case MENU_ENUM_LABEL_VALUE_STDIN_CMD_ENABLE:
-         return "stdin Commands";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_REMOTE_ENABLE:
-         return "Network Gamepad";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_DRIVER:
-         return "Video Driver";
-      case MENU_ENUM_LABEL_VALUE_RECORD_ENABLE:
-         return "Record Enable";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_RECORD:
-         return "GPU Record Enable";
-      case MENU_ENUM_LABEL_VALUE_RECORD_PATH:
-         return "Output File";
-      case MENU_ENUM_LABEL_VALUE_RECORD_USE_OUTPUT_DIRECTORY:
-         return "Use Output Dir";
-      case MENU_ENUM_LABEL_VALUE_RECORD_CONFIG:
-         return "Record Config";
-      case MENU_ENUM_LABEL_VALUE_CONFIG:
-         return "Config";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_POST_FILTER_RECORD:
-         return "Post filter record Enable";
-      case MENU_ENUM_LABEL_VALUE_CORE_ASSETS_DIRECTORY:
-         return "Downloads Dir";
-      case MENU_ENUM_LABEL_VALUE_ASSETS_DIRECTORY:
-         return "Assets Dir";
-      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPERS_DIRECTORY:
-         return "Dynamic Wallpapers Dir";
-      case MENU_ENUM_LABEL_VALUE_THUMBNAILS_DIRECTORY:
-         return "Thumbnails Dir";
-      case MENU_ENUM_LABEL_VALUE_RGUI_BROWSER_DIRECTORY:
-         return "File Browser Dir";
-      case MENU_ENUM_LABEL_VALUE_RGUI_CONFIG_DIRECTORY:
-         return "Config Dir";
-      case MENU_ENUM_LABEL_VALUE_LIBRETRO_INFO_PATH:
-         return "Core Info Dir";
-      case MENU_ENUM_LABEL_VALUE_LIBRETRO_DIR_PATH:
-         return "Core Dir";
-      case MENU_ENUM_LABEL_VALUE_CURSOR_DIRECTORY:
-         return "Cursor Dir";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_DATABASE_DIRECTORY:
-         return "Content Database Dir";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_DIRECTORY:
-         return "System/BIOS Dir";
-      case MENU_ENUM_LABEL_VALUE_CHEAT_DATABASE_PATH:
-         return "Cheat File Dir";
-      case MENU_ENUM_LABEL_VALUE_CACHE_DIRECTORY:
-         return "Cache Dir";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_FILTER_DIR:
-         return "Audio Filter Dir";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_DIR:
-         return "Video Shader Dir";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_DIR:
-         return "Video Filter Dir";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_DIRECTORY:
-         return "Overlay Dir";
-      case MENU_ENUM_LABEL_VALUE_OSK_OVERLAY_DIRECTORY:
-         return "OSK Overlay Dir";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT:
-         return "Netplay P2 Uses C1";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE:
-         return "Netplay Spectator Enable";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS:
-         return "Server Address";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT:
-         return "Netplay TCP/UDP Port";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE:
-         return "Netplay Enable";
-      case MENU_ENUM_LABEL_VALUE_SSH_ENABLE:
-         return "SSH Enable";
-      case MENU_ENUM_LABEL_VALUE_SAMBA_ENABLE:
-         return "SAMBA Enable";
-      case MENU_ENUM_LABEL_VALUE_BLUETOOTH_ENABLE:
-         return "Bluetooth Enable";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_DELAY_FRAMES:
-         return "Netplay Delay Frames";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_CHECK_FRAMES:
-         return "Netplay Check Frames";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_MODE:
-         return "Netplay Client Enable";
-      case MENU_ENUM_LABEL_VALUE_RGUI_SHOW_START_SCREEN:
-         return "Show Start Screen";
-      case MENU_ENUM_LABEL_VALUE_TITLE_COLOR:
-         return "Menu title color";
-      case MENU_ENUM_LABEL_VALUE_ENTRY_HOVER_COLOR:
-         return "Menu entry hover color";
-      case MENU_ENUM_LABEL_VALUE_TIMEDATE_ENABLE:
-         return "Display time / date";
-      case MENU_ENUM_LABEL_VALUE_THREADED_DATA_RUNLOOP_ENABLE:
-         return "Threaded data runloop";
-      case MENU_ENUM_LABEL_VALUE_ENTRY_NORMAL_COLOR:
-         return "Menu entry normal color";
-      case MENU_ENUM_LABEL_VALUE_SHOW_ADVANCED_SETTINGS:
-         return "Show Advanced thiết lập";
-      case MENU_ENUM_LABEL_VALUE_MOUSE_ENABLE:
-         return "Mouse Support";
-      case MENU_ENUM_LABEL_VALUE_POINTER_ENABLE:
-         return "Touch Support";
-      case MENU_ENUM_LABEL_VALUE_CORE_ENABLE:
-         return "Display core name";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE_HOST:
-         return "Start hosting";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE_CLIENT:
-         return "Connect to Netplay host";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_DISCONNECT:
-         return "Disconnect";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_SETTINGS:
-         return "Netplay thiết lập";
-      case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_ENABLE:
-         return "DPI Override Enable";
-      case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_VALUE:
-         return "DPI Override";
-      case MENU_ENUM_LABEL_VALUE_XMB_SCALE_FACTOR:
-         return "Menu Scale Factor";
-      case MENU_ENUM_LABEL_VALUE_XMB_ALPHA_FACTOR:
-         return "Menu Alpha Factor";
-      case MENU_ENUM_LABEL_VALUE_XMB_FONT:
-         return "Menu Font";
-      case MENU_ENUM_LABEL_VALUE_XMB_THEME:
-         return "Menu Icon Theme";
-      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME:
-         return "Menu Color Theme";
-      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME:
-         return "Menu Color Theme";
-      case MENU_ENUM_LABEL_VALUE_XMB_SHADOWS_ENABLE:
-         return "Icon Shadows Enable";
-      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_SETTINGS:
-         return "Show thiết lập Tab";
-      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_IMAGES:
-         return "Show Images Tab";
-      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_MUSIC:
-         return "Show Music Tab";
-      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_VIDEO:
-         return "Show Video Tab";
-      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_HISTORY:
-         return "Show History Tab";
-      case MENU_ENUM_LABEL_VALUE_XMB_RIBBON_ENABLE:
-         return "Menu Shader Pipeline";
-      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_MONOCHROME:
-         return "Monochrome";
-      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_MONOCHROME_JAGGED:
-         return "Monochrome Jagged";
-      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_FLATUI:
-         return "FlatUI";
-      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_RETROACTIVE:
-         return "RetroActive";
-      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_PIXEL:
-         return "Pixel";
-      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_CUSTOM:
-         return "Custom";
-      case MENU_ENUM_LABEL_VALUE_SUSPEND_SCREENSAVER_ENABLE:
-         return "Suspend Screensaver";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_DISABLE_COMPOSITION:
-         return "Disable Desktop Composition";
-      case MENU_ENUM_LABEL_VALUE_PAUSE_NONACTIVE:
-         return "Don't run in background";
-      case MENU_ENUM_LABEL_VALUE_UI_COMPANION_START_ON_BOOT:
-         return "UI Companion Start On Boot";
-      case MENU_ENUM_LABEL_VALUE_UI_COMPANION_ENABLE:
-         return "UI Companion Enable";
-      case MENU_ENUM_LABEL_VALUE_UI_MENUBAR_ENABLE:
-         return "Menubar";
       case MENU_ENUM_LABEL_VALUE_ARCHIVE_MODE:
          return "Archive File Association Action";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_ENABLE:
-         return "Network Commands";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_PORT:
-         return "Network Command Port";
-      case MENU_ENUM_LABEL_VALUE_HISTORY_LIST_ENABLE:
-         return "History List Enable";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_HISTORY_SIZE:
-         return "History List Size";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE_AUTO:
-         return "Estimated Monitor Framerate";
-      case MENU_ENUM_LABEL_VALUE_DUMMY_ON_CORE_SHUTDOWN:
-         return "Dummy On Core Shutdown";
-      case MENU_ENUM_LABEL_VALUE_CORE_SET_SUPPORTS_NO_CONTENT_ENABLE:
-         return "Automatically start a core";
-      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_ENABLE:
-         return "Limit Maximum Run Speed";
-      case MENU_ENUM_LABEL_VALUE_FASTFORWARD_RATIO:
-         return "Maximum Run Speed";
+      case MENU_ENUM_LABEL_VALUE_ASK_ARCHIVE:
+         return "Ask";
+      case MENU_ENUM_LABEL_VALUE_ASSETS_DIRECTORY:
+         return "Assets Dir";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_BLOCK_FRAMES:
+         return "Block Frames";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_DEVICE:
+         return "Audio Device";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_DRIVER:
+         return "Audio Driver";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_DSP_PLUGIN:
+         return "Audio DSP Plugin";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_ENABLE:
+         return "Audio Enable";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_FILTER_DIR:
+         return "Audio Filter Dir";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_LATENCY:
+         return "Audio Latency (ms)";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_MAX_TIMING_SKEW:
+         return "Audio Maximum Timing Skew";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_MUTE:
+         return "Audio Mute";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_OUTPUT_RATE:
+         return "Audio Output Rate (KHz)";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_RATE_CONTROL_DELTA:
+         return "Audio Rate Control Delta";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_RESAMPLER_DRIVER:
+         return "Audio Resampler Driver";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_SETTINGS:
+         return "Audio";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_SYNC:
+         return "Audio Sync Enable";
+      case MENU_ENUM_LABEL_VALUE_AUDIO_VOLUME:
+         return "Audio Volume Level (dB)";
+      case MENU_ENUM_LABEL_VALUE_AUTOSAVE_INTERVAL:
+         return "SaveRAM Autosave Interval";
+      case MENU_ENUM_LABEL_VALUE_AUTO_OVERRIDES_ENABLE:
+         return "Tải Override Files Automatically";
       case MENU_ENUM_LABEL_VALUE_AUTO_REMAPS_ENABLE:
          return "Tải Remap Files Automatically";
       case MENU_ENUM_LABEL_VALUE_AUTO_SHADERS_ENABLE:
          return "Tải Shader Presets Automatically";
-      case MENU_ENUM_LABEL_VALUE_SLOWMOTION_RATIO:
-         return "Slow-Motion Ratio";
-      case MENU_ENUM_LABEL_VALUE_CORE_SPECIFIC_CONFIG:
-         return "Configuration Per-Core";
-      case MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS:
-         return "Tải Content-specific core options automatically";
-      case MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS_CREATE:
-         return "Create game-options file";
-      case MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS_IN_USE:
-         return "Game-options file";
-      case MENU_ENUM_LABEL_VALUE_AUTO_OVERRIDES_ENABLE:
-         return "Tải Override Files Automatically";
-      case MENU_ENUM_LABEL_VALUE_CONFIG_SAVE_ON_EXIT:
-         return "Save Configuration On Exit";
-      case MENU_ENUM_LABEL_VALUE_CONFIRM_ON_EXIT:
-         return "Ask For Confirmation On Exit";
-      case MENU_ENUM_LABEL_VALUE_SHOW_HIDDEN_FILES:
-         return "Show Hidden Files and Folders";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SMOOTH:
-         return "HW Bilinear Filtering";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_GAMMA:
-         return "Video Gamma";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ALLOW_ROTATE:
-         return "Allow rotation";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC:
-         return "Hard GPU Sync";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SWAP_INTERVAL:
-         return "VSync Swap Interval";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VSYNC:
-         return "VSync";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_THREADED:
-         return "Threaded Video";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ROTATION:
-         return "Rotation";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_SCREENSHOT:
-         return "GPU Screenshot Enable";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_CROP_OVERSCAN:
-         return "Crop Overscan (Reload)";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_INDEX:
-         return "Aspect Ratio Index";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_AUTO:
-         return "Auto Aspect Ratio";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_ASPECT:
-         return "Force aspect ratio";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE:
-         return "Refresh Rate";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_SRGB_DISABLE:
-         return "Force-disable sRGB FBO";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_WINDOWED_FULLSCREEN:
-         return "Chế độ toàn màn hình trong khung";
-      case MENU_ENUM_LABEL_VALUE_PAL60_ENABLE:
-         return "Use PAL60 Mode";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VFILTER:
-         return "Deflicker";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_VI_WIDTH:
-         return "Set VI Screen Width";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_BLACK_FRAME_INSERTION:
-         return "Black Frame Insertion";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC_FRAMES:
-         return "Hard GPU Sync Frames";
-      case MENU_ENUM_LABEL_VALUE_SORT_SAVEFILES_ENABLE:
-         return "Sort Saves In Folders";
-      case MENU_ENUM_LABEL_VALUE_SORT_SAVESTATES_ENABLE:
-         return "Sort Savestates In Folders";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FULLSCREEN:
-         return "Sử dụng chế độ toàn màn hình";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE:
-         return "Windowed Scale";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE_INTEGER:
-         return "Integer Scale";
-      case MENU_ENUM_LABEL_VALUE_PERFCNT_ENABLE:
-         return "Performance Counters";
-      case MENU_ENUM_LABEL_VALUE_LIBRETRO_LOG_LEVEL:
-         return "Core Logging Level";
-      case MENU_ENUM_LABEL_VALUE_LOG_VERBOSITY:
-         return "Logging Verbosity";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_LOAD:
-         return "Tự động tải State";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_INDEX:
-         return "Save State Auto Index";
-      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_SAVE:
-         return "Auto Save State";
-      case MENU_ENUM_LABEL_VALUE_AUTOSAVE_INTERVAL:
-         return "SaveRAM Autosave Interval";
+      case MENU_ENUM_LABEL_VALUE_BACK:
+         return "BACK";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_BACK:
+         return "Back";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_CONFIRM:
+         return "Confirm";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_INFO:
+         return "Info";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_QUIT:
+         return "Quit";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_SCROLL_DOWN:
+         return "Scroll Down";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_SCROLL_UP:
+         return "Scroll Up";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_START:
+         return "Start";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_TOGGLE_KEYBOARD:
+         return "Toggle Keyboard";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_TOGGLE_MENU:
+         return "Toggle Menu";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS:
+         return "Basic menu controls";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_BACK:
+         return "Back";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_CONFIRM:
+         return "Confirm/OK";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_INFO:
+         return "Info";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_QUIT:
+         return "Quit";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_SCROLL_UP:
+         return "Scroll Up";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_START:
+         return "Defaults";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_TOGGLE_KEYBOARD:
+         return "Toggle Keyboard";
+      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_TOGGLE_MENU:
+         return "Toggle Menu";
       case MENU_ENUM_LABEL_VALUE_BLOCK_SRAM_OVERWRITE:
          return "Don't overwrite SaveRAM on loading savestate";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHARED_CONTEXT:
-         return "HW Shared Context Enable";
-      case MENU_ENUM_LABEL_VALUE_RESTART_RETROARCH:
-         return "Restart RetroArch";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY_NICKNAME:
-         return "Username";
-      case MENU_ENUM_LABEL_VALUE_USER_LANGUAGE:
-         return "Language";
+      case MENU_ENUM_LABEL_VALUE_BLUETOOTH_ENABLE:
+         return "Bluetooth Enable";
+      case MENU_ENUM_LABEL_VALUE_BUILDBOT_ASSETS_URL:
+         return "Buildbot Assets URL";
+      case MENU_ENUM_LABEL_VALUE_CACHE_DIRECTORY:
+         return "Cache Dir";
       case MENU_ENUM_LABEL_VALUE_CAMERA_ALLOW:
          return "Allow Camera";
-      case MENU_ENUM_LABEL_VALUE_LOCATION_ALLOW:
-         return "Allow Location";
-      case MENU_ENUM_LABEL_VALUE_PAUSE_LIBRETRO:
-         return "Pause when menu activated";
-      case MENU_ENUM_LABEL_VALUE_INPUT_OSK_OVERLAY_ENABLE:
-         return "Display Keyboard Overlay";
-      case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_ENABLE:
-         return "Display Overlay";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_MONITOR_INDEX:
-         return "Monitor Index";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FRAME_DELAY:
-         return "Frame Delay";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DUTY_CYCLE:
-         return "Duty Cycle";
-      case MENU_ENUM_LABEL_VALUE_INPUT_TURBO_PERIOD:
-         return "Turbo Period";
-      case MENU_ENUM_LABEL_VALUE_INPUT_BIND_TIMEOUT:
-         return "Bind Timeout";
-      case MENU_ENUM_LABEL_VALUE_INPUT_AXIS_THRESHOLD:
-         return "Input Axis Threshold";
-      case MENU_ENUM_LABEL_VALUE_INPUT_REMAP_BINDS_ENABLE:
-         return "Remap Binds Enable";
-      case MENU_ENUM_LABEL_VALUE_INPUT_MAX_USERS:
-         return "Max Users";
-      case MENU_ENUM_LABEL_VALUE_INPUT_AUTODETECT_ENABLE:
-         return "Autoconfig Enable";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_OUTPUT_RATE:
-         return "Audio Output Rate (KHz)";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_MAX_TIMING_SKEW:
-         return "Audio Maximum Timing Skew";
-      case MENU_ENUM_LABEL_VALUE_CHEAT_NUM_PASSES:
-         return "Cheat Passes";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_CORE:
-         return "Save Core Remap File";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_GAME:
-         return "Save Game Remap File";
+      case MENU_ENUM_LABEL_VALUE_CAMERA_DRIVER:
+         return "Camera Driver";
+      case MENU_ENUM_LABEL_VALUE_CHEAT:
+         return "Cheat";
       case MENU_ENUM_LABEL_VALUE_CHEAT_APPLY_CHANGES:
          return "Apply Cheat Changes";
-      case MENU_ENUM_LABEL_VALUE_SHADER_APPLY_CHANGES:
-         return "Apply Shader Changes";
-      case MENU_ENUM_LABEL_VALUE_REWIND_ENABLE:
-         return "Rewind Enable";
-      case MENU_ENUM_LABEL_VALUE_CONTENT_COLLECTION_LIST:
-         return "Collections";
-      case MENU_ENUM_LABEL_VALUE_DETECT_CORE_LIST:
-         return "Select File And Detect Core";
-      case MENU_ENUM_LABEL_VALUE_DOWNLOADED_FILE_DETECT_CORE_LIST:
-         return "Downloads Dir";
-      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_HISTORY:
-         return "Tải Recent";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_ENABLE:
-         return "Audio Enable";
-      case MENU_ENUM_LABEL_VALUE_FPS_SHOW:
-         return "Display Framerate";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_MUTE:
-         return "Audio Mute";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_VOLUME:
-         return "Audio Volume Level (dB)";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_SYNC:
-         return "Audio Sync Enable";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_RATE_CONTROL_DELTA:
-         return "Audio Rate Control Delta";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_NUM_PASSES:
-         return "Shader Passes";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_SHA1:
-         return "SHA1";
-      case MENU_ENUM_LABEL_VALUE_CONFIGURATIONS:
-         return "Tải Configuration";
-      case MENU_ENUM_LABEL_VALUE_REWIND_GRANULARITY:
-         return "Rewind Granularity";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_LOAD:
-         return "Tải Remap File";
-      case MENU_ENUM_LABEL_VALUE_CUSTOM_RATIO:
-         return "Custom Ratio";
-      case MENU_ENUM_LABEL_VALUE_USE_THIS_DIRECTORY:
-         return "<Use this directory>";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_START_CONTENT:
-         return "Start Content";
-      case MENU_ENUM_LABEL_VALUE_DISK_OPTIONS:
-         return "Disk Control";
-      case MENU_ENUM_LABEL_VALUE_CORE_OPTIONS:
-         return "Options";
-      case MENU_ENUM_LABEL_VALUE_CORE_CHEAT_OPTIONS:
-         return "Cheats";
-      case MENU_ENUM_LABEL_VALUE_REMAP_FILE:
-         return "Remap File";
+      case MENU_ENUM_LABEL_VALUE_CHEAT_DATABASE_PATH:
+         return "Cheat File Dir";
       case MENU_ENUM_LABEL_VALUE_CHEAT_FILE:
          return "Cheat File";
       case MENU_ENUM_LABEL_VALUE_CHEAT_FILE_LOAD:
          return "Cheat File Load";
       case MENU_ENUM_LABEL_VALUE_CHEAT_FILE_SAVE_AS:
          return "Cheat File Save As";
-      case MENU_ENUM_LABEL_VALUE_CORE_COUNTERS:
-         return "Core Counters";
-      case MENU_ENUM_LABEL_VALUE_TAKE_SCREENSHOT:
-         return "Chụp ảnh màn hình";
-      case MENU_ENUM_LABEL_VALUE_DELETE_ENTRY:
-         return "Remove";
-      case MENU_ENUM_LABEL_VALUE_RESUME:
-         return "Resume";
-      case MENU_ENUM_LABEL_VALUE_DISK_INDEX:
-         return "Disk Index";
-      case MENU_ENUM_LABEL_VALUE_FRONTEND_COUNTERS:
-         return "Frontend Counters";
-      case MENU_ENUM_LABEL_VALUE_DISK_IMAGE_APPEND:
-         return "Disk Image Append";
-      case MENU_ENUM_LABEL_VALUE_DISK_CYCLE_TRAY_STATUS:
-         return "Disk Cycle Tray Status";
-      case MENU_ENUM_LABEL_VALUE_NO_PLAYLIST_ENTRIES_AVAILABLE:
-         return "No playlist entries available.";
-      case MENU_ENUM_LABEL_VALUE_NO_HISTORY_AVAILABLE:
-         return "No history available.";
-      case MENU_ENUM_LABEL_VALUE_NO_CORE_INFORMATION_AVAILABLE:
-         return "No core information available.";
-      case MENU_ENUM_LABEL_VALUE_NO_CORE_OPTIONS_AVAILABLE:
-         return "No core options available.";
-      case MENU_ENUM_LABEL_VALUE_NO_CORES_AVAILABLE:
-         return "No cores available.";
-      case MENU_ENUM_LABEL_VALUE_NO_CORE:
-         return "No Core";
-      case MENU_ENUM_LABEL_VALUE_DATABASE_MANAGER:
-         return "Database Manager";
-      case MENU_ENUM_LABEL_VALUE_CURSOR_MANAGER:
-         return "Cursor Manager";
-      case MENU_ENUM_LABEL_VALUE_MAIN_MENU:
-         return "Main Menu";
-      case MENU_ENUM_LABEL_VALUE_SETTINGS:
-         return "Thiết lập";
-      case MENU_ENUM_LABEL_VALUE_QUIT_RETROARCH:
-         return "Thoát RetroArch";
-      case MENU_ENUM_LABEL_VALUE_SHUTDOWN:
-         return "Tắt Máy";
-      case MENU_ENUM_LABEL_VALUE_REBOOT:
-         return "Khởi động lại";
-      case MENU_ENUM_LABEL_VALUE_HELP:
-         return "help";
-      case MENU_ENUM_LABEL_VALUE_SAVE_NEW_CONFIG:
-         return "Save New Config";
-      case MENU_ENUM_LABEL_VALUE_RESTART_CONTENT:
-         return "Khởi động lại";
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_LIST:
-         return "Core Updater";
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_BUILDBOT_URL:
-         return "Buildbot Cores URL";
-      case MENU_ENUM_LABEL_VALUE_BUILDBOT_ASSETS_URL:
-         return "Buildbot Assets URL";
-      case MENU_ENUM_LABEL_VALUE_NAVIGATION_WRAPAROUND:
-         return "Navigation Wrap-Around";
-      case MENU_ENUM_LABEL_VALUE_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
-         return "Filter unknown extensions";
-      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
-         return "Automatically extract downloaded archive";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFORMATION:
-         return "System Information";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_INFORMATION:
-         return "Network Information";
-      case MENU_ENUM_LABEL_VALUE_ACHIEVEMENT_LIST:
-         return "Achievement List";
-      case MENU_ENUM_LABEL_VALUE_ONLINE_UPDATER:
-         return "Online Updater";
-      case MENU_ENUM_LABEL_VALUE_NETPLAY:
-         return "Netplay";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFORMATION:
-         return "Core Information";
-      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NOT_FOUND:
-         return "Directory not found.";
-      case MENU_ENUM_LABEL_VALUE_NO_ITEMS:
-         return "No items.";
-      case MENU_ENUM_LABEL_VALUE_NO_PLAYLISTS:
-         return "No playlists.";
-      case MENU_ENUM_LABEL_VALUE_CORE_LIST:
-         return "Tải Core";
-      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT:
-         return "Select File";
+      case MENU_ENUM_LABEL_VALUE_CHEAT_NUM_PASSES:
+         return "Cheat Passes";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_DESCRIPTION:
+         return "Description";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_HARDCORE_MODE_ENABLE:
+         return "Hardcore Mode";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_LOCKED_ACHIEVEMENTS:
+         return "Locked Achievements:";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_LOCKED_ENTRY:
+         return "Locked";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_SETTINGS:
+         return "Retro Achievements";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_TEST_UNOFFICIAL:
+         return "Test unofficial";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_UNLOCKED_ACHIEVEMENTS:
+         return "Unlocked Achievements:";
+      case MENU_ENUM_LABEL_VALUE_CHEEVOS_UNLOCKED_ENTRY:
+         return "Unlocked";
       case MENU_ENUM_LABEL_VALUE_CLOSE_CONTENT:
          return "Close";
-      case MENU_ENUM_LABEL_VALUE_MANAGEMENT:
-         return "Database thiết lập";
-      case MENU_ENUM_LABEL_VALUE_SAVE_STATE:
-         return "Save State";
-      case MENU_ENUM_LABEL_VALUE_LOAD_STATE:
-         return "Tải State";
-      case MENU_ENUM_LABEL_VALUE_UNDO_LOAD_STATE:
-         return "Undo Tải State";
-      case MENU_ENUM_LABEL_VALUE_UNDO_SAVE_STATE:
-         return "Undo Save State";
-      case MSG_UNDID_LOAD_STATE:
-         return "Undid Tải state.";
-      case MENU_ENUM_LABEL_VALUE_RESUME_CONTENT:
-         return "Resume";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DRIVER:
-         return "Input Driver";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_DRIVER:
-         return "Audio Driver";
-      case MENU_ENUM_LABEL_VALUE_JOYPAD_DRIVER:
-         return "Joypad Driver";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_RESAMPLER_DRIVER:
-         return "Audio Resampler Driver";
-      case MENU_ENUM_LABEL_VALUE_RECORD_DRIVER:
-         return "Record Driver";
-      case MENU_ENUM_LABEL_VALUE_MENU_DRIVER:
-         return "Menu Driver";
-      case MENU_ENUM_LABEL_VALUE_CAMERA_DRIVER:
-         return "Camera Driver";
-      case MENU_ENUM_LABEL_VALUE_WIFI_DRIVER:
-         return "Wi-Fi Driver";
-      case MENU_ENUM_LABEL_VALUE_LOCATION_DRIVER:
-         return "Location Driver";
-      case MENU_ENUM_LABEL_VALUE_UNABLE_TO_READ_COMPRESSED_FILE:
-         return "Unable to read compressed file.";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_SCALE:
-         return "Overlay Scale";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_PRESET:
-         return "Overlay Preset";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_LATENCY:
-         return "Audio Latency (ms)";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_DEVICE:
-         return "Audio Device";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY:
-         return "Overlay";
-      case MENU_ENUM_LABEL_VALUE_KEYBOARD_OVERLAY_PRESET:
-         return "Keyboard Overlay Preset";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_OPACITY:
-         return "Overlay Opacity";
-      case MENU_ENUM_LABEL_VALUE_MENU_WALLPAPER:
-         return "Menu Wallpaper";
-      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPER:
-         return "Dynamic Wallpaper";
-      case MENU_ENUM_LABEL_VALUE_THUMBNAILS:
-         return "Thumbnails";
-      case MENU_ENUM_LABEL_VALUE_CORE_INPUT_REMAPPING_OPTIONS:
-         return "Controls";
-      case MENU_ENUM_LABEL_VALUE_SHADER_OPTIONS:
-         return "Shaders";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PARAMETERS:
-         return "Preview Shader Parameters";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_PARAMETERS:
-         return "Menu Shader Parameters";
-      case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_TWO:
-         return "Shader Preset";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_AS:
-         return "Save Shader Preset As";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_CORE:
-         return "Save Core Preset";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_GAME:
-         return "Save Game Preset";
-      case MENU_ENUM_LABEL_VALUE_NO_SHADER_PARAMETERS:
-         return "No shader parameters.";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET:
-         return "Tải Shader Preset";
-      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER:
-         return "Video Filter";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_DSP_PLUGIN:
-         return "Audio DSP Plugin";
-      case MENU_ENUM_LABEL_VALUE_SECONDS:
-         return "seconds";
-      case MENU_ENUM_LABEL_VALUE_OFF:
-         return "OFF";
-      case MENU_ENUM_LABEL_VALUE_ON:
-         return "ON";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_ASSETS:
-         return "Cập nhật Assets";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_LAKKA:
-         return "Cập nhật Lakka";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_CHEATS:
-         return "Cập nhật Cheats";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_AUTOCONFIG_PROFILES:
-         return "Cập nhật Autoconfig Profiles";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_DATABASES:
-         return "Cập nhật Databases";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_OVERLAYS:
-         return "Cập nhật Overlays";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_CG_SHADERS:
-         return "Cập nhật Cg Shaders";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_GLSL_SHADERS:
-         return "Cập nhật GLSL Shaders";
-      case MENU_ENUM_LABEL_VALUE_UPDATE_SLANG_SHADERS:
-         return "Cập nhật Slang Shaders";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NAME:
-         return "Core name";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_LABEL:
-         return "Core label";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_NAME:
-         return "System name";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_MANUFACTURER:
-         return "System manufacturer";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CATEGORIES:
-         return "Categories";
+      case MENU_ENUM_LABEL_VALUE_CONFIG:
+         return "Config";
+      case MENU_ENUM_LABEL_VALUE_CONFIGURATIONS:
+         return "Tải Configuration";
+      case MENU_ENUM_LABEL_VALUE_CONFIGURATION_SETTINGS:
+         return "Configuration";
+      case MENU_ENUM_LABEL_VALUE_CONFIG_SAVE_ON_EXIT:
+         return "Save Configuration On Exit";
+      case MENU_ENUM_LABEL_VALUE_CONFIRM_ON_EXIT:
+         return "Ask For Confirmation On Exit";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_COLLECTION_LIST:
+         return "Collections";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_DATABASE_DIRECTORY:
+         return "Content Database Dir";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_DIR:
+         return "Content Dir";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_HISTORY_SIZE:
+         return "History List Size";
+      case MENU_ENUM_LABEL_VALUE_CONTENT_SETTINGS:
+         return "Quick Menu";
+      case MENU_ENUM_LABEL_VALUE_CORE_ASSETS_DIR:
+         return "Core Assets Dir";
+      case MENU_ENUM_LABEL_VALUE_CORE_ASSETS_DIRECTORY:
+         return "Downloads Dir";
+      case MENU_ENUM_LABEL_VALUE_CORE_CHEAT_OPTIONS:
+         return "Cheats";
+      case MENU_ENUM_LABEL_VALUE_CORE_COUNTERS:
+         return "Core Counters";
+      case MENU_ENUM_LABEL_VALUE_CORE_ENABLE:
+         return "Display core name";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFORMATION:
+         return "Core Information";
       case MENU_ENUM_LABEL_VALUE_CORE_INFO_AUTHORS:
          return "Authors";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_PERMISSIONS:
-         return "Permissions";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_LICENSES:
-         return "License(s)";
-      case MENU_ENUM_LABEL_VALUE_SUPPORTED_CORES:
-         return "Supported cores";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SUPPORTED_EXTENSIONS:
-         return "Supported extensions";
-      case MENU_ENUM_LABEL_VALUE_CORE_INFO_FIRMWARE:
-         return "Firmware";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CATEGORIES:
+         return "Categories";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_LABEL:
+         return "Core label";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NAME:
+         return "Core name";
       case MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NOTES:
          return "Core notes";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_BUILD_DATE:
-         return "Build date";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GIT_VERSION:
-         return "Git version";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CPU_FEATURES:
-         return "CPU Features";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_IDENTIFIER:
-         return "Frontend identifier";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_NAME:
-         return "Frontend name";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_OS:
-         return "Frontend OS";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RETRORATING_LEVEL:
-         return "RetroRating level";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE:
-         return "Power source";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_NO_SOURCE:
-         return "No source";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGING:
-         return "Charging";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGED:
-         return "Charged";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_DISCHARGING:
-         return "Discharging";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VIDEO_CONTEXT_DRIVER:
-         return "Video context driver";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_WIDTH:
-         return "Display metric width (mm)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_HEIGHT:
-         return "Display metric height (mm)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_DPI:
-         return "Display metric DPI";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBRETRODB_SUPPORT:
-         return "LibretroDB support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OVERLAY_SUPPORT:
-         return "Overlay support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COMMAND_IFACE_SUPPORT:
-         return "Command interface support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETWORK_REMOTE_SUPPORT:
-         return "Network Gamepad support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETWORK_COMMAND_IFACE_SUPPORT:
-         return "Network Command interface support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COCOA_SUPPORT:
-         return "Cocoa support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RPNG_SUPPORT:
-         return "PNG support (RPNG)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RJPEG_SUPPORT:
-         return "JPEG support (RJPEG)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RBMP_SUPPORT:
-         return "BMP support (RBMP)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RTGA_SUPPORT:
-         return "TGA support (RTGA)";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_SUPPORT:
-         return "SDL1.2 support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL2_SUPPORT:
-         return "SDL2 support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VULKAN_SUPPORT:
-         return "Vulkan support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGL_SUPPORT:
-         return "OpenGL support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGLES_SUPPORT:
-         return "OpenGL ES support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_THREADING_SUPPORT:
-         return "Threading support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_KMS_SUPPORT:
-         return "KMS/EGL support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_UDEV_SUPPORT:
-         return "Udev support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENVG_SUPPORT:
-         return "OpenVG support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_EGL_SUPPORT:
-         return "EGL support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_X11_SUPPORT:
-         return "X11 support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_WAYLAND_SUPPORT:
-         return "Wayland support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XVIDEO_SUPPORT:
-         return "XVideo support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ALSA_SUPPORT:
-         return "ALSA support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OSS_SUPPORT:
-         return "OSS support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENAL_SUPPORT:
-         return "OpenAL support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENSL_SUPPORT:
-         return "OpenSL support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RSOUND_SUPPORT:
-         return "RSound support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ROARAUDIO_SUPPORT:
-         return "RoarAudio support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_JACK_SUPPORT:
-         return "JACK support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PULSEAUDIO_SUPPORT:
-         return "PulseAudio support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DSOUND_SUPPORT:
-         return "DirectSound support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XAUDIO2_SUPPORT:
-         return "XAudio2 support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ZLIB_SUPPORT:
-         return "Zlib support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_7ZIP_SUPPORT:
-         return "7zip support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DYLIB_SUPPORT:
-         return "Dynamic library support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CG_SUPPORT:
-         return "Cg support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GLSL_SUPPORT:
-         return "GLSL support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SLANG_SUPPORT:
-         return "Slang support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_HLSL_SUPPORT:
-         return "HLSL support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBXML2_SUPPORT:
-         return "libxml2 XML parsing support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_IMAGE_SUPPORT:
-         return "SDL image support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FBO_SUPPORT:
-         return "OpenGL/Direct3D render-to-texture (multi-pass shaders) support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DYNAMIC_SUPPORT:
-         return "Dynamic run-time loading of libretro library";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FFMPEG_SUPPORT:
-         return "FFmpeg support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CORETEXT_SUPPORT:
-         return "CoreText support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FREETYPE_SUPPORT:
-         return "FreeType support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETPLAY_SUPPORT:
-         return "Netplay (peer-to-peer) support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PYTHON_SUPPORT:
-         return "Python (script support in shaders) support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_V4L2_SUPPORT:
-         return "Video4Linux2 support";
-      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBUSB_SUPPORT:
-         return "Libusb support";
-      case MENU_ENUM_LABEL_VALUE_YES:
-         return "Yes";
-      case MENU_ENUM_LABEL_VALUE_NO:
-         return "No";
-      case MENU_ENUM_LABEL_VALUE_BACK:
-         return "BACK";
-      case MSG_FAILED_TO_BIND_SOCKET:
-         return "Failed to bind socket.";
-      case MENU_ENUM_LABEL_VALUE_SCREEN_RESOLUTION:
-         return "Screen Resolution";
-      case MENU_ENUM_LABEL_VALUE_DISABLED:
-         return "Disabled";
-      case MENU_ENUM_LABEL_VALUE_PORT:
-         return "Port";
-      case MENU_ENUM_LABEL_VALUE_NONE:
-         return "None";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DEVELOPER:
-         return "Developer";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_PUBLISHER:
-         return "Publisher";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DESCRIPTION:
-         return "Description";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_GENRE:
-         return "Genre";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_NAME:
-         return "Name";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ORIGIN:
-         return "Origin";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_FRANCHISE:
-         return "Franchise";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_MONTH:
-         return "Releasedate Month";
-      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_YEAR:
-         return "Releasedate Year";
-      case MENU_ENUM_LABEL_VALUE_TRUE:
-         return "True";
-      case MENU_ENUM_LABEL_VALUE_FALSE:
-         return "False";
-      case MENU_ENUM_LABEL_VALUE_MISSING:
-         return "Missing";
-      case MENU_ENUM_LABEL_VALUE_PRESENT:
-         return "Present";
-      case MENU_ENUM_LABEL_VALUE_OPTIONAL:
-         return "Optional";
-      case MENU_ENUM_LABEL_VALUE_REQUIRED:
-         return "Required";
-      case MENU_ENUM_LABEL_VALUE_STATUS:
-         return "Status";
-      case MENU_ENUM_LABEL_VALUE_AUDIO_SETTINGS:
-         return "Audio";
-      case MENU_ENUM_LABEL_VALUE_INPUT_SETTINGS:
-         return "Input";
-      case MENU_ENUM_LABEL_VALUE_ONSCREEN_DISPLAY_SETTINGS:
-         return "Onscreen Display";
-      case MENU_ENUM_LABEL_VALUE_OVERLAY_SETTINGS:
-         return "Onscreen Overlay";
-      case MENU_ENUM_LABEL_VALUE_ONSCREEN_OVERLAY_SETTINGS:
-         return "Onscreen Overlay";
-      case MENU_ENUM_LABEL_VALUE_MENU_SETTINGS:
-         return "Menu";
-      case MENU_ENUM_LABEL_VALUE_MULTIMEDIA_SETTINGS:
-         return "Multimedia";
-      case MENU_ENUM_LABEL_VALUE_USER_INTERFACE_SETTINGS:
-         return "User Interface";
-      case MENU_ENUM_LABEL_VALUE_MENU_FILE_BROWSER_SETTINGS:
-         return "Menu File Browser";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_FIRMWARE:
+         return "Firmware";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_LICENSES:
+         return "License(s)";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_PERMISSIONS:
+         return "Permissions";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SUPPORTED_EXTENSIONS:
+         return "Supported extensions";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_MANUFACTURER:
+         return "System manufacturer";
+      case MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_NAME:
+         return "System name";
+      case MENU_ENUM_LABEL_VALUE_CORE_INPUT_REMAPPING_OPTIONS:
+         return "Controls";
+      case MENU_ENUM_LABEL_VALUE_CORE_LIST:
+         return "Tải Core";
+      case MENU_ENUM_LABEL_VALUE_CORE_OPTIONS:
+         return "Options";
+      case MENU_ENUM_LABEL_VALUE_CORE_SETTINGS:
+         return "Core";
+      case MENU_ENUM_LABEL_VALUE_CORE_SET_SUPPORTS_NO_CONTENT_ENABLE:
+         return "Automatically start a core";
+      case MENU_ENUM_LABEL_VALUE_CORE_SPECIFIC_CONFIG:
+         return "Configuration Per-Core";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
+         return "Automatically extract downloaded archive";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_BUILDBOT_URL:
+         return "Buildbot Cores URL";
+      case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_LIST:
+         return "Core Updater";
       case MENU_ENUM_LABEL_VALUE_CORE_UPDATER_SETTINGS:
          return "Cập nhậtr";
-      case MENU_ENUM_LABEL_VALUE_UPDATER_SETTINGS:
-         return "Updater";
-      case MENU_ENUM_LABEL_VALUE_NETWORK_SETTINGS:
-         return "Network";
-      case MENU_ENUM_LABEL_VALUE_WIFI_SETTINGS:
-         return "Wi-Fi";
-      case MENU_ENUM_LABEL_VALUE_LAKKA_SERVICES:
-         return "Lakka Services";
-      case MENU_ENUM_LABEL_VALUE_PLAYLIST_SETTINGS:
-         return "Playlists";
-      case MENU_ENUM_LABEL_VALUE_USER_SETTINGS:
-         return "User";
+      case MENU_ENUM_LABEL_VALUE_CPU_ARCHITECTURE:
+         return "CPU Architecture:";
+      case MENU_ENUM_LABEL_VALUE_CPU_CORES:
+         return "CPU Cores:";
+      case MENU_ENUM_LABEL_VALUE_CURSOR_DIRECTORY:
+         return "Cursor Dir";
+      case MENU_ENUM_LABEL_VALUE_CURSOR_MANAGER:
+         return "Cursor Manager";
+      case MENU_ENUM_LABEL_VALUE_CUSTOM_RATIO:
+         return "Custom Ratio";
+      case MENU_ENUM_LABEL_VALUE_DATABASE_MANAGER:
+         return "Database Manager";
+      case MENU_ENUM_LABEL_VALUE_DATABASE_SELECTION:
+         return "Database Selection";
+      case MENU_ENUM_LABEL_VALUE_DELETE_ENTRY:
+         return "Remove";
+      case MENU_ENUM_LABEL_VALUE_DETECT_CORE_LIST:
+         return "Select File And Detect Core";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_CONTENT:
+         return "<Content dir>";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_DEFAULT:
+         return "<Default>";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NONE:
+         return "<None>";
+      case MENU_ENUM_LABEL_VALUE_DIRECTORY_NOT_FOUND:
+         return "Directory not found.";
       case MENU_ENUM_LABEL_VALUE_DIRECTORY_SETTINGS:
          return "Directory";
-      case MENU_ENUM_LABEL_VALUE_RECORDING_SETTINGS:
-         return "Recording";
-      case MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE:
-         return "No information is available.";
-      case MENU_ENUM_LABEL_VALUE_INPUT_USER_BINDS:
-         return "Input User %u Binds";
-      case MENU_ENUM_LABEL_VALUE_LANG_ENGLISH:
-         return "Tiếng Anh";
-      case MENU_ENUM_LABEL_VALUE_LANG_JAPANESE:
-         return "Tiếng Nhật";
-      case MENU_ENUM_LABEL_VALUE_LANG_FRENCH:
-         return "Tiếng Pháp";
-      case MENU_ENUM_LABEL_VALUE_LANG_SPANISH:
-         return "Tiếng Tây Ban Nha";
-      case MENU_ENUM_LABEL_VALUE_LANG_GERMAN:
-         return "Tiếng Đức";
-      case MENU_ENUM_LABEL_VALUE_LANG_ITALIAN:
-         return "Tiếng Ý";
-      case MENU_ENUM_LABEL_VALUE_LANG_DUTCH:
-         return "Tiếng Hà Lan";
-      case MENU_ENUM_LABEL_VALUE_LANG_PORTUGUESE:
-         return "Tiếng Bồ Đào Nha";
-      case MENU_ENUM_LABEL_VALUE_LANG_RUSSIAN:
-         return "Tiếng Nga";
-      case MENU_ENUM_LABEL_VALUE_LANG_KOREAN:
-         return "Tiếng Hàn Quốc";
-      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_TRADITIONAL:
-         return "Tiếng Trung Quốc (Chữ Hán phồn thể)";
-      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_SIMPLIFIED:
-         return "Tiếng Trung Quốc (Chữ Hán giản thể)";
-      case MENU_ENUM_LABEL_VALUE_LANG_ESPERANTO:
-         return "Tiếng Quốc tế ngữ";
-      case MENU_ENUM_LABEL_VALUE_LANG_VIETNAMESE:
-         return "Tiếng Việt";
-      case MENU_ENUM_LABEL_VALUE_LEFT_ANALOG:
-         return "Left Analog";
-      case MENU_ENUM_LABEL_VALUE_RIGHT_ANALOG:
-         return "Right Analog";
-      case MENU_ENUM_LABEL_VALUE_INPUT_HOTKEY_BINDS:
-         return "Input Hotkey Binds";
-      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_SETTINGS:
-         return "Frame Throttle";
-      case MENU_ENUM_LABEL_VALUE_SEARCH:
-         return "Search:";
-      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_IMAGE_VIEWER:
-         return "Use Builtin Image Viewer";
+      case MENU_ENUM_LABEL_VALUE_DISABLED:
+         return "Disabled";
+      case MENU_ENUM_LABEL_VALUE_DISK_CYCLE_TRAY_STATUS:
+         return "Disk Cycle Tray Status";
+      case MENU_ENUM_LABEL_VALUE_DISK_IMAGE_APPEND:
+         return "Disk Image Append";
+      case MENU_ENUM_LABEL_VALUE_DISK_INDEX:
+         return "Disk Index";
+      case MENU_ENUM_LABEL_VALUE_DISK_OPTIONS:
+         return "Disk Control";
+      case MENU_ENUM_LABEL_VALUE_DONT_CARE:
+         return "Don't care";
+      case MENU_ENUM_LABEL_VALUE_DOWNLOADED_FILE_DETECT_CORE_LIST:
+         return "Downloads Dir";
+      case MENU_ENUM_LABEL_VALUE_DOWNLOAD_CORE:
+         return "Download Core...";
+      case MENU_ENUM_LABEL_VALUE_DOWNLOAD_CORE_CONTENT:
+         return "Download Content";
+      case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_ENABLE:
+         return "DPI Override Enable";
+      case MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_VALUE:
+         return "DPI Override";
+      case MENU_ENUM_LABEL_VALUE_DRIVER_SETTINGS:
+         return "Driver";
+      case MENU_ENUM_LABEL_VALUE_DUMMY_ON_CORE_SHUTDOWN:
+         return "Dummy On Core Shutdown";
+      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPER:
+         return "Dynamic Wallpaper";
+      case MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPERS_DIRECTORY:
+         return "Dynamic Wallpapers Dir";
       case MENU_ENUM_LABEL_VALUE_ENABLE:
          return "Enable";
-      case MENU_ENUM_LABEL_VALUE_START_CORE:
-         return "Start Core";
-      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR:
-         return "Poll Type Behavior";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_SCROLL_UP:
-         return "Scroll Up";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_SCROLL_DOWN:
-         return "Scroll Down";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_CONFIRM:
-         return "Confirm";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_BACK:
-         return "Back";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_START:
-         return "Start";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_INFO:
-         return "Info";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_TOGGLE_MENU:
-         return "Toggle Menu";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_QUIT:
-         return "Quit";
-      case MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_TOGGLE_KEYBOARD:
-         return "Toggle Keyboard";
-      case MENU_ENUM_LABEL_VALUE_THUMBNAIL_MODE_SCREENSHOTS:
-         return "Screenshots";
-      case MENU_ENUM_LABEL_VALUE_THUMBNAIL_MODE_TITLE_SCREENS:
-         return "Title Screens";
-      case MENU_ENUM_LABEL_VALUE_THUMBNAIL_MODE_BOXARTS:
-         return "Boxarts";
-      case MENU_ENUM_LABEL_VALUE_MENU_WALLPAPER_OPACITY:
-         return "Wallpaper opacity";
+      case MENU_ENUM_LABEL_VALUE_ENTRY_HOVER_COLOR:
+         return "Menu entry hover color";
+      case MENU_ENUM_LABEL_VALUE_ENTRY_NORMAL_COLOR:
+         return "Menu entry normal color";
+      case MENU_ENUM_LABEL_VALUE_FALSE:
+         return "False";
+      case MENU_ENUM_LABEL_VALUE_FASTFORWARD_RATIO:
+         return "Maximum Run Speed";
+      case MENU_ENUM_LABEL_VALUE_FPS_SHOW:
+         return "Display Framerate";
+      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_ENABLE:
+         return "Limit Maximum Run Speed";
+      case MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_SETTINGS:
+         return "Frame Throttle";
+      case MENU_ENUM_LABEL_VALUE_FRONTEND_COUNTERS:
+         return "Frontend Counters";
+      case MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS:
+         return "Tải Content-specific core options automatically";
+      case MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS_CREATE:
+         return "Create game-options file";
+      case MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS_IN_USE:
+         return "Game-options file";
+      case MENU_ENUM_LABEL_VALUE_HELP:
+         return "help";
+      case MENU_ENUM_LABEL_VALUE_HELP_AUDIO_VIDEO_TROUBLESHOOTING:
+         return "Audio/Video Troubleshooting";
+      case MENU_ENUM_LABEL_VALUE_HELP_CHANGE_VIRTUAL_GAMEPAD:
+         return "Changing Virtual Gamepad Overlay";
+      case MENU_ENUM_LABEL_VALUE_HELP_CONTROLS:
+         return "Basic Menu Controls";
+      case MENU_ENUM_LABEL_VALUE_HELP_LIST:
+         return "Help";
+      case MENU_ENUM_LABEL_VALUE_HELP_LOADING_CONTENT:
+         return "Đang tải Content";
+      case MENU_ENUM_LABEL_VALUE_HELP_SCANNING_CONTENT:
+         return "Scanning For Content";
+      case MENU_ENUM_LABEL_VALUE_HELP_WHAT_IS_A_CORE:
+         return "What Is A Core?";
+      case MENU_ENUM_LABEL_VALUE_HISTORY_LIST_ENABLE:
+         return "History List Enable";
+      case MENU_ENUM_LABEL_VALUE_HISTORY_TAB:
+         return "History";
+      case MENU_ENUM_LABEL_VALUE_HORIZONTAL_MENU:
+         return "Horizontal Menu";
+      case MENU_ENUM_LABEL_VALUE_IMAGES_TAB:
+         return "Images";
+      case MENU_ENUM_LABEL_VALUE_INFORMATION:
+         return "Information";
+      case MENU_ENUM_LABEL_VALUE_INFORMATION_LIST:
+         return "Information";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ADC_TYPE:
+         return "Analog To Digital Type";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ALL_USERS_CONTROL_MENU:
+         return "All Users Control Menu";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_X:
+         return "Left Analog X";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_X_MINUS:
+         return "Left analog X- (left)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_X_PLUS:
+         return "Left analog X+ (right)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_Y:
+         return "Left Analog Y";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_Y_MINUS:
+         return "Left analog Y- (up)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_Y_PLUS:
+         return "Left analog Y+ (down)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_X:
+         return "Right Analog X";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_X_MINUS:
+         return "Right analog X- (left)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_X_PLUS:
+         return "Right analog X+ (right)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_Y:
+         return "Right Analog Y";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_Y_MINUS:
+         return "Right analog Y- (up)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_Y_PLUS:
+         return "Right analog Y+ (down)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_AUTODETECT_ENABLE:
+         return "Autoconfig Enable";
+      case MENU_ENUM_LABEL_VALUE_INPUT_AXIS_THRESHOLD:
+         return "Input Axis Threshold";
+      case MENU_ENUM_LABEL_VALUE_INPUT_BACK_AS_MENU_ENUM_TOGGLE_ENABLE:
+         return "Back As Menu Toggle Enable";
+      case MENU_ENUM_LABEL_VALUE_INPUT_BIND_ALL:
+         return "Bind All";
+      case MENU_ENUM_LABEL_VALUE_INPUT_BIND_DEFAULT_ALL:
+         return "Bind Default All";
+      case MENU_ENUM_LABEL_VALUE_INPUT_BIND_TIMEOUT:
+         return "Bind Timeout";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_HIDE_UNBOUND:
+         return "Hide Unbound Core Input Descriptors";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_LABEL_SHOW:
+         return "Display Input Descriptor Labels";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DEVICE_INDEX:
+         return "Device Index";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DEVICE_TYPE:
+         return "Device Type";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DRIVER:
+         return "Input Driver";
+      case MENU_ENUM_LABEL_VALUE_INPUT_DUTY_CYCLE:
+         return "Duty Cycle";
+      case MENU_ENUM_LABEL_VALUE_INPUT_HOTKEY_BINDS:
+         return "Input Hotkey Binds";
+      case MENU_ENUM_LABEL_VALUE_INPUT_ICADE_ENABLE:
+         return "Keyboard Gamepad Mapping Enable";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_A:
+         return "A button (right)";
       case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_B:
          return "B button (down)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_Y:
-         return "Y button (left)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_DOWN:
+         return "Down D-pad";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_L2:
+         return "L2 button (trigger)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_L3:
+         return "L3 button (thumb)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_L:
+         return "L button (shoulder)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_LEFT:
+         return "Left D-pad";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_R2:
+         return "R2 button (trigger)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_R3:
+         return "R3 button (thumb)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_R:
+         return "R button (shoulder)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_RIGHT:
+         return "Right D-pad";
       case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_SELECT:
          return "Select button";
       case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_START:
          return "Start button";
       case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_UP:
          return "Up D-pad";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_DOWN:
-         return "Down D-pad";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_LEFT:
-         return "Left D-pad";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_RIGHT:
-         return "Right D-pad";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_A:
-         return "A button (right)";
       case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_X:
          return "X button (top)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_L:
-         return "L button (shoulder)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_R:
-         return "R button (shoulder)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_L2:
-         return "L2 button (trigger)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_R2:
-         return "R2 button (trigger)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_L3:
-         return "L3 button (thumb)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_R3:
-         return "R3 button (thumb)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_X:
-         return "Left Analog X";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_Y:
-         return "Left Analog Y";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_X:
-         return "Right Analog X";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_Y:
-         return "Right Analog Y";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_X_PLUS:
-         return "Left analog X+ (right)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_X_MINUS:
-         return "Left analog X- (left)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_Y_PLUS:
-         return "Left analog Y+ (down)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_Y_MINUS:
-         return "Left analog Y- (up)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_X_PLUS:
-         return "Right analog X+ (right)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_X_MINUS:
-         return "Right analog X- (left)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_Y_PLUS:
-         return "Right analog Y+ (down)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_Y_MINUS:
-         return "Right analog Y- (up)";
-      case MENU_ENUM_LABEL_VALUE_INPUT_TURBO_ENABLE:
-         return "Turbo enable";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_FAST_FORWARD_KEY:
-         return "Fast forward toggle";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_FAST_FORWARD_HOLD_KEY:
-         return "Fast forward hold";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_LOAD_STATE_KEY:
-         return "Tải state";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_SAVE_STATE_KEY:
-         return "Save state";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_FULLSCREEN_TOGGLE_KEY:
-         return "Bật/tắt chế độ toàn màn hình";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_QUIT_KEY:
-         return "Quit RetroArch";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_STATE_SLOT_PLUS:
-         return "Savestate slot +";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_STATE_SLOT_MINUS:
-         return "Savestate slot -";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_REWIND:
-         return "Rewind";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_MOVIE_RECORD_TOGGLE:
-         return "Movie record toggle";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_PAUSE_TOGGLE:
-         return "Pause toggle";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_FRAMEADVANCE:
-         return "Frameadvance";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_RESET:
-         return "Reset game";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_SHADER_NEXT:
-         return "Next shader";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_SHADER_PREV:
-         return "Previous shader";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_CHEAT_INDEX_PLUS:
-         return "Cheat index +";
+      case MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_Y:
+         return "Y button (left)";
+      case MENU_ENUM_LABEL_VALUE_INPUT_KEYBOARD_GAMEPAD_MAPPING_TYPE:
+         return "Keyboard Gamepad Mapping Type";
+      case MENU_ENUM_LABEL_VALUE_INPUT_MAX_USERS:
+         return "Max Users";
+      case MENU_ENUM_LABEL_VALUE_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
+         return "Menu Toggle Gamepad Combo";
       case MENU_ENUM_LABEL_VALUE_INPUT_META_CHEAT_INDEX_MINUS:
          return "Cheat index -";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_CHEAT_INDEX_PLUS:
+         return "Cheat index +";
       case MENU_ENUM_LABEL_VALUE_INPUT_META_CHEAT_TOGGLE:
          return "Cheat toggle";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_SCREENSHOT:
-         return "Chụp ảnh màn hình";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_MUTE:
-         return "Audio mute toggle";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_OSK:
-         return "On-screen keyboard toggle";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_NETPLAY_FLIP:
-         return "Netplay flip users";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_SLOWMOTION:
-         return "Slow motion";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_ENABLE_HOTKEY:
-         return "Enable hotkeys";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_VOLUME_UP:
-         return "Volume +";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_VOLUME_DOWN:
-         return "Volume -";
-      case MENU_ENUM_LABEL_VALUE_INPUT_META_OVERLAY_NEXT:
-         return "Overlay next";
       case MENU_ENUM_LABEL_VALUE_INPUT_META_DISK_EJECT_TOGGLE:
          return "Disk eject toggle";
       case MENU_ENUM_LABEL_VALUE_INPUT_META_DISK_NEXT:
          return "Disk next";
       case MENU_ENUM_LABEL_VALUE_INPUT_META_DISK_PREV:
          return "Disk prev";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_ENABLE_HOTKEY:
+         return "Enable hotkeys";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_FAST_FORWARD_HOLD_KEY:
+         return "Fast forward hold";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_FAST_FORWARD_KEY:
+         return "Fast forward toggle";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_FRAMEADVANCE:
+         return "Frameadvance";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_FULLSCREEN_TOGGLE_KEY:
+         return "Bật/tắt chế độ toàn màn hình";
       case MENU_ENUM_LABEL_VALUE_INPUT_META_GRAB_MOUSE_TOGGLE:
          return "Grab mouse toggle";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_LOAD_STATE_KEY:
+         return "Tải state";
       case MENU_ENUM_LABEL_VALUE_INPUT_META_MENU_TOGGLE:
          return "Menu toggle";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DEVICE_INDEX:
-         return "Device Index";
-      case MENU_ENUM_LABEL_VALUE_INPUT_DEVICE_TYPE:
-         return "Device Type";
-      case MENU_ENUM_LABEL_VALUE_INPUT_ADC_TYPE:
-         return "Analog To Digital Type";
-      case MENU_ENUM_LABEL_VALUE_INPUT_BIND_ALL:
-         return "Bind All";
-      case MENU_ENUM_LABEL_VALUE_INPUT_BIND_DEFAULT_ALL:
-         return "Bind Default All";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_MOVIE_RECORD_TOGGLE:
+         return "Movie record toggle";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_MUTE:
+         return "Audio mute toggle";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_NETPLAY_FLIP:
+         return "Netplay flip users";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_OSK:
+         return "On-screen keyboard toggle";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_OVERLAY_NEXT:
+         return "Overlay next";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_PAUSE_TOGGLE:
+         return "Pause toggle";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_QUIT_KEY:
+         return "Quit RetroArch";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_RESET:
+         return "Reset game";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_REWIND:
+         return "Rewind";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_SAVE_STATE_KEY:
+         return "Save state";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_SCREENSHOT:
+         return "Chụp ảnh màn hình";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_SHADER_NEXT:
+         return "Next shader";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_SHADER_PREV:
+         return "Previous shader";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_SLOWMOTION:
+         return "Slow motion";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_STATE_SLOT_MINUS:
+         return "Savestate slot -";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_STATE_SLOT_PLUS:
+         return "Savestate slot +";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_VOLUME_DOWN:
+         return "Volume -";
+      case MENU_ENUM_LABEL_VALUE_INPUT_META_VOLUME_UP:
+         return "Volume +";
+      case MENU_ENUM_LABEL_VALUE_INPUT_OSK_OVERLAY_ENABLE:
+         return "Display Keyboard Overlay";
+      case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_ENABLE:
+         return "Display Overlay";
+      case MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_HIDE_IN_MENU:
+         return "Hide Overlay In Menu";
+      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR:
+         return "Poll Type Behavior";
+      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR_EARLY:
+         return "Early";
+      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR_LATE:
+         return "Late";
+      case MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR_NORMAL:
+         return "Normal";
+      case MENU_ENUM_LABEL_VALUE_INPUT_PREFER_FRONT_TOUCH:
+         return "Prefer Front Touch";
+      case MENU_ENUM_LABEL_VALUE_INPUT_REMAPPING_DIRECTORY:
+         return "Input Remapping Dir";
+      case MENU_ENUM_LABEL_VALUE_INPUT_REMAP_BINDS_ENABLE:
+         return "Remap Binds Enable";
       case MENU_ENUM_LABEL_VALUE_INPUT_SAVE_AUTOCONFIG:
          return "Lưu Autoconfig";
+      case MENU_ENUM_LABEL_VALUE_INPUT_SETTINGS:
+         return "Input";
+      case MENU_ENUM_LABEL_VALUE_INPUT_SMALL_KEYBOARD_ENABLE:
+         return "Small Keyboard Enable";
+      case MENU_ENUM_LABEL_VALUE_INPUT_TOUCH_ENABLE:
+         return "Touch Enable";
+      case MENU_ENUM_LABEL_VALUE_INPUT_TURBO_ENABLE:
+         return "Turbo enable";
+      case MENU_ENUM_LABEL_VALUE_INPUT_TURBO_PERIOD:
+         return "Turbo Period";
+      case MENU_ENUM_LABEL_VALUE_INPUT_USER_BINDS:
+         return "Input User %u Binds";
+      case MENU_ENUM_LABEL_VALUE_INTERNAL_STORAGE_STATUS:
+         return "Internal storage status";
+      case MENU_ENUM_LABEL_VALUE_JOYPAD_AUTOCONFIG_DIR:
+         return "Input Device Autoconfig Dir";
+      case MENU_ENUM_LABEL_VALUE_JOYPAD_DRIVER:
+         return "Joypad Driver";
+      case MENU_ENUM_LABEL_VALUE_KEYBOARD_OVERLAY_PRESET:
+         return "Keyboard Overlay Preset";
+      case MENU_ENUM_LABEL_VALUE_LAKKA_SERVICES:
+         return "Lakka Services";
+      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_SIMPLIFIED:
+         return "Tiếng Trung Quốc (Chữ Hán giản thể)";
+      case MENU_ENUM_LABEL_VALUE_LANG_CHINESE_TRADITIONAL:
+         return "Tiếng Trung Quốc (Chữ Hán phồn thể)";
+      case MENU_ENUM_LABEL_VALUE_LANG_DUTCH:
+         return "Tiếng Hà Lan";
+      case MENU_ENUM_LABEL_VALUE_LANG_ENGLISH:
+         return "Tiếng Anh";
+      case MENU_ENUM_LABEL_VALUE_LANG_ESPERANTO:
+         return "Tiếng Quốc tế ngữ";
+      case MENU_ENUM_LABEL_VALUE_LANG_FRENCH:
+         return "Tiếng Pháp";
+      case MENU_ENUM_LABEL_VALUE_LANG_GERMAN:
+         return "Tiếng Đức";
+      case MENU_ENUM_LABEL_VALUE_LANG_ITALIAN:
+         return "Tiếng Ý";
+      case MENU_ENUM_LABEL_VALUE_LANG_JAPANESE:
+         return "Tiếng Nhật";
+      case MENU_ENUM_LABEL_VALUE_LANG_KOREAN:
+         return "Tiếng Hàn Quốc";
+      case MENU_ENUM_LABEL_VALUE_LANG_POLISH:
+         return "Polish";
+      case MENU_ENUM_LABEL_VALUE_LANG_PORTUGUESE:
+         return "Tiếng Bồ Đào Nha";
+      case MENU_ENUM_LABEL_VALUE_LANG_RUSSIAN:
+         return "Tiếng Nga";
+      case MENU_ENUM_LABEL_VALUE_LANG_SPANISH:
+         return "Tiếng Tây Ban Nha";
+      case MENU_ENUM_LABEL_VALUE_LANG_VIETNAMESE:
+         return "Tiếng Việt";
+      case MENU_ENUM_LABEL_VALUE_LEFT_ANALOG:
+         return "Left Analog";
+      case MENU_ENUM_LABEL_VALUE_LIBRETRO_DIR_PATH:
+         return "Core Dir";
+      case MENU_ENUM_LABEL_VALUE_LIBRETRO_INFO_PATH:
+         return "Core Info Dir";
+      case MENU_ENUM_LABEL_VALUE_LIBRETRO_LOG_LEVEL:
+         return "Core Logging Level";
+      case MENU_ENUM_LABEL_VALUE_LINEAR:
+         return "Linear";
+      case MENU_ENUM_LABEL_VALUE_LOAD_ARCHIVE:
+         return "Tải Archive With Core";
+      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT:
+         return "Select File";
+      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_HISTORY:
+         return "Tải Recent";
+      case MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_LIST:
+         return "Tải Content";
+      case MENU_ENUM_LABEL_VALUE_LOAD_STATE:
+         return "Tải State";
+      case MENU_ENUM_LABEL_VALUE_LOCATION_ALLOW:
+         return "Allow Location";
+      case MENU_ENUM_LABEL_VALUE_LOCATION_DRIVER:
+         return "Location Driver";
+      case MENU_ENUM_LABEL_VALUE_LOGGING_SETTINGS:
+         return "Logging";
+      case MENU_ENUM_LABEL_VALUE_LOG_VERBOSITY:
+         return "Logging Verbosity";
+      case MENU_ENUM_LABEL_VALUE_MAIN_MENU:
+         return "Main Menu";
+      case MENU_ENUM_LABEL_VALUE_MANAGEMENT:
+         return "Database thiết lập";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME:
+         return "Menu Color Theme";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_BLUE:
+         return "Blue";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_BLUE_GREY:
+         return "Blue Grey";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_DARK_BLUE:
+         return "Dark Blue";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_GREEN:
+         return "Green";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_NVIDIA_SHIELD:
+         return "Shield";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_RED:
+         return "Red";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_YELLOW:
+         return "Yellow";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_FOOTER_OPACITY:
+         return "Footer Opacity";
+      case MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_HEADER_OPACITY:
+         return "Header Opacity";
+      case MENU_ENUM_LABEL_VALUE_MENU_DRIVER:
+         return "Menu Driver";
+      case MENU_ENUM_LABEL_VALUE_MENU_ENUM_THROTTLE_FRAMERATE:
+         return "Throttle Menu Framerate";
+      case MENU_ENUM_LABEL_VALUE_MENU_FILE_BROWSER_SETTINGS:
+         return "Menu File Browser";
+      case MENU_ENUM_LABEL_VALUE_MENU_LINEAR_FILTER:
+         return "Menu Linear Filter";
+      case MENU_ENUM_LABEL_VALUE_MENU_SETTINGS:
+         return "Menu";
+      case MENU_ENUM_LABEL_VALUE_MENU_WALLPAPER:
+         return "Menu Wallpaper";
+      case MENU_ENUM_LABEL_VALUE_MENU_WALLPAPER_OPACITY:
+         return "Wallpaper opacity";
+      case MENU_ENUM_LABEL_VALUE_MISSING:
+         return "Missing";
+      case MENU_ENUM_LABEL_VALUE_MORE:
+         return "...";
+      case MENU_ENUM_LABEL_VALUE_MOUSE_ENABLE:
+         return "Mouse Support";
+      case MENU_ENUM_LABEL_VALUE_MULTIMEDIA_SETTINGS:
+         return "Multimedia";
+      case MENU_ENUM_LABEL_VALUE_MUSIC_TAB:
+         return "Music";
+      case MENU_ENUM_LABEL_VALUE_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
+         return "Filter unknown extensions";
+      case MENU_ENUM_LABEL_VALUE_NAVIGATION_WRAPAROUND:
+         return "Navigation Wrap-Around";
+      case MENU_ENUM_LABEL_VALUE_NEAREST:
+         return "Nearest";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY:
+         return "Netplay";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_CHECK_FRAMES:
+         return "Netplay Check Frames";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT:
+         return "Netplay P2 Uses C1";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_DELAY_FRAMES:
+         return "Netplay Delay Frames";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_DISCONNECT:
+         return "Disconnect";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE:
+         return "Netplay Enable";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE_CLIENT:
+         return "Connect to Netplay host";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE_HOST:
+         return "Start hosting";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS:
+         return "Server Address";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_MODE:
+         return "Netplay Client Enable";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_NICKNAME:
+         return "Username";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_SETTINGS:
+         return "Netplay thiết lập";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE:
+         return "Netplay Spectator Enable";
+      case MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT:
+         return "Netplay TCP/UDP Port";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_ENABLE:
+         return "Network Commands";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_CMD_PORT:
+         return "Network Command Port";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_INFORMATION:
+         return "Network Information";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_REMOTE_ENABLE:
+         return "Network Gamepad";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_REMOTE_PORT:
+         return "Network Remote Base Port";
+      case MENU_ENUM_LABEL_VALUE_NETWORK_SETTINGS:
+         return "Network";
+      case MENU_ENUM_LABEL_VALUE_NO:
+         return "No";
+      case MENU_ENUM_LABEL_VALUE_NONE:
+         return "None";
+      case MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE:
+         return "N/A";
+      case MENU_ENUM_LABEL_VALUE_NO_ACHIEVEMENTS_TO_DISPLAY:
+         return "No achievements to display.";
+      case MENU_ENUM_LABEL_VALUE_NO_CORE:
+         return "No Core";
+      case MENU_ENUM_LABEL_VALUE_NO_CORES_AVAILABLE:
+         return "No cores available.";
+      case MENU_ENUM_LABEL_VALUE_NO_CORE_INFORMATION_AVAILABLE:
+         return "No core information available.";
+      case MENU_ENUM_LABEL_VALUE_NO_CORE_OPTIONS_AVAILABLE:
+         return "No core options available.";
+      case MENU_ENUM_LABEL_VALUE_NO_ENTRIES_TO_DISPLAY:
+         return "No entries to display.";
+      case MENU_ENUM_LABEL_VALUE_NO_HISTORY_AVAILABLE:
+         return "No history available.";
+      case MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE:
+         return "No information is available.";
+      case MENU_ENUM_LABEL_VALUE_NO_ITEMS:
+         return "No items.";
+      case MENU_ENUM_LABEL_VALUE_NO_PERFORMANCE_COUNTERS:
+         return "No performance counters.";
+      case MENU_ENUM_LABEL_VALUE_NO_PLAYLISTS:
+         return "No playlists.";
+      case MENU_ENUM_LABEL_VALUE_NO_PLAYLIST_ENTRIES_AVAILABLE:
+         return "No playlist entries available.";
+      case MENU_ENUM_LABEL_VALUE_NO_SETTINGS_FOUND:
+         return "No thiết lập found.";
+      case MENU_ENUM_LABEL_VALUE_NO_SHADER_PARAMETERS:
+         return "No shader parameters.";
+      case MENU_ENUM_LABEL_VALUE_OFF:
+         return "OFF";
+      case MENU_ENUM_LABEL_VALUE_ON:
+         return "ON";
+      case MENU_ENUM_LABEL_VALUE_ONLINE_UPDATER:
+         return "Online Updater";
+      case MENU_ENUM_LABEL_VALUE_ONSCREEN_DISPLAY_SETTINGS:
+         return "Onscreen Display";
+      case MENU_ENUM_LABEL_VALUE_ONSCREEN_OVERLAY_SETTINGS:
+         return "Onscreen Overlay";
+      case MENU_ENUM_LABEL_VALUE_OPEN_ARCHIVE:
+         return "Open Archive As Folder";
+      case MENU_ENUM_LABEL_VALUE_OPTIONAL:
+         return "Optional";
+      case MENU_ENUM_LABEL_VALUE_OSK_OVERLAY_DIRECTORY:
+         return "OSK Overlay Dir";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY:
+         return "Overlay";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_AUTOLOAD_PREFERRED:
+         return "Tự động tải Preferred Overlay";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_DIRECTORY:
+         return "Overlay Dir";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_OPACITY:
+         return "Overlay Opacity";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_PRESET:
+         return "Overlay Preset";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_SCALE:
+         return "Overlay Scale";
+      case MENU_ENUM_LABEL_VALUE_OVERLAY_SETTINGS:
+         return "Onscreen Overlay";
+      case MENU_ENUM_LABEL_VALUE_PAL60_ENABLE:
+         return "Use PAL60 Mode";
+      case MENU_ENUM_LABEL_VALUE_PARENT_DIRECTORY:
+         return "Parent directory";
+      case MENU_ENUM_LABEL_VALUE_PAUSE_LIBRETRO:
+         return "Pause when menu activated";
+      case MENU_ENUM_LABEL_VALUE_PAUSE_NONACTIVE:
+         return "Don't run in background";
+      case MENU_ENUM_LABEL_VALUE_PERFCNT_ENABLE:
+         return "Performance Counters";
+      case MENU_ENUM_LABEL_VALUE_PLAYLISTS_TAB:
+         return "Playlists";
+      case MENU_ENUM_LABEL_VALUE_PLAYLIST_DIRECTORY:
+         return "Playlist Dir";
+      case MENU_ENUM_LABEL_VALUE_PLAYLIST_SETTINGS:
+         return "Playlists";
+      case MENU_ENUM_LABEL_VALUE_POINTER_ENABLE:
+         return "Touch Support";
+      case MENU_ENUM_LABEL_VALUE_PORT:
+         return "Port";
+      case MENU_ENUM_LABEL_VALUE_PRESENT:
+         return "Present";
+      case MENU_ENUM_LABEL_VALUE_PRIVACY_SETTINGS:
+         return "Privacy";
+      case MENU_ENUM_LABEL_VALUE_QUIT_RETROARCH:
+         return "Thoát RetroArch";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ANALOG:
+         return "Analog supported";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_BBFC_RATING:
+         return "BBFC Rating";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_CERO_RATING:
+         return "CERO Rating";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_COOP:
+         return "Co-op supported";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_CRC32:
+         return "CRC32";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DESCRIPTION:
+         return "Description";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DEVELOPER:
+         return "Developer";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_EDGE_MAGAZINE_ISSUE:
+         return "Edge Magazine Issue";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_EDGE_MAGAZINE_RATING:
+         return "Edge Magazine Rating";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_EDGE_MAGAZINE_REVIEW:
+         return "Edge Magazine Review";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ELSPA_RATING:
+         return "ELSPA Rating";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ENHANCEMENT_HW:
+         return "Enhancement Hardware";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ESRB_RATING:
+         return "ESRB Rating";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_FAMITSU_MAGAZINE_RATING:
+         return "Famitsu Magazine Rating";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_FRANCHISE:
+         return "Franchise";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_GENRE:
+         return "Genre";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_MD5:
+         return "MD5";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_NAME:
+         return "Name";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ORIGIN:
+         return "Origin";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_PEGI_RATING:
+         return "PEGI Rating";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_PUBLISHER:
+         return "Publisher";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_MONTH:
+         return "Releasedate Month";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_YEAR:
+         return "Releasedate Year";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RUMBLE:
+         return "Rumble supported";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_SERIAL:
+         return "Serial";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_SHA1:
+         return "SHA1";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_START_CONTENT:
+         return "Start Content";
+      case MENU_ENUM_LABEL_VALUE_RDB_ENTRY_TGDB_RATING:
+         return "TGDB Rating";
+      case MENU_ENUM_LABEL_VALUE_REBOOT:
+         return "Khởi động lại";
+      case MENU_ENUM_LABEL_VALUE_RECORDING_CONFIG_DIRECTORY:
+         return "Recording Config Dir";
+      case MENU_ENUM_LABEL_VALUE_RECORDING_OUTPUT_DIRECTORY:
+         return "Recording Output Dir";
+      case MENU_ENUM_LABEL_VALUE_RECORDING_SETTINGS:
+         return "Recording";
+      case MENU_ENUM_LABEL_VALUE_RECORD_CONFIG:
+         return "Record Config";
+      case MENU_ENUM_LABEL_VALUE_RECORD_DRIVER:
+         return "Record Driver";
+      case MENU_ENUM_LABEL_VALUE_RECORD_ENABLE:
+         return "Record Enable";
+      case MENU_ENUM_LABEL_VALUE_RECORD_PATH:
+         return "Output File";
+      case MENU_ENUM_LABEL_VALUE_RECORD_USE_OUTPUT_DIRECTORY:
+         return "Use Output Dir";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE:
+         return "Remap File";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_LOAD:
+         return "Tải Remap File";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_CORE:
+         return "Save Core Remap File";
+      case MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_GAME:
+         return "Save Game Remap File";
+      case MENU_ENUM_LABEL_VALUE_REQUIRED:
+         return "Required";
+      case MENU_ENUM_LABEL_VALUE_RESTART_CONTENT:
+         return "Khởi động lại";
+      case MENU_ENUM_LABEL_VALUE_RESTART_RETROARCH:
+         return "Restart RetroArch";
+      case MENU_ENUM_LABEL_VALUE_RESUME:
+         return "Resume";
+      case MENU_ENUM_LABEL_VALUE_RESUME_CONTENT:
+         return "Resume";
+      case MENU_ENUM_LABEL_VALUE_RETROKEYBOARD:
+         return "RetroKeyboard";
+      case MENU_ENUM_LABEL_VALUE_RETROPAD:
+         return "RetroPad";
+      case MENU_ENUM_LABEL_VALUE_RETRO_ACHIEVEMENTS_SETTINGS:
+         return "Retro Achievements";
+      case MENU_ENUM_LABEL_VALUE_REWIND_ENABLE:
+         return "Rewind Enable";
+      case MENU_ENUM_LABEL_VALUE_REWIND_GRANULARITY:
+         return "Rewind Granularity";
+      case MENU_ENUM_LABEL_VALUE_REWIND_SETTINGS:
+         return "Rewind";
+      case MENU_ENUM_LABEL_VALUE_RGUI_BROWSER_DIRECTORY:
+         return "File Browser Dir";
+      case MENU_ENUM_LABEL_VALUE_RGUI_CONFIG_DIRECTORY:
+         return "Config Dir";
+      case MENU_ENUM_LABEL_VALUE_RGUI_SHOW_START_SCREEN:
+         return "Show Start Screen";
+      case MENU_ENUM_LABEL_VALUE_RIGHT_ANALOG:
+         return "Right Analog";
+      case MENU_ENUM_LABEL_VALUE_RUN:
+         return "Run";
+      case MENU_ENUM_LABEL_VALUE_SAMBA_ENABLE:
+         return "SAMBA Enable";
+      case MENU_ENUM_LABEL_VALUE_SAVEFILE_DIRECTORY:
+         return "Savefile Dir";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_INDEX:
+         return "Save State Auto Index";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_LOAD:
+         return "Tự động tải State";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_SAVE:
+         return "Auto Save State";
+      case MENU_ENUM_LABEL_VALUE_SAVESTATE_DIRECTORY:
+         return "Savestate Dir";
+      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG:
+         return "Save Current Config";
+      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG_OVERRIDE_CORE:
+         return "Save Core Overrides";
+      case MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG_OVERRIDE_GAME:
+         return "Save Game Overrides";
+      case MENU_ENUM_LABEL_VALUE_SAVE_NEW_CONFIG:
+         return "Save New Config";
+      case MENU_ENUM_LABEL_VALUE_SAVE_STATE:
+         return "Save State";
+      case MENU_ENUM_LABEL_VALUE_SAVING_SETTINGS:
+         return "Saving";
+      case MENU_ENUM_LABEL_VALUE_SCAN_DIRECTORY:
+         return "Scan Directory";
+      case MENU_ENUM_LABEL_VALUE_SCAN_FILE:
+         return "Scan File";
+      case MENU_ENUM_LABEL_VALUE_SCAN_THIS_DIRECTORY:
+         return "<Scan This Directory>";
+      case MENU_ENUM_LABEL_VALUE_SCREENSHOT_DIRECTORY:
+         return "Screenshot Dir";
+      case MENU_ENUM_LABEL_VALUE_SCREEN_RESOLUTION:
+         return "Screen Resolution";
+      case MENU_ENUM_LABEL_VALUE_SEARCH:
+         return "Search:";
+      case MENU_ENUM_LABEL_VALUE_SECONDS:
+         return "seconds";
+      case MENU_ENUM_LABEL_VALUE_SETTINGS:
+         return "Thiết lập";
+      case MENU_ENUM_LABEL_VALUE_SETTINGS_TAB:
+         return "Thiết lập";
+      case MENU_ENUM_LABEL_VALUE_SHADER:
+         return "Shader";
+      case MENU_ENUM_LABEL_VALUE_SHADER_APPLY_CHANGES:
+         return "Apply Shader Changes";
+      case MENU_ENUM_LABEL_VALUE_SHADER_OPTIONS:
+         return "Shaders";
+      case MENU_ENUM_LABEL_VALUE_SHADER_PIPELINE_RIBBON:
+         return "Ribbon";
+      case MENU_ENUM_LABEL_VALUE_SHADER_PIPELINE_RIBBON_SIMPLIFIED:
+         return "Ribbon (simplified)";
+      case MENU_ENUM_LABEL_VALUE_SHOW_ADVANCED_SETTINGS:
+         return "Show Advanced thiết lập";
+      case MENU_ENUM_LABEL_VALUE_SHOW_HIDDEN_FILES:
+         return "Show Hidden Files and Folders";
+      case MENU_ENUM_LABEL_VALUE_SHUTDOWN:
+         return "Tắt Máy";
+      case MENU_ENUM_LABEL_VALUE_SLOWMOTION_RATIO:
+         return "Slow-Motion Ratio";
+      case MENU_ENUM_LABEL_VALUE_SORT_SAVEFILES_ENABLE:
+         return "Sort Saves In Folders";
+      case MENU_ENUM_LABEL_VALUE_SORT_SAVESTATES_ENABLE:
+         return "Sort Savestates In Folders";
+      case MENU_ENUM_LABEL_VALUE_SSH_ENABLE:
+         return "SSH Enable";
+      case MENU_ENUM_LABEL_VALUE_START_CORE:
+         return "Start Core";
+      case MENU_ENUM_LABEL_VALUE_START_NET_RETROPAD:
+         return "Start Remote RetroPad";
+      case MENU_ENUM_LABEL_VALUE_START_VIDEO_PROCESSOR:
+         return "Start Video Processor";
+      case MENU_ENUM_LABEL_VALUE_STATE_SLOT:
+         return "State Slot";
+      case MENU_ENUM_LABEL_VALUE_STATUS:
+         return "Status";
+      case MENU_ENUM_LABEL_VALUE_STDIN_CMD_ENABLE:
+         return "stdin Commands";
+      case MENU_ENUM_LABEL_VALUE_SUPPORTED_CORES:
+         return "Supported cores";
+      case MENU_ENUM_LABEL_VALUE_SUSPEND_SCREENSAVER_ENABLE:
+         return "Suspend Screensaver";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_BGM_ENABLE:
+         return "System BGM Enable";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_DIRECTORY:
+         return "System/BIOS Dir";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFORMATION:
+         return "System Information";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_7ZIP_SUPPORT:
+         return "7zip support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ALSA_SUPPORT:
+         return "ALSA support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_BUILD_DATE:
+         return "Build date";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CG_SUPPORT:
+         return "Cg support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COCOA_SUPPORT:
+         return "Cocoa support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_COMMAND_IFACE_SUPPORT:
+         return "Command interface support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CORETEXT_SUPPORT:
+         return "CoreText support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_CPU_FEATURES:
+         return "CPU Features";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_DPI:
+         return "Display metric DPI";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_HEIGHT:
+         return "Display metric height (mm)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_WIDTH:
+         return "Display metric width (mm)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DSOUND_SUPPORT:
+         return "DirectSound support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DYLIB_SUPPORT:
+         return "Dynamic library support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DYNAMIC_SUPPORT:
+         return "Dynamic run-time loading of libretro library";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_EGL_SUPPORT:
+         return "EGL support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FBO_SUPPORT:
+         return "OpenGL/Direct3D render-to-texture (multi-pass shaders) support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FFMPEG_SUPPORT:
+         return "FFmpeg support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FREETYPE_SUPPORT:
+         return "FreeType support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_IDENTIFIER:
+         return "Frontend identifier";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_NAME:
+         return "Frontend name";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_OS:
+         return "Frontend OS";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GIT_VERSION:
+         return "Git version";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GLSL_SUPPORT:
+         return "GLSL support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_HLSL_SUPPORT:
+         return "HLSL support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_JACK_SUPPORT:
+         return "JACK support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_KMS_SUPPORT:
+         return "KMS/EGL support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBRETRODB_SUPPORT:
+         return "LibretroDB support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBUSB_SUPPORT:
+         return "Libusb support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_LIBXML2_SUPPORT:
+         return "libxml2 XML parsing support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETPLAY_SUPPORT:
+         return "Netplay (peer-to-peer) support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETWORK_COMMAND_IFACE_SUPPORT:
+         return "Network Command interface support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETWORK_REMOTE_SUPPORT:
+         return "Network Gamepad support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENAL_SUPPORT:
+         return "OpenAL support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGLES_SUPPORT:
+         return "OpenGL ES support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGL_SUPPORT:
+         return "OpenGL support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENSL_SUPPORT:
+         return "OpenSL support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENVG_SUPPORT:
+         return "OpenVG support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OSS_SUPPORT:
+         return "OSS support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OVERLAY_SUPPORT:
+         return "Overlay support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE:
+         return "Power source";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGED:
+         return "Charged";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGING:
+         return "Charging";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_DISCHARGING:
+         return "Discharging";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_NO_SOURCE:
+         return "No source";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PULSEAUDIO_SUPPORT:
+         return "PulseAudio support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PYTHON_SUPPORT:
+         return "Python (script support in shaders) support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RBMP_SUPPORT:
+         return "BMP support (RBMP)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RETRORATING_LEVEL:
+         return "RetroRating level";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RJPEG_SUPPORT:
+         return "JPEG support (RJPEG)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ROARAUDIO_SUPPORT:
+         return "RoarAudio support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RPNG_SUPPORT:
+         return "PNG support (RPNG)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RSOUND_SUPPORT:
+         return "RSound support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RTGA_SUPPORT:
+         return "TGA support (RTGA)";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL2_SUPPORT:
+         return "SDL2 support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_IMAGE_SUPPORT:
+         return "SDL image support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_SUPPORT:
+         return "SDL1.2 support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SLANG_SUPPORT:
+         return "Slang support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_THREADING_SUPPORT:
+         return "Threading support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_UDEV_SUPPORT:
+         return "Udev support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_V4L2_SUPPORT:
+         return "Video4Linux2 support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VIDEO_CONTEXT_DRIVER:
+         return "Video context driver";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VULKAN_SUPPORT:
+         return "Vulkan support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_WAYLAND_SUPPORT:
+         return "Wayland support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_X11_SUPPORT:
+         return "X11 support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XAUDIO2_SUPPORT:
+         return "XAudio2 support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XVIDEO_SUPPORT:
+         return "XVideo support";
+      case MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ZLIB_SUPPORT:
+         return "Zlib support";
+      case MENU_ENUM_LABEL_VALUE_TAKE_SCREENSHOT:
+         return "Chụp ảnh màn hình";
+      case MENU_ENUM_LABEL_VALUE_THREADED_DATA_RUNLOOP_ENABLE:
+         return "Threaded data runloop";
+      case MENU_ENUM_LABEL_VALUE_THUMBNAILS:
+         return "Thumbnails";
+      case MENU_ENUM_LABEL_VALUE_THUMBNAILS_DIRECTORY:
+         return "Thumbnails Dir";
+      case MENU_ENUM_LABEL_VALUE_THUMBNAILS_UPDATER_LIST:
+         return "Thumbnails Updater";
+      case MENU_ENUM_LABEL_VALUE_THUMBNAIL_MODE_BOXARTS:
+         return "Boxarts";
+      case MENU_ENUM_LABEL_VALUE_THUMBNAIL_MODE_SCREENSHOTS:
+         return "Screenshots";
+      case MENU_ENUM_LABEL_VALUE_THUMBNAIL_MODE_TITLE_SCREENS:
+         return "Title Screens";
+      case MENU_ENUM_LABEL_VALUE_TIMEDATE_ENABLE:
+         return "Display time / date";
+      case MENU_ENUM_LABEL_VALUE_TITLE_COLOR:
+         return "Menu title color";
+      case MENU_ENUM_LABEL_VALUE_TRUE:
+         return "True";
+      case MENU_ENUM_LABEL_VALUE_UI_COMPANION_ENABLE:
+         return "UI Companion Enable";
+      case MENU_ENUM_LABEL_VALUE_UI_COMPANION_START_ON_BOOT:
+         return "UI Companion Start On Boot";
+      case MENU_ENUM_LABEL_VALUE_UI_MENUBAR_ENABLE:
+         return "Menubar";
+      case MENU_ENUM_LABEL_VALUE_UNABLE_TO_READ_COMPRESSED_FILE:
+         return "Unable to read compressed file.";
+      case MENU_ENUM_LABEL_VALUE_UNDO_LOAD_STATE:
+         return "Undo Tải State";
+      case MENU_ENUM_LABEL_VALUE_UNDO_SAVE_STATE:
+         return "Undo Save State";
+      case MENU_ENUM_LABEL_VALUE_UNKNOWN:
+         return "Unknown";
+      case MENU_ENUM_LABEL_VALUE_UPDATER_SETTINGS:
+         return "Updater";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_ASSETS:
+         return "Cập nhật Assets";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_AUTOCONFIG_PROFILES:
+         return "Cập nhật Autoconfig Profiles";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_CG_SHADERS:
+         return "Cập nhật Cg Shaders";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_CHEATS:
+         return "Cập nhật Cheats";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_CORE_INFO_FILES:
+         return "Cập nhật Core Info Files";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_DATABASES:
+         return "Cập nhật Databases";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_GLSL_SHADERS:
+         return "Cập nhật GLSL Shaders";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_LAKKA:
+         return "Cập nhật Lakka";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_OVERLAYS:
+         return "Cập nhật Overlays";
+      case MENU_ENUM_LABEL_VALUE_UPDATE_SLANG_SHADERS:
+         return "Cập nhật Slang Shaders";
+      case MENU_ENUM_LABEL_VALUE_USER:
+         return "User";
+      case MENU_ENUM_LABEL_VALUE_USER_INTERFACE_SETTINGS:
+         return "User Interface";
+      case MENU_ENUM_LABEL_VALUE_USER_LANGUAGE:
+         return "Language";
+      case MENU_ENUM_LABEL_VALUE_USER_SETTINGS:
+         return "User";
+      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_IMAGE_VIEWER:
+         return "Use Builtin Image Viewer";
+      case MENU_ENUM_LABEL_VALUE_USE_BUILTIN_PLAYER:
+         return "Use Builtin Media Player";
+      case MENU_ENUM_LABEL_VALUE_USE_THIS_DIRECTORY:
+         return "<Use this directory>";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ALLOW_ROTATE:
+         return "Allow rotation";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_AUTO:
+         return "Auto Aspect Ratio";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_INDEX:
+         return "Aspect Ratio Index";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_BLACK_FRAME_INSERTION:
+         return "Black Frame Insertion";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_CROP_OVERSCAN:
+         return "Crop Overscan (Reload)";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_DISABLE_COMPOSITION:
+         return "Disable Desktop Composition";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_DRIVER:
+         return "Video Driver";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER:
+         return "Video Filter";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_DIR:
+         return "Video Filter Dir";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_FLICKER:
+         return "Flicker filter";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_ENABLE:
+         return "Display OSD Message";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_PATH:
+         return "OSD Message Font";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FONT_SIZE:
+         return "OSD Message Size";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_ASPECT:
+         return "Force aspect ratio";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_SRGB_DISABLE:
+         return "Force-disable sRGB FBO";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FRAME_DELAY:
+         return "Frame Delay";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_FULLSCREEN:
+         return "Sử dụng chế độ toàn màn hình";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_GAMMA:
+         return "Video Gamma";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_RECORD:
+         return "GPU Record Enable";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_GPU_SCREENSHOT:
+         return "GPU Screenshot Enable";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC:
+         return "Hard GPU Sync";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC_FRAMES:
+         return "Hard GPU Sync Frames";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MAX_SWAPCHAIN_IMAGES:
+         return "Max swapchain images";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_X:
+         return "OSD Message X Position";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_Y:
+         return "OSD Message Y Position";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_MONITOR_INDEX:
+         return "Monitor Index";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_POST_FILTER_RECORD:
+         return "Post filter record Enable";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE:
+         return "Refresh Rate";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE_AUTO:
+         return "Estimated Monitor Framerate";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_ROTATION:
+         return "Rotation";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE:
+         return "Windowed Scale";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SCALE_INTEGER:
+         return "Integer Scale";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SETTINGS:
+         return "Video";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_DIR:
+         return "Video Shader Dir";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_NUM_PASSES:
+         return "Shader Passes";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PARAMETERS:
+         return "Preview Shader Parameters";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET:
+         return "Tải Shader Preset";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_PARAMETERS:
+         return "Menu Shader Parameters";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_AS:
+         return "Save Shader Preset As";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_CORE:
+         return "Save Core Preset";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_GAME:
+         return "Save Game Preset";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SHARED_CONTEXT:
+         return "HW Shared Context Enable";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SMOOTH:
+         return "HW Bilinear Filtering";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SOFT_FILTER:
+         return "Soft Filter Enable";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_SWAP_INTERVAL:
+         return "VSync Swap Interval";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_TAB:
+         return "Video";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_THREADED:
+         return "Threaded Video";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VFILTER:
+         return "Deflicker";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_HEIGHT:
+         return "Custom Viewport Height";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_WIDTH:
+         return "Custom Viewport Width";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_X:
+         return "Custom Viewport X";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_Y:
+         return "Custom Viewport Y";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VI_WIDTH:
+         return "Set VI Screen Width";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_VSYNC:
+         return "VSync";
+      case MENU_ENUM_LABEL_VALUE_VIDEO_WINDOWED_FULLSCREEN:
+         return "Chế độ toàn màn hình trong khung";
+      case MENU_ENUM_LABEL_VALUE_WIFI_DRIVER:
+         return "Wi-Fi Driver";
+      case MENU_ENUM_LABEL_VALUE_WIFI_SETTINGS:
+         return "Wi-Fi";
+      case MENU_ENUM_LABEL_VALUE_XMB_ALPHA_FACTOR:
+         return "Menu Alpha Factor";
+      case MENU_ENUM_LABEL_VALUE_XMB_FONT:
+         return "Menu Font";
+      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_CUSTOM:
+         return "Custom";
+      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_FLATUI:
+         return "FlatUI";
+      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_MONOCHROME:
+         return "Monochrome";
+      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_MONOCHROME_JAGGED:
+         return "Monochrome Jagged";
+      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_PIXEL:
+         return "Pixel";
+      case MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_RETROACTIVE:
+         return "RetroActive";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME:
+         return "Menu Color Theme";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_APPLE_GREEN:
+         return "Apple Green";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_DARK:
+         return "Dark";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_DARK_PURPLE:
+         return "Dark Purple";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_ELECTRIC_BLUE:
+         return "Electric Blue";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_GOLDEN:
+         return "Golden";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_LEGACY_RED:
+         return "Legacy Red";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_MIDNIGHT_BLUE:
+         return "Midnight Blue";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_PLAIN:
+         return "Plain";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_UNDERSEA:
+         return "Undersea";
+      case MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_VOLCANIC_RED:
+         return "Volcanic Red";
+      case MENU_ENUM_LABEL_VALUE_XMB_RIBBON_ENABLE:
+         return "Menu Shader Pipeline";
+      case MENU_ENUM_LABEL_VALUE_XMB_SCALE_FACTOR:
+         return "Menu Scale Factor";
+      case MENU_ENUM_LABEL_VALUE_XMB_SHADOWS_ENABLE:
+         return "Icon Shadows Enable";
+      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_HISTORY:
+         return "Show History Tab";
+      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_IMAGES:
+         return "Show Images Tab";
+      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_MUSIC:
+         return "Show Music Tab";
+      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_SETTINGS:
+         return "Show thiết lập Tab";
+      case MENU_ENUM_LABEL_VALUE_XMB_SHOW_VIDEO:
+         return "Show Video Tab";
+      case MENU_ENUM_LABEL_VALUE_XMB_THEME:
+         return "Menu Icon Theme";
+      case MENU_ENUM_LABEL_VALUE_YES:
+         return "Yes";
+      case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_TWO:
+         return "Shader Preset";
+      case MENU_ENUM_SUBLABEL_ADD_CONTENT_LIST:
+         return "Tải/quét nội dung và thêm vào bộ sưu tập.";
+      case MENU_ENUM_SUBLABEL_AUDIO_SETTINGS:
+         return "Điều chỉnh thiết lập cho âm thanh ra.";
+      case MENU_ENUM_SUBLABEL_BLUETOOTH_ENABLE:
+         return "Bật/tắt bluetooth.";
+      case MENU_ENUM_SUBLABEL_CONFIG_SAVE_ON_EXIT:
+         return "Lưu cấu hình khi thoát retroarch.";
+      case MENU_ENUM_SUBLABEL_CPU_CORES:
+         return "Số lượng lõi của CPU.";
+      case MENU_ENUM_SUBLABEL_FPS_SHOW:
+         return "Hiển thị tốc độ khung hình/giây trên màn hình.";
+      case MENU_ENUM_SUBLABEL_INPUT_HOTKEY_BINDS:
+         return "Đặt cấu hình thiết lập của hotkey.";
+      case MENU_ENUM_SUBLABEL_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
+         return "Kết hợp nút Gamepad để vào menu bật/tắt.";
+      case MENU_ENUM_SUBLABEL_INPUT_SETTINGS:
+         return "Điều chỉnh thiết lập cho joypads, bàn phím và chuột.";
+      case MENU_ENUM_SUBLABEL_INPUT_USER_BINDS:
+         return "Đặt cấu hình điều khiển cho người dùng này.";
+      case MENU_ENUM_SUBLABEL_LOG_VERBOSITY:
+         return "Enable or disable logging to the terminal.";
+      case MENU_ENUM_SUBLABEL_NETPLAY:
+         return "Tham gia hoặc làm máy chủ cho netplay.";
+      case MENU_ENUM_SUBLABEL_ONLINE_UPDATER:
+         return "Tải/cập nhật tiện ích và thành phần của RetroArch.";
+      case MENU_ENUM_SUBLABEL_SAMBA_ENABLE:
+         return "Bật/tắt chia sẻ thư mục trên mạng.";
+      case MENU_ENUM_SUBLABEL_SERVICES_SETTINGS:
+         return "Quản lý dịch vụ của hệ điều hành.";
+      case MENU_ENUM_SUBLABEL_SHOW_HIDDEN_FILES:
+         return "Hiện ra tập tin và thư mục ẩn trong trình duyệt tập tin.";
+      case MENU_ENUM_SUBLABEL_SSH_ENABLE:
+         return "Bật/tắt giao thức SSH.";
+      case MENU_ENUM_SUBLABEL_SUSPEND_SCREENSAVER_ENABLE:
+         return "Chặn tính năng screensaver (màn hình chờ).";
+      case MENU_ENUM_SUBLABEL_USER_LANGUAGE:
+         return "Thiết lập ngôn ngữ của giao diện .";
+      case MENU_ENUM_SUBLABEL_VIDEO_BLACK_FRAME_INSERTION:
+         return "Inserts a black frame inbetween frames. Useful for users of 120 Hz monitors who want to play 60 Hz material with eliminated ghosting.";
+      case MENU_ENUM_SUBLABEL_VIDEO_FRAME_DELAY:
+         return "Reduces latency at the cost of higher risk of video stuttering. Adds a delay after V-Sync (in ms).";
+      case MENU_ENUM_SUBLABEL_VIDEO_HARD_SYNC_FRAMES:
+         return "Sets how many frames the CPU can run ahead of the GPU when using 'Hard GPU Sync'.";
+      case MENU_ENUM_SUBLABEL_VIDEO_MAX_SWAPCHAIN_IMAGES:
+         return "Tells the video driver to explicitly use a specified buffering mode.";
+      case MENU_ENUM_SUBLABEL_VIDEO_MONITOR_INDEX:
+         return "Chọn màn hình hiển thị để sử dụng.";
+      case MENU_ENUM_SUBLABEL_VIDEO_REFRESH_RATE_AUTO:
+         return "The accurate estimated refresh rate of the monitor in Hz.";
+      case MENU_ENUM_SUBLABEL_VIDEO_SETTINGS:
+         return "Điều chỉnh thiết lập cho video ra.";
+      case MENU_ENUM_SUBLABEL_WIFI_SETTINGS:
+         return "Tìm mạng không dây và thiết lập kết nối.";
+      case MSG_APPENDED_DISK:
+         return "Appended disk";
+      case MSG_APPLICATION_DIR:
+         return "Application Dir";
+      case MSG_APPLYING_CHEAT:
+         return "Applying cheat changes.";
+      case MSG_APPLYING_SHADER:
+         return "Applying shader";
+      case MSG_AUDIO_MUTED:
+         return "Audio muted.";
+      case MSG_AUDIO_UNMUTED:
+         return "Audio unmuted.";
+      case MSG_AUTOCONFIG_FILE_ERROR_SAVING:
+         return "Tập tin Autoconfig bị lỗi khi lưu.";
+      case MSG_AUTOCONFIG_FILE_SAVED_SUCCESSFULLY:
+         return "Tập tin Autoconfig đã lưu thành công.";
+      case MSG_AUTOSAVE_FAILED:
+         return "Could not initialize autosave.";
+      case MSG_AUTO_SAVE_STATE_TO:
+         return "Auto save state to";
+      case MSG_BLOCKING_SRAM_OVERWRITE:
+         return "Blocking SRAM Overwrite";
+      case MSG_BRINGING_UP_COMMAND_INTERFACE_ON_PORT:
+         return "Đang đưa lên lệnh giao diện trên cổng";
+      case MSG_BYTES:
+         return "bytes";
+      case MSG_CANNOT_INFER_NEW_CONFIG_PATH:
+         return "Cannot infer new config path. Use current time.";
+      case MSG_CHEEVOS_HARDCORE_MODE_ENABLE:
+         return "Hardcore Mode Enabled: savestate & rewind were disabled.";
+      case MSG_COMPARING_WITH_KNOWN_MAGIC_NUMBERS:
+         return "Comparing with known magic numbers...";
+      case MSG_COMPILED_AGAINST_API:
+         return "Compiled against API";
+      case MSG_CONFIG_DIRECTORY_NOT_SET:
+         return "Config directory not set. Cannot save new config.";
+      case MSG_CONNECTED_TO:
+         return "Connected to";
+      case MSG_CONTENT_CRC32S_DIFFER:
+         return "Content CRC32s differ. Cannot use different games.";
+      case MSG_CONTENT_LOADING_SKIPPED_IMPLEMENTATION_WILL_DO_IT:
+         return "Content loading skipped. Implementation will tải it on its own.";
+      case MSG_CORE_DOES_NOT_SUPPORT_SAVESTATES:
+         return "Core does not support save states.";
+      case MSG_CORE_OPTIONS_FILE_CREATED_SUCCESSFULLY:
+         return "Core options file created successfully.";
+      case MSG_COULD_NOT_FIND_ANY_NEXT_DRIVER:
+         return "Could not find any next driver";
+      case MSG_COULD_NOT_FIND_COMPATIBLE_SYSTEM:
+         return "Could not find compatible system.";
+      case MSG_COULD_NOT_FIND_VALID_DATA_TRACK:
+         return "Could not find valid data track";
+      case MSG_COULD_NOT_OPEN_DATA_TRACK:
+         return "could not open data track";
+      case MSG_COULD_NOT_READ_CONTENT_FILE:
+         return "Could not read content file";
+      case MSG_COULD_NOT_READ_MOVIE_HEADER:
+         return "Could not read movie header.";
+      case MSG_COULD_NOT_READ_STATE_FROM_MOVIE:
+         return "Could not read state from movie.";
+      case MSG_CRC32_CHECKSUM_MISMATCH:
+         return "CRC32 checksum mismatch between content file and saved content checksum in replay file header; replay highly likely to desync on playback.";
+      case MSG_CUSTOM_TIMING_GIVEN:
+         return "Custom timing given";
+      case MSG_DECOMPRESSION_ALREADY_IN_PROGRESS:
+         return "Decompression already in progress.";
+      case MSG_DECOMPRESSION_FAILED:
+         return "Decompression failed.";
+      case MSG_DETECTED_VIEWPORT_OF:
+         return "Detected viewport of";
+      case MSG_DID_NOT_FIND_A_VALID_CONTENT_PATCH:
+         return "Did not find a valid content patch.";
+      case MSG_DISCONNECT_DEVICE_FROM_A_VALID_PORT:
+         return "Ngắt kết nối thiết bị từ cổng hợp lệ.";
+      case MSG_DISK_CLOSED:
+         return "Closed";
+      case MSG_DISK_EJECTED:
+         return "Ejected";
+      case MSG_DOWNLOADING:
+         return "Downloading";
+      case MSG_DOWNLOAD_FAILED:
+         return "Download failed";
+      case MSG_ERROR:
+         return "Error";
+      case MSG_ERROR_LIBRETRO_CORE_REQUIRES_CONTENT:
+         return "Libretro core requires content, but nothing was provided.";
+      case MSG_ERROR_LIBRETRO_CORE_REQUIRES_SPECIAL_CONTENT:
+         return "Libretro core requires special content, but none were provided.";
+      case MSG_ERROR_PARSING_ARGUMENTS:
+         return "Error parsing arguments.";
+      case MSG_ERROR_SAVING_CORE_OPTIONS_FILE:
+         return "Error saving core options file.";
+      case MSG_ERROR_SAVING_REMAP_FILE:
+         return "Error saving remap file.";
+      case MSG_ERROR_SAVING_SHADER_PRESET:
+         return "Error saving shader preset.";
+      case MSG_EXTERNAL_APPLICATION_DIR:
+         return "External Application Dir";
+      case MSG_EXTRACTING:
+         return "Extracting";
+      case MSG_EXTRACTING_FILE:
+         return "Extracting file";
+      case MSG_FAILED_SAVING_CONFIG_TO:
+         return "Failed saving config to";
+      case MSG_FAILED_TO:
+         return "Failed to";
+      case MSG_FAILED_TO_ACCEPT_INCOMING_SPECTATOR:
+         return "Failed to accept incoming spectator.";
+      case MSG_FAILED_TO_ALLOCATE_MEMORY_FOR_PATCHED_CONTENT:
+         return "Failed to allocate memory for patched content...";
+      case MSG_FAILED_TO_APPLY_SHADER:
+         return "Failed to apply shader.";
+      case MSG_FAILED_TO_BIND_SOCKET:
+         return "Failed to bind socket.";
+      case MSG_FAILED_TO_CREATE_THE_DIRECTORY:
+         return "Failed to create the directory.";
+      case MSG_FAILED_TO_EXTRACT_CONTENT_FROM_COMPRESSED_FILE:
+         return "Failed to extract content from compressed file";
+      case MSG_FAILED_TO_GET_NICKNAME_FROM_CLIENT:
+         return "Failed to get nickname from client.";
+      case MSG_FAILED_TO_LOAD:
+         return "Bị lỗi khi tải";
+      case MSG_FAILED_TO_LOAD_CONTENT:
+         return "Failed to tải content";
+      case MSG_FAILED_TO_LOAD_MOVIE_FILE:
+         return "Failed to tải movie file";
+      case MSG_FAILED_TO_LOAD_OVERLAY:
+         return "Failed to tải overlay.";
+      case MSG_FAILED_TO_LOAD_STATE:
+         return "Failed to tải state from";
+      case MSG_FAILED_TO_OPEN_LIBRETRO_CORE:
+         return "Failed to open libretro core";
+      case MSG_FAILED_TO_PATCH:
+         return "Failed to patch";
+      case MSG_FAILED_TO_RECEIVE_HEADER_FROM_CLIENT:
+         return "Failed to receive header from client.";
+      case MSG_FAILED_TO_RECEIVE_NICKNAME:
+         return "Failed to receive nickname.";
+      case MSG_FAILED_TO_RECEIVE_NICKNAME_FROM_HOST:
+         return "Failed to receive nickname from host.";
+      case MSG_FAILED_TO_RECEIVE_NICKNAME_SIZE_FROM_HOST:
+         return "Failed to receive nickname size from host.";
+      case MSG_FAILED_TO_RECEIVE_SRAM_DATA_FROM_HOST:
+         return "Failed to receive SRAM data from host.";
+      case MSG_FAILED_TO_REMOVE_DISK_FROM_TRAY:
+         return "Failed to remove disk from tray.";
+      case MSG_FAILED_TO_REMOVE_TEMPORARY_FILE:
+         return "Failed to remove temporary file";
+      case MSG_FAILED_TO_SAVE_SRAM:
+         return "Failed to save SRAM";
+      case MSG_FAILED_TO_SAVE_STATE_TO:
+         return "Failed to save state to";
+      case MSG_FAILED_TO_SEND_NICKNAME:
+         return "Failed to send nickname.";
+      case MSG_FAILED_TO_SEND_NICKNAME_SIZE:
+         return "Failed to send nickname size.";
+      case MSG_FAILED_TO_SEND_NICKNAME_TO_CLIENT:
+         return "Failed to send nickname to client.";
+      case MSG_FAILED_TO_SEND_NICKNAME_TO_HOST:
+         return "Failed to send nickname to host.";
+      case MSG_FAILED_TO_SEND_SRAM_DATA_TO_CLIENT:
+         return "Failed to send SRAM data to client.";
+      case MSG_FAILED_TO_START_AUDIO_DRIVER:
+         return "Bị lỗi khi chạy chương trình điều khiển âm thanh. Sẽ tiếp tục chạy và bỏ âm thanh.";
+      case MSG_FAILED_TO_START_MOVIE_RECORD:
+         return "Failed to start movie record.";
+      case MSG_FAILED_TO_START_RECORDING:
+         return "Failed to start recording.";
+      case MSG_FAILED_TO_TAKE_SCREENSHOT:
+         return "Bị lỗi khi chụp ảnh màn hình.";
+      case MSG_FAILED_TO_UNDO_LOAD_STATE:
+         return "Failed to undo tải state.";
+      case MSG_FAILED_TO_UNDO_SAVE_STATE:
+         return "Failed to undo save state.";
+      case MSG_FAILED_TO_UNMUTE_AUDIO:
+         return "Failed to unmute audio.";
+      case MSG_FATAL_ERROR_RECEIVED_IN:
+         return "Fatal error received in";
+      case MSG_FILE_NOT_FOUND:
+         return "Không tìm thấy tệp";
+      case MSG_FOUND_AUTO_SAVESTATE_IN:
+         return "Tìm thấy savestate tự đông trong";
+      case MSG_FOUND_DISK_LABEL:
+         return "Found disk label";
+      case MSG_FOUND_FIRST_DATA_TRACK_ON_FILE:
+         return "Found first data track on file";
+      case MSG_FOUND_LAST_STATE_SLOT:
+         return "Tiềm thấy state slot xài lần trước";
+      case MSG_FOUND_SHADER:
+         return "Found shader";
+      case MSG_FRAMES:
+         return "Frames";
+      case MSG_GAME_SPECIFIC_CORE_OPTIONS_FOUND_AT:
+         return "Per-Game Options: game-specific core options found at";
+      case MSG_GOT_INVALID_DISK_INDEX:
+         return "Got invalid disk index.";
+      case MSG_GRAB_MOUSE_STATE:
+         return "Grab mouse state";
+      case MSG_HW_RENDERED_MUST_USE_POSTSHADED_RECORDING:
+         return "Libretro core is hardware rendered. Must use post-shaded recording as well.";
+      case MSG_INFLATED_CHECKSUM_DID_NOT_MATCH_CRC32:
+         return "Inflated checksum did not match CRC32.";
+      case MSG_INPUT_CHEAT:
+         return "Input Cheat";
+      case MSG_INPUT_CHEAT_FILENAME:
+         return "Cheat Filename";
+      case MSG_INPUT_PRESET_FILENAME:
+         return "Preset Filename";
+      case MSG_INTERFACE:
+         return "Interface";
+      case MSG_INTERNAL_MEMORY:
+         return "Internal Memory";
+      case MSG_INVALID_NICKNAME_SIZE:
+         return "Invalid nickname size.";
+      case MSG_IN_BYTES:
+         return "in bytes";
+      case MSG_IN_GIGABYTES:
+         return "in gigabytes";
+      case MSG_IN_MEGABYTES:
+         return "in megabytes";
+      case MSG_LIBRETRO_ABI_BREAK:
+         return "is compiled against a different version of libretro than this libretro implementation.";
+      case MSG_LIBRETRO_FRONTEND:
+         return "Frontend for libretro";
+      case MSG_LOADED_STATE_FROM_SLOT:
+         return "Loaded state from slot";
+      case MSG_LOADING:
+         return "Đang tải";
+      case MSG_LOADING_CONTENT_FILE:
+         return "Loading content file";
+      case MSG_LOADING_HISTORY_FILE:
+         return "Đang nạp tập tin lịch sử";
+      case MSG_LOADING_STATE:
+         return "Đang tải state";
+      case MSG_MEMORY:
+         return "Memory";
+      case MSG_MOVIE_FILE_IS_NOT_A_VALID_BSV1_FILE:
+         return "Movie file is not a valid BSV1 file.";
+      case MSG_MOVIE_FORMAT_DIFFERENT_SERIALIZER_VERSION:
+         return "Movie format seems to have a different serializer version. Will most likely fail.";
+      case MSG_MOVIE_PLAYBACK_ENDED:
+         return "Movie playback ended.";
+      case MSG_MOVIE_RECORD_STOPPED:
+         return "Stopping movie record.";
+      case MSG_NETPLAY_FAILED:
+         return "Failed to initialize netplay.";
+      case MSG_NETPLAY_FAILED_MOVIE_PLAYBACK_HAS_STARTED:
+         return "Movie playback has started. Cannot start netplay.";
+      case MSG_NO_CONTENT_STARTING_DUMMY_CORE:
+         return "No content, starting dummy core.";
+      case MSG_NO_SAVE_STATE_HAS_BEEN_OVERWRITTEN_YET:
+         return "No save state has been overwritten yet.";
+      case MSG_NO_STATE_HAS_BEEN_LOADED_YET:
+         return "No state has been loaded yet.";
+      case MSG_OVERRIDES_ERROR_SAVING:
+         return "Error saving overrides.";
+      case MSG_OVERRIDES_SAVED_SUCCESSFULLY:
+         return "Overrides saved successfully.";
+      case MSG_PAUSED:
+         return "Paused.";
+      case MSG_PROGRAM:
+         return "RetroArch";
+      case MSG_READING_FIRST_DATA_TRACK:
+         return "Reading first data track...";
+      case MSG_RECEIVED:
+         return "received";
+      case MSG_RECORDING_TERMINATED_DUE_TO_RESIZE:
+         return "Recording terminated due to resize.";
+      case MSG_RECORDING_TO:
+         return "Recording to";
+      case MSG_REDIRECTING_CHEATFILE_TO:
+         return "Redirecting cheat file to";
+      case MSG_REDIRECTING_SAVEFILE_TO:
+         return "Redirecting save file to";
+      case MSG_REDIRECTING_SAVESTATE_TO:
+         return "Redirecting savestate to";
+      case MSG_REMAP_FILE_SAVED_SUCCESSFULLY:
+         return "Remap file saved successfully.";
+      case MSG_REMOVED_DISK_FROM_TRAY:
+         return "Removed disk from tray.";
+      case MSG_REMOVING_TEMPORARY_CONTENT_FILE:
+         return "Removing temporary content file";
+      case MSG_RESET:
+         return "Reset";
+      case MSG_RESTARTING_RECORDING_DUE_TO_DRIVER_REINIT:
+         return "Restarting recording due to driver reinit.";
+      case MSG_RESTORED_OLD_SAVE_STATE:
+         return "Restored old save state.";
+      case MSG_RESTORING_DEFAULT_SHADER_PRESET_TO:
+         return "Shaders: restoring default shader preset to";
+      case MSG_REVERTING_SAVEFILE_DIRECTORY_TO:
+         return "Reverting savefile directory to";
+      case MSG_REVERTING_SAVESTATE_DIRECTORY_TO:
+         return "Reverting savestate directory to";
+      case MSG_REWINDING:
+         return "Rewinding.";
+      case MSG_REWIND_INIT:
+         return "Initializing rewind buffer with size";
+      case MSG_REWIND_INIT_FAILED:
+         return "Failed to initialize rewind buffer. Rewinding will be disabled.";
+      case MSG_REWIND_INIT_FAILED_THREADED_AUDIO:
+         return "Implementation uses threaded audio. Cannot use rewind.";
+      case MSG_REWIND_REACHED_END:
+         return "Reached end of rewind buffer.";
+      case MSG_SAVED_NEW_CONFIG_TO:
+         return "Saved new config to";
+      case MSG_SAVED_STATE_TO_SLOT:
+         return "Saved state to slot";
+      case MSG_SAVED_SUCCESSFULLY_TO:
+         return "Saved successfully to";
+      case MSG_SAVING_RAM_TYPE:
+         return "Saving RAM type";
+      case MSG_SAVING_STATE:
+         return "Saving state";
+      case MSG_SCANNING:
+         return "Scanning";
+      case MSG_SCANNING_OF_DIRECTORY_FINISHED:
+         return "Scanning of directory finished";
+      case MSG_SENDING_COMMAND:
+         return "Sending command";
+      case MSG_SEVERAL_PATCHES_ARE_EXPLICITLY_DEFINED:
+         return "Several patches are explicitly defined, ignoring all...";
+      case MSG_SHADER_PRESET_SAVED_SUCCESSFULLY:
+         return "Shader preset saved successfully.";
+      case MSG_SKIPPING_SRAM_LOAD:
+         return "Skipping SRAM tải.";
+      case MSG_SLOW_MOTION:
+         return "Slow motion.";
+      case MSG_SLOW_MOTION_REWIND:
+         return "Slow motion rewind.";
+      case MSG_SRAM_WILL_NOT_BE_SAVED:
+         return "SRAM will not be saved.";
+      case MSG_STARTING_MOVIE_PLAYBACK:
+         return "Starting movie playback.";
+      case MSG_STARTING_MOVIE_RECORD_TO:
+         return "Starting movie record to";
+      case MSG_STATE_SIZE:
+         return "State size";
+      case MSG_STATE_SLOT:
+         return "State slot";
+      case MSG_TAKING_SCREENSHOT:
+         return "Taking screenshot.";
+      case MSG_TO:
+         return "to";
+      case MSG_UNDID_LOAD_STATE:
+         return "Undid Tải state.";
+      case MSG_UNDOING_SAVE_STATE:
+         return "Undoing save state";
+      case MSG_UNKNOWN:
+         return "Unknown";
+      case MSG_UNPAUSED:
+         return "Unpaused.";
+      case MSG_UNRECOGNIZED_COMMAND:
+         return "Unrecognized command";
+      case MSG_USING_CORE_NAME_FOR_NEW_CONFIG:
+         return "Using core name for new config.";
+      case MSG_USING_LIBRETRO_DUMMY_CORE_RECORDING_SKIPPED:
+         return "Using libretro dummy core. Skipping recording.";
+      case MSG_VALUE_CONNECT_DEVICE_FROM_A_VALID_PORT:
+         return "Kết nối thiết bị từ cổng hợp lệ.";
+      case MSG_VALUE_DISCONNECTING_DEVICE_FROM_PORT:
+         return "Đang ngắt kết nối thiết bị từ cổng";
+      case MSG_VALUE_REBOOTING:
+         return "Đang khởi động lại...";
+      case MSG_VALUE_SHUTTING_DOWN:
+         return "Đang tắt máy...";
+      case MSG_VERSION_OF_LIBRETRO_API:
+         return "Phiên bản của libretro API";
+      case MSG_VIEWPORT_SIZE_CALCULATION_FAILED:
+         return "Viewport size calculation failed! Will continue using raw data. This will probably not work right ...";
+      case MSG_VIRTUAL_DISK_TRAY:
+         return "virtual disk tray.";
       default:
 #if 0
          RARCH_LOG("Unimplemented: [%d]\n", msg);


### PR DESCRIPTION
I hope I did okay sorting all msg_hash_{LANG}.c. This should make things easier for others to find what they need to fix or to add missing labels by comparing files.

I also tried to sort those two files: msg_hash.c / msg_hash.h  and got lot of those...
```
intl/msg_hash_us.c: In function ‘menu_hash_to_str_us_label_enum’:
intl/msg_hash_us.c:3013:7: error: duplicate case value
       case MSG_WAITING_FOR_CLIENT:

intl/msg_hash_us.c:2973:7: error: previously used here
       case MSG_BRINGING_UP_COMMAND_INTERFACE_ON_PORT:
```
... so I won't be pushing those.