### PR TITLE
Silence -Wunknown-warning-option warnings with clang.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1141,7 +1141,7 @@ ifeq ($(HAVE_VULKAN), 1)
       CXXFLAGS += -fpermissive
    endif
 
-   CXXFLAGS += -Wno-switch -Wno-sign-compare -fno-strict-aliasing -Wno-maybe-uninitialized -Wno-reorder -Wno-parentheses
+   CXXFLAGS += -Wno-switch -Wno-sign-compare -fno-strict-aliasing -Wno-reorder -Wno-parentheses
 
    OBJ += gfx/drivers/vulkan.o \
           gfx/common/vulkan_common.o \


### PR DESCRIPTION
## Description

When building CXX code with clang it will print many warnings.

However removing this flag does not introduce any warnings so it should be safe to remove. I tested this with `gcc-8.2.0`, `gcc-5.5.0`, `clang-6.0.1` and `clang-3.8.0`.

## Related Issues

```
warning: unknown warning option '-Wno-maybe-uninitialized'; did you mean '-Wno-uninitialized'? [-Wunknown-warning-option]
```

## Related Pull Requests

N/A
