### PR TITLE
menu: Use the default dir for recording output when unset.

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -6864,7 +6864,7 @@ static bool setting_append_list(
                MENU_ENUM_LABEL_RECORDING_OUTPUT_DIRECTORY,
                MENU_ENUM_LABEL_VALUE_RECORDING_OUTPUT_DIRECTORY,
                g_defaults.dirs[DEFAULT_DIR_RECORD_OUTPUT],
-               MENU_ENUM_LABEL_VALUE_DIRECTORY_CONTENT,
+               MENU_ENUM_LABEL_VALUE_DIRECTORY_DEFAULT,
                &group_info,
                &subgroup_info,
                parent_group,


### PR DESCRIPTION
## Description

I looked at the enums closer and when the config setting is unset it will show either `<Default>` or `<Content dir>` accordingly. I think its more consistent and correct to use `MENU_ENUM_LABEL_VALUE_DIRECTORY_DEFAULT` here as its already used for the other use of `MENU_ENUM_LABEL_RECORDING_OUTPUT_DIRECTORY`.

## Related Issues

https://github.com/libretro/RetroArch/issues/7776

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/7780