### PR TITLE
Fix double root directory.

### DIFF
--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -6009,7 +6009,12 @@ static int menu_cbs_init_bind_ok_compare_type(menu_file_list_cbs_t *cbs,
             BIND_ACTION_OK(cbs, action_ok_parent_directory_push);
             break;
          case FILE_TYPE_DIRECTORY:
-            BIND_ACTION_OK(cbs, action_ok_directory_push);
+            if (cbs->enum_idx != MSG_UNKNOWN
+                  || menu_label_hash == MENU_LABEL_DISK_IMAGE_APPEND
+                  || menu_label_hash == MENU_LABEL_SUBSYSTEM_ADD)
+               BIND_ACTION_OK(cbs, action_ok_directory_push);
+            else
+               BIND_ACTION_OK(cbs, action_ok_push_random_dir);
             break;
          case FILE_TYPE_CARCHIVE:
             if (filebrowser_get_type() == FILEBROWSER_SCAN_FILE)


### PR DESCRIPTION
## Description

Fixes a double (`/`) root directory in the settings directory which I accidentally broke in commit https://github.com/libretro/RetroArch/commit/5fcedc86195c9b1b8a79c7b5f9e59f9c5c46012b.

I tested the file system as much as I could here and did not find any new issues. The disc control and subsystem issue remains fixed with this, but maybe the various conditionals for `MENU_LABEL_DISK_IMAGE_APPEND` and `MENU_LABEL_SUBSYSTEM_ADD` in this file could be handled better elsewhere in a followup PR?

## Related Issues

Fixes https://github.com/libretro/RetroArch/issues/8385

## Related Pull Requests

Regression after https://github.com/libretro/RetroArch/pull/8084.

## Reviewers

@twinaphex Please review this to make sure its acceptable.
