### PR TITLE
Qt: Don't force the fusion theme.

### DIFF
--- a/ui/drivers/qt/ui_qt_application.cpp
+++ b/ui/drivers/qt/ui_qt_application.cpp
@@ -118,8 +118,6 @@ static void* ui_application_qt_initialize(void)
    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
 
-   QApplication::setStyle("fusion");
-
    ui_application.app = new QApplication(app_argc, app_argv);
    ui_application.app->setOrganizationName("libretro");
    ui_application.app->setApplicationName("RetroArch");


### PR DESCRIPTION
## Description

This removes the hardcoded fusion theme and allows the user to set the Qt5 theme themselves.

## Related Issues

The Retroarch Qt companion does not respect Qt5 system themes. 

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/6668

## Reviewers

@bparker06 