### PR TITLE
Broadcom VC4: Add Videocore config option

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -111,7 +111,7 @@ if [ "$HAVE_EGL" != "no" -a "$OS" != 'Win32' ]; then
    fi
 fi
 
-if [ "HAVE_SSA" != "no" ]; then
+if [ "$HAVE_SSA" != "no" ]; then
    check_lib SSA -lass ass_library_init
 fi
 

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -35,10 +35,12 @@ fi
 add_define_make DYLIB_LIB "$DYLIB"
 
 [ "$OS" = 'Darwin' ] && HAVE_X11=no # X11 breaks on recent OSXes even if present.
-
-[ -d /opt/vc/lib ] && add_library_dirs /opt/vc/lib && add_library_dirs /opt/vc/lib/GL
-check_lib VIDEOCORE -lbcm_host bcm_host_init "-lvcos -lvchiq_arm"
 check_lib SYSTEMD -lsystemd sd_get_machine_names
+
+if [ "$HAVE_VIDEOCORE" != "no" ]; then
+   [ -d /opt/vc/lib ] && add_library_dirs /opt/vc/lib && add_library_dirs /opt/vc/lib/GL
+   check_lib VIDEOCORE -lbcm_host bcm_host_init "-lvcos -lvchiq_arm"
+fi
 
 if [ "$HAVE_VIDEOCORE" = 'yes' ]; then
    [ -d /opt/vc/include ] && add_include_dirs /opt/vc/include

--- a/qb/config.params.sh
+++ b/qb/config.params.sh
@@ -103,3 +103,4 @@ HAVE_HID=yes               # Low-level HID (Human Interface Device) support
 HAVE_LANGEXTRA=yes         # Multi-language support
 HAVE_OSMESA=no             # Off-screen Mesa rendering
 HAVE_VIDEOPROCESSOR=auto   # Enable video processor core
+HAVE_VIDEOCORE=auto        # Broadcom Videocore 4 support


### PR DESCRIPTION
Add option to disable Raspberry Pi Videocore autodetect so VC4 open source driver can be used.