### PR TITLE
(D3D11/12) prevent double-free when resizing framebuffers.

### DIFF
--- a/gfx/common/d3d11_common.c
+++ b/gfx/common/d3d11_common.c
@@ -202,9 +202,6 @@ bool d3d11_init_shader(
    }
    else /* char array */
    {
-      if (!size)
-         size = strlen(src);
-
       if (vs_entry && !d3d_compile(src, size, (LPCSTR)src_name, vs_entry, "vs_5_0", &vs_code))
          success = false;
       if (ps_entry && !d3d_compile(src, size, (LPCSTR)src_name, ps_entry, "ps_5_0", &ps_code))

--- a/gfx/common/d3d11_common.h
+++ b/gfx/common/d3d11_common.h
@@ -2549,7 +2549,6 @@ typedef struct
    struct
    {
       d3d11_shader_t             shader;
-      D3D11SamplerStateRef       sampler;
       D3D11Buffer                buffers[SLANG_CBUFFER_MAX];
       d3d11_texture_t            rt;
       d3d11_texture_t            feedback;

--- a/gfx/common/d3d12_common.c
+++ b/gfx/common/d3d12_common.c
@@ -201,6 +201,8 @@ bool d3d12_init_queue(d3d12_video_t* d3d12)
    d3d12->queue.fenceValue = 1;
    d3d12->queue.fenceEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
 
+   D3D12SignalCommandQueue(d3d12->queue.handle, d3d12->queue.fence, d3d12->queue.fenceValue);
+
    return true;
 }
 

--- a/gfx/drivers_shader/slang_process.cpp
+++ b/gfx/drivers_shader/slang_process.cpp
@@ -142,10 +142,10 @@ static bool slang_process_reflection(
 
    for (unsigned i = 0; i < shader_info->num_parameters; i++)
    {
-	   if (!set_unique_map(
-		   uniform_semantic_map, shader_info->parameters[i].id,
-		   slang_semantic_map{ SLANG_SEMANTIC_FLOAT_PARAMETER, i }))
-		   return false;
+      if (!set_unique_map(
+                uniform_semantic_map, shader_info->parameters[i].id,
+                slang_semantic_map{ SLANG_SEMANTIC_FLOAT_PARAMETER, i }))
+         return false;
    }
 
    slang_reflection sl_reflection;
@@ -228,9 +228,19 @@ static bool slang_process_reflection(
          if (src.stage_mask)
          {
             texture_sem_t texture = {
-               (void*)((uintptr_t)map->textures[semantic].image + index * map->textures[semantic].image_stride),
-               (void*)((uintptr_t)map->textures[semantic].sampler + index * map->textures[semantic].sampler_stride),
+               (void*)((uintptr_t)map->textures[semantic].image + index * map->textures[semantic].image_stride)
             };
+
+            if (semantic == SLANG_TEXTURE_SEMANTIC_USER)
+            {
+               texture.wrap   = shader_info->lut[index].wrap;
+               texture.filter = shader_info->lut[index].filter;
+            }
+            else
+            {
+               texture.wrap   = shader_info->pass[pass_number].wrap;
+               texture.filter = shader_info->pass[pass_number].filter;
+            }
             texture.stage_mask = src.stage_mask;
             texture.binding    = src.binding;
             string id = get_semantic_name(sl_reflection, (slang_texture_semantic)semantic, index);

--- a/gfx/drivers_shader/slang_process.h
+++ b/gfx/drivers_shader/slang_process.h
@@ -36,8 +36,6 @@ typedef struct
    size_t image_stride;
    void*  size;
    size_t size_stride;
-   void*  sampler;
-   size_t sampler_stride;
 } texture_map_t;
 
 typedef struct
@@ -48,19 +46,20 @@ typedef struct
 
 typedef struct
 {
-   void*       data;
-   unsigned    size;
-   unsigned    offset;
-   char        id[64];
+   void*    data;
+   unsigned size;
+   unsigned offset;
+   char     id[64];
 } uniform_sem_t;
 
 typedef struct
 {
-   void*       texture_data;
-   void*       sampler_data;
-   unsigned    stage_mask;
-   unsigned    binding;
-   char        id[64];
+   void*              texture_data;
+   enum gfx_wrap_type wrap;
+   unsigned           filter;
+   unsigned           stage_mask;
+   unsigned           binding;
+   char               id[64];
 } texture_sem_t;
 
 typedef struct


### PR DESCRIPTION
(D3D12)
- correctly support lut/filtering/wrap options for slang shaders.
- rework frame sync.