### PR TITLE
Fix forgotten parameter of video_monitor_get_fps

### DIFF
--- a/gfx/drivers/dispmanx_gfx.c
+++ b/gfx/drivers/dispmanx_gfx.c
@@ -476,7 +476,7 @@ static bool dispmanx_gfx_frame(void *data, const void *frame, unsigned width,
    if (_dispvars->menu_active)
    {
       char buf[128];
-      video_monitor_get_fps(buf, sizeof(buf), NULL, 0);
+      video_monitor_get_fps(video_info, buf, sizeof(buf), NULL, 0);
    }
 
    /* Update main surface: locate free page, blit and flip. */

--- a/gfx/video_driver.h
+++ b/gfx/video_driver.h
@@ -461,6 +461,7 @@ bool video_monitor_fps_statistics(double *refresh_rate,
 
 /**
  * video_monitor_get_fps:
+ * @video_info    : information about the video frame
  * @buf           : string suitable for Window title
  * @size          : size of buffer.
  * @buf_fps       : string of raw FPS only (optional).


### PR DESCRIPTION
Hey y'all.

I was building this for my Raspberry Pi 3 (on Arch Linux ARM) and compilation failed. Seems like a parameter was forgotten in a function call. It was a simple enough fix. I also added a note in video_monitor_get_fps 's documentation to make sure that such a parameter doesn't get forgotten in the future. 

I highly recommend someone who knows more about the internals of this project to give a more descriptive definition for the video_info parameter. (at ``gfx/video_driver.h`` line 464). 