### PR TITLE
Reverse catch-up, i.e., server-demanded stalling

### DIFF
--- a/network/netplay/README
+++ b/network/netplay/README
@@ -304,6 +304,14 @@ Payload: None
 Description:
     Indicates that the core is no longer paused.
 
+Command: STALL
+Payload:
+    {
+       frames: uint32
+    }
+Description:
+    Request that a client stall for the given number of frames.
+
 Command: CHEATS
 Unused
 

--- a/network/netplay/netplay_buf.c
+++ b/network/netplay/netplay_buf.c
@@ -322,7 +322,7 @@ ssize_t netplay_recv(struct socket_buffer *sbuf, int sockfd, void *buf,
    if (block)
    {
       sbuf->start = sbuf->read;
-      if (recvd < len)
+      if (recvd < 0 || recvd < (ssize_t) len)
       {
          if (!socket_receive_all_blocking(sockfd, (unsigned char *) buf + recvd, len - recvd))
             return -1;

--- a/network/netplay/netplay_discovery.c
+++ b/network/netplay/netplay_discovery.c
@@ -142,7 +142,7 @@ bool netplay_discovery_driver_ctl(enum rarch_netplay_discovery_ctl_state state, 
          /* And send it off */
          if (sendto(lan_ad_client_fd, (const char *) &ad_packet_buffer,
             2*sizeof(uint32_t), 0, addr->ai_addr, addr->ai_addrlen) <
-            2*sizeof(uint32_t))
+            (ssize_t) (2*sizeof(uint32_t)))
             RARCH_WARN("Failed to send netplay discovery response.\n");
 
          freeaddrinfo_retro(addr);

--- a/network/netplay/netplay_handshake.c
+++ b/network/netplay/netplay_handshake.c
@@ -257,7 +257,7 @@ struct info_buf_s
 
 #define RECV(buf, sz) \
    recvd = netplay_recv(&connection->recv_packet_buffer, connection->fd, (buf), (sz), false); \
-   if (recvd >= 0 && recvd < (sz)) \
+   if (recvd >= 0 && recvd < (ssize_t) (sz)) \
    { \
       netplay_recv_reset(&connection->recv_packet_buffer); \
       return true; \


### PR DESCRIPTION
Previously, if two clients were connected to the same server and one of them was ahead of the server, the only way to rectify that situation (i.e., make the user experience pleasant for that client) was for the client to get so far ahead that it stalled, as the server could only catch up with an ahead client if all clients were ahead. That's unrealistic. This gives the server the alternate option of demanding that a client stall. This keeps things nicely in line even with >2 players.

This change is noncrucial. If you'd rather keep things stable until after release, hold off on this until after.