### PR TITLE
filestream_exists() -> path_is_valid() replacements

### DIFF
--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -29,7 +29,6 @@
 #include <formats/image.h>
 #include <gfx/math/matrix_4x4.h>
 #include <string/stdstring.h>
-#include <streams/file_stream.h>
 #include <lists/string_list.h>
 #include <encodings/utf.h>
 
@@ -1884,7 +1883,7 @@ static void materialui_context_reset(void *data, bool is_threaded)
    menu_display_allocate_white_texture();
    materialui_context_reset_textures(mui);
 
-   if (filestream_exists(settings->paths.path_menu_wallpaper))
+   if (path_is_valid(settings->paths.path_menu_wallpaper))
       task_push_image_load(settings->paths.path_menu_wallpaper,
             video_driver_supports_rgba(),
             menu_display_handle_wallpaper_upload, NULL);

--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -31,7 +31,6 @@
 #include <file/file_path.h>
 #include <string/stdstring.h>
 #include <encodings/utf.h>
-#include <streams/file_stream.h>
 #include <features/features_cpu.h>
 #include <formats/image.h>
 #include <math/float_minmax.h>
@@ -410,7 +409,7 @@ static void ozone_update_thumbnail_image(void *data)
 
    if (menu_thumbnail_get_path(ozone->thumbnail_path_data, MENU_THUMBNAIL_RIGHT, &right_thumbnail_path))
    {
-      if (filestream_exists(right_thumbnail_path))
+      if (path_is_valid(right_thumbnail_path))
          task_push_image_load(right_thumbnail_path,
                supports_rgba,
                menu_display_handle_thumbnail_upload, NULL);
@@ -427,7 +426,7 @@ static void ozone_update_thumbnail_image(void *data)
 
    if (menu_thumbnail_get_path(ozone->thumbnail_path_data, MENU_THUMBNAIL_LEFT, &left_thumbnail_path))
    {
-      if (filestream_exists(left_thumbnail_path))
+      if (path_is_valid(left_thumbnail_path))
          task_push_image_load(left_thumbnail_path,
                supports_rgba,
                menu_display_handle_left_thumbnail_upload, NULL);

--- a/menu/drivers/ozone/ozone_sidebar.c
+++ b/menu/drivers/ozone/ozone_sidebar.c
@@ -25,7 +25,6 @@
 
 #include <string/stdstring.h>
 #include <file/file_path.h>
-#include <streams/file_stream.h>
 
 #include "../../menu_animation.h"
 
@@ -621,7 +620,7 @@ void ozone_context_reset_horizontal_list(ozone_handle_t *ozone)
 
          /* If the playlist icon doesn't exist return default */
 
-         if (!filestream_exists(texturepath))
+         if (!path_is_valid(texturepath))
                fill_pathname_join_concat(texturepath, icons_path, "default",
                file_path_str(FILE_PATH_PNG_EXTENSION),
                PATH_MAX_LENGTH * sizeof(char));
@@ -652,7 +651,7 @@ void ozone_context_reset_horizontal_list(ozone_handle_t *ozone)
          strlcat(content_texturepath, sysname, PATH_MAX_LENGTH * sizeof(char));
 
          /* If the content icon doesn't exist return default-content */
-         if (!filestream_exists(content_texturepath))
+         if (!path_is_valid(content_texturepath))
          {
             strlcat(icons_path, path_default_slash(), PATH_MAX_LENGTH * sizeof(char));
             strlcat(icons_path, "default", PATH_MAX_LENGTH * sizeof(char));

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -59,7 +59,6 @@
 
 /* Thumbnail additions */
 #include "../menu_thumbnail_path.h"
-#include <streams/file_stream.h>
 #include "../../tasks/tasks_internal.h"
 #include <gfx/scaler/scaler.h>
 #include <features/features_cpu.h>
@@ -1611,7 +1610,7 @@ static bool request_thumbnail(
    if (!string_is_empty(path))
    {
       thumbnail->path = strdup(path);
-      if (filestream_exists(path))
+      if (path_is_valid(path))
       {
          /* Would like to cancel any existing image load tasks
           * here, but can't see how to do it... */
@@ -2144,7 +2143,7 @@ static void load_custom_theme(rgui_t *rgui, rgui_theme_t *theme_colors, const ch
    /* Sanity check */
    if (string_is_empty(theme_path))
       goto end;
-   if (!filestream_exists(theme_path))
+   if (!path_is_valid(theme_path))
       goto end;
 
    /* Open config file */

--- a/runtime_file.c
+++ b/runtime_file.c
@@ -435,7 +435,7 @@ runtime_log_t *runtime_log_init(const char *content_path,
    strlcpy(runtime_log->path, log_file_path, sizeof(runtime_log->path));
    
    /* Load existing log file, if it exists */
-   if (filestream_exists(runtime_log->path))
+   if (path_is_valid(runtime_log->path))
       runtime_log_read_file(runtime_log);
    
    return runtime_log;

--- a/tasks/task_pl_thumbnail_download.c
+++ b/tasks/task_pl_thumbnail_download.c
@@ -22,7 +22,6 @@
 
 #include <string/stdstring.h>
 #include <file/file_path.h>
-#include <streams/file_stream.h>
 #include <net/net_http.h>
 
 #include "tasks_internal.h"
@@ -181,7 +180,7 @@ static void download_pl_thumbnail(pl_thumb_handle_t *pl_thumb)
    if (get_thumbnail_paths(pl_thumb, path, sizeof(path), url, sizeof(url)))
    {
       /* Only download missing thumbnails */
-      if (!filestream_exists(path) || pl_thumb->overwrite)
+      if (!path_is_valid(path) || pl_thumb->overwrite)
       {
          file_transfer_t *transf = (file_transfer_t*)calloc(1, sizeof(file_transfer_t));
          if (!transf)
@@ -262,7 +261,7 @@ static void task_pl_thumbnail_download_handler(retro_task_t *task)
       case PL_THUMB_BEGIN:
          {
             /* Load playlist */
-            if (!filestream_exists(pl_thumb->playlist_path))
+            if (!path_is_valid(pl_thumb->playlist_path))
                goto task_finished;
             
             pl_thumb->playlist = playlist_init(pl_thumb->playlist_path, COLLECTION_SIZE);
@@ -519,13 +518,13 @@ static void cb_task_pl_entry_thumbnail_refresh_menu(
    if (!pl_thumb->right_thumbnail_exists || pl_thumb->overwrite)
       if (menu_thumbnail_update_path(pl_thumb->thumbnail_path_data, MENU_THUMBNAIL_RIGHT))
          if (menu_thumbnail_get_path(pl_thumb->thumbnail_path_data, MENU_THUMBNAIL_RIGHT, &thumbnail_path))
-            do_refresh = filestream_exists(thumbnail_path);
+            do_refresh = path_is_valid(thumbnail_path);
    
    if (!do_refresh)
       if (!pl_thumb->left_thumbnail_exists || pl_thumb->overwrite)
          if (menu_thumbnail_update_path(pl_thumb->thumbnail_path_data, MENU_THUMBNAIL_LEFT))
             if (menu_thumbnail_get_path(pl_thumb->thumbnail_path_data, MENU_THUMBNAIL_LEFT, &left_thumbnail_path))
-               do_refresh = filestream_exists(left_thumbnail_path);
+               do_refresh = path_is_valid(left_thumbnail_path);
    
    if (do_refresh)
       menu_driver_ctl(RARCH_MENU_CTL_REFRESH_THUMBNAIL_IMAGE, NULL);
@@ -586,12 +585,12 @@ static void task_pl_entry_thumbnail_download_handler(retro_task_t *task)
             pl_thumb->right_thumbnail_exists = false;
             if (menu_thumbnail_update_path(pl_thumb->thumbnail_path_data, MENU_THUMBNAIL_RIGHT))
                if (menu_thumbnail_get_path(pl_thumb->thumbnail_path_data, MENU_THUMBNAIL_RIGHT, &right_thumbnail_path))
-                  pl_thumb->right_thumbnail_exists = filestream_exists(right_thumbnail_path);
+                  pl_thumb->right_thumbnail_exists = path_is_valid(right_thumbnail_path);
             
             pl_thumb->left_thumbnail_exists = false;
             if (menu_thumbnail_update_path(pl_thumb->thumbnail_path_data, MENU_THUMBNAIL_LEFT))
                if (menu_thumbnail_get_path(pl_thumb->thumbnail_path_data, MENU_THUMBNAIL_LEFT, &left_thumbnail_path))
-                  pl_thumb->left_thumbnail_exists = filestream_exists(left_thumbnail_path);
+                  pl_thumb->left_thumbnail_exists = path_is_valid(left_thumbnail_path);
             
             /* Set task title */
             task_free_title(task);


### PR DESCRIPTION
## Description

This PR replaces the function `filestream_exists()` with `path_is_valid()` in the following files:

`menu/drivers/materialui.c`
`menu/drivers/ozone/ozone.c`
`menu/drivers/ozone/ozone_sidebar.c`
`menu/drivers/rgui.c`
`runtime_file.c`
`tasks/task_pl_thumbnail_download.c`

(Note that this was already done for `menu/drivers/xmb.c` by commit 2c6ca885754690f864c3b6ccc04141d2621ba6dd)

The two functions are 'functionally' identical, but `filestream_exists()` has an increased performance overhead of **11,500%** vs `path_is_valid()`.

This is not necessarily noticeable on modern desktop platforms, but it makes a difference on devices with slow storage (consoles, etc.)