### PR TITLE
Runtime logging fixes

### DIFF
--- a/dynamic.c
+++ b/dynamic.c
@@ -1279,6 +1279,14 @@ bool rarch_environment_cb(unsigned cmd, void *data)
 
       case RETRO_ENVIRONMENT_SHUTDOWN:
          RARCH_LOG("Environ SHUTDOWN.\n");
+
+         /* This case occurs when a core (internally) requests
+          * a shutdown event. Must save runtime log file here,
+          * since normal command.c CMD_EVENT_CORE_DEINIT event
+          * will not occur until after the current content has
+          * been cleared (causing log to be skipped) */
+         rarch_ctl(RARCH_CTL_CONTENT_RUNTIME_LOG_DEINIT, NULL);
+
          rarch_ctl(RARCH_CTL_SET_SHUTDOWN,      NULL);
          rarch_ctl(RARCH_CTL_SET_CORE_SHUTDOWN, NULL);
          break;

--- a/retroarch.c
+++ b/retroarch.c
@@ -2426,6 +2426,11 @@ bool rarch_ctl(enum rarch_ctl_state state, void *data)
             }
          }
 
+         /* Reset runtime
+          * (Not required, but ensures that time can never
+          * be logged more than once...) */
+         libretro_core_runtime_usec = 0;
+
          break;
       }
       case RARCH_CTL_GET_PERFCNT:
@@ -4326,15 +4331,17 @@ int runloop_iterate(unsigned *sleep_ms)
       else
       {
          core_run();
-         rarch_core_runtime_tick();
       }
    }
 #else
    {
       core_run();
-      rarch_core_runtime_tick();
    }
 #endif
+
+   /* Increment runtime tick counter after each call to
+    * core_run() or run_ahead() */
+   rarch_core_runtime_tick();
 
 #ifdef HAVE_CHEEVOS
    if (runloop_check_cheevos())


### PR DESCRIPTION
## Description

As reported in the comments thread of issue #3527, runtime logging currently has two fatal flaws:

- The runtime clock 'counter' is not incremented when run-ahead is enabled(!), so no logs are generated.

- Log generation is skipped when closing cores via 'internal' mechanisms (e.g. selecting 'quit' from the in-game menu in PrBoom or TyrQuake). That is to say, any action that calls RETRO_ENVIRONMENT_SHUTDOWN.

This PR fixes both issues.

## Related Issues

#3527

