### PR TITLE
Clarify libretro.h documentation

### DIFF
--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -140,7 +140,8 @@ extern "C" {
 /* The ANALOG device is an extension to JOYPAD (RetroPad).
  * Similar to DualShock2 it adds two analog sticks and all buttons can
  * be analog. This is treated as a separate device type as it returns
- * axis values in the full analog range of [-0x7fff, 0x7fff].
+ * axis values in the full analog range of [-0x7fff, 0x7fff],
+ * although some devices may return -0x8000.
  * Positive X axis is right. Positive Y axis is down.
  * Buttons are returned in the range [0, 0x7fff].
  * Only use ANALOG type when polling for analog values.

--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -128,7 +128,8 @@ extern "C" {
 
 /* LIGHTGUN device is similar to Guncon-2 for PlayStation 2.
  * It reports X/Y coordinates in screen space (similar to the pointer)
- * in the range [-0x8000, 0x7fff] in both axes, with zero being center.
+ * in the range [-0x8000, 0x7fff] in both axes, with zero being center and
+ * -0x8000 being out of bounds.
  * As well as reporting on/off screen state. It features a trigger,
  * start/select buttons, auxiliary action buttons and a
  * directional pad. A forced off-screen shot can be requested for
@@ -139,7 +140,7 @@ extern "C" {
 /* The ANALOG device is an extension to JOYPAD (RetroPad).
  * Similar to DualShock2 it adds two analog sticks and all buttons can
  * be analog. This is treated as a separate device type as it returns
- * axis values in the full analog range of [-0x8000, 0x7fff].
+ * axis values in the full analog range of [-0x7fff, 0x7fff].
  * Positive X axis is right. Positive Y axis is down.
  * Buttons are returned in the range [0, 0x7fff].
  * Only use ANALOG type when polling for analog values.


### PR DESCRIPTION
-0x7FFF is clearly the proper minimum:

In input/drivers_joypad/gx_joypad.c there is an explicit conversion of -0x8000 to -0x7FFF:
```
for (i = 0; i < 2; i++)
	for (j = 0; j < 2; j++)
		if (analog_state[port][i][j] == -0x8000)
  			analog_state[port][i][j] = -0x7fff;
```

The same for PS3 in input/drivers_joypad/ps3_joypad.c:
```
static INLINE int16_t convert_u8_to_s16(uint8_t val)
{
	if (val == 0)
		return -0x7fff;
	return val * 0x0101 - 0x8000;
}
```
I also checked 3DS and its range is -0x7F00 to 0x7F00.
Android also bottoms out at -0x7FFF:
```
android->analog_state[port][0] = (int16_t)(x * 32767.0f);
android->analog_state[port][1] = (int16_t)(y * 32767.0f);
```

Also all RETRO_DEVICE_LIGHTGUN accesses are proxyed through video_driver_translate_coord_viewport where -0x8000 is returned for out of bounds.