### PR TITLE
show useful OSD messages to cheevos users after launching a game

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -2914,7 +2914,6 @@ static int cheevos_iterate(coro_t* coro)
          RARCH_ERR("CHEEVOS error loading achievements.\n");
          CORO_STOP();
       }
-   
 #endif
 
 #ifdef CHEEVOS_SAVE_JSON
@@ -2944,6 +2943,35 @@ static int cheevos_iterate(coro_t* coro)
        * Outputs: 
        */
       CORO_GOSUB(PLAYING);
+
+      if(SETTINGS->bools.cheevos_verbose_enable)
+      {
+         const cheevo_t* cheevo       = cheevos_locals.core.cheevos;
+         const cheevo_t* end          = cheevo + cheevos_locals.core.count;
+         int number_of_unlocked       = 0;
+         int mode;
+         char msg[256];
+
+         snprintf(msg, sizeof(msg), "RetroAchievements: logged in as \"%s\".",
+            SETTINGS->arrays.cheevos_username);
+         msg[sizeof(msg) - 1] = 0;
+         runloop_msg_queue_push(msg, 0, 3 * 60, false);
+
+         if(SETTINGS->bools.cheevos_hardcore_mode_enable)
+            mode = CHEEVOS_ACTIVE_HARDCORE;
+         else
+            mode = CHEEVOS_ACTIVE_SOFTCORE;
+
+         for(; cheevo < end; cheevo++)
+            if(cheevo->active & mode)
+               number_of_unlocked++;
+
+         snprintf(msg, sizeof(msg), "You have %d of %d achievements unlocked.",
+            number_of_unlocked, cheevos_locals.core.count);
+         msg[sizeof(msg) - 1] = 0;
+         runloop_msg_queue_push(msg, 0, 6 * 60, false);
+      }
+
       CORO_STOP();
 
    /**************************************************************************

--- a/configuration.c
+++ b/configuration.c
@@ -1219,6 +1219,7 @@ static struct config_bool_setting *populate_settings_bool(settings_t *settings, 
    SETTING_BOOL("cheevos_enable",               &settings->bools.cheevos_enable, true, cheevos_enable, false);
    SETTING_BOOL("cheevos_test_unofficial",      &settings->bools.cheevos_test_unofficial, true, false, false);
    SETTING_BOOL("cheevos_hardcore_mode_enable", &settings->bools.cheevos_hardcore_mode_enable, true, false, false);
+   SETTING_BOOL("cheevos_verbose_enable",       &settings->bools.cheevos_verbose_enable, true, false, false);
 #endif
 #ifdef HAVE_OVERLAY
    SETTING_BOOL("input_overlay_enable",         &settings->bools.input_overlay_enable, true, config_overlay_enable_default(), false);

--- a/configuration.h
+++ b/configuration.h
@@ -158,6 +158,7 @@ typedef struct settings
       bool cheevos_enable;
       bool cheevos_test_unofficial;
       bool cheevos_hardcore_mode_enable;
+      bool cheevos_verbose_enable;
 #endif
 
       /* Camera */


### PR DESCRIPTION
[This is a new attempt to add what I tried in #4217 ]

Creates a new boolean option named `cheevos_verbose_enable`. If it's true, right after launching a game with cheevos enabled, show messages like the following:

`RetroAchievements: logged in as "RAUser"`

`You have 3 of 20 achievements unlocked`

Obs.: the number of achievements unlocked is counted according to hardcore mode being enabled or not.

If you guys agree with this approach, I can start working on adding the `cheevos_verbose_enable` option in the Achievements menu.