### PR TITLE
qb: Replace remaining uses of echo with printf.

### DIFF
--- a/qb/qb.comp.sh
+++ b/qb/qb.comp.sh
@@ -35,7 +35,7 @@ elif [ -z "$CC" ]; then
 	cc_status='not found'
 fi
 
-echo "Checking for suitable working C compiler ... $CC $cc_status"
+printf %s\\n "Checking for suitable working C compiler ... $CC $cc_status"
 
 if [ "$cc_works" = '0' ] && [ "$USE_LANG_C" = 'yes' ]; then
 	die 1 'Error: Cannot proceed without a working C compiler.'
@@ -72,7 +72,7 @@ elif [ -z "$CXX" ]; then
 	cxx_status='not found'
 fi
 
-echo "Checking for suitable working C++ compiler ... $CXX $cxx_status"
+printf %s\\n "Checking for suitable working C++ compiler ... $CXX $cxx_status"
 
 if [ "$cxx_works" = '0' ] && [ "$USE_LANG_CXX" = 'yes' ]; then
 	die : 'Warning: A working C++ compiler was not found, C++ features will be disabled.'
@@ -84,7 +84,7 @@ if [ "$OS" = "Win32" ]; then
 		WINDRES="$(exists "${CROSS_COMPILE}windres")" || WINDRES=""
 		[ -z "$WINDRES" ] && die 1 "$echobuf ... Not found. Exiting."
 	fi
-	echo "$echobuf ... $WINDRES"
+	printf %s\\n "$echobuf ... $WINDRES"
 fi
 
 if [ -z "$PKG_CONF_PATH" ]; then
@@ -98,7 +98,7 @@ if [ -z "$PKG_CONF_PATH" ]; then
 	done
 fi
 
-echo "Checking for pkg-config ... $PKG_CONF_PATH"
+printf %s\\n "Checking for pkg-config ... $PKG_CONF_PATH"
 
 if [ "$PKG_CONF_PATH" = "none" ]; then
 	die : 'Warning: pkg-config not found, package checks will fail.'

--- a/qb/qb.params.sh
+++ b/qb/qb.params.sh
@@ -43,14 +43,13 @@ EOF
 	print_help_option "--host=HOST"              "Cross-compile with HOST-gcc instead of gcc"
 	print_help_option "--help"                   "Show this help"
 
-	echo ""
-	echo "Custom options:"
+	printf %s\\n '' 'Custom options:'
 
 	while read -r VAR COMMENT; do
 		TMPVAR="${VAR%=*}"
 		COMMENT="${COMMENT#*#}"
 		VAL="${VAR#*=}"
-		VAR="$(echo "${TMPVAR#HAVE_}" | tr '[:upper:]' '[:lower:]')"
+		VAR="$(printf %s "${TMPVAR#HAVE_}" | tr '[:upper:]' '[:lower:]')"
 		case "$VAR" in
 			'c89_'*) continue;;
 			*)
@@ -70,7 +69,7 @@ EOF
 }
 
 opt_exists() # $opt is returned if exists in OPTS
-{	opt="$(echo "$1" | tr '[:lower:]' '[:upper:]')"
+{	opt="$(printf %s "$1" | tr '[:lower:]' '[:upper:]')"
 	err="$2"
 	eval "set -- $OPTS"
 	for OPT do [ "$opt" = "$OPT" ] && return; done

--- a/qb/qb.system.sh
+++ b/qb/qb.system.sh
@@ -47,4 +47,4 @@ if [ -e /etc/lsb-release ]; then
 	DISTRO="(${DISTRIB_DESCRIPTION} ${DISTRIB_RELEASE})"
 fi
 
-echo "Checking operating system ... $OS ${DISTRO}"
+printf %s\\n "Checking operating system ... $OS ${DISTRO}"


### PR DESCRIPTION
## Description

This is cleanup and there are no changes in behavior. It replaces the remaining uses of `echo` in the qb configure script with `printf` which is far preferred by the posix spec and should ensure greater portability.