### PR TITLE
Simplified condition in `while`

### DIFF
--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -616,7 +616,7 @@ static bool make_proc_acpi_key_val(char **_ptr, char **_key, char **_val)
 
     *(ptr++) = '\0';  /* terminate the key. */
 
-    while ((*ptr == ' ') && (*ptr != '\0'))
+    while (*ptr == ' ')
         ptr++;  /* skip whitespace. */
 
     if (*ptr == '\0')


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A warning, found using PVS-Studio:
RetroArch/frontend/drivers/platform_unix.c  619     err     V590 Consider inspecting the '(* ptr == ' ') && (* ptr != '\\0')' expression. The expression is excessive or contains a misprint.

If `*ptr` value equals ' ', then condition `if(*ptr != '\0')` will always true