### PR TITLE
retroarch.cfg: Reorganize sections

### DIFF
--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -128,7 +128,13 @@
 # Shows hidden files and folders in directory listings.
 # show_hidden_files = false
 
-#### Video
+#### Driver
+
+# Input driver. Depending on video driver, it might force a different input driver.
+# input_driver = sdl
+
+# Joypad driver. (Valid: linuxraw, sdl, dinput)
+# input_joypad_driver =
 
 # Video driver to use. "gl", "xvideo", "sdl", "d3d"
 # video_driver = "gl"
@@ -137,6 +143,18 @@
 # Possible ones for desktop are: glx, x-egl, kms-egl, sdl-gl, wgl.
 # By default, tries to use first suitable driver.
 # video_context_driver =
+
+# Audio driver backend. Depending on configuration possible candidates are: alsa, pulse, oss, jack, rsound, roar, openal, sdl, xaudio.
+# audio_driver =
+
+# Audio resampler driver backend. Which audio resampler to use.
+# Default will use "sinc".
+# audio_resampler =
+
+# Menu driver to use. "rgui", "lakka", etc.
+# menu_driver = "rgui"
+
+#### Video
 
 # Windowed x resolution scale and y resolution scale
 # (Real x res: base_size * xscale * aspect_ratio, real y res: base_size * yscale)
@@ -303,13 +321,6 @@ video_message_bgcolor_opacity = 1.0
 # Audio output samplerate.
 # audio_out_rate = 48000
 
-# Audio resampler backend. Which audio resampler to use.
-# Default will use "sinc".
-# audio_resampler =
-
-# Audio driver backend. Depending on configuration possible candidates are: alsa, pulse, oss, jack, rsound, roar, openal, sdl, xaudio.
-# audio_driver =
-
 # Override the default audio device the audio_driver uses. This is driver dependant. E.g. ALSA wants a PCM device, OSS wants a path (e.g. /dev/dsp), Jack wants portnames (e.g. system:playback1,system:playback_2), and so on ...
 # audio_device =
 
@@ -366,12 +377,6 @@ video_message_bgcolor_opacity = 1.0
 # input_overlay_scale = 1.0
 
 #### Input
-
-# Input driver. Depending on video driver, it might force a different input driver.
-# input_driver = sdl
-
-# Joypad driver. (Valid: linuxraw, sdl, dinput)
-# input_joypad_driver =
 
 # Path to input remapping file.
 # input_remapping_path =
@@ -660,9 +665,6 @@ video_message_bgcolor_opacity = 1.0
 # input_grab_mouse_toggle = f11
 
 #### Menu
-
-# Menu driver to use. "rgui", "lakka", etc.
-# menu_driver = "rgui"
 
 # If disabled, will hide 'Online Updater' inside the menu.
 # menu_show_online_updater = true

--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -248,19 +248,20 @@
 
 # Offset for where messages will be placed on screen. Values are in range 0.0 to 1.0 for both x and y values.
 # [0.0, 0.0] maps to the lower left corner of the screen.
-# video_message_pos_x = 0.05
-# video_message_pos_y = 0.05
+# video_msg_pos_x = 0.05
+# video_msg_pos_y = 0.05
 
-# Color for message. The value is treated as a hexadecimal value.
-# It is a regular RGB hex number, i.e. red is "ff0000".
-# video_message_color = ffffff
+# Color for message.
+# video_msg_color_r =
+# video_msg_color_g =
+# video_msg_color_b =
 
 # Background color for OSD messages. Red/Green/Blue values are from 0 to 255 and opacity is 0.0 to 1.0.
-video_message_bgcolor_enable = false
-video_message_bgcolor_red = 0
-video_message_bgcolor_green = 0
-video_message_bgcolor_blue = 0
-video_message_bgcolor_opacity = 1.0
+# video_msg_bgcolor_enable = false
+# video_msg_bgcolor_red = 0
+# video_msg_bgcolor_green = 0
+# video_msg_bgcolor_blue = 0
+# video_msg_bgcolor_opacity = 1.0
 
 # Allows libretro cores to set rotation modes.
 # Setting this to false will honor, but ignore this request.

