### PR TITLE
[SDL2] Fix joypad info for SDL_GameController devices

### DIFF
--- a/input/drivers_joypad/sdl_joypad.c
+++ b/input/drivers_joypad/sdl_joypad.c
@@ -159,9 +159,36 @@ static void sdl_pad_connect(unsigned id)
              product, sdl_joypad_name(id));
 
 #ifdef HAVE_SDL2
-
    if (pad->controller)
+   {
+      /* SDL_GameController internally supports all axis/button IDs, even if
+       * the controller's mapping does not have a binding for it.
+       *
+       * So, we can claim to support all axes/buttons, and when we try to poll
+       * an unbound ID, SDL simply returns the correct unpressed value.
+       *
+       * Note that, in addition to 0 trackballs, we also have 0 hats. This is
+       * because the d-pad is in the button list, as the last 4 enum entries.
+       *
+       * -flibit
+       */
+      pad->num_axes    = SDL_CONTROLLER_AXIS_MAX;
+      pad->num_buttons = SDL_CONTROLLER_BUTTON_MAX;
+      pad->num_hats    = 0;
+      pad->num_balls   = 0;
+
       RARCH_LOG("[SDL]: Device #%u supports game controller api.\n", id);
+   }
+   else
+   {
+      pad->num_axes    = SDL_JoystickNumAxes(pad->joypad);
+      pad->num_buttons = SDL_JoystickNumButtons(pad->joypad);
+      pad->num_hats    = SDL_JoystickNumHats(pad->joypad);
+      pad->num_balls   = SDL_JoystickNumBalls(pad->joypad);
+
+      RARCH_LOG("[SDL]: Device #%u has: %u axes, %u buttons, %u hats and %u trackballs.\n",
+                id, pad->num_axes, pad->num_buttons, pad->num_hats, pad->num_balls);
+   }
 
    pad->haptic = g_has_haptic ? SDL_HapticOpenFromJoystick(pad->joypad) : NULL;
 
@@ -185,18 +212,11 @@ static void sdl_pad_connect(unsigned id)
          RARCH_WARN("[SDL]: Device #%u does not support rumble.\n", id);
       }
    }
-#endif
-
+#else
    pad->num_axes    = SDL_JoystickNumAxes(pad->joypad);
    pad->num_buttons = SDL_JoystickNumButtons(pad->joypad);
    pad->num_hats    = SDL_JoystickNumHats(pad->joypad);
 
-#ifdef HAVE_SDL2
-   pad->num_balls   = SDL_JoystickNumBalls(pad->joypad);
-
-   RARCH_LOG("[SDL]: Device #%u has: %u axes, %u buttons, %u hats and %u trackballs.\n",
-             id, pad->num_axes, pad->num_buttons, pad->num_hats, pad->num_balls);
-#else
    RARCH_LOG("[SDL]: Device #%u has: %u axes, %u buttons, %u hats.\n",
              id, pad->num_axes, pad->num_buttons, pad->num_hats);
 #endif


### PR DESCRIPTION
This patch fixes #4785 by setting the joypad info to the axis/button sizes established by SDL_GameController, when the device is recognized as a controller.

It includes a note to briefly explain why we do this; though if you want to see for yourself, this is what it looks like in SDL2 internally, for example:

- [Internal mapping format, with hats as a mapping type](https://hg.libsdl.org/SDL/file/8a29b371e2db/include/SDL_gamecontroller.h#l61)
- [GetButton with the fallback for missing bindings](https://hg.libsdl.org/SDL/file/8a29b371e2db/src/joystick/SDL_gamecontroller.c#l1312)