### PR TITLE
PS2 Support QuickNes

### DIFF
--- a/AUTHORS.h
+++ b/AUTHORS.h
@@ -94,6 +94,7 @@ FIX94
 Flame Sage (chris062689)
 flyinghead
 Francisco José García García (frangarcj)
+Francisco Javier Trujillo Mata (fjtrujy)
 GameDragon2k
 Garrett Brown (garbear)
 gblues

--- a/Makefile.ps2
+++ b/Makefile.ps2
@@ -2,7 +2,7 @@ BUILD_PRX          = 0
 DEBUG              = 1
 HAVE_KERNEL_PRX    = 0
 HAVE_LOGGER        = 0
-HAVE_FILE_LOGGER   = 0
+HAVE_FILE_LOGGER   = 1
 HAVE_THREADS       = 0
 BIG_STACK          = 0
 WHOLE_ARCHIVE_LINK = 0
@@ -34,13 +34,13 @@ CFLAGS = $(OPTIMIZE_LV)  -ffast-math -fsingle-precision-constant
 ASFLAGS = $(CFLAGS)
 
 RARCH_DEFINES += -DPS2 -DUSE_IOP_CTYPE_MACRO -D_MIPS_ARCH_R5900 -DHAVE_ZLIB -DHAVE_RPNG -DHAVE_RJPEG -DWANT_ZLIB
-RARCH_DEFINES += -DHAVE_GRIFFIN=1 -DRARCH_INTERNAL -DRARCH_CONSOLE -DHAVE_MENU -DHAVE_RGUI -DHAVE_FILTERS_BUILTIN -DHAVE_7ZIP -DHAVE_CC_RESAMPLER
+RARCH_DEFINES += -DHAVE_GRIFFIN=1 -DRARCH_INTERNAL -DRARCH_CONSOLE -DHAVE_MENU -DHAVE_RGUI -DHAVE_FILTERS_BUILTIN -DHAVE_IMAGEVIEWER -DHAVE_7ZIP -DHAVE_CC_RESAMPLER
 
 LIBDIR =
 LDFLAGS = -L$(PS2SDK)/ports/lib -L$(PS2DEV)/gsKit/lib -L$(PS2SDK)/ee/lib -L.
 #LIBS = $(WHOLE_START) -lretro_ps2 $(WHOLE_END) -lstdc++ -lm -lz -lgskit -ldmakit -lpng -laudsrv -lpad -lcdvd -lmad -lfileXio -lpatches
 LIBS += $(WHOLE_START) -lretro_ps2 $(WHOLE_END) 
-LIBS += -lm -lg -lz -ldebug -lfileXio -laudsrv -lpatches -lpoweroff -ldma -lgskit -ldmakit -lpad -lsdl
+LIBS += -lgskit -lpad -lsdl -lm -lz -lfileXio -laudsrv -lpatches -lpoweroff
 
 #IRX modules
 # IRX modules - modules have to be in IRX_DIR
@@ -102,4 +102,11 @@ $(EE_IRX_OBJ):
 #Include preferences
 include $(PS2SDK)/samples/Makefile.pref 
 include $(PS2SDK)/samples/Makefile.eeglobal
+
+   
+# $(EE_BIN): $(EE_OBJS) $(PS2SDK)/ee/startup/crt0.o
+# 	$(EE_CXX) $(EE_NO_CRT) -T$(PS2SDK)/ee/startup/linkfile $(EE_CXXFLAGS) \
+# 		-o $(EE_BIN) $(PS2SDK)/ee/startup/crt0.o $(CRTI_OBJ) $(CRTBEGIN_OBJ) $(EE_OBJS) $(CRTEND_OBJ) $(CRTN_OBJ) $(EE_LDFLAGS) $(EE_LIBS)
+
+
    

--- a/Makefile.ps2
+++ b/Makefile.ps2
@@ -1,5 +1,5 @@
 BUILD_PRX          = 0
-DEBUG              = 1
+DEBUG              = 0
 HAVE_KERNEL_PRX    = 0
 HAVE_LOGGER        = 0
 HAVE_FILE_LOGGER   = 1
@@ -13,6 +13,7 @@ EE_BIN2O = bin2o
 IRX_DIR = $(PS2SDK)/iop/irx
 
 TARGET = retroarchps2.elf
