### PR TITLE
Draw right thumb at 512px wide the same as libretro-thumbnails

### DIFF
--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -3497,7 +3497,7 @@ static void xmb_layout_ps3(xmb_handle_t *xmb, int width)
    new_header_height             = 128.0 * scale_factor;
 
 
-   xmb->thumbnail_width          = 460.0 * scale_factor;
+   xmb->thumbnail_width          = 512.0 * scale_factor;
    xmb->left_thumbnail_width     = 430.0 * scale_factor;
    xmb->savestate_thumbnail_width= 460.0 * scale_factor;
    xmb->cursor_size              = 64.0 * scale_factor;


### PR DESCRIPTION
libretro-thumbnails are 512px so this achieves 1:1 size if there is enough space,
If it doesn't fit, the auto size code merged earlier should resize it