### PR TITLE
[OSX]Modify HID buttons detection algorithm. [IOS9]Remove HID entry from menu.

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -228,6 +228,7 @@ enum joypad_driver_enum
    JOYPAD_HID,
    JOYPAD_QNX,
    JOYPAD_RWEBPAD,
+   JOYPAD_MFI,
    JOYPAD_NULL
 };
 
@@ -460,6 +461,8 @@ static enum joypad_driver_enum JOYPAD_DEFAULT_DRIVER = JOYPAD_HID;
 static enum joypad_driver_enum JOYPAD_DEFAULT_DRIVER = JOYPAD_QNX;
 #elif defined(EMSCRIPTEN)
 static enum joypad_driver_enum JOYPAD_DEFAULT_DRIVER = JOYPAD_RWEBPAD;
+#elif defined(IOS)
+static enum joypad_driver_enum JOYPAD_DEFAULT_DRIVER = JOYPAD_MFI;
 #else
 static enum joypad_driver_enum JOYPAD_DEFAULT_DRIVER = JOYPAD_NULL;
 #endif
@@ -863,6 +866,8 @@ const char *config_get_default_joypad(void)
          return "rwebpad";
       case JOYPAD_DOS:
          return "dos";
+      case JOYPAD_MFI:
+         return "mfi";
       case JOYPAD_NULL:
          break;
    }

--- a/pkg/apple/RetroArch_iOS9.xcodeproj/project.pbxproj
+++ b/pkg/apple/RetroArch_iOS9.xcodeproj/project.pbxproj
@@ -251,7 +251,7 @@
 				ORGANIZATIONNAME = RetroArch;
 				TargetAttributes = {
 					0FDA2A701BE1AFA800F2B5DA = {
-						DevelopmentTeam = UK699V5ZS8;
+						DevelopmentTeam = 38QVPJE4NW;
 					};
 				};
 			};
@@ -341,7 +341,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_RESOURCE_RULES_PATH = "$(SDKROOT)/ResourceRules.plist";
-				DEVELOPMENT_TEAM = UK699V5ZS8;
+				DEVELOPMENT_TEAM = 38QVPJE4NW;
 				ENABLE_BITCODE = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = NO;
 				GCC_PREFIX_HEADER = "";
@@ -360,7 +360,6 @@
 				OTHER_CFLAGS = (
 					"-DHAVE_NETWORKGAMEPAD",
 					"-DHAVE_CORETEXT",
-					"-DHAVE_HID",
 					"-DHAVE_NETWORKING",
 					"-DHAVE_AVFOUNDATION",
 					"-DHAVE_GRIFFIN",
@@ -424,7 +423,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_RESOURCE_RULES_PATH = "$(SDKROOT)/ResourceRules.plist";
-				DEVELOPMENT_TEAM = UK699V5ZS8;
+				DEVELOPMENT_TEAM = 38QVPJE4NW;
 				ENABLE_BITCODE = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = NO;
 				GCC_PREFIX_HEADER = "";
@@ -444,7 +443,6 @@
 					"-DNDEBUG",
 					"-DHAVE_NETWORKGAMEPAD",
 					"-DHAVE_CORETEXT",
-					"-DHAVE_HID",
 					"-DHAVE_NETWORKING",
 					"-DHAVE_AVFOUNDATION",
 					"-DHAVE_GRIFFIN",
@@ -495,7 +493,6 @@
 					"-DNDEBUG",
 					"-DHAVE_NETWORKGAMEPAD",
 					"-DHAVE_CORETEXT",
-					"-DHAVE_HID",
 					"-DHAVE_NETWORKING",
 					"-DHAVE_AVFOUNDATION",
 					"-DHAVE_GRIFFIN",


### PR DESCRIPTION
## Description

This pull request aims to improve HID input driver in RetroArch on IOS9/OSX platforms.
It's following my QUICK FIX posted this week-end [here](https://github.com/libretro/RetroArch/issues/4816). It was approved, merged and committed by @twinaphex.


1. **[OSX] HID driver 2nd improvement : button IDs allocation algorithm**

The list which contains HID cookies rely on HID enumeration code. Implementation of the last one may be variable and button IDs may be variable, which is not acceptable. In order to improve button ID allocation, we may insert cookies in an "Ordered List" instead of simple linked list. The list may be sorted with help of the "use" member criterium. Example of button allocation IDs using an "Ordered List" for the Nimbus pad:

                       +-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+
      "id" list member |  1  |  2  |  3  |  4  |  5  |  6  |  7  |  8  | 144 | 145 | 146 | 147 | 547 |
       Final Button ID |  0  |  1  |  2  |  3  |  4  |  5  |  6  |  7  |  8  |  9  | 10  | 11  | 12  |
                       +-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+
                Ranges |<         X/Y/A/B/L1/L2/R1/R2 buttons         >|<        D-PAD        >|MENU |
In that way, HID button IDs allocation:

  - becomes robust and determinist
  - remains compatible with previous algorithm (i.e. btn->id = (uint32_t)(use - 1)) and so compatible with previous autoconfig files. 

I tested my modifications with the following configuration: iMac/macOS High Sierra/Build and run from Xcode 9.2


2. **[iOS 9] Remove HID entry from RetroArch menu**

The -DHAVE_IOHIDMANAGER preprocessor directive is not set in project, so HID driver is not compiled. (I suppose It has been intentional. IOKit framework on iOS is an Apple Private Framework)
HID driver was displayed on iOS user menu (even if it was not functional). So, I remove "hid" from "Joypad Driver" menu options. Users were confused to see "hid". For now, iOS default input driver is MFI which works well.

I tested my modifications with the following configuration: iPad mini 1 (real device)/iOS 9.3.5/Build and run from Xcode 9.2

## Related Issues

App crashes when SteelSeries Nimbus controller connects // OS X 10.12.4 [$25] #4816

## Related Pull Requests

The new button IDs allocation algorithm impacts the Nimbus autoconfig file.
I proposed this new file here: [Take account of new HID button IDs allocation algorithm #427](https://github.com/libretro/retroarch-joypad-autoconfig/pull/427)

## Reviewers

@twinaphex 