### PR TITLE
More ozone improvements

### DIFF
--- a/intl/msg_hash_ar.h
+++ b/intl/msg_hash_ar.h
@@ -3695,4 +3695,4 @@ MSG_HASH(
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
       "Use preferred system color theme")
 MSG_HASH(MENU_ENUM_SUBLABEL_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
-      "Use your operating system's default color theme (if one is set).")
+      "Use your operating system's color theme (if any) - overrides theme settings.")

--- a/intl/msg_hash_chs.h
+++ b/intl/msg_hash_chs.h
@@ -4714,4 +4714,4 @@ MSG_HASH(
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
       "Use preferred system color theme")
 MSG_HASH(MENU_ENUM_SUBLABEL_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
-      "Use your operating system's default color theme (if one is set).")
+      "Use your operating system's color theme (if any) - overrides theme settings.")

--- a/intl/msg_hash_cht.h
+++ b/intl/msg_hash_cht.h
@@ -3471,4 +3471,4 @@ MSG_HASH(
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
       "Use preferred system color theme")
 MSG_HASH(MENU_ENUM_SUBLABEL_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
-      "Use your operating system's default color theme (if one is set).")
+      "Use your operating system's color theme (if any) - overrides theme settings.")

--- a/intl/msg_hash_de.h
+++ b/intl/msg_hash_de.h
@@ -3607,4 +3607,4 @@ MSG_HASH(
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
       "Use preferred system color theme")
 MSG_HASH(MENU_ENUM_SUBLABEL_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
-      "Use your operating system's default color theme (if one is set).")
+      "Use your operating system's color theme (if any) - overrides theme settings.")

--- a/intl/msg_hash_el.h
+++ b/intl/msg_hash_el.h
@@ -7699,4 +7699,4 @@ MSG_HASH(
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
       "Use preferred system color theme")
 MSG_HASH(MENU_ENUM_SUBLABEL_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
-      "Use your operating system's default color theme (if one is set).")
+      "Use your operating system's color theme (if any) - overrides theme settings.")

--- a/intl/msg_hash_el.h
+++ b/intl/msg_hash_el.h
@@ -7674,7 +7674,8 @@ MSG_HASH(
 MSG_HASH(
     MENU_ENUM_SUBLABEL_RESET_TO_DEFAULT_CONFIG,
     "Επαναφορά της τρέχουσας διαμόρφωσης στις προεπιλεγμένες ρυθμίσεις."
-    )
+    )
+
 MSG_HASH(
     MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_OK,
     "OK"

--- a/intl/msg_hash_eo.h
+++ b/intl/msg_hash_eo.h
@@ -3346,4 +3346,4 @@ MSG_HASH(
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
       "Use preferred system color theme")
 MSG_HASH(MENU_ENUM_SUBLABEL_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
-      "Use your operating system's default color theme (if one is set).")
+      "Use your operating system's color theme (if any) - overrides theme settings.")

--- a/intl/msg_hash_es.h
+++ b/intl/msg_hash_es.h
@@ -7636,4 +7636,4 @@ MSG_HASH(
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
       "Use preferred system color theme")
 MSG_HASH(MENU_ENUM_SUBLABEL_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
-      "Use your operating system's default color theme (if one is set).")
+      "Use your operating system's color theme (if any) - overrides theme settings.")

--- a/intl/msg_hash_fr.h
+++ b/intl/msg_hash_fr.h
@@ -3505,4 +3505,4 @@ MSG_HASH(
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
       "Use preferred system color theme")
 MSG_HASH(MENU_ENUM_SUBLABEL_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
-      "Use your operating system's default color theme (if one is set).")
+      "Use your operating system's color theme (if any) - overrides theme settings.")

--- a/intl/msg_hash_it.h
+++ b/intl/msg_hash_it.h
@@ -3565,4 +3565,4 @@ MSG_HASH(
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
       "Use preferred system color theme")
 MSG_HASH(MENU_ENUM_SUBLABEL_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
-      "Use your operating system's default color theme (if one is set).")
+      "Use your operating system's color theme (if any) - overrides theme settings.")

--- a/intl/msg_hash_ja.h
+++ b/intl/msg_hash_ja.h
@@ -4014,4 +4014,4 @@ MSG_HASH(
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
       "Use preferred system color theme")
 MSG_HASH(MENU_ENUM_SUBLABEL_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
-      "Use your operating system's default color theme (if one is set).")
+      "Use your operating system's color theme (if any) - overrides theme settings.")

--- a/intl/msg_hash_ko.h
+++ b/intl/msg_hash_ko.h
@@ -3466,4 +3466,4 @@ MSG_HASH(
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
       "Use preferred system color theme")
 MSG_HASH(MENU_ENUM_SUBLABEL_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
-      "Use your operating system's default color theme (if one is set).")
+      "Use your operating system's color theme (if any) - overrides theme settings.")

--- a/intl/msg_hash_nl.h
+++ b/intl/msg_hash_nl.h
@@ -3352,4 +3352,4 @@ MSG_HASH(
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
       "Use preferred system color theme")
 MSG_HASH(MENU_ENUM_SUBLABEL_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
-      "Use your operating system's default color theme (if one is set).")
+      "Use your operating system's color theme (if any) - overrides theme settings.")

