### PR TITLE
qb: Add --bindir and --mandir.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,8 @@
 - LOCALIZATION: Update Spanish translation.
 - NETPLAY: Add menu option to select different MITM (relay) server locations.
 - OSX: Modify HID buttons detection algorithm.
+- QB: Added --datarootdir.
+- QB: Added --bindir and --mandir and deprecated --with-bin_dir and --with-man_dir.
 - SHADERS: Allow saving of shader presets based on the parent directory (Saving one for */foo/bar/mario.sfc* would result in *shaders/presets/corename/bar.ext*). We decided it's safer to still isolate the presets to a single core because different cores may treat video output differently.
 - SHADERS: Don't save the path to the current preset to the main config. This was causing weird behavior, instead it will try to load *currentconfig.ext* and it will save a preset with that name when select *apply shader preset*. The resulting shader will restore properly after restarting and even after core/parent/game specific presets are loaded
 - SOLARIS: Initial port.

--- a/qb/config.params.sh
+++ b/qb/config.params.sh
@@ -1,7 +1,7 @@
 HAVE_LIBRETRO=             # Libretro library used
 HAVE_ASSETS_DIR=           # Assets install directory
-HAVE_BIN_DIR=              # Binary install directory
-HAVE_MAN_DIR=              # Manpage install directory
+HAVE_BIN_DIR=              # Binary install directory (Deprecated)
+HAVE_MAN_DIR=              # Manpage install directory (Deprecated)
 HAVE_OPENGLES_LIBS=        # Link flags for custom GLES library
 HAVE_OPENGLES_CFLAGS=      # C-flags for custom GLES library
 HAVE_CACA=no               # Libcaca support

--- a/qb/qb.params.sh
+++ b/qb/qb.params.sh
@@ -34,7 +34,9 @@ General options:
 EOF
 	print_help_option "--prefix=PATH"            "Install path prefix"
 	print_help_option "--global-config-dir=PATH" "System wide config file prefix"
+	print_help_option "--bindir=PATH"            "Binary install directory"
 	print_help_option "--datarootdir=PATH"       "Read-only data install directory"
+	print_help_option "--mandir=PATH"            "Manpage install directory"
 	print_help_option "--build=BUILD"            "The build system (no-op)"
 	print_help_option "--host=HOST"              "Cross-compile with HOST-gcc instead of gcc"
 	print_help_option "--help"                   "Show this help"
@@ -85,9 +87,11 @@ parse_input() # Parse stuff :V
 		case "$1" in
 			--prefix=*) PREFIX=${1##--prefix=};;
 			--global-config-dir=*) GLOBAL_CONFIG_DIR=${1##--global-config-dir=};;
+			--bindir=*) BIN_DIR="${1#*=}";;
 			--build=*) BUILD="${1#*=}";;
 			--datarootdir=*) SHARE_DIR="${1#*=}";;
 			--host=*) CROSS_COMPILE=${1##--host=}-;;
+			--mandir=*) MAN_DIR="${1#*=}";;
 			--enable-*)
 				opt_exists "${1##--enable-}" "$1"
 				eval "HAVE_$opt=yes"


### PR DESCRIPTION
## Description

This is a proposal to add `--bindir` and `--mandir` to configure and then deprecate `--with-bin_dir` and `--with-man_dir`. This better matches the naming scheme of autotools and some package maintainers may expect these configure flags to work instead of our current ones.

If accepted the user can continue using `--with-bin_dir` and `--with-man_dir` or update their build scripts to use `--bindir` and `--mandir`. I think there is no big need to remove the older flags in the near future and can just mark them as deprecated in `./configure --help` so that packagers know not to start using them. Maybe sometime after `v1.8.0` they can be removed.

## Related Issues

I realized that the qb configure scripts do not follow naming syntax from autotool's configure after reading the following fosdem pdf which has a section discussing the annoyance in `configure` scripts that are not autotools where the packager may be confused by its name. While using autotools for RetroArch is not a good idea, there is no reason we can't implement some good ideas autotools had.

https://fosdem.org/2018/schedule/event/how_to_make_package_managers_cry/attachments/slides/2297/export/events/attachments/how_to_make_package_managers_cry/slides/2297/how_to_make_package_managers_cry.pdf

## Related Pull Requests

N/A

## Reviewers

@sergiobenrocha2, @kwyxz, @twinaphex (Not sure what other RetroArch packagers there are?)