### PR TITLE
Runtime logging: Fix logging redirection bug when loading consecutive content

### DIFF
--- a/runtime_file.c
+++ b/runtime_file.c
@@ -650,6 +650,8 @@ void runtime_log_save(runtime_log_t *runtime_log)
    if (!runtime_log)
       return;
    
+   RARCH_LOG("Saving runtime log file: %s\n", runtime_log->path);
+   
    /* Attempt to open log file */
    file = filestream_open(runtime_log->path, RETRO_VFS_FILE_ACCESS_WRITE, RETRO_VFS_FILE_ACCESS_HINT_NONE);
    


### PR DESCRIPTION
## Description

As reported by @fr500 in issue #8417, there is currently a bug in the runtime logging implementation: if new content is loaded while content is already running (i.e. without selecting 'close content' first), the accumulated playtime for the old content gets written to the new content's log file. This is due to the order in which `RARCH_PATH_CONTENT` and `RARCH_PATH_CORE` are updated relative to core de-initialisation.

This PR fixes the problem.

## Related Issues

This addresses half of issue #8417
