### PR TITLE
[iOS] Playlist: support abbreviations for application/home directory

### DIFF
--- a/frontend/drivers/platform_darwin.m
+++ b/frontend/drivers/platform_darwin.m
@@ -358,6 +358,13 @@ static void frontend_darwin_get_environment_settings(int *argc, char *argv[],
             resolved_home_dir_buf,
             sizeof(home_dir_buf)) < sizeof(home_dir_buf));
    }
+    char resolved_bundle_dir_buf[PATH_MAX_LENGTH] = {0};
+    if (realpath(bundle_path_buf, resolved_bundle_dir_buf))
+    {
+        retro_assert(strlcpy(bundle_path_buf,
+                             resolved_bundle_dir_buf,
+                             sizeof(bundle_path_buf)) < sizeof(bundle_path_buf));
+    }
 #endif
 
    strlcat(home_dir_buf, "/RetroArch", sizeof(home_dir_buf));

--- a/libretro-common/file/file_path.c
+++ b/libretro-common/file/file_path.c
@@ -1197,10 +1197,23 @@ void fill_pathname_application_path(char *s, size_t len)
       CFURLRef bundle_url     = CFBundleCopyBundleURL(bundle);
       CFStringRef bundle_path = CFURLCopyPath(bundle_url);
       CFStringGetCString(bundle_path, s, len, kCFStringEncodingUTF8);
+#ifdef HAVE_COCOATOUCH
+       // This needs to be done so that the path becomes /private/var/... and this
+       // is used consistently throughout for the iOS bundle path
+       char resolved_bundle_dir_buf[PATH_MAX_LENGTH] = {0};
+       if (realpath(s, resolved_bundle_dir_buf))
+       {
+           strlcpy(s,resolved_bundle_dir_buf, len);
+           strlcat(s,"/",len);
+       }
+#endif
+
       CFRelease(bundle_path);
       CFRelease(bundle_url);
-
+#ifndef HAVE_COCOATOUCH
+      // Not sure what this does but it breaks stuff for iOS so skipping
       retro_assert(strlcat(s, "nobin", len) < len);
