### PR TITLE
qb: Define $2_LIBS in the check_lib function.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -322,7 +322,7 @@ endif
 endif
 
 ifeq ($(HAVE_SSA),1)
-LIBS += -lass
+LIBS += $(SSA_LIBS)
 endif
 
 # LibretroDB
@@ -601,7 +601,7 @@ ifeq ($(HAVE_AL), 1)
    ifeq ($(OSX),1)
       LIBS += -framework OpenAL
    else
-      LIBS += -lopenal
+      LIBS += $(AL_LIBS)
    endif
 endif
 
@@ -812,7 +812,7 @@ ifeq ($(HAVE_THREADS), 1)
           audio/audio_thread_wrapper.o
    DEFINES += -DHAVE_THREADS
    ifeq ($(findstring Haiku,$(OS)),)
-      LIBS += -lpthread
+      LIBS += $(THREADS_LIBS)
    endif
 endif
 
@@ -1066,7 +1066,7 @@ endif
    else
       DEFINES += -DHAVE_GL_SYNC
       OBJ += $(LIBRETRO_COMM_DIR)/glsym/glsym_gl.o
-      GL_LIBS := -lGL
+      GL_LIBS := $(OPENGL_LIBS)
       ifeq ($(OSX), 1)
          GL_LIBS := -framework OpenGL
          OBJ += gfx/drivers_context/cgl_ctx.o
@@ -1512,7 +1512,7 @@ ifeq ($(HAVE_NETWORKING), 1)
 					 $(DEPS_DIR)/miniupnpc/minixml.o \
 					 $(DEPS_DIR)/miniupnpc/minisoap.o
 		else
-		   LIBS += -lminiupnpc
+		   LIBS += $(MINIUPNPC_LIBS)
       endif
    endif
 endif

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -120,10 +120,8 @@ if [ "$HAVE_EGL" != "no" ] && [ "$OS" != 'Win32' ]; then
    check_pkgconf EGL "$VC_PREFIX"egl
    # some systems have EGL libs, but no pkgconfig
    if [ "$HAVE_EGL" = "no" ]; then
-      HAVE_EGL=auto; check_lib '' EGL "-l${VC_PREFIX}EGL $EXTRA_GL_LIBS"
-      if [ "$HAVE_EGL" = "yes" ]; then
-         EGL_LIBS="-l${VC_PREFIX}EGL $EXTRA_GL_LIBS"
-      fi
+      HAVE_EGL=auto
+      check_lib '' EGL "-l${VC_PREFIX}EGL $EXTRA_GL_LIBS"
    else
       EGL_LIBS="$EGL_LIBS $EXTRA_GL_LIBS"
    fi
@@ -239,7 +237,7 @@ check_header OSS_BSD soundcard.h
 check_lib '' OSS_LIB -lossaudio
 
 if [ "$OS" = 'Linux' ]; then
-	HAVE_TINYALSA=yes
+   HAVE_TINYALSA=yes
 fi
 
 if [ "$OS" = 'Darwin' ]; then
@@ -304,15 +302,12 @@ if [ "$HAVE_OPENGL" != 'no' ] && [ "$HAVE_OPENGLES" != 'yes' ]; then
 
    if [ "$HAVE_OPENGL" = 'yes' ]; then
       if [ "$OS" = 'Darwin' ]; then
-         check_lib '' CG "-framework Cg" cgCreateContext
-         [ "$HAVE_CG" = 'yes' ] && CG_LIBS='-framework Cg'
+         check_lib '' CG '-framework Cg' cgCreateContext
       elif [ "$OS" = 'Win32' ]; then
-         check_lib cxx CG -lcg cgCreateContext
-         [ "$HAVE_CG" = 'yes' ] && CG_LIBS='-lcg -lcgGL'
+         check_lib cxx CG '-lcg -lcgGL' cgCreateContext
       else
          # On some distros, -lCg doesn't link against -lstdc++ it seems ...
-         check_lib cxx CG -lCg cgCreateContext
-         [ "$HAVE_CG" = 'yes' ] && CG_LIBS='-lCg -lCgGL'
+         check_lib cxx CG '-lCg -lCgGL' cgCreateContext
       fi
 
       check_pkgconf OSMESA osmesa
@@ -403,10 +398,8 @@ check_pkgconf X11 x11
 check_pkgconf XCB xcb
 
 if [ "$HAVE_X11" = "no" ] && [ "$OS" != 'Darwin' ]; then
-   HAVE_X11=auto; check_lib '' X11 -lX11
-   if [ "$HAVE_X11" = "yes" ]; then
-      X11_LIBS="-lX11"
-   fi
+   HAVE_X11=auto
+   check_lib '' X11 -lX11
 fi
 
 check_pkgconf WAYLAND wayland-egl
@@ -419,17 +412,13 @@ check_pkgconf XF86VM xxf86vm
 
 if [ "$HAVE_X11" != "no" ]; then
    if [ "$HAVE_XEXT" = "no" ]; then
-      HAVE_XEXT=auto; check_lib '' XEXT -lXext
-      if [ "$HAVE_XEXT" = "yes" ]; then
-         XEXT_LIBS="-lXext"
-      fi
+      HAVE_XEXT=auto
+      check_lib '' XEXT -lXext
    fi
 
    if [ "$HAVE_XF86VM" = "no" ]; then
