### PR TITLE
menu: Reset position after pushing quick menu.

### DIFF
--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -1979,6 +1979,8 @@ bool menu_driver_iterate(menu_ctx_iterate_t *iterate)
          return false;
       }
 
+      menu_navigation_set_selection(0);
+
       return true;
    }
 

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -1654,7 +1654,7 @@ bool task_push_start_builtin_core(
    /* Preliminary stuff that has to be done before we
     * load the actual content. Can differ per mode. */
    retroarch_set_current_core_type(type, true);
-      printf("Step 1\n");
+
    /* Load content */
    if (!task_load_content_callback(content_info, true, false))
    {
@@ -1717,7 +1717,6 @@ bool task_push_load_content_with_core_from_menu(
 
    return true;
 }
-
 
 bool task_push_load_subsystem_with_core_from_menu(
       const char *fullpath,


### PR DESCRIPTION
## Description

This resets the position when opening the quick menu after loading content so it will show `Resume` instead of `Restart` or `Close content`.

I also took the liberty of removing some leftover `printf` debugging that was accidentally committed.

## Related Issues

Fixes:

https://github.com/libretro/RetroArch/issues/5595
https://github.com/libretro/RetroArch/issues/2506