### PR TITLE
Increase menu sublabel buffer size + fix Ozone sublabel spacing

### DIFF
--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -605,7 +605,7 @@ static void materialui_compute_entries_box(materialui_handle_t* mui, int width)
    for (i = 0; i < entries_end; i++)
    {
       menu_entry_t entry;
-      char wrapped_sublabel_str[512];
+      char wrapped_sublabel_str[MENU_SUBLABEL_MAX_LENGTH];
       const char *sublabel_str  = NULL;
       unsigned lines            = 0;
       materialui_node_t *node   = (materialui_node_t*)
@@ -744,7 +744,7 @@ static void materialui_render_label_value(
    menu_animation_ctx_ticker_t ticker;
    char label_str[255];
    char value_str[255];
-   char wrapped_sublabel_str[512];
+   char wrapped_sublabel_str[MENU_SUBLABEL_MAX_LENGTH];
    unsigned entry_type             = 0;
    const char *sublabel_str        = NULL;
    bool switch_is_on               = true;

--- a/menu/drivers/ozone/ozone_entries.c
+++ b/menu/drivers/ozone/ozone_entries.c
@@ -197,8 +197,9 @@ void ozone_compute_entries_position(ozone_handle_t *ozone)
    unsigned lines;
    size_t i, entries_end;
 
-   file_list_t *selection_buf = NULL;
-   int entry_padding          = ozone_get_entries_padding(ozone, false);
+   file_list_t *selection_buf    = NULL;
+   int entry_padding             = ozone_get_entries_padding(ozone, false);
+   unsigned sublabel_line_height = font_driver_get_line_height(ozone->fonts.entries_sublabel, 1.0f);
 
    menu_entries_ctl(MENU_ENTRIES_CTL_START_GET, &i);
 
@@ -250,7 +251,7 @@ void ozone_compute_entries_position(ozone_handle_t *ozone)
       if (!string_is_empty(sublabel_str))
       {
          int sublabel_max_width;
-         char wrapped_sublabel_str[512];
+         char wrapped_sublabel_str[MENU_SUBLABEL_MAX_LENGTH];
          wrapped_sublabel_str[0] = '\0';
 
          node->height += ozone->dimensions.entry_spacing + 40;
@@ -270,7 +271,7 @@ void ozone_compute_entries_position(ozone_handle_t *ozone)
 
          if (lines > 1)
          {
-            node->height += lines * 15;
+            node->height += (lines - 1) * sublabel_line_height;
             node->wrap = true;
          }
       }
@@ -476,7 +477,7 @@ border_iterate:
       static const char* const ticker_spacer = OZONE_TICKER_SPACER;
       char rich_label[255];
       char entry_value_ticker[255];
-      char wrapped_sublabel_str[512];
+      char wrapped_sublabel_str[MENU_SUBLABEL_MAX_LENGTH];
       const char *sublabel_str     = NULL;
       ozone_node_t *node           = NULL;
       const char *entry_rich_label = NULL;

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -545,7 +545,7 @@ typedef struct
    bool show_wallpaper;
    char theme_preset_path[PATH_MAX_LENGTH]; /* Must be a fixed length array... */
    char menu_title[255]; /* Must be a fixed length array... */
-   char menu_sublabel[255]; /* Must be a fixed length array... */
+   char menu_sublabel[MENU_SUBLABEL_MAX_LENGTH]; /* Must be a fixed length array... */
    unsigned menu_aspect_ratio;
    unsigned menu_aspect_ratio_lock;
    bool aspect_update_pending;
@@ -3537,7 +3537,7 @@ static void rgui_render(void *data, bool is_idle)
       /* Print menu sublabel/core name (if required) */
       if (settings->bools.menu_show_sublabels && !string_is_empty(rgui->menu_sublabel))
       {
-         char sublabel_buf[255];
+         char sublabel_buf[MENU_SUBLABEL_MAX_LENGTH];
          sublabel_buf[0] = '\0';
 
          ticker.s        = sublabel_buf;

--- a/menu/drivers/stripes.c
+++ b/menu/drivers/stripes.c
@@ -2472,7 +2472,7 @@ static int stripes_draw_item(
    if (i == current && width > 320 && height > 240
          && !string_is_empty(entry->sublabel))
    {
-      char entry_sublabel[255] = {0};
+      char entry_sublabel[MENU_SUBLABEL_MAX_LENGTH] = {0};
 
       label_offset      = - stripes->margins_label_top;
 

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -2994,7 +2994,9 @@ static int xmb_draw_item(
             && !string_is_empty(entry->sublabel))
       {
          menu_animation_ctx_line_ticker_t line_ticker;
-         char entry_sublabel[512] = {0};
+         char entry_sublabel[MENU_SUBLABEL_MAX_LENGTH];
+
+         entry_sublabel[0] = '\0';
 
          line_ticker.type_enum  = (enum menu_animation_ticker_type)settings->uints.menu_ticker_type;
          line_ticker.idx        = menu_animation_get_ticker_idx();

--- a/menu/menu_entries.c
+++ b/menu/menu_entries.c
@@ -449,7 +449,7 @@ void menu_entry_get(menu_entry_t *entry, size_t stack_idx,
                      cbs->action_sublabel_cache, sizeof(entry->sublabel));
          else if (cbs->action_sublabel)
          {
-            char tmp[512];
+            char tmp[MENU_SUBLABEL_MAX_LENGTH];
             tmp[0] = '\0';
 
             if (cbs->action_sublabel(list,

--- a/menu/menu_entries.h
+++ b/menu/menu_entries.h
@@ -30,6 +30,8 @@
 
 RETRO_BEGIN_DECLS
 
+#define MENU_SUBLABEL_MAX_LENGTH 1024
+
 enum menu_entries_ctl_state
 {
    MENU_ENTRIES_CTL_NONE = 0,
@@ -80,7 +82,7 @@ typedef struct menu_ctx_list
 
 typedef struct menu_file_list_cbs
 {
-   char action_sublabel_cache[512];
+   char action_sublabel_cache[MENU_SUBLABEL_MAX_LENGTH];
    char action_title_cache   [512];
 
    enum msg_hash_enums enum_idx;
@@ -210,7 +212,7 @@ typedef struct menu_entry
    size_t entry_idx;
    char path[255];
    char label[255];
-   char sublabel[512];
+   char sublabel[MENU_SUBLABEL_MAX_LENGTH];
    char rich_label[255];
    char value[255];
    char password_value[255];


### PR DESCRIPTION
## Description

To prepare for the influx of new core option sublabels, this PR increases the menu sublabel buffer size to `1024`. This is set 'globally' via a new `MENU_SUBLABEL_MAX_LENGTH` define in `menu_entries.h`, so we can easily change it in the future if required.

While doing this, I noticed an error in Ozone's sublabel spacing calculation. This PR fixes the issue.

