### PR TITLE
qb: Combine the add_include_dirs and add_library_dirs functions

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -5,9 +5,9 @@ check_switch '' NOUNUSED_VARIABLE -Wno-unused-variable
 add_define MAKEFILE NOUNUSED_VARIABLE "$HAVE_NOUNUSED_VARIABLE"
 
 # There are still broken 64-bit Linux distros out there. :)
-[ -z "$CROSS_COMPILE" ] && [ -d /usr/lib64 ] && add_library_dirs /usr/lib64
+[ -z "$CROSS_COMPILE" ] && [ -d /usr/lib64 ] && add_dirs LIBRARY /usr/lib64
 
-[ -z "$CROSS_COMPILE" ] && [ -d /opt/local/lib ] && add_library_dirs /opt/local/lib
+[ -z "$CROSS_COMPILE" ] && [ -d /opt/local/lib ] && add_dirs LIBRARY /opt/local/lib
 
 [ "$GLOBAL_CONFIG_DIR" ] || \
 {	case "$PREFIX" in
@@ -46,7 +46,7 @@ if [ "$HAVE_VIDEOCORE" != "no" ]; then
 
    # use fallback if pkgconfig is not available
    if [ ! "$VC_TEST_LIBS" ]; then
-      [ -d /opt/vc/lib ] && add_library_dirs /opt/vc/lib && add_library_dirs /opt/vc/lib/GL
+      [ -d /opt/vc/lib ] && add_dirs LIBRARY /opt/vc/lib /opt/vc/lib/GL
       check_lib '' VIDEOCORE -lbcm_host bcm_host_init "-lvcos -lvchiq_arm"
    else
       HAVE_VIDEOCORE="$HAVE_VC_TEST"
@@ -59,9 +59,9 @@ if [ "$HAVE_VIDEOCORE" = 'yes' ]; then
 
    # use fallback if pkgconfig is not available
    if [ ! "$VC_TEST_LIBS" ]; then
-      [ -d /opt/vc/include ] && add_include_dirs /opt/vc/include
-      [ -d /opt/vc/include/interface/vcos/pthreads ] && add_include_dirs /opt/vc/include/interface/vcos/pthreads
-      [ -d /opt/vc/include/interface/vmcs_host/linux ] && add_include_dirs /opt/vc/include/interface/vmcs_host/linux
+      [ -d /opt/vc/include ] && add_dirs INCLUDE /opt/vc/include
+      [ -d /opt/vc/include/interface/vcos/pthreads ] && add_dirs INCLUDE /opt/vc/include/interface/vcos/pthreads
+      [ -d /opt/vc/include/interface/vmcs_host/linux ] && add_dirs INCLUDE /opt/vc/include/interface/vmcs_host/linux
       EXTRA_GL_LIBS="-lbrcmEGL -lbrcmGLESv2 -lbcm_host -lvcos -lvchiq_arm"
    fi
 fi
@@ -73,7 +73,7 @@ if [ "$HAVE_NEON" = "yes" ]; then
 fi
 
 if [ "$HAVE_7ZIP" = "yes" ]; then
-   add_include_dirs ./deps/7zip/
+   add_dirs INCLUDE ./deps/7zip
 fi
 
 if [ "$HAVE_PRESERVE_DYLIB" = "yes" ]; then

--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -6,14 +6,13 @@ CONFIG_DEFINES=''
 add_define() # $1 = MAKEFILE or CONFIG $2 = define $3 = value
 { eval "${1}_DEFINES=\"\${${1}_DEFINES} $2=$3\""; }
 
-add_include_dirs()
-{	while [ "$1" ]; do INCLUDE_DIRS="$INCLUDE_DIRS -I$1"; shift; done
-	INCLUDE_DIRS="${INCLUDE_DIRS# }"
-}
-
-add_library_dirs()
-{	while [ "$1" ]; do LIBRARY_DIRS="$LIBRARY_DIRS -L$1"; shift; done
-	LIBRARY_DIRS="${LIBRARY_DIRS# }"
+add_dirs() # $1 = INCLUDE or LIBRARY  $@ = include or library paths
+{	ADD="$1"; LINK="${1%"${1#?}"}"; shift
+	while [ "$1" ]; do
+		eval "${ADD}_DIRS=\"\${${ADD}_DIRS} -${LINK}${1}\""
+		shift
+	done
+	eval "${ADD}_DIRS=\"\${${ADD}_DIRS# }\""
 }
 
 check_compiler() # $1 = language  $2 = function in lib


### PR DESCRIPTION
Combines the nearly identical `add_include_dirs` and `add_library_dirs` functions into `add_dirs`.

If anyone is interested, `LINK="${1%"${1#?}"}"` will return the first letter of `$1` which will either be `INCLUDE` or `LIBRARY`. Conveniently `I` and `L` will be the respective required result.