### PR TITLE
Invalidate `frame_cache_data` pointer to prevent crash if first frame is paused

### DIFF
--- a/core_impl.c
+++ b/core_impl.c
@@ -290,6 +290,8 @@ bool core_load_game(retro_ctx_load_content_info_t *load_info)
    bool contentless = false;
    bool is_inited   = false;
 
+   video_driver_set_cached_frame_ptr(NULL);
+
 #ifdef HAVE_RUNAHEAD
    set_load_content_info(load_info);
    clear_controller_port_map();
@@ -373,12 +375,16 @@ bool core_get_system_av_info(struct retro_system_av_info *av_info)
 
 bool core_reset(void)
 {
+   video_driver_set_cached_frame_ptr(NULL);
+
    current_core.retro_reset();
    return true;
 }
 
 bool core_init(void)
 {
+   video_driver_set_cached_frame_ptr(NULL);
+
    current_core.retro_init();
    current_core.inited          = true;
    return true;
@@ -386,6 +392,8 @@ bool core_init(void)
 
 bool core_unload(void)
 {
+   video_driver_set_cached_frame_ptr(NULL);
+
    current_core.retro_deinit();
    return true;
 }
@@ -396,9 +404,12 @@ bool core_unload_game(void)
    video_driver_free_hw_context();
    audio_driver_stop();
 
+   video_driver_set_cached_frame_ptr(NULL);
+
    current_core.retro_unload_game();
 
    current_core.game_loaded = false;
+
    return true;
 }
 

--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -1595,6 +1595,7 @@ void video_driver_destroy(void)
    video_driver_cache_context_ack = false;
    video_driver_record_gpu_buffer = NULL;
    current_video                  = NULL;
+   video_driver_set_cached_frame_ptr(NULL);
 }
 
 void video_driver_set_cached_frame_ptr(const void *data)
@@ -1779,6 +1780,7 @@ bool video_driver_init(bool *video_is_threaded)
 {
    video_driver_lock_new();
    video_driver_filter_free();
+   video_driver_set_cached_frame_ptr(NULL);
    return video_driver_init_internal(video_is_threaded);
 }
 
@@ -1792,6 +1794,7 @@ void video_driver_free(void)
    video_driver_free_internal();
    video_driver_lock_free();
    video_driver_data = NULL;
+   video_driver_set_cached_frame_ptr(NULL);
 }
 
 void video_driver_monitor_reset(void)


### PR DESCRIPTION
This hack sets the `frame_cache_data` pointer to NULL during the following events:
Load Game, Reset, Init, Unload, Unload Game, Video Driver Destroy, Video Driver Free, Video Driver Init

This prevents an invalid pointer from being read if the first frame starts out paused.  A NULL value for `frame_cache_data` is used as a signal to repeat the last frame in video memory when paused.

The invalidation in Unload Game specifically fixes Final Burn Alpha, the others are added "just in case".