### PR TITLE
WiiU: Build cleanup/refactors, fix Griffin, newest devkitPPC

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1922,7 +1922,7 @@ ifeq ($(HAVE_STATIC_VIDEO_FILTERS), 1)
 endif
 
 ifeq ($(WANT_IOSUHAX), 1)
-   DEFINES += -I$(DEPS_DIR)/libiosuhax
+   DEFINES += -DHAVE_IOSUHAX
    DEF_FLAGS += -I$(DEPS_DIR)/libiosuhax
    OBJ += $(DEPS_DIR)/libiosuhax/iosuhax.o \
           $(DEPS_DIR)/libiosuhax/iosuhax_devoptab.o \
@@ -1930,7 +1930,7 @@ ifeq ($(WANT_IOSUHAX), 1)
 endif
 
 ifeq ($(WANT_LIBFAT), 1)
-   DEFINES += -I$(DEPS_DIR)/libfat/include
+   DEFINES += -DHAVE_LIBFAT
    DEF_FLAGS += -I$(DEPS_DIR)/libfat/include
    OBJ += $(DEPS_DIR)/libfat/cache.o \
           $(DEPS_DIR)/libfat/directory.o \

--- a/Makefile.wiiu
+++ b/Makefile.wiiu
@@ -1,4 +1,4 @@
-TARGET		    := retroarch_wiiu
+TARGET := retroarch_wiiu
 
 BUILD_HBL_ELF              = 1
 BUILD_RPX                  = 1
@@ -10,7 +10,7 @@ WIIU_HID                   = 1
 HAVE_RUNAHEAD              = 1
 WIIU_LOG_RPX               = 0
 BUILD_DIR                  = objs/wiiu
-PC_DEVELOPMENT_TCP_PORT	   ?=
+PC_DEVELOPMENT_TCP_PORT    ?=
 
 ifeq ($(SALAMANDER_BUILD),1)
    BUILD_DIR := $(BUILD_DIR)-salamander
@@ -27,7 +27,13 @@ ifneq ($(V), 1)
    Q := @
 endif
 
+DEFINES :=
 OBJ :=
+INCDIRS :=
+
+#-----------------------------
+# Features and object files
+
 OBJ += wiiu/main.o
 OBJ += wiiu/system/memory.o
 OBJ += wiiu/system/atomic.o
@@ -37,23 +43,9 @@ OBJ += wiiu/fs/sd_fat_devoptab.o
 OBJ += wiiu/fs/fs_utils.o
 OBJ += wiiu/hbl.o
 
-DEFINES :=
-
-ifeq ($(WIIU_LOG_RPX),1)
-   defines += -DWIIU_LOG_RPX
-endif
-
-ifeq ($(WIIU_HID),1)
-   DEFINES += -DWIIU_HID
-   OBJ += input/drivers_joypad/wiiu/hidpad_driver.o
-   OBJ += input/drivers_hid/wiiu_hid.o
-   OBJ += input/connect/joypad_connection.o \
-          input/common/hid/hid_device_driver.o \
-          input/common/hid/device_wiiu_gca.o \
-          input/common/hid/device_ds3.o \
-          input/common/hid/device_ds4.o \
-          input/common/hid/device_null.o
-endif
+RPX_OBJ = $(BUILD_DIR)/wiiu/system/stubs_rpl.o
+HBL_ELF_OBJ = $(BUILD_DIR)/wiiu/system/dynamic.o \
+              $(BUILD_DIR)/wiiu/system/stubs_elf.o
 
 ifeq ($(SALAMANDER_BUILD),1)
    DEFINES += -DRARCH_CONSOLE -DIS_SALAMANDER
@@ -77,6 +69,8 @@ ifeq ($(SALAMANDER_BUILD),1)
    OBJ += libretro-common/hash/rhash.o
    OBJ += file_path_str.o
    OBJ += verbosity.o
+
+# $(SALAMANDER_BUILD),0
 else
    DEFINES += -DRARCH_INTERNAL
    DEFINES += -DHAVE_KEYMAPPER
@@ -86,7 +80,7 @@ else
    DEFINES += -DHAVE_SHADERPIPELINE
 
 ifeq ($(HAVE_RUNAHEAD),1)
-	DEFINES += -DHAVE_RUNAHEAD
+   DEFINES += -DHAVE_RUNAHEAD
 endif
 
    OBJ += wiiu/shader_utils.o
@@ -103,68 +97,162 @@ endif
    OBJ += gfx/drivers_shader/glslang_util.o
 
    ifeq ($(GRIFFIN_BUILD), 1)
