### PR TITLE
'menu_entry' optimisations

### DIFF
--- a/menu/cbs/menu_cbs_select.c
+++ b/menu/cbs/menu_cbs_select.c
@@ -46,6 +46,12 @@ static int action_select_default(const char *path, const char *label, unsigned t
    file_list_t *selection_buf = menu_entries_get_selection_buf_ptr(0);
 
    menu_entry_init(&entry);
+   /* Note: If menu_entry_action() is modified,
+    * will have to verify that these parameters
+    * remain unused... */
+   entry.rich_label_enabled = false;
+   entry.value_enabled      = false;
+   entry.sublabel_enabled   = false;
    menu_entry_get(&entry, 0, idx, NULL, false);
 
    if (selection_buf)
@@ -53,10 +59,7 @@ static int action_select_default(const char *path, const char *label, unsigned t
          file_list_get_actiondata_at_offset(selection_buf, idx);
 
    if (!cbs)
-   {
-      menu_entry_free(&entry);
       return -1;
-   }
 
    if (cbs->setting)
    {
@@ -101,8 +104,6 @@ static int action_select_default(const char *path, const char *label, unsigned t
 
    if (action != MENU_ACTION_NOOP)
        ret = menu_entry_action(&entry, (unsigned)idx, action);
-
-   menu_entry_free(&entry);
 
    task_queue_check();
 

--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -606,33 +606,35 @@ static void materialui_compute_entries_box(materialui_handle_t* mui, int width)
    for (i = 0; i < entries_end; i++)
    {
       menu_entry_t entry;
-      char *sublabel_str        = NULL;
+      char wrapped_sublabel_str[512];
+      const char *sublabel_str  = NULL;
       unsigned lines            = 0;
-      materialui_node_t *node          = (materialui_node_t*)
+      materialui_node_t *node   = (materialui_node_t*)
          file_list_get_userdata_at_offset(list, i);
 
+      wrapped_sublabel_str[0] = '\0';
+
       menu_entry_init(&entry);
+      entry.path_enabled       = false;
+      entry.label_enabled      = false;
+      entry.rich_label_enabled = false;
+      entry.value_enabled      = false;
       menu_entry_get(&entry, 0, i, NULL, true);
 
-      sublabel_str = menu_entry_get_sublabel(&entry);
-      menu_entry_free(&entry);
+      menu_entry_get_sublabel(&entry, &sublabel_str);
 
-      if (sublabel_str)
+      if (!string_is_empty(sublabel_str))
       {
-         if (!string_is_empty(sublabel_str))
-         {
-            int icon_margin = 0;
+         int icon_margin = 0;
 
-            if (node->texture_switch2_set)
-               if (mui->textures.list[node->texture_switch2_index])
-                  icon_margin = mui->icon_size;
+         if (node->texture_switch2_set)
+            if (mui->textures.list[node->texture_switch2_index])
+               icon_margin = mui->icon_size;
 
-            word_wrap(sublabel_str, sublabel_str,
-                  (int)((usable_width - icon_margin) / mui->glyph_width2),
-                  false, 0);
-            lines = materialui_count_lines(sublabel_str);
-         }
-         free(sublabel_str);
+         word_wrap(wrapped_sublabel_str, sublabel_str,
+               (int)((usable_width - icon_margin) / mui->glyph_width2),
+               false, 0);
+         lines = materialui_count_lines(wrapped_sublabel_str);
       }
 
       node->line_height  = (scale_factor / 3) + (lines * mui->font->size);
@@ -743,8 +745,9 @@ static void materialui_render_label_value(
    menu_animation_ctx_ticker_t ticker;
    char label_str[255];
    char value_str[255];
+   char wrapped_sublabel_str[512];
    unsigned entry_type             = 0;
-   char *sublabel_str              = NULL;
+   const char *sublabel_str        = NULL;
    bool switch_is_on               = true;
    int value_len                   = (int)utf8len(value);
    int ticker_limit                = 0;
@@ -761,9 +764,13 @@ static void materialui_render_label_value(
    ticker.type_enum = (enum menu_animation_ticker_type)settings->uints.menu_ticker_type;
    ticker.spacer = NULL;
 
-   label_str[0] = value_str[0]     = '\0';
+   label_str[0] = value_str[0] = wrapped_sublabel_str[0] = '\0';
 
    menu_entry_init(&entry);
+   entry.path_enabled       = false;
+   entry.label_enabled      = false;
+   entry.rich_label_enabled = false;
+   entry.value_enabled      = false;
    menu_entry_get(&entry, 0, i, NULL, true);
    entry_type = menu_entry_get_type_new(&entry);
 
@@ -861,27 +868,23 @@ static void materialui_render_label_value(
       }
    }
 
-   sublabel_str = menu_entry_get_sublabel(&entry);
+   menu_entry_get_sublabel(&entry, &sublabel_str);
 
    if (texture_switch2)
       icon_margin      = mui->icon_size;
 
    /* Sublabel */
-   if (sublabel_str)
+   if (!string_is_empty(sublabel_str) && mui->font)
    {
-      if (!string_is_empty(sublabel_str) && mui->font)
-      {
-         word_wrap(sublabel_str, sublabel_str,
-               (int)((usable_width - icon_margin) / mui->glyph_width2),
-               false, 0);
+      word_wrap(wrapped_sublabel_str, sublabel_str,
+            (int)((usable_width - icon_margin) / mui->glyph_width2),
+            false, 0);
 
-         menu_display_draw_text(mui->font2, sublabel_str,
-               mui->margin + icon_margin,
-               y + (scale_factor / 4) + mui->font->size,
-               width, height, sublabel_color, TEXT_ALIGN_LEFT,
-               1.0f, false, 0, false);
-      }
-      free(sublabel_str);
+      menu_display_draw_text(mui->font2, wrapped_sublabel_str,
+            mui->margin + icon_margin,
+            y + (scale_factor / 4) + mui->font->size,
+            width, height, sublabel_color, TEXT_ALIGN_LEFT,
+            1.0f, false, 0, false);
    }
 
    menu_display_draw_text(mui->font, label_str,
@@ -931,8 +934,6 @@ static void materialui_render_label_value(
             switch_is_on ? &label_color[0] :  &pure_white[0]
             );
    }
-
-   menu_entry_free(&entry);
 }
 
 static void materialui_render_menu_list(
@@ -964,15 +965,13 @@ static void materialui_render_menu_list(
    for (i = 0; i < entries_end; i++)
    {
       menu_entry_t entry;
-      char entry_value[255];
-      char *rich_label           = NULL;
+      const char *entry_value    = NULL;
+      const char *rich_label     = NULL;
       bool entry_selected        = false;
       materialui_node_t *node    = (materialui_node_t*)
          file_list_get_userdata_at_offset(list, i);
       size_t selection           = menu_navigation_get_selection();
       int               y        = header_height - mui->scroll_y + sum;
-
-      entry_value[0]      = '\0';
 
       sum += node->line_height;
 
@@ -983,9 +982,12 @@ static void materialui_render_menu_list(
          break;
 
       menu_entry_init(&entry);
+      entry.path_enabled     = false;
+      entry.label_enabled    = false;
+      entry.sublabel_enabled = false;
       menu_entry_get(&entry, 0, (unsigned)i, NULL, true);
-      menu_entry_get_value(&entry, entry_value, sizeof(entry_value));
-      rich_label     = menu_entry_get_rich_label(&entry);
+      menu_entry_get_value(&entry, &entry_value);
+      menu_entry_get_rich_label(&entry, &rich_label);
       entry_selected = selection == i;
 
       /* Render label, value, and associated icons */
@@ -1006,9 +1008,6 @@ static void materialui_render_menu_list(
             menu_list_color,
             sublabel_color
             );
-
-      menu_entry_free(&entry);
-      free(rich_label);
    }
 }
 

--- a/menu/drivers/menu_generic.c
+++ b/menu/drivers/menu_generic.c
@@ -233,10 +233,15 @@ int generic_menu_iterate(menu_handle_t *menu, void *userdata, enum menu_action a
             selection = MAX(MIN(selection, (menu_entries_get_size() - 1)), 0);
 
             menu_entry_init(&entry);
+            /* Note: If menu_entry_action() is modified,
+             * will have to verify that these parameters
+             * remain unused... */
+            entry.rich_label_enabled = false;
+            entry.value_enabled      = false;
+            entry.sublabel_enabled   = false;
             menu_entry_get(&entry, 0, selection, NULL, false);
             ret = menu_entry_action(&entry,
                   (unsigned)selection, (enum menu_action)action);
-            menu_entry_free(&entry);
             if (ret)
                goto end;
 

--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -1285,12 +1285,14 @@ static void ozone_set_thumbnail_content(void *data, const char *s)
          menu_entry_t entry;
 
          menu_entry_init(&entry);
+         entry.label_enabled      = false;
+         entry.rich_label_enabled = false;
+         entry.value_enabled      = false;
+         entry.sublabel_enabled   = false;
          menu_entry_get(&entry, 0, selection, NULL, true);
 
          if (!string_is_empty(entry.path))
             menu_thumbnail_set_content(ozone->thumbnail_path_data, entry.path);
-
-         menu_entry_free(&entry);
       }
    }
    else if (string_is_equal(s, "imageviewer"))
@@ -1301,13 +1303,15 @@ static void ozone_set_thumbnail_content(void *data, const char *s)
       ozone_node_t *node = (ozone_node_t*)file_list_get_userdata_at_offset(selection_buf, selection);
 
       menu_entry_init(&entry);
+      entry.label_enabled      = false;
+      entry.rich_label_enabled = false;
+      entry.value_enabled      = false;
+      entry.sublabel_enabled   = false;
       menu_entry_get(&entry, 0, selection, NULL, true);
 
       if (node)
          if (!string_is_empty(entry.path) && !string_is_empty(node->fullpath))
             menu_thumbnail_set_content_image(ozone->thumbnail_path_data, node->fullpath, entry.path);
-
-      menu_entry_free(&entry);
    }
    else if (!string_is_empty(s))
    {
@@ -1366,11 +1370,15 @@ static void ozone_selection_changed(ozone_handle_t *ozone, bool allow_animation)
    size_t new_selection = menu_navigation_get_selection();
    ozone_node_t *node   = (ozone_node_t*) file_list_get_userdata_at_offset(selection_buf, new_selection);
 
-   menu_entry_init(&entry);
-
    if (!node)
       return;
 
+   menu_entry_init(&entry);
+   entry.path_enabled       = false;
+   entry.label_enabled      = false;
+   entry.rich_label_enabled = false;
+   entry.value_enabled      = false;
+   entry.sublabel_enabled   = false;
    menu_entry_get(&entry, 0, selection, NULL, true);
 
    if (ozone->selection != new_selection)
@@ -1424,8 +1432,6 @@ static void ozone_selection_changed(ozone_handle_t *ozone, bool allow_animation)
 
       /* TODO: update savestate thumbnail and path */
    }
-
-   menu_entry_free(&entry);
 }
 
 static void ozone_navigation_clear(void *data, bool pending_push)

--- a/menu/drivers/stripes.c
+++ b/menu/drivers/stripes.c
@@ -863,11 +863,10 @@ static void stripes_update_thumbnail_path(void *data, unsigned i, char pos)
    playlist_t     *playlist       = NULL;
    const char    *dir_thumbnails  = settings->paths.directory_thumbnails;
 
-   menu_entry_init(&entry);
-
    if (!stripes || string_is_empty(dir_thumbnails))
       goto end;
 
+   menu_entry_init(&entry);
    menu_entry_get(&entry, 0, i, NULL, true);
 
    entry_type = menu_entry_get_type_new(&entry);
@@ -996,8 +995,6 @@ end:
       if (pos == 'L')
          stripes->left_thumbnail_file_path = strdup(new_path);
    }
-
-   menu_entry_free(&entry);
 }
 
 static void stripes_update_savestate_thumbnail_path(void *data, unsigned i)
@@ -1055,8 +1052,6 @@ static void stripes_update_savestate_thumbnail_path(void *data, unsigned i)
          free(path);
       }
    }
