### PR TITLE
(XMB) Fix Battery/Clock Icon Sizes

### DIFF
--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -2658,6 +2658,9 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
    /* Clock image */
    menu_display_set_alpha(coord_white, MIN(xmb->alpha, 1.00f));
 
+   /* The Clock/Battery icon size */
+   float status_icon_scale = 0.3f;
+
    if (video_info->battery_level_enable)
    {
       char msg[12];
@@ -2687,8 +2690,8 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
                   &mymat,
                   xmb->textures.list[charging
                   ? XMB_TEXTURE_BATTERY_CHARGING : XMB_TEXTURE_BATTERY_FULL],
-                  width - xmb->margins.title.left - (xmb->icon.size / 2),
-                  xmb->icon.size - (xmb->icon.size / 3),
+                  width - xmb->margins.title.left - (xmb->icon.size * status_icon_scale),
+                  xmb->margins.title.top + (xmb->icon.size * status_icon_scale) / 5,
                   width,
                   height,
                   1,
@@ -2696,14 +2699,14 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
                   1,
                   &coord_white[0],
                   xmb->shadow_offset,
-                  0.5);
+                  status_icon_scale);
 
          snprintf(msg, sizeof(msg), "%d%%", percent);
 
          percent_width = font_driver_get_message_width(xmb->font, msg, utf8len(msg), 1);
 
          xmb_draw_text(menu_disp_info, xmb, msg,
-               width - xmb->margins.title.left - (xmb->icon.size / 2),
+               width - xmb->margins.title.left - (xmb->icon.size * status_icon_scale),
                xmb->margins.title.top, 1, 1, TEXT_ALIGN_RIGHT,
                width, height, xmb->font);
       }
@@ -2726,8 +2729,8 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
                xmb->icon.size,
                &mymat,
                xmb->textures.list[XMB_TEXTURE_CLOCK],
-               width - xmb->margins.title.left - (xmb->icon.size / 2.5) - x_pos,
-               xmb->icon.size - (xmb->icon.size / 3),
+               width - xmb->margins.title.left - (xmb->icon.size * status_icon_scale) - x_pos,
+                  xmb->margins.title.top + (xmb->icon.size * status_icon_scale) / 5,
                width,
                height,
                1,
@@ -2735,7 +2738,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
                1,
                &coord_white[0],
                xmb->shadow_offset,
-               0.5);
+               status_icon_scale);
       }
 
       timedate[0]        = '\0';
@@ -2747,7 +2750,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
       menu_display_timedate(&datetime);
 
       xmb_draw_text(menu_disp_info, xmb, timedate,
-            width - xmb->margins.title.left - (xmb->icon.size / 2) - x_pos,
+            width - xmb->margins.title.left - (xmb->icon.size * status_icon_scale) - x_pos,
             xmb->margins.title.top, 1, 1, TEXT_ALIGN_RIGHT,
             width, height, xmb->font);
    }

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -2706,7 +2706,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
          percent_width = font_driver_get_message_width(xmb->font, msg, utf8len(msg), 1);
 
          xmb_draw_text(menu_disp_info, xmb, msg,
-               width - xmb->margins.title.left - (xmb->icon.size * status_icon_scale),
+               width - xmb->margins.title.left - (xmb->icon.size * status_icon_scale * 1.2),
                xmb->margins.title.top, 1, 1, TEXT_ALIGN_RIGHT,
                width, height, xmb->font);
       }
@@ -2750,7 +2750,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
       menu_display_timedate(&datetime);
 
       xmb_draw_text(menu_disp_info, xmb, timedate,
-            width - xmb->margins.title.left - (xmb->icon.size * status_icon_scale) - x_pos,
+            width - xmb->margins.title.left - (xmb->icon.size * status_icon_scale * 1.2) - x_pos,
             xmb->margins.title.top, 1, 1, TEXT_ALIGN_RIGHT,
             width, height, xmb->font);
    }

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -2720,7 +2720,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
 
       // Move the timedate widget over if the battery percent is active.
       if (percent_width)
-         x_pos = percent_width + xmb->icon.size;
+         x_pos = percent_width + (xmb->icon.size / 2);
 
       if (coord_white[3] != 0)
       {

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -2659,7 +2659,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
    menu_display_set_alpha(coord_white, MIN(xmb->alpha, 1.00f));
 
    /* The Clock/Battery icon size */
-   float status_icon_scale = 0.3f;
+   float status_icon_scale = 0.25f;
 
    if (video_info->battery_level_enable)
    {


### PR DESCRIPTION
This makes it so that the XMB battery/clock sizes are normal sizes, rather then the super small versions that currently exist. Fixes https://github.com/libretro/RetroArch/issues/4587 .

Requires the retroarch-assets PR over at: https://github.com/libretro/retroarch-assets/pull/122

![iconsize](https://cloud.githubusercontent.com/assets/25086/22854598/2b0528fc-f040-11e6-8169-511638242d83.png)
