### PR TITLE
Clean up deps file includes in audio_mixer.h

### DIFF
--- a/libretro-common/audio/audio_mixer.c
+++ b/libretro-common/audio/audio_mixer.c
@@ -44,11 +44,11 @@
 #define STB_VORBIS_NO_STDIO
 #define STB_VORBIS_NO_CRT
 
-#include "../../deps/stb/stb_vorbis.h"
+#include "stb/stb_vorbis.h"
 #endif
 
 #ifdef HAVE_IBXM
-#include "../../deps/ibxm/ibxm.h"
+#include "ibxm/ibxm.h"
 #endif
 
 #define AUDIO_MIXER_MAX_VOICES      8


### PR DESCRIPTION
The deps folder is already in the include path. This allows deps to be defined elsewhere.