### PR TITLE
Use the posix poll.h instead of sys/poll.h.

### DIFF
--- a/audio/librsound.c
+++ b/audio/librsound.c
@@ -52,7 +52,7 @@
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <arpa/inet.h>
-#include <sys/poll.h>
+#include <poll.h>
 #endif
 #include <fcntl.h>
 #ifdef _WIN32

--- a/gfx/drivers_context/drm_ctx.c
+++ b/gfx/drivers_context/drm_ctx.c
@@ -29,7 +29,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <sys/poll.h>
+#include <poll.h>
 
 #include <libdrm/drm.h>
 #include <gbm.h>

--- a/gfx/drivers_context/wayland_ctx.c
+++ b/gfx/drivers_context/wayland_ctx.c
@@ -14,7 +14,7 @@
  *  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <sys/poll.h>
+#include <poll.h>
 #include <unistd.h>
 
 #include <wayland-client.h>

--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -44,7 +44,7 @@
 #elif defined(HAVE_KQUEUE)
 #include <sys/event.h>
 #endif
-#include <sys/poll.h>
+#include <poll.h>
 
 #include <libudev.h>
 #ifdef __linux__

--- a/input/drivers_joypad/udev_joypad.c
+++ b/input/drivers_joypad/udev_joypad.c
@@ -23,7 +23,7 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <libudev.h>
 #ifdef __linux__
 #include <linux/types.h>


### PR DESCRIPTION
## Description

By chance I read a conversation in an unrelated irc channel where they were getting a lot of warnings with musl when projects use `<sys/poll.h>` instead of the posix `<poll.h>`. So I looked in RetroArch's code base and found that we are using both... This commit changes all the uses of `<sys/poll.h>` to `<poll.h>`.

There should be no change in behavior other than slightly better posix compatibility.

I intentionally ignored the examples in the `deps/` directory.
