### PR TITLE
qb: Use POSIX character classes instead of character ranges.

### DIFF
--- a/qb/qb.params.sh
+++ b/qb/qb.params.sh
@@ -30,7 +30,7 @@ EOF
 	echo "Custom options:"
 
 	while IFS='=#' read VAR VAL COMMENT; do
-		VAR=$(echo "${VAR##HAVE_}" | tr '[A-Z]' '[a-z]')
+		VAR=$(echo "${VAR##HAVE_}" | tr '[:upper:]' '[:lower:]')
 		case "$VAR" in
 			'c89_'*) true;;
 			*)
@@ -50,7 +50,7 @@ EOF
 }
 
 opt_exists() # $opt is returned if exists in OPTS
-{	opt=$(echo "$1" | tr '[a-z]' '[A-Z]')
+{	opt=$(echo "$1" | tr '[:lower:]' '[:upper:]')
 	for OPT in $OPTS; do [ "$opt" = "$OPT" ] && return; done
 	echo "Unknown option $2"; exit 1
 }


### PR DESCRIPTION
In practice this doesn't really make any difference for RetroArch, but there is no harm in doing this to silence some http://www.shellcheck.net/ warnings.
```
Line 35:
                VAR=$(echo "${VAR##HAVE_}" | tr '[A-Z]' '[a-z]')
                                                ^-- SC2021: Don't use [] around classes in tr, it replaces literal square brackets.
                                                        ^-- SC2021: Don't use [] around classes in tr, it replaces literal square brackets.

Line 55:
{        opt=$(echo "$1" | tr '[a-z]' '[A-Z]')
                             ^-- SC2021: Don't use [] around classes in tr, it replaces literal square brackets.
                                     ^-- SC2021: Don't use [] around classes in tr, it replaces literal square brackets.
```
For more info see these two links.
https://github.com/koalaman/shellcheck/wiki/SC2021
http://pubs.opengroup.org/onlinepubs/9699919799/utilities/tr.html