### PR TITLE
Increase size of playlist core association arrays

### DIFF
--- a/configuration.h
+++ b/configuration.h
@@ -557,8 +557,8 @@ typedef struct settings
       char audio_device[255];
       char camera_device[255];
 
-      char playlist_names[PATH_MAX_LENGTH];
-      char playlist_cores[PATH_MAX_LENGTH];
+      char playlist_names[8192];
+      char playlist_cores[8192];
       char bundle_assets_src[PATH_MAX_LENGTH];
       char bundle_assets_dst[PATH_MAX_LENGTH];
       char bundle_assets_dst_subdir[PATH_MAX_LENGTH];

--- a/menu/cbs/menu_cbs_left.c
+++ b/menu/cbs/menu_cbs_left.c
@@ -368,16 +368,15 @@ static int action_left_video_resolution(unsigned type, const char *label,
 static int playlist_association_left(unsigned type, const char *label,
       bool wraparound)
 {
-   unsigned i;
-   char core_path[PATH_MAX_LENGTH];
-   char new_playlist_cores[PATH_MAX_LENGTH];
-   int next, found, current         = 0;
+   size_t i, next, found, current   = 0;
    core_info_t *info                = NULL;
    struct string_list *stnames      = NULL;
    struct string_list *stcores      = NULL;
    settings_t *settings             = config_get_ptr();
    const char *path                 = path_basename(label);
    core_info_list_t           *list = NULL;
+   char core_path[PATH_MAX_LENGTH];
+   char new_playlist_cores[sizeof(settings->arrays.playlist_cores) / sizeof(settings->arrays.playlist_cores[0])];
 
    core_info_get_list(&list);
 

--- a/menu/cbs/menu_cbs_right.c
+++ b/menu/cbs/menu_cbs_right.c
@@ -389,8 +389,6 @@ static int action_right_video_resolution(unsigned type, const char *label,
 static int playlist_association_right(unsigned type, const char *label,
       bool wraparound)
 {
-   char core_path[PATH_MAX_LENGTH];
-   char new_playlist_cores[PATH_MAX_LENGTH];
    size_t i, next, found, current   = 0;
    core_info_t *info                = NULL;
    struct string_list *stnames      = NULL;
@@ -398,6 +396,8 @@ static int playlist_association_right(unsigned type, const char *label,
    core_info_list_t           *list = NULL;
    settings_t *settings             = config_get_ptr();
    const char *path                 = path_basename(label);
+   char core_path[PATH_MAX_LENGTH];
+   char new_playlist_cores[sizeof(settings->arrays.playlist_cores) / sizeof(settings->arrays.playlist_cores[0])];
 
    core_info_get_list(&list);
    if (!list)

--- a/menu/cbs/menu_cbs_start.c
+++ b/menu/cbs/menu_cbs_start.c
@@ -224,13 +224,13 @@ static int action_start_core_setting(unsigned type,
 
 static int action_start_playlist_association(unsigned type, const char *label)
 {
-   int found;
-   char new_playlist_cores[PATH_MAX_LENGTH];
    struct string_list *stnames      = NULL;
    struct string_list *stcores      = NULL;
    core_info_list_t           *list = NULL;
    settings_t *settings             = config_get_ptr();
    const char *path                 = path_basename(label);
+   int found;
+   char new_playlist_cores[sizeof(settings->arrays.playlist_cores) / sizeof(settings->arrays.playlist_cores[0])];
 
    core_info_get_list(&list);
    if (!list)

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -2574,8 +2574,8 @@ static void menu_displaylist_parse_playlist_associations(
    if (str_list && str_list->size)
    {
       unsigned i;
-      char new_playlist_names[PATH_MAX_LENGTH];
-      char new_playlist_cores[PATH_MAX_LENGTH];
+      char new_playlist_names[sizeof(settings->arrays.playlist_names) / sizeof(settings->arrays.playlist_names[0])];
+      char new_playlist_cores[sizeof(settings->arrays.playlist_cores) / sizeof(settings->arrays.playlist_cores[0])];
       struct string_list *stnames  = string_split(settings->arrays.playlist_names, ";");
       struct string_list *stcores  = string_split(settings->arrays.playlist_cores, ";");
 

--- a/ui/drivers/qt/qt_playlist.cpp
+++ b/ui/drivers/qt/qt_playlist.cpp
@@ -765,8 +765,8 @@ void MainWindow::onPlaylistWidgetContextMenuRequested(const QPoint&)
    int j = 0;
    size_t found = 0;
    const char *currentPlaylistFileNameData = NULL;
-   char new_playlist_names[PATH_MAX_LENGTH];
-   char new_playlist_cores[PATH_MAX_LENGTH];
+   char new_playlist_names[sizeof(settings->arrays.playlist_names) / sizeof(settings->arrays.playlist_names[0])];
+   char new_playlist_cores[sizeof(settings->arrays.playlist_cores) / sizeof(settings->arrays.playlist_cores[0])];
    bool specialPlaylist = false;
    bool foundHiddenPlaylist = false;
 


### PR DESCRIPTION
## Description

At present, playlist core associations are handled by storing core name/path pairs as delimited strings in the settings char arrays `playlist_names` and `playlist_cores`. This should probably be reworked at some point, so default core is stored in the playlist itself - but the current system is workable on most platforms.

The issue is this: the `playlist_names` and `playlist_cores` arrays have a size of `PATH_MAX_LENGTH`. This is generally sufficient, but a number of platforms have a very small `PATH_MAX_LENGTH` (e.g. 3DS, Wii, Wii U, PS2), which means the arrays 'overflow' once only a handful of playlists are assigned. This doesn't cause catastrophic harm (no segfaults or particularly bad behaviour) but it does mean that playlist associations are effectively unusable on these platforms.

This PR very simply increases the size of the `playlist_names` and `playlist_cores` arrays to `8192` on all platforms (and this is done in a way such that the size is only set in `configuration.h` - i.e. we don't have to keep track of the new value elsewhere in the code). I guess this is a band-aid until a 'proper' solution is implemented, but it makes playlist associations workable on all systems.