### PR TITLE
Fix path problems after b201d669b5ea1470bb239036aa944342a0591a95, again

### DIFF
--- a/libretro-common/file/file_path.c
+++ b/libretro-common/file/file_path.c
@@ -1028,7 +1028,16 @@ void fill_pathname_expand_special(char *out_path,
          out_path  += src_size;
          size      -= src_size;
 
-         in_path++;
+         if (!path_char_is_slash(out_path[-1]))
+         {
+            src_size = strlcpy(out_path, path_default_slash(), size);
+            retro_assert(src_size < size);
+
+            out_path += src_size;
+            size -= src_size;
+         }
+
+         in_path += 2;
       }
 
       free(home_dir);
@@ -1050,7 +1059,16 @@ void fill_pathname_expand_special(char *out_path,
          out_path  += src_size;
          size      -= src_size;
 
-         in_path++;
+         if (!path_char_is_slash(out_path[-1]))
+         {
+            src_size = strlcpy(out_path, path_default_slash(), size);
+            retro_assert(src_size < size);
+
+            out_path += src_size;
+            size -= src_size;
+         }
+
+         in_path += 2;
       }
 
       free(application_dir);


### PR DESCRIPTION
## Description

My previous patch sometimes generated double slashes. All of these
problems are because the original version of this function assumed that
the app path always ends with a slash and the home path never does,
which is not true on UWP... (they both have a slash)

## Related Issues

#7836
#7837

## Reviewers

@bparker06