### PR TITLE
qb: Fix building Qt without pkgconf

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -278,10 +278,10 @@ if [ "$HAVE_QT" != 'no' ] && [ "$MOC_PATH" != 'none' ]; then
    check_pkgconf QT5WIDGETS Qt5Widgets 5.2
    #check_pkgconf QT5WEBENGINE Qt5WebEngine 5.4
 
-   check_val '' QT5CORE -lQt5Core QT5CORE
-   check_val '' QT5GUI -lQt5Gui QT5GUI
-   check_val '' QT5WIDGETS -lQt5Widgets QT5WIDGETS
-   #check_val '' QT5WEBENGINE -lQt5WebEngine QT5WEBENGINE
+   check_val '' QT5CORE -lQt5Core 'qt5 qt5/QtCore'
+   check_val '' QT5GUI -lQt5Gui 'qt5 qt5/QtGui'
+   check_val '' QT5WIDGETS -lQt5Widgets 'qt5 qt5/QtWidgets'
+   #check_val '' QT5WEBENGINE -lQt5WebEngine 'qt5 qt5/QtWebEngine'
 
    if [ "$HAVE_QT5CORE" = "no" ] || [ "$HAVE_QT5GUI" = "no" ] || [ "$HAVE_QT5WIDGETS" = "no" ]; then
       die : 'Notice: Not building Qt support, required libraries were not found.'

--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -173,7 +173,7 @@ check_switch() # $1 = language  $2 = HAVE_$2  $3 = switch  $4 = critical error m
 	}
 }
 
-check_val() # $1 = language  $2 = HAVE_$2  $3 = lib  $4 = include directory [checked only if non-empty]
+check_val() # $1 = language  $2 = HAVE_$2  $3 = lib  $4 = include directories [checked only if non-empty]
 {	tmpval="$(eval "printf %s \"\$HAVE_$2\"")"
 	oldval="$(eval "printf %s \"\$TMP_$2\"")"
 	if [ "$tmpval" = 'no' ] && [ "$oldval" != 'no' ]; then
@@ -183,9 +183,19 @@ check_val() # $1 = language  $2 = HAVE_$2  $3 = lib  $4 = include directory [che
 		if [ "${4:-}" ] && [ "$answer" = 'yes' ]; then
 			val="$2"
 			include="$4"
+			tmpinc=""
 			eval "set -- $INCLUDES"
 			for dir do
-				[ -d "/$dir/$include" ] && { eval "${val}_CFLAGS=\"-I/$dir/$include\""; break; }
+				eval "set -- $include"
+				for inc do
+					if [ -d "/$dir/$inc" ]; then
+						tmpinc="${tmpinc} -I/$dir/$inc"
+					else
+						tmpinc=""
+						break
+					fi
+				done
+				[ "${tmpinc}" ] && { eval "${val}_CFLAGS=\"${tmpinc#${tmpinc%%[! ]*}}\""; break; }
 			done
 			[ -z "$(eval "printf %s \"\${${val}_CFLAGS}\"")" ] && eval "HAVE_$val=no"
 		fi


### PR DESCRIPTION
## Description

When building without a pkg-config implementation or with PKG_CONF_PATH=none Qt support will be disabled because the check_val function is not correctly being used.

The $4 argument is the relative include directory that needs to be checked. Correcting this exposes the new issue that two include directories need to be checked while check_val only supports one.

So check_val now supports checking 1 or more include directories and Qt5 support builds fine without pkg-config now.

## Related Issues

Qt support is not built with.
```
PKG_CONF_PATH=none ./configure
make
```

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/6668

## Reviewers

@twinaphex @bparker06 
