### PR TITLE
Two fixes for copy_load_info.c

### DIFF
--- a/runahead/copy_load_info.c
+++ b/runahead/copy_load_info.c
@@ -37,12 +37,15 @@ static struct retro_game_info* clone_retro_game_info(const
    dest->data    = NULL;
    dest->path    = strcpy_alloc(src->path);
 
-   data          = malloc(src->size);
-
-   if (data)
+   if (src->size && src->data)
    {
-      memcpy(data, src->data, src->size);
-      dest->data = data;
+      data = malloc(src->size);
+
+      if (data)
+      {
+         memcpy(data, src->data, src->size);
+         dest->data = data;
+      }
    }
 
    dest->size    = src->size;
@@ -77,9 +80,13 @@ static struct string_list *string_list_clone(
 
    dest->size      = src->size;
    dest->cap       = src->cap;
+   if (dest->cap < dest->size)
+   {
+      dest->cap = dest->size;
+   }
 
    elems           = (struct string_list_elem*)
-      calloc(dest->size, sizeof(struct string_list_elem));
+      calloc(dest->cap, sizeof(struct string_list_elem));
 
    if (!elems)
    {


### PR DESCRIPTION
* Additional check before copying data in `clone_retro_game_info`
* Sizes the dest string list in `string_list_clone` to capacity rather than size

Tries to address issue #6613