### PR TITLE
Define the platform enums if they aren't in eglext.h.

### DIFF
--- a/gfx/drivers_context/drm_ctx.c
+++ b/gfx/drivers_context/drm_ctx.c
@@ -60,6 +60,10 @@
 
 #endif
 
+#ifndef EGL_PLATFORM_GBM_KHR
+#define EGL_PLATFORM_GBM_KHR 0x31D7
+#endif
+
 static enum gfx_ctx_api drm_api           = GFX_CTX_NONE;
 
 static struct gbm_bo *g_bo                = NULL;

--- a/gfx/drivers_context/wayland_ctx.c
+++ b/gfx/drivers_context/wayland_ctx.c
@@ -113,6 +113,10 @@ static enum gfx_ctx_api wl_api   = GFX_CTX_NONE;
 #define EGL_OPENGL_ES3_BIT_KHR 0x0040
 #endif
 
+#ifndef EGL_PLATFORM_WAYLAND_KHR
+#define EGL_PLATFORM_WAYLAND_KHR 0x31D8
+#endif
+
 #ifdef HAVE_XKBCOMMON
 /* FIXME: Move this into a header? */
 int init_xkb(int fd, size_t size);

--- a/gfx/drivers_context/xegl_ctx.c
+++ b/gfx/drivers_context/xegl_ctx.c
@@ -34,6 +34,10 @@
 #define EGL_OPENGL_ES3_BIT_KHR 0x0040
 #endif
 
+#ifndef EGL_PLATFORM_X11_KHR
+#define EGL_PLATFORM_X11_KHR 0x31D5
+#endif
+
 typedef struct
 {
 #ifdef HAVE_EGL


### PR DESCRIPTION
Add #defines for EGL_PLATFORM_X11_KHR, EGL_PLATFORM_WAYLAND_KHR, and
EGL_PLATFORM_GBM_KHR, if they aren't already defiend in eglext.h.

This should fix the build errors with older versions of eglext.h mentioned in #4826.