### PR TITLE
[iOS] Comment out unsupported code for iOS for now, so that it does not crash

### DIFF
--- a/gfx/drivers_context/macos_ctx.m
+++ b/gfx/drivers_context/macos_ctx.m
@@ -299,7 +299,8 @@ static void *cocoagl_gfx_ctx_init(video_frame_info_t *video_info, void *video_dr
    {
 #if defined(HAVE_COCOATOUCH)
       case GFX_CTX_OPENGL_ES_API:
-         [apple_platform setViewType:APPLE_VIEW_TYPE_OPENGL_ES];
+         // setViewType is not (yet?) defined for iOS
+         // [apple_platform setViewType:APPLE_VIEW_TYPE_OPENGL_ES];
          break;
 #elif defined(HAVE_COCOA)
       case GFX_CTX_OPENGL_API:

--- a/pkg/apple/code-sign-cores.sh
+++ b/pkg/apple/code-sign-cores.sh
@@ -43,7 +43,9 @@ echo "${ITEMS}"
 
 # Change the Internal Field Separator (IFS) so that spaces in paths will not cause problems below.
 SAVED_IFS=$IFS
-IFS=$(echo -en "\n\b")
+# Doing IFS=$(echo -en "\n") does not work on Xcode 10 for some reason
+IFS="
+"
 
 # Loop through all items.
 for ITEM in $ITEMS;


### PR DESCRIPTION
## Description

Comments out code that prevented startup on iOS. I assume this is part of a larger effort to support the Metal renderer, but just not ready for iOS yet.

Also fixed the script that code signed the cores. For some reason, the IFS wasn't getting redefined correctly in Xcode 10. I blame Apple :)

Thanks to @Alex793 for finding out that merely skipping the code in question just made it work.

Addresses issue #7256 

## Reviewers

@stuartcarnie @twinaphex 
