### PR TITLE
Silence a -Wnonnull warning

### DIFF
--- a/frontend/drivers/platform_linux.c
+++ b/frontend/drivers/platform_linux.c
@@ -900,6 +900,9 @@ static bool next_string(char **_ptr, char **_str)
 
 static bool int_string(char *str, int *val)
 {
+   if (!str)
+      return false;
+
    char *endptr = NULL;
    *val = (int) strtol(str, &endptr, 0);
    return ((*str != '\0') && (*endptr == '\0'));


### PR DESCRIPTION
Silences the following warning with gcc-7.1.0.
```
frontend/drivers/platform_linux.c: In function ‘int_string.constprop’:
frontend/drivers/platform_linux.c:904:17: warning: argument 1 null where non-null expected [-Wnonnull]
    *val = (int) strtol(str, &endptr, 0);
                 ^~~~~~~~~~~~~~~~~~~~~~~
In file included from frontend/drivers/platform_linux.c:21:0:
/usr/include/stdlib.h:145:17: note: in a call to function ‘strtol’ declared here
 extern long int strtol (const char *__restrict __nptr,
                 ^~~~~~
```