### PR TITLE
(glcore) don't hardcode shader cross compilation target version but poll it

### DIFF
--- a/gfx/drivers_shader/shader_gl_core.cpp
+++ b/gfx/drivers_shader/shader_gl_core.cpp
@@ -93,10 +93,10 @@ static uint32_t gl_core_get_cross_compiler_target_version()
    unsigned patch = 0;
 
 #ifdef HAVE_OPENGLES3
-   if (version && sscanf(version, "OpenGL ES %u.%u.%u", &major, &minor, &patch) < 2)
+   if (!version || sscanf(version, "OpenGL ES %u.%u.%u", &major, &minor, &patch) < 2)
       return 300u;
 #else
-   if (version && sscanf(version, "%u.%u.%u", &major, &minor, &patch) < 2)
+   if (!version || sscanf(version, "%u.%u.%u", &major, &minor, &patch) < 2)
       return 150u;
 #endif
    if (major == 3u && minor == 2u)


### PR DESCRIPTION
## Description

glcore would always only use the minimum target shader version, i.e. GLSL ES 3.00 for OpenGL ES 3.0+ or GLSL 1.50 for OpenGL 3.2+.

References for OpenGL (ES) to GLSL (ES) version mapping:
https://www.khronos.org/registry/OpenGL/index_es.php#specs
https://www.khronos.org/opengl/wiki/Core_Language_(GLSL)#OpenGL_and_GLSL_versions

## Related Issues

Partial fix for #8839

