### PR TITLE
qb: Add some safe defaults.

### DIFF
--- a/qb/qb.system.sh
+++ b/qb/qb.system.sh
@@ -1,3 +1,7 @@
+IFS=' 	
+'
+\unalias -a 2>/dev/null
+PATH="$(command -p getconf PATH):$PATH"
 
 if [ -n "$CROSS_COMPILE" ]; then
 	case "$CROSS_COMPILE" in
@@ -26,4 +30,3 @@ if [ -e /etc/lsb-release ]; then
 fi
 
 echo "Checking operating system ... $OS ${DISTRO}"
-


### PR DESCRIPTION
This commit does three things in the hopes its makes the qb scripts a little more robust and failsafe. Please wait for the buildbot to ensure this is okay.

1. It sets `$IFS` to its default value of `<space><tab><newline>`.
2. It unaliases all aliases, `unalias` is escaped to ensure it is not an alias itself and the output is redirected to `/dev/null` since some limited shells do not have any aliases at all and this command will error harmlessly there.
3. `$PATH` is set to a safe default with `getconf`, I think this command should be available everywhere the `configure` script is used, but the buildbot will help test that.

This is adopted from the examples at the POSIX spec for `command`.
See here. http://pubs.opengroup.org/onlinepubs/9699919799/utilities/command.html