### PR TITLE
gitignore: Add .tmp.cxx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.map
 .tmp
 .tmp.c
+.tmp.cxx
 config.log
 /retroarch
 /retroarch.cfg


### PR DESCRIPTION
## Description

Adds `.tmp.cxx` which is another temporary file from configure which I missed in the last PR.

## Related Issues

N/A

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/5999

## Reviewers

@twinaphex
