### PR TITLE
(x_ctx.c) Add workaround for i915 bug

### DIFF
--- a/gfx/drivers_context/x_ctx.c
+++ b/gfx/drivers_context/x_ctx.c
@@ -107,6 +107,7 @@ static void gfx_ctx_x_destroy_resources(gfx_ctx_x_data_t *x)
 #ifdef HAVE_OPENGL
             if (x->g_ctx)
             {
+               glXSwapBuffers(g_x11_dpy, x->g_glx_win);
                glFinish();
                glXMakeContextCurrent(g_x11_dpy, None, None, NULL);
 


### PR DESCRIPTION
On certain Intel systems using DRI2, xorg fails to destroy the old
window when toggling between windowed fullscreen and windowed mode.

A fix at the driver level is being worked on by the i915 developers:
https://bugs.freedesktop.org/show_bug.cgi?id=93844

Thanks to https://github.com/diegoviola for investigating the issue.

This fixes #3752