### PR TITLE
set a default SRAM autosave interval on modern platforms

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -536,7 +536,13 @@ static const bool pause_nonactive = true;
 
 /* Saves non-volatile SRAM at a regular interval.
  * It is measured in seconds. A value of 0 disables autosave. */
+#if defined(__i386__) || defined(__i486__) || defined(__i686__) || defined(_WIN32) || defined(OSX) || defined(ANDROID) || defined(IOS)
+/* Flush to file every 10 seconds on modern platforms by default */
+static const unsigned autosave_interval = 10;
+#else
+/* Default to disabled on I/O-constrained platforms */
 static const unsigned autosave_interval = 0;
+#endif
 
 /* Publicly announce netplay */
 static const bool netplay_public_announce = true;


### PR DESCRIPTION
## Description

We get a lot of surly users who lose data due to crashes and/or failure to exit cleanly. This sets a default SRAM autosave interval of 10 seconds on Win/OSX/Android/iOS and any x86/64 system. I didn't include Linux directly, as I didn't want to bring in all of the random SBCs with eMMCs with limited writes, etc.

## Reviewers

@twinaphex @fr500 @bparker06 