### PR TITLE
Enable black frame insertion on Emscripten

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ retroarch.js
 retroarch.js.mem
 *.bc
 *.wasm
+
+# only ignore .js files in the repo root
+/*.js

--- a/frontend/drivers/platform_emscripten.c
+++ b/frontend/drivers/platform_emscripten.c
@@ -24,6 +24,8 @@
 #include <file/file_path.h>
 #include <string/stdstring.h>
 #include <retro_timers.h>
+#include <gfx/video_frame.h>
+#include <glsym/glsym.h>
 
 #ifdef HAVE_CONFIG_H
 #include "../../config.h"
@@ -47,6 +49,7 @@
 void RWebAudioRecalibrateTime(void);
 
 static unsigned emscripten_fullscreen_reinit;
+static unsigned emscripten_frame_count = 0;
 
 static EM_BOOL emscripten_fullscreenchange_cb(int event_type,
    const EmscriptenFullscreenChangeEvent *fullscreen_change_event,
@@ -63,10 +66,31 @@ static EM_BOOL emscripten_fullscreenchange_cb(int event_type,
 
 static void emscripten_mainloop(void)
 {
-   unsigned sleep_ms = 0;
    int ret;
+   video_frame_info_t video_info;
+   unsigned sleep_ms = 0;
 
    RWebAudioRecalibrateTime();
+
+   emscripten_frame_count++;
+
+   video_driver_build_info(&video_info);
+
+   /* Disable BFI during fast forward, slow-motion,
+    * and pause to prevent flicker. */
+   if (
+         video_info.black_frame_insertion
+         && !video_info.input_driver_nonblock_state
+         && !video_info.runloop_is_slowmotion
+         && !video_info.runloop_is_paused)
+   {
+      if ((emscripten_frame_count & 1) == 0)
+      {
+         glClear(GL_COLOR_BUFFER_BIT);
+         video_info.cb_swap_buffers(video_info.context_data, &video_info);
+         return;
+      }
+   }
 
    if (emscripten_fullscreen_reinit != 0)
    {

--- a/gfx/drivers/gl.c
+++ b/gfx/drivers/gl.c
@@ -1188,6 +1188,8 @@ static bool gl_frame(void *data, const void *frame,
 #endif
             gl_pbo_async_readback(gl);
 
+   /* emscripten has to do black frame insertion in its main loop */
+#ifndef EMSCRIPTEN
    /* Disable BFI during fast forward, slow-motion,
     * and pause to prevent flicker. */
    if (
@@ -1199,6 +1201,7 @@ static bool gl_frame(void *data, const void *frame,
       video_info->cb_swap_buffers(video_info->context_data, video_info);
       glClear(GL_COLOR_BUFFER_BIT);
    }
+#endif
 
    video_info->cb_swap_buffers(video_info->context_data, video_info);
 


### PR DESCRIPTION
since we don't have direct control over V-sync, we can do black frame insertion based on the emscripten main loop.

On a 120Hz monitor, it works fairly well in Chrome. Not quite as well in Firefox, since requestAnimationFrame seems to have issues in Firefox when you're past 60Hz.