### PR TITLE
Makefile.common: Clean up the miniupnpc check

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1525,27 +1525,24 @@ ifeq ($(HAVE_NETWORKING), 1)
              cores/libretro-net-retropad/net_retropad_core.o
    endif
 
-   ifeq ($(HAVE_MINIUPNPC), 1)
-      ifeq ($(HAVE_BUILTINMINIUPNPC), 1)
-         DEFINES += -DHAVE_BUILTINMINIUPNPC -DMINIUPNPC_SET_SOCKET_TIMEOUT -DMINIUPNPC_GET_SRC_ADDR
-			DEFINES += -I$(DEPS_DIR)
-         OBJ     += \
-					 $(DEPS_DIR)/miniupnpc/igd_desc_parse.o \
-					 $(DEPS_DIR)/miniupnpc/upnpreplyparse.o \
-					 $(DEPS_DIR)/miniupnpc/upnpcommands.o \
-					 $(DEPS_DIR)/miniupnpc/upnperrors.o \
-					 $(DEPS_DIR)/miniupnpc/connecthostport.o \
-					 $(DEPS_DIR)/miniupnpc/portlistingparse.o \
-					 $(DEPS_DIR)/miniupnpc/receivedata.o \
-					 $(DEPS_DIR)/miniupnpc/upnpdev.o \
-					 $(DEPS_DIR)/miniupnpc/minissdpc.o \
-					 $(DEPS_DIR)/miniupnpc/miniwget.o \
-					 $(DEPS_DIR)/miniupnpc/miniupnpc.o \
-					 $(DEPS_DIR)/miniupnpc/minixml.o \
-					 $(DEPS_DIR)/miniupnpc/minisoap.o
-		else
-		   LIBS += $(MINIUPNPC_LIBS)
-      endif
+   ifeq ($(HAVE_BUILTINMINIUPNPC), 1)
+      DEFINES += -DHAVE_BUILTINMINIUPNPC -DMINIUPNPC_SET_SOCKET_TIMEOUT -DMINIUPNPC_GET_SRC_ADDR
+      DEFINES += -I$(DEPS_DIR)
+      OBJ     += $(DEPS_DIR)/miniupnpc/igd_desc_parse.o \
+                 $(DEPS_DIR)/miniupnpc/upnpreplyparse.o \
+                 $(DEPS_DIR)/miniupnpc/upnpcommands.o \
+                 $(DEPS_DIR)/miniupnpc/upnperrors.o \
+                 $(DEPS_DIR)/miniupnpc/connecthostport.o \
+                 $(DEPS_DIR)/miniupnpc/portlistingparse.o \
+                 $(DEPS_DIR)/miniupnpc/receivedata.o \
+                 $(DEPS_DIR)/miniupnpc/upnpdev.o \
+                 $(DEPS_DIR)/miniupnpc/minissdpc.o \
+                 $(DEPS_DIR)/miniupnpc/miniwget.o \
+                 $(DEPS_DIR)/miniupnpc/miniupnpc.o \
+                 $(DEPS_DIR)/miniupnpc/minixml.o \
+                 $(DEPS_DIR)/miniupnpc/minisoap.o
+   else ifeq ($(HAVE_MINIUPNPC), 1)
+      LIBS    += $(MINIUPNPC_LIBS)
    endif
 endif
 

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -195,12 +195,8 @@ if [ "$HAVE_NETWORKING" = 'yes' ]; then
    HAVE_NETWORK_CMD=yes
    HAVE_NETWORKGAMEPAD=yes
 
-   if [ "$HAVE_MINIUPNPC" != "no" ]; then
+   if [ "$HAVE_BUILTINMINIUPNPC" != "yes" ]; then
       check_lib '' MINIUPNPC "-lminiupnpc"
-   fi
-
-   if [ "$HAVE_BUILTINMINIUPNPC" = "yes" ]; then
-      HAVE_MINIUPNPC='yes'
    fi
 else
    die : 'Warning: All networking features have been disabled.'


### PR DESCRIPTION
## Description

This is a clean up of the miniupnpc check in `Makefile.common`.

This should be the new behavior.

1. By default `HAVE_BUILTINMINIUPNPC=YES` and `deps/miniupnpc` will be used.
2. A user explicitly sets `HAVE_MINIUPNPC=NO` with configure and it will use `deps/miniupnpc`.

Now compare with the old behavior.

1. By default `HAVE_BUILTINMINIUPNPC=YES`, it will check if `miniupnpc` is installed and then `deps/miniupnpc` will be used.
3. A user explicitly sets `HAVE_MINIUPNPC=NO` with configure, it will force `HAVE_MINIUPNPC=YES` and then use `deps/miniupnpc`.

## Related Issues

N/A

## Related Pull Requests

N/A

## Reviewers

@twinaphex