--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -117,13 +117,13 @@
 
 #### Video
 
-# Windowed x resolution scale and y resolution scale
-# (Real x res: base_size * xscale * aspect_ratio, real y res: base_size * yscale)
-# video_scale = 3.0
+# Suspends the screensaver if set to true. Is a hint that does not necessarily have to be honored
+# by video driver.
+# suspend_screensaver_enable  = true
 
-# Fullscreen resolution. Resolution of 0 uses the resolution of the desktop.
-# video_fullscreen_x = 0
-# video_fullscreen_y = 0
+# Which monitor to prefer. 0 (default) means no particular monitor is preferred, 1 and up (1 being first monitor),
+# suggests RetroArch to use that particular monitor.
+# video_monitor_index = 0
 
 # Start in fullscreen. Can be changed at runtime.
 # video_fullscreen = false
@@ -131,15 +131,37 @@
 # If fullscreen, prefer using a windowed fullscreen mode.
 # video_windowed_fullscreen = true
 
+# Fullscreen resolution. Resolution of 0 uses the resolution of the desktop.
+# video_fullscreen_x = 0
+# video_fullscreen_y = 0
+
+# Video refresh rate of your monitor.
+# Used to calculate a suitable audio input rate.
+# video_refresh_rate = 59.94
+
+# Forcibly disable sRGB FBO support. Some Intel OpenGL drivers on Windows
+# have video problems with sRGB FBO support enabled.
+# video_force_srgb_disable = false
+
+# If this is true and video_aspect_ratio is not set,
+# aspect ratio is decided by libretro implementation.
+# If this is false, 1:1 PAR will always be assumed if video_aspect_ratio is not set.
+# video_aspect_ratio_auto = false
+
+# A floating point value for video aspect ratio (width / height).
+# If this is not set, aspect ratio is assumed to be automatic.
+# Behavior then is defined by video_aspect_ratio_auto.
+# video_aspect_ratio =
+
+# Windowed x resolution scale and y resolution scale
+# (Real x res: base_size * xscale * aspect_ratio, real y res: base_size * yscale)
+# video_scale = 3.0
+
 # Percentage of opacity to use for the window (100 is completely opaque).
 # video_window_opacity = 100
 
 # Whether to enable the default window decorations like border, titlebar etc.
 # video_window_show_decorations = true
-
-# Which monitor to prefer. 0 (default) means no particular monitor is preferred, 1 and up (1 being first monitor),
-# suggests RetroArch to use that particular monitor.
-# video_monitor_index = 0
 
 # Forcibly disable composition. Only works in Windows Vista/7 for now.
 # video_disable_composition = false
@@ -154,10 +176,6 @@
 # Max amount of swapchain images.
 # Single buffering = 1, Double buffering = 2, 3 = Triple buffering
 # video_max_swapchain_images = 3
-
-# Forcibly disable sRGB FBO support. Some Intel OpenGL drivers on Windows
-# have video problems with sRGB FBO support enabled.
-# video_force_srgb_disable = false
 
 # Attempts to hard-synchronize CPU and GPU. Can reduce latency at cost of performance.
 # video_hard_sync = false
@@ -198,16 +216,6 @@
 # 19 = Config, 20 = 1:1 PAR, 21 = Core Provided, 22 = Custom Aspect Ratio
 # aspect_ratio_index = 19
 
-# A floating point value for video aspect ratio (width / height).
-# If this is not set, aspect ratio is assumed to be automatic.
-# Behavior then is defined by video_aspect_ratio_auto.
-# video_aspect_ratio =
-
-# If this is true and video_aspect_ratio is not set,
-# aspect ratio is decided by libretro implementation.
-# If this is false, 1:1 PAR will always be assumed if video_aspect_ratio is not set.
-# video_aspect_ratio_auto = false
-
 # Forces cropping of overscanned frames.
 # Exact behavior of this option is implementation specific.
 # video_crop_overscan = true
@@ -247,10 +255,6 @@ video_message_bgcolor_red = 0
 video_message_bgcolor_green = 0
 video_message_bgcolor_blue = 0
 video_message_bgcolor_opacity = 1.0
