### PR TITLE
qb: Remove dead DISPMANX code.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1240,8 +1240,6 @@ endif
 ifeq ($(HAVE_DISPMANX), 1)
    OBJ += gfx/drivers/dispmanx_gfx.o
    HAVE_VIDEOCORE = 1
-   LIBS += $(DISPMANX_LIBS)
-   DEFINES += $(DISPMANX_CFLAGS)
 endif
 
 ifeq ($(HAVE_SUNXI), 1)

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -118,10 +118,6 @@ fi
 check_lib '' SSA -lass ass_library_init
 check_pkgconf EXYNOS libdrm_exynos
 
-if [ "$HAVE_DISPMANX" != "no" ]; then
-   PKG_CONF_USED="$PKG_CONF_USED DISPMANX"
-fi
-
 if [ "$LIBRETRO" ]; then
    die : 'Notice: Explicit libretro used, disabling dynamic libretro loading ...'
    HAVE_DYNAMIC='no'


### PR DESCRIPTION
## Description

This removes some code from `config.libs.sh` and `Makefile.common` which appears to have been dead since commit 72923f0913c480afb353e3b391705cd50117df39. Currently `$(DISPMANX_LIBS)` and `$(DISPMANX_CFLAGS)` are unset variables which do nothing.

There is probably further room to improve the `HAVE_VIDEOCORE` and `HAVE_DISPMANX` path, but its too risky without a working build environment.

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/1663