### PR TITLE
changed APP_UNIQUE_ID to next free & valid HEX number

### DIFF
--- a/pkg/ctr/Makefile.cores
+++ b/pkg/ctr/Makefile.cores
@@ -75,7 +75,7 @@ else ifeq ($(LIBRETRO), freeintv)
 	APP_TITLE            = FreeIntv
 	APP_AUTHOR           = various
 	APP_PRODUCT_CODE     = RARCH-FREEINTV
-	APP_UNIQUE_ID        = 0xBAC1G
+	APP_UNIQUE_ID        = 0xBAC21
 	APP_ICON             = pkg/ctr/assets/freeintv.png
 	APP_BANNER           = pkg/ctr/assets/freeintv_banner.png
 


### PR DESCRIPTION
was `0xBAC1G` in commit a couple of months ago by @MrHuu 

now `0xBAC21`

cc @twinaphex 