### PR TITLE
Set _NET_WM_PID

### DIFF
--- a/gfx/common/x11_common.c
+++ b/gfx/common/x11_common.c
@@ -21,6 +21,8 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
+#include <unistd.h>
+
 #include <X11/Xatom.h>
 
 #ifdef HAVE_CONFIG_H
@@ -155,9 +157,27 @@ static void x11_set_window_class(Display *dpy, Window win)
    XSetClassHint(dpy, win, &hint);
 }
 
+static void x11_set_window_pid(Display *dpy, Window win)
+{
+    pid_t pid = getpid();
+    char hostname[HOST_NAME_MAX + 1];
+
+	XChangeProperty(dpy, win, XInternAtom(dpy, "_NET_WM_PID", False),
+		XA_CARDINAL, 32, PropModeReplace, (unsigned char *)&pid, 1);
+
+	if(gethostname(hostname, HOST_NAME_MAX + 1) == -1)
+		RARCH_WARN("Failed to get hostname.\n");
+	else
+	{
+		XChangeProperty(dpy, win, XA_WM_CLIENT_MACHINE, XA_STRING, 8,
+			PropModeReplace, (unsigned char *)hostname, strlen(hostname));
+	}
+}
+
 void x11_set_window_attr(Display *dpy, Window win)
 {
    x11_set_window_class(dpy, win);
+   x11_set_window_pid(dpy, win);
 }
 
 static void xdg_screensaver_inhibit(Window wnd)


### PR DESCRIPTION
Hello,
Set _NET_WM_PID and WM_CLIENT_MACHINE since https://specifications.freedesktop.org/wm-spec/1.3/ar01s05.html says you must do so if setting the first.

Fixes https://github.com/libretro/RetroArch/issues/5726