### PR TITLE
phoenix: android studio fixes

### DIFF
--- a/pkg/android/phoenix/.gitignore
+++ b/pkg/android/phoenix/.gitignore
@@ -1,3 +1,5 @@
 .gradle
 .externalNativeBuild
 build
+phoenix.iml
+

--- a/pkg/android/phoenix/AndroidManifest.xml
+++ b/pkg/android/phoenix/AndroidManifest.xml
@@ -10,9 +10,7 @@
     <uses-feature android:name="android.software.leanback" android:required="false" />
     <uses-feature android:name="android.hardware.gamepad" android:required="false"/>
     <uses-feature android:name="android.hardware.location.gps" android:required="false"/>
-    <uses-sdk
-        android:minSdkVersion="16"
-        android:targetSdkVersion="28" />
+
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.INTERNET" />

--- a/pkg/android/phoenix/build.gradle
+++ b/pkg/android/phoenix/build.gradle
@@ -31,6 +31,7 @@ android {
         arguments "-j${Runtime.runtime.availableProcessors()}"
       }
     }
+    targetSdkVersion 28
   }
 
   productFlavors {
@@ -84,6 +85,11 @@ android {
         storePassword RELEASE_STORE_PASSWORD
         keyAlias RELEASE_KEY_ALIAS
         keyPassword RELEASE_KEY_PASSWORD
+      }
+    }
+    else {
+      release {
+        // Use debug if you don't have RELEASE_STORE_FILE
       }
     }
   }


### PR DESCRIPTION
This fixes gradle sync when using Android Studio - note that the `release` target is not usable unless you have `RELEASE_STORE_FILE` set.