### PR TITLE
Netplay: Add 'haspassword' and 'connectable' flags [WIP]

### DIFF
--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -1359,11 +1359,11 @@ static int action_ok_playlist_entry_collection(const char *path,
 
    menu_driver_ctl(RARCH_MENU_CTL_SYSTEM_INFO_GET, &info);
 
-   /* If the currently loaded core's name is equal 
+   /* If the currently loaded core's name is equal
     * to the core name from the playlist entry,
     * then we directly load this game with the current core.
     */
-   if (info && 
+   if (info &&
          string_is_equal(info->info.library_name, core_name))
    {
       if (playlist_initialized)
@@ -1571,7 +1571,7 @@ static int action_ok_playlist_entry_start_content(const char *path,
 
       new_core_path[0] = new_display_name[0] = '\0';
 
-      found_associated_core                  = 
+      found_associated_core                  =
          menu_content_playlist_find_associated_core(
             path_base, new_core_path, sizeof(new_core_path));
 
@@ -2329,7 +2329,7 @@ static int generic_action_ok_network(const char *path,
       default:
          break;
    }
-   
+
    menu_entries_ctl(MENU_ENTRIES_CTL_SET_REFRESH, &refresh);
 
    command_event(CMD_EVENT_NETWORK_INIT, NULL);
@@ -3137,11 +3137,11 @@ static int action_ok_netplay_connect_room(const char *path,
 
    snprintf(tmp_hostname,
          sizeof(tmp_hostname),
-         "%s:%d", 
+         "%s:%d",
       netplay_room_list[idx - 2].address,
       netplay_room_list[idx - 2].port);
 
-   RARCH_LOG("Connecting to: %s with game: %s/%08x\n", 
+   RARCH_LOG("Connecting to: %s with game: %s/%08x\n",
          tmp_hostname,
          netplay_room_list[idx - 2].gamename,
          netplay_room_list[idx - 2].gamecrc);
@@ -3397,9 +3397,11 @@ finish:
                   room_data->elems[j + 5].data,
                   sizeof(netplay_room_list[i].coreversion));
 
-            netplay_room_list[i].port      = atoi(room_data->elems[j + 2].data);
-            netplay_room_list[i].gamecrc   = atoi(room_data->elems[j + 6].data);
-            netplay_room_list[i].timestamp = atoi(room_data->elems[j + 7].data);
+            netplay_room_list[i].port        = atoi(room_data->elems[j + 2].data);
+            netplay_room_list[i].gamecrc     = atoi(room_data->elems[j + 6].data);
+            netplay_room_list[i].haspassword = atoi(room_data->elems[j + 7].data);
+            netplay_room_list[i].connectable = atoi(room_data->elems[j + 8].data);
+            netplay_room_list[i].timestamp   = atoi(room_data->elems[j + 9].data);
 
 /* Uncomment this to debug mismatched room parameters*/
 #if 0
@@ -3411,6 +3413,8 @@ finish:
                "Core Version:     %s\n"
                "Game:             %s\n"
                "Game CRC:         %08x\n"
+               "Has Password:     %d\n"
+               "Connectable:      %d\n"
                "Timestamp:        %d\n", room_data->elems[j + 6].data,
                netplay_room_list[i].nickname,
                netplay_room_list[i].address,
@@ -3419,6 +3423,8 @@ finish:
                netplay_room_list[i].coreversion,
                netplay_room_list[i].gamename,
                netplay_room_list[i].gamecrc,
+               netplay_room_list[i].haspassword,
+               netplay_room_list[i].connectable,
                netplay_room_list[i].timestamp);
 #endif
             j+=8;
@@ -3453,7 +3459,8 @@ finish:
 static int action_ok_push_netplay_refresh_rooms(const char *path,
       const char *label, unsigned type, size_t idx, size_t entry_idx)
 {
-   char url [2048] = "http://lobby.libretro.com/raw/";
+   //char url [2048] = "http://lobby.libretro.com/raw/";
+   char url [2048] = "http://localhost:9999/raw/";
    task_push_http_transfer(url, true, NULL, netplay_refresh_rooms_cb, NULL);
    return 0;
 }

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -3459,8 +3459,7 @@ finish:
 static int action_ok_push_netplay_refresh_rooms(const char *path,
       const char *label, unsigned type, size_t idx, size_t entry_idx)
 {
-   //char url [2048] = "http://lobby.libretro.com/raw/";
-   char url [2048] = "http://localhost:9999/raw/";
+   char url [2048] = "http://lobby.libretro.com/raw/";
    task_push_http_transfer(url, true, NULL, netplay_refresh_rooms_cb, NULL);
    return 0;
 }

--- a/network/netplay/netplay_discovery.h
+++ b/network/netplay/netplay_discovery.h
@@ -1,6 +1,6 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2016-2017 - Gregor Richards
- * 
+ *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-
  *  ation, either version 3 of the License, or (at your option) any later version.
@@ -58,6 +58,8 @@ struct netplay_room
    char coreversion [PATH_MAX_LENGTH];
    char gamename    [PATH_MAX_LENGTH];
    int  gamecrc;
+   int  haspassword;
+   int  connectable;
    int  timestamp;
 };
 

--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -69,7 +69,7 @@ static bool netplay_is_alive(void)
  * netplay_should_skip:
  * @netplay              : pointer to netplay object
  *
- * If we're fast-forward replaying to resync, check if we 
+ * If we're fast-forward replaying to resync, check if we
  * should actually show frame.
  *
  * Returns: bool (1) if we should skip this frame, otherwise
@@ -120,7 +120,7 @@ static bool get_self_input_state(netplay_t *netplay)
 
    if (!input_driver_is_libretro_input_blocked() && netplay->self_frame_count > 0)
    {
-      /* First frame we always give zero input since relying on 
+      /* First frame we always give zero input since relying on
        * input from first frame screws up when we use -F 0. */
       retro_input_state_t cb = netplay->cbs.state_cb;
       for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)
@@ -180,8 +180,8 @@ bool init_netplay_deferred(const char* server, unsigned port)
  * netplay_poll:
  * @netplay              : pointer to netplay object
  *
- * Polls network to see if we have anything new. If our 
- * network buffer is full, we simply have to block 
+ * Polls network to see if we have anything new. If our
+ * network buffer is full, we simply have to block
  * for new input data.
  *
  * Returns: true (1) if successful, otherwise false (0).
@@ -370,7 +370,7 @@ static int16_t netplay_input_state(netplay_t *netplay,
       unsigned port, unsigned device,
       unsigned idx, unsigned id)
 {
-   size_t ptr = netplay->is_replay ? 
+   size_t ptr = netplay->is_replay ?
       netplay->replay_ptr : netplay->self_ptr;
 
    const uint32_t *curr_input_state = NULL;
@@ -437,10 +437,11 @@ static void netplay_announce()
 
    buf[0] = '\0';
 
+   // TODO: Add haspassword flag.
    snprintf(buf, sizeof(buf), "%susername=%s&corename=%s&coreversion=%s&"
-   "gamename=%s&gamecrc=%d&port=%d", 
-      url, settings->username, system->info.library_name, 
-      system->info.library_version, 
+   "gamename=%s&gamecrc=%d&port=%d&haspassword=0",
+      url, settings->username, system->info.library_name,
+      system->info.library_version,
       !string_is_empty(path_basename(path_get(RARCH_PATH_BASENAME))) ? path_basename(path_get(RARCH_PATH_BASENAME)) : "N/A",*content_crc_ptr,
       settings->netplay.port);
 
@@ -464,7 +465,7 @@ int16_t input_state_net(unsigned port, unsigned device,
  * @sz                     : size of data
  * @command_str            : name of action
  * @success_msg            : message to display upon success
- * 
+ *
  * Sends a single netplay command and waits for response. Only actually used
  * for player flipping. FIXME: Should probably just be removed.
  */
@@ -490,7 +491,7 @@ bool netplay_command(netplay_t* netplay, struct netplay_connection *connection,
  */
 static void netplay_flip_users(netplay_t *netplay)
 {
-   /* Must be in the future because we may have 
+   /* Must be in the future because we may have
     * already sent this frame's data */
    uint32_t     flip_frame = netplay->self_frame_count + 1;
    uint32_t flip_frame_net = htonl(flip_frame);
@@ -564,7 +565,7 @@ static void netplay_frontend_paused(netplay_t *netplay, bool paused)
 }
 
 /**
- * netplay_pre_frame:   
+ * netplay_pre_frame:
  * @netplay              : pointer to netplay object
  *
  * Pre-frame for Netplay.
@@ -629,7 +630,7 @@ bool netplay_pre_frame(netplay_t *netplay)
 }
 
 /**
- * netplay_post_frame:   
+ * netplay_post_frame:
  * @netplay              : pointer to netplay object
  *
  * Post-frame for Netplay.
@@ -709,9 +710,9 @@ void netplay_send_savestate(netplay_t *netplay,
 /**
  * netplay_load_savestate
  * @netplay              : pointer to netplay object
- * @serial_info          : the savestate being loaded, NULL means 
+ * @serial_info          : the savestate being loaded, NULL means
  *                         "load it yourself"
- * @save                 : Whether to save the provided serial_info 
+ * @save                 : Whether to save the provided serial_info
  *                         into the frame buffer
  *
  * Inform Netplay of a savestate load and send it to the other side
@@ -752,7 +753,7 @@ void netplay_load_savestate(netplay_t *netplay,
       }
    }
 
-   /* We need to ignore any intervening data from the other side, 
+   /* We need to ignore any intervening data from the other side,
     * and never rewind past this */
    netplay_update_unread_ptr(netplay);
    if (netplay->unread_frame_count < netplay->self_frame_count)
@@ -951,9 +952,9 @@ bool init_netplay(void *direct_host, const char *server, unsigned port)
 
    netplay_data = (netplay_t*)netplay_new(
          netplay_is_client ? direct_host : NULL,
-         netplay_is_client ? (!netplay_client_deferred ? server 
+         netplay_is_client ? (!netplay_client_deferred ? server
             : server_address_deferred) : NULL,
-         netplay_is_client ? (!netplay_client_deferred ? port   
+         netplay_is_client ? (!netplay_client_deferred ? port
             : server_port_deferred   ) : (port != 0 ? port : RARCH_DEFAULT_PORT),
          settings->netplay.stateless_mode, settings->netplay.check_frames, &cbs,
          settings->netplay.nat_traversal, settings->username,
@@ -974,7 +975,7 @@ bool init_netplay(void *direct_host, const char *server, unsigned port)
 
 /**
  * netplay_driver_ctl
- * 
+ *
  * Frontend access to Netplay functionality
  */
 bool netplay_driver_ctl(enum rarch_netplay_ctl_state state, void *data)


### PR DESCRIPTION
Add two new fields:

- `haspassword`
- `connectable` ala https://github.com/RobLoach/libretro-netplay-registry/pull/24

This is not complete, and will need some work from @fr500 to make sure we:

1. Parse in the flags correctly
2. Merge https://github.com/RobLoach/libretro-netplay-registry/pull/24 and deploy it up to lobby.libretro.com