### PR TITLE
Fix segfault with a null gl context.

### DIFF
--- a/gfx/drivers/gl.c
+++ b/gfx/drivers/gl.c
@@ -1727,6 +1727,7 @@ static void *gl_init(const video_info_t *video,
    char *error_string                   = NULL;
    gl_t *gl                             = (gl_t*)calloc(1, sizeof(gl_t));
    const gfx_ctx_driver_t *ctx_driver   = gl_get_context(gl);
+
    if (!gl || !ctx_driver)
       goto error;
 
@@ -1781,6 +1782,9 @@ static void *gl_init(const video_info_t *video,
 
    RARCH_LOG("[GL]: Vendor: %s, Renderer: %s.\n", vendor, renderer);
    RARCH_LOG("[GL]: Version: %s.\n", version);
+
+   if (string_is_equal(ctx_driver->ident, "null"))
+      goto error;
 
    if (!string_is_empty(version))
       sscanf(version, "%d.%d", &gl->version_major, &gl->version_minor);

--- a/libretro-common/glsym/rglgen.c
+++ b/libretro-common/glsym/rglgen.c
@@ -38,5 +38,8 @@ void rglgen_resolve_symbols_custom(rglgen_proc_address_t proc,
 
 void rglgen_resolve_symbols(rglgen_proc_address_t proc)
 {
+   if (!proc)
+      return;
+
    rglgen_resolve_symbols_custom(proc, rglgen_symbol_map);
 }


### PR DESCRIPTION
## Description

If RetroArch is built without any contexts it will segfault in a few places when starting. With this commit it will now exit safely.
```
$ ./retroarch --verbose
[INFO] RetroArch 1.7.5 (Git 9a6fc26ae2)
[INFO] === Build =======================================
Capabilities: MMX MMXEXT SSE1 SSE2 SSE3 SSSE3 SSE4 SSE4.2 AVX AES 
Built: Jan 19 2019
[INFO] Version: 1.7.5
[INFO] Git: 9a6fc26ae2
[INFO] =================================================
[INFO] Environ SET_PIXEL_FORMAT: RGB565.
[INFO] Redirecting save file to "/media/data/home/games/roms/.saves/retroarch/.srm".
[INFO] Redirecting savestate to "/media/data/home/games/roms/.saves/retroarch/.sstates/.state".
[INFO] Version of libretro API: 1
[INFO] Compiled against API: 1
[INFO] [Audio]: Set audio input rate to: 30000.00 Hz.
[INFO] [Video]: Video @ 1152x720
[INFO] [GL]: Found GL context: null
[INFO] [GL]: Detecting screen resolution 320x240.
[INFO] [GL]: Vendor: (null), Renderer: (null).
[INFO] [GL]: Version: (null).
[ERROR] [Video]: Cannot open video driver ... Exiting ...
[ERROR] Fatal error received in: "init_video()"
```
This only seems to be a problem with gl and not vulkan on Linux.

## Related Issues

```
Thread 1 "retroarch" received signal SIGSEGV, Segmentation fault.
0x0000000000000000 in ?? ()
(gdb) bt
#0  0x0000000000000000 in ?? ()
#1  0x0000000000675e9b in rglgen_resolve_symbols_custom (proc=0x0, 
    map=0x97cd60 <rglgen_symbol_map>) at libretro-common/glsym/rglgen.c:34
#2  0x0000000000675edf in rglgen_resolve_symbols (proc=0x0)
    at libretro-common/glsym/rglgen.c:41
#3  0x000000000066f0bf in gl_init (video=0x7fffffffdb50, input=0xa86630 <current_input>, 
    input_data=0xa86638 <current_input_data>) at gfx/drivers/gl.c:1772
#4  0x00000000004744d8 in video_driver_init_internal (video_is_threaded=0x7fffffffdc17)
    at gfx/video_driver.c:1072
#5  0x00000000004758f7 in video_driver_init (video_is_threaded=0x7fffffffdc17)
    at gfx/video_driver.c:1790
#6  0x000000000047b025 in drivers_init (flags=1023) at driver.c:357
#7  0x000000000041254f in retroarch_main_init (argc=1, argv=0x7fffffffe208)
    at retroarch.c:1407
#8  0x000000000042c775 in content_load (info=0x7fffffffe0d0) at tasks/task_content.c:282
#9  0x000000000042d9d6 in task_load_content (content_info=0x7fffffffe0d0, 
    content_ctx=0x7fffffffdfe0, launched_from_menu=true, launched_from_cli=true, 
    error_string=0x7fffffffdfd8) at tasks/task_content.c:884
#10 0x000000000042ee5f in task_load_content_callback (content_info=0x7fffffffe0d0, 
    loading_from_menu=true, loading_from_cli=true) at tasks/task_content.c:1562
#11 0x000000000042f058 in task_push_load_content_from_cli (core_path=0x0, fullpath=0x0, 
    content_info=0x7fffffffe0d0, type=CORE_TYPE_PLAIN, cb=0x0, user_data=0x0)
    at tasks/task_content.c:1643
#12 0x000000000040ea46 in rarch_main (argc=1, argv=0x7fffffffe208, data=0x0)
    at frontend/frontend.c:138
#13 0x000000000040eac9 in main (argc=1, argv=0x7fffffffe208) at frontend/frontend.c:182
```