### PR TITLE
qb: Check for libroar 1.0.12.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -222,7 +222,7 @@ else
 fi
 
 check_pkgconf RSOUND rsound 1.1
-check_pkgconf ROAR libroar
+check_pkgconf ROAR libroar 1.0.12
 check_val '' JACK -ljack '' jack 0.120.1 '' false
 check_val '' PULSE -lpulse '' libpulse '' '' false
 check_val '' SDL -lSDL SDL sdl 1.2.10 '' false


### PR DESCRIPTION
## Description

This hides a now fixed upstream libroar build error which breaks LGTM. Unfortunately this only allows the most recent roaraudio version to be used. I am not sure anyone is really using it anyways?

## Related Issues

Fixes https://github.com/libretro/RetroArch/issues/8581

Also see: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=915345

## Reviewers

LGTM must pass.
