### PR TITLE
qb: Don't check for strlcpy on linux.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -450,7 +450,7 @@ check_header XSHM X11/Xlib.h X11/extensions/XShm.h
 check_header PARPORT linux/parport.h
 check_header PARPORT linux/ppdev.h
 
-if [ "$OS" != 'Win32' ]; then
+if [ "$OS" != 'Win32' ] && [ "$OS" != 'Linux' ]; then
    check_lib STRL "$CLIB" strlcpy
 fi
 check_lib STRCASESTR "$CLIB" strcasestr


### PR DESCRIPTION
My understanding is that `strlcpy` is not included with Linux libc, but is with BSD, osx and other unix variants so we should be able to skip testing for it if `$OS != Linux`.
This silences this error in `config.h`.
```
/tmp/cctAZHsy.o: In function `main':
.tmp.c:(.text+0x5): undefined reference to `strlcpy'
collect2: error: ld returned 1 exit status
```
It will also have this diff config.h and config.mk.

config.h
```
--- config.h.old	2017-10-27 11:07:54.190423697 -0700
+++ config.h	2017-10-27 11:14:20.514009784 -0700
@@ -105,7 +105,6 @@
 #define HAVE_STB_VORBIS 1
 #define HAVE_STDIN_CMD 1
 #define HAVE_STRCASESTR 1
-/* #undef HAVE_STRL */
 /* #undef HAVE_SUNXI */
 #define HAVE_SWRESAMPLE 1
 #define HAVE_SWSCALE 1
```
config.mk
```
--- config.mk.old	2017-10-27 11:07:51.726400816 -0700
+++ config.mk	2017-10-27 11:14:20.322008001 -0700
@@ -154,7 +154,6 @@
 HAVE_STB_VORBIS = 1
 HAVE_STDIN_CMD = 1
 HAVE_STRCASESTR = 1
-HAVE_STRL = 0
 HAVE_SUNXI = 0
 HAVE_SWRESAMPLE = 1
 SWRESAMPLE_CFLAGS = 
```