### PR TITLE
dist-scripts: Don't use the 'source' builtin.

### DIFF
--- a/dist-scripts/dist-cores.sh
+++ b/dist-scripts/dist-cores.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-source ../version.all
+. ../version.all
 PLATFORM=$1
 SALAMANDER=no
 MAKEFILE_GRIFFIN=no

--- a/dist-scripts/wiiu-cores.sh
+++ b/dist-scripts/wiiu-cores.sh
@@ -5,7 +5,7 @@
 # and icons (https://github.com/libretro/retroarch-assets/tree/master/pkg/wiiu) to this directory then run
 # the script. the output will be in retroarch/pkg/wiiu
 
-source ../version.all
+. ../version.all
 
 platform=wiiu
 EXT=a

--- a/dist-scripts/wiiu-new-cores.sh
+++ b/dist-scripts/wiiu-new-cores.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source ../version.all
+. ../version.all
 platform=wiiu
 EXT=a
 scriptDir=


### PR DESCRIPTION
## Description

The `source` builtin is not POSIX and not all of the build environments have it.

## Related Issues

For example the wiiu build log report:
```
./wiiu-cores.sh: 8: ./wiiu-cores.sh: source: not found
```

## Related Pull Requests

N/A

## Reviewers

@twinaphex
