### PR TITLE
pass content label when loading content from Qt

### DIFF
--- a/gfx/common/win32_common.c
+++ b/gfx/common/win32_common.c
@@ -483,7 +483,7 @@ bool win32_load_content_from_gui(const char *szFilename)
       if (info)
       {
          task_push_load_content_with_new_core_from_companion_ui(
-            info->path, NULL, &content_info, NULL, NULL);
+            info->path, NULL, NULL, &content_info, NULL, NULL);
          return true;
       }
    }

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -1591,10 +1591,13 @@ end:
 bool task_push_load_content_with_new_core_from_companion_ui(
       const char *core_path,
       const char *fullpath,
+      const char *label,
       content_ctx_info_t *content_info,
       retro_task_callback_t cb,
       void *user_data)
 {
+   global_t *global = global_get_ptr();
+
    /* Set content path */
    path_set(RARCH_PATH_CONTENT, fullpath);
 
@@ -1605,6 +1608,14 @@ bool task_push_load_content_with_new_core_from_companion_ui(
 #endif
 
    _launched_from_cli = false;
+
+   if (global)
+   {
+      if (label)
+         strlcpy(global->name.label, label, sizeof(global->name.label));
+      else
+         global->name.label[0] = '\0';
+   }
 
    /* Load content */
    if (!task_load_content_callback(content_info, true, false))

--- a/tasks/tasks_internal.h
+++ b/tasks/tasks_internal.h
@@ -184,6 +184,7 @@ bool task_push_start_dummy_core(content_ctx_info_t *content_info);
 bool task_push_load_content_with_new_core_from_companion_ui(
       const char *core_path,
       const char *fullpath,
+      const char *label,
       content_ctx_info_t *content_info,
       retro_task_callback_t cb,
       void *user_data);

--- a/ui/drivers/qt/ui_qt_window.cpp
+++ b/ui/drivers/qt/ui_qt_window.cpp
@@ -1748,7 +1748,7 @@ void MainWindow::loadContent(const QHash<QString, QString> &contentHash)
    command_event(CMD_EVENT_UNLOAD_CORE, NULL);
 
    if (!task_push_load_content_with_new_core_from_companion_ui(
-         corePath, contentPath, &content_info,
+         corePath, contentPath, contentLabel, &content_info,
          NULL, NULL))
    {
       QMessageBox::critical(this, msg_hash_to_str(MSG_ERROR), msg_hash_to_str(MSG_FAILED_TO_LOAD_CONTENT));


### PR DESCRIPTION
## Description

This makes it so the content label is saved in the history playlist when loading content from the Qt UI.
Not sure what the win32_common.c is for, I just made it pass NULL there.

## Reviewers

@bparker06 
