### PR TITLE
remove task_push_http_transfer_raw, encode before sending data to the…

### DIFF
--- a/menu/cbs/menu_cbs_left.c
+++ b/menu/cbs/menu_cbs_left.c
@@ -70,14 +70,13 @@ static int shader_action_parameter_left(unsigned type, const char *label, bool w
    video_shader_driver_get_current_shader(&shader_info);
 
    param_prev = &shader_info.data->parameters[type - MENU_SETTINGS_SHADER_PARAMETER_0];
-   if (!param_prev)
+   param_menu = shader ? &shader->parameters[type - 
+      MENU_SETTINGS_SHADER_PARAMETER_0] : NULL;
+
+   if (!param_prev || !param_menu)
       return menu_cbs_exit();
    ret = generic_shader_action_parameter_left(param_prev, type, label, wraparound);
 
-   param_menu = shader ? &shader->parameters[type - 
-      MENU_SETTINGS_SHADER_PARAMETER_0] : NULL;
-   if (!param_menu)
-      return menu_cbs_exit();
    param_menu->current = param_prev->current;
 
    return ret;

--- a/menu/cbs/menu_cbs_right.c
+++ b/menu/cbs/menu_cbs_right.c
@@ -64,23 +64,22 @@ static int generic_shader_action_parameter_right(struct video_shader_parameter *
 int shader_action_parameter_right(unsigned type, const char *label, bool wraparound)
 {
    video_shader_ctx_t shader_info;
-   struct video_shader_parameter *param_prev = NULL;
+   struct video_shader *shader          = menu_shader_get();
    struct video_shader_parameter *param_menu = NULL;
+   struct video_shader_parameter *param_prev = NULL;
 
    int ret = 0;
 
    video_shader_driver_get_current_shader(&shader_info);
 
    param_prev = &shader_info.data->parameters[type - MENU_SETTINGS_SHADER_PARAMETER_0];
+   param_menu = shader ? &shader->parameters[type - 
+      MENU_SETTINGS_SHADER_PARAMETER_0] : NULL;
 
-   if (!param_prev)
+   if (!param_prev || !param_menu)
       return menu_cbs_exit();
    ret = generic_shader_action_parameter_right(param_prev, type, label, wraparound);
-   
-   param_menu = &shader_info.data->parameters[type - 
-      MENU_SETTINGS_SHADER_PARAMETER_0];
-   if (!param_menu)
-      return menu_cbs_exit();
+
    param_menu->current = param_prev->current;
 
    return ret;


### PR DESCRIPTION
… task

This reverts the code to the state it was before the changes and makes the following changes:

- Rename: `net_http_urlencode_full` to `net_http_urlencode` since this function is used to encode individual string members
- Add `net_http_urlencode_full`, this function still needs more work but it's working ok so far, it takes a full URL, splits it up in parts and encodes the non-domain part

The idea is that the task caller would be responsible for encoding, the task assumes the URL is encoded / valid