### PR TITLE
Ozone improvements, new menu_animation features

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,7 @@
    "terminal.integrated.cursorBlinking": true,
 
    "editor.tabSize": 3,
+   "editor.detectIndentation": false,
    "editor.renderWhitespace": "all",
    "editor.insertSpaces": true,
    "files.associations": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,7 +27,8 @@
       "menu_driver.h": "c",
       "file_path.h": "c",
       "unordered_map": "c",
-      "unordered_set": "c"
+      "unordered_set": "c",
+      "sstream": "cpp"
    },
    "C_Cpp.dimInactiveRegions": false,
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,7 +28,12 @@
       "file_path.h": "c",
       "unordered_map": "c",
       "unordered_set": "c",
-      "sstream": "cpp"
+      "sstream": "cpp",
+      "hash_map": "c",
+      "hash_set": "c",
+      "initializer_list": "c",
+      "string_view": "c",
+      "utility": "c"
    },
    "C_Cpp.dimInactiveRegions": false,
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,12 +4,49 @@
    "version": "2.0.0",
    "tasks": [
       {
-         "taskName": "msys2-mingw64 build",
+         "label": "linux clean build",
+         "type": "shell",
+         "group": "build",
+         "command": "make clean && ./configure && make -j12"
+      },
+      {
+         "label": "linux clean",
+         "type": "shell",
+         "group": "build",
+         "command": "make clean"
+      },
+      {
+         "label": "linux build with debug symbols",
+         "type": "shell",
+         "group": "build",
+         "command": "DEBUG=1 make -j12"
+      },
+      {
+         "label": "linux build",
+         "type": "shell",
+         "group": "build",
+         "command": "make -j12"
+      },
+      {
+         "label": "linux build and run",
+         "type": "shell",
+         "group": "build",
+         "command": "make -j12 && ./retroarch -v"
+      },
+      {
+         "label": "linux build and run with debug symbols",
+         "type": "shell",
+         "group": "build",
+         "command": "DEBUG=1 make -j12 && ./retroarch -v"
+      },
+      {
+         "label": "msys2-mingw64 build",
          "type": "shell",
 
          "group": {
             "kind": "build",
-            "isDefault": true },
+            "isDefault": true 
+         },
 
          "command": "./configure; make -j2",
          "options": {
@@ -20,9 +57,9 @@
                ]
             }
          }
-      }
+      },
       {
-         "taskName": "msys2-mingw64 build with debug symbols",
+         "label": "msys2-mingw64 build with debug symbols",
          "type": "shell",
 
          "group": "build",
@@ -36,9 +73,9 @@
                ]
             }
          }
-      }
+      },
       {
-         "taskName": "msys2-mingw64 rebuild",
+         "label": "msys2-mingw64 rebuild",
          "type": "shell",
 
          "group": "build",
@@ -52,9 +89,9 @@
                ]
             }
          }
-      }
+      },
       {
-         "taskName": "msys2-mingw64 clean",
+         "label": "msys2-mingw64 clean",
          "type": "shell",
 
          "group": "build",
@@ -68,9 +105,9 @@
                ]
             }
          }
