### PR TITLE
Fix a couple crash bugs

### DIFF
--- a/wiiu/input/wiiu_hid.c
+++ b/wiiu/input/wiiu_hid.c
@@ -425,6 +425,7 @@ static void wiiu_hid_read_loop_callback(uint32_t handle, int32_t error,
  */
 static void wiiu_hid_polling_thread_cleanup(OSThread *thread, void *stack) {
   int incomplete = 0;
+  int retries = 0;
   wiiu_adapter_t *adapter;
   RARCH_LOG("Waiting for in-flight reads to finish.\n");
   do {
@@ -446,8 +447,11 @@ static void wiiu_hid_polling_thread_cleanup(OSThread *thread, void *stack) {
     }
     OSFastMutex_Unlock(&(adapters.lock));
     if(incomplete) {
-      RARCH_LOG("%d unfinished adapters found, waiting 1ms\n", incomplete);
-      usleep(1000);
+      usleep(5000);
+    }
+    if(++retries >= 1000) {
+      RARCH_WARN("[hid]: timed out waiting for in-flight read to finish.\n");
+      incomplete = 0;
     }
   } while(incomplete);
   RARCH_LOG("All in-flight reads complete.\n");


### PR DESCRIPTION
## Description

Fixes a couple crash bugs, one is specific to WiiU

1. [HID] Fix the iterators in `joypad_connection.c` so they use the new end-of-list marker; this fixes a crash when iterating over a list that is <MAX_USERS long.
2. [WIIU] Found a crash situation where the HID thread shutdown gets deadlocked if a call to HIDRead() blocks indefinitely.

## Reviewers

@twinaphex