-   	OBJ += griffin/griffin.o
-   	DEFINES += -DHAVE_GRIFFIN=1 -DHAVE_MENU -DHAVE_RGUI -DHAVE_LIBRETRODB
-   	DEFINES += -DHAVE_ZLIB -DHAVE_RPNG -DHAVE_RJPEG -DHAVE_RBMP -DHAVE_RTGA -DWANT_ZLIB -DHAVE_CC_RESAMPLER
-   	DEFINES += -DHAVE_STB_FONT -DHAVE_STB_VORBIS -DHAVE_LANGEXTRA -DHAVE_LIBRETRODB -DHAVE_NETWORKING -DHAVE_NETPLAYDISCOVERY
-   #	DEFINES += -DWANT_IFADDRS
-   #	DEFINES += -DHAVE_FREETYPE
-   	DEFINES += -DHAVE_XMB -DHAVE_MATERIALUI
+      OBJ += griffin/griffin.o
+
+      INCDIRS += -Ilibretro-common/include/compat/zlib
+      # for stb
+      INCDIRS += -Ideps
+
+      DEFINES += -DHAVE_GRIFFIN=1 -DHAVE_MENU -DHAVE_RGUI -DHAVE_LIBRETRODB
+      DEFINES += -DHAVE_ZLIB -DHAVE_RPNG -DHAVE_RJPEG -DHAVE_RBMP -DHAVE_RTGA -DWANT_ZLIB -DHAVE_CC_RESAMPLER
+      DEFINES += -DHAVE_STB_FONT -DHAVE_STB_VORBIS -DHAVE_LANGEXTRA -DHAVE_LIBRETRODB -DHAVE_NETWORKING -DHAVE_NETPLAYDISCOVERY
+      #DEFINES += -DWANT_IFADDRS
+      #DEFINES += -DHAVE_FREETYPE
+      DEFINES += -DHAVE_XMB -DHAVE_MATERIALUI
+
+   # $(GRIFFIN_BUILD),0
    else
-   	HAVE_MENU_COMMON = 1
-   	HAVE_RTGA = 1
-   	HAVE_RPNG = 1
-   	HAVE_RJPEG = 1
-   	HAVE_RBMP = 1
-	HAVE_MENU = 1
-   	HAVE_RGUI = 1
-   	HAVE_ZLIB = 1
-   	HAVE_7ZIP = 1
-	HAVE_BUILTINZLIB = 0
-   	HAVE_LIBRETRODB = 1
-   	HAVE_MATERIALUI = 1
-   	HAVE_XMB = 1
-   	HAVE_STB_FONT = 1
-   #	HAVE_FREETYPE = 1
-   	HAVE_LANGEXTRA = 1
-   	HAVE_LIBRETRODB = 1
-   	HAVE_NETWORKING = 1
-		HAVE_NETPLAYDISCOVERY = 1
-   	HAVE_CHEEVOS = 1
-   #	WANT_IFADDRS = 1
-   	HAVE_OVERLAY = 1
+      HAVE_MENU_COMMON = 1
+      HAVE_RTGA = 1
+      HAVE_RPNG = 1
+      HAVE_RJPEG = 1
+      HAVE_RBMP = 1
+      HAVE_MENU = 1
+      HAVE_RGUI = 1
+      HAVE_7ZIP = 1
+      HAVE_ZLIB = 1
+      HAVE_BUILTINZLIB = 0
+      HAVE_LIBRETRODB = 1
+      HAVE_MATERIALUI = 1
+      HAVE_XMB = 1
+      HAVE_STB_FONT = 1
+      #HAVE_FREETYPE = 1
+      HAVE_LANGEXTRA = 1
+      HAVE_LIBRETRODB = 1
+      HAVE_NETWORKING = 1
+      HAVE_NETPLAYDISCOVERY = 1
+      HAVE_CHEEVOS = 1
+      #WANT_IFADDRS = 1
+      HAVE_OVERLAY = 1
       HAVE_VIDEO_LAYOUT = 0
-   	HAVE_STATIC_VIDEO_FILTERS = 1
-   	HAVE_STATIC_AUDIO_FILTERS = 1
-   	WANT_LIBFAT = 1
-   	WANT_IOSUHAX = 1
+      HAVE_STATIC_VIDEO_FILTERS = 1
+      HAVE_STATIC_AUDIO_FILTERS = 1
+      WANT_LIBFAT = 1
+      WANT_IOSUHAX = 1
 
-   	include Makefile.common
+      include Makefile.common
+      DEFINES += $(DEF_FLAGS)
+      INCDIRS += $(INCLUDE_DIRS)
 
