### PR TITLE
Remove duplicate lua include.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1657,8 +1657,7 @@ ifeq ($(HAVE_NETWORKING), 1)
 
       ifeq ($(HAVE_NEW_CHEEVOS), 1)
          DEFINES += -DHAVE_NEW_CHEEVOS \
-            -Ideps/rcheevos/include \
-            -Ideps/lua/src
+            -Ideps/rcheevos/include
          OBJ += cheevos-new/cheevos.o \
             cheevos-new/badges.o \
             cheevos-new/fixup.o \


### PR DESCRIPTION
## Description

It seems rcheevos only needs `-Ideps/lua/src` if `-DRC_DISABLE_LUA` is not defined which is already set correctly when lua is disabled. So this is essentially duplicate and has the consequence of including lua even when its not used.
