### PR TITLE
Change to advanced settings: auto_remaps_enable & auto_overrides_enable

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -2817,13 +2817,13 @@ static bool setting_append_list(
             bool_entries[3].name_enum_idx  = MENU_ENUM_LABEL_AUTO_OVERRIDES_ENABLE;
             bool_entries[3].SHORT_enum_idx = MENU_ENUM_LABEL_VALUE_AUTO_OVERRIDES_ENABLE;
             bool_entries[3].default_value  = default_auto_overrides_enable;
-            bool_entries[3].flags          = SD_FLAG_NONE;
+            bool_entries[3].flags          = SD_FLAG_ADVANCED;
 
             bool_entries[4].target         = &settings->auto_remaps_enable;
             bool_entries[4].name_enum_idx  = MENU_ENUM_LABEL_AUTO_REMAPS_ENABLE;
             bool_entries[4].SHORT_enum_idx = MENU_ENUM_LABEL_VALUE_AUTO_REMAPS_ENABLE;
             bool_entries[4].default_value  = default_auto_remaps_enable;
-            bool_entries[4].flags          = SD_FLAG_NONE;
+            bool_entries[4].flags          = SD_FLAG_ADVANCED;
 
             bool_entries[5].target         = &settings->auto_shaders_enable;
             bool_entries[5].name_enum_idx  = MENU_ENUM_LABEL_AUTO_SHADERS_ENABLE;


### PR DESCRIPTION
There seems to be no reason to show these options as they default to true and there's no reason to disable them unless you were debugging something (and even then...). For me their only purpose would be for 'Advanced users'.

Maybe even remove the option entirely?