### PR TITLE
inet_ntoa missing on Vita

### DIFF
--- a/network/netplay/netplay.c
+++ b/network/netplay/netplay.c
@@ -1110,10 +1110,7 @@ static void announce_nat_traversal(netplay_t *netplay)
 #else
    if (netplay->nat_traversal_state.have_inet4)
    {
-      strncpy(host,
-         inet_ntoa(netplay->nat_traversal_state.ext_inet4_addr.sin_addr),
-         PATH_MAX_LENGTH);
-      host[PATH_MAX_LENGTH-1] = '\0';
+      host[0] = '\0';
       snprintf(port, 6, "%hu",
          ntohs(netplay->nat_traversal_state.ext_inet4_addr.sin_port));
       port[5] = '\0';


### PR DESCRIPTION
It's hard to know exactly how lacking SOCKET_LEGACY is, but evidently Vita doesn't support inet_ntoa, so I guess the poor SOCKET_LEGACY bastards don't get to know what their public IP address is.