### PR TITLE
Update Haiku port to allow it to build again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,23 +194,23 @@ install: $(TARGET)
 	rm -f $(OBJDIR)/git_version.o
 	mkdir -p $(DESTDIR)$(BIN_DIR) 2>/dev/null || /bin/true
 	mkdir -p $(DESTDIR)$(GLOBAL_CONFIG_DIR) 2>/dev/null || /bin/true
-	mkdir -p $(DESTDIR)$(PREFIX)/share/applications 2>/dev/null || /bin/true
+	mkdir -p $(DESTDIR)$(ASSETS_DIR)/applications 2>/dev/null || /bin/true
 	mkdir -p $(DESTDIR)$(MAN_DIR)/man6 2>/dev/null || /bin/true
-	mkdir -p $(DESTDIR)$(PREFIX)/share/pixmaps 2>/dev/null || /bin/true
+	mkdir -p $(DESTDIR)$(ASSETS_DIR)/pixmaps 2>/dev/null || /bin/true
 	cp $(TARGET) $(DESTDIR)$(BIN_DIR)
 	cp tools/cg2glsl.py $(DESTDIR)$(BIN_DIR)/retroarch-cg2glsl
 	cp retroarch.cfg $(DESTDIR)$(GLOBAL_CONFIG_DIR)
-	cp retroarch.desktop $(DESTDIR)$(PREFIX)/share/applications
+	cp retroarch.desktop $(DESTDIR)$(ASSETS_DIR)/applications
 	cp docs/retroarch.6 $(DESTDIR)$(MAN_DIR)/man6
 	cp docs/retroarch-cg2glsl.6 $(DESTDIR)$(MAN_DIR)/man6
-	cp media/retroarch.svg $(DESTDIR)$(PREFIX)/share/pixmaps
+	cp media/retroarch.svg $(DESTDIR)$(ASSETS_DIR)/pixmaps
 	chmod 755 $(DESTDIR)$(BIN_DIR)/$(TARGET)
 	chmod 755 $(DESTDIR)$(BIN_DIR)/retroarch-cg2glsl
 	chmod 644 $(DESTDIR)$(GLOBAL_CONFIG_DIR)/retroarch.cfg
-	chmod 644 $(DESTDIR)$(PREFIX)/share/applications/retroarch.desktop
+	chmod 644 $(DESTDIR)$(ASSETS_DIR)/applications/retroarch.desktop
 	chmod 644 $(DESTDIR)$(MAN_DIR)/man6/retroarch.6
 	chmod 644 $(DESTDIR)$(MAN_DIR)/man6/retroarch-cg2glsl.6
-	chmod 644 $(DESTDIR)$(PREFIX)/share/pixmaps/retroarch.svg
+	chmod 644 $(DESTDIR)$(ASSETS_DIR)/pixmaps/retroarch.svg
 	@if test -d media/assets; then \
 		echo "Installing media assets..."; \
 		mkdir -p $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb; \
@@ -224,10 +224,10 @@ uninstall:
 	rm -f $(DESTDIR)$(BIN_DIR)/retroarch
 	rm -f $(DESTDIR)$(BIN_DIR)/retroarch-cg2glsl
 	rm -f $(DESTDIR)$(GLOBAL_CONFIG_DIR)/retroarch.cfg
-	rm -f $(DESTDIR)$(PREFIX)/share/applications/retroarch.desktop
+	rm -f $(DESTDIR)$(ASSETS_DIR)/applications/retroarch.desktop
 	rm -f $(DESTDIR)$(MAN_DIR)/man6/retroarch.6
 	rm -f $(DESTDIR)$(MAN_DIR)/man6/retroarch-cg2glsl.6
-	rm -f $(DESTDIR)$(PREFIX)/share/pixmaps/retroarch.svg
+	rm -f $(DESTDIR)$(ASSETS_DIR)/pixmaps/retroarch.svg
 	rm -rf $(DESTDIR)$(ASSETS_DIR)/retroarch
 
 clean:

--- a/Makefile.common
+++ b/Makefile.common
@@ -115,6 +115,13 @@ else
    OSX := 0
 endif
 
+ifneq ($(findstring Haiku,$(OS)),)
+   LIBS += -lroot -lnetwork
+	HAVE_UNIX = 1
+else
+   LIBS += -lm
+endif
+
 ifneq ($(findstring Linux,$(OS)),)
    LIBS += -lrt
    OBJ += input/drivers/linuxraw_input.o \
@@ -129,12 +136,6 @@ endif
 
 ifeq ($(TARGET), retroarch_3ds)
 	OBJ += frontend/drivers/platform_ctr.o
-endif
-
-ifeq ($(findstring Haiku,$(OS)),)
-   LIBS += -lm
-else
-   LIBS += -lroot -lnetwork
 endif
 
 # Git
@@ -1108,7 +1109,8 @@ endif
 endif
 
 ifeq ($(HAVE_EGL), 1)
