### PR TITLE
allow easier scheduling of tasks in single threaded mode.

### DIFF
--- a/gfx/drivers/wiiu_gfx.c
+++ b/gfx/drivers/wiiu_gfx.c
@@ -502,12 +502,6 @@ static bool wiiu_gfx_frame(void* data, const void* frame,
 
    wiiu_video_t* wiiu = (wiiu_video_t*) data;
 
-   if (!width || !height)
-   {
-      GX2WaitForVsync();
-      return true;
-   }
-
    if(wiiu->vsync)
    {
       uint32_t swap_count;
@@ -526,6 +520,10 @@ static bool wiiu_gfx_frame(void* data, const void* frame,
          wiiu->last_vsync = last_vsync;
    }
    GX2WaitForFlip();
+
+
+   if (!width || !height)
+      return true;
 
    static u32 lastTick , currentTick;
    currentTick = OSGetSystemTick();

--- a/libretro-common/include/queues/task_queue.h
+++ b/libretro-common/include/queues/task_queue.h
@@ -57,6 +57,8 @@ typedef void (*retro_task_queue_msg_t)(const char *msg,
 
 typedef bool (*retro_task_retriever_t)(retro_task_t *task, void *data);
 
+typedef bool (*retro_task_condition_fn_t)(void *data);
+
 typedef struct
 {
    char *source_file;
@@ -200,9 +202,12 @@ void task_queue_check(void);
  * The task will start as soon as possible. */		
 void task_queue_push(retro_task_t *task);
 
-/* Blocks until all tasks have finished.		
+/* Blocks until all tasks have finished
+ * will return early if cond is not NULL
+ * and cond(data) returns false.
  * This must only be called from the main thread. */
-void task_queue_wait(void);
+void task_queue_wait(retro_task_condition_fn_t cond, void* data);
+
 
 /* Sends a signal to terminate all the tasks.		
  *		


### PR DESCRIPTION
this allows controlling task execution with a callback function.
the callback can be set to return false when a timer expires for example, or like in this case, after the next vsync event.