### PR TITLE
libretro-common: fix PRI_SIZET not being set in PS2

### DIFF
--- a/libretro-common/include/retro_miscellaneous.h
+++ b/libretro-common/include/retro_miscellaneous.h
@@ -165,6 +165,8 @@ typedef struct
 #      define PRI_SIZET "u"
 #    endif
 #  endif
+#elif PS2
+#  define PRI_SIZET "lu"
 #else
 #  if (SIZE_MAX == 0xFFFF)
 #    define PRI_SIZET "hu"


### PR DESCRIPTION
## Description

The PS2 build is failing because `SIZE_MAX` is not defined in this platform.
Fix by using `lu` for PS2 builds.

## Related Pull Requests

#8208 

## Reviewers

@twinaphex 
