### PR TITLE
Fix netplay on Wii U

### DIFF
--- a/libretro-common/net/net_compat.c
+++ b/libretro-common/net/net_compat.c
@@ -183,6 +183,16 @@ int getaddrinfo_retro(const char *node, const char *service,
 #endif
    }
 
+#if defined(WIIU)
+   if (node == NULL) {
+      /* Wii U's socket library chokes on NULL node */
+      if (hints->ai_flags & AI_PASSIVE)
+         node = "0.0.0.0";
+      else
+         node = "127.0.0.1";
+   }
+#endif
+
 #ifdef HAVE_SOCKET_LEGACY
    info = (struct addrinfo*)calloc(1, sizeof(*info));
    if (!info)


### PR DESCRIPTION
getaddrinfo on Wii U doesn't support node==NULL. As I don't know of this
bug on any other platform, I've made a Wii-U-specific workaround in
getaddrinfo_retro.

Please don't merge this until somebody with a Wii U has actually tested it!

## Reviewers

@gblues 
