### PR TITLE
[WiiU] Various warning fixes

### DIFF
--- a/audio/drivers/wiiu_audio.c
+++ b/audio/drivers/wiiu_audio.c
@@ -193,11 +193,11 @@ static bool ax_audio_start(void* data, bool is_shutdown)
 
 static ssize_t ax_audio_write(void* data, const void* buf, size_t size)
 {
-   int i;
+   uint32_t i;
    size_t countAvail   = 0;
    ax_audio_t* ax      = (ax_audio_t*)data;
    const uint16_t* src = buf;
-   int count           = size >> 2;
+   size_t count        = size >> 2;
 
    if(!size || (size & 0x3))
       return 0;
@@ -330,8 +330,8 @@ audio_driver_t audio_ax =
    ax_audio_free,
    ax_audio_use_float,
    "AX",
-   NULL,
-   NULL,
-/*   ax_audio_write_avail, */
-/*   ax_audio_buffer_size */
+   NULL, /* device_list_new */
+   NULL, /* device_list_free */
+   NULL, /* write_avail */
+   NULL, /* buffer_size */
 };

--- a/frontend/drivers/platform_wiiu.c
+++ b/frontend/drivers/platform_wiiu.c
@@ -308,6 +308,7 @@ frontend_ctx_driver_t frontend_ctx_wiiu =
    NULL,                         /* attach_console */
    NULL,                         /* detach_console */
    "wiiu",
+   NULL,                         /* get_video_driver */
 };
 
 static int wiiu_log_socket = -1;
@@ -379,6 +380,7 @@ void net_print_exp(const char *str)
    send(wiiu_log_socket, str, strlen(str), 0);
 }
 
+#if defined(PC_DEVELOPMENT_IP_ADDRESS) && defined(PC_DEVELOPMENT_TCP_PORT)
 static devoptab_t dotab_stdout =
 {
    "stdout_net", // device name
@@ -389,6 +391,7 @@ static devoptab_t dotab_stdout =
    NULL,
    /* ... */
 };
+#endif
 
 void SaveCallback()
 {
@@ -642,7 +645,7 @@ void _start(int argc, char **argv)
    __init();
    fsdev_init();
 
-   int ret = main(argc, argv);
+   main(argc, argv);
 
    fsdev_exit();
 //   __fini();

--- a/gfx/drivers/wiiu_gfx.c
+++ b/gfx/drivers/wiiu_gfx.c
@@ -51,7 +51,7 @@ static const wiiu_render_mode_t wiiu_render_mode_map[] =
    {1920, 1080, GX2_TV_RENDER_MODE_WIDE_1080P}  /* GX2_TV_SCAN_MODE_1080P */
 };
 
