### PR TITLE
qb: Don't force threads for win32.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -149,19 +149,13 @@ if [ "$OS" = 'DOS' ]; then
    HAVE_LANGEXTRA=no
 fi
 
+check_lib '' THREADS "$PTHREADLIB" pthread_create
+check_enabled THREADS THREAD_STORAGE 'Thread Local Storage' 'Threads are'
+check_lib '' THREAD_STORAGE "$PTHREADLIB" pthread_key_create
+
 if [ "$OS" = 'Win32' ]; then
-   HAVE_THREADS=yes
-   HAVE_THREAD_STORAGE=yes
    HAVE_DYLIB=yes
 else
-   check_lib '' THREADS "$PTHREADLIB" pthread_create
-
-   if [ "$HAVE_THREADS" = 'yes' ]; then
-      check_lib '' THREAD_STORAGE "$PTHREADLIB" pthread_key_create
-   else
-      HAVE_THREAD_STORAGE=no
-   fi
-
    check_lib '' DYLIB "$DYLIB" dlopen
 fi
 
@@ -255,8 +249,8 @@ if [ "$HAVE_SDL2" = 'yes' ] && [ "$HAVE_SDL" = 'yes' ]; then
    HAVE_SDL=no
 fi
 
-check_enabled CXX DISCORD discord 'the C++ compiler is'
-check_enabled CXX QT 'Qt companion' 'the C++ compiler is'
+check_enabled CXX DISCORD discord 'The C++ compiler is'
+check_enabled CXX QT 'Qt companion' 'The C++ compiler is'
 
 if [ "$HAVE_QT" != 'no' ]; then
    check_pkgconf QT5CORE Qt5Core 5.2
@@ -319,7 +313,7 @@ if [ "$HAVE_SSL" != 'no' ]; then
    fi
 fi
 
-check_enabled THREADS LIBUSB libusb 'threads are'
+check_enabled THREADS LIBUSB libusb 'Threads are'
 check_val '' LIBUSB -lusb-1.0 libusb-1.0 libusb-1.0 1.0.13 '' false
 
 if [ "$OS" = 'Win32' ]; then
@@ -380,13 +374,10 @@ fi
 
 check_val '' MPV -lmpv '' mpv '' '' false
 
-if [ "$HAVE_THREADS" = 'no' ] && [ "$HAVE_FFMPEG" != 'no' ]; then
-   HAVE_FFMPEG='no'
-   die : 'Notice: Threads are not available, FFmpeg will also be disabled.'
-fi
-
 check_header DRMINGW exchndl.h
 check_lib '' DRMINGW -lexchndl
+
+check_enabled THREADS FFMPEG FFmpeg 'Threads are'
 
 if [ "$HAVE_FFMPEG" != 'no' ]; then
    check_val '' AVCODEC -lavcodec '' libavcodec 54 '' false
@@ -498,8 +489,8 @@ fi
 check_lib '' STRCASESTR "$CLIB" strcasestr
 check_lib '' MMAP "$CLIB" mmap
 
-check_enabled CXX VULKAN vulkan 'the C++ compiler is'
-check_enabled THREADS VULKAN vulkan 'threads are'
+check_enabled CXX VULKAN vulkan 'The C++ compiler is'
+check_enabled THREADS VULKAN vulkan 'Threads are'
 
 if [ "$HAVE_VULKAN" != "no" ] && [ "$OS" = 'Win32' ]; then
    HAVE_VULKAN=yes

--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -49,11 +49,15 @@ check_enabled()
 	tmpval="$(eval "printf %s \"\$USER_$2\"")"
 
 	if [ "$tmpval" != 'yes' ]; then
-		eval "HAVE_$2=no"
+		setval="$(eval "printf %s \"\$HAVE_$2\"")"
+		if [ "$setval" != 'no' ]; then
+			eval "HAVE_$2=no"
+			die : "Notice: $4 disabled, $3 support will also be disabled."
+		fi
 		return 0
 	fi
 
-	die 1 "Forced to build with $3 support and $4 disabled. Exiting ..."
+	die 1 "Error: $4 disabled and forced to build with $3 support."
 }
 
 # check_lib:


### PR DESCRIPTION
## Description

The main goal of this PR is not force `HAVE_THREADS` and `HAVE_THREAD_STORAGE` for win32 builds where the existing `check_lib` checks seem to work just fine as tested by @fr500 and travis.

It also accomplishes a few other things.
* It restores the warning messages when features are automatically disabled because of other disabled features. I refactored them out in my previous PR, but in retrospect they are better to keep.
* Rewords the error message in `check_enabled` to be easier to work with.
* Replaces `HAVE_THREADS` conditionals in `config.libs.sh` for `HAVE_THREAD_STORAGE` and `HAVE_FFMPEG` with `check_enabled`.

## Related Issues

Fixes `--disable-threads` and `--disable-thread_storage` for win32 builds which now actually do something.

Further fixes https://github.com/libretro/RetroArch/issues/8091.

## Related Pull Requests

Followup to https://github.com/libretro/RetroArch/pull/8123.