### PR TITLE
Use RetroArch Assets' Makefile to install Assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,17 +201,7 @@ install: $(TARGET)
 	install -m644 media/retroarch.svg $(DESTDIR)$(PREFIX)/share/pixmaps
 	@if test -d media/assets; then \
 		echo "Installing media assets..."; \
-		mkdir -p $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb; \
-		mkdir -p $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/glui; \
-		cp -r media/assets/xmb/  $(DESTDIR)$(ASSETS_DIR)/retroarch/assets; \
-		cp -r media/assets/glui/ $(DESTDIR)$(ASSETS_DIR)/retroarch/assets; \
-		echo "Removing unneeded source image files.."; \
-		rm -rf $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb/flatui/src; \
-		rm -rf $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb/monochrome/src; \
-		rm -rf $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb/retroactive/src; \
-		rm -rf $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb/neoactive/src; \
-		rm -rf $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb/retrosystem/src; \
-		rm -rf $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb/dot-art/src; \
+		$(MAKE) install -C media/assets INSTALLDIR=$(ASSETS_DIR)/retroarch/assets; \
 		echo "Asset copying done."; \
 	fi
 


### PR DESCRIPTION
This updates the install process to use [retroarch-assets Makefile](https://github.com/libretro/retroarch-assets/blob/master/Makefile) to install the assets. Makes it so that we just need to update the Makefile whenever we add a new theme.

This is a follow up from https://github.com/libretro/retroarch-assets/pull/185 , and fixes an issue where some source files were being installed.