### PR TITLE
GUI English translation: clarify "Configurations" as "Configuration File"

### DIFF
--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -261,7 +261,7 @@ MSG_HASH(
     )
 MSG_HASH(
     MENU_ENUM_LABEL_VALUE_CONFIGURATIONS_LIST,
-    "Configurations"
+    "Configuration File"
     )
 MSG_HASH(
     MENU_ENUM_LABEL_VALUE_ADD_TAB,
@@ -6048,11 +6048,11 @@ MSG_HASH(
     )
 MSG_HASH(
     MENU_ENUM_LABEL_VALUE_MENU_SHOW_CONFIGURATIONS,
-    "Show Configurations"
+    "Show Configuration File"
     )
 MSG_HASH(
     MENU_ENUM_SUBLABEL_MENU_SHOW_CONFIGURATIONS,
-    "Show/hide the 'Configurations' option."
+    "Show/hide the 'Configuration File' option."
     )
 MSG_HASH(
     MENU_ENUM_LABEL_VALUE_MENU_SHOW_HELP,


### PR DESCRIPTION
On my latest trip, I have recently configured three fresh Lakka installations for friends.

This is a simple enhancement that I believe will make things a bit more clear for first-time users who are English speakers.

I am glad to change this from "Configuration File" to "Configuration Files" if that is preferred, although I personally think the singular is most appropriate and clear.

**For reference, here are the contents of the submenu that I suggest be labelled "Configuration File", as rendered in XMB:**
![screenshot 2018-11-15 14 47 11](https://user-images.githubusercontent.com/19554678/48577607-84ebc980-e8e5-11e8-9b68-2e3da34a7faa.png)
