### PR TITLE
Fix joypad_connection handling of unknown controllers

### DIFF
--- a/input/connect/joypad_connection.c
+++ b/input/connect/joypad_connection.c
@@ -116,6 +116,14 @@ int32_t pad_connection_pad_init(joypad_connection_t *joyconn,
             break;
          }
       }
+
+      //We failed to find a matching pad, set up one without an iface
+      if (!s->connected)
+      {
+         s->iface = NULL;
+         s->data = data;
+         s->connected = true;
+      }
    }
 
    return pad;

--- a/input/drivers_hid/iohidmanager_hid.c
+++ b/input/drivers_hid/iohidmanager_hid.c
@@ -237,6 +237,7 @@ static void iohidmanager_hid_device_input_callback(void *data, IOReturn result,
 static void iohidmanager_hid_device_remove(void *data,
       IOReturn result, void* sender)
 {
+   settings_t                     *settings = config_get_ptr();
    struct iohidmanager_hid_adapter *adapter = 
       (struct iohidmanager_hid_adapter*)data;
    iohidmanager_hid_t *hid = (iohidmanager_hid_t*)
@@ -245,6 +246,8 @@ static void iohidmanager_hid_device_remove(void *data,
    if (hid && adapter && (adapter->slot < MAX_USERS))
    {
       input_autoconfigure_disconnect(adapter->slot, adapter->name);
+
+      settings->input.device_names[adapter->slot][0] = '\0';
 
       hid->buttons[adapter->slot] = 0;
       memset(hid->axes[adapter->slot], 0, sizeof(hid->axes));


### PR DESCRIPTION
`joypad_connection` wasn't correctly handling the case where a controller is connected that doesn't match one in the `pad_map` lookup table.

This would result in a `joyconn` item being used, but not marked as being used, causing that item to be allocated against multiple physical controllers.

This possibly only affects mac, which is probably the only platform that uses `joypad_connection` and supports controllers other than those in the `pad_map` list.

Fixes #4215 
Probably #2808 too, I don't have the adaptor to test.