### PR TITLE
(WiiU) Colour and transparency fixes for texture menus (RGUI)

### DIFF
--- a/gfx/drivers/gx2_gfx.c
+++ b/gfx/drivers/gx2_gfx.c
@@ -371,7 +371,7 @@ static void *wiiu_gfx_init(const video_info_t *video,
    wiiu->menu.v->coord.v = 0.0f;
    wiiu->menu.v->coord.width = 1.0f;
    wiiu->menu.v->coord.height = 1.0f;
-   wiiu->menu.v->color = 0xFFFFFF80;
+   wiiu->menu.v->color = 0xFFFFFFFF;
    GX2Invalidate(GX2_INVALIDATE_MODE_CPU_ATTRIBUTE_BUFFER, wiiu->menu.v, 4 * sizeof(*wiiu->menu.v));
 
    wiiu->vertex_cache.size       = 0x1000;

--- a/gfx/drivers/gx2_gfx.c
+++ b/gfx/drivers/gx2_gfx.c
@@ -333,7 +333,8 @@ static void *wiiu_gfx_init(const video_info_t *video,
    wiiu->menu.texture.surface.format   = GX2_SURFACE_FORMAT_UNORM_R4_G4_B4_A4;
    wiiu->menu.texture.surface.tileMode = GX2_TILE_MODE_LINEAR_ALIGNED;
    wiiu->menu.texture.viewNumSlices    = 1;
-   wiiu->menu.texture.compMap          = GX2_COMP_SEL(_A, _R, _G, _B);
+   /* Presumably an endian thing. RGBA, but swap R and G, then B and A. */
+   wiiu->menu.texture.compMap          = GX2_COMP_SEL(_G, _R, _A, _B);
    GX2CalcSurfaceSizeAndAlignment(&wiiu->menu.texture.surface);
    GX2InitTextureRegs(&wiiu->menu.texture);
 


### PR DESCRIPTION
As the title says, this fixes up some colour format stuff for rgui, and also draws it without adding extra unwanted transparency.
Thanks!
-Ash