### PR TITLE
[WiiU] Toolchain: Actually fix C++ constructors/destructors (oops!)

### DIFF
--- a/frontend/drivers/platform_wiiu.c
+++ b/frontend/drivers/platform_wiiu.c
@@ -525,24 +525,23 @@ void __eabi()
 __attribute__((weak))
 void __init(void)
 {
-   extern void (**const __CTOR_LIST__)(void);
-   extern void (**const __CTOR_END__)(void);
+   extern void (*const __CTOR_LIST__)(void);
+   extern void (*const __CTOR_END__)(void);
 
-   void (**ctor)(void) = __CTOR_LIST__;
-   while (ctor < __CTOR_END__) {
+   void (*const *ctor)(void) = &__CTOR_LIST__;
+   while (ctor < &__CTOR_END__) {
       (*ctor++)();
    }
 }
 
-
 __attribute__((weak))
 void __fini(void)
 {
-   extern void (**const __DTOR_LIST__)(void);
-   extern void (**const __DTOR_END__)(void);
+   extern void (*const __DTOR_LIST__)(void);
+   extern void (*const __DTOR_END__)(void);
 
-   void (**dtor)(void) = __DTOR_LIST__;
-   while (dtor < __DTOR_END__) {
+   void (*const *dtor)(void) = &__DTOR_LIST__;
+   while (dtor < &__DTOR_END__) {
       (*dtor++)();
    }
 }
@@ -654,7 +653,10 @@ void _start(int argc, char **argv)
    main(argc, argv);
 
    fsdev_exit();
-//   __fini();
+
+/* TODO: fix elf2rpl so it doesn't error with "Could not find matching symbol
+         for relocation" then uncomment this */
+// __fini();
    memoryRelease();
    SYSRelaunchTitle(0, 0);
    exit(0);


### PR DESCRIPTION
I didn't quite get this right the first time. I've thoroughly tested these new patches against a core that actually needs constructors to function (ControllerPatcher didn't, apparently) so I know it works. Fixes this [problem](https://gbatemp.net/posts/7720955).

Also; I've noticed that calling `__fini` from the RPX build causes elf2rpl to error out. It doesn't do this if I change `__fini` to not use `__DTOR_END__`; so that's almost certainly the cause. Since it links just fine; I'll submit a bug report to the creators in the hope we can get destructors working on RPX.

Thanks again,
Ash