-   	OBJ += gfx/drivers/gx2_gfx.o
-   	OBJ += gfx/drivers_font/wiiu_font.o
-   	OBJ += menu/drivers_display/menu_display_wiiu.o
-   	OBJ += input/drivers/wiiu_input.o
-   	OBJ += input/drivers_joypad/wiiu_joypad.o
-        OBJ += input/drivers_joypad/wiiu/wpad_driver.o
-        OBJ += input/drivers_joypad/wiiu/kpad_driver.o
-        OBJ += input/drivers_joypad/wiiu/pad_functions.o
+      OBJ += gfx/drivers/gx2_gfx.o
+      OBJ += gfx/drivers_font/wiiu_font.o
+      OBJ += menu/drivers_display/menu_display_wiiu.o
+      OBJ += input/drivers/wiiu_input.o
+      OBJ += input/drivers_joypad/wiiu_joypad.o
+      OBJ += input/drivers_joypad/wiiu/wpad_driver.o
+      OBJ += input/drivers_joypad/wiiu/kpad_driver.o
+      OBJ += input/drivers_joypad/wiiu/pad_functions.o
+      INCDIRS += -Iinput/include
 
-   	OBJ += audio/drivers/wiiu_audio.o
-   	OBJ += frontend/drivers/platform_wiiu.o
+      OBJ += audio/drivers/wiiu_audio.o
+      OBJ += frontend/drivers/platform_wiiu.o
+
+      ifeq ($(WIIU_HID),1)
+         DEFINES += -DWIIU_HID
+         OBJ += input/drivers_joypad/wiiu/hidpad_driver.o
+         OBJ += input/drivers_hid/wiiu_hid.o
+         OBJ += input/connect/joypad_connection.o \
+                input/common/hid/hid_device_driver.o \
+                input/common/hid/device_wiiu_gca.o \
+                input/common/hid/device_ds3.o \
+                input/common/hid/device_ds4.o \
+                input/common/hid/device_null.o
+      endif
    endif
 endif
 
 OBJ := $(addprefix $(BUILD_DIR)/,$(OBJ))
 
+#-----------------------------
+# Compile flags
+
 DEFINES += -DWIIU -DMSB_FIRST -D__WUT__ -DHW_WUP -D__wiiu__
-#DEFINES += -D_GNU_SOURCE
 DEFINES += -DHAVE_MAIN
 DEFINES += -DRARCH_CONSOLE
+
+ifeq ($(WIIU_LOG_RPX),1)
+   DEFINES += -DWIIU_LOG_RPX
+endif
 
 ifneq ($(PC_DEVELOPMENT_TCP_PORT),)
    DEFINES += -DPC_DEVELOPMENT_TCP_PORT=$(PC_DEVELOPMENT_TCP_PORT)
 endif
+
+INCDIRS += -I.
+INCDIRS += -Ilibretro-common/include
+INCDIRS += -Iwiiu
+INCDIRS += -Iwiiu/include
+
+CFLAGS  := -mcpu=750 -meabi -mhard-float
+CFLAGS  += -ffast-math -Werror=implicit-function-declaration
+CFLAGS  += -ffunction-sections -fdata-sections
+#CFLAGS += -fomit-frame-pointer -mword-relocations
+#CFLAGS	+= -Wall
+
+ifeq ($(DEBUG), 1)
+   CFLAGS += -O0 -g
+else
+   CFLAGS += -O3
+endif
+
+ASFLAGS := $(CFLAGS) -mregnames
+CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions
+
+#-----------------------------
+# Linking/library flags
+
+LIBDIRS := -L.
+LDFLAGS := $(CFLAGS)
+
+ifeq ($(WHOLE_ARCHIVE_LINK), 1)
+   WHOLE_START := -Wl,--whole-archive
+   WHOLE_END := -Wl,--no-whole-archive
+endif
+
+LIBS := $(WHOLE_START) -lretro_wiiu $(WHOLE_END) -lm
+
+# Use portlibs libfat/iosuhax if not using ones in deps/
+ifneq ($(WANT_LIBFAT), 1)
+   INCDIRS += -I$(DEVKITPRO)/portlibs/ppc/include
+   LIBDIRS += -L$(DEVKITPRO)/portlibs/ppc/lib
+   LIBS += -lfat
+endif
+ifneq ($(WANT_IOSUHAX), 1)
+   INCDIRS += -I$(DEVKITPRO)/portlibs/ppc/include
+   LIBDIRS += -L$(DEVKITPRO)/portlibs/ppc/lib
+   LIBS += -liosuhax
+endif
+# Same deal for zlib
+ifeq ($(HAVE_ZLIB),1)
+ifeq ($(HAVE_BUILTINZLIB),0)
+   INCDIRS += -I$(DEVKITPRO)/portlibs/ppc/include
+   LIBDIRS += -L$(DEVKITPRO)/portlibs/ppc/lib
+   # Bonus: libpng for cores that need it
+   LIBS += -lpng -lz
+endif
+endif
+
+LDFLAGS += -Wl,--gc-sections
+
+RPX_LDFLAGS      := -pie -fPIE
+RPX_LDFLAGS      += -z common-page-size=64 -z max-page-size=64
+RPX_LDFLAGS      += -T wiiu/link_rpl.ld
+RPX_LDFLAGS      += -nostartfiles
+
+HBL_ELF_LDFLAGS  := -T wiiu/link_elf.ld
+
+#-----------------------------
+# Compiler setup
 
 ifeq ($(strip $(DEVKITPPC)),)
 $(error "Please set DEVKITPPC in your environment. export DEVKITPPC=<path to>devkitPPC")
