### PR TITLE
Deterministic input for RunAhead, guaranteed to match the last polled input

### DIFF
--- a/runahead/dirty_input.c
+++ b/runahead/dirty_input.c
@@ -80,7 +80,7 @@ static void input_state_set_last(unsigned port, unsigned device,
       element->state[id] = value;
 }
 
-static int16_t input_state_get_last(unsigned port,
+int16_t input_state_get_last(unsigned port,
       unsigned device, unsigned index, unsigned id)
 {
    unsigned i;

--- a/runahead/dirty_input.h
+++ b/runahead/dirty_input.h
@@ -9,6 +9,8 @@ RETRO_BEGIN_DECLS
 extern bool input_is_dirty;
 void add_input_state_hook(void);
 void remove_input_state_hook(void);
+int16_t input_state_get_last(unsigned port,
+   unsigned device, unsigned index, unsigned id);
 
 RETRO_END_DECLS
 

--- a/runahead/secondary_core.c
+++ b/runahead/secondary_core.c
@@ -23,6 +23,7 @@
 #include "../content.h"
 
 #include "secondary_core.h"
+#include "dirty_input.h"
 
 static int port_map[16];
 
@@ -304,11 +305,32 @@ void secondary_core_set_variable_update(void)
    has_variable_update = true;
 }
 
-bool secondary_core_run_no_input_polling(void)
+static void secondary_core_input_poll_null(void)
+{
+
+}
+
+bool secondary_core_run_use_last_input(void)
 {
    if (secondary_core_ensure_exists())
    {
+      retro_input_poll_t old_poll_function = secondary_callbacks.poll_cb;
+      retro_input_state_t old_input_function = secondary_callbacks.state_cb;
+
+      secondary_callbacks.poll_cb = secondary_core_input_poll_null;
+      secondary_callbacks.state_cb = input_state_get_last;
+
+      secondary_core.retro_set_input_poll(secondary_callbacks.poll_cb);
+      secondary_core.retro_set_input_state(secondary_callbacks.state_cb);
+
       secondary_core.retro_run();
+
+      secondary_callbacks.poll_cb = old_poll_function;
+      secondary_callbacks.state_cb = old_input_function;
+
+      secondary_core.retro_set_input_poll(secondary_callbacks.poll_cb);
+      secondary_core.retro_set_input_state(secondary_callbacks.state_cb);
+
       return true;
    }
    return false;

--- a/runahead/secondary_core.h
+++ b/runahead/secondary_core.h
@@ -10,7 +10,7 @@
 
 RETRO_BEGIN_DECLS
 
-bool secondary_core_run_no_input_polling(void);
+bool secondary_core_run_use_last_input(void);
 bool secondary_core_deserialize(const void *buffer, int size);
 bool secondary_core_ensure_exists(void);
 void secondary_core_destroy(void);


### PR DESCRIPTION
## Description

This changes how input on subsequent frames is handled for the RunAhead feature.  Rather than let it poll the joypads, this forces the joypad inputs to exactly match the last values they returned.

Note that this still does not fix the phantom button release problems with bsnes.
