### PR TITLE
Make mouse relative again.

### DIFF
--- a/input/drivers/dinput.c
+++ b/input/drivers/dinput.c
@@ -84,10 +84,10 @@ struct dinput_input
 
    int window_pos_x;
    int window_pos_y;
+   int mouse_rel_x;
+   int mouse_rel_y;
    int mouse_x;
-   int mouse_last_x;
    int mouse_y;
-   int mouse_last_y;
    bool mouse_l, mouse_r, mouse_m, mouse_wu, mouse_wd, mouse_hwu, mouse_hwd;
    struct pointer_status pointer_head;  /* dummy head for easier iteration */
 };
@@ -182,10 +182,7 @@ static void *dinput_init(const char *joypad_driver)
 
    if (di->mouse)
    {
-      DIDATAFORMAT c_dfDIMouse2_custom = c_dfDIMouse2;
-
-      c_dfDIMouse2_custom.dwFlags = DIDF_ABSAXIS;
-      IDirectInputDevice8_SetDataFormat(di->mouse, &c_dfDIMouse2_custom);
+      IDirectInputDevice8_SetDataFormat(di->mouse, &c_dfDIMouse2);
       IDirectInputDevice8_SetCooperativeLevel(di->mouse, (HWND)video_driver_window_get(),
             DISCL_NONEXCLUSIVE | DISCL_FOREGROUND);
       IDirectInputDevice8_Acquire(di->mouse);
@@ -242,11 +239,8 @@ static void dinput_poll(void *data)
             memset(&mouse_state, 0, sizeof(mouse_state));
       }
 
-      di->mouse_last_x = di->mouse_x;
-      di->mouse_last_y = di->mouse_y;
-
-      di->mouse_x = di->window_pos_x;
-      di->mouse_y = di->window_pos_y;
+      di->mouse_rel_x = mouse_state.lX;
+      di->mouse_rel_y = mouse_state.lY;
 
 
 	  if (!mouse_state.rgbButtons[0])
@@ -334,9 +328,9 @@ static int16_t dinput_lightgun_state(struct dinput_input *di, unsigned id)
    switch (id)
    {
       case RETRO_DEVICE_ID_LIGHTGUN_X:
-         return di->mouse_x - di->mouse_last_x;
+         return di->mouse_rel_x;
       case RETRO_DEVICE_ID_LIGHTGUN_Y:
-         return di->mouse_y - di->mouse_last_y;
+         return di->mouse_rel_y;
       case RETRO_DEVICE_ID_LIGHTGUN_TRIGGER:
          return di->mouse_l;
       case RETRO_DEVICE_ID_LIGHTGUN_CURSOR:
@@ -359,9 +353,9 @@ static int16_t dinput_mouse_state(struct dinput_input *di, unsigned id)
    switch (id)
    {
       case RETRO_DEVICE_ID_MOUSE_X:
-         return di->mouse_x - di->mouse_last_x;
+         return di->mouse_rel_x;
       case RETRO_DEVICE_ID_MOUSE_Y:
-         return di->mouse_y - di->mouse_last_y;
+         return di->mouse_rel_y;
       case RETRO_DEVICE_ID_MOUSE_LEFT:
          return di->mouse_l;
       case RETRO_DEVICE_ID_MOUSE_RIGHT:


### PR DESCRIPTION
Should fix https://github.com/libretro/RetroArch/issues/3408 https://github.com/libretro/RetroArch/issues/4788 for Windows.

Partial revert of https://github.com/libretro/RetroArch/commit/7755277b87eb6e8f56174fee96eaa9c8e26d7d14
System mouse cursor still works fine in menus windowed/fullscreen.
Back to relative in cores, no more screen edges limitation.

Tested on win7 x64, confirmed working for win10.