### PR TITLE
use "Playlist" rather than "Collection" in UI strings

### DIFF
--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -591,7 +591,7 @@ MSG_HASH(
     )
 MSG_HASH(
     MENU_ENUM_LABEL_VALUE_CONTENT_COLLECTION_LIST,
-    "Collections"
+    "Playlists"
     )
 MSG_HASH(
     MENU_ENUM_LABEL_VALUE_CONTENT_DATABASE_DIRECTORY,
@@ -2078,7 +2078,7 @@ MSG_HASH(
     )
 MSG_HASH(
     MENU_ENUM_LABEL_VALUE_PLAYLIST_DIRECTORY,
-    "Playlist"
+    "Playlists"
     )
 MSG_HASH(
     MENU_ENUM_LABEL_VALUE_PLAYLIST_SETTINGS,
@@ -5101,7 +5101,7 @@ MSG_HASH(
     )
 MSG_HASH(
     MENU_ENUM_LABEL_VALUE_SELECT_FROM_COLLECTION,
-    "Select From Collection"
+    "Select from a playlist"
     )
 MSG_HASH(
     MENU_ENUM_LABEL_VALUE_FILTER,
@@ -5685,11 +5685,11 @@ MSG_HASH(
     )
 MSG_HASH(
     MENU_ENUM_SUBLABEL_SCAN_DIRECTORY,
-    "Scans a directory for compatible files and add them to the collection."
+    "Scans a directory for compatible content. If found, content is added to playlists."
     )
 MSG_HASH(
     MENU_ENUM_SUBLABEL_SCAN_FILE,
-    "Scans a compatible file and add it to the collection."
+    "Scans a file for compatible content. If found, content is added to playlists."
     )
 MSG_HASH(
     MENU_ENUM_SUBLABEL_VIDEO_SWAP_INTERVAL,
@@ -5725,7 +5725,7 @@ MSG_HASH(
     )
 MSG_HASH(
     MENU_ENUM_SUBLABEL_DELETE_ENTRY,
-    "Remove this entry from the collection."
+    "Remove this entry from the playlist."
     )
 MSG_HASH(
     MENU_ENUM_SUBLABEL_INFORMATION,
@@ -5869,7 +5869,7 @@ MSG_HASH(
     )
 MSG_HASH(
     MENU_ENUM_SUBLABEL_PLAYLIST_ENTRY_REMOVE,
-    "Allow the user to remove entries from collections."
+    "Allow the user to remove entries from playlists."
     )
 MSG_HASH(
     MENU_ENUM_SUBLABEL_SYSTEM_DIRECTORY,
@@ -6039,7 +6039,7 @@ MSG_HASH(
     )
 MSG_HASH(
     MENU_ENUM_SUBLABEL_PLAYLIST_DIRECTORY,
-    "Save all collections to this directory."
+    "Save all playlists to this directory."
     )
 MSG_HASH(
     MENU_ENUM_SUBLABEL_CACHE_DIRECTORY,
@@ -6363,7 +6363,7 @@ MSG_HASH(
     )
 MSG_HASH(
     MENU_ENUM_SUBLABEL_PLAYLIST_ENTRY_RENAME,
-    "Allow the user to rename entries in collections."
+    "Allow the user to rename entries in playlists."
     )
 MSG_HASH(
     MENU_ENUM_LABEL_VALUE_PLAYLIST_ENTRY_RENAME,
@@ -6674,11 +6674,11 @@ MSG_HASH(
     )
 MSG_HASH(
     MENU_ENUM_LABEL_VALUE_AUTOMATICALLY_ADD_CONTENT_TO_PLAYLIST,
-    "Automatically add content to playlist"
+    "Automatically add content to playlists"
     )
 MSG_HASH(
     MENU_ENUM_SUBLABEL_AUTOMATICALLY_ADD_CONTENT_TO_PLAYLIST,
-    "Automatically scans loaded content so they appear inside playlists."
+    "Automatically scans loaded content with the playlist scanner."
     )
 MSG_HASH(
     MSG_SCANNING_OF_FILE_FINISHED,


### PR DESCRIPTION
At the moment, there is a blend of using "Playlist" and "Collection" throughout RA.

My informal assessment is that the majority of RA code and UI strings refer to "Playlist", while almost 100% of the documentation and discussion in the forums and discord uses "Playlist".

Because developers and users almost exclusively refer to this feature as Playlists in English -- and because word is simple, common, and accurate -- I suggest that "Playlist" be the standard term in RA.