### PR TITLE
qb: Fix '--disable-rgui'.

### DIFF
--- a/driver.c
+++ b/driver.c
@@ -35,6 +35,7 @@
 #include "wifi/wifi_driver.h"
 #include "led/led_driver.h"
 #include "midi/midi_driver.h"
+#include "command.h"
 #include "configuration.h"
 #include "core_info.h"
 #include "driver.h"

--- a/libretro-common/file/file_path.c
+++ b/libretro-common/file/file_path.c
@@ -961,7 +961,8 @@ void fill_pathname_join_delim(char *out_path, const char *dir,
    out_path[copied]   = delim;
    out_path[copied+1] = '\0';
 
-   strlcat(out_path, path, size);
+   if (path)
+      strlcat(out_path, path, size);
 }
 
 void fill_pathname_join_delim_concat(char *out_path, const char *dir,

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -569,7 +569,8 @@ if [ "$HAVE_MATERIALUI" != 'no' ] || [ "$HAVE_XMB" != 'no' ] || [ "$HAVE_ZARCH" 
       HAVE_STRIPES=no
       HAVE_ZARCH=no
       HAVE_OZONE=no
-      die : 'Notice: RGUI not available, MaterialUI, XMB, Ozone and ZARCH will also be disabled.'
+      HAVE_QT=no
+      die : 'Notice: RGUI not available, other menus will also be disabled.'
    elif [ "$HAVE_OPENGL" = 'no' ] && [ "$HAVE_OPENGLES" = 'no' ] && [ "$HAVE_VULKAN" = 'no' ]; then
       if [ "$OS" = 'Win32' ]; then
          HAVE_SHADERPIPELINE=no


### PR DESCRIPTION
## Description

This fixes `./configure --disable-rgui`.

Note:
* I tested this with both parallel-n64 and nestopia without issues.
* I tested a normal compile without issues.
* This will disable all menus including qt, I suppose this might be possible to improve in followup PRs.
* Since the menus are disabled the menu button does nothing.

## Related Issues

Fixes https://github.com/libretro/RetroArch/issues/7893

Also fixes a crash on startup with `--disable-rgui`.
```
Thread 1 "retroarch" received signal SIGSEGV, Segmentation fault.
0x0000000000529f52 in strlcpy_retro__ (dest=0x7fffffffbb17 "treaming_toggle",
    source=0x1 <error: Cannot access memory at address 0x1>, size=250)
    at libretro-common/compat/compat_strl.c:38
38	      while (--n && (*dest++ = *source++)) src_size++;
(gdb) bt
    dest=0x7fffffffbb17 "treaming_toggle",
    source=0x1 <error: Cannot access memory at address 0x1>, size=250)
    at libretro-common/compat/compat_strl.c:38
    size=250) at libretro-common/compat/compat_strl.c:60
    out_path=0x7fffffffbb10 "input_", dir=0x94b460 "input", path=0x0,
    delim=95 '_', size=256) at libretro-common/file/file_path.c:964
    prefix=0x94b460 "input", btn=0x0, bind=0x151e180 <input_autoconf_binds+4672>)
    at input/input_driver.c:2483
    binds=0x151cf40 <input_autoconf_binds>) at tasks/task_autodetect.c:172
    params=0x26adb40, task=0x26b74f0) at tasks/task_autodetect.c:252
    params=0x26adb40, task=0x26b74f0) at tasks/task_autodetect.c:393
    at tasks/task_autodetect.c:851
    at libretro-common/queues/task_queue.c:182
    at libretro-common/queues/task_queue.c:609
    at frontend/frontend.c:146
    at frontend/frontend.c:170
```