### PR TITLE
qb: Don't use sed.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -513,6 +513,12 @@ fi
 
 # Creates config.mk and config.h.
 add_define_make GLOBAL_CONFIG_DIR "$GLOBAL_CONFIG_DIR"
-VARS=$(eval set | grep ^HAVE_ | sed 's/=.*//' | sed 's/^HAVE_//')
+set -- $(set | grep ^HAVE_)
+while [ $# -gt 0 ]; do
+   tmpvar="${1%=*}"
+   shift 1
+   var="${tmpvar#HAVE_}"
+   VARS="${VARS} $var"
+done
 create_config_make config.mk $(printf %s "$VARS")
 create_config_header config.h $(printf %s "$VARS")


### PR DESCRIPTION
This replaces the only two uses of sed with pure shell. It also removes an unnecessary use of eval.