### PR TITLE
[Wii U] Enable shader preset saving

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -2265,7 +2265,8 @@ static bool check_shader_compatibility(enum file_path_enum enum_idx)
 {
    settings_t *settings = config_get_ptr();
 
-   if (string_is_equal(settings->arrays.video_driver, "vulkan"))
+   if (string_is_equal(settings->arrays.video_driver, "vulkan")) ||
+       string_is_equal(settings->arrays.video_driver, "gx2"))
    {
       if (enum_idx != FILE_PATH_SLANGP_EXTENSION)
          return false;


### PR DESCRIPTION
Enable shader preset saving on Wii U, initial implementation.
