### PR TITLE
Fix shaders init with glcore + kms.

### DIFF
--- a/gfx/drivers_context/drm_ctx.c
+++ b/gfx/drivers_context/drm_ctx.c
@@ -909,7 +909,12 @@ static uint32_t gfx_ctx_drm_get_flags(void *data)
    if (drm->core_hw_context_enable)
       BIT32_SET(flags, GFX_CTX_FLAGS_GL_CORE_CONTEXT);
 
-   BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_GLSL);
+   if (string_is_equal(video_driver_get_ident(), "glcore"))
+#ifdef HAVE_SLANG
+      BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_SLANG);
+#endif
+   else
+      BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_GLSL);
 
    return flags;
 }


### PR DESCRIPTION
## Description

When using `glcore` + a `KMS` context shaders will not init when starting content from the command-line, now they will.

## Related Issues

See https://github.com/libretro/RetroArch/issues/8834

## Related Pull Requests

Same fix as in PR https://github.com/libretro/RetroArch/pull/8894.