### PR TITLE
Fix full-screen mode change breaking Secondary Core's environment variables

### DIFF
--- a/managers/core_option_manager.c
+++ b/managers/core_option_manager.c
@@ -135,7 +135,7 @@ void core_option_manager_get(core_option_manager_t *opt, void *data)
 #ifdef HAVE_RUNAHEAD
    if (opt->updated)
    {
-      secondary_core_set_variable_update(true);
+      secondary_core_set_variable_update();
    }
 #endif
 

--- a/managers/core_option_manager.c
+++ b/managers/core_option_manager.c
@@ -29,6 +29,10 @@
 
 #include "../verbosity.h"
 
+#ifdef HAVE_RUNAHEAD
+#include "../runahead/secondary_core.h"
+#endif
+
 static bool core_option_manager_parse_variable(
       core_option_manager_t *opt, size_t idx,
       const struct retro_variable *var)
@@ -127,6 +131,13 @@ void core_option_manager_get(core_option_manager_t *opt, void *data)
 
    if (!opt)
       return;
+
+#ifdef HAVE_RUNAHEAD
+   if (opt->updated)
+   {
+      secondary_core_set_variable_update(true);
+   }
+#endif
 
    opt->updated = false;
 

--- a/runahead/run_ahead.c
+++ b/runahead/run_ahead.c
@@ -116,7 +116,6 @@ static void remove_hooks(void)
       current_core.retro_unload_game = originalRetroUnload;
       originalRetroUnload            = NULL;
    }
-   current_core.retro_set_environment(rarch_environment_cb);
    remove_input_state_hook();
 }
 
@@ -139,18 +138,6 @@ static void deinit_hook(void)
       current_core.retro_deinit();
 }
 
-static bool env_hook(unsigned cmd, void *data)
-{
-   bool result = rarch_environment_cb(cmd, data);
-   if (cmd == RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE && result)
-   {
-      bool *bool_p = (bool*)data;
-      if (*bool_p == true)
-         secondary_core_set_variable_update();
-   }
-   return result;
-}
-
 static void add_hooks(void)
 {
    if (!originalRetroDeinit)
@@ -164,7 +151,6 @@ static void add_hooks(void)
       originalRetroUnload = current_core.retro_unload_game;
       current_core.retro_unload_game = unload_hook;
    }
-   current_core.retro_set_environment(env_hook);
    add_input_state_hook();
 }
 

--- a/runahead/secondary_core.c
+++ b/runahead/secondary_core.c
@@ -278,12 +278,19 @@ static bool has_variable_update;
 static bool rarch_environment_secondary_core_hook(unsigned cmd, void *data)
 {
    bool result = rarch_environment_cb(cmd, data);
-   if (cmd == RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE && has_variable_update)
+   if (has_variable_update)
    {
-      bool *bool_p = (bool*)data;
-      *bool_p = true;
-      has_variable_update = false;
-      return true;
+      if (cmd == RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE)
+      {
+         bool *bool_p = (bool*)data;
+         *bool_p = true;
+         has_variable_update = false;
+         return true;
+      }
+      else if (cmd == RETRO_ENVIRONMENT_GET_VARIABLE)
+      {
+         has_variable_update = false;
+      }
    }
    return result;
 }


### PR DESCRIPTION
Fix full-screen mode change breaking Secondary Core's environment variables

* RunAhead: Remove Environment Hook from primary core
* Modify core option manager to trigger setting the secondary core's dirty environment flag
* RunAhead: Make secondary core reset dirty flag after `RETRO_ENVIRONMENT_GET_VARIABLE` command

I didn't want the RunAhead feature becoming too intrusive into other parts of the code, however, the function `libretro_get_environment_info` gets called every time you toggle fullscreen, and this resets the environment callback.  So the environment hook system I was using fails.

Either we change how callbacks work, and let there be proper hook chains, and fix `libretro_get_environment_info`, or we just patch the code for reading environment variables.