### PR TITLE
Fixed initializing controller port map.

### DIFF
--- a/core_impl.c
+++ b/core_impl.c
@@ -292,6 +292,7 @@ bool core_load_game(retro_ctx_load_content_info_t *load_info)
 
 #ifdef HAVE_RUNAHEAD
    set_load_content_info(load_info);
+   clear_controller_port_map();
 #endif
 
    content_get_status(&contentless, &is_inited);


### PR DESCRIPTION
## Description

This is a bug fix, I had accidentally forgotten to initialize controller_port_map, leaving it zero-filled by default.  With it zero-filled, it was crashing the VBA-M core when trying to set a high-numbered port to zero.
