### PR TITLE
Fix memory leak with strdup() usage

### DIFF
--- a/dynamic.c
+++ b/dynamic.c
@@ -356,12 +356,11 @@ bool libretro_get_system_info(const char *path,
    memcpy(info, &dummy_info, sizeof(*info));
 
    if (!string_is_empty(dummy_info.library_name))
-      info->library_name    = strdup(dummy_info.library_name);
+      info->library_name    = strndup(dummy_info.library_name, strlen(dummy_info.library_name));
    if (!string_is_empty(dummy_info.library_version))
-      info->library_version    = strdup(dummy_info.library_version);
-
-   if (dummy_info.valid_extensions)
-      info->valid_extensions = strdup(dummy_info.valid_extensions);
+      info->library_version    = strndup(dummy_info.library_version, strlen(dummy_info.library_version));
+   if (!string_is_empty(dummy_info.valid_extensions))
+      info->valid_extensions = strndup(dummy_info.valid_extensions, strlen(dummy_info.valid_extensions));
 
 #ifdef HAVE_DYNAMIC
    dylib_close(lib);


### PR DESCRIPTION
This updates to use `strndup()` to avoid running into memory leaks. The below is one such example of a memory leak of this sort:

```
Direct leak of 15 byte(s) in 1 object(s) allocated from:
    #0 0x7f079f50a30f in strdup (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x6230f)
    #1 0x526d93 in libretro_get_system_info /home/rob/Documents/RetroArch/dynamic.c:361
    #2 0x4328b9 in command_event /home/rob/Documents/RetroArch/command.c:1750
    #3 0x677200 in menu_update_libretro_info menu/menu_driver.c:1703
    #4 0x67721f in menu_driver_init_internal menu/menu_driver.c:1709
    #5 0x6774ff in menu_driver_init menu/menu_driver.c:1744
```