### PR TITLE
libretro-db: Ignore compiled binaries

### DIFF
--- a/libretro-db/.gitignore
+++ b/libretro-db/.gitignore
@@ -1,0 +1,4 @@
+# Ignore compiled binaries.
+/c_converter
+/libretrodb_tool
+/rmsgpack_test


### PR DESCRIPTION
This makes it so that the compiled libretro-db binaries are ignored from git.