### PR TITLE
(PSP) Strip and user 64MB where available

### DIFF
--- a/Makefile.psp1
+++ b/Makefile.psp1
@@ -1,6 +1,8 @@
-BUILD_PRX          = 1
+BUILD_PRX          = 0
+PSP_LARGE_MEMORY   = 1
 DEBUG              = 0
 HAVE_KERNEL_PRX    = 1
+HAVE_LOGGER        = 0
 HAVE_FILE_LOGGER   = 0
 HAVE_THREADS       = 0
 BIG_STACK          = 0
@@ -11,7 +13,7 @@ TARGET = retroarchpsp
 ifeq ($(DEBUG), 1)
    OPTIMIZE_LV	:= -O0 -g
 else
-   OPTIMIZE_LV	:= -O3 -g
+   OPTIMIZE_LV	:= -O3 
 endif
 
 ifeq ($(WHOLE_ARCHIVE_LINK), 1)

--- a/Makefile.psp1.salamander
+++ b/Makefile.psp1.salamander
@@ -1,4 +1,5 @@
-BUILD_PRX         = 1
+BUILD_PRX         = 0
+PSP_LARGE_MEMORY  = 1
 HAVE_FILE_LOGGER  = 0
 DEBUG             = 0
 
@@ -7,7 +8,7 @@ TARGET = retroarchpsp_salamander
 ifeq ($(DEBUG), 1)
    OPTIMIZE_LV	:= -O0 -g
 else
-   OPTIMIZE_LV	:= -O2 -g
+   OPTIMIZE_LV	:= -O2
 endif
 
 INCDIR = $(PSPPATH)/include libretro-common/include
@@ -24,7 +25,7 @@ ifeq ($(HAVE_FILE_LOGGER), 1)
 CFLAGS		+= -DHAVE_FILE_LOGGER
 endif
 
-CFLAGS += $(RARCH_DEFINES)
+CFLAGS += $(RARCH_DEFINES) 
 
 EXTRA_TARGETS   = EBOOT.PBP
 PSP_EBOOT_TITLE = RetroArch

--- a/bootstrap/psp1/kernel_functions_prx/Makefile
+++ b/bootstrap/psp1/kernel_functions_prx/Makefile
@@ -14,7 +14,7 @@ USE_KERNEL_LIBC=1
 USE_KERNEL_LIBS=1
 
 LIBDIR =
-LDFLAGS = -mno-crt0 -nostartfiles
+LDFLAGS = -nostartfiles
 LIBS = -lpspdebug -lpspge -lpspsdk -lc -lpspuser
 PSPSDK=$(shell psp-config --pspsdk-path)
 include $(PSPSDK)/lib/build.mak


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises


## Description

- Add option PSP_LARGE_MEMORY to use 64MB on PSP 2000 / 3000
- Set BUILD_PRX to 0 in order to strip binaries

## Related Issues

#3502

## Reviewers

@twinaphex @fr500 