### PR TITLE
add display name and config name to autoconf

### DIFF
--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -244,6 +244,8 @@ static uint16_t input_config_pid[MAX_USERS];
 
 uint64_t lifecycle_state;
 char input_device_names[MAX_INPUT_DEVICES][64];
+char input_device_display_names[MAX_INPUT_DEVICES][64];
+char input_device_config_names[MAX_INPUT_DEVICES][64];
 struct retro_keybind input_config_binds[MAX_USERS][RARCH_BIND_LIST_END];
 struct retro_keybind input_autoconf_binds[MAX_USERS][RARCH_BIND_LIST_END];
 const struct retro_keybind *libretro_input_binds[MAX_USERS];
@@ -2690,6 +2692,20 @@ const char *input_config_get_device_name(unsigned port)
    return input_device_names[port];
 }
 
+const char *input_config_get_device_display_name(unsigned port)
+{
+   if (string_is_empty(input_device_display_names[port]))
+      return NULL;
+   return input_device_display_names[port];
+}
+
+const char *input_config_get_device_config_name(unsigned port)
+{
+   if (string_is_empty(input_device_config_names[port]))
+      return NULL;
+   return input_device_config_names[port];
+}
+
 void input_config_set_device_name(unsigned port, const char *name)
 {
    if (!string_is_empty(name))
@@ -2702,10 +2718,40 @@ void input_config_set_device_name(unsigned port, const char *name)
    }
 }
 
+void input_config_set_device_config_name(unsigned port, const char *name)
+{
+   if (!string_is_empty(name))
+   {
+      strlcpy(input_device_config_names[port],
+            name,
+            sizeof(input_device_config_names[port]));
+   }
+}
+
+void input_config_set_device_display_name(unsigned port, const char *name)
+{
+   if (!string_is_empty(name))
+   {
+      strlcpy(input_device_display_names[port],
+            name,
+            sizeof(input_device_display_names[port]));
+   }
+}
+
 void input_config_clear_device_name(unsigned port)
 {
    input_device_names[port][0] = '\0';
    input_autoconfigure_joypad_reindex_devices();
+}
+
+void input_config_clear_device_display_name(unsigned port)
+{
+   input_device_display_names[port][0] = '\0';
+}
+
+void input_config_clear_device_config_name(unsigned port)
+{
+   input_device_config_names[port][0] = '\0';
 }
 
 unsigned *input_config_get_device_ptr(unsigned port)

--- a/input/input_driver.h
+++ b/input/input_driver.h
@@ -759,7 +759,15 @@ void input_config_parse_mouse_button(void *data, const char *prefix,
 
 void input_config_set_device_name(unsigned port, const char *name);
 
+void input_config_set_device_display_name(unsigned port, const char *name);
+
+void input_config_set_device_config_name(unsigned port, const char *name);
+
 void input_config_clear_device_name(unsigned port);
+
+void input_config_clear_device_display_name(unsigned port);
+
+void input_config_clear_device_config_name(unsigned port);
 
 unsigned input_config_get_device_count();
 
@@ -770,6 +778,10 @@ unsigned input_config_get_device(unsigned port);
 void input_config_set_device(unsigned port, unsigned id);
 
 const char *input_config_get_device_name(unsigned port);
+
+const char *input_config_get_device_display_name(unsigned port);
+
+const char *input_config_get_device_config_name(unsigned port);
 
 const struct retro_keybind *input_config_get_bind_auto(unsigned port, unsigned id);
 

--- a/libretro-common/file/config_file.c
+++ b/libretro-common/file/config_file.c
@@ -65,16 +65,6 @@ struct config_include_list
    struct config_include_list *next;
 };
 
-struct config_file
-{
-   char *path;
-   struct config_entry_list *entries;
-   struct config_entry_list *tail;
-   unsigned include_depth;
-
-   struct config_include_list *includes;
-};
-
 static config_file_t *config_file_new_internal(
       const char *path, unsigned depth);
 

--- a/libretro-common/include/file/config_file.h
+++ b/libretro-common/include/file/config_file.h
@@ -52,6 +52,17 @@ RETRO_BEGIN_DECLS
       base->var = tmp; \
 } while(0)
 
