### PR TITLE
phoenix: allow debug cert to be used for release on local builds

### DIFF
--- a/pkg/android/phoenix/build.gradle
+++ b/pkg/android/phoenix/build.gradle
@@ -87,16 +87,18 @@ android {
         keyPassword RELEASE_KEY_PASSWORD
       }
     }
-    else {
-      release {
-        // Use debug if you don't have RELEASE_STORE_FILE
-      }
-    }
   }
 
   buildTypes {
-    release {
-      signingConfig signingConfigs.release
+    if (project.hasProperty("RELEASE_STORE_FILE")) {
+      release {
+        signingConfig signingConfigs.release
+      }
+    }
+    else {
+      release {
+        signingConfig signingConfigs.debug
+      }
     }
   }
 }


### PR DESCRIPTION
This allows home compilers to produce a release APK with their own self-signed cert if `RELEASE_STORE_FILE` is not set.

If `RELEASE_STORE_FILE` is set, the usual environment variables are used for signing.