### PR TITLE
(menu_setting.c) Reinit audio driver when audio device is changed

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -1685,6 +1685,9 @@ void general_write_handler(void *data)
       case MENU_ENUM_LABEL_AUDIO_LATENCY:
          rarch_cmd = CMD_EVENT_AUDIO_REINIT;
          break;
+      case MENU_ENUM_LABEL_AUDIO_DEVICE:
+         rarch_cmd = CMD_EVENT_AUDIO_REINIT;
+         break;
       case MENU_ENUM_LABEL_PAL60_ENABLE:
          {
             global_t *global             = global_get_ptr();


### PR DESCRIPTION
This fixes an issue where changing the audio device in the menu doesn't immediately apply unless you did something else to make the driver reinit (i.e. change audio latency).