### PR TITLE
[NSW] Graphics driver speed improvements/fixes and audio driver improvement

### DIFF
--- a/gfx/drivers/switch_gfx.c
+++ b/gfx/drivers/switch_gfx.c
@@ -220,17 +220,18 @@ static bool switch_frame(void *data, const void *frame,
    if (msg && strlen(msg) > 0)
       RARCH_LOG("message: %s\n", msg);
 
-   do {
-	   if (sw->vsync) /* vsync seems to sometimes return before the buffer has actually been dequeued? */
-		   switch_wait_vsync(sw);
-	   
-	   r = surface_dequeue_buffer(&sw->surface, &out_buffer);
-   } while(r != RESULT_OK);
-
+   r = surface_dequeue_buffer(&sw->surface, &out_buffer);
+   if (sw->vsync)
+	   switch_wait_vsync(sw);
+   svcSleepThread(10000);
+   if(r != RESULT_OK) {
+	   return true; // just skip the frame
+   }
+   
    gfx_slow_swizzling_blit(out_buffer, sw->image, 1280, 720, 0, 0);
    
    r = surface_queue_buffer(&sw->surface);
-
+   
    if (r != RESULT_OK)
       return false;
 

--- a/libretro-common/gfx/scaler/scaler.c
+++ b/libretro-common/gfx/scaler/scaler.c
@@ -239,6 +239,10 @@ bool scaler_ctx_gen_filter(struct scaler_ctx *ctx)
             ctx->out_pixconv = conv_argb8888_bgr24;
             break;
 
+         case SCALER_FMT_ABGR8888:
+            ctx->out_pixconv = conv_argb8888_abgr8888;
+            break;
+            
          default:
             return false;
       }


### PR DESCRIPTION
Turns out clearing row-by-row (as I originally intended...) is a lot faster than column-by-column. All the heavy pixel crunching work is now abstracted away using scalers, and we can run at full speed again. 

Libtransistor v1.2.1 uses three buffers instead of two, which fixes some issues with not being able to get a buffer on time and screen tearing caused by ignoring the fence returned from the OS, since we don't know how to wait on it yet, and instead writing into the buffer while it is being composited by nvnflinger. It gets returned to us before it is done because the OS expects that we submit GPU commands that block on the fence it gives us. In my testing, I haven't seen us miss getting a single buffer after this change.

Finally, the audio driver can now acquire buffers through `alloc_pages` instead of keeping them in bss. There is still some issue when running under the Homebrew Launcher that causes it to abort with code 2347-0026 after we exit, which means that some part of the address space is not getting cleaned up as it should. This will take some investigation to track down.