### PR TITLE
iOS: fix stack overflow when loading glsl shader

### DIFF
--- a/ui/drivers/ui_cocoatouch.m
+++ b/ui/drivers/ui_cocoatouch.m
@@ -79,7 +79,6 @@ static void ui_companion_cocoatouch_event_command(
       void *data, enum event_command cmd)
 {
     (void)data;
-    command_event(cmd, NULL);
 }
 
 static void rarch_draw_observer(CFRunLoopObserverRef observer,


### PR DESCRIPTION
## Description

Re-applying this fix after the reverting to use cocoa_gl_ctx.m for the driver context. See issue #7298.

## Related Issues

#7298

## Reviewers

@stuartcarnie 
