### PR TITLE
tvOS/iOS: Fixes to controller handling and cores directory 

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -401,6 +401,8 @@ static unsigned menu_toggle_gamepad_combo    = INPUT_TOGGLE_HOLD_START;
 static unsigned menu_toggle_gamepad_combo    = INPUT_TOGGLE_L1_R1_START_SELECT;
 #elif defined(SWITCH) || defined(ORBIS)
 static unsigned menu_toggle_gamepad_combo    = INPUT_TOGGLE_START_SELECT;
+#elif TARGET_OS_TV
+static unsigned menu_toggle_gamepad_combo    = INPUT_TOGGLE_DOWN_Y_L_R;
 #else
 static unsigned menu_toggle_gamepad_combo    = INPUT_TOGGLE_NONE;
 #endif

--- a/configuration.c
+++ b/configuration.c
@@ -529,14 +529,14 @@ static enum joypad_driver_enum JOYPAD_DEFAULT_DRIVER = JOYPAD_ANDROID;
 static enum joypad_driver_enum JOYPAD_DEFAULT_DRIVER = JOYPAD_SDL;
 #elif defined(DJGPP)
 static enum joypad_driver_enum JOYPAD_DEFAULT_DRIVER = JOYPAD_DOS;
+#elif defined(IOS)
+static enum joypad_driver_enum JOYPAD_DEFAULT_DRIVER = JOYPAD_MFI;
 #elif defined(HAVE_HID)
 static enum joypad_driver_enum JOYPAD_DEFAULT_DRIVER = JOYPAD_HID;
 #elif defined(__QNX__)
 static enum joypad_driver_enum JOYPAD_DEFAULT_DRIVER = JOYPAD_QNX;
 #elif defined(EMSCRIPTEN)
 static enum joypad_driver_enum JOYPAD_DEFAULT_DRIVER = JOYPAD_RWEBPAD;
-#elif defined(IOS)
-static enum joypad_driver_enum JOYPAD_DEFAULT_DRIVER = JOYPAD_MFI;
 #else
 static enum joypad_driver_enum JOYPAD_DEFAULT_DRIVER = JOYPAD_NULL;
 #endif

--- a/input/drivers_joypad/hid_joypad.c
+++ b/input/drivers_joypad/hid_joypad.c
@@ -19,18 +19,8 @@
 
 static const hid_driver_t *generic_hid = NULL;
 
