### PR TITLE
LOAD_SAVESTATE can't use player frame timing from a server that's not playing

### DIFF
--- a/network/netplay/netplay_io.c
+++ b/network/netplay/netplay_io.c
@@ -1084,7 +1084,8 @@ static bool netplay_get_cmd(netplay_t *netplay,
             }
             frame = ntohl(frame);
 
-            if (frame != netplay->read_frame_count[connection->player])
+            if ((netplay->is_server && frame != netplay->read_frame_count[connection->player]) ||
+                (!netplay->is_server && frame != netplay->server_frame_count))
             {
                RARCH_ERR("CMD_LOAD_SAVESTATE loading a state out of order!\n");
                return netplay_cmd_nak(netplay, connection);


### PR DESCRIPTION
Very minor bug. Since a server can load a savestate even if they're not actually playing, we need to check a different frame when loading a state from the server than from a player.