### PR TITLE
Extend input bind limit to 256

### DIFF
--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -778,17 +778,13 @@ void state_tracker_update_input(uint16_t *input1, uint16_t *input2)
  * Grab an input sample for this frame. We exclude
  * keyboard input here.
  *
- * TODO: In case RARCH_BIND_LIST_END starts exceeding 64,
- * and you need a bitmask of more than 64 entries, reimplement
- * it to use something like rarch_bits_t.
- *
  * Returns: Input sample containing a mask of all pressed keys.
  */
-uint64_t input_menu_keys_pressed(void *data, uint64_t last_input)
+rarch_input_state_t input_menu_keys_pressed(void *data, rarch_input_state_t last_input)
 {
    unsigned i, port;
    rarch_joypad_info_t joypad_info;
-   uint64_t             ret                     = 0;
+   rarch_input_state_t new_state = {0};
    const struct retro_keybind *binds[MAX_USERS] = {NULL};
    settings_t     *settings                     = (settings_t*)data;
    const struct retro_keybind *binds_norm       = NULL;
@@ -898,7 +894,7 @@ uint64_t input_menu_keys_pressed(void *data, uint64_t last_input)
 
             if (pressed)
             {
-               BIT64_SET(ret, i);
+               RARCH_INPUT_STATE_BIT_SET(new_state, i);
                continue;
             }
          }
@@ -908,7 +904,7 @@ uint64_t input_menu_keys_pressed(void *data, uint64_t last_input)
       {
          if (current_input->meta_key_pressed(current_input_data, i))
          {
-            BIT64_SET(ret, i);
+            RARCH_INPUT_STATE_BIT_SET(new_state, i);
             continue;
          }
       }
@@ -916,7 +912,7 @@ uint64_t input_menu_keys_pressed(void *data, uint64_t last_input)
 #ifdef HAVE_OVERLAY
       if (overlay_ptr && input_overlay_key_pressed(overlay_ptr, i))
       {
-         BIT64_SET(ret, i);
+         RARCH_INPUT_STATE_BIT_SET(new_state, i);
          continue;
       }
 #endif
@@ -931,7 +927,7 @@ uint64_t input_menu_keys_pressed(void *data, uint64_t last_input)
 
          if (command_get(&handle))
          {
-            BIT64_SET(ret, i);
+            RARCH_INPUT_STATE_BIT_SET(new_state, i);
             continue;
          }
       }
@@ -940,7 +936,7 @@ uint64_t input_menu_keys_pressed(void *data, uint64_t last_input)
 #ifdef HAVE_NETWORKGAMEPAD
       if (input_driver_remote && input_remote_key_pressed(i, 0))
       {
-         BIT64_SET(ret, i);
+         RARCH_INPUT_STATE_BIT_SET(new_state, i);
          continue;
       }
 #endif
@@ -995,11 +991,11 @@ uint64_t input_menu_keys_pressed(void *data, uint64_t last_input)
       {
          if (current_input->input_state(current_input_data, joypad_info, binds, 0,
                   RETRO_DEVICE_KEYBOARD, 0, ids[i][0]))
-            BIT64_SET(ret, ids[i][1]);
+            RARCH_INPUT_STATE_BIT_SET(new_state, ids[i][1]);
       }
    }
 
-   return ret;
+   return new_state;
 }
 #endif
 
@@ -1008,17 +1004,13 @@ uint64_t input_menu_keys_pressed(void *data, uint64_t last_input)
  *
  * Grab an input sample for this frame.
  *
- * TODO: In case RARCH_BIND_LIST_END starts exceeding 64,
- * and you need a bitmask of more than 64 entries, reimplement
- * it to use something like rarch_bits_t.
- *
  * Returns: Input sample containing a mask of all pressed keys.
  */
-uint64_t input_keys_pressed(void *data, uint64_t last_input)
+rarch_input_state_t input_keys_pressed(void *data, rarch_input_state_t last_input)
 {
    unsigned i;
    rarch_joypad_info_t joypad_info;
-   uint64_t                      ret            = 0;
+   rarch_input_state_t new_state = {0};
    settings_t              *settings            = (settings_t*)data;
    const struct retro_keybind *binds            = input_config_binds[0];
    const struct retro_keybind *binds_auto       = &input_autoconf_binds[0][RARCH_ENABLE_HOTKEY];
@@ -1073,7 +1065,7 @@ uint64_t input_keys_pressed(void *data, uint64_t last_input)
                0, RETRO_DEVICE_JOYPAD, 0, i)
          )
       {
-         BIT64_SET(ret, i);
+         RARCH_INPUT_STATE_BIT_SET(new_state, i);
          continue;
       }
 
@@ -1081,7 +1073,7 @@ uint64_t input_keys_pressed(void *data, uint64_t last_input)
             current_input->meta_key_pressed(current_input_data, i)
             )
       {
-         BIT64_SET(ret, i);
+         RARCH_INPUT_STATE_BIT_SET(new_state, i);
          continue;
       }
 
@@ -1089,7 +1081,7 @@ uint64_t input_keys_pressed(void *data, uint64_t last_input)
       if (overlay_ptr && 
             input_overlay_key_pressed(overlay_ptr, i))
       {
-         BIT64_SET(ret, i);
+         RARCH_INPUT_STATE_BIT_SET(new_state, i);
          continue;
       }
 #endif
@@ -1104,7 +1096,7 @@ uint64_t input_keys_pressed(void *data, uint64_t last_input)
 
          if (command_get(&handle))
          {
-            BIT64_SET(ret, i);
+            RARCH_INPUT_STATE_BIT_SET(new_state, i);
             continue;
          }
       }
