### PR TITLE
Fix CXX_BUILD errors.

### DIFF
--- a/gfx/common/egl_common.c
+++ b/gfx/common/egl_common.c
@@ -358,7 +358,7 @@ bool egl_init_context(egl_ctx_data_t *egl,
       return false;
    }
 
-   configs = malloc(*count * sizeof(*configs));
+   configs = (EGLConfig*)malloc(*count * sizeof(*configs));
    if (!configs)
       return false;
 

--- a/input/drivers_joypad/udev_joypad.c
+++ b/input/drivers_joypad/udev_joypad.c
@@ -543,8 +543,8 @@ static void udev_joypad_poll(void)
 /* Used for sorting devnodes to appear in the correct order */
 static int sort_devnodes(const void *a, const void *b)
 {
-   const struct joypad_udev_entry *aa = a;
-   const struct joypad_udev_entry *bb = b;
+   const struct joypad_udev_entry *aa = (const struct joypad_udev_entry*)a;
+   const struct joypad_udev_entry *bb = (const struct joypad_udev_entry*)b;
    return strcmp(aa->devnode, bb->devnode);
 }
 


### PR DESCRIPTION
## Description

Fixes some `-fpermissive` errors with `CXX_BUILD=1`. It still will not build without `./configure --disable-ssl --disable-chd --disable-qt`.

## Reviewers

@twinaphex 
