### PR TITLE
(xmb) Fixed array index out of bounds

### DIFF
--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -177,7 +177,7 @@ typedef struct xmb_handle
    bool mouse_show;
 
    uint8_t system_tab_end;
-   uint8_t tabs[8];
+   uint8_t tabs[16];
 
    int depth;
    int old_depth;


### PR DESCRIPTION
Caught by asan:

menu/drivers/xmb.c:3491:16: runtime error: index 8 out of bounds for type 'uint8_t [8]'
menu/drivers/xmb.c:1149:23: runtime error: index 8 out of bounds for type 'uint8_t [8]'