### PR TITLE
qb: Honor the --build option.

### DIFF
--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -230,6 +230,7 @@ create_config_make()
 		echo "INCLUDE_DIRS = $INCLUDE_DIRS"
 		echo "LIBRARY_DIRS = $LIBRARY_DIRS"
 		echo "PACKAGE_NAME = $PACKAGE_NAME"
+		echo "BUILD = $BUILD"
 		echo "PREFIX = $PREFIX"
 
 		while [ "$1" ]; do

--- a/qb/qb.params.sh
+++ b/qb/qb.params.sh
@@ -34,6 +34,7 @@ General options:
 EOF
 	print_help_option "--prefix=PATH"            "Install path prefix"
 	print_help_option "--global-config-dir=PATH" "System wide config file prefix"
+	print_help_option "--build=BUILD"            "The build system (no-op)"
 	print_help_option "--host=HOST"              "call HOST-gcc instead of gcc; can be used for cross compilation"
 	print_help_option "--help"                   "Show this help"
 
@@ -83,6 +84,7 @@ parse_input() # Parse stuff :V
 		case "$1" in
 			--prefix=*) PREFIX=${1##--prefix=};;
 			--global-config-dir=*) GLOBAL_CONFIG_DIR=${1##--global-config-dir=};;
+			--build=*) BUILD="${1#*=}";;
 			--host=*) CROSS_COMPILE=${1##--host=}-;;
 			--enable-*)
 				opt_exists "${1##--enable-}" "$1"

--- a/qb/qb.params.sh
+++ b/qb/qb.params.sh
@@ -35,7 +35,7 @@ EOF
 	print_help_option "--prefix=PATH"            "Install path prefix"
 	print_help_option "--global-config-dir=PATH" "System wide config file prefix"
 	print_help_option "--build=BUILD"            "The build system (no-op)"
-	print_help_option "--host=HOST"              "call HOST-gcc instead of gcc; can be used for cross compilation"
+	print_help_option "--host=HOST"              "Cross-compile with HOST-gcc instead of gcc"
 	print_help_option "--help"                   "Show this help"
 
 	echo ""


### PR DESCRIPTION
This doesn't really add anything of value other than offering compat with autotools configure flags. Some distros have apparently patched RetroArch to not exit on configure with `--build`. See this gentoo patch for example.

https://pastebin.com/p1BvUhC9