### PR TITLE
[don't merge yet] GLES requires the 'es' after the version -_-

### DIFF
--- a/gfx/drivers_shader/shader_glsl.c
+++ b/gfx/drivers_shader/shader_glsl.c
@@ -266,9 +266,9 @@ static bool gl_glsl_compile_shader(glsl_shader_data_t *glsl,
       unsigned version_no = strtoul(existing_version + 8, (char**)&program, 10);
 #ifdef HAVE_OPENGLES
       if (version_no < 130)
-         version_no = 100;
+         version_no = "100 es";
       else
-         version_no = 300;
+         version_no = "300 es";
 #endif
       snprintf(version, sizeof(version), "#version %u\n", version_no);
       RARCH_LOG("[GLSL]: Using GLSL version %u.\n", version_no);


### PR DESCRIPTION
@fr500 can you test this on a shield device? Just update your GLSL shaders and try one of the super-xbr presets.