### PR TITLE
Fix savestates without HAVE_MENU.

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -1395,11 +1395,11 @@ static struct config_bool_setting *populate_settings_bool(settings_t *settings, 
 #ifdef GEKKO
    SETTING_BOOL("video_vfilter",                 &settings->bools.video_vfilter, true, video_vfilter, false);
 #endif
-#ifdef HAVE_MENU
-   SETTING_BOOL("menu_unified_controls",         &settings->bools.menu_unified_controls, true, false, false);
 #ifdef HAVE_THREADS
    SETTING_BOOL("threaded_data_runloop_enable",  &settings->bools.threaded_data_runloop_enable, true, threaded_data_runloop_enable, false);
 #endif
+#ifdef HAVE_MENU
+   SETTING_BOOL("menu_unified_controls",         &settings->bools.menu_unified_controls, true, false, false);
    SETTING_BOOL("menu_throttle_framerate",       &settings->bools.menu_throttle_framerate, true, true, false);
    SETTING_BOOL("menu_linear_filter",            &settings->bools.menu_linear_filter, true, true, false);
    SETTING_BOOL("menu_horizontal_animation",     &settings->bools.menu_horizontal_animation, true, true, false);


### PR DESCRIPTION
## Description

After the `--disable-menu` path was fixed it was discovered that loading savestates was much slower when `HAVE_MENU` is not defined.

As it turns out `threaded_data_runloop_enable` is hidden behind `HAVE_MENU` in `configuration.c`, it probably shouldn't do this and moving it allows savestates to be fast again when `HAVE_THREADS` is still defined and `HAVE_MENU` is not. I haven't noticed any issues from doing this after brief testing with snes9x and parallel-n64.

## Related Issues

Fixes https://github.com/libretro/RetroArch/issues/7933