### PR TITLE
Make netplay no longer cache passwords

### DIFF
--- a/command.c
+++ b/command.c
@@ -2363,9 +2363,7 @@ bool command_event(enum event_command cmd, void *data)
 #ifdef HAVE_NETWORKING
          if (!init_netplay(
               data, settings->netplay.server,
-              settings->netplay.port,
-              settings->netplay.password,
-              settings->netplay.spectate_password))
+              settings->netplay.port))
             return false;
 #endif
          break;

--- a/network/netplay/netplay.h
+++ b/network/netplay/netplay.h
@@ -62,8 +62,6 @@ size_t audio_sample_batch_net(const int16_t *data, size_t frames);
  * @direct_host          : Host to connect to directly, if applicable (client only)
  * @server               : server address to connect to (client only)
  * @port                 : TCP port to host on/connect to
- * @play_password        : Password required to play (server only)
- * @spectate_password    : Password required to connect (server only)
  *
  * Initializes netplay.
  *
@@ -71,8 +69,7 @@ size_t audio_sample_batch_net(const int16_t *data, size_t frames);
  *
  * Returns: true (1) if successful, otherwise false (0).
  **/
-bool init_netplay(void *direct_host, const char *server, unsigned port,
-   const char *play_password, const char *spectate_password);
+bool init_netplay(void *direct_host, const char *server, unsigned port);
 
 void deinit_netplay(void);
 

--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -838,8 +838,6 @@ void deinit_netplay(void)
  * @direct_host          : Host to connect to directly, if applicable (client only)
  * @server               : server address to connect to (client only)
  * @port                 : TCP port to host on/connect to
- * @play_password        : Password required to play (server only)
- * @spectate_password    : Password required to connect (server only)
  *
  * Initializes netplay.
  *
@@ -847,8 +845,7 @@ void deinit_netplay(void)
  *
  * Returns: true (1) if successful, otherwise false (0).
  **/
