### PR TITLE
Rename "cached_device" to "cached_device_d3d11" to avoid a name conflict on griffin builds

### DIFF
--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -39,7 +39,7 @@
 #include "../drivers_shader/slang_process.h"
 #endif
 
-static D3D11Device           cached_device;
+static D3D11Device           cached_device_d3d11;
 static D3D_FEATURE_LEVEL     cached_supportedFeatureLevel;
 static D3D11DeviceContext    cached_context;
 
@@ -555,7 +555,7 @@ static void d3d11_gfx_free(void* data)
 
 	if (video_driver_is_video_cache_context())
 	{
-		cached_device = d3d11->device;
+      cached_device_d3d11 = d3d11->device;
 		cached_context = d3d11->context;
 		cached_supportedFeatureLevel = d3d11->supportedFeatureLevel;
 	}
@@ -632,13 +632,13 @@ d3d11_gfx_init(const video_info_t* video, const input_driver_t** input, void** i
 #ifdef DEBUG
       flags |= D3D11_CREATE_DEVICE_DEBUG;
 #endif
-		if(cached_device && cached_context)
+		if(cached_device_d3d11 && cached_context)
 		{
 			IDXGIFactory* dxgiFactory = NULL;
 			IDXGIDevice* dxgiDevice = NULL;
 			IDXGIAdapter* adapter = NULL;
 
-			d3d11->device = cached_device;
+			d3d11->device = cached_device_d3d11;
 			d3d11->context = cached_context;
 			d3d11->supportedFeatureLevel = cached_supportedFeatureLevel;
 


### PR DESCRIPTION
## Description

In order to fix building on MSVC 2017, I renamed the variable `cached_device` to `cached_device_d3d11` in `d3d11.c` to make it build.

## Related Issues

This is for issue #6474

## Reviewers

@twinaphex was assigned to this on the bug report.