### PR TITLE
xmb_scale_factor min limit to 20

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -5546,7 +5546,7 @@ static bool setting_append_list(
                   parent_group,
                   general_write_handler,
                   general_read_handler);
-            menu_settings_list_current_add_range(list, list_info, 0, 200, 1, true, true);
+            menu_settings_list_current_add_range(list, list_info, 20, 200, 1, true, true);
             settings_data_list_current_add_flags(list, list_info, SD_FLAG_LAKKA_ADVANCED);
 
             CONFIG_PATH(


### PR DESCRIPTION
XMB crashes with really low values, 20 is small enough.