### PR TITLE
add missing %s

### DIFF
--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -2464,7 +2464,7 @@ void video_driver_frame(const void *data, unsigned width,
                      (uint64_t)video_driver_frame_count);
             }
             snprintf(video_driver_window_title, sizeof(video_driver_window_title),
-               "%s%s%s", title, video_info.fps_text,
+               "%s%s%s%s", title, video_info.fps_text,
                video_info.fps_show ? video_info.fps_text : "",
                video_info.framecount_show ? frames_text : "");
          }


### PR DESCRIPTION
gfx/video_driver.c: In function 'video_driver_frame':
gfx/video_driver.c:2467:16: warning: too many arguments for format [-Wformat-extra-args]
                "%s%s%s", title, video_info.fps_text,
