### PR TITLE
(XMB/Ozone) Ensure old thumbnails are cleared when selecting playlist entry with 'broken' thumbnails

### DIFF
--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -408,6 +408,8 @@ static void ozone_update_thumbnail_image(void *data)
       else
          video_driver_texture_unload(&ozone->thumbnail);
    }
+   else
+      video_driver_texture_unload(&ozone->thumbnail);
 
    if (menu_thumbnail_get_path(ozone->thumbnail_path_data, MENU_THUMBNAIL_LEFT, &left_thumbnail_path))
    {
@@ -417,6 +419,8 @@ static void ozone_update_thumbnail_image(void *data)
       else
          video_driver_texture_unload(&ozone->left_thumbnail);
    }
+   else
+      video_driver_texture_unload(&ozone->left_thumbnail);
 }
 
 /* TODO: Scale text */
@@ -2188,8 +2192,31 @@ static bool ozone_load_image(void *userdata, void *data, enum menu_image_type ty
    unsigned maximum_height, maximum_width;
    float display_aspect_ratio;
 
-   if (!ozone || !data)
+   if (!ozone)
       return false;
+
+   if (!data)
+   {
+      /* If this happens, the image we attempted to load
+       * was corrupt/incorrectly formatted. If this was a
+       * thumbnail image, have unload any existing thumbnails
+       * (otherwise entry with 'corrupt' thumbnail will show
+       * thumbnail from last selected 'good' entry) */
+      if (type == MENU_IMAGE_THUMBNAIL)
+      {
+         ozone->dimensions.thumbnail_width = 0.0f;
+         ozone->dimensions.thumbnail_height = 0.0f;
+         video_driver_texture_unload(&ozone->thumbnail);
+      }
+      else if (type == MENU_IMAGE_LEFT_THUMBNAIL)
+      {
+         ozone->dimensions.left_thumbnail_width = 0.0f;
+         ozone->dimensions.left_thumbnail_height = 0.0f;
+         video_driver_texture_unload(&ozone->left_thumbnail);
+      }
+
+      return false;
+   }
 
    video_driver_get_size(NULL, &height);
 

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -1020,6 +1020,8 @@ static void xmb_update_thumbnail_image(void *data)
       else
          video_driver_texture_unload(&xmb->thumbnail);
    }
+   else
+      video_driver_texture_unload(&xmb->thumbnail);
 
    if (menu_thumbnail_get_path(xmb->thumbnail_path_data, MENU_THUMBNAIL_LEFT, &left_thumbnail_path))
    {
@@ -1029,6 +1031,8 @@ static void xmb_update_thumbnail_image(void *data)
       else
          video_driver_texture_unload(&xmb->left_thumbnail);
    }
+   else
+      video_driver_texture_unload(&xmb->left_thumbnail);
 }
 
 static void xmb_set_thumbnail_system(void *data, char*s, size_t len)
@@ -4505,8 +4509,23 @@ static bool xmb_load_image(void *userdata, void *data, enum menu_image_type type
 {
    xmb_handle_t *xmb = (xmb_handle_t*)userdata;
 
-   if (!xmb || !data)
+   if (!xmb)
       return false;
+
+   if (!data)
+   {
+      /* If this happens, the image we attempted to load
+       * was corrupt/incorrectly formatted. If this was a
+       * thumbnail image, have unload any existing thumbnails
+       * (otherwise entry with 'corrupt' thumbnail will show
+       * thumbnail from last selected 'good' entry) */
+      if (type == MENU_IMAGE_THUMBNAIL)
+         video_driver_texture_unload(&xmb->thumbnail);
+      else if (type == MENU_IMAGE_LEFT_THUMBNAIL)
+         video_driver_texture_unload(&xmb->left_thumbnail);
+
+      return false;
+   }
 
    switch (type)
    {


### PR DESCRIPTION
## Description

XMB and Ozone are currently subject to the following thumbnail bug: if a playlist entry has corrupt/broken thumbnails (or the thumbnail path is indeterminate for any reason), the entry will display thumbnails from the last selected 'good' entry - i.e. the wrong thumbnail images will be shown.

This PR fixes the issue by ensuring that old thumbnails are cleared in the event of any kind of error.