### PR TITLE
WIP: Discord "ask to join"

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,7 +15,10 @@
       "*.rh": "c",
       "array": "c",
       "file_stream.h": "c",
-      "driver.h": "c"
+      "driver.h": "c",
+      "iosfwd": "c",
+      "xlocbuf": "c",
+      "xmemory0": "c"
    },
    "C_Cpp.dimInactiveRegions": false,
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,8 @@
       "*.in": "c",
       "*.rh": "c",
       "array": "c",
+      "file_stream.h": "c",
+      "driver.h": "c"
    },
    "C_Cpp.dimInactiveRegions": false,
 }

--- a/command.c
+++ b/command.c
@@ -98,6 +98,8 @@
 #define DEFAULT_NETWORK_CMD_PORT 55355
 #define STDIN_BUF_SIZE           4096
 
+extern bool discord_is_inited;
+
 enum cmd_source_t
 {
    CMD_NONE = 0,
@@ -1980,6 +1982,15 @@ bool command_event(enum event_command cmd, void *data)
             core_unload_game();
             if (!rarch_ctl(RARCH_CTL_IS_DUMMY_CORE, NULL))
                core_unload();
+#ifdef HAVE_DISCORD
+            if (discord_is_inited)
+            {
+               discord_userdata_t userdata;
+               userdata.status = DISCORD_PRESENCE_MENU;
+
+               command_event(CMD_EVENT_DISCORD_UPDATE, &userdata);
+            }
+#endif
          }
          break;
       case CMD_EVENT_QUIT:

--- a/discord/discord.c
+++ b/discord/discord.c
@@ -35,7 +35,7 @@
 #include "../cheevos/cheevos.h"
 #endif
 
-static const char* APPLICATION_ID = "399289711077752833";
+static const char* APPLICATION_ID = "475456035851599874";
 static int FrustrationLevel       = 0;
 
 static int64_t start_time         = 0;

--- a/discord/discord.h
+++ b/discord/discord.h
@@ -32,11 +32,13 @@
 
 enum discord_presence
 {
-   DISCORD_PRESENCE_MENU = 0,
+   DISCORD_PRESENCE_NONE = 0,
+   DISCORD_PRESENCE_MENU,
    DISCORD_PRESENCE_GAME,
    DISCORD_PRESENCE_GAME_PAUSED,
    DISCORD_PRESENCE_CHEEVO_UNLOCKED,
    DISCORD_PRESENCE_NETPLAY_HOSTING,
+   DISCORD_PRESENCE_NETPLAY_HOSTING_STOPPED,
    DISCORD_PRESENCE_NETPLAY_CLIENT
 };
 
@@ -50,5 +52,7 @@ void discord_init(void);
 void discord_shutdown(void);
 
 void discord_update(enum discord_presence presence);
+
+void discord_run_callbacks();
 
 #endif /* __RARCH_DISCORD_H */

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -467,16 +467,17 @@ bool menu_display_libretro(bool is_idle,
       return true;
    }
 
-#ifdef HAVE_DISCORD
-   discord_userdata_t userdata;
-   userdata.status = DISCORD_PRESENCE_GAME_PAUSED;
-
-   command_event(CMD_EVENT_DISCORD_UPDATE, &userdata);
-#endif
-
    if (is_idle)
+   {
+#ifdef HAVE_DISCORD
+      discord_userdata_t userdata;
+      userdata.status = DISCORD_PRESENCE_GAME_PAUSED;
+
+      command_event(CMD_EVENT_DISCORD_UPDATE, &userdata);
+#endif
       return true; /* Maybe return false here
                       for indication of idleness? */
+   }
    return video_driver_cached_frame();
 }
 

--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -26,6 +26,10 @@
 #include <string/stdstring.h>
 #include <net/net_http.h>
 
+#ifdef HAVE_DISCORD
+#include <discord/discord.h>
+#endif
+
 #include <file/file_path.h>
 
 #include "netplay_discovery.h"
@@ -59,6 +63,10 @@ static int reannounce = 0;
 static bool is_mitm = false;
 
 static bool netplay_disconnect(netplay_t *netplay);
