### PR TITLE
having a badge file is enough to show it in popup

### DIFF
--- a/menu/widgets/menu_widgets.c
+++ b/menu/widgets/menu_widgets.c
@@ -2314,9 +2314,8 @@ static void menu_widgets_get_badge_texture(menu_texture_item *tex, const char *b
 {
    char badge_file[16];
    char fullpath[PATH_MAX_LENGTH];
-   settings_t *settings = config_get_ptr();
 
-   if (!badge || !settings || !settings->bools.cheevos_badges_enable)
+   if (!badge)
    {
       *tex = 0;
       return;


### PR DESCRIPTION
## Description

As the title says: having a badge file available is enough to show it on the popup (no need to check if `cheevos_badges_enable = true`.

Reported by @Blazekickn (noticed when using `glui` menu driver).

## Reviewers

@natinusala 