### PR TITLE
Fix crash in xinput with verbose logging

### DIFF
--- a/input/drivers_joypad/xinput_joypad.c
+++ b/input/drivers_joypad/xinput_joypad.c
@@ -181,6 +181,9 @@ const char *xinput_joypad_name(unsigned pad)
       return XBOX_ONE_CONTROLLER_NAMES[xuser];
 #endif
 
+   if (xuser < 0)
+      return NULL;
+
    return XBOX_CONTROLLER_NAMES[xuser];
 }
 


### PR DESCRIPTION
## Description

This fixes a startup crash when xinput driver is used without dinput (UWP and older Xboxes) and verbose logging is enabled. This was probably introduced in my previous PR that fixed detection of multiple gamepads and is probably NOT related to the issues people reported on the StorageFile PR - it just came up while I was trying to debug it.