### PR TITLE
Add input_driver to config.def.h

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -20,6 +20,7 @@
 
 #include <boolean.h>
 #include "gfx/video_defines.h"
+#include "input/input_driver.h"
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"


### PR DESCRIPTION
This fixes the following compilation error:

```
CC core_info.c
In file included from core_info.c:31:0:
config.def.h:302:48: error: ‘INPUT_TOGGLE_NONE’ undeclared here (not in a function)
 static unsigned menu_toggle_gamepad_combo    = INPUT_TOGGLE_NONE
                                                ^
Makefile:155: recipe for target 'obj-unix/core_info.o' failed
```