### PR TITLE
Fix strdup() call when no path is provided

### DIFF
--- a/libretro-common/streams/file_stream.c
+++ b/libretro-common/streams/file_stream.c
@@ -330,7 +330,9 @@ RFILE *filestream_open(const char *path, unsigned mode, ssize_t len)
 
    {
       const char *ld = (const char*)strrchr(path, '.');
-      stream->ext    = strdup(ld ? ld + 1 : "");
+      if (ld) {
+         stream->ext = strdup(ld + 1);
+      }
    }
 
    filestream_set_size(stream);


### PR DESCRIPTION
Was getting the follow memory leak when exiting RetroArch:
https://hastebin.com/herolamiwi.pas

```
Direct leak of 1 byte(s) in 1 object(s) allocated from:
    #0 0x7f557ffa730f in strdup (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x6230f)
    #1 0x46ad00 in filestream_open libretro-common/streams/file_stream.c:333
    #2 0x46bc71 in filestream_read_file libretro-common/streams/file_stream.c:691
    #3 0x419196 in check_proc_acpi_sysfs_battery frontend/drivers/platform_unix.c:800
    #4 0x41b187 in frontend_unix_powerstate_check_acpi_sysfs frontend/drivers/platform_unix.c:1070
    #5 0x41b677 in frontend_unix_get_powerstate frontend/drivers/platform_unix.c:1129
    #6 0x56dca9 in task_powerstate_handler tasks/task_powerstate.c:60
    #7 0x445f18 in threaded_worker libretro-common/queues/task_queue.c:459
    #8 0x783174 in thread_wrap libretro-common/rthreads/rthreads.c:142
    #9 0x7f557ee3f6b9 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x76b9)
```

This change checks to make sure the pointer exists before calling `strdup()` on it.

@bparker06 should likely review this one.