### PR TITLE
qb: Add --docdir

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,7 @@
 - OSX: Modify HID buttons detection algorithm.
 - QB: Added --datarootdir.
 - QB: Added --bindir and --mandir and deprecated --with-bin_dir and --with-man_dir.
+- QB: Added --docdir.
 - SHADERS: Allow saving of shader presets based on the parent directory (Saving one for */foo/bar/mario.sfc* would result in *shaders/presets/corename/bar.ext*). We decided it's safer to still isolate the presets to a single core because different cores may treat video output differently.
 - SHADERS: Don't save the path to the current preset to the main config. This was causing weird behavior, instead it will try to load *currentconfig.ext* and it will save a preset with that name when select *apply shader preset*. The resulting shader will restore properly after restarting and even after core/parent/game specific presets are loaded
 - SOLARIS: Initial port.

--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,7 @@ install: $(TARGET)
 	mkdir -p $(DESTDIR)$(BIN_DIR) 2>/dev/null || /bin/true
 	mkdir -p $(DESTDIR)$(GLOBAL_CONFIG_DIR) 2>/dev/null || /bin/true
 	mkdir -p $(DESTDIR)$(DATA_DIR)/applications 2>/dev/null || /bin/true
+	mkdir -p $(DESTDIR)$(DOC_DIR) 2>/dev/null || /bin/true
 	mkdir -p $(DESTDIR)$(MAN_DIR)/man6 2>/dev/null || /bin/true
 	mkdir -p $(DESTDIR)$(DATA_DIR)/pixmaps 2>/dev/null || /bin/true
 	cp $(TARGET) $(DESTDIR)$(BIN_DIR)
@@ -211,6 +212,8 @@ install: $(TARGET)
 	cp docs/retroarch.6 $(DESTDIR)$(MAN_DIR)/man6
 	cp docs/retroarch-cg2glsl.6 $(DESTDIR)$(MAN_DIR)/man6
 	cp media/retroarch.svg $(DESTDIR)$(DATA_DIR)/pixmaps
+	cp COPYING $(DESTDIR)$(DOC_DIR)
+	cp README.md $(DESTDIR)$(DOC_DIR)
 	chmod 755 $(DESTDIR)$(BIN_DIR)/$(TARGET)
 	chmod 755 $(DESTDIR)$(BIN_DIR)/retroarch-cg2glsl
 	chmod 644 $(DESTDIR)$(GLOBAL_CONFIG_DIR)/retroarch.cfg
@@ -224,6 +227,7 @@ install: $(TARGET)
 		mkdir -p $(DESTDIR)$(ASSETS_DIR)/assets/glui; \
 		cp -r media/assets/xmb/ $(DESTDIR)$(ASSETS_DIR)/assets; \
 		cp -r media/assets/glui/ $(DESTDIR)$(ASSETS_DIR)/assets; \
+		cp media/assets/COPYING $(DESTDIR)$(DOC_DIR)/COPYING.assets; \
 		echo "Asset copying done."; \
 	fi
 
@@ -232,9 +236,12 @@ uninstall:
 	rm -f $(DESTDIR)$(BIN_DIR)/retroarch-cg2glsl
 	rm -f $(DESTDIR)$(GLOBAL_CONFIG_DIR)/retroarch.cfg
 	rm -f $(DESTDIR)$(DATA_DIR)/applications/retroarch.desktop
+	rm -f $(DESTDIR)$(DATA_DIR)/pixmaps/retroarch.svg
+	rm -f $(DESTDIR)$(DOC_DIR)/COPYING
+	rm -f $(DESTDIR)$(DOC_DIR)/COPYING.assets
+	rm -f $(DESTDIR)$(DOC_DIR)/README.md
 	rm -f $(DESTDIR)$(MAN_DIR)/man6/retroarch.6
 	rm -f $(DESTDIR)$(MAN_DIR)/man6/retroarch-cg2glsl.6
-	rm -f $(DESTDIR)$(DATA_DIR)/pixmaps/retroarch.svg
 	rm -rf $(DESTDIR)$(ASSETS_DIR)
 
 clean:

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -160,6 +160,7 @@ fi
 
 add_define MAKEFILE ASSETS_DIR "${ASSETS_DIR:-$SHARE_DIR}/retroarch"
 add_define MAKEFILE BIN_DIR "${BIN_DIR:-${PREFIX}/bin}"
+add_define MAKEFILE DOC_DIR "${DOC_DIR:-${SHARE_DIR}/doc/retroarch}"
 add_define MAKEFILE MAN_DIR "${MAN_DIR:-${SHARE_DIR}/man}"
 
 if [ "$OS" = 'DOS' ]; then

--- a/qb/qb.params.sh
+++ b/qb/qb.params.sh
@@ -36,6 +36,7 @@ EOF
 	print_help_option "--global-config-dir=PATH" "System wide config file prefix"
 	print_help_option "--bindir=PATH"            "Binary install directory"
 	print_help_option "--datarootdir=PATH"       "Read-only data install directory"
+	print_help_option "--docdir=PATH"            "Documentation install directory"
 	print_help_option "--mandir=PATH"            "Manpage install directory"
 	print_help_option "--build=BUILD"            "The build system (no-op)"
 	print_help_option "--host=HOST"              "Cross-compile with HOST-gcc instead of gcc"
@@ -90,6 +91,7 @@ parse_input() # Parse stuff :V
 			--bindir=*) BIN_DIR="${1#*=}";;
 			--build=*) BUILD="${1#*=}";;
 			--datarootdir=*) SHARE_DIR="${1#*=}";;
+			--docdir=*) DOC_DIR="${1#*=}";;
 			--host=*) CROSS_COMPILE=${1##--host=}-;;
 			--mandir=*) MAN_DIR="${1#*=}";;
 			--enable-*)


### PR DESCRIPTION
## Description

By default `make install` will now install the following 2-3 files to `$(DESTDIR)$(SHARE_DIR)/doc/retroarch` which by default is `/usr/local/share/doc/retroarch`.
```
COPYING
README.md
```
and if `media/assets` exists it will install `media/assets/COPYING` to `COPYING.assets`.

Users will be able to configure this install path with.
```
./configure --docdir=PATH
```
For example:
```
./configure --docdir=/usr/doc/RetroArch-1.7.0
```
I figure the `README.md` and `COPYING` files are the most useful to install by default.

## Related Issues

N/A

## Related Pull Requests

N/A

## Reviewers

@kwyxz