### PR TITLE
QT restore preferences if they exist

### DIFF
--- a/ui/drivers/ui_qt.cpp
+++ b/ui/drivers/ui_qt.cpp
@@ -451,11 +451,11 @@ static void* ui_companion_qt_init(void)
       if (qsettings->contains("save_geometry"))
          mainwindow->restoreGeometry(qsettings->value("geometry").toByteArray());
 
-   if (qsettings->value("save_dock_positions", false).toBool())
+   if (qsettings->contains("save_dock_positions"))
       if (qsettings->contains("dock_positions"))
          mainwindow->restoreState(qsettings->value("dock_positions").toByteArray());
 
-   if (qsettings->value("save_last_tab", false).toBool())
+   if (qsettings->contains("save_last_tab"))
    {
       if (qsettings->contains("last_tab"))
       {


### PR DESCRIPTION
## Description

Dock positions and browsing mode will be restored even if "remember choice" isn't checked.

## Related Issues

You make your window/dock customization, have the "remember settings" box checked, quit RA.
Then you don't want them changed, you uncheck each "remember setting".
Next RA start your settings won't be loaded and restored to default.

Now they are honoured and you'll have to delete them in retroarch_qt.cfg to get the default back.
