### PR TITLE
Fix configure for zsh.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -520,6 +520,6 @@ fi
 
 # Creates config.mk and config.h.
 add_define_make GLOBAL_CONFIG_DIR "$GLOBAL_CONFIG_DIR"
-VARS=$(eval set | grep ^HAVE_ | sed s/=.*// | sed s/^HAVE_//)
-create_config_make config.mk $VARS
-create_config_header config.h $VARS
+VARS=$(eval set | grep ^HAVE_ | sed 's/=.*//' | sed 's/^HAVE_//')
+create_config_make config.mk $(printf %s "$VARS")
+create_config_header config.h $(printf %s "$VARS")

--- a/qb/qb.comp.sh
+++ b/qb/qb.comp.sh
@@ -14,7 +14,7 @@ cc_works=0
 if [ "$CC" ]; then
 	"$CC" -o "$TEMP_EXE" "$TEMP_C" >/dev/null 2>&1 && cc_works=1
 else
-	for CC in ${CC:=$(which ${CROSS_COMPILE}gcc ${CROSS_COMPILE}cc ${CROSS_COMPILE}clang 2>/dev/null)} ''; do
+	for CC in $(printf %s "${CC:=$(which ${CROSS_COMPILE}gcc ${CROSS_COMPILE}cc ${CROSS_COMPILE}clang 2>/dev/null)}") ''; do
 		"$CC" -o "$TEMP_EXE" "$TEMP_C" >/dev/null 2>&1 && cc_works=1 && break
 	done
 fi
@@ -45,7 +45,7 @@ cxx_works=0
 if [ "$CXX" ]; then
 	"$CXX" -o "$TEMP_EXE" "$TEMP_CXX" >/dev/null 2>&1 && cxx_works=1
 else
-	for CXX in ${CXX:=$(which ${CROSS_COMPILE}g++ ${CROSS_COMPILE}c++ ${CROSS_COMPILE}clang++ 2>/dev/null)} ''; do
+	for CXX in $(printf %s "${CXX:=$(which ${CROSS_COMPILE}g++ ${CROSS_COMPILE}c++ ${CROSS_COMPILE}clang++ 2>/dev/null)}") ''; do
 		"$CXX" -o "$TEMP_EXE" "$TEMP_CXX" >/dev/null 2>&1 && cxx_works=1 && break
 	done
 fi

--- a/qb/qb.comp.sh
+++ b/qb/qb.comp.sh
@@ -78,9 +78,9 @@ fi
 [ -n "$PKG_CONF_PATH" ] || {
 	PKG_CONF_PATH="none"
 
-	for path in $(which "${CROSS_COMPILE}pkg-config" 2>/dev/null) ''; do
-		[ -n "$path" ] && {
-			PKG_CONF_PATH=$path;
+	for p in $(which "${CROSS_COMPILE}pkg-config" 2>/dev/null) ''; do
+		[ -n "$p" ] && {
+			PKG_CONF_PATH=$p;
 			break;
 		}
 	done

--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -40,7 +40,7 @@ check_lib()	#$1 = HAVE_$1	$2 = lib	$3 = function in lib	$4 = extralibs $5 = head
 	fi
 	answer='no'
 #	echo -n "$ECHOBUF"
-	"$CC" -o "$TEMP_EXE" "$TEMP_C" $INCLUDE_DIRS $LIBRARY_DIRS $4 $CFLAGS $LDFLAGS $2 >>config.log 2>&1 && answer='yes'
+	"$CC" -o "$TEMP_EXE" "$TEMP_C" $INCLUDE_DIRS $LIBRARY_DIRS $(printf %s "$4") $CFLAGS $LDFLAGS $(printf %s "$2") >>config.log 2>&1 && answer='yes'
 	eval HAVE_$1="$answer"; echo "$ECHOBUF ... $answer"
 	rm "$TEMP_C" "$TEMP_EXE" >/dev/null 2>&1
 	
@@ -65,7 +65,7 @@ check_lib_cxx()	#$1 = HAVE_$1	$2 = lib	$3 = function in lib	$4 = extralibs	$5 = 
 	fi
 	answer='no'
 #	echo -n "$ECHOBUF"
-	"$CXX" -o "$TEMP_EXE" "$TEMP_CXX" $INCLUDE_DIRS $LIBRARY_DIRS $4 $CFLAGS $LDFLAGS $2 >>config.log 2>&1 && answer='yes'
+	"$CXX" -o "$TEMP_EXE" "$TEMP_CXX" $INCLUDE_DIRS $LIBRARY_DIRS $(printf %s "$4") $CFLAGS $LDFLAGS $(printf %s "$2") >>config.log 2>&1 && answer='yes'
 	eval HAVE_$1="$answer"; echo "$ECHOBUF ... $answer"
 	rm "$TEMP_CXX" "$TEMP_EXE" >/dev/null 2>&1
 	[ "$answer" = 'no' ] && {

--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -40,7 +40,15 @@ check_lib()	#$1 = HAVE_$1	$2 = lib	$3 = function in lib	$4 = extralibs $5 = head
 	fi
 	answer='no'
 #	echo -n "$ECHOBUF"
-	"$CC" -o "$TEMP_EXE" "$TEMP_C" $INCLUDE_DIRS $LIBRARY_DIRS $(printf %s "$4") $CFLAGS $LDFLAGS $(printf %s "$2") >>config.log 2>&1 && answer='yes'
+	"$CC" -o \
+		"$TEMP_EXE" \
+		"$TEMP_C" \
+		$INCLUDE_DIRS \
+		$LIBRARY_DIRS \
+		$(printf %s "$4") \
+		$CFLAGS \
+		$LDFLAGS \
+		$(printf %s "$2") >>config.log 2>&1 && answer='yes'
 	eval HAVE_$1="$answer"; echo "$ECHOBUF ... $answer"
 	rm "$TEMP_C" "$TEMP_EXE" >/dev/null 2>&1
 	
@@ -65,7 +73,15 @@ check_lib_cxx()	#$1 = HAVE_$1	$2 = lib	$3 = function in lib	$4 = extralibs	$5 = 
 	fi
 	answer='no'
 #	echo -n "$ECHOBUF"
-	"$CXX" -o "$TEMP_EXE" "$TEMP_CXX" $INCLUDE_DIRS $LIBRARY_DIRS $(printf %s "$4") $CFLAGS $LDFLAGS $(printf %s "$2") >>config.log 2>&1 && answer='yes'
+	"$CXX" -o \
+		"$TEMP_EXE" \
+		"$TEMP_CXX" \
+		$INCLUDE_DIRS \
+		$LIBRARY_DIRS \
+		$(printf %s "$4") \
+		$CFLAGS \
+		$LDFLAGS \
+		$(printf %s "$2") >>config.log 2>&1 && answer='yes'
 	eval HAVE_$1="$answer"; echo "$ECHOBUF ... $answer"
 	rm "$TEMP_CXX" "$TEMP_EXE" >/dev/null 2>&1
 	[ "$answer" = 'no' ] && {

--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -14,10 +14,14 @@ add_define_make()
 { echo "$1=$2" >> "$MAKEFILE_DEFINES";}
 
 add_include_dirs()
-{	while [ "$1" ]; do INCLUDE_DIRS="$INCLUDE_DIRS -I$1"; shift; done;}
+{	while [ "$1" ]; do INCLUDE_DIRS="$INCLUDE_DIRS -I$1"; shift; done
+	INCLUDE_DIRS="${INCLUDE_DIRS#* }"
+}
 
 add_library_dirs()
-{	while [ "$1" ]; do LIBRARY_DIRS="$LIBRARY_DIRS -L$1"; shift; done;}
+{	while [ "$1" ]; do LIBRARY_DIRS="$LIBRARY_DIRS -L$1"; shift; done
+	LIBRARY_DIRS="${LIBRARY_DIRS#* }"
+}
 
 check_lib()	#$1 = HAVE_$1	$2 = lib	$3 = function in lib	$4 = extralibs $5 = headers
 {	tmpval="$(eval echo \$HAVE_$1)"

--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -266,8 +266,10 @@ create_config_make()
 			
 			case "$PKG_CONF_USED" in
 				*$1*)
-					echo "$1_CFLAGS = $(eval echo \$$1_CFLAGS)"
-					echo "$1_LIBS = $(eval echo \$$1_LIBS)"
+					FLAGS="$(eval echo \$$1_CFLAGS)"
+					LIBS="$(eval echo \$$1_LIBS)"
+					echo "$1_CFLAGS = ${FLAGS%"${FLAGS##*[! ]}"}"
+					echo "$1_LIBS = ${LIBS%"${LIBS##*[! ]}"}"
 				;;
 			esac
 			shift


### PR DESCRIPTION
These issues are present if someone tries to configure RetroArch with `zsh configure`, but not if `/bin/sh` is a symlink to zsh. After this the configure script should work just as well with zsh as it does with sh or bash.

Fixing them should not show any change in behavior for other unix shells and accomplishes this with more explicit behavior, it would be nice if someone could test this PR on windows to be sure.