### PR TITLE
libnx swkbd overclock fix + ozone memory leak fix

### DIFF
--- a/menu/drivers/ozone/ozone_sidebar.c
+++ b/menu/drivers/ozone/ozone_sidebar.c
@@ -423,16 +423,7 @@ void ozone_init_horizontal_list(ozone_handle_t *ozone)
    if (settings->bools.menu_content_show_playlists && !string_is_empty(info.path))
    {
       if (menu_displaylist_ctl(DISPLAYLIST_DATABASE_PLAYLISTS_HORIZONTAL, &info))
-      {
-         size_t i;
-         for (i = 0; i < ozone->horizontal_list->size; i++)
-         {
-            ozone_node_t *node = ozone_alloc_node();
-            file_list_set_userdata(ozone->horizontal_list, i, node);
-         }
-
          menu_displaylist_process(&info);
-      }
    }
 
    menu_displaylist_info_free(&info);

--- a/menu/widgets/menu_input_dialog.c
+++ b/menu/widgets/menu_input_dialog.c
@@ -23,6 +23,7 @@
 
 #ifdef HAVE_LIBNX
 #include <switch.h>
+#include "../../switch_performance_profiles.h"
 #include "menu_osk.h"
 #endif
 
@@ -92,6 +93,7 @@ unsigned menu_input_dialog_get_kb_idx(void)
 #ifdef HAVE_LIBNX
 #define LIBNX_SWKBD_LIMIT 500 /* enforced by HOS */
 extern u32 __nx_applet_type;
+extern void libnx_apply_overclock();
 #endif
 
 bool menu_input_dialog_get_display_kb(void)
@@ -105,6 +107,8 @@ bool menu_input_dialog_get_display_kb(void)
       return false;
 
    SwkbdConfig kbd;
+
+   pcvSetClockRate(PcvModule_Cpu, SWITCH_CPU_SPEEDS_VALUES[SWITCH_DEFAULT_CPU_PROFILE]);
 
    Result rc = swkbdCreate(&kbd, 0);
 
@@ -145,10 +149,14 @@ bool menu_input_dialog_get_display_kb(void)
       if (menu_input_dialog_keyboard_display)
          input_keyboard_event(true, '\n', '\n', 0, RETRO_DEVICE_KEYBOARD);
 
+      libnx_apply_overclock();
       return false;
    }
    else
+   {
+      libnx_apply_overclock();
       return menu_input_dialog_keyboard_display;
+   }
 #endif
    return menu_input_dialog_keyboard_display;
 }


### PR DESCRIPTION
- the libnx swkbd caused the console to panic if opened while overclocked, so now we reset the clock back to stock before opening it and reset overclock afterwards
- @bparker06 noticed a small memory leak in ozone, it is now fixed (for some reason the leak is not present in xmb, I guess loading playlists does not call `list_insert` for xmb but does for ozone, go figure)