### PR TITLE
RGUI: Fix ASAN misaligned address runtime error

### DIFF
--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -2397,7 +2397,7 @@ static void blit_line_regular_shadow(unsigned fb_width, int x, int y,
                   *frame_buf_ptr = shadow_color;
                   frame_buf_ptr += fb_width - 1;
                   /* Small performance hack... */
-                  *(uint32_t *)frame_buf_ptr = shadow_colour_32;
+                  memcpy(frame_buf_ptr, &shadow_colour_32, sizeof(uint32_t));
                }
             }
          }
@@ -2501,7 +2501,7 @@ static void blit_line_extended_shadow(unsigned fb_width, int x, int y,
                   *frame_buf_ptr = shadow_color;
                   frame_buf_ptr += fb_width - 1;
                   /* Small performance hack... */
-                  *(uint32_t *)frame_buf_ptr = shadow_colour_32;
+                  memcpy(frame_buf_ptr, &shadow_colour_32, sizeof(uint32_t));
                }
             }
          }
@@ -2605,7 +2605,7 @@ static void blit_symbol_shadow(unsigned fb_width, int x, int y,
             *frame_buf_ptr = shadow_color;
             frame_buf_ptr += fb_width - 1;
             /* Small performance hack... */
-            *(uint32_t *)frame_buf_ptr = shadow_colour_32;
+            memcpy(frame_buf_ptr, &shadow_colour_32, sizeof(uint32_t));
          }
       }
    }


### PR DESCRIPTION
## Description

When running RetroArch with ASAN enabled, RGUI generates the following runtime error:

```
menu/drivers/rgui.c:2506:46: runtime error: store to misaligned address 0x7f33b4683246 for type 'uint32_t', which requires 4 byte alignment
0x7f33b4683246: note: pointer points here
 4c 44 4c 44 4c 44  4c 44 4c 44 4c 44 4c 44  4c 44 4c 44 4c 44 4c 44  4c 44 4c 44 4c 44 4c 44  4c 44
             ^ 
```

This is the result of a performance 'hack' used when drawing menu shadow effects. As far as I can tell, the error is harmless on all platforms/architectures that RetroArch supports - but we should eliminate any kind of error whenever possible!

This PR fixes the error by using `memcpy()` instead of pointer tricks. It has no discernable performance impact.