+struct config_file
+{
+   char *path;
+   struct config_entry_list *entries;
+   struct config_entry_list *tail;
+   unsigned include_depth;
+
+   struct config_include_list *includes;
+};
+
+
 typedef struct config_file config_file_t;
 
 /* Config file format

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -491,18 +491,32 @@ static int menu_displaylist_parse_system_info(menu_displaylist_info_t *info)
    {
        if (input_is_autoconfigured(controller))
        {
-           snprintf(tmp, sizeof(tmp), "Port #%d device name: %s (#%d)",
+            snprintf(tmp, sizeof(tmp), "Port #%d device name: %s (#%d)",
                  controller,
                  input_config_get_device_name(controller),
                  input_autoconfigure_get_device_name_index(controller));
-           menu_entries_append_enum(info->list, tmp, "",
+            menu_entries_append_enum(info->list, tmp, "",
                  MENU_ENUM_LABEL_SYSTEM_INFO_ENTRY,
                  MENU_SETTINGS_CORE_INFO_NONE, 0, 0);
-           snprintf(tmp, sizeof(tmp), "Port #%d device VID/PID: %d/%d",
+            snprintf(tmp, sizeof(tmp), "Port #%d device display name: %s",
+                 controller,
+                 input_config_get_device_display_name(controller) ? 
+                    input_config_get_device_display_name(controller) : "N/A");
+            menu_entries_append_enum(info->list, tmp, "",
+                 MENU_ENUM_LABEL_SYSTEM_INFO_ENTRY,
+                 MENU_SETTINGS_CORE_INFO_NONE, 0, 0);
+            snprintf(tmp, sizeof(tmp), "Port #%d device config name: %s",
+                 controller,
+                 input_config_get_device_display_name(controller) ? 
+                    input_config_get_device_config_name(controller) : "N/A");
+            menu_entries_append_enum(info->list, tmp, "",
+                 MENU_ENUM_LABEL_SYSTEM_INFO_ENTRY,
+                 MENU_SETTINGS_CORE_INFO_NONE, 0, 0);
+            snprintf(tmp, sizeof(tmp), "Port #%d device VID/PID: %d/%d",
                  controller,
                  input_config_get_vid(controller),
                  input_config_get_pid(controller));
-           menu_entries_append_enum(info->list, tmp, "",
+            menu_entries_append_enum(info->list, tmp, "",
                  MENU_ENUM_LABEL_SYSTEM_INFO_ENTRY,
                  MENU_SETTINGS_CORE_INFO_NONE, 0, 0);
        }

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -1512,7 +1512,8 @@ static void get_string_representation_bind_device(void * data, char *s,
 
    if (map < max_devices)
    {
-      const char *device_name = input_config_get_device_name(map);
+      const char *device_name = input_config_get_device_display_name(map) ? 
+                                input_config_get_device_display_name(map) : input_config_get_device_name(map);
 
       if (!string_is_empty(device_name))
       {

--- a/tasks/task_autodetect.c
+++ b/tasks/task_autodetect.c
@@ -259,7 +259,7 @@ static void input_autoconfigure_joypad_add(config_file_t *conf,
             ? params->name : (!string_is_empty(display_name) ? display_name : "N/A"),
             msg_hash_to_str(MSG_DEVICE_CONFIGURED_IN_PORT),
             params->idx);
-
+   
       /* allow overriding the swap menu controls for player 1*/
       if (params->idx == 0)
       {
@@ -275,6 +275,8 @@ static void input_autoconfigure_joypad_add(config_file_t *conf,
          task_set_title(task, strdup(msg));
       }
    }
+   input_config_set_device_display_name(params->idx, display_name);
+   input_config_set_device_config_name(params->idx, path_basename(conf->path));
 
 
    input_autoconfigure_joypad_reindex_devices();
@@ -901,6 +903,8 @@ bool input_autoconfigure_disconnect(unsigned i, const char *ident)
    state->msg    = strdup(msg);
 
    input_config_clear_device_name(state->idx);
+   input_config_clear_device_display_name(state->idx);
+   input_config_clear_device_config_name(state->idx);
 
    task->state   = state;
    task->handler = input_autoconfigure_disconnect_handler;


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises


## Description

Adds some info that can be used for debugging in the system information panel
It will also use the display name instead of the name used for matching in Input Binds menu

![image](https://user-images.githubusercontent.com/1721040/34850577-66d8c4fe-f6f4-11e7-9397-7d3ff94a1361.png)

![image](https://user-images.githubusercontent.com/1721040/34850584-6e4767ae-f6f4-11e7-9f18-47866b700f75.png)

The display name was used only for the OSD which made the whole thing confusing

![image](https://user-images.githubusercontent.com/1721040/34850624-a1a38e02-f6f4-11e7-9c12-e227e31cc51e.png)


