### PR TITLE
Replace UCN identifiers with UTF-8 byte arrays

### DIFF
--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -847,7 +847,7 @@ static void ozone_draw_header(ozone_handle_t *ozone, video_frame_info_t *video_i
 {
    char title[255];
    menu_animation_ctx_ticker_t ticker;
-   static const char ticker_spacer[] = "\u2003\u2022\u2003"; /* <EM SPACE><BULLET><EM SPACE> */
+   static const char* const ticker_spacer = TICKER_SPACER;
    settings_t *settings     = config_get_ptr();
    unsigned timedate_offset = 0;
 

--- a/menu/drivers/ozone/ozone.h
+++ b/menu/drivers/ozone/ozone.h
@@ -62,6 +62,15 @@ typedef struct ozone_handle ozone_handle_t;
 #define INTERVAL_BATTERY_LEVEL_CHECK   (30 * 1000000)
 #define INTERVAL_OSK_CURSOR            (0.5f * 1000000)
 
+#if defined(__APPLE__)
+/* UTF-8 support is currently broken on Apple devices... */
+#define TICKER_SPACER "   |   "
+#else
+/* <EM SPACE><BULLET><EM SPACE>
+ * UCN equivalent: "\u2003\u2022\u2003" */
+#define TICKER_SPACER "\xE2\x80\x83\xE2\x80\xA2\xE2\x80\x83"
+#endif
+
 struct ozone_handle
 {
    struct

--- a/menu/drivers/ozone/ozone_entries.c
+++ b/menu/drivers/ozone/ozone_entries.c
@@ -408,7 +408,7 @@ border_iterate:
       menu_texture_item tex;
       menu_entry_t entry;
       menu_animation_ctx_ticker_t ticker;
-      static const char ticker_spacer[] = "\u2003\u2022\u2003"; /* <EM SPACE><BULLET><EM SPACE> */
+      static const char* const ticker_spacer = TICKER_SPACER;
       char entry_value[255];
       char rich_label[255];
       char entry_value_ticker[255];

--- a/menu/drivers/ozone/ozone_sidebar.c
+++ b/menu/drivers/ozone/ozone_sidebar.c
@@ -110,7 +110,7 @@ void ozone_draw_sidebar(ozone_handle_t *ozone, video_frame_info_t *video_info)
    unsigned i, sidebar_height, selection_y, selection_old_y, horizontal_list_size;
    char console_title[255];
    menu_animation_ctx_ticker_t ticker;
-   static const char ticker_spacer[] = "\u2003\u2022\u2003"; /* <EM SPACE><BULLET><EM SPACE> */
+   static const char* const ticker_spacer = TICKER_SPACER;
    settings_t *settings = config_get_ptr();
 
    /* Initial ticker configuration */

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -2696,7 +2696,18 @@ void hex32_to_rgba_normalized(uint32_t hex, float* rgba, float alpha)
 void menu_subsystem_populate(const struct retro_subsystem_info* subsystem, menu_displaylist_info_t *info)
 {
    settings_t *settings = config_get_ptr();
-   char star_char[8];
+   /* Note: Create this string here explicitly (rather than
+    * using a #define elsewhere) since we need to be aware of
+    * its length... */
+#if defined(__APPLE__)
+   /* UTF-8 support is currently broken on Apple devices... */
+   static const char utf8_star_char[] = "*";
+#else
+   /* <BLACK STAR>
+    * UCN equivalent: "\u2605" */
+   static const char utf8_star_char[] = "\xE2\x98\x85";
+#endif
+   char star_char[16];
    unsigned i = 0;
    int n = 0;
    bool is_rgui = string_is_equal(settings->arrays.menu_driver, "rgui");
@@ -2704,7 +2715,7 @@ void menu_subsystem_populate(const struct retro_subsystem_info* subsystem, menu_
    /* Select approriate 'star' marker for subsystem menu entries
     * (i.e. RGUI does not support unicode, so use a 'standard'
     * character fallback) */
-   snprintf(star_char, sizeof(star_char), "%s", is_rgui ? "*" : "\u2605");
+   snprintf(star_char, sizeof(star_char), "%s", is_rgui ? "*" : utf8_star_char);
    
    if (subsystem && subsystem_current_count > 0)
    {


### PR DESCRIPTION
## Description

As reported in the comments thread of PR #8291, the use of Universal Character Name (UCN) identifiers in strings is not supported by all compilers, and generates warnings with gcc.

This PR replaces the known instances of UCNs with UTF-8 byte arrays, which do not have this problem.

It also provides an ASCII fallback for Apple devices, since these currently have broken UTF-8 support (issue #7602).

(Note that this should probably be revisited at some point - see the comments thread of PR #8291 for details)

## Related Issues

#7602

## Related Pull Requests

 #8291

## Reviewers

@orbea This should fix the warnings
