### PR TITLE
Prevent crashes caused by loading shaders in incompatible contexts

### DIFF
--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -212,6 +212,8 @@ static gfx_ctx_driver_t current_video_context;
 
 static void *video_context_data                          = NULL;
 
+static enum gfx_ctx_api current_video_context_api        = GFX_CTX_NONE;
+
 shader_backend_t *current_shader                         = NULL;
 void *shader_data                                        = NULL;
 
@@ -2718,6 +2720,9 @@ static const gfx_ctx_driver_t *video_context_driver_init(
                video_info.shared_context && hw_render_ctx);
 
       video_context_driver_set_data(ctx_data);
+
+      current_video_context_api = api;
+
       return ctx;
    }
 
@@ -3010,6 +3015,11 @@ bool video_context_driver_set_flags(gfx_ctx_flags_t *flags)
       return false;
    current_video_context.set_flags(video_context_data, flags->flags);
    return true;
+}
+
+enum gfx_ctx_api video_context_driver_get_api(void)
+{
+   return current_video_context_api;
 }
 
 bool video_driver_has_windowed(void)

--- a/gfx/video_driver.h
+++ b/gfx/video_driver.h
@@ -1208,6 +1208,8 @@ bool video_context_driver_translate_aspect(gfx_ctx_aspect_t *aspect);
 
 bool video_context_driver_input_driver(gfx_ctx_input_t *inp);
 
+enum gfx_ctx_api video_context_driver_get_api(void);
+
 void video_context_driver_free(void);
 
 bool video_shader_driver_get_prev_textures(video_shader_ctx_texture_t *texture);

