### PR TITLE
d3d10/11/12: add GPU selection

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -874,6 +874,18 @@ static const bool enable_device_vibration    = false;
 #define DEFAULT_VULKAN_GPU_INDEX 0
 #endif
 
+#ifdef HAVE_D3D10
+#define DEFAULT_D3D10_GPU_INDEX 0
+#endif
+
+#ifdef HAVE_D3D11
+#define DEFAULT_D3D11_GPU_INDEX 0
+#endif
+
+#ifdef HAVE_D3D12
+#define DEFAULT_D3D12_GPU_INDEX 0
+#endif
+
 #if defined(HAKCHI)
 static char buildbot_server_url[] = "http://hakchicloud.com/Libretro_Cores/";
 #elif defined(ANDROID)

--- a/configuration.c
+++ b/configuration.c
@@ -1867,6 +1867,15 @@ static struct config_int_setting *populate_settings_int(settings_t *settings, in
 #ifdef HAVE_VULKAN
    SETTING_INT("vulkan_gpu_index",              &settings->ints.vulkan_gpu_index, true, DEFAULT_VULKAN_GPU_INDEX, false);
 #endif
+#ifdef HAVE_D3D10
+   SETTING_INT("d3d10_gpu_index",              &settings->ints.d3d10_gpu_index, true, DEFAULT_D3D10_GPU_INDEX, false);
+#endif
+#ifdef HAVE_D3D11
+   SETTING_INT("d3d11_gpu_index",              &settings->ints.d3d11_gpu_index, true, DEFAULT_D3D11_GPU_INDEX, false);
+#endif
+#ifdef HAVE_D3D12
+   SETTING_INT("d3d12_gpu_index",              &settings->ints.d3d12_gpu_index, true, DEFAULT_D3D12_GPU_INDEX, false);
+#endif
 
    *size = count;
 

--- a/configuration.h
+++ b/configuration.h
@@ -391,6 +391,15 @@ typedef struct settings
 #ifdef HAVE_VULKAN
       int vulkan_gpu_index;
 #endif
+#ifdef HAVE_D3D10
+      int d3d10_gpu_index;
+#endif
+#ifdef HAVE_D3D11
+      int d3d11_gpu_index;
+#endif
+#ifdef HAVE_D3D12
+      int d3d12_gpu_index;
+#endif
    } ints;
 
    struct

--- a/gfx/common/d3d12_common.h
+++ b/gfx/common/d3d12_common.h
@@ -1,5 +1,6 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2014-2018 - Ali Bouhlel
+ *  Copyright (C) 2016-2019 - Brad Parker
  *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-
@@ -1263,6 +1264,8 @@ D3D12GetGPUDescriptorHandleForHeapStart(D3D12DescriptorHeap descriptor_heap)
 #include "../../retroarch.h"
 #include "../drivers_shader/slang_process.h"
 
