### PR TITLE
Stop giant memory leak with --disable-discord and sixel.

### DIFF
--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -545,8 +545,7 @@ bool menu_display_libretro(bool is_idle,
 
       command_event(CMD_EVENT_DISCORD_UPDATE, &userdata);
 #endif
-      return true; /* Maybe return false here
-                      for indication of idleness? */
+      return false; /* Return false here for indication of idleness */
    }
    return video_driver_cached_frame();
 }


### PR DESCRIPTION
## Description

When building RetroArch with `--enable-sixel` and `--disable-discord` and then using the sixel video driver in  terminal that doesn't support sixel it will instantly leak all of my available ram.

I traced it down to a single `HAVE_DISCORD` and tested the already existing comment which solved my issue. I'm not really sure why this works, but it doesn't seem to be problematic?

## Related Issues

A large and dangerous memory leak with `--disable-discord`.