+#endif
       return;
    }
 #elif defined(__HAIKU__)

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -1020,10 +1020,19 @@ static bool menu_content_playlist_load(playlist_t *playlist, size_t idx)
 {
    const char *path     = NULL;
    const struct playlist_entry *entry = NULL;
+#ifdef HAVE_COCOATOUCH
+   char expanded_path[PATH_MAX_LENGTH];
+#endif
 
    playlist_get_index(playlist, idx, &entry);
 
    path = entry->path;
+
+#ifdef HAVE_COCOATOUCH
+   expanded_path[0] = '\0';
+   fill_pathname_expand_special(expanded_path, entry->path, sizeof(expanded_path));
+   path = expanded_path;
+#endif
 
    if (!string_is_empty(path))
    {
@@ -1586,6 +1595,15 @@ static int generic_action_ok(const char *path,
          break;
       case ACTION_OK_SET_DIRECTORY:
          flush_char = msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_DIRECTORY_SETTINGS_LIST);
+#ifdef HAVE_COCOATOUCH
+         // For iOS, set the path using realpath because the path name
+         // can start with /private and this ensures the path starts with it.
+         // This will allow the path to be properly substituted when fill_pathname_expand_special
+         // is called.
+         char real_action_path[PATH_MAX_LENGTH] = {0};
+         realpath(action_path, real_action_path);
+         strlcpy(action_path, real_action_path, sizeof(action_path));
+#endif
          ret        = set_path_generic(menu->filebrowser_label, action_path);
          break;
       case ACTION_OK_SET_PATH_VIDEO_FILTER:
@@ -1780,11 +1798,21 @@ static int action_ok_playlist_entry_collection(const char *path,
    const struct playlist_entry *entry  = NULL;
    unsigned i                          = 0;
 
+#ifdef HAVE_COCOATOUCH
+   char expanded_path[PATH_MAX_LENGTH];
+   char expanded_core_path[PATH_MAX_LENGTH] = {0};
+#endif
+
    if (!menu_driver_ctl(RARCH_MENU_CTL_DRIVER_DATA_GET, &menu))
       return menu_cbs_exit();
 
    new_core_path[0]                    = '\0';
    tmp_playlist                        = playlist_get_cached();
+
+#ifdef HAVE_COCOATOUCH
+   expanded_path[0]                    = '\0';
+   expanded_core_path[0]               = '\0';
+#endif
 
    if (!tmp_playlist)
    {
@@ -1878,7 +1906,13 @@ static int action_ok_playlist_entry_collection(const char *path,
       }
    }
    else
+   {
       strlcpy(new_core_path, entry->core_path, sizeof(new_core_path));
+#ifdef HAVE_COCOATOUCH
+      fill_pathname_expand_special(expanded_core_path, new_core_path, sizeof(expanded_core_path));
+      strlcpy(new_core_path, expanded_core_path, sizeof(new_core_path));
+#endif
+   }
 
    if (!playlist || !menu_content_playlist_load(playlist, selection_ptr))
    {
@@ -1893,8 +1927,14 @@ static int action_ok_playlist_entry_collection(const char *path,
 
    playlist_get_index(playlist, selection_ptr, &entry);
 
-   return default_action_ok_load_content_from_playlist_from_menu(
-         new_core_path, entry->path, entry->label);
+#ifdef HAVE_COCOATOUCH
+   fill_pathname_expand_special(expanded_path, entry->path, sizeof(expanded_path));
+    return default_action_ok_load_content_from_playlist_from_menu(
+            new_core_path, expanded_path, entry->label);
+#else
+    return default_action_ok_load_content_from_playlist_from_menu(
+            new_core_path, entry->path, entry->label);
+#endif
 }
 
 static int action_ok_playlist_entry(const char *path,
@@ -1908,6 +1948,11 @@ static int action_ok_playlist_entry(const char *path,
    const char *entry_label             = NULL;
 
    new_core_path[0] = '\0';
+
+#ifdef HAVE_COCOATOUCH
+   char expanded_core_path[PATH_MAX_LENGTH];
+   expanded_core_path[0]               = '\0';
+#endif
 
    if (!playlist ||
        !menu_driver_ctl(RARCH_MENU_CTL_DRIVER_DATA_GET, &menu))
@@ -1957,8 +2002,13 @@ static int action_ok_playlist_entry(const char *path,
       }
 
    }
-   else if (!string_is_empty(entry->core_path))
-      strlcpy(new_core_path, entry->core_path, sizeof(new_core_path));
+   else if (!string_is_empty(entry->core_path)) {
+       strlcpy(new_core_path, entry->core_path, sizeof(new_core_path));
+#ifdef HAVE_COCOATOUCH
+      fill_pathname_expand_special(expanded_core_path, new_core_path, sizeof(expanded_core_path));
+      strlcpy(new_core_path, expanded_core_path, sizeof(new_core_path));
+#endif
+   }
 
    if (!playlist || !menu_content_playlist_load(playlist, selection_ptr))
    {

--- a/playlist.c
+++ b/playlist.c
@@ -639,8 +639,18 @@ bool playlist_push(playlist_t *playlist,
    const char *core_name = entry->core_name;
    bool entry_updated    = false;
 
+#ifdef HAVE_COCOATOUCH
+    char abbreviated_path[PATH_MAX_LENGTH];
+    char abbreviated_core_path[PATH_MAX_LENGTH];
+#endif
+
    real_path[0] = '\0';
    real_core_path[0] = '\0';
+
+#ifdef HAVE_COCOATOUCH
+   abbreviated_path[0] = '\0';
+   abbreviated_core_path[0] = '\0';
+#endif
 
    if (!playlist || !entry)
       return false;
@@ -656,6 +666,11 @@ bool playlist_push(playlist_t *playlist,
    {
       strlcpy(real_path, entry->path, sizeof(real_path));
       path_resolve_realpath(real_path, sizeof(real_path));
+#ifdef HAVE_COCOATOUCH
+      strlcpy(abbreviated_path, real_path, sizeof(abbreviated_path));
+      fill_pathname_abbreviate_special(abbreviated_path, real_path, sizeof(abbreviated_path));
+      strlcpy(real_path, abbreviated_path, sizeof(real_path));
+#endif
    }
 
    /* Get 'real' core path */
@@ -668,6 +683,11 @@ bool playlist_push(playlist_t *playlist,
       RARCH_ERR("cannot push NULL or empty core path into the playlist.\n");
       return false;
    }
+#ifdef HAVE_COCOATOUCH
+   strlcpy(abbreviated_core_path, real_core_path, sizeof(abbreviated_core_path));
+   fill_pathname_abbreviate_special(abbreviated_core_path, real_core_path, sizeof(abbreviated_core_path));
+   strlcpy(real_core_path, abbreviated_core_path, sizeof(real_core_path));
+#endif
 
    if (string_is_empty(core_name))
    {


### PR DESCRIPTION
## Description

Currently, the playlists (history/favorites) save absolute paths for the cores and roms/content.

On iOS, every installation results in a new application (bundle) and home directory paths so playlist entries are not portable when the user updates the application.

This change uses the `fill_pathname_abbreviate_special` and `fill_pathname_abbreviate_special` file methods when saving and reading from playlist entries.

I don't think this impacts other systems, but I haven't tested on others just yet so a review would be nice - thanks! I'm also not by any means a C expert - I forgot dealing with strings was hard and the consequences fatal, so hopefully I did it right :)

