### PR TITLE
Silence menu_widgets max redefinition warning

### DIFF
--- a/menu/widgets/menu_widgets.c
+++ b/menu/widgets/menu_widgets.c
@@ -37,9 +37,13 @@
 #include <formats/image.h>
 #include <string/stdstring.h>
 
+#ifndef PI
 #define PI 3.14159265359f
+#endif
 
+#ifndef max(x, y)
 #define max(x, y) x >= y ? x : y
+#endif
 
 /* TODO: Fix context reset freezing everything in place (probably kills animations when it shouldn't anymore) */
 

--- a/menu/widgets/menu_widgets.c
+++ b/menu/widgets/menu_widgets.c
@@ -41,7 +41,7 @@
 #define PI 3.14159265359f
 #endif
 
-#ifndef max(x, y)
+#ifndef max
 #define max(x, y) x >= y ? x : y
 #endif
 


### PR DESCRIPTION
## Description

max(x, y) was already defined somewhere else. This silences the warning. It's probably best to squash-and-merge this, since one of the commits is a dumb syntax correction.

## Related Issues

none

## Related Pull Requests

none

## Reviewers

@natinusala @Tatsuya79 
