### PR TITLE
A few --disable-menu fixes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ matrix:
       env: C89_BUILD=1 CC=gcc-8 CXX=g++-8
     - compiler: gcc
       env: CXX_BUILD=1 CC=gcc-8 CXX=g++-8
+    - compiler: gcc
+      env: DISABLE_MENU=1 CC=gcc-8 CXX=g++-8
     - compiler: clang
       env: CC=clang-6.0 CXX=clang++-6.0
     - compiler: clang
@@ -70,6 +72,10 @@ script:
   - |
      if [ -n "$CROSS_COMPILE" ]; then
        ARGS="$ARGS --disable-d3d8 --disable-d3d9 --disable-d3d10 --disable-d3d11 --disable-d3d12 --enable-builtinzlib"
+     fi
+  - |
+     if [ -n "$DISABLE_MENU" ]; then
+       ARGS="$ARGS --disable-menu"
      fi
   - ./configure $ARGS
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,10 +69,9 @@ before_install:
 script:
   - |
      if [ -n "$CROSS_COMPILE" ]; then
-       ./configure --disable-d3d8 --disable-d3d9 --disable-d3d10 --disable-d3d11 --disable-d3d12 --enable-builtinzlib
-     else
-       ./configure
+       ARGS="$ARGS --disable-d3d8 --disable-d3d9 --disable-d3d10 --disable-d3d11 --disable-d3d12 --enable-builtinzlib"
      fi
+  - ./configure $ARGS
   - |
      if [ -n "$C89_BUILD" ]; then
        make C89_BUILD=1
@@ -84,6 +83,7 @@ script:
 
 env:
   global:
+   - ARGS=""
    - MAKEFLAGS="-j2"
    - secure: "qc91ReC3OlzSh2gFaSH6TYzC2qIQvgA2AZff6J13eaH8xijAhuMzttZ0rMQJ0DWCIhPeUb0kIzVyaGoe4MwPALzpw1C1AznIWiZJ53HN+hWCOcS/af7YVPk6HPySnwqrS+Wv3AIIvIKFV2mxv21F/JbT/N+pArlRrp904Xj+KPo="
 addons:

--- a/gfx/drivers/gl_core.c
+++ b/gfx/drivers/gl_core.c
@@ -1526,6 +1526,7 @@ static void gl_core_update_cpu_texture(gl_core_t *gl,
    }
 }
 
+#if defined(HAVE_MENU)
 static void gl_core_draw_menu_texture(gl_core_t *gl, video_frame_info_t *video_info)
 {
    const float vbo_data[] = {
@@ -1566,6 +1567,7 @@ static void gl_core_draw_menu_texture(gl_core_t *gl, video_frame_info_t *video_i
 
    glDisable(GL_BLEND);
 }
+#endif
 
 static bool gl_core_frame(void *data, const void *frame,
                           unsigned frame_width, unsigned frame_height,

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -524,5 +524,6 @@ if [ "$HAVE_DEBUG" = 'yes' ]; then
    fi
 fi
 
+check_enabled MENU MENU_WIDGETS 'menu widgets' 'The menu is' false
 check_enabled ZLIB RPNG RPNG 'zlib is' false
 check_enabled V4L2 VIDEOPROCESSOR 'video processor' 'Video4linux2 is' true


### PR DESCRIPTION
## Description

This contains a few related fixes for `--disable-menu`.

1. Fixes the build without `HAVE_MENU` which also needs `HAVE_MENU_WIDGETS` to be disabled. If the user build with `--disble-menu` it will automatically disable menu widgets too. If `--enable-menu_widgets` is also explicitly used it will result in a configure error.
2. Silences a trivial unused function warning with `--disable-menu`.
3. Refactors `.travis.yml` to handle configure arguments more robustly which allows the script to grow more easily.
4. Uses the previous refactor to add support for `--disable-menu` to travis. For now it will only test this on linux with gcc, but it should be possible to add `DISABLE_MENU=1` to any build's `env` excluding osx to test it there too.

## Related Issues

```
LD retroarch
/usr/bin/ld: obj-unix/release/tasks/task_screenshot.o: in function `task_screenshot_callback':
task_screenshot.c:(.text+0x8): undefined reference to `menu_widgets_ready'
/usr/bin/ld: task_screenshot.c:(.text+0x3e): undefined reference to `menu_widgets_screenshot_taken'
/usr/bin/ld: obj-unix/release/tasks/task_screenshot.o: in function `task_screenshot_handler':
task_screenshot.c:(.text+0x6b0): undefined reference to `menu_widgets_ready'
/usr/bin/ld: obj-unix/release/cheevos/badges.o: in function `set_badge_menu_texture':
badges.c:(.text+0x8b): undefined reference to `menu_display_reset_textures_list'
collect2: error: ld returned 1 exit status
make: *** [Makefile:196: retroarch] Error 1
```
and
```
    gfx/drivers/gl_core.c:1529:13: warning: ‘gl_core_draw_menu_texture’ defined but not used [-Wunused-function]
     static void gl_core_draw_menu_texture(gl_core_t *gl, video_frame_info_t *video_info)
                 ^~~~~~~~~~~~~~~~~~~~~~~~~
```

## Reviewers

Wait for travis to build.
