### PR TITLE
Replace 'PC' with the operating system name

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,11 @@ RetroArch also emphasizes on being easy to integrate into various launcher front
 
 ## Platforms
 
-RetroArch has been ported to the following platforms besides the PC:
+RetroArch has been ported to the following platforms:
 
+   - Windows
+   - Linux
+   - MacOS
    - PlayStation 3
    - PlayStation Portable
    - Original Xbox


### PR DESCRIPTION
"Personal Computer" usually just means Windows now, unfortunately. Let's list the operating system names instead.