### PR TITLE
Menu widgets stuff + vulkan sanity check

### DIFF
--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -2068,9 +2068,9 @@ bool vulkan_context_init(gfx_ctx_vulkan_data_t *vk,
       res = vkCreateInstance(&info, NULL, &vk->context.instance);
    }
 
-   if (res == VK_ERROR_INCOMPATIBLE_DRIVER)
+   if (res != VK_SUCCESS)
    {
-      RARCH_ERR("Failed to create Vulkan instance.\n");
+      RARCH_ERR("Failed to create Vulkan instance (%d).\n", res);
       return false;
    }
 

--- a/libretro-common/include/string/stdstring.h
+++ b/libretro-common/include/string/stdstring.h
@@ -133,8 +133,9 @@ char *string_trim_whitespace_right(char *const s);
 /* Remove leading and trailing whitespaces */
 char *string_trim_whitespace(char *const s);
 
+/* max_lines == 0 means no limit */
 char *word_wrap(char *buffer, const char *string,
-      int line_width, bool unicode);
+      int line_width, bool unicode, unsigned max_lines);
 
 RETRO_END_DECLS
 

--- a/libretro-common/string/stdstring.c
+++ b/libretro-common/string/stdstring.c
@@ -154,10 +154,11 @@ char *string_trim_whitespace(char *const s)
    return s;
 }
 
-char *word_wrap(char* buffer, const char *string, int line_width, bool unicode)
+char *word_wrap(char* buffer, const char *string, int line_width, bool unicode, unsigned max_lines)
 {
-   unsigned i   = 0;
-   unsigned len = (unsigned)strlen(string);
+   unsigned i     = 0;
+   unsigned len   = (unsigned)strlen(string);
+   unsigned lines = 1;
 
    while (i < len)
    {
@@ -194,14 +195,21 @@ char *word_wrap(char* buffer, const char *string, int line_width, bool unicode)
          /* check for newlines embedded in the original input
           * and reset the index */
          if (buffer[j] == '\n')
+         {
+            lines++;
             counter = 1;
+         }
       }
 
       /* check for whitespace */
       if (string[i] == ' ')
       {
-         buffer[i] = '\n';
-         i++;
+         if ((max_lines == 0 || lines < max_lines))
+         {
+            buffer[i] = '\n';
+            i++;
+            lines++;
+         }
       }
       else
       {
@@ -210,12 +218,13 @@ char *word_wrap(char* buffer, const char *string, int line_width, bool unicode)
          /* check for nearest whitespace back in string */
          for (k = i; k > 0; k--)
          {
-            if (string[k] != ' ')
+            if (string[k] != ' ' || (max_lines != 0 && lines >= max_lines))
                continue;
 
             buffer[k] = '\n';
             /* set string index back to character after this one */
             i         = k + 1;
+            lines++;
             break;
          }
 

--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -629,7 +629,7 @@ static void materialui_compute_entries_box(materialui_handle_t* mui, int width)
 
             word_wrap(sublabel_str, sublabel_str,
                   (int)((usable_width - icon_margin) / mui->glyph_width2),
-                  false);
+                  false, 0);
             lines = materialui_count_lines(sublabel_str);
          }
          free(sublabel_str);
