### PR TITLE
 (menu_thumbnail_path) Use content directory name as fallback for 'db_name' in history and favorites playlists

### DIFF
--- a/menu/menu_thumbnail_path.c
+++ b/menu/menu_thumbnail_path.c
@@ -351,7 +351,7 @@ bool menu_thumbnail_set_content_playlist(menu_thumbnail_path_data_t *path_data, 
       return false;
    
    /* Cache content path
-    * (This is required for imageviewer content) */
+    * (This is required for imageviewer, history and favourites content) */
    strlcpy(path_data->content_path,
             content_path, sizeof(path_data->content_path));
    
@@ -424,6 +424,7 @@ bool menu_thumbnail_update_path(menu_thumbnail_path_data_t *path_data, enum menu
    const char *type        = menu_thumbnail_get_type(thumbnail_id);
    const char *system_name = NULL;
    char *thumbnail_path    = NULL;
+   char content_dir[PATH_MAX_LENGTH];
    
    if (!path_data)
       return false;
@@ -456,23 +457,52 @@ bool menu_thumbnail_update_path(menu_thumbnail_path_data_t *path_data, enum menu
    /* Generate new path */
    
    /* > Check path_data for empty strings */
-   if (string_is_empty(path_data->content_img) ||
+   if (string_is_empty(path_data->content_path) ||
+       string_is_empty(path_data->content_img) ||
          (string_is_empty(path_data->system) &&
           string_is_empty(path_data->content_db_name)))
       return false;
    
    /* > Get current system */
-   system_name = string_is_empty(path_data->content_db_name) ?
-      path_data->system : path_data->content_db_name;
+   if (string_is_empty(path_data->content_db_name))
+   {
+      /* If this is a content history or favorites playlist
+       * then the current 'path_data->system' string is
+       * meaningless. In this case, we fall back to the
+       * content directory name */
+      if (string_is_equal(path_data->system, "history") ||
+          string_is_equal(path_data->system, "favorites"))
+      {
+         char tmp_buf[PATH_MAX_LENGTH] = {0};
+         const char *last_slash = find_last_slash(path_data->content_path);
+         
+         content_dir[0] = '\0';
+         system_name    = content_dir;
+         
+         if (last_slash)
+         {
+            size_t path_length = last_slash + 1 - path_data->content_path;
+            if ((path_length > 1) && (path_length < PATH_MAX_LENGTH))
+            {
+               strlcpy(tmp_buf, path_data->content_path, path_length * sizeof(char));
+               strlcpy(content_dir, path_basename(tmp_buf), sizeof(content_dir));
+            }
+         }
+         
+         if (string_is_empty(system_name))
+            return false;
+      }
+      else
+         system_name = path_data->system;
+   }
+   else
+      system_name = path_data->content_db_name;
    
    /* > Special case: thumbnail for imageviewer content
     *   is the image file itself */
    if (string_is_equal(system_name, "images_history") ||
        string_is_equal(path_data->content_core_name, "imageviewer"))
    {
-      if (string_is_empty(path_data->content_path))
-         return false;
-      
       /* imageviewer content is identical for left and right thumbnails */
       if (path_is_media_type(path_data->content_path) == RARCH_CONTENT_IMAGE)
          strlcpy(thumbnail_path,


### PR DESCRIPTION
## Description

At present, loading content via the file browser or command line produces a content history entry with missing `label`, `crc32` and `db_name` values. `db_name` is (probably) the most significant of these, since without it we cannot display associated thumbnails. This means:

- Users who rely exclusively on the file browser to load new content never see any thumbnails at all.

- Users on platforms that rely on forking to load content (i.e. consoles, such as 3DS) never see thumbnails on their content history playlists (since, in effect, everything is ultimately launched via the 'command line')

If a history item without a `db_name` is added to favourites, then of course it will have no thumbnail there, either...

This PR implements a very simple (crude?) workaround for this issue. When selecting either a history or favourites entry without a `db_name` value, the content directory name is used instead. Provided that the content and thumbnail directories have the same name, thumbnail images can be shown.

In order for this to work, I guess most users would have to rename their content directories (or their thumbnail directories, whichever is easier) - but I really don't think this is much of an imposition.

(And for users who can't be bothered with this, the PR has no downside - it essentially just adds two more `strlcpy()`s when selecting a history/favourites entry with no `db_name` value, which is entirely insignificant in the scheme of handling thumbnail-related stuff)

## Related Issues

This could be considered a partial solution to the second half of #8635.
