### PR TITLE
Restore Start+Select=Home Hacks

### DIFF
--- a/input/connect/connect_snesusb.c
+++ b/input/connect/connect_snesusb.c
@@ -62,12 +62,18 @@ static void hidpad_snesusb_deinit(void *data)
 
 static void hidpad_snesusb_get_buttons(void *data, retro_bits_t *state)
 {
-	struct hidpad_snesusb_data *device = (struct hidpad_snesusb_data*)data;
-	if ( device ) {
-		RARCH_INPUT_STATE_COPY16_PTR(state, device->buttons);
-	} else {
-		RARCH_INPUT_STATE_CLEAR_PTR(state);
-	}
+   struct hidpad_snesusb_data *device = (struct hidpad_snesusb_data*)data;
+   if ( device )
+   {
+      RARCH_INPUT_STATE_COPY16_PTR(state, device->buttons);
+
+      if (device->buttons & (1<<RARCH_FIRST_CUSTOM_BIND))
+         RARCH_INPUT_STATE_BIT_SET_PTR(state,RARCH_MENU_TOGGLE);
+   }
+   else
+   {
+      RARCH_INPUT_STATE_CLEAR_PTR(state);
+   }
 }
 
 static int16_t hidpad_snesusb_get_axis(void *data, unsigned axis)
@@ -87,7 +93,7 @@ static int16_t hidpad_snesusb_get_axis(void *data, unsigned axis)
 static void hidpad_snesusb_packet_handler(void *data, uint8_t *packet, uint16_t size)
 {
    uint32_t i, pressed_keys;
-   static const uint32_t button_mapping[16] =
+   static const uint32_t button_mapping[17] =
    {
       RETRO_DEVICE_ID_JOYPAD_L,
       RETRO_DEVICE_ID_JOYPAD_R,
@@ -104,7 +110,8 @@ static void hidpad_snesusb_packet_handler(void *data, uint8_t *packet, uint16_t 
       RETRO_DEVICE_ID_JOYPAD_X,
       RETRO_DEVICE_ID_JOYPAD_A,
       RETRO_DEVICE_ID_JOYPAD_B,
-      RETRO_DEVICE_ID_JOYPAD_Y
+      RETRO_DEVICE_ID_JOYPAD_Y,
+      RARCH_FIRST_CUSTOM_BIND, /* Fake HOME BUTTON when pressing SELECT+START */
    };
    struct hidpad_snesusb_data *device = (struct hidpad_snesusb_data*)data;
 
@@ -117,7 +124,7 @@ static void hidpad_snesusb_packet_handler(void *data, uint8_t *packet, uint16_t 
 
    pressed_keys  = device->data[7] | (device->data[6] << 8);
 
-   for (i = 0; i < 16; i ++)
+   for (i = 0; i < 17; i ++)
       if (button_mapping[i] != NO_BTN)
          device->buttons |= (pressed_keys & (1 << i)) ? (1 << button_mapping[i]) : 0;
 }
@@ -125,16 +132,16 @@ static void hidpad_snesusb_packet_handler(void *data, uint8_t *packet, uint16_t 
 static void hidpad_snesusb_set_rumble(void *data,
       enum retro_rumble_effect effect, uint16_t strength)
 {
-	(void)data;
-	(void)effect;
+   (void)data;
+   (void)effect;
    (void)strength;
 }
 
 const char * hidpad_snesusb_get_name(void *data)
 {
-	(void)data;
-	/* For now we return a single static name */
-	return "Generic SNES USB Controller";
+   (void)data;
+   /* For now we return a single static name */
+   return "Generic SNES USB Controller";
 }
 
 pad_connection_interface_t pad_connection_snesusb = {


### PR DESCRIPTION
## Description

While implementing PR #5812 I encountered three input drivers (NES, SNES and PSX USB in the connect folder) that map start+select presses as a shortcut for the menu toggle button. Since in my opinion this virtual button doesn't belong in an input driver and should be handled at a higher level, I didn't port it over to the new input code.

It's come to my attention that in making this decision I've negatively impacted at least @danieljg and presumably a few others using this combination on devices without access to other means of triggering a home button press. 

I'd like to first apologise for doing this without a discussion, that was unfair of me.

I'm still of the opinion that these combinations should not be included in the input driver for the following reasons:

* Not configurable by the user.
* Not consistently applied - only available on some controller types. For example the PS2 code doesn't appear to support this combination.
* Definite conflict with the TurboGrafx 16, which uses Select+Run(Start) button to restart the game.

However a replacement should have been put in place prior to removing this feature. So I've created this pull request to restore the missing button combinations and also to hopefully begin a discussion on the issue.

The solution found on RetroPie, where a 'shift key' is bound and then other buttons can be mapped to other hotkeys by the user, seems like a good solution. Even if the default ends up as select+start.

## Related Issues

Reported by @danieljg in PR #5812

## Related Pull Requests

No dependencies.

## Reviewers

@twinaphex @fr500 @bparker06 ?
