### PR TITLE
win32: support local multibyte encoding for file paths

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -3701,15 +3701,15 @@ bool config_save_file(const char *path)
    if (settings->bools.ssh_enable)
       fclose(fopen(LAKKA_SSH_PATH, "w"));
    else
-      remove(LAKKA_SSH_PATH);
+      path_file_remove(LAKKA_SSH_PATH);
    if (settings->bools.samba_enable)
       fclose(fopen(LAKKA_SAMBA_PATH, "w"));
    else
-      remove(LAKKA_SAMBA_PATH);
+      path_file_remove(LAKKA_SAMBA_PATH);
    if (settings->bools.bluetooth_enable)
       fclose(fopen(LAKKA_BLUETOOTH_PATH, "w"));
    else
-      remove(LAKKA_BLUETOOTH_PATH);
+      path_file_remove(LAKKA_BLUETOOTH_PATH);
 #endif
 
    for (i = 0; i < MAX_USERS; i++)

--- a/input/input_remapping.c
+++ b/input/input_remapping.c
@@ -241,7 +241,7 @@ bool input_remapping_remove_file(const char *path)
 
    fill_pathname_noext(remap_file, buf, ".rmp", path_size);
 
-   ret = remove(remap_file) == 0 ? true : false;;
+   ret = path_file_remove(remap_file) == 0 ? true : false;;
    free(buf);
    free(remap_file);
    return ret; 

--- a/libretro-common/encodings/encoding_utf.c
+++ b/libretro-common/encodings/encoding_utf.c
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <stddef.h>
@@ -30,6 +31,15 @@
 #include <retro_inline.h>
 
 #include <encodings/utf.h>
+
+#if defined(_WIN32) && !defined(_XBOX)
+#include <windows.h>
+
+/* Starting with Windows 8: MultiByteToWideChar is declared in stringapiset.h. Before Windows 8, it was declared in winnls.h (which windows.h includes for us). */
+#ifndef MultiByteToWideChar
+#include <stringapiset.h>
+#endif
+#endif
 
 static INLINE unsigned leading_ones(uint8_t c)
 {
@@ -260,3 +270,81 @@ bool utf16_to_char_string(const uint16_t *in, char *s, size_t len)
 
    return ret;
 }
+
+/* Returned pointer MUST be freed by the caller if non-NULL. */
+static char* mb_to_mb_string_alloc(const char *str, enum CodePage cp_in, enum CodePage cp_out)
+{
+   char *path_buf = NULL;
+   wchar_t *path_buf_wide = NULL;
+   int path_buf_len = 0;
+   int path_buf_wide_len = 0;
+
+   if (!str || !*str)
+      return NULL;
+
+#if !defined(_WIN32) || defined(_XBOX)
+   /* assume string needs no modification if not on Windows */
+   return strdup(str);
+#else
+#ifdef UNICODE
+   /* TODO/FIXME: Not implemented. */
+   return strdup(str);
+#else
+
+   path_buf_wide_len = MultiByteToWideChar(cp_in, 0, str, -1, NULL, 0);
+
+   if (path_buf_wide_len)
+   {
+      path_buf_wide = (wchar_t*)calloc(path_buf_wide_len + sizeof(wchar_t), sizeof(wchar_t));
+
+      if (path_buf_wide)
+      {
+         MultiByteToWideChar(cp_in, 0, str, -1, path_buf_wide, path_buf_wide_len);
+
+         if (*path_buf_wide)
+         {
+            path_buf_len = WideCharToMultiByte(cp_out, 0, path_buf_wide, -1, NULL, 0, NULL, NULL);
+
+            if (path_buf_len)
+            {
+               path_buf = (char*)calloc(path_buf_len + sizeof(char), sizeof(char));
+
+               if (path_buf)
+               {
+                  WideCharToMultiByte(cp_out, 0, path_buf_wide, -1, path_buf, path_buf_len, NULL, NULL);
+
+                  free(path_buf_wide);
+
+                  if (*path_buf)
+                     return path_buf;
+                  else
+                  {
+                     free(path_buf);
+                     return NULL;
+                  }
+               }
+            }
+         }
+      }
+   }
+#endif
+#endif
+
+   if (path_buf_wide)
+      free(path_buf_wide);
+
+   return NULL;
+}
+
+/* Returned pointer MUST be freed by the caller if non-NULL. */
+char* utf8_to_local_string_alloc(const char *str)
+{
+   return mb_to_mb_string_alloc(str, CODEPAGE_UTF8, CODEPAGE_LOCAL);
+}
+
+/* Returned pointer MUST be freed by the caller if non-NULL. */
+char* local_to_utf8_string_alloc(const char *str)
+{
+   return mb_to_mb_string_alloc(str, CODEPAGE_LOCAL, CODEPAGE_UTF8);
+}
+

--- a/libretro-common/include/encodings/utf.h
+++ b/libretro-common/include/encodings/utf.h
@@ -32,6 +32,12 @@
 
 RETRO_BEGIN_DECLS
 
+enum CodePage
+{
+   CODEPAGE_LOCAL = 0, /* CP_ACP */
+   CODEPAGE_UTF8 = 65001 /* CP_UTF8 */
+};
+
 size_t utf8_conv_utf32(uint32_t *out, size_t out_chars,
       const char *in, size_t in_size);
 
@@ -47,6 +53,10 @@ const char *utf8skip(const char *str, size_t chars);
 uint32_t utf8_walk(const char **string);
 
 bool utf16_to_char_string(const uint16_t *in, char *s, size_t len);
+
+char* utf8_to_local_string_alloc(const char *str);
+
+char* local_to_utf8_string_alloc(const char *str);
 
 RETRO_END_DECLS
 

--- a/libretro-common/include/file/file_path.h
+++ b/libretro-common/include/file/file_path.h
@@ -466,6 +466,8 @@ bool path_is_valid(const char *path);
 
 int32_t path_get_size(const char *path);
 
+int path_file_remove(const char *path);
+
 RETRO_END_DECLS
 
 #endif

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -2643,7 +2643,7 @@ static void cb_decompressed(void *task_data, void *user_data, const char *err)
    if (dec)
    {
       if (path_file_exists(dec->source_file))
-         remove(dec->source_file);
+         path_file_remove(dec->source_file);
 
       free(dec->source_file);
       free(dec);
@@ -4242,7 +4242,7 @@ static int action_ok_core_delete(const char *path,
    generic_action_ok_command(CMD_EVENT_UNLOAD_CORE);
    menu_entries_flush_stack(0, 0);
 
-   if (remove(core_path) != 0) { }
+   if (path_file_remove(core_path) != 0) { }
 
    free(core_path);
 

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -1860,7 +1860,7 @@ static void systemd_service_toggle(const char *path, char *unit, bool enable)
    if (enable)
       fclose(fopen(path, "w"));
    else
-      remove(path);
+      path_file_remove(path);
 
    if (pid == 0)
       execvp(args[0], args);

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -1717,7 +1717,7 @@ void content_deinit(void)
 
          RARCH_LOG("%s: %s.\n",
                msg_hash_to_str(MSG_REMOVING_TEMPORARY_CONTENT_FILE), path);
-         if (remove(path) < 0)
+         if (path_file_remove(path) < 0)
             RARCH_ERR("%s: %s.\n",
                   msg_hash_to_str(MSG_FAILED_TO_REMOVE_TEMPORARY_FILE),
                   path);


### PR DESCRIPTION
Fixes #5019. This allows for example the file browser to show and be able to load content with non-latin characters such as Japanese.