### PR TITLE
(GEKKO) Update default paths

### DIFF
--- a/frontend/drivers/platform_gx.c
+++ b/frontend/drivers/platform_gx.c
@@ -214,11 +214,11 @@ static void frontend_gx_get_environment_settings(
       fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_PORT], g_defaults.dirs[DEFAULT_DIR_PORT],
             "retroarch", sizeof(g_defaults.dirs[DEFAULT_DIR_PORT]));
 
+   /* System paths */
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CORE_INFO], g_defaults.dirs[DEFAULT_DIR_CORE],
          "info", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE_INFO]));
-   fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_AUTOCONFIG],
-         g_defaults.dirs[DEFAULT_DIR_CORE], "autoconfig",
-         sizeof(g_defaults.dirs[DEFAULT_DIR_AUTOCONFIG]));
+   fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_AUTOCONFIG], g_defaults.dirs[DEFAULT_DIR_CORE],
+         "autoconfig", sizeof(g_defaults.dirs[DEFAULT_DIR_AUTOCONFIG]));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_OVERLAY], g_defaults.dirs[DEFAULT_DIR_CORE],
          "overlays", sizeof(g_defaults.dirs[DEFAULT_DIR_OVERLAY]));
 #ifdef HAVE_VIDEO_LAYOUT
@@ -229,6 +229,12 @@ static void frontend_gx_get_environment_settings(
          "filters/video", sizeof(g_defaults.dirs[DEFAULT_DIR_VIDEO_FILTER]));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_AUDIO_FILTER], g_defaults.dirs[DEFAULT_DIR_CORE],
          "filters/audio", sizeof(g_defaults.dirs[DEFAULT_DIR_AUDIO_FILTER]));
+   fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_ASSETS], g_defaults.dirs[DEFAULT_DIR_CORE],
+         "assets", sizeof(g_defaults.dirs[DEFAULT_DIR_ASSETS]));
+   fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CHEATS], g_defaults.dirs[DEFAULT_DIR_CORE],
+         "cheats", sizeof(g_defaults.dirs[DEFAULT_DIR_CHEATS]));
+
+   /* User paths */
    fill_pathname_join(g_defaults.path.config, g_defaults.dirs[DEFAULT_DIR_PORT],
          "retroarch.cfg", sizeof(g_defaults.path.config));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_SYSTEM], g_defaults.dirs[DEFAULT_DIR_PORT],
@@ -236,11 +242,15 @@ static void frontend_gx_get_environment_settings(
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_SRAM], g_defaults.dirs[DEFAULT_DIR_PORT],
          "savefiles", sizeof(g_defaults.dirs[DEFAULT_DIR_SRAM]));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_SAVESTATE], g_defaults.dirs[DEFAULT_DIR_PORT],
-         "savefiles", sizeof(g_defaults.dirs[DEFAULT_DIR_SAVESTATE]));
+         "savestates", sizeof(g_defaults.dirs[DEFAULT_DIR_SAVESTATE]));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_PLAYLIST], g_defaults.dirs[DEFAULT_DIR_PORT],
          "playlists", sizeof(g_defaults.dirs[DEFAULT_DIR_PLAYLIST]));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_LOGS], g_defaults.dirs[DEFAULT_DIR_PORT],
          "logs", sizeof(g_defaults.dirs[DEFAULT_DIR_LOGS]));
+   fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_REMAP], g_defaults.dirs[DEFAULT_DIR_PORT],
+         "remaps", sizeof(g_defaults.dirs[DEFAULT_DIR_REMAP]));
+   fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_MENU_CONFIG], g_defaults.dirs[DEFAULT_DIR_PORT],
+         "config", sizeof(g_defaults.dirs[DEFAULT_DIR_MENU_CONFIG]));
 
 #ifdef IS_SALAMANDER
    if (*argc > 2 && argv[1] != NULL && argv[2] != NULL)


### PR DESCRIPTION
## Description

This PR improves the default path setup for GEKKO (predominantly Wii) builds with the following additions/changes:

- `DEFAULT_DIR_ASSETS` is set to `<core_dir>/assets` (these are included with [libretro-super
 PR #1059](https://github.com/libretro/libretro-super/pull/1059))

- `DEFAULT_DIR_CHEATS` is set to `<core_dir>/cheats` (we don't actually bundle any cheats, but the directory is already included in the buildbot package...)

- `DEFAULT_DIR_REMAP` is set to `<port_dir>/remaps`

- `DEFAULT_DIR_MENU_CONFIG` is set to `<port_dir>/config`

- `DEFAULT_DIR_SAVESTATE` is moved from `<port_dir>/savefiles` to `<port_dir>/savestates` (for parity with the other RetroArch ports)
