### PR TITLE
libretro-common: Silence redefined warning.

### DIFF
--- a/libretro-common/file/nbio/nbio_linux.c
+++ b/libretro-common/file/nbio/nbio_linux.c
@@ -24,7 +24,9 @@
 
 #if defined(__linux__)
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>


### PR DESCRIPTION
Silences the following warning.
```
libretro-common/file/nbio/nbio_linux.c:27:0: warning: "_GNU_SOURCE" redefined
 #define _GNU_SOURCE
 
<command-line>:0:0: note: this is the location of the previous definition
```