### PR TITLE
xmb: Prevent crashes when resizing to a tiny window.

### DIFF
--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -3156,7 +3156,7 @@ static void xmb_render(void *data, bool is_idle)
 
    scale_factor = (settings->uints.menu_xmb_scale_factor * (float)width) / (1920.0 * 100);
 
-   if (scale_factor != xmb->previous_scale_factor)
+   if (scale_factor >= 0.1f && scale_factor != xmb->previous_scale_factor)
       xmb_context_reset_internal(xmb, video_driver_is_threaded(),
             false);
 


### PR DESCRIPTION
## Description

After commit https://github.com/libretro/RetroArch/commit/c9bb537cdd33736c800a4c9ed30f8ead33bf4369 if the user resized their RetroArch window while using xmb it would initiate a context_reset to scale xmb. When the window is too small this would result in invalid pointers and a crash in the video driver.

This makes it so that when the window is too small it will skip the context_reset and not crash. The window at this size is not really useful to scale anyways.

## Related Issues

Fixes https://github.com/libretro/RetroArch/issues/8260.
```
Thread 1 "retroarch" received signal SIGABRT, Aborted.
0x00007ffff478f22b in raise () from /lib64/libc.so.6
(gdb) bt
#0  0x00007ffff478f22b in raise () from /lib64/libc.so.6
#1  0x00007ffff4771524 in abort () from /lib64/libc.so.6
#2  0x00007ffff47d65b6 in __libc_message () from /lib64/libc.so.6
#3  0x00007ffff47dd25a in malloc_printerr () from /lib64/libc.so.6
#4  0x00007ffff47e0dc4 in _int_malloc () from /lib64/libc.so.6
#5  0x00007ffff47e37b1 in calloc () from /lib64/libc.so.6
#6  0x00007fffef321a12 in ?? () from /usr/lib64/xorg/modules/dri/radeonsi_dri.so
#7  0x00007fffef2d5399 in ?? () from /usr/lib64/xorg/modules/dri/radeonsi_dri.so
#8  0x00007fffef3335c1 in ?? () from /usr/lib64/xorg/modules/dri/radeonsi_dri.so
#9  0x00007fffef050f97 in ?? () from /usr/lib64/xorg/modules/dri/radeonsi_dri.so
#10 0x00007fffeeef97e7 in ?? () from /usr/lib64/xorg/modules/dri/radeonsi_dri.so
#11 0x00007fffeeefa428 in ?? () from /usr/lib64/xorg/modules/dri/radeonsi_dri.so
#12 0x00007fffeee59766 in ?? () from /usr/lib64/xorg/modules/dri/radeonsi_dri.so
#13 0x00007fffeee59c70 in ?? () from /usr/lib64/xorg/modules/dri/radeonsi_dri.so
#14 0x00000000006858ee in gl_raster_font_upload_atlas (font=0x168ce30)
    at gfx/drivers_font/gl_raster_font.c:163
#15 0x0000000000685a49 in gl_raster_font_init_font (data=0xba5f50,
    font_path=0x7fffffffbcd0 "/usr/share/games/retroarch/assets/xmb/monochrome/font.ttf", font_size=1.6500001, is_threaded=false)
    at gfx/drivers_font/gl_raster_font.c:202
#16 0x00000000004b6000 in gl_font_init_first (font_driver=0x7fffffffbc18,
    font_handle=0x7fffffffbc10, video_data=0xba5f50,
    font_path=0x7fffffffbcd0 "/usr/share/games/retroarch/assets/xmb/monochrome/font.ttf", font_size=1.6500001, is_threaded=false) at gfx/font_driver.c:172
#17 0x00000000004b60bd in font_init_first (font_driver=0x7fffffffbc18,
    font_handle=0x7fffffffbc10, video_data=0xba5f50,
    font_path=0x7fffffffbcd0 "/usr/share/games/retroarch/assets/xmb/monochrome/font.ttf", font_size=1.6500001, api=FONT_DRIVER_RENDER_OPENGL_API,
    is_threaded=false) at gfx/font_driver.c:662
#18 0x00000000004b6ac9 in font_driver_init_first (video_data=0xba5f50,
    font_path=0x7fffffffbcd0 "/usr/share/games/retroarch/assets/xmb/monochrome/font.ttf", font_size=1.6500001, threading_hint=true, is_threaded=false,
    api=FONT_DRIVER_RENDER_OPENGL_API) at gfx/font_driver.c:1086
#19 0x0000000000687982 in menu_display_gl_font_init_first (
    font_handle=0x7fffffffbc98, video_data=0xba5f50,
    font_path=0x7fffffffbcd0 "/usr/share/games/retroarch/assets/xmb/monochrome/font.ttf", menu_font_size=1.6500001, is_threaded=false)
    at menu/drivers_display/menu_display_gl.c:240
#20 0x00000000005df471 in menu_display_font_file (
    fontpath=0x7fffffffbcd0 "/usr/share/games/retroarch/assets/xmb/monochrome/font.ttf", menu_font_size=1.6500001, is_threaded=false) at menu/menu_driver.c:478
#21 0x00000000005df409 in menu_display_font (
    type=APPLICATION_SPECIAL_DIRECTORY_ASSETS_XMB_FONT,
    menu_font_size=1.6500001, is_threaded=false) at menu/menu_driver.c:468
#22 0x00000000005d16e3 in xmb_context_reset_internal (xmb=0x1430c00,
    is_threaded=false, reinit_textures=false) at menu/drivers/xmb.c:5077
#23 0x00000000005cb448 in xmb_render (data=0x1430c00, is_idle=false)
    at menu/drivers/xmb.c:3160
#24 0x00000000005e4214 in menu_driver_render (is_idle=false,
    rarch_is_inited=true, rarch_is_dummy_core=true) at menu/menu_driver.c:1959
#25 0x0000000000418cc6 in runloop_check_state (settings=0x7ffff0137010,
    input_nonblock_state=false, runloop_is_paused=false, fastforward_ratio=5,
    sleep_ms=0x7fffffffe0f0) at retroarch.c:2997
#26 0x0000000000419fe9 in runloop_iterate (sleep_ms=0x7fffffffe0f0)
    at retroarch.c:3706
#27 0x00000000004127ec in rarch_main (argc=1, argv=0x7fffffffe208, data=0x0)
    at frontend/frontend.c:156
#28 0x0000000000412849 in main (argc=1, argv=0x7fffffffe208)
    at frontend/frontend.c:184
```

## Reviewers

@twinaphex Does this look okay to you?