-static void hid_joypad_autodetect_add(unsigned autoconf_pad)
-{
-#ifdef TARGET_OS_TV
-    /* AppleTV: mfi controllers are HID joypad - add an autodetect here */
-    if ( !input_autoconfigure_connect("Mfi Controller", NULL, hid_joypad.ident, autoconf_pad, 0, 0))
-        input_config_set_device_name(autoconf_pad, "Mfi Controller");
-#endif
-}
-
 static bool hid_joypad_init(void *data)
 {
-   hid_joypad_autodetect_add(0);
    generic_hid = input_hid_init_first();
    if (!generic_hid)
        return false;

--- a/input/drivers_joypad/mfi_joypad.m
+++ b/input/drivers_joypad/mfi_joypad.m
@@ -1,7 +1,7 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
  *  Copyright (C) 2011-2017 - Daniel De Matteis
- * 
+ *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-
  *  ation, either version 3 of the License, or (at your option) any later version.
@@ -22,6 +22,9 @@
 #include <boolean.h>
 
 #include <AvailabilityMacros.h>
+
+#include "../../tasks/tasks_internal.h"
+
 #import <GameController/GameController.h>
 
 #ifndef MAX_MFI_CONTROLLERS
@@ -37,108 +40,147 @@ static NSMutableArray *mfiControllers;
 
 enum
 {
-   GCCONTROLLER_PLAYER_INDEX_UNSET = -1,
+    GCCONTROLLER_PLAYER_INDEX_UNSET = -1,
 };
 
 static bool apple_gamecontroller_available(void)
 {
-   int major, minor;
-   get_ios_version(&major, &minor);
+    int major, minor;
+    get_ios_version(&major, &minor);
 
-   if (major <= 6)
-      return false;
+    if (major <= 6)
+        return false;
 
-   return true;
+    return true;
 }
 
 static void apple_gamecontroller_joypad_poll_internal(GCController *controller)
 {
-   uint32_t slot, pause;
-   uint32_t *buttons;
-   if (!controller)
-      return;
+    uint32_t slot, pause, select, l3, r3;
+    uint32_t *buttons;
+    if (!controller)
+        return;
 
-   slot               = (uint32_t)controller.playerIndex;
-   buttons            = &mfi_buttons[slot];
-   /* retain the start (pause) value */
-   pause              = *buttons & (1 << RETRO_DEVICE_ID_JOYPAD_START);
-   *buttons           = 0 | pause;
-    
-   memset(mfi_axes[slot], 0, sizeof(mfi_axes[0]));
+    slot               = (uint32_t)controller.playerIndex;
+    buttons            = &mfi_buttons[slot];
 
-   if (controller.extendedGamepad)
-   {
-      GCExtendedGamepad *gp = (GCExtendedGamepad *)controller.extendedGamepad;
+    /* retain the values from the paused controller handler and pass them through */
+    pause              = *buttons & (1 << RETRO_DEVICE_ID_JOYPAD_START);
+    select             = *buttons & (1 << RETRO_DEVICE_ID_JOYPAD_SELECT);
+    l3                 = *buttons & ( 1 << RETRO_DEVICE_ID_JOYPAD_L3 );
+    r3                 = *buttons & ( 1 << RETRO_DEVICE_ID_JOYPAD_R3 );
+    *buttons           = 0 | pause | select | l3 | r3;
 
-      *buttons             |= gp.dpad.up.pressed         ? (1 << RETRO_DEVICE_ID_JOYPAD_UP)    : 0;
-      *buttons             |= gp.dpad.down.pressed       ? (1 << RETRO_DEVICE_ID_JOYPAD_DOWN)  : 0;
-      *buttons             |= gp.dpad.left.pressed       ? (1 << RETRO_DEVICE_ID_JOYPAD_LEFT)  : 0;
-      *buttons             |= gp.dpad.right.pressed      ? (1 << RETRO_DEVICE_ID_JOYPAD_RIGHT) : 0;
-      *buttons             |= gp.buttonA.pressed         ? (1 << RETRO_DEVICE_ID_JOYPAD_B)     : 0;
-      *buttons             |= gp.buttonB.pressed         ? (1 << RETRO_DEVICE_ID_JOYPAD_A)     : 0;
-      *buttons             |= gp.buttonX.pressed         ? (1 << RETRO_DEVICE_ID_JOYPAD_Y)     : 0;
-      *buttons             |= gp.buttonY.pressed         ? (1 << RETRO_DEVICE_ID_JOYPAD_X)     : 0;
-      *buttons             |= gp.leftShoulder.pressed    ? (1 << RETRO_DEVICE_ID_JOYPAD_L)     : 0;
-      *buttons             |= gp.rightShoulder.pressed   ? (1 << RETRO_DEVICE_ID_JOYPAD_R)     : 0;
-      *buttons             |= gp.leftTrigger.pressed     ? (1 << RETRO_DEVICE_ID_JOYPAD_L2)    : 0;
-      *buttons             |= gp.rightTrigger.pressed    ? (1 << RETRO_DEVICE_ID_JOYPAD_R2)    : 0;
-      mfi_axes[slot][0]     = gp.leftThumbstick.xAxis.value * 32767.0f;
-      mfi_axes[slot][1]     = gp.leftThumbstick.yAxis.value * 32767.0f;
-      mfi_axes[slot][2]     = gp.rightThumbstick.xAxis.value * 32767.0f;
-      mfi_axes[slot][3]     = gp.rightThumbstick.yAxis.value * 32767.0f;
+    memset(mfi_axes[slot], 0, sizeof(mfi_axes[0]));
 
-   }
-   else if (controller.gamepad)
-   {
-      GCGamepad *gp = (GCGamepad *)controller.gamepad;
+    if (controller.extendedGamepad)
+    {
+        GCExtendedGamepad *gp = (GCExtendedGamepad *)controller.extendedGamepad;
 
-      *buttons |= gp.dpad.up.pressed       ? (1 << RETRO_DEVICE_ID_JOYPAD_UP)    : 0;
-      *buttons |= gp.dpad.down.pressed     ? (1 << RETRO_DEVICE_ID_JOYPAD_DOWN)  : 0;
-      *buttons |= gp.dpad.left.pressed     ? (1 << RETRO_DEVICE_ID_JOYPAD_LEFT)  : 0;
-      *buttons |= gp.dpad.right.pressed    ? (1 << RETRO_DEVICE_ID_JOYPAD_RIGHT) : 0;
-      *buttons |= gp.buttonA.pressed       ? (1 << RETRO_DEVICE_ID_JOYPAD_B)     : 0;
-      *buttons |= gp.buttonB.pressed       ? (1 << RETRO_DEVICE_ID_JOYPAD_A)     : 0;
-      *buttons |= gp.buttonX.pressed       ? (1 << RETRO_DEVICE_ID_JOYPAD_Y)     : 0;
-      *buttons |= gp.buttonY.pressed       ? (1 << RETRO_DEVICE_ID_JOYPAD_X)     : 0;
-      *buttons |= gp.leftShoulder.pressed  ? (1 << RETRO_DEVICE_ID_JOYPAD_L)     : 0;
-      *buttons |= gp.rightShoulder.pressed ? (1 << RETRO_DEVICE_ID_JOYPAD_R)     : 0;
-   }
+        *buttons             |= gp.dpad.up.pressed         ? (1 << RETRO_DEVICE_ID_JOYPAD_UP)    : 0;
+        *buttons             |= gp.dpad.down.pressed       ? (1 << RETRO_DEVICE_ID_JOYPAD_DOWN)  : 0;
+        *buttons             |= gp.dpad.left.pressed       ? (1 << RETRO_DEVICE_ID_JOYPAD_LEFT)  : 0;
+        *buttons             |= gp.dpad.right.pressed      ? (1 << RETRO_DEVICE_ID_JOYPAD_RIGHT) : 0;
+        *buttons             |= gp.buttonA.pressed         ? (1 << RETRO_DEVICE_ID_JOYPAD_B)     : 0;
+        *buttons             |= gp.buttonB.pressed         ? (1 << RETRO_DEVICE_ID_JOYPAD_A)     : 0;
+        *buttons             |= gp.buttonX.pressed         ? (1 << RETRO_DEVICE_ID_JOYPAD_Y)     : 0;
+        *buttons             |= gp.buttonY.pressed         ? (1 << RETRO_DEVICE_ID_JOYPAD_X)     : 0;
+        *buttons             |= gp.leftShoulder.pressed    ? (1 << RETRO_DEVICE_ID_JOYPAD_L)     : 0;
+        *buttons             |= gp.rightShoulder.pressed   ? (1 << RETRO_DEVICE_ID_JOYPAD_R)     : 0;
+        *buttons             |= gp.leftTrigger.pressed     ? (1 << RETRO_DEVICE_ID_JOYPAD_L2)    : 0;
+        *buttons             |= gp.rightTrigger.pressed    ? (1 << RETRO_DEVICE_ID_JOYPAD_R2)    : 0;
+        mfi_axes[slot][0]     = gp.leftThumbstick.xAxis.value * 32767.0f;
+        mfi_axes[slot][1]     = gp.leftThumbstick.yAxis.value * 32767.0f;
+        mfi_axes[slot][2]     = gp.rightThumbstick.xAxis.value * 32767.0f;
+        mfi_axes[slot][3]     = gp.rightThumbstick.yAxis.value * 32767.0f;
+
+    }
+    else if (controller.gamepad)
+    {
+        GCGamepad *gp = (GCGamepad *)controller.gamepad;
+
+        *buttons |= gp.dpad.up.pressed       ? (1 << RETRO_DEVICE_ID_JOYPAD_UP)    : 0;
+        *buttons |= gp.dpad.down.pressed     ? (1 << RETRO_DEVICE_ID_JOYPAD_DOWN)  : 0;
+        *buttons |= gp.dpad.left.pressed     ? (1 << RETRO_DEVICE_ID_JOYPAD_LEFT)  : 0;
+        *buttons |= gp.dpad.right.pressed    ? (1 << RETRO_DEVICE_ID_JOYPAD_RIGHT) : 0;
+        *buttons |= gp.buttonA.pressed       ? (1 << RETRO_DEVICE_ID_JOYPAD_B)     : 0;
+        *buttons |= gp.buttonB.pressed       ? (1 << RETRO_DEVICE_ID_JOYPAD_A)     : 0;
+        *buttons |= gp.buttonX.pressed       ? (1 << RETRO_DEVICE_ID_JOYPAD_Y)     : 0;
+        *buttons |= gp.buttonY.pressed       ? (1 << RETRO_DEVICE_ID_JOYPAD_X)     : 0;
+        *buttons |= gp.leftShoulder.pressed  ? (1 << RETRO_DEVICE_ID_JOYPAD_L)     : 0;
+        *buttons |= gp.rightShoulder.pressed ? (1 << RETRO_DEVICE_ID_JOYPAD_R)     : 0;
+    }
 }
 
 static void apple_gamecontroller_joypad_poll(void)
 {
-   if (!apple_gamecontroller_available())
-      return;
+    if (!apple_gamecontroller_available())
+        return;
 
-   for (GCController *controller in [GCController controllers])
-      apple_gamecontroller_joypad_poll_internal(controller);
+    for (GCController *controller in [GCController controllers])
+        apple_gamecontroller_joypad_poll_internal(controller);
 }
 
 static void apple_gamecontroller_joypad_register(GCGamepad *gamepad)
 {
-   gamepad.valueChangedHandler = ^(GCGamepad *updateGamepad, GCControllerElement *element)
-   {
-      apple_gamecontroller_joypad_poll_internal(updateGamepad.controller);
-   };
+    gamepad.valueChangedHandler = ^(GCGamepad *updateGamepad, GCControllerElement *element)
+    {
+        apple_gamecontroller_joypad_poll_internal(updateGamepad.controller);
+    };
 
-   gamepad.controller.controllerPausedHandler = ^(GCController *controller)
-   {
-      uint32_t slot      = (uint32_t)controller.playerIndex;
-      mfi_buttons[slot] |= (1 << RETRO_DEVICE_ID_JOYPAD_START);
+    gamepad.controller.controllerPausedHandler = ^(GCController *controller)
+    {
+        uint32_t slot      = (uint32_t)controller.playerIndex;
 
-      dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        // Support buttons that aren't supported by the mFi controller via "hotkey" combinations:
+        //
+        // LS + Menu => Select
+        // LT + Menu => L3
+        // RT + Menu => R3
+        // Note that these are just button presses, and it does not simulate holding down the button
+        if ( controller.gamepad.leftShoulder.pressed || controller.extendedGamepad.leftShoulder.pressed ) {
             mfi_buttons[slot] &= ~(1 << RETRO_DEVICE_ID_JOYPAD_START);
+            mfi_buttons[slot] &= ~(1 << RETRO_DEVICE_ID_JOYPAD_L);
+            mfi_buttons[slot] |= (1 << RETRO_DEVICE_ID_JOYPAD_SELECT);
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                mfi_buttons[slot] &= ~(1 << RETRO_DEVICE_ID_JOYPAD_SELECT);
             });
+            return;
+        }
+        if ( controller.extendedGamepad.leftTrigger.pressed ) {
+            mfi_buttons[slot] &= ~(1 << RETRO_DEVICE_ID_JOYPAD_L2);
+            mfi_buttons[slot] &= ~(1 << RETRO_DEVICE_ID_JOYPAD_START);
+            mfi_buttons[slot] |= (1 << RETRO_DEVICE_ID_JOYPAD_L3);
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                mfi_buttons[slot] &= ~(1 << RETRO_DEVICE_ID_JOYPAD_L3);
+            });
+            return;
+        }
+        if ( controller.extendedGamepad.rightTrigger.pressed ) {
+            mfi_buttons[slot] &= ~(1 << RETRO_DEVICE_ID_JOYPAD_R2);
+            mfi_buttons[slot] &= ~(1 << RETRO_DEVICE_ID_JOYPAD_START);
+            mfi_buttons[slot] |= (1 << RETRO_DEVICE_ID_JOYPAD_R3);
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                mfi_buttons[slot] &= ~(1 << RETRO_DEVICE_ID_JOYPAD_R3);
+            });
+            return;
+        }
 
