### PR TITLE
Assign some of the cheats menu to 'Advanced Settings'

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -67,8 +67,8 @@ static bool bundle_assets_extract_enable = false;
 static bool materialui_icons_enable      = true;
 #endif
 
-static const bool crt_switch_resolution = false; 	
-static const int crt_switch_resolution_super = 2560; 
+static const bool crt_switch_resolution = false;
+static const int crt_switch_resolution_super = 2560;
 
 
 static const bool def_history_list_enable = true;
@@ -527,7 +527,7 @@ static const bool framecount_show = true;
 static const bool rewind_enable = false;
 
 /* When set, any time a cheat is toggled it is immediately applied. */
-static const bool apply_cheats_after_toggle = false;
+static const bool apply_cheats_after_toggle = true;
 
 /* When set, all enabled cheats are auto-applied when a game is loaded. */
 static const bool apply_cheats_after_load = false;

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -3217,14 +3217,16 @@ static int menu_displaylist_parse_options_cheats(
       menu_displaylist_parse_settings_enum(menu, info,
             MENU_ENUM_LABEL_CHEAT_APPLY_AFTER_LOAD,
             PARSE_ONLY_BOOL, false);
-   menu_displaylist_parse_settings_enum(menu, info,
-         MENU_ENUM_LABEL_CHEAT_APPLY_AFTER_TOGGLE,
-         PARSE_ONLY_BOOL, false);
-   menu_entries_append_enum(info->list,
-         msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_APPLY_CHANGES),
-         msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_APPLY_CHANGES),
-         MENU_ENUM_LABEL_CHEAT_APPLY_CHANGES,
-         MENU_SETTING_ACTION, 0, 0);
+   if (show_advanced_settings)
+      menu_displaylist_parse_settings_enum(menu, info,
+            MENU_ENUM_LABEL_CHEAT_APPLY_AFTER_TOGGLE,
+            PARSE_ONLY_BOOL, false);
+   if (show_advanced_settings)
+      menu_entries_append_enum(info->list,
+            msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_APPLY_CHANGES),
+            msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_APPLY_CHANGES),
+            MENU_ENUM_LABEL_CHEAT_APPLY_CHANGES,
+            MENU_SETTING_ACTION, 0, 0);
    for (i = 0; i < cheat_manager_get_size(); i++)
    {
       char cheat_label[64];

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -3160,53 +3160,63 @@ static int menu_displaylist_parse_options_cheats(
       menu_displaylist_info_t *info, menu_handle_t *menu)
 {
    unsigned i;
+   settings_t *settings        = config_get_ptr();
+   bool show_advanced_settings = settings->bools.menu_show_advanced_settings;
 
    if (!cheat_manager_alloc_if_empty())
       return -1;
 
-   menu_entries_append_enum(info->list,
-         msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_START_OR_CONT),
-         msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_START_OR_CONT),
-         MENU_ENUM_LABEL_CHEAT_START_OR_CONT,
-         MENU_SETTING_ACTION, 0, 0);
+   if (show_advanced_settings)
+      menu_entries_append_enum(info->list,
+            msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_START_OR_CONT),
+            msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_START_OR_CONT),
+            MENU_ENUM_LABEL_CHEAT_START_OR_CONT,
+            MENU_SETTING_ACTION, 0, 0);
    menu_entries_append_enum(info->list,
          msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_FILE_LOAD),
          msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_FILE_LOAD),
          MENU_ENUM_LABEL_CHEAT_FILE_LOAD,
          MENU_SETTING_ACTION, 0, 0);
