### PR TITLE
Suppress a warning due to weird declarations on Windows

### DIFF
--- a/network/netplay/netplay.c
+++ b/network/netplay/netplay.c
@@ -105,7 +105,7 @@ static int init_tcp_connection(const struct addrinfo *res,
       int on = 0;
       if (res->ai_family == AF_INET6)
       {
-         if (setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &on, sizeof(on)) < 0)
+         if (setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, (void*)&on, sizeof(on)) < 0)
             RARCH_WARN("Failed to listen on both IPv6 and IPv4\n");
       }
 #endif


### PR DESCRIPTION
setsockopt's function declaration on Windows was written by a moron. Shocking, I know.