### PR TITLE
patch retro_opendir to handle nullptr and empty-string input

### DIFF
--- a/libretro-common/file/retro_dirent.c
+++ b/libretro-common/file/retro_dirent.c
@@ -108,8 +108,12 @@ struct RDIR *retro_opendir(const char *name)
 #endif
    struct RDIR *rdir  = (struct RDIR*)calloc(1, sizeof(*rdir));
 
-   if (!rdir)
+   if (!rdir||!name)
       return NULL;
+
+   /* Handle empty string as current dir */
+   if (*name==0)
+      name=".";
 
 #if defined(_WIN32)
    (void)path_wide;


### PR DESCRIPTION
Strengthen retro_opendir.