### PR TITLE
Makefile.common: Small clean up.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -64,13 +64,13 @@ ifeq ($(VULKAN_DEBUG), 1)
 endif
 
 ifeq ($(HAVE_FLOATHARD), 1)
-   ASFLAGS += $(FLOATHARD_CFLAGS)
-   DEFINES += $(FLOATHARD_CFLAGS)
+   DEF_FLAGS += $(FLOATHARD_CFLAGS)
+   ASFLAGS   += $(FLOATHARD_CFLAGS)
 endif
 
 ifeq ($(HAVE_FLOATSOFTFP), 1)
-   ASFLAGS += $(FLOATSOFTFP_CFLAGS)
-   DEFINES += $(FLOATSOFTFP_CFLAGS)
+   DEF_FLAGS += $(FLOATSOFTFP_CFLAGS)
+   ASFLAGS   += $(FLOATSOFTFP_CFLAGS)
 endif
 
 ifeq ($(TDM_GCC),)
@@ -377,7 +377,7 @@ ifeq ($(HAVE_SSA),1)
 endif
 
 ifeq ($(HAVE_SSE),1)
-   DEFINES += $(SSE_LIBS)
+   DEF_FLAGS += $(SSE_LIBS)
 endif
 
 # LibretroDB
@@ -632,8 +632,9 @@ ifeq ($(HAVE_NEON),1)
           audio/drivers_resampler/cc_resampler_neon.o \
           memory/neon/memcpy-neon.o
 
-   ASFLAGS += $(NEON_ASFLAGS)
-   DEFINES += -DHAVE_NEON $(NEON_CFLAGS)
+   DEFINES   += -DHAVE_NEON
+   ASFLAGS   += $(NEON_ASFLAGS)
+   DEF_FLAGS += $(NEON_CFLAGS)
 endif
 
 OBJ += $(LIBRETRO_COMM_DIR)/audio/conversion/s16_to_float.o \


### PR DESCRIPTION
## Description

In retrospect its more correct to use `DEF_FLAGS` here than `DEFINES`.