### PR TITLE
Don't install retroarch.cfg to /etc if --prefix is not set to /usr*

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,6 @@ TARGET = retroarch
 
 OBJDIR := obj-unix
 
-ifeq ($(GLOBAL_CONFIG_DIR),)
-   GLOBAL_CONFIG_DIR = /etc
-endif
-
 OBJ :=
 LIBS :=
 DEFINES := -DHAVE_CONFIG_H -DRARCH_INTERNAL -DHAVE_OVERLAY

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -10,6 +10,13 @@ add_define_make NOUNUSED_VARIABLE "$HAVE_NOUNUSED_VARIABLE"
 
 [ -z "$CROSS_COMPILE" ] && [ -d /opt/local/lib ] && add_library_dirs /opt/local/lib
 
+[ "$GLOBAL_CONFIG_DIR" ] || \
+{	case "$PREFIX" in
+		/usr*) GLOBAL_CONFIG_DIR=/etc ;;
+		*) GLOBAL_CONFIG_DIR="$PREFIX"/etc ;;
+	esac
+}
+
 DYLIB=-ldl;
 CLIB=-lc
 PTHREADLIB=-lpthread


### PR DESCRIPTION
This should work better for `make install` without root permissions. The idea is that is `$GLOBAL_CONFIG_DIR` is not defined and `$PREFIX` is set to something that is not `/usr*` then it will set the `$GLOBAL_CONFIG_DIR` to `$PREFIX/etc` instead of `/etc`. There should be no change to the default behavior. Additionally this no longer needs to be handled in the `Makefile` and can be done in `qb/config.libs.sh` instead.

Also see this issue. https://github.com/libretro/RetroArch/issues/4074