### PR TITLE
Attempt to fix LGTM alerts for tinyalsa.

### DIFF
--- a/audio/drivers/tinyalsa.c
+++ b/audio/drivers/tinyalsa.c
@@ -2169,10 +2169,9 @@ static void * tinyalsa_init(const char *devicestr, unsigned rate,
    unsigned int device          = 0;
    unsigned int frames_per_ms   = 0;
    unsigned int orig_rate       = rate;
-   unsigned int max_rate, min_rate;
+   unsigned int max_rate, min_rate, buffer_size;
    float initial_latency;
 
-   snd_pcm_uframes_t         buffer_size;
    struct pcm_config         config;
 
    tinyalsa_t *tinyalsa      = (tinyalsa_t*)calloc(1, sizeof(tinyalsa_t));


### PR DESCRIPTION
## Description

This attempts to fix a few LGTM alerts for tinyalsa.

## Related Issues

```
   RARCH_LOG("[TINYALSA]: Can pause: %s.\n", tinyalsa->can_pause ? "yes" : "no");
   RARCH_LOG("[TINYALSA]: Audio rate: %uHz.\n", config.rate);
   RARCH_LOG("[TINYALSA]: Buffer size: %u frames.\n", buffer_size);
This argument should be of type 'unsigned int' but is of type 'unsigned long'
This alert was introduced in 8b972a82 years ago
 RARCH_LOG("[TINYALSA]: Buffer size: %u bytes.\n", tinyalsa->buffer_size);
This argument should be of type 'unsigned int' but is of type 'unsigned long'
This alert was introduced in 8b972a82 years ago
   RARCH_LOG("[TINYALSA]: Frame  size: %u bytes.\n", tinyalsa->frame_bits / 8);
   RARCH_LOG("[TINYALSA]: Latency: %ums.\n", buffer_size * 1000 / (rate * 4));
This argument should be of type 'unsigned int' but is of type 'unsigned long'
This alert was introduced in 8b972a82 years ago

   pcm_params_free(tinyalsa->params);
```
https://lgtm.com/rules/2160310550/


## Reviewers

Please wait for LGTM and travis to finish.
