### PR TITLE
menu: Hide options for the kiosk menu.

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -2672,7 +2672,7 @@ static int menu_displaylist_parse_load_content_settings(
       {
          if (!recording_is_enabled())
          {
-            if (settings->bools.quick_menu_show_start_recording)
+            if (settings->bools.quick_menu_show_start_recording && !settings->bools.kiosk_mode_enable)
             {
                menu_entries_append_enum(info->list,
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_QUICK_MENU_START_RECORDING),
@@ -2680,7 +2680,7 @@ static int menu_displaylist_parse_load_content_settings(
                      MENU_ENUM_LABEL_QUICK_MENU_START_RECORDING, MENU_SETTING_ACTION, 0, 0);
             }
 
-            if (settings->bools.quick_menu_show_start_streaming)
+            if (settings->bools.quick_menu_show_start_streaming && !settings->bools.kiosk_mode_enable)
             {
                menu_entries_append_enum(info->list,
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_QUICK_MENU_START_STREAMING),
@@ -2893,7 +2893,7 @@ static int menu_displaylist_parse_horizontal_content_actions(
                MENU_ENUM_LABEL_ADD_TO_FAVORITES_PLAYLIST, FILE_TYPE_PLAYLIST_ENTRY, 0, 0);
       }
 
-      if (settings->bools.quick_menu_show_reset_core_association)
+      if (settings->bools.quick_menu_show_reset_core_association && !settings->bools.kiosk_mode_enable)
       {
          menu_entries_append_enum(info->list,
                msg_hash_to_str(MENU_ENUM_LABEL_VALUE_RESET_CORE_ASSOCIATION),


### PR DESCRIPTION
## Description

This hides `reset core association`, `start recording` and `start streaming` when the kiosk menu is active.

## Related Issues

Fixes https://github.com/libretro/RetroArch/issues/7824
Fixes https://github.com/libretro/RetroArch/issues/7825