### PR TITLE
config.libs.sh: fix Raspberry Pi library names

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -47,7 +47,7 @@ if [ "$HAVE_VIDEOCORE" = 'yes' ]; then
    [ -d /opt/vc/include/interface/vcos/pthreads ] && add_include_dirs /opt/vc/include/interface/vcos/pthreads
    [ -d /opt/vc/include/interface/vmcs_host/linux ] && add_include_dirs /opt/vc/include/interface/vmcs_host/linux
    HAVE_OPENGLES='auto'
-   EXTRA_GL_LIBS="-lEGL -lGLESv2 -lbcm_host -lvcos -lvchiq_arm"
+   EXTRA_GL_LIBS="-lbrcmEGL -lbrcmGLESv2 -lbcm_host -lvcos -lvchiq_arm"
 fi
 
 if [ "$HAVE_NEON" = "yes" ]; then


### PR DESCRIPTION
As of Debian stretch, the libraspberrypi0 and libraspberrypi-dev packages don't include libEGL.so or libGLES* in /opt/vc/lib; instead, the libraries have been renamed to libbrcmEGL, libbrcmGLES, etc.

This fixes compiling on stretch, but should also be backwards compatible with jessie (as recent firmware packages include these libraries too).