### PR TITLE
Fix invalid long command line options causing infinite loop on Windows (issue #6477)

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -743,6 +743,11 @@ static void retroarch_parse_input_and_config(int argc, char *argv[])
                   RARCH_OVERRIDE_SETTING_STATE_PATH, NULL);
             break;
 
+         /* Must handle '?' otherwise you get an infinite loop */
+         case '?':
+            retroarch_print_help(argv[0]);
+            retroarch_fail(1, "retroarch_parse_input()");
+            break;
          /* All other arguments are handled in the second pass */
       }
    }


### PR DESCRIPTION
## Description

Per issue #6477, you get an infinite loop on Windows if you specify a nonexistent long command line option.

Example: Run `retroarch --fake` and it freezes

All the invalid long commands map to '?', so this change forces it to handle the '?' command in the first pass, 

## Related Issues

issue #6477 