### PR TITLE
Qt: use native separators when loading content from file browser.

### DIFF
--- a/ui/drivers/qt/ui_qt_window.cpp
+++ b/ui/drivers/qt/ui_qt_window.cpp
@@ -1748,7 +1748,7 @@ QHash<QString, QString> MainWindow::getFileContentHash(const QModelIndex &index)
    QFileInfo fileInfo = m_fileModel->fileInfo(index);
    QHash<QString, QString> hash;
 
-   hash["path"] = m_fileModel->filePath(index);;
+   hash["path"] = QDir::toNativeSeparators(m_fileModel->filePath(index));
    hash["label"] = hash["path"];
    hash["label_noext"] = fileInfo.completeBaseName();
    hash["db_name"] = fileInfo.dir().dirName();


### PR DESCRIPTION
fixes #8403