### PR TITLE
Silence compiler warnings.

### DIFF
--- a/deps/ibxm/ibxm.c
+++ b/deps/ibxm/ibxm.c
@@ -4,7 +4,7 @@
 
 #include "ibxm.h"
 
-const char *IBXM_VERSION = "ibxm/ac mod/xm/s3m replay 20170704 (c)mumart@gmail.com";
+const char *IBXM_VERSION = "ibxm/ac mod/xm/s3m replay 20170901 (c)mumart@gmail.com";
 
 static const int FP_SHIFT = 15, FP_ONE = 32768, FP_MASK = 32767;
 
@@ -92,7 +92,7 @@ static char* data_ascii( struct data *data, int offset, int length, char *dest )
 	if( offset > data->length ) {
 		offset = data->length;
 	}
-	if( offset + length > data->length ) {
+	if( ( unsigned int ) offset + length > ( unsigned int ) data->length ) {
 		length = data->length - offset;
 	}
 	for( idx = 0; idx < length; idx++ ) {


### PR DESCRIPTION
Silences these two warnings with gcc7.
```
deps/ibxm/ibxm.c: In function ‘module_load’:
deps/ibxm/ibxm.c:95:4: warning: assuming signed overflow does not occur when assuming that (X + c) >= X is always true [-Wstrict-overflow]
  if( offset + length > data->length ) {
    ^
deps/ibxm/ibxm.c:95:4: warning: assuming signed overflow does not occur when assuming that (X + c) >= X is always true [-Wstrict-overflow]
  if( offset + length > data->length ) {
    ^
```
This was fixed upstream first, see.
https://github.com/martincameron/micromod/commit/010f30e404f1b703c31c46f6e67631b98d596ac9
https://github.com/martincameron/micromod/commit/9918b696478803e3a4abea59867b34ef11053a13