### PR TITLE
Disable Travis email notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,3 +64,5 @@ addons:
     build_command_prepend: "./configure; make clean"
     build_command:   "make"
     branch_pattern: coverity_scan
+notifications:
+  email: false


### PR DESCRIPTION
@twinaphex reported that he was getting a lot of Travis email notifications. These are not needed, as the build status is reported on both Pull Requests, and the Status Badge.

See the documentation over at https://docs.travis-ci.com/user/notifications/ .
## Reviewers

- @twinaphex 