### PR TITLE
Revert "Use RetroArch Assets' Makefile to install Assets"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,17 @@ install: $(TARGET)
 	install -m644 media/retroarch.svg $(DESTDIR)$(PREFIX)/share/pixmaps
 	@if test -d media/assets; then \
 		echo "Installing media assets..."; \
-		$(MAKE) install -C media/assets INSTALLDIR=$(ASSETS_DIR)/retroarch/assets; \
+		mkdir -p $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb; \
+		mkdir -p $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/glui; \
+		cp -r media/assets/xmb/  $(DESTDIR)$(ASSETS_DIR)/retroarch/assets; \
+		cp -r media/assets/glui/ $(DESTDIR)$(ASSETS_DIR)/retroarch/assets; \
+		echo "Removing unneeded source image files.."; \
+		rm -rf $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb/flatui/src; \
+		rm -rf $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb/monochrome/src; \
+		rm -rf $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb/retroactive/src; \
+		rm -rf $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb/neoactive/src; \
+		rm -rf $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb/retrosystem/src; \
+		rm -rf $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb/dot-art/src; \
 		echo "Asset copying done."; \
 	fi
 


### PR DESCRIPTION
Reverts libretro/RetroArch#5824

I don't know how I missed this, but this is not acceptable.

'make -c' is not part of the posix spec and not all make implementations have it.

See http://pubs.opengroup.org/onlinepubs/009695399/utilities/make.html