### PR TITLE
Vulkan: Maintenance fixes

### DIFF
--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -2464,8 +2464,8 @@ static void vulkan_acquire_clear_fences(gfx_ctx_vulkan_data_t *vk)
          vkDestroyFence(vk->context.device,
                vk->context.swapchain_fences[i], NULL);
          vk->context.swapchain_fences[i] = VK_NULL_HANDLE;
-         vk->context.swapchain_fences_signalled[i] = false;
       }
+      vk->context.swapchain_fences_signalled[i] = false;
    }
 }
 
@@ -2482,10 +2482,10 @@ static void vulkan_acquire_wait_fences(gfx_ctx_vulkan_data_t *vk)
       if (vk->context.swapchain_fences_signalled[index])
          vkWaitForFences(vk->context.device, 1, next_fence, true, UINT64_MAX);
       vkResetFences(vk->context.device, 1, next_fence);
-      vk->context.swapchain_fences_signalled[index] = false;
    }
    else
       vkCreateFence(vk->context.device, &fence_info, NULL, next_fence);
+   vk->context.swapchain_fences_signalled[index] = false;
 }
 
 static void vulkan_create_wait_fences(gfx_ctx_vulkan_data_t *vk)

--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -38,6 +38,10 @@
 #include "../../libretro-common/include/retro_math.h"
 #include "../../libretro-common/include/string/stdstring.h"
 
+#define VENDOR_ID_AMD 0x1002
+#define VENDOR_ID_NV 0x10DE
+#define VENDOR_ID_INTEL 0x8086
+
 // Windows is not particularly good at recreating swapchains.
 // Emulate vsync toggling by using vkAcquireNextImageKHR timeouts.
 #if defined(_WIN32)
@@ -1500,10 +1504,6 @@ static bool vulkan_context_init_device(gfx_ctx_vulkan_data_t *vk)
       "VK_KHR_sampler_mirror_clamp_to_edge",
    };
 
-#ifdef VULKAN_EMULATE_MAILBOX
-   vk->emulate_mailbox = true;
-#endif
-
 #ifdef VULKAN_DEBUG
    static const char *device_layers[] = { "VK_LAYER_LUNARG_standard_validation" };
 #endif
@@ -1577,6 +1577,13 @@ static bool vulkan_context_init_device(gfx_ctx_vulkan_data_t *vk)
          &vk->context.gpu_properties);
    vkGetPhysicalDeviceMemoryProperties(vk->context.gpu,
          &vk->context.memory_properties);
+
+#ifdef VULKAN_EMULATE_MAILBOX
+   // AMD can emulate Mailbox on Windows, but not NV.
+   // Not tested on Intel.
+   if (vk->context.gpu_properties.vendorID == VENDOR_ID_AMD)
+      vk->emulate_mailbox = true;
+#endif
 
    RARCH_LOG("[Vulkan]: Using GPU: %s\n", vk->context.gpu_properties.deviceName);
 

--- a/gfx/common/vulkan_common.h
+++ b/gfx/common/vulkan_common.h
@@ -96,6 +96,7 @@ typedef struct vulkan_context
    /* Used by screenshot to get blits with correct colorspace. */
    bool swapchain_is_srgb;
    bool swap_interval_emulation_lock;
+   bool has_acquired_swapchain;
 
    unsigned swapchain_width;
    unsigned swapchain_height;
@@ -131,6 +132,8 @@ typedef struct gfx_ctx_vulkan_data
 {
    bool need_new_swapchain;
    bool created_new_swapchain;
+   bool emulate_mailbox;
+   bool emulating_mailbox;
    vulkan_context_t context;
    VkSurfaceKHR vk_surface;
    VkSwapchainKHR swapchain;

--- a/gfx/common/vulkan_common.h
+++ b/gfx/common/vulkan_common.h
@@ -179,6 +179,7 @@ struct vk_texture
    VkImage image;
    VkImageView view;
    VkDeviceMemory memory;
+   VkBuffer buffer;
 
    VkFormat format;
 

--- a/gfx/common/vulkan_common.h
+++ b/gfx/common/vulkan_common.h
@@ -128,6 +128,27 @@ typedef struct vulkan_context
 #endif
 } vulkan_context_t;
 
