### PR TITLE
follow rules for setvbuf()

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -2605,7 +2605,7 @@ static int cheevos_iterate(coro_t* coro)
       /* Load the content into memory, or copy it over to our own buffer */
       if (!CHEEVOS_VAR_DATA)
       {
-         CHEEVOS_VAR_STREAM = filestream_open(CHEEVOS_VAR_PATH, RFILE_MODE_READ, 0);
+         CHEEVOS_VAR_STREAM = filestream_open(CHEEVOS_VAR_PATH, RFILE_MODE_READ, -1);
 
          if (!CHEEVOS_VAR_STREAM)
             CORO_STOP();

--- a/libretro-common/file/config_file.c
+++ b/libretro-common/file/config_file.c
@@ -389,14 +389,13 @@ static config_file_t *config_file_new_internal(
       goto error;
 
    conf->include_depth = depth;
-   file                = filestream_open(path, RFILE_MODE_READ_TEXT, -1);
+   file                = filestream_open(path, RFILE_MODE_READ_TEXT, 0x4000);
 
    if (!file)
    {
       free(conf->path);
       goto error;
    }
-   setvbuf(filestream_get_fp(file), NULL, _IOFBF, 0x4000);
 
    while (!filestream_eof(file))
    {
@@ -917,15 +916,9 @@ bool config_file_write(config_file_t *conf, const char *path)
 
    if (!string_is_empty(path))
    {
-      file = filestream_open(path, RFILE_MODE_WRITE, -1);
+      file = filestream_open(path, RFILE_MODE_WRITE, 0x4000);
       if (!file)
          return false;
-#ifdef WIIU
-      /* TODO: use FBF everywhere once https://i.imgur.com/muVhNeF.jpg is fixed */
-      setvbuf(filestream_get_fp(file), NULL, _IONBF, 0x4000);
-#else
-      setvbuf(filestream_get_fp(file), NULL, _IOFBF, 0x4000);
-#endif
       config_file_dump(conf, filestream_get_fp(file));
    }
    else

--- a/libretro-db/rmsgpack_test.c
+++ b/libretro-db/rmsgpack_test.c
@@ -186,7 +186,7 @@ static struct rmsgpack_read_callbacks stub_callbacks = {
 int main(void)
 {
    struct stub_state state;
-   RFILE *fd = filestream_open("test.msgpack", RFILE_MODE_READ, 0);
+   RFILE *fd = filestream_open("test.msgpack", RFILE_MODE_READ, -1);
 
    state.i = 0;
    state.stack[0] = 0;


### PR DESCRIPTION
This is a fix for #5686. According to the manpage for `setvbuf()`, there's two things we're doing incorrectly. First:
```
     The setvbuf() function may be used at any time, but may have peculiar
     side effects (such as discarding input or flushing output) if the stream
     is ``active''.  Portable applications should call it only once on any
     given stream, and before any I/O is performed.
```
Since 68a8198, `setvbuf()` was now being called after some I/O was performed (namely `filestream_set_size()` at the end of `filestream_open()`). I'm assuming that it depends on a certain filesystem/disk setup/performance as to whether this causes problems, which might explain why only certain devices were able to reproduce this.

To get around this, I made sure to only call `setvbuf()` directly after `fopen()`, and I used the previously unused `len` parameter to `filestream_open()` to optionally specify a buffer size.

Second:
```
If the size argument is not zero but buf is
     NULL, a buffer of the given size will be allocated immediately, and
     released on close.  This is an extension to ANSI C; portable code should
     use a size of 0 with any NULL buffer.
```
To keep C89 compatibility, I allocate a new buffer for each opened file, if a buffer size was specified (-1 means don't call setvbuf, and 0 means use the system default). Currently buffer sizes are only specified for files using the `config_file` interface.

#5664 should also be careful in case merging it clashes with these further modifications to the `file_stream` internals.