### PR TITLE
Fix #6747 Black bug

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -1377,7 +1377,7 @@ static struct config_bool_setting *populate_settings_bool(settings_t *settings, 
    SETTING_BOOL("video_scale_integer",           &settings->bools.video_scale_integer, true, scale_integer, false);
    SETTING_BOOL("video_smooth",                  &settings->bools.video_smooth, true, video_smooth, false);
    SETTING_BOOL("video_force_aspect",            &settings->bools.video_force_aspect, true, force_aspect, false);
-   SETTING_BOOL("video_threaded",                video_driver_get_threaded(), true, video_threaded, false);
+   SETTING_BOOL("video_threaded",                &settings->bools.video_threaded, true, video_threaded, false);
    SETTING_BOOL("video_shared_context",          &settings->bools.video_shared_context, true, video_shared_context, false);
    SETTING_BOOL("auto_screenshot_filename",      &settings->bools.auto_screenshot_filename, true, auto_screenshot_filename, false);
    SETTING_BOOL("video_force_srgb_disable",      &settings->bools.video_force_srgb_disable, true, false, false);

--- a/gfx/drivers/d3d10.c
+++ b/gfx/drivers/d3d10.c
@@ -1580,7 +1580,7 @@ static uintptr_t d3d10_gfx_load_texture(
 
    return (uintptr_t)texture;
 }
-static void d3d10_gfx_unload_texture(void* data, uintptr_t handle)
+static void d3d10_gfx_unload_texture(void* data, uintptr_t handle, bool threaded)
 {
    d3d10_texture_t* texture = (d3d10_texture_t*)handle;
 

--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -1640,7 +1640,7 @@ static uintptr_t d3d11_gfx_load_texture(
 
    return (uintptr_t)texture;
 }
-static void d3d11_gfx_unload_texture(void* data, uintptr_t handle)
+static void d3d11_gfx_unload_texture(void* data, uintptr_t handle, bool threaded)
 {
    d3d11_texture_t* texture = (d3d11_texture_t*)handle;
 

--- a/gfx/drivers/d3d12.c
+++ b/gfx/drivers/d3d12.c
@@ -1759,7 +1759,7 @@ static uintptr_t d3d12_gfx_load_texture(
 
    return (uintptr_t)texture;
 }
-static void d3d12_gfx_unload_texture(void* data, uintptr_t handle)
+static void d3d12_gfx_unload_texture(void* data, uintptr_t handle, bool threaded)
 {
    d3d12_texture_t* texture = (d3d12_texture_t*)handle;
 

--- a/gfx/drivers/d3d8.c
+++ b/gfx/drivers/d3d8.c
@@ -1818,7 +1818,7 @@ static uintptr_t d3d8_load_texture(void *video_data, void *data,
    return id;
 }
 
-static void d3d8_unload_texture(void *data, uintptr_t id)
+static void d3d8_unload_texture(void *data, uintptr_t id, bool threaded)
 {
    LPDIRECT3DTEXTURE8 texid;
    if (!id)

--- a/gfx/drivers/d3d9.c
+++ b/gfx/drivers/d3d9.c
@@ -1989,7 +1989,7 @@ static uintptr_t d3d9_load_texture(void *video_data, void *data,
    return id;
 }
 
-static void d3d9_unload_texture(void *data, uintptr_t id)
+static void d3d9_unload_texture(void *data, uintptr_t id, bool threaded)
 {
    LPDIRECT3DTEXTURE9 texid;
    if (!id)

--- a/gfx/drivers/gdi_gfx.c
+++ b/gfx/drivers/gdi_gfx.c
@@ -610,7 +610,7 @@ static uintptr_t gdi_load_texture(void *video_data, void *data,
    return (uintptr_t)texture;
 }
 
-static void gdi_unload_texture(void *data, uintptr_t handle)
+static void gdi_unload_texture(void *data, uintptr_t handle, bool threaded)
 {
    struct gdi_texture *texture = (struct gdi_texture*)handle;
 

--- a/gfx/drivers/gl.c
+++ b/gfx/drivers/gl.c
@@ -2492,6 +2492,12 @@ static void video_texture_load_gl(
          );
 }
 
+static void video_texture_unload_gl(
+      uintptr_t *id)
+{
+   glDeleteTextures(1, (GLuint*)id);
+}
+
 #ifdef HAVE_THREADS
 static int video_texture_load_wrap_gl_mipmap(void *data)
 {
@@ -2514,13 +2520,20 @@ static int video_texture_load_wrap_gl(void *data)
          TEXTURE_FILTER_LINEAR, &id);
    return (int)id;
 }
+
+static int video_texture_unload_wrap_gl(void *data)
+{
+   if (!data)
+      return 0;
+   video_texture_unload_gl((uintptr_t*)data);
+   return 0;
+}
 #endif
 
 static uintptr_t gl_load_texture(void *video_data, void *data,
       bool threaded, enum texture_filter_type filter_type)
 {
    uintptr_t id = 0;
-
 #ifdef HAVE_THREADS
    if (threaded)
    {
@@ -2535,7 +2548,8 @@ static uintptr_t gl_load_texture(void *video_data, void *data,
          default:
             break;
       }
-      return video_thread_texture_load(data, func);
+      id=video_thread_texture_load(data, func);
+      return id;
    }
 #endif
 
@@ -2543,14 +2557,22 @@ static uintptr_t gl_load_texture(void *video_data, void *data,
    return id;
 }
 
-static void gl_unload_texture(void *data, uintptr_t id)
+static void gl_unload_texture(void *video_data, uintptr_t data, bool threaded)
 {
-   GLuint glid;
-   if (!id)
+   if (!data)
       return;
+   GLuint glid = (GLuint)data;
 
-   glid = (GLuint)id;
-   glDeleteTextures(1, &glid);
+#ifdef HAVE_THREADS
+   if (threaded)
+   {
+      custom_command_method_t func = video_texture_unload_wrap_gl;
+      video_thread_texture_load((void *)&data, func);
+      return;
+   }
+#endif
+
+   video_texture_unload_gl(&data);
 }
 
 static void gl_set_coords(void *handle_data, void *shader_data,

--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -2334,7 +2334,7 @@ static uintptr_t vulkan_load_texture(void *video_data, void *data,
    return (uintptr_t)texture;
 }
 
-static void vulkan_unload_texture(void *data, uintptr_t handle)
+static void vulkan_unload_texture(void *data, uintptr_t handle, bool threaded)
 {
    vk_t *vk                         = (vk_t*)data;
    struct vk_texture *texture       = (struct vk_texture*)handle;

--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -147,6 +147,7 @@ static bool                video_driver_crt_switching_active = false;
 
 static struct retro_system_av_info video_driver_av_info;
 
+
 static enum retro_pixel_format video_driver_pix_fmt      = RETRO_PIXEL_FORMAT_0RGB1555;
 
 static const void *frame_cache_data                      = NULL;
@@ -1050,6 +1051,9 @@ static bool video_driver_init_internal(bool *video_is_threaded)
    video_driver_find_driver();
 
 #ifdef HAVE_THREADS
+   /* Set the driver to threaded based on the settings configuration */
+   video_driver_threaded = settings->bools.video_threaded;
+   /* Check video_driver_threaded and video_driver_hw-context to determine if the video driver is threaded */
    video.is_threaded   = video_driver_is_threaded_internal();
    *video_is_threaded  = video.is_threaded;
 
@@ -2725,7 +2729,7 @@ bool video_driver_texture_unload(uintptr_t *id)
    if (!video_driver_poke || !video_driver_poke->unload_texture)
       return false;
 
-   video_driver_poke->unload_texture(video_driver_data, *id);
+   video_driver_poke->unload_texture(video_driver_data, *id, video_driver_is_threaded_internal());
    *id = 0;
    return true;
 }

--- a/gfx/video_driver.h
+++ b/gfx/video_driver.h
@@ -710,7 +710,7 @@ typedef struct video_poke_interface
          const void *mat_data);
    uintptr_t (*load_texture)(void *video_data, void *data,
          bool threaded, enum texture_filter_type filter_type);
-   void (*unload_texture)(void *data, uintptr_t id);
+   void (*unload_texture)(void *data, uintptr_t id, bool threaded);
    void (*set_video_mode)(void *data, unsigned width,
          unsigned height, bool fullscreen);
    float (*get_refresh_rate)(void *data);

--- a/gfx/video_thread_wrapper.c
+++ b/gfx/video_thread_wrapper.c
@@ -1198,7 +1198,7 @@ static uintptr_t thread_load_texture(void *video_data, void *data,
    return thr->poke->load_texture(thr->driver_data, data, threaded, filter_type);
 }
 
-static void thread_unload_texture(void *video_data, uintptr_t id)
+static void thread_unload_texture(void *video_data, uintptr_t id, bool threaded)
 {
    thread_video_t *thr = (thread_video_t*)video_data;
 
@@ -1206,7 +1206,7 @@ static void thread_unload_texture(void *video_data, uintptr_t id)
       return;
 
    if (thr->poke && thr->poke->unload_texture)
-      thr->poke->unload_texture(thr->driver_data, id);
+      thr->poke->unload_texture(thr->driver_data, id, threaded);
 }
 
 static void thread_apply_state_changes(void *data)

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -5850,7 +5850,7 @@ static bool setting_append_list(
 #if defined(HAVE_THREADS)
             CONFIG_BOOL(
                   list, list_info,
-                  video_driver_get_threaded(),
+                  &settings->bools.video_threaded,
                   MENU_ENUM_LABEL_VIDEO_THREADED,
                   MENU_ENUM_LABEL_VALUE_VIDEO_THREADED,
                   video_threaded,


### PR DESCRIPTION
## Description

The texture unload is done in the video thread if the video_threaded is enabled.
I have tested carefully the fix on the folowing platforms:
- Raspberry Pi 3 (Lakka)
- Windows
- Ubuntu X86_64

Here are the tests done for each plateform:
- Start retroarch with VideoThreaded enabled
- Start retroarch with VideoThreaded disabled
- Switch VideoThreaded on/off/on/off
- Switch Fullscreen mode on/off/on/off
- Long Scroll on playlist to try to reproduce #6747 
- Switch VideoDecoration on/off/on/off

## Related Issues

#6747 XMB always stops displaying images with low-power/memory (rpi, Switch, Classic, others)

## Reviewers

@twinaphex 
