### PR TITLE
Content downloader: Allow for spaces (and other characters) in directory names

### DIFF
--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -3299,15 +3299,17 @@ static int generic_action_ok_network(const char *path,
       enum msg_hash_enums enum_idx)
 {
    char url_path[PATH_MAX_LENGTH];
+   char url_path_encoded[PATH_MAX_LENGTH];
    settings_t *settings           = config_get_ptr();
    unsigned type_id2              = 0;
-   file_transfer_t *transf   = NULL;
+   file_transfer_t *transf        = NULL;
    const char *url_label          = NULL;
    retro_task_callback_t callback = NULL;
    bool refresh                   = true;
    bool suppress_msg              = false;
 
-   url_path[0] = '\0';
+   url_path[0]         = '\0';
+   url_path_encoded[0] = '\0';
 
    switch (enum_idx)
    {
@@ -3376,7 +3378,8 @@ static int generic_action_ok_network(const char *path,
    transf           = (file_transfer_t*)calloc(1, sizeof(*transf));
    strlcpy(transf->path, url_path, sizeof(transf->path));
 
-   task_push_http_transfer(url_path, suppress_msg, url_label, callback, transf);
+   net_http_urlencode_full(url_path_encoded, url_path, sizeof(url_path_encoded));
+   task_push_http_transfer(url_path_encoded, suppress_msg, url_label, callback, transf);
 
    return generic_action_ok_displaylist_push(path, NULL,
          label, type, idx, entry_idx, type_id2);
@@ -3676,7 +3679,11 @@ static int action_ok_download_generic(const char *path,
    transf->enum_idx = enum_idx;
    strlcpy(transf->path, path, sizeof(transf->path));
 
-   net_http_urlencode_full(s3, s2, sizeof(s));
+   if (string_is_equal_fast(path, s, sizeof(path))) {
+      net_http_urlencode_full(s3, s, sizeof(s3));
+   } else {
+      net_http_urlencode_full(s3, s2, sizeof(s3));
+   }
 
    task_push_http_transfer(s3, suppress_msg, msg_hash_to_str(enum_idx), cb, transf);
 #endif

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -3679,11 +3679,10 @@ static int action_ok_download_generic(const char *path,
    transf->enum_idx = enum_idx;
    strlcpy(transf->path, path, sizeof(transf->path));
 
-   if (string_is_equal(path, s)) {
+   if (string_is_equal(path, s))
       net_http_urlencode_full(s3, s, sizeof(s3));
-   } else {
+   else
       net_http_urlencode_full(s3, s2, sizeof(s3));
-   }
 
    task_push_http_transfer(s3, suppress_msg, msg_hash_to_str(enum_idx), cb, transf);
 #endif

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -3679,7 +3679,7 @@ static int action_ok_download_generic(const char *path,
    transf->enum_idx = enum_idx;
    strlcpy(transf->path, path, sizeof(transf->path));
 
-   if (string_is_equal_fast(path, s, sizeof(path))) {
+   if (string_is_equal(path, s)) {
       net_http_urlencode_full(s3, s, sizeof(s3));
    } else {
       net_http_urlencode_full(s3, s2, sizeof(s3));

--- a/menu/menu_networking.c
+++ b/menu/menu_networking.c
@@ -268,9 +268,11 @@ finish:
    if (!err && !strstr(state->path, file_path_str(FILE_PATH_INDEX_DIRS_URL)))
    {
       char *parent_dir                 = (char*)malloc(PATH_MAX_LENGTH * sizeof(char));
+      char *parent_dir_encoded         = (char*)malloc(PATH_MAX_LENGTH * sizeof(char));
       file_transfer_t *transf     = NULL;
 
-      parent_dir[0] = '\0';
+      parent_dir[0]         = '\0';
+      parent_dir_encoded[0] = '\0';
 
       fill_pathname_parent_dir(parent_dir,
             state->path, PATH_MAX_LENGTH * sizeof(char));
@@ -283,10 +285,12 @@ finish:
       transf->enum_idx = MSG_UNKNOWN;
       strlcpy(transf->path, parent_dir, sizeof(transf->path));
 
-      task_push_http_transfer(parent_dir, true,
+      net_http_urlencode_full(parent_dir_encoded, parent_dir, PATH_MAX_LENGTH * sizeof(char));
+      task_push_http_transfer(parent_dir_encoded, true,
             "index_dirs", cb_net_generic_subdir, transf);
 
       free(parent_dir);
+      free(parent_dir_encoded);
    }
 
    if (state)


### PR DESCRIPTION
## Description

Fixes the issue of the content downloader not being able to load directories with spaces. 

This also fixes a malformed request in `action_ok_download_generic()`.

This should make the downloader a lot less touchy about the names of directories it has to deal with. I successfully tested this by pointing the content downloader to a local server. 

## Related Issues

Fixes #7056

## Reviewers

Since it touches some networking and menu code I'd like for @fr500 or @bparker06 to give it a look.