### PR TITLE
emscripten: fix README and add Theodore core

### DIFF
--- a/pkg/emscripten/README.md
+++ b/pkg/emscripten/README.md
@@ -31,8 +31,13 @@ I you want a self hosted version you need
 - Unzip it in the same dir you extracted the rest, inside **/assets/frontend/bundle**
 - Create an **assets/cores** dir, you can put game data in that dir so it's available under **downloads**
 - chmod +x the indexer script
-- run the indexer script (you need coffeescript) like this: ./indexer ./assets/frontend > ./assets/frontend/.index-xhr
-- run the indexer script (you need coffeescript) like this: ./indexer ./assets/cores > ./assets/cores/.index-xhr
+- run the indexer script (you need coffeescript) like this:
+```
+cd ${ROOT_WWW_PATH}/assets/frontend/bundle
+../../../indexer > .index-xhr
+cd ${ROOT_WWW_PATH}/assets/cores
+../../indexer > .index-xhr
+```
 
 That should be it, you can add more cores to the list by editing index.html
 

--- a/pkg/emscripten/libretro/embed.html
+++ b/pkg/emscripten/libretro/embed.html
@@ -34,6 +34,7 @@
                           <a class="dropdown-item" href="." data-core="genesis_plus_gx">Genesis Plus GX</a>
                           <a class="dropdown-item" href="." data-core="nestopia">Nestopia (NES)</a>
                           <a class="dropdown-item" href="." data-core="snes9x2010">Snes9x 2010 (SNES)</a>
+                          <a class="dropdown-item" href="." data-core="theodore">Theodore (Thomson TO8/TO9)</a>
                           <a class="dropdown-item" href="." data-core="vba_next">VBA Next (Gameboy Advance)</a>
                         </div>
                         <button class="btn btn-primary disabled" id="btnRun" onclick="startRetroArch()" disabled>

--- a/pkg/emscripten/libretro/index.html
+++ b/pkg/emscripten/libretro/index.html
@@ -71,6 +71,7 @@
                            <a class="dropdown-item" href="." data-core="snes9x">Snes9x</a>
                            <a class="dropdown-item" href="." data-core="stella">Stella</a>
                            <a class="dropdown-item" href="." data-core="tgbdual">TGB Dual</a>
+                           <a class="dropdown-item" href="." data-core="theodore">Theodore (Thomson TO8/TO9)</a>
                            <a class="dropdown-item" href="." data-core="tyrquake">TyrQuake</a>
                            <a class="dropdown-item" href="." data-core="vba_next">VBA Next</a>
                            <a class="dropdown-item" href="." data-core="vecx">Vecx</a>


### PR DESCRIPTION
Hi,
This PR fixes the README file of the emscripten package (the way the indexer script was called was not working, so I did the same kind of change than https://github.com/Inglebard/dockerfiles/pull/1/files and now the webplayer is working in self-hosted mode) and add Theodore core to the list of available cores.
Regards