### PR TITLE
qb: Minor cleanup.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -236,9 +236,7 @@ check_val '' ALSA -lasound alsa
 check_lib '' CACA -lcaca
 check_lib '' SIXEL -lsixel
 
-if [ "$HAVE_AUDIOIO" != 'no' ]; then
-   check_macro AUDIOIO AUDIO_SETINFO sys/audioio.h
-fi
+check_macro AUDIOIO AUDIO_SETINFO sys/audioio.h
 
 if [ "$HAVE_OSS" != 'no' ]; then
    check_header OSS sys/soundcard.h

--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -140,9 +140,9 @@ check_header() #$1 = HAVE_$1  $2, $3, ... = header files
 check_macro() #$1 = HAVE_$1  $2 = macro name  $3 = header name [included only if non-empty]
 {	tmpval="$(eval "printf %s \"\$HAVE_$1\"")"
 	[ "$tmpval" = 'no' ] && return 0
-	if [ $3 ]; then
+	if [ "${3}" ]; then
 		ECHOBUF="Checking presence of predefined macro $2 in $3"
-		header_include=$(printf '#include <%s>' "$3")
+		header_include="#include <$3>"
 	else
 		ECHOBUF="Checking presence of predefined macro $2"
 		header_include=""


### PR DESCRIPTION
## Description

This uses safer quoting and removes an unneeded use of printf.

## Related Issues

Fixes the following shellcheck warning.
```
In qb/qb.libs.sh line 143:
	if [ $3 ]; then
             ^-- SC2086: Double quote to prevent globbing and word splitting.
```

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/7787

## Reviewers

@ensra
