### PR TITLE
Fix memory management bugs

### DIFF
--- a/input/drivers_joypad/wiiu_joypad.c
+++ b/input/drivers_joypad/wiiu_joypad.c
@@ -66,8 +66,8 @@ static void build_pad_map(void)
 
 static bool wiiu_joypad_init(void* data)
 {
-  // the sub-drivers have to init first, otherwise
-  // build_pad_map will fail (because all lookups will return false).
+  /* the sub-drivers have to init first, otherwise
+   * build_pad_map will fail (because all lookups will return false). */
   wpad_driver.init(data);
   kpad_driver.init(data);
 #ifdef WIIU_HID

--- a/wiiu/input/hidpad_driver.c
+++ b/wiiu/input/hidpad_driver.c
@@ -61,7 +61,6 @@ error:
    if (hid_data)
    {
       wiiu_hid.free(hid_data);
-      free(hid_data);
       hid_data = NULL;
    }
    return NULL;
@@ -93,12 +92,16 @@ static void hidpad_destroy(void)
 {
    ready = false;
 
-   if (!hid_driver)
-      return;
+   if(hid_driver) {
+     hid_driver->free(hid_data);
+     hid_data = NULL;
+     hid_driver = NULL;
+   }
 
-   hid_driver->free(get_hid_data());
-   free(hid_data);
-   hid_data = NULL;
+   if(hid_data) {
+     free(hid_data);
+     hid_data = NULL;
+   }
 }
 
 static bool hidpad_button(unsigned pad, uint16_t button)

--- a/wiiu/input/wiiu_hid.c
+++ b/wiiu/input/wiiu_hid.c
@@ -214,8 +214,6 @@ static void start_polling_thread(wiiu_hid_t *hid)
       goto error;
    }
 
-   RARCH_LOG("[hid]: thread: 0x%x; stack: 0x%x\n", thread, stack);
-
    if (!OSCreateThread(thread,
             wiiu_hid_polling_thread,
             1, (char *)hid,
@@ -641,6 +639,11 @@ static void delete_adapter(wiiu_adapter_t *adapter)
       free(adapter->rx_buffer);
       adapter->rx_buffer = NULL;
    }
+   if(adapter->tx_buffer)
+   {
+      free(adapter->tx_buffer);
+      adapter->tx_buffer = NULL;
+   }
    free(adapter);
 }
 
@@ -654,9 +657,9 @@ static wiiu_attach_event *new_attach_event(HIDDevice *device)
    event->vendor_id          = device->vid;
    event->product_id         = device->pid;
    event->interface_index    = device->interface_index;
-   event->is_keyboard        = (device->sub_class == 1 
+   event->is_keyboard        = (device->sub_class == 1
          && device->protocol == 1);
-   event->is_mouse           = (device->sub_class == 1 
+   event->is_mouse           = (device->sub_class == 1
          && device->protocol == 2);
    event->max_packet_size_rx = device->max_packet_size_rx;
    event->max_packet_size_tx = device->max_packet_size_tx;


### PR DESCRIPTION
== DETAILS

 * Fix double-free in hidpad shutdown code
 * Fix possible double-free in hidpad error handling code
 * Fix memory leak in adapter delete method

== TESTING
@QuarkTheAwesome reported via discord that, when building with `WIIU_HID=1` set, toggling the video smoothing setting would cause a DSI or black screen error.

I loaded a core and toggled the setting repeatedly, and did not get a crash.