### PR TITLE
Server prompt when connecting to netplay host

### DIFF
--- a/command.c
+++ b/command.c
@@ -2395,48 +2395,58 @@ bool command_event(enum event_command cmd, void *data)
          command_event(CMD_EVENT_BSV_MOVIE_DEINIT, NULL);
          bsv_movie_ctl(BSV_MOVIE_CTL_INIT, NULL);
          break;
-      case CMD_EVENT_NETPLAY_DEINIT:
 #ifdef HAVE_NETWORKING
+      case CMD_EVENT_NETPLAY_DEINIT:
          deinit_netplay();
-#endif
          break;
       case CMD_EVENT_NETWORK_DEINIT:
-#ifdef HAVE_NETWORKING
          network_deinit();
-#endif
          break;
       case CMD_EVENT_NETWORK_INIT:
-#ifdef HAVE_NETWORKING
          network_init();
-#endif
          break;
       case CMD_EVENT_NETPLAY_INIT:
          {
-#ifdef HAVE_NETWORKING
-            settings_t *settings      = config_get_ptr();
-#endif
+            char *hostname = (char *) data;
+            settings_t *settings = config_get_ptr();
             command_event(CMD_EVENT_NETPLAY_DEINIT, NULL);
-#ifdef HAVE_NETWORKING
             if (!init_netplay(
-                     data, settings->netplay.server,
+                     NULL, hostname ? hostname : settings->netplay.server,
                      settings->netplay.port))
             {
                command_event(CMD_EVENT_NETPLAY_DEINIT, NULL);
                return false;
             }
-#endif
+         }
+         break;
+      case CMD_EVENT_NETPLAY_INIT_DIRECT:
+         {
+            settings_t *settings = config_get_ptr();
+            command_event(CMD_EVENT_NETPLAY_DEINIT, NULL);
+            if (!init_netplay(
+                     data, NULL, settings->netplay.port))
+            {
+               command_event(CMD_EVENT_NETPLAY_DEINIT, NULL);
+               return false;
+            }
          }
          break;
       case CMD_EVENT_NETPLAY_FLIP_PLAYERS:
-#ifdef HAVE_NETWORKING
          netplay_driver_ctl(RARCH_NETPLAY_CTL_FLIP_PLAYERS, NULL);
-#endif
          break;
       case CMD_EVENT_NETPLAY_GAME_WATCH:
-#ifdef HAVE_NETWORKING
          netplay_driver_ctl(RARCH_NETPLAY_CTL_GAME_WATCH, NULL);
-#endif
          break;
+#else
+      case CMD_EVENT_NETPLAY_DEINIT:
+      case CMD_EVENT_NETWORK_DEINIT:
+      case CMD_EVENT_NETWORK_INIT:
+      case CMD_EVENT_NETPLAY_INIT:
+      case CMD_EVENT_NETPLAY_INIT_DIRECT:
+      case CMD_EVENT_NETPLAY_FLIP_PLAYERS:
+      case CMD_EVENT_NETPLAY_GAME_WATCH:
+         return false;
+#endif
       case CMD_EVENT_FULLSCREEN_TOGGLE:
          {
             settings_t *settings      = config_get_ptr();

--- a/command.h
+++ b/command.h
@@ -167,8 +167,10 @@ enum event_command
    CMD_EVENT_NETWORK_DEINIT,
    /* Initializes network system. */
    CMD_EVENT_NETWORK_INIT,
-   /* Initializes netplay system. */
+   /* Initializes netplay system with a string or no host specified. */
    CMD_EVENT_NETPLAY_INIT,
+   /* Initializes netplay system with a direct host specified. */
+   CMD_EVENT_NETPLAY_INIT_DIRECT,
    /* Deinitializes netplay system. */
    CMD_EVENT_NETPLAY_DEINIT,
    /* Flip netplay players. */


### PR DESCRIPTION
Another minor thing. If you choose "connect to netplay host" when none is configured in the settings, it now prompts. This required a new command in command.c so that connecting to a string host and connecting to a discovered host in LAN scan could be differentiated. I also rejiggered the #ifdefs in command.c a bit because they were starting to become a hazy cloud of HAVE_NETWORKING blocks.