### PR TITLE
Serial magic should only match on full match

### DIFF
--- a/tasks/task_database_cue.c
+++ b/tasks/task_database_cue.c
@@ -381,7 +381,7 @@ int detect_system(intfstream_t *fd, const char **system_name)
       if (read < MAGIC_LEN)
          continue;
 
-      if (string_is_equal(MAGIC_NUMBERS[i].magic, magic))
+      if (memcmp(MAGIC_NUMBERS[i].magic, magic, MAGIC_LEN) == 0)
       {
          *system_name = MAGIC_NUMBERS[i].system_name;
          rv = 0;


### PR DESCRIPTION
As was mentioned on the wii dual layer disc issue, this line is comparing binary sequences as strings, which fails very obviously because neither of the 'strings' tested are strings and it's very likely both start with \0 (or 'end' with a \0 on the same place but more different bytes to test to be more pedantic).
