### PR TITLE
Don't show "Enable Settings Tab" option in RGUI

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -6365,10 +6365,6 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, void *data)
                         MENU_ENUM_LABEL_START_CORE, PARSE_ACTION, false);
             }
 
-            menu_displaylist_parse_settings_enum(menu, info,
-               MENU_ENUM_LABEL_XMB_MAIN_MENU_ENABLE_SETTINGS,
-               PARSE_ACTION, false);
-
 #ifndef HAVE_DYNAMIC
             if (frontend_driver_has_fork())
 #endif


### PR DESCRIPTION
The "Enable Settings Tab" menu item shall only be available in XMB. This pull request fixes a bug where the item was visible in RGUI.