### PR TITLE
travis: Test darwin builds with qb.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ matrix:
     - compiler: clang
       env: CXX_BUILD=1 CC=clang-6.0 CXX=clang++-6.0
     - os: osx
+      env: CC=clang CXX=clang++
+    - os: osx
       osx_image: xcode8
       script:
         - xcodebuild -target RetroArch -configuration Release -project pkg/apple/RetroArch.xcodeproj


### PR DESCRIPTION
## Description

There is a Darwin code path in the qb configure scripts and as far as I can tell it has not been tested heavily in a long time.

This will expose this code path for travis builds with only clang which will make it easier to test qb changes without breaking Darwin support. I am surprised that this hasn't already happened...

Some things to note are.

* It appears gcc is really clang on macOS.
* Both C89_BUILD and CXX_BUILD were ommitted because they are broken in ways I can not fix. In the event any interested parties wish to fix these issues they can be easily added.
* This will use the default macOS version available with travis which is currently 10.13. Other version(s) can be specified if desired, I am not sure which versions are best to test. See the following link for more details.

https://docs.travis-ci.com/user/reference/osx#macos-version

It might be nice if someone with osx actually tested builds like this. It might be missing features like metal however...

## Reviewers

Wait for travis to succeed.
