### PR TITLE
qb: Allow checking for multiple pkgconfig files.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -485,7 +485,7 @@ else
    check_lib '' VULKAN -lvulkan vkCreateInstance
 fi
 
-check_pkgconf PYTHON python3
+check_pkgconf PYTHON 'python3 python3 python-3.7 python-3.6 python-3.5 python-3.4 python-3.3 python-3.2'
 
 if [ "$HAVE_MENU" != 'no' ]; then
    if [ "$HAVE_OPENGL" = 'no' ] && [ "$HAVE_OPENGLES" = 'no' ] && [ "$HAVE_VULKAN" = 'no' ]; then


### PR DESCRIPTION
## Description

This reworks `check_pkgconf` to be able to check for multiple pkgconfig files for a single package.

Currently it is only useful for `python3` where for older versions upstream did not provide `python3.pc` and only versioned pkgconfig files like `python-3.5.pc`. I went back to version `python-3.2.3` without encountering a build failure which should cover the oldest `python3` versions out in the wild according to repology.org.

For everything else there should be no change in behavior, but this could be useful in the future for other things.

## Related Issues

Personally my own RetroArch build script has this ugly hack which I can finally remove...
```
if [ "${PYTHON:-0}" != 0 ]; then
  lib="${lib} --enable-python"
  # Needed for python3 in the 14.1 SBo branch.
  if ! pkg-config --exists python3 && pkg-config --exists python-3.5; then
    sed -i 's/python3/python-3.5/' qb/config.libs.sh
  fi
fi
```