### PR TITLE
Switch nxlink threading

### DIFF
--- a/audio/drivers/switch_audio.c
+++ b/audio/drivers/switch_audio.c
@@ -94,8 +94,6 @@ static ssize_t switch_audio_write(void *data, const void *buf, size_t size)
       {
          if (swa->blocking)
          {
-            RARCH_LOG("No buffer, blocking...\n");
-
             while(swa->current_buffer == NULL)
             {
                uint32_t handle_idx = 0;

--- a/frontend/drivers/platform_switch.c
+++ b/frontend/drivers/platform_switch.c
@@ -62,6 +62,10 @@ static uint32_t *splashData = NULL;
 
 static bool psmInitialized = false;
 
+#ifdef NXLINK
+extern bool nxlink_connected;
+#endif
+
 #endif // HAVE_LIBNX
 
 static void get_first_valid_core(char *path_return)
@@ -614,7 +618,7 @@ static void frontend_switch_init(void *data)
 #endif // HAVE_OPENGL
 #ifdef NXLINK
    socketInitializeDefault();
-   nxlinkStdio();
+   nxlink_connected = nxlinkStdio() != -1;
 #ifndef IS_SALAMANDER
    verbosity_enable();
 #endif // IS_SALAMANDER


### PR DESCRIPTION
[LIBNX] Removed extraneous logging when blocked in switch_audio
[LIBNX] Synchronize nxlink logging
- Logs were interleaved and caused instability on certain setups
