### PR TITLE
add "d3d" to list of retroarch.cfg video options

### DIFF
--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -130,7 +130,7 @@
 
 #### Video
 
-# Video driver to use. "gl", "xvideo", "sdl"
+# Video driver to use. "gl", "xvideo", "sdl", "d3d"
 # video_driver = "gl"
 
 # Which context implementation to use.


### PR DESCRIPTION
After referring to some forum posts suggesting using "d3d9" for the video mode on an older Windows installation (outdated) I finally figured out that the Direct3D mode is now called "d3d." Hopefully including it in these instructions will save someone else the same time and research.