### PR TITLE
fix some bugs found through Clang Static Analyzer

### DIFF
--- a/cheevos-new/cheevos.c
+++ b/cheevos-new/cheevos.c
@@ -1771,7 +1771,10 @@ found:
                               coro->json, coro->k))
                         CHEEVOS_ERR(RCHEEVOS_TAG "error writing badge %s\n", coro->badge_fullpath);
                      else
+                     {
                         CHEEVOS_FREE(coro->json);
+                        coro->json = NULL;
+                     }
                   }
                }
             }

--- a/frontend/drivers/platform_uwp.c
+++ b/frontend/drivers/platform_uwp.c
@@ -211,30 +211,31 @@ enum frontend_powerstate frontend_uwp_get_powerstate(
       int *seconds, int *percent)
 {
    SYSTEM_POWER_STATUS status;
-	enum frontend_powerstate ret = FRONTEND_POWERSTATE_NONE;
+   enum frontend_powerstate ret = FRONTEND_POWERSTATE_NONE;
 
-	if (!GetSystemPowerStatus(&status))
-		return ret;
+   if (!GetSystemPowerStatus(&status))
+      return ret;
 
-	if (status.BatteryFlag == 0xFF)
-		ret = FRONTEND_POWERSTATE_NONE;
-	if (status.BatteryFlag & (1 << 7))
-		ret = FRONTEND_POWERSTATE_NO_SOURCE;
-	else if (status.BatteryFlag & (1 << 3))
-		ret = FRONTEND_POWERSTATE_CHARGING;
-	else if (status.ACLineStatus == 1)
-		ret = FRONTEND_POWERSTATE_CHARGED;
-	else
-		ret = FRONTEND_POWERSTATE_ON_POWER_SOURCE;
+   if (status.BatteryFlag == 0xFF)
+      ret = FRONTEND_POWERSTATE_NONE;
+   else if (status.BatteryFlag & (1 << 7))
+      ret = FRONTEND_POWERSTATE_NO_SOURCE;
+   else if (status.BatteryFlag & (1 << 3))
+      ret = FRONTEND_POWERSTATE_CHARGING;
+   else if (status.ACLineStatus == 1)
+      ret = FRONTEND_POWERSTATE_CHARGED;
+   else
+      ret = FRONTEND_POWERSTATE_ON_POWER_SOURCE;
 
-	*percent  = (int)status.BatteryLifePercent;
-	*seconds  = (int)status.BatteryLifeTime;
+   *percent  = (int)status.BatteryLifePercent;
+   *seconds  = (int)status.BatteryLifeTime;
 
 #ifdef _WIN32
-      if (*percent == 255)
-         *percent = 0;
+   if (*percent == 255)
+      *percent = 0;
 #endif
-	return ret;
+
+   return ret;
 }
 
 enum frontend_architecture frontend_uwp_get_architecture(void)
@@ -394,15 +395,15 @@ static uint64_t frontend_uwp_get_mem_total(void)
    /* OSes below 2000 don't have the Ex version,
     * and non-Ex cannot work with >4GB RAM */
 #if _WIN32_WINNT >= 0x0500
-	MEMORYSTATUSEX mem_info;
-	mem_info.dwLength = sizeof(MEMORYSTATUSEX);
-	GlobalMemoryStatusEx(&mem_info);
-	return mem_info.ullTotalPhys;
+   MEMORYSTATUSEX mem_info;
+   mem_info.dwLength = sizeof(MEMORYSTATUSEX);
+   GlobalMemoryStatusEx(&mem_info);
+   return mem_info.ullTotalPhys;
 #else
-	MEMORYSTATUS mem_info;
-	mem_info.dwLength = sizeof(MEMORYSTATUS);
-	GlobalMemoryStatus(&mem_info);
-	return mem_info.dwTotalPhys;
+   MEMORYSTATUS mem_info;
+   mem_info.dwLength = sizeof(MEMORYSTATUS);
+   GlobalMemoryStatus(&mem_info);
+   return mem_info.dwTotalPhys;
 #endif
 }
 
@@ -411,15 +412,15 @@ static uint64_t frontend_uwp_get_mem_used(void)
    /* OSes below 2000 don't have the Ex version,
     * and non-Ex cannot work with >4GB RAM */
 #if _WIN32_WINNT >= 0x0500
-	MEMORYSTATUSEX mem_info;
-	mem_info.dwLength = sizeof(MEMORYSTATUSEX);
-	GlobalMemoryStatusEx(&mem_info);
-	return ((frontend_uwp_get_mem_total() - mem_info.ullAvailPhys));
+   MEMORYSTATUSEX mem_info;
+   mem_info.dwLength = sizeof(MEMORYSTATUSEX);
+   GlobalMemoryStatusEx(&mem_info);
+   return ((frontend_uwp_get_mem_total() - mem_info.ullAvailPhys));
 #else
