### PR TITLE
Fix out of bounds access in dirty_input code

### DIFF
--- a/runahead/dirty_input.c
+++ b/runahead/dirty_input.c
@@ -59,8 +59,11 @@ static void input_state_set_last(unsigned port, unsigned device,
    for (i = 0; i < (unsigned)input_state_list->size; i++)
    {
       element = (InputListElement*)input_state_list->data[i];
-      if (     element->port == port 
-            && element->device == device && element->index == index)
+      if (  (element->port == port )    &&
+            (element->device == device) &&
+            (element->index == index)   &&
+            (id >= 0 && id < (sizeof(element->state) / sizeof(int16_t)))
+         )
       {
          element->state[id] = value;
          return;
@@ -91,7 +94,8 @@ static int16_t input_state_get_last(unsigned port,
 
       if (  (element->port   == port)   && 
             (element->device == device) &&
-            (element->index  == index)
+            (element->index  == index)  &&
+            (id >= 0 && id < (sizeof(element->state) / sizeof(int16_t)))
          )
          return element->state[id];
    }

--- a/runahead/dirty_input.c
+++ b/runahead/dirty_input.c
@@ -59,9 +59,9 @@ static void input_state_set_last(unsigned port, unsigned device,
    for (i = 0; i < (unsigned)input_state_list->size; i++)
    {
       element = (InputListElement*)input_state_list->data[i];
-      if (  (element->port == port )    &&
+      if (  (element->port   == port)   &&
             (element->device == device) &&
-            (element->index == index)   &&
+            (element->index  == index)  &&
             (id >= 0 && id < (sizeof(element->state) / sizeof(int16_t)))
          )
       {


### PR DESCRIPTION
Added bounds checking to the dirty input code.
Only discovered this because Final Burn Alpha was requesting out of bounds id values, such as 255, when the highest is 36.

