### PR TITLE
Fix --disable-menu.

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -367,8 +367,6 @@ static bool xmb_shadows_enable   = true;
 #endif
 #endif
 
-static bool automatically_add_content_to_playlist = false;
-
 static float menu_framebuffer_opacity = 0.900;
 
 static float menu_wallpaper_opacity = 0.300;
@@ -399,9 +397,10 @@ static unsigned rgui_particle_effect = RGUI_PARTICLE_EFFECT_NONE;
 static bool rgui_extended_ascii = false;
 
 #else
-static bool default_block_config_read = false;
-static bool automatically_add_content_to_playlist = false;
+#define DEFAULT_BLOCK_CONFIG_READ false
 #endif
+
+static bool automatically_add_content_to_playlist = false;
 
 static bool default_game_specific_options = true;
 static bool default_auto_overrides_enable = true;


### PR DESCRIPTION
## Description

Fixes `--disable-menu` and removes a duplicate variable which was set to the same value twice for different code paths.

## Related Issues

```
CC configuration.c
configuration.c: In function ‘config_set_defaults’:
configuration.c:2367:8: error: ‘DEFAULT_BLOCK_CONFIG_READ’ undeclared (first use in this function); did you mean ‘RARCH_CTL_IS_BLOCK_CONFIG_READ’?
    if (DEFAULT_BLOCK_CONFIG_READ)
        ^~~~~~~~~~~~~~~~~~~~~~~~~
        RARCH_CTL_IS_BLOCK_CONFIG_READ
configuration.c:2367:8: note: each undeclared identifier is reported only once for each function it appears in
make: *** [obj-unix/release/configuration.o] Error 1
```

## Related Pull Requests

Accidentally broken in commit https://github.com/libretro/RetroArch/commit/7ea2034922bf8307e8dee1bb9855edb4c96b4405
