### PR TITLE
Introduce button mappings for generic usb controller

### DIFF
--- a/input/connect/connect_nesusb.c
+++ b/input/connect/connect_nesusb.c
@@ -86,10 +86,10 @@ static void hidpad_nesusb_packet_handler(void *data, uint8_t *packet, uint16_t s
    uint32_t i, pressed_keys;
    static const uint32_t button_mapping[17] =
    {
-      NO_BTN,
-      NO_BTN,
-      NO_BTN,
-      NO_BTN,
+      RETRO_DEVICE_ID_JOYPAD_L2,
+      RETRO_DEVICE_ID_JOYPAD_R2,
+      RETRO_DEVICE_ID_JOYPAD_L,
+      RETRO_DEVICE_ID_JOYPAD_R,
       RETRO_DEVICE_ID_JOYPAD_SELECT,
       RETRO_DEVICE_ID_JOYPAD_START,
       NO_BTN,
@@ -100,8 +100,8 @@ static void hidpad_nesusb_packet_handler(void *data, uint8_t *packet, uint16_t s
       NO_BTN,
       RETRO_DEVICE_ID_JOYPAD_B,
       RETRO_DEVICE_ID_JOYPAD_A,
-      NO_BTN,
-      NO_BTN,
+      RETRO_DEVICE_ID_JOYPAD_Y,
+      RETRO_DEVICE_ID_JOYPAD_X,
       16, /* HOME BUTTON when pressing SELECT+START */
    };
    struct hidpad_nesusb_data *device = (struct hidpad_nesusb_data*)data;

--- a/input/connect/connect_psxadapter.c
+++ b/input/connect/connect_psxadapter.c
@@ -25,7 +25,7 @@
 struct hidpad_psxadapter_data
 {
    struct pad_connection* connection;
-   uint8_t data[8];
+   uint8_t data[64];
    uint32_t slot;
    uint64_t buttons;
 };


### PR DESCRIPTION
The nes generic usb controller driver (used in the wii port) is extended here. This vid and pid appers in other controllers such as clones of the psx digital controller. The mapping of the face buttons is written so asnot to break existing nes controllers configurations.

Since all drivers use a 64 byte buffer for the usb commands, the buffer size is also increased here to for the psx to ps3 adapter.