### PR TITLE
Always use core 'display name' when populating playlists

### DIFF
--- a/core_info.c
+++ b/core_info.c
@@ -800,7 +800,8 @@ void core_info_list_get_supported_cores(core_info_list_t *core_info_list,
 
 void core_info_get_name(const char *path, char *s, size_t len,
       const char *path_info, const char *dir_cores,
-      const char *exts, bool dir_show_hidden_files)
+      const char *exts, bool dir_show_hidden_files,
+      bool get_display_name)
 {
    size_t i;
    const char       *path_basedir   = !string_is_empty(path_info) ?
@@ -842,7 +843,7 @@ void core_info_get_name(const char *path, char *s, size_t len,
          continue;
       }
 
-      if (config_get_string(conf, "corename",
+      if (config_get_string(conf, get_display_name ? "display_name" : "corename",
             &new_core_name))
       {
          strlcpy(s, new_core_name, len);

--- a/core_info.h
+++ b/core_info.h
@@ -101,7 +101,8 @@ bool core_info_get_display_name(const char *path, char *s, size_t len);
 
 void core_info_get_name(const char *path, char *s, size_t len,
       const char *path_info, const char *dir_cores,
-      const char *exts, bool show_hidden_files);
+      const char *exts, bool show_hidden_files,
+      bool get_display_name);
 
 core_info_t *core_info_get(core_info_list_t *list, size_t i);
 

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -2672,7 +2672,8 @@ static int action_ok_core_deferred_set(const char *new_core_path,
          settings->paths.path_libretro_info,
          settings->paths.directory_libretro,
          ext_name,
-         settings->bools.show_hidden_files);
+         settings->bools.show_hidden_files,
+         true);
    command_playlist_update_write(
          NULL,
          menu->scratchpad.unsigned_var,

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -1041,9 +1041,24 @@ static bool task_load_content(content_ctx_info_t *content_info,
 #endif
                break;
             default:
+            {
+               core_info_t *core_info = NULL;
+
+               /* Set core path */
                core_path            = path_get(RARCH_PATH_CORE);
-               core_name            = info->library_name;
+
+               /* Set core display name
+                * (As far as I can tell, core_info_get_current_core()
+                * should always provide a valid pointer here...) */
+               core_info_get_current_core(&core_info);
+               if (core_info)
+                  core_name         = core_info->display_name;
+
+               if (string_is_empty(core_name))
+                  core_name         = info->library_name;
+
                break;
+            }
          }
 
          if (launched_from_cli)


### PR DESCRIPTION
## Description

At present, RetroArch uses a mixture of core info `corename` and `display_name` values when populating the `core_name` fields of playlists. Essentially, `corename` gets used in content history and when manually selecting cores, and `display_name` gets used everywhere else.

This is inconsistent - and perhaps more importantly, it means the history list (which contains entries from all sorts of systems) lacks a clear indication of which platform each entry corresponds to (the short form `corename` can often be obtuse).

This PR standardises things, so the `display_name` is always used.

(Of course, this does not apply retroactively - it won't change the `core_name` fields in any existing playlists, but at least any new entries will be consistent)