### PR TITLE
(RPNG) Fix undefined behaviour when loading bad/corrupt PNG images

### DIFF
--- a/libretro-common/formats/image_texture.c
+++ b/libretro-common/formats/image_texture.c
@@ -175,7 +175,7 @@ static bool image_texture_load_internal(
    if (!img)
       goto end;
 
-   image_transfer_set_buffer_ptr(img, type, (uint8_t*)ptr);
+   image_transfer_set_buffer_ptr(img, type, (uint8_t*)ptr, len);
 
    if (!image_transfer_start(img, type))
       goto end;

--- a/libretro-common/formats/image_transfer.c
+++ b/libretro-common/formats/image_transfer.c
@@ -177,13 +177,14 @@ bool image_transfer_is_valid(
 void image_transfer_set_buffer_ptr(
       void *data,
       enum image_type_enum type,
-      void *ptr)
+      void *ptr,
+      size_t len)
 {
    switch (type)
    {
       case IMAGE_TYPE_PNG:
 #ifdef HAVE_RPNG
-         rpng_set_buf_ptr((rpng_t*)data, (uint8_t*)ptr);
+         rpng_set_buf_ptr((rpng_t*)data, (uint8_t*)ptr, len);
 #endif
          break;
       case IMAGE_TYPE_JPEG:

--- a/libretro-common/include/formats/image.h
+++ b/libretro-common/include/formats/image.h
@@ -84,7 +84,8 @@ bool image_transfer_start(void *data, enum image_type_enum type);
 void image_transfer_set_buffer_ptr(
       void *data,
       enum image_type_enum type,
-      void *ptr);
+      void *ptr,
+      size_t len);
 
 int image_transfer_process(
       void *data,

--- a/libretro-common/include/formats/rpng.h
+++ b/libretro-common/include/formats/rpng.h
@@ -38,7 +38,7 @@ rpng_t *rpng_init(const char *path);
 
 bool rpng_is_valid(rpng_t *rpng);
 
-bool rpng_set_buf_ptr(rpng_t *rpng, void *data);
+bool rpng_set_buf_ptr(rpng_t *rpng, void *data, size_t len);
 
 rpng_t *rpng_alloc(void);
 


### PR DESCRIPTION
## Description

RetroArch's PNG handling code currently has very serious issues:

- RPNG performs *no error checking whatsoever*. Attempting to load a bad/incomplete/corrupt PNG file causes undefined behaviour and will most likely generate a segfault. I guess this also makes RetroArch vulnerable to buffer overflow attacks... (note that even the `rpng_is_valid()` function - used after the file has been parsed - doesn't work...)

- The image task code also mishandles error conditions. In the event that a broken PNG does trigger some kind of error, the image task will get stuck in an infinite loop.

This PR fixes these issues.