### PR TITLE
Revert "ozone: Fix subsystem_data being undefined"

### DIFF
--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -589,7 +589,8 @@ static int ozone_list_push(void *data, void *userdata,
 
                if (subsystem_size > 0)
                {
-                  const struct retro_subsystem_info* subsystem = system->subsystem.data;
+                  const struct retro_subsystem_info* subsystem = NULL;
+                  subsystem           = subsystem_data;
                   for (i = 0; i < subsystem_size; i++, subsystem++)
                   {
                      char s[PATH_MAX_LENGTH];


### PR DESCRIPTION
Reverts libretro/RetroArch#7664