### PR TITLE
Makefile: Install assets only for enabled menus.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,12 +243,24 @@ install: $(TARGET)
 	chmod 644 $(DESTDIR)$(MAN_DIR)/man6/retroarch.6
 	chmod 644 $(DESTDIR)$(MAN_DIR)/man6/retroarch-cg2glsl.6
 	chmod 644 $(DESTDIR)$(DATA_DIR)/pixmaps/retroarch.svg
-	@if test -d media/assets; then \
+	@if test -d media/assets && test $(HAVE_ASSETS); then \
 		echo "Installing media assets..."; \
 		mkdir -p $(DESTDIR)$(ASSETS_DIR)/assets; \
-		cp -r media/assets/xmb/ $(DESTDIR)$(ASSETS_DIR)/assets; \
-		cp -r media/assets/glui/ $(DESTDIR)$(ASSETS_DIR)/assets; \
-		cp -r media/assets/ozone/ $(DESTDIR)$(ASSETS_DIR)/assets; \
+		if test $(HAVE_ZARCH) = 1; then \
+			cp -r media/assets/zarch/ $(DESTDIR)$(ASSETS_DIR)/assets; \
+		fi; \
+		if test $(HAVE_MATERIALUI) = 1; then \
+			cp -r media/assets/glui/ $(DESTDIR)$(ASSETS_DIR)/assets; \
+		fi; \
+		if test $(HAVE_NUKLEAR) = 1; then \
+			cp -r media/assets/nuklear/ $(DESTDIR)$(ASSETS_DIR)/assets; \
+		fi; \
+		if test $(HAVE_XMB) = 1; then \
+			cp -r media/assets/xmb/ $(DESTDIR)$(ASSETS_DIR)/assets; \
+		fi; \
+		if test $(HAVE_OZONE) = 1; then \
+			cp -r media/assets/ozone/ $(DESTDIR)$(ASSETS_DIR)/assets; \
+		fi; \
 		cp media/assets/COPYING $(DESTDIR)$(DOC_DIR)/COPYING.assets; \
 		echo "Asset copying done."; \
 	fi

--- a/Makefile.common
+++ b/Makefile.common
@@ -657,25 +657,25 @@ endif
 
 # XMB and MaterialUI are always enabled if supported and not explicitly disabled
 ifeq ($(HW_CONTEXT_MENU_DRIVERS), 1)
-   #ifeq ($(HAVE_ZARCH),)
-      #HAVE_ZARCH = 1
-   #endif
+   ifeq ($(HAVE_ZARCH),)
+      HAVE_ZARCH = 0
+   endif
 
    ifeq ($(HAVE_MATERIALUI),)
       HAVE_MATERIALUI = 1
    endif
 
-   #ifeq ($(HAVE_NUKLEAR),)
-      #HAVE_NUKLEAR = 1
-   #endif
+   ifeq ($(HAVE_NUKLEAR),)
+      HAVE_NUKLEAR = 0
+   endif
 
    ifeq ($(HAVE_XMB),)
       HAVE_XMB = 1
    endif
    
-   #ifeq ($(HAVE_STRIPES),)
-      #HAVE_STRIPES = 1
-   #endif
+   ifeq ($(HAVE_STRIPES),)
+      HAVE_STRIPES = 0
+   endif
 
    ifeq ($(HAVE_OZONE),)
       HAVE_OZONE = 1
@@ -697,6 +697,7 @@ ifeq ($(HAVE_RGUI), 1)
       OBJ += menu/drivers/materialui.o
       DEFINES += -DHAVE_MATERIALUI
       HAVE_MENU_COMMON = 1
+      HAVE_ASSETS = 1
    endif
    ifeq ($(HAVE_NUKLEAR), 1)
       OBJ += menu/drivers/nuklear/nk_common.o
@@ -704,10 +705,12 @@ ifeq ($(HAVE_RGUI), 1)
       OBJ += menu/drivers/nuklear/nk_wnd_debug.o
       OBJ += menu/drivers/nuklear.o
       DEFINES += -DHAVE_NUKLEAR
+      HAVE_ASSETS = 1
    endif
    ifeq ($(HAVE_ZARCH), 1)
       OBJ += menu/drivers/zarch.o
       DEFINES += -DHAVE_ZARCH
+      HAVE_ASSETS = 1
    endif
 endif
 
@@ -715,6 +718,7 @@ ifeq ($(HAVE_XMB), 1)
    OBJ += menu/drivers/xmb.o
    DEFINES += -DHAVE_XMB
    HAVE_MENU_COMMON = 1
+   HAVE_ASSETS = 1
 endif
 
 ifeq ($(HAVE_OZONE), 1)
@@ -726,6 +730,7 @@ ifeq ($(HAVE_OZONE), 1)
    OBJ += menu/drivers/ozone/ozone_sidebar.o
    DEFINES += -DHAVE_OZONE
    HAVE_MENU_COMMON = 1
+   HAVE_ASSETS = 1
 endif
 
 ifeq ($(HAVE_STRIPES), 1)

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -556,7 +556,7 @@ fi
 
 check_pkgconf PYTHON python3
 
-if [ "$HAVE_MATERIALUI" != 'no' ] || [ "$HAVE_XMB" != 'no' ] || [ "$HAVE_ZARCH" != 'no' ]; then
+if [ "$HAVE_MATERIALUI" != 'no' ] || [ "$HAVE_XMB" != 'no' ] || [ "$HAVE_ZARCH" != 'no' ] || [ "$HAVE_OZONE" != 'no' ]; then
    if [ "$HAVE_RGUI" = 'no' ]; then
       HAVE_MATERIALUI=no
       HAVE_XMB=no


### PR DESCRIPTION
## Description

Currently RetroArch will install assets for `xmb`, `materialui` and `ozone` unconditionally.

This change will now only install assets when RetroArch is compiled with support for the relevant menu driver. This also exposes assets from the `nuklear` and `zarch` menu drivers which are still disabled by
default.

Note:

* By default no behavior will change.
* `HAVE_ZARCH`, `HAVE_NUKLEAR` and `HAVE_STRIPES` are uncommented  in `Makefile.common` and their defaults set to `0`. If they are ever enabled everywhere like `xmb`, `materialui` or `ozone` then all that needs to be done is to set the default to `1` instead of uncommenting them like before. This is required to make sure these variables are not unset and then can be conditionally tested in `make install`.
* I also added a missing conditional in `qb/config.libs.sh`, but there might be room to improve this logic further in another PR.

## Related Issues

This allows using `make install` to only install assets that RetroArch can actually use, this can greatly reduce the size of the package if `--disable-xmb`, `--disable-materialui` and / or `--disable-ozone` are used.
