### PR TITLE
Add screensaver (idle) inhibition for Wayland driver

### DIFF
--- a/gfx/drivers_context/wayland_ctx.c
+++ b/gfx/drivers_context/wayland_ctx.c
@@ -42,6 +42,10 @@
 #include "../common/gl_common.h"
 #endif
 
+#ifdef HAVE_DBUS
+#include "../common/dbus_common.h"
+#endif
+
 #include "../common/wayland_common.h"
 #include "../../frontend/frontend_driver.h"
 #include "../../input/input_driver.h"
@@ -601,6 +605,11 @@ static void gfx_ctx_wl_destroy_resources(gfx_ctx_wayland_data_t *wl)
 
    wl->width      = 0;
    wl->height     = 0;
+
+#ifdef HAVE_DBUS
+   dbus_screensaver_uninhibit();
+   dbus_close_connection();
+#endif
 }
 
 void flush_wayland_fd(void *data)
@@ -922,6 +931,10 @@ static void *gfx_ctx_wl_init(video_frame_info_t *video_info, void *video_driver)
    wl->cursor.default_cursor = wl_cursor_theme_get_cursor(wl->cursor.theme, "left_ptr");
    flush_wayland_fd(&wl->input);
 
+#ifdef HAVE_DBUS
+   dbus_ensure_connection();
+#endif
+
    return wl;
 
 error:
@@ -1191,6 +1204,11 @@ static bool gfx_ctx_wl_suppress_screensaver(void *data, bool enable)
 {
    (void)data;
    (void)enable;
+
+#ifdef HAVE_DBUS
+   return dbus_suspend_screensaver(enable);
+#endif
+
    return true;
 }
 


### PR DESCRIPTION
The Wayland driver currently has no implementation for gfx_ctx_wl_suppress_screensaver. This adds a Dbus implementation using the same infrastructure used by the X11 driver.

## Related Issues

#6830 