### PR TITLE
Fix png file names for screenshots with contentless cores.

### DIFF
--- a/tasks/task_screenshot.c
+++ b/tasks/task_screenshot.c
@@ -195,9 +195,13 @@ static bool screenshot_dump(
          calloc(1, sizeof(*state));
    const char *screenshot_dir     = settings->paths.directory_screenshot;
    char shotname[256];
+   struct retro_system_info system_info;
 
    shotname[0]                    = '\0';
    screenshot_path[0]             = '\0';
+
+   if (!core_get_system_info(&system_info))
+         return false;
 
    /* If fullpath is true, name_base already contains a static path + filename to save the screenshot to. */
    if (fullpath)
@@ -232,8 +236,14 @@ static bool screenshot_dump(
       else
       {
          if (settings->bools.auto_screenshot_filename)
-            fill_str_dated_filename(shotname, path_basename(name_base),
-                  IMG_EXT, sizeof(shotname));
+         {
+            if (path_is_empty(RARCH_PATH_CONTENT))
+               fill_str_dated_filename(shotname, system_info.library_name,
+                     IMG_EXT, sizeof(shotname));
+            else
+               fill_str_dated_filename(shotname, path_basename(name_base),
+                     IMG_EXT, sizeof(shotname));
+         }
          else
             snprintf(shotname, sizeof(shotname),
                   "%s.png", path_basename(name_base));


### PR DESCRIPTION
## Description

For contentless cores like `2048` and the `retropad` RetroArch will save png files with the content field missing.
```
-181227-133151.png
```
Now RetroArch will save png files with the correct names for contentless cores.
```
2048-181227-133151.png
RetroPad Remote-181227-133202.png
```
Cores with content will have no change in behavior.
```
Akumajou Dracula (J)-181227-133232.png
```
And with cores that support content and no content such as `4DO` both variations will work.
```
4DO-181227-144102.png
LuciennesQuest-181227-144118.png
```
## Related Issues

Fixes https://github.com/libretro/RetroArch/issues/7828.

## Related Pull Requests

It used to use `RetroArch` instead of the core name until it was replaced by an empty string in PR https://github.com/libretro/RetroArch/pull/3407.

## Reviewers

@meleu