### PR TITLE
NAT traversal also needs to avoid IPv6 with SOCKET_LEGACY

### DIFF
--- a/libretro-common/include/net/net_natt.h
+++ b/libretro-common/include/net/net_natt.h
@@ -45,7 +45,7 @@ struct natt_status {
    /** True if we've resolved an external IPv6 address */
    bool have_inet6;
 
-#ifdef AF_INET6
+#if defined(AF_INET6) && !defined(HAVE_SOCKET_LEGACY)
    /** External IPv6 address */
    struct sockaddr_in6 ext_inet6_addr;
 #endif

--- a/libretro-common/net/net_natt.c
+++ b/libretro-common/net/net_natt.c
@@ -141,7 +141,7 @@ bool natt_open_port(struct natt_status *status, struct sockaddr *addr, socklen_t
       status->have_inet4 = true;
       status->ext_inet4_addr = *((struct sockaddr_in *) ext_addrinfo->ai_addr);
    }
-#ifdef AF_INET6
+#if defined(AF_INET6) && !defined(HAVE_SOCKET_LEGACY)
    else if (ext_addrinfo->ai_family == AF_INET6 &&
             ext_addrinfo->ai_addrlen >= sizeof(struct sockaddr_in6))
    {


### PR DESCRIPTION
Fixes left-over bug from #4203. I forgot the same changes needed to be made to the NAT traversal code, not just Netplay.