### PR TITLE
Silence errors for empty playlist files.

### DIFF
--- a/playlist.c
+++ b/playlist.c
@@ -832,6 +832,10 @@ static bool playlist_read_file(
       char buf[16] = {0};
       int64_t bytes_read = filestream_read(file, buf, 15);
 
+      /* Empty playlist file */
+      if (bytes_read == 0)
+         return true;
+
       filestream_seek(file, 0, SEEK_SET);
 
       if (bytes_read == 15)


### PR DESCRIPTION
## Description

Silences an error and warnings when a playlist file exists, but is empty.
```
[INFO] Loading history file: [/home/orbea/.config/retroarch/content_video_history.lpl].
[ERROR] Could not detect playlist format.
[WARN] Error parsing JSON.
[WARN] Error: Invalid JSON at line 1, column 1 (input byte 0) - the input ends when more tokens are expected.
```

## Related Issues

Fixes https://github.com/libretro/RetroArch/issues/8015.

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/7959

## Reviewers

@bparker06 