### PR TITLE
Disable "Show Hidden Files" by default

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -220,7 +220,7 @@ static unsigned aspect_ratio_idx = ASPECT_RATIO_CORE;
 /* Save configuration file on exit. */
 static bool config_save_on_exit = true;
 
-static bool show_hidden_files = true;
+static bool show_hidden_files = false;
 
 static const bool overlay_hide_in_menu = true;
 

--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -126,7 +126,7 @@
 # config_save_on_exit = true
 
 # Shows hidden files and folders in directory listings.
-# show_hidden_files = true
+# show_hidden_files = false
 
 #### Video
 


### PR DESCRIPTION
Hide hidden files by default. This cleans up the folder browsing list a bit for new users.

Advanced users can choose to "Show Hidden Files" by enabling it in the menu.