### PR TITLE
Attempt build fix for Windows 7 API usage.

### DIFF
--- a/gfx/common/win32_common.c
+++ b/gfx/common/win32_common.c
@@ -15,14 +15,21 @@
 
 #if !defined(_XBOX)
 
+#if !defined(_MSC_VER)
+
 #ifndef _WIN32_WINNT
 #define _WIN32_WINNT 0x0601 /* Windows 7 */
 #endif
 
-#if !defined(_MSC_VER) || _WIN32_WINNT >= 0x0601
-#undef WINVER
-#define WINVER 0x0601
+#ifndef _WIN32_WINDOWS
+#define _WIN32_WINDOWS _WIN32_WINNT
 #endif
+
+#ifndef WINVER
+#define WINVER _WIN32_WINNT
+#endif
+
+#endif /* !defined(_MSC_VER) */
 
 #define IDI_ICON 1
 


### PR DESCRIPTION
No idea why the Travis build is failing, since it works fine here. This is an attempt at a fix. Let's see if it builds before merging it. Otherwise, I suspect their mingw headers are outdated.