### PR TITLE
Fix segfault with null menu driver.

### DIFF
--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -2072,8 +2072,9 @@ static bool menu_driver_init_internal(bool video_is_threaded)
    if (menu_driver_data)
       return true;
 
-   menu_driver_data               = (menu_handle_t*)
-      menu_driver_ctx->init(&menu_userdata, video_is_threaded);
+   if (menu_driver_ctx->init)
+      menu_driver_data               = (menu_handle_t*)
+         menu_driver_ctx->init(&menu_userdata, video_is_threaded);
 
    if (!menu_driver_data || !menu_init(menu_driver_data))
       goto error;


### PR DESCRIPTION
## Description

Fixes a crash with `menu_driver = "null"`, it will now error safely instead.

## Related Issues

```
Thread 1 "retroarch" received signal SIGSEGV, Segmentation fault.
0x0000000000000000 in ?? ()
(gdb) bt
#0  0x0000000000000000 in ?? ()
#1  0x00000000006548b4 in menu_driver_init_internal (video_is_threaded=false)
    at menu/menu_driver.c:2076
#2  0x00000000006549ce in menu_driver_init (video_is_threaded=false)
    at menu/menu_driver.c:2106
#3  0x00000000004a729d in drivers_init (flags=1023) at driver.c:387
#4  0x000000000043bee4 in retroarch_main_init (argc=1, argv=0x7fffffffe198)
    at retroarch.c:1418
#5  0x0000000000457c5b in content_load (info=0x7fffffffe060)
    at tasks/task_content.c:281
#6  0x0000000000458ed8 in task_load_content (content_info=0x7fffffffe060, 
    content_ctx=0x7fffffffdf70, launched_from_menu=true, launched_from_cli=true, 
    error_string=0x7fffffffdf68) at tasks/task_content.c:889
#7  0x000000000045a39f in task_load_content_callback (
    content_info=0x7fffffffe060, loading_from_menu=true, loading_from_cli=true)
    at tasks/task_content.c:1571
#8  0x000000000045a54c in task_push_load_content_from_cli (core_path=0x0, 
    fullpath=0x0, content_info=0x7fffffffe060, type=CORE_TYPE_PLAIN, cb=0x0, 
    user_data=0x0) at tasks/task_content.c:1639
#9  0x0000000000437c56 in rarch_main (argc=1, argv=0x7fffffffe198, data=0x0)
    at frontend/frontend.c:125
#10 0x000000000057d79c in main (argc=1, argv=0x7fffffffe198)
    at ui/drivers/qt/ui_qt_application.cpp:182
```