### PR TITLE
[iOS] show quickmenu after loading content from playlist (#9118)

### DIFF
--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -1693,6 +1693,11 @@ bool task_push_load_content_from_playlist_from_menu(
    /* Load core */
 #ifdef HAVE_DYNAMIC
    command_event(CMD_EVENT_LOAD_CORE, NULL);
+#ifdef HAVE_COCOATOUCH
+    // this seems to needed for iOS for some reason to show the quick menu after the menu is shown
+   menu_entries_flush_stack(NULL, MENU_SETTINGS);
+   menu_driver_ctl(RARCH_MENU_CTL_SET_PENDING_QUICK_MENU, NULL);
+#endif
 #else
    rarch_ctl(RARCH_CTL_SET_SHUTDOWN, NULL);
    rarch_menu_running_finished(true);


### PR DESCRIPTION
## Description

Fixes #9118 

This seems to happen only on iOS - tested with macOS and Android and it doesn't appear to be an issue there.