### PR TITLE
qb: Enable menu widgets with CXX_BUILD again.

### DIFF
--- a/qb/config.params.sh
+++ b/qb/config.params.sh
@@ -10,7 +10,6 @@ HAVE_DEBUG=no              # Enable a debug build
 HAVE_LIBRETRODB=yes        # Libretrodb support
 HAVE_MENU=yes              # Enable menu drivers
 HAVE_MENU_WIDGETS=yes      # Enable menu widgets
-CXX_MENU_WIDGETS=no
 HAVE_RGUI=auto             # RGUI menu
 HAVE_MATERIALUI=auto       # MaterialUI menu
 HAVE_XMB=auto              # XMB menu


### PR DESCRIPTION
## Description

Thanks to @natinusala menu widgets now builds with `CXX_BUILD=1` so this can be enabled again.

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/8696