### PR TITLE
change --help text for --log-file option

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -434,7 +434,7 @@ static void retroarch_print_help(const char *arg0)
 
    puts("  -h, --help            Show this help message.");
    puts("  -v, --verbose         Verbose logging.");
-   puts("      --log-file=FILE   Log messages to FILE.");
+   puts("      --log-file FILE   Log messages to FILE.");
    puts("      --version         Show version.");
    puts("      --features        Prints available features compiled into "
          "program.");


### PR DESCRIPTION
--log-file seems to be one of the few CLI switches that doesn't accept both space and =. Instead, it will fail to launch if you use the '=', which is the suggested syntax in the --help text.