### PR TITLE
minor fixes for cheevos-new

### DIFF
--- a/deps/rcheevos/src/rcheevos/lboard.c
+++ b/deps/rcheevos/src/rcheevos/lboard.c
@@ -166,6 +166,8 @@ int rc_evaluate_lboard(rc_lboard_t* self, unsigned* value, rc_peek_t peek, void*
   int start_ok, cancel_ok, submit_ok;
   int action = -1;
 
+  if (!self) return RC_LBOARD_INACTIVE;
+
   rc_update_memref_values(self->memrefs, peek, peek_ud);
 
   /* ASSERT: these are always tested once every frame, to ensure delta variables work properly */

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -3271,6 +3271,7 @@ static int action_ok_cheevos_toggle_hardcore_mode(const char *path,
 {
 #ifdef HAVE_CHEEVOS
    cheevos_hardcore_paused = !cheevos_hardcore_paused;
+   rcheevos_hardcore_paused = !rcheevos_hardcore_paused;
 #endif
    generic_action_ok_command(CMD_EVENT_CHEEVOS_HARDCORE_MODE_TOGGLE);
    return generic_action_ok_command(CMD_EVENT_RESUME);


### PR DESCRIPTION
## Description

This PR fixes two minor issues reported by the user @LootusMaximus while playing with the new cheevos implementation:

1. The achievements feature (and only it) was being completely disabled when a game has a buggy leaderboard entry (and it was happening with the [Pokemon Prism (GBC)](https://retroachievements.org/game/9491) game.
2. the "Pause Hardcore Mode" feature was resetting the game, instead of "pausing" the hardcore mode and continuing the game from the same point, but in softcore mode.

## Related Issues

see above :point_up:

## Related Pull Requests

#8501 

## Reviewers

@leiradel @Jamiras 