### PR TITLE
decreasing verbosity in Achievements menu

### DIFF
--- a/intl/msg_hash_ar.h
+++ b/intl/msg_hash_ar.h
@@ -460,7 +460,7 @@ MSG_HASH(
       )
 MSG_HASH(
       MENU_ENUM_LABEL_VALUE_CHEEVOS_HARDCORE_MODE_ENABLE,
-      "Achievements Hardcore Mode"
+      "Hardcore Mode"
       )
 MSG_HASH(
       MENU_ENUM_LABEL_VALUE_CHEEVOS_LEADERBOARDS_ENABLE,
@@ -500,7 +500,7 @@ MSG_HASH(
       )
 MSG_HASH(
       MENU_ENUM_LABEL_VALUE_CHEEVOS_VERBOSE_ENABLE,
-      "Achievements Verbose Mode"
+      "Verbose Mode"
       )
 MSG_HASH(
       MENU_ENUM_LABEL_VALUE_CLOSE_CONTENT,

--- a/intl/msg_hash_chs.h
+++ b/intl/msg_hash_chs.h
@@ -413,7 +413,7 @@ MSG_HASH(
       )
 MSG_HASH(
       MENU_ENUM_LABEL_VALUE_CHEEVOS_HARDCORE_MODE_ENABLE,
-/* FIXME? Translate 'Achievements Hardcore Mode' */
+/* FIXME? Translate 'Hardcore Mode' */
       "专家模式"
       )
 MSG_HASH(

--- a/intl/msg_hash_cht.h
+++ b/intl/msg_hash_cht.h
@@ -413,7 +413,7 @@ MSG_HASH(
       )
 MSG_HASH(
       MENU_ENUM_LABEL_VALUE_CHEEVOS_HARDCORE_MODE_ENABLE,
-/* FIXME? Translate 'Achievements Hardcore Mode' */
+/* FIXME? Translate 'Hardcore Mode' */
       "成就-專家模式"
       )
 MSG_HASH(

--- a/intl/msg_hash_eo.h
+++ b/intl/msg_hash_eo.h
@@ -345,7 +345,7 @@ MSG_HASH(
       )
 MSG_HASH(
       MENU_ENUM_LABEL_VALUE_CHEEVOS_HARDCORE_MODE_ENABLE,
-      "Achievements Hardcore Mode"
+      "Hardcore Mode"
       )
 MSG_HASH(
       MENU_ENUM_LABEL_VALUE_CHEEVOS_LOCKED_ACHIEVEMENTS,

--- a/intl/msg_hash_nl.h
+++ b/intl/msg_hash_nl.h
@@ -345,7 +345,7 @@ MSG_HASH(
       )
 MSG_HASH(
       MENU_ENUM_LABEL_VALUE_CHEEVOS_HARDCORE_MODE_ENABLE,
-      "Achievements Hardcore Mode"
+      "Hardcore Mode"
       )
 MSG_HASH(
       MENU_ENUM_LABEL_VALUE_CHEEVOS_LOCKED_ACHIEVEMENTS,

--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -460,7 +460,7 @@ MSG_HASH(
       )
 MSG_HASH(
       MENU_ENUM_LABEL_VALUE_CHEEVOS_HARDCORE_MODE_ENABLE,
-      "Achievements Hardcore Mode"
+      "Hardcore Mode"
       )
 MSG_HASH(
       MENU_ENUM_LABEL_VALUE_CHEEVOS_LEADERBOARDS_ENABLE,
@@ -500,11 +500,11 @@ MSG_HASH(
       )
 MSG_HASH(
       MENU_ENUM_LABEL_VALUE_CHEEVOS_VERBOSE_ENABLE,
-      "Achievements Verbose Mode"
+      "Verbose Mode"
       )
 MSG_HASH(
       MENU_ENUM_LABEL_VALUE_CHEEVOS_AUTO_SCREENSHOT,
-      "Achievements Automatic Screenshot"
+      "Automatic Screenshot"
       )
 MSG_HASH(
       MENU_ENUM_LABEL_VALUE_CLOSE_CONTENT,


### PR DESCRIPTION
When inside Achievements menu, there's no need to put "Achievements " on some labels.

This PR is removing the "Achievements " from

- Achievements Hardcore Mode
- Achievements Verbose Mode
- Achievements Automatic Screenshot