### PR TITLE
fix hanging window under Windows 7 in threaded video mode

### DIFF
--- a/gfx/common/win32_common.c
+++ b/gfx/common/win32_common.c
@@ -1140,6 +1140,8 @@ void win32_check_window(bool *quit, bool *resize,
       unsigned *width, unsigned *height)
 {
 #if !defined(_XBOX)
+   if (video_driver_is_threaded())
+      ui_companion_win32.application->process_events();
    *quit                  = g_win32_quit;
 
    if (g_win32_resized)


### PR DESCRIPTION
## Description

https://github.com/libretro/RetroArch/commit/e02ff9c40ceb683d60ff22d45006a0e32f9a7e03 removed a `process_events();` in threaded video mode which caused the main window to hang under Windows 7 (and it probably has _some_ effect on newer Windows as well).

This PR simply adds the missing call again.