### PR TITLE
fix gdi scanning

### DIFF
--- a/managers/cheat_manager.c
+++ b/managers/cheat_manager.c
@@ -89,7 +89,8 @@ void cheat_manager_apply_cheats(void)
       }
    }
 
-   if ( cheat_manager_state.size > 0 ) {
+   if ( cheat_manager_state.size > 0 )
+   {
       runloop_msg_queue_push(msg_hash_to_str(MSG_APPLYING_CHEAT), 1, 180, true);
       RARCH_LOG("%s\n", msg_hash_to_str(MSG_APPLYING_CHEAT));
    }

--- a/managers/cheat_manager.c
+++ b/managers/cheat_manager.c
@@ -89,7 +89,7 @@ void cheat_manager_apply_cheats(void)
       }
    }
 
-   if ( cheat_manager_state.size > 0 )
+   if (cheat_manager_state.size > 0)
    {
       runloop_msg_queue_push(msg_hash_to_str(MSG_APPLYING_CHEAT), 1, 180, true);
       RARCH_LOG("%s\n", msg_hash_to_str(MSG_APPLYING_CHEAT));

--- a/managers/cheat_manager.c
+++ b/managers/cheat_manager.c
@@ -88,8 +88,11 @@ void cheat_manager_apply_cheats(void)
             core_set_cheat(&cheat_info);
       }
    }
-    runloop_msg_queue_push(msg_hash_to_str(MSG_APPLYING_CHEAT), 1, 180, true);
-    RARCH_LOG("%s\n", msg_hash_to_str(MSG_APPLYING_CHEAT));
+
+   if ( cheat_manager_state.size > 0 ) {
+      runloop_msg_queue_push(msg_hash_to_str(MSG_APPLYING_CHEAT), 1, 180, true);
+      RARCH_LOG("%s\n", msg_hash_to_str(MSG_APPLYING_CHEAT));
+   }
 
 #ifdef HAVE_CHEEVOS
    data_bool = idx != 0;

--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -455,7 +455,7 @@ static int task_database_gdi_get_crc(const char *name, uint32_t *crc)
 
    track_path[0] = '\0';
 
-   rv = gdi_find_track(name, false, track_path, PATH_MAX_LENGTH);
+   rv = gdi_find_track(name, true, track_path, PATH_MAX_LENGTH);
 
    if (rv < 0)
    {


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises


## Description

fix gdi scanning
libretro-database for dreamcast  only contains crcs for track 1, but the RA scanning was trying to find the largest data track.  Updated to just stop on track 1

## Related Issues



## Related Pull Requests



## Reviewers

@twinaphex 
