### PR TITLE
(xmb) Comment out visible item calculation in xmb_draw_items()

### DIFF
--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -2278,7 +2278,7 @@ static void xmb_draw_items(
    first = i;
    last  = end - 1;
 
-   xmb_calculate_visible_range(xmb, height, end, current, &first, &last);
+   /* xmb_calculate_visible_range(xmb, height, end, current, &first, &last); */
 
    menu_display_blend_begin();
 
@@ -2314,6 +2314,12 @@ static void xmb_draw_items(
       ticker_str[0] = name[0] = value[0] = '\0';
 
       icon_y = xmb->margins.screen.top + node->y + half_size;
+
+      if (icon_y < half_size)
+         continue;
+
+      if (icon_y > height + xmb->icon.size)
+         break;
 
       icon_x = node->x + xmb->margins.screen.left +
          xmb->icon.spacing.horizontal - half_size;


### PR DESCRIPTION
Fixes a regression where fading animations didn't render if you were far
into the previous list. This happened because "current" has an incorrect
value thanks to a menu_navigation_set_selection(0) call in
menu_cbs_left.c:162