### PR TITLE
C89_BUILD: Fix some clang compiler errors

### DIFF
--- a/gfx/common/x11_common.c
+++ b/gfx/common/x11_common.c
@@ -386,6 +386,7 @@ bool x11_get_metrics(void *data,
 static void x11_handle_key_event(XEvent *event, XIC ic, bool filter)
 {
    int i;
+   Status status;
    uint32_t chars[32];
    unsigned key   = 0;
    uint16_t mod   = 0;
@@ -404,7 +405,7 @@ static void x11_handle_key_event(XEvent *event, XIC ic, bool filter)
 
          keybuf[0] = '\0';
 #ifdef X_HAVE_UTF8_STRING
-         Status status = 0;
+         status = 0;
 
          /* XwcLookupString doesn't seem to work. */
          num = Xutf8LookupString(ic, &event->xkey, keybuf, ARRAY_SIZE(keybuf), &keysym, &status);

--- a/libretro-common/formats/libchdr/chd.c
+++ b/libretro-common/formats/libchdr/chd.c
@@ -604,6 +604,7 @@ void cdlz_codec_free(void* codec)
 
 chd_error cdlz_codec_decompress(void *codec, const uint8_t *src, uint32_t complen, uint8_t *dest, uint32_t destlen)
 {
+	uint8_t *sector;
 	uint32_t framenum;
 	cdlz_codec_data* cdlz = (cdlz_codec_data*)codec;
 
@@ -636,7 +637,7 @@ chd_error cdlz_codec_decompress(void *codec, const uint8_t *src, uint32_t comple
 
 #ifdef WANT_RAW_DATA_SECTOR
 		/* reconstitute the ECC data and sync header */
-		uint8_t *sector = &dest[framenum * CD_FRAME_SIZE];
+		sector = (uint8_t *)&dest[framenum * CD_FRAME_SIZE];
 		if ((src[framenum / 8] & (1 << (framenum % 8))) != 0)
 		{
 			memcpy(sector, s_cd_sync_header, sizeof(s_cd_sync_header));
@@ -690,6 +691,7 @@ void cdzl_codec_free(void *codec)
 
 chd_error cdzl_codec_decompress(void *codec, const uint8_t *src, uint32_t complen, uint8_t *dest, uint32_t destlen)
 {
+	uint8_t *sector;
 	uint32_t framenum;
 	cdzl_codec_data* cdzl = (cdzl_codec_data*)codec;
 
@@ -720,7 +722,7 @@ chd_error cdzl_codec_decompress(void *codec, const uint8_t *src, uint32_t comple
 
 #ifdef WANT_RAW_DATA_SECTOR
 		/* reconstitute the ECC data and sync header */
-		uint8_t *sector = &dest[framenum * CD_FRAME_SIZE];
+		sector = (uint8_t *)&dest[framenum * CD_FRAME_SIZE];
 		if ((src[framenum / 8] & (1 << (framenum % 8))) != 0)
 		{
 			memcpy(sector, s_cd_sync_header, sizeof(s_cd_sync_header));


### PR DESCRIPTION
## Description

Some build fixes for `C89_BUILD=1` with clang, the libchdr changes have already been merged upstream.

## Related Issues

```
gfx/common/x11_common.c:407:17: warning: ISO C90 forbids mixing declarations and code [-Wdeclaration-after-statement]
         Status status = 0;
                ^
libretro-common/formats/libchdr/chd.c:639:12: warning: ISO C90 forbids mixing declarations and code [-Wdeclaration-after-statement]
                uint8_t *sector = &dest[framenum * CD_FRAME_SIZE];
                         ^
libretro-common/formats/libchdr/chd.c:723:12: warning: ISO C90 forbids mixing declarations and code [-Wdeclaration-after-statement]
                uint8_t *sector = &dest[framenum * CD_FRAME_SIZE];
                         ^
```

## Related Pull Requests

https://github.com/rtissera/libchdr/pull/1

## Reviewers

@twinaphex