### PR TITLE
Standardise and improve playlist display

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -710,9 +710,8 @@ static const bool playlist_sort_alphabetical = true;
 /* File format to use when writing playlists to disk */
 static const bool playlist_use_old_format = false;
 
-/* Show currently associated core next to each playlist entry
- * (RGUI only) */
-static const bool playlist_show_core_name = true;
+/* Always show currently associated core next to each playlist entry */
+static const bool playlist_show_core_name = false;
 
 static const bool playlist_show_sublabels = false;
 

--- a/configuration.c
+++ b/configuration.c
@@ -1501,7 +1501,6 @@ static struct config_bool_setting *populate_settings_bool(settings_t *settings, 
    SETTING_BOOL("rgui_background_filler_thickness_enable",     &settings->bools.menu_rgui_background_filler_thickness_enable, true, true, false);
    SETTING_BOOL("rgui_border_filler_thickness_enable",     &settings->bools.menu_rgui_border_filler_thickness_enable, true, true, false);
    SETTING_BOOL("rgui_border_filler_enable",     &settings->bools.menu_rgui_border_filler_enable, true, true, false);
-   SETTING_BOOL("playlist_show_core_name",     &settings->bools.playlist_show_core_name, true, playlist_show_core_name, false);
 #endif
 #ifdef HAVE_XMB
    SETTING_BOOL("xmb_shadows_enable",            &settings->bools.menu_xmb_shadows_enable, true, xmb_shadows_enable, false);
@@ -1576,7 +1575,7 @@ static struct config_bool_setting *populate_settings_bool(settings_t *settings, 
    SETTING_BOOL("playlist_use_old_format",       &settings->bools.playlist_use_old_format, true, playlist_use_old_format, false);
    SETTING_BOOL("content_runtime_log",              &settings->bools.content_runtime_log, true, content_runtime_log, false);
    SETTING_BOOL("playlist_show_sublabels",       &settings->bools.playlist_show_sublabels, true, playlist_show_sublabels, false);
-
+   SETTING_BOOL("playlist_show_core_name",       &settings->bools.playlist_show_core_name, true, playlist_show_core_name, false);
    SETTING_BOOL("playlist_sort_alphabetical",    &settings->bools.playlist_sort_alphabetical, true, playlist_sort_alphabetical, false);
 
    *size = count;

--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -8240,7 +8240,7 @@ MSG_HASH(
     )
 MSG_HASH(
     MENU_ENUM_LABEL_VALUE_PLAYLIST_SHOW_CORE_NAME,
-    "Show associated cores in playlists"
+    "Always show associated cores in playlists"
     )
 MSG_HASH(
     MENU_ENUM_SUBLABEL_PLAYLIST_SHOW_CORE_NAME,

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -9853,24 +9853,21 @@ static bool setting_append_list(
                SD_FLAG_NONE
                );
 
-         if (string_is_equal(settings->arrays.menu_driver, "rgui"))
-         {
-            CONFIG_BOOL(
-                  list, list_info,
-                  &settings->bools.playlist_show_core_name,
-                  MENU_ENUM_LABEL_PLAYLIST_SHOW_CORE_NAME,
-                  MENU_ENUM_LABEL_VALUE_PLAYLIST_SHOW_CORE_NAME,
-                  playlist_show_core_name,
-                  MENU_ENUM_LABEL_VALUE_OFF,
-                  MENU_ENUM_LABEL_VALUE_ON,
-                  &group_info,
-                  &subgroup_info,
-                  parent_group,
-                  general_write_handler,
-                  general_read_handler,
-                  SD_FLAG_NONE
-                  );
-         }
+         CONFIG_BOOL(
+               list, list_info,
+               &settings->bools.playlist_show_core_name,
+               MENU_ENUM_LABEL_PLAYLIST_SHOW_CORE_NAME,
+               MENU_ENUM_LABEL_VALUE_PLAYLIST_SHOW_CORE_NAME,
+               playlist_show_core_name,
+               MENU_ENUM_LABEL_VALUE_OFF,
+               MENU_ENUM_LABEL_VALUE_ON,
+               &group_info,
+               &subgroup_info,
+               parent_group,
+               general_write_handler,
+               general_read_handler,
+               SD_FLAG_NONE
+               );
 
          END_SUB_GROUP(list, list_info, parent_group);
 


### PR DESCRIPTION
## Description

This PR ensures that playlists are shown consistently:

- All playlists now contain the same information regardless of menu driver.

- All playlists now contain the same information regardless of whether they are accessed from a playlist 'tab' or the 'Collections' menu.

In addition, there are the following improvements:

- Associated core names are automatically hidden when playlist sublabels are enabled.

- For visual consistency, whenever content+core name is shown on a playlist entry, the same spacer is used as for looping ticker text.

Here are some specifics/screenshots (probably redundant, but might as well include them...)

### Standard playlists (non-history, non-favourites)

- By default, only the content name is shown (`Always show associated cores in playlists` `OFF` - `Show playlist sublabels` `OFF`)

![screenshot_2019-02-22_15-03-35](https://user-images.githubusercontent.com/38211560/53252728-7fa5d400-36b7-11e9-9063-d51151bf94c9.png)

![screenshot_2019-02-22_15-04-10](https://user-images.githubusercontent.com/38211560/53252733-83395b00-36b7-11e9-98ee-a455972a04e6.png)

![screenshot_2019-02-22_15-05-06](https://user-images.githubusercontent.com/38211560/53252741-86cce200-36b7-11e9-8287-e91355034fd9.png)

![screenshot_2019-02-22_15-05-31](https://user-images.githubusercontent.com/38211560/53252749-89c7d280-36b7-11e9-801c-382e1ec156e0.png)

- Core names can be added by setting `Always show associated cores in playlists` `ON` (not sure why anyone would want this, but someone might be nostalgic for the RGUI layout before PR #8307...)

![screenshot_2019-02-22_15-06-08](https://user-images.githubusercontent.com/38211560/53252886-dc08f380-36b7-11e9-8bd3-172eea7cde23.png)

![screenshot_2019-02-22_15-06-40](https://user-images.githubusercontent.com/38211560/53252893-e0cda780-36b7-11e9-9047-41c08d4410bc.png)

![screenshot_2019-02-22_15-07-05](https://user-images.githubusercontent.com/38211560/53252904-e4612e80-36b7-11e9-9c7c-1b9fdc3d99d0.png)

![screenshot_2019-02-22_15-07-30](https://user-images.githubusercontent.com/38211560/53252908-e75c1f00-36b7-11e9-8b72-6877e715bebd.png)

- Setting `Show playlist sublabels` `ON` ensures that only content is shown on the entry line:

![screenshot_2019-02-22_15-08-07](https://user-images.githubusercontent.com/38211560/53252984-1a9eae00-36b8-11e9-9d3b-f30cf0a6a484.png)

![screenshot_2019-02-22_15-08-28](https://user-images.githubusercontent.com/38211560/53252993-1e323500-36b8-11e9-8b2e-119628c9b971.png)

![screenshot_2019-02-22_15-08-51](https://user-images.githubusercontent.com/38211560/53252999-212d2580-36b8-11e9-9fcb-cb2b883776ee.png)

![screenshot_2019-02-22_15-09-13](https://user-images.githubusercontent.com/38211560/53253004-24c0ac80-36b8-11e9-8e61-70fd606cce91.png)

### History and favourites playlists

- By default, content + core name is always shown (`Show playlist sublabels` `OFF`):

![screenshot_2019-02-22_15-10-22](https://user-images.githubusercontent.com/38211560/53253101-60f40d00-36b8-11e9-863a-5b05820d5d11.png)

![screenshot_2019-02-22_15-10-46](https://user-images.githubusercontent.com/38211560/53253110-64879400-36b8-11e9-8630-a54293f26de8.png)

![screenshot_2019-02-22_15-11-10](https://user-images.githubusercontent.com/38211560/53253113-681b1b00-36b8-11e9-9678-5e8dc019527b.png)

![screenshot_2019-02-22_15-11-41](https://user-images.githubusercontent.com/38211560/53253122-6b160b80-36b8-11e9-9a1a-f4f6d0650dc8.png)

- Setting `Show playlist sublabels` `ON` ensures that only content is shown on the entry line:

![screenshot_2019-02-22_15-12-25](https://user-images.githubusercontent.com/38211560/53253197-9b5daa00-36b8-11e9-9f65-1ede99741268.png)

![screenshot_2019-02-22_15-12-53](https://user-images.githubusercontent.com/38211560/53253205-9ef13100-36b8-11e9-8b6b-0e34bb9ded48.png)

![screenshot_2019-02-22_15-13-21](https://user-images.githubusercontent.com/38211560/53253215-a1ec2180-36b8-11e9-977a-e19fb481dbb5.png)

![screenshot_2019-02-22_15-13-44](https://user-images.githubusercontent.com/38211560/53253221-a4e71200-36b8-11e9-9aad-901356efdaa6.png)

This is all very simple stuff, but it unifies the menu drivers and allows for a 'cleaner' user interface.

## Related Pull Requests

Note that this partially reverts and reworks PR #8307, since all playlist formatting is now handled 'globally' (no more special cases for RGUI).

