### PR TITLE
use none zero as requested for udev mouse

### DIFF
--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -514,7 +514,7 @@ static bool udev_input_add_device(udev_input_t *udev,
          if (absinfo.minimum >= absinfo.maximum )
       	 {
             device->mouse.x_min = -1;
-            device->mouse.x_max = 1;
+            device->mouse.x_max = -1;
          }
          else
          {
@@ -528,7 +528,7 @@ static bool udev_input_add_device(udev_input_t *udev,
          if (absinfo.minimum >= absinfo.maximum )
          {
             device->mouse.y_min = -1;
-            device->mouse.y_max = 1;
+            device->mouse.y_max = -1;
          }
 	     else
          {


### PR DESCRIPTION
the value set here needs to be the same to work if abs fails. I set it to -1 please let me know what your preference is. 