### PR TITLE
allow playing video from http/https sources

### DIFF
--- a/paths.c
+++ b/paths.c
@@ -724,6 +724,8 @@ enum rarch_content_type path_is_media_type(const char *path)
    /* hack, to detect livestreams so the ffmpeg core can be started */
    if (
       strstr(path, "udp://")  ||
+      strstr(path, "http://") ||
+      strstr(path, "https://")||
       strstr(path, "tcp://")  ||
       strstr(path, "rtmp://") ||
       strstr(path, "rtp://")


### PR DESCRIPTION
Example:

```
retroarch -v "https://cdn-b-east.streamable.com/video/mp4/ex6u1.mp4?token=MBKhW8JJok-h7M85ua1aMw&expires=1545636742"
```

Although it may not work later, starting to work on streamable integration so though it would be nice to have this ready.