### PR TITLE
Fix conflicting types.

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -2582,6 +2582,7 @@ static enum runloop_state runloop_check_state(
 #endif
    static bool old_quit_key         = false;
    static bool quit_key             = false;
+   static bool trig_quit_key        = false;
    static bool runloop_exec         = false;
    static bool old_focus            = true;
    bool is_focused                  = false;
@@ -2720,10 +2721,9 @@ static enum runloop_state runloop_check_state(
 
    /* Check quit key */
    {
-      bool quit_key             = BIT256_GET(
+      quit_key                 = BIT256_GET(
             current_input, RARCH_QUIT_KEY);
-      bool trig_quit_key       = quit_key && !old_quit_key;
-
+      trig_quit_key            = quit_key && !old_quit_key;
       old_quit_key             = quit_key;
 
       if (time_to_exit(trig_quit_key))


### PR DESCRIPTION
## Description

One of my previous PRs accidentally set a variable to both `static bool` and `bool` which is probably not a good idea. The issue I fixed is still fixed with this PR.

## Related Issues

https://github.com/libretro/RetroArch/issues/8005

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/8006
