### PR TITLE
correctly centers screen on iPhone X landscape

### DIFF
--- a/ui/drivers/cocoa/cocoa_common.m
+++ b/ui/drivers/cocoa/cocoa_common.m
@@ -209,10 +209,10 @@ void *glkitview_init(void);
         CGRect newFrame = screenSize;
         if ( orientation == UIInterfaceOrientationPortrait ) {
             newFrame = CGRectMake(screenSize.origin.x, screenSize.origin.y + inset.top, screenSize.size.width, screenSize.size.height - inset.top);
-        } else if ( orientation == UIInterfaceOrientationLandscapeLeft ) {
-            newFrame = CGRectMake(screenSize.origin.x, screenSize.origin.y, screenSize.size.width - inset.right, screenSize.size.height);
-        } else if ( orientation == UIInterfaceOrientationLandscapeRight ) {
-            newFrame = CGRectMake(screenSize.origin.x + inset.left, screenSize.origin.y, screenSize.size.width - inset.left, screenSize.size.height);
+		} else if ( orientation == UIInterfaceOrientationLandscapeLeft ) {
+		    newFrame = CGRectMake(screenSize.origin.x + inset.right, screenSize.origin.y, screenSize.size.width - inset.right * 2, screenSize.size.height);
+		} else if ( orientation == UIInterfaceOrientationLandscapeRight ) {
+		    newFrame = CGRectMake(screenSize.origin.x + inset.left, screenSize.origin.y, screenSize.size.width - inset.left * 2, screenSize.size.height);
         }
         self.view.frame = newFrame;
     }


### PR DESCRIPTION
There was an issue that on iPhone X(S) in landscape mode, games were not centered on the screen, because only the unsafe area around the notch was considered. Now this code removes an equal amount of screen space from the non-notch side, so the display will be centered, which is especially important when using game controllers, which include a stand for the iPhone to sit above the controller. This way the iPhone X can be centered right above the controller and the content will be centered on the screen too.