### PR TITLE
Revert "allow saving and properly loading 0 pass shader presets"

### DIFF
--- a/gfx/video_shader_parse.c
+++ b/gfx/video_shader_parse.c
@@ -738,6 +738,12 @@ bool video_shader_read_conf_preset(config_file_t *conf,
       return false;
    }
 
+   if (!shaders)
+   {
+      RARCH_ERR("Need to define at least 1 shader.\n");
+      return false;
+   }
+
    if (!config_get_int(conf, "feedback_pass",
             &shader->feedback_pass))
       shader->feedback_pass = -1;

--- a/menu/menu_shader.c
+++ b/menu/menu_shader.c
@@ -451,16 +451,13 @@ void menu_shader_manager_clear_pass_path(unsigned i)
  **/
 unsigned menu_shader_manager_get_type(const void *data)
 {
-   enum rarch_shader_type type;
+   unsigned type                     = RARCH_SHADER_NONE;
    const struct video_shader *shader = (const struct video_shader*)data;
    /* All shader types must be the same, or we cannot use it. */
    uint8_t i                         = 0;
 
    if (!shader)
       return RARCH_SHADER_NONE;
-
-   type = video_shader_parse_type(shader->path,
-         RARCH_SHADER_NONE);
 
    for (i = 0; i < shader->passes; i++)
    {
@@ -473,7 +470,9 @@ unsigned menu_shader_manager_get_type(const void *data)
          case RARCH_SHADER_CG:
          case RARCH_SHADER_GLSL:
          case RARCH_SHADER_SLANG:
-            if (type != pass_type)
+            if (type == RARCH_SHADER_NONE)
+               type = pass_type;
+            else if (type != pass_type)
                return RARCH_SHADER_NONE;
             break;
          default:
@@ -499,7 +498,7 @@ void menu_shader_manager_apply_changes(void)
 
    shader_type = menu_shader_manager_get_type(shader);
 
-   if (shader_type != RARCH_SHADER_NONE)
+   if (shader->passes && shader_type != RARCH_SHADER_NONE)
    {
       menu_shader_manager_save_preset(NULL, true, false);
       return;


### PR DESCRIPTION
## Description

My original commit had unintended side effects which resulted in random menu crashes (segfaults) when setting shader passes back to 0 or loading a 0 pass preset in vulkan and glcore.
Since applying shaders also saves a kind of default preset, simply loading RetroArch would then also crash until the preset is removed.

A proper fix requires more work in the video drivers, so for now it's best to simply revert my bad commit.

## Related Issues

#8974

## Related Pull Requests

#8946
