### PR TITLE
added menu_swap_ok_cancel on retroarch.cfg

### DIFF
--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -497,13 +497,14 @@
 # input_player1_r3_btn =
 
 # Menu buttons.
-# menu_ok_btn          =
-# menu_cancel_btn      =
 # menu_search_btn      =
 # menu_info_btn        =
 # menu_default_btn     =
 # menu_scroll_down_btn =
 # menu_scroll_up_btn   =
+
+# Swap buttons for OK/Cancel
+# menu_swap_ok_cancel = false
 
 # Axis for RetroArch D-Pad. 
 # Needs to be either '+' or '-' in the first character signaling either positive or negative direction of the axis, then the axis number. 


### PR DESCRIPTION
Removed the deprecated `menu_ok_btn` and `menu_cancel_btn`.
It's somehow related with this issue: https://github.com/libretro/RetroArch/issues/4111