### PR TITLE
Added code for single port psx to ps3 adapter

### DIFF
--- a/dist-scripts/dist-cores.sh
+++ b/dist-scripts/dist-cores.sh
@@ -171,8 +171,9 @@ fi
 COUNTER=0
 
 #for f in *_${platform}.${EXT} ; do
-for f in `ls -v *_${platform}.${EXT}`; do
+for f in `ls -v ../*_${platform}.${EXT}`; do
    name=`echo "$f" | sed "s/\(_libretro_${platform}\|\).${EXT}$//"`
+   name=${name#../*}
    async=0
    pthread=0
    lto=0
@@ -335,7 +336,7 @@ for f in `ls -v *_${platform}.${EXT}`; do
    elif [ $PLATFORM = "ngc" ] ; then
       rm -f ../retroarch_${platform}.dol ../retroarch_${platform}.elf ../retroarch_${platform}.elf.map
    elif [ $PLATFORM = "wii" ] ; then
-      rm -f ../retroarch_${platform}.dol ../retroarch_${platform}.elf ../retroarch_${platform}.elf.map
+      rm -f ../retroarch_${platform}.dol ../retroarch_${platform}.elf ../retroarch_${platform}.elf.map ../libretro_${platform}.a
    elif [ $platform = "emscripten" ] ; then
       rm -f ../${name}_libretro.js
    fi

--- a/griffin/griffin.c
+++ b/griffin/griffin.c
@@ -531,6 +531,7 @@ INPUT (HID)
 #include "../input/connect/connect_nesusb.c"
 #include "../input/connect/connect_wiiugca.c"
 #include "../input/connect/connect_ps2adapter.c"
+#include "../input/connect/connect_psxadapter.c"
 #endif
 
 /*============================================================

--- a/input/connect/connect_ps2adapter.c
+++ b/input/connect/connect_ps2adapter.c
@@ -72,7 +72,7 @@ static int16_t hidpad_ps2adapter_get_axis(void *data, unsigned axis)
    int val                               = 0;
    struct hidpad_ps2adapter_data *device = (struct hidpad_ps2adapter_data*)data;
 
-   if (!device || axis >= 2)
+   if (!device || axis >= 4)
       return 0;
    
    switch (axis)

--- a/input/connect/connect_psxadapter.c
+++ b/input/connect/connect_psxadapter.c
@@ -1,0 +1,188 @@
+/*  RetroArch - A frontend for libretro.
+ *  Copyright (C) 2013-2014 - Jason Fetters
+ *  Copyright (C) 2011-2017 - Daniel De Matteis
+ *
+ *  RetroArch is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  RetroArch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with RetroArch.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include <boolean.h>
+#include "joypad_connection.h"
+#include "../input_defines.h"
+
+struct hidpad_psxadapter_data
+{
+   struct pad_connection* connection;
+   uint8_t data[8];
+   uint32_t slot;
+   uint64_t buttons;
+};
+
+static void* hidpad_psxadapter_init(void *data, uint32_t slot, send_control_t ptr)
+{
+   struct pad_connection* connection = (struct pad_connection*)data;
+   struct hidpad_psxadapter_data* device    = (struct hidpad_psxadapter_data*)
+      calloc(1, sizeof(struct hidpad_psxadapter_data));
+
+   if (!device)
+      return NULL;
+
+   if (!connection)
+   {
+      free(device);
+      return NULL;
+   }
+
+   device->connection   = connection;
+   device->slot         = slot;
+
+   return device;
+}
+
+static void hidpad_psxadapter_deinit(void *data)
+{
+   struct hidpad_psxadapter_data *device = (struct hidpad_psxadapter_data*)data;
+
+   if (device)
+      free(device);
+}
+
+static uint64_t hidpad_psxadapter_get_buttons(void *data)
+{
+   struct hidpad_psxadapter_data *device = (struct hidpad_psxadapter_data*)data;
+   if (!device)
+      return 0;
+   return device->buttons;
+}
+
+static int16_t hidpad_psxadapter_get_axis(void *data, unsigned axis)
+{
+   int val                               = 0;
+   struct hidpad_psxadapter_data *device = (struct hidpad_psxadapter_data*)data;
+
+   if (!device || axis >= 4   ||
+       (device->data[2]==0x7F) )//digital mode detection
+      return 0;
+   
+   switch (axis)
+   {
+      case 0:
+         val = device->data[4];
+         break;
+      case 1:
+         val = device->data[5];
+         break;
+      case 2:
+         val = device->data[3];
+         break;
+      case 3:
+         val = device->data[2];
+         break;
+   }
+   
+   val = (val << 8) - 0x8000;
+
+   return (abs(val) > 0x1000) ? val : 0;//hard coded deadzone
+}
+
+#define PSX_H_GET(a) (a & 0x0F) /*HAT MASK = 0x0F */
+#define PSX_H_LEFT(a) (a == 0x05) || (a == 0x06) || (a == 0x07)
+#define PSX_H_RIGHT(a) (a == 0x01) || (a == 0x02) || (a == 0x03)
+#define PSX_H_UP(a) (a == 0x07) || (a == 0x00) || (a == 0x01)
+#define PSX_H_DOWN(a) (a == 0x03) || (a == 0x04) || (a == 0x05)
+
+static void hidpad_psxadapter_packet_handler(void *data, uint8_t *packet, uint16_t size)
+{
+   uint32_t i, pressed_keys;
+   int16_t hat_value;
+   static const uint32_t button_mapping[17] =
+   {
+      RETRO_DEVICE_ID_JOYPAD_L2,
+      RETRO_DEVICE_ID_JOYPAD_R2,
+      RETRO_DEVICE_ID_JOYPAD_L,
+      RETRO_DEVICE_ID_JOYPAD_R,
+      RETRO_DEVICE_ID_JOYPAD_SELECT,
+      RETRO_DEVICE_ID_JOYPAD_START,
+      RETRO_DEVICE_ID_JOYPAD_L3,
+      RETRO_DEVICE_ID_JOYPAD_R3,
+      NO_BTN,
+      NO_BTN,
+      NO_BTN,
+      NO_BTN,
+      RETRO_DEVICE_ID_JOYPAD_X,
+      RETRO_DEVICE_ID_JOYPAD_A,
+      RETRO_DEVICE_ID_JOYPAD_B,
+      RETRO_DEVICE_ID_JOYPAD_Y,
+      16/* HOME BUTTON when pressing SELECT+START */
+   };
+   struct hidpad_psxadapter_data *device = (struct hidpad_psxadapter_data*)data;
+
+   if (!device)
+      return;
+
+   memcpy(device->data, packet, size);
+
+   device->buttons = 0;
+
+   pressed_keys  = device->data[7] | (device->data[6] << 8) |
+                (((device->data[7] & 0x30) == 0x30) ? (1 << 16) : 0); /* SELECT+START = MENU TOGGLE */
+
+   for (i = 0; i < 17; i ++)
+      if (button_mapping[i] != NO_BTN)
+         device->buttons |= (pressed_keys & (1 << i)) ? (UINT64_C(1) << button_mapping[i]) : 0;
+
+   if (device->data[2]==0x7F) //digital mode detection
+   {
+      /* We're in digital mode, process the dpad values */
+      device->buttons |= (device->data[4]==0x00) ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_LEFT) : 0;
+      device->buttons |= (device->data[4]==0xFF) ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_RIGHT) : 0;
+      device->buttons |= (device->data[5]==0x00) ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_UP) : 0;
+      device->buttons |= (device->data[5]==0xFF) ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_DOWN) : 0;
+   }
+   else
+   {
+      /* We're in analog mode, process the hat values as if they were pad buttons */
+      hat_value = PSX_H_GET(device->data[6]);
+      device->buttons |= PSX_H_LEFT(hat_value) ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_LEFT) : 0;
+      device->buttons |= PSX_H_RIGHT(hat_value) ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_RIGHT) : 0;
+      device->buttons |= PSX_H_UP(hat_value) ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_UP) : 0;
+      device->buttons |= PSX_H_DOWN(hat_value) ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_DOWN) : 0;
+   }
+}
+
+static void hidpad_psxadapter_set_rumble(void *data,
+      enum retro_rumble_effect effect, uint16_t strength)
+{
+	(void)data;
+	(void)effect;
+   (void)strength;
+}
+
+const char * hidpad_psxadapter_get_name(void *data)
+{
+	(void)data;
+	/* For now we return a single static name */
+	return "PSX to PS3 Controller Adapter";
+}
+
+pad_connection_interface_t pad_connection_psxadapter = {
+   hidpad_psxadapter_init,
+   hidpad_psxadapter_deinit,
+   hidpad_psxadapter_packet_handler,
+   hidpad_psxadapter_set_rumble,
+   hidpad_psxadapter_get_buttons,
+   hidpad_psxadapter_get_axis,
+   hidpad_psxadapter_get_name,
+};

