### PR TITLE
Added an overlay led driver, fixed a bug in the rpi led driver

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -200,6 +200,7 @@ OBJ += frontend/frontend.o \
        input/input_driver.o \
        led/led_driver.o \
        led/null_led_driver.o \
+       led/overlay_led_driver.o \
        gfx/video_coord_array.o \
        gfx/video_display_server.o \
        gfx/video_driver.o \

--- a/configuration.c
+++ b/configuration.c
@@ -2508,6 +2508,7 @@ static bool config_load_file(const char *path, bool set_defaults,
       buf[0] = '\0';
 
       snprintf(buf, sizeof(buf), "led%u_map", i + 1);
+      settings->uints.led_map[i]=-1;
       CONFIG_GET_INT_BASE(conf, settings, uints.led_map[i], buf);
    }
 

--- a/input/input_overlay.h
+++ b/input/input_overlay.h
@@ -94,6 +94,13 @@ enum overlay_image_transfer_status
    OVERLAY_IMAGE_TRANSFER_ERROR
 };
 
+enum overlay_visibility
+{
+   OVERLAY_VISIBILITY_DEFAULT = 0,
+   OVERLAY_VISIBILITY_VISIBLE,
+   OVERLAY_VISIBILITY_HIDDEN
+};
+
 struct overlay
 {
    bool full_screen;
@@ -256,6 +263,8 @@ bool input_overlay_key_pressed(input_overlay_t *ol, unsigned key);
 bool input_overlay_is_alive(input_overlay_t *ol);
 
 void input_overlay_loaded(void *task_data, void *user_data, const char *err);
+
+void input_overlay_set_visibility(int overlay_idx,enum overlay_visibility vis);
 
 /* FIXME - temporary. Globals are bad */
 extern input_overlay_t *overlay_ptr;

--- a/led/led_driver.c
+++ b/led/led_driver.c
@@ -20,6 +20,11 @@
 #include "../verbosity.h"
 
 static led_driver_t *current_led_driver = NULL;
+extern led_driver_t *null_led_driver;
+extern led_driver_t *overlay_led_driver;
+#if HAVE_RPILED
+extern led_driver_t *rpi_led_driver;
+#endif
 
 bool led_driver_init(void)
 {
@@ -31,10 +36,16 @@ bool led_driver_init(void)
 
    current_led_driver = null_led_driver;
 
-#if HAVE_RPILED      
-   if(string_is_equal("rpi", drivername))
+   if(string_is_equal("overlay",drivername))
+      current_led_driver = overlay_led_driver;
+#if HAVE_RPILED
+   else if(string_is_equal("rpi", drivername))
       current_led_driver = rpi_led_driver;
 #endif          
+   else
+   {
+      current_led_driver = null_led_driver;
+   }
 
    RARCH_LOG("[LED]: LED driver = '%s' %p\n",
          drivername,current_led_driver);

--- a/led/overlay_led_driver.c
+++ b/led/overlay_led_driver.c
@@ -1,0 +1,59 @@
+#include <stdio.h>
+#include "led_driver.h"
+#include "led_defines.h"
+
+#include "configuration.h"
+#include "verbosity.h"
+
+#include "../gfx/video_driver.h"
+#include "../input/input_overlay.h"
+
+typedef struct
+{
+    int setup[MAX_LEDS];
+    int map[MAX_LEDS];
+} overlayled_t;
+
+static overlayled_t curins;
+static overlayled_t *cur = &curins;
+
+static void overlay_init(void)
+{
+    int i;
+    settings_t *settings = config_get_ptr();
+    RARCH_LOG("[LED]: overlay LED driver init\n");
+    for(i=0;i<MAX_LEDS;i++) {
+        cur->setup[i] = 0;
+        cur->map[i] = settings->uints.led_map[i];
+        RARCH_LOG("[LED]: overlay map[%d]=%d\n",i,cur->map[i]);
+
+        if(cur->map[i] >= 0)
+        {
+            input_overlay_set_visibility(cur->map[i],OVERLAY_VISIBILITY_HIDDEN);
+        }
+    }
+}
+
+static void overlay_free(void)
+{
+    RARCH_LOG("[LED]: overlay LED driver free\n");
+}
+
+static void overlay_set(int led,int state)
+{
+    int gpio = 0;
+    if((led < 0) || (led >= MAX_LEDS))
+    {
+        RARCH_WARN("[LED]: invalid led %d\n",led);
+        return;
+    }
+
+    gpio = cur->map[led];
+
+    if(gpio < 0) return;
+    input_overlay_set_visibility(gpio,state?OVERLAY_VISIBILITY_VISIBLE:OVERLAY_VISIBILITY_HIDDEN);
+    RARCH_LOG("[LED]: set visibility %d %d\n",gpio,state);
+}
+
+static led_driver_t overlay_led_driver_ins = { overlay_init, overlay_free, overlay_set };
+led_driver_t *overlay_led_driver = &overlay_led_driver_ins;

--- a/led/rpi_led_driver.c
+++ b/led/rpi_led_driver.c
@@ -53,7 +53,7 @@ static int set_gpio(int gpio,int value)
 {
    FILE *fp;
    char buf[256];
-   snprintf(buf, sizeof(buf), "/sys/class/gpio/%d/value", gpio);
+   snprintf(buf, sizeof(buf), "/sys/class/gpio/gpio%d/value", gpio);
    fp = fopen(buf,"w");
 
    if(!fp)
@@ -71,7 +71,7 @@ static int setup_gpio(int gpio)
 {
    FILE *fp;
    char buf[256];
-   snprintf(buf, sizeof(buf), "/sys/class/gpio/%d/direction", gpio);
+   snprintf(buf, sizeof(buf), "/sys/class/gpio/gpio%d/direction", gpio);
    fp = fopen(buf,"w");
 
    if(!fp)
@@ -88,7 +88,7 @@ static int setup_gpio(int gpio)
       fprintf(fp,"%d\n",gpio);
       fclose(fp);
 
-      snprintf(buf, sizeof(buf), "/sys/class/gpio/%d/direction",gpio);
+      snprintf(buf, sizeof(buf), "/sys/class/gpio/gpio%d/direction",gpio);
       fp = fopen(buf,"w");    
    }
 
@@ -102,8 +102,8 @@ static int setup_gpio(int gpio)
    fprintf(fp,"out\n");
    fclose(fp);
    return 1;
-
 }
+
 static void rpi_set(int led,int state)
 {
    int gpio = 0;


### PR DESCRIPTION

## Description

Added a new LED driver called "overlay" which shows and hides overlay images based on LED state.
To make the 1st LED control the 1st overlay:
led_driver = "overlay"
led1_map = "0"

For multiple LEDs, set up an overlay with multiple desc images.  Set led#_map to "0" for the main overlay, "1" for desc0, "2" for desc1, etc...

