### PR TITLE
gl2: Update chain to only update to chain_data

### DIFF
--- a/gfx/drivers_renderchain/gl2_renderchain.c
+++ b/gfx/drivers_renderchain/gl2_renderchain.c
@@ -1278,10 +1278,8 @@ static void gl2_renderchain_copy_frame(
       const void *frame,
       unsigned width, unsigned height, unsigned pitch)
 {
-   gl_t                 *gl = (gl_t*)data;
-   gl2_renderchain_t *chain = (gl2_renderchain_t*)chain_data;
-
-   (void)chain;
+   gl_t *gl = (gl_t*)data;
+   gl2_renderchain_t *chain;
 
 #if defined(HAVE_PSGL)
    {
@@ -1301,6 +1299,7 @@ static void gl2_renderchain_copy_frame(
    }
 #elif defined(HAVE_OPENGLES)
 #if defined(HAVE_EGL)
+   chain = (gl2_renderchain_t*)chain_data;
    if (chain->egl_images)
    {
       gfx_ctx_image_t img_info;


### PR DESCRIPTION
This cleans up the declaration of chain.

## Description

On RPi, we were having some troubles with chain and chain_data. Found that it was setting chain, and then (void)chain-ing. Let's declare chain, but then only set it when needed.

## Related Pull Requests

- https://github.com/RobLoach/RetroArch/commit/763e6f766c921de5cf1254a5ea333f3f29a23000
- https://github.com/libretro/RetroArch/pull/5860

## Reviewers

- @Kivutar 
