### PR TITLE
DO NOT MERGE - Remove `frame_cache_data` completely (for review)

### DIFF
--- a/gfx/drivers/gl.c
+++ b/gfx/drivers/gl.c
@@ -2241,9 +2241,7 @@ static bool gl_read_viewport(void *data, uint8_t *buffer, bool is_idle)
          buffer, is_idle);
 }
 
-#if 0
 #define READ_RAW_GL_FRAME_TEST
-#endif
 
 #if defined(READ_RAW_GL_FRAME_TEST)
 static void* gl_read_frame_raw(void *data, unsigned *width_p,

--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -151,7 +151,9 @@ static struct retro_system_av_info video_driver_av_info;
 
 static enum retro_pixel_format video_driver_pix_fmt      = RETRO_PIXEL_FORMAT_0RGB1555;
 
+/*
 static const void *frame_cache_data                      = NULL;
+*/
 static unsigned frame_cache_width                        = 0;
 static unsigned frame_cache_height                       = 0;
 static size_t frame_cache_pitch                          = 0;
@@ -1215,8 +1217,10 @@ void video_driver_set_filtering(unsigned index, bool smooth)
 void video_driver_cached_frame_set(const void *data, unsigned width,
       unsigned height, size_t pitch)
 {
+/*
    if (data)
       frame_cache_data = data;
+*/
    frame_cache_width   = width;
    frame_cache_height  = height;
    frame_cache_pitch   = pitch;
@@ -1225,8 +1229,10 @@ void video_driver_cached_frame_set(const void *data, unsigned width,
 void video_driver_cached_frame_get(const void **data, unsigned *width,
       unsigned *height, size_t *pitch)
 {
+/*
    if (data)
       *data    = frame_cache_data;
+*/
    if (width)
       *width   = frame_cache_width;
    if (height)
@@ -1414,8 +1420,11 @@ bool video_driver_cached_frame(void)
    recording_data   = NULL;
 
    retro_ctx.frame_cb(
+/*
          (frame_cache_data != RETRO_HW_FRAME_BUFFER_VALID)
          ? frame_cache_data : NULL,
+*/
+         NULL,
          frame_cache_width,
          frame_cache_height, frame_cache_pitch);
 
@@ -1599,8 +1608,10 @@ void video_driver_destroy(void)
 
 void video_driver_set_cached_frame_ptr(const void *data)
 {
+/*
    if (data)
       frame_cache_data = data;
+*/
 }
 
 void video_driver_set_stub_frame(void)
@@ -2414,8 +2425,10 @@ void video_driver_frame(const void *data, unsigned width,
    }
 
 
+/*
    if (data)
       frame_cache_data = data;
+*/
    frame_cache_width   = width;
    frame_cache_height  = height;
    frame_cache_pitch   = pitch;
@@ -3391,9 +3404,12 @@ bool video_driver_has_windowed(void)
 
 bool video_driver_cached_frame_has_valid_framebuffer(void)
 {
+/*
    if (frame_cache_data)
       return (frame_cache_data == RETRO_HW_FRAME_BUFFER_VALID);
    return false;
+*/
+   return true;
 }
 
 static const shader_backend_t *video_shader_set_backend(

--- a/tasks/task_screenshot.c
+++ b/tasks/task_screenshot.c
@@ -301,6 +301,11 @@ static bool take_screenshot_raw(const char *name_base, void *userbuf,
 
    video_driver_cached_frame_get(&data, &width, &height, &pitch);
 
+   if (data == NULL)
+   {
+      data = userbuf;
+   }
+
    /* Negative pitch is needed as screenshot takes bottom-up,
     * but we use top-down.
     */


### PR DESCRIPTION
This is an alternative to the other patch that outright removes the `frame_cache_data` pointer entirely.  Since it is dangerous to use a pointer that is explicitly guaranteed to be dangling, this is another possible solution.

Changes:
* Enables the disabled code reading back the texture in GL mode
* Trying to read the `frame_cache_data` pointer will always give NULL, which is defined to mean to repeat the frame that is currently in video memory.
* `video_driver_cached_frame_has_valid_framebuffer` (a badly misnamed function!) always return true now to allow raw screenshots to work.
* Screenshot task workaround for `frame_cache_data` always being NULL.