### PR TITLE
qb: read without -r will mangle backslashes.

### DIFF
--- a/qb/qb.params.sh
+++ b/qb/qb.params.sh
@@ -29,7 +29,7 @@ EOF
 	echo ""
 	echo "Custom options:"
 
-	while IFS='=#' read VAR VAL COMMENT; do
+	while IFS='=#' read -r VAR VAL COMMENT; do
 		VAR=$(echo "${VAR##HAVE_}" | tr '[:upper:]' '[:lower:]')
 		case "$VAR" in
 			'c89_'*) continue;;
@@ -56,7 +56,7 @@ opt_exists() # $opt is returned if exists in OPTS
 }
 
 parse_input() # Parse stuff :V
-{	OPTS=; while IFS='=' read VAR dummy; do OPTS="$OPTS ${VAR##HAVE_}"; done < 'qb/config.params.sh'
+{	OPTS=; while IFS='=' read -r VAR _; do OPTS="$OPTS ${VAR##HAVE_}"; done < 'qb/config.params.sh'
 #OPTS contains all available options in config.params.sh - used to speedup
 #things in opt_exists()
 	


### PR DESCRIPTION
Silences these three shellcheck warnings. Shellcheck has an exception for dummy variables where they can be `_`. I think this is a good convention to follow as its clear.
```
Line 32:
        while IFS='=#' read VAR VAL COMMENT; do
              ^-- SC2162: read without -r will mangle backslashes.
 
Line 59:
{        OPTS=; while IFS='=' read VAR dummy; do OPTS="$OPTS ${VAR##HAVE_}"; done < 'qb/config.params.sh'
                     ^-- SC2162: read without -r will mangle backslashes.
                                      ^-- SC2034: dummy appears unused. Verify it or export it.
```
Also see these two links.
https://github.com/koalaman/shellcheck/wiki/SC2162
https://github.com/koalaman/shellcheck/wiki/SC2034