### PR TITLE
xmb: Fix segfault when appending disk images.

### DIFF
--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -975,7 +975,7 @@ static void xmb_update_thumbnail_path(void *data, unsigned i, char pos)
       xmb_node_t *node = (xmb_node_t*)
          file_list_get_userdata_at_offset(selection_buf, i);
 
-      if (!string_is_empty(node->fullpath) &&
+      if (node && !string_is_empty(node->fullpath) &&
             (pos == 'R' || (pos == 'L' && string_is_equal(xmb_thumbnails_ident('R'),
                                                           msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF)))))
       {


### PR DESCRIPTION
## Description

This fixes a segfault that occurs under some circumstances when appending a disk image with xmb. It doesn't seem to occur with rgui, glui or ozone.

I think it crashes when loading the first disk from a playlist and then loading the second disk from the same directory, but only after navigating to it with a symlink. It seems easier to fix than to reproduce...

## Related Issues

```
Thread 1 "retroarch" received signal SIGSEGV, Segmentation fault.
0x00000000005c28ff in xmb_update_thumbnail_path (data=0x13c6f10, i=87, 
    pos=76 'L') at menu/drivers/xmb.c:978
978	      if (!string_is_empty(node->fullpath) &&
(gdb) bt
#0  0x00000000005c28ff in xmb_update_thumbnail_path (data=0x13c6f10, i=87, 
    pos=76 'L') at menu/drivers/xmb.c:978
#1  0x00000000005e111a in menu_driver_ctl (
    state=RARCH_MENU_CTL_UPDATE_THUMBNAIL_PATH, data=0x0)
    at menu/menu_driver.c:2452
#2  0x0000000000637f0b in menu_displaylist_parse_playlist (info=0x7fffffffdbb0, 
    playlist=0x1709470, path_playlist=0x72480c "collection", is_history=false)
    at menu/menu_displaylist.c:1343
#3  0x000000000063aab3 in menu_displaylist_parse_horizontal_list (
    menu=0x13f1cd0, info=0x7fffffffdbb0) at menu/menu_displaylist.c:2582
#4  0x00000000006476e3 in menu_displaylist_ctl (type=DISPLAYLIST_HORIZONTAL, 
    info=0x7fffffffdbb0) at menu/menu_displaylist.c:7124
#5  0x000000000063e0ca in menu_displaylist_push_internal (
    label=0x1427cd0 "horizontal_menu", entry=0x7fffffffdc50, info=0x7fffffffdbb0)
    at menu/menu_displaylist.c:4040
#6  0x000000000063e219 in menu_displaylist_push (entry=0x7fffffffdc50)
    at menu/menu_displaylist.c:4078
#7  0x000000000061523e in action_refresh_default (list=0x13fcab0, 
    menu_list=0x13fca90) at menu/cbs/menu_cbs_refresh.c:34
#8  0x00000000006038df in menu_entry_action (entry=0x7fffffffdce0, i=2, 
    action=MENU_ACTION_OK) at menu/widgets/menu_entry.c:502
#9  0x000000000064f20e in generic_menu_iterate (menu=0x13f1cd0, 
    userdata=0x13c6f10, action=MENU_ACTION_OK) at menu/drivers/menu_generic.c:232
#10 0x00000000005e021d in menu_driver_iterate (iterate=0x7fffffffdea0)
    at menu/menu_driver.c:2011
#11 0x00000000004185dc in runloop_check_state (settings=0x7fffefe3d010, 
    input_nonblock_state=false, runloop_is_paused=false, fastforward_ratio=5, 
    sleep_ms=0x7fffffffe0f0) at retroarch.c:2846
#12 0x00000000004198dc in runloop_iterate (sleep_ms=0x7fffffffe0f0)
    at retroarch.c:3559
#13 0x000000000041276c in rarch_main (argc=1, argv=0x7fffffffe208, data=0x0)
    at frontend/frontend.c:155
#14 0x00000000004127c9 in main (argc=1, argv=0x7fffffffe208)
    at frontend/frontend.c:183
```