### PR TITLE
Update generate_wayland_protos.sh.

### DIFF
--- a/configure
+++ b/configure
@@ -4,6 +4,8 @@ PACKAGE_NAME=retroarch
 
 cat /dev/null > config.log
 
+. qb/qb.init.sh
+
 . qb/qb.system.sh
 
 . qb/qb.params.sh

--- a/gfx/common/wayland/generate_wayland_protos.sh
+++ b/gfx/common/wayland/generate_wayland_protos.sh
@@ -1,35 +1,65 @@
 #!/bin/sh
-WAYSCAN=/usr/bin/wayland-scanner
-WAYLAND_PROTOS=/usr/share/wayland-protocols
-OUTPUT=gfx/common/wayland
 
-if [ ! -d $WAYLAND_PROTOS ]; then
-    WAYSCAN=/usr/local/bin/wayland-scanner
-    WAYLAND_PROTOS=/usr/local/share/wayland-protocols
-fi
+set -eu
 
-if [ ! -d $OUTPUT ]; then
-    mkdir $OUTPUT
-fi
+cd -- "$(cd -- "${0%/*}/" && pwd -P)"
 
-if [ "${1:-}" = '1.12' ]; then
+. ../../../qb/qb.init.sh
+
+SCANNER_VERSION=''
+SHARE_DIR=''
+
+usage="generate_wayland_protos.sh - Generates wayland protocols.
+
+  Usage: generate_wayland_protos.sh [OPTIONS]
+    -c, --codegen version   Sets the wayland scanner compatibility version.
+    -h, --help              Shows this message.
+    -s, --share path        Sets the path of the wayland protocols directory."
+
+while [ $# -gt 0 ]; do
+   option="$1"
+   shift
+   case "$option" in
+      -- ) break ;;
+      -c|--codegen ) SCANNER_VERSION="$1"; shift ;;
+      -h|--help ) die 0 "$usage" ;;
+      -s|--share ) SHARE_DIR="$1/wayland-protocols"; shift ;;
+      * ) die 1 "Unrecognized option '$option', use -h for help." ;;
+   esac
+done
+
+WAYSCAN="$(exists wayland-scanner || :)"
+
+[ "${WAYSCAN}" ] || die 1 "Error: No wayscan in ($PATH)"
+
+WAYLAND_PROTOS=''
+
+for protos in "$SHARE_DIR" /usr/local/share/wayland-protocols /usr/share/wayland-protocols; do
+   [ -d "$protos" ] || continue
+   WAYLAND_PROTOS="$protos"
+   break
+done
+
+[ "${WAYLAND_PROTOS}" ] || die 1 'Error: No wayland-protocols directory found.'
+
+if [ "$SCANNER_VERSION" = '1.12' ]; then
    CODEGEN=code
 else
    CODEGEN=private-code
 fi
 
 #Generate xdg-shell_v6 header and .c files
-$WAYSCAN client-header $WAYLAND_PROTOS/unstable/xdg-shell/xdg-shell-unstable-v6.xml $OUTPUT/xdg-shell-unstable-v6.h
-$WAYSCAN $CODEGEN $WAYLAND_PROTOS/unstable/xdg-shell/xdg-shell-unstable-v6.xml $OUTPUT/xdg-shell-unstable-v6.c
+"$WAYSCAN" client-header "$WAYLAND_PROTOS/unstable/xdg-shell/xdg-shell-unstable-v6.xml" ./xdg-shell-unstable-v6.h
+"$WAYSCAN" $CODEGEN "$WAYLAND_PROTOS/unstable/xdg-shell/xdg-shell-unstable-v6.xml" ./xdg-shell-unstable-v6.c
 
 #Generate xdg-shell header and .c files
-$WAYSCAN client-header $WAYLAND_PROTOS/stable/xdg-shell/xdg-shell.xml $OUTPUT/xdg-shell.h
-$WAYSCAN $CODEGEN $WAYLAND_PROTOS/stable/xdg-shell/xdg-shell.xml $OUTPUT/xdg-shell.c
+"$WAYSCAN" client-header "$WAYLAND_PROTOS/stable/xdg-shell/xdg-shell.xml" ./xdg-shell.h
+"$WAYSCAN" $CODEGEN "$WAYLAND_PROTOS/stable/xdg-shell/xdg-shell.xml" ./xdg-shell.c
 
 #Generate idle-inhibit header and .c files
-$WAYSCAN client-header $WAYLAND_PROTOS/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml $OUTPUT/idle-inhibit-unstable-v1.h
-$WAYSCAN $CODEGEN $WAYLAND_PROTOS/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml $OUTPUT/idle-inhibit-unstable-v1.c
+"$WAYSCAN" client-header "$WAYLAND_PROTOS/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml" ./idle-inhibit-unstable-v1.h
+"$WAYSCAN" $CODEGEN "$WAYLAND_PROTOS/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml" ./idle-inhibit-unstable-v1.c
 
 #Generate xdg-decoration header and .c files
-$WAYSCAN client-header $WAYLAND_PROTOS/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml $OUTPUT/xdg-decoration-unstable-v1.h
-$WAYSCAN $CODEGEN $WAYLAND_PROTOS/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml $OUTPUT/xdg-decoration-unstable-v1.c
+"$WAYSCAN" client-header "$WAYLAND_PROTOS/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml" ./xdg-decoration-unstable-v1.h
+"$WAYSCAN" $CODEGEN "$WAYLAND_PROTOS/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml" ./xdg-decoration-unstable-v1.c

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -466,7 +466,8 @@ check_val '' XF86VM -lXxf86vm '' xxf86vm '' ''
 if [ "$HAVE_WAYLAND_PROTOS" = yes ] &&
    [ "$HAVE_WAYLAND_SCANNER" = yes ] &&
    [ "$HAVE_WAYLAND" = yes ]; then
-    ./gfx/common/wayland/generate_wayland_protos.sh "$WAYLAND_SCANNER_VERSION"
+    ./gfx/common/wayland/generate_wayland_protos.sh -c "$WAYLAND_SCANNER_VERSION" -s "$SHARE_DIR" ||
+       die 1 'Error: Failed generating wayland protocols.'
 else
     die : 'Notice: wayland libraries not found, disabling wayland support.'
     HAVE_WAYLAND='no'

--- a/qb/qb.init.sh
+++ b/qb/qb.init.sh
@@ -1,0 +1,43 @@
+# Only add standalone functions to this file which are easy to source anywhere.
+
+# die:
+# Prints a warning or an exit error.
+# $1 = exit code, use : to not exit when printing warnings
+# $@ = exit or warning messages
+die()
+{	ret="$1"
+	shift 1
+	printf %s\\n "$@" >&2
+	case "$ret" in
+		: ) return 0 ;;
+		* ) exit "$ret" ;;
+	esac
+}
+
+# exists:
+# Finds executable files in the $PATH
+# $@ = files
+exists()
+{	v=1
+	while [ $# -gt 0 ]; do
+		arg="$1"
+		shift 1
+		case "$arg" in ''|*/) continue ;; esac
+		x="${arg##*/}"
+		z="${arg%/*}"
+		[ ! -f "$z/$x" ] || [ ! -x "$z/$x" ] && [ "$z/$x" = "$arg" ] &&
+			continue
+		[ "$x" = "$z" ] && [ -x "$z/$x" ] && [ ! -f "$arg" ] && z=
+		p=":$z:$PATH"
+		while [ "$p" != "${p#*:}" ]; do
+			p="${p#*:}"
+			d="${p%%:*}"
+			if [ -f "$d/$x" ] && [ -x "$d/$x" ]; then
+				printf %s\\n "$d/$x"
+				v=0
+				break
+			fi
+		done
+	done
+	return $v
+}

