### PR TITLE
Makefile.common: Don't enable vulkan if the user disabled it.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -686,14 +686,6 @@ ifeq ($(HAVE_NEON),1)
           $(LIBRETRO_COMM_DIR)/audio/conversion/float_to_s16_neon.o
 endif
 
-ifneq ($(findstring Win32,$(OS)),)
-   # if user explicitly sets --disable-vulkan on Windows, then disable it
-   ifneq ($(HAVE_NO_VULKAN),1)
-      HAVE_VULKAN=1
-      DEFINES += -DHAVE_VULKAN
-   endif
-endif
-
 HW_CONTEXT_MENU_DRIVERS=$(HAVE_RGUI)
 
 ifeq ($(HW_CONTEXT_MENU_DRIVERS),0)

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -436,7 +436,12 @@ fi
 
 check_lib '' STRCASESTR "$CLIB" strcasestr
 check_lib '' MMAP "$CLIB" mmap
-check_lib '' VULKAN -lvulkan vkCreateInstance
+
+if [ "$HAVE_VULKAN" != "no" ] && [ "$OS" = 'Win32' ]; then
+   HAVE_VULKAN=yes
+else
+   check_lib '' VULKAN -lvulkan vkCreateInstance
+fi
 
 check_pkgconf PYTHON python3
 


### PR DESCRIPTION
## Description

This breaks `--disable-vulkan` and `C89_BUILD=1` build for windows. I have really no idea why this was done in the first place, but it does not seem like a good idea...

## Related Issues

CXX code was built with `C89_BUILD=1` for windows.

## Related Pull Requests

N/A

## Reviewers

@twinaphex, @fr500
