### PR TITLE
qb: Fix --disable-oss for openbsd.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -228,9 +228,12 @@ fi
 
 check_pkgconf ALSA alsa
 check_lib '' CACA -lcaca
-check_header OSS sys/soundcard.h
-check_header OSS_BSD soundcard.h
-check_lib '' OSS_LIB -lossaudio
+
+if [ "$HAVE_OSS" != 'no' ]; then
+   check_header OSS sys/soundcard.h
+   check_header OSS_BSD soundcard.h
+   check_lib '' OSS_LIB -lossaudio
+fi
 
 if [ "$OS" = 'Linux' ]; then
    HAVE_TINYALSA=yes


### PR DESCRIPTION
## Description

If `--disable-oss` is passed to configure we should not check for any oss support.

## Related Issues

Apparently `--disable-oss` didn't work for openbsd and maybe elsewhere.

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/6007

## Reviewers

@twinaphex, @bparker06, @devnexen 
