### PR TITLE
WiiU input driver compile fix

### DIFF
--- a/input/drivers/wiiu_input.c
+++ b/input/drivers/wiiu_input.c
@@ -105,7 +105,11 @@ static int16_t wiiu_pointer_device_state(wiiu_input_t* wiiu, unsigned id)
 	switch (id)
 	{
 		case RETRO_DEVICE_ID_POINTER_PRESSED:
-			return (wiiu->joypad->get_buttons(0) & VPAD_BUTTON_TOUCH) ? 1 : 0;
+		{
+			retro_bits_t state;
+			wiiu->joypad->get_buttons(0,&state);
+			return RARCH_INPUT_STATE_BIT_GET(state, VPAD_BUTTON_TOUCH) ? 1 : 0;
+		}
 		case RETRO_DEVICE_ID_POINTER_X:
 			return wiiu->joypad->axis(0, 0xFFFF0004UL);
 		case RETRO_DEVICE_ID_POINTER_Y:

--- a/input/drivers_hid/wiiusb_hid.c
+++ b/input/drivers_hid/wiiusb_hid.c
@@ -500,7 +500,7 @@ static bool wiiusb_hid_joypad_button(void *data, unsigned port, uint16_t joykey)
 
 	/* Check the button. */
 	if ((port < MAX_USERS) && (joykey < 32))
-		return (RARCH_INPUT_STATE_BIT_GET(buttons, joykey)) != 0);
+		return (RARCH_INPUT_STATE_BIT_GET(buttons, joykey) != 0);
 
 	return false;
 }


### PR DESCRIPTION
Fixed a compile error in the WiiU input driver reported by @orbea. I hadn't updated it for the new by-reference buttons state acquisition function. Sorry for any inconvenience caused.