### PR TITLE
Fix gcc -Wformat-truncation= warnings.

### DIFF
--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -667,7 +667,7 @@ static void rgui_render(void *data, bool is_idle)
       entry_title_buf_utf8len = utf8len(entry_title_buf);
       entry_title_buf_len     = strlen(entry_title_buf);
 
-      snprintf(message, sizeof(message), "%c %-*.*s %-*s",
+      snprintf(message, sizeof(message), "%c %-*.*s %-.*s",
             entry_selected ? '>' : ' ',
             (int)(RGUI_TERM_WIDTH(fb_width) - (entry_spacing + 1 + 2) - entry_title_buf_utf8len + entry_title_buf_len),
             (int)(RGUI_TERM_WIDTH(fb_width) - (entry_spacing + 1 + 2) - entry_title_buf_utf8len + entry_title_buf_len),


### PR DESCRIPTION
## Description

Please review this, I am not sure I have this right, but it makes `gcc-8.2.0` happy and rgui still looks the same. I also found no new warnings with `clang` which did not warn about this.

Reference: http://pubs.opengroup.org/onlinepubs/009695399/functions/fprintf.html

## Related Issues

```
menu/drivers/rgui.c: In function ‘rgui_render’:
menu/drivers/rgui.c:670:53: warning: ‘%-*s’ directive output may be truncated writing up to 2147483648 bytes into a region of size between 0 and 252 [-Wformat-truncation=]
       snprintf(message, sizeof(message), "%c %-*.*s %-*s",
                                                     ^~~~
menu/drivers/rgui.c:676:13:
             type_str_buf);
             ~~~~~~~~~~~~
menu/drivers/rgui.c:670:42: note: assuming directive output of 254 bytes
       snprintf(message, sizeof(message), "%c %-*.*s %-*s",
                                          ^~~~~~~~~~~~~~~~
menu/drivers/rgui.c:670:7: note: ‘snprintf’ output between 4 and 4294967300 bytes into a destination of size 255
       snprintf(message, sizeof(message), "%c %-*.*s %-*s",
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             entry_selected ? '>' : ' ',
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~
             (int)(RGUI_TERM_WIDTH(fb_width) - (entry_spacing + 1 + 2) - entry_title_buf_utf8len + entry_title_buf_len),
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             (int)(RGUI_TERM_WIDTH(fb_width) - (entry_spacing + 1 + 2) - entry_title_buf_utf8len + entry_title_buf_len),
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             entry_title_buf,
             ~~~~~~~~~~~~~~~~
             entry_spacing,
             ~~~~~~~~~~~~~~
             type_str_buf);
             ~~~~~~~~~~~~~
menu/drivers/rgui.c:670:53: warning: ‘%-*s’ directive output may be truncated writing up to 2147483648 bytes into a region of size between 0 and 252 [-Wformat-truncation=]
       snprintf(message, sizeof(message), "%c %-*.*s %-*s",
                                                     ^~~~
menu/drivers/rgui.c:676:13:
             type_str_buf);
             ~~~~~~~~~~~~
menu/drivers/rgui.c:670:42: note: assuming directive output of 254 bytes
       snprintf(message, sizeof(message), "%c %-*.*s %-*s",
                                          ^~~~~~~~~~~~~~~~
menu/drivers/rgui.c:670:7: note: ‘snprintf’ output between 4 and 4294967300 bytes into a destination of size 255
       snprintf(message, sizeof(message), "%c %-*.*s %-*s",
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             entry_selected ? '>' : ' ',
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~
             (int)(RGUI_TERM_WIDTH(fb_width) - (entry_spacing + 1 + 2) - entry_title_buf_utf8len + entry_title_buf_len),
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             (int)(RGUI_TERM_WIDTH(fb_width) - (entry_spacing + 1 + 2) - entry_title_buf_utf8len + entry_title_buf_len),
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             entry_title_buf,
             ~~~~~~~~~~~~~~~~
             entry_spacing,
             ~~~~~~~~~~~~~~
             type_str_buf);
             ~~~~~~~~~~~~~
```