### PR TITLE
Makefile: Fix debug builds.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ ifneq ($(V),1)
    Q := @
 endif
 
-ifneq ($(DEBUG), 0)
+ifeq ($(DEBUG), 1)
    OPTIMIZE_FLAG = -O0 -g
 else
    OPTIMIZE_FLAG = -O3 -ffast-math


### PR DESCRIPTION
## Description

RetroArch builds debug builds by default after commit https://github.com/libretro/RetroArch/commit/ec4b0f90896d9cca2b9eaa0df0e9127b3ca5445d
This is very bad and breaks ./configure && make which would explicitly need `DEBUG=0`.

## Related Issues

Debug support should not be enabled if `DEBUG` is undefined.

## Related Pull Requests

https://github.com/libretro/RetroArch/commit/ec4b0f90896d9cca2b9eaa0df0e9127b3ca5445d

## Reviewers

@twinaphex, @alcaro, @bparker06
