### PR TITLE
C89_BUILD=1 build fix

### DIFF
--- a/libretro-common/audio/resampler/drivers/sinc_resampler.c
+++ b/libretro-common/audio/resampler/drivers/sinc_resampler.c
@@ -56,7 +56,7 @@ enum sinc_window
 {
    SINC_WINDOW_NONE   = 0,
    SINC_WINDOW_KAISER,
-   SINC_WINDOW_LANCZOS,
+   SINC_WINDOW_LANCZOS
 };
 
 /* For the little amount of taps we're using,

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -199,11 +199,9 @@ if [ "$HAVE_NETWORKING" = 'yes' ]; then
 
    if [ "$HAVE_MINIUPNPC" = 'no' ]; then
       HAVE_BUILTINMINIUPNPC=no
-   elif [ "$HAVE_BUILTINMINIUPNPC" = 'yes' ]; then
-      HAVE_MINIUPNPC=yes
-   else
-      check_lib '' MINIUPNPC '-lminiupnpc'
    fi
+
+   check_lib '' MINIUPNPC '-lminiupnpc'
 else
    die : 'Warning: All networking features have been disabled.'
    HAVE_KEYMAPPER='no'


### PR DESCRIPTION
## Description

One trivial fix for `C89_BUILD=1`.

## Related Issues

```
libretro-common/audio/resampler/drivers/sinc_resampler.c:59:23: error: comma at end of enumerator list [-Werror=pedantic]
    SINC_WINDOW_LANCZOS,
                       ^
cc1: some warnings being treated as errors
make: *** [Makefile:164: obj-unix/./libretro-common/audio/resampler/drivers/sinc_resampler.o] Error 1
```

## Related Pull Requests

N/A

## Reviewers

@twinaphex