### PR TITLE
macOS: Fix travis metal build 

### DIFF
--- a/travis_metal_deploy.sh
+++ b/travis_metal_deploy.sh
@@ -15,7 +15,7 @@ cd ~/dist
 
 echo "Copying binary into dist folder..."
 
-cp -rv ~/libretro-super/retroarch/pkg/apple/build/Release/RetroArch.app .
+cp -rv  ${TRAVIS_BUILD_DIR}/pkg/apple/build/Release/RetroArch.app .
 
 echo "Downloading assets..."
 


### PR DESCRIPTION
## Description

This is my first PR, so hopefully I'm following all the guidelines properly. I'll be glad to make any updates as needed.

The current osx release and nightly metal bundles contain only the contents of the asset bundle (`bundle.zip`) and nothing else. This appears to be from an issue in the `travis_metal_deploy.sh` script.

Prior to 2d7bb55 travis was using `libretro-super` and `build-retroarch-metal.sh` for the osx metal builds. 2d7bb55 essentially changed that to use an `xcodebuild` command on the main repo. 

Right now the actual travis builds are succeeding, but the deployment script is still expecting things to be in previous build directory using the `libretro-super` checkout.

Examples from a random travis job: 

[Here](https://travis-ci.org/libretro/RetroArch/jobs/488810747#L3581) you'll see where it can't `cp` the completed build because it is no longer in that location (this is the main issue that this PR addresses).
[Here](https://travis-ci.org/libretro/RetroArch/jobs/488810747#L3583) is where the `cd` to the directory fails because of the failed copy.

In the next step, it successfully downloads and extracts the asset bundle. But since the cd failed, the extraction happens in the current directory (`~/dist`, which is the root of the dmg to be created).

I can't completely test this of course, without access to the travis builds. But I have successfully reproduced / simulated the steps locally on macOS 10.14.3 and expect (hope?) that it'll work on travis as well.

PS: Thanks for RetroArch!

## Related Issues

The incomplete build / dmg issue is mentioned in #7346. My local metal build also had the correct `CFBundleIdentifier` which is mentioned in the same issue. 

## Related Pull Requests

PR #8059 mentions the metal build issue that this PR should address. 
