### PR TITLE
nullptr check in pad_connection_destroy

### DIFF
--- a/input/connect/joypad_connection.c
+++ b/input/connect/joypad_connection.c
@@ -203,6 +203,9 @@ void pad_connection_destroy(joypad_connection_t *joyconn)
 {
    unsigned i;
 
+   if (!joyconn)
+      return;
+
    for (i = 0; i < MAX_USERS; i ++)
       pad_connection_pad_deinit(&joyconn[i], i);
 


### PR DESCRIPTION
While testing libusb I had a crash on startup. Tracked it down to pad_connection_destroy being called with a null pointer. On my build/system libusb_hid_init fails quite early on and never gets to call pad_connection_init. This patch adds a nullptr guard so it doesn't try to de-initialise pads without this initialisation succeeding first.

edit: re-created with adherence to coding style guide