### PR TITLE
Improve menu titles (collections, playlists, database info)

### DIFF
--- a/menu/cbs/menu_cbs_title.c
+++ b/menu/cbs/menu_cbs_title.c
@@ -91,6 +91,13 @@ static int action_get_title_mixer_stream_actions(const char *path, const char *l
    return 0;
 }
 
+static int action_get_title_deferred_playlist_list(const char *path, const char *label, unsigned menu_type, char *s, size_t len)
+{
+   if (!string_is_empty(path))
+      fill_pathname_base_noext(s, path, len);
+   return 0;
+}
+
 default_title_macro(action_get_quick_menu_override_options,     MENU_ENUM_LABEL_VALUE_QUICK_MENU_OVERRIDE_OPTIONS)
 default_title_macro(action_get_user_accounts_cheevos_list,      MENU_ENUM_LABEL_VALUE_ACCOUNTS_RETRO_ACHIEVEMENTS)
 default_title_macro(action_get_user_accounts_youtube_list,      MENU_ENUM_LABEL_VALUE_ACCOUNTS_YOUTUBE)
@@ -165,6 +172,7 @@ default_title_macro(action_get_title_goto_favorites,            MENU_ENUM_LABEL_
 default_title_macro(action_get_title_goto_image,                MENU_ENUM_LABEL_VALUE_GOTO_IMAGES)
 default_title_macro(action_get_title_goto_music,                MENU_ENUM_LABEL_VALUE_GOTO_MUSIC)
 default_title_macro(action_get_title_goto_video,                MENU_ENUM_LABEL_VALUE_GOTO_VIDEO)
+default_title_macro(action_get_title_collection,                MENU_ENUM_LABEL_VALUE_CONTENT_COLLECTION_LIST)
 
 default_fill_title_macro(action_get_title_disk_image_append,    MENU_ENUM_LABEL_VALUE_DISK_IMAGE_APPEND)
 default_fill_title_macro(action_get_title_cheat_file_load,      MENU_ENUM_LABEL_VALUE_CHEAT_FILE)
@@ -204,7 +212,6 @@ default_fill_title_macro(action_get_title_assets_directory,       MENU_ENUM_LABE
 default_fill_title_macro(action_get_title_extraction_directory,   MENU_ENUM_LABEL_VALUE_CACHE_DIRECTORY)
 default_fill_title_macro(action_get_title_menu,                   MENU_ENUM_LABEL_VALUE_MENU_SETTINGS)
 default_fill_title_macro(action_get_title_font_path,              MENU_ENUM_LABEL_VALUE_XMB_FONT)
-default_fill_title_macro(action_get_title_collection,             MENU_ENUM_LABEL_VALUE_SELECT_FROM_COLLECTION)
 
 default_title_copy_macro(action_get_title_help,                   MENU_ENUM_LABEL_VALUE_HELP_LIST)
 default_title_copy_macro(action_get_title_input_settings,         MENU_ENUM_LABEL_VALUE_INPUT_SETTINGS)
@@ -629,9 +636,6 @@ static int menu_cbs_init_bind_title_compare_label(menu_file_list_cbs_t *cbs,
          case MENU_ENUM_LABEL_DEFERRED_CURSOR_MANAGER_LIST_RDB_ENTRY_MAX_USERS:
             BIND_ACTION_GET_TITLE(cbs, action_get_title_list_rdb_entry_max_users);
             break;
-         case MENU_ENUM_LABEL_DEFERRED_RDB_ENTRY_DETAIL:
-            BIND_ACTION_GET_TITLE(cbs, action_get_title_list_rdb_entry_database_info);
-            break;
          case MENU_ENUM_LABEL_DEFERRED_CORE_LIST:
             BIND_ACTION_GET_TITLE(cbs, action_get_title_deferred_core_list);
             break;
@@ -961,9 +965,6 @@ static int menu_cbs_init_bind_title_compare_label(menu_file_list_cbs_t *cbs,
          case MENU_LABEL_DEFERRED_CURSOR_MANAGER_LIST_RDB_ENTRY_MAX_USERS:
             BIND_ACTION_GET_TITLE(cbs, action_get_title_list_rdb_entry_max_users);
             break;
-         case MENU_LABEL_DEFERRED_RDB_ENTRY_DETAIL:
-            BIND_ACTION_GET_TITLE(cbs, action_get_title_list_rdb_entry_database_info);
-            break;
          case MENU_LABEL_DEFERRED_CORE_LIST:
             BIND_ACTION_GET_TITLE(cbs, action_get_title_deferred_core_list);
             break;
@@ -1280,6 +1281,16 @@ int menu_cbs_init_bind_title(menu_file_list_cbs_t *cbs,
    if (string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_RPL_ENTRY_ACTIONS)))
    {
       BIND_ACTION_GET_TITLE(cbs, action_get_quick_menu_views_settings_list);
+      return 0;
+   }
+   if (string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_PLAYLIST_LIST)))
+   {
+      BIND_ACTION_GET_TITLE(cbs, action_get_title_deferred_playlist_list);
+      return 0;
+   }
+   if (strstr(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_RDB_ENTRY_DETAIL)))
+   {
+      BIND_ACTION_GET_TITLE(cbs, action_get_title_list_rdb_entry_database_info);
       return 0;
    }
 

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -2399,7 +2399,6 @@ static void rgui_populate_entries(void *data,
       const char *path,
       const char *label, unsigned k)
 {
-   bool title_set = false;
    rgui_t *rgui = (rgui_t*)data;
    
    if (!rgui)
@@ -2409,19 +2408,7 @@ static void rgui_populate_entries(void *data,
    rgui->is_playlist = string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_PLAYLIST_LIST));
    
    /* Set menu title */
