### PR TITLE
Fix --enable-opengles and --enable-opengles3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,10 @@ matrix:
       env: CXX_BUILD=1 CC=gcc-8 CXX=g++-8
     - compiler: gcc
       env: DISABLE_MENU=1 CC=gcc-8 CXX=g++-8
+    - compiler: gcc
+      env: ENABLE_GLES=1 CC=gcc-8 CXX=g++-8
+    - compiler: gcc
+      env: ENABLE_GLES=1 ENABLE_GLES3=1 CC=gcc-8 CXX=g++-8
     - compiler: clang
       env: CC=clang-6.0 CXX=clang++-6.0
     - compiler: clang
@@ -76,6 +80,14 @@ script:
   - |
      if [ -n "$DISABLE_MENU" ]; then
        ARGS="$ARGS --disable-menu"
+     fi
+  - |
+     if [ -n "$ENABLE_GLES" ]; then
+       ARGS="$ARGS --enable-opengles"
+     fi
+  - |
+     if [ -n "$ENABLE_GLES3" ]; then
+       ARGS="$ARGS --enable-opengles3"
      fi
   - ./configure $ARGS
   - |

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -351,6 +351,14 @@ fi
 if [ "$HAVE_OPENGL" = 'no' ] && [ "$HAVE_OPENGLES3" = 'no' ]; then
    die : 'Notice: OpenGL and OpenGLES3 are disabled. Disabling HAVE_OPENGL_CORE.'
    HAVE_OPENGL_CORE='no'
+elif [ "$HAVE_OPENGLES" != 'no' ] && [ "$HAVE_OPENGLES3" != 'yes' ]; then
+   die : 'Notice: OpenGLES2 is enabled. Disabling the OpenGL core driver.'
+   HAVE_OPENGL_CORE='no'
+fi
+
+if [ "$HAVE_OPENGLES" != 'no' ] || [ "$HAVE_OPENGLES3" != 'no' ]; then
+   die : 'Notice: OpenGLES is enabled. Disabling the OpenGL1 driver.'
+   HAVE_OPENGL1='no'
 fi
 
 if [ "$HAVE_ZLIB" = 'no' ]; then


### PR DESCRIPTION
## Description

This does a few things.

1. The OpenGL core video driver requires at least OpenGLES 3 and OpenGL 1 is not compatible with OpenGLES 2 or 3. This will automatically disable `HAVE_OPENGL_CORE` and `HAVE_OPENGL1` when appropriate to avoid build issues.

In the future maybe these drivers can work together better and these build issues can be avoided.

2. The `HAVE_OPENGLES` and `HAVE_OPENGLES3` build paths are rarely tested and easy to break without noticing. The former broke when `HAVE_OPENGL_CORE` was added and the both broke when `HAVE_OPENGL1` was added. The second commit adds both to `.travis.yml` so they will be both be tested, travis will only build them on linux with gcc which is probably enough to catch issues.

## Related Issues

