### PR TITLE
[WiiU] Fix DRC touch - proper scaling; press detection

### DIFF
--- a/input/drivers/wiiu_input.c
+++ b/input/drivers/wiiu_input.c
@@ -105,7 +105,7 @@ static int16_t wiiu_pointer_device_state(wiiu_input_t* wiiu, unsigned id)
 	switch (id)
 	{
 		case RETRO_DEVICE_ID_POINTER_PRESSED:
-			return wiiu->joypad->get_buttons(0) & VPAD_BUTTON_TOUCH;
+			return (wiiu->joypad->get_buttons(0) & VPAD_BUTTON_TOUCH) ? 1 : 0;
 		case RETRO_DEVICE_ID_POINTER_X:
 			return wiiu->joypad->axis(0, 0xFFFF0004UL);
 		case RETRO_DEVICE_ID_POINTER_Y:

--- a/input/drivers_joypad/wiiu_joypad.c
+++ b/input/drivers_joypad/wiiu_joypad.c
@@ -228,6 +228,11 @@ static void wiiu_joypad_poll(void)
             cal.y = vp.y + vp.height;
             touchClamped = true;
          }
+         /* Account for 12px clamp on VPADGetTPCalibratedPoint */
+         if (vp.x < 12) vp.x = 12;
+         if (vp.y < 12) vp.y = 12;
+         if (vp.x + vp.width > 1268) vp.width = 1268 - vp.x;
+         if (vp.y + vp.height > 708) vp.height = 708 - vp.y;
          /* Calibrate to libretro spec and save as axis 2 (idx 4,5) */
          analog_state[0][2][0] = scaleTP(vp.x, vp.x + vp.width, -0x7fff, 0x7fff, cal.x);
          analog_state[0][2][1] = scaleTP(vp.y, vp.y + vp.height, -0x7fff, 0x7fff, cal.y);


### PR DESCRIPTION
See commit message for info; hopefully RETRO_DEVICE_POINTER support on Wii U should finally work right. Thanks for putting up with my broken code :)