### PR TITLE
add a couple more qualifiers for the autosave interval

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -536,7 +536,7 @@ static const bool pause_nonactive = true;
 
 /* Saves non-volatile SRAM at a regular interval.
  * It is measured in seconds. A value of 0 disables autosave. */
-#if defined(__i386__) || defined(__i486__) || defined(__i686__) || defined(__x86_64__) || defined((_M_X64) || defined(_WIN32) || defined(OSX) || defined(ANDROID) || defined(IOS)
+#if defined(__i386__) || defined(__i486__) || defined(__i686__) || defined(__x86_64__) || defined(_M_X64) || defined(_WIN32) || defined(OSX) || defined(ANDROID) || defined(IOS)
 /* Flush to file every 10 seconds on modern platforms by default */
 static const unsigned autosave_interval = 10;
 #else

--- a/config.def.h
+++ b/config.def.h
@@ -536,7 +536,7 @@ static const bool pause_nonactive = true;
 
 /* Saves non-volatile SRAM at a regular interval.
  * It is measured in seconds. A value of 0 disables autosave. */
-#if defined(__i386__) || defined(__i486__) || defined(__i686__) || defined(_WIN32) || defined(OSX) || defined(ANDROID) || defined(IOS)
+#if defined(__i386__) || defined(__i486__) || defined(__i686__) || defined(__x86_64__) || defined((_M_X64) || defined(_WIN32) || defined(OSX) || defined(ANDROID) || defined(IOS)
 /* Flush to file every 10 seconds on modern platforms by default */
 static const unsigned autosave_interval = 10;
 #else


### PR DESCRIPTION
After talking with @bparker06 I realized that I had forgotten x86_64 altogether, so this PR adds that and the MSVC equivalent.