### PR TITLE
Fix input when the joypad driver is NULL.

### DIFF
--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -1184,6 +1184,9 @@ void input_get_state_for_port(void *data, unsigned port, input_bits_t *p_new_sta
          BIT256_SET_PTR(p_new_state, i);
    }
 
+   if (!joypad_driver)
+      return;
+
    for (i = 0; i < 2; i++)
    {
       for (j = 0; j < 2; j++)


### PR DESCRIPTION
This is quite possibly the smallest PR I've ever made, and superficially the silliest.

The null input driver doesn't work, because it tries to query the joypad driver, which is NULL, and segfaults. As no one USES the null input driver for obvious reasons, this presumably didn't affect anyone. This fixes the segfault. I want the null input driver for a netplay project using a second instance of RA with no I/O other than net.