### PR TITLE
Add NetBSD to the list of supported operating systems.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ RetroArch has been ported to the following platforms:
    - Windows
    - Linux
    - FreeBSD
+   - NetBSD
    - MacOS
    - PlayStation 3
    - PlayStation Portable


### PR DESCRIPTION
It should work according to this comment so I see no reason to not list it in the README.md.
https://github.com/libretro/RetroArch/issues/5655#issuecomment-342191995