### PR TITLE
qb: Combine HAVE_VIDEO_PROCESSOR with HAVE_VIDEOPROCCESOR.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -27,10 +27,6 @@ ifeq ($(HAVE_LIBRETRODB),)
    HAVE_LIBRETRODB = 1
 endif
 
-ifeq ($(HAVE_VIDEO_PROCESSOR), 1)
-   DEFINES += -DHAVE_VIDEO_PROCESSOR
-endif
-
 ifeq ($(HAVE_SOCKET_LEGACY), 1)
    DEFINES += -DHAVE_SOCKET_LEGACY
 endif
@@ -1602,7 +1598,8 @@ endif
 
 ifeq ($(HAVE_V4L2),1)
    OBJ += camera/drivers/video4linux2.o
-   ifeq ($(HAVE_VIDEO_PROCESSOR),1)
+   ifeq ($(HAVE_VIDEOPROCESSOR),1)
+      DEFINES += -DHAVE_VIDEOPROCESSOR
       OBJ += cores/libretro-video-processor/video_processor_v4l2.o
    endif
    DEFINES += -DHAVE_V4L2

--- a/dynamic.c
+++ b/dynamic.c
@@ -104,7 +104,7 @@ static dylib_t lib_handle;
 #define SYMBOL_NETRETROPAD(x) current_core->x = libretro_netretropad_##x
 #endif
 
-#if defined(HAVE_VIDEO_PROCESSOR)
+#if defined(HAVE_VIDEOPROCESSOR)
 #define SYMBOL_VIDEOPROCESSOR(x) current_core->x = libretro_videoprocessor_##x
 #endif
 
