### PR TITLE
fix scanner skipping directories with dots

### DIFF
--- a/libretro-common/lists/dir_list.c
+++ b/libretro-common/lists/dir_list.c
@@ -185,12 +185,15 @@ static int dir_list_read(const char *dir,
       bool is_dir                     = false;
       int ret                         = 0;
       const char *name                = retro_dirent_get_name(entry);
-      const char *file_ext            = path_get_extension(name);
+      const char *file_ext            = "";
 
       file_path[0] = '\0';
 
       fill_pathname_join(file_path, dir, name, sizeof(file_path));
       is_dir = retro_dirent_is_dir(entry, file_path);
+
+      if(!is_dir)
+         file_ext = path_get_extension(name);
 
       if (!include_hidden)
       {
@@ -200,7 +203,7 @@ static int dir_list_read(const char *dir,
 
       if(is_dir && recursive)
       {
-         if(strstr(name, ".") || strstr(name, ".."))
+         if(strcmp(name, ".") == 0 || strcmp(name, "..") == 0)
             continue;
 
          dir_list_read(file_path, list, ext_list, include_dirs,


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises


## Description

Fixes both the dirs having a 'extension', and scanning a directory skipping dirs with dots on the filename. Previously it was skipping 'any' directory with a dot anywhere in the name, while the code just wanted to skip the two symbolic directories '.' and '..'.

Modified the closed PR to not have different side effects than master (the extension could be set or not set depending on if the file was hidden, while in master it is always set).

## Related Issues

https://github.com/libretro/RetroArch/issues/5111
https://github.com/libretro/libretro-database/issues/464

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

@twinaphex 
