### PR TITLE
better handling HAVE_NEW_CHEEVOS compilation

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1665,54 +1665,78 @@ ifeq ($(HAVE_NETWORKING), 1)
                network/netplay/netplay_buf.o \
                network/netplay/netplay_room_parse.o
 
-   # Retro Achievements
+   # RetroAchievements
    ifeq ($(HAVE_CHEEVOS), 1)
       DEFINES += -DHAVE_CHEEVOS
-		
-      OBJ += cheevos/cheevos.o \
-             cheevos/badges.o \
-             cheevos/var.o \
-             cheevos/cond.o
 
-      ifeq ($(HAVE_LUA), 1)
-         DEFINES += -DHAVE_LUA \
-                    -DLUA_32BITS \
-                    -Ideps/lua/src
-         OBJ += deps/lua/src/lapi.o \
-                deps/lua/src/lcode.o \
-                deps/lua/src/lctype.o \
-                deps/lua/src/ldebug.o \
-                deps/lua/src/ldo.o \
-                deps/lua/src/ldump.o \
-                deps/lua/src/lfunc.o \
-                deps/lua/src/lgc.o \
-                deps/lua/src/llex.o \
-                deps/lua/src/lmem.o \
-                deps/lua/src/lobject.o \
-                deps/lua/src/lopcodes.o \
-                deps/lua/src/lparser.o \
-                deps/lua/src/lstate.o \
-                deps/lua/src/lstring.o \
-                deps/lua/src/ltable.o \
-                deps/lua/src/ltm.o \
-                deps/lua/src/lundump.o \
-                deps/lua/src/lvm.o \
-                deps/lua/src/lzio.o \
-                deps/lua/src/lauxlib.o \
-                deps/lua/src/lbaselib.o \
-                deps/lua/src/lbitlib.o \
-                deps/lua/src/lcorolib.o \
-                deps/lua/src/ldblib.o \
-                deps/lua/src/liolib.o \
-                deps/lua/src/lmathlib.o \
-                deps/lua/src/loslib.o \
-                deps/lua/src/lstrlib.o \
-                deps/lua/src/ltablib.o \
-                deps/lua/src/lutf8lib.o \
-                deps/lua/src/loadlib.o \
-                deps/lua/src/linit.o
+      ifeq ($(HAVE_NEW_CHEEVOS), 1)
+         DEFINES += -DHAVE_NEW_CHEEVOS \
+            -Ideps/rcheevos/include \
+            -Ideps/lua/src
+         OBJ += cheevos-new/cheevos.o \
+            cheevos-new/badges.o \
+            cheevos-new/fixup.o \
+            cheevos-new/parser.o \
+            cheevos-new/hash.o \
+            deps/rcheevos/src/rcheevos/trigger.o \
+            deps/rcheevos/src/rcheevos/condset.o \
+            deps/rcheevos/src/rcheevos/condition.o \
+            deps/rcheevos/src/rcheevos/operand.o \
+            deps/rcheevos/src/rcheevos/term.o \
+            deps/rcheevos/src/rcheevos/expression.o \
+            deps/rcheevos/src/rcheevos/value.o \
+            deps/rcheevos/src/rcheevos/lboard.o \
+            deps/rcheevos/src/rcheevos/alloc.o \
+            deps/rcheevos/src/rcheevos/format.o \
+            deps/rcheevos/src/rurl/url.o
+
+         ifeq ($(HAVE_LUA), 1)
+            DEFINES += -DHAVE_LUA \
+                       -DLUA_32BITS \
+                       -Ideps/lua/src
+            OBJ += deps/lua/src/lapi.o \
+                   deps/lua/src/lcode.o \
+                   deps/lua/src/lctype.o \
+                   deps/lua/src/ldebug.o \
+                   deps/lua/src/ldo.o \
+                   deps/lua/src/ldump.o \
+                   deps/lua/src/lfunc.o \
+                   deps/lua/src/lgc.o \
+                   deps/lua/src/llex.o \
+                   deps/lua/src/lmem.o \
+                   deps/lua/src/lobject.o \
+                   deps/lua/src/lopcodes.o \
+                   deps/lua/src/lparser.o \
+                   deps/lua/src/lstate.o \
+                   deps/lua/src/lstring.o \
+                   deps/lua/src/ltable.o \
+                   deps/lua/src/ltm.o \
+                   deps/lua/src/lundump.o \
+                   deps/lua/src/lvm.o \
+                   deps/lua/src/lzio.o \
+                   deps/lua/src/lauxlib.o \
+                   deps/lua/src/lbaselib.o \
+                   deps/lua/src/lbitlib.o \
+                   deps/lua/src/lcorolib.o \
+                   deps/lua/src/ldblib.o \
+                   deps/lua/src/liolib.o \
+                   deps/lua/src/lmathlib.o \
+                   deps/lua/src/loslib.o \
+                   deps/lua/src/lstrlib.o \
+                   deps/lua/src/ltablib.o \
+                   deps/lua/src/lutf8lib.o \
+                   deps/lua/src/loadlib.o \
+                   deps/lua/src/linit.o
+         else
+            DEFINES += -DRC_DISABLE_LUA
+         endif
+
+      # if not HAVE_NEW_CHEEVOS
       else
