### PR TITLE
Dropdown lists: Add a checked bool to menu_entry_t

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -8012,6 +8012,9 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, menu_displaylist
                      unsigned size                   = (unsigned)tmp_str_list->size;
                      unsigned i                      = atoi(tmp_str_list->elems[size-1].data);
                      struct core_option *option      = NULL;
+                     bool checked_found              = false;
+                     unsigned checked                = 0;
+                     const char *val                 = core_option_manager_get_val(coreopts, i-1);
 
                      i--;
 
@@ -8033,9 +8036,19 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, menu_displaylist
                                     val_d,
                                     MENU_ENUM_LABEL_NO_ITEMS,
                                     MENU_SETTING_DROPDOWN_SETTING_CORE_OPTIONS_ITEM, k, 0);
+
+                              if (!checked_found && string_is_equal(str, val))
+                              {
+                                 checked = k;
+                                 checked_found = true;
+                              }
+
                               count++;
                            }
                         }
+
+                        if (checked_found)
+                           menu_entries_set_checked(info->list, checked, true);
                      }
                   }
                }
@@ -8057,7 +8070,9 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, menu_displaylist
                            if (tmp_str_list && tmp_str_list->size > 0)
                            {
                               unsigned i;
-                              unsigned size = (unsigned)tmp_str_list->size;
+                              unsigned size        = (unsigned)tmp_str_list->size;
+                              bool checked_found   = false;
+                              unsigned checked     = 0;
 
                               for (i = 0; i < size; i++)
                               {
@@ -8068,7 +8083,16 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, menu_displaylist
                                        val_d,
                                        MENU_ENUM_LABEL_NO_ITEMS,
                                        MENU_SETTING_DROPDOWN_SETTING_STRING_OPTIONS_ITEM, i, 0);
+
+                                 if (!checked_found && string_is_equal(tmp_str_list->elems[i].data, setting->value.target.string))
+                                 {
+                                    checked = i;
+                                    checked_found = true;
+                                 }
                               }
+
+                              if (checked_found)
+                                 menu_entries_set_checked(info->list, checked, true);
                            }
                         }
                         break;
@@ -8080,6 +8104,8 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, menu_displaylist
                            float step             = setting->step;
                            double min             = setting->enforce_minrange ? setting->min : 0.00;
                            double max             = setting->enforce_maxrange ? setting->max : 999.00;
+                           bool checked_found     = false;
+                           unsigned checked       = 0;
 
                            if (setting->get_string_representation)
                            {
@@ -8098,6 +8124,12 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, menu_displaylist
                                        val_d,
                                        MENU_ENUM_LABEL_NO_ITEMS,
                                        setting_type, val, 0);
+
+                                 if (!checked_found && string_is_equal(val_s, setting->value.target.string))
+                                 {
+                                    checked = i;
+                                    checked_found = true;
+                                 }
                               }
 
                               *setting->value.target.integer = orig_value;
@@ -8117,8 +8149,17 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, menu_displaylist
                                        val_d,
                                        MENU_ENUM_LABEL_NO_ITEMS,
                                        setting_type, val, 0);
+
+                                 if (!checked_found && string_is_equal(val_s, setting->value.target.string))
+                                 {
+                                    checked = i;
+                                    checked_found = true;
+                                 }
                               }
                            }
+
+                           if (checked_found)
+                              menu_entries_set_checked(info->list, checked, true);
                         }
                         break;
                      case ST_FLOAT:
@@ -8129,6 +8170,8 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, menu_displaylist
                            float step             = setting->step;
                            double min             = setting->enforce_minrange ? setting->min : 0.00;
                            double max             = setting->enforce_maxrange ? setting->max : 999.00;
+                           bool checked_found     = false;
+                           unsigned checked       = 0;
 
                            if (setting->get_string_representation)
                            {
@@ -8146,6 +8189,12 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, menu_displaylist
                                        val_d,
                                        MENU_ENUM_LABEL_NO_ITEMS,
                                        setting_type, 0, 0);
+
+                                 if (!checked_found && string_is_equal(val_s, setting->value.target.string))
+                                 {
+                                    checked = i;
+                                    checked_found = true;
+                                 }
                               }
 
                               *setting->value.target.fraction = orig_value;
