### PR TITLE
Use this code for GLES2 and GLES3

### DIFF
--- a/gfx/drivers/gl.c
+++ b/gfx/drivers/gl.c
@@ -642,7 +642,7 @@ static void gl_init_textures(gl_t *gl, const video_info_t *video)
    texture_fmt  = gl->texture_fmt;
 #endif
 
-#ifdef HAVE_OPENGLES2
+#if defined(HAVE_OPENGLES) && !defined(HAVE_PSGL)
    /* GLES is picky about which format we use here.
     * Without extensions, we can *only* render to 16-bit FBOs. */
 


### PR DESCRIPTION
Sorry this is the last time I mess with this stuff I promise. This makes everything work properly in glupen.

This will make GLES3 use RGBA for the libretro framebuffer internal format. It doesn't affect GLES2 (Android build is GLES2, so guaranteed to not break that), and it doesn't affect desktop, just GLES3.

Tested and working with Mesa.