### PR TITLE
qb: Add $PKG_CONF_USED to the check_lib function to help avoid undefined references.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -123,7 +123,6 @@ if [ "$HAVE_EGL" != "no" ] && [ "$OS" != 'Win32' ]; then
       HAVE_EGL=auto; check_lib '' EGL "-l${VC_PREFIX}EGL $EXTRA_GL_LIBS"
       if [ "$HAVE_EGL" = "yes" ]; then
          EGL_LIBS="-l${VC_PREFIX}EGL $EXTRA_GL_LIBS"
-         PKG_CONF_USED="$PKG_CONF_USED EGL"
       fi
    else
       EGL_LIBS="$EGL_LIBS $EXTRA_GL_LIBS"
@@ -316,9 +315,6 @@ if [ "$HAVE_OPENGL" != 'no' ] && [ "$HAVE_OPENGLES" != 'yes' ]; then
          [ "$HAVE_CG" = 'yes' ] && CG_LIBS='-lCg -lCgGL'
       fi
 
-      # fix undefined variables
-      PKG_CONF_USED="$PKG_CONF_USED CG"
-
       check_pkgconf OSMESA osmesa
    else
       die : 'Notice: Ignoring Cg. Desktop OpenGL is not enabled.'
@@ -410,7 +406,6 @@ if [ "$HAVE_X11" = "no" ] && [ "$OS" != 'Darwin' ]; then
    HAVE_X11=auto; check_lib '' X11 -lX11
    if [ "$HAVE_X11" = "yes" ]; then
       X11_LIBS="-lX11"
-      PKG_CONF_USED="$PKG_CONF_USED X11"
    fi
 fi
 
@@ -427,7 +422,6 @@ if [ "$HAVE_X11" != "no" ]; then
       HAVE_XEXT=auto; check_lib '' XEXT -lXext
       if [ "$HAVE_XEXT" = "yes" ]; then
          XEXT_LIBS="-lXext"
-         PKG_CONF_USED="$PKG_CONF_USED XEXT"
       fi
    fi
 
@@ -435,7 +429,6 @@ if [ "$HAVE_X11" != "no" ]; then
       HAVE_XF86VM=auto; check_lib '' XF86VM -lXxf86vm
       if [ "$HAVE_XF86VM" = "yes" ]; then
          XF86VM_LIBS="-lXxf86vm"
-         PKG_CONF_USED="$PKG_CONF_USED XF86VM"
       fi
    fi
 else
@@ -457,7 +450,6 @@ if [ "$HAVE_UDEV" != "no" ]; then
       HAVE_UDEV=auto; check_lib '' UDEV "-ludev"
       if [ "$HAVE_UDEV" = "yes" ]; then
          UDEV_LIBS='-ludev'
-         PKG_CONF_USED="$PKG_CONF_USED UDEV"
       fi
    fi
 fi

--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -58,13 +58,14 @@ check_lib() # $1 = language  $2 = HAVE_$2  $3 = lib  $4 = function in lib  $5 = 
 	printf %s\\n "$ECHOBUF ... $answer"
 	rm -f -- "$TEMP_CODE" "$TEMP_EXE"
 
-	[ "$answer" = 'no' ] && {
+	if [ "$answer" = 'no' ]; then
 		[ "$7" ] && die 1 "$7"
 		[ "$tmpval" = 'yes' ] && {
 			die 1 "Forced to build with library $3, but cannot locate. Exiting ..."
 		}
-
-	}
+	else
+		PKG_CONF_USED="$PKG_CONF_USED $2"
+	fi
 
 	return 0
 }
@@ -219,8 +220,8 @@ create_config_make()
 				*$1*)
 					FLAGS="$(eval "printf %s \"\$$1_CFLAGS\"")"
 					LIBS="$(eval "printf %s \"\$$1_LIBS\"")"
