### PR TITLE
Adds unique IDs to prevent 3DS cores overwriting each other

### DIFF
--- a/pkg/ctr/Makefile.cores
+++ b/pkg/ctr/Makefile.cores
@@ -283,11 +283,26 @@ else ifeq ($(LIBRETRO), stella)
 	APP_BANNER           = pkg/ctr/assets/stella_banner.png
 
 else ifeq ($(LIBRETRO), pokemini)
-	APP_TITLE            = PokeMini
+	APP_TITLE            = PokeMini Libretro
 	APP_AUTHOR           = justburn
 	APP_PRODUCT_CODE     = RARCH-POKEMINI
 	APP_UNIQUE_ID        = 0xBAC20
 	APP_ICON             = pkg/ctr/assets/pokemini.png
 	APP_BANNER           = pkg/ctr/assets/pokemini_banner.png
+
+else ifeq ($(LIBRETRO), theodore)
+	APP_TITLE            = Theodore Libretro
+	APP_PRODUCT_CODE     = RARCH-THEODORE
+	APP_UNIQUE_ID        = 0xBAC2E
+
+else ifeq ($(LIBRETRO), 2048)
+	APP_TITLE            = 2048
+	APP_PRODUCT_CODE     = RARCH-2048
+	APP_UNIQUE_ID        = 0xBAC2F
+
+else ifeq ($(LIBRETRO), mu)
+	APP_TITLE            = Mu Libretro
+	APP_PRODUCT_CODE     = RARCH-MU
+	APP_UNIQUE_ID        = 0xBAC30
 
 endif

--- a/pkg/ctr/Makefile.cores
+++ b/pkg/ctr/Makefile.cores
@@ -298,6 +298,6 @@ else ifeq ($(LIBRETRO), theodore)
 else ifeq ($(LIBRETRO), mu)
 	APP_TITLE            = Mu Palm Emulator
 	APP_PRODUCT_CODE     = RARCH-MU
-	APP_UNIQUE_ID        = 0xBAC30
+	APP_UNIQUE_ID        = 0xBAC2F
 
 endif

--- a/pkg/ctr/Makefile.cores
+++ b/pkg/ctr/Makefile.cores
@@ -295,11 +295,6 @@ else ifeq ($(LIBRETRO), theodore)
 	APP_PRODUCT_CODE     = RARCH-THEODORE
 	APP_UNIQUE_ID        = 0xBAC2E
 
-else ifeq ($(LIBRETRO), 2048)
-	APP_TITLE            = 2048
-	APP_PRODUCT_CODE     = RARCH-2048
-	APP_UNIQUE_ID        = 0xBAC2F
-
 else ifeq ($(LIBRETRO), mu)
 	APP_TITLE            = Mu Palm Emulator
 	APP_PRODUCT_CODE     = RARCH-MU

--- a/pkg/ctr/Makefile.cores
+++ b/pkg/ctr/Makefile.cores
@@ -283,7 +283,7 @@ else ifeq ($(LIBRETRO), stella)
 	APP_BANNER           = pkg/ctr/assets/stella_banner.png
 
 else ifeq ($(LIBRETRO), pokemini)
-	APP_TITLE            = PokeMini Libretro
+	APP_TITLE            = PokeMini
 	APP_AUTHOR           = justburn
 	APP_PRODUCT_CODE     = RARCH-POKEMINI
 	APP_UNIQUE_ID        = 0xBAC20
@@ -291,7 +291,7 @@ else ifeq ($(LIBRETRO), pokemini)
 	APP_BANNER           = pkg/ctr/assets/pokemini_banner.png
 
 else ifeq ($(LIBRETRO), theodore)
-	APP_TITLE            = Theodore Libretro
+	APP_TITLE            = Theodore
 	APP_PRODUCT_CODE     = RARCH-THEODORE
 	APP_UNIQUE_ID        = 0xBAC2E
 
@@ -301,7 +301,7 @@ else ifeq ($(LIBRETRO), 2048)
 	APP_UNIQUE_ID        = 0xBAC2F
 
 else ifeq ($(LIBRETRO), mu)
-	APP_TITLE            = Mu Libretro
+	APP_TITLE            = Mu Palm Emulator
 	APP_PRODUCT_CODE     = RARCH-MU
 	APP_UNIQUE_ID        = 0xBAC30
 


### PR DESCRIPTION
## Description

Adds unique IDs to prevent 3DS cores overwriting each other.

- mu_libretro.cia
- theodore_libretro.cia

Until now, 
- Theodore is default core (overwriting retroarch_3ds)
- running Mu would get the Theodore core

## Related Pull Requests

Previous pull requests to fix the same issue when it happened in the past:

https://github.com/libretro/RetroArch/pull/5567
https://github.com/libretro/RetroArch/pull/6630

## Reviewers

cc @twinaphex

## Notes

I will create new artwork banners and icons for these new cores when I have time.