### PR TITLE
qb: Include /usr/local/lib for *bsd too

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -24,6 +24,7 @@ SOCKETHEADER=
 
 if [ "$OS" = 'BSD' ]; then
    [ -d /usr/local/include ] && add_dirs INCLUDE /usr/local/include
+   [ -d /usr/local/lib ] && add_dirs LIBRARY /usr/local/lib
    DYLIB=-lc;
 elif [ "$OS" = 'Haiku' ]; then
    DYLIB=""


### PR DESCRIPTION
## Description

Warning, untested, wait for @dariusc93 confirm it works.

If `$OS = BSD` it includes `/usr/local/lib` in `$LIBRARY_DIRS` since freebsd and maybe some other bsd systems does not include it in their default compilers.

## Related Issues

https://github.com/libretro/RetroArch/issues/5958

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/5991

## Reviewers

@twinaphex, @bparker06, @dariusc93