### PR TITLE
Fix compile with --disable-fbo.

### DIFF
--- a/gfx/drivers_renderchain/gl2_renderchain.c
+++ b/gfx/drivers_renderchain/gl2_renderchain.c
@@ -1109,6 +1109,7 @@ error:
    return false;
 }
 
+#ifdef HAVE_FBO
 gl_renderchain_driver_t gl2_renderchain = {
    gl2_renderchain_init,
    gl2_renderchain_init_hw_render,
@@ -1120,3 +1121,4 @@ gl_renderchain_driver_t gl2_renderchain = {
    gl2_renderchain_render,
    "gl2",
 };
+#endif


### PR DESCRIPTION
Fixes https://github.com/libretro/RetroArch/issues/5647.

The first bad commit was 674dbfed1934a8b2511f616f7b92be8df4b3ff81.