### PR TITLE
Core association warning

### DIFF
--- a/command.c
+++ b/command.c
@@ -2338,10 +2338,11 @@ TODO: Add a setting for these tweaks */
 
          core_name = "DETECT";
          core_path = "DETECT";
+         size_t *playlist_index = (size_t *)data;
 
          command_playlist_update_write(
             NULL,
-            (size_t)data,
+            *playlist_index,
             NULL,
             NULL,
             core_path,

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -2875,7 +2875,7 @@ static int action_ok_reset_core_association(const char *path,
    playlist_get_index(tmp_playlist,
          rpl_entry_selection_ptr, &tmp_path, NULL, NULL, NULL, NULL, NULL);
 
-   if (!command_event(CMD_EVENT_RESET_CORE_ASSOCIATION, (void *)rpl_entry_selection_ptr))
+   if (!command_event(CMD_EVENT_RESET_CORE_ASSOCIATION, (void *)&rpl_entry_selection_ptr))
       return menu_cbs_exit();
    return 0;
 }


### PR DESCRIPTION
cast and dereference pointer without compiler warn

follows: https://github.com/libretro/RetroArch/pull/6447

@retro-wertz 