### PR TITLE
(OSX) Update info.plist to v1.7.3

### DIFF
--- a/pkg/apple/OSX/Info.plist
+++ b/pkg/apple/OSX/Info.plist
@@ -30,7 +30,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.2</string>
+	<string>1.7.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
must have been missed in the previous update.

Fixes https://github.com/libretro/RetroArch/issues/7004