### PR TITLE
Increase maximum sample rate in tinyalsa and implement check for upper and lower bounds

### DIFF
--- a/audio/drivers/tinyalsa.c
+++ b/audio/drivers/tinyalsa.c
@@ -2203,12 +2203,12 @@ static void * tinyalsa_init(const char *devicestr, unsigned rate,
    {
       RARCH_WARN("[TINYALSA]: Sample rate cannot be larger than %uHz "\
                  "or smaller than %uHz.\n", max_rate, min_rate);
-      RARCH_WARN("[TINYALSA]: Trying the default rate or else max rate.\n");
-      
-      if (max_rate >= 192000)
-         rate = 192000;
-      else 
+      RARCH_WARN("[TINYALSA]: Trying to set a valid sample rate.\n");
+
+      if (rate > max_rate)
          rate = max_rate;
+      else if (rate < min_rate)
+         rate = min_rate;
    }
 
    if (orig_rate != rate)

--- a/audio/drivers/tinyalsa.c
+++ b/audio/drivers/tinyalsa.c
@@ -2205,8 +2205,8 @@ static void * tinyalsa_init(const char *devicestr, unsigned rate,
                  "or smaller than %uHz.\n", max_rate, min_rate);
       RARCH_WARN("[TINYALSA]: Trying the default rate or else max rate.\n");
       
-      if (max_rate >= 48000)
-         rate = 48000;
+      if (max_rate >= 192000)
+         rate = 192000;
       else 
          rate = max_rate;
    }


### PR DESCRIPTION
The current implementation has a hard limit of 48000 khz for the sample rate. This commit removes the limits, using the driver-reported values of the min and max rates. Also, it uses the min and max sample rates to decide which rate to use when out-of-bounds values are attempted to be set.