### PR TITLE
[iOS10+]Handle hardware keyboards and iCade controllers

### DIFF
--- a/pkg/apple/RetroArch_iOS10.xcodeproj/project.pbxproj
+++ b/pkg/apple/RetroArch_iOS10.xcodeproj/project.pbxproj
@@ -222,7 +222,7 @@
 				ORGANIZATIONNAME = RetroArch;
 				TargetAttributes = {
 					9204BE091D319EF300BD49DB = {
-						DevelopmentTeam = UK699V5ZS8;
+						DevelopmentTeam = 38QVPJE4NW;
 						DevelopmentTeamName = "Yoshinobu Sugawara";
 					};
 				};
@@ -309,7 +309,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_RESOURCE_RULES_PATH = "$(SDKROOT)/ResourceRules.plist";
-				DEVELOPMENT_TEAM = UK699V5ZS8;
+				DEVELOPMENT_TEAM = 38QVPJE4NW;
 				ENABLE_BITCODE = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = NO;
 				GCC_PREFIX_HEADER = "";
@@ -327,7 +327,6 @@
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CFLAGS = (
 					"-DDONT_WANT_ARM_OPTIMIZATIONS",
-					"-DHAVE_APPLE_STORE",
 					"-DHAVE_NETWORKGAMEPAD",
 					"-DHAVE_CORETEXT",
 					"-DHAVE_HID",
@@ -394,7 +393,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_RESOURCE_RULES_PATH = "$(SDKROOT)/ResourceRules.plist";
-				DEVELOPMENT_TEAM = UK699V5ZS8;
+				DEVELOPMENT_TEAM = 38QVPJE4NW;
 				ENABLE_BITCODE = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = NO;
 				GCC_PREFIX_HEADER = "";
@@ -413,7 +412,6 @@
 					"-DNS_BLOCK_ASSERTIONS=1",
 					"-DNDEBUG",
 					"-DDONT_WANT_ARM_OPTIMIZATIONS",
-					"-DHAVE_APPLE_STORE",
 					"-DHAVE_NETWORKGAMEPAD",
 					"-DHAVE_CORETEXT",
 					"-DHAVE_HID",
@@ -466,7 +464,6 @@
 					"-DNS_BLOCK_ASSERTIONS=1",
 					"-DNDEBUG",
 					"-DDONT_WANT_ARM_OPTIMIZATIONS",
-					"-DHAVE_APPLE_STORE",
 					"-DHAVE_NETWORKGAMEPAD",
 					"-DHAVE_CORETEXT",
 					"-DHAVE_HID",
@@ -553,7 +550,6 @@
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CFLAGS = (
 					"-DDONT_WANT_ARM_OPTIMIZATIONS",
-					"-DHAVE_APPLE_STORE",
 					"-DHAVE_NETWORKGAMEPAD",
 					"-DHAVE_CORETEXT",
 					"-DHAVE_HID",
@@ -624,7 +620,6 @@
 					"-DNS_BLOCK_ASSERTIONS=1",
 					"-DNDEBUG",
 					"-DDONT_WANT_ARM_OPTIMIZATIONS",
-					"-DHAVE_APPLE_STORE",
 					"-DHAVE_NETWORKGAMEPAD",
 					"-DHAVE_CORETEXT",
 					"-DHAVE_HID",


### PR DESCRIPTION
## Description

Continue to support hardware keyboards and iCade controllers on iOS10+.
This one was interrupted.

## Related Issues

[#6197](https://github.com/libretro/RetroArch/issues/6197)

## Related Pull Requests

None.

## Reviewers

@twinaphex 
@yoshisuga 