### PR TITLE
allow building and debugging RetroArch from Visual Studio code automa…

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+   // Use IntelliSense to learn about possible attributes.
+   // Hover to view descriptions of existing attributes.
+   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+   "version": "0.2.0",
+   "configurations": [
+      {
+         "name": "MINGW64 (MSYS2) debug",
+         "type": "cppdbg",
+         "request": "launch",
+         "program": "${workspaceFolder}/retroarch.exe",
+         "args": [],
+         "stopAtEntry": false,
+         "cwd": "${workspaceFolder}",
+         "environment": [],
+         "externalConsole": true,
+         "MIMode": "gdb",
+         "miDebuggerPath": "c:\\msys64\\mingw64\\bin\\gdb.exe",
+         "setupCommands": [
+            {
+               "description": "Enable pretty-printing for gdb",
+               "text": "-enable-pretty-printing",
+               "ignoreFailures": true
+            }
+         ]
+      }
+   ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+   "terminal.integrated.shell.windows":    "C:\\msys64\\usr\\bin\\bash.exe",
+   "terminal.integrated.env.windows": {
+      "PATH": "/mingw64/lib/ccache/bin:/mingw64/lib/ccache/bin:/mingw64/lib/ccache/bin:/mingw64/bin:/usr/local/bin:/usr/bin:/bin:$PATH",
+      "MSYSTEM": "MINGW64",
+   },
+   "terminal.integrated.cursorBlinking": true,
+
+   "editor.tabSize": 3,
+   "editor.renderWhitespace": "all",
+   "editor.insertSpaces": true,
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,91 @@
+{
+   // See https://go.microsoft.com/fwlink/?LinkId=733558
+   // for the documentation about the tasks.json format
+   "version": "2.0.0",
+   "tasks": [
+      {
+         "taskName": "Build",
+         "type": "shell",
+
+         "group": {
+            "kind": "build",
+            "isDefault": true },
+
+         "command": "./configure; make -j2",
+         "options": {
+            "shell": {
+               "executable": "C:\\msys64\\usr\\bin\\bash.exe",
+               "args": [
+                  "-c"
+               ]
+            }
+         }
+      }
+      {
+         "taskName": "Build with debugging symbols",
+         "type": "shell",
+
+         "group": "build",
+
+         "command": "./configure; DEBUG=1 make -j2",
+         "options": {
+            "shell": {
+               "executable": "C:\\msys64\\usr\\bin\\bash.exe",
+               "args": [
+                  "-c"
+               ]
+            }
+         }
+      }
+      {
+         "taskName": "Build without reconfiguring",
+         "type": "shell",
+
+         "group": "build",
+
+         "command": "make -j2",
+         "options": {
+            "shell": {
+               "executable": "C:\\msys64\\usr\\bin\\bash.exe",
+               "args": [
+                  "-c"
+               ]
+            }
+         }
+      }
+      {
+         "taskName": "Clean",
+         "type": "shell",
+
+         "group": "build",
+
+         "command": "make clean",
+         "options": {
+            "shell": {
+               "executable": "C:\\msys64\\usr\\bin\\bash.exe",
+               "args": [
+                  "-c"
+               ]
+            }
+         }
+      }
+      {
+         "taskName": "Start",
+         "type": "shell",
+
+         "group": {
+            "kind": "test",
+            "isDefault": true },
+
+         "command": "./retroarch -v",
+         "options": {
+            "shell": {
+               "executable": "C:\\msys64\\usr\\bin\\bash.exe",
+               "args": [
+                  "-c"
+               ]
+            }
+         }
+      }
+   ]
+}


### PR DESCRIPTION
## Description

Allows building and debugging RetroArch from Visual Studio code automatically on a MINGW64 (MSYS2) installation.
This works if MSYS2 is installed in the default path.

It also sets the terminal to bash.

To use this, set the visual studio workspace to your RetroArch folder.

## Related Issues

N//A

## Related Pull Requests

N//A

## Reviewers

N//A
