### PR TITLE
Fix stall-out causing total disconnection with >2 players

### DIFF
--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -500,16 +500,23 @@ static bool netplay_poll(void)
          /* Stalled out! */
          if (netplay_data->is_server)
          {
+            bool fixed = false;
             for (i = 0; i < netplay_data->connections_size; i++)
             {
                struct netplay_connection *connection = &netplay_data->connections[i];
                if (connection->active &&
                    connection->mode == NETPLAY_CONNECTION_PLAYING &&
-                   connection->stall &&
-                   now - connection->stall_time >= MAX_SERVER_STALL_TIME_USEC)
+                   connection->stall)
                {
                   netplay_hangup(netplay_data, connection);
+                  fixed = true;
                }
+            }
+
+            if (fixed) {
+               /* Not stalled now :) */
+               netplay_data->stall = NETPLAY_STALL_NONE;
+               return true;
             }
          }
          else

--- a/network/netplay/netplay_init.c
+++ b/network/netplay/netplay_init.c
@@ -376,8 +376,9 @@ static bool netplay_init_buffers(netplay_t *netplay)
 {
    struct delta_frame *delta_frames = NULL;
 
-   /* Enough to get ahead or behind by MAX_STALL_FRAMES frames */
-   netplay->buffer_size = NETPLAY_MAX_STALL_FRAMES + 1;
+   /* Enough to get ahead or behind by MAX_STALL_FRAMES frames, plus one for
+    * other remote clients, plus one to send the stall message */
+   netplay->buffer_size = NETPLAY_MAX_STALL_FRAMES + 2;
 
    /* If we're the server, we need enough to get ahead AND behind by
     * MAX_STALL_FRAMES frame */


### PR DESCRIPTION
## Description

There was a bug which cause stall-outs by one player to disconnect _all_ players in netplay. I believe this is a bug that has been reported under other guises by users who didn't realize what exactly was happening. In short, there was an off-by-one error which prevented the other clients from ever receiving the disconnection notification from the client who was causing the stall, causing them to continue stalling even if the server was free to go, which would then cascade to a total collapse. One line fix. Bleh. (I also fixed an extremely minor bug by which the server pointlessly stalled one extra frame when the stall is resolved)

## Related Issues

Probably some!