### PR TITLE
qb: Add --enable-debug.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -588,6 +588,18 @@ check_macro NEON __ARM_NEON__
 
 add_define MAKEFILE OS "$OS"
 
+if [ "$HAVE_DEBUG" = 'yes' ]; then
+   add_define MAKEFILE DEBUG 1
+   if [ "$HAVE_OPENGL" = 'yes' ] ||
+      [ "$HAVE_OPENGLES" = 'yes' ] ||
+      [ "$HAVE_OPENGLES3" = 'yes' ]; then
+      add_define MAKEFILE GL_DEBUG 1
+   fi
+   if [ "$HAVE_VULKAN" = 'yes' ]; then
+      add_define MAKEFILE VULKAN_DEBUG 1
+   fi
+fi
+
 if [ "$HAVE_ZLIB" = 'no' ] && [ "$HAVE_RPNG" != 'no' ]; then
    HAVE_RPNG=no
    die : 'Notice: zlib is not available, RPNG will also be disabled.'

--- a/qb/config.params.sh
+++ b/qb/config.params.sh
@@ -6,6 +6,7 @@ HAVE_OPENGLES_LIBS=        # Link flags for custom GLES library
 HAVE_OPENGLES_CFLAGS=      # C-flags for custom GLES library
 HAVE_CACA=no               # Libcaca support
 HAVE_SIXEL=no              # Libsixel support
+HAVE_DEBUG=no              # Enable a debug build
 HAVE_LIBRETRODB=yes        # Libretrodb support
 HAVE_MENU=yes              # Enable menu drivers
 HAVE_RGUI=auto             # RGUI menu


### PR DESCRIPTION
## Description

This adds `--enable-debug` to the qb configure script which will be disabled by default. When used it will add `DEBUG=1` to `config.mk`. It will also check if `HAVE_OPENGL`, `HAVE_OPENGLES` or `HAVE_OPENGLES3` are enabled and add `GL_DEBUG=1` then. Likewise if `HAVE_VULKAN` is enabled it will add `VULKAN_DEBUG=1`.

The goal is to make it a little more convenient to get a debug build, but using `DEBUG=1`, `GL_DEBUG=1`, and `VULKAN_DEBUG=1` as make arguments will still work to retain backwards compatibility.
