### PR TITLE
improve cross-platform support for thumbnail filenames

### DIFF
--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -865,7 +865,7 @@ static void xmb_update_thumbnail_path(void *data, unsigned i)
    char *scrub_char_pointer = 0;
    tmp = strdup(entry.path);
    
-   while(scrub_char_pointer = strpbrk(tmp, "&*/:`<>?\|"))
+   while(scrub_char_pointer = strpbrk(tmp, "&*/:`<>?\\|"))
    {
       *scrub_char_pointer = '_';
    }

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -861,8 +861,17 @@ static void xmb_update_thumbnail_path(void *data, unsigned i)
    fill_pathname_join(xmb->thumbnail_file_path, xmb->thumbnail_file_path,
          xmb_thumbnails_ident(), sizeof(xmb->thumbnail_file_path));
 
-   tmp = string_replace_substring(entry.path, "/", "-");
-
+   tmp = string_replace_substring(entry.path, "&", "_");
+   tmp = string_replace_substring(entry.path, "\", "_");
+   tmp = string_replace_substring(entry.path, "/", "_");
+   tmp = string_replace_substring(entry.path, "?", "_");
+   tmp = string_replace_substring(entry.path, ":", "_");   
+   tmp = string_replace_substring(entry.path, "<", "_");
+   tmp = string_replace_substring(entry.path, ">", "_");
+   tmp = string_replace_substring(entry.path, ":", "_");   
+   tmp = string_replace_substring(entry.path, "*", "_");
+   tmp = string_replace_substring(entry.path, "|", "_");
+                                  
    if (tmp)
    {
       char tmp_new[PATH_MAX_LENGTH];

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -865,7 +865,7 @@ static void xmb_update_thumbnail_path(void *data, unsigned i)
     * http://datomatic.no-intro.org/stuff/The%20Official%20No-Intro%20Convention%20(20071030).zip
     * Replace these characters in the entry name with underscores
     */
-   char *scrub_char_pointer = 0;
+   char *scrub_char_pointer = NULL;
    tmp = strdup(entry.path);
    
    while((scrub_char_pointer = strpbrk(tmp, "&*/:`<>?\\|")))

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -862,16 +862,39 @@ static void xmb_update_thumbnail_path(void *data, unsigned i)
          xmb_thumbnails_ident(), sizeof(xmb->thumbnail_file_path));
 
    /* Scrub characters that are not cross-platform safe from 'display name' in playlist and replace with underscore */
-   tmp = string_replace_substring(entry.path, "&", "_");
-   tmp = string_replace_substring(entry.path, "\\", "_");
-   tmp = string_replace_substring(entry.path, "/", "_");
-   tmp = string_replace_substring(entry.path, "\?", "_");
-   tmp = string_replace_substring(entry.path, ":", "_");  
-   tmp = string_replace_substring(entry.path, ";", "_");
-   tmp = string_replace_substring(entry.path, "<", "_");
-   tmp = string_replace_substring(entry.path, ">", "_");
-   tmp = string_replace_substring(entry.path, "*", "_");
-   tmp = string_replace_substring(entry.path, "|", "_");
+   char *scrub_char_pointer = 0;
+   *tmp = *entry.path;
+   
+   while ((scrub_char_pointer = strchr (tmp, '&')) != NULL) {
+      *scrub_char_pointer = '_';
+   }
+   while ((scrub_char_pointer = strchr (tmp, '\\')) != NULL) {
+      *scrub_char_pointer = '_';
+   }
+   while ((scrub_char_pointer = strchr (tmp, '/')) != NULL) {
+      *scrub_char_pointer = '_';
+   }
+   while ((scrub_char_pointer = strchr (tmp, '?')) != NULL) {
+      *scrub_char_pointer = '_';
+   }
+   while ((scrub_char_pointer = strchr (tmp, ':')) != NULL) {
+      *scrub_char_pointer = '_';
+   }
+   while ((scrub_char_pointer = strchr (tmp, '`')) != NULL) {
+      *scrub_char_pointer = '_';
+   }
+   while ((scrub_char_pointer = strchr (tmp, '<')) != NULL) {
+      *scrub_char_pointer = '_';
+   }
+   while ((scrub_char_pointer = strchr (tmp, '>')) != NULL) {
+      *scrub_char_pointer = '_';
+   }
+   while ((scrub_char_pointer = strchr (tmp, '*')) != NULL) {
+      *scrub_char_pointer = '_';
+   }
+   while ((scrub_char_pointer = strchr (tmp, '_')) != NULL) {
+      *scrub_char_pointer = '_';
+   }
 
    /* Look for thumbnail file with the scrubbed filename */
    

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -861,16 +861,19 @@ static void xmb_update_thumbnail_path(void *data, unsigned i)
    fill_pathname_join(xmb->thumbnail_file_path, xmb->thumbnail_file_path,
          xmb_thumbnails_ident(), sizeof(xmb->thumbnail_file_path));
 
-   /* Scrub characters that are not cross-platform safe from 'display name' in playlist and replace with underscore */
+   /* Scrub characters that are not cross-platform and/or violate the No-Intro filename standard:
+    * http://datomatic.no-intro.org/stuff/The%20Official%20No-Intro%20Convention%20(20071030).zip
+    * Replace these characters in the entry name with underscores
+    */
    char *scrub_char_pointer = 0;
    tmp = strdup(entry.path);
    
-   while(scrub_char_pointer = strpbrk(tmp, "&*/:`<>?\\|"))
+   while((scrub_char_pointer = strpbrk(tmp, "&*/:`<>?\\|")))
    {
       *scrub_char_pointer = '_';
    }
 
-   /* Look for thumbnail file with the scrubbed filename */
+   /* Look for thumbnail file with this scrubbed filename */
   if (tmp)
    {
       char tmp_new[PATH_MAX_LENGTH];

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -863,36 +863,36 @@ static void xmb_update_thumbnail_path(void *data, unsigned i)
 
    /* Scrub characters that are not cross-platform safe from 'display name' in playlist and replace with underscore */
    char *scrub_char_pointer = 0;
-   *tmp = *entry.path;
+   tmp = strdup(entry.path);
    
-   while ((scrub_char_pointer = strchr (tmp, '&')) != NULL) {
+   while ((scrub_char_pointer = strchr(tmp, '&')) != NULL) {
       *scrub_char_pointer = '_';
    }
-   while ((scrub_char_pointer = strchr (tmp, '\\')) != NULL) {
+   while ((scrub_char_pointer = strchr(tmp, '\\')) != NULL) {
       *scrub_char_pointer = '_';
    }
-   while ((scrub_char_pointer = strchr (tmp, '/')) != NULL) {
+   while ((scrub_char_pointer = strchr(tmp, '/')) != NULL) {
       *scrub_char_pointer = '_';
    }
-   while ((scrub_char_pointer = strchr (tmp, '?')) != NULL) {
+   while ((scrub_char_pointer = strchr(tmp, '?')) != NULL) {
       *scrub_char_pointer = '_';
    }
-   while ((scrub_char_pointer = strchr (tmp, ':')) != NULL) {
+   while ((scrub_char_pointer = strchr(tmp, ':')) != NULL) {
       *scrub_char_pointer = '_';
    }
-   while ((scrub_char_pointer = strchr (tmp, '`')) != NULL) {
+   while ((scrub_char_pointer = strchr(tmp, '`')) != NULL) {
       *scrub_char_pointer = '_';
    }
-   while ((scrub_char_pointer = strchr (tmp, '<')) != NULL) {
+   while ((scrub_char_pointer = strchr(tmp, '<')) != NULL) {
       *scrub_char_pointer = '_';
    }
-   while ((scrub_char_pointer = strchr (tmp, '>')) != NULL) {
+   while ((scrub_char_pointer = strchr(tmp, '>')) != NULL) {
       *scrub_char_pointer = '_';
    }
-   while ((scrub_char_pointer = strchr (tmp, '*')) != NULL) {
+   while ((scrub_char_pointer = strchr(tmp, '*')) != NULL) {
       *scrub_char_pointer = '_';
    }
-   while ((scrub_char_pointer = strchr (tmp, '|')) != NULL) {
+   while ((scrub_char_pointer = strchr(tmp, '|')) != NULL) {
       *scrub_char_pointer = '_';
    }
 

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -866,7 +866,8 @@ static void xmb_update_thumbnail_path(void *data, unsigned i)
    tmp = string_replace_substring(entry.path, "\\", "_");
    tmp = string_replace_substring(entry.path, "/", "_");
    tmp = string_replace_substring(entry.path, "\?", "_");
-   tmp = string_replace_substring(entry.path, ":", "_");   
+   tmp = string_replace_substring(entry.path, ":", "_");  
+   tmp = string_replace_substring(entry.path, ";", "_");
    tmp = string_replace_substring(entry.path, "<", "_");
    tmp = string_replace_substring(entry.path, ">", "_");
    tmp = string_replace_substring(entry.path, "*", "_");

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -861,17 +861,19 @@ static void xmb_update_thumbnail_path(void *data, unsigned i)
    fill_pathname_join(xmb->thumbnail_file_path, xmb->thumbnail_file_path,
          xmb_thumbnails_ident(), sizeof(xmb->thumbnail_file_path));
 
+   /* Scrub characters that are not cross-platform safe from 'display name' in playlist and replace with underscore */
    tmp = string_replace_substring(entry.path, "&", "_");
-   tmp = string_replace_substring(entry.path, "\", "_");
+   tmp = string_replace_substring(entry.path, "\\", "_");
    tmp = string_replace_substring(entry.path, "/", "_");
-   tmp = string_replace_substring(entry.path, "?", "_");
+   tmp = string_replace_substring(entry.path, "\?", "_");
    tmp = string_replace_substring(entry.path, ":", "_");   
    tmp = string_replace_substring(entry.path, "<", "_");
    tmp = string_replace_substring(entry.path, ">", "_");
-   tmp = string_replace_substring(entry.path, ":", "_");   
    tmp = string_replace_substring(entry.path, "*", "_");
    tmp = string_replace_substring(entry.path, "|", "_");
-                                  
+
+   /* Look for thumbnail file with the scrubbed filename */
+   
    if (tmp)
    {
       char tmp_new[PATH_MAX_LENGTH];

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -892,7 +892,7 @@ static void xmb_update_thumbnail_path(void *data, unsigned i)
    while ((scrub_char_pointer = strchr (tmp, '*')) != NULL) {
       *scrub_char_pointer = '_';
    }
-   while ((scrub_char_pointer = strchr (tmp, '_')) != NULL) {
+   while ((scrub_char_pointer = strchr (tmp, '|')) != NULL) {
       *scrub_char_pointer = '_';
    }
 

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -865,40 +865,13 @@ static void xmb_update_thumbnail_path(void *data, unsigned i)
    char *scrub_char_pointer = 0;
    tmp = strdup(entry.path);
    
-   while ((scrub_char_pointer = strchr(tmp, '&')) != NULL) {
-      *scrub_char_pointer = '_';
-   }
-   while ((scrub_char_pointer = strchr(tmp, '\\')) != NULL) {
-      *scrub_char_pointer = '_';
-   }
-   while ((scrub_char_pointer = strchr(tmp, '/')) != NULL) {
-      *scrub_char_pointer = '_';
-   }
-   while ((scrub_char_pointer = strchr(tmp, '?')) != NULL) {
-      *scrub_char_pointer = '_';
-   }
-   while ((scrub_char_pointer = strchr(tmp, ':')) != NULL) {
-      *scrub_char_pointer = '_';
-   }
-   while ((scrub_char_pointer = strchr(tmp, '`')) != NULL) {
-      *scrub_char_pointer = '_';
-   }
-   while ((scrub_char_pointer = strchr(tmp, '<')) != NULL) {
-      *scrub_char_pointer = '_';
-   }
-   while ((scrub_char_pointer = strchr(tmp, '>')) != NULL) {
-      *scrub_char_pointer = '_';
-   }
-   while ((scrub_char_pointer = strchr(tmp, '*')) != NULL) {
-      *scrub_char_pointer = '_';
-   }
-   while ((scrub_char_pointer = strchr(tmp, '|')) != NULL) {
+   while(scrub_char_pointer = strpbrk(tmp, "&*/:`<>?\|"))
+   {
       *scrub_char_pointer = '_';
    }
 
    /* Look for thumbnail file with the scrubbed filename */
-   
-   if (tmp)
+  if (tmp)
    {
       char tmp_new[PATH_MAX_LENGTH];
 


### PR DESCRIPTION
Certain characters in filenames can cause problems for various filesystems. Because the game names which appear in playlists sometimes include these characters, some mechanism is needed in order to allow the playlist entry to be correlated with a thumbnail filename without causing problems for filesystems.

The intention of this PR is to continue to allow RetroArch playlists to display 'prohibited' characters ``& \ / ? : \` < > * |`` on the screen, while searching for matching thumbnail files with a 'sanitized' filename that replaces any of these problematic characters with an underscore. This step of the process is bolded in the flowchart below as #2 under 'Playlist display.'

I don't normally work in C -- this change is a hack job. It did look like string_replace_substring could handle being daisy-chained so I thought I'd see if this PR could help spark a productive conversation.

Playlist generation:
    1) Use hash values to match ROM files to known-good databases such as No-Intro. (exists)
    2) Create playlist using 'display names' from the known-good databases (exists)

Playlist display:
    1) Read display name from the playlist file (exists)
    **2) Transform characters that are not cross-platform friendly into underscores to determine thumb filename (this PR)**
    3) Look for a thumbnail file that matches this filename (exists)
    4) Display the thumbnail image (exists)