### PR TITLE
show the menu entries when no achievements found even if hardcore mod…

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -2588,7 +2588,7 @@ static int menu_displaylist_parse_load_content_settings(
       }
 
       if (settings->bools.quick_menu_show_save_load_state &&
-          ! settings->bools.cheevos_hardcore_mode_enable)
+          !(settings->bools.cheevos_hardcore_mode_enable && cheevos_loaded))
       {
          menu_displaylist_parse_settings_enum(menu, info,
                MENU_ENUM_LABEL_STATE_SLOT, PARSE_ONLY_INT, true);
@@ -2608,7 +2608,7 @@ static int menu_displaylist_parse_load_content_settings(
 
       if (settings->bools.quick_menu_show_save_load_state &&
           settings->bools.quick_menu_show_undo_save_load_state &&
-          ! settings->bools.cheevos_hardcore_mode_enable)
+          !(settings->bools.cheevos_hardcore_mode_enable && cheevos_loaded))
       {
          menu_entries_append_enum(info->list,
                msg_hash_to_str(MENU_ENUM_LABEL_VALUE_UNDO_LOAD_STATE),


### PR DESCRIPTION
…e is enabled)

## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises


## Description

The hotkeys were working but the menu entries weren't being shown when hardcore mode was enabled and achievements weren't found

