### PR TITLE
make the verbosity toggle less weird:

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -3567,8 +3567,11 @@ bool config_save_file(const char *path)
    }
 #endif
 
-   config_set_bool(conf, "log_verbosity",
-         verbosity_is_enabled());
+   if (!retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_VERBOSITY, NULL))
+   {
+      config_set_bool(conf, "log_verbosity",
+            verbosity_is_enabled());
+   }
    config_set_bool(conf, "perfcnt_enable",
          rarch_ctl(RARCH_CTL_IS_PERFCNT_ENABLE, NULL));
 

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -1697,19 +1697,11 @@ void general_write_handler(void *data)
          settings->uints.input_joypad_map[4] = *setting->value.target.integer;
          break;
       case MENU_ENUM_LABEL_LOG_VERBOSITY:
-         if (setting
-               && setting->value.target.boolean
-               && *setting->value.target.boolean)
+         if (!verbosity_is_enabled())
             verbosity_enable();
          else
             verbosity_disable();
-
-         if (setting
-               && setting->value.target.boolean
-               && *setting->value.target.boolean)
-            retroarch_override_setting_set(RARCH_OVERRIDE_SETTING_VERBOSITY, NULL);
-         else
-            retroarch_override_setting_unset(RARCH_OVERRIDE_SETTING_VERBOSITY, NULL);
+         retroarch_override_setting_unset(RARCH_OVERRIDE_SETTING_VERBOSITY, NULL);
          break;
       case MENU_ENUM_LABEL_VIDEO_SMOOTH:
          video_driver_set_filtering(1, settings->bools.video_smooth);


### PR DESCRIPTION
right now, enabling verbosity via -v causes it to change the config parameter.
Now it doesn't change the config parameter unless the switch is actually flicked manually.

The original logic was really weird I couldn't figure it out. It works fine here now and it's cleaner imho.