### PR TITLE
Fix build with '--enable-sixel'.

### DIFF
--- a/gfx/drivers/sixel_gfx.c
+++ b/gfx/drivers/sixel_gfx.c
@@ -30,6 +30,7 @@
 
 #include "../../driver.h"
 #include "../../configuration.h"
+#include "../../retroarch.h"
 #include "../../verbosity.h"
 #include "../../frontend/frontend_driver.h"
 #include "../common/sixel_common.h"


### PR DESCRIPTION
```
CC gfx/drivers/sixel_gfx.c
gfx/drivers/sixel_gfx.c: In function ‘output_sixel’:
gfx/drivers/sixel_gfx.c:85:4: warning: ‘sixel_output_create’ is deprecated [-Wdeprecated-declarations]
    context = sixel_output_create(sixel_write, stdout);
    ^~~~~~~
In file included from gfx/drivers/../common/sixel_common.h:21,
                 from gfx/drivers/sixel_gfx.c:35:
/usr/include/sixel.h:582:1: note: declared here
 sixel_output_create(
 ^~~~~~~~~~~~~~~~~~~
gfx/drivers/sixel_gfx.c:86:4: warning: ‘sixel_dither_create’ is deprecated [-Wdeprecated-declarations]
    dither = sixel_dither_create(ncolors);
    ^~~~~~
In file included from gfx/drivers/../common/sixel_common.h:21,
                 from gfx/drivers/sixel_gfx.c:35:
/usr/include/sixel.h:670:1: note: declared here
 sixel_dither_create(int /* in */ ncolors); /* number of colors */
 ^~~~~~~~~~~~~~~~~~~
gfx/drivers/sixel_gfx.c: In function ‘sixel_gfx_alive’:
gfx/drivers/sixel_gfx.c:442:27: warning: implicit declaration of function ‘rarch_ctl’; did you mean ‘driver_ctl’? [-Wimplicit-function-declaration]
    bool is_shutdown     = rarch_ctl(RARCH_CTL_IS_SHUTDOWN, NULL);
                           ^~~~~~~~~
                           driver_ctl
gfx/drivers/sixel_gfx.c:442:37: error: ‘RARCH_CTL_IS_SHUTDOWN’ undeclared (first use in this function); did you mean ‘RARCH_VOLUME_DOWN’?
    bool is_shutdown     = rarch_ctl(RARCH_CTL_IS_SHUTDOWN, NULL);
                                     ^~~~~~~~~~~~~~~~~~~~~
                                     RARCH_VOLUME_DOWN
gfx/drivers/sixel_gfx.c:442:37: note: each undeclared identifier is reported only once for each function it appears in
make: *** [Makefile:193: obj-unix/release/gfx/drivers/sixel_gfx.o] Error
``` 

First bad commit 2edd03361c35ef2648d30ff421bfcee44158bb4f