### PR TITLE
Add PokeMini index for 3ds

### DIFF
--- a/pkg/ctr/Makefile.cores
+++ b/pkg/ctr/Makefile.cores
@@ -273,5 +273,13 @@ else ifeq ($(LIBRETRO), stella)
 	APP_UNIQUE_ID        = 0xBAC2C
 	APP_ICON             = pkg/ctr/assets/stella.png
 	APP_BANNER           = pkg/ctr/assets/stella_banner.png
+	
+else ifeq ($(LIBRETRO), pokemini)
+	APP_TITLE            = PokeMini
+	APP_AUTHOR           = justburn
+	APP_PRODUCT_CODE     = RARCH-POKEMINI
+	APP_UNIQUE_ID        = 0xBAC20
+	APP_ICON             = pkg/ctr/assets/default.png
+	APP_BANNER           = pkg/ctr/assets/libretro_banner.png
 
 endif


### PR DESCRIPTION
PokeMini currently compiles and opens on 3ds but doesnt run any frames(no crash or lockup though).