### PR TITLE
Make RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE work on the secondary core

### DIFF
--- a/runahead/run_ahead.c
+++ b/runahead/run_ahead.c
@@ -112,6 +112,7 @@ static void remove_hooks(void)
       current_core.retro_unload_game = originalRetroUnload;
       originalRetroUnload            = NULL;
    }
+   current_core.retro_set_environment(rarch_environment_cb);
    remove_input_state_hook();
 }
 
@@ -134,6 +135,20 @@ static void deinit_hook(void)
       current_core.retro_deinit();
 }
 
+static bool env_hook(unsigned cmd, void *data)
+{
+   bool result = rarch_environment_cb(cmd, data);
+   if (cmd == RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE && result)
+   {
+      bool *bool_p = (bool*)data;
+      if (*bool_p == true)
+      {
+         secondary_core_set_variable_update();
+      }
+   }
+   return result;
+}
+
 static void add_hooks(void)
 {
    if (!originalRetroDeinit)
@@ -147,7 +162,7 @@ static void add_hooks(void)
       originalRetroUnload = current_core.retro_unload_game;
       current_core.retro_unload_game = unload_hook;
    }
-
+   current_core.retro_set_environment(env_hook);
    add_input_state_hook();
 }
 

--- a/runahead/run_ahead.c
+++ b/runahead/run_ahead.c
@@ -142,9 +142,7 @@ static bool env_hook(unsigned cmd, void *data)
    {
       bool *bool_p = (bool*)data;
       if (*bool_p == true)
-      {
          secondary_core_set_variable_update();
-      }
    }
    return result;
 }

--- a/runahead/secondary_core.c
+++ b/runahead/secondary_core.c
@@ -281,9 +281,9 @@ static bool rarch_environment_secondary_core_hook(unsigned cmd, void *data)
    bool result = rarch_environment_cb(cmd, data);
    if (cmd == RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE && has_variable_update)
    {
-      has_variable_update = false;
       bool *bool_p = (bool*)data;
       *bool_p = true;
+      has_variable_update = false;
       return true;
    }
    return result;

--- a/runahead/secondary_core.c
+++ b/runahead/secondary_core.c
@@ -22,6 +22,8 @@
 #include "../paths.h"
 #include "../content.h"
 
+#include "secondary_core.h"
+
 static int port_map[16];
 
 static char *secondary_library_path;
@@ -45,6 +47,8 @@ static bool secondary_core_create(void);
 bool secondary_core_run_no_input_polling(void);
 
 bool secondary_core_deserialize(const void *buffer, int size);
+
+static bool rarch_environment_secondary_core_hook(unsigned cmd, void *data);
 
 void secondary_core_destroy(void);
 
@@ -205,7 +209,8 @@ bool secondary_core_create(void)
       secondary_core.retro_set_audio_sample_batch(secondary_callbacks.sample_batch_cb);
       secondary_core.retro_set_input_state(secondary_callbacks.state_cb);
       secondary_core.retro_set_input_poll(secondary_callbacks.poll_cb);
-      secondary_core.retro_set_environment(rarch_environment_cb);
+      secondary_core.retro_set_environment(rarch_environment_secondary_core_hook);
+      secondary_core_set_variable_update();
 
       secondary_core.retro_init();
 
@@ -267,6 +272,26 @@ bool secondary_core_create(void)
       return false;
 
    return true;
+}
+
+static bool has_variable_update;
+
+static bool rarch_environment_secondary_core_hook(unsigned cmd, void *data)
+{
+   bool result = rarch_environment_cb(cmd, data);
+   if (cmd == RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE && has_variable_update)
+   {
+      has_variable_update = false;
+      bool *bool_p = (bool*)data;
+      *bool_p = true;
+      return true;
+   }
+   return result;
+}
+
+void secondary_core_set_variable_update(void)
+{
+   has_variable_update = true;
 }
 
 bool secondary_core_run_no_input_polling(void)
@@ -350,5 +375,10 @@ void remember_controller_port_device(long port, long device)
 {
    /* do nothing */
 }
+void secondary_core_set_variable_update(void)
+{
+   /* do nothing */
+}
+
 #endif
 

--- a/runahead/secondary_core.h
+++ b/runahead/secondary_core.h
@@ -14,6 +14,7 @@ void secondary_core_destroy(void);
 void set_last_core_type(enum rarch_core_type type);
 void remember_controller_port_device(long port, long device);
 void clear_controller_port_map(void);
+void secondary_core_set_variable_update(void);
 
 RETRO_END_DECLS
 


### PR DESCRIPTION
## Description

Calling RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE is a one-shot event, so the primary core will see dirty variables, but the secondary core will not see that.

This change makes the primary core now watch for dirty variables, then have the secondary core also return that variables are dirty.

I'm doing it with yet another hook, also the first time the secondary core runs, it will always think the variables are dirty.

Specifically, this fixes people turning on Overclock in Snes9x, then the cores getting out of sync when one core lags and the other core does not.

edit: whoops, not C89 compliant, will fix first... and fixed.