-
-   menu_entry_free(&entry);
 }
 
 static void stripes_update_thumbnail_image(void *data)
@@ -1180,7 +1175,7 @@ static void stripes_selection_pointer_changed(
    menu_entry_init(&entry);
 
    if (!stripes)
-      goto end;
+      return;
 
    menu_entry_get(&entry, 0, selection, NULL, true);
 
@@ -1244,9 +1239,6 @@ static void stripes_selection_pointer_changed(
          menu_animation_push(&anim_entry);
       }
    }
-
-end:
-   menu_entry_free(&entry);
 }
 
 static void stripes_list_open_old(stripes_handle_t *stripes,
@@ -1749,8 +1741,6 @@ static void stripes_list_switch(stripes_handle_t *stripes)
       if (!string_is_empty(entry.path))
          stripes_set_thumbnail_content(stripes, entry.path, 0 /* will be ignored */);
 
-      menu_entry_free(&entry);
-
       stripes_update_thumbnail_path(stripes, 0, 'R');
       stripes_update_thumbnail_image(stripes);
    }
@@ -1764,8 +1754,6 @@ static void stripes_list_switch(stripes_handle_t *stripes)
 
       if (!string_is_empty(entry.path))
          stripes_set_thumbnail_content(stripes, entry.path, 0 /* will be ignored */);
