### PR TITLE
Fall back to libvulkan.so.1 if libvulkan.so isn't present

### DIFF
--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -2000,6 +2000,10 @@ bool vulkan_context_init(gfx_ctx_vulkan_data_t *vk,
       vulkan_library = dylib_load("libMoltenVK.dylib");
 #else
       vulkan_library = dylib_load("libvulkan.so");
+      if (!vulkan_library)
+      {
+         vulkan_library = dylib_load("libvulkan.so.1");
+      }
 #endif
    }
 


### PR DESCRIPTION
## Description

If libvulkan.so fails to load, then try to fall back to libvulkan.so.1.  libvulkan.so is sometimes treated as a development symlink and can be missing even when vulkan is available.

This change lets me launch retroarch with vulkan on ubuntu without the libvulkan-dev package, and would presumably fix the flatpak version as well.

## Related Issues

#7887
https://github.com/flathub/org.libretro.RetroArch/issues/106
