### PR TITLE
[VITA] Bluetooth mouse and keyboard support

### DIFF
--- a/Makefile.griffin
+++ b/Makefile.griffin
@@ -271,7 +271,7 @@ else ifeq ($(platform), vita)
    PLATCFLAGS := -mfloat-abi=hard -fsingle-precision-constant \
         -mword-relocations -fno-unwind-tables -fno-asynchronous-unwind-tables -ftree-vectorize -fno-optimize-sibling-calls
    LIBS += -lSceDisplay_stub -lSceGxm_stub -lSceNet_stub -lSceNetCtl_stub\
-           -lSceSysmodule_stub -lSceCtrl_stub -lSceTouch_stub -lSceAudio_stub -lSceFiber_stub\
+           -lSceSysmodule_stub -lSceCtrl_stub -lSceHid_stub -lSceTouch_stub -lSceAudio_stub -lSceFiber_stub\
            -lScePower_stub -lSceRtc_stub -lSceCommonDialog_stub -lScePgf_stub \
            -lSceMotion_stub -lSceAppMgr_stub -lpng -lm -lc
 

--- a/Makefile.vita
+++ b/Makefile.vita
@@ -116,7 +116,7 @@ endif
 CXXFLAGS := $(CFLAGS) -fno-rtti -fno-exceptions
 
 VITA_LIBS := -lSceDisplay_stub -lSceGxm_stub -lSceNet_stub -lSceNetCtl_stub \
-	-lSceSysmodule_stub -lSceCtrl_stub -lSceTouch_stub -lSceAudio_stub \
+	-lSceSysmodule_stub -lSceCtrl_stub -lSceHid_stub -lSceTouch_stub -lSceAudio_stub \
 	-lScePower_stub -lSceRtc_stub -lSceCommonDialog_stub -lScePgf_stub \
 	-lSceFiber_stub -lSceMotion_stub -lSceAppMgr_stub -lpthread -lpng -lz
 

--- a/Makefile.vita.salamander
+++ b/Makefile.vita.salamander
@@ -22,7 +22,7 @@ RARCH_DEFINES = -DVITA -DIS_SALAMANDER -DRARCH_CONSOLE
 LIBDIR =
 LDFLAGS =
 LIBS = -lSceDisplay_stub -lSceGxm_stub -lSceNet_stub -lSceNetCtl_stub\
-     -lSceSysmodule_stub -lSceCtrl_stub -lSceAudio_stub -lSceFiber_stub\
+     -lSceSysmodule_stub -lSceCtrl_stub -lSceHid_stub -lSceAudio_stub -lSceFiber_stub\
      -lScePower_stub -lSceRtc_stub -lSceCommonDialog_stub -lScePgf_stub \
      -lSceMotion_stub -lSceAppMgr_stub -lfreetype -lpng -lm -lc
 

--- a/input/input_keymaps.c
+++ b/input/input_keymaps.c
@@ -411,6 +411,147 @@ const struct rarch_key_map rarch_key_map_switch[] = {
 };
 #endif
 
