### PR TITLE
Move win32 message loop, now compatible with threaded video

### DIFF
--- a/gfx/common/win32_common.c
+++ b/gfx/common/win32_common.c
@@ -56,6 +56,7 @@
 #include "../../input/input_keymaps.h"
 #include "../video_thread_wrapper.h"
 #include "../video_display_server.h"
+#include "../../gfx/video_driver.h"
 #include <shellapi.h>
 
 #ifdef HAVE_MENU
@@ -1045,12 +1046,14 @@ void win32_check_window(bool *quit, bool *resize,
       unsigned *width, unsigned *height)
 {
 #if !defined(_XBOX)
-   const ui_application_t *application =
-      ui_companion_driver_get_application_ptr();
-   if (application)
-      application->process_events();
+   if (video_driver_is_threaded())
+   {
+      const ui_application_t *application =
+         ui_companion_driver_get_application_ptr();
+      if (application)
+         application->process_events();
+   }
    *quit            = g_win32_quit;
-#endif
 
    if (g_win32_resized)
    {
@@ -1059,6 +1062,7 @@ void win32_check_window(bool *quit, bool *resize,
       *height             = g_win32_resize_height;
       g_win32_resized     = false;
    }
+#endif
 }
 
 bool win32_suppress_screensaver(void *data, bool enable)
@@ -1189,7 +1193,7 @@ void win32_set_window(unsigned *width, unsigned *height,
       settings_t *settings      = config_get_ptr();
       const ui_window_t *window = ui_companion_driver_get_window_ptr();
 
-      if (!fullscreen && settings->bools.ui_menubar_enable)
+      if (!fullscreen && settings->bools.ui_menubar_enable && !video_driver_is_threaded())
       {
          RECT rc_temp;
          rc_temp.left   = 0;

--- a/retroarch.c
+++ b/retroarch.c
@@ -2535,6 +2535,14 @@ static enum runloop_state runloop_check_state(
       }
    }
 
+   if (!video_driver_is_threaded())
+   {
+      const ui_application_t *application =
+         ui_companion_driver_get_application_ptr();
+      if (application)
+         application->process_events();
+   }
+
    video_driver_get_status(&frame_count, &is_alive, &is_focused);
 
 #ifdef HAVE_MENU
@@ -2687,7 +2695,7 @@ static enum runloop_state runloop_check_state(
          if (focused || !runloop_idle)
          {
             bool libretro_running = menu_display_libretro_running(
-                  rarch_is_inited, 
+                  rarch_is_inited,
                   (current_core_type == CORE_TYPE_DUMMY));
 
             menu_driver_render(runloop_idle, rarch_is_inited,


### PR DESCRIPTION
Win32 message loop moved to a place where it is safe to execute menu commands (this is only for non-threaded video).
For threaded video, it behaves like the older versions.
Menu Bar is also removed when using threaded video, since it is not safe to carry out commands.
