### PR TITLE
Makefile: Better respect CFLAGS and CXXFLAGS as environment variables.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,26 +16,33 @@ include config.mk
 
 TARGET = retroarch
 
+OBJ :=
+LIBS :=
+DEF_FLAGS :=
+DEFINES := -DHAVE_CONFIG_H -DRARCH_INTERNAL -D_FILE_OFFSET_BITS=64
+DEFINES += -DGLOBAL_CONFIG_DIR='"$(GLOBAL_CONFIG_DIR)"'
+
 OBJDIR_BASE := obj-unix
 
 ifeq ($(DEBUG), 1)
    OBJDIR := $(OBJDIR_BASE)/debug
+   CFLAGS ?= -O0 -g
+   CXXFLAGS ?= -O0 -g
+   DEFINES += -DDEBUG -D_DEBUG
 else
    OBJDIR := $(OBJDIR_BASE)/release
+   CFLAGS ?= -O3
+   CXXFLAGS ?= -O3
+   DEF_FLAGS += -ffast-math
 endif
 
-OBJ :=
-LIBS :=
-DEFINES := -DHAVE_CONFIG_H -DRARCH_INTERNAL -D_FILE_OFFSET_BITS=64
-DEFINES += -DGLOBAL_CONFIG_DIR='"$(GLOBAL_CONFIG_DIR)"'
-
 ifneq ($(findstring BSD,$(OS)),)
-   CFLAGS += -DBSD
+   DEF_FLAGS += -DBSD
    LDFLAGS += -L/usr/local/lib
 endif
 
 ifneq ($(findstring DOS,$(OS)),)
-   CFLAGS += -march=i386
+   DEF_FLAGS += -march=i386
    LDFLAGS += -lemu
 endif
 
@@ -75,15 +82,8 @@ ifneq ($(V),1)
    Q := @
 endif
 
-ifeq ($(DEBUG), 1)
-   OPTIMIZE_FLAG = -O0 -g
-   DEFINES += -DDEBUG -D_DEBUG
-else
-   OPTIMIZE_FLAG = -O3 -ffast-math
-endif
-
 ifeq ($(HAVE_DRMINGW), 1)
-   CFLAGS   += -DHAVE_DRMINGW
+   DEF_FLAGS += -DHAVE_DRMINGW
    LDFLAGS += $(DRMINGW_LIBS)
 endif
 
@@ -91,10 +91,10 @@ ifneq ($(findstring Win32,$(OS)),)
    LDFLAGS += -mwindows
 endif
 
-CFLAGS   += -Wall $(OPTIMIZE_FLAG) $(INCLUDE_DIRS) -I. -Ideps -Ideps/stb
+DEF_FLAGS += -Wall $(INCLUDE_DIRS) -I. -Ideps -Ideps/stb
 
-APPEND_CFLAGS := $(CFLAGS)
-CXXFLAGS += $(APPEND_CFLAGS) -std=c++11 -D__STDC_CONSTANT_MACROS
+CFLAGS += $(DEF_FLAGS)
+CXXFLAGS += $(DEF_FLAGS) -std=c++11 -D__STDC_CONSTANT_MACROS
 OBJCFLAGS :=  $(CFLAGS) -D__STDC_CONSTANT_MACROS
 
 ifeq ($(HAVE_CXX), 1)

--- a/Makefile.common
+++ b/Makefile.common
@@ -4,7 +4,7 @@ LIBRETRO_COMM_DIR := $(ROOT_DIR)/libretro-common
 WANT_WGL           = 0
 
 ifeq ($(HAVE_STACK_USAGE), 1)
-   CFLAGS += -fstack-usage
+   DEF_FLAGS += -fstack-usage
 endif
 
 ifeq ($(HAVE_GL_CONTEXT),)
@@ -65,13 +65,11 @@ ifeq ($(HAVE_PRESERVE_DYLIB),1)
 endif
 
 ifeq ($(GL_DEBUG), 1)
