### PR TITLE
fix to have a deterministic HID device registration 

### DIFF
--- a/input/drivers_hid/iohidmanager_hid.c
+++ b/input/drivers_hid/iohidmanager_hid.c
@@ -903,6 +903,7 @@ static int iohidmanager_hid_manager_set_device_matching(
 		free(devList);
 		devList = ptr;
 	}
+	free(device_array);
 
    return 0;
 }


### PR DESCRIPTION
today, hid devices (pad) are registered by the OS callback in random order
so if both identical pad (same name, same vendor_id, same product_id) are plugged in, randomly pad1 will get assigned to player1/2 and pad2 to player2/1...
for an arcade box, this could lead to player1 being on the left side then on right side following 2 different launch of retroarch
this fix uses the location_id (which somehow translate to the usb port the pad is plugged into) to register the devices, thus making sure pad1 always gets register before pad2, etc...
