### PR TITLE
iOS/Android: Support detecting multi-touch input

### DIFF
--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -1469,6 +1469,8 @@ static int16_t android_input_state(void *data,
                return (idx < android->pointer_count) &&
                   (android->pointer[idx].x != -0x8000) &&
                   (android->pointer[idx].y != -0x8000);
+            case RETRO_DEVICE_ID_POINTER_COUNT:
+               return android->pointer_count;
             case RARCH_DEVICE_ID_POINTER_BACK:
             {
                const struct retro_keybind *keyptr = &input_autoconf_binds[0][RARCH_MENU_TOGGLE];
@@ -1488,6 +1490,8 @@ static int16_t android_input_state(void *data,
                return (idx < android->pointer_count) &&
                   (android->pointer[idx].full_x != -0x8000) &&
                   (android->pointer[idx].full_y != -0x8000);
+            case RETRO_DEVICE_ID_POINTER_COUNT:
+               return android->pointer_count;
             case RARCH_DEVICE_ID_POINTER_BACK:
                {
                   const struct retro_keybind *keyptr = &input_autoconf_binds[0][RARCH_MENU_TOGGLE];

--- a/input/drivers/cocoa_input.c
+++ b/input/drivers/cocoa_input.c
@@ -281,6 +281,8 @@ static int16_t cocoa_pointer_state(cocoa_input_data_t *apple,
             return x;
          case RETRO_DEVICE_ID_POINTER_Y:
             return y;
+         case RETRO_DEVICE_ID_POINTER_COUNT:
+            return apple->touch_count;
       }
    }
 

--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -248,6 +248,7 @@ extern "C" {
 #define RETRO_DEVICE_ID_POINTER_X         0
 #define RETRO_DEVICE_ID_POINTER_Y         1
 #define RETRO_DEVICE_ID_POINTER_PRESSED   2
+#define RETRO_DEVICE_ID_POINTER_COUNT     3
 
 /* Returned from retro_get_region(). */
 #define RETRO_REGION_NTSC  0


### PR DESCRIPTION
## Description

Support a new input id called `RETRO_DEVICE_ID_POINTER_COUNT`. It corresponds to the number of touches made on the touchscreen. This is to support 2-finger presses to support secondary fire or reloading on lightgun games, for example.

Here is example usage (using the beetle saturn core i'm updating):

```
// use multi-touch to support different button inputs:
// 3-finger touch: START button
// 2-finger touch: Reload
int touch_count = input_state_cb( iplayer, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_COUNT );
if ( touch_count == 3 )
{
	p_input->u8[ 4 ] |= 0x2;  // START button
}
else if ( touch_count == 2 )
{
	p_input->u8[ 4 ] |= 0x4;  // Offscreen Reload
}
```

This PR adds support for iOS and Android, but this new input id will need to be added to other input drivers in order to support it.

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
