### PR TITLE
qb: Improve win32 checks.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -300,40 +300,25 @@ fi
 check_enabled THREADS LIBUSB libusb 'Threads are' false
 check_val '' LIBUSB -lusb-1.0 libusb-1.0 libusb-1.0 1.0.13 '' false
 
-if [ "$OS" = 'Win32' ]; then
-   check_lib '' DINPUT -ldinput8
-   check_lib '' D3D8 -ld3d8
-   check_lib '' D3D9 -ld3d9
-   check_lib '' DSOUND -ldsound
+check_lib '' DINPUT -ldinput8
+check_lib '' D3D8 -ld3d8
+check_lib '' D3D9 -ld3d9
+check_lib '' DSOUND -ldsound
 
-   if [ "$HAVE_D3DX" != 'no' ]; then
-      check_lib '' D3DX8 -ld3dx8
-      check_lib '' D3DX9 -ld3dx9
-   fi
+check_enabled DINPUT XINPUT xinput 'Dinput is' true
 
-   if [ "$HAVE_DINPUT" != 'no' ]; then
-      HAVE_XINPUT=yes
-   fi
-
-   if [ "$HAVE_WASAPI" != 'no' ]; then
-      HAVE_WASAPI=yes
-   fi
-
-   if [ "$HAVE_XAUDIO" != 'no' ]; then
-      HAVE_XAUDIO=yes
-   fi
-
-   if [ "$HAVE_WINMM" != 'no' ]; then
-      HAVE_WINMM=yes
-   fi
+if [ "$HAVE_D3DX" != 'no' ]; then
+   check_lib '' D3DX8 -ld3dx8
+   check_lib '' D3DX9 -ld3dx9
 fi
 
-check_platform Win32 D3D8 'Direct3D 8 is' true
-check_platform Win32 D3D9 'Direct3D 9 is' true
 check_platform Win32 D3D10 'Direct3D 10 is' true
 check_platform Win32 D3D11 'Direct3D 11 is' true
 check_platform Win32 D3D12 'Direct3D 12 is' true
 check_platform Win32 D3DX 'Direct3DX is' true
+check_platform Win32 WASAPI 'WASAPI is' true
+check_platform Win32 XAUDIO 'XAudio is' true
+check_platform Win32 WINMM 'WinMM is' true
 
 if [ "$HAVE_OPENGL" != 'no' ] && [ "$HAVE_OPENGLES" != 'yes' ]; then
    if [ "$OS" = 'Darwin' ]; then

--- a/qb/config.params.sh
+++ b/qb/config.params.sh
@@ -63,6 +63,7 @@ C89_D3D11=no
 HAVE_D3D12=yes             # Direct3D 12 support
 C89_D3D12=no
 HAVE_D3DX=auto             # Direct3DX support
+HAVE_DINPUT=auto           # Dinput support
 HAVE_OPENGL=auto           # OpenGL 2.0 support
 HAVE_OPENGL_CORE=yes       # Modern OpenGL driver support (GLES3+/GL3.2 core+), requires OpenGL.
 C89_OPENGL_CORE=no


### PR DESCRIPTION
## Description

Cleans up some of the recent changes to qb.

Some things to note.

1. This `WIN32` conditional is not needed and removing it allows to easier respect `--enable-*` flags for win32 features on other platforms where they can correctly fail. Also allows removing a few uses of `check_platform`.
2. Allows users to disable or force dinput as enabled, its set to `auto` to reflect the current behavior.
3. Uses `check_enabled` to correctly enable `HAVE_XINPUT` when `HAVE_DINPUT` is enabled. Since `check_lib` will only find dinput on windows this is enough for other platforms.
4. Uses `check_platform` to correctly enable win32 features for windows.