### PR TITLE
qb: Sort set variables.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -518,7 +518,8 @@ while [ $# -gt 0 ]; do
    tmpvar="${1%=*}"
    shift 1
    var="${tmpvar#HAVE_}"
-   VARS="${VARS} $var"
+   vars="${vars} $var"
 done
+VARS="$(printf %s "$vars" | tr ' ' '\n' | sort)"
 create_config_make config.mk $(printf %s "$VARS")
 create_config_header config.h $(printf %s "$VARS")


### PR DESCRIPTION
Not all shells will sort the variables with `set` and this can lead to differences in the contents order of `config.h` and `config.mk`. Additionally piping `set` to `sort` can have strange and inconsistent behavior like ordering `SDL2` before `SDL` in some shells. So taking an extra step to sort the set variables makes sure the order will always be the same.