### PR TITLE
[PS2] Fix Load/Save state

### DIFF
--- a/frontend/drivers/platform_ps2.c
+++ b/frontend/drivers/platform_ps2.c
@@ -195,17 +195,15 @@ static void create_path_names(void)
 {
    char cwd[FILENAME_MAX];
    getcwd(cwd, sizeof(cwd));
-   
-   strcat(cwd, "app");
+   if (strncmp(cwd, "mc0:", 4) || strncmp(cwd, "mc1:", 4)) {
+      /* For now the save and load states just working in MCs */
+      strlcpy(cwd, "mc0:/", sizeof(cwd));
+   }
+   strcat(cwd, "RETROARCH");
+
    strlcpy(eboot_path, cwd, sizeof(eboot_path));
    strlcpy(g_defaults.dirs[DEFAULT_DIR_PORT], eboot_path, sizeof(g_defaults.dirs[DEFAULT_DIR_PORT]));
-
-   strcat(cwd, "/data/retroarch");
-   strlcpy(user_path, cwd, sizeof(user_path));
-
-   // strlcpy(eboot_path, "mc0:/RETROARCH", sizeof(eboot_path));
-   // strlcpy(g_defaults.dirs[DEFAULT_DIR_PORT], eboot_path, sizeof(g_defaults.dirs[DEFAULT_DIR_PORT]));
-   // strlcpy(user_path, "mc0:/RETROARCH/data/retroarch", sizeof(user_path));
+   strlcpy(user_path, eboot_path, sizeof(user_path));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CORE], g_defaults.dirs[DEFAULT_DIR_PORT],
          "CORES", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE]));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CORE_INFO], g_defaults.dirs[DEFAULT_DIR_PORT],

--- a/frontend/drivers/platform_ps2.c
+++ b/frontend/drivers/platform_ps2.c
@@ -193,6 +193,19 @@ static const char *getMountParams(const char *command, char *BlockDevice)
 
 static void create_path_names(void)
 {
+   char cwd[FILENAME_MAX];
+   getcwd(cwd, sizeof(cwd));
+   
+   strcat(cwd, "app");
+   strlcpy(eboot_path, cwd, sizeof(eboot_path));
+   strlcpy(g_defaults.dirs[DEFAULT_DIR_PORT], eboot_path, sizeof(g_defaults.dirs[DEFAULT_DIR_PORT]));
+
+   strcat(cwd, "/data/retroarch");
+   strlcpy(user_path, cwd, sizeof(user_path));
+
+   // strlcpy(eboot_path, "mc0:/RETROARCH", sizeof(eboot_path));
+   // strlcpy(g_defaults.dirs[DEFAULT_DIR_PORT], eboot_path, sizeof(g_defaults.dirs[DEFAULT_DIR_PORT]));
+   // strlcpy(user_path, "mc0:/RETROARCH/data/retroarch", sizeof(user_path));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CORE], g_defaults.dirs[DEFAULT_DIR_PORT],
          "CORES", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE]));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CORE_INFO], g_defaults.dirs[DEFAULT_DIR_PORT],

--- a/gfx/drivers/ps2_gfx.c
+++ b/gfx/drivers/ps2_gfx.c
@@ -35,6 +35,7 @@ typedef struct ps2_video
    GSTEXTURE *menuTexture;
    GSTEXTURE *coreTexture;
    bool clearVRAM;
+   bool clearVRAM_font; /* I need to create this additional field to be used in the font driver*/
    struct retro_hw_render_interface_gskit_ps2 iface; /* Palette in the cores */
 
    bool menuVisible;
@@ -184,6 +185,7 @@ static void clearVRAMIfNeeded(ps2_video_t *ps2, void *frame, int width, int heig
    if (ps2->clearVRAM) {
       gsKit_vram_clear(ps2->gsGlobal);
       ps2->iface.updatedPalette = true;
+      ps2->clearVRAM_font = true; /* we need to upload also palette in the font driver */
    }
 }
 
@@ -194,6 +196,8 @@ static void refreshScreen(ps2_video_t *ps2)
    }
    gsKit_queue_exec(ps2->gsGlobal);
 
+   /* Here we are just puting in false the ps2->clearVRAM field
+      however, the ps2->clearVRAM_font should be done in the ps2_font driver */
    ps2->clearVRAM = false;
 }
 

--- a/gfx/drivers_font/ps2_font.c
+++ b/gfx/drivers_font/ps2_font.c
@@ -108,8 +108,9 @@ static void ps2_font_render_msg(
    if (ps2) {
       int x = FONTM_TEXTURE_LEFT_MARGIN;
       int y = ps2->ps2_video->gsGlobal->Height - FONTM_TEXTURE_BOTTOM_MARGIN;
-      if (ps2->ps2_video->clearVRAM) {
+      if (ps2->ps2_video->clearVRAM_font) {
          ps2_upload_font(ps2->ps2_video->gsGlobal, ps2->gsFontM);
+         ps2->ps2_video->clearVRAM_font = false;
       }
       gsKit_fontm_print_scaled(ps2->ps2_video->gsGlobal, ps2->gsFontM, x, y, FONTM_TEXTURE_ZPOSITION,
                                  FONTM_TEXTURE_SCALED , FONTM_TEXTURE_COLOR, msg);

--- a/libretro-common/vfs/vfs_implementation.c
+++ b/libretro-common/vfs/vfs_implementation.c
@@ -222,7 +222,12 @@ int64_t retro_vfs_file_seek_internal(libretro_vfs_implementation_file *stream, i
 #elif defined(__CELLOS_LV2__) || defined(_MSC_VER) && _MSC_VER <= 1310
       return fseek(stream->fp, (long)offset, whence);
 #elif defined(PS2)
-      return fioLseek(fileno(stream->fp), (off_t)offset, whence);
+      int64_t ret = fioLseek(fileno(stream->fp), (off_t)offset, whence);
+      /* fioLseek could return positive numbers */
+      if (ret > 0) {
+         ret = 0;
+      }
+      return ret;
 #elif defined(ORBIS)
       int ret = orbisLseek(stream->fd, offset, whence);
       if (ret < 0)
@@ -924,9 +929,9 @@ int retro_vfs_mkdir_impl(const char *dir)
 #elif defined(VITA) || defined(PSP)
    int ret = sceIoMkdir(dir, 0777);
 #elif defined(PS2)
-   int ret =fileXioMkdir(dir, 0777);
+   int ret = fileXioMkdir(dir, 0777);
 #elif defined(ORBIS)
-   int ret =orbisMkdir(dir, 0755);
+   int ret = orbisMkdir(dir, 0755);
 #elif defined(__QNX__)
    int ret = mkdir(dir, 0777);
 #else


### PR DESCRIPTION
## Description

This PR fixes the issues loading and saving the states.
It ideally first try to save in the same place where the Retroarch.elf is executed, the thing is right now the PS2SDK libraries just are working if they save in the memory cards. So it is executed from MC will use the same directory if they are executed from a different place it will use MC0:/Retroarch as the default folder.
Additionally, I have fixed also some strange behavior in the ps2_font driver for the screen notifications.