@@ -748,7 +748,7 @@ bool init_libretro_sym_custom(enum rarch_core_type type, struct retro_core_t *cu
 #endif
          break;
       case CORE_TYPE_VIDEO_PROCESSOR:
-#if defined(HAVE_VIDEO_PROCESSOR)
+#if defined(HAVE_VIDEOPROCESSOR)
          SYMBOL_VIDEOPROCESSOR(retro_init);
          SYMBOL_VIDEOPROCESSOR(retro_deinit);
 

--- a/griffin/griffin.c
+++ b/griffin/griffin.c
@@ -728,7 +728,7 @@ CAMERA
 #include "../camera/drivers/video4linux2.c"
 #endif
 
-#ifdef HAVE_VIDEO_PROCESSOR
+#ifdef HAVE_VIDEOPROCESSOR
 #include "../cores/libretro-video-processor/video_processor_v4l2.c"
 #endif
 

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -4207,7 +4207,7 @@ bool menu_displaylist_process(menu_displaylist_info_t *info)
 
    if (info->push_builtin_cores)
    {
-#if defined(HAVE_VIDEO_PROCESSOR)
+#if defined(HAVE_VIDEOPROCESSOR)
       menu_entries_append_enum(info->list,
             msg_hash_to_str(MENU_ENUM_LABEL_VALUE_START_VIDEO_PROCESSOR),
             msg_hash_to_str(MENU_ENUM_LABEL_START_VIDEO_PROCESSOR),

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -3746,7 +3746,7 @@ static bool setting_append_list(
                &subgroup_info,
                parent_group);
 
-#if defined(HAVE_VIDEO_PROCESSOR)
+#if defined(HAVE_VIDEOPROCESSOR)
          CONFIG_ACTION(
                list, list_info,
                MENU_ENUM_LABEL_START_VIDEO_PROCESSOR,

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -145,7 +145,7 @@ if [ "$OS" = 'DOS' ]; then
 fi
 
 check_lib '' THREADS "$PTHREADLIB" pthread_create
-check_enabled THREADS THREAD_STORAGE 'Thread Local Storage' 'Threads are'
+check_enabled THREADS THREAD_STORAGE 'Thread Local Storage' 'Threads are' false
 check_lib '' THREAD_STORAGE "$PTHREADLIB" pthread_key_create
 
 if [ "$OS" = 'Win32' ]; then
@@ -244,8 +244,8 @@ if [ "$HAVE_SDL2" = 'yes' ] && [ "$HAVE_SDL" = 'yes' ]; then
    HAVE_SDL=no
 fi
 
-check_enabled CXX DISCORD discord 'The C++ compiler is'
-check_enabled CXX QT 'Qt companion' 'The C++ compiler is'
+check_enabled CXX DISCORD discord 'The C++ compiler is' false
+check_enabled CXX QT 'Qt companion' 'The C++ compiler is' false
 
 if [ "$HAVE_QT" != 'no' ]; then
    check_pkgconf QT5CORE Qt5Core 5.2
@@ -308,7 +308,7 @@ if [ "$HAVE_SSL" != 'no' ]; then
    fi
 fi
 
-check_enabled THREADS LIBUSB libusb 'Threads are'
+check_enabled THREADS LIBUSB libusb 'Threads are' false
 check_val '' LIBUSB -lusb-1.0 libusb-1.0 libusb-1.0 1.0.13 '' false
 
 if [ "$OS" = 'Win32' ]; then
@@ -372,7 +372,7 @@ check_val '' MPV -lmpv '' mpv '' '' false
 check_header DRMINGW exchndl.h
 check_lib '' DRMINGW -lexchndl
 
-check_enabled THREADS FFMPEG FFmpeg 'Threads are'
+check_enabled THREADS FFMPEG FFmpeg 'Threads are' false
 
 if [ "$HAVE_FFMPEG" != 'no' ]; then
    check_val '' AVCODEC -lavcodec '' libavcodec 54 '' false
@@ -484,8 +484,8 @@ fi
 check_lib '' STRCASESTR "$CLIB" strcasestr
 check_lib '' MMAP "$CLIB" mmap
 
-check_enabled CXX VULKAN vulkan 'The C++ compiler is'
-check_enabled THREADS VULKAN vulkan 'Threads are'
+check_enabled CXX VULKAN vulkan 'The C++ compiler is' false
+check_enabled THREADS VULKAN vulkan 'Threads are' false
 
 if [ "$HAVE_VULKAN" != "no" ] && [ "$OS" = 'Win32' ]; then
    HAVE_VULKAN=yes
@@ -532,8 +532,5 @@ if [ "$HAVE_DEBUG" = 'yes' ]; then
    fi
 fi
 
-check_enabled ZLIB RPNG RPNG 'zlib is'
-
-if [ "$HAVE_V4L2" != 'no' ] && [ "$HAVE_VIDEOPROCESSOR" != 'no' ]; then
-   HAVE_VIDEO_PROCESSOR=yes
-fi
+check_enabled ZLIB RPNG RPNG 'zlib is' false
+check_enabled V4L2 VIDEOPROCESSOR 'video processor' 'Video4linux2 is' true

--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -43,16 +43,26 @@ check_compiler()
 # $2 = USER_$2 [Enabled feature]
 # $3 = lib
 # $4 = feature
+# $5 = enable lib when true [checked only if non-empty]
 check_enabled()
 {	tmpvar="$(eval "printf %s \"\$HAVE_$1\"")"
-	[ "$tmpvar" != 'no' ] && return 0
+	setval="$(eval "printf %s \"\$HAVE_$2\"")"
+
+	if [ "$tmpvar" != 'no' ]; then
+		if [ "$setval" != 'no' ] && [ "${5:-}" = 'true' ]; then
+			eval "HAVE_$2=yes"
+		fi
+		return 0
+	fi
+
 	tmpval="$(eval "printf %s \"\$USER_$2\"")"
 
 	if [ "$tmpval" != 'yes' ]; then
-		setval="$(eval "printf %s \"\$HAVE_$2\"")"
 		if [ "$setval" != 'no' ]; then
 			eval "HAVE_$2=no"
-			die : "Notice: $4 disabled, $3 support will also be disabled."
+			if [ "${5:-}" != 'true' ]; then
+				die : "Notice: $4 disabled, $3 support will also be disabled."
+			fi
 		fi
 		return 0
 	fi


### PR DESCRIPTION
## Description

The main goal of this PR is to combine the defines `HAVE_VIDEO_PROCESSOR` and `HAVE_VIDEO_PROCESSOR` where using both is confusing and harder to grep.

I chose to keep `HAVE_VIDEOPROCESSOR` to avoid breaking any build scripts that rely on `--enable-videoproccesor` or `--disable-videoprocessor`.

This also adds another argument to `check_enabled`, when set to `true` it will check to enable the feature instead of disabling it. This allows checking to enable features related to other features with more consistency.

## Related Pull Requests

More followup for https://github.com/libretro/RetroArch/pull/8123 and https://github.com/libretro/RetroArch/pull/8126.