### PR TITLE
fix crashes when trying to connect with contentless cores

### DIFF
--- a/command.c
+++ b/command.c
@@ -1350,15 +1350,6 @@ static bool event_init_content(void)
 
    content_get_status(&contentless, &is_inited);
 
-   if (contentless)
-   {
-#ifdef HAVE_NETWORKING
-      if (netplay_driver_ctl(RARCH_NETPLAY_CTL_IS_ENABLED, NULL))
-         RARCH_ERR("%s\n", msg_hash_to_str(MSG_SORRY_UNIMPLEMENTED_CORES_DONT_DEMAND_CONTENT_NETPLAY));
-#endif
-      return true;
-   }
-
    command_event_set_savestate_auto_index();
 
    if (event_load_save_files())

--- a/tasks/task_netplay_find_content.c
+++ b/tasks/task_netplay_find_content.c
@@ -71,7 +71,7 @@ static void netplay_crc_scan_callback(void *task_data,
    else if (!string_is_empty(state->core_path) && !string_is_empty(state->content_path) &&
       string_is_equal(state->content_path, "N/A"))
    {
-      printf("Content: %s Core: %s\n", state->content_path, state->core_path);
+      command_event(CMD_EVENT_NETPLAY_INIT_DIRECT_DEFERRED, state->hostname);
       task_push_content_load_default(
             state->core_path, NULL,
             &content_info,

--- a/tasks/task_netplay_find_content.c
+++ b/tasks/task_netplay_find_content.c
@@ -57,7 +57,8 @@ static void netplay_crc_scan_callback(void *task_data,
       return;
 
    fflush(stdout);
-   if (!string_is_empty(state->core_path) && !string_is_empty(state->content_path))
+   if (!string_is_empty(state->core_path) && !string_is_empty(state->content_path) &&
+       !string_is_equal(state->content_path, "N/A"))
    {
       command_event(CMD_EVENT_NETPLAY_INIT_DIRECT_DEFERRED, state->hostname);
       task_push_content_load_default(
@@ -67,14 +68,21 @@ static void netplay_crc_scan_callback(void *task_data,
             CONTENT_MODE_LOAD_CONTENT_WITH_NEW_CORE_FROM_MENU,
             NULL, NULL);
    }
-   else if(string_is_equal(state->content_path, "N/A"))
+   else if (!string_is_empty(state->core_path) && !string_is_empty(state->content_path) &&
+      string_is_equal(state->content_path, "N/A"))
    {
       printf("Content: %s Core: %s\n", state->content_path, state->core_path);
       task_push_content_load_default(
             state->core_path, NULL,
-            NULL,
+            &content_info,
             CORE_TYPE_PLAIN,
             CONTENT_MODE_LOAD_NOTHING_WITH_NEW_CORE_FROM_MENU,
+            NULL, NULL);
+      task_push_content_load_default(
+            state->core_path, NULL,
+            &content_info,
+            CORE_TYPE_PLAIN,
+            CONTENT_MODE_LOAD_NOTHING_WITH_CURRENT_CORE_FROM_MENU,
             NULL, NULL);
    }
    else
@@ -263,8 +271,12 @@ bool task_push_netplay_crc_scan(uint32_t crc, char* name,
       if(string_is_equal(info->list[i].core_name, state->core_name))
       {
          strlcpy(state->core_path, info->list[i].path, sizeof(state->core_path));
-         strlcpy(state->core_extensions,
-               info->list[i].supported_extensions, sizeof(state->core_extensions));
+
+         if (!string_is_equal(state->content_path, "N/A"))
+         {
+            strlcpy(state->core_extensions,
+                  info->list[i].supported_extensions, sizeof(state->core_extensions));
+         }
          break;
       }
    }


### PR DESCRIPTION
@twinaphex with this, clients will load the core (mrboom) correctly and it will no longer crash
there is still something going on differently for both server and client when starting a contentless core so netplay_init is never called.

You can reproduce this by doing "start netplay host" and starting mrboom. You'll notice netplay isn't really enabled. Once that is fixed it will work 100%