### PR TITLE
[discord] use discord username if available

### DIFF
--- a/discord/discord.c
+++ b/discord/discord.c
@@ -76,12 +76,16 @@ DiscordRichPresence discord_presence;
 
 char* discord_get_own_username(void)
 {
-   return user_name;
+   if (discord_is_ready)
+      return user_name;
+   return NULL;
 }
 
 char* discord_get_own_avatar(void)
 {
-   return user_avatar;
+   if (discord_is_ready)
+      return user_avatar;
+   return NULL;
 }
 
 bool discord_avatar_is_ready(void)

--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -893,7 +893,12 @@ static void netplay_announce(void)
 
    netplay_get_architecture(frontend_architecture, sizeof(frontend_architecture));
 
-   net_http_urlencode(&username, settings->paths.username);
+   if (!string_is_empty(settings->paths.username))
+      net_http_urlencode(&username, settings->paths.username);
+#ifdef HAVE_DISCORD
+   else
+      net_http_urlencode(&username, discord_get_own_username());
+#endif
    net_http_urlencode(&corename, system->library_name);
    net_http_urlencode(&coreversion, system->library_version);
    net_http_urlencode(&frontend_ident, frontend_architecture);
@@ -1492,6 +1497,9 @@ bool init_netplay(void *direct_host, const char *server, unsigned port)
          settings->ints.netplay_check_frames,
          &cbs,
          settings->bools.netplay_nat_traversal,
+#ifdef HAVE_DISCORD
+         string_is_empty(settings->paths.username) ? discord_get_own_username() :
+#endif
          settings->paths.username,
          quirks);
 


### PR DESCRIPTION
The username is only used when the defined name is empty.
Tried it both in hosting and client scenarios with no issue.

But I guess more testing would be desirable.