### PR TITLE
Add a make install command to the video filters

### DIFF
--- a/gfx/video_filters/Makefile
+++ b/gfx/video_filters/Makefile
@@ -3,6 +3,8 @@ extra_flags :=
 use_neon    := 0
 release	    := release
 DYLIB	    := so
+PREFIX      := /usr
+INSTALLDIR  := $(PREFIX)/lib/retroarch/filters/video
 
 ifeq ($(platform),)
 platform = unix
@@ -89,3 +91,10 @@ clean:
 
 strip:
 	strip -s *.$(DYLIB)
+
+install:
+	mkdir -p $(DESTDIR)$(INSTALLDIR)
+	cp -t $(DESTDIR)$(INSTALLDIR) $(objects) *.filt
+
+test-install:
+	DESTDIR=/tmp/build $(MAKE) install


### PR DESCRIPTION
This allows running `make install` from the gfx video filters to install them locally.