--- a/intl/msg_hash_pl.h
+++ b/intl/msg_hash_pl.h
@@ -3768,4 +3768,4 @@ MSG_HASH(
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
       "Use preferred system color theme")
 MSG_HASH(MENU_ENUM_SUBLABEL_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
-      "Use your operating system's default color theme (if one is set).")
+      "Use your operating system's color theme (if any) - overrides theme settings.")

--- a/intl/msg_hash_pt_br.h
+++ b/intl/msg_hash_pt_br.h
@@ -7730,4 +7730,4 @@ MSG_HASH(
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
       "Use preferred system color theme")
 MSG_HASH(MENU_ENUM_SUBLABEL_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
-      "Use your operating system's default color theme (if one is set).")
+      "Use your operating system's color theme (if any) - overrides theme settings.")

--- a/intl/msg_hash_pt_pt.h
+++ b/intl/msg_hash_pt_pt.h
@@ -3432,4 +3432,4 @@ MSG_HASH(
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
       "Use preferred system color theme")
 MSG_HASH(MENU_ENUM_SUBLABEL_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
-      "Use your operating system's default color theme (if one is set).")
+      "Use your operating system's color theme (if any) - overrides theme settings.")

--- a/intl/msg_hash_ru.h
+++ b/intl/msg_hash_ru.h
@@ -3635,4 +3635,4 @@ MSG_HASH(
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
       "Use preferred system color theme")
 MSG_HASH(MENU_ENUM_SUBLABEL_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
-      "Use your operating system's default color theme (if one is set).")
+      "Use your operating system's color theme (if any) - overrides theme settings.")

--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -7730,4 +7730,4 @@ MSG_HASH(
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
       "Use preferred system color theme")
 MSG_HASH(MENU_ENUM_SUBLABEL_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
-      "Use your operating system's default color theme (if one is set).")
+      "Use your operating system's color theme (if any) - overrides theme settings.")

--- a/intl/msg_hash_vn.h
+++ b/intl/msg_hash_vn.h
@@ -3505,4 +3505,4 @@ MSG_HASH(
 MSG_HASH(MENU_ENUM_LABEL_VALUE_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
       "Use preferred system color theme")
 MSG_HASH(MENU_ENUM_SUBLABEL_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,
-      "Use your operating system's default color theme (if one is set).")
+      "Use your operating system's color theme (if any) - overrides theme settings.")

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -1120,7 +1120,7 @@ static void ozone_set_theme_path(ozone_handle_t *ozone)
 static void ozone_unload_theme_textures(ozone_handle_t *ozone)
 {
    int i;
-   
+
    for (i = 0; i < OZONE_THEME_TEXTURE_LAST; i++)
       video_driver_texture_unload(&ozone->theme_textures[i]);
 }
@@ -2241,7 +2241,7 @@ static void ozone_draw_entries(ozone_handle_t *ozone, video_frame_info_t *video_
    size_t i, y, entries_end;
    float sidebar_offset, bottom_boundary, invert, alpha_anim;
    unsigned video_info_height, entry_width;
-   int x_offset      = 0;
+   int x_offset           = 22;
    size_t selection_y     = 0;
    size_t old_selection_y = 0;
 
@@ -2265,9 +2265,9 @@ static void ozone_draw_entries(ozone_handle_t *ozone, video_frame_info_t *video_
    if (alpha != 1.0f)
    {    
       if (old_list)
-         x_offset = invert * -(alpha_anim * 120); /* left */
+         x_offset += invert * -(alpha_anim * 120); /* left */
       else
-         x_offset = invert * (alpha_anim * 120);  /* right */
+         x_offset += invert * (alpha_anim * 120);  /* right */
    }
 
    x_offset     += (int) sidebar_offset;

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -2687,7 +2687,7 @@ static int ozone_menu_iterate(menu_handle_t *menu, void *userdata, enum menu_act
 
          new_selection = (ozone->categories_selection_ptr + 1);
 
-         if (new_selection > ozone->system_tab_end) /* TODO Check against actual tabs count and not just system tabs */
+         if (new_selection >= OZONE_SYSTEM_TAB_LAST) /* TODO Check against actual tabs count and not just system tabs */
             new_selection = 0;
 
          if (ozone->categories_selection_ptr != new_selection)
@@ -2726,7 +2726,7 @@ static int ozone_menu_iterate(menu_handle_t *menu, void *userdata, enum menu_act
          new_selection = ozone->categories_selection_ptr - 1;
          
          if (new_selection < 0)
-            new_selection = ozone->system_tab_end; /* TODO Set this to actual tabs count and not just system tabs */
+            new_selection = OZONE_SYSTEM_TAB_LAST-1; /* TODO Set this to actual tabs count and not just system tabs */
 
          if (ozone->categories_selection_ptr != new_selection)
          {


### PR DESCRIPTION
- Tabs wrapping should now be fixed once and for all (until we add consoles playlists tabs)
- Entries should now be properly centered whether the sidebar is shown or not
- Theme setting was improved :
    - Everything works on the fly
    - If `Use preferred system color theme` is set to ON, `Menu Color Theme` doesn't change anything
    - If `Use preferred system color theme` is set to OFF, the `Menu Color Theme` setting is used instead
    - The sublabel for `Use preferred system color theme` has been adjusted to emphasize this change
- `msg_hash_el.h` was converted to LF