### PR TITLE
Avoid unpredictable sublabel wrap

### DIFF
--- a/intl/msg_hash_eo.h
+++ b/intl/msg_hash_eo.h
@@ -1671,7 +1671,7 @@ MSG_HASH(MENU_ENUM_SUBLABEL_LOG_VERBOSITY,
 MSG_HASH(MENU_ENUM_SUBLABEL_NETPLAY,
       "Join or host a netplay session.")
 MSG_HASH(MENU_ENUM_SUBLABEL_INFORMATION_LIST_LIST,
-      "Display information for core, network, and system.\nDisplay manager for database and cursor.")
+      "Display information for core, network, and system. Display manager for database and cursor.")
 MSG_HASH(MENU_ENUM_SUBLABEL_ONLINE_UPDATER,
       "Download add-ons, components and contents for RetroArch.")
 MSG_HASH(MENU_ENUM_SUBLABEL_SAMBA_ENABLE,

--- a/intl/msg_hash_fr.h
+++ b/intl/msg_hash_fr.h
@@ -1639,7 +1639,7 @@ MSG_HASH(MENU_ENUM_SUBLABEL_LOG_VERBOSITY,
 MSG_HASH(MENU_ENUM_SUBLABEL_NETPLAY,
       "Join or host a netplay session.")
 MSG_HASH(MENU_ENUM_SUBLABEL_INFORMATION_LIST_LIST,
-      "Display information for core, network, and system.\nDisplay manager for database and cursor.")
+      "Display information for core, network, and system. Display manager for database and cursor.")
 MSG_HASH(MENU_ENUM_SUBLABEL_ONLINE_UPDATER,
       "Download add-ons, components and contents for RetroArch.")
 MSG_HASH(MENU_ENUM_SUBLABEL_SAMBA_ENABLE,

--- a/intl/msg_hash_nl.h
+++ b/intl/msg_hash_nl.h
@@ -1671,7 +1671,7 @@ MSG_HASH(MENU_ENUM_SUBLABEL_LOG_VERBOSITY,
 MSG_HASH(MENU_ENUM_SUBLABEL_NETPLAY,
       "Join or host a netplay session.")
 MSG_HASH(MENU_ENUM_SUBLABEL_INFORMATION_LIST_LIST,
-      "Display information for core, network, and system.\nDisplay manager for database and cursor.")
+      "Display information for core, network, and system. Display manager for database and cursor.")
 MSG_HASH(MENU_ENUM_SUBLABEL_ONLINE_UPDATER,
       "Download add-ons, components and contents for RetroArch.")
 MSG_HASH(MENU_ENUM_SUBLABEL_SAMBA_ENABLE,

--- a/intl/msg_hash_ru.h
+++ b/intl/msg_hash_ru.h
@@ -1667,7 +1667,7 @@ MSG_HASH(MENU_ENUM_SUBLABEL_LOG_VERBOSITY,
 MSG_HASH(MENU_ENUM_SUBLABEL_NETPLAY,
       "Join or host a netplay session.")
 MSG_HASH(MENU_ENUM_SUBLABEL_INFORMATION_LIST_LIST,
-      "Display information for core, network, and system.\nDisplay manager for database and cursor.")
+      "Display information for core, network, and system. Display manager for database and cursor.")
 MSG_HASH(MENU_ENUM_SUBLABEL_ONLINE_UPDATER,
       "Download add-ons, components and contents for RetroArch.")
 MSG_HASH(MENU_ENUM_SUBLABEL_SAMBA_ENABLE,

--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -1681,7 +1681,7 @@ MSG_HASH(MENU_ENUM_SUBLABEL_LOG_VERBOSITY,
 MSG_HASH(MENU_ENUM_SUBLABEL_NETPLAY,
       "Join or host a netplay session.")
 MSG_HASH(MENU_ENUM_SUBLABEL_INFORMATION_LIST_LIST,
-      "Display information for core, network, and system.\nDisplay manager for database and cursor.")
+      "Display information for core, network, and system. Display manager for database and cursor.")
 MSG_HASH(MENU_ENUM_SUBLABEL_ONLINE_UPDATER,
       "Download add-ons, components and contents for RetroArch.")
 MSG_HASH(MENU_ENUM_SUBLABEL_SAMBA_ENABLE,


### PR DESCRIPTION
Using `\n` in sublabel can lead to unpredictable sublabel behavior...
when used in different font and/or scale.

When I first made it...
```
Display information for core, network, and system.
Display manager for database and cursor.
```

It eventually somehow turns into...
```
Display information for core, network, and
system.
Display manager for database and cursor.
```

I tried something else only to get...

```
Display information for core, network, and system.

Display manager for database and cursor.
```
Best course of action? Avoid using `\n` to minimize unpredictable wrap.