### PR TITLE
Fix content scanner creating false positive playlist entries

### DIFF
--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -732,6 +732,9 @@ static int database_info_list_iterate_end_no_match(
    if (db_state->crc != 0)
       db_state->crc = 0;
 
+   if (db_state->archive_crc != 0)
+      db_state->archive_crc = 0;
+
    return 0;
 }
 
@@ -857,6 +860,7 @@ static int database_info_list_iterate_found_match(
 
    db_state->info = NULL;
    db_state->crc  = 0;
+   db_state->archive_crc = 0;
 
    free(entry_path_str);
    free(db_playlist_path);


### PR DESCRIPTION
## Description

In the following circumstance the content scanner will add a false positive to a playlist:
- The first item scanned is a zip archive with a file inside, neither of which have a crc match in a rdb.
- The second item scanned is a zip archive which has a crc match in a rdb.
- The third item scanned is the file inside the first item. This is because the third item is enqueued for later scanning when the first item fails the crc match.

This results in a playlist containg entries for the first and second items, even though the first item should not have been included.

The issue occurs because:
1. The state variable `archive_crc` is not reset between the scanning of the second and the third item.
2. When the third item's `crc` is looked up in the rdb, the second item's `archive_crc` is matched, which causes the false positive:
```
tasks/task_database.c:

lines 926-928:
      snprintf(query, sizeof(query),
            "{crc:or(b\"%08X\",b\"%08X\")}",
            db_state->crc, db_state->archive_crc);

lines 944-947:
         if (db_state->archive_crc == db_info_entry->crc32)
            return database_info_list_iterate_found_match(
                  _db,
                  db_state, db, NULL);
```
In addition, in the playlist, the false positive item wrongly gets the label and crc32 of the second item.