+#ifdef VITA
+// Vita scancodes are identical to USB 2.0 standard, e.g. SDL2
+const struct rarch_key_map rarch_key_map_vita[] = {
+   { 0x02A, RETROK_BACKSPACE },
+   { 0x02B, RETROK_TAB },
+   { 0x09C, RETROK_CLEAR },
+   { 0x028, RETROK_RETURN },
+   { 0x048, RETROK_PAUSE },
+   { 0x029, RETROK_ESCAPE },
+   { 0x02C, RETROK_SPACE },
+   /*{ ?, RETROK_EXCLAIM },*/
+   /*{ ?, RETROK_QUOTEDBL },*/
+   /*{ ?, RETROK_HASH },*/
+   /*{ ?, RETROK_DOLLAR },*/
+   /*{ ?, RETROK_AMPERSAND },*/
+   { 0x034, RETROK_QUOTE },
+   /*{ ?, RETROK_LEFTPAREN },*/
+   /*{ ?, RETROK_RIGHTPAREN },*/
+   /*{ ?, RETROK_ASTERISK },*/
+   /*{ ?, RETROK_PLUS },*/
+   { 0x036, RETROK_COMMA },
+   { 0x02D, RETROK_MINUS },
+   { 0x037, RETROK_PERIOD },
+   { 0x038, RETROK_SLASH },
+   { 0x027, RETROK_0 },
+   { 0x01E, RETROK_1 },
+   { 0x01F, RETROK_2 },
+   { 0x020, RETROK_3 },
+   { 0x021, RETROK_4 },
+   { 0x022, RETROK_5 },
+   { 0x023, RETROK_6 },
+   { 0x024, RETROK_7 },
+   { 0x025, RETROK_8 },
+   { 0x026, RETROK_9 },
+   /*{ ?, RETROK_COLON },*/
+   { 0x033, RETROK_SEMICOLON },
+   /*{ ?, RETROK_OEM_102 },*/
+   { 0x02E, RETROK_EQUALS },
+   /*{ ?, RETROK_GREATER },*/
+   /*{ ?, RETROK_QUESTION },*/
+   /*{ ?, RETROK_AT },*/
+   { 0x02F, RETROK_LEFTBRACKET },
+   { 0x031, RETROK_BACKSLASH },
+   { 0x030, RETROK_RIGHTBRACKET },
+   /*{ ?, RETROK_CARET },*/
+   /*{ ?, RETROK_UNDERSCORE },*/
+   { 0x035, RETROK_BACKQUOTE },
+   { 0x004, RETROK_a },
+   { 0x005, RETROK_b },
+   { 0x006, RETROK_c },
+   { 0x007, RETROK_d },
+   { 0x008, RETROK_e },
+   { 0x009, RETROK_f },
+   { 0x00A, RETROK_g },
+   { 0x00B, RETROK_h },
+   { 0x00C, RETROK_i },
+   { 0x00D, RETROK_j },
+   { 0x00E, RETROK_k },
+   { 0x00F, RETROK_l },
+   { 0x010, RETROK_m },
+   { 0x011, RETROK_n },
+   { 0x012, RETROK_o },
+   { 0x013, RETROK_p },
+   { 0x014, RETROK_q },
+   { 0x015, RETROK_r },
+   { 0x016, RETROK_s },
+   { 0x017, RETROK_t },
+   { 0x018, RETROK_u },
+   { 0x019, RETROK_v },
+   { 0x01A, RETROK_w },
+   { 0x01B, RETROK_x },
+   { 0x01C, RETROK_y },
+   { 0x01D, RETROK_z },
+   { 0x04C, RETROK_DELETE },
+   { 0x062, RETROK_KP0 },
+   { 0x059, RETROK_KP1 },
+   { 0x05A, RETROK_KP2 },
+   { 0x05B, RETROK_KP3 },
+   { 0x05C, RETROK_KP4 },
+   { 0x05D, RETROK_KP5 },
+   { 0x05E, RETROK_KP6 },
+   { 0x05F, RETROK_KP7 },
+   { 0x060, RETROK_KP8 },
+   { 0x061, RETROK_KP9 },
+   { 0x063, RETROK_KP_PERIOD },
+   { 0x054, RETROK_KP_DIVIDE },
+   { 0x055, RETROK_KP_MULTIPLY },
+   { 0x056, RETROK_KP_MINUS },
+   { 0x057, RETROK_KP_PLUS },
+   { 0x058, RETROK_KP_ENTER },
+   { 0x067, RETROK_KP_EQUALS },
+   { 0x052, RETROK_UP },
+   { 0x051, RETROK_DOWN },
+   { 0x04F, RETROK_RIGHT },
+   { 0x050, RETROK_LEFT },
+   { 0x049, RETROK_INSERT },
+   { 0x04A, RETROK_HOME },
+   { 0x04D, RETROK_END },
+   { 0x04B, RETROK_PAGEUP },
+   { 0x04E, RETROK_PAGEDOWN },
+   { 0x03A, RETROK_F1 },
+   { 0x03B, RETROK_F2 },
+   { 0x03C, RETROK_F3 },
+   { 0x03D, RETROK_F4 },
+   { 0x03E, RETROK_F5 },
+   { 0x03F, RETROK_F6 },
+   { 0x040, RETROK_F7 },
+   { 0x041, RETROK_F8 },
+   { 0x042, RETROK_F9 },
+   { 0x043, RETROK_F10 },
+   { 0x044, RETROK_F11 },
+   { 0x045, RETROK_F12 },
+   { 0x068, RETROK_F13 },
+   { 0x069, RETROK_F14 },
+   { 0x06A, RETROK_F15 },
+   { 0x053, RETROK_NUMLOCK },
+   { 0x039, RETROK_CAPSLOCK },
+   { 0x047, RETROK_SCROLLOCK },
+   { 0x0E5, RETROK_RSHIFT },
+   { 0x0E1, RETROK_LSHIFT },
+   { 0x0E4, RETROK_RCTRL },
+   { 0x0E0, RETROK_LCTRL },
+   { 0x0E6, RETROK_RALT },
+   { 0x0E2, RETROK_LALT },
+   /* { ?, RETROK_RMETA }, */
+   /* { ?, RETROK_LMETA }, */
+   { 0x0E3, RETROK_LSUPER },
+   { 0x0E7, RETROK_RSUPER },
+   /* { ?, RETROK_MODE },*/
+   { 0x075, RETROK_HELP },
+   { 0x046, RETROK_PRINT },
+   { 0x09A, RETROK_SYSREQ },
+   { 0x048, RETROK_BREAK },
+   { 0x076, RETROK_MENU },
+   { 0x066, RETROK_POWER },
+   /*{ ?, RETROK_EURO },*/
+   { 0x07A, RETROK_UNDO },
+   { 0, RETROK_UNKNOWN },
+};
+#endif
+
 #if defined(HAVE_SDL) || defined(HAVE_SDL2)
 const struct rarch_key_map rarch_key_map_sdl[] = {
    { SDLK_BACKSPACE, RETROK_BACKSPACE },

--- a/input/input_keymaps.h
+++ b/input/input_keymaps.h
@@ -68,6 +68,9 @@ extern const struct rarch_key_map rarch_key_map_winraw[];
 #ifdef HAVE_LIBNX
 extern const struct rarch_key_map rarch_key_map_switch[];
 #endif
+#ifdef VITA
+extern const struct rarch_key_map rarch_key_map_vita[];
+#endif
 
 /**
  * input_keymaps_init_keyboard_lut:


### PR DESCRIPTION
## Description

This PR implements Bluetooth keyboard and mouse support for the Vita (PSP2) platform, similar to my recent libnx implementation.

[![Vita-keyb.jpg](https://i.postimg.cc/FHg1RVFr/Vita-keyb.jpg)](https://postimg.cc/k2G7Y8tz)

## Related Issues

none

## Related Pull Requests

none

## Reviewers

Tested working in menu and dosbox core, but if people must look, maybe @frangarcj or @m4xw.