### PR TITLE
cli: Fix the --no-patch argument.

### DIFF
--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -1899,6 +1899,7 @@ bool content_init(void)
    temporary_content                          = string_list_new();
 
    content_ctx.check_firmware_before_loading  = settings->bools.check_firmware_before_loading;
+   content_ctx.patch_is_blocked               = rarch_ctl(RARCH_CTL_IS_PATCH_BLOCKED, NULL);
    content_ctx.is_ips_pref                    = rarch_ctl(RARCH_CTL_IS_IPS_PREF, NULL);
    content_ctx.is_bps_pref                    = rarch_ctl(RARCH_CTL_IS_BPS_PREF, NULL);
    content_ctx.is_ups_pref                    = rarch_ctl(RARCH_CTL_IS_UPS_PREF, NULL);
@@ -1913,7 +1914,6 @@ bool content_init(void)
    content_ctx.block_extract                  = false;
    content_ctx.need_fullpath                  = false;
    content_ctx.set_supports_no_game_enable    = false;
-   content_ctx.patch_is_blocked               = false;
 
    content_ctx.subsystem.data                 = NULL;
    content_ctx.subsystem.size                 = 0;


### PR DESCRIPTION
## Description

Between `v1.3.6` and `v1.4.1` the `--no-patch` command-line argument broke during a clean up commit, this change will allow it to work again as tested with `snes9x-libretro` using an `ips` patch.

Scenarios I have tested:
* No patch loads when loaded with `--no-patch`.
* Patch loads when loaded from the command-line without `--no-patch` and the patch file is found.
* Patch loads when loaded from the menu and the patch file is found.
* Patch doesn't load when loaded from the command-line or menu when the patch file is not found.

I could not find a `No patch` option exposed in the menu so I did not test that, please point me to it if it exists.

## Related Issues

Fixes https://github.com/libretro/RetroArch/issues/5885.

First bad commit https://github.com/libretro/RetroArch/commit/d28c138d09922f5458c8ee86a049aa3a961d0262.

## Reviewers

@twinaphex 