### PR TITLE
udev input: support controlling the menu with a TV remote control

### DIFF
--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -392,7 +392,7 @@ static void udev_input_handle_hotplug(udev_input_t *udev)
 {
    device_handle_cb cb;
    enum udev_input_dev_type dev_type = UDEV_INPUT_KEYBOARD;
-   const char *val_keyboard          = NULL;
+   const char *val_key               = NULL;
    const char *val_mouse             = NULL;
    const char *val_touchpad          = NULL;
    const char *action                = NULL;
@@ -403,14 +403,15 @@ static void udev_input_handle_hotplug(udev_input_t *udev)
    if (!dev)
       return;
 
-   val_keyboard  = udev_device_get_property_value(dev, "ID_INPUT_KEYBOARD");
+   val_key       = udev_device_get_property_value(dev, "ID_INPUT_KEY");
    val_mouse     = udev_device_get_property_value(dev, "ID_INPUT_MOUSE");
    val_touchpad  = udev_device_get_property_value(dev, "ID_INPUT_TOUCHPAD");
    action        = udev_device_get_action(dev);
    devnode       = udev_device_get_devnode(dev);
 
-   if (val_keyboard && string_is_equal_fast(val_keyboard, "1", 1) && devnode)
+   if (val_key && string_is_equal_fast(val_key, "1", 1) && devnode)
    {
+      /* EV_KEY device, can be a keyboard or a remote control device.  */
       dev_type   = UDEV_INPUT_KEYBOARD;
       cb         = udev_handle_keyboard;
    }

--- a/input/input_keymaps.c
+++ b/input/input_keymaps.c
@@ -189,6 +189,8 @@ const struct input_key_map input_config_key_map[] = {
    { "subtract", RETROK_KP_MINUS },
    { "kp_plus", RETROK_KP_PLUS },
    { "kp_minus", RETROK_KP_MINUS },
+   { "volume-", RETROK_VOLUMEDOWN },
+   { "volume+", RETROK_VOLUMEUP },
    { "f1", RETROK_F1 },
    { "f2", RETROK_F2 },
    { "f3", RETROK_F3 },
@@ -1087,6 +1089,9 @@ const struct rarch_key_map rarch_key_map_linux[] = {
    { KEY_EURO, RETROK_EURO },
 #endif
    { KEY_UNDO, RETROK_UNDO },
+   { KEY_VOLUMEDOWN, RETROK_VOLUMEDOWN },
+   { KEY_VOLUMEUP, RETROK_VOLUMEUP },
+
    { 0, RETROK_UNKNOWN },
 };
 #endif

--- a/input/input_keymaps.c
+++ b/input/input_keymaps.c
@@ -1092,6 +1092,10 @@ const struct rarch_key_map rarch_key_map_linux[] = {
    { KEY_VOLUMEDOWN, RETROK_VOLUMEDOWN },
    { KEY_VOLUMEUP, RETROK_VOLUMEUP },
 
+   /* Extra keys for remote controls.  */
+   { KEY_OK, RETROK_RETURN },
+   { KEY_BACK, RETROK_BACKSPACE },
+
    { 0, RETROK_UNKNOWN },
 };
 #endif

--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -422,6 +422,9 @@ enum retro_key
    RETROK_EURO           = 321,
    RETROK_UNDO           = 322,
 
+   RETROK_VOLUMEDOWN     = 323,
+   RETROK_VOLUMEUP       = 324,
+
    RETROK_LAST,
 
    RETROK_DUMMY          = INT_MAX /* Ensure sizeof(enum) == sizeof(int) */


### PR DESCRIPTION
This pull requests adds support for controlling the retroarch menu with a TV remote control, for cases where there is no keyboard attached to the system:

* the remote control presents itself as ID_INPUT_KEY, not ID_INPUT_KEYBOARD.  However, ID_INPUT_KEYBOARD is a subset of ID_INPUT_KEY. For a 10-feet interface such as RetroArch, ID_INPUT_KEY is enough.

* the remote control lacks the backspace and enter keys, which are hard coded in RetroArch. It has "back" and "ok" instead, so map those to RETROK_BACKSPACE and RETROK_ENTER as well.

* In addition, such a remote control usually has volume-/volume+ buttons, so add them to the RETROK_* enum and map them too. I placed this patch first because it seems possibly less controversial.

Remote controls also have no ESC key, but that one is customizable and I used the Power key of the remote (which already has a mapping to RETROK_POWER).

The functionality provided is really the bare minimum, but it is enough for basic navigation if the gamepad doesn't work, and especially it lets me teach a kid "press the power button here to watch TV"; compared to "press L1+R1+START+SELECT and navigating to the RetroArch's "quit" menu item, that hopefully has more chances of success.