### PR TITLE
libretro-common: Sort config file conditionally.

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -2275,7 +2275,7 @@ static config_file_t *open_default_config_file(void)
          fill_pathname_resolve_relative(conf_path, app_path,
                file_path_str(FILE_PATH_MAIN_CONFIG), path_size);
          config_set_bool(conf, "config_save_on_exit", true);
-         saved = config_file_write(conf, conf_path);
+         saved = config_file_write(conf, conf_path, true);
       }
 
       if (!saved)
@@ -2311,7 +2311,7 @@ static config_file_t *open_default_config_file(void)
       if (conf)
       {
          config_set_bool(conf, "config_save_on_exit", true);
-         saved = config_file_write(conf, conf_path);
+         saved = config_file_write(conf, conf_path, true);
       }
 
       if (!saved)
@@ -2386,7 +2386,7 @@ static config_file_t *open_default_config_file(void)
          {
             /* Since this is a clean config file, we can safely use config_save_on_exit. */
             config_set_bool(conf, "config_save_on_exit", true);
-            saved = config_file_write(conf, conf_path);
+            saved = config_file_write(conf, conf_path, true);
          }
 
          if (!saved)
@@ -4046,7 +4046,7 @@ static bool config_save_keybinds_file(const char *path)
    for (i = 0; i < MAX_USERS; i++)
       save_keybinds_user(conf, i);
 
-   ret = config_file_write(conf, path);
+   ret = config_file_write(conf, path, true);
    config_file_free(conf);
    return ret;
 }
@@ -4155,7 +4155,7 @@ bool config_save_autoconf_profile(const char *path, unsigned user)
             &input_config_binds[user][i], false, false);
    }
 
-   ret = config_file_write(conf, autoconf_file);
+   ret = config_file_write(conf, autoconf_file, false);
 
    config_file_free(conf);
    free(buf);
@@ -4405,7 +4405,7 @@ bool config_save_file(const char *path)
    for (i = 0; i < MAX_USERS; i++)
       save_keybinds_user(conf, i);
 
-   ret = config_file_write(conf, path);
+   ret = config_file_write(conf, path, true);
    config_file_free(conf);
 
    return ret;
@@ -4677,17 +4677,17 @@ bool config_save_overrides(int override_type)
          case OVERRIDE_CORE:
             /* Create a new config file from core_path */
             RARCH_LOG ("[overrides] path %s\n", core_path);
-            ret = config_file_write(conf, core_path);
+            ret = config_file_write(conf, core_path, true);
             break;
          case OVERRIDE_GAME:
             /* Create a new config file from core_path */
             RARCH_LOG ("[overrides] path %s\n", game_path);
-            ret = config_file_write(conf, game_path);
+            ret = config_file_write(conf, game_path, true);
             break;
          case OVERRIDE_CONTENT_DIR:
             /* Create a new config file from content_path */
             RARCH_LOG ("[overrides] path %s\n", content_path);
-            ret = config_file_write(conf, content_path);
+            ret = config_file_write(conf, content_path, true);
             break;
          default:
             break;

--- a/frontend/frontend_salamander.c
+++ b/frontend/frontend_salamander.c
@@ -162,7 +162,7 @@ static void salamander_init(char *s, size_t len)
       if (conf)
       {
          config_set_string(conf, "libretro_path", s);
-         config_file_write(conf, g_defaults.path.config);
+         config_file_write(conf, g_defaults.path.config, true);
          config_file_free(conf);
       }
    }

--- a/input/input_remapping.c
+++ b/input/input_remapping.c
@@ -245,7 +245,7 @@ bool input_remapping_save_file(const char *path)
       config_set_int(conf, s1, settings->uints.input_analog_dpad_mode[i]);
    }
 
-   ret = config_file_write(conf, remap_file);
+   ret = config_file_write(conf, remap_file, true);
    config_file_free(conf);
 
    free(remap_file);

--- a/libretro-common/file/config_file.c
+++ b/libretro-common/file/config_file.c
@@ -976,7 +976,7 @@ void config_set_bool(config_file_t *conf, const char *key, bool val)
    config_set_string(conf, key, val ? "true" : "false");
 }
 
-bool config_file_write(config_file_t *conf, const char *path)
+bool config_file_write(config_file_t *conf, const char *path, bool sort)
 {
    if (!string_is_empty(path))
    {
@@ -991,19 +991,19 @@ bool config_file_write(config_file_t *conf, const char *path)
       setvbuf(file, (char*)buf, _IOFBF, 0x4000);
 #endif
 
-      config_file_dump(conf, file);
+      config_file_dump(conf, file, sort);
 
       if (file != stdout)
          fclose(file);
       free(buf);
    }
    else
-      config_file_dump(conf, stdout);
+      config_file_dump(conf, stdout, sort);
 
    return true;
 }
 
-void config_file_dump(config_file_t *conf, FILE *file)
+void config_file_dump(config_file_t *conf, FILE *file, bool sort)
 {
    struct config_entry_list       *list = NULL;
    struct config_include_list *includes = conf->includes;
@@ -1014,7 +1014,11 @@ void config_file_dump(config_file_t *conf, FILE *file)
       includes = includes->next;
    }
 
