### PR TITLE
Makefile.common: Fix the system zlib check.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1592,11 +1592,9 @@ ifeq ($(HAVE_BUILTINZLIB), 1)
           $(DEPS_DIR)/libz/zutil.o
    INCLUDE_DIRS += -I$(LIBRETRO_COMM_DIR)/include/compat/zlib
    DEFINES += -DWANT_ZLIB
-else
-ifneq ($(HAVE_ZLIB), 0)
+else ifeq ($(HAVE_ZLIB),1)
    HAVE_ZLIB_COMMON = 1
    LIBS += $(ZLIB_LIBS)
-endif
 endif
 
 ifeq ($(HAVE_ZLIB_COMMON), 1)


### PR DESCRIPTION
## Description

Small fix for when building without zlib.

## Related Pull Requests

Correct fix for https://github.com/libretro/RetroArch/commit/f0e70882191a612780b5f2b221d56ec340e7d180.

Seems I accidentally forgot this line in PR https://github.com/libretro/RetroArch/pull/8943.
