### PR TITLE
Fix travis warnings.

### DIFF
--- a/cores/libretro-gong/gong.c
+++ b/cores/libretro-gong/gong.c
@@ -84,7 +84,7 @@ typedef struct
    float last_dt;
 } Game_Input;
 
-static Game_Input g_input = {0};
+static Game_Input g_input = {{{0}}};
 
 typedef struct
 {

--- a/gfx/drivers/d3d10.c
+++ b/gfx/drivers/d3d10.c
@@ -632,7 +632,7 @@ d3d10_gfx_init(const video_info_t* video,
 
    {
       UINT                 flags = 0;
-      DXGI_SWAP_CHAIN_DESC desc  = {0};
+      DXGI_SWAP_CHAIN_DESC desc  = {{0}};
 
       desc.BufferCount           = 1;
       desc.BufferDesc.Width      = d3d10->vp.full_width;

--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -649,9 +649,9 @@ d3d11_gfx_init(const video_info_t* video, const input_driver_t** input, void** i
          };
 #ifdef __WINRT__
       /* UWP requires the use of newer version of the factory which requires newer version of this struct */
-      DXGI_SWAP_CHAIN_DESC1 desc              = { 0 };
+      DXGI_SWAP_CHAIN_DESC1 desc              = {{0}};
 #else
-      DXGI_SWAP_CHAIN_DESC desc               = { 0 };
+      DXGI_SWAP_CHAIN_DESC desc               = {{0}};
 #endif
       UINT number_feature_levels              = ARRAY_SIZE(requested_feature_levels);
 

--- a/menu/drivers_display/menu_display_gdi.c
+++ b/menu/drivers_display/menu_display_gdi.c
@@ -50,7 +50,7 @@ static void menu_display_gdi_draw(menu_display_ctx_draw_t *draw,
 {
    struct gdi_texture *texture = NULL;
    gdi_t *gdi = (gdi_t*)video_driver_get_ptr(false);
-   BITMAPINFO info = {0};
+   BITMAPINFO info = {{0}};
 
    if (!gdi || !draw || draw->x < 0 || draw->y < 0 || draw->width <= 1 || draw->height <= 1)
       return;


### PR DESCRIPTION
## Description

Silences various warnings from the travis logs.

## Related Issues
```
menu/drivers_display/menu_display_gdi.c: In function ‘menu_display_gdi_draw’:
menu/drivers_display/menu_display_gdi.c:53:4: warning: missing braces around initializer [-Wmissing-braces]
    BITMAPINFO info = {0};
    ^
menu/drivers_display/menu_display_gdi.c:53:4: warning: (near initialization for ‘info.bmiHeader’) [-Wmissing-braces]
```
```
cores/libretro-gong/gong.c:87:1: warning: missing braces around initializer [-Wmissing-braces]
 static Game_Input g_input = {0};
 ^
cores/libretro-gong/gong.c:87:1: warning: (near initialization for ‘g_input.buttons’) [-Wmissing-braces]
```
```
gfx/drivers/d3d11.c: In function ‘d3d11_gfx_init’:
gfx/drivers/d3d11.c:654:7: warning: missing braces around initializer [-Wmissing-braces]
       DXGI_SWAP_CHAIN_DESC desc               = { 0 };
       ^
gfx/drivers/d3d11.c:654:7: warning: (near initialization for ‘desc.BufferDesc’) [-Wmissing-braces]
```
```
gfx/drivers/d3d10.c: In function ‘d3d10_gfx_init’:
gfx/drivers/d3d10.c:635:7: warning: missing braces around initializer [-Wmissing-braces]
       DXGI_SWAP_CHAIN_DESC desc  = {0};
       ^
gfx/drivers/d3d10.c:635:7: warning: (near initialization for ‘desc.BufferDesc’) [-Wmissing-braces]
```