@@ -1114,13 +1106,13 @@ uint64_t input_keys_pressed(void *data, uint64_t last_input)
       if (input_driver_remote && 
             input_remote_key_pressed(i, 0))
       {
-         BIT64_SET(ret, i);
+         RARCH_INPUT_STATE_BIT_SET(new_state, i);
          continue;
       }
 #endif
    }
 
-   return ret;
+   return new_state;
 }
 
 

--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -780,11 +780,10 @@ void state_tracker_update_input(uint16_t *input1, uint16_t *input2)
  *
  * Returns: Input sample containing a mask of all pressed keys.
  */
-rarch_input_state_t input_menu_keys_pressed(void *data, rarch_input_state_t last_input)
+void input_menu_keys_pressed(void *data, retro_bits_t* p_new_state)
 {
    unsigned i, port;
    rarch_joypad_info_t joypad_info;
-   rarch_input_state_t new_state = {0};
    const struct retro_keybind *binds[MAX_USERS] = {NULL};
    settings_t     *settings                     = (settings_t*)data;
    const struct retro_keybind *binds_norm       = NULL;
@@ -793,6 +792,8 @@ rarch_input_state_t input_menu_keys_pressed(void *data, rarch_input_state_t last
    uint8_t port_max                             = 
             settings->bools.input_all_users_control_menu 
             ? max_users : 1;
+
+   RARCH_INPUT_STATE_CLEAR_PTR( p_new_state );
 
    input_driver_block_libretro_input            = false;
    input_driver_block_hotkey                    = false;
@@ -894,7 +895,7 @@ rarch_input_state_t input_menu_keys_pressed(void *data, rarch_input_state_t last
 
             if (pressed)
             {
-               RARCH_INPUT_STATE_BIT_SET(new_state, i);
+               RARCH_INPUT_STATE_BIT_SET_PTR(p_new_state, i);
                continue;
             }
          }
@@ -904,7 +905,7 @@ rarch_input_state_t input_menu_keys_pressed(void *data, rarch_input_state_t last
       {
          if (current_input->meta_key_pressed(current_input_data, i))
          {
-            RARCH_INPUT_STATE_BIT_SET(new_state, i);
+            RARCH_INPUT_STATE_BIT_SET_PTR(p_new_state, i);
             continue;
          }
       }
@@ -912,7 +913,7 @@ rarch_input_state_t input_menu_keys_pressed(void *data, rarch_input_state_t last
 #ifdef HAVE_OVERLAY
       if (overlay_ptr && input_overlay_key_pressed(overlay_ptr, i))
       {
-         RARCH_INPUT_STATE_BIT_SET(new_state, i);
+         RARCH_INPUT_STATE_BIT_SET_PTR(p_new_state, i);
          continue;
       }
 #endif
@@ -927,7 +928,7 @@ rarch_input_state_t input_menu_keys_pressed(void *data, rarch_input_state_t last
 
          if (command_get(&handle))
          {
-            RARCH_INPUT_STATE_BIT_SET(new_state, i);
+            RARCH_INPUT_STATE_BIT_SET_PTR(p_new_state, i);
             continue;
          }
       }
@@ -936,7 +937,7 @@ rarch_input_state_t input_menu_keys_pressed(void *data, rarch_input_state_t last
 #ifdef HAVE_NETWORKGAMEPAD
       if (input_driver_remote && input_remote_key_pressed(i, 0))
       {
-         RARCH_INPUT_STATE_BIT_SET(new_state, i);
+         RARCH_INPUT_STATE_BIT_SET_PTR(p_new_state, i);
          continue;
       }
 #endif
@@ -991,11 +992,9 @@ rarch_input_state_t input_menu_keys_pressed(void *data, rarch_input_state_t last
       {
          if (current_input->input_state(current_input_data, joypad_info, binds, 0,
                   RETRO_DEVICE_KEYBOARD, 0, ids[i][0]))
-            RARCH_INPUT_STATE_BIT_SET(new_state, ids[i][1]);
+            RARCH_INPUT_STATE_BIT_SET_PTR(p_new_state, ids[i][1]);
       }
    }
-
-   return new_state;
 }
 #endif
 
@@ -1006,11 +1005,10 @@ rarch_input_state_t input_menu_keys_pressed(void *data, rarch_input_state_t last
  *
  * Returns: Input sample containing a mask of all pressed keys.
  */
-rarch_input_state_t input_keys_pressed(void *data, rarch_input_state_t last_input)
+void input_keys_pressed(void *data, retro_bits_t* p_new_state)
 {
    unsigned i;
    rarch_joypad_info_t joypad_info;
-   rarch_input_state_t new_state = {0};
    settings_t              *settings            = (settings_t*)data;
    const struct retro_keybind *binds            = input_config_binds[0];
    const struct retro_keybind *binds_auto       = &input_autoconf_binds[0][RARCH_ENABLE_HOTKEY];
@@ -1020,6 +1018,8 @@ rarch_input_state_t input_keys_pressed(void *data, rarch_input_state_t last_inpu
    const struct retro_keybind *focus_normal     = &binds[RARCH_GAME_FOCUS_TOGGLE];
    const struct retro_keybind *enable_hotkey    = &input_config_binds[0][RARCH_ENABLE_HOTKEY];
    bool game_focus_toggle_valid                 = false;
+
+   RARCH_INPUT_STATE_CLEAR_PTR( p_new_state );
 
    joypad_info.joy_idx                          = settings->uints.input_joypad_map[0];
    joypad_info.auto_binds                       = input_autoconf_binds[joypad_info.joy_idx];
@@ -1065,7 +1065,7 @@ rarch_input_state_t input_keys_pressed(void *data, rarch_input_state_t last_inpu
                0, RETRO_DEVICE_JOYPAD, 0, i)
          )
       {
-         RARCH_INPUT_STATE_BIT_SET(new_state, i);
+         RARCH_INPUT_STATE_BIT_SET_PTR(p_new_state, i);
          continue;
       }
 
@@ -1073,7 +1073,7 @@ rarch_input_state_t input_keys_pressed(void *data, rarch_input_state_t last_inpu
             current_input->meta_key_pressed(current_input_data, i)
             )
       {
-         RARCH_INPUT_STATE_BIT_SET(new_state, i);
+         RARCH_INPUT_STATE_BIT_SET_PTR(p_new_state, i);
          continue;
       }
 
@@ -1081,7 +1081,7 @@ rarch_input_state_t input_keys_pressed(void *data, rarch_input_state_t last_inpu
       if (overlay_ptr && 
             input_overlay_key_pressed(overlay_ptr, i))
       {
-         RARCH_INPUT_STATE_BIT_SET(new_state, i);
+         RARCH_INPUT_STATE_BIT_SET_PTR(p_new_state, i);
          continue;
       }
 #endif
@@ -1096,7 +1096,7 @@ rarch_input_state_t input_keys_pressed(void *data, rarch_input_state_t last_inpu
 
          if (command_get(&handle))
          {
-            RARCH_INPUT_STATE_BIT_SET(new_state, i);
+            RARCH_INPUT_STATE_BIT_SET_PTR(p_new_state, i);
             continue;
          }
       }
@@ -1106,13 +1106,11 @@ rarch_input_state_t input_keys_pressed(void *data, rarch_input_state_t last_inpu
       if (input_driver_remote && 
             input_remote_key_pressed(i, 0))
       {
-         RARCH_INPUT_STATE_BIT_SET(new_state, i);
+         RARCH_INPUT_STATE_BIT_SET_PTR(p_new_state, i);
          continue;
       }
 #endif
    }
-
-   return new_state;
 }
 
 

--- a/input/input_driver.h
+++ b/input/input_driver.h
@@ -334,7 +334,7 @@ int16_t input_state(unsigned port, unsigned device,
       unsigned idx, unsigned id);
 
 typedef struct {
-	uint32_t bank[ 4 ]; // 128 bits
+	uint32_t bank[ 4 ]; /* 128 bits */
 } rarch_input_state_t;
 
 #define RARCH_INPUT_STATE_BIT_SET(a, bit)   ((a).bank[((bit) >> 5)&3] |=  (1 << ((bit) & 31)))

--- a/input/input_driver.h
+++ b/input/input_driver.h
@@ -333,10 +333,24 @@ void input_poll(void);
 int16_t input_state(unsigned port, unsigned device,
       unsigned idx, unsigned id);
 
-uint64_t input_keys_pressed(void *data, uint64_t last_input);
+typedef struct {
+	uint32_t bank[ 4 ]; // 128 bits
+} rarch_input_state_t;
+
+#define RARCH_INPUT_STATE_BIT_SET(a, bit)   ((a).bank[((bit) >> 5)&3] |=  (1 << ((bit) & 31)))
+#define RARCH_INPUT_STATE_BIT_GET(a, bit)   ((a).bank[((bit) >> 5)&3] &   (1 << ((bit) & 31)))
+#define RARCH_INPUT_STATE_CLEAR(a)          memset(&(a), 0, sizeof(a));
+#define RARCH_INPUT_STATE_ANY_SET(a)        (((a).bank[0])||((a).bank[1])||((a).bank[2])||((a).bank[3]))
+#define RARCH_INPUT_STATE_CLEAR_BITS(a,b)    \
+            ((a).bank[0])&=(~((b).bank[0])); \
+            ((a).bank[1])&=(~((b).bank[1])); \
+            ((a).bank[2])&=(~((b).bank[2])); \
+            ((a).bank[3])&=(~((b).bank[3]));
+
+rarch_input_state_t input_keys_pressed(void *data, rarch_input_state_t last_input);
 
 #ifdef HAVE_MENU
-uint64_t input_menu_keys_pressed(void *data, uint64_t last_input);
+rarch_input_state_t input_menu_keys_pressed(void *data, rarch_input_state_t last_input);
 #endif
 
 void *input_driver_get_data(void);

--- a/input/input_driver.h
+++ b/input/input_driver.h
@@ -30,6 +30,7 @@
 #include <retro_common_api.h>
 #include <retro_inline.h>
 #include <libretro.h>
+#include <retro_miscellaneous.h>
 
 #include "input_defines.h"
 
@@ -333,24 +334,30 @@ void input_poll(void);
 int16_t input_state(unsigned port, unsigned device,
       unsigned idx, unsigned id);
 
-typedef struct {
-	uint32_t bank[ 4 ]; /* 128 bits */
-} rarch_input_state_t;
-
-#define RARCH_INPUT_STATE_BIT_SET(a, bit)   ((a).bank[((bit) >> 5)&3] |=  (1 << ((bit) & 31)))
-#define RARCH_INPUT_STATE_BIT_GET(a, bit)   ((a).bank[((bit) >> 5)&3] &   (1 << ((bit) & 31)))
-#define RARCH_INPUT_STATE_CLEAR(a)          memset(&(a), 0, sizeof(a));
-#define RARCH_INPUT_STATE_ANY_SET(a)        (((a).bank[0])||((a).bank[1])||((a).bank[2])||((a).bank[3]))
+#define RARCH_INPUT_STATE_BIT_SET(a,bit)       ((a).data [((bit) >> 5)] |=  (1 << ((bit) & 31)))
+#define RARCH_INPUT_STATE_BIT_SET_PTR(a,bit)   ((a)->data[((bit) >> 5)] |=  (1 << ((bit) & 31)))
+#define RARCH_INPUT_STATE_BIT_GET(a,bit)       ((a).data [((bit) >> 5)] &   (1 << ((bit) & 31)))
+#define RARCH_INPUT_STATE_BIT_GET_PTR(a,bit)   ((a)->data[((bit) >> 5)] &   (1 << ((bit) & 31)))
+#define RARCH_INPUT_STATE_CLEAR(a)              memset(&a, 0, sizeof(a));
+#define RARCH_INPUT_STATE_CLEAR_PTR(a)          memset(a, 0, sizeof(retro_bits_t));
+#define RARCH_INPUT_STATE_ANY_SET(a)            ( ((a).data[0])||((a).data[1])||((a).data[2])||((a).data[3])||       \
+                                                  ((a).data[4])||((a).data[5])||((a).data[6])||((a).data[7]) )
+#define RARCH_INPUT_STATE_ANY_SET_PTR(a)        ( ((a)->data[0])||((a)->data[1])||((a)->data[2])||((a)->data[3])||   \
+                                                  ((a)->data[4])||((a)->data[5])||((a)->data[6])||((a)->data[7]) )
 #define RARCH_INPUT_STATE_CLEAR_BITS(a,b)    \
-            ((a).bank[0])&=(~((b).bank[0])); \
-            ((a).bank[1])&=(~((b).bank[1])); \
-            ((a).bank[2])&=(~((b).bank[2])); \
-            ((a).bank[3])&=(~((b).bank[3]));
+            ((a).data[0])&=(~((b).data[0])); \
+            ((a).data[1])&=(~((b).data[1])); \
+            ((a).data[2])&=(~((b).data[2])); \
+            ((a).data[3])&=(~((b).data[3])); \
+            ((a).data[4])&=(~((b).data[4])); \
+            ((a).data[5])&=(~((b).data[5])); \
+            ((a).data[6])&=(~((b).data[6])); \
+            ((a).data[7])&=(~((b).data[7]));
 
-rarch_input_state_t input_keys_pressed(void *data, rarch_input_state_t last_input);
+void input_keys_pressed(void *data, retro_bits_t* new_state);
 
 #ifdef HAVE_MENU
-rarch_input_state_t input_menu_keys_pressed(void *data, rarch_input_state_t last_input);
+void input_menu_keys_pressed(void *data, retro_bits_t* new_state);
 #endif
 
 void *input_driver_get_data(void);

--- a/menu/menu_event.c
+++ b/menu/menu_event.c
@@ -137,7 +137,7 @@ void menu_event_kb_set(bool down, enum retro_key key)
  * entire button state either but do a separate event per button
  * state.
  */
-unsigned menu_event(uint64_t input, uint64_t trigger_input)
+unsigned menu_event(rarch_input_state_t input, rarch_input_state_t trigger_input)
 {
    menu_animation_ctx_delta_t delta;
    float delta_time;
@@ -160,12 +160,12 @@ unsigned menu_event(uint64_t input, uint64_t trigger_input)
    unsigned menu_cancel_btn                = (!input_swap_override && 
       settings->bools.input_menu_swap_ok_cancel_buttons) ?
       RETRO_DEVICE_ID_JOYPAD_A : RETRO_DEVICE_ID_JOYPAD_B;
-   unsigned ok_current                     = (unsigned)(input & UINT64_C(1) << menu_ok_btn);
+   unsigned ok_current                     = RARCH_INPUT_STATE_BIT_GET( input, menu_ok_btn );
    unsigned ok_trigger                     = ok_current & ~ok_old;
 
    ok_old                                  = ok_current;
 
-   if (input)
+   if (RARCH_INPUT_STATE_ANY_SET(input))
    {
       if (!first_held)
       {
@@ -179,7 +179,7 @@ unsigned menu_event(uint64_t input, uint64_t trigger_input)
 
       if (delay_count >= delay_timer)
       {
-         uint64_t input_repeat = 0;
+         uint32_t input_repeat = 0;
          BIT32_SET(input_repeat, RETRO_DEVICE_ID_JOYPAD_UP);
          BIT32_SET(input_repeat, RETRO_DEVICE_ID_JOYPAD_DOWN);
          BIT32_SET(input_repeat, RETRO_DEVICE_ID_JOYPAD_LEFT);
@@ -189,7 +189,7 @@ unsigned menu_event(uint64_t input, uint64_t trigger_input)
 
          set_scroll           = true;
          first_held           = false;
-         trigger_input |= input & input_repeat;
+         trigger_input.bank[0] |= input.bank[0] & input_repeat;
 
          menu_driver_ctl(MENU_NAVIGATION_CTL_GET_SCROLL_ACCEL,
                &new_scroll_accel);
@@ -221,31 +221,31 @@ unsigned menu_event(uint64_t input, uint64_t trigger_input)
    {
       menu_event_osk_iterate();
 
-      if (trigger_input & (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_DOWN))
+      if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_DOWN))
       {
          if (menu_event_get_osk_ptr() < 33)
             menu_event_set_osk_ptr(menu_event_get_osk_ptr() + OSK_CHARS_PER_LINE);
       }
 
-      if (trigger_input & (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_UP))
+      if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_UP))
       {
          if (menu_event_get_osk_ptr() >= OSK_CHARS_PER_LINE)
             menu_event_set_osk_ptr(menu_event_get_osk_ptr() - OSK_CHARS_PER_LINE);
       }
 
-      if (trigger_input & (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_RIGHT))
+      if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_RIGHT))
       {
          if (menu_event_get_osk_ptr() < 43)
             menu_event_set_osk_ptr(menu_event_get_osk_ptr() + 1);
       }
 
-      if (trigger_input & (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_LEFT))
+      if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_LEFT))
       {
          if (menu_event_get_osk_ptr() >= 1)
             menu_event_set_osk_ptr(menu_event_get_osk_ptr() - 1);
       }
 
-      if (trigger_input & (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_L))
+      if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_L))
       {
          if (menu_event_get_osk_idx() > OSK_TYPE_UNKNOWN + 1)
             menu_event_set_osk_idx((enum osk_type)(menu_event_get_osk_idx() - 1));
@@ -253,7 +253,7 @@ unsigned menu_event(uint64_t input, uint64_t trigger_input)
             menu_event_set_osk_idx((enum osk_type)(OSK_TYPE_LAST - 1));
       }
 
