### PR TITLE
font driver: expose line height

### DIFF
--- a/gfx/drivers_font/ctr_font.c
+++ b/gfx/drivers_font/ctr_font.c
@@ -446,6 +446,16 @@ static const struct font_glyph* ctr_font_get_glyph(
    return font->font_driver->get_glyph((void*)font->font_driver, code);
 }
 
+static int ctr_font_get_line_height(void *data)
+{
+   ctr_font_t* font = (ctr_font_t*)data;
+
+   if (!font || !font->font_driver || !font->font_data)
+      return -1;
+
+   return font->font_driver->get_line_height(font->font_data);
+}
+
 font_renderer_t ctr_font =
 {
    ctr_font_init_font,
@@ -456,4 +466,5 @@ font_renderer_t ctr_font =
    NULL,                         /* bind_block */
    NULL,                         /* flush_block */
    ctr_font_get_message_width,
+   ctr_font_get_line_height
 };

--- a/gfx/drivers_font/d3d10_font.c
+++ b/gfx/drivers_font/d3d10_font.c
@@ -362,6 +362,16 @@ static const struct font_glyph* d3d10_font_get_glyph(void *data, uint32_t code)
    return font->font_driver->get_glyph((void*)font->font_driver, code);
 }
 
+static int d3d10_font_get_line_height(void *data)
+{
+   d3d10_font_t* font = (d3d10_font_t*)data;
+
+   if (!font || !font->font_driver || !font->font_data)
+      return -1;
+
+   return font->font_driver->get_line_height(font->font_data);
+}
+
 font_renderer_t d3d10_font = {
    d3d10_font_init_font,
    d3d10_font_free_font,
@@ -371,4 +381,5 @@ font_renderer_t d3d10_font = {
    NULL, /* bind_block */
    NULL, /* flush */
    d3d10_font_get_message_width,
+   d3d10_font_get_line_height
 };

--- a/gfx/drivers_font/d3d11_font.c
+++ b/gfx/drivers_font/d3d11_font.c
@@ -359,6 +359,16 @@ static const struct font_glyph* d3d11_font_get_glyph(void *data, uint32_t code)
    return font->font_driver->get_glyph((void*)font->font_driver, code);
 }
 
