### PR TITLE
Fall back to IPv4 when IPv6 connections fail

### DIFF
--- a/libretro-common/include/net/net_socket.h
+++ b/libretro-common/include/net/net_socket.h
@@ -60,6 +60,8 @@ typedef struct socket_target
 
 int socket_init(void **address, uint16_t port, const char *server, enum socket_type type);
 
+int socket_next(void **address);
+
 int socket_close(int fd);
 
 bool socket_nonblock(int fd);

--- a/libretro-common/net/net_socket.c
+++ b/libretro-common/net/net_socket.c
@@ -68,6 +68,15 @@ error:
    return -1;
 }
 
+int socket_next(void **addrinfo)
+{
+   struct addrinfo *addr = (struct addrinfo*)*addrinfo;
+   if ((*addrinfo = addr = addr->ai_next))
+      return socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol);
+   else
+      return -1;
+}
+
 ssize_t socket_receive_all_nonblocking(int fd, bool *error,
       void *data_, size_t size)
 {


### PR DESCRIPTION
Hi, in one of my environments the networking config is out of my control and IPv6 is screwed up.  This yields the error "[http] Could not create new HTTP session handle."  My IPv4 network works fine, though, so this patch proceeds to other addresses returned by getaddrinfo until one of them succeeds at socket_connect.