-static int wiiu_set_position(position_t* position, GX2ColorBuffer* draw_buffer, float x0, float y0, float x1, float y1)
+static void wiiu_set_position(position_t* position, GX2ColorBuffer* draw_buffer, float x0, float y0, float x1, float y1)
 {
    position[0].x = (2.0f * x0 / draw_buffer->surface.width) - 1.0f;
    position[0].y = (2.0f * y0 / draw_buffer->surface.height) - 1.0f;
@@ -194,7 +194,6 @@ static void wiiu_gfx_set_aspect_ratio(void* data, unsigned aspect_ratio_idx)
 static void* wiiu_gfx_init(const video_info_t* video,
       const input_driver_t** input, void** input_data)
 {
-   int i;
    float refresh_rate = 60.0f / 1.001f;
    u32 size           = 0;
    u32 tmp            = 0;
@@ -387,9 +386,9 @@ static void* wiiu_gfx_init(const video_info_t* video,
 
    wiiu->vertex_cache.size       = 0x1000;
    wiiu->vertex_cache.current    = 0;
-   wiiu->vertex_cache.positions  = MEM2_alloc(wiiu->vertex_cache.size 
+   wiiu->vertex_cache.positions  = MEM2_alloc(wiiu->vertex_cache.size
          * sizeof(position_t), GX2_VERTEX_BUFFER_ALIGNMENT);
-   wiiu->vertex_cache.tex_coords = MEM2_alloc(wiiu->vertex_cache.size 
+   wiiu->vertex_cache.tex_coords = MEM2_alloc(wiiu->vertex_cache.size
          * sizeof(tex_coord_t), GX2_VERTEX_BUFFER_ALIGNMENT);
 
    /* Initialize samplers */
@@ -498,7 +497,7 @@ static bool wiiu_gfx_frame(void* data, const void* frame,
    static u32 lastTick , currentTick;
    u32 diff;
 #endif
-   int i;
+   uint32_t i;
    wiiu_video_t* wiiu = (wiiu_video_t*) data;
 
    (void)msg;
@@ -572,7 +571,7 @@ static bool wiiu_gfx_frame(void* data, const void* frame,
 
          for (i = 0; i < height; i++)
          {
-            int j;
+            uint32_t j;
             for(j = 0; j < width; j++)
                dst[j] = src[j];
             dst += wiiu->texture.surface.pitch;
@@ -725,7 +724,7 @@ static bool wiiu_gfx_read_viewport(void* data, uint8_t* buffer, bool is_idle)
 static uintptr_t wiiu_gfx_load_texture(void* video_data, void* data,
       bool threaded, enum texture_filter_type filter_type)
 {
-   int i;
+   uint32_t i;
    wiiu_video_t* wiiu = (wiiu_video_t*) video_data;
    struct texture_image *image = (struct texture_image*)data;
 
@@ -785,7 +784,7 @@ static void wiiu_gfx_apply_state_changes(void* data)
 static void wiiu_gfx_set_texture_frame(void* data, const void* frame, bool rgb32,
                                    unsigned width, unsigned height, float alpha)
 {
-   int i;
+   uint32_t i;
    const uint16_t *src = NULL;
    uint16_t *dst       = NULL;
    wiiu_video_t* wiiu  = (wiiu_video_t*) data;
@@ -851,13 +850,13 @@ static const video_poke_interface_t wiiu_poke_interface =
 {
    wiiu_gfx_load_texture,
    wiiu_gfx_unload_texture,
-   NULL,
+   NULL, /* set_video_mode */
    wiiu_gfx_set_filtering,
    NULL, /* get_video_output_size */
    NULL, /* get_video_output_prev */
    NULL, /* get_video_output_next */
    NULL, /* get_current_framebuffer */
-   NULL,
+   NULL, /* get_proc_address */
    wiiu_gfx_set_aspect_ratio,
    wiiu_gfx_apply_state_changes,
 #ifdef HAVE_MENU
@@ -865,9 +864,11 @@ static const video_poke_interface_t wiiu_poke_interface =
 #endif
    wiiu_gfx_set_texture_enable,
    wiiu_gfx_set_osd_msg,
-   NULL,
-   NULL,
-   NULL
+   NULL, /* show_mouse */
+   NULL, /* grab_mouse_toggle */
+   NULL, /* get_current_shader */
+   NULL, /* get_current_software_framebuffer */
+   NULL, /* get_hw_render_interface */
 };
 
 static void wiiu_gfx_get_poke_interface(void* data,
@@ -898,4 +899,5 @@ video_driver_t video_wiiu =
    NULL, /* overlay_interface */
 #endif
    wiiu_gfx_get_poke_interface,
+   NULL, /* wrap_type_to_enum */
 };

--- a/gfx/drivers_font/wiiu_font.c
+++ b/gfx/drivers_font/wiiu_font.c
@@ -40,7 +40,7 @@ typedef struct
 static void* wiiu_font_init_font(void* data, const char* font_path,
       float font_size, bool is_threaded)
 {
-   int i;
+   uint32_t i;
    wiiu_font_t* font = (wiiu_font_t*)calloc(1, sizeof(*font));
 
    if (!font)

--- a/input/drivers_joypad/wiiu_joypad.c
+++ b/input/drivers_joypad/wiiu_joypad.c
@@ -65,17 +65,16 @@ static char hidName[HID_COUNT][255];
 
 static const char* wiiu_joypad_name(unsigned pad)
 {
-   if (pad == 0)
+   if (pad > MAX_PADS) return "N/A";
+
+   if (pad == GAMEPAD_OFFSET)
       return "WIIU Gamepad";
 
-   if (pad < MAX_PADS && pad < (HID_OFFSET) && pad > GAMEPAD_OFFSET)
+   if (pad >= KPAD_OFFSET && pad < KPAD_OFFSET + KPAD_COUNT)
    {
       int i = pad - KPAD_OFFSET;
       switch (pad_type[i])
       {
-         case WIIUINPUT_TYPE_NONE:
-            return "N/A";
-
          case WIIUINPUT_TYPE_PRO_CONTROLLER:
             return "WIIU Pro Controller";
 
@@ -87,13 +86,17 @@ static const char* wiiu_joypad_name(unsigned pad)
 
          case WIIUINPUT_TYPE_CLASSIC_CONTROLLER:
             return "Classic Controller";
+
+         case WIIUINPUT_TYPE_NONE:
+         default:
+            return "N/A";
       }
    }
 
-   if (pad < MAX_PADS)
+   if (pad >= HID_OFFSET && pad < HID_OFFSET + HID_COUNT)
    {
-      s32 hid_index = pad-HID_OFFSET;
-      sprintf(hidName[hid_index],"HID %04X/%04X(%02X)",hid_data[hid_index].device_info.vidpid.vid,hid_data[hid_index].device_info.vidpid.pid,hid_data[hid_index].pad);
+      s32 hid_index = pad - HID_OFFSET;
+      sprintf(hidName[hid_index], "HID %04X/%04X(%02X)", hid_data[hid_index].device_info.vidpid.vid, hid_data[hid_index].device_info.vidpid.pid, hid_data[hid_index].pad);
       return hidName[hid_index];
    }
 

--- a/wiiu/fs/fs_utils.c
+++ b/wiiu/fs/fs_utils.c
@@ -31,174 +31,174 @@
 
 int MountFS(void *pClient, void *pCmd, char **mount_path)
 {
-    int result = -1;
+   int result = -1;
 
-    void *mountSrc = malloc(FS_MOUNT_SOURCE_SIZE);
-    if(!mountSrc)
-        return -3;
+   void *mountSrc = malloc(FS_MOUNT_SOURCE_SIZE);
+   if(!mountSrc)
+   return -3;
 
-    char* mountPath = (char*) malloc(FS_MAX_MOUNTPATH_SIZE);
-    if(!mountPath) {
-        free(mountSrc);
-        return -4;
-    }
+   char* mountPath = (char*) malloc(FS_MAX_MOUNTPATH_SIZE);
+   if(!mountPath) {
+      free(mountSrc);
+      return -4;
+   }
 
-    memset(mountSrc, 0, FS_MOUNT_SOURCE_SIZE);
-    memset(mountPath, 0, FS_MAX_MOUNTPATH_SIZE);
+   memset(mountSrc, 0, FS_MOUNT_SOURCE_SIZE);
+   memset(mountPath, 0, FS_MAX_MOUNTPATH_SIZE);
 
-    // Mount sdcard
-    if (FSGetMountSource(pClient, pCmd, FS_SOURCETYPE_EXTERNAL, mountSrc, -1) == 0)
-    {
-        result = FSMount(pClient, pCmd, mountSrc, mountPath, FS_MAX_MOUNTPATH_SIZE, -1);
-        if((result == 0) && mount_path) {
-            *mount_path = (char*)malloc(strlen(mountPath) + 1);
-            if(*mount_path)
-                strcpy(*mount_path, mountPath);
-        }
-    }
+   // Mount sdcard
+   if (FSGetMountSource(pClient, pCmd, FS_SOURCETYPE_EXTERNAL, mountSrc, -1) == 0)
+   {
+      result = FSMount(pClient, pCmd, mountSrc, mountPath, FS_MAX_MOUNTPATH_SIZE, -1);
+      if((result == 0) && mount_path) {
+         *mount_path = (char*)malloc(strlen(mountPath) + 1);
+         if(*mount_path)
+         strcpy(*mount_path, mountPath);
+      }
+   }
 
-    free(mountPath);
-    free(mountSrc);
-    return result;
+   free(mountPath);
+   free(mountSrc);
+   return result;
 }
 
 int UmountFS(void *pClient, void *pCmd, const char *mountPath)
 {
-    int result = -1;
-    result = FSUnmount(pClient, pCmd, mountPath, -1);
+   int result = -1;
+   result = FSUnmount(pClient, pCmd, mountPath, -1);
 
-    return result;
+   return result;
 }
 
 int LoadFileToMem(const char *filepath, u8 **inbuffer, u32 *size)
 {
-    //! always initialze input
-	*inbuffer = NULL;
-    if(size)
-        *size = 0;
+   //! always initialze input
+   *inbuffer = NULL;
+   if(size)
+   *size = 0;
 
-    int iFd = open(filepath, O_RDONLY);
-	if (iFd < 0)
-		return -1;
+   int iFd = open(filepath, O_RDONLY);
+   if (iFd < 0)
+   return -1;
 
-	u32 filesize = lseek(iFd, 0, SEEK_END);
-    lseek(iFd, 0, SEEK_SET);
+   u32 filesize = lseek(iFd, 0, SEEK_END);
+   lseek(iFd, 0, SEEK_SET);
 
-	u8 *buffer = (u8 *) malloc(filesize);
-	if (buffer == NULL)
-	{
-        close(iFd);
-		return -2;
-	}
+   u8 *buffer = (u8 *) malloc(filesize);
+   if (buffer == NULL)
+   {
+      close(iFd);
+      return -2;
+   }
 
-    u32 blocksize = 0x4000;
-    u32 done = 0;
-    int readBytes = 0;
+   u32 blocksize = 0x4000;
+   u32 done = 0;
+   int readBytes = 0;
 
-	while(done < filesize)
-    {
-        if(done + blocksize > filesize) {
-            blocksize = filesize - done;
-        }
-        readBytes = read(iFd, buffer + done, blocksize);
-        if(readBytes <= 0)
-            break;
-        done += readBytes;
-    }
+   while(done < filesize)
+   {
+      if(done + blocksize > filesize) {
+         blocksize = filesize - done;
+      }
+      readBytes = read(iFd, buffer + done, blocksize);
+      if(readBytes <= 0)
+      break;
+      done += readBytes;
+   }
 
-    close(iFd);
+   close(iFd);
 
-	if (done != filesize)
-	{
-		free(buffer);
-		return -3;
-	}
+   if (done != filesize)
+   {
+      free(buffer);
+      return -3;
+   }
 
-	*inbuffer = buffer;
+   *inbuffer = buffer;
 
-    //! sign is optional input
-    if(size)
-        *size = filesize;
+   //! sign is optional input
+   if(size)
+   *size = filesize;
 
-	return filesize;
+   return filesize;
 }
 
 int CheckFile(const char * filepath)
 {
-	if(!filepath)
-		return 0;
+   if(!filepath)
+   return 0;
 
-	struct stat filestat;
+   struct stat filestat;
 
-	char dirnoslash[strlen(filepath)+2];
-	snprintf(dirnoslash, sizeof(dirnoslash), "%s", filepath);
+   char dirnoslash[strlen(filepath)+2];
+   snprintf(dirnoslash, sizeof(dirnoslash), "%s", filepath);
 
-	while(dirnoslash[strlen(dirnoslash)-1] == '/')
-		dirnoslash[strlen(dirnoslash)-1] = '\0';
+   while(dirnoslash[strlen(dirnoslash)-1] == '/')
+   dirnoslash[strlen(dirnoslash)-1] = '\0';
 
-	char * notRoot = strrchr(dirnoslash, '/');
-	if(!notRoot)
-	{
-		strcat(dirnoslash, "/");
-	}
+   char * notRoot = strrchr(dirnoslash, '/');
+   if(!notRoot)
+   {
+      strcat(dirnoslash, "/");
+   }
 
-	if (stat(dirnoslash, &filestat) == 0)
-		return 1;
+   if (stat(dirnoslash, &filestat) == 0)
+   return 1;
 
-	return 0;
+   return 0;
 }
 
 int CreateSubfolder(const char * fullpath)
 {
-	if(!fullpath)
-		return 0;
+   if(!fullpath)
+   return 0;
 
-	int result = 0;
+   int result = 0;
 
-	char dirnoslash[strlen(fullpath)+1];
-	strcpy(dirnoslash, fullpath);
+   char dirnoslash[strlen(fullpath)+1];
+   strcpy(dirnoslash, fullpath);
 
-	int pos = strlen(dirnoslash)-1;
-	while(dirnoslash[pos] == '/')
-	{
-		dirnoslash[pos] = '\0';
-		pos--;
-	}
+   int pos = strlen(dirnoslash)-1;
+   while(dirnoslash[pos] == '/')
+   {
+      dirnoslash[pos] = '\0';
+      pos--;
+   }
 
-	if(CheckFile(dirnoslash))
-	{
-		return 1;
-	}
-	else
-	{
-		char parentpath[strlen(dirnoslash)+2];
-		strcpy(parentpath, dirnoslash);
-		char * ptr = strrchr(parentpath, '/');
+   if(CheckFile(dirnoslash))
+   {
+      return 1;
+   }
+   else
+   {
+      char parentpath[strlen(dirnoslash)+2];
+      strcpy(parentpath, dirnoslash);
+      char * ptr = strrchr(parentpath, '/');
 
-		if(!ptr)
-		{
-			//!Device root directory (must be with '/')
-			strcat(parentpath, "/");
-			struct stat filestat;
-			if (stat(parentpath, &filestat) == 0)
-				return 1;
+      if(!ptr)
+      {
+         //!Device root directory (must be with '/')
+         strcat(parentpath, "/");
+         struct stat filestat;
+         if (stat(parentpath, &filestat) == 0)
+         return 1;
 
-			return 0;
-		}
+         return 0;
+      }
 
-		ptr++;
-		ptr[0] = '\0';
+      ptr++;
+      ptr[0] = '\0';
 
-		result = CreateSubfolder(parentpath);
-	}
+      result = CreateSubfolder(parentpath);
+   }
 
-	if(!result)
-		return 0;
+   if(!result)
+   return 0;
 
-	if (mkdir(dirnoslash, 0777) == -1)
-	{
-		return 0;
-	}
+   if (mkdir(dirnoslash, 0777) == -1)
+   {
+      return 0;
+   }
 
-	return 1;
+   return 1;
 }

--- a/wiiu/hbl.c
+++ b/wiiu/hbl.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <malloc.h>
 #include <string.h>
+#include <inttypes.h>
 #include <wiiu/os.h>
 
 #include "hbl.h"
@@ -236,7 +237,7 @@ int HBL_loadToMemory(const char *filepath, u32 args_size)
    if (bytesRead != fileSize)
    {
       free(buffer);
-      printf("File loading not finished for file %s, finished %i of %i bytes\n", filepath, bytesRead,
+      printf("File loading not finished for file %s, finished %" PRIi32 " of %" PRIi32 " bytes\n", filepath, bytesRead,
              fileSize);
       printf("File read failure");
       return -1;

--- a/wiiu/wiiu_dbg.h
+++ b/wiiu/wiiu_dbg.h
@@ -3,6 +3,7 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include <inttypes.h>
 
 #ifdef WIIU
 #include <wiiu/types.h>
@@ -26,11 +27,11 @@ void DisassemblePPCRange(void *start, void *end, void* printf_func, void* GetSym
 //#define DEBUG_HOLD() do{printf("%s@%s:%d.\n",__FUNCTION__, __FILE__, __LINE__);fflush(stdout);wait_for_input();}while(0)
 #define DEBUG_LINE() do{printf("%s:%4d %s().\n", __FILE__, __LINE__, __FUNCTION__);fflush(stdout);}while(0)
 #define DEBUG_STR(X) printf( "%s: %s\n", #X, (char*)(X))
-#define DEBUG_VAR(X) printf( "%-20s: 0x%08X\n", #X, (uint32_t)(X))
-#define DEBUG_VAR2(X) printf( "%-20s: 0x%08X (%i)\n", #X, (uint32_t)(X), (int)(X))
-#define DEBUG_INT(X) printf( "%-20s: %10i\n", #X, (int32_t)(X))
+#define DEBUG_VAR(X) printf( "%-20s: 0x%08" PRIX32 "\n", #X, (uint32_t)(X))
+#define DEBUG_VAR2(X) printf( "%-20s: 0x%08" PRIX32 " (%i)\n", #X, (uint32_t)(X), (int)(X))
+#define DEBUG_INT(X) printf( "%-20s: %10" PRIi32 "\n", #X, (int32_t)(X))
 #define DEBUG_FLOAT(X) printf( "%-20s: %10.3f\n", #X, (float)(X))
-#define DEBUG_VAR64(X) printf( #X"\r\t\t\t\t : 0x%016llX\n", (uint64_t)(X))
+#define DEBUG_VAR64(X) printf( #X"\r\t\t\t\t : 0x%016" PRIX64 "\n", (uint64_t)(X))
 //#define DEBUG_ERROR(X) do{if(X)dump_result_value(X);}while(0)
 #define PRINTFPOS(X,Y) "\x1b["#X";"#Y"H"
 #define PRINTFPOS_STR(X,Y) "\x1b[" X ";" Y "H"


### PR DESCRIPTION
Basic work on some gcc warnings emitted by the wiiu code. I'd like to turn on -Wall eventually like on some of the other ports. Hopefully the use of inttypes.h should also deal with a certain toolchain's propensity to swap between int and long int.