### PR TITLE
settings: Add Slow Motion Ratio granularity

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -4790,7 +4790,7 @@ static bool setting_append_list(
                parent_group,
                general_write_handler,
                general_read_handler);
-         menu_settings_list_current_add_range(list, list_info, 1, 10, 1.0, true, true);
+         menu_settings_list_current_add_range(list, list_info, 1, 10, 0.1, true, true);
 
          CONFIG_BOOL(
                list, list_info,


### PR DESCRIPTION



## Description
This makes it so that the Slow Motion setting can be set to something like 1.2, rather than 1 increments.

Fixes #5917

## Related Issues

- #5917 

## Reviewers 
@ofry