### PR TITLE
travis: Update to xenial.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 # Use 'generic' to be able to override CC/CXX for clang
 language: generic
 
+# Use a release with a longer normal LTS
+dist: xenial
+
 matrix:
   include:
     - compiler: mingw-x86
@@ -64,14 +67,11 @@ before_install:
        sudo apt-get install -y g++-8
      elif [ "$CC" = clang-6.0 ]; then
        # Install a more recent clang than the default
-       sudo apt-get install -y libstdc++-7-dev
        sudo apt-get install -y clang-6.0
      elif [ "$CROSS_COMPILE" = i686-w64-mingw32- ]; then
-       sudo apt-get install -y g++-mingw-w64-i686
-       sudo apt-get install -y mingw-w64-i686-dev
+       sudo update-alternatives --set i686-w64-mingw32-g++ /usr/bin/i686-w64-mingw32-g++-posix
      elif [ "$CROSS_COMPILE" = x86_64-w64-mingw32- ]; then
-       sudo apt-get install -y g++-mingw-w64-x86-64
-       sudo apt-get install -y mingw-w64-x86-64-dev
+       sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
      fi
 
 script:
@@ -115,7 +115,7 @@ addons:
       - qtdeclarative5-dev
     sources:
       - ubuntu-toolchain-r-test
-      - llvm-toolchain-trusty-6.0
+      - llvm-toolchain-xenial
   coverity_scan:
     project:
       name: "RetroArch"


### PR DESCRIPTION
## Description

This updates travis from Ubuntu trusty (`14.04`) to xenial (`16.04`).

## Related Issues

The normal LTS period for trusty is set to expire on `April 25, 2019` while xenial will expire in `April 2021`. I imagine most users are using xenial or newer releases.

## Reviewers

Note:

* This also allows testing wayland with travis where some of the required dependencies were too old with trusty.
* This will expose a preexisting `CXX_BUILD` error for wayland which I am struggling to fix. Its probably better to expose it than leave it silently broken.