### PR TITLE
Add back override-redirect to allow G-SYNC

### DIFF
--- a/gfx/common/x11_common.c
+++ b/gfx/common/x11_common.c
@@ -107,47 +107,6 @@ void x11_show_mouse(Display *dpy, Window win, bool state)
       x11_hide_mouse(dpy, win);
 }
 
-static bool x11_check_atom_supported(Display *dpy, Atom atom)
-{
-   Atom XA_NET_SUPPORTED = XInternAtom(dpy, "_NET_SUPPORTED", True);
-   Atom type;
-   int format;
-   unsigned long nitems;
-   unsigned long bytes_after;
-   Atom *prop;
-   int i;
-
-   if (XA_NET_SUPPORTED == None)
-      return false;
-
-   XGetWindowProperty(dpy, DefaultRootWindow(dpy), XA_NET_SUPPORTED, 0, UINT_MAX, False, XA_ATOM, &type, &format,&nitems, &bytes_after, (unsigned char **) &prop);
-
-   if (!prop || type != XA_ATOM)
-   {
-      return false;
-   }
-
-   for (i = 0; i < nitems; i++)
-   {
-      if (prop[i] == atom)
-      {
-         XFree(prop);
-         return true;
-      }
-   }
-
-   XFree(prop);
-
-   return false;
-}
-
-bool x11_has_net_wm_fullscreen(Display *dpy)
-{
-   XA_NET_WM_STATE_FULLSCREEN = XInternAtom(dpy, "_NET_WM_STATE_FULLSCREEN", False);
-
-   return x11_check_atom_supported(dpy, XA_NET_WM_STATE_FULLSCREEN);
-}
-
 void x11_set_net_wm_fullscreen(Display *dpy, Window win)
 {
    XEvent xev                 = {0};

--- a/gfx/common/x11_common.h
+++ b/gfx/common/x11_common.h
@@ -29,7 +29,6 @@ extern Colormap g_x11_cmap;
 extern unsigned g_x11_screen;
 
 void x11_show_mouse(Display *dpy, Window win, bool state);
-bool x11_has_net_wm_fullscreen(Display *dpy);
 void x11_set_net_wm_fullscreen(Display *dpy, Window win);
 void x11_suspend_screensaver(Window win, bool enable);
 bool x11_enter_fullscreen(video_frame_info_t *video_info,

--- a/gfx/drivers_context/x_ctx.c
+++ b/gfx/drivers_context/x_ctx.c
@@ -691,7 +691,7 @@ static bool gfx_ctx_x_set_video_mode(void *data,
          RARCH_ERR("[GLX]: Entering true fullscreen failed. Will attempt windowed mode.\n");
    }
 
-   swa.override_redirect = (true_full) ? True : False;
+   swa.override_redirect = true_full ? True : False;
 
    if (video_info->monitor_index)
       g_x11_screen = video_info->monitor_index - 1;

--- a/gfx/drivers_context/x_ctx.c
+++ b/gfx/drivers_context/x_ctx.c
@@ -691,7 +691,7 @@ static bool gfx_ctx_x_set_video_mode(void *data,
          RARCH_ERR("[GLX]: Entering true fullscreen failed. Will attempt windowed mode.\n");
    }
 
-   swa.override_redirect = (!x11_has_net_wm_fullscreen(g_x11_dpy) && true_full) ? True : False;
+   swa.override_redirect = (true_full) ? True : False;
 
    if (video_info->monitor_index)
       g_x11_screen = video_info->monitor_index - 1;
@@ -722,8 +722,8 @@ static bool gfx_ctx_x_set_video_mode(void *data,
    g_x11_win = XCreateWindow(g_x11_dpy, RootWindow(g_x11_dpy, vi->screen),
          x_off, y_off, width, height, 0,
          vi->depth, InputOutput, vi->visual,
-         CWBorderPixel | CWColormap | CWEventMask |
-         CWOverrideRedirect, &swa);
+         CWBorderPixel | CWColormap | CWEventMask,
+         &swa);
    XSetWindowBackground(g_x11_dpy, g_x11_win, 0);
 
    XChangeProperty(g_x11_dpy, g_x11_win, net_wm_icon, cardinal, 32, PropModeReplace, (const unsigned char*)retroarch_icon_data, sizeof(retroarch_icon_data) / sizeof(*retroarch_icon_data));
@@ -780,8 +780,8 @@ static bool gfx_ctx_x_set_video_mode(void *data,
    {
       RARCH_LOG("[GLX]: Using true fullscreen.\n");
       XMapRaised(g_x11_dpy, g_x11_win);
-      if (swa.override_redirect == False)
-         x11_set_net_wm_fullscreen(g_x11_dpy, g_x11_win);
+      x11_set_net_wm_fullscreen(g_x11_dpy, g_x11_win);
+      XChangeWindowAttributes(g_x11_dpy, g_x11_win, CWOverrideRedirect, &swa);
    }
    else if (fullscreen)
    {

--- a/gfx/drivers_context/xegl_ctx.c
+++ b/gfx/drivers_context/xegl_ctx.c
@@ -310,7 +310,7 @@ static bool gfx_ctx_xegl_set_video_mode(void *data,
          RARCH_ERR("[X/EGL]: Entering true fullscreen failed. Will attempt windowed mode.\n");
    }
 
-   swa.override_redirect = (!x11_has_net_wm_fullscreen(g_x11_dpy) && true_full) ? True : False;
+   swa.override_redirect = true_full ? True : False;
 
    if (video_info->monitor_index)
       g_x11_screen = video_info->monitor_index - 1;
@@ -341,8 +341,8 @@ static bool gfx_ctx_xegl_set_video_mode(void *data,
    g_x11_win = XCreateWindow(g_x11_dpy, RootWindow(g_x11_dpy, vi->screen),
          x_off, y_off, width, height, 0,
          vi->depth, InputOutput, vi->visual,
-         CWBorderPixel | CWColormap | CWEventMask |
-         CWOverrideRedirect, &swa);
+         CWBorderPixel | CWColormap | CWEventMask,
+         &swa);
    XSetWindowBackground(g_x11_dpy, g_x11_win, 0);
 
    if (fullscreen && settings && settings->bools.video_disable_composition)
@@ -374,8 +374,8 @@ static bool gfx_ctx_xegl_set_video_mode(void *data,
    {
       RARCH_LOG("[X/EGL]: Using true fullscreen.\n");
       XMapRaised(g_x11_dpy, g_x11_win);
-      if (swa.override_redirect == False)
-         x11_set_net_wm_fullscreen(g_x11_dpy, g_x11_win);
+      x11_set_net_wm_fullscreen(g_x11_dpy, g_x11_win);
+      XChangeWindowAttributes(g_x11_dpy, g_x11_win, CWOverrideRedirect, &swa);
    }
    else if (fullscreen)
    {


### PR DESCRIPTION
Sets override-redirect on true fullscreen windows again. This changes the timing so that the window manager can set up a bypass before it sets the window as unmanaged.