### PR TITLE
explicit use flag `RTLD_LOCAL` with dlopen()

### DIFF
--- a/libretro-common/dynamic/dylib.c
+++ b/libretro-common/dynamic/dylib.c
@@ -120,7 +120,7 @@ dylib_t dylib_load(const char *path)
    }
    last_dyn_error[0] = 0;
 #else
-   dylib_t lib = dlopen(path, RTLD_LAZY);
+   dylib_t lib = dlopen(path, RTLD_LAZY | RTLD_LOCAL);
 #endif
    return lib;
 }


### PR DESCRIPTION
## Description

On OSX, `dlopen()` default to`RTLD_GLOBAL` while linux defaults to `RTLD_LOCAL`.
so on OSX, it can cause issue with false positively detecting shared library as statically linked, as was the case with `Play!`.

