### PR TITLE
menu: By default, hide the Images, Videos and Music

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -273,11 +273,11 @@ static bool menu_show_core_updater       = true;
 static bool content_show_settings    = true;
 static bool content_show_favorites   = true;
 #ifdef HAVE_IMAGEVIEWER
-static bool content_show_images      = true;
+static bool content_show_images      = false;
 #endif
-static bool content_show_music       = true;
+static bool content_show_music       = false;
 #ifdef HAVE_FFMPEG
-static bool content_show_video       = true;
+static bool content_show_video       = false;
 #endif
 #ifdef HAVE_NETWORKING
 static bool content_show_netplay     = true;

--- a/configuration.c
+++ b/configuration.c
@@ -1250,11 +1250,11 @@ static struct config_bool_setting *populate_settings_bool(settings_t *settings, 
    SETTING_BOOL("content_show_settings",         &settings->bools.menu_content_show_settings, true, content_show_settings, false);
    SETTING_BOOL("content_show_favorites",        &settings->bools.menu_content_show_favorites, true, content_show_favorites, false);
 #ifdef HAVE_IMAGEVIEWER
-   SETTING_BOOL("content_show_images",           &settings->bools.menu_content_show_images, true, content_show_images, false);
+   SETTING_BOOL("content_show_images",           &settings->bools.menu_content_show_images, false, content_show_images, false);
 #endif
-   SETTING_BOOL("content_show_music",            &settings->bools.menu_content_show_music, true, content_show_music, false);
+   SETTING_BOOL("content_show_music",            &settings->bools.menu_content_show_music, false, content_show_music, false);
 #ifdef HAVE_FFMPEG
-   SETTING_BOOL("content_show_video",            &settings->bools.menu_content_show_video, true, content_show_video, false);
+   SETTING_BOOL("content_show_video",            &settings->bools.menu_content_show_video, false, content_show_video, false);
 #endif
 #ifdef HAVE_NETWORKING
    SETTING_BOOL("content_show_netplay",          &settings->bools.menu_content_show_netplay, true, content_show_netplay, false);


### PR DESCRIPTION
## Description

Some people have asked to disable the Music, Images and Video playlists. This PR makes them disabled by default. You are still able to go into the options and enable them.