@@ -873,7 +873,7 @@ static void materialui_render_label_value(
       {
          word_wrap(sublabel_str, sublabel_str,
                (int)((usable_width - icon_margin) / mui->glyph_width2),
-               false);
+               false, 0);
 
          menu_display_draw_text(mui->font2, sublabel_str,
                mui->margin + icon_margin,

--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -1151,7 +1151,7 @@ void ozone_update_content_metadata(ozone_handle_t *ozone)
             || string_is_equal(core_label, "musicplayer")
             || string_is_equal(core_label, "movieplayer");
 
-      word_wrap(ozone->selection_core_name, ozone->selection_core_name, (unsigned)((float)ozone->dimensions.thumbnail_bar_width * (float)0.85) / ozone->footer_font_glyph_width, false);
+      word_wrap(ozone->selection_core_name, ozone->selection_core_name, (unsigned)((float)ozone->dimensions.thumbnail_bar_width * (float)0.85) / ozone->footer_font_glyph_width, false, 0);
       ozone->selection_core_name_lines = ozone_count_lines(ozone->selection_core_name);
 
       /* Fill play time if applicable */

--- a/menu/drivers/ozone/ozone_display.c
+++ b/menu/drivers/ozone/ozone_display.c
@@ -300,7 +300,7 @@ void ozone_draw_osk(ozone_handle_t *ozone,
       text_color  = ozone_theme_light.text_sublabel_rgba;
    }
 
-   word_wrap(message, text, (video_info->width - margin*2 - padding*2) / ozone->entry_font_glyph_width, true);
+   word_wrap(message, text, (video_info->width - margin*2 - padding*2) / ozone->entry_font_glyph_width, true, 0);
 
    list = string_split(message, "\n");
 

--- a/menu/drivers/ozone/ozone_entries.c
+++ b/menu/drivers/ozone/ozone_entries.c
@@ -253,7 +253,7 @@ void ozone_compute_entries_position(ozone_handle_t *ozone)
          if (ozone->show_thumbnail_bar)
             sublabel_max_width -= ozone->dimensions.thumbnail_bar_width;
 
-         word_wrap(sublabel_str, sublabel_str, sublabel_max_width / ozone->sublabel_font_glyph_width, false);
+         word_wrap(sublabel_str, sublabel_str, sublabel_max_width / ozone->sublabel_font_glyph_width, false, 0);
 
          lines = ozone_count_lines(sublabel_str);
 
@@ -528,7 +528,7 @@ border_iterate:
             if (ozone->depth == 1)
                sublabel_max_width -= (unsigned) ozone->dimensions.sidebar_width;
 
-            word_wrap(sublabel_str, sublabel_str, sublabel_max_width / ozone->sublabel_font_glyph_width, false);
+            word_wrap(sublabel_str, sublabel_str, sublabel_max_width / ozone->sublabel_font_glyph_width, false, 0);
       }
 
       /* Icon */

--- a/menu/drivers/stripes.c
+++ b/menu/drivers/stripes.c
@@ -2464,7 +2464,7 @@ static int stripes_draw_item(
 
       label_offset      = - stripes->margins_label_top;
 
-      word_wrap(entry_sublabel, entry->sublabel, 50 * stripes_scale_mod[3], true);
+      word_wrap(entry_sublabel, entry->sublabel, 50 * stripes_scale_mod[3], true, 0);
 
       stripes_draw_text(video_info, stripes, entry_sublabel,
             node->x + stripes->margins_screen_left +

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -2811,7 +2811,7 @@ static int xmb_draw_item(
 
          label_offset      = - xmb->margins_label_top;
 
-         word_wrap(entry_sublabel, entry->sublabel, 50 * scale_mod[3], true);
+         word_wrap(entry_sublabel, entry->sublabel, 50 * scale_mod[3], true, 0);
 
          xmb_draw_text(video_info, xmb, entry_sublabel,
                node->x + xmb->margins_screen_left +

--- a/menu/widgets/menu_widgets.c
+++ b/menu/widgets/menu_widgets.c
@@ -431,7 +431,7 @@ static bool menu_widgets_msg_queue_push_internal(retro_task_t *task, const char 
                   width += 10 * msg_queue_glyph_width;
                }
 
-               word_wrap(msg, msg, title_length/2 + 10, false);
+               word_wrap(msg, msg, title_length/2 + 10, false, 2);
 
                msg_widget->text_height *= 2.5f;
             }

--- a/tasks/task_screenshot.c
+++ b/tasks/task_screenshot.c
@@ -320,12 +320,14 @@ static bool screenshot_dump(
    if (use_thread)
    {
 #if defined(HAVE_MENU) && defined(HAVE_MENU_WIDGETS)
-      if (menu_widgets_ready())
+      if (menu_widgets_ready() && !savestate)
          task_free_title(task);
       else
 #endif
+      {
          if (!savestate)
             task->title = strdup(msg_hash_to_str(MSG_TAKING_SCREENSHOT));
+      }
 
       if (task_queue_push(task))
          return true;


### PR DESCRIPTION
- The screenshot task no longer hangs when taking a savestate screenshot with menu widgets
- `word_wrap` now has a `max_lines` parameter, that does what you expect
- vulkan now properly checks if the instance was created before continuing