### PR TITLE
fix black screen in Metal

### DIFF
--- a/gfx/common/metal_common.m
+++ b/gfx/common/metal_common.m
@@ -1134,10 +1134,6 @@ typedef struct MTLALIGN(16)
 
 - (BOOL)setShaderFromPath:(NSString *)path
 {
-   /* TODO use stock shader if string_is_empty(path.UTF8String), this is just a safety guard: */
-   if (string_is_empty(path.UTF8String))
-      return YES;
-
    [self _freeVideoShader:_shader];
    _shader = nil;
 

--- a/gfx/drivers/metal.m
+++ b/gfx/drivers/metal.m
@@ -129,11 +129,16 @@ static bool metal_set_shader(void *data,
    if (!md)
       return false;
 
-   if (!string_is_empty(path) && type != RARCH_SHADER_SLANG)
+   if (type != RARCH_SHADER_SLANG)
    {
-      RARCH_WARN("[Metal] Only Slang shaders are supported. Falling back to stock.\n");
+      if (!string_is_empty(path) && type != RARCH_SHADER_SLANG)
+         RARCH_WARN("[Metal] Only Slang shaders are supported. Falling back to stock.\n");
       path = NULL;
    }
+
+   /* TODO actually return to stock */
+   if (string_is_empty(path))
+      return true;
 
    return [md.frameView setShaderFromPath:[NSString stringWithUTF8String:path]];
 #else


### PR DESCRIPTION
## Description

The "safety guard" I added to `setShaderFromPath` would not actually safety guard against `path = NULL`.