-					printf %s\\n "$1_CFLAGS = ${FLAGS%"${FLAGS##*[! ]}"}" \
-						"$1_LIBS = ${LIBS%"${LIBS##*[! ]}"}"
+					[ "${FLAGS}" ] && printf %s\\n "$1_CFLAGS = ${FLAGS%"${FLAGS##*[! ]}"}"
+					[ "${LIBS}" ] && printf %s\\n "$1_LIBS = ${LIBS%"${LIBS##*[! ]}"}"
 				;;
 			esac
 			shift


### PR DESCRIPTION
This is the first step in cleaning up the repetitive checks for when `pkg-config` is not used. Adding `$PKG_CONF_USED` to the `check_lib` function helps the `create_config_make` function not miss any variables. Before now each one would have to be done manually since they were only automatically added to `config.mk` if `pkg-config` was used.

This also has the side effect of removing more empty defines from config.mk. See the lines with a `+` in this diff for an example.
```
--- config.mk	2017-11-25 13:55:02.517038914 -0800
+++ config.mk.old	2017-11-25 13:54:57.355990282 -0800
@@ -10,20 +10,27 @@
 PREFIX = /usr/local
 HAVE_7ZIP = 1
 HAVE_AL = 1
+AL_CFLAGS = 
+AL_LIBS = 
 ifneq ($(C89_BUILD),1)
 HAVE_ALSA = 1
 endif
 ALSA_CFLAGS = -I/usr/include/alsa
 ALSA_LIBS = -lasound
 HAVE_AVCODEC = 1
+AVCODEC_CFLAGS = 
 AVCODEC_LIBS = -lavcodec
 HAVE_AVDEVICE = 1
+AVDEVICE_CFLAGS = 
 AVDEVICE_LIBS = -lavdevice
 HAVE_AVFORMAT = 1
+AVFORMAT_CFLAGS = 
 AVFORMAT_LIBS = -lavformat
 HAVE_AVRESAMPLE = 1
+AVRESAMPLE_CFLAGS = 
 AVRESAMPLE_LIBS = -lavresample
 HAVE_AVUTIL = 1
+AVUTIL_CFLAGS = 
 AVUTIL_LIBS = -lavutil
 HAVE_AV_CHANNEL_LAYOUT = 1
 ifneq ($(C89_BUILD),1)
@@ -33,6 +40,7 @@
 HAVE_C99 = 1
 HAVE_CACA = 0
 HAVE_CG = 1
+CG_CFLAGS = 
 CG_LIBS = -lCg -lCgGL
 HAVE_CHEEVOS = 1
 HAVE_COMMAND = 1
@@ -62,11 +70,14 @@
 FREETYPE_CFLAGS = -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/harfbuzz -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include
 FREETYPE_LIBS = -lfreetype
 HAVE_GBM = 1
+GBM_CFLAGS = 
 GBM_LIBS = -lgbm
 HAVE_GETADDRINFO = 1
 HAVE_GETOPT_LONG = 1
 HAVE_HID = 1
 HAVE_IBXM = 1
+IBXM_CFLAGS = 
+IBXM_LIBS = 
 HAVE_IMAGEVIEWER = 1
 HAVE_JACK = 0
 HAVE_KEYMAPPER = 1
@@ -137,14 +148,17 @@
 HAVE_STRCASESTR = 1
 HAVE_SUNXI = 0
 HAVE_SWRESAMPLE = 1
+SWRESAMPLE_CFLAGS = 
 SWRESAMPLE_LIBS = -lswresample
 HAVE_SWSCALE = 1
+SWSCALE_CFLAGS = 
 SWSCALE_LIBS = -lswscale
 HAVE_SYSTEMD = 0
 HAVE_THREADS = 1
 HAVE_THREAD_STORAGE = 1
 HAVE_TINYALSA = 1
 HAVE_UDEV = 1
+UDEV_CFLAGS = 
 UDEV_LIBS = -ludev
 HAVE_UPDATE_ASSETS = 1
 HAVE_V4L2 = 0
@@ -159,22 +173,30 @@
 HAVE_WAYLAND = 0
 HAVE_WAYLAND_CURSOR = 0
 HAVE_X11 = 1
+X11_CFLAGS = 
 X11_LIBS = -lX11
 HAVE_XCB = 1
+XCB_CFLAGS = 
 XCB_LIBS = -lxcb
 HAVE_XEXT = 1
+XEXT_CFLAGS = 
 XEXT_LIBS = -lXext
 HAVE_XF86VM = 1
+XF86VM_CFLAGS = 
 XF86VM_LIBS = -lXxf86vm
 HAVE_XINERAMA = 1
+XINERAMA_CFLAGS = 
 XINERAMA_LIBS = -lXinerama
 HAVE_XKBCOMMON = 1
+XKBCOMMON_CFLAGS = 
 XKBCOMMON_LIBS = -lxkbcommon
 HAVE_XSHM = 0
 HAVE_XVIDEO = 1
+XVIDEO_CFLAGS = 
 XVIDEO_LIBS = -lXv
 HAVE_ZARCH = 0
 HAVE_ZLIB = 1
+ZLIB_CFLAGS = 
 ZLIB_LIBS = -lz
 NOUNUSED = yes
 NOUNUSED_VARIABLE = yes
```