### PR TITLE
Disable gl hard sync in menu

### DIFF
--- a/gfx/drivers/gl.c
+++ b/gfx/drivers/gl.c
@@ -1202,8 +1202,11 @@ static bool gl_frame(void *data, const void *frame,
 
    video_info->cb_swap_buffers(video_info->context_data, video_info);
 
-   /* check if we are fast forwarding, if we are ignore hard sync */
-   if (gl->have_sync && video_info->hard_sync && !video_info->input_driver_nonblock_state)
+   /* check if we are fast forwarding or in menu, if we are ignore hard sync */
+   if (  gl->have_sync
+         && video_info->hard_sync
+         && !video_info->input_driver_nonblock_state
+         && !gl->menu_texture_enable)
    {
       glClear(GL_COLOR_BUFFER_BIT);
 


### PR DESCRIPTION
Hard Sync will be disabled when the menu is ON.

CPU usage was always quite high in the menu, even without anything loaded, no core, no menu shader.
Here with an nvidia 770, the CPU usage goes from 15-20% to 2-4% now that hard sync is disabled.
It only happens in GL, other video drivers are in the 2-4% range too.

There's an additional setting that can trigger even higher cpu usage with GL, that's Settings->Frame Throttle Maximum Run speed.
I have it at the default 0 for that test, but as soon as I change it to something above 1 the CPU usage skyrocket to 100% and can't go down until I quit and restart RA completely. (can be random)