### PR TITLE
prevent crashing in cores that don't range check retro_set_controller…

### DIFF
--- a/command.c
+++ b/command.c
@@ -1015,7 +1015,7 @@ static void command_event_init_controllers(void)
             /* Ideally these checks shouldn't be required but if we always
              * call core_set_controller_port_device input won't work on
              * cores that don't set port information properly */
-            if (info && info->ports.size != 0 && i < info->ports.size)
+            if (info && info->ports.size != 0)
                set_controller = true;
             break;
          default:
@@ -1029,7 +1029,7 @@ static void command_event_init_controllers(void)
             break;
       }
 
-      if (set_controller)
+      if (set_controller && i < info->ports.size)
       {
          pad.device     = device;
          pad.port       = i;


### PR DESCRIPTION
…_port

some people were having crashes when device is set to RETRO_DEVICE_NONE and the cores don't check the number of ports, in VBAM's case it was overflowing and crashing. QuickNES was crashing too.

It's quite weird that this wasn't spotted before but this code is so fragile I don't really like messing with it.

In VBAM's case it was crashing because:

```C
void retro_set_controller_port_device(unsigned port, unsigned device)
{
   log_cb(RETRO_LOG_INFO, "Controller %d'\n", device);
   switch(device)
   {

      case RETRO_DEVICE_JOYPAD:
      case RETRO_DEVICE_GBA:
      default:
         controller_layout[port] = 0;
      break;   
      case RETRO_DEVICE_GBA_ALT1:
         controller_layout[port] = 1;
      break;
      case RETRO_DEVICE_GBA_ALT2:
         controller_layout[port] = 2;
      break;
      case RETRO_DEVICE_NONE:
         controller_layout[port] = -1;
      break;
   }
}
```

controller_layout is sized 2, so it was overflowing at port 3.