### PR TITLE
Fix missing BOM markers

### DIFF
--- a/intl/msg_hash_ar.h
+++ b/intl/msg_hash_ar.h
@@ -1,4 +1,4 @@
-MSG_HASH(
+﻿MSG_HASH(
       MSG_COMPILER,
       "Compiler"
       )

--- a/intl/msg_hash_chs.h
+++ b/intl/msg_hash_chs.h
@@ -1,4 +1,4 @@
-MSG_HASH(
+﻿MSG_HASH(
       MSG_COMPILER,
       "编译器"
       )

--- a/intl/msg_hash_cht.h
+++ b/intl/msg_hash_cht.h
@@ -1,4 +1,4 @@
-MSG_HASH(
+﻿MSG_HASH(
       MSG_COMPILER,
       "編譯器"
       )

--- a/intl/msg_hash_ja.h
+++ b/intl/msg_hash_ja.h
@@ -1,4 +1,4 @@
-#if defined(_MSC_VER) && !defined(_XBOX)
+﻿#if defined(_MSC_VER) && !defined(_XBOX)
 /* https://support.microsoft.com/en-us/kb/980263 */
 #pragma execution_character_set("utf-8")
 #endif

--- a/intl/msg_hash_ko.h
+++ b/intl/msg_hash_ko.h
@@ -1,4 +1,4 @@
-MSG_HASH(
+﻿MSG_HASH(
       MSG_COMPILER,
       "컴파일러"
       )

--- a/intl/msg_hash_pl.h
+++ b/intl/msg_hash_pl.h
@@ -1,4 +1,4 @@
-MSG_HASH(
+﻿MSG_HASH(
       MSG_COMPILER,
       "Kompilator"
       )

--- a/intl/msg_hash_ru.h
+++ b/intl/msg_hash_ru.h
@@ -1,4 +1,4 @@
-#if defined(_MSC_VER) && !defined(_XBOX)
+﻿#if defined(_MSC_VER) && !defined(_XBOX)
 /* https://support.microsoft.com/en-us/kb/980263 */
 #pragma execution_character_set("utf-8")
 #endif

--- a/intl/msg_hash_vn.h
+++ b/intl/msg_hash_vn.h
@@ -1,4 +1,4 @@
-MSG_HASH(
+﻿MSG_HASH(
       MSG_COMPILER,
       "Compiler"
       )


### PR DESCRIPTION
Added BOM markers to these files:

- intl/msg_hash_ar.h
- intl/msg_hash_chs.h
- intl/msg_hash_cht.h
- intl/msg_hash_ja.h
- intl/msg_hash_ko.h
- intl/msg_hash_pl.h
- intl/msg_hash_ru.h
- intl/msg_hash_vn.h
