### PR TITLE
Fix bug in string length in strlcpy.

### DIFF
--- a/network/netplay/netplay_discovery.c
+++ b/network/netplay/netplay_discovery.c
@@ -488,7 +488,7 @@ static bool netplay_lan_ad_client(void)
          strlcpy(host->content, ad_packet_buffer.content,
             NETPLAY_HOST_LONGSTR_LEN);
          strlcpy(host->frontend, ad_packet_buffer.frontend,
-            NETPLAY_HOST_LONGSTR_LEN);
+            NETPLAY_HOST_STR_LEN);
 
          host->content_crc                  =
             atoi(ad_packet_buffer.content_crc);


### PR DESCRIPTION
## Description

There's a bug here that could cause an overflow due to an incorrect string length.