### PR TITLE
Fix conditional jump on uninitialized data

### DIFF
--- a/tasks/task_image.c
+++ b/tasks/task_image.c
@@ -322,6 +322,7 @@ bool task_push_image_load(const char *fullpath, retro_task_callback_t cb, void *
    image->status                     = IMAGE_STATUS_TRANSFER;
    image->is_blocking                = false;
    image->is_blocking_on_processing  = false;
+   image->is_finished                = false;
    image->processing_final_state     = 0;
    image->processing_pos_increment   = 0;
    image->pos_increment              = 0;


### PR DESCRIPTION
This fixes a bug introduced in 862cf481081f58e3961c6dc1430af67ac147f828