### PR TITLE
Fix cheevos crash when peeking out of range

### DIFF
--- a/cheevos-new/cheevos.c
+++ b/cheevos-new/cheevos.c
@@ -527,11 +527,14 @@ static unsigned cheevos_peek(unsigned address, unsigned num_bytes, void* ud)
       address, cheevos_locals.patchdata.console_id);
    unsigned value = 0;
 
-   switch (num_bytes)
+   if (data)
    {
-      case 4: value |= data[2] << 16 | data[3] << 24;
-      case 2: value |= data[1] << 8;
-      case 1: value |= data[0];
+      switch (num_bytes)
+      {
+         case 4: value |= data[2] << 16 | data[3] << 24;
+         case 2: value |= data[1] << 8;
+         case 1: value |= data[0];
+      }
    }
 
    return value;


### PR DESCRIPTION
## Description

This would occur if the address being peeked at was not part of a memory region defined in the core.

See https://github.com/libretro/RetroArch/issues/7341#issuecomment-480472019.

## Related Issues

#7341 (part)