### PR TITLE
initial CD reading support

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1617,6 +1617,15 @@ ifeq ($(HAVE_ZLIB_COMMON), 1)
    endif
 endif
 
+ifeq ($(HAVE_CDROM), 1)
+   ifeq ($(CDROM_DEBUG), 1)
+      DEFINES += -DCDROM_DEBUG
+   endif
+
+   DEFINES += -DHAVE_CDROM
+   OBJ += $(LIBRETRO_COMM_DIR)/cdrom/cdrom.o
+endif
+
 ifeq ($(HAVE_RTGA), 1)
    DEFINES += -DHAVE_RTGA
    OBJ += $(LIBRETRO_COMM_DIR)/formats/tga/rtga.o

--- a/Makefile.common
+++ b/Makefile.common
@@ -1623,7 +1623,8 @@ ifeq ($(HAVE_CDROM), 1)
    endif
 
    DEFINES += -DHAVE_CDROM
-   OBJ += $(LIBRETRO_COMM_DIR)/cdrom/cdrom.o
+   OBJ += $(LIBRETRO_COMM_DIR)/cdrom/cdrom.o \
+       $(LIBRETRO_COMM_DIR)/vfs/vfs_implementation_cdrom.o
 endif
 
 ifeq ($(HAVE_RTGA), 1)

--- a/core_type.h
+++ b/core_type.h
@@ -1,5 +1,6 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2011-2017 - Daniel De Matteis
+ *  Copyright (C) 2016-2019 - Brad Parker
  *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-

--- a/dynamic.c
+++ b/dynamic.c
@@ -1,6 +1,7 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
  *  Copyright (C) 2011-2017 - Daniel De Matteis
+ *  Copyright (C) 2016-2019 - Brad Parker
  *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-

--- a/dynamic.h
+++ b/dynamic.h
@@ -1,6 +1,7 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
  *  Copyright (C) 2011-2017 - Daniel De Matteis
+ *  Copyright (C) 2016-2019 - Brad Parker
  *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-

--- a/file_path_special.c
+++ b/file_path_special.c
@@ -1,5 +1,6 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2011-2017 - Daniel De Matteis
+ *  Copyright (C) 2016-2019 - Brad Parker
  *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-

--- a/file_path_special.h
+++ b/file_path_special.h
@@ -1,6 +1,7 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
  *  Copyright (C) 2011-2016 - Daniel De Matteis
+ *  Copyright (C) 2016-2019 - Brad Parker
  *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-

--- a/griffin/griffin.c
+++ b/griffin/griffin.c
@@ -1,6 +1,7 @@
 /* RetroArch - A frontend for libretro.
 * Copyright (C) 2010-2014 - Hans-Kristian Arntzen
 * Copyright (C) 2011-2017 - Daniel De Matteis
+* Copyright (C) 2016-2019 - Brad Parker
 *
 * RetroArch is free software: you can redistribute it and/or modify it under the terms
 * of the GNU General Public License as published by the Free Software Found-

--- a/griffin/griffin_cpp.cpp
+++ b/griffin/griffin_cpp.cpp
@@ -1,5 +1,6 @@
 /* RetroArch - A frontend for libretro.
 * Copyright (C) 2011-2017 - Daniel De Matteis
+* Copyright (C) 2016-2019 - Brad Parker
 *
 * RetroArch is free software: you can redistribute it and/or modify it under the terms
 * of the GNU General Public License as published by the Free Software Found-

--- a/libretro-common/cdrom/cdrom.c
+++ b/libretro-common/cdrom/cdrom.c
@@ -151,6 +151,7 @@ retry:
          case 2:
          case 3:
          case 4:
+         case 6:
             if (retries_left)
             {
 #ifdef CDROM_DEBUG

--- a/libretro-common/cdrom/cdrom.c
+++ b/libretro-common/cdrom/cdrom.c
@@ -213,7 +213,9 @@ retry:
 #endif
    {
       rv = 0;
-      memcpy(buf, xfer_buf + skip, len);
+
+      if (buf)
+         memcpy(buf, xfer_buf + skip, len);
    }
    else
    {
@@ -516,6 +518,7 @@ int cdrom_write_cue(libretro_vfs_implementation_file *stream, char **out_buf, si
       unsigned char pmin = buf[4 + (i * 11) + 8];
       unsigned char psec = buf[4 + (i * 11) + 9];
       unsigned char pframe = buf[4 + (i * 11) + 10];
+      unsigned lba = msf_to_lba(pmin, psec, pframe);
 
       /*printf("i %d control %d adr %d tno %d point %d: ", i, control, adr, tno, point);*/
       /* why is control always 0? */
@@ -538,6 +541,7 @@ int cdrom_write_cue(libretro_vfs_implementation_file *stream, char **out_buf, si
          toc->track[point - 1].min = pmin;
          toc->track[point - 1].sec = psec;
          toc->track[point - 1].frame = pframe;
+         toc->track[point - 1].lba = lba;
          toc->track[point - 1].mode = mode;
          toc->track[point - 1].audio = audio;
 

--- a/libretro-common/cdrom/cdrom.c
+++ b/libretro-common/cdrom/cdrom.c
@@ -560,7 +560,7 @@ int cdrom_write_cue(libretro_vfs_implementation_file *stream, char **out_buf, si
          pos += snprintf(*out_buf + pos, len - pos, "FILE \"cdrom://drive%c-track%02d.bin\" BINARY\n", cdrom_drive, point);
 #endif
          pos += snprintf(*out_buf + pos, len - pos, "  TRACK %02d %s\n", point, track_type);
-         pos += snprintf(*out_buf + pos, len - pos, "    INDEX 01 %02d:%02d:%02d\n", pmin, psec, pframe);
+         pos += snprintf(*out_buf + pos, len - pos, "    INDEX 01 00:00:00\n");
       }
    }
 

