### PR TITLE
Allow compositor disabling on X11 fullscreen through _NET_WM_BYPASS_COMPOSITOR

### DIFF
--- a/gfx/drivers/xvideo.c
+++ b/gfx/drivers/xvideo.c
@@ -562,6 +562,16 @@ static void *xv_init(const video_info_t *video,
    XFree(visualinfo);
    XSetWindowBackground(g_x11_dpy, g_x11_win, 0);
 
+   if (video->fullscreen && settings->bools.video_disable_composition)
+   {
+      uint32_t value = 1;
+      Atom cardinal = XInternAtom(g_x11_dpy, "CARDINAL", False);
+      Atom net_wm_bypass_compositor = XInternAtom(g_x11_dpy, "_NET_WM_BYPASS_COMPOSITOR", False);
+
+      RARCH_LOG("[XVideo]: Requesting compositor bypass.\n");
+      XChangeProperty(g_x11_dpy, g_x11_win, net_wm_bypass_compositor, cardinal, 32, PropModeReplace, (const unsigned char*)&value, 1);
+   }
+
    XMapWindow(g_x11_dpy, g_x11_win);
 
    video_driver_get_window_title(title, sizeof(title));

--- a/gfx/drivers_context/x_ctx.c
+++ b/gfx/drivers_context/x_ctx.c
@@ -726,6 +726,15 @@ static bool gfx_ctx_x_set_video_mode(void *data,
 
    XChangeProperty(g_x11_dpy, g_x11_win, net_wm_icon, cardinal, 32, PropModeReplace, (const unsigned char*)retroarch_icon_data, sizeof(retroarch_icon_data) / sizeof(*retroarch_icon_data));
 
+   if (fullscreen && settings->bools.video_disable_composition)
+   {
+      uint32_t value = 1;
+      Atom net_wm_bypass_compositor = XInternAtom(g_x11_dpy, "_NET_WM_BYPASS_COMPOSITOR", False);
+
+      RARCH_LOG("[GLX]: Requesting compositor bypass.\n");
+      XChangeProperty(g_x11_dpy, g_x11_win, net_wm_bypass_compositor, cardinal, 32, PropModeReplace, (const unsigned char*)&value, 1);
+   }
+
    if (opacity < (unsigned)-1)
    {
       Atom net_wm_opacity = XInternAtom(g_x11_dpy, "_NET_WM_WINDOW_OPACITY", False);

--- a/gfx/drivers_context/xegl_ctx.c
+++ b/gfx/drivers_context/xegl_ctx.c
@@ -24,6 +24,7 @@
 #endif
 
 #include "../../frontend/frontend_driver.h"
+#include "../../configuration.h"
 
 #include "../common/egl_common.h"
 #include "../common/gl_common.h"
@@ -341,6 +342,16 @@ static bool gfx_ctx_xegl_set_video_mode(void *data,
          CWBorderPixel | CWColormap | CWEventMask |
          (true_full ? CWOverrideRedirect : 0), &swa);
    XSetWindowBackground(g_x11_dpy, g_x11_win, 0);
+
+   if (fullscreen && config_get_ptr()->bools.video_disable_composition)
+   {
+      uint32_t value = 1;
+      Atom cardinal = XInternAtom(g_x11_dpy, "CARDINAL", False);
+      Atom net_wm_bypass_compositor = XInternAtom(g_x11_dpy, "_NET_WM_BYPASS_COMPOSITOR", False);
+
+      RARCH_LOG("[X/EGL]: Requesting compositor bypass.\n");
+      XChangeProperty(g_x11_dpy, g_x11_win, net_wm_bypass_compositor, cardinal, 32, PropModeReplace, (const unsigned char*)&value, 1);
+   }
 
    if (!egl_create_context(&xegl->egl, (attr != egl_attribs) ? egl_attribs : NULL))
    {

--- a/intl/msg_hash_ar.h
+++ b/intl/msg_hash_ar.h
@@ -2565,7 +2565,7 @@ MSG_HASH(MSG_NETPLAY_LAN_SCANNING,
 MSG_HASH(MENU_ENUM_SUBLABEL_PAUSE_NONACTIVE,
       "Pause gameplay when RetroArch is not the active window.")
 MSG_HASH(MENU_ENUM_SUBLABEL_VIDEO_DISABLE_COMPOSITION,
-      "Enable or disable composition (Windows only).")
+      "Enable or disable composition.")
 MSG_HASH(MENU_ENUM_SUBLABEL_HISTORY_LIST_ENABLE,
       "Enable or disable recent playlist for games, images, music, and videos.")
 MSG_HASH(MENU_ENUM_SUBLABEL_CONTENT_HISTORY_SIZE,

--- a/intl/msg_hash_chs.h
+++ b/intl/msg_hash_chs.h
@@ -2407,7 +2407,7 @@ MSG_HASH(MSG_NETPLAY_LAN_SCANNING,
 MSG_HASH(MENU_ENUM_SUBLABEL_PAUSE_NONACTIVE,
       "当窗口失去焦点时暂停游戏。")
 MSG_HASH(MENU_ENUM_SUBLABEL_VIDEO_DISABLE_COMPOSITION,
-      "Enable or disable composition (Windows only).")
+      "Enable or disable composition.")
 MSG_HASH(MENU_ENUM_SUBLABEL_HISTORY_LIST_ENABLE,
       "为游戏、图片、音乐和视频启用/禁用历史记录。")
 MSG_HASH(MENU_ENUM_SUBLABEL_CONTENT_HISTORY_SIZE,

--- a/intl/msg_hash_cht.h
+++ b/intl/msg_hash_cht.h
@@ -2399,7 +2399,7 @@ MSG_HASH(MSG_NETPLAY_LAN_SCANNING,
 MSG_HASH(MENU_ENUM_SUBLABEL_PAUSE_NONACTIVE,
       "當窗口失去焦點時暫停遊戲。")
 MSG_HASH(MENU_ENUM_SUBLABEL_VIDEO_DISABLE_COMPOSITION,
-      "Enable or disable composition (Windows only).")
+      "Enable or disable composition.")
 MSG_HASH(MENU_ENUM_SUBLABEL_HISTORY_LIST_ENABLE,
       "為遊戲、圖片、音樂和視訊啟用/禁用歷史記錄。")
 MSG_HASH(MENU_ENUM_SUBLABEL_CONTENT_HISTORY_SIZE,

--- a/intl/msg_hash_eo.h
+++ b/intl/msg_hash_eo.h
@@ -2286,7 +2286,7 @@ MSG_HASH(MENU_ENUM_LABEL_VALUE_DATABASE_CURSOR_LIST_ENTRY_DATABASE_INFO,
 MSG_HASH(MENU_ENUM_SUBLABEL_PAUSE_NONACTIVE,
       "Pause gameplay when window focus is lost.")
 MSG_HASH(MENU_ENUM_SUBLABEL_VIDEO_DISABLE_COMPOSITION,
-      "Enable or disable composition (Windows only).")
+      "Enable or disable composition.")
 MSG_HASH(MENU_ENUM_SUBLABEL_HISTORY_LIST_ENABLE,
       "Enable or disable recent playlist for games, images, music, and videos.")
 MSG_HASH(MENU_ENUM_SUBLABEL_CONTENT_HISTORY_SIZE,

--- a/intl/msg_hash_ja.h
+++ b/intl/msg_hash_ja.h
@@ -2525,7 +2525,7 @@ MSG_HASH(MSG_NETPLAY_LAN_SCANNING,
 MSG_HASH(MENU_ENUM_SUBLABEL_PAUSE_NONACTIVE,
       "Pause gameplay when window focus is lost.")
 MSG_HASH(MENU_ENUM_SUBLABEL_VIDEO_DISABLE_COMPOSITION,
-      "Enable or disable composition (Windows only).")
+      "Enable or disable composition.")
 MSG_HASH(MENU_ENUM_SUBLABEL_HISTORY_LIST_ENABLE,
       "Enable or disable recent playlist for games, images, music, and videos.")
 MSG_HASH(MENU_ENUM_SUBLABEL_CONTENT_HISTORY_SIZE,

--- a/intl/msg_hash_nl.h
+++ b/intl/msg_hash_nl.h
@@ -2288,7 +2288,7 @@ MSG_HASH(MENU_ENUM_LABEL_VALUE_DATABASE_CURSOR_LIST_ENTRY_DATABASE_INFO,
 MSG_HASH(MENU_ENUM_SUBLABEL_PAUSE_NONACTIVE,
       "Pause gameplay when window focus is lost.")
 MSG_HASH(MENU_ENUM_SUBLABEL_VIDEO_DISABLE_COMPOSITION,
-      "Enable or disable composition (Windows only).")
+      "Enable or disable composition.")
 MSG_HASH(MENU_ENUM_SUBLABEL_HISTORY_LIST_ENABLE,
       "Enable or disable recent playlist for games, images, music, and videos.")
 MSG_HASH(MENU_ENUM_SUBLABEL_CONTENT_HISTORY_SIZE,

--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -2585,7 +2585,7 @@ MSG_HASH(MSG_NETPLAY_LAN_SCANNING,
 MSG_HASH(MENU_ENUM_SUBLABEL_PAUSE_NONACTIVE,
       "Pause gameplay when RetroArch is not the active window.")
 MSG_HASH(MENU_ENUM_SUBLABEL_VIDEO_DISABLE_COMPOSITION,
-      "Enable or disable composition (Windows only).")
+      "Enable or disable composition.")
 MSG_HASH(MENU_ENUM_SUBLABEL_HISTORY_LIST_ENABLE,
       "Enable or disable recent playlist for games, images, music, and videos.")
 MSG_HASH(MENU_ENUM_SUBLABEL_CONTENT_HISTORY_SIZE,

--- a/intl/msg_hash_vn.h
+++ b/intl/msg_hash_vn.h
@@ -2433,7 +2433,7 @@ MSG_HASH(MSG_NETPLAY_LAN_SCANNING,
 MSG_HASH(MENU_ENUM_SUBLABEL_PAUSE_NONACTIVE,
       "Pause gameplay when RetroArch is not the active window.")
 MSG_HASH(MENU_ENUM_SUBLABEL_VIDEO_DISABLE_COMPOSITION,
-      "Enable or disable composition (Windows only).")
+      "Enable or disable composition.")
 MSG_HASH(MENU_ENUM_SUBLABEL_HISTORY_LIST_ENABLE,
       "Enable or disable recent playlist for games, images, music, and videos.")
 MSG_HASH(MENU_ENUM_SUBLABEL_CONTENT_HISTORY_SIZE,


### PR DESCRIPTION
Use the "new" NETWM hint _NET_WM_BYPASS_COMPOSITOR to let users disable the compositor on X11. 

I have it so that this only works on fullscreen windows, which is just my opinion. If wanted, you can remove the fullscreen conditionals to make it work on non-fullscreen windows, too, if the window manager allows it.

In GNOME, which normally uses heuristics to detect fullscreen windows, this eliminates the hiccup exactly 3 seconds into switching.

I noticed in testing that KWin will not use this hint if using an override-redirect window, which RetroArch uses when the "windowed fullscreen" option is disabled. This seems to be a philosophical decision by the KWin developer(s), with them arguing that the override-redirect flag was never meant to be used with fullscreen windows and that it was a hack. I can understand that point, but for backwards-compatibility it's necessary to keep it. Regardless, KWin ignores the override-redirect flag, and requires manually turning off the compositor in that case.

I may look into implementing _NET_WM_STATE_FULLSCREEN as a priority for "true fullscreen" with override-redirect as a fallback.