### PR TITLE
(RGUI) Fix thumbnail updates after loading a 'broken' thumbnail image

### DIFF
--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -1799,8 +1799,30 @@ static bool rgui_load_image(void *userdata, void *data, enum menu_image_type typ
    rgui_t *rgui         = (rgui_t*)userdata;
    settings_t *settings = config_get_ptr();
 
-   if (!rgui || !data || !settings)
+   if (!rgui || !settings)
+   {
       return false;
+   }
+
+   if (!data)
+   {
+      /* This means we have a 'broken' image. There is no
+       * data, but we still have to decrement any thumbnail
+       * queues (otherwise further thumbnail processing will
+       * be blocked) */
+      if (type == MENU_IMAGE_THUMBNAIL)
+      {
+         if (rgui->thumbnail_queue_size > 0)
+            rgui->thumbnail_queue_size--;
+      }
+      else if (type == MENU_IMAGE_LEFT_THUMBNAIL)
+      {
+         if (rgui->left_thumbnail_queue_size > 0)
+            rgui->left_thumbnail_queue_size--;
+      }
+
+      return false;
+   }
 
    switch (type)
    {


### PR DESCRIPTION
## Description

While testing PR #8783, I noticed a small bug in the way that some incorrectly formatted PNG thumbnails are handled. Essentially, if the image is 'intact' enough to load, but 'broken' enough that proper image data cannot be extracted, it triggers a menu thumbnail update with `NULL` data.

This is a problem in the case of RGUI, since it uses a queue system to determine whether thumbnails should be processed. A thumbnail update with zero data is an error condition, which means the corresponding queue never gets decremented, and so thumbnail updates get blocked following a broken image load.

(I never noticed this before, since I normally use my own curated collection of thumbnails - apparently some new PNGs on the server aren't so 'clean'!)

This PR fixes the issue by properly handling the error condition.