### PR TITLE
[libretro-common] Fix null dereference where argc is 0

### DIFF
--- a/libretro-common/compat/compat_getopt.c
+++ b/libretro-common/compat/compat_getopt.c
@@ -184,7 +184,7 @@ int getopt_long(int argc, char *argv[],
    if (optind == 0)
       optind = 1;
 
-   if (argc == 1)
+   if (argc < 2)
       return -1;
 
    short_index = find_short_index(&argv[optind]);


### PR DESCRIPTION
Hi!

Just a tiny bugfix in getopt_long - it checks for one argument but allows situations where there are no arguments. I know this is an edge case (only happening in the Wii U emulator Decaf as far as I can tell) but hey, it's still a null deref.

Thanks again,
Ash