### PR TITLE
glcore rotation fix for desmume

### DIFF
--- a/gfx/drivers/gl_core.c
+++ b/gfx/drivers/gl_core.c
@@ -1419,7 +1419,7 @@ static void gl_core_set_rotation(void *data, unsigned rotation)
    if (!gl)
       return;
 
-   gl->rotation = video_driver_is_hw_context() ? 90 * rotation : 270 * rotation;
+   gl->rotation = video_driver_is_hw_context() && gl->hw_render_bottom_left ? 90 * rotation : 270 * rotation;
    gl_core_set_projection(gl, &gl_core_default_ortho, true);
 }
 


### PR DESCRIPTION
Works for "not bottom_left origin" too now.