### PR TITLE
Solaris 11 RetroArch build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,12 @@ ifneq ($(findstring Win32,$(OS)),)
    LDFLAGS += -static-libgcc -lwinmm
 endif
 
+ifneq ($(findstring SunOS,$(OS)),)
+   INSTALL = ginstall
+else
+   INSTALL = install
+endif
+
 include Makefile.common
 
 ifeq ($(shell $(CC) -v 2>&1 | grep -c "clang"),1)
@@ -197,13 +203,13 @@ install: $(TARGET)
 	mkdir -p $(DESTDIR)$(PREFIX)/share/applications 2>/dev/null || /bin/true
 	mkdir -p $(DESTDIR)$(MAN_DIR)/man6 2>/dev/null || /bin/true
 	mkdir -p $(DESTDIR)$(PREFIX)/share/pixmaps 2>/dev/null || /bin/true
-	install -m755 $(TARGET) $(DESTDIR)$(BIN_DIR)
-	install -m755 tools/cg2glsl.py $(DESTDIR)$(BIN_DIR)/retroarch-cg2glsl
-	install -m644 retroarch.cfg $(DESTDIR)$(GLOBAL_CONFIG_DIR)/retroarch.cfg
-	install -m644 retroarch.desktop $(DESTDIR)$(PREFIX)/share/applications
-	install -m644 docs/retroarch.6 $(DESTDIR)$(MAN_DIR)/man6
-	install -m644 docs/retroarch-cg2glsl.6 $(DESTDIR)$(MAN_DIR)/man6
-	install -m644 media/retroarch.svg $(DESTDIR)$(PREFIX)/share/pixmaps
+	$(INSTALL) -m755 $(TARGET) $(DESTDIR)$(BIN_DIR)
+	$(INSTALL) -m755 tools/cg2glsl.py $(DESTDIR)$(BIN_DIR)/retroarch-cg2glsl
+	$(INSTALL) -m644 retroarch.cfg $(DESTDIR)$(GLOBAL_CONFIG_DIR)/retroarch.cfg
+	$(INSTALL) -m644 retroarch.desktop $(DESTDIR)$(PREFIX)/share/applications
+	$(INSTALL) -m644 docs/retroarch.6 $(DESTDIR)$(MAN_DIR)/man6
+	$(INSTALL) -m644 docs/retroarch-cg2glsl.6 $(DESTDIR)$(MAN_DIR)/man6
+	$(INSTALL) -m644 media/retroarch.svg $(DESTDIR)$(PREFIX)/share/pixmaps
 	@if test -d media/assets; then \
 		echo "Installing media assets..."; \
 		mkdir -p $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb; \

--- a/libretro-common/rthreads/rthreads.c
+++ b/libretro-common/rthreads/rthreads.c
@@ -21,7 +21,9 @@
  */
 
 #ifdef __unix__
+#ifndef __sun__
 #define _POSIX_C_SOURCE 199309
+#endif
 #endif
 
 #include <stdlib.h>

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -22,6 +22,7 @@ PTHREADLIB=-lpthread
 SOCKETLIB=-lc
 SOCKETHEADER=
 INCLUDES='usr/include usr/local/include'
+SORT=sort
 
 if [ "$OS" = 'BSD' ]; then
    [ -d /usr/local/include ] && add_dirs INCLUDE /usr/local/include
@@ -39,6 +40,8 @@ elif [ "$OS" = 'Win32' ]; then
    DYLIB=
 elif [ "$OS" = 'Cygwin' ]; then
    die 1 'Error: Cygwin is not a supported platform. See https://bot.libretro.com/docs/compilation/windows/'
+elif [ "$OS" = 'SunOS' ]; then
+   SORT=gsort
 fi
 
 add_define MAKEFILE DYLIB_LIB "$DYLIB"
@@ -514,6 +517,6 @@ while [ $# -gt 0 ]; do
    var="${tmpvar#HAVE_}"
    vars="${vars} $var"
 done
-VARS="$(printf %s "$vars" | tr ' ' '\n' | sort)"
+VARS="$(printf %s "$vars" | tr ' ' '\n' | $SORT)"
 create_config_make config.mk $(printf %s "$VARS")
 create_config_header config.h $(printf %s "$VARS")

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -42,6 +42,9 @@ elif [ "$OS" = 'Cygwin' ]; then
    die 1 'Error: Cygwin is not a supported platform. See https://bot.libretro.com/docs/compilation/windows/'
 elif [ "$OS" = 'SunOS' ]; then
    SORT=gsort
+   # for now disabling Pulse as it breaks linking
+   # this will need to be investigated later
+   HAVE_PULSE=no
 fi
 
 add_define MAKEFILE DYLIB_LIB "$DYLIB"

--- a/qb/qb.system.sh
+++ b/qb/qb.system.sh
@@ -36,6 +36,7 @@ if [ -z "$CROSS_COMPILE" ] || [ -z "$OS" ]; then
 		'CYGWIN'*) OS='Cygwin';;
 		'Haiku') OS='Haiku';;
 		'MINGW'*) OS='Win32';;
+		'SunOS') OS='SunOS';;
 		*) OS="Win32";;
 	esac
 fi


### PR DESCRIPTION
These commits allow building RetroArch under Solaris 11 using the GNU developer tools

To build run `./configure` then `gmake` then `sudo gmake install`

Solaris support should be considered very preliminary if not experimental at this point
Only rgui and the sdl video driver are supported for now
Pulse is also disabled on Solaris for now (issue during linking)

There are still issues remaining, like these messages upon runtime:

```
kwyxz@solaris:~$ retroarch
/usr/bin/xdg-screensaver: line 377: no: command not found
mv: illegal option -- T
Usage: mv [-f] [-i] f1 f2
       mv [-f] [-i] f1 ... fn d1
       mv [-f] [-i] d1 d2
```
These will need to be addressed eventually.

I hope I did not do anything too horrifying in my commits :D 