### PR TITLE
fix auto shader preset loading in d3d10, d3d11, d3d12

### DIFF
--- a/gfx/drivers/d3d10.c
+++ b/gfx/drivers/d3d10.c
@@ -23,6 +23,8 @@
 #include "../../driver.h"
 #include "../../verbosity.h"
 #include "../../configuration.h"
+#include "../../retroarch.h"
+
 #include "../video_driver.h"
 #include "../font_driver.h"
 #include "../common/win32_common.h"
@@ -909,10 +911,10 @@ d3d10_gfx_init(const video_info_t* video,
 
    if (settings->bools.video_shader_enable)
    {
-      const char* ext = path_get_extension(settings->paths.path_shader);
+      const char* ext = path_get_extension(retroarch_get_shader_preset());
 
       if (ext && !strncmp(ext, "slang", 5))
-         d3d10_gfx_set_shader(d3d10, RARCH_SHADER_SLANG, settings->paths.path_shader);
+         d3d10_gfx_set_shader(d3d10, RARCH_SHADER_SLANG, retroarch_get_shader_preset());
    }
 
 #if 0

--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -25,6 +25,7 @@
 #include "../../driver.h"
 #include "../../verbosity.h"
 #include "../configuration.h"
+#include "../../retroarch.h"
 #include "../video_driver.h"
 #include "../font_driver.h"
 #include "../common/win32_common.h"
@@ -954,10 +955,10 @@ d3d11_gfx_init(const video_info_t* video, const input_driver_t** input, void** i
 
    if (settings->bools.video_shader_enable)
    {
-      const char* ext = path_get_extension(settings->paths.path_shader);
+      const char* ext = path_get_extension(retroarch_get_shader_preset());
 
       if (ext && !strncmp(ext, "slang", 5))
-         d3d11_gfx_set_shader(d3d11, RARCH_SHADER_SLANG, settings->paths.path_shader);
+         d3d11_gfx_set_shader(d3d11, RARCH_SHADER_SLANG, retroarch_get_shader_preset());
    }
 
    if (video_driver_get_hw_context()->context_type == RETRO_HW_CONTEXT_DIRECT3D &&

--- a/gfx/drivers/d3d12.c
+++ b/gfx/drivers/d3d12.c
@@ -31,6 +31,7 @@
 #include "../../driver.h"
 #include "../../verbosity.h"
 #include "../../configuration.h"
+#include "../../retroarch.h"
 
 #include "wiiu/wiiu_dbg.h"
 
@@ -971,10 +972,10 @@ d3d12_gfx_init(const video_info_t* video, const input_driver_t** input, void** i
 
    if (settings->bools.video_shader_enable)
    {
-      const char* ext = path_get_extension(settings->paths.path_shader);
+      const char* ext = path_get_extension(retroarch_get_shader_preset());
 
       if (ext && string_is_equal(ext, "slangp"))
-         d3d12_gfx_set_shader(d3d12, RARCH_SHADER_SLANG, settings->paths.path_shader);
+         d3d12_gfx_set_shader(d3d12, RARCH_SHADER_SLANG, retroarch_get_shader_preset());
    }
 
    return d3d12;


### PR DESCRIPTION
@hunterk fixes what you reported

BTW d3d10 seems to crash after 10 seconds in menu, didn't open an issue because noone else confirmed