--- a/input/connect/joypad_connection.c
+++ b/input/connect/joypad_connection.c
@@ -83,6 +83,7 @@ int32_t pad_connection_pad_init(joypad_connection_t *joyconn,
       { "Generic NES USB Controller",  121,   17,     &pad_connection_nesusb },
       { "Wii U GC Controller Adapter", 1406,  823,    &pad_connection_wiiugca },
       { "PS2/PSX Controller Adapter",  2064,  1,      &pad_connection_ps2adapter },
+      { "PSX to PS3 Controller Adapter", 2064, 3,     &pad_connection_psxadapter },
       { 0, 0}
    };
    joypad_connection_t *s = NULL;

--- a/input/connect/joypad_connection.h
+++ b/input/connect/joypad_connection.h
@@ -53,6 +53,7 @@ extern pad_connection_interface_t pad_connection_snesusb;
 extern pad_connection_interface_t pad_connection_nesusb;
 extern pad_connection_interface_t pad_connection_wiiugca;
 extern pad_connection_interface_t pad_connection_ps2adapter;
+extern pad_connection_interface_t pad_connection_psxadapter;
 
 int32_t pad_connection_pad_init(joypad_connection_t *joyconn,
    const char* name, uint16_t vid, uint16_t pid,


### PR DESCRIPTION
 This PR adds the psxadapter driver, which makes the wii build of retroarch compatible with a single port ps1/ps2 to usb controller adapter that is made to work on a ps3 (it also works in PCs) through hid. The driver is based on the existing ps2adapter driver, although compatibility with digital controllers has been added. Digital mode in analog controllers works here, too.

A bug is also fixed in the existing ps2adapter driver which would make it impossible to use the rigth stick with an analog controller.