### PR TITLE
Fix WiFi online detection

### DIFF
--- a/wifi/drivers/connmanctl.c
+++ b/wifi/drivers/connmanctl.c
@@ -102,7 +102,20 @@ static bool connmanctl_ssid_is_online(unsigned i)
    if (connman_counter == 60)
    {
       connman_counter = 0;
-      strlcpy(service, line+25, sizeof(service));
+
+      static struct string_list* list = NULL;
+      list = string_split(line, " ");
+      if (!list)
+         return false;
+
+      if (list->size == 0)
+      {
+         string_list_free(list);
+         return false;
+      }
+
+      strlcpy(service, list->elems[list->size-1].data, sizeof(service));
+      string_list_free(list);
 
       strlcat(command, "connmanctl services ", sizeof(command));
       strlcat(command, service, sizeof(command));
@@ -146,17 +159,19 @@ static bool connmanctl_connect_ssid(unsigned i, const char* passphrase)
    //     '*A0 SSID some_unique_id'
    //     '    SSID some_another_unique_id'
    list = string_split(line+4, " ");
-   if(!list)
-       return false;
+   if (!list)
+      return false;
 
-   if (list->size == 0) {
-       string_list_free(list);
-       return false;
+   if (list->size == 0)
+   {
+      string_list_free(list);
+      return false;
    }
 
-   for (int i = 0; i < list->size-1; i++) {
-        strlcat(name, list->elems[i].data, sizeof(name));
-        strlcat(name, " ", sizeof(name));
+   for (int i = 0; i < list->size-1; i++)
+   {
+      strlcat(name, list->elems[i].data, sizeof(name));
+      strlcat(name, " ", sizeof(name));
    }
    strlcpy(service, list->elems[list->size-1].data, sizeof(service));
 


### PR DESCRIPTION
Before this patch, RetroArch prints `Error 'services': Argument list too long` non-stop. The problem is same as #4038 

Apply the same behaviour to wifi online detection as well.