### PR TITLE
support subsystem type netplay lobbies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
 - MENU: User Interface -> Appearance -> 'Menu Font Green/Blue Color' settings now work properly.
 - MIDI: Add a Linux ALSA driver for MIDI.
 - NETPLAY: Force fast-save-states when netlay is enabled
+- NETPLAY: Allow quick joining subsystem lobbies
 - PS2: Initial PlayStation2 port.
 - PS4: Initial PlayStation4 port.
 - RECORDING: Implement recording options in the menu complete with quality profiles, streaming, and proper file naming

--- a/content.h
+++ b/content.h
@@ -109,6 +109,9 @@ void content_set_subsystem_info(void);
 /* Get the path to the last selected subsystem rom */
 char* content_get_subsystem_rom(unsigned index);
 
+/* Sets the subsystem by name */
+bool content_set_subsystem_by_name(const char* subsystem_name);
+
 RETRO_END_DECLS
 
 #endif

--- a/discord/discord.c
+++ b/discord/discord.c
@@ -187,8 +187,7 @@ static void handle_discord_join_cb(void *task_data, void *user_data, const char 
 
       RARCH_LOG("[Discord] joining lobby at: %s\n", tmp_hostname);
       task_push_netplay_crc_scan(room->gamecrc,
-         room->gamename, tmp_hostname, room->corename);
-
+         room->gamename, tmp_hostname, room->corename, room->subsystem_name);
    }
 
 finish:

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -4263,6 +4263,9 @@ static void netplay_refresh_rooms_cb(void *task_data, void *user_data, const cha
                strlcpy(netplay_room_list[i].frontend,
                      host->frontend,
                      sizeof(netplay_room_list[i].frontend));
+               strlcpy(netplay_room_list[i].subsystem_name,
+                     host->subsystem_name,
+                     sizeof(netplay_room_list[i].subsystem_name));
 
                netplay_room_list[i].port      = host->port;
                netplay_room_list[i].gamecrc   = host->content_crc;

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -4016,7 +4016,7 @@ static int action_ok_netplay_connect_room(const char *path,
 
    task_push_netplay_crc_scan(netplay_room_list[idx - 3].gamecrc,
       netplay_room_list[idx - 3].gamename,
-      tmp_hostname, netplay_room_list[idx - 3].corename);
+      tmp_hostname, netplay_room_list[idx - 3].corename, netplay_room_list[idx - 3].subsystem_name);
 
 #else
    return -1;

--- a/menu/cbs/menu_cbs_select.c
+++ b/menu/cbs/menu_cbs_select.c
@@ -180,7 +180,7 @@ static int action_select_netplay_connect_room(const char *path,
 
    task_push_netplay_crc_scan(netplay_room_list[idx - 3].gamecrc,
          netplay_room_list[idx - 3].gamename,
-         tmp_hostname, netplay_room_list[idx - 3].corename);
+         tmp_hostname, netplay_room_list[idx - 3].corename, netplay_room_list[idx - 3].subsystem_name);
 
    return 0;
 }

--- a/menu/cbs/menu_cbs_sublabel.c
+++ b/menu/cbs/menu_cbs_sublabel.c
@@ -741,6 +741,7 @@ static int action_bind_sublabel_netplay_room(
             corename, core_ver, subsystem,
             !string_is_equal(gamename, na) ? buf : na
             );
