### PR TITLE
Add missing include directive

### DIFF
--- a/gfx/drivers/drm_gfx.c
+++ b/gfx/drivers/drm_gfx.c
@@ -38,6 +38,7 @@
 
 #include "../font_driver.h"
 #include "../../retroarch.h"
+#include "../../verbosity.h"
 
 #include "drm_pixformats.h"
 


### PR DESCRIPTION
One question unrelated to this commit:

What is the proper way of compiling RA with DRM video driver. Instructions at [https://github.com/libretro/RetroArch/wiki/KMS-mode](https://github.com/libretro/RetroArch/wiki/KMS-mode) helped only for DRM context.

I had to change config.params.sh file in order to compile-in DRM video driver (line with HAVE_PLAIN_DRM) and this probably isn't proper way to do it.