### PR TITLE
xmb: Allow menu scale of 200%

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -5517,7 +5517,7 @@ static bool setting_append_list(
                   parent_group,
                   general_write_handler,
                   general_read_handler);
-            menu_settings_list_current_add_range(list, list_info, 0, 100, 1, true, true);
+            menu_settings_list_current_add_range(list, list_info, 0, 200, 1, true, true);
             settings_data_list_current_add_flags(list, list_info, SD_FLAG_LAKKA_ADVANCED);
 
             CONFIG_PATH(


### PR DESCRIPTION
## Description

This allows you to scale your menu to 200%. I've wanted it at 120% before.... This is helpful on super large monitors, TVs or projectors.

## Reviewers

- @fr500 
- @Kivutar 