### PR TITLE
ozone thumbnails improvements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -66,7 +66,8 @@
       "xutility": "c",
       "menu_input_dialog.h": "c",
       "menu_filebrowser.h": "c",
-      "ozone_sidebar.h": "c"
+      "ozone_sidebar.h": "c",
+      "menu_thumbnail_path.h": "c"
    },
    "C_Cpp.dimInactiveRegions": false,
 }

--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -461,9 +461,9 @@ static void ozone_update_thumbnail_path(void *data, unsigned i, char pos)
          core_label = core_name;
 
       snprintf(ozone->selection_core_name, sizeof(ozone->selection_core_name),
-         "%s", core_label);
+         "%s %s", msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLIST_SUBLABEL_CORE), core_label);
 
-      word_wrap(ozone->selection_core_name, ozone->selection_core_name, (unsigned)((float)ozone->dimensions.thumbnail_bar_width * (float)0.66) / ozone->footer_font_glyph_width, false);
+      word_wrap(ozone->selection_core_name, ozone->selection_core_name, (unsigned)((float)ozone->dimensions.thumbnail_bar_width * (float)0.85) / ozone->footer_font_glyph_width, false);
       ozone->selection_core_name_lines = ozone_count_lines(ozone->selection_core_name);
 
       /* Fill play time if applicable */
@@ -485,18 +485,20 @@ static void ozone_update_thumbnail_path(void *data, unsigned i, char pos)
             &last_played_year, &last_played_month, &last_played_day,
             &last_played_hour, &last_played_minute, &last_played_second);
 
-         snprintf(ozone->selection_playtime, sizeof(ozone->selection_playtime), "%02u:%02u:%02u",
-            runtime_hours, runtime_minutes, runtime_seconds);
+         snprintf(ozone->selection_playtime, sizeof(ozone->selection_playtime), "%s %02u:%02u:%02u",
+            msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLIST_SUBLABEL_RUNTIME), runtime_hours, runtime_minutes, runtime_seconds);
 
          if (last_played_year == 0 && last_played_month == 0 && last_played_day == 0
             && last_played_hour == 0 && last_played_minute == 0 && last_played_second == 0)
          {
-            snprintf(ozone->selection_lastplayed, sizeof(ozone->selection_lastplayed), "%s",
+            snprintf(ozone->selection_lastplayed, sizeof(ozone->selection_lastplayed), "%s %s",
+               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLIST_SUBLABEL_LAST_PLAYED),
                msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLIST_INLINE_CORE_DISPLAY_NEVER));
          }
          else
          {
-            snprintf(ozone->selection_lastplayed, sizeof(ozone->selection_lastplayed), "%04u/%02u/%02u - %02u:%02u:%02u",
+            snprintf(ozone->selection_lastplayed, sizeof(ozone->selection_lastplayed), "%s %04u/%02u/%02u -\n%02u:%02u:%02u",
+                        msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLIST_SUBLABEL_LAST_PLAYED),
                         last_played_year, last_played_month, last_played_day,
                         last_played_hour, last_played_minute, last_played_second);
          }

