### PR TITLE
Fix black boxes conspiracy

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -3287,9 +3287,13 @@ static int menu_displaylist_parse_playlists(
          continue;
 
       /* Need to preserve slash first time. */
-      path      = str_list->elems[i].data;
+      path = str_list->elems[i].data;
 
-      if (!strstr(path, file_path_str(FILE_PATH_LPL_EXTENSION)))
+      if (!strstr(path, file_path_str(FILE_PATH_LPL_EXTENSION)) ||
+         (strstr(path, file_path_str(FILE_PATH_CONTENT_HISTORY))) ||
+         (strstr(path, file_path_str(FILE_PATH_CONTENT_MUSIC_HISTORY))) ||
+         (strstr(path, file_path_str(FILE_PATH_CONTENT_VIDEO_HISTORY))) ||
+         (strstr(path, file_path_str(FILE_PATH_CONTENT_IMAGE_HISTORY))))
          continue;
 
       file_type = FILE_TYPE_PLAYLIST_COLLECTION;


### PR DESCRIPTION
Fixes https://github.com/libretro/RetroArch/issues/3858
Vindicates https://github.com/libretro/RetroArch/issues/3928 

It's apparent clear nobody tested this one.

You can still see black boxes conspiracy doing something like...
> $ for i in {A..Z}; do touch ~/.config/retroarch/playlists/"$i".lpl; done

The example playlists above likely will never go in there in real life scenario... but the content history playlists could be. In fact, I threw content history playlists in the playlists directory... together with the other playlists... not knowing it would cause black boxes and it have been what I'm trying to say for days. 
