### PR TITLE
Revert "Fix building with built-in flac"

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -273,12 +273,10 @@ fi
 
 if [ "$HAVE_FLAC" = 'no' ]; then
    HAVE_BUILTINFLAC=no
-elif [ "$HAVE_BUILTINFLAC" = 'yes' ]; then
-   HAVE_FLAC=yes
-else
-   check_pkgconf FLAC flac
-   check_val '' FLAC '-lFLAC'
 fi
+
+check_pkgconf FLAC flac
+check_val '' FLAC '-lFLAC'
 
 check_pkgconf LIBUSB libusb-1.0 1.0.13
 check_val '' LIBUSB -lusb-1.0 libusb-1.0


### PR DESCRIPTION
Reverts libretro/RetroArch#6064

This breaks stuff and undoes my fixes for C89_BUILD=1.

@bkoropoff Please explain your issue in detail, I was not able to reproduce your issue when I made it this way.