### PR TITLE
Fix build errors on machines without HAVE_DYNAMIC

### DIFF
--- a/runahead/run_ahead.c
+++ b/runahead/run_ahead.c
@@ -203,6 +203,11 @@ void run_ahead(int runAheadCount, bool useSecondary)
    bool okay;
    bool lastFrame;
    bool suspendedFrame;
+#if defined(HAVE_DYNAMIC) && HAVE_DYNAMIC
+   const bool haveDynamic = true;
+#else
+   const bool haveDynamic = false;
+#endif
 
    if (runAheadCount <= 0 || !runahead_available)
    {
@@ -224,7 +229,7 @@ void run_ahead(int runAheadCount, bool useSecondary)
 
    runahead_check_for_gui();
 
-   if (!useSecondary || !HAVE_DYNAMIC || !runahead_secondary_core_available)
+   if (!useSecondary || !haveDynamic || !runahead_secondary_core_available)
    {
       /* TODO: multiple savestates for higher performance when not using secondary core */
       for (frameNumber = 0; frameNumber <= runAheadCount; frameNumber++)

--- a/runahead/secondary_core.c
+++ b/runahead/secondary_core.c
@@ -379,6 +379,9 @@ void secondary_core_set_variable_update(void)
 {
    /* do nothing */
 }
-
+void clear_controller_port_map(void)
+{
+   /* do nothing */
+}
 #endif
 


### PR DESCRIPTION
## Description

This fixes build errors when building with HAVE_RUNAHEAD and not HAVE_DYNAMIC.

run_ahead.c: Replaces the macro check HAVE_DYNAMIC with a variable check
secondary_core.c: Added a missing stub function