+TARGET_RELEASE = retroarchps2-release.elf
 
 ifeq ($(DEBUG), 1)
    OPTIMIZE_LV	:= -O0 -g
@@ -93,6 +94,9 @@ run:
 	ps2client -h $(PS2_IP) execee host:$(EE_BIN)
 
 debug: clean prepare all run
+
+release: clean all
+	ps2-packer $(EE_BIN) $(TARGET_RELEASE)
 
 #Specific file name and output per IRX Module
 $(EE_IRX_OBJ):

--- a/Makefile.ps2
+++ b/Makefile.ps2
@@ -6,7 +6,7 @@ HAVE_FILE_LOGGER   = 1
 HAVE_THREADS       = 0
 BIG_STACK          = 0
 WHOLE_ARCHIVE_LINK = 0
-PS2_IP = 192.168.1.150
+PS2_IP = 192.168.2.150
 
 #Configuration for IRX
 EE_BIN2O = bin2o
@@ -26,7 +26,7 @@ ifeq ($(WHOLE_ARCHIVE_LINK), 1)
    WHOLE_END := -Wl,--no-whole-archive
 endif
 
-INCDIR = -I$(PS2SDK)/ports/include -I$(PS2DEV)/gsKit/include -I$(PS2SDK)/iop/include -I$(PS2SDK)/ee/include -I$(PS2SDK)/common/include
+INCDIR = -I$(PS2DEV)/gsKit/include -I$(PS2SDK)/ports/include
 INCDIR += -Ips2 -Ips2/include -Ilibretro-common/include
 INCDIR += -Ideps -Ideps/stb -Ideps/libz -Ideps/7zip -Ideps/pthreads -Ideps/pthreads/platform/ps2 -Ideps/pthreads/platform/helper
 GPVAL = -G0
@@ -37,10 +37,9 @@ RARCH_DEFINES += -DPS2 -DUSE_IOP_CTYPE_MACRO -D_MIPS_ARCH_R5900 -DHAVE_ZLIB -DHA
 RARCH_DEFINES += -DHAVE_GRIFFIN=1 -DRARCH_INTERNAL -DRARCH_CONSOLE -DHAVE_MENU -DHAVE_RGUI -DHAVE_FILTERS_BUILTIN -DHAVE_IMAGEVIEWER -DHAVE_7ZIP -DHAVE_CC_RESAMPLER
 
 LIBDIR =
-LDFLAGS = -L$(PS2SDK)/ports/lib -L$(PS2DEV)/gsKit/lib -L$(PS2SDK)/ee/lib -L.
-#LIBS = $(WHOLE_START) -lretro_ps2 $(WHOLE_END) -lstdc++ -lm -lz -lgskit -ldmakit -lpng -laudsrv -lpad -lcdvd -lmad -lfileXio -lpatches
+LDFLAGS = -L$(PS2SDK)/ports/lib -L$(PS2DEV)/gsKit/lib -L$(PS2SDK)/ee/lib -L. -s
 LIBS += $(WHOLE_START) -lretro_ps2 $(WHOLE_END) 
-LIBS += -lgskit -lpad -lsdl -lm -lz -lfileXio -laudsrv -lpatches -lpoweroff
+LIBS += -lgskit -ldmakit -lpad -lmc -lhdd -lsdl -lc -lfileXio -lpatches -lpoweroff -ldebug -lc
 
 #IRX modules
 # IRX modules - modules have to be in IRX_DIR
@@ -104,9 +103,9 @@ include $(PS2SDK)/samples/Makefile.pref
 include $(PS2SDK)/samples/Makefile.eeglobal
 
    
-# $(EE_BIN): $(EE_OBJS) $(PS2SDK)/ee/startup/crt0.o
-# 	$(EE_CXX) $(EE_NO_CRT) -T$(PS2SDK)/ee/startup/linkfile $(EE_CXXFLAGS) \
-# 		-o $(EE_BIN) $(PS2SDK)/ee/startup/crt0.o $(CRTI_OBJ) $(CRTBEGIN_OBJ) $(EE_OBJS) $(CRTEND_OBJ) $(CRTN_OBJ) $(EE_LDFLAGS) $(EE_LIBS)
+$(EE_BIN): $(EE_OBJS) $(PS2SDK)/ee/startup/crt0.o
+	$(EE_CXX) $(EE_NO_CRT) -T$(PS2SDK)/ee/startup/linkfile $(EE_CXXFLAGS) \
+		-o $(EE_BIN) $(PS2SDK)/ee/startup/crt0.o $(CRTI_OBJ) $(CRTBEGIN_OBJ) $(EE_OBJS) $(CRTEND_OBJ) $(CRTN_OBJ) $(EE_LDFLAGS) $(EE_LIBS)
 
 
    

