### PR TITLE
Hide 'scan content' entries from Collections menu when 'Show Import content Tab' is disabled

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -3458,16 +3458,19 @@ static int menu_displaylist_parse_playlists(
    if (!horizontal)
    {
 #ifdef HAVE_LIBRETRODB
-      menu_entries_append_enum(info->list,
-            msg_hash_to_str(MENU_ENUM_LABEL_VALUE_SCAN_DIRECTORY),
-            msg_hash_to_str(MENU_ENUM_LABEL_SCAN_DIRECTORY),
-            MENU_ENUM_LABEL_SCAN_DIRECTORY,
-            MENU_SETTING_ACTION, 0, 0);
-      menu_entries_append_enum(info->list,
-            msg_hash_to_str(MENU_ENUM_LABEL_VALUE_SCAN_FILE),
-            msg_hash_to_str(MENU_ENUM_LABEL_SCAN_FILE),
-            MENU_ENUM_LABEL_SCAN_FILE,
-            MENU_SETTING_ACTION, 0, 0);
+      if (settings->bools.menu_content_show_add)
+      {
+         menu_entries_append_enum(info->list,
+               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_SCAN_DIRECTORY),
+               msg_hash_to_str(MENU_ENUM_LABEL_SCAN_DIRECTORY),
+               MENU_ENUM_LABEL_SCAN_DIRECTORY,
+               MENU_SETTING_ACTION, 0, 0);
+         menu_entries_append_enum(info->list,
+               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_SCAN_FILE),
+               msg_hash_to_str(MENU_ENUM_LABEL_SCAN_FILE),
+               MENU_ENUM_LABEL_SCAN_FILE,
+               MENU_SETTING_ACTION, 0, 0);
+      }
 #endif
      if (settings->bools.menu_content_show_favorites)
       menu_entries_append_enum(info->list,


### PR DESCRIPTION
## Description

As reported in issue #7713, there is currently no way to hide the 'Scan directory' and 'Scan file' entries in the 'Collections' menu (affects RGUI and GLUI). It seems it would be sensible to remove these entries if the 'Show Import content Tab' setting is disabled, so this pull request does exactly that. This allows for users to configure a nice uncluttered 'Collections' menu interface (also saves having to press 'd-pad down' twice to skip over the unwanted entries each time the 'Collections' menu is used).

## Related Issues

This should close issue #7713.
