### PR TITLE
qb: Disable all miniupnpc support with --disable-miniupnpc.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -195,10 +195,12 @@ if [ "$HAVE_NETWORKING" = 'yes' ]; then
    HAVE_NETWORK_CMD=yes
    HAVE_NETWORKGAMEPAD=yes
 
-   if [ "$HAVE_BUILTINMINIUPNPC" = "yes" ]; then
-      HAVE_MINIUPNPC=yes
-   else
-      check_lib '' MINIUPNPC "-lminiupnpc"
+   if [ "$HAVE_MINIUPNPC" != 'no' ]; then
+      if [ "$HAVE_BUILTINMINIUPNPC" = 'yes' ]; then
+         HAVE_MINIUPNPC=yes
+      else
+         check_lib '' MINIUPNPC '-lminiupnpc'
+      fi
    fi
 else
    die : 'Warning: All networking features have been disabled.'


### PR DESCRIPTION
## Description

I am not sure what the best behavior is here so if you like the current behavior please feel free to reject this. This is just a proposal hoping for more opinions.

Basically it might more sense and be more convenient if `--disable-miniupnpc` disables all miniupnpc support including the system and builtin miniupnpc while `--disable-builtinminiupnpc` only disables the builtin miniupnpc.

Otherwise it currently disables the system miniupnpc with `--disable-miniupnpc` and the builtin miniupnpc with `--disable-builtinminiupnpc`.

## Related Issues

N/A

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/5953 https://github.com/libretro/RetroArch/pull/5956

## Reviewers

@twinaphex