### PR TITLE
sdl2 renderer: remove the random flashing black borders

### DIFF
--- a/gfx/drivers/sdl2_gfx.c
+++ b/gfx/drivers/sdl2_gfx.c
@@ -505,6 +505,7 @@ static bool sdl2_gfx_frame(void *data, const void *frame, unsigned width,
    {
       static struct retro_perf_counter sdl_copy_frame = {0};
 
+      SDL_RenderClear(vid->renderer);
       sdl_refresh_input_size(vid, false, vid->video.rgb32, width, height, pitch);
 
       performance_counter_init(sdl_copy_frame, "sdl_copy_frame");


### PR DESCRIPTION
on the batocera linux distribution (https://github.com/nadenislamarre/batocera.linux),
retroarch gives some flashing black borders sometimes when running a game.
It looks like sometimes the rendering is done without clearing the screen causing
this flashing effect.

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>