### PR TITLE
fix frame_direction type for vulkan

### DIFF
--- a/gfx/drivers_shader/shader_vulkan.cpp
+++ b/gfx/drivers_shader/shader_vulkan.cpp
@@ -495,7 +495,7 @@ class Pass
             slang_texture_semantic semantic, unsigned index, const Texture &texture);
 
       uint64_t frame_count = 0;
-      uint32_t frame_direction = 1;
+      int32_t frame_direction = 1;
       unsigned frame_count_period = 0;
       unsigned pass_number = 0;
 


### PR DESCRIPTION
Small oversight in #8845.
It worked before because `-1 == (int32_t)(uint32_t)-1` on practically all compilers (actually guaranteed in C++20), but a fix is a fix.