### PR TITLE
Correctly check errors if preset cannot be found.

### DIFF
--- a/gfx/drivers_shader/shader_vulkan.cpp
+++ b/gfx/drivers_shader/shader_vulkan.cpp
@@ -2851,7 +2851,7 @@ vulkan_filter_chain_t *vulkan_filter_chain_create_from_preset(
       return nullptr;
 
    unique_ptr<config_file_t, ConfigDeleter> conf{ config_file_new(path) };
-   if (!path)
+   if (!conf)
       return nullptr;
 
    if (!video_shader_read_conf_cgp(conf.get(), shader.get()))


### PR DESCRIPTION
Should fix https://github.com/libretro/RetroArch/issues/4136