### PR TITLE
Qt: fix file browser resorting

### DIFF
--- a/ui/drivers/qt/qt_playlist.cpp
+++ b/ui/drivers/qt/qt_playlist.cpp
@@ -56,6 +56,9 @@ int PlaylistModel::columnCount(const QModelIndex & /* parent */) const
 
 QVariant PlaylistModel::data(const QModelIndex &index, int role) const
 {
+   if (role ==Qt::SizeHintRole)
+      return QSize(1, 22);
+
    if (index.column() == 0)
    {
       if (!index.isValid())
@@ -110,12 +113,16 @@ bool PlaylistModel::setData(const QModelIndex &index, const QVariant &value, int
 
 QVariant PlaylistModel::headerData(int section, Qt::Orientation orientation, int role) const
 {
-   if (role != Qt::DisplayRole)
-      return QVariant();
-
-   if (orientation == Qt::Horizontal)
-      return msg_hash_to_str(MENU_ENUM_LABEL_VALUE_QT_NAME);
-   return section + 1;
+   switch (role)
+   {
+   case Qt::TextAlignmentRole:
+      return Qt::AlignLeft;
+   case Qt::DisplayRole:
+      if (orientation == Qt::Horizontal && section == 0)
+         return msg_hash_to_str(MENU_ENUM_LABEL_VALUE_QT_NAME);
+   default:
+      return QAbstractItemModel::headerData(section, orientation, role);
+   }
 }
 
 void PlaylistModel::setThumbnailType(const ThumbnailType type)

--- a/ui/drivers/qt/ui_qt_themes.h
+++ b/ui/drivers/qt/ui_qt_themes.h
@@ -355,7 +355,7 @@ static const QString qt_theme_dark_stylesheet = QStringLiteral(R"(
    QTableView, QListWidget {
       background-color:rgb(25,25,25);
    }
-   QTreeView QHeaderView::section, QTableView QHeaderView::section {
+   QHeaderView::section {
       /*height:24px;*/
       background-color:qlineargradient(x1:0,y1:1,x2:0,y2:0,stop:0 rgba(25,25,25,127),stop:1 rgba(53,53,53,75));
       border-style:none;
@@ -363,7 +363,7 @@ static const QString qt_theme_dark_stylesheet = QStringLiteral(R"(
       padding-left:5px;
       padding-right:5px;
    }
-   QTableView {
+   QTableView, QTreeView {
       background-color:rgb(25,25,25);
       alternate-background-color:rgb(40,40,40);
    }

--- a/ui/drivers/ui_qt.cpp
+++ b/ui/drivers/ui_qt.cpp
@@ -532,9 +532,11 @@ static void* ui_companion_qt_init(void)
          mainwindow->restoreState(qsettings->value("dock_positions").toByteArray());
 
    if (qsettings->contains("file_browser_table_headers"))
-      mainwindow->fileTableView()->horizontalHeader()->restoreState(qsettings->value("file_browser_table_headers").toByteArray());
+      mainwindow->fileTableView()->header()->restoreState(qsettings->value("file_browser_table_headers").toByteArray());
    else
-      mainwindow->fileTableView()->horizontalHeader()->resizeSection(0, 300);
+      mainwindow->fileTableView()->header()->resizeSection(0, 300);
+
+   mainwindow->fileTableView()->header()->setHighlightSections(false);
 
    if (qsettings->contains("icon_view_zoom"))
       mainwindow->setIconViewZoom(qsettings->value("icon_view_zoom", 50).toInt());

--- a/ui/drivers/ui_qt.h
+++ b/ui/drivers/ui_qt.h
@@ -642,7 +642,6 @@ private:
    GridItem m_gridItem;
    BrowserType m_currentBrowser;
    QRegExp m_searchRegExp;
-   QByteArray m_fileTableHeaderState;
    QWidget *m_zoomWidget;
    QString m_itemsCountLiteral;
    QLabel *m_itemsCountLabel;

--- a/ui/drivers/ui_qt.h
+++ b/ui/drivers/ui_qt.h
@@ -220,7 +220,7 @@ protected slots:
    void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
 };
 
-class TableView : public QTableView
+class TableView : public QTreeView
 {
    Q_OBJECT
 public:
@@ -307,6 +307,8 @@ public:
 class FileSystemProxyModel : public QSortFilterProxyModel
 {
 protected:
+   virtual QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
+   virtual QVariant headerData(int section, Qt::Orientation orientation, int role) const;
    virtual bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const;
    void sort(int column, Qt::SortOrder order = Qt::AscendingOrder);
 };
@@ -351,7 +353,7 @@ public:
    ListWidget* playlistListWidget();
    QStackedWidget* centralWidget();
    TableView* contentTableView();
-   QTableView* fileTableView();
+   QTreeView* fileTableView();
    FileDropWidget* playlistViews();
    GridView* contentGridView();
    QWidget* playlistViewsAndFooter();
@@ -497,7 +499,6 @@ private slots:
    void onContributorsClicked();
    void onItemChanged();
    void onFileSystemDirLoaded(const QString &path);
-   void onFileBrowserTableDirLoaded(const QString &path);
    void onDownloadScroll(QString path);
    void onDownloadScrollAgain(QString path);
    int onExtractArchive(QString path, QString extractionDir, QString tempExtension, retro_task_callback_t cb);
@@ -564,7 +565,7 @@ private:
    ListWidget *m_listWidget;
    QStackedWidget *m_centralWidget;
    TableView *m_tableView;
-   QTableView *m_fileTableView;
+   TableView *m_fileTableView;
    FileDropWidget *m_playlistViews;
    QWidget *m_searchWidget;
    QLineEdit *m_searchLineEdit;


### PR DESCRIPTION
This fixes a bug @retro-wertz reported on Discord in which the table view of the file browser is sorted by name upon launching compressed content.
Appears to be an issue with QTableView, since just changing it for a QTreeView solves it.
So I did that for both the file browser and content browser to keep them consistent.
It looks a bit diferent, there are no grid lines and the rows are a bit shorter.
I think it looks better but I welcome @bparker06 @Tatsuya79 and others' input.