### PR TITLE
Ozone thumbnails display fix + add menu widgets notice in configure

### DIFF
--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -197,6 +197,7 @@ static void *ozone_init(void **userdata, bool video_is_threaded)
 
    ozone->animations.thumbnail_bar_position  = 0.0f;
    ozone->show_thumbnail_bar                 = false;
+   ozone->dimensions.sidebar_width           = 0.0f;
 
    ozone_sidebar_update_collapse(ozone, false);
 
@@ -700,7 +701,8 @@ static void ozone_context_reset(void *data, bool is_threaded)
          + ozone->dimensions.sidebar_entry_icon_padding * 2
          + ozone->dimensions.sidebar_padding_horizontal * 2;
 
-      ozone->dimensions.sidebar_width                    = (float) ozone->dimensions.sidebar_width_normal;
+      if (ozone->dimensions.sidebar_width == 0)
+         ozone->dimensions.sidebar_width                    = (float) ozone->dimensions.sidebar_width_normal;
 
       ozone->dimensions.thumbnail_bar_width              = ozone->dimensions.sidebar_width_normal 
          - ozone->dimensions.sidebar_entry_icon_size

--- a/menu/drivers/ozone/ozone.h
+++ b/menu/drivers/ozone/ozone.h
@@ -200,7 +200,7 @@ struct ozone_handle
       int sidebar_width_normal;
       int sidebar_width_collapsed;
 
-      float sidebar_width;
+      float sidebar_width; /* animated field */
       int sidebar_padding_horizontal;
       int sidebar_padding_vertical;
       int sidebar_entry_padding_vertical;

--- a/menu/drivers/ozone/ozone_entries.c
+++ b/menu/drivers/ozone/ozone_entries.c
@@ -737,7 +737,7 @@ void ozone_draw_thumbnail_bar(ozone_handle_t *ozone, video_frame_info_t *video_i
    }
 
    /* Bottom row : "left" thumbnail or content metadata */
-   if (left_thumbnail)
+   if (thumbnail && left_thumbnail)
    {
       unsigned thumb_x_position = x_position + sidebar_width/2 - (ozone->dimensions.left_thumbnail_width + ozone->dimensions.sidebar_entry_icon_padding) / 2;
       unsigned thumb_y_position = video_info->height / 2 + ozone->dimensions.sidebar_entry_icon_padding / 2;

--- a/menu/drivers/ozone/ozone_sidebar.c
+++ b/menu/drivers/ozone/ozone_sidebar.c
@@ -746,29 +746,38 @@ bool ozone_is_playlist(ozone_handle_t *ozone, bool depth)
 {
    bool is_playlist;
 
-   switch (ozone->categories_selection_ptr)
+   if (ozone->categories_selection_ptr > ozone->system_tab_end)
    {
-      case OZONE_SYSTEM_TAB_MAIN:
-      case OZONE_SYSTEM_TAB_SETTINGS:
-      case OZONE_SYSTEM_TAB_ADD:
-         is_playlist = false;
-         break;
-      case OZONE_SYSTEM_TAB_HISTORY:
-      case OZONE_SYSTEM_TAB_FAVORITES:
-      case OZONE_SYSTEM_TAB_MUSIC:
+      is_playlist = true;
+   }
+   else
+   {
+      switch (ozone->tabs[ozone->categories_selection_ptr])
+      {
+         case OZONE_SYSTEM_TAB_MAIN:
+         case OZONE_SYSTEM_TAB_SETTINGS:
+         case OZONE_SYSTEM_TAB_ADD:
+#ifdef HAVE_NETWORKING
+         case OZONE_SYSTEM_TAB_NETPLAY:
+#endif
+            is_playlist = false;
+            break;
+         case OZONE_SYSTEM_TAB_HISTORY:
+         case OZONE_SYSTEM_TAB_FAVORITES:
+         case OZONE_SYSTEM_TAB_MUSIC:
 #if defined(HAVE_FFMPEG) || defined(HAVE_MPV)
-      case OZONE_SYSTEM_TAB_VIDEO:
+         case OZONE_SYSTEM_TAB_VIDEO:
 #endif
 #ifdef HAVE_IMAGEVIEWER
-      case OZONE_SYSTEM_TAB_IMAGES:
+         case OZONE_SYSTEM_TAB_IMAGES:
 #endif
-#ifdef HAVE_NETWORKING
-      case OZONE_SYSTEM_TAB_NETPLAY:
-#endif
-      default:
-         is_playlist = true;
-         break;
+         default:
+            is_playlist = true;
+            break;
+      }
    }
+
+
 
    if (depth)
       return is_playlist && ozone->depth == 1;

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -509,6 +509,11 @@ if [ "$HAVE_MENU" != 'no' ]; then
    fi
 fi
 
+if [ "$HAVE_MENU_WIDGETS" != 'no' ]; then
+   die : 'Notice: Menu widgets are not fully implemented and should not be enabled' \
+         'Please do not report any bug concerning widgets until this message is removed'
+fi
+
 check_macro NEON __ARM_NEON__
 
 add_define MAKEFILE OS "$OS"


### PR DESCRIPTION
- Playlist detection has been fixed, which fixes incorrect thumbnails display in playlists
- I added a notice in ./configure to warn users not to use menu widgets and, most important of all, don't report bugs because they are not fully integrated back yet. I'll remove the notice once every widget is back in master. @orbea could you tell me if it's OK before merging ? Thanks