### PR TITLE
Fix android input where source is reported as a stylus

### DIFF
--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -503,7 +503,8 @@ static INLINE int android_input_poll_event_type_motion(
    size_t motion_ptr;
    bool keyup;
 
-   if (source & ~(AINPUT_SOURCE_TOUCHSCREEN | AINPUT_SOURCE_MOUSE))
+   // Only handle events from a touchscreen or mouse
+   if (!(source & (AINPUT_SOURCE_TOUCHSCREEN | AINPUT_SOURCE_MOUSE)))
       return 1;
 
    getaction  = AMotionEvent_getAction(event);


### PR DESCRIPTION
On the Nvidia Shield Tablet using custom roms, touch input is reported as being from both the touchscreen and a stylus. The current code ignores this input because the extra stylus bit is set. This changes the check to accept touch or mouse sources regardless of any other source bits being set.