### PR TITLE
DO NOT MERGE - libnx: implement swkbd for menu drivers

### DIFF
--- a/menu/widgets/menu_input_dialog.c
+++ b/menu/widgets/menu_input_dialog.c
@@ -21,6 +21,11 @@
 #include "../menu_driver.h"
 #include "../../input/input_driver.h"
 
+#ifdef HAVE_LIBNX
+#include <switch.h>
+#include "menu_osk.h"
+#endif
+
 static const char **menu_input_dialog_keyboard_buffer      = {NULL};
 static bool menu_input_dialog_keyboard_display             = false;
 static unsigned menu_input_dialog_keyboard_type            = 0;
@@ -84,8 +89,58 @@ unsigned menu_input_dialog_get_kb_idx(void)
    return menu_input_dialog_keyboard_idx;
 }
 
+#ifdef HAVE_LIBNX
+#define LIBNX_SWKBD_LIMIT 500 /* enforced by HOS */
+#endif
+
 bool menu_input_dialog_get_display_kb(void)
 {
+#ifdef HAVE_LIBNX
+   if (!menu_input_dialog_keyboard_display)
+      return false;
+
+   SwkbdConfig kbd;
+
+   Result rc = swkbdCreate(&kbd, 0);
+
+   if (R_SUCCEEDED(rc))
+   {
+      char buf[LIBNX_SWKBD_LIMIT] = {'\0'};
+      swkbdConfigMakePresetDefault(&kbd);
+
+      swkbdConfigSetGuideText(&kbd, menu_input_dialog_keyboard_label);
+
+      rc = swkbdShow(&kbd, buf, sizeof(buf));
+
+      swkbdClose(&kbd);
+
+      /* RetroArch uses key-by-key input
+         so we need to simulate it */
+      for (int i = 0; i < LIBNX_SWKBD_LIMIT; i++)
+      {
+         /* In case a previous "Enter" press closed the keyboard */
+         if (!menu_input_dialog_keyboard_display)
+            break;
+
+         if (buf[i] == '\n' || buf[i] == '\0')
+            input_keyboard_event(true, '\n', '\n', 0, RETRO_DEVICE_KEYBOARD);
+         else
+         {
+            /* input_keyboard_line_append expects a null-terminated
+               string, so just make one (yes, the touch keyboard is
+               a list of null-terminated characters) */
+            char oldchar = buf[i+1];
+            buf[i+1] = '\0';
+            input_keyboard_line_append(&buf[i]);
+            buf[i+1] = oldchar;
+         }
+      }
+
+      return false;
+   }
+   else
+      return menu_input_dialog_keyboard_display;
+#endif
    return menu_input_dialog_keyboard_display;
 }
 


### PR DESCRIPTION
**DO NOT MERGE - this requires libnx 2.0 which has potentially breaking changes to the OpenGL code**

This replaces the RetroArch on screen keyboard by the native HOS keyboard for menu input.

Here is what it looks like : https://twitter.com/natinusala/status/1080485002889101317