### PR TITLE
Fix audio sync issue with fullscreen toggling

### DIFF
--- a/audio/drivers/wasapi.c
+++ b/audio/drivers/wasapi.c
@@ -560,12 +560,13 @@ static void *wasapi_init(const char *dev_id, unsigned rate, unsigned latency,
          AUDCLNT_BUFFERFLAGS_SILENT);
    WASAPI_HR_CHECK(hr, "IAudioRenderClient::ReleaseBuffer", goto error);
 
-   /* TODO: remove next three lines after
+   /* TODO: remove next four lines after
       "Pause when menu activated" option and
       fullscreen toggling are fixed */
-   hr  = w->client->lpVtbl->Start(w->client);
+   hr = w->client->lpVtbl->Start(w->client);
    WASAPI_HR_CHECK(hr, "IAudioClient::Start", goto error);
    w->running = true;
+   w->blocking = settings->bools.audio_sync;
 
    return w;
 
@@ -723,7 +724,7 @@ static ssize_t wasapi_write(void *wh, const void *data, size_t size)
 
    if (w->blocking)
    {
-      for (writen = 0, ir = -1; writen < size && ir; writen += ir)
+      for (writen = 0, ir = -1; writen < size; writen += ir)
       {
          if (w->exclusive)
             ir = wasapi_write_ex(w, data + writen, size - writen);


### PR DESCRIPTION
I'm not sure whether this is fix or workaround since after toggling fullscreen audio driver function set_nonblock_state doesn't get called.