### PR TITLE
avoid dinput reinitialization on unrelated WM_DEVICECHANGE events

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # 1.7.1 (future)
-- COMMON: Fix menu toggle with keymapper active.
+- DINPUT: don't reinitialize input driver on network events / media insertion / network drive connection
+- KEYMAPPER: prevent a condition that caused input_menu_toggle to stop working when a RETRO_DEVICE_KEYBOARD type device is enabled
 - PS3: Enable Cheevos.
 - PSP: Enable threading support through pthreads.
 

--- a/input/drivers/dinput.c
+++ b/input/drivers/dinput.c
@@ -21,6 +21,8 @@
 #undef DIRECTINPUT_VERSION
 #define DIRECTINPUT_VERSION 0x0800
 
+#define DBT_DEVNODES_CHANGED 0x0007
+
 #ifndef WM_MOUSEHWHEEL
 #define WM_MOUSEHWHEEL 0x20e
 #endif
@@ -802,9 +804,12 @@ bool dinput_handle_message(void *dinput, UINT message, WPARAM wParam, LPARAM lPa
             return true;
          }
       case WM_DEVICECHANGE:
-            if (di->joypad)
-               di->joypad->destroy();
-            di->joypad = input_joypad_init_driver(di->joypad_driver_name, di);
+            if (wParam == DBT_DEVNODES_CHANGED)
+            {
+               if (di->joypad)
+                  di->joypad->destroy();
+               di->joypad = input_joypad_init_driver(di->joypad_driver_name, di);
+            }
          break;
       case WM_MOUSEWHEEL:
             if (((short) HIWORD(wParam))/120 > 0)


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises


## Description

avoid dinput reinitialization on unrelated WM_DEVICECHANGE events

## Related Issues

I have faced this issue for years making RA on windows unusable on one of my PCs that has lots of network connections.

Basically RetroArch would reinitialize the whole input subsistem on WM_DEVICECHANGE without considering the actual event. Now we check if a device node is actually changed before triggering a reinit so hotplug functionality should remain intact.

## Reviewers

@bparker06 @twinaphex 
