### PR TITLE
(msvc) support msvc's Predefined Macros in features_cpu.c

### DIFF
--- a/Makefile.msvc
+++ b/Makefile.msvc
@@ -108,7 +108,8 @@ export PATH    := $(PATH)
 #$(info PATH : $(PATH))
 #$(error end)
 
-ifeq ($(TARGET_ARCH),x64)
+DEFINES += -D__SSE__ -D__SSE2__
+ifeq ($(TARGET_ARCH2),x64)
 DEFINES += -D__x86_64__
 else
 #DEFINES += -D__i686__

--- a/libretro-common/features/features_cpu.c
+++ b/libretro-common/features/features_cpu.c
@@ -243,7 +243,7 @@ retro_time_t cpu_features_get_time_usec(void)
 #endif
 }
 
-#if defined(__x86_64__) || defined(__i386__) || defined(__i486__) || defined(__i686__)
+#if defined(__x86_64__) || defined(__i386__) || defined(__i486__) || defined(__i686__) || defined(_M_X64) || defined(_M_IX86)
 #define CPU_X86
 #endif
 


### PR DESCRIPTION
- add missing defines to makefile.msvc.
