### PR TITLE
Fix crashes when changing cores.

### DIFF
--- a/command.c
+++ b/command.c
@@ -2020,9 +2020,6 @@ bool command_event(enum event_command cmd, void *data)
             path_clear(RARCH_PATH_CORE);
             rarch_ctl(RARCH_CTL_SYSTEM_INFO_FREE, NULL);
 #endif
-            core_unload_game();
-            if (!rarch_ctl(RARCH_CTL_IS_DUMMY_CORE, NULL))
-               core_unload();
 #ifdef HAVE_DISCORD
             if (discord_is_inited)
             {


### PR DESCRIPTION
## Description

When switching cores it was possible to hit `core_unload_game` and `core_load` twice which potentially led to crashes when switching some cores without closing content before loading the new core.

The other instance `core_unload_game` and `core_load` is found here.

https://github.com/libretro/RetroArch/blob/13ccf4d408c1e2e2541cdc285562df7e5c4d25ea/command.c#L1118

Testing with `printf` it seems that this code is always executed when starting or closing content, if the content is not closed before starting new content then it will unload the game and core before starting the new core.

I tested this with the commandline, the menu and qt companion ui while switching, starting and closing cores in every way I could imagine without finding problems.

## Related Issues

Fixes crashes in various cores such as `2048` or `4do`, an easy way to reproduce a crash is.
1. Load any core + content.
2. Load `2048` (Or `4do`) without closing the previous core + content.
3. Now close the previous core + content from the quick menu without starting the new core.
4. Crash.
```
$ ./retroarch
GW:4 GH:4  GSZ:16
SP:8 TSZ:80
BW:360 BH:360 BOY:96 
size:376x464x1504 
AddressSanitizer:DEADLYSIGNAL
=================================================================
==26081==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x7ffbca04ae1b bp 0x7fff08df7b30 sp 0x7fff08df7b30 T0)
==26081==The signal is caused by a WRITE memory access.
==26081==Hint: address points to the zero page.
    #0 0x7ffbca04ae1a in DrawFBoxBmp /tmp/SBo/libretro-2048/game_noncairo.c:67
    #1 0x7ffbca04b278 in fill_rectangle /tmp/SBo/libretro-2048/game_noncairo.c:172
    #2 0x7ffbca04b7df in init_static_surface /tmp/SBo/libretro-2048/game_noncairo.c:286
    #3 0x7ffbca04c201 in game_render /tmp/SBo/libretro-2048/game_noncairo.c:511
    #4 0x7ffbca04aaaf in retro_run /tmp/SBo/libretro-2048/libretro.c:218
    #5 0x41d4ed in core_run /home/orbea/gittings/forks/RetroArch/core_impl.c:446
    #6 0x427dae in runloop_iterate /home/orbea/gittings/forks/RetroArch/retroarch.c:3633
    #7 0x41a5fd in rarch_main frontend/frontend.c:141
    #8 0x41a733 in main frontend/frontend.c:169
    #9 0x7ffbd0d8ac66 in __libc_start_main (/lib64/libc.so.6+0x22c66)
    #10 0x40fd59 in _start (/media/gittings/forks/RetroArch/retroarch+0x40fd59)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV /tmp/SBo/libretro-2048/game_noncairo.c:67 in DrawFBoxBmp
==26081==ABORTING
```
Fixes https://github.com/libretro/RetroArch/issues/4107

## Reviewers

@twinaphex 