### PR TITLE
ozone: more fixes

### DIFF
--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -389,6 +389,16 @@ static void ozone_free(void *data)
    }
 }
 
+unsigned ozone_count_lines(const char *str)
+{
+   unsigned c     = 0;
+   unsigned lines = 1;
+
+   for (c = 0; str[c]; c++)
+      lines += (str[c] == '\n');
+   return lines;
+}
+
 static void ozone_update_thumbnail_path(void *data, unsigned i, char pos)
 {
    menu_entry_t entry;
@@ -451,6 +461,9 @@ static void ozone_update_thumbnail_path(void *data, unsigned i, char pos)
 
       snprintf(ozone->selection_core_name, sizeof(ozone->selection_core_name),
          "%s", core_label);
+
+      word_wrap(ozone->selection_core_name, ozone->selection_core_name, (unsigned)((float)ozone->dimensions.thumbnail_bar_width * (float)0.66) / ozone->footer_font_glyph_width, false);
+      ozone->selection_core_name_lines = ozone_count_lines(ozone->selection_core_name);
 
       /* Fill play time if applicable */
       if (settings->bools.content_runtime_log || settings->bools.content_runtime_log_aggregate)
@@ -703,6 +716,7 @@ static void ozone_context_reset(void *data, bool is_threaded)
       ozone->entry_font_glyph_width    = FONT_SIZE_ENTRIES_LABEL * 3/4;
       ozone->sublabel_font_glyph_width = FONT_SIZE_ENTRIES_SUBLABEL * 3/4;
       ozone->sidebar_font_glyph_width  = FONT_SIZE_SIDEBAR * 3/4;
+      ozone->footer_font_glyph_width   = FONT_SIZE_FOOTER * 3/4;
 
       /* More realistic font size */
       size = font_driver_get_message_width(ozone->fonts.title, "a", 1, 1);
@@ -717,6 +731,9 @@ static void ozone_context_reset(void *data, bool is_threaded)
       size = font_driver_get_message_width(ozone->fonts.sidebar, "a", 1, 1);
       if (size)
          ozone->sidebar_font_glyph_width = size;
+      size = font_driver_get_message_width(ozone->fonts.footer, "a", 1, 1);
+      if (size)
+         ozone->footer_font_glyph_width = size;
 
       /* Textures init */
       for (i = 0; i < OZONE_TEXTURE_LAST; i++)

--- a/menu/drivers/ozone/ozone.h
+++ b/menu/drivers/ozone/ozone.h
@@ -143,6 +143,7 @@ struct ozone_handle
    unsigned title_font_glyph_width;
    unsigned entry_font_glyph_width;
    unsigned sublabel_font_glyph_width;
+   unsigned footer_font_glyph_width;
    unsigned sidebar_font_glyph_width;
 
    ozone_theme_t *theme;
@@ -239,6 +240,7 @@ struct ozone_handle
    char selection_core_name[255];
    char selection_playtime[64];
    char selection_lastplayed[64];
+   unsigned selection_core_name_lines;
 };
 
 /* If you change this struct, also
@@ -306,5 +308,7 @@ void ozone_entries_update_thumbnail_bar(ozone_handle_t *ozone, bool is_playlist,
 void ozone_draw_thumbnail_bar(ozone_handle_t *ozone, video_frame_info_t *video_info);
 
 const char *ozone_thumbnails_ident(char pos);
+
+unsigned ozone_count_lines(const char *str);
 
 #endif

--- a/menu/drivers/ozone/ozone_entries.c
+++ b/menu/drivers/ozone/ozone_entries.c
@@ -183,16 +183,6 @@ void ozone_update_scroll(ozone_handle_t *ozone, bool allow_animation, ozone_node
    }
 }
 
-static unsigned ozone_count_lines(const char *str)
-{
-   unsigned c     = 0;
-   unsigned lines = 1;
-
-   for (c = 0; str[c]; c++)
-      lines += (str[c] == '\n');
-   return lines;
-}
-
 void ozone_compute_entries_position(ozone_handle_t *ozone)
 {
    /* Compute entries height and adjust scrolling if needed */
