### PR TITLE
libretro-common: Silence warnings for linux

### DIFF
--- a/libretro-common/include/retro_common_api.h
+++ b/libretro-common/include/retro_common_api.h
@@ -79,6 +79,10 @@ typedef int ssize_t;
 #define STRING_REP_INT64  "%I64d"
 #define STRING_REP_UINT64 "%I64u"
 #define STRING_REP_USIZE  "%Iu"
+#elif defined(__linux__) && defined(__x86_64__)
+#define STRING_REP_INT64  "%ld"
+#define STRING_REP_UINT64 "%lu"
+#define STRING_REP_USIZE  "%lu"
 #elif defined(__STDC_VERSION__) && __STDC_VERSION__>=199901L && !defined(VITA) && !defined(WIIU)
 #define STRING_REP_INT64  "%lld"
 #define STRING_REP_UINT64 "%llu"


### PR DESCRIPTION
Please review and make sure this is correct!

This silences the following warnings for linux. As I am not sure about other platforms this is only applied if  `__linux__` and `__x86_64__` are defined as these warnings are not present for 32-bit linux.
```
In file included from ./libretro-common/include/compat/strl.h:33:0,
                 from gfx/video_driver.c:20:
gfx/video_driver.c: In function ‘video_driver_frame’:
./libretro-common/include/retro_common_api.h:84:27: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 4 has type ‘long unsigned int’ [-Wformat=]
 #define STRING_REP_UINT64 "%llu"
                           ^
gfx/video_driver.c:2315:19: note: in expansion of macro ‘STRING_REP_UINT64’
                   STRING_REP_UINT64,
                   ^~~~~~~~~~~~~~~~~
gfx/video_driver.c:2333:19: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 6 has type ‘long unsigned int’ [-Wformat=]
                   "FPS: %6.1f || %s: " STRING_REP_UINT64,
                   ^~~~~~~~~~~~~~~~~~~~
gfx/video_driver.c:2336:19:
                   (uint64_t)video_driver_frame_count);
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ./libretro-common/include/compat/strl.h:33:0,
                 from gfx/video_driver.c:20:
./libretro-common/include/retro_common_api.h:84:31: note: format string is defined here
 #define STRING_REP_UINT64 "%llu"
                            ~~~^
                            %lu

In file included from ./libretro-common/include/compat/strl.h:33:0,
                 from libretro-common/file/config_file.c:39:
libretro-common/file/config_file.c: In function ‘config_set_uint64’:
./libretro-common/include/retro_common_api.h:84:27: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 4 has type ‘uint64_t {aka long unsigned int}’ [-Wformat=]
 #define STRING_REP_UINT64 "%llu"
                           ^
libretro-common/file/config_file.c:895:31: note: in expansion of macro ‘STRING_REP_UINT64’
    snprintf(buf, sizeof(buf), STRING_REP_UINT64, val);
                               ^~~~~~~~~~~~~~~~~

In file included from ./libretro-common/include/compat/strl.h:33:0,
                 from libretro-db/query.c:34:
libretro-db/query.c: In function ‘query_raise_expected_number’:
./libretro-common/include/retro_common_api.h:84:27: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 4 has type ‘long unsigned int’ [-Wformat=]
 #define STRING_REP_UINT64 "%llu"
                           ^
libretro-db/query.c:292:10: note: in expansion of macro ‘STRING_REP_UINT64’
          STRING_REP_UINT64 "::Expected number",
          ^~~~~~~~~~~~~~~~~
./libretro-common/include/retro_common_api.h:84:31: note: format string is defined here
 #define STRING_REP_UINT64 "%llu"
                            ~~~^
                            %lu
libretro-db/query.c: In function ‘query_raise_expected_string’:
./libretro-common/include/retro_common_api.h:84:27: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 4 has type ‘long unsigned int’ [-Wformat=]
 #define STRING_REP_UINT64 "%llu"
                           ^
libretro-db/query.c:300:10: note: in expansion of macro ‘STRING_REP_UINT64’
          STRING_REP_UINT64 "::Expected string",
          ^~~~~~~~~~~~~~~~~
./libretro-common/include/retro_common_api.h:84:31: note: format string is defined here
 #define STRING_REP_UINT64 "%llu"
                            ~~~^
                            %lu
libretro-db/query.c: In function ‘query_raise_unexpected_eof’:
./libretro-common/include/retro_common_api.h:84:27: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 4 has type ‘long unsigned int’ [-Wformat=]
 #define STRING_REP_UINT64 "%llu"
                           ^
libretro-db/query.c:308:10: note: in expansion of macro ‘STRING_REP_UINT64’
          STRING_REP_UINT64 "::Unexpected EOF",
          ^~~~~~~~~~~~~~~~~
./libretro-common/include/retro_common_api.h:84:31: note: format string is defined here
 #define STRING_REP_UINT64 "%llu"
                            ~~~^
                            %lu
libretro-db/query.c: In function ‘query_raise_unknown_function’:
./libretro-common/include/retro_common_api.h:84:27: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 4 has type ‘long unsigned int’ [-Wformat=]
 #define STRING_REP_UINT64 "%llu"
                           ^
libretro-db/query.c:324:10: note: in expansion of macro ‘STRING_REP_UINT64’
          STRING_REP_UINT64 "::Unknown function '",
          ^~~~~~~~~~~~~~~~~
./libretro-common/include/retro_common_api.h:84:31: note: format string is defined here
 #define STRING_REP_UINT64 "%llu"
                            ~~~^
                            %lu
libretro-db/query.c: In function ‘query_raise_expected_eof’:
./libretro-common/include/retro_common_api.h:84:27: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 4 has type ‘long unsigned int’ [-Wformat=]
 #define STRING_REP_UINT64 "%llu"
                           ^
libretro-db/query.c:339:10: note: in expansion of macro ‘STRING_REP_UINT64’
          STRING_REP_UINT64 "::Expected EOF found '%c'",
          ^~~~~~~~~~~~~~~~~
./libretro-common/include/retro_common_api.h:84:31: note: format string is defined here
 #define STRING_REP_UINT64 "%llu"
                            ~~~^
                            %lu
libretro-db/query.c: In function ‘query_raise_unexpected_char’:
./libretro-common/include/retro_common_api.h:84:27: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 4 has type ‘long unsigned int’ [-Wformat=]
 #define STRING_REP_UINT64 "%llu"
                           ^
libretro-db/query.c:351:10: note: in expansion of macro ‘STRING_REP_UINT64’
          STRING_REP_UINT64 "::Expected '%c' found '%c'",
          ^~~~~~~~~~~~~~~~~
./libretro-common/include/retro_common_api.h:84:31: note: format string is defined here
 #define STRING_REP_UINT64 "%llu"
                            ~~~^
                            %lu
libretro-db/query.c: In function ‘query_parse_integer’:
./libretro-common/include/retro_common_api.h:83:27: warning: format ‘%lld’ expects argument of type ‘long long int *’, but argument 3 has type ‘int64_t * {aka long int *}’ [-Wformat=]
 #define STRING_REP_INT64  "%lld"
                           ^
libretro-db/query.c:381:26: note: in expansion of macro ‘STRING_REP_INT64’
                          STRING_REP_INT64,
                          ^~~~~~~~~~~~~~~~
CC database_info.c
In file included from libretro-db/rmsgpack_dom.h:28:0,
                 from libretro-db/rmsgpack_dom.c:23:
libretro-db/rmsgpack_dom.c: In function ‘rmsgpack_dom_value_print’:
./libretro-common/include/retro_common_api.h:83:27: warning: format ‘%lld’ expects argument of type ‘long long int’, but argument 2 has type ‘long int’ [-Wformat=]
 #define STRING_REP_INT64  "%lld"
                           ^
libretro-db/rmsgpack_dom.c:318:17: note: in expansion of macro ‘STRING_REP_INT64’
          printf(STRING_REP_INT64, (int64_t)obj->val.int_);
                 ^~~~~~~~~~~~~~~~
./libretro-common/include/retro_common_api.h:84:27: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 2 has type ‘long unsigned int’ [-Wformat=]
 #define STRING_REP_UINT64 "%llu"
                           ^
libretro-db/rmsgpack_dom.c:321:17: note: in expansion of macro ‘STRING_REP_UINT64’
          printf(STRING_REP_UINT64, (uint64_t)obj->val.uint_);
                 ^~~~~~~~~~~~~~~~~

In file included from ./libretro-common/include/file/file_path.h:31:0,
                 from menu/cbs/menu_cbs_get_value.c:16:
menu/cbs/menu_cbs_get_value.c: In function ‘menu_action_setting_disp_set_label_perf_counters_common’:
./libretro-common/include/retro_common_api.h:84:27: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 4 has type ‘long unsigned int’ [-Wformat=]
 #define STRING_REP_UINT64 "%llu"
                           ^
menu/cbs/menu_cbs_get_value.c:575:10: note: in expansion of macro ‘STRING_REP_UINT64’
          STRING_REP_UINT64 " ticks, " STRING_REP_UINT64 " runs.",
          ^~~~~~~~~~~~~~~~~
./libretro-common/include/retro_common_api.h:84:31: note: format string is defined here
 #define STRING_REP_UINT64 "%llu"
                            ~~~^
                            %lu
./libretro-common/include/retro_common_api.h:84:27: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 5 has type ‘long unsigned int’ [-Wformat=]
 #define STRING_REP_UINT64 "%llu"
                           ^
menu/cbs/menu_cbs_get_value.c:575:10: note: in expansion of macro ‘STRING_REP_UINT64’
          STRING_REP_UINT64 " ticks, " STRING_REP_UINT64 " runs.",
          ^~~~~~~~~~~~~~~~~
./libretro-common/include/retro_common_api.h:84:31: note: format string is defined here
 #define STRING_REP_UINT64 "%llu"
                            ~~~^
                            %lu

menu/menu_displaylist.c: In function ‘menu_displaylist_parse_system_info’:
menu/menu_displaylist.c:837:19: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 6 has type ‘uint64_t {aka long unsigned int}’ [-Wformat=]
                   "%s %s: " STRING_REP_UINT64 "/" STRING_REP_UINT64 " B",
                   ^~~~~~~~~
In file included from ./libretro-common/include/compat/strl.h:33:0,
                 from menu/menu_displaylist.c:21:
./libretro-common/include/retro_common_api.h:84:31: note: format string is defined here
 #define STRING_REP_UINT64 "%llu"
                            ~~~^
                            %lu
menu/menu_displaylist.c:837:19: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 7 has type ‘uint64_t {aka long unsigned int}’ [-Wformat=]
                   "%s %s: " STRING_REP_UINT64 "/" STRING_REP_UINT64 " B",
                   ^~~~~~~~~
In file included from ./libretro-common/include/compat/strl.h:33:0,
                 from menu/menu_displaylist.c:21:
./libretro-common/include/retro_common_api.h:84:31: note: format string is defined here
 #define STRING_REP_UINT64 "%llu"
                            ~~~^
                            %lu
menu/menu_displaylist.c:844:19: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 6 has type ‘uint64_t {aka long unsigned int}’ [-Wformat=]
                   "%s %s: " STRING_REP_UINT64 "/" STRING_REP_UINT64 " MB",
                   ^~~~~~~~~
menu/menu_displaylist.c:847:19:
                   bytes_to_mb(memory_used),
                   ~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ./libretro-common/include/compat/strl.h:33:0,
                 from menu/menu_displaylist.c:21:
./libretro-common/include/retro_common_api.h:84:31: note: format string is defined here
 #define STRING_REP_UINT64 "%llu"
                            ~~~^
                            %lu
menu/menu_displaylist.c:844:19: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 7 has type ‘uint64_t {aka long unsigned int}’ [-Wformat=]
                   "%s %s: " STRING_REP_UINT64 "/" STRING_REP_UINT64 " MB",
                   ^~~~~~~~~
menu/menu_displaylist.c:848:19:
                   bytes_to_mb(memory_total)
                   ~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ./libretro-common/include/compat/strl.h:33:0,
                 from menu/menu_displaylist.c:21:
./libretro-common/include/retro_common_api.h:84:31: note: format string is defined here
 #define STRING_REP_UINT64 "%llu"
                            ~~~^
                            %lu
menu/menu_displaylist.c:851:19: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 6 has type ‘uint64_t {aka long unsigned int}’ [-Wformat=]
                   "%s %s: " STRING_REP_UINT64 "/" STRING_REP_UINT64 " GB",
                   ^~~~~~~~~
menu/menu_displaylist.c:854:19:
                   bytes_to_gb(memory_used),
                   ~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ./libretro-common/include/compat/strl.h:33:0,
                 from menu/menu_displaylist.c:21:
./libretro-common/include/retro_common_api.h:84:31: note: format string is defined here
 #define STRING_REP_UINT64 "%llu"
                            ~~~^
                            %lu
menu/menu_displaylist.c:851:19: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 7 has type ‘uint64_t {aka long unsigned int}’ [-Wformat=]
                   "%s %s: " STRING_REP_UINT64 "/" STRING_REP_UINT64 " GB",
                   ^~~~~~~~~
menu/menu_displaylist.c:855:19:
                   bytes_to_gb(memory_total)
                   ~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ./libretro-common/include/compat/strl.h:33:0,
                 from menu/menu_displaylist.c:21:
./libretro-common/include/retro_common_api.h:84:31: note: format string is defined here
 #define STRING_REP_UINT64 "%llu"
                            ~~~^
                            %lu
```