### PR TITLE
(3DS) Improve default configuration

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -244,6 +244,11 @@ static const bool aspect_ratio_auto = false;
 static unsigned aspect_ratio_idx = ASPECT_RATIO_16_9;
 #elif defined(PSP)
 static unsigned aspect_ratio_idx = ASPECT_RATIO_CORE;
+#elif defined(_3DS)
+/* Previously defaulted to ASPECT_RATIO_4_3.
+ * Non-4:3 content looks dreadful when stretched
+ * to 4:3 on the 3DS screen... */
+static unsigned aspect_ratio_idx = ASPECT_RATIO_CORE;
 #elif defined(RARCH_CONSOLE)
 static unsigned aspect_ratio_idx = ASPECT_RATIO_4_3;
 #else

--- a/configuration.c
+++ b/configuration.c
@@ -543,6 +543,9 @@ static enum location_driver_enum LOCATION_DEFAULT_DRIVER = LOCATION_CORELOCATION
 static enum location_driver_enum LOCATION_DEFAULT_DRIVER = LOCATION_NULL;
 #endif
 
+#if defined(_3DS) && defined(HAVE_RGUI)
+static enum menu_driver_enum MENU_DEFAULT_DRIVER = MENU_RGUI;
+#else
 #if defined(HAVE_XUI)
 static enum menu_driver_enum MENU_DEFAULT_DRIVER = MENU_XUI;
 #elif defined(HAVE_MATERIALUI) && defined(RARCH_MOBILE)
@@ -556,7 +559,7 @@ static enum menu_driver_enum MENU_DEFAULT_DRIVER = MENU_RGUI;
 #else
 static enum menu_driver_enum MENU_DEFAULT_DRIVER = MENU_NULL;
 #endif
-
+#endif
 
 #define GENERAL_SETTING(key, configval, default_enable, default_setting, type, handle_setting) \
 { \
@@ -678,7 +681,7 @@ const char *config_get_default_audio(void)
       case AUDIO_PS2:
          return "ps2";
       case AUDIO_CTR:
-         return "csnd";
+         return "dsp";
       case AUDIO_SWITCH:
          return "switch";
       case AUDIO_RWEBAUDIO:

--- a/frontend/drivers/platform_ctr.c
+++ b/frontend/drivers/platform_ctr.c
@@ -240,13 +240,15 @@ static void frontend_ctr_exec(const char* path, bool should_load_game)
       }
       else
       {
-         RARCH_LOG("\n");
-         RARCH_LOG("\n");
-         RARCH_LOG("Warning:\n");
-         RARCH_LOG("First core launch may take 20 seconds!\n");
-         RARCH_LOG("Do not force quit before then or your memory card may be corrupted!\n");
-         RARCH_LOG("\n");
-         RARCH_LOG("\n");
+         RARCH_WARN("\n");
+         RARCH_WARN("\n");
+         RARCH_WARN("Warning:\n");
+         RARCH_WARN("First core launch may take 20\n");
+         RARCH_WARN("seconds! Do not force quit\n");
+         RARCH_WARN("before then or your memory\n");
+         RARCH_WARN("card may be corrupted!\n");
+         RARCH_WARN("\n");
+         RARCH_WARN("\n");
          exec_cia(path, arg_data);
       }
 
@@ -355,6 +357,17 @@ static void ctr_check_dspfirm(void)
             free(code_buffer);
          }
          fclose(code_fp);
+      }
+      else
+      {
+         RARCH_WARN("\n");
+         RARCH_WARN("\n");
+         RARCH_WARN("Warning:\n");
+         RARCH_WARN("3DS DSP dump is missing.\n");
+         RARCH_WARN("A working DSP dump is required\n");
+         RARCH_WARN("for correct operation.\n");
+         RARCH_WARN("\n");
+         RARCH_WARN("\n");
       }
    }
 }


### PR DESCRIPTION
## Description

The 3DS build currently has suboptimal default driver configuration settings. These cause performance issues/crashes, which is not friendly, and in some quarters has led to the perception that RetroArch 3DS is 'broken' (reddit and the gbatemp forums have quite a lot of this sort of misinformation...)

This pull request tries to rectify the situation by choosing more appropriate defaults. It sets the following:

- Audio Driver: dsp

   The current value is 'csnd', which is bad. csnd was never really meant for game audio - it's intended for system/background/applet related stuff. The dsp driver is better, higher quality and more robust.

   The dsp driver of course requires a working DSP dump, but anyone with a hacked 3DS should have this already. If the user doesn't have a DSP dump, RetroArch will automatically fall back to the csnd driver and print a big clear warning to the bottom screen (this will get displayed every time they launch a core or load content, until they do something about it).

- Menu Driver: rgui

   The current value is 'xmb'. This is a fine user interface, but it's a little too heavy for the 3DS (particularly o3DS) and - more importantly -  it's not very stable. It kinda works most of the time, but can randomly crash when scrolling through tabs, loading content, closing content, etc. (and to be honest, the 3DS screen is just too small for a good XMB experience).

   RGUI, on the other hand, is blazingly fast, looks excellent on a tiny screen and is absolutely stable. After many hours of using this menu driver on the 3DS, I simply cannot fault it.

While editing the code, I also changed the default aspect ratio to 'core provided'. This was previously set to 4:3, which I believe was an oversight. (If someone loads a Game Boy game and it's presented to them stretched to the wrong aspect ratio, that'll turn them off RetroArch right from the start!)

These very simple changes should make the 3DS experience smooth and stable for new users. (And perhaps reduce the number of complaints posted online...)

## Related Issues

This PR was prompted by issue #5543, where the general consensus was that changing the default drivers would be sensible.


