### PR TITLE
qb: Don't use variables in the printf format string.

### DIFF
--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -26,7 +26,7 @@ check_lib()	#$1 = HAVE_$1	$2 = lib	$3 = function in lib	$4 = extralibs $5 = head
 	if [ "$3" ]; then
 		ECHOBUF="Checking function $3 in ${2% }"
 		if [ "$5" ]; then
-			printf "$5\nint main(void) { void *p = (void*)$3; return 0; }" > $TEMP_C
+			printf %s\\n "$5" "int main(void) { void *p = (void*)$3; return 0; }" > $TEMP_C
 		else
 			echo "void $3(void); int main(void) { $3(); return 0; }" > $TEMP_C
 		fi


### PR DESCRIPTION
This should be a more portable way to printf more than one line and silences these two http://www.shellcheck.net/ warnings.
```
Line 31:
                        printf "$5\nint main(void) { void *p = (void*)$3; return 0; }" > $TEMP_C
                               ^-- SC2059: Don't use variables in the printf format string. Use printf "..%s.." "$foo".
                                  ^-- SC1117: Backslash is literal in "\n". Prefer explicit escaping: "\\n".
```
https://github.com/koalaman/shellcheck/wiki/SC2059
https://github.com/koalaman/shellcheck/wiki/SC1117