### PR TITLE
Fix CXX_BUILD.

### DIFF
--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -754,7 +754,7 @@ static void materialui_render_label_value(
    settings_t *settings            = config_get_ptr();
 
    /* Initial ticker configuration */
-   ticker.type_enum = settings->uints.menu_ticker_type;
+   ticker.type_enum = (menu_animation_ticker_type)settings->uints.menu_ticker_type;
    ticker.spacer = ticker_spacer;
 
    label_str[0] = value_str[0]     = '\0';
@@ -1171,7 +1171,7 @@ static void materialui_frame(void *data, video_frame_info_t *video_info)
       return;
 
    /* Initial ticker configuration */
-   ticker.type_enum = settings->uints.menu_ticker_type;
+   ticker.type_enum = (menu_animation_ticker_type)settings->uints.menu_ticker_type;
    ticker.spacer = ticker_spacer;
 
    usable_width                    = width - (mui->margin * 2);

--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -852,7 +852,7 @@ static void ozone_draw_header(ozone_handle_t *ozone, video_frame_info_t *video_i
    unsigned timedate_offset = 0;
 
    /* Initial ticker configuration */
-   ticker.type_enum = settings->uints.menu_ticker_type;
+   ticker.type_enum = (menu_animation_ticker_type)settings->uints.menu_ticker_type;
    ticker.spacer = ticker_spacer;
 
    /* Separator */

--- a/menu/drivers/ozone/ozone_entries.c
+++ b/menu/drivers/ozone/ozone_entries.c
@@ -420,7 +420,7 @@ border_iterate:
       float *icon_color       = NULL;
 
       /* Initial ticker configuration */
-      ticker.type_enum = settings->uints.menu_ticker_type;
+      ticker.type_enum = (menu_animation_ticker_type)settings->uints.menu_ticker_type;
       ticker.spacer = ticker_spacer;
 
       entry_value[0]         = '\0';

--- a/menu/drivers/ozone/ozone_sidebar.c
+++ b/menu/drivers/ozone/ozone_sidebar.c
@@ -113,7 +113,7 @@ void ozone_draw_sidebar(ozone_handle_t *ozone, video_frame_info_t *video_info)
    settings_t *settings = config_get_ptr();
 
    /* Initial ticker configuration */
-   ticker.type_enum = settings->uints.menu_ticker_type;
+   ticker.type_enum = (menu_animation_ticker_type)settings->uints.menu_ticker_type;
    ticker.spacer = ticker_spacer;
 
    unsigned selection_y          = 0;

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -1586,7 +1586,7 @@ static void rgui_render(void *data, bool is_idle)
    /* We use a single ticker for all text animations,
     * with the following configuration: */
    ticker.idx = menu_animation_get_ticker_idx();
-   ticker.type_enum = settings->uints.menu_ticker_type;
+   ticker.type_enum = (menu_animation_ticker_type)settings->uints.menu_ticker_type;
    ticker.spacer = ticker_spacer;
 
    /* If thumbnails are enabled and we are viewing a playlist,

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -2815,7 +2815,7 @@ static int xmb_draw_item(
    settings_t *settings              = config_get_ptr();
 
    /* Initial ticker configuration */
-   ticker.type_enum = settings->uints.menu_ticker_type;
+   ticker.type_enum = (menu_animation_ticker_type)settings->uints.menu_ticker_type;
    ticker.spacer = ticker_spacer;
 
    if (!node)


### PR DESCRIPTION
## Description

Fixes `CXX_BUILD=1`.

## Related Issues

```
menu/drivers/rgui.c: In function ‘void rgui_render(void*, bool)’:
menu/drivers/rgui.c:1589:39: error: invalid conversion from ‘unsigned int’ to ‘menu_animation_ticker_type’ [-fpermissive]
    ticker.type_enum = settings->uints.menu_ticker_type;
                       ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
make: *** [Makefile:201: obj-unix/release/menu/drivers/rgui.o] Error 1
make: *** Waiting for unfinished jobs....
menu/drivers/materialui.c: In function ‘void materialui_render_label_value(materialui_handle_t*, video_frame_info_t*, materialui_node_t*, int, int, unsigned int, unsigned int, uint64_t, uint32_t, bool, const char*, const char*, float*, uint32_t)’:
menu/drivers/materialui.c:757:39: error: invalid conversion from ‘unsigned int’ to ‘menu_animation_ticker_type’ [-fpermissive]
    ticker.type_enum = settings->uints.menu_ticker_type;
                       ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
menu/drivers/materialui.c: In function ‘void materialui_frame(void*, video_frame_info_t*)’:
menu/drivers/materialui.c:1174:39: error: invalid conversion from ‘unsigned int’ to ‘menu_animation_ticker_type’ [-fpermissive]
    ticker.type_enum = settings->uints.menu_ticker_type;
                       ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
make: *** [Makefile:201: obj-unix/release/menu/drivers/materialui.o] Error 1
menu/drivers/xmb.c: In function ‘int xmb_draw_item(video_frame_info_t*, menu_entry_t*, math_matrix_4x4*, xmb_handle_t*, xmb_node_t*, file_list_t*, float*, const char*, const char*, size_t, size_t, unsigned int, unsigned int)’:
menu/drivers/xmb.c:2818:39: error: invalid conversion from ‘unsigned int’ to ‘menu_animation_ticker_type’ [-fpermissive]
    ticker.type_enum = settings->uints.menu_ticker_type;
                       ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
make: *** [Makefile:199: obj-unix/release/menu/drivers/xmb.o] Error 1
```

## Reviewers

@jdgleaver Does this look right to you?
