### PR TITLE
qb: Add a function to find executables in the $PATH

### DIFF
--- a/qb/qb.comp.sh
+++ b/qb/qb.comp.sh
@@ -14,7 +14,7 @@ cc_works=0
 if [ "$CC" ]; then
 	"$CC" -o "$TEMP_EXE" "$TEMP_C" >/dev/null 2>&1 && cc_works=1
 else
-	for CC in $(printf %s "$(which ${CROSS_COMPILE}gcc ${CROSS_COMPILE}cc ${CROSS_COMPILE}clang 2>/dev/null)") ''; do
+	for CC in $(exists ${CROSS_COMPILE}gcc ${CROSS_COMPILE}cc ${CROSS_COMPILE}clang) ''; do
 		"$CC" -o "$TEMP_EXE" "$TEMP_C" >/dev/null 2>&1 && cc_works=1 && break
 	done
 fi
@@ -44,7 +44,7 @@ cxx_works=0
 if [ "$CXX" ]; then
 	"$CXX" -o "$TEMP_EXE" "$TEMP_CXX" >/dev/null 2>&1 && cxx_works=1
 else
-	for CXX in $(printf %s "$(which ${CROSS_COMPILE}g++ ${CROSS_COMPILE}c++ ${CROSS_COMPILE}clang++ 2>/dev/null)") ''; do
+	for CXX in $(exists ${CROSS_COMPILE}g++ ${CROSS_COMPILE}c++ ${CROSS_COMPILE}clang++) ''; do
 		"$CXX" -o "$TEMP_EXE" "$TEMP_CXX" >/dev/null 2>&1 && cxx_works=1 && break
 	done
 fi
@@ -67,7 +67,7 @@ fi
 if [ "$OS" = "Win32" ]; then
 	echobuf="Checking for windres"
 	if [ -z "$WINDRES" ]; then
-		WINDRES=$(which ${CROSS_COMPILE}windres)
+		WINDRES=$(exists ${CROSS_COMPILE}windres)
 		[ "$WINDRES" ] || die 1 "$echobuf ... Not found. Exiting."
 	fi
 	echo "$echobuf ... $WINDRES"
@@ -76,7 +76,7 @@ fi
 [ -n "$PKG_CONF_PATH" ] || {
 	PKG_CONF_PATH="none"
 
-	for p in $(which "${CROSS_COMPILE}pkg-config" 2>/dev/null) ''; do
+	for p in $(exists "${CROSS_COMPILE}pkg-config") ''; do
 		[ -n "$p" ] && {
 			PKG_CONF_PATH=$p;
 			break;

--- a/qb/qb.system.sh
+++ b/qb/qb.system.sh
@@ -1,3 +1,24 @@
+exists() # checks executables listed in $@ against the $PATH
+{
+	v=1
+	while [ "$#" -gt 0 ]; do
+		arg="$1"
+		shift 1
+		case "$arg" in ''|*/) continue ;; esac
+		x="${arg##*/}"
+		z="${arg%/*}"
+		[ ! -f "$z/$x" ] || [ ! -x "$z/$x" ] && [ "$z/$x" = "$arg" ] && continue
+		[ "$x" = "$z" ] && [ -x "$z/$x" ] && [ ! -f "$arg" ] && z=
+		p=":$z:$PATH"
+		while [ "$p" != "${p#*:}" ]; do
+			p="${p#*:}"
+			d="${p%%:*}"
+			{ [ -f "$d/$x" ] && [ -x "$d/$x" ] && \
+				{ printf %s\\n "$d/$x"; v=0; break; }; } || :
+		done
+	done
+	return "$v"
+}
 
 if [ -n "$CROSS_COMPILE" ]; then
 	case "$CROSS_COMPILE" in
@@ -26,4 +47,3 @@ if [ -e /etc/lsb-release ]; then
 fi
 
 echo "Checking operating system ... $OS ${DISTRO}"
-


### PR DESCRIPTION
NOTE: It would be good to test this with windows and let the buildbot finish before merging, if it fails to find any compilers with the configure script then there is a problem and this should not be merged.

This function also addresses several edge cases which the configure script should never encounter, but are best to include for easy portability to other scripts.

This function intends to achieve a fully portable and robust pure shell solution to `which` vs `command -v` neither which are advisable to use in portable shell scripts and will find executable files in the `$PATH`. It will require a sane `$PATH` variable, but the same could be said for the current solution which uses `which`.

`command -v` is an optional component of the POSIX spec and the debian script `checkbashisms` will warn against its use. Additionally its not implemented in very limited shells like `posh` and has inconsistent behavior in some other shells such as `mksh`. `which` is an inheritance from c shells with many different implementations and its problems are explained in depth in the following link.

https://unix.stackexchange.com/questions/85249/why-not-use-which-what-to-use-then/85250#85250

The function is placed in `qb.system.sh` because that is the first sourced file and makes it easier to use the function anywhere else in the script.
```
exists () # checks executables listed in $@ against the $PATH
{
	v=1
	while [ "$#" -gt 0 ]; do
		arg="$1"
		shift 1
		case "$arg" in ''|*/) continue ;; esac
		x="${arg##*/}"
		z="${arg%/*}"
		[ ! -f "$z/$x" ] || [ ! -x "$z/$x" ] && [ "$z/$x" = "$arg" ] && continue
		[ "$x" = "$z" ] && [ -x "$z/$x" ] && [ ! -f "$arg" ] && z=
		p=":$z:$PATH"
		while [ "$p" != "${p#*:}" ]; do
			p="${p#*:}"
			d="${p%%:*}"
			{ [ -f "$d/$x" ] && [ -x "$d/$x" ] && \
				{ printf %s\\n "$d/$x"; v=0; break; }; } || :
		done
	done
	return "$v"
}
```