### PR TITLE
Fix parent of root directory turning into ./ on Windows

### DIFF
--- a/libretro-common/include/file/file_path.h
+++ b/libretro-common/include/file/file_path.h
@@ -136,6 +136,7 @@ void path_basedir(char *path);
  *
  * Extracts parent directory by mutating path.
  * Assumes that path is a directory. Keeps trailing '/'.
+ * If the path was already at the root directory, returns empty string
  **/
 void path_parent_dir(char *path);
 
@@ -314,6 +315,7 @@ bool fill_pathname_parent_dir_name(char *out_dir,
  *
  * Copies parent directory of @in_dir into @out_dir.
  * Assumes @in_dir is a directory. Keeps trailing '/'.
+ * If the path was already at the root directory, @out_dir will be an empty string.
  **/
 void fill_pathname_parent_dir(char *out_dir,
       const char *in_dir, size_t size);


### PR DESCRIPTION
## Description

This fixes an issue in file_path.c which causes the parent dir of `C:\` to be `./`, while the parent dir of `/` on Linux correctly turned into an empty string. As far as I could find, this code doesn't seem to have been changed since at least around https://github.com/libretro/libretro-common/commit/e3d635f24c3d59867493b4b3c1fe41c41e679915 so I assume this was a bug in the original implementation.

## Related Issues

Fixes #7803

## Reviewers

@fr500 @twinaphex
