### PR TITLE
(RGUI) Improve playlist titles

### DIFF
--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -2364,15 +2364,29 @@ static void rgui_populate_entries(void *data,
       const char *path,
       const char *label, unsigned k)
 {
+   bool title_set = false;
    rgui_t *rgui = (rgui_t*)data;
    
    if (!rgui)
       return;
    
-   menu_entries_get_title(rgui->menu_title, sizeof(rgui->menu_title));
-   
    /* Check whether we are currently viewing a playlist */
    rgui->is_playlist = string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_PLAYLIST_LIST));
+   
+   /* Set menu title */
+   if (rgui->is_playlist)
+   {
+      if (!string_is_empty(rgui->thumbnail_system))
+      {
+         /* Note: rgui->thumbnail_system is *always* the basename (without
+          * extension) of the currently loaded playlist */
+         memcpy(rgui->menu_title, rgui->thumbnail_system, sizeof(rgui->menu_title));
+         title_set = true;
+      }
+   }
+   
+   if (!title_set)
+      menu_entries_get_title(rgui->menu_title, sizeof(rgui->menu_title));
    
    rgui_navigation_set(data, true);
 }


### PR DESCRIPTION
## Description

When viewing a playlist from the 'Collections' menu, the playlist title is currently shown as `SELECT FILE CURRENT/PLAYLIST/DIRECTORY/PLAYLIST_FILE.LPL`. I don't think there is anything inherently wrong with this (on XMB/Ozone it looks okay), but when using RGUI the title text field is rather narrow. Making the playlist titles unnecessarily long therefore just serves to clutter the display, and means that titles always have to ticker-scroll through a mostly irrelevant stream of characters.

This tiny PR tweaks RGUI such that the menu title when viewing playlists is the playlist *name*. For example:

**Before:**

![screenshot_2019-02-18_10-27-14](https://user-images.githubusercontent.com/38211560/52946223-717c4e80-336b-11e9-8d94-ab2208ffc968.png)

**After:**

![screenshot_2019-02-18_10-32-17](https://user-images.githubusercontent.com/38211560/52946232-78a35c80-336b-11e9-9ad8-4adc97572872.png)

This is far cleaner.

(Note: If anyone would prefer that I change these playlist titles 'globally', so it affects XMB/Ozone/etc., please let me know...)
