### PR TITLE
Fix warnings.

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -670,6 +670,8 @@ const char *config_get_default_audio(void)
          return "roar";
       case AUDIO_COREAUDIO:
          return "coreaudio";
+      case AUDIO_COREAUDIO3:
+         return "coreaudio3";
       case AUDIO_AL:
          return "openal";
       case AUDIO_SL:

--- a/input/drivers_joypad/parport_joypad.c
+++ b/input/drivers_joypad/parport_joypad.c
@@ -17,6 +17,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <limits.h>
+#include <stdio.h>
 #include <errno.h>
 
 #include <linux/parport.h>


### PR DESCRIPTION
## Description

Silences a couple obvious warnings.

## Related Issues
```
configuration.c: In function ‘config_get_default_audio’:
configuration.c:657:4: warning: enumeration value ‘AUDIO_COREAUDIO3’ not handled in switch [-Wswitch]
    switch (default_driver)
    ^~~~~~
```
```
input/drivers_joypad/parport_joypad.c: In function ‘parport_joypad_init’:
input/drivers_joypad/parport_joypad.c:255:7: warning: implicit declaration of function ‘snprintf’ [-Wimplicit-function-declaration]
       snprintf(path, sizeof(path), "/dev/parport%u", i);
       ^~~~~~~~
input/drivers_joypad/parport_joypad.c:255:7: warning: incompatible implicit declaration of built-in function ‘snprintf’
input/drivers_joypad/parport_joypad.c:255:7: note: include ‘<stdio.h>’ or provide a declaration of ‘snprintf’
input/drivers_joypad/parport_joypad.c:35:1:
+#include <stdio.h>
 
input/drivers_joypad/parport_joypad.c:255:7:
       snprintf(path, sizeof(path), "/dev/parport%u", i);
       ^~~~~~~~
```