-   };
+        mfi_buttons[slot] |= (1 << RETRO_DEVICE_ID_JOYPAD_START);
+
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            mfi_buttons[slot] &= ~(1 << RETRO_DEVICE_ID_JOYPAD_START);
+        });
+
+    };
 }
 
 static void apple_gamecontroller_joypad_connect(GCController *controller)
 {
     signed desired_index = (int32_t)controller.playerIndex;
     desired_index        = (desired_index >= 0 && desired_index < MAX_MFI_CONTROLLERS)
-       ? desired_index : 0;
-    
+    ? desired_index : 0;
+
     /* prevent same controller getting set twice */
     if (mfi_controllers[desired_index] != (uint32_t)controller.hash)
     {
@@ -150,18 +192,18 @@ static void apple_gamecontroller_joypad_connect(GCController *controller)
         }
         else
         {
-           /* find a new slot for this controller that's unused */
-           unsigned i;
+            /* find a new slot for this controller that's unused */
+            unsigned i;
             
-           for (i = 0; i < MAX_MFI_CONTROLLERS; ++i)
-           {
-              if (mfi_controllers[i])
-                 continue;
+            for (i = 0; i < MAX_MFI_CONTROLLERS; ++i)
+            {
+                if (mfi_controllers[i])
+                    continue;
 
-              mfi_controllers[i] = (uint32_t)controller.hash;
-              controller.playerIndex = i;
-              break;
-           }
+                mfi_controllers[i] = (uint32_t)controller.hash;
+                controller.playerIndex = i;
+                break;
+            }
         }
 
         [mfiControllers addObject:controller];
@@ -185,48 +227,56 @@ static void apple_gamecontroller_joypad_connect(GCController *controller)
                 gc.playerIndex = newPlayerIndex++;
             }
         }
