### PR TITLE
Fast Savestate and Hard Audio Disable flags in RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE

### DIFF
--- a/dynamic.c
+++ b/dynamic.c
@@ -68,6 +68,7 @@
 
 #ifdef HAVE_RUNAHEAD
 #include "runahead/secondary_core.h"
+#include "runahead/run_ahead.h"
 #endif
 
 #ifdef HAVE_DYNAMIC
@@ -1763,6 +1764,16 @@ bool rarch_environment_cb(unsigned cmd, void *data)
          {
             result |= 1;
          }
+#ifdef HAVE_RUNAHEAD
+         if (want_fast_savestate())
+         {
+            result |= 4;
+         }
+         if (get_hard_disable_audio())
+         {
+            result |= 8;
+         }
+#endif
          if (data != NULL)
          {
             int* result_p = (int*)data;

--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -1144,6 +1144,7 @@ struct retro_led_interface
                                             * Fast Savestates:
                                             * * Guaranteed to be created by the same binary that will load them.
                                             * * Will not be written to or read from the disk.
+                                            * * Suggest that the core assumes loading state will succeed.
                                             * * Suggest that the core updates its memory buffers in-place if possible.
                                             * * Suggest that the core skips clearing memory.
                                             * * Suggest that the core skips resetting the system.

--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -1119,12 +1119,43 @@ struct retro_led_interface
 
 #define RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE (47 | RETRO_ENVIRONMENT_EXPERIMENTAL)
                                            /* int * --
-                                            * Queries the frontend if audio and video are enabled or not.
-                                            * If not enabled, the frontend will discard the audio or video,
-                                            * so the core may decide to skip producing audio or video.
-                                            * Bit 0 (value 1) is set if Video is enabled,
-                                            * Bit 1 (value 2) is set if Audio is enabled.
-                                            * Other bits are reserved for future use.
+                                            * Tells the core if the frontend wants audio or video.
+                                            * If disabled, the frontend will discard the audio or video,
+                                            * so the core may decide to skip generating a frame or generating audio.
+                                            * This is mainly used for increasing performance.
+                                            * Bit 0 (value 1): Enable Video
+                                            * Bit 1 (value 2): Enable Audio
+                                            * Bit 2 (value 4): Use Fast Savestates.
+                                            * Bit 3 (value 8): Hard Disable Audio
+                                            * Other bits are reserved for future use and will default to zero.
+                                            * If video is disabled:
+                                            * * The frontend wants the core to not generate any video,
+                                            *   including presenting frames via hardware acceleration.
+                                            * * The frontend's video frame callback will do nothing.
+                                            * * After running the frame, the video output of the next frame should be
+                                            *   no different than if video was enabled, and saving and loading state
+                                            *   should have no issues.
+                                            * If audio is disabled:
+                                            * * The frontend wants the core to not generate any audio.
+                                            * * The frontend's audio callbacks will do nothing.
+                                            * * After running the frame, the audio output of the next frame should be
+                                            *   no different than if audio was enabled, and saving and loading state
+                                            *   should have no issues.
+                                            * Fast Savestates:
+                                            * * Guaranteed to be created by the same binary that will load them.
+                                            * * Will not be written to or read from the disk.
+                                            * * Suggest that the core updates its memory buffers in-place if possible.
+                                            * * Suggest that the core skips clearing memory.
+                                            * * Suggest that the core skips resetting the system.
+                                            * * Suggest that the core may skip validation steps.
+                                            * Hard Disable Audio:
+                                            * * Used for a secondary core when running ahead.
+                                            * * Indicates that the frontend will never need audio from the core.
+                                            * * Suggests that the core may stop synthesizing audio, but this should not
+                                            *   compromise emulation accuracy.
+                                            * * Audio output for the next frame does not matter, and the frontend will
+                                            *   never need an accurate audio state in the future.
+                                            * * State will never be saved when using Hard Disable Audio.
                                             */
 
 #define RETRO_ENVIRONMENT_GET_HW_RENDER_INTERFACE (41 | RETRO_ENVIRONMENT_EXPERIMENTAL)

--- a/runahead/run_ahead.c
+++ b/runahead/run_ahead.c
@@ -23,6 +23,10 @@ static void runahead_suspend_audio(void);
 static void runahead_resume_audio(void);
 static void runahead_suspend_video(void);
 static void runahead_resume_video(void);
+static void set_fast_savestate(void);
+static void unset_fast_savestate(void);
+static void set_hard_disable_audio(void);
+static void unset_hard_disable_audio(void);
 
 static size_t runahead_save_state_size = -1;
 
@@ -274,7 +278,9 @@ void run_ahead(int runAheadCount, bool useSecondary)
          {
             runahead_suspend_video();
             runahead_suspend_audio();
+            set_hard_disable_audio();
             okay = runahead_run_secondary();
+            unset_hard_disable_audio();
             runahead_resume_audio();
             runahead_resume_video();
 
@@ -285,7 +291,9 @@ void run_ahead(int runAheadCount, bool useSecondary)
          }
       }
       runahead_suspend_audio();
