### PR TITLE
allow saving and properly loading 0 pass shader presets

### DIFF
--- a/gfx/video_shader_parse.c
+++ b/gfx/video_shader_parse.c
@@ -737,12 +737,6 @@ bool video_shader_read_conf_cgp(config_file_t *conf,
       return false;
    }
 
-   if (!shaders)
-   {
-      RARCH_ERR("Need to define at least 1 shader.\n");
-      return false;
-   }
-
    if (!config_get_int(conf, "feedback_pass",
             &shader->feedback_pass))
       shader->feedback_pass = -1;

--- a/menu/menu_shader.c
+++ b/menu/menu_shader.c
@@ -451,13 +451,16 @@ void menu_shader_manager_clear_pass_path(unsigned i)
  **/
 unsigned menu_shader_manager_get_type(const void *data)
 {
-   unsigned type                     = RARCH_SHADER_NONE;
+   enum rarch_shader_type type;
    const struct video_shader *shader = (const struct video_shader*)data;
    /* All shader types must be the same, or we cannot use it. */
    uint8_t i                         = 0;
 
    if (!shader)
       return RARCH_SHADER_NONE;
+
+   type = video_shader_parse_type(shader->path,
+         RARCH_SHADER_NONE);
 
    for (i = 0; i < shader->passes; i++)
    {
@@ -470,9 +473,7 @@ unsigned menu_shader_manager_get_type(const void *data)
          case RARCH_SHADER_CG:
          case RARCH_SHADER_GLSL:
          case RARCH_SHADER_SLANG:
-            if (type == RARCH_SHADER_NONE)
-               type = pass_type;
-            else if (type != pass_type)
+            if (type != pass_type)
                return RARCH_SHADER_NONE;
             break;
          default:
@@ -498,7 +499,7 @@ void menu_shader_manager_apply_changes(void)
 
    shader_type = menu_shader_manager_get_type(shader);
 
-   if (shader->passes && shader_type != RARCH_SHADER_NONE)
+   if (shader_type != RARCH_SHADER_NONE)
    {
       menu_shader_manager_save_preset(NULL, true, false);
       return;


### PR DESCRIPTION
## Description

Shader presets with 0 passes can be thought of as a kind of "no shader" preset, which are useful for overriding more general presets, e.g. overriding a folder preset by a game preset.

## Implementation

The change in `menu_shader_manager_get_type()` only has an effect in `menu_shader_manager_save_preset()`:
https://github.com/libretro/RetroArch/blob/53c91d6e5628fa90912269255a94f749e983e2fd/menu/menu_shader.c#L240-L243
This will now not trigger for 0 pass shaders and thus save the preset.

The change in `video_shader_read_conf_cgp()` ensures that loaded 0 pass presets are properly setup, i.e. have a `path` so that `video_shader_parse_type()` can parse the type.

## Possible bugs

This change might cause issues if a video driver's `init()` doesn't handle 0 pass shaders well, which is unlikely.

## Related Issues

See discussion in #5398.