### PR TITLE
Vulkan: Fix menu shader parameters for slangp.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -903,6 +903,7 @@ ifeq ($(HAVE_VULKAN), 1)
           gfx/drivers_shader/shader_vulkan.o \
           gfx/drivers_shader/glslang_util.o \
           gfx/drivers_shader/slang_reflection.o \
+          gfx/drivers_shader/slang_preprocess.o \
           $(GLSLANG_OBJ) \
           $(SPIRV_CROSS_OBJ)
 
@@ -913,6 +914,7 @@ ifeq ($(HAVE_VULKAN), 1)
       OBJ += menu/drivers_display/menu_display_vulkan.o
    endif
    LIBS += -lstdc++
+   DEFINES += -DHAVE_SLANG
 endif
 
 

--- a/gfx/drivers_shader/glslang_util.cpp
+++ b/gfx/drivers_shader/glslang_util.cpp
@@ -32,7 +32,7 @@
 
 using namespace std;
 
-static bool read_shader_file(const char *path, vector<string> *output, bool root_file)
+bool glslang_read_shader_file(const char *path, vector<string> *output, bool root_file)
 {
    vector<const char *> lines;
    char include_path[PATH_MAX_LENGTH];
@@ -122,7 +122,7 @@ static bool read_shader_file(const char *path, vector<string> *output, bool root
 
          fill_pathname_resolve_relative(include_path, path, c, sizeof(include_path));
 
-         if (!read_shader_file(include_path, output, false))
+         if (!glslang_read_shader_file(include_path, output, false))
          {
             free(buf);
             return false;
@@ -268,7 +268,7 @@ static glslang_format glslang_find_format(const char *fmt)
    return SLANG_FORMAT_UNKNOWN;
 }
 
-static bool glslang_parse_meta(const vector<string> &lines, glslang_meta *meta)
+bool glslang_parse_meta(const vector<string> &lines, glslang_meta *meta)
 {
    char id[64]   = {};
    char desc[64] = {};
@@ -362,7 +362,7 @@ bool glslang_compile_shader(const char *shader_path, glslang_output *output)
    vector<string> lines;
 
    RARCH_LOG("[slang]: Compiling shader \"%s\".\n", shader_path);
-   if (!read_shader_file(shader_path, &lines, true))
+   if (!glslang_read_shader_file(shader_path, &lines, true))
       return false;
 
    if (!glslang_parse_meta(lines, &output->meta))

--- a/gfx/drivers_shader/glslang_util.hpp
+++ b/gfx/drivers_shader/glslang_util.hpp
@@ -90,5 +90,9 @@ struct glslang_output
 bool glslang_compile_shader(const char *shader_path, glslang_output *output);
 const char *glslang_format_to_string(enum glslang_format fmt);
 
+// Helpers for internal use.
+bool glslang_read_shader_file(const char *path, std::vector<std::string> *output, bool root_file);
+bool glslang_parse_meta(const std::vector<std::string> &lines, glslang_meta *meta);
+
 #endif
 

--- a/gfx/drivers_shader/slang_preprocess.cpp
+++ b/gfx/drivers_shader/slang_preprocess.cpp
@@ -1,0 +1,87 @@
+/*  RetroArch - A frontend for libretro.
+ *  Copyright (C) 2010-2016 - Hans-Kristian Arntzen
+ * 
+ *  RetroArch is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  RetroArch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with RetroArch.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "slang_preprocess.h"
+#include "glslang_util.hpp"
+#include <vector>
+#include <string>
+#include <algorithm>
+#include "../../verbosity.h"
+#include "../../libretro-common/include/compat/strl.h"
+
+using namespace std;
+
+bool slang_preprocess_parse_parameters(const char *shader_path,
+      struct video_shader *shader)
+{
+   glslang_meta meta;
+   vector<string> lines;
+   if (!glslang_read_shader_file(shader_path, &lines, true))
+      return false;
+
+   if (!glslang_parse_meta(lines, &meta))
+      return false;
+
+   unsigned old_num_parameters = shader->num_parameters;
+
+   // Assumes num_parameters is initialized to something sane.
+   for (auto &param : meta.parameters)
+   {
+      bool mismatch_dup = false;
+      bool dup = false;
+
+      auto itr = find_if(shader->parameters, shader->parameters + shader->num_parameters,
+         [&](const video_shader_parameter &parsed_param) {
+            return param.id == parsed_param.id;
+         });
+
+      if (itr != shader->parameters + shader->num_parameters)
+      {
+         dup = true;
+         // Allow duplicate #pragma parameter, but only if they are exactly the same.
+         if (param.desc != itr->desc ||
+             param.initial != itr->initial ||
+             param.minimum != itr->minimum ||
+             param.maximum != itr->maximum ||
+             param.step != itr->step)
+         {
+            RARCH_ERR("[Vulkan]: Duplicate parameters found for \"%s\", but arguments do not match.\n",
+                  itr->id);
+            mismatch_dup = true;
+         }
+      }
+
+      if (dup && !mismatch_dup)
+         continue;
+
+      if (mismatch_dup || shader->num_parameters == GFX_MAX_PARAMETERS)
+      {
+         shader->num_parameters = old_num_parameters;
+         return false;
+      }
+
+      auto &p = shader->parameters[shader->num_parameters++];
+      strlcpy(p.id, param.id.c_str(), sizeof(p.id));
+      strlcpy(p.desc, param.desc.c_str(), sizeof(p.desc));
+      p.initial = param.initial;
+      p.minimum = param.minimum;
+      p.maximum = param.maximum;
+      p.step = param.step;
+      p.current = param.initial;
+   }
+
+   return true;
+}
+

--- a/gfx/drivers_shader/slang_preprocess.h
+++ b/gfx/drivers_shader/slang_preprocess.h
@@ -1,0 +1,34 @@
+/*  RetroArch - A frontend for libretro.
+ *  Copyright (C) 2010-2016 - Hans-Kristian Arntzen
+ * 
+ *  RetroArch is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  RetroArch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with RetroArch.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SLANG_PREPROCESS_H
+#define SLANG_PREPROCESS_H
+
+#include <boolean.h>
+#include <retro_common_api.h>
+#include "../video_shader_driver.h"
+
+RETRO_BEGIN_DECLS
+
+/* Utility function to implement the same parameter reflection
+ * which happens in the slang backend.
+ * This does preprocess over the input file to handle #includes and so on. */
+bool slang_preprocess_parse_parameters(const char *shader_path,
+      struct video_shader *shader);
+
+RETRO_END_DECLS
+
+#endif
+


### PR DESCRIPTION
video_shader_resolve_parameters did not take #includes into account
while the Vulkan implementation did. Added a helper function which
parses a shader file and figures out the shader parameters in the same
way.