### PR TITLE
qb: Remove outdated checks.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -562,17 +562,6 @@ fi
 
 check_pkgconf PYTHON python3
 
-if [ "$HAVE_MATERIALUI" = no ] &&
-   [ "$HAVE_OZONE" = no ] &&
-   [ "$HAVE_RGUI" = no ] &&
-   [ "$HAVE_XMB" = no ] &&
-   [ "$HAVE_NUKLEAR" = no ] &&
-   [ "$HAVE_STRIPES" = no ] &&
-   [ "$HAVE_ZARCH" = no ]; then
-   HAVE_MENU=no
-   die : 'Notice: No menu drivers available.'
-fi
-
 if [ "$HAVE_MENU" != 'no' ]; then
    if [ "$HAVE_OPENGL" = 'no' ] && [ "$HAVE_OPENGLES" = 'no' ] && [ "$HAVE_VULKAN" = 'no' ]; then
       if [ "$OS" = 'Win32' ]; then
@@ -581,7 +570,6 @@ if [ "$HAVE_MENU" != 'no' ]; then
       else
          if [ "$HAVE_CACA" != 'yes' ] && [ "$HAVE_SIXEL" != 'yes' ] &&
             [ "$HAVE_SDL" != 'yes' ] && [ "$HAVE_SDL2" != 'yes' ]; then
-            HAVE_MENU=no
             HAVE_RGUI=no
          fi
          HAVE_MATERIALUI=no


### PR DESCRIPTION
## Description

After the improvements to the null menu driver these qb checks don't really make much sense anymore.

* If no menus are built the null menu driver will still be available while `--disable-menu` will disable all the menu drivers including the null menu driver.
* There is no reason to disable `HAVE_MENU` when there are no video drivers, the user will just get the null video driver either way where the qt companion ui will still work even its not very useful there.