### PR TITLE
Set language to OS/user default on first startup

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -1754,7 +1754,7 @@ static struct config_uint_setting *populate_settings_uint(settings_t *settings, 
    SETTING_UINT("netplay_share_analog",         &settings->uints.netplay_share_analog,  true, netplay_share_analog, false);
 #endif
 #ifdef HAVE_LANGEXTRA
-   SETTING_UINT("user_language",                msg_hash_get_uint(MSG_HASH_USER_LANGUAGE), true, RETRO_LANGUAGE_ENGLISH, false);
+   SETTING_UINT("user_language",                msg_hash_get_uint(MSG_HASH_USER_LANGUAGE), true, def_user_language, false);
 #endif
    SETTING_UINT("bundle_assets_extract_version_current", &settings->uints.bundle_assets_extract_version_current, true, 0, false);
    SETTING_UINT("bundle_assets_extract_last_version",    &settings->uints.bundle_assets_extract_last_version, true, 0, false);
@@ -3280,6 +3280,9 @@ static bool config_load_file(const char *path, bool set_defaults,
 
    frontend_driver_set_sustained_performance_mode(settings->bools.sustained_performance_mode);
    recording_driver_update_streaming_url();
+
+   if (!config_entry_exists(conf, "user_language"))
+      msg_hash_set_uint(MSG_HASH_USER_LANGUAGE, frontend_driver_get_user_language());
 
    ret = true;
 end:

--- a/frontend/drivers/platform_ctr.c
+++ b/frontend/drivers/platform_ctr.c
@@ -604,5 +604,6 @@ frontend_ctx_driver_t frontend_ctx_ctr =
    NULL,                         /* check_for_path_changes */
    NULL,                         /* set_sustained_performance_mode */
    NULL,                         /* get_cpu_model_name */
+   NULL,                         /* get_user_language */
    "ctr",
 };

--- a/frontend/drivers/platform_darwin.m
+++ b/frontend/drivers/platform_darwin.m
@@ -773,10 +773,11 @@ frontend_ctx_driver_t frontend_ctx_darwin = {
    NULL,                         /* watch_path_for_changes */
    NULL,                         /* check_for_path_changes */
    NULL,                         /* set_sustained_performance_mode */
-   #if (defined(OSX) && !(defined(__ppc__) || defined(__ppc64__)))
+#if (defined(OSX) && !(defined(__ppc__) || defined(__ppc64__)))
     frontend_darwin_get_cpu_model_name,
-    #else
+#else
    NULL,
-    #endif
+#endif
+   NULL,                         /* get_user_language */
    "darwin",
 };

--- a/frontend/drivers/platform_dos.c
+++ b/frontend/drivers/platform_dos.c
@@ -72,5 +72,6 @@ frontend_ctx_driver_t frontend_ctx_dos = {
    NULL,                         /* check_for_path_changes */
    NULL,                         /* set_sustained_performance_mode */
    NULL,                         /* get_cpu_model_name */
+   NULL,                         /* get_user_language */
    "dos",
 };

--- a/frontend/drivers/platform_emscripten.c
+++ b/frontend/drivers/platform_emscripten.c
@@ -267,5 +267,6 @@ frontend_ctx_driver_t frontend_ctx_emscripten = {
    NULL,                         /* check_for_path_changes */
    NULL,                         /* set_sustained_performance_mode */
    NULL,                         /* get_cpu_model_name */
+   NULL,                         /* get_user_language */
    "emscripten"
 };

--- a/frontend/drivers/platform_gx.c
+++ b/frontend/drivers/platform_gx.c
@@ -548,5 +548,6 @@ frontend_ctx_driver_t frontend_ctx_gx = {
    NULL,                            /* check_for_path_changes */
    NULL,                            /* set_sustained_performance_mode */
    NULL,                            /* get_cpu_model_name */
+   NULL,                            /* get_user_language */
    "gx",
 };

--- a/frontend/drivers/platform_null.c
+++ b/frontend/drivers/platform_null.c
@@ -48,5 +48,6 @@ frontend_ctx_driver_t frontend_ctx_null = {
    NULL,                         /* check_for_path_changes */
    NULL,                         /* set_sustained_performance_mode */
    NULL,                         /* get_cpu_model_name */
+   NULL,                         /* get_user_language */
    "null",
 };

--- a/frontend/drivers/platform_orbis.c
+++ b/frontend/drivers/platform_orbis.c
@@ -369,5 +369,6 @@ frontend_ctx_driver_t frontend_ctx_orbis = {
    NULL,                         /* check_for_path_changes */
    NULL,                         /* set_sustained_performance_mode */
    NULL,                         /* get_cpu_model_name */
+   NULL,                         /* get_user_language */
    "orbis",
 };

--- a/frontend/drivers/platform_ps2.c
+++ b/frontend/drivers/platform_ps2.c
@@ -415,5 +415,6 @@ frontend_ctx_driver_t frontend_ctx_ps2 = {
    NULL,                         /* check_for_path_changes */
    NULL,                         /* set_sustained_performance_mode */
    NULL,                         /* get_cpu_model_name */
+   NULL,                         /* get_user_language */
    "null",
 };

--- a/frontend/drivers/platform_ps3.c
+++ b/frontend/drivers/platform_ps3.c
@@ -639,5 +639,6 @@ frontend_ctx_driver_t frontend_ctx_ps3 = {
    NULL,                         /* check_for_path_changes */
    NULL,                         /* set_sustained_performance_mode */
    NULL,                         /* get_cpu_model_name */
+   NULL,                         /* get_user_language */
    "ps3",
 };

--- a/frontend/drivers/platform_psp.c
+++ b/frontend/drivers/platform_psp.c
@@ -534,6 +534,7 @@ frontend_ctx_driver_t frontend_ctx_psp = {
    NULL,                         /* check_for_path_changes */
    NULL,                         /* set_sustained_performance_mode */
    NULL,                         /* get_cpu_model_name */
+   NULL,                         /* get_user_language */
 #ifdef VITA
    "vita",
 #else

--- a/frontend/drivers/platform_qnx.c
+++ b/frontend/drivers/platform_qnx.c
@@ -208,5 +208,6 @@ frontend_ctx_driver_t frontend_ctx_qnx = {
    NULL,                         /* check_for_path_changes */
    NULL,                         /* set_sustained_performance_mode */
    NULL,                         /* get_cpu_model_name */
+   NULL,                         /* get_user_language */
    "qnx",
 };

--- a/frontend/drivers/platform_switch.c
+++ b/frontend/drivers/platform_switch.c
@@ -945,5 +945,6 @@ frontend_ctx_driver_t frontend_ctx_switch =
         NULL, /* check_for_path_changes */
         NULL, /* set_sustained_performance_mode */
         NULL, /* get_cpu_model_name */
+        NULL, /* get_user_language */
         "switch",
 };

--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -2496,11 +2496,15 @@ static const char* frontend_unix_get_cpu_model_name(void)
 
 enum retro_language frontend_unix_get_user_language(void)
 {
+   enum retro_language lang = RETRO_LANGUAGE_ENGLISH;
+#ifdef HAVE_LANGEXTRA
 #ifdef ANDROID
    return RETRO_LANGUAGE_ENGLISH;
 #else
-   return rarch_get_language_from_iso(getenv("LANG"));
+   lang = rarch_get_language_from_iso(getenv("LANG"));
 #endif
+#endif
+   return lang;
 }
 
 frontend_ctx_driver_t frontend_ctx_unix = {

--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -2494,6 +2494,15 @@ static const char* frontend_unix_get_cpu_model_name(void)
 #endif
 }
 
+enum retro_language frontend_unix_get_user_language(void)
+{
+#ifdef ANDROID
+   return RETRO_LANGUAGE_ENGLISH;
+#else
+   return rarch_get_language_from_iso(getenv("LANG"));
+#endif
+}
+
 frontend_ctx_driver_t frontend_ctx_unix = {
    frontend_unix_get_env,       /* environment_get */
    frontend_unix_init,          /* init */
@@ -2539,6 +2548,7 @@ frontend_ctx_driver_t frontend_ctx_unix = {
    frontend_unix_check_for_path_changes,
    frontend_unix_set_sustained_performance_mode,
    frontend_unix_get_cpu_model_name,
+   frontend_unix_get_user_language,
 #ifdef ANDROID
    "android"
 #else

--- a/frontend/drivers/platform_unix.h
+++ b/frontend/drivers/platform_unix.h
@@ -163,6 +163,7 @@ struct android_app
    jmethodID getBatteryLevel;
    jmethodID setSustainedPerformanceMode;
    jmethodID setScreenOrientation;
+   jmethodID getUserLanguageString;
    jmethodID doVibrate;
 };
 

--- a/frontend/drivers/platform_uwp.c
+++ b/frontend/drivers/platform_uwp.c
@@ -447,5 +447,6 @@ frontend_ctx_driver_t frontend_ctx_uwp = {
    NULL,                            /* check_for_path_changes */
    NULL,                            /* set_sustained_performance_mode */
    NULL,                            /* get_cpu_model_name */
+   NULL,                            /* get_user_language */
    "uwp"
 };

--- a/frontend/drivers/platform_wiiu.c
+++ b/frontend/drivers/platform_wiiu.c
@@ -302,6 +302,7 @@ frontend_ctx_driver_t frontend_ctx_wiiu =
    NULL,                         /* check_for_path_changes */
    NULL,                         /* set_sustained_performance_mode */
    NULL,                         /* get_cpu_model_name */
+   NULL,                         /* get_user_language */
    "wiiu",
    NULL,                         /* get_video_driver */
 };

--- a/frontend/drivers/platform_win32.c
+++ b/frontend/drivers/platform_win32.c
@@ -603,5 +603,6 @@ frontend_ctx_driver_t frontend_ctx_win32 = {
    NULL,                            /* check_for_path_changes */
    NULL,                            /* set_sustained_performance_mode */
    frontend_win32_get_cpu_model_name,
+   NULL,                            /* get_user_language */
    "win32"
 };

--- a/frontend/drivers/platform_win32.c
+++ b/frontend/drivers/platform_win32.c
@@ -575,6 +575,61 @@ static const char* frontend_win32_get_cpu_model_name(void)
 #endif
 }
 
