### PR TITLE
Adding blocks in the empty-RECV case to (hopefully) suppress warnings

### DIFF
--- a/network/netplay/netplay_handshake.c
+++ b/network/netplay/netplay_handshake.c
@@ -602,7 +602,7 @@ bool netplay_handshake_pre_nick(netplay_t *netplay,
 
    msg[0] = '\0';
 
-   RECV(&nick_buf, sizeof(nick_buf));
+   RECV(&nick_buf, sizeof(nick_buf)) {}
 
    /* Expecting only a nick command */
    if (recvd < 0 ||
@@ -670,7 +670,7 @@ bool netplay_handshake_pre_password(netplay_t *netplay,
 
    msg[0] = '\0';
 
-   RECV(&password_buf, sizeof(password_buf));
+   RECV(&password_buf, sizeof(password_buf)) {}
 
    /* Expecting only a password command */
    if (recvd < 0 ||
@@ -740,7 +740,7 @@ bool netplay_handshake_pre_info(netplay_t *netplay,
    uint32_t *content_crc_ptr;
    const char *dmsg = NULL;
 
-   RECV(&info_buf, sizeof(info_buf));
+   RECV(&info_buf, sizeof(info_buf)) {}
 
    if (recvd < 0 ||
        ntohl(info_buf.cmd[0]) != NETPLAY_CMD_INFO)


### PR DESCRIPTION
(Please wait until Travis's Mac OS X build is done so I can check whether this actually suppresses said warnings)