### PR TITLE
Fix Netplay IPv6 support

### DIFF
--- a/libretro-common/net/net_compat.c
+++ b/libretro-common/net/net_compat.c
@@ -165,11 +165,14 @@ int getaddrinfo_retro(const char *node, const char *service,
    (void)in_addr;
    (void)info;
 
+   if (!hints->ai_family)
+   {
 #if defined(_WIN32) || defined(HAVE_SOCKET_LEGACY)
-   hints->ai_family    = AF_INET;
+      hints->ai_family    = AF_INET;
 #else
-   hints->ai_family    = AF_UNSPEC;
+      hints->ai_family    = AF_UNSPEC;
 #endif
+   }
 
 #ifdef HAVE_SOCKET_LEGACY
    info = (struct addrinfo*)calloc(1, sizeof(*info));


### PR DESCRIPTION
getaddrinfo_retro was forcing things into IPv4 mode, plus getaddrinfo seems to just prefer IPv4. This PR makes getaddrinf_retro not muss with the requested protocol family if one is requested, and makes Netplay use an IPv6 address correctly.