-         DEFINES += -DRC_DISABLE_LUA
+         OBJ += cheevos/cheevos.o \
+                cheevos/badges.o \
+                cheevos/var.o \
+                cheevos/cond.o
       endif
    endif
 

--- a/Makefile.ctr
+++ b/Makefile.ctr
@@ -137,7 +137,6 @@ CFLAGS += -I. \
 			 -Ideps/libz \
 			 -Ideps/7zip \
 			 -Ideps/stb \
-			 -Ideps/rcheevos/include \
 			 -Ilibretro-common/include
 
 CFLAGS += -DRARCH_INTERNAL -DRARCH_CONSOLE

--- a/cheevos-new/cheevos.c
+++ b/cheevos-new/cheevos.c
@@ -1415,7 +1415,7 @@ found:
          CORO_RET();
       }
 
-      coro->offset = 512;
+      coro->offset = snes_header_len;
       coro->count  = 0;
 
       CORO_GOSUB(EVAL_MD5);

--- a/cheevos-new/cheevos.c
+++ b/cheevos-new/cheevos.c
@@ -1118,6 +1118,8 @@ enum
 
 static int cheevos_iterate(coro_t* coro)
 {
+   const int snes_header_len = 0x200;
+   const int lynx_header_len = 0x40;
    ssize_t num_read = 0;
    size_t to_read   = 4096;
    uint8_t *buffer  = NULL;
@@ -1159,10 +1161,10 @@ static int cheevos_iterate(coro_t* coro)
 
    static cheevos_finder_t finders[] =
    {
-      {SNES_MD5,    "SNES (8Mb padding)",                snes_exts},
+      {SNES_MD5,    "SNES (discards header)",            snes_exts},
       {GENESIS_MD5, "Genesis (6Mb padding)",             genesis_exts},
-      {LYNX_MD5,    "Atari Lynx (only first 512 bytes)", lynx_exts},
-      {NES_MD5,     "NES (discards VROM)",               NULL},
+      {LYNX_MD5,    "Atari Lynx (discards header)", lynx_exts},
+      {NES_MD5,     "NES (discards header)",             NULL},
       {GENERIC_MD5, "Generic (plain content)",           NULL},
       {FILENAME_MD5, "Generic (filename)",               NULL}
    };
@@ -1403,33 +1405,22 @@ found:
          * Output CHEEVOS_VAR_GAMEID the Retro Achievements game ID, or 0 if not found
          *************************************************************************/
    CORO_SUB(SNES_MD5)
-
       MD5_Init(&coro->md5);
 
-      coro->offset = 0;
-      coro->count  = 0;
-
-      CORO_GOSUB(EVAL_MD5);
-
-      if (coro->count == 0)
+      /* Checks for the existence of a headered SNES file.
+         Unheadered files fall back to GENERIC_MD5. */
+      if (coro->len < 0x2000 || coro->len % 0x2000 != snes_header_len)
       {
-         MD5_Final(coro->hash, &coro->md5);
          coro->gameid = 0;
          CORO_RET();
       }
 
-      if (coro->count < CHEEVOS_MB(8))
-      {
-         /*
-            * Inputs:  CHEEVOS_VAR_MD5, CHEEVOS_VAR_OFFSET, CHEEVOS_VAR_COUNT
-            * Outputs: CHEEVOS_VAR_MD5
-            */
-         coro->offset      = 0;
-         coro->count       = CHEEVOS_MB(8) - coro->count;
-         CORO_GOSUB(FILL_MD5);
-      }
+      coro->offset = 512;
+      coro->count  = 0;
 
+      CORO_GOSUB(EVAL_MD5);
       MD5_Final(coro->hash, &coro->md5);
+
       CORO_GOTO(GET_GAMEID);
 
       /**************************************************************************
@@ -1469,16 +1460,18 @@ found:
          *************************************************************************/
    CORO_SUB(LYNX_MD5)
 
-      if (coro->len < 0x0240)
+      /* Checks for the existence of a headered Lynx file.
+         Unheadered files fall back to GENERIC_MD5. */
+      if (coro->len <= lynx_header_len ||
+        memcmp("LYNX", (void *)coro->data, 5) != 0)
       {
          coro->gameid = 0;
          CORO_RET();
       }
 
       MD5_Init(&coro->md5);
-
-      coro->offset       = 0x0040;
-      coro->count        = 0x0200;
+      coro->offset = lynx_header_len;
+      coro->count  = coro->len - lynx_header_len;
       CORO_GOSUB(EVAL_MD5);
 
       MD5_Final(coro->hash, &coro->md5);
@@ -1491,13 +1484,8 @@ found:
          *************************************************************************/
    CORO_SUB(NES_MD5)
 
-      /* Note about the references to the FCEU emulator below. There is no
-         * core-specific code in this function, it's rather Retro Achievements
-         * specific code that must be followed to the letter so we compute
-         * the correct ROM hash. Retro Achievements does indeed use some
-         * FCEU related method to compute the hash, since its NES emulator
-         * is based on it. */
-
+      /* Checks for the existence of a headered NES file.
+         Unheadered files fall back to GENERIC_MD5. */
       if (coro->len < sizeof(coro->header))
       {
          coro->gameid = 0;
@@ -1506,84 +1494,23 @@ found:
 
       memcpy((void*)&coro->header, coro->data,
             sizeof(coro->header));
-      
-      if (coro->header.id[0] == 'N'
-        && coro->header.id[1] == 'E'
-        && coro->header.id[2] == 'S'
-        && coro->header.id[3] == 0x1a)
+
+      if (     coro->header.id[0] != 'N'
+            || coro->header.id[1] != 'E'
+            || coro->header.id[2] != 'S'
+            || coro->header.id[3] != 0x1a)
       {
-         size_t romsize = 256;
-         /* from FCEU core - compute size using the cart mapper */
-         int mapper     = (coro->header.rom_type >> 4) | (coro->header.rom_type2 & 0xF0);
-
-         if (coro->header.rom_size)
-            romsize     = next_pow2(coro->header.rom_size);
-
-         /* for games not to the power of 2, so we just read enough
-            * PRG rom from it, but we have to keep ROM_size to the power of 2
-            * since PRGCartMapping wants ROM_size to be to the power of 2
-            * so instead if not to power of 2, we just use head.ROM_size when
-            * we use FCEU_read. */
-         coro->round       = mapper != 53 && mapper != 198 && mapper != 228;
-         coro->bytes       = coro->round ? romsize : coro->header.rom_size;
-         
-         coro->offset = sizeof(coro->header) + (coro->header.rom_type & 4
-            ? sizeof(coro->header) : 0);
-            
-          /* from FCEU core - check if Trainer included in ROM data */
-          MD5_Init(&coro->md5);
-          coro->count  = 0x4000 * coro->bytes;
-          CORO_GOSUB(EVAL_MD5);
-
-          if (coro->count < 0x4000 * coro->bytes)
-          {
-             coro->offset      = 0xff;
-             coro->count       = 0x4000 * coro->bytes - coro->count;
-             CORO_GOSUB(FILL_MD5);
-          }
-
-          MD5_Final(coro->hash, &coro->md5);
-          CORO_GOTO(GET_GAMEID);
+         coro->gameid = 0;
+         CORO_RET();
       }
-      else
-      {
-         unsigned i;
-          size_t chunks     = coro->len >> 14;
-          size_t chunk_size = 0x4000;
 
-          /* Fall back to headerless hashing
-           * PRG ROM size is unknown, so test by 16KB chunks */
+      MD5_Init(&coro->md5);
+      coro->offset = sizeof(coro->header);
+      coro->count  = coro->len - coro->offset;
+      CORO_GOSUB(EVAL_MD5);
 
-          coro->round       = 0;
-          coro->offset      = 0;
-          
-          for (i = 0; i < chunks; i++)
-          {
-              MD5_Init(&coro->md5);
-              
-              coro->bytes = i + 1;
-              coro->count = coro->bytes * chunk_size;
-              
-              CORO_GOSUB(EVAL_MD5);
-
-              if (coro->count < 0x4000 * coro->bytes)
-              {
-                 coro->offset      = 0xff;
-                 coro->count       = 0x4000 * coro->bytes - coro->count;
-                 CORO_GOSUB(FILL_MD5);
-              }
-
-              MD5_Final(coro->hash, &coro->md5);
-              CORO_GOSUB(GET_GAMEID);
-              
-              if (coro->gameid > 0)
-              {
-                  break;
-              }
-          }
-
-          CORO_RET();
-      }
+      MD5_Final(coro->hash, &coro->md5);
+      CORO_GOTO(GET_GAMEID);
 
       /**************************************************************************
        * Info   Tries to identify a "generic" game

--- a/qb/config.params.sh
+++ b/qb/config.params.sh
@@ -117,6 +117,7 @@ HAVE_QT=auto               # Qt companion support
 C89_QT=no
 HAVE_XSHM=no               # XShm video driver support
 HAVE_CHEEVOS=yes           # Retro Achievements
+HAVE_NEW_CHEEVOS=no        # use rcheevos to process RetroAchievements
 C89_CHEEVOS=no
 HAVE_LUA=no                # Lua support (for Retro Achievements)
 HAVE_DISCORD=yes           # Discord Integration


### PR DESCRIPTION
## Note

**The changes here don't affect anything in the binaries currently built by the buildbot.**

**[UPDATE]** based on [orbea's comment](https://github.com/libretro/RetroArch/pull/8045#issuecomment-455876540), I've added the `./configure --enable-new_cheevos` option to easily build RetroArch with the new cheevos implementation.


## Description

This is a preliminary work to allow further investigations of the problems occurred when @leiradel's [rcheevos](https://github.com/RetroAchievements/rcheevos/) were integrated to RetroArch (PR #7321, later reverted). 


### Changes

- **`Makefile.ctr`**: removing a leftover mention to `deps/rcheevos/include`.
- **`Makefile.common`**: better handling the HAVE_NEW_CHEEVOS flag (when it's set, use the `cheevos-new/*` files).
- **`cheevos-new/cheevos.c`**: using the new nes/snes/lynx hashing methods (changed in the current cheevos code in #7769 and #8010).


## Related Issues

#7341
https://github.com/RetroAchievements/rcheevos/issues/3
https://github.com/RetroAchievements/rcheevos/issues/7


## Reviewers

@leiradel @fr500 @Jamiras