### PR TITLE
Use glTexStorage2D for FBO textures

### DIFF
--- a/gfx/drivers/gl.c
+++ b/gfx/drivers/gl.c
@@ -606,7 +606,12 @@ static void gl_init_textures_reference(gl_t *gl, unsigned i,
    if (gl->egl_images)
       return;
 
-   glTexImage2D(GL_TEXTURE_2D,
+#ifndef HAVE_OPENGLES2
+   if (gl_check_capability(GL_CAPS_TEX_STORAGE))
+      glTexStorage2D(GL_TEXTURE_2D, 1, internal_fmt, gl->tex_w, gl->tex_h);
+   else
+#endif
+      glTexImage2D(GL_TEXTURE_2D,
          0, internal_fmt, gl->tex_w, gl->tex_h, 0, texture_type,
          texture_fmt, gl->empty_buf ? gl->empty_buf : NULL);
 #endif

--- a/libretro-common/gfx/gl_capabilities.c
+++ b/libretro-common/gfx/gl_capabilities.c
@@ -306,6 +306,15 @@ bool gl_check_capability(enum gl_capability_enum enum_idx)
          return true;
 #endif
          break;
+      case GL_CAPS_TEX_STORAGE:
+#ifdef HAVE_OPENGLES
+         if (major >= 3)
+            return true;
+#else
+         if (gl_query_extension("ARB_texture_storage"))
+            return true;
+#endif
+         break;
       case GL_CAPS_NONE:
       default:
          break;

--- a/libretro-common/include/gfx/gl_capabilities.h
+++ b/libretro-common/include/gfx/gl_capabilities.h
@@ -44,7 +44,8 @@ enum gl_capability_enum
    GL_CAPS_SRGB_FBO_ES3,
    GL_CAPS_FP_FBO,
    GL_CAPS_BGRA8888,
-   GL_CAPS_GLES3_SUPPORTED
+   GL_CAPS_GLES3_SUPPORTED,
+   GL_CAPS_TEX_STORAGE
 };
 
 bool gl_check_error(char **error_string);


### PR DESCRIPTION
I've tested this, but it would be worth testing whatever triggers ```gl_recreate_fbo()```, I'm not sure how to trigger that action. glTexStorage2D is supposd to provide better peformance than glTexImage2D.

From the Adreno developer guide:

> The new glTexStorage* entry-points make a texture immutable.

> Immutable textures do not have a specific use case. Instead, they should be considered a means of
reducing the load on the driver, which often translates to a better rendering performance.
On Adreno platforms, the use of immutable textures has a major performance advantage. Always
use immutable textures and avoid all mutable textures