### PR TITLE
Silence -Wmisleading-indentation warning

### DIFF
--- a/gfx/video_crt_switch.c
+++ b/gfx/video_crt_switch.c
@@ -93,8 +93,11 @@ static void crt_screen_setup_aspect(unsigned width, unsigned height)
    {
       /* detect menu only */	
       if (width < 1920)
+      {
          width = 704;
          height = 480;
+      }
+
       crt_aspect_ratio_switch(width, height);
    }
 


### PR DESCRIPTION
## Description

Silences a `-Wmisleading-indentation` warning.

## Related Issues

```
gfx/video_crt_switch.c: In function ‘crt_screen_setup_aspect’:
gfx/video_crt_switch.c:95:7: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
       if (width < 1920)
       ^~
gfx/video_crt_switch.c:97:10: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
          height = 480;
          ^~~~~~
```

## Related Pull Requests

N/A

## Reviewers

@twinaphex 
