### PR TITLE
Wii: Fix HID driver

### DIFF
--- a/input/connect/connect_ps3.c
+++ b/input/connect/connect_ps3.c
@@ -136,12 +136,8 @@ static void hidpad_ps3_get_buttons(void *data, input_bits_t *state)
 	struct hidpad_ps3_data *device = (struct hidpad_ps3_data*)data;
 	if ( device )
 	{
-		/*copy first 16 bits - standard RetroPad controls*/
-		BITS_COPY16_PTR(state, device->buttons);
-
-		/*PS button?*/
-		if (device->buttons & 0x10000)
-			BIT256_SET_PTR(state, RARCH_MENU_TOGGLE);
+		/* copy 32 bits : needed for PS button? */
+		BITS_COPY32_PTR(state, device->buttons);
 	}
 	else
       BIT256_CLEAR_ALL_PTR(state);

--- a/input/connect/joypad_connection.h
+++ b/input/connect/joypad_connection.h
@@ -25,24 +25,31 @@
 #include <retro_endianness.h>
 #include "../input_driver.h"
 
+/* Wii have PID/VID already swapped by USB_GetDescriptors from libogc */
+#ifdef GEKKO
+#define SWAP_IF_BIG(val) (val)
+#else
+#define SWAP_IF_BIG(val) swap_if_big16(val)
+#endif
+
 #define VID_NONE          0x0000
-#define VID_NINTENDO      swap_if_big16(0x057e)
-#define VID_SONY          swap_if_big16(0x054c)
-#define VID_MICRONTEK     swap_if_big16(0x0079)
-#define VID_PCS           swap_if_big16(0x0810)
-#define VID_PS3_CLONE     swap_if_big16(0x0313)
-#define VID_SNES_CLONE    swap_if_big16(0x081f)
+#define VID_NINTENDO      SWAP_IF_BIG(0x057e)
+#define VID_SONY          SWAP_IF_BIG(0x054c)
+#define VID_MICRONTEK     SWAP_IF_BIG(0x0079)
+#define VID_PCS           SWAP_IF_BIG(0x0810)
+#define VID_PS3_CLONE     SWAP_IF_BIG(0x0313)
+#define VID_SNES_CLONE    SWAP_IF_BIG(0x081f)
 
 #define PID_NONE          0x0000
-#define PID_NINTENDO_PRO  swap_if_big16(0x0330)
-#define PID_SONY_DS3      swap_if_big16(0x0268)
-#define PID_SONY_DS4      swap_if_big16(0x05c4)
-#define PID_DS3_CLONE     swap_if_big16(0x20d6)
-#define PID_SNES_CLONE    swap_if_big16(0xe401)
-#define PID_MICRONTEK_NES swap_if_big16(0x0011)
-#define PID_NINTENDO_GCA  swap_if_big16(0x0337)
-#define PID_PCS_PS2PSX    swap_if_big16(0x0001)
-#define PID_PCS_PSX2PS3   swap_if_big16(0x0003)
+#define PID_NINTENDO_PRO  SWAP_IF_BIG(0x0330)
+#define PID_SONY_DS3      SWAP_IF_BIG(0x0268)
+#define PID_SONY_DS4      SWAP_IF_BIG(0x05c4)
+#define PID_DS3_CLONE     SWAP_IF_BIG(0x20d6)
+#define PID_SNES_CLONE    SWAP_IF_BIG(0xe401)
+#define PID_MICRONTEK_NES SWAP_IF_BIG(0x0011)
+#define PID_NINTENDO_GCA  SWAP_IF_BIG(0x0337)
+#define PID_PCS_PS2PSX    SWAP_IF_BIG(0x0001)
+#define PID_PCS_PSX2PS3   SWAP_IF_BIG(0x0003)
 
 struct joypad_connection
 {


### PR DESCRIPTION

## Description

This should fix the broken HID driver. Even if the Wii is big endian, the PID/VID values are already swapped here: https://github.com/libretro/RetroArch/blob/master/wii/libogc/libogc/usb.c#L924

I have tested with an original DualShock 3 and it's working now. The PS button wasn't working at all before changing to BITS_COPY32_PTR. I'm not sure it's the best and proper way to do.

## Related Issues
As reported in #7015 it happened since PR #5997

