### PR TITLE
Makefile.common: Fix vulkan builds on 32-bit linux.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1189,7 +1189,7 @@ ifeq ($(HAVE_VULKAN), 1)
    ifeq ($(HAVE_MENU_COMMON), 1)
       OBJ += menu/drivers_display/menu_display_vulkan.o
    endif
-   #LIBS += -lstdc++
+   NEED_CXX_LINKER = 1
    DEFINES += -DHAVE_VULKAN
    INCLUDE_DIRS += -Igfx/include
 


### PR DESCRIPTION
## Description

Builds with vulkan support with `clang-6.0.0` or `gcc-7.3.0` on 32-bit linux fail with literally countless undefined references during linking.

## Related Issues

In `Makefile.common` `LIBS += -lstdc++` was commented by @bparker06 because of build failures with `clang-3.8.0` in an older ubuntu version. However this exposed other build issues here even if I could not reproduce the `clang-3.8.0` build issue. It seems easier to just set `NEED_CXX_LINKER` here instead of trying to make all of the compilers happy.

Second opinions would be appreciated!

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/6668

## Reviewers

@twinaphex @bparker06 
