### PR TITLE
libretro-common: Restore libretro-common/audio/dsp_filters/configure

### DIFF
--- a/libretro-common/audio/dsp_filters/configure
+++ b/libretro-common/audio/dsp_filters/configure
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+PACKAGE_NAME=retroarch-filters-audio


### PR DESCRIPTION
## Description

This allows Flatpak to build correctly.

## Related Issues

- https://github.com/flathub/org.libretro.RetroArch/issues/68

## Related Pull Requests

- https://github.com/flathub/org.libretro.RetroArch/pull/69
- https://github.com/libretro/libretro-common/pull/85
