### PR TITLE
This should fix netplay passwords

### DIFF
--- a/network/netplay/netplay_handshake.c
+++ b/network/netplay/netplay_handshake.c
@@ -278,7 +278,8 @@ static void handshake_password(void *ignore, const char *line)
    struct netplay_connection *connection = &netplay->connections[0];
 
    snprintf(password, sizeof(password), "%08X", connection->salt);
-   strlcpy(password + 8, line, sizeof(password)-8);
+   if (line)
+      strlcpy(password + 8, line, sizeof(password)-8);
 
    password_buf.cmd[0] = htonl(NETPLAY_CMD_PASSWORD);
    password_buf.cmd[1] = htonl(sizeof(password_buf.password));

--- a/network/netplay/netplay_private.h
+++ b/network/netplay/netplay_private.h
@@ -35,7 +35,7 @@
 
 #define NETPLAY_NICK_LEN      32
 #define NETPLAY_PASS_LEN      128
-#define NETPLAY_PASS_HASH_LEN 64 /* length of a SHA-256 hash */
+#define NETPLAY_PASS_HASH_LEN 65 /* length of a SHA-256 hash + NULL terminator*/
 
 #define MAX_SERVER_STALL_TIME_USEC  (5*1000*1000)
 #define MAX_CLIENT_STALL_TIME_USEC  (10*1000*1000)


### PR DESCRIPTION
Passwords should work on netplay, its untested, but either way it fixes a buffer overflow.

Also ads a check to prevent copying from an uninitialized string, caused a crash when the password entered was empty.