### PR TITLE
Fix incorrect labels on dialogs due to incorrect macro

### DIFF
--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -2090,12 +2090,12 @@ static void menu_input_st_string_cb_cheat_file_save_as(
    menu_input_dialog_end();
 }
 
-#define default_action_dialog_start(funcname, _label_setting, _idx, _cb) \
-static int (funcname)(const char *path, const char *label, unsigned type, size_t idx, size_t entry_idx) \
+#define default_action_dialog_start(funcname, _label, _idx, _cb) \
+static int (funcname)(const char *path, const char *label_setting, unsigned type, size_t idx, size_t entry_idx) \
 { \
    menu_input_ctx_line_t line; \
-   line.label         = label; \
-   line.label_setting = _label_setting; \
+   line.label         = _label; \
+   line.label_setting = label_setting; \
    line.type          = type; \
    line.idx           = (_idx); \
    line.cb            = _cb; \


### PR DESCRIPTION
In the not-so-distant past, a macro was made to replace the individual functions for showing dialogs. This macro switched around two values, so that the descriptive text that should be shown in the dialog is replaced by the setting name. This can be seen when going to the Enable Settings Tab dialog in the Main section of the menu or when renaming playlist entries, among other places.

This pull request fixes the issue by swapping the values in question and also changes their names to reduce the risk of such confusions in the future.