### PR TITLE
qb: Improve menu check without opengl, opengles or vulkan.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -578,18 +578,20 @@ if [ "$HAVE_MENU" != 'no' ]; then
       if [ "$OS" = 'Win32' ]; then
          HAVE_SHADERPIPELINE=no
          HAVE_VULKAN=no
-         die : 'Notice: Hardware rendering context not available.'
-      elif [ "$HAVE_CACA" = 'yes' ] || [ "$HAVE_SIXEL" = 'yes' ]; then
-         die : 'Notice: Hardware rendering context not available.'
       else
+         if [ "$HAVE_CACA" != 'yes' ] && [ "$HAVE_SIXEL" != 'yes' ] &&
+            [ "$HAVE_SDL" != 'yes' ] && [ "$HAVE_SDL2" != 'yes' ]; then
+            HAVE_MENU=no
+            HAVE_RGUI=no
+         fi
          HAVE_MATERIALUI=no
          HAVE_OZONE=no
          HAVE_XMB=no
          HAVE_NUKLEAR=no
          HAVE_STRIPES=no
          HAVE_ZARCH=no
-         die : 'Notice: Hardware rendering context not available, menu drivers will also be disabled.'
       fi
+      die : 'Notice: Hardware rendering context not available.'
    fi
 fi
 


### PR DESCRIPTION
## Description

When building without `HAVE_OPENGL`, `HAVE_OPENGLES` and `HAVE_VULKAN` all the menu drivers will be disabled except rgui. Now if `HAVE_CACA`, `HAVE_SIXEL`, `HAVE_SDL` and `HAVE_SDL2` are all disabled too then all the menu drivers will also be disabled since the user won't be able to use them.

Note:
* This doesn't affect windows.
* I did not consider `xvideo` because I wasn't able to get it to work even when going back to `v1.3.6`.

## Related Pull Requests

Followup to PR https://github.com/libretro/RetroArch/pull/7910.