### PR TITLE
hardcode struct for compatibility between various mali EGL headers

### DIFF
--- a/gfx/drivers_context/mali_fbdev_ctx.c
+++ b/gfx/drivers_context/mali_fbdev_ctx.c
@@ -44,7 +44,10 @@ typedef struct
    egl_ctx_data_t egl;
 #endif
 
-   struct mali_native_window native_window;
+   struct {
+      unsigned short width;
+      unsigned short height;
+   } native_window;
    bool resize;
    unsigned width, height;
 } mali_ctx_data_t;


### PR DESCRIPTION
Old kronos headers used mali_native_window, ARM's headers used fbdev_window, and on latest mali-fbdev package on the odroid with newer khronos headers, the struct seems missing