### PR TITLE
Fixes a bug where jack audio device setting would be clamped down to …

### DIFF
--- a/audio/drivers/jack.c
+++ b/audio/drivers/jack.c
@@ -103,10 +103,12 @@ static void shutdown_cb(void *data)
 static int parse_ports(char **dest_ports, const char **jports)
 {
    int i;
-   char           *save = NULL;
+   char           *save = NULL, *audio_device_cpy;
    int           parsed = 0;
    settings_t *settings = config_get_ptr();
-   const char      *con = strtok_r(settings->audio.device, ",", &save);
+
+   audio_device_cpy = strdup(settings->audio.device);
+   const char      *con = strtok_r(audio_device_cpy, ",", &save);
 
    if (con)
       dest_ports[parsed++] = strdup(con);
@@ -117,6 +119,7 @@ static int parse_ports(char **dest_ports, const char **jports)
    for (i = parsed; i < 2; i++)
       dest_ports[i] = strdup(jports[i]);
 
+   free(audio_device_cpy);
    return 2;
 }
 


### PR DESCRIPTION
…only one channel. Caused by a misuse of strtok.