### PR TITLE
qb: Clean up for qb.libs.sh

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -1,8 +1,7 @@
-check_switch_c C99 -std=gnu99  "Cannot find C99 compatible compiler."
-
-check_switch_c NOUNUSED -Wno-unused-result
+check_switch '' C99 -std=gnu99 "Cannot find C99 compatible compiler."
+check_switch '' NOUNUSED -Wno-unused-result
 add_define MAKEFILE NOUNUSED "$HAVE_NOUNUSED"
-check_switch_c NOUNUSED_VARIABLE -Wno-unused-variable
+check_switch '' NOUNUSED_VARIABLE -Wno-unused-variable
 add_define MAKEFILE NOUNUSED_VARIABLE "$HAVE_NOUNUSED_VARIABLE"
 
 # There are still broken 64-bit Linux distros out there. :)

--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -17,7 +17,7 @@ add_library_dirs()
 }
 
 check_lib() # $1 = language  $2 = HAVE_$2  $3 = lib  $4 = function in lib  $5 = extralibs $6 = headers $7 = critical error message [checked only if non-empty]
-{	tmpval="$(eval echo \$HAVE_$2)"
+{	tmpval="$(eval "printf %s \"\$HAVE_$2\"")"
 	[ "$tmpval" = 'no' ] && return 0
 
 	if [ "$1" = cxx ]; then
@@ -35,11 +35,11 @@ check_lib() # $1 = language  $2 = HAVE_$2  $3 = lib  $4 = function in lib  $5 = 
 		if [ "$6" ]; then
 			printf %s\\n "$6" "int main(void) { void *p = (void*)$4; return 0; }" > "$TEMP_CODE"
 		else
-			echo "$TEST_C" > "$TEMP_CODE"
+			printf %s\\n "$TEST_C" > "$TEMP_CODE"
 		fi
 	else
 		ECHOBUF="Checking existence of ${3% }"
-		echo "int main(void) { return 0; }" > "$TEMP_CODE"
+		printf %s\\n 'int main(void) { return 0; }' > "$TEMP_CODE"
 	fi
 	answer='no'
 	"$COMPILER" -o \
@@ -51,7 +51,8 @@ check_lib() # $1 = language  $2 = HAVE_$2  $3 = lib  $4 = function in lib  $5 = 
 		$CFLAGS \
 		$LDFLAGS \
 		$(printf %s "$3") >>config.log 2>&1 && answer='yes'
-	eval HAVE_$2="$answer"; echo "$ECHOBUF ... $answer"
+	eval "HAVE_$2=\"$answer\""
+	printf %s\\n "$ECHOBUF ... $answer"
 	rm -f -- "$TEMP_CODE" "$TEMP_EXE"
 
 	[ "$answer" = 'no' ] && {

--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -16,19 +16,23 @@ add_library_dirs()
 	LIBRARY_DIRS="${LIBRARY_DIRS# }"
 }
 
+check_compiler() # $1 = language  $2 = function in lib
+{	if [ "$1" = cxx ]; then
+		COMPILER="$CXX"
+		TEMP_CODE="$TEMP_CXX"
+		TEST_C="extern \"C\" { void $2(void); } int main() { $2(); }"
+	else
+		COMPILER="$CC"
+		TEMP_CODE="$TEMP_C"
+		TEST_C="void $2(void); int main(void) { $2(); return 0; }"
+	fi
+}
+
 check_lib() # $1 = language  $2 = HAVE_$2  $3 = lib  $4 = function in lib  $5 = extralibs $6 = headers $7 = critical error message [checked only if non-empty]
 {	tmpval="$(eval "printf %s \"\$HAVE_$2\"")"
 	[ "$tmpval" = 'no' ] && return 0
 
-	if [ "$1" = cxx ]; then
-		COMPILER="$CXX"
-		TEMP_CODE="$TEMP_CXX"
-		TEST_C="extern \"C\" { void $4(void); } int main() { $4(); }"
-	else
-		COMPILER="$CC"
-		TEMP_CODE="$TEMP_C"
-		TEST_C="void $4(void); int main(void) { $4(); return 0; }"
-	fi
+	check_compiler "$1" "$4"
 
 	if [ "$4" ]; then
 		ECHOBUF="Checking function $4 in ${3% }"

--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -70,28 +70,6 @@ check_lib() # $1 = language  $2 = HAVE_$2  $3 = lib  $4 = function in lib  $5 = 
 	return 0
 }
 
