### PR TITLE
qb: Fix the HAVE_OPENGLES check.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -409,11 +409,7 @@ if [ "$HAVE_EGL" = "yes" ]; then
          add_define MAKEFILE OPENGLES_LIBS "$OPENGLES_LIBS"
          add_define MAKEFILE OPENGLES_CFLAGS "$OPENGLES_CFLAGS"
       else
-         HAVE_OPENGLES=auto; check_pkgconf OPENGLES "$VC_PREFIX"glesv2
-         if [ "$HAVE_OPENGLES" = "no" ]; then
-            HAVE_OPENGLES=auto; check_lib '' OPENGLES "-l${VC_PREFIX}GLESv2 $EXTRA_GL_LIBS"
-            add_define MAKEFILE OPENGLES_LIBS "-l${VC_PREFIX}GLESv2 $EXTRA_GL_LIBS"
-         fi
+         check_val '' OPENGLES "-l${VC_PREFIX}GLESv2 $EXTRA_GL_LIBS" '' "${VC_PREFIX}glesv2" '' '' true
       fi
    fi
    check_val '' VG "-l${VC_PREFIX}OpenVG $EXTRA_GL_LIBS" '' "${VC_PREFIX}vg" '' '' false

--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -154,6 +154,7 @@ check_lib()
 # $2 = package ['package' or 'package package1 package2', $1 = name]
 # $3 = version [checked only if non-empty]
 # $4 = critical error message [checked only if non-empty]
+# $5 = force check_lib when true [checked only if non-empty, set by check_val]
 check_pkgconf()
 {	tmpval="$(eval "printf %s \"\$HAVE_$1\"")"
 	eval "TMP_$1=\$tmpval"
@@ -175,6 +176,7 @@ check_pkgconf()
 	val="$1"
 	ver="${3:-0.0}"
 	err="${4:-}"
+	lib="${5:-}"
 	answer='no'
 	version='no'
 
@@ -199,6 +201,7 @@ check_pkgconf()
 	eval "HAVE_$val=\"$answer\""
 
 	if [ "$answer" = 'no' ]; then
+		[ "$lib" != 'true' ] || return 0
 		[ "$err" ] && die 1 "$err"
 		setval="$(eval "printf %s \"\$USER_$val\"")"
 		if [ "$setval" = 'yes' ]; then
@@ -303,13 +306,13 @@ check_switch()
 # $7 = critical error message [checked only if non-empty]
 # $8 = force check_lib when true [checked only if non-empty]
 check_val()
-{	check_pkgconf "$2" "$5" "${6:-}" "${7:-}"
+{	check_pkgconf "$2" "$5" "${6:-}" "${7:-}" "${8:-}"
 	[ "$PKG_CONF_PATH" = "none" ] || [ "${8:-}" = true ] || return 0
 	tmpval="$(eval "printf %s \"\$HAVE_$2\"")"
 	oldval="$(eval "printf %s \"\$TMP_$2\"")"
 	if [ "$tmpval" = 'no' ] && [ "$oldval" != 'no' ]; then
 		eval "HAVE_$2=auto"
-		check_lib "$1" "$2" "$3" '' '' '' "$4" ''
+		check_lib "$1" "$2" "$3" '' '' '' "${4:-}" "${7:-}"
 	fi
 }
 


### PR DESCRIPTION
## Description

I accidentally broke a rather hacky way to check `HAVE_OPENGLES` on arm linux so this patch fixes that and make the logic less likely to break again in the future.

## Related Issues

Fixes https://github.com/libretro/RetroArch/issues/8274.

## Related Pull Requests

I suspect it started in PR https://github.com/libretro/RetroArch/pull/8247.