-   CFLAGS += -DGL_DEBUG
-   CXXFLAGS += -DGL_DEBUG
+   DEF_FLAGS += -DGL_DEBUG
 endif
 
 ifeq ($(VULKAN_DEBUG), 1)
-   CFLAGS += -DVULKAN_DEBUG
-   CXXFLAGS += -DVULKAN_DEBUG
+   DEF_FLAGS += -DVULKAN_DEBUG
 endif
 
 ifeq ($(HAVE_HARD_FLOAT), 1)
@@ -83,23 +81,23 @@ ifeq ($(TDM_GCC),)
 endif
 
 ifeq ($(HAVE_FILE_LOGGER), 1)
-   CFLAGS += -DHAVE_FILE_LOGGER
+   DEF_FLAGS += -DHAVE_FILE_LOGGER
 endif
 
 ifeq ($(HAVE_SHADERPIPELINE), 1)
-   CFLAGS += -DHAVE_SHADERPIPELINE
+   DEF_FLAGS += -DHAVE_SHADERPIPELINE
 endif
 
-CFLAGS += -I$(LIBRETRO_COMM_DIR)/include -I$(DEPS_DIR)
+DEF_FLAGS += -I$(LIBRETRO_COMM_DIR)/include -I$(DEPS_DIR)
 
 # Switches
 #
 ifeq ($(HAVE_NETPLAYDISCOVERY), 1)
-   CFLAGS += -DHAVE_NETPLAYDISCOVERY
+   DEF_FLAGS += -DHAVE_NETPLAYDISCOVERY
 endif
 
 ifeq ($(HAVE_NETLOGGER), 1)
-	CFLAGS += -DHAVE_LOGGER
+	DEF_FLAGS += -DHAVE_LOGGER
 	DEFINES += -DHAVE_LOGGER
 	OBJ += network/net_logger.o
 endif
@@ -151,7 +149,7 @@ endif
 
 # General object files
 DEFINES += -DHAVE_DR_MP3
-CFLAGS  += -DHAVE_DR_MP3
+DEF_FLAGS += -DHAVE_DR_MP3
 
 OBJ += frontend/frontend.o \
        frontend/frontend_driver.o \
@@ -839,7 +837,7 @@ ifeq ($(HAVE_VITA2D), 1)
    OBJ += gfx/drivers/vita2d_gfx.o \
           gfx/drivers_font/vita2d_font.o
 
-   CFLAGS += -I$(DEPS_DIR)/libvita2d/include
+   DEF_FLAGS += -I$(DEPS_DIR)/libvita2d/include
 endif
 
 ifeq ($(TARGET), retroarch_3ds)
@@ -940,7 +938,7 @@ endif
 
 ifeq ($(HAVE_DBUS), 1)
    LIBS += $(DBUS_LIBS)
-   CFLAGS += $(DBUS_CFLAGS)
+   DEF_FLAGS += $(DBUS_CFLAGS)
    OBJ += gfx/common/dbus_common.o
 endif
 
@@ -1035,7 +1033,7 @@ endif
 
 ifeq ($(HAVE_SIXEL), 1)
    DEFINES += -DHAVE_SIXEL
-   CFLAGS += -I/usr/include/sixel
+   DEF_FLAGS += -I/usr/include/sixel
    OBJ += gfx/drivers/sixel_gfx.o gfx/drivers_font/sixel_font.o \
           gfx/drivers_context/sixel_ctx.o
    LIBS += -lsixel
@@ -1047,7 +1045,7 @@ endif
 
 ifeq ($(HAVE_PLAIN_DRM), 1)
    OBJ += gfx/drivers/drm_gfx.o
-   CFLAGS += -I/usr/include/libdrm
+   DEF_FLAGS += -I/usr/include/libdrm
    LIBS += -ldrm
 endif
 
