### PR TITLE
qb: Add --datarootdir to configure.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,29 +201,29 @@ install: $(TARGET)
 	rm -f $(OBJDIR)/git_version.o
 	mkdir -p $(DESTDIR)$(BIN_DIR) 2>/dev/null || /bin/true
 	mkdir -p $(DESTDIR)$(GLOBAL_CONFIG_DIR) 2>/dev/null || /bin/true
-	mkdir -p $(DESTDIR)$(PREFIX)/share/applications 2>/dev/null || /bin/true
+	mkdir -p $(DESTDIR)$(DATA_DIR)/applications 2>/dev/null || /bin/true
 	mkdir -p $(DESTDIR)$(MAN_DIR)/man6 2>/dev/null || /bin/true
-	mkdir -p $(DESTDIR)$(PREFIX)/share/pixmaps 2>/dev/null || /bin/true
+	mkdir -p $(DESTDIR)$(DATA_DIR)/pixmaps 2>/dev/null || /bin/true
 	cp $(TARGET) $(DESTDIR)$(BIN_DIR)
 	cp tools/cg2glsl.py $(DESTDIR)$(BIN_DIR)/retroarch-cg2glsl
 	cp retroarch.cfg $(DESTDIR)$(GLOBAL_CONFIG_DIR)
-	cp retroarch.desktop $(DESTDIR)$(PREFIX)/share/applications
+	cp retroarch.desktop $(DESTDIR)$(DATA_DIR)/applications
 	cp docs/retroarch.6 $(DESTDIR)$(MAN_DIR)/man6
 	cp docs/retroarch-cg2glsl.6 $(DESTDIR)$(MAN_DIR)/man6
-	cp media/retroarch.svg $(DESTDIR)$(PREFIX)/share/pixmaps
+	cp media/retroarch.svg $(DESTDIR)$(DATA_DIR)/pixmaps
 	chmod 755 $(DESTDIR)$(BIN_DIR)/$(TARGET)
 	chmod 755 $(DESTDIR)$(BIN_DIR)/retroarch-cg2glsl
 	chmod 644 $(DESTDIR)$(GLOBAL_CONFIG_DIR)/retroarch.cfg
-	chmod 644 $(DESTDIR)$(PREFIX)/share/applications/retroarch.desktop
+	chmod 644 $(DESTDIR)$(DATA_DIR)/applications/retroarch.desktop
 	chmod 644 $(DESTDIR)$(MAN_DIR)/man6/retroarch.6
 	chmod 644 $(DESTDIR)$(MAN_DIR)/man6/retroarch-cg2glsl.6
-	chmod 644 $(DESTDIR)$(PREFIX)/share/pixmaps/retroarch.svg
+	chmod 644 $(DESTDIR)$(DATA_DIR)/pixmaps/retroarch.svg
 	@if test -d media/assets; then \
 		echo "Installing media assets..."; \
-		mkdir -p $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/xmb; \
-		mkdir -p $(DESTDIR)$(ASSETS_DIR)/retroarch/assets/glui; \
-		cp -r media/assets/xmb/  $(DESTDIR)$(ASSETS_DIR)/retroarch/assets; \
-		cp -r media/assets/glui/ $(DESTDIR)$(ASSETS_DIR)/retroarch/assets; \
+		mkdir -p $(DESTDIR)$(ASSETS_DIR)/assets/xmb; \
+		mkdir -p $(DESTDIR)$(ASSETS_DIR)/assets/glui; \
+		cp -r media/assets/xmb/ $(DESTDIR)$(ASSETS_DIR)/assets; \
+		cp -r media/assets/glui/ $(DESTDIR)$(ASSETS_DIR)/assets; \
 		echo "Asset copying done."; \
 	fi
 
@@ -231,11 +231,11 @@ uninstall:
 	rm -f $(DESTDIR)$(BIN_DIR)/retroarch
 	rm -f $(DESTDIR)$(BIN_DIR)/retroarch-cg2glsl
 	rm -f $(DESTDIR)$(GLOBAL_CONFIG_DIR)/retroarch.cfg
