### PR TITLE
Controller 'get all buttons state' - replace uint64_t with retro_bits_t*

### DIFF
--- a/input/connect/connect_nesusb.c
+++ b/input/connect/connect_nesusb.c
@@ -27,7 +27,7 @@ struct hidpad_nesusb_data
    struct pad_connection* connection;
    uint8_t data[64];
    uint32_t slot;
-   uint64_t buttons;
+   uint32_t buttons;
 };
 
 static void* hidpad_nesusb_init(void *data, uint32_t slot, send_control_t ptr)
@@ -59,12 +59,14 @@ static void hidpad_nesusb_deinit(void *data)
       free(device);
 }
 
-static uint64_t hidpad_nesusb_get_buttons(void *data)
+static void hidpad_nesusb_get_buttons(void *data, retro_bits_t* state)
 {
-   struct hidpad_nesusb_data *device = (struct hidpad_nesusb_data*)data;
-   if (!device)
-      return 0;
-   return device->buttons;
+	struct hidpad_nesusb_data *device = (struct hidpad_nesusb_data*)data;
+	if (device) {
+		RARCH_INPUT_STATE_COPY16_PTR(state, device->buttons);
+	} else {
+		RARCH_INPUT_STATE_CLEAR_PTR(state);
+	}
 }
 
 static int16_t hidpad_nesusb_get_axis(void *data, unsigned axis)
@@ -102,7 +104,6 @@ static void hidpad_nesusb_packet_handler(void *data, uint8_t *packet, uint16_t s
       RETRO_DEVICE_ID_JOYPAD_A,
       RETRO_DEVICE_ID_JOYPAD_Y,
       RETRO_DEVICE_ID_JOYPAD_X,
-      16, /* HOME BUTTON when pressing SELECT+START */
    };
    struct hidpad_nesusb_data *device = (struct hidpad_nesusb_data*)data;
 
@@ -113,12 +114,11 @@ static void hidpad_nesusb_packet_handler(void *data, uint8_t *packet, uint16_t s
 
    device->buttons = 0;
 
-   pressed_keys  = device->data[7] | (device->data[6] << 8) |
-                (((device->data[7] & 0x30) == 0x30) ? (1 << 16) : 0);  /* SELECT+START=HOME */
+   pressed_keys  = device->data[7] | (device->data[6] << 8);
 
-   for (i = 0; i < 17; i ++)
+   for (i = 0; i < 16; i ++)
       if (button_mapping[i] != NO_BTN)
-         device->buttons |= (pressed_keys & (1 << i)) ? (UINT64_C(1) << button_mapping[i]) : 0;
+         device->buttons |= (pressed_keys & (1 << i)) ? (1 << button_mapping[i]) : 0;
 }
 
 static void hidpad_nesusb_set_rumble(void *data,

--- a/input/connect/connect_ps2adapter.c
+++ b/input/connect/connect_ps2adapter.c
@@ -27,7 +27,7 @@ struct hidpad_ps2adapter_data
    struct pad_connection* connection;
    uint8_t data[64];
    uint32_t slot;
-   uint64_t buttons;
+   uint32_t buttons;
 };
 
 static void* hidpad_ps2adapter_init(void *data, uint32_t slot, send_control_t ptr)
@@ -59,12 +59,14 @@ static void hidpad_ps2adapter_deinit(void *data)
       free(device);
 }
 
-static uint64_t hidpad_ps2adapter_get_buttons(void *data)
+static void hidpad_ps2adapter_get_buttons(void *data, retro_bits_t *state)
 {
-   struct hidpad_ps2adapter_data *device = (struct hidpad_ps2adapter_data*)data;
-   if (!device)
-      return 0;
-   return device->buttons;
+	struct hidpad_ps2adapter_data *device = (struct hidpad_ps2adapter_data*)data;
+	if ( device ) {
+		RARCH_INPUT_STATE_COPY16_PTR(state, device->buttons);
+	} else {
+		RARCH_INPUT_STATE_CLEAR_PTR(state);
+	}
 }
 
 static int16_t hidpad_ps2adapter_get_axis(void *data, unsigned axis)
@@ -74,7 +76,7 @@ static int16_t hidpad_ps2adapter_get_axis(void *data, unsigned axis)
 
    if (!device || axis >= 4)
       return 0;
-   
+
    switch (axis)
    {
       case 0:
@@ -90,7 +92,7 @@ static int16_t hidpad_ps2adapter_get_axis(void *data, unsigned axis)
          val = device->data[2];
          break;
    }
-   
+
    val = (val << 8) - 0x8000;
 
    return (abs(val) > 0x1000) ? val : 0;
@@ -133,7 +135,7 @@ static void hidpad_ps2adapter_packet_handler(void *data, uint8_t *packet, uint16
    /* Check if the data corresponds to the first controller, exit otherwise */
    if (packet[1] != 1)
       return;
-   
+
    memcpy(device->data, packet, size);
 
    device->buttons = 0;
@@ -143,7 +145,7 @@ static void hidpad_ps2adapter_packet_handler(void *data, uint8_t *packet, uint16
    for (i = 0; i < 16; i ++)
       if (button_mapping[i] != NO_BTN)
          device->buttons |= (pressed_keys & (1 << i)) ? (UINT64_C(1) << button_mapping[i]) : 0;
-         
+
    /* Now process the hat values as if they were pad buttons */
    hat_value = PS2_H_GET(device->data[6]);
    device->buttons |= PS2_H_LEFT(hat_value) ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_LEFT) : 0;

--- a/input/connect/connect_ps3.c
+++ b/input/connect/connect_ps3.c
@@ -20,6 +20,7 @@
 
 #include <boolean.h>
 #include "joypad_connection.h"
+#include "../input_defines.h"
 
 struct hidpad_ps3_data
 {
@@ -27,7 +28,7 @@ struct hidpad_ps3_data
    send_control_t send_control;
    uint8_t data[512];
    uint32_t slot;
-   uint64_t buttons;
+   uint32_t buttons;
    bool have_led;
    uint16_t motors[2];
 };
@@ -104,12 +105,23 @@ static void hidpad_ps3_deinit(void *data)
       free(device);
 }
 
-static uint64_t hidpad_ps3_get_buttons(void *data)
+static void hidpad_ps3_get_buttons(void *data, retro_bits_t *state)
 {
-   struct hidpad_ps3_data *device = (struct hidpad_ps3_data*)data;
-   if (!device)
-      return 0;
-   return device->buttons;
+	struct hidpad_ps3_data *device = (struct hidpad_ps3_data*)data;
+	if ( device )
+	{
+		/*copy first 16 bits - standard RetroPad controls*/
+		RARCH_INPUT_STATE_COPY16_PTR(state, device->buttons);
+
+		/*PS button?*/
+		if ( device->buttons & 0x10000 ) {
+			RARCH_INPUT_STATE_BIT_SET_PTR( state, RARCH_MENU_TOGGLE );
+		}
+	}
+	else
+	{
+		RARCH_INPUT_STATE_CLEAR_PTR( state );
+	}
 }
 
 static int16_t hidpad_ps3_get_axis(void *data, unsigned axis)

--- a/input/connect/connect_ps4.c
+++ b/input/connect/connect_ps4.c
@@ -186,12 +186,13 @@ static bool hidpad_ps4_check_dpad(struct ps4 *rpt, unsigned id)
 
 static void hidpad_ps4_get_buttons(void *data, retro_bits_t* state)
 {
-   uint64_t buttonstate           = 0;
    struct hidpad_ps4_data *device = (struct hidpad_ps4_data*)data;
    struct ps4 *rpt = device ? (struct ps4*)&device->data : NULL;
 
    if (!device || !rpt)
       return;
+
+    RARCH_INPUT_STATE_CLEAR_PTR( state );
 
 	if ( rpt->btn.r3 ) {
 		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_R3 );

--- a/input/connect/connect_ps4.c
+++ b/input/connect/connect_ps4.c
@@ -184,35 +184,66 @@ static bool hidpad_ps4_check_dpad(struct ps4 *rpt, unsigned id)
    return false;
 }
 
-static uint64_t hidpad_ps4_get_buttons(void *data)
+static void hidpad_ps4_get_buttons(void *data, retro_bits_t* state)
 {
    uint64_t buttonstate           = 0;
    struct hidpad_ps4_data *device = (struct hidpad_ps4_data*)data;
    struct ps4 *rpt = device ? (struct ps4*)&device->data : NULL;
 
    if (!device || !rpt)
-      return 0;
+      return;
 
-   buttonstate |= (rpt->btn.r3 ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_R3)     : 0);
-   buttonstate |= (rpt->btn.l3 ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_L3)     : 0);
-   buttonstate |= (rpt->btn.options ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_START)  : 0);
-   buttonstate |= (rpt->btn.share ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_SELECT) : 0);
-   buttonstate |= (rpt->btn.r2 ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_R2)     : 0);
-   buttonstate |= (rpt->btn.l2 ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_L2)     : 0);
-   buttonstate |= (rpt->btn.r1 ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_R)      : 0);
-   buttonstate |= (rpt->btn.l1 ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_L)      : 0);
-
-   buttonstate |= (rpt->btn.triangle ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_X)      : 0);
-   buttonstate |= (rpt->btn.circle ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_A)      : 0);
-   buttonstate |= (rpt->btn.cross  ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_B)      : 0);
-   buttonstate |= (rpt->btn.square  ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_Y)      : 0);
-   buttonstate |= ((hidpad_ps4_check_dpad(rpt, RETRO_DEVICE_ID_JOYPAD_LEFT))   ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_LEFT)   : 0);
-   buttonstate |= ((hidpad_ps4_check_dpad(rpt, RETRO_DEVICE_ID_JOYPAD_DOWN))   ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_DOWN)   : 0);
-   buttonstate |= ((hidpad_ps4_check_dpad(rpt, RETRO_DEVICE_ID_JOYPAD_RIGHT))   ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_RIGHT)  : 0);
-   buttonstate |= ((hidpad_ps4_check_dpad(rpt, RETRO_DEVICE_ID_JOYPAD_UP))   ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_UP)     : 0);
-   buttonstate |= (rpt->btn.ps ? (UINT64_C(1) << RARCH_MENU_TOGGLE)             : 0);
-
-   return buttonstate;
+	if ( rpt->btn.r3 ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_R3 );
+	}
+	if ( rpt->btn.l3 ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_L3 );
+	}
+	if ( rpt->btn.options ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_START );
+	}
+	if ( rpt->btn.share ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_SELECT );
+	}
+	if ( rpt->btn.r2 ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_R2 );
+	}
+	if ( rpt->btn.l2 ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_L2 );
+	}
+	if ( rpt->btn.r1 ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_R );
+	}
+	if ( rpt->btn.l1 ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_L );
+	}
+	if ( rpt->btn.triangle ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_X );
+	}
+	if ( rpt->btn.circle ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_A );
+	}
+	if ( rpt->btn.cross ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_B );
+	}
+	if ( rpt->btn.square ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_Y );
+	}
+	if ( (hidpad_ps4_check_dpad(rpt, RETRO_DEVICE_ID_JOYPAD_LEFT)) ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_LEFT );
+	}
+	if ( (hidpad_ps4_check_dpad(rpt, RETRO_DEVICE_ID_JOYPAD_DOWN)) ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_DOWN );
+	}
+	if ( (hidpad_ps4_check_dpad(rpt, RETRO_DEVICE_ID_JOYPAD_RIGHT)) ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_RIGHT );
+	}
+	if ( (hidpad_ps4_check_dpad(rpt, RETRO_DEVICE_ID_JOYPAD_UP)) ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_UP );
+	}
+	if ( rpt->btn.ps ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RARCH_MENU_TOGGLE );
+	}
 }
 
 static int16_t hidpad_ps4_get_axis(void *data, unsigned axis)

