### PR TITLE
fixing cheevos (broken after #6389)

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -1906,7 +1906,7 @@ static void cheevos_unlocked(void *task_data, void *user_data,
       RARCH_ERR("[CHEEVOS]: error awarding achievement %u, retrying...\n", cheevo->id);
 
       cheevos_make_unlock_url(cheevo, url, sizeof(url));
-      task_push_http_transfer(url, true, NULL, cheevos_unlocked, cheevo);
+      task_push_http_transfer_raw(url, true, NULL, cheevos_unlocked, cheevo);
    }
 }
 
@@ -1961,7 +1961,7 @@ static void cheevos_test_cheevo_set(const cheevoset_t *set)
             runloop_msg_queue_push(cheevo->description, 0, 3 * 60, false);
 
             cheevos_make_unlock_url(cheevo, url, sizeof(url));
-            task_push_http_transfer(url, true, NULL,
+            task_push_http_transfer_raw(url, true, NULL,
                   cheevos_unlocked, cheevo);
 
             if(settings->bools.cheevos_auto_screenshot)
@@ -2176,7 +2176,7 @@ static void cheevos_test_leaderboards(void)
                char formatted_value[16];
 
                cheevos_make_lboard_url(lboard, url, sizeof(url));
-               task_push_http_transfer(url, true, NULL,
+               task_push_http_transfer_raw(url, true, NULL,
                      cheevos_lboard_submit, lboard);
                RARCH_LOG("[CHEEVOS]: submit lboard %s\n", lboard->title);
 

--- a/tasks/task_http.c
+++ b/tasks/task_http.c
@@ -349,6 +349,17 @@ void* task_push_http_transfer(const char *url, bool mute,
    return task_push_http_transfer_generic(conn, url, mute, type, cb, user_data);
 }
 
+void* task_push_http_transfer_raw(const char *url, bool mute,
+      const char *type,
+      retro_task_callback_t cb, void *user_data)
+{
+   struct http_connection_t *conn;
+
+   conn = net_http_connection_new(url, "GET", NULL);
+
+   return task_push_http_transfer_generic(conn, url, mute, type, cb, user_data);
+}
+
 void* task_push_http_post_transfer(const char *url,
       const char *post_data, bool mute,
       const char *type, retro_task_callback_t cb, void *user_data)

--- a/tasks/tasks_internal.h
+++ b/tasks/tasks_internal.h
@@ -102,6 +102,9 @@ typedef struct
 void *task_push_http_transfer(const char *url, bool mute, const char *type,
       retro_task_callback_t cb, void *userdata);
 
+void *task_push_http_transfer_raw(const char *url, bool mute, const char *type,
+      retro_task_callback_t cb, void *userdata);
+
 void *task_push_http_post_transfer(const char *url, const char *post_data, bool mute, const char *type,
       retro_task_callback_t cb, void *userdata);
 


### PR DESCRIPTION
## Description

This fixes the cheevos feature, which was broken after PR #6389.

~~In order to make it work I had to declare the function `task_push_http_transfer_generic()` in `tasks/task_http.c` without the `static` modifier.~~

**UPDATE**: I created a function named `task_push_http_transfer_raw()` and made it NOT perform all that encoding url stuff implemented in #6389. And then made `cheevos.c` call the `_raw` version.


## Related Pull Requests

#6389 


## Reviewers

@leiradel @fr500 @RobLoach 