### PR TITLE
Better warning fix for 32-bit linux.

### DIFF
--- a/cores/libretro-video-processor/video_processor_v4l2.c
+++ b/cores/libretro-video-processor/video_processor_v4l2.c
@@ -1297,7 +1297,7 @@ RETRO_API bool VIDEOPROC_CORE_PREFIX(retro_load_game)(const struct retro_game_in
    }
 
    printf("Allocated %" PRI_SIZET " byte conversion buffer\n",
-         video_cap_width * video_cap_height * sizeof(uint32_t));
+         (size_t)(video_cap_width * video_cap_height) * sizeof(uint32_t));
 
    pixel_format = RETRO_PIXEL_FORMAT_XRGB8888;
    if (!VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_SET_PIXEL_FORMAT, &pixel_format))


### PR DESCRIPTION
## Description

A better warning fix as suggested by @hhromic.

## Related Issues

```
cores/libretro-video-processor/video_processor_v4l2.c:1298:11: warning: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'uint32_t {aka unsigned int}' [-Wformat=]
    printf("Allocated %lu byte conversion buffer\n",
           ^
```

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/8215

## Reviewers

@hhromic
