### PR TITLE
Fix crash with the null menu driver and Qt frontend.

### DIFF
--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -281,12 +281,14 @@ int generic_action_ok_displaylist_push(const char *path,
    enum msg_hash_enums enum_idx            = MSG_UNKNOWN;
    settings_t            *settings         = config_get_ptr();
    file_list_t           *menu_stack       = menu_entries_get_menu_stack_ptr(0);
+   char                  *menu_driver      = settings->arrays.menu_driver;
 
    menu_displaylist_info_init(&info);
 
    info.list                               = menu_stack;
 
-   if (!menu_driver_ctl(RARCH_MENU_CTL_DRIVER_DATA_GET, &menu))
+   if (!menu_driver_ctl(RARCH_MENU_CTL_DRIVER_DATA_GET, &menu) ||
+       string_is_equal(menu_driver, "null"))
       goto end;
 
    tmp[0] = '\0';


### PR DESCRIPTION
## Description

When failing to load content in the Qt companion ui while using the null menu driver RetroArch will crash.

Now it just prints that it failed to load content in the Qt ui.

## Related Issues
```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==4321==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x000000485c0d bp 0x7ffd76250290 sp 0x7ffd76250280 T0)
==4321==The signal is caused by a READ memory access.
==4321==Hint: address points to the zero page.
    #0 0x485c0c in file_list_get_last_actiondata libretro-common/lists/file_list.c:401
    #1 0x8f4391 in menu_entries_get_last_stack_actiondata menu/menu_entries.c:649
    #2 0x8f4402 in menu_entries_get_last_stack menu/menu_entries.c:663
    #3 0x931ad4 in generic_action_ok_displaylist_push menu/cbs/menu_cbs_ok.c:294
    #4 0x8e7f4f in menu_driver_iterate menu/menu_driver.c:1974
    #5 0x4459e1 in runloop_check_state /home/orbea/gittings/forks/RetroArch/retroarch.c:2858
    #6 0x447ddf in runloop_iterate /home/orbea/gittings/forks/RetroArch/retroarch.c:3562
    #7 0x675f77 in ui_application_qt_run ui/drivers/qt/ui_qt_application.cpp:158
    #8 0x43a34f in rarch_main frontend/frontend.c:157
    #9 0x67606d in main ui/drivers/qt/ui_qt_application.cpp:182
    #10 0x7f04032cac66 in __libc_start_main (/lib64/libc.so.6+0x22c66)
    #11 0x42f8c9 in _start (/media/gittings/forks/RetroArch/retroarch+0x42f8c9)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV libretro-common/lists/file_list.c:401 in file_list_get_last_actiondata
==4321==ABORTING
```

## Reviewers

@bparker06 