### PR TITLE
Fix building with built-in flac

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -273,10 +273,12 @@ fi
 
 if [ "$HAVE_FLAC" = 'no' ]; then
    HAVE_BUILTINFLAC=no
+elif [ "$HAVE_BUILTINFLAC" = 'yes' ]; then
+   HAVE_FLAC=yes
+else
+   check_pkgconf FLAC flac
+   check_val '' FLAC '-lFLAC'
 fi
-
-check_pkgconf FLAC flac
-check_val '' FLAC '-lFLAC'
 
 check_pkgconf LIBUSB libusb-1.0 1.0.13
 check_val '' LIBUSB -lusb-1.0 libusb-1.0


### PR DESCRIPTION
Not having HAVE_FLAC caused CHD support to be missing, etc.
This updates the logic to match how zlib is handled.

@twinaphex
