### PR TITLE
[iOS] Support viewing/opening files in Files app

### DIFF
--- a/pkg/apple/iOS/Info.plist
+++ b/pkg/apple/iOS/Info.plist
@@ -40,6 +40,8 @@
 	<string>1.7.2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
 	<key>NSCameraUsageDescription</key>
 	<string>YES</string>
 	<key>UIApplicationExitsOnSuspend</key>


### PR DESCRIPTION
## Description

A baby-sized update to the Info.plist file to support viewing the RetroArch files in the Files app.

## Related Issues

N/A

## Related Pull Requests

N/A

## Reviewers


