### PR TITLE
menu: Hide 'Parent Directory' in compressed archives.

### DIFF
--- a/menu/widgets/menu_filebrowser.c
+++ b/menu/widgets/menu_filebrowser.c
@@ -305,7 +305,7 @@ void filebrowser_parse(menu_displaylist_info_t *info, unsigned type_data)
    }
 
 end:
-   if (info)
+   if (info && !path_is_compressed)
       menu_entries_prepend(info->list,
             msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PARENT_DIRECTORY),
             path,


### PR DESCRIPTION
## Description

Note: I am not sure this will work for compressed directories with sub directories, but as these already do not work and only show `No items` I am not sure its a concern or worth fixing.

When browsing compressed archives `Parent Directory` will not work and will endlessly recurse into non-existent empty directories where the user will have to press the back button to get out of every instance.

This will now hide `Parent Directory` in compressed archives to avoid this issue. The user will still be able to press the back button to exit.

## Related Issues

Fixes https://github.com/libretro/RetroArch/issues/2604.

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

@bparker06 