### PR TITLE
(RGUI) Add on-screen keyboard

### DIFF
--- a/frontend/frontend_driver.h
+++ b/frontend/frontend_driver.h
@@ -24,6 +24,8 @@
 #include <retro_common_api.h>
 #include <lists/string_list.h>
 
+#include <libretro.h>
+
 RETRO_BEGIN_DECLS
 
 enum frontend_powerstate

--- a/menu/menu_input.c
+++ b/menu/menu_input.c
@@ -186,6 +186,7 @@ unsigned menu_event(input_bits_t *p_input, input_bits_t *p_trigger_input)
    unsigned ok_current                     = BIT256_GET_PTR(p_input,
          menu_ok_btn );
    unsigned ok_trigger                     = ok_current & ~ok_old;
+   bool is_rgui                            = string_is_equal(settings->arrays.menu_driver, "rgui");
 
    ok_old                                  = ok_current;
 
@@ -272,12 +273,12 @@ unsigned menu_event(input_bits_t *p_input, input_bits_t *p_trigger_input)
             menu_event_set_osk_idx((enum osk_type)(
                      menu_event_get_osk_idx() - 1));
          else
-            menu_event_set_osk_idx((enum osk_type)(OSK_TYPE_LAST - 1));
+            menu_event_set_osk_idx((enum osk_type)(is_rgui ? OSK_HIRAGANA_PAGE1 - 1 : OSK_TYPE_LAST - 1));
       }
 
       if (BIT256_GET_PTR(p_trigger_input, RETRO_DEVICE_ID_JOYPAD_R))
       {
-         if (menu_event_get_osk_idx() < OSK_TYPE_LAST - 1)
+         if (menu_event_get_osk_idx() < (is_rgui ? OSK_HIRAGANA_PAGE1 - 1 : OSK_TYPE_LAST - 1))
             menu_event_set_osk_idx((enum osk_type)(
                      menu_event_get_osk_idx() + 1));
          else

--- a/menu/widgets/menu_osk.c
+++ b/menu/widgets/menu_osk.c
@@ -31,6 +31,7 @@
 #include "menu_osk.h"
 
 #include "../../input/input_driver.h"
+#include "../../configuration.h"
 
 static char *osk_grid[45]        = {NULL};
 
@@ -83,8 +84,13 @@ void menu_event_set_osk_ptr(int i)
 
 void menu_event_osk_append(int ptr)
 {
-   if (ptr < 0)
+   settings_t *settings = config_get_ptr();
+   bool is_rgui;
+
+   if (ptr < 0 || !settings)
       return;
+
+   is_rgui = string_is_equal(settings->arrays.menu_driver, "rgui");
 
 #ifdef HAVE_LANGEXTRA
    if (string_is_equal(osk_grid[ptr],"\xe2\x87\xa6")) /* backspace character */
@@ -109,7 +115,7 @@ void menu_event_osk_append(int ptr)
       menu_event_set_osk_idx(OSK_LOWERCASE_LATIN);
    else if (string_is_equal(osk_grid[ptr], "Next"))
 #endif
-      if (menu_event_get_osk_idx() < OSK_TYPE_LAST - 1)
+      if (menu_event_get_osk_idx() < (is_rgui ? OSK_HIRAGANA_PAGE1 - 1 : OSK_TYPE_LAST - 1))
          menu_event_set_osk_idx((enum osk_type)(menu_event_get_osk_idx() + 1));
       else
          menu_event_set_osk_idx((enum osk_type)(OSK_TYPE_UNKNOWN + 1));


### PR DESCRIPTION
## Description

At present, RGUI does not have an on-screen keyboard. This means we cannot use it to enter text (usernames, passwords, etc.) without access to a physical keyboard, which is annoying in most cases and impossible for many of the console ports.

This PR adds an on-screen keyboard. Here it is in action:

![window_record__2019_04_17__16_57_35](https://user-images.githubusercontent.com/38211560/56303448-db2e9400-6133-11e9-813d-fae30f4a7fdb.gif)

If the entered string is too long to fit in the box, it only shows that last 37 characters, like so:

![window_record__2019_04_17__17_01_09](https://user-images.githubusercontent.com/38211560/56303548-103ae680-6134-11e9-9869-b38330e03e79.gif)

The on-screen keyboard behaves exactly the same as in the other menu drivers, but only the lower case/upper case Latin and symbols pages are available (since RGUI cannot display the rest...)
