### PR TITLE
(Ozone) Use more attractive 'spacer' string for looping menu ticker text

### DIFF
--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -847,7 +847,7 @@ static void ozone_draw_header(ozone_handle_t *ozone, video_frame_info_t *video_i
 {
    char title[255];
    menu_animation_ctx_ticker_t ticker;
-   static const char ticker_spacer[] = "   |   ";
+   static const char ticker_spacer[] = "\u2003\u2022\u2003"; /* <EM SPACE><BULLET><EM SPACE> */
    settings_t *settings     = config_get_ptr();
    unsigned timedate_offset = 0;
 

--- a/menu/drivers/ozone/ozone_entries.c
+++ b/menu/drivers/ozone/ozone_entries.c
@@ -408,7 +408,7 @@ border_iterate:
       menu_texture_item tex;
       menu_entry_t entry;
       menu_animation_ctx_ticker_t ticker;
-      static const char ticker_spacer[] = "   |   ";
+      static const char ticker_spacer[] = "\u2003\u2022\u2003"; /* <EM SPACE><BULLET><EM SPACE> */
       char entry_value[255];
       char rich_label[255];
       char entry_value_ticker[255];

--- a/menu/drivers/ozone/ozone_sidebar.c
+++ b/menu/drivers/ozone/ozone_sidebar.c
@@ -109,7 +109,7 @@ void ozone_draw_sidebar(ozone_handle_t *ozone, video_frame_info_t *video_info)
    unsigned i, sidebar_height;
    char console_title[255];
    menu_animation_ctx_ticker_t ticker;
-   static const char ticker_spacer[] = "   |   ";
+   static const char ticker_spacer[] = "\u2003\u2022\u2003"; /* <EM SPACE><BULLET><EM SPACE> */
    settings_t *settings = config_get_ptr();
 
    /* Initial ticker configuration */


### PR DESCRIPTION
## Description

Ozone uses a fixed font with good UTF-8 coverage, so it has considerable leeway when it comes to displaying 'special' characters. This tiny PR just replaces the current string used as padding for looping ticker text with something more aesthetically pleasing (a round bullet sandwiched between two fixed-width spaces).

(Note: I would do the same for XMB, but the font there is theme-dependent and UTF-8 coverage isn't consistent, so it's tricky to find characters that will always display correctly...)