### PR TITLE
Fix warning with '--disable-rgui' and '--disable-easteregg'.

### DIFF
--- a/qb/config.params.sh
+++ b/qb/config.params.sh
@@ -135,4 +135,4 @@ HAVE_OSMESA=no             # Off-screen Mesa rendering
 HAVE_VIDEOPROCESSOR=auto   # Enable video processor core
 HAVE_VIDEOCORE=auto        # Broadcom Videocore 4 support
 HAVE_DRMINGW=no            # DrMingw exception handler
-HAVE_EASTEREGG=yes
+HAVE_EASTEREGG=yes         # Easter egg

--- a/retroarch.c
+++ b/retroarch.c
@@ -2590,10 +2590,12 @@ static enum runloop_state runloop_check_state(
    bool focused                     = true;
    bool pause_nonactive             = settings->bools.pause_nonactive;
    bool fs_toggle_triggered         = false;
-   static uint64_t seq              = 0;
 #ifdef HAVE_MENU
    bool menu_driver_binding_state   = menu_driver_is_binding_state();
    bool menu_is_alive               = menu_driver_is_alive();
+#ifdef HAVE_EASTEREGG
+   static uint64_t seq              = 0;
+#endif
 #endif
 
 #ifdef HAVE_LIBNX
@@ -2908,8 +2910,9 @@ static enum runloop_state runloop_check_state(
    else
 #endif
    {
+#if defined(HAVE_MENU) && defined(HAVE_EASTEREGG)
       seq = 0;
-
+#endif
       if (runloop_idle)
          return RUNLOOP_STATE_SLEEP;
    }


### PR DESCRIPTION
## Description

Fixes an unused variable warning with either `--disable-rgui` or `--disable-easteregg`. The `seq` variable is only used if both `HAVE_MENU` and `HAVE_EASTEREGG` are defined so for now the warning can be silenced with extra conditionals even if its kind of ugly...

I also added a comment to `qb/config.params.sh` for `./configure --help`.

## Related Issues

```
Fixes:

retroarch.c: In function ‘runloop_check_state’:
retroarch.c:2593:20: warning: variable ‘seq’ set but not used [-Wunused-but-set-variable]
    static uint64_t seq              = 0;
                    ^~~
```