+enum retro_language frontend_win32_get_user_language(void)
+{
+   enum retro_language lang = RETRO_LANGUAGE_ENGLISH;
+#if defined(HAVE_LANGEXTRA) && !defined(_XBOX)
+#if (defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0500) || !defined(_MSC_VER)
+   LANGID langid = GetUserDefaultUILanguage();
+   unsigned i;
+
+   struct lang_pair
+   {
+      unsigned short lang_ident;
+      enum retro_language lang;
+   };
+
+   /* https://docs.microsoft.com/en-us/windows/desktop/Intl/language-identifier-constants-and-strings */
+   const struct lang_pair pairs[] =
+   {
+      {0x9, RETRO_LANGUAGE_ENGLISH},
+      {0x11, RETRO_LANGUAGE_JAPANESE},
+      {0xc, RETRO_LANGUAGE_FRENCH},
+      {0xa, RETRO_LANGUAGE_SPANISH},
+      {0x7, RETRO_LANGUAGE_GERMAN},
+      {0x10, RETRO_LANGUAGE_ITALIAN},
+      {0x13, RETRO_LANGUAGE_DUTCH},
+      {0x416, RETRO_LANGUAGE_PORTUGUESE_BRAZIL},
+      {0x816, RETRO_LANGUAGE_PORTUGUESE_PORTUGAL},
+      {0x16, RETRO_LANGUAGE_PORTUGUESE_PORTUGAL},
+      {0x19, RETRO_LANGUAGE_RUSSIAN},
+      {0x12, RETRO_LANGUAGE_KOREAN},
+      {0xC04, RETRO_LANGUAGE_CHINESE_TRADITIONAL}, /* HK/PRC */
+      {0x1404, RETRO_LANGUAGE_CHINESE_TRADITIONAL}, /* MO */
+      {0x1004, RETRO_LANGUAGE_CHINESE_SIMPLIFIED}, /* SG */
+      {0x7c04, RETRO_LANGUAGE_CHINESE_TRADITIONAL}, /* neutral */
+      {0x4, RETRO_LANGUAGE_CHINESE_SIMPLIFIED}, /* neutral */
+      /* MS does not support Esperanto */
+      /*{0x0, RETRO_LANGUAGE_ESPERANTO},*/
+      {0x15, RETRO_LANGUAGE_POLISH},
+      {0x2a, RETRO_LANGUAGE_VIETNAMESE},
+      {0x1, RETRO_LANGUAGE_ARABIC},
+      {0x8, RETRO_LANGUAGE_GREEK},
+   };
+
+   for (i = 0; i < sizeof(pairs) / sizeof(pairs[0]); i++)
+   {
+      if ((langid & pairs[i].lang_ident) == pairs[i].lang_ident)
+      {
+         lang = pairs[i].lang;
+         break;
+      }
+   }
+#endif
+#endif
+   return lang;
+}
+
 frontend_ctx_driver_t frontend_ctx_win32 = {
    frontend_win32_environment_get,
    frontend_win32_init,
@@ -603,6 +658,6 @@ frontend_ctx_driver_t frontend_ctx_win32 = {
    NULL,                            /* check_for_path_changes */
    NULL,                            /* set_sustained_performance_mode */
    frontend_win32_get_cpu_model_name,
-   NULL,                            /* get_user_language */
+   frontend_win32_get_user_language,
    "win32"
 };

--- a/frontend/drivers/platform_xdk.c
+++ b/frontend/drivers/platform_xdk.c
@@ -434,5 +434,6 @@ frontend_ctx_driver_t frontend_ctx_xdk = {
    NULL,                         /* check_for_path_changes */
    NULL,                         /* set_sustained_performance_mode */
    NULL,                         /* get_cpu_model_name */
+   NULL,                         /* get_user_language */
    "xdk",
 };

--- a/frontend/drivers/platform_xenon.c
+++ b/frontend/drivers/platform_xenon.c
@@ -95,5 +95,6 @@ frontend_ctx_driver_t frontend_ctx_qnx = {
    NULL,                         /* check_for_path_changes */
    NULL,                         /* set_sustained_performance_mode */
    NULL,                         /* get_cpu_model_name */
+   NULL,                         /* get_user_language */
    "xenon",
 };

--- a/frontend/frontend_driver.c
+++ b/frontend/frontend_driver.c
@@ -18,6 +18,7 @@
 
 #include <compat/strl.h>
 #include <string/stdstring.h>
+#include <libretro.h>
 
 #if defined(_3DS)
 #include <3ds.h>
@@ -463,5 +464,13 @@ const char* frontend_driver_get_cpu_model_name(void)
    if (!frontend || !frontend->get_cpu_model_name)
       return NULL;
    return frontend->get_cpu_model_name();
+}
+
+enum retro_language frontend_driver_get_user_language(void)
+{
+   frontend_ctx_driver_t *frontend = frontend_get_ptr();
+   if (!frontend || !frontend->get_user_language)
+      return RETRO_LANGUAGE_ENGLISH;
+   return frontend->get_user_language();
 }
 #endif

