### PR TITLE
make shader presets use relative paths

### DIFF
--- a/gfx/video_shader_parse.h
+++ b/gfx/video_shader_parse.h
@@ -183,14 +183,17 @@ bool video_shader_read_conf_cgp(config_file_t *conf,
 
 /**
  * video_shader_write_conf_cgp:
- * @conf              : Preset file to read from.
+ * @conf              : Preset file to write to.
  * @shader            : Shader passes handle.
+ * @preset_path       : Optional path to where the preset will be written.
  *
  * Saves preset and all associated state (passes,
  * textures, imports, etc) to disk.
+ * If @preset_path is not NULL, shader paths are saved
+ * relative to it.
  **/
 void video_shader_write_conf_cgp(config_file_t *conf,
-      struct video_shader *shader);
+      struct video_shader *shader, const char *preset_path);
 
 /**
  * video_shader_resolve_relative:

--- a/libretro-common/include/file/file_path.h
+++ b/libretro-common/include/file/file_path.h
@@ -150,10 +150,27 @@ void path_parent_dir(char *path);
  * @buf                : buffer for path
  * @size               : size of buffer
  *
- * Turns relative paths into absolute path.
+ * Turns relative paths into absolute paths and
+ * resolves use of "." and ".." in absolute paths.
  * If relative, rebases on current working dir.
  **/
 void path_resolve_realpath(char *buf, size_t size);
+
+/**
+ * path_relative_to:
+ * @out                : buffer to write the relative path to
+ * @path               : path to be expressed relatively
+ * @base               : relative to this
+ * @size               : size of output buffer
+ *
+ * Turns @path into a path relative to @base and writes it to @out.
+ *
+ * @base is assumed to be a base directory, i.e. a path ending with '/' or '\'.
+ * Both @path and @base are assumed to be absolute paths without "." or "..".
+ *
+ * E.g. path /a/b/e/f.cgp with base /a/b/c/d/ turns into ../../e/f.cgp
+ **/
+void path_relative_to(char *out, const char *path, const char *base, size_t size);
 
 /**
  * path_is_absolute:

--- a/menu/menu_shader.c
+++ b/menu/menu_shader.c
@@ -316,12 +316,12 @@ bool menu_shader_manager_save_preset(
    if (!conf)
       return false;
 
-   video_shader_write_conf_cgp(conf, shader);
-
    if (fullpath)
    {
       if (!string_is_empty(basename))
          strlcpy(preset_path, buffer, sizeof(preset_path));
+
+      video_shader_write_conf_cgp(conf, shader, preset_path);
 
       if (config_file_write(conf, preset_path, false))
       {
@@ -342,6 +342,8 @@ bool menu_shader_manager_save_preset(
 
          fill_pathname_join(preset_path, dirs[d],
                buffer, sizeof(preset_path));
+
+         video_shader_write_conf_cgp(conf, shader, preset_path);
 
          if (config_file_write(conf, preset_path, false))
          {


### PR DESCRIPTION
## Description

This is not thoroughly tested. It seems to work on Windows and should on Linux too, not sure about any other system.

I also made it so that `path_relative_to()` always uses the `'/'` directory separator instead of `path_default_slash()`, because that works on Windows too and shader files with `'\'` might not be portable.

## Related Issues

Implements #1326, it's about time!