### PR TITLE
fix a bad in_addr manipulation - fixes #6127

### DIFF
--- a/libretro-common/net/net_compat.c
+++ b/libretro-common/net/net_compat.c
@@ -213,7 +213,7 @@ int getaddrinfo_retro(const char *node, const char *service,
 
       in_addr->sin_family = host->h_addrtype;
 
-#if defined(AF_INET6) && !defined(__CELLOS_LV2__)
+#if defined(AF_INET6) && !defined(__CELLOS_LV2__) || defined(VITA)
       /* TODO/FIXME - In case we ever want to support IPv6 */
       in_addr->sin_addr.s_addr = inet_addr(host->h_addr_list[0]);
 #else


### PR DESCRIPTION
The `in_addr` manipulation with `memcpy()` was causing the issue described in #6127 . It was introduced in the commit https://github.com/libretro/RetroArch/commit/a565ba0149cf91fe4aecb1b7cd93d9925627bef9

This PR fixes the problem on PS Vita.

Kudos to @frangarcj , who guided me on how to use `git bisect`. :kissing_heart: 

**EDIT**: I think this PR solves #6147 too.