### PR TITLE
CHANGES.md: Update NES/SNES/Lynx hashing methods

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # 1.7.6 (future)
 - ANDROID: Fix Xperia Play input binding
 - CHEEVOS: Reset when hardcore mode is toggled
+- CHEEVOS: Update the hashing methods to identify NES, SNES and Lynx games (more accurate and accepting headerless ROMs).
 - COMMON: Add new JSON playlist format
 - CORE UPDATER: Allow sideloading cores from the menu
 - CPU FILTERS: Add Normal2x filter.


### PR DESCRIPTION
- CHEEVOS: Update the hashing methods to identify NES, SNES and Lynx games (more accurate and accepting headerless ROMs).