### PR TITLE
Make the client send an INFO even if it's wrong

### DIFF
--- a/network/netplay/netplay_handshake.c
+++ b/network/netplay/netplay_handshake.c
@@ -832,6 +832,15 @@ error:
       RARCH_ERR("%s\n", dmsg);
       runloop_msg_queue_push(dmsg, 1, 180, false);
    }
+
+   if (!netplay->is_server)
+   {
+      /* Counter-intuitively, we still want to send our info. This is simply so
+       * that the server knows why we disconnected. */
+      if (!netplay_handshake_info(netplay, connection))
+         return false;
+   }
+
    return false;
 }
 /**


### PR DESCRIPTION
This simply gives the server a reason why the client disconnected,
rather than a generic, unexplained disconnection.

Fixes https://github.com/libretro/RetroArch/issues/3729#issuecomment-274276989