@@ -8164,8 +8213,17 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, menu_displaylist
                                        val_d,
                                        MENU_ENUM_LABEL_NO_ITEMS,
                                        setting_type, 0, 0);
+
+                                 if (!checked_found && string_is_equal(val_s, setting->value.target.string))
+                                 {
+                                    checked = i;
+                                    checked_found = true;
+                                 }
                               }
                            }
+
+                           if (checked_found)
+                              menu_entries_set_checked(info->list, checked, true);
                         }
                         break;
                      case ST_UINT:
@@ -8176,6 +8234,8 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, menu_displaylist
                            float step             = setting->step;
                            double min             = setting->enforce_minrange ? setting->min : 0.00;
                            double max             = setting->enforce_maxrange ? setting->max : 999.00;
+                           bool checked_found     = false;
+                           unsigned checked       = 0;
 
                            if (setting->get_string_representation)
                            {
@@ -8194,6 +8254,12 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, menu_displaylist
                                        val_d,
                                        MENU_ENUM_LABEL_NO_ITEMS,
                                        setting_type, val, 0);
+
+                                 if (!checked_found && string_is_equal(val_s, setting->value.target.string))
+                                 {
+                                    checked = i;
+                                    checked_found = true;
+                                 }
                               }
 
                               *setting->value.target.unsigned_integer = orig_value;
@@ -8213,8 +8279,17 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, menu_displaylist
                                        val_d,
                                        MENU_ENUM_LABEL_NO_ITEMS,
                                        setting_type, val, 0);
+
+                                 if (!checked_found && string_is_equal(val_s, setting->value.target.string))
+                                 {
+                                    checked = i;
+                                    checked_found = true;
+                                 }
                               }
                            }
+
+                           if (checked_found)
+                              menu_entries_set_checked(info->list, checked, true);
                         }
                         break;
                      default:

--- a/menu/menu_entries.c
+++ b/menu/menu_entries.c
@@ -487,6 +487,15 @@ error:
    return false;
 }
 
+void menu_entries_set_checked(file_list_t *list, size_t entry_idx,
+      bool checked)
+{
+   menu_file_list_cbs_t *cbs = (menu_file_list_cbs_t*)file_list_get_actiondata_at_offset(list, entry_idx);
+
+   if (cbs)
+      cbs->checked = checked;
+}
+
 void menu_entries_append(file_list_t *list, const char *path, const char *label,
       unsigned type, size_t directory_ptr, size_t entry_idx)
 {

--- a/menu/menu_entries.h
+++ b/menu/menu_entries.h
@@ -99,6 +99,8 @@ typedef struct menu_file_list_cbs
    const char *action_down_ident;
    const char *action_get_value_ident;
 
+   bool checked;
+
    rarch_setting_t *setting;
 
    int (*action_iterate)(const char *label, unsigned action);
@@ -179,6 +181,9 @@ void menu_entries_append_enum(file_list_t *list, const char *path, const char *l
       unsigned type, size_t directory_ptr, size_t entry_idx);
 
 bool menu_entries_ctl(enum menu_entries_ctl_state state, void *data);
+
+void menu_entries_set_checked(file_list_t *list, size_t entry_idx,
+      bool checked);
 
 RETRO_END_DECLS
 

--- a/menu/widgets/menu_entry.c
+++ b/menu/widgets/menu_entry.c
@@ -325,6 +325,7 @@ void menu_entry_get(menu_entry_t *entry, size_t stack_idx,
       enum msg_hash_enums enum_idx  = MSG_UNKNOWN;
 
       entry->enum_idx               = cbs->enum_idx;
+      entry->checked                = cbs->checked;
 
       menu_entries_get_last_stack(NULL, &label, NULL, &enum_idx, NULL);
 

--- a/menu/widgets/menu_entry.h
+++ b/menu/widgets/menu_entry.h
@@ -56,6 +56,7 @@ typedef struct menu_entry
    char *sublabel;
    char *rich_label;
    char *value;
+   bool checked;
 } menu_entry_t;
 
 enum menu_entry_type menu_entry_get_type(uint32_t i);


### PR DESCRIPTION
This adds a new bool to `menu_entry_t` called `checked`. It will be set to true if the current list is a dropdown list and the entry is "checked", so that menu drivers can show an appropriate icon.

I implemented the icon display in ozone, it still needs to be done in xmb, materialui and rgui.