### PR TITLE
[iOS]: more fixes for abbreviated paths when scanning files

### DIFF
--- a/playlist.h
+++ b/playlist.h
@@ -35,6 +35,12 @@ enum playlist_runtime_status
    PLAYLIST_RUNTIME_VALID
 };
 
+enum playlist_file_mode
+{
+    PLAYLIST_LOAD,
+    PLAYLIST_SAVE
+};
+
 struct playlist_entry
 {
    char *path;
@@ -117,6 +123,21 @@ void playlist_get_index(playlist_t *playlist,
  **/
 void playlist_delete_index(playlist_t *playlist,
       size_t idx);
+
+/**
+ * playlist_resolve_path:
+ * @mode      : PLAYLIST_LOAD or PLAYLIST_SAVE
+ * @path        : The path to be modified
+ *
+ * Resolves the path of an item, such as the content path or path to the core, to a format
+ * appropriate for saving or loading depending on the @mode parameter
+ *
+ * Can be platform specific. File paths for saving can be abbreviated to avoid saving absolute
+ * paths, as the base directory (home or application dir) may change after each subsequent
+ * install (iOS)
+ **/
+void playlist_resolve_path(enum playlist_file_mode mode,
+      char *path, size_t size);
 
 /**
  * playlist_push:


### PR DESCRIPTION
## Description

Call `fill_pathname_abbreviate_special()` when choosing a core after scanning a file (when the core becomes "DETECT"). This fixes the core path for playlist entries when scanning content.
