### PR TITLE
android: enable sustained performance mode if supported

### DIFF
--- a/pkg/android/phoenix/AndroidManifest.xml
+++ b/pkg/android/phoenix/AndroidManifest.xml
@@ -10,7 +10,7 @@
     <uses-feature android:name="android.hardware.gamepad" android:required="false"/>
     <uses-sdk
         android:minSdkVersion="9"
-        android:targetSdkVersion="23" />
+        android:targetSdkVersion="24" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.INTERNET" />

--- a/pkg/android/phoenix/project.properties
+++ b/pkg/android/phoenix/project.properties
@@ -11,5 +11,5 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-23
+target=android-24
 android.library.reference.1=libs/googleplay

--- a/pkg/android/phoenix/src/com/retroarch/browser/retroactivity/RetroActivityCommon.java
+++ b/pkg/android/phoenix/src/com/retroarch/browser/retroactivity/RetroActivityCommon.java
@@ -1,11 +1,15 @@
 package com.retroarch.browser.retroactivity;
 
 import com.retroarch.browser.preferences.util.UserPreferences;
+import android.annotation.TargetApi;
 import android.content.res.Configuration;
+import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.app.UiModeManager;
 import android.os.BatteryManager;
+import android.os.Build;
+import android.os.PowerManager;
 import android.util.Log;
 
 /**
@@ -26,6 +30,31 @@ public class RetroActivityCommon extends RetroActivityLocation
 	{
       finish();
 	}
+
+  @TargetApi(24)
+  public void setSustainedPerformanceMode(boolean on)
+  {
+    Log.i("RetroActivity", "setting sustained performance mode to " + on);
+    getWindow().setSustainedPerformanceMode(on);
+  }
+
+  public boolean isSustainedPerformanceModeSupported()
+  {
+    boolean supported = false;
+
+    if (Build.VERSION.SDK_INT >= 24)
+    {
+      PowerManager powerManager = (PowerManager)getSystemService(Context.POWER_SERVICE);
+
+      if (powerManager.isSustainedPerformanceModeSupported())
+        supported = true;
+    }
+
+
+    Log.i("RetroActivity", "isSustainedPerformanceModeSupported? " + supported);
+
+    return supported;
+  }
 
   public int getBatteryLevel()
   {

--- a/pkg/android/phoenix/src/com/retroarch/browser/retroactivity/RetroActivityFuture.java
+++ b/pkg/android/phoenix/src/com/retroarch/browser/retroactivity/RetroActivityFuture.java
@@ -4,9 +4,10 @@ import android.view.View;
 import android.view.WindowManager;
 import android.content.Intent;
 import android.content.Context;
+import android.hardware.input.InputManager;
+import android.os.Build;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import android.hardware.input.InputManager;
 
 public final class RetroActivityFuture extends RetroActivityCamera {
 
@@ -17,7 +18,12 @@ public final class RetroActivityFuture extends RetroActivityCamera {
 	public void onResume() {
 		super.onResume();
 
-		if (android.os.Build.VERSION.SDK_INT >= 19) {
+		if (Build.VERSION.SDK_INT >= 24) {
+			if (isSustainedPerformanceModeSupported())
+				setSustainedPerformanceMode(true);
+		}
+
+		if (Build.VERSION.SDK_INT >= 19) {
 			// Immersive mode
 
 			// Constants from API > 14


### PR DESCRIPTION
Fixes #5316.

I'm assuming this is something we do want to have enabled all the time? I know PPSSPP makes it an option, but do we really need that? If so I can add it (and let me know the default setting).

Also do note that this bumps the target API from 23 to 24. Would appreciate testing from @fr500 and/or @meepingsnesroms if needed. Unfortunately I'm not sure how to actually test this feature.
