### PR TITLE
(task_image) Make image loading/processing non-blocking on non-threaded systems

### DIFF
--- a/libretro-common/formats/image_transfer.c
+++ b/libretro-common/formats/image_transfer.c
@@ -217,9 +217,6 @@ int image_transfer_process(
    {
       case IMAGE_TYPE_PNG:
 #ifdef HAVE_RPNG
-         if (!rpng_is_valid((rpng_t*)data))
-            return IMAGE_PROCESS_ERROR;
-
          return rpng_process_image(
                (rpng_t*)data,
                (void**)buf, len, width, height);


### PR DESCRIPTION
## Description

At present, the loading/processing phases of a 'task image load' operation are supposed iterate a set number of times per task iteration - but these set values are so large that each phase is run to completion within a single task iteration, which means they can block the UI thread for an arbitrary length of time when run on non-threaded systems.

This PR changes the image load handler so the loading/processing phases each iterate for a maximum of one frame duration (`1 / [display refresh rate]`) before moving on - so the 'task iterate' performs as intended, and no longer blocks anything.

This PR also fixes a bug in RPNG, which prevented data from being processed correctly if the process phase took more than one task iteration.