### PR TITLE
UWP VFS: Calculate buffer offset correctly when read fails due to EOF

### DIFF
--- a/libretro-common/file/file_path.c
+++ b/libretro-common/file/file_path.c
@@ -1198,7 +1198,7 @@ void fill_pathname_home_dir(char *s, size_t len)
 }
 #endif
 
-bool is_path_accessible_using_standard_io(char *path)
+bool is_path_accessible_using_standard_io(const char *path)
 {
 #ifdef __WINRT__
    bool result;

--- a/libretro-common/include/file/file_path.h
+++ b/libretro-common/include/file/file_path.h
@@ -498,7 +498,7 @@ bool path_is_valid(const char *path);
 
 int32_t path_get_size(const char *path);
 
-bool is_path_accessible_using_standard_io(char *path);
+bool is_path_accessible_using_standard_io(const char *path);
 
 RETRO_END_DECLS
 


### PR DESCRIPTION

![Screenshot_20190428_121702-fs8](https://user-images.githubusercontent.com/1331889/56862874-d2e61c80-69af-11e9-98d2-33f1fa7594f0.png)

@Autechre64 