-
-# Video refresh rate of your monitor.
-# Used to calculate a suitable audio input rate.
-# video_refresh_rate = 59.94
 
 # Allows libretro cores to set rotation modes.
 # Setting this to false will honor, but ignore this request.
@@ -664,10 +668,6 @@ video_message_bgcolor_opacity = 1.0
 # check_firmware_before_loading = "false"
 
 #### UI
-
-# Suspends the screensaver if set to true. Is a hint that does not necessarily have to be honored
-# by video driver.
-# suspend_screensaver_enable  = true
 
 # Start UI companion driver's interface on boot (if available).
 # ui_companion_start_on_boot  = true

--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -121,6 +121,12 @@
 # by video driver.
 # suspend_screensaver_enable  = true
 
+# Display framerate.
+# fps_show = false
+
+# Display total number of frames rendered. (only displays if fps_show is enabled)
+# framecount_show =
+
 # Which monitor to prefer. 0 (default) means no particular monitor is preferred, 1 and up (1 being first monitor),
 # suggests RetroArch to use that particular monitor.
 # video_monitor_index = 0

--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -85,7 +85,7 @@
 # Input driver. Depending on video driver, it might force a different input driver.
 # input_driver = sdl
 
-# Joypad driver. (Valid: linuxraw, sdl, dinput)
+# Joypad driver. ("udev", "linuxraw", "paraport", "sdl2", "hid", "dinput")
 # input_joypad_driver =
 
 # Video driver to use. "gl", "xvideo", "sdl", "d3d"

--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -103,8 +103,17 @@
 # Default will use "sinc".
 # audio_resampler =
 
+# Camera driver.
+# camera_driver =
+
+# Location driver.
+# location_driver =
+
 # Menu driver to use. "rgui", "lakka", etc.
 # menu_driver = "rgui"
+
+# Record driver. Used when recording video.
+# record_driver =
 
 #### Video
 

--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -109,7 +109,7 @@
 # Location driver.
 # location_driver =
 
-# Menu driver to use. "rgui", "lakka", etc.
+# Menu driver to use. ("rgui", "xmb", "glui")
 # menu_driver = "rgui"
 
 # Record driver. Used when recording video.

--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -1,32 +1,8 @@
 ## Skeleton config file for RetroArch
 
-# Save all save files (*.srm) to this directory. This includes related files like .bsv, .rtc, .psrm, etc ...
-# This will be overridden by explicit command line options.
-# savefile_directory =
-
-# Save all save states (*.state) to this directory.
-# This will be overridden by explicit command line options.
-# savestate_directory =
-
-# If set to a directory, content which is temporarily extracted
-# will be extracted to this directory.
-# cache_directory =
-
-# Save all downloaded files to this directory.
-# core_assets_directory =
-
-# Save all remapped controls to this directory.
-# input_remapping_directory =
-
-# Save all playlists/collections to this directory.
-# playlist_directory =
-
 # If set to a directory, the content history playlist will be saved
 # to this directory.
 # content_history_dir =
-
-# Saved queries are stored to this directory.
-# cursor_directory =
 
 # Automatically saves a savestate at the end of RetroArch's lifetime.
 # The path is $SRAM_PATH.auto.
@@ -39,12 +15,6 @@
 
 # Path to a libretro implementation.
 # libretro_path = "/path/to/libretro.so"
-
-# A directory for where to search for libretro core implementations.
-# libretro_directory =
-
-# A directory for where to search for libretro core information.
-# libretro_info_path =
 
 # Sets log level for libretro cores (GET_LOG_INTERFACE).
 # If a log level issued by a libretro core is below libretro_log_level, it is ignored.
@@ -91,27 +61,9 @@
 # Number of entries that will be kept in content history file.
 # content_history_size = 100
 
-# Sets the "system" directory.
-# Implementations can query for this directory to load BIOSes, system-specific configs, etc.
-# system_directory =
-
-# Sets start directory for menu file browser.
-# rgui_browser_directory =
-
 # Content directory. Interacts with RETRO_ENVIRONMENT_GET_CONTENT_DIRECTORY.
 # Usually set by developers who bundle libretro/RetroArch apps to point to assets.
 # content_directory =
