### PR TITLE
Makefile.common: Fix building discord-rpc with --disable-threads.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1744,6 +1744,11 @@ ifeq ($(HAVE_NETWORKING), 1)
       NEED_CXX_LINKER = 1
       DEFINES += -DHAVE_DISCORD
       DEFINES += -Ideps/discord-rpc/include/ -Ideps/discord-rpc/thirdparty/rapidjson-1.1.0/include/
+
+      ifneq ($(HAVE_THREADS), 1)
+         DEFINES += -DDISCORD_DISABLE_IO_THREAD
+      endif
+
       OBJ     += deps/discord-rpc/src/discord_rpc.o \
                  deps/discord-rpc/src/rpc_connection.o \
                  deps/discord-rpc/src/serialization.o \


### PR DESCRIPTION
## Description

Fixes the discord-rpc build with `--disable-threads`. It still doesn't build without `--disable-vulkan`.

## Related Issues

https://github.com/libretro/RetroArch/issues/8091

```
LD retroarch
/usr/bin/ld: obj-unix/release/deps/discord-rpc/src/discord_rpc.o: undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
/usr/bin/ld: /lib64/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make: *** [Makefile:195: retroarch] Error 1
```