### PR TITLE
Add missing {, |, } and ~ to the libretro API

### DIFF
--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -375,6 +375,10 @@ enum retro_key
    RETROK_x              = 120,
    RETROK_y              = 121,
    RETROK_z              = 122,
+   RETROK_LEFTBRACE      = 123,
+   RETROK_BAR            = 124,
+   RETROK_RIGHTBRACE     = 125,
+   RETROK_TILDE          = 126,
    RETROK_DELETE         = 127,
 
    RETROK_KP0            = 256,


### PR DESCRIPTION
## Description

This adds four keys to the libretro API.

Missing keys are found in TyrQuake's source:

https://github.com/libretro/tyrquake/blob/be5aede91/common/keys.h#L111-L114