### PR TITLE
Replace double quotes in thumbnail names

### DIFF
--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -1004,7 +1004,7 @@ static void xmb_update_thumbnail_path(void *data, unsigned i)
 
       if (!string_is_empty(tmp))
       {
-         while((scrub_char_pointer = strpbrk(tmp, "&*/:`<>?\\|")))
+         while((scrub_char_pointer = strpbrk(tmp, "&*/:`\"<>?\\|")))
             *scrub_char_pointer = '_';
       }
 


### PR DESCRIPTION
## Description

Using " causes some issues in Windows.

- @alfrix 