### PR TITLE
Playlist duplication fixes

### DIFF
--- a/playlist.c
+++ b/playlist.c
@@ -309,9 +309,17 @@ bool playlist_push(playlist_t *playlist,
    for (i = 0; i < playlist->size; i++)
    {
       struct playlist_entry tmp;
-      bool equal_path = (!path && !playlist->entries[i].path) ||
+      bool equal_path;
+
+      equal_path = (!path && !playlist->entries[i].path) ||
          (path && playlist->entries[i].path &&
-          string_is_equal(path,playlist->entries[i].path));
+#ifdef _WIN32
+          /*prevent duplicates on case-insensitive operating systems*/
+          string_is_equal_noncase(path,playlist->entries[i].path)
+#else
+          string_is_equal(path,playlist->entries[i].path)
+#endif
+          );
 
       /* Core name can have changed while still being the same core.
        * Differentiate based on the core path only. */

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -996,7 +996,7 @@ static bool command_event_cmd_exec(const char *data,
 
 #if defined(HAVE_DYNAMIC)
    if (!task_load_content(&content_info, content_ctx,
-            false, launched_from_cli, error_string))
+            true, launched_from_cli, error_string))
       return false;
 #else
    frontend_driver_set_fork(FRONTEND_FORK_CORE_WITH_ARGS);


### PR DESCRIPTION
## Description

Fixes two possible methods for generating duplicate entries in the history playlist.

1st. Using a relative path in "rgui_browser_directory" setting. Load some content. Quit and then load that same content from the history - generates a duplicate because the path is normalised on the second load, due to incorrect setting of the loading_from_menu parameter.

2nd. Loading content from the command line in lower case on Windows (with its case insensitive file system) will load the content OK but generates a duplicate because of a case _sensitive_ duplicate path check.

## Related Issues

None.

## Related Pull Requests

No dependencies.

## Reviewers

@bparker @twinaphex 

Note: I suppose #ifdef _WIN32 isn't perfect to determine case sensitive file systems but it'll probably be just fine given the context of what it's doing.