-      if (trigger_input & (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_R))
+      if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_R))
       {
          if (menu_event_get_osk_idx() < OSK_TYPE_LAST - 1)
             menu_event_set_osk_idx((enum osk_type)(menu_event_get_osk_idx() + 1));
@@ -261,50 +261,50 @@ unsigned menu_event(uint64_t input, uint64_t trigger_input)
             menu_event_set_osk_idx((enum osk_type)(OSK_TYPE_UNKNOWN + 1));
       }
 
-      if (trigger_input & (UINT64_C(1) << menu_ok_btn))
+      if (RARCH_INPUT_STATE_BIT_GET(trigger_input, menu_ok_btn))
       {
          if (menu_event_get_osk_ptr() >= 0)
             menu_event_osk_append(menu_event_get_osk_ptr());
       }
 
-      if (trigger_input & (UINT64_C(1) << menu_cancel_btn))
+      if (RARCH_INPUT_STATE_BIT_GET(trigger_input, menu_cancel_btn))
       {
          input_keyboard_event(true, '\x7f', '\x7f', 0, RETRO_DEVICE_KEYBOARD);
       }
 
       /* send return key to close keyboard input window */
-      if (trigger_input & (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_START))
+      if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_START))
          input_keyboard_event(true, '\n', '\n', 0, RETRO_DEVICE_KEYBOARD);
 
