### PR TITLE
Fix issue #2791 black bug

### DIFF
--- a/gfx/drivers/gl.c
+++ b/gfx/drivers/gl.c
@@ -2502,6 +2502,12 @@ static void video_texture_load_gl(
          );
 }
 
+static void video_texture_unload_gl(
+      uintptr_t *id)
+{
+   glDeleteTextures(1, (GLuint*)id);
+}
+
 #ifdef HAVE_THREADS
 static int video_texture_load_wrap_gl_mipmap(void *data)
 {
@@ -2524,6 +2530,14 @@ static int video_texture_load_wrap_gl(void *data)
          TEXTURE_FILTER_LINEAR, &id);
    return (int)id;
 }
+
+static int video_texture_unload_wrap_gl(void *data)
+{
+   if (!data)
+      return 0;
+   video_texture_unload_gl((uintptr_t *)data);
+   return 0;
+}
 #endif
 
 static uintptr_t gl_load_texture(void *video_data, void *data,
@@ -2545,7 +2559,7 @@ static uintptr_t gl_load_texture(void *video_data, void *data,
          default:
             break;
       }
-      return video_thread_texture_load(data, func);
+      return video_thread_custom_cmd(data, func);
    }
 #endif
 
@@ -2553,14 +2567,23 @@ static uintptr_t gl_load_texture(void *video_data, void *data,
    return id;
 }
 
-static void gl_unload_texture(void *data, uintptr_t id)
+static void gl_unload_texture(void *data, uintptr_t id, bool threaded)
 {
    GLuint glid;
    if (!id)
       return;
-
    glid = (GLuint)id;
-   glDeleteTextures(1, &glid);
+
+#ifdef HAVE_THREADS
+   if (threaded)
+   {
+      custom_command_method_t func = video_texture_unload_wrap_gl;
+      video_thread_custom_cmd(&glid, func);
+      return;
+   }
+#endif
+
+   video_texture_unload_gl(&glid);
 }
 
 static void gl_set_coords(void *handle_data, void *shader_data,

--- a/gfx/video_thread_wrapper.c
+++ b/gfx/video_thread_wrapper.c
@@ -1425,7 +1425,7 @@ bool video_thread_font_init(const void **font_driver, void **font_handle,
    return pkt.data.font_init.return_value;
 }
 
-unsigned video_thread_texture_load(void *data,
+unsigned video_thread_custom_cmd(void *data,
       custom_command_method_t func)
 {
    thread_video_t *thr  = (thread_video_t*)video_driver_get_ptr(true);

--- a/gfx/video_thread_wrapper.h
+++ b/gfx/video_thread_wrapper.h
@@ -83,7 +83,7 @@ bool video_thread_font_init(
       custom_font_command_method_t func,
       bool is_threaded);
 
-unsigned video_thread_texture_load(void *data,
+unsigned video_thread_custom_cmd(void *data,
       custom_command_method_t func);
 
 RETRO_END_DECLS


### PR DESCRIPTION
## Description

Unload the Textures of thumbnail images in a thread when the video is threaded.

## Related Issues

Fix issue #2791: XMB GUI lag and "black bug" for boxart and dynamic wallpaper 
