### PR TITLE
Replace malloc() with calloc() in switch_gfx.c

### DIFF
--- a/gfx/drivers/switch_gfx.c
+++ b/gfx/drivers/switch_gfx.c
@@ -63,7 +63,7 @@ static void *switch_init(const video_info_t *video,
       const input_driver_t **input, void **input_data)
 {
    unsigned x, y;
-   switch_video_t *sw = malloc(sizeof(*sw));
+   switch_video_t *sw = calloc(sizeof(*sw), 1);
    if (!sw)
       return NULL;
 


### PR DESCRIPTION
## Description

Fixes random crashes caused by uninitialised memory on the Nintendo Switch

## Reviewers

@misson20000 