### PR TITLE
Revert "config.lib.sh: use brcm vg/egl/glesv2 packages on RPI"

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -48,7 +48,6 @@ if [ "$HAVE_VIDEOCORE" = 'yes' ]; then
    [ -d /opt/vc/include/interface/vmcs_host/linux ] && add_include_dirs /opt/vc/include/interface/vmcs_host/linux
    HAVE_OPENGLES='auto'
    EXTRA_GL_LIBS="-lbrcmEGL -lbrcmGLESv2 -lbcm_host -lvcos -lvchiq_arm"
-   BRCM_PREFIX="brcm"
 fi
 
 if [ "$HAVE_NEON" = "yes" ]; then
@@ -102,7 +101,7 @@ if [ "$HAVE_SSE" = "yes" ]; then
 fi
 
 if [ "$HAVE_EGL" != "no" -a "$OS" != 'Win32' ]; then
-   check_pkgconf EGL "$BRCM_PREFIX"egl
+   check_pkgconf EGL egl
    # some systems have EGL libs, but no pkgconfig
    if [ "$HAVE_EGL" = "no" ]; then
       HAVE_EGL=auto && check_lib EGL "-lEGL $EXTRA_GL_LIBS"
@@ -379,12 +378,12 @@ if [ "$HAVE_EGL" = "yes" ]; then
          add_define_make OPENGLES_LIBS "$OPENGLES_LIBS"
          add_define_make OPENGLES_CFLAGS "$OPENGLES_CFLAGS"
       else
-         HAVE_OPENGLES=auto check_pkgconf OPENGLES "$BRCM_PREFIX"glesv2
+         HAVE_OPENGLES=auto check_pkgconf OPENGLES glesv2
          [ "$HAVE_OPENGLES" = "no" ] && HAVE_OPENGLES=auto check_lib OPENGLES "-lGLESv2 $EXTRA_GL_LIBS" && add_define_make OPENGLES_LIBS "-lGLESv2 $EXTRA_GL_LIBS"
       fi
    fi
    if [ "$HAVE_VG" != "no" ]; then
-      check_pkgconf VG "$BRCM_PREFIX"vg
+      check_pkgconf VG vg
       if [ "$HAVE_VG" = "no" ]; then
          HAVE_VG=auto check_lib VG "-lOpenVG $EXTRA_GL_LIBS"
          [ "$HAVE_VG" = "yes" ] && VG_LIBS=-lOpenVG


### PR DESCRIPTION
Reverts libretro/RetroArch#5351

This commit breaks building on all current RPI builds. It would require changes to libraspberrypi-dev (a PR has been sent, but it's yet to be evaluated, let alone accepted) to avoid breaking current builds. Apologies.