### PR TITLE
Close the audio driver after unload_game to avoid threads deadlocks

### DIFF
--- a/core_impl.c
+++ b/core_impl.c
@@ -402,13 +402,14 @@ bool core_unload(void)
 bool core_unload_game(void)
 {
    video_driver_free_hw_context();
-   audio_driver_stop();
 
    video_driver_set_cached_frame_ptr(NULL);
 
    current_core.retro_unload_game();
 
    current_core.game_loaded = false;
+
+   audio_driver_stop();
 
    return true;
 }


### PR DESCRIPTION
## Description

Close the audio driver after unloading the game to avoid blocking threads that are pushing audio.
This can happen if the core is using a separate thread that produces audio.

## Related Issues

reicast multi-threading option sometimes deadlock during unload