+struct vulkan_emulated_mailbox
+{
+   sthread_t *thread;
+   VkDevice device;
+   VkSwapchainKHR swapchain;
+   slock_t *lock;
+   scond_t *cond;
+
+   unsigned index;
+   bool acquired;
+   bool request_acquire;
+   bool dead;
+   bool has_pending_request;
+   VkResult result;
+};
+
+bool vulkan_emulated_mailbox_init(struct vulkan_emulated_mailbox *mailbox,
+      VkDevice device, VkSwapchainKHR swapchain);
+void vulkan_emulated_mailbox_deinit(struct vulkan_emulated_mailbox *mailbox);
+VkResult vulkan_emulated_mailbox_acquire_next_image(struct vulkan_emulated_mailbox *mailbox, unsigned *index);
+
 typedef struct gfx_ctx_vulkan_data
 {
    bool need_new_swapchain;
@@ -137,6 +158,8 @@ typedef struct gfx_ctx_vulkan_data
    vulkan_context_t context;
    VkSurfaceKHR vk_surface;
    VkSwapchainKHR swapchain;
+
+   struct vulkan_emulated_mailbox mailbox;
 } gfx_ctx_vulkan_data_t;
 
 struct vulkan_display_surface_info

--- a/gfx/common/vulkan_common.h
+++ b/gfx/common/vulkan_common.h
@@ -160,6 +160,9 @@ typedef struct gfx_ctx_vulkan_data
    VkSwapchainKHR swapchain;
 
    struct vulkan_emulated_mailbox mailbox;
+   /* Used to check if we need to use mailbox emulation or not.
+    * Only relevant on Windows for now. */
+   bool fullscreen;
 } gfx_ctx_vulkan_data_t;
 
 struct vulkan_display_surface_info

--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -854,6 +854,8 @@ static void vulkan_init_static_resources(vk_t *vk)
    uint32_t blank[4 * 4];
    VkCommandPoolCreateInfo pool_info = {
       VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO };
+   pool_info.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+
    /* Create the pipeline cache. */
    VkPipelineCacheCreateInfo cache   = {
       VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO };
