### PR TITLE
show the frontend name and CPU architecture on netplay rooms

### DIFF
--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -3431,6 +3431,9 @@ static void netplay_refresh_rooms_cb(void *task_data, void *user_data, const cha
                strlcpy(netplay_room_list[i].gamename,
                      host->content,
                      sizeof(netplay_room_list[i].gamename));
+               strlcpy(netplay_room_list[i].frontend,
+                     host->frontend,
+                     sizeof(netplay_room_list[i].frontend));
 
                netplay_room_list[i].port      = host->port;
                netplay_room_list[i].gamecrc   = host->content_crc;

--- a/menu/cbs/menu_cbs_sublabel.c
+++ b/menu/cbs/menu_cbs_sublabel.c
@@ -405,6 +405,8 @@ static int action_bind_sublabel_netplay_room(
    const char *corename   = NULL;
    const char *gamename   = NULL;
    const char *core_ver   = NULL;
+   const char *frontend   = NULL;
+   
    /* This offset may cause issues if any entries are added to this menu */
    unsigned offset        = i - 3;
 
@@ -415,11 +417,13 @@ static int action_bind_sublabel_netplay_room(
    corename   = netplay_room_list[offset].corename;
    gamename   = netplay_room_list[offset].gamename;
    core_ver   = netplay_room_list[offset].coreversion;
-   gamecrc   = netplay_room_list[offset].gamecrc;
+   gamecrc    = netplay_room_list[offset].gamecrc;
+   frontend   = netplay_room_list[offset].frontend;
 
    snprintf(s, len,
-	   "RetroArch: %s\nCore: %s (%s)\nGame: %s (%08x)",
+	   "RetroArch: %s (%s)\nCore: %s (%s)\nGame: %s (%08x)",
       string_is_empty(ra_version) ? "n/a" : ra_version,
+      string_is_empty(frontend) ? "n/a" : frontend,
       corename, core_ver,
       !string_is_equal(gamename, "N/A") ? gamename : "n/a",
       gamecrc);

--- a/network/netplay/netplay.h
+++ b/network/netplay/netplay.h
@@ -91,4 +91,6 @@ int netplay_rooms_get_count();
 
 void netplay_rooms_free();
 
+void netplay_get_architecture(char *frontend_architecture, size_t size);
+
 #endif

--- a/network/netplay/netplay_discovery.c
+++ b/network/netplay/netplay_discovery.c
@@ -63,6 +63,7 @@ struct ad_packet
    char address[NETPLAY_HOST_STR_LEN];
    char retroarch_version[NETPLAY_HOST_STR_LEN];
    char nick[NETPLAY_HOST_STR_LEN];
+   char frontend[NETPLAY_HOST_STR_LEN];
    char core[NETPLAY_HOST_STR_LEN];
    char core_version[NETPLAY_HOST_STR_LEN];
    char content[NETPLAY_HOST_LONGSTR_LEN];
@@ -290,6 +291,8 @@ bool netplay_lan_ad_server(netplay_t *netplay)
          {
             char *p;
             char sub[NETPLAY_HOST_STR_LEN];
+            char frontend[NETPLAY_HOST_STR_LEN];
+            netplay_get_architecture(frontend, sizeof(frontend));
 
             p=strrchr(reply_addr,'.');
             if (p)
@@ -321,6 +324,7 @@ bool netplay_lan_ad_server(netplay_t *netplay)
                         ? path_basename(path_get(RARCH_PATH_BASENAME)) : "N/A",
                         NETPLAY_HOST_LONGSTR_LEN);
                   strlcpy(ad_packet_buffer.nick, netplay->nick, NETPLAY_HOST_STR_LEN);
+                  strlcpy(ad_packet_buffer.frontend, frontend, NETPLAY_HOST_STR_LEN);
 
                   if (info)
                   {
@@ -481,6 +485,8 @@ static bool netplay_lan_ad_client(void)
          strlcpy(host->core_version, ad_packet_buffer.core_version,
             NETPLAY_HOST_STR_LEN);
          strlcpy(host->content, ad_packet_buffer.content,
+            NETPLAY_HOST_LONGSTR_LEN);
+         strlcpy(host->frontend, ad_packet_buffer.frontend,
             NETPLAY_HOST_LONGSTR_LEN);
 
          host->content_crc                  =

--- a/network/netplay/netplay_discovery.h
+++ b/network/netplay/netplay_discovery.h
@@ -39,6 +39,7 @@ struct netplay_host
 
    char address[NETPLAY_HOST_STR_LEN];
    char nick[NETPLAY_HOST_STR_LEN];
+   char frontend[NETPLAY_HOST_STR_LEN];
    char core[NETPLAY_HOST_STR_LEN];
    char core_version[NETPLAY_HOST_STR_LEN];
    char retroarch_version[NETPLAY_HOST_STR_LEN];
@@ -69,6 +70,7 @@ struct netplay_room
    int  port;
    int  mitm_port;
    char corename    [PATH_MAX_LENGTH];
+   char frontend    [PATH_MAX_LENGTH];
    char coreversion [PATH_MAX_LENGTH];
    char gamename    [PATH_MAX_LENGTH];
    int  gamecrc;

--- a/network/netplay/netplay_room_parse.c
+++ b/network/netplay/netplay_room_parse.c
@@ -283,6 +283,11 @@ static JSON_Parser_HandlerResult JSON_CALL ObjectMemberHandler(JSON_Parser parse
             pCtx->cur_field       = strdup(pValue);
             pCtx->cur_member      = &rooms->cur->country;
          }
+         else if (string_is_equal_fast(pValue, "frontend", 7))
+         {
+            pCtx->cur_field       = strdup(pValue);
+            pCtx->cur_member      = &rooms->cur->frontend;
+         }
       }
    }
 


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises


## Description

Adds the frontend identified and CPU architecture to the netplay room list which should help users ascertain compatibility before attempting to join.

![image](https://user-images.githubusercontent.com/1721040/34081815-246bd2a0-e321-11e7-8f78-0fe214dfb76d.png)


