### PR TITLE
menu_display_gl: added scissoring support

### DIFF
--- a/menu/drivers_display/menu_display_caca.c
+++ b/menu/drivers_display/menu_display_caca.c
@@ -101,5 +101,7 @@ menu_display_ctx_driver_t menu_display_ctx_caca = {
    menu_display_caca_font_init_first,
    MENU_VIDEO_DRIVER_CACA,
    "menu_display_caca",
-   false
+   false,
+   NULL,
+   NULL
 };

--- a/menu/drivers_display/menu_display_ctr.c
+++ b/menu/drivers_display/menu_display_ctr.c
@@ -211,5 +211,7 @@ menu_display_ctx_driver_t menu_display_ctx_ctr = {
    menu_display_ctr_font_init_first,
    MENU_VIDEO_DRIVER_CTR,
    "menu_display_ctr",
-   true
+   true,
+   NULL,
+   NULL
 };

--- a/menu/drivers_display/menu_display_d3d10.c
+++ b/menu/drivers_display/menu_display_d3d10.c
@@ -289,5 +289,7 @@ menu_display_ctx_driver_t menu_display_ctx_d3d10 = {
    menu_display_d3d10_font_init_first,
    MENU_VIDEO_DRIVER_DIRECT3D10,
    "menu_display_d3d10",
-   true
+   true,
+   NULL,
+   NULL
 };

--- a/menu/drivers_display/menu_display_d3d11.c
+++ b/menu/drivers_display/menu_display_d3d11.c
@@ -288,5 +288,7 @@ menu_display_ctx_driver_t menu_display_ctx_d3d11 = {
    menu_display_d3d11_font_init_first,
    MENU_VIDEO_DRIVER_DIRECT3D11,
    "menu_display_d3d11",
-   true
+   true,
+   NULL,
+   NULL
 };

--- a/menu/drivers_display/menu_display_d3d12.c
+++ b/menu/drivers_display/menu_display_d3d12.c
@@ -309,5 +309,7 @@ menu_display_ctx_driver_t menu_display_ctx_d3d12 = {
    menu_display_d3d12_font_init_first,
    MENU_VIDEO_DRIVER_DIRECT3D12,
    "menu_display_d3d12",
-   true
+   true,
+   NULL,
+   NULL
 };

--- a/menu/drivers_display/menu_display_d3d8.c
+++ b/menu/drivers_display/menu_display_d3d8.c
@@ -286,5 +286,7 @@ menu_display_ctx_driver_t menu_display_ctx_d3d8 = {
    menu_display_d3d8_font_init_first,
    MENU_VIDEO_DRIVER_DIRECT3D8,
    "menu_display_d3d8",
-   false
+   false,
+   NULL,
+   NULL
 };

--- a/menu/drivers_display/menu_display_d3d9.c
+++ b/menu/drivers_display/menu_display_d3d9.c
@@ -323,5 +323,7 @@ menu_display_ctx_driver_t menu_display_ctx_d3d9 = {
    menu_display_d3d9_font_init_first,
    MENU_VIDEO_DRIVER_DIRECT3D9,
    "menu_display_d3d9",
-   false
+   false,
+   NULL,
+   NULL
 };

--- a/menu/drivers_display/menu_display_gdi.c
+++ b/menu/drivers_display/menu_display_gdi.c
@@ -110,5 +110,7 @@ menu_display_ctx_driver_t menu_display_ctx_gdi = {
    menu_display_gdi_font_init_first,
    MENU_VIDEO_DRIVER_GDI,
    "menu_display_gdi",
-   false
+   false,
+   NULL,
+   NULL
 };

--- a/menu/drivers_display/menu_display_gl.c
+++ b/menu/drivers_display/menu_display_gl.c
@@ -250,6 +250,18 @@ static bool menu_display_gl_font_init_first(
    return true;
 }
 
