### PR TITLE
Revert "config.libs.sh: reintroduce HAVE_X11 check"

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -395,16 +395,15 @@ fi
 
 check_pkgconf V4L2 libv4l2
 check_pkgconf FREETYPE freetype2
-check_pkgconf X11 x11
-check_pkgconf XCB xcb
 
-if [ "$OS" != 'Darwin' ]; then
+if [ "$HAVE_X11" != 'no' ]; then
+   check_pkgconf X11 x11
    check_val '' X11 -lX11
 fi
 
+check_pkgconf XCB xcb
 check_pkgconf WAYLAND wayland-egl
 check_pkgconf WAYLAND_CURSOR wayland-cursor
-
 check_pkgconf XKBCOMMON xkbcommon 0.3.2
 check_pkgconf DBUS dbus-1
 check_pkgconf XEXT xext

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -398,7 +398,7 @@ check_pkgconf FREETYPE freetype2
 check_pkgconf X11 x11
 check_pkgconf XCB xcb
 
-if [ "$HAVE_X11" != 'no' ] && [ "$OS" != 'Darwin' ]; then
+if [ "$OS" != 'Darwin' ]; then
    check_val '' X11 -lX11
 fi
 


### PR DESCRIPTION
Reverts libretro/RetroArch#5983

This commit is bad, not a solution and breaks builds without `pkg-config`, `check_val` is intended for specifically for when `HAVE_FOO=no`. Lets revert this and then come up with a proper fix. @psyke83 make an issue report explaining the problems with raspi and I will come up with a proper fix.