--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -1403,8 +1403,6 @@ static void ozone_selection_changed(ozone_handle_t *ozone, bool allow_animation)
 
    if (ozone->selection != new_selection)
    {
-      ozone_node_t *node   = NULL;
-
       ozone->selection_old         = ozone->selection;
       ozone->selection             = new_selection;
 
@@ -1414,79 +1412,73 @@ static void ozone_selection_changed(ozone_handle_t *ozone, bool allow_animation)
       ozone_update_scroll(ozone, allow_animation, node);
 
       /* Update thumbnail */
-      node = (ozone_node_t*)
-         file_list_get_userdata_at_offset(selection_buf, ozone->selection);
-
-      if (node)
+      if (!string_is_equal(thumb_ident,
+               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF)) || !string_is_equal(left_thumb_ident,
+               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF)))
       {
-         if (!string_is_equal(thumb_ident,
-                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF)) || !string_is_equal(left_thumb_ident,
-                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF)))
+         menu_entry_t entry;
+         unsigned entry_type;
+         unsigned i = ozone->selection;
+
+         menu_entry_init(&entry);
+         menu_entry_get(&entry, 0, (unsigned)i, NULL, true);
+         entry_type = menu_entry_get_type_new(&entry);
+
+         if (ozone->is_playlist && ozone->depth == 1)
          {
-            menu_entry_t entry;
-            unsigned entry_type;
-            unsigned i = ozone->selection;
-
-            menu_entry_init(&entry);
-            menu_entry_get(&entry, 0, (unsigned)i, NULL, true);
-            entry_type = menu_entry_get_type_new(&entry);
-
-            if (ozone->is_playlist && ozone->depth == 1)
+            if (!string_is_empty(entry.path))
+               ozone_set_thumbnail_content(ozone, entry.path);
+            if (!string_is_equal(thumb_ident,
+                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF)))
             {
-               if (!string_is_empty(entry.path))
-                  ozone_set_thumbnail_content(ozone, entry.path);
-               if (!string_is_equal(thumb_ident,
-                        msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF)))
-               {
-                  ozone_update_thumbnail_path(ozone, i, 'R');
-                  ozone_update_thumbnail_image(ozone);
-               }
-               if (!string_is_equal(left_thumb_ident,
-                        msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF)))
-               {
-                  ozone_update_thumbnail_path(ozone, i, 'L');
-                  ozone_update_thumbnail_image(ozone);
-               }
+               ozone_update_thumbnail_path(ozone, i, 'R');
+               ozone_update_thumbnail_image(ozone);
             }
-            else if (((entry_type == FILE_TYPE_IMAGE || entry_type == FILE_TYPE_IMAGEVIEWER ||
-                        entry_type == FILE_TYPE_RDB || entry_type == FILE_TYPE_RDB_ENTRY)
-                     && ozone->tabs[ozone->categories_selection_ptr] <= OZONE_SYSTEM_TAB_SETTINGS))
+            if (!string_is_equal(left_thumb_ident,
+                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF)))
             {
-               if (!string_is_empty(entry.path))
-                  ozone_set_thumbnail_content(ozone, entry.path);
-               if (!string_is_equal(thumb_ident,
-                        msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF)))
-               {
-                  ozone_update_thumbnail_path(ozone, i, 'R');
-                  ozone_update_thumbnail_image(ozone);
-               }
-               else if (!string_is_equal(left_thumb_ident,
-                        msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF)))
-               {
-                  ozone_update_thumbnail_path(ozone, i, 'L');
-                  ozone_update_thumbnail_image(ozone);
-               }
+               ozone_update_thumbnail_path(ozone, i, 'L');
+               ozone_update_thumbnail_image(ozone);
             }
-            else if (filebrowser_get_type() != FILEBROWSER_NONE)
-            {
-               ozone_reset_thumbnail_content(ozone);
-               if (!string_is_equal(thumb_ident,
-                        msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF)))
-               {
-                  ozone_update_thumbnail_path(ozone, i, 'R');
-                  ozone_update_thumbnail_image(ozone);
-               }
-               else if (!string_is_equal(left_thumb_ident,
-                        msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF)))
-               {
-                  ozone_update_thumbnail_path(ozone, i, 'L');
-                  ozone_update_thumbnail_image(ozone);
-               }
-            }
-            menu_entry_free(&entry);
          }
-         /* TODO: Update savestate thumbnail */
+         else if (((entry_type == FILE_TYPE_IMAGE || entry_type == FILE_TYPE_IMAGEVIEWER ||
+                     entry_type == FILE_TYPE_RDB || entry_type == FILE_TYPE_RDB_ENTRY)
+                  && ozone->tabs[ozone->categories_selection_ptr] <= OZONE_SYSTEM_TAB_SETTINGS))
+         {
+            if (!string_is_empty(entry.path))
+               ozone_set_thumbnail_content(ozone, entry.path);
+            if (!string_is_equal(thumb_ident,
+                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF)))
+            {
+               ozone_update_thumbnail_path(ozone, i, 'R');
+               ozone_update_thumbnail_image(ozone);
+            }
+            else if (!string_is_equal(left_thumb_ident,
+                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF)))
+            {
+               ozone_update_thumbnail_path(ozone, i, 'L');
+               ozone_update_thumbnail_image(ozone);
+            }
+         }
+         else if (filebrowser_get_type() != FILEBROWSER_NONE)
+         {
+            ozone_reset_thumbnail_content(ozone);
+            if (!string_is_equal(thumb_ident,
+                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF)))
+            {
+               ozone_update_thumbnail_path(ozone, i, 'R');
+               ozone_update_thumbnail_image(ozone);
+            }
+            else if (!string_is_equal(left_thumb_ident,
+                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF)))
+            {
+               ozone_update_thumbnail_path(ozone, i, 'L');
+               ozone_update_thumbnail_image(ozone);
+            }
+         }
+         menu_entry_free(&entry);
       }
