### PR TITLE
Make net_ifinfo's allocation behavior simpler and clearer

### DIFF
--- a/libretro-common/net/net_ifinfo.c
+++ b/libretro-common/net/net_ifinfo.c
@@ -65,7 +65,6 @@ void net_ifinfo_free(net_ifinfo_t *list)
       ptr->host = NULL;
    }
    free(list->entries);
-   free(list);
 }
 
 bool net_ifinfo_new(net_ifinfo_t *list)
@@ -81,6 +80,8 @@ bool net_ifinfo_new(net_ifinfo_t *list)
    adapter_addresses = (PIP_ADAPTER_ADDRESSES)malloc(size);
 
    rv = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, NULL, adapter_addresses, &size);
+
+   memset(list, 0, sizeof(net_ifinfo_t));
 
    if (rv != ERROR_SUCCESS)
       goto error;
@@ -121,6 +122,8 @@ bool net_ifinfo_new(net_ifinfo_t *list)
 #else
    struct ifaddrs *ifa     = NULL;
    struct ifaddrs *ifaddr  = NULL;
+
+   memset(list, 0, sizeof(net_ifinfo_t));
 
    if (getifaddrs(&ifaddr) == -1)
       goto error;

--- a/libretro-common/net/net_natt.c
+++ b/libretro-common/net/net_natt.c
@@ -163,7 +163,7 @@ bool natt_open_port(struct natt_status *status, struct sockaddr *addr, socklen_t
 
 bool natt_open_port_any(struct natt_status *status, uint16_t port, enum socket_protocol proto)
 {
-   struct net_ifinfo *list;
+   struct net_ifinfo list;
    bool ret = false;
    size_t i;
    struct addrinfo hints = {0}, *addr;
@@ -172,15 +172,13 @@ bool natt_open_port_any(struct natt_status *status, uint16_t port, enum socket_p
    sprintf(port_str, "%hu", port);
 
    /* get our interfaces */
-   if ((list = (struct net_ifinfo *) calloc(1, sizeof(struct net_ifinfo))) == NULL)
-       return false;
-   if (!net_ifinfo_new(list))
+   if (!net_ifinfo_new(&list))
       return false;
 
    /* loop through them */
-   for (i = 0; i < list->size; i++)
+   for (i = 0; i < list.size; i++)
    {
-      struct net_ifinfo_entry *entry = list->entries + i;
+      struct net_ifinfo_entry *entry = list.entries + i;
 
       /* ignore localhost */
       if (!strcmp(entry->host, "127.0.0.1") || !strcmp(entry->host, "::1"))
@@ -194,8 +192,7 @@ bool natt_open_port_any(struct natt_status *status, uint16_t port, enum socket_p
       }
    }
 
-   /* This really shouldn't free list, but does */
-   net_ifinfo_free(list);
+   net_ifinfo_free(&list);
 
    return ret;
 }

--- a/libretro-common/samples/net/net_ifinfo_test.c
+++ b/libretro-common/samples/net/net_ifinfo_test.c
@@ -29,21 +29,17 @@
 int main(int argc, const char *argv[])
 {
    unsigned k              = 0;
-   net_ifinfo_t *list = 
-      (net_ifinfo_t*)calloc(1, sizeof(*list));
+   net_ifinfo_t list;
 
-   if (!list)
+   if (!net_ifinfo_new(&list))
       return -1;
 
-   if (!net_ifinfo_new(list))
-      return -1;
-
-   for (k = 0; k < list->size; k++)
+   for (k = 0; k < list.size; k++)
    {
-      printf("%s:%s\n", list->entries[k].name, list->entries[k].host);
+      printf("%s:%s\n", list.entries[k].name, list.entries[k].host);
    }
 
-   net_ifinfo_free(list);
+   net_ifinfo_free(&list);
 
    return 0;
 }

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -430,16 +430,12 @@ static int menu_displaylist_parse_core_info(menu_displaylist_info_t *info)
 static int menu_displaylist_parse_network_info(menu_displaylist_info_t *info)
 {
    unsigned k              = 0;
-   net_ifinfo_t      *list =
-      (net_ifinfo_t*)calloc(1, sizeof(*list));
+   net_ifinfo_t      list;
 
-   if (!list)
+   if (!net_ifinfo_new(&list))
       return -1;
 
-   if (!net_ifinfo_new(list))
-      return -1;
-
-   for (k = 0; k < list->size; k++)
+   for (k = 0; k < list.size; k++)
    {
       char tmp[255];
 
@@ -447,12 +443,12 @@ static int menu_displaylist_parse_network_info(menu_displaylist_info_t *info)
 
       snprintf(tmp, sizeof(tmp), "%s (%s) : %s\n",
             msg_hash_to_str(MSG_INTERFACE),
-            list->entries[k].name, list->entries[k].host);
+            list.entries[k].name, list.entries[k].host);
       menu_entries_append_enum(info->list, tmp, "",
             MENU_ENUM_LABEL_NETWORK_INFO_ENTRY, MENU_SETTINGS_CORE_INFO_NONE, 0, 0);
    }
 
-   net_ifinfo_free(list);
+   net_ifinfo_free(&list);
    return 0;
 }
 #endif


### PR DESCRIPTION
net_ifinfo previously demanded that you allocate the list, but freed it itself. This made it so you couldn't e.g. stack allocate it, and also made it really unclear exactly when it is or isn't freed. Now allocation and freeing are both the caller's responsibility.