### PR TITLE
fix display name for builtin autoconfs again

### DIFF
--- a/tasks/task_autodetect.c
+++ b/tasks/task_autodetect.c
@@ -278,7 +278,7 @@ static void input_autoconfigure_joypad_add(config_file_t *conf,
    if (!string_is_empty(display_name))
       input_config_set_device_display_name(params->idx, display_name);
    else
-      input_config_set_device_display_name(params->idx, "N/A");
+      input_config_set_device_display_name(params->idx, params->name);
    if (!string_is_empty(conf->path))
       input_config_set_device_config_name(params->idx, path_basename(conf->path));
    else


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises


## Description

Fix builtin autoconfs properly this time so it won't show N/A all the time

https://github.com/libretro/RetroArch/commit/2e210b6bb4d4ea512dbc3903c68a25255dc98303
