### PR TITLE
gitignore: Add .tmp and .tmp.c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 *.elf
 *.dol
 *.map
+.tmp
+.tmp.c
 config.log
 /retroarch
 /retroarch.cfg


### PR DESCRIPTION
## Description

These are test programs for checking if features can be enabled and should not be committed.

## Related Issues

N/A

## Related Pull Requests

This was cherry-picked from PR https://github.com/libretro/RetroArch/pull/5998 given that PR still needs work and this commit is ready to go and not really connected.

## Reviewers

@twinaphex