-   list = merge_sort_linked_list((struct config_entry_list*)conf->entries, config_sort_compare_func);
+   if (sort)
+      list = merge_sort_linked_list((struct config_entry_list*)conf->entries, config_sort_compare_func);
+   else
+      list = (struct config_entry_list*)conf->entries;
+
    conf->entries = list;
 
    while (list)

--- a/libretro-common/include/file/config_file.h
+++ b/libretro-common/include/file/config_file.h
@@ -20,7 +20,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-
 #ifndef __LIBRETRO_SDK_CONFIG_FILE_H
 #define __LIBRETRO_SDK_CONFIG_FILE_H
 
@@ -63,7 +62,6 @@ struct config_file
 
    struct config_include_list *includes;
 };
-
 
 typedef struct config_file config_file_t;
 
@@ -181,15 +179,14 @@ void config_set_bool(config_file_t *conf, const char *entry, bool val);
 void config_set_uint(config_file_t *conf, const char *key, unsigned int val);
 
 /* Write the current config to a file. */
-bool config_file_write(config_file_t *conf, const char *path);
+bool config_file_write(config_file_t *conf, const char *path, bool val);
 
 /* Dump the current config to an already opened file.
  * Does not close the file. */
-void config_file_dump(config_file_t *conf, FILE *file);
+void config_file_dump(config_file_t *conf, FILE *file, bool val);
 
 bool config_file_exists(const char *path);
 
 RETRO_END_DECLS
 
 #endif
-

--- a/managers/cheat_manager.c
+++ b/managers/cheat_manager.c
@@ -52,7 +52,6 @@
 #include "../input/input_driver.h"
 #include "../configuration.h"
 
-
 unsigned cheat_manager_get_buf_size(void)
 {
    return cheat_manager_state.buf_size;
@@ -227,7 +226,7 @@ bool cheat_manager_save(const char *path, const char *cheat_database, bool overw
 
    }
 
-   ret = config_file_write(conf, cheats_file);
+   ret = config_file_write(conf, cheats_file, true);
    config_file_free(conf);
 
    return ret;

--- a/managers/core_option_manager.c
+++ b/managers/core_option_manager.c
@@ -253,7 +253,7 @@ bool core_option_manager_flush(core_option_manager_t *opt)
    }
 
    RARCH_LOG("Saved core options file to \"%s\"\n", opt->conf_path);
-   return config_file_write(opt->conf, opt->conf_path);
+   return config_file_write(opt->conf, opt->conf_path, true);
 }
 
 /**
@@ -279,7 +279,7 @@ bool core_option_manager_flush_game_specific(
                core_option_manager_get_val(opt, i));
 }
 
-   return config_file_write(opt->conf, path);
+   return config_file_write(opt->conf, path, true);
 }
 
 /**

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -3661,7 +3661,7 @@ static int action_ok_option_create(const char *path,
          return false;
    }
 
-   if (config_file_write(conf, game_path))
+   if (config_file_write(conf, game_path, true))
    {
       runloop_msg_queue_push(
             msg_hash_to_str(MSG_CORE_OPTIONS_FILE_CREATED_SUCCESSFULLY),

--- a/menu/menu_shader.c
+++ b/menu/menu_shader.c
@@ -341,7 +341,7 @@ bool menu_shader_manager_save_preset(
       if (!string_is_empty(basename))
          strlcpy(preset_path, buffer, sizeof(preset_path));
 
-      if (config_file_write(conf, preset_path))
+      if (config_file_write(conf, preset_path, true))
       {
          RARCH_LOG("Saved shader preset to %s.\n", preset_path);
          if (apply)
@@ -361,7 +361,7 @@ bool menu_shader_manager_save_preset(
          fill_pathname_join(preset_path, dirs[d],
                buffer, sizeof(preset_path));
 
-         if (config_file_write(conf, preset_path))
+         if (config_file_write(conf, preset_path, true))
          {
             RARCH_LOG("Saved shader preset to %s.\n", preset_path);
             if (apply)

--- a/ui/drivers/qt/coreoptionsdialog.cpp
+++ b/ui/drivers/qt/coreoptionsdialog.cpp
@@ -139,7 +139,7 @@ void CoreOptionsDialog::onSaveGameSpecificOptions()
       }
    }
 
-   if (config_file_write(conf, game_path))
+   if (config_file_write(conf, game_path, true))
    {
       runloop_msg_queue_push(
             msg_hash_to_str(MSG_CORE_OPTIONS_FILE_CREATED_SUCCESSFULLY),


### PR DESCRIPTION
## Description

Note: I think only RetroArch is using this so it should be safe to change?

This allows optionally sorting configure files and is needed to fix the order of inputs in the autoconfig profiles which should not be sorted alphabetically.

## Related Issues

Fixes https://github.com/libretro/RetroArch/issues/7873.

## Related Pull Requests

Issue introduced in https://github.com/libretro/RetroArch/pull/6998.

## Reviewers

@bparker06 and @twinaphex 