-      trigger_input = 0;
+      RARCH_INPUT_STATE_CLEAR(trigger_input);
    }
    else
    {
-      if (trigger_input & (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_UP))
+      if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_UP))
          ret = MENU_ACTION_UP;
-      else if (trigger_input & (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_DOWN))
+      else if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_DOWN))
          ret = MENU_ACTION_DOWN;
-      else if (trigger_input & (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_LEFT))
+      else if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_LEFT))
          ret = MENU_ACTION_LEFT;
-      else if (trigger_input & (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_RIGHT))
+      else if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_RIGHT))
          ret = MENU_ACTION_RIGHT;
-      else if (trigger_input & (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_L))
+      else if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_L))
          ret = MENU_ACTION_SCROLL_UP;
-      else if (trigger_input & (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_R))
+      else if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_R))
          ret = MENU_ACTION_SCROLL_DOWN;
       else if (ok_trigger)
          ret = MENU_ACTION_OK;
-      else if (trigger_input & (UINT64_C(1) << menu_cancel_btn))
+      else if (RARCH_INPUT_STATE_BIT_GET(trigger_input, menu_cancel_btn))
          ret = MENU_ACTION_CANCEL;
-      else if (trigger_input & (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_X))
+      else if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_X))
          ret = MENU_ACTION_SEARCH;
