### PR TITLE
discord: use playlist & platform titles when launching content

### DIFF
--- a/command.c
+++ b/command.c
@@ -2254,7 +2254,7 @@ TODO: Add a setting for these tweaks */
          break;
       case CMD_EVENT_CORE_INFO_DEINIT:
          core_info_deinit_list();
-         //core_info_free_current_core();
+         core_info_free_current_core();
          break;
       case CMD_EVENT_CORE_INFO_INIT:
          {

--- a/command.c
+++ b/command.c
@@ -1336,8 +1336,8 @@ static void command_event_restore_default_shader_preset(void)
 
 static void command_event_restore_remaps(void)
 {
-   if (rarch_ctl(RARCH_CTL_IS_REMAPS_CORE_ACTIVE, NULL) || 
-       rarch_ctl(RARCH_CTL_IS_REMAPS_CONTENT_DIR_ACTIVE, NULL) || 
+   if (rarch_ctl(RARCH_CTL_IS_REMAPS_CORE_ACTIVE, NULL) ||
+       rarch_ctl(RARCH_CTL_IS_REMAPS_CONTENT_DIR_ACTIVE, NULL) ||
        rarch_ctl(RARCH_CTL_IS_REMAPS_GAME_ACTIVE, NULL))
       input_remapping_set_defaults(true);
 }
@@ -2254,7 +2254,7 @@ TODO: Add a setting for these tweaks */
          break;
       case CMD_EVENT_CORE_INFO_DEINIT:
          core_info_deinit_list();
-         core_info_free_current_core();
+         //core_info_free_current_core();
          break;
       case CMD_EVENT_CORE_INFO_INIT:
          {

--- a/discord/discord.c
+++ b/discord/discord.c
@@ -21,6 +21,7 @@
 #include "../core.h"
 #include "../core_info.h"
 #include "../paths.h"
+#include "../playlist.h"
 
 #include "../msg_hash.h"
 
@@ -80,7 +81,7 @@ void discord_update(enum discord_presence presence)
       return;
 
    if (
-         (discord_status != DISCORD_PRESENCE_MENU) && 
+         (discord_status != DISCORD_PRESENCE_MENU) &&
          (discord_status == presence))
       return;
 
@@ -104,16 +105,29 @@ void discord_update(enum discord_presence presence)
             const char *system_name  = string_replace_substring(
                   string_to_lower(core_info->core_name), " ", "_");
 
+            char *label = NULL;
+            playlist_t *current_playlist = playlist_get_cached();
+
+            if (current_playlist)
+            {
+               playlist_get_index_by_path(
+                  current_playlist, path_get(RARCH_PATH_CONTENT), NULL, &label, NULL, NULL, NULL, NULL);
+            }
+
+            if (!label)
+            {
+               label = (char *)path_basename(path_get(RARCH_PATH_BASENAME));
+            }
+
             start_time                       = time(0);
-            discord_presence.state           = system ? system->info.library_name : "---";
-            discord_presence.details         = path_basename(path_get(RARCH_PATH_BASENAME));
+            discord_presence.state           = core_info->display_name;
+            discord_presence.details         = label;
 #if 1
             RARCH_LOG("[Discord] system name: %s\n", system_name);
+            RARCH_LOG("[Discord] current content: %s\n", label);
 #endif
             discord_presence.largeImageKey   = system_name;
-
             discord_presence.smallImageKey   = "base";
-
             discord_presence.instance        = 0;
             discord_presence.startTimestamp  = start_time;
 

--- a/discord/discord.c
+++ b/discord/discord.c
@@ -109,15 +109,11 @@ void discord_update(enum discord_presence presence)
             playlist_t *current_playlist = playlist_get_cached();
 
             if (current_playlist)
-            {
                playlist_get_index_by_path(
                   current_playlist, path_get(RARCH_PATH_CONTENT), NULL, &label, NULL, NULL, NULL, NULL);
-            }
 
             if (!label)
-            {
                label = (char *)path_basename(path_get(RARCH_PATH_BASENAME));
-            }
 
             start_time                       = time(0);
             discord_presence.state           = core_info->display_name;


### PR DESCRIPTION
Now, if the content was loaded from a playlist, the content name will be the playlist entry's title instead of the filename of the content.

Also, `state` was modified to show the display name of the core, not the library name. The difference is that the display name shows the platform as well, not just the core name (i.e. "NEC - PC Engine SuperGrafx (Beetle SGX)" instead of "Mednafen SuperGrafx").

One thing of note: 73f2710 returns `core_info` as `NULL` when called within `discord.c`. Without `core_info`, the RPC connection is not updated when playing a game, only when in the main menu. @bparker06 mentioned it's likely because the core info is removed from memory before the discord calls are able to access it. This means the discord calls need to be moved around, but my experimentation with that very thing for a few hours only resulted in failure. I am open to all suggestions on how to fix this issue.

This PR is related to #5690.