### PR TITLE
Fix -Wformat-truncation warning.

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -542,7 +542,7 @@ static int menu_displaylist_parse_system_info(menu_displaylist_info_t *info)
 
    if (frontend)
    {
-      char tmp2[8192];
+      char tmp2[PATH_MAX_LENGTH];
       int                  major = 0;
       int                  minor = 0;
 


### PR DESCRIPTION
## Description

This partially reverts commit https://github.com/libretro/RetroArch/commit/6e1658bb305387f22a26c5b4fb55cf00e5bb7384#diff-d1072fe770e89d097760ba62488be2a2R545 to silence a new warning.

## Related Issues

```
menu/menu_displaylist.c: In function ‘menu_displaylist_ctl’:
menu/menu_displaylist.c:594:43: warning: ‘%s’ directive output may be truncated writing up to 8191 bytes into a region of size 8189 [-Wformat-truncation=]
          snprintf(tmp, sizeof(tmp), "%s : %s (v%d.%d)",
                                           ^~
menu/menu_displaylist.c:596:16:
                tmp2,
                ~~~~                        
menu/menu_displaylist.c:594:10: note: ‘snprintf’ output 11 or more bytes (assuming 8202) into a destination of size 8192
          snprintf(tmp, sizeof(tmp), "%s : %s (v%d.%d)",
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                msg_hash_to_str(MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_OS),
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                tmp2,
                ~~~~~
                major, minor);
                ~~~~~~~~~~~~~
```

## Reviewers

@twinaphex 
