### PR TITLE
Populate crc32 and db_name fields when adding history/favourites playlist entries

### DIFF
--- a/command.c
+++ b/command.c
@@ -2395,7 +2395,7 @@ TODO: Add a setting for these tweaks */
 
          if (str_list)
          {
-            if (str_list->size >= 4)
+            if (str_list->size >= 6)
             {
                /* Write playlist entry */
                command_playlist_push_write(
@@ -2403,7 +2403,9 @@ TODO: Add a setting for these tweaks */
                      str_list->elems[0].data, /* content_path */
                      str_list->elems[1].data, /* content_label */
                      str_list->elems[2].data, /* core_path */
-                     str_list->elems[3].data  /* core_name */
+                     str_list->elems[3].data, /* core_name */
+                     str_list->elems[4].data, /* crc32 */
+                     str_list->elems[5].data  /* db_name */
                      );
                runloop_msg_queue_push(msg_hash_to_str(MSG_ADDED_TO_FAVORITES), 1, 180, true, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
             }

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -1756,7 +1756,7 @@ static int menu_displaylist_parse_database_entry(menu_handle_t *menu,
 
             playlist_get_index(playlist, j,
                   NULL, NULL, NULL, NULL,
-                  NULL, &crc32);
+                  &crc32, NULL);
 
             if (crc32)
                 tmp_str_list = string_split(crc32, "|");

--- a/playlist.h
+++ b/playlist.h
@@ -76,8 +76,8 @@ void playlist_get_index(playlist_t *playlist,
       size_t idx,
       const char **path, const char **label,
       const char **core_path, const char **core_name,
-      const char **db_name,
-      const char **crc32);
+      const char **crc32,
+      const char **db_name);
 
 void playlist_get_runtime_index(playlist_t *playlist,
       size_t idx,
@@ -139,8 +139,8 @@ void playlist_get_index_by_path(playlist_t *playlist,
       const char *search_path,
       char **path, char **label,
       char **core_path, char **core_name,
-      char **db_name,
-      char **crc32);
+      char **crc32,
+      char **db_name);
 
 bool playlist_entry_exists(playlist_t *playlist,
       const char *path,
@@ -167,7 +167,9 @@ void command_playlist_push_write(
       const char *path,
       const char *label,
       const char *core_path,
-      const char *core_name);
+      const char *core_name,
+      const char *crc32,
+      const char *db_name);
 
 void command_playlist_update_write(
       playlist_t *playlist,
@@ -178,6 +180,18 @@ void command_playlist_update_write(
       const char *core_display_name,
       const char *crc32,
       const char *db_name);
+
+/* Returns true if specified playlist index matches
+ * specified content/core paths */
+bool playlist_index_is_valid(playlist_t *playlist, size_t idx,
+      const char *path, const char *core_path);
+
+void playlist_get_crc32(playlist_t *playlist, size_t idx,
+      const char **crc32);
+
+/* If db_name is empty, 'returns' playlist file basename */
+void playlist_get_db_name(playlist_t *playlist, size_t idx,
+      const char **db_name);
 
 RETRO_END_DECLS
 

--- a/tasks/task_netplay_find_content.c
+++ b/tasks/task_netplay_find_content.c
@@ -277,7 +277,7 @@ static void task_netplay_crc_scan_handler(retro_task_t *task)
             const char *playlist_crc32    = NULL;
             const char *playlist_path     = NULL;
 
-            playlist_get_index(playlist, j, &playlist_path, NULL, NULL, NULL, NULL, &playlist_crc32);
+            playlist_get_index(playlist, j, &playlist_path, NULL, NULL, NULL, &playlist_crc32, NULL);
 
             if(have_crc && string_is_equal(playlist_crc32, state->content_crc))
             {
@@ -345,7 +345,7 @@ static void task_netplay_crc_scan_handler(retro_task_t *task)
                const char *playlist_crc32    = NULL;
                const char *playlist_path     = NULL;
 
-               playlist_get_index(playlist, k, &playlist_path, NULL, NULL, NULL, NULL, &playlist_crc32);
+               playlist_get_index(playlist, k, &playlist_path, NULL, NULL, NULL, &playlist_crc32, NULL);
                get_entry(entry, sizeof(entry), playlist_path);
 
                if(!string_is_empty(entry) &&

--- a/tasks/task_screenshot.c
+++ b/tasks/task_screenshot.c
@@ -166,7 +166,9 @@ static void task_screenshot_handler(retro_task_t *task)
             state->filename,
             NULL,
             "builtin",
-            "imageviewer");
+            "imageviewer",
+            NULL,
+            NULL);
 #endif
 
    task_set_progress(task, 100);


### PR DESCRIPTION
## Description

As the title says, this PR ensures that `crc32` and `db_name` fields are populated when adding new favourite or content history playlist entries. Note that this only works for content selected/launched from an existing playlist:

- `crc32` is copied from the parent playlist.

- `db_name` is copied from the parent playlist, but if this is blank then the parent playlist file basename is used.

For content launched via the file browser, the fields are left empty. (If it were possible to extract `db_name` from core_info then we could use this as a fallback for 'parent-less' content, but since many cores are associated with multiple databases this is not really practical)

The motivation here is that I want to start using `db_name` to associate thumbnails with playlist entries. This will allow thumbnails to be displayed when viewing history/favourites or any other mixed content playlists. (I plan to work on this sometime next week)

Note 1: This is not retroactive - it will not change existing history/favourites entries (users will have to start over to get the full benefit)

Note 2: This PR also fixes some old playlist-related bugs (some of the functions had `crc32` and `db_name` the wrong way around, with obvious consequences...)