### PR TITLE
Makefile.common: Don't hardcode -g

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ ifneq ($(findstring Win32,$(OS)),)
    LDFLAGS += -mwindows
 endif
 
-CFLAGS   += -Wall $(OPTIMIZE_FLAG) $(INCLUDE_DIRS) $(DEBUG_FLAG) -I. -Ideps -Ideps/stb
+CFLAGS   += -Wall $(OPTIMIZE_FLAG) $(INCLUDE_DIRS) -I. -Ideps -Ideps/stb
 
 APPEND_CFLAGS := $(CFLAGS)
 CXXFLAGS += $(APPEND_CFLAGS) -std=c++11 -D__STDC_CONSTANT_MACROS

--- a/Makefile.common
+++ b/Makefile.common
@@ -133,11 +133,8 @@ endif
 
 ifeq ($(findstring Haiku,$(OS)),)
    LIBS += -lm
-   DEBUG_FLAG = -g
 else
    LIBS += -lroot -lnetwork
-   # stable and nightly haiku builds are stuck on gdb 6.x but we use gcc4
-   DEBUG_FLAG = -gdwarf-2
 endif
 
 # Git


### PR DESCRIPTION
## Description

Its not good practice to hardcode `-g` which is should be only used with `DEBUG=1` (Which is already true). So this removes `DEBUG_FLAGS` and relies on the already existing `DEBUG=1` check in the `Makefile`. I'm not sure why haiku is hardcoding `-gdwarf-2` instead of just using `-g` and the comment doesn't really explain this, in the event their default compilers don't work with `-g` that is really their bug...

## Related Issues

Release builds are currently hardcoding `-g`, this stops that and removes a redundant `-g` when building with `DEBUG=1`.

## Related Pull Requests

N/A

## Reviewers

@twinaphex, @bparker06, @extrowerk
