### PR TITLE
qb: Add a die function to print a warning or exit messages.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -35,8 +35,7 @@ elif [ "$OS" = 'Win32' ]; then
    SOCKETHEADER="#include <winsock2.h>"
    DYLIB=
 elif [ "$OS" = 'Cygwin' ]; then
-   echo "Error: Cygwin is not a supported platform. See https://bot.libretro.com/docs/compilation/windows/"
-   exit 1
+   die 1 'Error: Cygwin is not a supported platform. See https://bot.libretro.com/docs/compilation/windows/'
 fi
 
 add_define_make DYLIB_LIB "$DYLIB"
@@ -79,7 +78,7 @@ if [ "$HAVE_7ZIP" = "yes" ]; then
 fi
 
 if [ "$HAVE_PRESERVE_DYLIB" = "yes" ]; then
-   echo "Notice: Disabling dlclose() of shared objects for Valgrind support."
+   die : 'Notice: Disabling dlclose() of shared objects for Valgrind support.'
    add_define_make HAVE_PRESERVE_DYLIB "1"
 fi
 
@@ -143,7 +142,7 @@ if [ "$HAVE_DISPMANX" != "no" ]; then
 fi
 
 if [ "$LIBRETRO" ]; then
-   echo "Notice: Explicit libretro used, disabling dynamic libretro loading ..."
+   die : 'Notice: Explicit libretro used, disabling dynamic libretro loading ...'
    HAVE_DYNAMIC='no'
 else LIBRETRO="-lretro"
 fi
@@ -197,7 +196,7 @@ if [ "$HAVE_NETWORKING" = 'yes' ]; then
       check_lib '' GETADDRINFO "$SOCKETLIB" getaddrinfo
       if [ "$HAVE_GETADDRINFO" != 'yes' ]; then
          HAVE_SOCKET_LEGACY=yes
-         echo "Notice: RetroArch will use legacy socket support"
+         die : 'Notice: RetroArch will use legacy socket support'
       fi
    fi
    HAVE_NETWORK_CMD=yes
@@ -211,7 +210,7 @@ if [ "$HAVE_NETWORKING" = 'yes' ]; then
       HAVE_MINIUPNPC='yes'
    fi
 else
-   echo "Warning: All networking features have been disabled."
+   die : 'Warning: All networking features have been disabled.'
    HAVE_KEYMAPPER='no'
    HAVE_NETWORK_CMD='no'
    HAVE_NETWORKGAMEPAD='no'
@@ -229,8 +228,7 @@ fi
 check_lib '' GETOPT_LONG "$CLIB" getopt_long
 
 if [ "$HAVE_DYLIB" = 'no' ] && [ "$HAVE_DYNAMIC" = 'yes' ]; then
-   echo "Error: Dynamic loading of libretro is enabled, but your platform does not appear to have dlopen(), use --disable-dynamic or --with-libretro=\"-lretro\"".
-   exit 1
+   die 1 'Error: Dynamic loading of libretro is enabled, but your platform does not appear to have dlopen(), use --disable-dynamic or --with-libretro="-lretro".'
 fi
 
 check_pkgconf ALSA alsa
@@ -266,10 +264,10 @@ check_pkgconf SDL2 sdl2 2.0.0
 
 if [ "$HAVE_SDL2" = 'yes' ]; then
    if [ "$HAVE_SDL2" = 'yes' ] && [ "$HAVE_SDL" = 'yes' ]; then
-      echo "Notice: SDL drivers will be replaced by SDL2 ones."
+      die : 'Notice: SDL drivers will be replaced by SDL2 ones.'
       HAVE_SDL=no
    elif [ "$HAVE_SDL2" = 'no' ]; then
-      echo "Warning: SDL2 not found, skipping."
+      die : 'Warning: SDL2 not found, skipping.'
       HAVE_SDL2=no
    fi
 fi
@@ -321,7 +319,7 @@ if [ "$HAVE_OPENGL" != 'no' ] && [ "$HAVE_OPENGLES" != 'yes' ]; then
 
       check_pkgconf OSMESA osmesa
    else
-      echo "Notice: Ignoring Cg. Desktop OpenGL is not enabled."
+      die : 'Notice: Ignoring Cg. Desktop OpenGL is not enabled.'
       HAVE_CG='no'
    fi
 fi
