### PR TITLE
qb: Add missing checks for EGL support.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -99,6 +99,7 @@ if [ "$HAVE_FLOATSOFTFP" = "yes" ]; then
 fi
 
 if [ "$HAVE_EGL" != "no" ] && [ "$OS" != 'Win32' ]; then
+   check_header EGL EGL/egl.h EGL/eglext.h
    # some systems have EGL libs, but no pkgconfig
    # https://github.com/linux-sunxi/sunxi-mali/pull/8
    check_val '' EGL "-l${VC_PREFIX}EGL $EXTRA_GL_LIBS" '' "${VC_PREFIX}egl" '' '' true
@@ -353,6 +354,7 @@ else
    HAVE_OPENGL='no'
 fi
 
+check_enabled EGL OPENGLES OpenGLES 'EGL is' false
 check_enabled EGL OPENGLES3 OpenGLES3 'EGL is' false
 check_enabled OPENGL CG Cg 'OpenGL is' false
 check_enabled OPENGL OSMESA osmesa 'OpenGL is' false


### PR DESCRIPTION
## Description

Some systems may have egl libraries, but not egl headers which will result in failing to build EGL support.

Also OpenGLES2 also required EGL support so lets make that clear.

## Related Issues

Doesn't attempt to build EGL support when `EGL/egl.h` or `EGL/eglext.h` is missing.