--- a/libretro-common/cdrom/cdrom.c
+++ b/libretro-common/cdrom/cdrom.c
@@ -140,8 +140,6 @@ static int cdrom_send_command_linux(int fd, CDROM_CMD_Direction dir, void *buf, 
    sg_io_hdr_t sgio = {0};
    int rv;
 
-   sgio.interface_id = 'S';
-
    switch (dir)
    {
       case DIRECTION_IN:
@@ -156,15 +154,11 @@ static int cdrom_send_command_linux(int fd, CDROM_CMD_Direction dir, void *buf, 
          break;
    }
 
+   sgio.interface_id = 'S';
    sgio.cmd_len = cmd_len;
    sgio.cmdp = cmd;
-
-   if (xfer_buf)
-      sgio.dxferp = buf;
-
-   if (len)
-      sgio.dxfer_len = len;
-
+   sgio.dxferp = buf;
+   sgio.dxfer_len = len;
    sgio.sbp = sense;
    sgio.mx_sb_len = sense_len;
    sgio.timeout = 30000;

--- a/libretro-common/cdrom/cdrom.c
+++ b/libretro-common/cdrom/cdrom.c
@@ -1,0 +1,461 @@
+/* Copyright  (C) 2010-2019 The RetroArch team
+*
+* ---------------------------------------------------------------------------------------
+* The following license statement only applies to this file (cdrom.c).
+* ---------------------------------------------------------------------------------------
+*
+* Permission is hereby granted, free of charge,
+* to any person obtaining a copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation the rights to
+* use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+* and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+* INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+* WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <cdrom/cdrom.h>
+#include <libretro.h>
+#include <stdio.h>
+#include <string.h>
+#include <compat/strl.h>
+#include <retro_math.h>
+#include <streams/file_stream.h>
+#include <retro_endianness.h>
+
+#include <math.h>
+
+#ifdef __linux__
+#include <stropts.h>
+#include <scsi/sg.h>
+#endif
+
+#define CDROM_CUE_TRACK_BYTES 78
+
+typedef enum
+{
+   DIRECTION_NONE,
+   DIRECTION_IN,
+   DIRECTION_OUT
+} CDROM_CMD_Direction;
+
+void lba_to_msf(unsigned lba, unsigned char *min, unsigned char *sec, unsigned char *frame)
+{
+   if (!min || !sec || !frame)
+      return;
+
+   *frame = lba % 75;
+   lba /= 75;
+   *sec = lba % 60;
+   lba /= 60;
+   *min = lba;
+}
+
+unsigned msf_to_lba(unsigned char min, unsigned char sec, unsigned char frame)
+{
+   return (min * 60 + sec) * 75 + frame;
+}
+
+void increment_msf(unsigned char *min, unsigned char *sec, unsigned char *frame)
+{
+   if (!min || !sec || !frame)
+      return;
+
+   *min = (*frame == 74) ? (*sec < 59 ? *min : *min + 1) : *min;
+   *sec = (*frame == 74) ? (*sec < 59 ? (*sec + 1) : 0) : *sec;
+   *frame = (*frame < 74) ? (*frame + 1) : 0;
+}
+
+static int cdrom_send_command(int fd, CDROM_CMD_Direction dir, void *buf, size_t len, unsigned char *cmd, size_t cmd_len)
+{
+#ifdef __linux__
+   sg_io_hdr_t sgio = {0};
+   unsigned char sense[SG_MAX_SENSE] = {0};
+   int rv;
+
+   if (!cmd || cmd_len == 0)
+      return 1;
+
+   sgio.interface_id = 'S';
+
+   switch (dir)
+   {
+      case DIRECTION_IN:
+         sgio.dxfer_direction = SG_DXFER_FROM_DEV;
+         break;
+      case DIRECTION_OUT:
+         sgio.dxfer_direction = SG_DXFER_TO_DEV;
+         break;
+      case DIRECTION_NONE:
+      default:
+         sgio.dxfer_direction = SG_DXFER_NONE;
+         break;
+   }
+
+   sgio.cmd_len = cmd_len;
+   sgio.cmdp = cmd;
+
+   if (buf)
+      sgio.dxferp = buf;
+
+   if (len)
+      sgio.dxfer_len = len;
+
+   sgio.sbp = sense;
+   sgio.mx_sb_len = sizeof(sense);
+   sgio.timeout = 30000;
+
+   rv = ioctl(fd, SG_IO, &sgio);
+
+#ifdef CDROM_DEBUG
+   if (sgio.info & SG_INFO_CHECK)
+   {
+      unsigned i;
+
+      printf("CHECK CONDITION\n");
+
+      for (i = 0; i < SG_MAX_SENSE; i++)
+      {
+         printf("%02X ", sense[i]);
+      }
+
+      printf("\n");
+
+      if (sense[0] == 0x70)
+         printf("CURRENT ERROR:\n");
+      if (sense[0] == 0x71)
+         printf("DEFERRED ERROR:\n");
+
+      printf("Sense Key: %02X\n", sense[2] & 0xF);
+      printf("ASC: %02X\n", sense[12]);
+      printf("ASCQ: %02X\n", sense[13]);
+   }
+#endif
+
+   if (rv == -1)
+      return 1;
+
+   return 0;
+#else
+   (void)fd;
+   (void)dir;
+   (void)buf;
+   (void)len;
+   (void)cmd;
+   (void)cmd_len;
+
+   return 1;
+#endif
+}
+
+int cdrom_read_subq(int fd, unsigned char *buf, size_t len)
+{
+   /* MMC Command: READ TOC/PMA/ATIP */
+   unsigned char cdb[] = {0x43, 0x2, 0x2, 0, 0, 0, 0x1, 0x9, 0x30, 0};
+#ifdef CDROM_DEBUG
+   unsigned short data_len = 0;
+   unsigned char first_session = 0;
+   unsigned char last_session = 0;
+   int i;
+#endif
+   int rv;
+
+   if (!buf)
+      return 1;
+
+   rv = cdrom_send_command(fd, DIRECTION_IN, buf, len, cdb, sizeof(cdb));
+
+   if (rv)
+     return 1;
+
+#ifdef CDROM_DEBUG
+   data_len = buf[0] << 8 | buf[1];
+   first_session = buf[2];
+   last_session = buf[3];
+
+   printf("Data Length: %d\n", data_len);
+   printf("First Session: %d\n", first_session);
+   printf("Last Session: %d\n", last_session);
+
+   for (i = 0; i < (data_len - 2) / 11; i++)
+   {
+      unsigned char session_num = buf[4 + (i * 11) + 0];
+      unsigned char adr = (buf[4 + (i * 11) + 1] >> 4) & 0xF;
+      /*unsigned char control = buf[4 + (i * 11) + 1] & 0xF;*/
+      unsigned char tno = buf[4 + (i * 11) + 2];
+      unsigned char point = buf[4 + (i * 11) + 3];
+      unsigned char pmin = buf[4 + (i * 11) + 8];
+      unsigned char psec = buf[4 + (i * 11) + 9];
+      unsigned char pframe = buf[4 + (i * 11) + 10];
+
+      /*printf("i %d control %d adr %d tno %d point %d: ", i, control, adr, tno, point);*/
+      /* why is control always 0? */
+
+      if (/*(control == 4 || control == 6) && */adr == 1 && tno == 0 && point >= 1 && point <= 99)
+      {
+         printf("- Session#: %d TNO %d POINT %d ", session_num, tno, point);
+         printf("Track start time: (MSF %02u:%02u:%02u) ", pmin, psec, pframe);
+      }
+      else if (/*(control == 4 || control == 6) && */adr == 1 && tno == 0 && point == 0xA0)
+      {
+         printf("- Session#: %d TNO %d POINT %d ", session_num, tno, point);
+         printf("First Track Number: %d ", pmin);
+         printf("Disc Type: %d ", psec);
+      }
+      else if (/*(control == 4 || control == 6) && */adr == 1 && tno == 0 && point == 0xA1)
+      {
+         printf("- Session#: %d TNO %d POINT %d ", session_num, tno, point);
+         printf("Last Track Number: %d ", pmin);
+      }
+      else if (/*(control == 4 || control == 6) && */adr == 1 && tno == 0 && point == 0xA2)
+      {
+         printf("- Session#: %d TNO %d POINT %d ", session_num, tno, point);
+         printf("Lead-out runtime: (MSF %02u:%02u:%02u) ", pmin, psec, pframe);
+      }
+
+      printf("\n");
+   }
+#endif
+   return 0;
+}
+
+static int cdrom_read_track_info(int fd, unsigned char track, cdrom_toc_t *toc)
+{
+   /* MMC Command: READ TRACK INFORMATION */
+   unsigned char cdb[] = {0x52, 0x1, 0, 0, 0, track, 0, 0x1, 0x80, 0};
+   unsigned char buf[384] = {0};
+   unsigned lba = 0;
+   unsigned track_size = 0;
+   int rv = cdrom_send_command(fd, DIRECTION_IN, buf, sizeof(buf), cdb, sizeof(cdb));
+
+   if (rv)
+     return 1;
+
+   memcpy(&lba, buf + 8, 4);
+   memcpy(&track_size, buf + 24, 4);
+
+   lba = swap_if_little32(lba);
+   track_size = swap_if_little32(track_size);
+
+   toc->track[track - 1].lba_start = lba;
+   toc->track[track - 1].track_size = track_size;
+
+#ifdef CDROM_DEBUG
+   printf("Track %d Info: ", track);
+   printf("Copy: %d ", (buf[5] & 0x10) > 0);
+   printf("Data Mode: %d ", buf[6] & 0xF);
+   printf("LBA Start: %d ", lba);
+   printf("Track Size: %d\n", track_size);
+#endif
+
+   return 0;
+}
+
+int cdrom_write_cue(int fd, char **out_buf, size_t *out_len, char cdrom_drive, unsigned char *num_tracks, cdrom_toc_t *toc)
+{
+   unsigned char buf[2352] = {0};
+   unsigned short data_len = 0;
+   size_t len = 0;
+   size_t pos = 0;
+   int rv = 0;
+   int i;
+
+   if (!out_buf || !out_len || !num_tracks || !toc)
+   {
+#ifdef CDROM_DEBUG
+      printf("Invalid buffer/length pointer for CDROM cue sheet\n");
+#endif
+      return 1;
+   }
+
+   rv = cdrom_read_subq(fd, buf, sizeof(buf));
+
+   if (rv)
+      return rv;
+
+   data_len = buf[0] << 8 | buf[1];
+
+   for (i = 0; i < (data_len - 2) / 11; i++)
+   {
+      unsigned char adr = (buf[4 + (i * 11) + 1] >> 4) & 0xF;
+      unsigned char tno = buf[4 + (i * 11) + 2];
+      unsigned char point = buf[4 + (i * 11) + 3];
+      unsigned char pmin = buf[4 + (i * 11) + 8];
+
+      if (/*(control == 4 || control == 6) && */adr == 1 && tno == 0 && point == 0xA1)
+      {
+         *num_tracks = pmin;
+#ifdef CDROM_DEBUG
+         printf("Number of CDROM tracks: %d\n", *num_tracks);
+#endif
+         break;
+      }
+   }
+
+   if (!*num_tracks || *num_tracks > 99)
+   {
+#ifdef CDROM_DEBUG
+      printf("Invalid number of CDROM tracks: %d\n", *num_tracks);
+#endif
+      return 1;
+   }
+
+   len = CDROM_CUE_TRACK_BYTES * (*num_tracks);
+   toc->num_tracks = *num_tracks;
+   *out_buf = (char*)calloc(1, len);
+   *out_len = len;
+
+   for (i = 0; i < (data_len - 2) / 11; i++)
+   {
+      /*unsigned char session_num = buf[4 + (i * 11) + 0];*/
+      unsigned char adr = (buf[4 + (i * 11) + 1] >> 4) & 0xF;
+      /*unsigned char control = buf[4 + (i * 11) + 1] & 0xF;*/
+      unsigned char tno = buf[4 + (i * 11) + 2];
+      unsigned char point = buf[4 + (i * 11) + 3];
+      unsigned char pmin = buf[4 + (i * 11) + 8];
+      unsigned char psec = buf[4 + (i * 11) + 9];
+      unsigned char pframe = buf[4 + (i * 11) + 10];
+
+      /*printf("i %d control %d adr %d tno %d point %d: ", i, control, adr, tno, point);*/
+      /* why is control always 0? */
+
+      if (/*(control == 4 || control == 6) && */adr == 1 && tno == 0 && point >= 1 && point <= 99)
+      {
+         unsigned char next_pmin = (pframe == 74) ? (psec < 59 ? pmin : pmin + 1) : pmin;
+         unsigned char next_psec = (pframe == 74) ? (psec < 59 ? (psec + 1) : 0) : psec;
+         unsigned char next_pframe = (pframe < 74) ? (pframe + 1) : 0;
+         /* MMC Command: READ CD MSF */
+         unsigned char q_cdb[] = {0xB9, 0, 0, pmin, psec, pframe, next_pmin, next_psec, next_pframe, 0, 0x2, 0};
+         unsigned char q_buf[3] = {0};
+         unsigned char mode = 1;
+         bool audio = false;
+         const char *track_type = "MODE1/2352";
+
+         rv = cdrom_send_command(fd, DIRECTION_IN, q_buf, sizeof(q_buf), q_cdb, sizeof(q_cdb));
+
+         if (rv)
+            continue;
+
+         mode = q_buf[0] & 0xF;
+         audio = (q_buf[0] & 0x40) == 0;
+
+#ifdef CDROM_DEBUG
+         printf("Track %02d CONTROL %02X %02X %02X MODE %d AUDIO? %d\n", point, q_buf[0], q_buf[1], q_buf[2], mode, audio);
+#endif
+
+         toc->track[point - 1].track_num = point;
+         toc->track[point - 1].min = pmin;
+         toc->track[point - 1].sec = psec;
+         toc->track[point - 1].frame = pframe;
+         toc->track[point - 1].mode = mode;
+         toc->track[point - 1].audio = audio;
+
+         if (audio)
+            track_type = "AUDIO";
+         else if (mode == 1)
+            track_type = "MODE1/2352";
+         else if (mode == 2)
+            track_type = "MODE2/2352";
+
+         pos += snprintf(*out_buf + pos, len - pos, "FILE \"cdrom://drive%c.bin\" BINARY\n", cdrom_drive);
+         pos += snprintf(*out_buf + pos, len - pos, "  TRACK %02d %s\n", point, track_type);
+         pos += snprintf(*out_buf + pos, len - pos, "    INDEX 01 %02d:%02d:%02d\n", pmin, psec, pframe);
+
+         cdrom_read_track_info(fd, point, toc);
+      }
+   }
+
+   return 0;
+}
+
+/* needs 32 bytes for full vendor, product and version */
+int cdrom_get_inquiry(int fd, char *model, int len)
+{
+   /* MMC Command: INQUIRY */
+   unsigned char cdb[] = {0x12, 0, 0, 0, 0xff, 0};
+   unsigned char buf[256] = {0};
+   int rv = cdrom_send_command(fd, DIRECTION_IN, buf, sizeof(buf), cdb, sizeof(cdb));
+
+   if (rv)
+      return 1;
+
+   if (model && len >= 32)
+   {
+      memset(model, 0, len);
+
+      /* vendor */
+      memcpy(model, buf + 8, 8);
+
+      model[8] = ' ';
+
+      /* product */
+      memcpy(model + 9, buf + 16, 16);
+
+      model[25] = ' ';
+
+      /* version */
+      memcpy(model + 26, buf + 32, 4);
+   }
+
+   return 0;
+}
+
+int cdrom_read(int fd, unsigned char min, unsigned char sec, unsigned char frame, void *s, size_t len)
+{
+   /* MMC Command: READ CD MSF */
+   unsigned char cdb[] = {0xB9, 0, 0, min, sec, frame, 0, 0, 0, 0xF8, 0, 0};
+   int rv;
+
+   if (len <= 2352)
+   {
+      unsigned char next_min = (frame == 74) ? (sec < 59 ? min : min + 1) : min;
+      unsigned char next_sec = (frame == 74) ? (sec < 59 ? (sec + 1) : 0) : sec;
+      unsigned char next_frame = (frame < 74) ? (frame + 1) : 0;
+
+      cdb[6] = next_min;
+      cdb[7] = next_sec;
+      cdb[8] = next_frame;
+   }
+   else
+   {
+      unsigned frames = round(len / 2352.0);
+
+      cdb[6] = frames / 75 / 60;
+      cdb[7] = frames / 75;
+      cdb[8] = frames - ((cdb[6] * 75 * 60) + (cdb[7] * 75));
+
+      if (cdb[8] > 74)
+      {
+         cdb[8] = 0;
+         cdb[7]++;
+
+         if (cdb[7] > 59)
+         {
+            cdb[7] = 0;
+            cdb[6]++;
+         }
+      }
+   }
+
+   rv = cdrom_send_command(fd, DIRECTION_IN, s, len, cdb, sizeof(cdb));
+
+#ifdef CDROM_DEBUG
+   printf("read status code %d\n", rv);
+#endif
+
+   if (rv)
+      return 1;
+
+   return 0;
+}
+

--- a/libretro-common/cdrom/cdrom.c
+++ b/libretro-common/cdrom/cdrom.c
@@ -199,6 +199,7 @@ static int cdrom_send_command(libretro_vfs_implementation_file *stream, CDROM_CM
       }
 
       printf("\n");
+      fflush(stdout);
    }
 #endif
 
