### PR TITLE
freetype: Allow getting OSD Font from Assets Directory

### DIFF
--- a/gfx/drivers_font_renderer/freetype.c
+++ b/gfx/drivers_font_renderer/freetype.c
@@ -24,6 +24,8 @@
 #include <file/file_path.h>
 #include <streams/file_stream.h>
 #include <retro_miscellaneous.h>
+#include <string/stdstring.h>
+#include "../../configuration.h"
 
 #ifdef WIIU
 #include <wiiu/os.h>
@@ -268,6 +270,7 @@ error:
  * but should hopefully work ... */
 
 static const char *font_paths[] = {
+   "assets://pkg/DejaVuSansMono.ttf",
 #if defined(_WIN32)
    "C:\\Windows\\Fonts\\consola.ttf",
    "C:\\Windows\\Fonts\\verdana.ttf",
@@ -295,9 +298,18 @@ static const char *font_renderer_ft_get_default_font(void)
    return "";
 #else
    size_t i;
+   settings_t *settings = config_get_ptr();
+   char asset_path[PATH_MAX_LENGTH];
 
    for (i = 0; i < ARRAY_SIZE(font_paths); i++)
    {
+      /* Check if we are getting the font from the assets directory. */
+      if (string_is_equal(font_paths[i], "assets://pkg/DejaVuSansMono.ttf"))
+      {
+         fill_pathname_join(asset_path, settings->paths.directory_assets, "pkg/DejaVuSansMono.ttf", PATH_MAX_LENGTH);
+         font_paths[i] = asset_path;
+      }
+
       if (filestream_exists(font_paths[i]))
          return font_paths[i];
    }

--- a/gfx/drivers_font_renderer/freetype.c
+++ b/gfx/drivers_font_renderer/freetype.c
@@ -270,6 +270,7 @@ error:
  * but should hopefully work ... */
 
 static const char *font_paths[] = {
+   /* Assets directory OSD Font, @see font_renderer_ft_get_default_font() */
    "assets://pkg/osd-font.ttf",
 #if defined(_WIN32)
    "C:\\Windows\\Fonts\\consola.ttf",

--- a/gfx/drivers_font_renderer/freetype.c
+++ b/gfx/drivers_font_renderer/freetype.c
@@ -270,7 +270,7 @@ error:
  * but should hopefully work ... */
 
 static const char *font_paths[] = {
-   "assets://pkg/DejaVuSansMono.ttf",
+   "assets://pkg/osd-font.ttf",
 #if defined(_WIN32)
    "C:\\Windows\\Fonts\\consola.ttf",
    "C:\\Windows\\Fonts\\verdana.ttf",
@@ -304,9 +304,9 @@ static const char *font_renderer_ft_get_default_font(void)
    for (i = 0; i < ARRAY_SIZE(font_paths); i++)
    {
       /* Check if we are getting the font from the assets directory. */
-      if (string_is_equal(font_paths[i], "assets://pkg/DejaVuSansMono.ttf"))
+      if (string_is_equal(font_paths[i], "assets://pkg/osd-font.ttf"))
       {
-         fill_pathname_join(asset_path, settings->paths.directory_assets, "pkg/DejaVuSansMono.ttf", PATH_MAX_LENGTH);
+         fill_pathname_join(asset_path, settings->paths.directory_assets, "pkg/osd-font.ttf", PATH_MAX_LENGTH);
          font_paths[i] = asset_path;
       }
 


### PR DESCRIPTION
## Description

This allows the OSD Font to be loaded from the assets directory. Useful for platforms that don't have a nice looking on-screen-display font available ([Flatpak for example](https://github.com/flathub/org.libretro.RetroArch/issues/51)). See https://github.com/libretro/retroarch-assets/pull/219 for where the OSD Font is added to retroarch-assets.

## Related Issues

- https://github.com/libretro/RetroArch/issues/5678
- https://github.com/libretro/RetroArch/issues/5755

## Related Pull Requests

- https://github.com/libretro/retroarch-assets/pull/219
