### PR TITLE
Make command-line overrides (somewhat) clearer

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -1746,8 +1746,10 @@ static void config_set_defaults(void)
 
    /* Make sure settings from other configs carry over into defaults
     * for another config. */
-   dir_clear(RARCH_DIR_SAVEFILE);
-   dir_clear(RARCH_DIR_SAVESTATE);
+   if (!retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_SAVE_PATH, NULL))
+      dir_clear(RARCH_DIR_SAVEFILE);
+   if (!retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_STATE_PATH, NULL))
+      dir_clear(RARCH_DIR_SAVESTATE);
 
    *settings->paths.path_libretro_info = '\0';
    *settings->paths.directory_libretro = '\0';


### PR DESCRIPTION
This commit:

(1) Changes the order of command-line loading so that config loading
happens before command line overrides. This way, config loading does not
itself have to be concerned with being pre-overridden.

(2) Adds overrides to the data structures that configuration saving uses
to save configuration blocks of the same type, so that they can easily
be added in the future.

(3) Corrects some (all?) existing problems with command-line overrides
being ignored.



This really must be tested on some platform that uses the compat getopt_long. I don't know of any reason why it wouldn't work, since `optind` is there, but just for completeness.