### PR TITLE
(RGUI) Performance optimisations

### DIFF
--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -181,9 +181,7 @@ static unsigned menu_display_header_height       = 0;
 
 static bool menu_display_has_windowed            = false;
 static bool menu_display_msg_force               = false;
-static bool menu_display_font_alloc_framebuf     = false;
 static bool menu_display_framebuf_dirty          = false;
-static const uint8_t *menu_display_font_framebuf = NULL;
 static menu_display_ctx_driver_t *menu_disp      = NULL;
 
 /* when enabled, on next iteration the 'Quick Menu' list will
@@ -502,16 +500,6 @@ video_coord_array_t *menu_display_get_coords_array(void)
    return &menu_disp_ca;
 }
 
-const uint8_t *menu_display_get_font_framebuffer(void)
-{
-   return menu_display_font_framebuf;
-}
-
-void menu_display_set_font_framebuffer(const uint8_t *buffer)
-{
-   menu_display_font_framebuf = buffer;
-}
-
 bool menu_display_libretro_running(
       bool rarch_is_inited,
       bool rarch_is_dummy_core)
@@ -606,16 +594,6 @@ bool menu_display_get_msg_force(void)
 void menu_display_set_msg_force(bool state)
 {
    menu_display_msg_force = state;
-}
-
-bool menu_display_get_font_data_init(void)
-{
-   return menu_display_font_alloc_framebuf;
-}
-
-void menu_display_set_font_data_init(bool state)
-{
-   menu_display_font_alloc_framebuf = state;
 }
 
 /* Returns true if an animation is still active or

--- a/menu/menu_driver.h
+++ b/menu/menu_driver.h
@@ -549,8 +549,6 @@ void menu_display_font_free(font_data_t *font);
 
 void menu_display_coords_array_reset(void);
 video_coord_array_t *menu_display_get_coords_array(void);
-const uint8_t *menu_display_get_font_framebuffer(void);
-void menu_display_set_font_framebuffer(const uint8_t *buffer);
 bool menu_display_libretro(bool is_idle, bool is_inited, bool is_dummy);
 bool menu_display_libretro_running(bool rarch_is_inited,
       bool rarch_is_dummy_core);
@@ -566,8 +564,6 @@ void menu_display_set_framebuffer_pitch(size_t pitch);
 
 bool menu_display_get_msg_force(void);
 void menu_display_set_msg_force(bool state);
-bool menu_display_get_font_data_init(void);
-void menu_display_set_font_data_init(bool state);
 bool menu_display_get_update_pending(void);
 void menu_display_set_viewport(unsigned width, unsigned height);
 void menu_display_unset_viewport(unsigned width, unsigned height);


### PR DESCRIPTION
## Description

This PR heavily optimises the software rendering aspect of RGUI. It makes the following changes:

- `blit_line()`: When printing text, all the heavy calculations have been replaced with a lookup table

- `blit_line()`: When printing text, we no longer waste CPU cycles 'drawing' whitespace

- `blit_line()`: A little pointer trick has been used to increase the efficiency of drawing text shadows

- Regular (non-wallpaper) backgrounds are now handled in the same way as wallpaper backgrounds - i.e. they are generated/cached only when they change, and are written to the framebuffer using `memcpy()`. This is almost 3x faster than the old drawing method.

- Fullscreen and inline playlist thumbnails are now written line-by-line using `memcpy()`, rather than pixel-by-pixel

- `rgui_render()`: The clock display is now generated directly using `time()` and `localtime()`, rather than the (surprisingly) expensive `menu_display_timedate()` function

- `rgui_render()`: A number of redundant/repeated function calls have been removed

This was profiled with Callgrind under Linux using the `gl` driver with Nvidia hardware. The results are as follows:

- When generating 'normal' (text-only) menus, the performance overheads of `rgui_render()` are reduced by ~74%

- The performance overhead of drawing fullscreen thumbnails is reduced by ~77%

- The performance overhead of drawing inline playlist thumbnails is reduced by ~31%

- Enabling menu shadows only increases performance overheads by ~4%

Note that the actual 'real world' performance gains are harder to quantify, since 'rendering' is only half the story - we still have to put the generated framebuffer on-screen, and this is entirely dependent upon GFX drivers.

For example, on my system with these optimisations in place, almost 95% of the total CPU time is spent inside `gl2_set_texture_frame()` - so RGUI itself is basically having no performance impact at all now. GFX driver stuff is outside of my comfort zone, so I can't really help with optimising this side of things...

---

**SIDE NOTE:**

While working on this, I noticed that RGUI is underutilising its font. What I mean here is that the internal bitmap font supports extended ASCII characters, but we have no way of actually displaying them due to the way that char arrays are formatted. This is an encoding issue that I could (with some effort) handle inside RGUI - but the performance impact would make this untenable.

Maybe this could be handled at a higher level, but it would be quite far reaching...

In the meantime, I have just edited RGUI such that non-standard ASCII characters (with a value above 127) simply are not drawn. This prevents the display of 'garbage' characters, and - more importantly -  means that we can never overflow the framebuffer and get a segfault (which was a very real possibility before).