### PR TITLE
qb: Remove old submodule tests.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -444,18 +444,6 @@ check_lib '' STRCASESTR "$CLIB" strcasestr
 check_lib '' MMAP "$CLIB" mmap
 check_lib '' VULKAN -lvulkan vkCreateInstance
 
-if [ "$HAVE_VULKAN" != 'no' ] && [ ! -e deps/glslang/glslang/README.md ]; then
-	echo "Warning: glslang submodule not loaded, can't use Vulkan."
-	echo "To fix, use:  git submodule init && git submodule update"
-	HAVE_VULKAN=no
-fi
-
-if [ "$HAVE_VULKAN" != 'no' ] && [ ! -e deps/SPIRV-Cross/README.md ]; then
-	echo "Warning: SPIRV-Cross submodule not loaded, can't use Vulkan."
-	echo "To fix, use:  git submodule init && git submodule update"
-	HAVE_VULKAN=no
-fi
-
 check_pkgconf PYTHON python3
 
 if [ "$HAVE_MATERIALUI" != 'no' ] || [ "$HAVE_XMB" != 'no' ] || [ "$HAVE_ZARCH" != 'no' ]; then


### PR DESCRIPTION
RetroArch no longer uses submodules for various good reasons and now uses git subtrees instead. As a result these files will always exist and these tests will always be true.