### PR TITLE
enabling shutdown menu option by default for lakka-switch

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -323,11 +323,7 @@ static bool menu_show_configurations     = true;
 static bool menu_show_help               = true;
 static bool menu_show_quit_retroarch     = true;
 static bool menu_show_reboot             = true;
-#ifdef HAVE_LAKKA_SWITCH
-static bool menu_show_shutdown           = false;
-#else
 static bool menu_show_shutdown           = true;
-#endif
 #if defined(HAVE_LAKKA) || defined(VITA) || defined(_3DS)
 static bool menu_show_core_updater       = false;
 #else


### PR DESCRIPTION
## Description

shutdown option was disabled in lakka-switch because it was not behaving properly. With the recent kernel upgrade, it is behaving as it should. This PR will enable it by default.

## Reviewers

@natinusala - you mentioned wanting to do this in discord. If you're still in favor, here it is. Otherwise go ahead and close.
