### PR TITLE
Start adding descriptions to lobbies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 - INPUT: Overlay controller response - when we press buttons on the gamepad or keyboard, the corresponding buttons on the overlay will be highlighted as well.
 - NETBSD: Silence some compilation warnings.
 - COMMON: Fixed bug 'Deleting an entry from a playlist would not update the list view inside XMB'.
+- COMMON: Fix inet_ntop_compat on *nix
+- LOBBY: Add skeleton to add help descriptions to lobbies
 
 # 1.6.5
 Skipped this one.

--- a/libretro-common/net/net_compat.c
+++ b/libretro-common/net/net_compat.c
@@ -393,6 +393,8 @@ const char *inet_ntop_compat(int af, const void *src, char *dst, socklen_t cnt)
       return dst;
    }
 #endif
+#else
+   return inet_ntop(af, src, dst, cnt);
 #endif
 
    return NULL;

--- a/menu/cbs/menu_cbs_info.c
+++ b/menu/cbs/menu_cbs_info.c
@@ -17,6 +17,7 @@
 
 #include "../menu_driver.h"
 #include "../menu_cbs.h"
+#include "../verbosity.h"
 
 #include "../widgets/menu_dialog.h"
 
@@ -24,6 +25,10 @@
 #define BIND_ACTION_INFO(cbs, name) \
    cbs->action_info = name; \
    cbs->action_info_ident = #name;
+#endif
+
+#ifdef HAVE_NETWORKING
+#include "../../network/netplay/netplay_discovery.h"
 #endif
 
 static int action_info_default(unsigned type, const char *label)
@@ -60,8 +65,22 @@ static int action_info_cheevos(unsigned type, const char *label)
    menu_dialog_set_current_id(new_id);
 
    return generic_action_ok_help(NULL, label, new_id, 0, 0,
-         MENU_ENUM_LABEL_CHEEVOS_DESCRIPTION,
-         MENU_DIALOG_HELP_CHEEVOS_DESCRIPTION);
+      MENU_ENUM_LABEL_CHEEVOS_DESCRIPTION,
+      MENU_DIALOG_HELP_CHEEVOS_DESCRIPTION);
+}
+#endif
+
+#ifdef HAVE_NETWORKING
+static int action_info_room(unsigned type, const char *label)
+{
+   unsigned new_id        = type - MENU_SETTINGS_NETPLAY_ROOMS_START;
+#if 1
+   RARCH_LOG ("Room id: %u IP: %s Port: %u\n", new_id, 
+      netplay_room_list[new_id].address, netplay_room_list[new_id].port);
+#endif
+   /* add description here 
+      the relevant data is in netplay_room_list[new_id]*/
+   return 0;
 }
 #endif
 
@@ -72,9 +91,18 @@ int menu_cbs_init_bind_info(menu_file_list_cbs_t *cbs,
       return -1;
 
 #ifdef HAVE_CHEEVOS
-   if ((type >= MENU_SETTINGS_CHEEVOS_START))
+   if ((type >= MENU_SETTINGS_CHEEVOS_START) && 
+      (type < MENU_SETTINGS_NETPLAY_ROOMS_START))
    {
       BIND_ACTION_INFO(cbs, action_info_cheevos);
+      return 0;
+   }
+#endif
+
+#ifdef HAVE_NETWORKING
+   if ((type >= MENU_SETTINGS_NETPLAY_ROOMS_START))
+   {
+      BIND_ACTION_INFO(cbs, action_info_room);
       return 0;
    }
 #endif

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -3417,7 +3417,6 @@ void netplay_refresh_rooms_menu(file_list_t *list)
 {
    char s[4115];
    int i                                = 0;
-   int j                                = 0;
 
    menu_entries_ctl(MENU_ENTRIES_CTL_CLEAR, list);
 
@@ -3496,20 +3495,18 @@ void netplay_refresh_rooms_menu(file_list_t *list)
                netplay_room_list[i].gamecrc,
                netplay_room_list[i].timestamp);
 #endif
-         j+=8;
+
          snprintf(s, sizeof(s), "%s: %s%s",
             netplay_room_list[i].lan ? "Local" :
             (netplay_room_list[i].host_method == NETPLAY_HOST_METHOD_MITM ?
             "Internet (relay)" : "Internet (direct)"),
             netplay_room_list[i].nickname, country);
 
-         /*int room_type = netplay_room_list[i].lan ? MENU_ROOM_LAN :
-            (netplay_room_list[i].host_method == NETPLAY_HOST_METHOD_MITM ? MENU_ROOM_MITM : MENU_ROOM); */
          menu_entries_append_enum(list,
                s,
                msg_hash_to_str(MENU_ENUM_LABEL_CONNECT_NETPLAY_ROOM),
                MENU_ENUM_LABEL_CONNECT_NETPLAY_ROOM,
-               MENU_ROOM, 0, 0);
+               MENU_SETTINGS_NETPLAY_ROOMS_START + i, 0, 0);
       }
 
       netplay_rooms_free();

--- a/network/netplay/netplay_discovery.c
+++ b/network/netplay/netplay_discovery.c
@@ -45,6 +45,8 @@
 
 #include "../../retroarch.h"
 #include "../../version.h"
+#include "../../verbosity.h"
+
 #include "netplay.h"
 #include "netplay_discovery.h"
 #include "netplay_private.h"
@@ -346,6 +348,7 @@ static bool netplay_lan_ad_client(void)
          /* And that we know how to handle it */
          if (their_addr.sa_family == AF_INET)
          {
+            RARCH_WARN ("[lobby] using IPv4 for discovery\n");
             struct sockaddr_in *sin = (struct sockaddr_in *) &their_addr;
             sin->sin_port = htons(ntohl(ad_packet_buffer.port));
 
@@ -353,6 +356,7 @@ static bool netplay_lan_ad_client(void)
 #ifdef HAVE_INET6
          else if (their_addr.sa_family == AF_INET6)
          {
+            RARCH_WARN ("[lobby] using IPv6 for discovery\n");
             struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *) &their_addr;
             sin6->sin6_port = htons(ad_packet_buffer.port);
 


### PR DESCRIPTION
@twinaphex 

I was adding descriptions to lobbies, I wanted to print the lobby info in a bigger space than the sublabel provides, but I stumbled on how to trigger the dialog, maybe you can do that instead?


Also, fixed inet_ntop_compat on linux, maybe it will fix lan peer discovery on android too.