### PR TITLE
mbedtls in 1.7.4 broke Haiku build

### DIFF
--- a/deps/mbedtls/entropy_poll.c
+++ b/deps/mbedtls/entropy_poll.c
@@ -44,7 +44,7 @@
 #if !defined(MBEDTLS_NO_PLATFORM_ENTROPY)
 
 #if !defined(unix) && !defined(__unix__) && !defined(__unix) && \
-    !defined(__APPLE__) && !defined(_WIN32)
+    !defined(__APPLE__) && !defined(_WIN32) && !defined(__HAIKU__)
 #error "Platform entropy sources only work on Unix and Windows, see MBEDTLS_NO_PLATFORM_ENTROPY in config.h"
 #endif
 

--- a/deps/mbedtls/net_sockets.c
+++ b/deps/mbedtls/net_sockets.c
@@ -32,7 +32,7 @@
 #if defined(MBEDTLS_NET_C)
 
 #if !defined(unix) && !defined(__unix__) && !defined(__unix) && \
-    !defined(__APPLE__) && !defined(_WIN32)
+    !defined(__APPLE__) && !defined(_WIN32) && !defined(__HAIKU__)
 #error "This module only works on Unix and Windows, see MBEDTLS_NET_C in config.h"
 #endif
 

--- a/deps/mbedtls/timing.c
+++ b/deps/mbedtls/timing.c
@@ -39,7 +39,7 @@
 #if !defined(MBEDTLS_TIMING_ALT)
 
 #if !defined(unix) && !defined(__unix__) && !defined(__unix) && \
-    !defined(__APPLE__) && !defined(_WIN32)
+    !defined(__APPLE__) && !defined(_WIN32) && !defined(__HAIKU__)
 #error "This module only works on Unix and Windows, see MBEDTLS_TIMING_C in config.h"
 #endif
 


### PR DESCRIPTION
This restores Haiku build after disabling Discord during ./configure
No big loss since Discord is unavailable for Haiku anyway