### PR TITLE
qb: Create qb.moc.sh and qb.make.sh.

### DIFF
--- a/configure
+++ b/configure
@@ -11,3 +11,7 @@ cat /dev/null > config.log
 . qb/qb.comp.sh
 
 . qb/qb.libs.sh
+
+. qb/qb.moc.sh
+
+. qb/qb.make.sh

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -277,7 +277,7 @@ check_val '' SDL2 -lSDL2 SDL2
 
 check_enabled QT 'Qt companion'
 
-if [ "$HAVE_QT" != 'no' ] && [ "$HAVE_MOC" = 'yes' ]; then
+if [ "$HAVE_QT" != 'no' ] && [ "$HAVE_CXX" != "no" ]; then
    check_pkgconf QT5CORE Qt5Core 5.2
    check_pkgconf QT5GUI Qt5Gui 5.2
    check_pkgconf QT5WIDGETS Qt5Widgets 5.2
@@ -594,16 +594,3 @@ fi
 if [ "$HAVE_V4L2" != 'no' ] && [ "$HAVE_VIDEOPROCESSOR" != 'no' ]; then
    HAVE_VIDEO_PROCESSOR=yes
 fi
-
-# Creates config.mk and config.h.
-add_define MAKEFILE GLOBAL_CONFIG_DIR "$GLOBAL_CONFIG_DIR"
-set -- $(set | grep ^HAVE_)
-while [ $# -gt 0 ]; do
-   tmpvar="${1%=*}"
-   shift 1
-   var="${tmpvar#HAVE_}"
-   vars="${vars} $var"
-done
-VARS="$(printf %s "$vars" | tr ' ' '\n' | $SORT)"
-create_config_make config.mk $(printf %s "$VARS")
-create_config_header config.h $(printf %s "$VARS")

--- a/qb/qb.comp.sh
+++ b/qb/qb.comp.sh
@@ -2,8 +2,6 @@
 
 TEMP_C=.tmp.c
 TEMP_CXX=.tmp.cxx
-TEMP_MOC=.moc.h
-TEMP_CPP=.moc.cpp
 TEMP_EXE=.tmp
 
 # Checking for working C compiler
@@ -105,58 +103,3 @@ echo "Checking for pkg-config ... $PKG_CONF_PATH"
 if [ "$PKG_CONF_PATH" = "none" ]; then
 	die : 'Warning: pkg-config not found, package checks will fail.'
 fi
-
-# Checking for working moc
-cat << EOF > "$TEMP_MOC"
-#include <QTimeZone>
-class Test : public QObject
-{
-public:
-   Q_OBJECT
-   QTimeZone tz;
-};
-EOF
-
-HAVE_MOC=no
-if [ "$HAVE_QT" != "no" ] && [ "$HAVE_CXX" != "no" ] && [ "$PKG_CONF_PATH" != "none" ]; then
-	moc_works=0
-	if "$PKGCONF" --exists Qt5Core; then
-		if [ "$MOC" ]; then
-			"$MOC" -o "$TEMP_CPP" "$TEMP_MOC" >/dev/null 2>&1 &&
-			"$CXX" -o "$TEMP_EXE" $("$PKGCONF" --cflags --libs Qt5Core) -fPIC \
-				-c "$TEMP_CPP" >/dev/null 2>&1 &&
-			moc_works=1
-		else
-			for moc in moc-qt5 moc; do
-				MOC="$(exists "$moc")" || MOC=""
-				if [ "$MOC" ]; then
-					"$MOC" -o "$TEMP_CPP" "$TEMP_MOC" >/dev/null 2>&1 ||
-						continue
-					"$CXX" -o "$TEMP_EXE" $("$PKGCONF" --cflags --libs Qt5Core) \
-						-fPIC -c "$TEMP_CPP" >/dev/null 2>&1 && {
-						moc_works=1
-						break
-					}
-				fi
-			done
-		fi
-	else
-		MOC=""
-	fi
-
-	moc_status='does not work'
-	if [ "$moc_works" = '1' ]; then
-		moc_status='works'
-		HAVE_MOC='yes'
-	elif [ -z "$MOC" ]; then
-		moc_status='not found'
-	fi
-
-	echo "Checking for moc ... $MOC $moc_status"
-
-	if [ "$HAVE_MOC" != 'yes' ]; then
-		die : 'Warning: moc not found, Qt companion support will be disabled.'
-	fi
-fi
-
-rm -f -- "$TEMP_CPP" "$TEMP_EXE" "$TEMP_MOC"

--- a/qb/qb.make.sh
+++ b/qb/qb.make.sh
@@ -1,0 +1,12 @@
+# Creates config.mk and config.h.
+add_define MAKEFILE GLOBAL_CONFIG_DIR "$GLOBAL_CONFIG_DIR"
+set -- $(set | grep ^HAVE_)
+while [ $# -gt 0 ]; do
+	tmpvar="${1%=*}"
+	shift 1
+	var="${tmpvar#HAVE_}"
+	vars="${vars} $var"
+done
+VARS="$(printf %s "$vars" | tr ' ' '\n' | $SORT)"
+create_config_make config.mk $(printf %s "$VARS")
+create_config_header config.h $(printf %s "$VARS")

--- a/qb/qb.moc.sh
+++ b/qb/qb.moc.sh
@@ -1,0 +1,55 @@
+TEMP_MOC=.moc.h
+TEMP_CPP=.moc.cpp
+
+# Checking for working moc
+cat << EOF > "$TEMP_MOC"
+#include <QTimeZone>
+class Test : public QObject
+{
+public:
+   Q_OBJECT
+   QTimeZone tz;
+};
+EOF
+
+HAVE_MOC=no
+if [ "$HAVE_QT" = "yes" ]; then
+	moc_works=0
+	if [ "$MOC" ]; then
+		"$MOC" -o "$TEMP_CPP" "$TEMP_MOC" >/dev/null 2>&1 &&
+		"$CXX" -o "$TEMP_EXE" $(printf %s "$QT5CORE_CFLAGS $QT5CORE_LIBS") \
+			-fPIC -c "$TEMP_CPP" >/dev/null 2>&1 &&
+		moc_works=1
+	else
+		for moc in moc-qt5 moc; do
+			MOC="$(exists "$moc")" || MOC=""
+			if [ "$MOC" ]; then
+				"$MOC" -o "$TEMP_CPP" "$TEMP_MOC" >/dev/null 2>&1 ||
+					continue
+				"$CXX" -o "$TEMP_EXE" \
+					$(printf %s "$QT5CORE_CFLAGS $QT5CORE_LIBS") \
+					-fPIC -c "$TEMP_CPP" >/dev/null 2>&1 && {
+					moc_works=1
+					break
+				}
+			fi
+		done
+	fi
+
+	moc_status='does not work'
+	if [ "$moc_works" = '1' ]; then
+		moc_status='works'
+		HAVE_MOC='yes'
+	elif [ -z "$MOC" ]; then
+		moc_status='not found'
+	fi
+
+	printf %s\\n "Checking for moc ... $MOC $moc_status"
+
+	if [ "$HAVE_MOC" != 'yes' ]; then
+		HAVE_QT='no'
+		die : 'Warning: moc not found, Qt companion support will be disabled.'
+	fi
+fi
+
+rm -f -- "$TEMP_CPP" "$TEMP_EXE" "$TEMP_MOC"


### PR DESCRIPTION
## Description

This moves the check for a Qt5 moc into its own file, `qb.moc.sh` which is executed at the end of the script to avoid the direct dependency on pkg-config. Now instead it depends on the `QT5CORE_CFLAGS` and `QT5CORE_LIBS` variables set in config.lib.sh. These should always be set
if `HAVE_QT=yes`.

This also creates a new `qb.make.sh` file to ensure that the config.mk and config.h files are created at the end of the configure script.

For reference the main visible difference is.
```
configure.log
========================
--- configure.log.old	2019-01-17 18:13:09.355788645 -0800
+++ configure.log	2019-01-17 18:13:56.087235500 -0800
@@ -2,7 +2,6 @@
 Checking for suitable working C compiler ... /usr/local/bin/gcc works
 Checking for suitable working C++ compiler ... /usr/local/bin/g++ works
 Checking for pkg-config ... /usr/bin/pkgconf
-Checking for moc ... /usr/bin/moc-qt5 works
 Checking for availability of switch -std=gnu99 in /usr/local/bin/gcc ... yes
 Checking for availability of switch -Wno-unused-result in /usr/local/bin/gcc ... yes
 Checking for availability of switch -Wno-unused-variable in /usr/local/bin/gcc ... yes
@@ -88,5 +87,6 @@
 Checking function strcasestr in -lc ... yes
 Checking function mmap in -lc ... yes
 Checking function vkCreateInstance in -lvulkan ... yes
+Checking for moc ... /usr/bin/moc-qt5 works
 Creating make config: config.mk
 Creating config header: config.h
```

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/8029

## Reviewers

@bparker06 Do you think this change is worthwhile?