### PR TITLE
SET_ROTATION: not only for accelerated video drivers

### DIFF
--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -485,7 +485,6 @@ enum retro_mod
 /* Environment commands. */
 #define RETRO_ENVIRONMENT_SET_ROTATION  1  /* const unsigned * --
                                             * Sets screen rotation of graphics.
-                                            * Is only implemented if rotation can be accelerated by hardware.
                                             * Valid values are 0, 1, 2, 3, which rotates screen by 0, 90, 180,
                                             * 270 degrees counter-clockwise respectively.
                                             */


### PR DESCRIPTION
I would suggest that there is no reason to limit SET_ROTATION to hardware-accelerated frontend implementation.

For cores that need to rotate video, for example arcade emulation cores, if the core cannot rely on the frontend to implement rotation, the core have to create its own duplicate/internal rotation code.

I'll add that at least one software-rendered video driver in RetroArch already implements SET_ROTATION contrary to this part of the API -- GDI.