### PR TITLE
Show GL hex error in hex

### DIFF
--- a/gfx/drivers_renderchain/gl2_renderchain.c
+++ b/gfx/drivers_renderchain/gl2_renderchain.c
@@ -1038,8 +1038,8 @@ static bool gl2_renderchain_init_hw_render(
       status = gl2_check_fb_status(RARCH_GL_FRAMEBUFFER);
       if (status != RARCH_GL_FRAMEBUFFER_COMPLETE)
       {
-         RARCH_ERR("[GL]: Failed to create HW render FBO #%u, error: 0x%u.\n",
-               i, (unsigned)status);
+         RARCH_ERR("[GL]: Failed to create HW render FBO #%u, error: 0x%04x.\n",
+               i, status);
          return false;
       }
    }


### PR DESCRIPTION
Fixes an issue whereby a hexadecimal error value was being printed in
decimal.

Tested on a RPi that suffers from issue #6078.

Signed-off-by: Mahyar Koshkouei <mahyar.koshkouei@gmail.com>