### PR TITLE
Fix false [ERROR] when closing content

### DIFF
--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -1820,7 +1820,7 @@ void content_deinit(void)
 
          RARCH_LOG("%s: %s.\n",
                msg_hash_to_str(MSG_REMOVING_TEMPORARY_CONTENT_FILE), path);
-         if (!filestream_delete(path))
+         if (filestream_delete(path) != 0)
             RARCH_ERR("%s: %s.\n",
                   msg_hash_to_str(MSG_FAILED_TO_REMOVE_TEMPORARY_FILE),
                   path);


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises


## Description

filestream_delete() returns 0 on success, and -1 on failure.
This PR removes this false error when closing content.

e.g.
[ERROR] Failed to remove temporary file: /EMULATORS/ConsoleRoms/Nintendo - Nintendo Entertainment System/Super Mario Bros. (World).nes.


## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers
@twinaphex 
