### PR TITLE
Small fix for certain RetroAchievement conditions.

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -1695,6 +1695,7 @@ static int cheevos_test_cond_set(const cheevos_condset_t *condset,
             (cond->req_hits != 0) &&
             (cond->curr_hits + cheevos_locals.add_hits) >= cond->req_hits)
          {
+            cheevos_locals.add_hits = 0;
             continue;
          }
 

--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -1691,9 +1691,12 @@ static int cheevos_test_cond_set(const cheevos_condset_t *condset,
          continue;
       }
 
-      if (  (cond->req_hits != 0) && 
+      if (  (cheevos_locals.add_hits > 0) &&
+            (cond->req_hits != 0) &&
             (cond->curr_hits + cheevos_locals.add_hits) >= cond->req_hits)
-         continue;
+         {
+            continue;
+         }
 
       cond_valid = cheevos_test_condition(cond);
 


### PR DESCRIPTION
## Description

A problem was recently brought to my attention with achievements incorrectly using the "Add Hits" condition flag. 

The issue has been resolved in the RetroAchievement repo already. Just copying over the small fix to RetroArch.
 
https://github.com/RetroAchievements/RASuite/commit/0c9db36762f516f2df686bc2f7a02474fe475bb1
