### PR TITLE
Bugfixes to #7235 - creating swap chain twice in d3d11 and HOME path problems

### DIFF
--- a/gfx/common/d3d11_common.c
+++ b/gfx/common/d3d11_common.c
@@ -23,6 +23,39 @@
 #if defined(HAVE_DYNAMIC) && !defined(__WINRT__)
 #include <dynamic/dylib.h>
 
+HRESULT WINAPI D3D11CreateDevice(
+      IDXGIAdapter*   pAdapter,
+      D3D_DRIVER_TYPE DriverType,
+      HMODULE         Software,
+      UINT            Flags,
+      CONST D3D_FEATURE_LEVEL* pFeatureLevels,
+      UINT                     FeatureLevels,
+      UINT                     SDKVersion,
+      ID3D11Device**              ppDevice,
+      D3D_FEATURE_LEVEL*          pFeatureLevel,
+      ID3D11DeviceContext**       ppImmediateContext)
+{
+   static dylib_t                                d3d11_dll;
+   static PFN_D3D11_CREATE_DEVICE                fp;
+
+   if (!d3d11_dll)
+      d3d11_dll = dylib_load("d3d11.dll");
+
+   if (!d3d11_dll)
+      return TYPE_E_CANTLOADLIBRARY;
+
+   if (!fp)
+      fp = (PFN_D3D11_CREATE_DEVICE)dylib_proc(
+            d3d11_dll, "D3D11CreateDevice");
+
+   if (!fp)
+      return TYPE_E_DLLFUNCTIONNOTFOUND;
+
+   return fp(
+         pAdapter, DriverType, Software, Flags, pFeatureLevels, FeatureLevels, SDKVersion,
+         ppDevice, pFeatureLevel, ppImmediateContext);
+}
+
 HRESULT WINAPI D3D11CreateDeviceAndSwapChain(
       IDXGIAdapter*   pAdapter,
       D3D_DRIVER_TYPE DriverType,

--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -687,20 +687,11 @@ d3d11_gfx_init(const video_info_t* video, const input_driver_t** input, void** i
       }
       else
       {
-#if defined(__WINRT__)
          if (FAILED(D3D11CreateDevice(
                      NULL, D3D_DRIVER_TYPE_HARDWARE, NULL, flags,
                      requested_feature_levels, number_feature_levels,
                      D3D11_SDK_VERSION, &d3d11->device,
                      &d3d11->supportedFeatureLevel, &d3d11->context)))
-#else
-         if (FAILED(D3D11CreateDeviceAndSwapChain(
-                     NULL, D3D_DRIVER_TYPE_HARDWARE, NULL, flags,
-                     requested_feature_levels, number_feature_levels,
-                     D3D11_SDK_VERSION, &desc,
-                     (IDXGISwapChain**)&d3d11->swapChain, &d3d11->device,
-                     &d3d11->supportedFeatureLevel, &d3d11->context)))
-#endif
             goto error;
       }
 

--- a/libretro-common/file/file_path.c
+++ b/libretro-common/file/file_path.c
@@ -1028,29 +1028,12 @@ void fill_pathname_expand_special(char *out_path,
          out_path  += src_size;
          size      -= src_size;
 
-         if (
-            (in_path[1] == '/')
-#ifdef _WIN32
-            || (in_path[1] == '\\')
-#endif
-            )
-         {
-            in_path += 2;
-         }
-         else
-         {
-            in_path++;
-         }
+         in_path++;
       }
+
+      free(home_dir);
    }
-   else if ((in_path[0] == ':') &&
-         (
-         (in_path[1] == '/')
-#ifdef _WIN32
-         || (in_path[1] == '\\')
-#endif
-         )
-            )
+   else if (in_path[0] == ':')
    {
       char *application_dir = (char*)malloc(PATH_MAX_LENGTH * sizeof(char));
 
@@ -1064,12 +1047,13 @@ void fill_pathname_expand_special(char *out_path,
          size_t src_size   = strlcpy(out_path, application_dir, size);
          retro_assert(src_size < size);
 
-         free(application_dir);
-
          out_path  += src_size;
          size      -= src_size;
-         in_path   += 2;
+
+         in_path++;
       }
+
+      free(application_dir);
    }
 #endif
 


### PR DESCRIPTION
Not sure what I was thinking when writing this but somehow I managed to create the swap chain twice on "regular" Win32

## Related Issues

https://github.com/libretro/RetroArch/commit/dd60b5d5764dae20974e1df3dea50e1ccf738205#commitcomment-31801518