### PR TITLE
Fix shader warnings

### DIFF
--- a/gfx/drivers/gl_shaders/shaders_common.h
+++ b/gfx/drivers/gl_shaders/shaders_common.h
@@ -23,11 +23,11 @@
                   "#else\n" \
                   "  precision mediump float;\n" \
                   "#endif\n" #src
+#define GLSL_300(src)   "#version 300 es\n"   #src
 #else
 #define CG(src)   "" #src
 #define GLSL(src) "" #src
-#define GLSL_300(src)   "#version 300 es\n"   #src
-#define GLSL_330(src)   "#version 330 core\n"   #src
+#define GLSL_330(src)   "#version 330\n"   #src
 #endif
 
 #endif

--- a/gfx/drivers_shader/shader_glsl.c
+++ b/gfx/drivers_shader/shader_glsl.c
@@ -344,7 +344,6 @@ static bool gl_glsl_compile_shader(glsl_shader_data_t *glsl,
       }
 #endif
       snprintf(version, sizeof(version), "#version %u%s\n", version_no, version_extra);
-      RARCH_LOG("[GLSL]: Using GLSL version %u%s.\n", version_no, version_extra);
    }
    else if (glsl_core)
    {
@@ -368,9 +367,14 @@ static bool gl_glsl_compile_shader(glsl_shader_data_t *glsl,
       }
 
       snprintf(version, sizeof(version), "#version %u\n", version_no);
-      RARCH_LOG("[GLSL]: Using GLSL version %u.\n", version_no);
+   }
+   else
+   {
+      /* Don't leave version empty, prevent the compiler warning */
+      snprintf(version, sizeof(version), "#version 110\n");
    }
 
+   RARCH_LOG("[GLSL]: Using GLSL %s", version);
    source[0] = version;
    source[1] = define;
    source[2] = glsl->alias_define;


### PR DESCRIPTION
I was testing some shaders and noticed a few problems
you cannot request `#version 300 es` if you don't have opengles support to begin with
core is the default, no need to specify it, and doing so causes warnings on windows with an intel gpu
no `#version` directive causes a bunch of warnings on the logs, i've read in the khronos docs that the compiler fallbacks to 110 if no directive is given, so just use that, it's cleaner