### PR TITLE
add SET_MIRROR callback to libretro.h (arcade games, rear projection)

### DIFF
--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -1086,6 +1086,11 @@ enum retro_mod
                                             * The core can use the returned value to set an ideal 
                                             * refresh rate/framerate.
                                             */
+#define RETRO_ENVIRONMENT_SET_MIRROR     51 /* const unsigned * --
+                                            * Indicates to frontend to 'mirror' graphics.
+                                            * Valid values are 0, 1, and 2 which correspond to not mirroring the
+                                            * graphics, mirroring graphics with respect to the the vertical axis, 
+                                            * and mirroring the screen with respect to the horizontal axis, respectively.
 
 /* VFS functionality */
 

--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -1090,7 +1090,7 @@ enum retro_mod
                                             * Indicates to frontend to 'mirror' graphics.
                                             * Valid values are 0, 1, and 2 which correspond to not mirroring the
                                             * graphics, mirroring graphics with respect to the the vertical axis, 
-                                            * and mirroring the screen with respect to the horizontal axis, respectively.
+                                            * and mirroring the graphics with respect to the horizontal axis, respectively.
 
 /* VFS functionality */
 


### PR DESCRIPTION
## Summary
**Add a video mirroring callback `RETRO_ENVIRONMENT_SET_MIRROR` based on `RETRO_ENVIRONMENT_SET_ROTATION`**

**Purposes**: Facilitate emulating mirrored arcade video. Mirroring also allows rear projection.

SET_ROTATION is important -- and works great -- for emulating games that used physically rotated monitors. Cores don't have to implement rotation themselves and can benefit from whatever optimizations the frontend can offer for that operation.

If there were a callback to ask for the video to be mirrored, this too could be handled by the frontend in a way that is most appropriate to the host system.

Here's what the raw video output of an emulated mirror game (Lethal Enforcers) looks like without having the video mirrored:
![lethal-enforcers](https://user-images.githubusercontent.com/16081693/40593014-42536570-61f3-11e8-973e-a8dc420c40f8.jpg)


