### PR TITLE
(RGUI) Fix colours for PSP and GEKKO builds

### DIFF
--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -94,6 +94,19 @@ static uint16_t argb32_to_abgr1555(uint32_t col)
 
 #define argb32_to_pixel_platform_format(color) argb32_to_abgr1555(color)
 
+#elif defined(PSP) || defined(GEKKO)
+
+static uint16_t argb32_to_abgr4444(uint32_t col)
+{
+   unsigned a = ((col >> 24) & 0xff) >> 4;
+   unsigned r = ((col >> 16) & 0xff) >> 4;
+   unsigned g = ((col >> 8)  & 0xff) >> 4;
+   unsigned b = ((col & 0xff)      ) >> 4;
+   return (a << 12) | (b << 8) | (g << 4) | r;
+}
+
+#define argb32_to_pixel_platform_format(color) argb32_to_abgr4444(color)
+
 #else
 
 static uint16_t argb32_to_rgba4444(uint32_t col)


### PR DESCRIPTION
## Description

This PR should fix RGUI colours for the PSP and GEKKO builds (this is a required addendum to PR #7886).

Note that I've only been able to test the PSP build (via PPSSPP), but the GEKKO platforms *should* use the same pixel format (it would be great if someone with a hacked Wii could test this!).

Note also that in the original rgui.c code (before PR #7779), it seems that the PSP and GEKKO builds were configured assuming a pixel format of `ABGR3444`. I can't see any reason for this. `ABGR4444` works correctly on the PSP, at least.

## Related Pull Requests

Please refer to PR #7886
