### PR TITLE
qb: Explicitly set variables as a single command.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -122,7 +122,7 @@ if [ "$HAVE_EGL" != "no" -a "$OS" != 'Win32' ]; then
    check_pkgconf EGL "$VC_PREFIX"egl
    # some systems have EGL libs, but no pkgconfig
    if [ "$HAVE_EGL" = "no" ]; then
-      HAVE_EGL=auto && check_lib EGL "-l"$VC_PREFIX"EGL $EXTRA_GL_LIBS"
+      HAVE_EGL=auto; check_lib EGL "-l"$VC_PREFIX"EGL $EXTRA_GL_LIBS"
       [ "$HAVE_EGL" = "yes" ] && EGL_LIBS=-l"$VC_PREFIX"EGL
    else
       EGL_LIBS="$EGL_LIBS $EXTRA_GL_LIBS"
@@ -383,14 +383,17 @@ if [ "$HAVE_EGL" = "yes" ]; then
          add_define_make OPENGLES_LIBS "$OPENGLES_LIBS"
          add_define_make OPENGLES_CFLAGS "$OPENGLES_CFLAGS"
       else
-         HAVE_OPENGLES=auto check_pkgconf OPENGLES "$VC_PREFIX"glesv2
-         [ "$HAVE_OPENGLES" = "no" ] && HAVE_OPENGLES=auto check_lib OPENGLES "-l"$VC_PREFIX"GLESv2 $EXTRA_GL_LIBS" && add_define_make OPENGLES_LIBS "-l"$VC_PREFIX"GLESv2 $EXTRA_GL_LIBS"
+         HAVE_OPENGLES=auto; check_pkgconf OPENGLES "$VC_PREFIX"glesv2
+         if [ "$HAVE_OPENGLES" = "no" ]; then
+            HAVE_OPENGLES=auto; check_lib OPENGLES "-l"$VC_PREFIX"GLESv2 $EXTRA_GL_LIBS"
+            add_define_make OPENGLES_LIBS "-l"$VC_PREFIX"GLESv2 $EXTRA_GL_LIBS"
+         fi
       fi
    fi
    if [ "$HAVE_VG" != "no" ]; then
       check_pkgconf VG "$VC_PREFIX"vg
       if [ "$HAVE_VG" = "no" ]; then
-         HAVE_VG=auto check_lib VG "-l"$VC_PREFIX"OpenVG $EXTRA_GL_LIBS"
+         HAVE_VG=auto; check_lib VG "-l"$VC_PREFIX"OpenVG $EXTRA_GL_LIBS"
          [ "$HAVE_VG" = "yes" ] && VG_LIBS=-l"$VC_PREFIX"OpenVG
       fi
    fi
@@ -437,7 +440,7 @@ fi
 if [ "$HAVE_UDEV" != "no" ]; then
    check_pkgconf UDEV libudev
    if [ "$HAVE_UDEV" = "no" ]; then
-      HAVE_UDEV=auto && check_lib UDEV "-ludev"
+      HAVE_UDEV=auto; check_lib UDEV "-ludev"
       [ "$HAVE_UDEV" = "yes" ] && UDEV_LIBS=-ludev
    fi
 fi


### PR DESCRIPTION
With some shells like the linux port of the openbsd version of pdksh if RetroArch is configured with `pdksh configure` it will swallow `HAVE_VG` from both `config.h` and `config.mk`. This can be avoided by not setting `HAVE_$1` as an environment variable and do it explicitly as its own command.

So this commit does three things.
1. Explicitly sets variables as a single command.
2. In cases where this was already done with `&&` change it to `;` as setting a variable will never fail.
3. Cleans up a long line for future readability.