### PR TITLE
Remove Music/Movies/... entrys from directory list and fixes

### DIFF
--- a/frontend/drivers/platform_ctr.c
+++ b/frontend/drivers/platform_ctr.c
@@ -376,7 +376,6 @@ static void frontend_ctr_init(void *data)
 #endif
 }
 
-
 static int frontend_ctr_get_rating(void)
 {
    u8 device_model = 0xFF;
@@ -388,7 +387,7 @@ static int frontend_ctr_get_rating(void)
       case 1:
       case 3:
          /*Old 3/2DS*/
-         break;
+         return 3;
 
       case 2:
       case 4:
@@ -401,7 +400,7 @@ static int frontend_ctr_get_rating(void)
          break;
    }
 
-   return 3;
+   return -1;
 }
 
 enum frontend_architecture frontend_ctr_get_architecture(void)

--- a/libretro-common/features/features_cpu.c
+++ b/libretro-common/features/features_cpu.c
@@ -500,8 +500,9 @@ unsigned cpu_features_get_core_amount(void)
 	   
 		default:
 			/*Unknown Device Or Check Failed*/
-			return 1;
+			break;
    }
+   return 1;
 #elif defined(WIIU)
    return 3;
 #elif defined(_SC_NPROCESSORS_ONLN)

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -36,9 +36,8 @@
 #include "../../config.h"
 #endif
 
-#ifndef HAVE_DYNAMIC
+//this is needed regardless of HAVE_DYNAMIC because of frontend_driver_parse_drive_list
 #include "../../frontend/frontend_driver.h"
-#endif
 
 #include "menu_generic.h"
 

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -6108,32 +6108,6 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, void *data)
       case DISPLAYLIST_LOAD_CONTENT_SPECIAL:
          menu_entries_ctl(MENU_ENTRIES_CTL_CLEAR, info->list);
 
-         menu_entries_append_enum(info->list,
-               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_GOTO_FAVORITES),
-               msg_hash_to_str(MENU_ENUM_LABEL_GOTO_FAVORITES),
-               MENU_ENUM_LABEL_GOTO_FAVORITES,
-               MENU_SETTING_ACTION, 0, 0);
-
-         menu_entries_append_enum(info->list,
-               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_GOTO_IMAGES),
-               msg_hash_to_str(MENU_ENUM_LABEL_GOTO_IMAGES),
-               MENU_ENUM_LABEL_GOTO_IMAGES,
-               MENU_SETTING_ACTION, 0, 0);
-
-         menu_entries_append_enum(info->list,
-               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_GOTO_MUSIC),
-               msg_hash_to_str(MENU_ENUM_LABEL_GOTO_MUSIC),
-               MENU_ENUM_LABEL_GOTO_MUSIC,
-               MENU_SETTING_ACTION, 0, 0);
-
-#ifdef HAVE_FFMPEG
-         menu_entries_append_enum(info->list,
-               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_GOTO_VIDEO),
-               msg_hash_to_str(MENU_ENUM_LABEL_GOTO_VIDEO),
-               MENU_ENUM_LABEL_GOTO_VIDEO,
-               MENU_SETTING_ACTION, 0, 0);
-#endif
-
          if (!string_is_empty(settings->paths.directory_menu_content))
             menu_entries_append_enum(info->list,
                   msg_hash_to_str(MENU_ENUM_LABEL_VALUE_FAVORITES),


### PR DESCRIPTION
Fix potential switch statement never returns compiler warning, wont rate an unknown 3DS device as Old 3DS in retro ratings.
Music/Movies/Images/Favorites still exist as playlists in "Load Content"->"Collections" like they should but no longer as content folders which they arnt.
