### PR TITLE
emscripten: Allow hiding the top menu

### DIFF
--- a/pkg/emscripten/libretro/index.html
+++ b/pkg/emscripten/libretro/index.html
@@ -95,6 +95,11 @@
                    </li>
                 </div>
                </ul>
+               <div class="toggleMenu">
+                  <button class="btn btn-primary" id="btnHideMenu" title="Toggle Menu">
+                     <span class="fa fa-chevron-up" id="icnHideMenu"></span> <span class="sr-only">Hide Top Navigation</span>
+                  </button>
+               </div>
            </div>
            <!--/.Collapse content-->
        </div>
@@ -102,6 +107,11 @@
    <div class="bg-inverse webplayer-container">
       <div class="container">
          <div class="webplayer_border text-xs-center" id="canvas_div">
+            <div class="showMenu">
+               <button type="button" class="btn btn-link">
+                  <span class="fa fa-chevron-down" id="icnShowMenu"></span> <span class="sr-only">Show Top Navigation</span>
+               </button>
+            </div>
             <canvas class="webplayer" id="canvas" tabindex="1" oncontextmenu="event.preventDefault()" style="display: none"></canvas>
             <img class="webplayer-preview img-fluid" src="media/canvas.png" width="960px" height="720px" alt="RetroArch Logo">
          </div>

--- a/pkg/emscripten/libretro/libretro.css
+++ b/pkg/emscripten/libretro/libretro.css
@@ -92,8 +92,23 @@ textarea {
     font-size: 0.7em;
     height: 95%;
     width:  95%;
-    border-style: none; 
-    border-color: transparent; 
+    border-style: none;
+    border-color: transparent;
     overflow: auto;
     resize: none;
+}
+
+/**
+ * Toggle Top Navigation
+ */
+.toggleMenu {
+   float: right;
+}
+.showMenu {
+   position: absolute;
+   right: 0;
+   cursor: pointer;
+}
+#icnShowMenu {
+   color: #565656 !important;
 }

--- a/pkg/emscripten/libretro/libretro.js
+++ b/pkg/emscripten/libretro/libretro.js
@@ -230,6 +230,13 @@ $(function() {
       placement: 'right'
    });
 
+   // Allow hiding the top menu.
+   $('.showMenu').hide();
+   $('#btnHideMenu, .showMenu').click(function () {
+      $('nav').slideToggle('slow');
+      $('.showMenu').toggle('slow');
+   });
+
    /**
     * Attempt to disable some default browser keys.
     */


### PR DESCRIPTION

## Description

This allows you to hide the top navigation to allow focus on RetroArch. You can re-expand it afterwards by clicking the discreet chevron that appear afterwards.

![screenshot at 2018-01-14 23-59-18](https://user-images.githubusercontent.com/25086/34927813-0774632a-f987-11e7-87e6-30c91fd8782a.png)
