### PR TITLE
Fix XMB when using threaded video and shared context

### DIFF
--- a/gfx/drivers_font/gl_raster_font.c
+++ b/gfx/drivers_font/gl_raster_font.c
@@ -163,7 +163,7 @@ static void *gl_raster_font_init_font(void *data,
       return NULL;
    }
 
-   if (settings->video.threaded)
+   if (video_driver_is_threaded())
       video_context_driver_make_current(false);
 
    glGenTextures(1, &font->tex);
@@ -203,7 +203,7 @@ static void gl_raster_font_free_font(void *data)
    if (font->font_driver && font->font_data)
       font->font_driver->free(font->font_data);
 
-   if (settings->video.threaded)
+   if (video_driver_is_threaded())
       video_context_driver_make_current(true);
 
    glDeleteTextures(1, &font->tex);

--- a/gfx/font_driver.c
+++ b/gfx/font_driver.c
@@ -372,7 +372,7 @@ font_data_t *font_driver_init_first(
    settings_t *settings = config_get_ptr();
 
    if (threading_hint 
-         && settings->video.threaded 
+         && video_driver_is_threaded() 
          && !video_driver_is_hw_context())
       ok = video_thread_font_init(&font_driver, &font_handle,
             video_data, font_path, font_size, api, font_init_first);

--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -297,7 +297,7 @@ static bool hw_render_context_is_gl(enum retro_hw_context_type type)
    return false;
 }
 
-static bool video_driver_is_threaded(void)
+bool video_driver_is_threaded(void)
 {
 #ifdef HAVE_THREADS
    settings_t *settings = config_get_ptr();
@@ -497,7 +497,7 @@ static void video_monitor_compute_fps_statistics(void)
    unsigned samples     = 0;
    settings_t *settings = config_get_ptr();
 
-   if (settings->video.threaded)
+   if (video_driver_is_threaded())
    {
       RARCH_LOG("Monitor FPS estimation is disabled for threaded video.\n");
       return;
@@ -982,7 +982,7 @@ bool video_monitor_fps_statistics(double *refresh_rate,
    unsigned samples      = MIN(MEASURE_FRAME_TIME_SAMPLES_COUNT,
          video_driver_frame_time_count);
 
-   if (settings->video.threaded || (samples < 2))
+   if (video_driver_is_threaded() || (samples < 2))
       return false;
 
    /* Measure statistics on frame time (microsecs), *not* FPS. */

--- a/gfx/video_driver.h
+++ b/gfx/video_driver.h
@@ -285,6 +285,7 @@ bool video_driver_get_hw_render_interface(const struct
 bool video_driver_get_viewport_info(struct video_viewport *viewport);
 void video_driver_set_title_buf(void);
 void video_driver_monitor_adjust_system_rates(void);
+bool video_driver_is_threaded(void);
 
 /**
  * video_driver_find_handle:

--- a/menu/menu_display.c
+++ b/menu/menu_display.c
@@ -102,7 +102,7 @@ static const char *menu_video_get_ident(void)
 #ifdef HAVE_THREADS
    settings_t *settings = config_get_ptr();
 
-   if (settings->video.threaded)
+   if (video_driver_is_threaded())
       return video_thread_get_ident();
 #endif
 


### PR DESCRIPTION
Threaded video gets disabled for GL contexts, so you can't rely on the settings value