### PR TITLE
(RGUI) Sanitise menu sublabels

### DIFF
--- a/menu/cbs/menu_cbs_sublabel.c
+++ b/menu/cbs/menu_cbs_sublabel.c
@@ -776,7 +776,9 @@ static int action_bind_sublabel_netplay_room(
          {
             strlcat(buf, "   ", sizeof(buf));
             strlcat(buf, list->elems[i].data, sizeof(buf));
-            strlcat(buf, "\n", sizeof(buf));
+            /* Never terminate a UI string with a newline */
+            if (i != list->size - 1)
+               strlcat(buf, "\n", sizeof(buf));
          }
          snprintf(s, len,
             "RetroArch: %s (%s)\nCore: %s (%s)\nSubsystem: %s\nGames:\n%s",


### PR DESCRIPTION
## Description

A handful of menu sublabels are formatted on multiple lines, sometimes with leading spaces to serve as indentation. This is fine for XMB, Ozone, etc., but RGUI only has a single line for displaying sublabels. Newline characters get rendered as spaces so all text is shown, but lines essentially bleed together and sometimes have unsightly gaps.

This PR sanitises all RGUI sublabels such that unnecessary whitespace is removed, and newlines are replaced with the same delimiter used for looping ticker text. Examples:

![rgui_multiline_sublabel](https://user-images.githubusercontent.com/38211560/53012615-6395fe80-343b-11e9-981f-138125404c50.gif)

![rgui_multiline_sublabel2](https://user-images.githubusercontent.com/38211560/53012634-73adde00-343b-11e9-9320-9f8f3b134c88.gif)

(It's only a small change, but it'll also be useful for the upcoming playlist sublabel feature...)