### PR TITLE
reverse code/state display so that users can see at a glance which codes are active

### DIFF
--- a/menu/cbs/menu_cbs_get_value.c
+++ b/menu/cbs/menu_cbs_get_value.c
@@ -690,21 +690,22 @@ static void menu_action_setting_disp_set_label_cheat(
    {
       if ( cheat_manager_state.cheats[cheat_index].handler == CHEAT_HANDLER_TYPE_EMU)
       {
-         snprintf(s, len, "%s : (%s)",
+         snprintf(s, len, "(%s) : %s",
                (cheat_manager_get_code(cheat_index) != NULL)
                ? cheat_manager_get_code(cheat_index) :
-               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE),
                cheat_manager_get_code_state(cheat_index) ?
                msg_hash_to_str(MENU_ENUM_LABEL_VALUE_ON) :
-               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF)
+               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF),
+               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE)
                );
       }
       else
       {
-         snprintf(s, len, "%08X : (%s)", cheat_manager_state.cheats[cheat_index].address,
+         snprintf(s, len, "(%s) : %08X",
                cheat_manager_get_code_state(cheat_index) ?
                msg_hash_to_str(MENU_ENUM_LABEL_VALUE_ON) :
-               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF)
+               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF),
+               cheat_manager_state.cheats[cheat_index].address
                );
       }
    }


### PR DESCRIPTION
…des are enabled

## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises


## Description

reverse code/state display so that users can see at a glance which codes are active

if a code is very long it takes a while for the enabled state to scroll into view

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@twinaphex 
