### PR TITLE
qb: Disable all miniupnpc support with --disable-miniupnpc.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -195,10 +195,12 @@ if [ "$HAVE_NETWORKING" = 'yes' ]; then
    HAVE_NETWORK_CMD=yes
    HAVE_NETWORKGAMEPAD=yes
 
-   if [ "$HAVE_BUILTINMINIUPNPC" = "yes" ]; then
+   if [ "$HAVE_MINIUPNPC" = 'no' ]; then
+      HAVE_BUILTINMINIUPNPC=no
+   elif [ "$HAVE_BUILTINMINIUPNPC" = 'yes' ]; then
       HAVE_MINIUPNPC=yes
    else
-      check_lib '' MINIUPNPC "-lminiupnpc"
+      check_lib '' MINIUPNPC '-lminiupnpc'
    fi
 else
    die : 'Warning: All networking features have been disabled.'


### PR DESCRIPTION
## Description

This changes the `--disable-miniupnpc` configure flag to disable both the system and builtin miniupnpc instead of only the system miniupnpc.

Here are the possible scenarios.

Default: 
Uses `deps/miniupnpc` because `--enable-builtinminiupnpc` is the default.

`--disable-miniupnpc`: 
Doesn't use miniupnpc

`--enable-miniupnpc`:
Ignored and uses `deps/miniupnpc` because `--enable-builtinminiupnpc` is the default.

`--disable-builtinminiupnpc`:
Checks if a system miniupnpc is installed and uses that if true or disables miniupnpc if not.

`--enable-miniupnpc --disable-builtinminiupnpc`:
Checks if a system miniupnpc is installed and then uses it if true. If not true it will bail and print a configure error.

## Related Issues

N/A

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/5953 https://github.com/libretro/RetroArch/pull/5956 https://github.com/libretro/RetroArch/pull/5957

## Reviewers

@twinaphex