### PR TITLE
Make video_threaded=false the default on Android

### DIFF
--- a/frontend/drivers/platform_linux.c
+++ b/frontend/drivers/platform_linux.c
@@ -1625,14 +1625,11 @@ static void frontend_linux_get_env(int *argc,
    frontend_android_get_name(device_model, sizeof(device_model));
    system_property_get("getprop", "ro.product.id", device_id);
 
-   g_defaults.settings.video_threaded_enable = true;
-
    /* Set automatic default values per device */
    if (device_is_xperia_play(device_model))
    {
       g_defaults.settings.out_latency = 128;
       g_defaults.settings.video_refresh_rate = 59.19132938771038;
-      g_defaults.settings.video_threaded_enable = false;
    }
    else if (strstr(device_model, "GAMEMID_BT"))
       g_defaults.settings.out_latency = 160;


### PR DESCRIPTION
I'd like to maybe hear some comments on this (maybe as to why this was configured like this in the first place)

With the continued growth of GL/Vulkan based emulators, I think it would be nice to have this setting set to false (which is the default on other platforms). It doesn't do anything for GL/Vulkans renderers except cause latency.

As an alternative, perhaps if GL/Vulkan rendering is happening then this setting could be ignored/disabled altogether? (on all platforms) I thought of that as I was typing this, maybe that is the better solution?