--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -6,7 +6,8 @@ SHARE_DIR="${SHARE_DIR:-${PREFIX}/share}"
 
 # add_define:
 # $1 = MAKEFILE or CONFIG
-# $2 = define $3 = value
+# $2 = define
+# $3 = value
 add_define()
 { eval "${1}_DEFINES=\"\${${1}_DEFINES} $2=$3\""; }
 

--- a/qb/qb.params.sh
+++ b/qb/qb.params.sh
@@ -1,14 +1,3 @@
-die() # $1 = exit code, use : to not exit when printing warnings $@ = exit or warning messages
-{
-	ret="$1"
-	shift 1
-	printf %s\\n "$@" >&2
-	case "$ret" in
-		: ) return 0 ;;
-		* ) exit "$ret" ;;
-	esac
-}
-
 print_help_option() # $1 = option $@ = description
 {
 	_opt="$1"

--- a/qb/qb.system.sh
+++ b/qb/qb.system.sh
@@ -1,25 +1,3 @@
-exists() # checks executables listed in $@ against the $PATH
-{
-	v=1
-	while [ "$#" -gt 0 ]; do
-		arg="$1"
-		shift 1
-		case "$arg" in ''|*/) continue ;; esac
-		x="${arg##*/}"
-		z="${arg%/*}"
-		[ ! -f "$z/$x" ] || [ ! -x "$z/$x" ] && [ "$z/$x" = "$arg" ] && continue
-		[ "$x" = "$z" ] && [ -x "$z/$x" ] && [ ! -f "$arg" ] && z=
-		p=":$z:$PATH"
-		while [ "$p" != "${p#*:}" ]; do
-			p="${p#*:}"
-			d="${p%%:*}"
-			{ [ -f "$d/$x" ] && [ -x "$d/$x" ] && \
-				{ printf %s\\n "$d/$x"; v=0; break; }; } || :
-		done
-	done
-	return "$v"
-}
-
 if [ -n "$CROSS_COMPILE" ]; then
 	case "$CROSS_COMPILE" in
 		*'-mingw32'*) OS='Win32';;


### PR DESCRIPTION
## Description

This updates `gfx/common/wayland/generate_wayland_protos.sh` to be a bit more robust.

Some things this PR does.
* Creates `qb/qb.init.sh` which contains two standalone general functions. Its easier to keep them in their own file so they can be sourced more easily.
* Adds a missing error in case `generate_wayland_protos.sh` fails instead of letting it fail during compilation later.
* Reworks the logic in `generate_wayland_protos.sh` to avoid hardcoded paths, provide more error checking and a basic argument handler for better handling of configuration.

## Reviewers

@Sunderland93 Can you please test this and make sure its still working for you?
