### PR TITLE
WIP: try to load subsystems without loading content

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -41,6 +41,8 @@
       "ozone_texture.h": "c",
       "string_list.h": "c",
       "core_info.h": "c"
+      "thread": "c",
+      "xlocale": "c"
    },
    "C_Cpp.dimInactiveRegions": false,
 }

--- a/command.c
+++ b/command.c
@@ -1899,6 +1899,8 @@ bool command_event(enum event_command cmd, void *data)
          break;
       case CMD_EVENT_LOAD_CORE:
       {
+         subsystem_size = 0;
+         content_clear_subsystem();
          bool success = command_event(CMD_EVENT_LOAD_CORE_PERSIST, NULL);
          (void)success;
 
@@ -2019,8 +2021,10 @@ bool command_event(enum event_command cmd, void *data)
             command_event(CMD_EVENT_RESTORE_REMAPS, NULL);
 
             if (is_inited)
+            {
                if (!task_push_start_dummy_core(&content_info))
                   return false;
+            }
 #ifdef HAVE_DYNAMIC
             path_clear(RARCH_PATH_CORE);
             rarch_ctl(RARCH_CTL_SYSTEM_INFO_FREE, NULL);
@@ -2037,6 +2041,11 @@ bool command_event(enum event_command cmd, void *data)
                command_event(CMD_EVENT_DISCORD_UPDATE, &userdata);
             }
 #endif
+            if (is_inited)
+            {
+               subsystem_size = 0;
+               content_clear_subsystem();
+            }
          }
          break;
       case CMD_EVENT_QUIT:

--- a/dynamic.h
+++ b/dynamic.h
@@ -146,6 +146,10 @@ bool init_libretro_sym_custom(enum rarch_core_type type, struct retro_core_t *cu
  **/
 void uninit_libretro_sym(struct retro_core_t *core);
 
+struct retro_subsystem_info subsystem_data[20];
+struct retro_subsystem_rom_info subsystem_data_roms[10][10];
+unsigned subsystem_size;
+
 RETRO_END_DECLS
 
 #endif

--- a/menu/cbs/menu_cbs_sublabel.c
+++ b/menu/cbs/menu_cbs_sublabel.c
@@ -40,6 +40,7 @@
 
 #include "../../retroarch.h"
 #include "../../content.h"
+#include "../../dynamic.h"
 #include "../../configuration.h"
 #include "../../managers/cheat_manager.h"
 
@@ -513,14 +514,14 @@ static int action_bind_sublabel_subsystem_add(
       char *s, size_t len)
 {
    rarch_system_info_t *system                  = runloop_get_system_info();
-   const struct retro_subsystem_info *subsystem = (system && system->subsystem.data) ?
-	   system->subsystem.data + (type - MENU_SETTINGS_SUBSYSTEM_ADD) : NULL;
+   const struct retro_subsystem_info *subsystem = (system && subsystem_size > 0) ?
+	   subsystem_data + (type - MENU_SETTINGS_SUBSYSTEM_ADD) : NULL;
 
-   if (subsystem && content_get_subsystem_rom_id() < subsystem->num_roms)
+   if (subsystem_size > 0 && content_get_subsystem_rom_id() < subsystem->num_roms)
       snprintf(s, len, " Current Content: %s",
-	  content_get_subsystem() == type - MENU_SETTINGS_SUBSYSTEM_ADD
-	  ? subsystem->roms[content_get_subsystem_rom_id()].desc
-	  : subsystem->roms[0].desc);
+         content_get_subsystem() == type - MENU_SETTINGS_SUBSYSTEM_ADD
+         ? subsystem->roms[content_get_subsystem_rom_id()].desc
+         : subsystem->roms[0].desc);
 
    return 0;
 }
@@ -539,8 +540,8 @@ static int action_bind_sublabel_remap_kbd_sublabel(
          input_config_get_device_display_name(user_idx) ?
          input_config_get_device_display_name(user_idx) :
          (input_config_get_device_name(user_idx) ?
-          input_config_get_device_name(user_idx) : 
-          msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE)));
+            input_config_get_device_name(user_idx) :
+            msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE)));
    return 0;
 }
 

