### PR TITLE
Fix compilation with --enable-xshm.

### DIFF
--- a/gfx/drivers/xshm_gfx.c
+++ b/gfx/drivers/xshm_gfx.c
@@ -255,7 +255,7 @@ video_driver_t video_xshm = {
    xshm_gfx_alive,
    xshm_gfx_focus,
    xshm_gfx_suppress_screensaver,
-   xshm_gfx_has_windowed,
+   NULL, /* has_windowed */
    xshm_gfx_set_shader,
    xshm_gfx_free,
    "xshm",


### PR DESCRIPTION
Fixes https://github.com/libretro/RetroArch/issues/5551.

Please note I did not test beyond compilation as the xshm driver does not seem to work here? This seems it was just forgotten in commit https://github.com/libretro/RetroArch/commit/d4756f83e55a58d1df322f6a6e9b39b5c9bdc0f6.