### PR TITLE
Fix uninitialised read of "override" field

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -1313,7 +1313,7 @@ static struct config_path_setting *populate_settings_path(settings_t *settings, 
 
 static struct config_bool_setting *populate_settings_bool(settings_t *settings, int *size)
 {
-   struct config_bool_setting  *tmp    = (struct config_bool_setting*)malloc((*size + 1) * sizeof(struct config_bool_setting));
+   struct config_bool_setting  *tmp    = (struct config_bool_setting*)calloc(1, (*size + 1) * sizeof(struct config_bool_setting));
    unsigned count                      = 0;
 
    SETTING_BOOL("crt_switch_resolution_use_custom_refresh_rate", &settings->bools.crt_switch_custom_refresh_enable, true, false, false);
@@ -1621,7 +1621,7 @@ static struct config_float_setting *populate_settings_float(settings_t *settings
 static struct config_uint_setting *populate_settings_uint(settings_t *settings, int *size)
 {
    unsigned count                     = 0;
-   struct config_uint_setting  *tmp   = (struct config_uint_setting*)malloc((*size + 1) * sizeof(struct config_uint_setting));
+   struct config_uint_setting  *tmp   = (struct config_uint_setting*)calloc(1, (*size + 1) * sizeof(struct config_uint_setting));
 
    if (!tmp)
       return NULL;


### PR DESCRIPTION
TLTR: fix uninitialised read of "override" field of structs config_uint_setting and config_bool_setting.

Running RetroArch with Valgrind shows the following warnings:
```
==7908== Conditional jump or move depends on uninitialised value(s)
==7908==    at 0x210515: config_save_file (configuration.c:4302)
==7908==    by 0x19752D: command_event_save_config (command.c:1451)
==7908==    by 0x197A22: command_event_save_current_config (command.c:1610)
==7908==    by 0x199194: command_event (command.c:2455)
==7908==    by 0x18AB61: main_exit (frontend.c:67)
==7908==    by 0x2D10A7: ui_application_qt_run(void*) (ui_qt_application.cpp:178)
==7908==    by 0x18ACDD: rarch_main (frontend.c:173)
==7908==    by 0x2D10CF: main (ui_qt_application.cpp:188)
==7908== 
==7908== Conditional jump or move depends on uninitialised value(s)
==7908==    at 0x210870: config_save_file (configuration.c:4345)
==7908==    by 0x19752D: command_event_save_config (command.c:1451)
==7908==    by 0x197A22: command_event_save_current_config (command.c:1610)
==7908==    by 0x199194: command_event (command.c:2455)
==7908==    by 0x18AB61: main_exit (frontend.c:67)
==7908==    by 0x2D10A7: ui_application_qt_run(void*) (ui_qt_application.cpp:178)
==7908==    by 0x18ACDD: rarch_main (frontend.c:173)
==7908==    by 0x2D10CF: main (ui_qt_application.cpp:188)
==7908== 
==7908== Conditional jump or move depends on uninitialised value(s)
==7908==    at 0x190148: retroarch_override_setting_is_set (retroarch.c:2123)
==7908==    by 0x21089A: config_save_file (configuration.c:4346)
==7908==    by 0x19752D: command_event_save_config (command.c:1451)
==7908==    by 0x197A22: command_event_save_current_config (command.c:1610)
==7908==    by 0x199194: command_event (command.c:2455)
==7908==    by 0x18AB61: main_exit (frontend.c:67)
==7908==    by 0x2D10A7: ui_application_qt_run(void*) (ui_qt_application.cpp:178)
==7908==    by 0x18ACDD: rarch_main (frontend.c:173)
==7908==    by 0x2D10CF: main (ui_qt_application.cpp:188)
==7908== 
==7908== Use of uninitialised value of size 8
==7908==    at 0x190160: retroarch_override_setting_is_set (retroarch.c:2123)
==7908==    by 0x21089A: config_save_file (configuration.c:4346)
==7908==    by 0x19752D: command_event_save_config (command.c:1451)
==7908==    by 0x197A22: command_event_save_current_config (command.c:1610)
==7908==    by 0x199194: command_event (command.c:2455)
==7908==    by 0x18AB61: main_exit (frontend.c:67)
==7908==    by 0x2D10A7: ui_application_qt_run(void*) (ui_qt_application.cpp:178)
==7908==    by 0x18ACDD: rarch_main (frontend.c:173)
==7908==    by 0x2D10CF: main (ui_qt_application.cpp:188)
```

These warnings are related to the read of the "override" field in structures config_uint32_setting/config_bool_settings.
Two of the "populate_settings_..." functions use malloc instead of calloc to allocation space for these structures. As the "override" field of these structs are most of the time never written, this keeps this field uninitialized. Replacing malloc by calloc fixes this problem.