### PR TITLE
Handle forwarding of netplay state demotions correctly.

### DIFF
--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -165,6 +165,10 @@ static bool get_self_input_state(netplay_t *netplay)
          netplay_send_cur_input(netplay, &netplay->connections[i]);
    }
 
+   /* Handle any delayed state changes */
+   if (netplay->is_server)
+      netplay_delayed_state_change(netplay);
+
    return true;
 }
 
@@ -847,7 +851,7 @@ void netplay_post_frame(netplay_t *netplay)
       if (connection->active &&
           !netplay_send_flush(&connection->send_packet_buffer, connection->fd,
             false))
-         netplay_hangup(netplay, &netplay->connections[0]);
+         netplay_hangup(netplay, connection);
    }
 }
 

--- a/network/netplay/netplay_private.h
+++ b/network/netplay/netplay_private.h
@@ -192,12 +192,18 @@ enum netplay_cmd_mode_reasons
    NETPLAY_CMD_MODE_REFUSED_REASON_UNPRIVILEGED,
 
    /* There are no free player slots */
-   NETPLAY_CMD_MODE_REFUSED_REASON_NO_SLOTS
+   NETPLAY_CMD_MODE_REFUSED_REASON_NO_SLOTS,
+
+   /* You're changing modes too fast */
+   NETPLAY_CMD_MODE_REFUSED_REASON_TOO_FAST
 };
 
 enum rarch_netplay_connection_mode
 {
    NETPLAY_CONNECTION_NONE = 0,
+
+   NETPLAY_CONNECTION_DELAYED_DISCONNECT, /* The connection is dead, but data
+                                             is still waiting to be forwarded */
 
    /* Initialization: */
    NETPLAY_CONNECTION_INIT, /* Waiting for header */
@@ -297,6 +303,11 @@ struct netplay_connection
 
    /* Mode of the connection */
    enum rarch_netplay_connection_mode mode;
+
+   /* If the mode is a DELAYED_DISCONNECT or SPECTATOR, the transmission of the
+    * mode change may have to wait for data to be forwarded. This is the frame
+    * to wait for, or 0 if no delay is active. */
+   uint32_t delay_frame;
 
    /* Player # of connected player */
    uint32_t player;
@@ -719,6 +730,14 @@ void netplay_free(netplay_t *netplay);
  * Disconnects an active Netplay connection due to an error
  */
 void netplay_hangup(netplay_t *netplay, struct netplay_connection *connection);
+
+/**
+ * netplay_delayed_state_change:
+ *
+ * Handle any pending state changes which are ready as of the beginning of the
+ * current frame.
+ */
+void netplay_delayed_state_change(netplay_t *netplay);
 
 /**
  * netplay_send_cur_input

--- a/network/netplay/netplay_sync.c
+++ b/network/netplay/netplay_sync.c
@@ -298,7 +298,8 @@ bool netplay_sync_pre_frame(netplay_t *netplay)
 
          /* Allocate a connection */
          for (connection_num = 0; connection_num < netplay->connections_size; connection_num++)
-            if (!netplay->connections[connection_num].active) break;
+            if (!netplay->connections[connection_num].active &&
+                netplay->connections[connection_num].mode != NETPLAY_CONNECTION_DELAYED_DISCONNECT) break;
          if (connection_num == netplay->connections_size)
          {
             if (connection_num == 0)


### PR DESCRIPTION
I pray that at long last this finally fixes #4955. Commit description below.

Netplay state demotions, i.e. changes from playing to spectating or
disconnected states, could cause chain disconnections of all other
clients. This was due to a bug in when MODE change messages were sent.
Clients rely on the server sending all messages in its own order, and as
a consequence, the server typically holds messages for retransmission
until they can be retransmitted at the correct time. MODE messages were
not held, so could be sent early. When they were sent early, this caused
other clients to panic and disconnect.

A smaller but much stupider secondary bug was also fixed, in which the
first connection could be dropped due simply to writing connections[0]
instead of connections[i] somewhere.