### PR TITLE
(GX) Changes to gx_gfx

### DIFF
--- a/gfx/drivers/gx_gfx.c
+++ b/gfx/drivers/gx_gfx.c
@@ -435,7 +435,7 @@ static void gx_set_video_mode(void *data, unsigned fbWidth, unsigned lines,
    for (i = 0; i < 12; i++)
       gx_mode.sample_pattern[i][0] = gx_mode.sample_pattern[i][1] = 6;
 
-   if (modetype == VI_INTERLACE)
+   if (modetype != VI_NON_INTERLACE && settings->bools.video_vfilter)
    {
       gx_mode.vfilter[0] = 8;
       gx_mode.vfilter[1] = 8;
@@ -485,9 +485,7 @@ static void gx_set_video_mode(void *data, unsigned fbWidth, unsigned lines,
    GX_SetDispCopyDst((u16)xfbWidth, (u16)xfbHeight);
 
    GX_SetCopyFilter(gx_mode.aa, gx_mode.sample_pattern,
-         (gx_mode.xfbMode == VI_XFBMODE_SF)
-         ? GX_FALSE : settings->bools.video_vfilter,
-         gx_mode.vfilter);
+         GX_TRUE, gx_mode.vfilter);
    GXColor color = { 0, 0, 0, 0xff };
    GX_SetCopyClear(color, GX_MAX_Z24);
    GX_SetFieldMode(gx_mode.field_rendering,
@@ -1596,8 +1594,11 @@ static bool gx_frame(void *data, const void *frame,
 #endif
 
    _CPU_ISR_Disable(level);
-   if (referenceRetraceCount > retraceCount)
-      VIDEO_WaitVSync();
+   if (referenceRetraceCount > retraceCount) {
+      if(g_vsync) {
+         VIDEO_WaitVSync();
+      }
+   }
    referenceRetraceCount = retraceCount;
    _CPU_ISR_Restore(level);
 


### PR DESCRIPTION
This changes the deflicker setting to work in 480p or higher, and always enables vfilter so that the user can easily change brightness. Not so useful but makes more sense.

Regarding this 86f7972aa8af0d2f20b2775e49f0e89a8c918e51, these changes come from endrift, I ported them to RA because of the aforementioned choppiness. However the current changes make it so disabling vsync doesn't work, so this should now work.

The dropped frames seemed to happen in any core randomly, but in the pce-fast core it was extremely easy to reproduce in the Asuka 120% main menu, I added the changes and the dropped frames stopped.