--- a/frontend/frontend_driver.h
+++ b/frontend/frontend_driver.h
@@ -107,6 +107,7 @@ typedef struct frontend_ctx_driver
    bool (*check_for_path_changes)(path_change_data_t *change_data);
    void (*set_sustained_performance_mode)(bool on);
    const char* (*get_cpu_model_name)(void);
+   enum retro_language (*get_user_language)(void);
 
    const char *ident;
 
@@ -213,6 +214,8 @@ bool frontend_driver_check_for_path_changes(path_change_data_t *change_data);
 void frontend_driver_set_sustained_performance_mode(bool on);
 
 const char* frontend_driver_get_cpu_model_name(void);
+
+enum retro_language frontend_driver_get_user_language(void);
 
 RETRO_END_DECLS
 

--- a/pkg/android/phoenix/src/com/retroarch/browser/retroactivity/RetroActivityCommon.java
+++ b/pkg/android/phoenix/src/com/retroarch/browser/retroactivity/RetroActivityCommon.java
@@ -21,6 +21,7 @@ import android.os.VibrationEffect;
 import android.util.Log;
 import java.lang.Math;
 import java.util.concurrent.CountDownLatch;
+import java.util.Locale;
 
 /**
  * Class which provides common methods for RetroActivity related classes.
@@ -151,6 +152,20 @@ public class RetroActivityCommon extends RetroActivityLocation
         setRequestedOrientation(screenOrientation);
       }
     });
+  }
+
+  public String getUserLanguageString()
+  {
+    String lang = Locale.getDefault().getLanguage();
+    String country = Locale.getDefault().getCountry();
+
+    if (lang.length() == 0)
+      return "en";
+
+    if (country.length() == 0)
+      return lang;
+
+    return lang + '_' + country;
   }
 
   @TargetApi(24)

--- a/retroarch.c
+++ b/retroarch.c
@@ -5415,3 +5415,52 @@ void rarch_log_file_deinit(void)
       retro_main_log_file_init(NULL, false);
    }
 }
+
+enum retro_language rarch_get_language_from_iso(const char *iso639)
+{
+   unsigned i;
+   enum retro_language lang = RETRO_LANGUAGE_ENGLISH;
+
+   struct lang_pair
+   {
+      const char *iso639;
+      enum retro_language lang;
+   };
+
+   const struct lang_pair pairs[] =
+   {
+      {"en", RETRO_LANGUAGE_ENGLISH},
+      {"ja", RETRO_LANGUAGE_JAPANESE},
+      {"fr", RETRO_LANGUAGE_FRENCH},
+      {"es", RETRO_LANGUAGE_SPANISH},
+      {"de", RETRO_LANGUAGE_GERMAN},
+      {"it", RETRO_LANGUAGE_ITALIAN},
+      {"nl", RETRO_LANGUAGE_DUTCH},
+      {"pt_BR", RETRO_LANGUAGE_PORTUGUESE_BRAZIL},
+      {"pt_PT", RETRO_LANGUAGE_PORTUGUESE_PORTUGAL},
+      {"pt", RETRO_LANGUAGE_PORTUGUESE_PORTUGAL},
+      {"ru", RETRO_LANGUAGE_RUSSIAN},
+      {"ko", RETRO_LANGUAGE_KOREAN},
+      {"zh_CN", RETRO_LANGUAGE_CHINESE_SIMPLIFIED},
+      {"zh_SG", RETRO_LANGUAGE_CHINESE_SIMPLIFIED},
+      {"zh_HK", RETRO_LANGUAGE_CHINESE_TRADITIONAL},
+      {"zh_TW", RETRO_LANGUAGE_CHINESE_TRADITIONAL},
+      {"zh", RETRO_LANGUAGE_CHINESE_SIMPLIFIED},
+      {"eo", RETRO_LANGUAGE_ESPERANTO},
+      {"pl", RETRO_LANGUAGE_POLISH},
+      {"vi", RETRO_LANGUAGE_VIETNAMESE},
+      {"ar", RETRO_LANGUAGE_ARABIC},
+      {"el", RETRO_LANGUAGE_GREEK},
+   };
+
+   for (i = 0; i < sizeof(pairs) / sizeof(pairs[0]); i++)
+   {
+      if (strcasestr(iso639, pairs[i].iso639))
+      {
+         lang = pairs[i].lang;
+         break;
+      }
+   }
+
+   return lang;
+}

--- a/retroarch.c
+++ b/retroarch.c
@@ -44,6 +44,7 @@
 #include <retro_timers.h>
 
 #include <compat/strl.h>
+#include <compat/strcasestr.h>
 #include <compat/getopt.h>
 #include <audio/audio_mixer.h>
 #include <compat/posix_string.h>

--- a/retroarch.h
+++ b/retroarch.h
@@ -432,6 +432,8 @@ void rarch_log_file_init(void);
 
 void rarch_log_file_deinit(void);
 
+enum retro_language rarch_get_language_from_iso(const char *lang);
+
 RETRO_END_DECLS
 
 #endif


### PR DESCRIPTION
Any time the `user_language` setting is missing from the config on startup (mostly just on first startup or if config is wiped) then the default language is set to the system's user (or OS) default/preferred language.

Includes implementations for Windows, *nix and Android. Requested by twinaphex.