-bool init_netplay(void *direct_host, const char *server, unsigned port,
-   const char *play_password, const char *spectate_password)
+bool init_netplay(void *direct_host, const char *server, unsigned port)
 {
    struct retro_callbacks cbs    = {0};
    settings_t *settings          = config_get_ptr();
@@ -896,7 +893,6 @@ bool init_netplay(void *direct_host, const char *server, unsigned port,
          netplay_is_client ? direct_host : NULL,
          netplay_is_client ? server : NULL,
          port ? port : RARCH_DEFAULT_PORT,
-         play_password, spectate_password,
          settings->netplay.stateless_mode, settings->netplay.check_frames, &cbs,
          settings->netplay.nat_traversal, settings->username,
          quirks);

--- a/network/netplay/netplay_handshake.c
+++ b/network/netplay/netplay_handshake.c
@@ -207,11 +207,13 @@ bool netplay_handshake_init_send(netplay_t *netplay,
    struct netplay_connection *connection)
 {
    uint32_t header[4] = {0};
+   settings_t *settings = config_get_ptr();
 
    header[0] = htonl(netplay_impl_magic());
    header[1] = htonl(netplay_platform_magic());
    header[2] = htonl(NETPLAY_COMPRESSION_SUPPORTED);
-   if (netplay->is_server && (netplay->play_password[0] || netplay->spectate_password[0]))
+   if (netplay->is_server &&
+       (settings->netplay.password[0] || settings->netplay.spectate_password[0]))
    {
       /* Demand a password */
       if (simple_rand_next == 1)
@@ -600,6 +602,7 @@ bool netplay_handshake_pre_nick(netplay_t *netplay,
    struct nick_buf_s nick_buf;
    ssize_t recvd;
    char msg[512];
+   settings_t *settings = config_get_ptr();
 
    msg[0] = '\0';
 
@@ -628,7 +631,7 @@ bool netplay_handshake_pre_nick(netplay_t *netplay,
 
    if (netplay->is_server)
    {
-      if (netplay->play_password[0] || netplay->spectate_password[0])
+      if (settings->netplay.password[0] || settings->netplay.spectate_password[0])
       {
          /* There's a password, so just put them in PRE_PASSWORD mode */
          connection->mode = NETPLAY_CONNECTION_PRE_PASSWORD;
@@ -668,6 +671,7 @@ bool netplay_handshake_pre_password(netplay_t *netplay,
    ssize_t recvd;
    char msg[512];
    bool correct;
+   settings_t *settings = config_get_ptr();
 
    msg[0] = '\0';
 
@@ -693,9 +697,9 @@ bool netplay_handshake_pre_password(netplay_t *netplay,
    /* Calculate the correct password hash(es) and compare */
    correct = false;
    snprintf(password, sizeof(password), "%08X", connection->salt);
-   if (netplay->play_password[0])
+   if (settings->netplay.password[0])
    {
-      strlcpy(password + 8, netplay->play_password, sizeof(password)-8);
+      strlcpy(password + 8, settings->netplay.password, sizeof(password)-8);
       sha256_hash(corr_password_buf.password, (uint8_t *) password, strlen(password));
       if (!memcmp(password_buf.password, corr_password_buf.password, sizeof(password_buf.password)))
       {
@@ -703,9 +707,9 @@ bool netplay_handshake_pre_password(netplay_t *netplay,
          connection->can_play = true;
       }
    }
-   if (netplay->spectate_password[0])
+   if (settings->netplay.spectate_password[0])
    {
-      strlcpy(password + 8, netplay->spectate_password, sizeof(password)-8);
+      strlcpy(password + 8, settings->netplay.spectate_password, sizeof(password)-8);
       sha256_hash(corr_password_buf.password, (uint8_t *) password, strlen(password));
       if (!memcmp(password_buf.password, corr_password_buf.password, sizeof(password_buf.password)))
          correct = true;

--- a/network/netplay/netplay_init.c
+++ b/network/netplay/netplay_init.c
@@ -395,8 +395,6 @@ static bool netplay_init_buffers(netplay_t *netplay)
  * @direct_host          : Netplay host discovered from scanning.
  * @server               : IP address of server.
  * @port                 : Port of server.
- * @play_password        : Password required to play.
- * @spectate_password    : Password required to connect.
  * @stateless_mode       : Shall we use stateless mode?
  * @check_frames         : Frequency with which to check CRCs.
  * @cb                   : Libretro callbacks.
@@ -410,7 +408,6 @@ static bool netplay_init_buffers(netplay_t *netplay)
  * Returns: new netplay data.
  */
 netplay_t *netplay_new(void *direct_host, const char *server, uint16_t port,
-   const char *play_password, const char *spectate_password,
    bool stateless_mode, int check_frames,
    const struct retro_callbacks *cb, bool nat_traversal, const char *nick,
    uint64_t quirks)
@@ -448,8 +445,6 @@ netplay_t *netplay_new(void *direct_host, const char *server, uint16_t port,
    }
 
    strlcpy(netplay->nick, nick[0] ? nick : RARCH_DEFAULT_NICK, sizeof(netplay->nick));
-   strlcpy(netplay->play_password, play_password ? play_password : "", sizeof(netplay->play_password));
-   strlcpy(netplay->spectate_password, spectate_password ? spectate_password : "", sizeof(netplay->spectate_password));
 
    if (!init_socket(netplay, direct_host, server, port))
    {

--- a/network/netplay/netplay_private.h
+++ b/network/netplay/netplay_private.h
@@ -306,12 +306,6 @@ struct netplay
    /* TCP connection for listening (server only) */
    int listen_fd;
 
-   /* Password required to play (server only) */
-   char play_password[NETPLAY_PASS_LEN];
-
-   /* Password required to connect (server only) */
-   char spectate_password[NETPLAY_PASS_LEN];
-
    /* Our player number */
    uint32_t self_player;
 
@@ -632,8 +626,6 @@ bool netplay_wait_and_init_serialization(netplay_t *netplay);
  * @direct_host          : Netplay host discovered from scanning.
  * @server               : IP address of server.
  * @port                 : Port of server.
- * @play_password        : Password required to play.
- * @spectate_password    : Password required to connect.
  * @stateless_mode       : Shall we run in stateless mode?
  * @check_frames         : Frequency with which to check CRCs.
  * @cb                   : Libretro callbacks.
@@ -647,7 +639,6 @@ bool netplay_wait_and_init_serialization(netplay_t *netplay);
  * Returns: new netplay data.
  */
 netplay_t *netplay_new(void *direct_host, const char *server, uint16_t port,
-   const char *play_password, const char *spectate_password,
    bool stateless_mode, int check_frames,
    const struct retro_callbacks *cb, bool nat_traversal, const char *nick,
    uint64_t quirks);


### PR DESCRIPTION
Netplay now always loads passwords from the configuration, so that passwords can be changed mid-session. Just a small usability improvement.