### PR TITLE
Update config entries pointer to the new beginning of the list

### DIFF
--- a/libretro-common/file/config_file.c
+++ b/libretro-common/file/config_file.c
@@ -999,6 +999,7 @@ void config_file_dump(config_file_t *conf, FILE *file)
    }
 
    list = merge_sort_linked_list((struct config_entry_list*)conf->entries, config_sort_compare_func);
+   conf->entries = list;
 
    while (list)
    {
@@ -1092,7 +1093,7 @@ static void test_config_file(void)
    test_config_file_parse_contains("foo = \"bar\"",     "foo", "bar");
 
 #if 0
-   /* turns out it treats empty as nonexistent - 
+   /* turns out it treats empty as nonexistent -
     * should probably be fixed */
    test_config_file_parse_contains("foo = \"\"\n",   "foo", "");
    test_config_file_parse_contains("foo = \"\"",     "foo", "");


### PR DESCRIPTION
This is a patch contributed by @bparker06 from  https://github.com/libretro/RetroArch/issues/7160#issuecomment-418154425 .

It updates the entries pointer after the list is sorted. It aims to fix an issue where `/etc/retroarch.cfg` wasn't being read at first run.