### PR TITLE
config.lib.sh: use brcm vg/egl/glesv2 packages on RPI

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -48,6 +48,7 @@ if [ "$HAVE_VIDEOCORE" = 'yes' ]; then
    [ -d /opt/vc/include/interface/vmcs_host/linux ] && add_include_dirs /opt/vc/include/interface/vmcs_host/linux
    HAVE_OPENGLES='auto'
    EXTRA_GL_LIBS="-lbrcmEGL -lbrcmGLESv2 -lbcm_host -lvcos -lvchiq_arm"
+   BRCM_PREFIX="brcm"
 fi
 
 if [ "$HAVE_NEON" = "yes" ]; then
@@ -101,7 +102,7 @@ if [ "$HAVE_SSE" = "yes" ]; then
 fi
 
 if [ "$HAVE_EGL" != "no" -a "$OS" != 'Win32' ]; then
-   check_pkgconf EGL egl
+   check_pkgconf EGL "$BRCM_PREFIX"egl
    # some systems have EGL libs, but no pkgconfig
    if [ "$HAVE_EGL" = "no" ]; then
       HAVE_EGL=auto && check_lib EGL "-lEGL $EXTRA_GL_LIBS"
@@ -378,12 +379,12 @@ if [ "$HAVE_EGL" = "yes" ]; then
          add_define_make OPENGLES_LIBS "$OPENGLES_LIBS"
          add_define_make OPENGLES_CFLAGS "$OPENGLES_CFLAGS"
       else
-         HAVE_OPENGLES=auto check_pkgconf OPENGLES glesv2
+         HAVE_OPENGLES=auto check_pkgconf OPENGLES "$BRCM_PREFIX"glesv2
          [ "$HAVE_OPENGLES" = "no" ] && HAVE_OPENGLES=auto check_lib OPENGLES "-lGLESv2 $EXTRA_GL_LIBS" && add_define_make OPENGLES_LIBS "-lGLESv2 $EXTRA_GL_LIBS"
       fi
    fi
    if [ "$HAVE_VG" != "no" ]; then
-      check_pkgconf VG vg
+      check_pkgconf VG "$BRCM_PREFIX"vg
       if [ "$HAVE_VG" = "no" ]; then
          HAVE_VG=auto check_lib VG "-lOpenVG $EXTRA_GL_LIBS"
          [ "$HAVE_VG" = "yes" ] && VG_LIBS=-lOpenVG


### PR DESCRIPTION
Do not merge yet, please - needs discussion.

Unfortunately, my previous commit was not sufficient to ensure the proper Broadcom libraries were being linked - it was adding -lEGL and -lbrcmEGL, -lGLESv2 and -lbrcmGLESv2, and I forgot that OpenVG was also renamed.

The commit would fix the issue, but for some reason, libraspberrypi0 and libraspberrypi-dev omits the pkgconfig configuration files here: https://github.com/raspberrypi/firmware/tree/master/opt/vc/lib/pkgconfig

If I copy the brcm*.pc to /usr/lib/pkgconfig/*, then this commit will work as intended and will use the proper libs for linking.

Suggestions? I can raise the issue upstream in order for future packages to include the necessary files, or maybe I'm overlooking another solution?