+#define D3D12_MAX_GPU_COUNT 16
+
 typedef struct d3d12_vertex_t
 {
    float position[2];
@@ -1350,6 +1353,9 @@ typedef struct
 #endif
    DXGIAdapter adapter;
    D3D12Device device;
+
+   IDXGIAdapter1 *adapters[D3D12_MAX_GPU_COUNT];
+   struct string_list *gpu_list;
 
    struct
    {

--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -1,5 +1,6 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2016-2017 - Hans-Kristian Arntzen
+ *  Copyright (C) 2016-2019 - Brad Parker
  *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-
@@ -1646,7 +1647,7 @@ static bool vulkan_context_init_gpu(gfx_ctx_vulkan_data_t *vk)
       vkGetPhysicalDeviceProperties(gpus[i],
             &gpu_properties);
 
-      RARCH_LOG("[Vulkan]: Found GPU: %s\n", gpu_properties.deviceName);
+      RARCH_LOG("[Vulkan]: Found GPU at index %d: %s\n", i, gpu_properties.deviceName);
 
       string_list_append(vulkan_gpu_list, gpu_properties.deviceName, attr);
    }

--- a/gfx/drivers/d3d12.c
+++ b/gfx/drivers/d3d12.c
@@ -1,5 +1,6 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2014-2018 - Ali Bouhlel
+ *  Copyright (C) 2016-2019 - Brad Parker
  *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-
@@ -870,6 +871,15 @@ static void d3d12_gfx_free(void* data)
    Release(d3d12->factory);
    Release(d3d12->device);
    Release(d3d12->adapter);
+
+   for (i = 0; i < D3D12_MAX_GPU_COUNT; i++)
+   {
+      if (d3d12->adapters[i])
+      {
+         Release(d3d12->adapters[i]);
+         d3d12->adapters[i] = NULL;
+      }
+   }
 
 #ifdef HAVE_MONITOR
    win32_monitor_from_window();

--- a/menu/cbs/menu_cbs_left.c
+++ b/menu/cbs/menu_cbs_left.c
@@ -466,6 +466,54 @@ static int action_left_video_gpu_index(unsigned type, const char *label,
          break;
       }
 #endif
+#ifdef HAVE_D3D10
+      case GFX_CTX_DIRECT3D10_API:
+      {
+         struct string_list *list = video_driver_get_gpu_api_devices(api);
+
+         if (list)
+         {
+            if (settings->ints.d3d10_gpu_index > 0)
+               settings->ints.d3d10_gpu_index--;
+            else
+               settings->ints.d3d10_gpu_index = list->size - 1;
+         }
+
+         break;
+      }
+#endif
+#ifdef HAVE_D3D11
+      case GFX_CTX_DIRECT3D11_API:
+      {
+         struct string_list *list = video_driver_get_gpu_api_devices(api);
+
+         if (list)
+         {
+            if (settings->ints.d3d11_gpu_index > 0)
+               settings->ints.d3d11_gpu_index--;
+            else
+               settings->ints.d3d11_gpu_index = list->size - 1;
+         }
+
+         break;
+      }
+#endif
+#ifdef HAVE_D3D12
+      case GFX_CTX_DIRECT3D12_API:
+      {
+         struct string_list *list = video_driver_get_gpu_api_devices(api);
+
+         if (list)
+         {
+            if (settings->ints.d3d12_gpu_index > 0)
+               settings->ints.d3d12_gpu_index--;
+            else
+               settings->ints.d3d12_gpu_index = list->size - 1;
+         }
+
+         break;
+      }
+#endif
       default:
          break;
    }

--- a/menu/cbs/menu_cbs_right.c
+++ b/menu/cbs/menu_cbs_right.c
@@ -394,6 +394,54 @@ static int action_right_video_gpu_index(unsigned type, const char *label,
          break;
       }
 #endif
+#ifdef HAVE_D3D10
+      case GFX_CTX_DIRECT3D10_API:
+      {
+         struct string_list *list = video_driver_get_gpu_api_devices(api);
+
+         if (list)
+         {
+            if (settings->ints.d3d10_gpu_index < list->size - 1)
+               settings->ints.d3d10_gpu_index++;
+            else if (settings->ints.d3d10_gpu_index == list->size - 1)
+               settings->ints.d3d10_gpu_index = 0;
+         }
+
+         break;
+      }
+#endif
+#ifdef HAVE_D3D11
+      case GFX_CTX_DIRECT3D11_API:
+      {
+         struct string_list *list = video_driver_get_gpu_api_devices(api);
+
+         if (list)
+         {
+            if (settings->ints.d3d11_gpu_index < list->size - 1)
+               settings->ints.d3d11_gpu_index++;
+            else if (settings->ints.d3d11_gpu_index == list->size - 1)
+               settings->ints.d3d11_gpu_index = 0;
+         }
+
+         break;
+      }
+#endif
+#ifdef HAVE_D3D12
+      case GFX_CTX_DIRECT3D12_API:
+      {
+         struct string_list *list = video_driver_get_gpu_api_devices(api);
+
+         if (list)
+         {
+            if (settings->ints.d3d12_gpu_index < list->size - 1)
+               settings->ints.d3d12_gpu_index++;
+            else if (settings->ints.d3d12_gpu_index == list->size - 1)
+               settings->ints.d3d12_gpu_index = 0;
+         }
+
+         break;
+      }
+#endif
       default:
          break;
    }

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -8364,6 +8364,66 @@ static bool setting_append_list(
             }
 #endif
 
