### PR TITLE
(RGUI) Ensure menu color theme is applied immediately

### DIFF
--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -1142,6 +1142,7 @@ static void prepare_rgui_colors(rgui_t *rgui, settings_t *settings)
    rgui->colors.border_light_color = argb32_to_pixel_platform_format(theme_colors.border_light_color);
 
    rgui->bg_modified = true;
+   rgui->force_redraw = true;
 }
 
 static uint16_t rgui_bg_filler(rgui_t *rgui, unsigned x, unsigned y)


### PR DESCRIPTION
## Description

I noticed a tiny bug in the RGUI menu appearance settings, which must have crept in when I added custom theme support...

When cycling through the `Menu Color Theme` options, depending on the current config the display does not always update immediately, which means the applied theme 'lags behind' the current setting until the user changes menu levels. It's a stupid trivial thing, but it's annoying. This PR fixes the issue.