-
-# Assets directory. This location is queried by default when menu interfaces try to look for
-# loadable assets, etc.
-# assets_directory =
-
-# Dynamic wallpapers directory. The place to store the wallpapers dynamically
-# loaded by the menu depending on context.
-# dynamic_wallpapers_directory =
-
-# Thumbnails directory. To store thumbnail files.
-# thumbnails_directory =
 
 # Sets start directory for menu config browser.
 # rgui_config_directory =
@@ -258,14 +210,8 @@
 # Other shaders can still be loaded later in runtime.
 # video_shader_enable = false
 
-# Defines a directory where shaders (Cg, CGP, GLSL) are kept for easy access.
-# video_shader_dir =
-
 # CPU-based video filter. Path to a dynamic library.
 # video_filter =
-
-# Defines a directory where CPU-based video filters are kept.
-# video_filter_dir =
 
 # Path to a font used for rendering messages. This path must be defined to enable fonts.
 # Do note that the _full_ path of the font is necessary!
@@ -327,9 +273,6 @@ video_message_bgcolor_opacity = 1.0
 # Audio DSP plugin that processes audio before it's sent to the driver. Path to a dynamic library.
 # audio_dsp_plugin =
 
-# Directory where DSP plugins are kept.
-# audio_filter_dir =
-
 # Will sync (block) on audio. Recommended.
 # audio_sync = true
 
@@ -357,9 +300,6 @@ video_message_bgcolor_opacity = 1.0
 # audio_mixer_volume = 0.0
 
 #### Overlay
-
-# Defines a directory where overlays are kept for easy access.
-# overlay_directory =
 
 # Enable the overlay.
 # input_overlay_enable = true
@@ -422,14 +362,6 @@ video_message_bgcolor_opacity = 1.0
 # When netplay is enabled, the default polling behavior (1) will
 # be used regardless of the value set here.
 # input_poll_type_behavior = 1
-
-# Directory for joypad autoconfigs.
-# If a joypad is plugged in, that joypad will be autoconfigured if a config file
-# corresponding to that joypad is present in joypad_autoconfig_dir.
-# Input binds which are made explicit (input_playerN_*_btn/axis) will take priority over autoconfigs.
-# Autoconfigs can be created with retroarch-joyconfig, manually, or with a frontend.
-# Requires input_autodetect_enable to be enabled.
-# joypad_autoconfig_dir =
 
 # Sets which libretro device is used for a user.
 # Devices are indentified with a number.
@@ -786,6 +718,91 @@ video_message_bgcolor_opacity = 1.0
 # The requested MITM server to use.
 # netplay_mitm_server = "nyc"
 
+#### Directory
+
+# Sets the System/BIOS directory.
+# Implementations can query for this directory to load BIOSes, system-specific configs, etc.
+# system_directory =
+
+# Save all downloaded files to this directory.
+# core_assets_directory =
+
+# Assets directory. This location is queried by default when menu interfaces try to look for
+# loadable assets, etc.
+# assets_directory =
+
+# Dynamic wallpapers directory. The place to store the wallpapers dynamically
+# loaded by the menu depending on context.
+# dynamic_wallpapers_directory =
+
+# Thumbnails directory. To store thumbnail files.
+# thumbnails_directory =
+
+# File browser directory. Sets start directory for menu file browser.
+# rgui_browser_directory =
+
+# Core directory for libretro core implementations.
+# libretro_directory =
+
+# Core info directory for libretro core information.
+# libretro_info_path =
+
+# Path to content database directory.
+# content_database_path =
+
+# Saved queries are stored to this directory.
+# cursor_directory =
+
+# Path to cheat database directory.
+# cheat_database_path =
+
+# Defines a directory where CPU-based video filters are kept.
+# video_filter_dir =
+
+# Directory where DSP plugins are kept.
+# audio_filter_dir =
+
+# Defines a directory where shaders (Cg, CGP, GLSL) are kept for easy access.
+# video_shader_dir =
+
+# Recording output directory. Where recordings are saved.
+# recording_output_directory =
+
+# Recording config directory. Where recording settings are kept.
+# recording_config_directory =
+
+# Overlay directory. Where overlays are kept for easy access.
+# overlay_directory =
+
+# Directory to dump screenshots to.
+# screenshot_directory =
+
+# Directory for joypad autoconfigs.
+# If a joypad is plugged in, that joypad will be autoconfigured if a config file
+# corresponding to that joypad is present in joypad_autoconfig_dir.
+# Input binds which are made explicit (input_playerN_*_btn/axis) will take priority over autoconfigs.
+# Autoconfigs can be created with retroarch-joyconfig, manually, or with a frontend.
+# Requires input_autodetect_enable to be enabled.
+# joypad_autoconfig_dir =
+
+# Save all remapped controls to this directory.
+# input_remapping_directory =
+
+# Save all playlists/collections to this directory.
+# playlist_directory =
+
+# Save all save files (*.srm) to this directory. This includes related files like .bsv, .rtc, .psrm, etc ...
+# This will be overridden by explicit command line options.
+# savefile_directory =
+
+# Save all save states (*.state) to this directory.
+# This will be overridden by explicit command line options.
+# savestate_directory =
+
+# If set to a directory, content which is temporarily extracted
+# will be extracted to this directory.
+# cache_directory =
+
 #### Misc
 
 # Enable rewinding. This will take a performance hit when playing, so it is disabled by default.
