### PR TITLE
Makefile.common: Remove duplicate -DHAVE_GLSL.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1160,7 +1160,6 @@ ifeq ($(HAVE_GL_CONTEXT), 1)
    endif
 
    OBJ += gfx/drivers_shader/shader_glsl.o
-   DEFINES += -DHAVE_GLSL
 endif
 
 ifeq ($(HAVE_EGL), 1)


### PR DESCRIPTION
## Description

Trivial cleanup, `Makefile.common` is setting `-DHAVE_GLSL` twice under a single conditional.

The other one is here.

https://github.com/libretro/RetroArch/blob/ffe65cdad8ecae3ed2a22f587779cbeda2865404/Makefile.common#L1062