### PR TITLE
menu: Fix quick menu toggle crash with the null menu driver.

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -2954,8 +2954,10 @@ static enum runloop_state runloop_check_state(
    /* Check menu toggle */
    {
       static bool old_pressed = false;
+      char *menu_driver       = settings->arrays.menu_driver;
       bool pressed            = BIT256_GET(
-            current_input, RARCH_MENU_TOGGLE);
+            current_input, RARCH_MENU_TOGGLE) &&
+            !string_is_equal(menu_driver, "null");
 
       if (menu_event_kb_is_set(RETROK_F1) == 1)
       {


### PR DESCRIPTION
## Description

After the recent improvements to the null menu driver if the user tries to toggle the quick menu while running content RetroArch will segfault.

This patch will disable the menu toggle button for null menu driver and will still work normally with other menu drivers.

## Related Issues

To reproduce:
1. Set `menu_driver = "null"` in `retroarch.cfg`.
2. Start content from the command line or companion ui.
3. Press `F1` or the gamepad menu button.
4. Segfault.

Fixes:
```
Thread 1 "retroarch" received signal SIGSEGV, Segmentation fault.
file_list_get_last_actiondata (list=0x1d0fa70)
    at libretro-common/lists/file_list.c:402
402        return list->list[list->size - 1].actiondata;
(gdb) bt
#0  file_list_get_last_actiondata (list=0x1d0fa70)
    at libretro-common/lists/file_list.c:402
#1  0x00000000005e0f11 in menu_entries_get_last_stack_actiondata ()
    at menu/menu_entries.c:651
#2  0x00000000005e0f7e in menu_entries_get_last_stack (path=0x7fffffffbc70, 
    label=0x7fffffffbc78, file_type=0x0, enum_idx=0x7fffffffbc64, entry_idx=0x0)
    at menu/menu_entries.c:665
#3  0x00000000006004ef in generic_action_ok_displaylist_push (path=0x968400 "", 
    new_path=0x0, label=0x968400 "", type=0, idx=0, entry_idx=0, action_type=99)
    at menu/cbs/menu_cbs_ok.c:294
#4  0x00000000005dc8de in menu_driver_iterate (iterate=0x7fffffffde60)
    at menu/menu_driver.c:1974
#5  0x0000000000418517 in runloop_check_state (settings=0x7fffefe3d010, 
    input_nonblock_state=false, sleep_ms=0x7fffffffe080) at retroarch.c:2860
#6  0x0000000000419743 in runloop_iterate (sleep_ms=0x7fffffffe080)
    at retroarch.c:3563
#7  0x0000000000412717 in rarch_main (argc=4, argv=0x7fffffffe198, data=0x0)
    at frontend/frontend.c:141
#8  0x0000000000412774 in main (argc=4, argv=0x7fffffffe198)
    at frontend/frontend.c:170
```