### PR TITLE
(UWP) Fix Bundle.Mapping.txt path

### DIFF
--- a/pkg/msvc-uwp/RetroArch-msvc2017-UWP/Bundle.Mapping.txt
+++ b/pkg/msvc-uwp/RetroArch-msvc2017-UWP/Bundle.Mapping.txt
@@ -1,2 +1,2 @@
 [ExternalPackages]
-"..\AppPackages\RetroArch-UWP-cores-nonfree\RetroArch-UWP-cores-nonfree_1.0.0.0_Test\RetroArch-UWP-cores-nonfree_1.0.0.0_x86_x64_arm.appxbundle"
+"..\AppPackages\RetroArch-msvc2017-UWP-cores-nonfree\RetroArch-msvc2017-UWP-cores-nonfree_1.0.0.0_Test\RetroArch-msvc2017-UWP-cores-nonfree_1.0.0.0_x86_x64_arm.appxbundle"


### PR DESCRIPTION
## Description

@twinaphex forgot to change this when he renamed the projects to include `-msvc2017` a few weeks ago, this causes build failures when trying to create .appx files

## Reviewers

@twinaphex
