### PR TITLE
Fix a possible NULL dereference in load_savestate

### DIFF
--- a/network/netplay/netplay.c
+++ b/network/netplay/netplay.c
@@ -1575,6 +1575,11 @@ void netplay_load_savestate(netplay_t *netplay,
             }
          }
       }
+      else
+      {
+         /* FIXME: This is a critical failure! */
+         return;
+      }
    }
 
    /* We need to ignore any intervening data from the other side, 


### PR DESCRIPTION
In the unlikely situation that serial_info wasn't provided and the delta frame wasn't ready (possibly an impossible situation) it previously would have segfaulted. This fixes that.

Fixes Coverity report 158303.