-        
-       apple_gamecontroller_joypad_register(controller.gamepad);
+
+        apple_gamecontroller_joypad_register(controller.gamepad);
     }
 }
 
 static void apple_gamecontroller_joypad_disconnect(GCController* controller)
 {
-   signed pad = (int32_t)controller.playerIndex;
-    
-   if (pad == GCCONTROLLER_PLAYER_INDEX_UNSET)
-      return;
+    signed pad = (int32_t)controller.playerIndex;
 
-   mfi_controllers[pad] = 0;
+    if (pad == GCCONTROLLER_PLAYER_INDEX_UNSET)
+        return;
+
+    mfi_controllers[pad] = 0;
     [mfiControllers removeObject:controller];
+}
+
+static void mfi_joypad_autodetect_add(unsigned autoconf_pad)
+{
+    if ( !input_autoconfigure_connect("mFi Controller", NULL, mfi_joypad.ident, autoconf_pad, 0, 0) ) {
+        input_config_set_device(autoconf_pad, "mFi Controller");
+    }
 }
 
 bool apple_gamecontroller_joypad_init(void *data)
 {
-   static bool inited = false;
-   if (inited)
-      return true;
-   if (!apple_gamecontroller_available())
-      return false;
+    mfi_joypad_autodetect_add(0);
+    static bool inited = false;
+    if (inited)
+        return true;
+    if (!apple_gamecontroller_available())
+        return false;
     mfiControllers = [[NSMutableArray alloc] initWithCapacity:MAX_MFI_CONTROLLERS];
 #ifdef __IPHONE_7_0
-   [[NSNotificationCenter defaultCenter] addObserverForName:GCControllerDidConnectNotification
-                                                     object:nil
-                                                      queue:[NSOperationQueue mainQueue]
-                                                 usingBlock:^(NSNotification *note)
-                                                 {
-                                                    apple_gamecontroller_joypad_connect([note object]);
-                                                 }];
-   [[NSNotificationCenter defaultCenter] addObserverForName:GCControllerDidDisconnectNotification
-                                                     object:nil
-                                                      queue:[NSOperationQueue mainQueue]
-                                                 usingBlock:^(NSNotification *note)
-                                                 {
-                                                    apple_gamecontroller_joypad_disconnect([note object]);
-                                                 } ];
+    [[NSNotificationCenter defaultCenter] addObserverForName:GCControllerDidConnectNotification
+                                                      object:nil
+                                                       queue:[NSOperationQueue mainQueue]
+                                                  usingBlock:^(NSNotification *note)
+     {
+         apple_gamecontroller_joypad_connect([note object]);
+     }];
+    [[NSNotificationCenter defaultCenter] addObserverForName:GCControllerDidDisconnectNotification
+                                                      object:nil
+                                                       queue:[NSOperationQueue mainQueue]
+                                                  usingBlock:^(NSNotification *note)
+     {
+         apple_gamecontroller_joypad_disconnect([note object]);
+     } ];
 #endif
 
-   return true;
+    return true;
 }
 
 static void apple_gamecontroller_joypad_destroy(void)
