### PR TITLE
Added an indicator of the current video driver to the menu.

### DIFF
--- a/menu/menu_entries.c
+++ b/menu/menu_entries.c
@@ -26,6 +26,7 @@
 #include "../core.h"
 #include "../retroarch.h"
 #include "../version.h"
+#include "../configuration.h"
 
 /* Flagged when menu entries need to be refreshed */
 static bool menu_entries_need_refresh              = false;
@@ -421,6 +422,7 @@ int menu_entries_get_core_title(char *s, size_t len)
    const char *core_version       = NULL;
    rarch_system_info_t      *info      = runloop_get_system_info();
    struct retro_system_info    *system = &info->info;
+   settings_t *settings = config_get_ptr();
 
    if (system)
    {
@@ -438,8 +440,10 @@ int menu_entries_get_core_title(char *s, size_t len)
    if (!core_version)
       core_version = "";
 
-   snprintf(s, len, "%s - %s %s", PACKAGE_VERSION,
-         core_name, core_version);
+   const char *video_driver = settings->arrays.video_driver;
+
+   snprintf(s, len, "%s - %s - %s %s", PACKAGE_VERSION,
+         video_driver, core_name, core_version);
 
    return 0;
 }


### PR DESCRIPTION
## Description

This pull request implements a simple visual indicator of what video driver you are using to the menu. It is displayed along the bottom left-hand corner, with the current RetroArch version & core. The new format would look something like this: `1.7.2 - vulkan - No Core` or `1.7.2 - gl - No Core`.

This small change is helpful for those with multiple configurations with multiple video drivers used (i.e. mednafen & Citra both use OpenGL while Beetle-PSX HW uses Vulkan). Previously there wasn't an easy way to know what video driver you were using other than checking it within multiple submenus. This change rectifies that.

This is my first time working with the RetroArch source code, so I'd appreciate any feedback.