### PR TITLE
[recording] hook up the options properly

### DIFF
--- a/command.c
+++ b/command.c
@@ -2170,7 +2170,6 @@ TODO: Add a setting for these tweaks */
          break;
       case CMD_EVENT_RECORD_DEINIT:
          {
-            recording_set_state(false);
             if (!recording_deinit())
                return false;
          }

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -71,6 +71,8 @@
 #include "../cheevos/cheevos.h"
 #endif
 
+#include "record/record_driver.h"
+
 enum
 {
    ACTION_OK_LOAD_PRESET = 0,
@@ -2681,40 +2683,34 @@ static int action_ok_cheat_reload_cheats(const char *path,
 static int action_ok_start_recording(const char *path,
       const char *label, unsigned type, size_t idx, size_t entry_idx)
 {
-   /* TODO/FIXME */
-#if 0
-   streaming_set_status(false);
-#endif
+   streaming_set_state(false);
    command_event(CMD_EVENT_RECORD_INIT, NULL);
-
    return 0;
 }
 
 static int action_ok_start_streaming(const char *path,
       const char *label, unsigned type, size_t idx, size_t entry_idx)
 {
-   /* TODO/FIXME */
-#if 0
-   streaming_set_status(true);
-#endif
+   streaming_set_state(true);
    command_event(CMD_EVENT_RECORD_INIT, NULL);
-
    return 0;
 }
 
 static int action_ok_stop_recording(const char *path,
       const char *label, unsigned type, size_t idx, size_t entry_idx)
 {
-   /* TODO/FIXME */
-
+   recording_set_state(false);
+   streaming_set_state(false);
+   command_event(CMD_EVENT_RECORD_DEINIT, NULL);
    return 0;
 }
 
 static int action_ok_stop_streaming(const char *path,
       const char *label, unsigned type, size_t idx, size_t entry_idx)
 {
-   /* TODO/FIXME */
-
+   recording_set_state(false);
+   streaming_set_state(false);
+   command_event(CMD_EVENT_RECORD_DEINIT, NULL);
    return 0;
 }
 

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -2685,7 +2685,7 @@ static int action_ok_start_recording(const char *path,
 {
    streaming_set_state(false);
    command_event(CMD_EVENT_RECORD_INIT, NULL);
-   return 0;
+   return generic_action_ok_command(CMD_EVENT_RESUME);
 }
 
 static int action_ok_start_streaming(const char *path,
@@ -2693,7 +2693,7 @@ static int action_ok_start_streaming(const char *path,
 {
    streaming_set_state(true);
    command_event(CMD_EVENT_RECORD_INIT, NULL);
-   return 0;
+   return generic_action_ok_command(CMD_EVENT_RESUME);
 }
 
 static int action_ok_stop_recording(const char *path,
@@ -2702,7 +2702,7 @@ static int action_ok_stop_recording(const char *path,
    recording_set_state(false);
    streaming_set_state(false);
    command_event(CMD_EVENT_RECORD_DEINIT, NULL);
-   return 0;
+   return generic_action_ok_command(CMD_EVENT_RESUME);
 }
 
 static int action_ok_stop_streaming(const char *path,
@@ -2711,7 +2711,7 @@ static int action_ok_stop_streaming(const char *path,
    recording_set_state(false);
    streaming_set_state(false);
    command_event(CMD_EVENT_RECORD_DEINIT, NULL);
-   return 0;
+   return generic_action_ok_command(CMD_EVENT_RESUME);
 }
 
 static int action_ok_cheat_add_top(const char *path,

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -2669,16 +2669,16 @@ static int menu_displaylist_parse_load_content_settings(
       }
       else
       {
-         menu_entries_append_enum(info->list,
-               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_QUICK_MENU_STOP_RECORDING),
-               msg_hash_to_str(MENU_ENUM_LABEL_QUICK_MENU_STOP_RECORDING),
-               MENU_ENUM_LABEL_QUICK_MENU_STOP_RECORDING, MENU_SETTING_ACTION, 0, 0);
-
-         if (!streaming_is_enabled())
+         if (streaming_is_enabled())
             menu_entries_append_enum(info->list,
                   msg_hash_to_str(MENU_ENUM_LABEL_VALUE_QUICK_MENU_STOP_STREAMING),
                   msg_hash_to_str(MENU_ENUM_LABEL_QUICK_MENU_STOP_STREAMING),
                   MENU_ENUM_LABEL_QUICK_MENU_STOP_STREAMING, MENU_SETTING_ACTION, 0, 0);
+         else
+            menu_entries_append_enum(info->list,
+               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_QUICK_MENU_STOP_RECORDING),
+               msg_hash_to_str(MENU_ENUM_LABEL_QUICK_MENU_STOP_RECORDING),
+               MENU_ENUM_LABEL_QUICK_MENU_STOP_RECORDING, MENU_SETTING_ACTION, 0, 0);
 
       }
 

--- a/record/record_driver.c
+++ b/record/record_driver.c
@@ -356,6 +356,8 @@ bool recording_init()
          (float)av_info->timing.fps,
          (float)av_info->timing.sample_rate);
 
+   RARCH_LOG("STREAM!!! %d\n", streaming_is_enabled());
+
    if (!string_is_empty(global->record.path))
       strlcpy(output, global->record.path, sizeof(output));
    else

--- a/record/record_driver.h
+++ b/record/record_driver.h
@@ -164,6 +164,8 @@ bool recording_is_enabled(void);
 
 void recording_set_state(bool state);
 
+void streaming_set_state(bool state);
+
 void recording_push_audio(const int16_t *data, size_t samples);
 
 void *recording_driver_get_data_ptr(void);


### PR DESCRIPTION
Ok, fixed up the options, still need:
~~- Refresh menu entries when one of the options has been used~~
~~- Toggle menu off when one of the options has been used~~

Also we need menu entries for the new settings.

`video_record_config` maps to `settings->paths.path_record_config`
`video_stream_config` maps to `settings->paths.path_stream_config`
`video_stream_port` maps to `settings->uints.video_stream_port`
`video_stream_url` maps to `settings->paths.video_stream_url`

Those should be under recording.
And these:

![image](https://user-images.githubusercontent.com/1721040/45628675-32636d80-ba5a-11e8-8b2b-6ddb6345083b.png)

Are probably no longer relevant.