### PR TITLE
Have "All Users Control the Menu" default to ON

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -67,8 +67,8 @@ static bool bundle_assets_extract_enable = false;
 static bool materialui_icons_enable      = true;
 #endif
 
-static const bool crt_switch_resolution = false; 	
-static const int crt_switch_resolution_super = 2560; 
+static const bool crt_switch_resolution = false;
+static const int crt_switch_resolution_super = 2560;
 
 
 static const bool def_history_list_enable = true;
@@ -371,7 +371,7 @@ static unsigned input_backtouch_toggle       = false;
 
 static bool show_physical_inputs             = true;
 
-static bool all_users_control_menu = false;
+static bool all_users_control_menu = true;
 
 #if defined(ANDROID) || defined(_WIN32)
 static bool menu_swap_ok_cancel_buttons = true;

--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -652,7 +652,7 @@ video_message_bgcolor_opacity = 1.0
 # input_menu_toggle_gamepad_combo = 0
 
 # allow any RetroPad to control the menu
-# all_users_control_menu = false
+# all_users_control_menu = true
 
 # Toggles mouse grab. When mouse is grabbed, RetroArch hides the mouse,
 # and keeps the mouse pointer inside the window to allow relative mouse input


### PR DESCRIPTION
When running RetroArch for the first time, it can be confusing which controller is Player 1 in order to control the menu.

Defaulting to having "All Users Control the Menu" *on* means on the first run, any controller will be able to use the menu. Afterwards, once controllers are set up properly, you're able to disable it. Having it on at first makes set up much easier.