+
+#ifdef HAVE_DISCORD
+extern bool discord_is_inited;
+#endif
 
 /**
  * netplay_is_alive:
@@ -1490,6 +1498,14 @@ bool netplay_driver_ctl(enum rarch_netplay_ctl_state state, void *data)
          case RARCH_NETPLAY_CTL_ENABLE_SERVER:
             netplay_enabled = true;
             netplay_is_client = false;
+#ifdef HAVE_DISCORD
+            if (discord_is_inited)
+            {
+               discord_userdata_t userdata;
+               userdata.status = DISCORD_PRESENCE_NETPLAY_HOSTING;
+               command_event(CMD_EVENT_DISCORD_UPDATE, &userdata);
+            }
+#endif
             goto done;
 
          case RARCH_NETPLAY_CTL_ENABLE_CLIENT:
@@ -1499,6 +1515,14 @@ bool netplay_driver_ctl(enum rarch_netplay_ctl_state state, void *data)
 
          case RARCH_NETPLAY_CTL_DISABLE:
             netplay_enabled = false;
+#ifdef HAVE_DISCORD
+            if (discord_is_inited)
+            {
+               discord_userdata_t userdata;
+               userdata.status = DISCORD_PRESENCE_NETPLAY_HOSTING_STOPPED;
+               command_event(CMD_EVENT_DISCORD_UPDATE, &userdata);
+            }
+#endif
             goto done;
 
          case RARCH_NETPLAY_CTL_IS_ENABLED:

--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -640,6 +640,15 @@ static void netplay_announce_cb(void *task_data, void *user_data, const char *er
 {
    RARCH_LOG("[netplay] announcing netplay game... \n");
 
+#ifdef HAVE_DISCORD
+   if (discord_is_inited)
+   {
+      discord_userdata_t userdata;
+      userdata.status = DISCORD_PRESENCE_NETPLAY_HOSTING;
+      command_event(CMD_EVENT_DISCORD_UPDATE, &userdata);
+   }
+#endif
+
    if (task_data)
    {
       unsigned i, ip_len, port_len;
@@ -1498,14 +1507,6 @@ bool netplay_driver_ctl(enum rarch_netplay_ctl_state state, void *data)
          case RARCH_NETPLAY_CTL_ENABLE_SERVER:
             netplay_enabled = true;
             netplay_is_client = false;
-#ifdef HAVE_DISCORD
-            if (discord_is_inited)
-            {
-               discord_userdata_t userdata;
-               userdata.status = DISCORD_PRESENCE_NETPLAY_HOSTING;
-               command_event(CMD_EVENT_DISCORD_UPDATE, &userdata);
-            }
-#endif
             goto done;
 
          case RARCH_NETPLAY_CTL_ENABLE_CLIENT:
@@ -1541,6 +1542,7 @@ bool netplay_driver_ctl(enum rarch_netplay_ctl_state state, void *data)
          case RARCH_NETPLAY_CTL_IS_CONNECTED:
             ret = false;
             goto done;
+
          default:
             goto done;
       }

--- a/retroarch.c
+++ b/retroarch.c
@@ -204,7 +204,7 @@ static retro_bits_t has_set_libretro_device;
 static bool has_set_core                                        = false;
 static bool has_set_username                                    = false;
 #ifdef HAVE_DISCORD
-static bool discord_is_inited                                   = false;
+bool discord_is_inited                                         = false;
 #endif
 static bool rarch_is_inited                                     = false;
 static bool rarch_error_on_init                                 = false;
@@ -3357,6 +3357,13 @@ int runloop_iterate(unsigned *sleep_ms)
    settings_t *settings                         = config_get_ptr();
    unsigned max_users                           = *(input_driver_get_uint(INPUT_ACTION_MAX_USERS));
 
+   if (discord_is_inited)
+   {
+#ifdef HAVE_DISCORD
+      discord_run_callbacks();
+#endif
+   }
+
    if (runloop_frame_time.callback)
    {
       /* Updates frame timing if frame timing callback is in use by the core.
@@ -3452,7 +3459,6 @@ int runloop_iterate(unsigned *sleep_ms)
    if (runloop_check_cheevos())
       cheevos_test();
 #endif
-
    cheat_manager_apply_retro_cheats() ;
 
 #ifdef HAVE_DISCORD


### PR DESCRIPTION
**Feature video**:

[![](http://img.youtube.com/vi/E0bUwKn-D2w/0.jpg)](http://www.youtube.com/watch?v=E0bUwKn-D2w "")

Ok so first things first:

The Application ID should not be merged or should be reset after merging.
As for testing, make sure you add me and other users to your application whitelist here:

https://discordapp.com/developers/applications/

To get the feature approved for all users you need to submit a video and an explanation, process outlined here:

https://discordapp.com/developers/docs/rich-presence/getting-approved

**Make sure to make a good video**.

Before merging also consider this:

> To keep security on the up and up, Discord requires that you properly hash/encode/encrypt/put-a-padlock-on-and-swallow-the-key-but-wait-then-how-would-you-open-it your secrets.

> When you send the relevant payload data in the Discord_UpdatePresence() call, your player will gain the ability to invite a Discord chat channel to spectate their game. This invite is tied to the matchSecret and will expire when it changes.

> Other Discord users can click "Spectate" on the invitation. Their game will launch, and the spectateGame() callback will fire in their client with the original player's spectateSecret. The client should reverse hash or otherwise unencrypt this secret and spectate that player's game.

The secret right now is:
`IP|PORT|GAMENAME|GAMECRC|CORENAME`

so:
`255.255.255.255|55435|Super Mario Kart|00000000|Snes9x 2010`

The string limit is 128, and it's not encrypted yet, might have to look at that before submitting.
An alternative would be to just use the lobby id (encrypted), I considered it since we use the lobby after all, I just got lazy. Requires querying the lobby list and rewriting the connect code, query the lobby list then connect. May be better in the long run.

Also password support would be nice (so it could be a public lobby protected by password, and also it would forward the password automatically to discord clients)

AND, I didn't test MITM, try with that enabled too.

Lastly, spectator mode is not implemented (but it's trivial), just follow the same concept.

Also I think there are too many caveats in the netplay subsystem for this to be able to shine. I'll outline them here:

- The input sharing stuff is still quite hard to figure out, the menu entries don't really help
- Need a way to determine if ports were forwarded succesfully. If they weren't fallback automatically to relay
- Floating lag indicator or something like that (requires in-game widgets, requires PING command in the protocol)
- In-game dialog to accept/refuse a discord connection
- Relay/MITM disconnects on client load state

IF we ever get in-game widgets I'd like something like what switch online games are doing, show the avatar of the connected users in a corner together with the indicator:

![image](https://user-images.githubusercontent.com/1721040/45407473-1f523700-b62f-11e8-93fc-dc7b933d5e82.png)

FWIW I have had this idea for years but the lack of in-game widgets has prevented me from doing anything about it.

Also for in-game chat, we could try to leverage discord to create game parties, the overlay now works, but that needs a far deeper understanding of the API

This is how the discord overlay looks:

![image](https://user-images.githubusercontent.com/1721040/45407422-ffbb0e80-b62e-11e8-8c9a-98a2e6251cfa.png)

Of course we need a fallback (not all platforms support discord/discord-rpc)

Feel free to merge whenever you like, it's as far as I can take the feature right now.