### PR TITLE
iOS: Fix mFi controller connecting

### DIFF
--- a/input/drivers_joypad/mfi_joypad.m
+++ b/input/drivers_joypad/mfi_joypad.m
@@ -182,6 +182,9 @@ static void apple_gamecontroller_joypad_connect(GCController *controller)
     ? desired_index : 0;
 
     /* prevent same controller getting set twice */
+    if ( [mfiControllers containsObject:controller] ) {
+        return;
+    }
     if (mfi_controllers[desired_index] != (uint32_t)controller.hash)
     {
         /* desired slot is unused, take it */


### PR DESCRIPTION
When an mfi controller is connected, it sometimes would get added twice to its internal list and affect the player index it's assigned to.