### PR TITLE
use new cheevos implementation as default

### DIFF
--- a/cheevos-new/cheevos.c
+++ b/cheevos-new/cheevos.c
@@ -1407,11 +1407,6 @@ found:
          const rcheevos_cheevo_t* end    = cheevo + rcheevos_locals.patchdata.core_count;
          int number_of_unlocked = rcheevos_locals.patchdata.core_count;
 
-         /* RCHEEVOS TODO: remove this msg */
-         snprintf(msg, sizeof(msg), "cheevos: using the new implementation.");
-         msg[sizeof(msg) - 1] = 0;
-         runloop_msg_queue_push(msg, 0, 3 * 60, false, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
-
          if (coro->settings->bools.cheevos_hardcore_mode_enable && !rcheevos_hardcore_paused)
             mode = RCHEEVOS_ACTIVE_HARDCORE;
 

--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -2887,6 +2887,10 @@ found:
          const cheevo_t* end          = cheevo + cheevos_locals.core.count;
          int number_of_unlocked       = cheevos_locals.core.count;
 
+         snprintf(msg, sizeof(msg), "cheevos: using the old implementation.");
+         msg[sizeof(msg) - 1] = 0;
+         runloop_msg_queue_push(msg, 0, 3 * 60, false, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
+
          if (coro->settings->bools.cheevos_hardcore_mode_enable && !cheevos_hardcore_paused)
             mode = CHEEVOS_ACTIVE_HARDCORE;
 

--- a/configuration.c
+++ b/configuration.c
@@ -1536,7 +1536,7 @@ static struct config_bool_setting *populate_settings_bool(settings_t *settings, 
    SETTING_BOOL("cheevos_leaderboards_enable",  &settings->bools.cheevos_leaderboards_enable, true, false, false);
    SETTING_BOOL("cheevos_verbose_enable",       &settings->bools.cheevos_verbose_enable, true, false, false);
    SETTING_BOOL("cheevos_auto_screenshot",      &settings->bools.cheevos_auto_screenshot, true, false, false);
-   SETTING_BOOL("cheevos_rcheevos_enable",      &settings->bools.cheevos_rcheevos_enable, true, false, false);
+   SETTING_BOOL("cheevos_rcheevos_enable",      &settings->bools.cheevos_rcheevos_enable, true, true, false);
    /* RCHEEVOS TODO: remove line above */
 #ifdef HAVE_XMB
    SETTING_BOOL("cheevos_badges_enable",        &settings->bools.cheevos_badges_enable, true, false, false);


### PR DESCRIPTION
## Description

Defining the new cheevos implementation (using rcheevos) as the default one.

The old implemenation is still an option, if we need to compare something along the way (the plan is to get rid of the old code in the near future). To use the old implementation the user must explicitly set `cheevos_rcheevos_enable = false` in `retroarch.cfg`.

We, at RetroAchievements scene, are really excited about RetroArch 1.7.7 and the new cheevos related features!!! :confetti_ball: :tada: 

## Related Pull Requests

#8501 

## Reviewers

@leiradel @Jamiras @twinaphex 