### PR TITLE
netplay: save lobby details received back from server after first announcement

### DIFF
--- a/network/netplay/netplay_discovery.c
+++ b/network/netplay/netplay_discovery.c
@@ -87,6 +87,13 @@ static struct ad_packet ad_packet_buffer;
 static struct netplay_host_list discovered_hosts;
 static size_t discovered_hosts_allocated;
 
+static struct netplay_room netplay_host_room = {0};
+
+struct netplay_room* netplay_get_host_room(void)
+{
+   return &netplay_host_room;
+}
+
 /** Initialize Netplay discovery (client) */
 bool init_netplay_discovery(void)
 {

--- a/network/netplay/netplay_discovery.h
+++ b/network/netplay/netplay_discovery.h
@@ -54,6 +54,7 @@ struct netplay_host_list
    size_t size;
 };
 
+/* Keep these in order, they coincide with a server-side enum and must match. */
 enum netplay_host_method
 {
    NETPLAY_HOST_METHOD_UNKNOWN = 0,
@@ -64,6 +65,7 @@ enum netplay_host_method
 
 struct netplay_room
 {
+   int id;
    char nickname    [PATH_MAX_LENGTH];
    char address     [PATH_MAX_LENGTH];
    char mitm_address[PATH_MAX_LENGTH];
@@ -97,5 +99,7 @@ void deinit_netplay_discovery(void);
 
 /** Discovery control */
 bool netplay_discovery_driver_ctl(enum rarch_netplay_discovery_ctl_state state, void *data);
+
+struct netplay_room* netplay_get_host_room(void);
 
 #endif

--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -28,6 +28,7 @@
 
 #include <file/file_path.h>
 
+#include "netplay_discovery.h"
 #include "netplay_private.h"
 
 #include "../../configuration.h"
@@ -57,7 +58,7 @@ static unsigned  server_port_deferred = 0;
 static int reannounce = 0;
 static bool is_mitm = false;
 
-bool netplay_disconnect(netplay_t *netplay);
+static bool netplay_disconnect(netplay_t *netplay);
 
 /**
  * netplay_is_alive:
@@ -635,6 +636,7 @@ static void netplay_announce_cb(void *task_data, void *user_data, const char *er
    {
       http_transfer_data_t *data = (http_transfer_data_t*)task_data;
       struct string_list *lines;
+      struct netplay_room *host_room = netplay_get_host_room();
       unsigned i, ip_len, port_len;
       const char *mitm_ip = NULL;
       const char *mitm_port = NULL;
@@ -661,15 +663,88 @@ static void netplay_announce_cb(void *task_data, void *user_data, const char *er
          return;
       }
 
+      memset(host_room, 0, sizeof(*host_room));
+
       for (i = 0; i < lines->size; i++)
       {
          const char *line = lines->elems[i].data;
 
-         if (!strncmp(line, "mitm_ip=", 8))
-            mitm_ip = line + 8;
+         if (!string_is_empty(line))
+         {
+            struct string_list *kv = string_split(line, "=");
+            const char *key = NULL;
+            const char *val = NULL;
 
-         if (!strncmp(line, "mitm_port=", 10))
-            mitm_port = line + 10;
+            if (!kv)
+               continue;
+
+            if (kv->size != 2)
+            {
+               string_list_free(kv);
+               continue;
+            }
+
+            key = kv->elems[0].data;
+            val = kv->elems[1].data;
+
+            if (string_is_equal(key, "id"))
+               sscanf(val, "%i", &host_room->id);
+            if (string_is_equal(key, "username"))
+               strlcpy(host_room->nickname, val, sizeof(host_room->nickname));
+            if (string_is_equal(key, "ip"))
+               strlcpy(host_room->address, val, sizeof(host_room->address));
+            if (string_is_equal(key, "mitm_ip"))
+            {
+               mitm_ip = strdup(val);
+               strlcpy(host_room->mitm_address, val, sizeof(host_room->mitm_address));
+            }
+            if (string_is_equal(key, "port"))
+               sscanf(val, "%i", &host_room->port);
+            if (string_is_equal(key, "mitm_port"))
+            {
+               mitm_port = strdup(val);
+               sscanf(mitm_port, "%i", &host_room->mitm_port);
+            }
+            if (string_is_equal(key, "core_name"))
+               strlcpy(host_room->corename, val, sizeof(host_room->corename));
+            if (string_is_equal(key, "frontend"))
+               strlcpy(host_room->frontend, val, sizeof(host_room->frontend));
+            if (string_is_equal(key, "core_version"))
+               strlcpy(host_room->coreversion, val, sizeof(host_room->coreversion));
+            if (string_is_equal(key, "game_name"))
+               strlcpy(host_room->gamename, val, sizeof(host_room->gamename));
+            if (string_is_equal(key, "game_crc"))
+               sscanf(val, "%08X", &host_room->gamecrc);
+            if (string_is_equal(key, "host_method"))
+               sscanf(val, "%i", &host_room->host_method);
+            if (string_is_equal(key, "has_password"))
+            {
+               if (string_is_equal_noncase(val, "true") || string_is_equal(val, "1"))
+                  host_room->has_password = true;
+               else
+                  host_room->has_password = false;
+            }
+            if (string_is_equal(key, "has_spectate_password"))
+            {
+               if (string_is_equal_noncase(val, "true") || string_is_equal(val, "1"))
+                  host_room->has_spectate_password = true;
+               else
+                  host_room->has_spectate_password = false;
+            }
+            if (string_is_equal(key, "fixed"))
+            {
+               if (string_is_equal_noncase(val, "true") || string_is_equal(val, "1"))
+                  host_room->fixed = true;
+               else
+                  host_room->fixed = false;
+            }
+            if (string_is_equal(key, "retroarch_version"))
+               strlcpy(host_room->retroarch_version, val, sizeof(host_room->retroarch_version));
+            if (string_is_equal(key, "country"))
+               strlcpy(host_room->country, val, sizeof(host_room->country));
+
+            string_list_free(kv);
+         }
       }
 
       if (mitm_ip && mitm_port)
@@ -684,6 +759,7 @@ static void netplay_announce_cb(void *task_data, void *user_data, const char *er
          {
             command_event(CMD_EVENT_NETPLAY_DEINIT, NULL);
             is_mitm = true;
+            host_room->host_method = NETPLAY_HOST_METHOD_MITM;
          }
 
          netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE_CLIENT, NULL);
@@ -704,6 +780,10 @@ static void netplay_announce_cb(void *task_data, void *user_data, const char *er
       string_list_free(lines);
       free(buf);
       free(task_data);
+      if (mitm_ip)
+         free(mitm_ip);
+      if (mitm_port)
+         free(mitm_port);
    }
 
    return;
@@ -755,7 +835,7 @@ void netplay_get_architecture(char *frontend_architecture, size_t size)
 static void netplay_announce(void)
 {
    char buf [2048];
-   char url [2048]               = "http://newlobby.libretro.com/add/";
+   char url [2048]               = "http://lobby.libretro.com/add/";
    char *username                = NULL;
    char *corename                = NULL;
    char *gamename                = NULL;
@@ -1275,7 +1355,7 @@ static void netplay_toggle_play_spectate(netplay_t *netplay)
  *
  * Returns: true (1) if successful. At present, cannot fail.
  **/
-bool netplay_disconnect(netplay_t *netplay)
+static bool netplay_disconnect(netplay_t *netplay)
 {
    size_t i;
 


### PR DESCRIPTION
This adds the function `netplay_get_host_room()` that returns information about the created lobby when hosting a game.

The returned pointer is guaranteed to always be valid, but all fields will be zero until the response comes back from the server when creating a new lobby entry.

Fixes #7199
