### PR TITLE
Makefile.common: Clean up zlib check.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1366,14 +1366,27 @@ endif
 ifeq ($(HAVE_ZLIB), 1)
    OBJ += $(LIBRETRO_COMM_DIR)/file/archive_file_zlib.o \
           $(LIBRETRO_COMM_DIR)/streams/trans_stream_zlib.o
-   OBJ += $(ZLIB_OBJS)
    DEFINES += -DHAVE_ZLIB
    HAVE_COMPRESSION = 1
    ifeq ($(HAVE_BUILTINZLIB), 1)
+      OBJ += $(DEPS_DIR)/libz/adler32.o \
+             $(DEPS_DIR)/libz/compress.o \
+             $(DEPS_DIR)/libz/crc32.o \
+             $(DEPS_DIR)/libz/deflate.o \
+             $(DEPS_DIR)/libz/gzclose.o \
+             $(DEPS_DIR)/libz/gzlib.o \
+             $(DEPS_DIR)/libz/gzread.o \
+             $(DEPS_DIR)/libz/gzwrite.o \
+             $(DEPS_DIR)/libz/inffast.o \
+             $(DEPS_DIR)/libz/inflate.o \
+             $(DEPS_DIR)/libz/inftrees.o \
+             $(DEPS_DIR)/libz/trees.o \
+             $(DEPS_DIR)/libz/uncompr.o \
+             $(DEPS_DIR)/libz/zutil.o
       INCLUDE_DIRS += -I$(LIBRETRO_COMM_DIR)/include/compat
       DEFINES += -DWANT_ZLIB
    else
-      LIBS += -lz
+      LIBS += $(ZLIB_LIBS)
    endif
 endif
 
@@ -1410,27 +1423,6 @@ OBJ += $(LIBRETRO_COMM_DIR)/formats/bmp/rbmp_encode.o \
 
 ifdef HAVE_COMPRESSION
    DEFINES += -DHAVE_COMPRESSION
-endif
-
-ifeq ($(HAVE_BUILTINZLIB),1)
-   OBJ += $(DEPS_DIR)/libz/adler32.o \
-          $(DEPS_DIR)/libz/compress.o \
-          $(DEPS_DIR)/libz/crc32.o \
-          $(DEPS_DIR)/libz/deflate.o \
-          $(DEPS_DIR)/libz/gzclose.o \
-          $(DEPS_DIR)/libz/gzlib.o \
-          $(DEPS_DIR)/libz/gzread.o \
-          $(DEPS_DIR)/libz/gzwrite.o \
-          $(DEPS_DIR)/libz/inffast.o \
-          $(DEPS_DIR)/libz/inflate.o \
-          $(DEPS_DIR)/libz/inftrees.o \
-          $(DEPS_DIR)/libz/trees.o \
-          $(DEPS_DIR)/libz/uncompr.o \
-          $(DEPS_DIR)/libz/zutil.o
-else
-ifeq ($(HAVE_ZLIB), 1)
-OBJ += $(ZLIB_OBJS)
-endif
 endif
 
 ifeq ($(HAVE_7ZIP), 1)

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -311,7 +311,11 @@ if [ "$HAVE_OPENGL" != 'no' ] && [ "$HAVE_OPENGLES" != 'yes' ]; then
    fi
 fi
 
-if [ "$HAVE_ZLIB" != 'no' ]; then
+if [ "$HAVE_ZLIB" = 'no' ]; then
+   HAVE_BUILTINZLIB=no
+elif [ "$HAVE_BUILTINZLIB" = 'yes' ]; then
+   HAVE_ZLIB=yes
+else
    check_pkgconf ZLIB zlib
    check_val '' ZLIB '-lz'
 fi


### PR DESCRIPTION
## Description

This cleans up the check for `zlib` in `Makefile.common`. Also `ZLIB_OBJS` appears to be unused and unset so I am removing it. There are at least no other references to it in the repo.

Here are the possible scenarios.

Default:
Checks if zlib is installed and uses it if true, if false zlib is disabled.

`--disable-zlib`:
Doesn't use zlib.

`--enable-zlib`:
Checks if zlib is installed and uses it if true, if false it bails and prints a configure error.

`--enable-builtinzlib`:
Uses the builtin `deps/libz`, this is currently disabled by default.

## Related Issues

`--enable-builtinzlib` is broken before this commit and will still be broken after this commit...

## Related Pull Requests

N/A

## Reviewers

@twinaphex