### PR TITLE
RGUI OSK - HAVE_LANGEXTRA=0 build fix

### DIFF
--- a/menu/menu_input.c
+++ b/menu/menu_input.c
@@ -273,12 +273,12 @@ unsigned menu_event(input_bits_t *p_input, input_bits_t *p_trigger_input)
             menu_event_set_osk_idx((enum osk_type)(
                      menu_event_get_osk_idx() - 1));
          else
-            menu_event_set_osk_idx((enum osk_type)(is_rgui ? OSK_HIRAGANA_PAGE1 - 1 : OSK_TYPE_LAST - 1));
+            menu_event_set_osk_idx((enum osk_type)(is_rgui ? OSK_SYMBOLS_PAGE1 : OSK_TYPE_LAST - 1));
       }
 
       if (BIT256_GET_PTR(p_trigger_input, RETRO_DEVICE_ID_JOYPAD_R))
       {
-         if (menu_event_get_osk_idx() < (is_rgui ? OSK_HIRAGANA_PAGE1 - 1 : OSK_TYPE_LAST - 1))
+         if (menu_event_get_osk_idx() < (is_rgui ? OSK_SYMBOLS_PAGE1 : OSK_TYPE_LAST - 1))
             menu_event_set_osk_idx((enum osk_type)(
                      menu_event_get_osk_idx() + 1));
          else

--- a/menu/widgets/menu_osk.c
+++ b/menu/widgets/menu_osk.c
@@ -115,7 +115,7 @@ void menu_event_osk_append(int ptr)
       menu_event_set_osk_idx(OSK_LOWERCASE_LATIN);
    else if (string_is_equal(osk_grid[ptr], "Next"))
 #endif
-      if (menu_event_get_osk_idx() < (is_rgui ? OSK_HIRAGANA_PAGE1 - 1 : OSK_TYPE_LAST - 1))
+      if (menu_event_get_osk_idx() < (is_rgui ? OSK_SYMBOLS_PAGE1 : OSK_TYPE_LAST - 1))
          menu_event_set_osk_idx((enum osk_type)(menu_event_get_osk_idx() + 1));
       else
          menu_event_set_osk_idx((enum osk_type)(OSK_TYPE_UNKNOWN + 1));


### PR DESCRIPTION
## Description

PR #8594 contains a small and silly copy/paste oversight:

In `menu_input.c` and `menu_osk.c`, reference is made to `OSK_HIRAGANA_PAGE1 - 1`. This is fine in most cases, but when HAVE_LANGEXTRA is disabled it causes a build error (since the enum value `OSK_HIRAGANA_PAGE1` does not exist!). `OSK_SYMBOLS_PAGE1` should have been used instead.

This PR fixes the issue.

## Related Pull Requests

#8594

