### PR TITLE
reset controllers when the core has set controller info

### DIFF
--- a/command.c
+++ b/command.c
@@ -1018,6 +1018,11 @@ static void command_event_init_controllers(void)
             set_controller = true;
             break;
          case RETRO_DEVICE_JOYPAD:
+            /* ideally this check wouldn't be required but if we always
+             *  call core_set_controller_port_device input won't work on 
+             *  cores that don't set port information */
+            if (info->ports.size != 0)
+               set_controller = true;
             break;
          default:
             /* Some cores do not properly range check port argument.


### PR DESCRIPTION
@twinaphex this seems to work around the issue and solve the issue with descriptors not showing at startup on some cores, I'll do more testing tho.