### PR TITLE
Fix ISO scan crash from buffer overflow

### DIFF
--- a/tasks/task_database_cue.c
+++ b/tasks/task_database_cue.c
@@ -350,7 +350,8 @@ int detect_serial_ascii_game(const char *track_path, char *game_id)
    for (pos = 0; pos < 10000; pos++)
    {
       filestream_seek(fd, pos, SEEK_SET);
-      if (filestream_read(fd, game_id, 10000) > 0)
+      /* Current logic only requires 15 characters (max of 4096 per sizeof game_id). */
+      if (filestream_read(fd, game_id, 15) > 0)
       {
          unsigned i;
          game_id[15] = '\0';


### PR DESCRIPTION
Recent additions in commit bbb2a7d6f to scan ISO files with ASCII characters overflowed the serial number buffer and caused a crash. This fix limits the read to 15 bytes which is all that is actually required.