### PR TITLE
Remove all HID code from WiiU build via ifdef

### DIFF
--- a/Makefile.wiiu
+++ b/Makefile.wiiu
@@ -6,7 +6,8 @@ DEBUG                      = 0
 GRIFFIN_BUILD              = 0
 SALAMANDER_BUILD           = 0
 WHOLE_ARCHIVE_LINK         = 0
-HAVE_HID                   = 1
+HAVE_HID                   = 0
+WIIU_HID                   = 0
 BUILD_DIR                  = objs/wiiu
 PC_DEVELOPMENT_IP_ADDRESS  ?=
 PC_DEVELOPMENT_TCP_PORT	   ?=
@@ -25,10 +26,8 @@ ifneq ($(V), 1)
 endif
 
 OBJ :=
-OBJ += wiiu/input/wiiu_hid.o
 OBJ += wiiu/input/wpad_driver.o
 OBJ += wiiu/input/kpad_driver.o
-OBJ += wiiu/input/hidpad_driver.o
 OBJ += wiiu/input/pad_functions.o
 OBJ += wiiu/system/memory.o
 OBJ += wiiu/system/exception_handler.o
@@ -37,6 +36,12 @@ OBJ += wiiu/fs/fs_utils.o
 OBJ += wiiu/hbl.o
 
 DEFINES :=
+
+ifeq ($(WIIU_HID),1)
+   DEFINES += -DWIIU_HID
+   OBJ += wiiu/input/hidpad_driver.o
+   OBJ += wiiu/input/wiiu_hid.o
+endif
 
 ifeq ($(SALAMANDER_BUILD),1)
    DEFINES += -DRARCH_CONSOLE -DIS_SALAMANDER

--- a/frontend/drivers/platform_wiiu.c
+++ b/frontend/drivers/platform_wiiu.c
@@ -314,6 +314,8 @@ static volatile int wiiu_log_lock = 0;
 
 void wiiu_log_init(const char *ipString, int port)
 {
+   wiiu_log_lock = 0;
+
    wiiu_log_socket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
 
    if (wiiu_log_socket < 0)

--- a/input/drivers_joypad/wiiu_joypad.c
+++ b/input/drivers_joypad/wiiu_joypad.c
@@ -19,6 +19,7 @@
 #include "wiiu_dbg.h"
 
 static input_device_driver_t *pad_drivers[MAX_USERS];
+
 static bool ready = false;
 
 static bool wiiu_joypad_init(void *data);
@@ -42,7 +43,11 @@ static input_device_driver_t *get_driver_for_pad(unsigned pad)
   if(kpad_driver.query_pad(pad))
     return &kpad_driver;
 
+#ifdef WIIU_HID
   return &hidpad_driver;
+#else
+  return NULL;
+#endif
 }
 
 /**
@@ -65,7 +70,9 @@ static bool wiiu_joypad_init(void* data)
   // build_pad_map will fail (because all lookups will return false).
   wpad_driver.init(data);
   kpad_driver.init(data);
+#ifdef WIIU_HID
   hidpad_driver.init(data);
+#endif
 
   build_pad_map();
 
@@ -77,7 +84,11 @@ static bool wiiu_joypad_init(void* data)
 
 static bool wiiu_joypad_query_pad(unsigned pad)
 {
+#ifdef WIIU_HID
   return ready && pad < MAX_USERS;
+#else
+  return ready && pad < 5;
+#endif
 }
 
 static void wiiu_joypad_destroy(void)
@@ -86,7 +97,9 @@ static void wiiu_joypad_destroy(void)
 
   wpad_driver.destroy();
   kpad_driver.destroy();
+#ifdef WIIU_HID
   hidpad_driver.destroy();
+#endif
 }
 
 static bool wiiu_joypad_button(unsigned pad, uint16_t key)
@@ -117,7 +130,9 @@ static void wiiu_joypad_poll(void)
 {
   wpad_driver.poll();
   kpad_driver.poll();
+#ifdef WIIU_HID
   hidpad_driver.poll();
+#endif
 }
 
 static const char* wiiu_joypad_name(unsigned pad)
@@ -141,4 +156,3 @@ input_device_driver_t wiiu_joypad =
   wiiu_joypad_name,
   "wiiu",
 };
-

--- a/wiiu/input/hidpad_driver.c
+++ b/wiiu/input/hidpad_driver.c
@@ -71,6 +71,7 @@ static bool hidpad_init(void *data)
 {
    (void *)data;
 
+#if 0
    hid_driver = init_hid_driver();
    if (!hid_driver)
    {
@@ -82,6 +83,9 @@ static bool hidpad_init(void *data)
    ready = true;
 
    return true;
+#else
+   return false;
+#endif
 }
 
 static bool hidpad_query_pad(unsigned pad)

--- a/wiiu/system/imports.h
+++ b/wiiu/system/imports.h
@@ -267,6 +267,7 @@ IMPORT(KBDTeardown);
 IMPORT_END();
 
 /* syshid */
+#ifdef WIIU_HID
 IMPORT_BEGIN(nsyshid);
 
 IMPORT(HIDSetup);
@@ -284,3 +285,4 @@ IMPORT(HIDRead);
 IMPORT(HIDWrite);
 
 IMPORT_END();
+#endif


### PR DESCRIPTION
== DETAILS
We're trying to track down the source of crashes when switching cores.
To rule out the HID code, this commit does the following:

- Wraps the library imports in an ifdef
- Wraps the object files in conditionals in Makefile.wiiu
- In wiiu_joypad, calls into the hidpad driver are wrapped in ifdef

== TESTING
This didn't solve the "System memory error" crash I've been experiencing.
But, maybe it will impact the other flavors of crashes others are seeing.

==REVIEW
@twinaphex @QuarkTheAwesome
  