### PR TITLE
Different (more intuitive?) default netplay share policy

### DIFF
--- a/network/netplay/README
+++ b/network/netplay/README
@@ -247,10 +247,15 @@ Payload:
 Description:
     Request to enter player mode. The client must wait for a MODE command
     before sending input. Server may refuse or force slave connections, so the
-    request is not necessarily honored. If no devices are explicitly requested,
-    the server may choose how to assign; the default is to assign the first
-    unassigned device, and share the first device if all devices are assigned
-    and the first device is shareable.
+    request is not necessarily honored. The server may choose to override the
+    share mode, and if no devices are explicitly requested, the server may
+    choose how to assign. The default handling of the share mode is to always
+    accept it if the client is the first to get the device. If the share mode
+    requested is don't-care, then a default share mode is chosen. The default
+    device selection depends on the number of devices available:  If there is
+    only one device, then the default is to share that device. If there are
+    more than one, then the default is to refuse PLAY requests when all are
+    assigned.
 
 Command: MODE
 Payload:

--- a/network/netplay/netplay_io.c
+++ b/network/netplay/netplay_io.c
@@ -806,16 +806,16 @@ static void handle_play_spectate(netplay_t *netplay, uint32_t client_num,
                if (!netplay->device_clients[device])
                   break;
             }
-            if (device >= MAX_INPUT_DEVICES && share_mode)
+            if (device >= MAX_INPUT_DEVICES &&
+                netplay->config_devices[1] == RETRO_DEVICE_NONE && share_mode)
             {
-               /* No device was totally free, maybe one is shareable? */
-               for (device = 0; device < MAX_INPUT_DEVICES; device++)
+               /* No device free and no device specifically asked for, but only
+                * one device, so share it */
+               if (netplay->device_share_modes[0])
                {
-                  if (netplay->device_clients[device] && netplay->device_share_modes[device])
-                  {
-                     share_mode = netplay->device_share_modes[device];
-                     break;
-                  }
+                  device = 0;
+                  share_mode = netplay->device_share_modes[0];
+                  break;
                }
             }
             if (device >= MAX_INPUT_DEVICES)


### PR DESCRIPTION
The previous default policy in netplay for sharing was to always share.
This appears to be causing more confusion than anything else, mainly
because the UI is terrible. The UI is a different problem, but for now,
I've changed the share policy: If you netplay with only one input
configured, it will share; if you netplay with multiple inputs, and
don't explicitly ask to share one, each device will get one client.


## Related Issues

Possibly #6287 