+      /* TODO: Update savestate thumbnail */
    }
 }
 

--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -373,13 +373,10 @@ static void ozone_update_thumbnail_path(void *data, unsigned i, char pos)
 {
    settings_t     *settings       = config_get_ptr();
    ozone_handle_t    *ozone       = (ozone_handle_t*)data;
-   playlist_t     *playlist       = NULL;
    const char    *core_name       = NULL;
 
    if (!ozone)
       return;
-
-   playlist = playlist_get_cached();
 
    /* imageviewer content requires special treatment... */
    menu_thumbnail_get_core_name(ozone->thumbnail_path_data, &core_name);
@@ -390,71 +387,6 @@ static void ozone_update_thumbnail_path(void *data, unsigned i, char pos)
    }
    else
       menu_thumbnail_update_path(ozone->thumbnail_path_data, pos == 'R' ? MENU_THUMBNAIL_RIGHT : MENU_THUMBNAIL_LEFT);
-
-   if (playlist)
-   {
-      const char    *core_label      = NULL;
-      playlist_get_index(playlist, i,
-            NULL, NULL, NULL, &core_name, NULL, NULL);
-
-      /* Fill core name */
-      if (!core_name || string_is_equal(core_name, "DETECT"))
-         core_label = msg_hash_to_str(MSG_AUTODETECT);
-      else
-         core_label = core_name;
-
-      snprintf(ozone->selection_core_name, sizeof(ozone->selection_core_name),
-         "%s %s", msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLIST_SUBLABEL_CORE), core_label);
-
-      word_wrap(ozone->selection_core_name, ozone->selection_core_name, (unsigned)((float)ozone->dimensions.thumbnail_bar_width * (float)0.85) / ozone->footer_font_glyph_width, false);
-      ozone->selection_core_name_lines = ozone_count_lines(ozone->selection_core_name);
-
-      /* Fill play time if applicable */
-      if (settings->bools.content_runtime_log || settings->bools.content_runtime_log_aggregate)
-      {
-         unsigned runtime_hours        = 0;
-         unsigned runtime_minutes      = 0;
-         unsigned runtime_seconds      = 0;
-
-         unsigned last_played_year     = 0;
-         unsigned last_played_month    = 0;
-         unsigned last_played_day      = 0;
-         unsigned last_played_hour     = 0;
-         unsigned last_played_minute   = 0;
-         unsigned last_played_second   = 0;
-
-         playlist_get_runtime_index(playlist, i, NULL, NULL,
-            &runtime_hours, &runtime_minutes, &runtime_seconds,
-            &last_played_year, &last_played_month, &last_played_day,
-            &last_played_hour, &last_played_minute, &last_played_second);
-
-         snprintf(ozone->selection_playtime, sizeof(ozone->selection_playtime), "%s %02u:%02u:%02u",
-            msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLIST_SUBLABEL_RUNTIME), runtime_hours, runtime_minutes, runtime_seconds);
-
-         if (last_played_year == 0 && last_played_month == 0 && last_played_day == 0
-            && last_played_hour == 0 && last_played_minute == 0 && last_played_second == 0)
-         {
-            snprintf(ozone->selection_lastplayed, sizeof(ozone->selection_lastplayed), "%s %s",
-               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLIST_SUBLABEL_LAST_PLAYED),
-               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLIST_INLINE_CORE_DISPLAY_NEVER));
-         }
-         else
-         {
-            snprintf(ozone->selection_lastplayed, sizeof(ozone->selection_lastplayed), "%s %04u/%02u/%02u -\n%02u:%02u:%02u",
-                        msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLIST_SUBLABEL_LAST_PLAYED),
-                        last_played_year, last_played_month, last_played_day,
-                        last_played_hour, last_played_minute, last_played_second);
-         }
-      }
-      else
-      {
-         snprintf(ozone->selection_playtime, sizeof(ozone->selection_playtime), "%s",
-            msg_hash_to_str(MENU_ENUM_LABEL_VALUE_DISABLED));
-
-         snprintf(ozone->selection_lastplayed, sizeof(ozone->selection_lastplayed), "%s",
-            msg_hash_to_str(MENU_ENUM_LABEL_VALUE_DISABLED));
-      }
-   }
 }
 
 static void ozone_update_thumbnail_image(void *data)
