### PR TITLE
fix iOS/tvOS build patch.

### DIFF
--- a/frontend/drivers/platform_darwin.m
+++ b/frontend/drivers/platform_darwin.m
@@ -771,6 +771,10 @@ frontend_ctx_driver_t frontend_ctx_darwin = {
    NULL,                         /* watch_path_for_changes */
    NULL,                         /* check_for_path_changes */
    NULL,                         /* set_sustained_performance_mode */
-   frontend_darwin_get_cpu_model_name,
+   #if (defined(OSX) && !(defined(__ppc__) || defined(__ppc64__)))
+    frontend_darwin_get_cpu_model_name,
+    #else
+   NULL,
+    #endif
    "darwin",
 };


### PR DESCRIPTION
if/else around retroarch/frontend/drivers/platform_darwin.m:743:4: Implicit declaration of function 'cpu_features_get_model_name' is invalid in C99

@yoshisuga as discussed.
