### PR TITLE
Fix wiiu touchpad scaling

### DIFF
--- a/wiiu/include/wiiu/pad_driver.h
+++ b/wiiu/include/wiiu/pad_driver.h
@@ -36,7 +36,6 @@
 #include "../../retroarch.h"
 #include "../../verbosity.h"
 #include "../../command.h"
-#include "../../gfx/video_driver.h"
 
 /**
  * Magic button sequence that triggers an exit. Useful for if the visuals are

--- a/wiiu/input/wpad_driver.c
+++ b/wiiu/input/wpad_driver.c
@@ -49,56 +49,54 @@ static int16_t scale_touchpad(int16_t from_min, int16_t from_max,
   return (((value - from_min) * to_range) / from_range) + to_min;
 }
 
+#if 0
+/**
+ * Get absolute value of a signed integer using bit manipulation.
+ */
+static int16_t bitwise_abs(int16_t value)
+{
+  bool is_negative = value & 0x8000;
+  if(!is_negative)
+    return value;
 
-static void get_calibrated_point(VPADTouchData *point, struct video_viewport *viewport, VPADStatus *vpad)
+  value = value &~ 0x8000;
+  return ~value & 0x7fff;
+}
+
+/**
+ * printf doesn't have a concept of a signed hex digit, so we fake it.
+ */
+static void log_coords(int16_t x, int16_t y)
+{
+  bool x_negative = x & 0x8000;
+  bool y_negative = y & 0x8000;
+
+  int16_t x_digit = bitwise_abs(x);
+  int16_t y_digit = bitwise_abs(y);
+
+  RARCH_LOG("[wpad]: calibrated point: %s%04x, %s%04x\n",
+    x_negative ? "-" : "",
+    x_digit,
+    y_negative ? "-" : "",
+    y_digit);
+}
+#endif
+
+static void get_calibrated_point(VPADTouchData *point, VPADStatus *vpad)
 {
    VPADTouchData calibrated720p = {0};
 
    VPADGetTPCalibratedPoint(PAD_GAMEPAD, &calibrated720p, &(vpad->tpNormal));
-   point->x = scale_touchpad(12, 1268, 0, viewport->full_width, calibrated720p.x);
-   point->y = scale_touchpad(12, 708, 0, viewport->full_height, calibrated720p.y);
-}
-
-static void apply_clamping(VPADTouchData *point, struct video_viewport *viewport, bool *clamped)
-{
-  /* clamp the x domain to the viewport */
-  if(point->x < viewport->x)
-  {
-    point->x = viewport->x;
-    *clamped = true;
-  }
-  else if(point->x > (viewport->x + viewport->width))
-  {
-    point->x = viewport->x + viewport->width;
-    *clamped = true;
-  }
-  
-  /* clamp the y domain to the viewport */
-  if(point->y < viewport->y)
-  {
-    point->y = viewport->y;
-    *clamped = true;
-  }
-  else if(point->y > (viewport->y + viewport->height))
-  {
-    point->y =  viewport->y + viewport->height;
-    *clamped = true;
-  }
-}
-
-static void get_touch_coordinates(VPADTouchData *point, VPADStatus *vpad,  bool *clamped)
-{
-  struct video_viewport viewport = {0};
-
-  video_driver_get_viewport_info(&viewport);
-  get_calibrated_point(point, &viewport, vpad);
-  apply_clamping(point, &viewport, clamped);
+   point->x = scale_touchpad(12, 1268, -0x7fff, 0x7fff, calibrated720p.x);
+   point->y = scale_touchpad(12, 708, -0x7fff, 0x7fff, calibrated720p.y);
+#if 0
+   log_coords(point->x, point->y);
+#endif
 }
 
 static void update_touch_state(int16_t state[3][2], uint64_t *buttons, VPADStatus *vpad)
 {
    VPADTouchData point = {0};
-   bool touch_clamped = false;
 
    if(!vpad->tpNormal.touched || vpad->tpNormal.validity != VPAD_VALID)
    {
@@ -106,15 +104,12 @@ static void update_touch_state(int16_t state[3][2], uint64_t *buttons, VPADStatu
       return;
    }
 
-   get_touch_coordinates(&point, vpad, &touch_clamped);
+   get_calibrated_point(&point, vpad);
 
    state[WIIU_DEVICE_INDEX_TOUCHPAD][RETRO_DEVICE_ID_ANALOG_X] = point.x;
    state[WIIU_DEVICE_INDEX_TOUCHPAD][RETRO_DEVICE_ID_ANALOG_Y] = point.y;
 
-   if(!touch_clamped)
-      *buttons |= VPAD_BUTTON_TOUCH;
-   else
-      *buttons &= ~VPAD_BUTTON_TOUCH;
+   *buttons |= VPAD_BUTTON_TOUCH;
 }
 
 static void check_panic_button(uint32_t held_buttons)


### PR DESCRIPTION
== DETAILS

Apparently when I refactored this code, I missed out on the fix for
touchpad coordinates that @QuarkTheAwesome had committed.

Oops.

- Fix the touchpad coordinates
- Remove unneeded references to video driver in wpad_driver.c
- Remove unneeded video driver include in pad_driver.h
- Add logging in wpad_driver to verify the fix (#ifdef'd out by default)

== TESTING

Verified fix manually.

## Reviewers
@QuarkTheAwesome @twinaphex @r-type 
