### PR TITLE
qb: Rewrite the create_config_make function to use printf instead of echo

### DIFF
--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -214,46 +214,46 @@ create_config_header()
 create_config_make()
 {	outfile="$1"; shift
 
-	echo "Creating make config: $outfile"
+	printf %s\\n "Creating make config: $outfile"
 
-	{	if [ "$USE_LANG_C" = 'yes' ]; then
-			echo "CC = $CC"
-			echo "CFLAGS = $CFLAGS"
-		fi
-		if [ "$USE_LANG_CXX" = 'yes' ]; then
-			echo "CXX = $CXX"
-			echo "CXXFLAGS = $CXXFLAGS"
-		fi
-		echo "WINDRES = $WINDRES"
-		echo "ASFLAGS = $ASFLAGS"
-		echo "LDFLAGS = $LDFLAGS"
-		echo "INCLUDE_DIRS = $INCLUDE_DIRS"
-		echo "LIBRARY_DIRS = $LIBRARY_DIRS"
-		echo "PACKAGE_NAME = $PACKAGE_NAME"
-		echo "BUILD = $BUILD"
-		echo "PREFIX = $PREFIX"
+	{	[ "$USE_LANG_C" = 'yes' ] && printf %s\\n "CC = $CC" "CFLAGS = $CFLAGS"
+		[ "$USE_LANG_CXX" = 'yes' ] && printf %s\\n "CXX = $CXX" "CXXFLAGS = $CXXFLAGS"
+
+		printf %s\\n "WINDRES = $WINDRES" \
+			"ASFLAGS = $ASFLAGS" \
+			"LDFLAGS = $LDFLAGS" \
+			"INCLUDE_DIRS = $INCLUDE_DIRS" \
+			"LIBRARY_DIRS = $LIBRARY_DIRS" \
+			"PACKAGE_NAME = $PACKAGE_NAME" \
+			"BUILD = $BUILD" \
+			"PREFIX = $PREFIX"
 
 		while [ "$1" ]; do
-			case $(eval echo \$HAVE_$1) in
+			case "$(eval "printf %s \"\$HAVE_$1\"")" in
 				'yes')
-					if [ "$(eval echo \$C89_$1)" = "no" ]; then echo "ifneq (\$(C89_BUILD),1)"; fi
-					echo "HAVE_$1 = 1"
-					if [ "$(eval echo \$C89_$1)" = "no" ]; then echo "endif"; fi
-					;;
-				'no') echo "HAVE_$1 = 0";;
+					if [ "$(eval "printf %s \"\$C89_$1\"")" = 'no' ]; then
+						printf %s\\n "ifneq (\$(C89_BUILD),1)" \
+							"HAVE_$1 = 1" 'endif'
+					else
+						printf %s\\n "HAVE_$1 = 1"
+					fi
+				;;
+				'no') printf %s\\n "HAVE_$1 = 0";;
 			esac
 			
 			case "$PKG_CONF_USED" in
 				*$1*)
-					FLAGS="$(eval echo \$$1_CFLAGS)"
-					LIBS="$(eval echo \$$1_LIBS)"
-					echo "$1_CFLAGS = ${FLAGS%"${FLAGS##*[! ]}"}"
-					echo "$1_LIBS = ${LIBS%"${LIBS##*[! ]}"}"
+					FLAGS="$(eval "printf %s \"\$$1_CFLAGS\"")"
+					LIBS="$(eval "printf %s \"\$$1_LIBS\"")"
+					printf %s\\n "$1_CFLAGS = ${FLAGS%"${FLAGS##*[! ]}"}" \
+						"$1_LIBS = ${LIBS%"${LIBS##*[! ]}"}"
 				;;
 			esac
 			shift
 		done
-		while IFS='=' read VAR VAL; do echo "$VAR = $VAL"; done < "$MAKEFILE_DEFINES"
+		while IFS='=' read -r VAR VAL; do
+			printf %s\\n "$VAR = $VAL"
+		done < "$MAKEFILE_DEFINES"
 
 	} > "$outfile"
 }


### PR DESCRIPTION
Using `echo` has a huge range of possible portability concerns in shell scripts and is only included in the posix spec because it was so heavily used in bourne shell scripting that it got grandfathered in. In the current day `printf` is greatly preferred by the posix spec while `echo` is only really portable with plain text strings wrapped with single quotes (`'`).

The posix spec explains the problem here.
```
It is not possible to use echo portably across all POSIX systems unless both -n (as the first argument) and escape sequences are omitted.

The printf utility can be used portably to emulate any of the traditional behaviors of the echo utility as follows (assuming that IFS has its standard value or is unset)
```
http://pubs.opengroup.org/onlinepubs/9699919799/utilities/echo.html

Also see this link under the first section, "Printing the value of a variable".
http://www.etalabs.net/sh_tricks.html

I used this function to test this commit which ensures that `config.mk` experiences no changes after this commit with any compatible shell I can find, build and install.
```
$ type configtest 
configtest is a function
configtest () 
{ 
    branch="$1";
    git clean -xdf;
    git reset --hard;
    git checkout master;
    ./configure 2>&1 | tee configure.log.test;
    for i in config.h config.mk config.log;
    do
        mv "$i" "$i.test";
    done;
    git checkout "$branch";
    for shell in ash dash posh bash ksh mksh pdksh yash zsh;
    do
        echo "$shell";
        echo ====================================================;
        "$shell" configure 2>&1 | tee configure.log;
        for i in config.h config.mk config.log configure.log;
        do
            echo "$i";
            echo ========================;
            diff -u "$i" "$i.test";
        done;
    done
}
```