### PR TITLE
Add glsym private

### DIFF
--- a/libretro-common/include/glsym/glsym.h
+++ b/libretro-common/include/glsym/glsym.h
@@ -38,4 +38,8 @@
 #endif
 #endif
 
+#ifdef HAVE_GLSYM_PRIVATE
+#include "glsym_private.h"
+#endif
+
 #endif


### PR DESCRIPTION
Allows core developpers to add their own definitions when working with glsm. 2 things needed : 
- enable the `HAVE_GLSYM_PRIVATE` define
- create a glsym_private.h with your logic
You can find an example of usage at https://github.com/libretro/yabause/tree/yabasanshiro/yabause/src/libretro