-      else if (trigger_input & (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_Y))
+      else if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_Y))
          ret = MENU_ACTION_SCAN;
-      else if (trigger_input & (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_START))
+      else if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_START))
          ret = MENU_ACTION_START;
-      else if (trigger_input & (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_SELECT))
+      else if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_SELECT))
          ret = MENU_ACTION_INFO;
-      else if (trigger_input & (UINT64_C(1) << RARCH_MENU_TOGGLE))
+      else if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RARCH_MENU_TOGGLE))
          ret = MENU_ACTION_TOGGLE;
    }
 

--- a/menu/menu_event.c
+++ b/menu/menu_event.c
@@ -137,7 +137,7 @@ void menu_event_kb_set(bool down, enum retro_key key)
  * entire button state either but do a separate event per button
  * state.
  */
-unsigned menu_event(rarch_input_state_t input, rarch_input_state_t trigger_input)
+unsigned menu_event(retro_bits_t* p_input, retro_bits_t* p_trigger_input)
 {
    menu_animation_ctx_delta_t delta;
    float delta_time;
@@ -160,12 +160,12 @@ unsigned menu_event(rarch_input_state_t input, rarch_input_state_t trigger_input
    unsigned menu_cancel_btn                = (!input_swap_override && 
       settings->bools.input_menu_swap_ok_cancel_buttons) ?
       RETRO_DEVICE_ID_JOYPAD_A : RETRO_DEVICE_ID_JOYPAD_B;
-   unsigned ok_current                     = RARCH_INPUT_STATE_BIT_GET( input, menu_ok_btn );
+   unsigned ok_current                     = RARCH_INPUT_STATE_BIT_GET_PTR(p_input, menu_ok_btn );
    unsigned ok_trigger                     = ok_current & ~ok_old;
 
    ok_old                                  = ok_current;
 
-   if (RARCH_INPUT_STATE_ANY_SET(input))
+   if (RARCH_INPUT_STATE_ANY_SET_PTR(p_input))
    {
       if (!first_held)
       {
@@ -189,7 +189,7 @@ unsigned menu_event(rarch_input_state_t input, rarch_input_state_t trigger_input
 
          set_scroll           = true;
          first_held           = false;
-         trigger_input.bank[0] |= input.bank[0] & input_repeat;
+         p_trigger_input->data[0] |= p_input->data[0] & input_repeat;
 
          menu_driver_ctl(MENU_NAVIGATION_CTL_GET_SCROLL_ACCEL,
                &new_scroll_accel);
@@ -221,31 +221,31 @@ unsigned menu_event(rarch_input_state_t input, rarch_input_state_t trigger_input
    {
       menu_event_osk_iterate();
 
-      if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_DOWN))
+      if (RARCH_INPUT_STATE_BIT_GET_PTR(p_trigger_input, RETRO_DEVICE_ID_JOYPAD_DOWN))
       {
          if (menu_event_get_osk_ptr() < 33)
             menu_event_set_osk_ptr(menu_event_get_osk_ptr() + OSK_CHARS_PER_LINE);
       }
 
-      if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_UP))
+      if (RARCH_INPUT_STATE_BIT_GET_PTR(p_trigger_input, RETRO_DEVICE_ID_JOYPAD_UP))
       {
          if (menu_event_get_osk_ptr() >= OSK_CHARS_PER_LINE)
             menu_event_set_osk_ptr(menu_event_get_osk_ptr() - OSK_CHARS_PER_LINE);
       }
 
-      if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_RIGHT))
+      if (RARCH_INPUT_STATE_BIT_GET_PTR(p_trigger_input, RETRO_DEVICE_ID_JOYPAD_RIGHT))
       {
          if (menu_event_get_osk_ptr() < 43)
             menu_event_set_osk_ptr(menu_event_get_osk_ptr() + 1);
       }
 
-      if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_LEFT))
+      if (RARCH_INPUT_STATE_BIT_GET_PTR(p_trigger_input, RETRO_DEVICE_ID_JOYPAD_LEFT))
       {
          if (menu_event_get_osk_ptr() >= 1)
             menu_event_set_osk_ptr(menu_event_get_osk_ptr() - 1);
       }
 