-
-      menu_entry_free(&entry);
 
       stripes_update_thumbnail_path(stripes, 0, 'L');
       stripes_update_thumbnail_image(stripes);
@@ -2350,7 +2338,7 @@ static int stripes_draw_item(
    float icon_x, icon_y, label_offset;
    menu_animation_ctx_ticker_t ticker;
    char tmp[255];
-   char *ticker_str                  = NULL;
+   const char *ticker_str            = NULL;
    unsigned entry_type               = 0;
    const float half_size             = stripes->icon_size / 2.0f;
    uintptr_t texture_switch          = 0;
@@ -2467,7 +2455,7 @@ static int stripes_draw_item(
    }
 
    if (!string_is_empty(entry->path))
-      ticker_str      = menu_entry_get_rich_label(entry);
+      menu_entry_get_rich_label(entry, &ticker_str);
 
    ticker.s        = tmp;
    ticker.len      = ticker_limit;
@@ -2585,13 +2573,9 @@ static int stripes_draw_item(
             stripes->shadow_offset);
 
 iterate:
-   if (!string_is_empty(ticker_str))
-      free(ticker_str);
    return 0;
 
 end:
-   if (!string_is_empty(ticker_str))
-      free(ticker_str);
    return -1;
 }
 
@@ -2662,7 +2646,6 @@ static void stripes_draw_items(
             list, color, thumb_ident, left_thumb_ident,
             i, current,
             width, height);
