### PR TITLE
macOS: Add missing PRODUCT_BUNDLE_IDENTIFIER

### DIFF
--- a/pkg/apple/RetroArch.xcodeproj/project.pbxproj
+++ b/pkg/apple/RetroArch.xcodeproj/project.pbxproj
@@ -387,6 +387,7 @@
 					"-DHAVE_CG",
 				);
 				PRECOMPS_INCLUDE_HEADERS_FROM_BUILT_PRODUCTS_DIR = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = libretro.RetroArch;
 				PRODUCT_NAME = RetroArchCg;
 			};
 			name = Debug;
@@ -421,6 +422,7 @@
 					"-DHAVE_CG",
 				);
 				PRECOMPS_INCLUDE_HEADERS_FROM_BUILT_PRODUCTS_DIR = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = libretro.RetroArch;
 				PRODUCT_NAME = RetroArchCg;
 			};
 			name = Release;
@@ -453,6 +455,7 @@
 				INSTALL_PATH = "$(HOME)/Applications";
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				PRECOMPS_INCLUDE_HEADERS_FROM_BUILT_PRODUCTS_DIR = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = libretro.RetroArch;
 				PRODUCT_NAME = RetroArch;
 			};
 			name = Debug;
@@ -483,6 +486,7 @@
 				INSTALL_PATH = "$(HOME)/Applications";
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				PRECOMPS_INCLUDE_HEADERS_FROM_BUILT_PRODUCTS_DIR = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = libretro.RetroArch;
 				PRODUCT_NAME = RetroArch;
 			};
 			name = Release;


### PR DESCRIPTION
## Description

The `RetroArch` and `RetroArchCg` targets in the non-metal OSX build are missing `PRODUCT_BUNDLE_IDENTIFIER` in the `project.pbxproj` file. As a result, the `Info.plist` file in the compiled app is missing the `CFBundleIdentifier` key.

I've confirmed that the `CFBundleIdentifier` appears as expected after adding `PRODUCT_BUNDLE_IDENTIFIER`:

```
pkg/apple/build/Release/RetroArch.app/Contents/Info.plist
26:	<key>CFBundleIdentifier</key>
27-	<string>libretro.RetroArch</string>

pkg/apple/build/Release/RetroArchCg.app/Contents/Info.plist
26:	<key>CFBundleIdentifier</key>
27-	<string>libretro.RetroArch</string>

pkg/apple/build/Debug/RetroArch.app/Contents/Info.plist
26:	<key>CFBundleIdentifier</key>
27-	<string>libretro.RetroArch</string>

pkg/apple/build/Debug/RetroArchCg.app/Contents/Info.plist
26:	<key>CFBundleIdentifier</key>
27-	<string>libretro.RetroArch</string>
```

## Related Issues

This was reported in #7346 and should fix the issue. 