### PR TITLE
Fix image mirroring in vertical games on the 3ds port (bug #4817)

### DIFF
--- a/gfx/drivers/ctr_gfx.c
+++ b/gfx/drivers/ctr_gfx.c
@@ -100,9 +100,9 @@ static INLINE void ctr_set_screen_coords(ctr_video_t * ctr)
    }
    else if (ctr->rotation == 1) /* 90° */
    {
-      ctr->frame_coords->x1 = ctr->vp.x;
+      ctr->frame_coords->x0 = ctr->vp.x;
       ctr->frame_coords->y0 = ctr->vp.y;
-      ctr->frame_coords->x0 = ctr->vp.x + ctr->vp.width;
+      ctr->frame_coords->x1 = ctr->vp.x + ctr->vp.width;
       ctr->frame_coords->y1 = ctr->vp.y + ctr->vp.height;
    }
    else if (ctr->rotation == 2) /* 180° */
@@ -114,9 +114,9 @@ static INLINE void ctr_set_screen_coords(ctr_video_t * ctr)
    }
    else /* 270° */
    {
-      ctr->frame_coords->x0 = ctr->vp.x;
+      ctr->frame_coords->x1 = ctr->vp.x;
       ctr->frame_coords->y1 = ctr->vp.y;
-      ctr->frame_coords->x1 = ctr->vp.x + ctr->vp.width;
+      ctr->frame_coords->x0 = ctr->vp.x + ctr->vp.width;
       ctr->frame_coords->y0 = ctr->vp.y + ctr->vp.height;
    }
 }


### PR DESCRIPTION
The current implementation of screen rotation is broken, as per bug #4817. The image is not rotated, but rather it's mirrored. This pull request contains a small fix for this. The image is still not rotated, as it would reduce the screen real state considerably, but it is not mirrored anymore.