### PR TITLE
Fix crash in GLSL shader driver

### DIFF
--- a/gfx/drivers_shader/shader_glsl.c
+++ b/gfx/drivers_shader/shader_glsl.c
@@ -1433,10 +1433,10 @@ static bool gl_glsl_set_coords(void *handle_data, void *shader_data,
       /* Avoid hitting malloc on every single regular quad draw. */
 
       size_t elems  = 0;
-      elems        += (uni->color)         * 4;
-      elems        += (uni->tex_coord)     * 2;
-      elems        += (uni->vertex_coord)  * 2;
-      elems        += (uni->lut_tex_coord) * 2;
+      elems        += (uni->color >= 0)         * 4;
+      elems        += (uni->tex_coord >= 0)     * 2;
+      elems        += (uni->vertex_coord >= 0)  * 2;
+      elems        += (uni->lut_tex_coord >= 0) * 2;
 
       elems        *= coords->vertices * sizeof(GLfloat);
 


### PR DESCRIPTION
This reverts changes from commit 24ce77155a15f00eee9277b2b931647ea667eaf2 Author: twinaphex <libretro@gmail.com> Date:   Fri May 19 03:52:04 2017 +0200.

Some of these variables are set to -1 so check is necessary, if not here then probably in caller(s) of gl_glsl_set_coords.