### PR TITLE
Fix Slow Motion message timing and priority

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -2898,10 +2898,10 @@ static enum runloop_state runloop_check_state(
 
          if (state_manager_frame_is_reversed())
             runloop_msg_queue_push(
-                  msg_hash_to_str(MSG_SLOW_MOTION_REWIND), 2, 30, true);
+                  msg_hash_to_str(MSG_SLOW_MOTION_REWIND), 1, 1, false);
          else
             runloop_msg_queue_push(
-                  msg_hash_to_str(MSG_SLOW_MOTION), 2, 30, true);
+                  msg_hash_to_str(MSG_SLOW_MOTION), 1, 1, false);
       }
    }
 


### PR DESCRIPTION
This makes three changes to the Slow motion and Slow motion rewind messages:

1. Makes the "Slow motion." message show only when it's in slow motion (reduce `delay`)
2. Lowers the priority of the message so that it doesn't overtake over FPS display (reduce `priority`)
3. Makes it so that it doesn't clear the previous message (remove `flash`)