### PR TITLE
android autoconf improvements

### DIFF
--- a/configuration.h
+++ b/configuration.h
@@ -283,6 +283,7 @@ typedef struct settings
       /* Set by autoconfiguration in joypad_autoconfig_dir.
        * Does not override main binds. */
       bool autoconfigured[MAX_USERS];
+      bool swap_override;
       int vid[MAX_USERS];
       int pid[MAX_USERS];
 

--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -949,13 +949,10 @@ static void handle_hotplug(android_input_t *android,
       }
    }
 
-   /* NVIDIA Shield Portable
-    * This is a simple hack, basically groups the "back"
-    * button with the rest of the gamepad
-    */
    else if(strstr(device_model, "SHIELD") && (
       strstr(device_name, "Virtual") || strstr(device_name, "gpio") ||
-      strstr(device_name, "NVIDIA Corporation NVIDIA Controller v01.01")))
+      strstr(device_name, "NVIDIA Corporation NVIDIA Controller v01.01") ||
+      strstr(device_name, "NVIDIA Corporation NVIDIA Controller v01.02")))
    {
       /* only use the hack if the device is one of the built-in devices */
       RARCH_LOG("Special Device Detected: %s\n", device_model);
@@ -967,8 +964,26 @@ static void handle_hotplug(android_input_t *android,
 
          if ( pad_id2 > 0)
             return;
-
          strlcpy (name_buf, "NVIDIA SHIELD Portable", sizeof(name_buf));
+      }
+   }
+   
+   else if(strstr(device_model, "SHIELD") && (
+      strstr(device_name, "Virtual") || strstr(device_name, "gpio") ||
+      strstr(device_name, "NVIDIA Corporation NVIDIA Controller v01.03")))
+   {
+      /* only use the hack if the device is one of the built-in devices */
+      RARCH_LOG("Special Device Detected: %s\n", device_model);
+      {
+         if (strstr(device_name, "NVIDIA Corporation NVIDIA Controller v01.03")
+             && android->pads_connected==0)
+            pad_id1 = id;
+         else if (strstr(device_name, "Virtual") || strstr(device_name, "gpio"))
+         {
+            id = pad_id1;
+            return;
+         }
+         strlcpy (name_buf, "NVIDIA SHIELD Gamepad", sizeof(name_buf));
       }
    }
 

--- a/menu/menu_event.c
+++ b/menu/menu_event.c
@@ -123,9 +123,11 @@ unsigned menu_event(uint64_t input, uint64_t trigger_input)
    menu_input_t *menu_input                = NULL;
    settings_t *settings                    = config_get_ptr();
    static unsigned ok_old                  = 0;
-   unsigned menu_ok_btn                    = settings->input.menu_swap_ok_cancel_buttons ?
+   unsigned menu_ok_btn                    = (!settings->input.swap_override && 
+      settings->input.menu_swap_ok_cancel_buttons) ?
       RETRO_DEVICE_ID_JOYPAD_B : RETRO_DEVICE_ID_JOYPAD_A;
-   unsigned menu_cancel_btn                = settings->input.menu_swap_ok_cancel_buttons ?
+   unsigned menu_cancel_btn                = (!settings->input.swap_override && 
+      settings->input.menu_swap_ok_cancel_buttons) ?
       RETRO_DEVICE_ID_JOYPAD_A : RETRO_DEVICE_ID_JOYPAD_B;
    unsigned ok_current                     = (unsigned)(input & UINT64_C(1) << menu_ok_btn);
    unsigned ok_trigger                     = ok_current & ~ok_old;

--- a/tasks/task_autodetect.c
+++ b/tasks/task_autodetect.c
@@ -173,8 +173,11 @@ static void input_autoconfigure_joypad_add(config_file_t *conf,
             string_is_empty(display_name) ? params->name : display_name,
             msg_hash_to_str(MSG_DEVICE_CONFIGURED_IN_PORT),
             params->idx);
+
+      /* allow overriding the swap menu controls for player 1*/
       if (params->idx == 0)
-         settings->input.swap_override = false;
+         config_get_bool(conf, "input_swap_override", &settings->input.swap_override);
+
       if (!block_osd_spam)
          task_set_title(task, strdup(msg));
    }

--- a/tasks/task_autodetect.c
+++ b/tasks/task_autodetect.c
@@ -133,6 +133,8 @@ static void input_autoconfigure_joypad_add(config_file_t *conf,
    char display_name[128];
    char device_type[128];
    bool block_osd_spam                = false;
+   static bool remote_is_bound        = false;
+
    settings_t      *settings          = config_get_ptr();
 
    msg[0] = display_name[0] = device_type[0] = '\0';
@@ -156,14 +158,14 @@ static void input_autoconfigure_joypad_add(config_file_t *conf,
 
    if (string_is_equal(device_type, "remote"))
    {
-      static bool remote_is_bound        = false;
-
       snprintf(msg, sizeof(msg), "%s configured.",
             string_is_empty(display_name) ? params->name : display_name);
 
       if(!remote_is_bound)
          task_set_title(task, strdup(msg));
       remote_is_bound = true;
+      if (params->idx == 0)
+         settings->input.swap_override = true;
    }
    else
    {
@@ -171,7 +173,8 @@ static void input_autoconfigure_joypad_add(config_file_t *conf,
             string_is_empty(display_name) ? params->name : display_name,
             msg_hash_to_str(MSG_DEVICE_CONFIGURED_IN_PORT),
             params->idx);
-
+      if (params->idx == 0)
+         settings->input.swap_override = false;
       if (!block_osd_spam)
          task_set_title(task, strdup(msg));
    }


### PR DESCRIPTION
Improves the SHIELD portable hack so the wireless gamepad doesn't clash with the native gamepads, add gamepad ver 1.02 to the mix and allow overriding the menu_ok_cancel_swap setting via autoconf

Use "input_swap_override" in autoconfs for this purpose.