### PR TITLE
Silence warnings with 32-bit linux.

### DIFF
--- a/cores/libretro-video-processor/video_processor_v4l2.c
+++ b/cores/libretro-video-processor/video_processor_v4l2.c
@@ -33,6 +33,7 @@
 
 #include <libretro.h>
 #include <clamping.h>
+#include <retro_miscellaneous.h>
 
 #include <sys/mman.h>
 #include <errno.h>
@@ -1011,9 +1012,9 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_cheat_set)(unsigned index, bool enabl
 {
 }
 
+#if 0
 static void videoinput_set_control_v4l2( uint32_t id, double val )
 {
-#if 0
     struct v4l2_queryctrl query;
 
     query.id = id;
@@ -1023,8 +1024,8 @@ static void videoinput_set_control_v4l2( uint32_t id, double val )
         control.value = query.minimum + ((int) ((val * ((double) (query.maximum - query.minimum))) + 0.5));
         ioctl( video_device_fd, VIDIOC_S_CTRL, &control );
     }
-#endif
 }
+#endif
 
 RETRO_API bool VIDEOPROC_CORE_PREFIX(retro_load_game)(const struct retro_game_info *game)
 {
@@ -1197,7 +1198,7 @@ RETRO_API bool VIDEOPROC_CORE_PREFIX(retro_load_game)(const struct retro_game_in
          return false;
       }
       v4l2_ncapbuf = reqbufs.count;
-      printf("GOT v4l2_ncapbuf=%ld\n", v4l2_ncapbuf);
+      printf("GOT v4l2_ncapbuf=%" PRI_SIZET "\n", v4l2_ncapbuf);
 
       for (index = 0; index < v4l2_ncapbuf; index++)
       {
@@ -1295,7 +1296,7 @@ RETRO_API bool VIDEOPROC_CORE_PREFIX(retro_load_game)(const struct retro_game_in
       return false;
    }
 
-   printf("Allocated %lu byte conversion buffer\n",
+   printf("Allocated %" PRI_SIZET " byte conversion buffer\n",
          video_cap_width * video_cap_height * sizeof(uint32_t));
 
    pixel_format = RETRO_PIXEL_FORMAT_XRGB8888;


### PR DESCRIPTION
## Description

Silences more warnings with `--enable-v4l2`, two are only with 32-bit linux.

Reference:

https://stackoverflow.com/questions/3168275/printf-format-specifiers-for-uint32-t-and-size-t

## Related Issues

```
cores/libretro-video-processor/video_processor_v4l2.c: In function 'libretro_videoprocessor_retro_load_game':
cores/libretro-video-processor/video_processor_v4l2.c:1200:14: warning: format '%ld' expects argument of type 'long int', but argument 2 has type 'size_t {aka unsigned int}' [-Wformat=]
       printf("GOT v4l2_ncapbuf=%ld\n", v4l2_ncapbuf);
              ^
cores/libretro-video-processor/video_processor_v4l2.c:1298:11: warning: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'uint32_t {aka unsigned int}' [-Wformat=]
    printf("Allocated %lu byte conversion buffer\n",
           ^
cores/libretro-video-processor/video_processor_v4l2.c: At top level:
cores/libretro-video-processor/video_processor_v4l2.c:1014:13: warning: 'videoinput_set_control_v4l2' defined but not used [-Wunused-function]
 static void videoinput_set_control_v4l2( uint32_t id, double val )
             ^
```

## Reviewers

@hhromic 
