### PR TITLE
[WiiU] Add build information to exception handler

### DIFF
--- a/wiiu/system/exception_handler.c
+++ b/wiiu/system/exception_handler.c
@@ -22,6 +22,8 @@
 #include <wiiu/os.h>
 #include "wiiu_dbg.h"
 #include "exception_handler.h"
+#include "version.h"
+#include "version_git.h"
 
 /*	Settings */
 #define NUM_STACK_TRACE_LINES 5
@@ -182,6 +184,11 @@ void __attribute__((__noreturn__)) exception_cb(OSContext* ctx, OSExceptionType 
    else
       buf_add("Stack pointer invalid. Could not trace further.\n");
 
+#ifdef HAVE_GIT_VERSION
+   buf_add("RetroArch " PACKAGE_VERSION " (%s) built " __DATE__, retroarch_git_version);
+#else
+   buf_add("RetroArch " PACKAGE_VERSION " built " __DATE__);
+#endif
    OSFatal(exception_msgbuf);
    for (;;) {}
 }


### PR DESCRIPTION
Heyo!

Just a quick patch to add a little bit of identifying information to the Wii U's exception handler. I've been seeing a lot of issues like #6572 - perfectly fine issues that are a little vauge on the version ("latest"? nightlies or stable? when?). Adding the build date (and git version) to the handler should quickly clear this up and allow debuggers to easily grab the exact file the user ran when they got an error.

Thanks again,
Ash