### PR TITLE
libnx: add network interfaces info

### DIFF
--- a/Makefile.libnx
+++ b/Makefile.libnx
@@ -70,7 +70,7 @@ else
 endif
 
 include Makefile.common
-BLACKLIST := $(LIBRETRO_COMM_DIR)/net/net_ifinfo.o
+BLACKLIST :=
 
 OBJ := $(filter-out $(BLACKLIST),$(OBJ))
 

--- a/frontend/drivers/platform_switch.c
+++ b/frontend/drivers/platform_switch.c
@@ -191,6 +191,7 @@ static void frontend_switch_deinit(void *data)
    (void)data;
 
 #ifdef HAVE_LIBNX
+   nifmExit();
 #if defined(SWITCH) && defined(NXLINK)
    socketExit();
 #endif
@@ -607,6 +608,7 @@ static void frontend_switch_init(void *data)
    (void)data;
 
 #ifdef HAVE_LIBNX
+   nifmInitialize();
 #ifndef HAVE_OPENGL
    /* Init Resolution before initDefault */
    gfxInitResolution(1280, 720);

--- a/libretro-common/net/net_natt.c
+++ b/libretro-common/net/net_natt.c
@@ -184,7 +184,7 @@ static bool natt_open_port(struct natt_status *status,
 bool natt_open_port_any(struct natt_status *status,
       uint16_t port, enum socket_protocol proto)
 {
-#if !defined(HAVE_SOCKET_LEGACY) && !defined(SWITCH)
+#if !defined(HAVE_SOCKET_LEGACY) && (!defined(SWITCH) || defined(SWITCH) && defined(HAVE_LIBNX))
    size_t i;
    char port_str[6];
    struct net_ifinfo list;

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -97,7 +97,7 @@ static enum msg_hash_enums new_type     = MSG_UNKNOWN;
  * function pointer callback functions that don't necessarily
  * call each other. */
 
-#if !defined(HAVE_SOCKET_LEGACY) && !defined(SWITCH)
+#if !defined(HAVE_SOCKET_LEGACY) && (!defined(SWITCH) || defined(SWITCH) && defined(HAVE_LIBNX))
 #include <net/net_ifinfo.h>
 
 static int menu_displaylist_parse_network_info(menu_displaylist_info_t *info)
@@ -4834,7 +4834,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, void *data)
          break;
       case DISPLAYLIST_NETWORK_INFO:
          menu_entries_ctl(MENU_ENTRIES_CTL_CLEAR, info->list);
-#if defined(HAVE_NETWORKING) && !defined(HAVE_SOCKET_LEGACY) && !defined(SWITCH)
+#if defined(HAVE_NETWORKING) && !defined(HAVE_SOCKET_LEGACY) && (!defined(SWITCH) || defined(SWITCH) && defined(HAVE_LIBNX))
          count = menu_displaylist_parse_network_info(info);
 #endif
 


### PR DESCRIPTION
This adds network interfaces info to the Switch libnx platform.

There are two interfaces available : 
- `lo`, for loopback
- `switch` for eth (through a Wii U adapter) or wlan if eth isn't connected

The `switch` interface will not appear if the console is in airplane mode or not connected to any Wi-Fi network.