### PR TITLE
Fix -Wmissing-braces warning with clang.

### DIFF
--- a/playlist.c
+++ b/playlist.c
@@ -928,7 +928,7 @@ static bool playlist_read_file(
    }
    else
    {
-      char buf[PLAYLIST_ENTRIES][1024] = {0};
+      char buf[PLAYLIST_ENTRIES][1024] = {{0}};
 
       for (i = 0; i < PLAYLIST_ENTRIES; i++)
          buf[i][0] = '\0';


### PR DESCRIPTION
## Description

Fixes a `-Wmissing-braces` warning with `clang-7.0.0`.

## Related Issues

```
playlist.c:931:43: warning: suggest braces around initialization of subobject [-Wmissing-braces]
      char buf[PLAYLIST_ENTRIES][1024] = {0};
                                          ^
                                          {}
1 warning generated.
```