### PR TITLE
ui_companion: fix status message

### DIFF
--- a/menu/widgets/menu_widgets.h
+++ b/menu/widgets/menu_widgets.h
@@ -42,7 +42,8 @@ bool menu_widgets_ready(void);
 bool menu_widgets_msg_queue_push(const char *msg,
       unsigned duration,
       char *title,
-      enum message_queue_icon icon, enum message_queue_category category);
+      enum message_queue_icon icon, enum message_queue_category category,
+      unsigned prio, bool flush);
 
 bool menu_widgets_volume_update_and_show(void);
 
@@ -54,7 +55,10 @@ bool menu_widgets_set_paused(bool is_paused);
 bool menu_widgets_set_fast_forward(bool is_fast_forward);
 bool menu_widgets_set_rewind(bool is_rewind);
 
-bool menu_widgets_task_msg_queue_push(retro_task_t *task);
+bool menu_widgets_task_msg_queue_push(retro_task_t *task,
+      const char *msg,
+      unsigned prio, unsigned duration,
+      bool flush);
 
 void menu_widgets_take_screenshot(void);
 

--- a/retroarch.c
+++ b/retroarch.c
@@ -2445,7 +2445,7 @@ void runloop_task_msg_queue_push(retro_task_t *task, const char *msg,
       bool flush)
 {
 #if defined(HAVE_MENU) && defined(HAVE_MENU_WIDGETS)
-   if (!video_driver_has_widgets() || !menu_widgets_task_msg_queue_push(task))
+   if (!video_driver_has_widgets() || !menu_widgets_task_msg_queue_push(task, msg, prio, duration, flush))
 #endif
       runloop_msg_queue_push(msg, prio, duration, flush, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
 }
@@ -2460,8 +2460,8 @@ void runloop_msg_queue_push(const char *msg,
 
 #if defined(HAVE_MENU) && defined(HAVE_MENU_WIDGETS)
    /* People have 60FPS in mind when they use runloop_msg_queue_push */
-   if (video_driver_has_widgets() && menu_widgets_msg_queue_push(msg, duration / 60 * 1000, title, icon, category))
-     return;
+   if (video_driver_has_widgets() && menu_widgets_msg_queue_push(msg, duration / 60 * 1000, title, icon, category, prio, flush))
+      return;
 #endif
 
 #ifdef HAVE_THREADS


### PR DESCRIPTION
The menu widgets implementation of `runloop_msg_queue_push` didn't call `ui_companion_driver_msg_queue_push` - this is solved now