+      set_hard_disable_audio();
       okay = runahead_run_secondary();
+      unset_hard_disable_audio();
       runahead_resume_audio();
 
       /* Could not create a secondary core. RunAhead
@@ -330,8 +338,10 @@ static bool runahead_save_state(void)
 {
    retro_ctx_serialize_info_t *serialize_info =
       (retro_ctx_serialize_info_t*)runahead_save_state_list->data[0];
-   bool okay = core_serialize(serialize_info);
-
+   bool okay;
+   set_fast_savestate();
+   okay = core_serialize(serialize_info);
+   unset_fast_savestate();
    if (!okay)
       runahead_error();
    return okay;
@@ -342,7 +352,10 @@ static bool runahead_load_state(void)
    retro_ctx_serialize_info_t *serialize_info = (retro_ctx_serialize_info_t*)
       runahead_save_state_list->data[0];
    bool lastDirty = input_is_dirty;
-   bool okay      = core_unserialize(serialize_info);
+   bool okay;
+   set_fast_savestate();
+   okay = core_unserialize(serialize_info);
+   unset_fast_savestate();
    input_is_dirty = lastDirty;
 
    if (!okay)
@@ -355,7 +368,10 @@ static bool runahead_load_state_secondary(void)
 {
    retro_ctx_serialize_info_t *serialize_info =
       (retro_ctx_serialize_info_t*)runahead_save_state_list->data[0];
-   bool okay = secondary_core_deserialize(serialize_info->data_const, serialize_info->size);
+   bool okay;
+   set_fast_savestate();
+   okay = secondary_core_deserialize(serialize_info->data_const, serialize_info->size);
+   unset_fast_savestate();
 
    if (!okay)
       runahead_secondary_core_available = false;
@@ -399,4 +415,38 @@ void runahead_destroy(void)
    runahead_save_state_list_destroy();
    remove_hooks();
    runahead_clear_variables();
+}
+
+static bool request_fast_savestate;
+static bool hard_disable_audio;
+
+
+bool want_fast_savestate(void)
+{
+   return request_fast_savestate;
+}
+
+static void set_fast_savestate(void)
+{
+   request_fast_savestate = true;
+}
+
+static void unset_fast_savestate(void)
+{
+   request_fast_savestate = false;
+}
+
+bool get_hard_disable_audio(void)
+{
+   return hard_disable_audio;
+}
+
+static void set_hard_disable_audio(void)
+{
+   hard_disable_audio = true;
+}
+
+static void unset_hard_disable_audio(void)
+{
+   hard_disable_audio = false;
 }

--- a/runahead/run_ahead.h
+++ b/runahead/run_ahead.h
@@ -10,6 +10,9 @@ void runahead_destroy(void);
 
 void run_ahead(int runAheadCount, bool useSecondary);
 
+bool want_fast_savestate(void);
+bool get_hard_disable_audio(void);
+
 RETRO_END_DECLS
 
 #endif


### PR DESCRIPTION
## Description

I am adding two more bits to RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE.
First is the Fast Savestate flag, which suggests that a core should use a faster way of loading a savestate if possible.
Next is the Hard Audio Disable flag, which suggests that the core should stop running the sound chip entirely.

I've implemented these features into the Snes9x cores and will pull request those later.  Fast Savestates works well, and the Hard Audio Disable disables the DSP in the sound chip.

I'm not 100% sure if a Fast Savestates flag belongs in something called "RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE" though.  If you think I should make another entry in the Environment function list for that, let me know.
