### PR TITLE
(RGUI) Fix background + border colours for PS2

### DIFF
--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -417,11 +417,32 @@ static uint16_t *rgui_framebuf_data      = NULL;
 
 static uint16_t argb32_to_abgr1555(uint32_t col)
 {
-   unsigned a = ((col >> 24) & 0xff) >> 7;
-   unsigned r = ((col >> 16) & 0xff) >> 3;
-   unsigned g = ((col >> 8)  & 0xff) >> 3;
-   unsigned b = ((col & 0xff)      ) >> 3;
-   return (a << 15) | (b << 10) | (g << 5) | r;
+   /* Extract colour components */
+   unsigned a = (col >> 24) & 0xff;
+   unsigned r = (col >> 16) & 0xff;
+   unsigned g = (col >> 8)  & 0xff;
+   unsigned b = col & 0xff;
+   /* Background and border colours are normally semi-transparent
+    * (so we can see suspended content when opening the quick menu).
+    * When no content is loaded, the 'image' behind the RGUI background
+    * and border is black - which has the effect of darkening the
+    * perceived background/border colours. All the preset theme (and
+    * default 'custom') colour values have been adjusted to account for
+    * this, but abgr1555 only has a 1 bit alpha channel. This means all
+    * colours become fully opaque, and consequently backgrounds/borders
+    * become abnormally bright.
+    * We therefore have to darken each RGB value according to the alpha
+    * component of the input colour... */
+   float a_factor = (float)a * (1.0 / 255.0);
+   r = (unsigned)(((float)r * a_factor) + 0.5) & 0xff;
+   g = (unsigned)(((float)g * a_factor) + 0.5) & 0xff;
+   b = (unsigned)(((float)b * a_factor) + 0.5) & 0xff;
+   /* Convert from 8 bit to 5 bit */
+   r = r >> 3;
+   g = g >> 3;
+   b = b >> 3;
+   /* Return final value - alpha always set to 1 */
+   return (1 << 15) | (b << 10) | (g << 5) | r;
 }
 
 #define argb32_to_pixel_platform_format(color) argb32_to_abgr1555(color)


### PR DESCRIPTION
## Description

RGUI colours look identical on all platforms apart from the PS2.

Basically, the menu background and border colours are meant to be semi-transparent (so you can see the current content when opening the quick menu), but PS2 uses the abgr1555 pixel format which only has a 1 bit alpha channel. This means all colours become fully opaque, and consequently backgrounds and borders are rendered far too bright. (You can see this quite clearly in the demo PS2 RetroArch pics and videos that have been posted, e.g. https://t.co/HpiHLXk8U3)

This PR just alters the PS2 pixel format conversion function so colours are automatically darkened according to their alpha value. This should ensure that colour themes are properly consistent across all platforms (and menu text on the PS2 should be easier to read, since contrast is increased).

## Reviewers

While I have tested the concept with some debugging code, I do not have the means to check that it works on real hardware...

It would therefore be great if @fjtrujy could find time to test this on a PS2, just to make sure that everything looks correct.