### PR TITLE
Change "Retroarch" to "RetroArch" in HB Launcher for consistency.

### DIFF
--- a/Makefile.ctr
+++ b/Makefile.ctr
@@ -9,8 +9,8 @@ BUILD_3DS               = 1
 BUILD_CIA               = 1
 LIBCTRU_NO_DEPRECATION  = 1
 
-APP_TITLE            = Retroarch 3DS
-APP_DESCRIPTION      = Retroarch 3DS
+APP_TITLE            = RetroArch 3DS
+APP_DESCRIPTION      = RetroArch 3DS
 APP_AUTHOR           = Team Libretro
 APP_PRODUCT_CODE     = RETROARCH-3DS
 APP_UNIQUE_ID        = 0xBAC00


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
( I just deleted and reforked my repository idk how. )

2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
( ✔ )

3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

( I literally changed two characters, calm down. )

## Description

In the Homebrew Launcher, RetroArch has always appeared as "Retroarch" which doesn't make sense if everything else is "RetroArch". This just does not look right and I get pissed just looking at it. lol
I don't think it is an personal preference thing, because I have literally never seen it typed like that.

## Related Issues

Maybe it is "Retroarch" in other areas?

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

@aliaspider Because he is the 3DS lord and knows all.
@twinaphex He most likely knows about how RetroArch is typed.
( The Libretro leader should know how to type "RetroArch" and when it's typed different. )