@@ -349,11 +347,11 @@ if [ "$HAVE_THREADS" != 'no' ]; then
       HAVE_FFMPEG='yes'
       if [ "$HAVE_AVCODEC" = 'no' ] || [ "$HAVE_SWRESAMPLE" = 'no' ] || [ "$HAVE_AVFORMAT" = 'no' ] || [ "$HAVE_AVUTIL" = 'no' ] || [ "$HAVE_SWSCALE" = 'no' ]; then
          HAVE_FFMPEG='no'
-         echo "Notice: FFmpeg built-in support disabled due to missing or unsuitable packages."
+         die : 'Notice: FFmpeg built-in support disabled due to missing or unsuitable packages.'
       fi
    fi
 else
-   echo "Notice: Not building with threading support. Will skip FFmpeg."
+   die : 'Notice: Not building with threading support. Will skip FFmpeg.'
    HAVE_FFMPEG='no'
 fi
 
@@ -367,8 +365,7 @@ if [ "$HAVE_KMS" != "no" ]; then
    if [ "$HAVE_GBM" = "yes" ] && [ "$HAVE_DRM" = "yes" ] && [ "$HAVE_EGL" = "yes" ]; then
       HAVE_KMS=yes
    elif [ "$HAVE_KMS" = "yes" ]; then
-      echo "Error: Cannot find libgbm, libdrm and EGL libraries required for KMS. Compile without --enable-kms."
-      exit 1
+      die 1 'Error: Cannot find libgbm, libdrm and EGL libraries required for KMS. Compile without --enable-kms.'
    else
       HAVE_KMS=no
    fi
@@ -379,7 +376,7 @@ check_pkgconf LIBXML2 libxml-2.0
 if [ "$HAVE_EGL" = "yes" ]; then
    if [ "$HAVE_OPENGLES" != "no" ]; then
       if [ "$OPENGLES_LIBS" ] || [ "$OPENGLES_CFLAGS" ]; then
-         echo "Notice: Using custom OpenGLES CFLAGS ($OPENGLES_CFLAGS) and LDFLAGS ($OPENGLES_LIBS)."
+         die : "Notice: Using custom OpenGLES CFLAGS ($OPENGLES_CFLAGS) and LDFLAGS ($OPENGLES_LIBS)."
          add_define_make OPENGLES_LIBS "$OPENGLES_LIBS"
          add_define_make OPENGLES_CFLAGS "$OPENGLES_CFLAGS"
       else
@@ -419,7 +416,7 @@ check_pkgconf XINERAMA xinerama
 if [ "$HAVE_X11" = 'yes' ] && [ "$HAVE_XEXT" = 'yes' ] && [ "$HAVE_XF86VM" = 'yes' ]; then
    check_pkgconf XVIDEO xv
 else
-   echo "Notice: X11, Xext or xf86vm not present. Skipping X11 code paths."
+   die : 'Notice: X11, Xext or xf86vm not present. Skipping X11 code paths.'
    HAVE_X11='no'
    HAVE_XVIDEO='no'
 fi
