### PR TITLE
workaround for crash due to glcore not always using at least OpenGL 3.2

### DIFF
--- a/gfx/drivers/gl_core.c
+++ b/gfx/drivers/gl_core.c
@@ -1028,7 +1028,7 @@ static void *gl_core_init(const video_info_t *video,
    }
 
    if (!string_is_empty(version))
-      sscanf(version, "%d.%d", &gl->version_major, &gl->version_minor);
+      sscanf(version, "%u.%u", &gl->version_major, &gl->version_minor);
 
    {
       char device_str[128];

--- a/gfx/drivers_shader/shader_gl_core.cpp
+++ b/gfx/drivers_shader/shader_gl_core.cpp
@@ -94,15 +94,39 @@ static uint32_t gl_core_get_cross_compiler_target_version()
 
 #ifdef HAVE_OPENGLES3
    if (!version || sscanf(version, "OpenGL ES %u.%u", &major, &minor) != 2)
-      return 300u;
+      return 300;
+   
+   if (major == 2 && minor == 0)
+      return 100;
 #else
    if (!version || sscanf(version, "%u.%u", &major, &minor) != 2)
-      return 150u;
-#endif
-   if (major == 3u && minor == 2u)
-      return 150u;
+      return 150;
 
-   return 100u * major + 10u * minor;
+   if (major == 3)
+   {
+      switch (minor)
+      {
+         case 2:
+            return 150;
+         case 1:
+            return 140;
+         case 0:
+            return 130;
+      }
+   }
+   else if (major == 2)
+   {
+      switch (minor)
+      {
+         case 1:
+            return 120;
+         case 0:
+            return 110;
+      }
+   }
+#endif
+
+   return 100 * major + 10 * minor;
 }
 
 GLuint gl_core_cross_compile_program(
@@ -719,7 +743,7 @@ void Framebuffer::init()
 
    levels = num_miplevels(size.width, size.height);
    if (max_levels < levels)
-	   levels = max_levels;
+      levels = max_levels;
    if (levels == 0)
       levels = 1;
 


### PR DESCRIPTION
## Description

glcore is currently not always using OpenGL version 3.2+ when a core requests an OpenGL Core profile of lower version (e.g. dolphin requests 3.1 Core).
Since the OpenGL version -> GLSL version mapping in `gl_core_get_cross_compiler_target_version()` only works for OpenGL 3.2+, this will cause basic shaders to not crosscompile, causing crashes.

This commit completes the OpenGL (ES) version -> GLSL (ES) version mapping in `gl_core_get_cross_compiler_target_version()` as a workaround.

## Related Issues

https://github.com/libretro/RetroArch/issues/8839#issuecomment-502709990
https://github.com/libretro/dolphin/issues/100

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/8846
https://github.com/libretro/RetroArch/pull/8848