### PR TITLE
Fixed twice assigned values

### DIFF
--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -1077,7 +1077,6 @@ bool task_push_start_dummy_core(content_ctx_info_t *content_info)
    content_ctx.is_ups_pref                    = rarch_ctl(RARCH_CTL_IS_UPS_PREF, NULL);
    content_ctx.patch_is_blocked               = rarch_ctl(RARCH_CTL_IS_PATCH_BLOCKED, NULL);
    content_ctx.bios_is_missing                = rarch_ctl(RARCH_CTL_IS_MISSING_BIOS, NULL);
-   content_ctx.history_list_enable            = false;
    content_ctx.directory_system               = NULL;
    content_ctx.directory_cache                = NULL;
    content_ctx.name_ips                       = NULL;
@@ -1169,7 +1168,6 @@ bool task_push_load_content_from_playlist_from_menu(
    content_ctx.is_ups_pref                    = rarch_ctl(RARCH_CTL_IS_UPS_PREF, NULL);
    content_ctx.patch_is_blocked               = rarch_ctl(RARCH_CTL_IS_PATCH_BLOCKED, NULL);
    content_ctx.bios_is_missing                = rarch_ctl(RARCH_CTL_IS_MISSING_BIOS, NULL);
-   content_ctx.history_list_enable            = false;
    content_ctx.directory_system               = NULL;
    content_ctx.directory_cache                = NULL;
    content_ctx.name_ips                       = NULL;
@@ -1267,7 +1265,6 @@ bool task_push_start_current_core(content_ctx_info_t *content_info)
    content_ctx.is_ups_pref                    = rarch_ctl(RARCH_CTL_IS_UPS_PREF, NULL);
    content_ctx.patch_is_blocked               = rarch_ctl(RARCH_CTL_IS_PATCH_BLOCKED, NULL);
    content_ctx.bios_is_missing                = rarch_ctl(RARCH_CTL_IS_MISSING_BIOS, NULL);
-   content_ctx.history_list_enable            = false;
    content_ctx.directory_system               = NULL;
    content_ctx.directory_cache                = NULL;
    content_ctx.name_ips                       = NULL;
@@ -1395,7 +1392,6 @@ bool task_push_load_content_with_new_core_from_menu(
    content_ctx.is_ups_pref                    = rarch_ctl(RARCH_CTL_IS_UPS_PREF, NULL);
    content_ctx.patch_is_blocked               = rarch_ctl(RARCH_CTL_IS_PATCH_BLOCKED, NULL);
    content_ctx.bios_is_missing                = rarch_ctl(RARCH_CTL_IS_MISSING_BIOS, NULL);
-   content_ctx.history_list_enable            = false;
    content_ctx.directory_system               = NULL;
    content_ctx.directory_cache                = NULL;
    content_ctx.name_ips                       = NULL;
@@ -1499,7 +1495,6 @@ static bool task_load_content_callback(content_ctx_info_t *content_info,
    content_ctx.is_ups_pref                    = rarch_ctl(RARCH_CTL_IS_UPS_PREF, NULL);
    content_ctx.patch_is_blocked               = rarch_ctl(RARCH_CTL_IS_PATCH_BLOCKED, NULL);
    content_ctx.bios_is_missing                = rarch_ctl(RARCH_CTL_IS_MISSING_BIOS, NULL);
-   content_ctx.history_list_enable            = false;
    content_ctx.directory_system               = NULL;
    content_ctx.directory_cache                = NULL;
    content_ctx.name_ips                       = NULL;


### PR DESCRIPTION
I like your project and I'm exploring it as part of the competition the Pinguem.ru competition on finding errors in open source projects. New warnings, found using PVS-Studio:
RetroArch/tasks/task_content.c	1094	warn	V519 The 'content_ctx.history_list_enable' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 1080, 1094.
RetroArch/tasks/task_content.c	1186	warn	V519 The 'content_ctx.history_list_enable' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 1172, 1186.
RetroArch/tasks/task_content.c	1284	warn	V519 The 'content_ctx.history_list_enable' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 1270, 1284.
RetroArch/tasks/task_content.c	1412	warn	V519 The 'content_ctx.history_list_enable' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 1398, 1412.
RetroArch/tasks/task_content.c	1516	warn	V519 The 'content_ctx.history_list_enable' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 1502, 1516.