### PR TITLE
Update NES and SNES hashing methods

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -2081,7 +2081,7 @@ void cheevos_populate_menu(void *data)
    cheevo_t *cheevo              = cheevos_locals.core.cheevos;
    end                           = cheevo + cheevos_locals.core.count;
 
-   if(settings->bools.cheevos_enable && settings->bools.cheevos_hardcore_mode_enable 
+   if(settings->bools.cheevos_enable && settings->bools.cheevos_hardcore_mode_enable
       && cheevos_loaded)
    {
       if (!cheevos_hardcore_paused)
@@ -2904,10 +2904,10 @@ found:
 
       /* Checks for the existence of a headered SNES file.
          Unheadered files fall back to GENERIC_MD5. */
-      
+
       const int SNES_HEADER_LEN = 0x200;
-      
-      if (coro->len % 0x2000 != SNES_HEADER_LEN || coro->len <= SNES_HEADER_LEN)
+
+      if (coro->len < 0x2000 || coro->len % 0x2000 != SNES_HEADER_LEN)
       {
           coro->gameid = 0;
           CORO_RET();
@@ -2918,7 +2918,7 @@ found:
 
       CORO_GOSUB(EVAL_MD5);
       MD5_Final(coro->hash, &coro->md5);
-      
+
       CORO_GOTO(GET_GAMEID);
 
       /**************************************************************************
@@ -3001,10 +3001,8 @@ found:
          CORO_RET();
       }
 
-      /* from FCEU core - check if Trainer included in ROM data */
       MD5_Init(&coro->md5);
-      coro->offset = sizeof(coro->header) + (coro->header.rom_type & 4
-            ? sizeof(coro->header) : 0);
+      coro->offset = sizeof(coro->header);
       coro->count  = coro->len - coro->offset;
       CORO_GOSUB(EVAL_MD5);
 

--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -2902,24 +2902,23 @@ found:
 
       MD5_Init(&coro->md5);
 
-      /* if the file contains header, ignore it */
-      if (coro->len - ((coro->len / 0x2000) * 0x2000) == 512)
-          coro->offset = 512;
-      else
-        coro->offset = 0;
+      /* Checks for the existence of a headered SNES file.
+         Unheadered files fall back to GENERIC_MD5. */
+      
+      const int SNES_HEADER_LEN = 0x200;
+      
+      if (coro->len % 0x2000 != SNES_HEADER_LEN || coro->len <= SNES_HEADER_LEN)
+      {
+          coro->gameid = 0;
+          CORO_RET();
+      }
 
+      coro->offset = 512;
       coro->count  = 0;
 
       CORO_GOSUB(EVAL_MD5);
-
-      if (coro->count == 0)
-      {
-         MD5_Final(coro->hash, &coro->md5);
-         coro->gameid = 0;
-         CORO_RET();
-      }
-
       MD5_Final(coro->hash, &coro->md5);
+      
       CORO_GOTO(GET_GAMEID);
 
       /**************************************************************************


### PR DESCRIPTION
## Description

VROM was discarded from the content hashed in the NES strategy for historical reasons, but full content hashes are now available in the database, so this method is deprecated and full content hashing (excluding the header) is now preferred.

This is tested and matches https://github.com/RetroAchievements/RAEmus/commit/67884716c8e8d14d4a744ff49717982c4cd47bfd.

In addition, SNES headers should be skipped on hashing. This attempts to detect a headered file based on file size, and falls back to `GENERIC_MD5` if it does not match an expected pattern, as is done with NES.

## Reviewers

@leiradel
