### PR TITLE
udev: Disable the mouse when the window has lost focus.

### DIFF
--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -225,7 +225,7 @@ static udev_input_mouse_t *udev_get_mouse(struct udev_input *udev, unsigned port
    settings_t *settings      = config_get_ptr();
    udev_input_mouse_t *mouse = NULL;
 
-   if (port >= MAX_USERS)
+   if (port >= MAX_USERS || !video_driver_cb_has_focus())
       return NULL;
 
    for (i = 0; i < udev->num_devices; ++i)


### PR DESCRIPTION
## Description

This disables the mouse when RetroArch has lost focus to prevent the user from pressing things in RetroArch with the mouse when another program has focus. This can be easily reproduced with multiple workspaces in linux. Mouse still works when RetroArch is focused.

## Related Issues

Fixes https://github.com/libretro/RetroArch/issues/5520

## Reviewers

@retro-wertz 