-      if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_L))
+      if (RARCH_INPUT_STATE_BIT_GET_PTR(p_trigger_input, RETRO_DEVICE_ID_JOYPAD_L))
       {
          if (menu_event_get_osk_idx() > OSK_TYPE_UNKNOWN + 1)
             menu_event_set_osk_idx((enum osk_type)(menu_event_get_osk_idx() - 1));
@@ -253,7 +253,7 @@ unsigned menu_event(rarch_input_state_t input, rarch_input_state_t trigger_input
             menu_event_set_osk_idx((enum osk_type)(OSK_TYPE_LAST - 1));
       }
 
-      if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_R))
+      if (RARCH_INPUT_STATE_BIT_GET_PTR(p_trigger_input, RETRO_DEVICE_ID_JOYPAD_R))
       {
          if (menu_event_get_osk_idx() < OSK_TYPE_LAST - 1)
             menu_event_set_osk_idx((enum osk_type)(menu_event_get_osk_idx() + 1));
@@ -261,50 +261,50 @@ unsigned menu_event(rarch_input_state_t input, rarch_input_state_t trigger_input
             menu_event_set_osk_idx((enum osk_type)(OSK_TYPE_UNKNOWN + 1));
       }
 
-      if (RARCH_INPUT_STATE_BIT_GET(trigger_input, menu_ok_btn))
+      if (RARCH_INPUT_STATE_BIT_GET_PTR(p_trigger_input, menu_ok_btn))
       {
          if (menu_event_get_osk_ptr() >= 0)
             menu_event_osk_append(menu_event_get_osk_ptr());
       }
 
-      if (RARCH_INPUT_STATE_BIT_GET(trigger_input, menu_cancel_btn))
+      if (RARCH_INPUT_STATE_BIT_GET_PTR(p_trigger_input, menu_cancel_btn))
       {
          input_keyboard_event(true, '\x7f', '\x7f', 0, RETRO_DEVICE_KEYBOARD);
       }
 
       /* send return key to close keyboard input window */
-      if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_START))
+      if (RARCH_INPUT_STATE_BIT_GET_PTR(p_trigger_input, RETRO_DEVICE_ID_JOYPAD_START))
          input_keyboard_event(true, '\n', '\n', 0, RETRO_DEVICE_KEYBOARD);
 
-      RARCH_INPUT_STATE_CLEAR(trigger_input);
+      RARCH_INPUT_STATE_CLEAR_PTR(p_trigger_input);
    }
    else
    {
-      if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_UP))
+      if (RARCH_INPUT_STATE_BIT_GET_PTR(p_trigger_input, RETRO_DEVICE_ID_JOYPAD_UP))
          ret = MENU_ACTION_UP;
-      else if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_DOWN))
+      else if (RARCH_INPUT_STATE_BIT_GET_PTR(p_trigger_input, RETRO_DEVICE_ID_JOYPAD_DOWN))
          ret = MENU_ACTION_DOWN;
-      else if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_LEFT))
+      else if (RARCH_INPUT_STATE_BIT_GET_PTR(p_trigger_input, RETRO_DEVICE_ID_JOYPAD_LEFT))
          ret = MENU_ACTION_LEFT;
-      else if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_RIGHT))
+      else if (RARCH_INPUT_STATE_BIT_GET_PTR(p_trigger_input, RETRO_DEVICE_ID_JOYPAD_RIGHT))
          ret = MENU_ACTION_RIGHT;
