### PR TITLE
added cheevos console ID for atari7800

### DIFF
--- a/cheevos/cheevos.h
+++ b/cheevos/cheevos.h
@@ -98,7 +98,8 @@ typedef enum
    CHEEVOS_CONSOLE_VIRTUAL_BOY     = 28,
    CHEEVOS_CONSOLE_MSX             = 29,
    CHEEVOS_CONSOLE_COMMODORE_64    = 30,
-   CHEEVOS_CONSOLE_ZX81            = 31
+   CHEEVOS_CONSOLE_ZX81            = 31,
+   CHEEVOS_CONSOLE_ATARI_7800      = 51
 } cheevos_console_t;
 
 enum


### PR DESCRIPTION
## Description

We, at RetroAchievements, recently added support to Atari 7800, and its console ID is 51.