### PR TITLE
Add missing files in libretro-db Makefile

### DIFF
--- a/libretro-db/Makefile
+++ b/libretro-db/Makefile
@@ -13,6 +13,8 @@ endif
 
 LIBRETRO_COMMON_C = \
 			 $(LIBRETRO_COMM_DIR)/streams/file_stream.c \
+			 $(LIBRETRO_COMM_DIR)/compat/compat_strcasestr.c \
+			 $(LIBRETRO_COMM_DIR)/file/file_path.c \
 			 $(LIBRETRO_COMM_DIR)/vfs/vfs_implementation.c \
 			 $(LIBRETRO_COMM_DIR)/encodings/encoding_utf.c \
 			 $(LIBRETRO_COMM_DIR)/compat/compat_strl.c \


### PR DESCRIPTION
I had to add these 2 files to compile the programs in the libretro-db folder.