### PR TITLE
Default game_specific_options to true.

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -652,7 +652,7 @@ static const uint32_t menu_title_color        = 0xff64ff64;
 static bool default_block_config_read = false;
 #endif
 
-static bool default_game_specific_options = false;
+static bool default_game_specific_options = true;
 static bool default_auto_overrides_enable = true;
 static bool default_auto_remaps_enable = true;
 static bool default_auto_shaders_enable = true;


### PR DESCRIPTION
This is the core-option per-game overrides functionality. If the user hasn't created any per-game override files, they won't be used. Seems to me like there's no harm in defaulting this to on.