### PR TITLE
qb: Disable wayland for CXX_BUILD for now.

### DIFF
--- a/qb/config.params.sh
+++ b/qb/config.params.sh
@@ -76,6 +76,7 @@ HAVE_DISPMANX=no           # Dispmanx video support
 HAVE_SUNXI=no              # Sunxi video support
 HAVE_WAYLAND=auto          # Wayland support
 C89_WAYLAND=no
+CXX_WAYLAND=no
 HAVE_EGL=auto              # EGL context support
 HAVE_VG=auto               # OpenVG support
 HAVE_CG=auto               # Cg shader support


### PR DESCRIPTION
## Description

This disables `CXX_BUILD=1` for wayland code which is unfortunately blocked by an upstream build issue. Unless the upstream issue is fixed the only way to solve this would be to somehow work around the dependency `wayland-protocols` or to generate our own compatible code. Both solutions are beyond what I can do and undoing this will be easy if the upstream issue is ever resolved.

Note that travis will not actually test wayland until after PR https://github.com/libretro/RetroArch/pull/8621 which I will rebase after this one.

## Related Issues

```
/usr/bin/ld: obj-unix/release/gfx/drivers_context/wayland_ctx.o: in function `registry_handle_global(void*, wl_registry*, unsigned int, char const*, unsigned int)':
wayland_ctx.c:(.text+0x1e52): undefined reference to `zxdg_decoration_manager_v1_interface'
/usr/bin/ld: wayland_ctx.c:(.text+0x1f6b): undefined reference to `xdg_wm_base_interface'
/usr/bin/ld: wayland_ctx.c:(.text+0x1fa3): undefined reference to `zxdg_shell_v6_interface'
/usr/bin/ld: wayland_ctx.c:(.text+0x2053): undefined reference to `zwp_idle_inhibit_manager_v1_interface'
collect2: error: ld returned 1 exit status
make: *** [Makefile:196: retroarch] Error 1
```
https://gitlab.freedesktop.org/wayland/wayland/issues/90