### PR TITLE
Remove an incorrect double-check

### DIFF
--- a/network/netplay/netplay_sync.c
+++ b/network/netplay/netplay_sync.c
@@ -768,8 +768,7 @@ void netplay_sync_post_frame(netplay_t *netplay, bool stalled)
 
    /* Now replay the real input if we've gotten ahead of it */
    if (netplay->force_rewind ||
-       (netplay->replay_frame_count < netplay->unread_frame_count &&
-        netplay->replay_frame_count < netplay->run_frame_count))
+       netplay->replay_frame_count < netplay->run_frame_count)
    {
       retro_ctx_serialize_info_t serial_info;
 


### PR DESCRIPTION
## Description

Netplay sync incorrectly checked whether the replay pointer was behind
the unread pointer twice, when in the second check it should only have
been checking if it was behind the current execution pointer. Because of
how resimulation works with device sharing, I THINK this could affect
sync. Even if it can't, it's wrong.