### PR TITLE
qb: Fix --enable-* options for zsh.

### DIFF
--- a/qb/qb.params.sh
+++ b/qb/qb.params.sh
@@ -50,9 +50,11 @@ EOF
 }
 
 opt_exists() # $opt is returned if exists in OPTS
-{	opt=$(echo "$1" | tr '[:lower:]' '[:upper:]')
-	for OPT in $OPTS; do [ "$opt" = "$OPT" ] && return; done
-	echo "Unknown option $2"; exit 1
+{	opt="$(echo "$1" | tr '[:lower:]' '[:upper:]')"
+	err="$2"
+	eval "set -- $OPTS"
+	for OPT do [ "$opt" = "$OPT" ] && return; done
+	echo "Unknown option $err"; exit 1
 }
 
 parse_input() # Parse stuff :V


### PR DESCRIPTION
I missed this error earlier with zsh.
```
$ zsh configure --enable-vulkan
Checking operating system ... Linux 
Unknown option --enable-vulkan
```
I chose it to do it this way because it avoids all shellcheck warnings which other solutions would not since it explicitly warns against unquoted variables which may suffer from word splitting even when that is desired.