### PR TITLE
Adjust travis build to only use libraries the build-server supports.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
             - g++-mingw-w64-i686
             - mingw-w64-i686-dev
       script:
-        - CROSS_COMPILE=i686-w64-mingw32- ./configure --disable-d3d8 --disable-d3d9 --disable-d3d10 --disable-d3d11 --disable-d3d12 && make HAVE_ZLIB=1 HAVE_BUILTINZLIB=1 HAVE_RPNG=1
+        - CROSS_COMPILE=i686-w64-mingw32- CFLAGS="-D_WIN32_WINNT=0x0501" ./configure --disable-d3d8 --disable-d3d9 --disable-d3d10 --disable-d3d11 --disable-d3d12 && make HAVE_ZLIB=1 HAVE_BUILTINZLIB=1 HAVE_RPNG=1
     - compiler: mingw-x64
       addons:
         apt:
@@ -18,7 +18,7 @@ matrix:
             - g++-mingw-w64-x86-64
             - mingw-w64-x86-64-dev
       script:
-        - CROSS_COMPILE=x86_64-w64-mingw32- ./configure --disable-d3d8 --disable-d3d9 --disable-d3d10 --disable-d3d11 --disable-d3d12 && make HAVE_ZLIB=1 HAVE_BUILTINZLIB=1 HAVE_RPNG=1
+        - CROSS_COMPILE=x86_64-w64-mingw32- CFLAGS="-D_WIN32_WINNT=0x0501" ./configure --disable-d3d8 --disable-d3d9 --disable-d3d10 --disable-d3d11 --disable-d3d12 && make HAVE_ZLIB=1 HAVE_BUILTINZLIB=1 HAVE_RPNG=1
     - compiler: gcc
     - compiler: clang
       addons:


### PR DESCRIPTION
Travis servers only have old windows headers and libraries ATM.