### PR TITLE
prevent these tasks to run more than once on shutdown

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -2159,9 +2159,12 @@ void retroarch_fail(int error_code, const char *error)
 
 bool retroarch_main_quit(void)
 {
-   command_event(CMD_EVENT_AUTOSAVE_STATE, NULL);
-   command_event(CMD_EVENT_DISABLE_OVERRIDES, NULL);
-   command_event(CMD_EVENT_RESTORE_DEFAULT_SHADER_PRESET, NULL);
+   if (!runloop_shutdown_initiated)
+   {
+      command_event(CMD_EVENT_AUTOSAVE_STATE, NULL);
+      command_event(CMD_EVENT_DISABLE_OVERRIDES, NULL);
+      command_event(CMD_EVENT_RESTORE_DEFAULT_SHADER_PRESET, NULL);
+   }
 
    runloop_shutdown_initiated = true;
    rarch_menu_running_finished();


### PR DESCRIPTION
this fixes a rare issue causing autosave state to be called twice when:
- overrides are enabled AND
- savestate sorting is enabled