### PR TITLE
menu_display_gl: fix scissoring implementation for gl enabled cores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ run.sh
 convert_rumble.awk
 *~
 assets
+info
 
 # Wii U
 *.depend

--- a/menu/drivers_display/menu_display_gl.c
+++ b/menu/drivers_display/menu_display_gl.c
@@ -259,6 +259,7 @@ static void menu_display_gl_scissor_begin(video_frame_info_t *video_info, int x,
 
 static void menu_display_gl_scissor_end(video_frame_info_t *video_info)
 {
+   glScissor(0, 0, video_info->width, video_info->height);
    glDisable(GL_SCISSOR_TEST);
 }
 


### PR DESCRIPTION
Turns out mupen64plus uses scissoring, but the core enables the test **without** resetting the scissor rectangle first. This results in the core enabling scissoring with a leftover rect from ozone, which gave a black bar after viewport / resolution translation. Setting the scissor rect back to the whole viewport when disabling the test fixes it.

Also I added core info to gitignore, since Windows likes to download stuff at the root directory.