### PR TITLE
Fix the reset command not closing the menu

### DIFF
--- a/command.c
+++ b/command.c
@@ -1862,7 +1862,7 @@ bool command_event(enum event_command cmd, void *data)
 #if HAVE_NETWORKING
          netplay_driver_ctl(RARCH_NETPLAY_CTL_RESET, NULL);
 #endif
-         break;
+         return false;
       case CMD_EVENT_SAVE_STATE:
          {
             settings_t *settings      = config_get_ptr();


### PR DESCRIPTION
Replaced the `break` with `return false` so it closes the menu.

Issue #6788