### PR TITLE
Add missing brackets.

### DIFF
--- a/gfx/video_crt_switch.c
+++ b/gfx/video_crt_switch.c
@@ -240,9 +240,11 @@ int crt_compute_dynamic_width(int width)
    for (int i =1; i < 10; i++)
    {
       if (((width*0.5*i) * min_height * ra_core_hz) > p_clock)
+      {
          width = width*i;
          return width;
          break;        
+      }
    }
   return 0;
 }


### PR DESCRIPTION
## Description

Adds missing brackets caught by a gcc warning.

## Related Issues

```
gfx/video_crt_switch.c: In function ‘crt_compute_dynamic_width’:
gfx/video_crt_switch.c:242:7: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
       if (((width*0.5*i) * min_height * ra_core_hz) > p_clock)
       ^~
gfx/video_crt_switch.c:244:10: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
          return width;
          ^~~~~~
```
