### PR TITLE
Revert "don't allow slow motion if cheevos enabled"

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -3001,9 +3001,7 @@ static enum runloop_state runloop_check_state(
    }
 
    /* Checks if slowmotion toggle/hold was being pressed and/or held. */
-#ifdef HAVE_CHEEVOS
-   if (!settings->bools.cheevos_enable)
-#endif
+   
    {
       static bool old_slowmotion_button_state      = false;
       static bool old_slowmotion_hold_button_state = false;


### PR DESCRIPTION
Reverts libretro/RetroArch#6664

That is what the Hardcore mode is for. The sublabel and [achievements documentation](https://docs.libretro.com/guides/retroachievements/#how-to-setup-achievements) describes this best.......

![29458239-14b1b24c-83ec-11e7-8806-0621b5f988d7](https://user-images.githubusercontent.com/25086/39445134-062b3f26-4c88-11e8-93f7-4783cf944a5c.png)
