### PR TITLE
fix scanner bypassing directories with a dot

### DIFF
--- a/libretro-common/lists/dir_list.c
+++ b/libretro-common/lists/dir_list.c
@@ -185,7 +185,7 @@ static int dir_list_read(const char *dir,
       bool is_dir                     = false;
       int ret                         = 0;
       const char *name                = retro_dirent_get_name(entry);
-      const char *file_ext            = path_get_extension(name);
+      const char *file_ext            = "";
 
       file_path[0] = '\0';
 
@@ -198,9 +198,13 @@ static int dir_list_read(const char *dir,
             continue;
       }
 
+      if(!is_dir){  
+         file_ext = path_get_extension(name);
+      }
+
       if(is_dir && recursive)
       {
-         if(strstr(name, ".") || strstr(name, ".."))
+         if(strcmp(name, ".") == 0 || strcmp(name, "..") == 0)
             continue;
 
          dir_list_read(file_path, list, ext_list, include_dirs,


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises


## Description

This fixes bug https://github.com/libretro/RetroArch/issues/5111

There were two problems with function dir_list_read
1. It tried to find 'extensions' to directories when directories don't actually have extensions. Fairly harmeless.
2. It tried to skip the '.' or '..' entries by using strstr, ie: it would always skip going deeper for a directory that had a dot (or two but it doesn't matter).

## Related Issues

https://github.com/libretro/RetroArch/issues/5111

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