+         string_list_free(list);
       }
       else
       {

--- a/menu/cbs/menu_cbs_sublabel.c
+++ b/menu/cbs/menu_cbs_sublabel.c
@@ -26,6 +26,7 @@
 
 #include <string.h>
 #include <string/stdstring.h>
+#include <file/file_path.h>
 
 #ifndef BIND_ACTION_SUBLABEL
 #define BIND_ACTION_SUBLABEL(cbs, name) \
@@ -580,6 +581,31 @@ static int action_bind_sublabel_subsystem_add(
    return 0;
 }
 
+static int action_bind_sublabel_subsystem_load(
+      file_list_t *list,
+      unsigned type, unsigned i,
+      const char *label, const char *path,
+      char *s, size_t len)
+{
+   unsigned j = 0;
+   char buf[4096];
+
+   buf[0] = '\0';
+
+   for (j = 0; j < content_get_subsystem_rom_id(); j++)
+   {
+      strlcat(buf, "   ", sizeof(buf));
+      strlcat(buf, path_basename(content_get_subsystem_rom(j)), sizeof(buf));
+      if (j != content_get_subsystem_rom_id() - 1)
+         strlcat(buf, "\n", sizeof(buf));
+   }
+
+   if (!string_is_empty(buf))
+      strlcpy(s, buf, len);
+
+   return 0;
+}
+
 static int action_bind_sublabel_remap_kbd_sublabel(
       file_list_t *list,
       unsigned type, unsigned i,
@@ -730,7 +756,7 @@ static int action_bind_sublabel_netplay_room(
          buf[0] = '\0';
          for (i = 0; i < list->size; i++)
          {
-            strlcat(buf, "  ", sizeof(buf));
+            strlcat(buf, "   ", sizeof(buf));
             strlcat(buf, list->elems[i].data, sizeof(buf));
             strlcat(buf, "\n", sizeof(buf));
          }
@@ -1214,6 +1240,9 @@ int menu_cbs_init_bind_sublabel(menu_file_list_cbs_t *cbs,
             break;
          case MENU_ENUM_LABEL_SUBSYSTEM_ADD:
             BIND_ACTION_SUBLABEL(cbs, action_bind_sublabel_subsystem_add);
+            break;
+         case MENU_ENUM_LABEL_SUBSYSTEM_LOAD:
+            BIND_ACTION_SUBLABEL(cbs, action_bind_sublabel_subsystem_load);
             break;
          case MENU_ENUM_LABEL_DISK_CYCLE_TRAY_STATUS:
             BIND_ACTION_SUBLABEL(cbs, action_bind_sublabel_disk_cycle_tray_status);

--- a/menu/cbs/menu_cbs_sublabel.c
+++ b/menu/cbs/menu_cbs_sublabel.c
@@ -692,6 +692,7 @@ static int action_bind_sublabel_netplay_room(
    const char *core_ver   = NULL;
    const char *frontend   = NULL;
    const char *na         = NULL;
+   const char *subsystem  = NULL;
 
    /* This offset may cause issues if any entries are added to this menu */
    unsigned offset        = i - 3;
@@ -705,15 +706,53 @@ static int action_bind_sublabel_netplay_room(
    core_ver   = netplay_room_list[offset].coreversion;
    gamecrc    = netplay_room_list[offset].gamecrc;
    frontend   = netplay_room_list[offset].frontend;
+   subsystem  = netplay_room_list[offset].subsystem_name;
    na         = msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE);
 
-   snprintf(s, len,
-	   "RetroArch: %s (%s)\nCore: %s (%s)\nGame: %s (%08x)",
-      string_is_empty(ra_version)    ? na : ra_version,
-      string_is_empty(frontend)      ? na : frontend,
-      corename, core_ver,
-      !string_is_equal(gamename, na) ? gamename : na,
-      gamecrc);
+   if (string_is_empty(subsystem) || string_is_equal(subsystem, "N/A"))
+   {
+      snprintf(s, len,
+         "RetroArch: %s (%s)\nCore: %s (%s)\nGame: %s (%08x)",
+         string_is_empty(ra_version)    ? na : ra_version,
+         string_is_empty(frontend)      ? na : frontend,
+         corename, core_ver,
+         !string_is_equal(gamename, na) ? gamename : na,
+         gamecrc);
+   }
+   else
+   {
+      if (strstr(gamename, "|"))
+      {
+         char buf[4096];
+         unsigned i               = 0;
+         struct string_list *list = string_split(gamename, "|");
+
+         buf[0] = '\0';
+         for (i = 0; i < list->size; i++)
+         {
+            strlcat(buf, "  ", sizeof(buf));
+            strlcat(buf, list->elems[i].data, sizeof(buf));
+            strlcat(buf, "\n", sizeof(buf));
+         }
+         snprintf(s, len,
+            "RetroArch: %s (%s)\nCore: %s (%s)\nSubsystem: %s\nGames:\n%s",
+            string_is_empty(ra_version)    ? na : ra_version,
+            string_is_empty(frontend)      ? na : frontend,
+            corename, core_ver, subsystem,
+            !string_is_equal(gamename, na) ? buf : na
+            );
+      }
+      else
+      {
+         snprintf(s, len,
+            "RetroArch: %s (%s)\nCore: %s (%s)\nSubsystem: %s\nGame: %s (%08x)",
+            string_is_empty(ra_version)    ? na : ra_version,
+            string_is_empty(frontend)      ? na : frontend,
+            corename, core_ver, subsystem,
+            !string_is_equal(gamename, na) ? gamename : na,
+            gamecrc);
+      }
+   }
 #if 0
    strlcpy(s, corename, len);
 #endif

--- a/network/netplay/netplay_discovery.c
+++ b/network/netplay/netplay_discovery.c
@@ -68,6 +68,7 @@ struct ad_packet
    char core_version[NETPLAY_HOST_STR_LEN];
    char content[NETPLAY_HOST_LONGSTR_LEN];
    char content_crc[NETPLAY_HOST_STR_LEN];
+   char subsystem_name[NETPLAY_HOST_STR_LEN];
 };
 
 static bool netplay_lan_ad_client(void);
@@ -247,6 +248,8 @@ bool netplay_lan_ad_server(netplay_t *netplay)
    unsigned k = 0;
    char reply_addr[NETPLAY_HOST_STR_LEN], port_str[6];
    struct addrinfo *our_addr, hints = {0};
+   struct string_list *subsystem    = path_get_subsystem_list();
+   char buf[4096];
 
    net_ifinfo_t interfaces;
 
@@ -313,10 +316,36 @@ bool netplay_lan_ad_server(netplay_t *netplay)
                      reply_addr, interfaces.entries[k].host);
 
                   /* Now build our response */
+                  buf[0] = '\0';
                   content_crc = content_get_crc();
 
                   memset(&ad_packet_buffer, 0, sizeof(struct ad_packet));
                   memcpy(&ad_packet_buffer, "RANS", 4);
+
+                  if (subsystem)
+                  {
+                     unsigned i;
+
+                     for (i = 0; i < subsystem->size; i++)
+                     {
+                        strlcat(buf, path_basename(subsystem->elems[i].data), NETPLAY_HOST_LONGSTR_LEN);
+                        if (i < subsystem->size - 1)
+                           strlcat(buf, "|", NETPLAY_HOST_LONGSTR_LEN);
+                     }
+                     RARCH_LOG("%s\n", buf);
+                     strlcpy(ad_packet_buffer.content, buf,
+                        NETPLAY_HOST_LONGSTR_LEN);
+                     strlcpy(ad_packet_buffer.subsystem_name, path_get(RARCH_PATH_SUBSYSTEM),
+                        NETPLAY_HOST_STR_LEN);
+                  }
+                  else
+                  {
+                     strlcpy(ad_packet_buffer.content, !string_is_empty(
+                              path_basename(path_get(RARCH_PATH_BASENAME)))
+                           ? path_basename(path_get(RARCH_PATH_BASENAME)) : "N/A",
+                           NETPLAY_HOST_LONGSTR_LEN);
+                     strlcpy(ad_packet_buffer.subsystem_name, "N/A", NETPLAY_HOST_STR_LEN);
+                  }
 
                   strlcpy(ad_packet_buffer.address, interfaces.entries[k].host,
                      NETPLAY_HOST_STR_LEN);
@@ -325,10 +354,6 @@ bool netplay_lan_ad_server(netplay_t *netplay)
                   ad_packet_buffer.port = htonl(netplay->tcp_port);
                   strlcpy(ad_packet_buffer.retroarch_version, PACKAGE_VERSION,
                      NETPLAY_HOST_STR_LEN);
-                  strlcpy(ad_packet_buffer.content, !string_is_empty(
-                           path_basename(path_get(RARCH_PATH_BASENAME)))
-                        ? path_basename(path_get(RARCH_PATH_BASENAME)) : "N/A",
-                        NETPLAY_HOST_LONGSTR_LEN);
                   strlcpy(ad_packet_buffer.nick, netplay->nick, NETPLAY_HOST_STR_LEN);
                   strlcpy(ad_packet_buffer.frontend, frontend, NETPLAY_HOST_STR_LEN);
 
@@ -393,7 +418,7 @@ static bool netplay_lan_ad_client(void)
    struct timeval tmp_tv = {0};
 
    if (lan_ad_client_fd < 0)
-       return false;
+      return false;
 
    /* Check for any ad queries */
    while (1)
@@ -491,6 +516,8 @@ static bool netplay_lan_ad_client(void)
          strlcpy(host->core_version, ad_packet_buffer.core_version,
             NETPLAY_HOST_STR_LEN);
          strlcpy(host->content, ad_packet_buffer.content,
+            NETPLAY_HOST_LONGSTR_LEN);
+         strlcpy(host->subsystem_name, ad_packet_buffer.subsystem_name,
             NETPLAY_HOST_LONGSTR_LEN);
          strlcpy(host->frontend, ad_packet_buffer.frontend,
             NETPLAY_HOST_STR_LEN);

--- a/network/netplay/netplay_discovery.c
+++ b/network/netplay/netplay_discovery.c
@@ -332,7 +332,6 @@ bool netplay_lan_ad_server(netplay_t *netplay)
                         if (i < subsystem->size - 1)
                            strlcat(buf, "|", NETPLAY_HOST_LONGSTR_LEN);
                      }
-                     RARCH_LOG("%s\n", buf);
                      strlcpy(ad_packet_buffer.content, buf,
                         NETPLAY_HOST_LONGSTR_LEN);
                      strlcpy(ad_packet_buffer.subsystem_name, path_get(RARCH_PATH_SUBSYSTEM),

--- a/network/netplay/netplay_discovery.h
+++ b/network/netplay/netplay_discovery.h
@@ -43,6 +43,7 @@ struct netplay_host
    char core_version[NETPLAY_HOST_STR_LEN];
    char retroarch_version[NETPLAY_HOST_STR_LEN];
    char content[NETPLAY_HOST_LONGSTR_LEN];
+   char subsystem_name[NETPLAY_HOST_LONGSTR_LEN];
    int  content_crc;
    int  port;
 };
@@ -82,6 +83,7 @@ struct netplay_room
    bool lan;
    bool fixed;
    char retroarch_version[PATH_MAX_LENGTH];
+   char subsystem_name[PATH_MAX_LENGTH];
    char country[PATH_MAX_LENGTH];
    struct netplay_room *next;
 };

--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -879,6 +879,7 @@ static void netplay_announce(void)
       }
       net_http_urlencode(&gamename, buf);
       net_http_urlencode(&subsystemname, path_get(RARCH_PATH_SUBSYSTEM));
