### PR TITLE
remove conditional hiding CRT SwitchRes options

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -6684,10 +6684,9 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, menu_displaylist
          break;
       case DISPLAYLIST_VIDEO_SETTINGS_LIST:
          menu_entries_ctl(MENU_ENTRIES_CTL_CLEAR, info->list);
-         if (!string_is_equal(video_display_server_get_ident(), "null"))
-            menu_displaylist_parse_settings_enum(menu, info,
-                  MENU_ENUM_LABEL_CRT_SWITCHRES_SETTINGS,
-                  PARSE_ACTION, false);
+         menu_displaylist_parse_settings_enum(menu, info,
+               MENU_ENUM_LABEL_CRT_SWITCHRES_SETTINGS,
+               PARSE_ACTION, false);
          menu_displaylist_parse_settings_enum(menu, info,
                MENU_ENUM_LABEL_SUSPEND_SCREENSAVER_ENABLE,
                PARSE_ONLY_BOOL, false);

--- a/pkg/debian/control
+++ b/pkg/debian/control
@@ -10,6 +10,7 @@ Build-Depends:	debhelper (>= 9),
 				libsdl2-dev,
 				libxml2-dev,
 				libavcodec-dev,
+				libavdevice-dev,
 				libavformat-dev,
 				libavutil-dev,
 				libswscale-dev,
@@ -29,6 +30,9 @@ Build-Depends:	debhelper (>= 9),
 				libegl1-mesa-dev,
 				python3-dev,
 				zlib1g-dev,
+				qt5-default,
+				libusb-1.0-0-dev,
+				libass-dev,
 				nvidia-cg-dev [!armhf]
 Standards-Version: 3.9.5
 Homepage: http://www.libretro.com/
@@ -41,6 +45,7 @@ Depends:		${shlibs:Depends},
 				${misc:Depends},
 				fonts-dejavu-core,
 				python3,
+				libqt5waylandclient5,
 				nvidia-cg-toolkit [!armhf]
 Replaces: ssnes
 Suggests: retroarch-joypad-autoconfig, libretro-common-shaders, libretro-common-overlays, retroarch-assets
@@ -49,5 +54,3 @@ Description: Simple frontend for the libretro library
  It can be used as a modular multi emulator system, game engine, media player 
  and 3D technical demonstration. These features are available through 
  libretro cores.
- .
- It provides a simple built-in GUI, the RGUI.


### PR DESCRIPTION
Since RPi will support switching without X in alphanu's next revision, these options need to be visible even when there's no display server.
