### PR TITLE
Fix strdup() memory leak

### DIFF
--- a/menu/widgets/menu_dialog.c
+++ b/menu/widgets/menu_dialog.c
@@ -263,8 +263,13 @@ void menu_dialog_push(void)
 
    info.list                 = menu_entries_get_menu_stack_ptr(0);
    info.enum_idx             = MENU_ENUM_LABEL_HELP;
-   info.label                = strdup(
-         msg_hash_to_str(MENU_ENUM_LABEL_HELP));
+
+   // Set the label string, if it exists.
+   const char *label = msg_hash_to_str(MENU_ENUM_LABEL_HELP);
+   if (label)
+   {
+      info.label = strdup(label);
+   }
 
    menu_displaylist_ctl(DISPLAYLIST_HELP, &info);
 }

--- a/menu/widgets/menu_dialog.c
+++ b/menu/widgets/menu_dialog.c
@@ -255,6 +255,7 @@ void menu_dialog_push_pending(bool push, enum menu_dialog_type type)
 void menu_dialog_push(void)
 {
    menu_displaylist_info_t info;
+   const char *label;
 
    if (!menu_dialog_is_push_pending())
       return;
@@ -264,10 +265,10 @@ void menu_dialog_push(void)
    info.list                 = menu_entries_get_menu_stack_ptr(0);
    info.enum_idx             = MENU_ENUM_LABEL_HELP;
 
-   // Set the label string, if it exists.
-   const char *label = msg_hash_to_str(MENU_ENUM_LABEL_HELP);
+   /* Set the label string, if it exists. */
+   label                     = msg_hash_to_str(MENU_ENUM_LABEL_HELP);
    if (label)
-      info.label = strdup(label);
+      info.label             = strdup(label);
 
    menu_displaylist_ctl(DISPLAYLIST_HELP, &info);
 }

--- a/menu/widgets/menu_dialog.c
+++ b/menu/widgets/menu_dialog.c
@@ -267,9 +267,7 @@ void menu_dialog_push(void)
    // Set the label string, if it exists.
    const char *label = msg_hash_to_str(MENU_ENUM_LABEL_HELP);
    if (label)
-   {
       info.label = strdup(label);
-   }
 
    menu_displaylist_ctl(DISPLAYLIST_HELP, &info);
 }


### PR DESCRIPTION
Protect against strdup() calls with no string.

```
Direct leak of 5 byte(s) in 1 object(s) allocated from:
    #0 0x7f8b9d06d30f in strdup (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x6230f)
    #1 0x6adf87 in menu_dialog_push menu/widgets/menu_dialog.c:266
    #2 0x74e363 in generic_menu_iterate menu/drivers/menu_generic.c:243
    #3 0x677061 in menu_driver_iterate menu/menu_driver.c:1682
    #4 0x424526 in runloop_check_state /home/rob/Documents/RetroArch/retroarch.c:2546
    #5 0x426acc in runloop_iterate /home/rob/Documents/RetroArch/retroarch.c:3067
    #6 0x4182d7 in rarch_main frontend/frontend.c:131
    #7 0x4183cc in main frontend/frontend.c:151
    #8 0x7f8b97bb782f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)
```