### PR TITLE
gfx: enable menu transparency only when game loaded

### DIFF
--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -2502,8 +2502,8 @@ void video_driver_build_info(video_frame_info_t *video_info)
    video_info->xmb_alpha_factor       = settings->uints.menu_xmb_alpha_factor;
    video_info->menu_wallpaper_opacity = settings->floats.menu_wallpaper_opacity;
 
-   video_info->libretro_running    = (rarch_ctl(RARCH_CTL_IS_INITED, NULL)
-         && !rarch_ctl(RARCH_CTL_IS_DUMMY_CORE, NULL));
+   video_info->libretro_running       = core_is_game_loaded();
+
 #else
    video_info->menu_is_alive          = false;
    video_info->menu_footer_opacity    = 0.0f;


### PR DESCRIPTION
Normally, video_info->libretro_running only checks if RetroArch is initialized and a non-dummy core
is loaded. However, loading a core will cause the menu to become transparent even when there is no
game loaded, and toggling the menu before loading a game will render a black or corrupt image
(plugin dependant).

Change the libretro_running function to explicity check for a loaded game to avoid all these problems.