### PR TITLE
glcore fix wrong rotation with HW cores

### DIFF
--- a/gfx/drivers/gl_core.c
+++ b/gfx/drivers/gl_core.c
@@ -1419,7 +1419,7 @@ static void gl_core_set_rotation(void *data, unsigned rotation)
    if (!gl)
       return;
 
-   gl->rotation = 270 * rotation;
+   gl->rotation = video_driver_is_hw_context() ? 90 * rotation : 270 * rotation;
    gl_core_set_projection(gl, &gl_core_default_ortho, true);
 }
 


### PR DESCRIPTION
Desmume in opengl still rotates in the opposite direction...
All other HW cores are fine.