### PR TITLE
try to resolve IPv6 mapped IPv4 addresses

### DIFF
--- a/libretro-common/net/net_compat.c
+++ b/libretro-common/net/net_compat.c
@@ -365,7 +365,7 @@ const char *inet_ntop_compat(int af, const void *src, char *dst, socklen_t cnt)
 {
 #if defined(VITA) || defined(__ORBIS__)
    return sceNetInetNtop(af,src,dst,cnt);
-#else
+#elif defined (_WIN32)
    if (af == AF_INET)
    {
       struct sockaddr_in in;
@@ -388,9 +388,10 @@ const char *inet_ntop_compat(int af, const void *src, char *dst, socklen_t cnt)
       return dst;
    }
 #endif
-
-   return NULL;
+#else
+   return inet_ntop(af, src, dst, cnt);
 #endif
+   return NULL;
 }
 
 bool udp_send_packet(const char *host,

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -3156,7 +3156,7 @@ static int action_ok_netplay_connect_room(const char *path,
    {
       snprintf(tmp_hostname,
             sizeof(tmp_hostname),
-            "%s:%d",
+            "%s|%d",
          netplay_room_list[idx - 2].mitm_address,
          netplay_room_list[idx - 2].mitm_port);
    }
@@ -3164,7 +3164,7 @@ static int action_ok_netplay_connect_room(const char *path,
    {
       snprintf(tmp_hostname,
             sizeof(tmp_hostname),
-            "%s:%d",
+            "%s|%d",
          netplay_room_list[idx - 2].address,
          netplay_room_list[idx - 2].port);
    }
@@ -3442,6 +3442,26 @@ void netplay_refresh_rooms_menu(file_list_t *list)
 #ifndef INET6_ADDRSTRLEN
 #define INET6_ADDRSTRLEN 46
 #endif
+/*
++int IN6_IS_ADDR_V4MAPPED(const struct in6_addr *a)
++{
++	return ((a->s6_words[0] == 0) &&
++		(a->s6_words[1] == 0) &&
++		(a->s6_words[2] == 0) &&
++		(a->s6_words[3] == 0) &&
++		(a->s6_words[4] == 0) &&
++		(a->s6_words[5] == 0xffff));
++}
+*/
+#ifndef IN6_IS_ADDR_V4MAPPED
+#define IN6_IS_ADDR_V4MAPPED(a) \
+       ((((a)->s6_words[0]) == 0) && \
+        (((a)->s6_words[1]) == 0) && \
+        (((a)->s6_words[2]) == 0) && \
+        (((a)->s6_words[3]) == 0) && \
+        (((a)->s6_words[4]) == 0) && \
+        (((a)->s6_words[5]) == 0xFFFF))
+#endif
 
 static void netplay_refresh_rooms_cb(void *task_data, void *user_data, const char *err)
 {
@@ -3526,7 +3546,8 @@ finish:
                {
                    struct sockaddr_in *sin = (struct sockaddr_in *) address;
                    inet_ntop_compat(AF_INET, &sin->sin_addr, 
-                      netplay_room_list[i].address, INET6_ADDRSTRLEN);
+                      netplay_room_list[i].address, INET_ADDRSTRLEN);
+                  RARCH_LOG("IPv4 address: %s\n", netplay_room_list[i].address);
                }
 #if defined(AF_INET6) && !defined(HAVE_SOCKET_LEGACY)
                else if (address->sa_family == AF_INET6)
@@ -3534,6 +3555,18 @@ finish:
                   struct sockaddr_in6 *sin = (struct sockaddr_in6 *) address;
                   inet_ntop_compat(AF_INET6, &sin->sin6_addr, 
                      netplay_room_list[i].address, INET6_ADDRSTRLEN);
+
+                  RARCH_LOG("IPv6 address: %s\n", netplay_room_list[i].address);
+                  if (IN6_IS_ADDR_V4MAPPED(&sin->sin6_addr))
+                  {
+                     RARCH_LOG("IPv6 address is mapped\n");
+                     const uint8_t *bytes = ((const struct sockaddr_in6 *)address)->sin6_addr.s6_addr;
+                     bytes += 12;
+                     struct in_addr addr4 = { *(const uint32_t *)bytes };
+                     inet_ntop_compat(AF_INET, &addr4, 
+                        netplay_room_list[i].address, INET6_ADDRSTRLEN);
+                     RARCH_LOG("IPv4 address: %s\n", netplay_room_list[i].address);
+                  }
                }
 #endif
 


### PR DESCRIPTION
@GregorR 

I  have tested my code (a lot) and it should work if it was in fact an IPv6 mapped IPv4 address I'm receiving.
My problem persists (on Android)

My netplay host is 192.168.1.241. When I do a inet_ntop from the received address on Windows the result is 192.168.1.241 as expected.

When I do the same on android though it reads **::1c00:0:5261:6469** which is not an IPv6 mapped address...

I thought my inet_ntop implementation might be wrong but on android I'm just using the builtin function so my assumption now is that the data I'm getting in L3538 is wrong...

I wrote this sample program to test my code an my portion is fine at least. So assuming the data is correct it should resolve the correct address.

```
#include <stdio.h>
#include <stdlib.h>
#include <arpa/inet.h>

#ifndef IN6_IS_ADDR_V4MAPPED
#define IN6_IS_ADDR_V4MAPPED(a) \
       ((((a)->s6_words[0]) == 0) && \
        (((a)->s6_words[1]) == 0) && \
        (((a)->s6_words[2]) == 0) && \
        (((a)->s6_words[3]) == 0) && \
        (((a)->s6_words[4]) == 0) && \
        (((a)->s6_words[5]) == 0xFFFF))
#endif

int main()
{
    struct sockaddr_in6 sa;
    char str[INET6_ADDRSTRLEN];
    
    // store this IP address in sa:
    inet_pton(AF_INET6, "::FFFF:192.168.1.241", &(sa.sin6_addr));
    
    // now get it back and print it
    inet_ntop(AF_INET6, &(sa.sin6_addr), str, INET6_ADDRSTRLEN);
    
    printf("IPv6 %s\n", str);

    if (IN6_IS_ADDR_V4MAPPED(&sa.sin6_addr))
    {
        printf("IPv6 %s is IPv6 mapped IPv6\n", str);
        const uint8_t *bytes = ((const struct sockaddr_in6 *) &sa)->sin6_addr.s6_addr;
        bytes += 12;
        struct in_addr addr4 = { *(const uint32_t *)bytes };
        inet_ntop(AF_INET, &addr4, str, INET_ADDRSTRLEN + 1);
        printf("IPv4 %s\n", str);
    }

}
```