### PR TITLE
iOS: remove pause indicator

### DIFF
--- a/gfx/drivers_context/cocoa_gl_ctx.m
+++ b/gfx/drivers_context/cocoa_gl_ctx.m
@@ -60,7 +60,6 @@ static enum gfx_ctx_api cocoagl_api = GFX_CTX_NONE;
 
 #if defined(HAVE_COCOATOUCH)
 static GLKView *g_view;
-UIView *g_pause_indicator_view;
 #endif
 
 static GLContextClass* g_hw_ctx;
@@ -151,16 +150,9 @@ static void cocoagl_gfx_ctx_set_flags(void *data, uint32_t flags)
 void *glkitview_init(void)
 {
 #if defined(HAVE_COCOATOUCH)
-#if TARGET_OS_IOS
-   /* iOS Pause menu and lifecycle. */
-   UINib *xib = (UINib*)[UINib nibWithNibName:BOXSTRING("PauseIndicatorView") bundle:nil];
-   g_pause_indicator_view = [[xib instantiateWithOwner:[RetroArch_iOS get] options:nil] lastObject];
-#endif
-
    g_view = [GLKView new];
 #if TARGET_OS_IOS
    g_view.multipleTouchEnabled = YES;
-    [g_view addSubview:g_pause_indicator_view];
 #endif
    g_view.enableSetNeedsDisplay = NO;
 

--- a/ui/drivers/cocoa/cocoa_common.m
+++ b/ui/drivers/cocoa/cocoa_common.m
@@ -31,7 +31,6 @@
 #import "GCDWebUploader.h"
 #import "WebServer.h"
 
-extern UIView *g_pause_indicator_view;
 #endif
 
 #ifdef HAVE_METAL
@@ -113,7 +112,10 @@ void *glkitview_init(void);
 #elif defined(HAVE_COCOATOUCH)
    self.view = (BRIDGE GLKView*)glkitview_init();
 #if TARGET_OS_IOS
-   [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(showPauseIndicator) name:UIApplicationWillEnterForegroundNotification object:nil];
+    UISwipeGestureRecognizer *swipe = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(showNativeMenu)];
+    swipe.numberOfTouchesRequired = 4;
+    swipe.direction = UISwipeGestureRecognizerDirectionDown;
+    [self.view addGestureRecognizer:swipe];
 #endif
 #endif
 
@@ -179,6 +181,10 @@ void *glkitview_init(void);
 }
 
 #elif TARGET_OS_IOS
+-(void) showNativeMenu {
+    [[RetroArch_iOS get] toggleUI];
+}
+
 - (UIRectEdge)preferredScreenEdgesDeferringSystemGestures
 {
     return UIRectEdgeBottom;
@@ -218,13 +224,6 @@ void *glkitview_init(void);
     }
 }
 
-- (void)showPauseIndicator
-{
-   g_pause_indicator_view.alpha = 1.0f;
-   [NSObject cancelPreviousPerformRequestsWithTarget:g_instance];
-   [g_instance performSelector:@selector(hidePauseButton) withObject:g_instance afterDelay:3.0f];
-}
-
 - (void)viewWillLayoutSubviews
 {
    float width = 0.0f, height = 0.0f, tenpctw, tenpcth;
@@ -248,19 +247,7 @@ void *glkitview_init(void);
    tenpctw          = width  / 10.0f;
    tenpcth          = height / 10.0f;
 
-   g_pause_indicator_view.frame = CGRectMake(tenpctw * 4.0f, 0.0f, tenpctw * 2.0f, tenpcth);
-   [g_pause_indicator_view viewWithTag:1].frame = CGRectMake(0, 0, tenpctw * 2.0f, tenpcth);
    [self adjustViewFrameForSafeArea];
-}
-
-#define ALMOST_INVISIBLE (.021f)
-
-- (void)hidePauseButton
-{
-   [UIView animateWithDuration:0.2
-      animations:^{ g_pause_indicator_view.alpha = ALMOST_INVISIBLE; }
-      completion:^(BOOL finished) { }
-   ];
 }
 
 /* NOTE: This version runs on iOS6+. */
@@ -295,8 +282,6 @@ void *glkitview_init(void);
 - (void)viewDidAppear:(BOOL)animated
 {
 #if TARGET_OS_IOS
-    /* Pause Menus. */
-    [self showPauseIndicator];
     if (@available(iOS 11.0, *)) {
         [self setNeedsUpdateOfHomeIndicatorAutoHidden];
     }


### PR DESCRIPTION
## Description

Remove the pause indicator for iOS, as it's more obstructive than useful - it frequently interferes with opening the retroarch gui when using the default overlay.

It opens the RetroArch menu using the native UI (UIKit) but it's rather limited - though it might help when you accidentally remove overlays, for example. For this reason, I changed opening the native UI menu to be done using a four-finger swipe down.