### PR TITLE
qb: Include /usr/local/include for bsd based systems.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -23,6 +23,7 @@ SOCKETLIB=-lc
 SOCKETHEADER=
 
 if [ "$OS" = 'BSD' ]; then
+   [ -d /usr/local/include ] && add_dirs INCLUDE /usr/local/include
    DYLIB=-lc;
 elif [ "$OS" = 'Haiku' ]; then
    DYLIB=""


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises


## Description

This resolves an issue where the default freebsd compiler does not
include /usr/local/include which contains important headers such as
GL/gl.h and results in the check_header function failing to find them.

Unfortunately pkg-config/pkgconf will not work here for two reasons.
1. It does not seem able to actually check for gl.h which RetroArch
explicitly needs.
2. Not all systems have a pkg-config implementation so we will still
have to fall back to checking for gl.h...

## Related Issues

Fixes https://github.com/libretro/RetroArch/issues/5958

## Related Pull Requests

N/A

## Reviewers

@twinaphex, @bparker06, @dariusc93