### PR TITLE
Fixed mismatching *printf fmt spec in translations.

### DIFF
--- a/intl/msg_hash_de.h
+++ b/intl/msg_hash_de.h
@@ -48,7 +48,7 @@ MSG_HASH(
       )
 MSG_HASH(
       MSG_NETPLAY_YOU_HAVE_JOINED_AS_PLAYER_N,
-      "Du bist als Spieler %d beigetreten"
+      "Du bist als Spieler %u beigetreten"
       )
 MSG_HASH(
       MSG_NETPLAY_ENDIAN_DEPENDENT,

--- a/intl/msg_hash_es.h
+++ b/intl/msg_hash_es.h
@@ -48,7 +48,7 @@ MSG_HASH(
 	)
 MSG_HASH(
 	MSG_NETPLAY_YOU_HAVE_JOINED_AS_PLAYER_N,
-	"Unido como jugador %d"
+	"Unido como jugador %u"
 	)
 MSG_HASH(
 	MSG_NETPLAY_YOU_HAVE_JOINED_WITH_INPUT_DEVICES_S,

--- a/intl/msg_hash_fr.h
+++ b/intl/msg_hash_fr.h
@@ -48,7 +48,7 @@ MSG_HASH(
       )
 MSG_HASH(
       MSG_NETPLAY_YOU_HAVE_JOINED_AS_PLAYER_N,
-      "Vous avez rejoint le jeu en tant que joueur %d"
+      "Vous avez rejoint le jeu en tant que joueur %u"
       )
 MSG_HASH(
       MSG_NETPLAY_ENDIAN_DEPENDENT,

--- a/intl/msg_hash_it.h
+++ b/intl/msg_hash_it.h
@@ -48,7 +48,7 @@ MSG_HASH(
       )
 MSG_HASH(
       MSG_NETPLAY_YOU_HAVE_JOINED_AS_PLAYER_N,
-      "Sei entrato come giocatore %d"
+      "Sei entrato come giocatore %u"
       )
 MSG_HASH(
       MSG_NETPLAY_ENDIAN_DEPENDENT,

--- a/intl/msg_hash_ja.h
+++ b/intl/msg_hash_ja.h
@@ -53,7 +53,7 @@ MSG_HASH(
       )
 MSG_HASH(
       MSG_NETPLAY_YOU_HAVE_JOINED_AS_PLAYER_N,
-      "「プレイヤー%d」で接続しました"
+      "「プレイヤー%u」で接続しました"
       )
 MSG_HASH(
       MSG_NETPLAY_YOU_HAVE_JOINED_WITH_INPUT_DEVICES_S,

--- a/intl/msg_hash_ko.h
+++ b/intl/msg_hash_ko.h
@@ -48,7 +48,7 @@ MSG_HASH(
       )
 MSG_HASH(
       MSG_NETPLAY_YOU_HAVE_JOINED_AS_PLAYER_N,
-      "Y%d 플레이어로 입장했습니다"
+      "Y%u 플레이어로 입장했습니다"
       )
 MSG_HASH(
       MSG_NETPLAY_ENDIAN_DEPENDENT,

--- a/intl/msg_hash_pl.h
+++ b/intl/msg_hash_pl.h
@@ -48,7 +48,7 @@ MSG_HASH(
       )
 MSG_HASH(
       MSG_NETPLAY_YOU_HAVE_JOINED_AS_PLAYER_N,
-      "Dołączyłeś jako gracz %d"
+      "Dołączyłeś jako gracz %u"
       )
 MSG_HASH(
       MSG_NETPLAY_ENDIAN_DEPENDENT,

--- a/intl/msg_hash_pt_br.h
+++ b/intl/msg_hash_pt_br.h
@@ -35,7 +35,7 @@ MSG_HASH(MSG_NETPLAY_YOU_HAVE_LEFT_THE_GAME,
 	 "Você deixou o jogo"
 	)
 MSG_HASH(MSG_NETPLAY_YOU_HAVE_JOINED_AS_PLAYER_N,
-	 "Você se juntou como jogador %d"
+	 "Você se juntou como jogador %u"
 	)
 MSG_HASH(MSG_NETPLAY_ENDIAN_DEPENDENT,
 	 "Este núcleo não suporta Netplay inter-arquitetura entre estes sistemas"

--- a/intl/msg_hash_pt_pt.h
+++ b/intl/msg_hash_pt_pt.h
@@ -48,7 +48,7 @@ MSG_HASH(
       )
 MSG_HASH(
       MSG_NETPLAY_YOU_HAVE_JOINED_AS_PLAYER_N,
-      "Você juntou-se como o(a) jogador(a) %d"
+      "Você juntou-se como o(a) jogador(a) %u"
       )
 MSG_HASH(
       MSG_NETPLAY_ENDIAN_DEPENDENT,

--- a/intl/msg_hash_ru.h
+++ b/intl/msg_hash_ru.h
@@ -53,7 +53,7 @@ MSG_HASH(
       )
 MSG_HASH(
       MSG_NETPLAY_YOU_HAVE_JOINED_AS_PLAYER_N,
-      "Вы присоединились под именем %d"
+      "Вы присоединились под именем %u"
       )
 MSG_HASH(
       MSG_NETPLAY_ENDIAN_DEPENDENT,

--- a/intl/msg_hash_vn.h
+++ b/intl/msg_hash_vn.h
@@ -48,7 +48,7 @@ MSG_HASH(
       )
 MSG_HASH(
       MSG_NETPLAY_YOU_HAVE_JOINED_AS_PLAYER_N,
-      "You have joined as player %d"
+      "You have joined as player %u"
       )
 MSG_HASH(
       MSG_NETPLAY_ENDIAN_DEPENDENT,


### PR DESCRIPTION
## Description

Changed/updated integer *prinf format specifier to match the English original one for one specific literal.

## Related Issues

Somewhat related to #5831.

## Related Pull Requests

N/A

## Reviewers

N/A
