### PR TITLE
devkitarm-r52 WIP.

### DIFF
--- a/Makefile.ctr
+++ b/Makefile.ctr
@@ -212,13 +212,13 @@ else
 endif
 
 %.o: %.vsh %.gsh
-	$(DEVKITARM)/bin/picasso $^ -o $*.shbin
-	$(DEVKITARM)/bin/bin2s $*.shbin | $(PREFIX)as -o $@
+	picasso $^ -o $*.shbin
+	bin2s $*.shbin | $(PREFIX)as -o $@
 	rm $*.shbin
 
 %.o: %.vsh
-	$(DEVKITARM)/bin/picasso $^ -o $*.shbin
-	$(DEVKITARM)/bin/bin2s $*.shbin | $(PREFIX)as -o $@
+	picasso $^ -o $*.shbin
+	bin2s $*.shbin | $(PREFIX)as -o $@
 	rm $*.shbin
 
 %.o: %.cpp
@@ -239,7 +239,7 @@ endif
 %.vsh:
 
 $(TARGET).smdh: $(APP_ICON)
-	$(DEVKITARM)/bin/smdhtool --create "$(APP_TITLE)" "$(APP_DESCRIPTION)" "$(APP_AUTHOR)" $(APP_ICON) $@
+	smdhtool --create "$(APP_TITLE)" "$(APP_DESCRIPTION)" "$(APP_AUTHOR)" $(APP_ICON) $@
 
 $(TARGET).3dsx: $(TARGET).elf
 ifeq ($(APP_BIG_TEXT_SECTION), 1)
@@ -247,7 +247,7 @@ ifeq ($(APP_BIG_TEXT_SECTION), 1)
 else
 	rm -f $(TARGET).xml
 endif
-	$(DEVKITARM)/bin/3dsxtool $< $@ $(_3DSXFLAGS)
+	3dsxtool $< $@ $(_3DSXFLAGS)
 
 $(TARGET).elf: ctr/3dsx_custom_crt0.o
 	$(LD) $(LDFLAGS) $(OBJ) $(LIBDIRS) $(LIBS) -o $@

--- a/Makefile.ctr.salamander
+++ b/Makefile.ctr.salamander
@@ -153,13 +153,13 @@ else
 endif
 
 %.o: %.vsh %.gsh
-	$(DEVKITARM)/bin/picasso $^ -o $*.shbin
-	$(DEVKITARM)/bin/bin2s $*.shbin | $(PREFIX)as -o $@
+	picasso $^ -o $*.shbin
+	bin2s $*.shbin | $(PREFIX)as -o $@
 	rm $*.shbin
 
 %.o: %.vsh
-	$(DEVKITARM)/bin/picasso $^ -o $*.shbin
-	$(DEVKITARM)/bin/bin2s $*.shbin | $(PREFIX)as -o $@
+	picasso $^ -o $*.shbin
+	bin2s $*.shbin | $(PREFIX)as -o $@
 	rm $*.shbin
 
 %.o: %.cpp
@@ -180,7 +180,7 @@ endif
 %.vsh:
 
 $(TARGET).smdh: $(APP_ICON)
-	$(DEVKITARM)/bin/smdhtool --create "$(APP_TITLE)" "$(APP_DESCRIPTION)" "$(APP_AUTHOR)" $(APP_ICON) $@
+	smdhtool --create "$(APP_TITLE)" "$(APP_DESCRIPTION)" "$(APP_AUTHOR)" $(APP_ICON) $@
 
 $(TARGET).3dsx: $(TARGET).elf
 ifeq ($(APP_BIG_TEXT_SECTION), 1)
@@ -188,7 +188,7 @@ ifeq ($(APP_BIG_TEXT_SECTION), 1)
 else
 	rm -f $(TARGET).xml
 endif
-	$(DEVKITARM)/bin/3dsxtool $< $@ $(_3DSXFLAGS)
+	3dsxtool $< $@ $(_3DSXFLAGS)
 
 $(TARGET).elf: ctr/3dsx_custom_crt0.o
 	$(LD) $(LDFLAGS) $(OBJ) $(LIBDIRS) $(LIBS) -o $@

--- a/frontend/drivers/platform_ctr.c
+++ b/frontend/drivers/platform_ctr.c
@@ -392,7 +392,9 @@ static void ctr_check_dspfirm(void)
 __attribute__((weak)) Result svchax_init(bool patch_srv);
 __attribute__((weak)) u32 __ctr_patch_services;
 
+#if 0
 void gfxSetFramebufferInfo(gfxScreen_t screen, u8 id);
+#endif
 
 static void frontend_ctr_init(void* data)
 {
@@ -421,8 +423,10 @@ static void frontend_ctr_init(void* data)
    gfxBottomFramebuffers  [0] = linearAlloc(bottomSize);
    gfxBottomFramebuffers  [1] = linearAlloc(bottomSize);
 
+#if 0
    gfxSetFramebufferInfo(GFX_TOP, 0);
    gfxSetFramebufferInfo(GFX_BOTTOM, 0);
+#endif
 
    gfxSet3D(true);
    consoleInit(GFX_BOTTOM, NULL);
@@ -516,7 +520,7 @@ static enum frontend_powerstate frontend_ctr_get_powerstate(
    u8                 battery_percent = 0;
    u8                        charging = 0;
 
-   mcuHwcGetBatteryLevel(&battery_percent);
+   MCUHWC_GetBatteryLevel(&battery_percent);
 
    *percent                           = battery_percent;
    /* 3DS does not support seconds of charge remaining */


### PR DESCRIPTION
## Description

I am making this as  PR because it is easier to show what has been done with diffs. This should not be merged as is and needs further discussion first.

After a lot of effort I managed to build and install `devkitarm-r52` using their `buildscripts` repo. It is complete with the toolchain, SDKs and tools. It seems that RetroArch has not been fully updated for the new release and upstream suggests only using new releases.

For reference here are the list of files in my package.

[devkitarm.txt](https://github.com/libretro/RetroArch/files/3170478/devkitarm.txt)

I am sourcing this script before building anything.
```
# set needed variables
export DEVKITPRO=/opt/devkitpro
export DEVKITARM=${DEVKITPRO}/devkitARM
export PATH="${DEVKITPRO}/tools/bin:$PATH"
```
```
. /etc/profile.d/devkitarm.sh
```
And before I built RetroArch I built without issue `gambatte` and copied `gambatte_libretro_ctr.a` to the RetroArch source directory as `libretro_ctr.a`.
```
make -f Makefile.libretro platform=ctr
```

## Related Issues

When building RetroArch I encountered a few issues.

1. When compiling `Makefile.ctr.salamander` I found that `mcuHwcGetBatteryLevel` is now `MCUHWC_GetBatteryLevel`.
2. It appears several tools moved from `$(DEVKITARM)/bin` to `${DEVKITPRO}/tools/bin`. The upstream `buildscripts` suggests adding this directory to the `$PATH`. I think these probably should be not be absolute paths.
3. As seen in the following commit `gfxSetFramebufferInfo` is now static and I do not think we can use it. I just got undefined references during linking.

https://github.com/smealum/ctrulib/commit/4ceebb8b4470d0f31ee775b679571f688e3121ad

The minimal changes I made in the example commit allow the build to succeed, but I do not have an environment to test the builds and I do not expect them to be correct.

## Reviewers

@jdgleaver Maybe you can help me understand what is going on here? Also can you explain the process for building multiple cores? The RetroArch docs do not explain that other than suggesting to use libretro-super scripts.
