### PR TITLE
remap-redux: allow the menu to display manual keybinds

### DIFF
--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -2576,7 +2576,7 @@ static void input_config_get_bind_string_joykey(
    {
       if (bind->joykey_label &&
             !string_is_empty(bind->joykey_label) && label_show)
-         snprintf(buf, size, "%s %s ", prefix, bind->joykey_label);
+         snprintf(buf, size, "%s %s (hat)", prefix, bind->joykey_label);
       else
       {
          const char *dir = "?";

--- a/input/input_remapping.c
+++ b/input/input_remapping.c
@@ -115,7 +115,7 @@ bool input_remapping_load_file(void *data, const char *path)
                s3,
                key_strings[j]);
 
-         RARCH_LOG("pre_ident: %s:%d\n", stk_ident[j], settings->uints.input_remap_ids[i][j]);
+         /* RARCH_LOG("pre_ident: %s:%d\n", stk_ident[j], settings->uints.input_remap_ids[i][j]); */
 
          if (config_get_int(conf, stk_ident[j], &stk_remap) && stk_remap != -1)
             settings->uints.input_remap_ids[i][j] = stk_remap;

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -3271,7 +3271,8 @@ static int menu_displaylist_parse_options_remappings(
                   const struct retro_keybind *keyptr =
                      &input_config_binds[p][retro_id];
 
-                  strlcpy(descriptor, msg_hash_to_str(keyptr->enum_idx), sizeof(descriptor));
+                  snprintf(desc_label, sizeof(desc_label), "%s %s", msg_hash_to_str(keyptr->enum_idx), descriptor);
+                  strlcpy(descriptor, desc_label, sizeof(descriptor));
                }
 
                menu_entries_append_enum(info->list, descriptor, "",


### PR DESCRIPTION
Some users don't use autoconf, so made the menu nicer for them

![image](https://user-images.githubusercontent.com/1721040/38471827-40fb6c0a-3b3c-11e8-9aea-5858964b5b5c.png)
