### PR TITLE
MUI New dpi calculation. (needs improvement)

### DIFF
--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -536,20 +536,19 @@ void menu_display_unset_framebuffer_dirty_flag(void)
  * RGUI or XMB use this. */
 float menu_display_get_dpi(void)
 {
-   gfx_ctx_metrics_t metrics;
    settings_t *settings = config_get_ptr();
-   float            dpi = menu_dpi_override_value;
+   float            dpi;
+   unsigned width, height;
+
+   video_driver_get_size(&width, &height);
 
    if (!settings)
       return true;
 
-   metrics.type  = DISPLAY_METRIC_DPI;
-   metrics.value = &dpi;
+   dpi = sqrt((width * width) + (height * height)) / 6.5;
 
    if (settings->bools.menu_dpi_override_enable)
       return settings->uints.menu_dpi_override_value;
-   else if (!video_context_driver_get_metrics(&metrics) || !dpi)
-      return menu_dpi_override_value;
 
    return dpi;
 }


### PR DESCRIPTION

## Description

Auto DPI should now work better by default, displaying something usable on all phones.

## Related Issues

On desktop, switching from fullscreen to window mode will not refresh the scaling directly.
You need to move to another list for it to look fine again.
(What happens when switching orientation on phones? dpi shouldn't change?
I could only test on desktop.)

I got rid of the metrics part that didn't seem to do much but I could be wrong.
I'm not sure if they're used at all.
