### PR TITLE
check if lang code is null before processing

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -5477,6 +5477,10 @@ enum retro_language rarch_get_language_from_iso(const char *iso639)
       {"ar", RETRO_LANGUAGE_ARABIC},
       {"el", RETRO_LANGUAGE_GREEK},
    };
+   
+   if (string_is_empty(iso639)) {
+      return lang;
+   }
 
    for (i = 0; i < sizeof(pairs) / sizeof(pairs[0]); i++)
    {


### PR DESCRIPTION
## Description

this checks the passed language code to see if it's null before processing with `strcasestr` as this segfaults on some systems when passing null.