### PR TITLE
One option moved to advanced settings.

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -2811,7 +2811,7 @@ static bool setting_append_list(
             bool_entries[2].name_enum_idx  = MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS;
             bool_entries[2].SHORT_enum_idx = MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS;
             bool_entries[2].default_value  = default_game_specific_options;
-            bool_entries[2].flags          = SD_FLAG_NONE;
+            bool_entries[2].flags          = SD_FLAG_ADVANCED;
 
             bool_entries[3].target         = &settings->auto_overrides_enable;
             bool_entries[3].name_enum_idx  = MENU_ENUM_LABEL_AUTO_OVERRIDES_ENABLE;


### PR DESCRIPTION
Following https://github.com/libretro/RetroArch/pull/4670, game_specific_options defaults to true and would need some specific test cases for them to be turned off. same with show_hidden_files - defaults to false, and you'd pretty much always want them hidden unless testing something.

so let's get them in the 'advanced' section :)