--- a/audio/drivers/nullaudio.c
+++ b/audio/drivers/nullaudio.c
@@ -21,7 +21,7 @@ static void *null_audio_init(const char *device, unsigned rate, unsigned latency
       unsigned block_frames,
       unsigned *new_rate)
 {
-   RARCH_ERR("Using the null audio driver. RetroArch will be silent.");
+   RARCH_ERR("Using the null audio driver. RetroArch will be silent.\n");
 
    (void)device;
    (void)rate;

--- a/frontend/drivers/platform_ps2.c
+++ b/frontend/drivers/platform_ps2.c
@@ -165,13 +165,6 @@ static const char *getMountParams(const char *command, char *BlockDevice) {
 
 static void create_path_names(void)
 {
-#ifndef IS_SALAMANDER
-#if defined(HAVE_LOGGER)
-   
-#elif defined(HAVE_FILE_LOGGER)
-   retro_main_log_file_init("ux0:/temp/retroarch-log.txt"); // It really depend from where we are executing this
-#endif
-#endif
 
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CORE], g_defaults.dirs[DEFAULT_DIR_PORT],
          "CORES", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE]));
@@ -231,7 +224,6 @@ static void frontend_ps2_get_environment_settings(int *argc, char *argv[],
    const char *mountPoint;
    int bootDeviceID;
 
-   //TODO: I DONT KNOW YET, WHY IT CRASHES IF UNCOMENT THIS PART 
    getcwd(cwd, sizeof(cwd));
    bootDeviceID=getBootDeviceID(cwd);
    //Mount the HDD partition, if required.
@@ -331,6 +323,14 @@ static void frontend_ps2_init(void *data)
    audsrv_init();
 
    SDL_Init(SDL_INIT_TIMER);
+
+
+retro_sleep(100);
+
+#if defined(HAVE_FILE_LOGGER)
+   retro_main_log_file_init("retroarch.log");
+   verbosity_enable();
+#endif
 }
 
 static void frontend_ps2_deinit(void *data)
@@ -466,7 +466,7 @@ static int frontend_ps2_parse_drive_list(void *data, bool load_content)
          enum_idx,
          FILE_TYPE_DIRECTORY, 0, 0);
    menu_entries_append_enum(list,
-         "host:/",
+         "host:",
          msg_hash_to_str(MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR),
          enum_idx,
          FILE_TYPE_DIRECTORY, 0, 0);

