### PR TITLE
Netplay pause fix redux.

### DIFF
--- a/core_impl.c
+++ b/core_impl.c
@@ -390,7 +390,10 @@ bool core_run(void)
 #ifdef HAVE_NETWORKING
    if (!netplay_driver_ctl(RARCH_NETPLAY_CTL_PRE_FRAME, NULL))
    {
-      /* Paused due to Netplay */
+      /* Paused due to netplay. We must poll and display something so that a
+       * netplay peer pausing doesn't just hang. */
+      input_poll();
+      video_driver_cached_frame();
       return true;
    }
 #endif


### PR DESCRIPTION
We must actually poll input when netplay is paused, or it just looks stalled. This fixes that. Again.

I'm not confident about video_driver_cached_frame being in core_impl; I put netplay callbacks there in the first place because alternate paths to core_run were bypassing netplay and effing up everything, but maybe there's a more elegant way to communicate that particular issue.