### PR TITLE
Change shared-mode settings

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -416,9 +416,9 @@ static const float audio_volume = 0.0;
 
 #ifdef HAVE_WASAPI
 /* WASAPI defaults */
-static const bool wasapi_exclusive_mode = true;
-static const bool wasapi_float_format = false;
-static const unsigned wasapi_sh_buffer_length = 0;
+static const bool wasapi_exclusive_mode  = true;
+static const bool wasapi_float_format    = false;
+static const int wasapi_sh_buffer_length = -16; /* auto */
 #endif
 
 /* MISC */

--- a/configuration.c
+++ b/configuration.c
@@ -1356,9 +1356,6 @@ static struct config_uint_setting *populate_settings_uint(settings_t *settings, 
 #endif
    SETTING_UINT("bundle_assets_extract_version_current", &settings->uints.bundle_assets_extract_version_current, true, 0, false);
    SETTING_UINT("bundle_assets_extract_last_version",    &settings->uints.bundle_assets_extract_last_version, true, 0, false);
-#ifdef HAVE_WASAPI
-   SETTING_UINT("audio_wasapi_sh_buffer_length", &settings->uints.audio_wasapi_sh_buffer_length, true, wasapi_sh_buffer_length, false);
-#endif
 
    *size = count;
 
@@ -1373,6 +1370,9 @@ static struct config_int_setting *populate_settings_int(settings_t *settings, in
    SETTING_INT("state_slot",                   &settings->ints.state_slot, false, 0 /* TODO */, false);
 #ifdef HAVE_NETWORKING
    SETTING_INT("netplay_check_frames",         &settings->ints.netplay_check_frames, true, netplay_check_frames, false);
+#endif
+#ifdef HAVE_WASAPI
+   SETTING_INT("audio_wasapi_sh_buffer_length", &settings->ints.audio_wasapi_sh_buffer_length, true, wasapi_sh_buffer_length, false);
 #endif
 
    *size = count;

--- a/configuration.h
+++ b/configuration.h
@@ -245,6 +245,10 @@ typedef struct settings
       int location_update_interval_ms;
       int location_update_interval_distance;
       int state_slot;
+
+#ifdef HAVE_WASAPI
+      int audio_wasapi_sh_buffer_length;
+#endif
    } ints;
 
    struct
@@ -311,10 +315,6 @@ typedef struct settings
 
       unsigned camera_width;
       unsigned camera_height;
-
-#ifdef HAVE_WASAPI
-      unsigned audio_wasapi_sh_buffer_length; /* in frames (0 disables buffering) */
-#endif
    } uints;
 
    struct

--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -2267,7 +2267,7 @@ MSG_HASH(
       )
 MSG_HASH(
       MENU_ENUM_SUBLABEL_AUDIO_WASAPI_SH_BUFFER_LENGTH,
-      "The audio buffer length when using the WASAPI driver in shared mode."
+      "The intermediate buffer length (in frames) when using the WASAPI driver in shared mode."
       )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_AUDIO_SYNC,

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -5525,7 +5525,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, void *data)
                PARSE_ONLY_BOOL, false);
          menu_displaylist_parse_settings_enum(menu, info,
                MENU_ENUM_LABEL_AUDIO_WASAPI_SH_BUFFER_LENGTH,
-               PARSE_ONLY_UINT, false);
+               PARSE_ONLY_INT, false);
 #endif
 
          info->need_refresh = true;

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -174,6 +174,24 @@ static void setting_get_string_representation_uint_custom_viewport_height(void *
             *setting->value.target.unsigned_integer);
 }
 
+#ifdef HAVE_WASAPI
+static void setting_get_string_representation_int_audio_wasapi_sh_buffer_length(void *data,
+      char *s, size_t len)
+{
+   rarch_setting_t *setting = (rarch_setting_t*)data;
+   if (!setting)
+      return;
+
+   if (*setting->value.target.integer > 0)
+      snprintf(s, len, "%d",
+            *setting->value.target.integer);
+   else if (*setting->value.target.integer == 0)
+      strlcpy(s, "0 (Off)", len);
+   else
+      strlcpy(s, "Auto", len);
+}
+#endif
+
 static int setting_uint_action_left_custom_viewport_width(void *data, bool wraparound)
 {
    video_viewport_t vp;
@@ -4011,12 +4029,12 @@ static bool setting_append_list(
                   parent_group,
                   general_write_handler,
                   general_read_handler,
-                  SD_FLAG_ADVANCED
+                  SD_FLAG_NONE
                   );
 
-            CONFIG_UINT(
+            CONFIG_INT(
                   list, list_info,
-                  &settings->uints.audio_wasapi_sh_buffer_length,
+                  &settings->ints.audio_wasapi_sh_buffer_length,
                   MENU_ENUM_LABEL_AUDIO_WASAPI_SH_BUFFER_LENGTH,
                   MENU_ENUM_LABEL_VALUE_AUDIO_WASAPI_SH_BUFFER_LENGTH,
                   wasapi_sh_buffer_length,
@@ -4025,8 +4043,10 @@ static bool setting_append_list(
                   parent_group,
                   general_write_handler,
                   general_read_handler);
-            menu_settings_list_current_add_range(list, list_info, 0, 1024, 16.0, true, true);
+            menu_settings_list_current_add_range(list, list_info, -16.0f, 0.0f, 16.0f, true, false);
             settings_data_list_current_add_flags(list, list_info, SD_FLAG_ADVANCED);
+            (*list)[list_info->index - 1].get_string_representation =
+                  &setting_get_string_representation_int_audio_wasapi_sh_buffer_length;
             }
 #endif
 


### PR DESCRIPTION
This changes default intermediate buffer length (in shared-mode) and adds option to auto-select the length (default). Also menu description for this option is clarified and float/pcm option is moved from advanced to regular settings.