### PR TITLE
Fix Buffer Overflow with netplay passwords

### DIFF
--- a/network/netplay/netplay_handshake.c
+++ b/network/netplay/netplay_handshake.c
@@ -274,6 +274,7 @@ static void handshake_password(void *ignore, const char *line)
 {
    struct password_buf_s password_buf;
    char password[8+NETPLAY_PASS_LEN]; /* 8 for salt, 128 for password */
+   char hash[NETPLAY_PASS_HASH_LEN+1]; /* + NULL terminator */
    netplay_t *netplay = handshake_password_netplay;
    struct netplay_connection *connection = &netplay->connections[0];
 
@@ -282,7 +283,8 @@ static void handshake_password(void *ignore, const char *line)
 
    password_buf.cmd[0] = htonl(NETPLAY_CMD_PASSWORD);
    password_buf.cmd[1] = htonl(sizeof(password_buf.password));
-   sha256_hash(password_buf.password, (uint8_t *) password, strlen(password));
+   sha256_hash(hash, (uint8_t *) password, strlen(password));
+   memcpy(password_buf.password, hash, NETPLAY_PASS_HASH_LEN);
 
    /* We have no way to handle an error here, so we'll let the next function error out */
    if (netplay_send(&connection->send_packet_buffer, connection->fd, &password_buf, sizeof(password_buf)))
@@ -750,8 +752,9 @@ bool netplay_handshake_pre_nick(netplay_t *netplay,
 bool netplay_handshake_pre_password(netplay_t *netplay,
    struct netplay_connection *connection, bool *had_input)
 {
-   struct password_buf_s password_buf, corr_password_buf;
+   struct password_buf_s password_buf;
    char password[8+NETPLAY_PASS_LEN]; /* 8 for salt */
+   char hash[NETPLAY_PASS_HASH_LEN+1]; /* + NULL terminator */
    ssize_t recvd;
    char msg[512];
    bool correct         = false;
@@ -787,11 +790,9 @@ bool netplay_handshake_pre_password(netplay_t *netplay,
       strlcpy(password + 8,
             settings->paths.netplay_password, sizeof(password)-8);
 
-      sha256_hash(corr_password_buf.password,
-            (uint8_t *) password, strlen(password));
+      sha256_hash(hash, (uint8_t *) password, strlen(password));
 
-      if (!memcmp(password_buf.password,
-               corr_password_buf.password, sizeof(password_buf.password)))
+      if (!memcmp(password_buf.password, hash, NETPLAY_PASS_HASH_LEN))
       {
          correct = true;
          connection->can_play = true;
@@ -802,11 +803,9 @@ bool netplay_handshake_pre_password(netplay_t *netplay,
       strlcpy(password + 8,
             settings->paths.netplay_spectate_password, sizeof(password)-8);
 
-      sha256_hash(corr_password_buf.password,
-            (uint8_t *) password, strlen(password));
+      sha256_hash(hash, (uint8_t *) password, strlen(password));
 
-      if (!memcmp(password_buf.password,
-               corr_password_buf.password, sizeof(password_buf.password)))
+      if (!memcmp(password_buf.password, hash, NETPLAY_PASS_HASH_LEN))
          correct = true;
    }
 

--- a/network/netplay/netplay_handshake.c
+++ b/network/netplay/netplay_handshake.c
@@ -278,8 +278,7 @@ static void handshake_password(void *ignore, const char *line)
    struct netplay_connection *connection = &netplay->connections[0];
 
    snprintf(password, sizeof(password), "%08X", connection->salt);
-   if (line)
-      strlcpy(password + 8, line, sizeof(password)-8);
+   strlcpy(password + 8, line, sizeof(password)-8);
 
    password_buf.cmd[0] = htonl(NETPLAY_CMD_PASSWORD);
    password_buf.cmd[1] = htonl(sizeof(password_buf.password));

--- a/network/netplay/netplay_private.h
+++ b/network/netplay/netplay_private.h
@@ -35,7 +35,7 @@
 
 #define NETPLAY_NICK_LEN      32
 #define NETPLAY_PASS_LEN      128
-#define NETPLAY_PASS_HASH_LEN 65 /* length of a SHA-256 hash + NULL terminator*/
+#define NETPLAY_PASS_HASH_LEN 64 /* length of a SHA-256 hash */
 
 #define MAX_SERVER_STALL_TIME_USEC  (5*1000*1000)
 #define MAX_CLIENT_STALL_TIME_USEC  (10*1000*1000)


### PR DESCRIPTION
Reverts libretro/RetroArch#7635. Don't pull this 'til I've added my own changes :)

This change is not innocuous and breaks the netplay protocol, because NETPLAY_PASSWORD_HASH_LEN is used in the protocol buffers. I believe that intuition has led to the real problem tho. I don't nul-terminate password hashes because they're always the same length, but the function to generate password hashes does nul-terminate, which is a buffer overflow. I will fix that issue and update this pull request.