+static void menu_display_gl_scissor_begin(video_frame_info_t *video_info, int x, int y,
+      unsigned width, unsigned height)
+{
+   glScissor(x, video_info->height - y - height, width, height);
+   glEnable(GL_SCISSOR_TEST);
+}
+
+static void menu_display_gl_scissor_end()
+{
+   glDisable(GL_SCISSOR_TEST);
+}
+
 menu_display_ctx_driver_t menu_display_ctx_gl = {
    menu_display_gl_draw,
    menu_display_gl_draw_pipeline,
@@ -264,5 +276,7 @@ menu_display_ctx_driver_t menu_display_ctx_gl = {
    menu_display_gl_font_init_first,
    MENU_VIDEO_DRIVER_OPENGL,
    "menu_display_gl",
-   false
+   false,
+   menu_display_gl_scissor_begin,
+   menu_display_gl_scissor_end
 };

--- a/menu/drivers_display/menu_display_metal.m
+++ b/menu/drivers_display/menu_display_metal.m
@@ -135,5 +135,7 @@ menu_display_ctx_driver_t menu_display_ctx_metal = {
    .type                   = MENU_VIDEO_DRIVER_METAL,
    .ident                  = "menu_display_metal",
    .handles_transform      = NO,
+   .scissor_begin          = NULL,
+   .scissor_end            = NULL
 };
 

--- a/menu/drivers_display/menu_display_null.c
+++ b/menu/drivers_display/menu_display_null.c
@@ -96,5 +96,7 @@ menu_display_ctx_driver_t menu_display_ctx_null = {
    menu_display_null_font_init_first,
    MENU_VIDEO_DRIVER_GENERIC,
    "menu_display_null",
-   false
+   false,
+   NULL,
+   NULL
 };

--- a/menu/drivers_display/menu_display_sixel.c
+++ b/menu/drivers_display/menu_display_sixel.c
@@ -103,4 +103,7 @@ menu_display_ctx_driver_t menu_display_ctx_sixel = {
    menu_display_sixel_font_init_first,
    MENU_VIDEO_DRIVER_SIXEL,
    "menu_display_sixel",
+   false,
+   NULL,
+   NULL
 };

--- a/menu/drivers_display/menu_display_switch.c
+++ b/menu/drivers_display/menu_display_switch.c
@@ -100,5 +100,7 @@ menu_display_ctx_driver_t menu_display_ctx_switch = {
    menu_display_switch_font_init_first,
    MENU_VIDEO_DRIVER_SWITCH,
    "menu_display_switch",
-   false
+   false,
+   NULL,
+   NULL
 };

--- a/menu/drivers_display/menu_display_vga.c
+++ b/menu/drivers_display/menu_display_vga.c
@@ -102,5 +102,7 @@ menu_display_ctx_driver_t menu_display_ctx_vga = {
    menu_display_vga_font_init_first,
    MENU_VIDEO_DRIVER_VGA,
    "menu_display_vga",
-   false
+   false,
+   NULL,
+   NULL
 };

--- a/menu/drivers_display/menu_display_vita2d.c
+++ b/menu/drivers_display/menu_display_vita2d.c
@@ -248,5 +248,7 @@ menu_display_ctx_driver_t menu_display_ctx_vita2d = {
    menu_display_vita2d_font_init_first,
    MENU_VIDEO_DRIVER_VITA2D,
    "menu_display_vita2d",
-   true
+   true,
+   NULL,
+   NULL
 };

--- a/menu/drivers_display/menu_display_vulkan.c
+++ b/menu/drivers_display/menu_display_vulkan.c
@@ -360,5 +360,7 @@ menu_display_ctx_driver_t menu_display_ctx_vulkan = {
    menu_display_vk_font_init_first,
    MENU_VIDEO_DRIVER_VULKAN,
    "menu_display_vulkan",
-   false
+   false,
+   NULL,
+   NULL
 };

--- a/menu/drivers_display/menu_display_wiiu.c
+++ b/menu/drivers_display/menu_display_wiiu.c
@@ -342,5 +342,7 @@ menu_display_ctx_driver_t menu_display_ctx_wiiu = {
    menu_display_wiiu_font_init_first,
    MENU_VIDEO_DRIVER_WIIU,
    "menu_display_wiiu",
-   true
+   true,
+   NULL,
+   NULL
 };

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -385,6 +385,20 @@ void menu_display_blend_end(video_frame_info_t *video_info)
       menu_disp->blend_end(video_info);
 }
 
+/* Begin scissoring operation */
+void menu_display_scissor_begin(video_frame_info_t *video_info, int x, int y, unsigned width, unsigned height)
+{
+   if (menu_disp && menu_disp->scissor_begin)
+      menu_disp->scissor_begin(video_info, x, y, width, height);
+}
+
+/* End scissoring operation */
+void menu_display_scissor_end()
+{
+   if (menu_disp && menu_disp->scissor_end)
+      menu_disp->scissor_end();
+}
+
 /* Teardown; deinitializes and frees all
  * fonts associated to the menu driver */
 void menu_display_font_free(font_data_t *font)

--- a/menu/menu_driver.h
+++ b/menu/menu_driver.h
@@ -378,6 +378,9 @@ typedef struct menu_display_ctx_driver
    enum menu_display_driver_type type;
    const char *ident;
    bool handles_transform;
+   /* Enables and disables scissoring */
+   void (*scissor_begin)(video_frame_info_t *video_info, int x, int y, unsigned width, unsigned height);
+   void (*scissor_end)(void);
 } menu_display_ctx_driver_t;
 
 
@@ -671,6 +674,9 @@ void menu_display_toggle_set_reason(enum menu_toggle_reason reason);
 
 void menu_display_blend_begin(video_frame_info_t *video_info);
 void menu_display_blend_end(video_frame_info_t *video_info);
+
+void menu_display_scissor_begin(video_frame_info_t *video_info, int x, int y, unsigned width, unsigned height);
+void menu_display_scissor_end();
 
 void menu_display_font_free(font_data_t *font);
 


### PR DESCRIPTION
## Description

This adds scissoring support to the GL menu display driver. Others drivers will need to be updated to implement scissoring too.

I added two new functions to the menu display driver, `scissor_begin` and `scissor_end`, along with two functions `menu_display_scissor_begin(int, int, unsigned, unsigned)` and `menu_display_scissor_end(void)`.
