### PR TITLE
qb: Create a check_val function for the no pkg-config fallback path.

### DIFF
--- a/qb/config.comp.sh
+++ b/qb/config.comp.sh
@@ -4,4 +4,3 @@ USE_LANG_C="yes"
 if [ "$OS" = 'Win32' ]; then
 	USE_LANG_CXX="yes"
 fi
-

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -119,10 +119,8 @@ fi
 if [ "$HAVE_EGL" != "no" ] && [ "$OS" != 'Win32' ]; then
    check_pkgconf EGL "$VC_PREFIX"egl
    # some systems have EGL libs, but no pkgconfig
-   if [ "$HAVE_EGL" = "no" ]; then
-      HAVE_EGL=auto
-      check_lib '' EGL "-l${VC_PREFIX}EGL $EXTRA_GL_LIBS"
-   else
+   check_val '' EGL "-l${VC_PREFIX}EGL $EXTRA_GL_LIBS"
+   if [ "$HAVE_EGL" = "yes" ]; then
       EGL_LIBS="$EGL_LIBS $EXTRA_GL_LIBS"
    fi
 fi
@@ -319,11 +317,7 @@ fi
 
 if [ "$HAVE_ZLIB" != 'no' ]; then
    check_pkgconf ZLIB zlib
-
-   if [ "$HAVE_ZLIB" = 'no' ]; then
-      HAVE_ZLIB='auto'
-      check_lib '' ZLIB '-lz'
-   fi
+   check_val '' ZLIB '-lz'
 fi
 
 if [ "$HAVE_THREADS" != 'no' ]; then
@@ -382,10 +376,7 @@ if [ "$HAVE_EGL" = "yes" ]; then
    fi
    if [ "$HAVE_VG" != "no" ]; then
       check_pkgconf VG "$VC_PREFIX"vg
-      if [ "$HAVE_VG" = "no" ]; then
-         HAVE_VG=auto; check_lib '' VG "-l${VC_PREFIX}OpenVG $EXTRA_GL_LIBS"
-         [ "$HAVE_VG" = "yes" ] && VG_LIBS=-l"$VC_PREFIX"OpenVG
-      fi
+      check_val '' VG "-l${VC_PREFIX}OpenVG $EXTRA_GL_LIBS"
    fi
 else
    HAVE_VG=no
@@ -397,9 +388,8 @@ check_pkgconf FREETYPE freetype2
 check_pkgconf X11 x11
 check_pkgconf XCB xcb
 
-if [ "$HAVE_X11" = "no" ] && [ "$OS" != 'Darwin' ]; then
-   HAVE_X11=auto
-   check_lib '' X11 -lX11
+if [ "$OS" != 'Darwin' ]; then
+   check_val '' X11 -lX11
 fi
 
 check_pkgconf WAYLAND wayland-egl
@@ -411,15 +401,8 @@ check_pkgconf XEXT xext
 check_pkgconf XF86VM xxf86vm
 
 if [ "$HAVE_X11" != "no" ]; then
-   if [ "$HAVE_XEXT" = "no" ]; then
-      HAVE_XEXT=auto
-      check_lib '' XEXT -lXext
-   fi
-
-   if [ "$HAVE_XF86VM" = "no" ]; then
-      HAVE_XF86VM=auto
-      check_lib '' XF86VM -lXxf86vm
-   fi
+   check_val '' XEXT -lXext
+   check_val '' XF86VM -lXxf86vm
 else
    HAVE_XEXT=no; HAVE_XF86VM=no; HAVE_XINERAMA=no; HAVE_XSHM=no
 fi
@@ -435,10 +418,7 @@ fi
 
 if [ "$HAVE_UDEV" != "no" ]; then
    check_pkgconf UDEV libudev
-   if [ "$HAVE_UDEV" = "no" ]; then
-      HAVE_UDEV=auto
-      check_lib '' UDEV "-ludev"
-   fi
+   check_val '' UDEV "-ludev"
 fi
 
 check_header XSHM X11/Xlib.h X11/extensions/XShm.h

--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -71,7 +71,7 @@ check_lib() # $1 = language  $2 = HAVE_$2  $3 = lib  $4 = function in lib  $5 = 
 	return 0
 }
 
-check_pkgconf()	#$1 = HAVE_$1	$2 = package	$3 = version	$4 = critical error message [checked only if non-empty]
+check_pkgconf() # $1 = HAVE_$1  $2 = package  $3 = version  $4 = critical error message [checked only if non-empty]
 {	tmpval="$(eval echo \$HAVE_$1)"
 	[ "$tmpval" = 'no' ] && return 0
 
@@ -152,6 +152,14 @@ check_switch() # $1 = language  $2 = HAVE_$2  $3 = switch  $4 = critical error m
 	[ "$answer" = 'no' ] && {
 		[ "$4" ] && die 1 "$4"
 	}
+}
+
+check_val() # $1 = language  $2 = HAVE_$2  $3 = lib
+{	tmpval="$(eval "printf %s \"\$HAVE_$2\"")"
+	if [ "$tmpval" = 'no' ]; then
+		eval "HAVE_$2=auto"
+		check_lib "$1" "$2" "$3"
+	fi
 }
 
 create_config_header()


### PR DESCRIPTION
This is the third pass at reducing repetitive code for the fallback path without pkg-config.

This time it will add a `check_val` function (Better names welcome) to `qb.lib.sh` that wraps around the `check_lib` function and is to be used when the `check_pkgconf` function may fail.
```
check_val() # $1 = language  $2 = HAVE_$2  $3 = lib
{	tmpval="$(eval "printf %s \"\$HAVE_$2\"")"
	if [ "$tmpval" = 'no' ]; then
		eval "HAVE_$2=auto"
		check_lib "$1" "$2" "$3"
	fi
}
```