### PR TITLE
flatpak: Install audio filters to correct place

### DIFF
--- a/libretro-common/audio/dsp_filters/Makefile
+++ b/libretro-common/audio/dsp_filters/Makefile
@@ -4,7 +4,7 @@ use_neon    := 0
 build       = release
 DYLIB	      := so
 PREFIX      := /usr
-INSTALLDIR  := $(PREFIX)/lib/retroarch/filters/audio
+INSTALLDIR  := $(PREFIX)/share/libretro/filters/audio
 
 ifeq ($(platform),)
    platform = unix


### PR DESCRIPTION
This makes the audio filters install to the correctly location.