### PR TITLE
temporary workaround for d3d10-12, gx2 not being able to poll flags during init

### DIFF
--- a/gfx/drivers/d3d10.c
+++ b/gfx/drivers/d3d10.c
@@ -50,6 +50,10 @@
 
 #define D3D10_MAX_GPU_COUNT 16
 
+/* Temporary workaround for d3d10 not being able to poll flags during init */
+static gfx_ctx_driver_t d3d10_fake_context;
+static uint32_t d3d10_get_flags(void *data);
+
 static struct string_list *d3d10_gpu_list = NULL;
 static IDXGIAdapter1 *d3d10_adapters[D3D10_MAX_GPU_COUNT] = {NULL};
 static IDXGIAdapter1 *d3d10_current_adapter = NULL;
@@ -966,6 +970,8 @@ d3d10_gfx_init(const video_info_t* video,
    font_driver_init_osd(d3d10, false, video->is_threaded, FONT_DRIVER_RENDER_D3D10_API);
 
    {
+      d3d10_fake_context.get_flags = d3d10_get_flags;
+      video_context_driver_set(&d3d10_fake_context); 
       const char *shader_preset   = retroarch_get_shader_preset();
       enum rarch_shader_type type = video_shader_parse_type(shader_preset);
       d3d10_gfx_set_shader(d3d10, type, shader_preset);

--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -58,10 +58,13 @@
 #include "../../uwp/uwp_func.h"
 #endif
 
+/* Temporary workaround for d3d11 not being able to poll flags during init */
+static gfx_ctx_driver_t d3d11_fake_context;
+static uint32_t d3d11_get_flags(void *data);
+
 static D3D11Device           cached_device_d3d11;
 static D3D_FEATURE_LEVEL     cached_supportedFeatureLevel;
 static D3D11DeviceContext    cached_context;
-
 #define D3D11_MAX_GPU_COUNT 16
 
 static struct string_list *d3d11_gpu_list = NULL;
@@ -1042,6 +1045,8 @@ d3d11_gfx_init(const video_info_t* video, const input_driver_t** input, void** i
    font_driver_init_osd(d3d11, false, video->is_threaded, FONT_DRIVER_RENDER_D3D11_API);
 
    {
+      d3d11_fake_context.get_flags = d3d11_get_flags;
+      video_context_driver_set(&d3d11_fake_context); 
       const char *shader_preset   = retroarch_get_shader_preset();
       enum rarch_shader_type type = video_shader_parse_type(shader_preset);
       d3d11_gfx_set_shader(d3d11, type, shader_preset);

--- a/gfx/drivers/d3d12.c
+++ b/gfx/drivers/d3d12.c
@@ -43,6 +43,10 @@
 
 #include "wiiu/wiiu_dbg.h"
 
+/* Temporary workaround for d3d12 not being able to poll flags during init */
+static gfx_ctx_driver_t d3d12_fake_context;
+static uint32_t d3d12_get_flags(void *data);
+
 static void d3d12_gfx_sync(d3d12_video_t* d3d12)
 {
    if (D3D12GetCompletedValue(d3d12->queue.fence) < d3d12->queue.fenceValue)
@@ -1007,6 +1011,8 @@ d3d12_gfx_init(const video_info_t* video, const input_driver_t** input, void** i
    font_driver_init_osd(d3d12, false, video->is_threaded, FONT_DRIVER_RENDER_D3D12_API);
 
    {
+      d3d12_fake_context.get_flags = d3d12_get_flags;
+      video_context_driver_set(&d3d12_fake_context); 
       const char *shader_preset   = retroarch_get_shader_preset();
       enum rarch_shader_type type = video_shader_parse_type(shader_preset);
       d3d12_gfx_set_shader(d3d12, type, shader_preset);

--- a/gfx/drivers/gx2_gfx.c
+++ b/gfx/drivers/gx2_gfx.c
@@ -47,6 +47,10 @@
 
 #include "../font_driver.h"
 
+/* Temporary workaround for gx2 not being able to poll flags during init */
+static gfx_ctx_driver_t wiiu_fake_context;
+uint32_t wiiu_gfx_get_flags(void *data);
+
 static const wiiu_render_mode_t wiiu_render_mode_map[] =
 {
    {0},                                         /* GX2_TV_SCAN_MODE_NONE  */
@@ -451,6 +455,8 @@ static void *wiiu_gfx_init(const video_info_t *video,
                         FONT_DRIVER_RENDER_WIIU);
 
    {
+      wiiu_fake_context.get_flags = wiiu_get_flags;
+      video_context_driver_set(&wiiu_fake_context); 
       const char *shader_preset   = retroarch_get_shader_preset();
       enum rarch_shader_type type = video_shader_parse_type(shader_preset);
       wiiu_gfx_set_shader(wiiu, type, shader_preset);

--- a/gfx/video_shader_parse.c
+++ b/gfx/video_shader_parse.c
@@ -1179,7 +1179,6 @@ bool video_shader_is_supported(enum rarch_shader_type type)
       default:
          return false;
    }
-   video_driver_get_flags(&flags);
    video_context_driver_get_flags(&flags);
 
    return BIT32_GET(flags.flags, testflag);


### PR DESCRIPTION
## Description

d3d10-12 and gx2 need a way to poll shader flags during init* and since they don't have context drivers, nor a set up poke interface at this point, we add a "fake" context driver as a workaround.

*If they don't, loading content directly via command-line will not load shader presets.

## Related Issues

This commit fixes the similar issue glcore had: #8834

## Related Pull Requests

5d91af629e9837667cfb424902e6796b222d5867

---

P.S. I hope that are all of them.