### PR TITLE
Fix warnings with clang.

### DIFF
--- a/dynamic.c
+++ b/dynamic.c
@@ -184,7 +184,8 @@ static bool environ_cb_get_system_info(unsigned cmd, void *data)
          break;
       case RETRO_ENVIRONMENT_SET_SUBSYSTEM_INFO:
       {
-         unsigned i, j;
+         unsigned i = 0;
+         unsigned j = 0;
          unsigned size = i;
          const struct retro_subsystem_info *info =
             (const struct retro_subsystem_info*)data;

--- a/gfx/drivers_shader/shader_vulkan.cpp
+++ b/gfx/drivers_shader/shader_vulkan.cpp
@@ -1106,12 +1106,12 @@ StaticTexture::StaticTexture(string id,
       bool linear,
       bool mipmap,
       vulkan_filter_chain_address address)
-   : id(move(id)),
-     device(device),
+   : device(device),
      image(image),
      view(view),
      memory(memory),
-     buffer(move(buffer))
+     buffer(move(buffer)),
+     id(move(id))
 {
    texture.filter = linear ? VULKAN_FILTER_CHAIN_LINEAR : VULKAN_FILTER_CHAIN_NEAREST;
    texture.mip_filter =
@@ -2104,8 +2104,8 @@ Framebuffer::Framebuffer(
       const VkPhysicalDeviceMemoryProperties &mem_props,
       const Size2D &max_size, VkFormat format,
       unsigned max_levels) :
-   device(device),
    memory_properties(mem_props),
+   device(device),
    size(max_size),
    format(format),
    max_levels(max(max_levels, 1u))


### PR DESCRIPTION
## Description

Fixes some trivial warnings with clang.

## Related Issues

```
gfx/drivers_shader/shader_vulkan.cpp:1109:6: warning: field 'id' will be initialized after field 'device' [-Wreorder]
   : id(move(id)),
     ^
gfx/drivers_shader/shader_vulkan.cpp:2107:4: warning: field 'device' will be initialized after field 'memory_properties' [-Wreorder]
   device(device),
   ^
2 warnings generated.
```
```
dynamic.c:188:26: warning: variable 'i' is uninitialized when used here [-Wuninitialized]
         unsigned size = i;
                         ^
dynamic.c:187:20: note: initialize the variable 'i' to silence this warning
         unsigned i, j;
                   ^
                    = 0
1 warning generated.
```
