### PR TITLE
Makefile: Define GL_DEBUG=1 and VULKAN_DEBUG=1 with DEBUG=1.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,14 @@ ifneq ($(findstring Win32,$(OS)),)
    LDFLAGS += -static-libgcc -lwinmm
 endif
 
+ifeq ($(DEBUG), 1)
+   OPTIMIZE_FLAG = -O0 -g
+   GL_DEBUG = 1
+   VULKAN_DEBUG = 1
+else
+   OPTIMIZE_FLAG = -O3 -ffast-math
+endif
+
 include Makefile.common
 
 ifeq ($(shell $(CC) -v 2>&1 | grep -c "clang"),1)
@@ -67,12 +75,6 @@ endif
 
 ifneq ($(V),1)
    Q := @
-endif
-
-ifeq ($(DEBUG), 1)
-   OPTIMIZE_FLAG = -O0 -g
-else
-   OPTIMIZE_FLAG = -O3 -ffast-math
 endif
 
 ifneq ($(findstring Win32,$(OS)),)


### PR DESCRIPTION
## Description

When building with `DEBUG=1` it defines `GL_DEBUG=1` and `VULKAN_DEBUG=1` too. I think these defines should do nothing if built without `gl` or `vulkan`.

## Related Issues

No longer requires `make DEBUG=1 GL_DEBUG=1 VULKAN_DEBUG=1` where just `make DEBUG=1` can be used now.

## Related Pull Requests

N/A

## Reviewers

@twinaphex, @Alcaro, @bparker06