### PR TITLE
WII: Fix .cfg not found with loaders + compiling with external libogc

### DIFF
--- a/Makefile.griffin
+++ b/Makefile.griffin
@@ -158,8 +158,6 @@ else ifeq ($(libogc_platform), 1)
       endif
    endif
 
-   LIBS += -logc
-
    ifeq ($(EXTERNAL_LIBOGC), 1)
       LIBS += -lfat
    endif
@@ -175,6 +173,8 @@ else ifeq ($(libogc_platform), 1)
         LIBS += -lbba
       endif
    endif
+
+   LIBS += -logc
 
    CFLAGS += -DGEKKO -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
 

--- a/Makefile.wii.salamander
+++ b/Makefile.wii.salamander
@@ -42,11 +42,12 @@ endif
 MACHDEP := -DGEKKO -DHW_RVL -mrvl -mcpu=750 -meabi -mhard-float
 CFLAGS += -Wall -std=gnu99 $(MACHDEP) $(INCLUDE)
 LDFLAGS := $(MACHDEP) -Wl,-Map,$(notdir $(ELF_TARGET)).map
-LIBS := -lwiiuse -logc -lbte
 
 ifeq ($(EXTERNAL_LIBOGC), 1)
-LIBS += -lfat
+LIBS := -lfat
 endif
+
+LIBS += -lwiiuse -logc -lbte
 
 APP_BOOTER_DIR = wii/app_booter
 

--- a/frontend/drivers/platform_gx.c
+++ b/frontend/drivers/platform_gx.c
@@ -209,7 +209,21 @@ static void frontend_gx_get_environment_settings(
    chdir("carda:/retroarch");
 #endif
    getcwd(g_defaults.dirs[DEFAULT_DIR_CORE], PATH_MAX_LENGTH);
-
+#if defined(HW_RVL) && !defined(IS_SALAMANDER)
+   /* When using external loaders(Wiiflow etc.), getcwd doesn't return the path correctly and
+    * as a result the cfg file is not found. */
+   if (*argc > 2 && argv[1] != NULL && argv[2] != NULL)
+   {
+      if(gx_devices[GX_DEVICE_SD].mounted)
+      {
+         chdir("sd:/");
+      }
+      else if(gx_devices[GX_DEVICE_USB].mounted)
+      {
+         chdir("usb:/");
+      }
+   }
+#endif
    last_slash = strrchr(g_defaults.dirs[DEFAULT_DIR_CORE], '/');
    if (last_slash)
       *last_slash = 0;


### PR DESCRIPTION
## Description

The .cfg file is ignored when using Retroarch as a plugin with other loaders like WiiFlow etc...
It's because getcwd is not returning the path correctly. It seems related to the most recent Devkit.
Morevover, when compiling with libogc the order of the libs matters. -logc must be the last one.