-	MEMORYSTATUS mem_info;
-	mem_info.dwLength = sizeof(MEMORYSTATUS);
-	GlobalMemoryStatus(&mem_info);
-	return ((frontend_uwp_get_mem_total() - mem_info.dwAvailPhys));
+   MEMORYSTATUS mem_info;
+   mem_info.dwLength = sizeof(MEMORYSTATUS);
+   GlobalMemoryStatus(&mem_info);
+   return ((frontend_uwp_get_mem_total() - mem_info.dwAvailPhys));
 #endif
 }
 

--- a/frontend/drivers/platform_win32.c
+++ b/frontend/drivers/platform_win32.c
@@ -111,7 +111,7 @@ static bool gfx_init_dwm(void)
       (VOID (WINAPI*)(HWND, BOOL))dylib_proc(shell32lib, "DragAcceptFiles");
 
    mmcss =
-	   (HRESULT(WINAPI*)(BOOL))dylib_proc(dwmlib, "DwmEnableMMCSS");
+      (HRESULT(WINAPI*)(BOOL))dylib_proc(dwmlib, "DwmEnableMMCSS");
 #else
    DragAcceptFiles_func = DragAcceptFiles;
 #if 0
@@ -121,8 +121,8 @@ static bool gfx_init_dwm(void)
 
    if (mmcss)
    {
-	   RARCH_LOG("Setting multimedia scheduling for DWM.\n");
-	   mmcss(TRUE);
+      RARCH_LOG("Setting multimedia scheduling for DWM.\n");
+      mmcss(TRUE);
    }
 
    inited = true;
@@ -317,53 +317,54 @@ static void frontend_win32_get_os(char *s, size_t len, int *major, int *minor)
 
 static void frontend_win32_init(void *data)
 {
-	typedef BOOL (WINAPI *isProcessDPIAwareProc)();
-	typedef BOOL (WINAPI *setProcessDPIAwareProc)();
+   typedef BOOL (WINAPI *isProcessDPIAwareProc)();
+   typedef BOOL (WINAPI *setProcessDPIAwareProc)();
 #ifdef HAVE_DYNAMIC
-	HMODULE handle                         =
+   HMODULE handle                         =
       GetModuleHandle("User32.dll");
-	isProcessDPIAwareProc  isDPIAwareProc  =
+   isProcessDPIAwareProc  isDPIAwareProc  =
       (isProcessDPIAwareProc)dylib_proc(handle, "IsProcessDPIAware");
-	setProcessDPIAwareProc setDPIAwareProc =
+   setProcessDPIAwareProc setDPIAwareProc =
       (setProcessDPIAwareProc)dylib_proc(handle, "SetProcessDPIAware");
 #else
-	isProcessDPIAwareProc  isDPIAwareProc  = IsProcessDPIAware;
-	setProcessDPIAwareProc setDPIAwareProc = SetProcessDPIAware;
+   isProcessDPIAwareProc  isDPIAwareProc  = IsProcessDPIAware;
+   setProcessDPIAwareProc setDPIAwareProc = SetProcessDPIAware;
 #endif
 
-	if (isDPIAwareProc)
-		if (!isDPIAwareProc())
-			if (setDPIAwareProc)
-				setDPIAwareProc();
+   if (isDPIAwareProc)
+      if (!isDPIAwareProc())
+         if (setDPIAwareProc)
+            setDPIAwareProc();
 }
 
 enum frontend_powerstate frontend_win32_get_powerstate(int *seconds, int *percent)
 {
    SYSTEM_POWER_STATUS status;
-	enum frontend_powerstate ret = FRONTEND_POWERSTATE_NONE;
+   enum frontend_powerstate ret = FRONTEND_POWERSTATE_NONE;
 
-	if (!GetSystemPowerStatus(&status))
-		return ret;
+   if (!GetSystemPowerStatus(&status))
+      return ret;
 
-	if (status.BatteryFlag == 0xFF)
-		ret = FRONTEND_POWERSTATE_NONE;
-	if (status.BatteryFlag & (1 << 7))
-		ret = FRONTEND_POWERSTATE_NO_SOURCE;
-	else if (status.BatteryFlag & (1 << 3))
-		ret = FRONTEND_POWERSTATE_CHARGING;
-	else if (status.ACLineStatus == 1)
-		ret = FRONTEND_POWERSTATE_CHARGED;
-	else
-		ret = FRONTEND_POWERSTATE_ON_POWER_SOURCE;
+   if (status.BatteryFlag == 0xFF)
+      ret = FRONTEND_POWERSTATE_NONE;
+   else if (status.BatteryFlag & (1 << 7))
+      ret = FRONTEND_POWERSTATE_NO_SOURCE;
+   else if (status.BatteryFlag & (1 << 3))
+      ret = FRONTEND_POWERSTATE_CHARGING;
+   else if (status.ACLineStatus == 1)
+      ret = FRONTEND_POWERSTATE_CHARGED;
+   else
+      ret = FRONTEND_POWERSTATE_ON_POWER_SOURCE;
 
-	*percent  = (int)status.BatteryLifePercent;
-	*seconds  = (int)status.BatteryLifeTime;
+   *percent  = (int)status.BatteryLifePercent;
+   *seconds  = (int)status.BatteryLifeTime;
 
 #ifdef _WIN32
-      if (*percent == 255)
-         *percent = 0;
+   if (*percent == 255)
+      *percent = 0;
 #endif
-	return ret;
+
+   return ret;
 }
 
 enum frontend_architecture frontend_win32_get_architecture(void)
