### PR TITLE
fix heap overflow with playlists

### DIFF
--- a/playlist.c
+++ b/playlist.c
@@ -119,10 +119,11 @@ void playlist_delete_index(playlist_t *playlist,
    if (!playlist)
       return;
 
+   playlist->size     = playlist->size - 1;
+
    memmove(playlist->entries + idx, playlist->entries + idx + 1,
          (playlist->size - idx) * sizeof(struct playlist_entry));
 
-   playlist->size     = playlist->size - 1;
    playlist->modified = true;
 }
 


### PR DESCRIPTION
Possibly related to #7543?

This appears to be a long-standing memory corruption bug when deleting a playlist entry.

An example that reproduces the original issue under ASAN:

- have a history playlist with exactly 100 entries (or whatever number the default size is set to?)
- delete the first entry
- crash:

```
==11463==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x621003e183c0 at pc 0x7f395257cdab bp 0x7ffef0b68440 sp 0x7ffef0b67be8
READ of size 4800 at 0x621003e183c0 thread T0
    #0 0x7f395257cdaa in __interceptor_memmove /build/gcc/src/gcc/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:720
    #1 0x55a49aa77c5c in playlist_delete_index /home/bp/RetroArch/playlist.c:122
```

Just in case I'm wrong, I wanted someone else to look at this and make sure it's right. My thinking on this is:

`memmove()` here is being used to take the memory for all the playlist entries (minus one), and move it all to the left, so that the second entry becomes the first, etc., and there is now an extra space at the end of the list. memmove takes a source, dest and size. In this case:

- source is `playlist->entries + idx + 1`, the entry right after the selected one
- dest is `playlist->entries + idx`, the location of the selected entry
- size is `(playlist->size - idx) * sizeof(struct playlist_entry)`, the number of bytes for every playlist item (including the one to delete)

In this case, it tries to move `size` entries (all 100) up one, starting at the top entry plus one. This means that it is wrongly reading one entry's worth of memory past the end of the array.

My change basically makes it read the number of entries *minus one* from the starting point and moves them up, since the idea is that we're deleting one and need to make room for it.