### PR TITLE
qb: Improve the check_val function.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1348,49 +1348,34 @@ ifeq ($(HAVE_IBXM), 1)
    OBJ += $(DEPS_DIR)/ibxm/ibxm.o
 endif
 
-ifeq ($(HAVE_FLAC),1)
-   DEFINES += -DHAVE_FLAC
-   ifeq ($(HAVE_BUILTINFLAC),1)
-      CFLAGS  += -I$(DEPS_DIR)/libFLAC/include
-      DEFINES += -DHAVE_STDINT_H -DHAVE_LROUND -DFLAC__HAS_OGG=0 \
-                 -DFLAC_PACKAGE_VERSION="\"retroarch\""
-      FLACOBJ = $(DEPS_DIR)/libFLAC/bitmath.o \
-                $(DEPS_DIR)/libFLAC/bitreader.o \
-                $(DEPS_DIR)/libFLAC/cpu.o \
-                $(DEPS_DIR)/libFLAC/crc.o \
-                $(DEPS_DIR)/libFLAC/fixed.o \
-                $(DEPS_DIR)/libFLAC/float.o \
-                $(DEPS_DIR)/libFLAC/format.o \
-                $(DEPS_DIR)/libFLAC/lpc.o \
-                $(DEPS_DIR)/libFLAC/lpc_intrin_avx2.o \
-                $(DEPS_DIR)/libFLAC/lpc_intrin_sse2.o \
-                $(DEPS_DIR)/libFLAC/lpc_intrin_sse41.o \
-                $(DEPS_DIR)/libFLAC/lpc_intrin_sse.o \
-                $(DEPS_DIR)/libFLAC/md5.o \
-                $(DEPS_DIR)/libFLAC/memory.o \
-                $(DEPS_DIR)/libFLAC/stream_decoder.o
-      ifneq ($(findstring Win32,$(OS)),)
-         DEFINES += -DHAVE_FSEEKO
-         # make sure not to use this on legacy Windows versions that don't have W-functions implemented
-         DEFINES += -DNEED_UTF8_SUPPORT
-         FLACOBJ += $(DEPS_DIR)/libFLAC/windows_unicode_filenames.o
-      endif
-      OBJ += $(FLACOBJ)
-   else
-      LIBS += $(FLAC_LIBS)
+ifeq ($(HAVE_BUILTINFLAC),1)
+   CFLAGS  += -DHAVE_FLAC -I$(DEPS_DIR)/libFLAC/include
+   DEFINES += -DHAVE_STDINT_H -DHAVE_LROUND -DFLAC__HAS_OGG=0 \
+              -DFLAC_PACKAGE_VERSION="\"retroarch\""
+   FLACOBJ = $(DEPS_DIR)/libFLAC/bitmath.o \
+             $(DEPS_DIR)/libFLAC/bitreader.o \
+             $(DEPS_DIR)/libFLAC/cpu.o \
+             $(DEPS_DIR)/libFLAC/crc.o \
+             $(DEPS_DIR)/libFLAC/fixed.o \
+             $(DEPS_DIR)/libFLAC/float.o \
+             $(DEPS_DIR)/libFLAC/format.o \
+             $(DEPS_DIR)/libFLAC/lpc.o \
+             $(DEPS_DIR)/libFLAC/lpc_intrin_avx2.o \
+             $(DEPS_DIR)/libFLAC/lpc_intrin_sse2.o \
+             $(DEPS_DIR)/libFLAC/lpc_intrin_sse41.o \
+             $(DEPS_DIR)/libFLAC/lpc_intrin_sse.o \
+             $(DEPS_DIR)/libFLAC/md5.o \
+             $(DEPS_DIR)/libFLAC/memory.o \
+             $(DEPS_DIR)/libFLAC/stream_decoder.o
+   ifneq ($(findstring Win32,$(OS)),)
+      DEFINES += -DHAVE_FSEEKO
+      # make sure not to use this on legacy Windows versions that don't have W-functions implemented
+      DEFINES += -DNEED_UTF8_SUPPORT
+      FLACOBJ += $(DEPS_DIR)/libFLAC/windows_unicode_filenames.o
    endif
