### PR TITLE
show cheevos description on RGUI - fixes #6764

### DIFF
--- a/menu/drivers/menu_generic.c
+++ b/menu/drivers/menu_generic.c
@@ -40,7 +40,8 @@ static enum action_iterate_type action_iterate_type(const char *label)
          string_is_equal(label, "help_loading_content") ||
          string_is_equal(label, "help_scanning_content") ||
          string_is_equal(label, "help_change_virtual_gamepad") ||
-         string_is_equal(label, "help_audio_video_troubleshooting")
+         string_is_equal(label, "help_audio_video_troubleshooting") ||
+         string_is_equal(label, "cheevos_description")
          )
       return ITERATE_TYPE_HELP;
    if (


### PR DESCRIPTION
## Description

Nothing big happening here. Just a single line of code that I believe has been forgotten when @twinaphex was getting rid of hashes in `menu_generic.c` in commit 7a3d7e784a52ebbb405caca1ff72383626afaa4d , and since then we are unable to see the Achievement description when using RGUI.

## Related Issues

#6764 


## Reviewers

@twinaphex 