### PR TITLE
Optimize scanning using directory name hint

### DIFF
--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -386,7 +386,7 @@ static int stream_get_crc(intfstream_t *fd, uint32_t *crc)
    while ((read = intfstream_read(fd, buffer, sizeof(buffer))) > 0)
       acc = encoding_crc32(acc, buffer, read);
 
-   if ( sread < 0)
+   if (read < 0)
       return 0;
 
    *crc = acc;

--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -1115,6 +1115,35 @@ static void task_database_handler(retro_task_t *task)
             dbstate->list        = dir_list_new_special(
                   db->content_database_path,
                   DIR_LIST_DATABASES, NULL);
+
+            /* If the scan path matches a database path exactly then
+             * save time by only processing that database. */
+            if (dbstate->list && db->is_directory)
+            {
+               char *dirname = find_last_slash(db->fullpath) + 1;
+
+               for (size_t i = 0; i < dbstate->list->size; i++)
+               {
+                  char *dbpath = strdup(dbstate->list->elems[i].data);
+                  path_remove_extension(dbpath);
+                  char *dbname = find_last_slash(dbpath) + 1;
+
+                  if (strcasecmp(dbname, dirname) == 0)
+                  {
+                     free(dbpath);
+                     struct string_list *single_list = string_list_new();
+                     string_list_append(single_list, dbstate->list->elems[i].data,
+                        dbstate->list->elems[i].attr);
+                     dir_list_free(dbstate->list);
+                     dbstate->list = single_list;
+                     break;
+                  }
+                  else
+                  {
+                     free(dbpath);
+                  }
+               }
+            }
          }
          dbinfo->status = DATABASE_STATUS_ITERATE_START;
          break;


### PR DESCRIPTION
As discussed in issue #5440, directory scans are slow when compressed files must be checked against multiple databases. This commit adds support to hint to the scanner that a particular database should be used so that only a single scan is required. If the directory name being scanned matches the database name then that single database is selected.

Additionally this PR fixes a typo from 9a76a93 that broke the build.