### PR TITLE
Move / to the bottom in Load Content

### DIFF
--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -1794,12 +1794,6 @@ static int mui_list_push(void *data, void *userdata,
       case DISPLAYLIST_LOAD_CONTENT_LIST:
          menu_entries_ctl(MENU_ENTRIES_CTL_CLEAR, info->list);
 
-         if (frontend_driver_parse_drive_list(info->list) != 0)
-            menu_entries_append_enum(info->list, "/",
-                  msg_hash_to_str(MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR),
-                  MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR,
-                  MENU_SETTING_ACTION, 0, 0);
-
          menu_entries_append_enum(info->list,
                msg_hash_to_str(MENU_ENUM_LABEL_VALUE_FAVORITES),
                msg_hash_to_str(MENU_ENUM_LABEL_FAVORITES),
@@ -1815,6 +1809,12 @@ static int mui_list_push(void *data, void *userdata,
                   MENU_ENUM_LABEL_DOWNLOADED_FILE_DETECT_CORE_LIST,
                   MENU_SETTING_ACTION, 0, 0);
          }
+
+         if (frontend_driver_parse_drive_list(info->list) != 0)
+            menu_entries_append_enum(info->list, "/",          
+                  msg_hash_to_str(MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR),
+                  MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR,
+                  MENU_SETTING_ACTION, 0, 0);
 
          info->need_push    = true;
          info->need_refresh = true;

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -5373,12 +5373,6 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, void *data)
          info->need_refresh = true;
          break;
       case DISPLAYLIST_LOAD_CONTENT_LIST:
-         if (frontend_driver_parse_drive_list(info->list) != 0)
-            menu_entries_append_enum(info->list, "/",
-                  msg_hash_to_str(MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR),
-                  MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR,
-                  MENU_SETTING_ACTION, 0, 0);
-
          if (!string_is_empty(settings->directory.menu_content))
             menu_entries_append_enum(info->list,
                   msg_hash_to_str(MENU_ENUM_LABEL_VALUE_FAVORITES),
@@ -5404,6 +5398,12 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, void *data)
                MENU_ENUM_LABEL_CONTENT_COLLECTION_LIST,
                MENU_SETTING_ACTION, 0, 0);
 #endif
+
+         if (frontend_driver_parse_drive_list(info->list) != 0)
+            menu_entries_append_enum(info->list, "/",
+                  msg_hash_to_str(MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR),
+                  MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR,
+                  MENU_SETTING_ACTION, 0, 0);
 
 #if 0
          menu_entries_append_enum(info->list,


### PR DESCRIPTION
Note: This is a suggestion, opinions and suggestions welcome. :)

This will move `/` in `Load Content` to the bottom of the list so that `Favorites` will be the default option. The idea is that most users likely will want their `File Browser` setting as the default when loading content. This has been discussed in #retroarch before, but I guess it never happened and more recently it confused a user updating to a nightly.
```
02:10 <EDM> Just updated to the 01/31 Nightly
02:10 <EDM> Load content doesnt open the directory specified in "File Browswer"
02:21 <orbea> EDM: it should be favorites now
02:22 <orbea> load content > favorites
02:22 <EDM> Hmmm
02:22 <EDM> Went from a one button process to 3 button process
02:23 <orbea> there was some discussion about moving / to the buttom, guess it never happened though
```
This should work for at least xmb, materialui and rgui.