### PR TITLE
(win32)  disable WS_EX_LAYERED when opacity == 100.

### DIFF
--- a/gfx/common/win32_common.c
+++ b/gfx/common/win32_common.c
@@ -813,11 +813,14 @@ bool win32_window_create(void *data, unsigned style,
 
 #if defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0500 /* 2K */
    /* Windows 2000 and above use layered windows to enable transparency */
-   SetWindowLongPtr(main_window.hwnd,
-        GWL_EXSTYLE,
-        GetWindowLongPtr(main_window.hwnd, GWL_EXSTYLE) | WS_EX_LAYERED);
-   SetLayeredWindowAttributes(main_window.hwnd, 0, (255 * 
-            settings->uints.video_window_opacity) / 100, LWA_ALPHA);
+   if(settings->uints.video_window_opacity < 100)
+   {
+      SetWindowLongPtr(main_window.hwnd,
+           GWL_EXSTYLE,
+           GetWindowLongPtr(main_window.hwnd, GWL_EXSTYLE) | WS_EX_LAYERED);
+      SetLayeredWindowAttributes(main_window.hwnd, 0, (255 *
+               settings->uints.video_window_opacity) / 100, LWA_ALPHA);
+   }
 #endif
 #endif
    return true;

--- a/gfx/display_servers/dispserv_win32.c
+++ b/gfx/display_servers/dispserv_win32.c
@@ -113,8 +113,20 @@ static bool win32_set_window_opacity(void *data, unsigned opacity)
 
 #if defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0500
    /* Set window transparency on Windows 2000 and above */
-   if (SetLayeredWindowAttributes(hwnd, 0, (255 * opacity) / 100, LWA_ALPHA))
+   if(opacity < 100)
+   {
+      SetWindowLongPtr(hwnd,
+           GWL_EXSTYLE,
+           GetWindowLongPtr(hwnd, GWL_EXSTYLE) | WS_EX_LAYERED);
+      return SetLayeredWindowAttributes(hwnd, 0, (255 * opacity) / 100, LWA_ALPHA);
+   }
+   else
+   {
+      SetWindowLongPtr(hwnd,
+           GWL_EXSTYLE,
+           GetWindowLongPtr(hwnd, GWL_EXSTYLE) & ~WS_EX_LAYERED);
       return true;
+   }
 #endif
    return false;
 }


### PR DESCRIPTION
WS_EX_LAYERED drastically decreases performance, so only set it when needed.
