### PR TITLE
Fix the taskbar extension not initializing properly

### DIFF
--- a/audio/drivers/xaudio.c
+++ b/audio/drivers/xaudio.c
@@ -201,9 +201,12 @@ static xaudio2_t *xaudio2_new(unsigned samplerate, unsigned channels,
 {
    xaudio2_t *handle = NULL;
    WAVEFORMATEX wfx  = {0};
+   HRESULT hr;
 
 #ifndef _XBOX
-   CoInitializeEx(0, COINIT_MULTITHREADED);
+   hr = CoInitialize(NULL);
+   if (FAILED(hr))
+      return NULL;
 #endif
 
 #if defined(__cplusplus) && !defined(CINTERFACE)
@@ -255,6 +258,9 @@ static xaudio2_t *xaudio2_new(unsigned samplerate, unsigned channels,
 
 error:
    xaudio2_free(handle);
+#ifndef _XBOX
+   CoUninitialize();
+#endif
    return NULL;
 }
 
@@ -404,6 +410,10 @@ static void xa_free(void *data)
    if (xa->xa)
       xaudio2_free(xa->xa);
    free(xa);
+
+#ifndef _XBOX
+   CoUninitialize();
+#endif
 }
 
 static size_t xa_write_avail(void *data)

--- a/gfx/display_servers/dispserv_win32.c
+++ b/gfx/display_servers/dispserv_win32.c
@@ -82,6 +82,8 @@ static void* win32_display_server_init(void)
       return NULL;
 
 #ifdef HAS_TASKBAR_EXT
+   CoInitialize(NULL);
+
 #ifdef __cplusplus
    /* When compiling in C++ mode, GUIDs are references instead of pointers */
    hr = CoCreateInstance(CLSID_TaskbarList, NULL,

--- a/gfx/display_servers/dispserv_win32.c
+++ b/gfx/display_servers/dispserv_win32.c
@@ -82,7 +82,11 @@ static void* win32_display_server_init(void)
       return NULL;
 
 #ifdef HAS_TASKBAR_EXT
-   CoInitialize(NULL);
+   if (FAILED(CoInitialize(NULL)))
+   {
+      RARCH_ERR("COM initialization failed, ITaskbarList3 disabled\n");
+      return dispserv;
+   }
 
 #ifdef __cplusplus
    /* When compiling in C++ mode, GUIDs are references instead of pointers */
@@ -98,6 +102,7 @@ static void* win32_display_server_init(void)
    {
       g_taskbarList = NULL;
       RARCH_ERR("[dispserv]: CoCreateInstance of ITaskbarList3 failed.\n");
+      CoUninitialize();
    }
 #endif
 
@@ -117,6 +122,7 @@ static void win32_display_server_destroy(void *data)
    {
       ITaskbarList3_Release(g_taskbarList);
       g_taskbarList = NULL;
+      CoUninitialize();
    }
 #endif
 

--- a/input/drivers/dinput.c
+++ b/input/drivers/dinput.c
@@ -98,6 +98,8 @@ void dinput_destroy_context(void)
 
    IDirectInput8_Release(g_dinput_ctx);
    g_dinput_ctx = NULL;
+
+   CoUninitialize();
 }
 
 bool dinput_init_context(void)
@@ -105,7 +107,11 @@ bool dinput_init_context(void)
    if (g_dinput_ctx)
       return true;
 
-   CoInitialize(NULL);
+   if (FAILED(CoInitialize(NULL)))
+   {
+      RARCH_ERR("[DINPUT]: Failed to initialize the COM interface\n");
+      return false;
+   }
 
    /* Who said we shouldn't have same call signature in a COM API? <_< */
 #ifdef __cplusplus
@@ -125,6 +131,7 @@ bool dinput_init_context(void)
 
 error:
    RARCH_ERR("[DINPUT]: Failed to initialize DirectInput.\n");
+   CoUninitialize();
    return false;
 }
 


### PR DESCRIPTION
## Description

The COM interface is initialized a thousand times everywhere, but
apparently not before the taskbar extension is loaded ;)

Somehow this managed to work sometimes and even return a valid object,
but that object was destroyed soon afterwards causing crashes

## Related Issues

#7842

## Reviewers

@bparker06 @orbea @fr500