@@ -235,90 +285,89 @@ static void apple_gamecontroller_joypad_destroy(void)
 
 static bool apple_gamecontroller_joypad_button(unsigned port, uint16_t joykey)
 {
-   /* Check hat. */
-   if (GET_HAT_DIR(joykey))
-      return false;
+    /* Check hat. */
+    if (GET_HAT_DIR(joykey))
+        return false;
+    /* Check the button. */
+    if ((port < MAX_USERS) && (joykey < 32))
+        return ((mfi_buttons[port] & (1 << joykey)) != 0);
 
-   /* Check the button. */
-   if ((port < MAX_USERS) && (joykey < 32))
-      return ((mfi_buttons[port] & (1 << joykey)) != 0);
-
-   return false;
+    return false;
 }
 
 static void apple_gamecontroller_joypad_get_buttons(unsigned port,
-      input_bits_t *state)
+                                                    input_bits_t *state)
 {
-	BITS_COPY16_PTR(state, mfi_buttons[port]);
+    BITS_COPY16_PTR(state, mfi_buttons[port]);
 }
 
 static int16_t apple_gamecontroller_joypad_axis(unsigned port, uint32_t joyaxis)
 {
-   int16_t val   = 0;
-   int16_t axis = -1;
-   bool is_neg  = false;
-   bool is_pos  = false;
+    int16_t val   = 0;
+    int16_t axis = -1;
+    bool is_neg  = false;
+    bool is_pos  = false;
 
-   if (joyaxis == AXIS_NONE)
-      return 0;
+    if (joyaxis == AXIS_NONE)
+        return 0;
 
-   if (AXIS_NEG_GET(joyaxis) < 4)
-   {
-      axis  = AXIS_NEG_GET(joyaxis);
-      is_neg = true;
-   }
-   else if(AXIS_POS_GET(joyaxis) < 4)
-   {
-      axis  = AXIS_POS_GET(joyaxis);
-      is_pos = true;
-   }
-    
-   switch (axis)
-   {
-      case 0:
-         val = mfi_axes[port][0];
-         break;
-      case 1:
-         val = mfi_axes[port][1];
-         break;
-      case 2:
-         val = mfi_axes[port][2];
-         break;
-      case 3:
-         val = mfi_axes[port][3];
-         break;
-   }
-    
-   if (is_neg && val > 0)
-      val = 0;
-   else if (is_pos && val < 0)
-      val = 0;
+    if (AXIS_NEG_GET(joyaxis) < 4)
+    {
+        axis  = AXIS_NEG_GET(joyaxis);
+        is_neg = true;
+    }
+    else if(AXIS_POS_GET(joyaxis) < 4)
+    {
+        axis  = AXIS_POS_GET(joyaxis);
+        is_pos = true;
+    }
 
-   return val;
+    switch (axis)
+    {
+        case 0:
+            val = mfi_axes[port][0];
+            break;
+        case 1:
+            val = mfi_axes[port][1];
+            break;
+        case 2:
+            val = mfi_axes[port][2];
+            break;
+        case 3:
+            val = mfi_axes[port][3];
+            break;
+    }
+
+    if (is_neg && val > 0)
+        val = 0;
+    else if (is_pos && val < 0)
+        val = 0;
+
+    return val;
 }
 
 static bool apple_gamecontroller_joypad_query_pad(unsigned pad)
 {
-   return pad < MAX_USERS;
+    return pad < MAX_USERS;
 }
 
 static const char *apple_gamecontroller_joypad_name(unsigned pad)
 {
-   if (pad >= MAX_USERS)
-      return NULL;
-
-   return "MFi pad";
+    if (pad >= MAX_USERS)
+        return NULL;
+    
+    return "mFi Controller";
 }
 
 input_device_driver_t mfi_joypad = {
-   apple_gamecontroller_joypad_init,
-   apple_gamecontroller_joypad_query_pad,
-   apple_gamecontroller_joypad_destroy,
-   apple_gamecontroller_joypad_button,
-   apple_gamecontroller_joypad_get_buttons,
-   apple_gamecontroller_joypad_axis,
-   apple_gamecontroller_joypad_poll,
-   NULL,
-   apple_gamecontroller_joypad_name,
-   "mfi",
+    apple_gamecontroller_joypad_init,
+    apple_gamecontroller_joypad_query_pad,
+    apple_gamecontroller_joypad_destroy,
+    apple_gamecontroller_joypad_button,
+    apple_gamecontroller_joypad_get_buttons,
+    apple_gamecontroller_joypad_axis,
+    apple_gamecontroller_joypad_poll,
+    NULL,
+    apple_gamecontroller_joypad_name,
+    "mfi",
 };

