### PR TITLE
(video driver) If we can't set flag data, do it later

### DIFF
--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -587,7 +587,7 @@ bool video_context_driver_set(const gfx_ctx_driver_t *data)
 {
    if (!data)
       return false;
-   current_video_context                     = *data;
+   current_video_context = *data;
    video_context_driver_reset();
    return true;
 }


### PR DESCRIPTION
Currently, there is at least one instance where video_context_driver_set_flags() is called when current_video_context.set_flags is set to NULL (see #5538). To solve this, we create 2 new global variables - one to store flag data and the other to symbolize we deferred setting flag data.
This way, the next time we do get_flags(), we first check if we have anything stored first.

Should fix #5538