### PR TITLE
cheevos: cancel lboards on reset

### DIFF
--- a/cheevos-new/cheevos.c
+++ b/cheevos-new/cheevos.c
@@ -698,21 +698,26 @@ static void cheevos_test_leaderboards(void)
 
 void cheevos_reset_game(void)
 {
-   cheevos_cheevo_t* cheevo = NULL;
-   int i, count;
+   cheevos_cheevo_t* cheevo;
+   cheevos_lboard_t* lboard;
+   unsigned i;
 
    cheevo = cheevos_locals.core;
-
-   for (i = 0, count = cheevos_locals.patchdata.core_count; i < count; i++, cheevo++)
+   for (i = 0; i < cheevos_locals.patchdata.core_count; i++, cheevo++)
    {
       cheevo->last = 1;
    }
 
    cheevo = cheevos_locals.unofficial;
-
-   for (i = 0, count = cheevos_locals.patchdata.unofficial_count; i < count; i++, cheevo++)
+   for (i = 0; i < cheevos_locals.patchdata.unofficial_count; i++, cheevo++)
    {
       cheevo->last = 1;
+   }
+
+   lboard = cheevos_locals.lboards;
+   for (i = 0; i < cheevos_locals.patchdata.lboard_count; i++, lboard++)
+   {
+      lboard->active = 0;
    }
 }
 

--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -2056,22 +2056,21 @@ static int cheevos_deactivate_unlocks(const char* json, unsigned mode)
 
 void cheevos_reset_game(void)
 {
-   cheevo_t *end       = NULL;
-   cheevo_t *cheevo    = cheevos_locals.core.cheevos;
+   cheevo_t *cheevo;
+   cheevos_leaderboard_t *lboard;
+   unsigned i;
 
-   if (!cheevo)
-      return;
-
-   end                 = cheevo + cheevos_locals.core.count;
-
-   for (; cheevo < end; cheevo++)
+   cheevo = cheevos_locals.core.cheevos;
+   for (i = 0; i < cheevos_locals.core.count; i++, cheevo++)
       cheevo->last     = 1;
 
-   cheevo              = cheevos_locals.unofficial.cheevos;
-   end                 = cheevo + cheevos_locals.unofficial.count;
-
-   for (; cheevo < end; cheevo++)
+   cheevo = cheevos_locals.unofficial.cheevos;
+   for (i = 0; i < cheevos_locals.unofficial.count; i++, cheevo++)
       cheevo->last = 1;
+
+   lboard = cheevos_locals.leaderboards;
+   for (i = 0; i < cheevos_locals.lboard_count; i++, lboard++)
+      lboard->active = 0;
 }
 
 void cheevos_populate_menu(void *data)


### PR DESCRIPTION
## Description

Leaderboards should be cancelled when the game is reset (otherwise it can be used for cheating the leaderboards in RetroAchievements site).

This is the behavior on the official standalone emulators and should be in RetroArch too.

## Related Issues

closes #6384
closes meleu/RetroArch-problematic-cheevos#38

## Reviewers

@leiradel @Jamiras