--- a/input/input_autodetect_builtin.c
+++ b/input/input_autodetect_builtin.c
@@ -630,7 +630,7 @@ DECL_AXIS(r_x_minus, -2) \
 DECL_AXIS(r_y_plus,  +3) \
 DECL_AXIS(r_y_minus, -3)
 
-#define TVOS_MFI_DEFAULT_BINDS \
+#define IOS_MFI_DEFAULT_BINDS \
 DECL_BTN(a, 8) \
 DECL_BTN(b, 0) \
 DECL_BTN(x, 9) \
@@ -641,8 +641,12 @@ DECL_BTN(left, 6) \
 DECL_BTN(right, 7) \
 DECL_BTN(l, 10) \
 DECL_BTN(r, 11) \
-DECL_AXIS(l2, 12) \
-DECL_AXIS(r2, 13) \
+DECL_BTN(start, 3) \
+DECL_BTN(select, 2) \
+DECL_BTN(l2, 12) \
+DECL_BTN(r2, 13) \
+DECL_BTN(l3, 14) \
+DECL_BTN(r3, 15) \
 DECL_AXIS(l_x_plus,  +0) \
 DECL_AXIS(l_x_minus, -0) \
 DECL_AXIS(l_y_plus,  -1) \
@@ -727,8 +731,8 @@ const char* const input_builtin_autoconfs[] =
 #ifdef EMSCRIPTEN
    DECL_AUTOCONF_PID(1, 1, "rwebpad", EMSCRIPTEN_DEFAULT_BINDS),
 #endif
