### PR TITLE
cheevos/var.c: removed unnecessary memory adjustment for NeoGeo Pocket

### DIFF
--- a/cheevos/var.c
+++ b/cheevos/var.c
@@ -191,12 +191,6 @@ void cheevos_var_patch_addr(cheevos_var_t* var, cheevos_console_t console)
          var->value -= 0x2000;
       }
    }
-   else if (console == CHEEVOS_CONSOLE_NEOGEO_POCKET)
-   {
-      if (var->value >= 0x4000 && var->value <= 0x7fff)
-      CHEEVOS_LOG(CHEEVOS_TAG "NGP memory address %X adjusted to %X\n", var->value, var->value - 0x004000);
-      var->value -= 0x4000;
-   }
 
    if (system->mmaps.num_descriptors != 0)
    {


### PR DESCRIPTION
## Description

I'm removing the unnecessary memory adjustment made for NeoGeo Pocket games.

That adjustment was made because we, at RetroAchievements.org, were using a tool with wrong memory mapping to develop NeoGeo Pocket cheevos. But now we are using @leiradel's [RALibretro](https://github.com/RetroAchievements/RALibretro), which uses the correct memory mapping.


## Related Pull Requests

#5981 from @celerizer 


## Reviewers

@leiradel @celerizer 