### PR TITLE
more precise definition of cheevos_hardcore_active

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -3154,7 +3154,7 @@ static enum runloop_state runloop_check_state(
 #ifdef HAVE_CHEEVOS
    cheevos_hardcore_active =  settings->bools.cheevos_enable
                               && settings->bools.cheevos_hardcore_mode_enable
-                              && cheevos_loaded && !cheevos_hardcore_paused;
+                              && !cheevos_hardcore_paused;
 
    if (!cheevos_hardcore_active)
 #endif


### PR DESCRIPTION
## Description

Currently `cheevos_loaded` is one of the conditions that must be true to make `cheevos_hardcore_active` be true.

The problem is, once the achievements are loaded in parallel with the emulation, there's a small time interval right after the ROM is loaded and before the cheevos are loaded where the `cheevos_hardcore_active` is not yet true. And this is an unwanted behavior.


## Reviewers

@fr500 @leiradel 