### PR TITLE
Fix the way offsets are calculated for keyboard remapping

### DIFF
--- a/menu/cbs/menu_cbs_get_value.c
+++ b/menu/cbs/menu_cbs_get_value.c
@@ -642,22 +642,20 @@ static void menu_action_setting_disp_set_label_input_desc_kbd(
    char *s2, size_t len2)
 {
    char desc[PATH_MAX_LENGTH];
-   unsigned key_id, id;
+   unsigned key_id, btn_idx;
    unsigned remap_id;
-   unsigned offset = 0;
+   unsigned user_idx = 0;
 
    settings_t *settings = config_get_ptr();
 
    if (!settings)
       return;
 
-   offset = type / ((MENU_SETTINGS_INPUT_DESC_KBD_END - 
-      (MENU_SETTINGS_INPUT_DESC_KBD_END - 
-      MENU_SETTINGS_INPUT_DESC_KBD_BEGIN))) - 1;
+   user_idx = (type - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN) / RARCH_FIRST_CUSTOM_BIND;
+   btn_idx  = (type - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN) - RARCH_FIRST_CUSTOM_BIND * user_idx;
 
-   id = (type / (offset + 1)) - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN;
    remap_id =
-      settings->uints.input_keymapper_ids[offset][id];
+      settings->uints.input_keymapper_ids[user_idx][btn_idx];
 
    for (key_id = 0; key_id < RARCH_MAX_KEYS - 1; key_id++)
    {

--- a/menu/cbs/menu_cbs_left.c
+++ b/menu/cbs/menu_cbs_left.c
@@ -396,20 +396,17 @@ static int action_left_input_desc_kbd(unsigned type, const char *label,
    bool wraparound)
 {
    unsigned remap_id;
-   unsigned key_id, id, offset;
+   unsigned key_id, user_idx, btn_idx;
    settings_t *settings = config_get_ptr();
 
    if (!settings)
       return 0;
 
-   offset = type / ((MENU_SETTINGS_INPUT_DESC_KBD_END - 
-      (MENU_SETTINGS_INPUT_DESC_KBD_END - 
-      MENU_SETTINGS_INPUT_DESC_KBD_BEGIN))) - 1;
-
-   id = (type / (offset + 1)) - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN;
+   user_idx = (type - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN) / RARCH_FIRST_CUSTOM_BIND;
+   btn_idx  = (type - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN) - RARCH_FIRST_CUSTOM_BIND * user_idx;
 
    remap_id =
-      settings->uints.input_keymapper_ids[offset][id];
+      settings->uints.input_keymapper_ids[user_idx][btn_idx];
 
    for (key_id = 0; key_id < RARCH_MAX_KEYS - 1; key_id++)
    {
@@ -422,7 +419,7 @@ static int action_left_input_desc_kbd(unsigned type, const char *label,
    else
       key_id = (RARCH_MAX_KEYS - 1) + MENU_SETTINGS_INPUT_DESC_KBD_BEGIN;
 
-   settings->uints.input_keymapper_ids[offset][id] = key_descriptors[key_id].key;
+   settings->uints.input_keymapper_ids[user_idx][btn_idx] = key_descriptors[key_id].key;
 
    return 0;
 }

--- a/menu/cbs/menu_cbs_right.c
+++ b/menu/cbs/menu_cbs_right.c
@@ -103,21 +103,18 @@ int action_right_cheat(unsigned type, const char *label,
 int action_right_input_desc_kbd(unsigned type, const char *label,
       bool wraparound)
 {
-   unsigned key_id, id, offset;
+   unsigned key_id, user_idx, btn_idx;
    unsigned remap_id;
    settings_t *settings = config_get_ptr();
 
    if (!settings)
       return 0;
 
-   offset = type / ((MENU_SETTINGS_INPUT_DESC_KBD_END -
-      (MENU_SETTINGS_INPUT_DESC_KBD_END -
-      MENU_SETTINGS_INPUT_DESC_KBD_BEGIN))) - 1;
-
-   id = (type / (offset + 1)) - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN;
+   user_idx = (type - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN) / RARCH_FIRST_CUSTOM_BIND;
+   btn_idx  = (type - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN) - RARCH_FIRST_CUSTOM_BIND * user_idx;
 
    remap_id =
-      settings->uints.input_keymapper_ids[offset][id];
+      settings->uints.input_keymapper_ids[user_idx][btn_idx];
 
    for (key_id = 0; key_id < RARCH_MAX_KEYS - 1; key_id++)
    {
@@ -130,7 +127,7 @@ int action_right_input_desc_kbd(unsigned type, const char *label,
    else
       key_id = 0;
 
-   settings->uints.input_keymapper_ids[offset][id] = key_descriptors[key_id].key;
+   settings->uints.input_keymapper_ids[user_idx][btn_idx] = key_descriptors[key_id].key;
 
    return 0;
 }

--- a/menu/cbs/menu_cbs_sublabel.c
+++ b/menu/cbs/menu_cbs_sublabel.c
@@ -462,15 +462,13 @@ static int action_bind_sublabel_remap_kbd_sublabel(
       const char *label, const char *path,
       char *s, size_t len)
 {
-   unsigned offset = type / ((MENU_SETTINGS_INPUT_DESC_KBD_END - 
-      (MENU_SETTINGS_INPUT_DESC_KBD_END - 
-      MENU_SETTINGS_INPUT_DESC_KBD_BEGIN))) - 1;
+   unsigned user_idx = (type - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN) / RARCH_FIRST_CUSTOM_BIND;
 
-   snprintf(s, len, "User #%d: %s", offset + 1,
-      input_config_get_device_display_name(offset) ? 
-      input_config_get_device_display_name(offset) : 
-      (input_config_get_device_name(offset) ? 
-      input_config_get_device_name(offset) : "N/A"));
+   snprintf(s, len, "User #%d: %s", user_idx + 1,
+      input_config_get_device_display_name(user_idx) ? 
+      input_config_get_device_display_name(user_idx) : 
+      (input_config_get_device_name(user_idx) ? 
+      input_config_get_device_name(user_idx) : "N/A"));
    return 0;
 }
 

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -3298,7 +3298,8 @@ static int menu_displaylist_parse_options_remappings(
 
                menu_entries_append_enum(info->list, descriptor, "",
                      MSG_UNKNOWN,
-                     (MENU_SETTINGS_INPUT_DESC_KBD_BEGIN  +  retro_id) * (p + 1), 0, 0);
+                     MENU_SETTINGS_INPUT_DESC_KBD_BEGIN +
+                     (p * RARCH_FIRST_CUSTOM_BIND) + retro_id, 0, 0);
             }
          }
       }


### PR DESCRIPTION
## Description

This fixes a problem when trying to map the Keyboard to more than 2 users. The way offsets were calculated/applied, made the final `type` / identifiers go beyond `MENU_SETTINGS_INPUT_DESC_KBD_END`.

Initially they were like: `(MENU_SETTINGS_INPUT_DESC_KBD_BEGIN  +  retro_id) * (p + 1)`, where `retro_id` is the identifier of one of the buttons being mapped (from 0 to 15), and `p` is the number of player.

In this PR it has changed to follow the same approach as other mappers: `MENU_SETTINGS_INPUT_DESC_KBD_BEGIN + (p * RARCH_FIRST_CUSTOM_BIND) + retro_id`

Changing this also required to fix the way `retro_id` and `p` are obtained back from those identifiers.

## Related Issues

I found this issue while implementing https://github.com/libretro/dosbox-libretro/pull/85 (original issue: https://github.com/libretro/dosbox-libretro/issues/57)

## Reviewers

@twinaphex @fr500 since I see you're the most active devs in these files lately 😅 
