### PR TITLE
Rewrite German translation (part 2)

### DIFF
--- a/intl/msg_hash_de.h
+++ b/intl/msg_hash_de.h
@@ -1,113 +1,436 @@
-MSG_HASH(MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_PASSWORD,
-      "Passwort")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_USERNAME,
-      "Benutzername")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_ACCOUNTS_LIST,
-      "Konten")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_ACHIEVEMENT_LIST,
-      "Errungenschaften")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_ACHIEVEMENT_LIST_HARDCORE,
-      "Errungenschaften (Hardcore)")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_ADD_TAB,
-      "Hinzufügen")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_ARCHIVE_MODE,
-      "Verknüpfte Aktion bei Archivdateien")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_ASK_ARCHIVE,
-      "Nachfragen")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_ASSETS_DIRECTORY,
-      "Assets-Verzeichnis")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_AUDIO_BLOCK_FRAMES,
-      "Warte auf Audio-Frames")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_AUDIO_DEVICE,
-      "Soundkarte")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_AUDIO_DRIVER,
-      "Audiotreiber")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_AUDIO_DSP_PLUGIN,
-      "Audio-DSP-Plugin")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_AUDIO_ENABLE,
-      "Aktiviere Audio")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_AUDIO_FILTER_DIR,
-      "Audiofilterverzeichnis")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_AUDIO_LATENCY,
-      "Audiolatenz (ms)")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_AUDIO_MAX_TIMING_SKEW,
-      "Maximaler Audioversatz")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_AUDIO_MUTE,
-      "Stumm")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_AUDIO_OUTPUT_RATE,
-      "Audiofrequenzrate (kHz)")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_AUDIO_RATE_CONTROL_DELTA,
-      "Audio Rate Control Delta")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_AUDIO_RESAMPLER_DRIVER,
-      "Audio-Resampler-Treiber")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_AUDIO_SETTINGS,
-      "Audioeinstellungen")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_AUDIO_SYNC,
-      "Synchronisiere Audio")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_AUDIO_VOLUME,
-      "Lautstärke (dB)")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_AUTOSAVE_INTERVAL,
-      "Automatischespeicherungsintervall")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_AUTO_OVERRIDES_ENABLE,
-      "Override-Dateien automatisch laden")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_AUTO_REMAPS_ENABLE,
-      "Remap-Dateien automatisch laden")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_BLOCK_SRAM_OVERWRITE,
-      "Blockiere SRAM-Überschreibung")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_BUILDBOT_ASSETS_URL,
-      "Buildbot-Assets-URL")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_CACHE_DIRECTORY, /* FIXME/UPDATE */
-      "Entpackverzeichnis")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_CAMERA_ALLOW,
-      "Erlaube Kamera-Zugriff")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_CAMERA_DRIVER,
-      "Kameratreiber")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_CHEAT,
-      "Cheat")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_CHEAT_APPLY_CHANGES,
-      "Änderungen übernehmen")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_CHEAT_DATABASE_PATH,
-      "Cheat-Dateiverzeichnis")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_CHEAT_FILE_LOAD,
-      "Cheat-Datei laden")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_CHEAT_FILE_SAVE_AS,
-      "Speichere Cheat-Datei unter...")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_CHEAT_NUM_PASSES,
-      "Cheat-Durchgänge")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_CHECK_FOR_MISSING_FIRMWARE,
-      "Überprüfe Firmware vor dem Laden.")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_CHEEVOS_ENABLE,
-      "Aktiviere Errungenschaften")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_CHEEVOS_HARDCORE_MODE_ENABLE,
-      "Hardcore-Modus")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_CHEEVOS_TEST_UNOFFICIAL,
-      "Teste unoffizielle Errungenschaften")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_CLOSE_CONTENT,
-      "Schließen")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_CONFIGURATIONS,
-      "Konfigurationsdatei laden") /* FIXME/UPDATE */
-MSG_HASH(MENU_ENUM_LABEL_VALUE_CONFIGURATION_SETTINGS,
-      "Konfigurationseinstellungen")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_CONFIGURATIONS_LIST,
-      "Konfigurationen")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_CONFIG_SAVE_ON_EXIT,
-      "Speichere Konfiguration beim Beenden")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_CONTENT_COLLECTION_LIST,
-      "Inhalt laden")  /* FIXME/TODO - rewrite */
-MSG_HASH(MENU_ENUM_LABEL_VALUE_CONTENT_DATABASE_DIRECTORY,
-      "Inhaltsdatenbankverzeichnis")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_CONTENT_HISTORY_SIZE,
+MSG_HASH(
+      MSG_COMPILER,
+      "Compiler"
+      )
+MSG_HASH(
+      MSG_UNKNOWN_COMPILER,
+      "Unbekannter Compiler"
+      )
+MSG_HASH(
+      MSG_DEVICE_DISCONNECTED_FROM_PORT,
+      "Gerät nicht mit dem Anschluss verbunden"
+      )
+MSG_HASH(
+      MSG_UNKNOWN_NETPLAY_COMMAND_RECEIVED,
+      "Unbekannter Netplay-Befehl empfangen"
+      )
+MSG_HASH(
+      MSG_FILE_ALREADY_EXISTS_SAVING_TO_BACKUP_BUFFER,
+      "Datei existiert bereits. Speichern im Backup-Puffer"
+      )
+MSG_HASH(
+      MSG_GOT_CONNECTION_FROM,
+      "Verbindung erhalten von"
+      )
+MSG_HASH(
+      MSG_PUBLIC_ADDRESS,
+      "Öffentliche Addresse"
+      )
+MSG_HASH(
+      MSG_NO_ARGUMENTS_SUPPLIED_AND_NO_MENU_BUILTIN,
+      "Es wurden keine Argumente übergeben, außerdem ist kein Menü vorhanden - zeige Hilfe an..."
+      )
+MSG_HASH(
+      MSG_NETPLAY_USERS_HAS_FLIPPED,
+      "Netplay-Benutzer wurden vertauscht"
+      )
+MSG_HASH(
+      MSG_SETTING_DISK_IN_TRAY,
+      "Lege Datenträger in Laufwerksschublade ein"
+      )
+MSG_HASH(
+      MSG_WAITING_FOR_CLIENT,
+      "Warte auf Client ..."
+      )
+MSG_HASH(
+      MENU_ENUM_SUBLABEL_VIDEO_SHARED_CONTEXT,
+      "Gibt Hardware-gerenderten Cores einen eigenen privaten Kontext. Vermeidet, dass der Hardware-Status zwischen den Frames geschätzt werden muss."
+      )
+MSG_HASH(
+      MENU_ENUM_SUBLABEL_MENU_SETTINGS,
+      "Legt die Einstellungen für das Aussehen des Menübildschirms fest."
+      )
+MSG_HASH(
+      MENU_ENUM_SUBLABEL_VIDEO_HARD_SYNC,
+      "'Harte' Synchronisation der CPU und der GPU. Reduziert Latenz, braucht aber mehr Leistung."
+      )
+MSG_HASH(
+      MENU_ENUM_SUBLABEL_VIDEO_THREADED,
+      "Verbessert die Leistung, führt aber zu größerer Latenz und Videoproblemen. "
+      "Verwende dies nur, wenn Du sonst die gewünschte Leistung nicht erreichst."
+	  )
+MSG_HASH(
+      MSG_AUDIO_VOLUME,
+      "Audio-Lautstärke"
+      )
+MSG_HASH(
+      MSG_AUTODETECT,
+      "Automatisch erkennen"
+      )
+MSG_HASH(
+      MSG_AUTOLOADING_SAVESTATE_FROM,
+      "Lade Spielstände automatisch von"
+      )
+MSG_HASH(
+      MSG_CAPABILITIES,
+      "Fähikeiten"
+      )
+MSG_HASH(
+      MSG_CONNECTING_TO_NETPLAY_HOST,
+      "Verbinde zu Netplay-Host"
+      )
+MSG_HASH(
+      MSG_CONNECTING_TO_PORT,
+      "Verbinde zu Port"
+      )
+MSG_HASH(
+      MSG_CONNECTION_SLOT,
+      "Verbindungs-Slot"
+      )
+MSG_HASH(
+      MSG_SORRY_UNIMPLEMENTED_CORES_DONT_DEMAND_CONTENT_NETPLAY,
+      "Entschuldigung, nicht implementiert: Cores, die keinen Inhalt verlangen, können nicht an Netplay teilnehmen."
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_PASSWORD,
+      "Passwort"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_SETTINGS,
+      "Cheevos-Benutzerkonten"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_ACCOUNTS_CHEEVOS_USERNAME,
+      "Benutzername"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_ACCOUNTS_LIST,
+      "Benutzerkonten"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_ACCOUNTS_LIST_END,
+      "Endpunkt der Benutzerkonten-Liste"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_ACCOUNTS_RETRO_ACHIEVEMENTS,
+      "Retro-Errungenschaften"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_ACHIEVEMENT_LIST,
+      "Errungenschaften"
+      )
+
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_ACHIEVEMENT_LIST_HARDCORE,
+      "Errungenschaften (Hardcore)"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_ADD_CONTENT_LIST,
+      "Inhalt durchsuchen"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_CONFIGURATIONS_LIST,
+      "Konfigurationen"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_ADD_TAB,
+      "Inhalt importieren"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_ARCHIVE_MODE,
+      "Verknüpfte Aktion bei Archivdateien"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_ASK_ARCHIVE,
+      "Nachfragen"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_ASSETS_DIRECTORY,
+      "Assets-Verzeichnis"
+	  )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_AUDIO_BLOCK_FRAMES,
+      "Warte auf Audio-Frames"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_AUDIO_DEVICE,
+      "Soundkarte"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_AUDIO_DRIVER,
+      "Audiotreiber"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_AUDIO_DSP_PLUGIN,
+      "Audio-DSP-Plugin"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_AUDIO_ENABLE,
+      "Aktiviere Audio"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_AUDIO_FILTER_DIR,
+      "Audiofilter-Verzeichnis"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_TURBO_DEADZONE_LIST,
+      "Turbo/Deadzone"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_AUDIO_LATENCY,
+      "Audiolatenz (ms)"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_AUDIO_MAX_TIMING_SKEW,
+      "Maximaler Audioversatz"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_AUDIO_MUTE,
+      "Stumm"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_AUDIO_OUTPUT_RATE,
+      "Audiofrequenzrate (KHz)"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_AUDIO_RATE_CONTROL_DELTA,
+      "Dynamische Audio-Ratenkontrolle"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_AUDIO_RESAMPLER_DRIVER,
+      "Audio-Resampling-Treiber"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_AUDIO_SETTINGS,
+      "Audio-Einstellungen"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_AUDIO_SYNC,
+      "Synchronisiere Audio"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_AUDIO_VOLUME,
+      "Lautstärke (dB)"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_AUTOSAVE_INTERVAL,
+      "Intervall für automatisches Speichern des SaveRAM"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_AUTO_OVERRIDES_ENABLE,
+      "Override-Dateien automatisch laden"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_AUTO_REMAPS_ENABLE,
+      "Remap-Dateien automatisch laden"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_AUTO_SHADERS_ENABLE,
+      "Shader-Vorlagen automatisch laden"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_BACK,
+      "Zurück"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_CONFIRM,
+      "Bestätigen"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_INFO,
+      "Info"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_QUIT,
+      "Beenden"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_SCROLL_DOWN,
+      "Nach unten scrollen"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_SCROLL_UP,
+      "Nach oben scrollen"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_START,
+      "Start"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_TOGGLE_KEYBOARD,
+      "Tastatur ein-/ausschalten"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_TOGGLE_MENU,
+      "Menü ein-/ausschalten"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS,
+      "Grundlegende Menüsteuerung"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_CONFIRM,
+      "Bestätigen/OK"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_INFO,
+      "Info"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_QUIT,
+      "Beenden"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_SCROLL_UP,
+      "Nach oben scrollen"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_START,
+      "Standardwerte"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_TOGGLE_KEYBOARD,
+      "Tastatur ein-/ausschalten"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_BASIC_MENU_ENUM_CONTROLS_TOGGLE_MENU,
+      "Menü ein-/ausschalten"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_BLOCK_SRAM_OVERWRITE,
+      "Überschreibe SaveRAM nicht, wenn ein Savestate geladen wird"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_BLUETOOTH_ENABLE,
+      "Bluetooth aktivieren"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_BUILDBOT_ASSETS_URL,
+      "Buildbot-Assets-URL"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_CACHE_DIRECTORY,
+      "Temporäre Dateien"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_CAMERA_ALLOW,
+      "Erlaube Kamera-Zugriff"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_CAMERA_DRIVER,
+      "Kamera-Treiber"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_CHEAT,
+      "Cheat"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_CHEAT_APPLY_CHANGES,
+      "Änderungen übernehmen"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_CHEAT_DATABASE_PATH,
+      "Cheat-Datei"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_CHEAT_FILE,
+      "Cheat-Date"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_CHEAT_FILE_LOAD,
+      "Cheat-Datei laden"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_CHEAT_FILE_SAVE_AS,
+      "Speichere Cheat-Datei unter..."
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_CHEAT_NUM_PASSES,
+      "Cheat-Durchläufe"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_CHEEVOS_DESCRIPTION,
+      "Beschreibung"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_CHEEVOS_HARDCORE_MODE_ENABLE,
+      "Hardcore-Modus"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_CHEEVOS_LOCKED_ACHIEVEMENTS,
+      "Gesperrte Errungenschaften:"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_CHEEVOS_LOCKED_ENTRY,
+      "Gesperrt"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_CHEEVOS_SETTINGS,
+      "Retro-Errungenschaften"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_CHEEVOS_TEST_UNOFFICIAL,
+      "Teste inoffizielle Errungenschaften"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_CHEEVOS_UNLOCKED_ACHIEVEMENTS,
+      "Entsperrte Errungenschaften:"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_CHEEVOS_UNLOCKED_ENTRY,
+      "Entsperrt"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_CLOSE_CONTENT,
+      "Schließen"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_CONFIG,
+      "Konfiguration"
+	  )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_CONFIGURATIONS,
+      "Konfgurationsdatei laden"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_CONFIGURATION_SETTINGS,
+      "Konfigurations-Einstellungen"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_CONFIG_SAVE_ON_EXIT,
+      "Einstellungen beim Beenden speichern"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_CONFIRM_ON_EXIT,
+      "Vor dem Beenden nachfragen"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_CONTENT_COLLECTION_LIST,
+      "Sammlungen"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_CONTENT_DATABASE_DIRECTORY,
+      "Inhalts-Datenbank"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_CONTENT_DIR,
+      "Inhalt"
+      )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_CONTENT_HISTORY_SIZE,
       "Länge der Verlaufsliste")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_CONTENT_SETTINGS,
-      "Inhaltseinstellungen") /* FIXME */
+      "Inhaltseinstellungen")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_CORE_ASSETS_DIR,
+      "Core-Assets")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_CORE_ASSETS_DIRECTORY,
-      "Core-Assets-Verzeichnis") /* FIXME/UPDATE */
+      "Downloads")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_CORE_CHEAT_OPTIONS,
       "Cheats")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_CORE_COUNTERS,
       "Core-Zähler")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_CORE_ENABLE,
-      "Zeige Core-Namen")
+      "Core-Namen anzeigen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_CORE_INFORMATION,
       "Core-Informationen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_CORE_INFO_AUTHORS,
@@ -115,7 +438,7 @@ MSG_HASH(MENU_ENUM_LABEL_VALUE_CORE_INFO_AUTHORS,
 MSG_HASH(MENU_ENUM_LABEL_VALUE_CORE_INFO_CATEGORIES,
       "Kategorien")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_LABEL,
-      "Core-Beschriftung")
+      "Core-Bezeichnung")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_CORE_INFO_CORE_NAME,
       "Core-Name")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_CORE_INFO_FIRMWARE,
