### PR TITLE
reset on hardcore enable

### DIFF
--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -3558,7 +3558,7 @@ MSG_HASH(
     )
 MSG_HASH(
     MENU_ENUM_SUBLABEL_CHEEVOS_HARDCORE_MODE_ENABLE,
-    "Enable or disable savestates, cheats, rewind, pause, and slow-motion for all games."
+    "Enables hardcore mode, this will enable or disable savestates, cheats, rewind, pause, and slow-motion.\nToggling this setting at runtime will restart your game."
     )
 MSG_HASH(
     MENU_ENUM_SUBLABEL_CHEEVOS_LEADERBOARDS_ENABLE,

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -3021,12 +3021,12 @@ static void achievement_hardcore_mode_write_handler(rarch_setting_t *setting)
    if (!setting)
       return;
 
-   if (settings && settings->bools.cheevos_hardcore_mode_enable
+   if (settings && settings->bools.cheevos_enable && settings->bools.cheevos_hardcore_mode_enable
          && cheevos_state_loaded_flag
          )
    {
-      cheevos_hardcore_paused = true;
-      runloop_msg_queue_push(msg_hash_to_str(MSG_CHEEVOS_HARDCORE_MODE_DISABLED), 0, 180, true);
+      cheevos_toggle_hardcore_mode();
+      command_event(CMD_EVENT_RESET, NULL);
       return;
    }
 }
@@ -9289,7 +9289,7 @@ static bool setting_append_list(
                &group_info,
                &subgroup_info,
                parent_group,
-               general_write_handler,
+               achievement_hardcore_mode_write_handler,
                general_read_handler,
                SD_FLAG_NONE
                );


### PR DESCRIPTION
This changes the achievements behavior again so if the hardcore mode toggle is... toggled at runtime it will reset the current content.

Before it was only warning the user to reset, but that only tracked SAVESTATES which is not "complete", a cheat could have been applied.

So the new behavior would be to reset content.

Please do not merge before @meleu and @leiradel agree with this

https://github.com/libretro/RetroArch/issues/7800