### PR TITLE
Fix console mode loading core without content

### DIFF
--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -814,6 +814,11 @@ static bool content_file_init(
 
       free(info);
    }
+   else if (special == NULL)
+   {
+      *error_string = strdup(msg_hash_to_str(MSG_ERROR_LIBRETRO_CORE_REQUIRES_CONTENT));
+      ret = false;
+   }
 
    return ret;
 }
@@ -874,7 +879,6 @@ static bool task_load_content(content_ctx_info_t *content_info,
 
    if (!content_load(content_info))
    {
-      *error_string = strdup("This core requires a content file, could not load content.\n");
       return false;
    }
 


### PR DESCRIPTION
In the function `content_file_init`, it will return true if you specify zero filenames (I accidentally introduced this bug earlier while trying to remove a crash, whoops).

This fixes that.

I also took out a redundant and unlocalized error message.  This one is a generic error for content failing to load, but there are already more specific error messages generated elsewhere, such as errors for failing to read the file, core not accepting the content file, missing content filenames, etc.  It would just be a second item in the error log file.  Using a less-specific second error message can possibly cover up another error message.

##Related Issues:

#7082