### PR TITLE
Fix parsing of connmanctl output

### DIFF
--- a/wifi/drivers/connmanctl.c
+++ b/wifi/drivers/connmanctl.c
@@ -140,7 +140,12 @@ static bool connmanctl_connect_ssid(unsigned i, const char* passphrase)
    const char *line = lines->elems[i].data;
 
    static struct string_list* list = NULL;
-   list = string_split(line, " ");
+   // connmanctl services outputs a 4 character prefixed lines, either whispace
+   // or an identifier. i.e.:
+   // $ connmanctl services
+   //     '*A0 SSID some_unique_id'
+   //     '    SSID some_another_unique_id'
+   list = string_split(line+4, " ");
    if(!list)
        return false;
 

--- a/wifi/drivers/connmanctl.c
+++ b/wifi/drivers/connmanctl.c
@@ -130,21 +130,32 @@ static bool connmanctl_ssid_is_online(unsigned i)
 static bool connmanctl_connect_ssid(unsigned i, const char* passphrase)
 {
    char ln[512] = {0};
-   char name[20] = {0};
+   char name[64] = {0};
    char service[128] = {0};
    char command[256] = {0};
    char settings_dir[PATH_MAX_LENGTH] = {0};
    char settings_path[PATH_MAX_LENGTH] = {0};
    FILE *command_file = NULL;
    FILE *settings_file = NULL;
-   FILE *serv_file = NULL;
-   union string_list_elem_attr attr;
    const char *line = lines->elems[i].data;
 
-   strlcpy(name, line+4, sizeof(name));
-   strlcpy(name, string_trim_whitespace(name), sizeof(name));
+   static struct string_list* list = NULL;
+   list = string_split(line, " ");
+   if(!list)
+       return false;
 
-   strlcpy(service, line+25, sizeof(service));
+   if (list->size == 0) {
+       string_list_free(list);
+       return false;
+   }
+
+   for (int i = 0; i < list->size-1; i++) {
+        strlcat(name, list->elems[i].data, sizeof(name));
+        strlcat(name, " ", sizeof(name));
+   }
+   strlcpy(service, list->elems[list->size-1].data, sizeof(service));
+
+   string_list_free(list);
 
    strlcat(settings_dir, LAKKA_CONNMAN_DIR, sizeof(settings_dir));
    strlcat(settings_dir, service, sizeof(settings_dir));


### PR DESCRIPTION
`connmanctl services` output is something like this:

```
Δ connmanctl services
    NetMASTER Uydunet-N4832 wifi_742f68cd1f13_4e65744d415354455220557964756e65742d4e34383332_managed_psk
    DIRECT-Dn-Android_d703 wifi_742f68cd1f13_4449524543542d446e2d416e64726f69645f64373033_managed_psk
    PS4-8E777390BB63     wifi_742f68cd1f13_5053342d384537373733393042423633_managed_psk
```

So, instead of assuming the SSID length, just split the lines by space
character, and treat the last item as the unique id.

Updates libretro/Lakka#538