### PR TITLE
Update file_stream.c (It causes slow "Scan directory" option on Linux)

### DIFF
--- a/libretro-common/streams/file_stream.c
+++ b/libretro-common/streams/file_stream.c
@@ -26,9 +26,9 @@
 #include <stdarg.h>
 #include <errno.h>
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
+/* #ifdef HAVE_CONFIG_H */
+/* #include "config.h" */
+/* #endif */
 
 #include <streams/file_stream.h>
 #define VFS_FRONTEND


### PR DESCRIPTION
It causes slow "Scan directory" option on Linux. The problem starts from this commit:
https://github.com/libretro/RetroArch/commit/72fdfb1edd4ce50c158a16b6c14bb4dc18978d9c
