### PR TITLE
Use Open GL 3 on OSX

### DIFF
--- a/gfx/common/gl_common.h
+++ b/gfx/common/gl_common.h
@@ -91,8 +91,10 @@ RETRO_BEGIN_DECLS
 #define glGenerateMipmap glGenerateMipmapOES
 #endif
 
-#if defined(HAVE_PSGL)
+#if defined(__APPLE__) || defined(HAVE_PSGL)
+#ifndef GL_RGBA32F
 #define GL_RGBA32F GL_RGBA32F_ARB
+#endif
 #endif
 
 #if defined(HAVE_PSGL)

--- a/libretro-common/include/glsym/rglgen_headers.h
+++ b/libretro-common/include/glsym/rglgen_headers.h
@@ -39,8 +39,13 @@
 #endif
 
 #elif defined(__APPLE__)
+#if defined(__x86_64__)
 #include <OpenGL/gl3.h>
 #include <OpenGL/gl3ext.h>
+#else
+#include <OpenGL/gl.h>
+#include <OpenGL/glext.h>
+#endif
 #elif defined(HAVE_PSGL)
 #include <PSGL/psgl.h>
 #include <GLES/glext.h>


### PR DESCRIPTION
## Description

Upgrade to Open GL 3 on OSX so that cores can request an Open GL 3.1 or better context.
By default RA still uses Open GL 2.1.

## Related Issues

Dolphin not running on OSX and reicast using Open GL 2 features only.
