### PR TITLE
(UWP) Minor fixes

### DIFF
--- a/gfx/drivers_font_renderer/stb_unicode.c
+++ b/gfx/drivers_font_renderer/stb_unicode.c
@@ -262,7 +262,7 @@ static const char *font_renderer_stb_unicode_get_default_font(void)
    return "";
 #else
    static const char *paths[] = {
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(__WINRT__)
       "C:\\Windows\\Fonts\\consola.ttf",
       "C:\\Windows\\Fonts\\verdana.ttf",
 #elif defined(__APPLE__)
@@ -283,7 +283,7 @@ static const char *font_renderer_stb_unicode_get_default_font(void)
       "vs0:data/external/font/pvf/k006004ds.ttf",
       "vs0:data/external/font/pvf/n023055ms.ttf",
       "vs0:data/external/font/pvf/n023055ts.ttf",
-#else
+#elif !defined(__WINRT__)
       "/usr/share/fonts/TTF/DejaVuSansMono.ttf",
       "/usr/share/fonts/TTF/DejaVuSans.ttf",
       "/usr/share/fonts/truetype/ttf-dejavu/DejaVuSansMono.ttf",

--- a/libretro-common/file/nbio/nbio_intf.c
+++ b/libretro-common/file/nbio/nbio_intf.c
@@ -38,7 +38,7 @@ extern nbio_intf_t nbio_stdio;
 static nbio_intf_t *internal_nbio = &nbio_linux;
 #elif defined(HAVE_MMAP) && defined(BSD)
 static nbio_intf_t *internal_nbio = &nbio_mmap_unix;
-#elif defined(_WIN32) && !defined(_XBOX) && !defined(__WINRT__)
+#elif defined(_WIN32) && !defined(_XBOX)
 static nbio_intf_t *internal_nbio = &nbio_mmap_win32;
 #else
 static nbio_intf_t *internal_nbio = &nbio_stdio;

--- a/libretro-common/file/nbio/nbio_windowsmmap.c
+++ b/libretro-common/file/nbio/nbio_windowsmmap.c
@@ -22,7 +22,7 @@
 
 #include <file/nbio.h>
 
-#if defined(_WIN32) && !defined(_XBOX) && !defined(__WINRT__)
+#if defined(_WIN32) && !defined(_XBOX)
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -69,7 +69,11 @@ static void *nbio_mmap_win32_open(const char * filename, unsigned mode)
    HANDLE file                       = CreateFile(filename, access, FILE_SHARE_ALL, NULL, dispositions[mode], FILE_ATTRIBUTE_NORMAL, NULL);
 #else
    wchar_t *filename_wide            = utf8_to_utf16_string_alloc(filename);
+#ifdef __WINRT__
+   HANDLE file                       = CreateFile2(filename_wide, access, FILE_SHARE_ALL, dispositions[mode], NULL);
+#else
    HANDLE file                       = CreateFileW(filename_wide, access, FILE_SHARE_ALL, NULL, dispositions[mode], FILE_ATTRIBUTE_NORMAL, NULL);
+#endif
 
    if (filename_wide)
       free(filename_wide);

--- a/pkg/msvc-uwp/RetroArch-msvc2017-UWP-cores-nonfree/RetroArch-msvc2017-UWP-cores-nonfree.vcxproj
+++ b/pkg/msvc-uwp/RetroArch-msvc2017-UWP-cores-nonfree/RetroArch-msvc2017-UWP-cores-nonfree.vcxproj
@@ -118,7 +118,7 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
-    <PackageCertificateKeyFile>..\msvc2017-UWP\RetroArch-msvc2017-UWP_TemporaryKey.pfx</PackageCertificateKeyFile>
+    <PackageCertificateKeyFile>..\RetroArch-msvc2017-UWP\RetroArch-UWP_TemporaryKey.pfx</PackageCertificateKeyFile>
     <GenerateAppInstallerFile>False</GenerateAppInstallerFile>
     <AppxAutoIncrementPackageRevision>False</AppxAutoIncrementPackageRevision>
     <AppxBundle>Always</AppxBundle>


### PR DESCRIPTION
## Description

A couple of minor one-line fixes I made while working on the next pull request that don't really fit with anything else

* Fix the signing certificate path for non-free cores packaging project
* Make the win32 nbio driver work on UWP (it needed a one-line fix)
* Prevent attempts to load fonts from `C:\Windows\Fonts` since they are going to fail anyway

## Reviewers

@twinaphex