--- a/frontend/drivers/platform_ps2.c
+++ b/frontend/drivers/platform_ps2.c
@@ -1,6 +1,5 @@
 /* RetroArch - A frontend for libretro.
- * Copyright (C) 2010-2014 - Hans-Kristian Arntzen
- * Copyright (C) 2011-2017 - Daniel De Matteis
+ * Copyright (C) 2010-2018 - Francisco Javier Trujillo Mata - fjtrujy
  *
  * RetroArch is free software: you can redistribute it and/or modify it under the terms
  * of the GNU General Public License as published by the Free Software Found-

--- a/gfx/drivers/ps2_gfx.c
+++ b/gfx/drivers/ps2_gfx.c
@@ -45,7 +45,7 @@ static GSGLOBAL *init_GSGlobal(void) {
 	GSGLOBAL *gsGlobal = gsKit_init_global();
 
       gsGlobal->PSM = GS_PSM_CT16;
-	gsGlobal->PSMZ = GS_PSMZ_16S;
+	gsGlobal->PSMZ = GS_PSMZ_16;
 	gsGlobal->DoubleBuffering = GS_SETTING_OFF;
 	gsGlobal->ZBuffering = GS_SETTING_OFF;
       gsGlobal->PrimAlphaEnable = GS_SETTING_OFF;
@@ -98,7 +98,7 @@ static void color_correction16(uint16_t *buffer, uint32_t dimensions)
     uint16_t x16;
     for (i = 0; i < dimensions; i++) {
       x16 = buffer[i];
-      buffer[i] = (x16 & 0x8000) | ((x16 << 10) & 0x7C00) | (x16 & 0x3E0) | ((x16 >> 10) & 0x1F);
+      buffer[i] = (x16 & 0x8000) | ((x16 << 10) & 0x7C00) | ((x16 >> 1) & 0x3E0) | ((x16 >> 11) & 0x1F);
     }
 }
 

--- a/gfx/drivers/ps2_gfx.c
+++ b/gfx/drivers/ps2_gfx.c
@@ -66,10 +66,7 @@ static GSGLOBAL *init_GSGlobal(void) {
 }
 
 static GSTEXTURE * prepare_new_texture(void) {
-      GSTEXTURE *texture = malloc(sizeof *texture);
-      texture->Width = 0;
-      texture->Height = 0;
-      texture->Mem = NULL;
+      GSTEXTURE *texture = calloc(1, sizeof(*texture));
       return texture;
 }
 

--- a/gfx/drivers/ps2_gfx.c
+++ b/gfx/drivers/ps2_gfx.c
@@ -18,7 +18,6 @@
 #include "../../driver.h"
 #include "../../verbosity.h"
 
-#include <loadcore.h>
 #include <kernel.h>
 #include <gsKit.h>
 #include <gsInline.h>

--- a/gfx/drivers/ps2_gfx.c
+++ b/gfx/drivers/ps2_gfx.c
@@ -1,5 +1,5 @@
 /*  RetroArch - A frontend for libretro.
- *  Copyright (C) 2018 - Francisco Javier Trujillo Mata
+ *  Copyright (C) 2018 - Francisco Javier Trujillo Mata - fjtrujy
  *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-

--- a/input/drivers/ps2_input.c
+++ b/input/drivers/ps2_input.c
@@ -1,6 +1,5 @@
 /*  RetroArch - A frontend for libretro.
- *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
- *  Copyright (C) 2011-2017 - Daniel De Matteis
+ *  Copyright (C) 2011-2018 - Francisco Javier Trujillo Mata - fjtrujy
  *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-

--- a/input/drivers_joypad/ps2_joypad.c
+++ b/input/drivers_joypad/ps2_joypad.c
@@ -1,7 +1,5 @@
 /*  RetroArch - A frontend for libretro.
- *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
- *  Copyright (C) 2011-2017 - Daniel De Matteis
- *  Copyright (C) 2013-2014 - CatalystG
+ *  Copyright (C) 2011-2018 - Francisco Javier Trujillo Mata - fjtrujy
  *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-

--- a/libretro-common/file/config_file.c
+++ b/libretro-common/file/config_file.c
@@ -986,8 +986,10 @@ bool config_file_write(config_file_t *conf, const char *path)
          return false;
 
       /* TODO: this is only useful for a few platforms, find which and add ifdef */
+#if !defined(PS2)
       buf = calloc(1, 0x4000);
       setvbuf(file, (char*)buf, _IOFBF, 0x4000);
+#endif
 
       config_file_dump(conf, file);
 

