### PR TITLE
libretro-common: improve PRI_SIZET for non-windows platforms

### DIFF
--- a/libretro-common/include/retro_miscellaneous.h
+++ b/libretro-common/include/retro_miscellaneous.h
@@ -159,14 +159,22 @@ typedef struct
 #  ifdef _WIN64
 #    define PRI_SIZET PRIu64
 #  else
-#if _MSC_VER == 1800
-#    define PRI_SIZET PRIu32
-#else
-#    define PRI_SIZET "u"
-#endif
+#    if _MSC_VER == 1800
+#      define PRI_SIZET PRIu32
+#    else
+#      define PRI_SIZET "u"
+#    endif
 #  endif
 #else
-#  define PRI_SIZET "lu"
+#  if (SIZE_MAX == 0xFFFF)
+#    define PRI_SIZET "hu"
+#  elif (SIZE_MAX == 0xFFFFFFFF)
+#    define PRI_SIZET "u"
+#  elif (SIZE_MAX == 0xFFFFFFFFFFFFFFFF)
+#    define PRI_SIZET "lu"
+#  else
+#    error PRI_SIZET: unknown SIZE_MAX
+#  endif
 #endif
 
 #endif


### PR DESCRIPTION
## Description

In non-windows platfoms, the `size_t` type may not necessarily use
the `%lu` format specification. For example in 32 bits platforms
instead it needs to be `%u`. Therefore, for non-windows platforms,
it is better to define PRI_SIZET more precisely.

Silences these types of warnings in 32 bits non-windows platforms:

    libretro-common/file/config_file.c: In function ‘config_get_size_t’:
    libretro-common/file/config_file.c:694:32: warning: format ‘%lu’ expects
    argument of type ‘long unsigned int *’, but argument 3 has type
    ‘size_t * {aka unsigned int *}’ [-Wformat=]
           if (sscanf(entry->value, "%" PRI_SIZET, &val) == 1)
                                    ^~~

Tested build in c89 mode without these warnings in Linux32/64, ARM32 and Win64.

## Related Issues

Discussed in #8191

## Reviewers

@orbea 