### PR TITLE
(WIIU) add preliminary multi-pass shader support.

### DIFF
--- a/Makefile.wiiu
+++ b/Makefile.wiiu
@@ -64,12 +64,15 @@ else
    DEFINES += -DHAVE_KEYMAPPER
    DEFINES += -DHAVE_UPDATE_ASSETS
    DEFINES += -DHAVE_FILTERS_BUILTIN
+   DEFINES += -DHAVE_SLANG
 
    OBJ += wiiu/system/missing_libc_functions.o
    OBJ += wiiu/shader_utils.o
    OBJ += wiiu/tex_shader.o
    OBJ += wiiu/sprite_shader.o
    OBJ += wiiu/frame_shader.o
+   OBJ += gfx/drivers_shader/slang_preprocess.o
+   OBJ += gfx/drivers_shader/glslang_util.o
 
    ifeq ($(GRIFFIN_BUILD), 1)
    	OBJ += griffin/griffin.o

--- a/gfx/common/gx2_common.h
+++ b/gfx/common/gx2_common.h
@@ -2,6 +2,7 @@
 
 #include "wiiu/frame_shader.h"
 #include "wiiu/sprite_shader.h"
+#include "gfx/video_shader_parse.h"
 
 #undef _X
 #undef _B
@@ -81,6 +82,15 @@ typedef struct
    GX2ColorBuffer color_buffer;
    GX2ContextState* ctx_state;
    void* cmd_buffer;
+   struct video_shader* shader_preset;
+   struct
+   {
+      GFDFile* gfd;
+      float* vs_ubo;
+      float* ps_ubo;
+      GX2Texture texture;
+      GX2ColorBuffer color_buffer;
+   }pass[GFX_MAX_SHADERS];
 
    wiiu_render_mode_t render_mode;
    video_viewport_t vp;

--- a/gfx/drivers_shader/glslang_util.cpp
+++ b/gfx/drivers_shader/glslang_util.cpp
@@ -25,9 +25,14 @@
 #include <lists/string_list.h>
 #include <string/stdstring.h>
 
-#include "glslang_util.hpp"
-#include "glslang.hpp"
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
 
+#include "glslang_util.hpp"
+#ifdef HAVE_VULKAN
+#include "glslang.hpp"
+#endif
 #include "../../verbosity.h"
 
 using namespace std;
@@ -363,6 +368,7 @@ bool glslang_parse_meta(const vector<string> &lines, glslang_meta *meta)
    return true;
 }
 
+#ifdef HAVE_VULKAN
 bool glslang_compile_shader(const char *shader_path, glslang_output *output)
 {
    vector<string> lines;
@@ -391,4 +397,4 @@ bool glslang_compile_shader(const char *shader_path, glslang_output *output)
 
    return true;
 }
-
+#endif

--- a/gfx/video_shader_parse.c
+++ b/gfx/video_shader_parse.c
@@ -1116,12 +1116,15 @@ enum rarch_shader_type video_shader_parse_type(const char *path,
          break;
       case FILE_TYPE_SHADER_SLANG:
       case FILE_TYPE_SHADER_PRESET_SLANGP:
+#ifdef __wiiu__
+         return RARCH_SHADER_SLANG;
+#else
          shader_type = RARCH_SHADER_SLANG;
          break;
+#endif
       default:
          break;
    }
-
    switch (api)
    {
       case GFX_CTX_OPENGL_API:

--- a/libretro-common/file/file_path.c
+++ b/libretro-common/file/file_path.c
@@ -731,6 +731,9 @@ bool path_is_absolute(const char *path)
          || strstr(path, ":\\")
          || strstr(path, ":\\\\"))
       return true;
+#elif defined(__wiiu__)
+   if (strstr(path, ":/"))
+      return true;
 #endif
    return false;
 }

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -6599,7 +6599,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, void *data)
          {
             char new_exts[PATH_MAX_LENGTH];
             struct string_list *str_list;
-#if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_VULKAN)
+#if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG)
             union string_list_elem_attr attr;
             attr.i = 0;
 #endif
@@ -6616,7 +6616,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, void *data)
 #ifdef HAVE_GLSL
             string_list_append(str_list, "glslp", attr);
 #endif
-#ifdef HAVE_VULKAN
+#ifdef HAVE_SLANG
             string_list_append(str_list, "slangp", attr);
 #endif
             string_list_join_concat(new_exts, sizeof(new_exts), str_list, "|");
@@ -6632,7 +6632,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, void *data)
          {
             char new_exts[PATH_MAX_LENGTH];
             struct string_list *str_list;
-#if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_VULKAN)
+#if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG)
             union string_list_elem_attr attr;
             attr.i = 0;
 #endif
@@ -6650,7 +6650,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, void *data)
 #ifdef HAVE_GLSL
             string_list_append(str_list, "glsl", attr);
 #endif
-#ifdef HAVE_VULKAN
+#ifdef HAVE_SLANG
             string_list_append(str_list, "slang", attr);
 #endif
             string_list_join_concat(new_exts, sizeof(new_exts), str_list, "|");

--- a/menu/menu_shader.c
+++ b/menu/menu_shader.c
@@ -603,7 +603,7 @@ void menu_shader_manager_apply_changes(void)
       shader_type = RARCH_SHADER_GLSL;
 #elif defined(HAVE_CG) || defined(HAVE_HLSL)
       shader_type = RARCH_SHADER_CG;
-#elif defined(HAVE_VULKAN)
+#elif defined(HAVE_SLANG)
       shader_type = RARCH_SHADER_SLANG;
 #endif
    }

--- a/wiiu/shader_utils.c
+++ b/wiiu/shader_utils.c
@@ -452,6 +452,7 @@ GFDFile *gfd_open(const char *filename)
          if(gfd->vs->program)
             continue;
 
+         GX2Invalidate(GX2_INVALIDATE_MODE_CPU_SHADER, block->data, block->header.dataSize);
          gfd->vs->program = block->data;
          break;
 
@@ -469,6 +470,7 @@ GFDFile *gfd_open(const char *filename)
          if(gfd->ps->program)
             continue;
 
+         GX2Invalidate(GX2_INVALIDATE_MODE_CPU_SHADER, block->data, block->header.dataSize);
          gfd->ps->program = block->data;
          break;
 


### PR DESCRIPTION
can load *.slangp and *.slang files. since there is no runtime compiler,
precompiled shaders (*.gsh) need to be present next to each *.slang
source file.