### PR TITLE
(GC) ACTUALLY fix up build

### DIFF
--- a/frontend/drivers/platform_gx.c
+++ b/frontend/drivers/platform_gx.c
@@ -310,9 +310,7 @@ static void frontend_gx_init(void *data)
    __exception_setreload(8);
 #endif
 
-#ifdef HW_RVL
    fatInitDefault();
-#endif
 
 #ifdef HAVE_LOGGER
    devoptab_list[STD_OUT] = &dotab_stdout;

--- a/griffin/griffin.c
+++ b/griffin/griffin.c
@@ -72,7 +72,6 @@ CONSOLE EXTENSIONS
 #endif
 
 #ifdef INTERNAL_LIBOGC
-#ifdef HW_RVL
 #include "../wii/libogc/libfat/cache.c"
 #include "../wii/libogc/libfat/directory.c"
 #include "../wii/libogc/libfat/disc.c"
@@ -83,7 +82,6 @@ CONSOLE EXTENSIONS
 #include "../wii/libogc/libfat/libfat.c"
 #include "../wii/libogc/libfat/lock.c"
 #include "../wii/libogc/libfat/partition.c"
-#endif
 #endif
 
 #endif


### PR DESCRIPTION
in my last PR a few days ago I accidentally had external libogc enabled in my makefile so I did not even realize it produced an error with the internal one, now I commented in the files needed to get it compiled again even with internal libogc, without fatInitDefault on gamecube the gamecube build will not work at all as its needed to mount the only storage device available on it.