### PR TITLE
Initialize COM only once, globally

### DIFF
--- a/audio/drivers/wasapi.c
+++ b/audio/drivers/wasapi.c
@@ -589,7 +589,6 @@ static void *wasapi_init(const char *dev_id, unsigned rate, unsigned latency,
       unsigned u1, unsigned *u2)
 {
    HRESULT hr;
-   bool com_initialized      = false;
    UINT32 frame_count        = 0;
    REFERENCE_TIME dev_period = 0;
    BYTE *dest                = NULL;
@@ -600,11 +599,6 @@ static void *wasapi_init(const char *dev_id, unsigned rate, unsigned latency,
    w->exclusive              = settings->bools.audio_wasapi_exclusive_mode;
 
    WASAPI_CHECK(w, "Out of memory", return NULL);
-
-   hr = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
-   WASAPI_HR_CHECK(hr, "CoInitializeEx", goto error);
-
-   com_initialized = true;
 
    w->device = wasapi_init_device(dev_id);
    if (!w->device && dev_id)
@@ -685,8 +679,6 @@ error:
    if (w->buffer)
       fifo_free(w->buffer);
    free(w);
-   if (com_initialized)
-      CoUninitialize();
 
    return NULL;
 }
@@ -898,7 +890,6 @@ static void wasapi_free(void *wh)
       _IAudioClient_Stop(w->client);
    WASAPI_RELEASE(w->client);
    WASAPI_RELEASE(w->device);
-   CoUninitialize();
    if (w->buffer)
       fifo_free(w->buffer);
    free(w);

--- a/audio/drivers/xaudio.c
+++ b/audio/drivers/xaudio.c
@@ -201,11 +201,6 @@ static xaudio2_t *xaudio2_new(unsigned samplerate, unsigned channels,
 {
    xaudio2_t *handle = NULL;
    WAVEFORMATEX wfx  = {0};
-#if !defined(_XBOX) && !defined(__WINRT__)
-   HRESULT hr        = CoInitialize(NULL);
-   if (FAILED(hr))
-      return NULL;
-#endif
 
 #if defined(__cplusplus) && !defined(CINTERFACE)
    handle = new xaudio2;
@@ -256,9 +251,6 @@ static xaudio2_t *xaudio2_new(unsigned samplerate, unsigned channels,
 
 error:
    xaudio2_free(handle);
-#if !defined(_XBOX) && !defined(__WINRT__)
-   CoUninitialize();
-#endif
    return NULL;
 }
 
@@ -408,10 +400,6 @@ static void xa_free(void *data)
    if (xa->xa)
       xaudio2_free(xa->xa);
    free(xa);
-
-#if !defined(_XBOX) && !defined(__WINRT__)
-   CoUninitialize();
-#endif
 }
 
 static size_t xa_write_avail(void *data)

--- a/frontend/frontend.c
+++ b/frontend/frontend.c
@@ -46,6 +46,11 @@
 
 #ifndef HAVE_MAIN
 #include "../retroarch.h"
+#include "../verbosity.h"
+
+#if defined(_WIN32) && !defined(_XBOX) && !defined(__WINRT__)
+#include <objbase.h>
+#endif
 #endif
 
 /**

--- a/frontend/frontend.c
+++ b/frontend/frontend.c
@@ -109,6 +109,14 @@ int rarch_main(int argc, char *argv[], void *data)
    const ui_application_t *ui_application = NULL;
 #endif
 
+#if !defined(HAVE_MAIN) && defined(_WIN32) && !defined(_XBOX) && !defined(__WINRT__)
+   if (FAILED(CoInitialize(NULL)))
+   {
+      RARCH_ERR("FATAL: Failed to initialize the COM interface\n");
+      return 1;
+   }
+#endif
+
    rarch_ctl(RARCH_CTL_PREINIT, NULL);
    frontend_driver_init_first(args);
    rarch_ctl(RARCH_CTL_INIT, NULL);
@@ -155,6 +163,10 @@ int rarch_main(int argc, char *argv[], void *data)
 
    if (ui_application && ui_application->run)
       ui_application->run(args);
+#endif
+
+#if !defined(HAVE_MAIN) && defined(_WIN32) && !defined(_XBOX) && !defined(__WINRT__)
+   CoUninitialize();
 #endif
 
    return 0;

--- a/gfx/display_servers/dispserv_win32.c
+++ b/gfx/display_servers/dispserv_win32.c
@@ -83,12 +83,6 @@ static void* win32_display_server_init(void)
       return NULL;
 
 #ifdef HAS_TASKBAR_EXT
-   if (FAILED(CoInitialize(NULL)))
-   {
-      RARCH_ERR("COM initialization failed, ITaskbarList3 disabled\n");
-      return dispserv;
-   }
-
 #ifdef __cplusplus
    /* When compiling in C++ mode, GUIDs are references instead of pointers */
    hr = CoCreateInstance(CLSID_TaskbarList, NULL,
@@ -130,8 +124,6 @@ static void win32_display_server_destroy(void *data)
       ITaskbarList3_Release(g_taskbarList);
       g_taskbarList = NULL;
    }
-
-   CoUninitialize();
 #endif
 
    if (dispserv)

--- a/input/drivers/dinput.c
+++ b/input/drivers/dinput.c
@@ -98,20 +98,12 @@ void dinput_destroy_context(void)
 
    IDirectInput8_Release(g_dinput_ctx);
    g_dinput_ctx = NULL;
-
-   CoUninitialize();
 }
 
 bool dinput_init_context(void)
 {
    if (g_dinput_ctx)
       return true;
-
-   if (FAILED(CoInitialize(NULL)))
-   {
-      RARCH_ERR("[DINPUT]: Failed to initialize the COM interface\n");
-      return false;
-   }
 
    /* Who said we shouldn't have same call signature in a COM API? <_< */
 #ifdef __cplusplus
@@ -131,7 +123,6 @@ bool dinput_init_context(void)
 
 error:
    RARCH_ERR("[DINPUT]: Failed to initialize DirectInput.\n");
-   CoUninitialize();
    return false;
 }
 


### PR DESCRIPTION
## Description

This removes all calls to CoInitialize/CoUninitialize from drivers and instead inits/deinits only once in main(). [It is a common and recommended practice](https://stackoverflow.com/questions/2154151/coinitialize-couninitialize-calls-pairing#comment2098496_2154151) for libraries and components to require the caller to initialize COM for them instead of trying to initialize it yourself.

Also see this stackoverflow question which is the same issue we are having (but without an answer, unfortunately): https://stackoverflow.com/questions/2154151/coinitialize-couninitialize-calls-pairing

## Related Issues

#7842

## Reviewers

@bparker06 @twinaphex
