### PR TITLE
Fix RETRO_DEVICE_ID_POINTER_PRESSED handling

### DIFF
--- a/wiiu/input/wpad_driver.c
+++ b/wiiu/input/wpad_driver.c
@@ -211,7 +211,7 @@ static void wpad_get_buttons(unsigned pad, retro_bits_t *state)
    if(!wpad_query_pad(pad))
       BIT256_CLEAR_ALL_PTR(state);
    else
-      BITS_COPY16_PTR(state, button_state);
+      BITS_COPY32_PTR(state, button_state);
 }
 
 static int16_t wpad_axis(unsigned pad, uint32_t axis)


### PR DESCRIPTION
== DETAILS

The joypad driver was only copying the first 16 bits when executing
get_buttons(). The touchpad button is bit 19, so as a result
RETRO_DEVICE_ID_POINTER_PRESSED would never fire.

We fix this for now by copying 32 bits.

== TESTING

Will need someone to verify. I don't  have a core handy that leverages
the pointer device state functionality.

== REVIEW
@QuarkTheAwesome @twinaphex @r-type 