### PR TITLE
reenable network gamepad and fix slow motion

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -2718,7 +2718,9 @@ static bool config_load_file(const char *path, bool set_defaults,
       *settings->paths.directory_system = '\0';
 
    if (settings->floats.slowmotion_ratio < 1.0f)
-      configuration_set_float(settings, settings->floats.slowmotion_ratio, 1.0f);
+   {
+      configuration_set_float(settings, settings->floats.slowmotion_ratio, 15.0f);
+   }
 
    /* Sanitize fastforward_ratio value - previously range was -1
     * and up (with 0 being skipped) */
@@ -2726,6 +2728,7 @@ static bool config_load_file(const char *path, bool set_defaults,
    {
       configuration_set_float(settings, settings->floats.fastforward_ratio, 0.0f);
    }
+
 
 #ifdef HAVE_LAKKA
    settings->bools.ssh_enable       = path_file_exists(LAKKA_SSH_PATH);

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -4273,7 +4273,7 @@ bool menu_displaylist_process(menu_displaylist_info_t *info)
             MENU_SETTING_ACTION, 0, 0);
 #endif
 
-#if defined(HAVE_NETWORKING) && defined(HAVE_NETWORKGAMEPAD) && defined(HAVE_NETWORKGAMEPAD_CORE)
+#if defined(HAVE_NETWORKING) && defined(HAVE_NETWORKGAMEPAD)
       menu_entries_append_enum(info->list,
             msg_hash_to_str(MENU_ENUM_LABEL_VALUE_START_NET_RETROPAD),
             msg_hash_to_str(MENU_ENUM_LABEL_START_NET_RETROPAD),

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -2263,7 +2263,7 @@ static bool setting_append_list(
                parent_group);
 #endif
 
-#if defined(HAVE_NETWORKING) && defined(HAVE_NETWORKGAMEPAD) && defined(HAVE_NETWORKGAMEPAD_CORE)
+#if defined(HAVE_NETWORKING) && defined(HAVE_NETWORKGAMEPAD)
          CONFIG_ACTION(
                list, list_info,
                MENU_ENUM_LABEL_START_NET_RETROPAD,


### PR DESCRIPTION
## Description

Reenables the Remote Retropad core that was disabled for some reason

## Related Issues
https://github.com/libretro/RetroArch/issues/5379
https://github.com/libretro/RetroArch/issues/5820

## Related Pull Requests
## Reviewers