### PR TITLE
add drmingw's exchndl support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,11 @@ else
    OPTIMIZE_FLAG = -O3 -ffast-math
 endif
 
+ifeq ($(HAVE_DRMINGW), 1)
+   CFLAGS   += -DHAVE_DRMINGW
+   LDFLAGS += $(DRMINGW_LIBS)
+endif
+
 ifneq ($(findstring Win32,$(OS)),)
    LDFLAGS += -mwindows
 endif

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -418,6 +418,9 @@ if [ "$HAVE_THREADS" = 'no' ] && [ "$HAVE_FFMPEG" != 'no' ]; then
    die : 'Notice: Threads are not available, FFmpeg will also be disabled.'
 fi
 
+check_header DRMINGW exchndl.h
+check_lib '' DRMINGW -lexchndl
+
 if [ "$HAVE_FFMPEG" != 'no' ]; then
    check_pkgconf AVCODEC libavcodec 54
    check_pkgconf AVFORMAT libavformat 54

--- a/qb/config.params.sh
+++ b/qb/config.params.sh
@@ -134,3 +134,4 @@ HAVE_LANGEXTRA=yes         # Multi-language support
 HAVE_OSMESA=no             # Off-screen Mesa rendering
 HAVE_VIDEOPROCESSOR=auto   # Enable video processor core
 HAVE_VIDEOCORE=auto        # Broadcom Videocore 4 support
+HAVE_DRMINGW=no            # DrMingw exception handler

--- a/retroarch.c
+++ b/retroarch.c
@@ -23,6 +23,9 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif
+#if defined(DEBUG) && defined(HAVE_DRMINGW)
+#include "exchndl.h"
+#endif
 #endif
 
 #include <stdlib.h>