-#ifdef TARGET_OS_TV
-   DECL_AUTOCONF_DEVICE("Mfi Controller", "hid", TVOS_MFI_DEFAULT_BINDS),
+#if TARGET_OS_IPHONE
+   DECL_AUTOCONF_DEVICE("mFi Controller", "mfi", IOS_MFI_DEFAULT_BINDS),
 #endif
    NULL
 };

--- a/pkg/apple/RetroArch_iOS11.xcodeproj/project.pbxproj
+++ b/pkg/apple/RetroArch_iOS11.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		926C77EB21FD20C400103EDE /* griffin.c in Sources */ = {isa = PBXBuildFile; fileRef = 501232C9192E5FC40063A359 /* griffin.c */; };
 		926C77EF21FD263800103EDE /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 926C77EE21FD263800103EDE /* AudioToolbox.framework */; };
 		926C77F121FD26E800103EDE /* GameController.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 926C77F021FD26E800103EDE /* GameController.framework */; };
+		927BD1A42203DA3A00ECF6C9 /* iOS/modules in Resources */ = {isa = PBXBuildFile; fileRef = 83EB675F19EEAF050096F441 /* iOS/modules */; };
 		929784502200EEE400989A60 /* iOS/Resources/Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 69D31DE31A547EC800EF4C92 /* iOS/Resources/Media.xcassets */; };
 		92CC05A221FE3C1700FF79F0 /* GCDWebServerResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 92CC058221FE3C1700FF79F0 /* GCDWebServerResponse.m */; };
 		92CC05A321FE3C1700FF79F0 /* GCDWebServerResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 92CC058221FE3C1700FF79F0 /* GCDWebServerResponse.m */; };
