### PR TITLE
[Wayland] Set minimum wayland version to 1.12

### DIFF
--- a/gfx/common/wayland/generate_wayland_protos.sh
+++ b/gfx/common/wayland/generate_wayland_protos.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 WAYSCAN=/usr/bin/wayland-scanner
+WAYSCAN_VER=$($WAYSCAN --version 2>&1 | awk '{print $2}')
 WAYLAND_PROTOS=/usr/share/wayland-protocols
 OUTPUT=gfx/common/wayland
 
@@ -12,18 +13,25 @@ if [ ! -d $OUTPUT ]; then
     mkdir $OUTPUT
 fi
 
+#Since Wayland 1.15 option "code" is deprecated. Recommended to use "private-code" option instead.
+if [ "$WAYSCAN_VER -ge 1.15" ]; then
+    CODEGEN=private-code
+else
+    CODEGEN=code
+fi
+
 #Generate xdg-shell_v6 header and .c files
 $WAYSCAN client-header $WAYLAND_PROTOS/unstable/xdg-shell/xdg-shell-unstable-v6.xml $OUTPUT/xdg-shell-unstable-v6.h
-$WAYSCAN private-code $WAYLAND_PROTOS/unstable/xdg-shell/xdg-shell-unstable-v6.xml $OUTPUT/xdg-shell-unstable-v6.c
+$WAYSCAN $CODEGEN $WAYLAND_PROTOS/unstable/xdg-shell/xdg-shell-unstable-v6.xml $OUTPUT/xdg-shell-unstable-v6.c
 
 #Generate xdg-shell header and .c files
 $WAYSCAN client-header $WAYLAND_PROTOS/stable/xdg-shell/xdg-shell.xml $OUTPUT/xdg-shell.h
-$WAYSCAN private-code $WAYLAND_PROTOS/stable/xdg-shell/xdg-shell.xml $OUTPUT/xdg-shell.c
+$WAYSCAN $CODEGEN $WAYLAND_PROTOS/stable/xdg-shell/xdg-shell.xml $OUTPUT/xdg-shell.c
 
 #Generate idle-inhibit header and .c files
 $WAYSCAN client-header $WAYLAND_PROTOS/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml $OUTPUT/idle-inhibit-unstable-v1.h
-$WAYSCAN private-code $WAYLAND_PROTOS/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml $OUTPUT/idle-inhibit-unstable-v1.c
+$WAYSCAN $CODEGEN $WAYLAND_PROTOS/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml $OUTPUT/idle-inhibit-unstable-v1.c
 
 #Generate xdg-decoration header and .c files
 $WAYSCAN client-header $WAYLAND_PROTOS/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml $OUTPUT/xdg-decoration-unstable-v1.h
-$WAYSCAN private-code $WAYLAND_PROTOS/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml $OUTPUT/xdg-decoration-unstable-v1.c
+$WAYSCAN $CODEGEN $WAYLAND_PROTOS/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml $OUTPUT/xdg-decoration-unstable-v1.c

--- a/gfx/common/wayland/generate_wayland_protos.sh
+++ b/gfx/common/wayland/generate_wayland_protos.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 WAYSCAN=/usr/bin/wayland-scanner
-WAYSCAN_VER=$($WAYSCAN --version 2>&1 | awk '{print $2}')
 WAYLAND_PROTOS=/usr/share/wayland-protocols
 OUTPUT=gfx/common/wayland
 
@@ -11,13 +10,6 @@ fi
 
 if [ ! -d $OUTPUT ]; then
     mkdir $OUTPUT
-fi
-
-#Since Wayland 1.15 option "code" is deprecated. Recommended to use "private-code" option instead.
-if [ "$WAYSCAN_VER -ge 1.15" ]; then
-    CODEGEN=private-code
-else
-    CODEGEN=code
 fi
 
 #Generate xdg-shell_v6 header and .c files

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -463,10 +463,10 @@ check_val '' XEXT -lXext '' xext '' ''
 check_val '' XF86VM -lXxf86vm '' xxf86vm '' ''
 
 if [ "$HAVE_WAYLAND_PROTOS" = yes ] && [ "$HAVE_WAYLAND" = yes ]; then
-    check_pkgconf WAYLAND_SCANNER wayland-scanner 1.12
+    check_pkgconf WAYLAND_SCANNER wayland-scanner 1.15
     ./gfx/common/wayland/generate_wayland_protos.sh
 else
-    die : 'Notice: wayland (>=1.12) or wayland-protocols (>=1.15) not found. Disabling Wayland support.'
+    die : 'Notice: wayland-egl or wayland-protocols not found, disabling wayland support.'
     HAVE_WAYLAND='no'
 fi
 

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -454,8 +454,8 @@ check_val '' V4L2 -lv4l2 '' libv4l2 '' ''
 check_val '' FREETYPE -lfreetype freetype2 freetype2 '' ''
 check_val '' X11 -lX11 '' x11 '' ''
 check_val '' XCB -lxcb '' xcb '' ''
-check_val '' WAYLAND '-lwayland-egl -lwayland-client' '' wayland-egl 1.15 ''
-check_val '' WAYLAND_CURSOR -lwayland-cursor '' wayland-cursor 1.15 ''
+check_val '' WAYLAND '-lwayland-egl -lwayland-client' '' wayland-egl 1.12 ''
+check_val '' WAYLAND_CURSOR -lwayland-cursor '' wayland-cursor 1.12 ''
 check_pkgconf WAYLAND_PROTOS wayland-protocols 1.15
 check_val '' XKBCOMMON -lxkbcommon '' xkbcommon 0.3.2 ''
 check_pkgconf DBUS dbus-1
@@ -463,10 +463,10 @@ check_val '' XEXT -lXext '' xext '' ''
 check_val '' XF86VM -lXxf86vm '' xxf86vm '' ''
 
 if [ "$HAVE_WAYLAND_PROTOS" = yes ] && [ "$HAVE_WAYLAND" = yes ]; then
-    check_pkgconf WAYLAND_SCANNER wayland-scanner 1.15
+    check_pkgconf WAYLAND_SCANNER wayland-scanner 1.12
     ./gfx/common/wayland/generate_wayland_protos.sh
 else
-    die : 'Notice: wayland-egl or wayland-protocols not found, disabling wayland support.'
+    die : 'Notice: wayland (>=1.12) or wayland-protocols (>=1.15) not found. Disabling Wayland support.'
     HAVE_WAYLAND='no'
 fi
 


### PR DESCRIPTION
This allows to build RetroArch with Wayland support on Debian 9, Ubuntu 16.04, which have Wayland 1.12. Maybe additionally supplying `wayland-protocols` as part of the RetroArch?