### PR TITLE
Clean thumbnail filenames 

### DIFF
--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -1013,6 +1013,15 @@ static void xmb_update_thumbnail_path(void *data, unsigned i)
 
       if (!string_is_empty(tmp))
       {
+         /* Remove common strings. */
+         tmp = string_replace_substring(tmp, " [b]", "");
+         tmp = string_replace_substring(tmp, " (Proto)", "");
+         tmp = string_replace_substring(tmp, " (Rev A)", "");
+         tmp = string_replace_substring(tmp, " (Rev B)", "");
+         tmp = string_replace_substring(tmp, " (Rev C)", "");
+         tmp = string_replace_substring(tmp, " (Rev D)", "");
+         tmp = string_replace_substring(tmp, " (Rev E)", "");
+
          fill_pathname_join(tmp_new,
                xmb->thumbnail_file_path,
                tmp, PATH_MAX_LENGTH * sizeof(char));
@@ -2252,7 +2261,7 @@ static uintptr_t xmb_icon_get_id(xmb_handle_t *xmb,
       if (get_badge_texture(new_id) != 0)
          return get_badge_texture(new_id);
       /* Should be replaced with placeholder badge icon. */
-      return xmb->textures.list[XMB_TEXTURE_SUBSETTING]; 
+      return xmb->textures.list[XMB_TEXTURE_SUBSETTING];
    }
 #endif
 

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -1021,6 +1021,11 @@ static void xmb_update_thumbnail_path(void *data, unsigned i)
          tmp = string_replace_substring(tmp, " (Rev C)", "");
          tmp = string_replace_substring(tmp, " (Rev D)", "");
          tmp = string_replace_substring(tmp, " (Rev E)", "");
+         tmp = string_replace_substring(tmp, " (Rev 1)", "");
+         tmp = string_replace_substring(tmp, " (Rev 2)", "");
+         tmp = string_replace_substring(tmp, " (Rev 3)", "");
+         tmp = string_replace_substring(tmp, " (Rev 4)", "");
+         tmp = string_replace_substring(tmp, " (Rev 5)", "");
 
          fill_pathname_join(tmp_new,
                xmb->thumbnail_file_path,


### PR DESCRIPTION
## Description

Thumbnails get misnamed when new revisions of games come out. Removing common beta, proto, or revision flags from the thumbnail name will mean that we won't have to rename the thumbnail when a new revision comes out.

This will mean that games like `Mine Storm II (USA) (Rev 2)` will need a thumb named `Mine Storm II (USA).png". Overall this will help with two ways:

- Ease maintenance, as we won't need to rename the thumbnails as much
- Reduce size of thumbnails as a we won't have to have duplicate images

## Related Issues

- Originally proposed over at https://github.com/libretro/libretro-thumbnails/issues/355

## Reviewers

- @markwkidd 
- @Kivutar
