### PR TITLE
update, expand, and re-sequence the libretro-db doc

### DIFF
--- a/libretro-db/README.md
+++ b/libretro-db/README.md
@@ -5,11 +5,67 @@ Mainly to be used by retroarch
 # Usage
 Files specified later in the chain **will override** earlier ones if the same key exists multiple times.
 
-To list out the content of a db `libretrodb_tool <db file> list`
-To create an index `libretrodb_tool <db file> create-index <index name> <field name>`
-To find an entry with an index `libretrodb_tool <db file> find <index name> <value>`
+* To list out the content of a db `libretrodb_tool <db file> list`
+* To create an index `libretrodb_tool <db file> create-index <index name> <field name>`
+* To find an entry with an index `libretrodb_tool <db file> find <index name> <value>`
 
-# lua converters
+# Compiling a single database with `c_converter`
+```
+git clone git@github.com:libretro/libretro-super.git
+cd libretro-super
+./libretro-fetch.sh retroarch
+cd retroarch
+./configure
+cd libretro-db
+c_converter "NAME_OF_RDB_FILE.rdb" "NAME_OF_SOURCE_DAT.dat"
+```
+
+# Compiling all databases with libretro-build-database.sh
+**This approach builds and uses the `c_converter` program to compile the databases**
+
+```
+git clone git@github.com:libretro/libretro-super.git
+cd libretro-super
+./libretro-fetch.sh retroarch
+cd retroarch
+./configure
+cd ..
+./libretro-build-database.sh
+```
+
+# Lua DAT file converter
+To convert a dat file use:
+~~~
+dat_converter <db file> <dat file>
+~~~
+If you want to merge multiple dat files you need to run:
+~~~
+dat_converter <db file> <match key> <dat file> ...
+~~~
+for example:
+~~~
+dat_converter snes.rdb rom.crc snes1.dat snes2.dat
+~~~
+
+# Query examples
+Some examples of queries you can use with libretrodbtool:
+
+1) Glob pattern matching
+Usecase : Search for all games starting with 'Street Fighter' in the 'name' field (glob pattern matching)
+
+`libretrodb_tool <db file> find "{'name':glob('Street Fighter*')}"`
+
+2) Combined number matching query
+Usecase: Search for all games released on October 1995.
+
+`libretrodb_tool <db file> find "{'releasemonth':10,'releaseyear':1995}"`
+
+3) Names only search
+Usecase: Search for all games released on October 1995, wont print checksums, filename or rom size, only the game name.
+
+`libretrodb_tool <db file> get-names "{'releasemonth':10,'releaseyear':1995}"`
+
+# Writing Lua converters
 In order to write you own converter you must have a lua file that implements the following functions:
 
 ~~~.lua
@@ -33,51 +89,3 @@ function get_value()
 	}
 end
 ~~~
-
-# dat file converter
-To convert a dat file use:
-
-~~~
-dat_converter <db file> <dat file>
-~~~
-
-If you want to merge multiple dat files you need to run:
-
-~~~
-dat_converter <db file> <match key> <dat file> ...
-~~~
-
-for example:
-
-~~~
-dat_converter snes.rdb rom.crc snes1.dat snes2.dat
-~~~
-
-# Query examples
-Some examples of queries you can use with libretrodbtool:
-
-1) Glob pattern matching
-Usecase : Search for all games starting with 'Street Fighter' in the 'name' field (glob pattern matching)
-
-`libretrodb_tool <db file> find "{'name':glob('Street Fighter*')}"`
-
-2) Combined number matching query
-Usecase: Search for all games released on October 1995.
-
-`libretrodb_tool <db file> find "{'releasemonth':10,'releaseyear':1995}"`
-
-3) Names only search
-Usecase: Search for all games released on October 1995, wont print checksums, filename or rom size, only the game name.
-
-`libretrodb_tool <db file> get-names "{'releasemonth':10,'releaseyear':1995}"`
-
-# Compiling the Database
-
-Use [libretro-super](https://github.com/libretro/libretro-super) to compile the entire database:
-
-```
-git clone git@github.com:libretro/libretro-super.git
-cd libretro-super
-./libretro-fetch.sh retroarch
-./libretro-build-database.sh
-```


### PR DESCRIPTION
At the moment it is not possible to build database files by following any of the procedures listed here in their current form. In other words the README is a little out of date.

This updates the compilation instructions for building all databases and adds instructions for building just one database via `c_converter`. By the way, `c_converter` is at the moment is the only converter that compiles and runs "out of the box" in msys2.

I've made it clearer which instructions pertain to the Lua converter but someone with knowledge of Lua might want to see how those instructions can also be fixed.