### PR TITLE
macos: fix call to video_shader_read_conf_preset

### DIFF
--- a/gfx/common/metal_common.m
+++ b/gfx/common/metal_common.m
@@ -1144,10 +1144,8 @@ typedef struct MTLALIGN(16)
    {
       unsigned i;
       texture_t *source = NULL;
-      if (!video_shader_read_conf_preset(conf, shader))
+      if (!video_shader_read_conf_preset(conf, shader, path.UTF8String))
          return NO;
-
-      video_shader_resolve_relative(shader, path.UTF8String);
 
       source = &_engine.frame.texture[0];
 


### PR DESCRIPTION
## Description

Just noticed that the recent change for shader paths wasn't applied for the macOS metal build, and caused the build to not compile. I think this is the right fix?

## Related Pull Requests

#9140 