-	DEFINES += -DHAVE_EGL
+   DEFINES += -DHAVE_EGL $(EGL_CFLAGS)
+   LIBS += $(EGL_LIBS)
    OBJ += gfx/common/egl_common.o
 endif
 

--- a/file_path_special.c
+++ b/file_path_special.c
@@ -101,16 +101,18 @@ bool fill_pathname_application_data(char *s, size_t len)
    const char *xdg     = getenv("XDG_CONFIG_HOME");
    const char *appdata = getenv("HOME");
 
-   /* XDG_CONFIG_HOME falls back to $HOME/.config. */
+   /* XDG_CONFIG_HOME falls back to $HOME/.config with most Unix systems */
+   /* On Haiku, it is set by default to /home/user/config/settings */
    if (xdg)
    {
-      fill_pathname_join(s, xdg, "retroarch", len);
+      fill_pathname_join(s, xdg, "retroarch/", len);
       return true;
    }
 
    if (appdata)
    {
 #ifdef __HAIKU__
+      /* in theory never used as Haiku has XDG_CONFIG_HOME set by default */
       fill_pathname_join(s, appdata,
             "config/settings/retroarch/", len);
 #else

--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -1226,6 +1226,8 @@ static void frontend_unix_get_os(char *s,
    strlcpy(s, "DragonFly BSD", len);
 #elif defined(BSD)
    strlcpy(s, "BSD", len);
+#elif defined(__HAIKU__)
+   strlcpy(s, "Haiku", len);
 #else
    strlcpy(s, "Linux", len);
 #endif

--- a/libretro-common/file/file_path.c
+++ b/libretro-common/file/file_path.c
@@ -36,6 +36,9 @@
 #ifdef __APPLE__
 #include <CoreFoundation/CoreFoundation.h>
 #endif
+#ifdef __HAIKU__
+#include <kernel/image.h>
+#endif
 #ifndef __MACH__
 #include <compat/strl.h>
 #include <compat/posix_string.h>

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -10,10 +10,15 @@ add_define MAKEFILE NOUNUSED_VARIABLE "$HAVE_NOUNUSED_VARIABLE"
 [ -z "$CROSS_COMPILE" ] && [ -d /opt/local/lib ] && add_dirs LIBRARY /opt/local/lib
 
 [ "$GLOBAL_CONFIG_DIR" ] || \
-{	case "$PREFIX" in
-		/usr*) GLOBAL_CONFIG_DIR=/etc ;;
-		*) GLOBAL_CONFIG_DIR="$PREFIX"/etc ;;
-	esac
+{
+	if [ "$OS" = 'Haiku' ]; then
+		GLOBAL_CONFIG_DIR="$PREFIX"/settings
+	else
+		case "$PREFIX" in
+			/usr*) GLOBAL_CONFIG_DIR=/etc ;;
+			*) GLOBAL_CONFIG_DIR="$PREFIX"/etc ;;
+		esac
+	fi
 }
 
 DYLIB=-ldl;
@@ -157,9 +162,16 @@ fi
    add_define MAKEFILE libretro "$LIBRETRO"
 }
 
+
+if [ "$OS" = 'Haiku' ]; then
+add_define MAKEFILE ASSETS_DIR "${ASSETS_DIR:-${PREFIX}/data}"
+add_define MAKEFILE MAN_DIR "${MAN_DIR:-${PREFIX}/documentation/man}"
+else
 add_define MAKEFILE ASSETS_DIR "${ASSETS_DIR:-${PREFIX}/share}"
-add_define MAKEFILE BIN_DIR "${BIN_DIR:-${PREFIX}/bin}"
 add_define MAKEFILE MAN_DIR "${MAN_DIR:-${PREFIX}/share/man}"
+fi
+
+add_define MAKEFILE BIN_DIR "${BIN_DIR:-${PREFIX}/bin}"
 
 if [ "$OS" = 'DOS' ]; then
    HAVE_SHADERPIPELINE=no

--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -1,7 +1,11 @@
 MAKEFILE_DEFINES=''
 CONFIG_DEFINES=''
 
-[ "$PREFIX" ] || PREFIX="/usr/local"
+if [ "$OS" = 'Haiku' ]; then
+	[ "$PREFIX" ] || PREFIX="/boot/home/config/non-packaged"
+else
+	[ "$PREFIX" ] || PREFIX="/usr/local"
+fi
 
 add_define() # $1 = MAKEFILE or CONFIG $2 = define $3 = value
 { eval "${1}_DEFINES=\"\${${1}_DEFINES} $2=$3\""; }


### PR DESCRIPTION
## Description

It seems like the Haiku port had been left untouched since 2012, and it was not properly building any more. This is an attempt to remediate the situation.

## Related Issues

Fixes a few build issues during compilation and linking.

## Note

There still are things that will need to be worked on, the most urgent that come to mind:
- subfolders in retroarch configuration folder are not created
- command line invocation ignores additional options