### PR TITLE
Fix warning with CXX_BUILD.

### DIFF
--- a/runahead/secondary_core.c
+++ b/runahead/secondary_core.c
@@ -81,11 +81,11 @@ static char *get_temp_directory_alloc(void)
       path = strcpy_alloc_force(settings->paths.directory_libretro);
    }
 #else
-   path = "/tmp";
    if (getenv("TMPDIR"))
-      path = getenv("TMPDIR");
+      path = strcpy_alloc_force(getenv("TMPDIR"));
+   else
+      path = strcpy_alloc_force("/tmp");
 
-   path = strcpy_alloc_force(path);
 #endif
    return path;
 }


### PR DESCRIPTION
## Description

Fixes a warning with `CXX_BUILD` as suggested by @hhromic in comment https://github.com/libretro/RetroArch/issues/8191#issuecomment-461883999.

## Related Issues

```
runahead/secondary_core.c: In function ‘char* get_temp_directory_alloc()’:
runahead/secondary_core.c:84:11: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
    path = "/tmp";
           ^~~~~~
```

## Reviewers

@hhromic 