### PR TITLE
WIIU: Disable screen-dimming while core is running

### DIFF
--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -25,6 +25,10 @@
 #include <streams/file_stream.h>
 #include <string/stdstring.h>
 
+#ifdef WIIU
+#include <wiiu/os/energy.h>
+#endif
+
 #ifdef HAVE_CONFIG_H
 #include "../config.h"
 #endif
@@ -1678,6 +1682,12 @@ static void menu_driver_toggle(bool on)
    if (menu_driver_alive)
    {
       bool refresh = false;
+
+#ifdef WIIU
+      /* Enable burn-in protection menu is running */
+      IMEnableDim();
+#endif
+
       menu_entries_ctl(MENU_ENTRIES_CTL_SET_REFRESH, &refresh);
 
       /* Menu should always run with vsync on. */
@@ -1701,6 +1711,13 @@ static void menu_driver_toggle(bool on)
    }
    else
    {
+#ifdef WIIU
+      /* Disable burn-in protection while core is running; this is needed
+       * because HID inputs don't count for the purpose of Wii U
+       * power-saving. */
+      IMDisableDim();
+#endif
+
       if (!rarch_ctl(RARCH_CTL_IS_SHUTDOWN, NULL))
          driver_set_nonblock_state();
 


### PR DESCRIPTION
== DETAILS
In my extended testing, I found that the HID device inputs don't get factored
into resetting things like the burn-in protection and automatic power down.

The automatic power-down can't be changed in software, but the screen dimming
can!

This patch disables the screen dimming while the core is running, but turns
it back on while the menu is displayed. This way, users who want the screen
dimming functionality to kick in need to simply enter the RA menu.

## Reviewers

@aliaspider @QuarkTheAwesome 
