### PR TITLE
Fix themes without menu icons

### DIFF
--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -2279,9 +2279,9 @@ static uintptr_t xmb_icon_get_id(xmb_handle_t *xmb,
       /* Menu icons are here waiting for theme support*/
       {
             settings_t *settings = config_get_ptr();
-            if (settings->uints.menu_xmb_theme != XMB_ICON_THEME_FLATUI ||
-                settings->uints.menu_xmb_theme != XMB_ICON_THEME_NEOACTIVE ||
-                settings->uints.menu_xmb_theme != XMB_ICON_THEME_RETROACTIVE ||
+            if (settings->uints.menu_xmb_theme != XMB_ICON_THEME_FLATUI &&
+                settings->uints.menu_xmb_theme != XMB_ICON_THEME_NEOACTIVE &&
+                settings->uints.menu_xmb_theme != XMB_ICON_THEME_RETROACTIVE &&
                 settings->uints.menu_xmb_theme != XMB_ICON_THEME_PIXEL )
             {
                switch (enum_idx)


### PR DESCRIPTION
Themes without menu icons are showing blank squares, this fixes the problem