### PR TITLE
(RGUI) Add Subsystem support

### DIFF
--- a/dynamic.c
+++ b/dynamic.c
@@ -222,6 +222,13 @@ static bool environ_cb_get_system_info(unsigned cmd, void *data)
          {
             for (i = 0; i < size && i < SUBSYSTEM_MAX_SUBSYSTEMS; i++)
             {
+               /* Nasty, but have to do it like this since
+                * the pointers are const char *
+                * (if we don't free them, we get a memory leak) */
+               if (!string_is_empty(subsystem_data[i].desc))
+                  free((char *)subsystem_data[i].desc);
+               if (!string_is_empty(subsystem_data[i].ident))
+                  free((char *)subsystem_data[i].ident);
                subsystem_data[i].desc = strdup(info[i].desc);
                subsystem_data[i].ident = strdup(info[i].ident);
                subsystem_data[i].id = info[i].id;
@@ -232,6 +239,13 @@ static bool environ_cb_get_system_info(unsigned cmd, void *data)
 
                for (j = 0; j < subsystem_data[i].num_roms && j < SUBSYSTEM_MAX_SUBSYSTEM_ROMS; j++)
                {
+                  /* Nasty, but have to do it like this since
+                   * the pointers are const char *
+                   * (if we don't free them, we get a memory leak) */
+                  if (!string_is_empty(subsystem_data_roms[i][j].desc))
+                     free((char *)subsystem_data_roms[i][j].desc);
+                  if (!string_is_empty(subsystem_data_roms[i][j].valid_extensions))
+                     free((char *)subsystem_data_roms[i][j].valid_extensions);
                   subsystem_data_roms[i][j].desc = strdup(info[i].roms[j].desc);
                   subsystem_data_roms[i][j].valid_extensions = strdup(info[i].roms[j].valid_extensions);
                   subsystem_data_roms[i][j].required = info[i].roms[j].required;

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -92,6 +92,7 @@
 #include "../core_info.h"
 #include "../wifi/wifi_driver.h"
 #include "../tasks/tasks_internal.h"
+#include "../dynamic.h"
 
 static char new_path_entry[4096]        = {0};
 static char new_lbl_entry[4096]         = {0};
@@ -7507,6 +7508,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, menu_displaylist
          {
             settings_t      *settings      = config_get_ptr();
             rarch_system_info_t *sys_info  = runloop_get_system_info();
+            const struct retro_subsystem_info* subsystem;
 
             if (sys_info)
             {
@@ -7529,18 +7531,32 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, menu_displaylist
             if (frontend_driver_has_fork())
 #endif
             {
-            if (settings->bools.menu_show_load_core)
-                  menu_displaylist_parse_settings_enum(menu, info,
-                        MENU_ENUM_LABEL_CORE_LIST, PARSE_ACTION, false);
-            if (settings->bools.menu_show_load_core)
-                  menu_displaylist_parse_settings_enum(menu, info,
-                        MENU_ENUM_LABEL_SIDELOAD_CORE_LIST, PARSE_ACTION, false);
+               if (settings->bools.menu_show_load_core)
+               {
+                  if (!core_is_game_loaded())
+                  {
+                     menu_displaylist_parse_settings_enum(menu, info,
+                           MENU_ENUM_LABEL_CORE_LIST, PARSE_ACTION, false);
+                  }
+               }
             }
 
             if (settings->bools.menu_show_load_content)
+            {
                menu_displaylist_parse_settings_enum(menu, info,
                      MENU_ENUM_LABEL_LOAD_CONTENT_LIST,
                      PARSE_ACTION, false);
+
+               /* Core fully loaded, use the subsystem data */
+               if (sys_info->subsystem.data)
+                     subsystem = sys_info->subsystem.data;
+               /* Core not loaded completely, use the data we peeked on load core */
+               else
+                  subsystem = subsystem_data;
+
+               menu_subsystem_populate(subsystem, info);
+            }
+
             if (settings->bools.menu_content_show_history)
                menu_displaylist_parse_settings_enum(menu, info,
                      MENU_ENUM_LABEL_LOAD_CONTENT_HISTORY,

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -7533,11 +7533,8 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, menu_displaylist
             {
                if (settings->bools.menu_show_load_core)
                {
-                  if (!core_is_game_loaded())
-                  {
-                     menu_displaylist_parse_settings_enum(menu, info,
-                           MENU_ENUM_LABEL_CORE_LIST, PARSE_ACTION, false);
-                  }
+                  menu_displaylist_parse_settings_enum(menu, info,
+                        MENU_ENUM_LABEL_CORE_LIST, PARSE_ACTION, false);
                }
             }
 

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -2667,7 +2667,16 @@ void hex32_to_rgba_normalized(uint32_t hex, float* rgba, float alpha)
 
 void menu_subsystem_populate(const struct retro_subsystem_info* subsystem, menu_displaylist_info_t *info)
 {
+   settings_t *settings = config_get_ptr();
+   char star_char[8];
    unsigned i = 0;
+   bool is_rgui = string_is_equal(settings->arrays.menu_driver, "rgui");
+   
+   /* Select approriate 'star' marker for subsystem menu entries
+    * (i.e. RGUI does not support unicode, so use a 'standard'
+    * character fallback) */
+   snprintf(star_char, sizeof(star_char), "%s", is_rgui ? "*" : "\u2605");
+   
    if (subsystem && subsystem_current_count > 0)
    {
       for (i = 0; i < subsystem_current_count; i++, subsystem++)
@@ -2680,8 +2689,20 @@ void menu_subsystem_populate(const struct retro_subsystem_info* subsystem, menu_
                snprintf(s, sizeof(s),
                   "Load %s %s",
                   subsystem->desc,
-                  i == content_get_subsystem()
-                  ? "\u2605" : " ");
+                  star_char);
+               
+               /* RGUI does not support sublabels, so have to add the
+                * appropriate text to the menu entry itself... */
+               if (is_rgui)
+               {
+                  char tmp[PATH_MAX_LENGTH];
+                  
+                  snprintf(tmp, sizeof(tmp),
+                     "%s [%s %s]", s, "Current Content:",
+                     subsystem->roms[content_get_subsystem_rom_id()].desc);
+                  strlcpy(s, tmp, sizeof(s));
+               }
+               
                menu_entries_append_enum(info->list,
                   s,
                   msg_hash_to_str(MENU_ENUM_LABEL_SUBSYSTEM_ADD),
@@ -2693,8 +2714,31 @@ void menu_subsystem_populate(const struct retro_subsystem_info* subsystem, menu_
                snprintf(s, sizeof(s),
                   "Start %s %s",
                   subsystem->desc,
-                  i == content_get_subsystem()
-                  ? "\u2605" : " ");
+                  star_char);
+               
+               /* RGUI does not support sublabels, so have to add the
+                * appropriate text to the menu entry itself... */
+               if (is_rgui)
+               {
+                  unsigned j = 0;
+                  char rom_buff[PATH_MAX_LENGTH];
+                  char tmp[PATH_MAX_LENGTH];
+                  rom_buff[0] = '\0';
+
+                  for (j = 0; j < content_get_subsystem_rom_id(); j++)
+                  {
+                     strlcat(rom_buff, path_basename(content_get_subsystem_rom(j)), sizeof(rom_buff));
+                     if (j != content_get_subsystem_rom_id() - 1)
+                        strlcat(rom_buff, "|", sizeof(rom_buff));
+                  }
+
+                  if (!string_is_empty(rom_buff))
+                  {
+                     snprintf(tmp, sizeof(tmp), "%s [%s]", s, rom_buff);
+                     strlcpy(s, tmp, sizeof(s));
+                  }
+               }
+               
                menu_entries_append_enum(info->list,
                   s,
                   msg_hash_to_str(MENU_ENUM_LABEL_SUBSYSTEM_LOAD),
@@ -2705,10 +2749,27 @@ void menu_subsystem_populate(const struct retro_subsystem_info* subsystem, menu_
          else
          {
             snprintf(s, sizeof(s),
-               "Load %s %s",
-               subsystem->desc,
-               i == content_get_subsystem()
-               ? "\u2605" : " ");
+               "Load %s",
+               subsystem->desc);
+            
+            /* RGUI does not support sublabels, so have to add the
+             * appropriate text to the menu entry itself... */
+            if (is_rgui)
+            {
+               /* This check is probably not required (it's not done
+                * in menu_cbs_sublabel.c action_bind_sublabel_subsystem_add(),
+                * anyway), but no harm in being safe... */
+               if (subsystem->num_roms > 0)
+               {
+                  char tmp[PATH_MAX_LENGTH];
+                  
+                  snprintf(tmp, sizeof(tmp),
+                     "%s [%s %s]", s, "Current Content:",
+                     subsystem->roms[0].desc);
+                  strlcpy(s, tmp, sizeof(s));
+               }
+            }
+            
             menu_entries_append_enum(info->list,
                s,
                msg_hash_to_str(MENU_ENUM_LABEL_SUBSYSTEM_ADD),


### PR DESCRIPTION
## Description

This PR adds to RGUI the menu entry (entries?) required for subsystem support. This addresses half of issue #8070 (GLUI still needs to be updated).

It also disables the 'Load Core' menu entry when content is loaded, as suggested in the comments thread of issue #7997 as a workaround for subsystem-related segfaults. This is a trivial fix, and I guess it should be applied to the other menu drivers, too.

NOTE: Exposing subsystem functionality highlights an inconvenient quirk of RGUI. On most systems (not all - 3DS for example handles things correctly), the RGUI quick menu is stretched to the dimensions of the currently loaded content. Normally this isn't too much of an issue, but as soon as you do something like this:

![screenshot_2019-02-06_13-05-49](https://user-images.githubusercontent.com/38211560/52349114-bd4eff80-2a1d-11e9-9c61-3553f9861bf1.png)

...you end up with this:

![screenshot_2019-02-06_13-06-02](https://user-images.githubusercontent.com/38211560/52349128-c63fd100-2a1d-11e9-8e20-d7548a4fd106.png)

...which is ridiculous. It therefore seems that we need to modify the gfx driver code such that RGUI is always displayed with a fixed aspect ratio. I will try to address this in a future PR...

## Related Issues

 #8070,  #7997

## Reviewers

@twinaphex While testing this, I noticed a memory leak in environ_cb_get_system_info(). I've fixed it, but the fact that const char pointers are being modified is probably not good design. Someone might want to think about reviewing the code in `dynamic.c` at some point...
