### PR TITLE
(Vulkan) Enable RGUI 'Menu Linear Filter' option (please review)

### DIFF
--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -1867,6 +1867,8 @@ static bool vulkan_frame(void *data, const void *frame,
 #if defined(HAVE_MENU)
       if (vk->menu.enable)
       {
+         settings_t *settings = config_get_ptr();
+
          menu_driver_frame(video_info);
 
          if (vk->menu.textures[vk->menu.last_index].image != VK_NULL_HANDLE ||
@@ -1882,8 +1884,16 @@ static bool vulkan_frame(void *data, const void *frame,
             if (optimal->memory != VK_NULL_HANDLE)
                quad.texture = optimal;
 
-            quad.sampler = optimal->mipmap ?
-               vk->samplers.mipmap_linear : vk->samplers.linear;
+            if (settings->bools.menu_linear_filter)
+            {
+               quad.sampler = optimal->mipmap ?
+                  vk->samplers.mipmap_linear : vk->samplers.linear;
+            }
+            else
+            {
+               quad.sampler = optimal->mipmap ?
+                  vk->samplers.mipmap_nearest : vk->samplers.nearest;
+            }
 
             quad.mvp     = &vk->mvp_no_rot;
             quad.color.r = 1.0f;
@@ -2371,6 +2381,7 @@ static uint32_t vulkan_get_flags(void *data)
 
    BIT32_SET(flags, GFX_CTX_FLAGS_CUSTOMIZABLE_SWAPCHAIN_IMAGES);
    BIT32_SET(flags, GFX_CTX_FLAGS_BLACK_FRAME_INSERTION);
+   BIT32_SET(flags, GFX_CTX_FLAGS_MENU_FRAME_FILTERING);
 
    return flags;
 }


### PR DESCRIPTION
## Description

As reported in issue #8073, when using the Vulkan display driver there is no option to disable menu linear filtering in RGUI. This means the menu is permanently blurry and revolting, rendering most of the recent RGUI additions worthless for Vulkan users.

This PR simply enables the option, and allows for a crisp RGUI interface.

## Related Issues

#8073

## Reviewers

Please note that I don't know any details about the Vulkan driver implementation, but since this was such a trivial/obvious fix I felt I could go ahead with it. I have tested that it works with RGUI and does not affect the other menu drivers, but this should be reviewed by someone who does understand Vulkan before it is merged.