-   ifeq ($(HAVE_7ZIP), 1)
-   ifeq ($(HAVE_ZLIB), 1)
-      DEFINES += -DHAVE_CHD -DWANT_SUBCODE -DWANT_RAW_DATA_SECTOR
-      CFLAGS  += -I$(LIBRETRO_COMM_DIR)/formats/libchdr
-      OBJ     += $(LIBRETRO_COMM_DIR)/formats/libchdr/bitstream.o \
-                 $(LIBRETRO_COMM_DIR)/formats/libchdr/cdrom.o \
-                 $(LIBRETRO_COMM_DIR)/formats/libchdr/chd.o \
-                 $(LIBRETRO_COMM_DIR)/formats/libchdr/flac.o \
-                 $(LIBRETRO_COMM_DIR)/formats/libchdr/huffman.o \
-                 $(LIBRETRO_COMM_DIR)/streams/chd_stream.o
-   endif
-   endif
+   OBJ += $(FLACOBJ)
+else ifeq ($(HAVE_FLAC),1)
+   LIBS += $(FLAC_LIBS)
 endif
 
 ifeq ($(HAVE_ZLIB), 1)
@@ -1418,6 +1403,21 @@ ifeq ($(HAVE_ZLIB), 1)
    else
       LIBS += $(ZLIB_LIBS)
    endif
+endif
+
+ifeq ($(HAVE_FLAC), 1)
+ifeq ($(HAVE_7ZIP), 1)
+ifeq ($(HAVE_ZLIB), 1)
+   DEFINES += -DHAVE_CHD -DWANT_SUBCODE -DWANT_RAW_DATA_SECTOR
+   CFLAGS  += -I$(LIBRETRO_COMM_DIR)/formats/libchdr
+   OBJ     += $(LIBRETRO_COMM_DIR)/formats/libchdr/bitstream.o \
+              $(LIBRETRO_COMM_DIR)/formats/libchdr/cdrom.o \
+              $(LIBRETRO_COMM_DIR)/formats/libchdr/chd.o \
+              $(LIBRETRO_COMM_DIR)/formats/libchdr/flac.o \
+              $(LIBRETRO_COMM_DIR)/formats/libchdr/huffman.o \
+              $(LIBRETRO_COMM_DIR)/streams/chd_stream.o
+endif
+endif
 endif
 
 ifeq ($(HAVE_RTGA), 1)

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -275,12 +275,10 @@ fi
 
 if [ "$HAVE_FLAC" = 'no' ]; then
    HAVE_BUILTINFLAC=no
-elif [ "$HAVE_BUILTINFLAC" = 'yes' ]; then
-   HAVE_FLAC=yes
-else
-   check_pkgconf FLAC flac
-   check_val '' FLAC '-lFLAC'
 fi
+
+check_pkgconf FLAC flac
+check_val '' FLAC '-lFLAC'
 
 check_pkgconf LIBUSB libusb-1.0 1.0.13
 

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -389,10 +389,8 @@ if [ "$HAVE_EGL" = "yes" ]; then
          fi
       fi
    fi
-   if [ "$HAVE_VG" != "no" ]; then
-      check_pkgconf VG "$VC_PREFIX"vg
-      check_val '' VG "-l${VC_PREFIX}OpenVG $EXTRA_GL_LIBS"
-   fi
+   check_pkgconf VG "$VC_PREFIX"vg
+   check_val '' VG "-l${VC_PREFIX}OpenVG $EXTRA_GL_LIBS"
 else
    HAVE_VG=no
    HAVE_OPENGLES=no
@@ -400,12 +398,7 @@ fi
 
 check_pkgconf V4L2 libv4l2
 check_pkgconf FREETYPE freetype2
-
-if [ "$HAVE_X11" != 'no' ]; then
-   check_pkgconf X11 x11
-   check_val '' X11 -lX11
-fi
-
+check_pkgconf X11 x11
 check_pkgconf XCB xcb
 check_pkgconf WAYLAND wayland-egl
 check_pkgconf WAYLAND_CURSOR wayland-cursor
@@ -414,14 +407,16 @@ check_pkgconf DBUS dbus-1
 check_pkgconf XEXT xext
 check_pkgconf XF86VM xxf86vm
 
-if [ "$HAVE_X11" != "no" ]; then
-   check_val '' XEXT -lXext
-   check_val '' XF86VM -lXxf86vm
-else
+check_val '' X11 -lX11
+check_val '' XEXT -lXext
+check_val '' XF86VM -lXxf86vm
+
+if [ "$HAVE_X11" = "no" ]; then
    HAVE_XEXT=no; HAVE_XF86VM=no; HAVE_XINERAMA=no; HAVE_XSHM=no
 fi
 
 check_pkgconf XINERAMA xinerama
