### PR TITLE
Better console behavior

### DIFF
--- a/frontend/drivers/platform_win32.c
+++ b/frontend/drivers/platform_win32.c
@@ -345,13 +345,12 @@ static void frontend_win32_attach_console(void)
 {
 #ifdef _WIN32
 #ifdef _WIN32_WINNT_WINXP
-   if (!AttachConsole(ATTACH_PARENT_PROCESS))
-   {
-      AllocConsole();
-      AttachConsole( GetCurrentProcessId()) ;
-      freopen( "CON", "w", stdout );
-      freopen( "CON", "w", stderr );
-   }
+   AttachConsole(ATTACH_PARENT_PROCESS);
+   AllocConsole();
+   AttachConsole( GetCurrentProcessId()) ;
+   freopen( "CON", "w", stdout );
+   freopen( "CON", "w", stderr );
+
 #endif
 #endif
 }

--- a/verbosity.c
+++ b/verbosity.c
@@ -56,7 +56,7 @@ void verbosity_enable(void)
 {
    main_verbosity = true;
 #ifdef RARCH_INTERNAL
-   if (!log_file)
+   if (!log_file_initialized)
       frontend_driver_attach_console();
 #endif
 }
@@ -65,7 +65,7 @@ void verbosity_disable(void)
 {
    main_verbosity = false;
 #ifdef RARCH_INTERNAL
-   if (!log_file)
+   if (!log_file_initialized)
       frontend_driver_detach_console();
 #endif
 }


### PR DESCRIPTION
Now it works like this:

- If opened from cmd and log specified, logs to file, doesn't attach to console and logs to file
- If opened from cmd and no log specified, logs to file, doesn't attach to console and logs to stdout
- If opened directly and log specified, logs to file
- If opened directly and no log specified, creates a console window

Tested thoroughly, seems to be in good working order