### PR TITLE
qb: Fix undefined udev references without pkg-config

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -425,7 +425,10 @@ if [ "$HAVE_UDEV" != "no" ]; then
    check_pkgconf UDEV libudev
    if [ "$HAVE_UDEV" = "no" ]; then
       HAVE_UDEV=auto; check_lib '' UDEV "-ludev"
-      [ "$HAVE_UDEV" = "yes" ] && UDEV_LIBS=-ludev
+      if [ "$HAVE_UDEV" = "yes" ]; then
+         UDEV_LIBS='-ludev'
+         PKG_CONF_USED="$PKG_CONF_USED UDEV"
+      fi
    fi
 fi
 


### PR DESCRIPTION
If trying to compile RetroArch on linux without a pkg-config implementation installed it will use a fallback lib check path and set various variables accordingly. The problem is that unless the variables start with `$HAVE_` they will not be added to the `config.mk` unless they are included in the `$PKG_CONF_USED` variable which is only automatically set if pkg-config detects them. So doing this manually for udev in the fallback path if its detected fixes these undefined references. Please note that there are still several undefined references to `egl_common.c` and further it will segfault if compiled with `--disable-egl`. So while this does fix the the issues without pkg-config entirely, it does make a good first step.
```
obj-unix/input/drivers/udev_input.o: In function `open_devices':
/home/orbea/gittings/forks/RetroArch/input/drivers/udev_input.c:905: undefined reference to `udev_enumerate_new'
/home/orbea/gittings/forks/RetroArch/input/drivers/udev_input.c:911: undefined reference to `udev_enumerate_add_match_property'
/home/orbea/gittings/forks/RetroArch/input/drivers/udev_input.c:912: undefined reference to `udev_enumerate_scan_devices'
/home/orbea/gittings/forks/RetroArch/input/drivers/udev_input.c:913: undefined reference to `udev_enumerate_get_list_entry'
/home/orbea/gittings/forks/RetroArch/input/drivers/udev_input.c:917: undefined reference to `udev_list_entry_get_name'
/home/orbea/gittings/forks/RetroArch/input/drivers/udev_input.c:921: undefined reference to `udev_device_new_from_syspath'
/home/orbea/gittings/forks/RetroArch/input/drivers/udev_input.c:922: undefined reference to `udev_device_get_devnode'
/home/orbea/gittings/forks/RetroArch/input/drivers/udev_input.c:941: undefined reference to `udev_device_unref'
/home/orbea/gittings/forks/RetroArch/input/drivers/udev_input.c:915: undefined reference to `udev_list_entry_get_next'
/home/orbea/gittings/forks/RetroArch/input/drivers/udev_input.c:944: undefined reference to `udev_enumerate_unref'
obj-unix/input/drivers/udev_input.o: In function `udev_input_free':
/home/orbea/gittings/forks/RetroArch/input/drivers/udev_input.c:890: undefined reference to `udev_monitor_unref'
/home/orbea/gittings/forks/RetroArch/input/drivers/udev_input.c:892: undefined reference to `udev_unref'
obj-unix/input/drivers/udev_input.o: In function `udev_input_init':
/home/orbea/gittings/forks/RetroArch/input/drivers/udev_input.c:959: undefined reference to `udev_new'
/home/orbea/gittings/forks/RetroArch/input/drivers/udev_input.c:966: undefined reference to `udev_monitor_new_from_netlink'
/home/orbea/gittings/forks/RetroArch/input/drivers/udev_input.c:969: undefined reference to `udev_monitor_filter_add_match_subsystem_devtype'
/home/orbea/gittings/forks/RetroArch/input/drivers/udev_input.c:970: undefined reference to `udev_monitor_enable_receiving'
obj-unix/input/drivers/udev_input.o: In function `udev_input_poll_hotplug_available':
/home/orbea/gittings/forks/RetroArch/input/drivers/udev_input.c:632: undefined reference to `udev_monitor_get_fd'
obj-unix/input/drivers/udev_input.o: In function `udev_input_handle_hotplug':
/home/orbea/gittings/forks/RetroArch/input/drivers/udev_input.c:567: undefined reference to `udev_monitor_receive_device'
/home/orbea/gittings/forks/RetroArch/input/drivers/udev_input.c:573: undefined reference to `udev_device_get_property_value'
/home/orbea/gittings/forks/RetroArch/input/drivers/udev_input.c:574: undefined reference to `udev_device_get_property_value'
/home/orbea/gittings/forks/RetroArch/input/drivers/udev_input.c:575: undefined reference to `udev_device_get_property_value'
/home/orbea/gittings/forks/RetroArch/input/drivers/udev_input.c:576: undefined reference to `udev_device_get_action'
/home/orbea/gittings/forks/RetroArch/input/drivers/udev_input.c:577: undefined reference to `udev_device_get_devnode'
/home/orbea/gittings/forks/RetroArch/input/drivers/udev_input.c:612: undefined reference to `udev_device_unref'
obj-unix/input/drivers_joypad/udev_joypad.o: In function `udev_add_pad':
/home/orbea/gittings/forks/RetroArch/input/drivers_joypad/udev_joypad.c:161: undefined reference to `udev_device_get_parent_with_subsystem_devtype'
/home/orbea/gittings/forks/RetroArch/input/drivers_joypad/udev_joypad.c:165: undefined reference to `udev_device_get_sysattr_value'
/home/orbea/gittings/forks/RetroArch/input/drivers_joypad/udev_joypad.c:168: undefined reference to `udev_device_get_sysattr_value'
obj-unix/input/drivers_joypad/udev_joypad.o: In function `udev_joypad_poll_hotplug_available':
/home/orbea/gittings/forks/RetroArch/input/drivers_joypad/udev_joypad.c:425: undefined reference to `udev_monitor_get_fd'
obj-unix/input/drivers_joypad/udev_joypad.o: In function `udev_joypad_poll':
/home/orbea/gittings/forks/RetroArch/input/drivers_joypad/udev_joypad.c:438: undefined reference to `udev_monitor_receive_device'
/home/orbea/gittings/forks/RetroArch/input/drivers_joypad/udev_joypad.c:442: undefined reference to `udev_device_get_property_value'
/home/orbea/gittings/forks/RetroArch/input/drivers_joypad/udev_joypad.c:443: undefined reference to `udev_device_get_action'
/home/orbea/gittings/forks/RetroArch/input/drivers_joypad/udev_joypad.c:444: undefined reference to `udev_device_get_devnode'
/home/orbea/gittings/forks/RetroArch/input/drivers_joypad/udev_joypad.c:460: undefined reference to `udev_device_unref'
obj-unix/input/drivers_joypad/udev_joypad.o: In function `udev_joypad_destroy':
/home/orbea/gittings/forks/RetroArch/input/drivers_joypad/udev_joypad.c:342: undefined reference to `udev_monitor_unref'
/home/orbea/gittings/forks/RetroArch/input/drivers_joypad/udev_joypad.c:345: undefined reference to `udev_unref'
obj-unix/input/drivers_joypad/udev_joypad.o: In function `udev_joypad_init':
/home/orbea/gittings/forks/RetroArch/input/drivers_joypad/udev_joypad.c:541: undefined reference to `udev_new'
/home/orbea/gittings/forks/RetroArch/input/drivers_joypad/udev_joypad.c:545: undefined reference to `udev_monitor_new_from_netlink'
/home/orbea/gittings/forks/RetroArch/input/drivers_joypad/udev_joypad.c:548: undefined reference to `udev_monitor_filter_add_match_subsystem_devtype'
/home/orbea/gittings/forks/RetroArch/input/drivers_joypad/udev_joypad.c:550: undefined reference to `udev_monitor_enable_receiving'
/home/orbea/gittings/forks/RetroArch/input/drivers_joypad/udev_joypad.c:553: undefined reference to `udev_enumerate_new'
/home/orbea/gittings/forks/RetroArch/input/drivers_joypad/udev_joypad.c:557: undefined reference to `udev_enumerate_add_match_property'
/home/orbea/gittings/forks/RetroArch/input/drivers_joypad/udev_joypad.c:558: undefined reference to `udev_enumerate_scan_devices'
/home/orbea/gittings/forks/RetroArch/input/drivers_joypad/udev_joypad.c:559: undefined reference to `udev_enumerate_get_list_entry'
/home/orbea/gittings/forks/RetroArch/input/drivers_joypad/udev_joypad.c:563: undefined reference to `udev_list_entry_get_name'
/home/orbea/gittings/forks/RetroArch/input/drivers_joypad/udev_joypad.c:564: undefined reference to `udev_device_new_from_syspath'
/home/orbea/gittings/forks/RetroArch/input/drivers_joypad/udev_joypad.c:565: undefined reference to `udev_device_get_devnode'
/home/orbea/gittings/forks/RetroArch/input/drivers_joypad/udev_joypad.c:569: undefined reference to `udev_device_unref'
/home/orbea/gittings/forks/RetroArch/input/drivers_joypad/udev_joypad.c:561: undefined reference to `udev_list_entry_get_next'
/home/orbea/gittings/forks/RetroArch/input/drivers_joypad/udev_joypad.c:572: undefined reference to `udev_enumerate_unref'
obj-unix/input/drivers_joypad/udev_joypad.o: In function `udev_joypad_destroy':
/home/orbea/gittings/forks/RetroArch/input/drivers_joypad/udev_joypad.c:342: undefined reference to `udev_monitor_unref'
/home/orbea/gittings/forks/RetroArch/input/drivers_joypad/udev_joypad.c:345: undefined reference to `udev_unref'
```