@@ -125,101 +448,115 @@ MSG_HASH(MENU_ENUM_LABEL_VALUE_CORE_INFO_LICENSES,
 MSG_HASH(MENU_ENUM_LABEL_VALUE_CORE_INFO_PERMISSIONS,
       "Berechtigungen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_CORE_INFO_SUPPORTED_EXTENSIONS,
-      "Unterstütze Erweiterungen")
+      "Unterstützte Erweiterungen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_MANUFACTURER,
       "System-Hersteller")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_CORE_INFO_SYSTEM_NAME,
       "System-Name")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_CORE_INPUT_REMAPPING_OPTIONS, /* UPDATE/FIXME */
-      "Core-Input-Optionen")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_CORE_INPUT_REMAPPING_OPTIONS,
+      "Core-Eingabeoptionen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_CORE_LIST,
       "Core laden")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_CORE_OPTIONS,
       "Optionen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_CORE_SETTINGS,
       "Core-Einstellungen")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_CORE_SET_SUPPORTS_NO_CONTENT_ENABLE, /* TODO/FIXME */
-      "Cores nicht automatisch starten")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_CORE_SET_SUPPORTS_NO_CONTENT_ENABLE,
+      "Cores automatisch starten")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE,
       "Heruntergeladene Archive automatisch entpacken")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_CORE_UPDATER_BUILDBOT_URL,
       "Buildbot-Cores-URL")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_CORE_UPDATER_LIST,
-      "Aktualisiere Core")
+      "Cores aktualisieren")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_CORE_UPDATER_SETTINGS,
-      "Core-Aktualisierungseinstellungen") /* UPDATE/FIXME */
+      "Aktualisierungen")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_CPU_ARCHITECTURE,
+      "CPU-Architektur:")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_CPU_CORES,
-      "Prozessorkerne:")
+      "CPU-Kerne:")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_CURSOR_DIRECTORY,
-      "Cursor-Verzeichnis")
+      "Cursor")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_CURSOR_MANAGER,
-      "Zeiger-Manager")
+      "Mauszeiger-Manager")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_CUSTOM_RATIO,
       "Benutzerdefiniertes Verhältnis")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_DATABASE_MANAGER,
       "Datenbank-Manager")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_DATABASE_SELECTION,
+      "Datenbank-Auswahl")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_DELETE_ENTRY,
       "Von der Wiedergabeliste löschen")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_FAVORITES,
-      "Lesezeichen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_DIRECTORY_CONTENT,
       "<Inhaltsverzeichnis>")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_DIRECTORY_DEFAULT,
-      "<Voreinstellung>")
+      "<Standard>")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_DIRECTORY_NONE,
       "<Keins>")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_DIRECTORY_NOT_FOUND,
-      "Ordner nicht gefunden.")
+      "Verzeichnis nicht gefunden.")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_DIRECTORY_SETTINGS,
-      "Verzeichniseinstellungen")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_DISABLED,
-      "Deaktiviert")
+      "Verzeichnis")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_DISK_CYCLE_TRAY_STATUS,
-      "Datenträgerstatus")
+      "Datentägerstatus")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_DISK_IMAGE_APPEND,
       "Füge Datenträgerabbild hinzu")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_DISK_INDEX,
       "Datenträger-Nummer")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_DISK_OPTIONS, /* UPDATE/FIXME */
+MSG_HASH(MENU_ENUM_LABEL_VALUE_DISK_OPTIONS,
       "Datenträger-Optionen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_DONT_CARE,
-      "Mir egal")
+      "Ignorieren")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_DOWNLOADED_FILE_DETECT_CORE_LIST,
+      "Downloads")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_DOWNLOAD_CORE,
       "Core herunterladen...")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_DOWNLOAD_CORE_CONTENT,
-      "Inhalt Downloader")
+      "Inhalt herunterladen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_ENABLE,
       "Aktiviere DPI-Override")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_DPI_OVERRIDE_VALUE,
       "DPI-Override")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_DRIVER_SETTINGS,
-      "Treibereinstellungen")
+      "Treiber")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_DUMMY_ON_CORE_SHUTDOWN,
-      "Dummy bei Core-Abschaltung")
+      "Dummy laden, wenn Core beendet wird")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_CHECK_FOR_MISSING_FIRMWARE,
+      "Vor dem Laden nach fehlender Firmware suchen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPER,
-      "Dynamischer Hintergrund")
+      "Dynamisches Hintergrundbild")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_DYNAMIC_WALLPAPERS_DIRECTORY,
-      "Dynamischehintergrundbilderverzeichnis")
+      "Dynamische Hintergrundbilder")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_CHEEVOS_ENABLE,
+      "Aktiviere Errungenschaften")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_ENTRY_HOVER_COLOR,
-      "Hover-Farbe für Menü-Einträge")
+      "Farbe für gewählte Menü-Einträge")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_ENTRY_NORMAL_COLOR,
-      "Normale Farbe für Menü-Einträge")
+      "Farbe für nicht gewählte Menü-Einträge")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_FALSE,
-      "False")
+      "Aus")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_FASTFORWARD_RATIO,
-      "Maximale Ausführungsgeschwindigkeit")
+      "Maximale Ausführgeschwindigkeit")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_FPS_SHOW,
       "Zeige Bildwiederholrate")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_ENABLE,
-      "Begrenze maximale Ausführungsgeschwindigkeit")
+      "Begrenze maximale Ausführgeschwindigkeit")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_SETTINGS,
+      "Bildgeschwindigkeit")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_FRONTEND_COUNTERS,
-      "Frontendzähler")
+      "Frontend-Zähler")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS,
+      "Lade inhaltsspezifische Core-Einstellungen automatisch")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS_CREATE,
+      "Erstelle Datei für Spieloptionen")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS_IN_USE,
+      "Spieloptionen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_HELP,
       "Hilfe")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_HELP_AUDIO_VIDEO_TROUBLESHOOTING,
-      "Audio/Video Fehlerbehebung")
+      "Audio/Video-Fehlerbehebung")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_HELP_CHANGE_VIRTUAL_GAMEPAD,
-      "Ändere das Virtual Gamepad Overlay")
+      "Ändere virtuelles Gamepad-Overlay")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_HELP_CONTROLS,
       "Grundlegende Menüsteuerung")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_HELP_LIST,
@@ -231,45 +568,61 @@ MSG_HASH(MENU_ENUM_LABEL_VALUE_HELP_SCANNING_CONTENT,
 MSG_HASH(MENU_ENUM_LABEL_VALUE_HELP_WHAT_IS_A_CORE,
       "Was ist ein Core?")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_HISTORY_LIST_ENABLE,
-      "Aktiviere Verlaufsliste")
+      "Verlaufliste aktivieren")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_HISTORY_TAB,
       "Verlauf")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_HORIZONTAL_MENU, /* Don't change. Breaks everything. (Would be, "Horizontales Menu") */
-      "Horizontal Menu")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_HORIZONTAL_MENU,
+      "Horizontales Menü")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_IMAGES_TAB,
       "Bilder")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_INFORMATION,
+      "Informationen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INFORMATION_LIST,
       "Informationen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_ADC_TYPE,
       "Analog-zu-Digital-Typ")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_ALL_USERS_CONTROL_MENU,
-      "Jeder Nutzer kann das Menü steuern")
+      "Alle Benutzer können das Menü steuern")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_X,
       "Linker Analogstick X")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_X_MINUS,
       "Linker Analogstick X- (links)")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_X_PLUS,
-      "Linker Analogstick X+ (Rechts)")
+      "Linker Analogstick X+ (rechts)")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_Y,
       "Linker Analogstick Y")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_Y_MINUS,
-      "Linker Analogstick Y- (hoch)")
+      "Linker Analogstick Y- (nach oben)")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_LEFT_Y_PLUS,
-      "Linker Analogstick Y+ (runter)")
+      "Linker Analogstick Y+ (nach unten)")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_X,
+      "Rechter Analogstick X")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_X_MINUS,
+      "Rechter Analogstick X- (links)")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_X_PLUS,
+      "Rechter Analogstick X+ (rechts)")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_Y,
+      "Rechter Analogstick Y")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_Y_MINUS,
+      "Rechter Analogstick Y- (nach oben)")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_ANALOG_RIGHT_Y_PLUS,
+      "Rechter Analogstick Y+ (nach unten)")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_AUTODETECT_ENABLE,
       "Automatische Konfiguration aktivieren")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_AXIS_THRESHOLD,
-      "Schwellwert der Eingabe-Achsen")
+      "Schwellenwert der Analogsticks")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_MENU_INPUT_SWAP_OK_CANCEL,
+      "Vertausche OK- und Zurück-Tasten im  Menü")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_BIND_ALL,
-      "Binde alle")
+      "Alle zuordnen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_BIND_DEFAULT_ALL,
-      "Binde alle Standard") /* @TODO: What is this */
+      "Standard-Belegung wiederherstellen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_BIND_TIMEOUT,
-      "Bindeunterbrechung")
+      "Zeitlimit für Belegung")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_HIDE_UNBOUND,
-      "Verstecke nicht zugewiesene Core-Eingabe-Beschriftungen")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_LABEL_SHOW, /* TODO/FIXME */
-      "Zeige Core-Eingabe-Beschriftungen")
+      "Verstecke nicht zugewiesene Eingabe-Beschriftungen")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_DESCRIPTOR_LABEL_SHOW,
+      "Zeige Eingabe-Beschriftungen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_DEVICE_INDEX,
       "Geräteindex")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_DEVICE_TYPE,
@@ -277,87 +630,93 @@ MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_DEVICE_TYPE,
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_DRIVER,
       "Eingabetreiber")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_DUTY_CYCLE,
-      "Auslastungsgrad")
+      "Haltedauer")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_HOTKEY_BINDS,
+      "Hotkeys belegen")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_ICADE_ENABLE,
+      "Gamepad-Eingabe auf Tastatur legen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_A,
       "A-Knopf (rechts)")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_B,
-      "B-Knopf (unten)")
+      "B-Knopf (nach unten)")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_DOWN,
-      "Steuerkreuz unten")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_L,
-      "L-Knopf (Schultertaste)")
+      "Steuerkreuz nach unten")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_L2,
       "L2-Knopf (Abzug)")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_L3,
       "L3-Knopf (Daumen)")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_L,
+      "L-Knopf (Schultertaste)")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_LEFT,
-      "Steuerkreuz links")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_R,
-      "R-Knopf (Schultertaste)")
+      "Steuerkreuz nach links")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_R2,
       "R2-Knopf (Abzug)")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_R3,
       "R3-Knopf (Daumen)")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_R,
+      "R-Knopf (Schultertaste)")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_RIGHT,
-      "Steuerkreuz rechts")
+      "Steuerkreuz nach rechts")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_SELECT,
       "Select-Knopf")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_START,
-      "Startknopf")
+      "Start-Knopf")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_UP,
-      "Steuerkreuz oben")
+      "Steuerkreuz nach oben")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_X,
       "X-Knopf (oben)")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_JOYPAD_Y,
       "Y-Knopf (links)")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_KEY,
+      "(Taste: %s)")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_KEYBOARD_GAMEPAD_MAPPING_TYPE,
+      "Typ der Keyboard-Gamepad-Abbildung")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_MAX_USERS,
       "Maximale Benutzeranzahl")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO,
-      "Gamepad-Menükombination")
+      "Gamepad-Tastenkombination für Menü")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_CHEAT_INDEX_MINUS,
       "Cheat-Index -")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_CHEAT_INDEX_PLUS,
       "Cheat-Index +")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_CHEAT_TOGGLE,
-      "Cheat ein/aus")
+      "Cheat ein-/ausschalten")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_DISK_EJECT_TOGGLE,
-      "Disk ein-/auswerfen")
+      "Datenträger einlegen/auswerfen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_DISK_NEXT,
-      "Nächste Disk")
+      "Nächster Datenträger")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_DISK_PREV,
-      "Vorherige Disk")
+      "Vorheriger Datenträger")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_ENABLE_HOTKEY,
-      "Hotkeys ein/aus")
+      "Hotkeys aktivieren")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_FAST_FORWARD_HOLD_KEY,
-      "Zeitraffer")
+      "Zeitraffer (halten)")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_FAST_FORWARD_KEY,
-      "Zeitraffer ein/aus")
+      "Zeitraffer ein-/ausschalten")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_FRAMEADVANCE,
-      "Bildervorlauf") /* @TODO: I don't know what this is */
+      "Einzelbildvorlauf")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_FULLSCREEN_TOGGLE_KEY,
-      "Vollbild ein/aus")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_GAME_FOCUS_TOGGLE,
-      "Spielfokus ein/aus")
+      "Vollbildmodus ein-/ausschalten")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_GRAB_MOUSE_TOGGLE,
-      "Maus greiffen ein/aus")
+      "Mauszeiger einfangen/loslassen")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_GAME_FOCUS_TOGGLE,
+      "Spielfokus ein-/ausschalten")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_LOAD_STATE_KEY,
-      "Lade Speicherstand")
+      "Savestate laden")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_MENU_TOGGLE,
-      "Menü ein/aus")
+      "Menü aufrufen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_MOVIE_RECORD_TOGGLE,
-      "Videoaufzeichnung ein/aus")
+      "Videoaufzeichnung starten/beenden")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_MUTE,
-      "Stumm ein/aus")
+      "Audio stumm-/lautschalten")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_NETPLAY_FLIP,
-      "Netplay wechsle Benutzer") /* @TODO What does flip mean in this context? */
-MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_NETPLAY_GAME_WATCH,
-      "Netplay Zuschauermodus ein/aus")
+      "Netplay-Benutzer vertauschen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_OSK,
-      "Bildschirmtastatus ein/aus")
+      "Bildschirmtastatur ein-/ausschalten")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_OVERLAY_NEXT,
       "Nächstes Overlay")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_PAUSE_TOGGLE,
-      "Pause ein/aus")
+      "Pause/weiter")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_QUIT_KEY,
       "RetroArch beenden")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_RESET,
@@ -365,63 +724,69 @@ MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_RESET,
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_REWIND,
       "Zurückspulen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_SAVE_STATE_KEY,
-      "Erstelle Speicherstand")
+      "Erstelle Savestate")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_SCREENSHOT,
       "Erstelle Bildschirmfoto")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_SHADER_NEXT,
       "Nächster Shader")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_SHADER_PREV,
-      "Verheriger Shader")
+      "Vorheriger Shader")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_SLOWMOTION,
       "Zeitlupe")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_STATE_SLOT_MINUS,
-      "Speicherstandplatz -")
+      "Savestate-Slot -")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_STATE_SLOT_PLUS,
-      "Speicherstandplatz +")
+      "Savestate-Slot +")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_VOLUME_DOWN,
       "Lautstärke -")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_META_VOLUME_UP,
       "Lautstärke +")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_OSK_OVERLAY_ENABLE,
-      "Zeige Tastatur-Overlay")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_ENABLE,
       "Aktiviere Overlay")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_HIDE_IN_MENU,
       "Overlay im Menü nicht anzeigen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR,
-      "Eingabeabfrageverhalten")
+      "Abfrageverhalten")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR_EARLY,
       "Früh")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR_LATE,
       "Spät")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_POLL_TYPE_BEHAVIOR_NORMAL,
       "Normal")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_REMAPPING_DIRECTORY, /* UPDATE/FIXME */
-      "Eingabebelegungsverzeichnis")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_PREFER_FRONT_TOUCH,
+      "Touch-Eingabe auf der Vorderseite bevorzugen")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_REMAPPING_DIRECTORY,
+      "Eingabe-Belegungen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_REMAP_BINDS_ENABLE,
-      "Bind-Remapping aktivieren")
+      "Tasten-Umbelegung aktivieren")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_SAVE_AUTOCONFIG,
-      "Speichere Autokonfigurationen")
+      "Speichere Autokonfiguration")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_SETTINGS,
-      "Eingabeeinstellungen")
+      "Eingabe-Einstellungen")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_SMALL_KEYBOARD_ENABLE,
+      "Kleine Tastatur aktivieren")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_TOUCH_ENABLE,
+      "Touch-Eingabe aktivieren")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_TURBO_ENABLE,
       "Turbo aktivieren")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_TURBO_PERIOD,
       "Turbo-Dauer")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_UNIFIED_MENU_CONTROLS,
