### PR TITLE
Disable "Bilinear Filtering" by default

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -180,7 +180,7 @@ static const bool video_vfilter = true;
 #endif
 
 /* Smooths picture. */
-static const bool video_smooth = true;
+static const bool video_smooth = false;
 
 /* On resize and fullscreen, rendering area will stay 4:3 */
 static const bool force_aspect = true;

--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -199,7 +199,7 @@
 # video_shared_context = false
 
 # Smoothens picture with bilinear filtering. Should be disabled if using pixel shaders.
-# video_smooth = true
+# video_smooth = false
 
 # Forces rendering area to stay equal to content aspect ratio or as defined in video_aspect_ratio.
 # video_force_aspect = true


### PR DESCRIPTION
I find the *Bilinear Filtering* or `video_smooth` option makes the image extremely blurry and rather ugly. This setting is enabled by default. It seems like a setting that users should opt-in to rather than opt-out of. This PR makes Bilinear Filtering disabled by default; users can still enable it in the settings.

For a comparison, see Cave Story below. You'll find the image is much sharper and clearer with Bilinear Filtering disabled. Let's just have Bilinear Filtering disabled by default, and let users choose to enable it if desired.

### Bilinear Filtering Enabled (current default)

![doukutsu-170618-200147](https://user-images.githubusercontent.com/25086/27265318-4545d542-5461-11e7-89b5-0f0e012ea9db.png)

### Bilinear Filtering Disabled

![doukutsu-170618-200128](https://user-images.githubusercontent.com/25086/27265320-4a8864b6-5461-11e7-9d4e-06290f6db39f.png)

Again, this may be a matter of opinion, but I feel like I need to have my eyes checked whenever I have Bilinear Filtering enabled. Let users opt-in to it rather than opt-out.