### PR TITLE
Quick fix for "multiple definitions of osk_dark" in Ozone

### DIFF
--- a/menu/menu_driver.h
+++ b/menu/menu_driver.h
@@ -57,7 +57,7 @@ RETRO_BEGIN_DECLS
 #define MENU_SETTINGS_CHEEVOS_START              0x40000
 #define MENU_SETTINGS_NETPLAY_ROOMS_START        0x80000
 
-float osk_dark[16];
+extern float osk_dark[16];
 
 enum menu_image_type
 {


### PR DESCRIPTION
Fix for the following:

```
LD retroarch
/usr/bin/ld: obj-unix/release/ui/drivers/qt/updateretroarch.o:(.bss+0x0): multiple definition of osk_dark'; obj-unix/release/ui/drivers/qt/ui_qt_window.o:(.bss+0x0): first defined here
/usr/bin/ld: obj-unix/release/ui/drivers/qt/thumbnaildownload.o:(.bss+0x0): multiple definition ofosk_dark'; obj-unix/release/ui/drivers/qt/ui_qt_window.o:(.bss+0x0): first defined here
/usr/bin/ld: obj-unix/release/ui/drivers/qt/thumbnailpackdownload.o:(.bss+0x0): multiple definition of osk_dark'; obj-unix/release/ui/drivers/qt/ui_qt_window.o:(.bss+0x0): first defined here
/usr/bin/ld: obj-unix/release/ui/drivers/qt/playlistthumbnaildownload.o:(.bss+0x0): multiple definition ofosk_dark'; obj-unix/release/ui/drivers/qt/ui_qt_window.o:(.bss+0x0): first defined here
/usr/bin/ld: obj-unix/release/menu/menu_driver.o:(.data+0x0): multiple definition of osk_dark'; obj-unix/release/ui/drivers/qt/ui_qt_window.o:(.bss+0x0): first defined here
/usr/bin/ld: obj-unix/release/deps/lua/src/loslib.o: in functionos_tmpname':
loslib.c:(.text+0x2a0): warning: the use of tmpnam' is dangerous, better usemkstemp'
collect2: error: ld returned 1 exit status
make: *** [Makefile:188: retroarch] Error 1
```