-      "Einheitliche Menüsteuerung")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_INPUT_USER_BINDS,
-      "Spieler %u Tastenbelegung")
+      "Belegungen für Benutzer %u")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_INTERNAL_STORAGE_STATUS,
+      "Status des internen Speichers")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_JOYPAD_AUTOCONFIG_DIR,
-      "Eingabegerät-Autoconfig-Verzeichnis")
+      "Eingabe-Autokonfiguration")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_JOYPAD_DRIVER,
       "Joypad-Treiber")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_LAKKA_SERVICES,
+      "Services")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_LANG_CHINESE_SIMPLIFIED,
-      "Chinesisch (Vereinfacht)")
+      "Chinesisch (vereinfacht)")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_LANG_CHINESE_TRADITIONAL,
-      "Chinesisch (Traditionell)")
+      "Chinesisch (traditionell)")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_LANG_DUTCH,
-      "Niederländisch")
+      "Niederlöndisch")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_LANG_ENGLISH,
       "Englisch")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_LANG_ESPERANTO,
@@ -436,132 +801,140 @@ MSG_HASH(MENU_ENUM_LABEL_VALUE_LANG_JAPANESE,
       "Japanisch")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_LANG_KOREAN,
       "Koreanisch")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_LANG_POLISH,
+      "Polnisch")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_LANG_PORTUGUESE,
       "Portugiesisch")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_LANG_RUSSIAN,
       "Russisch")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_LANG_SPANISH,
       "Spanisch")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_LANG_VIETNAMESE,
+      "Vietnamesisch")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_LEFT_ANALOG,
       "Linker Analogstick")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_LIBRETRO_DIR_PATH,
-      "Core-Verzeichnis")
+      "Core")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_LIBRETRO_INFO_PATH,
-      "Core-Info-Verzeichnis")
+      "Core-Infos")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_LIBRETRO_LOG_LEVEL,
-      "Core-Logging-Stufe")
+      "Core-Loglevel")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_LINEAR,
       "Linear")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_LOAD_ARCHIVE,
       "Archiv laden")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_HISTORY,
-      "Inhalt laden (Verlauf)") /* FIXME/UPDATE */
+      "Inhalt aus Verlauf laden")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_LIST,
       "Inhalt laden")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_LOAD_STATE,
-      "Spielstand laden")
+      "Savestate laden")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_LOCATION_ALLOW,
-      "Erlaube Standort-Lokalisierung")
+      "Standortbestimmung erlauben")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_LOCATION_DRIVER,
-      "Standorttreiber")
+      "Standort-Treiber")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_LOGGING_SETTINGS,
       "Logging-Einstellungen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_LOG_VERBOSITY,
-      "Log-Ausführlichkeit")
+      "Logs auf Kommandozeile ausgeben")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MAIN_MENU,
       "Hauptmenü")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MANAGEMENT,
-      "Datenbankeinstellungen")
+      "Datenbank-Einstellungen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME,
-      "Menüfarbschema")
+      "Menü-Farbschema")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_BLUE,
+      "Blau")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_BLUE_GREY,
+      "Blau/Grau")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_DARK_BLUE,
+      "Dunkelblau")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_GREEN,
+      "Grün")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_NVIDIA_SHIELD,
+      "Shield")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_RED,
+      "Rot")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_COLOR_THEME_YELLOW,
+      "Gelb")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_FOOTER_OPACITY,
+      "Footer-Transparenz")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_HEADER_OPACITY,
+      "Header-Transparenz")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MENU_DRIVER,
       "Menütreiber")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MENU_ENUM_THROTTLE_FRAMERATE,
-      "Drossle Menübildwiederholrate")
+      "Bildwiederholrate im Menü begrenzen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MENU_FILE_BROWSER_SETTINGS,
-      "Einstellungen")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_MENU_INPUT_SWAP_OK_CANCEL,
-      "Wechsle Ok & Zurück Tasten im Menü")
+      "Dateibrowser")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MENU_LINEAR_FILTER,
-      "Linearer Filter")
+      "Linearer Filter für Menü")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MENU_SETTINGS,
-      "Menüeinstellungen")
+      "Menü")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MENU_WALLPAPER,
-      "Menühintergrund")
+      "Menü-Hintergrundbild")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MENU_WALLPAPER_OPACITY,
-      "Hintergrundtransparenz")
+      "Hintergrundbild-Transparenz")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MISSING,
       "Fehlt")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MORE,
       "...")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MOUSE_ENABLE,
-      "Mausunterstützung")
+      "Maus-Unterstützung")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MULTIMEDIA_SETTINGS,
-      "Multimediaeinstellungen")
+      "Multimedia")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MUSIC_TAB,
       "Musik")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE,
-      "Bekannte Dateiendungen filtern") /* TODO/FIXME - rewrite */
+      "Unbekannte Dateierweiterungen filtern")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NAVIGATION_WRAPAROUND,
       "Navigation umbrechen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NEAREST,
       "Nächster")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NETPLAY,
       "Netplay")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_NETPLAY_CHECK_FRAMES, /* TODO: What actually does this? The translation might be odd. */
-      "Netplay Bildübetragungsrate prüfen")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT, /* TODO, Original string changed */
-      "Tausche Netplay-Eingabe")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_NETPLAY_CHECK_FRAMES,
+      "Netplay-Frames prüfen") /* TODO: What does this setting do? Need more context. */
+MSG_HASH(MENU_ENUM_LABEL_VALUE_NETPLAY_CLIENT_SWAP_INPUT,
+      "Netplay-Spieler 2 verwendet Client 1")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NETPLAY_DELAY_FRAMES,
-      "Verzögere Netplay-Frames")
+      "Netplay-Verzögerungsframes")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NETPLAY_DISCONNECT,
       "Verbindung trennen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE,
       "Aktiviere Netplay")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE_CLIENT,
-      "Verbinde zu einem Netplay Host")
+      "Verbinde zu einem Netplay-Host")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NETPLAY_ENABLE_HOST,
-      "Starte Host")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS, /* TODO, Original string changed */
-      "IP-Addresse für Netplay")
+      "Starte Hosting")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_NETPLAY_IP_ADDRESS,
+      "Server-Adresse")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NETPLAY_LAN_SCAN_SETTINGS,
-      "Durchsuche lokales Netzwerk")
+      "Lokales Netzwerk durchsuchen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NETPLAY_MODE,
-      "Aktiviere Netplay-Client")
+      "Netplay-Client aktivieren")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NETPLAY_NICKNAME,
       "Benutzername")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_NETPLAY_PASSWORD,
-      "Server Passwort")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_NETPLAY_REFRESH_ROOMS,
-      "Aktualisiere Lobby-Liste")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NETPLAY_SETTINGS,
-      "Netplay settings")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATE_PASSWORD,
-      "Server Passwort für Zuschauer")
+      "Netplay-Einstellungen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE,
-      "Aktiviere Netplay-Zuschauermodus")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_NETPLAY_START_WHEN_LOADED,
-      "Netplay wird gestartet sobald ein Inhalt geladen wurde.")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_NETPLAY_STATELESS_MODE, /* TODO: What is this actually? */
-      "Zustandsloser Netplay-Modus")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_NETPLAY_TAB,
-      "Netplay Lobbies")
+      "Netplay-Zuschauermodus aktivieren")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT,
-      "TCP/UDP-Port für Netplay")
+      "Netplay TCP/UDP-Port")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NETPLAY_NAT_TRAVERSAL,
-      "Netplay NAT Traversal")
+      "Netplay NAT-Traversal")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NETWORK_CMD_ENABLE,
-      "Netzwerkbefehle")
+      "Netzwerk-Befehle")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NETWORK_CMD_PORT,
-      "Port für Netzwerkbefehle")
+      "Port für Netzwerk-Befehle")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NETWORK_INFORMATION,
-      "Netzwerkinformationen")
+      "Netzwerk-Informationen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NETWORK_REMOTE_ENABLE,
-      "Network Gamepad")
+      "Netzwerk-Gamepad aktivieren")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NETWORK_REMOTE_PORT,
-      "Network Remote Base Port")
+      "Netzwerk-Remote-Port")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NETWORK_SETTINGS,
-      "Netzwerkeinstellungen")
+      "Netzwerk")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NO,
       "Nein")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NONE,
@@ -579,45 +952,49 @@ MSG_HASH(MENU_ENUM_LABEL_VALUE_NO_CORE_INFORMATION_AVAILABLE,
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NO_CORE_OPTIONS_AVAILABLE,
       "Keine Core-Optionen verfügbar.")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NO_ENTRIES_TO_DISPLAY,
-      "No entries to display.")
+      "Keine Einträge.")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NO_HISTORY_AVAILABLE,
-      "No history available.")
+      "Kein Verlauf verfügbar.")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE,
       "Keine Informationen verfügbar.")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NO_ITEMS,
       "Keine Einträge.")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NO_NETPLAY_HOSTS_FOUND,
-      "Kein Netplay Host gefunden.")
+      "Keine Netplay-Hosts gefunden.")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NO_NETWORKS_FOUND,
-      "No networks found.")
+      "Kein Netzwerk gefunden.")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NO_PERFORMANCE_COUNTERS,
       "Keine Leistungszähler.")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NO_PLAYLISTS,
       "Keine Wiedergabelisten.")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NO_PLAYLIST_ENTRIES_AVAILABLE,
-      "Keine Einträge verfügbar.")
+      "Keine Wiedergabelisten-Einträge verfügbar.")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NO_SETTINGS_FOUND,
       "Keine Einstellungen gefunden.")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NO_SHADER_PARAMETERS,
-      "Keine Shaderparameter")
+      "Keine Shader-Parameter.")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_OFF,
-      "AN")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_ON,
       "AUS")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_ON,
+      "EIN")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_ONLINE,
+      "Online")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_ONLINE_UPDATER,
-      "Online-Aktualisierung")
+      "Online-Aktualisierungen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_ONSCREEN_DISPLAY_SETTINGS,
       "OSD-Einstellungen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_ONSCREEN_OVERLAY_SETTINGS,
       "Bildschirm-Overlay")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_ONSCREEN_NOTIFICATIONS_SETTINGS,
+      "Bildschirm-Benachrichtigungen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_OPEN_ARCHIVE,
-      "Öffne Archiv") /* TODO/FIXME */
+      "Öffne Archiv als Ordner")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_OPTIONAL,
       "Optional")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_OSK_OVERLAY_DIRECTORY,
-      "OSK-Overlay-Verzeichnis")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_OVERLAY,
+      "Overlay")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_OVERLAY_AUTOLOAD_PREFERRED,
-      "Automatisch bevorzuges Overlay laden")
+      "Bevorzugtes Overlay automatisch laden")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_OVERLAY_DIRECTORY,
       "Overlay-Verzeichnis")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_OVERLAY_OPACITY,
@@ -633,17 +1010,17 @@ MSG_HASH(MENU_ENUM_LABEL_VALUE_PAL60_ENABLE,
 MSG_HASH(MENU_ENUM_LABEL_VALUE_PARENT_DIRECTORY,
       "Übergeordnetes Verzeichnis")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_PAUSE_LIBRETRO,
-      "Pausiere wenn das Menü aktiv ist")
+      "Pausiere, wenn das Menü aktiv ist")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_PAUSE_NONACTIVE,
-      "Nicht im Hintergrund laufen")
+      "Nicht im Hintergrund ausführen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_PERFCNT_ENABLE,
       "Leistungsindikatoren")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_PLAYLISTS_TAB,
+      "Wiedergabelisten")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_PLAYLIST_DIRECTORY,
-      "Wiedergabelistenverzeichnis")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_PLAYLIST_ENTRY_REMOVE,
-      "Löschen von Einträgen erlauben")
+      "Wiedergabelisten")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_PLAYLIST_SETTINGS,
-      "Wiedergabelisteneinstellungen")
+      "Wiedergabelisten")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_POINTER_ENABLE,
       "Touch-Unterstützung")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_PORT,
@@ -651,51 +1028,85 @@ MSG_HASH(MENU_ENUM_LABEL_VALUE_PORT,
 MSG_HASH(MENU_ENUM_LABEL_VALUE_PRESENT,
       "Vorhanden")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_PRIVACY_SETTINGS,
-      "Privatsphäreeinstellungen")
+      "Privatsphären-Einstellungen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_QUIT_RETROARCH,
       "RetroArch beenden")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ANALOG,
+      "Analog unterstützt")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_RDB_ENTRY_BBFC_RATING,
+      "BBFC-Bewertung")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_RDB_ENTRY_CERO_RATING,
+      "CERO-Bewertung")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_RDB_ENTRY_COOP,
+      "Co-op unterstützt")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_RDB_ENTRY_CRC32,
       "CRC32")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DESCRIPTION,
       "Beschreibung")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_RDB_ENTRY_DEVELOPER,
       "Entwickler")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_RDB_ENTRY_EDGE_MAGAZINE_ISSUE,
+      "Edge Magazine-Ausgabe")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_RDB_ENTRY_EDGE_MAGAZINE_RATING,
+      "Edge Magazine-Bewertung")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_RDB_ENTRY_EDGE_MAGAZINE_REVIEW,
+      "Edge Magazine-Testbericht")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ELSPA_RATING,
+      "ELSPA-Bewertung")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ENHANCEMENT_HW,
+      "Hardware-Erweiterungen")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ESRB_RATING,
+      "ESRB-Bewertung")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_RDB_ENTRY_FAMITSU_MAGAZINE_RATING,
+      "Famitsu Magazine-Bewertung")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_RDB_ENTRY_FRANCHISE,
       "Franchise")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_RDB_ENTRY_GENRE,
+      "Genre")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_RDB_ENTRY_MD5,
       "MD5")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_RDB_ENTRY_NAME,
       "Name")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_RDB_ENTRY_ORIGIN,
       "Herkunft")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_RDB_ENTRY_PEGI_RATING,
+      "PEGI-Bewertung")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_RDB_ENTRY_PUBLISHER,
       "Publisher")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_MONTH,
       "Veröffentlichungsmonat")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RELEASE_YEAR,
       "Veröffentlichungsjahr")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_RDB_ENTRY_RUMBLE,
+      "Rumble unterstützt")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_RDB_ENTRY_SERIAL,
+      "Seriennummer")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_RDB_ENTRY_SHA1,
       "SHA1")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_RDB_ENTRY_START_CONTENT,
       "Starte Inhalt")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_RDB_ENTRY_TGDB_RATING,
+      "TGDB-Bewertung")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_REBOOT,
       "Neustart")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_RECORDING_CONFIG_DIRECTORY,
-      "Aufnahme-Konfigurationsverzeichnis")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_RECORDING_OUTPUT_DIRECTORY,
-      "Aufnahme-Ausgabeverzeichnis")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_RECORDING_SETTINGS,
-      "Aufnahmeeinstellungen")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_RECORD_CONFIG,
       "Aufnahme-Konfiguration")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_RECORDING_OUTPUT_DIRECTORY,
+      "Aufnahme-Verzeichnis")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_RECORDING_SETTINGS,
+      "Aufnahme")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_RECORD_CONFIG,
+      "Lade Aufnahme-Konfiguration...")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_RECORD_DRIVER,
-      "Aufnahmetreiber")
+      "Aufnahme-Treiber")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_RECORD_ENABLE,
       "Aktiviere Aufnahmefunktion")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_RECORD_PATH, /* FIXME/UPDATE */
-      "Aufnahmepfad")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_RECORD_PATH,
+      "Speichere Aufnahme als...")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_RECORD_USE_OUTPUT_DIRECTORY,
-      "Verwende Aufnahme-Ausgabeverzeichnis")
+      "Speichere Aufname im Ausgabeverzeichnis")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_REMAP_FILE,
+      "Remap-Datei")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_REMAP_FILE_LOAD,
       "Remap-Datei laden")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_CORE,
@@ -705,107 +1116,131 @@ MSG_HASH(MENU_ENUM_LABEL_VALUE_REMAP_FILE_SAVE_GAME,
 MSG_HASH(MENU_ENUM_LABEL_VALUE_REQUIRED,
       "Notwendig")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_RESTART_CONTENT,
-      "Neustarten")
+      "Neu starten")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_RESTART_RETROARCH,
       "RetroArch neustarten")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_RESUME,
       "Fortsetzen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_RESUME_CONTENT,
       "Fortsetzen")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_RETRO_ACHIEVEMENTS_SETTINGS,