--- a/libretro-common/vfs/vfs_implementation.c
+++ b/libretro-common/vfs/vfs_implementation.c
@@ -294,8 +294,10 @@ libretro_vfs_implementation_file *retro_vfs_file_open_impl(const char *path, uns
        */
       /* TODO: this is only useful for a few platforms, find which and add ifdef */
       stream->fp  = fp;
+#if !defined(PS2)
       stream->buf = (char*)calloc(1, 0x4000);
       setvbuf(stream->fp, stream->buf, _IOFBF, 0x4000);
+#endif
    }
    else
    {

--- a/ps2/compat_ctype.c
+++ b/ps2/compat_ctype.c
@@ -439,3 +439,8 @@ int link(const char *oldpath, const char *newpath)
 {
 	return fileXioSymlink(oldpath, newpath);
 }
+
+int unlink(const char *path)
+{
+	return fileXioRemove(path);
+}

--- a/ps2/compat_ctype.c
+++ b/ps2/compat_ctype.c
@@ -1,3 +1,17 @@
+/* RetroArch - A frontend for libretro.
+ * Copyright (C) 2010-2018 - Francisco Javier Trujillo Mata - fjtrujy
+ *
+ * RetroArch is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Found-
+ * ation, either version 3 of the License, or (at your option) any later version.
+ *
+ * RetroArch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ * * You should have received a copy of the GNU General Public License along with RetroArch.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include <compat_ctype.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/ps2/include/compat_ctype.h
+++ b/ps2/include/compat_ctype.h
@@ -20,5 +20,6 @@ char *strtok_r(char *str, const char *delim, char **saveptr);
 unsigned long long strtoull(const char * __restrict nptr, char ** __restrict endptr, int base);
 
 int link(const char *oldpath, const char *newpath);
+int unlink(const char *path);
 
 #endif

--- a/ps2/include/compat_ctype.h
+++ b/ps2/include/compat_ctype.h
@@ -1,3 +1,17 @@
+/* RetroArch - A frontend for libretro.
+ * Copyright (C) 2010-2018 - Francisco Javier Trujillo Mata - fjtrujy
+ *
+ * RetroArch is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Found-
+ * ation, either version 3 of the License, or (at your option) any later version.
+ *
+ * RetroArch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ * * You should have received a copy of the GNU General Public License along with RetroArch.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #ifndef COMPAT_CTYPE_H
 #define COMPAT_CTYPE_H
 

--- a/ps2/include/inttypes.h
+++ b/ps2/include/inttypes.h
@@ -1,3 +1,17 @@
+/* RetroArch - A frontend for libretro.
+ * Copyright (C) 2010-2018 - Francisco Javier Trujillo Mata - fjtrujy
+ *
+ * RetroArch is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Found-
+ * ation, either version 3 of the License, or (at your option) any later version.
+ *
+ * RetroArch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ * * You should have received a copy of the GNU General Public License along with RetroArch.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #ifndef INTTYPES_H
 #define INTTYPES_H
 

--- a/ps2/include/math.h
+++ b/ps2/include/math.h
@@ -1,3 +1,17 @@
+/* RetroArch - A frontend for libretro.
+ * Copyright (C) 2010-2018 - Francisco Javier Trujillo Mata - fjtrujy
+ *
+ * RetroArch is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Found-
+ * ation, either version 3 of the License, or (at your option) any later version.
+ *
+ * RetroArch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ * * You should have received a copy of the GNU General Public License along with RetroArch.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #ifndef MATH_H
 #define MATH_H
 

--- a/ps2/include/pte_types.h
+++ b/ps2/include/pte_types.h
@@ -1,4 +1,16 @@
-/* pte_types.h  */
+/* RetroArch - A frontend for libretro.
+ * Copyright (C) 2010-2018 - Francisco Javier Trujillo Mata - fjtrujy
+ *
+ * RetroArch is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Found-
+ * ation, either version 3 of the License, or (at your option) any later version.
+ *
+ * RetroArch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ * * You should have received a copy of the GNU General Public License along with RetroArch.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #ifndef PTE_TYPES_H
 #define PTE_TYPES_H

--- a/ps2/include/stdint.h
+++ b/ps2/include/stdint.h
@@ -1,3 +1,17 @@
+/* RetroArch - A frontend for libretro.
+ * Copyright (C) 2010-2018 - Francisco Javier Trujillo Mata - fjtrujy
+ *
+ * RetroArch is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Found-
+ * ation, either version 3 of the License, or (at your option) any later version.
+ *
+ * RetroArch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ * * You should have received a copy of the GNU General Public License along with RetroArch.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #ifndef STDINT_H
 #define STDINT_H
 

--- a/verbosity.c
+++ b/verbosity.c
@@ -118,9 +118,11 @@ void retro_main_log_file_init(const char *path)
    log_file_fp          = (FILE*)fopen_utf8(path, "wb");
    log_file_initialized = true;
 
+#if !defined(PS2)
    /* TODO: this is only useful for a few platforms, find which and add ifdef */
    log_file_buf = calloc(1, 0x4000);
    setvbuf(log_file_fp, (char*)log_file_buf, _IOFBF, 0x4000);
+#endif
 }
 
 void retro_main_log_file_deinit(void)


### PR DESCRIPTION
## Description

This PR make QuickNes core work for the PS2.
Basically the main changes are:

- Updated licenses for PS2 files.
- Including myself in the list of authors 👏 
- Improvements regarding the libraries linked in the `Makefile`
- Disabling the `setvbuf` for the PS2
- Improving regarding the color correction for 16 bits.

Thanks for your help