### PR TITLE
Fix cheevos.c performance issues due to headerless NES hashing

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -3058,10 +3058,16 @@ found:
 
       size_t chunks     = coro->len >> 14;
 
+      /* Avoid memcpy, since we only want to check that
+       * the file is headerless. */
+      char* header = (char*)(coro->data);
+
       /* Assume that valid (including unlicensed) NES titles do not 
-       * exceed 32MiB, in order to avoid excessive requests
+       * exceed 32Mb, in order to avoid excessive requests
        * with large non-NES files. */
-      if (chunks > 250)
+      if (chunks == 0 || chunks > 250 ||
+        (header[0] == 'N' && header[1] == 'E'
+        && header[2] == 'S' && header[3] == 0x1a))
       {
           CORO_RET();
       }

--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -3048,16 +3048,23 @@ found:
 
     CORO_SUB(HEADERLESS_NES_MD5)
 
-      unsigned i;
       size_t chunks     = coro->len >> 14;
+
+      /* Assume that valid (including unlicensed) NES titles do not 
+       * exceed 32MiB, in order to avoid excessive requests
+       * with large non-NES files. */
+      if (chunks > 250)
+      {
+          CORO_RET();
+      }
+
       size_t chunk_size = 0x4000;
 
-      /* Fall back to headerless hashing
-       * PRG ROM size is unknown, so test by 16KB chunks */
-
+      /* PRG ROM size is unknown, so test by 16KB chunks. */
       coro->round       = 0;
       coro->offset      = 0;
-      
+
+      unsigned i;
       for (i = chunks; i > 0; i--)
       {
           MD5_Init(&coro->md5);

--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -3029,18 +3029,21 @@ found:
 
       coro->offset = sizeof(coro->header) + (coro->header.rom_type & 4
             ? sizeof(coro->header) : 0);
+
+          size_t chunk_size = 0x4000;
             
           /* from FCEU core - check if Trainer included in ROM data */
           MD5_Init(&coro->md5);
-      coro->count  = 0x4000 * coro->bytes;
-      CORO_GOSUB(EVAL_MD5);
 
-      if (coro->count < 0x4000 * coro->bytes)
-      {
-         coro->offset      = 0xff;
-         coro->count       = 0x4000 * coro->bytes - coro->count;
-         CORO_GOSUB(FILL_MD5);
-      }
+          coro->count  = chunk_size * coro->bytes;
+          CORO_GOSUB(EVAL_MD5);
+
+          if (coro->count < chunk_size * coro->bytes)
+          {
+             coro->offset      = 0xff;
+             coro->count       = chunk_size * coro->bytes - coro->count;
+             CORO_GOSUB(FILL_MD5);
+          }
 
       MD5_Final(coro->hash, &coro->md5);
       CORO_GOTO(GET_GAMEID);
@@ -3074,10 +3077,10 @@ found:
           
           CORO_GOSUB(EVAL_MD5);
 
-          if (coro->count < 0x4000 * coro->bytes)
+          if (coro->count < chunk_size * coro->bytes)
           {
              coro->offset      = 0xff;
-             coro->count       = 0x4000 * coro->bytes - coro->count;
+             coro->count       = chunk_size * coro->bytes - coro->count;
              CORO_GOSUB(FILL_MD5);
           }
 

--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -2604,6 +2604,12 @@ static int cheevos_iterate(coro_t *coro)
       0x0b88abd2U, /* swc */
       0
    };
+   
+   static const uint32_t nes_exts[] =
+   {
+      0x0b88944bU, /* nes */
+      0
+   };
 
    static const uint32_t lynx_exts[] =
    {
@@ -2619,9 +2625,8 @@ static int cheevos_iterate(coro_t *coro)
       {NES_MD5,             "NES (discards VROM)",               NULL},
       {GENERIC_MD5,         "Generic (plain content)",           NULL},
       {FILENAME_MD5,        "Generic (filename)",                NULL},
-      /* Headerless NES comes last due to the volume of requests
-       * and lack of extension filtering. */
-      {HEADERLESS_NES_MD5,  "Headerless NES (discards VROM)",    NULL}
+      /* Headerless NES comes last due to the volume of requests. */
+      {HEADERLESS_NES_MD5,  "Headerless NES (discards VROM)",    nes_exts}
    };
 
    CORO_ENTER();

