### PR TITLE
menu_widgets: add libretro message widget, have RETRO_ENVIRONMENT_SET_MESSAGE use it

### DIFF
--- a/dynamic.c
+++ b/dynamic.c
@@ -72,6 +72,10 @@
 #include "verbosity.h"
 #include "tasks/tasks_internal.h"
 
+#ifdef HAVE_MENU_WIDGETS
+#include "menu/widgets/menu_widgets.h"
+#endif
+
 #ifdef HAVE_RUNAHEAD
 #include "runahead/secondary_core.h"
 #include "runahead/run_ahead.h"
@@ -1258,7 +1262,10 @@ bool rarch_environment_cb(unsigned cmd, void *data)
       {
          const struct retro_message *msg = (const struct retro_message*)data;
          RARCH_LOG("Environ SET_MESSAGE: %s\n", msg->msg);
-         runloop_msg_queue_push(msg->msg, 3, msg->frames, true, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
+#ifdef HAVE_MENU_WIDGETS
+         if (!menu_widgets_set_libretro_message(msg->msg, msg->frames / 60 * 1000))
+#endif
+            runloop_msg_queue_push(msg->msg, 3, msg->frames, true, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
          break;
       }
 

--- a/menu/widgets/menu_widgets.h
+++ b/menu/widgets/menu_widgets.h
@@ -76,6 +76,9 @@ bool menu_widgets_push_achievement(const char *title, const char *badge);
 /* Warning: not thread safe! */
 bool menu_widgets_set_message(char *message);
 
+/* Warning: not thread safe! */
+bool menu_widgets_set_libretro_message(const char *message, unsigned duration);
+
 /* All the functions below should be called in
  * the video driver - once they are all added, set
  * enable_menu_widgets to true for that driver */


### PR DESCRIPTION
- new widget: libretro message
- `RETRO_ENVIRONMENT_SET_MESSAGE` environ cb now uses this widget if available