### PR TITLE
Makefile.orbis: Fix makefile.

### DIFF
--- a/Makefile.orbis
+++ b/Makefile.orbis
@@ -55,6 +55,7 @@ else
 	endif
 
 	include Makefile.common
+	CFLAGS += $(DEF_FLAGS)
 	BLACKLIST :=
 	OBJ := $(filter-out $(BLACKLIST),$(OBJ))
 


### PR DESCRIPTION
## Description

A fix for Makefile.orbis which didn't exist until after PR https://github.com/libretro/RetroArch/pull/7772 was made and I unfortunately missed it until now.