### PR TITLE
cheevos.c: avoid excessive login error information

### DIFF
--- a/cheevos.c
+++ b/cheevos.c
@@ -1865,9 +1865,6 @@ static int cheevos_login(retro_time_t *timeout)
 
    runloop_msg_queue_push("Retro Achievements login error.",
          0, 5 * 60, false);
-   runloop_msg_queue_push(
-         "Please make sure your account information is correct.",
-         0, 5 * 60, false);
    RARCH_ERR("CHEEVOS error getting user token.\n");
    return -1;
 }


### PR DESCRIPTION
A login error can happen for several reasons. So the message "Please make sure your account information is correct." is a bit excessive. I think "Retro Achievements login error." is enough.

I was frustrated when received this message, went to check my configs and saw that everything was right.