### PR TITLE
(Menu) Clarify the BIOS Missing/Present screen

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -318,8 +318,8 @@ static int menu_displaylist_parse_core_info(menu_displaylist_info_t *info)
             {
                snprintf(tmp, sizeof(tmp), "%s %s - %s, %s",
                      core_info->firmware[i].missing ?
-                     "[ ]" :
-                     "[*]",
+                     "[-]" :
+                     "[+]",
                      core_info->firmware[i].desc ?
                      core_info->firmware[i].desc :
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_RDB_ENTRY_NAME),

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -316,16 +316,19 @@ static int menu_displaylist_parse_core_info(menu_displaylist_info_t *info)
          {
             if (core_info->firmware[i].desc)
             {
-               snprintf(tmp, sizeof(tmp), "(!) %s, %s: %s",
+               snprintf(tmp, sizeof(tmp), "%s %s - %s, %s",
+                     core_info->firmware[i].missing ?
+                     "[ ]" :
+                     "[*]",
+                     core_info->firmware[i].desc ?
+                     core_info->firmware[i].desc :
+                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_RDB_ENTRY_NAME),
                      core_info->firmware[i].missing ?
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_MISSING) :
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PRESENT),
                      core_info->firmware[i].optional ?
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OPTIONAL) :
-                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_REQUIRED),
-                     core_info->firmware[i].desc ?
-                     core_info->firmware[i].desc :
-                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_RDB_ENTRY_NAME)
+                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_REQUIRED)
                      );
 
                menu_entries_append_enum(info->list, tmp, "",


### PR DESCRIPTION
This aims to clean up the user interface around the BIOS checks on the Core Information screen.

## Changes
- Replaces the `(!)` for every entry with `[-]` or `[+]` depending on if the bios file was found.
- Moves the name of the bios file first, so that it's easier to know what entry is being considered

## Before

You'll find the text prior to the name make it difficult to parse whether or not the given bios files are there.

![screenshot at 2019-01-05 19-25-59](https://user-images.githubusercontent.com/25086/50730632-ccd9e080-111f-11e9-98a4-8d6a47f7539c.png)

## After

Making the critical information up front makes it easier to understand which files are missing or not.

![screenshot at 2018-09-25 00-01-23](https://user-images.githubusercontent.com/25086/45992194-6cce9b00-c056-11e8-8b74-c5ca770b5e61.png)

## References
- #6514

## Next Steps

Would love some thoughts on this. Tested out using `☐ ☑ ☒`, but the UTF-8 characters don't work in RGUI. Would like to keep them the same for simplicity.