### PR TITLE
fix missing include

### DIFF
--- a/gfx/drivers_context/xegl_ctx.c
+++ b/gfx/drivers_context/xegl_ctx.c
@@ -19,6 +19,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include <string/stdstring.h>
+
 #ifdef HAVE_CONFIG_H
 #include "../../config.h"
 #endif


### PR DESCRIPTION
## Description

Fixes build error due to an include missing after https://github.com/libretro/RetroArch/commit/c20c67bd3abec74446b08ffd86be1686921c7320

```
gfx/drivers_context/xegl_ctx.c:607:8: warning: implicit declaration of function ‘string_is_equal’ [-Wimplicit-function-declaration]
  607 |    if (string_is_equal(video_driver_get_ident(), "glcore"))
      |        ^~~~~~~~~~~~~~~

--- SNIP UNNEEDED WALL OF TEXT ---

LD retroarch
/home/asavah/kross/host/msib450ig/lib/gcc/x86_64-msib450ig-linux-gnu/9.1.1/../../../../x86_64-msib450ig-linux-gnu/bin/ld: obj-unix/release/gfx/drivers_context/xegl_ctx.o: in function `gfx_ctx_xegl_get_flags':
xegl_ctx.c:(.text+0xb6): undefined reference to `string_is_equal'

```

Same build error can currently be observed on travis with gcc/g++.

## Related Issues

## Related Pull Requests

## Reviewers
