### PR TITLE
Fix keyboard on android

### DIFF
--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -1430,6 +1430,8 @@ static int16_t android_input_state(void *data,
 
    switch (device)
    {
+      case RETRO_DEVICE_KEYBOARD:
+         return (id < RETROK_LAST) && BIT_GET(android_keyboard_state_get(ANDROID_KEYBOARD_PORT), rarch_keysym_lut[id]);
       case RETRO_DEVICE_JOYPAD:
          ret = input_joypad_pressed(android->joypad, joypad_info,
                port, binds[port], id);


### PR DESCRIPTION
android_input_state is missing a case for keyboard and as a result keyboard doesn't work with cores that require android_input_state for keyboard.