### PR TITLE
(RGUI) Enable playlist display on platforms without database support

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -6639,13 +6639,19 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
             }
          }
 
-#ifdef HAVE_LIBRETRODB
-         if (menu_entries_append_enum(info->list,
-               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLISTS_TAB),
-               msg_hash_to_str(MENU_ENUM_LABEL_PLAYLISTS_TAB),
-               MENU_ENUM_LABEL_PLAYLISTS_TAB,
-               MENU_SETTING_ACTION, 0, 0))
-            count++;
+#ifndef HAVE_LIBRETRODB
+         {
+            settings_t *settings = config_get_ptr();
+            if (settings->bools.menu_show_advanced_settings)
+#endif
+               if (menu_entries_append_enum(info->list,
+                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLISTS_TAB),
+                     msg_hash_to_str(MENU_ENUM_LABEL_PLAYLISTS_TAB),
+                     MENU_ENUM_LABEL_PLAYLISTS_TAB,
+                     MENU_SETTING_ACTION, 0, 0))
+                  count++;
+#ifndef HAVE_LIBRETRODB
+         }
 #endif
 
          if (frontend_driver_parse_drive_list(info->list, true) != 0)
@@ -7171,15 +7177,19 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                      MENU_ENUM_LABEL_LOAD_CONTENT_HISTORY,
                      PARSE_ACTION, false) == 0)
                   count++;
-#ifdef HAVE_LIBRETRODB
-            if (string_is_equal(settings->arrays.menu_driver, "rgui") && settings->bools.menu_content_show_playlists)
+
+            if (string_is_equal(settings->arrays.menu_driver, "rgui") &&
+#ifndef HAVE_LIBRETRODB
+                settings->bools.menu_show_advanced_settings &&
+#endif
+                settings->bools.menu_content_show_playlists)
                if (menu_entries_append_enum(info->list,
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLISTS_TAB),
                      msg_hash_to_str(MENU_ENUM_LABEL_PLAYLISTS_TAB),
                      MENU_ENUM_LABEL_PLAYLISTS_TAB,
                      MENU_SETTING_ACTION, 0, 0))
                   count++;
-#endif
+
             if (settings->bools.menu_content_show_add)
                if (menu_displaylist_parse_settings_enum(info->list,
                      MENU_ENUM_LABEL_ADD_CONTENT_LIST,


### PR DESCRIPTION
## Description

At present, and by default, XMB, Ozone and GLUI will all display existing playlists regardless of whether the current platform has database support (`HAVE_LIBRETRODB`). RGUI has no such option. Given that playlists can be created by hand, or via any number of external tools, this is an unnecessary and artificial limitation that really hamstrings RetroArch on platforms like the Wii and PSP (where database support is disabled, and RGUI is the only menu driver).

This PR very simply allows the 'main menu' and 'load content' playlists entries to be shown when using RGUI on platforms without database support. However: since this is intended for 'power users' (who can make their own playlists), the entries are hidden (on platforms without database support) unless the menu option `Show Advanced Settings` is enabled.