### PR TITLE
menu widgets: fix rounding error with timings

### DIFF
--- a/dynamic.c
+++ b/dynamic.c
@@ -1263,7 +1263,7 @@ bool rarch_environment_cb(unsigned cmd, void *data)
          const struct retro_message *msg = (const struct retro_message*)data;
          RARCH_LOG("Environ SET_MESSAGE: %s\n", msg->msg);
 #ifdef HAVE_MENU_WIDGETS
-         if (!menu_widgets_set_libretro_message(msg->msg, msg->frames / 60 * 1000))
+         if (!menu_widgets_set_libretro_message(msg->msg, roundf((float)msg->frames / 60.0f * 1000.0f)))
 #endif
             runloop_msg_queue_push(msg->msg, 3, msg->frames, true, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
          break;

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -517,10 +517,6 @@ void menu_display_scissor_begin(video_frame_info_t *video_info, int x, int y, un
          height = menu_display_framebuf_height - y;
       if ((x + width) > menu_display_framebuf_width)
          width = menu_display_framebuf_width - x;
-      if (height <= 0)
-         return;
-      if (width <= 0)
-         return;      
 
       menu_disp->scissor_begin(video_info, x, y, width, height);
    }

--- a/retroarch.c
+++ b/retroarch.c
@@ -3210,7 +3210,7 @@ void runloop_msg_queue_push(const char *msg,
    runloop_ctx_msg_info_t msg_info;
 #if defined(HAVE_MENU) && defined(HAVE_MENU_WIDGETS)
    if (menu_widgets_msg_queue_push(msg,
-            duration / 60 * 1000, title, icon, category, prio, flush))
+            roundf((float)duration / 60.0f * 1000.0f), title, icon, category, prio, flush))
       return;
 #endif
 


### PR DESCRIPTION
If some widgets timings were not multiple of 60, a rounding error occured and prevented them from displaying for the correct amount of time.

Fixes #8850.