-      "Errungenschaften")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_RETROKEYBOARD,
       "RetroKeyboard")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_RETROPAD,
       "RetroPad")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_RETROPAD_WITH_ANALOG,
+      "RetroPad mit Analogsticks")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_RETRO_ACHIEVEMENTS_SETTINGS,
+      "Errungenschaften")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_REWIND_ENABLE,
       "Zurückspulen (Rewind) aktivieren")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_REWIND_GRANULARITY,
       "Genauigkeit des Zurückspulens (Rewind)")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_REWIND_SETTINGS,
-      "Zurückspuleinstellungen")
+      "Zurückspulen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_RGUI_BROWSER_DIRECTORY,
-      "Dateibrowserverzeichnis")
+      "File Browser")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_RGUI_CONFIG_DIRECTORY,
-      "Konfigurationsverzeichnis")
+      "Dateibrowser-Verzeichnis")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_RGUI_SHOW_START_SCREEN,
       "Zeige Startbildschirm")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_RIGHT_ANALOG,
       "Rechter Analogstick")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_RUN,
       "Starten")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_SAMBA_ENABLE,
+      "SAMBA aktivieren")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SAVEFILE_DIRECTORY,
-      "Spielstandverzeichnis")
+      "Speicherdaten-Verzeichnis")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_INDEX,
       "Automatische Indexierung von Spielständen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_LOAD,
-      "Automatisches Laden von Spielständen")
+      "Spielstand automatisch laden")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SAVESTATE_AUTO_SAVE,
-      "Automatisch Spielstände speichern")
+      "Spielstand automatisch speichern")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SAVESTATE_DIRECTORY,
-      "Spielstandverzeichnis")
+      "Spielstand-Verzeichnis")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SAVESTATE_THUMBNAIL_ENABLE,
-      "Spielstandminiaturansichten")
+      "Spielstand-Vorschaubilder")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG,
-      "Aktuelle Konfigurationen speichern")
+      "Speichere aktuelle Konfiguration")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG_OVERRIDE_CORE,
       "Speichere Core-Überschreibungen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SAVE_CURRENT_CONFIG_OVERRIDE_GAME,
-      "Speichere Spieleüberschreibungen")
+      "Speichere Spiel-Überschreibungen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SAVE_NEW_CONFIG,
-      "Neue Konfigurationen speichern")
+      "Speichere neue Konfiguration")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SAVE_STATE,
       "Spielstand speichern")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SAVING_SETTINGS,
-      "Spielstandeinstellungen")
+      "Speichern")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SCAN_DIRECTORY,
-      "Verzeichnis Durchsuchen")
+      "Verzeichnis durchsuchen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SCAN_FILE,
-      "Datei Durchsuchen")
+      "Datei durchsuchen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SCAN_THIS_DIRECTORY,
-      "<- Durchsuchen ->")
+      "<Dieses Verzeichnis durchsuchen>")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SCREENSHOT_DIRECTORY,
-      "Bildschirmfotoverzeichnis")
+      "Bildschirmfotos")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SCREEN_RESOLUTION,
-      "Bildschirmauflösung")
+      "Bildschirm-Auflösung")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_SEARCH,
+      "Suchen:")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SECONDS,
       "Sekunden")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SETTINGS,
+      "Einstellungen")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_SETTINGS_TAB,
       "Einstellungen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SHADER,
       "Shader")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SHADER_APPLY_CHANGES,
       "Änderungen übernehmen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SHADER_OPTIONS,
-      "Shaders")
+      "Shader")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_SHADER_PIPELINE_RIBBON,
+      "Band")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_SHADER_PIPELINE_RIBBON_SIMPLIFIED,
+      "Band (vereinfacht)")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_SHADER_PIPELINE_SIMPLE_SNOW,
+      "Schnee (vereinfacht)")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_SHADER_PIPELINE_SNOW,
+      "Schnee")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SHOW_ADVANCED_SETTINGS,
-      "Zeige erweitere Einstellungen")
+      "Zeige erweiterte Einstellungen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SHOW_HIDDEN_FILES,
-      "Zeige versteckte Ordner und Dateien")
+      "Zeige versteckte Dateien und Ordner")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_SHUTDOWN,
+      "Beenden")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SLOWMOTION_RATIO,
       "Zeitlupen-Verhältnis")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SORT_SAVEFILES_ENABLE,
-      "Sortiere Speicherdateien per Ordner")
+      "Sortiere Speicherdaten in Ordnern")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SORT_SAVESTATES_ENABLE,
-      "Sortiere Spielstände per Ordner")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_STATE_SLOT,
-      "Spielstand Feld")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_STATUS,
-      "Status")
+      "Sortiere Spielstände in Ordnern")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_SSH_ENABLE,
+      "SSH aktivieren")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_START_CORE,
+      "Core starten")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_START_NET_RETROPAD,
       "Starte Remote-RetroPad")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_START_VIDEO_PROCESSOR,
       "Starte Videoprozessor")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_STATE_SLOT,
+      "Spielstand-Speicherplatz")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_STATUS,
+      "Status")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_STDIN_CMD_ENABLE,
       "stdin-Befehle")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_SUPPORTED_CORES,
+      "Unterstützte Cores")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SUSPEND_SCREENSAVER_ENABLE,
       "Bildschirmschoner ausschalten")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_BGM_ENABLE,
       "Aktiviere System-BGM")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_DIRECTORY,
-      "System/BIOS-Verzeichnis")
+      "System/BIOS")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFORMATION,
-      "Systeminformationen")
+      "System-Informationen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_7ZIP_SUPPORT,
       "7zip-Unterstützung")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ALSA_SUPPORT,
@@ -831,7 +1266,7 @@ MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_WIDTH,
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DSOUND_SUPPORT,
       "DirectSound-Unterstützung")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DYLIB_SUPPORT,
-      "Dynamic-Library-Unterstützung")
+      "Unterstützung für dynamische Bibliotheken")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_EGL_SUPPORT,
       "EGL-Unterstützung")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FBO_SUPPORT,
@@ -866,6 +1301,8 @@ MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETPLAY_SUPPORT,
       "Netplay-Unterstützung (Peer-to-Peer)")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETWORK_COMMAND_IFACE_SUPPORT,
       "Netzwerk-Befehlsinterface-Unterstützung")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_NETWORK_REMOTE_SUPPORT,
+      "Unterstützung für Netzwerk-Gamepads")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENAL_SUPPORT,
       "OpenAL-Unterstützung")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_OPENGLES_SUPPORT,
@@ -889,25 +1326,33 @@ MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_CHARGING,
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_DISCHARGING,
       "Entlädt")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_POWER_SOURCE_NO_SOURCE,
-      "Keine Quelle")
+      "Keine Stromquelle")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PULSEAUDIO_SUPPORT,
       "PulseAudio-Unterstützung")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_PYTHON_SUPPORT,
       "Python-Unterstützung (Script-Unterstützung in Shadern)")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RBMP_SUPPORT,
+      "BMP-Unterstützung (RBMP)")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RETRORATING_LEVEL,
       "RetroRating-Stufe")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RJPEG_SUPPORT,
+      "JPEG-Unterstützung (RJPEG)")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ROARAUDIO_SUPPORT,
       "RoarAudio-Unterstützung")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RPNG_SUPPORT,
       "PNG-Unterstützung (RPNG)")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RSOUND_SUPPORT,
       "RSound-Unterstützung")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_RTGA_SUPPORT,
+      "TGA-Unterstützung (RTGA)")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL2_SUPPORT,
       "SDL2-Unterstützung")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_IMAGE_SUPPORT,
       "SDL-Image-Unterstützung")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL_SUPPORT,
       "SDL1.2-Unterstützung")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SLANG_SUPPORT,
+      "Slang-Unterstützung")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_THREADING_SUPPORT,
       "Threading-Unterstützung")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_UDEV_SUPPORT,
@@ -915,7 +1360,9 @@ MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_UDEV_SUPPORT,
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_V4L2_SUPPORT,
       "Video4Linux2-Unterstützung")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VIDEO_CONTEXT_DRIVER,
-      "Video-Context-Treiber")
+      "Video-Kontext-Treiber")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_VULKAN_SUPPORT,
+      "Vulkan-Unterstützung")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_WAYLAND_SUPPORT,
       "Wayland-Unterstützung")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_X11_SUPPORT,
@@ -927,27 +1374,29 @@ MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_XVIDEO_SUPPORT,
 MSG_HASH(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_ZLIB_SUPPORT,
       "Zlib-Unterstützung")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_TAKE_SCREENSHOT,
-      "Bildschirmfoto")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_THREADED_DATA_RUNLOOP_ENABLE, /* TODO/FIXME - update */
-      "Threaded Datenschlaufe")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_THUMBNAIL_MODE_BOXARTS,
-      "Boxart")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_THUMBNAIL_MODE_SCREENSHOTS,
-      "Bildschirmfoto")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_THUMBNAIL_MODE_TITLE_SCREENS,
-      "Titelbildschrim")
+      "Bildschirmfoto anfertigen")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_THREADED_DATA_RUNLOOP_ENABLE,
+      "Multithreading")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_THUMBNAILS,
       "Miniaturansichten")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_THUMBNAILS_DIRECTORY,
-      "Miniaturansichtenverzeichnis")
+      "Miniaturansichten-Verzeichnis")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_THUMBNAILS_UPDATER_LIST,
-      "Aktualisiere Miniaturansichten")
+      "Miniaturansichten aktualisieren")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_THUMBNAIL_MODE_BOXARTS,
+      "Boxarts")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_THUMBNAIL_MODE_SCREENSHOTS,
+      "Bildschirmfoto")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_THUMBNAIL_MODE_TITLE_SCREENS,
+      "Titelbildschirm")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_TIMEDATE_ENABLE,
-      "Zeige Uhrzeit / Datum")
+      "Uhrzeit / Datum anzeigen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_TITLE_COLOR,
-      "Menü-Titel-Farbe")
+      "Menü-Titelfarbe")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_TRUE,
-      "True")
+      "An")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_UI_COMPANION_ENABLE,
+      "UI-Companion aktivieren")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_UI_COMPANION_START_ON_BOOT,
       "UI-Companion beim Hochfahren starten")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_UI_MENUBAR_ENABLE,
@@ -955,69 +1404,73 @@ MSG_HASH(MENU_ENUM_LABEL_VALUE_UI_MENUBAR_ENABLE,
 MSG_HASH(MENU_ENUM_LABEL_VALUE_UNABLE_TO_READ_COMPRESSED_FILE,
       "Komprimiertes Archiv kann nicht gelesen werden.")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_UNDO_LOAD_STATE,
-      "Spielstand laden rückgängig machen")
+      "Laden des Spielstandes rückgängig machen")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_UNDO_SAVE_STATE,
+      "Speichern des Spielstandes rückgängig machen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_UNKNOWN,
       "Unbekannt")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_UNDO_SAVE_STATE,
-      "Spielstand speichern rückgängig machen")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_UPDATE_ASSETS,
-      "Aktualisiere Assets")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_UPDATE_AUTOCONFIG_PROFILES,
-      "Aktualisiere Autoconfig-Profile")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_UPDATE_CG_SHADERS,
-      "Aktualisiere CG-Shader")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_UPDATE_CHEATS,
-      "Aktualisiere Cheats")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_UPDATE_CORE_INFO_FILES,
-      "Aktualisiere Core Info Dateien")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_UPDATE_DATABASES,
-      "Aktualisiere Datenbanken")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_UPDATE_GLSL_SHADERS,
-      "Aktualisiere GLSL-Shader")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_UPDATE_LAKKA,
-      "Aktualisiere Lakka")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_UPDATE_OVERLAYS,
-      "Aktualisiere Overlays")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_UPDATER_SETTINGS,
-      "Aktualisierungen")
+      "Online-Aktualisierungen")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_UPDATE_ASSETS,
+      "Assets aktualisieren")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_UPDATE_AUTOCONFIG_PROFILES,
+      "Profile f. automatische Konfiguration aktualisieren")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_UPDATE_CG_SHADERS,
+      "CG-Shader aktualisieren")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_UPDATE_CHEATS,
+      "Cheats aktualisieren")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_UPDATE_CORE_INFO_FILES,
+      "Core-Infodateien aktualisieren")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_UPDATE_DATABASES,
+      "Datenbanken aktualisieren")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_UPDATE_GLSL_SHADERS,
+      "GLSL-Shader aktualisieren")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_UPDATE_LAKKA,
+      "Lakka aktualisieren")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_UPDATE_OVERLAYS,
+      "Overlays aktualisieren")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_UPDATE_SLANG_SHADERS,
+      "Slang-Shader aktualisieren")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_USER,
       "Benutzer")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_USER_INTERFACE_SETTINGS,
-      "Benutzeroberflächeneinstellungen")
+      "Benutzeroberfläche")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_USER_LANGUAGE,
       "Sprache")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_USER_SETTINGS,
-      "Benutzereinstellungen")
+      "Benutzer")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_USE_BUILTIN_IMAGE_VIEWER,
+      "Verwende eingebauten Bildbetrachter")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_USE_BUILTIN_PLAYER,
-      "Verwende integrierten Player") /* FIXME/UPDATE */
+      "Verwende eingebauten Medienplayer")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_USE_THIS_DIRECTORY,
-      "<Diesen Ordner verwenden>")
+      "<Dieses Verzeichnis verwenden>")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_ALLOW_ROTATE,
       "Erlaube Bildrotation")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_AUTO,
       "Automatisches Bildseitenverhältnis")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO_INDEX,
-      "Video-Seitenverhältnis")
+      "Bildseitenverhältnis")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_BLACK_FRAME_INSERTION,
-      "Setze schwarzes Bild zwischen Frames ein")
+      "Schwarzes Bild zwischen Einzelbildern einfügen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_CROP_OVERSCAN,
       "Bildränder (Overscan) zuschneiden (Neustart erforderlich)")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_DISABLE_COMPOSITION,
-      "Deaktiviere Desktop-Komposition")
+      "Deaktiviere Desktop-Gestaltung")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_DRIVER,
       "Grafiktreiber")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_FILTER,
-      "Videofilter")
+      "Grafikfilter")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_DIR,
-      "Grafikfilter-Verzeichnis")
+      "Grafikfilter")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_FILTER_FLICKER,
-      "Aktiviere Flacker-Filter")
+      "Flacker-Filter aktivieren")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_FONT_ENABLE,
-      "Zeige OSD-Nachrichten")
+      "Bildschirm-Benachrichtigungen aktivieren")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_FONT_PATH,
-      "Schriftart der OSD-Nachrichten")
+      "Schriftart für Bildschirm-Benachrichtigungen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_FONT_SIZE,
-      "Schriftgröße der OSD-Nachrichten")
+      "Schritftgröße der Bildschirm-Benachrichtigungen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_ASPECT,
       "Erzwinge Bildseitenverhältnis")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_FORCE_SRGB_DISABLE,
@@ -1029,23 +1482,23 @@ MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_FULLSCREEN,
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_GAMMA,
       "Gamma")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_GPU_RECORD,
-      "Aktiviere GPU-Aufnahmefunktion")
+      "Verwende GPU für Aufnahme")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_GPU_SCREENSHOT,
-      "Aktiviere GPU-Bildschirmfotos")
+      "Verwende GPU für Bildschirmfotos")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC,
       "Synchronisiere GPU und CPU")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_HARD_SYNC_FRAMES,
-      "Synchronisiere Frames fest mit GPU")
+      "Anzahl der Frames für GPU-CPU-Sync")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_MAX_SWAPCHAIN_IMAGES,
-      "Maximale Anzahl der Wechselkettenbilder")
+      "Maximale Anzahl von Zwischenbildern")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_X,
-      "X-Position der OSD-Nachrichten")
+      "X-Position der Bildschirm-Benachrichtigungen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_POS_Y,
-      "Y-Position der OSD-Nachrichten")
+      "Y-Position der Bildschirm-Benachrichtigungen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_MONITOR_INDEX,
-      "Monitorindex")
+      "Monitor-Index")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_POST_FILTER_RECORD,
-      "Aktiviere Aufnahme von Post-Filtern")
+      "Wende Filter auf Aufnahme an")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE,
       "Bildwiederholrate")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE_AUTO,
