### PR TITLE
(Menu Widgets) Fix text alignment issues with Vulkan and D3D video drivers

### DIFF
--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -2366,7 +2366,7 @@ static void vulkan_unload_texture(void *data, uintptr_t handle)
 {
    vk_t *vk                         = (vk_t*)data;
    struct vk_texture *texture       = (struct vk_texture*)handle;
-   if (!texture)
+   if (!texture || !vk)
       return;
 
    /* TODO: We really want to defer this deletion instead,

--- a/gfx/drivers_font/d3d10_font.c
+++ b/gfx/drivers_font/d3d10_font.c
@@ -178,8 +178,8 @@ static void d3d10_font_render_line(
       if (!glyph)
          continue;
 
-      v->pos.x = (x + glyph->draw_offset_x) * scale / (float)d3d10->viewport.Width;
-      v->pos.y = (y + glyph->draw_offset_y) * scale / (float)d3d10->viewport.Height;
+      v->pos.x = (x + (glyph->draw_offset_x * scale)) / (float)d3d10->viewport.Width;
+      v->pos.y = (y + (glyph->draw_offset_y * scale)) / (float)d3d10->viewport.Height;
       v->pos.w = glyph->width * scale / (float)d3d10->viewport.Width;
       v->pos.h = glyph->height * scale / (float)d3d10->viewport.Height;
 

--- a/gfx/drivers_font/d3d11_font.c
+++ b/gfx/drivers_font/d3d11_font.c
@@ -176,8 +176,8 @@ static void d3d11_font_render_line(
       if (!glyph)
          continue;
 
-      v->pos.x = (x + glyph->draw_offset_x) * scale / (float)d3d11->viewport.Width;
-      v->pos.y = (y + glyph->draw_offset_y) * scale / (float)d3d11->viewport.Height;
+      v->pos.x = (x + (glyph->draw_offset_x * scale)) / (float)d3d11->viewport.Width;
+      v->pos.y = (y + (glyph->draw_offset_y * scale)) / (float)d3d11->viewport.Height;
       v->pos.w = glyph->width * scale / (float)d3d11->viewport.Width;
       v->pos.h = glyph->height * scale / (float)d3d11->viewport.Height;
 

--- a/gfx/drivers_font/d3d12_font.c
+++ b/gfx/drivers_font/d3d12_font.c
@@ -184,8 +184,8 @@ static void d3d12_font_render_line(
       if (!glyph)
          continue;
 
-      v->pos.x = (x + glyph->draw_offset_x) * scale / (float)d3d12->chain.viewport.Width;
-      v->pos.y = (y + glyph->draw_offset_y) * scale / (float)d3d12->chain.viewport.Height;
+      v->pos.x = (x + (glyph->draw_offset_x * scale)) / (float)d3d12->chain.viewport.Width;
+      v->pos.y = (y + (glyph->draw_offset_y * scale)) / (float)d3d12->chain.viewport.Height;
       v->pos.w = glyph->width * scale  / (float)d3d12->chain.viewport.Width;
       v->pos.h = glyph->height * scale / (float)d3d12->chain.viewport.Height;
 

--- a/gfx/drivers_font/vulkan_raster_font.c
+++ b/gfx/drivers_font/vulkan_raster_font.c
@@ -203,8 +203,8 @@ static void vulkan_raster_font_render_line(
       height = glyph->height;
 
       vulkan_write_quad_vbo(font->pv + font->vertices,
-            (x + off_x + delta_x * scale) * inv_win_width,
-            (y + off_y + delta_y * scale) * inv_win_height,
+            (x + (off_x + delta_x) * scale) * inv_win_width,
+            (y + (off_y + delta_y) * scale) * inv_win_height,
             width * scale * inv_win_width,
             height * scale * inv_win_height,
             tex_x * inv_tex_size_x,

--- a/menu/widgets/menu_widgets.c
+++ b/menu/widgets/menu_widgets.c
@@ -208,7 +208,7 @@ static char *menu_widgets_icons_names[MENU_WIDGETS_ICON_LAST] = {
    "menu_info.png"
 };
 
-static menu_texture_item menu_widgets_icons_textures[MENU_WIDGETS_ICON_LAST];
+static menu_texture_item menu_widgets_icons_textures[MENU_WIDGETS_ICON_LAST] = {0};
 
 /* Volume */
 static float volume_db              = 0.0f;
@@ -1775,6 +1775,9 @@ void menu_widgets_context_destroy(void)
 void menu_widgets_free(void)
 {
    int i;
+
+   if (!menu_widgets_inited)
+      return;
 
    menu_widgets_inited = false;
 

--- a/retroarch.c
+++ b/retroarch.c
@@ -700,6 +700,13 @@ void driver_uninit(int flags)
 #ifdef HAVE_MENU
    if (flags & DRIVER_MENU_MASK)
    {
+#if defined(HAVE_MENU_WIDGETS)
+      /* This absolutely has to be done before video_driver_free()
+       * is called/completes, otherwise certain menu drivers
+       * (e.g. Vulkan) will segfault */
+      menu_widgets_context_destroy();
+      menu_widgets_free();
+#endif
       menu_driver_ctl(RARCH_MENU_CTL_DEINIT, NULL);
       menu_driver_free();
    }


### PR DESCRIPTION
## Description

This PR fixes text alignment issues when using menu widgets with the following GFX drivers: `Vulkan`. `D3D10`, `D3D11` and `D3D12`

While implementing this, a small fix was also added to prevent a segfault when closing RetroArch with menu widgets enabled when using `Vulkan`
