### PR TITLE
(Vita/PSP) Use proper button labels, fix inverted R-Stick Y axis

### DIFF
--- a/input/input_autodetect_builtin.c
+++ b/input/input_autodetect_builtin.c
@@ -153,30 +153,30 @@ DECL_AXIS(r_y_minus, +3)
 #endif
 
 #define PSPINPUT_DEFAULT_BINDS \
-DECL_BTN(a, 8) \
-DECL_BTN(b, 0) \
-DECL_BTN(x, 9) \
-DECL_BTN(y, 1) \
-DECL_BTN(start, 3) \
-DECL_BTN(select, 2) \
-DECL_BTN(up, 4) \
-DECL_BTN(down, 5) \
-DECL_BTN(left, 6) \
-DECL_BTN(right, 7) \
-DECL_BTN(l, 10) \
-DECL_BTN(r, 11) \
-DECL_BTN(l2, 12) \
-DECL_BTN(r2, 13) \
-DECL_BTN(l3, 14) \
-DECL_BTN(r3, 15) \
-DECL_AXIS(l_x_plus,  +0) \
-DECL_AXIS(l_x_minus, -0) \
-DECL_AXIS(l_y_plus,  +1) \
-DECL_AXIS(l_y_minus, -1) \
-DECL_AXIS(r_x_plus,  +2) \
-DECL_AXIS(r_x_minus, -2) \
-DECL_AXIS(r_y_plus,  -3) \
-DECL_AXIS(r_y_minus, +3)
+DECL_BTN_EX(a, 8, "Circle") \
+DECL_BTN_EX(b, 0, "Cross") \
+DECL_BTN_EX(x, 9, "Triangle") \
+DECL_BTN_EX(y, 1, "Square") \
+DECL_BTN_EX(start, 3, "Start") \
+DECL_BTN_EX(select, 2, "Select") \
+DECL_BTN_EX(up, 4, "D-Pad up") \
+DECL_BTN_EX(down, 5, "D-Pad down") \
+DECL_BTN_EX(left, 6, "D-Pad left") \
+DECL_BTN_EX(right, 7, "D-Pad right") \
+DECL_BTN_EX(l, 10, "L1") \
+DECL_BTN_EX(r, 11, "R1") \
+DECL_BTN_EX(l2, 12, "L2") \
+DECL_BTN_EX(r2, 13, "R2") \
+DECL_BTN_EX(l3, 14, "L3") \
+DECL_BTN_EX(r3, 15, "R3") \
+DECL_AXIS_EX(l_x_plus,  +0, "L-Stick right") \
+DECL_AXIS_EX(l_x_minus, -0, "L-Stick left") \
+DECL_AXIS_EX(l_y_plus,  +1, "L-Stick down") \
+DECL_AXIS_EX(l_y_minus, -1, "L-Stick up") \
+DECL_AXIS_EX(r_x_plus,  +2, "R-Stick right") \
+DECL_AXIS_EX(r_x_minus, -2, "R-Stick left") \
+DECL_AXIS_EX(r_y_plus,  +3, "R-Stick down") \
+DECL_AXIS_EX(r_y_minus, -3, "R-Stick up")
 
 #define CTRINPUT_DEFAULT_BINDS \
 DECL_BTN(a, 8) \


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises


## Description

- The Vita and PSP were missing proper button labels in the Input dialogs. The controller was correctly identified for example as "Vita controller #1," but in the input remapping dialogs, the buttons were just listed as Auto: 1, Auto: 2, Auto: 3 etc.

- In addition, on Vita and PSP, the right analog y axis was inverted (tested with Dosbox and PCSX-Rearmed). This inversion was also obvious from the source code, as the sign of axis 3 and only axis 3 was flipped compared to the other axes.

Both these issues are fixed with this PR

## Related Issues

none.

## Related Pull Requests

none.

## Reviewers

not neccessary. Simple fix.