### PR TITLE
Optimise 'Add to Favorites' option

### DIFF
--- a/command.c
+++ b/command.c
@@ -2412,44 +2412,25 @@ TODO: Add a setting for these tweaks */
          break;
       case CMD_EVENT_ADD_TO_FAVORITES:
       {
-         /* TODO/FIXME - does path_get(RARCH_PATH_CORE) depend on the system info struct? Investigate */
-         global_t *global                 = global_get_ptr();
-         struct retro_system_info *system = runloop_get_libretro_system_info();
-         const char *label                = NULL;
-         char core_path[PATH_MAX_LENGTH];
-         char core_name[PATH_MAX_LENGTH];
+         struct string_list *str_list = (struct string_list*)data;
 
-         core_path[0] = '\0';
-         core_name[0] = '\0';
-
-         if (system)
+         if (str_list)
          {
-            if (!string_is_empty(path_get(RARCH_PATH_CORE)))
-               strlcpy(core_path, path_get(RARCH_PATH_CORE), sizeof(core_path));
-
-            if (!string_is_empty(system->library_name))
-               strlcpy(core_name, system->library_name, sizeof(core_name));
+            if (str_list->size >= 4)
+            {
+               /* Write playlist entry */
+               command_playlist_push_write(
+                     g_defaults.content_favorites,
+                     str_list->elems[0].data, /* content_path */
+                     str_list->elems[1].data, /* content_label */
+                     str_list->elems[2].data, /* core_path */
+                     str_list->elems[3].data  /* core_name */
+                     );
+               runloop_msg_queue_push(msg_hash_to_str(MSG_ADDED_TO_FAVORITES), 1, 180, true, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
+            }
          }
 
-         if (string_is_empty(core_path))
-            strlcpy(core_path, file_path_str(FILE_PATH_DETECT), sizeof(core_path));
-
-         if (string_is_empty(core_name))
-            strlcpy(core_name, file_path_str(FILE_PATH_DETECT), sizeof(core_name));
-
-         if (!string_is_empty(global->name.label))
-            label = global->name.label;
-
-         command_playlist_push_write(
-               g_defaults.content_favorites,
-               (const char*)data,
-               label,
-               core_path,
-               core_name
-               );
-         runloop_msg_queue_push(msg_hash_to_str(MSG_ADDED_TO_FAVORITES), 1, 180, true, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
          break;
-
       }
       case CMD_EVENT_RESET_CORE_ASSOCIATION:
       {

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -2987,15 +2987,6 @@ static int menu_displaylist_parse_horizontal_content_actions(
 
       if (settings->bools.quick_menu_show_add_to_favorites)
       {
-         global_t *global = global_get_ptr();
-
-         /* Have to update global->name.label here, otherwise
-          * the 'Add to Favorites' option will produce nonsensical
-          * playlist entries... */
-         if (global)
-            if (!string_is_empty(label))
-               strlcpy(global->name.label, label, sizeof(global->name.label));
-
          menu_entries_append_enum(info->list,
                msg_hash_to_str(MENU_ENUM_LABEL_VALUE_ADD_TO_FAVORITES_PLAYLIST),
                msg_hash_to_str(MENU_ENUM_LABEL_ADD_TO_FAVORITES_PLAYLIST),


### PR DESCRIPTION
## Description

This is a follow-up to PR #8393. It further enhances the 'Add to Favourites' option with the following changes:

- When adding favourites from a playlist, any existing core associations are preserved

- Having a core loaded no longer affects the favourites entry when adding from a playlist (i.e. no more incorrect core associations)

- The favourites 'label' field is always populated, using either the existing playlist label, or the content file name (i.e. no more blank labels)

- The favourites 'core name' field is always set to the display name, if available 

(Note: Do we want to standardise on using the core display name on all playlists? We currently fallback to the core library name on content history, and when manually associating cores. This is a little ugly/inconsistent...)

## Related Pull Requests

#8393

## Reviewers

@orbea may want to give this a once over before it's merged.
