### PR TITLE
Adds lan games to the ROOM list

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -4941,8 +4941,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, void *data)
 
             if (!hosts || hosts->size == 0)
             {
-               if (!hosts)
-                  task_push_netplay_lan_scan();
+               task_push_netplay_lan_scan();
 
                menu_entries_append_enum(info->list,
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NO_NETPLAY_HOSTS_FOUND),

--- a/tasks/task_netplay_lan_scan.c
+++ b/tasks/task_netplay_lan_scan.c
@@ -107,3 +107,20 @@ bool task_push_netplay_lan_scan(void)
 
    return true;
 }
+
+bool task_push_netplay_lan_scan_rooms(void)
+{
+   retro_task_t *task = (retro_task_t*)calloc(1, sizeof(*task));
+
+   if (!task)
+      return false;
+
+   task->type     = TASK_TYPE_BLOCKING;
+   task->handler  = task_netplay_lan_scan_handler;
+   task->callback = netplay_lan_scan_callback;
+   task->title    = strdup(msg_hash_to_str(MSG_NETPLAY_LAN_SCANNING));
+
+   task_queue_ctl(TASK_QUEUE_CTL_PUSH, task);
+
+   return true;
+}


### PR DESCRIPTION
This is incomplete
- Needs the host to announce the gamecrc
- We need to get the address from struct sockaddr, I could look into it but I don't have time now, @GregorR said he could help me tomorrow
- It always works with port 55435. I see two alternatives:

1. Always listen in 55435|UDP for LAN scanning and report back the correct port
2. Make an entry that reads "start lan game" that makes it always use 55435
