### PR TITLE
Fix screenshot filename with no core or content.

### DIFF
--- a/tasks/task_screenshot.c
+++ b/tasks/task_screenshot.c
@@ -237,12 +237,20 @@ static bool screenshot_dump(
       {
          if (settings->bools.auto_screenshot_filename)
          {
+            const char *screenshot_name = NULL;
+
             if (path_is_empty(RARCH_PATH_CONTENT))
-               fill_str_dated_filename(shotname, system_info.library_name,
-                     IMG_EXT, sizeof(shotname));
+            {
+               if (string_is_empty(system_info.library_name))
+                  screenshot_name = "RetroArch";
+               else
+                  screenshot_name = system_info.library_name;
+            }
             else
-               fill_str_dated_filename(shotname, path_basename(name_base),
-                     IMG_EXT, sizeof(shotname));
+               screenshot_name = path_basename(name_base);
+
+            fill_str_dated_filename(shotname, screenshot_name,
+                  IMG_EXT, sizeof(shotname));
          }
          else
             snprintf(shotname, sizeof(shotname),


### PR DESCRIPTION
## Description

If RetroArch takes a screenshot without any cores or content loaded it will create a file name like `-190115-215142.png`, now it will be `RetroArch-190115-215142.png`. If any content or cores are loaded then the current behavior will remain unchanged.

So far the only way I know to take a screenshot of the menu is with a command like.
```
retroarch --max-frames 200 --max-frames-ss
```
Unfortunately the created image just shows black and no menu, but at least the file name is right now...

## Related Issues

https://github.com/libretro/libretro-common/issues/94
https://github.com/libretro/RetroArch/issues/7828

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/7829
https://github.com/libretro/RetroArch/pull/3407
