### PR TITLE
Use EVIOCGID's ioctl to get vendor/product id, #6325

### DIFF
--- a/input/drivers_joypad/udev_joypad.c
+++ b/input/drivers_joypad/udev_joypad.c
@@ -151,6 +151,7 @@ static int udev_add_pad(struct udev_device *dev, unsigned p, int fd, const char 
    unsigned axes                        = 0;
    struct udev_device *parent           = NULL;
    struct udev_joypad *pad              = (struct udev_joypad*)&udev_pads[p];
+   struct input_id inputid              = {0};
    unsigned long keybit[NBITS(KEY_MAX)] = {0};
    unsigned long absbit[NBITS(ABS_MAX)] = {0};
    unsigned long ffbit[NBITS(FF_MAX)]   = {0};
@@ -163,16 +164,12 @@ static int udev_add_pad(struct udev_device *dev, unsigned p, int fd, const char 
       return -1;
    }
 
-   /* Don't worry about unref'ing the parent. */
-   parent = udev_device_get_parent_with_subsystem_devtype(dev, "usb", "usb_device");
-
    pad->vid = pad->pid = 0;
 
-   if ((buf = udev_device_get_sysattr_value(parent, "idVendor")) != NULL)
-      pad->vid = strtol(buf, NULL, 16);
-
-   if ((buf = udev_device_get_sysattr_value(parent, "idProduct")) != NULL)
-      pad->pid = strtol(buf, NULL, 16);
+   if (ioctl(fd, EVIOCGID, &inputid) >= 0) {
+      pad->vid = inputid.vendor;
+      pad->pid = inputid.product;
+   }
 
    RARCH_LOG("[udev]: Plugged pad: %s (%u:%u) on port #%u.\n",
              pad->ident, pad->vid, pad->pid, p);


### PR DESCRIPTION
The current code get the USB vendor/product controller, in case of
bluetooth connection this means that you get the bluetooth dongle ids
instead of gamepads. This is not fine as we match gamepads using their
product and vendor ids.

Credits go to SDL which helped me to figure out this issue.

http://hg.libsdl.org/SDL/file/f7c6b974d5af/src/joystick/linux/SDL_sysjoystick.c#l208

## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises


## Description

[Description of the pull request, detail any issues you are fixing or any features you are implementing]

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
