### PR TITLE
qb: Test for user set variables.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -119,7 +119,7 @@ else
 fi
 
 [ "$HAVE_DYNAMIC" = 'yes' ] || {
-   check_lib '' RETRO "$LIBRETRO" retro_init "$DYLIB" '' 'Cannot find libretro, did you forget --with-libretro="-lretro"?'
+   check_lib '' RETRO "$LIBRETRO" retro_init "$DYLIB" '' '' 'Cannot find libretro, did you forget --with-libretro="-lretro"?'
    add_define MAKEFILE libretro "$LIBRETRO"
 }
 

--- a/qb/qb.params.sh
+++ b/qb/qb.params.sh
@@ -70,7 +70,9 @@ parse_input() # Parse stuff :V
 	OPTS=''
 	while read -r VAR _; do
 		TMPVAR="${VAR%=*}"
-		OPTS="$OPTS ${TMPVAR##HAVE_}"
+		NEWVAR="${TMPVAR##HAVE_}"
+		OPTS="$OPTS $NEWVAR"
+		eval "USER_$NEWVAR=no"
 	done < 'qb/config.params.sh'
 	#OPTS contains all available options in config.params.sh - used to speedup
 	#things in opt_exists()
@@ -93,7 +95,6 @@ parse_input() # Parse stuff :V
 			--disable-*)
 				opt_exists "${1##--disable-}" "$1"
 				eval "HAVE_$opt=no"
-				eval "USER_$opt=no"
 				eval "HAVE_NO_$opt=yes"
 			;;
 			--with-*)


### PR DESCRIPTION
## Description

This fixes issues where if both `check_header` and `check_lib` are used it would set `HAVE_FOO=yes` and then result in a configure failure when `check_lib` failed. This was also implemented for the other functions to avoid similar issues.

This also allows making `config.params.sh` more flexible, cleans up `check_val` and makes sure `$USER_FOO` is not an unset variable.

## Related Pull Requests

Second version of https://github.com/libretro/RetroArch/pull/8246 where the first half of the PR was bogus, but the second half is still good.
