### PR TITLE
For platforms without HAVE_THREADS, don't automatically resume content when saving/loading states

### DIFF
--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -3255,7 +3255,11 @@ static int action_ok_load_state(const char *path,
 {
    if (generic_action_ok_command(CMD_EVENT_LOAD_STATE) == -1)
       return menu_cbs_exit();
+#if defined(HAVE_THREADS)
    return generic_action_ok_command(CMD_EVENT_RESUME);
+#else
+   return 0;
+#endif
 }
 
 static int action_ok_save_state(const char *path,
@@ -3263,7 +3267,11 @@ static int action_ok_save_state(const char *path,
 {
    if (generic_action_ok_command(CMD_EVENT_SAVE_STATE) == -1)
       return menu_cbs_exit();
+#if defined(HAVE_THREADS)
    return generic_action_ok_command(CMD_EVENT_RESUME);
+#else
+   return 0;
+#endif
 }
 
 static int action_ok_cheevos_toggle_hardcore_mode(const char *path,

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -3255,6 +3255,7 @@ static int action_ok_load_state(const char *path,
 {
    if (generic_action_ok_command(CMD_EVENT_LOAD_STATE) == -1)
       return menu_cbs_exit();
+   /* TODO/FIXME: Make this a user-configurable option */
 #if defined(HAVE_THREADS)
    return generic_action_ok_command(CMD_EVENT_RESUME);
 #else
@@ -3267,6 +3268,7 @@ static int action_ok_save_state(const char *path,
 {
    if (generic_action_ok_command(CMD_EVENT_SAVE_STATE) == -1)
       return menu_cbs_exit();
+   /* TODO/FIXME: Make this a user-configurable option */
 #if defined(HAVE_THREADS)
    return generic_action_ok_command(CMD_EVENT_RESUME);
 #else


### PR DESCRIPTION
## Description

On most platforms, save states have zero performance issues - but on very weak devices (typically consoles, such as the 3DS) with slow storage and no threading support, the current save state interface is quite painful. It essentially goes as follows:

- Select save state from the quick menu

- Content resumes, and proceeds to run at 1 FPS (with hideous sound distortion) for several seconds (up to 15-20 seconds for cores like snes9x2002)

- Save eventually completes, and normal service is resumed

We can't do anything about a device's inherent performance limitations, but this PR at least makes the user experience more bearable by disabling the automatic content resume when saving/loading states on devices that lack threading support. Remaining in the menu while states are handled both reduces the time taken to save/load, and it prevents the user from being assaulted by broken audio.