### PR TITLE
qb: Always print CC and CXX variables when set.

### DIFF
--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -222,8 +222,8 @@ create_config_make()
 
 	printf %s\\n "Creating make config: $outfile"
 
-	{	[ "$USE_LANG_C" = 'yes' ] && printf %s\\n "CC = $CC" "CFLAGS = $CFLAGS"
-		[ "$USE_LANG_CXX" = 'yes' ] && printf %s\\n "CXX = $CXX" "CXXFLAGS = $CXXFLAGS"
+	{	[ "${CC}" ] && printf %s\\n "CC = $CC" "CFLAGS = $CFLAGS"
+		[ "${CXX}" ] && printf %s\\n "CXX = $CXX" "CXXFLAGS = $CXXFLAGS"
 
 		printf %s\\n "WINDRES = $WINDRES" \
 			"MOC = $MOC" \


### PR DESCRIPTION
## Description

With this commit if `$CC` is not an empty variable `CC` and `CFLAGS` will be added to `config.mk`. This is likewise truse if `$CXX` is not an empty variable it will add `CXX` and `CXXFLAGS`. This allows correctly setting `CXX` for configure and not having it fall back to `g++`.

## Related Issues

This command would silently use `g++` erroneously before this commit.
```
CXX=clang++ ./configure && make
```
This also exposes several unrelated and preexisting compiler warnings with `clang++`.

## Related Pull Requests

Implements part of the following problematic PR based on a comment from @heuripedes. I will revisit the other parts next.

https://github.com/libretro/RetroArch/pull/6409#issuecomment-376696184

## Reviewers

@twinaphex, @bparker06, @heuripedes 