@@ -451,19 +448,19 @@ if [ "$HAVE_MATERIALUI" != 'no' ] || [ "$HAVE_XMB" != 'no' ] || [ "$HAVE_ZARCH" 
       HAVE_MATERIALUI=no
       HAVE_XMB=no
       HAVE_ZARCH=no
-      echo "Notice: RGUI not available, MaterialUI, XMB and ZARCH will also be disabled."
+      die : 'Notice: RGUI not available, MaterialUI, XMB and ZARCH will also be disabled.'
    elif [ "$HAVE_OPENGL" = 'no' ] && [ "$HAVE_OPENGLES" = 'no' ] && [ "$HAVE_VULKAN" = 'no' ]; then
       if [ "$OS" = 'Win32' ]; then
          HAVE_SHADERPIPELINE=no
          HAVE_VULKAN=no
-         echo "Notice: Hardware rendering context not available."
+         die : 'Notice: Hardware rendering context not available.'
       elif [ "$HAVE_CACA" = 'yes' ]; then
-         echo "Notice: Hardware rendering context not available."
+         die : 'Notice: Hardware rendering context not available.'
       else
          HAVE_MATERIALUI=no
          HAVE_XMB=no
          HAVE_ZARCH=no
-         echo "Notice: Hardware rendering context not available, XMB, MaterialUI and ZARCH will also be disabled."
+         die : 'Notice: Hardware rendering context not available, XMB, MaterialUI and ZARCH will also be disabled.'
       fi
    fi
 fi
@@ -474,12 +471,12 @@ add_define_make OS "$OS"
 
 if [ "$HAVE_ZLIB" = 'no' ] && [ "$HAVE_RPNG" != 'no' ]; then
    HAVE_RPNG=no
-   echo "Notice: zlib is not available, RPNG will also be disabled."
+   die : 'Notice: zlib is not available, RPNG will also be disabled.'
 fi
 
 if [ "$HAVE_THREADS" = 'no' ] && [ "$HAVE_LIBUSB" != 'no' ]; then
    HAVE_LIBUSB=no
-   echo "Notice: Threads are not available, libusb will also be disabled."
+   die : 'Notice: Threads are not available, libusb will also be disabled.'
 fi
 
 if [ "$HAVE_V4L2" != 'no' ] && [ "$HAVE_VIDEOPROCESSOR" != 'no' ]; then

--- a/qb/qb.comp.sh
+++ b/qb/qb.comp.sh
@@ -31,8 +31,7 @@ fi
 echo "Checking for suitable working C compiler ... $CC $cc_status"
 
 if [ "$cc_works" = '0' ] && [ "$USE_LANG_C" = 'yes' ]; then
-	echo "Error: Cannot proceed without a working C compiler."
-	exit 1
+	die 1 'Error: Cannot proceed without a working C compiler.'
 fi
 
 # Checking for working C++
@@ -62,15 +61,14 @@ fi
 echo "Checking for suitable working C++ compiler ... $CXX $cxx_status"
 
 if [ "$cxx_works" = '0' ] && [ "$USE_LANG_CXX" = 'yes' ]; then
-	echo "Error: Cannot proceed without a working C++ compiler."
-	exit 1
+	die 1 'Error: Cannot proceed without a working C++ compiler.'
 fi
 
 if [ "$OS" = "Win32" ]; then
 	echobuf="Checking for windres"
 	if [ -z "$WINDRES" ]; then
 		WINDRES=$(which ${CROSS_COMPILE}windres)
-		[ "$WINDRES" ] || { echo "$echobuf ... Not found. Exiting."; exit 1; }
+		[ "$WINDRES" ] || die 1 "$echobuf ... Not found. Exiting."
 	fi
 	echo "$echobuf ... $WINDRES"
 fi
@@ -90,5 +88,5 @@ fi
 echo "Checking for pkg-config ... $PKG_CONF_PATH"
 
 if [ "$PKG_CONF_PATH" = "none" ]; then
-	echo "Warning: pkg-config not found, package checks will fail."
+	die : 'Warning: pkg-config not found, package checks will fail.'
 fi

--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -60,10 +60,9 @@ check_lib() # $1 = language  $2 = HAVE_$2  $3 = lib  $4 = function in lib  $5 = 
 	rm -f -- "$TEMP_CODE" "$TEMP_EXE"
 
 	[ "$answer" = 'no' ] && {
-		[ "$7" ] && { echo "$7"; exit 1;}
+		[ "$7" ] && die 1 "$7"
 		[ "$tmpval" = 'yes' ] && {
-			echo "Forced to build with library $3, but cannot locate. Exiting ..."
-			exit 1
+			die 1 "Forced to build with library $3, but cannot locate. Exiting ..."
 		}
 
 	}
@@ -119,11 +118,9 @@ check_pkgconf()	#$1 = HAVE_$1	$2 = package	$3 = version	$4 = critical error mess
 	echo "$ECHOBUF ... $version"
 	PKG_CONF_USED="$PKG_CONF_USED $1"
 	[ "$answer" = 'no' ] && {
-		[ "$4" ] && { echo "$4"; exit 1;}
-		[ "$tmpval" = 'yes' ] && {
-			echo "Forced to build with package $2, but cannot locate. Exiting ..."
-			exit 1
-		}
+		[ "$4" ] && die 1 "$4"
+		[ "$tmpval" = 'yes' ] && \
+			die 1 "Forced to build with package $2, but cannot locate. Exiting ..."
 	}
 }
 
@@ -140,10 +137,8 @@ check_header()	#$1 = HAVE_$1	$2..$5 = header files
 	"$CC" -o "$TEMP_EXE" "$TEMP_C" $INCLUDE_DIRS >>config.log 2>&1 && answer='yes'
 	eval HAVE_$1="$answer"; echo "Checking presence of header file $CHECKHEADER ... $answer"
 	rm -f -- "$TEMP_C" "$TEMP_EXE"
