### PR TITLE
Remove duplicate command.h includes.

### DIFF
--- a/dirs.c
+++ b/dirs.c
@@ -25,7 +25,6 @@
 #include "dirs.h"
 #include "command.h"
 #include "configuration.h"
-#include "command.h"
 #include "defaults.h"
 #include "list_special.h"
 #include "file_path_special.h"

--- a/retroarch.c
+++ b/retroarch.c
@@ -58,10 +58,6 @@
 #include "config.h"
 #endif
 
-#ifdef HAVE_COMMAND
-#include "command.h"
-#endif
-
 #ifdef HAVE_MENU
 #include "menu/menu_driver.h"
 #include "menu/menu_input.h"
@@ -90,6 +86,7 @@
 #endif
 
 #include "autosave.h"
+#include "command.h"
 #include "config.features.h"
 #include "content.h"
 #include "core_type.h"
@@ -122,8 +119,6 @@
 #include "version_git.h"
 
 #include "retroarch.h"
-
-#include "command.h"
 
 #ifdef HAVE_RUNAHEAD
 #include "runahead/run_ahead.h"


### PR DESCRIPTION
## Description

Minor cleanup, these files have included `command.h` twice.
