### PR TITLE
(WiiU) disabled log init and properly init the audio buffer with 0 on audio init

### DIFF
--- a/audio/drivers/wiiu_audio.c
+++ b/audio/drivers/wiiu_audio.c
@@ -98,18 +98,25 @@ static void* ax_audio_init(const char* device, unsigned rate, unsigned latency)
    }
    ax->buffer_l = malloc(AX_AUDIO_SIZE);
    ax->buffer_r = malloc(AX_AUDIO_SIZE);
+   memset(ax->buffer_l,0,AX_AUDIO_SIZE);
+   memset(ax->buffer_r,0,AX_AUDIO_SIZE);
+   DCFlushRange(ax->buffer_l,AX_AUDIO_SIZE);
+   DCFlushRange(ax->buffer_r,AX_AUDIO_SIZE);
+
    ax->offsets_l.data = ax->buffer_l;
    ax->offsets_l.currentOffset = 0;
    ax->offsets_l.loopOffset = 0;
    ax->offsets_l.endOffset = AX_AUDIO_COUNT;
    ax->offsets_l.loopingEnabled = AX_VOICE_LOOP_ENABLED;
    ax->offsets_l.dataType = AX_VOICE_FORMAT_LPCM16;
+
    ax->offsets_r.data = ax->buffer_r;
    ax->offsets_r.currentOffset = 0;
    ax->offsets_r.loopOffset = 0;
    ax->offsets_r.endOffset = AX_AUDIO_COUNT;
    ax->offsets_r.loopingEnabled = AX_VOICE_LOOP_ENABLED;
    ax->offsets_r.dataType = AX_VOICE_FORMAT_LPCM16;
+
    AXSetVoiceOffsets(ax->voice_l, &ax->offsets_l);
    AXSetVoiceOffsets(ax->voice_r, &ax->offsets_r);
 

--- a/frontend/drivers/platform_wiiu.c
+++ b/frontend/drivers/platform_wiiu.c
@@ -248,7 +248,9 @@ int __entry_menu(int argc, char **argv)
    InstallExceptionHandler();
 #endif
    socket_lib_init();
+#if 0
    log_init("10.42.0.1");
+#endif
    devoptab_list[STD_OUT] = &dotab_stdout;
    devoptab_list[STD_ERR] = &dotab_stdout;
    memoryInitialize();


### PR DESCRIPTION
starts retroarch much quicker and does not rape your ears anymore when switching games or adjusting the audio latency