### PR TITLE
Allow audio latency setting to be fine tuned with 1ms intervals

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -3803,7 +3803,7 @@ static bool setting_append_list(
                parent_group,
                general_write_handler,
                general_read_handler);
-         menu_settings_list_current_add_range(list, list_info, 8, 512, 16.0, true, true);
+         menu_settings_list_current_add_range(list, list_info, 0, 512, 1.0, true, true);
          settings_data_list_current_add_flags(list, list_info, SD_FLAG_LAKKA_ADVANCED);
 
          CONFIG_FLOAT(


### PR DESCRIPTION
Makes it possible to set the audio latency in the menu to non 16ms intervals (i.e. 12ms or 20ms, etc).