### PR TITLE
Use the right value for BIT256_GET macro

### DIFF
--- a/input/drivers/wiiu_input.c
+++ b/input/drivers/wiiu_input.c
@@ -105,7 +105,7 @@ static int16_t wiiu_pointer_device_state(wiiu_input_t* wiiu, unsigned id)
 		{
 			retro_bits_t state;
 			wiiu->joypad->get_buttons(0, &state);
-			return BIT256_GET(state, VPAD_BUTTON_TOUCH) ? 1 : 0;
+			return BIT256_GET(state, VPAD_BUTTON_TOUCH_BIT) ? 1 : 0;
 		}
 		case RETRO_DEVICE_ID_POINTER_X:
 			return wiiu->joypad->axis(0, 0xFFFF0004UL);

--- a/wiiu/include/wiiu/vpad.h
+++ b/wiiu/include/wiiu/vpad.h
@@ -5,6 +5,40 @@
 extern "C" {
 #endif
 
+typedef enum VPADButtonBits {
+   VPAD_BUTTON_SYNC_BIT             = 0,
+   VPAD_BUTTON_HOME_BIT             = 1,
+   VPAD_BUTTON_MINUS_BIT            = 2,
+   VPAD_BUTTON_PLUS_BIT             = 3,
+   VPAD_BUTTON_R_BIT                = 4,
+   VPAD_BUTTON_L_BIT                = 5,
+   VPAD_BUTTON_ZR_BIT               = 6,
+   VPAD_BUTTON_ZL_BIT               = 7,
+   VPAD_BUTTON_DOWN_BIT             = 8,
+   VPAD_BUTTON_UP_BIT               = 9,
+   VPAD_BUTTON_RIGHT_BIT            = 10,
+   VPAD_BUTTON_LEFT_BIT             = 11,
+   VPAD_BUTTON_Y_BIT                = 12,
+   VPAD_BUTTON_X_BIT                = 13,
+   VPAD_BUTTON_B_BIT                = 14,
+   VPAD_BUTTON_A_BIT                = 15,
+   VPAD_BUTTON_TV_BIT               = 16,
+   VPAD_BUTTON_STICK_R_BIT          = 17,
+   VPAD_BUTTON_STICK_L_BIT          = 18,
+   VPAD_BUTTON_TOUCH_BIT            = 19,
+   VPAD_BUTTON_UNUSED1_BIT          = 20,
+   VPAD_BUTTON_UNUSED2_BIT          = 21,
+   VPAD_BUTTON_UNUSED3_BIT          = 22,
+   VPAD_STICK_R_EMULATION_DOWN_BIT  = 23,
+   VPAD_STICK_R_EMULATION_UP_BIT    = 24,
+   VPAD_STICK_R_EMULATION_RIGHT_BIT = 25,
+   VPAD_STICK_R_EMULATION_LEFT_BIT  = 26,
+   VPAD_STICK_L_EMULATION_DOWN_BIT  = 27,
+   VPAD_STICK_L_EMULATION_UP_BIT    = 28,
+   VPAD_STICK_L_EMULATION_RIGHT_BIT = 29,
+   VPAD_STICK_L_EMULATION_LEFT_BIT  = 30,
+} VPADButtonBits;
+
 typedef enum VPADButtons
 {
    VPAD_BUTTON_SYNC             = 0x00000001,
@@ -26,20 +60,28 @@ typedef enum VPADButtons
    VPAD_BUTTON_TV               = 0x00010000,
    VPAD_BUTTON_STICK_R          = 0x00020000,
    VPAD_BUTTON_STICK_L          = 0x00040000,
-   VPAD_STICK_R_EMULATION_LEFT  = 0x04000000,
-   VPAD_STICK_R_EMULATION_RIGHT = 0x02000000,
-   VPAD_STICK_R_EMULATION_UP    = 0x01000000,
+   VPAD_BUTTON_TOUCH            = 0x00080000,
+   VPAD_BUTTON_UNUSED1          = 0x00100000,
+   VPAD_BUTTON_UNUSED2          = 0x00200000,
+   VPAD_BUTTON_UNUSED3          = 0x00400000,
    VPAD_STICK_R_EMULATION_DOWN  = 0x00800000,
-   VPAD_STICK_L_EMULATION_LEFT  = 0x40000000,
-   VPAD_STICK_L_EMULATION_RIGHT = 0x20000000,
-   VPAD_STICK_L_EMULATION_UP    = 0x10000000,
+   VPAD_STICK_R_EMULATION_UP    = 0x01000000,
+   VPAD_STICK_R_EMULATION_RIGHT = 0x02000000,
+   VPAD_STICK_R_EMULATION_LEFT  = 0x04000000,
    VPAD_STICK_L_EMULATION_DOWN  = 0x08000000,
-
-
+   VPAD_STICK_L_EMULATION_UP    = 0x10000000,
+   VPAD_STICK_L_EMULATION_RIGHT = 0x20000000,
+   VPAD_STICK_L_EMULATION_LEFT  = 0x40000000,
 } VPADButtons;
 
-#define VPAD_BUTTON_TOUCH               0x00080000
-#define VPAD_MASK_EMULATED_STICKS       0x7F800000
+#define VPAD_MASK_EMULATED_STICKS       (VPAD_STICK_R_EMULATION_LEFT  | \
+                                         VPAD_STICK_R_EMULATION_RIGHT | \
+                                         VPAD_STICK_R_EMULATION_UP    | \
+                                         VPAD_STICK_R_EMULATION_DOWN  | \
+                                         VPAD_STICK_L_EMULATION_LEFT  | \
+                                         VPAD_STICK_L_EMULATION_RIGHT | \
+                                         VPAD_STICK_L_EMULATION_UP    | \
+                                         VPAD_STICK_L_EMULATION_DOWN)
 #define VPAD_MASK_BUTTONS               ~VPAD_MASK_EMULATED_STICKS
 
 typedef enum VPADTouchPadValidity


### PR DESCRIPTION
== DETAILS

The BIT256_GET() macro expects a bit number (from 0-255), and we're giving it
a 32-bit mask (0x000080000).

Solution:

- Define VPAD_BUTTON_xxx_BIT macros using the bit number
- Use said macro in wiiu_input.c
- organizational cleanup:

  * put VPAD_BUTTON_TOUCH into the enum in stead of as a hokey define
  * put the touch bits in the right order
  * put in placeholder enums for (currently) unused bits

I considered making the mask enums expressed in terms of the bit enum, e.g.:

`VPAD_BUTTON_SYNC = (1 << VPAD_BUTTON_SYNC_BITS)`

But, I'm not sure if the compiler would actually just convert that to 0x1 at compile-time or if it'd put in a bunch of bit shift operations.

== REVIEW
@twinaphex @QuarkTheAwesome @r-type 