### PR TITLE
Update JSON playlist detection

### DIFF
--- a/playlist.c
+++ b/playlist.c
@@ -1363,9 +1363,9 @@ static bool playlist_read_file(
 
       filestream_seek(file, 0, SEEK_SET);
 
-      if (bytes_read == 15)
+      if (bytes_read == 1)
       {
-         if (string_is_equal(buf, "{\n  \"version\": "))
+         if (string_is_equal(buf, "{"))
          {
             /* new playlist format detected */
             /*RARCH_LOG("New playlist format detected.\n");*/


### PR DESCRIPTION
This pull request loosens the restriction requirements on detecting a JSON playlist. If the first character in the playlist is a `{`, then it assumes it's the JSON format.

## Related Issues

- https://github.com/libretro/RetroArch/issues/8439

## Reviewers

- @bparker06 
- @fr500 
