### PR TITLE
(Menu Widgets) Fix text alignment issues for ctr, metal and vita2d drivers

### DIFF
--- a/gfx/drivers_font/ctr_font.c
+++ b/gfx/drivers_font/ctr_font.c
@@ -215,8 +215,8 @@ static void ctr_font_render_line(
       width  = glyph->width;
       height = glyph->height;
 
-      v->x0 = x + off_x + delta_x * scale;
-      v->y0 = y + off_y + delta_y * scale;
+      v->x0 = x + (off_x + delta_x) * scale;
+      v->y0 = y + (off_y + delta_y) * scale;
       v->u0 = tex_x;
       v->v0 = tex_y;
       v->x1 = v->x0 + width * scale;

--- a/gfx/drivers_font/metal_raster_font.m
+++ b/gfx/drivers_font/metal_raster_font.m
@@ -298,8 +298,8 @@ static INLINE void write_quad6(SpriteVertex *pv,
       height = glyph->height;
 
       write_quad6(v,
-                  (x + off_x + delta_x * scale) * inv_win_width,
-                  (y + off_y + delta_y * scale) * inv_win_height,
+                  (x + (off_x + delta_x) * scale) * inv_win_width,
+                  (y + (off_y + delta_y) * scale) * inv_win_height,
                   width * scale * inv_win_width,
                   height * scale * inv_win_height,
                   tex_x * inv_tex_size_x,

--- a/gfx/drivers_font/vita2d_font.c
+++ b/gfx/drivers_font/vita2d_font.c
@@ -209,8 +209,8 @@ static void vita2d_font_render_line(
       }
 
       vita2d_draw_texture_tint_part_scale(font->texture,
-            x + off_x + delta_x * scale,
-            y + off_y + delta_y * scale,
+            x + (off_x + delta_x) * scale,
+            y + (off_y + delta_y) * scale,
             tex_x, tex_y, width, height,
             scale,
             scale,


### PR DESCRIPTION
## Description

This is a follow-up to PR #8559. It applies the same text alignment fix to the ctr, metal and vita2d font drivers.
