### PR TITLE
travis: Don't use libretro-super for xcode9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,20 +44,17 @@ matrix:
     - os: osx
       osx_image: xcode8
       script:
-          - xcodebuild -target RetroArch -configuration Release -project pkg/apple/RetroArch.xcodeproj
+        - xcodebuild -target RetroArch -configuration Release -project pkg/apple/RetroArch.xcodeproj
     - os: osx
       osx_image: xcode9.3
       script:
-        - cd ~/
         - brew update
         - brew install --force-bottle qt5
-        - git clone --depth=50 https://github.com/libretro/libretro-super
-        - cd libretro-super/travis
-        - ./build-retroarch-metal.sh
+        - xcodebuild -target RetroArchQt -configuration Release -project pkg/apple/RetroArch_Metal.xcodeproj
       deploy:
         skip_cleanup: true
         provider: script
-        script: cd ../retroarch; bash travis_metal_deploy.sh
+        script: bash travis_metal_deploy.sh
         on:
           branch: master
 


### PR DESCRIPTION
## Description

This stops using libretro-super for the xcode9.3 travis build for two reasons.

* After fixing the error code so the build failed as expected, the redirected logging made it not possible to actually see the travis errors. When avoiding the libretro-super repo this problem is entirely avoided and the build command should remain the same.
* When using libretro-super travis clones Retroarch twice and the libretro-super repo once, now it should only need to clone RetroArch once which should make the build a little bit faster.

## Related Issues

The travis xcode9.3 build is failing, but we can't see the error.

## Related Pull Requests

https://github.com/libretro/libretro-super/pull/932

## Reviewers

Wait for travis to finish so the output can be reviewed. It should fail and the error should be visible.
