### PR TITLE
(GC/Wii) revert commit 822e2fd

### DIFF
--- a/frontend/drivers/platform_gx.c
+++ b/frontend/drivers/platform_gx.c
@@ -310,9 +310,7 @@ static void frontend_gx_init(void *data)
    __exception_setreload(8);
 #endif
 
-#ifdef HW_RVL
    fatInitDefault();
-#endif
 
 #ifdef HAVE_LOGGER
    devoptab_list[STD_OUT] = &dotab_stdout;


### PR DESCRIPTION
commit 822e2fd broke sd gecko mounting on gamecube, making the gamecube build unusable, reverting it makes it run fine again