### PR TITLE
subsystem: remember last used folder

### DIFF
--- a/content.h
+++ b/content.h
@@ -103,6 +103,9 @@ unsigned content_get_subsystem_rom_id(void);
 /* Set environment variables before a subsystem load */
 void content_set_subsystem_info(void);
 
+/* Get the path to the last selected subsystem rom */
+char* content_get_subsystem_rom(unsigned index);
+
 RETRO_END_DECLS
 
 #endif

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -538,7 +538,10 @@ int generic_action_ok_displaylist_push(const char *path,
          {
             char game_dir[PATH_MAX_LENGTH];
             filebrowser_clear_type();
-            strlcpy(game_dir, path_get(RARCH_PATH_CONTENT), sizeof(game_dir));
+            if (content_get_subsystem_rom_id() > 0)
+               strlcpy(game_dir, content_get_subsystem_rom(content_get_subsystem_rom_id() - 1), sizeof(game_dir));
+            else
+               strlcpy(game_dir, path_get(RARCH_PATH_CONTENT), sizeof(game_dir));
             path_basedir(game_dir);
 
             if (content_get_subsystem() != type - MENU_SETTINGS_SUBSYSTEM_ADD)

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -1838,6 +1838,11 @@ uint32_t content_get_crc(void)
    return content_rom_crc;
 }
 
+char* content_get_subsystem_rom(unsigned index)
+{
+   return pending_subsystem_roms[index];
+}
+
 bool content_is_inited(void)
 {
    return _content_is_inited;


### PR DESCRIPTION
Allows faster loading of subsystem carts by using the previously used dir.