### PR TITLE
libnx: remove HAVE_CHD + add assets to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ libretro-super
 run.sh
 convert_rumble.awk
 *~
+assets
 
 # Wii U
 *.depend

--- a/Makefile.libnx
+++ b/Makefile.libnx
@@ -41,7 +41,7 @@ HAVE_NETWORKING = 1
 HAVE_NETPLAYDISCOVERY = 1
 HAVE_STB_FONT = 1
 HAVE_CHEEVOS = 1
-HAVE_CHD = 1
+HAVE_CHD = 0 # disabled due to static libretro-common and libchdr conflicts between different cores
 HAVE_STB_VORBIS = 1
 
 # RetroArch libnx useful flags


### PR DESCRIPTION
Fixes https://github.com/libretro/Genesis-Plus-GX/issues/163 (temporarly)

Also, Windows build puts assets in `./assets` for some reason so I added that to the gitignore