### PR TITLE
menu_animations: make animations menu independent

### DIFF
--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -643,7 +643,6 @@ static void materialui_compute_entries_box(materialui_handle_t* mui, int width)
    with acceleration */
 static void materialui_render(void *data, bool is_idle)
 {
-   menu_animation_ctx_delta_t delta;
    unsigned bottom, width, height, header_height;
    size_t        i             = 0;
    materialui_handle_t *mui    = (materialui_handle_t*)data;
@@ -661,11 +660,6 @@ static void materialui_render(void *data, bool is_idle)
          materialui_compute_entries_box(mui, width);
       mui->need_compute = false;
    }
-
-   delta.current = menu_animation_get_delta_time();
-
-   if (menu_animation_get_ideal_delta_time(&delta))
-      menu_animation_update(delta.ideal);
 
    menu_display_set_width(width);
    menu_display_set_height(height);

--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -932,7 +932,6 @@ static void ozone_compute_entries_position(ozone_handle_t *ozone)
 static void ozone_render(void *data, bool is_idle)
 {
    size_t i;
-   menu_animation_ctx_delta_t delta;
    unsigned end                     = (unsigned)menu_entries_get_size();
    ozone_handle_t *ozone            = (ozone_handle_t*)data;
    if (!data)
@@ -945,11 +944,6 @@ static void ozone_render(void *data, bool is_idle)
    }
 
    ozone->selection = menu_navigation_get_selection();
-
-   delta.current = menu_animation_get_delta_time();
-
-   if (menu_animation_get_ideal_delta_time(&delta))
-      menu_animation_update(delta.ideal);
 
    /* TODO Handle pointer & mouse */
 

--- a/menu/drivers/stripes.c
+++ b/menu/drivers/stripes.c
@@ -2654,7 +2654,6 @@ static void stripes_draw_items(
 static void stripes_render(void *data, bool is_idle)
 {
    size_t i;
-   menu_animation_ctx_delta_t delta;
    settings_t   *settings   = config_get_ptr();
    stripes_handle_t *stripes        = (stripes_handle_t*)data;
    unsigned      end        = (unsigned)menu_entries_get_size();
@@ -2663,11 +2662,6 @@ static void stripes_render(void *data, bool is_idle)
 
    if (!stripes)
       return;
-
-   delta.current = menu_animation_get_delta_time();
-
-   if (menu_animation_get_ideal_delta_time(&delta))
-      menu_animation_update(delta.ideal);
 
    if (pointer_enable || mouse_enable)
    {

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -3140,7 +3140,6 @@ static void xmb_context_reset_internal(xmb_handle_t *xmb,
 static void xmb_render(void *data, bool is_idle)
 {
    size_t i;
-   menu_animation_ctx_delta_t delta;
    settings_t   *settings   = config_get_ptr();
    xmb_handle_t *xmb        = (xmb_handle_t*)data;
    unsigned      end        = (unsigned)menu_entries_get_size();
@@ -3162,11 +3161,6 @@ static void xmb_render(void *data, bool is_idle)
             false);
 
    xmb->previous_scale_factor = scale_factor;
-
-   delta.current = menu_animation_get_delta_time();
-
-   if (menu_animation_get_ideal_delta_time(&delta))
-      menu_animation_update(delta.ideal);
 
    if (pointer_enable || mouse_enable)
    {

--- a/retroarch.c
+++ b/retroarch.c
@@ -2828,6 +2828,15 @@ static enum runloop_state runloop_check_state(
    }
 
 #if defined(HAVE_MENU)
+   {
+      menu_animation_ctx_delta_t delta;
+
+      delta.current = menu_animation_get_delta_time();
+
+      if (menu_animation_get_ideal_delta_time(&delta))
+         menu_animation_update(delta.ideal);
+   }
+
    if (menu_is_alive)
    {
       enum menu_action action;


### PR DESCRIPTION
Animations were ran by each menu driver in their `render` function. This prevents animations from running while content is running (needed for menu widgets).

This commit moves the `menu_animation_update` from the menu driver to the runloop directly, and it will run regardless of the current menu state.

It has been tested and runs fine on Linux, OSX, Switch and Android by me and two other people. _It should not break anything._