-      else if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_L))
+      else if (RARCH_INPUT_STATE_BIT_GET_PTR(p_trigger_input, RETRO_DEVICE_ID_JOYPAD_L))
          ret = MENU_ACTION_SCROLL_UP;
-      else if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_R))
+      else if (RARCH_INPUT_STATE_BIT_GET_PTR(p_trigger_input, RETRO_DEVICE_ID_JOYPAD_R))
          ret = MENU_ACTION_SCROLL_DOWN;
       else if (ok_trigger)
          ret = MENU_ACTION_OK;
-      else if (RARCH_INPUT_STATE_BIT_GET(trigger_input, menu_cancel_btn))
+      else if (RARCH_INPUT_STATE_BIT_GET_PTR(p_trigger_input, menu_cancel_btn))
          ret = MENU_ACTION_CANCEL;
-      else if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_X))
+      else if (RARCH_INPUT_STATE_BIT_GET_PTR(p_trigger_input, RETRO_DEVICE_ID_JOYPAD_X))
          ret = MENU_ACTION_SEARCH;
-      else if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_Y))
+      else if (RARCH_INPUT_STATE_BIT_GET_PTR(p_trigger_input, RETRO_DEVICE_ID_JOYPAD_Y))
          ret = MENU_ACTION_SCAN;
-      else if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_START))
+      else if (RARCH_INPUT_STATE_BIT_GET_PTR(p_trigger_input, RETRO_DEVICE_ID_JOYPAD_START))
          ret = MENU_ACTION_START;
-      else if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RETRO_DEVICE_ID_JOYPAD_SELECT))
+      else if (RARCH_INPUT_STATE_BIT_GET_PTR(p_trigger_input, RETRO_DEVICE_ID_JOYPAD_SELECT))
          ret = MENU_ACTION_INFO;
-      else if (RARCH_INPUT_STATE_BIT_GET(trigger_input, RARCH_MENU_TOGGLE))
+      else if (RARCH_INPUT_STATE_BIT_GET_PTR(p_trigger_input, RARCH_MENU_TOGGLE))
          ret = MENU_ACTION_TOGGLE;
    }
 
@@ -314,7 +314,7 @@ unsigned menu_event(rarch_input_state_t input, rarch_input_state_t trigger_input
       menu_event_kb_set_internal(RETROK_F11, 0);
    }
 
-   if (runloop_cmd_press(trigger_input, RARCH_QUIT_KEY))
+   if (RARCH_INPUT_STATE_BIT_GET_PTR(p_trigger_input, RARCH_QUIT_KEY))
       return MENU_ACTION_QUIT;
 
    mouse_enabled                      = settings->bools.menu_mouse_enable;

--- a/menu/menu_event.h
+++ b/menu/menu_event.h
@@ -44,7 +44,7 @@ RETRO_BEGIN_DECLS
  * entire button state either but do a separate event per button
  * state.
  */
-unsigned menu_event(uint64_t input, uint64_t trigger_state);
+unsigned menu_event(rarch_input_state_t input, rarch_input_state_t trigger_state);
 
 /* Set a specific keyboard key.
  *

--- a/menu/menu_event.h
+++ b/menu/menu_event.h
@@ -44,7 +44,7 @@ RETRO_BEGIN_DECLS
  * entire button state either but do a separate event per button
  * state.
  */
