### PR TITLE
fix d3d9 not rendering xmb and temporarily disable widgets due to segfault

### DIFF
--- a/gfx/drivers/d3d9.c
+++ b/gfx/drivers/d3d9.c
@@ -2092,7 +2092,7 @@ static bool d3d9_has_windowed(void *data)
 static bool d3d9_menu_widgets_enabled(void *data)
 {
    (void)data;
-   return true;
+   return false; /* currently disabled due to memory issues */
 }
 #endif
 

--- a/menu/menu_animation.h
+++ b/menu/menu_animation.h
@@ -145,10 +145,6 @@ void menu_timer_start(menu_timer_t *timer, menu_timer_ctx_entry_t *timer_entry);
 
 void menu_timer_kill(menu_timer_t *timer);
 
-void menu_animation_init(void);
-
-void menu_animation_free(void);
-
 bool menu_animation_update(void);
 
 bool menu_animation_ticker(menu_animation_ctx_ticker_t *ticker);

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -2224,15 +2224,9 @@ static bool menu_driver_context_reset(bool video_is_threaded)
 
 bool menu_driver_init(bool video_is_threaded)
 {
-   menu_animation_init();
    if (menu_driver_init_internal(video_is_threaded))
       return menu_driver_context_reset(video_is_threaded);
    return false;
-}
-
-void menu_driver_free(void)
-{
-   menu_animation_free();
 }
 
 void menu_driver_navigation_set(bool scroll)

--- a/menu/menu_driver.h
+++ b/menu/menu_driver.h
@@ -525,8 +525,6 @@ bool menu_driver_push_list(menu_ctx_displaylist_t *disp_list);
 
 bool menu_driver_init(bool video_is_threaded);
 
-void menu_driver_free(void);
-
 void menu_driver_set_thumbnail_system(char *s, size_t len);
 
 void menu_driver_get_thumbnail_system(char *s, size_t len);

--- a/retroarch.c
+++ b/retroarch.c
@@ -12340,7 +12340,6 @@ void driver_uninit(int flags)
       menu_widgets_free();
 #endif
       menu_driver_ctl(RARCH_MENU_CTL_DEINIT, NULL);
-      menu_driver_free();
    }
 #endif
 


### PR DESCRIPTION
## Description

d3d9 is calling `d3d9_restore` multiple times upon launching RetroArch.
This will result in multiple `d3d9_initialize` -> `menu_driver_init` -> `menu_animation_init` calls, which would clear all active animations after they've been pushed, resulting in effectively no XMB menu being rendered.

There might be a similar issue happening with menu widgets, where seemingly released textures are used, causing a [segfault](https://hatebin.com/mbwgsnblnq) for example by
 - opening the menu while ingame, while widgets are still showing
 - simply exiting RetroArch

## Changes
 -  automatically initialize the animation list when needed, replaces `menu_animation_init`
 - remove `menu_animation_free` because of it's redundancy to `menu_driver_ctl(RARCH_MENU_CTL_DEINIT, NULL);`
 - disable menu widgets for d3d9 until the segfault is figured out

## Related Pull Requests

#7750