-      menu_entry_free(&entry);
       if (ret == -1)
          break;
    }

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -955,6 +955,10 @@ static void xmb_update_savestate_thumbnail_path(void *data, unsigned i)
       return;
 
    menu_entry_init(&entry);
+   entry.path_enabled       = false;
+   entry.rich_label_enabled = false;
+   entry.value_enabled      = false;
+   entry.sublabel_enabled   = false;
    menu_entry_get(&entry, 0, i, NULL, true);
 
    if (!string_is_empty(xmb->savestate_thumbnail_file_path))
@@ -1000,8 +1004,6 @@ static void xmb_update_savestate_thumbnail_path(void *data, unsigned i)
          free(path);
       }
    }
-
-   menu_entry_free(&entry);
 }
 
 static void xmb_update_thumbnail_image(void *data)
@@ -1184,12 +1186,14 @@ static void xmb_set_thumbnail_content(void *data, const char *s)
          menu_entry_t entry;
 
          menu_entry_init(&entry);
+         entry.label_enabled      = false;
+         entry.rich_label_enabled = false;
+         entry.value_enabled      = false;
+         entry.sublabel_enabled   = false;
          menu_entry_get(&entry, 0, selection, NULL, true);
 
          if (!string_is_empty(entry.path))
             menu_thumbnail_set_content(xmb->thumbnail_path_data, entry.path);