+static int d3d11_font_get_line_height(void *data)
+{
+   d3d11_font_t* font = (d3d11_font_t*)data;
+
+   if (!font || !font->font_driver || !font->font_data)
+      return -1;
+
+   return font->font_driver->get_line_height(font->font_data);
+}
+
 font_renderer_t d3d11_font = {
    d3d11_font_init_font,
    d3d11_font_free_font,
@@ -368,4 +378,5 @@ font_renderer_t d3d11_font = {
    NULL, /* bind_block */
    NULL, /* flush */
    d3d11_font_get_message_width,
+   d3d11_font_get_line_height
 };

--- a/gfx/drivers_font/d3d12_font.c
+++ b/gfx/drivers_font/d3d12_font.c
@@ -376,6 +376,16 @@ static const struct font_glyph* d3d12_font_get_glyph(
    return font->font_driver->get_glyph((void*)font->font_driver, code);
 }
 
+static int d3d12_font_get_line_height(void *data)
+{
+   d3d12_font_t* font = (d3d12_font_t*)data;
+
+   if (!font || !font->font_driver || !font->font_data)
+      return -1;
+
+   return font->font_driver->get_line_height(font->font_data);
+}
+
 font_renderer_t d3d12_font = {
    d3d12_font_init_font,
    d3d12_font_free_font,
@@ -385,4 +395,5 @@ font_renderer_t d3d12_font = {
    NULL, /* bind_block */
    NULL, /* flush */
    d3d12_font_get_message_width,
+   d3d12_font_get_line_height
 };

--- a/gfx/drivers_font/gl1_raster_font.c
+++ b/gfx/drivers_font/gl1_raster_font.c
@@ -560,6 +560,17 @@ static void gl1_raster_font_bind_block(void *data, void *userdata)
       font->block = block;
 }
 
+
+static int gl1_get_line_height(void *data)
+{
+   gl1_raster_t *font = (gl1_raster_t*)data;
+
+   if (!font || !font->font_driver || !font->font_data)
+      return -1;
+
+   return font->font_driver->get_line_height(font->font_data);
+}
+
 font_renderer_t gl1_raster_font = {
    gl1_raster_font_init_font,
    gl1_raster_font_free_font,
@@ -568,5 +579,6 @@ font_renderer_t gl1_raster_font = {
    gl1_raster_font_get_glyph,
    gl1_raster_font_bind_block,
    gl1_raster_font_flush_block,
-   gl1_get_message_width
+   gl1_get_message_width,
+   gl1_get_line_height
 };

--- a/gfx/drivers_font/gl_raster_font.c
+++ b/gfx/drivers_font/gl_raster_font.c
@@ -549,6 +549,16 @@ static void gl_raster_font_bind_block(void *data, void *userdata)
       font->block = block;
 }
 
+static int gl_get_line_height(void *data)
+{
+   gl_raster_t *font   = (gl_raster_t*)data;
+
+   if (!font || !font->font_driver || !font->font_data)
+      return -1;
+
+   return font->font_driver->get_line_height(font->font_data);
+}
+
 font_renderer_t gl_raster_font = {
    gl_raster_font_init_font,
    gl_raster_font_free_font,
@@ -557,5 +567,6 @@ font_renderer_t gl_raster_font = {
    gl_raster_font_get_glyph,
    gl_raster_font_bind_block,
    gl_raster_font_flush_block,
-   gl_get_message_width
+   gl_get_message_width,
+   gl_get_line_height
 };

--- a/gfx/drivers_font/switch_font.c
+++ b/gfx/drivers_font/switch_font.c
@@ -341,6 +341,15 @@ static void switch_font_bind_block(void *data, void *userdata)
       (void)data;
 }
 
+static int switch_font_get_line_height(void *data)
+{
+      switch_font_t *font = (switch_font_t *)data;
+      if (!font || !font->font_driver || !font->font_data)
+      return -1;
+
+      return font->font_driver->get_line_height(font->font_data);
+}
+
 font_renderer_t switch_font =
     {
         switch_font_init_font,
@@ -351,4 +360,5 @@ font_renderer_t switch_font =
         switch_font_bind_block,
         NULL, /* flush_block */
         switch_font_get_message_width,
+        switch_font_get_line_height
 };

--- a/gfx/drivers_font/vita2d_font.c
+++ b/gfx/drivers_font/vita2d_font.c
@@ -347,6 +347,16 @@ static const struct font_glyph *vita2d_font_get_glyph(
    return font->font_driver->get_glyph((void*)font->font_driver, code);
 }
 
+static int vita2d_font_get_line_height(void *data)
+{
+   vita_font_t *font = (vita_font_t*)data;
+
+   if (!font || !font->font_driver || !font->font_data)
+      return -1;
+
+   return font->font_driver->get_line_height(font->font_data);
+}
+
 font_renderer_t vita2d_vita_font = {
    vita2d_font_init_font,
    vita2d_font_free_font,
@@ -356,4 +366,5 @@ font_renderer_t vita2d_vita_font = {
    NULL,                      /* bind_block */
    NULL,                      /* flush */
    vita2d_font_get_message_width,
+   vita2d_font_get_line_height
 };

--- a/gfx/drivers_font/vulkan_raster_font.c
+++ b/gfx/drivers_font/vulkan_raster_font.c
@@ -435,6 +435,16 @@ static const struct font_glyph *vulkan_raster_font_get_glyph(
    return glyph;
 }
 
+static int vulkan_get_line_height(void *data)
+{
+   vulkan_raster_t *font = (vulkan_raster_t*)data;
+
+   if (!font || !font->font_driver || !font->font_data)
+      return -1;
+
+   return font->font_driver->get_line_height(font->font_data);
+}
+
 font_renderer_t vulkan_raster_font = {
    vulkan_raster_font_init_font,
    vulkan_raster_font_free_font,
@@ -443,5 +453,6 @@ font_renderer_t vulkan_raster_font = {
    vulkan_raster_font_get_glyph,
    NULL,                            /* bind_block */
    NULL,                            /* flush_block */
-   vulkan_get_message_width
+   vulkan_get_message_width,
+   vulkan_get_line_height
 };

--- a/gfx/drivers_font/wiiu_font.c
+++ b/gfx/drivers_font/wiiu_font.c
@@ -374,6 +374,16 @@ static const struct font_glyph* wiiu_font_get_glyph(
    return font->font_driver->get_glyph((void*)font->font_driver, code);
 }
 
+static int wiiu_font_get_line_height(void *data)
+{
+   wiiu_font_t* font = (wiiu_font_t*)data;
+
+   if (!font || !font->font_driver || !font->font_data)
+      return -1;
+
+   return font->font_driver->get_line_height(font->font_data);
+}
+
 font_renderer_t wiiu_font =
 {
    wiiu_font_init_font,
@@ -384,4 +394,5 @@ font_renderer_t wiiu_font =
    NULL,                   /* bind_block */
    NULL,                   /* flush */
    wiiu_font_get_message_width,
+   wiiu_font_get_line_height
 };

--- a/gfx/font_driver.c
+++ b/gfx/font_driver.c
@@ -1043,6 +1043,20 @@ int font_driver_get_message_width(void *font_data,
    return -1;
 }
 
+int font_driver_get_line_height(void *font_data, float scale)
+{
+   font_data_t *font = (font_data_t*)(font_data ? font_data : video_font_driver);
+   int line_height;
+
+   /* First try the line height implementation */
+   if (font && font->renderer && font->renderer->get_line_height)
+      if ((line_height = font->renderer->get_line_height(font->renderer_data)) != -1)
+         return line_height * round(scale);
+
+   /* Else return an approximation (width of 'a') */
+   return font_driver_get_message_width(font_data, "a", 1, scale);
+}
+
 void font_driver_free(void *font_data)
 {
    font_data_t *font = (font_data_t*)font_data;

--- a/gfx/font_driver.h
+++ b/gfx/font_driver.h
@@ -96,6 +96,7 @@ typedef struct font_renderer
          video_frame_info_t *video_info);
 
    int (*get_message_width)(void *data, const char *msg, unsigned msg_len_full, float scale);
+   int (*get_line_height)(void* data);
 } font_renderer_t;
 
 typedef struct font_renderer_driver
@@ -155,6 +156,8 @@ void font_driver_init_osd(
       bool is_threaded,
       enum font_driver_render_api api);
 void font_driver_free_osd(void);
+
+int font_driver_get_line_height(void *font_data, float scale);
 
 extern font_renderer_t gl_raster_font;
 extern font_renderer_t gl1_raster_font;


### PR DESCRIPTION
This exposes `get_line_height` of font drivers so that menu drivers / menu widgets can use the font metrics for more accurate drawing.

If `get_line_height` isn't available for the current font renderer, it will return the width of the character `a` instead (as an approximation), or `-1` if message width isn't implemented either.

I implemented it on the following font drivers:
- ctr
- d3d10
- d3d11
- d3d12
- gl1
- gl
- switch
- vita2d
- vulkan
- wiiu

The following font drivers can have it implemented but I didn't do it because I didn't know how:
- metal (it uses an obj-c class instead of the regular struct and I don't have the courage to write obj-c right now)
- d3d9 (it uses an entirely different font renderer it seems?)