### PR TITLE
Raise menu key repeat delay to account for slow input devices

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -2937,7 +2937,7 @@ static unsigned menu_event(input_bits_t *p_input, input_bits_t *p_trigger_input)
           * for old_input_state. */
 
          first_held  = true;
-         delay_timer = initial_held ? 200 : 100;
+         delay_timer = initial_held ? 300 : 200;
          delay_count = 0;
       }
 


### PR DESCRIPTION
## Description

Some input devices are physically incapable of generating key presses shorter than 100ms. For example, NEC IR remote protocol [has very long messages](https://techdocs.altium.com/display/FPGA/NEC+Infrared+Transmission+Protocol) with each message over 70ms long (plus extra delay to distinguish subsequent messages). That's just protocol overhead, not counting time spent in kernel and user-space OS components. RetroArch defaults to generating key repeat after 100ms, so pressing a key on such devices always appears as two key presses in RetroArch menu UI.

This PR increases key repeat delay by 100ms.

## Related Issues

Different people have encountered a similar issue and solved it in the same way:

https://forums.libretro.com/t/retroarch-on-enigma2/21306