### PR TITLE
Fallback to a default icon in if there is no playlist icon

### DIFF
--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -2028,6 +2028,13 @@ static void xmb_context_reset_horizontal_list(
                file_path_str(FILE_PATH_PNG_EXTENSION),
                PATH_MAX_LENGTH * sizeof(char));
 
+         /* If the playlist icon doesn't exist return default */
+
+         if (!filestream_exists(texturepath))
+               fill_pathname_join_concat(texturepath, iconpath, "default",
+               file_path_str(FILE_PATH_PNG_EXTENSION),
+               PATH_MAX_LENGTH * sizeof(char));
+
          ti.width         = 0;
          ti.height        = 0;
          ti.pixels        = NULL;
@@ -2045,10 +2052,21 @@ static void xmb_context_reset_horizontal_list(
             image_texture_free(&ti);
          }
 
-         strlcat(iconpath, sysname, PATH_MAX_LENGTH * sizeof(char));
-         fill_pathname_join_delim(content_texturepath, iconpath,
+         fill_pathname_join_delim(sysname, sysname,
                file_path_str(FILE_PATH_CONTENT_BASENAME), '-',
                PATH_MAX_LENGTH * sizeof(char));
+         strlcat(content_texturepath, iconpath, PATH_MAX_LENGTH * sizeof(char));
+         strlcat(content_texturepath, sysname, PATH_MAX_LENGTH * sizeof(char));
+
+         /* If the content icon doesn't exist return default-content */
+
+         if (!filestream_exists(content_texturepath))
+         {
+            strlcat(iconpath, "default", PATH_MAX_LENGTH * sizeof(char));
+            fill_pathname_join_delim(content_texturepath, iconpath,
+                  file_path_str(FILE_PATH_CONTENT_BASENAME), '-',
+                  PATH_MAX_LENGTH * sizeof(char));
+         }
 
          if (image_texture_load(&ti, content_texturepath))
          {

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -5295,13 +5295,10 @@ static int xmb_list_push(void *data, void *userdata,
             }
 #endif
 #if defined(HAVE_NETWORKING)
+            if (settings->bools.menu_show_online_updater && !settings->bools.kiosk_mode_enable)
             {
-               settings_t *settings      = config_get_ptr();
-               if (settings->bools.menu_show_online_updater && !settings->bools.kiosk_mode_enable)
-               {
-                  entry.enum_idx      = MENU_ENUM_LABEL_ONLINE_UPDATER;
-                  menu_displaylist_ctl(DISPLAYLIST_SETTING_ENUM, &entry);
-               }
+               entry.enum_idx      = MENU_ENUM_LABEL_ONLINE_UPDATER;
+               menu_displaylist_ctl(DISPLAYLIST_SETTING_ENUM, &entry);
             }
 #endif
             if (!settings->bools.menu_content_show_settings && !string_is_empty(settings->paths.menu_content_show_settings_password))


### PR DESCRIPTION
If no icon exists that matches the playlist then load default.png and default-content.png

![captura](https://user-images.githubusercontent.com/1247237/44668490-eb063600-a9f3-11e8-86f9-bd2197031852.PNG)