-	rm -f $(DESTDIR)$(PREFIX)/share/applications/retroarch.desktop
+	rm -f $(DESTDIR)$(DATA_DIR)/applications/retroarch.desktop
 	rm -f $(DESTDIR)$(MAN_DIR)/man6/retroarch.6
 	rm -f $(DESTDIR)$(MAN_DIR)/man6/retroarch-cg2glsl.6
-	rm -f $(DESTDIR)$(PREFIX)/share/pixmaps/retroarch.svg
-	rm -rf $(DESTDIR)$(ASSETS_DIR)/retroarch
+	rm -f $(DESTDIR)$(DATA_DIR)/pixmaps/retroarch.svg
+	rm -rf $(DESTDIR)$(ASSETS_DIR)
 
 clean:
 	rm -rf $(OBJDIR_BASE)

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -44,6 +44,7 @@ elif [ "$OS" = 'SunOS' ]; then
    SORT='gsort'
 fi
 
+add_define MAKEFILE DATA_DIR "$SHARE_DIR"
 add_define MAKEFILE DYLIB_LIB "$DYLIB"
 
 check_lib '' SYSTEMD -lsystemd sd_get_machine_names
@@ -157,9 +158,9 @@ fi
    add_define MAKEFILE libretro "$LIBRETRO"
 }
 
-add_define MAKEFILE ASSETS_DIR "${ASSETS_DIR:-${PREFIX}/share}"
+add_define MAKEFILE ASSETS_DIR "${ASSETS_DIR:-$SHARE_DIR}/retroarch"
 add_define MAKEFILE BIN_DIR "${BIN_DIR:-${PREFIX}/bin}"
-add_define MAKEFILE MAN_DIR "${MAN_DIR:-${PREFIX}/share/man}"
+add_define MAKEFILE MAN_DIR "${MAN_DIR:-${SHARE_DIR}/man}"
 
 if [ "$OS" = 'DOS' ]; then
    HAVE_SHADERPIPELINE=no

--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -1,7 +1,8 @@
 MAKEFILE_DEFINES=''
 CONFIG_DEFINES=''
 
-[ "$PREFIX" ] || PREFIX="/usr/local"
+PREFIX="${PREFIX:-/usr/local}"
+SHARE_DIR="${SHARE_DIR:-${PREFIX}/share}"
 
 add_define() # $1 = MAKEFILE or CONFIG $2 = define $3 = value
 { eval "${1}_DEFINES=\"\${${1}_DEFINES} $2=$3\""; }

--- a/qb/qb.params.sh
+++ b/qb/qb.params.sh
@@ -34,6 +34,7 @@ General options:
 EOF
 	print_help_option "--prefix=PATH"            "Install path prefix"
 	print_help_option "--global-config-dir=PATH" "System wide config file prefix"
+	print_help_option "--datarootdir=PATH"       "Read-only data install directory"
 	print_help_option "--build=BUILD"            "The build system (no-op)"
 	print_help_option "--host=HOST"              "Cross-compile with HOST-gcc instead of gcc"
 	print_help_option "--help"                   "Show this help"
@@ -85,6 +86,7 @@ parse_input() # Parse stuff :V
 			--prefix=*) PREFIX=${1##--prefix=};;
 			--global-config-dir=*) GLOBAL_CONFIG_DIR=${1##--global-config-dir=};;
 			--build=*) BUILD="${1#*=}";;
+			--datarootdir=*) SHARE_DIR="${1#*=}";;
 			--host=*) CROSS_COMPILE=${1##--host=}-;;
 			--enable-*)
 				opt_exists "${1##--enable-}" "$1"


### PR DESCRIPTION
## Description

This allows a user to use `--datarootdir=PATH` to configure the share directory used for pixmaps, desktop files, man pages and assets.

By default this will be '/usr/local/share'. Assets and man page install paths can still be configured with:
  `--with-man_dir=PATH`
and
  `--with-assets_dir=PATH`

Some operating systems like Haiku use unconventional install paths and this should allow them to configure their build correctly.

## Related Issues

Removes more hard coded paths and allows more customization of system packages.

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/6140 https://github.com/libretro/RetroArch/pull/6142

## Reviewers

@twinaphex and @kwyxz

@kwyxz Can you make sure this allows for the proper configuration for haiku?