### PR TITLE
Enable 'Add to Favorites' without loading a core

### DIFF
--- a/command.c
+++ b/command.c
@@ -2416,8 +2416,26 @@ TODO: Add a setting for these tweaks */
          global_t *global                 = global_get_ptr();
          struct retro_system_info *system = runloop_get_libretro_system_info();
          const char *label                = NULL;
-         const char *core_path            = system ? path_get(RARCH_PATH_CORE) : NULL;
-         const char *core_name            = system ? system->library_name : NULL;
+         char core_path[PATH_MAX_LENGTH];
+         char core_name[PATH_MAX_LENGTH];
+
+         core_path[0] = '\0';
+         core_name[0] = '\0';
+
+         if (system)
+         {
+            if (!string_is_empty(path_get(RARCH_PATH_CORE)))
+               strlcpy(core_path, path_get(RARCH_PATH_CORE), sizeof(core_path));
+
+            if (!string_is_empty(system->library_name))
+               strlcpy(core_name, system->library_name, sizeof(core_name));
+         }
+
+         if (string_is_empty(core_path))
+            strlcpy(core_path, file_path_str(FILE_PATH_DETECT), sizeof(core_path));
+
+         if (string_is_empty(core_name))
+            strlcpy(core_name, file_path_str(FILE_PATH_DETECT), sizeof(core_name));
 
          if (!string_is_empty(global->name.label))
             label = global->name.label;

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -2987,6 +2987,15 @@ static int menu_displaylist_parse_horizontal_content_actions(
 
       if (settings->bools.quick_menu_show_add_to_favorites)
       {
+         global_t *global = global_get_ptr();
+
+         /* Have to update global->name.label here, otherwise
+          * the 'Add to Favorites' option will produce nonsensical
+          * playlist entries... */
+         if (global)
+            if (!string_is_empty(label))
+               strlcpy(global->name.label, label, sizeof(global->name.label));
+
          menu_entries_append_enum(info->list,
                msg_hash_to_str(MENU_ENUM_LABEL_VALUE_ADD_TO_FAVORITES_PLAYLIST),
                msg_hash_to_str(MENU_ENUM_LABEL_ADD_TO_FAVORITES_PLAYLIST),


### PR DESCRIPTION
## Description

At present, it is impossible to add content to favourites without first loading a core/content.

This PR fixes this behaviour, so content can be added to favourites from any playlist, without loading anything first.

I did this while trying to debug issue #8389 (which appears completely unrelated...), but with this fix in place I can no longer reproduce the problems that @orbea reported. I have no explanation for this...

## Related Issues

This should close issue #6909

Also seems to fix issue #8389 (@orbea please test!)
