### PR TITLE
Show useful messages to RetroAchievements user

### DIFF
--- a/cheevos.c
+++ b/cheevos.c
@@ -1861,7 +1861,7 @@ static int cheevos_login(retro_time_t *timeout)
 
       if (!res)
       {
-         if(verbosity_is_enabled())
+         if(settings->video.msg_verbosity)
          {
             char msg[256];
             snprintf(msg, sizeof(msg), "RetroAchievements: logged in as \"%s\".",
@@ -2690,7 +2690,7 @@ found:
          free((void*)json);
          cheevos_loaded = true;
          
-         if(verbosity_is_enabled())
+         if(settings->video.msg_verbosity)
          {
             int number_of_cheevos        = cheevos_locals.core.count;
             const cheevo_t* cheevo       = cheevos_locals.core.cheevos;

--- a/cheevos.c
+++ b/cheevos.c
@@ -1860,7 +1860,15 @@ static int cheevos_login(retro_time_t *timeout)
       free((void*)json);
 
       if (!res)
+       {
+         char msg[256];
+         snprintf(msg, sizeof(msg), "RetroAchievements: logged in as \"%s\".",
+            username);
+         msg[sizeof(msg) - 1] = 0;
+         runloop_msg_queue_push(msg, 0, 3 * 60, false);
+         RARCH_LOG("CHEEVOS %s\n", msg);
          return 0;
+      }
    }
 
    runloop_msg_queue_push("Retro Achievements login error.",

--- a/cheevos.c
+++ b/cheevos.c
@@ -2682,9 +2682,30 @@ found:
    {
       if (!cheevos_parse(json))
       {
+         int number_of_cheevos        = cheevos_locals.core.count;
+         const cheevo_t* cheevo       = cheevos_locals.core.cheevos;
+         const cheevo_t* end          = cheevo + number_of_cheevos;
+         int number_of_unlocked       = 0;
+         int mode;
+         char msg[256];
+
          cheevos_deactivate_unlocks(game_id, &timeout);
          free((void*)json);
          cheevos_loaded = true;
+
+         if(settings->cheevos.hardcore_mode_enable)
+            mode = CHEEVOS_ACTIVE_HARDCORE;
+         else
+            mode = CHEEVOS_ACTIVE_SOFTCORE;
+
+         for(; cheevo < end; cheevo++)
+            if(cheevo->active & mode)
+               number_of_unlocked++;
+
+         snprintf(msg, sizeof(msg), "You have %d of %d achievements unlocked.",
+            number_of_unlocked, number_of_cheevos);
+         msg[sizeof(msg) - 1] = 0;
+         runloop_msg_queue_push(msg, 0, 5 * 60, false);
 
          cheevos_make_playing_url(game_id, url, sizeof(url));
          task_push_http_transfer(url, true, NULL,

--- a/cheevos.c
+++ b/cheevos.c
@@ -1860,13 +1860,17 @@ static int cheevos_login(retro_time_t *timeout)
       free((void*)json);
 
       if (!res)
-       {
-         char msg[256];
-         snprintf(msg, sizeof(msg), "RetroAchievements: logged in as \"%s\".",
-            username);
-         msg[sizeof(msg) - 1] = 0;
-         runloop_msg_queue_push(msg, 0, 3 * 60, false);
-         RARCH_LOG("CHEEVOS %s\n", msg);
+      {
+         if(verbosity_is_enabled())
+         {
+            char msg[256];
+            snprintf(msg, sizeof(msg), "RetroAchievements: logged in as \"%s\".",
+               username);
+            msg[sizeof(msg) - 1] = 0;
+            runloop_msg_queue_push(msg, 0, 3 * 60, false);
+            RARCH_LOG("CHEEVOS %s\n", msg);
+         }
+
          return 0;
       }
    }
@@ -2682,31 +2686,34 @@ found:
    {
       if (!cheevos_parse(json))
       {
-         int number_of_cheevos        = cheevos_locals.core.count;
-         const cheevo_t* cheevo       = cheevos_locals.core.cheevos;
-         const cheevo_t* end          = cheevo + number_of_cheevos;
-         int number_of_unlocked       = 0;
-         int mode;
-         char msg[256];
-
          cheevos_deactivate_unlocks(game_id, &timeout);
          free((void*)json);
          cheevos_loaded = true;
+         
+         if(verbosity_is_enabled())
+         {
+            int number_of_cheevos        = cheevos_locals.core.count;
+            const cheevo_t* cheevo       = cheevos_locals.core.cheevos;
+            const cheevo_t* end          = cheevo + number_of_cheevos;
+            int number_of_unlocked       = 0;
+            int mode;
+            char msg[256];
 
-         if(settings->cheevos.hardcore_mode_enable)
-            mode = CHEEVOS_ACTIVE_HARDCORE;
-         else
-            mode = CHEEVOS_ACTIVE_SOFTCORE;
+            if(settings->cheevos.hardcore_mode_enable)
+               mode = CHEEVOS_ACTIVE_HARDCORE;
+            else
+               mode = CHEEVOS_ACTIVE_SOFTCORE;
 
-         for(; cheevo < end; cheevo++)
-            if(cheevo->active & mode)
-               number_of_unlocked++;
+            for(; cheevo < end; cheevo++)
+               if(cheevo->active & mode)
+                  number_of_unlocked++;
 
-         snprintf(msg, sizeof(msg), "You have %d of %d achievements unlocked.",
-            number_of_unlocked, number_of_cheevos);
-         msg[sizeof(msg) - 1] = 0;
-         runloop_msg_queue_push(msg, 0, 5 * 60, false);
-
+            snprintf(msg, sizeof(msg), "You have %d of %d achievements unlocked.",
+               number_of_unlocked, number_of_cheevos);
+            msg[sizeof(msg) - 1] = 0;
+            runloop_msg_queue_push(msg, 0, 5 * 60, false);
+         }
+         
          cheevos_make_playing_url(game_id, url, sizeof(url));
          task_push_http_transfer(url, true, NULL,
                cheevos_playing, (void*)(uintptr_t)game_id);

--- a/configuration.c
+++ b/configuration.c
@@ -760,6 +760,7 @@ static int populate_settings_bool(settings_t *settings, struct config_bool_setti
    SETTING_BOOL("audio_mute_enable",             &settings->audio.mute_enable, true, false, false);
    SETTING_BOOL("location_allow",                &settings->location.allow, true, false, false);
    SETTING_BOOL("video_font_enable",             &settings->video.font_enable, true, font_enable, false);
+   SETTING_BOOL("video_message_verbosity",       &settings->video.msg_verbosity, true, false, false);
    SETTING_BOOL("core_updater_auto_extract_archive", &settings->network.buildbot_auto_extract_archive, true, true, false);
    SETTING_BOOL("camera_allow",                  &settings->camera.allow, true, false, false);
 #if defined(VITA)

--- a/configuration.h
+++ b/configuration.h
@@ -89,6 +89,7 @@ typedef struct settings
 
       float font_size;
       bool font_enable;
+      bool msg_verbosity;
       float msg_pos_x;
       float msg_pos_y;
       float msg_color_r;

--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -245,6 +245,9 @@
 # Enable usage of OSD messages.
 # video_font_enable = true
 
+# Enable verbose mode for OSD messages.
+# video_message_verbosity = false
+
 # Offset for where messages will be placed on screen. Values are in range 0.0 to 1.0 for both x and y values.
 # [0.0, 0.0] maps to the lower left corner of the screen.
 # video_message_pos_x = 0.05


### PR DESCRIPTION
When launching a game with RetroAchievements enabled, show messages like the following:

`RetroAchievements: logged in as "RAUser"`

`You have 3 of 20 achievements unlocked`

Obs.: the number of achievements unlocked is counted according to hardcore mode being enabled or not.

**UPDATE:**
In the last commit I tried to satisfy these requirements/suggestions:

@twinaphex 
>  I can accept this as an 'achievement debug' setting, but it should not be enabled by default at least.

@leiradel 
> RetroArch has too many options already. I'd go with a unique global setting to control the verboseness of everything though.

I added the `video_message_verbosity` option (default is false). I chose this name because it's similar to other OSD-related configs (`video_message_pos_*`, `video_message_color_*`, etc). It was added in configuration.c, `settings_t.video` and named `msg_verbosity` (again, to match the `msg_pos_*`, etc.).

The RetroAchievements messages I'm introducing in this PR will only be shown if `settings->video.msg_verbosity` is true (`video_message_verbosity = true` on retroarch.cfg).