@@ -1193,10 +1125,86 @@ static void ozone_draw_footer(ozone_handle_t *ozone, video_frame_info_t *video_i
    menu_display_blend_end(video_info);
 }
 
+void ozone_update_content_metadata(ozone_handle_t *ozone)
+{
+   playlist_t *playlist       = playlist_get_cached();
+   const char *core_name      = NULL;
+   settings_t *settings       = config_get_ptr();
+
+   menu_thumbnail_get_core_name(ozone->thumbnail_path_data, &core_name);
+
+   if (ozone->is_playlist && playlist)
+   {
+      const char    *core_label      = NULL;
+      playlist_get_index(playlist, ozone->selection,
+            NULL, NULL, NULL, &core_name, NULL, NULL);
+
+      /* Fill core name */
+      if (!core_name || string_is_equal(core_name, "DETECT"))
+         core_label = msg_hash_to_str(MSG_AUTODETECT);
+      else
+         core_label = core_name;
+
+      snprintf(ozone->selection_core_name, sizeof(ozone->selection_core_name),
+         "%s %s", msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLIST_SUBLABEL_CORE), core_label);
+
+      word_wrap(ozone->selection_core_name, ozone->selection_core_name, (unsigned)((float)ozone->dimensions.thumbnail_bar_width * (float)0.85) / ozone->footer_font_glyph_width, false);
+      ozone->selection_core_name_lines = ozone_count_lines(ozone->selection_core_name);
+
+      /* Fill play time if applicable */
+      if (settings->bools.content_runtime_log || settings->bools.content_runtime_log_aggregate)
+      {
+         unsigned runtime_hours        = 0;
+         unsigned runtime_minutes      = 0;
+         unsigned runtime_seconds      = 0;
+
+         unsigned last_played_year     = 0;
+         unsigned last_played_month    = 0;
+         unsigned last_played_day      = 0;
+         unsigned last_played_hour     = 0;
+         unsigned last_played_minute   = 0;
+         unsigned last_played_second   = 0;
+
+         playlist_get_runtime_index(playlist, ozone->selection, NULL, NULL,
+            &runtime_hours, &runtime_minutes, &runtime_seconds,
+            &last_played_year, &last_played_month, &last_played_day,
+            &last_played_hour, &last_played_minute, &last_played_second);
+
+         snprintf(ozone->selection_playtime, sizeof(ozone->selection_playtime), "%s %02u:%02u:%02u",
+            msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLIST_SUBLABEL_RUNTIME), runtime_hours, runtime_minutes, runtime_seconds);
+
+         if (last_played_year == 0 && last_played_month == 0 && last_played_day == 0
+            && last_played_hour == 0 && last_played_minute == 0 && last_played_second == 0)
+         {
+            snprintf(ozone->selection_lastplayed, sizeof(ozone->selection_lastplayed), "%s %s",
+               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLIST_SUBLABEL_LAST_PLAYED),
+               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLIST_INLINE_CORE_DISPLAY_NEVER));
+         }
+         else
+         {
+            snprintf(ozone->selection_lastplayed, sizeof(ozone->selection_lastplayed), "%s %04u/%02u/%02u -\n%02u:%02u:%02u",
+                        msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLIST_SUBLABEL_LAST_PLAYED),
+                        last_played_year, last_played_month, last_played_day,
+                        last_played_hour, last_played_minute, last_played_second);
+         }
+      }
+      else
+      {
+         snprintf(ozone->selection_playtime, sizeof(ozone->selection_playtime), "%s",
+            msg_hash_to_str(MENU_ENUM_LABEL_VALUE_DISABLED));
+
+         snprintf(ozone->selection_lastplayed, sizeof(ozone->selection_lastplayed), "%s",
+            msg_hash_to_str(MENU_ENUM_LABEL_VALUE_DISABLED));
+      }
+   }
+
+}
+
 static void ozone_set_thumbnail_content(void *data, const char *s)
 {
-   size_t selection = menu_navigation_get_selection();
-   ozone_handle_t *ozone = (ozone_handle_t*)data;
+   size_t selection           = menu_navigation_get_selection();
+   ozone_handle_t *ozone      = (ozone_handle_t*)data;
+
    if (!ozone)
       return;
 
@@ -1282,6 +1290,8 @@ static void ozone_selection_changed(ozone_handle_t *ozone, bool allow_animation)
 
    size_t new_selection = menu_navigation_get_selection();
    ozone_node_t *node   = (ozone_node_t*) file_list_get_userdata_at_offset(selection_buf, new_selection);
+
+   ozone_update_content_metadata(ozone);
 
    menu_entry_init(&entry);
 

--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -2333,7 +2333,7 @@ static bool ozone_load_image(void *userdata, void *data, enum menu_image_type ty
    ozone_handle_t *ozone = (ozone_handle_t*) userdata;
    unsigned sidebar_height;
    unsigned height;
-   unsigned maximum_height;
+   unsigned maximum_height, maximum_width;
 
    if (!ozone || !data)
       return false;
@@ -2342,18 +2342,27 @@ static bool ozone_load_image(void *userdata, void *data, enum menu_image_type ty
 
    sidebar_height = height - ozone->dimensions.header_height - 55 - ozone->dimensions.footer_height;
    maximum_height = sidebar_height / 2;
+   maximum_width  = ozone->dimensions.thumbnail_bar_width - ozone->dimensions.sidebar_entry_icon_padding * 2;
 
    switch (type)
    {
       case MENU_IMAGE_THUMBNAIL:
       {
          struct texture_image *img  = (struct texture_image*)data;
+         float scale_down;
+
          ozone->dimensions.thumbnail_height      = ozone->dimensions.thumbnail_width
             * (float)img->height / (float)img->width;
 
-         if (ozone->dimensions.thumbnail_height > maximum_height)
+         scale_down = (float) maximum_height / ozone->dimensions.thumbnail_height;
+
+         ozone->dimensions.thumbnail_height  *= scale_down;
+         ozone->dimensions.thumbnail_width   *= scale_down;
+
+         if (ozone->dimensions.thumbnail_width > (float)maximum_width)
          {
-            float scale_down = (float) maximum_height / (float) ozone->dimensions.thumbnail_height;
+            scale_down = (float) maximum_width / ozone->dimensions.thumbnail_width;
+
             ozone->dimensions.thumbnail_height  *= scale_down;
             ozone->dimensions.thumbnail_width   *= scale_down;
          }

--- a/menu/drivers/ozone/ozone.h
+++ b/menu/drivers/ozone/ozone.h
@@ -24,7 +24,9 @@ typedef struct ozone_handle ozone_handle_t;
 
 #include <retro_miscellaneous.h>
 
+#include "../../menu_thumbnail_path.h"
 #include "../../menu_driver.h"
+
 #include "../../../retroarch.h"
 
 #define ANIMATION_PUSH_ENTRY_DURATION  166
@@ -229,18 +231,17 @@ struct ozone_handle
    /* Thumbnails data */
    bool show_thumbnail_bar;
 
-   char *thumbnail_content;
-   char *thumbnail_system;
-   char *thumbnail_file_path;
-   char *left_thumbnail_file_path; /* name taken from xmb for consistency but not actually on the left */
-
    uintptr_t thumbnail;
    uintptr_t left_thumbnail;
+
+   menu_thumbnail_path_data_t *thumbnail_path_data;
 
    char selection_core_name[255];
    char selection_playtime[255];
    char selection_lastplayed[255];
    unsigned selection_core_name_lines;
+
+   bool is_db_manager_list;
 };
 
 /* If you change this struct, also
@@ -306,8 +307,6 @@ void ozone_sidebar_update_collapse(ozone_handle_t *ozone, bool allow_animation);
 void ozone_entries_update_thumbnail_bar(ozone_handle_t *ozone, bool is_playlist, bool allow_animation);
 
 void ozone_draw_thumbnail_bar(ozone_handle_t *ozone, video_frame_info_t *video_info);
-
-const char *ozone_thumbnails_ident(char pos);
 
 unsigned ozone_count_lines(const char *str);
 

--- a/menu/drivers/ozone/ozone.h
+++ b/menu/drivers/ozone/ozone.h
@@ -238,8 +238,8 @@ struct ozone_handle
    uintptr_t left_thumbnail;
 
    char selection_core_name[255];
-   char selection_playtime[64];
-   char selection_lastplayed[64];
+   char selection_playtime[255];
+   char selection_lastplayed[255];
    unsigned selection_core_name_lines;
 };
 

--- a/menu/drivers/ozone/ozone.h
+++ b/menu/drivers/ozone/ozone.h
@@ -310,4 +310,6 @@ void ozone_draw_thumbnail_bar(ozone_handle_t *ozone, video_frame_info_t *video_i
 
 unsigned ozone_count_lines(const char *str);
 
+void ozone_update_content_metadata(ozone_handle_t *ozone);
+
 #endif

--- a/menu/drivers/ozone/ozone_entries.c
+++ b/menu/drivers/ozone/ozone_entries.c
@@ -700,7 +700,7 @@ void ozone_draw_thumbnail_bar(ozone_handle_t *ozone, video_frame_info_t *video_i
    /* Top row : thumbnail or no thumbnail available message */
    if (thumbnail)
    {
-      unsigned thumb_x_position = x_position + sidebar_width/2 - (ozone->dimensions.thumbnail_width + ozone->dimensions.sidebar_entry_icon_padding) / 2;
+      unsigned thumb_x_position = x_position + sidebar_width/2 - ozone->dimensions.thumbnail_width / 2;
       unsigned thumb_y_position = video_info->height / 2 - ozone->dimensions.thumbnail_height / 2;
 
       if (!string_is_equal(ozone->selection_core_name, "imageviewer"))
@@ -731,7 +731,7 @@ void ozone_draw_thumbnail_bar(ozone_handle_t *ozone, video_frame_info_t *video_i
    /* Bottom row : "left" thumbnail or content metadata */
    if (thumbnail && left_thumbnail)
    {
-      unsigned thumb_x_position = x_position + sidebar_width/2 - (ozone->dimensions.left_thumbnail_width + ozone->dimensions.sidebar_entry_icon_padding) / 2;
+      unsigned thumb_x_position = x_position + sidebar_width/2 - ozone->dimensions.left_thumbnail_width / 2;
       unsigned thumb_y_position = video_info->height / 2 + ozone->dimensions.sidebar_entry_icon_padding / 2;
 
       ozone_draw_icon(video_info,

--- a/menu/drivers/ozone/ozone_entries.c
+++ b/menu/drivers/ozone/ozone_entries.c
@@ -682,11 +682,9 @@ void ozone_draw_thumbnail_bar(ozone_handle_t *ozone, video_frame_info_t *video_i
 
    /* Thumbnails */
    thumbnail = ozone->thumbnail &&
-      !string_is_equal(ozone_thumbnails_ident('R'),
-         msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF));
+     menu_thumbnail_is_enabled(MENU_THUMBNAIL_RIGHT);
    left_thumbnail = ozone->left_thumbnail &&
-      !string_is_equal(ozone_thumbnails_ident('L'),
-         msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF));
+      menu_thumbnail_is_enabled(MENU_THUMBNAIL_LEFT);
 
    /* If user requested "left" thumbnail instead of content metadata
     * and no thumbnails are available, show a centered message and

--- a/menu/drivers/ozone/ozone_entries.c
+++ b/menu/drivers/ozone/ozone_entries.c
@@ -138,7 +138,13 @@ void ozone_update_scroll(ozone_handle_t *ozone, bool allow_animation, ozone_node
 
    video_driver_get_size(NULL, &video_info_height);
 
-   current_selection_middle_onscreen    = ozone->dimensions.header_height + ozone->dimensions.entry_padding_vertical + ozone->animations.scroll_y + node->position_y + node->height / 2;
+   current_selection_middle_onscreen    =
+      ozone->dimensions.header_height +
+      ozone->dimensions.entry_padding_vertical +
+      ozone->animations.scroll_y +
+      node->position_y +
+      node->height / 2;
+
    bottom_boundary                      = video_info_height - ozone->dimensions.header_height - 1 - ozone->dimensions.footer_height;
    entries_middle                       = video_info_height/2;
 
@@ -639,28 +645,14 @@ static void ozone_draw_no_thumbnail_available(ozone_handle_t *ozone,
 }
 
 static void ozone_content_metadata_line(video_frame_info_t *video_info, ozone_handle_t *ozone,
-   unsigned *y, unsigned title_column_x, unsigned data_column_x,
-   const char *title, const char *data, unsigned lines_count)
+   unsigned *y, unsigned column_x,
+   const char *text, unsigned lines_count)
 {
    ozone_draw_text(video_info, ozone,
-      title,
-      title_column_x,
+      text,
+      column_x,
       *y + FONT_SIZE_FOOTER,
       TEXT_ALIGN_LEFT,
-      video_info->width, video_info->height,
-      ozone->fonts.footer,
-      ozone->theme->text_rgba,
-      true
-   );
-
-   if (font_driver_get_message_width(ozone->fonts.footer, data, strlen(data), 1) > ozone->dimensions.thumbnail_bar_width / 2)
-      *y += font_driver_get_line_height(ozone->fonts.footer, 1);
-
-   ozone_draw_text(video_info, ozone,
-      data,
-      data_column_x,
-      *y + FONT_SIZE_FOOTER,
-      TEXT_ALIGN_RIGHT,
       video_info->width, video_info->height,
       ozone->fonts.footer,
       ozone->theme->text_rgba,
@@ -758,8 +750,7 @@ void ozone_draw_thumbnail_bar(ozone_handle_t *ozone, video_frame_info_t *video_i
       unsigned y                          = video_info->height / 2 + ozone->dimensions.sidebar_entry_icon_padding / 2;
       unsigned content_metadata_padding   = ozone->dimensions.sidebar_entry_icon_padding*3;
       unsigned separator_padding          = ozone->dimensions.sidebar_entry_icon_padding*2;
-      unsigned title_column_x             = x_position + content_metadata_padding;
-      unsigned data_column_x              = x_position + sidebar_width - content_metadata_padding;
+      unsigned column_x                   = x_position + content_metadata_padding;
 
       /* Content metadata */
       y += 10;
@@ -775,26 +766,23 @@ void ozone_draw_thumbnail_bar(ozone_handle_t *ozone, video_frame_info_t *video_i
 
       /* Core association */
       ozone_content_metadata_line(video_info, ozone,
-         &y, title_column_x, data_column_x,
-         msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLIST_SUBLABEL_CORE),
+         &y, column_x,
          ozone->selection_core_name,
          ozone->selection_core_name_lines
       );
 
       /* Playtime */
       ozone_content_metadata_line(video_info, ozone,
-         &y, title_column_x, data_column_x,
-         msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLIST_SUBLABEL_RUNTIME),
+         &y, column_x,
          ozone->selection_playtime,
          1
       );
 
       /* Last played */
       ozone_content_metadata_line(video_info, ozone,
-         &y, title_column_x, data_column_x,
-         msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLIST_SUBLABEL_LAST_PLAYED),
+         &y, column_x,
          ozone->selection_lastplayed,
-         1
+         2
       );
    }
 }

--- a/menu/drivers/ozone/ozone_sidebar.c
+++ b/menu/drivers/ozone/ozone_sidebar.c
@@ -292,6 +292,8 @@ void ozone_leave_sidebar(ozone_handle_t *ozone, uintptr_t tag)
    if (ozone->empty_playlist)
       return;
 
+   ozone_update_content_metadata(ozone);
+
    ozone->categories_active_idx_old = ozone->categories_selection_ptr;
    ozone->cursor_in_sidebar_old     = ozone->cursor_in_sidebar;
    ozone->cursor_in_sidebar         = false;


### PR DESCRIPTION
 - fixed a crash introduced by commit 643cd1923e40be9320b457fcf678d9c0a7f44958
 - changed the content metadata panel layout to have everything left-aligned
 - fixed the thumbnails position and size
 - changed the code to use the new menu_thumbnail system by @jdgleaver 