### PR TITLE
Fix RGUI regression on Vulkan.

### DIFF
--- a/gfx/common/vulkan_common.h
+++ b/gfx/common/vulkan_common.h
@@ -501,6 +501,7 @@ static INLINE unsigned vulkan_format_to_bpp(VkFormat format)
          return 4;
 
       case VK_FORMAT_R4G4B4A4_UNORM_PACK16:
+      case VK_FORMAT_B4G4R4A4_UNORM_PACK16:
       case VK_FORMAT_R5G6B5_UNORM_PACK16:
          return 2;
 


### PR DESCRIPTION
- Check for buffer as well as image when uploading menu texture.
- Fix really whacky validation error where image is copied in render pass (surprised layers didn't catch this one before ...)