### PR TITLE
qb: HAVE_MINIUPNPC is needed for builtin miniupnpc

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -195,7 +195,9 @@ if [ "$HAVE_NETWORKING" = 'yes' ]; then
    HAVE_NETWORK_CMD=yes
    HAVE_NETWORKGAMEPAD=yes
 
-   if [ "$HAVE_BUILTINMINIUPNPC" != "yes" ]; then
+   if [ "$HAVE_BUILTINMINIUPNPC" = "yes" ]; then
+      HAVE_MINIUPNPC=yes
+   else
       check_lib '' MINIUPNPC "-lminiupnpc"
    fi
 else


### PR DESCRIPTION
## Description

Sorry,  I had a lapse of judgement, `HAVE_MINIUPNPC=YES` is of course needed if `HAVE_BUILTINMINIUPNPC=YES` as there are `#if HAVE_MINIUPNPC` in the code base. This still avoids the needless `check_lib` check if using a builtin miniupnpc.

## Related Issues

N/A

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/5953

## Reviewers

@twinaphex
