### PR TITLE
Add SquirrelJME to the live web core list.

### DIFF
--- a/pkg/emscripten/libretro/index.html
+++ b/pkg/emscripten/libretro/index.html
@@ -70,6 +70,7 @@
                            <a class="dropdown-item" href="." data-core="snes9x2005">Snes9x 2005</a>
                            <a class="dropdown-item" href="." data-core="snes9x2010">Snes9x 2010</a>
                            <a class="dropdown-item" href="." data-core="snes9x">Snes9x</a>
+                           <a class="dropdown-item" href="." data-core="squirreljme">SquirrelJME</a>
                            <a class="dropdown-item" href="." data-core="stella">Stella</a>
                            <a class="dropdown-item" href="." data-core="tgbdual">TGB Dual</a>
                            <a class="dropdown-item" href="." data-core="theodore">Theodore (Thomson TO8/TO9)</a>


### PR DESCRIPTION
This adds SquirrelJME to the list of cores for the web demo <https://web.libretro.com/>.