### PR TITLE
Fix warnings with --enable-sixel.

### DIFF
--- a/gfx/drivers_font/sixel_font.c
+++ b/gfx/drivers_font/sixel_font.c
@@ -76,7 +76,7 @@ static const struct font_glyph *sixel_font_get_glyph(
 
 static void sixel_render_msg(video_frame_info_t *video_info,
       void *data, const char *msg,
-      const void *userdata)
+      const struct font_params *userdata)
 {
    float x, y, scale;
    unsigned width, height;

--- a/menu/drivers_display/menu_display_sixel.c
+++ b/menu/drivers_display/menu_display_sixel.c
@@ -25,30 +25,33 @@
 
 #include "../menu_driver.h"
 
-static void *menu_display_sixel_get_default_mvp(void)
+static void *menu_display_sixel_get_default_mvp(video_frame_info_t *video_info)
 {
    return NULL;
 }
 
-static void menu_display_sixel_blend_begin(void)
+static void menu_display_sixel_blend_begin(video_frame_info_t *video_info)
 {
 }
 
-static void menu_display_sixel_blend_end(void)
+static void menu_display_sixel_blend_end(video_frame_info_t *video_info)
 {
 }
 
-static void menu_display_sixel_draw(void *data)
-{
-   (void)data;
-}
-
-static void menu_display_sixel_draw_pipeline(void *data)
+static void menu_display_sixel_draw(menu_display_ctx_draw_t *data,
+      video_frame_info_t *video_info)
 {
    (void)data;
 }
 
-static void menu_display_sixel_viewport(void *data)
+static void menu_display_sixel_draw_pipeline(menu_display_ctx_draw_t *data,
+      video_frame_info_t *video_info)
+{
+   (void)data;
+}
+
+static void menu_display_sixel_viewport(menu_display_ctx_draw_t *data,
+      video_frame_info_t *video_info)
 {
    (void)data;
 }
@@ -57,7 +60,9 @@ static void menu_display_sixel_restore_clear_color(void)
 {
 }
 
-static void menu_display_sixel_clear_color(menu_display_ctx_clearcolor_t *clearcolor)
+static void menu_display_sixel_clear_color(
+      menu_display_ctx_clearcolor_t *clearcolor,
+      video_frame_info_t *video_info)
 {
    (void)clearcolor;
 


### PR DESCRIPTION
## Description

Fixes most of the warnings with `--enable-sixel`.

## Related Issues

```
gfx/drivers_font/sixel_font.c: At top level:
gfx/drivers_font/sixel_font.c:133:4: warning: initialization of ‘void (*)(video_frame_info_t *, void *, const char *, const struct font_params *)’ {aka ‘void (*)(struct video_frame_info *, void *, const char *, const struct font_params *)’} from incompatible pointer type ‘void (*)(video_frame_info_t *, void *, const char *, const void *)’ {aka ‘void (*)(struct video_frame_info *, void *, const char *, const void *)’} [-Wincompatible-pointer-types]
    sixel_render_msg,
    ^~~~~~~~~~~~~~~~
gfx/drivers_font/sixel_font.c:133:4: note: (near initialization for ‘sixel_font.render_msg’)
CC gfx/drivers_context/sixel_ctx.c
CC menu/drivers_display/menu_display_sixel.c
menu/drivers_display/menu_display_sixel.c:93:4: warning: initialization of ‘void (*)(menu_display_ctx_draw_t *, video_frame_info_t *)’ {aka ‘void (*)(struct menu_display_ctx_draw *, struct video_frame_info *)’} from incompatible pointer type ‘void (*)(void *)’ [-Wincompatible-pointer-types]
    menu_display_sixel_draw,
    ^~~~~~~~~~~~~~~~~~~~~~~
menu/drivers_display/menu_display_sixel.c:93:4: note: (near initialization for ‘menu_display_ctx_sixel.draw’)
menu/drivers_display/menu_display_sixel.c:94:4: warning: initialization of ‘void (*)(menu_display_ctx_draw_t *, video_frame_info_t *)’ {aka ‘void (*)(struct menu_display_ctx_draw *, struct video_frame_info *)’} from incompatible pointer type ‘void (*)(void *)’ [-Wincompatible-pointer-types]
    menu_display_sixel_draw_pipeline,
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
menu/drivers_display/menu_display_sixel.c:94:4: note: (near initialization for ‘menu_display_ctx_sixel.draw_pipeline’)
menu/drivers_display/menu_display_sixel.c:95:4: warning: initialization of ‘void (*)(menu_display_ctx_draw_t *, video_frame_info_t *)’ {aka ‘void (*)(struct menu_display_ctx_draw *, struct video_frame_info *)’} from incompatible pointer type ‘void (*)(void *)’ [-Wincompatible-pointer-types]
    menu_display_sixel_viewport,
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~
menu/drivers_display/menu_display_sixel.c:95:4: note: (near initialization for ‘menu_display_ctx_sixel.viewport’)
menu/drivers_display/menu_display_sixel.c:96:4: warning: initialization of ‘void (*)(video_frame_info_t *)’ {aka ‘void (*)(struct video_frame_info *)’} from incompatible pointer type ‘void (*)(void)’ [-Wincompatible-pointer-types]
    menu_display_sixel_blend_begin,
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
menu/drivers_display/menu_display_sixel.c:96:4: note: (near initialization for ‘menu_display_ctx_sixel.blend_begin’)
menu/drivers_display/menu_display_sixel.c:97:4: warning: initialization of ‘void (*)(video_frame_info_t *)’ {aka ‘void (*)(struct video_frame_info *)’} from incompatible pointer type ‘void (*)(void)’ [-Wincompatible-pointer-types]
    menu_display_sixel_blend_end,
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
menu/drivers_display/menu_display_sixel.c:97:4: note: (near initialization for ‘menu_display_ctx_sixel.blend_end’)
menu/drivers_display/menu_display_sixel.c:99:4: warning: initialization of ‘void (*)(menu_display_ctx_clearcolor_t *, video_frame_info_t *)’ {aka ‘void (*)(struct menu_display_ctx_clearcolor *, struct video_frame_info *)’} from incompatible pointer type ‘void (*)(menu_display_ctx_clearcolor_t *)’ {aka ‘void (*)(struct menu_display_ctx_clearcolor *)’} [-Wincompatible-pointer-types]
    menu_display_sixel_clear_color,
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
menu/drivers_display/menu_display_sixel.c:99:4: note: (near initialization for ‘menu_display_ctx_sixel.clear_color’)
menu/drivers_display/menu_display_sixel.c:100:4: warning: initialization of ‘void * (*)(video_frame_info_t *)’ {aka ‘void * (*)(struct video_frame_info *)’} from incompatible pointer type ‘void * (*)(void)’ [-Wincompatible-pointer-types]
    menu_display_sixel_get_default_mvp,
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
menu/drivers_display/menu_display_sixel.c:100:4: note: (near initialization for ‘menu_display_ctx_sixel.get_default_mvp’)
```

## Reviewers

@bparker06 and @hhromic