### PR TITLE
Frame count should be OFF by default.

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -1317,7 +1317,7 @@ static struct config_bool_setting *populate_settings_bool(settings_t *settings, 
    SETTING_BOOL("builtin_imageviewer_enable",    &settings->bools.multimedia_builtin_imageviewer_enable, true, true, false);
    SETTING_BOOL("fps_show",                      &settings->bools.video_fps_show, true, false, false);
    SETTING_BOOL("statistics_show",               &settings->bools.video_statistics_show, true, false, false);
-   SETTING_BOOL("framecount_show",               &settings->bools.video_framecount_show, true, true, false);
+   SETTING_BOOL("framecount_show",               &settings->bools.video_framecount_show, true, false, false);
    SETTING_BOOL("memory_show",                   &settings->bools.video_memory_show, true, false, false);
    SETTING_BOOL("ui_menubar_enable",             &settings->bools.ui_menubar_enable, true, true, false);
    SETTING_BOOL("suspend_screensaver_enable",    &settings->bools.ui_suspend_screensaver_enable, true, true, false);


### PR DESCRIPTION
It was still showing because of this.