### PR TITLE
Silence warning with --enable-python and 32-bit linux.

### DIFF
--- a/gfx/drivers_tracker/video_state_python.c
+++ b/gfx/drivers_tracker/video_state_python.c
@@ -314,7 +314,7 @@ py_state_t *py_state_new(const char *script,
        * isn't standardized across environments.
        * PyRun_SimpleFile() breaks on Windows because it's
        * compiled with MSVC. */
-      ssize_t len;
+      int64_t len;
       char *script_ = NULL;
       bool ret      = filestream_read_file
          (script, (void**)&script_, &len);


### PR DESCRIPTION
## Description

Silences a warning with 32-bit linux and `--enable-python`.

## Related Issues

```
gfx/drivers_tracker/video_state_python.c: In function 'py_state_new':
gfx/drivers_tracker/video_state_python.c:320:37: warning: passing argument 3 of 'filestream_read_file' from incompatible pointer type [-Wincompatible-pointer-types]
          (script, (void**)&script_, &len);
                                     ^
In file included from gfx/drivers_tracker/video_state_python.c:25:0:
./libretro-common/include/streams/file_stream.h:77:9: note: expected 'int64_t * {aka long long int *}' but argument is of type 'ssize_t * {aka int *}'
 int64_t filestream_read_file(const char *path, void **buf, int64_t *len);
         ^
```

## Reviewers

@hhromic 
