### PR TITLE
fix menu toggle with keymapper active

### DIFF
--- a/input/input_mapper.c
+++ b/input/input_mapper.c
@@ -30,6 +30,7 @@
 #include <compat/posix_string.h>
 #include <retro_miscellaneous.h>
 #include <libretro.h>
+#include "menu/menu_driver.h"
 
 #ifdef HAVE_CONFIG_H
 #include "../config.h"
@@ -81,11 +82,12 @@ void input_mapper_poll(input_mapper_t *handle)
    int i;
    settings_t *settings = config_get_ptr();
    unsigned device      = settings->uints.input_libretro_device[handle->port];
+   bool menu_is_alive   = menu_driver_is_alive();
 
    device              &= RETRO_DEVICE_MASK;
 
    /* for now we only handle keyboard inputs */
-   if (device != RETRO_DEVICE_KEYBOARD)
+   if (device != RETRO_DEVICE_KEYBOARD || menu_is_alive)
       return;
 
    memset(handle->keys, 0, sizeof(handle->keys));


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises


## Description

Fixes an issue were you can't use F1 to go back to game if device is set to keyboad

