### PR TITLE
Fix a calloc(0) which led to uninitialized data being used later on.

### DIFF
--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -796,8 +796,11 @@ static bool content_file_init(
          !content_file_init_set_attribs(content, special, content_ctx, error_string))
       return false;
 
-   info                   = (struct retro_game_info*)
-      calloc(content->size, sizeof(*info));
+   if (content->size > 0)
+   {
+      info = (struct retro_game_info*)
+         calloc(content->size, sizeof(*info));
+   }
 
    if (info)
    {

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -797,10 +797,8 @@ static bool content_file_init(
       return false;
 
    if (content->size > 0)
-   {
-      info = (struct retro_game_info*)
+      info                   = (struct retro_game_info*)
          calloc(content->size, sizeof(*info));
-   }
 
    if (info)
    {


### PR DESCRIPTION
Managed to trigger a crash in RetroArch by executing "retroarch -L &lt;core&gt;" with no content specified.

This led to `calloc` getting called with a size of 0, and it would return a non-null pointer that pointed to garbage data.  So the load content functions were getting called with garbage data, and runahead's `set_load_content_info` crashed after receiving invalid data.