### PR TITLE
[discord] rewrite secret/join logic to use a queried lobby name

### DIFF
--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -640,15 +640,6 @@ static void netplay_announce_cb(void *task_data, void *user_data, const char *er
 {
    RARCH_LOG("[netplay] announcing netplay game... \n");
 
-#ifdef HAVE_DISCORD
-   if (discord_is_inited)
-   {
-      discord_userdata_t userdata;
-      userdata.status = DISCORD_PRESENCE_NETPLAY_HOSTING;
-      command_event(CMD_EVENT_DISCORD_UPDATE, &userdata);
-   }
-#endif
-
    if (task_data)
    {
       unsigned i, ip_len, port_len;
@@ -793,6 +784,15 @@ static void netplay_announce_cb(void *task_data, void *user_data, const char *er
 
          free(host_string);
       }
+
+#ifdef HAVE_DISCORD
+      if (discord_is_inited)
+      {
+         discord_userdata_t userdata;
+         userdata.status = DISCORD_PRESENCE_NETPLAY_HOSTING;
+         command_event(CMD_EVENT_DISCORD_UPDATE, &userdata);
+      }
+#endif
 
       string_list_free(lines);
       free(buf);


### PR DESCRIPTION
We were using a very long string in this format for the secret:

`255.255.255.255|65536|Super Long Game Name - Gaiden (USA).zip|000000000|Snes9x EX+ Alpha`

While this works, it would be feasible for that to overflow the discord secret making it impossible to parse and consequentially to join.

Now instead the secret is the lobby id of the hoster, so the client end gets the lobby id from discord and then proceeds to query the lobby list.

This would also make it possible to have a "discord only" option for netplay, lobbies would still be announced and published on the list but would not be shown on the GUI.