+#ifdef HAVE_D3D10
+            if (string_is_equal(video_driver_get_ident(), "d3d10"))
+            {
+               CONFIG_INT(
+                     list, list_info,
+                     &settings->ints.d3d10_gpu_index,
+                     MENU_ENUM_LABEL_VIDEO_GPU_INDEX,
+                     MENU_ENUM_LABEL_VALUE_VIDEO_GPU_INDEX,
+                     0,
+                     &group_info,
+                     &subgroup_info,
+                     parent_group,
+                     general_write_handler,
+                     general_read_handler);
+               menu_settings_list_current_add_range(list, list_info, 0, 15, 1, true, true);
+               (*list)[list_info->index - 1].get_string_representation =
+                  &setting_get_string_representation_int_gpu_index;
+            }
+#endif
+
+#ifdef HAVE_D3D11
+            if (string_is_equal(video_driver_get_ident(), "d3d11"))
+            {
+               CONFIG_INT(
+                     list, list_info,
+                     &settings->ints.d3d11_gpu_index,
+                     MENU_ENUM_LABEL_VIDEO_GPU_INDEX,
+                     MENU_ENUM_LABEL_VALUE_VIDEO_GPU_INDEX,
+                     0,
+                     &group_info,
+                     &subgroup_info,
+                     parent_group,
+                     general_write_handler,
+                     general_read_handler);
+               menu_settings_list_current_add_range(list, list_info, 0, 15, 1, true, true);
+               (*list)[list_info->index - 1].get_string_representation =
+                  &setting_get_string_representation_int_gpu_index;
+            }
+#endif
+
+#ifdef HAVE_D3D12
+            if (string_is_equal(video_driver_get_ident(), "d3d12"))
+            {
+               CONFIG_INT(
+                     list, list_info,
+                     &settings->ints.d3d12_gpu_index,
+                     MENU_ENUM_LABEL_VIDEO_GPU_INDEX,
+                     MENU_ENUM_LABEL_VALUE_VIDEO_GPU_INDEX,
+                     0,
+                     &group_info,
+                     &subgroup_info,
+                     parent_group,
+                     general_write_handler,
+                     general_read_handler);
+               menu_settings_list_current_add_range(list, list_info, 0, 15, 1, true, true);
+               (*list)[list_info->index - 1].get_string_representation =
+                  &setting_get_string_representation_int_gpu_index;
+            }
+#endif
+
             if (video_driver_has_windowed())
             {
                CONFIG_BOOL(

--- a/retroarch.c
+++ b/retroarch.c
@@ -7390,7 +7390,10 @@ typedef struct {
 } gfx_api_gpu_map;
 
 static gfx_api_gpu_map gpu_map[] = {
-   { GFX_CTX_VULKAN_API, NULL }
+   { GFX_CTX_VULKAN_API, NULL },
+   { GFX_CTX_DIRECT3D10_API, NULL },
+   { GFX_CTX_DIRECT3D11_API, NULL },
+   { GFX_CTX_DIRECT3D12_API, NULL }
 };
 
 bool video_driver_started_fullscreen(void)

--- a/retroarch.h
+++ b/retroarch.h
@@ -1,6 +1,7 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
  *  Copyright (C) 2011-2016 - Daniel De Matteis
+ *  Copyright (C) 2016-2019 - Brad Parker
  *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-


### PR DESCRIPTION
This extends #8937 to add support for choosing which GPU to render on, when using d3d10, 11 or 12. The option is in Settings -> Video -> GPU Index and is stored in the config independently for each driver (d3d10_gpu_index, d3d11_gpu_index etc.).