### PR TITLE
fix libretro-db Makefile

### DIFF
--- a/libretro-db/Makefile
+++ b/libretro-db/Makefile
@@ -13,7 +13,10 @@ endif
 
 LIBRETRO_COMMON_C = \
 			 $(LIBRETRO_COMM_DIR)/streams/file_stream.c \
-			 $(LIBRETRO_COMM_DIR)/vfs/vfs_implementation.c
+			 $(LIBRETRO_COMM_DIR)/vfs/vfs_implementation.c \
+			 $(LIBRETRO_COMM_DIR)/encodings/encoding_utf.c \
+			 $(LIBRETRO_COMM_DIR)/compat/compat_strl.c \
+			 $(LIBRETRO_COMM_DIR)/compat/fopen_utf8.c
 
 C_CONVERTER_C = \
 			 $(LIBRETRODB_DIR)/rmsgpack.c \
@@ -25,9 +28,7 @@ C_CONVERTER_C = \
 			 $(LIBRETRO_COMM_DIR)/hash/rhash.c \
 			 $(LIBRETRO_COMM_DIR)/compat/compat_fnmatch.c \
 			 $(LIBRETRO_COMM_DIR)/string/stdstring.c \
-			 $(LIBRETRO_COMM_DIR)/encodings/encoding_utf.c \
-			 $(LIBRETRO_COMMON_C) \
-			 $(LIBRETRO_COMM_DIR)/compat/compat_strl.c
+			 $(LIBRETRO_COMMON_C)
 
 C_CONVERTER_OBJS := $(C_CONVERTER_C:.c=.o)
 
@@ -40,9 +41,7 @@ RARCHDB_TOOL_C = \
 			 $(LIBRETRODB_DIR)/libretrodb.c \
 			 $(LIBRETRO_COMM_DIR)/compat/compat_fnmatch.c \
 			 $(LIBRETRO_COMM_DIR)/string/stdstring.c \
-			 $(LIBRETRO_COMM_DIR)/encodings/encoding_utf.c \
-			 $(LIBRETRO_COMMON_C) \
-			 $(LIBRETRO_COMM_DIR)/compat/compat_strl.c
+			 $(LIBRETRO_COMMON_C)
 
 RARCHDB_TOOL_OBJS := $(RARCHDB_TOOL_C:.c=.o)
 


### PR DESCRIPTION
The current Makefile doesn't work. This patch comes via @grant2258 and originally from @swingflip and is intended to resolve https://github.com/libretro/RetroArch/issues/7586
