### PR TITLE
ozone: fix ghost sidebar when toggling menu + icons update

### DIFF
--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -256,7 +256,7 @@ enum
    OZONE_ENTRIES_ICONS_TEXTURE_UPDATER,
    OZONE_ENTRIES_ICONS_TEXTURE_VIDEO,
    OZONE_ENTRIES_ICONS_TEXTURE_RECORD,
-   OZONE_ENTRIES_ICONS_TEXTURE_INPUT,
+   OZONE_ENTRIES_ICONS_TEXTURE_INPUT_SETTINGS,
    OZONE_ENTRIES_ICONS_TEXTURE_MIXER,
    OZONE_ENTRIES_ICONS_TEXTURE_LOG,
    OZONE_ENTRIES_ICONS_TEXTURE_OSD,
@@ -272,6 +272,26 @@ enum
    OZONE_ENTRIES_ICONS_TEXTURE_OVERRIDE,
    OZONE_ENTRIES_ICONS_TEXTURE_NOTIFICATIONS,
    OZONE_ENTRIES_ICONS_TEXTURE_STREAM,
+   OZONE_ENTRIES_ICONS_TEXTURE_SHUTDOWN,
+   OZONE_ENTRIES_ICONS_TEXTURE_INPUT_DPAD_U,
+   OZONE_ENTRIES_ICONS_TEXTURE_INPUT_DPAD_D,
+   OZONE_ENTRIES_ICONS_TEXTURE_INPUT_DPAD_L,
+   OZONE_ENTRIES_ICONS_TEXTURE_INPUT_DPAD_R,
+   OZONE_ENTRIES_ICONS_TEXTURE_INPUT_STCK_U,
+   OZONE_ENTRIES_ICONS_TEXTURE_INPUT_STCK_D,
+   OZONE_ENTRIES_ICONS_TEXTURE_INPUT_STCK_L,
+   OZONE_ENTRIES_ICONS_TEXTURE_INPUT_STCK_R,
+   OZONE_ENTRIES_ICONS_TEXTURE_INPUT_STCK_P,
+   OZONE_ENTRIES_ICONS_TEXTURE_INPUT_SELECT,
+   OZONE_ENTRIES_ICONS_TEXTURE_INPUT_START,
+   OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_U,
+   OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_D,
+   OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_L,
+   OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_R,
+   OZONE_ENTRIES_ICONS_TEXTURE_INPUT_LB,
+   OZONE_ENTRIES_ICONS_TEXTURE_INPUT_RB,
+   OZONE_ENTRIES_ICONS_TEXTURE_INPUT_LT,
+   OZONE_ENTRIES_ICONS_TEXTURE_INPUT_RT,
    OZONE_ENTRIES_ICONS_TEXTURE_LAST
 };
 
