### PR TITLE
qb: Minor config.libs.sh fixes.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -437,6 +437,7 @@ check_val '' XF86VM -lXxf86vm '' xxf86vm '' '' false
 
 if [ "$HAVE_WAYLAND_PROTOS" = yes ] &&
    [ "$HAVE_WAYLAND_SCANNER" = yes ] &&
+   [ "$HAVE_WAYLAND_CURSOR" = yes ] &&
    [ "$HAVE_WAYLAND" = yes ]; then
     ./gfx/common/wayland/generate_wayland_protos.sh -c "$WAYLAND_SCANNER_VERSION" -s "$SHARE_DIR" ||
        die 1 'Error: Failed generating wayland protocols.'
@@ -511,6 +512,7 @@ add_define MAKEFILE OS "$OS"
 if [ "$HAVE_DEBUG" = 'yes' ]; then
    add_define MAKEFILE DEBUG 1
    if [ "$HAVE_OPENGL" = 'yes' ] ||
+      [ "$HAVE_OPENGL1" = 'yes' ] ||
       [ "$HAVE_OPENGLES" = 'yes' ] ||
       [ "$HAVE_OPENGLES3" = 'yes' ]; then
       add_define MAKEFILE GL_DEBUG 1


### PR DESCRIPTION
## Description

Minor fixes for `config.libs.sh`.

1. Checks if `HAVE_WAYLAND_CURSOR` is actually found for wayland support.
2. Checks `HAVE_OPENGL1` for enabling `GL_DEBUG` with `--enable-debug`.
