### PR TITLE
nullptr check in pad_connection_destroy

### DIFF
--- a/input/connect/joypad_connection.c
+++ b/input/connect/joypad_connection.c
@@ -201,12 +201,16 @@ bool pad_connection_has_interface(joypad_connection_t *joyconn, unsigned pad)
 
 void pad_connection_destroy(joypad_connection_t *joyconn)
 {
-   unsigned i;
+	unsigned i;
 
-   for (i = 0; i < MAX_USERS; i ++)
-      pad_connection_pad_deinit(&joyconn[i], i);
+	if ( joyconn )
+	{
+		for ( i = 0; i < MAX_USERS; ++i ) {
+			pad_connection_pad_deinit( &joyconn[ i ], i );
+		}
 
-   free(joyconn);
+		free( joyconn );
+	}
 }
 
 bool pad_connection_rumble(joypad_connection_t *joyconn,


### PR DESCRIPTION
While testing libusb I had a crash on startup. Tracked it down to pad_connection_destroy being called with a null pointer. On my build/system libusb_hid_init fails quite early on and never gets to call pad_connection_init. This patch adds a nullptr guard so it doesn't try to de-initialise pads without this initialisation succeeding first.