### PR TITLE
Fix font selection.

### DIFF
--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -6222,7 +6222,8 @@ static int menu_cbs_init_bind_ok_compare_type(menu_file_list_cbs_t *cbs,
                   || menu_label_hash == MENU_LABEL_DISK_IMAGE_APPEND
                   || menu_label_hash == MENU_LABEL_SUBSYSTEM_ADD
                   || menu_label_hash == MENU_LABEL_VIDEO_FONT_PATH
-                  || menu_label_hash == MENU_LABEL_XMB_FONT)
+                  || menu_label_hash == MENU_LABEL_XMB_FONT
+                  || menu_label_hash == MENU_LABEL_AUDIO_DSP_PLUGIN)
                BIND_ACTION_OK(cbs, action_ok_directory_push);
             else
                BIND_ACTION_OK(cbs, action_ok_push_random_dir);

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -6220,7 +6220,9 @@ static int menu_cbs_init_bind_ok_compare_type(menu_file_list_cbs_t *cbs,
          case FILE_TYPE_DIRECTORY:
             if (cbs->enum_idx != MSG_UNKNOWN
                   || menu_label_hash == MENU_LABEL_DISK_IMAGE_APPEND
-                  || menu_label_hash == MENU_LABEL_SUBSYSTEM_ADD)
+                  || menu_label_hash == MENU_LABEL_SUBSYSTEM_ADD
+                  || menu_label_hash == MENU_LABEL_VIDEO_FONT_PATH
+                  || menu_label_hash == MENU_LABEL_XMB_FONT)
                BIND_ACTION_OK(cbs, action_ok_directory_push);
             else
                BIND_ACTION_OK(cbs, action_ok_push_random_dir);


### PR DESCRIPTION
## Description

This fixes selecting the menu font and notification font. I missed this case when fixing previous related issues.

## Related Issues

Fixes https://github.com/libretro/RetroArch/issues/8593

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/8084
https://github.com/libretro/RetroArch/pull/8390
