### PR TITLE
Fix some CXX_BUILD errors.

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -5357,7 +5357,7 @@ void rarch_log_file_init(void)
     * logging to file, and wish to do so */
    
    /* > Check whether we are already logging to console */
-   fp = retro_main_log_file();
+   fp = (FILE*)retro_main_log_file();
    if (fp)
    {
       /* De-initialise existing logger */
@@ -5413,7 +5413,7 @@ void rarch_log_file_deinit(void)
    }
    
    /* If logging is currently disabled... */
-   fp = retro_main_log_file();
+   fp = (FILE*)retro_main_log_file();
    if (!fp)
    {
       /* ...initialise logging to console */


### PR DESCRIPTION
## Description

Some CXX_BUILD=1 fixes, it still doesn't build, but at least it gets farther now.

## Related Issues

```
retroarch.c: In function ‘void rarch_log_file_init()’:
retroarch.c:5360:28: error: invalid conversion from ‘void*’ to ‘FILE*’ {aka ‘_IO_FILE*’} [-fpermissive]
    fp = retro_main_log_file();
         ~~~~~~~~~~~~~~~~~~~^~
retroarch.c: In function ‘void rarch_log_file_deinit()’:
retroarch.c:5416:28: error: invalid conversion from ‘void*’ to ‘FILE*’ {aka ‘_IO_FILE*’} [-fpermissive]
    fp = retro_main_log_file();
         ~~~~~~~~~~~~~~~~~~~^~
make: *** [Makefile:201: obj-unix/release/retroarch.o] Error 1
make: *** Waiting for unfinished jobs....
```