### PR TITLE
qb: Improve the CDROM check.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -137,11 +137,11 @@ check_lib '' THREADS "$PTHREADLIB" pthread_create
 check_enabled THREADS THREAD_STORAGE 'Thread Local Storage' 'Threads are' false
 check_lib '' THREAD_STORAGE "$PTHREADLIB" pthread_key_create
 
-if [ "$HAVE_NO_CDROM" = "" ]; then
-   if [ "$OS" = 'Win32' ] || [ "$OS" = 'Linux' ]; then
-      HAVE_CDROM=yes
-   fi
+if [ "$OS" = 'Linux' ]; then
+   check_header CDROM stropts.h scsi/sg.h
 fi
+
+check_platform 'Linux Win32' CDROM 'CD-ROM is' user
 
 if [ "$OS" = 'Win32' ]; then
    HAVE_DYLIB=yes

--- a/qb/config.params.sh
+++ b/qb/config.params.sh
@@ -144,4 +144,4 @@ HAVE_VIDEOPROCESSOR=auto   # Enable video processor core
 HAVE_VIDEOCORE=auto        # Broadcom Videocore 4 support
 HAVE_DRMINGW=no            # DrMingw exception handler
 HAVE_EASTEREGG=yes         # Easter egg
-HAVE_CDROM=no
+HAVE_CDROM=auto            # CD-ROM support

--- a/qb/qb.init.sh
+++ b/qb/qb.init.sh
@@ -41,3 +41,19 @@ exists()
 	done
 	return $v
 }
+
+# match:
+# Compares a variable against a list of variables
+# $1 = variable
+# $@ = list of variables
+match()
+{
+	var="$1"
+	shift
+	for string do
+		case "$string" in
+			"$var" ) return 0 ;;
+		esac
+	done
+	return 1
+}


### PR DESCRIPTION
## Description

The first commit extends the `check_platform` function to be able to check for more than one OS per feature and also adds a `match` helper function in `qb/qb.init.sh`. This will have no change in behavior on its own, but this will allow to improve the CDROM check in the second commit to correctly respect configure arguments. I also added a missing configure check for headers which are required on Linux and this prevents build failures on some distros where these headers are not available. @bparker06 may want to find more portable headers in a followup commit.

Currently the CDROM code will be enabled automatically for `Linux` and `Win32` while other platforms will require `--enable-cdrom`. It can be enabled automatically for other platforms if the platform string is added to the `check_platform` `CDROM` check in `qb/config.libs.sh` or it can be enabled everywhere by removing that check and changing `HAVE_CDROM=auto` in `qb/config.params.sh` to `yes`.

If specific platforms should disable `CDROM` support or if it should only be enabled for certain platforms with `--enable-cdrom` resulting in an error on other platforms this can be easily changed, please let me know?

## Related Issues

Fixes https://github.com/libretro/RetroArch/issues/9096.