### PR TITLE
Normal2x/Scanline2x video filters: Fix misaligned address error

### DIFF
--- a/gfx/video_filters/normal2x.c
+++ b/gfx/video_filters/normal2x.c
@@ -18,6 +18,7 @@
 
 #include "softfilter.h"
 #include <stdlib.h>
+#include <string.h>
 
 #ifdef RARCH_INTERNAL
 #define softfilter_get_implementation normal2x_get_implementation
@@ -118,17 +119,20 @@ static void normal2x_work_cb_xrgb8888(void *data, void *thread_data)
       uint32_t *out_ptr = output;
       for (x = 0; x < thr->width; ++x)
       {
-         uint64_t colour = (uint64_t)*(input + x);
-         colour |= colour << 32;
+         uint32_t color = *(input + x);
+         uint32_t color_buf[2];
 
-         *(uint64_t *)(out_ptr) = colour;
-         *(uint64_t *)(out_ptr + out_stride) = colour;
+         color_buf[0] = color;
+         color_buf[1] = color;
+
+         memcpy(out_ptr,              color_buf, sizeof(color_buf));
+         memcpy(out_ptr + out_stride, color_buf, sizeof(color_buf));
 
          out_ptr += 2;
       }
 
-      input += in_stride;
-		output += out_stride << 1;
+      input  += in_stride;
+      output += out_stride << 1;
    }
 }
 
@@ -143,20 +147,23 @@ static void normal2x_work_cb_rgb565(void *data, void *thread_data)
 
    for (y = 0; y < thr->height; ++y)
    {
-      uint16_t * out_ptr = output;
+      uint16_t *out_ptr = output;
       for (x = 0; x < thr->width; ++x)
       {
-         uint32_t colour = (uint32_t)*(input + x);
-         colour |= colour << 16;
+         uint16_t color = *(input + x);
+         uint16_t color_buf[2];
 
-         *(uint32_t *)(out_ptr) = colour;
-         *(uint32_t *)(out_ptr + out_stride) = colour;
+         color_buf[0] = color;
+         color_buf[1] = color;
+
+         memcpy(out_ptr,              color_buf, sizeof(color_buf));
+         memcpy(out_ptr + out_stride, color_buf, sizeof(color_buf));
 
          out_ptr += 2;
       }
 
-      input += in_stride;
-		output += out_stride << 1;
+      input  += in_stride;
+      output += out_stride << 1;
    }
 }
 

--- a/gfx/video_filters/scanline2x.c
+++ b/gfx/video_filters/scanline2x.c
@@ -18,6 +18,7 @@
 
 #include "softfilter.h"
 #include <stdlib.h>
+#include <string.h>
 
 #ifdef RARCH_INTERNAL
 #define softfilter_get_implementation scanline2x_get_implementation
@@ -121,29 +122,33 @@ static void scanline2x_work_cb_xrgb8888(void *data, void *thread_data)
          /* Note: We process the 'padding' bits as though they
           * matter (they don't), since this deals with any potential
           * byte swapping issues */ 
-         uint32_t color            = *(input + x);
-         uint8_t  p                = (color >> 24 & 0xFF); /* Padding bits */
-         uint8_t  r                = (color >> 16 & 0xFF);
-         uint8_t  g                = (color >>  8 & 0xFF);
-         uint8_t  b                = (color       & 0xFF);
-         uint64_t color64          = (uint64_t)color;
-         uint64_t scanline_color64 =
+         uint32_t color          = *(input + x);
+         uint8_t  p              = (color >> 24 & 0xFF); /* Padding bits */
+         uint8_t  r              = (color >> 16 & 0xFF);
+         uint8_t  g              = (color >>  8 & 0xFF);
+         uint8_t  b              = (color       & 0xFF);
+         uint32_t scanline_color =
                (((p >> 1) + (p >> 2)) << 24) |
                (((r >> 1) + (r >> 2)) << 16) |
                (((g >> 1) + (g >> 2)) <<  8) |
                (((b >> 1) + (b >> 2))      );
+         uint32_t color_buf[2];
+         uint32_t scanline_color_buf[2];
 
-         color64          |= (color64          << 32);
-         scanline_color64 |= (scanline_color64 << 32);
+         color_buf[0] = color;
+         color_buf[1] = color;
 
-         *(uint64_t *)(out_ptr)              = color64;
-         *(uint64_t *)(out_ptr + out_stride) = scanline_color64;
+         scanline_color_buf[0] = scanline_color;
+         scanline_color_buf[1] = scanline_color;
+
+         memcpy(out_ptr,              color_buf,          sizeof(color_buf));
+         memcpy(out_ptr + out_stride, scanline_color_buf, sizeof(scanline_color_buf));
 
          out_ptr += 2;
       }
 
       input  += in_stride;
-		output += out_stride << 1;
+      output += out_stride << 1;
    }
 }
 
@@ -158,30 +163,34 @@ static void scanline2x_work_cb_rgb565(void *data, void *thread_data)
 
    for (y = 0; y < thr->height; ++y)
    {
-      uint16_t * out_ptr = output;
+      uint16_t *out_ptr = output;
       for (x = 0; x < thr->width; ++x)
       {
-         uint16_t color            = *(input + x);
-         uint8_t  r                = (color >> 11 & 0x1F);
-         uint8_t  g                = (color >>  6 & 0x1F);
-         uint8_t  b                = (color       & 0x1F);
-         uint32_t color32          = (uint32_t)color;
-         uint32_t scanline_color32 =
+         uint16_t color          = *(input + x);
+         uint8_t  r              = (color >> 11 & 0x1F);
+         uint8_t  g              = (color >>  6 & 0x1F);
+         uint8_t  b              = (color       & 0x1F);
+         uint16_t scanline_color =
                (((r >> 1) + (r >> 2)) << 11) |
                (((g >> 1) + (g >> 2)) <<  6) |
                (((b >> 1) + (b >> 2))      );
+         uint16_t color_buf[2];
+         uint16_t scanline_color_buf[2];
 
-         color32          |= (color32          << 16);
-         scanline_color32 |= (scanline_color32 << 16);
+         color_buf[0] = color;
+         color_buf[1] = color;
 
-         *(uint32_t *)(out_ptr)              = color32;
-         *(uint32_t *)(out_ptr + out_stride) = scanline_color32;
+         scanline_color_buf[0] = scanline_color;
+         scanline_color_buf[1] = scanline_color;
+
+         memcpy(out_ptr,              color_buf,          sizeof(color_buf));
+         memcpy(out_ptr + out_stride, scanline_color_buf, sizeof(scanline_color_buf));
 
          out_ptr += 2;
       }
 
       input  += in_stride;
-		output += out_stride << 1;
+      output += out_stride << 1;
    }
 }
 


### PR DESCRIPTION
## Description

This is related to PR #9057.

The `Normal2x` and `Scanline2x` CPU video filters currently use the same 'pointer casting' performance hack that we originally used in RGUI - and so they are subject to the same 'misaligned address' runtime error when ASAN is enabled.

This should be harmless on all platforms/architectures that RetroArch supports, but this PR implements a 'standard compliant' fix.
