### PR TITLE
Fix scaling bug in video_driver_translate_coord_viewport()

### DIFF
--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -2568,27 +2568,35 @@ bool video_driver_translate_coord_viewport(
 {
    int scaled_screen_x, scaled_screen_y, scaled_x, scaled_y;
    struct video_viewport *vp = (struct video_viewport*)data;
+   int norm_vp_width         = (int)vp->width;
+   int norm_vp_height        = (int)vp->height;
    int norm_full_vp_width    = (int)vp->full_width;
    int norm_full_vp_height   = (int)vp->full_height;
 
    if (norm_full_vp_width <= 0 || norm_full_vp_height <= 0)
       return false;
 
-   scaled_screen_x     = (2 * mouse_x * 0x7fff) / norm_full_vp_width  - 0x7fff;
-   scaled_screen_y     = (2 * mouse_y * 0x7fff) / norm_full_vp_height - 0x7fff;
-   if (scaled_screen_x < -0x7fff || scaled_screen_x > 0x7fff)
-      scaled_screen_x  = -0x8000; /* OOB */
-   if (scaled_screen_y < -0x7fff || scaled_screen_y > 0x7fff)
-      scaled_screen_y  = -0x8000; /* OOB */
+   if (mouse_x >= 0 && mouse_x <= norm_full_vp_width)
+      scaled_screen_x = ((2 * mouse_x * 0x7fff) / norm_full_vp_width)  - 0x7fff;
+   else
+      scaled_screen_x = -0x8000; /* OOB */
+
+   if (mouse_y >= 0 && mouse_y <= norm_full_vp_height)
+      scaled_screen_y = ((2 * mouse_y * 0x7fff) / norm_full_vp_height) - 0x7fff;
+   else
+      scaled_screen_y = -0x8000; /* OOB */
 
    mouse_x           -= vp->x;
    mouse_y           -= vp->y;
 
-   scaled_x           = (2 * mouse_x * 0x7fff) / norm_full_vp_width  - 0x7fff;
-   scaled_y           = (2 * mouse_y * 0x7fff) / norm_full_vp_height - 0x7fff;
-   if (scaled_x < -0x7fff || scaled_x > 0x7fff)
+   if (mouse_x >= 0 && mouse_x <= norm_vp_width)
+      scaled_x        = ((2 * mouse_x * 0x7fff) / norm_vp_width) - 0x7fff;
+   else
       scaled_x        = -0x8000; /* OOB */
-   if (scaled_y < -0x7fff || scaled_y > 0x7fff)
+
+   if (mouse_y >= 0 && mouse_y <= norm_vp_height)
+      scaled_y        = ((2 * mouse_y * 0x7fff) / norm_vp_height) - 0x7fff;
+   else
       scaled_y        = -0x8000; /* OOB */
 
    *res_x             = scaled_x;


### PR DESCRIPTION
- now scaled_x and height are correctly calculated, using viewports's width and height, respectively, as the scaling factor
-- previously the scaling factor was the screen's width/height, which meant that if screen and viewport had different bounds, scaled_x/scaled_y were incorrectly calculated