@@ -194,64 +282,8 @@ else
    ELF2RPL   := $(ELF2RPL).exe
 endif
 
-INCDIRS := -I.
-INCDIRS += -Ideps
-INCDIRS += -Ideps/stb
-INCDIRS += -Ideps/libz
-INCDIRS += -Ideps/7zip
-INCDIRS += -Ilibretro-common/include
-INCDIRS += -Iinput/include
-INCDIRS += -Iwiiu
-INCDIRS += -Iwiiu/include
-INCDIRS += -I$(DEVKITPRO)/portlibs/ppc/include
-LIBDIRS := -L. -L$(DEVKITPRO)/portlibs/ppc/lib
-
-CFLAGS  := -mcpu=750 -meabi -mhard-float
-LDFLAGS :=
-
-ifeq ($(DEBUG), 1)
-   CFLAGS += -O0 -g
-else
-   CFLAGS += -O3
-endif
-
-LDFLAGS := $(CFLAGS)
-
-ASFLAGS := $(CFLAGS) -mregnames
-
-CFLAGS +=  -ffast-math -Werror=implicit-function-declaration
-CFLAGS +=  -ffunction-sections -fdata-sections
-#CFLAGS += -fomit-frame-pointer -mword-relocations
-#CFLAGS	+= -Wall
-
-ifeq ($(WHOLE_ARCHIVE_LINK), 1)
-   WHOLE_START := -Wl,--whole-archive
-   WHOLE_END := -Wl,--no-whole-archive
-endif
-
-CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions
-
-LDFLAGS  += -Wl,--gc-sections
-
-LIBS	:= $(WHOLE_START) -lretro_wiiu $(WHOLE_END) -lm -lpng -lz
-
-ifneq ($(WANT_LIBFAT), 1)
-LIBS += -lfat
-endif
-
-ifneq ($(WANT_IOSUHAX), 1)
-LIBS += -liosuhax
-endif
-
-RPX_OBJ           = $(BUILD_DIR)/wiiu/system/stubs_rpl.o
-HBL_ELF_OBJ       = $(BUILD_DIR)/wiiu/system/dynamic.o $(BUILD_DIR)/wiiu/system/stubs_elf.o
-
-RPX_LDFLAGS      := -pie -fPIE
-RPX_LDFLAGS      += -z common-page-size=64 -z max-page-size=64
-RPX_LDFLAGS      += -T wiiu/link_rpl.ld
-RPX_LDFLAGS      += -nostartfiles
-
-HBL_ELF_LDFLAGS  := -T wiiu/link_elf.ld
+#-----------------------------
+# Targets and build rules
 
 TARGETS :=
 ifeq ($(BUILD_RPX), 1)
@@ -315,10 +347,11 @@ $(BUILD_DIR)/$(TARGET).rpx: $(BUILD_DIR)/$(TARGET).rpx.elf $(ELF2RPL) .$(TARGET)
 	$(Q)-$(ELF2RPL) $< $@
 
 clean:
-	rm -f $(OBJ) $(RPX_OBJ) $(HBL_ELF_OBJ) $(TARGET).elf $(TARGET).rpx.elf $(TARGET).rpx
-	rm -f $(BUILD_DIR)/$(TARGET).elf $(BUILD_DIR)/$(TARGET).rpx.elf $(BUILD_DIR)/$(TARGET).rpx
-	rm -f .$(TARGET).elf.last .$(TARGET).rpx.elf.last .$(TARGET).rpx.last
-	rm -f $(OBJ:.o=.depend) $(RPX_OBJ:.o=.depend) $(HBL_ELF_OBJ:.o=.depend)
+	@$(if $(Q), echo $@,)
+	$(Q)rm -f $(OBJ) $(RPX_OBJ) $(HBL_ELF_OBJ) $(TARGET).elf $(TARGET).rpx.elf $(TARGET).rpx
+	$(Q)rm -f $(BUILD_DIR)/$(TARGET).elf $(BUILD_DIR)/$(TARGET).rpx.elf $(BUILD_DIR)/$(TARGET).rpx
+	$(Q)rm -f .$(TARGET).elf.last .$(TARGET).rpx.elf.last .$(TARGET).rpx.last
+	$(Q)rm -f $(OBJ:.o=.depend) $(RPX_OBJ:.o=.depend) $(HBL_ELF_OBJ:.o=.depend)
 
 .PHONY: clean all
 .PRECIOUS: %.depend %.last

