### PR TITLE
ozone: Fix crash with menu_use_preferred_system_color_theme.

### DIFF
--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -195,8 +195,8 @@ static void *ozone_init(void **userdata, bool video_is_threaded)
          setsysExit();
       }
       else
-         fallback_color_theme = true;
 #endif
+         fallback_color_theme = true;
    }
    else
       fallback_color_theme = true;


### PR DESCRIPTION
## Description

This prevents a crash when `menu_use_preferred_system_color_theme` is enabled with the ozone menu driver when not using libnx. The setting now does nothing as its only hooked up for the switch, but at least it won't cause unexpected failures.

## Related Issues

Fixes https://github.com/libretro/RetroArch/issues/7805