### PR TITLE
(task_image) Fix TSAN reported data race condition

### DIFF
--- a/tasks/task_image.c
+++ b/tasks/task_image.c
@@ -28,7 +28,7 @@
 #include "task_file_transfer.h"
 #include "tasks_internal.h"
 
-#include "../dynamic.h"
+#include "../configuration.h"
 
 enum image_status_enum
 {
@@ -192,7 +192,8 @@ static int cb_nbio_image_thumbnail(void *data, size_t len)
    nbio_handle_t *nbio             = (nbio_handle_t*)data;
    struct nbio_image_handle *image = nbio  ? (struct nbio_image_handle*)nbio->data : NULL;
    void *handle                    = image ? image_transfer_new(image->type)       : NULL;
-   float refresh_rate;
+   settings_t *settings            = config_get_ptr();
+   float refresh_rate              = 0.0f;
 
    if (!handle)
       return -1;
@@ -209,8 +210,10 @@ static int cb_nbio_image_thumbnail(void *data, size_t len)
    image->size                     = len;
 
    /* Set task iteration duration */
-   rarch_environment_cb(RETRO_ENVIRONMENT_GET_TARGET_REFRESH_RATE, &refresh_rate);
-   if (refresh_rate == 0.0f)
+   if (settings)
+      refresh_rate = settings->floats.video_refresh_rate;
+
+   if (refresh_rate <= 0.0f)
       refresh_rate = 60.0f;
    image->frame_duration = (unsigned)((1.0 / refresh_rate) * 1000000.0f);
 


### PR DESCRIPTION
## Description

While trying to investigate issue #9070, I discovered a potential data race condition in `task_image.c`:

```
WARNING: ThreadSanitizer: data race (pid=11500)
  Write of size 1 at 0x000003752e69 by main thread:
    #0 video_driver_frame /home/james/Dev/github/libretro/RetroArch/retroarch.c:10217 (retroarch+0x454835)
    #1 video_driver_cached_frame /home/james/Dev/github/libretro/RetroArch/retroarch.c:9168 (retroarch+0x44f328)
    #2 menu_display_libretro menu/menu_driver.c:644 (retroarch+0x82aaf7)
    #3 menu_driver_render menu/menu_driver.c:2053 (retroarch+0x839758)
    #4 runloop_check_state /home/james/Dev/github/libretro/RetroArch/retroarch.c:16092 (retroarch+0x469d1f)
    #5 runloop_iterate /home/james/Dev/github/libretro/RetroArch/retroarch.c:16671 (retroarch+0x46c876)
    #6 rarch_main frontend/frontend.c:155 (retroarch+0x42566c)
    #7 main frontend/frontend.c:183 (retroarch+0x4256fa)

  Previous read of size 1 at 0x000003752e69 by thread T1:
    #0 video_context_driver_get_refresh_rate /home/james/Dev/github/libretro/RetroArch/retroarch.c:10774 (retroarch+0x458a98)
    #1 gl2_get_refresh_rate gfx/drivers/gl.c:4516 (retroarch+0xa283ef)
    #2 video_driver_get_refresh_rate /home/james/Dev/github/libretro/RetroArch/retroarch.c:10981 (retroarch+0x459ab8)
    #3 rarch_environment_cb /home/james/Dev/github/libretro/RetroArch/dynamic.c:1852 (retroarch+0x57efe3)
    #4 cb_nbio_image_thumbnail tasks/task_image.c:212 (retroarch+0x4a5328)
    #5 task_file_transfer_iterate_parse tasks/task_file_transfer.c:53 (retroarch+0x4a3fe9)
    #6 task_file_load_handler tasks/task_file_transfer.c:86 (retroarch+0x4a4230)
    #7 threaded_worker libretro-common/queues/task_queue.c:463 (retroarch+0x48f08b)
    #8 thread_wrap libretro-common/rthreads/rthreads.c:146 (retroarch+0x9bdd0e)
    #9 <null> <null> (libtsan.so.0+0x2c1dd)
```

This PR removes the problem.

It also seems to reduce the frequency of the lock-ups described in issue #9070 when using AMD graphics under Linux, but it absolutely does not address #9070 (since this is a lower level mesa driver issue...)

## Related Issues

#9070