@@ -650,7 +640,7 @@ static void ozone_draw_no_thumbnail_available(ozone_handle_t *ozone,
 
 static void ozone_content_metadata_line(video_frame_info_t *video_info, ozone_handle_t *ozone,
    unsigned *y, unsigned title_column_x, unsigned data_column_x,
-   const char *title, const char *data)
+   const char *title, const char *data, unsigned lines_count)
 {
    ozone_draw_text(video_info, ozone,
       title,
@@ -677,7 +667,7 @@ static void ozone_content_metadata_line(video_frame_info_t *video_info, ozone_ha
       true
    );
 
-   *y += font_driver_get_line_height(ozone->fonts.footer, 1) * 1.5;
+   *y += (font_driver_get_line_height(ozone->fonts.footer, 1) * 1.5) * lines_count;
 }
 
 void ozone_draw_thumbnail_bar(ozone_handle_t *ozone, video_frame_info_t *video_info)
@@ -787,21 +777,24 @@ void ozone_draw_thumbnail_bar(ozone_handle_t *ozone, video_frame_info_t *video_i
       ozone_content_metadata_line(video_info, ozone,
          &y, title_column_x, data_column_x,
          msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLIST_SUBLABEL_CORE),
-         ozone->selection_core_name
+         ozone->selection_core_name,
+         ozone->selection_core_name_lines
       );
 
       /* Playtime */
       ozone_content_metadata_line(video_info, ozone,
          &y, title_column_x, data_column_x,
          msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLIST_SUBLABEL_RUNTIME),
-         ozone->selection_playtime
+         ozone->selection_playtime,
+         1
       );
 
       /* Last played */
       ozone_content_metadata_line(video_info, ozone,
          &y, title_column_x, data_column_x,
          msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLIST_SUBLABEL_LAST_PLAYED),
-         ozone->selection_lastplayed
+         ozone->selection_lastplayed,
+         1
       );
    }
 }

--- a/menu/drivers/ozone/ozone_entries.c
+++ b/menu/drivers/ozone/ozone_entries.c
@@ -737,8 +737,13 @@ void ozone_draw_thumbnail_bar(ozone_handle_t *ozone, video_frame_info_t *video_i
    }
    else
    {
+      /* If thumbnails are disabled, we don't know the thumbnail
+       * height but we still need to move it to leave room for the
+       * content metadata panel */
+      unsigned height = video_info->height / 4;
+
       ozone_draw_no_thumbnail_available(ozone, video_info, x_position, sidebar_width,
-         ozone->dimensions.thumbnail_height / 2 + ozone->dimensions.sidebar_entry_icon_padding/2);
+         height / 2 + ozone->dimensions.sidebar_entry_icon_padding/2);
    }
 
    /* Bottom row : "left" thumbnail or content metadata */

--- a/menu/drivers/ozone/ozone_entries.c
+++ b/menu/drivers/ozone/ozone_entries.c
@@ -252,7 +252,10 @@ void ozone_compute_entries_position(ozone_handle_t *ozone)
             entry_padding * 2 - ozone->dimensions.entry_icon_padding * 2;
 
          if (ozone->depth == 1)
-            entry_padding -= (unsigned) ozone->dimensions.sidebar_width;
+            sublabel_max_width -= (unsigned) ozone->dimensions.sidebar_width;
+
+         if (ozone->show_thumbnail_bar)
+            sublabel_max_width -= ozone->dimensions.thumbnail_bar_width;
 
          word_wrap(sublabel_str, sublabel_str, sublabel_max_width / ozone->sublabel_font_glyph_width, false);
 
@@ -519,11 +522,14 @@ border_iterate:
 
       if (node->wrap && sublabel_str)
       {
-            int sublabel_max_width = video_info_width - (unsigned) ozone->dimensions.sidebar_width -
+            int sublabel_max_width = video_info_width -
                entry_padding * 2 - ozone->dimensions.entry_icon_padding * 2;
 
             if (ozone->show_thumbnail_bar)
                sublabel_max_width -= ozone->dimensions.thumbnail_bar_width;
+
+            if (ozone->depth == 1)
+               sublabel_max_width -= (unsigned) ozone->dimensions.sidebar_width;
 
             word_wrap(sublabel_str, sublabel_str, sublabel_max_width / ozone->sublabel_font_glyph_width, false);
       }


### PR DESCRIPTION
- Sublabels should now properly wrap and not overlap
- The "No thumbnail available" message should not overlap
- The core name metadata now wraps if too long