### PR TITLE
Change number of combo choices from 3 to 4

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -3999,7 +3999,7 @@ static bool setting_append_list(
                   parent_group,
                   general_write_handler,
                   general_read_handler);
-            menu_settings_list_current_add_range(list, list_info, 0, 3, 1, true, true);
+            menu_settings_list_current_add_range(list, list_info, 0, 4, 1, true, true);
 
             CONFIG_BOOL(
                   list, list_info,


### PR DESCRIPTION
This was causing the start+select combo to not actually be selectable.