### PR TITLE
(RGUI) Add rudimentary playlist thumbnail support

### DIFF
--- a/menu/cbs/menu_cbs_scan.c
+++ b/menu/cbs/menu_cbs_scan.c
@@ -118,9 +118,15 @@ int action_switch_thumbnail(const char *path,
    }
    else
    {
-      settings->uints.menu_thumbnails++;
-      if (settings->uints.menu_thumbnails > 3)
-         settings->uints.menu_thumbnails = 1;
+      /* RGUI is a special case where thumbnail 'switch' corresponds to
+       * toggling thumbnail view on/off. For other menu drivers, we
+       * cycle through available thumbnail types. */
+      if(!string_is_equal(settings->arrays.menu_driver, "rgui"))
+      {
+         settings->uints.menu_thumbnails++;
+         if (settings->uints.menu_thumbnails > 3)
+            settings->uints.menu_thumbnails = 1;
+      }
       menu_driver_ctl(RARCH_MENU_CTL_UPDATE_THUMBNAIL_PATH, NULL);
       menu_driver_ctl(RARCH_MENU_CTL_UPDATE_THUMBNAIL_IMAGE, NULL);
    }

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -8722,7 +8722,7 @@ static bool setting_append_list(
                general_read_handler,
                SD_FLAG_ADVANCED);
 
-         if (string_is_equal(settings->arrays.menu_driver, "xmb") || string_is_equal(settings->arrays.menu_driver, "ozone"))
+         if (string_is_equal(settings->arrays.menu_driver, "xmb") || string_is_equal(settings->arrays.menu_driver, "ozone") || string_is_equal(settings->arrays.menu_driver, "rgui"))
          {
             CONFIG_UINT(
                   list, list_info,
@@ -8739,7 +8739,10 @@ static bool setting_append_list(
             (*list)[list_info->index - 1].get_string_representation =
                &setting_get_string_representation_uint_menu_thumbnails;
             menu_settings_list_current_add_range(list, list_info, 0, 3, 1, true, true);
+         }
 
+         if (string_is_equal(settings->arrays.menu_driver, "xmb") || string_is_equal(settings->arrays.menu_driver, "ozone"))
+         {
             CONFIG_UINT(
                   list, list_info,
                   &settings->uints.menu_left_thumbnails,


### PR DESCRIPTION
## Description

This PR adds thumbnail support to the RGUI menu driver. Due to the low resolution framebuffer of the RGUI menu (a paltry 320x240 pixels), this works quite differently from the XMB implementation - but I think it is usable and user friendly. Basically, while viewing a playlist (under 'Load Content > Collections'):

![screenshot_2019-01-18_15-57-47](https://user-images.githubusercontent.com/38211560/51399737-9009e280-1b3e-11e9-80ca-ad594ed6d7f1.png)

...pressing the 'scan' button (RetroPad Y) will toggle the display of the thumbnail image type specified in 'Settings > User Interface > Appearance':

![screenshot_2019-01-18_15-58-01](https://user-images.githubusercontent.com/38211560/51399850-d6f7d800-1b3e-11e9-9ee5-95f22aa05033.png)

Note that it is a *toggle* of the *currently set* thumbnail type. In the XMB menu, pressing the 'scan' button cycles through all available types - that behaviour just doesn't work here (it's too laborious). In addition, there is no menu option to keep thumbnail display 'on' permanently. You can scroll through a playlist while thumbnails are displayed, but it's quite painful to do so - this is really intended to be used 'on demand' (i.e. scroll through text list > see a title you don't recognise > check out a screenshot).

Because RGUI targets weak hardware, there is no image scaling - every thumbnail is displayed 1:1, centred and cropped as required. This actually looks pretty good in most cases, e.g.:

![screenshot_2019-01-18_15-58-44](https://user-images.githubusercontent.com/38211560/51400671-df511280-1b40-11e9-9c10-9197ab62c34e.png)

![screenshot_2019-01-18_15-59-15](https://user-images.githubusercontent.com/38211560/51400684-e6782080-1b40-11e9-934e-02ad958c1de7.png)

![screenshot_2019-01-18_16-00-59](https://user-images.githubusercontent.com/38211560/51400698-f0018880-1b40-11e9-9b09-494e34573d5d.png)

...and for things like box art, which is often high resolution, users can easily resize their images to fit using something like:

> for FILE in *.png; do convert "$FILE" -filter Lanczos -resize 320x240\> "$FILE" && pngquant --force -o "$FILE" "$FILE" && optipng -o7 "$FILE"; done

![screenshot_2019-01-18_16-09-03](https://user-images.githubusercontent.com/38211560/51400810-38b94180-1b41-11e9-9111-2b5eb93a5f45.png)

I've tried to make the thumbnail display fairly lightweight, and it should work on all platforms that have RPNG support (basically everything). Also, there is (essentially) no performance impact if thumbnail display is toggled 'off' (other than an extra ~150kb memory usage), so I don't foresee any issues.
