### PR TITLE
More scanning rework

### DIFF
--- a/libretro-common/include/streams/chd_stream.h
+++ b/libretro-common/include/streams/chd_stream.h
@@ -32,8 +32,12 @@ RETRO_BEGIN_DECLS
 
 typedef struct chdstream chdstream_t;
 
+// First data track
 #define CHDSTREAM_TRACK_FIRST_DATA (-1)
+// Last track
 #define CHDSTREAM_TRACK_LAST (-2)
+// Primary (largest) data track, used for CRC identification purposes
+#define CHDSTREAM_TRACK_PRIMARY (-3)
 
 chdstream_t *chdstream_open(const char *path, int32_t track);
 

--- a/libretro-common/streams/chd_stream.c
+++ b/libretro-common/streams/chd_stream.c
@@ -103,8 +103,19 @@ chdstream_get_meta(chd_file *chd, int idx, metadata_t *md)
                           sizeof(meta), &meta_size, NULL, NULL);
    if (err == CHDERR_NONE)
    {
-      sscanf(meta, CDROM_TRACK_METADATA_FORMAT,
-            &md->track, md->type, md->subtype, &md->frames);
+      sscanf(meta, CDROM_TRACK_METADATA_FORMAT, &md->track, md->type,
+             md->subtype, &md->frames);
+      md->extra = padding_frames(md->frames);
+      return true;
+   }
+
+   err = chd_get_metadata(chd, GDROM_TRACK_METADATA_TAG, idx, meta,
+                          sizeof(meta), &meta_size, NULL, NULL);
+   if (err == CHDERR_NONE)
+   {
+      sscanf(meta, GDROM_TRACK_METADATA_FORMAT, &md->track, md->type,
+             md->subtype, &md->frames, &md->pad, &md->pregap, md->pgtype,
+             md->pgsub, &md->postgap);
       md->extra = padding_frames(md->frames);
       return true;
    }

