### PR TITLE
Fix to the netplay_is_alive function when server isn't playing

### DIFF
--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -50,7 +50,8 @@ static bool netplay_is_alive(void)
 {
    if (!netplay_data)
       return false;
-   return !!netplay_data->connected_players;
+   return (netplay_data->is_server && !!netplay_data->connected_players) ||
+          (!netplay_data->is_server && netplay_data->self_mode >= NETPLAY_CONNECTION_CONNECTED);
 }
 
 /**


### PR DESCRIPTION
Fixes a bug by which very strange things would happen if the server went to spectator mode with exactly one connected client.