### PR TITLE
Fix unofficial achievements not being loaded

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -3131,9 +3131,10 @@ static int cheevos_iterate(coro_t* coro)
    CORO_GOSUB(LOGIN);
 
    snprintf(CHEEVOS_VAR_URL, sizeof(CHEEVOS_VAR_URL),
-      "http://retroachievements.org/dorequest.php?r=patch&u=%s&g=%u&f=3&l=1&t=%s",
+      "http://retroachievements.org/dorequest.php?r=patch&u=%s&g=%u&f=%u&l=1&t=%s",
       CHEEVOS_VAR_SETTINGS->arrays.cheevos_username,
-      CHEEVOS_VAR_GAMEID, cheevos_locals.token);
+      CHEEVOS_VAR_GAMEID, CHEEVOS_VAR_SETTINGS->bools.cheevos_test_unofficial ? 0:3,
+      cheevos_locals.token);
 
       CHEEVOS_VAR_URL[sizeof(CHEEVOS_VAR_URL) - 1] = 0;
 


### PR DESCRIPTION
RetroArch is currently returning only achievements with flag 3 from the site, regardless of whether "Test Unofficial" is on or not. This change makes RetroArch return every achievement from the site when this the option is on, or only those marked with Flag 3 (core cheevos) when off.