### PR TITLE
More menu widgets changes

### DIFF
--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -167,8 +167,6 @@ typedef struct materialui_handle
    float textures_arrow_alpha;
    float categories_x_pos;
 
-   uint64_t frame_count;
-
    char *box_message;
 
    char menu_title[255];
@@ -936,7 +934,6 @@ static void materialui_render_menu_list(
    float sum                               = 0;
    size_t entries_end                      = 0;
    file_list_t *list                       = NULL;
-   uint64_t frame_count                    = mui->frame_count;
    unsigned header_height                  =
       menu_display_get_header_height();
 
@@ -987,7 +984,7 @@ static void materialui_render_menu_list(
             y,
             width,
             height,
-            frame_count / 20,
+            menu_animation_get_ticker_idx(),
             font_hover_color,
             entry_selected,
             rich_label,
@@ -1178,8 +1175,6 @@ static void materialui_frame(void *data, video_frame_info_t *video_info)
    ticker.spacer = ticker_spacer;
 
    usable_width                    = width - (mui->margin * 2);
-
-   mui->frame_count++;
 
    msg[0] = title_buf[0] = title_msg[0] = '\0';
 
@@ -1532,7 +1527,7 @@ static void materialui_frame(void *data, video_frame_info_t *video_info)
 
    ticker.s        = title_buf;
    ticker.len      = ticker_limit;
-   ticker.idx      = mui->frame_count / 100;
+   ticker.idx      = menu_animation_get_ticker_slow_idx();
    ticker.str      = mui->menu_title;
    ticker.selected = true;
 
@@ -1554,7 +1549,7 @@ static void materialui_frame(void *data, video_frame_info_t *video_info)
 
       ticker.s        = title_buf_msg_tmp;
       ticker.len      = ticker_limit;
-      ticker.idx      = mui->frame_count / 20;
+      ticker.idx      = menu_animation_get_ticker_idx();
       ticker.str      = title_buf_msg;
       ticker.selected = true;
 
@@ -1810,7 +1805,7 @@ static void materialui_navigation_set(void *data, bool scroll)
    if (!mui || !scroll)
       return;
 
-   entry.duration     = 10;
+   entry.duration     = 166;
    entry.target_value = scroll_pos;
    entry.subject      = &mui->scroll_y;
    entry.easing_enum  = EASING_IN_OUT_QUAD;

--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -482,7 +482,6 @@ static void ozone_context_reset(void *data, bool is_threaded)
       ozone_context_reset_horizontal_list(ozone);
 
       /* State reset */
-      ozone->frame_count                  = 0;
       ozone->fade_direction               = false;
       ozone->cursor_in_sidebar            = false;
       ozone->cursor_in_sidebar_old        = false;
@@ -862,7 +861,7 @@ static void ozone_draw_header(ozone_handle_t *ozone, video_frame_info_t *video_i
    /* Title */
    ticker.s = title;
    ticker.len = (video_info->width - 128 - 47 - 130) / ozone->title_font_glyph_width;
-   ticker.idx = ozone->frame_count / 20;
+   ticker.idx = menu_animation_get_ticker_idx();
    ticker.str = ozone->title;
    ticker.selected = true;
 
@@ -1100,8 +1099,6 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
 
       last_use_preferred_system_color_theme = settings->bools.menu_use_preferred_system_color_theme;
    }
-
-   ozone->frame_count++;
 
    menu_display_set_viewport(video_info->width, video_info->height);
 

--- a/menu/drivers/ozone/ozone.h
+++ b/menu/drivers/ozone/ozone.h
@@ -27,9 +27,9 @@ typedef struct ozone_handle ozone_handle_t;
 #include "../../menu_driver.h"
 #include "../../../retroarch.h"
 
-#define ANIMATION_PUSH_ENTRY_DURATION  10
-#define ANIMATION_CURSOR_DURATION      8
-#define ANIMATION_CURSOR_PULSE         30
+#define ANIMATION_PUSH_ENTRY_DURATION  166
+#define ANIMATION_CURSOR_DURATION      133
+#define ANIMATION_CURSOR_PULSE         500
 
 #define FONT_SIZE_FOOTER            18
 #define FONT_SIZE_TITLE             36
@@ -64,8 +64,6 @@ typedef struct ozone_handle ozone_handle_t;
 
 struct ozone_handle
 {
-   uint64_t frame_count;
-
    struct
    {
       font_data_t *footer;

--- a/menu/drivers/ozone/ozone_display.c
+++ b/menu/drivers/ozone/ozone_display.c
@@ -107,9 +107,6 @@ void ozone_draw_text(
       uint32_t color,
       bool draw_outside)
 {
-   if ((color & 0x000000FF) == 0)
-      return;
-
    menu_display_draw_text(font, str, x, y,
          width, height, color, text_align, 1.0f,
          false,

--- a/menu/drivers/ozone/ozone_entries.c
+++ b/menu/drivers/ozone/ozone_entries.c
@@ -442,7 +442,7 @@ border_iterate:
       /* Prepare text */
       entry_rich_label = menu_entry_get_rich_label(&entry);
 
-      ticker.idx      = ozone->frame_count / 20;
+      ticker.idx      = menu_animation_get_ticker_idx();
       ticker.s        = rich_label;
       ticker.str      = entry_rich_label;
       ticker.selected = entry_selected && !ozone->cursor_in_sidebar;
@@ -518,7 +518,7 @@ border_iterate:
             y + ozone->dimensions.entry_height + 1 + 5 + FONT_SIZE_ENTRIES_SUBLABEL + scroll_y, TEXT_ALIGN_LEFT, video_info->width, video_info->height, ozone->fonts.entries_sublabel, COLOR_TEXT_ALPHA(ozone->theme->text_sublabel_rgba, alpha_uint32), false);
 
       /* Value */
-      ticker.idx      = ozone->frame_count / 20;
+      ticker.idx      = menu_animation_get_ticker_idx();
       ticker.s        = entry_value_ticker;
       ticker.str      = entry_value;
       ticker.selected = entry_selected && !ozone->cursor_in_sidebar;

--- a/menu/drivers/ozone/ozone_sidebar.c
+++ b/menu/drivers/ozone/ozone_sidebar.c
@@ -226,7 +226,7 @@ void ozone_draw_sidebar(ozone_handle_t *ozone, video_frame_info_t *video_info)
 
 
          /* Text */
-         ticker.idx        = ozone->frame_count / 20;
+         ticker.idx        = menu_animation_get_ticker_idx();
          ticker.len        = (entry_width - ozone->dimensions.sidebar_entry_icon_size - 35) / ozone->sidebar_font_glyph_width;
          ticker.s          = console_title;
          ticker.selected   = selected;

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -411,7 +411,6 @@ typedef struct
    bool mouse_show;
    unsigned last_width;
    unsigned last_height;
-   unsigned frame_count;
    bool bg_thickness;
    bool border_thickness;
    float scroll_y;
@@ -1457,8 +1456,6 @@ static void rgui_frame(void *data, video_frame_info_t *video_info)
          prepare_rgui_colors(rgui, settings);
       }
    }
-
-   rgui->frame_count++;
 }
 
 static void rgui_render(void *data, bool is_idle)
@@ -1473,7 +1470,6 @@ static void rgui_render(void *data, bool is_idle)
    bool msg_force                 = false;
    settings_t *settings           = config_get_ptr();
    rgui_t *rgui                   = (rgui_t*)data;
-   uint64_t frame_count           = rgui->frame_count;
 
    static bool display_kb         = false;
    bool current_display_cb        = false;
@@ -1589,7 +1585,7 @@ static void rgui_render(void *data, bool is_idle)
 
    /* We use a single ticker for all text animations,
     * with the following configuration: */
-   ticker.idx = frame_count / RGUI_TERM_START_X(fb_width);
+   ticker.idx = menu_animation_get_ticker_idx();
    ticker.type_enum = settings->uints.menu_ticker_type;
    ticker.spacer = ticker_spacer;
 

--- a/menu/drivers/stripes.c
+++ b/menu/drivers/stripes.c
@@ -69,7 +69,7 @@
 #define STRIPES_RIBBON_VERTICES 2*STRIPES_RIBBON_COLS*STRIPES_RIBBON_ROWS-2*STRIPES_RIBBON_COLS
 
 #ifndef STRIPES_DELAY
-#define STRIPES_DELAY 10
+#define STRIPES_DELAY 166
 #endif
 
 #define BATTERY_LEVEL_CHECK_INTERVAL (30 * 1000000)
@@ -248,8 +248,6 @@ typedef struct stripes_handle
    float categories_active_zoom;
    float categories_active_alpha;
    float categories_active_width;
-
-   uint64_t frame_count;
 
    char title_name[255];
    char *box_message;
@@ -2323,7 +2321,6 @@ static int stripes_draw_item(
       float *color,
       const char *thumb_ident,
       const char *left_thumb_ident,
-      uint64_t frame_count,
       size_t i,
       size_t current,
       unsigned width,
@@ -2455,7 +2452,7 @@ static int stripes_draw_item(
 
    ticker.s        = tmp;
    ticker.len      = ticker_limit;
-   ticker.idx      = frame_count / 20;
+   ticker.idx      = menu_animation_get_ticker_idx();
    ticker.str      = ticker_str;
    ticker.selected = (i == current);
 
@@ -2491,7 +2488,7 @@ static int stripes_draw_item(
 
    ticker.s        = tmp;
    ticker.len      = 35 * stripes_scale_mod[7];
-   ticker.idx      = frame_count / 20;
+   ticker.idx      = menu_animation_get_ticker_idx();
    ticker.selected = (i == current);
 
    if (!string_is_empty(entry->value))
@@ -2592,7 +2589,6 @@ static void stripes_draw_items(
    menu_display_ctx_rotate_draw_t rotate_draw;
    stripes_node_t *core_node       = NULL;
    size_t end                  = 0;
-   uint64_t frame_count        = stripes ? stripes->frame_count : 0;
    const char *thumb_ident     = stripes_thumbnails_ident('R');
    const char *left_thumb_ident= stripes_thumbnails_ident('L');
 
@@ -2645,7 +2641,6 @@ static void stripes_draw_items(
             &mymat,
             stripes, core_node,
             list, color, thumb_ident, left_thumb_ident,
-            frame_count,
             i, current,
             width, height);
       menu_entry_free(&entry);
@@ -2827,8 +2822,6 @@ static void stripes_frame(void *data, video_frame_info_t *video_info)
 
    scale_factor                            = (settings->uints.menu_xmb_scale_factor * (float)width) / (1920.0 * 100);
    pseudo_font_length                      = stripes->icon_spacing_horizontal * 4 - stripes->icon_size / 4;
-
-   stripes->frame_count++;
 
    msg[0]             = '\0';
    title_msg[0]       = '\0';

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -71,7 +71,7 @@
 #define XMB_RIBBON_VERTICES 2*XMB_RIBBON_COLS*XMB_RIBBON_ROWS-2*XMB_RIBBON_COLS
 
 #ifndef XMB_DELAY
-#define XMB_DELAY 10
+#define XMB_DELAY 166
 #endif
 
 #define BATTERY_LEVEL_CHECK_INTERVAL (30 * 1000000)
@@ -303,8 +303,6 @@ typedef struct xmb_handle
    float categories_passive_zoom;
    float categories_active_zoom;
    float categories_active_alpha;
-
-   uint64_t frame_count;
 
    char title_name[255];
    char *box_message;
@@ -2796,7 +2794,6 @@ static int xmb_draw_item(
       float *color,
       const char *thumb_ident,
       const char *left_thumb_ident,
-      uint64_t frame_count,
       size_t i,
       size_t current,
       unsigned width,
@@ -2931,7 +2928,7 @@ static int xmb_draw_item(
 
    ticker.s        = tmp;
    ticker.len      = ticker_limit;
-   ticker.idx      = frame_count / 20;
+   ticker.idx      = menu_animation_get_ticker_idx();
    ticker.str      = ticker_str;
    ticker.selected = (i == current);
 
@@ -2967,7 +2964,7 @@ static int xmb_draw_item(
 
    ticker.s        = tmp;
    ticker.len      = 35 * scale_mod[7];
-   ticker.idx      = frame_count / 20;
+   ticker.idx      = menu_animation_get_ticker_idx();
    ticker.selected = (i == current);
 
    if (!string_is_empty(entry->value))
@@ -3078,7 +3075,6 @@ static void xmb_draw_items(
    menu_display_ctx_rotate_draw_t rotate_draw;
    xmb_node_t *core_node       = NULL;
    size_t end                  = 0;
-   uint64_t frame_count        = xmb->frame_count;
    const char *thumb_ident     = xmb_thumbnails_ident('R');
    const char *left_thumb_ident= xmb_thumbnails_ident('L');
 
@@ -3131,7 +3127,6 @@ static void xmb_draw_items(
             &mymat,
             xmb, core_node,
             list, color, thumb_ident, left_thumb_ident,
-            frame_count,
             i, current,
             width, height);
       menu_entry_free(&entry);
@@ -3397,8 +3392,6 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
 
    scale_factor                            = (settings->uints.menu_xmb_scale_factor * (float)width) / (1920.0 * 100);
    pseudo_font_length                      = xmb->icon_spacing_horizontal * 4 - xmb->icon_size / 4;
-
-   xmb->frame_count++;
 
    msg[0]             = '\0';
    title_msg[0]       = '\0';

--- a/menu/drivers/xui.cpp
+++ b/menu/drivers/xui.cpp
@@ -69,7 +69,6 @@ HXUIOBJ m_back;
 HXUIOBJ root_menu;
 HXUIOBJ current_menu;
 static msg_queue_t *xui_msg_queue = NULL;
-static uint64_t xui_frame_count   = 0;
 
 class CRetroArch : public CXuiModule
 {
@@ -366,8 +365,6 @@ static void xui_free(void *data)
    (void)data;
    app.Uninit();
 
-   xui_frame_count = 0;
-
    if (xui_msg_queue)
       msg_queue_free(xui_msg_queue);
 }
@@ -421,8 +418,6 @@ static void xui_frame(void *data, video_frame_info_t *video_info)
 
    if (!d3d)
       return;
-
-   xui_frame_count++;
 
    menu_display_set_viewport(video_info->width, video_info->height);
 
@@ -544,7 +539,6 @@ static void xui_render(void *data, bool is_idle)
    const char *dir             = NULL;
    const char *label           = NULL;
    unsigned menu_type          = 0;
-   uint64_t frame_count        = xui_frame_count;
    bool              msg_force = menu_display_get_msg_force();
    settings_t *settings        = config_get_ptr();
 
@@ -577,7 +571,7 @@ static void xui_render(void *data, bool is_idle)
 
 	  ticker.s        = title;
 	  ticker.len      = RXUI_TERM_WIDTH(fb_width) - 3;
-	  ticker.idx      = (unsigned int)frame_count / 15;
+	  ticker.idx      = menu_animation_get_ticker_idx();
 	  ticker.str      = title;
 	  ticker.selected = true;
 

--- a/menu/menu_animation.h
+++ b/menu/menu_animation.h
@@ -94,12 +94,6 @@ enum menu_animation_ticker_type
    TICKER_TYPE_LAST
 };
 
-typedef struct menu_animation_ctx_delta
-{
-   float current;
-   float ideal;
-} menu_animation_ctx_delta_t;
-
 typedef uintptr_t menu_animation_ctx_tag;
 
 typedef struct menu_animation_ctx_subject
@@ -153,13 +147,11 @@ void menu_animation_init(void);
 
 void menu_animation_free(void);
 
-bool menu_animation_update(float delta_time);
-
-void menu_animation_get_time(menu_animation_ctx_delta_t *delta);
+bool menu_animation_update(void);
 
 bool menu_animation_ticker(const menu_animation_ctx_ticker_t *ticker);
 
-void menu_animation_update_time(bool timedate_enable);
+float menu_animation_get_delta_time(void);
 
 bool menu_animation_is_active(void);
 
@@ -172,6 +164,10 @@ bool menu_animation_push(menu_animation_ctx_entry_t *entry);
 void menu_animation_push_delayed(unsigned delay, menu_animation_ctx_entry_t *entry);
 
 bool menu_animation_ctl(enum menu_animation_ctl_state state, void *data);
+
+uint64_t menu_animation_get_ticker_idx(void);
+
+uint64_t menu_animation_get_ticker_slow_idx(void);
 
 RETRO_END_DECLS
 

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -1955,9 +1955,6 @@ bool menu_driver_render(bool is_idle, bool rarch_is_inited,
 
    if (BIT64_GET(menu_driver_data->state, MENU_STATE_BLIT))
    {
-      settings_t *settings = config_get_ptr();
-      menu_animation_update_time(settings->bools.menu_timedate_enable);
-
       if (menu_driver_ctx->render)
          menu_driver_ctx->render(menu_userdata, is_idle);
    }

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -1588,10 +1588,13 @@ void menu_display_draw_text(
 {
    struct font_params params;
 
+   if ((color & 0x000000FF) == 0)
+      return;
+
    /* Don't draw outside of the screen */
-   if (     ((x < -64 || x > width  + 64)
+   if (!draw_outside &&
+           ((x < -64 || x > width  + 64)
          || (y < -64 || y > height + 64))
-         && !draw_outside
       )
       return;
 

--- a/menu/menu_input.c
+++ b/menu/menu_input.c
@@ -162,7 +162,6 @@ void menu_event_kb_set(bool down, enum retro_key key)
  */
 unsigned menu_event(input_bits_t *p_input, input_bits_t *p_trigger_input)
 {
-   menu_animation_ctx_delta_t delta;
    /* Used for key repeat */
    static float delay_timer                = 0.0f;
    static float delay_count                = 0.0f;
@@ -198,7 +197,7 @@ unsigned menu_event(input_bits_t *p_input, input_bits_t *p_trigger_input)
           * for old_input_state. */
 
          first_held  = true;
-         delay_timer = initial_held ? 12 : 6;
+         delay_timer = initial_held ? 200 : 100;
          delay_count = 0;
       }
 
@@ -235,8 +234,7 @@ unsigned menu_event(input_bits_t *p_input, input_bits_t *p_trigger_input)
       menu_driver_ctl(MENU_NAVIGATION_CTL_SET_SCROLL_ACCEL,
             &new_scroll_accel);
 
-   menu_animation_get_time(&delta);
-   delay_count += delta.ideal;
+   delay_count += menu_animation_get_delta_time();
 
    if (menu_input_dialog_get_display_kb())
    {

--- a/retroarch.c
+++ b/retroarch.c
@@ -2732,7 +2732,6 @@ static enum runloop_state runloop_check_state(
    bool rarch_is_initialized        = rarch_ctl(RARCH_CTL_IS_INITED, NULL);
    bool fs_toggle_triggered         = false;
 #ifdef HAVE_MENU
-   menu_animation_ctx_delta_t delta;
    bool menu_driver_binding_state   = menu_driver_is_binding_state();
    bool menu_is_alive               = menu_driver_is_alive();
    unsigned menu_toggle_gamepad_combo = settings->uints.input_menu_toggle_gamepad_combo;
@@ -2920,8 +2919,7 @@ static enum runloop_state runloop_check_state(
    }
 
 #if defined(HAVE_MENU)
-   menu_animation_get_time(&delta);
-   menu_animation_update(delta.ideal);
+   menu_animation_update();
 
    if (menu_is_alive)
    {


### PR DESCRIPTION
_Baby steps_

- menu animation unit was changed to milliseconds instead of 60ths of seconds
- menu animations are now untied to the runloop speed and will run constantly whatever the FPS are
- tickers were changed to use their own timer, unit is also milliseconds
- menu display now doesn't draw text if alpha is 0

This PR has been tested on Linux, OSX, Android and Switch.