### PR TITLE
Minor fix for previous pull request

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -3204,7 +3204,7 @@ static bool setting_append_list(
                      general_write_handler,
                      general_read_handler);
                menu_settings_list_current_add_range(list, list_info, 0, 7680, 8, true, true);
-               settings_data_list_current_add_flags(list, list_info, SD_FLAG_LAKKA_ADVANCED);
+               settings_data_list_current_add_flags(list, list_info, SD_FLAG_ADVANCED);
 
                CONFIG_UINT(
                      list, list_info,
@@ -3218,7 +3218,7 @@ static bool setting_append_list(
                      general_write_handler,
                      general_read_handler);
                menu_settings_list_current_add_range(list, list_info, 0, 4320, 8, true, true);
-               settings_data_list_current_add_flags(list, list_info, SD_FLAG_LAKKA_ADVANCED);
+               settings_data_list_current_add_flags(list, list_info, SD_FLAG_ADVANCED);
             }
             CONFIG_FLOAT(
                   list, list_info,
@@ -3320,7 +3320,7 @@ static bool setting_append_list(
                   list_info,
                   CMD_EVENT_VIDEO_SET_ASPECT_RATIO);
             menu_settings_list_current_add_range(list, list_info, 0.1, 16.0, 0.01, true, false);
-            settings_data_list_current_add_flags(list, list_info, SD_FLAG_LAKKA_ADVANCED);
+            settings_data_list_current_add_flags(list, list_info, SD_FLAG_ADVANCED);
 
             CONFIG_INT(
                   list, list_info,


### PR DESCRIPTION
The settings weren't hiding when "Show Advanced Settings" when using SD_FLAG_LAKKA_ADVANCED, so use SD_FLAG_ADVANCED instead.