### PR TITLE
Buildbot: PS2 Generation

### DIFF
--- a/Makefile.ps2
+++ b/Makefile.ps2
@@ -95,8 +95,10 @@ run:
 
 debug: clean prepare all run
 
-release: clean all
+package:
 	ps2-packer $(EE_BIN) $(TARGET_RELEASE)
+
+release: clean all package
 
 #Specific file name and output per IRX Module
 $(EE_IRX_OBJ):

--- a/dist-scripts/dist-cores.sh
+++ b/dist-scripts/dist-cores.sh
@@ -18,6 +18,13 @@ cd ..
 LDFLAGS=-L. ./configure --disable-dynamic
 cd dist-scripts
 
+elif [ $PLATFORM = "ps2" ] ; then
+platform=ps2
+SALAMANDER=NO
+EXT=a
+
+mkdir -p ../pkg/${platform}/cores/
+
 elif [ $PLATFORM = "psp1" ] ; then
 platform=psp1
 SALAMANDER=yes
@@ -230,7 +237,9 @@ for f in `ls -v *_${platform}.${EXT}`; do
    fi
 
    # Do manual executable step
-   if [ $PLATFORM = "dex-ps3" ] ; then
+   if [ $PLATFORM = "ps2" ] ; then
+      make -C ../ -f Makefile.${platform} package -j3
+   elif [ $PLATFORM = "dex-ps3" ] ; then
       $MAKE_FSELF_NPDRM -c ../retroarch_${platform}.elf ../CORE.SELF
    elif [ $PLATFORM = "cex-ps3" ] ; then
       $SCETOOL_PATH $SCETOOL_FLAGS_CORE ../retroarch_${platform}.elf ../CORE.SELF
@@ -253,6 +262,8 @@ for f in `ls -v *_${platform}.${EXT}`; do
             cp -fv ../../dist/info/"${name}_libretro.info" ../pkg/${platform}/SSNE10000/USRDIR/cores/info/"${name}_libretro.info"
          fi
       fi
+   elif [ $PLATFORM = "ps2" ] ; then
+      mv -f ../retroarchps2-release.elf ../pkg/${platform}/cores/retroarchps2_${name}.elf
    elif [ $PLATFORM = "psp1" ] ; then
       mv -f ../EBOOT.PBP ../pkg/${platform}/cores/${name}_libretro.PBP
    elif [ $PLATFORM = "vita" ] ; then
@@ -288,6 +299,8 @@ for f in `ls -v *_${platform}.${EXT}`; do
    # Remove executable files
    if [ $platform = "ps3" ] ; then
       rm -f ../retroarch_${platform}.elf ../retroarch_${platform}.self ../CORE.SELF
+   elif [ $PLATFORM = "ps2" ] ; then
+      rm -f ../retroarchps2.elf
    elif [ $PLATFORM = "psp1" ] ; then
       rm -f ../retroarchpsp.elf
    elif [ $PLATFORM = "vita" ] ; then

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -1743,9 +1743,10 @@ static bool menu_init(menu_handle_t *menu_data)
 
       configuration_set_bool(settings,
             settings->bools.menu_show_start_screen, false);
-
+#if !defined(PS2) // TODO: PS2 IMPROVEMENT
       if (settings->bools.config_save_on_exit)
          command_event(CMD_EVENT_MENU_SAVE_CURRENT_CONFIG, NULL);
+#endif
    }
 
    if (      settings->bools.bundle_assets_extract_enable

--- a/verbosity.c
+++ b/verbosity.c
@@ -127,7 +127,7 @@ void retro_main_log_file_init(const char *path)
    log_file_fp          = (FILE*)fopen_utf8(path, "wb");
    log_file_initialized = true;
 
-#if !defined(PS2)
+#if !defined(PS2) // TODO: PS2 IMPROVEMENT
    /* TODO: this is only useful for a few platforms, find which and add ifdef */
    log_file_buf = calloc(1, 0x4000);
    setvbuf(log_file_fp, (char*)log_file_buf, _IOFBF, 0x4000);


### PR DESCRIPTION
## Description

This PR offer to the Buildbot the possibility to generate PS2 elfs.
If you notice there are a couple of `TODO` this is needed in order to make RetroArch works for `PS2`, the idea is to be fixed in a near future, but in order to proceed with the generation of the executables is a needed step for now.

There is an additional PR created for libretro-super
https://github.com/libretro/libretro-super/pull/921

Thanks