@@ -1509,23 +1511,22 @@ static void vulkan_set_viewport(void *data, unsigned viewport_width,
 
 static void vulkan_readback(vk_t *vk)
 {
-   VkImageCopy region;
+   VkBufferImageCopy region;
    struct vk_texture *staging;
    struct video_viewport vp;
+   VkMemoryBarrier barrier = { VK_STRUCTURE_TYPE_MEMORY_BARRIER };
 
    vulkan_viewport_info(vk, &vp);
    memset(&region, 0, sizeof(region));
-   region.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-   region.srcSubresource.layerCount = 1;
-   region.dstSubresource            = region.srcSubresource;
+   region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+   region.imageSubresource.layerCount = 1;
+   region.imageOffset.x               = vp.x;
+   region.imageOffset.y               = vp.y;
+   region.imageExtent.width           = vp.width;
+   region.imageExtent.height          = vp.height;
+   region.imageExtent.depth           = 1;
 
-   region.srcOffset.x               = vp.x;
-   region.srcOffset.y               = vp.y;
-   region.extent.width              = vp.width;
-   region.extent.height             = vp.height;
-   region.extent.depth              = 1;
-
-   /* FIXME: We won't actually get format conversion with vkCmdCopyImage, so have to check
+   /* FIXME: We won't actually get format conversion with vkCmdCopyImageToBuffer, so have to check
     * properly for this. BGRA seems to be the default for all swapchains. */
    if (vk->context->swapchain_format != VK_FORMAT_B8G8R8A8_UNORM)
       RARCH_WARN("[Vulkan]: Backbuffer is not BGRA8888, readbacks might not work properly.\n");
@@ -1537,25 +1538,18 @@ static void vulkan_readback(vk_t *vk)
          VK_FORMAT_B8G8R8A8_UNORM,
          NULL, NULL, VULKAN_TEXTURE_READBACK);
 
-   /* Go through the long-winded dance of remapping image layouts. */
-   vulkan_image_layout_transition(vk, vk->cmd, staging->image,
-         VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_GENERAL,
-         0, VK_ACCESS_TRANSFER_WRITE_BIT,
-         VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-         VK_PIPELINE_STAGE_TRANSFER_BIT);
-
-   vkCmdCopyImage(vk->cmd, vk->chain->backbuffer.image,
+   vkCmdCopyImageToBuffer(vk->cmd, vk->chain->backbuffer.image,
          VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-         staging->image,
-         VK_IMAGE_LAYOUT_GENERAL,
+         staging->buffer,
          1, &region);
 
    /* Make the data visible to host. */
-   vulkan_image_layout_transition(vk, vk->cmd, staging->image,
-         VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_GENERAL,
-         VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_HOST_READ_BIT,
+   barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+   barrier.dstAccessMask = VK_ACCESS_HOST_READ_BIT;
+   vkCmdPipelineBarrier(vk->cmd,
          VK_PIPELINE_STAGE_TRANSFER_BIT,
-         VK_PIPELINE_STAGE_HOST_BIT);
+         VK_PIPELINE_STAGE_HOST_BIT, 0,
+         1, &barrier, 0, NULL, 0, NULL);
 }
 
 static void vulkan_inject_black_frame(vk_t *vk, video_frame_info_t *video_info)

--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -1778,7 +1778,7 @@ static bool vulkan_frame(void *data, const void *frame,
          (vulkan_filter_chain_t*)vk->filter_chain,
          vk->cmd, &vk->vk_vp);
    /* Render to backbuffer. */
-   if (chain->backbuffer.image != VK_NULL_HANDLE)
+   if (chain->backbuffer.image != VK_NULL_HANDLE && vk->context->has_acquired_swapchain)
    {
       rp_info.renderPass               = vk->render_pass;
       rp_info.framebuffer              = chain->backbuffer.framebuffer;
@@ -1874,6 +1874,7 @@ static bool vulkan_frame(void *data, const void *frame,
    vulkan_filter_chain_end_frame((vulkan_filter_chain_t*)vk->filter_chain, vk->cmd);
 
    if (chain->backbuffer.image != VK_NULL_HANDLE &&
+         vk->context->has_acquired_swapchain &&
          (vk->readback.pending || vk->readback.streamed))
    {
       /* We cannot safely read back from an image which

--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -1906,7 +1906,8 @@ static bool vulkan_frame(void *data, const void *frame,
 
       vk->readback.pending = false;
    }
-   else if (chain->backbuffer.image != VK_NULL_HANDLE)
+   else if (chain->backbuffer.image != VK_NULL_HANDLE &&
+         vk->context->has_acquired_swapchain)
    {
       /* Prepare backbuffer for presentation. */
       vulkan_image_layout_transition(vk, vk->cmd,
@@ -1966,8 +1967,11 @@ static bool vulkan_frame(void *data, const void *frame,
 
    submit_info.signalSemaphoreCount = 0;
 
-   if (vk->context->swapchain_semaphores[frame_index] != VK_NULL_HANDLE)
+   if (vk->context->swapchain_semaphores[frame_index] != VK_NULL_HANDLE &&
+         vk->context->has_acquired_swapchain)
+   {
       signal_semaphores[submit_info.signalSemaphoreCount++] = vk->context->swapchain_semaphores[frame_index];
+   }
 
    if (vk->hw.signal_semaphore != VK_NULL_HANDLE)
    {
@@ -2009,7 +2013,9 @@ static bool vulkan_frame(void *data, const void *frame,
    /* Disable BFI during fast forward, slow-motion,
     * and pause to prevent flicker. */
    if (
-         video_info->black_frame_insertion
+         chain->backbuffer.image != VK_NULL_HANDLE
+         && vk->context->has_acquired_swapchain
+         && video_info->black_frame_insertion
          && !video_info->input_driver_nonblock_state
          && !video_info->runloop_is_slowmotion
          && !video_info->runloop_is_paused)

--- a/gfx/drivers_context/wgl_ctx.c
+++ b/gfx/drivers_context/wgl_ctx.c
@@ -584,6 +584,8 @@ static bool gfx_ctx_wgl_set_video_mode(void *data,
       unsigned width, unsigned height,
       bool fullscreen)
 {
+   win32_vk.fullscreen = fullscreen;
+
    if (!win32_set_video_mode(NULL, width, height, fullscreen))
    {
       RARCH_ERR("[WGL]: win32_set_video_mode failed.\n");


### PR DESCRIPTION
This is a fairly large maintenance update.
- Use VkBuffer as staging buffers instead of LINEAR VkImage, which isn't guaranteed to be supported, and is also discouraged by desktop vendors.
- Fixes a few minor validation errors uncovered by latest validation layers.
- Should finally fix the broken experience on Vulkan Windows w.r.t toggling fast forward, at least on Windows 10. I've had to make some pretty insane workarounds to workaround bad drivers on Windows, which do not properly support toggling VSync. The fix was to do AcquireNextImageKHR in a thread to fake MAILBOX support.