### PR TITLE
(macOS) Add temporary GL hack

### DIFF
--- a/gfx/drivers/gl.c
+++ b/gfx/drivers/gl.c
@@ -3305,6 +3305,10 @@ static void *gl2_init(const video_info_t *video,
 
    if (!video_context_driver_set_video_mode(&mode))
       goto error;
+#if defined(__APPLE__) && !defined(IOS)
+   if (!video_context_driver_set_video_mode(&mode))
+      goto error;
+#endif
 
 #if !defined(RARCH_CONSOLE) || defined(HAVE_LIBNX)
    rglgen_resolve_symbols(ctx_driver->get_proc_address);


### PR DESCRIPTION
## Description

This implements a temporary hack for some of the GL issues on macOS. Without this hack, using the GL driver will intermittently incorrectly size the display window and the text/assets will also be the incorrect size. Loading a GL core also displays incorrectly. Setting the display mode twice is a temporary workaround while the underlying issue is identified. 

I briefly tested this on macOS but wasn’t able to test on any other platforms to verify there was no impact, but the second init should be safely ifdef’d away. I tested 1) that the initial screen loaded properly and 2) loading a GL core displayed properly. 

## Reviewers

@twinaphex 