### PR TITLE
implement FrameDirection slang semantic for d3d10-12, gx2_gfx and metal

### DIFF
--- a/gfx/common/d3d10_common.h
+++ b/gfx/common/d3d10_common.h
@@ -1208,6 +1208,7 @@ typedef struct
       D3D10_VIEWPORT             viewport;
       pass_semantics_t           semantics;
       uint32_t                   frame_count;
+      int32_t                    frame_direction;
    } pass[GFX_MAX_SHADERS];
 
    struct video_shader* shader_preset;

--- a/gfx/common/d3d11_common.h
+++ b/gfx/common/d3d11_common.h
@@ -2584,6 +2584,7 @@ typedef struct
       D3D11_VIEWPORT             viewport;
       pass_semantics_t           semantics;
       uint32_t                   frame_count;
+      int32_t                    frame_direction;
    } pass[GFX_MAX_SHADERS];
 
    struct video_shader* shader_preset;

--- a/gfx/common/d3d12_common.h
+++ b/gfx/common/d3d12_common.h
@@ -1444,6 +1444,7 @@ typedef struct
       D3D12_RECT                      scissorRect;
       pass_semantics_t                semantics;
       uint32_t                        frame_count;
+      int32_t                         frame_direction;
       D3D12_GPU_DESCRIPTOR_HANDLE     textures;
       D3D12_GPU_DESCRIPTOR_HANDLE     samplers;
    } pass[GFX_MAX_SHADERS];

--- a/gfx/common/metal_common.m
+++ b/gfx/common/metal_common.m
@@ -14,6 +14,7 @@
 #include <simd/simd.h>
 
 #import <gfx/video_frame.h>
+#include "../../managers/state_manager.h"
 
 #import "metal_common.h"
 #import "../../ui/drivers/cocoa/cocoa_common.h"
@@ -552,6 +553,7 @@ typedef struct MTLALIGN(16)
       texture_t rt;
       texture_t feedback;
       uint32_t frame_count;
+      int32_t frame_direction;
       pass_semantics_t semantics;
       MTLViewport viewport;
       __unsafe_unretained id<MTLRenderPipelineState> _state;
@@ -927,6 +929,8 @@ typedef struct MTLALIGN(16)
       if (_shader->pass[i].frame_count_mod)
          _engine.pass[i].frame_count %= _shader->pass[i].frame_count_mod;
 
+      _engine.pass[i].frame_direction = state_manager_frame_is_reversed() ? -1 : 1;
+
       for (unsigned j = 0; j < SLANG_CBUFFER_MAX; j++)
       {
          id<MTLBuffer> buffer = _engine.pass[i].buffers[j];
@@ -1176,10 +1180,11 @@ typedef struct MTLALIGN(16)
                   &_engine.luts[0].size_data, sizeof(*_engine.luts)},
             },
             {
-               mvp,                           /* MVP */
-               &_engine.pass[i].rt.size_data, /* OutputSize */
-               &_engine.frame.output_size,    /* FinalViewportSize */
-               &_engine.pass[i].frame_count,  /* FrameCount */
+               mvp,                              /* MVP */
+               &_engine.pass[i].rt.size_data,    /* OutputSize */
+               &_engine.frame.output_size,       /* FinalViewportSize */
+               &_engine.pass[i].frame_count,     /* FrameCount */
+               &_engine.pass[i].frame_direction, /* FrameDirection */
             }
          };
          /* clang-format on */

--- a/gfx/drivers/d3d10.c
+++ b/gfx/drivers/d3d10.c
@@ -27,6 +27,7 @@
 #include "../../verbosity.h"
 #include "../../configuration.h"
 #include "../../retroarch.h"
+#include "../../managers/state_manager.h"
 
 #include "../video_driver.h"
 #include "../font_driver.h"
@@ -390,10 +391,11 @@ static bool d3d10_gfx_set_shader(void* data,
                &d3d10->luts[0].size_data, sizeof(*d3d10->luts)},
          },
          {
-            &d3d10->mvp,                  /* MVP */
-            &d3d10->pass[i].rt.size_data, /* OutputSize */
-            &d3d10->frame.output_size,    /* FinalViewportSize */
-            &d3d10->pass[i].frame_count,  /* FrameCount */
+            &d3d10->mvp,                     /* MVP */
+            &d3d10->pass[i].rt.size_data,    /* OutputSize */
+            &d3d10->frame.output_size,       /* FinalViewportSize */
+            &d3d10->pass[i].frame_count,     /* FrameCount */
+            &d3d10->pass[i].frame_direction, /* FrameDirection */
          }
       };
       /* clang-format on */
