### PR TITLE
Fix xmb.c and stripes.c menu drivers texture memory leak

### DIFF
--- a/menu/drivers/stripes.c
+++ b/menu/drivers/stripes.c
@@ -897,7 +897,7 @@ static void stripes_update_thumbnail_path(void *data, unsigned i, char pos)
    }
    else if (filebrowser_get_type() != FILEBROWSER_NONE)
    {
-      stripes->thumbnail              = 0;
+      video_driver_texture_unload(&stripes->thumbnail);
       goto end;
    }
 
@@ -921,7 +921,7 @@ static void stripes_update_thumbnail_path(void *data, unsigned i, char pos)
          }
          else
          {
-            stripes->left_thumbnail              = 0;
+            video_driver_texture_unload(&stripes->left_thumbnail);
             goto end;
          }
       }
@@ -1075,7 +1075,7 @@ static void stripes_update_thumbnail_image(void *data)
             task_push_image_load(stripes->thumbnail_file_path,
                   menu_display_handle_thumbnail_upload, NULL);
          else
-            stripes->thumbnail = 0;
+            video_driver_texture_unload(&stripes->thumbnail);
 
          free(stripes->thumbnail_file_path);
          stripes->thumbnail_file_path = NULL;
@@ -1087,7 +1087,7 @@ static void stripes_update_thumbnail_image(void *data)
             task_push_image_load(stripes->left_thumbnail_file_path,
                   menu_display_handle_left_thumbnail_upload, NULL);
          else
-            stripes->left_thumbnail = 0;
+            video_driver_texture_unload(&stripes->left_thumbnail);
 
          free(stripes->left_thumbnail_file_path);
          stripes->left_thumbnail_file_path = NULL;
@@ -1136,7 +1136,7 @@ static void stripes_update_savestate_thumbnail_image(void *data)
       task_push_image_load(stripes->savestate_thumbnail_file_path,
             menu_display_handle_savestate_thumbnail_upload, NULL);
    else
-      stripes->savestate_thumbnail = 0;
+      video_driver_texture_unload(&stripes->savestate_thumbnail);
 }
 
 static unsigned stripes_get_system_tab(stripes_handle_t *stripes, unsigned i)

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -948,7 +948,7 @@ static void xmb_update_thumbnail_path(void *data, unsigned i, char pos)
    }
    else if (filebrowser_get_type() != FILEBROWSER_NONE)
    {
-      xmb->thumbnail              = 0;
+      video_driver_texture_unload(&xmb->thumbnail);
       goto end;
    }
 
@@ -976,7 +976,7 @@ static void xmb_update_thumbnail_path(void *data, unsigned i, char pos)
                      sizeof(new_path));
          }
          else
-            xmb->left_thumbnail              = 0;
+            video_driver_texture_unload(&xmb->left_thumbnail);
          goto end;
       }
    }
@@ -1129,7 +1129,7 @@ static void xmb_update_thumbnail_image(void *data)
          task_push_image_load(xmb->thumbnail_file_path,
                menu_display_handle_thumbnail_upload, NULL);
       else
-         xmb->thumbnail = 0;
+         video_driver_texture_unload(&xmb->thumbnail);
 
       free(xmb->thumbnail_file_path);
       xmb->thumbnail_file_path = NULL;
@@ -1141,7 +1141,7 @@ static void xmb_update_thumbnail_image(void *data)
          task_push_image_load(xmb->left_thumbnail_file_path,
                menu_display_handle_left_thumbnail_upload, NULL);
       else
-         xmb->left_thumbnail = 0;
+         video_driver_texture_unload(&xmb->left_thumbnail);
 
       free(xmb->left_thumbnail_file_path);
       xmb->left_thumbnail_file_path = NULL;
@@ -1190,7 +1190,7 @@ static void xmb_update_savestate_thumbnail_image(void *data)
       task_push_image_load(xmb->savestate_thumbnail_file_path,
             menu_display_handle_savestate_thumbnail_upload, NULL);
    else
-      xmb->savestate_thumbnail = 0;
+      video_driver_texture_unload(&xmb->savestate_thumbnail);
 }
 
 static unsigned xmb_get_system_tab(xmb_handle_t *xmb, unsigned i)


### PR DESCRIPTION
# Description
This PR fixes a few resource leaks in both xmb.c and stripes.c menu drivers that resulted in thumbnail textures not being deallocated in playlist menus. The leak can be reproduced by browsing through a playlist that has entries both with and without thumbnails. If you scroll through a playlist repeatedly, the memory usage will increase at a rate of 1MB/sec.

## Related Issues
The PR is supposed to fix #6747, though this may be a completely different resource leak.
