### PR TITLE
Default to gl instead of vulkan.

### DIFF
--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -262,11 +262,11 @@ struct aspect_ratio_elem aspectratio_lut[ASPECT_RATIO_END] = {
 };
 
 static const video_driver_t *video_drivers[] = {
-#ifdef HAVE_VULKAN
-   &video_vulkan,
-#endif
 #ifdef HAVE_OPENGL
    &video_gl,
+#endif
+#ifdef HAVE_VULKAN
+   &video_vulkan,
 #endif
 #ifdef HAVE_METAL
    &video_metal,


### PR DESCRIPTION
## Description

If the `video_driver` is set incorrectly it will default to vulkan instead of gl. However its possible to have RetroArch built with vulkan even with no working vulkan drivers and this will cause a segfault.

Defaulting to gl again should be a safer default which should crash for fewer users.

## Related Issues

Fixes https://github.com/libretro/RetroArch/issues/5568.

## Related Pull Requests

N/A