--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -3062,10 +3062,8 @@ found:
        * the file is headerless. */
       char* header = (char*)(coro->data);
 
-      /* Assume that valid (including unlicensed) NES titles do not 
-       * exceed 32Mb, in order to avoid excessive requests
-       * with large non-NES files. */
-      if (chunks == 0 || chunks > 250 ||
+      /* Restrict size to the maximum known licensed cart size of 8MiB */
+      if (chunks == 0 || chunks > 64 ||
         (header[0] == 'N' && header[1] == 'E'
         && header[2] == 'S' && header[3] == 0x1a))
       {

--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -3003,15 +3003,10 @@ found:
       memcpy((void*)&coro->header, coro->data,
             sizeof(coro->header));
 
-      if (     coro->header.id[0] != 'N'
-            || coro->header.id[1] != 'E'
-            || coro->header.id[2] != 'S'
-            || coro->header.id[3] != 0x1a)
-      {
-         coro->gameid = 0;
-         CORO_RET();
-      }
-
+      if (coro->header.id[0] == 'N'
+        && coro->header.id[1] == 'E'
+        && coro->header.id[2] == 'S'
+        && coro->header.id[3] == 0x1a)
       {
          size_t romsize = 256;
          /* from FCEU core - compute size using the cart mapper */
@@ -3027,12 +3022,12 @@ found:
             * we use FCEU_read. */
          coro->round       = mapper != 53 && mapper != 198 && mapper != 228;
          coro->bytes       = coro->round ? romsize : coro->header.rom_size;
-      }
 
-      /* from FCEU core - check if Trainer included in ROM data */
-      MD5_Init(&coro->md5);
       coro->offset = sizeof(coro->header) + (coro->header.rom_type & 4
             ? sizeof(coro->header) : 0);
+            
+          /* from FCEU core - check if Trainer included in ROM data */
+          MD5_Init(&coro->md5);
       coro->count  = 0x4000 * coro->bytes;
       CORO_GOSUB(EVAL_MD5);
 
@@ -3045,6 +3040,43 @@ found:
 
       MD5_Final(coro->hash, &coro->md5);
       CORO_GOTO(GET_GAMEID);
+      }
+      else
+      {
+          // Fall back to headerless hashing
+          // PRG ROM size is unknown, so test by 16KB chunks          
+          size_t chunks = coro->len >> 14;
+          size_t chunk_size = 0x4000;
+          coro->round = 0;
+          coro->offset = 0;
+          
+          for (int i = 0; i < chunks; i++)
+          {
+              MD5_Init(&coro->md5);
+              
+              coro->bytes = i + 1;
+              coro->count = coro->bytes * chunk_size;
+              
+              CORO_GOSUB(EVAL_MD5);
+
+              if (coro->count < 0x4000 * coro->bytes)
+              {
+                 coro->offset      = 0xff;
+                 coro->count       = 0x4000 * coro->bytes - coro->count;
+                 CORO_GOSUB(FILL_MD5);
+              }
+
+              MD5_Final(coro->hash, &coro->md5);
+              CORO_GOSUB(GET_GAMEID);
+              
+              if (coro->gameid > 0)
+              {
+                  break;
+              }
+          }
+
+          CORO_RET();
+      }
 
       /**************************************************************************
        * Info   Tries to identify a "generic" game


### PR DESCRIPTION
## Description

The NES hashing strategy happens to be applied to all files regardless of extension or system, so #7201 dramatically increased the number of requests for systems that benefit from the generic MD5 hashing strategy (including SNES), causing delays in retrieving game IDs.

This reduces the average number of iterations for headerless NES hashing by decreasing the chunk count in the hashing loop with every iteration instead of increasing it, and moves the NES subroutine to the bottom of the list in order to avoid blocking other systems.

## Reviewers

@leiradel
