### PR TITLE
Silence -Wformat-truncation warnings with DEBUG=1.

### DIFF
--- a/gfx/video_shader_parse.c
+++ b/gfx/video_shader_parse.c
@@ -1062,7 +1062,7 @@ void video_shader_write_conf_cgp(config_file_t *conf,
 
          for (i = 0; i < shader->luts; i++)
          {
-            char key[64];
+            char key[128];
 
             key[0] = '\0';
 

--- a/input/input_remapping.c
+++ b/input/input_remapping.c
@@ -56,7 +56,7 @@ bool input_remapping_load_file(void *data, const char *path)
       char s1[64], s2[64], s3[64];
       char btn_ident[RARCH_FIRST_CUSTOM_BIND][128]       = {{0}};
       char key_ident[RARCH_FIRST_CUSTOM_BIND][128]       = {{0}};
-      char stk_ident[8][128]                             = {{0}};
+      char stk_ident[8][192]                             = {{0}};
 
       char key_strings[RARCH_FIRST_CUSTOM_BIND + 8][128] = {
          "b", "y", "select", "start",


### PR DESCRIPTION
## Description

When built with `gcc-8.2.0` and `DEBUG=1` or `--enable-debug` warnings will be printed in two places.

## Related Issues

```
input/input_remapping.c:113:23: warning: ‘%s’ directive output may be truncated writing up to 127 bytes into a region of size between 64 and 127 [-Wformat-truncation=]
                   "%s_%s",
                       ^~
input/input_remapping.c:111:13: note: ‘snprintf’ output between 2 and 192 bytes into a destination of size 128
             snprintf(stk_ident[k],
             ^~~~~~~~~~~~~~~~~~~~~~
                   sizeof(stk_ident[k]),
                   ~~~~~~~~~~~~~~~~~~~~~
                   "%s_%s",
                   ~~~~~~~~
                   s3,
                   ~~~
                   key_strings[j]);
```
```
gfx/video_shader_parse.c: In function ‘video_shader_write_conf_cgp’:
gfx/video_shader_parse.c:1073:46: warning: ‘_linear’ directive output may be truncated writing 7 bytes into a region of size between 1 and 64 [-Wformat-truncation=]
                snprintf(key, sizeof(key), "%s_linear", shader->lut[i].id);
                                              ^~~~~~~
gfx/video_shader_parse.c:1073:16: note: ‘snprintf’ output between 8 and 71 bytes into a destination of size 64
                snprintf(key, sizeof(key), "%s_linear", shader->lut[i].id);
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
gfx/video_shader_parse.c:1079:22: warning: ‘_wrap_mode’ directive output may be truncated writing 10 bytes into a region of size between 1 and 64 [-Wformat-truncation=]
                   "%s_wrap_mode", shader->lut[i].id);
                      ^~~~~~~~~~
gfx/video_shader_parse.c:1078:13: note: ‘snprintf’ output between 11 and 74 bytes into a destination of size 64
             snprintf(key, sizeof(key),
             ^~~~~~~~~~~~~~~~~~~~~~~~~~
                   "%s_wrap_mode", shader->lut[i].id);
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
gfx/video_shader_parse.c:1084:22: warning: ‘_mipmap’ directive output may be truncated writing 7 bytes into a region of size between 1 and 64 [-Wformat-truncation=]
                   "%s_mipmap", shader->lut[i].id);
                      ^~~~~~~
gfx/video_shader_parse.c:1083:13: note: ‘snprintf’ output between 8 and 71 bytes into a destination of size 64
             snprintf(key, sizeof(key),
             ^~~~~~~~~~~~~~~~~~~~~~~~~~
                   "%s_mipmap", shader->lut[i].id);
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```