@@ -1282,6 +1284,8 @@ static bool d3d10_gfx_frame(
                frame_count % d3d10->shader_preset->pass[i].frame_count_mod;
          else
             d3d10->pass[i].frame_count = frame_count;
+
+         d3d10->pass[i].frame_direction = state_manager_frame_is_reversed() ? -1 : 1;
 
          for (j = 0; j < SLANG_CBUFFER_MAX; j++)
          {

--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -43,6 +43,7 @@
 #include "../../menu/menu_driver.h"
 #include "../video_shader_parse.h"
 #include "../drivers_shader/slang_preprocess.h"
+#include "../../managers/state_manager.h"
 
 #include "../common/d3d_common.h"
 #include "../common/d3d11_common.h"
@@ -408,10 +409,11 @@ static bool d3d11_gfx_set_shader(void* data, enum rarch_shader_type type, const 
                &d3d11->luts[0].size_data, sizeof(*d3d11->luts)},
          },
          {
-            &d3d11->mvp,                  /* MVP */
-            &d3d11->pass[i].rt.size_data, /* OutputSize */
-            &d3d11->frame.output_size,    /* FinalViewportSize */
-            &d3d11->pass[i].frame_count,  /* FrameCount */
+            &d3d11->mvp,                     /* MVP */
+            &d3d11->pass[i].rt.size_data,    /* OutputSize */
+            &d3d11->frame.output_size,       /* FinalViewportSize */
+            &d3d11->pass[i].frame_count,     /* FrameCount */
+            &d3d11->pass[i].frame_direction, /* FrameDirection */
          }
       };
       /* clang-format on */
@@ -1355,6 +1357,8 @@ static bool d3d11_gfx_frame(
                frame_count % d3d11->shader_preset->pass[i].frame_count_mod;
          else
             d3d11->pass[i].frame_count = frame_count;
+
+         d3d11->pass[i].frame_direction = state_manager_frame_is_reversed() ? -1 : 1;
 
          for (j = 0; j < SLANG_CBUFFER_MAX; j++)
          {

--- a/gfx/drivers/d3d12.c
+++ b/gfx/drivers/d3d12.c
@@ -32,6 +32,7 @@
 #include "../../verbosity.h"
 #include "../../configuration.h"
 #include "../../retroarch.h"
+#include "../../managers/state_manager.h"
 
 #ifdef HAVE_MENU
 #include "../../menu/menu_driver.h"
@@ -398,10 +399,11 @@ static bool d3d12_gfx_set_shader(void* data, enum rarch_shader_type type, const 
                &d3d12->luts[0].size_data, sizeof(*d3d12->luts)},
          },
          {
-            &d3d12->mvp,                  /* MVP */
-            &d3d12->pass[i].rt.size_data, /* OutputSize */
-            &d3d12->frame.output_size,    /* FinalViewportSize */
-            &d3d12->pass[i].frame_count,  /* FrameCount */
+            &d3d12->mvp,                     /* MVP */
+            &d3d12->pass[i].rt.size_data,    /* OutputSize */
+            &d3d12->frame.output_size,       /* FinalViewportSize */
+            &d3d12->pass[i].frame_count,     /* FrameCount */
+            &d3d12->pass[i].frame_direction, /* FrameDirection */
          }
       };
       /* clang-format on */
@@ -1293,6 +1295,8 @@ static bool d3d12_gfx_frame(
                   frame_count % d3d12->shader_preset->pass[i].frame_count_mod;
          else
             d3d12->pass[i].frame_count = frame_count;
+
+         d3d12->pass[i].frame_direction = state_manager_frame_is_reversed() ? -1 : 1;
 
          for (j = 0; j < SLANG_CBUFFER_MAX; j++)
          {


### PR DESCRIPTION
With #8845 this should be all Slang video drivers.
Tested only for d3d11, but should work for d3d10 and d3d12 too, because the code changes are identical.