### PR TITLE
Discord: Show game name and a core icon

### DIFF
--- a/discord/discord.c
+++ b/discord/discord.c
@@ -14,10 +14,15 @@
  */
 
 #include "discord.h"
+#include "retroarch.h"
+#include "core.h"
+#include "core_info.h"
+#include "paths.h"
+#include <file/file_path.h>
 
 #include "../msg_hash.h"
 
-static const char* APPLICATION_ID = "450822022025576457";
+static const char* APPLICATION_ID = "475414681587154944";
 static int FrustrationLevel       = 0;
 static int64_t start_time         = 0;
 
@@ -66,6 +71,10 @@ static void handle_discord_join_request(const DiscordUser* request)
 
 void discord_update(enum discord_presence presence)
 {
+   rarch_system_info_t *system = runloop_get_system_info();
+   core_info_t *core_info    = NULL;
+   core_info_get_current_core(&core_info);
+
    if (!discord_ready)
       return;
    if (
@@ -81,20 +90,28 @@ void discord_update(enum discord_presence presence)
    {
       case DISCORD_PRESENCE_MENU:
          discord_presence.state           = msg_hash_to_str(MENU_ENUM_LABEL_VALUE_DISCORD_IN_MENU);
-         discord_presence.largeImageKey   = "icon";
+         discord_presence.largeImageKey   = "base";
          discord_presence.instance        = 0;
          discord_presence.startTimestamp  = start_time;
          break;
       case DISCORD_PRESENCE_GAME:
-         start_time                       = time(0);
-         discord_presence.state           = "Link's House";
-         discord_presence.details         = "Legend of Zelda, The - Link's Awakening DX";
-         discord_presence.largeImageKey   = "icon";
-#if 0
-         discord_presence.smallImageKey   = "icon";
+         {
+            const char *system_name  = string_replace_substring(string_to_lower(core_info->core_name), " ", "_");
+
+            start_time                       = time(0);
+            discord_presence.state           = system ? system->info.library_name : "---";
+            discord_presence.details         = path_basename(path_get(RARCH_PATH_BASENAME));
+#if 1
+            RARCH_LOG("[Discord] system name: %s\n", system_name);
 #endif
-         discord_presence.instance        = 0;
-         discord_presence.startTimestamp  = start_time;
+            discord_presence.largeImageKey   = system_name;
+
+            discord_presence.smallImageKey   = "base";
+
+            discord_presence.instance        = 0;
+            discord_presence.startTimestamp  = start_time;
+
+         }
          break;
       case DISCORD_PRESENCE_NETPLAY_HOSTING:
       case DISCORD_PRESENCE_NETPLAY_CLIENT:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1721040/43681016-b93f7afc-980d-11e8-8062-ecdb6a244617.png)

Guess I'll do it myself.
So here is what needs to be done:

LibRetro should create it's own discord app and change the ID, I'm using a testing APP **I own** for this and I'll nuke it, change icons to dicks or whatever I want any time I want to.

Creating the app is straightforward anyway, just add an icon, fill the app name:

![image](https://user-images.githubusercontent.com/1721040/43681026-f5e15002-980d-11e8-9fa0-a2798e767e8d.png)

Then add the assets:

![image](https://user-images.githubusercontent.com/1721040/43681028-ff70353e-980d-11e8-8e72-27cd2bf61693.png)

For this implementation I'm using core_name (lowercase, spaces removed), so something would have to upload icons with the corenames (again lowercase, spaces removed) to discord. 

I tried just using system_name but it seems the discord API doesn't like long strings and there is nothing in the documentation that indicates a max size (https://discordapp.com/developers/docs/rich-presence/how-to) So I wouldn't know how to truncate them otherwise (so core name seemed easier)

Basically the assets uploaded have to have the same name as the return value of this:
```C
const char *system_name  = string_replace_substring(string_to_lower(core_info->core_name), " ", "_");
```

That's all!

