### PR TITLE
qb: Log the configure arguments in config.log.

### DIFF
--- a/qb/qb.params.sh
+++ b/qb/qb.params.sh
@@ -68,6 +68,8 @@ opt_exists() # $opt is returned if exists in OPTS
 parse_input() # Parse stuff :V
 {	BUILD=''
 	OPTS=''
+	config_opts='./configure'
+
 	while read -r VAR _; do
 		TMPVAR="${VAR%=*}"
 		NEWVAR="${TMPVAR##HAVE_}"
@@ -78,6 +80,7 @@ parse_input() # Parse stuff :V
 	#things in opt_exists()
 
 	while [ $# -gt 0 ]; do
+		config_opts="${config_opts} $1"
 		case "$1" in
 			--prefix=*) PREFIX=${1##--prefix=};;
 			--global-config-dir=*|--sysconfdir=*) GLOBAL_CONFIG_DIR="${1#*=}";;
@@ -110,6 +113,17 @@ parse_input() # Parse stuff :V
 		esac
 		shift
 	done
+
+	cat > config.log << EOF
+Command line invocation:
+
+  \$ ${config_opts}
+
+## ----------- ##
+## Core Tests. ##
+## ----------- ##
+
+EOF
 }
 
 . qb/config.params.sh


### PR DESCRIPTION
## Description

This logs the configure command line arguments to `config.log` for easier debugging.

With this patch and when using no command line arguments it will prefix `config.log` with:
```
Command line invocation:

  $ ./configure

## ----------- ##
## Core Tests. ##
## ----------- ##

```
Or in the case of my own build script that uses many command line arguments.
```
Command line invocation:

  $ ./configure --prefix=/usr --bindir=/usr/games --mandir=/usr/man --docdir=/usr/doc/RetroArch-2019.06.02_cc22680 --with-assets_dir=/usr/share/games --disable-update_assets --build=x86_64-slackware-linux --disable-discord --enable-caca --disable-builtinflac --enable-sixel --disable-builtinzlib --disable-builtinmbedtls --disable-builtinminiupnpc

## ----------- ##
## Core Tests. ##
## ----------- ##

```
Below will be the regular output that already exists in `config.log`. This will have no effect on the actual build besides a more useful `config.log`.