@@ -1255,7 +1258,7 @@ static void retroarch_validate_cpu_features(void)
 
 static void retroarch_main_init_media(void)
 {
-   settings_t *settings     = config_get_ptr();
+   settings_t *settings = config_get_ptr();
    const char    *fullpath  = path_get(RARCH_PATH_CONTENT);
    bool builtin_imageviewer = false;
    bool builtin_mediaplayer = false;
@@ -1316,6 +1319,10 @@ bool retroarch_main_init(int argc, char *argv[])
    bool init_failed = false;
    global_t  *global = global_get_ptr();
 
+#if defined(DEBUG) && defined(HAVE_DRMINGW)
+   char log_file_name[128];
+#endif
+
    retroarch_init_state();
 
    if (setjmp(error_sjlj_context) > 0)
@@ -1334,7 +1341,6 @@ bool retroarch_main_init(int argc, char *argv[])
    if (verbosity_is_enabled())
    {
       char str[128];
-
       str[0] = '\0';
 
       RARCH_LOG_OUTPUT("=== Build =======================================\n");
@@ -1347,6 +1353,14 @@ bool retroarch_main_init(int argc, char *argv[])
 #endif
       RARCH_LOG_OUTPUT("=================================================\n");
    }
+
+#if defined(DEBUG) && defined(HAVE_DRMINGW)
+   RARCH_LOG("Initializing Dr.MingW Exception handler\n");
+   fill_str_dated_filename(log_file_name, "crash",
+         "log", sizeof(log_file_name));
+   ExcHndlInit();
+   ExcHndlSetLogFileNameA(log_file_name);
+#endif
 
    retroarch_validate_cpu_features();
 


### PR DESCRIPTION
This adds drmingw's exchndl support when available on debug builds.
This means debug builds will generate report files on crashes that look like the one attached.

Which could then be used for post crash debugging and better issue submission.
It shouldn't break anything or change anything otherwise

```
-------------------

Error occured on Monday, December 10, 2018 at 20:01:37.

retroarch_debug.exe caused an Access Violation at location 0000000000496132 in module retroarch_debug.exe Reading from location FFFFFFFFFFFFFFFF.

AddrPC           Params
0000000000496132 000000001A6719B0 000000000000000E 0000000000000000  retroarch_debug.exe!core_option_manager_get_val  [C:\msys64\home\Andres\repos\retroarch/managers/core_option_manager.c @ 331]
   329:       return NULL;
   330:    option = (struct core_option*)&opt->opts[idx];
>  331:    return option->vals->elems[option->index].data;
   332: }
   333: 
000000000062E52F 000000001A0FDF60 0000000006E5EC8C 000000000001000E  retroarch_debug.exe!menu_action_setting_disp_set_label_core_options  [C:\msys64\home\Andres\repos\retroarch/menu/cbs/menu_cbs_get_value.c @ 1179]
  1177:    if (rarch_ctl(RARCH_CTL_CORE_OPTIONS_LIST_GET, &coreopts))
  1178:    {
> 1179:       core_opt = core_option_manager_get_val(coreopts,
  1180:             type - MENU_SETTINGS_CORE_OPTION_START);
  1181: 
000000000060F602 0000000006E5EC80 0000000000000000 000000000000000F  retroarch_debug.exe!menu_entry_get  [C:\msys64\home\Andres\repos\retroarch/menu/widgets/menu_entry.c @ 337]
   335:          tmp[0] = '\0';
   336: 
>  337:          cbs->action_get_value(list,
   338:                &entry->spacing, entry->type,
   339:                (unsigned)i, label,
00000000005DBC6C 000000001A10A770 0000000006E5F410 0000000000000002  retroarch_debug.exe!ozone_draw_entries  [C:\msys64\home\Andres\repos\retroarch/menu/drivers/ozone/ozone_entries.c @ 216]
   214: 
   215:       menu_entry_init(&entry);
>  216:       menu_entry_get(&entry, 0, (unsigned)i, selection_buf, true);
   217:       menu_entry_get_value(&entry, entry_value, sizeof(entry_value));
   218: 
00000000005D9A80 000000001A10A770 0000000006E5F410 0000000100000005  retroarch_debug.exe!ozone_frame  [C:\msys64\home\Andres\repos\retroarch/menu/drivers/ozone/ozone.c @ 1228]
  1226: 
  1227:    /* Current list */
> 1228:    ozone_draw_entries(ozone,
  1229:       video_info,
  1230:       ozone->selection,
00000000005E685F 0000000006E5F410 000000001A7BBB00 000000001A81CA48  retroarch_debug.exe!menu_driver_frame  [C:\msys64\home\Andres\repos\retroarch/menu/menu_driver.c @ 1893]
  1891: {
  1892:    if (menu_driver_alive && menu_driver_ctx->frame)
> 1893:       menu_driver_ctx->frame(menu_userdata, video_info);
  1894: }
  1895: 
0000000000684905 000000001A81C8F0 0000000000000000 0000000000000140  retroarch_debug.exe!gl_frame  [C:\msys64\home\Andres\repos\retroarch/gfx/drivers/gl.c @ 1125]
  1123:    if (gl->menu_texture_enable)
  1124:    {
> 1125:       menu_driver_frame(video_info);
  1126: 
  1127:       if (gl->menu_texture)
000000000046D309 0000000000000000 0000000000000140 00000000000000C8  retroarch_debug.exe!video_driver_frame  [C:\msys64\home\Andres\repos\retroarch/gfx/video_driver.c @ 2641]
  2639:    }
  2640: 
> 2641:    video_driver_active = current_video->frame(
  2642:          video_driver_data, data, width, height,
  2643:          video_driver_frame_count,
000000001F2D9AF2 0000000000000003 0000000000000000 0000000000000000  dosbox_svn_libretro.dll!retro_run
0000000000403061 0000000006E5FA01 3F4EBEE00065E100 3F4EBEE046525000  retroarch_debug.exe!core_run  [C:\msys64\home\Andres\repos\retroarch/core_impl.c @ 448]
   446:    }
   447: 
>  448:    current_core.retro_run();
   449: 
   450:    if (current_core.poll_type == POLL_TYPE_LATE && !current_core.input_polled)
00000000005E1CED 000000001A10A700 0000000800000001 0100000000000000  retroarch_debug.exe!menu_display_libretro  [C:\msys64\home\Andres\repos\retroarch/menu/menu_driver.c @ 531]
   529:          input_driver_set_libretro_input_blocked();
   530: 
>  531:       core_run();
   532:       input_driver_unset_libretro_input_blocked();
   533: 
00000000005E6A05 0000000006E5FB00 0000000006E5FA01 0000000000000000  retroarch_debug.exe!menu_driver_render  [C:\msys64\home\Andres\repos\retroarch/menu/menu_driver.c @ 1934]
  1932: 
  1933:    if (menu_driver_alive && !is_idle)
> 1934:       menu_display_libretro(is_idle, rarch_is_inited, rarch_is_dummy_core);
  1935: 
  1936:    if (menu_driver_ctx->set_texture)
0000000000407DA0 0000000009D67780 0000000000000000 0000000006E5FDC0  retroarch_debug.exe!runloop_check_state  [C:\msys64\home\Andres\repos\retroarch/retroarch.c @ 2793]
  2791:                   (current_core_type == CORE_TYPE_DUMMY));
  2792: 
> 2793:             menu_driver_render(runloop_idle, rarch_is_inited,
  2794:                   (current_core_type == CORE_TYPE_DUMMY)
  2795:                   )
0000000000408FB9 0000000006E5FDC0 0000000000000000 0000000006E5FDA0  retroarch_debug.exe!runloop_iterate  [C:\msys64\home\Andres\repos\retroarch/retroarch.c @ 3456]
  3454:    }
  3455: 
> 3456:    switch ((enum runloop_state)
  3457:          runloop_check_state(
  3458:             settings,
000000000040170F 0000000000000005 0000000009D67740 0000000000000000  retroarch_debug.exe!rarch_main  [C:\msys64\home\Andres\repos\retroarch/frontend/frontend.c @ 141]
   139:    {
   140:       unsigned sleep_ms = 0;
>  141:       int           ret = runloop_iterate(&sleep_ms);
   142: 
   143:       if (ret == 1 && sleep_ms > 0)
000000000040176F 0000000000000005 0000000009D67740 0000000007033C80  retroarch_debug.exe!SDL_main  [C:\msys64\home\Andres\repos\retroarch/frontend/frontend.c @ 169]
   167: int main(int argc, char *argv[])
   168: {
>  169:    return rarch_main(argc, argv, NULL);
   170: }
   171: #endif
00000000009598D8 0000000000000020 0000000000000003 000000000170A838  retroarch_debug.exe!main_getcmdline
00000000004013C7 0000000000000000 0000000000000000 0000000000000000  retroarch_debug.exe!__tmainCRTStartup  [C:/repo/mingw-w64-crt-git/src/mingw-w64/mingw-w64-crt/crt/crtexe.c @ 331]
00000000004014CB 0000000000000000 0000000000000000 0000000000000000  retroarch_debug.exe!WinMainCRTStartup  [C:/repo/mingw-w64-crt-git/src/mingw-w64/mingw-w64-crt/crt/crtexe.c @ 187]
00007FFDC3F73034 0000000000000000 0000000000000000 0000000000000000  KERNEL32.DLL!BaseThreadInitThunk
00007FFDC6551471 0000000000000000 0000000000000000 0000000000000000  ntdll.dll!RtlUserThreadStart

retroarch_debug.exe
ntdll.dll   	10.0.17134.376
KERNEL32.DLL	10.0.17134.1
KERNELBASE.dll	10.0.17134.407
ADVAPI32.dll	10.0.17134.319
msvcrt.dll  	7.0.17134.1
sechost.dll 	10.0.17134.319
RPCRT4.dll  	10.0.17134.407
comdlg32.dll	10.0.17134.1
combase.dll 	10.0.17134.407
ucrtbase.dll	10.0.17134.319
bcryptPrimitives.dll	10.0.17134.1
shcore.dll  	10.0.17134.112
USER32.dll  	10.0.17134.376
win32u.dll  	10.0.17134.1
GDI32.dll   	10.0.17134.285
gdi32full.dll	10.0.17134.345
msvcp_win.dll	10.0.17134.137
SHLWAPI.dll 	10.0.17134.1
SHELL32.dll 	10.0.17134.376
cfgmgr32.dll	10.0.17134.1
windows.storage.dll	10.0.17134.407
COMCTL32.dll	5.82.17134.407
kernel.appcore.dll	10.0.17134.112
profapi.dll 	10.0.17134.1
powrprof.dll	10.0.17134.1
FLTLIB.DLL  	10.0.17134.1
ole32.dll   	10.0.17134.407
SETUPAPI.dll	10.0.17134.1
WS2_32.dll  	10.0.17134.1
DINPUT8.dll 	10.0.17134.254
DSOUND.dll  	10.0.17134.1
HID.DLL     	10.0.17134.1
MSIMG32.dll 	10.0.17134.1
IPHLPAPI.DLL	10.0.17134.1
OPENGL32.dll	10.0.17134.1
libwinpthread-1.dll	1.0.0.0
WINMM.dll   	10.0.17134.1
libstdc++-6.dll
libass-9.dll
avutil-56.dll	56.19.101.0
avcodec-58.dll	58.30.100.0
avformat-58.dll	58.18.101.0
cgD3D9.dll  	3.1.0.13
cgGL.dll    	3.1.0.13
CRYPT32.dll 	10.0.17134.1
exchndl.dll 	0.7.6.0
libfreetype-6.dll	2.9.1.0
PSAPI.DLL   	10.0.17134.1
MSASN1.dll  	10.0.17134.1
libopenal-1.dll
SDL2.dll    	2.0.8.0
swresample-3.dll	3.2.100.0
IMM32.dll   	10.0.17134.1
libusb-1.0.dll	1.0.22.11312
swscale-5.dll	5.2.100.0
zlib1.dll
OLEAUT32.dll	10.0.17134.48
WINMMBASE.dll	10.0.17134.1
libgcc_s_seh-1.dll
libfontconfig-1.dll
libfribidi-0.dll
libharfbuzz-0.dll
bcrypt.dll  	10.0.17134.112
libbz2-1.dll
libpng16-16.dll
mgwhelp.dll 	0.7.6.0
VERSION.dll 	10.0.17134.1
libexpat-1.dll
libintl-8.dll	0.19.8.0
libglib-2.0-0.dll	2.56.1.0
libgraphite2.dll
dbghelp.dll 	10.0.17134.1
libpcre-1.dll
GLU32.dll   	10.0.17134.1
dbgcore.DLL 	10.0.17134.1
cg.dll      	3.1.0.13
libiconv-2.dll	1.15.0.0
ncrypt.dll  	10.0.17134.1
NTASN1.dll  	10.0.17134.1
CRYPTSP.dll 	10.0.17134.1
rsaenh.dll  	10.0.17134.254
CRYPTBASE.dll	10.0.17134.1
dwmapi.dll  	10.0.17134.1
inputhost.dll
wintypes.dll	10.0.17134.407
CoreMessaging.dll	10.0.17134.407
CoreUIComponents.dll	10.0.17134.376
ntmarta.dll 	10.0.17134.1
uxtheme.dll 	10.0.17134.1
MSCTF.dll   	10.0.17134.376
nvoglv64.dll	25.21.14.1722
WTSAPI32.dll	10.0.17134.1
DEVOBJ.dll  	10.0.17134.1
WINTRUST.dll	10.0.17134.81
nvspcap64.dll	3.16.0.122
WINSTA.dll  	10.0.17134.1
TextInputFramework.dll	10.0.17134.376
xinput1_4.dll	10.0.17134.1
clbcatq.dll 	2001.12.10941.16384
explorerframe.dll	10.0.17134.1
XAudio2_7.dll	9.29.1962.0
MMDevApi.dll	10.0.17134.1
PROPSYS.dll 	7.0.17134.112
AUDIOSES.DLL	10.0.17134.407
AVRT.dll    	10.0.17134.1
Windows.UI.dll	10.0.17134.1
wdmaud.drv  	10.0.17134.1
ksuser.dll  	10.0.17134.1
OmniMIDI.dll	5.1.2.0
msacm32.drv 	10.0.17134.1
MSACM32.dll 	10.0.17134.1
midimap.dll 	10.0.17134.1
bass.dll    	2.4.13.14
bassmidi.dll	2.4.11.5
bassenc.dll 	2.4.13.9
bassasio.dll	1.3.1.8
mswsock.dll 	10.0.17134.1
dosbox_svn_libretro.dll
DNSAPI.dll  	10.0.17134.165
NSI.dll     	10.0.17134.1
fwpuclnt.dll	10.0.17134.1
rasadhlp.dll	10.0.17134.1
chorus.dll
crystalizer.dll
echo.dll
eq.dll
iir.dll
panning.dll
phaser.dll
reverb.dll
wahwah.dll

Windows 10.0.17134
DrMingw 0.7.6

```
