### PR TITLE
Silence implicit declaration warning.

### DIFF
--- a/menu/menu_networking.c
+++ b/menu/menu_networking.c
@@ -27,7 +27,7 @@
 #include <string/stdstring.h>
 
 #ifdef HAVE_NETWORKING
-#include <net/net_http_parse.h>
+#include <net/net_http.h>
 #endif
 
 #include "menu_driver.h"


### PR DESCRIPTION
## Description

Warning fix...

## Related Issues

```
menu/menu_networking.c: In function ‘cb_net_generic’:
menu/menu_networking.c:288:7: warning: implicit declaration of function ‘net_http_urlencode_full’ [-Wimplicit-function-declaration]
       net_http_urlencode_full(parent_dir_encoded, parent_dir, PATH_MAX_LENGTH * sizeof(char));
       ^~~~~~~~~~~~~~~~~~~~~~~
```