### PR TITLE
Fix documentation center links

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ or visit our IRC channel: #retroarch @ irc.freenode.org.
 
 ## Documentation
 
-See our [Documentation Center](https://buildbot.libretro.com/docs). On Unix, man-pages are provided.
+See our [Documentation Center](http://docs.libretro.com). On Unix, man-pages are provided.
 More developer-centric stuff is found [here](https://github.com/libretro/libretro.github.com/wiki/Documentation-devs).
 
 ## Related projects
@@ -131,4 +131,4 @@ To configure joypads, use the built-in menu or the `retroarch-joyconfig` command
 
 ## Compiling and installing
 
-Instructions for compiling and installing RetroArch can be found in the [Libretro/RetroArch Documentation Center](https://buildbot.libretro.com/docs).
+Instructions for compiling and installing RetroArch can be found in the [Libretro/RetroArch Documentation Center](http://docs.libretro.com).


### PR DESCRIPTION
Use docs.libretro.com instead of buildbot links.

From https://github.com/libretro/RetroArch/pull/5623