### PR TITLE
force fast-save-states while netplay is enabled

### DIFF
--- a/dynamic.c
+++ b/dynamic.c
@@ -1837,6 +1837,8 @@ bool rarch_environment_cb(unsigned cmd, void *data)
 #ifdef HAVE_NETWORKING
          if (netplay_driver_ctl(RARCH_NETPLAY_CTL_IS_REPLAYING, NULL))
             result &= ~(1|2);
+         if (netplay_driver_ctl(RARCH_NETPLAY_CTL_IS_ENABLED, NULL))
+            result |= 4;
 #endif
          if (data != NULL)
          {


### PR DESCRIPTION
https://github.com/libretro/RetroArch/issues/7299

Basically it will enable fast_savestates whenever a netplay session is underway.
Maybe we should add an option under netplay for this purpose?

Currently only hooked up on FBA CPS3
 
@barbudreadmon @GregorR @Dwedit 