### PR TITLE
Fix a bug in remembering device availability for netplay

### DIFF
--- a/network/netplay/netplay_io.c
+++ b/network/netplay/netplay_io.c
@@ -681,7 +681,7 @@ static void handle_play_spectate(netplay_t *netplay, uint32_t client_num,
          netplay->connected_slaves &= ~(1 << client_num);
          netplay->client_devices[client_num] = 0;
          for (i = 0; i < MAX_INPUT_DEVICES; i++)
-            netplay->device_clients[client_num] &= ~(1 << client_num);
+            netplay->device_clients[i] &= ~(1 << client_num);
 
          /* Tell someone */
          payload[0] = htonl(netplay->read_frame_count[client_num]);


### PR DESCRIPTION
Really silly bug had netplay forgetting to unset device availability
when a client goes to spectator mode. As a consequence, in certain
configurations, later joins would automatically choose the wrong device,
and you'd have to manually specify a device to get the right one. This
fixes that.


## Related Issues

(I don't know of anyone other than me finding this in the wild)
