### PR TITLE
Show VID/PID values for unsupported devices.

### DIFF
--- a/input/drivers_hid/libusb_hid.c
+++ b/input/drivers_hid/libusb_hid.c
@@ -314,7 +314,8 @@ static int add_adapter(void *data, struct libusb_device *dev)
 
    if (!pad_connection_has_interface(hid->slots, adapter->slot))
    {
-      RARCH_ERR(" Interface not found (%s).\n", adapter->name);
+      RARCH_ERR("Interface not found (%s) (VID/PID: %04x:%04x).\n",
+         adapter->name, desc.idVendor, desc.idProduct);
       goto error;
    }
 


### PR DESCRIPTION
## Description

Add VID/PID display to "Interface not found" error message. To make it easier to create new interfaces, or detect ones that change ID (such as the blissbox in update mode)

## Related Issues

none.

## Related Pull Requests

none.

## Reviewers

@bparker06 please review.
