### PR TITLE
Update the 3ds build system to match new core format

### DIFF
--- a/Makefile.ctr
+++ b/Makefile.ctr
@@ -5,7 +5,7 @@ DEBUG                   = 0
 GRIFFIN_BUILD           = 1
 WHOLE_ARCHIVE_LINK      = 0
 BUILD_3DSX              = 1
-BUILD_3DS               = 1
+BUILD_3DS               = 0
 BUILD_CIA               = 1
 LIBCTRU_NO_DEPRECATION  = 1
 
@@ -168,7 +168,7 @@ endif
 
 all: $(TARGET)
 
-$(TARGET): $(TARGET_3DSX) $(TARGET_3DS) $(TARGET_CIA) $(TARGET).core
+$(TARGET): $(TARGET_3DSX) $(TARGET_3DS) $(TARGET_CIA)
 $(TARGET).3dsx: $(TARGET).elf
 $(TARGET).elf: $(OBJ) libretro_ctr.a
 
@@ -261,9 +261,6 @@ $(TARGET).3ds: $(TARGET).elf $(TARGET).bnr $(TARGET).icn $(APP_RSF)
 $(TARGET).cia: $(TARGET).elf $(TARGET).bnr $(TARGET).icn $(APP_RSF)
 	$(MAKEROM) -f cia -o $@ $(MAKEROM_ARGS_COMMON) -DAPP_ENCRYPTED=false
 
-$(TARGET).core: $(TARGET).elf
-	echo $(APP_UNIQUE_ID) > $(TARGET).core
-
 
 clean:
 	rm -f $(OBJ)
@@ -271,7 +268,6 @@ clean:
 	rm -f $(TARGET).elf
 	rm -f $(TARGET).3ds
 	rm -f $(TARGET).cia
-	rm -f $(TARGET).core
 	rm -f $(TARGET).smdh
 	rm -f $(TARGET).bnr
 	rm -f $(TARGET).icn

--- a/Makefile.ctr.salamander
+++ b/Makefile.ctr.salamander
@@ -189,7 +189,7 @@ ifeq ($(APP_BIG_TEXT_SECTION), 1)
 else
 	rm -f $(TARGET).xml
 endif
-	-3dsxtool $< $@ $(_3DSXFLAGS)
+	$(DEVKITARM)/bin/3dsxtool $< $@ $(_3DSXFLAGS)
 
 $(TARGET).elf: ctr/3dsx_custom_crt0.o
 	$(LD) $(LDFLAGS) $(OBJ) $(LIBDIRS) $(LIBS) -o $@

--- a/Makefile.ctr.salamander
+++ b/Makefile.ctr.salamander
@@ -2,7 +2,7 @@ TARGET := retroarch_3ds_salamander
 LIBRETRO =
 
 DEBUG                   = 0
-BUILD_3DSX              = 0
+BUILD_3DSX              = 1
 BUILD_3DS               = 0
 BUILD_CIA               = 1
 

--- a/dist-scripts/dist-cores.sh
+++ b/dist-scripts/dist-cores.sh
@@ -140,9 +140,9 @@ if [ $SALAMANDER = "yes" ]; then
    fi
    if [ $PLATFORM = "ctr" ] ; then
    mv -f ../retroarch_3ds_salamander.cia ../pkg/${platform}/build/cia/retroarch_3ds.cia
-   mkdir -p ../pkg/${platform}/build/3dsx/RetroArch
-   mv -f ../retroarch_3ds_salamander.3dsx ../pkg/${platform}/build/3dsx/RetroArch/RetroArch.3dsx
-   mv -f ../retroarch_3ds_salamander.smdh ../pkg/${platform}/build/3dsx/RetroArch/RetroArch.smdh
+   mkdir -p ../pkg/${platform}/build/3dsx/3ds/RetroArch
+   mv -f ../retroarch_3ds_salamander.3dsx ../pkg/${platform}/build/3dsx/3ds/RetroArch/RetroArch.3dsx
+   mv -f ../retroarch_3ds_salamander.smdh ../pkg/${platform}/build/3dsx/3ds/RetroArch/RetroArch.smdh
    # the .3ds port cant use salamander since you can only have one ROM on a cartridge at once
    make -C ../ -f Makefile.${platform}.salamander clean || exit 1
    fi

--- a/dist-scripts/dist-cores.sh
+++ b/dist-scripts/dist-cores.sh
@@ -247,7 +247,7 @@ for f in `ls -v *_${platform}.${EXT}`; do
          fi
    elif [ $PLATFORM = "ctr" ] ; then
       mv -f ../retroarch_3ds.cia ../pkg/${platform}/build/cia/${name}_libretro.cia
-	  mv -f ../retroarch_3ds.3dsx ../pkg/${platform}/build/3dsx/${name}_libretro.3dsx
+      mv -f ../retroarch_3ds.3dsx ../pkg/${platform}/build/3dsx/${name}_libretro.3dsx
       mv -f ../retroarch_3ds.3ds ../pkg/${platform}/build/rom/${name}_libretro.3ds
    elif [ $PLATFORM = "unix" ] ; then
       mv -f ../retroarch ../pkg/${platform}/${name}_libretro.elf

