### PR TITLE
Expand symlinks in default configuration paths for iOS devices

### DIFF
--- a/frontend/drivers/platform_darwin.m
+++ b/frontend/drivers/platform_darwin.m
@@ -48,6 +48,7 @@
 
 #include <boolean.h>
 #include <compat/apple_compat.h>
+#include <retro_assert.h>
 #include <retro_miscellaneous.h>
 #include <file/file_path.h>
 #include <rhash.h>
@@ -334,6 +335,15 @@ static void frontend_darwin_get_environment_settings(int *argc, char *argv[],
 
    CFSearchPathForDirectoriesInDomains(CFDocumentDirectory,
          CFUserDomainMask, 1, home_dir_buf, sizeof(home_dir_buf));
+
+#if TARGET_OS_IPHONE
+   char resolved_home_dir_buf[PATH_MAX_LENGTH] = {0};
+   if (realpath(home_dir_buf, resolved_home_dir_buf)) {
+      retro_assert(strlcpy(home_dir_buf,
+            resolved_home_dir_buf,
+            sizeof(home_dir_buf)) < sizeof(home_dir_buf));
+   }
+#endif
 
    strlcat(home_dir_buf, "/RetroArch", sizeof(home_dir_buf));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_SHADER],


### PR DESCRIPTION
`CFSearchPathForDirectoriesInDomains` returns a path in `/var`, while `getenv(HOME)` returns the same path in `/private/var`. `/var` is a symlink to `/private/var`, but when config is generated, the difference in paths means they won't be abbreviated correctly.

This change expands symlinks before filling in the default directories, so those paths will match.

There's still an issue where paths set to `default` will use use `/var`, which won't be expanded. It also seems like playlists write the absolute path, instead of abbreviating it -- that means playlists and the recent content list still won't work after a reinstall of the app. I'm not sure what the best way to resolve that is, but this fix alone makes upgrades a lot less painful.