### PR TITLE
Fix issue #6747 black bug

### DIFF
--- a/gfx/drivers/d3d10.c
+++ b/gfx/drivers/d3d10.c
@@ -1579,7 +1579,7 @@ static uintptr_t d3d10_gfx_load_texture(
 
    return (uintptr_t)texture;
 }
-static void d3d10_gfx_unload_texture(void* data, uintptr_t handle)
+static void d3d10_gfx_unload_texture(void* data, uintptr_t handle, bool threaded)
 {
    d3d10_texture_t* texture = (d3d10_texture_t*)handle;
 

--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -1640,7 +1640,7 @@ static uintptr_t d3d11_gfx_load_texture(
 
    return (uintptr_t)texture;
 }
-static void d3d11_gfx_unload_texture(void* data, uintptr_t handle)
+static void d3d11_gfx_unload_texture(void* data, uintptr_t handle, bool threaded)
 {
    d3d11_texture_t* texture = (d3d11_texture_t*)handle;
 

--- a/gfx/drivers/d3d12.c
+++ b/gfx/drivers/d3d12.c
@@ -1759,7 +1759,7 @@ static uintptr_t d3d12_gfx_load_texture(
 
    return (uintptr_t)texture;
 }
-static void d3d12_gfx_unload_texture(void* data, uintptr_t handle)
+static void d3d12_gfx_unload_texture(void* data, uintptr_t handle, bool threaded)
 {
    d3d12_texture_t* texture = (d3d12_texture_t*)handle;
 

--- a/gfx/drivers/d3d8.c
+++ b/gfx/drivers/d3d8.c
@@ -1811,14 +1811,14 @@ static uintptr_t d3d8_load_texture(void *video_data, void *data,
    info.type     = filter_type;
 
    if (threaded)
-      return video_thread_texture_load(&info,
+      return video_thread_custom_cmd(&info,
             d3d8_video_texture_load_wrap_d3d);
 
    d3d8_video_texture_load_d3d(&info, &id);
    return id;
 }
 
-static void d3d8_unload_texture(void *data, uintptr_t id)
+static void d3d8_unload_texture(void *data, uintptr_t id, bool threaded)
 {
    LPDIRECT3DTEXTURE8 texid;
    if (!id)

--- a/gfx/drivers/d3d9.c
+++ b/gfx/drivers/d3d9.c
@@ -1978,14 +1978,14 @@ static uintptr_t d3d9_load_texture(void *video_data, void *data,
    info.type     = filter_type;
 
    if (threaded)
-      return video_thread_texture_load(&info,
+      return video_thread_custom_cmd(&info,
             d3d9_video_texture_load_wrap_d3d);
 
    d3d9_video_texture_load_d3d(&info, &id);
    return id;
 }
 
-static void d3d9_unload_texture(void *data, uintptr_t id)
+static void d3d9_unload_texture(void *data, uintptr_t id, bool threaded)
 {
    LPDIRECT3DTEXTURE9 texid;
    if (!id)

--- a/gfx/drivers/gdi_gfx.c
+++ b/gfx/drivers/gdi_gfx.c
@@ -578,7 +578,7 @@ static uintptr_t gdi_load_texture(void *video_data, void *data,
    return (uintptr_t)texture;
 }
 
-static void gdi_unload_texture(void *data, uintptr_t handle)
+static void gdi_unload_texture(void *data, uintptr_t handle, bool threaded)
 {
    struct gdi_texture *texture = (struct gdi_texture*)handle;
 

--- a/gfx/drivers/gl.c
+++ b/gfx/drivers/gl.c
@@ -14,7 +14,7 @@
  *  You should have received a copy of the GNU General Public License along with RetroArch.
  *  If not, see <http://www.gnu.org/licenses/>.
  */
-
+ 
 #ifdef _MSC_VER
 #pragma comment(lib, "opengl32")
 #endif
@@ -127,6 +127,7 @@ void context_bind_hw_render(void *data, bool enable)
    gl_t *gl = (gl_t*)data;
    gl_context_bind_hw_render(gl, enable);
 }
+
 
 #ifdef HAVE_OVERLAY
 static void gl_free_overlay(gl_t *gl)
@@ -245,6 +246,7 @@ static void gl_render_overlay(gl_t *gl, video_frame_info_t *video_info)
       glViewport(gl->vp.x, gl->vp.y, gl->vp.width, gl->vp.height);
 }
 #endif
+
 
 static void gl_set_projection(gl_t *gl,
       struct video_ortho *ortho, bool allow_rotate)
@@ -686,6 +688,7 @@ static void gl_set_texture_frame(void *data,
    if (!gl->menu_texture)
       glGenTextures(1, &gl->menu_texture);
 
+
    gl_load_texture_data(gl->menu_texture,
          RARCH_WRAP_EDGE, menu_filter,
          video_pixel_get_alignment(width * base_size),
@@ -936,6 +939,7 @@ static void gl_pbo_async_readback(gl_t *gl)
    if (gl->renderchain_driver->unbind_pbo)
       gl->renderchain_driver->unbind_pbo(gl, gl->renderchain_data);
 }
+
 
 static bool gl_frame(void *data, const void *frame,
       unsigned frame_width, unsigned frame_height,
@@ -1229,6 +1233,7 @@ static bool gl_frame(void *data, const void *frame,
 
    return true;
 }
+
 
 static void gl_destroy_resources(gl_t *gl)
 {
@@ -2352,6 +2357,8 @@ static bool gl_overlay_load(void *data,
    return true;
 }
 
+
+
 static void gl_overlay_enable(void *data, bool state)
 {
    gl_t *gl           = (gl_t*)data;
@@ -2388,6 +2395,7 @@ static void gl_overlay_set_alpha(void *data, unsigned image, float mod)
    color[12 + 3]  = mod;
 }
 
+
 static const video_overlay_interface_t gl_overlay_interface = {
    gl_overlay_enable,
    gl_overlay_load,
@@ -2404,6 +2412,7 @@ static void gl_get_overlay_interface(void *data,
    *iface = &gl_overlay_interface;
 }
 #endif
+
 
 static retro_proc_address_t gl_get_proc_address(void *data, const char *sym)
 {
@@ -2449,6 +2458,7 @@ static void gl_set_aspect_ratio(void *data, unsigned aspect_ratio_idx)
    gl->should_resize = true;
 }
 
+
 static void gl_apply_state_changes(void *data)
 {
    gl_t *gl = (gl_t*)data;
@@ -2456,6 +2466,7 @@ static void gl_apply_state_changes(void *data)
    if (gl)
       gl->should_resize = true;
 }
+
 
 static void gl_get_video_output_size(void *data,
       unsigned *width, unsigned *height)
@@ -2491,6 +2502,12 @@ static void video_texture_load_gl(
          );
 }
 
+static void video_texture_unload_gl(
+      uintptr_t *id)
+{
+   glDeleteTextures(1, (GLuint*)id);
+}
+
 #ifdef HAVE_THREADS
 static int video_texture_load_wrap_gl_mipmap(void *data)
 {
@@ -2513,13 +2530,20 @@ static int video_texture_load_wrap_gl(void *data)
          TEXTURE_FILTER_LINEAR, &id);
    return (int)id;
 }
+
+static int video_texture_unload_wrap_gl(void *data)
+{
+   if (!data)
+      return 0;
+   video_texture_unload_gl((uintptr_t*)data);
+   return 0;
+}
 #endif
 
 static uintptr_t gl_load_texture(void *video_data, void *data,
       bool threaded, enum texture_filter_type filter_type)
 {
    uintptr_t id = 0;
-
 #ifdef HAVE_THREADS
    if (threaded)
    {
@@ -2534,7 +2558,8 @@ static uintptr_t gl_load_texture(void *video_data, void *data,
          default:
             break;
       }
-      return video_thread_texture_load(data, func);
+      id=video_thread_custom_cmd(data, func);
+      return id;
    }
 #endif
 
@@ -2542,14 +2567,22 @@ static uintptr_t gl_load_texture(void *video_data, void *data,
    return id;
 }
 
-static void gl_unload_texture(void *data, uintptr_t id)
+static void gl_unload_texture(void *video_data, uintptr_t data, bool threaded)
 {
-   GLuint glid;
-   if (!id)
+   if (!data)
       return;
+   GLuint* glid = (GLuint*)data;
 
-   glid = (GLuint)id;
-   glDeleteTextures(1, &glid);
+#ifdef HAVE_THREADS
+   if (threaded)
+   {
+      custom_command_method_t func = video_texture_unload_wrap_gl;
+      video_thread_custom_cmd((void *)&data, func);
+      return;
+   }
+#endif
+
+   video_texture_unload_gl(&data);
 }
 
 static void gl_set_coords(void *handle_data, void *shader_data,

--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -2329,7 +2329,7 @@ static uintptr_t vulkan_load_texture(void *video_data, void *data,
    return (uintptr_t)texture;
 }
 
-static void vulkan_unload_texture(void *data, uintptr_t handle)
+static void vulkan_unload_texture(void *data, uintptr_t handle, bool threaded)
 {
    vk_t *vk                         = (vk_t*)data;
    struct vk_texture *texture       = (struct vk_texture*)handle;

--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -2715,7 +2715,7 @@ bool video_driver_texture_unload(uintptr_t *id)
    if (!video_driver_poke || !video_driver_poke->unload_texture)
       return false;
 
-   video_driver_poke->unload_texture(video_driver_data, *id);
+   video_driver_poke->unload_texture(video_driver_data, *id, video_driver_is_threaded_internal());
    *id = 0;
    return true;
 }

--- a/gfx/video_driver.h
+++ b/gfx/video_driver.h
@@ -710,7 +710,7 @@ typedef struct video_poke_interface
          const void *mat_data);
    uintptr_t (*load_texture)(void *video_data, void *data,
          bool threaded, enum texture_filter_type filter_type);
-   void (*unload_texture)(void *data, uintptr_t id);
+   void (*unload_texture)(void *data, uintptr_t id, bool threaded);
    void (*set_video_mode)(void *data, unsigned width,
          unsigned height, bool fullscreen);
    float (*get_refresh_rate)(void *data);

--- a/gfx/video_thread_wrapper.c
+++ b/gfx/video_thread_wrapper.c
@@ -1195,15 +1195,13 @@ static uintptr_t thread_load_texture(void *video_data, void *data,
    return thr->poke->load_texture(thr->driver_data, data, threaded, filter_type);
 }
 
-static void thread_unload_texture(void *video_data, uintptr_t id)
+static void thread_unload_texture(void *video_data, uintptr_t id, bool threaded)
 {
    thread_video_t *thr = (thread_video_t*)video_data;
-
    if (!thr)
       return;
-
    if (thr->poke && thr->poke->unload_texture)
-      thr->poke->unload_texture(thr->driver_data, id);
+      thr->poke->unload_texture(thr->driver_data, id, threaded);
 }
 
 static void thread_apply_state_changes(void *data)
@@ -1425,7 +1423,7 @@ bool video_thread_font_init(const void **font_driver, void **font_handle,
    return pkt.data.font_init.return_value;
 }
 
-unsigned video_thread_texture_load(void *data,
+unsigned video_thread_custom_cmd(void *data,
       custom_command_method_t func)
 {
    thread_video_t *thr  = (thread_video_t*)video_driver_get_ptr(true);

--- a/gfx/video_thread_wrapper.h
+++ b/gfx/video_thread_wrapper.h
@@ -83,7 +83,7 @@ bool video_thread_font_init(
       custom_font_command_method_t func,
       bool is_threaded);
 
-unsigned video_thread_texture_load(void *data,
+unsigned video_thread_custom_cmd(void *data,
       custom_command_method_t func);
 
 RETRO_END_DECLS


### PR DESCRIPTION
Description
Unload the Textures of thumbnail images in a thread when the video is threaded.

Related Issues
 #2791 XMB GUI lag and "black bug" for boxart and dynamic wallpaper
 #6747 XMB always stops displaying images with low-power/memory (rpi, Switch, Classic, others) 