### PR TITLE
strlcpy() safety checks

### DIFF
--- a/menu/menu_thumbnail_path.c
+++ b/menu/menu_thumbnail_path.c
@@ -243,6 +243,8 @@ bool menu_thumbnail_set_content(menu_thumbnail_path_data_t *path_data, const cha
  * Returns true if content is valid */
 bool menu_thumbnail_set_content_image(menu_thumbnail_path_data_t *path_data, const char *img_dir, const char *img_name)
 {
+   char *content_img_no_ext = NULL;
+   
    if (!path_data)
       return false;
    
@@ -272,8 +274,13 @@ bool menu_thumbnail_set_content_image(menu_thumbnail_path_data_t *path_data, con
             img_name, sizeof(path_data->content_img));
    
    /* Get image label */
-   strlcpy(path_data->content_label,
-               path_remove_extension(path_data->content_img), sizeof(path_data->content_label));
+   content_img_no_ext = path_remove_extension(path_data->content_img);
+   if (!string_is_empty(content_img_no_ext))
+      strlcpy(path_data->content_label,
+            content_img_no_ext, sizeof(path_data->content_label));
+   else
+      strlcpy(path_data->content_label,
+            path_data->content_img, sizeof(path_data->content_label));
    
    /* Set file path */
    fill_pathname_join(path_data->content_path,
@@ -376,16 +383,22 @@ bool menu_thumbnail_set_content_playlist(menu_thumbnail_path_data_t *path_data, 
                "MAME", sizeof(path_data->content_db_name));
       else
       {
+         char *db_name_no_ext = NULL;
          char tmp_buf[PATH_MAX_LENGTH];
          tmp_buf[0] = '\0';
-         
-         strlcpy(tmp_buf, db_name, sizeof(tmp_buf));
          
          /* Remove .lpl extension
           * > path_remove_extension() requires a char * (not const)
           *   so have to use a temporary buffer... */
-         strlcpy(path_data->content_db_name,
-               path_remove_extension(tmp_buf), sizeof(path_data->content_db_name));
+         strlcpy(tmp_buf, db_name, sizeof(tmp_buf));
+         db_name_no_ext = path_remove_extension(tmp_buf);
+         
+         if (!string_is_empty(db_name_no_ext))
+            strlcpy(path_data->content_db_name,
+                  db_name_no_ext, sizeof(path_data->content_db_name));
+         else
+            strlcpy(path_data->content_db_name,
+                  tmp_buf, sizeof(path_data->content_db_name));
       }
    }
    

--- a/runtime_file.c
+++ b/runtime_file.c
@@ -319,8 +319,13 @@ runtime_log_t *runtime_log_init(const char *content_path, const char *core_path,
    {
       if (string_is_equal(path_basename(core_info->list[i].path), core_path_basename))
       {
-         strlcpy(core_name, core_info->list[i].core_name, sizeof(core_name));
-         break;
+         if (!string_is_empty(core_info->list[i].core_name))
+         {
+            strlcpy(core_name, core_info->list[i].core_name, sizeof(core_name));
+            break;
+         }
+         else
+            return NULL;
       }
    }
    
@@ -340,6 +345,9 @@ runtime_log_t *runtime_log_init(const char *content_path, const char *core_path,
    }
    else
       strlcpy(tmp_buf, settings->paths.directory_runtime_log, sizeof(tmp_buf));
+   
+   if (string_is_empty(tmp_buf))
+      return NULL;
    
    if (log_per_core)
    {
@@ -388,9 +396,14 @@ runtime_log_t *runtime_log_init(const char *content_path, const char *core_path,
    {
       /* path_remove_extension() requires a char * (not const)
        * so have to use a temporary buffer... */
+      char *tmp_buf_no_ext = NULL;
       tmp_buf[0] = '\0';
       strlcpy(tmp_buf, path_basename(content_path), sizeof(tmp_buf));
-      strlcpy(content_name, path_remove_extension(tmp_buf), sizeof(content_name));
+      tmp_buf_no_ext = path_remove_extension(tmp_buf);
+      if (!string_is_empty(tmp_buf_no_ext))
+         strlcpy(content_name, tmp_buf_no_ext, sizeof(content_name));
+      else
+         return NULL;
    }
    
    if (string_is_empty(content_name))


### PR DESCRIPTION
## Description

At present, there are a few instances in `runtime_file.c` and `menu_thumbnail_path.c` where strlcpy() can potentially be called with a NULL argument (leading to segfaults).

This PR removes this issue.
