### PR TITLE
Tweaks to let DOSBox core work on Wii U

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,11 @@ menu/driverspzarch.c
 /media/shaders_glsl/
 /obj-w32/
 
+# Wii U
+*.depend
+*.rpx
+wiiu/wut/elf2rpl/elf2rpl
+
 # Ctags
 /tags
 

--- a/Makefile.wiiu
+++ b/Makefile.wiiu
@@ -11,6 +11,7 @@ PC_DEVELOPMENT_TCP_PORT	   ?=
 OBJ :=
 OBJ += wiiu/system/memory.o
 OBJ += wiiu/system/exception_handler.o
+OBJ += wiiu/system/missing_libc_functions.o
 OBJ += wiiu/fs/sd_fat_devoptab.o
 OBJ += wiiu/fs/fs_utils.o
 OBJ += wiiu/controller_patcher/ControllerPatcher.o

--- a/wiiu/system/exception_handler.c
+++ b/wiiu/system/exception_handler.c
@@ -81,7 +81,7 @@ static const char exception_print_formats[18][45] =
    "%p:  %08X %08X %08X %08X\n",                         // 17
 };
 void net_print_exp(const char* str);
-void log_deinit(void);
+void wiiu_log_deinit(void);
 
 static unsigned char exception_cb(void* c, unsigned char exception_type)
 {
@@ -182,7 +182,7 @@ static unsigned char exception_cb(void* c, unsigned char exception_type)
    //}
    net_print_exp(gdb_buf);
 //   net_print_exp(buf);
-   log_deinit();
+   wiiu_log_deinit();
    OSFatal(buf);
    return 1;
 }

--- a/wiiu/system/missing_libc_functions.c
+++ b/wiiu/system/missing_libc_functions.c
@@ -1,0 +1,61 @@
+/* devkitPPC is missing a few functions that are kinda needed for some cores.
+ * This should add them back in.
+ */
+
+#include <unistd.h>
+#include <stdio.h>
+#include <wiiu/os.h>
+#include <pwd.h>
+#include <features/features_cpu.h>
+
+//This is usually in libogc; we can't use that on wiiu
+int usleep(useconds_t microseconds) {
+	OSSleepTicks(us_to_ticks(microseconds));
+	return 0;
+}
+
+//Can't find this one anywhere for some reason :/
+//This could probably be done a lot better with some love
+int access(const char* path, int mode) {
+	return 0; //TODO temp hack, real code below
+
+	FILE* fd = fopen(path, "rb");
+	if (fd < 0) {
+		fclose(fd);
+		//We're supposed to set errono here
+		return -1;
+	} else {
+		fclose(fd);
+		return 0;
+	}
+}
+
+//Just hardcode the Linux User ID, we're not on linux anyway
+//Feasible cool addition: nn::act for this?
+uid_t getuid() {
+	return 1000;
+}
+
+//Fake user info
+//Not thread safe, but avoids returning local variable, so...
+struct passwd out;
+struct passwd* getpwuid(uid_t uid) {
+	out.pw_name = "retroarch";
+	out.pw_passwd = "Wait, what?";
+	out.pw_uid = uid;
+	out.pw_gid = 1000;
+	out.pw_gecos = "retroarch";
+	out.pw_dir = "sd:/";
+	out.pw_shell = "/vol/system_slc/fw.img";
+
+	return &out;
+}
+
+//Try to vaugely spoof the POISX clock. Epoch is off by about 30
+//years, so this could be better...
+//Only has second accuracy since I'm lazy.
+int clock_gettime(clockid_t clk_id, struct timespec* tp) {
+	int64_t time_usec = cpu_features_get_time_usec();
+	tp->tv_sec = time_usec / 1000000;
+	return 0;
+}


### PR DESCRIPTION
Heyo!

Just a few tweaks to make the DOSBox core work right on Wii U ([Here's a PR for the core](https://github.com/libretro/dosbox-libretro/pull/67)). There's a few functions missing from devkitPro's libc that DOSBox uses. These are provided by libogc on the Wii, but that's unavailable on Wii U so I've had to add them in. I also had to rename the logging functions to avoid conflicts while linking. Let me know if I need to change anything.

Thanks!
-Ash