### PR TITLE
(Wii) Add widescreen RGUI support

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -11120,7 +11120,6 @@ static bool setting_append_list(
                (*list)[list_info->index - 1].ui_type   = ST_UI_TYPE_UINT_COMBOBOX;
             }
 
-#if !defined(GEKKO)
             CONFIG_UINT(
                   list, list_info,
                   &settings->uints.menu_rgui_aspect_ratio,
@@ -11136,7 +11135,6 @@ static bool setting_append_list(
                (*list)[list_info->index - 1].get_string_representation =
                   &setting_get_string_representation_uint_rgui_aspect_ratio;
             menu_settings_list_current_add_range(list, list_info, 0, RGUI_ASPECT_RATIO_LAST-1, 1, true, true);
-#endif
 
             CONFIG_UINT(
                   list, list_info,
@@ -11152,7 +11150,11 @@ static bool setting_append_list(
                (*list)[list_info->index - 1].action_ok = &setting_action_ok_uint;
                (*list)[list_info->index - 1].get_string_representation =
                   &setting_get_string_representation_uint_rgui_aspect_ratio_lock;
+#if defined(GEKKO)
+            menu_settings_list_current_add_range(list, list_info, 0, RGUI_ASPECT_RATIO_LOCK_LAST-2, 1, true, true);
+#else
             menu_settings_list_current_add_range(list, list_info, 0, RGUI_ASPECT_RATIO_LOCK_LAST-1, 1, true, true);
+#endif
             (*list)[list_info->index - 1].ui_type   = ST_UI_TYPE_UINT_COMBOBOX;
 
             CONFIG_UINT(


### PR DESCRIPTION
## Description

At present, the Wii port sets the RGUI framebuffer to an essentially arbitrary size - with an aspect sort of 4:3, but not necessarily so, depending upon video settings etc. This means that the RGUI display aspect ratio is always wrong to some degree, and we are stuck with a square or stretched image when using the Wii port on a widescreen TV.

This PR enables the RGUI setting `Menu Aspect Ratio` for the Wii port, so it now has 'proper' widescreen support (like all the other builds). The setting `Lock Menu Aspect Ratio` has also been fixed, accounting for the Wii's use of anamorphic widescreen (although the `Integer Scale` aspect ratio lock option is disabled for the Wii, since the way the framebuffer is set up means that only the `Fit Screen` setting is of use). All of this should Just Work (TM), regardless of video settings.

Here are some examples (excuse the crappy photos):

- `Menu Aspect Ratio`: `4:3`

![4-3](https://user-images.githubusercontent.com/38211560/59284029-77bc7080-8c63-11e9-815d-4d2c7519eb58.png)

- `Menu Aspect Ratio`: `16:10`

![16-10](https://user-images.githubusercontent.com/38211560/59284050-8145d880-8c63-11e9-8a3c-10e4b0f2bb06.png)


- `Menu Aspect Ratio`: `16:9`

![16-9](https://user-images.githubusercontent.com/38211560/59284071-8a36aa00-8c63-11e9-957a-9fd9a7bbb9f7.png)

As a bonus, now that we use 'standard' menu framebuffer sizes whenever possible, custom wallpaper themes are supported for most video resolution settings - e.g.:

![wallpaper_1](https://user-images.githubusercontent.com/38211560/59284233-d2ee6300-8c63-11e9-81e5-70173a004467.png)

![wallpaper_2](https://user-images.githubusercontent.com/38211560/59284240-d71a8080-8c63-11e9-8fb4-db8b02049487.png)
