### PR TITLE
(wgl_ctx) set GFX_CTX_FLAGS_SHADERS_SLANG for glcore

### DIFF
--- a/gfx/drivers_context/wgl_ctx.c
+++ b/gfx/drivers_context/wgl_ctx.c
@@ -816,7 +816,12 @@ static uint32_t gfx_ctx_wgl_get_flags(void *data)
          }
 
          if (string_is_equal(video_driver_get_ident(), "gl1")) { }
-         else if (string_is_equal(video_driver_get_ident(), "glcore")) { }
+         else if (string_is_equal(video_driver_get_ident(), "glcore"))
+         {
+#ifdef HAVE_SLANG
+         BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_SLANG);
+#endif
+         }
          else
          {
 #ifdef HAVE_CG


### PR DESCRIPTION
Simple fix for [Shaders not loaded properly when RetroArch is started trough command-line (glcore) ](https://github.com/libretro/RetroArch/issues/8834)