--- a/input/connect/connect_snesusb.c
+++ b/input/connect/connect_snesusb.c
@@ -28,7 +28,7 @@ struct hidpad_snesusb_data
    struct pad_connection* connection;
    uint8_t data[64];
    uint32_t slot;
-   uint64_t buttons;
+   uint32_t buttons;
 };
 
 static void* hidpad_snesusb_init(void *data, uint32_t slot, send_control_t ptr)
@@ -60,12 +60,14 @@ static void hidpad_snesusb_deinit(void *data)
       free(device);
 }
 
-static uint64_t hidpad_snesusb_get_buttons(void *data)
+static void hidpad_snesusb_get_buttons(void *data, retro_bits_t *state)
 {
-   struct hidpad_snesusb_data *device = (struct hidpad_snesusb_data*)data;
-   if (!device)
-      return 0;
-   return device->buttons;
+	struct hidpad_snesusb_data *device = (struct hidpad_snesusb_data*)data;
+	if ( device ) {
+		RARCH_INPUT_STATE_COPY16_PTR(state, device->buttons);
+	} else {
+		RARCH_INPUT_STATE_CLEAR_PTR(state);
+	}
 }
 
 static int16_t hidpad_snesusb_get_axis(void *data, unsigned axis)
@@ -85,7 +87,7 @@ static int16_t hidpad_snesusb_get_axis(void *data, unsigned axis)
 static void hidpad_snesusb_packet_handler(void *data, uint8_t *packet, uint16_t size)
 {
    uint32_t i, pressed_keys;
-   static const uint32_t button_mapping[17] =
+   static const uint32_t button_mapping[16] =
    {
       RETRO_DEVICE_ID_JOYPAD_L,
       RETRO_DEVICE_ID_JOYPAD_R,
@@ -102,8 +104,7 @@ static void hidpad_snesusb_packet_handler(void *data, uint8_t *packet, uint16_t 
       RETRO_DEVICE_ID_JOYPAD_X,
       RETRO_DEVICE_ID_JOYPAD_A,
       RETRO_DEVICE_ID_JOYPAD_B,
-      RETRO_DEVICE_ID_JOYPAD_Y,
-      16, /* HOME BUTTON when pressing SELECT+START */
+      RETRO_DEVICE_ID_JOYPAD_Y
    };
    struct hidpad_snesusb_data *device = (struct hidpad_snesusb_data*)data;
 
@@ -114,12 +115,11 @@ static void hidpad_snesusb_packet_handler(void *data, uint8_t *packet, uint16_t 
 
    device->buttons = 0;
 
-   pressed_keys  = device->data[7] | (device->data[6] << 8) |
-                (((device->data[7] & 0x30) == 0x30) ? (1 << 16) : 0);  /* SELECT+START = MENU TOGGLE */
+   pressed_keys  = device->data[7] | (device->data[6] << 8);
 
-   for (i = 0; i < 17; i ++)
+   for (i = 0; i < 16; i ++)
       if (button_mapping[i] != NO_BTN)
-         device->buttons |= (pressed_keys & (1 << i)) ? (UINT64_C(1) << button_mapping[i]) : 0;
+         device->buttons |= (pressed_keys & (1 << i)) ? (1 << button_mapping[i]) : 0;
 }
 
 static void hidpad_snesusb_set_rumble(void *data,

--- a/input/connect/connect_wii.c
+++ b/input/connect/connect_wii.c
@@ -25,6 +25,7 @@
 #include <retro_timers.h>
 
 #include "joypad_connection.h"
+#include "../input_defines.h"
 
 /* wiimote state flags*/
 #define WIIMOTE_STATE_DEV_FOUND              0x0001
@@ -198,7 +199,7 @@ static int wiimote_send(struct connect_wii_wiimote_t* wm,
    return 1;
 }
 
-/* 
+/*
  * Request the wiimote controller status.
  *
  * Controller status includes: battery level, LED status, expansions.
@@ -426,13 +427,13 @@ static int wiimote_handshake(struct connect_wii_wiimote_t* wm,
       switch (wm->handshake_state)
       {
          case 0:
-            /* no ha habido nunca handshake, debemos forzar un 
+            /* no ha habido nunca handshake, debemos forzar un
              * mensaje de staus para ver que pasa. */
 
             WIIMOTE_ENABLE_STATE(wm, WIIMOTE_STATE_HANDSHAKE);
             wiimote_set_leds(wm, WIIMOTE_LED_NONE);
 
-            /* Request the status of the Wiimote to 
+            /* Request the status of the Wiimote to
              * see if there is an expansion */
             wiimote_status(wm);
 
@@ -440,16 +441,16 @@ static int wiimote_handshake(struct connect_wii_wiimote_t* wm,
             return 0;
          case 1:
             {
-               /* estamos haciendo handshake o bien se necesita iniciar un 
+               /* estamos haciendo handshake o bien se necesita iniciar un
                 * nuevo handshake ya que se inserta(quita una expansion. */
                int attachment = 0;
 
                if(event != WM_RPT_CTRL_STATUS)
                   return 0;
 
-               /* Is an attachment connected to 
+               /* Is an attachment connected to
                 * the expansion port? */
-               if ((data[2] & WM_CTRL_STATUS_BYTE1_ATTACHMENT) == 
+               if ((data[2] & WM_CTRL_STATUS_BYTE1_ATTACHMENT) ==
                      WM_CTRL_STATUS_BYTE1_ATTACHMENT)
                   attachment = 1;
 
@@ -473,19 +474,19 @@ static int wiimote_handshake(struct connect_wii_wiimote_t* wm,
                      /* Rehandshake. */
 
                      WIIMOTE_DISABLE_STATE(wm, WIIMOTE_STATE_HANDSHAKE_COMPLETE);
-                     /* forzamos un handshake por si venimos 
+                     /* forzamos un handshake por si venimos
                       * de un hanshake completo. */
                      WIIMOTE_ENABLE_STATE(wm, WIIMOTE_STATE_HANDSHAKE);
                   }
 
-                  /*Old way. initialize the extension was by writing the 
+                  /*Old way. initialize the extension was by writing the
                    * single encryption byte 0x00 to 0x(4)A40040. */
 #if 0
                   buf = 0x00;
                   wiimote_write_data(wm, WM_EXP_MEM_ENABLE, &buf, 1);
 #endif
 
-                  /* NEW WAY 0x55 to 0x(4)A400F0, then writing 
+                  /* NEW WAY 0x55 to 0x(4)A400F0, then writing
                    * 0x00 to 0x(4)A400FB. (support clones) */
                   buf = 0x55;
                   wiimote_write_data(wm, 0x04A400F0, &buf, 1);
@@ -515,7 +516,7 @@ static int wiimote_handshake(struct connect_wii_wiimote_t* wm,
                      printf("rehandshake\n");
 #endif
                      WIIMOTE_DISABLE_STATE(wm, WIIMOTE_STATE_HANDSHAKE_COMPLETE);
-                     /* forzamos un handshake por si venimos 
+                     /* forzamos un handshake por si venimos
                       * de un hanshake completo. */
                      WIIMOTE_ENABLE_STATE(wm, WIIMOTE_STATE_HANDSHAKE);
                   }
@@ -671,12 +672,15 @@ static int16_t hidpad_wii_get_axis(void *data, unsigned axis)
    return 0;
 }
 
-static uint64_t hidpad_wii_get_buttons(void *data)
+static void hidpad_wii_get_buttons(void *data, retro_bits_t *state)
 {
-   struct connect_wii_wiimote_t* device = (struct connect_wii_wiimote_t*)data;
-   if (!device)
-      return 0;
-   return  device->btns | (device->exp.cc.classic.btns << 16);
+	struct connect_wii_wiimote_t* device = (struct connect_wii_wiimote_t*)data;
+	if ( device )
+	{
+		uint32_t b;
+		b = device->btns | (device->exp.cc.classic.btns << 16); /*broken? this doesn't match retropad!!*/
+		RARCH_INPUT_STATE_COPY32_PTR(state, b);
+	}
 }
 
 static void hidpad_wii_packet_handler(void *data,

--- a/input/connect/connect_wiiugca.c
+++ b/input/connect/connect_wiiugca.c
@@ -20,6 +20,7 @@
 
 #include <boolean.h>
 #include "joypad_connection.h"
+#include "../input_defines.h"
 
 struct hidpad_wiiugca_data
 {
@@ -27,7 +28,7 @@ struct hidpad_wiiugca_data
    send_control_t send_control;
    uint8_t data[64];
    uint32_t slot;
-   uint64_t buttons;
+   uint32_t buttons;
 };
 
 static void* hidpad_wiiugca_init(void *data, uint32_t slot, send_control_t ptr)
@@ -62,12 +63,14 @@ static void hidpad_wiiugca_deinit(void *data)
       free(device);
 }
 
-static uint64_t hidpad_wiiugca_get_buttons(void *data)
+static void hidpad_wiiugca_get_buttons(void *data, retro_bits_t *state)
 {
-   struct hidpad_wiiugca_data *device = (struct hidpad_wiiugca_data*)data;
-   if (!device)
-      return 0;
-   return device->buttons;
+	struct hidpad_wiiugca_data *device = (struct hidpad_wiiugca_data*)data;
+	if ( device ) {
+		RARCH_INPUT_STATE_COPY16_PTR(state, device->buttons);
+	} else {
+		RARCH_INPUT_STATE_CLEAR_PTR(state);
+	}
 }
 
 static int16_t hidpad_wiiugca_get_axis(void *data, unsigned axis)

--- a/input/connect/connect_wiiupro.c
+++ b/input/connect/connect_wiiupro.c
@@ -97,7 +97,7 @@ static void* hidpad_wiiupro_init(void *data,
    device->connection   = connection;
    device->slot         = slot;
    device->send_control = ptr;
-   
+
    calib_data->calib_round = 0;
    /* Without this, the digital buttons won't be reported. */
    hidpad_wiiupro_send_control(device);
@@ -118,35 +118,65 @@ static void hidpad_wiiupro_deinit(void *data)
       free(device);
 }
 
-static uint64_t hidpad_wiiupro_get_buttons(void *data)
+static void hidpad_wiiupro_get_buttons(void *data, retro_bits_t *state)
 {
-   uint64_t buttonstate           = 0;
    struct hidpad_wiiupro_data *device = (struct hidpad_wiiupro_data*)data;
    struct wiiupro *rpt = device ? (struct wiiupro*)&device->data : NULL;
 
    if (!device || !rpt)
-      return 0;
+      return;
 
-   buttonstate |= (rpt->btn.r3       ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_R3)     : 0);
-   buttonstate |= (rpt->btn.l3       ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_L3)     : 0);
-   buttonstate |= (rpt->btn.plus     ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_START)  : 0);
-   buttonstate |= (rpt->btn.minus    ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_SELECT) : 0);
-   buttonstate |= (rpt->btn.zr       ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_R2)     : 0);
-   buttonstate |= (rpt->btn.zl       ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_L2)     : 0);
-   buttonstate |= (rpt->btn.r        ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_R)      : 0);
-   buttonstate |= (rpt->btn.l        ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_L)      : 0);
-
-   buttonstate |= (rpt->btn.x        ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_X)      : 0);
-   buttonstate |= (rpt->btn.a        ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_A)      : 0);
-   buttonstate |= (rpt->btn.b        ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_B)      : 0);
-   buttonstate |= (rpt->btn.y        ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_Y)      : 0);
-   buttonstate |= (rpt->btn.left     ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_LEFT)   : 0);
-   buttonstate |= (rpt->btn.right    ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_RIGHT)  : 0);
-   buttonstate |= (rpt->btn.up       ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_UP)     : 0);
-   buttonstate |= (rpt->btn.down     ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_DOWN)   : 0);
-   buttonstate |= (rpt->btn.home     ? (UINT64_C(1) << RARCH_MENU_TOGGLE)             : 0);
-
-   return buttonstate;
+	if ( rpt->btn.r3 ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_R3 );
+	}
+	if ( rpt->btn.l3 ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_L3 );
+	}
+	if ( rpt->btn.plus ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_START );
+	}
+	if ( rpt->btn.minus ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_SELECT );
+	}
+	if ( rpt->btn.zr ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_R2 );
+	}
+	if ( rpt->btn.zl ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_L2 );
+	}
+	if ( rpt->btn.r ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_R );
+	}
+	if ( rpt->btn.l ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_L );
+	}
+	if ( rpt->btn.x ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_X );
+	}
+	if ( rpt->btn.a ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_A );
+	}
+	if ( rpt->btn.b ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_B );
+	}
+	if ( rpt->btn.y ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_Y );
+	}
+	if ( rpt->btn.left ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_LEFT );
+	}
+	if ( rpt->btn.down ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_DOWN );
+	}
+	if ( rpt->btn.right ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_RIGHT );
+	}
+	if ( rpt->btn.up ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_UP );
+	}
+	if ( rpt->btn.home ) {
+		RARCH_INPUT_STATE_BIT_SET_PTR( state, RARCH_MENU_TOGGLE );
+	}
 }
 
 static int16_t hidpad_wiiupro_get_axis(void *data, unsigned axis)
