### PR TITLE
replace realpath() by custom code which does not resolve symlinks

### DIFF
--- a/gfx/drivers_shader/glslang_util.cpp
+++ b/gfx/drivers_shader/glslang_util.cpp
@@ -53,7 +53,7 @@ bool glslang_read_shader_file(const char *path, vector<string> *output, bool roo
    include_path[0] = tmp[0] = '\0';
 
    strlcpy(tmp_path, path, path_size);
-   path_resolve_realpath(tmp_path, path_size);
+   path_resolve_realpath(tmp_path, path_size, false);
 
    if (!path_is_valid(tmp_path))
       strlcpy(tmp_path, path, path_size);

--- a/gfx/video_shader_parse.c
+++ b/gfx/video_shader_parse.c
@@ -756,7 +756,7 @@ void video_shader_write_conf_preset(config_file_t *conf,
       strlcpy(tmp_base, preset_path, tmp_size);
 
       /* ensure we use a clean base like the shader passes and texture paths do */
-      path_resolve_realpath(tmp_base, tmp_size);
+      path_resolve_realpath(tmp_base, tmp_size, false);
       path_basedir(tmp_base);
    }
 

--- a/libretro-common/include/file/file_path.h
+++ b/libretro-common/include/file/file_path.h
@@ -149,6 +149,7 @@ void path_parent_dir(char *path);
  * path_resolve_realpath:
  * @buf                : input and output buffer for path
  * @size               : size of buffer
+ * @resolve_symlinks   : whether to resolve symlinks or not
  *
  * Resolves use of ".", "..", multiple slashes etc in absolute paths.
  *
@@ -156,11 +157,12 @@ void path_parent_dir(char *path);
  *
  * Returns: @buf if successful, NULL otherwise.
  * Note: Not implemented on consoles
+ * Note: Symlinks are only resolved on Unix-likes
  * Note: The current working dir might not be what you expect,
  *       e.g. on Android it is "/"
  *       Use of fill_pathname_resolve_relative() should be prefered
  **/
-char *path_resolve_realpath(char *buf, size_t size);
+char *path_resolve_realpath(char *buf, size_t size, bool resolve_symlinks);
 
 /**
  * path_relative_to:

--- a/libretro-common/include/file/file_path.h
+++ b/libretro-common/include/file/file_path.h
@@ -147,14 +147,20 @@ void path_parent_dir(char *path);
 
 /**
  * path_resolve_realpath:
- * @buf                : buffer for path
+ * @buf                : input and output buffer for path
  * @size               : size of buffer
  *
- * Turns relative paths into absolute paths and
- * resolves use of "." and ".." in absolute paths.
- * If relative, rebases on current working dir.
+ * Resolves use of ".", "..", multiple slashes etc in absolute paths.
+ *
+ * Relative paths are rebased on the current working dir.
+ *
+ * Returns: @buf if successful, NULL otherwise.
+ * Note: Not implemented on consoles
+ * Note: The current working dir might not be what you expect,
+ *       e.g. on Android it is "/"
+ *       Use of fill_pathname_resolve_relative() should be prefered
  **/
-void path_resolve_realpath(char *buf, size_t size);
+char *path_resolve_realpath(char *buf, size_t size);
 
 /**
  * path_relative_to:

--- a/retroarch.c
+++ b/retroarch.c
@@ -4335,7 +4335,7 @@ static bool load_dynamic_core(const char *path, char *buf, size_t size)
    /* Need to use absolute path for this setting. It can be
     * saved to content history, and a relative path would
     * break in that scenario. */
-   path_resolve_realpath(buf, size);
+   path_resolve_realpath(buf, size, true);
    if ((lib_handle = dylib_load(path)))
       return true;
    return false;

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -1325,7 +1325,7 @@ static void task_push_to_history_list(
       /* Path can be relative here.
        * Ensure we're pushing absolute path. */
       if (!launched_from_menu && !string_is_empty(tmp))
-         path_resolve_realpath(tmp, tmp_size);
+         path_resolve_realpath(tmp, tmp_size, true);
 
 #ifdef HAVE_MENU
       /* Push quick menu onto menu stack */


### PR DESCRIPTION
## Description
The fact that `realpath()` resolves symlinks has been causing issues with relative paths.
Usually relative paths are simply concatenated with a base path, e.g. `/foo/bar/` + `../baz/`.
Resolving `/../` would result in the path `/foo/baz/`.

`realpath()`, however, will resolve symlinks *first*, resulting in unexpected paths.
E.g. if `/foo/bar/` is a symlink to `/bart/`
`/foo/bar/../baz/`
first turns into
`/bart/../baz/`
and finally into
`/baz/`
The example `/foo/bar/../../bort` would even result in an illegal path, even though it looks legal.

This is one part of the reason why core shader presets for Android broke (#9116), a (legal looking) relative path from a symlink to a realpath was written, which would then be resolved in an unexpected way.

Since the Windows analog `_fullpath()` does not resolve symlinks, this change will make `path_resolve_realpath()` more consistent.

## Content
 - replace `realpath()` with an extensively tested piece of code that does not resolve symlinks
 - add `char*` return value to `path_resolve_realpath()` to check for errors if one really wants to
 - update the documentation

## Tests

This replacement for `realpath()` fulfills all the following test cases:
```
input          expected output
"/",           "/",
"/.",          "/",
"/a",          "/a",
"/a/",         "/a/",
"/a/.",        "/a/",
"/a/./",       "/a/",
"/a/..",       "/",
"/a/../",      "/",
"/a/foo/..",   "/a/",
"/a/foo/../",  "/a/",
"/a/foo/../",  "/a/",
"/a/foo/.b",   "/a/foo/.b",
"/a/foo/.b/",  "/a/foo/.b/",
"/a/foo/..b",  "/a/foo/..b",
"/a/foo/..b/", "/a/foo/..b/",
"/a/foo/...",  "/a/foo/...",
"/a/foo/.../", "/a/foo/.../",

"//",           "//",
"//.",          "//",
"//a",          "//a",
"//a/",         "//a/",
"//a/.",        "//a/",
"//a/./",       "//a/",
"//a/..",       "//",
"//a/../",      "//",
"//a/foo/..",   "//a/",
"//a/foo/../",  "//a/",
"//a/foo/../",  "//a/",
"//a/foo/.b",   "//a/foo/.b",
"//a/foo/.b/",  "//a/foo/.b/",
"//a/foo/..b",  "//a/foo/..b",
"//a/foo/..b/", "//a/foo/..b/",
"//a/foo/...",  "//a/foo/...",
"//a/foo/.../", "//a/foo/.../",

/* relative to cwd = /home/dev/test */
"",                     "/home/dev/test/",
".",                    "/home/dev/test/",
"../..",                "/home/",
"../../",               "/home/",
"..",                   "/home/dev/",
"../",                  "/home/dev/",
"aa//bar//bazi",        "/home/dev/test/aa/bar/bazi",
".//bar//.././baz/foo", "/home/dev/test/baz/foo",

/* illegal cases */
"/..",             NULL,
"/../",            NULL,
"/../..",          NULL,
"/../foo",         NULL,
"/../foo/",        NULL,
"/../../foo",      NULL,
"/../../foo/",     NULL,
"//..",            NULL,
"//../",           NULL,
"//../..",         NULL,
"//../foo",        NULL,
"//../foo/",       NULL,
"//../../foo",     NULL,
"//../../foo/",    NULL,
"../../../../foo", NULL, /* relative to cwd = /home/dev/test */
```

## Related Issues
#9116
