### PR TITLE
Mayflash DolphinBar

### DIFF
--- a/input/connect/joypad_connection.c
+++ b/input/connect/joypad_connection.c
@@ -84,6 +84,7 @@ int32_t pad_connection_pad_init(joypad_connection_t *joyconn,
       { "Wii U GC Controller Adapter", 1406,  823,    &pad_connection_wiiugca },
       { "PS2/PSX Controller Adapter",  2064,  1,      &pad_connection_ps2adapter },
       { "PSX to PS3 Controller Adapter", 2064, 3,     &pad_connection_psxadapter },
+      { "Mayflash DolphinBar",         1406,  774,    &pad_connection_wii },
       { 0, 0}
    };
    joypad_connection_t *s = NULL;


### PR DESCRIPTION
## Description

Adds support for the Mayflash DolphinBar.

"The Mayflash DolphinBar is a combination Bluetooth adapter and Sensor Bar. It doesn't reveal any of the Bluetooth information to the operating system, instead sending HID packets directly to Dolphin without a Bluetooth Stack, thus allowing -TR [Wii MotionPlus] support and syncing of Wii Remotes"

Basically I just added the correct VID/PID for the bar and used the existing wiimote code and it just worked. I'm not able to sync my wiimote to my PC via my bluetooth adapter so I'm not able to compare the experience, but I was able to map buttons and navigate in the front-end with it, so it's a start.

## Related Issues

NOTE: I had crashes when attaching and removing extension peripherals (such as the nunchuk and classic controller pro) requiring a power cycling on the remote. When booting with these attached the controller didn't function at all.

I don't know whether this is consistent with using a wiimote via a bluetooth adapter.

## Related Pull Requests

none

## Reviewers

@bparker06 
