### PR TITLE
Don't use more than 32 MB of the content data to compute the hash

### DIFF
--- a/griffin/griffin.c
+++ b/griffin/griffin.c
@@ -134,7 +134,7 @@ ACHIEVEMENTS
 
 #include "../libretro-common/formats/json/jsonsax.c"
 #include "../network/net_http_special.c"
-#include "../tasks/task_cheevos.c"
+#include "../cheevos/cheevos.c"
 #endif
 
 /*============================================================

--- a/network/httpserver/httpserver.c
+++ b/network/httpserver/httpserver.c
@@ -29,7 +29,7 @@
 #include "../../core.h"
 #include "../../gfx/video_driver.h"
 #include "../../managers/core_option_manager.h"
-#include "../../tasks/task_cheevos.h"
+#include "../../cheevos/cheevos.h"
 #include "../../content.h"
 
 #define BASIC_INFO "info"


### PR DESCRIPTION
It fixes slow start times when the content is big (i.e. ISO files.) The task version will also have a size limit to use with the MD5 hash.