-
-         menu_entry_free(&entry);
       }
    }
    else if (string_is_equal(s, "imageviewer"))
@@ -1200,13 +1204,15 @@ static void xmb_set_thumbnail_content(void *data, const char *s)
       xmb_node_t *node = (xmb_node_t*)file_list_get_userdata_at_offset(selection_buf, selection);
 
       menu_entry_init(&entry);
+      entry.label_enabled      = false;
+      entry.rich_label_enabled = false;
+      entry.value_enabled      = false;
+      entry.sublabel_enabled   = false;
       menu_entry_get(&entry, 0, selection, NULL, true);
 
       if (node)
          if (!string_is_empty(entry.path) && !string_is_empty(node->fullpath))
             menu_thumbnail_set_content_image(xmb->thumbnail_path_data, node->fullpath, entry.path);
-
-      menu_entry_free(&entry);
    }
    else if (!string_is_empty(s))
    {
@@ -1246,12 +1252,17 @@ static void xmb_selection_pointer_changed(
    file_list_t *selection_buf = menu_entries_get_selection_buf_ptr(0);
    size_t selection           = menu_navigation_get_selection();
 
-   menu_entries_ctl(MENU_ENTRIES_CTL_LIST_GET, &menu_list);
-   menu_entry_init(&entry);
-
    if (!xmb)
-      goto end;
+      return;
 
+   menu_entries_ctl(MENU_ENTRIES_CTL_LIST_GET, &menu_list);
+
+   menu_entry_init(&entry);
+   entry.path_enabled       = false;
+   entry.label_enabled      = false;
+   entry.rich_label_enabled = false;
+   entry.value_enabled      = false;
+   entry.sublabel_enabled   = false;
    menu_entry_get(&entry, 0, selection, NULL, true);
 
    end       = (unsigned)menu_entries_get_size();
@@ -1377,9 +1388,6 @@ static void xmb_selection_pointer_changed(
          menu_animation_push(&anim_entry);
       }
    }
-
-end:
-   menu_entry_free(&entry);
 }
 
 static void xmb_list_open_old(xmb_handle_t *xmb,
@@ -2832,7 +2840,7 @@ static int xmb_draw_item(
    float icon_x, icon_y, label_offset;
    menu_animation_ctx_ticker_t ticker;
    char tmp[255];
-   char *ticker_str                  = NULL;
+   const char *ticker_str            = NULL;
    unsigned entry_type               = 0;
    const float half_size             = xmb->icon_size / 2.0f;
    uintptr_t texture_switch          = 0;
@@ -2876,11 +2884,7 @@ static int xmb_draw_item(
             sizeof(entry_path));
 
       if (!string_is_empty(entry_path))
-      {
-         if (!string_is_empty(entry->path))
-            free(entry->path);
-         entry->path = strdup(entry_path);
-      }
+         strlcpy(entry->path, entry_path, sizeof(entry->path));
    }
 
    if (string_is_equal(entry->value,
@@ -2948,7 +2952,7 @@ static int xmb_draw_item(
    }
 
    if (!string_is_empty(entry->path))
-      ticker_str   = menu_entry_get_rich_label(entry);
+      menu_entry_get_rich_label(entry, &ticker_str);
 
    ticker.s        = tmp;
    ticker.len      = ticker_limit;
@@ -2997,8 +3001,8 @@ static int xmb_draw_item(
 
    if (!string_is_empty(entry->value))
    {
-      char entry_value[255];
-      menu_entry_get_value(entry, entry_value, sizeof(entry_value));
+      const char *entry_value = NULL;
+      menu_entry_get_value(entry, &entry_value);
       ticker.str   = entry_value;
 
       menu_animation_ticker(&ticker);
@@ -3079,8 +3083,6 @@ static int xmb_draw_item(
             &color[0],
             xmb->shadow_offset);
 
-   if (!string_is_empty(ticker_str))
-      free(ticker_str);
    return 0;
 }
 
@@ -3141,6 +3143,9 @@ static void xmb_draw_items(
       int ret;
       menu_entry_t entry;
       menu_entry_init(&entry);
+      entry.label_enabled      = false;
+      entry.rich_label_enabled = false;
+      entry.sublabel_enabled   = (i == current);
       menu_entry_get(&entry, 0, i, list, true);
       ret = xmb_draw_item(video_info,
             &entry,
@@ -3149,7 +3154,6 @@ static void xmb_draw_items(
             list, color,
             i, current,
             width, height);
-      menu_entry_free(&entry);
       if (ret == -1)
          break;
    }

--- a/menu/drivers/xui.cpp
+++ b/menu/drivers/xui.cpp
@@ -584,24 +584,20 @@ static void xui_render(void *data, bool is_idle)
    for (i = 0; i < end; i++)
    {
       menu_entry_t entry;
-      char *entry_path                     = NULL;
-      char entry_value[PATH_MAX_LENGTH]    = {0};
+      const char *entry_path               = NULL;
+      const char *entry_value              = NULL;
       wchar_t msg_right[PATH_MAX_LENGTH]   = {0};
       wchar_t msg_left[PATH_MAX_LENGTH]    = {0};
 
       menu_entry_init(&entry);
       menu_entry_get(&entry, 0, i, NULL, true);
 
-      menu_entry_get_value(&entry, entry_value, sizeof(entry_value));
-      entry_path = menu_entry_get_path(&entry);
+      menu_entry_get_value(&entry, &entry_value);
+      menu_entry_get_path(&entry, &entry_path);
 
       mbstowcs(msg_left,  entry_path,  sizeof(msg_left)  / sizeof(wchar_t));
       mbstowcs(msg_right, entry_value, sizeof(msg_right) / sizeof(wchar_t));
       xui_set_list_text(i, msg_left, msg_right);
-
-      menu_entry_free(&entry);
-      if (!string_is_empty(entry_path))
-         free(entry_path);
    }
 
    selection = menu_navigation_get_selection();

--- a/menu/menu_entries.h
+++ b/menu/menu_entries.h
@@ -208,19 +208,25 @@ typedef struct menu_entry
    unsigned type;
    unsigned spacing;
    size_t entry_idx;
-   char *path;
-   char *label;
-   char *sublabel;
-   char *rich_label;
-   char *value;
+   char path[255];
+   char label[255];
+   char sublabel[512];
+   char rich_label[255];
+   char value[255];
+   char password_value[255];
    bool checked;
+   bool path_enabled;
+   bool label_enabled;
+   bool rich_label_enabled;
+   bool value_enabled;
+   bool sublabel_enabled;
 } menu_entry_t;
 
 enum menu_entry_type menu_entry_get_type(uint32_t i);
 
-char *menu_entry_get_path(menu_entry_t *entry);
+void menu_entry_get_path(menu_entry_t *entry, const char **path);
 
-void menu_entry_get_label(menu_entry_t *entry, char *s, size_t len);
+void menu_entry_get_label(menu_entry_t *entry, const char **label);
 
 unsigned menu_entry_get_spacing(menu_entry_t *entry);
 
@@ -250,11 +256,11 @@ void menu_entry_pathdir_extensions(uint32_t i, char *s, size_t len);
 
 void menu_entry_reset(uint32_t i);
 
-char *menu_entry_get_rich_label(menu_entry_t *entry);
+void menu_entry_get_rich_label(menu_entry_t *entry, const char **rich_label);
 
-char *menu_entry_get_sublabel(menu_entry_t *entry);
+void menu_entry_get_sublabel(menu_entry_t *entry, const char **sublabel);
 
-void menu_entry_get_value(menu_entry_t *entry, char *s, size_t len);
+void menu_entry_get_value(menu_entry_t *entry, const char **value);
 
 void menu_entry_set_value(uint32_t i, const char *s);
 
@@ -275,8 +281,6 @@ int menu_entry_select(uint32_t i);
 
 int menu_entry_action(menu_entry_t *entry,
                       unsigned i, enum menu_action action);
-
-void menu_entry_free(menu_entry_t *entry);
 
 void menu_entry_init(menu_entry_t *entry);
 

--- a/menu/menu_input.c
+++ b/menu/menu_input.c
@@ -882,12 +882,17 @@ void menu_input_post_iterate(int *ret, unsigned action)
       : NULL;
 
    menu_entry_init(&entry);
+   /* Note: If menu_input_mouse_frame() or
+    * menu_input_pointer_post_iterate() are
+    * modified, will have to verify that these
+    * parameters remain unused... */
+   entry.rich_label_enabled = false;
+   entry.value_enabled      = false;
+   entry.sublabel_enabled   = false;
    menu_entry_get(&entry, 0, selection, NULL, false);
 
    *ret = menu_input_mouse_frame(cbs, &entry, action);
 
    if (settings->bools.menu_pointer_enable)
       *ret |= menu_input_pointer_post_iterate(cbs, &entry, action);
-
-   menu_entry_free(&entry);
 }

--- a/menu/menu_thumbnail_path.c
+++ b/menu/menu_thumbnail_path.c
@@ -258,6 +258,10 @@ bool menu_thumbnail_set_content(menu_thumbnail_path_data_t *path_data, const cha
    /* Determine content image name */
    fill_content_img(path_data);
    
+   /* Have to set content path to *something*...
+    * Just use label value (it doesn't matter) */
+   strlcpy(path_data->content_path, label, sizeof(path_data->content_path));
+   
    /* Redundant error check... */
    if (string_is_empty(path_data->content_img))
       return false;

--- a/ui/drivers/cocoa/cocoatouch_menu.m
+++ b/ui/drivers/cocoa/cocoatouch_menu.m
@@ -113,7 +113,7 @@ static void RunActionSheet(const char* title, const struct string_list* items,
 {
   menu_entry_t entry;
   char buffer[PATH_MAX_LENGTH];
-  char *label                    = NULL;
+  const char *label              = NULL;
   static NSString* const cell_id = @"text";
 
   self.parentTable = tableView;
@@ -125,7 +125,7 @@ static void RunActionSheet(const char* title, const struct string_list* items,
 
   menu_entry_init(&entry);
   menu_entry_get(&entry, 0, (unsigned)self.i, NULL, true);
-  label = menu_entry_get_path(&entry);
+  menu_entry_get_path(&entry, &label);
   menu_entry_get_value(&entry, buffer, sizeof(buffer));
 
   if (string_is_empty(label))
@@ -136,10 +136,6 @@ static void RunActionSheet(const char* title, const struct string_list* items,
   if (!string_is_empty(label))
      result.textLabel.text    = BOXSTRING(label);
   result.detailTextLabel.text = BOXSTRING(buffer);
-
-  menu_entry_free(&entry);
-  if (!string_is_empty(label))
-     free(label);
 
   return result;
 }
@@ -158,7 +154,7 @@ static void RunActionSheet(const char* title, const struct string_list* items,
 - (UITableViewCell*)cellForTableView:(UITableView*)tableView
 {
    menu_entry_t entry;
-   char *label                    = NULL;
+   const char *label              = NULL;
    static NSString* const cell_id = @"boolean_setting";
 
    UITableViewCell* result =
@@ -175,7 +171,7 @@ static void RunActionSheet(const char* title, const struct string_list* items,
    menu_entry_init(&entry);
    menu_entry_get(&entry, 0, (unsigned)self.i, NULL, true);
 
-   label = menu_entry_get_path(&entry);
+   menu_entry_get_path(&entry, &label);
 
    if (!string_is_empty(label))
       result.textLabel.text = BOXSTRING(label);
@@ -187,9 +183,6 @@ static void RunActionSheet(const char* title, const struct string_list* items,
                                 action:@selector(handleBooleanSwitch:)
                       forControlEvents:UIControlEventValueChanged];
    [(id)result.accessoryView setOn:(menu_entry_get_bool_value(self.i))];
-   menu_entry_free(&entry);
-   if (!string_is_empty(label))
-      free(label);
    return result;
 }
 
@@ -226,12 +219,12 @@ static void RunActionSheet(const char* title, const struct string_list* items,
 {
    menu_entry_t entry;
    struct string_list* items       = NULL;
-   char *label                     = NULL;
+   const char *label               = NULL;
    RAMenuItemEnum __weak* weakSelf = self;
 
    menu_entry_init(&entry);
    menu_entry_get(&entry, 0, (unsigned)self.i, NULL, true);
-   label = menu_entry_get_path(&entry);
+   menu_entry_get_path(&entry, &label);
    items = menu_entry_enum_values(self.i);
 
    if (!string_is_empty(label))
@@ -248,9 +241,6 @@ static void RunActionSheet(const char* title, const struct string_list* items,
       });
    }
    string_list_free(items);
-   menu_entry_free(&entry);
-   if (!string_is_empty(label))
-      free(label);
 }
 @end
 
@@ -265,11 +255,11 @@ static void RunActionSheet(const char* title, const struct string_list* items,
                   ofController:(UIViewController *)controller
 {
    menu_entry_t entry;
-   char *label = NULL;
+   const char *label = NULL;
 
    menu_entry_init(&entry);
    menu_entry_get(&entry, 0, (unsigned)self.i, NULL, true);
-   label = menu_entry_get_path(&entry);
+   menu_entry_get_path(&entry, &label);
 
    self.alert = [[UIAlertView alloc]
 
@@ -290,9 +280,6 @@ static void RunActionSheet(const char* title, const struct string_list* items,
                             selector:@selector(checkBind:)
                             userInfo:nil
                              repeats:YES];
-   menu_entry_free(&entry);
-   if (!string_is_empty(label))
-      free(label);
 }
 
 - (void)finishWithClickedButton:(bool)clicked
@@ -444,14 +431,14 @@ replacementString:(NSString *)string
 {
    menu_entry_t entry;
    char buffer[PATH_MAX_LENGTH];
-   char *label            = NULL;
+   const char *label      = NULL;
    UIAlertView *alertView = NULL;
    UITextField     *field = NULL;
    NSString         *desc = NULL;
 
    menu_entry_init(&entry);
    menu_entry_get(&entry, 0, (unsigned)self.i, NULL, true);
-   label     = menu_entry_get_path(&entry);
+   menu_entry_get_path(&entry, &label);
 
    desc      = BOXSTRING(label);
 
@@ -473,11 +460,6 @@ replacementString:(NSString *)string
             sizeof(buffer));
 
    field.placeholder = BOXSTRING(buffer);
-
-   menu_entry_free(&entry);
-
-   if (!string_is_empty(label))
-      free(label);
 
    [alertView show];
 }


### PR DESCRIPTION
## Description

At present, the code for accessing menu entry parameters is rather inefficient:

- The char array members of the `menu_entry_t` struct are allocated dynamically via `strdup()`. Moreover, most of the `menu_entry_get_*()` functions (interface for accessing members of a populated  `menu_entry_t` object) rely on further string duplication. This means we create and destroy an enormous number of strings every frame for no good reason whatsoever.

- `menu_entry_get()` (the main function we have to use for accessing menu entry parameters) is currently monolithic - i.e. it fetches every parameter regardless of whether we need it. For example: both Ozone and GLUI have a separate pass that runs through all entries in order to determine correct entry draw height - the only parameter needed here is the sublabel, but we also have to fetch path, label, rich label and value, all of which are discarded. Another example: both XMB and RGUI only show sublabels for the currently selected entry, but we have to fetch (and discard) sublabels for every entry on screen.

This PR makes the following changes:

- `menu_entry_t` char arrays are now allocated statically, and populated via `strlcpy()`

- The `menu_entry_get_*()` functions now all 'return' pointers to existing char arrays within the parent `menu_entry_t` object

- A mechanism is provided for disabling unwanted parameters when calling `menu_entry_get()`

This provides a nice performance boost both to menu rendering (10% improvement in the case of RGUI, 5% in the case of Ozone) and menu navigation.

It also means that RGUI and XMB now only fetch one menu sublabel at a time - which has the bonus of almost completely mitigating the performance overheads of displaying content runtime in playlists.

Finally, there is a safety benefit - fewer `strdup()`s means less chance of memory leaks  :)