### PR TITLE
Fix gcc -Wformat-truncation= warning.

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -3438,7 +3438,7 @@ static int menu_displaylist_parse_options_remappings(
             if (string_is_equal(settings->arrays.menu_driver, "rgui") && (max_users > 1))
             {
                snprintf(desc_label, sizeof(desc_label),
-                        "%s [%s %u]", descriptor, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_USER), p + 1);
+                        "%.5s [%s %u]", descriptor, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_USER), p + 1);
                strlcpy(descriptor, desc_label, sizeof(descriptor));
             }
 


### PR DESCRIPTION
## Description

This silences the warning here and the previous PR still works, but I am not sure what what precision value I want exactly as several different numbers seem to work the same.

## Related Issues

```
menu/menu_displaylist.c: In function ‘menu_displaylist_ctl’:
menu/menu_displaylist.c:3441:28: warning: ‘ [’ directive output may be truncated writing 2 bytes into a region of size between 1 and 255 [-Wformat-truncation=]
                         "%s [%s %u]", descriptor, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_USER), p + 1);
                            ^~
menu/menu_displaylist.c:3441:25: note: using the range [0, 4294967295] for directive argument
                         "%s [%s %u]", descriptor, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_USER), p + 1);
                         ^~~~~~~~~~~~
menu/menu_displaylist.c:3440:16: note: ‘snprintf’ output 6 or more bytes (assuming 260) into a destination of size 255
                snprintf(desc_label, sizeof(desc_label),
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                         "%s [%s %u]", descriptor, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_USER), p + 1);
                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Also see https://github.com/libretro/RetroArch/issues/6843.

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/7770

## Reviewers

@jdgleaver 