### PR TITLE
qb: Test a real version of wayland-egl.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -454,7 +454,7 @@ check_val '' V4L2 -lv4l2 '' libv4l2 '' ''
 check_val '' FREETYPE -lfreetype freetype2 freetype2 '' ''
 check_val '' X11 -lX11 '' x11 '' ''
 check_val '' XCB -lxcb '' xcb '' ''
-check_val '' WAYLAND '-lwayland-egl -lwayland-client' '' wayland-egl 1.12 ''
+check_val '' WAYLAND '-lwayland-egl -lwayland-client' '' wayland-egl 10.1.0 ''
 check_val '' WAYLAND_CURSOR -lwayland-cursor '' wayland-cursor 1.12 ''
 check_pkgconf WAYLAND_PROTOS wayland-protocols 1.15
 check_pkgconf WAYLAND_SCANNER wayland-scanner '1.15 1.12'


### PR DESCRIPTION
## Description

This matches the default mesa version in Ubuntu 14.04 and should be older than most installed mesa versions.
