### PR TITLE
menu_widgets: implement the user setting

### DIFF
--- a/cheevos-new/cheevos.c
+++ b/cheevos-new/cheevos.c
@@ -505,7 +505,7 @@ static void rcheevos_award(rcheevos_cheevo_t* cheevo, int mode)
 
    /* Show the OSD message. */
 #if defined(HAVE_MENU) && defined(HAVE_MENU_WIDGETS)
-   if (!video_driver_has_widgets() || !menu_widgets_push_achievement(cheevo->info->title, cheevo->info->badge))
+   if (!menu_widgets_push_achievement(cheevo->info->title, cheevo->info->badge))
 #endif
    {
       snprintf(buffer, sizeof(buffer), "Achievement Unlocked: %s", cheevo->info->title);

--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -1658,7 +1658,7 @@ static void cheevos_test_cheevo_set(const cheevoset_t *set)
                   cheevo->id, cheevo->title, cheevo->description);
 
 #if defined(HAVE_MENU) && defined(HAVE_MENU_WIDGETS)
-            if (!video_driver_has_widgets() || !menu_widgets_push_achievement(cheevo->title, cheevo->badge))
+            if (!menu_widgets_push_achievement(cheevo->title, cheevo->badge))
 #endif
             {
                char msg[256];

--- a/command.c
+++ b/command.c
@@ -988,7 +988,7 @@ static void command_event_set_volume(float gain)
          new_volume);
 
 #if defined(HAVE_MENU) && defined(HAVE_MENU_WIDGETS)
-   if (!video_driver_has_widgets() || !menu_widgets_volume_update_and_show())
+   if (!menu_widgets_volume_update_and_show())
 #endif
       runloop_msg_queue_push(msg, 1, 180, true, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
 
@@ -2141,7 +2141,7 @@ TODO: Add a setting for these tweaks */
             }
 
 #if defined(HAVE_MENU) && defined(HAVE_MENU_WIDGETS)
