### PR TITLE
Minor Emscripten template fixes

### DIFF
--- a/pkg/emscripten/libretro/embed.html
+++ b/pkg/emscripten/libretro/embed.html
@@ -71,18 +71,6 @@
          </div>
       </div>
    </div>
-   <div class="container">
-      <div class="row">
-         <div class="col-sm-12 form-group btn-group text-xs-center p-t-2">
-            <div class="card">
-                <div class="view overlay hm-white-slight" align="center">
-                     <textarea id="output" rows="15"></textarea>
-                </div>
-            </div>
-
-         </div>
-      </div>
-   </div>
 
    <script src="//code.jquery.com/jquery-3.1.0.min.js"></script>
    <script src="//rawgit.com/jeresig/jquery.hotkeys/master/jquery.hotkeys.js"></script>

--- a/pkg/emscripten/libretro/libretro.css
+++ b/pkg/emscripten/libretro/libretro.css
@@ -6,9 +6,11 @@
 
 /**
  * Make sure the background of the player is black.
+ * Also make sure line height is 0 so there's no extra space on the bottom.
  */
 .webplayer-container {
   background-color: black;
+  line-height: 0;
 }
 
 /**
@@ -113,7 +115,6 @@ textarea {
    color: #565656 !important;
 }
 
-/* fix weird white bar in chrome when fullscreen */
-:-webkit-full-screen {
-  height: 100%;
+.navbar {
+  box-shadow: none;
 }


### PR DESCRIPTION
Mainly fixes the padding around the render area. No longer has extra padding on the bottom of the black render area. Also removes the drop shadow from the navbar so it doesn't appear over the render area.