### PR TITLE
WIP: travis: Enable building qt for linux.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,11 +35,11 @@ matrix:
       addons:
         # Install a more recent clang than the default
         apt:
+          packages:
+            - clang-3.8
           sources:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-precise-3.8
-          packages:
-            - clang-3.8
       env: COMPILER_NAME=clang-3.8 CXX=clang++-3.8 CC=clang-3.8
     - os: osx
       osx_image: xcode8
@@ -82,6 +82,8 @@ addons:
       - qt5-default
       - qt5-qmake
       - qtbase5-dev-tools
+      - qtbase5-dev
+      - qtdeclarative5-dev
   coverity_scan:
     project:
       name: "RetroArch"

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ script:
 env:
   global:
    - MAKEFLAGS="-j2"
+   - QT_SELECT=qt5
    - secure: "qc91ReC3OlzSh2gFaSH6TYzC2qIQvgA2AZff6J13eaH8xijAhuMzttZ0rMQJ0DWCIhPeUb0kIzVyaGoe4MwPALzpw1C1AznIWiZJ53HN+hWCOcS/af7YVPk6HPySnwqrS+Wv3AIIvIKFV2mxv21F/JbT/N+pArlRrp904Xj+KPo="
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,19 +24,15 @@ matrix:
         - make
       env: CROSS_COMPILE=x86_64-w64-mingw32- CFLAGS="-D_WIN32_WINNT=0x0501"
     - compiler: gcc
-      addons:
-        # Install a more recent gcc than the default
-        apt:
-          packages:
-            - g++-7
-          sources:
-            - ubuntu-toolchain-r-test
+      # Install a more recent gcc than the default
+      before_install:
+        - sudo apt-get install -y g++-7
     - compiler: clang
+      # Install a more recent clang than the default
+      before_install:
+        - sudo apt-get install -y clang-3.8
       addons:
-        # Install a more recent clang than the default
         apt:
-          packages:
-            - clang-3.8
           sources:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-precise-3.8
@@ -70,21 +66,15 @@ env:
 addons:
   apt:
     packages:
-      - curl
-      - pkg-config
-      - libglu1-mesa-dev
-      - freeglut3-dev
-      - mesa-common-dev
       - libsdl1.2-dev
       - libsdl-image1.2-dev
       - libsdl-mixer1.2-dev
       - libsdl-ttf2.0-dev
       - libusb-1.0-0-dev
-      - qt5-default
-      - qt5-qmake
-      - qtbase5-dev-tools
       - qtbase5-dev
       - qtdeclarative5-dev
+    sources:
+      - ubuntu-toolchain-r-test
   coverity_scan:
     project:
       name: "RetroArch"

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -284,7 +284,6 @@ if [ "$HAVE_QT" != 'no' ] && [ "$HAVE_MOC" = 'yes' ]; then
    check_pkgconf QT5CONCURRENT Qt5Concurrent 5.2
    check_pkgconf QT5NETWORK Qt5Network 5.2
    #check_pkgconf QT5WEBENGINE Qt5WebEngine 5.4
-   check_pkgconf OPENSSL openssl 1.0.0
 
    # pkg-config is needed to reliably find Qt5 libraries.
 
@@ -294,6 +293,8 @@ if [ "$HAVE_QT" != 'no' ] && [ "$HAVE_MOC" = 'yes' ]; then
    else
       HAVE_QT=yes
    fi
+
+   check_pkgconf OPENSSL openssl 1.0.0
 
    #if [ "$HAVE_QT5WEBENGINE" = "no" ]; then
    #   die : 'Notice: Qt5WebEngine not found, disabling web browser support.'


### PR DESCRIPTION
## Description

Note: I can't test this locally so this may take some troubleshooting, wait for this to be done before merging.

The goal of this PR is to enable qt for the linux travis builds so that build path will also be tested.

## Related Issues

Currently travis fails to build qt support because of missing dependencies.
