### PR TITLE
Don't unload content if it was never loaded.

### DIFF
--- a/core_impl.c
+++ b/core_impl.c
@@ -396,7 +396,9 @@ bool core_unload(void)
 {
    video_driver_set_cached_frame_ptr(NULL);
 
-   current_core.retro_deinit();
+   if (current_core.inited)
+      current_core.retro_deinit();
+
    return true;
 }
 

--- a/core_impl.c
+++ b/core_impl.c
@@ -400,16 +400,17 @@ bool core_unload(void)
    return true;
 }
 
-
 bool core_unload_game(void)
 {
    video_driver_free_hw_context();
 
    video_driver_set_cached_frame_ptr(NULL);
 
-   current_core.retro_unload_game();
-
-   current_core.game_loaded = false;
+   if (current_core.game_loaded)
+   {
+      current_core.retro_unload_game();
+      current_core.game_loaded = false;
+   }
 
    audio_driver_stop();
 


### PR DESCRIPTION
## Description

Fixes crashes for a few more cores when loading the core without content.

Please see the nxengine issue report Alcaro closed with:

> At this point, retro_load_game has not returned true, or been called at all. As such, calling this function is not allowed. Frontend bug.

This fixes the crashes for `dolphin-emu`, `mame2000`, `nxengine`  and `reicast`.

~~Unfortunately `lutro` and `hatari` still crash.~~

Note that I tested this with a lot of cores without finding regressions, but there are still untested cores...

## Related Issues

https://github.com/libretro/RetroArch/issues/4493
https://github.com/libretro/RetroArch/issues/7082
https://github.com/libretro/nxengine-libretro/issues/29

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/7090

## Reviewers

@twinaphex and @Dwedit Does this look right to you?
