### PR TITLE
Only show 'Information' if the .lpl playlist points to an existing database

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -2813,6 +2813,7 @@ static int menu_displaylist_parse_horizontal_content_actions(
       strlcat(db_path, file_path_str(FILE_PATH_RDB_EXTENSION),
             sizeof(db_path));
 
+      if (path_file_exists(db_path))
       menu_entries_append_enum(info->list, label,
             db_path,
             MENU_ENUM_LABEL_INFORMATION, FILE_TYPE_RDB_ENTRY, 0, idx);


### PR DESCRIPTION
This commit provides a workaround addressing issue #4330, limiting the display of the Playlist->Information option to those playlist entries that point to an existing database file. 
The previous configuration made it so that, if the respective 6th line in the corresponding .lpl file pertaining to a playlist entry indicated a non-existant path, the user would be unable to escape from a blank menu upon selecting 'Information' for that entry.