### PR TITLE
revert change to core association to fix regression

### DIFF
--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -2875,7 +2875,7 @@ static int action_ok_reset_core_association(const char *path,
    playlist_get_index(tmp_playlist,
          rpl_entry_selection_ptr, &tmp_path, NULL, NULL, NULL, NULL, NULL);
 
-   if (!command_event(CMD_EVENT_RESET_CORE_ASSOCIATION, (void *)&rpl_entry_selection_ptr))
+   if (!command_event(CMD_EVENT_RESET_CORE_ASSOCIATION, (void *)rpl_entry_selection_ptr))
       return menu_cbs_exit();
    return 0;
 }


### PR DESCRIPTION
This re-enables the core reset feature which stopped working here: https://github.com/libretro/RetroArch/commit/0ece3d839706b260fff007a5d5521e077bab7281#r28246933