### PR TITLE
menu display: don't move scissoring rect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,9 +186,11 @@ ifeq ($(MAKECMDGOALS),clean)
 config.mk:
 else
 -include $(RARCH_OBJ:.o=.d)
+ifeq ($(HAVE_CONFIG_MK),)
 config.mk: configure qb/*
 	@echo "config.mk is outdated or non-existing. Run ./configure again."
 	@exit 1
+endif
 endif
 
 retroarch: $(RARCH_OBJ)

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -506,13 +506,31 @@ void menu_display_scissor_begin(video_frame_info_t *video_info, int x, int y, un
    if (menu_disp && menu_disp->scissor_begin)
    {
       if (y < 0)
+      {
+         if (height < (unsigned)(-y))
+            height = 0;
+         else
+            height += y;
          y = 0;
+      }
       if (x < 0)
+      {
+         if (width < (unsigned)(-x))
+            width = 0;
+         else
+            width += x;
          x = 0;
+      }
       if (y >= (int)menu_display_framebuf_height)
-         return;
+      {
+         height = 0;
+         y = 0;
+      }
       if (x >= (int)menu_display_framebuf_width)
-         return;
+      {
+         width = 0;
+         x = 0;
+      }
       if ((y + height) > menu_display_framebuf_height)
          height = menu_display_framebuf_height - y;
       if ((x + width) > menu_display_framebuf_width)


### PR DESCRIPTION
my previous commit moved scissoring rect if coords were negative. negative coords don't actually happen in current code, but it helps to stay vigilant.