### PR TITLE
Fix the OpenGLES3 build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ matrix:
       env: DISABLE_MENU=1 CC=gcc-8 CXX=g++-8
     - compiler: gcc
       env: ENABLE_GLES=1 CC=gcc-8 CXX=g++-8
+    - compiler: gcc
+      env: ENABLE_GLES=1 ENABLE_GLES3=1 CC=gcc-8 CXX=g++-8
     - compiler: clang
       env: CC=clang-6.0 CXX=clang++-6.0
     - compiler: clang

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -348,6 +348,7 @@ else
    HAVE_OPENGL='no'
 fi
 
+check_enabled EGL OPENGLES3 OpenGLES3 'EGL is' false
 check_enabled OPENGL CG Cg 'OpenGL is' false
 check_enabled OPENGL OSMESA osmesa 'OpenGL is' false
 check_enabled OPENGL OPENGL1 OpenGL1 'OpenGL is' false


### PR DESCRIPTION
## Description

This adds back the travis GLES3 build which depends on EGL and adds a configure check to make this fact more obvious in the future.

## Related Issues

Enables checking gles3 builds with travis again.

## Related Pull Requests

This reverts commit 678089c2dec04e3cdf1aefade73a13fa07bb1d9f.

The issue was really fixed in PR https://github.com/libretro/RetroArch/pull/8892.