### PR TITLE
Fix multi-line text spacing in menus with Vulkan driver.

### DIFF
--- a/gfx/drivers_context/x_ctx.c
+++ b/gfx/drivers_context/x_ctx.c
@@ -455,6 +455,7 @@ static bool gfx_ctx_x_set_resize(void *data,
             if (!vulkan_create_swapchain(&x->vk, width, height, x->g_interval))
             {
                RARCH_ERR("[X/Vulkan]: Failed to update swapchain.\n");
+               x->vk.swapchain = VK_NULL_HANDLE;
                return false;
             }
 
@@ -469,7 +470,7 @@ static bool gfx_ctx_x_set_resize(void *data,
       default:
          break;
    }
-   return false;
+   return true;
 }
 
 static void *gfx_ctx_x_init(video_frame_info_t *video_info, void *data)

--- a/gfx/drivers_font/vulkan_raster_font.c
+++ b/gfx/drivers_font/vulkan_raster_font.c
@@ -240,7 +240,8 @@ static void vulkan_raster_font_render_message(
       return;
    }
 
-   line_height = scale / font->font_driver->get_line_height(font->font_data);
+   line_height = (float) font->font_driver->get_line_height(font->font_data) *
+                     scale / font->vk->vp.height;
 
    for (;;)
    {


### PR DESCRIPTION
Multi-line label text in menus is spaced erratically, depending on resolution and scale, with the Vulkan driver. Copying the formula from the GL driver fixes this.