### PR TITLE
Added Fuse so that it has an APP_UNIQUE_ID

### DIFF
--- a/ctr/Makefile.cores
+++ b/ctr/Makefile.cores
@@ -210,4 +210,11 @@ else ifeq ($(LIBRETRO), dosbox)
 	APP_ICON            = ctr/assets/dosbox.png
 	APP_BANNER          = ctr/assets/dosbox_banner.png
 
+else ifeq ($(LIBRETRO), fuse)
+	APP_TITLE           = Fuse
+	APP_PRODUCT_CODE    = RARCH-FUSE
+	APP_UNIQUE_ID       = 0xBAC1C
+	APP_ICON            = ctr/assets/fuse.png
+	APP_BANNER          = ctr/assets/fuse_banner.png
+
 endif


### PR DESCRIPTION
Will add 81 and np2kai when I have created icons and banners for them and after checking this fixes things for Fuse in the next nightly.