### PR TITLE
Hide the 'Core delete' option if the 'Core updater' is also hidden.

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -153,6 +153,7 @@ static int menu_displaylist_parse_core_info(menu_displaylist_info_t *info)
    unsigned i;
    char tmp[PATH_MAX_LENGTH];
    core_info_t *core_info    = NULL;
+   settings_t *settings      = config_get_ptr();
 
    tmp[0] = '\0';
 
@@ -336,11 +337,12 @@ static int menu_displaylist_parse_core_info(menu_displaylist_info_t *info)
       }
    }
 
-  menu_entries_append_enum(info->list,
-        msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CORE_DELETE),
-        msg_hash_to_str(MENU_ENUM_LABEL_CORE_DELETE),
-        MENU_ENUM_LABEL_CORE_DELETE,
-        MENU_SETTING_ACTION_CORE_DELETE, 0, 0);
+  if (settings->bools.menu_show_core_updater)
+     menu_entries_append_enum(info->list,
+           msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CORE_DELETE),
+           msg_hash_to_str(MENU_ENUM_LABEL_CORE_DELETE),
+           MENU_ENUM_LABEL_CORE_DELETE,
+           MENU_SETTING_ACTION_CORE_DELETE, 0, 0);
 
    return 0;
 }


### PR DESCRIPTION
## Description

This is a minor suggestion. If the `Core updater` is hidden (Cores are installed by a package manager) then the `Delete core` option should also be hidden. If RetroArch is not downloading the cores itself, then it really has no reason to remove them either. In these cases `Delete core` probably would not work without root permissions either.

Of course the 'Core updater' is on by default and the 'Core delete' option will also be visible by default.

This can be tested by loading a core and then looking in: `Information` -> `Core Information`.

## Related Issues

N/A

## Related Pull Requests

N/A

## Reviewers

@twinaphex