### PR TITLE
gfx video filters: blargg ntsc snes conflicts

### DIFF
--- a/gfx/video_filters/blargg_ntsc_snes.c
+++ b/gfx/video_filters/blargg_ntsc_snes.c
@@ -84,35 +84,35 @@ static void blargg_ntsc_snes_initialize(void *data,
    {
       if (memcmp(tvtype, "composite", 9) == 0)
       {
-         setup = snes_ntsc_composite;
+         setup = retroarch_snes_ntsc_composite;
          setup.merge_fields = 1;
       }
       else if (memcmp(tvtype, "rf", 2) == 0)
       {
-         setup = snes_ntsc_composite;
+         setup = retroarch_snes_ntsc_composite;
          setup.merge_fields = 0;
       }
       else if (memcmp(tvtype, "rgb", 3) == 0)
       {
-         setup = snes_ntsc_rgb;
+         setup = retroarch_snes_ntsc_rgb;
          setup.merge_fields = 1;
       }
       else if (memcmp(tvtype, "svideo", 6) == 0)
       {
-         setup = snes_ntsc_svideo;
+         setup = retroarch_snes_ntsc_svideo;
          setup.merge_fields = 1;
       }
    }
    else
    {
-      setup = snes_ntsc_composite;
+      setup = retroarch_snes_ntsc_composite;
       setup.merge_fields = 1;
    }
 
    config->free(tvtype);
    tvtype = NULL;
 
-   snes_ntsc_init(filt->ntsc, &setup);
+   retroarch_snes_ntsc_init(filt->ntsc, &setup);
 
    filt->burst = 0;
    filt->burst_toggle = (setup.merge_fields ? 0 : 1);
@@ -170,10 +170,10 @@ static void blargg_ntsc_snes_render_rgb565(void *data, int width, int height,
 {
    struct filter_data *filt = (struct filter_data*)data;
    if(width <= 256)
-      snes_ntsc_blit(filt->ntsc, input, pitch, filt->burst,
+      retroarch_snes_ntsc_blit(filt->ntsc, input, pitch, filt->burst,
             width, height, output, outpitch * 2, first, last);
    else
-      snes_ntsc_blit_hires(filt->ntsc, input, pitch, filt->burst,
+      retroarch_snes_ntsc_blit_hires(filt->ntsc, input, pitch, filt->burst,
             width, height, output, outpitch * 2, first, last);
 
    filt->burst ^= filt->burst_toggle;

--- a/gfx/video_filters/snes_ntsc/snes_ntsc.c
+++ b/gfx/video_filters/snes_ntsc/snes_ntsc.c
@@ -15,10 +15,10 @@ details. You should have received a copy of the GNU Lesser General Public
 License along with this module; if not, write to the Free Software Foundation,
 Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA */
 
-snes_ntsc_setup_t const snes_ntsc_monochrome = { 0,-1, 0, 0,.2,  0,.2,-.2,-.2,-1,  1, 0, 0 };
-snes_ntsc_setup_t const snes_ntsc_composite  = { 0, 0, 0, 0, 0,  0, 0,  0,  0, 0,  1, 0, 0 };
-snes_ntsc_setup_t const snes_ntsc_svideo     = { 0, 0, 0, 0,.2,  0,.2, -1, -1, 0,  1, 0, 0 };
-snes_ntsc_setup_t const snes_ntsc_rgb        = { 0, 0, 0, 0,.2,  0,.7, -1, -1,-1,  1, 0, 0 };
+snes_ntsc_setup_t const retroarch_snes_ntsc_monochrome = { 0,-1, 0, 0,.2,  0,.2,-.2,-.2,-1,  1, 0, 0 };
+snes_ntsc_setup_t const retroarch_snes_ntsc_composite  = { 0, 0, 0, 0, 0,  0, 0,  0,  0, 0,  1, 0, 0 };
+snes_ntsc_setup_t const retroarch_snes_ntsc_svideo     = { 0, 0, 0, 0,.2,  0,.2, -1, -1, 0,  1, 0, 0 };
+snes_ntsc_setup_t const retroarch_snes_ntsc_rgb        = { 0, 0, 0, 0,.2,  0,.7, -1, -1,-1,  1, 0, 0 };
 
 #define alignment_count 3
 #define burst_count     3
@@ -35,7 +35,7 @@ snes_ntsc_setup_t const snes_ntsc_rgb        = { 0, 0, 0, 0,.2,  0,.7, -1, -1,-1
 #include "snes_ntsc_impl.h"
 
 /* 3 input pixels -> 8 composite samples */
-pixel_info_t const snes_ntsc_pixels [alignment_count] = {
+pixel_info_t const retroarch_snes_ntsc_pixels [alignment_count] = {
 	{ PIXEL_OFFSET( -4, -9 ), { 1, 1, .6667f, 0 } },
 	{ PIXEL_OFFSET( -2, -7 ), {       .3333f, 1, 1, .3333f } },
 	{ PIXEL_OFFSET(  0, -5 ), {                  0, .6667f, 1, 1 } },
@@ -77,13 +77,13 @@ static void correct_errors( snes_ntsc_rgb_t color, snes_ntsc_rgb_t* out )
 	}
 }
 
-void snes_ntsc_init( snes_ntsc_t* ntsc, snes_ntsc_setup_t const* setup )
+void retroarch_snes_ntsc_init( snes_ntsc_t* ntsc, snes_ntsc_setup_t const* setup )
 {
 	int merge_fields;
 	int entry;
 	init_t impl;
 	if ( !setup )
-		setup = &snes_ntsc_composite;
+		setup = &retroarch_snes_ntsc_composite;
 	init( &impl, setup );
 
 	merge_fields = setup->merge_fields;
@@ -118,7 +118,7 @@ void snes_ntsc_init( snes_ntsc_t* ntsc, snes_ntsc_setup_t const* setup )
 
 #ifndef SNES_NTSC_NO_BLITTERS
 
-void snes_ntsc_blit( snes_ntsc_t const* ntsc, SNES_NTSC_IN_T const* input, long in_row_width,
+void retroarch_snes_ntsc_blit( snes_ntsc_t const* ntsc, SNES_NTSC_IN_T const* input, long in_row_width,
 		int burst_phase, int in_width, int in_height, void* rgb_out, long out_pitch, int first, int last )
 {
 	int chunk_count = (in_width - 1) / snes_ntsc_in_chunk;
@@ -171,7 +171,7 @@ void snes_ntsc_blit( snes_ntsc_t const* ntsc, SNES_NTSC_IN_T const* input, long 
 	}
 }
 
-void snes_ntsc_blit_hires( snes_ntsc_t const* ntsc, SNES_NTSC_IN_T const* input, long in_row_width,
+void retroarch_snes_ntsc_blit_hires( snes_ntsc_t const* ntsc, SNES_NTSC_IN_T const* input, long in_row_width,
 		int burst_phase, int in_width, int in_height, void* rgb_out, long out_pitch, int first, int last )
 {
 	int chunk_count = (in_width - 2) / (snes_ntsc_in_chunk * 2);

--- a/gfx/video_filters/snes_ntsc/snes_ntsc.h
+++ b/gfx/video_filters/snes_ntsc/snes_ntsc.h
@@ -34,25 +34,25 @@ typedef struct snes_ntsc_setup_t
 } snes_ntsc_setup_t;
 
 /* Video format presets */
-extern snes_ntsc_setup_t const snes_ntsc_composite; /* color bleeding + artifacts */
-extern snes_ntsc_setup_t const snes_ntsc_svideo;    /* color bleeding only */
-extern snes_ntsc_setup_t const snes_ntsc_rgb;       /* crisp image */
-extern snes_ntsc_setup_t const snes_ntsc_monochrome;/* desaturated + artifacts */
+extern snes_ntsc_setup_t const retroarch_snes_ntsc_composite; /* color bleeding + artifacts */
+extern snes_ntsc_setup_t const retroarch_snes_ntsc_svideo;    /* color bleeding only */
+extern snes_ntsc_setup_t const retroarch_snes_ntsc_rgb;       /* crisp image */
+extern snes_ntsc_setup_t const retroarch_snes_ntsc_monochrome;/* desaturated + artifacts */
 
 /* Initializes and adjusts parameters. Can be called multiple times on the same
 snes_ntsc_t object. Can pass NULL for either parameter. */
 typedef struct snes_ntsc_t snes_ntsc_t;
-void snes_ntsc_init( snes_ntsc_t* ntsc, snes_ntsc_setup_t const* setup );
+void retroarch_snes_ntsc_init( snes_ntsc_t* ntsc, snes_ntsc_setup_t const* setup );
 
 /* Filters one or more rows of pixels. Input pixel format is set by SNES_NTSC_IN_FORMAT
 and output RGB depth is set by SNES_NTSC_OUT_DEPTH. Both default to 16-bit RGB.
 In_row_width is the number of pixels to get to the next input row. Out_pitch
 is the number of *bytes* to get to the next output row. */
-void snes_ntsc_blit( snes_ntsc_t const* ntsc, SNES_NTSC_IN_T const* input,
+void retroarch_snes_ntsc_blit( snes_ntsc_t const* ntsc, SNES_NTSC_IN_T const* input,
 		long in_row_width, int burst_phase, int in_width, int in_height,
 		void* rgb_out, long out_pitch, int first, int last);
 
-void snes_ntsc_blit_hires( snes_ntsc_t const* ntsc, SNES_NTSC_IN_T const* input,
+void retroarch_snes_ntsc_blit_hires( snes_ntsc_t const* ntsc, SNES_NTSC_IN_T const* input,
 		long in_row_width, int burst_phase, int in_width, int in_height,
 		void* rgb_out, long out_pitch, int first, int last);
 

--- a/gfx/video_filters/snes_ntsc/snes_ntsc_impl.h
+++ b/gfx/video_filters/snes_ntsc/snes_ntsc_impl.h
@@ -311,7 +311,7 @@ typedef struct pixel_info_t
 		(1.0f - (((ntsc) + 100) & 2))
 #endif
 
-extern pixel_info_t const snes_ntsc_pixels [alignment_count];
+extern pixel_info_t const retroarch_snes_ntsc_pixels [alignment_count];
 
 /* Generate pixel at all burst phases and column alignments */
 static void gen_kernel( init_t* impl, float y, float i, float q, snes_ntsc_rgb_t* out )
@@ -326,7 +326,7 @@ static void gen_kernel( init_t* impl, float y, float i, float q, snes_ntsc_rgb_t
 		Convolve these with kernels which: filter respective components, apply
 		sharpening, and rescale horizontally. Convert resulting yiq to rgb and pack
 		into integer. Based on algorithm by NewRisingSun. */
-		pixel_info_t const* pixel = snes_ntsc_pixels;
+		pixel_info_t const* pixel = retroarch_snes_ntsc_pixels;
 		int alignment_remain = alignment_count;
 		do
 		{


### PR DESCRIPTION
emscipten: avoid global symbol multiply defined linkage errors (ex. snes9x cores compiling their own snes_ntsc.c library)