### PR TITLE
lboard null pointer check must be done by caller

### DIFF
--- a/cheevos-new/cheevos.c
+++ b/cheevos-new/cheevos.c
@@ -382,16 +382,15 @@ static int rcheevos_parse(const char* json)
       lboard->info = rcheevos_locals.patchdata.lboards + j;
       res = rc_lboard_size(lboard->info->mem);
 
-      CHEEVOS_LOG(RCHEEVOS_TAG "rc_lboard_size() = %d\n", res);
-
       if (res < 0)
       {
-         snprintf(buffer, sizeof(buffer), "Error in leaderboard %d \"%s\"", lboard->info->id, lboard->info->title);
+         snprintf(buffer, sizeof(buffer), "Error in leaderboard %d \"%s\": %s",
+            lboard->info->id, lboard->info->title, rcheevos_rc_error(res));
 
          if (settings->bools.cheevos_verbose_enable)
-            runloop_msg_queue_push(buffer, 0, 3 * 60, false, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
+            runloop_msg_queue_push(buffer, 0, 4 * 60, false, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
 
-         CHEEVOS_ERR(RCHEEVOS_TAG "%s: '%s' mem: %s\n", buffer, rcheevos_rc_error(res), lboard->info->mem);
+         CHEEVOS_ERR(RCHEEVOS_TAG "%s mem: %s\n", buffer, lboard->info->mem);
          lboard->lboard = NULL;
          continue;
       }
@@ -675,6 +674,7 @@ static void rcheevos_test_leaderboards(void)
 
    for (i = 0; i < rcheevos_locals.patchdata.lboard_count; i++, lboard++)
    {
+      if (!lboard->lboard) continue;
       switch (rc_evaluate_lboard(lboard->lboard, &lboard->last_value, rcheevos_peek, NULL, NULL))
       {
          default:

--- a/deps/rcheevos/src/rcheevos/lboard.c
+++ b/deps/rcheevos/src/rcheevos/lboard.c
@@ -166,8 +166,6 @@ int rc_evaluate_lboard(rc_lboard_t* self, unsigned* value, rc_peek_t peek, void*
   int start_ok, cancel_ok, submit_ok;
   int action = -1;
 
-  if (!self) return RC_LBOARD_INACTIVE;
-
   rc_update_memref_values(self->memrefs, peek, peek_ud);
 
   /* ASSERT: these are always tested once every frame, to ensure delta variables work properly */


### PR DESCRIPTION
## Description

Just doing what was suggested by @leiradel in https://github.com/libretro/RetroArch/pull/8681#issuecomment-489202367

Also, showing the lboard error description in the OSD message, as suggested by @Jamiras.
**Note**: the error message is only displayed if `cheevos_verbose_enable = true`

It will look like this:
![lboard-error](https://user-images.githubusercontent.com/8508804/57178241-c8aa9f00-6e43-11e9-8993-5faffcdef280.png)

## Related Pull Requests

#8681 

## Reviewers

@leiradel @Jamiras 