@@ -1330,7 +1328,7 @@ ifneq ($(findstring 1, $(HAVE_D3D10) $(HAVE_D3D11) $(HAVE_D3D12)),)
    INCLUDE_DIRS += -isystemgfx/include/dxsdk
    OBJ += gfx/common/d3dcompiler_common.o \
           gfx/common/dxgi_common.o
-   CFLAGS += -Wno-unknown-pragmas
+   DEF_FLAGS += -Wno-unknown-pragmas
 endif
 
 ifeq ($(HAVE_D3D8), 1)
@@ -1446,7 +1444,7 @@ OBJ += $(LIBRETRO_COMM_DIR)/file/archive_file.o \
        $(LIBRETRO_COMM_DIR)/streams/trans_stream_pipe.o
 
 ifeq ($(HAVE_7ZIP),1)
-   CFLAGS  += -I$(DEPS_DIR)/7zip
+   DEF_FLAGS  += -I$(DEPS_DIR)/7zip
    HAVE_COMPRESSION = 1
    DEFINES += -DHAVE_7ZIP -D_7ZIP_ST
    7ZOBJ = $(DEPS_DIR)/7zip/7zIn.o \
@@ -1475,8 +1473,8 @@ endif
 ifeq ($(HAVE_BUILTINFLAC),1)
    HAVE_FLAC = 1
    DEFINES += -DHAVE_DR_FLAC -I$(DEPS_DIR)
-   CFLAGS  += -DHAVE_DR_FLAC
-   CFLAGS  += -DHAVE_FLAC -I$(DEPS_DIR)/libFLAC/include
+   DEF_FLAGS += -DHAVE_DR_FLAC
+   DEF_FLAGS += -DHAVE_FLAC -I$(DEPS_DIR)/libFLAC/include
    DEFINES += -DHAVE_STDINT_H -DHAVE_LROUND -DFLAC__HAS_OGG=0 \
               -DFLAC_PACKAGE_VERSION="\"retroarch\""
    FLACOBJ = $(DEPS_DIR)/libFLAC/bitmath.o \
@@ -1534,7 +1532,7 @@ ifeq ($(HAVE_ZLIB), 1)
 endif
 
 ifeq ($(HAVE_CHD), 1)
-   CFLAGS  += -I$(LIBRETRO_COMM_DIR)/formats/libchdr
+   DEF_FLAGS += -I$(LIBRETRO_COMM_DIR)/formats/libchdr
    DEFINES += -DHAVE_CHD -DWANT_SUBCODE -DWANT_RAW_DATA_SECTOR
    OBJ     += $(LIBRETRO_COMM_DIR)/formats/libchdr/libchdr_bitstream.o \
               $(LIBRETRO_COMM_DIR)/formats/libchdr/libchdr_cdrom.o \
@@ -1826,7 +1824,7 @@ endif
 
 ifeq ($(WANT_IOSUHAX), 1)
    DEFINES += -I$(DEPS_DIR)/libiosuhax
-   CFLAGS  += -I$(DEPS_DIR)/libiosuhax
+   DEF_FLAGS += -I$(DEPS_DIR)/libiosuhax
    OBJ += $(DEPS_DIR)/libiosuhax/iosuhax.o \
           $(DEPS_DIR)/libiosuhax/iosuhax_devoptab.o \
           $(DEPS_DIR)/libiosuhax/iosuhax_disc_interface.o
@@ -1834,7 +1832,7 @@ endif
 
 ifeq ($(WANT_LIBFAT), 1)
    DEFINES += -I$(DEPS_DIR)/libfat/include
-   CFLAGS  += -I$(DEPS_DIR)/libfat/include
+   DEF_FLAGS += -I$(DEPS_DIR)/libfat/include
    OBJ += $(DEPS_DIR)/libfat/cache.o \
           $(DEPS_DIR)/libfat/directory.o \
           $(DEPS_DIR)/libfat/disc.o \
@@ -1868,7 +1866,7 @@ endif
 # Help at https://modmyclassic.com/comp
 
 ifeq ($(HAVE_CLASSIC), 1)
