### PR TITLE
retro_opendir fix#2

### DIFF
--- a/libretro-common/file/retro_dirent.c
+++ b/libretro-common/file/retro_dirent.c
@@ -106,14 +106,16 @@ struct RDIR *retro_opendir(const char *name)
    wchar_t *path_wide = NULL;
    unsigned path_len;
 #endif
-   struct RDIR *rdir  = (struct RDIR*)calloc(1, sizeof(*rdir));
+   struct RDIR *rdir;
 
-   if (!rdir||!name)
+   /*Reject null or empty string paths*/
+   if (!name||(*name==0))
       return NULL;
 
-   /* Handle empty string as current dir */
-   if (*name==0)
-      name=".";
+   /*Allocate RDIR struct. Tidied later with retro_closedir*/
+   rdir = (struct RDIR*)calloc(1, sizeof(*rdir));
+   if (!rdir)
+      return NULL;
 
 #if defined(_WIN32)
    (void)path_wide;

--- a/libretro-common/include/retro_dirent.h
+++ b/libretro-common/include/retro_dirent.h
@@ -32,6 +32,16 @@ RETRO_BEGIN_DECLS
 
 typedef struct RDIR RDIR;
 
+/**
+ *
+ * retro_opendir:
+ * @name         : path to the directory to open.
+ *
+ * Opens a directory for reading. Tidy up with retro_closedir.
+ *
+ * Returns: RDIR pointer on success, NULL if name is not a
+ * valid directory, null itself or the empty string.
+ */
 struct RDIR *retro_opendir(const char *name);
 
 int retro_readdir(struct RDIR *rdir);


### PR DESCRIPTION
## Description

This is a fix for my previous work on retro_opendir. It now consistently rejects calls to the function with null or empty string input - this behaviour is also mentioned in a comment in the header.

Existing cores would have caused a crash* in this function on _WIN32 builds so it's safe to say there should be no compatibility issues caused by strengthening this function.

@twinaphex suggested an improved approach was needed. I believe this meets the brief for being cross-platform and putting some of the burden of correct operation back onto the caller (i.e. the core).

\* read before array with empty string; null pointer read for null input

## Related Pull Requests

This is a revision of patch #6563

## Reviewers

@twinaphex 
