### PR TITLE
WiiU: fix network information

### DIFF
--- a/Makefile.wiiu
+++ b/Makefile.wiiu
@@ -137,8 +137,6 @@ endif
    	WANT_IOSUHAX = 1
 
    	include Makefile.common
-   	BLACKLIST := $(LIBRETRO_COMM_DIR)/net/net_ifinfo.o
-   	OBJ := $(filter-out $(BLACKLIST),$(OBJ))
 
    	OBJ += gfx/drivers/gx2_gfx.o
    	OBJ += gfx/drivers_font/wiiu_font.o

--- a/frontend/drivers/platform_wiiu.c
+++ b/frontend/drivers/platform_wiiu.c
@@ -530,6 +530,9 @@ static void wiiu_log_init(int port)
 {
    wiiu_log_lock = 0;
 
+   if(wiiu_log_socket >= 0)
+      return;
+
    if(broadcast_init(port) < 0)
       return;
 

--- a/libretro-common/net/net_natt.c
+++ b/libretro-common/net/net_natt.c
@@ -184,7 +184,7 @@ static bool natt_open_port(struct natt_status *status,
 bool natt_open_port_any(struct natt_status *status,
       uint16_t port, enum socket_protocol proto)
 {
-#if !defined(HAVE_SOCKET_LEGACY) && !defined(WIIU) && !defined(SWITCH)
+#if !defined(HAVE_SOCKET_LEGACY) && !defined(SWITCH)
    size_t i;
    char port_str[6];
    struct net_ifinfo list;

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -97,7 +97,7 @@ static enum msg_hash_enums new_type     = MSG_UNKNOWN;
  * function pointer callback functions that don't necessarily
  * call each other. */
 
-#if !defined(HAVE_SOCKET_LEGACY) && !defined(WIIU) && !defined(SWITCH)
+#if !defined(HAVE_SOCKET_LEGACY) && !defined(SWITCH)
 #include <net/net_ifinfo.h>
 
 static int menu_displaylist_parse_network_info(menu_displaylist_info_t *info)
@@ -4834,7 +4834,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, void *data)
          break;
       case DISPLAYLIST_NETWORK_INFO:
          menu_entries_ctl(MENU_ENTRIES_CTL_CLEAR, info->list);
-#if defined(HAVE_NETWORKING) && !defined(HAVE_SOCKET_LEGACY) && !defined(WIIU) && !defined(SWITCH)
+#if defined(HAVE_NETWORKING) && !defined(HAVE_SOCKET_LEGACY) && !defined(SWITCH)
          count = menu_displaylist_parse_network_info(info);
 #endif
 

--- a/wiiu/include/arpa/inet.h
+++ b/wiiu/include/arpa/inet.h
@@ -6,6 +6,7 @@ extern "C" {
 #endif
 
 #include <netinet/in.h>
+#include <sys/socket.h>
 
 char *inet_ntoa(struct in_addr in);
 const char *inet_ntop(int af, const void *cp, char *buf, socklen_t len);

--- a/wiiu/include/ifaddrs.h
+++ b/wiiu/include/ifaddrs.h
@@ -1,0 +1,18 @@
+#ifndef _IFADDRS_H_
+#define _IFADDRS_H_
+
+#include <sys/socket.h>
+
+struct ifaddrs {
+   struct ifaddrs *ifa_next;
+   char *ifa_name;
+   unsigned int ifa_flags;
+   struct sockaddr *ifa_addr;
+   struct sockaddr *ifa_netmask;
+   struct sockaddr *ifa_dstaddr;
+   void *ifa_data;
+};
+
+int getifaddrs(struct ifaddrs **ifap);
+void freeifaddrs(struct ifaddrs *ifp);
+#endif // _IFADDRS_H_


### PR DESCRIPTION
== DETAILS

For local netplay, it's useful to have your IP address easily
available. This commit makes the Information > Network Information
menu display the Wii U's IP address.

Change summary:
- Fix the logging init to be reentrant to avoid socket consumption
- Add implementation of POSIX `getifaddrs()` and `freeifaddrs()`
  to `missing_libc_functions.c`
- Remove compiler directives protecting the code paths that call
  `getifaddrs()` from being used in Wii U builds

== TESTING

Have tested locally, successfully get IP address information in
the Information > Network Information.

I think this may also fix NAT traversal. Will need to be tested.

Reviewers:
@twinaphex @aliaspider @QuarkTheAwesome 
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises


## Description

[Description of the pull request, detail any issues you are fixing or any features you are implementing]

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
