### PR TITLE
qb: Enable pulse detection for SunOS again.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -42,9 +42,6 @@ elif [ "$OS" = 'Cygwin' ]; then
    die 1 'Error: Cygwin is not a supported platform. See https://bot.libretro.com/docs/compilation/windows/'
 elif [ "$OS" = 'SunOS' ]; then
    SORT='gsort'
-   # for now disabling Pulse as it breaks linking
-   # this will need to be investigated later
-   HAVE_PULSE=no
 fi
 
 add_define MAKEFILE DYLIB_LIB "$DYLIB"


### PR DESCRIPTION
## Description

Enables pulse audio detection for SunOS again since it should no longer break linking.

## Related Issues

https://github.com/libretro/RetroArch/issues/6111

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/6086

## Reviewers

@twinaphex, @kwyxz