@@ -230,6 +231,7 @@ retry:
             {
 #ifdef CDROM_DEBUG
                printf("CDROM Read Retry...\n");
+               fflush(stdout);
 #endif
                retries_left--;
                usleep(1000 * 1000);
@@ -240,6 +242,7 @@ retry:
                rv = 1;
 #ifdef CDROM_DEBUG
                printf("CDROM Read Retries failed, giving up.\n");
+               fflush(stdout);
 #endif
             }
 
@@ -312,6 +315,8 @@ retry:
       printf("Sense Key: %02X (%s)\n", sense[2] & 0xF, sense_key_text);
       printf("ASC: %02X\n", sense[12]);
       printf("ASCQ: %02X\n", sense[13]);
+
+      fflush(stdout);
 
       rv = 1;
 #endif
@@ -390,6 +395,8 @@ int cdrom_read_subq(libretro_vfs_implementation_file *stream, unsigned char *buf
 
       printf("\n");
    }
+
+   fflush(stdout);
 #endif
    return 0;
 }
@@ -422,6 +429,7 @@ static int cdrom_read_track_info(libretro_vfs_implementation_file *stream, unsig
    printf("Data Mode: %d ", buf[6] & 0xF);
    printf("LBA Start: %d ", lba);
    printf("Track Size: %d\n", track_size);
+   fflush(stdout);
 #endif
 
    return 0;
@@ -440,6 +448,7 @@ int cdrom_write_cue(libretro_vfs_implementation_file *stream, char **out_buf, si
    {
 #ifdef CDROM_DEBUG
       printf("Invalid buffer/length pointer for CDROM cue sheet\n");
+      fflush(stdout);
 #endif
       return 1;
    }
@@ -463,6 +472,7 @@ int cdrom_write_cue(libretro_vfs_implementation_file *stream, char **out_buf, si
          *num_tracks = pmin;
 #ifdef CDROM_DEBUG
          printf("Number of CDROM tracks: %d\n", *num_tracks);
+         fflush(stdout);
 #endif
          break;
       }
@@ -472,6 +482,7 @@ int cdrom_write_cue(libretro_vfs_implementation_file *stream, char **out_buf, si
    {
 #ifdef CDROM_DEBUG
       printf("Invalid number of CDROM tracks: %d\n", *num_tracks);
+      fflush(stdout);
 #endif
       return 1;
    }
@@ -497,9 +508,6 @@ int cdrom_write_cue(libretro_vfs_implementation_file *stream, char **out_buf, si
 
       if (/*(control == 4 || control == 6) && */adr == 1 && tno == 0 && point >= 1 && point <= 99)
       {
-         unsigned char next_pmin = (pframe == 74) ? (psec < 59 ? pmin : pmin + 1) : pmin;
-         unsigned char next_psec = (pframe == 74) ? (psec < 59 ? (psec + 1) : 0) : psec;
-         unsigned char next_pframe = (pframe < 74) ? (pframe + 1) : 0;
          unsigned char mode = 1;
          bool audio = false;
          const char *track_type = "MODE1/2352";
@@ -509,6 +517,7 @@ int cdrom_write_cue(libretro_vfs_implementation_file *stream, char **out_buf, si
 
 #ifdef CDROM_DEBUG
          printf("Track %02d CONTROL %01X ADR %01X MODE %d AUDIO? %d\n", point, control, adr, mode, audio);
+         fflush(stdout);
 #endif
 
          toc->track[point - 1].track_num = point;
@@ -586,6 +595,7 @@ int cdrom_read(libretro_vfs_implementation_file *stream, unsigned char min, unsi
 
 #ifdef CDROM_DEBUG
       printf("single-frame read: from %d %d %d to %d %d %d skip %" PRId64 "\n", cdb[3], cdb[4], cdb[5], cdb[6], cdb[7], cdb[8], skip);
+      fflush(stdout);
 #endif
    }
    else
@@ -596,6 +606,7 @@ int cdrom_read(libretro_vfs_implementation_file *stream, unsigned char min, unsi
 
 #ifdef CDROM_DEBUG
       printf("multi-frame read: from %d %d %d to %d %d %d skip %" PRId64 "\n", cdb[3], cdb[4], cdb[5], cdb[6], cdb[7], cdb[8], skip);
+      fflush(stdout);
 #endif
    }
 
@@ -603,6 +614,7 @@ int cdrom_read(libretro_vfs_implementation_file *stream, unsigned char min, unsi
 
 #ifdef CDROM_DEBUG
    printf("read status code %d\n", rv);
+   fflush(stdout);
 #endif
 
    if (rv)

--- a/libretro-common/cdrom/cdrom.c
+++ b/libretro-common/cdrom/cdrom.c
@@ -438,6 +438,15 @@ static int cdrom_read_track_info(libretro_vfs_implementation_file *stream, unsig
    return 0;
 }
 
+int cdrom_set_read_speed(libretro_vfs_implementation_file *stream, unsigned speed)
+{
+   unsigned new_speed = swap_if_big32(speed);
+   /* MMC Command: SET CD SPEED */
+   unsigned char cmd[] = {0xBB, 0, (new_speed >> 24) & 0xFF, (new_speed >> 16) & 0xFF, (new_speed >> 8) & 0xFF, new_speed & 0xFF, 0, 0, 0, 0, 0, 0 };
+
+   return cdrom_send_command(stream, DIRECTION_NONE, NULL, 0, cmd, sizeof(cmd), 0);
+}
+
 int cdrom_write_cue(libretro_vfs_implementation_file *stream, char **out_buf, size_t *out_len, char cdrom_drive, unsigned char *num_tracks, cdrom_toc_t *toc)
 {
    unsigned char buf[2352] = {0};
@@ -455,6 +464,8 @@ int cdrom_write_cue(libretro_vfs_implementation_file *stream, char **out_buf, si
 #endif
       return 1;
    }
+
+   cdrom_set_read_speed(stream, 0xFFFFFFFF);
 
    rv = cdrom_read_subq(stream, buf, sizeof(buf));
 

--- a/libretro-common/cdrom/cdrom.c
+++ b/libretro-common/cdrom/cdrom.c
@@ -536,7 +536,11 @@ int cdrom_write_cue(libretro_vfs_implementation_file *stream, char **out_buf, si
 
          cdrom_read_track_info(stream, point, toc);
 
+#ifdef _WIN32
+         pos += snprintf(*out_buf + pos, len - pos, "FILE \"cdrom://%c://drive-track%02d.bin\" BINARY\n", cdrom_drive, point);
+#else
          pos += snprintf(*out_buf + pos, len - pos, "FILE \"cdrom://drive%c-track%02d.bin\" BINARY\n", cdrom_drive, point);
+#endif
          pos += snprintf(*out_buf + pos, len - pos, "  TRACK %02d %s\n", point, track_type);
          pos += snprintf(*out_buf + pos, len - pos, "    INDEX 01 %02d:%02d:%02d\n", pmin, psec, pframe);
       }

--- a/libretro-common/cdrom/cdrom.c
+++ b/libretro-common/cdrom/cdrom.c
@@ -220,6 +220,9 @@ retry:
       unsigned i;
       const char *sense_key_text = NULL;
 
+      (void)sense_key_text;
+      (void)i;
+
       switch (sense[2] & 0xF)
       {
          case 0:

--- a/libretro-common/include/cdrom/cdrom.h
+++ b/libretro-common/include/cdrom/cdrom.h
@@ -34,6 +34,12 @@
 
 #include <boolean.h>
 
+#ifdef VFS_FRONTEND
+typedef struct retro_vfs_file_handle libretro_vfs_implementation_file;
+#else
+typedef struct libretro_vfs_implementation_file libretro_vfs_implementation_file;
+#endif
+
 RETRO_BEGIN_DECLS
 
 typedef struct
@@ -63,14 +69,14 @@ unsigned msf_to_lba(unsigned char min, unsigned char sec, unsigned char frame);
 
 void increment_msf(unsigned char *min, unsigned char *sec, unsigned char *frame);
 
-int cdrom_read_subq(int fd, unsigned char *buf, size_t len);
+int cdrom_read_subq(libretro_vfs_implementation_file *stream, unsigned char *buf, size_t len);
 
-int cdrom_write_cue(int fd, char **out_buf, size_t *out_len, char cdrom_drive, unsigned char *num_tracks, cdrom_toc_t *toc);
+int cdrom_write_cue(libretro_vfs_implementation_file *stream, char **out_buf, size_t *out_len, char cdrom_drive, unsigned char *num_tracks, cdrom_toc_t *toc);
 
 /* needs 32 bytes for full vendor, product and version */
-int cdrom_get_inquiry(int fd, char *model, int len);
+int cdrom_get_inquiry(libretro_vfs_implementation_file *stream, char *model, int len);
 
-int cdrom_read(int fd, unsigned char min, unsigned char sec, unsigned char frame, void *s, size_t len, size_t skip);
+int cdrom_read(libretro_vfs_implementation_file *stream, unsigned char min, unsigned char sec, unsigned char frame, void *s, size_t len, size_t skip);
 
 RETRO_END_DECLS
 

--- a/libretro-common/include/cdrom/cdrom.h
+++ b/libretro-common/include/cdrom/cdrom.h
@@ -44,10 +44,11 @@ RETRO_BEGIN_DECLS
 
 typedef struct
 {
-   unsigned lba_start;
+   unsigned lba_start; /* start of pregap */
+   unsigned lba; /* start of data */
    unsigned track_size;
    unsigned char track_num;
-   unsigned char min;
+   unsigned char min; /* start of data */
    unsigned char sec;
    unsigned char frame;
    unsigned char mode;

--- a/libretro-common/include/cdrom/cdrom.h
+++ b/libretro-common/include/cdrom/cdrom.h
@@ -1,0 +1,77 @@
+/* Copyright  (C) 2010-2019 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (cdrom.h).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef __LIBRETRO_SDK_CDROM_H
+#define __LIBRETRO_SDK_CDROM_H
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <sys/types.h>
+
+#include <libretro.h>
+#include <retro_common_api.h>
+#include <retro_inline.h>
+
+#include <boolean.h>
+
+RETRO_BEGIN_DECLS
+
+typedef struct
+{
+   unsigned lba_start;
+   unsigned track_size;
+   unsigned char track_num;
+   unsigned char min;
+   unsigned char sec;
+   unsigned char frame;
+   unsigned char mode;
+   bool audio;
+} cdrom_track_t;
+
+typedef struct
+{
+   unsigned char cur_min;
+   unsigned char cur_sec;
+   unsigned char cur_frame;
+   unsigned char num_tracks;
+   cdrom_track_t track[99];
+} cdrom_toc_t;
+
+void lba_to_msf(unsigned lba, unsigned char *min, unsigned char *sec, unsigned char *frame);
+
+unsigned msf_to_lba(unsigned char min, unsigned char sec, unsigned char frame);
+
+void increment_msf(unsigned char *min, unsigned char *sec, unsigned char *frame);
+
+int cdrom_read_subq(int fd, unsigned char *buf, size_t len);
+
+int cdrom_write_cue(int fd, char **out_buf, size_t *out_len, char cdrom_drive, unsigned char *num_tracks, cdrom_toc_t *toc);
+
+/* needs 32 bytes for full vendor, product and version */
+int cdrom_get_inquiry(int fd, char *model, int len);
+
+int cdrom_read(int fd, unsigned char min, unsigned char sec, unsigned char frame, void *s, size_t len);
+
+RETRO_END_DECLS
+
+#endif

--- a/libretro-common/include/cdrom/cdrom.h
+++ b/libretro-common/include/cdrom/cdrom.h
@@ -70,7 +70,7 @@ int cdrom_write_cue(int fd, char **out_buf, size_t *out_len, char cdrom_drive, u
 /* needs 32 bytes for full vendor, product and version */
 int cdrom_get_inquiry(int fd, char *model, int len);
 
-int cdrom_read(int fd, unsigned char min, unsigned char sec, unsigned char frame, void *s, size_t len);
+int cdrom_read(int fd, unsigned char min, unsigned char sec, unsigned char frame, void *s, size_t len, size_t skip);
 
 RETRO_END_DECLS
 

--- a/libretro-common/include/cdrom/cdrom.h
+++ b/libretro-common/include/cdrom/cdrom.h
@@ -56,9 +56,7 @@ typedef struct
 
 typedef struct
 {
-   unsigned char cur_min;
-   unsigned char cur_sec;
-   unsigned char cur_frame;
+   char drive;
    unsigned char num_tracks;
    cdrom_track_t track[99];
 } cdrom_toc_t;

--- a/libretro-common/include/cdrom/cdrom.h
+++ b/libretro-common/include/cdrom/cdrom.h
@@ -76,6 +76,8 @@ int cdrom_get_inquiry(libretro_vfs_implementation_file *stream, char *model, int
 
 int cdrom_read(libretro_vfs_implementation_file *stream, unsigned char min, unsigned char sec, unsigned char frame, void *s, size_t len, size_t skip);
 
+int cdrom_set_read_speed(libretro_vfs_implementation_file *stream, unsigned speed);
+
 RETRO_END_DECLS
 
 #endif

--- a/libretro-common/include/streams/file_stream.h
+++ b/libretro-common/include/streams/file_stream.h
@@ -36,6 +36,7 @@
 #include <boolean.h>
 
 #include <stdarg.h>
+#include <vfs/vfs_implementation.h>
 
 #define FILESTREAM_REQUIRED_VFS_VERSION 2
 
@@ -105,6 +106,8 @@ const char *filestream_get_path(RFILE *stream);
 bool filestream_exists(const char *path);
 
 char *filestream_getline(RFILE *stream);
+
+const libretro_vfs_implementation_file* filestream_get_vfs_handle(RFILE *stream);
 
 RETRO_END_DECLS
 

--- a/libretro-common/include/vfs/vfs_implementation.h
+++ b/libretro-common/include/vfs/vfs_implementation.h
@@ -23,6 +23,7 @@
 #ifndef __LIBRETRO_SDK_VFS_IMPLEMENTATION_H
 #define __LIBRETRO_SDK_VFS_IMPLEMENTATION_H
 
+#include <stdio.h>
 #include <stdint.h>
 #include <libretro.h>
 

--- a/libretro-common/include/vfs/vfs_implementation.h
+++ b/libretro-common/include/vfs/vfs_implementation.h
@@ -26,6 +26,10 @@
 #include <stdint.h>
 #include <libretro.h>
 
+#ifdef HAVE_CDROM
+#include <vfs/vfs_implementation_cdrom.h>
+#endif
+
 #ifdef _WIN32
 typedef void* HANDLE;
 #endif
@@ -56,10 +60,7 @@ struct libretro_vfs_implementation_file
    uint8_t *mapped;
    enum vfs_scheme scheme;
 #ifdef HAVE_CDROM
-   char *cdrom_cue_buf;
-   size_t cdrom_cue_len;
-   size_t cdrom_byte_pos;
-   char cdrom_drive;
+   vfs_cdrom_t cdrom;
 #endif
 };
 

--- a/libretro-common/include/vfs/vfs_implementation.h
+++ b/libretro-common/include/vfs/vfs_implementation.h
@@ -26,6 +26,10 @@
 #include <stdint.h>
 #include <libretro.h>
 
+#ifdef _WIN32
+typedef void* HANDLE;
+#endif
+
 enum vfs_scheme
 {
    VFS_SCHEME_NONE = 0,
@@ -43,6 +47,9 @@ struct libretro_vfs_implementation_file
    int64_t size;
    char *buf;
    FILE *fp;
+#ifdef _WIN32
+   HANDLE fh;
+#endif
    char* orig_path;
    uint64_t mappos;
    uint64_t mapsize;

--- a/libretro-common/include/vfs/vfs_implementation.h
+++ b/libretro-common/include/vfs/vfs_implementation.h
@@ -26,6 +26,36 @@
 #include <stdint.h>
 #include <libretro.h>
 
+enum vfs_scheme
+{
+   VFS_SCHEME_NONE = 0,
+   VFS_SCHEME_CDROM
+};
+
+#ifdef VFS_FRONTEND
+struct retro_vfs_file_handle
+#else
+struct libretro_vfs_implementation_file
+#endif
+{
+   int fd;
+   unsigned hints;
+   int64_t size;
+   char *buf;
+   FILE *fp;
+   char* orig_path;
+   uint64_t mappos;
+   uint64_t mapsize;
+   uint8_t *mapped;
+   enum vfs_scheme scheme;
+#ifdef HAVE_CDROM
+   char *cdrom_cue_buf;
+   size_t cdrom_cue_len;
+   size_t cdrom_byte_pos;
+   char cdrom_drive;
+#endif
+};
+
 /* Replace the following symbol with something appropriate
  * to signify the file is being compiled for a front end instead of a core.
  * This allows the same code to act as reference implementation

--- a/libretro-common/include/vfs/vfs_implementation_cdrom.h
+++ b/libretro-common/include/vfs/vfs_implementation_cdrom.h
@@ -24,9 +24,26 @@
 #define __LIBRETRO_SDK_VFS_IMPLEMENTATION_CDROM_H
 
 #include <cdrom/cdrom.h>
-#include <vfs/vfs_implementation.h>
 
 RETRO_BEGIN_DECLS
+
+typedef struct
+{
+   char *cue_buf;
+   size_t cue_len;
+   size_t byte_pos;
+   char drive;
+   unsigned char cur_min;
+   unsigned char cur_sec;
+   unsigned char cur_frame;
+   unsigned char cur_track;
+} vfs_cdrom_t;
+
+#ifdef VFS_FRONTEND
+struct retro_vfs_file_handle;
+#else
+struct libretro_vfs_implementation_file;
+#endif
 
 int64_t retro_vfs_file_seek_cdrom(libretro_vfs_implementation_file *stream, int64_t offset, int whence);
 
@@ -42,6 +59,8 @@ int64_t retro_vfs_file_read_cdrom(libretro_vfs_implementation_file *stream,
       void *s, uint64_t len);
 
 int retro_vfs_file_error_cdrom(libretro_vfs_implementation_file *stream);
+
+const cdrom_toc_t* retro_vfs_file_get_cdrom_toc(void);
 
 RETRO_END_DECLS
 

--- a/libretro-common/include/vfs/vfs_implementation_cdrom.h
+++ b/libretro-common/include/vfs/vfs_implementation_cdrom.h
@@ -27,6 +27,8 @@
 
 RETRO_BEGIN_DECLS
 
+typedef struct RFILE RFILE;
+
 typedef struct
 {
    char *cue_buf;
@@ -61,6 +63,8 @@ int64_t retro_vfs_file_read_cdrom(libretro_vfs_implementation_file *stream,
 int retro_vfs_file_error_cdrom(libretro_vfs_implementation_file *stream);
 
 const cdrom_toc_t* retro_vfs_file_get_cdrom_toc(void);
+
+const vfs_cdrom_t* retro_vfs_file_get_cdrom_position(const libretro_vfs_implementation_file *stream);
 
 RETRO_END_DECLS
 

--- a/libretro-common/include/vfs/vfs_implementation_cdrom.h
+++ b/libretro-common/include/vfs/vfs_implementation_cdrom.h
@@ -1,0 +1,46 @@
+/* Copyright  (C) 2010-2019 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (vfs_implementation_cdrom.h).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef __LIBRETRO_SDK_VFS_IMPLEMENTATION_CDROM_H
+#define __LIBRETRO_SDK_VFS_IMPLEMENTATION_CDROM_H
+
+#include <cdrom/cdrom.h>
+#include <vfs/vfs_implementation.h>
+
+RETRO_BEGIN_DECLS
+
+int64_t retro_vfs_file_seek_cdrom(libretro_vfs_implementation_file *stream, int64_t offset, int whence);
+
+FILE* retro_vfs_file_open_cdrom(
+      libretro_vfs_implementation_file *stream,
+      const char *path, unsigned mode, unsigned hints);
+
+int retro_vfs_file_close_cdrom(libretro_vfs_implementation_file *stream);
+
+int64_t retro_vfs_file_tell_cdrom(libretro_vfs_implementation_file *stream);
+
+int64_t retro_vfs_file_read_cdrom(libretro_vfs_implementation_file *stream,
+      void *s, uint64_t len);
+
+RETRO_END_DECLS
+
+#endif

--- a/libretro-common/include/vfs/vfs_implementation_cdrom.h
+++ b/libretro-common/include/vfs/vfs_implementation_cdrom.h
@@ -33,12 +33,13 @@ typedef struct
 {
    char *cue_buf;
    size_t cue_len;
-   size_t byte_pos;
+   int64_t byte_pos;
    char drive;
    unsigned char cur_min;
    unsigned char cur_sec;
    unsigned char cur_frame;
    unsigned char cur_track;
+   unsigned cur_lba;
 } vfs_cdrom_t;
 
 #ifdef VFS_FRONTEND

--- a/libretro-common/include/vfs/vfs_implementation_cdrom.h
+++ b/libretro-common/include/vfs/vfs_implementation_cdrom.h
@@ -30,7 +30,7 @@ RETRO_BEGIN_DECLS
 
 int64_t retro_vfs_file_seek_cdrom(libretro_vfs_implementation_file *stream, int64_t offset, int whence);
 
-FILE* retro_vfs_file_open_cdrom(
+void retro_vfs_file_open_cdrom(
       libretro_vfs_implementation_file *stream,
       const char *path, unsigned mode, unsigned hints);
 
@@ -40,6 +40,8 @@ int64_t retro_vfs_file_tell_cdrom(libretro_vfs_implementation_file *stream);
 
 int64_t retro_vfs_file_read_cdrom(libretro_vfs_implementation_file *stream,
       void *s, uint64_t len);
+
+int retro_vfs_file_error_cdrom(libretro_vfs_implementation_file *stream);
 
 RETRO_END_DECLS
 

--- a/libretro-common/streams/file_stream.c
+++ b/libretro-common/streams/file_stream.c
@@ -609,3 +609,8 @@ char *filestream_getline(RFILE *stream)
    newline[idx]      = '\0';
    return newline;
 }
+
+const libretro_vfs_implementation_file* filestream_get_vfs_handle(RFILE *stream)
+{
+   return (const libretro_vfs_implementation_file*)stream->hfile;
+}

--- a/libretro-common/vfs/vfs_implementation.c
+++ b/libretro-common/vfs/vfs_implementation.c
@@ -490,6 +490,7 @@ libretro_vfs_implementation_file *retro_vfs_file_open_impl(
    stream->size = orbisLseek(stream->fd, 0, SEEK_END);
    orbisLseek(stream->fd, 0, SEEK_SET);
 #else
+#ifdef HAVE_CDROM
    if (stream->scheme == VFS_SCHEME_CDROM)
    {
       retro_vfs_file_seek_cdrom(stream, 0, SEEK_SET);
@@ -500,6 +501,7 @@ libretro_vfs_implementation_file *retro_vfs_file_open_impl(
       retro_vfs_file_seek_cdrom(stream, 0, SEEK_SET);
    }
    else
+#endif
    {
       retro_vfs_file_seek_internal(stream, 0, SEEK_SET);
       retro_vfs_file_seek_internal(stream, 0, SEEK_END);

--- a/libretro-common/vfs/vfs_implementation.c
+++ b/libretro-common/vfs/vfs_implementation.c
@@ -521,7 +521,7 @@ int retro_vfs_file_close_impl(libretro_vfs_implementation_file *stream)
    {
       if (stream->fp)
       {
-            fclose(stream->fp);
+         fclose(stream->fp);
       }
    }
    else
@@ -549,8 +549,8 @@ end:
       free(stream->orig_path);
 
 #ifdef HAVE_CDROM
-   if (stream->cdrom_cue_buf)
-      free(stream->cdrom_cue_buf);
+   if (stream->cdrom.cue_buf)
+      free(stream->cdrom.cue_buf);
 #endif
    free(stream);
 

--- a/libretro-common/vfs/vfs_implementation.c
+++ b/libretro-common/vfs/vfs_implementation.c
@@ -409,10 +409,14 @@ libretro_vfs_implementation_file *retro_vfs_file_open_impl(
 #ifdef HAVE_CDROM
       if (stream->scheme == VFS_SCHEME_CDROM)
       {
-         fp = retro_vfs_file_open_cdrom(stream, path, mode, hints);
-
-         if (!fp)
+         retro_vfs_file_open_cdrom(stream, path, mode, hints);
+#ifdef _WIN32
+         if (!stream->fh)
             goto error;
+#else
+         if (!stream->fp)
+            goto error;
+#endif
       }
       else
 #endif
@@ -551,9 +555,12 @@ int retro_vfs_file_error_impl(libretro_vfs_implementation_file *stream)
 #ifdef ORBIS
    /* TODO/FIXME - implement this? */
    return 0;
-#else
-   return ferror(stream->fp);
 #endif
+#ifdef HAVE_CDROM
+   if (stream->scheme == VFS_SCHEME_CDROM)
+      return retro_vfs_file_error_cdrom(stream);
+#endif
+   return ferror(stream->fp);
 }
 
 int64_t retro_vfs_file_size_impl(libretro_vfs_implementation_file *stream)

--- a/libretro-common/vfs/vfs_implementation.c
+++ b/libretro-common/vfs/vfs_implementation.c
@@ -555,17 +555,17 @@ int retro_vfs_file_close_impl(libretro_vfs_implementation_file *stream)
       close(stream->fd);
 #endif
    }
+#ifdef HAVE_CDROM
 end:
+   if (stream->cdrom.cue_buf)
+      free(stream->cdrom.cue_buf);
+#endif
    if (stream->buf)
       free(stream->buf);
 
    if (stream->orig_path)
       free(stream->orig_path);
 
-#ifdef HAVE_CDROM
-   if (stream->cdrom.cue_buf)
-      free(stream->cdrom.cue_buf);
-#endif
    free(stream);
 
    return 0;

--- a/libretro-common/vfs/vfs_implementation.c
+++ b/libretro-common/vfs/vfs_implementation.c
@@ -854,11 +854,20 @@ int64_t retro_vfs_file_read_impl(libretro_vfs_implementation_file *stream,
 
          if (string_is_equal_noncase(ext, "cue"))
          {
+            if (len < stream->cdrom_cue_len - stream->cdrom_cue_pos)
+            {
 #ifdef CDROM_DEBUG
-            printf("CDROM Read: Reading %lu bytes from cuesheet starting at %lu...\n", len, stream->cdrom_cue_pos);
+               printf("CDROM Read: Reading %lu bytes from cuesheet starting at %lu...\n", len, stream->cdrom_cue_pos);
 #endif
-            strlcpy(s, stream->cdrom_cue_buf + stream->cdrom_cue_pos, len);
-            stream->cdrom_cue_pos += len;
+               memcpy(s, stream->cdrom_cue_buf + stream->cdrom_cue_pos, len);
+               stream->cdrom_cue_pos += len;
+            }
+            else
+            {
+#ifdef CDROM_DEBUG
+               printf("CDROM Read: Reading %lu bytes from cuesheet starting at %lu failed.\n", len, stream->cdrom_cue_pos);
+#endif
+            }
          }
          else if (string_is_equal_noncase(ext, "bin"))
          {

--- a/libretro-common/vfs/vfs_implementation.c
+++ b/libretro-common/vfs/vfs_implementation.c
@@ -158,12 +158,6 @@
 #define FIO_S_ISDIR SCE_S_ISDIR
 #endif
 
-#if defined(__linux__)
-#include <math.h>
-#include <stropts.h>
-#include <scsi/sg.h>
-#endif
-
 #if (defined(__CELLOS_LV2__) && !defined(__PSL1GHT__)) || defined(__QNX__) || defined(PSP)
 #include <unistd.h> /* stat() is defined here */
 #endif
@@ -197,45 +191,10 @@
 #include <file/file_path.h>
 
 #ifdef HAVE_CDROM
-#include <cdrom/cdrom.h>
+#include <vfs/vfs_implementation_cdrom.h>
 #endif
 
 #define RFILE_HINT_UNBUFFERED (1 << 8)
-
-enum vfs_scheme
-{
-   VFS_SCHEME_NONE = 0,
-   VFS_SCHEME_CDROM
-};
-
-#ifdef VFS_FRONTEND
-struct retro_vfs_file_handle
-#else
-struct libretro_vfs_implementation_file
-#endif
-{
-   int fd;
-   unsigned hints;
-   int64_t size;
-   char *buf;
-   FILE *fp;
-   char* orig_path;
-#if defined(HAVE_MMAP)
-   uint64_t mappos;
-   uint64_t mapsize;
-   uint8_t *mapped;
-#endif
-   enum vfs_scheme scheme;
-#ifdef HAVE_CDROM
-   char *cdrom_cue_buf;
-   size_t cdrom_cue_len;
-   size_t cdrom_cue_pos;
-   size_t cdrom_byte_pos;
-   char cdrom_drive;
-#endif
-};
-
-static cdrom_toc_t vfs_cdrom_toc = {0};
 
 int64_t retro_vfs_file_seek_internal(libretro_vfs_implementation_file *stream, int64_t offset, int whence)
 {
@@ -263,79 +222,7 @@ int64_t retro_vfs_file_seek_internal(libretro_vfs_implementation_file *stream, i
 #else
 #ifdef HAVE_CDROM
       if (stream->scheme == VFS_SCHEME_CDROM)
-      {
-         const char *ext = path_get_extension(stream->orig_path);
-
-         if (string_is_equal_noncase(ext, "cue"))
-         {
-            switch (whence)
-            {
-               case SEEK_SET:
-                  stream->cdrom_cue_pos = offset;
-                  break;
-               case SEEK_CUR:
-                  stream->cdrom_cue_pos += offset;
-                  break;
-               case SEEK_END:
-                  stream->cdrom_cue_pos = (stream->cdrom_cue_len - 1) + offset;
-                  break;
-            }
-
-#ifdef CDROM_DEBUG
-            printf("CDROM Seek: Path %s Offset %lu is now at %lu\n", stream->orig_path, offset, stream->cdrom_cue_pos);
-#endif
-         }
-         else if (string_is_equal_noncase(ext, "bin"))
-         {
-            unsigned char min = offset / 75 / 60;
-            unsigned char sec = offset / 75;
-            unsigned char frame = offset - ((min * 75 * 60) + (sec * 75));
-
-            switch (whence)
-            {
-               case SEEK_CUR:
-               {
-                  min += vfs_cdrom_toc.cur_min;
-                  sec += vfs_cdrom_toc.cur_sec;
-                  frame += vfs_cdrom_toc.cur_frame;
-
-                  stream->cdrom_byte_pos += offset;
-
-                  break;
-               }
-               case SEEK_END:
-               {
-                  unsigned char end_min = 0;
-                  unsigned char end_sec = 0;
-                  unsigned char end_frame = 0;
-                  size_t end_lba = vfs_cdrom_toc.track[vfs_cdrom_toc.num_tracks - 1].lba_start + vfs_cdrom_toc.track[vfs_cdrom_toc.num_tracks - 1].track_size;
-
-                  lba_to_msf(end_lba, &min, &sec, &frame);
-
-                  min += end_min;
-                  sec += end_sec;
-                  frame += end_frame;
-
-                  stream->cdrom_byte_pos = end_lba * 2352;
-
-                  break;
-               }
-               case SEEK_SET:
-               default:
-                  stream->cdrom_byte_pos = offset;
-                  break;
-            }
-
-            vfs_cdrom_toc.cur_min = min;
-            vfs_cdrom_toc.cur_sec = sec;
-            vfs_cdrom_toc.cur_frame = frame;
-
-#ifdef CDROM_DEBUG
-            printf("CDROM Seek: Path %s Offset %lu is now at %lu\n", stream->orig_path, offset, stream->cdrom_byte_pos);
-#endif
-         }
-
-      }
+         return retro_vfs_file_seek_cdrom(stream, offset, whence);
       else
 #endif
          return fseeko(stream->fp, (off_t)offset, whence);
@@ -421,7 +308,7 @@ libretro_vfs_implementation_file *retro_vfs_file_open_impl(
       size_t cdrom_prefix_siz = strlen(cdrom_prefix);
       int cdrom_prefix_len = (int)cdrom_prefix_siz;
 
-      if (path_len >= cdrom_prefix_len)
+      if (path_len > cdrom_prefix_len)
       {
          if (!memcmp(path, cdrom_prefix, cdrom_prefix_len))
          {
@@ -522,70 +409,10 @@ libretro_vfs_implementation_file *retro_vfs_file_open_impl(
 #ifdef HAVE_CDROM
       if (stream->scheme == VFS_SCHEME_CDROM)
       {
-#ifdef __linux__
-         char model[32] = {0};
-         char cdrom_path[] = "/dev/sg1";
-         size_t path_len = strlen(path);
-         const char *ext = path_get_extension(path);
+         fp = retro_vfs_file_open_cdrom(stream, path, mode, hints);
 
-         if (path_len >= strlen("drive1.cue"))
-         {
-            if (!memcmp(path, "drive", strlen("drive")))
-            {
-               if (path[5] >= '0' && path[5] <= '9')
-               {
-                  cdrom_path[7] = path[5];
-                  stream->cdrom_drive = path[5];
-               }
-            }
-         }
-
-#ifdef CDROM_DEBUG
-         printf("CDROM Open: Path %s URI %s\n", cdrom_path, path);
-#endif
-         fp = (FILE*)fopen_utf8(cdrom_path, "r+b");
-
-         if (fp)
-         {
-            int cdrom_fd = fileno(fp);
-
-            if (!cdrom_get_inquiry(cdrom_fd, model, sizeof(model)))
-            {
-               size_t len = 0;
-
-#ifdef CDROM_DEBUG
-               printf("CDROM Model: %s\n", model);
-#endif
-            }
-         }
-         else
+         if (!fp)
             goto error;
-
-         if (string_is_equal_noncase(ext, "cue"))
-         {
-            if (stream->cdrom_cue_buf)
-            {
-               free(stream->cdrom_cue_buf);
-               stream->cdrom_cue_buf = NULL;
-            }
-
-            cdrom_write_cue(fileno(fp), &stream->cdrom_cue_buf, &stream->cdrom_cue_len, stream->cdrom_drive, &vfs_cdrom_toc.num_tracks, &vfs_cdrom_toc);
-
-            if (vfs_cdrom_toc.num_tracks > 1)
-            {
-               vfs_cdrom_toc.cur_min = vfs_cdrom_toc.track[0].min;
-               vfs_cdrom_toc.cur_sec = vfs_cdrom_toc.track[0].sec;
-               vfs_cdrom_toc.cur_frame = vfs_cdrom_toc.track[0].frame;
-            }
-
-            if (string_is_empty(stream->cdrom_cue_buf))
-               printf("Error writing cue sheet.\n");
-#ifdef CDROM_DEBUG
-            else
-               printf("CDROM CUE Sheet:\n%s\n", stream->cdrom_cue_buf);
-#endif
-         }
-#endif
       }
       else
 #endif
@@ -678,7 +505,14 @@ int retro_vfs_file_close_impl(libretro_vfs_implementation_file *stream)
    if ((stream->hints & RFILE_HINT_UNBUFFERED) == 0)
    {
       if (stream->fp)
-         fclose(stream->fp);
+      {
+#ifdef HAVE_CDROM
+         if (stream->scheme == VFS_SCHEME_CDROM)
+            retro_vfs_file_close_cdrom(stream);
+         else
+#endif
+            fclose(stream->fp);
+      }
    }
    else
    {
@@ -699,13 +533,6 @@ int retro_vfs_file_close_impl(libretro_vfs_implementation_file *stream)
    }
    if (stream->buf)
       free(stream->buf);
-
-#ifdef HAVE_CDROM
-#ifdef CDROM_DEBUG
-   if (stream->scheme == VFS_SCHEME_CDROM)
-      printf("CDROM Close: Path %s\n", stream->orig_path);
-#endif
-#endif
 
    if (stream->orig_path)
       free(stream->orig_path);
@@ -771,30 +598,7 @@ int64_t retro_vfs_file_tell_impl(libretro_vfs_implementation_file *stream)
 #else
 #ifdef HAVE_CDROM
       if (stream->scheme == VFS_SCHEME_CDROM)
-      {
-         const char *ext = path_get_extension(stream->orig_path);
-
-         if (string_is_equal_noncase(ext, "cue"))
-         {
-#ifdef HAVE_CDROM
-#ifdef CDROM_DEBUG
-            printf("CDROM (cue) Tell: Path %s Position %lu\n", stream->orig_path, stream->cdrom_cue_pos);
-#endif
-#endif
-            return stream->cdrom_cue_pos;
-         }
-         else if (string_is_equal_noncase(ext, "bin"))
-         {
-            unsigned lba = msf_to_lba(vfs_cdrom_toc.cur_min, vfs_cdrom_toc.cur_sec, vfs_cdrom_toc.cur_frame);
-
-#ifdef HAVE_CDROM
-#ifdef CDROM_DEBUG
-            printf("CDROM (bin) Tell: Path %s Position %u\n", stream->orig_path, lba * 2352);
-#endif
-#endif
-            return lba * 2352;
-         }
-      }
+         return retro_vfs_file_tell_cdrom(stream);
       else
 #endif
          return ftell(stream->fp);
@@ -848,60 +652,7 @@ int64_t retro_vfs_file_read_impl(libretro_vfs_implementation_file *stream,
 #else
 #ifdef HAVE_CDROM
       if (stream->scheme == VFS_SCHEME_CDROM)
-      {
-         int rv;
-         const char *ext = path_get_extension(stream->orig_path);
-
-         if (string_is_equal_noncase(ext, "cue"))
-         {
-            if (len < stream->cdrom_cue_len - stream->cdrom_cue_pos)
-            {
-#ifdef CDROM_DEBUG
-               printf("CDROM Read: Reading %lu bytes from cuesheet starting at %lu...\n", len, stream->cdrom_cue_pos);
-#endif
-               memcpy(s, stream->cdrom_cue_buf + stream->cdrom_cue_pos, len);
-               stream->cdrom_cue_pos += len;
-            }
-            else
-            {
-#ifdef CDROM_DEBUG
-               printf("CDROM Read: Reading %lu bytes from cuesheet starting at %lu failed.\n", len, stream->cdrom_cue_pos);
-#endif
-            }
-         }
-         else if (string_is_equal_noncase(ext, "bin"))
-         {
-            unsigned frames = len / 2352;
-            unsigned i;
-
-#ifdef CDROM_DEBUG
-            printf("CDROM Read: Reading %lu bytes from CD starting at byte offset %lu (MSF %02d:%02d:%02d) (LBA %u)...\n", len, stream->cdrom_byte_pos, vfs_cdrom_toc.cur_min, vfs_cdrom_toc.cur_sec, vfs_cdrom_toc.cur_frame, msf_to_lba(vfs_cdrom_toc.cur_min, vfs_cdrom_toc.cur_sec, vfs_cdrom_toc.cur_frame));
-#endif
-
-            rv = cdrom_read(fileno(stream->fp), vfs_cdrom_toc.cur_min, vfs_cdrom_toc.cur_sec, vfs_cdrom_toc.cur_frame, s, (size_t)len);
-
-            if (rv)
-            {
-#ifdef CDROM_DEBUG
-               printf("Failed to read %lu bytes from CD.\n", len);
-#endif
-               return 0;
-            }
-
-            stream->cdrom_byte_pos += len;
-
-            for (i = 0; i < frames; i++)
-            {
-               increment_msf(&vfs_cdrom_toc.cur_min, &vfs_cdrom_toc.cur_sec, &vfs_cdrom_toc.cur_frame);
-            }
-
-#ifdef CDROM_DEBUG
-            printf("CDROM read %lu bytes, position is now: %lu (MSF %02d:%02d:%02d) (LBA %u)\n", len, stream->cdrom_byte_pos, vfs_cdrom_toc.cur_min, vfs_cdrom_toc.cur_sec, vfs_cdrom_toc.cur_frame, msf_to_lba(vfs_cdrom_toc.cur_min, vfs_cdrom_toc.cur_sec, vfs_cdrom_toc.cur_frame));
-#endif
-         }
-
-         return len;
-      }
+         return retro_vfs_file_read_cdrom(stream, s, len);
       else
 #endif
          return fread(s, 1, (size_t)len, stream->fp);

--- a/libretro-common/vfs/vfs_implementation_cdrom.c
+++ b/libretro-common/vfs/vfs_implementation_cdrom.c
@@ -52,6 +52,7 @@ int64_t retro_vfs_file_seek_cdrom(libretro_vfs_implementation_file *stream, int6
 
 #ifdef CDROM_DEBUG
       printf("CDROM Seek: Path %s Offset %" PRIu64 " is now at %" PRIu64 "\n", stream->orig_path, offset, stream->cdrom_byte_pos);
+      fflush(stdout);
 #endif
    }
    else if (string_is_equal_noncase(ext, "bin"))
@@ -98,8 +99,6 @@ int64_t retro_vfs_file_seek_cdrom(libretro_vfs_implementation_file *stream, int6
          case SEEK_SET:
          default:
          {
-            unsigned lba = msf_to_lba(min, sec, frame);
-
             seek_type = "SEEK_SET";
             stream->cdrom_byte_pos = offset;
 
@@ -113,6 +112,7 @@ int64_t retro_vfs_file_seek_cdrom(libretro_vfs_implementation_file *stream, int6
 
 #ifdef CDROM_DEBUG
       printf("CDROM Seek %s: Path %s Offset %" PRIu64 " is now at %" PRIu64 " (MSF %02d:%02d:%02d) (LBA %u)...\n", seek_type, stream->orig_path, offset, stream->cdrom_byte_pos, vfs_cdrom_toc.cur_min, vfs_cdrom_toc.cur_sec, vfs_cdrom_toc.cur_frame, msf_to_lba(vfs_cdrom_toc.cur_min, vfs_cdrom_toc.cur_sec, vfs_cdrom_toc.cur_frame));
+      fflush(stdout);
 #endif
    }
    else
@@ -148,6 +148,7 @@ void retro_vfs_file_open_cdrom(
 
 #ifdef CDROM_DEBUG
    printf("CDROM Open: Path %s URI %s\n", cdrom_path, path);
+   fflush(stdout);
 #endif
    stream->fp = (FILE*)fopen_utf8(cdrom_path, "r+b");
 
@@ -155,10 +156,9 @@ void retro_vfs_file_open_cdrom(
    {
       if (!cdrom_get_inquiry(stream, model, sizeof(model)))
       {
-         size_t len = 0;
-
 #ifdef CDROM_DEBUG
          printf("CDROM Model: %s\n", model);
+         fflush(stdout);
 #endif
       }
    }
@@ -184,7 +184,10 @@ void retro_vfs_file_open_cdrom(
 
 #ifdef CDROM_DEBUG
       if (string_is_empty(stream->cdrom_cue_buf))
+      {
          printf("Error writing cue sheet.\n");
+         fflush(stdout);
+      }
       else
       {
          printf("CDROM CUE Sheet:\n%s\n", stream->cdrom_cue_buf);
@@ -216,6 +219,7 @@ void retro_vfs_file_open_cdrom(
 
 #ifdef CDROM_DEBUG
    printf("CDROM Open: Path %s URI %s\n", cdrom_path, path);
+   fflush(stdout);
 #endif
    stream->fh = CreateFile(cdrom_path, GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
 
@@ -229,6 +233,7 @@ void retro_vfs_file_open_cdrom(
 
 #ifdef CDROM_DEBUG
          printf("CDROM Model: %s\n", model);
+         fflush(stdout);
 #endif
       }
    }
@@ -252,7 +257,10 @@ void retro_vfs_file_open_cdrom(
 
 #ifdef CDROM_DEBUG
       if (string_is_empty(stream->cdrom_cue_buf))
+      {
          printf("Error writing cue sheet.\n");
+         fflush(stdout);
+      }
       else
       {
          printf("CDROM CUE Sheet:\n%s\n", stream->cdrom_cue_buf);
@@ -266,8 +274,8 @@ void retro_vfs_file_open_cdrom(
 int retro_vfs_file_close_cdrom(libretro_vfs_implementation_file *stream)
 {
 #ifdef CDROM_DEBUG
-   if (stream->scheme == VFS_SCHEME_CDROM)
-      printf("CDROM Close: Path %s\n", stream->orig_path);
+   printf("CDROM Close: Path %s\n", stream->orig_path);
+   fflush(stdout);
 #endif
 
 #ifdef _WIN32
@@ -292,6 +300,7 @@ int64_t retro_vfs_file_tell_cdrom(libretro_vfs_implementation_file *stream)
    {
 #ifdef CDROM_DEBUG
       printf("CDROM (cue) Tell: Path %s Position %" PRIu64 "\n", stream->orig_path, stream->cdrom_byte_pos);
+      fflush(stdout);
 #endif
       return stream->cdrom_byte_pos;
    }
@@ -301,6 +310,7 @@ int64_t retro_vfs_file_tell_cdrom(libretro_vfs_implementation_file *stream)
 
 #ifdef CDROM_DEBUG
       printf("CDROM (bin) Tell: Path %s Position %u\n", stream->orig_path, lba * 2352);
+      fflush(stdout);
 #endif
       return lba * 2352;
    }
@@ -320,6 +330,7 @@ int64_t retro_vfs_file_read_cdrom(libretro_vfs_implementation_file *stream,
       {
 #ifdef CDROM_DEBUG
          printf("CDROM Read: Reading %" PRIu64 " bytes from cuesheet starting at %" PRIu64 "...\n", len, stream->cdrom_byte_pos);
+         fflush(stdout);
 #endif
          memcpy(s, stream->cdrom_cue_buf + stream->cdrom_byte_pos, len);
          stream->cdrom_byte_pos += len;
@@ -330,6 +341,7 @@ int64_t retro_vfs_file_read_cdrom(libretro_vfs_implementation_file *stream,
       {
 #ifdef CDROM_DEBUG
          printf("CDROM Read: Reading %" PRIu64 " bytes from cuesheet starting at %" PRIu64 " failed.\n", len, stream->cdrom_byte_pos);
+         fflush(stdout);
 #endif
          return 0;
       }
@@ -353,6 +365,7 @@ int64_t retro_vfs_file_read_cdrom(libretro_vfs_implementation_file *stream,
 
 #ifdef CDROM_DEBUG
       printf("CDROM Read: Reading %" PRIu64 " bytes from %s starting at byte offset %" PRIu64 " (MSF %02d:%02d:%02d) (LBA %u) skip %" PRIu64 "...\n", len, stream->orig_path, stream->cdrom_byte_pos, min, sec, frame, msf_to_lba(min, sec, frame), skip);
+      fflush(stdout);
 #endif
 
       rv = cdrom_read(stream, min, sec, frame, s, (size_t)len, skip);
@@ -361,6 +374,7 @@ int64_t retro_vfs_file_read_cdrom(libretro_vfs_implementation_file *stream,
       {
 #ifdef CDROM_DEBUG
          printf("Failed to read %" PRIu64 " bytes from CD.\n", len);
+         fflush(stdout);
 #endif
          return 0;
       }
@@ -374,6 +388,7 @@ int64_t retro_vfs_file_read_cdrom(libretro_vfs_implementation_file *stream,
 
 #ifdef CDROM_DEBUG
       printf("CDROM read %" PRIu64 " bytes, position is now: %" PRIu64 " (MSF %02d:%02d:%02d) (LBA %u)\n", len, stream->cdrom_byte_pos, vfs_cdrom_toc.cur_min, vfs_cdrom_toc.cur_sec, vfs_cdrom_toc.cur_frame, msf_to_lba(vfs_cdrom_toc.cur_min, vfs_cdrom_toc.cur_sec, vfs_cdrom_toc.cur_frame));
+      fflush(stdout);
 #endif
 
       return len;

--- a/libretro-common/vfs/vfs_implementation_cdrom.c
+++ b/libretro-common/vfs/vfs_implementation_cdrom.c
@@ -147,7 +147,7 @@ void retro_vfs_file_open_cdrom(
       {
          if (!memcmp(path + 6, "-track", strlen("-track")))
          {
-            if (sscanf(path + 12, "%02hhd", &stream->cdrom.cur_track))
+            if (sscanf(path + 12, "%02u", (unsigned*)&stream->cdrom.cur_track))
             {
 #ifdef CDROM_DEBUG
                printf("CDROM: Opening track %d\n", stream->cdrom.cur_track);
@@ -227,7 +227,7 @@ void retro_vfs_file_open_cdrom(
    {
       if (!memcmp(path + 1, ":/drive-track", strlen(":/drive-track")))
       {
-         if (sscanf(path + 14, "%02hhd", &stream->cdrom.cur_track))
+         if (sscanf(path + 14, "%02u", (unsigned*)&stream->cdrom.cur_track))
          {
 #ifdef CDROM_DEBUG
             printf("CDROM: Opening track %d\n", stream->cdrom.cur_track);

--- a/libretro-common/vfs/vfs_implementation_cdrom.c
+++ b/libretro-common/vfs/vfs_implementation_cdrom.c
@@ -68,6 +68,8 @@ int64_t retro_vfs_file_seek_cdrom(libretro_vfs_implementation_file *stream, int6
       unsigned char frame = 0;
       const char *seek_type = "SEEK_SET";
 
+      (void)seek_type;
+
       lba_to_msf(frames, &min, &sec, &frame);
 
       switch (whence)

--- a/libretro-common/vfs/vfs_implementation_cdrom.c
+++ b/libretro-common/vfs/vfs_implementation_cdrom.c
@@ -173,7 +173,7 @@ void retro_vfs_file_open_cdrom(
          stream->cdrom_cue_buf = NULL;
       }
 
-      cdrom_write_cue(fileno(stream->fp), &stream->cdrom_cue_buf, &stream->cdrom_cue_len, stream->cdrom_drive, &vfs_cdrom_toc.num_tracks, &vfs_cdrom_toc);
+      cdrom_write_cue(stream, &stream->cdrom_cue_buf, &stream->cdrom_cue_len, stream->cdrom_drive, &vfs_cdrom_toc.num_tracks, &vfs_cdrom_toc);
 
       if (vfs_cdrom_toc.num_tracks > 1)
       {

--- a/libretro-common/vfs/vfs_implementation_cdrom.c
+++ b/libretro-common/vfs/vfs_implementation_cdrom.c
@@ -132,6 +132,8 @@ void retro_vfs_file_open_cdrom(
    size_t path_len = strlen(path);
    const char *ext = path_get_extension(path);
 
+   stream->cdrom.cur_track = 1;
+
    if (!string_is_equal_noncase(ext, "cue") && !string_is_equal_noncase(ext, "bin"))
       return;
 

--- a/libretro-common/vfs/vfs_implementation_cdrom.c
+++ b/libretro-common/vfs/vfs_implementation_cdrom.c
@@ -262,8 +262,6 @@ void retro_vfs_file_open_cdrom(
    {
       if (!cdrom_get_inquiry(stream, model, sizeof(model)))
       {
-         size_t len = 0;
-
 #ifdef CDROM_DEBUG
          printf("CDROM Model: %s\n", model);
          fflush(stdout);

--- a/libretro-common/vfs/vfs_implementation_cdrom.c
+++ b/libretro-common/vfs/vfs_implementation_cdrom.c
@@ -440,3 +440,8 @@ int retro_vfs_file_error_cdrom(libretro_vfs_implementation_file *stream)
 {
    return 0;
 }
+
+const vfs_cdrom_t* retro_vfs_file_get_cdrom_position(const libretro_vfs_implementation_file *stream)
+{
+   return &stream->cdrom;
+}

--- a/libretro-common/vfs/vfs_implementation_cdrom.c
+++ b/libretro-common/vfs/vfs_implementation_cdrom.c
@@ -1,0 +1,311 @@
+/* Copyright  (C) 2010-2019 The RetroArch team
+*
+* ---------------------------------------------------------------------------------------
+* The following license statement only applies to this file (vfs_implementation_cdrom.c).
+* ---------------------------------------------------------------------------------------
+*
+* Permission is hereby granted, free of charge,
+* to any person obtaining a copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation the rights to
+* use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+* and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+* INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+* WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include <vfs/vfs_implementation_cdrom.h>
+#include <file/file_path.h>
+#include <compat/fopen_utf8.h>
+#include <string/stdstring.h>
+
+static cdrom_toc_t vfs_cdrom_toc = {0};
+
+int64_t retro_vfs_file_seek_cdrom(libretro_vfs_implementation_file *stream, int64_t offset, int whence)
+{
+   const char *ext = path_get_extension(stream->orig_path);
+
+   if (string_is_equal_noncase(ext, "cue"))
+   {
+      switch (whence)
+      {
+         case SEEK_SET:
+            stream->cdrom_byte_pos = offset;
+            break;
+         case SEEK_CUR:
+            stream->cdrom_byte_pos += offset;
+            break;
+         case SEEK_END:
+            stream->cdrom_byte_pos = (stream->cdrom_cue_len - 1) + offset;
+            break;
+      }
+
+#ifdef CDROM_DEBUG
+      printf("CDROM Seek: Path %s Offset %lu is now at %lu\n", stream->orig_path, offset, stream->cdrom_byte_pos);
+#endif
+   }
+   else if (string_is_equal_noncase(ext, "bin"))
+   {
+      unsigned frames = (offset / 2352);
+      unsigned char min = 0;
+      unsigned char sec = 0;
+      unsigned char frame = 0;
+      const char *seek_type = "SEEK_SET";
+
+      lba_to_msf(frames, &min, &sec, &frame);
+
+      switch (whence)
+      {
+         case SEEK_CUR:
+         {
+            min += vfs_cdrom_toc.cur_min;
+            sec += vfs_cdrom_toc.cur_sec;
+            frame += vfs_cdrom_toc.cur_frame;
+
+            stream->cdrom_byte_pos += offset;
+            seek_type = "SEEK_CUR";
+
+            break;
+         }
+         case SEEK_END:
+         {
+            unsigned char end_min = 0;
+            unsigned char end_sec = 0;
+            unsigned char end_frame = 0;
+            size_t end_lba = vfs_cdrom_toc.track[vfs_cdrom_toc.num_tracks - 1].lba_start + vfs_cdrom_toc.track[vfs_cdrom_toc.num_tracks - 1].track_size;
+
+            lba_to_msf(end_lba, &min, &sec, &frame);
+
+            min += end_min;
+            sec += end_sec;
+            frame += end_frame;
+
+            stream->cdrom_byte_pos = end_lba * 2352;
+            seek_type = "SEEK_END";
+
+            break;
+         }
+         case SEEK_SET:
+         default:
+         {
+            unsigned lba = msf_to_lba(min, sec, frame);
+
+            seek_type = "SEEK_SET";
+            stream->cdrom_byte_pos = offset;
+
+            break;
+         }
+      }
+
+      vfs_cdrom_toc.cur_min = min;
+      vfs_cdrom_toc.cur_sec = sec;
+      vfs_cdrom_toc.cur_frame = frame;
+
+#ifdef CDROM_DEBUG
+      printf("CDROM Seek %s: Path %s Offset %lu is now at %lu (MSF %02d:%02d:%02d) (LBA %u)...\n", seek_type, stream->orig_path, offset, stream->cdrom_byte_pos, vfs_cdrom_toc.cur_min, vfs_cdrom_toc.cur_sec, vfs_cdrom_toc.cur_frame, msf_to_lba(vfs_cdrom_toc.cur_min, vfs_cdrom_toc.cur_sec, vfs_cdrom_toc.cur_frame));
+#endif
+   }
+   else
+      return -1;
+
+   return 0;
+}
+
+FILE* retro_vfs_file_open_cdrom(
+      libretro_vfs_implementation_file *stream,
+      const char *path, unsigned mode, unsigned hints)
+{
+   FILE *fp = NULL;
+#ifdef __linux__
+   char model[32] = {0};
+   char cdrom_path[] = "/dev/sg1";
+   size_t path_len = strlen(path);
+   const char *ext = path_get_extension(path);
+
+   if (!string_is_equal_noncase(ext, "cue") && !string_is_equal_noncase(ext, "bin"))
+      return NULL;
+
+   if (path_len >= strlen("drive1.cue"))
+   {
+      if (!memcmp(path, "drive", strlen("drive")))
+      {
+         if (path[5] >= '0' && path[5] <= '9')
+         {
+            cdrom_path[7] = path[5];
+            stream->cdrom_drive = path[5];
+         }
+      }
+   }
+
+#ifdef CDROM_DEBUG
+   printf("CDROM Open: Path %s URI %s\n", cdrom_path, path);
+#endif
+   fp = (FILE*)fopen_utf8(cdrom_path, "r+b");
+
+   if (fp)
+   {
+      int cdrom_fd = fileno(fp);
+
+      if (!cdrom_get_inquiry(cdrom_fd, model, sizeof(model)))
+      {
+         size_t len = 0;
+
+#ifdef CDROM_DEBUG
+         printf("CDROM Model: %s\n", model);
+#endif
+      }
+   }
+   else
+      return NULL;
+
+   if (string_is_equal_noncase(ext, "cue"))
+   {
+      if (stream->cdrom_cue_buf)
+      {
+         free(stream->cdrom_cue_buf);
+         stream->cdrom_cue_buf = NULL;
+      }
+
+      cdrom_write_cue(fileno(fp), &stream->cdrom_cue_buf, &stream->cdrom_cue_len, stream->cdrom_drive, &vfs_cdrom_toc.num_tracks, &vfs_cdrom_toc);
+
+      if (vfs_cdrom_toc.num_tracks > 1)
+      {
+         vfs_cdrom_toc.cur_min = vfs_cdrom_toc.track[0].min;
+         vfs_cdrom_toc.cur_sec = vfs_cdrom_toc.track[0].sec;
+         vfs_cdrom_toc.cur_frame = vfs_cdrom_toc.track[0].frame;
+      }
+
+#ifdef CDROM_DEBUG
+      if (string_is_empty(stream->cdrom_cue_buf))
+         printf("Error writing cue sheet.\n");
+      else
+      {
+         printf("CDROM CUE Sheet:\n%s\n", stream->cdrom_cue_buf);
+         fflush(stdout);
+      }
+#endif
+   }
+#endif
+
+   return fp;
+}
+
+int retro_vfs_file_close_cdrom(libretro_vfs_implementation_file *stream)
+{
+#ifdef CDROM_DEBUG
+   if (stream->scheme == VFS_SCHEME_CDROM)
+      printf("CDROM Close: Path %s\n", stream->orig_path);
+#endif
+
+   if (fclose(stream->fp))
+      return -1;
+
+   return 0;
+}
+
+int64_t retro_vfs_file_tell_cdrom(libretro_vfs_implementation_file *stream)
+{
+   if (!stream)
+      return -1;
+
+   const char *ext = path_get_extension(stream->orig_path);
+
+   if (string_is_equal_noncase(ext, "cue"))
+   {
+#ifdef CDROM_DEBUG
+      printf("CDROM (cue) Tell: Path %s Position %lu\n", stream->orig_path, stream->cdrom_byte_pos);
+#endif
+      return stream->cdrom_byte_pos;
+   }
+   else if (string_is_equal_noncase(ext, "bin"))
+   {
+      unsigned lba = msf_to_lba(vfs_cdrom_toc.cur_min, vfs_cdrom_toc.cur_sec, vfs_cdrom_toc.cur_frame);
+
+#ifdef CDROM_DEBUG
+      printf("CDROM (bin) Tell: Path %s Position %u\n", stream->orig_path, lba * 2352);
+#endif
+      return lba * 2352;
+   }
+
+   return -1;
+}
+
+int64_t retro_vfs_file_read_cdrom(libretro_vfs_implementation_file *stream,
+      void *s, uint64_t len)
+{
+   int rv;
+   const char *ext = path_get_extension(stream->orig_path);
+
+   if (string_is_equal_noncase(ext, "cue"))
+   {
+      if (len < stream->cdrom_cue_len - stream->cdrom_byte_pos)
+      {
+#ifdef CDROM_DEBUG
+         printf("CDROM Read: Reading %lu bytes from cuesheet starting at %lu...\n", len, stream->cdrom_byte_pos);
+#endif
+         memcpy(s, stream->cdrom_cue_buf + stream->cdrom_byte_pos, len);
+         stream->cdrom_byte_pos += len;
+
+         return len;
+      }
+      else
+      {
+#ifdef CDROM_DEBUG
+         printf("CDROM Read: Reading %lu bytes from cuesheet starting at %lu failed.\n", len, stream->cdrom_byte_pos);
+#endif
+         return 0;
+      }
+   }
+   else if (string_is_equal_noncase(ext, "bin"))
+   {
+      unsigned frames = len / 2352;
+      unsigned i;
+      size_t skip = stream->cdrom_byte_pos % 2352;
+      unsigned char min = 0;
+      unsigned char sec = 0;
+      unsigned char frame = 0;
+      unsigned lba_cur = 0;
+      unsigned lba_start = 0;
+
+      lba_cur = msf_to_lba(vfs_cdrom_toc.cur_min, vfs_cdrom_toc.cur_sec, vfs_cdrom_toc.cur_frame);
+
+      lba_start = msf_to_lba(vfs_cdrom_toc.track[0].min, vfs_cdrom_toc.track[0].sec, vfs_cdrom_toc.track[0].frame);
+
+      lba_to_msf(lba_start + lba_cur, &min, &sec, &frame);
+
+#ifdef CDROM_DEBUG
+      printf("CDROM Read: Reading %lu bytes from %s starting at byte offset %lu (MSF %02d:%02d:%02d) (LBA %u) skip %lu...\n", len, stream->orig_path, stream->cdrom_byte_pos, min, sec, frame, msf_to_lba(min, sec, frame), skip);
+#endif
+
+      rv = cdrom_read(fileno(stream->fp), min, sec, frame, s, (size_t)len, skip);
+
+      if (rv)
+      {
+#ifdef CDROM_DEBUG
+         printf("Failed to read %lu bytes from CD.\n", len);
+#endif
+         return 0;
+      }
+
+      stream->cdrom_byte_pos += len;
+
+      for (i = 0; i < frames; i++)
+      {
+         increment_msf(&vfs_cdrom_toc.cur_min, &vfs_cdrom_toc.cur_sec, &vfs_cdrom_toc.cur_frame);
+      }
+
+#ifdef CDROM_DEBUG
+      printf("CDROM read %lu bytes, position is now: %lu (MSF %02d:%02d:%02d) (LBA %u)\n", len, stream->cdrom_byte_pos, vfs_cdrom_toc.cur_min, vfs_cdrom_toc.cur_sec, vfs_cdrom_toc.cur_frame, msf_to_lba(vfs_cdrom_toc.cur_min, vfs_cdrom_toc.cur_sec, vfs_cdrom_toc.cur_frame));
+#endif
+
+      return len;
+   }
+
+   return 0;
+}

--- a/libretro-common/vfs/vfs_implementation_cdrom.c
+++ b/libretro-common/vfs/vfs_implementation_cdrom.c
@@ -78,7 +78,7 @@ int64_t retro_vfs_file_seek_cdrom(libretro_vfs_implementation_file *stream, int6
             unsigned char end_min = 0;
             unsigned char end_sec = 0;
             unsigned char end_frame = 0;
-            size_t end_lba = vfs_cdrom_toc.track[vfs_cdrom_toc.num_tracks - 1].lba_start + vfs_cdrom_toc.track[vfs_cdrom_toc.num_tracks - 1].track_size;
+            size_t end_lba = (vfs_cdrom_toc.track[vfs_cdrom_toc.num_tracks - 1].lba_start + vfs_cdrom_toc.track[vfs_cdrom_toc.num_tracks - 1].track_size) - 1;
 
             lba_to_msf(end_lba, &min, &sec, &frame);
 

--- a/paths.c
+++ b/paths.c
@@ -1,6 +1,7 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2011-2019 - Daniel De Matteis
  *  Copyright (C) 2017-2019 - Andrés Suárez
+ *  Copyright (C) 2016-2019 - Brad Parker
  *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-

--- a/paths.h
+++ b/paths.h
@@ -1,5 +1,6 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2011-2019 - Daniel De Matteis
+ *  Copyright (C) 2016-2019 - Brad Parker
  *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-

--- a/performance_counters.c
+++ b/performance_counters.c
@@ -1,6 +1,7 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
  *  Copyright (C) 2011-2017 - Daniel De Matteis
+ *  Copyright (C) 2016-2019 - Brad Parker
  *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-

--- a/verbosity.c
+++ b/verbosity.c
@@ -1,5 +1,6 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2011-2017 - Daniel De Matteis
+ *  Copyright (C) 2016-2019 - Brad Parker
  *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-


### PR DESCRIPTION
This extends the filestream and VFS facilities in libretro-common to add basic CDROM read support. It works by emulating the file I/O normally performed on bin/cue files and substituting those commands with ones to read from the CDROM drive instead, in an attempt to greatly lessen the burden of changes necessary to cores to support real CD reading.

The CD commands themselves are implemented using ATAPI packets (according to the MMC spec) via the SCSI pass-through facilities of the OS. For Windows this is accomplished with `IOCTL_SCSI_PASS_THROUGH_DIRECT` and on Linux with the `SG_IO` ioctl. These are currently the only two supported platforms, but adding additional platforms that have similar facilities should be easy.

Normal usage is as follows:

The first open command given should be for the cue file, so we can build a cuesheet from the TOC of the disk. This information will persist throughout the duration that the core is loaded as it will be needed for subsequent I/O of the "bin files". For Windows the path for the initial cue file should be `cdrom://d:/drive.cue` where `d:` is the drive letter of your device. For Linux use `cdrom://drive1.cue` where `1` translates to `/dev/sg1` internally. You can check which device is correct with `sg_scan -i`. Trying to use `/dev/cdrom` or `/dev/sr1` etc. will not work. The `cdrom://` scheme and the `drive.cue` filename are also hardcoded and thus required.

After the cue is opened and read, a generated cuesheet suitable for reading from the CD will be available to the core. The file parameters in the cue sheet will be VFS paths and should be used as-is without removing any path information.

From this point on, any bin files opened and read will return the equivalent data from the CD in a blocking fashion, at the maximum speed preferred by the drive. Non-blocking and/or mmap mode is not currently supported. To open a bin file:

Linux: `cdrom://drive1-track01.bin`

Windows: `cdrom://d:/drive-track01.bin`

The track number should always be two zero-padded numbers, and the first track is always `01` and not `00`.

Currently tested cores that work with these changes are GPGX and Beetle PSX. I also have a simple redbook audio player core for testing here: https://github.com/bparker06/redbook

## Related Issues

Bounty #7245 
