### PR TITLE
Remove leftover positional intl strings.

### DIFF
--- a/intl/msg_hash_ar.h
+++ b/intl/msg_hash_ar.h
@@ -60,11 +60,11 @@ MSG_HASH(
       )
 MSG_HASH(
       MSG_NETPLAY_S_HAS_JOINED_AS_PLAYER_N,
-      "%2$.*1$s has joined as player %3$u"
+      "%.*s has joined as player %u"
       )
 MSG_HASH(
       MSG_NETPLAY_S_HAS_JOINED_WITH_INPUT_DEVICES_S,
-      "%2$.*1$s has joined with input devices %4$.*3$s"
+      "%.*s has joined with input devices %.*s"
       )
 MSG_HASH(
       MSG_NETPLAY_NOT_RETROARCH,

--- a/intl/msg_hash_es.h
+++ b/intl/msg_hash_es.h
@@ -60,11 +60,11 @@ MSG_HASH(
 	)
 MSG_HASH(
 	MSG_NETPLAY_S_HAS_JOINED_AS_PLAYER_N,
-	"%2$.*1$s se ha unido como jugador %3$u"
+	"%.*s se ha unido como jugador %u"
 	)
 MSG_HASH(
 	MSG_NETPLAY_S_HAS_JOINED_WITH_INPUT_DEVICES_S,
-	"%2$.*1$s se ha unido con los dispositivos de entrada %4$.*3$s"
+	"%.*s se ha unido con los dispositivos de entrada %.*s"
 	)
 MSG_HASH(
 	MSG_NETPLAY_NOT_RETROARCH,

--- a/intl/msg_hash_ja.h
+++ b/intl/msg_hash_ja.h
@@ -65,11 +65,11 @@ MSG_HASH(
       )
 MSG_HASH(
       MSG_NETPLAY_S_HAS_JOINED_AS_PLAYER_N,
-      "「%2$.*1$s」がプレヤー「%3$u」で接続しました"
+      "「%.*s」がプレヤー「%u」で接続しました"
       )
 MSG_HASH(
       MSG_NETPLAY_S_HAS_JOINED_WITH_INPUT_DEVICES_S,
-      "「%2$.*1$s」が入力デバイス「%4$.*3$s」で接続しました"
+      "「%.*s」が入力デバイス「%.*s」で接続しました"
       )
 MSG_HASH(
       MSG_NETPLAY_NOT_RETROARCH,

--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -60,11 +60,11 @@ MSG_HASH(
       )
 MSG_HASH(
       MSG_NETPLAY_S_HAS_JOINED_AS_PLAYER_N,
-      "%2$.*1$s has joined as player %3$u"
+      "%.*s has joined as player %u"
       )
 MSG_HASH(
       MSG_NETPLAY_S_HAS_JOINED_WITH_INPUT_DEVICES_S,
-      "%2$.*1$s has joined with input devices %4$.*3$s"
+      "%.*s has joined with input devices %.*s"
       )
 MSG_HASH(
       MSG_NETPLAY_NOT_RETROARCH,


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises


## Description

We stubbed out positional printf on Windows but didn't stub out this strings. This fixes that.

## Related Issues

#6288

## Related Pull Requests

None
