### PR TITLE
qb: Improve moc detection

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -270,7 +270,7 @@ check_val '' PULSE -lpulse
 check_val '' SDL -lSDL SDL
 check_val '' SDL2 -lSDL2 SDL2
 
-if [ "$HAVE_QT" != 'no' ]; then
+if [ "$HAVE_QT" != 'no' ] && [ "$MOC_PATH" != 'none' ]; then
    check_pkgconf QT5CORE Qt5Core 5.2
    check_pkgconf QT5GUI Qt5Gui 5.2
    check_pkgconf QT5WIDGETS Qt5Widgets 5.2

--- a/qb/qb.comp.sh
+++ b/qb/qb.comp.sh
@@ -86,14 +86,20 @@ fi
 if [ "$HAVE_QT" != "no" ]; then
 	echobuf="Checking for moc"
 	if [ -z "$MOC" ]; then
-		MOC="$(exists "moc")" || MOC=""
-		if [ -z "$MOC" ]; then
-			die : "$echobuf ... Not found."
-		else
-			echo "$echobuf ... $MOC"
-		fi
-	else
-		echo "$echobuf ... $MOC"
+		MOC_PATH="none"
+		for moc in moc-qt5 moc; do
+			MOC="$(exists "$moc")" || MOC=""
+			[ "${MOC}" ] && {
+				MOC_PATH="$MOC"
+				break
+			}
+		done
+	fi
+
+	echo "$echobuf ... $MOC_PATH"
+
+	if [ "$MOC_PATH" = "none" ]; then
+		die : 'Warning: moc not found, Qt companion support will be disabled.'
 	fi
 fi
 


### PR DESCRIPTION
## Description

On systems with both Qt4 and Qt5 the first `moc` in the user's `$PATH` may not be the qt5 `moc`. In these cases RetroArch would try to use it and resulted in a build failure. On my system `moc-qt5` is the correct symlink to the `moc` binary so this commit will then check for that first and then for the `moc` binary. While I am not sure if `moc-qt5` will work for other distros that may have both Qt4 and Qt5, this should be easy to extend for any other such symlinks as they are discovered.

Additionally this will helpfully only build Qt5 support if `moc` is found and will print a warning in the event it is not. Before it would try to build Qt5 even when moc was not found and this also resulted in a build error.

## Related Issues

Two issues are solved here.

1. Build issues when both Qt4 and Qt5 are installed.
2. Build issues when moc is not found.

## Related Pull Requests

https://github.com/libretro/RetroArch/commit/a1aefc901c042e0ac1121b3fd5c193b1afeda026#diff-0d47b8346d57b12a5807c36fb1f14f3c

## Reviewers

@bparker06
