### PR TITLE
Add workarounds based on window manager for override-redirect.

### DIFF
--- a/gfx/common/x11_common.c
+++ b/gfx/common/x11_common.c
@@ -685,6 +685,47 @@ void x11_event_queue_check(XEvent *event)
    XIfEvent(g_x11_dpy, event, x11_wait_notify, NULL);
 }
 
+static bool x11_check_atom_supported(Display *dpy, Atom atom)
+{
+   Atom XA_NET_SUPPORTED = XInternAtom(dpy, "_NET_SUPPORTED", True);
+   Atom type;
+   int format;
+   unsigned long nitems;
+   unsigned long bytes_after;
+   Atom *prop;
+   int i;
+
+   if (XA_NET_SUPPORTED == None)
+      return false;
+
+   XGetWindowProperty(dpy, DefaultRootWindow(dpy), XA_NET_SUPPORTED, 0, UINT_MAX, False, XA_ATOM, &type, &format,&nitems, &bytes_after, (unsigned char **) &prop);
+
+   if (!prop || type != XA_ATOM)
+   {
+      return false;
+   }
+
+   for (i = 0; i < nitems; i++)
+   {
+      if (prop[i] == atom)
+      {
+         XFree(prop);
+         return true;
+      }
+   }
+
+   XFree(prop);
+
+   return false;
+}
+
+bool x11_has_net_wm_fullscreen(Display *dpy)
+{
+   XA_NET_WM_STATE_FULLSCREEN = XInternAtom(dpy, "_NET_WM_STATE_FULLSCREEN", False);
+
+   return x11_check_atom_supported(dpy, XA_NET_WM_STATE_FULLSCREEN);
+}
+
 char *x11_get_wm_name(Display *dpy)
 {
    Atom XA_NET_SUPPORTING_WM_CHECK = XInternAtom(g_x11_dpy, "_NET_SUPPORTING_WM_CHECK", False);

--- a/gfx/common/x11_common.h
+++ b/gfx/common/x11_common.h
@@ -77,5 +77,7 @@ void x11_event_queue_check(XEvent *event);
 
 char *x11_get_wm_name(Display *dpy);
 
+bool x11_has_net_wm_fullscreen(Display *dpy);
+
 #endif
 

--- a/gfx/common/x11_common.h
+++ b/gfx/common/x11_common.h
@@ -75,5 +75,7 @@ void x11_install_quit_atom(void);
 
 void x11_event_queue_check(XEvent *event);
 
+char *x11_get_wm_name(Display *dpy);
+
 #endif
 

--- a/gfx/drivers_context/x_ctx.c
+++ b/gfx/drivers_context/x_ctx.c
@@ -705,6 +705,8 @@ static bool gfx_ctx_x_set_video_mode(void *data,
       }
       free(wm_name);
    }
+   if (!x11_has_net_wm_fullscreen(g_x11_dpy) && true_full)
+      swa.override_redirect = True;
 
    if (video_info->monitor_index)
       g_x11_screen = video_info->monitor_index - 1;

--- a/gfx/drivers_context/x_ctx.c
+++ b/gfx/drivers_context/x_ctx.c
@@ -632,6 +632,7 @@ static bool gfx_ctx_x_set_video_mode(void *data,
    int y_off                 = 0;
    XVisualInfo *vi           = NULL;
    XSetWindowAttributes swa  = {0};
+   char *wm_name             = NULL;
    int (*old_handler)(Display*, XErrorEvent*) = NULL;
    gfx_ctx_x_data_t *x       = (gfx_ctx_x_data_t*)data;
    Atom net_wm_icon = XInternAtom(g_x11_dpy, "_NET_WM_ICON", False);
@@ -679,6 +680,7 @@ static bool gfx_ctx_x_set_video_mode(void *data,
    swa.event_mask = StructureNotifyMask | KeyPressMask | KeyReleaseMask |
       LeaveWindowMask | EnterWindowMask |
       ButtonReleaseMask | ButtonPressMask;
+   swa.override_redirect = False;
 
    if (fullscreen && !windowed_full)
    {
@@ -691,7 +693,18 @@ static bool gfx_ctx_x_set_video_mode(void *data,
          RARCH_ERR("[GLX]: Entering true fullscreen failed. Will attempt windowed mode.\n");
    }
 
-   swa.override_redirect = true_full ? True : False;
+   wm_name = x11_get_wm_name(g_x11_dpy);
+   if (wm_name)
+   {
+      RARCH_LOG("[GLX]: Window manager is %s.\n", wm_name);
+
+      if (true_full && strcasestr(wm_name, "xfwm"))
+      {
+         RARCH_LOG("[GLX]: Using override-redirect workaround.\n");
+         swa.override_redirect = True;
+      }
+      free(wm_name);
+   }
 
    if (video_info->monitor_index)
       g_x11_screen = video_info->monitor_index - 1;
@@ -722,7 +735,7 @@ static bool gfx_ctx_x_set_video_mode(void *data,
    g_x11_win = XCreateWindow(g_x11_dpy, RootWindow(g_x11_dpy, vi->screen),
          x_off, y_off, width, height, 0,
          vi->depth, InputOutput, vi->visual,
-         CWBorderPixel | CWColormap | CWEventMask,
+         CWBorderPixel | CWColormap | CWEventMask | CWOverrideRedirect,
          &swa);
    XSetWindowBackground(g_x11_dpy, g_x11_win, 0);
 
@@ -781,7 +794,6 @@ static bool gfx_ctx_x_set_video_mode(void *data,
       RARCH_LOG("[GLX]: Using true fullscreen.\n");
       XMapRaised(g_x11_dpy, g_x11_win);
       x11_set_net_wm_fullscreen(g_x11_dpy, g_x11_win);
-      XChangeWindowAttributes(g_x11_dpy, g_x11_win, CWOverrideRedirect, &swa);
    }
    else if (fullscreen)
    {

--- a/gfx/drivers_context/xegl_ctx.c
+++ b/gfx/drivers_context/xegl_ctx.c
@@ -324,6 +324,8 @@ static bool gfx_ctx_xegl_set_video_mode(void *data,
       }
       free(wm_name);
    }
+   if (!x11_has_net_wm_fullscreen(g_x11_dpy) && true_full)
+      swa.override_redirect = True;
 
    if (video_info->monitor_index)
       g_x11_screen = video_info->monitor_index - 1;


### PR DESCRIPTION
Check for buggy compositor and use override-redirect to allow the window managers's heuristic to unredirect it. If there's any other legacy compositors like this, they can be added to the list.