### PR TITLE
Fixing a bug that caused retroarch to crash if netplay failed to connect

### DIFF
--- a/command.c
+++ b/command.c
@@ -2420,7 +2420,10 @@ bool command_event(enum event_command cmd, void *data)
             if (!init_netplay(
                      data, settings->netplay.server,
                      settings->netplay.port))
+            {
+               command_event(CMD_EVENT_NETPLAY_DEINIT, NULL);
                return false;
+            }
 #endif
          }
          break;


### PR DESCRIPTION
Simple bug, failing to unset the netplay callbacks if netplay didn't actually connect in the first place.