### PR TITLE
libretrodb: Update the whitespace

### DIFF
--- a/libretro-db/c_converter.c
+++ b/libretro-db/c_converter.c
@@ -531,7 +531,7 @@ static dat_converter_list_t* dat_converter_parser(
                   {
                      if (warning_displayed == false)
                      {
-                        printf("  - Missing match key '");
+                        printf("    - Missing match key '");
                         while (match_key->next)
                         {
                            printf("%s.", match_key->value);
@@ -782,7 +782,7 @@ int main(int argc, char** argv)
 
       if (!dat_file)
       {
-         printf("could not open dat file '%s': %s\n",
+         printf("  could not open dat file '%s': %s\n",
                *argv, strerror(errno));
          dat_converter_exit(1);
       }
@@ -795,7 +795,7 @@ int main(int argc, char** argv)
       fclose(dat_file);
       (*dat_buffer)[dat_file_size] = '\0';
 
-      printf("Parsing dat file '%s'...\n", *argv);
+      printf("  %s\n", *argv);
       dat_lexer_list  = dat_converter_lexer(*dat_buffer, *argv);
       dat_parser_list = dat_converter_parser(
             dat_parser_list, dat_lexer_list, match_key);

--- a/libretro-db/lua/dat_converter.lua
+++ b/libretro-db/lua/dat_converter.lua
@@ -150,17 +150,17 @@ function init(...)
     for _, dat_path in ipairs(args) do
         local dat_file, err = io.open(dat_path, "r")
         if err then
-            error("could not open dat file '" .. dat_path .. "':" .. err)
+            error("  could not open dat file '" .. dat_path .. "':" .. err)
         end
 
-        print("Parsing dat file '" .. dat_path .. "'...")
+        print("  " .. dat_path)
         local objs = dat_parser(dat_lexer(dat_file, dat_path))
         dat_file:close()
         for _, obj in pairs(objs) do
             if match_key then
                 local mk = get_match_key(match_key, obj)
                 if mk == nil then
-                    error("missing match key '" .. match_key .. "' in one of the entries")
+                    error("  missing match key '" .. match_key .. "' in one of the entries")
                 end
                 if dat_hash[mk] == nil then
                     dat_hash[mk] = {}


### PR DESCRIPTION
This cleans up the whitespace in libretro-database to make it output like the following...

```
GCE - Vectrex.rdb
  /tmp/super/retroarch/media/libretrodb/metadat/developer/GCE - Vectrex.dat
  /tmp/super/retroarch/media/libretrodb/metadat/franchise/GCE - Vectrex.dat
  /tmp/super/retroarch/media/libretrodb/metadat/publisher/GCE - Vectrex.dat
  /tmp/super/retroarch/media/libretrodb/metadat/releasemonth/GCE - Vectrex.dat
  /tmp/super/retroarch/media/libretrodb/metadat/releaseyear/GCE - Vectrex.dat
  /tmp/super/retroarch/media/libretrodb/metadat/serial/GCE - Vectrex.dat
  /tmp/super/retroarch/media/libretrodb/metadat/no-intro/GCE - Vectrex.dat
Hartung - Game Master.rdb
  /tmp/super/retroarch/media/libretrodb/metadat/no-intro/Hartung - Game Master.dat
LeapFrog - Leapster Learning Game System.rdb
  /tmp/super/retroarch/media/libretrodb/metadat/no-intro/LeapFrog - Leapster Learning Game System.dat
Magnavox - Odyssey2.rdb
  /tmp/super/retroarch/media/libretrodb/metadat/developer/Magnavox - Odyssey2.dat
  /tmp/super/retroarch/media/libretrodb/metadat/franchise/Magnavox - Odyssey2.dat
  /tmp/super/retroarch/media/libretrodb/metadat/publisher/Magnavox - Odyssey2.dat
  /tmp/super/retroarch/media/libretrodb/metadat/releasemonth/Magnavox - Odyssey2.dat
  /tmp/super/retroarch/media/libretrodb/metadat/releaseyear/Magnavox - Odyssey2.dat
  /tmp/super/retroarch/media/libretrodb/metadat/serial/Magnavox - Odyssey2.dat
  /tmp/super/retroarch/media/libretrodb/metadat/no-intro/Magnavox - Odyssey2.dat
```

A lot more readable than before. Great for debugging.