@@ -68,7 +69,6 @@
 		92CC05C321FE3C6D00FF79F0 /* WebServer.m in Sources */ = {isa = PBXBuildFile; fileRef = 92CC05C121FE3C6D00FF79F0 /* WebServer.m */; };
 		92CC05C521FEDC9F00FF79F0 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 92CC05C421FEDC9F00FF79F0 /* CFNetwork.framework */; };
 		92CC05C721FEDD0B00FF79F0 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 92CC05C621FEDD0B00FF79F0 /* MobileCoreServices.framework */; };
-		92CC05CE21FF798F00FF79F0 /* modules in Resources */ = {isa = PBXBuildFile; fileRef = 92CC05CD21FF798F00FF79F0 /* modules */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -127,7 +127,6 @@
 		92CC05C121FE3C6D00FF79F0 /* WebServer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WebServer.m; sourceTree = "<group>"; };
 		92CC05C421FEDC9F00FF79F0 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
 		92CC05C621FEDD0B00FF79F0 /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
-		92CC05CD21FF798F00FF79F0 /* modules */ = {isa = PBXFileReference; lastKnownFileType = folder; path = modules; sourceTree = "<group>"; };
 		96366C5416C9AC3300D64A22 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
 		96366C5816C9ACF500D64A22 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		963C3C33186E3DED00A6EB1E /* GameController.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GameController.framework; path = System/Library/Frameworks/GameController.framework; sourceTree = SDKROOT; };
@@ -192,7 +191,6 @@
 		926C77D821FD1E6500103EDE /* tvOS */ = {
 			isa = PBXGroup;
 			children = (
-				92CC05CD21FF798F00FF79F0 /* modules */,
 				926C77E221FD1E6700103EDE /* Assets.xcassets */,
 				926C77E421FD1E6700103EDE /* Info.plist */,
 			);
@@ -452,7 +450,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				92CC05CE21FF798F00FF79F0 /* modules in Resources */,
+				927BD1A42203DA3A00ECF6C9 /* iOS/modules in Resources */,
 				92CC05BD21FE3C1700FF79F0 /* GCDWebUploader.bundle in Resources */,
 				926C77E321FD1E6700103EDE /* Assets.xcassets in Resources */,
 			);

--- a/pkg/apple/tvOS/modules/.gitignore
+++ b/pkg/apple/tvOS/modules/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore


### PR DESCRIPTION
tvOS: remove the tvOS modules directory and use the iOS modules one since cores built using the iOS SDK work on tvOS
iOS: change default joypad driver to be mfi
iOS: move autodetect of mfi controller to mfi_joypad driver and set the default mapping for both iOS and tvOS. This enables autodetect of mfi controller for iOS as well.
iOS: support unsupported buttons on mfi controller (select,L3,R3) by using hotkey combinations using the MENU button: L + Menu = Select, L2 + Menu = L3, R2 + Menu = R3
tvos: use INPUT_TOGGLE_DOWN_Y_L_R as default for menu toggle gamepad combo
