### PR TITLE
Fix null pointer read in action_bind_sublabel_subsystem_add

### DIFF
--- a/menu/cbs/menu_cbs_sublabel.c
+++ b/menu/cbs/menu_cbs_sublabel.c
@@ -448,7 +448,7 @@ static int action_bind_sublabel_subsystem_add(
       char *s, size_t len)
 {
    rarch_system_info_t *system                  = runloop_get_system_info();
-   const struct retro_subsystem_info *subsystem = system ?
+   const struct retro_subsystem_info *subsystem = (system && system->subsystem.data) ?
 	   system->subsystem.data + (type - MENU_SETTINGS_SUBSYSTEM_ADD) : NULL;
 
    if (subsystem && content_get_subsystem_rom_id() < subsystem->num_roms)


### PR DESCRIPTION
The function `action_bind_sublabel_subsystem_add` can read a null pointer + 0x20 if `system->subsystem` is null, this change fixes that.

A way to trigger the bug:
* Run Final Burn Alpha core
* Run King of Fighters 2002
* Close Content
