### PR TITLE
delay_frames naming consistency

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -922,7 +922,7 @@ static int populate_settings_int(settings_t *settings, struct config_int_setting
    SETTING_INT("state_slot",                   (unsigned*)&settings->state_slot, false, 0 /* TODO */, false);
 #ifdef HAVE_NETWORKING
    SETTING_INT("netplay_ip_port",              &settings->netplay.port, false, 0 /* TODO */, false);
-   SETTING_INT("netplay_delay_frames",         &settings->netplay.sync_frames, true, 16, false);
+   SETTING_INT("netplay_delay_frames",         &settings->netplay.delay_frames, true, 16, false);
    SETTING_INT("netplay_check_frames",         &settings->netplay.check_frames, true, 30, false);
 #endif
 #ifdef HAVE_LANGEXTRA
@@ -1839,7 +1839,7 @@ static bool config_load_file(const char *path, bool set_defaults,
 
 #ifdef HAVE_NETWORKING
    if (!retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_NETPLAY_DELAY_FRAMES, NULL))
-      CONFIG_GET_INT_BASE(conf, settings, netplay.sync_frames, "netplay_delay_frames");
+      CONFIG_GET_INT_BASE(conf, settings, netplay.delay_frames, "netplay_delay_frames");
    if (!retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_NETPLAY_CHECK_FRAMES, NULL))
       CONFIG_GET_INT_BASE(conf, settings, netplay.check_frames, "netplay_check_frames");
    if (!retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_NETPLAY_IP_PORT, NULL))

--- a/configuration.h
+++ b/configuration.h
@@ -399,7 +399,7 @@ typedef struct settings
    {
       char server[255];
       unsigned port;
-      unsigned sync_frames;
+      unsigned delay_frames;
       unsigned check_frames;
       bool is_spectate;
       bool swap_input;

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -1717,7 +1717,7 @@ void general_write_handler(void *data)
       case MENU_ENUM_LABEL_NETPLAY_DELAY_FRAMES:
 #ifdef HAVE_NETWORKING
          {
-            bool val = (settings->netplay.sync_frames > 0);
+            bool val = (settings->netplay.delay_frames > 0);
             
             if (val)
                retroarch_override_setting_set(RARCH_OVERRIDE_SETTING_NETPLAY_DELAY_FRAMES, NULL);
@@ -5548,7 +5548,7 @@ static bool setting_append_list(
 
             CONFIG_UINT(
                   list, list_info,
-                  &settings->netplay.sync_frames,
+                  &settings->netplay.delay_frames,
                   MENU_ENUM_LABEL_NETPLAY_DELAY_FRAMES,
                   MENU_ENUM_LABEL_VALUE_NETPLAY_DELAY_FRAMES,
                   0,

--- a/network/netplay/netplay.h
+++ b/network/netplay/netplay.h
@@ -110,7 +110,7 @@ enum netplay_cmd_cfg
    /* input.netplay_client_swap_input */
    NETPLAY_CFG_SWAP_INPUT     = 0x0002, 
 
-   /* netplay.sync_frames */
+   /* netplay.delay_frames */
    NETPLAY_CFG_DELAY_FRAMES   = 0x0004, 
 
    /* For more than 2 players */
@@ -133,7 +133,7 @@ size_t audio_sample_batch_net(const int16_t *data, size_t frames);
  * netplay_new:
  * @server               : IP address of server.
  * @port                 : Port of server.
- * @frames               : Amount of lag frames.
+ * @delay_frames         : Amount of delay frames.
  * @check_frames         : Frequency with which to check CRCs.
  * @cb                   : Libretro callbacks.
  * @spectate             : If true, enable spectator mode.
@@ -147,7 +147,7 @@ size_t audio_sample_batch_net(const int16_t *data, size_t frames);
  * Returns: new netplay handle.
  **/
 netplay_t *netplay_new(const char *server,
-      uint16_t port, unsigned frames, unsigned check_frames,
+      uint16_t port, unsigned delay_frames, unsigned check_frames,
       const struct retro_callbacks *cb, bool spectate, bool nat_traversal,
       const char *nick, uint64_t quirks);
 

--- a/network/netplay/netplay_net.c
+++ b/network/netplay/netplay_net.c
@@ -101,7 +101,7 @@ static bool netplay_net_pre_frame(netplay_t *netplay)
          /* If the core can't serialize properly, we must stall for the
           * remote input on EVERY frame, because we can't recover */
          netplay->quirks |= NETPLAY_QUIRK_NO_SAVESTATES;
-         netplay->stall_frames = 0;
+         netplay->delay_frames = 0;
       }
 
       /* If we can't transmit savestates, we must stall until the client is ready */

--- a/network/netplay/netplay_private.h
+++ b/network/netplay/netplay_private.h
@@ -212,7 +212,7 @@ struct netplay
    bool remote_paused;
 
    /* And stalling */
-   uint32_t stall_frames;
+   uint32_t delay_frames;
    int stall;
    retro_time_t stall_time;
 

--- a/network/netplay/netplay_spectate.c
+++ b/network/netplay/netplay_spectate.c
@@ -243,7 +243,7 @@ static void netplay_spectate_post_frame(netplay_t *netplay)
       }
 
       /* If the server gets significantly ahead, skip to catch up */
-      if (netplay->self_frame_count + netplay->stall_frames <= netplay->read_frame_count)
+      if (netplay->self_frame_count + netplay->delay_frames <= netplay->read_frame_count)
       {
          /* "Replay" into the future */
          netplay->is_replay = true;

--- a/retroarch.c
+++ b/retroarch.c
@@ -339,7 +339,7 @@ static void retroarch_print_help(const char *arg0)
    puts("  -H, --host            Host netplay as user 1.");
    puts("  -C, --connect=HOST    Connect to netplay server as user 2.");
    puts("      --port=PORT       Port used to netplay. Default is 55435.");
-   puts("  -F, --frames=NUMBER   Sync frames when using netplay.");
+   puts("  -F, --frames=NUMBER   Delay frames when using netplay.");
    puts("      --check-frames=NUMBER\n"
         "                        Check frames when using netplay.");
    puts("      --spectate        Connect to netplay server as spectator.");
@@ -708,7 +708,7 @@ static void retroarch_parse_input(int argc, char *argv[])
             break;
 
          case 'F':
-            settings->netplay.sync_frames = strtol(optarg, NULL, 0);
+            settings->netplay.delay_frames = strtol(optarg, NULL, 0);
             retroarch_override_setting_set(
                   RARCH_OVERRIDE_SETTING_NETPLAY_DELAY_FRAMES, NULL);
             break;


### PR DESCRIPTION
As has come up in discussion before, delay_frames is confusing, in part because of the names: In various parts of RetroArch, the same value was called delay frames, lag frames, sync frames and stall frames. This patch simply unifies all of the various inconsistent names of delay_frames into a single name, delay_frames, which is the name used in the configuration file.