### PR TITLE
xmb: enable menu transparency support when emulation is paused

### DIFF
--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -1063,7 +1063,8 @@ static bool video_driver_init_internal(bool *video_is_threaded)
    command_event(CMD_EVENT_OVERLAY_DEINIT, NULL);
    command_event(CMD_EVENT_OVERLAY_INIT, NULL);
 
-   video_driver_cached_frame_set(&dummy_pixels, 4, 4, 8);
+   if (!frame_cache_data)
+      video_driver_cached_frame_set(&dummy_pixels, 4, 4, 8);
 
 #if defined(PSP)
    video_driver_set_texture_frame(&dummy_pixels, false, 1, 1, 1.0f);
@@ -2502,9 +2503,7 @@ void video_driver_build_info(video_frame_info_t *video_info)
    video_info->xmb_alpha_factor       = settings->uints.menu_xmb_alpha_factor;
    video_info->menu_wallpaper_opacity = settings->floats.menu_wallpaper_opacity;
 
-   if (!settings->bools.menu_pause_libretro)
-      video_info->libretro_running    = (rarch_ctl(RARCH_CTL_IS_INITED, NULL)
-            && !rarch_ctl(RARCH_CTL_IS_DUMMY_CORE, NULL));
+   video_info->libretro_running       = core_is_game_loaded();
 #else
    video_info->menu_is_alive          = false;
    video_info->menu_footer_opacity    = 0.0f;

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -2582,7 +2582,7 @@ static void xmb_draw_bg(
          if (!running && draw.texture)
             draw.color = &coord_white[0];
 
-         if (video_info->xmb_color_theme == XMB_THEME_WALLPAPER)
+         if (running || video_info->xmb_color_theme == XMB_THEME_WALLPAPER)
             add_opacity = true;
 
          menu_display_draw_bg(&draw, video_info, add_opacity);

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -543,7 +543,7 @@ void menu_display_draw_bg(menu_display_ctx_draw_t *draw,
 
    draw->coords      = &coords;
 
-   if (!video_info->libretro_running && !draw->pipeline.active)
+   if (draw->texture)
       add_opacity_to_wallpaper = true;
 
    if (add_opacity_to_wallpaper)


### PR DESCRIPTION
Allow xmb menu driver transparency when "Pause when menu activated" is enabled (default setting).
This is also the default behaviour of the rgui driver and is helpful for users to preview
video/shader changes on the fly.

Issues fixed:

gfx/video_driver: enable menu transparency only when game is loaded (as a loaded core can display
                  black or corrupt image)
gfx/video_driver: don't clobber cached frame (fixes missing background on full screen toggle)
menu/drivers/xmb: ensure transparency is applied when game is loaded and no shader pipeline active.
menu/menu_driver: explicitly apply transparency only for existing textures (i.e. wallpapers), to
                  avoid background of cores with no content yet loaded mixing with wallpaper.