### PR TITLE
(Menu) Fix crash when changing core's options on Android

### DIFF
--- a/menu/menu_input.c
+++ b/menu/menu_input.c
@@ -565,10 +565,15 @@ static int menu_input_pointer_post_iterate(
 void menu_input_post_iterate(int *ret, unsigned action)
 {
    menu_entry_t entry;
+   size_t selection;
+   menu_file_list_cbs_t *cbs;
    settings_t *settings       = config_get_ptr();
    file_list_t *selection_buf = menu_entries_get_selection_buf_ptr(0);
-   size_t selection           = menu_navigation_get_selection();
-   menu_file_list_cbs_t *cbs  = selection_buf ?
+   menu_input_t *menu_input   = menu_input_get_ptr();
+   if (menu_input != NULL && menu_input->pointer.pressed[0])
+      menu_navigation_set_selection(menu_input->pointer.ptr);
+   selection           = menu_navigation_get_selection();
+   cbs  = selection_buf ?
       (menu_file_list_cbs_t*)file_list_get_actiondata_at_offset(selection_buf, selection) : NULL;
 
    menu_entry_init(&entry);


### PR DESCRIPTION
Fixes crashes on Android when changing a core's option on cores having less then 10 option items (cf. #7130), take two!
The previous PR (#7271) made XMB menu controls not working (cf. #7276).
This one was tested on both Android and Linux and seems to be ok. However, as I said previously, I do not master the code base so there is maybe a cleaner way to fix this bug.