### PR TITLE
Small fixes for D3D12

### DIFF
--- a/gfx/common/d3d12_common.c
+++ b/gfx/common/d3d12_common.c
@@ -192,10 +192,10 @@ bool d3d12_init_base(d3d12_video_t* d3d12)
 
 #ifdef __WINRT__
          if (FAILED(DXGIEnumAdapters2(d3d12->factory, i, &d3d12->adapter)))
-            return false;
+            break;
 #else
          if (FAILED(DXGIEnumAdapters(d3d12->factory, i, &d3d12->adapter)))
-            return false;
+            break;
 #endif
 
          IDXGIAdapter_GetDesc(d3d12->adapter, &desc);

--- a/gfx/common/d3d12_common.h
+++ b/gfx/common/d3d12_common.h
@@ -159,7 +159,7 @@ static INLINE HRESULT D3D12ResetCommandAllocator(D3D12CommandAllocator command_a
 static INLINE ULONG  D3D12ReleaseFence(D3D12Fence fence) { return fence->lpVtbl->Release(fence); }
 static INLINE UINT64 D3D12GetCompletedValue(D3D12Fence fence)
 {
-   return fence->lpVtbl->GetCompletedValue(fence);
+   return fence && fence->lpVtbl->GetCompletedValue(fence);
 }
 static INLINE HRESULT D3D12SetEventOnCompletion(D3D12Fence fence, UINT64 value, HANDLE h_event)
 {


### PR DESCRIPTION
Just a few small fixes for D3D12.

`DXGIEnumAdapters2` will always return a failure condition when you have exceeded the number of adapters in the system, thus using `return false;` will always cause D3D12 initialization to fail.  Replaced with `break;` to continue execution of the program.

When initializing D3D12 fails, it calls the function to destroy it, however, this can lead to the Fence object being NULL before calling a function from that object.  Add a NULL check there.