### PR TITLE
Fix the blocking call to HIDRead()

### DIFF
--- a/wiiu/include/wiiu/os/thread.h
+++ b/wiiu/include/wiiu/os/thread.h
@@ -227,7 +227,7 @@ typedef struct OSThread
    //! Queue of threads waiting for a thread to be suspended.
    OSThreadQueue suspendQueue;
 
-   uint32_t unknown4[0x2A];
+   uint32_t unknown4[0x2B];
 } OSThread;
 #pragma pack(pop)
 

--- a/wiiu/include/wiiu/pad_driver.h
+++ b/wiiu/include/wiiu/pad_driver.h
@@ -138,6 +138,8 @@ struct wiiu_adapter {
   uint8_t state;
   uint8_t *rx_buffer;
   int32_t rx_size;
+  uint8_t *tx_buffer;
+  int32_t tx_size;
   int32_t slot;
   uint32_t handle;
   uint8_t interface_index;


### PR DESCRIPTION
== DETAILS

TIL that the "max_packet_size_*" fields in the HIDDevice struct
are actually requirements, not maximums.

The reason HIDRead() was blocking was because the HIDWrite() that
sent the activation command was silently failing.

The reason HIDWrite() was silently failing was because I was using too
small of a buffer for the device.

In this case: the Wii U GC adapter, which has a "max" tx packet size of 5.

"max" is misleading. You actually have to write all 5 bytes.

Which means: copying the 1-byte buffer to the 5-byte buffer, and writing
the 5-byte buffer via HIDWrite().

So, in summary:

- Use correct semantics for HIDWrite() so that HIDRead() can work.
- Update the OSThread struct to reflect the current knowledge over at
  WUT. It's unlikely this was actually causing a problem, but never
  hurts to be more correct.

== TESTING
I temporarily enabled the call to log_buffer() and confirmed that the
GC adapter's state is successfully being read.

@twinaphex @QuarkTheAwesome 