### PR TITLE
qb: Check for a Qt5 moc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 .tmp
 .tmp.c
 .tmp.cxx
+.moc.h
+.moc.cpp
 config.log
 /.project
 /.externalToolBuilders/

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -277,7 +277,7 @@ check_val '' SDL2 -lSDL2 SDL2
 
 check_enabled QT 'Qt companion'
 
-if [ "$HAVE_QT" != 'no' ] && [ "$MOC_PATH" != 'none' ]; then
+if [ "$HAVE_QT" != 'no' ] && [ "$HAVE_MOC" = 'yes' ]; then
    check_pkgconf QT5CORE Qt5Core 5.2
    check_pkgconf QT5GUI Qt5Gui 5.2
    check_pkgconf QT5WIDGETS Qt5Widgets 5.2
@@ -286,13 +286,7 @@ if [ "$HAVE_QT" != 'no' ] && [ "$MOC_PATH" != 'none' ]; then
    #check_pkgconf QT5WEBENGINE Qt5WebEngine 5.4
    check_pkgconf OPENSSL openssl 1.0.0
 
-   check_val '' QT5CORE -lQt5Core QT5CORE
-   check_val '' QT5GUI -lQt5Gui QT5GUI
-   check_val '' QT5WIDGETS -lQt5Widgets QT5WIDGETS
-   check_val '' QT5CONCURRENT -lQt5Concurrent QT5CONCURRENT
-   check_val '' QT5NETWORK -lQt5Network QT5NETWORK
-   #check_val '' QT5WEBENGINE -lQt5WebEngine QT5WEBENGINE
-   check_val '' OPENSSL -lssl OPENSSL
+   # pkg-config is needed to reliably find Qt5 libraries.
 
    if [ "$HAVE_QT5CORE" = "no" ] || [ "$HAVE_QT5GUI" = "no" ] || [ "$HAVE_QT5WIDGETS" = "no" ] || [ "$HAVE_QT5CONCURRENT" = "no" ] || [ "$HAVE_QT5NETWORK" = "no" ]; then
       die : 'Notice: Not building Qt support, required libraries were not found.'


### PR DESCRIPTION
## Description

This adds a check to the qb configure script to make sure its using the Qt5 moc and not the Qt4 moc. The test code it compiles to check moc is thanks to @bparker06.

This also increases the dependency on a working `pkg-config` implementation for Qt support, but its unlikely to ever work well without `pkg-config` anyways and not really worth the effort to fix that.

I tested this patch with the following cases.

* With `$MOC` unset where it found `moc-qt5` like before.
* With setting `$MOC` to `moc-qt5` where it worked as expected.
* With setting `$MOC` to `moc` (Qt4) where it failed and skipped the Qt build as expected.
* With setting `$MOC` to a non-existent variable where it failed and skipped the Qt build as expected.

## Related Issues

This prevents users from trying to compile the Qt5 companion ui with a Qt4 moc which will certainly fail and matches the existing checks for c and c++ compilers.

See https://github.com/libretro/RetroArch/issues/8028.

## Reviewers

@bparker06 Can you test this?