### PR TITLE
Return to content when Reset is used.

### DIFF
--- a/command.c
+++ b/command.c
@@ -1804,7 +1804,7 @@ bool command_event(enum event_command cmd, void *data)
 #if HAVE_NETWORKING
          netplay_driver_ctl(RARCH_NETPLAY_CTL_RESET, NULL);
 #endif
-         break;
+         return command_event_main_state(cmd);
       case CMD_EVENT_SAVE_STATE:
          {
             settings_t *settings      = config_get_ptr();


### PR DESCRIPTION
When `Reset` is used from the quick menu it will return to the content automatically instead of waiting for the user to exit the menu. This matches the behavior of `Save State` and `Load State`.

Fixes https://github.com/libretro/RetroArch/issues/4805.