+      content_crc = 0;
    }
    else
    {

--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -851,9 +851,9 @@ void netplay_get_architecture(char *frontend_architecture, size_t size)
 
 static void netplay_announce(void)
 {
-   char buf [4600];
+   char buf[4600];
    char frontend_architecture[PATH_MAX_LENGTH];
-   char url [2048]                  = "http://lobby.libretro.com/add/";
+   char url[2048]                   = "http://lobby.libretro.com/add/";
    char *username                   = NULL;
    char *corename                   = NULL;
    char *gamename                   = NULL;
@@ -865,6 +865,8 @@ static void netplay_announce(void)
    uint32_t content_crc             = content_get_crc();
    struct string_list *subsystem    = path_get_subsystem_list();
 
+   buf[0] = '\0';
+
    if (subsystem)
    {
       unsigned i;
@@ -875,7 +877,6 @@ static void netplay_announce(void)
          if (i < subsystem->size - 1)
             strlcat(buf, "|", sizeof(buf));
       }
-      RARCH_LOG("%s\n", buf);
       net_http_urlencode(&gamename, buf);
       net_http_urlencode(&subsystemname, path_get(RARCH_PATH_SUBSYSTEM));
    }

--- a/network/netplay/netplay_room_parse.c
+++ b/network/netplay/netplay_room_parse.c
@@ -288,6 +288,11 @@ static JSON_Parser_HandlerResult JSON_CALL ObjectMemberHandler(JSON_Parser parse
             pCtx->cur_field       = strdup(pValue);
             pCtx->cur_member      = &rooms->cur->frontend;
          }
+         else if (string_is_equal(pValue, "subsystem_name"))
+         {
+            pCtx->cur_field       = strdup(pValue);
+            pCtx->cur_member      = &rooms->cur->subsystem_name;
+         }
       }
    }
 

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -1811,6 +1811,32 @@ void content_set_subsystem(unsigned idx)
       pending_subsystem_id, pending_subsystem_ident, pending_subsystem_rom_num);
 }
 
