### PR TITLE
more build modifications to emscripten (needed for mupen64 to work)

### DIFF
--- a/Makefile.emscripten
+++ b/Makefile.emscripten
@@ -26,7 +26,7 @@ HAVE_STATIC_VIDEO_FILTERS = 1
 HAVE_STATIC_AUDIO_FILTERS = 1
 MEMORY = 536870912
 
-PRECISE_F32 = 2
+PRECISE_F32 = 1
 
 OBJDIR := obj-emscripten
 
@@ -37,7 +37,7 @@ endif
 #if you compile with SDL2 flag add this Emscripten flag "-s USE_SDL=2" to LDFLAGS:
 
 LIBS    := -s USE_ZLIB=1
-LDFLAGS := -L. --no-heap-copy -s USE_ZLIB=1 -s TOTAL_MEMORY=$(MEMORY) -s NO_EXIT_RUNTIME=0 \
+LDFLAGS := -L. --no-heap-copy -s USE_ZLIB=1 -s TOTAL_MEMORY=$(MEMORY) -s NO_EXIT_RUNTIME=0 -s FULL_ES2=1 -s BINARYEN_TRAP_MODE=\"clamp\" \
            -s EXPORTED_FUNCTIONS="['_main', '_malloc', '_cmd_savefiles', '_cmd_save_state', '_cmd_load_state', '_cmd_take_screenshot']" \
            --js-library emscripten/library_rwebaudio.js \
            --js-library emscripten/library_rwebcam.js
@@ -83,7 +83,7 @@ RARCH_OBJ := $(addprefix $(OBJDIR)/,$(OBJ))
 
 all: $(TARGET)
 
-$(TARGET): $(RARCH_OBJ)
+$(TARGET): $(RARCH_OBJ) $(libretro)
 	@$(if $(Q), $(shell echo echo LD $@),)
 	$(Q)$(LD) -o $@ $(RARCH_OBJ) $(libretro) $(LIBS) $(LDFLAGS)
 


### PR DESCRIPTION
This enabled more accurate floating-point WASM code, along with fixing potential errors with float->int conversions in WASM. It also enabled full GLES2 which helps Mupen64 show more on the screen, but is still glitchy.