### PR TITLE
GLsync build fix for HAVE_OPENGLES2

### DIFF
--- a/gfx/drivers_renderchain/gl2_renderchain.c
+++ b/gfx/drivers_renderchain/gl2_renderchain.c
@@ -53,6 +53,12 @@
 
 #define MAX_FENCES 4
 
+#ifndef HAVE_PSGL
+#if defined(HAVE_OPENGLES2)
+   typedef struct __GLsync *GLsync;
+#endif
+#endif
+
 typedef struct gl2_renderchain
 {
    bool egl_images;


### PR DESCRIPTION
## Description
fixing error at compilation for Lakka when configured with --enable-opengles:

gfx/drivers_renderchain/gl2_renderchain.c:73:4: error: unknown type name 'GLsync'
     GLsync fences[MAX_FENCES];
     ^~~~~~
