### PR TITLE
Runahead: Stop savestate transmission in netplay

### DIFF
--- a/runahead/run_ahead.c
+++ b/runahead/run_ahead.c
@@ -354,7 +354,9 @@ static bool runahead_load_state(void)
    bool lastDirty = input_is_dirty;
    bool okay;
    set_fast_savestate();
-   okay = core_unserialize(serialize_info);
+   /* calling core_unserialize has side effects with netplay (it triggers transmitting your save state)
+      call retro_unserialize directly from the core instead */
+   okay = current_core.retro_unserialize(serialize_info->data_const, serialize_info->size);
    unset_fast_savestate();
    input_is_dirty = lastDirty;
 

--- a/runahead/run_ahead.c
+++ b/runahead/run_ahead.c
@@ -96,8 +96,7 @@ static void runahead_save_state_list_rotate(void)
 static function_t originalRetroDeinit = NULL;
 static function_t originalRetroUnload = NULL;
 
-typedef struct retro_core_t _retro_core_t;
-extern _retro_core_t current_core;
+extern struct retro_core_t current_core;
 extern struct retro_callbacks retro_ctx;
 
 static void remove_hooks(void)


### PR DESCRIPTION
## Description
In Runahead, Call `current_core.retro_unserialize` instead of `core_unserialize` to prevent transmitting the savestate when using netplay.