@@ -1053,289 +1506,747 @@ MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE_AUTO,
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_ROTATION,
       "Rotation")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_SCALE,
-      "Fenterskalierung")
+      "Skalierung im Fenstermodus")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_SCALE_INTEGER,
       "Ganzzahlige Bildskalierung")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_SETTINGS,
-      "Videoeinstellungen")
+      "Video-Einstellungen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_DIR,
-      "Grafikshader-Verzeichnis")
+      "Video-Shader")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_NUM_PASSES,
-      "Shader-Durchgänge")  /* FIXME */
+      "Shader-Durchläufe")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PARAMETERS,
-      "Momentane Shaderparameter") /* FIXME/UPDATE */
+      "Vorschau der Shader-Parameter")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET,
       "Shader-Voreinstellung laden")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_PARAMETERS,
-      "Menü Shaderparameter (Menü)")
+      "Shader-Parameter für Menü")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_AS,
-      "Speichere Shader-Voreinstellung unter...")
+      "Shader-Voreinstellung speichern unter...")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_CORE,
+      "Core-Voreinstellung speichern")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_GAME,
+      "Spiel-Voreinstellung speichern")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_SHARED_CONTEXT,
-      "HW-Shared-Context aktivieren")
+      "Gemeinsamen Hardware-Kontext aktivieren")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_SMOOTH,
-      "Bilineare Filterung (HW)")
+      "Bilineare Filterung")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_SOFT_FILTER,
-      "Aktiviere Soft-Filter")
+      "Soft-Filter aktivieren")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_SWAP_INTERVAL,
       "VSync-Intervall")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_TAB,
-      "Videos")
+      "Video")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_THREADED,
-      "Threaded Video")
+      "Video in separatem Thread")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_VFILTER,
-      "Bild entflackern")
+      "Entflackern")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_HEIGHT,
-      "Bildchirmauflösung Höhe")
+      "Bildhöhe")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_WIDTH,
-      "Bildchirmauflösung Breite")
+      "Bildbreite")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_X,
-      "Bildchirmauflösung X")
+      "X-Position des Bildes")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_VIEWPORT_CUSTOM_Y,
-      "Bildchirmauflösung Y")
+      "Y-Position des Bildes")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_VI_WIDTH,
-      "Kalibriere VI-Bildbreite")
+      "VI-Bildgröße")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_VSYNC,
-      "Vertikale Synchronisation (VSync)")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_WINDOW_HEIGHT,
-      "Fensterhöhe")
+      "Vertikale Synchronisation (Vsync)")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_WINDOWED_FULLSCREEN,
+      "Unechter Vollbildmodus (Windowed Fullscreen)")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_WINDOW_WIDTH,
       "Fensterbreite")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_WINDOWED_FULLSCREEN,
-      "Unechter Vollbild-Modus (Windowed Fullscreen)")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_VIDEO_WINDOW_HEIGHT,
+      "Fensterhöhe")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_WIFI_DRIVER,
       "WLAN-Treiber")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_WIFI_SETTINGS,
       "WLAN")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_XMB_ALPHA_FACTOR,
-      "Menüalphafaktor")
+      "Menü-Transparenz")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_XMB_FONT,
-      "Menüschriftart")
+      "Menü-Schriftart")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_CUSTOM,
+      "Benutzerdefiniert")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_FLATUI,
+      "FlatUI")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_MONOCHROME,
+      "Monochrome")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_NEOACTIVE,
+      "NeoActive")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_PIXEL,
+      "Pixel")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_XMB_ICON_THEME_RETROACTIVE,
+      "RetroActive")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME,
+      "Menü-Farbschema")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_APPLE_GREEN,
+      "Apple Green")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_DARK,
+      "Dark")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_DARK_PURPLE,
+      "Dark Purple")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_ELECTRIC_BLUE,
+      "Electric Blue")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_GOLDEN,
+      "Golden")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_LEGACY_RED,
+      "Legacy Red")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_MIDNIGHT_BLUE,
+      "Midnight Blue")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_PLAIN,
+      "Plain")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_UNDERSEA,
+      "Undersea")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME_VOLCANIC_RED,
+      "Volcanic Red")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_XMB_RIBBON_ENABLE,
-      "Menü-Shaderpipeline")
+      "Menü-Shader")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_XMB_SCALE_FACTOR,
-      "Menüskalierungsfaktor")
+      "Menü-Skalierungsfaktor")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_XMB_SHADOWS_ENABLE,
-      "Bild Schatten")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_XMB_SHOW_ADD,
-      "Zeige Inhalte importieren Tab")
+      "Icon-Schatten aktivieren")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_XMB_SHOW_HISTORY,
-      "Zeige Verlauf Tab")
+      "Zeige Tab 'Verlauf'")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_XMB_SHOW_IMAGES,
-      "Zeige Bilder Tab")
+      "Zeige Tab 'Bilder'")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_XMB_SHOW_MUSIC,
-      "Zeige Musik Tab")
+      "Zeige Tab 'Musik'")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_XMB_SHOW_SETTINGS,
-      "Zeige Einstellungen Tab")
+      "Zeige Tab 'Einstellungen'")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_XMB_SHOW_VIDEO,
-      "Zeige Videos Tab")
+      "Zeige Tab 'Video'")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_XMB_THEME,
-      "Menüdesign")
+      "Menü-Design")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_YES,
       "Ja")
-MSG_HASH(MENU_ENUM_SUBLABEL_AUDIO_ENABLE,
-      "Aktiviert den Audioausgang.")
-MSG_HASH(MENU_ENUM_SUBLABEL_AUDIO_LATENCY,
-      "Gewünschte Audiolatenz in Millisekunden. Je nach Audiotreiber kann die gewünschte Latenz nicht erzielt werden.")
-MSG_HASH(MENU_ENUM_SUBLABEL_AUDIO_MAX_TIMING_SKEW,
-      "Die maximale Änderung der Audioeingangsleistung. "
-      "Wenn du PAL Cores auf NTSC Monitoren spielen willst, kannst du diesen Wert erhöhen um bessere Timings zu erreichen, "
-      "als Nebeneffekt kann es zu unechten Tonhöhen kommen.")
-MSG_HASH(MENU_ENUM_SUBLABEL_AUDIO_MUTE,
-      "Audio Stummschalten.")
-MSG_HASH(MENU_ENUM_SUBLABEL_AUDIO_RATE_CONTROL_DELTA,
-      "Hilft Fehler bei der Audio- und Videosynchronisierung auszubügeln. "
-      "Wenn deaktiviert, ist eine brauchbare Synchronisation nahezu unmöglich.")
-MSG_HASH(MENU_ENUM_SUBLABEL_AUDIO_SETTINGS,
-      "Einstellungen zur Audioausgabe.")
-MSG_HASH(MENU_ENUM_SUBLABEL_AUDIO_SYNC,
-      "Synchronisiert Audio. Empfohlen.")
-MSG_HASH(MENU_ENUM_SUBLABEL_AUDIO_VOLUME,
-      "Lautstärkeverstärkung in dB.")
-MSG_HASH(MENU_ENUM_SUBLABEL_CHECK_FOR_MISSING_FIRMWARE,
-      "Überprüfe benötigte Firmware bevor versucht wird einen Core zu laden.")
-MSG_HASH(MENU_ENUM_SUBLABEL_CHEEVOS_ENABLE,
-      "Aktiviert Errungenschaften. "
-      "Für weitere Informationen, besuche http://retroachievements.org")
+MSG_HASH(MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_TWO,
+      "Shader-Voreinstellungen")
 MSG_HASH(MENU_ENUM_SUBLABEL_CHEEVOS_HARDCORE_MODE_ENABLE,
-      "Deaktiviert Spielstände, Cheats, Zurückspulen, Zeitraffer, Pause, und Zeitlupe für alle Spiele.")
-MSG_HASH(MENU_ENUM_SUBLABEL_CHEEVOS_TEST_UNOFFICIAL,
-      "Aktiviere unoffizielle Errungenschaften und/oder Beta-Features zu Testzwecken.")
-MSG_HASH(MENU_ENUM_SUBLABEL_CONFIG_SAVE_ON_EXIT,
-      "Speichert Änderungen in die Konfigurationsdatei beim Beenden.")
-MSG_HASH(MENU_ENUM_SUBLABEL_CONFIGURATION_SETTINGS,
-      "Ändere die Standardeinstellungen für Konfigurationsdateien.")
-MSG_HASH(MENU_ENUM_SUBLABEL_CONFIGURATIONS_LIST,
-      "Verwalte und erstelle Konfigurationsdateien.")
-MSG_HASH(MENU_ENUM_SUBLABEL_CONTENT_HISTORY_SIZE,
-      "Limitiert die Anzahl der Einträge in der Verlaufsliste.")
+      "Deaktiviert Spielstände, Cheats, Zurückspulen, Zeitraffer, Pause und Zeitlupe für alle Spiele.")
+MSG_HASH(MENU_ENUM_SUBLABEL_DRIVER_SETTINGS,
+      "Ändere die Treiber für dieses System.")
+MSG_HASH(MENU_ENUM_SUBLABEL_RETRO_ACHIEVEMENTS_SETTINGS,
+      "Ändere die Einstellungen für Errungenschaften.")
 MSG_HASH(MENU_ENUM_SUBLABEL_CORE_SETTINGS,
       "Ändere die Einstellungen der Cores.")
-MSG_HASH(MENU_ENUM_SUBLABEL_DIRECTORY_SETTINGS,
-      "Ändere das Standardverzeichis für dieses System.")
-MSG_HASH(MENU_ENUM_SUBLABEL_DRIVER_SETTINGS,
-      "Ändere Treiber für dieses System.")
-MSG_HASH(MENU_ENUM_SUBLABEL_DUMMY_ON_CORE_SHUTDOWN,
-      "Einige Cores haben ein Herunterfahren-Feature. "
-      "Wenn aktive, wird der Core davon abgehalten RetroArch herunterzufahren. "
-      "Stattdessen lädt es einen Dummy-Core.")
+MSG_HASH(MENU_ENUM_SUBLABEL_RECORDING_SETTINGS,
+      "Ändere die Einstellungen für die Aufnahme-Funktion.")
+MSG_HASH(MENU_ENUM_SUBLABEL_ONSCREEN_DISPLAY_SETTINGS,
+      "Ändere die Einstellungen für Bildschirm-Overlays, Bildschirmtastatur und Bildschirmbenachrichtigung.")
 MSG_HASH(MENU_ENUM_SUBLABEL_FRAME_THROTTLE_SETTINGS,
-      "Ändere die Einstellungen für Rückspulen, Zeitraffer, und Zeitlupe.") /* This does not sound like a correct sentence. Suggestions are appreciated. */
+      "Ändere die Einstellungen für Zurückspulen, Zeitraffer und Zeitlupe.")
+MSG_HASH(MENU_ENUM_SUBLABEL_SAVING_SETTINGS,
+      "Ändere die Einstellungen der Speicherfunktion.")
+MSG_HASH(MENU_ENUM_SUBLABEL_LOGGING_SETTINGS,
+      "Ändere die Log-Einstellungen.")
+MSG_HASH(MENU_ENUM_SUBLABEL_USER_INTERFACE_SETTINGS,
+      "Ändere die Einstellungen für die Benutzeroberläche.")
+MSG_HASH(MENU_ENUM_SUBLABEL_USER_SETTINGS,
+      "Konten, Benutzername, Sprache.")
+MSG_HASH(MENU_ENUM_SUBLABEL_PRIVACY_SETTINGS,
+      "Ändere deine Privatsphären-Einstellungen.")
+MSG_HASH(MENU_ENUM_SUBLABEL_DIRECTORY_SETTINGS,
+      "Ändere die Standard-Verzeichnisse für dieses System")
+MSG_HASH(MENU_ENUM_SUBLABEL_PLAYLIST_SETTINGS,
+      "Ändere die Einstellungen für die Wiedergabelisten.")
+MSG_HASH(MENU_ENUM_SUBLABEL_NETWORK_SETTINGS,
+      "Ändere die Einstellungen für das Netzwerk.")
+MSG_HASH(MENU_ENUM_SUBLABEL_ADD_CONTENT_LIST,
+      "Sucht nach Inhalten und fügt diese zur Datenbank hinzu.")
+MSG_HASH(MENU_ENUM_SUBLABEL_AUDIO_SETTINGS,
+      "Ändert die Einstellungen der Audio-Ausgabe.")
+MSG_HASH(MENU_ENUM_SUBLABEL_BLUETOOTH_ENABLE,
+      "Aktiviert oder deaktiviert Bluetooth.")
+MSG_HASH(MENU_ENUM_SUBLABEL_CONFIG_SAVE_ON_EXIT,
+      "Speichert Änderungen in die Konfigurationsdatei beim Beenden.")
+MSG_HASH(MENU_ENUM_SUBLABEL_CPU_CORES,
+      "Anzahl der verfügbaren CPU-Kerne.")
 MSG_HASH(MENU_ENUM_SUBLABEL_FPS_SHOW,
       "Zeigt die aktuelle Bildwiederholrate auf dem Bildschirm an.")
-MSG_HASH(MENU_ENUM_SUBLABEL_HELP_LIST,
-      "Erfahre mehr derüber wie Retroarch funktioniert.")
-MSG_HASH(MENU_ENUM_SUBLABEL_HISTORY_LIST_ENABLE,
-      "Aktiviere Wiedergabeliste für kürzlich geöffnete Medien.")
-MSG_HASH(MENU_ENUM_SUBLABEL_INFORMATION_LIST_LIST,
-      "Zeigt Informationen über Core, Netzwerk, und des Systems an. Anzeigen-Manager für Datenbank und Zeiger.")
-MSG_HASH(MENU_ENUM_SUBLABEL_INPUT_ALL_USERS_CONTROL_MENU,
-      "Ermöglicht jedem Spieler das Menü zu benutzen. Wenn deaktiviert, kann nur Spieler 1 das Menü benutzen.")
-MSG_HASH(MENU_ENUM_SUBLABEL_INPUT_AXIS_THRESHOLD,
-      "Wie weit ein Analog-Stick bewegt werden muss bis er reagiert.")
-MSG_HASH(MENU_ENUM_SUBLABEL_INPUT_BIND_TIMEOUT,
-      "Anzahl Sekunden bis der nächste Bind abgehandelt wird.") /* @TODO: What is a Bind? */
-MSG_HASH(MENU_ENUM_SUBLABEL_INPUT_DUTY_CYCLE,
-      "Anzahl Bilder wie lange ein Durchlauf während dem Turbomodus dauert.")
 MSG_HASH(MENU_ENUM_SUBLABEL_INPUT_HOTKEY_BINDS,
-      "Einstellungen der Hotkeys.")
-MSG_HASH(MENU_ENUM_SUBLABEL_INPUT_MAX_USERS,
-      "Maximale Anzahl Benutzer welche von RetroArch unterstützt werden.")
+      "Konfiguriere Hotkey-Einstellungen.")
 MSG_HASH(MENU_ENUM_SUBLABEL_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO,
-      "Gamepad-Tastenkombination um ins Menü zu gelangen.")
-MSG_HASH(MENU_ENUM_SUBLABEL_INPUT_POLL_TYPE_BEHAVIOR,
-      "Hat Einwirkungen auf die Art wie Eingabeabfragen in RetroArch abgehandelt werden. "
-      "Werte 'Früh' und 'Spät' kann die Latenz verringern, je nach Konfiguration.")
+      "Gamepad-Tastenkombination, mit der das Menü aufgerufen wird.")
 MSG_HASH(MENU_ENUM_SUBLABEL_INPUT_SETTINGS,
       "Einstellungen für Joypads, Tastaturen und Mäuse.")
