### PR TITLE
gfx: Test the sdl_gl context driver before kms.

### DIFF
--- a/gfx/drivers_context/sdl_gl_ctx.c
+++ b/gfx/drivers_context/sdl_gl_ctx.c
@@ -89,7 +89,12 @@ static void *sdl_ctx_init(video_frame_info_t *video_info, void *video_driver)
          goto error;
    }
    else if (SDL_InitSubSystem(SDL_INIT_VIDEO) < 0)
+   {
+      RARCH_WARN("[SDL_GL]: Failed to initialize SDL gfx context driver: %s\n",
+              SDL_GetError());
+
       goto error;
+   }
 
    RARCH_LOG("[SDL_GL] SDL %i.%i.%i gfx context driver initialized.\n",
            SDL_MAJOR_VERSION, SDL_MINOR_VERSION, SDL_PATCHLEVEL);
@@ -97,9 +102,6 @@ static void *sdl_ctx_init(video_frame_info_t *video_info, void *video_driver)
    return sdl;
 
 error:
-   RARCH_WARN("[SDL_GL]: Failed to initialize SDL gfx context driver: %s\n",
-              SDL_GetError());
-
    sdl_ctx_destroy_resources(sdl);
 
    if (sdl)

--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -390,6 +390,9 @@ static const gfx_ctx_driver_t *gfx_ctx_drivers[] = {
 #if defined(HAVE_X11) && defined(HAVE_OPENGL) && defined(HAVE_EGL)
    &gfx_ctx_x_egl,
 #endif
+#if (defined(HAVE_SDL) || defined(HAVE_SDL2)) && defined(HAVE_OPENGL)
+   &gfx_ctx_sdl_gl,
+#endif
 #if defined(HAVE_KMS)
    &gfx_ctx_drm,
 #endif
@@ -404,9 +407,6 @@ static const gfx_ctx_driver_t *gfx_ctx_drivers[] = {
 #endif
 #if defined(__APPLE__) && !defined(TARGET_IPHONE_SIMULATOR) && !defined(TARGET_OS_IPHONE)
    &gfx_ctx_cgl,
-#endif
-#if (defined(HAVE_SDL) || defined(HAVE_SDL2)) && defined(HAVE_OPENGL)
-   &gfx_ctx_sdl_gl,
 #endif
 #ifdef HAVE_OSMESA
    &gfx_ctx_osmesa,


### PR DESCRIPTION
## Description

If RetroArch is built with `--disable-x11` and `--disable-wayland` on linux it will default to a kms context and potentially fail unless `--disable-kms` is also used where it will use a sdl_gl context instead. This makes it so it will check sdl_gl before kms and default to that if neither x11 or wayland are available.

The downside of this is that it adds around 100 system calls when starting kms, I'm not sure there is a better way?

## Related Issues

See https://github.com/libretro/RetroArch/issues/8042#issuecomment-455804241 and related comments.
```
$ ./retroarch --verbose
[INFO] RetroArch 1.7.5 (Git 5611977de0)
[INFO] === Build =======================================
Capabilities: MMX MMXEXT SSE1 SSE2 SSE3 SSSE3 SSE4 SSE4.2 AVX AES 
Built: Jan 19 2019
[INFO] Version: 1.7.5
[INFO] Git: 5611977de0
[INFO] =================================================
[INFO] Environ SET_PIXEL_FORMAT: RGB565.
[INFO] Redirecting save file to "/media/data/home/games/roms/.saves/retroarch/.srm".
[INFO] Redirecting savestate to "/media/data/home/games/roms/.saves/retroarch/.sstates/.state".
[INFO] Version of libretro API: 1
[INFO] Compiled against API: 1
[INFO] [Audio]: Set audio input rate to: 30000.00 Hz.
[INFO] [Video]: Video @ 1152x720
[INFO] [DRM]: Found 4 connectors.
[INFO] [DRM]: Connector 0 connected: no
[INFO] [DRM]: Connector 0 has 0 modes.
[INFO] [DRM]: Connector 1 connected: no
[INFO] [DRM]: Connector 1 has 0 modes.
[INFO] [DRM]: Connector 2 connected: no
[INFO] [DRM]: Connector 2 has 0 modes.
[INFO] [DRM]: Connector 3 connected: yes
[INFO] [DRM]: Connector 3 has 14 modes.
[INFO] [DRM]: Connector 3 assigned to monitor index: #1.
[INFO] [DRM]: Mode 0: (1680x1050) 1680 x 1050, 60 Hz
[INFO] [DRM]: Mode 1: (1280x1024) 1280 x 1024, 75 Hz
[INFO] [DRM]: Mode 2: (1280x1024) 1280 x 1024, 60 Hz
[INFO] [DRM]: Mode 3: (1440x900) 1440 x 900, 60 Hz
[INFO] [DRM]: Mode 4: (1280x800) 1280 x 800, 60 Hz
[INFO] [DRM]: Mode 5: (1152x864) 1152 x 864, 75 Hz
[INFO] [DRM]: Mode 6: (1280x720) 1280 x 720, 60 Hz
[INFO] [DRM]: Mode 7: (1024x768) 1024 x 768, 75 Hz
[INFO] [DRM]: Mode 8: (1024x768) 1024 x 768, 60 Hz
[INFO] [DRM]: Mode 9: (800x600) 800 x 600, 75 Hz
[INFO] [DRM]: Mode 10: (800x600) 800 x 600, 60 Hz
[INFO] [DRM]: Mode 11: (640x480) 640 x 480, 75 Hz
[INFO] [DRM]: Mode 12: (640x480) 640 x 480, 60 Hz
[INFO] [DRM]: Mode 13: (720x400) 720 x 400, 70 Hz
amdgpu_device_initialize: amdgpu_query_info(ACCEL_WORKING) failed (-13)
amdgpu: amdgpu_device_initialize failed.
do_winsys_init: DRM version is 3.27.0 but this driver is only compatible with 2.12.0 (kernel 3.2) or later.
[INFO] [GL]: Found GL context: kms
[INFO] [GL]: Detecting screen resolution 1680x1050.
[INFO] [EGL] Found EGL_EXT_platform_base, trying eglGetPlatformDisplayEXT
[INFO] [EGL]: EGL version: 1.4
[INFO] [EGL]: Current context: 0xdaa400.
[INFO] [KMS]: New FB: 1680x1050 (stride: 6912).
[ERROR] [Video]: Cannot open video driver ... Exiting ...
[ERROR] Fatal error received in: "init_video()"
```

## Reviewers

@twinaphex 
