### PR TITLE
Fix caca warning.

### DIFF
--- a/gfx/drivers/caca_gfx.c
+++ b/gfx/drivers/caca_gfx.c
@@ -317,6 +317,7 @@ static const video_poke_interface_t caca_poke_interface = {
    NULL,
    NULL,
    NULL,
+   NULL,
    caca_set_texture_frame,
    NULL,
    caca_set_osd_msg,


### PR DESCRIPTION
## Description

One too many lines were removed in `gfx/drivers/caca_gfx.c` causing a warning and maybe other issues.

## Related Issues

```
gfx/drivers/caca_gfx.c:320:4: warning: initialization of ‘void (*)(void *)’ from incompatible pointer type ‘void (*)(void *, const void *, _Bool,  unsigned int,  unsigned int,  float)’ [-Wincompatible-pointer-types]
    caca_set_texture_frame,
    ^~~~~~~~~~~~~~~~~~~~~~
gfx/drivers/caca_gfx.c:320:4: note: (near initialization for ‘caca_poke_interface.apply_state_changes’)
gfx/drivers/caca_gfx.c:322:4: warning: initialization of ‘void (*)(void *, _Bool,  _Bool)’ from incompatible pointer type ‘void (*)(void *, video_frame_info_t *, const char *, const void *, void *)’ {aka ‘void (*)(void *, struct video_frame_info *, const char *, const void *, void *)’} [-Wincompatible-pointer-types]
    caca_set_osd_msg,
    ^~~~~~~~~~~~~~~~
gfx/drivers/caca_gfx.c:322:4: note: (near initialization for ‘caca_poke_interface.set_texture_enable’)
```

## Related Pull Requests

https://github.com/libretro/RetroArch/commit/f67bfa24efed294dec4410d04c970c53cca793f0#diff-74ea0717ca6841276ab0a023f34a870aL309

## Reviewers

@twinaphex 