-unsigned menu_event(rarch_input_state_t input, rarch_input_state_t trigger_state);
+unsigned menu_event(retro_bits_t* p_input, retro_bits_t* p_trigger_state);
 
 /* Set a specific keyboard key.
  *

--- a/retroarch.c
+++ b/retroarch.c
@@ -2310,40 +2310,40 @@ bool runloop_msg_queue_pull(const char **ret)
 
 #ifdef HAVE_MENU
 static bool input_driver_toggle_button_combo(
-      unsigned mode, uint64_t input)
+      unsigned mode, rarch_input_state_t input)
 {
    switch (mode)
    {
       case INPUT_TOGGLE_DOWN_Y_L_R:
-         if (!BIT64_GET(input, RETRO_DEVICE_ID_JOYPAD_DOWN))
+         if (!RARCH_INPUT_STATE_BIT_GET(input, RETRO_DEVICE_ID_JOYPAD_DOWN))
             return false;
-         if (!BIT64_GET(input, RETRO_DEVICE_ID_JOYPAD_Y))
+         if (!RARCH_INPUT_STATE_BIT_GET(input, RETRO_DEVICE_ID_JOYPAD_Y))
             return false;
-         if (!BIT64_GET(input, RETRO_DEVICE_ID_JOYPAD_L))
+         if (!RARCH_INPUT_STATE_BIT_GET(input, RETRO_DEVICE_ID_JOYPAD_L))
             return false;
-         if (!BIT64_GET(input, RETRO_DEVICE_ID_JOYPAD_R))
+         if (!RARCH_INPUT_STATE_BIT_GET(input, RETRO_DEVICE_ID_JOYPAD_R))
             return false;
          break;
       case INPUT_TOGGLE_L3_R3:
-         if (!BIT64_GET(input, RETRO_DEVICE_ID_JOYPAD_L3))
+         if (!RARCH_INPUT_STATE_BIT_GET(input, RETRO_DEVICE_ID_JOYPAD_L3))
             return false;
-         if (!BIT64_GET(input, RETRO_DEVICE_ID_JOYPAD_R3))
+         if (!RARCH_INPUT_STATE_BIT_GET(input, RETRO_DEVICE_ID_JOYPAD_R3))
             return false;
          break;
       case INPUT_TOGGLE_L1_R1_START_SELECT:
-         if (!BIT64_GET(input, RETRO_DEVICE_ID_JOYPAD_START))
+         if (!RARCH_INPUT_STATE_BIT_GET(input, RETRO_DEVICE_ID_JOYPAD_START))
             return false;
-         if (!BIT64_GET(input, RETRO_DEVICE_ID_JOYPAD_SELECT))
+         if (!RARCH_INPUT_STATE_BIT_GET(input, RETRO_DEVICE_ID_JOYPAD_SELECT))
             return false;
-         if (!BIT64_GET(input, RETRO_DEVICE_ID_JOYPAD_L))
+         if (!RARCH_INPUT_STATE_BIT_GET(input, RETRO_DEVICE_ID_JOYPAD_L))
             return false;
-         if (!BIT64_GET(input, RETRO_DEVICE_ID_JOYPAD_R))
+         if (!RARCH_INPUT_STATE_BIT_GET(input, RETRO_DEVICE_ID_JOYPAD_R))
             return false;
          break;
       case INPUT_TOGGLE_START_SELECT:
-         if (!BIT64_GET(input, RETRO_DEVICE_ID_JOYPAD_START))
+         if (!RARCH_INPUT_STATE_BIT_GET(input, RETRO_DEVICE_ID_JOYPAD_START))
             return false;
-         if (!BIT64_GET(input, RETRO_DEVICE_ID_JOYPAD_SELECT))
+         if (!RARCH_INPUT_STATE_BIT_GET(input, RETRO_DEVICE_ID_JOYPAD_SELECT))
             return false;
          break;
       default:
@@ -2360,7 +2360,7 @@ static enum runloop_state runloop_check_state(
       bool input_nonblock_state,
       unsigned *sleep_ms)
 {
-   static uint64_t last_input       = 0;
+   static rarch_input_state_t last_input = {0};
    static bool old_fs_toggle_pressed= false;
    static bool old_focus            = true;
    bool is_focused                  = false;
@@ -2372,7 +2372,7 @@ static enum runloop_state runloop_check_state(
 #ifdef HAVE_MENU
    bool menu_driver_binding_state   = menu_driver_is_binding_state();
    bool menu_is_alive               = menu_driver_is_alive();
-   uint64_t current_input           =
+   rarch_input_state_t current_input =
       menu_is_alive && !(settings->bools.menu_unified_controls && !menu_input_dialog_get_display_kb())?
       input_menu_keys_pressed(settings, last_input) :
       input_keys_pressed(settings, last_input);
@@ -2388,18 +2388,18 @@ static enum runloop_state runloop_check_state(
           input_driver_toggle_button_combo(
              settings->uints.input_menu_toggle_gamepad_combo, last_input)))
    {
-      BIT64_SET(current_input, RARCH_MENU_TOGGLE);
+      RARCH_INPUT_STATE_BIT_SET(current_input, RARCH_MENU_TOGGLE);
    }
 #endif
 
    if (input_driver_flushing_input)
    {
       input_driver_flushing_input = false;
-      if (current_input)
+      if (RARCH_INPUT_STATE_ANY_SET(current_input))
       {
-         current_input = 0;
+         RARCH_INPUT_STATE_CLEAR( current_input );
          if (runloop_paused)
-            BIT64_SET(current_input, RARCH_PAUSE_TOGGLE);
+            RARCH_INPUT_STATE_BIT_SET(current_input, RARCH_PAUSE_TOGGLE);
          input_driver_flushing_input = true;
       }
    }
@@ -2408,7 +2408,7 @@ static enum runloop_state runloop_check_state(
 
 #ifdef HAVE_MENU
    if (menu_driver_binding_state)
-      current_input = 0;
+      RARCH_INPUT_STATE_CLEAR( current_input );
 #endif
 
 #ifdef HAVE_OVERLAY
@@ -2529,15 +2529,21 @@ static enum runloop_state runloop_check_state(
 #ifdef HAVE_MENU
    if (menu_is_alive)
    {
-      static uint64_t old_input = 0;
+      static rarch_input_state_t old_input = {0};
       menu_ctx_iterate_t iter;
 
       retro_ctx.poll_cb();
 
       {
-         uint64_t trigger_input    = current_input & ~old_input;
-         enum menu_action action   = (enum menu_action)menu_event(current_input, trigger_input);
-         bool focused              = pause_nonactive ? is_focused : true;
+         rarch_input_state_t trigger_input;
+         enum menu_action action;
+         bool focused;
+
+         trigger_input = current_input;
+         RARCH_INPUT_STATE_CLEAR_BITS( trigger_input, old_input );
+
+         action   = (enum menu_action)menu_event(current_input, trigger_input);
+         focused              = pause_nonactive ? is_focused : true;
 
          focused                   = focused && !ui_companion_is_on_foreground();
 

--- a/retroarch.h
+++ b/retroarch.h
@@ -27,7 +27,7 @@
 #include "core_type.h"
 #include "core.h"
 
-#define runloop_cmd_press(current_input, id)     (BIT64_GET(current_input, id))
+#define runloop_cmd_press(current_input, id)     (RARCH_INPUT_STATE_BIT_GET(current_input, id))
 
 RETRO_BEGIN_DECLS
 


### PR DESCRIPTION
The current "input_keys_pressed" and "input_menu_keys_pressed" functions rely on a 64-bit value to capture the digital state of inputs. The current input bind list is approaching this limit so I've doubled it 128 maximum binds (and made it much easier to extend it further if this new limit becomes an issue).

Note: This is a pre-requisite for lightgun input remapping, which pushes the bind list over 64 items and results in a broken hotkey system.