+/* Sets the subsystem by name */
+bool content_set_subsystem_by_name(const char* subsystem_name)
+{
+   rarch_system_info_t                  *system = runloop_get_system_info();
+   const struct retro_subsystem_info *subsystem;
+   unsigned i = 0;
+
+   /* Core fully loaded, use the subsystem data */
+   if (system->subsystem.data)
+      subsystem = system->subsystem.data;
+   /* Core not loaded completely, use the data we peeked on load core */
+   else
+      subsystem = subsystem_data;
+
+   for (i = 0; i < subsystem_current_count; i++, subsystem++)
+   {
+      if (string_is_equal(subsystem_name, subsystem->ident))
+      {
+         content_set_subsystem(i);
+         return true;
+      }
+   }
+
+   return false;
+}
+
 /* Add a rom to the subsystem rom buffer */
 void content_add_subsystem(const char* path)
 {

--- a/tasks/tasks_internal.h
+++ b/tasks/tasks_internal.h
@@ -113,7 +113,7 @@ bool task_push_wifi_scan(retro_task_callback_t cb);
 bool task_push_netplay_lan_scan(retro_task_callback_t cb);
 
 bool task_push_netplay_crc_scan(uint32_t crc, char* name,
-      const char *hostname, const char *corename);
+      const char *hostname, const char *corename, const char* subsystem);
 
 bool task_push_netplay_lan_scan_rooms(retro_task_callback_t cb);
 


### PR DESCRIPTION
It still doesn't allow connecting!!! **do-not-merge**
This will allow loading subsystem type content for netplay

Usecases:
- Pokemon battles with sameboy and tgb dual
- Netplay all the fba subsystems

Hopefully we'll get more subsystem support in the future now that the gui is functional

Previews:

Single game subsystem lobby:
![image](https://user-images.githubusercontent.com/1721040/51081276-bac8e680-16b9-11e9-9bb9-d5a33e1291b2.png)

Dual game subsystem lobby:
![image](https://user-images.githubusercontent.com/1721040/51081283-ee0b7580-16b9-11e9-8ba5-a8dbc9342563.png)

Progress:
- [x] lobby server changes
- [x] announcing lobbies
- [x] querying lobbies
- [x] scan for the content files in playlists
- [x] load and connect
