### PR TITLE
Expand environment strings on Windows (allow %temp% in paths), and use system temp directory on Windows for Cache

### DIFF
--- a/frontend/drivers/platform_win32.c
+++ b/frontend/drivers/platform_win32.c
@@ -458,7 +458,9 @@ static void frontend_win32_environment_get(int *argc, char *argv[],
    fill_pathname_expand_special(g_defaults.dirs[DEFAULT_DIR_SAVESTATE],
       ":\\states", sizeof(g_defaults.dirs[DEFAULT_DIR_SAVESTATE]));
    fill_pathname_expand_special(g_defaults.dirs[DEFAULT_DIR_SYSTEM],
-      ":\\system", sizeof(g_defaults.dirs[DEFAULT_DIR_SYSTEM]));
+	   ":\\system", sizeof(g_defaults.dirs[DEFAULT_DIR_SYSTEM]));
+   fill_pathname_expand_special(g_defaults.dirs[DEFAULT_DIR_CACHE],
+	   "%temp%/retroarch_temp/", sizeof(g_defaults.dirs[DEFAULT_DIR_CACHE]));
 
 #ifdef HAVE_MENU
 #if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES)

--- a/libretro-common/compat/fopen_utf8.c
+++ b/libretro-common/compat/fopen_utf8.c
@@ -18,7 +18,7 @@ void *fopen_utf8(const char * filename, const char * mode)
    return fopen(filename, mode);
 #elif defined(LEGACY_WIN32)
    FILE             *ret = NULL;
-   char * filename_local = utf8_to_local_string_alloc(filename);
+   char * filename_local = utf8_to_local_string_alloc_expand_environment_strings(filename);
 
    if (!filename_local)
       return NULL;

--- a/libretro-common/compat/fopen_utf8.c
+++ b/libretro-common/compat/fopen_utf8.c
@@ -27,7 +27,7 @@ void *fopen_utf8(const char * filename, const char * mode)
       free(filename_local);
    return ret;
 #else
-   wchar_t * filename_w = utf8_to_utf16_string_alloc(filename);
+   wchar_t * filename_w = utf8_to_utf16_string_alloc_expand_environment_strings(filename);
    wchar_t * mode_w = utf8_to_utf16_string_alloc(mode);
    FILE* ret = _wfopen(filename_w, mode_w);
    free(filename_w);

--- a/libretro-common/dynamic/dylib.c
+++ b/libretro-common/dynamic/dylib.c
@@ -78,7 +78,7 @@ dylib_t dylib_load(const char *path)
 #ifdef LEGACY_WIN32
    dylib_t lib  = LoadLibrary(path);
 #else
-   wchar_t *pathW = utf8_to_utf16_string_alloc(path);
+   wchar_t *pathW = utf8_to_utf16_string_alloc_expand_environment_strings(path);
    dylib_t lib  = LoadLibraryW(pathW);
 
    free(pathW);

--- a/libretro-common/encodings/encoding_utf.c
+++ b/libretro-common/encodings/encoding_utf.c
@@ -372,6 +372,44 @@ char* local_to_utf8_string_alloc(const char *str)
 }
 
 /* Returned pointer MUST be freed by the caller if non-NULL. */