--- a/gfx/video_shader_parse.c
+++ b/gfx/video_shader_parse.c
@@ -1095,7 +1095,6 @@ enum rarch_shader_type video_shader_parse_type(const char *path,
    switch (msg_hash_to_file_type(
             msg_hash_calculate(path_get_extension(path))))
    {
-      
       case FILE_TYPE_SHADER_CG:
       case FILE_TYPE_SHADER_PRESET_CGP:
          shader_type = RARCH_SHADER_CG;
@@ -1119,20 +1118,25 @@ enum rarch_shader_type video_shader_parse_type(const char *path,
          if (shader_type == RARCH_SHADER_GLSL 
             || (cg_supported && shader_type == RARCH_SHADER_CG))
             return shader_type;
+         break;
       case GFX_CTX_DIRECT3D9_API:
          if (cg_supported && shader_type == RARCH_SHADER_CG)
             return shader_type;
+         break;
       case GFX_CTX_VULKAN_API:
          if (shader_type == RARCH_SHADER_SLANG)
-            return fallback;
+            return shader_type;
+         break;
       case GFX_CTX_GDI_API:
       case GFX_CTX_OPENVG_API:
       case GFX_CTX_DIRECT3D8_API:
       case GFX_CTX_NONE:
       default:
-         RARCH_WARN("Current video context is incompatible with file: %s", path);
-         return fallback;
+         break;
    }
+
+   RARCH_WARN("Current video context is incompatible with file: %s", path);
+   return fallback;
 }
 
 /**

--- a/gfx/video_shader_parse.c
+++ b/gfx/video_shader_parse.c
@@ -1135,7 +1135,7 @@ enum rarch_shader_type video_shader_parse_type(const char *path,
          break;
    }
 
-   RARCH_WARN("Current video context is incompatible with file: %s", path);
+   RARCH_WARN("Rendering context is incompatible with shader type: %s\n", path);
    return fallback;
 }
 

--- a/gfx/video_shader_parse.c
+++ b/gfx/video_shader_parse.c
@@ -21,6 +21,7 @@
 #include <compat/msvc.h>
 #include <compat/strl.h>
 #include <file/file_path.h>
+#include <gfx/video_driver.h> /* video_context_driver_get_api */
 #include <rhash.h>
 #include <string/stdstring.h>
 #include <streams/file_stream.h>

--- a/gfx/video_shader_parse.c
+++ b/gfx/video_shader_parse.c
@@ -1080,10 +1080,11 @@ void video_shader_write_conf_cgp(config_file_t *conf,
 enum rarch_shader_type video_shader_parse_type(const char *path,
       enum rarch_shader_type fallback)
 {
+   enum rarch_shader_type shader_type = RARCH_SHADER_NONE;   
+
    if (!path)
       return fallback;
 
-   enum rarch_shader_type shader_type = RARCH_SHADER_NONE;
    switch (msg_hash_to_file_type(
             msg_hash_calculate(path_get_extension(path))))
    {
@@ -1105,7 +1106,6 @@ enum rarch_shader_type video_shader_parse_type(const char *path,
    }
 
    enum gfx_ctx_api api = video_context_driver_get_api();
-
 
    switch (api)
    {

--- a/gfx/video_shader_parse.c
+++ b/gfx/video_shader_parse.c
@@ -1080,7 +1080,8 @@ void video_shader_write_conf_cgp(config_file_t *conf,
 enum rarch_shader_type video_shader_parse_type(const char *path,
       enum rarch_shader_type fallback)
 {
-   enum rarch_shader_type shader_type = RARCH_SHADER_NONE;   
+   enum rarch_shader_type shader_type = RARCH_SHADER_NONE;
+   enum gfx_ctx_api api = video_context_driver_get_api(); 
 
    if (!path)
       return fallback;
@@ -1104,8 +1105,6 @@ enum rarch_shader_type video_shader_parse_type(const char *path,
       default:
          break;
    }
-
-   enum gfx_ctx_api api = video_context_driver_get_api();
 
    switch (api)
    {

--- a/gfx/video_shader_parse.c
+++ b/gfx/video_shader_parse.c
@@ -1081,7 +1081,13 @@ enum rarch_shader_type video_shader_parse_type(const char *path,
       enum rarch_shader_type fallback)
 {
    enum rarch_shader_type shader_type = RARCH_SHADER_NONE;
-   enum gfx_ctx_api api = video_context_driver_get_api(); 
+   enum gfx_ctx_api api = video_context_driver_get_api();
+
+   #ifdef HAVE_CG
+   bool cg_supported = true;
+   #else
+   bool cg_supported = false;
+   #endif
 
    if (!path)
       return fallback;
@@ -1109,22 +1115,22 @@ enum rarch_shader_type video_shader_parse_type(const char *path,
    switch (api)
    {
       case GFX_CTX_OPENGL_API:
-         if (shader_type == RARCH_SHADER_GLSL || shader_type == RARCH_SHADER_CG)
-            return shader_type;
       case GFX_CTX_OPENGL_ES_API:
-         if (shader_type == RARCH_SHADER_GLSL)
+         if (shader_type == RARCH_SHADER_GLSL 
+            || (cg_supported && shader_type == RARCH_SHADER_CG))
             return shader_type;
       case GFX_CTX_DIRECT3D9_API:
-         if (shader_type == RARCH_SHADER_CG)
+         if (cg_supported && shader_type == RARCH_SHADER_CG)
             return shader_type;
       case GFX_CTX_VULKAN_API:
          if (shader_type == RARCH_SHADER_SLANG)
             return fallback;
-      case GFX_CTX_NONE:
       case GFX_CTX_GDI_API:
       case GFX_CTX_OPENVG_API:
       case GFX_CTX_DIRECT3D8_API:
+      case GFX_CTX_NONE:
       default:
+         RARCH_WARN("Current video context is incompatible with file: %s", path);
          return fallback;
    }
 }

--- a/gfx/video_shader_parse.c
+++ b/gfx/video_shader_parse.c
@@ -1083,23 +1083,51 @@ enum rarch_shader_type video_shader_parse_type(const char *path,
    if (!path)
       return fallback;
 
+   enum rarch_shader_type shader_type = RARCH_SHADER_NONE;
    switch (msg_hash_to_file_type(
             msg_hash_calculate(path_get_extension(path))))
    {
+      
       case FILE_TYPE_SHADER_CG:
       case FILE_TYPE_SHADER_PRESET_CGP:
-         return RARCH_SHADER_CG;
+         shader_type = RARCH_SHADER_CG;
+         break;
       case FILE_TYPE_SHADER_GLSL:
       case FILE_TYPE_SHADER_PRESET_GLSLP:
-         return RARCH_SHADER_GLSL;
+         shader_type = RARCH_SHADER_GLSL;
+         break;
       case FILE_TYPE_SHADER_SLANG:
       case FILE_TYPE_SHADER_PRESET_SLANGP:
-         return RARCH_SHADER_SLANG;
+         shader_type = RARCH_SHADER_SLANG;
+         break;
       default:
          break;
    }
 
-   return fallback;
+   enum gfx_ctx_api api = video_context_driver_get_api();
+
+
+   switch (api)
+   {
+      case GFX_CTX_OPENGL_API:
+         if (shader_type == RARCH_SHADER_GLSL || shader_type == RARCH_SHADER_CG)
+            return shader_type;
+      case GFX_CTX_OPENGL_ES_API:
+         if (shader_type == RARCH_SHADER_GLSL)
+            return shader_type;
+      case GFX_CTX_DIRECT3D9_API:
+         if (shader_type == RARCH_SHADER_CG)
+            return shader_type;
+      case GFX_CTX_VULKAN_API:
+         if (shader_type == RARCH_SHADER_SLANG)
+            return fallback;
+      case GFX_CTX_NONE:
+      case GFX_CTX_GDI_API:
+      case GFX_CTX_OPENVG_API:
+      case GFX_CTX_DIRECT3D8_API:
+      default:
+         return fallback;
+   }
 }
 
 /**


### PR DESCRIPTION
This isn't a catch-all fix for these types of crashes, but it prevents the most significant ones on the desktop - for example loading a .cgp file when the video driver is 'vulkan'.

This PR extends video_driver.c - it now stores a static global variable that stores which API we're currently using and has a related getter function so files that include video_driver.h can query it.

The logic to prevent crashes can be seen in video_shader_parse.c:1080. After we determine the extension of the shader preset/file we're currently handling, we check if the API we're using is compatible with said extension.
If the API isn't compatible, then we return the value of 'fallback'. If HAVE_CG is not defined, then on cases where the shader type is Cg, we return 'fallback' as well.

Maybe we should also check if HAVE_GLSL is defined too and prevent loading of .glslp/.glsl files like we do in the Cg/HAVE_CG cases?