### PR TITLE
better filename matching 

### DIFF
--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -3138,7 +3138,7 @@ static int action_ok_netplay_connect_room(const char *path,
       netplay_room_list[idx - 1].port);
 
    RARCH_LOG("Connecting to: %s with game: %s/%08x\n", 
-         netplay_room_list[idx - 1].address,
+         tmp_hostname,
          netplay_room_list[idx - 1].gamename,
          netplay_room_list[idx - 1].gamecrc);
 


### PR DESCRIPTION
The current filename matching process uses strstr which ends up causing lots of mismatched roms.
(looking for garou ended up loading garoubl, looking for super mario kart with a full no intro set ended up loading Power Fest 94 - Super Mario Kart)

I am now using path_basename and removing the extension
I tried using path_remove_extension but it always returned null so I used an algo I found on the Internet. 

Must be reviewed before merghing.