### PR TITLE
(Emscripten) Add ChaiLove selection to web player

### DIFF
--- a/pkg/emscripten/libretro/embed.html
+++ b/pkg/emscripten/libretro/embed.html
@@ -28,6 +28,7 @@
                   <li class="nav-item dropdown">
                         <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Core Selection</button>
                         <div class="dropdown-menu dropdown-primary" aria-labelledby="dropdownMenu1" data-dropdown-in="fadeIn" data-dropdown-out="fadeOut" id="core-selector">
+                          <a class="dropdown-item" href="." data-core="chailove">ChaiLove</a>
                           <a class="dropdown-item" href="." data-core="fceumm">FCEUmm</a>
                           <a class="dropdown-item" href="." data-core="gambatte">Gambatte</a>
                           <a class="dropdown-item" href="." data-core="genesis_plus_gx">Genesis Plus GX</a>

--- a/pkg/emscripten/libretro/index.html
+++ b/pkg/emscripten/libretro/index.html
@@ -30,6 +30,7 @@
                            <a class="dropdown-item" href="." data-core="2048">2048</a>
                            <a class="dropdown-item" href="." data-core="4do">4DO</a>
                            <a class="dropdown-item" href="." data-core="bluemsx">BlueMSX</a>
+                           <a class="dropdown-item" href="." data-core="chailove">ChaiLove</a>
                            <a class="dropdown-item" href="." data-core="craft">Craft</a>
                            <a class="dropdown-item" href="." data-core="desmume">DeSmuME</a>
                            <a class="dropdown-item" href="." data-core="dosbox">DOSBox</a>


### PR DESCRIPTION
This allows selecting [ChaiLove](https://github.com/libretro/libretro-chailove) in the [RetroArch web player](https://web.libretro.com/). It builds correctly on buildbot.