### PR TITLE
[WiiU] Add quiet support to makefile

### DIFF
--- a/Makefile.wiiu
+++ b/Makefile.wiiu
@@ -5,6 +5,10 @@ DEBUG                = 0
 GRIFFIN_BUILD        = 0
 WHOLE_ARCHIVE_LINK   = 0
 
+ifneq ($(V), 1)
+   Q := @
+endif
+
 PC_DEVELOPMENT_IP_ADDRESS  ?=
 PC_DEVELOPMENT_TCP_PORT	   ?=
 
@@ -202,41 +206,50 @@ all: $(TARGETS)
 
 %.o: %.cpp
 %.o: %.cpp %.depend
-	$(CXX) -c -o $@ $< $(CXXFLAGS) $(INCDIRS) $(DEPFLAGS)
-	$(POSTCOMPILE)
+	@$(if $(Q), echo CXX $<,)
+	$(Q)$(CXX) -c -o $@ $< $(CXXFLAGS) $(INCDIRS) $(DEPFLAGS)
+	$(Q)$(POSTCOMPILE)
 
 %.o: %.c
 %.o: %.c %.depend
-	$(CC) -c -o $@ $< $(CFLAGS) $(INCDIRS) $(DEPFLAGS)
-	$(POSTCOMPILE)
+	@$(if $(Q), echo CC $<,)
+	$(Q)$(CC) -c -o $@ $< $(CFLAGS) $(INCDIRS) $(DEPFLAGS)
+	$(Q)$(POSTCOMPILE)
 
 
 %.o: %.S
 %.o: %.S %.depend
-	$(CC) -c -o $@ $< $(ASFLAGS) $(INCDIRS) $(DEPFLAGS)
-	$(POSTCOMPILE)
+	@$(if $(Q), echo AS $<,)
+	$(Q)$(CC) -c -o $@ $< $(ASFLAGS) $(INCDIRS) $(DEPFLAGS)
+	$(Q)$(POSTCOMPILE)
 
 %.o: %.s
 %.o: %.s %.depend
-	$(CC) -c -o $@ $< $(ASFLAGS) $(INCDIRS) $(DEPFLAGS)
-	$(POSTCOMPILE)
+	@$(if $(Q), echo AS $<,)
+	$(Q)$(CC) -c -o $@ $< $(ASFLAGS) $(INCDIRS) $(DEPFLAGS)
+	$(Q)$(POSTCOMPILE)
 %.a:
-	$(AR) -rc $@ $^
+	@$(if $(Q), echo AR $<,)
+	$(Q)$(AR) -rc $@ $^
 
 %.depend: ;
 
 
 $(ELF2RPL):
-	$(MAKE) -C wiiu/wut/elf2rpl/
+	@$(if $(Q), echo MAKE $@,)
+	$(Q)$(MAKE) -C wiiu/wut/elf2rpl/
 
 $(TARGET).elf: $(OBJ) $(HBL_ELF_OBJ) libretro_wiiu.a wiiu/link_elf.ld
-	$(LD) $(OBJ) $(HBL_ELF_OBJ) $(LDFLAGS) $(HBL_ELF_LDFLAGS) $(LIBDIRS) $(LIBS) -o $@
+	@$(if $(Q), echo LD $@,)
+	$(Q)$(LD) $(OBJ) $(HBL_ELF_OBJ) $(LDFLAGS) $(HBL_ELF_LDFLAGS) $(LIBDIRS) $(LIBS) -o $@
 
 $(TARGET).rpx.elf: $(OBJ) $(RPX_OBJ) libretro_wiiu.a wiiu/link_elf.ld
-	$(LD) $(OBJ) $(RPX_OBJ) $(LDFLAGS) $(RPX_LDFLAGS) $(LIBDIRS)  $(LIBS) -o $@
+	@$(if $(Q), echo LD $@,)
+	$(Q)$(LD) $(OBJ) $(RPX_OBJ) $(LDFLAGS) $(RPX_LDFLAGS) $(LIBDIRS)  $(LIBS) -o $@
 
 $(TARGET).rpx: $(TARGET).rpx.elf $(ELF2RPL)
-	-$(ELF2RPL) $(TARGET).rpx.elf $@
+	@$(if $(Q), echo ELF2RPL $@,)
+	$(Q)-$(ELF2RPL) $(TARGET).rpx.elf $@
 
 clean:
 	rm -f $(OBJ) $(RPX_OBJ) $(HBL_ELF_OBJ) $(TARGET).elf $(TARGET).rpx.elf $(TARGET).rpx


### PR DESCRIPTION
As the Wii U port has grown, the final linking stages have involved gradually more and more files. It's at the point now where the link commands easily fill a few screens of scrollback on an average terminal; which makes it very easy to miss compiler warnings. I'm actually guilty of this - the int16_t cast bug fixed in #5646  threw a warning, but I didn't see it for weeks. Thus, I think it's a good idea to take a little bit of a lead from the PC versions and make a quieter makefile. These changes place a @ in front of all compiler commands and instead echo the current filename. The old behaviour can be restored by passing V=1 to make.

Thanks again;
-Ash