### PR TITLE
wayland: Fix build.

### DIFF
--- a/gfx/drivers_context/wayland_ctx.c
+++ b/gfx/drivers_context/wayland_ctx.c
@@ -626,7 +626,7 @@ static void wl_surface_enter(void *data, struct wl_surface *wl_surface,
     };
 }
 
-static void wl_nop(void *a, wl_surface *b, wl_output *c)
+static void wl_nop(void *a, struct wl_surface *b, struct wl_output *c)
 {
    (void)a;
    (void)b;


### PR DESCRIPTION
## Description

The wayland build was accidentally broken without `CXX_BUILD=1`, this fixes to work here with `C89_BUILD=1`, `CXX_BUILD=1` and without either.

There was a dependency problem when testing wayland with travis, I'll have to see if that is resolved yet.

## Related Issues

Fixes https://github.com/libretro/RetroArch/issues/8614.