### PR TITLE
RetroAchievements reset addition buffer

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -1691,11 +1691,11 @@ static int cheevos_test_cond_set(const cheevos_condset_t *condset,
          continue;
       }
 
-      if (  (cheevos_locals.add_hits > 0) &&
-            (cond->req_hits != 0) &&
+      if (  (cond->req_hits != 0) &&
             (cond->curr_hits + cheevos_locals.add_hits) >= cond->req_hits)
          {
-            cheevos_locals.add_hits = 0;
+            cheevos_locals.add_buffer = 0;
+            cheevos_locals.add_hits   = 0;
             continue;
          }
 


### PR DESCRIPTION
## Description
Forgot to reset add buffer in my last PR.
line 1694 is also unnecessary.

## Related Pull Requests
https://github.com/libretro/RetroArch/pull/6300
