### PR TITLE
Small Bugfix to not trigger savestate code

### DIFF
--- a/command.c
+++ b/command.c
@@ -1862,7 +1862,7 @@ bool command_event(enum event_command cmd, void *data)
 #if HAVE_NETWORKING
          netplay_driver_ctl(RARCH_NETPLAY_CTL_RESET, NULL);
 #endif
-         return command_event_main_state(cmd);
+         break;
       case CMD_EVENT_SAVE_STATE:
          {
             settings_t *settings      = config_get_ptr();


### PR DESCRIPTION
Just a small bugfix to make the Reset command no longer trigger the savestate system.