### PR TITLE
[iOS]: fixed configuration file path 

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -1905,8 +1905,11 @@ static void config_set_defaults(void)
             g_defaults.dirs[DEFAULT_DIR_MENU_CONFIG],
             sizeof(settings->paths.directory_menu_config));
 #if TARGET_OS_IPHONE
-      path_set(RARCH_PATH_CONFIG,
-            settings->paths.directory_menu_config);
+       char *config_file_path                        = (char*)malloc(PATH_MAX_LENGTH * sizeof(char));
+       size_t config_file_path_size                       = PATH_MAX_LENGTH * sizeof(char);
+       fill_pathname_join(config_file_path, settings->paths.directory_menu_config, file_path_str(FILE_PATH_MAIN_CONFIG), config_file_path_size);
+       path_set(RARCH_PATH_CONFIG,
+                config_file_path);
 #endif
    }
 


### PR DESCRIPTION
## Description

The configuration file path for iOS for previous versions had the config file path to be:
~/Documents/RetroArch/config

Doing the above prevented the config directory to be created, preventing functionality like core and game overrides to work.

This fixes the issue for new installs. If you install over an existing version, the issue remains because the config directory cannot be created. 

I'm thinking of writing iOS-specific code in retroarch's view controller to create the config directory and move the existing config file there (along with the content_history and content_favorites files).