@@ -214,18 +244,18 @@ static void hidpad_wiiupro_packet_handler(void *data,
        calib_data->hatvalue_calib[1] = (packet[8] |  (packet[8 + 1] << 8));
        calib_data->hatvalue_calib[2] = (packet[6] |  (packet[6 + 1] << 8));
        calib_data->hatvalue_calib[3] = (packet[10] | (packet[10 + 1] << 8));
-       
+
        calib_data->calib_round++;
    }
    else
    {
-       device->data.hatvalue[0] = (packet[4] |  (packet[4 + 1] << 8)) 
+       device->data.hatvalue[0] = (packet[4] |  (packet[4 + 1] << 8))
           - calib_data->hatvalue_calib[0];
-       device->data.hatvalue[1] = (packet[8] |  (packet[8 + 1] << 8)) 
+       device->data.hatvalue[1] = (packet[8] |  (packet[8 + 1] << 8))
           - calib_data->hatvalue_calib[1];
-       device->data.hatvalue[2] = (packet[6] |  (packet[6 + 1] << 8)) 
+       device->data.hatvalue[2] = (packet[6] |  (packet[6 + 1] << 8))
           - calib_data->hatvalue_calib[2];
-       device->data.hatvalue[3] = (packet[10] | (packet[10 + 1] << 8)) 
+       device->data.hatvalue[3] = (packet[10] | (packet[10 + 1] << 8))
           - calib_data->hatvalue_calib[3];
    }
 }

--- a/input/connect/connect_wiiupro.c
+++ b/input/connect/connect_wiiupro.c
@@ -126,6 +126,8 @@ static void hidpad_wiiupro_get_buttons(void *data, retro_bits_t *state)
    if (!device || !rpt)
       return;
 
+    RARCH_INPUT_STATE_CLEAR_PTR( state );
+
 	if ( rpt->btn.r3 ) {
 		RARCH_INPUT_STATE_BIT_SET_PTR( state, RETRO_DEVICE_ID_JOYPAD_R3 );
 	}