@@ -540,261 +560,319 @@ static const char *ozone_entries_icon_texture_path(ozone_handle_t *ozone, unsign
    char icon_fullpath[255];
    char *icon_name         = NULL;
 
-   switch (id)
+switch (id)
    {
       case OZONE_ENTRIES_ICONS_TEXTURE_MAIN_MENU:
 #if defined(HAVE_LAKKA)
          icon_name = "lakka.png";
-			break;
+         break;
 #else
          icon_name = "retroarch.png";
-			break;
+         break;
 #endif
       case OZONE_ENTRIES_ICONS_TEXTURE_SETTINGS:
          icon_name = "settings.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_HISTORY:
          icon_name = "history.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_FAVORITES:
          icon_name = "favorites.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_ADD_FAVORITE:
          icon_name = "add-favorite.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_MUSICS:
          icon_name = "musics.png";
-			break;
+         break;
 #if defined(HAVE_FFMPEG) || defined(HAVE_MPV)
       case OZONE_ENTRIES_ICONS_TEXTURE_MOVIES:
          icon_name = "movies.png";
-			break;
+         break;
 #endif
 #ifdef HAVE_IMAGEVIEWER
       case OZONE_ENTRIES_ICONS_TEXTURE_IMAGES:
          icon_name = "images.png";
-			break;
+         break;
 #endif
       case OZONE_ENTRIES_ICONS_TEXTURE_SETTING:
          icon_name = "setting.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_SUBSETTING:
          icon_name = "subsetting.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_ARROW:
          icon_name = "arrow.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_RUN:
          icon_name = "run.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_CLOSE:
          icon_name = "close.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_RESUME:
          icon_name = "resume.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_CLOCK:
          icon_name = "clock.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_BATTERY_FULL:
          icon_name = "battery-full.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_BATTERY_CHARGING:
          icon_name = "battery-charging.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_POINTER:
          icon_name = "pointer.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_SAVESTATE:
          icon_name = "savestate.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_LOADSTATE:
          icon_name = "loadstate.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_UNDO:
          icon_name = "undo.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_CORE_INFO:
          icon_name = "core-infos.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_WIFI:
          icon_name = "wifi.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_CORE_OPTIONS:
          icon_name = "core-options.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_INPUT_REMAPPING_OPTIONS:
          icon_name = "core-input-remapping-options.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_CHEAT_OPTIONS:
          icon_name = "core-cheat-options.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_DISK_OPTIONS:
          icon_name = "core-disk-options.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_SHADER_OPTIONS:
          icon_name = "core-shader-options.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_ACHIEVEMENT_LIST:
          icon_name = "achievement-list.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_SCREENSHOT:
          icon_name = "screenshot.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_RELOAD:
          icon_name = "reload.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_RENAME:
          icon_name = "rename.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_FILE:
          icon_name = "file.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_FOLDER:
          icon_name = "folder.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_ZIP:
          icon_name = "zip.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_MUSIC:
          icon_name = "music.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_FAVORITE:
          icon_name = "favorites-content.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_IMAGE:
          icon_name = "image.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_MOVIE:
          icon_name = "movie.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_CORE:
          icon_name = "core.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_RDB:
          icon_name = "database.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_CURSOR:
          icon_name = "cursor.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_SWITCH_ON:
          icon_name = "on.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_SWITCH_OFF:
          icon_name = "off.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_ADD:
          icon_name = "add.png";
-			break;
+         break;
 #ifdef HAVE_NETWORKING
       case OZONE_ENTRIES_ICONS_TEXTURE_NETPLAY:
          icon_name = "netplay.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_ROOM:
          icon_name = "menu_room.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_ROOM_LAN:
          icon_name = "menu_room_lan.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_ROOM_RELAY:
          icon_name = "menu_room_relay.png";
-			break;
+         break;
 #endif
       case OZONE_ENTRIES_ICONS_TEXTURE_KEY:
          icon_name = "key.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_KEY_HOVER:
          icon_name = "key-hover.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_DIALOG_SLICE:
          icon_name = "dialog-slice.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_ACHIEVEMENTS:
          icon_name = "menu_achievements.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_AUDIO:
          icon_name = "menu_audio.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_DRIVERS:
          icon_name = "menu_drivers.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_EXIT:
          icon_name = "menu_exit.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_FRAMESKIP:
          icon_name = "menu_frameskip.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_HELP:
          icon_name = "menu_help.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_INFO:
          icon_name = "menu_info.png";
-			break;
-      case OZONE_ENTRIES_ICONS_TEXTURE_INPUT:
+         break;
+      case OZONE_ENTRIES_ICONS_TEXTURE_INPUT_SETTINGS:
          icon_name = "Libretro - Pad.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_LATENCY:
          icon_name = "menu_latency.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_NETWORK:
          icon_name = "menu_network.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_POWER:
          icon_name = "menu_power.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_RECORD:
          icon_name = "menu_record.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_SAVING:
          icon_name = "menu_saving.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_UPDATER:
          icon_name = "menu_updater.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_VIDEO:
          icon_name = "menu_video.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_MIXER:
          icon_name = "menu_mixer.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_LOG:
          icon_name = "menu_log.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_OSD:
          icon_name = "menu_osd.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_UI:
          icon_name = "menu_ui.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_USER:
          icon_name = "menu_user.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_PRIVACY:
          icon_name = "menu_privacy.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_PLAYLIST:
          icon_name = "menu_playlist.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_QUICKMENU:
          icon_name = "menu_quickmenu.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_REWIND:
          icon_name = "menu_rewind.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_OVERLAY:
          icon_name = "menu_overlay.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_OVERRIDE:
          icon_name = "menu_override.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_NOTIFICATIONS:
          icon_name = "menu_notifications.png";
-			break;
+         break;
       case OZONE_ENTRIES_ICONS_TEXTURE_STREAM:
          icon_name = "menu_stream.png";
-			break;
+         break;
+      case OZONE_ENTRIES_ICONS_TEXTURE_SHUTDOWN:
+         icon_name = "menu_shutdown.png";
+      case OZONE_ENTRIES_ICONS_TEXTURE_INPUT_DPAD_U:
+         icon_name = "input_DPAD-U.png";
+         break;
+      case OZONE_ENTRIES_ICONS_TEXTURE_INPUT_DPAD_D:
+         icon_name = "input_DPAD-D.png";
+         break;
+      case OZONE_ENTRIES_ICONS_TEXTURE_INPUT_DPAD_L:
+         icon_name = "input_DPAD-L.png";
+         break;
+      case OZONE_ENTRIES_ICONS_TEXTURE_INPUT_DPAD_R:
+         icon_name = "input_DPAD-R.png";
+         break;
+      case OZONE_ENTRIES_ICONS_TEXTURE_INPUT_STCK_U:
+         icon_name = "input_STCK-U.png";
+         break;
+      case OZONE_ENTRIES_ICONS_TEXTURE_INPUT_STCK_D:
+         icon_name = "input_STCK-D.png";
+         break;
+      case OZONE_ENTRIES_ICONS_TEXTURE_INPUT_STCK_L:
+         icon_name = "input_STCK-L.png";
+         break;
+      case OZONE_ENTRIES_ICONS_TEXTURE_INPUT_STCK_R:
+         icon_name = "input_STCK-R.png";
+         break;
+      case OZONE_ENTRIES_ICONS_TEXTURE_INPUT_STCK_P:
+         icon_name = "input_STCK-P.png";
+         break;
+      case OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_U:
+         icon_name = "input_BTN-U.png";
+         break;
+      case OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_D:
+         icon_name = "input_BTN-D.png";
+         break;
+      case OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_L:
+         icon_name = "input_BTN-L.png";
+         break;
+      case OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_R:
+         icon_name = "input_BTN-R.png";
+         break;
+      case OZONE_ENTRIES_ICONS_TEXTURE_INPUT_LB:
+         icon_name = "input_LB.png";
+         break;
+      case OZONE_ENTRIES_ICONS_TEXTURE_INPUT_RB:
+         icon_name = "input_RB.png";
+         break;
+      case OZONE_ENTRIES_ICONS_TEXTURE_INPUT_LT:
+         icon_name = "input_LT.png";
+         break;
+      case OZONE_ENTRIES_ICONS_TEXTURE_INPUT_RT:
+         icon_name = "input_RT.png";
+         break;
+      case OZONE_ENTRIES_ICONS_TEXTURE_INPUT_SELECT:
+         icon_name = "input_SELECT.png";
+         break;
+      case OZONE_ENTRIES_ICONS_TEXTURE_INPUT_START:
+         icon_name = "input_START.png";
+         break;
    }
-
 
    fill_pathname_join(
       icon_fullpath,
@@ -872,129 +950,165 @@ static unsigned ozone_entries_icon_get_id(ozone_handle_t *ozone,
          return OZONE_ENTRIES_ICONS_TEXTURE_MOVIE;
       case MENU_ENUM_LABEL_GOTO_MUSIC:
          return OZONE_ENTRIES_ICONS_TEXTURE_MUSIC;
-      case MENU_ENUM_LABEL_CONTENT_SETTINGS:
-      case MENU_ENUM_LABEL_UPDATE_ASSETS:
-         return OZONE_ENTRIES_ICONS_TEXTURE_QUICKMENU;
-      case MENU_ENUM_LABEL_START_CORE:
-         return OZONE_ENTRIES_ICONS_TEXTURE_RUN;
-      case MENU_ENUM_LABEL_CORE_LIST:
-      case MENU_ENUM_LABEL_CORE_SETTINGS:
-      case MENU_ENUM_LABEL_CORE_UPDATER_LIST:
-         return OZONE_ENTRIES_ICONS_TEXTURE_CORE;
-      case MENU_ENUM_LABEL_LOAD_CONTENT_LIST:
-      case MENU_ENUM_LABEL_SCAN_FILE:
-         return OZONE_ENTRIES_ICONS_TEXTURE_FILE;
-      case MENU_ENUM_LABEL_ONLINE_UPDATER:
-      case MENU_ENUM_LABEL_UPDATER_SETTINGS:
-         return OZONE_ENTRIES_ICONS_TEXTURE_UPDATER;
-      case MENU_ENUM_LABEL_UPDATE_LAKKA:
-         return OZONE_ENTRIES_ICONS_TEXTURE_MAIN_MENU;
-      case MENU_ENUM_LABEL_UPDATE_CHEATS:
-         return OZONE_ENTRIES_ICONS_TEXTURE_CHEAT_OPTIONS;
-      case MENU_ENUM_LABEL_THUMBNAILS_UPDATER_LIST:
-         return OZONE_ENTRIES_ICONS_TEXTURE_IMAGE;
-      case MENU_ENUM_LABEL_UPDATE_OVERLAYS:
-      case MENU_ENUM_LABEL_ONSCREEN_OVERLAY_SETTINGS:
-         return OZONE_ENTRIES_ICONS_TEXTURE_OVERLAY;
-      case MENU_ENUM_LABEL_UPDATE_CG_SHADERS:
-      case MENU_ENUM_LABEL_UPDATE_GLSL_SHADERS:
-      case MENU_ENUM_LABEL_UPDATE_SLANG_SHADERS:
-         return OZONE_ENTRIES_ICONS_TEXTURE_SHADER_OPTIONS;
-      case MENU_ENUM_LABEL_INFORMATION:
-      case MENU_ENUM_LABEL_INFORMATION_LIST:
-      case MENU_ENUM_LABEL_SYSTEM_INFORMATION:
-      case MENU_ENUM_LABEL_UPDATE_CORE_INFO_FILES:
-         return OZONE_ENTRIES_ICONS_TEXTURE_INFO;
-      case MENU_ENUM_LABEL_UPDATE_DATABASES:
-      case MENU_ENUM_LABEL_DATABASE_MANAGER_LIST:
-         return OZONE_ENTRIES_ICONS_TEXTURE_RDB;
-      case MENU_ENUM_LABEL_CURSOR_MANAGER_LIST:
-         return OZONE_ENTRIES_ICONS_TEXTURE_CURSOR;
-      case MENU_ENUM_LABEL_HELP_LIST:
-      case MENU_ENUM_LABEL_HELP_CONTROLS:
-      case MENU_ENUM_LABEL_HELP_LOADING_CONTENT:
-      case MENU_ENUM_LABEL_HELP_SCANNING_CONTENT:
-      case MENU_ENUM_LABEL_HELP_WHAT_IS_A_CORE:
-      case MENU_ENUM_LABEL_HELP_CHANGE_VIRTUAL_GAMEPAD:
-      case MENU_ENUM_LABEL_HELP_AUDIO_VIDEO_TROUBLESHOOTING:
-         return OZONE_ENTRIES_ICONS_TEXTURE_HELP;
-      case MENU_ENUM_LABEL_QUIT_RETROARCH:
-         return OZONE_ENTRIES_ICONS_TEXTURE_EXIT;
-      /* Settings icons*/
-      case MENU_ENUM_LABEL_DRIVER_SETTINGS:
-         return OZONE_ENTRIES_ICONS_TEXTURE_DRIVERS;
-      case MENU_ENUM_LABEL_VIDEO_SETTINGS:
-         return OZONE_ENTRIES_ICONS_TEXTURE_VIDEO;
-      case MENU_ENUM_LABEL_AUDIO_SETTINGS:
-         return OZONE_ENTRIES_ICONS_TEXTURE_AUDIO;
-      case MENU_ENUM_LABEL_AUDIO_MIXER_SETTINGS:
-         return OZONE_ENTRIES_ICONS_TEXTURE_MIXER;
-      case MENU_ENUM_LABEL_INPUT_SETTINGS:
-      case MENU_ENUM_LABEL_UPDATE_AUTOCONFIG_PROFILES:
-         return OZONE_ENTRIES_ICONS_TEXTURE_INPUT;
-      case MENU_ENUM_LABEL_LATENCY_SETTINGS:
-         return OZONE_ENTRIES_ICONS_TEXTURE_LATENCY;
-      case MENU_ENUM_LABEL_SAVING_SETTINGS:
-      case MENU_ENUM_LABEL_SAVE_CURRENT_CONFIG_OVERRIDE_CORE:
-      case MENU_ENUM_LABEL_SAVE_CURRENT_CONFIG_OVERRIDE_CONTENT_DIR:
-      case MENU_ENUM_LABEL_SAVE_CURRENT_CONFIG_OVERRIDE_GAME:
-         return OZONE_ENTRIES_ICONS_TEXTURE_SAVING;
-      case MENU_ENUM_LABEL_LOGGING_SETTINGS:
-         return OZONE_ENTRIES_ICONS_TEXTURE_LOG;
-      case MENU_ENUM_LABEL_FRAME_THROTTLE_SETTINGS:
-         return OZONE_ENTRIES_ICONS_TEXTURE_FRAMESKIP;
-      case MENU_ENUM_LABEL_QUICK_MENU_START_RECORDING:
-      case MENU_ENUM_LABEL_RECORDING_SETTINGS:
-         return OZONE_ENTRIES_ICONS_TEXTURE_RECORD;
-      case MENU_ENUM_LABEL_QUICK_MENU_START_STREAMING:
-         return OZONE_ENTRIES_ICONS_TEXTURE_STREAM;
-      case MENU_ENUM_LABEL_QUICK_MENU_STOP_STREAMING:
-      case MENU_ENUM_LABEL_QUICK_MENU_STOP_RECORDING:
-         return OZONE_ENTRIES_ICONS_TEXTURE_CLOSE;
-      case MENU_ENUM_LABEL_ONSCREEN_DISPLAY_SETTINGS:
-         return OZONE_ENTRIES_ICONS_TEXTURE_OSD;
-      case MENU_ENUM_LABEL_SHOW_WIMP:
-      case MENU_ENUM_LABEL_USER_INTERFACE_SETTINGS:
-         return OZONE_ENTRIES_ICONS_TEXTURE_UI;
-#ifdef HAVE_LAKKA_SWITCH
-      case MENU_ENUM_LABEL_SWITCH_GPU_PROFILE:
-      case MENU_ENUM_LABEL_SWITCH_CPU_PROFILE:
-#endif
-      case MENU_ENUM_LABEL_POWER_MANAGEMENT_SETTINGS:
-         return OZONE_ENTRIES_ICONS_TEXTURE_POWER;
-      case MENU_ENUM_LABEL_RETRO_ACHIEVEMENTS_SETTINGS:
-         return OZONE_ENTRIES_ICONS_TEXTURE_ACHIEVEMENTS;
-      case MENU_ENUM_LABEL_NETWORK_INFORMATION:
-      case MENU_ENUM_LABEL_NETWORK_SETTINGS:
-         return OZONE_ENTRIES_ICONS_TEXTURE_NETWORK;
-      case MENU_ENUM_LABEL_PLAYLIST_SETTINGS:
-         return OZONE_ENTRIES_ICONS_TEXTURE_PLAYLIST;
-      case MENU_ENUM_LABEL_USER_SETTINGS:
-         return OZONE_ENTRIES_ICONS_TEXTURE_USER;
-      case MENU_ENUM_LABEL_DIRECTORY_SETTINGS:
-      case MENU_ENUM_LABEL_SCAN_DIRECTORY:
-         return OZONE_ENTRIES_ICONS_TEXTURE_FOLDER;
-      case MENU_ENUM_LABEL_PRIVACY_SETTINGS:
-         return OZONE_ENTRIES_ICONS_TEXTURE_PRIVACY;
 
-      case MENU_ENUM_LABEL_REWIND_SETTINGS:
-         return OZONE_ENTRIES_ICONS_TEXTURE_REWIND;
-      case MENU_ENUM_LABEL_QUICK_MENU_OVERRIDE_OPTIONS:
-         return OZONE_ENTRIES_ICONS_TEXTURE_OVERRIDE;
-      case MENU_ENUM_LABEL_ONSCREEN_NOTIFICATIONS_SETTINGS:
-         return OZONE_ENTRIES_ICONS_TEXTURE_NOTIFICATIONS;
-#ifdef HAVE_NETWORKING
-      case MENU_ENUM_LABEL_NETPLAY_ENABLE_HOST:
-         return OZONE_ENTRIES_ICONS_TEXTURE_RUN;
-      case MENU_ENUM_LABEL_NETPLAY_DISCONNECT:
-         return OZONE_ENTRIES_ICONS_TEXTURE_CLOSE;
-      case MENU_ENUM_LABEL_NETPLAY_ENABLE_CLIENT:
-         return OZONE_ENTRIES_ICONS_TEXTURE_ROOM;
-      case MENU_ENUM_LABEL_NETPLAY_REFRESH_ROOMS:
-         return OZONE_ENTRIES_ICONS_TEXTURE_RELOAD;
-#endif
       default:
+      /* Menu icons are here waiting for theme support*/
+      {
+            settings_t *settings = config_get_ptr();
+            if (settings->uints.menu_xmb_theme != XMB_ICON_THEME_FLATUI &&
+                settings->uints.menu_xmb_theme != XMB_ICON_THEME_PIXEL )
+            {
+               switch (enum_idx)
+               {
+                  /* Menu icons */
+                  case MENU_ENUM_LABEL_CONTENT_SETTINGS:
+                  case MENU_ENUM_LABEL_UPDATE_ASSETS:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_QUICKMENU;
+                  case MENU_ENUM_LABEL_START_CORE:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_RUN;
+                  case MENU_ENUM_LABEL_CORE_LIST:
+                  case MENU_ENUM_LABEL_CORE_SETTINGS:
+                  case MENU_ENUM_LABEL_CORE_UPDATER_LIST:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_CORE;
+                  case MENU_ENUM_LABEL_LOAD_CONTENT_LIST:
+                  case MENU_ENUM_LABEL_SCAN_FILE:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_FILE;
+                  case MENU_ENUM_LABEL_ONLINE_UPDATER:
+                  case MENU_ENUM_LABEL_UPDATER_SETTINGS:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_UPDATER;
+                  case MENU_ENUM_LABEL_UPDATE_LAKKA:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_MAIN_MENU;
+                  case MENU_ENUM_LABEL_UPDATE_CHEATS:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_CHEAT_OPTIONS;
+                  case MENU_ENUM_LABEL_THUMBNAILS_UPDATER_LIST:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_IMAGE;
+                  case MENU_ENUM_LABEL_UPDATE_OVERLAYS:
+                  case MENU_ENUM_LABEL_ONSCREEN_OVERLAY_SETTINGS:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_OVERLAY;
+                  case MENU_ENUM_LABEL_UPDATE_CG_SHADERS:
+                  case MENU_ENUM_LABEL_UPDATE_GLSL_SHADERS:
+                  case MENU_ENUM_LABEL_UPDATE_SLANG_SHADERS:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_SHADER_OPTIONS;
+                  case MENU_ENUM_LABEL_INFORMATION:
+                  case MENU_ENUM_LABEL_INFORMATION_LIST:
+                  case MENU_ENUM_LABEL_SYSTEM_INFORMATION:
+                  case MENU_ENUM_LABEL_UPDATE_CORE_INFO_FILES:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_INFO;
+                  case MENU_ENUM_LABEL_UPDATE_DATABASES:
+                  case MENU_ENUM_LABEL_DATABASE_MANAGER_LIST:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_RDB;
+                  case MENU_ENUM_LABEL_CURSOR_MANAGER_LIST:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_CURSOR;
+                  case MENU_ENUM_LABEL_HELP_LIST:
+                  case MENU_ENUM_LABEL_HELP_CONTROLS:
+                  case MENU_ENUM_LABEL_HELP_LOADING_CONTENT:
+                  case MENU_ENUM_LABEL_HELP_SCANNING_CONTENT:
+                  case MENU_ENUM_LABEL_HELP_WHAT_IS_A_CORE:
+                  case MENU_ENUM_LABEL_HELP_CHANGE_VIRTUAL_GAMEPAD:
+                  case MENU_ENUM_LABEL_HELP_AUDIO_VIDEO_TROUBLESHOOTING:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_HELP;
+                  case MENU_ENUM_LABEL_QUIT_RETROARCH:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_EXIT;
+                  /* Settings icons*/
+                  case MENU_ENUM_LABEL_DRIVER_SETTINGS:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_DRIVERS;
+                  case MENU_ENUM_LABEL_VIDEO_SETTINGS:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_VIDEO;
+                  case MENU_ENUM_LABEL_AUDIO_SETTINGS:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_AUDIO;
+                  case MENU_ENUM_LABEL_AUDIO_MIXER_SETTINGS:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_MIXER;
+                  case MENU_ENUM_LABEL_INPUT_SETTINGS:
+                  case MENU_ENUM_LABEL_UPDATE_AUTOCONFIG_PROFILES:
+                  case MENU_ENUM_LABEL_INPUT_USER_1_BINDS:
+                  case MENU_ENUM_LABEL_INPUT_USER_2_BINDS:
+                  case MENU_ENUM_LABEL_INPUT_USER_3_BINDS:
+                  case MENU_ENUM_LABEL_INPUT_USER_4_BINDS:
+                  case MENU_ENUM_LABEL_INPUT_USER_5_BINDS:
+                  case MENU_ENUM_LABEL_INPUT_USER_6_BINDS:
+                  case MENU_ENUM_LABEL_INPUT_USER_7_BINDS:
+                  case MENU_ENUM_LABEL_INPUT_USER_8_BINDS:
+                  case MENU_ENUM_LABEL_INPUT_USER_9_BINDS:
+                  case MENU_ENUM_LABEL_INPUT_USER_10_BINDS:
+                  case MENU_ENUM_LABEL_INPUT_USER_11_BINDS:
+                  case MENU_ENUM_LABEL_INPUT_USER_12_BINDS:
+                  case MENU_ENUM_LABEL_INPUT_USER_13_BINDS:
+                  case MENU_ENUM_LABEL_INPUT_USER_14_BINDS:
+                  case MENU_ENUM_LABEL_INPUT_USER_15_BINDS:
+                  case MENU_ENUM_LABEL_INPUT_USER_16_BINDS:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_INPUT_SETTINGS;
+                  case MENU_ENUM_LABEL_LATENCY_SETTINGS:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_LATENCY;
+                  case MENU_ENUM_LABEL_SAVING_SETTINGS:
+                  case MENU_ENUM_LABEL_SAVE_CURRENT_CONFIG_OVERRIDE_CORE:
+                  case MENU_ENUM_LABEL_SAVE_CURRENT_CONFIG_OVERRIDE_CONTENT_DIR:
+                  case MENU_ENUM_LABEL_SAVE_CURRENT_CONFIG_OVERRIDE_GAME:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_SAVING;
+                  case MENU_ENUM_LABEL_LOGGING_SETTINGS:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_LOG;
+                  case MENU_ENUM_LABEL_FRAME_THROTTLE_SETTINGS:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_FRAMESKIP;
+                  case MENU_ENUM_LABEL_QUICK_MENU_START_RECORDING:
+                  case MENU_ENUM_LABEL_RECORDING_SETTINGS:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_RECORD;
+                  case MENU_ENUM_LABEL_QUICK_MENU_START_STREAMING:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_STREAM;
+                  case MENU_ENUM_LABEL_QUICK_MENU_STOP_STREAMING:
+                  case MENU_ENUM_LABEL_QUICK_MENU_STOP_RECORDING:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_CLOSE;
+                  case MENU_ENUM_LABEL_ONSCREEN_DISPLAY_SETTINGS:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_OSD;
+                  case MENU_ENUM_LABEL_SHOW_WIMP:
+                  case MENU_ENUM_LABEL_USER_INTERFACE_SETTINGS:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_UI;
+#ifdef HAVE_LAKKA_SWITCH
+                  case MENU_ENUM_LABEL_SWITCH_GPU_PROFILE:
+                  case MENU_ENUM_LABEL_SWITCH_CPU_PROFILE:
+#endif
+                  case MENU_ENUM_LABEL_POWER_MANAGEMENT_SETTINGS:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_POWER;
+                  case MENU_ENUM_LABEL_RETRO_ACHIEVEMENTS_SETTINGS:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_ACHIEVEMENTS;
+                  case MENU_ENUM_LABEL_NETWORK_INFORMATION:
+                  case MENU_ENUM_LABEL_NETWORK_SETTINGS:
+                  case MENU_ENUM_LABEL_WIFI_SETTINGS:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_NETWORK;
+                  case MENU_ENUM_LABEL_PLAYLIST_SETTINGS:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_PLAYLIST;
+                  case MENU_ENUM_LABEL_USER_SETTINGS:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_USER;
+                  case MENU_ENUM_LABEL_DIRECTORY_SETTINGS:
+                  case MENU_ENUM_LABEL_SCAN_DIRECTORY:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_FOLDER;
+                  case MENU_ENUM_LABEL_PRIVACY_SETTINGS:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_PRIVACY;
+
+                  case MENU_ENUM_LABEL_REWIND_SETTINGS:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_REWIND;
+                  case MENU_ENUM_LABEL_QUICK_MENU_OVERRIDE_OPTIONS:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_OVERRIDE;
+                  case MENU_ENUM_LABEL_ONSCREEN_NOTIFICATIONS_SETTINGS:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_NOTIFICATIONS;
+#ifdef HAVE_NETWORKING
+                  case MENU_ENUM_LABEL_NETPLAY_ENABLE_HOST:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_RUN;
+                  case MENU_ENUM_LABEL_NETPLAY_DISCONNECT:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_CLOSE;
+                  case MENU_ENUM_LABEL_NETPLAY_ENABLE_CLIENT:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_ROOM;
+                  case MENU_ENUM_LABEL_NETPLAY_REFRESH_ROOMS:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_RELOAD;
+#endif
+                  case MENU_ENUM_LABEL_REBOOT:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_RELOAD;
+                  case MENU_ENUM_LABEL_SHUTDOWN:
+                     return OZONE_ENTRIES_ICONS_TEXTURE_SHUTDOWN;
+                  default:
+                     break;
+                  }
+            }
             break;
+      }
    }
 
    switch(type)
@@ -1003,7 +1117,6 @@ static unsigned ozone_entries_icon_get_id(ozone_handle_t *ozone,
          return OZONE_ENTRIES_ICONS_TEXTURE_FOLDER;
       case FILE_TYPE_PLAIN:
       case FILE_TYPE_IN_CARCHIVE:
-         return OZONE_ENTRIES_ICONS_TEXTURE_FILE;
       case FILE_TYPE_RPL_ENTRY:
          return OZONE_ENTRIES_ICONS_TEXTURE_FILE;
       case FILE_TYPE_SHADER:
@@ -1076,9 +1189,8 @@ static unsigned ozone_entries_icon_get_id(ozone_handle_t *ozone,
          return OZONE_ENTRIES_ICONS_TEXTURE_ROOM_RELAY;
 #endif
       case MENU_SETTING_ACTION:
-         if (ozone->depth <= 3)
-         return OZONE_ENTRIES_ICONS_TEXTURE_SETTING;
-      default:
+         if (ozone->depth == 3)
+            return OZONE_ENTRIES_ICONS_TEXTURE_SETTING;
          return OZONE_ENTRIES_ICONS_TEXTURE_SUBSETTING;
    }
 
@@ -1096,6 +1208,66 @@ static unsigned ozone_entries_icon_get_id(ozone_handle_t *ozone,
    }
 #endif
 
+   if (
+         (type >= MENU_SETTINGS_INPUT_DESC_BEGIN) &&
+         (type <= MENU_SETTINGS_INPUT_DESC_END)
+      )
+      {
+         unsigned input_id;
+         input_id = MENU_SETTINGS_INPUT_DESC_BEGIN;
+         while (type > (input_id + 23))
+         {
+            input_id = (input_id + 24) ;
+         }
+         if ( type == input_id )
+            return OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_D;
+         if ( type == (input_id + 1))
+            return OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_L;
+         if ( type == (input_id + 2))
+            return OZONE_ENTRIES_ICONS_TEXTURE_INPUT_SELECT;
+         if ( type == (input_id + 3))
+            return OZONE_ENTRIES_ICONS_TEXTURE_INPUT_START;
+         if ( type == (input_id + 4))
+            return OZONE_ENTRIES_ICONS_TEXTURE_INPUT_DPAD_U;
+         if ( type == (input_id + 5))
+            return OZONE_ENTRIES_ICONS_TEXTURE_INPUT_DPAD_D;
+         if ( type == (input_id + 6))
+            return OZONE_ENTRIES_ICONS_TEXTURE_INPUT_DPAD_L;
+         if ( type == (input_id + 7))
+            return OZONE_ENTRIES_ICONS_TEXTURE_INPUT_DPAD_R;
+         if ( type == (input_id + 8))
+            return OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_R;
+         if ( type == (input_id + 9))
+            return OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_U;
+         if ( type == (input_id + 10))
+            return OZONE_ENTRIES_ICONS_TEXTURE_INPUT_LB;
+         if ( type == (input_id + 11))
+            return OZONE_ENTRIES_ICONS_TEXTURE_INPUT_RB;
+         if ( type == (input_id + 12))
+            return OZONE_ENTRIES_ICONS_TEXTURE_INPUT_LT;
+         if ( type == (input_id + 13))
+            return OZONE_ENTRIES_ICONS_TEXTURE_INPUT_RT;
+         if ( type == (input_id + 14))
+            return OZONE_ENTRIES_ICONS_TEXTURE_INPUT_STCK_P;
+         if ( type == (input_id + 15))
+            return OZONE_ENTRIES_ICONS_TEXTURE_INPUT_STCK_P;
+         if ( type == (input_id + 16))
+            return OZONE_ENTRIES_ICONS_TEXTURE_INPUT_STCK_R;
+         if ( type == (input_id + 17))
+            return OZONE_ENTRIES_ICONS_TEXTURE_INPUT_STCK_L;
+         if ( type == (input_id + 18))
+            return OZONE_ENTRIES_ICONS_TEXTURE_INPUT_STCK_D;
+         if ( type == (input_id + 19))
+            return OZONE_ENTRIES_ICONS_TEXTURE_INPUT_STCK_U;
+         if ( type == (input_id + 20))
+            return OZONE_ENTRIES_ICONS_TEXTURE_INPUT_STCK_R;
+         if ( type == (input_id + 21))
+            return OZONE_ENTRIES_ICONS_TEXTURE_INPUT_STCK_L;
+         if ( type == (input_id + 22))
+            return OZONE_ENTRIES_ICONS_TEXTURE_INPUT_STCK_D;
+         if ( type == (input_id + 23))
+            return OZONE_ENTRIES_ICONS_TEXTURE_INPUT_STCK_U;
+      }
    return OZONE_ENTRIES_ICONS_TEXTURE_SUBSETTING;
 }
 

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -1210,6 +1210,8 @@ static void *ozone_init(void **userdata, bool video_is_threaded)
    *userdata = ozone;
    ozone->selection_buf_old = (file_list_t*)calloc(1, sizeof(file_list_t));
    ozone->want_horizontal_animation = false;
+   ozone->draw_sidebar = true;
+   ozone->sidebar_offset = 0;
 
    ozone->system_tab_end                = 0;
    ozone->tabs[ozone->system_tab_end]     = OZONE_SYSTEM_TAB_MAIN;
@@ -1422,8 +1424,6 @@ static void ozone_context_reset(void *data, bool is_threaded)
       ozone->fade_direction = false;
       ozone->cursor_in_sidebar = false;
       ozone->cursor_in_sidebar_old = false;
-      ozone->draw_sidebar = true;
-      ozone->sidebar_offset = 0;
       ozone->draw_old_list = false;
 
       /* Animations */


### PR DESCRIPTION
There was an issue where the sidebar was visible but not interactable with when you toggled the menu after starting a core. This is now fixed (the sidebar is properly hidden).

I also updated all the icons to be on par with XMB.