### PR TITLE
Makefile.ctr: Add missing comment.

### DIFF
--- a/Makefile.ctr
+++ b/Makefile.ctr
@@ -77,6 +77,7 @@ else
 	#HAVE_SOCKET_LEGACY = 1
 	#HAVE_THREADS = 1
 	#HAVE_SSL = 1
+	#HAVE_BUILTINMBEDTLS = 1
 
 	include Makefile.common
 	BLACKLIST :=


### PR DESCRIPTION
## Description

Adds a missing comment from a previous PR, it should have no impact now, but if `HAVE_SSL` is ever hooked up for ctr it might be confusing when this is missing.

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/7745