### PR TITLE
Fix apitrace shader compiler warning.

### DIFF
--- a/gfx/drivers/gl_shaders/pipeline_snowflake.glsl.frag.h
+++ b/gfx/drivers/gl_shaders/pipeline_snowflake.glsl.frag.h
@@ -24,7 +24,7 @@ static const char* stock_fragment_xmb_snowflake = GLSL(
    float snow(vec3 pos, vec2 uv, float o)
    {
       vec2 d = (pos.xy - uv);
-      float a = atan(d.y,d.x) + sin(atime*1.0 + o) * 10.0;
+      float a = atan(d.y,d.x) + sin(time*1.0 + o) * 10.0;
 
       float dist = d.x*d.x + d.y*d.y;
 


### PR DESCRIPTION
## Description

Fixes a shader compiler warning as reported by apitrace.

## Related Issues
```
2418: message: major shader compiler issue 2: 0:3(311): warning: `atime' used uninitialized
2418 @0 glCompileShader(shader = 27)
2418: warning: 0:3(311): warning: `atime' used uninitialized
```

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/5852
https://github.com/libretro/RetroArch/commit/2747067f6188d0e4f845c6ceb5d39a33ab193b87#diff-cbae9e1afabf9b627a5a90861f4c0896

## Reviewers

This was reviewed in irc by @hunterk.