### PR TITLE
added stdlib.h - fixes warning with free / system

### DIFF
--- a/gfx/drivers_context/mali_fbdev_ctx.c
+++ b/gfx/drivers_context/mali_fbdev_ctx.c
@@ -13,6 +13,7 @@
  *  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <stdlib.h>
 #include <unistd.h>
 
 #include <sys/ioctl.h>


### PR DESCRIPTION
fixes these warnings

```
**gfx/drivers_context/mali_fbdev_ctx.c: In function ‘gfx_ctx_mali_fbdev_destroy’:
gfx/drivers_context/mali_fbdev_ctx.c:68:8: warning: implicit declaration of function ‘free’ [-Wimplicit-function-declaration]
        free(mali);
        ^
gfx/drivers_context/mali_fbdev_ctx.c:68:8: warning: incompatible implicit declaration of built-in function ‘free’
gfx/drivers_context/mali_fbdev_ctx.c:68:8: note: include ‘<stdlib.h>’ or provide a declaration of ‘free’
gfx/drivers_context/mali_fbdev_ctx.c:78:4: warning: implicit declaration of function ‘system’ [-Wimplicit-function-declaration]
    system("setterm -cursor on");
    ^
```