### PR TITLE
coreaudio: fix setting audio output device

### DIFF
--- a/audio/drivers/coreaudio.c
+++ b/audio/drivers/coreaudio.c
@@ -139,7 +139,7 @@ static void choose_output_device(coreaudio_t *dev, const char* device)
    AudioObjectPropertyAddress propaddr =
    { 
       kAudioHardwarePropertyDevices, 
-      kAudioObjectPropertyScopeGlobal, 
+      kAudioObjectPropertyScopeOutput,
       kAudioObjectPropertyElementMaster 
    };
    UInt32 size = 0;
@@ -155,14 +155,13 @@ static void choose_output_device(coreaudio_t *dev, const char* device)
             &propaddr, 0, 0, &size, devices) != noErr)
       goto done;
 
-   propaddr.mScope    = kAudioDevicePropertyScopeOutput;
    propaddr.mSelector = kAudioDevicePropertyDeviceName;
-   size               = 1024;
 
    for (i = 0; i < deviceCount; i ++)
    {
       char device_name[1024];
       device_name[0] = 0;
+      size           = 1024;
 
       if (AudioObjectGetPropertyData(devices[i],
                &propaddr, 0, 0, &size, device_name) == noErr 


### PR DESCRIPTION
The "size" variable is modified by the call to AudioObjectGetPropertyData, so it should be re-initialized during each run of the loop.

Additionally, the initial AudioObjectPropertyAddress setting is using a 'ScopeGlobal' scope, but then changes to 'ScopeOutput'. I changed it to just use 'ScopeOutput' throughout.