### PR TITLE
Fix background rendering when resizing window

### DIFF
--- a/menu/drivers_display/menu_display_gl.c
+++ b/menu/drivers_display/menu_display_gl.c
@@ -83,7 +83,6 @@ static void menu_display_gl_blend_begin(void)
 
    glEnable(GL_BLEND);
    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-   glEnable(GL_SCISSOR_TEST);
 
    shader_info.data       = NULL;
    shader_info.idx        = VIDEO_SHADER_STOCK_BLEND;
@@ -95,14 +94,13 @@ static void menu_display_gl_blend_begin(void)
 static void menu_display_gl_blend_end(void)
 {
    glDisable(GL_BLEND);
-   glDisable(GL_SCISSOR_TEST);
 }
 
 static void menu_display_gl_viewport(void *data)
 {
    gl_t             *gl          = (gl_t*)video_driver_get_ptr(false);
    menu_display_ctx_draw_t *draw = (menu_display_ctx_draw_t*)data;
-   
+
    if (!gl || !draw)
       return;
    glViewport(draw->x, draw->y, draw->width, draw->height);
@@ -111,7 +109,7 @@ static void menu_display_gl_viewport(void *data)
 static void menu_display_gl_bind_texture(void *data)
 {
    menu_display_ctx_draw_t *draw = (menu_display_ctx_draw_t*)data;
-   
+
    if (!draw)
       return;
 
@@ -124,7 +122,7 @@ static void menu_display_gl_draw(void *data)
    video_shader_ctx_coords_t coords;
    gl_t             *gl          = (gl_t*)video_driver_get_ptr(false);
    menu_display_ctx_draw_t *draw = (menu_display_ctx_draw_t*)data;
-   
+
    if (!gl || !draw)
       return;
 
@@ -140,11 +138,11 @@ static void menu_display_gl_draw(void *data)
 
    coords.handle_data = gl;
    coords.data        = draw->coords;
-   
+
    video_shader_driver_set_coords(coords);
 
    mvp.data   = gl;
-   mvp.matrix = draw->matrix_data ? (math_matrix_4x4*)draw->matrix_data 
+   mvp.matrix = draw->matrix_data ? (math_matrix_4x4*)draw->matrix_data
       : (math_matrix_4x4*)menu_display_gl_get_default_mvp();
 
    video_shader_driver_set_mvp(mvp);
@@ -208,7 +206,7 @@ static void menu_display_gl_draw_pipeline(void *data)
 
          uniform_param.result.f.v0       = t;
 
-         video_shader_driver_set_parameter(uniform_param);            
+         video_shader_driver_set_parameter(uniform_param);
          break;
    }
 
@@ -252,7 +250,7 @@ static bool menu_display_gl_font_init_first(
 {
    font_data_t **handle = (font_data_t**)font_handle;
    if (!(*handle = font_driver_init_first(video_data,
-         font_path, font_size, true, 
+         font_path, font_size, true,
          is_threaded,
          FONT_DRIVER_RENDER_OPENGL_API)))
 		 return false;


### PR DESCRIPTION
Removes the use of `GL_SCISSOR_TEST` in the GL display driver.

Fixes #5534