### PR TITLE
Add ability to manually set default core option values when using the new v1 core options interface

### DIFF
--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -1142,7 +1142,7 @@ enum retro_mod
                                             * options must not change from the number in the initial call.
                                             *
                                             * 'data' points to an array of retro_core_option_definition structs
-                                            * terminated by a { NULL, NULL, NULL, {{0}} } element.
+                                            * terminated by a { NULL, NULL, NULL, {{0}}, NULL } element.
                                             * retro_core_option_definition::key should be namespaced to not collide
                                             * with other implementations' keys. e.g. A core called
                                             * 'foo' should use keys named as 'foo_option'.
@@ -1151,13 +1151,18 @@ enum retro_mod
                                             * retro_core_option_definition::info should contain any additional human
                                             * readable information text that a typical user may need to
                                             * understand the functionality of the option.
-                                            * retro_variable::values is an array of retro_core_option_value
+                                            * retro_core_option_definition::values is an array of retro_core_option_value
                                             * structs terminated by a { NULL, NULL } element.
-                                            * > retro_variable::values[index].value is an expected option
+                                            * > retro_core_option_definition::values[index].value is an expected option
                                             *   value.
-                                            * > retro_variable::values[index].label is a human readable
+                                            * > retro_core_option_definition::values[index].label is a human readable
                                             *   label used when displaying the value on screen. If NULL,
                                             *   the value itself is used.
+                                            * retro_core_option_definition::default_value is the default core option
+                                            * setting. It must match one of the expected option values in the
+                                            * retro_core_option_definition::values array. If it does not, or the
+                                            * default value is NULL, the first entry in the
+                                            * retro_core_option_definition::values array is treated as the default.
                                             *
                                             * The number of possible options should be very limited,
                                             * and must be less than RETRO_NUM_CORE_OPTION_VALUES_MAX.
@@ -1176,7 +1181,8 @@ enum retro_mod
                                             *         { "true",     NULL },
                                             *         { "unstable", "Turbo (Unstable)" },
                                             *         { NULL, NULL },
-                                            *     }
+                                            *     },
+                                            *     "false"
                                             * }
                                             *
                                             * Only strings are operated on. The possible values will
@@ -1216,6 +1222,10 @@ enum retro_mod
                                             * retro_core_options_intl::us is used by the frontend). Any items
                                             * missing from this array will be read from retro_core_options_intl::us
                                             * instead.
+                                            *
+                                            * NOTE: Default core option values are always taken from the
+                                            * retro_core_options_intl::us array. Any default values in
+                                            * retro_core_options_intl::local array will be ignored.
                                             */
 
 #define RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY 55
@@ -2521,6 +2531,11 @@ struct retro_core_option_definition
 
    /* Array of retro_core_option_value structs, terminated by NULL */
    struct retro_core_option_value values[RETRO_NUM_CORE_OPTION_VALUES_MAX];
+
+   /* Default core option value. Must match one of the values
+    * in the retro_core_option_value array, otherwise will be
+    * ignored */
+   const char *default_value;
 };
 
 struct retro_core_options_intl

--- a/managers/core_option_manager.h
+++ b/managers/core_option_manager.h
@@ -34,6 +34,7 @@ struct core_option
    char *key;
    struct string_list *vals;
    struct string_list *val_labels;
+   size_t default_index;
    size_t index;
    bool visible;
 };


### PR DESCRIPTION
## Description

**Note: this PR was made in a huge rush as a last-minute request from @twinaphex. It is therefore based on a PR that has not been merged yet. @twinaphex basically wanted this done immediately, and I have no more time, so it is what it is...**

This PR makes one addition to the new core options interface defined in PR #9092. It allows a default core option value to be set manually - as opposed to using the first setting in the values array.

[PokeMini PR #25](https://github.com/libretro/PokeMini/pull/25) serves as an example. The default value is entered as follows:

```c
struct retro_core_option_definition option_defs_us[] = {
   {
      "option_key",
      "option_description (menu label)",
      "option_info (menu sublabel)",
      {
         { "value_1", "value_1_label (displayed in menu)" },
         { "value_2", "value_2_label (displayed in menu)" },
         { NULL, NULL },
      },
      "default_value"
   },
   { NULL, NULL, NULL, {{0}} },
}
```

If `default_value` is NULL or does not match any entry in the values array, then the first value in the array is selected as the default.



## Related Pull Requests

This is based upon PR #9100