--- a/Makefile.wiiu
+++ b/Makefile.wiiu
@@ -157,8 +157,7 @@ endif
 
 OBJ := $(addprefix $(BUILD_DIR)/,$(OBJ))
 
-#todo: remove -DWIIU and use the built-in macros instead (HW_WUP or __wiiu__).
-DEFINES += -DWIIU -DMSB_FIRST -D__WUT__
+DEFINES += -DWIIU -DMSB_FIRST -D__WUT__ -DHW_WUP -D__wiiu__
 #DEFINES += -D_GNU_SOURCE
 DEFINES += -DHAVE_MAIN
 DEFINES += -DRARCH_CONSOLE
@@ -207,7 +206,7 @@ INCDIRS += -Iwiiu/include
 INCDIRS += -I$(DEVKITPRO)/portlibs/ppc/include
 LIBDIRS := -L. -L$(DEVKITPRO)/portlibs/ppc/lib
 
-CFLAGS  := -mwup -mcpu=750 -meabi -mhard-float
+CFLAGS  := -mcpu=750 -meabi -mhard-float
 LDFLAGS :=
 
 ifeq ($(DEBUG), 1)
@@ -221,6 +220,7 @@ LDFLAGS := $(CFLAGS)
 ASFLAGS := $(CFLAGS) -mregnames
 
 CFLAGS +=  -ffast-math -Werror=implicit-function-declaration
+CFLAGS +=  -ffunction-sections -fdata-sections
 #CFLAGS += -fomit-frame-pointer -mword-relocations
 #CFLAGS	+= -Wall
 

--- a/Makefile.wiiu
+++ b/Makefile.wiiu
@@ -100,8 +100,8 @@ endif
       OBJ += griffin/griffin.o
 
       INCDIRS += -Ilibretro-common/include/compat/zlib
-      # for stb
-      INCDIRS += -Ideps
+      # for stb, libfat, iosuhax
+      INCDIRS += -Ideps -Ideps/libfat/include -Ideps/libiosuhax
       # pad_functions uses wiiu/input.h
       INCDIRS += -Iinput/include
 
@@ -112,6 +112,7 @@ endif
       #DEFINES += -DHAVE_FREETYPE
       DEFINES += -DHAVE_XMB -DHAVE_MATERIALUI
       DEFINES += -DHAVE_HID
+      DEFINES += -DWANT_LIBFAT -DHAVE_LIBFAT -DWANT_IOSUHAX -DHAVE_IOSUHAX
 
    # $(GRIFFIN_BUILD),0
    else
@@ -224,18 +225,7 @@ endif
 
 LIBS := $(WHOLE_START) -lretro_wiiu $(WHOLE_END) -lm
 
-# Use portlibs libfat/iosuhax if not using ones in deps/
-ifneq ($(WANT_LIBFAT), 1)
-   INCDIRS += -I$(DEVKITPRO)/portlibs/ppc/include
-   LIBDIRS += -L$(DEVKITPRO)/portlibs/ppc/lib
-   LIBS += -lfat
-endif
-ifneq ($(WANT_IOSUHAX), 1)
-   INCDIRS += -I$(DEVKITPRO)/portlibs/ppc/include
-   LIBDIRS += -L$(DEVKITPRO)/portlibs/ppc/lib
-   LIBS += -liosuhax
-endif
-# Same deal for zlib
+# Use portlibs zlib if deps/ isn't being used
 ifeq ($(HAVE_ZLIB),1)
 ifeq ($(HAVE_BUILTINZLIB),0)
    INCDIRS += -I$(DEVKITPRO)/portlibs/ppc/include

--- a/Makefile.wiiu
+++ b/Makefile.wiiu
@@ -102,6 +102,8 @@ endif
       INCDIRS += -Ilibretro-common/include/compat/zlib
       # for stb
       INCDIRS += -Ideps
+      # pad_functions uses wiiu/input.h
+      INCDIRS += -Iinput/include
 
       DEFINES += -DHAVE_GRIFFIN=1 -DHAVE_MENU -DHAVE_RGUI -DHAVE_LIBRETRODB
       DEFINES += -DHAVE_ZLIB -DHAVE_RPNG -DHAVE_RJPEG -DHAVE_RBMP -DHAVE_RTGA -DWANT_ZLIB -DHAVE_CC_RESAMPLER
@@ -109,6 +111,7 @@ endif
       #DEFINES += -DWANT_IFADDRS
       #DEFINES += -DHAVE_FREETYPE
       DEFINES += -DHAVE_XMB -DHAVE_MATERIALUI
+      DEFINES += -DHAVE_HID
 
    # $(GRIFFIN_BUILD),0
    else

