### PR TITLE
try to fix #8121 by making the interval configurable

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -1636,6 +1636,9 @@ static struct config_uint_setting *populate_settings_uint(settings_t *settings, 
    SETTING_UINT("audio_latency",                &settings->uints.audio_latency, false, 0 /* TODO */, false);
    SETTING_UINT("audio_resampler_quality",      &settings->uints.audio_resampler_quality, true, audio_resampler_quality_level, false);
    SETTING_UINT("audio_block_frames",           &settings->uints.audio_block_frames, true, 0, false);
+#ifdef ANDROID
+   SETTING_UINT("input_block_timeout",           &settings->uints.input_block_timeout, true, 1, false);
+#endif
    SETTING_UINT("rewind_granularity",           &settings->uints.rewind_granularity, true, rewind_granularity, false);
    SETTING_UINT("rewind_buffer_size_step",      &settings->uints.rewind_buffer_size_step, true, rewind_buffer_size_step, false);
    SETTING_UINT("autosave_interval",            &settings->uints.autosave_interval,  true, autosave_interval, false);

--- a/configuration.h
+++ b/configuration.h
@@ -357,6 +357,8 @@ typedef struct settings
       unsigned audio_block_frames;
       unsigned audio_latency;
 
+      unsigned input_block_timeout;
+
       unsigned audio_resampler_quality;
 
       unsigned input_turbo_period;

--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -42,6 +42,8 @@
 #include "../../tasks/tasks_internal.h"
 #include "../../performance_counters.h"
 
+#include "../../configuration.h"
+
 #define MAX_TOUCH 16
 #define MAX_NUM_KEYBOARDS 3
 
@@ -1337,13 +1339,14 @@ static bool android_input_key_pressed(void *data, int key)
  */
 static void android_input_poll(void *data)
 {
+   settings_t *settings = config_get_ptr();
    int ident;
    unsigned key                    = RARCH_PAUSE_TOGGLE;
    struct android_app *android_app = (struct android_app*)g_android;
 
    while ((ident =
             ALooper_pollAll((android_input_key_pressed(data, key))
-               ? -1 : 1,
+               ? -1 : settings->uints.input_block_timeout,
                NULL, NULL, NULL)) >= 0)
    {
       switch (ident)


### PR DESCRIPTION
@diablodiab fixed this a while back, but it seems it has never been "too responsive"
https://github.com/diablodiab/RetroArch/commit/58c5cc6f46ce07581e221c6e2213a76701bf19e6

He changed the polling window from 0 to 1ms, but that's.... quite low, so I thought I'd make it configurable (config file only for now for testing)