### PR TITLE
Attempt to fix xcode8 travis build failure.

### DIFF
--- a/led/drivers/led_null.c
+++ b/led/drivers/led_null.c
@@ -15,14 +15,13 @@
 #include "../led_driver.h"
 #include "../../verbosity.h"
 
-static void null_init(void) { }
-static void null_free(void) { }
-static void null_set(int led, int state) { }
+static void null_led_init(void) { }
+static void null_led_free(void) { }
+static void null_led_set(int led, int state) { }
 
 const led_driver_t null_led_driver = {
-   null_init,
-   null_free,
-   null_set,
+   null_led_init,
+   null_led_free,
+   null_led_set,
    "null"
 };
-


### PR DESCRIPTION
## Description

Attempts to fix xcode8 build failures with travis after commit https://github.com/libretro/RetroArch/commit/459a19be5758fbd1337554eca43199db05605816.

## Related Issues

```
In file included from /Users/travis/build/libretro/RetroArch/griffin/griffin.c:1181:
/Users/travis/build/libretro/RetroArch/griffin/../menu/menu_setting.c:1249:20: warning: comparison of unsigned expression >= 0 is always true [-Wtautological-compare]
         if (i - 1 >= 0)
             ~~~~~ ^  ~
In file included from /Users/travis/build/libretro/RetroArch/griffin/griffin.c:1214:
/Users/travis/build/libretro/RetroArch/griffin/../menu/drivers/null.c:27:14: error: conflicting types for 'null_init'
static void* null_init(void **userdata, bool video_is_threaded)
             ^
In file included from /Users/travis/build/libretro/RetroArch/griffin/griffin.c:737:
/Users/travis/build/libretro/RetroArch/griffin/../led/drivers/led_null.c:18:13: note: previous definition is here
static void null_init(void) { }
            ^
In file included from /Users/travis/build/libretro/RetroArch/griffin/griffin.c:1214:
/Users/travis/build/libretro/RetroArch/griffin/../menu/drivers/null.c:37:13: error: conflicting types for 'null_free'
static void null_free(void *data)
            ^
In file included from /Users/travis/build/libretro/RetroArch/griffin/griffin.c:737:
/Users/travis/build/libretro/RetroArch/griffin/../led/drivers/led_null.c:19:13: note: previous definition is here
static void null_free(void) { }
            ^
In file included from /Users/travis/build/libretro/RetroArch/griffin/griffin.c:1214:
/Users/travis/build/libretro/RetroArch/griffin/../menu/drivers/null.c:67:3: warning: incompatible pointer types initializing 'void *(*)(void **, bool)' with an expression of type 'void (void)' [-Wincompatible-pointer-types]
  null_init,
  ^~~~~~~~~
/Users/travis/build/libretro/RetroArch/griffin/../menu/drivers/null.c:68:3: warning: incompatible pointer types initializing 'void (*)(void *)' with an expression of type 'void (void)' [-Wincompatible-pointer-types]
  null_free,
  ^~~~~~~~~
In file included from /Users/travis/build/libretro/RetroArch/griffin/griffin.c:1284:
/Users/travis/build/libretro/RetroArch/griffin/../menu/drivers/xmb.c:5477:13: warning: unused variable 'i' [-Wunused-variable]
   unsigned i             = 0;
            ^
In file included from /Users/travis/build/libretro/RetroArch/griffin/griffin.c:1287:
/Users/travis/build/libretro/RetroArch/griffin/../menu/drivers/ozone/ozone.c:530:13: warning: unused variable 'i' [-Wunused-variable]
   unsigned i             = 0;
            ^
In file included from /Users/travis/build/libretro/RetroArch/griffin/griffin.c:1331:
/Users/travis/build/libretro/RetroArch/griffin/../runahead/secondary_core.c:54:16: warning: unused variable 'settings' [-Wunused-variable]
   settings_t *settings   = config_get_ptr();
               ^
6 warnings and 2 errors generated.
** BUILD FAILED **
```

## Reviewers

Make sure travis passes before merging.