### PR TITLE
Fix formatting use in order title ids

### DIFF
--- a/pkg/ctr/Makefile.cores
+++ b/pkg/ctr/Makefile.cores
@@ -240,17 +240,17 @@ else ifeq ($(LIBRETRO), fuse)
    APP_BANNER          = pkg/ctr/assets/fuse_banner.png
    
 else ifeq ($(LIBRETRO), stella)
-	APP_TITLE           = Stella Libretro
-	APP_PRODUCT_CODE    = RARCH-STELLA
-	APP_UNIQUE_ID       = 0xBAC2C
-	APP_ICON            = pkg/ctr/assets/stella.png
-	APP_BANNER          = pkg/ctr/assets/stella_banner.png
+   APP_TITLE           = Stella Libretro
+   APP_PRODUCT_CODE    = RARCH-STELLA
+   APP_UNIQUE_ID       = 0xBAC20
+   APP_ICON            = pkg/ctr/assets/stella.png
+   APP_BANNER          = pkg/ctr/assets/stella_banner.png
 	
 else ifeq ($(LIBRETRO), prosystem)
-	APP_TITLE           = ProSystem Libretro
-	APP_PRODUCT_CODE    = RARCH-PROSYSTEM
-	APP_UNIQUE_ID       = 0xBAC3C
-	APP_ICON            = pkg/ctr/assets/prosystem.png
-	APP_BANNER          = pkg/ctr/assets/prosystem_banner.png
+   APP_TITLE           = ProSystem Libretro
+   APP_PRODUCT_CODE    = RARCH-PROSYSTEM
+   APP_UNIQUE_ID       = 0xBAC21
+   APP_ICON            = pkg/ctr/assets/prosystem.png
+   APP_BANNER          = pkg/ctr/assets/prosystem_banner.png
 
 endif


### PR DESCRIPTION
Its best to change the title ids now before anyone installs these with the old ones.(there not on the build bot yet)