### PR TITLE
Extra mouse buttons

### DIFF
--- a/input/drivers/dinput.c
+++ b/input/drivers/dinput.c
@@ -85,7 +85,7 @@ struct dinput_input
    int mouse_rel_y;
    int mouse_x;
    int mouse_y;
-   bool mouse_l, mouse_r, mouse_m, mouse_wu, mouse_wd, mouse_hwu, mouse_hwd;
+   bool mouse_l, mouse_r, mouse_m, mouse_b4, mouse_b5, mouse_wu, mouse_wd, mouse_hwu, mouse_hwd;
    struct pointer_status pointer_head;  /* dummy head for easier iteration */
 };
 
@@ -246,6 +246,8 @@ static void dinput_poll(void *data)
          di->mouse_l  = mouse_state.rgbButtons[0];
       di->mouse_r     = mouse_state.rgbButtons[1];
       di->mouse_m     = mouse_state.rgbButtons[2];
+      di->mouse_b4    = mouse_state.rgbButtons[3];
+      di->mouse_b5    = mouse_state.rgbButtons[4];
 
       /* No simple way to get absolute coordinates
        * for RETRO_DEVICE_POINTER. Just use Win32 APIs. */
@@ -368,6 +370,10 @@ static int16_t dinput_mouse_state(struct dinput_input *di, unsigned id)
          return state;
       case RETRO_DEVICE_ID_MOUSE_MIDDLE:
          return di->mouse_m;
+      case RETRO_DEVICE_ID_MOUSE_BUTTON_4:
+         return di->mouse_b4;
+      case RETRO_DEVICE_ID_MOUSE_BUTTON_5:
+         return di->mouse_b5;
    }
 
    return 0;

--- a/input/drivers/sdl_input.c
+++ b/input/drivers/sdl_input.c
@@ -38,7 +38,7 @@ typedef struct sdl_input
 
    int mouse_x, mouse_y;
    int mouse_abs_x, mouse_abs_y;
-   int mouse_l, mouse_r, mouse_m, mouse_wu, mouse_wd, mouse_wl, mouse_wr;
+   int mouse_l, mouse_r, mouse_m, mouse_b4, mouse_b5, mouse_wu, mouse_wd, mouse_wl, mouse_wr;
 } sdl_input_t;
 
 static void *sdl_input_init(const char *joypad_driver)
@@ -131,6 +131,10 @@ static int16_t sdl_mouse_device_state(sdl_input_t *sdl, unsigned id)
          return sdl->mouse_y;
       case RETRO_DEVICE_ID_MOUSE_MIDDLE:
          return sdl->mouse_m;
+      case RETRO_DEVICE_ID_MOUSE_BUTTON_4:
+         return sdl->mouse_b4;
+      case RETRO_DEVICE_ID_MOUSE_BUTTON_5:
+         return sdl->mouse_b5;
    }
 
    return 0;
@@ -310,6 +314,8 @@ static void sdl_poll_mouse(sdl_input_t *sdl)
    sdl->mouse_l  = (SDL_BUTTON(SDL_BUTTON_LEFT)      & btn) ? 1 : 0;
    sdl->mouse_r  = (SDL_BUTTON(SDL_BUTTON_RIGHT)     & btn) ? 1 : 0;
    sdl->mouse_m  = (SDL_BUTTON(SDL_BUTTON_MIDDLE)    & btn) ? 1 : 0;
+   sdl->mouse_b4 = (SDL_BUTTON(SDL_BUTTON_X1)        & btn) ? 1 : 0;
+   sdl->mouse_b5 = (SDL_BUTTON(SDL_BUTTON_X2)        & btn) ? 1 : 0;
 #ifndef HAVE_SDL2
    sdl->mouse_wu = (SDL_BUTTON(SDL_BUTTON_WHEELUP)   & btn) ? 1 : 0;
    sdl->mouse_wd = (SDL_BUTTON(SDL_BUTTON_WHEELDOWN) & btn) ? 1 : 0;

--- a/input/drivers/winraw_input.c
+++ b/input/drivers/winraw_input.c
@@ -32,7 +32,7 @@ typedef struct
    HANDLE hnd;
    LONG x, y, dlt_x, dlt_y;
    LONG whl_u, whl_d;
-   bool btn_l, btn_m, btn_r;
+   bool btn_l, btn_m, btn_r, btn_b4, btn_b5;
 } winraw_mouse_t;
 
 typedef struct
@@ -279,6 +279,10 @@ static int16_t winraw_mouse_state(winraw_input_t *wr,
          return mouse->whl_d ? 1 : 0;
       case RETRO_DEVICE_ID_MOUSE_MIDDLE:
          return mouse->btn_m ? 1 : 0;
+      case RETRO_DEVICE_ID_MOUSE_BUTTON_4:
+         return mouse->btn_b4 ? 1 : 0;
+      case RETRO_DEVICE_ID_MOUSE_BUTTON_5:
+         return mouse->btn_b5 ? 1 : 0;
    }
 
    return 0;
@@ -418,6 +422,16 @@ static void winraw_update_mouse_state(winraw_mouse_t *mouse, RAWMOUSE *state)
       mouse->btn_r = true;
    else if (state->usButtonFlags & RI_MOUSE_RIGHT_BUTTON_UP)
       mouse->btn_r = false;
+
+   if (state->usButtonFlags & RI_MOUSE_BUTTON_4_DOWN)
+      mouse->btn_b4 = true;
+   else if (state->usButtonFlags & RI_MOUSE_BUTTON_4_UP)
+      mouse->btn_b4 = false;
+
+   if (state->usButtonFlags & RI_MOUSE_BUTTON_5_DOWN)
+      mouse->btn_b5 = true;
+   else if (state->usButtonFlags & RI_MOUSE_BUTTON_5_UP)
+      mouse->btn_b5 = false;
 
    if (state->usButtonFlags & RI_MOUSE_WHEEL)
    {
@@ -566,6 +580,8 @@ static void winraw_poll(void *d)
       wr->mice[i].btn_l = g_mice[i].btn_l;
       wr->mice[i].btn_m = g_mice[i].btn_m;
       wr->mice[i].btn_r = g_mice[i].btn_r;
+      wr->mice[i].btn_b4 = g_mice[i].btn_b4;
+      wr->mice[i].btn_b5 = g_mice[i].btn_b5;
    }
 
    if (wr->joypad)

--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -208,6 +208,8 @@ extern "C" {
 #define RETRO_DEVICE_ID_MOUSE_MIDDLE           6
 #define RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELUP    7
 #define RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELDOWN  8
+#define RETRO_DEVICE_ID_MOUSE_BUTTON_4         9
+#define RETRO_DEVICE_ID_MOUSE_BUTTON_5         10
 
 /* Id values for LIGHTGUN types. */
 #define RETRO_DEVICE_ID_LIGHTGUN_X        0


### PR DESCRIPTION
Given the common occurrence of additional buttons on modern mice, I propose adding controls RETRO_DEVICE_ID_MOUSE_BUTTON_4 and RETRO_DEVICE_ID_MOUSE_BUTTON_5 to the set of constants. 

Sega Saturn cores can map these to the required start button input on its official mouse, to more accurately represent the real hardware. Other cores, such as for ports of Doom and Quake would also benefit.