### PR TITLE
Set netplay_enabled to false during deinit_netplay

### DIFF
--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -885,6 +885,7 @@ void deinit_netplay(void)
    if (netplay_data)
       netplay_free(netplay_data);
    netplay_data = NULL;
+   netplay_enabled = false;
    core_unset_netplay_callbacks();
 }
 


### PR DESCRIPTION
This simply prevents the odd behavior of netplay automatically
restarting, or trying to restart, when you load a new game.