### PR TITLE
Fix 7zip dependency include directory

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -57,7 +57,7 @@ if [ "$HAVE_NEON" = "yes" ]; then
 fi
 
 if [ "$HAVE_7ZIP" = "yes" ]; then
-   add_include_dirs ./decompress/7zip/
+   add_include_dirs ./deps/7zip/
 fi
 
 if [ "$HAVE_PRESERVE_DYLIB" = "yes" ]; then


### PR DESCRIPTION
Found `./decompress/7zip/`, which doesn't exist. It may be at [`deps/7zip`](https://github.com/libretro/RetroArch/tree/master/deps/7zip) instead.