+wchar_t* utf8_to_utf16_string_alloc_expand_environment_strings(const char *str)
+{
+   /* Windows only for now, otherwise just returns utf8_to_utf16_string_alloc */
+#ifdef _WIN32
+   wchar_t *result;
+   wchar_t *result2;
+   DWORD requiredSize;
+   int bufferSize;
+
+   result = utf8_to_utf16_string_alloc(str);
+   if (result == NULL)
+   {
+      return NULL;
+   }
+   /* if the path contains %, try expanding the environment strings */
+   if (wcschr(result, L'%'))
+   {
+      requiredSize = ExpandEnvironmentStringsW(result, NULL, 0);
+      if (requiredSize == 0)
+      {
+         return result;
+      }
+      bufferSize = (int)(requiredSize + 1);
+      result2 = (wchar_t*)malloc(bufferSize * sizeof(wchar_t));
+      ExpandEnvironmentStringsW(result, result2, bufferSize);
+      free(result);
+      return result2;
+   }
+   else
+   {
+      return result;
+   }
+#else
+   return utf8_to_utf16_string_alloc(str);
+#endif
+}
+
+/* Returned pointer MUST be freed by the caller if non-NULL. */
 wchar_t* utf8_to_utf16_string_alloc(const char *str)
 {
 #ifdef _WIN32

--- a/libretro-common/file/file_path.c
+++ b/libretro-common/file/file_path.c
@@ -141,7 +141,7 @@ static bool path_stat(const char *path, enum stat_mode mode, int32_t *size)
    (void)file_info;
 
 #if defined(LEGACY_WIN32)
-   path_local = utf8_to_local_string_alloc(path);
+   path_local = utf8_to_local_string_alloc_expand_environment_strings(path);
    file_info  = GetFileAttributes(path_local);
 
    _stat(path_local, &buf);

--- a/libretro-common/file/file_path.c
+++ b/libretro-common/file/file_path.c
@@ -149,7 +149,7 @@ static bool path_stat(const char *path, enum stat_mode mode, int32_t *size)
    if (path_local)
      free(path_local);
 #else
-   path_wide = utf8_to_utf16_string_alloc(path);
+   path_wide = utf8_to_utf16_string_alloc_expand_environment_strings(path);
    file_info = GetFileAttributesW(path_wide);
 
    _wstat(path_wide, &buf);
@@ -286,7 +286,7 @@ bool path_mkdir(const char *dir)
 #ifdef LEGACY_WIN32
       int ret = _mkdir(dir);
 #else
-      wchar_t *dirW = utf8_to_utf16_string_alloc(dir);
+      wchar_t *dirW = utf8_to_utf16_string_alloc_expand_environment_strings(dir);
       int ret = -1;
 
       if (dirW)

--- a/libretro-common/file/nbio/nbio_stdio.c
+++ b/libretro-common/file/nbio/nbio_stdio.c
@@ -65,7 +65,7 @@ static void *nbio_stdio_open(const char * filename, unsigned mode)
 #if !defined(_WIN32) || defined(LEGACY_WIN32)
    FILE* f                     = fopen(filename, stdio_modes[mode]);
 #else
-   wchar_t *filename_wide      = utf8_to_utf16_string_alloc(filename);
+   wchar_t *filename_wide      = utf8_to_utf16_string_alloc_expand_environment_strings(filename);
    FILE* f                     = _wfopen(filename_wide, stdio_modes[mode]);
 
    if (filename_wide)

--- a/libretro-common/file/nbio/nbio_windowsmmap.c
+++ b/libretro-common/file/nbio/nbio_windowsmmap.c
@@ -68,7 +68,7 @@ static void *nbio_mmap_win32_open(const char * filename, unsigned mode)
 #if !defined(_WIN32) || defined(LEGACY_WIN32)
    HANDLE file                       = CreateFile(filename, access, FILE_SHARE_ALL, NULL, dispositions[mode], FILE_ATTRIBUTE_NORMAL, NULL);
 #else
-   wchar_t *filename_wide            = utf8_to_utf16_string_alloc(filename);
+   wchar_t *filename_wide            = utf8_to_utf16_string_alloc_expand_environment_strings(filename);
    HANDLE file                       = CreateFileW(filename_wide, access, FILE_SHARE_ALL, NULL, dispositions[mode], FILE_ATTRIBUTE_NORMAL, NULL);
 
    if (filename_wide)

--- a/libretro-common/file/retro_dirent.c
+++ b/libretro-common/file/retro_dirent.c
@@ -131,7 +131,7 @@ struct RDIR *retro_opendir(const char *name)
    if (path_local)
       free(path_local);
 #else
-   path_wide       = utf8_to_utf16_string_alloc(path_buf);
+   path_wide       = utf8_to_utf16_string_alloc_expand_environment_strings(path_buf);
    rdir->directory = FindFirstFileW(path_wide, &rdir->entry);
 
    if (path_wide)

--- a/libretro-common/file/retro_dirent.c
+++ b/libretro-common/file/retro_dirent.c
@@ -125,7 +125,7 @@ struct RDIR *retro_opendir(const char *name)
       snprintf(path_buf, sizeof(path_buf), "%s\\*", name);
 
 #if defined(LEGACY_WIN32)
-   path_local      = utf8_to_local_string_alloc(path_buf);
+   path_local      = utf8_to_local_string_alloc_expand_environment_strings(path_buf);
    rdir->directory = FindFirstFile(path_local, &rdir->entry);
 
    if (path_local)

--- a/libretro-common/include/encodings/utf.h
+++ b/libretro-common/include/encodings/utf.h
@@ -56,6 +56,8 @@ bool utf16_to_char_string(const uint16_t *in, char *s, size_t len);
 
 char* utf8_to_local_string_alloc(const char *str);
 
+char* utf8_to_local_string_alloc_expand_environment_strings(const char *str);
+
 char* local_to_utf8_string_alloc(const char *str);
 
 wchar_t* utf8_to_utf16_string_alloc_expand_environment_strings(const char *str);

--- a/libretro-common/include/encodings/utf.h
+++ b/libretro-common/include/encodings/utf.h
@@ -58,6 +58,8 @@ char* utf8_to_local_string_alloc(const char *str);
 
 char* local_to_utf8_string_alloc(const char *str);
 
+wchar_t* utf8_to_utf16_string_alloc_expand_environment_strings(const char *str);
+
 wchar_t* utf8_to_utf16_string_alloc(const char *str);
 
 char* utf16_to_utf8_string_alloc(const wchar_t *str);

--- a/libretro-common/vfs/vfs_implementation.c
+++ b/libretro-common/vfs/vfs_implementation.c
@@ -287,7 +287,7 @@ libretro_vfs_implementation_file *retro_vfs_file_open_impl(const char *path, uns
    {
 #if defined(_WIN32) && !defined(_XBOX)
 #if defined(LEGACY_WIN32)
-      char *path_local    = utf8_to_local_string_alloc(path);
+      char *path_local    = utf8_to_local_string_alloc_expand_environment_strings(path);
       stream->fd          = open(path_local, flags, 0);
       if (path_local)
          free(path_local);
@@ -492,7 +492,7 @@ int retro_vfs_file_remove_impl(const char *path)
 
 #if defined(_WIN32) && !defined(_XBOX)
 #if defined(_WIN32_WINNT) && _WIN32_WINNT < 0x0500
-   path_local = utf8_to_local_string_alloc(path);
+   path_local = utf8_to_local_string_alloc_expand_environment_strings(path);
 
    if (path_local)
    {
@@ -538,8 +538,8 @@ int retro_vfs_file_rename_impl(const char *old_path, const char *new_path)
 
 #if defined(_WIN32) && !defined(_XBOX)
 #if defined(_WIN32_WINNT) && _WIN32_WINNT < 0x0500
-   old_path_local = utf8_to_local_string_alloc(old_path);
-   new_path_local = utf8_to_local_string_alloc(new_path);
+   old_path_local = utf8_to_local_string_alloc_expand_environment_strings(old_path);
+   new_path_local = utf8_to_local_string_alloc_expand_environment_strings(new_path);
 
    if (old_path_local)
    {

--- a/libretro-common/vfs/vfs_implementation.c
+++ b/libretro-common/vfs/vfs_implementation.c
@@ -292,7 +292,7 @@ libretro_vfs_implementation_file *retro_vfs_file_open_impl(const char *path, uns
       if (path_local)
          free(path_local);
 #else
-      wchar_t * path_wide = utf8_to_utf16_string_alloc(path);
+      wchar_t * path_wide = utf8_to_utf16_string_alloc_expand_environment_strings(path);
       stream->fd          = _wopen(path_wide, flags, 0);
       if (path_wide)
          free(path_wide);
@@ -503,7 +503,7 @@ int retro_vfs_file_remove_impl(const char *path)
          return 0;
    }
 #else
-   path_wide = utf8_to_utf16_string_alloc(path);
+   path_wide = utf8_to_utf16_string_alloc_expand_environment_strings(path);
 
    if (path_wide)
    {
@@ -557,8 +557,8 @@ int retro_vfs_file_rename_impl(const char *old_path, const char *new_path)
    if (new_path_local)
       free(new_path_local);
 #else
-   old_path_wide = utf8_to_utf16_string_alloc(old_path);
-   new_path_wide = utf8_to_utf16_string_alloc(new_path);
+   old_path_wide = utf8_to_utf16_string_alloc_expand_environment_strings(old_path);
+   new_path_wide = utf8_to_utf16_string_alloc_expand_environment_strings(new_path);
 
    if (old_path_wide)
    {


### PR DESCRIPTION
## Description

This is a change for RetroArch to allow use of environment variables (such as %temp%) in path names on Windows.
The default Cache directory is also now set on Windows to be "%temp%/retroarch_temp/", rather than defaulting to the RetroArch directory.
On a typical system, %temp% is "C:\users\username\appdata\local\temp\"

Use of the %temp% environment variable vs a call to get the system temp directory allows the same installation to be used by multiple users without temp files getting created into another user's temp directory.

## Related Issues

Fixes #6438, and addresses part of #6458