-check_code_c()
-{	tmpval="$(eval echo \$HAVE_$1)"
-	[ "$tmpval" = 'no' ] && return 0
-
-	ECHOBUF="Checking C code snippet \"$3\""
-	answer='no'
-	"$CC" -o "$TEMP_EXE" "$TEMP_C" $INCLUDE_DIRS $LIBRARY_DIRS $2 $CFLAGS $LDFLAGS >>config.log 2>&1 && answer='yes'
-	eval HAVE_$1="$answer"; echo "$ECHOBUF ... $answer"
-	rm -f -- "$TEMP_C" "$TEMP_EXE"
-}
-
-check_code_cxx()
-{	tmpval="$(eval echo \$HAVE_$1)"
-	[ "$tmpval" = 'no' ] && return 0
-
-	ECHOBUF="Checking C++ code snippet \"$3\""
-	answer='no'
-	"$CXX" -o "$TEMP_EXE" "$TEMP_CXX" $INCLUDE_DIRS $LIBRARY_DIRS $2 $CXXFLAGS $LDFLAGS >>config.log 2>&1 && answer='yes'
-	eval HAVE_$1="$answer"; echo "$ECHOBUF ... $answer"
-	rm -f -- "$TEMP_CXX" "$TEMP_EXE"
-}
-
 check_pkgconf()	#$1 = HAVE_$1	$2 = package	$3 = version	$4 = critical error message [checked only if non-empty]
 {	tmpval="$(eval echo \$HAVE_$1)"
 	[ "$tmpval" = 'no' ] && return 0

--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -137,27 +137,18 @@ EOF
 		die 1 "Build assumed that $2 is defined, but it's not. Exiting ..."
 }
 
-check_switch_c()	#$1 = HAVE_$1	$2 = switch	$3 = critical error message [checked only if non-empty]
-{	ECHOBUF="Checking for availability of switch $2 in $CC"
-	echo "int main(void) { return 0; }" > $TEMP_C
-	answer='no'
-	"$CC" -o "$TEMP_EXE" "$TEMP_C" $2 >>config.log 2>&1 && answer='yes'
-	eval HAVE_$1="$answer"; echo "$ECHOBUF ... $answer"
-	rm -f -- "$TEMP_C" "$TEMP_EXE"
-	[ "$answer" = 'no' ] && {
-		[ "$3" ] && die 1 "$3"
-	}
-}
+check_switch() # $1 = language  $2 = HAVE_$2  $3 = switch  $4 = critical error message [checked only if non-empty]
+{	check_compiler "$1" ''
 
-check_switch_cxx()	#$1 = HAVE_$1	$2 = switch	$3 = critical error message [checked only if non-empty]
-{	ECHOBUF="Checking for availability of switch $2 in $CXX"
-	echo "int main() { return 0; }" > $TEMP_CXX
+	ECHOBUF="Checking for availability of switch $3 in $COMPILER"
+	printf %s\\n 'int main(void) { return 0; }' > "$TEMP_CODE"
 	answer='no'
-	"$CXX" -o "$TEMP_EXE" "$TEMP_CXX" "$2" >>config.log 2>&1 && answer='yes'
-	eval HAVE_$1="$answer"; echo "$ECHOBUF ... $answer"
-	rm -f -- "$TEMP_CXX" "$TEMP_EXE"
+	"$COMPILER" -o "$TEMP_EXE" "$TEMP_CODE" "$3" >>config.log 2>&1 && answer='yes'
+	eval "HAVE_$2=\"$answer\""
+	printf %s\\n "$ECHOBUF ... $answer"
+	rm -f -- "$TEMP_CODE" "$TEMP_EXE"
 	[ "$answer" = 'no' ] && {
-		[ "$3" ] && die 1 "$3"
+		[ "$4" ] && die 1 "$4"
 	}
 }
 


### PR DESCRIPTION
This adds 4 commits.

1. More use of `printf` instead of `echo` and some better quoting practices in the check_lib function.
2. It moves the language check in the `check_lib` function for `cxx` or `c` into its own `check_compiler` function so it can be later reused.
3. Removes the unused and broken `check_code_c` and `check_code_cxx` functions. They do not create any temporary files required for the check. Without examples of how they should be used It seems they don't offer much use that `check_lib` doesn't cover so I propose to just remove them. This commit can be changed if someone objects.
4. It uses the new `check_compiler` function to combine the `check_switch_c` and `check_switch_cxx` functions into `check_switch`. Note that `check_switch_cxx` was unused.