--- a/input/connect/joypad_connection.c
+++ b/input/connect/joypad_connection.c
@@ -103,7 +103,7 @@ int32_t pad_connection_pad_init(joypad_connection_t *joyconn,
          const char *name_match = strstr(pad_map[i].name, name);
 
          /* Never change, Nintendo. */
-         if(pad_map[i].vid == 1406 && pad_map[i].pid == 816)  
+         if(pad_map[i].vid == 1406 && pad_map[i].pid == 816)
          {
             if(!string_is_equal(pad_map[i].name, name))
                continue;
@@ -133,7 +133,7 @@ int32_t pad_connection_pad_init(joypad_connection_t *joyconn,
          }
       }
 
-      /* We failed to find a matching pad, 
+      /* We failed to find a matching pad,
        * set up one without an interface */
       if (!s->connected)
       {
@@ -173,11 +173,13 @@ void pad_connection_packet(joypad_connection_t *joyconn, uint32_t pad,
       joyconn->iface->packet_handler(joyconn->data, data, length);
 }
 
-uint64_t pad_connection_get_buttons(joypad_connection_t *joyconn, unsigned pad)
+void pad_connection_get_buttons(joypad_connection_t *joyconn, unsigned pad, retro_bits_t* state)
 {
-   if (!joyconn->iface)
-      return 0;
-   return joyconn->iface->get_buttons(joyconn->data);
+	if (joyconn->iface) {
+		joyconn->iface->get_buttons(joyconn->data, state);
+	} else {
+		RARCH_INPUT_STATE_CLEAR_PTR( state );
+	}
 }
 
 int16_t pad_connection_get_axis(joypad_connection_t *joyconn,
@@ -190,8 +192,8 @@ int16_t pad_connection_get_axis(joypad_connection_t *joyconn,
 
 bool pad_connection_has_interface(joypad_connection_t *joyconn, unsigned pad)
 {
-   if (     joyconn && pad < MAX_USERS 
-         && joyconn[pad].connected 
+   if (     joyconn && pad < MAX_USERS
+         && joyconn[pad].connected
          && joyconn[pad].iface)
       return true;
    return false;

--- a/input/connect/joypad_connection.h
+++ b/input/connect/joypad_connection.h
@@ -21,6 +21,7 @@
 #include <stddef.h>
 
 #include <libretro.h>
+#include <retro_miscellaneous.h>
 
 typedef void (*send_control_t)(void *data, uint8_t *buf, size_t size);
 
@@ -38,7 +39,7 @@ typedef struct pad_connection_interface
    void     	(*packet_handler)(void* device, uint8_t *packet, uint16_t size);
    void     	(*set_rumble)(void* device, enum retro_rumble_effect effect,
 					uint16_t strength);
-   uint64_t 	(*get_buttons)(void *data);
+   void			(*get_buttons)(void *data, retro_bits_t *state);
    int16_t  	(*get_axis)(void *data, unsigned axis);
    const char*	(*get_name)(void *data);
 } pad_connection_interface_t;
@@ -69,8 +70,8 @@ void pad_connection_pad_deinit(joypad_connection_t *joyconn,
 void pad_connection_packet(joypad_connection_t *joyconn,
    uint32_t idx, uint8_t* data, uint32_t length);
 
-uint64_t pad_connection_get_buttons(joypad_connection_t *joyconn,
-   unsigned idx);
+void pad_connection_get_buttons(joypad_connection_t *joyconn,
+   unsigned idx, retro_bits_t* state);
 
 int16_t pad_connection_get_axis(joypad_connection_t *joyconn,
    unsigned idx, unsigned i);

--- a/input/drivers_hid/btstack_hid.c
+++ b/input/drivers_hid/btstack_hid.c
@@ -1,7 +1,7 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2013-2014 - Jason Fetters
  *  Copyright (C) 2011-2017 - Daniel De Matteis
- * 
+ *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-
  *  ation, either version 3 of the License, or (at your option) any later version.
@@ -44,13 +44,13 @@
 #define LINK_KEY_LEN       16
 /* The device name type. */
 #define DEVICE_NAME_LEN    248
-    
+
 /* Type definitions. */
 typedef uint16_t hci_con_handle_t;
 typedef uint8_t bd_addr_t[BD_ADDR_LEN];
 typedef uint8_t link_key_t[LINK_KEY_LEN];
 typedef uint8_t device_name_t[DEVICE_NAME_LEN+1];
-    
+
 /* Packet handler. */
 typedef void (*btstack_packet_handler_t) (uint8_t packet_type,
     uint16_t channel, uint8_t *packet, uint16_t size);
@@ -62,7 +62,7 @@ typedef enum
    HCI_POWER_ON,
    HCI_POWER_SLEEP
 } HCI_POWER_MODE;
-    
+
 /* State of BTstack */
 typedef enum
 {
@@ -73,14 +73,14 @@ typedef enum
    HCI_STATE_SLEEPING,
    HCI_STATE_FALLING_ASLEEP
 } HCI_STATE;
-    
+
 typedef enum
 {
    RUN_LOOP_POSIX = 1,
    RUN_LOOP_COCOA,
    RUN_LOOP_EMBEDDED
 } RUN_LOOP_TYPE;
-    
+
 /* compact HCI Command packet description */
 typedef struct
 {
@@ -93,7 +93,7 @@ typedef struct linked_item
    struct linked_item *next; /* <-- next element in list, or NULL */
    void *user_data;          /* <-- pointer to struct base */
 } linked_item_t;
-    
+
 typedef linked_item_t *linked_list_t;
 
 typedef struct data_source
@@ -108,7 +108,7 @@ typedef struct data_source
 
 typedef struct timer
 {
-   linked_item_t item; 
+   linked_item_t item;
    /* Next timeout. */
    struct timeval timeout;
 #ifdef HAVE_TICK
@@ -167,7 +167,7 @@ BTDIMPORT const hci_cmd_t* l2cap_decline_connection_ptr;
 
 /* extension for client/server communication */
 #define DAEMON_EVENT_PACKET                                 0x05
-    
+
 /* L2CAP data */
 #define L2CAP_DATA_PACKET                                   0x06
 
@@ -179,7 +179,7 @@ BTDIMPORT const hci_cmd_t* l2cap_decline_connection_ptr;
 
 /* Security Manager protocol data */
 #define SM_DATA_PACKET                                      0x09
-    
+
 /* debug log messages */
 #define LOG_MESSAGE_PACKET                                  0xFC
 
@@ -228,7 +228,7 @@ BTDIMPORT const hci_cmd_t* l2cap_decline_connection_ptr;
 #define HCI_SUBEVENT_LE_CONNECTION_UPDATE_COMPLETE          0x03
 #define HCI_SUBEVENT_LE_READ_REMOTE_USED_FEATURES_COMPLETE  0x04
 #define HCI_SUBEVENT_LE_LONG_TERM_KEY_REQUEST               0x05
-    
+
 /* last used HCI_EVENT in 2.1 is 0x3d */
 
 /* events 0x50-0x5f are used internally */
@@ -257,7 +257,7 @@ BTDIMPORT const hci_cmd_t* l2cap_decline_connection_ptr;
 #define BTSTACK_EVENT_DISCOVERABLE_ENABLED                  0x66
 
 /* L2CAP EVENTS */
-	
+
 /* data: event (8), len(8), status (8), address(48), handle (16), psm (16), local_cid(16), remote_cid (16), local_mtu(16), remote_mtu(16)  */
 #define L2CAP_EVENT_CHANNEL_OPENED                          0x70
 
@@ -277,31 +277,31 @@ BTDIMPORT const hci_cmd_t* l2cap_decline_connection_ptr;
 #define L2CAP_EVENT_SERVICE_REGISTERED                      0x75
 
 /* RFCOMM EVENTS */
-	
+
 // data: event(8), len(8), status (8), address (48), handle (16), server channel(8), rfcomm_cid(16), max frame size(16)
 #define RFCOMM_EVENT_OPEN_CHANNEL_COMPLETE                  0x80
-	
+
 // data: event(8), len(8), rfcomm_cid(16)
 #define RFCOMM_EVENT_CHANNEL_CLOSED                         0x81
-	
+
 // data: event (8), len(8), address(48), channel (8), rfcomm_cid (16)
 #define RFCOMM_EVENT_INCOMING_CONNECTION                    0x82
-	
+
 // data: event (8), len(8), rfcommid (16), ...
 #define RFCOMM_EVENT_REMOTE_LINE_STATUS                     0x83
-	
+
 /* data: event(8), len(8), rfcomm_cid(16), credits(8) */
 #define RFCOMM_EVENT_CREDITS                                0x84
-	
+
 /* data: event(8), len(8), status (8), rfcomm server channel id (8)  */
 #define RFCOMM_EVENT_SERVICE_REGISTERED                     0x85
-    
+
 /* data: event(8), len(8), status (8), rfcomm server channel id (8)  */
 #define RFCOMM_EVENT_PERSISTENT_CHANNEL                     0x86
-    
+
 /* data: event(8), len(8), status(8), service_record_handle(32) */
 #define SDP_SERVICE_REGISTERED                              0x90
-	
+
 /* last error code in 2.1 is 0x38 - we start with 0x50 for BTstack errors */
 
 #define BTSTACK_CONNECTION_TO_BTDAEMON_FAILED               0x50
@@ -329,14 +329,14 @@ BTDIMPORT const hci_cmd_t* l2cap_decline_connection_ptr;
 #define L2CAP_CONFIG_RESPONSE_RESULT_REJECTED               0x68
 #define L2CAP_CONFIG_RESPONSE_RESULT_UNKNOWN_OPTIONS        0x69
 #define L2CAP_SERVICE_ALREADY_REGISTERED                    0x6a
-    
+
 #define RFCOMM_MULTIPLEXER_STOPPED                          0x70
 #define RFCOMM_CHANNEL_ALREADY_REGISTERED                   0x71
 #define RFCOMM_NO_OUTGOING_CREDITS                          0x72
 
 #define SDP_HANDLE_ALREADY_REGISTERED                       0x80
- 
-/* Default INQ Mode 
+
+/* Default INQ Mode
  * 0x9E8B33: General/Unlimited Inquiry Access Code (GIAC)
  **/
 #define HCI_INQUIRY_LAP                                     0x9E8B33L
@@ -350,7 +350,7 @@ extern const hci_cmd_t btstack_get_system_bluetooth_enabled;
 extern const hci_cmd_t btstack_set_system_bluetooth_enabled;
 extern const hci_cmd_t btstack_set_discoverable;
 extern const hci_cmd_t btstack_set_bluetooth_enabled;    /* only used by btstack config */
-	
+
 extern const hci_cmd_t hci_accept_connection_request;
 extern const hci_cmd_t hci_authentication_requested;
 extern const hci_cmd_t hci_change_connection_link_key;
@@ -425,7 +425,7 @@ extern const hci_cmd_t hci_le_set_scan_response_data;
 extern const hci_cmd_t hci_le_start_encryption;
 extern const hci_cmd_t hci_le_test_end;
 extern const hci_cmd_t hci_le_transmitter_test;
-    
+
 extern const hci_cmd_t l2cap_accept_connection;
 extern const hci_cmd_t l2cap_create_channel;
 extern const hci_cmd_t l2cap_create_channel_mtu;
@@ -487,12 +487,12 @@ void run_loop_set_timer_handler(timer_source_t *ts,
       void (*process)(timer_source_t *_ts));
 
 /* Add timer source. */
-void run_loop_add_timer(timer_source_t *timer); 
+void run_loop_add_timer(timer_source_t *timer);
 
 /* Remove timer source. */
 int  run_loop_remove_timer(timer_source_t *timer);
 
-/* Init must be called before any other run_loop call. 
+/* Init must be called before any other run_loop call.
  * Use RUN_LOOP_EMBEDDED for embedded devices.
  */
 void run_loop_init(RUN_LOOP_TYPE type);
@@ -507,7 +507,7 @@ void run_loop_add_data_source(data_source_t *dataSource);
 /* Remove data source. */
 int  run_loop_remove_data_source(data_source_t *dataSource);
 
-/* Execute configured run loop. 
+/* Execute configured run loop.
  * This function does not return. */
 void run_loop_execute(void);
 
@@ -525,7 +525,7 @@ uint32_t embedded_get_ticks(void);
 
 /* Connection handle type. */
 
-	
+
 /* helper for BT little endian format. */
 #define READ_BT_16( buffer, pos) ( ((uint16_t) buffer[pos]) | (((uint16_t)buffer[pos+1]) << 8))
 #define READ_BT_24( buffer, pos) ( ((uint32_t) buffer[pos]) | (((uint32_t)buffer[pos+1]) << 8) | (((uint32_t)buffer[pos+2]) << 16))
@@ -578,13 +578,13 @@ void print_bd_addr( bd_addr_t addr);
 char * bd_addr_to_str(bd_addr_t addr);
 
 int sscan_bd_addr(uint8_t * addr_string, bd_addr_t addr);
-    
+
 uint8_t crc8_check(uint8_t *data, uint16_t len, uint8_t check_sum);
 
 uint8_t crc8_calc(uint8_t *data, uint16_t len);
 
 /* btstack.h */
-	
+
 /* Default TCP port for BTstack daemon. */
 #define BTSTACK_PORT            13333
 
@@ -594,13 +594,13 @@ uint8_t crc8_calc(uint8_t *data, uint16_t len);
 
 /* Optional
  *
- * If called before bt_open, TCP socket is used 
+ * If called before bt_open, TCP socket is used
  * instead of local UNIX socket.
  *
- * note: Address is not copied and must be 
+ * note: Address is not copied and must be
  * valid during bt_open.
  */
-void bt_use_tcp(const char * address, uint16_t port); 
+void bt_use_tcp(const char * address, uint16_t port);
 
 /* Init BTstack library. */
 int bt_open(void);
@@ -611,7 +611,7 @@ int bt_close(void);
 /* Send HCI cmd packet. */
 int bt_send_cmd(const hci_cmd_t *cmd, ...);
 
-/* Register packet handler -- channel only valid 
+/* Register packet handler -- channel only valid
  for L2CAP and RFCOMM packets.
  */
 btstack_packet_handler_t bt_register_packet_handler(
@@ -783,7 +783,7 @@ static void btpad_queue_process_cmd(struct btpad_queue_command *cmd)
 {
     if (!cmd)
         return;
-    
+
     if (cmd->command == btstack_set_power_mode_ptr)
         bt_send_cmd_ptr(
                         cmd->command,
@@ -808,7 +808,7 @@ static void btpad_queue_process_cmd(struct btpad_queue_command *cmd)
                         cmd->hci_remote_name_request.page_scan_repetition_mode,
                         cmd->hci_remote_name_request.reserved,
                         cmd->hci_remote_name_request.clock_offset);
-    
+
     else if (cmd->command == hci_pin_code_request_reply_ptr)
         bt_send_cmd_ptr(
                         cmd->command,
@@ -889,7 +889,7 @@ static void btpad_queue_hci_remote_name_request(
 
    cmd->command = hci_remote_name_request_ptr;
    memcpy(cmd->hci_remote_name_request.bd_addr, bd_addr, sizeof(bd_addr_t));
-   cmd->hci_remote_name_request.page_scan_repetition_mode = 
+   cmd->hci_remote_name_request.page_scan_repetition_mode =
       page_scan_repetition_mode;
    cmd->hci_remote_name_request.reserved     = reserved;
    cmd->hci_remote_name_request.clock_offset = clock_offset;
@@ -1024,7 +1024,7 @@ static void btpad_packet_handler(uint8_t packet_type,
             if (!connection || connection->state != BTPAD_CONNECTED)
                continue;
 
-            if (     connection->channels[0] == channel 
+            if (     connection->channels[0] == channel
                   || connection->channels[1] == channel)
                pad_connection_packet(&slots[connection->slot], connection->slot, packet, size);
          }
@@ -1036,14 +1036,14 @@ static void btpad_packet_handler(uint8_t packet_type,
                RARCH_LOG("[BTstack]: HCI State %d.\n", packet[2]);
 
                switch (packet[2])
-               {                  
+               {
                   case HCI_STATE_WORKING:
                      btpad_queue_reset();
                      btpad_queue_hci_read_bd_addr(cmd);
 
                      /* TODO: Where did I get 672 for MTU? */
 
-                     bt_send_cmd_ptr(l2cap_register_service_ptr, PSM_HID_CONTROL,   672);  
+                     bt_send_cmd_ptr(l2cap_register_service_ptr, PSM_HID_CONTROL,   672);
                      bt_send_cmd_ptr(l2cap_register_service_ptr, PSM_HID_INTERRUPT, 672);
                      btpad_queue_hci_inquiry(cmd, HCI_INQUIRY_LAP, 3, 1);
 
@@ -1052,7 +1052,7 @@ static void btpad_packet_handler(uint8_t packet_type,
 
                   case HCI_STATE_HALTING:
                      btpad_close_all_connections();
-                     break;                  
+                     break;
                }
                break;
 
@@ -1100,7 +1100,7 @@ static void btpad_packet_handler(uint8_t packet_type,
                break;
 
             case HCI_EVENT_INQUIRY_COMPLETE:
-               /* This must be turned off during gameplay 
+               /* This must be turned off during gameplay
                 * as it causes a ton of lag. */
                inquiry_running = !inquiry_off;
 
@@ -1363,26 +1363,30 @@ static const char *btstack_hid_joypad_name(void *data, unsigned pad)
    return NULL;
 }
 
-static uint64_t btstack_hid_joypad_get_buttons(void *data, unsigned port)
+static void btstack_hid_joypad_get_buttons(void *data, unsigned port, retro_bits_t *state)
 {
-   btstack_hid_t        *hid   = (btstack_hid_t*)data;
-   if (hid)
-      return pad_connection_get_buttons(&hid->slots[port], port);
-   return 0;
+	btstack_hid_t        *hid   = (btstack_hid_t*)data;
+	if ( hid ) {
+		pad_connection_get_buttons(&hid->slots[port], port, state);
+	} else {
+		RARCH_INPUT_STATE_CLEAR_PTR( state );
+	}
 }
 
 static bool btstack_hid_joypad_button(void *data, unsigned port, uint16_t joykey)
 {
-   uint64_t buttons          = btstack_hid_joypad_get_buttons(data, port);
+	retro_bits_t buttons;
+	btstack_hid_joypad_get_buttons(data, port, &buttons);
 
-   /* Check hat. */
-   if (GET_HAT_DIR(joykey))
-      return false;
+	/* Check hat. */
+	if (GET_HAT_DIR(joykey))
+		return false;
 
-   /* Check the button. */
-   if ((port < MAX_USERS) && (joykey < 32))
-      return ((buttons & (1 << joykey)) != 0);
-   return false;
+	/* Check the button. */
+	if ((port < MAX_USERS) && (joykey < 32))
+		return ( RARCH_INPUT_STATE_BIT_GET( buttons, joykey ) != 0 );
+
+	return false;
 }
 
 static bool btstack_hid_joypad_rumble(void *data, unsigned pad,

--- a/input/drivers_hid/iohidmanager_hid.c
+++ b/input/drivers_hid/iohidmanager_hid.c
@@ -108,21 +108,24 @@ static const char *iohidmanager_hid_joypad_name(void *data, unsigned pad)
    return NULL;
 }
 
-static uint64_t iohidmanager_hid_joypad_get_buttons(void *data, unsigned port)
+static void iohidmanager_hid_joypad_get_buttons(void *data, unsigned port, retro_bits_t *state)
 {
-   iohidmanager_hid_t        *hid   = (iohidmanager_hid_t*)data;
-   if (hid)
-      return pad_connection_get_buttons(&hid->slots[port], port);
-   return 0;
+	iohidmanager_hid_t        *hid   = (iohidmanager_hid_t*)data;
+	if (hid) {
+		return pad_connection_get_buttons(&hid->slots[port], port, state);
+	} else {
+		RARCH_INPUT_STATE_CLEAR_PTR( state );
+	}
 }
 
 static bool iohidmanager_hid_joypad_button(void *data,
       unsigned port, uint16_t joykey)
 {
-   uint64_t buttons          =
-      iohidmanager_hid_joypad_get_buttons(data, port);
-   iohidmanager_hid_t *hid   = (iohidmanager_hid_t*)data;
-   unsigned hat_dir = GET_HAT_DIR(joykey);
+	retro_bits_t buttons;
+	iohidmanager_hid_t *hid   = (iohidmanager_hid_t*)data;
+	unsigned hat_dir = GET_HAT_DIR(joykey);
+
+	iohidmanager_hid_joypad_get_buttons(data, port, &buttons);
 
    /* Check hat. */
    if (hat_dir)
@@ -148,8 +151,9 @@ static bool iohidmanager_hid_joypad_button(void *data,
 
    /* Check the button. */
    if ((port < MAX_USERS) && (joykey < 32))
-      return ((buttons & (1 << joykey)) != 0)
+      return (RARCH_INPUT_STATE_BIT_GET( buttons, joykey )) != 0)
          || ((hid->buttons[port] & (1 << joykey)) != 0);
+
    return false;
 }
 

--- a/input/drivers_hid/iohidmanager_hid.c
+++ b/input/drivers_hid/iohidmanager_hid.c
@@ -151,7 +151,7 @@ static bool iohidmanager_hid_joypad_button(void *data,
 
    /* Check the button. */
    if ((port < MAX_USERS) && (joykey < 32))
-      return (RARCH_INPUT_STATE_BIT_GET( buttons, joykey )) != 0)
+      return (RARCH_INPUT_STATE_BIT_GET( buttons, joykey ) != 0)
          || ((hid->buttons[port] & (1 << joykey)) != 0);
 
    return false;

--- a/input/drivers_hid/libusb_hid.c
+++ b/input/drivers_hid/libusb_hid.c
@@ -16,11 +16,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef __FreeBSD__
-#include <libusb.h>
-#else
 #include <libusb-1.0/libusb.h>
-#endif
 
 #include <rthreads/rthreads.h>
 #include <compat/strl.h>
@@ -42,11 +38,7 @@ typedef struct libusb_hid
    libusb_context *ctx;
    joypad_connection_t *slots;
    sthread_t *poll_thread;
-#if defined(__FreeBSD__) && LIBUSB_API_VERSION <= 0x01000102
-   libusb_hotplug_callback_handle hp;
-#else
    int hp; /* libusb_hotplug_callback_handle is just int */
-#endif
    int quit;
 } libusb_hid_t;
 
@@ -93,13 +85,13 @@ static void adapter_thread(void *data)
       int size = 0;
 
       slock_lock(adapter->send_control_lock);
-      if (fifo_read_avail(adapter->send_control_buffer) 
+      if (fifo_read_avail(adapter->send_control_buffer)
             >= sizeof(send_command_size))
       {
          fifo_read(adapter->send_control_buffer,
                &send_command_size, sizeof(send_command_size));
 
-         if (fifo_read_avail(adapter->send_control_buffer) 
+         if (fifo_read_avail(adapter->send_control_buffer)
                >= sizeof(send_command_size))
          {
             fifo_read(adapter->send_control_buffer,
@@ -165,13 +157,7 @@ static void libusb_get_description(struct libusb_device *device,
    unsigned i, k;
    struct libusb_config_descriptor *config;
 
-   int desc_ret = libusb_get_config_descriptor(device, 0, &config);
-
-   if (desc_ret != 0)
-   {
-      RARCH_ERR("Error %d getting libusb config descriptor\n", desc_ret);
-      return;
-   }
+   libusb_get_config_descriptor(device, 0, &config);
 
    for (i = 0; i < (int)config->bNumInterfaces; i++)
    {
@@ -179,7 +165,7 @@ static void libusb_get_description(struct libusb_device *device,
 
       for(j = 0; j < inter->num_altsetting; j++)
       {
-         const struct libusb_interface_descriptor *interdesc = 
+         const struct libusb_interface_descriptor *interdesc =
             &inter->altsetting[j];
 
 #if 0
@@ -190,13 +176,13 @@ static void libusb_get_description(struct libusb_device *device,
 
             for(k = 0; k < (int)interdesc->bNumEndpoints; k++)
             {
-               const struct libusb_endpoint_descriptor *epdesc = 
+               const struct libusb_endpoint_descriptor *epdesc =
                   &interdesc->endpoint[k];
-               bool is_int = (epdesc->bmAttributes & LIBUSB_TRANSFER_TYPE_MASK) 
+               bool is_int = (epdesc->bmAttributes & LIBUSB_TRANSFER_TYPE_MASK)
                   == LIBUSB_TRANSFER_TYPE_INTERRUPT;
-               bool is_out = (epdesc->bEndpointAddress & LIBUSB_ENDPOINT_DIR_MASK) 
+               bool is_out = (epdesc->bEndpointAddress & LIBUSB_ENDPOINT_DIR_MASK)
                   == LIBUSB_ENDPOINT_OUT;
-               bool is_in = (epdesc->bEndpointAddress & LIBUSB_ENDPOINT_DIR_MASK) 
+               bool is_in = (epdesc->bEndpointAddress & LIBUSB_ENDPOINT_DIR_MASK)
                   == LIBUSB_ENDPOINT_IN;
 
                if (is_int)
@@ -214,12 +200,11 @@ static void libusb_get_description(struct libusb_device *device,
                }
             }
          }
-
          goto ret;
       }
    }
 
-ret:
+   ret:
    libusb_free_config_descriptor(config);
 }
 
@@ -441,27 +426,30 @@ static const char *libusb_hid_joypad_name(void *data, unsigned pad)
    return NULL;
 }
 
-static uint64_t libusb_hid_joypad_get_buttons(void *data, unsigned port)
+static void libusb_hid_joypad_get_buttons(void *data, unsigned port, retro_bits_t *state)
 {
-   libusb_hid_t        *hid   = (libusb_hid_t*)data;
-   if (hid)
-      return pad_connection_get_buttons(&hid->slots[port], port);
-   return 0;
+	libusb_hid_t        *hid   = (libusb_hid_t*)data;
+	if (hid) {
+		return pad_connection_get_buttons(&hid->slots[port], port, state);
+	} else {
+		RARCH_INPUT_STATE_CLEAR_PTR( state );
+	}
 }
 
 static bool libusb_hid_joypad_button(void *data,
       unsigned port, uint16_t joykey)
 {
-   uint64_t buttons          = libusb_hid_joypad_get_buttons(data, port);
+	retro_bits_t buttons;
+	libusb_hid_joypad_get_buttons(data, port, &buttons);
 
-   /* Check hat. */
-   if (GET_HAT_DIR(joykey))
-      return false;
+	/* Check hat. */
+	if (GET_HAT_DIR(joykey))
+		return false;
 
-   /* Check the button. */
-   if ((port < MAX_USERS) && (joykey < 32))
-      return ((buttons & (1 << joykey)) != 0);
-   return false;
+	/* Check the button. */
+	if ((port < MAX_USERS) && (joykey < 32))
+		return (RARCH_INPUT_STATE_BIT_GET(buttons, joykey) != 0);
+	return false;
 }
 
 static bool libusb_hid_joypad_rumble(void *data, unsigned pad,
@@ -517,8 +505,7 @@ static void libusb_hid_free(void *data)
       sthread_join(hid->poll_thread);
    }
 
-   if (hid->slots)
-      pad_connection_destroy(hid->slots);
+   pad_connection_destroy(hid->slots);
 
    libusb_hotplug_deregister_callback(hid->ctx, hid->hp);
 
@@ -553,14 +540,8 @@ static void *libusb_hid_init(void)
    if (ret < 0)
       goto error;
 
-#if 0
-   /* Don't use this for now since it requires a newer API
-    * version than FreeBSD has, and always returns false on Windows anyway.
-    * https://github.com/libusb/libusb/issues/86
-    */
    if (!libusb_has_capability(LIBUSB_CAP_HAS_HOTPLUG))
       goto error;
-#endif
 
    hid->slots = pad_connection_init(MAX_USERS);
 

--- a/input/drivers_hid/null_hid.c
+++ b/input/drivers_hid/null_hid.c
@@ -1,7 +1,7 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2013-2014 - Jason Fetters
  *  Copyright (C) 2011-2017 - Daniel De Matteis
- * 
+ *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-
  *  ation, either version 3 of the License, or (at your option) any later version.
@@ -38,12 +38,12 @@ static const char *null_hid_joypad_name(void *data, unsigned pad)
    return NULL;
 }
 
-static uint64_t null_hid_joypad_get_buttons(void *data, unsigned port)
+static void null_hid_joypad_get_buttons(void *data, unsigned port, retro_bits_t *state)
 {
    (void)data;
    (void)port;
 
-   return 0;
+   RARCH_INPUT_STATE_CLEAR_PTR(state);
 }
 
 static bool null_hid_joypad_button(void *data, unsigned port, uint16_t joykey)

--- a/input/drivers_hid/wiiusb_hid.c
+++ b/input/drivers_hid/wiiusb_hid.c
@@ -478,27 +478,31 @@ static bool wiiusb_hid_joypad_query(void *data, unsigned pad)
    return pad < MAX_USERS;
 }
 
-static uint64_t wiiusb_hid_joypad_get_buttons(void *data, unsigned port)
+static void wiiusb_hid_joypad_get_buttons(void *data, unsigned port, retro_bits_t *state)
 {
-   wiiusb_hid_t *hid = (wiiusb_hid_t*)data;
-   if (hid)
-      return pad_connection_get_buttons(&hid->connections[port], port);
-   return 0;
+	wiiusb_hid_t *hid = (wiiusb_hid_t*)data;
+	if (hid) {
+		return pad_connection_get_buttons(&hid->connections[port], port, state);
+	} else {
+		RARCH_INPUT_STATE_CLEAR_PTR( state );
+	}
 }
 
 static bool wiiusb_hid_joypad_button(void *data, unsigned port, uint16_t joykey)
 {
-   uint64_t buttons = wiiusb_hid_joypad_get_buttons(data, port);
+	retro_bits_t buttons;
 
-   /* Check hat. */
-   if (GET_HAT_DIR(joykey))
-      return false;
+	wiiusb_hid_joypad_get_buttons(data, port, &buttons);
 
-   /* Check the button. */
-   if ((port < MAX_USERS) && (joykey < 32))
-      return ((buttons & (1 << joykey)) != 0);
+	/* Check hat. */
+	if (GET_HAT_DIR(joykey))
+		return false;
 
-   return false;
+	/* Check the button. */
+	if ((port < MAX_USERS) && (joykey < 32))
+		return (RARCH_INPUT_STATE_BIT_GET(buttons, joykey)) != 0);
+
+	return false;
 }
 
 static bool wiiusb_hid_joypad_rumble(void *data, unsigned pad,

--- a/input/drivers_joypad/ctr_joypad.c
+++ b/input/drivers_joypad/ctr_joypad.c
@@ -31,7 +31,7 @@
 #define MAX_PADS 1
 #endif
 
-static uint64_t pad_state;
+static uint32_t pad_state;
 static int16_t analog_state[1][2][2];
 extern uint64_t lifecycle_state;
 
@@ -67,12 +67,16 @@ static bool ctr_joypad_button(unsigned port_num, uint16_t key)
    if (port_num >= MAX_PADS)
       return false;
 
-   return (pad_state & (UINT64_C(1) << key));
+   return (pad_state & (1 << key));
 }
 
-static uint64_t ctr_joypad_get_buttons(unsigned port_num)
+static void ctr_joypad_get_buttons(unsigned port_num, retro_bits_t *state)
 {
-   return pad_state;
+	if ( port_num < MAX_PADS ) {
+		RARCH_INPUT_STATE_COPY16_PTR( state, pad_state );
+	} else {
+		RARCH_INPUT_STATE_CLEAR_PTR(state);
+	}
 }
 
 static int16_t ctr_joypad_axis(unsigned port_num, uint32_t joyaxis)
@@ -140,20 +144,20 @@ static void ctr_joypad_poll(void)
    hidTouchRead(&state_tmp_touch);
 
    pad_state = 0;
-   pad_state |= (state_tmp & KEY_DLEFT) ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_LEFT) : 0;
-   pad_state |= (state_tmp & KEY_DDOWN) ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_DOWN) : 0;
-   pad_state |= (state_tmp & KEY_DRIGHT) ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_RIGHT) : 0;
-   pad_state |= (state_tmp & KEY_DUP) ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_UP) : 0;
-   pad_state |= (state_tmp & KEY_START) ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_START) : 0;
-   pad_state |= (state_tmp & KEY_SELECT) ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_SELECT) : 0;
-   pad_state |= (state_tmp & KEY_X) ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_X) : 0;
-   pad_state |= (state_tmp & KEY_Y) ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_Y) : 0;
-   pad_state |= (state_tmp & KEY_B) ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_B) : 0;
-   pad_state |= (state_tmp & KEY_A) ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_A) : 0;
-   pad_state |= (state_tmp & KEY_R) ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_R) : 0;
-   pad_state |= (state_tmp & KEY_L) ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_L) : 0;
-   pad_state |= (state_tmp & KEY_ZR) ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_R2) : 0;
-   pad_state |= (state_tmp & KEY_ZL) ? (UINT64_C(1) << RETRO_DEVICE_ID_JOYPAD_L2) : 0;
+   pad_state |= (state_tmp & KEY_DLEFT) ? (1 << RETRO_DEVICE_ID_JOYPAD_LEFT) : 0;
+   pad_state |= (state_tmp & KEY_DDOWN) ? (1 << RETRO_DEVICE_ID_JOYPAD_DOWN) : 0;
+   pad_state |= (state_tmp & KEY_DRIGHT) ? (1 << RETRO_DEVICE_ID_JOYPAD_RIGHT) : 0;
+   pad_state |= (state_tmp & KEY_DUP) ? (1 << RETRO_DEVICE_ID_JOYPAD_UP) : 0;
+   pad_state |= (state_tmp & KEY_START) ? (1 << RETRO_DEVICE_ID_JOYPAD_START) : 0;
+   pad_state |= (state_tmp & KEY_SELECT) ? (1 << RETRO_DEVICE_ID_JOYPAD_SELECT) : 0;
+   pad_state |= (state_tmp & KEY_X) ? (1 << RETRO_DEVICE_ID_JOYPAD_X) : 0;
+   pad_state |= (state_tmp & KEY_Y) ? (1 << RETRO_DEVICE_ID_JOYPAD_Y) : 0;
+   pad_state |= (state_tmp & KEY_B) ? (1 << RETRO_DEVICE_ID_JOYPAD_B) : 0;
+   pad_state |= (state_tmp & KEY_A) ? (1 << RETRO_DEVICE_ID_JOYPAD_A) : 0;
+   pad_state |= (state_tmp & KEY_R) ? (1 << RETRO_DEVICE_ID_JOYPAD_R) : 0;
+   pad_state |= (state_tmp & KEY_L) ? (1 << RETRO_DEVICE_ID_JOYPAD_L) : 0;
+   pad_state |= (state_tmp & KEY_ZR) ? (1 << RETRO_DEVICE_ID_JOYPAD_R2) : 0;
+   pad_state |= (state_tmp & KEY_ZL) ? (1 << RETRO_DEVICE_ID_JOYPAD_L2) : 0;
 
    analog_state[0][RETRO_DEVICE_INDEX_ANALOG_LEFT] [RETRO_DEVICE_ID_ANALOG_X]  =  ctr_joypad_fix_range(state_tmp_left_analog.dx);
    analog_state[0][RETRO_DEVICE_INDEX_ANALOG_LEFT] [RETRO_DEVICE_ID_ANALOG_Y]  = -ctr_joypad_fix_range(state_tmp_left_analog.dy);

--- a/input/drivers_joypad/gx_joypad.c
+++ b/input/drivers_joypad/gx_joypad.c
@@ -162,9 +162,13 @@ static bool gx_joypad_button(unsigned port, uint16_t key)
    return (pad_state[port] & (UINT64_C(1) << key));
 }
 
-static uint64_t gx_joypad_get_buttons(unsigned port)
+static void gx_joypad_get_buttons(unsigned port, retro_bits_t *state)
 {
-   return pad_state[port];
+	if ( port < MAX_PADS ) {
+		RARCH_INPUT_STATE_COPY16_PTR( state, pad_state[port] );
+	} else {
+		RARCH_INPUT_STATE_CLEAR_PTR(state);
+	}
 }
 
 static int16_t gx_joypad_axis(unsigned port, uint32_t joyaxis)
@@ -501,8 +505,8 @@ static void gx_joypad_destroy(void)
    int i;
    for (i = 0; i < MAX_PADS; i++)
    {
-      /* Commenting this out fixes the Wii 
-       * remote not reconnecting after 
+      /* Commenting this out fixes the Wii
+       * remote not reconnecting after
        * core load, exit, etc. */
       WPAD_Flush(i);
       WPADDisconnect(i);

--- a/input/drivers_joypad/hid_joypad.c
+++ b/input/drivers_joypad/hid_joypad.c
@@ -1,7 +1,7 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2013-2014 - Jason Fetters
  *  Copyright (C) 2011-2017 - Daniel De Matteis
- * 
+ *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-
  *  ation, either version 3 of the License, or (at your option) any later version.
@@ -44,7 +44,7 @@ static void hid_joypad_free(void)
 
    if (generic_hid->free)
       generic_hid->free((void*)hid_driver_get_data());
-    
+
    generic_hid = NULL;
 }
 
@@ -55,11 +55,13 @@ static bool hid_joypad_button(unsigned port, uint16_t joykey)
    return false;
 }
 
