### PR TITLE
intl: Translate the new Netplay settings to German

### DIFF
--- a/intl/msg_hash_de.c
+++ b/intl/msg_hash_de.c
@@ -1548,6 +1548,21 @@ int menu_hash_get_help_de_enum(enum msg_hash_enums msg, char *s, size_t len)
                " \n"
                "Wird dieser Wert erhöht, verbessert sich \n"
                "die Leistung, die Latenz erhöht sich jedoch.");
+        case MENU_ENUM_LABEL_NETPLAY_PUBLIC_ANNOUNCE:
+            snprintf(s, len,
+                     "Legt fest, ob Netplay-Spiele öffentlich angekündigt werden. \n"
+                             " \n"
+                             "Wenn diese Option deaktiviert ist, müssen sich Clients manuell \n"
+                             "verbinden und können die öffentliche Lobby nicht verwenden.");
+            break;
+        case MENU_ENUM_LABEL_NETPLAY_START_AS_SPECTATOR:
+            snprintf(s, len,
+                     "Legt fest, ob Netplay im Beobachtermodus gestartet wird. \n"
+                             " \n"
+                             "Wenn diese Option aktiviert ist, wird Netplay im \n"
+                             "Beobachtermodus starten. Es ist jederzeit möglich, \n"
+                             "den Modus zu ändern.");
+            break;
         case MENU_ENUM_LABEL_NETPLAY_STATELESS_MODE: /* Maybe FIXME*/
             snprintf(s, len,
                      "Legt fest, ob Netplay in einem Modus laufen soll, der keine\n"
@@ -1717,7 +1732,7 @@ int menu_hash_get_help_de_enum(enum msg_hash_enums msg, char *s, size_t len)
          break;
       case MENU_ENUM_LABEL_NETPLAY_SPECTATOR_MODE_ENABLE:
          snprintf(s, len,
-               "Aktiviere oder deaktiviere Beobachter-Modus\n"
+               "Aktiviere oder deaktiviere Beobachtermodus\n"
                "für den Benutzer im Netplay-Spiel.");
          break;
       case MENU_ENUM_LABEL_NETPLAY_IP_ADDRESS:

--- a/intl/msg_hash_de.h
+++ b/intl/msg_hash_de.h
@@ -993,10 +993,12 @@ MSG_HASH(MENU_ENUM_LABEL_VALUE_NETPLAY_PUBLIC_ANNOUNCE,
       "Netplay öffentlich ankündigen")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NETPLAY_SETTINGS,
       "Netplay-Einstellungen")
+MSG_HASH(MENU_ENUM_LABEL_VALUE_NETPLAY_START_AS_SPECTATOR,
+      "Im Beobachtermodus starten")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NETPLAY_STATELESS_MODE,
       "Netplay ohne Savestates")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATE_PASSWORD,
-      "Server-Passwort für Beobachter-Modus")
+      "Server-Passwort für Beobachtermodus")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NETPLAY_SPECTATOR_MODE_ENABLE,
       "Beobachtermodus aktivieren")
 MSG_HASH(MENU_ENUM_LABEL_VALUE_NETPLAY_TCP_UDP_PORT,
@@ -2631,6 +2633,10 @@ MSG_HASH(
 MSG_HASH(
       MENU_ENUM_SUBLABEL_NETPLAY_SPECTATE_PASSWORD,
       "Das Passwort, das für die Verbindung zum Netplay-Host mit Beobachter-Privilegien verwendet wird. Wird nur im Host-Modus verwendet."
+      )
+MSG_HASH(
+      MENU_ENUM_SUBLABEL_NETPLAY_START_AS_SPECTATOR,
+      "Lege fest, ob Netplay im Beobachtermodus starten soll."
       )
 MSG_HASH(
       MENU_ENUM_SUBLABEL_NETPLAY_STATELESS_MODE,


### PR DESCRIPTION
This adds translations for the new Netplay settings (Spectator Mode)
to the German GUI translation.