### PR TITLE
fix potential wiiu crash

### DIFF
--- a/gfx/drivers/gx2_gfx.c
+++ b/gfx/drivers/gx2_gfx.c
@@ -445,7 +445,8 @@ static void *wiiu_gfx_init(const video_info_t *video,
                         video->is_threaded,
                         FONT_DRIVER_RENDER_WIIU);
 
-   if(settings->bools.video_shader_enable)
+   if(settings->bools.video_shader_enable &&
+      !string_is_empty(retroarch_get_shader_preset()))
    {
       const char* ext = path_get_extension(retroarch_get_shader_preset());
 


### PR DESCRIPTION
## Description

Hopefully fixes a crash reported here:
https://gbatemp.net/threads/retroarch-wiiu-wip.447670/page-488#post-7832324

Seems the `path_get_extension` function doesn't like empty strings.

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/6249/files#diff-cd6dc48859a35a935e95f3037b68711dR450

