### PR TITLE
qb: Fix typo.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -477,7 +477,7 @@ if [ "$HAVE_WAYLAND_PROTOS" = yes ] && [ "$HAVE_WAYLAND" = yes ]; then
     check_pkgconf WAYLAND_SCANNER wayland-scanner 1.15
     ./gfx/common/wayland/generate_wayland_protos.sh
 else
-    die : 'Notice: wayland-egl or wayland-protocols not present. Skiping Wayland code paths.'
+    die : 'Notice: wayland-egl or wayland-protocols not found, disabling wayland support.'
     HAVE_WAYLAND='no'
 fi
 


### PR DESCRIPTION
## Description

Fixes a trivial typo in a `configure` and makes the warning slightly shorter to fit in a terminal that has a 80 column width.