### PR TITLE
Fix X11 Vulkan bug from Wayland driver.

### DIFF
--- a/gfx/drivers_context/wayland_ctx.c
+++ b/gfx/drivers_context/wayland_ctx.c
@@ -545,7 +545,7 @@ static void gfx_ctx_wl_destroy_resources(gfx_ctx_wayland_data_t *wl)
 #ifdef HAVE_VULKAN
          vulkan_context_destroy(&wl->vk, wl->surface);
 
-         if (wl->input.fd >= 0)
+         if (wl->input.dpy != NULL && wl->input.fd >= 0)
             close(wl->input.fd);
 #endif
          break;


### PR DESCRIPTION
The wayland vulkan driver is closing a non-initialized file descriptor that happens to be 0. Other open requests allocate file descriptor 0, and the wayland driver closes it every time when it fails to initialize. This breaks X11 Vulkan, which initializes afterward.