```
gfx/drivers/gl_core.c:62:10: warning: implicit declaration of function 'glDeleteSync' is invalid in C99 [-Wimplicit-function-declaration]
         glDeleteSync(gl->fences[i]);
         ^
gfx/drivers/gl_core.c:77:20: error: use of undeclared identifier 'GL_PIXEL_PACK_BUFFER'
      glBindBuffer(GL_PIXEL_PACK_BUFFER, gl->pbo_readback[i]);
                   ^
gfx/drivers/gl_core.c:78:20: error: use of undeclared identifier 'GL_PIXEL_PACK_BUFFER'
      glBufferData(GL_PIXEL_PACK_BUFFER, gl->vp.width * gl->vp.height * sizeof(uint32_t), NULL, GL_STREAM_READ);
                   ^
gfx/drivers/gl_core.c:78:97: error: use of undeclared identifier 'GL_STREAM_READ'
      glBufferData(GL_PIXEL_PACK_BUFFER, gl->vp.width * gl->vp.height * sizeof(uint32_t), NULL, GL_STREAM_READ);
                                                                                                ^
gfx/drivers/gl_core.c:80:17: error: use of undeclared identifier 'GL_PIXEL_PACK_BUFFER'
   glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
                ^
gfx/drivers/gl_core.c:144:18: error: use of undeclared identifier 'GL_PACK_ROW_LENGTH'
   glPixelStorei(GL_PACK_ROW_LENGTH, 0);
                 ^
gfx/drivers/gl_core.c:145:17: error: use of undeclared identifier 'GL_PIXEL_PACK_BUFFER'
   glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
                ^
gfx/drivers/gl_core.c:157:17: error: use of undeclared identifier 'GL_PIXEL_PACK_BUFFER'
   glBindBuffer(GL_PIXEL_PACK_BUFFER, gl->pbo_readback[gl->pbo_readback_index++]);
                ^
gfx/drivers/gl_core.c:159:18: error: use of undeclared identifier 'GL_PACK_ROW_LENGTH'
   glPixelStorei(GL_PACK_ROW_LENGTH, 0);
                 ^
gfx/drivers/gl_core.c:170:17: error: use of undeclared identifier 'GL_PIXEL_PACK_BUFFER'
   glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
                ^
gfx/drivers/gl_core.c:187:39: warning: implicit declaration of function 'glFenceSync' is invalid in C99 [-Wimplicit-function-declaration]
      gl->fences[gl->fence_count++] = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
                                      ^
gfx/drivers/gl_core.c:187:51: error: use of undeclared identifier 'GL_SYNC_GPU_COMMANDS_COMPLETE'
      gl->fences[gl->fence_count++] = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
                                                  ^
gfx/drivers/gl_core.c:192:7: warning: implicit declaration of function 'glClientWaitSync' is invalid in C99 [-Wimplicit-function-declaration]
      glClientWaitSync(gl->fences[0], GL_SYNC_FLUSH_COMMANDS_BIT, 1000000000);
      ^
gfx/drivers/gl_core.c:192:39: error: use of undeclared identifier 'GL_SYNC_FLUSH_COMMANDS_BIT'
      glClientWaitSync(gl->fences[0], GL_SYNC_FLUSH_COMMANDS_BIT, 1000000000);
                                      ^
gfx/drivers/gl_core.c:193:7: warning: implicit declaration of function 'glDeleteSync' is invalid in C99 [-Wimplicit-function-declaration]
      glDeleteSync(gl->fences[0]);
      ^
gfx/drivers/gl_core.c:351:4: warning: implicit declaration of function 'glBindVertexArray' is invalid in C99 [-Wimplicit-function-declaration]
   glBindVertexArray(0);
   ^
gfx/drivers/gl_core.c:353:7: warning: implicit declaration of function 'glDeleteVertexArrays' is invalid in C99 [-Wimplicit-function-declaration]
      glDeleteVertexArrays(1, &gl->vao);
      ^
gfx/drivers/gl_core.c:416:4: warning: implicit declaration of function 'glTexStorage2D' is invalid in C99 [-Wimplicit-function-declaration]
   glTexStorage2D(GL_TEXTURE_2D, 1, GL_RGBA8, width, height);
   ^
gfx/drivers/gl_core.c:416:37: error: use of undeclared identifier 'GL_RGBA8'
   glTexStorage2D(GL_TEXTURE_2D, 1, GL_RGBA8, width, height);
                                    ^
gfx/drivers/gl_core.c:425:61: error: use of undeclared identifier 'GL_DEPTH24_STENCIL8'
      glRenderbufferStorage(GL_RENDERBUFFER, hwr->stencil ? GL_DEPTH24_STENCIL8 : GL_DEPTH_COMPONENT16,
                                                            ^
gfx/drivers/gl_core.c:430:52: error: use of undeclared identifier 'GL_DEPTH_STENCIL_ATTACHMENT'
         glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, gl->hw_render_rb_ds);
                                                   ^
gfx/drivers/gl_core.c:1091:4: warning: implicit declaration of function 'glGenVertexArrays' is invalid in C99 [-Wimplicit-function-declaration]
   glGenVertexArrays(1, &gl->vao);
   ^
gfx/drivers/gl_core.c:1092:4: warning: implicit declaration of function 'glBindVertexArray' is invalid in C99 [-Wimplicit-function-declaration]
   glBindVertexArray(gl->vao);
   ^
gfx/drivers/gl_core.c:1135:4: warning: implicit declaration of function 'glTexStorage2D' is invalid in C99 [-Wimplicit-function-declaration]
   glTexStorage2D(GL_TEXTURE_2D, levels, GL_RGBA8, ti->width, ti->height);
   ^
gfx/drivers/gl_core.c:1135:42: error: use of undeclared identifier 'GL_RGBA8'
   glTexStorage2D(GL_TEXTURE_2D, levels, GL_RGBA8, ti->width, ti->height);
                                         ^
gfx/drivers/gl_core.c:1166:18: error: use of undeclared identifier 'GL_UNPACK_ROW_LENGTH'; did you mean 'GL_CAPS_UNPACK_ROW_LENGTH'?
   glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
                 ^~~~~~~~~~~~~~~~~~~~
                 GL_CAPS_UNPACK_ROW_LENGTH
./libretro-common/include/gfx/gl_capabilities.h:43:4: note: 'GL_CAPS_UNPACK_ROW_LENGTH' declared here
   GL_CAPS_UNPACK_ROW_LENGTH,
   ^
gfx/drivers/gl_core.c:1172:35: error: use of undeclared identifier 'GL_TEXTURE_SWIZZLE_R'
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_R, GL_BLUE);
                                  ^
gfx/drivers/gl_core.c:1172:57: error: use of undeclared identifier 'GL_BLUE'
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_R, GL_BLUE);
                                                        ^
gfx/drivers/gl_core.c:1173:35: error: use of undeclared identifier 'GL_TEXTURE_SWIZZLE_B'
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_B, GL_RED);
                                  ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
10 warnings and 20 errors generated.
make: *** [Makefile:201: obj-unix/release/gfx/drivers/gl_core.o] Error 1
```
and
```
LD retroarch
/usr/bin/ld: obj-unix/release/gfx/drivers_font/gl1_raster_font.o: undefined reference to symbol 'glTexCoordPointer'
/usr/bin/ld: /usr/lib64/libGL.so.1: error adding symbols: DSO missing from command line
clang-8: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [Makefile:196: retroarch] Error 1
```
