### PR TITLE
(WiiU) Attempt to fix black screen when using RGUI

### DIFF
--- a/gfx/drivers/gx2_gfx.c
+++ b/gfx/drivers/gx2_gfx.c
@@ -327,6 +327,7 @@ static void *wiiu_gfx_init(const video_info_t *video,
    memset(&wiiu->menu.texture, 0, sizeof(GX2Texture));
    wiiu->menu.texture.surface.width    = 512;
    wiiu->menu.texture.surface.height   = 512;
+   wiiu->menu.texture.surface.pitch    = wiiu->menu.texture.surface.width * sizeof(uint16_t);
    wiiu->menu.texture.surface.depth    = 1;
    wiiu->menu.texture.surface.dim      = GX2_SURFACE_DIM_TEXTURE_2D;
    wiiu->menu.texture.surface.format   = GX2_SURFACE_FORMAT_UNORM_R4_G4_B4_A4;


### PR DESCRIPTION
## Description

As described in #8852, the WiiU build currently shows a black screen when using RGUI.

This seems to be a trivial bug - the menu texture pitch is never set, so `wiiu_gfx_set_texture_frame()` does not copy the RGUI framebuffer to screen.

This PR fixes the bug - but I do not have a WiiU, and so cannot verify that it works...

## Related Issues

#8852
