### PR TITLE
cli: Only print verbose output when '--verbose' is used.

### DIFF
--- a/verbosity.c
+++ b/verbosity.c
@@ -65,11 +65,7 @@
  * will write to this file. */
 static FILE *log_file_fp         = NULL;
 static void* log_file_buf        = NULL;
-#if _DEBUG
-static bool main_verbosity       = true;
-#else
 static bool main_verbosity       = false;
-#endif
 static bool log_file_initialized = false;
 
 #ifdef NXLINK


### PR DESCRIPTION
## Description

An extra debugging `#if` was committed in PR https://github.com/libretro/RetroArch/pull/7834 accidentally, this removes it.

This however highlights the related issue that these logging messages are never actually printed since they happen before the cli arguments are initialized.

## Related Issues

Fixes https://github.com/libretro/RetroArch/issues/7844

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/7834

## Reviewers

@krzys-h