### PR TITLE
cheevos: do not show "0 of 0 cheevos unlocked" msg

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -2853,7 +2853,7 @@ static int cheevos_iterate(coro_t* coro)
             runloop_msg_queue_push(msg, 0, 6 * 60, false);
          }
          else
-            runloop_msg_queue_push("This game doesn't have any achievement.", 0, 5 * 60, false);
+            runloop_msg_queue_push("This game has no achievements.", 0, 5 * 60, false);
 
       }
 

--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -2830,25 +2830,31 @@ static int cheevos_iterate(coro_t* coro)
 
       if(CHEEVOS_VAR_SETTINGS->bools.cheevos_verbose_enable)
       {
-         const cheevo_t* cheevo       = cheevos_locals.core.cheevos;
-         const cheevo_t* end          = cheevo + cheevos_locals.core.count;
-         int number_of_unlocked       = cheevos_locals.core.count;
-         int mode;
-         char msg[256];
+         if(cheevos_locals.core.count > 0)
+         {
+            const cheevo_t* cheevo       = cheevos_locals.core.cheevos;
+            const cheevo_t* end          = cheevo + cheevos_locals.core.count;
+            int number_of_unlocked       = cheevos_locals.core.count;
+            int mode;
+            char msg[256];
 
-         if(CHEEVOS_VAR_SETTINGS->bools.cheevos_hardcore_mode_enable)
-            mode = CHEEVOS_ACTIVE_HARDCORE;
+            if(CHEEVOS_VAR_SETTINGS->bools.cheevos_hardcore_mode_enable)
+               mode = CHEEVOS_ACTIVE_HARDCORE;
+            else
+               mode = CHEEVOS_ACTIVE_SOFTCORE;
+
+            for(; cheevo < end; cheevo++)
+               if(cheevo->active & mode)
+                  number_of_unlocked--;
+
+            snprintf(msg, sizeof(msg), "You have %d of %d achievements unlocked.",
+               number_of_unlocked, cheevos_locals.core.count);
+            msg[sizeof(msg) - 1] = 0;
+            runloop_msg_queue_push(msg, 0, 6 * 60, false);
+         }
          else
-            mode = CHEEVOS_ACTIVE_SOFTCORE;
+            runloop_msg_queue_push("This game doesn't have any achievement.", 0, 5 * 60, false);
 
-         for(; cheevo < end; cheevo++)
-            if(cheevo->active & mode)
-               number_of_unlocked--;
-
-         snprintf(msg, sizeof(msg), "You have %d of %d achievements unlocked.",
-            number_of_unlocked, cheevos_locals.core.count);
-         msg[sizeof(msg) - 1] = 0;
-         runloop_msg_queue_push(msg, 0, 6 * 60, false);
       }
 
       CORO_STOP();


### PR DESCRIPTION
**This happens only if `cheevos_verbose_enable = true`.**

When loading a game that doesn't have any achievement, instead of showing an OSD message saying "**You have 0 of 0 achievements unlocked.**" just say "**This game has no achievements.**"

I've just added an `if(cheevos_locals.core.count > 0)`, added indentation, and an one-liner else. The diff makes it look like it got more changes than it actually did.