--- a/libretro-common/streams/chd_stream.c
+++ b/libretro-common/streams/chd_stream.c
@@ -82,10 +82,12 @@ chdstream_get_meta(chd_file *chd, int idx, metadata_t *md)
 {
    char meta[256];
    uint32_t meta_size = 0;
-   chd_error err      = chd_get_metadata(
-         chd, CDROM_TRACK_METADATA2_TAG, idx, meta,
-         sizeof(meta), &meta_size, NULL, NULL);
+   chd_error err;
 
+   memset(md, 0, sizeof(*md));
+
+   err = chd_get_metadata(chd, CDROM_TRACK_METADATA2_TAG, idx, meta,
+                          sizeof(meta), &meta_size, NULL, NULL);
    if (err == CHDERR_NONE)
    {
       sscanf(meta, CDROM_TRACK_METADATA2_FORMAT,
@@ -111,40 +113,84 @@ chdstream_get_meta(chd_file *chd, int idx, metadata_t *md)
 }
 
 static bool
-chdstream_find_track(chd_file *fd, int32_t track, metadata_t *meta)
+chdstream_find_track_number(chd_file *fd, int32_t track, metadata_t *meta)
 {
    uint32_t i;
-
-   memset(meta, 0, sizeof(*meta));
+   uint32_t frame_offset = 0;
 
    for (i = 0; true; ++i)
    {
       if (!chdstream_get_meta(fd, i, meta))
       {
-         if (track != CHDSTREAM_TRACK_LAST)
-            return false;
+         return false;
+      }
 
-         meta->frame_offset -= meta->frames + meta->extra;
+      if (track == meta->track)
+      {
+         meta->frame_offset = frame_offset;
          return true;
       }
 
-      if ((track == CHDSTREAM_TRACK_FIRST_DATA &&
-           strcmp(meta->type, "AUDIO")) ||
-          (track > 0 && track == meta->track))
-         return true;
+      frame_offset += meta->frames + meta->extra;
+   }
+}
 
-      meta->frame_offset += meta->frames + meta->extra;
+static bool
+chdstream_find_special_track(chd_file *fd, int32_t track, metadata_t *meta)
+{
+   int32_t i;
+   metadata_t iter;
+   int32_t largest_track = 0;
+   uint32_t largest_size = 0;
+
+   for (i = 1; true; ++i)
+   {
+      if (!chdstream_find_track_number(fd, i, &iter)) {
+         if (track == CHDSTREAM_TRACK_LAST && i > 1) {
+            *meta = iter;
+            return true;
+         } else if (track == CHDSTREAM_TRACK_PRIMARY && largest_track != 0) {
+            return chdstream_find_track_number(fd, largest_track, meta);
+         }
+      }
+
+      switch (track) {
+         case CHDSTREAM_TRACK_FIRST_DATA:
+            if (strcmp(iter.type, "AUDIO")) {
+               *meta = iter;
+               return true;
+            }
+            break;
+         case CHDSTREAM_TRACK_PRIMARY:
+            if (strcmp(iter.type, "AUDIO") && iter.frames > largest_size) {
+               largest_size = iter.frames;
+               largest_track = iter.track;
+            }
+            break;
+         default:
+            break;
+      }
+   }
+}
+
+static bool
+chdstream_find_track(chd_file *fd, int32_t track, metadata_t *meta)
+{
+   if (track < 0) {
+      return chdstream_find_special_track(fd, track, meta);
+   } else {
+      return chdstream_find_track_number(fd, track, meta);
    }
 }
 
 chdstream_t *chdstream_open(const char *path, int32_t track)
 {
-   metadata_t meta;
    uint32_t pregap      = 0;
    const chd_header *hd = NULL;
    chdstream_t *stream  = NULL;
    chd_file *chd        = NULL;
    chd_error err        = chd_open(path, CHD_OPEN_READ, NULL, &chd);
+   metadata_t meta;
 
    if (err != CHDERR_NONE)
       goto error;

--- a/msg_hash.c
+++ b/msg_hash.c
@@ -231,6 +231,8 @@ uint32_t msg_hash_calculate(const char *s)
 #define HASH_EXTENSION_ZIP_UPP                                                 0x0b883b78U
 #define HASH_EXTENSION_CUE                                                     0x0b886782U
 #define HASH_EXTENSION_CUE_UPPERCASE                                           0x0b87db22U
+#define HASH_EXTENSION_GDI                                                     0x00b887659
+#define HASH_EXTENSION_GDI_UPPERCASE                                           0x00b87e9f9
 #define HASH_EXTENSION_ISO                                                     0x0b8880d0U
 #define HASH_EXTENSION_ISO_UPPERCASE                                           0x0b87f470U
 #define HASH_EXTENSION_LUTRO                                                   0x0fe37b7bU
@@ -376,6 +378,9 @@ enum msg_file_type msg_hash_to_file_type(uint32_t hash)
       case HASH_EXTENSION_CUE:
       case HASH_EXTENSION_CUE_UPPERCASE:
          return FILE_TYPE_CUE;
+      case HASH_EXTENSION_GDI:
+      case HASH_EXTENSION_GDI_UPPERCASE:
+         return FILE_TYPE_GDI;
       case HASH_EXTENSION_ISO:
       case HASH_EXTENSION_ISO_UPPERCASE:
          return FILE_TYPE_ISO;

--- a/msg_hash.h
+++ b/msg_hash.h
@@ -132,6 +132,7 @@ enum msg_file_type
    FILE_TYPE_XM,
 
    FILE_TYPE_CUE,
+   FILE_TYPE_GDI,
    FILE_TYPE_ISO,
    FILE_TYPE_LUTRO,
    FILE_TYPE_CHD,

--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -606,7 +606,9 @@ static int task_database_iterate_playlist(
       case FILE_TYPE_GDI:
          gdi_prune(db, name);
          db_state->serial[0] = '\0';
-         if (gdi_get_serial(name, db_state->serial))
+         /* There are no serial databases, so don't bother with
+            serials at the moment */
+         if (0 && gdi_get_serial(name, db_state->serial))
          {
             database_info_set_type(db, DATABASE_TYPE_SERIAL_LOOKUP);
          }
@@ -623,9 +625,7 @@ static int task_database_iterate_playlist(
          break;
       case FILE_TYPE_CHD:
          db_state->serial[0] = '\0';
-         /* There are no serial databases, so don't bother with
-            serials at the moment */
-         if (0 && chd_get_serial(name, db_state->serial))
+         if (chd_get_serial(name, db_state->serial))
          {
             database_info_set_type(db, DATABASE_TYPE_SERIAL_LOOKUP);
          }

--- a/tasks/task_database_cue.c
+++ b/tasks/task_database_cue.c
@@ -424,6 +424,10 @@ int cue_find_track(const char *cue_path, bool first,
    size_t largest = 0;
    ssize_t volatile file_size = -1;
    bool is_data = false;
+   char *cue_dir = (char*)malloc(PATH_MAX_LENGTH);
+   cue_dir[0]    = '\0';
+
+   fill_pathname_basedir(cue_dir, cue_path, PATH_MAX_LENGTH);
 
    info.type        = INTFSTREAM_FILE;
 
@@ -450,9 +454,6 @@ int cue_find_track(const char *cue_path, bool first,
    {
       if (string_is_equal(tmp_token, "FILE"))
       {
-         char *cue_dir = (char*)malloc(PATH_MAX_LENGTH);
-         cue_dir[0]    = '\0';
-
          /* Set last index to last EOF */
          if (file_size != -1) {
             last_index = file_size;
@@ -467,14 +468,11 @@ int cue_find_track(const char *cue_path, bool first,
             }
          }
 
-         fill_pathname_basedir(cue_dir, cue_path, PATH_MAX_LENGTH);
-
          get_token(fd, tmp_token, MAX_TOKEN_LEN);
          fill_pathname_join(last_file, cue_dir, tmp_token, PATH_MAX_LENGTH);
 
          file_size = get_file_size(last_file);
 
-         free(cue_dir);
          get_token(fd, tmp_token, MAX_TOKEN_LEN);
 
       }
@@ -524,12 +522,14 @@ int cue_find_track(const char *cue_path, bool first,
    }
 
 clean:
+   free(cue_dir);
    free(tmp_token);
    free(last_file);
    intfstream_close(fd);
    return rv;
 
 error:
+   free(cue_dir);
    free(tmp_token);
    free(last_file);
    if (fd)

--- a/tasks/task_database_cue.c
+++ b/tasks/task_database_cue.c
@@ -415,8 +415,7 @@ int find_first_data_track(const char *cue_path,
    fd = intfstream_init(&info);
    if (!fd)
    {
-      free(tmp_token);
-      return -errno;
+      goto error;
    }
 
    if (!intfstream_open(fd, cue_path, RFILE_MODE_READ, -1))

--- a/tasks/task_database_cue.c
+++ b/tasks/task_database_cue.c
@@ -516,6 +516,10 @@ int cue_find_track(const char *cue_path, bool first,
       }
    }
 
+   if (file_size != -1) {
+      last_index = file_size;
+   }
+
    if (update_cand(&cand_index, &last_index, &largest, last_file, offset,
                    size, track_path, max_len)) {
       rv = 0;


### PR DESCRIPTION
- As discussed before, use largest data track for CRC identification
- Make scanning cue files work with a database using data track CRCs
- As a bonus, scanning cue files that have multiple tracks in the same physical file now works

It occurs to me that scanning a directory with both a cue and a data track in its own file will now detect both, which means the wrong one may end up getting added to the playlist.  It also wastes a lot of time scanning binaries we don't care about, so this should probably be fixed by e.g. scanning cue files first, then removing any references files from the remainder of the list to be scanned.  This, as well as GDI file support, will have to come later.

Sorry for some of the unintentional reformatting, I need to write a clang-format file for retroarch.