### PR TITLE
Fix qt with CXX_BUILD.

### DIFF
--- a/ui/drivers/qt/coreinfodialog.cpp
+++ b/ui/drivers/qt/coreinfodialog.cpp
@@ -5,10 +5,15 @@
 #include "coreinfodialog.h"
 #include "../ui_qt.h"
 
-extern "C"
-{
+#ifndef CXX_BUILD
+extern "C" {
+#endif
+
 #include "../../../msg_hash.h"
+
+#ifndef CXX_BUILD
 }
+#endif
 
 CoreInfoDialog::CoreInfoDialog(MainWindow *mainwindow, QWidget *parent) :
    QDialog(parent)
@@ -93,4 +98,3 @@ void CoreInfoDialog::showCoreInfo()
 
    show();
 }
-

--- a/ui/drivers/qt/coreoptionsdialog.cpp
+++ b/ui/drivers/qt/coreoptionsdialog.cpp
@@ -20,7 +20,10 @@
 #include "coreoptionsdialog.h"
 #include "../ui_qt.h"
 
+#ifndef CXX_BUILD
 extern "C" {
+#endif
+
 #include <string/stdstring.h>
 #include <streams/file_stream.h>
 #include <file/file_path.h>
@@ -30,7 +33,10 @@ extern "C" {
 #include "../../../paths.h"
 #include "../../../file_path_special.h"
 #include "../../../managers/core_option_manager.h"
+
+#ifndef CXX_BUILD
 }
+#endif
 
 CoreOptionsDialog::CoreOptionsDialog(QWidget *parent) :
    QDialog(parent)

--- a/ui/drivers/qt/filedropwidget.cpp
+++ b/ui/drivers/qt/filedropwidget.cpp
@@ -15,10 +15,16 @@
 #include "playlistentrydialog.h"
 #include "../ui_qt.h"
 
+#ifndef CXX_BUILD
 extern "C" {
+#endif
+
 #include "../../../file_path_special.h"
 #include "../../../configuration.h"
+
+#ifndef CXX_BUILD
 }
+#endif
 
 FileDropWidget::FileDropWidget(QWidget *parent) :
    QWidget(parent)

--- a/ui/drivers/qt/playlistentrydialog.cpp
+++ b/ui/drivers/qt/playlistentrydialog.cpp
@@ -13,10 +13,16 @@
 #include "playlistentrydialog.h"
 #include "../ui_qt.h"
 
+#ifndef CXX_BUILD
 extern "C" {
+#endif
+
 #include "../../../core_info.h"
 #include "../../../file_path_special.h"
+
+#ifndef CXX_BUILD
 }
+#endif
 
 inline static bool comp_string_lower(const QString &lhs, const QString &rhs)
 {

--- a/ui/drivers/qt/playlistthumbnaildownload.cpp
+++ b/ui/drivers/qt/playlistthumbnaildownload.cpp
@@ -4,7 +4,10 @@
 
 #include "../ui_qt.h"
 
+#ifndef CXX_BUILD
 extern "C" {
+#endif
+
 #include <string/stdstring.h>
 #include <streams/file_stream.h>
 #include <file/archive_file.h>
@@ -13,7 +16,10 @@ extern "C" {
 #include "../../../config.def.h"
 #include "../../../configuration.h"
 #include "../../../version.h"
+
+#ifndef CXX_BUILD
 }
+#endif
 
 #define USER_AGENT "RetroArch-WIMP/" PACKAGE_VERSION
 #define PARTIAL_EXTENSION ".partial"

--- a/ui/drivers/qt/qt_playlist.cpp
+++ b/ui/drivers/qt/qt_playlist.cpp
@@ -15,7 +15,10 @@
 #include "../ui_qt.h"
 #include "playlistentrydialog.h"
 
+#ifndef CXX_BUILD
 extern "C" {
+#endif
+
 #include <file/file_path.h>
 #include <file/archive_file.h>
 #include <lists/string_list.h>
@@ -27,7 +30,10 @@ extern "C" {
 #include "../../../configuration.h"
 #include "../../../core_info.h"
 #include "../../../verbosity.h"
+
+#ifndef CXX_BUILD
 }
+#endif
 
 PlaylistModel::PlaylistModel(QObject *parent)
    : QAbstractListModel(parent)

--- a/ui/drivers/qt/shaderparamsdialog.cpp
+++ b/ui/drivers/qt/shaderparamsdialog.cpp
@@ -19,7 +19,10 @@
 #include "shaderparamsdialog.h"
 #include "../ui_qt.h"
 
+#ifndef CXX_BUILD
 extern "C" {
+#endif
+
 #include <string/stdstring.h>
 #include <streams/file_stream.h>
 #include <file/file_path.h>
@@ -29,7 +32,10 @@ extern "C" {
 #include "../../../paths.h"
 #include "../../../file_path_special.h"
 #include "../../../menu/menu_shader.h"
+
+#ifndef CXX_BUILD
 }
+#endif
 
 enum
 {

--- a/ui/drivers/qt/shaderparamsdialog.h
+++ b/ui/drivers/qt/shaderparamsdialog.h
@@ -4,9 +4,15 @@
 #include <QDialog>
 #include <QPointer>
 
+#ifndef CXX_BUILD
 extern "C" {
+#endif
+
 #include "../.././gfx/video_shader_parse.h"
+
+#ifndef CXX_BUILD
 }
+#endif
 
 class QCloseEvent;
 class QResizeEvent;

--- a/ui/drivers/qt/thumbnaildownload.cpp
+++ b/ui/drivers/qt/thumbnaildownload.cpp
@@ -4,7 +4,10 @@
 
 #include "../ui_qt.h"
 
+#ifndef CXX_BUILD
 extern "C" {
+#endif
+
 #include <string/stdstring.h>
 #include <streams/file_stream.h>
 #include <file/archive_file.h>
@@ -13,7 +16,10 @@ extern "C" {
 #include "../../../config.def.h"
 #include "../../../configuration.h"
 #include "../../../version.h"
+
+#ifndef CXX_BUILD
 }
+#endif
 
 #undef USER_AGENT
 #define USER_AGENT "RetroArch-WIMP/" PACKAGE_VERSION

--- a/ui/drivers/qt/thumbnailpackdownload.cpp
+++ b/ui/drivers/qt/thumbnailpackdownload.cpp
@@ -4,7 +4,10 @@
 
 #include "../ui_qt.h"
 
+#ifndef CXX_BUILD
 extern "C" {
+#endif
+
 #include <string/stdstring.h>
 #include <streams/file_stream.h>
 #include <file/archive_file.h>
@@ -13,7 +16,10 @@ extern "C" {
 #include "../../../config.def.h"
 #include "../../../configuration.h"
 #include "../../../version.h"
+
+#ifndef CXX_BUILD
 }
+#endif
 
 #undef TEMP_EXTENSION
 #define USER_AGENT "RetroArch-WIMP/" PACKAGE_VERSION

--- a/ui/drivers/qt/ui_qt_application.cpp
+++ b/ui/drivers/qt/ui_qt_application.cpp
@@ -17,7 +17,10 @@
 #include <QApplication>
 #include <QAbstractEventDispatcher>
 
+#ifndef CXX_BUILD
 extern "C" {
+#endif
+
 #include "../../ui_companion_driver.h"
 #include "../../../retroarch.h"
 #include "../../../verbosity.h"
@@ -28,7 +31,10 @@ extern "C" {
 #ifdef Q_OS_UNIX
 #include <locale.h>
 #endif
+
+#ifndef CXX_BUILD
 }
+#endif
 
 #include "../ui_qt.h"
 
@@ -174,7 +180,7 @@ static void ui_application_qt_run(void *args)
 }
 
 #ifdef HAVE_MAIN
-#ifdef __cplusplus
+#if defined(__cplusplus) && !defined(CXX_BUILD)
 extern "C"
 #endif
 int main(int argc, char *argv[])

--- a/ui/drivers/qt/ui_qt_load_core_window.cpp
+++ b/ui/drivers/qt/ui_qt_load_core_window.cpp
@@ -20,7 +20,10 @@
 #include <QFileDialog>
 #include <QDesktopWidget>
 
+#ifndef CXX_BUILD
 extern "C" {
+#endif
+
 #include "../../../core_info.h"
 #include "../../../verbosity.h"
 #include "../../../configuration.h"
@@ -31,7 +34,10 @@ extern "C" {
 #include <string/stdstring.h>
 #include <file/file_path.h>
 #include <retro_miscellaneous.h>
+
+#ifndef CXX_BUILD
 }
+#endif
 
 #define CORE_NAME_COLUMN 0
 #define CORE_VERSION_COLUMN 1

--- a/ui/drivers/qt/ui_qt_load_core_window.h
+++ b/ui/drivers/qt/ui_qt_load_core_window.h
@@ -18,9 +18,15 @@
 #ifndef _QT_LOAD_CORE_WINDOW_H
 #define _QT_LOAD_CORE_WINDOW_H
 
+#ifndef CXX_BUILD
 extern "C" {
+#endif
+
 #include <retro_common_api.h>
+
+#ifndef CXX_BUILD
 }
+#endif
 
 #include <QtWidgets>
 

--- a/ui/drivers/qt/ui_qt_window.cpp
+++ b/ui/drivers/qt/ui_qt_window.cpp
@@ -49,7 +49,10 @@
 #include "playlistentrydialog.h"
 #include "viewoptionsdialog.h"
 
+#ifndef CXX_BUILD
 extern "C" {
+#endif
+
 #include "../../../version.h"
 #include "../../../verbosity.h"
 #include "../../../retroarch.h"
@@ -76,7 +79,10 @@ extern "C" {
 #include <openssl/ssl.h>
 #include <openssl/opensslv.h>
 #endif
+
+#ifndef CXX_BUILD
 }
+#endif
 
 #include "../../../AUTHORS.h"
 

--- a/ui/drivers/qt/updateretroarch.cpp
+++ b/ui/drivers/qt/updateretroarch.cpp
@@ -4,14 +4,20 @@
 
 #include "../ui_qt.h"
 
+#ifndef CXX_BUILD
 extern "C" {
+#endif
+
 #include <string/stdstring.h>
 #include <streams/file_stream.h>
 #include <file/archive_file.h>
 #include "../../../tasks/tasks_internal.h"
 #include "../../../verbosity.h"
 #include "../../../config.def.h"
+
+#ifndef CXX_BUILD
 }
+#endif
 
 #define USER_AGENT "RetroArch-WIMP/1.0"
 #define PARTIAL_EXTENSION ".partial"

--- a/ui/drivers/qt/viewoptionsdialog.cpp
+++ b/ui/drivers/qt/viewoptionsdialog.cpp
@@ -14,9 +14,15 @@
 #include "viewoptionsdialog.h"
 #include "../ui_qt.h"
 
+#ifndef CXX_BUILD
 extern "C" {
+#endif
+
 #include "../../../msg_hash.h"
+
+#ifndef CXX_BUILD
 }
+#endif
 
 ViewOptionsDialog::ViewOptionsDialog(MainWindow *mainwindow, QWidget *parent) :
    QDialog(mainwindow)

--- a/ui/drivers/ui_qt.cpp
+++ b/ui/drivers/ui_qt.cpp
@@ -14,7 +14,10 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef CXX_BUILD
 extern "C" {
+#endif
+
 #include <file/file_path.h>
 #include <string/stdstring.h>
 
@@ -29,7 +32,10 @@ extern "C" {
 #include "../../verbosity.h"
 #include "../../msg_hash.h"
 #include "../../tasks/tasks_internal.h"
+
+#ifndef CXX_BUILD
 }
+#endif
 
 #include "ui_qt.h"
 #include "qt/filedropwidget.h"

--- a/ui/drivers/ui_qt.h
+++ b/ui/drivers/ui_qt.h
@@ -43,13 +43,19 @@
 #include <QSortFilterProxyModel>
 #include <QDir>
 
+#ifndef CXX_BUILD
 extern "C" {
+#endif
+
 #include <retro_assert.h>
 #include <retro_common_api.h>
 #include <queues/task_queue.h>
 #include "../ui_companion_driver.h"
 #include "../../gfx/video_driver.h"
+
+#ifndef CXX_BUILD
 }
+#endif
 
 #define ALL_PLAYLISTS_TOKEN "|||ALL|||"
 #define ICON_PATH "/xmb/dot-art/png/"


### PR DESCRIPTION
## Description

Fix numerous undefined references for qt with `CXX_BUILD=1`. It still requires `./configure --disable-chd --disable-ssl` to build.

## Related Issues

```
LD retroarch
/usr/bin/ld: obj-unix/release/ui/drivers/ui_qt.o: in function `ui_companion_qt_event_command(void*, event_command)':
ui_qt.cpp:(.text+0x6f): undefined reference to `RARCH_LOG'
/usr/bin/ld: obj-unix/release/ui/drivers/ui_qt.o: in function `ui_companion_qt_toggle(void*, bool)':
ui_qt.cpp:(.text+0x213): undefined reference to `config_get_ptr'
/usr/bin/ld: ui_qt.cpp:(.text+0x23c): undefined reference to `video_driver_show_mouse'
/usr/bin/ld: ui_qt.cpp:(.text+0x249): undefined reference to `video_driver_started_fullscreen'
/usr/bin/ld: ui_qt.cpp:(.text+0x278): undefined reference to `command_event'
/usr/bin/ld: obj-unix/release/ui/drivers/ui_qt.o: in function `ui_companion_qt_init()':
ui_qt.cpp:(.text+0xa0e): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt.cpp:(.text+0xa96): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt.cpp:(.text+0xb93): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt.cpp:(.text+0xce7): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt.cpp:(.text+0xd81): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/ui_qt.o:ui_qt.cpp:(.text+0xe14): more undefined references to `msg_hash_to_str' follow
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_application.o: in function `ui_application_qt_run(void*)':
ui_qt_application.cpp:(.text+0x149): undefined reference to `task_queue_check'
/usr/bin/ld: ui_qt_application.cpp:(.text+0x17d): undefined reference to `runloop_iterate'
/usr/bin/ld: ui_qt_application.cpp:(.text+0x191): undefined reference to `task_queue_check'
/usr/bin/ld: ui_qt_application.cpp:(.text+0x1b5): undefined reference to `main_exit'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_application.o: in function `main':
ui_qt_application.cpp:(.text.startup+0x3): undefined reference to `rarch_main'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o: in function `MainWindow::onStartCoreClicked()':
ui_qt_window.cpp:(.text+0xefb): undefined reference to `path_clear'
/usr/bin/ld: ui_qt_window.cpp:(.text+0xf05): undefined reference to `task_push_start_current_core'
/usr/bin/ld: ui_qt_window.cpp:(.text+0xf2b): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0xf40): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o: in function `MainWindow::isContentLessCore()':
ui_qt_window.cpp:(.text+0xfa5): undefined reference to `runloop_get_system_info'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o: in function `MainWindow::isCoreLoaded()':
ui_qt_window.cpp:(.text+0xfda): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o: in function `MainWindow::onBrowserDownloadsClicked()':
ui_qt_window.cpp:(.text+0x130e): undefined reference to `config_get_ptr'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o: in function `MainWindow::onBrowserStartClicked()':
ui_qt_window.cpp:(.text+0x1570): undefined reference to `config_get_ptr'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o: in function `MainWindow::onContributorsClicked()':
ui_qt_window.cpp:(.text+0x1d8f): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o: in function `MainWindow::showMessageBox(QString, MainWindow::MessageBoxType, Qt::WindowModality, bool, bool*)':
ui_qt_window.cpp:(.text+0x2323): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x23e6): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x2463): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x24a3): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o:ui_qt_window.cpp:(.text+0x24d3): more undefined references to `msg_hash_to_str' follow
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o: in function `scan_finished_handler(void*, void*, char const*)':
ui_qt_window.cpp:(.text+0x2760): undefined reference to `menu_driver_ctl'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x27f5): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o: in function `MainWindow::onViewClosedDocksAboutToShow()':
ui_qt_window.cpp:(.text+0x2b76): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x2ba6): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o: in function `MainWindow::onFileBrowserTreeContextMenuRequested(QPoint const&)':
ui_qt_window.cpp:(.text+0x2e84): undefined reference to `config_get_ptr'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x2f0d): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x30eb): undefined reference to `task_push_dbscan'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o: in function `MainWindow::loadContent(QHash<QString, QString> const&)':
ui_qt_window.cpp:(.text+0x392c): undefined reference to `path_get'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x3a47): undefined reference to `menu_navigation_set_selection'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x3a53): undefined reference to `command_event'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x3a6d): undefined reference to `task_push_load_content_with_new_core_from_companion_ui'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x3a81): undefined reference to `menu_driver_ctl'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x3b06): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x3b1b): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x418c): undefined reference to `path_is_compressed_file'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x419e): undefined reference to `file_archive_get_file_list'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x41da): undefined reference to `path_get_extension'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x4234): undefined reference to `string_list_free'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o: in function `MainWindow::getSelectedCore()':
ui_qt_window.cpp:(.text+0x4647): undefined reference to `path_get'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o: in function `MainWindow::getCoreInfo()':
ui_qt_window.cpp:(.text+0x4a91): undefined reference to `core_info_get_list'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x4b97): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x4c8f): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x4d87): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x4e7f): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x500e): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o:ui_qt_window.cpp:(.text+0x519e): more undefined references to `msg_hash_to_str' follow
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o: in function `MainWindow::getCoreInfo()':
ui_qt_window.cpp:(.text+0x5926): undefined reference to `config_get_ptr'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x594d): undefined reference to `rarch_ctl'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x595a): undefined reference to `core_info_list_update_missing_firmware'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x5996): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x5ab6): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x5af1): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x5dec): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x5f86): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o:ui_qt_window.cpp:(.text+0x5f96): more undefined references to `msg_hash_to_str' follow
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o: in function `MainWindow::getCoreInfo()':
ui_qt_window.cpp:(.text+0x5faa): undefined reference to `rarch_ctl'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o: in function `MainWindow::setCoreActions()':
ui_qt_window.cpp:(.text+0x6ad0): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x6c19): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x6d00): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x708b): undefined reference to `file_path_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x70df): undefined reference to `core_info_get_list'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x733c): undefined reference to `file_path_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x7800): undefined reference to `path_get'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o: in function `MainWindow::onTabWidgetIndexChanged(int)':
ui_qt_window.cpp:(.text+0x80b3): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x811e): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o: in function `MainWindow::setCurrentCoreLabel()':
ui_qt_window.cpp:(.text+0x8252): undefined reference to `runloop_get_libretro_system_info'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x826f): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o: in function `MainWindow::onTimeout()':
ui_qt_window.cpp:(.text+0x85ad): undefined reference to `content_get_status'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o: in function `MainWindow::onStopClicked()':
ui_qt_window.cpp:(.text+0x8667): undefined reference to `menu_navigation_set_selection'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x8673): undefined reference to `command_event'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o: in function `MainWindow::onUnloadCoreMenuAction()':
ui_qt_window.cpp:(.text+0x8773): undefined reference to `menu_navigation_set_selection'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x877f): undefined reference to `command_event'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o: in function `MainWindow::renamePlaylistItem(QListWidgetItem*, QString)':
ui_qt_window.cpp:(.text+0x8bbb): undefined reference to `config_get_ptr'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x90fa): undefined reference to `RARCH_ERR'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o: in function `MainWindow::setCustomThemeFile(QString)':
ui_qt_window.cpp:(.text+0x9426): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x9440): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x94ab): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x94c0): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0x9586): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o:ui_qt_window.cpp:(.text+0x95a0): more undefined references to `msg_hash_to_str' follow
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o: in function `MainWindow::currentItemChanged(QModelIndex const&)':
ui_qt_window.cpp:(.text+0x9948): undefined reference to `config_get_ptr'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o: in function `MainWindow::initContentTableWidget()':
ui_qt_window.cpp:(.text+0xaa71): undefined reference to `config_get_ptr'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o: in function `MainWindow::onCurrentListItemChanged(QListWidgetItem*, QListWidgetItem*)':
ui_qt_window.cpp:(.text+0xabe3): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o: in function `MainWindow::showAbout()':
ui_qt_window.cpp:(.text+0xae69): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0xafaf): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o: in function `MainWindow::onExtractArchive(QString, QString, QString, void (*)(void*, void*, char const*))':
ui_qt_window.cpp:(.text+0xb1ea): undefined reference to `file_archive_get_file_list'
/usr/bin/ld: ui_qt_window.cpp:(.text+0xb38c): undefined reference to `string_list_free'
/usr/bin/ld: ui_qt_window.cpp:(.text+0xb43a): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0xb4d8): undefined reference to `task_push_decompress'
/usr/bin/ld: ui_qt_window.cpp:(.text+0xb557): undefined reference to `RARCH_ERR'
/usr/bin/ld: ui_qt_window.cpp:(.text+0xb580): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0xb5c7): undefined reference to `RARCH_ERR'
/usr/bin/ld: ui_qt_window.cpp:(.text+0xb5ea): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0xb631): undefined reference to `RARCH_ERR'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o: in function `MainWindow::MainWindow(QWidget*)':
ui_qt_window.cpp:(.text+0xb802): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0xb9b8): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0xba58): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0xbe15): undefined reference to `config_get_ptr'
/usr/bin/ld: ui_qt_window.cpp:(.text+0xbe50): undefined reference to `path_get'
/usr/bin/ld: ui_qt_window.cpp:(.text+0xbef1): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0xbf2d): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0xc08e): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0xc0ff): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_window.cpp:(.text+0xc12c): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o:ui_qt_window.cpp:(.text+0xc745): more undefined references to `msg_hash_to_str' follow
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_window.o: in function `MainWindow::MainWindow(QWidget*)':
ui_qt_window.cpp:(.text+0xdd43): undefined reference to `RARCH_LOG'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_load_core_window.o: in function `LoadCoreWindow::initCoreList(QStringList const&)':
ui_qt_load_core_window.cpp:(.text+0xf8): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_load_core_window.cpp:(.text+0x17f): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_load_core_window.cpp:(.text+0x1e9): undefined reference to `core_info_get_list'
/usr/bin/ld: ui_qt_load_core_window.cpp:(.text+0x2a9): undefined reference to `core_info_get'
/usr/bin/ld: ui_qt_load_core_window.cpp:(.text+0x345): undefined reference to `path_basename'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_load_core_window.o: in function `LoadCoreWindow::LoadCoreWindow(QWidget*)':
ui_qt_load_core_window.cpp:(.text+0x166f): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_load_core_window.cpp:(.text+0x17a1): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_load_core_window.o: in function `LoadCoreWindow::loadCore(char const*)':
ui_qt_load_core_window.cpp:(.text+0x19b8): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_load_core_window.cpp:(.text+0x1a58): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_load_core_window.cpp:(.text+0x1aea): undefined reference to `rarch_ctl'
/usr/bin/ld: ui_qt_load_core_window.cpp:(.text+0x1af6): undefined reference to `command_event'
/usr/bin/ld: ui_qt_load_core_window.cpp:(.text+0x1b02): undefined reference to `command_event'
/usr/bin/ld: ui_qt_load_core_window.cpp:(.text+0x1b07): undefined reference to `core_info_init_current_core'
/usr/bin/ld: ui_qt_load_core_window.cpp:(.text+0x1b13): undefined reference to `command_event'
/usr/bin/ld: ui_qt_load_core_window.cpp:(.text+0x1bc6): undefined reference to `msg_hash_to_str'
/usr/bin/ld: ui_qt_load_core_window.cpp:(.text+0x1bf3): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/ui_qt_load_core_window.o: in function `LoadCoreWindow::onLoadCustomCoreClicked()':
ui_qt_load_core_window.cpp:(.text+0x230b): undefined reference to `config_get_ptr'
/usr/bin/ld: ui_qt_load_core_window.cpp:(.text+0x235b): undefined reference to `frontend_driver_get_core_extension'
/usr/bin/ld: ui_qt_load_core_window.cpp:(.text+0x236f): undefined reference to `strlcpy_retro__'
/usr/bin/ld: ui_qt_load_core_window.cpp:(.text+0x237f): undefined reference to `strlcat_retro__'
/usr/bin/ld: ui_qt_load_core_window.cpp:(.text+0x2393): undefined reference to `strlcat_retro__'
/usr/bin/ld: ui_qt_load_core_window.cpp:(.text+0x2422): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/shaderparamsdialog.o: in function `ShaderParamsDialog::getFilterLabel(unsigned int)':
shaderparamsdialog.cpp:(.text+0x26b): undefined reference to `msg_hash_to_str'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x2c6): undefined reference to `msg_hash_to_str'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x336): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/shaderparamsdialog.o: in function `ShaderParamsDialog::getShaders(video_shader**, video_shader**)':
shaderparamsdialog.cpp:(.text+0x416): undefined reference to `menu_shader_get'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x43b): undefined reference to `video_shader_driver_get_current_shader'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/shaderparamsdialog.o: in function `ShaderParamsDialog::onFilterComboBoxIndexChanged(int)':
shaderparamsdialog.cpp:(.text+0x635): undefined reference to `command_event'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/shaderparamsdialog.o: in function `ShaderParamsDialog::onScaleComboBoxIndexChanged(int)':
shaderparamsdialog.cpp:(.text+0x83d): undefined reference to `command_event'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/shaderparamsdialog.o: in function `ShaderParamsDialog::onShaderLoadPresetClicked()':
shaderparamsdialog.cpp:(.text+0x89c): undefined reference to `config_get_ptr'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x91a): undefined reference to `video_shader_is_supported'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x92c): undefined reference to `file_path_str'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x938): undefined reference to `video_shader_get_type_from_ext'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x94a): undefined reference to `video_shader_is_supported'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x958): undefined reference to `file_path_str'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x964): undefined reference to `video_shader_get_type_from_ext'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x976): undefined reference to `video_shader_is_supported'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x988): undefined reference to `file_path_str'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x994): undefined reference to `video_shader_get_type_from_ext'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0xa10): undefined reference to `msg_hash_to_str'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0xb28): undefined reference to `video_shader_parse_type'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0xb36): undefined reference to `menu_shader_manager_set_preset'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0xc36): undefined reference to `file_path_str'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0xd2e): undefined reference to `file_path_str'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0xe2e): undefined reference to `file_path_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/shaderparamsdialog.o: in function `ShaderParamsDialog::onShaderAddPassClicked()':
shaderparamsdialog.cpp:(.text+0x10c7): undefined reference to `config_get_ptr'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x1166): undefined reference to `video_shader_is_supported'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x1187): undefined reference to `video_shader_is_supported'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x119b): undefined reference to `video_shader_get_type_from_ext'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x11b1): undefined reference to `video_shader_is_supported'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x11c5): undefined reference to `video_shader_get_type_from_ext'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x1244): undefined reference to `msg_hash_to_str'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x1373): undefined reference to `menu_shader_manager_increment_amount_passes'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x13a4): undefined reference to `strlcpy_retro__'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x13af): undefined reference to `video_shader_resolve_parameters'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x13bb): undefined reference to `command_event'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x14db): undefined reference to `video_shader_get_type_from_ext'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/shaderparamsdialog.o: in function `ShaderParamsDialog::saveShaderPreset(char const*, unsigned int)':
shaderparamsdialog.cpp:(.text+0x1625): undefined reference to `config_get_ptr'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x162d): undefined reference to `runloop_get_libretro_system_info'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x1668): undefined reference to `filestream_exists'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x16a4): undefined reference to `path_get'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x16b4): undefined reference to `fill_pathname_parent_dir_name'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x16c7): undefined reference to `fill_pathname_join'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x16d6): undefined reference to `menu_shader_manager_save_preset'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x16e9): undefined reference to `msg_hash_to_str'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x1700): undefined reference to `runloop_msg_queue_push'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x1738): undefined reference to `strlcpy_retro__'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x175f): undefined reference to `fill_pathname_join'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x1772): undefined reference to `fill_pathname_join'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x177a): undefined reference to `filestream_exists'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x178a): undefined reference to `path_mkdir'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x17a5): undefined reference to `path_get'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x17ad): undefined reference to `path_basename'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x17c0): undefined reference to `fill_pathname_join'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/shaderparamsdialog.o: in function `ShaderParamsDialog::onShaderSavePresetAsClicked()':
shaderparamsdialog.cpp:(.text+0x1833): undefined reference to `config_get_ptr'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x1876): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/shaderparamsdialog.o: in function `ShaderParamsDialog::onShaderClearAllPassesClicked()':
shaderparamsdialog.cpp:(.text+0x1b99): undefined reference to `menu_shader_manager_decrement_amount_passes'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/shaderparamsdialog.o: in function `ShaderParamsDialog::ShaderParamsDialog(QWidget*)':
shaderparamsdialog.cpp:(.text+0x4670): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/shaderparamsdialog.o: in function `ShaderParamsDialog::onShaderRemovePassClicked()':
shaderparamsdialog.cpp:(.text+0x48fe): undefined reference to `menu_shader_manager_decrement_amount_passes'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/shaderparamsdialog.o: in function `ShaderParamsDialog::buildLayout()':
shaderparamsdialog.cpp:(.text+0x4d8b): undefined reference to `msg_hash_to_str'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x4e03): undefined reference to `msg_hash_to_str'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x4e7b): undefined reference to `msg_hash_to_str'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x4ef3): undefined reference to `msg_hash_to_str'
/usr/bin/ld: shaderparamsdialog.cpp:(.text+0x4fa5): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/shaderparamsdialog.o:shaderparamsdialog.cpp:(.text+0x5044): more undefined references to `msg_hash_to_str' follow
/usr/bin/ld: obj-unix/release/ui/drivers/qt/shaderparamsdialog.o: in function `ShaderParamsDialog::onShaderApplyClicked()':
shaderparamsdialog.cpp:(.text+0x1b58): undefined reference to `command_event'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/coreoptionsdialog.o: in function `CoreOptionsDialog::onSaveGameSpecificOptions()':
coreoptionsdialog.cpp:(.text+0x1a6): undefined reference to `retroarch_validate_game_options'
/usr/bin/ld: coreoptionsdialog.cpp:(.text+0x1b2): undefined reference to `config_file_new'
/usr/bin/ld: coreoptionsdialog.cpp:(.text+0x1ce): undefined reference to `config_file_write'
/usr/bin/ld: coreoptionsdialog.cpp:(.text+0x1da): undefined reference to `config_file_free'
/usr/bin/ld: coreoptionsdialog.cpp:(.text+0x1f6): undefined reference to `msg_hash_to_str'
/usr/bin/ld: coreoptionsdialog.cpp:(.text+0x20d): undefined reference to `runloop_msg_queue_push'
/usr/bin/ld: coreoptionsdialog.cpp:(.text+0x21a): undefined reference to `path_set'
/usr/bin/ld: coreoptionsdialog.cpp:(.text+0x226): undefined reference to `msg_hash_to_str'
/usr/bin/ld: coreoptionsdialog.cpp:(.text+0x254): undefined reference to `msg_hash_to_str'
/usr/bin/ld: coreoptionsdialog.cpp:(.text+0x303): undefined reference to `config_file_new'
/usr/bin/ld: coreoptionsdialog.cpp:(.text+0x319): undefined reference to `msg_hash_to_str'
/usr/bin/ld: coreoptionsdialog.cpp:(.text+0x347): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/coreoptionsdialog.o: in function `CoreOptionsDialog::onCoreOptionComboBoxCurrentIndexChanged(int)':
coreoptionsdialog.cpp:(.text+0x4d5): undefined reference to `rarch_ctl'
/usr/bin/ld: coreoptionsdialog.cpp:(.text+0x4e8): undefined reference to `rarch_ctl'
/usr/bin/ld: coreoptionsdialog.cpp:(.text+0x5ca): undefined reference to `rarch_ctl'
/usr/bin/ld: coreoptionsdialog.cpp:(.text+0x79c): undefined reference to `core_option_manager_set_val'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/coreoptionsdialog.o: in function `CoreOptionsDialog::CoreOptionsDialog(QWidget*)':
coreoptionsdialog.cpp:(.text+0x8f0): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/coreoptionsdialog.o: in function `CoreOptionsDialog::buildLayout()':
coreoptionsdialog.cpp:(.text+0xdf5): undefined reference to `config_get_ptr'
/usr/bin/ld: coreoptionsdialog.cpp:(.text+0xe15): undefined reference to `rarch_ctl'
/usr/bin/ld: coreoptionsdialog.cpp:(.text+0xf2b): undefined reference to `rarch_ctl'
/usr/bin/ld: coreoptionsdialog.cpp:(.text+0xf41): undefined reference to `msg_hash_to_str'
/usr/bin/ld: coreoptionsdialog.cpp:(.text+0x1053): undefined reference to `runloop_get_system_info'
/usr/bin/ld: coreoptionsdialog.cpp:(.text+0x1070): undefined reference to `path_get'
/usr/bin/ld: coreoptionsdialog.cpp:(.text+0x1151): undefined reference to `rarch_ctl'
/usr/bin/ld: coreoptionsdialog.cpp:(.text+0x116d): undefined reference to `msg_hash_to_str'
/usr/bin/ld: coreoptionsdialog.cpp:(.text+0x120f): undefined reference to `msg_hash_to_str'
/usr/bin/ld: coreoptionsdialog.cpp:(.text+0x140a): undefined reference to `rarch_ctl'
/usr/bin/ld: coreoptionsdialog.cpp:(.text+0x1477): undefined reference to `core_option_manager_get_desc'
/usr/bin/ld: coreoptionsdialog.cpp:(.text+0x14a8): undefined reference to `core_option_manager_get_val'
/usr/bin/ld: coreoptionsdialog.cpp:(.text+0x17c6): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/filedropwidget.o: in function `MainWindow::onFileDropWidgetContextMenuRequested(QPoint const&)':
filedropwidget.cpp:(.text+0x273): undefined reference to `msg_hash_to_str'
/usr/bin/ld: filedropwidget.cpp:(.text+0x6ae): undefined reference to `msg_hash_to_str'
/usr/bin/ld: filedropwidget.cpp:(.text+0x72a): undefined reference to `msg_hash_to_str'
/usr/bin/ld: filedropwidget.cpp:(.text+0x7a6): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/filedropwidget.o:filedropwidget.cpp:(.text+0x822): more undefined references to `msg_hash_to_str' follow
/usr/bin/ld: obj-unix/release/ui/drivers/qt/filedropwidget.o: in function `MainWindow::onFileDropWidgetContextMenuRequested(QPoint const&)':
filedropwidget.cpp:(.text+0x104f): undefined reference to `file_path_str'
/usr/bin/ld: filedropwidget.cpp:(.text+0x1545): undefined reference to `msg_hash_to_str'
/usr/bin/ld: filedropwidget.cpp:(.text+0x1681): undefined reference to `msg_hash_to_str'
/usr/bin/ld: filedropwidget.cpp:(.text+0x1818): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/coreinfodialog.o: in function `CoreInfoDialog::CoreInfoDialog(MainWindow*, QWidget*)':
coreinfodialog.cpp:(.text+0xfd): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/playlistentrydialog.o: in function `PlaylistEntryDialog::PlaylistEntryDialog(MainWindow*, QWidget*)':
playlistentrydialog.cpp:(.text+0x588): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/playlistentrydialog.o:playlistentrydialog.cpp:(.text+0x677): more undefined references to `msg_hash_to_str' follow
/usr/bin/ld: obj-unix/release/ui/drivers/qt/playlistentrydialog.o: in function `PlaylistEntryDialog::loadPlaylistOptions()':
playlistentrydialog.cpp:(.text+0x1780): undefined reference to `file_path_str'
/usr/bin/ld: playlistentrydialog.cpp:(.text+0x17d0): undefined reference to `msg_hash_to_str'
/usr/bin/ld: playlistentrydialog.cpp:(.text+0x1a27): undefined reference to `core_info_get_list'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/playlistentrydialog.o: in function `PlaylistEntryDialog::setEntryValues(QHash<QString, QString> const&)':
playlistentrydialog.cpp:(.text+0x3d3e): undefined reference to `msg_hash_to_str'
/usr/bin/ld: playlistentrydialog.cpp:(.text+0x3db9): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/viewoptionsdialog.o: in function `ViewOptionsDialog::onThemeComboBoxIndexChanged(int)':
viewoptionsdialog.cpp:(.text+0x16d): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/viewoptionsdialog.o: in function `ViewOptionsDialog::onHighlightColorChoose()':
viewoptionsdialog.cpp:(.text+0x103b): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/viewoptionsdialog.o: in function `ViewOptionsDialog::ViewOptionsDialog(MainWindow*, QWidget*)':
viewoptionsdialog.cpp:(.text+0x21fc): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/viewoptionsdialog.o:viewoptionsdialog.cpp:(.text+0x2280): more undefined references to `msg_hash_to_str' follow
/usr/bin/ld: obj-unix/release/ui/drivers/qt/qt_playlist.o: in function `MainWindow::currentPlaylistIsSpecial()':
qt_playlist.cpp:(.text+0x142): undefined reference to `config_get_ptr'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/qt_playlist.o: in function `MainWindow::getPlaylistFiles()':
qt_playlist.cpp:(.text+0x44e): undefined reference to `config_get_ptr'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/qt_playlist.o: in function `PlaylistModel::getThumbnailPath(QModelIndex const&, QString) const':
qt_playlist.cpp:(.text+0x77c): undefined reference to `config_get_ptr'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/qt_playlist.o: in function `MainWindow::reloadPlaylists()':
qt_playlist.cpp:(.text+0xd15): undefined reference to `config_get_ptr'
/usr/bin/ld: qt_playlist.cpp:(.text+0xe8b): undefined reference to `msg_hash_to_str'
/usr/bin/ld: qt_playlist.cpp:(.text+0xf05): undefined reference to `msg_hash_to_str'
/usr/bin/ld: qt_playlist.cpp:(.text+0xf82): undefined reference to `msg_hash_to_str'
/usr/bin/ld: qt_playlist.cpp:(.text+0x1006): undefined reference to `msg_hash_to_str'
/usr/bin/ld: qt_playlist.cpp:(.text+0x1080): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/qt_playlist.o:qt_playlist.cpp:(.text+0x10f3): more undefined references to `msg_hash_to_str' follow
/usr/bin/ld: obj-unix/release/ui/drivers/qt/qt_playlist.o: in function `MainWindow::reloadPlaylists()':
qt_playlist.cpp:(.text+0x16d8): undefined reference to `file_path_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/qt_playlist.o: in function `MainWindow::updateCurrentPlaylistEntry(QHash<QString, QString> const&)':
qt_playlist.cpp:(.text+0x2466): undefined reference to `file_path_str'
/usr/bin/ld: qt_playlist.cpp:(.text+0x2579): undefined reference to `path_is_compressed_file'
/usr/bin/ld: qt_playlist.cpp:(.text+0x2587): undefined reference to `file_archive_get_file_list'
/usr/bin/ld: qt_playlist.cpp:(.text+0x25aa): undefined reference to `string_list_free'
/usr/bin/ld: qt_playlist.cpp:(.text+0x25bb): undefined reference to `playlist_init'
/usr/bin/ld: qt_playlist.cpp:(.text+0x25f0): undefined reference to `playlist_update'
/usr/bin/ld: qt_playlist.cpp:(.text+0x25fa): undefined reference to `playlist_write_file'
/usr/bin/ld: qt_playlist.cpp:(.text+0x2602): undefined reference to `playlist_free'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/qt_playlist.o: in function `MainWindow::deleteCurrentPlaylistItem()':
qt_playlist.cpp:(.text+0x287e): undefined reference to `msg_hash_to_str'
/usr/bin/ld: qt_playlist.cpp:(.text+0x2910): undefined reference to `playlist_init'
/usr/bin/ld: qt_playlist.cpp:(.text+0x291f): undefined reference to `playlist_delete_index'
/usr/bin/ld: qt_playlist.cpp:(.text+0x2927): undefined reference to `playlist_write_file'
/usr/bin/ld: qt_playlist.cpp:(.text+0x292f): undefined reference to `playlist_free'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/qt_playlist.o: in function `MainWindow::addDirectoryFilesToList(QProgressDialog*, QStringList&, QDir&, QStringList&) [clone .localalias.146]':
qt_playlist.cpp:(.text+0x2c14): undefined reference to `path_is_compressed_file'
/usr/bin/ld: qt_playlist.cpp:(.text+0x2c22): undefined reference to `file_archive_get_file_list'
/usr/bin/ld: qt_playlist.cpp:(.text+0x2c3b): undefined reference to `string_list_free'
/usr/bin/ld: qt_playlist.cpp:(.text+0x2cf4): undefined reference to `string_list_free'
/usr/bin/ld: qt_playlist.cpp:(.text+0x2d79): undefined reference to `string_list_free'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/qt_playlist.o: in function `MainWindow::addFilesToPlaylist(QStringList)':
qt_playlist.cpp:(.text+0x3247): undefined reference to `file_path_str'
/usr/bin/ld: qt_playlist.cpp:(.text+0x328a): undefined reference to `msg_hash_to_str'
/usr/bin/ld: qt_playlist.cpp:(.text+0x34ce): undefined reference to `msg_hash_to_str'
/usr/bin/ld: qt_playlist.cpp:(.text+0x372c): undefined reference to `msg_hash_to_str'
/usr/bin/ld: qt_playlist.cpp:(.text+0x38f3): undefined reference to `msg_hash_to_str'
/usr/bin/ld: qt_playlist.cpp:(.text+0x3946): undefined reference to `playlist_init'
/usr/bin/ld: qt_playlist.cpp:(.text+0x3b37): undefined reference to `path_is_compressed_file'
/usr/bin/ld: qt_playlist.cpp:(.text+0x3b49): undefined reference to `file_archive_get_file_list'
/usr/bin/ld: qt_playlist.cpp:(.text+0x3b6c): undefined reference to `string_list_free'
/usr/bin/ld: qt_playlist.cpp:(.text+0x3ba5): undefined reference to `playlist_push'
/usr/bin/ld: qt_playlist.cpp:(.text+0x3ee8): undefined reference to `path_is_compressed_file'
/usr/bin/ld: qt_playlist.cpp:(.text+0x3fac): undefined reference to `playlist_write_file'
/usr/bin/ld: qt_playlist.cpp:(.text+0x3fb8): undefined reference to `playlist_free'
/usr/bin/ld: qt_playlist.cpp:(.text+0x4154): undefined reference to `string_list_free'
/usr/bin/ld: qt_playlist.cpp:(.text+0x4168): undefined reference to `playlist_free'
/usr/bin/ld: qt_playlist.cpp:(.text+0x41d7): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/qt_playlist.o: in function `MainWindow::getPlaylistDefaultCores()':
qt_playlist.cpp:(.text+0x4547): undefined reference to `config_get_ptr'
/usr/bin/ld: qt_playlist.cpp:(.text+0x455d): undefined reference to `string_split'
/usr/bin/ld: qt_playlist.cpp:(.text+0x4573): undefined reference to `string_split'
/usr/bin/ld: qt_playlist.cpp:(.text+0x4645): undefined reference to `file_path_str'
/usr/bin/ld: qt_playlist.cpp:(.text+0x46d0): undefined reference to `string_list_free'
/usr/bin/ld: qt_playlist.cpp:(.text+0x46dd): undefined reference to `string_list_free'
/usr/bin/ld: qt_playlist.cpp:(.text+0x4702): undefined reference to `RARCH_WARN'
/usr/bin/ld: qt_playlist.cpp:(.text+0x471a): undefined reference to `RARCH_WARN'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/qt_playlist.o: in function `PlaylistModel::getPlaylistItems(QString)':
qt_playlist.cpp:(.text+0x47bd): undefined reference to `playlist_init'
/usr/bin/ld: qt_playlist.cpp:(.text+0x47cc): undefined reference to `playlist_get_size'
/usr/bin/ld: qt_playlist.cpp:(.text+0x49c1): undefined reference to `file_path_str'
/usr/bin/ld: qt_playlist.cpp:(.text+0x4a9b): undefined reference to `playlist_get_index'
/usr/bin/ld: qt_playlist.cpp:(.text+0x4bb0): undefined reference to `playlist_free'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/qt_playlist.o: in function `PlaylistModel::reloadSystemThumbnails(QString)':
qt_playlist.cpp:(.text+0x5401): undefined reference to `config_get_ptr'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/qt_playlist.o: in function `MainWindow::onPlaylistWidgetContextMenuRequested(QPoint const&)':
qt_playlist.cpp:(.text+0x67f8): undefined reference to `config_get_ptr'
/usr/bin/ld: qt_playlist.cpp:(.text+0x694f): undefined reference to `string_split'
/usr/bin/ld: qt_playlist.cpp:(.text+0x6973): undefined reference to `string_split'
/usr/bin/ld: qt_playlist.cpp:(.text+0x6b62): undefined reference to `msg_hash_to_str'
/usr/bin/ld: qt_playlist.cpp:(.text+0x6b9e): undefined reference to `msg_hash_to_str'
/usr/bin/ld: qt_playlist.cpp:(.text+0x6c6c): undefined reference to `msg_hash_to_str'
/usr/bin/ld: qt_playlist.cpp:(.text+0x6df7): undefined reference to `msg_hash_to_str'
/usr/bin/ld: qt_playlist.cpp:(.text+0x70d0): undefined reference to `string_list_free'
/usr/bin/ld: qt_playlist.cpp:(.text+0x70e4): undefined reference to `string_list_free'
/usr/bin/ld: qt_playlist.cpp:(.text+0x7246): undefined reference to `msg_hash_to_str'
/usr/bin/ld: qt_playlist.cpp:(.text+0x72aa): undefined reference to `core_info_get_list'
/usr/bin/ld: qt_playlist.cpp:(.text+0x78c2): undefined reference to `msg_hash_to_str'
/usr/bin/ld: qt_playlist.cpp:(.text+0x791c): undefined reference to `msg_hash_to_str'
/usr/bin/ld: qt_playlist.cpp:(.text+0x7958): undefined reference to `msg_hash_to_str'
/usr/bin/ld: qt_playlist.cpp:(.text+0x79d6): undefined reference to `msg_hash_to_str'
/usr/bin/ld: qt_playlist.cpp:(.text+0x7a3e): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/qt_playlist.o:qt_playlist.cpp:(.text+0x7c1d): more undefined references to `msg_hash_to_str' follow
/usr/bin/ld: obj-unix/release/ui/drivers/qt/qt_playlist.o: in function `MainWindow::onPlaylistWidgetContextMenuRequested(QPoint const&)':
qt_playlist.cpp:(.text+0x7c99): undefined reference to `file_path_str'
/usr/bin/ld: qt_playlist.cpp:(.text+0x7d94): undefined reference to `string_list_find_elem'
/usr/bin/ld: qt_playlist.cpp:(.text+0x7e14): undefined reference to `string_list_set'
/usr/bin/ld: qt_playlist.cpp:(.text+0x7e4e): undefined reference to `string_list_join_concat'
/usr/bin/ld: qt_playlist.cpp:(.text+0x7e70): undefined reference to `string_list_join_concat'
/usr/bin/ld: qt_playlist.cpp:(.text+0x7e84): undefined reference to `strlcpy_retro__'
/usr/bin/ld: qt_playlist.cpp:(.text+0x7e98): undefined reference to `strlcpy_retro__'
/usr/bin/ld: qt_playlist.cpp:(.text+0x7f39): undefined reference to `msg_hash_to_str'
/usr/bin/ld: qt_playlist.cpp:(.text+0x7f4e): undefined reference to `msg_hash_to_str'
/usr/bin/ld: qt_playlist.cpp:(.text+0x8223): undefined reference to `msg_hash_to_str'
/usr/bin/ld: qt_playlist.cpp:(.text+0x8416): undefined reference to `string_list_append'
/usr/bin/ld: qt_playlist.cpp:(.text+0x842b): undefined reference to `string_list_append'
/usr/bin/ld: qt_playlist.cpp:(.text+0x843a): undefined reference to `string_list_find_elem'
/usr/bin/ld: qt_playlist.cpp:(.text+0x84ba): undefined reference to `string_list_set'
/usr/bin/ld: qt_playlist.cpp:(.text+0x8530): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/updateretroarch.o: in function `MainWindow::onUpdateNetworkError(QNetworkReply::NetworkError)':
updateretroarch.cpp:(.text+0xd9): undefined reference to `RARCH_ERR'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/updateretroarch.o: in function `MainWindow::onUpdateNetworkSslErrors(QList<QSslError> const&)':
updateretroarch.cpp:(.text+0x2ff): undefined reference to `RARCH_ERR'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/updateretroarch.o: in function `MainWindow::onUpdateRetroArchFinished(bool)':
updateretroarch.cpp:(.text+0x63a): undefined reference to `RARCH_LOG'
/usr/bin/ld: updateretroarch.cpp:(.text+0x644): undefined reference to `msg_hash_to_str'
/usr/bin/ld: updateretroarch.cpp:(.text+0x6ca): undefined reference to `RARCH_ERR'
/usr/bin/ld: updateretroarch.cpp:(.text+0x6d4): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/updateretroarch.o: in function `extractUpdateCB(void*, void*, char const*)':
updateretroarch.cpp:(.text+0x74f): undefined reference to `RARCH_ERR'
/usr/bin/ld: updateretroarch.cpp:(.text+0x75c): undefined reference to `filestream_exists'
/usr/bin/ld: updateretroarch.cpp:(.text+0x799): undefined reference to `filestream_exists'
/usr/bin/ld: updateretroarch.cpp:(.text+0x7a5): undefined reference to `filestream_delete'
/usr/bin/ld: updateretroarch.cpp:(.text+0x7ec): undefined reference to `filestream_delete'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/updateretroarch.o: in function `MainWindow::removeUpdateTempFiles()':
updateretroarch.cpp:(.text+0xb0f): undefined reference to `RARCH_LOG'
/usr/bin/ld: updateretroarch.cpp:(.text+0xc8a): undefined reference to `RARCH_LOG'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/updateretroarch.o: in function `MainWindow::onRetroArchUpdateDownloadFinished()':
updateretroarch.cpp:(.text+0xf2a): undefined reference to `RARCH_LOG'
/usr/bin/ld: updateretroarch.cpp:(.text+0x10d6): undefined reference to `RARCH_ERR'
/usr/bin/ld: updateretroarch.cpp:(.text+0x10f7): undefined reference to `msg_hash_to_str'
/usr/bin/ld: updateretroarch.cpp:(.text+0x13cb): undefined reference to `msg_hash_to_str'
/usr/bin/ld: updateretroarch.cpp:(.text+0x1514): undefined reference to `RARCH_ERR'
/usr/bin/ld: updateretroarch.cpp:(.text+0x171a): undefined reference to `RARCH_ERR'
/usr/bin/ld: updateretroarch.cpp:(.text+0x1724): undefined reference to `msg_hash_to_str'
/usr/bin/ld: updateretroarch.cpp:(.text+0x1830): undefined reference to `RARCH_ERR'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/updateretroarch.o: in function `MainWindow::updateRetroArchNightly()':
updateretroarch.cpp:(.text+0x1cb0): undefined reference to `RARCH_LOG'
/usr/bin/ld: updateretroarch.cpp:(.text+0x1cc6): undefined reference to `RARCH_LOG'
/usr/bin/ld: updateretroarch.cpp:(.text+0x1d5f): undefined reference to `msg_hash_to_str'
/usr/bin/ld: updateretroarch.cpp:(.text+0x2272): undefined reference to `RARCH_ERR'
/usr/bin/ld: updateretroarch.cpp:(.text+0x22be): undefined reference to `msg_hash_to_str'
/usr/bin/ld: updateretroarch.cpp:(.text+0x233f): undefined reference to `RARCH_ERR'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/thumbnaildownload.o: in function `MainWindow::onThumbnailDownloadNetworkError(QNetworkReply::NetworkError)':
thumbnaildownload.cpp:(.text+0xd9): undefined reference to `RARCH_ERR'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/thumbnaildownload.o: in function `MainWindow::onThumbnailDownloadNetworkSslErrors(QList<QSslError> const&)':
thumbnaildownload.cpp:(.text+0x2ff): undefined reference to `RARCH_ERR'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/thumbnaildownload.o: in function `MainWindow::downloadThumbnail(QString, QString, QUrl) [clone .localalias.18]':
thumbnaildownload.cpp:(.text+0x7e0): undefined reference to `config_get_ptr'
/usr/bin/ld: thumbnaildownload.cpp:(.text+0x1404): undefined reference to `RARCH_LOG'
/usr/bin/ld: thumbnaildownload.cpp:(.text+0x141c): undefined reference to `RARCH_LOG'
/usr/bin/ld: thumbnaildownload.cpp:(.text+0x14b3): undefined reference to `msg_hash_to_str'
/usr/bin/ld: thumbnaildownload.cpp:(.text+0x1972): undefined reference to `msg_hash_to_str'
/usr/bin/ld: thumbnaildownload.cpp:(.text+0x19f9): undefined reference to `RARCH_ERR'
/usr/bin/ld: thumbnaildownload.cpp:(.text+0x1f1a): undefined reference to `RARCH_ERR'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/thumbnaildownload.o: in function `MainWindow::onThumbnailDownloadFinished()':
thumbnaildownload.cpp:(.text+0x255e): undefined reference to `RARCH_ERR'
/usr/bin/ld: thumbnaildownload.cpp:(.text+0x2736): undefined reference to `RARCH_ERR'
/usr/bin/ld: thumbnaildownload.cpp:(.text+0x275c): undefined reference to `msg_hash_to_str'
/usr/bin/ld: thumbnaildownload.cpp:(.text+0x2bf7): undefined reference to `RARCH_LOG'
/usr/bin/ld: thumbnaildownload.cpp:(.text+0x2e28): undefined reference to `RARCH_LOG'
/usr/bin/ld: thumbnaildownload.cpp:(.text+0x30da): undefined reference to `RARCH_ERR'
/usr/bin/ld: thumbnaildownload.cpp:(.text+0x30e4): undefined reference to `msg_hash_to_str'
/usr/bin/ld: thumbnaildownload.cpp:(.text+0x3238): undefined reference to `RARCH_ERR'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/thumbnailpackdownload.o: in function `MainWindow::onThumbnailPackDownloadNetworkError(QNetworkReply::NetworkError)':
thumbnailpackdownload.cpp:(.text+0xd9): undefined reference to `RARCH_ERR'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/thumbnailpackdownload.o: in function `MainWindow::onThumbnailPackDownloadNetworkSslErrors(QList<QSslError> const&)':
thumbnailpackdownload.cpp:(.text+0x2ff): undefined reference to `RARCH_ERR'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/thumbnailpackdownload.o: in function `MainWindow::onThumbnailPackExtractFinished(bool)':
thumbnailpackdownload.cpp:(.text+0x770): undefined reference to `RARCH_LOG'
/usr/bin/ld: thumbnailpackdownload.cpp:(.text+0x77a): undefined reference to `msg_hash_to_str'
/usr/bin/ld: thumbnailpackdownload.cpp:(.text+0x8ba): undefined reference to `RARCH_ERR'
/usr/bin/ld: thumbnailpackdownload.cpp:(.text+0x8c4): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/thumbnailpackdownload.o: in function `extractThumbnailPackCB(void*, void*, char const*)':
thumbnailpackdownload.cpp:(.text+0x99f): undefined reference to `RARCH_ERR'
/usr/bin/ld: thumbnailpackdownload.cpp:(.text+0x9ac): undefined reference to `filestream_exists'
/usr/bin/ld: thumbnailpackdownload.cpp:(.text+0x9e9): undefined reference to `filestream_exists'
/usr/bin/ld: thumbnailpackdownload.cpp:(.text+0x9f5): undefined reference to `filestream_delete'
/usr/bin/ld: thumbnailpackdownload.cpp:(.text+0xa3c): undefined reference to `filestream_delete'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/thumbnailpackdownload.o: in function `MainWindow::downloadAllThumbnails(QString, QUrl)':
thumbnailpackdownload.cpp:(.text+0xab2): undefined reference to `config_get_ptr'
/usr/bin/ld: thumbnailpackdownload.cpp:(.text+0x1026): undefined reference to `RARCH_LOG'
/usr/bin/ld: thumbnailpackdownload.cpp:(.text+0x103c): undefined reference to `RARCH_LOG'
/usr/bin/ld: thumbnailpackdownload.cpp:(.text+0x10d3): undefined reference to `msg_hash_to_str'
/usr/bin/ld: thumbnailpackdownload.cpp:(.text+0x14f2): undefined reference to `msg_hash_to_str'
/usr/bin/ld: thumbnailpackdownload.cpp:(.text+0x1573): undefined reference to `RARCH_ERR'
/usr/bin/ld: thumbnailpackdownload.cpp:(.text+0x1712): undefined reference to `RARCH_ERR'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/thumbnailpackdownload.o: in function `MainWindow::onThumbnailPackDownloadFinished()':
thumbnailpackdownload.cpp:(.text+0x1ba7): undefined reference to `msg_hash_to_str'
/usr/bin/ld: thumbnailpackdownload.cpp:(.text+0x1d07): undefined reference to `RARCH_ERR'
/usr/bin/ld: thumbnailpackdownload.cpp:(.text+0x1e45): undefined reference to `RARCH_ERR'
/usr/bin/ld: thumbnailpackdownload.cpp:(.text+0x1e66): undefined reference to `msg_hash_to_str'
/usr/bin/ld: thumbnailpackdownload.cpp:(.text+0x2213): undefined reference to `config_get_ptr'
/usr/bin/ld: thumbnailpackdownload.cpp:(.text+0x222d): undefined reference to `RARCH_LOG'
/usr/bin/ld: thumbnailpackdownload.cpp:(.text+0x2377): undefined reference to `RARCH_LOG'
/usr/bin/ld: thumbnailpackdownload.cpp:(.text+0x2442): undefined reference to `RARCH_ERR'
/usr/bin/ld: thumbnailpackdownload.cpp:(.text+0x244c): undefined reference to `msg_hash_to_str'
/usr/bin/ld: thumbnailpackdownload.cpp:(.text+0x2768): undefined reference to `RARCH_ERR'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/playlistthumbnaildownload.o: in function `MainWindow::onPlaylistThumbnailDownloadNetworkSslErrors(QList<QSslError> const&)':
playlistthumbnaildownload.cpp:(.text+0x13f): undefined reference to `RARCH_ERR'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/playlistthumbnaildownload.o: in function `MainWindow::downloadNextPlaylistThumbnail(QString, QString, QString, QUrl) [clone .localalias.42]':
playlistthumbnaildownload.cpp:(.text+0x5e6): undefined reference to `config_get_ptr'
/usr/bin/ld: playlistthumbnaildownload.cpp:(.text+0x1377): undefined reference to `RARCH_ERR'
/usr/bin/ld: playlistthumbnaildownload.cpp:(.text+0x19d3): undefined reference to `msg_hash_to_str'
/usr/bin/ld: playlistthumbnaildownload.cpp:(.text+0x1a1e): undefined reference to `msg_hash_to_str'
/usr/bin/ld: playlistthumbnaildownload.cpp:(.text+0x1cb2): undefined reference to `RARCH_ERR'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/playlistthumbnaildownload.o: in function `MainWindow::onPlaylistThumbnailDownloadFinished()':
playlistthumbnaildownload.cpp:(.text+0x2ba6): undefined reference to `RARCH_LOG'
/usr/bin/ld: playlistthumbnaildownload.cpp:(.text+0x31ef): undefined reference to `RARCH_ERR'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/playlistthumbnaildownload.o: in function `MainWindow::downloadPlaylistThumbnails(QString)':
playlistthumbnaildownload.cpp:(.text+0x3405): undefined reference to `config_get_ptr'
/usr/bin/ld: playlistthumbnaildownload.cpp:(.text+0x399c): undefined reference to `msg_hash_to_str'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/playlistthumbnaildownload.o: in function `MainWindow::onPlaylistThumbnailDownloadCanceled()':
playlistthumbnaildownload.cpp:(.text+0x462): undefined reference to `RARCH_LOG'
collect2: error: ld returned 1 exit status
make: *** [Makefile:195: retroarch] Error 1
```

## Reviewers

@twinaphex 