### PR TITLE
Fix gcc warnings with C89_BUILD.

### DIFF
--- a/gfx/display_servers/dispserv_x11.c
+++ b/gfx/display_servers/dispserv_x11.c
@@ -218,14 +218,14 @@ static bool x11_display_server_set_resolution(void *data,
    /* create interlaced newmode from modline variables */
    if (height < 300)
    {
-      snprintf(xrandr, sizeof(xrandr), "xrandr --newmode \"%dx%d_%0.2f\" %lf %d %d %d %d %d %d %d %d -hsync -vsync", width, height, hz, pixel_clock,
+      snprintf(xrandr, sizeof(xrandr), "xrandr --newmode \"%dx%d_%0.2f\" %f %d %d %d %d %d %d %d %d -hsync -vsync", width, height, hz, pixel_clock,
             width, hfp, hsp, hbp, height, vfp, vsp, vbp);
       system(xrandr);
    }
    /* create interlaced newmode from modline variables */
    if (height > 300)
    {
-      snprintf(xrandr, sizeof(xrandr), "xrandr --newmode \"%dx%d_%0.2f\" %lf %d %d %d %d %d %d %d %d interlace -hsync -vsync", width, height, hz, pixel_clock,
+      snprintf(xrandr, sizeof(xrandr), "xrandr --newmode \"%dx%d_%0.2f\" %f %d %d %d %d %d %d %d %d interlace -hsync -vsync", width, height, hz, pixel_clock,
             width, hfp, hsp, hbp, height, vfp, vsp, vbp);
       system(xrandr);
    }

--- a/libretro-common/include/retro_miscellaneous.h
+++ b/libretro-common/include/retro_miscellaneous.h
@@ -166,7 +166,7 @@ typedef struct
 #endif
 #  endif
 #else
-#  define PRI_SIZET "zu"
+#  define PRI_SIZET "lu"
 #endif
 
 #endif

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -392,7 +392,7 @@ void menu_display_timedate(menu_display_ctx_datetime_t *datetime)
       case 7: /* Time (hours-minutes), in 12 hour AM-PM designation */
 #if defined(__linux__) && !defined(ANDROID)
          strftime(datetime->s, datetime->len,
-            "%r", localtime(&time_));
+            "%I : %M : %S %p", localtime(&time_));
 #else
          {
             char *local;

--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -731,7 +731,7 @@ static void netplay_announce_cb(void *task_data, void *user_data, const char *er
             if (string_is_equal(key, "game_name"))
                strlcpy(host_room->gamename, val, sizeof(host_room->gamename));
             if (string_is_equal(key, "game_crc"))
-               sscanf(val, "%08X", &host_room->gamecrc);
+               sscanf(val, "%08d", &host_room->gamecrc);
             if (string_is_equal(key, "host_method"))
                sscanf(val, "%i", &host_room->host_method);
             if (string_is_equal(key, "has_password"))


### PR DESCRIPTION
## Description

Fixes several `-Wformat=` warnings with `gcc-8.2.0` and `C89_BUILD=1`. I split this up into 4 commits as they seem to be 4 different similar issues.

## Related Issues

I used printf to make sure the output remained unchanged for the first one as I wasn't sure which one I wanted at first.
```
gfx/display_servers/dispserv_x11.c: In function ‘x11_display_server_set_resolution’:
gfx/display_servers/dispserv_x11.c:221:76: warning: ISO C90 does not support the ‘%lf’ gnu_printf format [-Wformat=]
       snprintf(xrandr, sizeof(xrandr), "xrandr --newmode \"%dx%d_%0.2f\" %lf %d %d %d %d %d %d %d %d -hsync -vsync", width, height, hz, pixel_clock,
                                                                            ^
gfx/display_servers/dispserv_x11.c:228:76: warning: ISO C90 does not support the ‘%lf’ gnu_printf format [-Wformat=]
       snprintf(xrandr, sizeof(xrandr), "xrandr --newmode \"%dx%d_%0.2f\" %lf %d %d %d %d %d %d %d %d interlace -hsync -vsync", width, height, hz, pixel_clock,
```
The posix spec claims `"%r"` is equivelent to `"%I : %M : %S %p"`. See http://pubs.opengroup.org/onlinepubs/9699919799/functions/strftime.html.
```

menu/menu_driver.c:395:15: warning: ISO C90 does not support the ‘%r’ gnu_strftime format [-Wformat=]
             "%r", localtime(&time_));
               ^
```
The `"z"` modifier was introduced in c99, but using `"l"` instead seems to work.
```
setting_list.c: In function ‘setting_get_string_representation_size’:
setting_list.c:175:24: warning: ISO C90 does not support the ‘z’ gnu_printf length modifier [-Wformat=]
       snprintf(s, len, "%" PRI_SIZET,
                        ^~~
setting_list.c: In function ‘setting_get_string_representation_size_in_mb’:
setting_list.c:183:24: warning: ISO C90 does not support the ‘z’ gnu_printf length modifier [-Wformat=]
       snprintf(s, len, "%" PRI_SIZET,
                        ^~~
setting_list.c: In function ‘setting_set_with_string_representation’:
setting_list.c:508:24: warning: ISO C90 does not support the ‘z’ gnu_scanf length modifier [-Wformat=]
          sscanf(value, "%" PRI_SIZET, setting->value.target.sizet);
                        ^~~

libretro-common/file/config_file.c: In function ‘config_get_size_t’:
libretro-common/file/config_file.c:692:32: warning: ISO C90 does not support the ‘z’ gnu_scanf length modifier [-Wformat=]
       if (sscanf(entry->value, "%" PRI_SIZET, &val) == 1
```
Reference: http://manpages.sgvulcan.com/sscanf.3.php
```
network/netplay/netplay_frontend.c: In function ‘netplay_announce_cb’:
network/netplay/netplay_frontend.c:734:32: warning: format ‘%X’ expects argument of type ‘unsigned int *’, but argument 3 has type ‘int *’ [-Wformat=]
                sscanf(val, "%08X", &host_room->gamecrc);
                             ~~~^   ~~~~~~~~~~~~~~~~~~~
                             %08X
```