### PR TITLE
Vita: ensure the displayed time is in the local timezone

### DIFF
--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -30,6 +30,10 @@
 #include <wiiu/os/energy.h>
 #endif
 
+#ifdef VITA
+#include <psp2/rtc.h>
+#endif
+
 #ifdef HAVE_DISCORD
 #include "discord/discord.h"
 #endif
@@ -356,7 +360,17 @@ void menu_display_timedate(menu_display_ctx_datetime_t *datetime)
    if (!datetime)
       return;
 
+#ifdef VITA
+   SceRtcTick tick;
+   SceDateTime time_local;
+
+   sceRtcGetCurrentTick(&tick);
+   sceRtcConvertUtcToLocalTime(&tick, &tick);
+   sceRtcSetTick(&time_local, &tick);
+   sceRtcGetTime_t(&time_local, &time_);
+#else
    time(&time_);
+#endif
 
    setlocale(LC_TIME, "");
 


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request :white_check_mark: 
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each :white_check_mark: 
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises :white_check_mark: 

## Description

This makes the time displayed in the main menu the local time instead of the UTC time, using SDK functions because newlib's `localtime` is not aware of timezones.

The patch works (tested on a UTC+1 PS Vita) but my main concern is to know whether the code is in the right place or not.

## Related Issues

* Fixes #7632

## Reviewers

*I don't know who's the PS Vita expert dev in here :sweat_smile:*
