### PR TITLE
retroarch.cfg: Rename "UI" to "User Interface"

### DIFF
--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -720,7 +720,7 @@ video_message_bgcolor_opacity = 1.0
 # Check for firmware requirement(s) before loading a content.
 # check_firmware_before_loading = "false"
 
-#### UI
+#### User Interface
 
 # Suspends the screensaver if set to true. Is a hint that does not necessarily have to be honored
 # by video driver.


### PR DESCRIPTION
Use full name for UI section to match the terminology used when changing settings in RGUI.