### PR TITLE
Hide mouse after SET_SYSTEM_AV_INFO (please Check before merge)

### DIFF
--- a/driver.c
+++ b/driver.c
@@ -289,6 +289,7 @@ void driver_set_nonblock_state(void)
 static bool driver_update_system_av_info(const struct retro_system_av_info *info)
 {
    struct retro_system_av_info *av_info    = video_viewport_get_system_av_info();
+   settings_t *settings = config_get_ptr();
 
    memcpy(av_info, info, sizeof(*av_info));
    command_event(CMD_EVENT_REINIT, NULL);
@@ -306,7 +307,6 @@ static bool driver_update_system_av_info(const struct retro_system_av_info *info
 
    /* Hide mouse cursor in fullscreen after 
     * a RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO call. */
-   settings_t *settings = config_get_ptr();
    if (settings->bools.video_fullscreen)
       video_driver_hide_mouse();
 

--- a/driver.c
+++ b/driver.c
@@ -304,6 +304,12 @@ static bool driver_update_system_av_info(const struct retro_system_av_info *info
       command_event(CMD_EVENT_RECORD_INIT, NULL);
    }
 
+   /* Hide mouse cursor in fullscreen after 
+    * a RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO call. */
+   settings_t *settings = config_get_ptr();
+   if (settings->bools.video_fullscreen)
+      video_driver_hide_mouse();
+
    return true;
 }
 


### PR DESCRIPTION
Hide mouse cursor after RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO in fullcreen.

It fixes https://github.com/libretro/mame/issues/52 in Mame and probably
https://github.com/libretro/RetroArch/issues/4586 too (haven't found another core to test with that issue but Mame on my side).

Tested on win7 x64, only hides the cursor in fullscreen.