--- a/menu/drivers/nuklear/nk_common.c
+++ b/menu/drivers/nuklear/nk_common.c
@@ -1,7 +1,7 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2011-2017 - Daniel De Matteis
- *  Copyright (C) 2014-2017 - Jean-Andr� Santoni
- *  Copyright (C) 2016-2017 - Andr�s Su�rez
+ *  Copyright (C) 2014-2017 - Jean-André Santoni
+ *  Copyright (C) 2016-2017 - Andrés Suárez
  *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-

--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -45,6 +45,7 @@
 #include "../../../core.h"
 #include "../../../verbosity.h"
 #include "../../../tasks/tasks_internal.h"
+#include "../../../dynamic.h"
 
 ozone_node_t *ozone_alloc_node()
 {
@@ -583,16 +584,16 @@ static int ozone_list_push(void *data, void *userdata,
 
             if (settings->bools.menu_show_load_content)
             {
-               const struct retro_subsystem_info* subsystem = NULL;
-
                entry.enum_idx      = MENU_ENUM_LABEL_LOAD_CONTENT_LIST;
                menu_displaylist_setting(&entry);
 
                subsystem           = system->subsystem.data;
 
-               if (subsystem)
+               if (subsystem_size > 0)
                {
-                  for (i = 0; i < (unsigned)system->subsystem.size; i++, subsystem++)
+                  const struct retro_subsystem_info* subsystem = NULL;
+                  subsystem           = subsystem_data;
+                  for (i = 0; i < subsystem_size; i++, subsystem++)
                   {
                      char s[PATH_MAX_LENGTH];
                      if (content_get_subsystem() == i)

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -55,6 +55,7 @@
 #include "../widgets/menu_filebrowser.h"
 
 #include "../../verbosity.h"
+#include "../../dynamic.h"
 #include "../../configuration.h"
 #include "../../playlist.h"
 #include "../../retroarch.h"
@@ -5597,16 +5598,15 @@ static int xmb_list_push(void *data, void *userdata,
 
             if (settings->bools.menu_show_load_content)
             {
-               const struct retro_subsystem_info* subsystem = NULL;
+
 
                entry.enum_idx      = MENU_ENUM_LABEL_LOAD_CONTENT_LIST;
                menu_displaylist_setting(&entry);
-
-               subsystem           = system->subsystem.data;
-
-               if (subsystem)
+               if (subsystem_size > 0)
                {
-                  for (i = 0; i < (unsigned)system->subsystem.size; i++, subsystem++)
+                  const struct retro_subsystem_info* subsystem = NULL;
+                  subsystem           = subsystem_data;
+                  for (i = 0; i < subsystem_size; i++, subsystem++)
                   {
                      char s[PATH_MAX_LENGTH];
                      if (content_get_subsystem() == i)

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -1,7 +1,7 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2011-2017 - Daniel De Matteis
- *  Copyright (C) 2014-2017 - Jean-André Santoni
- *  Copyright (C) 2015-2017 - Andrés Suárez
+ *  Copyright (C) 2014-2017 - Jean-AndrÃ© Santoni
+ *  Copyright (C) 2015-2017 - AndrÃ©s SuÃ¡rez
  *  Copyright (C) 2016-2017 - Brad Parker
  *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
@@ -2584,25 +2584,6 @@ static int menu_displaylist_parse_load_content_settings(
 #endif
       rarch_system_info_t *system    = runloop_get_system_info();
 
-#if 0
-      const struct retro_subsystem_info* subsystem = system ? system->subsystem.data : NULL;
-
-      if (subsystem)
-      {
-         unsigned p;
-
-         for (p = 0; p < system->subsystem.size; p++, subsystem++)
-         {
-            char s[PATH_MAX_LENGTH];
-            snprintf(s, sizeof(s), "%s (%s)", msg_hash_to_str(MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_LIST), subsystem->desc);
-            menu_entries_append_enum(info->list,
-                  s,
-                  msg_hash_to_str(MENU_ENUM_LABEL_LOAD_CONTENT_SPECIAL),
-                  MENU_ENUM_LABEL_LOAD_CONTENT_SPECIAL,
-                  MENU_SETTING_ACTION, 0, 0);
-         }
-      }
-#endif
       menu_entries_append_enum(info->list,
             msg_hash_to_str(MENU_ENUM_LABEL_VALUE_RESUME_CONTENT),
             msg_hash_to_str(MENU_ENUM_LABEL_RESUME_CONTENT),
@@ -2633,7 +2614,7 @@ static int menu_displaylist_parse_load_content_settings(
 
       if (settings->bools.quick_menu_show_save_load_state
 #ifdef HAVE_CHEEVOS
-          && !cheevos_hardcore_active
+         && !cheevos_hardcore_active
 #endif
          )
       {

--- a/menu/widgets/menu_filebrowser.c
+++ b/menu/widgets/menu_filebrowser.c
@@ -39,6 +39,7 @@
 #include "../../core.h"
 #include "../../content.h"
 #include "../../verbosity.h"
+#include "../../dynamic.h"
 
 static enum filebrowser_enums filebrowser_types = FILEBROWSER_NONE;
 
@@ -83,10 +84,9 @@ void filebrowser_parse(menu_displaylist_info_t *info, unsigned type_data)
          str_list = file_archive_get_file_list(path, info->exts);
       else
       {
-         rarch_system_info_t         *system          = runloop_get_system_info();
-         const struct retro_subsystem_info *subsystem = system->subsystem.data + content_get_subsystem();
+         const struct retro_subsystem_info *subsystem = &subsystem_data[content_get_subsystem()];
 
-         if (subsystem)
+         if (subsystem_size > 0)
             str_list  = file_archive_get_file_list(path, subsystem->roms[content_get_subsystem_rom_id()].valid_extensions);
       }
    }
@@ -94,11 +94,9 @@ void filebrowser_parse(menu_displaylist_info_t *info, unsigned type_data)
    {
       if (filebrowser_types == FILEBROWSER_SELECT_FILE_SUBSYSTEM)
       {
-         rarch_system_info_t         *system          = runloop_get_system_info();
-         const struct retro_subsystem_info *subsystem = 
-            system->subsystem.data + content_get_subsystem();
+         const struct retro_subsystem_info *subsystem = &subsystem_data[content_get_subsystem()];
 
-         if (subsystem && content_get_subsystem_rom_id() < subsystem->num_roms)
+         if (subsystem_size > 0 && content_get_subsystem_rom_id() < subsystem->num_roms)
             str_list = dir_list_new(path,
                   (filter_ext && info) ? subsystem->roms[content_get_subsystem_rom_id()].valid_extensions : NULL,
                   true, settings->bools.show_hidden_files, true, false);

--- a/paths.c
+++ b/paths.c
@@ -311,7 +311,7 @@ static bool path_init_subsystem(void)
    /* For subsystems, we know exactly which RAM types are supported. */
 
    info = libretro_find_subsystem_info(
-         system->subsystem.data,
+         subsystem_data,
          system->subsystem.size,
          path_get(RARCH_PATH_SUBSYSTEM));
 

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -1782,11 +1782,11 @@ void content_set_subsystem(unsigned idx)
 {
    rarch_system_info_t                  *system = runloop_get_system_info();
    const struct retro_subsystem_info *subsystem = system ?
-	   system->subsystem.data + idx : NULL;
+	   subsystem_data + idx : NULL;
 
    pending_subsystem_id                         = idx;
 
-   if (subsystem)
+   if (subsystem_size > 0)
    {
       strlcpy(pending_subsystem_ident,
          subsystem->ident, sizeof(pending_subsystem_ident));


### PR DESCRIPTION
This allows loading subsystem games.
Tested:
- [X] Sameboy
- [X] TGB-Dual
- [X] FBA
- [ ] SNES9x (not working, most likely it sets subsystems after RETRO_SET_ENVIRONMENT that should be mandatory)

Only works with XMB, the other menu drivers don't have the code to handle subsystems.
Also it's worth nothing it would be important to move this into a submenu (Load Subsystem or whatever) to prevent this on the main menu:

![image](https://user-images.githubusercontent.com/1721040/48975447-df9bc880-f03d-11e8-9ff7-fdb5adeb7520.png)

Issues:

Probably leaks.. I'm ~~allocating strings and never freeing them~~ using strdup a lot, and since I failed at the deep copy using dynamic allocation, I limited subsystems and roms per subsystem to 20

Also I used some globals, I guess it would be important to refactor some of this code to go thru several layers of indirection as usual 🤣 

This is as far as I can take the feature for now. Pushing it so it doesn't get lost.

I think @barbudreadmon was interested on this for some other core, maybe Kronos but I'm not certain.