### PR TITLE
FreeBSD build fixes for Wayland and udev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ DEFINES += -DGLOBAL_CONFIG_DIR='"$(GLOBAL_CONFIG_DIR)"'
 ifneq ($(findstring BSD,$(OS)),)
    CFLAGS += -DBSD
    LDFLAGS += -L/usr/local/lib
+   UDEV_CFLAGS += -I/usr/local/include/libepoll-shim
+   UDEV_LIBS += -lepoll-shim
 endif
 
 ifneq ($(findstring DOS,$(OS)),)

--- a/gfx/common/wayland/generate_wayland_protos.sh
+++ b/gfx/common/wayland/generate_wayland_protos.sh
@@ -3,6 +3,11 @@ WAYSCAN=/usr/bin/wayland-scanner
 WAYLAND_PROTOS=/usr/share/wayland-protocols
 OUTPUT=gfx/common/wayland
 
+if [ ! -d $WAYLAND_PROTOS ]; then
+    WAYSCAN=/usr/local/bin/wayland-scanner
+    WAYLAND_PROTOS=/usr/local/share/wayland-protocols
+fi
+
 if [ ! -d $OUTPUT ]; then
     mkdir $OUTPUT
 fi

--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -14,7 +14,8 @@
  *  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* TODO/FIXME - set this once the kqueue codepath is implemented and working properly */
+/* TODO/FIXME - set this once the kqueue codepath is implemented and working properly,
+ * also remove libepoll-shim from the Makefile when that happens. */
 #if 1
 #define HAVE_EPOLL
 #else
@@ -46,7 +47,9 @@
 #include <sys/poll.h>
 
 #include <libudev.h>
+#ifdef __linux__
 #include <linux/types.h>
+#endif
 #include <linux/input.h>
 #include <linux/kd.h>
 
@@ -1204,7 +1207,9 @@ static void *udev_input_init(const char *joypad_driver)
    udev->joypad = input_joypad_init_driver(joypad_driver, udev);
    input_keymaps_init_keyboard_lut(rarch_key_map_linux);
 
+#ifdef __linux__
    linux_terminal_disable_input();
+#endif
 
 #ifndef HAVE_X11
    RARCH_WARN("[udev]: Full-screen pointer won't be available.\n");
@@ -1299,7 +1304,11 @@ input_driver_t input_udev = {
    udev_input_get_capabilities,
    "udev",
    udev_input_grab_mouse,
+#ifdef __linux__
    linux_terminal_grab_stdin,
+#else
+   NULL,
+#endif
    udev_input_set_rumble,
    udev_input_get_joypad_driver,
    NULL,

--- a/input/drivers_joypad/udev_joypad.c
+++ b/input/drivers_joypad/udev_joypad.c
@@ -25,7 +25,9 @@
 #include <sys/stat.h>
 #include <sys/poll.h>
 #include <libudev.h>
+#ifdef __linux__
 #include <linux/types.h>
+#endif
 #include <linux/input.h>
 
 #include <retro_inline.h>

--- a/input/input_keymaps.c
+++ b/input/input_keymaps.c
@@ -44,7 +44,7 @@
 #include "SDL.h"
 #endif
 
-#ifdef __linux__
+#if defined(__linux__) || defined(HAVE_WAYLAND)
 #include <linux/input.h>
 #include <linux/kd.h>
 #endif
@@ -848,7 +848,7 @@ const struct rarch_key_map rarch_key_map_x11[] = {
 };
 #endif
 
-#ifdef __linux__
+#if defined(__linux__) || defined(HAVE_WAYLAND)
 const struct rarch_key_map rarch_key_map_linux[] = {
    { KEY_BACKSPACE, RETROK_BACKSPACE },
    { KEY_TAB, RETROK_TAB },


### PR DESCRIPTION
- `/usr/local/bin/wayland-scanner` / protocols
- `input_keymaps.c` ifdefs — necessary for Wayland
- `udev`. it compiles and seems to work, but we don't yet have actual evdev gamepad drivers. I think there are some userspace (`uinput`) ones though…