### PR TITLE
silence warnings

### DIFF
--- a/audio/drivers/xaudio.c
+++ b/audio/drivers/xaudio.c
@@ -219,7 +219,7 @@ static xaudio2_t *xaudio2_new(unsigned samplerate, unsigned channels,
       goto error;
 
 #if (_WIN32_WINNT >= 0x0602 /*_WIN32_WINNT_WIN8*/)
-   if (FAILED(IXAudio2_CreateMasteringVoice(handle->pXAudio2, &handle->pMasterVoice, channels, samplerate, 0, device, NULL, AudioCategory_GameEffects)))
+   if (FAILED(IXAudio2_CreateMasteringVoice(handle->pXAudio2, &handle->pMasterVoice, channels, samplerate, 0, (LPCWSTR)(uintptr_t)device, NULL, AudioCategory_GameEffects)))
       goto error;
 #else
    if (FAILED(IXAudio2_CreateMasteringVoice(handle->pXAudio2, &handle->pMasterVoice, channels, samplerate, 0, device, NULL)))

--- a/dynamic.c
+++ b/dynamic.c
@@ -1394,7 +1394,7 @@ bool rarch_environment_cb(unsigned cmd, void *data)
          {
             unsigned retro_id;
             const struct retro_input_descriptor *desc = NULL;
-            memset(&system->input_desc_btn, 0,
+            memset((void*)&system->input_desc_btn, 0,
                   sizeof(system->input_desc_btn));
 
             desc = (const struct retro_input_descriptor*)data;

--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -1,4 +1,4 @@
-﻿/*  RetroArch - A frontend for libretro.
+/*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2016-2017 - Hans-Kristian Arntzen
  *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
@@ -618,7 +618,7 @@ struct vk_texture vulkan_create_texture(vk_t *vk,
       RARCH_LOG("[Vulkan]: GPU supports linear images as textures, but not DEVICE_LOCAL. Falling back to copy path.\n");
       type = VULKAN_TEXTURE_STAGING;
       vkDestroyImage(device, tex.image, NULL);
-      tex.image          = NULL;
+      tex.image          = (VkImage)NULL;
       info.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
 
       buffer_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
@@ -1580,7 +1580,7 @@ static bool vulkan_find_device_extensions(VkPhysicalDevice gpu,
       goto end;
    }
 
-   memcpy(enabled, exts, num_exts * sizeof(*exts));
+   memcpy((void*)enabled, exts, num_exts * sizeof(*exts));
    *enabled_count = num_exts;
 
    for (i = 0; i < num_optional_exts; i++)

--- a/gfx/drivers/gl_core.c
+++ b/gfx/drivers/gl_core.c
@@ -400,13 +400,13 @@ static bool gl_core_init_hw_render(gl_core_t *gl, unsigned width, unsigned heigh
    RARCH_LOG("[GLCore]: Max texture size: %d px, renderbuffer size: %d px.\n",
              max_fbo_size, max_rb_size);
 
-   if (width > max_fbo_size)
+   if (width > (unsigned)max_fbo_size)
        width = max_fbo_size;
-   if (width > max_rb_size)
+   if (width > (unsigned)max_rb_size)
        width = max_rb_size;
-   if (height > max_fbo_size)
+   if (height > (unsigned)max_fbo_size)
        height = max_fbo_size;
-   if (height > max_rb_size)
+   if (height > (unsigned)max_rb_size)
        height = max_rb_size;
 
    glGenFramebuffers(1, &gl->hw_render_fbo);

--- a/gfx/drivers_font_renderer/stb_unicode.c
+++ b/gfx/drivers_font_renderer/stb_unicode.c
@@ -163,7 +163,7 @@ static const struct font_glyph *font_renderer_stb_unicode_get_glyph(
       /* This means the glyph is empty. In this case, stbtt_MakeGlyphBitmap()
        * fills the corresponding region of the atlas buffer with garbage,
        * so just zero it */
-      unsigned x, y;
+      int x, y;
       for (x = 0; x < self->max_glyph_width; x++)
          for (y = 0; y < self->max_glyph_height; y++)
             dst[x + (y * self->atlas.width)] = 0;

--- a/libretro-common/features/features_cpu.c
+++ b/libretro-common/features/features_cpu.c
@@ -872,7 +872,7 @@ void cpu_features_get_model_name(char *name, int len)
    }
 end:
    /* terminate our string */
-   if (pos < len)
+   if (pos < (size_t)len)
       name[pos] = '\0';
 #elif defined(__MACH__)
    if (!name)

--- a/libretro-common/glsym/glsym_gl.c
+++ b/libretro-common/glsym/glsym_gl.c
@@ -24,7 +24,7 @@
 
 #include <glsym/glsym.h>
 
-#define SYM(x) { "gl" #x, &(gl##x) }
+#define SYM(x) { "gl" #x, (void*)&(gl##x) }
 
 const struct rglgen_sym_map rglgen_symbol_map[] = {
 #ifdef HAVE_LIBNX

--- a/libretro-common/include/compat/msvc.h
+++ b/libretro-common/include/compat/msvc.h
@@ -56,6 +56,8 @@ extern "C"  {
 #undef UNICODE /* Do not bother with UNICODE at this time. */
 #include <direct.h>
 #include <stddef.h>
+
+#define _USE_MATH_DEFINES
 #include <math.h>
 
 /* Python headers defines ssize_t and sets HAVE_SSIZE_T.

--- a/pkg/msvc/msvc-2010/RetroArch-msvc2010.vcxproj
+++ b/pkg/msvc/msvc-2010/RetroArch-msvc2010.vcxproj
@@ -228,7 +228,6 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <CompileAs>CompileAsCpp</CompileAs>
       <FloatingPointModel>Fast</FloatingPointModel>
-      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
     </ClCompile>
     <Link>
@@ -248,7 +247,6 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <CompileAs>CompileAsCpp</CompileAs>
       <FloatingPointModel>Fast</FloatingPointModel>
-      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
     </ClCompile>
     <Link>
@@ -324,7 +322,6 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <CompileAs>CompileAsCpp</CompileAs>
       <FloatingPointModel>Fast</FloatingPointModel>
-      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
     </ClCompile>
@@ -350,7 +347,6 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <CompileAs>CompileAsCpp</CompileAs>
       <FloatingPointModel>Fast</FloatingPointModel>
-      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
     </ClCompile>

--- a/pkg/msvc/msvc-2015/RetroArch-msvc2015.vcxproj
+++ b/pkg/msvc/msvc-2015/RetroArch-msvc2015.vcxproj
@@ -237,7 +237,6 @@
       <CompileAs>CompileAsCpp</CompileAs>
       <AdditionalOptions>/bigobj</AdditionalOptions>
       <FloatingPointModel>Fast</FloatingPointModel>
-      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
     </ClCompile>
     <Link>
@@ -257,7 +256,6 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <CompileAs>CompileAsCpp</CompileAs>
       <FloatingPointModel>Fast</FloatingPointModel>
-      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
     </ClCompile>
     <Link>
@@ -331,7 +329,6 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <CompileAs>CompileAsCpp</CompileAs>
       <FloatingPointModel>Fast</FloatingPointModel>
-      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
     </ClCompile>
@@ -356,7 +353,6 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <CompileAs>CompileAsCpp</CompileAs>
       <FloatingPointModel>Fast</FloatingPointModel>
-      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
     </ClCompile>

--- a/pkg/msvc/msvc-2017/RetroArch-msvc2017.vcxproj
+++ b/pkg/msvc/msvc-2017/RetroArch-msvc2017.vcxproj
@@ -722,7 +722,6 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <CompileAs>CompileAsCpp</CompileAs>
       <FloatingPointModel>Fast</FloatingPointModel>
-      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
     </ClCompile>
     <Link>
@@ -742,7 +741,6 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <CompileAs>CompileAsCpp</CompileAs>
       <FloatingPointModel>Fast</FloatingPointModel>
-      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
     </ClCompile>
     <Link>
@@ -763,7 +761,6 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <CompileAs>CompileAsCpp</CompileAs>
       <FloatingPointModel>Fast</FloatingPointModel>
-      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
     </ClCompile>
     <Link>
@@ -784,7 +781,6 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <CompileAs>CompileAsCpp</CompileAs>
       <FloatingPointModel>Fast</FloatingPointModel>
-      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
     </ClCompile>
     <Link>
@@ -1014,7 +1010,6 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <CompileAs>CompileAsCpp</CompileAs>
       <FloatingPointModel>Fast</FloatingPointModel>
-      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
     </ClCompile>
@@ -1040,7 +1035,6 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <CompileAs>CompileAsCpp</CompileAs>
       <FloatingPointModel>Fast</FloatingPointModel>
-      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
     </ClCompile>
@@ -1066,7 +1060,6 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <CompileAs>CompileAsCpp</CompileAs>
       <FloatingPointModel>Fast</FloatingPointModel>
-      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
     </ClCompile>
@@ -1092,7 +1085,6 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <CompileAs>CompileAsCpp</CompileAs>
       <FloatingPointModel>Fast</FloatingPointModel>
-      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
     </ClCompile>


### PR DESCRIPTION
## Description
Added casts to type comparisons / conversions.
Removed the [unused SSE2](https://stackoverflow.com/a/1067819/) build options on MSVC x64.