@@ -489,15 +490,15 @@ static uint64_t frontend_win32_get_mem_total(void)
    /* OSes below 2000 don't have the Ex version,
     * and non-Ex cannot work with >4GB RAM */
 #if _WIN32_WINNT >= 0x0500
-	MEMORYSTATUSEX mem_info;
-	mem_info.dwLength = sizeof(MEMORYSTATUSEX);
-	GlobalMemoryStatusEx(&mem_info);
-	return mem_info.ullTotalPhys;
+   MEMORYSTATUSEX mem_info;
+   mem_info.dwLength = sizeof(MEMORYSTATUSEX);
+   GlobalMemoryStatusEx(&mem_info);
+   return mem_info.ullTotalPhys;
 #else
-	MEMORYSTATUS mem_info;
-	mem_info.dwLength = sizeof(MEMORYSTATUS);
-	GlobalMemoryStatus(&mem_info);
-	return mem_info.dwTotalPhys;
+   MEMORYSTATUS mem_info;
+   mem_info.dwLength = sizeof(MEMORYSTATUS);
+   GlobalMemoryStatus(&mem_info);
+   return mem_info.dwTotalPhys;
 #endif
 }
 
@@ -506,15 +507,15 @@ static uint64_t frontend_win32_get_mem_used(void)
    /* OSes below 2000 don't have the Ex version,
     * and non-Ex cannot work with >4GB RAM */
 #if _WIN32_WINNT >= 0x0500
-	MEMORYSTATUSEX mem_info;
-	mem_info.dwLength = sizeof(MEMORYSTATUSEX);
-	GlobalMemoryStatusEx(&mem_info);
-	return ((frontend_win32_get_mem_total() - mem_info.ullAvailPhys));
+   MEMORYSTATUSEX mem_info;
+   mem_info.dwLength = sizeof(MEMORYSTATUSEX);
+   GlobalMemoryStatusEx(&mem_info);
+   return ((frontend_win32_get_mem_total() - mem_info.ullAvailPhys));
 #else
-	MEMORYSTATUS mem_info;
-	mem_info.dwLength = sizeof(MEMORYSTATUS);
-	GlobalMemoryStatus(&mem_info);
-	return ((frontend_win32_get_mem_total() - mem_info.dwAvailPhys));
+   MEMORYSTATUS mem_info;
+   mem_info.dwLength = sizeof(MEMORYSTATUS);
+   GlobalMemoryStatus(&mem_info);
+   return ((frontend_win32_get_mem_total() - mem_info.dwAvailPhys));
 #endif
 }
 

--- a/gfx/drivers/gdi_gfx.c
+++ b/gfx/drivers/gdi_gfx.c
@@ -557,8 +557,6 @@ static uintptr_t gdi_load_texture(void *video_data, void *data,
    void *tmpdata               = NULL;
    gdi_texture_t *texture      = NULL;
    struct texture_image *image = (struct texture_image*)data;
-   int size                    = image->width *
-      image->height * sizeof(uint32_t);
 
    if (!image || image->width > 2048 || image->height > 2048)
       return 0;

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -453,12 +453,15 @@ static bool load_content_from_compressed_archive(
    info[i].path =
       additional_path_allocs->elems[additional_path_allocs->size - 1].data;
 
-   free(new_path);
 
    if (!string_list_append(content_ctx->temporary_content,
             new_path, attributes))
+   {
+      free(new_path);
       return false;
+   }
 
+   free(new_path);
    return true;
 }
 


### PR DESCRIPTION
 - task_content.c, load_content_from_compressed_archive: fix use after free
 - platform_win32/uwp: fix frontend_..._get_powerstate never returning FRONTEND_POWERSTATE_NONE*
 - platform_win32/uwp: fix whitespace
 - cheevos.c: fix potential use after free in a loop, just to be save

\* [SYSTEM_POWER_STATUS reference](https://docs.microsoft.com/de-de/windows/win32/api/winbase/ns-winbase-_system_power_status#members)

There might be more that the analyser is pointing to, the list is [very long](https://pastebin.com/vCQVusKa), though a lot of it seems to be false positives for example due to the analyzer not knowing pointers can't be NULL or being confused by macros in cheevos.c