### PR TITLE
Wii U: Fix menu lag when built with DevKitPro r32

### DIFF
--- a/libretro-common/features/features_cpu.c
+++ b/libretro-common/features/features_cpu.c
@@ -221,6 +221,8 @@ retro_time_t cpu_features_get_time_usec(void)
    return sys_time_get_system_time();
 #elif defined(GEKKO)
    return ticks_to_microsecs(gettime());
+#elif defined(WIIU)
+   return ticks_to_us(OSGetSystemTime());
 #elif defined(SWITCH) || defined(HAVE_LIBNX)
    return (svcGetSystemTick() * 10) / 192;
 #elif defined(_POSIX_MONOTONIC_CLOCK) || defined(__QNX__) || defined(ANDROID) || defined(__MACH__)
@@ -238,8 +240,6 @@ retro_time_t cpu_features_get_time_usec(void)
    return osGetTime() * 1000;
 #elif defined(VITA)
    return sceKernelGetProcessTimeWide();
-#elif defined(WIIU)
-   return ticks_to_us(OSGetSystemTime());
 #else
 #error "Your platform does not have a timer function implemented in cpu_features_get_time_usec(). Cannot continue."
 #endif


### PR DESCRIPTION
== DETAILS

Updates to the newlib library bundled with DevKitPro have caused
incorrect behavior in `cpu_features_get_time_usec()`. Specifically,
it defines `_POSIX_MONTONIC_CLOCK` which results in calling newlib's
time functions which are.. buggy, at least on Wii U.

By moving the WIIU case higher up, we end up calling the actual
Wii U time library routines, and get nice snappy animations as a
result.

== TESTING
I tested this locally on my wiiu and confirmed resolved menu sluggishness.

Reviewers: @QuarkTheAwesome @aliaspider