### PR TITLE
Runahead: ensure prefixed second-instance temp directory on linux

### DIFF
--- a/runahead/secondary_core.c
+++ b/runahead/secondary_core.c
@@ -80,7 +80,11 @@ char* get_temp_directory_alloc(void)
    return path;
 #endif
 #else
-   char *path = strcpy_alloc_force(getenv("TMPDIR"));
+   char *path = "/tmp";
+   if (getenv("TMPDIR"))
+      path = getenv("TMPDIR");
+
+   path = strcpy_alloc_force(path);
    return path;
 #endif
 }


### PR DESCRIPTION
On linux computers when using both runahead and its "use second instance" option, if the TMPDIR environment variable is not set retroarch will attempt to create a non-prefixed temporary directory at `/retroarch_temp/`

This will now default to `/tmp/retroarch_temp/`