### PR TITLE
task_database: use regular progress report

### DIFF
--- a/libretro-common/include/queues/task_queue.h
+++ b/libretro-common/include/queues/task_queue.h
@@ -114,9 +114,14 @@ struct retro_task
    /* task identifier */
    uint32_t ident;
 
-   /* frontend userdata 
+   /* frontend userdata
     * (e.g. associate a sticky notification to a task) */
    void *frontend_userdata;
+
+   /* if set to true, frontend will
+      use an alternative look for the
+      task progress display */
+   bool alternative_look;
 
    /* don't touch this. */
    retro_task_t *next;

--- a/menu/widgets/menu_widgets.c
+++ b/menu/widgets/menu_widgets.c
@@ -158,6 +158,7 @@ typedef struct menu_widget_msg
    uint8_t task_count; /* how many tasks have used this notification? */
 
    int8_t task_progress;
+   bool task_alternative_look;
    bool task_finished;
    bool task_error;
    bool task_cancelled;
@@ -380,24 +381,25 @@ static bool menu_widgets_msg_queue_push_internal(retro_task_t *task, const char 
 
          if (task)
          {
-            msg_widget->msg                  = strdup(title);
-            msg_widget->msg_len              = strlen(title);
+            msg_widget->msg                     = strdup(title);
+            msg_widget->msg_len                 = strlen(title);
 
-            msg_widget->task_error           = task->error;
-            msg_widget->task_cancelled       = task->cancelled;
-            msg_widget->task_finished        = task->finished;
-            msg_widget->task_progress        = task->progress;
-            msg_widget->task_ident           = task->ident;
-            msg_widget->task_title_ptr       = task->title;
-            msg_widget->task_count           = 1;
+            msg_widget->task_error              = task->error;
+            msg_widget->task_cancelled          = task->cancelled;
+            msg_widget->task_finished           = task->finished;
+            msg_widget->task_alternative_look   = task->alternative_look;
+            msg_widget->task_progress           = task->progress;
+            msg_widget->task_ident              = task->ident;
+            msg_widget->task_title_ptr          = task->title;
+            msg_widget->task_count              = 1;
 
-            msg_widget->unfolded             = true;
+            msg_widget->unfolded                = true;
 
-            msg_widget->width                = font_driver_get_message_width(font_regular, title, msg_widget->msg_len, msg_queue_text_scale_factor) + simple_widget_padding/2;
+            msg_widget->width                   = font_driver_get_message_width(font_regular, title, msg_widget->msg_len, msg_queue_text_scale_factor) + simple_widget_padding/2;
 
-            task->frontend_userdata          = msg_widget;
+            task->frontend_userdata             = msg_widget;
 
-            msg_widget->hourglass_rotation   = 0;
+            msg_widget->hourglass_rotation      = 0;
          }
          else
          {
@@ -448,7 +450,6 @@ static bool menu_widgets_msg_queue_push_internal(retro_task_t *task, const char 
 
          if (task->title != msg_widget->task_title_ptr)
          {
-            menu_animation_ctx_entry_t entry;
             unsigned len         = strlen(task->title);
             unsigned new_width   = font_driver_get_message_width(font_regular, task->title, len, msg_queue_text_scale_factor);
 
@@ -460,15 +461,23 @@ static bool menu_widgets_msg_queue_push_internal(retro_task_t *task, const char 
             msg_widget->task_title_ptr             = task->title;
             msg_widget->msg_transition_animation   = 0;
 
-            entry.easing_enum = EASING_OUT_QUAD;
-            entry.tag = (uintptr_t) NULL;
-            entry.duration = MSG_QUEUE_ANIMATION_DURATION*2;
-            entry.target_value = msg_queue_height/2.0f;
-            entry.subject = &msg_widget->msg_transition_animation;
-            entry.cb = msg_widget_msg_transition_animation_done;
-            entry.userdata = msg_widget;
+            if (!task->alternative_look)
+            {
+               menu_animation_ctx_entry_t entry;
+               entry.easing_enum = EASING_OUT_QUAD;
+               entry.tag = (uintptr_t) NULL;
+               entry.duration = MSG_QUEUE_ANIMATION_DURATION*2;
+               entry.target_value = msg_queue_height/2.0f;
+               entry.subject = &msg_widget->msg_transition_animation;
+               entry.cb = msg_widget_msg_transition_animation_done;
+               entry.userdata = msg_widget;
 
-            menu_animation_push(&entry);
+               menu_animation_push(&entry);
+            }
+            else
+            {
+               msg_widget_msg_transition_animation_done(msg_widget);
+            }
 
             msg_widget->task_count++;
 

--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -15,6 +15,7 @@
  *  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <math.h>
 #include <compat/strcasestr.h>
 #include <compat/strl.h>
 #include <retro_miscellaneous.h>
@@ -131,13 +132,23 @@ static const char *database_info_get_current_element_name(
    return handle->list->elems[handle->list_ptr].data;
 }
 
-static int task_database_iterate_start(database_info_handle_t *db,
+static int task_database_iterate_start(retro_task_t *task,
+      database_info_handle_t *db,
       const char *name)
 {
    char msg[511];
 
    msg[0] = msg[510] = '\0';
-
+#ifdef RARCH_INTERNAL
+   snprintf(msg, sizeof(msg),
+         "%s %s\n",
+         msg_hash_to_str(MSG_SCANNING),
+         path_basename(name));
+   task_free_title(task);
+   task_set_title(task, strdup(msg));
+   if (db->list->size != 0)
+      task_set_progress(task, roundf((float)db->list_ptr / (float)db->list->size * 100.0f));
+#else
    snprintf(msg, sizeof(msg),
          STRING_REP_USIZE "/" STRING_REP_USIZE ": %s %s...\n",
          (size_t)db->list_ptr,
@@ -146,13 +157,8 @@ static int task_database_iterate_start(database_info_handle_t *db,
          name);
 
    if (!string_is_empty(msg))
-   {
-#ifdef RARCH_INTERNAL
-      runloop_msg_queue_push(msg, 1, 180, true, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
-#else
       fprintf(stderr, "msg: %s\n", msg);
 #endif
-   }
 
    db->status = DATABASE_STATUS_ITERATE;
 
@@ -1204,8 +1210,6 @@ static void task_database_handler(retro_task_t *task)
             db->handle = database_info_file_init(db->fullpath, DATABASE_TYPE_ITERATE, task);
       }
 
-      task_free_title(task);
-
       if (db->handle)
          db->handle->status = DATABASE_STATUS_ITERATE_BEGIN;
    }
@@ -1275,7 +1279,7 @@ static void task_database_handler(retro_task_t *task)
          task_database_cleanup_state(dbstate);
          dbstate->list_index  = 0;
          dbstate->entry_index = 0;
-         task_database_iterate_start(dbinfo, name);
+         task_database_iterate_start(task, dbinfo, name);
          break;
       case DATABASE_STATUS_ITERATE:
          if (task_database_iterate(db, dbstate, dbinfo) == 0)
@@ -1292,14 +1296,14 @@ static void task_database_handler(retro_task_t *task)
          }
          else
          {
+#ifdef RARCH_INTERNAL
+            task_set_progress(task, 100);
+#else
             const char *msg = NULL;
             if (db->is_directory)
                msg = msg_hash_to_str(MSG_SCANNING_OF_DIRECTORY_FINISHED);
             else
                msg = msg_hash_to_str(MSG_SCANNING_OF_FILE_FINISHED);
-#ifdef RARCH_INTERNAL
-            runloop_msg_queue_push(msg, 0, 180, true, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
-#else
             fprintf(stderr, "msg: %s\n", msg);
 #endif
             ui_companion_driver_notify_refresh();
@@ -1351,7 +1355,7 @@ bool task_push_dbscan(
       bool db_dir_show_hidden_files,
       retro_task_callback_t cb)
 {
-   retro_task_t *t      = (retro_task_t*)calloc(1, sizeof(*t));
+   retro_task_t *t      = task_init();
    db_handle_t *db      = (db_handle_t*)calloc(1, sizeof(db_handle_t));
 
    if (!t || !db)
@@ -1361,6 +1365,8 @@ bool task_push_dbscan(
    t->state                  = db;
    t->callback               = cb;
    t->title                  = strdup(msg_hash_to_str(MSG_PREPARING_FOR_CONTENT_SCAN));
+
+   t->alternative_look       = true;
 
    db->show_hidden_files     = db_dir_show_hidden_files;
    db->is_directory          = directory;

--- a/tasks/task_decompress.c
+++ b/tasks/task_decompress.c
@@ -332,7 +332,7 @@ bool task_push_decompress(
    s->archive.type   = ARCHIVE_TRANSFER_INIT;
    s->userdata = (struct archive_extract_userdata*)calloc(1, sizeof(*s->userdata));
 
-   t              = (retro_task_t*)calloc(1, sizeof(*t));
+   t              = task_init();
 
    if (!t)
       goto error;


### PR DESCRIPTION
This commit makes it so the database task uses regular progress report instead of calling `runloop_msg_queue_push` manually.

The progress is now shown as a percentage instead of `number scanned / total number of files`. Only the file name of each scanned file is displayed instead of the full path (to reduce the width of the onscreen message).

The `alternative_look` flag was added to tasks, set it to `true` to notify that the task title will change during its execution. It prevents the task menu widget from being illegible due to the title change animation.

This has been tested on PC with both menu widgets enabled and disabled, as well as the Qt interface.