### PR TITLE
menu: Reset initial menu position after selecting a core.

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -7081,6 +7081,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, menu_displaylist
          menu_entries_ctl(MENU_ENTRIES_CTL_CLEAR, info->list);
          ret = menu_displaylist_parse_horizontal_content_actions(menu, info);
          info->need_refresh = true;
+         info->need_clear   = true;
          info->need_push    = true;
          break;
       case DISPLAYLIST_CONTENT_SETTINGS:


### PR DESCRIPTION
## Description

When loading content from a playlist or the history and then selecting which core to use the menu position will not be initially reset to `Run` if the content was not the first item in the list. Now it will be reset.

## Related Issues

Fixes https://github.com/libretro/RetroArch/issues/2506 (Again)

1. Proceed to any playlist with at least two items.
2. Select any content that is not the first in the list.
3. Select Reset Core Association if previously set.
4. Load any core.
5. The quick menu position will not be initially reset to Run.

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/7794