### PR TITLE
Makefile.common: Fix segfaults with --disable-builtinflac.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1463,7 +1463,8 @@ ifeq ($(HAVE_BUILTINFLAC),1)
    endif
    OBJ += $(FLACOBJ)
 else ifeq ($(HAVE_FLAC),1)
-   LIBS += $(FLAC_LIBS)
+   DEFINES += -DHAVE_FLAC
+   LIBS    += $(FLAC_LIBS)
 endif
 
 ifeq ($(HAVE_ZLIB), 1)


### PR DESCRIPTION
## Description

This fixes the crash when RetrorArch is built with `--disable-builtinflac` and scanning chd v5 files.

A relatively recent commit exposed the problem when I previously forget to define `-DHAVE_FLAC` in `Makefile.common`...

It will still fail scanning with `--disable-flac`, but earlier behavior would have not built chd support without flac at all so I would consider this a different bug.

## Related Issues

https://github.com/libretro/RetroArch/issues/6553

## Related Pull Requests

https://github.com/libretro/RetroArch/commit/997c24ae0c45a40e055f9c9d90debc7c13782350

## Reviewers

@twinaphex @i30817
