### PR TITLE
qb: Clean up empty defines in config.mk

### DIFF
--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -93,12 +93,13 @@ check_pkgconf()	#$1 = HAVE_$1	$2 = package	$3 = version	$4 = critical error mess
 	
 	eval HAVE_$1="$answer";
 	echo "$ECHOBUF ... $version"
-	PKG_CONF_USED="$PKG_CONF_USED $1"
-	[ "$answer" = 'no' ] && {
+	if [ "$answer" = 'no' ]; then
 		[ "$4" ] && die 1 "$4"
 		[ "$tmpval" = 'yes' ] && \
 			die 1 "Forced to build with package $2, but cannot locate. Exiting ..."
-	}
+	else
+		PKG_CONF_USED="$PKG_CONF_USED $1"
+	fi
 }
 
 check_header()	#$1 = HAVE_$1	$2..$5 = header files


### PR DESCRIPTION
This removes several empty defines from config.mk. For example see this diff where the `+` lines are the defines removed.
```
--- config.mk	2017-11-25 12:25:57.267647369 -0800
+++ config.mk.old	2017-11-25 12:25:52.201596389 -0800
@@ -80,6 +80,8 @@
 IBXM_LIBS = 
 HAVE_IMAGEVIEWER = 1
 HAVE_JACK = 0
+JACK_CFLAGS = 
+JACK_LIBS = 
 HAVE_KEYMAPPER = 1
 HAVE_KMS = 1
 HAVE_LANGEXTRA = 1
@@ -117,6 +119,8 @@
 HAVE_PLAIN_DRM = 0
 HAVE_PRESERVE_DYLIB = 0
 HAVE_PULSE = 0
+PULSE_CFLAGS = 
+PULSE_LIBS = 
 HAVE_PYTHON = 0
 HAVE_QT = 0
 HAVE_QT_WRAPPER = 0
@@ -124,8 +128,12 @@
 HAVE_RGUI = 1
 HAVE_RJPEG = 1
 HAVE_ROAR = 0
+ROAR_CFLAGS = 
+ROAR_LIBS = 
 HAVE_RPNG = 1
 HAVE_RSOUND = 0
+RSOUND_CFLAGS = 
+RSOUND_LIBS = 
 HAVE_RTGA = 1
 HAVE_SDL = 0
 SDL_CFLAGS = -I/usr/include/SDL -D_GNU_SOURCE=1 -D_REENTRANT
@@ -162,8 +170,14 @@
 UDEV_LIBS = -ludev
 HAVE_UPDATE_ASSETS = 1
 HAVE_V4L2 = 0
+V4L2_CFLAGS = 
+V4L2_LIBS = 
 HAVE_VC_TEST = 0
+VC_TEST_CFLAGS = 
+VC_TEST_LIBS = 
 HAVE_VG = 0
+VG_CFLAGS = 
+VG_LIBS = 
 HAVE_VIDEOCORE = 0
 HAVE_VIVANTE_FBDEV = 0
 ifneq ($(C89_BUILD),1)
@@ -171,7 +185,11 @@
 endif
 HAVE_VULKAN_DISPLAY = 1
 HAVE_WAYLAND = 0
+WAYLAND_CFLAGS = 
+WAYLAND_LIBS = 
 HAVE_WAYLAND_CURSOR = 0
+WAYLAND_CURSOR_CFLAGS = 
+WAYLAND_CURSOR_LIBS = 
 HAVE_X11 = 1
 X11_CFLAGS = 
 X11_LIBS = -lX11
```