### PR TITLE
SRAM Autosave: Default to 10 seconds on non-console builds and allow changing it in 1 second intervals.

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -816,7 +816,11 @@ static const bool pause_nonactive = true;
 
 /* Saves non-volatile SRAM at a regular interval.
  * It is measured in seconds. A value of 0 disables autosave. */
+#if defined(RARCH_CONSOLE)
 static const unsigned autosave_interval = 0;
+#else
+static const unsigned autosave_interval = 10;
+#endif
 
 /* Publicly announce netplay */
 static const bool netplay_public_announce = true;

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -3025,7 +3025,7 @@ static bool setting_append_list(
                   general_write_handler,
                   general_read_handler);
             menu_settings_list_current_add_cmd(list, list_info, CMD_EVENT_AUTOSAVE_INIT);
-            menu_settings_list_current_add_range(list, list_info, 0, 0, 10, true, false);
+            menu_settings_list_current_add_range(list, list_info, 0, 0, 1, true, false);
             settings_data_list_current_add_flags(list, list_info, SD_FLAG_CMD_APPLY_AUTO);
             (*list)[list_info->index - 1].get_string_representation = 
                &setting_get_string_representation_uint_autosave_interval;


### PR DESCRIPTION
Console builds will still default to having SRAM Autosave disabled. PC and Android should be able to handle a 10 second interval, at least in my experience. Also, allow setting less than 10 second intervals in the menu by increasing/decreasing by 1 second instead of 10 seconds.

This should reduce reports of people losing SRAM data because of a crash or because RA was force closed in Android.