### PR TITLE
C89_BUILD: Remove c++ style comments

### DIFF
--- a/gfx/drivers/gl_shaders/pipeline_snow.glsl.frag.h
+++ b/gfx/drivers/gl_shaders/pipeline_snow.glsl.frag.h
@@ -4,9 +4,9 @@ static const char* stock_fragment_xmb_snow = GLSL(
    uniform float time;
    uniform vec2 OutputSize;
 
-   float baseScale = 3.5;  //  [1.0  .. 10.0]
-   float density   = 0.7;  //  [0.01 ..  1.0]
-   float speed     = 0.25; //  [0.1  ..  1.0]
+   float baseScale = 3.5;  /* [1.0  .. 10.0] */
+   float density   = 0.7;  /* [0.01 ..  1.0] */
+   float speed     = 0.25; /* [0.1  ..  1.0] */
 
    float rand(vec2 co)
    {
@@ -39,9 +39,9 @@ static const char* stock_fragment_xmb_snow = GLSL(
 
    float snow(vec2 pos, float time, float scale)
    {
-      // add wobble
+      /* add wobble */
       pos.x += cos(pos.y * 1.2 + time * 3.14159 * 2.0 + 1.0 / scale) / (8.0 / scale) * 4.0;
-      // add gravity
+      /* add gravity */
       pos += time * scale * vec2(-0.5, 1.0) * 4.0;
       return random_dots(pos / scale) * (scale * 0.5 + 0.5);
    }
@@ -51,9 +51,11 @@ static const char* stock_fragment_xmb_snow = GLSL(
       float tim = time * 0.4 * speed;
       vec2 pos = gl_FragCoord.xy / OutputSize.xx;
       float a = 0.0;
-      // Each of these is a layer of snow
-      // Remove some for better performance
-      // Changing the scale (3rd value) will mess with the looping
+      /**
+       * Each of these is a layer of snow
+       * Remove some for better performance
+       * Changing the scale (3rd value) will mess with the looping
+       **/
       a += snow(pos, tim, 1.0);
       a += snow(pos, tim, 0.7);
       a += snow(pos, tim, 0.6);

--- a/gfx/drivers/gl_shaders/pipeline_snow_simple.glsl.frag.h
+++ b/gfx/drivers/gl_shaders/pipeline_snow_simple.glsl.frag.h
@@ -4,9 +4,9 @@ static const char *stock_fragment_xmb_simple_snow = GLSL(
    uniform float time;
    uniform vec2 OutputSize;
 
-   float baseScale = 1.25;  //  [1.0  .. 10.0]
-   float density   = 0.5;  //  [0.01 ..  1.0]
-   float speed     = 0.15; //  [0.1  ..  1.0]
+   float baseScale = 1.25; /* [1.0  .. 10.0] */
+   float density   = 0.5;  /* [0.01 ..  1.0] */
+   float speed     = 0.15; /* [0.1  ..  1.0] */
 
    float rand(vec2 co)
    {
@@ -39,9 +39,9 @@ static const char *stock_fragment_xmb_simple_snow = GLSL(
 
    float snow(vec2 pos, float time, float scale)
    {
-      // add wobble
+      /* add wobble */
       pos.x += cos(pos.y * 1.2 + time * 3.14159 * 2.0 + 1.0 / scale) / (8.0 / scale) * 4.0;
-      // add gravity
+      /* add gravity */
       pos += time * scale * vec2(-0.5, 1.0) * 4.0;
       return random_dots(pos / scale) * (scale * 0.5 + 0.5);
    }
@@ -51,9 +51,11 @@ static const char *stock_fragment_xmb_simple_snow = GLSL(
       float tim = time * 0.4 * speed;
       vec2 pos = gl_FragCoord.xy / OutputSize.xx;
       float a = 0.0;
-      // Each of these is a layer of snow
-      // Remove some for better performance
-      // Changing the scale (3rd value) will mess with the looping
+      /**
+       * Each of these is a layer of snow
+       * Remove some for better performance
+       * Changing the scale (3rd value) will mess with the looping
+       **/
       a += snow(pos, tim, 1.0);
       a += snow(pos, tim, 0.7);
       a += snow(pos, tim, 0.6);


### PR DESCRIPTION
## Description

Fixes some trivial build errors with `C89_BUILD=1` because of c++ style comments. This code still disabled by default because of `C89_SHADERPIPELINE=no` in `qb/config.params.sh`, but it does now build with warnings if enabled for `C89_BUILD=1`.

## Related Issues

N/A

## Related Pull Requests

N/A

## Reviewers

@twinaphex
