### PR TITLE
Fix COM initialization on Qt builds

### DIFF
--- a/frontend/frontend.c
+++ b/frontend/frontend.c
@@ -36,20 +36,16 @@
 #include "../driver.h"
 #include "../paths.h"
 #include "../retroarch.h"
+#include "../verbosity.h"
+
+#if defined(_WIN32) && !defined(_XBOX) && !defined(__WINRT__)
+#include <objbase.h>
+#endif
 
 /* griffin hack */
 #ifdef HAVE_QT
 #ifndef HAVE_MAIN
 #define HAVE_MAIN
-#endif
-#endif
-
-#ifndef HAVE_MAIN
-#include "../retroarch.h"
-#include "../verbosity.h"
-
-#if defined(_WIN32) && !defined(_XBOX) && !defined(__WINRT__)
-#include <objbase.h>
 #endif
 #endif
 
@@ -94,6 +90,10 @@ void main_exit(void *args)
    driver_ctl(RARCH_DRIVER_CTL_DEINIT, NULL);
    ui_companion_driver_free();
    frontend_driver_free();
+
+#if defined(_WIN32) && !defined(_XBOX) && !defined(__WINRT__)
+   CoUninitialize();
+#endif
 }
 
 /**
@@ -114,7 +114,7 @@ int rarch_main(int argc, char *argv[], void *data)
    const ui_application_t *ui_application = NULL;
 #endif
 
-#if !defined(HAVE_MAIN) && defined(_WIN32) && !defined(_XBOX) && !defined(__WINRT__)
+#if defined(_WIN32) && !defined(_XBOX) && !defined(__WINRT__)
    if (FAILED(CoInitialize(NULL)))
    {
       RARCH_ERR("FATAL: Failed to initialize the COM interface\n");
@@ -168,10 +168,6 @@ int rarch_main(int argc, char *argv[], void *data)
 
    if (ui_application && ui_application->run)
       ui_application->run(args);
-#endif
-
-#if !defined(HAVE_MAIN) && defined(_WIN32) && !defined(_XBOX) && !defined(__WINRT__)
-   CoUninitialize();
 #endif
 
    return 0;


### PR DESCRIPTION
## Description

This should fix the problems with COM initialization in Qt builds. Note that I'm still working on actually testing it since I have to install Qt first and it's suprisingly big... (but @bparker06 yesterday said that this works)

## Related Issues

#7985
#7980

## Reviewers

@bparker06
