### PR TITLE
qb: Avoid using 'true' which could be a binary on some systems.

### DIFF
--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -57,7 +57,7 @@ check_lib()	#$1 = HAVE_$1	$2 = lib	$3 = function in lib	$4 = extralibs $5 = head
 		exit 1
 	}
 
-	true
+	return 0
 }
 
 check_lib_cxx()	#$1 = HAVE_$1	$2 = lib	$3 = function in lib	$4 = extralibs	$5 = critical error message [checked only if non-empty]
@@ -93,7 +93,7 @@ check_lib_cxx()	#$1 = HAVE_$1	$2 = lib	$3 = function in lib	$4 = extralibs	$5 = 
 	
 	}
 
-	true
+	return 0
 }
 
 check_code_c()

--- a/qb/qb.params.sh
+++ b/qb/qb.params.sh
@@ -32,7 +32,7 @@ EOF
 	while IFS='=#' read VAR VAL COMMENT; do
 		VAR=$(echo "${VAR##HAVE_}" | tr '[:upper:]' '[:lower:]')
 		case "$VAR" in
-			'c89_'*) true;;
+			'c89_'*) continue;;
 			*)
 			case "$VAL" in
 				'yes'*)


### PR DESCRIPTION
Minor clean up. On some systems `true` could be `/bin/true` and not a shell builtin. Its better to use `return` and `continue` here as they fit the specific use better and will always be shell builtins even on legacy true bourne shells like hsh or osh.