### PR TITLE
Core Info: Use basename when searching core paths

### DIFF
--- a/core_info.c
+++ b/core_info.c
@@ -539,6 +539,7 @@ static core_info_t *core_info_find_internal(
       const char *core)
 {
    size_t i;
+   const char *core_path_basename = path_basename(core);
 
    for (i = 0; i < list->count; i++)
    {
@@ -546,7 +547,7 @@ static core_info_t *core_info_find_internal(
 
       if (!info || !info->path)
          continue;
-      if (string_is_equal(info->path, core))
+      if (string_is_equal(path_basename(info->path), core_path_basename))
          return info;
    }
 
@@ -806,6 +807,8 @@ void core_info_get_name(const char *path, char *s, size_t len,
       path_info : dir_cores;
    struct string_list *contents     = dir_list_new(
          dir_cores, exts, false, dir_show_hidden_files, false, false);
+   const char *core_path_basename   = path_basename(path);
+
    if (!contents)
       return;
 
@@ -817,7 +820,7 @@ void core_info_get_name(const char *path, char *s, size_t len,
       char *new_core_name             = NULL;
       const char *current_path        = contents->elems[i].data;
 
-      if (!string_is_equal(current_path, path))
+      if (!string_is_equal(path_basename(current_path), core_path_basename))
          continue;
 
       info_path                       = (char*)malloc(PATH_MAX_LENGTH * sizeof(char));

--- a/runtime_file.c
+++ b/runtime_file.c
@@ -273,6 +273,7 @@ runtime_log_t *runtime_log_init(const char *content_path, const char *core_path)
    settings_t *settings = config_get_ptr();
    core_info_list_t *core_info = NULL;
    runtime_log_t *runtime_log = NULL;
+   const char *core_path_basename = path_basename(core_path);
    
    char content_name[PATH_MAX_LENGTH];
    char core_name[PATH_MAX_LENGTH];
@@ -298,7 +299,7 @@ runtime_log_t *runtime_log_init(const char *content_path, const char *core_path)
       return NULL;
    }
    
-   if (string_is_empty(content_path) || string_is_empty(core_path))
+   if (string_is_empty(content_path) || string_is_empty(core_path_basename))
       return NULL;
    
    if (string_is_equal(core_path, "builtin") || string_is_equal(core_path, file_path_str(FILE_PATH_DETECT)))
@@ -312,7 +313,7 @@ runtime_log_t *runtime_log_init(const char *content_path, const char *core_path)
    
    for (i = 0; i < core_info->count; i++)
    {
-      if (string_is_equal(core_info->list[i].path, core_path))
+      if (string_is_equal(path_basename(core_info->list[i].path), core_path_basename))
       {
          strlcpy(core_name, core_info->list[i].core_name, sizeof(core_name));
          break;


### PR DESCRIPTION
## Description

As reported by @fr500 in issue #8417, RetroArch quietly breaks when the cores directory is on a symlinked filesystem. Essentially, `core_info` operations stop working, which means (a) playlist core association can go haywire and (b) the display of runtime logging info becomes inconsistent (since different playlists with the same content end up with different core path settings, so often the runtime log file cannot be identified).

This PR fixes symlink-related issues by changing `core_info` so all path search operations only use the path basename (i.e. we check the shared object library, which is the only part that matters, and discard the irrelevant filesystem/symlink-dependent directory string).

## Related Issues

 This should close issue #8417 (but @fr500 should check first!)
