### PR TITLE
Fix warning in uwp_input.c

### DIFF
--- a/input/drivers/uwp_input.c
+++ b/input/drivers/uwp_input.c
@@ -184,7 +184,6 @@ static int16_t uwp_input_state(void *data,
       unsigned port, unsigned device,
       unsigned index, unsigned id)
 {
-   int16_t ret;
    uwp_input_t *uwp           = (uwp_input_t*)data;
 
    switch (device)


### PR DESCRIPTION
## Description

Fixes an "unused variable" warning in uwp_input.c introduced in #7986