### PR TITLE
Subsystem

### DIFF
--- a/command.c
+++ b/command.c
@@ -1901,7 +1901,7 @@ bool command_event(enum event_command cmd, void *data)
       case CMD_EVENT_LOAD_CORE:
       {
 	 bool success   = false;
-         subsystem_size = 0;
+         subsystem_current_count = 0;
          content_clear_subsystem();
          success = command_event(CMD_EVENT_LOAD_CORE_PERSIST, NULL);
          (void)success;
@@ -2045,7 +2045,7 @@ bool command_event(enum event_command cmd, void *data)
 #endif
             if (is_inited)
             {
-               subsystem_size = 0;
+               subsystem_current_count = 0;
                content_clear_subsystem();
             }
          }

--- a/dynamic.h
+++ b/dynamic.h
@@ -146,9 +146,14 @@ bool init_libretro_sym_custom(enum rarch_core_type type, struct retro_core_t *cu
  **/
 void uninit_libretro_sym(struct retro_core_t *core);
 
-struct retro_subsystem_info subsystem_data[20];
-struct retro_subsystem_rom_info subsystem_data_roms[10][10];
-unsigned subsystem_size;
+/* Arbitrary twenty subsystems limite */
+#define SUBSYSTEM_MAX_SUBSYSTEMS 20
+/* Arbitrary 10 roms for each subsystem limit */
+#define SUBSYSTEM_MAX_SUBSYSTEM_ROMS 10
+
+struct retro_subsystem_info subsystem_data[SUBSYSTEM_MAX_SUBSYSTEMS];
+struct retro_subsystem_rom_info subsystem_data_roms[SUBSYSTEM_MAX_SUBSYSTEMS][SUBSYSTEM_MAX_SUBSYSTEM_ROMS];
+unsigned subsystem_current_count;
 
 RETRO_END_DECLS
 

--- a/menu/cbs/menu_cbs_sublabel.c
+++ b/menu/cbs/menu_cbs_sublabel.c
@@ -521,10 +521,11 @@ static int action_bind_sublabel_subsystem_add(
       char *s, size_t len)
 {
    rarch_system_info_t *system                  = runloop_get_system_info();
-   const struct retro_subsystem_info *subsystem = (system && subsystem_size > 0) ?
-	   subsystem_data + (type - MENU_SETTINGS_SUBSYSTEM_ADD) : NULL;
+   const struct retro_subsystem_info *subsystem = (system && subsystem_current_count > 0) ?
+      subsystem_data + (type - MENU_SETTINGS_SUBSYSTEM_ADD) : NULL;
 
-   if (subsystem_size > 0 && content_get_subsystem_rom_id() < subsystem->num_roms)
+   /* To-Do: localization & sublabels for pre-init case */
+   if (subsystem_current_count > 0 && content_get_subsystem_rom_id() < subsystem->num_roms)
       snprintf(s, len, " Current Content: %s",
          content_get_subsystem() == type - MENU_SETTINGS_SUBSYSTEM_ADD
          ? subsystem->roms[content_get_subsystem_rom_id()].desc

--- a/menu/cbs/menu_cbs_sublabel.c
+++ b/menu/cbs/menu_cbs_sublabel.c
@@ -521,15 +521,23 @@ static int action_bind_sublabel_subsystem_add(
       char *s, size_t len)
 {
    rarch_system_info_t *system                  = runloop_get_system_info();
-   const struct retro_subsystem_info *subsystem = (system && subsystem_current_count > 0) ?
-      subsystem_data + (type - MENU_SETTINGS_SUBSYSTEM_ADD) : NULL;
+   const struct retro_subsystem_info *subsystem;
 
-   /* To-Do: localization & sublabels for pre-init case */
-   if (subsystem_current_count > 0 && content_get_subsystem_rom_id() < subsystem->num_roms)
-      snprintf(s, len, " Current Content: %s",
-         content_get_subsystem() == type - MENU_SETTINGS_SUBSYSTEM_ADD
-         ? subsystem->roms[content_get_subsystem_rom_id()].desc
-         : subsystem->roms[0].desc);
+   /* Core fully loaded, use the subsystem data */
+   if (system->subsystem.data)
+      subsystem = system->subsystem.data + (type - MENU_SETTINGS_SUBSYSTEM_ADD);
+   /* Core not loaded completely, use the data we peeked on load core */
+   else
+      subsystem = subsystem_data + (type - MENU_SETTINGS_SUBSYSTEM_ADD);
+
+   if (subsystem && subsystem_current_count > 0)
+   {
+      if (content_get_subsystem_rom_id() < subsystem->num_roms)
+         snprintf(s, len, " Current Content: %s",
+            content_get_subsystem() == type - MENU_SETTINGS_SUBSYSTEM_ADD
+            ? subsystem->roms[content_get_subsystem_rom_id()].desc
+            : subsystem->roms[0].desc);
+   }
 
    return 0;
 }

--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -502,6 +502,7 @@ static int ozone_list_push(void *data, void *userdata,
    unsigned i             = 0;
    core_info_list_t *list = NULL;
    menu_handle_t *menu    = (menu_handle_t*)data;
+   const struct retro_subsystem_info* subsystem;
 
    switch (type)
    {
@@ -596,56 +597,14 @@ static int ozone_list_push(void *data, void *userdata,
                entry.enum_idx      = MENU_ENUM_LABEL_LOAD_CONTENT_LIST;
                menu_displaylist_setting(&entry);
 
-               if (subsystem_current_count > 0)
-               {
-                  const struct retro_subsystem_info* subsystem = subsystem_data;
-                  for (i = 0; i < subsystem_current_count; i++, subsystem++)
-                  {
-                     char s[PATH_MAX_LENGTH];
-                     if (content_get_subsystem() == i)
-                     {
-                        if (content_get_subsystem_rom_id() < subsystem->num_roms)
-                        {
-                           snprintf(s, sizeof(s),
-                                 "Load %s %s",
-                                 subsystem->desc,
-                                 i == content_get_subsystem()
-                                 ? "\u2605" : " ");
-                           menu_entries_append_enum(info->list,
-                                 s,
-                                 msg_hash_to_str(MENU_ENUM_LABEL_SUBSYSTEM_ADD),
-                                 MENU_ENUM_LABEL_SUBSYSTEM_ADD,
-                                 MENU_SETTINGS_SUBSYSTEM_ADD + i, 0, 0);
-                        }
-                        else
-                        {
-                           snprintf(s, sizeof(s),
-                                 "Start %s %s",
-                                 subsystem->desc,
-                                 i == content_get_subsystem()
-                                 ? "\u2605" : " ");
-                           menu_entries_append_enum(info->list,
-                                 s,
-                                 msg_hash_to_str(MENU_ENUM_LABEL_SUBSYSTEM_LOAD),
-                                 MENU_ENUM_LABEL_SUBSYSTEM_LOAD,
-                                 MENU_SETTINGS_SUBSYSTEM_LOAD, 0, 0);
-                        }
-                     }
-                     else
-                     {
-                        snprintf(s, sizeof(s),
-                              "Load %s %s",
-                              subsystem->desc,
-                              i == content_get_subsystem()
-                              ? "\u2605" : " ");
-                        menu_entries_append_enum(info->list,
-                              s,
-                              msg_hash_to_str(MENU_ENUM_LABEL_SUBSYSTEM_ADD),
-                              MENU_ENUM_LABEL_SUBSYSTEM_ADD,
-                              MENU_SETTINGS_SUBSYSTEM_ADD + i, 0, 0);
-                     }
-                  }
-               }
+               /* Core fully loaded, use the subsystem data */
+               if (system->subsystem.data)
+                     subsystem = system->subsystem.data;
+               /* Core not loaded completely, use the data we peeked on load core */
+               else
+                  subsystem = subsystem_data;
+
+               menu_subsystem_populate(subsystem, info);
             }
 
             entry.enum_idx      = MENU_ENUM_LABEL_ADD_CONTENT_LIST;

--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -596,10 +596,10 @@ static int ozone_list_push(void *data, void *userdata,
                entry.enum_idx      = MENU_ENUM_LABEL_LOAD_CONTENT_LIST;
                menu_displaylist_setting(&entry);
 
-               if (subsystem_size > 0)
+               if (subsystem_current_count > 0)
                {
                   const struct retro_subsystem_info* subsystem = subsystem_data;
-                  for (i = 0; i < subsystem_size; i++, subsystem++)
+                  for (i = 0; i < subsystem_current_count; i++, subsystem++)
                   {
                      char s[PATH_MAX_LENGTH];
                      if (content_get_subsystem() == i)

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -5548,10 +5548,10 @@ static int xmb_list_push(void *data, void *userdata,
 
                entry.enum_idx      = MENU_ENUM_LABEL_LOAD_CONTENT_LIST;
                menu_displaylist_setting(&entry);
-               if (subsystem_size > 0)
+               if (subsystem_current_count > 0)
                {
                   const struct retro_subsystem_info* subsystem = subsystem_data;
-                  for (i = 0; i < subsystem_size; i++, subsystem++)
+                  for (i = 0; i < subsystem_current_count; i++, subsystem++)
                   {
                      char s[PATH_MAX_LENGTH];
                      if (content_get_subsystem() == i)

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -5453,6 +5453,7 @@ static int xmb_list_push(void *data, void *userdata,
    unsigned i             = 0;
    core_info_list_t *list = NULL;
    menu_handle_t *menu    = (menu_handle_t*)data;
+   const struct retro_subsystem_info* subsystem;
 
    switch (type)
    {
@@ -5548,56 +5549,14 @@ static int xmb_list_push(void *data, void *userdata,
 
                entry.enum_idx      = MENU_ENUM_LABEL_LOAD_CONTENT_LIST;
                menu_displaylist_setting(&entry);
-               if (subsystem_current_count > 0)
-               {
-                  const struct retro_subsystem_info* subsystem = subsystem_data;
-                  for (i = 0; i < subsystem_current_count; i++, subsystem++)
-                  {
-                     char s[PATH_MAX_LENGTH];
-                     if (content_get_subsystem() == i)
-                     {
-                        if (content_get_subsystem_rom_id() < subsystem->num_roms)
-                        {
-                           snprintf(s, sizeof(s),
-                                 "Load %s %s",
-                                 subsystem->desc,
-                                 i == content_get_subsystem()
-                                 ? "\u2605" : " ");
-                           menu_entries_append_enum(info->list,
-                                 s,
-                                 msg_hash_to_str(MENU_ENUM_LABEL_SUBSYSTEM_ADD),
-                                 MENU_ENUM_LABEL_SUBSYSTEM_ADD,
-                                 MENU_SETTINGS_SUBSYSTEM_ADD + i, 0, 0);
-                        }
-                        else
-                        {
-                           snprintf(s, sizeof(s),
-                                 "Start %s %s",
-                                 subsystem->desc,
-                                 i == content_get_subsystem()
-                                 ? "\u2605" : " ");
-                           menu_entries_append_enum(info->list,
-                                 s,
-                                 msg_hash_to_str(MENU_ENUM_LABEL_SUBSYSTEM_LOAD),
-                                 MENU_ENUM_LABEL_SUBSYSTEM_LOAD,
-                                 MENU_SETTINGS_SUBSYSTEM_LOAD, 0, 0);
-                        }
-                     }
-                     else
-                     {
-                        snprintf(s, sizeof(s),
-                              "Load %s %s",
-                              subsystem->desc,
-                              i == content_get_subsystem()
-                              ? "\u2605" : " ");
-                        menu_entries_append_enum(info->list,
-                              s,
-                              msg_hash_to_str(MENU_ENUM_LABEL_SUBSYSTEM_ADD),
-                              MENU_ENUM_LABEL_SUBSYSTEM_ADD,
-                              MENU_SETTINGS_SUBSYSTEM_ADD + i, 0, 0);
-                     }
-                  }
-               }
+               /* Core fully loaded, use the subsystem data */
+               if (system->subsystem.data)
+                     subsystem = system->subsystem.data;
+               /* Core not loaded completely, use the data we peeked on load core */
+               else
+                  subsystem = subsystem_data;
+
+               menu_subsystem_populate(subsystem, info);
             }
 
             entry.enum_idx      = MENU_ENUM_LABEL_ADD_CONTENT_LIST;

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -2654,3 +2654,57 @@ void hex32_to_rgba_normalized(uint32_t hex, float* rgba, float alpha)
    rgba[2] = rgba[6] = rgba[10] = rgba[14] = ((hex >> 0 ) & 0xFF) * (1.0f / 255.0f); /* b */
    rgba[3] = rgba[7] = rgba[11] = rgba[15] = alpha;
 }
+
+void menu_subsystem_populate(const struct retro_subsystem_info* subsystem, menu_displaylist_info_t *info)
+{
+   int i = 0;
+   if (subsystem && subsystem_current_count > 0)
+   {
+      for (i = 0; i < subsystem_current_count; i++, subsystem++)
+      {
+         char s[PATH_MAX_LENGTH];
+         if (content_get_subsystem() == i)
+         {
+            if (content_get_subsystem_rom_id() < subsystem->num_roms)
+            {
+               snprintf(s, sizeof(s),
+                  "Load %s %s",
+                  subsystem->desc,
+                  i == content_get_subsystem()
+                  ? "\u2605" : " ");
+               menu_entries_append_enum(info->list,
+                  s,
+                  msg_hash_to_str(MENU_ENUM_LABEL_SUBSYSTEM_ADD),
+                  MENU_ENUM_LABEL_SUBSYSTEM_ADD,
+                  MENU_SETTINGS_SUBSYSTEM_ADD + i, 0, 0);
+            }
+            else
+            {
+               snprintf(s, sizeof(s),
+                  "Start %s %s",
+                  subsystem->desc,
+                  i == content_get_subsystem()
+                  ? "\u2605" : " ");
+               menu_entries_append_enum(info->list,
+                  s,
+                  msg_hash_to_str(MENU_ENUM_LABEL_SUBSYSTEM_LOAD),
+                  MENU_ENUM_LABEL_SUBSYSTEM_LOAD,
+                  MENU_SETTINGS_SUBSYSTEM_LOAD, 0, 0);
+            }
+         }
+         else
+         {
+            snprintf(s, sizeof(s),
+               "Load %s %s",
+               subsystem->desc,
+               i == content_get_subsystem()
+               ? "\u2605" : " ");
+            menu_entries_append_enum(info->list,
+               s,
+               msg_hash_to_str(MENU_ENUM_LABEL_SUBSYSTEM_ADD),
+               MENU_ENUM_LABEL_SUBSYSTEM_ADD,
+               MENU_SETTINGS_SUBSYSTEM_ADD + i, 0, 0);
+         }
+      }
+   }
+}

--- a/menu/menu_driver.h
+++ b/menu/menu_driver.h
@@ -844,6 +844,8 @@ void menu_driver_destroy(void);
 
 void hex32_to_rgba_normalized(uint32_t hex, float* rgba, float alpha);
 
+void menu_subsystem_populate(const struct retro_subsystem_info* subsystem, menu_displaylist_info_t *info);
+
 extern uintptr_t menu_display_white_texture;
 
 extern menu_display_ctx_driver_t menu_display_ctx_gl;

--- a/menu/widgets/menu_filebrowser.c
+++ b/menu/widgets/menu_filebrowser.c
@@ -86,7 +86,7 @@ void filebrowser_parse(menu_displaylist_info_t *info, unsigned type_data)
       {
          const struct retro_subsystem_info *subsystem = &subsystem_data[content_get_subsystem()];
 
-         if (subsystem_size > 0)
+         if (subsystem_current_count > 0)
             str_list  = file_archive_get_file_list(path, subsystem->roms[content_get_subsystem_rom_id()].valid_extensions);
       }
    }
@@ -96,7 +96,7 @@ void filebrowser_parse(menu_displaylist_info_t *info, unsigned type_data)
       {
          const struct retro_subsystem_info *subsystem = &subsystem_data[content_get_subsystem()];
 
-         if (subsystem_size > 0 && content_get_subsystem_rom_id() < subsystem->num_roms)
+         if (subsystem_current_count > 0 && content_get_subsystem_rom_id() < subsystem->num_roms)
             str_list = dir_list_new(path,
                   (filter_ext && info) ? subsystem->roms[content_get_subsystem_rom_id()].valid_extensions : NULL,
                   true, settings->bools.show_hidden_files, true, false);

--- a/menu/widgets/menu_filebrowser.c
+++ b/menu/widgets/menu_filebrowser.c
@@ -74,6 +74,16 @@ void filebrowser_parse(menu_displaylist_info_t *info, unsigned type_data)
    bool filter_ext                      =
       settings->bools.menu_navigation_browser_filter_supported_extensions_enable;
 
+   rarch_system_info_t *system = runloop_get_system_info();
+   const struct retro_subsystem_info *subsystem;
+
+   /* Core fully loaded, use the subsystem data */
+   if (system->subsystem.data)
+      subsystem = system->subsystem.data + content_get_subsystem();
+   /* Core not loaded completely, use the data we peeked on load core */
+   else
+      subsystem = subsystem_data + content_get_subsystem();
+
    if (info && string_is_equal(info->label,
             msg_hash_to_str(MENU_ENUM_LABEL_SCAN_FILE)))
       filter_ext = false;
@@ -82,21 +92,14 @@ void filebrowser_parse(menu_displaylist_info_t *info, unsigned type_data)
    {
       if (filebrowser_types != FILEBROWSER_SELECT_FILE_SUBSYSTEM)
          str_list = file_archive_get_file_list(path, info->exts);
-      else
-      {
-         const struct retro_subsystem_info *subsystem = &subsystem_data[content_get_subsystem()];
-
-         if (subsystem_current_count > 0)
-            str_list  = file_archive_get_file_list(path, subsystem->roms[content_get_subsystem_rom_id()].valid_extensions);
-      }
+      else if (subsystem && subsystem_current_count > 0)
+         str_list  = file_archive_get_file_list(path, subsystem->roms[content_get_subsystem_rom_id()].valid_extensions);
    }
    else if (!string_is_empty(path))
    {
       if (filebrowser_types == FILEBROWSER_SELECT_FILE_SUBSYSTEM)
       {
-         const struct retro_subsystem_info *subsystem = &subsystem_data[content_get_subsystem()];
-
-         if (subsystem_current_count > 0 && content_get_subsystem_rom_id() < subsystem->num_roms)
+         if (subsystem && subsystem_current_count > 0 && content_get_subsystem_rom_id() < subsystem->num_roms)
             str_list = dir_list_new(path,
                   (filter_ext && info) ? subsystem->roms[content_get_subsystem_rom_id()].valid_extensions : NULL,
                   true, settings->bools.show_hidden_files, true, false);

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -663,7 +663,7 @@ error:
 static const struct
 retro_subsystem_info *content_file_init_subsystem(
       const struct retro_subsystem_info *subsystem_data,
-      size_t subsystem_size,
+      size_t subsystem_current_count,
       char **error_string,
       bool *ret)
 {
@@ -671,7 +671,7 @@ retro_subsystem_info *content_file_init_subsystem(
    char *msg                                  = (char*)malloc(path_size);
    struct string_list *subsystem              = path_get_subsystem_list();
    const struct retro_subsystem_info *special = libretro_find_subsystem_info(
-            subsystem_data, subsystem_size,
+            subsystem_data, subsystem_current_count,
             path_get(RARCH_PATH_SUBSYSTEM));
 
    msg[0] = '\0';
@@ -1786,7 +1786,7 @@ void content_set_subsystem(unsigned idx)
 
    pending_subsystem_id                         = idx;
 
-   if (subsystem_size > 0)
+   if (subsystem_current_count > 0)
    {
       strlcpy(pending_subsystem_ident,
          subsystem->ident, sizeof(pending_subsystem_ident));

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -1781,12 +1781,18 @@ int content_get_subsystem()
 void content_set_subsystem(unsigned idx)
 {
    rarch_system_info_t                  *system = runloop_get_system_info();
-   const struct retro_subsystem_info *subsystem = system ?
-	   subsystem_data + idx : NULL;
+   const struct retro_subsystem_info *subsystem;
 
-   pending_subsystem_id                         = idx;
+   /* Core fully loaded, use the subsystem data */
+   if (system->subsystem.data)
+      subsystem = system->subsystem.data + idx;
+   /* Core not loaded completely, use the data we peeked on load core */
+   else
+      subsystem = subsystem_data + idx;
 
-   if (subsystem_current_count > 0)
+   pending_subsystem_id = idx;
+
+   if (subsystem && subsystem_current_count > 0)
    {
       strlcpy(pending_subsystem_ident,
          subsystem->ident, sizeof(pending_subsystem_ident));


### PR DESCRIPTION
Fixed the issue at https://github.com/libretro/fbalpha/issues/24#issuecomment-445803876
Also cleaned up the menu code, and now subsystem will use the best data available, if the core isn't fully loaded it will use the cached copy that is obtained from "Load Core", otherwise it will use the complete proper data directly from the core.

Also cleaned up menu driver code to avoid so much repetition.
This should make it easier to add this code to rgui, mui and friends.