### PR TITLE
Automatically hide "Configuration Override options" in Quick Menu

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -2758,11 +2758,16 @@ static int menu_displaylist_parse_load_content_settings(
          }
       }
 
-      menu_entries_append_enum(info->list,
+      if ((settings->bools.quick_menu_show_save_core_overrides ||
+         settings->bools.quick_menu_show_save_game_overrides) &&
+         !settings->bools.kiosk_mode_enable)
+      {
+         menu_entries_append_enum(info->list,
             msg_hash_to_str(MENU_ENUM_LABEL_VALUE_QUICK_MENU_OVERRIDE_OPTIONS),
             msg_hash_to_str(MENU_ENUM_LABEL_QUICK_MENU_OVERRIDE_OPTIONS),
             MENU_ENUM_LABEL_QUICK_MENU_OVERRIDE_OPTIONS,
             MENU_SETTING_ACTION, 0, 0);
+      }
 
 
 #ifdef HAVE_CHEEVOS


### PR DESCRIPTION
I just noticed that the options for saving core/game overrides were moved in under a new "Configuration Override options" Quick Menu entry. While I think this is good from a UI perspective, it didn't look very good on my slimmed down installation were those original Quick Menu entries have been hidden. Instead of them now being completely hidden, the new "Configuration Override options" appears but when you select it there's no sub-items available (since they're disabled).

This pull request makes it so that the new "Configuration Override options" Quick Menu entry is only shown if at least one of the sub-items is active. I think this makes sense and it certainly looks better for those of us who like to keep the Quick Menu extremely simple and without superfluous items/info.