### PR TITLE
Use autosave_lock and autosave_unlock during SRAM negotiation

### DIFF
--- a/network/netplay/netplay_handshake.c
+++ b/network/netplay/netplay_handshake.c
@@ -25,6 +25,7 @@
 
 #include "netplay_private.h"
 
+#include "../../autosave.h"
 #include "../../configuration.h"
 #include "../../content.h"
 #include "../../retroarch.h"
@@ -508,8 +509,10 @@ bool netplay_handshake_sync(netplay_t *netplay, struct netplay_connection *conne
    int matchct;
    bool nick_matched;
 
+   autosave_lock();
    mem_info.id = RETRO_MEMORY_SAVE_RAM;
    core_get_memory(&mem_info);
+   autosave_unlock();
 
    /* Send basic sync info */
    cmd[0] = htonl(NETPLAY_CMD_SYNC);
@@ -578,11 +581,16 @@ bool netplay_handshake_sync(netplay_t *netplay, struct netplay_connection *conne
       return false;
 
    /* And finally, the SRAM */
+   autosave_lock();
    if (!netplay_send(&connection->send_packet_buffer, connection->fd,
             mem_info.data, mem_info.size) ||
          !netplay_send_flush(&connection->send_packet_buffer, connection->fd,
             false))
+   {
+      autosave_unlock();
       return false;
+   }
+   autosave_unlock();
 
    /* Now we're ready! */
    connection->mode = NETPLAY_CONNECTION_SPECTATING;
@@ -938,6 +946,7 @@ bool netplay_handshake_pre_sync(netplay_t *netplay,
    }
 
    /* Now check the SRAM */
+   autosave_lock();
    mem_info.id = RETRO_MEMORY_SAVE_RAM;
    core_get_memory(&mem_info);
 
@@ -951,6 +960,7 @@ bool netplay_handshake_pre_sync(netplay_t *netplay,
       {
          RARCH_ERR("%s\n",
                msg_hash_to_str(MSG_FAILED_TO_RECEIVE_SRAM_DATA_FROM_HOST));
+         autosave_unlock();
          return false;
       }
 
@@ -965,6 +975,7 @@ bool netplay_handshake_pre_sync(netplay_t *netplay,
          {
             RARCH_ERR("%s\n",
                   msg_hash_to_str(MSG_FAILED_TO_RECEIVE_SRAM_DATA_FROM_HOST));
+            autosave_unlock();
             return false;
          }
          if (remote_sram_size > sizeof(uint32_t))
@@ -974,6 +985,7 @@ bool netplay_handshake_pre_sync(netplay_t *netplay,
       }
 
    }
+   autosave_unlock();
 
    /* We're ready! */
    *had_input = true;


### PR DESCRIPTION
The SRAM transfer in netplay handshake now uses autosave_lock and
autosave_unlock. Will possibly fix a hang/crash bug on Android with
netplay and autosave conflicting.