### PR TITLE
qb: Add --sysconfdir

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,9 +36,8 @@
 - LOCALIZATION: Update Spanish translation.
 - NETPLAY: Add menu option to select different MITM (relay) server locations.
 - OSX: Modify HID buttons detection algorithm.
-- QB: Added --datarootdir.
-- QB: Added --bindir and --mandir and deprecated --with-bin_dir and --with-man_dir.
-- QB: Added --docdir.
+- QB: Added --datarootdir, --sysconfdir, --bindir, --docdir and --mandir.
+- QB: Deprecated --global-config-dir, --with-bin_dir and --with-man_dir.
 - SHADERS: Allow saving of shader presets based on the parent directory (Saving one for */foo/bar/mario.sfc* would result in *shaders/presets/corename/bar.ext*). We decided it's safer to still isolate the presets to a single core because different cores may treat video output differently.
 - SHADERS: Don't save the path to the current preset to the main config. This was causing weird behavior, instead it will try to load *currentconfig.ext* and it will save a preset with that name when select *apply shader preset*. The resulting shader will restore properly after restarting and even after core/parent/game specific presets are loaded
 - SOLARIS: Initial port.

--- a/qb/qb.params.sh
+++ b/qb/qb.params.sh
@@ -33,11 +33,12 @@ General environment variables:
 General options:
 EOF
 	print_help_option "--prefix=PATH"            "Install path prefix"
-	print_help_option "--global-config-dir=PATH" "System wide config file prefix"
+	print_help_option "--sysconfdir=PATH"        "System wide config file prefix"
 	print_help_option "--bindir=PATH"            "Binary install directory"
 	print_help_option "--datarootdir=PATH"       "Read-only data install directory"
 	print_help_option "--docdir=PATH"            "Documentation install directory"
 	print_help_option "--mandir=PATH"            "Manpage install directory"
+	print_help_option "--global-config-dir=PATH" "System wide config file prefix (Deprecated)"
 	print_help_option "--build=BUILD"            "The build system (no-op)"
 	print_help_option "--host=HOST"              "Cross-compile with HOST-gcc instead of gcc"
 	print_help_option "--help"                   "Show this help"
@@ -87,7 +88,7 @@ parse_input() # Parse stuff :V
 	while [ "$1" ]; do
 		case "$1" in
 			--prefix=*) PREFIX=${1##--prefix=};;
-			--global-config-dir=*) GLOBAL_CONFIG_DIR=${1##--global-config-dir=};;
+			--global-config-dir=*|--sysconfdir=*) GLOBAL_CONFIG_DIR="${1#*=}";;
 			--bindir=*) BIN_DIR="${1#*=}";;
 			--build=*) BUILD="${1#*=}";;
 			--datarootdir=*) SHARE_DIR="${1#*=}";;


### PR DESCRIPTION
## Description

This adds `--syconfdir` to `./configure` and deprecates `--global-config-dir`. The goal behind this is to remove the non-conformant options from `../configure` and use the standard options which have become expected from the prevalence of autotools. I think `--global-config-dir` should be the last one to change. Like the previously deprecated `--with-bin_dir` and `--with-man_dir` I suggest removing `--global-config-dir` for the future `v1.8.0` release which should give packagers plenty of time to update. In the meantime both the new and old option will work.

By default it will install `retroarch.cfg` to `/etc/retroarch.cfg` if the `$PREFIX` is `/usr*`. If its not it will install it to `$PREFIX/etc/retroarch.cfg`. This might be good to change in the future, but I'm not sure what the best behavior is and its not important for this current PR. In short the FHS claims it should be `/etc` while autotools uses `PREFIX/etc`...

See: http://www.pathname.com/fhs/pub/fhs-2.3.html#ETCHOSTSPECIFICSYSTEMCONFIGURATION

## Related Issues

Less reinventing the wheel for `./configure` options.

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/6259

## Reviewers

@kwyxz