+
 if [ "$HAVE_X11" = 'yes' ] && [ "$HAVE_XEXT" = 'yes' ] && [ "$HAVE_XF86VM" = 'yes' ]; then
    check_pkgconf XVIDEO xv
 else
@@ -430,19 +425,17 @@ else
    HAVE_XVIDEO='no'
 fi
 
-if [ "$HAVE_UDEV" != "no" ]; then
-   check_pkgconf UDEV libudev
-   check_val '' UDEV "-ludev"
-fi
+check_pkgconf UDEV libudev
+check_val '' UDEV "-ludev"
 
 check_header XSHM X11/Xlib.h X11/extensions/XShm.h
-
 check_header PARPORT linux/parport.h
 check_header PARPORT linux/ppdev.h
 
 if [ "$OS" != 'Win32' ] && [ "$OS" != 'Linux' ]; then
    check_lib '' STRL "$CLIB" strlcpy
 fi
+
 check_lib '' STRCASESTR "$CLIB" strcasestr
 check_lib '' MMAP "$CLIB" mmap
 check_lib '' VULKAN -lvulkan vkCreateInstance

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -261,6 +261,8 @@ check_pkgconf PULSE libpulse
 check_pkgconf SDL sdl 1.2.10
 check_pkgconf SDL2 sdl2 2.0.0
 
+check_val '' JACK -ljack
+
 if [ "$HAVE_SDL2" = 'yes' ]; then
    if [ "$HAVE_SDL2" = 'yes' ] && [ "$HAVE_SDL" = 'yes' ]; then
       die : 'Notice: SDL drivers will be replaced by SDL2 ones.'

--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -70,6 +70,7 @@ check_lib() # $1 = language  $2 = HAVE_$2  $3 = lib  $4 = function in lib  $5 = 
 
 check_pkgconf() # $1 = HAVE_$1  $2 = package  $3 = version  $4 = critical error message [checked only if non-empty]
 {	tmpval="$(eval "printf %s \"\$HAVE_$1\"")"
+	eval "TMP_$1=\$tmpval"
 	[ "$tmpval" = 'no' ] && return 0
 
 	ECHOBUF="Checking presence of package $2"
@@ -161,9 +162,14 @@ check_switch() # $1 = language  $2 = HAVE_$2  $3 = switch  $4 = critical error m
 
 check_val() # $1 = language  $2 = HAVE_$2  $3 = lib
 {	tmpval="$(eval "printf %s \"\$HAVE_$2\"")"
-	if [ "$tmpval" = 'no' ]; then
+	oldval="$(eval "printf %s \"\$TMP_$2\"")"
+	if [ "$tmpval" = 'no' ] && [ "$oldval" != 'no' ]; then
 		eval "HAVE_$2=auto"
 		check_lib "$1" "$2" "$3"
+
+		if [ "$answer" = 'no' ] && [ "$oldval" = 'yes' ]; then
+			die 1 "Forced to build with library $lib, but cannot locate. Exiting ..."
+		fi
 	fi
 }
 


### PR DESCRIPTION
## Description

Please wait for a user like @psyke83 to test this for the raspi before merging to make sure I did not miss anything.

This accomplishes two things for the fallback path without pkg-config.

1. If --disable-foo is passed to configure it will explicitly skip check_val. This has the benefit of reducing checks in qb/config.libs.sh which are easy to break due to human error.
2. When a fallback path exists and --enable-foo is passed to configure, but fails due to the missing -lfoo check_val will now bail and print a configure error. However --enable-foo will still be ignored if there is no fallback path and pkg-config is not installed.

One issue with this is that if pkg-config is installed and the package foo is not, it will still check if -lfoo works. As not all pkg-config implemenations can be trusted to work even if they exist this seems unavoidable.

The second commit is included as a proof of concept for these changes.

## Related Issues

Fixes three things for the fallback path without pkg-config.
1. Reduces many tests in `qb/config.libs.sh` which are easy to cause issues if not implemented correctly,
2. If using the fall-back path without pkg-config and package foo does not exist, it will exit and print a configure error if `--enable-foo` is passed to configure.
3. It adds fallback detection for jack, this is mostly a proof of concept.

## Related Pull Requests

These are idea incorporated from PR https://github.com/libretro/RetroArch/pull/5998, given the issues in that PR I think its best to do it a few steps at a time and then rebase that PR after the fact. This will make it easier to test, bisect and review.

Also see #5983 #5990

## Reviewers

@psyke83
