### PR TITLE
Add missing rcheevos include.

### DIFF
--- a/pkg/apple/RetroArch_iOS11.xcodeproj/project.pbxproj
+++ b/pkg/apple/RetroArch_iOS11.xcodeproj/project.pbxproj
@@ -893,6 +893,7 @@
 					../../,
 					"../../libretro-common/include",
 					../../deps/stb,
+					../../deps/rcheevos/include,
 					../../deps/libz,
 					../../deps,
 				);


### PR DESCRIPTION
## Description

Fixes a compile issue for the apple TVOs.

## Related Issues

```
RetroArch/deps/rcheevos/src/rcheevos/internal.h:5:10: 'rcheevos.h' file not found
```
Fixes https://github.com/libretro/RetroArch/issues/8899.

## Reviewers

This was tested by the OP of the related issue.
