### PR TITLE
Update make install for new retroarch-assets src

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,13 +205,6 @@ install: $(TARGET)
 		mkdir -p $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/glui; \
 		cp -r media/assets/xmb/  $(DESTDIR)$(ASSETS_DIR)/retroarch/assets; \
 		cp -r media/assets/glui/ $(DESTDIR)$(ASSETS_DIR)/retroarch/assets; \
-		echo "Removing unneeded source image files.."; \
-		rm -rf $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb/flatui/src; \
-		rm -rf $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb/monochrome/src; \
-		rm -rf $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb/retroactive/src; \
-		rm -rf $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb/neoactive/src; \
-		rm -rf $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb/retrosystem/src; \
-		rm -rf $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb/dot-art/src; \
 		echo "Asset copying done."; \
 	fi
 


### PR DESCRIPTION
The assets over at [retroarch-assets](https://github.com/libretro/retroarch-assets) have [moved the source files](https://github.com/libretro/retroarch-assets/pull/191) so that the asset installation process is a much easier. We no longer have the need to delete the theme src directories.

## Description

Theme src directories no longer exist.

https://github.com/libretro/retroarch-assets/pull/191

## Related Issues
https://github.com/libretro/retroarch-assets/pull/191

## Reviewers

- @orbea 