### PR TITLE
allow downscaling too

### DIFF
--- a/record/drivers/record_ffmpeg.c
+++ b/record/drivers/record_ffmpeg.c
@@ -183,7 +183,7 @@ struct ff_config_param
    unsigned threads;
    unsigned frame_drop_ratio;
    unsigned sample_rate;
-   unsigned scale_factor;
+   float scale_factor;
 
    bool audio_enable;
    /* Keep same naming conventions as libavcodec. */
@@ -477,8 +477,8 @@ static bool ffmpeg_init_video(ffmpeg_t *handle)
    /* Useful to set scale_factor to 2 for chroma subsampled formats to
     * maintain full chroma resolution. (Or just use 4:4:4 or RGB ...)
     */
-   param->out_width  *= params->scale_factor;
-   param->out_height *= params->scale_factor;
+   param->out_width  = (float)param->out_width  * params->scale_factor;
+   param->out_height = (float)param->out_height * params->scale_factor;
 
    video->codec->codec_type          = AVMEDIA_TYPE_VIDEO;
    video->codec->width               = param->out_width;
@@ -567,7 +567,7 @@ static bool ffmpeg_init_config(struct ff_config_param *params,
       params->audio_enable = true;
 
    config_get_uint(params->conf, "sample_rate", &params->sample_rate);
-   config_get_uint(params->conf, "scale_factor", &params->scale_factor);
+   config_get_float(params->conf, "scale_factor", &params->scale_factor);
 
    params->audio_qscale = config_get_int(params->conf, "audio_global_quality",
          &params->audio_global_quality);


### PR DESCRIPTION
I wasn't sure if this is the proper way to multiply these values so I thought it would be safer to cast...
anyway this allows ffmpeg streaming to scale up and down.

Useful for HW cores that render at viewport size.