### PR TITLE
XMB Left thumb dynamic positioning and scaling.

### DIFF
--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -747,8 +747,8 @@ static void xmb_draw_thumbnail(
    coords.tex_coord         = NULL;
    coords.lut_tex_coord     = NULL;
 
-   draw.width               = w * scale_mod[4];
-   draw.height              = h * scale_mod[4];
+   draw.width               = w;
+   draw.height              = h;
    draw.coords              = &coords;
    draw.matrix_data         = &mymat;
    draw.texture             = texture;
@@ -2587,11 +2587,7 @@ static int xmb_draw_item(
             (!string_is_equal
              (thumb_ident,
               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF))
-             && xmb->thumbnail) ||
-            (!string_is_equal
-             (left_thumb_ident,
-              msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF))
-             && xmb->left_thumbnail)
+             && xmb->thumbnail)
          )
          ticker_limit = 40 * scale_mod[1];
       else
@@ -3119,7 +3115,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
             + xmb->icon_spacing_horizontal +
             xmb->icon_spacing_horizontal * 4 - xmb->icon_size / 4,
             xmb->margins_screen_top + xmb->icon_size + xmb->savestate_thumbnail_height * scale_mod[4],
-            xmb->savestate_thumbnail_width, xmb->savestate_thumbnail_height,
+            xmb->savestate_thumbnail_width, xmb->savestate_thumbnail_height * scale_mod[4],
             xmb->savestate_thumbnail);
    else if (xmb->thumbnail
       && !string_is_equal(xmb_thumbnails_ident('R'),
@@ -3152,7 +3148,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
             xmb->margins_screen_left * scale_mod[5] + xmb->icon_spacing_horizontal +
                   xmb->icon_spacing_horizontal*4 - xmb->icon_size / 4,
             xmb->margins_screen_top + xmb->icon_size + thumb_height * scale_mod[4],
-            thumb_width, thumb_height,
+            thumb_width * scale_mod[4], thumb_height * scale_mod[4],
             xmb->thumbnail);
 
    }
@@ -3163,29 +3159,32 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
       && !string_is_equal(xmb_thumbnails_ident('L'),
          msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF)))
    {
+      float scale_factor =  (settings->uints.menu_xmb_scale_factor * width) / (1920.0 * 100);
 
-      /* Limit thumbnail height to screen height + margin. */
-
-      if( xmb->margins_screen_top + xmb->icon_size * 2.2 + xmb->left_thumbnail_height >=
-         (float)(height * 0.9) )
+      /* Limit left thumbnail height to screen height + margin. */
+      if (xmb->margins_screen_top + xmb->icon_size * (!(xmb->depth == 1)? 2.1 : 1) +
+         xmb->left_thumbnail_height >= (float)(height - (96.0 * scale_factor)))
       {
-         left_thumb_width = (xmb->left_thumbnail_width / scale_mod[4]) *
-            (((float)(height * 0.9) - xmb->margins_screen_top - xmb->icon_size * 2.2) /
-               (xmb->left_thumbnail_height * scale_mod[4]));
-         left_thumb_height = (xmb->left_thumbnail_height / scale_mod[4]) *
-            (((float)(height * 0.9) - xmb->margins_screen_top - xmb->icon_size * 2.2) /
-               (xmb->left_thumbnail_height * scale_mod[4]));
+         left_thumb_width = xmb->left_thumbnail_width *
+            (((float)(height - (96.0 * scale_factor)) - xmb->margins_screen_top -
+               (xmb->icon_size * (!(xmb->depth == 1)? 2.1 : 1))) /
+                  xmb->left_thumbnail_height);
+
+         left_thumb_height = xmb->left_thumbnail_height *
+            (((float)(height - (96.0 * scale_factor)) - xmb->margins_screen_top -
+               (xmb->icon_size * (!(xmb->depth == 1)? 2.1 : 1))) /
+                  xmb->left_thumbnail_height);
       }
       else
       {
-         left_thumb_width = xmb->left_thumbnail_width / scale_mod[4];
-         left_thumb_height = xmb->left_thumbnail_height / scale_mod[4];
+         left_thumb_width = xmb->left_thumbnail_width;
+         left_thumb_height = xmb->left_thumbnail_height;
       }
 
       xmb_draw_thumbnail(video_info,
       xmb, &coord_white[0], width, height,
-      xmb->margins_title_left - 10,
-      xmb->margins_screen_top + xmb->icon_size * 2.2 + left_thumb_height * scale_mod[4],
+      20 * scale_factor + ((xmb->left_thumbnail_width - left_thumb_width) / 2),
+      xmb->margins_screen_top + xmb->icon_size * (!(xmb->depth == 1)? 2.1 : 1) + left_thumb_height,
       left_thumb_width, left_thumb_height,
       xmb->left_thumbnail);
    }
@@ -3740,7 +3739,7 @@ static void *xmb_init(void **userdata, bool video_is_threaded)
    if (!xmb->selection_buf_old)
       goto error;
 
-   xmb->categories_active_idx          = 0;
+   xmb->categories_active_idx         = 0;
    xmb->categories_active_idx_old     = 0;
    xmb->x                             = 0;
    xmb->categories_x_pos              = 0;


### PR DESCRIPTION
When selecting an item in a playlist, the left thumbnail will position itself under the cart icon and scale accordingly.
When using only the Left Thumbnail, the text size will be longer in a playlist to take advantage of the empty space.