### PR TITLE
Fix crashes with '--disable-menu' and the Qt frontend.

### DIFF
--- a/content.h
+++ b/content.h
@@ -82,10 +82,13 @@ bool content_reset_savestate_backups(void);
 bool content_undo_load_buf_is_empty(void);
 bool content_undo_save_buf_is_empty(void);
 
-/* Clears the pending subsystem rom buffer*/
+/* Checks if launched from the commandline */
+bool content_launched_from_cli(void);
+
+/* Clears the pending subsystem rom buffer */
 bool content_is_subsystem_pending_load(void);
 
-/* Clears the pending subsystem rom buffer*/
+/* Clears the pending subsystem rom buffer */
 void content_clear_subsystem(void);
 
 /* Set the current subsystem*/

--- a/retroarch.c
+++ b/retroarch.c
@@ -1406,9 +1406,12 @@ bool retroarch_main_init(int argc, char *argv[])
    /* Handle core initialization failure */
    if (init_failed)
    {
-#ifdef HAVE_MENU
       /* Check if menu was active prior to core initialization */
-      if (menu_driver_is_alive())
+      if (!content_launched_from_cli()
+#ifdef HAVE_MENU
+          || menu_driver_is_alive()
+#endif
+         )
       {
          /* Attempt initializing dummy core */
          current_core_type = CORE_TYPE_DUMMY;
@@ -1416,7 +1419,6 @@ bool retroarch_main_init(int argc, char *argv[])
             goto error;
       }
       else
-#endif
       {
          /* Fall back to regular error handling */
          goto error;

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -138,6 +138,7 @@ struct content_information_ctx
 };
 
 static struct string_list *temporary_content                  = NULL;
+static bool _launched_from_cli                                = true;
 static bool _content_is_inited                                = false;
 static bool core_does_not_need_content                        = false;
 static uint32_t content_rom_crc                               = 0;
@@ -1603,6 +1604,8 @@ bool task_push_load_content_with_new_core_from_companion_ui(
    command_event(CMD_EVENT_LOAD_CORE, NULL);
 #endif
 
+   _launched_from_cli = false;
+
    /* Load content */
    if (!task_load_content_callback(content_info, true, false))
       return false;
@@ -1756,6 +1759,12 @@ void content_clear_subsystem(void)
          pending_subsystem_roms[i] = NULL;
       }
    }
+}
+
+/* Checks if launched from the commandline */
+bool content_launched_from_cli()
+{
+   return _launched_from_cli;
 }
 
 /* Get the current subsystem */


### PR DESCRIPTION
## Description

When failing to load content in the companion ui when `HAVE_MENU` is not defined RetroArch will crash in just about every input and video driver. Even if several sanity checks are added the dummy core will immediately exit.

Now it will print that it failed to load the core in the companion ui and reinit the dummy core to match the behavior with the null menu driver.

Here are some notes about the new behavior with this patch.

* When failing to load content from the commandline it exits immediately while printing the error.
* When failing to load content from the companion ui it will print so in the Qt frontend and reinit the dummy core allowing the user to load different content.
* Loading content from the commandline, menu or companion ui works as normal.

I tested this with `HAVE_MENU=no`, `HAVE_MENU=yes`, the null menu driver and with a regular menu driver (xmb).

## Related Issues

Avoids many crashes in the input/video drivers like the following.
```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==8753==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000018 (pc 0x0000008b18b5 bp 0x7ffc574838d0 sp 0x7ffc574838a0 T0)
==8753==The signal is caused by a READ memory access.
==8753==Hint: address points to the zero page.
    #0 0x8b18b4 in udev_is_pressed input/drivers/udev_input.c:911
    #1 0x8b20c2 in udev_input_state input/drivers/udev_input.c:973
    #2 0x5128be in input_keys_pressed input/input_driver.c:1147
    #3 0x443f15 in runloop_check_state /home/orbea/gittings/forks/RetroArch/retroarch.c:2621
    #4 0x4464c2 in runloop_iterate /home/orbea/gittings/forks/RetroArch/retroarch.c:3562
    #5 0x6548a3 in ui_application_qt_run ui/drivers/qt/ui_qt_application.cpp:158
    #6 0x43a290 in rarch_main frontend/frontend.c:157
    #7 0x654999 in main ui/drivers/qt/ui_qt_application.cpp:182
    #8 0x7fe980822c66 in __libc_start_main (/lib64/libc.so.6+0x22c66)
    #9 0x42f879 in _start (/media/gittings/forks/RetroArch/retroarch+0x42f879)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV input/drivers/udev_input.c:911 in udev_is_pressed
==8753==ABORTING
```

## Related Pull Requests

Recently fixed similar issue.
https://github.com/libretro/RetroArch/pull/7947

## Reviewers

@bparker06 