### PR TITLE
Use RetroArch Assets make install to handle assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,17 +201,7 @@ install: $(TARGET)
 	install -m644 media/retroarch.svg $(DESTDIR)$(PREFIX)/share/pixmaps
 	@if test -d media/assets; then \
 		echo "Installing media assets..."; \
-		mkdir -p $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb; \
-		mkdir -p $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/glui; \
-		cp -r media/assets/xmb/  $(DESTDIR)$(ASSETS_DIR)/retroarch/assets; \
-		cp -r media/assets/glui/ $(DESTDIR)$(ASSETS_DIR)/retroarch/assets; \
-		echo "Removing unneeded source image files.."; \
-		rm -rf $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb/flatui/src; \
-		rm -rf $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb/monochrome/src; \
-		rm -rf $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb/retroactive/src; \
-		rm -rf $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb/neoactive/src; \
-		rm -rf $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb/retrosystem/src; \
-		rm -rf $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb/dot-art/src; \
+		cd media/assets && $(MAKE) install INSTALLDIR=$(ASSETS_DIR)/retroarch/assets && cd ../..; \
 		echo "Asset copying done."; \
 	fi
 


### PR DESCRIPTION
This updates the `make install` installation of retroarch-assets to not use -C, as it is not implemented across all versions of `make`. Allows us to maintain just one Makefile, rather than two.

## Related Issues

https://github.com/libretro/retroarch-assets/pull/185

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/5841

## Reviewers

@orbea @twinaphex 
