### PR TITLE
Fix archive scanning

### DIFF
--- a/core_info.c
+++ b/core_info.c
@@ -825,45 +825,6 @@ size_t core_info_list_num_info_files(core_info_list_t *core_info_list)
    return num;
 }
 
-bool core_info_unsupported_content_path(const char *path)
-{
-   size_t i;
-   const char *archive_path = NULL;
-   const char *delim        = path_get_archive_delim(path);
-
-   if (delim)
-      archive_path = delim - 1;
-
-   if (!core_info_curr_list)
-      return false;
-
-   /* if the path contains a compressed file and the core supports archives,
-    * we don't want to look at this file */
-   if (archive_path)
-   {
-      for (i = 0; i < core_info_curr_list->count; i++)
-      {
-         const core_info_t *info = &core_info_curr_list->list[i];
-
-         if (     !string_list_find_elem(info->supported_extensions_list, "zip")
-               && !string_list_find_elem(info->supported_extensions_list, "7z"))
-            continue;
-
-         return false;
-      }
-   }
-
-   for (i = 0; i < core_info_curr_list->count; i++)
-   {
-      const core_info_t *info = &core_info_curr_list->list[i];
-
-      if (string_list_find_elem(info->supported_extensions_list, path_get_extension(path)))
-         return false;
-   }
-
-   return true;
-}
-
 bool core_info_database_supports_content_path(const char *database_path, const char *path)
 {
    char *database           = NULL;
@@ -882,31 +843,6 @@ bool core_info_database_supports_content_path(const char *database_path, const c
    if (core_info_curr_list)
    {
       size_t i;
-      const char *delim           = path_get_archive_delim(path);
-
-      if (delim)
-      {
-         const char *archive_path = delim - 1;
-
-         /* if the path contains a compressed file and the core supports archives,
-          * we don't want to look at this file */
-         if (archive_path)
-         {
-            for (i = 0; i < core_info_curr_list->count; i++)
-            {
-               const core_info_t *info = &core_info_curr_list->list[i];
-
-               if (!string_list_find_elem(info->databases_list, database))
-                  continue;
-
-               if (     !string_list_find_elem(info->supported_extensions_list, "zip")
-                     && !string_list_find_elem(info->supported_extensions_list, "7z"))
-                  continue;
-
-               goto error;
-            }
-         }
-      }
 
       for (i = 0; i < core_info_curr_list->count; i++)
       {

--- a/database_info.c
+++ b/database_info.c
@@ -417,56 +417,6 @@ database_info_handle_t *database_info_dir_init(const char *dir,
    db->status         = DATABASE_STATUS_ITERATE;
    db->type           = type;
 
-   if (db->list->size > 0)
-   {
-      for (i = 0; i < db->list->size; i++)
-      {
-         const char *path = db->list->elems[i].data;
-
-         if (task)
-            task_set_progress(task, (i / (float)db->list->size) * 100);
-
-         if (path_is_compressed_file(path) && !path_contains_compressed_file(path))
-         {
-            struct string_list *archive_list = path_is_compressed_file(path) ?
-                  file_archive_get_file_list(path, NULL) : NULL;
-
-            if (archive_list && archive_list->size > 0)
-            {
-               unsigned i;
-
-               for (i = 0; i < archive_list->size; i++)
-               {
-                  char *new_path   = (char*)malloc(
-                        PATH_MAX_LENGTH * sizeof(char));
-                  size_t path_size = PATH_MAX_LENGTH * sizeof(char);
-                  size_t path_len  = strlen(path);
-
-                  new_path[0] = '\0';
-
-                  strlcpy(new_path, path, path_size);
-
-                  if (path_len + strlen(archive_list->elems[i].data)
-                         + 1 < PATH_MAX_LENGTH)
-                  {
-                     new_path[path_len] = '#';
-                     strlcpy(new_path + path_len + 1,
-                           archive_list->elems[i].data,
-                           path_size - path_len);
-                  }
-
-                  string_list_append(db->list, new_path,
-                        archive_list->elems[i].attr);
-
-                  free(new_path);
-               }
-
-               string_list_free(archive_list);
-            }
-         }
-      }
-   }
-
    return db;
 
 error:
@@ -493,47 +443,6 @@ database_info_handle_t *database_info_file_init(const char *path,
       goto error;
 
    string_list_append(db->list, path, attr);
-
-   if (path_is_compressed_file(path))
-   {
-      struct string_list *archive_list =path_is_compressed_file(path) ?
-            file_archive_get_file_list(path, NULL) : NULL;
-
-      if (archive_list && archive_list->size > 0)
-      {
-         unsigned i;
-
-         for (i = 0; i < archive_list->size; i++)
-         {
-            char *new_path   = (char*)malloc(PATH_MAX_LENGTH * sizeof(char));
-            size_t path_size = PATH_MAX_LENGTH * sizeof(char);
-            size_t path_len  = strlen(path);
-
-            if (task)
-               task_set_progress(task,
-                     (i / (float)archive_list->size) * 100);
-
-            new_path[0] = '\0';
-
-            strlcpy(new_path, path, path_size);
-
-            if (path_len + strlen(archive_list->elems[i].data)
-                   + 1 < PATH_MAX_LENGTH)
-            {
-               new_path[path_len] = '#';
-               strlcpy(new_path + path_len + 1,
-                     archive_list->elems[i].data,
-                     path_size - path_len);
-            }
-
-            string_list_append(db->list, new_path,
-                                  archive_list->elems[i].attr);
-            free(new_path);
-         }
-
-         string_list_free(archive_list);
-      }
-   }
 
    db->list_ptr       = 0;
    db->status         = DATABASE_STATUS_ITERATE;


### PR DESCRIPTION
Archive scans were broken for cores like Atari 5200 and Commodore 64 because archive contents were skipped if a core reported it supported compressed files. The problem is, it's a false assumption that just because a core supports compressed files that the content database contains CRCs for compressed files.

Instead of adding the contents of every compressed file to the scan list ahead of time, the patched logic now checks for the CRC of the archive itself as it always has but then adds the archive contents to the scan list if the archive itself is no match. This maintains the logic of adding only the archive if the core supports compressed files and the archive CRC matches but also allows for deeper content scans when there is no match.

The patch also removes `core_info_unsupported_content_path` as it was redundant with existing `core_info_database_supports_content_path` logic.