### PR TITLE
Update theme selection sublabel in msg_hash_us.h

### DIFF
--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -5646,7 +5646,7 @@ MSG_HASH(
     )
 MSG_HASH(
     MENU_ENUM_SUBLABEL_XMB_THEME,
-    "Select a different theme for the icon. Changes will take effect after you restart the program."
+    "Select a different icon theme for RetroArch."
     )
 MSG_HASH(
     MENU_ENUM_SUBLABEL_XMB_SHADOWS_ENABLE,


### PR DESCRIPTION
This PR updates the sub-label for the Menu Icon Theme in order to remove the outdated instruction to restart RA.