### PR TITLE
Set max bus & gpu clock rates for PS VITA

### DIFF
--- a/frontend/drivers/platform_psp.c
+++ b/frontend/drivers/platform_psp.c
@@ -288,6 +288,9 @@ static void frontend_psp_init(void *data)
 
 #ifdef VITA
    scePowerSetArmClockFrequency(444);
+   scePowerSetBusClockFrequency(222);
+   scePowerSetGpuClockFrequency(222);
+   scePowerSetGpuXbarClockFrequency(166);
    sceSysmoduleLoadModule(SCE_SYSMODULE_NET);
 #else
    (void)data;


### PR DESCRIPTION
## Description

This basically sets the max clock rates (BUS and GPU) for PS VITA. This does **not** cause any overheating issues or anything, it's basically using the max performance mode. There haven't been any issues regarding heating or severe battery drainage using the following clock rates addressed in these commits. 
