### PR TITLE
Improved handling of libusb hotplug capability

### DIFF
--- a/input/drivers_hid/libusb_hid.c
+++ b/input/drivers_hid/libusb_hid.c
@@ -524,7 +524,8 @@ static void libusb_hid_free(void *data)
    if (hid->slots)
       pad_connection_destroy(hid->slots);
 
-   libusb_hotplug_deregister_callback(hid->ctx, hid->hp);
+   if (hid->can_hotplug)
+      libusb_hotplug_deregister_callback(hid->ctx, hid->hp);
 
    libusb_exit(hid->ctx);
    free(hid);


### PR DESCRIPTION
## Description

This patch improves the process of detecting libusb hotplug capability. It handles the lack of a caps. check function on older APIs, and also the failure of the callback registration without aborting the initialisation process.

## Related Issues

No formal issue was recorded, but this does fix Windows libusb support on my system. I'm now able to use the Mayflash GameCube controller adapter to navigate the menu system of RetroArch.

## Related Pull Requests

No related/dependent PRs

## Reviewers

FAO @bparker06 who I've been in discussions with.

Personally tested only on Windows 10 / MSYS2 with package mingw-w64-x86_64-libusb 1.0.21-1
