### PR TITLE
menu_setting: add forgotten ifdefs for building without XMB menu

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -819,6 +819,7 @@ static void setting_get_string_representation_uint_rgui_thumbnail_scaler(
    }
 }
 
+#ifdef HAVE_XMB
 static void setting_get_string_representation_uint_xmb_icon_theme(
       rarch_setting_t *setting,
       char *s, size_t len)
@@ -878,7 +879,9 @@ static void setting_get_string_representation_uint_xmb_icon_theme(
          break;
    }
 }
+#endif
 
+#ifdef HAVE_XMB
 static void setting_get_string_representation_uint_xmb_layout(
       rarch_setting_t *setting,
       char *s, size_t len)
@@ -899,6 +902,7 @@ static void setting_get_string_representation_uint_xmb_layout(
          break;
    }
 }
+#endif
 
 #ifdef HAVE_MATERIALUI
 static void setting_get_string_representation_uint_materialui_menu_color_theme(
@@ -1066,7 +1070,7 @@ static void setting_get_string_representation_uint_ozone_menu_color_theme(
 }
 #endif
 
-#ifdef HAVE_SHADERPIPELINE
+#if defined(HAVE_XMB) && defined(HAVE_SHADERPIPELINE)
 static void setting_get_string_representation_uint_xmb_shader_pipeline(
       rarch_setting_t *setting,
       char *s, size_t len)


### PR DESCRIPTION
## Description

When compiling without XMB menu support, some XMB-related functions were left defined and not used. Fix that by adding missing `HAVE_XMB` define-checks.

Silences these warnings when compiling without XMB:

    menu/menu_setting.c:882:13: warning: ‘setting_get_string_representation_uint_xmb_layout’
    defined but not used [-Wunused-function]
     static void setting_get_string_representation_uint_xmb_layout(
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    menu/menu_setting.c:822:13: warning: ‘setting_get_string_representation_uint_xmb_icon_theme’
    defined but not used [-Wunused-function]
     static void setting_get_string_representation_uint_xmb_icon_theme(
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    menu/menu_setting.c:1074:13: warning: ‘setting_get_string_representation_uint_xmb_shader_pipeline’
    defined but not used [-Wunused-function]
     static void setting_get_string_representation_uint_xmb_shader_pipeline(
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Tested build in c89 mode without these warnings in Linux32/64, ARM32 and Win64.

## Reviewers

@orbea 