-  CFLAGS += -DHAVE_CLASSIC
+  DEF_FLAGS += -DHAVE_CLASSIC
 endif
 
 ifeq ($(HAVE_C_A7A7), 1)
@@ -1880,12 +1878,11 @@ ifeq ($(HAVE_C_A7A7), 1)
                 -fno-unwind-tables -fno-asynchronous-unwind-tables -fno-unroll-loops \
                 -fmerge-all-constants -fno-math-errno \
                 -marm -mtune=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard
-   CFLAGS += $(C_A7A7_OPT)
-   CXXFLAGS += $(C_A7A7_OPT)
+   DEF_FLAGS += $(C_A7A7_OPT)
    ifeq ($(shell echo `$(CC) -dumpversion` "< 4.9" | bc -l), 1)
-      CFLAGS += -march=armv7-a
+      DEF_FLAGS += -march=armv7-a
    else
-      CFLAGS += -march=armv7ve
+      DEF_FLAGS += -march=armv7ve
       # If gcc is 5.0 or later
       ifeq ($(shell echo `$(CC) -dumpversion` ">= 5" | bc -l), 1)
          LDFLAGS += -static-libgcc -static-libstdc++
@@ -1894,6 +1891,6 @@ ifeq ($(HAVE_C_A7A7), 1)
 endif
 
 ifeq ($(HAVE_HAKCHI), 1)
-   CFLAGS += -DHAVE_HAKCHI
+   DEF_FLAGS += -DHAVE_HAKCHI
 endif
 ##################################

--- a/Makefile.ctr
+++ b/Makefile.ctr
@@ -80,6 +80,7 @@ else
 	#HAVE_BUILTINMBEDTLS = 1
 
 	include Makefile.common
+	CFLAGS += $(DEF_FLAGS)
 	BLACKLIST :=
 	BLACKLIST += input/input_overlay.o
 	BLACKLIST += tasks/task_overlay.o

--- a/Makefile.emscripten
+++ b/Makefile.emscripten
@@ -57,7 +57,7 @@ endif
 
 include Makefile.common
 
-CFLAGS += -Ideps/libz -Ideps -Ideps/stb
+CFLAGS += $(DEF_FLAGS) -Ideps/libz -Ideps -Ideps/stb
 libretro = libretro_emscripten.bc
 
 ifneq ($(V), 1)

--- a/Makefile.msvc
+++ b/Makefile.msvc
@@ -7,7 +7,6 @@ ARCH            = amd64
 BUILD_DIR       = objs/msvc
 CXX_BUILD       = 0
 
-
 WindowsSdkDir = C:\Program Files (x86)\Windows Kits\10\$(NOTHING)
 WindowsSDKVersion := 10.0.14393.0\$(NOTHING)
 VCINSTALLDIR := C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\$(NOTHING)
@@ -59,7 +58,7 @@ HAVE_IMAGEVIEWER         := 1
 
 include Makefile.common
 INCLUDE_DIRS := $(patsubst  -isystem%,-I%,$(INCLUDE_DIRS))
-CFLAGS       := $(filter-out  -Wno-unknown-pragmas,$(CFLAGS))
+CFLAGS       := $(filter-out  -Wno-unknown-pragmas,$(DEF_FLAGS))
 CXXFLAGS     := $(filter-out  -fpermissive -Wno-switch -Wno-sign-compare -fno-strict-aliasing -Wno-maybe-uninitialized -Wno-reorder -Wno-parentheses,$(CXXFLAGS))
 LIBS         := $(filter-out  -lstdc++,$(LIBS))
 
@@ -90,13 +89,11 @@ ifeq ($(ARCH),x86)
 CROSS =
 endif
 
