### PR TITLE
libusb hotplug fix

### DIFF
--- a/input/drivers_hid/libusb_hid.c
+++ b/input/drivers_hid/libusb_hid.c
@@ -42,7 +42,10 @@ typedef struct libusb_hid
    libusb_context *ctx;
    joypad_connection_t *slots;
    sthread_t *poll_thread;
+#if 0
+/*disabled - see libusb_hid_init*/
    int can_hotplug;
+#endif
 #if defined(__FreeBSD__) && LIBUSB_API_VERSION <= 0x01000102
    libusb_hotplug_callback_handle hp;
 #else
@@ -406,6 +409,8 @@ static int remove_adapter(void *data, struct libusb_device *dev)
    return -1;
 }
 
+#if 0
+/*disabled - see libusb_hid_init*/
 static int libusb_hid_hotplug_callback(struct libusb_context *ctx,
       struct libusb_device *dev, libusb_hotplug_event event, void *user_data)
 {
@@ -426,6 +431,7 @@ static int libusb_hid_hotplug_callback(struct libusb_context *ctx,
 
    return 0;
 }
+#endif
 
 
 static bool libusb_hid_joypad_query(void *data, unsigned pad)
@@ -565,8 +571,6 @@ static void *libusb_hid_init(void)
       hid->can_hotplug = 1;
    else
       hid->can_hotplug = 0;
-#else
-   hid->can_hotplug = 0;
 #endif
 
    hid->slots = pad_connection_init(MAX_USERS);
@@ -588,6 +592,12 @@ static void *libusb_hid_init(void)
    if (count > 0)
       libusb_free_device_list(devices, 1);
 
+#if 0
+   /* We disable this block as well because, given above, we cannot
+    * determine hotplug capability on FreeBSD, and it is always false on
+    * Windows. This in turn causes the callback registration below to
+    * fail and this initialisation function to fail with it.
+    */
    if (hid->can_hotplug)
    {
       ret = libusb_hotplug_register_callback(
@@ -608,6 +618,7 @@ static void *libusb_hid_init(void)
          goto error;
       }
    }
+#endif
 
    hid->poll_thread = sthread_create(poll_thread, hid);
 

--- a/input/drivers_hid/libusb_hid.c
+++ b/input/drivers_hid/libusb_hid.c
@@ -42,6 +42,7 @@ typedef struct libusb_hid
    libusb_context *ctx;
    joypad_connection_t *slots;
    sthread_t *poll_thread;
+   int can_hotplug;
 #if defined(__FreeBSD__) && LIBUSB_API_VERSION <= 0x01000102
    libusb_hotplug_callback_handle hp;
 #else
@@ -560,8 +561,12 @@ static void *libusb_hid_init(void)
     * version than FreeBSD has, and always returns false on Windows anyway.
     * https://github.com/libusb/libusb/issues/86
     */
-   if (!libusb_has_capability(LIBUSB_CAP_HAS_HOTPLUG))
-      goto error;
+   if (libusb_has_capability(LIBUSB_CAP_HAS_HOTPLUG))
+      hid->can_hotplug = 1;
+   else
+      hid->can_hotplug = 0;
+#else
+   hid->can_hotplug = 0;
 #endif
 
    hid->slots = pad_connection_init(MAX_USERS);
@@ -583,22 +588,25 @@ static void *libusb_hid_init(void)
    if (count > 0)
       libusb_free_device_list(devices, 1);
 
-   ret = libusb_hotplug_register_callback(
-         hid->ctx,
-         (libusb_hotplug_event)(LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED |
-         LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT),
-         (libusb_hotplug_flag)LIBUSB_HOTPLUG_ENUMERATE,
-         LIBUSB_HOTPLUG_MATCH_ANY,
-         LIBUSB_HOTPLUG_MATCH_ANY,
-         LIBUSB_HOTPLUG_MATCH_ANY,
-         libusb_hid_hotplug_callback,
-         hid,
-         &hid->hp);
-
-   if (ret != LIBUSB_SUCCESS)
+   if (hid->can_hotplug)
    {
-      RARCH_ERR("Error creating a hotplug callback.\n");
-      goto error;
+      ret = libusb_hotplug_register_callback(
+            hid->ctx,
+            (libusb_hotplug_event)(LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED |
+            LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT),
+            (libusb_hotplug_flag)LIBUSB_HOTPLUG_ENUMERATE,
+            LIBUSB_HOTPLUG_MATCH_ANY,
+            LIBUSB_HOTPLUG_MATCH_ANY,
+            LIBUSB_HOTPLUG_MATCH_ANY,
+            libusb_hid_hotplug_callback,
+            hid,
+            &hid->hp);
+
+      if (ret != LIBUSB_SUCCESS)
+      {
+         RARCH_ERR("Error creating a hotplug callback.\n");
+         goto error;
+      }
    }
 
    hid->poll_thread = sthread_create(poll_thread, hid);


### PR DESCRIPTION
Only try and register a hotplug callback if the feature is supported on the platform.

n.b. I've added code to store the hotplug state for platforms that do support it, but left the cap check disabled as I found it in the code.