-MSG_HASH(MENU_ENUM_SUBLABEL_INPUT_TURBO_PERIOD,
-      "Anzahl Bilder wie lange der Turbomodus anhält.")
-MSG_HASH(MENU_ENUM_SUBLABEL_INPUT_UNIFIED_MENU_CONTROLS,
-      "Verwende die selbe Steuerung für Menü und Spiele. Betrifft nur Tastatur.")
 MSG_HASH(MENU_ENUM_SUBLABEL_INPUT_USER_BINDS,
-      "Bedienungseinstellungen dieses Spielers.")
+      "Steuerung für diesen Benutzer konfigurieren.")
 MSG_HASH(MENU_ENUM_SUBLABEL_LOG_VERBOSITY,
       "Aktiviere Logging im Terminal.")
-MSG_HASH(MENU_ENUM_SUBLABEL_LOGGING_SETTINGS,
-      "Ändere die Logging-Einstellungen.")
-MSG_HASH(MENU_ENUM_SUBLABEL_MENU_SETTINGS,
-      "Stellt die Einstellungen für das Aussehen des Menübildschirms ein.")
 MSG_HASH(MENU_ENUM_SUBLABEL_NETPLAY,
-      "Hoste eine Netplay Session oder trete einer bei.")
+      "Hoste eine Netplay-Sitzung oder trete einer bei.")
 MSG_HASH(MENU_ENUM_SUBLABEL_NETPLAY_LAN_SCAN_SETTINGS,
-      "Suche und verbinde mit Netplay Hosts in deinem lokalen Netzwerk.")
-MSG_HASH(MENU_ENUM_SUBLABEL_NETWORK_SETTINGS,
-      "Ändere die Netzwerkeinstellungen.")
+      "Suche und verbinde mit Netplay-Hosts in deinem lokalen Netzwerk.")
+MSG_HASH(MENU_ENUM_SUBLABEL_INFORMATION_LIST_LIST,
+      "Zeigt Informationen über Core, Netzwerk und das Systems an.")
 MSG_HASH(MENU_ENUM_SUBLABEL_ONLINE_UPDATER,
-      "Lade Add-Ons, Komponenten und Inhalte für RetroArch herunter.")
-MSG_HASH(MENU_ENUM_SUBLABEL_ONSCREEN_DISPLAY_SETTINGS,
-      "Ändere die Einstellungen des Display-Overlays, Bildschirmtastatur und Bildschirmbenachrichtigung.") /* There is no Translation for display overlay. */
-MSG_HASH(MENU_ENUM_SUBLABEL_PAUSE_NONACTIVE,
-      "Spiel pausieren wenn das Fenster den Fokus verliert.")
-MSG_HASH(MENU_ENUM_SUBLABEL_PLAYLIST_SETTINGS,
-      "Ändere die Einstellungen der Wiedergabelisten.")
-MSG_HASH(MENU_ENUM_SUBLABEL_PRIVACY_SETTINGS,
-      "Ändere deine Privatsphäreneinstellungen.")
-MSG_HASH(MENU_ENUM_SUBLABEL_RETRO_ACHIEVEMENTS_SETTINGS,
-      "Ändere die Einstellungen der Errungenschaften.")
-MSG_HASH(MENU_ENUM_SUBLABEL_SAVING_SETTINGS,
-      "Ändere die Einstellungen der Spielstände.")
+      "Lade Erweiterungen, Komponenten und Inhalte für RetroArch herunter.")
+MSG_HASH(MENU_ENUM_SUBLABEL_SAMBA_ENABLE,
+      "Aktiviere die Netzwerkfreigabe deiner Ordner.")
+MSG_HASH(MENU_ENUM_SUBLABEL_SERVICES_SETTINGS,
+      "Verwalte Service-Einstellungen deines Betriebssystems.")
 MSG_HASH(MENU_ENUM_SUBLABEL_SHOW_HIDDEN_FILES,
-      "Zeigt versteckte Dateien und Ordner im Dateimanager an.")
+      "Zeige versteckte Dateien und Ordner im Dateimanager an.")
+MSG_HASH(MENU_ENUM_SUBLABEL_SSH_ENABLE,
+      "Aktiviere Fernzugriff auf die Kommandozeile.")
 MSG_HASH(MENU_ENUM_SUBLABEL_SUSPEND_SCREENSAVER_ENABLE,
-      "Haltet dein System davon ab den Bildschirmschoner zu aktivieren.")
-MSG_HASH(MENU_ENUM_SUBLABEL_USER_INTERFACE_SETTINGS,
-      "Ändere die Einstellungen der Benutzeroberfläche.")
-MSG_HASH(MENU_ENUM_SUBLABEL_USER_LANGUAGE,
-      "Ändere die Sprache der Oberfläche.")
-MSG_HASH(MENU_ENUM_SUBLABEL_USER_SETTINGS,
-      "Ändere das Konto, Benutzername, und die Sprache.")
-MSG_HASH(MENU_ENUM_SUBLABEL_VIDEO_ALLOW_ROTATE,
-      "Erlaubt Cores die Rotation zu setzen. Wenn deaktiviert, Rotationsanfragen werden ignoriert. Nützlich für Geräte bei denen man die Rotation manuell wählt.")
-MSG_HASH(MENU_ENUM_SUBLABEL_VIDEO_BLACK_FRAME_INSERTION,
-      "Zeigt ein schwarzes Bild zwischen Frames an. Nützlich für 120 Hz Monitore welche 60 Hz mit weniger 'ghosting' möchten.")
-MSG_HASH(MENU_ENUM_SUBLABEL_VIDEO_DISABLE_COMPOSITION,
-      "Deaktiviere Desktop-Komposition. (Nur bei Windows)")
-MSG_HASH(MENU_ENUM_SUBLABEL_VIDEO_FONT_ENABLE,
-      "Zeige Bildschirmbenachrichtigungen an.")
-MSG_HASH(MENU_ENUM_SUBLABEL_VIDEO_FRAME_DELAY,
-      "Reduziert Latenz, kann aber zu Anzeigefehlern führen. Fügt einen Unterbruch bei V-Sync hinzu (in ms).")
-MSG_HASH(MENU_ENUM_SUBLABEL_VIDEO_HARD_SYNC,
-      "Hartsynchronisierung des CPU und der GPU. Reduziert Latenz, braucht aber mehr Leistung.")
-MSG_HASH(MENU_ENUM_SUBLABEL_VIDEO_HARD_SYNC_FRAMES,
-      "Anzahl Bilder welche die CPU der GPU voraus sein darf wenn die 'Hartsynchronisierung' verwendet wird.")
-MSG_HASH(MENU_ENUM_SUBLABEL_VIDEO_MAX_SWAPCHAIN_IMAGES,
-      "Zwingt den Videotreiber explizit einen bestimmten Puffer zu verwenden.")
-MSG_HASH(MENU_ENUM_SUBLABEL_VIDEO_MONITOR_INDEX,
-      "Wählt den Monitor aus welcher RetroArch anzeigen soll.")
-MSG_HASH(MENU_ENUM_SUBLABEL_VIDEO_REFRESH_RATE,
-      "Vertikale Bildwiederholrate des Monitors. "
-      "Wird verwendet um die passende Audioinputrate zu berechnen. "
-      "WICHTIG: Diese Option wird ignoriert wenn du 'Threaded Video' aktiviert hast.") /* TODO: Any way to inject the reference in the .h file? */
-MSG_HASH(MENU_ENUM_SUBLABEL_VIDEO_REFRESH_RATE_AUTO,
-      "Die genau geschätzte Bildwiederholrate des Monitors in Hz.")
-MSG_HASH(MENU_ENUM_SUBLABEL_VIDEO_SETTINGS,
-      "Einstellungen zur Videoausgabe.")
-MSG_HASH(MENU_ENUM_SUBLABEL_VIDEO_SHARED_CONTEXT,
-      "Gibt hardware-gerendered Cores einen eigenen privaten Kontext. Vermeided den Hardware-State anzunehmen zwischen den Frames.")
-MSG_HASH(MENU_ENUM_SUBLABEL_VIDEO_THREADED,
-      "Verbessert die Leistung, führt aber zu grösserer Latenz und Videoproblemen. "
-      "Verwende dies nur wenn du sonst die gewünschte Leistung erbringst.")
-MSG_HASH(MENU_ENUM_SUBLABEL_VIDEO_VSYNC,
-      "Synchronisiert den Video-Output der Grafikkarte zu der Bildwiederholrate des Monitors. Empfohlen.")
+      "Hält dein System davon ab, den Bildschirmschoner zu aktivieren.")
 MSG_HASH(MENU_ENUM_SUBLABEL_VIDEO_WINDOW_SCALE,
-      "Setzt die Fenstergrösse relativ zu der Core-Fenstergrösse. "
-      "Alternativ kannst du die Fenstergrösse weiter unten setzten für eine konstante Grösse.")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_BACK,
-      "Zurück")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_CONFIRM,
-      "Bestätigen")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_INFO,
-      "Info")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_SCROLL_DOWN,
-      "Runter Scrollen")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_SCROLL_UP,
-      "Hoch Scrollen")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_START,
-      "Starten")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_TOGGLE_KEYBOARD,
-      "Tastatur ein/aus")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_TOGGLE_MENU,
-      "Menü ein/aus")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_QUIT,
-      "Beenden")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_BATTERY_LEVEL_ENABLE,
-      "Batteriestand anzeigen")
-MSG_HASH(MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS,
-      "Lade inhaltsspezifische Core-Optionen automatisch")
-MSG_HASH(
-      MENU_ENUM_LABEL_VALUE_BROWSE_URL_LIST,
-      "Browse URL"
-      )
-MSG_HASH(
-      MENU_ENUM_LABEL_VALUE_BROWSE_URL,
-      "URL Path"
-      )
-MSG_HASH(
-      MENU_ENUM_LABEL_VALUE_BROWSE_START,
-      "Start"
-      )
-MSG_HASH(MENU_ENUM_LABEL_VALUE_SHADER_PIPELINE_BOKEH,
-      "Bokeh")
+      "Legt die Fenstergröße relativ zu der Core-Bildgröße fest. Alternativ kannst Du weiter unten die Höhe und Breite des Bildes selbst anpassen.")
+MSG_HASH(MENU_ENUM_SUBLABEL_USER_LANGUAGE,
+      "Legt die Sprache der Benutzeroberfläche fest.")
+MSG_HASH(MENU_ENUM_SUBLABEL_VIDEO_BLACK_FRAME_INSERTION,
+      "Fügt ein schwarzes Bild zwischen Einzelbildern ein. Nützlich für Benutzer von 120Hz-Monitoren, die 60Hz mit weniger 'ghosting' wünschen.")
+MSG_HASH(MENU_ENUM_SUBLABEL_VIDEO_FRAME_DELAY,
+      "Reduziert Latenz, kann aber zu Anzeigefehlern führen. Fügt eine Verzögerung bei V-Sync hinzu (in ms).")
+MSG_HASH(MENU_ENUM_SUBLABEL_VIDEO_HARD_SYNC_FRAMES,
+      "Anzahl der Bilder, die die CPU der GPU voraus sein darf, wenn die CPU/GPU-Synchronisation aktiviert ist.")
+MSG_HASH(MENU_ENUM_SUBLABEL_VIDEO_MAX_SWAPCHAIN_IMAGES,
+      "Zwingt den Videotreiber dazu, einen bestimmten Framebuffer zu verwenden.")
+MSG_HASH(MENU_ENUM_SUBLABEL_VIDEO_MONITOR_INDEX,
+      "Wält den Bildschirm aus, der für RetroArch verwendet wird.")
+MSG_HASH(MENU_ENUM_SUBLABEL_VIDEO_REFRESH_RATE_AUTO,
+      "Die geschätzte Bildwiederholrate des Bildschirms in Hz.")
+MSG_HASH(MENU_ENUM_SUBLABEL_VIDEO_SETTINGS,
+      "Einstellungen für die Videoausgabe anpassen.")
+MSG_HASH(MENU_ENUM_SUBLABEL_WIFI_SETTINGS,
+      "Sucht nach drahtlosen Netzwerken und stellt eine Verbindung her.")
+MSG_HASH(MENU_ENUM_SUBLABEL_HELP_LIST,
+      "Erfahre mehr darüber, wie Retroarch funktioniert.")
+MSG_HASH(MSG_APPENDED_DISK,
+      "Datenträger hinzufügen")
+MSG_HASH(MSG_APPLICATION_DIR,
+      "Anwendungs-Verzeichnis")
+MSG_HASH(MSG_APPLYING_CHEAT,
+      "Änderungen übernehmen.")
+MSG_HASH(MSG_APPLYING_SHADER,
+      "Shader anwenden")
+MSG_HASH(MSG_AUDIO_MUTED,
+      "Audio stummgeschaltet.")
+MSG_HASH(MSG_AUDIO_UNMUTED,
+      "Audio laut.")
+MSG_HASH(MSG_AUTOCONFIG_FILE_ERROR_SAVING,
+      "Speichern der Autokonfigurations-Datei fehlgeschlagen.")
+MSG_HASH(MSG_AUTOCONFIG_FILE_SAVED_SUCCESSFULLY,
+      "Autokonfigurations-Datei erfolgreich gespeichert.")
+MSG_HASH(MSG_AUTOSAVE_FAILED,
+      "Initialisierung der Autospeichern-Funktion fehlgeschlagen.")
+MSG_HASH(MSG_AUTO_SAVE_STATE_TO,
+      "Spielstand automatisch speichern in")
+MSG_HASH(MSG_BLOCKING_SRAM_OVERWRITE,
+      "Überschreiben des SRAM blockieren")
+MSG_HASH(MSG_BRINGING_UP_COMMAND_INTERFACE_ON_PORT,
+      "Starte Befehlsinterface auf Port")
+MSG_HASH(MSG_BYTES,
+      "Bytes")
+MSG_HASH(MSG_CANNOT_INFER_NEW_CONFIG_PATH,
+      "Kann neuen Konfigurationspfad nicht ableiten. Verwende aktuelle Zeit.") /* huh?*/
+MSG_HASH(MSG_CHEEVOS_HARDCORE_MODE_ENABLE,
+      "Hardcore-Modus aktiviert. Spielstände & die Rückspul-Funktion wurden ausgeschaltet.")
+MSG_HASH(MSG_COMPARING_WITH_KNOWN_MAGIC_NUMBERS,
+      "Vergleiche mit bekannten Magic Numbers...")
+MSG_HASH(MSG_COMPILED_AGAINST_API,
+      "Kompiliert gegen API")
+MSG_HASH(MSG_CONFIG_DIRECTORY_NOT_SET,
+      "Konfigurations-Verzeichnis nicht definiert. Kann neue Konfiguration nicht speichern.")
+MSG_HASH(MSG_CONNECTED_TO,
+      "Verbunden mit")
+MSG_HASH(MSG_CONTENT_CRC32S_DIFFER,
+      "CRC32-Prüfsummen des Inhalts weichen ab. Andere Spiele können nicht verwendet werden.")
+MSG_HASH(MSG_CONTENT_LOADING_SKIPPED_IMPLEMENTATION_WILL_DO_IT,
+      "Laden des Inhalts übersprungen. Die Implementierung wird ihn selbst laden.")
+MSG_HASH(MSG_CORE_DOES_NOT_SUPPORT_SAVESTATES,
+      "Core unterstützt keine Spielstände.")
+MSG_HASH(MSG_CORE_OPTIONS_FILE_CREATED_SUCCESSFULLY,
+      "Core-Optionsdatei wurde erfolgreich erstellt.")
+MSG_HASH(MSG_COULD_NOT_FIND_ANY_NEXT_DRIVER,
+      "Konnte keinen nächsten Treiber finden")
+MSG_HASH(MSG_COULD_NOT_FIND_COMPATIBLE_SYSTEM,
+      "Konnte kein kompatibles System finden")
+MSG_HASH(MSG_COULD_NOT_FIND_VALID_DATA_TRACK,
+      "Konnte keinen gültigen Daten-Track finden")
+MSG_HASH(MSG_COULD_NOT_OPEN_DATA_TRACK,
+      "Konnte Daten-Track nicht öffnen")
+MSG_HASH(MSG_COULD_NOT_READ_CONTENT_FILE,
+      "Konnte Inhalts-Datei nicht lesen")
+MSG_HASH(MSG_COULD_NOT_READ_MOVIE_HEADER,
+      "Konnte Film-Header nicht lesen.")
+MSG_HASH(MSG_COULD_NOT_READ_STATE_FROM_MOVIE,
+      "Konnte Status der Filmdatei nicht lesen.")
+MSG_HASH(MSG_CRC32_CHECKSUM_MISMATCH,
+      "CRC32-Prüfsumme des Inhalts und die gespeicherte Prüfsumme der Replay-Datei stimmen nicht überein. Wird die Aufzeichnung wiedergegeben, wird sie sehr wahrscheinlich asynchron.")
+MSG_HASH(MSG_CUSTOM_TIMING_GIVEN,
+      "Benutzerdefiniertes Timing gefunden")
+MSG_HASH(MSG_DECOMPRESSION_ALREADY_IN_PROGRESS,
+      "Dekompression läuft bereits.")
+MSG_HASH(MSG_DECOMPRESSION_FAILED,
+      "Dekompression fehlgeschlagen.")
+MSG_HASH(MSG_DETECTED_VIEWPORT_OF,
+      "Erkannte Bildbereich von")
+MSG_HASH(MSG_DID_NOT_FIND_A_VALID_CONTENT_PATCH,
+      "Kein gültiger Patch für diesen Inhalt gefunden.")
+MSG_HASH(MSG_DISCONNECT_DEVICE_FROM_A_VALID_PORT,
+      "Gerät von einem gültigen Anschluss trennen.")
+MSG_HASH(MSG_DISK_CLOSED,
+      "Geschlossen")
+MSG_HASH(MSG_DISK_EJECTED,
+      "Ausgeworfen")
 MSG_HASH(MSG_DOWNLOADING,
-      "Herunterladen")
+      "Herunterladen von")
 MSG_HASH(MSG_DOWNLOAD_FAILED,
       "Herunterladen fehlgeschlagen")
 MSG_HASH(MSG_ERROR,
       "Fehler")
