### PR TITLE
Analog stick to trigger remap functionality.

### DIFF
--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -1180,9 +1180,14 @@ void input_get_state_for_port(void *data, unsigned port, input_bits_t *p_new_sta
    joypad_info.auto_binds                       = input_autoconf_binds[joypad_info.joy_idx];
    joypad_info.axis_threshold                   = input_driver_axis_threshold;
 
+   if (!joypad_driver)
+      return;
+
    for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)
    {
       bool bit_pressed = false;
+      int16_t val;
+      val = input_joypad_analog(joypad_driver, joypad_info, port, RETRO_DEVICE_INDEX_ANALOG_BUTTON, i, libretro_input_binds[port]);
 
       if (input_driver_input_state(joypad_info, libretro_input_binds,
                port, RETRO_DEVICE_JOYPAD, 0, i) != 0)
@@ -1190,10 +1195,9 @@ void input_get_state_for_port(void *data, unsigned port, input_bits_t *p_new_sta
 
       if (bit_pressed)
          BIT256_SET_PTR(p_new_state, i);
+      if (bit_pressed && val)
+         p_new_state->analog_buttons[i] = val;
    }
-
-   if (!joypad_driver)
-      return;
 
    for (i = 0; i < 2; i++)
    {

--- a/input/input_mapper.c
+++ b/input/input_mapper.c
@@ -195,7 +195,7 @@ void input_mapper_poll(input_mapper_t *handle)
 
                      handle->analog_value[i][
                         remap_button - RARCH_FIRST_CUSTOM_BIND] =
-                           32767 * invert;
+                           (current_input.analog_buttons[j] ? current_input.analog_buttons[j] : 32767) * invert;
                   }
                }
             }

--- a/input/input_types.h
+++ b/input/input_types.h
@@ -25,6 +25,7 @@ typedef struct input_keyboard_ctx_wait input_keyboard_ctx_wait_t;
 typedef struct {
    uint32_t data[8];
    uint16_t analogs[8];
+   uint16_t analog_buttons[16];
 } input_bits_t;
 typedef struct joypad_connection joypad_connection_t;
 typedef struct pad_connection_listener_interface pad_connection_listener_t;


### PR DESCRIPTION
Made by Radius.

Ability to remap an analog stick to an analog trigger.
The opposite is not possible for now.