### PR TITLE
config.libs.sh: reintroduce HAVE_X11 check

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -398,7 +398,7 @@ check_pkgconf FREETYPE freetype2
 check_pkgconf X11 x11
 check_pkgconf XCB xcb
 
-if [ "$OS" != 'Darwin' ]; then
+if [ "$HAVE_X11" != 'no' ] && [ "$OS" != 'Darwin' ]; then
    check_val '' X11 -lX11
 fi
 


### PR DESCRIPTION
Current behaviour would force check_val to check for X11 even if explicitly disabled.

Fixes Raspberry Pi build (which requires --disable-x11).