+MSG_HASH(MSG_ERROR_LIBRETRO_CORE_REQUIRES_CONTENT,
+      "Libretro-Core benötigt Inhalt, es wurde jedoch keiner bereitgestellt.")
+MSG_HASH(MSG_ERROR_LIBRETRO_CORE_REQUIRES_SPECIAL_CONTENT,
+      "Libretro-Core benötigt speziellen Inhalt, es wurde jedoch keiner bereitgestellt.")
+MSG_HASH(MSG_ERROR_PARSING_ARGUMENTS,
+      "Fehler beim Verarbeiten der Argumente.")
+MSG_HASH(MSG_ERROR_SAVING_CORE_OPTIONS_FILE,
+      "Fehler beim Speichern der Core-Optionen")
+MSG_HASH(MSG_ERROR_SAVING_REMAP_FILE,
+      "Fehler beim Speichern der Tasten-Umbelegung.")
+MSG_HASH(MSG_ERROR_SAVING_SHADER_PRESET,
+      "Fehler beim Speichern der Shader-Voreinstellungen.")
+MSG_HASH(MSG_EXTERNAL_APPLICATION_DIR,
+      "Externe Anwendungen")
 MSG_HASH(MSG_EXTRACTING,
-      "Extrahiere")
+      "Entpacke")
 MSG_HASH(MSG_EXTRACTING_FILE,
-      "Extrahiere Datei")
+      "Entpacke Datei")
+MSG_HASH(MSG_FAILED_SAVING_CONFIG_TO,
+      "Fehler beim Speichern der Konfiguration in")
+MSG_HASH(MSG_FAILED_TO,
+      "Fehler beim")
+MSG_HASH(MSG_FAILED_TO_ACCEPT_INCOMING_SPECTATOR,
+      "Ankommender Beobachter konnte nicht akzeptiert werden.")
+MSG_HASH(MSG_FAILED_TO_ALLOCATE_MEMORY_FOR_PATCHED_CONTENT,
+      "Fehler beim zuweisen des Arbeitsspeichers für den gepatchten Inhalt...")
+MSG_HASH(MSG_FAILED_TO_APPLY_SHADER,
+      "Fehler beim Anwenden des Shaders.")
+MSG_HASH(MSG_FAILED_TO_BIND_SOCKET,
+      "Fehler beim binden des Sockets.")
+MSG_HASH(MSG_FAILED_TO_CREATE_THE_DIRECTORY,
+      "Fehler beim Erstellen des Verzeichnisses.")
+MSG_HASH(MSG_FAILED_TO_EXTRACT_CONTENT_FROM_COMPRESSED_FILE,
+      "Fehler beim Entpacken des Inhalts aus dem Archiv")
+MSG_HASH(MSG_FAILED_TO_GET_NICKNAME_FROM_CLIENT,
+      "Benutzername konnte vom Client nicht gelesen werden.")
+MSG_HASH(MSG_FAILED_TO_LOAD,
+      "Laden fehlgeschlagen")
+MSG_HASH(MSG_FAILED_TO_LOAD_CONTENT,
+      "Laden des Inhalts fehlgeschlagen")
+MSG_HASH(MSG_FAILED_TO_LOAD_MOVIE_FILE,
+      "Laden der Filmdatei fehlgeschlagen")
+MSG_HASH(MSG_FAILED_TO_LOAD_OVERLAY,
+      "Laden des Overlays fehlgeschlagen.")
+MSG_HASH(MSG_FAILED_TO_LOAD_STATE,
+      "Fehler beim Laden des Spielstands von")
+MSG_HASH(MSG_FAILED_TO_OPEN_LIBRETRO_CORE,
+      "Öffnen des Libretro-Cores fehlgeschlagen")
+MSG_HASH(MSG_FAILED_TO_PATCH,
+      "Patch fehlgeschlagen")
+MSG_HASH(MSG_FAILED_TO_RECEIVE_HEADER_FROM_CLIENT,
+      "Header konnte nicht vom Client empfangen werden.")
+MSG_HASH(MSG_FAILED_TO_RECEIVE_NICKNAME,
+      "Empfangen des Nickname fehlgeschlagen.")
+MSG_HASH(MSG_FAILED_TO_RECEIVE_NICKNAME_FROM_HOST,
+      "Empfangen des Nickname vom Host fehlgeschlagen.")
+MSG_HASH(MSG_FAILED_TO_RECEIVE_NICKNAME_SIZE_FROM_HOST,
+      "Länge des Nickname wurde vom Host nicht empfangen.")
+MSG_HASH(MSG_FAILED_TO_RECEIVE_SRAM_DATA_FROM_HOST,
+      "SRAM-Daten wurden vom Host nicht empfangen.")
+MSG_HASH(MSG_FAILED_TO_REMOVE_DISK_FROM_TRAY,
+      "Auswerfen des Datenträgers fehlgeschlagen.")
+MSG_HASH(MSG_FAILED_TO_REMOVE_TEMPORARY_FILE,
+      "Fehler beim entfernen der temporären Datei")
+MSG_HASH(MSG_FAILED_TO_SAVE_SRAM,
+      "Fehler beim Speichern des SRAM")
+MSG_HASH(MSG_FAILED_TO_SAVE_STATE_TO,
+      "Fehler beim Speichern des Spielstands in")
+MSG_HASH(MSG_FAILED_TO_SEND_NICKNAME,
+      "Fehler beim Senden des Nickname.")
+MSG_HASH(MSG_FAILED_TO_SEND_NICKNAME_SIZE,
+      "Fehler beim Senden der Nickname-Länge.")
+MSG_HASH(MSG_FAILED_TO_SEND_NICKNAME_TO_CLIENT,
+      "Fehler beim Senden des Nickname zum Client.")
+MSG_HASH(MSG_FAILED_TO_SEND_NICKNAME_TO_HOST,
+      "Fehler beim Senden des Nickname zum Host.")
+MSG_HASH(MSG_FAILED_TO_SEND_SRAM_DATA_TO_CLIENT,
+      "Fehler beim Senden der SRAM-Daten zum Client.")
+MSG_HASH(MSG_FAILED_TO_START_AUDIO_DRIVER,
+      "Audiotreiber konnte nicht gestartet werden. Fahre ohne Audio fort.")
+MSG_HASH(MSG_FAILED_TO_START_MOVIE_RECORD,
+      "Konnte Film-Aufzeichnung nicht starten.")
+MSG_HASH(MSG_FAILED_TO_START_RECORDING,
+      "Konnte Aufzeichnung nicht starten.")
+MSG_HASH(MSG_FAILED_TO_TAKE_SCREENSHOT,
+      "Konnte Bildschirmfoto nicht erstellen.")
+MSG_HASH(MSG_FAILED_TO_UNDO_LOAD_STATE,
+      "Laden des Spielstands konnte nicht rückgängig gemacht werden.")
+MSG_HASH(MSG_FAILED_TO_UNDO_SAVE_STATE,
+      "Speichern des Spielstands konnte nicht rückgängig gemacht werden.")
+MSG_HASH(MSG_FAILED_TO_UNMUTE_AUDIO,
+      "Audio konnte nicht lautgeschaltet werden.")
+MSG_HASH(MSG_FATAL_ERROR_RECEIVED_IN,
+      "Fataler Fehler in")
+MSG_HASH(MSG_FILE_NOT_FOUND,
+      "Datei nicht gefunden")
+MSG_HASH(MSG_FOUND_AUTO_SAVESTATE_IN,
+      "Spielstand gefunden in")
+MSG_HASH(MSG_FOUND_DISK_LABEL,
+      "Datenträger-Label gefunden")
+MSG_HASH(MSG_FOUND_FIRST_DATA_TRACK_ON_FILE,
+      "Ersten Daten-Track in der Datei gefunden")
+MSG_HASH(MSG_FOUND_LAST_STATE_SLOT,
+      "Letzten Speicherplatz gefunden")
+MSG_HASH(MSG_FOUND_SHADER,
+      "Shader gefunden")
+MSG_HASH(MSG_FRAMES,
+      "Bilder")
+MSG_HASH(MSG_GAME_SPECIFIC_CORE_OPTIONS_FOUND_AT,
+      "Spieloptionen: Spielspezifische Core-Optionen gefunden in")
+MSG_HASH(MSG_GOT_INVALID_DISK_INDEX,
+      "Ungültiger Datenträger-Index.")
+MSG_HASH(MSG_GRAB_MOUSE_STATE,
+      "Maus-Status")
+MSG_HASH(MSG_GAME_FOCUS_ON,
+      "Spielfokus ein")
+MSG_HASH(MSG_GAME_FOCUS_OFF,
+      "Spielfokus aus")
+MSG_HASH(MSG_HW_RENDERED_MUST_USE_POSTSHADED_RECORDING,
+      "Der Libretro-Core ist Hardware-gerendert. GPU-Aufzeichnung muss ebenfalls aktiviert werden.")
+MSG_HASH(MSG_INFLATED_CHECKSUM_DID_NOT_MATCH_CRC32,
+      "Prüfsumme entspricht nicht CRC32.")
+MSG_HASH(MSG_INPUT_CHEAT,
+      "Cheat eingeben")
+MSG_HASH(MSG_INPUT_CHEAT_FILENAME,
+      "Cheat-Dateiname")
+MSG_HASH(MSG_INPUT_PRESET_FILENAME,
+      "Vorlagen-Dateiname")
+MSG_HASH(MSG_INTERFACE,
+      "Benutzeroberläche")
+MSG_HASH(MSG_INTERNAL_STORAGE,
+      "Interner Speicher")
+MSG_HASH(MSG_REMOVABLE_STORAGE,
+      "Wechseldatenträger")
+MSG_HASH(MSG_INVALID_NICKNAME_SIZE,
+      "Ungültige Nickname-Länge.")
+MSG_HASH(MSG_IN_BYTES,
+      "in Bytes")
+MSG_HASH(MSG_IN_GIGABYTES,
+      "in Gigabyte")
+MSG_HASH(MSG_IN_MEGABYTES,
+      "in Megabyte")
+MSG_HASH(MSG_LIBRETRO_ABI_BREAK,
+      "ist gegen eine andere libretro-Version als diese kompiliert.")
+MSG_HASH(MSG_LIBRETRO_FRONTEND,
+      "Frontend für libretro")
+MSG_HASH(MSG_LOADED_STATE_FROM_SLOT,
+      "Spielstand aus Speicherplatz #%d geladen.")
+MSG_HASH(MSG_LOADED_STATE_FROM_SLOT_AUTO,
+      "Spielstand aus Speicherplatz #-1 (auto) geladen.")
+MSG_HASH(MSG_LOADING,
+      "Laden...")
+MSG_HASH(MSG_FIRMWARE,
+      "Eine oder mehrere Firmware-Dateien fehlen")
+MSG_HASH(MSG_LOADING_CONTENT_FILE,
+      "Lade Inhalts-Datei")
+MSG_HASH(MSG_LOADING_HISTORY_FILE,
+      "Lade Verlaufs-Datei")
+MSG_HASH(MSG_LOADING_STATE,
+      "Lade Spielstand")
+MSG_HASH(MSG_MEMORY,
+      "Speicher")
+MSG_HASH(MSG_MOVIE_FILE_IS_NOT_A_VALID_BSV1_FILE,
+      "Filmdatei ist keine gültige BSV1-Datei.")
+MSG_HASH(MSG_MOVIE_FORMAT_DIFFERENT_SERIALIZER_VERSION,
+      "Filmdatei besitzt offenbar eine andere Serializer-Version. Wird höchstwahrscheinlich fehlschlagen.")
+MSG_HASH(MSG_MOVIE_PLAYBACK_ENDED,
+      "Film-Wiedergabe beendet.")
+MSG_HASH(MSG_MOVIE_RECORD_STOPPED,
+      "Beende Film-Aufzeichnung.")
+MSG_HASH(MSG_NETPLAY_FAILED,
+      "Netplay-Initialisierung fehlgeschlagen.")
+MSG_HASH(MSG_NO_CONTENT_STARTING_DUMMY_CORE,
+      "Kein Inhalt, starte Dummy-Core.")
+MSG_HASH(MSG_NO_SAVE_STATE_HAS_BEEN_OVERWRITTEN_YET,
+      "Kein Spielstand wurde bis jetzt überschrieben.")
+MSG_HASH(MSG_NO_STATE_HAS_BEEN_LOADED_YET,
+      "Kein Spielstand wurde bis jetzt geladen.")
 MSG_HASH(MSG_OVERRIDES_ERROR_SAVING,
       "Fehler beim Speichern der Überschreibungen.")
 MSG_HASH(MSG_OVERRIDES_SAVED_SUCCESSFULLY,
-      "Überschreibungen wurden erfolgreich gespeichert.")
+      "Überschreibungen erfolgreich gespeichert.")
+MSG_HASH(MSG_PAUSED,
+      "Pausiert.")
+MSG_HASH(MSG_PROGRAM,
+      "RetroArch")
+MSG_HASH(MSG_READING_FIRST_DATA_TRACK,
+      "Lese ersten Daten-Track...")
+MSG_HASH(MSG_RECEIVED,
+      "empfangen")
+MSG_HASH(MSG_RECORDING_TERMINATED_DUE_TO_RESIZE,
+      "Aufzeichnung wurde wegen Größenänderung beendet.")
+MSG_HASH(MSG_RECORDING_TO,
+      "Aufzeichen in")
+MSG_HASH(MSG_REDIRECTING_CHEATFILE_TO,
+      "Cheat-Datei umleiten in")
+MSG_HASH(MSG_REDIRECTING_SAVEFILE_TO,
+      "Speicherdaten umleiten in")
+MSG_HASH(MSG_REDIRECTING_SAVESTATE_TO,
+      "Spielstand umleiten in")
+MSG_HASH(MSG_REMAP_FILE_SAVED_SUCCESSFULLY,
+      "Remap-Datei wurde erfolgreich gespeichert.")
+MSG_HASH(MSG_REMOVED_DISK_FROM_TRAY,
+      "Datenträger aus Laufwerk entfernt.")
+MSG_HASH(MSG_REMOVING_TEMPORARY_CONTENT_FILE,
+      "Entferne temporäre Inhalts-Datei")
+MSG_HASH(MSG_RESET,
+      "Zurücksetzen")
+MSG_HASH(MSG_RESTARTING_RECORDING_DUE_TO_DRIVER_REINIT,
+      "Starte Aufzeichnung neu, da Treiber reinitialisiert wurde.")
+MSG_HASH(MSG_RESTORED_OLD_SAVE_STATE,
+      "Alter Spielstand wiederhergestellt")
+MSG_HASH(MSG_RESTORING_DEFAULT_SHADER_PRESET_TO,
+      "Shader: Standard-Shader-Voreinstellung wiederhergestellt zu")
+MSG_HASH(MSG_REVERTING_SAVEFILE_DIRECTORY_TO,
+      "Setze Speicherdaten-Verzeichnis zurück auf")
+MSG_HASH(MSG_REVERTING_SAVESTATE_DIRECTORY_TO,
+      "Setze Spielstand-Verzeichnis zurück auf")
+MSG_HASH(MSG_REWINDING,
+      "Zurückspulen.")
+MSG_HASH(MSG_REWIND_INIT,
+      "Initialisiere Rückspul-Puffer mit Größe")
+MSG_HASH(MSG_REWIND_INIT_FAILED,
+      "Fehler beim Initialisieren des Rückspul-Puffers. Zurückspulen wird deaktiviert.")
+MSG_HASH(MSG_REWIND_INIT_FAILED_THREADED_AUDIO,
+      "Implementierung verwendet separaten Audio-Thread. Zurückspulen kann nicht verwendet werden.")
+MSG_HASH(MSG_REWIND_REACHED_END,
+      "Ende des Rückspul-Puffers erreicht.")
+MSG_HASH(MSG_SAVED_NEW_CONFIG_TO,
+      "Neue Konfiguration gespeichert in")
+MSG_HASH(MSG_SAVED_STATE_TO_SLOT,
+      "Spielstand in Speicherplatz #%d gespeichert.")
+MSG_HASH(MSG_SAVED_STATE_TO_SLOT_AUTO,
+      "Spielstand in Speicherplatz #-1 (auto) gespeichert.")
+MSG_HASH(MSG_SAVED_SUCCESSFULLY_TO,
+      "Erfolgreich gespeichert in")
+MSG_HASH(MSG_SAVING_RAM_TYPE,
+      "Speichere RAM-Typ")
+MSG_HASH(MSG_SAVING_STATE,
+      "Speichere Spielstand") /* more context needed */
 MSG_HASH(MSG_SCANNING,
-      "Durchsuche") /* Used for displaying progress */
+      "Durchsuchen")
 MSG_HASH(MSG_SCANNING_OF_DIRECTORY_FINISHED,
-      "Durchsuchen des Verzeichnisses wurde beendet.")
+      "Durchsuchen des Verzeichnisses beendet")
+MSG_HASH(MSG_SENDING_COMMAND,
+      "Sende Befehl")
+MSG_HASH(MSG_SEVERAL_PATCHES_ARE_EXPLICITLY_DEFINED,
+      "Mehrere Patches wurden explizit definiert, ignoriere alle...")
+MSG_HASH(MSG_SHADER,
+      "Shader")
+MSG_HASH(MSG_SHADER_PRESET_SAVED_SUCCESSFULLY,
+      "Shader-Voreinstellung erfolgreich gespeichert.")
+MSG_HASH(MSG_SKIPPING_SRAM_LOAD,
+      "Überspringe Laden des SRAM.")
+MSG_HASH(MSG_SLOW_MOTION,
+      "Zeitlupe.")
+MSG_HASH(MSG_SLOW_MOTION_REWIND,
+      "In Zeitlupe zurückspulen.")
+MSG_HASH(MSG_SRAM_WILL_NOT_BE_SAVED,
+      "SRAM wird nicht gespeichert.")
+MSG_HASH(MSG_STARTING_MOVIE_PLAYBACK,
+      "Starte Film-Wiedergabe.")
+MSG_HASH(MSG_STARTING_MOVIE_RECORD_TO,
+      "Starte Film-Aufzeichnung in")
+MSG_HASH(MSG_STATE_SIZE,
+      "Spielstand-Größe")
+MSG_HASH(MSG_STATE_SLOT,
+      "Spielstand-Speicherplatz")
+MSG_HASH(MSG_TAKING_SCREENSHOT,
+      "Erstelle Bildschirmfoto.")
+MSG_HASH(MSG_TO,
+      "nach")
+MSG_HASH(MSG_UNDID_LOAD_STATE,
+      "Laden des Spielstands wurde rückgängig gemacht.")
+MSG_HASH(MSG_UNDOING_SAVE_STATE,
+      "Speichern des Spielstands wurde rückgängig gemacht.")
+MSG_HASH(MSG_UNKNOWN,
+      "Unbekannt")
+MSG_HASH(MSG_UNPAUSED,
+      "Nicht pausiert.")
+MSG_HASH(MSG_UNRECOGNIZED_COMMAND,
+      "Unbekannter Befehl")
+MSG_HASH(MSG_USING_CORE_NAME_FOR_NEW_CONFIG,
+      "Verwende Core-Namen für neue Konfiguration.")
+MSG_HASH(MSG_USING_LIBRETRO_DUMMY_CORE_RECORDING_SKIPPED,
+      "Verwende libretro-Dumy-Core. Überspringe Aufzeichnung.")
+MSG_HASH(MSG_VALUE_CONNECT_DEVICE_FROM_A_VALID_PORT,
+      "Verbinde Gerät von einem gültigen Anschluss.") /* sounds odd, maybe improper translation*/
+MSG_HASH(MSG_VALUE_DISCONNECTING_DEVICE_FROM_PORT,
+      "Trenne Gerät von Anschluss")
+MSG_HASH(MSG_VALUE_REBOOTING,
+      "Neustart...")
+MSG_HASH(MSG_VALUE_SHUTTING_DOWN,
+      "Beenden...")
+MSG_HASH(MSG_VERSION_OF_LIBRETRO_API,
+      "Version der libretro-API")
+MSG_HASH(MSG_VIEWPORT_SIZE_CALCULATION_FAILED,
+      "Berechnung der Bildgröße fehlgeschlagen! Wird unter Verwendung von Rohdaten fortfahren. Dies wird wahrscheinlich nicht richtig funktionieren ...")
+MSG_HASH(MSG_VIRTUAL_DISK_TRAY,
+      "Virtuelle Laufwerksschublade.")
+MSG_HASH(MENU_ENUM_SUBLABEL_AUDIO_LATENCY,
+      "Gewünschte Audiolatenz in Millisekunden. Je nach Audiotreiber kann die gewünschte Latenz nicht erzielt werden; diese Einstellung wird dann ignoriert.")
+MSG_HASH(MENU_ENUM_SUBLABEL_AUDIO_MUTE,
+      "Audio stumm-/lautschalten.")
+MSG_HASH(
+      MENU_ENUM_SUBLABEL_AUDIO_RATE_CONTROL_DELTA,
+      "Hilft Fehler bei der Audio- und Videosynchronisierung auszubügeln. "
+      "Wenn deaktiviert, ist eine brauchbare Synchronisation nahezu unmöglich.")
+MSG_HASH(
+      MENU_ENUM_SUBLABEL_CAMERA_ALLOW,
+      "Erlaube oder verbiete den Cores Zugriff auf die Kamera."
+      )
+MSG_HASH(
+      MENU_ENUM_SUBLABEL_LOCATION_ALLOW,
+      "Erlaube oder verbiete den Cores Zugriff auf Ortsdienste."
+      )
+MSG_HASH(
+      MENU_ENUM_SUBLABEL_INPUT_MAX_USERS,
+      "Maximale Anzahl von Benutzern, die von RetroArch unterstützt werden."
+      )
+MSG_HASH(
+      MENU_ENUM_SUBLABEL_INPUT_POLL_TYPE_BEHAVIOR,
+      "Beeinflusst, wie die Eingabe in RetroArch abgefragt wird. Wird dieser Wert auf 'Früh' oder 'Spät' gesetzt, kann sich je nach Konfiguration die Latenz verringern."
+      )
+MSG_HASH(
+      MENU_ENUM_SUBLABEL_INPUT_ALL_USERS_CONTROL_MENU,
+      "Ermöglicht jedem Benutzer das Menü zu benutzen. Wenn deaktiviert, kann nur Benutzer 1 das Menü benutzen."
+      )
+MSG_HASH(
+      MENU_ENUM_SUBLABEL_AUDIO_VOLUME,
+      "Lautstärkeverstärkung in dB. 0 dB ist die normale Lautstärke, es erfolgt eine Verstärkung."
+      )
+MSG_HASH(
+   MENU_ENUM_SUBLABEL_AUDIO_SYNC,
+   "Synchronisiere Audio. Empfohlen."
+   )
+MSG_HASH(
+   MENU_ENUM_SUBLABEL_INPUT_AXIS_THRESHOLD,
+      "Wie weit ein Analog-Stick bewegt werden muss, bis er reagiert."
+   )
+MSG_HASH(
+   MENU_ENUM_SUBLABEL_INPUT_BIND_TIMEOUT,
+   "Zeitdauer in Sekunden, nach der die nächste Tastenbelegung abgefragt wird."
+   )
+MSG_HASH(
+   MENU_ENUM_SUBLABEL_INPUT_TURBO_PERIOD,
+   "Beschreibt, nach wie vielen Einzelbildern eine Taste mit aktiviertem Turbo-Modus erneut gedrückt wird."
+   )
+MSG_HASH(
+   MENU_ENUM_SUBLABEL_INPUT_DUTY_CYCLE,
+   "Beschreibt, wie lange eine Taste mit aktivierem Turbo-Modus 'gedrückt' wird. Dieser Wert wird in der Anzahl der Einzelbilder angegeben."
+   )
+MSG_HASH(
+   MENU_ENUM_SUBLABEL_VIDEO_VSYNC,
+   "Synchronisiert die Video-Ausgabe der Grafikkarte mit der Bildwiederholrate des Bildschirms. Empfohlen."
+   )
+MSG_HASH(
+   MENU_ENUM_SUBLABEL_VIDEO_ALLOW_ROTATE,
+   "Erlaubt Cores, die Bildrotation zu setzen. Wenn deaktiviert, werden Anfragen nach der Bildrotation deaktiviert. Nützlich für Bildschirme, die manuell gedreht werden sollen."
+   )
+MSG_HASH(
+   MENU_ENUM_SUBLABEL_DUMMY_ON_CORE_SHUTDOWN,
+   "Einige Cores haben eine eigene Abschalt-Funktion. Wenn aktiviert, wird der Core daran gehindert, RetroArch zu beenden. Stattdessen wird ein Dummy-Core geladen."
+   )
+MSG_HASH(
+   MENU_ENUM_SUBLABEL_CHECK_FOR_MISSING_FIRMWARE,
+   "Überprüft, ob eventuell benötigte Firmware vorhanden ist, bevor versucht wird, Inhalte zu laden."
+   )
+MSG_HASH(
+   MENU_ENUM_SUBLABEL_VIDEO_REFRESH_RATE,
+   "Vertikale Bildwiederholrate des Bildschirms. Wird verwendet, um eine geeignete Audio-Eingangsrate zu berechnen. Hinweis: Diese Einstellung wird ignoriert, wenn 'Video in separatem Thread' aktiviert ist."
+   )
+MSG_HASH(
+   MENU_ENUM_SUBLABEL_AUDIO_ENABLE,
+   "Aktiviere Audio-Ausgabe."
+   )
+MSG_HASH(
+   MENU_ENUM_SUBLABEL_AUDIO_MAX_TIMING_SKEW,
+   "Maximale Änderung der Audio-Eingangsrate. Dieser Wert kann erhöht werden, wenn sehr große Änderungen im Timing aktiviert werden sollen, (beispielsweise um einen PAL-Core auf einem NTSC-Bildschirm darzustellen), verursacht jedoch fehlerhafte Tonhöhen."
+   )
+MSG_HASH(
+   MSG_FAILED,
+   "fehlgeschlagen"
+   )
+MSG_HASH(
+   MSG_SUCCEEDED,
+   "erfolgreich"
+   )
+MSG_HASH(
+   MSG_DEVICE_NOT_CONFIGURED,
+   "nicht konfiguriert"
+   )
+MSG_HASH(
+   MENU_ENUM_LABEL_VALUE_DATABASE_CURSOR_LIST,
+   "Datenbank-Zeiger" /* might be inaccurate */
+   )
+MSG_HASH(
+   MENU_ENUM_LABEL_VALUE_DATABASE_CURSOR_LIST_ENTRY_DEVELOPER,
+   "Datenbank - Filter : Entwickler"
+   )
+MSG_HASH(
+   MENU_ENUM_LABEL_VALUE_DATABASE_CURSOR_LIST_ENTRY_PUBLISHER,
+   "Datenbank - Filter : Publisher"
+   )
+MSG_HASH(
+   MENU_ENUM_LABEL_VALUE_DISABLED,
+   "Deaktiviert"
+   )
+MSG_HASH(
+   MENU_ENUM_LABEL_VALUE_ENABLED,
+   "Aktiviert"
+   )
+MSG_HASH(
+   MENU_ENUM_LABEL_VALUE_CONTENT_HISTORY_PATH,
+   "Pfad zur Verlaufsliste"
+   )
+MSG_HASH(
+      MENU_ENUM_LABEL_VALUE_DATABASE_CURSOR_LIST_ENTRY_ORIGIN,
+      "Datenbank - Filter : Herkunft")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_DATABASE_CURSOR_LIST_ENTRY_FRANCHISE,
+      "Datenbank - Filter : Franchise")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_DATABASE_CURSOR_LIST_ENTRY_ESRB_RATING,
+      "Datenbank - Filter : ESRB-Bewertung")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_DATABASE_CURSOR_LIST_ENTRY_ELSPA_RATING,
+      "Datenbank - Filter : ELSPA-Bewertung")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_DATABASE_CURSOR_LIST_ENTRY_PEGI_RATING,
+      "Datenbank - Filter : PEGI-Bewertung")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_DATABASE_CURSOR_LIST_ENTRY_CERO_RATING,
+      "Datenbank - Filter : CERO-Bewertung")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_DATABASE_CURSOR_LIST_ENTRY_BBFC_RATING,
+      "Datenbank - Filter : BBFC-Bewertung")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_DATABASE_CURSOR_LIST_ENTRY_MAX_USERS,
+      "Datenbank - Filter : Max. Spieler")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_DATABASE_CURSOR_LIST_ENTRY_RELEASEDATE_BY_MONTH,
+      "Datenbank - Filter : Veröffentlichungsdatum nach Monat")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_DATABASE_CURSOR_LIST_ENTRY_RELEASEDATE_BY_YEAR,
+      "Datenbank - Filter : Veröffentlichungsdatum nach Jahr")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_DATABASE_CURSOR_LIST_ENTRY_EDGE_MAGAZINE_ISSUE,
+      "Datenbank - Filter : Edge Magazine-Ausgabe")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_DATABASE_CURSOR_LIST_ENTRY_EDGE_MAGAZINE_RATING,
+      "Datenbank - Filter : Edge Magazine-Bewertung")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_DATABASE_CURSOR_LIST_ENTRY_DATABASE_INFO,
+      "Datenbank-Informationen")
+MSG_HASH(MSG_WIFI_SCAN_COMPLETE,
+      "Suche nach WLAN-Netzwerken abgeschlossen.")
+MSG_HASH(MSG_SCANNING_WIRELESS_NETWORKS,
+      "Suche nach WLAN-Netzwerken...")
+MSG_HASH(MSG_NETPLAY_LAN_SCAN_COMPLETE,
+      "Netplay-Suche abgeschlossen.")
+MSG_HASH(MSG_NETPLAY_LAN_SCANNING,
+      "Suche nach Netplay-Hosts...")


### PR DESCRIPTION
This is the 2nd part of the new German translation. This time, I translated a bunch of missing strings, fixed some issues and improved some strings. All strings are now sorted in the same order as the upstream file, so future maintenance will be much easier.

Hopefully, most of @CoalaJoe's changes are included. If not, I will add them in part 3. Part 3 will constist of merging the German language file with the current upstream and the translate all the missing strings. If a string was already translated by @CoalaJoe, I will consider using his translation.

@CoalaJoe, because I am currently partially working on part 3, please don't modify the German translation in the meantime, thanks!