### PR TITLE
always filter by extensions in shader (preset) file browser

### DIFF
--- a/menu/widgets/menu_filebrowser.c
+++ b/menu/widgets/menu_filebrowser.c
@@ -85,6 +85,10 @@ void filebrowser_parse(menu_displaylist_info_t *info, unsigned type_data)
    else
       subsystem = subsystem_data + content_get_subsystem();
 
+   if (info && (info->type_default == FILE_TYPE_SHADER_PRESET ||
+                info->type_default == FILE_TYPE_SHADER))
+      filter_ext = true;
+
    if (info && string_is_equal(info->label,
             msg_hash_to_str(MENU_ENUM_LABEL_SCAN_FILE)))
       filter_ext = false;


### PR DESCRIPTION
## Description
The "filter unknown extensions" file browser setting should not be honored in the shader (preset) browser, because it will show unsupported shader files (and any other files) otherwise.

## Related Issues
 - fixes contributors having a mental breakdown
