### PR TITLE
Add experimental way to make max_swapchain=2 work Rpi with GLES on dispmanx

### DIFF
--- a/gfx/drivers_context/vc_egl_ctx.c
+++ b/gfx/drivers_context/vc_egl_ctx.c
@@ -311,6 +311,15 @@ static bool gfx_ctx_vc_set_video_mode(void *data,
    frontend_driver_install_signal_handler();
    gfx_ctx_vc_set_swap_interval(&vc->egl, vc->egl.interval);
 
+   /* If we set this env variable, Broadcom's EGL implementation will block
+    * on vsync with a double buffer when we call eglSwapBuffers. Less input lag!  */
+   if (video_info->max_swapchain_images <= 2)
+      setenv("V3D_DOUBLE_BUFFER", "1", 1);
+   else
+      setenv("V3D_DOUBLE_BUFFER", "0", 1);
+
+   gfx_ctx_vc_set_swap_interval(&vc->egl, vc->egl.interval);
+
    g_egl_inited = true;
 #endif
 


### PR DESCRIPTION
On the Raspberry Pi, when using the propietary graphics stack, double buffer (low input lag) was only possible when using the plain dispmanx graphics backend. So the max_swapchain=2 option was ignored on this configuration.
With this small patch, eglSwapBuffers() is supposed to wait for vsync and NOT triple-buffer when max_swapchain=2. It was found out thanks to popcornmix on this thread:
https://github.com/raspberrypi/userland/issues/432