### PR TITLE
Fix disk control and subsystems when navigating to the root directory.

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -8140,6 +8140,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, menu_displaylist
          break;
       case DISPLAYLIST_DEFAULT:
          menu_entries_ctl(MENU_ENTRIES_CTL_CLEAR, info->list);
+         load_content    = false;
          use_filebrowser = true;
          break;
       case DISPLAYLIST_CORES_DETECTED:


### PR DESCRIPTION
## Description

When navigating to the root directory (i.e. "`/`") RetroArch will overwrite the current `menu_label` such as `subsystem_add` with `favorites` effectively breaking features like subsystems or the disk control interface where it will try to detect which core to use instead of appending roms or disks to the current core. This is much more problematic if the `File Browser` path is not set which is the default.

The problem is discussed in more depth in the comments for issue https://github.com/libretro/RetroArch/issues/8071.

## Related Issues

Fixes https://github.com/libretro/RetroArch/issues/5642
Fixes https://github.com/libretro/RetroArch/issues/8071