-   menu_entries_append_enum(info->list,
-         msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_FILE_LOAD_APPEND),
-         msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_FILE_LOAD_APPEND),
-         MENU_ENUM_LABEL_CHEAT_FILE_LOAD_APPEND,
-         MENU_SETTING_ACTION, 0, 0);
-   menu_entries_append_enum(info->list,
-         msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_RELOAD_CHEATS),
-         msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_RELOAD_CHEATS),
-         MENU_ENUM_LABEL_CHEAT_RELOAD_CHEATS,
-         MENU_SETTING_ACTION, 0, 0);
-   menu_entries_append_enum(info->list,
-         msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_FILE_SAVE_AS),
-         msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_FILE_SAVE_AS),
-         MENU_ENUM_LABEL_CHEAT_FILE_SAVE_AS,
-         MENU_SETTING_ACTION, 0, 0);
-   menu_entries_append_enum(info->list,
-         msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_ADD_NEW_TOP),
-         msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_ADD_NEW_TOP),
-         MENU_ENUM_LABEL_CHEAT_ADD_NEW_TOP,
-         MENU_SETTING_ACTION, 0, 0);
+   if (show_advanced_settings)
+      menu_entries_append_enum(info->list,
+            msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_FILE_LOAD_APPEND),
+            msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_FILE_LOAD_APPEND),
+            MENU_ENUM_LABEL_CHEAT_FILE_LOAD_APPEND,
+            MENU_SETTING_ACTION, 0, 0);
+
+   if (show_advanced_settings)
+      menu_entries_append_enum(info->list,
+            msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_RELOAD_CHEATS),
+            msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_RELOAD_CHEATS),
+            MENU_ENUM_LABEL_CHEAT_RELOAD_CHEATS,
+            MENU_SETTING_ACTION, 0, 0);
+   if (show_advanced_settings)
+      menu_entries_append_enum(info->list,
+            msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_FILE_SAVE_AS),
+            msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_FILE_SAVE_AS),
+            MENU_ENUM_LABEL_CHEAT_FILE_SAVE_AS,
+            MENU_SETTING_ACTION, 0, 0);
+   if (show_advanced_settings)
+      menu_entries_append_enum(info->list,
+            msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_ADD_NEW_TOP),
+            msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_ADD_NEW_TOP),
+            MENU_ENUM_LABEL_CHEAT_ADD_NEW_TOP,
+            MENU_SETTING_ACTION, 0, 0);
    menu_entries_append_enum(info->list,
          msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_ADD_NEW_BOTTOM),
          msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_ADD_NEW_BOTTOM),
          MENU_ENUM_LABEL_CHEAT_ADD_NEW_BOTTOM,
          MENU_SETTING_ACTION, 0, 0);
-   menu_entries_append_enum(info->list,
-         msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_DELETE_ALL),
-         msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_DELETE_ALL),
-         MENU_ENUM_LABEL_CHEAT_DELETE_ALL,
-         MENU_SETTING_ACTION, 0, 0);
-   menu_displaylist_parse_settings_enum(menu, info,
-         MENU_ENUM_LABEL_CHEAT_APPLY_AFTER_LOAD,
-         PARSE_ONLY_BOOL, false);
+   if (show_advanced_settings)
+      menu_entries_append_enum(info->list,
+            msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_DELETE_ALL),
+            msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_DELETE_ALL),
+            MENU_ENUM_LABEL_CHEAT_DELETE_ALL,
+            MENU_SETTING_ACTION, 0, 0);
+   if (show_advanced_settings)
+      menu_displaylist_parse_settings_enum(menu, info,
+            MENU_ENUM_LABEL_CHEAT_APPLY_AFTER_LOAD,
+            PARSE_ONLY_BOOL, false);
    menu_displaylist_parse_settings_enum(menu, info,
          MENU_ENUM_LABEL_CHEAT_APPLY_AFTER_TOGGLE,
          PARSE_ONLY_BOOL, false);


### PR DESCRIPTION
Following https://github.com/libretro/RetroArch/issues/7212#issuecomment-421174838 , this is the first step in cleaning up the cheats menu. It shows some advanced cheat management only when you have "Advanced Settings" enabled. The result is a trimmed down Cheats menu....

![screenshot at 2018-09-15 10-15-02](https://user-images.githubusercontent.com/25086/45587173-3d8a9200-b8d0-11e8-8a9f-6e977adc2f0c.png)


It also defaults "Apply After Toggle" to true, so that cheats are applied directly after you switch them on, saving another step for end users.

## Reviewers

- @RetroSven 