### PR TITLE
Add "configure" to audio and video filters

### DIFF
--- a/gfx/video_filters/configure
+++ b/gfx/video_filters/configure
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+PACKAGE_NAME=retroarch-filters-video

--- a/libretro-common/audio/dsp_filters/configure
+++ b/libretro-common/audio/dsp_filters/configure
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+PACKAGE_NAME=retroarch-filters-audio


### PR DESCRIPTION
This allows creating a package out of the audio and video filters. Useful for build tools in Flatpak, Lakka, and otherwise.