### PR TITLE
Fix title window fps counter.

### DIFF
--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -2454,7 +2454,7 @@ void video_driver_frame(const void *data, unsigned width,
             if (video_info.fps_show)
             {
                snprintf(video_info.fps_text, sizeof(video_info.fps_text),
-                     "||  FPS: %6.1f ", last_fps);
+                     " ||  FPS: %6.1f ", last_fps);
             }
             if (video_info.framecount_show)
             {
@@ -2464,7 +2464,7 @@ void video_driver_frame(const void *data, unsigned width,
                      (uint64_t)video_driver_frame_count);
             }
             snprintf(video_driver_window_title, sizeof(video_driver_window_title),
-               "%s%s%s%s", title, video_info.fps_text,
+               "%s%s%s", title,
                video_info.fps_show ? video_info.fps_text : "",
                video_info.framecount_show ? frames_text : "");
          }


### PR DESCRIPTION
FPS counter was shown twice on window title bar.