-	[ "$tmpval" = 'yes' ] && [ "$answer" = 'no' ] && {
-		echo "Build assumed that $2 exists, but cannot locate. Exiting ..."
-		exit 1
-	}
+	[ "$tmpval" = 'yes' ] && [ "$answer" = 'no' ] && \
+		die 1 "Build assumed that $2 exists, but cannot locate. Exiting ..."
 }
 
 check_macro()	#$1 = HAVE_$1	$2 = macro name
@@ -160,10 +155,8 @@ EOF
 	"$CC" -o "$TEMP_EXE" "$TEMP_C" $CFLAGS $INCLUDE_DIRS >>config.log 2>&1 && answer='yes'
 	eval HAVE_$1="$answer"; echo "$ECHOBUF ... $answer"
 	rm -f -- "$TEMP_C" "$TEMP_EXE"
-	[ "$tmpval" = 'yes' ] && [ "$answer" = 'no' ] && {
-		echo "Build assumed that $2 is defined, but it's not. Exiting ..."
-		exit 1
-	}
+	[ "$tmpval" = 'yes' ] && [ "$answer" = 'no' ] && \
+		die 1 "Build assumed that $2 is defined, but it's not. Exiting ..."
 }
 
 check_switch_c()	#$1 = HAVE_$1	$2 = switch	$3 = critical error message [checked only if non-empty]
@@ -174,7 +167,7 @@ check_switch_c()	#$1 = HAVE_$1	$2 = switch	$3 = critical error message [checked 
 	eval HAVE_$1="$answer"; echo "$ECHOBUF ... $answer"
 	rm -f -- "$TEMP_C" "$TEMP_EXE"
 	[ "$answer" = 'no' ] && {
-		[ "$3" ] && { echo "$3"; exit 1;}
+		[ "$3" ] && die 1 "$3"
 	}
 }
 
@@ -186,7 +179,7 @@ check_switch_cxx()	#$1 = HAVE_$1	$2 = switch	$3 = critical error message [checke
 	eval HAVE_$1="$answer"; echo "$ECHOBUF ... $answer"
 	rm -f -- "$TEMP_CXX" "$TEMP_EXE"
 	[ "$answer" = 'no' ] && {
-		[ "$3" ] && { echo "$3"; exit 1;}
+		[ "$3" ] && die 1 "$3"
 	}
 }
 

--- a/qb/qb.params.sh
+++ b/qb/qb.params.sh
@@ -1,3 +1,14 @@
+die() # $1 = exit code, use : to not exit when printing warnings $@ = exit or warning messages
+{
+	ret="$1"
+	shift 1
+	printf %s\\n "$@" >&2
+	case "$ret" in
+		: ) return 0 ;;
+		* ) exit "$ret" ;;
+	esac
+}
+
 print_help_option() # $1 = option $@ = description
 {
 	_opt="$1"
@@ -54,7 +65,7 @@ opt_exists() # $opt is returned if exists in OPTS
 	err="$2"
 	eval "set -- $OPTS"
 	for OPT do [ "$opt" = "$OPT" ] && return; done
-	echo "Unknown option $err"; exit 1
+	die 1 "Unknown option $err"
 }
 
 parse_input() # Parse stuff :V
@@ -83,7 +94,7 @@ parse_input() # Parse stuff :V
 				eval "$opt=\"$val\""
 			;;
 			-h|--help) print_help; exit 0;;
-			*) echo "Unknown option $1"; exit 1;;
+			*) die 1 "Unknown option $1";;
 		esac
 		shift
 	done
@@ -91,4 +102,4 @@ parse_input() # Parse stuff :V
 
 . qb/config.params.sh
 
-parse_input "$@" 
+parse_input "$@"


### PR DESCRIPTION
This adds the following function to `qb.params.sh` which allows an easy way to handle error and warning messages. Additionally it will correctly redirect the output to stderr.
```
die() # $1 = exit code, use : to not exit when printing warnings $@ = exit or warning messages
{
	ret="$1"
	shift 1
	printf %s\\n "$@" >&2
	case "$ret" in
		: ) return 0 ;;
		* ) exit "$ret" ;;
	esac
}
```