### PR TITLE
differentiate xbox one controllers

### DIFF
--- a/input/drivers_joypad/xinput_joypad.c
+++ b/input/drivers_joypad/xinput_joypad.c
@@ -139,7 +139,7 @@ static INLINE int pad_index_to_xuser_index(unsigned pad)
 /* Generic "XInput" instead of "Xbox 360", because there are
  * some other non-xbox third party PC controllers.
  */
-static const char* const XBOX_CONTROLLER_NAMES[4] = 
+static const char* const XBOX_CONTROLLER_NAMES[4] =
 {
    "XInput Controller (User 1)",
    "XInput Controller (User 2)",
@@ -147,13 +147,25 @@ static const char* const XBOX_CONTROLLER_NAMES[4] =
    "XInput Controller (User 4)"
 };
 
+static const char* const XBOX_ONE_CONTROLLER_NAMES[4] =
+{
+   "XBOX One Controller (User 1)",
+   "XBOX One Controller (User 2)",
+   "XBOX One Controller (User 3)",
+   "XBOX One Controller (User 4)"
+};
+
 const char *xinput_joypad_name(unsigned pad)
 {
    int xuser = pad_index_to_xuser_index(pad);
-
+   /* Use the real controller name for XBOX One controllers since
+      they are slightly different  */
    if (xuser < 0)
       return dinput_joypad.name(pad);
-   /* TODO: Different name if disconnected? */
+
+   if (strstr(dinput_joypad.name(pad), "Xbox One For Windows"))
+      return XBOX_ONE_CONTROLLER_NAMES[xuser];
+
    return XBOX_CONTROLLER_NAMES[xuser];
 }
 


### PR DESCRIPTION
It allows a bit more flexibility for the XBOX One pads, show the proper name and labels as soon as an autoconf is pushed (some button labels are different)

![image](https://cloud.githubusercontent.com/assets/1721040/21295675/66252bf0-c528-11e6-9be1-e1bf4d47656a.png)
