### PR TITLE
qb: Clean up qb.comp.sh

### DIFF
--- a/qb/qb.comp.sh
+++ b/qb/qb.comp.sh
@@ -85,7 +85,7 @@ fi
 
 if [ -z "$PKG_CONF_PATH" ]; then
 	PKG_CONF_PATH="none"
-	for pkgconf in pkg-config; do
+	for pkgconf in pkgconf pkg-config; do
 		PKGCONF="$(exists "${CROSS_COMPILE}${pkgconf}")" || PKGCONF=""
 		[ "$PKGCONF" ] && {
 			PKG_CONF_PATH="$PKGCONF"


### PR DESCRIPTION
This adds two commits.

1. This cleans up `qb.comp.sh` to reduce the long lines and hopefully make it easier to read and maintain. Also it should detect compilers in a slightly more fail proof way. Its good to note that unlike GNU `which` the `exists` function does not suffer a performance loss if its invoked in a loop or not. It might be even insignificantly faster if checking only one program at a time.
For example:
```
$ time for i in $(exists gcc cc clang g++ c++ clang++); do echo $i; done
/usr/bin/gcc
/usr/bin/cc
/usr/bin/clang
/usr/bin/g++
/usr/bin/c++
/usr/bin/clang++

real	0m0.007s
user	0m0.005s
sys	0m0.002s
```
```
$ time for i in gcc cc clang g++ c++ clang++; do exists $i; done
/usr/bin/gcc
/usr/bin/cc
/usr/bin/clang
/usr/bin/g++
/usr/bin/c++
/usr/bin/clang++

real	0m0.005s
user	0m0.005s
sys	0m0.000s
```
2. The qb scripts will now prefer the newer `pkgconf` instead of the legacy GNU `pkg-config`. In the event that `pkgconf` does not exist it will fall back to `pkg-config`. As far as RetroArch is concerned both work equally well, but `pkgconf` is arguably a far better implementation.

Currently its used in the following places:
* `FreeBSD`
* `Alpine`
* `Funtoo`
* `Sabotage`
* `pkgsrc`
* `OpenMandriva` (In the next release)
* `Fedora`

And it is available optionally for:
* `Gentoo`
* `ArchLinux`
* `Mageia`
* `Debian`
* `Ubuntu`
* `Slackware`

https://github.com/pkgconf/pkgconf/wiki/Roadmap