-static uint64_t hid_joypad_get_buttons(unsigned port)
+static void hid_joypad_get_buttons(unsigned port, retro_bits_t *state)
 {
-   if (generic_hid && generic_hid->get_buttons)
-      return generic_hid->get_buttons((void*)hid_driver_get_data(), port);
-   return 0;
+   if (generic_hid && generic_hid->get_buttons) {
+      generic_hid->get_buttons((void*)hid_driver_get_data(), port, state);
+   } else {
+      RARCH_INPUT_STATE_CLEAR_PTR( state );
+   }
 }
 
 static int16_t hid_joypad_axis(unsigned port, uint32_t joyaxis)

--- a/input/drivers_joypad/linuxraw_joypad.c
+++ b/input/drivers_joypad/linuxraw_joypad.c
@@ -1,7 +1,7 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
  *  Copyright (C) 2011-2017 - Daniel De Matteis
- * 
+ *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-
  *  ation, either version 3 of the License, or (at your option) any later version.
@@ -41,7 +41,7 @@
 struct linuxraw_joypad
 {
    int fd;
-   uint64_t buttons;
+   uint32_t buttons;
    int16_t axes[NUM_AXES];
 
    char *ident;
@@ -55,7 +55,7 @@ static bool linuxraw_hotplug                           = false;
 static void linuxraw_poll_pad(struct linuxraw_joypad *pad)
 {
    struct js_event event;
-   
+
    while (read(pad->fd, &event, sizeof(event)) == (ssize_t)sizeof(event))
    {
       unsigned type = event.type & ~JS_EVENT_INIT;
@@ -66,9 +66,9 @@ static void linuxraw_poll_pad(struct linuxraw_joypad *pad)
             if (event.number < NUM_BUTTONS)
             {
                if (event.value)
-                  BIT64_SET(pad->buttons, event.number);
+                  BIT32_SET(pad->buttons, event.number);
                else
-                  BIT64_CLEAR(pad->buttons, event.number);
+                  BIT32_CLEAR(pad->buttons, event.number);
             }
             break;
 
@@ -200,7 +200,7 @@ retry:
                         input_config_set_device_name(idx, NULL);
                   }
                }
-               /* Sometimes, device will be created before 
+               /* Sometimes, device will be created before
                 * access to it is established. */
                else if (event->mask & (IN_CREATE | IN_ATTRIB))
                {
@@ -210,7 +210,7 @@ retry:
 
                   snprintf(path, sizeof(path), "/dev/input/%s", event->name);
 
-                  if (     !string_is_empty(linuxraw_pads[idx].ident) 
+                  if (     !string_is_empty(linuxraw_pads[idx].ident)
                         && linuxraw_joypad_init_pad(path, &linuxraw_pads[idx]))
                   {
                      if (!input_autoconfigure_connect(
@@ -251,7 +251,7 @@ static bool linuxraw_joypad_init(void *data)
 
       pad->fd                     = -1;
       pad->ident                  = input_device_names[i];
-      
+
       snprintf(path, sizeof(path), "/dev/input/js%u", i);
 
       if (!input_autoconfigure_connect(
@@ -323,15 +323,17 @@ static bool linuxraw_joypad_button(unsigned port, uint16_t joykey)
    const struct linuxraw_joypad *pad = (const struct linuxraw_joypad*)
       &linuxraw_pads[port];
 
-   return joykey < NUM_BUTTONS && BIT64_GET(pad->buttons, joykey);
+   return joykey < NUM_BUTTONS && BIT32_GET(pad->buttons, joykey);
 }
 
-static uint64_t linuxraw_joypad_get_buttons(unsigned port)
+static void linuxraw_joypad_get_buttons(unsigned port, retro_bits_t *state)
 {
-   const struct linuxraw_joypad *pad = (const struct linuxraw_joypad*)
-      &linuxraw_pads[port];
-
-   return pad->buttons;
+	const struct linuxraw_joypad *pad = (const struct linuxraw_joypad*)&linuxraw_pads[port];
+	if ( pad ) {
+		RARCH_INPUT_STATE_COPY16_PTR(state, pad->buttons);
+	} else {
+		RARCH_INPUT_STATE_CLEAR_PTR(state);
+	}
 }
 
 static int16_t linuxraw_joypad_axis(unsigned port, uint32_t joyaxis)

--- a/input/drivers_joypad/mfi_joypad.m
+++ b/input/drivers_joypad/mfi_joypad.m
@@ -221,9 +221,9 @@ static bool apple_gamecontroller_joypad_button(unsigned port, uint16_t joykey)
    return false;
 }
 
-static uint64_t apple_gamecontroller_joypad_get_buttons(unsigned port)
+static void apple_gamecontroller_joypad_get_buttons(unsigned port, retro_bits_t *state)
 {
-   return mfi_buttons[port];
+	RARCH_INPUT_STATE_COPY16_PTR(state, mfi_buttons[port]);
 }
 
 static int16_t apple_gamecontroller_joypad_axis(unsigned port, uint32_t joyaxis)

--- a/input/drivers_joypad/null_joypad.c
+++ b/input/drivers_joypad/null_joypad.c
@@ -37,9 +37,9 @@ static bool null_joypad_button(unsigned port_num, uint16_t joykey)
    return false;
 }
 
-static uint64_t null_joypad_get_buttons(unsigned port_num)
+static void null_joypad_get_buttons(unsigned port_num, retro_bits_t *state)
 {
-   return 0;
+	RARCH_INPUT_STATE_CLEAR_PTR( state );
 }
 
 static int16_t null_joypad_axis(unsigned port_num, uint32_t joyaxis)

--- a/input/drivers_joypad/parport_joypad.c
+++ b/input/drivers_joypad/parport_joypad.c
@@ -40,7 +40,7 @@
 struct parport_joypad
 {
    int fd;
-   uint64_t buttons;
+   uint32_t buttons;
    bool button_enable[PARPORT_NUM_BUTTONS];
    char saved_data;
    char saved_control;
@@ -97,22 +97,22 @@ static void parport_poll_pad(struct parport_joypad *pad)
    for (i = 0; i < 8; i++)
    {
       if (!(data & UINT8_C(1 << i)) && pad->button_enable[i])
-         BIT64_SET(pad->buttons, i);
+         BIT32_SET(pad->buttons, i);
       else
-         BIT64_CLEAR(pad->buttons, i);
+         BIT32_CLEAR(pad->buttons, i);
    }
    for (i = 3; i < 8; i++)
    {
       if (!(status & UINT8_C(1 << i)) && pad->button_enable[i + 5])
-         BIT64_SET(pad->buttons, i + 5);
+         BIT32_SET(pad->buttons, i + 5);
       else
-         BIT64_CLEAR(pad->buttons, i + 5);
+         BIT32_CLEAR(pad->buttons, i + 5);
    }
 
-   if (BIT64_GET(pad->buttons, 12) && pad->button_enable[12])
-      BIT64_CLEAR(pad->buttons, 12);
+   if (BIT32_GET(pad->buttons, 12) && pad->button_enable[12])
+      BIT32_CLEAR(pad->buttons, 12);
    else
-      BIT64_SET(pad->buttons, 12);
+      BIT32_SET(pad->buttons, 12);
 }
 
 static bool parport_joypad_init_pad(const char *path, struct parport_joypad *pad)
@@ -268,7 +268,7 @@ static bool parport_joypad_init(void *data)
 
          for (j = 0; j < PARPORT_NUM_BUTTONS; j++)
          {
-            if (!(BIT64_GET(pad->buttons, j)))
+            if (!(BIT32_GET(pad->buttons, j)))
             {
                pad->button_enable[j] = true;
                found_enabled_button = true;
@@ -337,13 +337,17 @@ static void parport_joypad_destroy(void)
 static bool parport_joypad_button(unsigned port, uint16_t joykey)
 {
    const struct parport_joypad *pad = (const struct parport_joypad*)&parport_pads[port];
-   return joykey < PARPORT_NUM_BUTTONS && BIT64_GET(pad->buttons, joykey);
+   return joykey < PARPORT_NUM_BUTTONS && BIT32_GET(pad->buttons, joykey);
 }
 
-static uint64_t parport_joypad_get_buttons(unsigned port)
+static void parport_joypad_get_buttons(unsigned port, retro_bits_t *state)
 {
-   const struct parport_joypad *pad = (const struct parport_joypad*)&parport_pads[port];
-   return pad->buttons;
+	const struct parport_joypad *pad = (const struct parport_joypad*)&parport_pads[port];
+	if ( pad ) {
+		RARCH_INPUT_STATE_COPY16_PTR(state, pad->buttons);
+	} else {
+		RARCH_INPUT_STATE_CLEAR_PTR(state);
+	}
 }
 
 static int16_t parport_joypad_axis(unsigned port, uint32_t joyaxis)

--- a/input/drivers_joypad/ps3_joypad.c
+++ b/input/drivers_joypad/ps3_joypad.c
@@ -1,7 +1,7 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
  *  Copyright (C) 2011-2017 - Daniel De Matteis
- * 
+ *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-
  *  ation, either version 3 of the License, or (at your option) any later version.
@@ -68,9 +68,13 @@ static bool ps3_joypad_button(unsigned port_num, uint16_t joykey)
    return pad_state[port_num] & (UINT64_C(1) << joykey);
 }
 
-static uint64_t ps3_joypad_get_buttons(unsigned port_num)
+static void ps3_joypad_get_buttons(unsigned port_num, retro_bits_t *state)
 {
-   return pad_state[port_num];
+	if ( port_num < MAX_PADS ) {
+		RARCH_INPUT_STATE_COPY16_PTR( state, pad_state[port_num] );
+	} else {
+		RARCH_INPUT_STATE_CLEAR_PTR(state);
+	}
 }
 
 static int16_t ps3_joypad_axis(unsigned port_num, uint32_t joyaxis)
@@ -142,7 +146,7 @@ static void ps3_joypad_poll(void)
             ps3_joypad_autodetect_add(port);
          }
       }
-      
+
       if (pads_connected[port] == 0)
          continue;
 

--- a/input/drivers_joypad/psp_joypad.c
+++ b/input/drivers_joypad/psp_joypad.c
@@ -124,9 +124,13 @@ static bool psp_joypad_button(unsigned port_num, uint16_t key)
    return (pad_state[port_num] & (UINT64_C(1) << key));
 }
 
-static uint64_t psp_joypad_get_buttons(unsigned port_num)
+static void psp_joypad_get_buttons(unsigned port_num, retro_bits_t *state)
 {
-   return pad_state[port_num];
+	if ( port_num < PSP_MAX_PADS ) {
+		RARCH_INPUT_STATE_COPY16_PTR( state, pad_state[port_num] );
+	} else {
+		RARCH_INPUT_STATE_CLEAR_PTR(state);
+	}
 }
 
 static int16_t psp_joypad_axis(unsigned port_num, uint32_t joyaxis)
@@ -236,10 +240,10 @@ static void psp_joypad_poll(void)
       if (curr_ctrl_info.port[p] == SCE_CTRL_TYPE_UNPAIRED)
          continue;
 #elif defined(SN_TARGET_PSP2)
-      /* Dumb hack, but here's the explanation - 
+      /* Dumb hack, but here's the explanation -
        * sceCtrlPeekBufferPositive's port parameter
        * can be 0 or 1 to read the first controller on
-       * a PSTV, but HAS to be 0 for a real VITA and 2 
+       * a PSTV, but HAS to be 0 for a real VITA and 2
        * for the 2nd controller on a PSTV */
       unsigned p  = (player > 0) ? player+1 : player;
 #else
@@ -256,12 +260,12 @@ static void psp_joypad_poll(void)
          continue;
 #endif
 #if defined(VITA)
-      if (psp2_model == SCE_KERNEL_MODEL_VITA 
+      if (psp2_model == SCE_KERNEL_MODEL_VITA
          && settings->bools.input_backtouch_enable)
       {
          unsigned i;
          SceTouchData touch_surface = {0};
-         sceTouchPeek(settings->bools.input_backtouch_toggle 
+         sceTouchPeek(settings->bools.input_backtouch_toggle
                ? SCE_TOUCH_PORT_FRONT : SCE_TOUCH_PORT_BACK, &touch_surface, 1);
 
          for (i = 0; i < touch_surface.reportNum; i++)

--- a/input/drivers_joypad/udev_joypad.c
+++ b/input/drivers_joypad/udev_joypad.c
@@ -1,7 +1,7 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2010-2015 - Hans-Kristian Arntzen
  *  Copyright (C) 2011-2017 - Daniel De Matteis
- * 
+ *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-
  *  ation, either version 3 of the License, or (at your option) any later version.
@@ -204,7 +204,7 @@ static int udev_add_pad(struct udev_device *dev, unsigned p, int fd, const char 
          i = ABS_HAT3Y;
          continue;
       }
-      
+
       if (test_bit(i, absbit))
       {
          struct input_absinfo *abs = &pad->absinfo[axes];
@@ -420,11 +420,11 @@ static bool udev_set_rumble(unsigned i,
 
 static bool udev_joypad_poll_hotplug_available(struct udev_monitor *dev)
 {
-   struct pollfd fds;		
+   struct pollfd fds;
 
-   fds.fd      = udev_monitor_get_fd(dev);		
-   fds.events  = POLLIN;		
-   fds.revents = 0;		
+   fds.fd      = udev_monitor_get_fd(dev);
+   fds.events  = POLLIN;
+   fds.revents = 0;
 
    return (poll(&fds, 1, 0) == 1) && (fds.revents & POLLIN);
 }
@@ -604,10 +604,14 @@ static bool udev_joypad_button(unsigned port, uint16_t joykey)
    return joykey < UDEV_NUM_BUTTONS && BIT64_GET(pad->buttons, joykey);
 }
 
-static uint64_t udev_joypad_get_buttons(unsigned port)
+static void udev_joypad_get_buttons(unsigned port, retro_bits_t *state)
 {
-   const struct udev_joypad *pad = (const struct udev_joypad*)&udev_pads[port];
-   return pad->buttons;
+	const struct udev_joypad *pad = (const struct udev_joypad*)&udev_pads[port];
+	if ( pad ) {
+		RARCH_INPUT_STATE_COPY16_PTR( state, pad->buttons );
+	} else {
+		RARCH_INPUT_STATE_CLEAR_PTR(state);
+	}
 }
 
 static int16_t udev_joypad_axis(unsigned port, uint32_t joyaxis)

--- a/input/drivers_joypad/wiiu_joypad.c
+++ b/input/drivers_joypad/wiiu_joypad.c
@@ -122,9 +122,13 @@ static bool wiiu_joypad_button(unsigned port_num, uint16_t key)
    return (pad_state[port_num] & (UINT64_C(1) << key));
 }
 
-static uint64_t wiiu_joypad_get_buttons(unsigned port_num)
+static void wiiu_joypad_get_buttons(unsigned port_num, retro_bits_t *state)
 {
-   return pad_state[port_num];
+	if ( port_num < MAX_PADS ) {
+		RARCH_INPUT_STATE_COPY16_PTR( state, pad_state[port_num] );
+	} else {
+		RARCH_INPUT_STATE_CLEAR_PTR(state);
+	}
 }
 
 static int16_t wiiu_joypad_axis(unsigned port_num, uint32_t joyaxis)

--- a/input/drivers_joypad/xdk_joypad.c
+++ b/input/drivers_joypad/xdk_joypad.c
@@ -1,7 +1,7 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
  *  Copyright (C) 2011-2017 - Daniel De Matteis
- * 
+ *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-
  *  ation, either version 3 of the License, or (at your option) any later version.
@@ -19,7 +19,7 @@
 #include "../input_driver.h"
 #include "../../tasks/tasks_internal.h"
 
-static uint64_t pad_state[MAX_PADS];
+static uint32_t pad_state[MAX_PADS];
 static int16_t analog_state[MAX_PADS][2][2];
 #ifdef _XBOX1
 static HANDLE gamepads[MAX_PADS];
@@ -73,12 +73,16 @@ static bool xdk_joypad_button(unsigned port_num, uint16_t joykey)
    if (port_num >= MAX_PADS)
       return false;
 
-   return pad_state[port_num] & (UINT64_C(1) << joykey);
+   return pad_state[port_num] & (1 << joykey);
 }
 
-static uint64_t xdk_joypad_get_buttons(unsigned port_num)
+static void xdk_joypad_get_buttons(unsigned port_num, retro_bits_t *state)
 {
-   return pad_state[port_num];
+	if ( port_num < MAX_PADS ) {
+		RARCH_INPUT_STATE_COPY16_PTR( state, pad_state[port_num] );
+	} else {
+		RARCH_INPUT_STATE_CLEAR_PTR(state);
+	}
 }
 
 static int16_t xdk_joypad_axis(unsigned port_num, uint32_t joyaxis)
@@ -154,7 +158,7 @@ static void xdk_joypad_poll(void)
 
       if(bRemoved[port])
       {
-         /* if the controller was removed after 
+         /* if the controller was removed after
           * XGetDeviceChanges but before
           * XInputOpen, the device handle will be NULL. */
          if(gamepads[port])
@@ -178,14 +182,14 @@ static void xdk_joypad_poll(void)
          m_pollingParameters.bOutputInterval = 8;
          gamepads[port] = XInputOpen(XDEVICE_TYPE_GAMEPAD, port,
                XDEVICE_NO_SLOT, NULL);
-         
+
          xdk_joypad_autodetect_add(port);
       }
 
       if (!gamepads[port])
          continue;
 
-      /* if the controller is removed after 
+      /* if the controller is removed after
        * XGetDeviceChanges but before XInputOpen,
        * the device handle will be NULL. */
 #endif

--- a/input/input_defines.h
+++ b/input/input_defines.h
@@ -1,7 +1,7 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
  *  Copyright (C) 2011-2017 - Daniel De Matteis
- * 
+ *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-
  *  ation, either version 3 of the License, or (at your option) any later version.
@@ -18,6 +18,7 @@
 #define __INPUT_DEFINES__H
 
 #include <stdint.h>
+#include <string.h>
 
 #include <retro_common_api.h>
 
@@ -156,6 +157,30 @@ enum analog_dpad_mode
 #define HAT_MASK           (HAT_UP_MASK | HAT_DOWN_MASK | HAT_LEFT_MASK | HAT_RIGHT_MASK)
 #define GET_HAT_DIR(x)     (x & HAT_MASK)
 #define GET_HAT(x)         (x & (~HAT_MASK))
+
+#define RARCH_INPUT_STATE_BIT_SET(a,bit)       ((a).data [((bit) >> 5)] |=  (1 << ((bit) & 31)))
+#define RARCH_INPUT_STATE_BIT_SET_PTR(a,bit)   ((a)->data[((bit) >> 5)] |=  (1 << ((bit) & 31)))
+#define RARCH_INPUT_STATE_BIT_GET(a,bit)       ((a).data [((bit) >> 5)] &   (1 << ((bit) & 31)))
+#define RARCH_INPUT_STATE_BIT_GET_PTR(a,bit)   ((a)->data[((bit) >> 5)] &   (1 << ((bit) & 31)))
+#define RARCH_INPUT_STATE_CLEAR(a)              memset(&a, 0, sizeof(a));
+#define RARCH_INPUT_STATE_CLEAR_PTR(a)          memset(a, 0, sizeof(retro_bits_t));
+#define RARCH_INPUT_STATE_ANY_SET(a)            ( ((a).data[0])||((a).data[1])||((a).data[2])||((a).data[3])||       \
+                                                  ((a).data[4])||((a).data[5])||((a).data[6])||((a).data[7]) )
+#define RARCH_INPUT_STATE_ANY_SET_PTR(a)        ( ((a)->data[0])||((a)->data[1])||((a)->data[2])||((a)->data[3])||   \
+                                                  ((a)->data[4])||((a)->data[5])||((a)->data[6])||((a)->data[7]) )
+#define RARCH_INPUT_STATE_CLEAR_BITS(a,b)    \
+            ((a).data[0])&=(~((b).data[0])); \
+            ((a).data[1])&=(~((b).data[1])); \
+            ((a).data[2])&=(~((b).data[2])); \
+            ((a).data[3])&=(~((b).data[3])); \
+            ((a).data[4])&=(~((b).data[4])); \
+            ((a).data[5])&=(~((b).data[5])); \
+            ((a).data[6])&=(~((b).data[6])); \
+            ((a).data[7])&=(~((b).data[7]));
+
+#define RARCH_INPUT_STATE_COPY16_PTR(a,bits)   {memset(a, 0, sizeof(retro_bits_t));((a)->data[0] = (bits)&0xffff);}
+#define RARCH_INPUT_STATE_COPY32_PTR(a,bits)   {memset(a, 0, sizeof(retro_bits_t));((a)->data[0] = (bits));}
+
 
 RETRO_END_DECLS
 


### PR DESCRIPTION
The current set of pad drivers use uint64_t to return the state of all pad buttons. However due to recent changes, there are now more than 64 bindable inputs and for certain HID pads that also return a 'home' button state this was pushing beyond the 64 bit limit. I've updated all pad drivers to use the 256-bit retro_bits_t struct (passed by ref), which matches recent changes to fix a similar problem in the front-end.

A nice side effect of this is that pad drivers can return any number of extended controls/hotkeys. This might be useful for unusual devices like a Wiimote with an extension peripheral to report extended controls beyond the usual RetroPad set.

Naturally I've been unable to test this on all platforms / devices but it compiles without warnings.

Thanks to @orbea for support :)