### PR TITLE
(XMB) Fix display glitches when refreshing current menu

### DIFF
--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -2061,6 +2061,8 @@ static void xmb_list_open(xmb_handle_t *xmb)
       dir = 1;
    else if (xmb->depth < xmb->old_depth)
       dir = -1;
+   else
+      return; /* If menu hasn't changed, do nothing */
 
    xmb_list_open_horizontal_list(xmb);
 


### PR DESCRIPTION
## Description

XMB currently presents visual glitches when refreshing the currently displayed menu. This does not happen often, but it can be triggered by e.g. resetting the number of shader passes or resetting cheats.

This is caused by XMB performing a standard (fade out old list)/(fade in new list) operation each time a 'refresh' is triggered - even when the current menu hasn't changed. The resultant animation therefore pushes irrelevant icons from the previous menu level onto the screen.

This PR fixes the issue by disabling animations when 'refresh' is triggered without changing menu levels.
