### PR TITLE
sdl: Flush the joypad events.

### DIFF
--- a/input/drivers_joypad/sdl_joypad.c
+++ b/input/drivers_joypad/sdl_joypad.c
@@ -399,6 +399,8 @@ static void sdl_joypad_poll(void)
             break;
       }
    }
+
+   SDL_FlushEvents(SDL_JOYAXISMOTION, SDL_CONTROLLERDEVICEREMAPPED);
 #else
    SDL_JoystickUpdate();
 #endif


### PR DESCRIPTION
## Description

Note: Fix is from issue https://github.com/libretro/RetroArch/issues/7868.

Decreases cpu usage over time with the SDL joypad driver.

## Related Issues

> Bastien found a fix to the issue
"The lag after 10-15 minutes issue appears to be a bug in the sdl2 input driver in RetroArch. RetroArch never clears the SDL event queue. After a while it is so large it takes a significant time to traverse."

Fixes https://github.com/libretro/RetroArch/issues/7868