### PR TITLE
qb: Fix checking the CXX compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,20 +92,19 @@ APPEND_CFLAGS := $(CFLAGS)
 CXXFLAGS += $(APPEND_CFLAGS) -std=c++11 -D__STDC_CONSTANT_MACROS
 OBJCFLAGS :=  $(CFLAGS) -D__STDC_CONSTANT_MACROS
 
-ifeq ($(CXX_BUILD), 1)
-   LINK = $(CXX)
-   CFLAGS   := $(CXXFLAGS) -xc++
-   CFLAGS   += -DCXX_BUILD
-   CXXFLAGS += -DCXX_BUILD
-else
-   ifeq ($(NEED_CXX_LINKER),1)
+ifeq ($(HAVE_CXX), 1)
+   ifeq ($(CXX_BUILD), 1)
       LINK = $(CXX)
-   else ifeq ($(findstring Win32,$(OS)),)
-      LINK = $(CC)
+      CFLAGS   := $(CXXFLAGS) -xc++
+      CFLAGS   += -DCXX_BUILD
+      CXXFLAGS += -DCXX_BUILD
+   else ifeq ($(NEED_CXX_LINKER),1)
+      LINK = $(CXX)
    else
-      # directx-related code is c++
-      LINK = $(CXX)
+      LINK = $(CC)
    endif
+else
+   LINK = $(CC)
 
    ifneq ($(GNU90_BUILD), 1)
       ifneq ($(findstring icc,$(CC)),)

--- a/qb/config.comp.sh
+++ b/qb/config.comp.sh
@@ -1,6 +1,2 @@
 USE_LANG_C="yes"
-
-# C++ compiler is optional in other platforms supported by ./configure
-if [ "$OS" = 'Win32' ]; then
-	USE_LANG_CXX="yes"
-fi
+USE_LANG_CXX="yes"

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -270,6 +270,8 @@ check_val '' PULSE -lpulse
 check_val '' SDL -lSDL SDL
 check_val '' SDL2 -lSDL2 SDL2
 
+check_enabled QT 'Qt companion'
+
 if [ "$HAVE_QT" != 'no' ] && [ "$MOC_PATH" != 'none' ]; then
    check_pkgconf QT5CORE Qt5Core 5.2
    check_pkgconf QT5GUI Qt5Gui 5.2
@@ -486,6 +488,8 @@ fi
 
 check_lib '' STRCASESTR "$CLIB" strcasestr
 check_lib '' MMAP "$CLIB" mmap
+
+check_enabled VULKAN vulkan
 
 if [ "$HAVE_VULKAN" != "no" ] && [ "$OS" = 'Win32' ]; then
    HAVE_VULKAN=yes

--- a/qb/qb.comp.sh
+++ b/qb/qb.comp.sh
@@ -11,6 +11,7 @@ int main(void) { puts("Hai world!"); return 0; }
 EOF
 
 cc_works=0
+HAVE_CC=no
 if [ "$CC" ]; then
 	"$CC" -o "$TEMP_EXE" "$TEMP_C" >/dev/null 2>&1 && cc_works=1
 else
@@ -29,6 +30,7 @@ rm -f -- "$TEMP_C" "$TEMP_EXE"
 cc_status='does not work'
 if [ "$cc_works" = '1' ]; then
 	cc_status='works'
+	HAVE_CC='yes'
 elif [ -z "$CC" ]; then
 	cc_status='not found'
 fi
@@ -46,6 +48,7 @@ int main() { std::cout << "Hai guise" << std::endl; return 0; }
 EOF
 
 cxx_works=0
+HAVE_CXX=no
 if [ "$CXX" ]; then
 	"$CXX" -o "$TEMP_EXE" "$TEMP_CXX" >/dev/null 2>&1 && cxx_works=1
 else
@@ -64,6 +67,7 @@ rm -f -- "$TEMP_CXX" "$TEMP_EXE"
 cxx_status='does not work'
 if [ "$cxx_works" = '1' ]; then
 	cxx_status='works'
+	HAVE_CXX='yes'
 elif [ -z "$CXX" ]; then
 	cxx_status='not found'
 fi
@@ -71,7 +75,7 @@ fi
 echo "Checking for suitable working C++ compiler ... $CXX $cxx_status"
 
 if [ "$cxx_works" = '0' ] && [ "$USE_LANG_CXX" = 'yes' ]; then
-	die 1 'Error: Cannot proceed without a working C++ compiler.'
+	die : 'Warning: A working C++ compiler was not found, C++ features will be disabled.'
 fi
 
 if [ "$OS" = "Win32" ]; then

--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -28,6 +28,18 @@ check_compiler() # $1 = language  $2 = function in lib
 	fi
 }
 
+check_enabled() # $1 = HAVE_$1  $2 = lib
+{	[ "$HAVE_CXX" != 'no' ] && return 0
+	tmpval="$(eval "printf %s \"\$HAVE_$1\"")"
+
+	if [ "$tmpval" != 'yes' ]; then
+		eval "HAVE_$1=no"
+		return 0
+	fi
+
+	die 1 "Forced to build with $2 support and the C++ compiler is disabled. Exiting ..."
+}
+
 check_lib() # $1 = language  $2 = HAVE_$2  $3 = lib  $4 = function in lib  $5 = extralibs $6 = headers $7 = critical error message [checked only if non-empty]
 {	tmpval="$(eval "printf %s \"\$HAVE_$2\"")"
 	[ "$tmpval" = 'no' ] && return 0
@@ -222,8 +234,8 @@ create_config_make()
 
 	printf %s\\n "Creating make config: $outfile"
 
-	{	[ "${CC}" ] && printf %s\\n "CC = $CC" "CFLAGS = $CFLAGS"
-		[ "${CXX}" ] && printf %s\\n "CXX = $CXX" "CXXFLAGS = $CXXFLAGS"
+	{	[ "$HAVE_CC" = 'yes' ] && printf %s\\n "CC = $CC" "CFLAGS = $CFLAGS"
+		[ "$HAVE_CXX" = 'yes' ] && printf %s\\n "CXX = $CXX" "CXXFLAGS = $CXXFLAGS"
 
 		printf %s\\n "WINDRES = $WINDRES" \
 			"MOC = $MOC" \


### PR DESCRIPTION
## Description

WARNING: Please review this and make sure I did not miss any scenarios when C++ support needs to be enabled. Does windows always need a C++ compiler?

This does the following.

1. Fixes checking if the CXX compiler works on platforms other than windows.
2. Turns the error when the CXX compiler is missing or doesn't work into a warning.
3. Adds HAVE_CC and HAVE_CXX.
4. Only adds CC and CXX to config.mk when HAVE_CC or HAVE_CXX are true.
5. Disables Qt companion, Vulkan, CXX_BUILD and NEED_CXX_LINKER if HAVE_CXX is false.
6. Explicitly errors when the CXX compiler is broken or missing and Qt or vulkan support is enabled.

This also adds the function `check_enabled` to `qb/qb.lib.sh` which can be used to dynamically disable any libraries that require C++ support.

## Related Issues

On platforms other than windows `configure` will never check if the CXX compiler actually works and after my previous PR it will try to use it even if it doesn't work (Which is still better than ignoring it).

## Related Pull Requests

Replaces https://github.com/libretro/RetroArch/pull/6409.

Also see https://github.com/libretro/RetroArch/pull/6695.

## Reviewers

@twinaphex @bparker06 @heuripedes 