### PR TITLE
Moved WIN32 message loop from win32_check_window to before runloop_iterate

### DIFF
--- a/frontend/frontend.c
+++ b/frontend/frontend.c
@@ -138,7 +138,12 @@ int rarch_main(int argc, char *argv[], void *data)
    do
    {
       unsigned sleep_ms = 0;
-      int           ret = runloop_iterate(&sleep_ms);
+      int ret;
+      const ui_application_t *application =
+         ui_companion_driver_get_application_ptr();
+      if (application)
+         application->process_events();
+      ret = runloop_iterate(&sleep_ms);
 
       if (ret == 1 && sleep_ms > 0)
          retro_sleep(sleep_ms);

--- a/gfx/common/win32_common.c
+++ b/gfx/common/win32_common.c
@@ -1117,12 +1117,7 @@ void win32_check_window(bool *quit, bool *resize,
       unsigned *width, unsigned *height)
 {
 #if !defined(_XBOX)
-   const ui_application_t *application =
-      ui_companion_driver_get_application_ptr();
-   if (application)
-      application->process_events();
    *quit            = g_win32_quit;
-#endif
 
    if (g_win32_resized)
    {
@@ -1131,6 +1126,7 @@ void win32_check_window(bool *quit, bool *resize,
       *height             = g_win32_resize_height;
       g_win32_resized     = false;
    }
+#endif
 }
 
 bool win32_suppress_screensaver(void *data, bool enable)


### PR DESCRIPTION
Moved the WIN32 message loop call from win32_check_window in to before runloop_iterate.  This allows the GUI code to run code that can destroy the context without triggering crashes due to being inside of another function.

Fixes issue #6943