@@ -804,15 +821,6 @@ video_message_bgcolor_opacity = 1.0
 # Autosaves the non-volatile SRAM at a regular interval. This is disabled by default unless set otherwise.
 # The interval is measured in seconds. A value of 0 disables autosave.
 # autosave_interval =
-
-# Path to content database directory.
-# content_database_path =
-
-# Path to cheat database directory.
-# cheat_database_path =
-
-# Directory to dump screenshots to.
-# screenshot_directory =
 
 # Records video after CPU video filter.
 # video_post_filter_record = false

--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -256,11 +256,11 @@
 # video_message_color = ffffff
 
 # Background color for OSD messages. Red/Green/Blue values are from 0 to 255 and opacity is 0.0 to 1.0.
-video_message_bgcolor_enable = false
-video_message_bgcolor_red = 0
-video_message_bgcolor_green = 0
-video_message_bgcolor_blue = 0
-video_message_bgcolor_opacity = 1.0
+# video_message_bgcolor_enable = false
+# video_message_bgcolor_red = 0
+# video_message_bgcolor_green = 0
+# video_message_bgcolor_blue = 0
+# video_message_bgcolor_opacity = 1.0
 
 # Allows libretro cores to set rotation modes.
 # Setting this to false will honor, but ignore this request.

--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -248,20 +248,19 @@
 
 # Offset for where messages will be placed on screen. Values are in range 0.0 to 1.0 for both x and y values.
 # [0.0, 0.0] maps to the lower left corner of the screen.
-# video_msg_pos_x = 0.05
-# video_msg_pos_y = 0.05
+# video_message_pos_x = 0.05
+# video_message_pos_y = 0.05
 
-# Color for message.
-# video_msg_color_r =
-# video_msg_color_g =
-# video_msg_color_b =
+# Color for message. The value is treated as a hexadecimal value.
+# It is a regular RGB hex number, i.e. red is "ff0000".
+# video_message_color = ffffff
 
 # Background color for OSD messages. Red/Green/Blue values are from 0 to 255 and opacity is 0.0 to 1.0.
-# video_msg_bgcolor_enable = false
-# video_msg_bgcolor_red = 0
-# video_msg_bgcolor_green = 0
-# video_msg_bgcolor_blue = 0
-# video_msg_bgcolor_opacity = 1.0
+video_message_bgcolor_enable = false
+video_message_bgcolor_red = 0
+video_message_bgcolor_green = 0
+video_message_bgcolor_blue = 0
+video_message_bgcolor_opacity = 1.0
 
 # Allows libretro cores to set rotation modes.
 # Setting this to false will honor, but ignore this request.


### PR DESCRIPTION
Reorganizes sections in `retroarch.cfg` to match RGUI.

- Add new sections (Directory, Driver)
- Move settings to correct sections
- Add missing settings (`camera_driver`, `recording_output_directory`, etc)
- Update code comments