--- a/dist-scripts/dist-cores.sh
+++ b/dist-scripts/dist-cores.sh
@@ -40,10 +40,9 @@ elif [ $PLATFORM = "ctr" ] ; then
 platform=ctr
 SALAMANDER=yes
 EXT=a
-mkdir -p ../pkg/3ds/cia
-mkdir -p ../pkg/3ds/rom
-mkdir -p ../pkg/3ds/3ds
-mkdir -p ../pkg/3ds/retroarch/cores
+mkdir -p ../pkg/${platform}/build/cia
+mkdir -p ../pkg/${platform}/build/3dsx
+mkdir -p ../pkg/${platform}/build/rom
 
 # Emscripten
 elif [ $PLATFORM = "emscripten" ] ; then
@@ -140,8 +139,12 @@ if [ $SALAMANDER = "yes" ]; then
      make -C ../ -f Makefile.${platform}.salamander clean || exit 1
    fi
    if [ $PLATFORM = "ctr" ] ; then
-   mv -f ../retroarch_3ds_salamander.cia ../pkg/3ds/cia/retroarch_3ds.cia
-   make -C ../ -f Makefile.${platform} clean || exit 1
+   mv -f ../retroarch_3ds_salamander.cia ../pkg/${platform}/build/cia/retroarch_3ds.cia
+   mkdir -p ../pkg/${platform}/build/3dsx/RetroArch
+   mv -f ../retroarch_3ds_salamander.3dsx ../pkg/${platform}/build/3dsx/RetroArch/RetroArch.3dsx
+   mv -f ../retroarch_3ds_salamander.smdh ../pkg/${platform}/build/3dsx/RetroArch/RetroArch.smdh
+   # the .3ds port cant use salamander since you can only have one ROM on a cartridge at once
+   make -C ../ -f Makefile.${platform}.salamander clean || exit 1
    fi
    if [ $PLATFORM = "wii" ] ; then
    mv -f ../retroarch-salamander_wii.dol ../pkg/${platform}/boot.dol
@@ -243,13 +246,9 @@ for f in `ls -v *_${platform}.${EXT}`; do
             cp -fv ../../dist/info/"${name}_libretro.info" ../pkg/${platform}/retroarch.vpk/vpk/info/"${name}_libretro.info"
          fi
    elif [ $PLATFORM = "ctr" ] ; then
-      mv -f ../retroarch_3ds.cia ../pkg/3ds/cia/${name}_libretro.cia
-      mv -f ../retroarch_3ds.3ds ../pkg/3ds/rom/${name}_libretro.3ds
-      mv -f ../retroarch_3ds.core ../pkg/3ds/retroarch/cores/${name}_libretro.core
-      mkdir -p ../pkg/3ds/3ds/${name}_libretro
-      mv -f ../retroarch_3ds.3dsx ../pkg/3ds/3ds/${name}_libretro/${name}_libretro.3dsx
-      mv -f ../retroarch_3ds.smdh ../pkg/3ds/3ds/${name}_libretro/${name}_libretro.smdh
-      mv -f ../retroarch_3ds.xml  ../pkg/3ds/3ds/${name}_libretro/${name}_libretro.xml 2> /dev/null
+      mv -f ../retroarch_3ds.cia ../pkg/${platform}/build/cia/${name}_libretro.cia
+	  mv -f ../retroarch_3ds.3dsx ../pkg/${platform}/build/3dsx/${name}_libretro.3dsx
+      mv -f ../retroarch_3ds.3ds ../pkg/${platform}/build/rom/${name}_libretro.3ds
    elif [ $PLATFORM = "unix" ] ; then
       mv -f ../retroarch ../pkg/${platform}/${name}_libretro.elf
    elif [ $PLATFORM = "ngc" ] ; then

--- a/frontend/drivers/platform_ctr.c
+++ b/frontend/drivers/platform_ctr.c
@@ -185,7 +185,7 @@ static void frontend_ctr_exec(const char* path, bool should_load_game)
    char game_path[PATH_MAX];
    const char* arg_data[3];
    errorConf error_dialog;
-   char error_string[PATH_MAX + 200];
+   char error_string[200 + PATH_MAX];
    int args = 0;
    int error = 0;
 
@@ -251,7 +251,7 @@ static void frontend_ctr_exec(const char* path, bool should_load_game)
       }
 
       errorInit(&error_dialog, ERROR_TEXT, CFG_LANGUAGE_EN);
-      sprintf(error_string, "Cant launch core:%s", path);
+      snprintf(error_string, sizeof(error_string), "Cant launch core:%s", path);
       errorText(&error_dialog, error_string);
       errorDisp(&error_dialog);
       exit(0);//couldnt launch new core, but context is corrupt so we have to quit


### PR DESCRIPTION
These files also need to be replaced in the buildbot repos:
[BuildBotFiles.zip](https://github.com/libretro/RetroArch/files/2019742/BuildBotFiles.zip)


RetroArch and salamander compile fine but I cant test the buildbot portions since I dont have a buildbot.