### PR TITLE
qb: Silence shellcheck warning.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -22,7 +22,7 @@ PTHREADLIB=-lpthread
 SOCKETLIB=-lc
 SOCKETHEADER=
 INCLUDES='usr/include usr/local/include'
-SORT=sort
+SORT='sort'
 
 if [ "$OS" = 'BSD' ]; then
    [ -d /usr/local/include ] && add_dirs INCLUDE /usr/local/include
@@ -41,7 +41,7 @@ elif [ "$OS" = 'Win32' ]; then
 elif [ "$OS" = 'Cygwin' ]; then
    die 1 'Error: Cygwin is not a supported platform. See https://bot.libretro.com/docs/compilation/windows/'
 elif [ "$OS" = 'SunOS' ]; then
-   SORT=gsort
+   SORT='gsort'
    # for now disabling Pulse as it breaks linking
    # this will need to be investigated later
    HAVE_PULSE=no


### PR DESCRIPTION
## Description

Silences a trivial shellcheck warning from a recent PR.

## Related Issues

```
Line 25:
SORT=sort
^-- SC2209: Use var=$(command) to assign output (or quote to assign string).
```
https://github.com/koalaman/shellcheck/wiki/SC2209

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/6086

## Reviewers

@twinaphex, @kwyxz