-
 INCLUDE := $(VCINSTALLDIR)include;$(VCINSTALLDIR)atlmfc\include;$(WindowsSdkDir)include\$(WindowsSDKVersion)ucrt;$(WindowsSdkDir)include\$(WindowsSDKVersion)shared;$(WindowsSdkDir)include\$(WindowsSDKVersion)um;
 LIB     := $(VCINSTALLDIR)LIB\$(CROSS);$(VCINSTALLDIR)atlmfc\lib\$(CROSS);$(WindowsSdkDir)lib\$(WindowsSDKVersion)ucrt\$(TARGET_ARCH2);$(WindowsSdkDir)lib\$(WindowsSDKVersion)um\$(TARGET_ARCH2);C:\Program Files (x86)\NVIDIA Corporation\Cg\lib.$(TARGET_ARCH2);C:\Program Files (x86)\Microsoft DirectX SDK (February 2010)\Lib\$(TARGET_ARCH2);
 LIBPATH := $(VCINSTALLDIR)LIB\$(CROSS);$(VCINSTALLDIR)atlmfc\lib\$(CROSS);
 
 PATH := $(shell IFS=$$'\n'; cygpath "$(VCINSTALLDIR)bin\\$(CROSS)"):$(shell IFS=$$'\n'; cygpath "$(WindowsSdkDir)\bin\\$(ARCH2)"):$(PATH)
-
 
 export INCLUDE := $(INCLUDE)
 export LIB     := $(LIB)
@@ -144,7 +141,6 @@ RC = rc.exe
 LIBS += shell32.lib user32.lib gdi32.lib comdlg32.lib winmm.lib ole32.lib
 LDFLAGS  += -nologo -wx -nxcompat -machine:$(TARGET_ARCH2)
 
-
 ifeq ($(DEBUG),1)
    FLAGS += -GS -Gy -Od -RTC1 -D_SECURE_SCL=1 -Zi
    FLAGS += -MDd
@@ -154,7 +150,6 @@ else
    FLAGS += -GS- -Gy- -O2 -Ob2 -GF -GT -Oy -Ot -D_SECURE_SCL=0
    FLAGS += -MD
 endif
-
 
 ifeq ($(DEBUG),1)
    BUILD_DIR := $(BUILD_DIR)-debug
@@ -169,7 +164,6 @@ BUILD_DIR := $(BUILD_DIR)-$(TARGET_ARCH2)
 ifneq ($(V), 1)
    Q := @
 endif
-
 
 ifeq ($(GRIFFIN_BUILD), 1)
    OBJ       := griffin/griffin.o griffin/griffin_cpp.o
@@ -188,16 +182,12 @@ OBJ := $(patsubst %rarch.o,%rarch.res,$(OBJ))
 OBJ := $(addprefix $(BUILD_DIR)/,$(OBJ))
 OBJ := $(OBJ:.o=.obj)
 
-
-
-
 LDFLAGS += -WX -SUBSYSTEM:WINDOWS -ENTRY:mainCRTStartup
 
 DEFINES := $(patsubst -f%,,$(DEFINES))
 LDFLAGS := $(patsubst -l%,%.lib,$(LDFLAGS))
 LIBS := $(filter-out -lm,$(LIBS))
 LIBS := $(patsubst -l%,%.lib,$(LIBS))
-
 
 #$(info INCLUDE_DIRS : $(INCLUDE_DIRS))
 #$(info DEFINES : $(DEFINES))

--- a/Makefile.switch
+++ b/Makefile.switch
@@ -34,12 +34,12 @@ else
 	HAVE_DYNAMIC = 1
 
 	include Makefile.common
-        BLACKLIST :=
+	CFLAGS += $(DEF_FLAGS)
+	BLACKLIST :=
 	BLACKLIST += input/input_overlay.o
-        BLACKLIST += tasks/task_overlay.o
+	BLACKLIST += tasks/task_overlay.o
 	OBJ := $(filter-out $(BLACKLIST),$(OBJ))
 endif
-
 
 ifeq ($(strip $(LIBTRANSISTOR_HOME)),)
 $(error "Please set LIBTRANSISTOR_HOME in your environment. export LIBTRANSISTOR_HOME=<path/to/libtransistor/dist/>")

