### PR TITLE
menu: Reset initial menu position after selecting a core.

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -4296,6 +4296,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, menu_displaylist
    menu_handle_t       *menu     = NULL;
    bool load_content             = true;
    bool use_filebrowser          = false;
+   static bool core_selected     = false;
    unsigned count                = 0;
    int ret                       = 0;
 
@@ -5032,6 +5033,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, menu_displaylist
          info->need_sort    = true;
          info->need_refresh = true;
          info->need_push    = true;
+         core_selected      = true;
 
          {
             unsigned cores_names_len        = 0;
@@ -7082,6 +7084,13 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, menu_displaylist
          ret = menu_displaylist_parse_horizontal_content_actions(menu, info);
          info->need_refresh = true;
          info->need_push    = true;
+
+         if (core_selected)
+         {
+            info->need_clear = true;
+            core_selected = false;
+         }
+
          break;
       case DISPLAYLIST_CONTENT_SETTINGS:
          menu_entries_ctl(MENU_ENTRIES_CTL_CLEAR, info->list);


### PR DESCRIPTION
## Description

Please review, while I tested this and found it works as expected maybe there is a smarter method?

When loading content from a playlist or the history and then selecting which core to use the menu position will not be initially reset to `Run` if the content was not the first item in the list. Now it will be reset.

This is the second attempt at fixing this and unlike the first attempt it will now only reset the menu position after selecting a core in the core detection menu rather than when just toggling the menu button while playing a game. This includes when loading a second core while content is already loaded. I couldn't find any other places that needs this, but they should be easy to add if and when they are found.

## Related Issues

Fixes https://github.com/libretro/RetroArch/issues/2506 (Again)

1. Proceed to any playlist with at least two items.
2. Select any content that is not the first in the list.
3. Select Reset Core Association if previously set.
4. Load any core.
5. The quick menu position will not be initially reset to Run.

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/7794 (Similar issue)
https://github.com/libretro/RetroArch/pull/7816 (Previous attempt)