### PR TITLE
review: make preset loading more robust

### DIFF
--- a/gfx/video_shader_parse.c
+++ b/gfx/video_shader_parse.c
@@ -151,14 +151,11 @@ static bool video_shader_parse_pass(config_file_t *conf,
 
    strlcpy(tmp_path, tmp_str, sizeof(tmp_path));
    path_resolve_realpath(tmp_path, sizeof(tmp_path));
-   RFILE *file = filestream_open(tmp_path, RFILE_MODE_READ_TEXT, -1);
 
-   if (!file)
+   if (!path_file_exists(tmp_path))
       strlcpy(pass->source.path, tmp_str, sizeof(pass->source.path));
    else
       strlcpy(pass->source.path, tmp_path, sizeof(pass->source.path));
-
-   filestream_close(file);
 
    /* Smooth */
    snprintf(filter_name_buf, sizeof(filter_name_buf), "filter_linear%u", i);
@@ -362,13 +359,12 @@ static bool video_shader_parse_textures(config_file_t *conf,
 
       strlcpy(tmp_path, shader->lut[shader->luts].path, sizeof(tmp_path));
       path_resolve_realpath(tmp_path, sizeof(tmp_path));
-      RFILE *file = filestream_open(tmp_path, RFILE_MODE_READ_TEXT, -1);
-      if (file)
+
+      if (path_file_exists(tmp_path))
       {
          strlcpy(shader->lut[shader->luts].path, 
             tmp_path, sizeof(shader->lut[shader->luts].path));
       }
-      filestream_close(file);
 
       strlcpy(shader->lut[shader->luts].id, id,
             sizeof(shader->lut[shader->luts].id));

--- a/gfx/video_shader_parse.c
+++ b/gfx/video_shader_parse.c
@@ -149,7 +149,7 @@ static bool video_shader_parse_pass(config_file_t *conf,
    }
 
    strlcpy(pass->source.path, tmp_str, sizeof(pass->source.path));
-   
+
    /* Smooth */
    snprintf(filter_name_buf, sizeof(filter_name_buf), "filter_linear%u", i);
 
@@ -842,12 +842,17 @@ void video_shader_write_conf_cgp(config_file_t *conf,
    for (i = 0; i < shader->passes; i++)
    {
       char key[64];
+      char tmp[PATH_MAX_LENGTH];
       const struct video_shader_pass *pass = &shader->pass[i];
 
       key[0] = '\0';
 
       snprintf(key, sizeof(key), "shader%u", i);
-      config_set_string(conf, key, pass->source.path);
+      strlcpy(tmp, pass->source.path, sizeof(tmp));
+
+      if (!path_is_absolute(tmp))
+         path_resolve_realpath(tmp, sizeof(tmp));
+      config_set_string(conf, key, tmp);
 
       if (pass->filter != RARCH_FILTER_UNSPEC)
       {


### PR DESCRIPTION
This works around this:
https://github.com/libretro/RetroArch/issues/4153

We don't use relative paths by default in any platforms but windows so it's not really problematic and this won't change anything for any other platform.