### PR TITLE
qb: Extend the check_enabled function.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -524,5 +524,5 @@ if [ "$HAVE_DEBUG" = 'yes' ]; then
 fi
 
 check_enabled MENU MENU_WIDGETS 'menu widgets' 'The menu is' false
-check_enabled ZLIB RPNG RPNG 'zlib is' false
+check_enabled 'ZLIB BUILTINZLIB' RPNG RPNG 'zlib is' false
 check_enabled V4L2 VIDEOPROCESSOR 'video processor' 'Video4linux2 is' true

--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -48,21 +48,23 @@ check_compiler()
 }
 
 # check_enabled:
-# $1 = HAVE_$1 [Disabled feature]
+# $1 = HAVE_$1 [Disabled 'feature' or 'feature feature1 feature2', $1 = name]
 # $2 = USER_$2 [Enabled feature]
 # $3 = lib
 # $4 = feature
 # $5 = enable lib when true [checked only if non-empty]
 check_enabled()
-{	tmpvar="$(eval "printf %s \"\$HAVE_$1\"")"
-	setval="$(eval "printf %s \"\$HAVE_$2\"")"
+{	setval="$(eval "printf %s \"\$HAVE_$2\"")"
 
-	if [ "$tmpvar" != 'no' ]; then
-		if [ "$setval" != 'no' ] && [ "${5:-}" = 'true' ]; then
-			eval "HAVE_$2=yes"
+	for val in $(printf %s "$1"); do
+		tmpvar="$(eval "printf %s \"\$HAVE_$val\"")"
+		if [ "$tmpvar" != 'no' ]; then
+			if [ "$setval" != 'no' ] && [ "${5:-}" = 'true' ]; then
+				eval "HAVE_$2=yes"
+			fi
+			return 0
 		fi
-		return 0
-	fi
+	done
 
 	tmpval="$(eval "printf %s \"\$USER_$2\"")"
 


### PR DESCRIPTION
## Description

This extends the `check_enabled` function to be able to check more than one feature. This currently will have no effect except for RPNG, but could be more useful in the future.

## Related Issues

If the system zlib was not found RPNG support would be erroneously disabled even when the builtin zlib was still available. Now RPNG support will only be force disabled when both the system and builtin zlib are disabled.

## Related Pull Requests

This issue was exposed by https://github.com/libretro/RetroArch/pull/8943.
