### PR TITLE
Makefile: Fix make install.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,23 +194,23 @@ install: $(TARGET)
 	rm -f $(OBJDIR)/git_version.o
 	mkdir -p $(DESTDIR)$(BIN_DIR) 2>/dev/null || /bin/true
 	mkdir -p $(DESTDIR)$(GLOBAL_CONFIG_DIR) 2>/dev/null || /bin/true
-	mkdir -p $(DESTDIR)$(ASSETS_DIR)/applications 2>/dev/null || /bin/true
+	mkdir -p $(DESTDIR)$(PREFIX)/share/applications 2>/dev/null || /bin/true
 	mkdir -p $(DESTDIR)$(MAN_DIR)/man6 2>/dev/null || /bin/true
-	mkdir -p $(DESTDIR)$(ASSETS_DIR)/pixmaps 2>/dev/null || /bin/true
+	mkdir -p $(DESTDIR)$(PREFIX)/share/pixmaps 2>/dev/null || /bin/true
 	cp $(TARGET) $(DESTDIR)$(BIN_DIR)
 	cp tools/cg2glsl.py $(DESTDIR)$(BIN_DIR)/retroarch-cg2glsl
 	cp retroarch.cfg $(DESTDIR)$(GLOBAL_CONFIG_DIR)
-	cp retroarch.desktop $(DESTDIR)$(ASSETS_DIR)/applications
+	cp retroarch.desktop $(DESTDIR)$(PREFIX)/share/applications
 	cp docs/retroarch.6 $(DESTDIR)$(MAN_DIR)/man6
 	cp docs/retroarch-cg2glsl.6 $(DESTDIR)$(MAN_DIR)/man6
-	cp media/retroarch.svg $(DESTDIR)$(ASSETS_DIR)/pixmaps
+	cp media/retroarch.svg $(DESTDIR)$(PREFIX)/share/pixmaps
 	chmod 755 $(DESTDIR)$(BIN_DIR)/$(TARGET)
 	chmod 755 $(DESTDIR)$(BIN_DIR)/retroarch-cg2glsl
 	chmod 644 $(DESTDIR)$(GLOBAL_CONFIG_DIR)/retroarch.cfg
-	chmod 644 $(DESTDIR)$(ASSETS_DIR)/applications/retroarch.desktop
+	chmod 644 $(DESTDIR)$(PREFIX)/share/applications/retroarch.desktop
 	chmod 644 $(DESTDIR)$(MAN_DIR)/man6/retroarch.6
 	chmod 644 $(DESTDIR)$(MAN_DIR)/man6/retroarch-cg2glsl.6
-	chmod 644 $(DESTDIR)$(ASSETS_DIR)/pixmaps/retroarch.svg
+	chmod 644 $(DESTDIR)$(PREFIX)/share/pixmaps/retroarch.svg
 	@if test -d media/assets; then \
 		echo "Installing media assets..."; \
 		mkdir -p $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb; \
@@ -224,10 +224,10 @@ uninstall:
 	rm -f $(DESTDIR)$(BIN_DIR)/retroarch
 	rm -f $(DESTDIR)$(BIN_DIR)/retroarch-cg2glsl
 	rm -f $(DESTDIR)$(GLOBAL_CONFIG_DIR)/retroarch.cfg
-	rm -f $(DESTDIR)$(ASSETS_DIR)/applications/retroarch.desktop
+	rm -f $(DESTDIR)$(PREFIX)/share/applications/retroarch.desktop
 	rm -f $(DESTDIR)$(MAN_DIR)/man6/retroarch.6
 	rm -f $(DESTDIR)$(MAN_DIR)/man6/retroarch-cg2glsl.6
-	rm -f $(DESTDIR)$(ASSETS_DIR)/pixmaps/retroarch.svg
+	rm -f $(DESTDIR)$(PREFIX)/share/pixmaps/retroarch.svg
 	rm -rf $(DESTDIR)$(ASSETS_DIR)/retroarch
 
 clean:

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -10,15 +10,10 @@ add_define MAKEFILE NOUNUSED_VARIABLE "$HAVE_NOUNUSED_VARIABLE"
 [ -z "$CROSS_COMPILE" ] && [ -d /opt/local/lib ] && add_dirs LIBRARY /opt/local/lib
 
 [ "$GLOBAL_CONFIG_DIR" ] || \
-{
-	if [ "$OS" = 'Haiku' ]; then
-		GLOBAL_CONFIG_DIR="$PREFIX"/settings
-	else
-		case "$PREFIX" in
-			/usr*) GLOBAL_CONFIG_DIR=/etc ;;
-			*) GLOBAL_CONFIG_DIR="$PREFIX"/etc ;;
-		esac
-	fi
+{	case "$PREFIX" in
+		/usr*) GLOBAL_CONFIG_DIR=/etc ;;
+		*) GLOBAL_CONFIG_DIR="$PREFIX"/etc ;;
+	esac
 }
 
 DYLIB=-ldl;
@@ -162,16 +157,9 @@ fi
    add_define MAKEFILE libretro "$LIBRETRO"
 }
 
-
-if [ "$OS" = 'Haiku' ]; then
-add_define MAKEFILE ASSETS_DIR "${ASSETS_DIR:-${PREFIX}/data}"
-add_define MAKEFILE MAN_DIR "${MAN_DIR:-${PREFIX}/documentation/man}"
-else
 add_define MAKEFILE ASSETS_DIR "${ASSETS_DIR:-${PREFIX}/share}"
-add_define MAKEFILE MAN_DIR "${MAN_DIR:-${PREFIX}/share/man}"
-fi
-
 add_define MAKEFILE BIN_DIR "${BIN_DIR:-${PREFIX}/bin}"
+add_define MAKEFILE MAN_DIR "${MAN_DIR:-${PREFIX}/share/man}"
 
 if [ "$OS" = 'DOS' ]; then
    HAVE_SHADERPIPELINE=no

--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -1,11 +1,7 @@
 MAKEFILE_DEFINES=''
 CONFIG_DEFINES=''
 
-if [ "$OS" = 'Haiku' ]; then
-	[ "$PREFIX" ] || PREFIX="/boot/home/config/non-packaged"
-else
-	[ "$PREFIX" ] || PREFIX="/usr/local"
-fi
+[ "$PREFIX" ] || PREFIX="/usr/local"
 
 add_define() # $1 = MAKEFILE or CONFIG $2 = define $3 = value
 { eval "${1}_DEFINES=\"\${${1}_DEFINES} $2=$3\""; }


### PR DESCRIPTION
## Description

Partially reverts https://github.com/libretro/RetroArch/commit/b9585df325234b9545903112f554b25e4fe39139

That commit broke my Slackbuild and likely other linux packages which does not use `$(ASSETS_DIR)` for anything, but assets... Which for example the `.svg` or `.desktop` files are not part of.

## Related Issues

`make install` will install files to the wrong directories.

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/6140

## Reviewers

@twinaphex, @kwyxz
