### PR TITLE
(xmb) De-hardcode the size of 'tabs' array

### DIFF
--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -169,7 +169,10 @@ enum
 #ifdef HAVE_NETWORKING
    XMB_SYSTEM_TAB_NETPLAY,
 #endif
-   XMB_SYSTEM_TAB_ADD
+   XMB_SYSTEM_TAB_ADD,
+
+   /* End of this enum - use the last one to determine num of possible tabs */
+   XMB_SYSTEM_TAB_MAX_LENGTH
 };
 
 typedef struct xmb_handle
@@ -177,7 +180,7 @@ typedef struct xmb_handle
    bool mouse_show;
 
    uint8_t system_tab_end;
-   uint8_t tabs[16];
+   uint8_t tabs[XMB_SYSTEM_TAB_MAX_LENGTH];
 
    int depth;
    int old_depth;


### PR DESCRIPTION
As per @bparker06's recommendation.

First element of the enum is forced to be zero, so we can add a tail to the enum that we can use to query its max length.