--- a/deps/libfat/libfat.c
+++ b/deps/libfat/libfat.c
@@ -174,7 +174,8 @@ bool fatInit (uint32_t cacheSize, bool setAsDefaultDevice)
       char filePath[PATH_MAX];
       strcpy (filePath, _FAT_disc_interfaces[defaultDevice].name);
       strcat (filePath, ":/");
-#ifdef ARGV_MAGIC
+//ARGV_MAGIC means something else on wiiu
+#if defined(ARGV_MAGIC) && !defined(WIIU)
       if ( __system_argv->argvMagic == ARGV_MAGIC && __system_argv->argc >= 1 && strrchr( __system_argv->argv[0], '/' )!=NULL )
       {
          /* Check the app's path against each of our mounted devices, to see

--- a/deps/libiosuhax/os_functions.h
+++ b/deps/libiosuhax/os_functions.h
@@ -7,6 +7,11 @@ extern "C" {
 
 #define OS_MUTEX_SIZE                   44
 
+// RetroArch mod: use existing headers; prevents conflicts in griffin
+#include <wiiu/os.h>
+#include <wiiu/ios.h>
+#if 0
+
 #ifndef __WUT__
 //!----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 //! Mutex functions
@@ -40,5 +45,7 @@ extern int IOS_Close(int fd);
 #ifdef __cplusplus
 }
 #endif
+
+#endif // 0
 
 #endif // __OS_FUNCTIONS_H_

--- a/griffin/griffin.c
+++ b/griffin/griffin.c
@@ -620,6 +620,11 @@ INPUT
 #include "../input/drivers/gx_input.c"
 #include "../input/drivers_joypad/gx_joypad.c"
 #elif defined(__wiiu__)
+#include "../input/common/hid/hid_device_driver.c"
+#include "../input/common/hid/device_wiiu_gca.c"
+#include "../input/common/hid/device_ds3.c"
+#include "../input/common/hid/device_ds4.c"
+#include "../input/common/hid/device_null.c"
 #include "../input/drivers/wiiu_input.c"
 #include "../input/drivers_joypad/wiiu_joypad.c"
 #include "../input/drivers_joypad/wiiu/hidpad_driver.c"

--- a/griffin/griffin.c
+++ b/griffin/griffin.c
@@ -622,6 +622,10 @@ INPUT
 #elif defined(__wiiu__)
 #include "../input/drivers/wiiu_input.c"
 #include "../input/drivers_joypad/wiiu_joypad.c"
+#include "../input/drivers_joypad/wiiu/hidpad_driver.c"
+#include "../input/drivers_joypad/wiiu/kpad_driver.c"
+#include "../input/drivers_joypad/wiiu/wpad_driver.c"
+#include "../input/drivers_joypad/wiiu/pad_functions.c"
 #elif defined(_XBOX)
 #include "../input/drivers/xdk_xinput_input.c"
 #include "../input/drivers_joypad/xdk_joypad.c"
@@ -1182,7 +1186,7 @@ NETPLAY
 #include "../libretro-common/net/net_socket.c"
 #include "../libretro-common/net/net_http.c"
 #include "../libretro-common/net/net_natt.c"
-#if !defined(HAVE_SOCKET_LEGACY) && !defined(__wiiu__)
+#if !defined(HAVE_SOCKET_LEGACY)
 #include "../libretro-common/net/net_ifinfo.c"
 #endif
 #include "../tasks/task_http.c"

--- a/griffin/griffin.c
+++ b/griffin/griffin.c
@@ -1470,6 +1470,25 @@ DEPENDENCIES
 #include "../deps/7zip/7zBuf.c"
 #endif
 
+#ifdef WANT_LIBFAT
+#include "../deps/libfat/cache.c"
+#include "../deps/libfat/directory.c"
+#include "../deps/libfat/disc.c"
+#include "../deps/libfat/fatdir.c"
+#include "../deps/libfat/fatfile.c"
+#include "../deps/libfat/file_allocation_table.c"
+#include "../deps/libfat/filetime.c"
+#include "../deps/libfat/libfat.c"
+#include "../deps/libfat/lock.c"
+#include "../deps/libfat/partition.c"
+#endif
+
+#ifdef WANT_IOSUHAX
+#include "../deps/libiosuhax/iosuhax.c"
+#include "../deps/libiosuhax/iosuhax_devoptab.c"
+#include "../deps/libiosuhax/iosuhax_disc_interface.c"
+#endif
+
 /*============================================================
 XML
 ============================================================ */

--- a/input/common/hid/device_null.c
+++ b/input/common/hid/device_null.c
@@ -48,7 +48,7 @@ typedef struct hid_null_instance
  *
  * If initialization fails, return NULL.
  */
-static void *null_init(void *handle)
+static void *hid_null_init(void *handle)
 {
    hid_null_instance_t *instance = (hid_null_instance_t *)calloc(1, sizeof(hid_null_instance_t));
    if (!instance)
@@ -75,7 +75,7 @@ static void *null_init(void *handle)
  * Gets called when the pad is disconnected. It must clean up any memory
  * allocated and used by the instance data.
  */
-static void null_free(void *data)
+static void hid_null_free(void *data)
 {
    hid_null_instance_t *instance = (hid_null_instance_t *)data;
 
@@ -91,7 +91,7 @@ static void null_free(void *data)
  * For most pads you'd just forward it onto the pad driver (see below).
  * A more complicated example is in the Wii U GC adapter driver.
  */
-static void null_handle_packet(void *data, uint8_t *buffer, size_t size)
+static void hid_null_handle_packet(void *data, uint8_t *buffer, size_t size)
 {
    hid_null_instance_t *instance = (hid_null_instance_t *)data;
 
@@ -102,7 +102,7 @@ static void null_handle_packet(void *data, uint8_t *buffer, size_t size)
 /**
  * Return true if the passed in VID and PID are supported by the driver.
  */
-static bool null_detect(uint16_t vendor_id, uint16_t product_id)
+static bool hid_null_detect(uint16_t vendor_id, uint16_t product_id)
 {
   return vendor_id == VID_NONE && product_id == PID_NONE;
 }
@@ -111,10 +111,10 @@ static bool null_detect(uint16_t vendor_id, uint16_t product_id)
  * Assign function pointers to the driver structure.
  */
 hid_device_t null_hid_device = {
-  null_init,
-  null_free,
-  null_handle_packet,
-  null_detect,
+  hid_null_init,
+  hid_null_free,
+  hid_null_handle_packet,
+  hid_null_detect,
   "Null HID device"
 };
 

--- a/input/common/hid/device_wiiu_gca.c
+++ b/input/common/hid/device_wiiu_gca.c
@@ -257,7 +257,7 @@ const char *axes[] = {
 };
 #endif
 
-static void update_analog_state(gca_pad_t *pad)
+static void wiiu_gca_update_analog_state(gca_pad_t *pad)
 {
    int pad_axis;
    int16_t interpolated;
@@ -302,7 +302,7 @@ static void wiiu_gca_packet_handler(void *data, uint8_t *packet, uint16_t size)
 
    memcpy(pad->data, packet, size);
    update_buttons(pad);
-   update_analog_state(pad);
+   wiiu_gca_update_analog_state(pad);
 }
 
 static void wiiu_gca_set_rumble(void *data, enum retro_rumble_effect effect, uint16_t strength)

--- a/input/drivers_joypad/wiiu/hidpad_driver.c
+++ b/input/drivers_joypad/wiiu/hidpad_driver.c
@@ -25,7 +25,7 @@ static int16_t hidpad_axis(unsigned pad, uint32_t axis);
 static void hidpad_poll(void);
 static const char *hidpad_name(unsigned pad);
 
-static bool ready = false;
+static bool hidpad_ready = false;
 
 static bool init_hid_driver(void)
 {
@@ -44,19 +44,19 @@ static bool hidpad_init(void *data)
    }
 
    hidpad_poll();
-   ready = true;
+   hidpad_ready = true;
 
    return true;
 }
 
 static bool hidpad_query_pad(unsigned pad)
 {
-   return ready && pad < MAX_USERS;
+   return hidpad_ready && pad < MAX_USERS;
 }
 
 static void hidpad_destroy(void)
 {
-   ready = false;
+   hidpad_ready = false;
 
    hid_deinit(&hid_instance);
 }
@@ -87,7 +87,7 @@ static int16_t hidpad_axis(unsigned pad, uint32_t axis)
 
 static void hidpad_poll(void)
 {
-   if (ready)
+   if (hidpad_ready)
       HID_POLL();
 }
 

--- a/input/drivers_joypad/wiiu/kpad_driver.c
+++ b/input/drivers_joypad/wiiu/kpad_driver.c
@@ -41,7 +41,7 @@ struct _wiimote_state
    uint8_t  type;
 };
 
-static bool ready = false;
+static bool kpad_ready = false;
 
 /* it would be nice to use designated initializers here,
  * but those are only in C99 and newer. Oh well.
@@ -84,17 +84,17 @@ static bool kpad_init(void *data)
    (void *)data;
 
    kpad_poll();
-   ready = true;
+   kpad_ready = true;
 }
 
 static bool kpad_query_pad(unsigned pad)
 {
-   return ready && pad < MAX_USERS;
+   return kpad_ready && pad < MAX_USERS;
 }
 
 static void kpad_destroy(void)
 {
-   ready = false;
+   kpad_ready = false;
 }
 
 static bool kpad_button(unsigned pad, uint16_t button_bit)

--- a/input/drivers_joypad/wiiu/pad_functions.c
+++ b/input/drivers_joypad/wiiu/pad_functions.c
@@ -17,13 +17,13 @@
 #include "wiiu/input.h"
 
 enum wiiu_pad_axes {
-  AXIS_LEFT_ANALOG_X,
-  AXIS_LEFT_ANALOG_Y,
-  AXIS_RIGHT_ANALOG_X,
-  AXIS_RIGHT_ANALOG_Y,
-  AXIS_TOUCH_X,
-  AXIS_TOUCH_Y,
-  AXIS_INVALID
+  WIIU_AXIS_LEFT_ANALOG_X,
+  WIIU_AXIS_LEFT_ANALOG_Y,
+  WIIU_AXIS_RIGHT_ANALOG_X,
+  WIIU_AXIS_RIGHT_ANALOG_Y,
+  WIIU_AXIS_TOUCH_X,
+  WIIU_AXIS_TOUCH_Y,
+  WIIU_AXIS_INVALID
 };
 
 static int16_t clamp_axis(int16_t value, bool is_negative)
@@ -43,21 +43,21 @@ static int16_t wiiu_pad_get_axis_value(int32_t axis,
 
    switch(axis)
    {
-      case AXIS_LEFT_ANALOG_X:
+      case WIIU_AXIS_LEFT_ANALOG_X:
          value = state[RETRO_DEVICE_INDEX_ANALOG_LEFT][RETRO_DEVICE_ID_ANALOG_X];
          break;
-      case AXIS_LEFT_ANALOG_Y:
+      case WIIU_AXIS_LEFT_ANALOG_Y:
          value = state[RETRO_DEVICE_INDEX_ANALOG_LEFT][RETRO_DEVICE_ID_ANALOG_Y];
          break;
-      case AXIS_RIGHT_ANALOG_X:
+      case WIIU_AXIS_RIGHT_ANALOG_X:
          value = state[RETRO_DEVICE_INDEX_ANALOG_RIGHT][RETRO_DEVICE_ID_ANALOG_X];
          break;
-      case AXIS_RIGHT_ANALOG_Y:
+      case WIIU_AXIS_RIGHT_ANALOG_Y:
          value = state[RETRO_DEVICE_INDEX_ANALOG_RIGHT][RETRO_DEVICE_ID_ANALOG_Y];
          break;
-      case AXIS_TOUCH_X:
+      case WIIU_AXIS_TOUCH_X:
          return state[WIIU_DEVICE_INDEX_TOUCHPAD][RETRO_DEVICE_ID_ANALOG_X];
-      case AXIS_TOUCH_Y:
+      case WIIU_AXIS_TOUCH_Y:
          return state[WIIU_DEVICE_INDEX_TOUCHPAD][RETRO_DEVICE_ID_ANALOG_Y];
    }
 

--- a/input/drivers_joypad/wiiu/wpad_driver.c
+++ b/input/drivers_joypad/wiiu/wpad_driver.c
@@ -25,7 +25,7 @@
 
 #define PANIC_BUTTON_MASK (VPAD_BUTTON_R | VPAD_BUTTON_L | VPAD_BUTTON_STICK_R | VPAD_BUTTON_STICK_L)
 
-static bool     ready        = false;
+static bool     wpad_ready        = false;
 static uint64_t button_state = 0;
 static int16_t  analog_state[3][2];
 
@@ -190,19 +190,19 @@ static bool wpad_init(void *data)
    hid_instance.pad_list[slot].connected = true;
    input_pad_connect(slot, &wpad_driver);
    wpad_poll();
-   ready = true;
+   wpad_ready = true;
 
    return true;
 }
 
 static bool wpad_query_pad(unsigned pad)
 {
-   return ready && pad < MAX_USERS;
+   return wpad_ready && pad < MAX_USERS;
 }
 
 static void wpad_destroy(void)
 {
-   ready = false;
+   wpad_ready = false;
 }
 
 static bool wpad_button(unsigned pad, uint16_t button_bit)


### PR DESCRIPTION
Heyo!

This PR has a good whack of changes to the way WiiU builds. To sum up:
- Removed `-mwup` flag and replaced it with the equivalent `-D__wiiu__ -DHW_WUP -ffunction-sections -fdata-sections` (devkitPro removed this flag a few versions ago). Something similar will have to be done to all cores if they are to be compiled with newer toolchains too.
- Format `Makefile.wiiu` and organise it a bit, hopefully it's more readable
- Fix griffin build by renaming symbols and including missing libraries, this required tweaking deps/libfat and deps/libiosuhax

Both regular and Griffin builds are tested working and salamander compiles; however salamander also doesn't have libfat/libiosuhax in it (this shouldn't affect anything).

Thanks again!
-Ash