### PR TITLE
make sure to always encode urls, also change the PS3 default urls

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -719,11 +719,11 @@ static char buildbot_server_url[] = "";
 #elif defined(WIIU)
 static char buildbot_server_url[] = "http://buildbot.libretro.com/nightly/nintendo/wiiu/latest/";
 #elif defined(__CELLOS_LV2__) && defined(DEX_BUILD)
-static char buildbot_server_url[] = "http://xbins.org/libretro/nightly/playstation/ps3/latest/dex-ps3/";
+static char buildbot_server_url[] = "http://libretro.xbins.org/libretro/nightly/playstation/ps3/latest/dex-ps3/";
 #elif defined(__CELLOS_LV2__) && defined(CEX_BUILD)
-static char buildbot_server_url[] = "http://xbins.org/libretro/nightly/playstation/ps3/latest/cex-ps3/";
+static char buildbot_server_url[] = "http://libretro.xbins.org/libretro/nightly/playstation/ps3/latest/cex-ps3/";
 #elif defined(__CELLOS_LV2__) && defined(ODE_BUILD)
-static char buildbot_server_url[] = "http://xbins.org/libretro/nightly/playstation/ps3/latest/ode-ps3/";
+static char buildbot_server_url[] = "http://libretro.xbins.org/libretro/nightly/playstation/ps3/latest/ode-ps3/";
 #else
 static char buildbot_server_url[] = "";
 #endif

--- a/libretro-common/net/net_http.c
+++ b/libretro-common/net/net_http.c
@@ -97,7 +97,7 @@ void urlencode_lut_init()
 
    for (i = 0; i < 256; i++)
    {
-      urlencode_lut[i] = isalnum(i) || i == '*' || i == '-' || i == '.' || i == '_' ? i : (i == ' ') ? '+' : 0;
+      urlencode_lut[i] = isalnum(i) || i == '*' || i == '-' || i == '.' || i == '_' || i == '/' ? i : 0;
    }
 }
 

--- a/tasks/task_http.c
+++ b/tasks/task_http.c
@@ -320,9 +320,32 @@ void* task_push_http_transfer(const char *url, bool mute,
       retro_task_callback_t cb, void *user_data)
 {
    struct http_connection_t *conn;
+   char *tmp;
+   char url_domain[PATH_MAX_LENGTH];
+   char url_path[PATH_MAX_LENGTH];
+   char url_encoded[PATH_MAX_LENGTH];
 
-   conn = net_http_connection_new(url, "GET", NULL);
+   int count = 0;
+   strlcpy (url_path, url, sizeof(url_path));
+   tmp = url_path;
 
+   while (count < 3 && tmp[0] != '\0')
+   {
+      tmp = strchr(tmp, '/');
+      count ++;
+      tmp++;
+   }
+
+   strlcpy(url_domain, url, tmp - url_path);
+   strlcpy(url_path, tmp, sizeof(url_path));
+
+   tmp = NULL;
+   net_http_urlencode_full (&tmp, url_path);
+   snprintf(url_encoded, sizeof(url_encoded), "%s/%s", url_domain, tmp);
+
+   conn = net_http_connection_new(url_encoded, "GET", NULL);
+
+   free (tmp);
    return task_push_http_transfer_generic(conn, url, mute, type, cb, user_data);
 }
 


### PR DESCRIPTION
## Description

This fixes the PS3 URLs, also fixes edge cases with the content downloader (I have my own content downloader with the full no intro set and it failed to download stuff all the time because spaces, parenthesis, commas, etc)

It should be reviewed / tested because some cheevos code uses it's own url encoding

@leiradel please take a look if you can