-   if (rgui->is_playlist)
-   {
-      if (!string_is_empty(rgui->thumbnail_system))
-      {
-         /* Note: rgui->thumbnail_system is *always* the basename (without
-          * extension) of the currently loaded playlist */
-         memcpy(rgui->menu_title, rgui->thumbnail_system, sizeof(rgui->menu_title));
-         title_set = true;
-      }
-   }
-   
-   if (!title_set)
-      menu_entries_get_title(rgui->menu_title, sizeof(rgui->menu_title));
+   menu_entries_get_title(rgui->menu_title, sizeof(rgui->menu_title));
    
    rgui_navigation_set(data, true);
 }


### PR DESCRIPTION
## Description

Following on from PR #8314, this makes the playlist title change 'global' and also improves/fixes two other menu titles. This is the complete list, with screenshots: (I'm using XMB here since it has the longest title field)

### Playlists:

*Before:*

![screenshot_2019-02-19_17-07-21](https://user-images.githubusercontent.com/38211560/53033897-0b2a2580-346a-11e9-8cd5-49e5328f5d5d.png)

*After:*

![screenshot_2019-02-19_17-08-58](https://user-images.githubusercontent.com/38211560/53033930-1a10d800-346a-11e9-8d7c-6cf3be42c817.png)

### Collections:

*Before:*

![screenshot_2019-02-19_17-06-58](https://user-images.githubusercontent.com/38211560/53033958-2c8b1180-346a-11e9-9bf4-0b267d8bebd1.png)

*After:*

![screenshot_2019-02-19_17-08-45](https://user-images.githubusercontent.com/38211560/53033980-344ab600-346a-11e9-813b-03e0f99fd1ff.png)

### Database info

This one was actually a bug fix. Since the label for database entries resolves as `deferred_rdb_entry_detail|<entry_name>`, the usual title bind checks were failing (they only test for `deferred_rdb_entry_detail`). So database entries have always had the wrong title!

*Before:*

![screenshot_2019-02-19_17-07-42](https://user-images.githubusercontent.com/38211560/53034229-aa4f1d00-346a-11e9-9c03-63f0539c50eb.png)

*After:*

![screenshot_2019-02-19_17-09-14](https://user-images.githubusercontent.com/38211560/53034243-b044fe00-346a-11e9-89f2-8e8a577f3549.png)

These changes benefit RGUI the most (due to the limited width of title text fields, anything that shortens titles is good), but I think it improves things for all the menu drivers.

I believe that all menu titles are correctly formatted now.

## Related Pull Requests

This reverts the additon to RGUI introduced by PR #8314, since the title fix is now implemented in `menu_cbs_title.c`
