### PR TITLE
Couple of minor fixes

### DIFF
--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -1669,6 +1669,7 @@ static void rgui_render(void *data, bool is_idle)
          char message[255];
          char entry_title_buf[255];
          char type_str_buf[255];
+         menu_entry_t entry;
          char *entry_path                      = NULL;
          unsigned entry_spacing                = 0;
          size_t entry_title_max_len            = 0;
@@ -1687,7 +1688,6 @@ static void rgui_render(void *data, bool is_idle)
          type_str_buf[0]    = '\0';
 
          /* Get current entry */
-         menu_entry_t entry;
          menu_entry_init(&entry);
          menu_entry_get(&entry, 0, (unsigned)i, NULL, true);
 

--- a/menu/menu_animation.c
+++ b/menu/menu_animation.c
@@ -63,7 +63,7 @@ typedef struct menu_animation menu_animation_t;
 #define TICKER_SPEED       333
 #define TICKER_SLOW_SPEED  1600
 
-static const char ticker_spacer_default[] = TICKER_SPACER_DEFAULT
+static const char ticker_spacer_default[] = TICKER_SPACER_DEFAULT;
 
 static menu_animation_t anim;
 static retro_time_t cur_time    = 0;

--- a/menu/menu_animation.h
+++ b/menu/menu_animation.h
@@ -25,7 +25,7 @@
 
 RETRO_BEGIN_DECLS
 
-#define TICKER_SPACER_DEFAULT "   |   ";
+#define TICKER_SPACER_DEFAULT "   |   "
 
 typedef float (*easing_cb) (float, float, float, float);
 typedef void  (*tween_cb)  (void*);


### PR DESCRIPTION
## Description

This PR fixes/corrects a couple of minor things:

* (menu_animation.c) Use semi-colon properly for TICKER_SPACER_DEFAULT
* (rgui.c) silence warning in C89_BUILD

## Related Pull Requests

First fix improves 3cbae9c

## Reviewers

@twinaphex  @orbea 