-      }
+      },
       {
-         "taskName": "msys2-mingw64 run",
+         "label": "msys2-mingw64 run",
          "type": "shell",
 
          "group": {

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -2750,19 +2750,16 @@ static void ozone_draw_entry_value(ozone_handle_t *ozone,
       char *value,
       unsigned x, unsigned y,
       uint32_t alpha_uint32,
-      bool checked)
+      menu_entry_t *entry)
 {
-   enum msg_file_type hash_type;
    bool switch_is_on = true;
    bool do_draw_text = false;
 
-   if (!checked && string_is_empty(value))
+   if (!entry->checked && string_is_empty(value))
       return;
 
-   hash_type    = msg_hash_to_file_type(msg_hash_calculate(value));
-
    /* check icon */
-   if (checked)
+   if (entry->checked)
    {
       menu_display_blend_begin(video_info);
       ozone_draw_icon(video_info, 30, 30, ozone->theme->textures[OZONE_THEME_TEXTURE_CHECK], x - 20, y - 22, video_info->width, video_info->height, 0, 1, ozone->theme_dynamic.entries_checkmark);
@@ -2785,25 +2782,31 @@ static void ozone_draw_entry_value(ozone_handle_t *ozone,
    }
    else
    {
-      switch (hash_type)
+      if (!string_is_empty(entry->value))
       {
-         case FILE_TYPE_IN_CARCHIVE:
-         case FILE_TYPE_COMPRESSED:
-         case FILE_TYPE_MORE:
-         case FILE_TYPE_CORE:
-         case FILE_TYPE_DIRECT_LOAD:
-         case FILE_TYPE_RDB:
-         case FILE_TYPE_CURSOR:
-         case FILE_TYPE_PLAIN:
-         case FILE_TYPE_DIRECTORY:
-         case FILE_TYPE_MUSIC:
-         case FILE_TYPE_IMAGE:
-         case FILE_TYPE_MOVIE:
+         if (
+               string_is_equal(entry->value, "...")     ||
+               string_is_equal(entry->value, "(PRESET)")  ||
+               string_is_equal(entry->value, "(SHADER)")  ||
+               string_is_equal(entry->value, "(COMP)")  ||
+               string_is_equal(entry->value, "(CORE)")  ||
+               string_is_equal(entry->value, "(MOVIE)") ||
+               string_is_equal(entry->value, "(MUSIC)") ||
+               string_is_equal(entry->value, "(DIR)")   ||
+               string_is_equal(entry->value, "(RDB)")   ||
+               string_is_equal(entry->value, "(CURSOR)")||
+               string_is_equal(entry->value, "(CFILE)") ||
+               string_is_equal(entry->value, "(FILE)")  ||
+               string_is_equal(entry->value, "(IMAGE)")
+            )
+         {
             return;
-         default:
+         }
+         else
             do_draw_text = true;
-            break;
       }
+      else
+         do_draw_text = true;
    }
 
    if (do_draw_text)
@@ -2983,7 +2986,7 @@ border_iterate:
       ticker.len = (entry_width - 60 - ((int)utf8len(entry_rich_label) * ozone->entry_font_glyph_width)) / ozone->entry_font_glyph_width;
 
       menu_animation_ticker(&ticker);
-      ozone_draw_entry_value(ozone, video_info, entry_value_ticker, x_offset + 426 + entry_width, y + FONT_SIZE_ENTRIES_LABEL + 8 - 1 + scroll_y,alpha_uint32, entry.checked);
+      ozone_draw_entry_value(ozone, video_info, entry_value_ticker, x_offset + 426 + entry_width, y + FONT_SIZE_ENTRIES_LABEL + 8 - 1 + scroll_y,alpha_uint32, &entry);
       
       free(entry_rich_label);
       free(sublabel_str);

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -2953,7 +2953,7 @@ border_iterate:
       {
          unsigned text_width = font_driver_get_message_width(ozone->fonts.entries_label, rich_label, (unsigned)strlen(rich_label), 1);
          x_offset = (video_info_width - 408 - 162)/2 - text_width/2;
-         y = video_info_height/2 - 23;
+         y = video_info_height/2 - 60;
       }
 
       sublabel_str = menu_entry_get_sublabel(&entry);

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -2700,9 +2700,12 @@ static void ozone_draw_sidebar(ozone_handle_t *ozone, video_frame_info_t *video_
    /* Background */
    sidebar_height = video_info->height - 87 - 55 - 78;
 
-   menu_display_draw_quad(video_info, ozone->sidebar_offset, 88, 408, 55/2, video_info->width, video_info->height, ozone->theme->sidebar_top_gradient);
-   menu_display_draw_quad(video_info, ozone->sidebar_offset, 88 + 55/2, 408, sidebar_height, video_info->width, video_info->height, ozone->theme->sidebar_background);
-   menu_display_draw_quad(video_info, ozone->sidebar_offset, 55*2 + sidebar_height, 408, 55/2 + 1, video_info->width, video_info->height, ozone->theme->sidebar_bottom_gradient);
+   if (!video_info->libretro_running)
+   {
+      menu_display_draw_quad(video_info, ozone->sidebar_offset, 88, 408, 55/2, video_info->width, video_info->height, ozone->theme->sidebar_top_gradient);
+      menu_display_draw_quad(video_info, ozone->sidebar_offset, 88 + 55/2, 408, sidebar_height, video_info->width, video_info->height, ozone->theme->sidebar_background);
+      menu_display_draw_quad(video_info, ozone->sidebar_offset, 55*2 + sidebar_height, 408, 55/2 + 1, video_info->width, video_info->height, ozone->theme->sidebar_bottom_gradient);
+   }
 
    /* Tabs */
    /* TODO Scroll */
@@ -3079,7 +3082,7 @@ static unsigned ozone_get_system_theme()
 
 static void ozone_draw_backdrop(video_frame_info_t *video_info)
 {
-   /* TODO Replace this backdrop by a blur shader on the whole screen */
+   /* TODO Replace this backdrop by a blur shader on the whole screen if available */
    menu_display_draw_quad(video_info, 0, 0, video_info->width, video_info->height, video_info->width, video_info->height, ozone_backdrop);
 }
 
@@ -3297,6 +3300,9 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
    ozone->raster_blocks.entries_label.carr.coords.vertices = 0;
    ozone->raster_blocks.entries_sublabel.carr.coords.vertices = 0;
    ozone->raster_blocks.sidebar.carr.coords.vertices = 0;
+
+   /* TODO Replace this by blur backdrop if available */
+   ozone_color_alpha(ozone->theme->background, video_info->libretro_running ? 0.75f : 1.0f);
 
    /* Background */
    menu_display_draw_quad(video_info, 

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -5415,7 +5415,7 @@ static void xmb_toggle(void *userdata, bool menu_on)
    xmb_toggle_horizontal_list(xmb);
 }
 
-static int deferred_push_content_actions(menu_displaylist_info_t *info)
+static int xmb_deferred_push_content_actions(menu_displaylist_info_t *info)
 {
    if (!menu_displaylist_ctl(
             DISPLAYLIST_HORIZONTAL_CONTENT_ACTIONS, info))
@@ -5432,7 +5432,7 @@ static int xmb_list_bind_init_compare_label(menu_file_list_cbs_t *cbs)
       switch (cbs->enum_idx)
       {
          case MENU_ENUM_LABEL_CONTENT_ACTIONS:
-            cbs->action_deferred_push = deferred_push_content_actions;
+            cbs->action_deferred_push = xmb_deferred_push_content_actions;
             break;
          default:
             return -1;

--- a/menu/menu_animation.c
+++ b/menu/menu_animation.c
@@ -711,3 +711,30 @@ bool menu_animation_ctl(enum menu_animation_ctl_state state, void *data)
 
    return true;
 }
+
+void menu_timer_start(menu_timer_t *timer, menu_timer_ctx_entry_t *timer_entry)
+{
+   menu_animation_ctx_tag tag = (uintptr_t) timer;
+
+   menu_timer_kill(timer);
+
+   *timer = 0.0f;
+
+   menu_animation_ctx_entry_t entry;
+
+   entry.easing_enum    = EASING_LINEAR;
+   entry.tag            = tag;
+   entry.duration       = timer_entry->duration;
+   entry.target_value   = 1.0f;
+   entry.subject        = timer;
+   entry.cb             = timer_entry->cb;
+   entry.userdata       = timer_entry->userdata;
+
+   menu_animation_push(&entry);
+}
+
+void menu_timer_kill(menu_timer_t *timer)
+{
+   menu_animation_ctx_tag tag = (uintptr_t) timer;
+   menu_animation_kill_by_tag(&tag);
+}

--- a/menu/menu_animation.h
+++ b/menu/menu_animation.h
@@ -118,6 +118,19 @@ typedef struct menu_animation_ctx_ticker
    const char *str;
 } menu_animation_ctx_ticker_t;
 
+typedef float menu_timer_t;
+
+typedef struct menu_timer_ctx_entry
+{
+   float duration;
+   tween_cb cb;
+   void *userdata;
+} menu_timer_ctx_entry_t;
+
+void menu_timer_start(menu_timer_t *timer, menu_timer_ctx_entry_t *timer_entry);
+
+void menu_timer_kill(menu_timer_t *timer);
+
 bool menu_animation_update(float delta_time);
 
 bool menu_animation_get_ideal_delta_time(menu_animation_ctx_delta_t *delta);

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -76,6 +76,13 @@ typedef struct menu_ctx_load_image
    enum menu_image_type type;
 } menu_ctx_load_image_t;
 
+float osk_dark[16] =  {
+   0.00, 0.00, 0.00, 0.85,
+   0.00, 0.00, 0.00, 0.85,
+   0.00, 0.00, 0.00, 0.85,
+   0.00, 0.00, 0.00, 0.85,
+};
+
 /* Menu drivers */
 static const menu_ctx_driver_t *menu_ctx_drivers[] = {
 #if defined(HAVE_OZONE)
@@ -1510,12 +1517,6 @@ void menu_display_draw_keyboard(
    int ptr_width, ptr_height;
    unsigned width    = video_info->width;
    unsigned height   = video_info->height;
-   float dark[16]    =  {
-      0.00, 0.00, 0.00, 0.85,
-      0.00, 0.00, 0.00, 0.85,
-      0.00, 0.00, 0.00, 0.85,
-      0.00, 0.00, 0.00, 0.85,
-   };
 
    float white[16]=  {
       1.00, 1.00, 1.00, 1.00,
@@ -1528,7 +1529,7 @@ void menu_display_draw_keyboard(
          video_info,
          0, height/2.0, width, height/2.0,
          width, height,
-         &dark[0]);
+         &osk_dark[0]);
 
    ptr_width  = width  / 11;
    ptr_height = height / 10;

--- a/menu/menu_driver.h
+++ b/menu/menu_driver.h
@@ -57,6 +57,8 @@ RETRO_BEGIN_DECLS
 #define MENU_SETTINGS_CHEEVOS_START              0x40000
 #define MENU_SETTINGS_NETPLAY_ROOMS_START        0x80000
 
+float osk_dark[16];
+
 enum menu_image_type
 {
    MENU_IMAGE_NONE = 0,


### PR DESCRIPTION
# Ozone improvements 

- cursor goes back to Main Menu when pressing B on the sidebar
- empty playlist messages are now centered
- improved OSK look and feel (will need blur shader for it to be really finished)
- content is now visible behind the menu when content is running
- fixed incorrect value display on some entries which shouldn't have a value

# `menu_timer` system 

This allows menu drivers to schedule a function call at the end of a given duration. It internally uses a linear menu animation with a `float` going from 0 to 1. This will be used later on in ozone.