-      HAVE_XF86VM=auto; check_lib '' XF86VM -lXxf86vm
-      if [ "$HAVE_XF86VM" = "yes" ]; then
-         XF86VM_LIBS="-lXxf86vm"
-      fi
+      HAVE_XF86VM=auto
+      check_lib '' XF86VM -lXxf86vm
    fi
 else
    HAVE_XEXT=no; HAVE_XF86VM=no; HAVE_XINERAMA=no; HAVE_XSHM=no
@@ -447,10 +436,8 @@ fi
 if [ "$HAVE_UDEV" != "no" ]; then
    check_pkgconf UDEV libudev
    if [ "$HAVE_UDEV" = "no" ]; then
-      HAVE_UDEV=auto; check_lib '' UDEV "-ludev"
-      if [ "$HAVE_UDEV" = "yes" ]; then
-         UDEV_LIBS='-ludev'
-      fi
+      HAVE_UDEV=auto
+      check_lib '' UDEV "-ludev"
    fi
 fi
 

--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -64,6 +64,7 @@ check_lib() # $1 = language  $2 = HAVE_$2  $3 = lib  $4 = function in lib  $5 = 
 			die 1 "Forced to build with library $3, but cannot locate. Exiting ..."
 		}
 	else
+		eval "${2}_LIBS=\"$3\""
 		PKG_CONF_USED="$PKG_CONF_USED $2"
 	fi
 


### PR DESCRIPTION
This is the second pass at reducing repetitive code for building RetroArch without pkg-config. Now the `check_lib` function will define `"${2}_LIBS="$3"` if it determines the library is there and it will no longer be necessary to check if it has succeeded and add the libraries manually in `config.libs.sh`.

This has the side effect of adding the following defines to `config.mk`, some of which are useful for the `Makefile.common` and they will now be used in the second commit. See the `-` lines in this diff.
```
--- config.mk	2017-11-25 15:33:04.926470516 -0800
+++ config.mk.old	2017-11-25 15:33:02.194445827 -0800
@@ -10,7 +10,6 @@
 PREFIX = /usr/local
 HAVE_7ZIP = 1
 HAVE_AL = 1
-AL_LIBS = -lopenal
 ifneq ($(C89_BUILD),1)
 HAVE_ALSA = 1
 endif
@@ -46,9 +45,7 @@
 DRM_CFLAGS = -I/usr/include/libdrm
 DRM_LIBS = -ldrm
 HAVE_DYLIB = 1
-DYLIB_LIBS = -ldl
 HAVE_DYNAMIC = 1
-DYNAMIC_LIBS = -ldl
 HAVE_EGL = 1
 EGL_CFLAGS = -I/usr/include/libdrm
 EGL_LIBS = -lEGL
@@ -67,9 +64,7 @@
 HAVE_GBM = 1
 GBM_LIBS = -lgbm
 HAVE_GETADDRINFO = 1
-GETADDRINFO_LIBS = -lc
 HAVE_GETOPT_LONG = 1
-GETOPT_LONG_LIBS = -lc
 HAVE_HID = 1
 HAVE_IBXM = 1
 HAVE_IMAGEVIEWER = 1
@@ -88,15 +83,12 @@
 LIBXML2_LIBS = -lxml2
 HAVE_MALI_FBDEV = 0
 HAVE_MINIUPNPC = 1
-MINIUPNPC_LIBS = -lminiupnpc
 HAVE_MMAP = 1
-MMAP_LIBS = -lc
 HAVE_NEON = 0
 ifneq ($(C89_BUILD),1)
 HAVE_NETWORKGAMEPAD = 1
 endif
 HAVE_NETWORKING = 1
-NETWORKING_LIBS = -lc
 HAVE_NETWORK_CMD = 1
 HAVE_NOUNUSED = 1
 HAVE_NOUNUSED_VARIABLE = 1
@@ -104,7 +96,6 @@
 HAVE_OMAP = 0
 HAVE_OPENDINGUX_FBDEV = 0
 HAVE_OPENGL = 1
-OPENGL_LIBS = -lGL
 HAVE_OPENGLES = 0
 HAVE_OPENGLES3 = 0
 HAVE_OSMESA = 0
@@ -138,15 +129,12 @@
 endif
 HAVE_SOCKET_LEGACY = 0
 HAVE_SSA = 1
-SSA_LIBS = -lass
 HAVE_SSE = 0
 HAVE_STB_FONT = 1
 HAVE_STB_IMAGE = 1
 HAVE_STB_VORBIS = 1
 HAVE_STDIN_CMD = 1
-STDIN_CMD_LIBS = -lc
 HAVE_STRCASESTR = 1
-STRCASESTR_LIBS = -lc
 HAVE_SUNXI = 0
 HAVE_SWRESAMPLE = 1
 SWRESAMPLE_LIBS = -lswresample
@@ -154,9 +142,7 @@
 SWSCALE_LIBS = -lswscale
 HAVE_SYSTEMD = 0
 HAVE_THREADS = 1
-THREADS_LIBS = -lpthread
 HAVE_THREAD_STORAGE = 1
-THREAD_STORAGE_LIBS = -lpthread
 HAVE_TINYALSA = 1
 HAVE_UDEV = 1
 UDEV_LIBS = -ludev
@@ -169,7 +155,6 @@
 ifneq ($(C89_BUILD),1)
 HAVE_VULKAN = 1
 endif
-VULKAN_LIBS = -lvulkan
 HAVE_VULKAN_DISPLAY = 1
 HAVE_WAYLAND = 0
 HAVE_WAYLAND_CURSOR = 0
```