### PR TITLE
Fix error when compiling without cheevos

### DIFF
--- a/command.c
+++ b/command.c
@@ -140,12 +140,14 @@ struct command
 };
 
 #if defined(HAVE_COMMAND)
-#if defined(HAVE_CHEEVOS) && (defined(HAVE_STDIN_CMD) || defined(HAVE_NETWORK_CMD) && defined(HAVE_NETWORKING))
 static enum cmd_source_t lastcmd_source;
+#if defined(HAVE_NETWORK_CMD) && defined(HAVE_NETWORKING)
 static int lastcmd_net_fd;
 static struct sockaddr_storage lastcmd_net_source;
 static socklen_t lastcmd_net_source_len;
+#endif
 
+#if defined(HAVE_CHEEVOS) && (defined(HAVE_STDIN_CMD) || defined(HAVE_NETWORK_CMD) && defined(HAVE_NETWORKING))
 static void command_reply(const char * data, size_t len)
 {
    switch (lastcmd_source)


### PR DESCRIPTION
- Fixes error when trying to compile with `--disable-cheevos`
- The added `#if` line is pulled from [here](https://github.com/libretro/RetroArch/commit/0ba8597041545d0d1fcc7b2bf9b90afae09d5bbe#diff-22dda82c4f511a2b00e369c0649da0f2L203)