### PR TITLE
Makefile: Try to fix logic.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,9 @@ ifeq ($(HAVE_CXX), 1)
    endif
 else
    LINK = $(CC)
+endif
 
+ifneq ($(CXX_BUILD), 1)
    ifneq ($(GNU90_BUILD), 1)
       ifneq ($(findstring icc,$(CC)),)
          CFLAGS += -std=c99 -D_GNU_SOURCE


### PR DESCRIPTION
## Description

NOTE: Please let travis test this.

This tries to fix a small misstep in logic. It should check `C89_BUILD` and `GNU90_BUILD` regardless if we have a 

## Related Issues

Maybe some travis failures?

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/6701

## Reviewers

travis, @twinaphex 
