### PR TITLE
(RGUI) Add optional 'Collections' entry to main menu

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -7545,6 +7545,16 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type, menu_displaylist
                menu_displaylist_parse_settings_enum(menu, info,
                      MENU_ENUM_LABEL_LOAD_CONTENT_HISTORY,
                      PARSE_ACTION, false);
+#ifdef HAVE_LIBRETRODB
+            if (string_is_equal(settings->arrays.menu_driver, "rgui") && settings->bools.menu_content_show_playlists)
+            {
+               menu_entries_append_enum(info->list,
+                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CONTENT_COLLECTION_LIST),
+                     msg_hash_to_str(MENU_ENUM_LABEL_CONTENT_COLLECTION_LIST),
+                     MENU_ENUM_LABEL_CONTENT_COLLECTION_LIST,
+                     MENU_SETTING_ACTION, 0, 0);
+            }
+#endif
             if (settings->bools.menu_content_show_add)
                menu_displaylist_parse_settings_enum(menu, info,
                      MENU_ENUM_LABEL_ADD_CONTENT_LIST,


### PR DESCRIPTION
## Description

Now that RGUI has subsystem support (PR #8194), the main menu can get rather crowded (e.g. just try loading the FBAlpha core - the additional subsystem entries basically fill the screen, requiring a heap of scrolling...). Users can hide all this extra noise by turning off 'Show Load Content' - but whereas the other menu drivers have alternative ways of accessing playlists, RGUI has 'Load Content' or nothing. If you turn it off, the menu becomes useless.

This PR adds a second instance of the 'Collections' entry to the main menu itself. It can be enabled/disabled via the existing 'Show Playlist Tabs' option (since this is the closest thing RGUI has to a playlist 'tab'...). This permits the user to disable 'Load Content' without losing access to all their games, and allows for a very clean/minimalist playlist-based setup:

![screenshot_2019-02-07_11-51-49](https://user-images.githubusercontent.com/38211560/52410198-8df8cb00-2acf-11e9-9a7a-69d22e73b522.png)

