### PR TITLE
qb: Remove redundant variables.

### DIFF
--- a/qb/qb.comp.sh
+++ b/qb/qb.comp.sh
@@ -14,7 +14,7 @@ cc_works=0
 if [ "$CC" ]; then
 	"$CC" -o "$TEMP_EXE" "$TEMP_C" >/dev/null 2>&1 && cc_works=1
 else
-	for CC in $(printf %s "${CC:=$(which ${CROSS_COMPILE}gcc ${CROSS_COMPILE}cc ${CROSS_COMPILE}clang 2>/dev/null)}") ''; do
+	for CC in $(printf %s "$(which ${CROSS_COMPILE}gcc ${CROSS_COMPILE}cc ${CROSS_COMPILE}clang 2>/dev/null)") ''; do
 		"$CC" -o "$TEMP_EXE" "$TEMP_C" >/dev/null 2>&1 && cc_works=1 && break
 	done
 fi
@@ -45,7 +45,7 @@ cxx_works=0
 if [ "$CXX" ]; then
 	"$CXX" -o "$TEMP_EXE" "$TEMP_CXX" >/dev/null 2>&1 && cxx_works=1
 else
-	for CXX in $(printf %s "${CXX:=$(which ${CROSS_COMPILE}g++ ${CROSS_COMPILE}c++ ${CROSS_COMPILE}clang++ 2>/dev/null)}") ''; do
+	for CXX in $(printf %s "$(which ${CROSS_COMPILE}g++ ${CROSS_COMPILE}c++ ${CROSS_COMPILE}clang++ 2>/dev/null)") ''; do
 		"$CXX" -o "$TEMP_EXE" "$TEMP_CXX" >/dev/null 2>&1 && cxx_works=1 && break
 	done
 fi


### PR DESCRIPTION
`$CC` and `$CXX` are set by the `for` loop and do not need to be set again with `${CC:=$(which ...)}` as it will `break` out of the loop as soon as it finds its match or will be set to a blank variable which is always the intended compiler in this case. Additionally it silences these new http://www.shellcheck.net/ warnings which are my fault from a previous commit, but they do not have any negative effect on the qb scripts because of the above.
```
Line 17:
        for CC in $(printf %s "${CC:=$(which ${CROSS_COMPILE}gcc ${CROSS_COMPILE}cc ${CROSS_COMPILE}clang 2>/dev/null)}") ''; do
                               ^-- SC2030: Modification of CC is local (to subshell caused by $(..) expansion).

Line 18:
                "$CC" -o "$TEMP_EXE" "$TEMP_C" >/dev/null 2>&1 && cc_works=1 && break
                 ^-- SC2031: CC was modified in a subshell. That change might be lost.

Line 27:
elif [ -z "$CC" ]; then
           ^-- SC2031: CC was modified in a subshell. That change might be lost.
 
Line 31:
echo "Checking for suitable working C compiler ... $CC $cc_status"
                                                   ^-- SC2031: CC was modified in a subshell. That change might be lost.
 
Line 48:
        for CXX in $(printf %s "${CXX:=$(which ${CROSS_COMPILE}g++ ${CROSS_COMPILE}c++ ${CROSS_COMPILE}clang++ 2>/dev/null)}") ''; do
                                ^-- SC2030: Modification of CXX is local (to subshell caused by $(..) expansion).

Line 49:
                "$CXX" -o "$TEMP_EXE" "$TEMP_CXX" >/dev/null 2>&1 && cxx_works=1 && break
                 ^-- SC2031: CXX was modified in a subshell. That change might be lost.
 
Line 58:
elif [ -z "$CXX" ]; then
           ^-- SC2031: CXX was modified in a subshell. That change might be lost.
 
Line 62:
echo "Checking for suitable working C++ compiler ... $CXX $cxx_status"
                                                     ^-- SC2031: CXX was modified in a subshell. That change might be lost.
```