### PR TITLE
Fix segfaults when starting vulkan without a working vulkan driver.

### DIFF
--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -1827,7 +1827,10 @@ bool vulkan_context_init(gfx_ctx_vulkan_data_t *vk,
          VK_DEBUG_REPORT_WARNING_BIT_EXT |
          VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT;
       info.pfnCallback = vulkan_debug_cb;
-      vkCreateDebugReportCallbackEXT(vk->context.instance, &info, NULL, &vk->context.debug_callback);
+
+      if (vk->context.instance)
+         vkCreateDebugReportCallbackEXT(vk->context.instance, &info, NULL,
+               &vk->context.debug_callback);
    }
    RARCH_LOG("[Vulkan]: Enabling Vulkan debug layers.\n");
 #endif

--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -744,6 +744,9 @@ static bool vulkan_init_default_filter_chain(vk_t *vk)
 
    memset(&info, 0, sizeof(info));
 
+   if (!vk->context)
+      return false;
+
    info.device                = vk->context->device;
    info.gpu                   = vk->context->gpu;
    info.memory_properties     = &vk->context->memory_properties;
@@ -832,7 +835,7 @@ static bool vulkan_init_filter_chain(vk_t *vk)
 
 static void vulkan_init_resources(vk_t *vk)
 {
-   if (!vk)
+   if (!vk->context)
       return;
 
    vk->num_swapchain_images = vk->context->num_swapchain_images;
@@ -854,6 +857,9 @@ static void vulkan_init_static_resources(vk_t *vk)
    /* Create the pipeline cache. */
    VkPipelineCacheCreateInfo cache   = {
       VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO };
+
+   if (!vk->context)
+      return;
 
    vkCreatePipelineCache(vk->context->device,
          &cache, NULL, &vk->pipelines.cache);
@@ -2356,6 +2362,9 @@ static void vulkan_viewport_info(void *data, struct video_viewport *vp)
    vk_t *vk = (vk_t*)data;
 
    video_driver_get_size(&width, &height);
+
+   if (!vk)
+      return;
 
    /* Make sure we get the correct viewport. */
    vulkan_set_viewport(vk, width, height, false, true);


### PR DESCRIPTION
## Description

RetroArch will crash in several places when running vulkan in an environment that does not have working vulkan drivers.

This should guard against those crashes and allow RetroArch to fail safely in those cases and has been tested with and without asan, `VULKAN_DEBUG=1` and `video_threaded`.

Here is an example crash with the current master.
```
[INFO] RetroArch 1.7.3 (Git a6d5931412)
[INFO] === Build =======================================
Capabilities: MMX MMXEXT SSE1 SSE2 SSE3 SSSE3 SSE4 SSE4.2 AVX AES 
Built: Aug 24 2018
[INFO] Version: 1.7.3
[INFO] Git: a6d5931412
[INFO] =================================================
[INFO] Environ SET_PIXEL_FORMAT: RGB565.
[INFO] Redirecting save file to "/media/data/home/games/roms/.saves/retroarch/.srm".
[INFO] Redirecting savestate to "/media/data/home/games/roms/.saves/retroarch/.sstates/.state".
[INFO] Version of libretro API: 1
[INFO] Compiled against API: 1
[INFO] [Audio]: Set audio input rate to: 29970.03 Hz.
[INFO] [Video]: Video @ fullscreen
[INFO] [Video]: Starting threaded video driver ...
[INFO] Vulkan dynamic library loaded.
[ERROR] [Vulkan]: Could not find instance extensions. Will attempt without them.
[ERROR] Failed to create Vulkan instance.
[WARN] Failed to bind API (#9, version 1.0) on context driver "x-egl".
[WARN] Failed to bind API (#9, version 1.0) on context driver "kms".
[WARN] Failed to bind API (#9, version 1.0) on context driver "sdl_gl".
[INFO] Vulkan dynamic library loaded.
[ERROR] [Vulkan]: Could not find instance extensions. Will attempt without them.
[ERROR] Failed to create Vulkan instance.
[ERROR] [Vulkan]: Failed to create Vulkan context.
[INFO] [Vulkan]: Detecting screen resolution 320x240.
[INFO] [Vulkan]: Using resolution 320x240
[INFO] [Vulkan]: Using RGB565 format.
AddressSanitizer:DEADLYSIGNAL
=================================================================
==7865==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000030 (pc 0x0000008fc6cd bp 0x7f8c87a87fa0 sp 0x7f8c87a87dc0 T2)
==7865==The signal is caused by a READ memory access.
==7865==Hint: address points to the zero page.
    #0 0x8fc6cc in vulkan_init_static_resources gfx/drivers/vulkan.c:858
    #1 0x8fefc6 in vulkan_init gfx/drivers/vulkan.c:1193
    #2 0x8787b9 in video_thread_handle_packet gfx/video_thread_wrapper.c:341
    #3 0x87af3e in video_thread_loop gfx/video_thread_wrapper.c:597
    #4 0x876a02 in thread_wrap libretro-common/rthreads/rthreads.c:145
    #5 0x7f8c90257636 in start_thread (/lib64/libpthread.so.0+0x7636)
    #6 0x7f8c8dcece8e in __GI___clone (/lib64/libc.so.6+0x11ce8e)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV gfx/drivers/vulkan.c:858 in vulkan_init_static_resources
Thread T2 created by T0 here:
    #0 0x7f8c91179f50 in pthread_create (/usr/lib64/libasan.so.5+0x49f50)
    #1 0x876aed in sthread_create libretro-common/rthreads/rthreads.c:186
    #2 0x87d15f in video_thread_init gfx/video_thread_wrapper.c:843
    #3 0x8813f0 in video_init_thread gfx/video_thread_wrapper.c:1380
    #4 0x5035de in video_driver_init_internal gfx/video_driver.c:1061
    #5 0x505f89 in video_driver_init gfx/video_driver.c:1799
    #6 0x512e25 in drivers_init /home/orbea/gittings/forks/RetroArch/driver.c:361
    #7 0x423237 in retroarch_main_init /home/orbea/gittings/forks/RetroArch/retroarch.c:1395
    #8 0x448ae8 in content_load tasks/task_content.c:279
    #9 0x44b8e2 in task_load_content tasks/task_content.c:880
    #10 0x44fb86 in task_load_content_callback tasks/task_content.c:1565
    #11 0x44ff0c in task_push_load_content_from_cli tasks/task_content.c:1633
    #12 0x41c7cf in rarch_main frontend/frontend.c:125
    #13 0x41c993 in main frontend/frontend.c:169
    #14 0x7f8c8dbf1ba6 in __libc_start_main (/lib64/libc.so.6+0x21ba6)
```
And now with this patch.
```
$ ./retroarch --verbose 
[INFO] RetroArch 1.7.3 (Git 260ce526c2)
[INFO] === Build =======================================
Capabilities: MMX MMXEXT SSE1 SSE2 SSE3 SSSE3 SSE4 SSE4.2 AVX AES 
Built: Aug 24 2018
[INFO] Version: 1.7.3
[INFO] Git: 260ce526c2
[INFO] =================================================
[INFO] Environ SET_PIXEL_FORMAT: RGB565.
[INFO] Redirecting save file to "/media/data/home/games/roms/.saves/retroarch/.srm".
[INFO] Redirecting savestate to "/media/data/home/games/roms/.saves/retroarch/.sstates/.state".
[INFO] Version of libretro API: 1
[INFO] Compiled against API: 1
[INFO] [Audio]: Set audio input rate to: 29970.03 Hz.
[INFO] [Video]: Video @ fullscreen
[INFO] [Video]: Starting threaded video driver ...
[INFO] Vulkan dynamic library loaded.
[ERROR] [Vulkan]: Could not find instance extensions. Will attempt without them.
[ERROR] Failed to create Vulkan instance.
[WARN] Failed to bind API (#9, version 1.0) on context driver "x-egl".
[WARN] Failed to bind API (#9, version 1.0) on context driver "kms".
[WARN] Failed to bind API (#9, version 1.0) on context driver "sdl_gl".
[INFO] Vulkan dynamic library loaded.
[ERROR] [Vulkan]: Could not find instance extensions. Will attempt without them.
[ERROR] Failed to create Vulkan instance.
[ERROR] [Vulkan]: Failed to create Vulkan context.
[INFO] [Vulkan]: Detecting screen resolution 320x240.
[INFO] [Vulkan]: Using resolution 320x240
[INFO] [Vulkan]: Using RGB565 format.
[INFO] [Vulkan]: Loading stock shader.
[ERROR] [Vulkan]: Failed to init filter chain.
[ERROR] [Video]: Cannot open threaded video driver ... Exiting ...
[ERROR] Fatal error received in: "init_video()"
```

## Related Issues

Maybe some of the existing vulkan crash issues will fail safer now.

## Related Pull Requests

N/A

## Reviewers

@twinaphex Please actually test this with vulkan, a friend with vulkan says its works as well as before for him and I did not find any memory leaks with asan or valgrind, but I do not have a working vulkan setup to test...
