### PR TITLE
X11 auto-repeat event fixed

### DIFF
--- a/gfx/common/x11_common.c
+++ b/gfx/common/x11_common.c
@@ -570,8 +570,22 @@ bool x11_alive(void *data)
          case ButtonRelease:
             break;
 
-         case KeyPress:
          case KeyRelease:
+            /*  When you receive a key release and the next event is a key press
+               of the same key combination, then it's auto-repeat and the 
+               key wasn't acutally released. */
+            if(XEventsQueued(g_x11_dpy, QueuedAfterReading))
+            {
+               XEvent next_event;
+               XPeekEvent(g_x11_dpy, &next_event);
+               if (next_event.type == KeyPress && 
+                   next_event.xkey.time == event.xkey.time &&
+                   next_event.xkey.keycode == event.xkey.keycode)
+               {
+                  break; // Key wasn’t actually released 
+               }
+            }
+         case KeyPress:
             if (event.xkey.window == g_x11_win)
                x11_handle_key_event(keycode, &event, g_x11_xic, filter);
             break;

--- a/gfx/common/x11_common.c
+++ b/gfx/common/x11_common.c
@@ -573,7 +573,7 @@ bool x11_alive(void *data)
          case KeyRelease:
             /*  When you receive a key release and the next event is a key press
                of the same key combination, then it's auto-repeat and the 
-               key wasn't acutally released. */
+               key wasn't actually released. */
             if(XEventsQueued(g_x11_dpy, QueuedAfterReading))
             {
                XEvent next_event;
@@ -582,7 +582,7 @@ bool x11_alive(void *data)
                    next_event.xkey.time == event.xkey.time &&
                    next_event.xkey.keycode == event.xkey.keycode)
                {
-                  break; // Key wasn’t actually released 
+                  break; // Key wasn't actually released 
                }
             }
          case KeyPress:


### PR DESCRIPTION
## Description

X11 sends false KeyRelease events because of the auto-repeat . Actually after each keypress it sends to the core both events KeyPress and KeyRelease. (Linux/SDL driver is not affected)

Linux/X11
![imagen](https://user-images.githubusercontent.com/560310/54076900-1629e600-42b1-11e9-9f56-a0b5690e7037.png)

Win/dinput
![imagen](https://user-images.githubusercontent.com/560310/54076912-41acd080-42b1-11e9-9b53-baa702da5ceb.png)

more info:
https://stackoverflow.com/questions/2100654/ignore-auto-repeat-in-x11-applications

## Reviewers
@orbea @twinaphex 

After patch...
![imagen](https://user-images.githubusercontent.com/560310/54076926-73be3280-42b1-11e9-8102-34a5a51f38d1.png)

Thanks :+1: 