### PR TITLE
only reinit when HID devices are attached on dinput

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,4 +9,9 @@
    "editor.tabSize": 3,
    "editor.renderWhitespace": "all",
    "editor.insertSpaces": true,
+   "files.associations": {
+      "frontend_driver.h": "c",
+      "*.in": "c",
+      "*.rh": "c"
+   },
 }

--- a/gfx/common/win32_common.c
+++ b/gfx/common/win32_common.c
@@ -22,7 +22,6 @@
 
 #include "win32_common.h"
 #include "gdi_common.h"
-#include "dbt.h"
 #include "../../frontend/frontend_driver.h"
 #include "../../configuration.h"
 #include "../../verbosity.h"
@@ -42,6 +41,7 @@
 
 #include <windows.h>
 #include <commdlg.h>
+#include <dbt.h>
 #include "../../retroarch.h"
 #include "../../input/input_driver.h"
 #include "../../input/input_keymaps.h"

--- a/gfx/common/win32_common.c
+++ b/gfx/common/win32_common.c
@@ -22,6 +22,7 @@
 
 #include "win32_common.h"
 #include "gdi_common.h"
+#include "dbt.h"
 #include "../../frontend/frontend_driver.h"
 #include "../../configuration.h"
 #include "../../verbosity.h"
@@ -68,6 +69,9 @@
 #else
 #define DragQueryFileR DragQueryFileW
 #endif
+
+const GUID GUID_DEVINTERFACE_HID = { 0x4d1e55b2, 0xf16f, 0x11Cf, { 0x88, 0xcb, 0x00, 0x11, 0x11, 0x00, 0x00, 0x30 } };
+HDEVNOTIFY notification_handler;
 
 extern LRESULT win32_menu_loop(HWND owner, WPARAM wparam);
 
@@ -759,6 +763,16 @@ bool win32_window_create(void *data, unsigned style,
    if (!main_window.hwnd)
       return false;
 
+   DEV_BROADCAST_DEVICEINTERFACE notification_filter;
+   ZeroMemory( &notification_filter, sizeof(notification_filter) );
+   notification_filter.dbcc_size = sizeof(DEV_BROADCAST_DEVICEINTERFACE);
+   notification_filter.dbcc_devicetype = DBT_DEVTYP_DEVICEINTERFACE;
+   notification_filter.dbcc_classguid = GUID_DEVINTERFACE_HID;
+   notification_handler = RegisterDeviceNotification(main_window.hwnd, &notification_filter, DEVICE_NOTIFY_WINDOW_HANDLE);
+
+   if (notification_handler)
+      RARCH_ERR("Error registering for notifications\n");
+
    video_driver_display_type_set(RARCH_DISPLAY_WIN32);
    video_driver_display_set(0);
    video_driver_window_set((uintptr_t)main_window.hwnd);
@@ -1145,6 +1159,7 @@ void win32_destroy_window(void)
 #ifndef _XBOX
    UnregisterClass("RetroArch", GetModuleHandle(NULL));
 #endif
+   UnregisterDeviceNotification(notification_handler);
    main_window.hwnd = NULL;
 }
 

--- a/input/drivers/dinput.c
+++ b/input/drivers/dinput.c
@@ -21,8 +21,6 @@
 #undef DIRECTINPUT_VERSION
 #define DIRECTINPUT_VERSION 0x0800
 
-#define DBT_DEVNODES_CHANGED 0x0007
-
 #ifndef WM_MOUSEHWHEEL
 #define WM_MOUSEHWHEEL 0x20e
 #endif
@@ -32,6 +30,7 @@
 #endif
 
 #include <dinput.h>
+#include <dbt.h>
 
 #include <stdlib.h>
 #include <stddef.h>
@@ -804,11 +803,17 @@ bool dinput_handle_message(void *dinput, UINT message, WPARAM wParam, LPARAM lPa
             return true;
          }
       case WM_DEVICECHANGE:
-            if (wParam == DBT_DEVNODES_CHANGED)
+            if (wParam == DBT_DEVICEARRIVAL  || wParam == DBT_DEVICEREMOVECOMPLETE)
             {
-               if (di->joypad)
-                  di->joypad->destroy();
-               di->joypad = input_joypad_init_driver(di->joypad_driver_name, di);
+               PDEV_BROADCAST_HDR pHdr = (PDEV_BROADCAST_HDR)lParam;
+               if( pHdr->dbch_devicetype == DBT_DEVTYP_DEVICEINTERFACE)
+               {
+                  PDEV_BROADCAST_DEVICEINTERFACE pDevInf = (PDEV_BROADCAST_DEVICEINTERFACE)pHdr;
+                  /* To-Do: Don't destroy everything, lets just handle new devices gracefully */
+                  if (di->joypad)
+                     di->joypad->destroy();
+                  di->joypad = input_joypad_init_driver(di->joypad_driver_name, di);
+               }
             }
          break;
       case WM_MOUSEWHEEL:

--- a/input/drivers/dinput.c
+++ b/input/drivers/dinput.c
@@ -806,9 +806,10 @@ bool dinput_handle_message(void *dinput, UINT message, WPARAM wParam, LPARAM lPa
             if (wParam == DBT_DEVICEARRIVAL  || wParam == DBT_DEVICEREMOVECOMPLETE)
             {
                PDEV_BROADCAST_HDR pHdr = (PDEV_BROADCAST_HDR)lParam;
-               if( pHdr->dbch_devicetype == DBT_DEVTYP_DEVICEINTERFACE)
+               if(pHdr->dbch_devicetype == DBT_DEVTYP_DEVICEINTERFACE)
                {
                   PDEV_BROADCAST_DEVICEINTERFACE pDevInf = (PDEV_BROADCAST_DEVICEINTERFACE)pHdr;
+
                   /* To-Do: Don't destroy everything, lets just handle new devices gracefully */
                   if (di->joypad)
                      di->joypad->destroy();


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises


## Description

The issue I mentioned in my last PR was still apparent when DLNA devices went away or came back, now it should only reinit when HID devices are detected 

## Reviewers
@twinaphex  @bparker06 
