### PR TITLE
Cast ctype args to unsigned char

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -921,7 +921,7 @@ static unsigned cheevos_prefix_to_comp_size(char prefix)
 {
    /* Careful not to use ABCDEF here, this denotes part of an actual variable! */
 
-   switch( toupper( prefix ) )
+   switch( toupper( (unsigned char)prefix ) )
    {
       case 'M':
          return CHEEVOS_VAR_SIZE_BIT_0;
@@ -1141,13 +1141,13 @@ static void cheevos_parse_var(cheevos_var_t *var, const char **memaddr)
    const char *str = *memaddr;
    unsigned base   = 16;
 
-   if (toupper(*str) == 'D' && str[1] == '0' && toupper(str[2]) == 'X')
+   if (toupper((unsigned char)*str) == 'D' && str[1] == '0' && toupper((unsigned char)str[2]) == 'X')
    {
       /* d0x + 4 hex digits */
       str += 3;
       var->type = CHEEVOS_VAR_TYPE_DELTA_MEM;
    }
-   else if (*str == '0' && toupper(str[1]) == 'X')
+   else if (*str == '0' && toupper((unsigned char)str[1]) == 'X')
    {
       /* 0x + 4 hex digits */
       str += 2;
@@ -1157,11 +1157,11 @@ static void cheevos_parse_var(cheevos_var_t *var, const char **memaddr)
    {
       var->type = CHEEVOS_VAR_TYPE_VALUE_COMP;
 
-      if (toupper(*str) == 'H')
+      if (toupper((unsigned char)*str) == 'H')
          str++;
       else
       {
-         if (toupper(*str) == 'V')
+         if (toupper((unsigned char)*str) == 'V')
             str++;
          
          base = 10;
@@ -2072,7 +2072,7 @@ static void cheevos_url_encode(const char *str, char *encoded, size_t len)
 {
    while (*str)
    {
-      if (     isalnum(*str) || *str == '-'
+      if (     isalnum((unsigned char)*str) || *str == '-'
             || *str == '_' || *str == '.'
             || *str == '~')
       {

--- a/libretro-common/formats/json/jsonsax.c
+++ b/libretro-common/formats/json/jsonsax.c
@@ -54,13 +54,13 @@ state_t;
 
 static INLINE void skip_spaces( state_t* state )
 {
-  while ( isspace( *state->json ) )
+  while ( isspace( (unsigned char)*state->json ) )
     state->json++;
 }
 
 static INLINE void skip_digits( state_t* state )
 {
-  while ( isdigit( *state->json ) )
+  while ( isdigit( (unsigned char)*state->json ) )
     state->json++;
 }
 
@@ -218,7 +218,7 @@ static void jsonx_parse_number(state_t* state)
    if ( *state->json == '-' )
       state->json++;
 
-   if ( !isdigit( *state->json ) )
+   if ( !isdigit( (unsigned char)*state->json ) )
       longjmp( state->env, JSONSAX_INVALID_VALUE );
 
    skip_digits( state );
@@ -227,7 +227,7 @@ static void jsonx_parse_number(state_t* state)
    {
       state->json++;
 
-      if ( !isdigit( *state->json ) )
+      if ( !isdigit( (unsigned char)*state->json ) )
          longjmp( state->env, JSONSAX_INVALID_VALUE );
 
       skip_digits( state );
@@ -240,7 +240,7 @@ static void jsonx_parse_number(state_t* state)
       if ( *state->json == '-' || *state->json == '+' )
          state->json++;
 
-      if ( !isdigit( *state->json ) )
+      if ( !isdigit( (unsigned char)*state->json ) )
          longjmp( state->env, JSONSAX_INVALID_VALUE );
 
       skip_digits( state );

--- a/libretro-common/string/stdstring.c
+++ b/libretro-common/string/stdstring.c
@@ -30,7 +30,7 @@ char *string_to_upper(char *s)
 {
    char *cs = (char *)s;
    for ( ; *cs != '\0'; cs++)
-      *cs = toupper(*cs);
+      *cs = toupper((unsigned char)*cs);
    return s;
 }
 
@@ -38,7 +38,7 @@ char *string_to_lower(char *s)
 {
    char *cs = (char *)s;
    for ( ; *cs != '\0'; cs++)
-      *cs = tolower(*cs);
+      *cs = tolower((unsigned char)*cs);
    return s;
 }
 
@@ -48,10 +48,10 @@ char *string_ucwords(char *s)
    for ( ; *cs != '\0'; cs++)
    {
       if (*cs == ' ')
-         *(cs+1) = toupper(*(cs+1));
+         *(cs+1) = toupper((unsigned char)*(cs+1));
    }
 
-   s[0] = toupper(s[0]);
+   s[0] = toupper((unsigned char)s[0]);
    return s;
 }
 
@@ -108,7 +108,7 @@ char *string_trim_whitespace_left(char *const s)
       size_t len = strlen(s);
       char *cur  = s;
 
-      while(*cur && isspace(*cur))
+      while(*cur && isspace((unsigned char)*cur))
          ++cur, --len;
 
       if(s != cur)
@@ -127,10 +127,10 @@ char *string_trim_whitespace_right(char *const s)
       size_t len = strlen(s);
       char  *cur = s + len - 1;
 
-      while(cur != s && isspace(*cur))
+      while(cur != s && isspace((unsigned char)*cur))
          --cur, --len;
 
-      cur[isspace(*cur) ? 0 : 1] = '\0';
+      cur[isspace((unsigned char)*cur) ? 0 : 1] = '\0';
    }
 
    return s;

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -860,7 +860,7 @@ static bool menu_content_playlist_load(menu_content_ctx_playlist_info_t *info)
       char *path_tolower  = strdup(path);
 
       for (i = 0; i < strlen(path_tolower); ++i)
-         path_tolower[i] = tolower(path_tolower[i]);
+         path_tolower[i] = tolower((unsigned char)path_tolower[i]);
 
       if (strstr(path_tolower, file_path_str(FILE_PATH_ZIP_EXTENSION)))
          strstr(path_tolower, file_path_str(FILE_PATH_ZIP_EXTENSION))[4] = '\0';


### PR DESCRIPTION
> warning: array subscript has type 'char' [-Wchar-subscripts]

Silence this warning on NetBSD.

See also: [Do I need to cast to unsigned char before calling toupper?](https://stackoverflow.com/questions/21805674/do-i-need-to-cast-to-unsigned-char-before-calling-toupper#21805970)