### PR TITLE
Prevent OSS driver from being compiled & linked twice

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -366,9 +366,7 @@ endif
 
 ifeq ($(HAVE_OSS), 1)
    OBJ += audio/drivers/oss.o
-endif
-
-ifeq ($(HAVE_OSS_BSD), 1)
+else ifeq ($(HAVE_OSS_BSD), 1)
    OBJ += audio/drivers/oss.o
 endif
 


### PR DESCRIPTION
Fixes build on NetBSD.

btw, i've [patched retroarch in pkgsrc](https://github.com/NetBSD/pkgsrc-wip/tree/master/retroarch/patches) to force the use of the Linux frontend on NetBSD, because it seems to work better than the (seemingly incomplete) BSD frontend code, with working command line and so on.