### PR TITLE
deleted "Fix 'All Users Control Menu' setting" msg

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,6 @@ lower-level.
 - LOCALIZATION: Update Russian translation
 - WAYLAND: Fix menu mouse input
 - WII: Add support for single-port 'PS1/PS2 to USB controller adapter'
-- INPUT: Fix 'All Users Control Menu' setting
 - INPUT: Add mouse index selection; ability now to select between different mice
 - SETTINGS: Fix regression 'Custom Viewport is no longer overridable per-core or per-game'
 


### PR DESCRIPTION
The `all_users_control_menu` option is not fixed. It just doesn't work anymore, as confirmed by @twinaphex here: https://github.com/libretro/RetroArch/issues/3337#issuecomment-314384361