### PR TITLE
qb: Remove poorly defined test behavior.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -118,7 +118,7 @@ if [ "$HAVE_SSE" = "yes" ]; then
    CXXFLAGS="$CXXFLAGS -msse -msse2"
 fi
 
-if [ "$HAVE_EGL" != "no" -a "$OS" != 'Win32' ]; then
+if [ "$HAVE_EGL" != "no" ] && [ "$OS" != 'Win32' ]; then
    check_pkgconf EGL "$VC_PREFIX"egl
    # some systems have EGL libs, but no pkgconfig
    if [ "$HAVE_EGL" = "no" ]; then


### PR DESCRIPTION
Using `-a` or `-o` operators with `test` is poorly defined and using `&&` or `||` is preferred. Additionally this matches the style of the rest of the qb script better.

This also silences the following http://www.shellcheck.net/ warning.
```

Line 121:
if [ "$HAVE_EGL" != "no" -a "$OS" != 'Win32' ]; then
                         ^-- SC2166: Prefer [ p ] && [ q ] as [ p -a q ] is not well defined.
```
https://github.com/koalaman/shellcheck/wiki/SC2166