### PR TITLE
Add make install command for the audio filters

### DIFF
--- a/libretro-common/audio/dsp_filters/Makefile
+++ b/libretro-common/audio/dsp_filters/Makefile
@@ -3,6 +3,8 @@ extra_flags :=
 use_neon    := 0
 build       = release
 DYLIB	      := so
+PREFIX      := /usr
+INSTALLDIR  := $(PREFIX)/lib/retroarch/filters/audio
 
 ifeq ($(platform),)
    platform = unix
@@ -89,3 +91,10 @@ clean:
 
 strip:
 	strip -s *.$(DYLIB)
+
+install:
+	mkdir -p $(DESTDIR)$(INSTALLDIR)
+	cp -t $(DESTDIR)$(INSTALLDIR) $(targets) *.dsp
+
+test-install:
+	DESTDIR=/tmp/build $(MAKE) install


### PR DESCRIPTION
This allows running `make install` from the audio filters to install them locally.