### PR TITLE
Revert "allow serial scanner to match PBP"

### DIFF
--- a/msg_hash.c
+++ b/msg_hash.c
@@ -221,8 +221,6 @@ uint32_t msg_hash_calculate(const char *s)
 #define HASH_EXTENSION_ISO                                                     0x0b8880d0U
 #define HASH_EXTENSION_ISO_UPPERCASE                                           0x0b87f470U
 #define HASH_EXTENSION_LUTRO                                                   0x0fe37b7bU
-#define HASH_EXTENSION_PBP                                                     0x0b889c67U
-#define HASH_EXTENSION_PBP_UPPERCASE                                           0x0b881007U
 
 enum msg_file_type msg_hash_to_file_type(uint32_t hash)
 {
@@ -359,9 +357,6 @@ enum msg_file_type msg_hash_to_file_type(uint32_t hash)
       case HASH_EXTENSION_ISO:
       case HASH_EXTENSION_ISO_UPPERCASE:
          return FILE_TYPE_ISO;
-      case HASH_EXTENSION_PBP:
-      case HASH_EXTENSION_PBP_UPPERCASE:
-         return FILE_TYPE_PBP;
       case HASH_EXTENSION_LUTRO:
          return FILE_TYPE_LUTRO;
       default:

--- a/msg_hash.h
+++ b/msg_hash.h
@@ -123,7 +123,6 @@ enum msg_file_type
 
    FILE_TYPE_CUE,
    FILE_TYPE_ISO,
-   FILE_TYPE_PBP,
    FILE_TYPE_LUTRO,
 
    FILE_TYPE_DIRECT_LOAD,

--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -215,7 +215,6 @@ static int task_database_iterate_playlist(
          database_info_set_type(db, DATABASE_TYPE_SERIAL_LOOKUP);
          break;
       case FILE_TYPE_ISO:
-      case FILE_TYPE_PBP:
          db_state->serial[0] = '\0';
          iso_get_serial(db_state, db, name, db_state->serial);
          database_info_set_type(db, DATABASE_TYPE_SERIAL_LOOKUP);


### PR DESCRIPTION
Reverts libretro/RetroArch#4377

@fr500 This doesn't work according to user retro-wertz.