### PR TITLE
libnx: call retroarch_main_quit on exit

### DIFF
--- a/frontend/drivers/platform_switch.c
+++ b/frontend/drivers/platform_switch.c
@@ -62,9 +62,18 @@ static uint32_t *splashData = NULL;
 
 static bool psmInitialized = false;
 
+static AppletHookCookie applet_hook_cookie;
+
 #ifdef NXLINK
 extern bool nxlink_connected;
 #endif
+
+static void on_applet_hook(AppletHookType hook, void* param) {
+   if(hook == AppletHookType_OnExitRequest) {
+      RARCH_LOG("Got AppletHook OnExitRequest, exiting.\n");
+      retroarch_main_quit();
+   }
+}
 
 #endif /* HAVE_LIBNX */
 
@@ -209,6 +218,7 @@ static void frontend_switch_deinit(void *data)
 #ifndef HAVE_OPENGL
    gfxExit();
 #endif
+   appletUnlockExit();
 #endif
 }
 
@@ -609,6 +619,8 @@ static void frontend_switch_init(void *data)
 
 #ifdef HAVE_LIBNX
    nifmInitialize();
+   appletLockExit();
+   appletHook(&applet_hook_cookie, on_applet_hook, NULL);
 #ifndef HAVE_OPENGL
    /* Init Resolution before initDefault */
    gfxInitResolution(1280, 720);


### PR DESCRIPTION
## Description

This PR specific to the switch "libnx" platform makes RA shutdown cleanly on exit request.
**Note:** requires at least latest stable libnx v1.5.0

## Reviewers

@m4xw (approval needed before merge)