--- a/Makefile.vita
+++ b/Makefile.vita
@@ -55,6 +55,7 @@ else
 	endif
 
 	include Makefile.common
+	CFLAGS += $(DEF_FLAGS)
 	BLACKLIST :=
 	OBJ := $(filter-out $(BLACKLIST),$(OBJ))
 
@@ -63,7 +64,6 @@ else
 	OBJ += audio/drivers/psp_audio.o
 	OBJ += frontend/drivers/platform_psp.o
 endif
-
 
 ifeq ($(strip $(VITASDK)),)
 $(error "Please set VITASDK in your environment. export VITASDK=<path to>vitasdk")

--- a/Makefile.win
+++ b/Makefile.win
@@ -102,7 +102,6 @@ else
    WINDRES = windres
 endif
 
-
 libretro ?= -lretro
 
 ifeq ($(DYNAMIC), 1)
@@ -123,7 +122,7 @@ else
    CXXFLAGS += -O3 -ffast-math
 endif
 
-CFLAGS += -Wall -Wno-unused-result -Wno-unused-variable -I. -Ideps 
+CFLAGS += $(DEF_FLAGS) -Wall -Wno-unused-result -Wno-unused-variable -I. -Ideps
 CXXFLAGS += -Wall -Wno-unused-result -Wno-unused-variable -I. -Ideps -std=c++98 -D__STDC_CONSTANT_MACROS
 ifeq ($(CXX_BUILD), 1)
    CFLAGS += -std=c++98 -xc++ -D__STDC_CONSTANT_MACROS

--- a/cores/libretro-ffmpeg/Makefile
+++ b/cores/libretro-ffmpeg/Makefile
@@ -195,7 +195,7 @@ CFLAGS += -D__LIBRETRO__
 
 include Makefile.common
 
-CFLAGS   += $(DEFINES) $(INCFLAGS) $(GLFLAGS)
+CFLAGS += $(DEFINES) $(INCFLAGS) $(GLFLAGS) $(DEF_FLAGS)
 CFLAGS += -Wall $(fpic)
 
 ifeq ($(DEBUG), 1)

--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -242,8 +242,21 @@ create_config_make()
 
 	printf %s\\n "Creating make config: $outfile"
 
-	{	[ "$HAVE_CC" = 'yes' ] && printf %s\\n "CC = $CC" "CFLAGS = $CFLAGS"
-		[ "$HAVE_CXX" = 'yes' ] && printf %s\\n "CXX = $CXX" "CXXFLAGS = $CXXFLAGS"
+	{	if [ "$HAVE_CC" = 'yes' ]; then
+			printf %s\\n "CC = $CC"
+
+			if [ "${CFLAGS}" ]; then
+				printf %s\\n "CFLAGS = $CFLAGS"
+			fi
+		fi
+
+		if [ "$HAVE_CXX" = 'yes' ]; then
+			printf %s\\n "CXX = $CXX"
+
+			if [ "${CXXFLAGS}" ]; then
+				printf %s\\n "CXXFLAGS = $CXXFLAGS"
+			fi
+		fi
 
 		printf %s\\n "WINDRES = $WINDRES" \
 			"MOC = $MOC" \


### PR DESCRIPTION
Please wait for travis, I only tested the qb build system.

## Description

This fixes a few subtle problems with passing CFLAGS and CXXFLAGS as environment variables for configure.

First it will now only add these variables to config.mk when they are actually set. If they are unset then the default optimizations in the Makefile are set. This avoids passing more than one conflicting optimization level to the compiler.

Next all CFLAGS are added to CXXFLAGS to avoid issues with forgetting to set both CFLAGS and CXXFLAGS. This results in the cxx compiler getting passed several redundant optimization levels when both the CFLAGS and CXXFLAGS environment variabls are used. Now these uses of CFLAGS in Makefile.common are set to DEF_FLAGS. This allows adding $(DEF_FLAGS) to the CXXFLAGS variable without adding redundant flags from CFLAGS.