### PR TITLE
Fix c89 build.

### DIFF
--- a/libretro-common/include/array/dynarray.h
+++ b/libretro-common/include/array/dynarray.h
@@ -196,12 +196,7 @@
  * but wants "__inline__" or something instead, #define DG_DYNARR_INLINE accordingly.
  */
 #ifndef DG_DYNARR_INLINE
-	/* for pre-C99 compilers you might have to use something compiler-specific (or maybe only "static") */
-	#ifdef _MSC_VER
-		#define DG_DYNARR_INLINE static __inline
-	#else
-		#define DG_DYNARR_INLINE static inline
-	#endif
+	#define DG_DYNARR_INLINE static INLINE
 #endif
 
 /* ############### Short da_* aliases for the long names ############### */
@@ -220,8 +215,7 @@
 #define da_init(a) \
 	dg_dynarr_init(a)
 
-/*
- * This allows you to provide an external buffer that'll be used as long as it's big enough
+/* This allows you to provide an external buffer that'll be used as long as it's big enough
  * once you add more elements than buf can hold, fresh memory will be allocated on the heap
  * Use like:
  * DA_TYPEDEF(double, MyDoubleArrType);

--- a/menu/menu_animation.c
+++ b/menu/menu_animation.c
@@ -46,7 +46,7 @@ struct tween
    void        *userdata;
 };
 
-DA_TYPEDEF(struct tween, tween_array_t);
+DA_TYPEDEF(struct tween, tween_array_t)
 
 struct menu_animation
 {


### PR DESCRIPTION
## Description

Please review and let travis test this!

Should fix the remaining c89 build failures.

## Related Issues
```
In file included from menu/menu_animation.c:27:
./libretro-common/include/array/dynarray.h:793:18: error: expected ‘;’ before ‘void’
 DG_DYNARR_INLINE void
                  ^~~~
./libretro-common/include/array/dynarray.h:802:18: error: expected ‘;’ before ‘int’
 DG_DYNARR_INLINE int
                  ^~~
./libretro-common/include/array/dynarray.h:809:18: error: expected ‘;’ before ‘int’
 DG_DYNARR_INLINE int
                  ^~~
./libretro-common/include/array/dynarray.h:817:18: error: expected ‘;’ before ‘int’
 DG_DYNARR_INLINE int
                  ^~~
./libretro-common/include/array/dynarray.h:838:18: error: expected ‘;’ before ‘int’
 DG_DYNARR_INLINE int
                  ^~~
./libretro-common/include/array/dynarray.h:854:18: error: expected ‘;’ before ‘void’
 DG_DYNARR_INLINE void
                  ^~~~
./libretro-common/include/array/dynarray.h:871:18: error: expected ‘;’ before ‘void’
 DG_DYNARR_INLINE void
                  ^~~~
menu/menu_animation.c:49:40: error: ISO C does not allow extra ‘;’ outside of a function [-Werror=pedantic]
 DA_TYPEDEF(struct tween, tween_array_t);
                                        ^
cc1: some warnings being treated as errors
make: *** [Makefile:193: obj-unix/release/menu/menu_animation.o] Error 1
make: *** Waiting for unfinished jobs....
```

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/7750
https://github.com/libretro/RetroArch/pull/7751