### PR TITLE
Update black boxes conspiracy

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -3290,10 +3290,7 @@ static int menu_displaylist_parse_playlists(
       path = str_list->elems[i].data;
 
       if (!strstr(path, file_path_str(FILE_PATH_LPL_EXTENSION)) ||
-         (strstr(path, file_path_str(FILE_PATH_CONTENT_HISTORY))) ||
-         (strstr(path, file_path_str(FILE_PATH_CONTENT_MUSIC_HISTORY))) ||
-         (strstr(path, file_path_str(FILE_PATH_CONTENT_VIDEO_HISTORY))) ||
-         (strstr(path, file_path_str(FILE_PATH_CONTENT_IMAGE_HISTORY))))
+         ((strcasestr(path, "content") && strcasestr(path, "history"))))
          continue;
 
       file_type = FILE_TYPE_PLAYLIST_COLLECTION;


### PR DESCRIPTION
Final update. Tested with...
```
# Keep all played contents in the menu and from CLI directly for convenient quick loading.`
content_history_path = "~/.config/retroarch/playlists/content_history.lpl"
content_music_history_path = "~/.config/retroarch/playlists/content_music_history.lpl"
content_image_history_path = "~/.config/retroarch/playlists/content_image_history.lpl"
content_video_history_path = "~/.config/retroarch/playlists/ontent_video_history.lpl"
```
```
# Keep all played contents in the menu and from CLI directly for convenient quick loading.`
content_history_path = "~/.config/retroarch/playlists/Content - History.lpl"
content_music_history_path = "~/.config/retroarch/playlists/Content - Music - History.lpl"
content_image_history_path = "~/.config/retroarch/playlists/Content - Image - History.lpl"
content_video_history_path = "~/.config/retroarch/playlists/Content - Video - History.lpl"
```
```
# Keep all played contents in the menu and from CLI directly for convenient quick loading.`
content_history_path = "~/.config/retroarch/playlists/Content - History.lpl"
content_music_history_path = "~/.config/retroarch/playlists/Content - History - Music.lpl"
content_image_history_path = "~/.config/retroarch/playlists/Content - History - Image.lpl"
content_video_history_path = "~/.config/retroarch/playlists/Content - History - Video.lpl"
```
It is also possible to use `Content - Game - History.lpl` or `Content - History - Game.lpl` in  `content_history_path` if you wish to... as it is no longer conforming to hidden filenames (inside the playlists directory only). The files will need to contain: `content`, `history` & `.lpl`