### PR TITLE
libnx: implement focus gain and loss callbacks

### DIFF
--- a/frontend/drivers/platform_switch.c
+++ b/frontend/drivers/platform_switch.c
@@ -55,6 +55,8 @@ static const char *elf_path_cst = "/switch/retroarch_switch.nro";
 
 static uint64_t frontend_switch_get_mem_used(void);
 
+bool platform_switch_has_focus = true;
+
 #ifdef HAVE_LIBNX
 
 /* Splash */
@@ -69,9 +71,17 @@ extern bool nxlink_connected;
 #endif
 
 static void on_applet_hook(AppletHookType hook, void* param) {
+   /* Exit request */
    if(hook == AppletHookType_OnExitRequest) {
       RARCH_LOG("Got AppletHook OnExitRequest, exiting.\n");
       retroarch_main_quit();
+   }
+   /* Focus state*/
+   else if (hook == AppletHookType_OnFocusState) {
+      AppletFocusState focus_state = appletGetFocusState();
+      RARCH_LOG("Got AppletHook OnFocusState - new focus state is %d\n", focus_state);
+
+      platform_switch_has_focus = focus_state == AppletFocusState_Focused;
    }
 }
 
@@ -621,6 +631,8 @@ static void frontend_switch_init(void *data)
    nifmInitialize();
    appletLockExit();
    appletHook(&applet_hook_cookie, on_applet_hook, NULL);
+
+   appletSetFocusHandlingMode(AppletFocusHandlingMode_NoSuspend);
 #ifndef HAVE_OPENGL
    /* Init Resolution before initDefault */
    gfxInitResolution(1280, 720);

--- a/gfx/drivers/gl.c
+++ b/gfx/drivers/gl.c
@@ -957,12 +957,6 @@ static bool gl_frame(void *data, const void *frame,
    if (!gl)
       return false;
 
-#ifdef HAVE_LIBNX
-   // Should be called once per frame
-   if(!appletMainLoop())
-    return false;
-#endif
-
    gl_context_bind_hw_render(gl, false);
 
    if (gl->core_context_in_use && gl->renderchain_driver->bind_vao)

--- a/gfx/drivers_context/switch_ctx.c
+++ b/gfx/drivers_context/switch_ctx.c
@@ -27,6 +27,8 @@
 static enum gfx_ctx_api ctx_nx_api = GFX_CTX_OPENGL_API;
 switch_ctx_data_t *nx_ctx_ptr = NULL;
 
+extern bool platform_switch_has_focus;
+
 void switch_ctx_destroy(void *data)
 {
     switch_ctx_data_t *ctx_nx = (switch_ctx_data_t *)data;
@@ -190,7 +192,7 @@ static bool switch_ctx_bind_api(void *data,
 static bool switch_ctx_has_focus(void *data)
 {
     (void)data;
-    return true;
+    return platform_switch_has_focus;
 }
 
 static bool switch_ctx_suppress_screensaver(void *data, bool enable)

--- a/retroarch.c
+++ b/retroarch.c
@@ -2522,6 +2522,12 @@ static enum runloop_state runloop_check_state(
    bool menu_is_alive               = menu_driver_is_alive();
 #endif
 
+#ifdef HAVE_LIBNX
+   // Should be called once per frame
+   if(!appletMainLoop())
+      return RUNLOOP_STATE_QUIT;
+#endif
+
    BIT256_CLEAR_ALL_PTR(&current_input);
 
 #ifdef HAVE_MENU


### PR DESCRIPTION
This implements `switch_ctx_has_focus` for libnx platform, makes the "Don't run in background" setting work when pressing HOME. Needs libnx 1.6.0.