-            if (!video_driver_has_widgets() || !menu_widgets_volume_update_and_show())
+            if (!menu_widgets_volume_update_and_show())
 #endif
                runloop_msg_queue_push(msg, 1, 180, true, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
 
@@ -2531,11 +2531,11 @@ TODO: Add a setting for these tweaks */
                command_event(CMD_EVENT_AUDIO_STOP, NULL);
 
 #if defined(HAVE_MENU) && defined(HAVE_MENU_WIDGETS)
-               if (!video_driver_has_widgets() || !menu_widgets_set_paused(is_paused))
+               if (!menu_widgets_set_paused(is_paused))
 #endif
-               runloop_msg_queue_push(msg_hash_to_str(MSG_PAUSED), 1,
-                     1, true,
-                     NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
+                  runloop_msg_queue_push(msg_hash_to_str(MSG_PAUSED), 1,
+                        1, true,
+                        NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
 
                if (!is_idle)
                   video_driver_cached_frame();
@@ -2548,8 +2548,7 @@ TODO: Add a setting for these tweaks */
             else
             {
 #if defined(HAVE_MENU) && defined(HAVE_MENU_WIDGETS)
-               if (video_driver_has_widgets())
-                  menu_widgets_set_paused(is_paused);
+               menu_widgets_set_paused(is_paused);
 #endif
                RARCH_LOG("%s\n", msg_hash_to_str(MSG_UNPAUSED));
                command_event(CMD_EVENT_AUDIO_START, NULL);

--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -2497,10 +2497,12 @@ void video_driver_frame(const void *data, unsigned width,
 
    /* Display the FPS, with a higher priority. */
    if (video_info.fps_show || video_info.framecount_show)
+   {
 #if defined(HAVE_MENU) && defined(HAVE_MENU_WIDGETS)
-      if (!video_driver_has_widgets() || !menu_widgets_set_fps_text(video_info.fps_text))
+      if (!menu_widgets_set_fps_text(video_info.fps_text))
 #endif
          runloop_msg_queue_push(video_info.fps_text, 2, 1, true, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
+   }
 
    /* trigger set resolution*/
    if (video_info.crt_switch_resolution)

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -37,6 +37,10 @@
 #include "../../config.h"
 #endif
 
+#if defined(HAVE_MENU_WIDGETS)
+#include "../widgets/menu_widgets.h"
+#endif
+
 #include "../../playlist.h"
 #include "../../frontend/frontend_driver.h"
 
@@ -3866,7 +3870,7 @@ static void *rgui_init(void **userdata, bool video_is_threaded)
     * but for extra safety we will only permit menu widget
     * additions when the current gfx driver reports that it
     * has widget support */
-   rgui->widgets_supported = video_driver_has_widgets();
+   rgui->widgets_supported = menu_widgets_ready();
 
    if (rgui->widgets_supported)
    {

--- a/menu/widgets/menu_widgets.c
+++ b/menu/widgets/menu_widgets.c
@@ -1730,6 +1730,9 @@ void menu_widgets_context_reset(bool is_threaded)
 
    unsigned video_info_width;
 
+   if (!menu_widgets_inited)
+      return;
+
    video_driver_get_size(&video_info_width, NULL);
 
    /* Textures paths */

--- a/retroarch.c
+++ b/retroarch.c
@@ -584,6 +584,7 @@ static bool driver_update_system_av_info(const struct retro_system_av_info *info
 void drivers_init(int flags)
 {
    bool video_is_threaded = false;
+   settings_t *settings = config_get_ptr();
 
 #ifdef HAVE_MENU
    /* By default, we want the menu to persist through driver reinits. */
@@ -635,7 +636,8 @@ void drivers_init(int flags)
 
 #ifdef HAVE_MENU
 #ifdef HAVE_MENU_WIDGETS
-   if (video_driver_has_widgets())
+   if (settings->bools.menu_enable_widgets
+      && video_driver_has_widgets())
    {
       menu_widgets_init(video_is_threaded);
       menu_widgets_context_reset(video_is_threaded);
@@ -3154,7 +3156,7 @@ void runloop_task_msg_queue_push(retro_task_t *task, const char *msg,
       bool flush)
 {
 #if defined(HAVE_MENU) && defined(HAVE_MENU_WIDGETS)
-   if (!video_driver_has_widgets() || !menu_widgets_task_msg_queue_push(task, msg, prio, duration, flush))
+   if (!menu_widgets_task_msg_queue_push(task, msg, prio, duration, flush))
 #endif
       runloop_msg_queue_push(msg, prio, duration, flush, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
 }
@@ -3171,9 +3173,10 @@ void runloop_msg_queue_push(const char *msg,
 
    rarch_environment_cb(RETRO_ENVIRONMENT_GET_TARGET_REFRESH_RATE, &target_hz);
 
-   if (video_driver_has_widgets() && menu_widgets_msg_queue_push(msg,
+   if (menu_widgets_msg_queue_push(msg,
             duration / target_hz * 1000, title, icon, category, prio, flush))
       return;
+
 #endif
 
 #ifdef HAVE_THREADS
@@ -4057,7 +4060,7 @@ static enum runloop_state runloop_check_state(
       if (runloop_fastmotion)
       {
 #if defined(HAVE_MENU) && defined(HAVE_MENU_WIDGETS)
-         if (!video_driver_has_widgets() || !menu_widgets_set_fast_forward(true))
+         if (!menu_widgets_set_fast_forward(true))
 #endif
             runloop_msg_queue_push(
                   msg_hash_to_str(MSG_FAST_FORWARD), 1, 1, false, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
@@ -4159,7 +4162,7 @@ static enum runloop_state runloop_check_state(
             settings->uints.rewind_granularity, runloop_paused, s, sizeof(s), &t);
 
 #if defined(HAVE_MENU) && defined(HAVE_MENU_WIDGETS)
-      if (!video_driver_has_widgets())
+      if (!menu_widgets_ready())
 #endif
          if (rewinding)
             runloop_msg_queue_push(s, 0, t, true, NULL,
@@ -4205,7 +4208,7 @@ static enum runloop_state runloop_check_state(
                video_driver_cached_frame();
 
 #if defined(HAVE_MENU) && defined(HAVE_MENU_WIDGETS)
-         if (!video_driver_has_widgets())
+         if (!menu_widgets_ready())
          {
 #endif
             if (state_manager_frame_is_reversed())

--- a/tasks/task_screenshot.c
+++ b/tasks/task_screenshot.c
@@ -157,7 +157,7 @@ static void task_screenshot_handler(retro_task_t *task)
       /* If menu widgets are enabled, state is freed
          in the callback after the notification
          is displayed */
-      if (!video_driver_has_widgets())
+      if (!menu_widgets_ready())
 #endif
          free(state);
       return;
@@ -202,7 +202,7 @@ static void task_screenshot_callback(retro_task_t *task,
 {
    screenshot_task_state_t *state = (screenshot_task_state_t*)task->state;
 
-   if (!video_driver_has_widgets())
+   if (!menu_widgets_ready())
       return;
 
    if (state && !state->silence)
@@ -320,7 +320,7 @@ static bool screenshot_dump(
    if (use_thread)
    {
 #if defined(HAVE_MENU) && defined(HAVE_MENU_WIDGETS)
-      if (video_driver_has_widgets())
+      if (menu_widgets_ready())
          task_free_title(task);
       else
 #endif


### PR DESCRIPTION
Widgets are now only initialized on startup if the associated setting is set to `true` and if the current video driver supports them. All `menu_widgets_*` functions don't do anything and return `false` if widgets aren't initialized.