### PR TITLE
(Wii) Fix recursive path_mkdir() operations

### DIFF
--- a/libretro-common/file/file_path.c
+++ b/libretro-common/file/file_path.c
@@ -205,6 +205,20 @@ bool path_mkdir(const char *dir)
       return false;
    }
 
+#if defined(GEKKO)
+   {
+      size_t len = strlen(basedir);
+
+      /* path_parent_dir() keeps the trailing slash.
+       * On Wii, mkdir() fails if the path has a
+       * trailing slash...
+       * We must therefore remove it. */
+      if (len > 0)
+         if (basedir[len - 1] == '/')
+            basedir[len - 1] = '\0';
+   }
+#endif
+
    if (path_is_directory(basedir))
       norecurse = true;
    else


### PR DESCRIPTION
## Description

At present, all recursive `path_mkdir()` operations currently fail on the Wii build. This is because mkdir only works on the Wii if the provided path *does not* have a trailing slash (which `path_mkdir()` always includes when handling base/parent directories).

The most immediate consequence of this is that runtime logging (by default) fails on the Wii, because on first run it tries to create the directory `<playlists_dir>/logs/<core_name>` - this is recursive, so it's a non-starter. The user has to manually set the runtime log directory to an existing folder before logs will be enabled.

This PR fixes `path_mkdir()` for GEKKO builds such that base/parent directory trailing slashes are removed. Runtime logging therefore now functions correctly by default (this may fix other issues too, but I haven't noticed any other situation where recursive `path_mkdir()`s happen on the Wii...)