### PR TITLE
qb: Set configure paths without unset variables.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -150,14 +150,9 @@ fi
    add_define MAKEFILE libretro "$LIBRETRO"
 }
 
-[ -z "$ASSETS_DIR" ] && ASSETS_DIR="${PREFIX}/share"
-add_define MAKEFILE ASSETS_DIR "$ASSETS_DIR"
-
-[ -z "$BIN_DIR" ] && BIN_DIR="${PREFIX}/bin"
-add_define MAKEFILE BIN_DIR "$BIN_DIR"
-
-[ -z "$MAN_DIR" ] && MAN_DIR="${PREFIX}/share/man"
-add_define MAKEFILE MAN_DIR "$MAN_DIR"
+add_define MAKEFILE ASSETS_DIR "${ASSETS_DIR:-${PREFIX}/share}"
+add_define MAKEFILE BIN_DIR "${BIN_DIR:-${PREFIX}/bin}"
+add_define MAKEFILE MAN_DIR "${MAN_DIR:-${PREFIX}/share/man}"
 
 if [ "$OS" = 'DOS' ]; then
    HAVE_SHADERPIPELINE=no


### PR DESCRIPTION
This is a minor cleanup and avoids relying on a few more potentially unset variables. In practice `[ -z "$foo" ]` will detect if `$foo` is unset or blank, but if a script is run with `set -u` it will exit if its true. While the RetroArch configure script does not do this, it is still better practice to avoid unset variables. Using `"${FOO:-bar}"` will set the variable to the value of `$FOO` if its set, but if its unset or blank it will set it to `bar`.