### PR TITLE
Add FreeBSD to the list of supported operating systems.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ RetroArch has been ported to the following platforms:
 
    - Windows
    - Linux
+   - FreeBSD
    - MacOS
    - PlayStation 3
    - PlayStation Portable


### PR DESCRIPTION
FreeBSD should work and I don't see any reason to not include it with other platforms such as Windows or Linux.

This is a followup to PR https://github.com/libretro/RetroArch/pull/5626.