### PR TITLE
(menu_driver) Prevent spurious navigation events when invoking MENU_NAVIGATION_CTL_CLEAR

### DIFF
--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -2573,13 +2573,21 @@ bool menu_driver_ctl(enum rarch_menu_ctl_state state, void *data)
          {
             bool *pending_push = (bool*)data;
 
+            /* Always set current selection to first entry */
             menu_navigation_set_selection(0);
-            menu_driver_navigation_set(true);
 
-            if (pending_push)
+            /* menu_driver_navigation_set() will be called
+             * at the next 'push'.
+             * If a push is *not* pending, have to do it here
+             * instead */
+            if (!(*pending_push))
+            {
+               menu_driver_navigation_set(true);
+
                if (menu_driver_ctx->navigation_clear)
                   menu_driver_ctx->navigation_clear(
                         menu_userdata, *pending_push);
+            }
          }
          break;
       case MENU_NAVIGATION_CTL_INCREMENT:


### PR DESCRIPTION
## Description

Roughly speaking, whenever a RetroArch menu is updated (i.e. tab switch, or menu level change) we call 'clear' followed by 'populate entries'. At present, there is a logic bug in the `menu_driver` which means this kind of update consists of the following sequence:

(Clear)

1. Reset selection index
2. Call `menu_driver_navigation_set()`

(Populate entries)

3. Populate new entry list
4. Call `menu_driver_navigation_set()`

No. 2 is the problem here - it's called unnecessarily **and** it operates on the **old** menu list (i.e. it happens before the new one is populated). `menu_driver_navigation_set()` is not a particularly light function, so this wastes CPU cycles each time the menu changes, but the real issue is when thumbnails are enabled:

- Navigate to playlist entry -> thumbnails are loaded
- Select playlists entry -> spurious `menu_driver_navigation_set()` causes thumbnails for the *first* playlist entry to be loaded

...So basically, we're doubling the thumbnail performance overheads when using playlists. (NOTE: This part doesn't actually affect XMB because it handles loading somewhat differently, but it's still hit by the unnecessary `menu_driver_navigation_set()`)

This PR fixes the issue by modifying the 'clear' operation such that `menu_driver_navigation_set()` is only called if a new menu *is not* going to be opened - so menu navigation overheads are basically halved.

## Reviewers

This should work without issue, but it's very difficult to check all possible edge cases (i.e. it may be that some obscure menu function invokes a `MENU_NAVIGATION_CTL_CLEAR` with a mistakenly set `pending_push` value...). I guess other people may want to check this (I found no problems while testing)