### PR TITLE
(RGUI) Add user index label to control menu entries

### DIFF
--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -2683,7 +2683,7 @@ static void input_config_get_bind_string_joyaxis(char *buf, const char *prefix,
    if (bind->joyaxis_label &&
          !string_is_empty(bind->joyaxis_label)
          && settings->bools.input_descriptor_label_show)
-      snprintf(buf, size, "%s%s (axis) ", prefix, bind->joyaxis_label);
+      snprintf(buf, size, "%s%s (axis)", prefix, bind->joyaxis_label);
    else
    {
       unsigned axis        = 0;

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -3394,6 +3394,15 @@ static int menu_displaylist_parse_options_remappings(
                strlcpy(descriptor, desc_label, sizeof(descriptor));
             }
 
+            /* Add user index when display driver == rgui,
+             * but only if there is more than one user */
+            if (string_is_equal(settings->arrays.menu_driver, "rgui") && (max_users > 1))
+            {
+               snprintf(desc_label, sizeof(desc_label),
+                        "%s [%s %u]", descriptor, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_USER), p + 1);
+               strlcpy(descriptor, desc_label, sizeof(descriptor));
+            }
+
             menu_entries_append_enum(info->list, descriptor, "",
                   MSG_UNKNOWN,
                   MENU_SETTINGS_INPUT_DESC_BEGIN +
@@ -3404,6 +3413,7 @@ static int menu_displaylist_parse_options_remappings(
       {
          for (retro_id = 0; retro_id < RARCH_FIRST_CUSTOM_BIND; retro_id++)
          {
+            char desc_label[255];
             char descriptor[255];
             const struct retro_keybind *auto_bind = NULL;
             const struct retro_keybind *keybind   = NULL;
@@ -3421,6 +3431,15 @@ static int menu_displaylist_parse_options_remappings(
                   &input_config_binds[p][retro_id];
 
                strlcpy(descriptor, msg_hash_to_str(keyptr->enum_idx), sizeof(descriptor));
+            }
+
+            /* Add user index when display driver == rgui,
+             * but only if there is more than one user */
+            if (string_is_equal(settings->arrays.menu_driver, "rgui") && (max_users > 1))
+            {
+               snprintf(desc_label, sizeof(desc_label),
+                        "%s [%s %u]", descriptor, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_USER), p + 1);
+               strlcpy(descriptor, desc_label, sizeof(descriptor));
             }
 
             menu_entries_append_enum(info->list, descriptor, "",


### PR DESCRIPTION
## Description

As described in issue #6843, the RGUI `Quick Menu > Controls` menu provides no indication of which control input belongs to which user.

This PR simply adds a `[User #]` label to the end of the descriptor string of each control remapping entry.

Note: The label is only shown if more than one user is enabled.

(I also removed an erroneous space character from a snprintf() inside input_config_get_bind_string_joyaxis(), since this made the labelled descriptor strings look ugly...)

## Related Issues

This should close issue #6843.
