### PR TITLE
(libchdr) Use int types and format aligned to the `chd_header` typedef

### DIFF
--- a/libretro-common/formats/libchdr/libchdr_chd.c
+++ b/libretro-common/formats/libchdr/libchdr_chd.c
@@ -1335,7 +1335,7 @@ static UINT32 header_guess_unitbytes(chd_file *chd)
 {
 	/* look for hard disk metadata; if found, then the unit size == sector size */
 	char metadata[512];
-	int i0, i1, i2, i3;
+	unsigned int i0, i1, i2, i3;
 	if (chd_get_metadata(chd, HARD_DISK_METADATA_TAG, 0, metadata, sizeof(metadata), NULL, NULL, NULL) == CHDERR_NONE &&
 		sscanf(metadata, HARD_DISK_METADATA_FORMAT, &i0, &i1, &i2, &i3) == 4)
 		return i3;

--- a/libretro-common/include/libchdr/chd.h
+++ b/libretro-common/include/libchdr/chd.h
@@ -212,7 +212,7 @@ extern "C" {
 
 /* standard hard disk metadata */
 #define HARD_DISK_METADATA_TAG		0x47444444	/* 'GDDD' */
-#define HARD_DISK_METADATA_FORMAT	"CYLS:%d,HEADS:%d,SECS:%d,BPS:%d"
+#define HARD_DISK_METADATA_FORMAT	"CYLS:%u,HEADS:%u,SECS:%u,BPS:%u"
 
 /* hard disk identify information */
 #define HARD_DISK_IDENT_METADATA_TAG 0x49444e54 /* 'IDNT' */


### PR DESCRIPTION
## Description

In `libchdr_chd.c`, the `HARD_DISK_METADATA_FORMAT` define is used to format unsigned int values:

```
sprintf(faux_metadata, HARD_DISK_METADATA_FORMAT, chd->header.obsolete_cylinders, chd->header.obsolete_heads, chd->header.obsolete_sectors, chd->header.hunkbytes / chd->header.obsolete_hunksize);
```

```
typedef struct _chd_header chd_header;
struct _chd_header
{
       :
       UINT32          hunkbytes;
       :
       UINT32          obsolete_cylinders;
       UINT32          obsolete_sectors;
       UINT32          obsolete_heads;
       UINT32          obsolete_hunksize;
       :
}
```

Therefore, use the correct format specification (`%u`) in the corresponding format define. This change creates a warning later in an `sscanf` call due to the new format, fix that too. Note that the function where this `sscanf` is used does in fact return an unsigned integer, so using `unsigned int` is actually correct.

Tested with plain make, with `C89_BUILD=1` and `CXX_BUILD=1` and all is building fine.

## Related Pull Requests

Follow up of #8469 regarding libchdr

## Reviewers

@orbea 
