### PR TITLE
travis: Attempt to fix xcode9.3 travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ matrix:
       osx_image: xcode9.3
       script:
         - cd ~/
+        - brew update
         - brew install --force-bottle qt5
         - git clone --depth=50 https://github.com/libretro/libretro-super
         - cd libretro-super/travis


### PR DESCRIPTION
## Description

This attempts to fix the travis build with xcode9.3, its failing to build because `moc` is not in the path. I guess homebrew is not installing it and how hard can it be to fix that?

I am not sure this is right, do not merge unless travis passes first.

## Related Issues

xcode9.3 travis build failure
```
   /bin/sh -c /Users/travis/libretro-super/retroarch/pkg/apple/build/RetroArch_Metal.build/Release/RetroArchQt.build/Script-053FC2782143764B00D98D46.sh
/usr/local/opt/qt/bin/moc -o ui/drivers/moc_ui_qt.cpp ui/drivers/ui_qt.h
make: /usr/local/opt/qt/bin/moc: No such file or directory
/usr/local/opt/qt/bin/moc -o ui/drivers/qt/moc_ui_qt_load_core_window.cpp ui/drivers/qt/ui_qt_load_core_window.h
make: /usr/local/opt/qt/bin/moc: No such file or directory
make: *** [ui/drivers/moc_ui_qt.cpp] Error 1
make: *** Waiting for unfinished jobs....
make: *** [ui/drivers/qt/moc_ui_qt_load_core_window.cpp] Error 1

** BUILD FAILED **
```

## Reviewers

Do not merge unless travis passes!