### PR TITLE
Correctly fixes --disable-menu.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -348,7 +348,6 @@ ifeq ($(HAVE_SLANG), 1)
    HAVE_SHADERS_COMMON = 1
 endif
 
-
 # Qt WIMP GUI
 
 ifeq ($(HAVE_OPENSSL), 1)
@@ -791,6 +790,11 @@ ifeq ($(HAVE_LAKKA_SWITCH), 1)
    DEFINES += -DHAVE_LAKKA_SWITCH
 endif
 
+# Does not depend on HAVE_MENU
+ifeq ($(HAVE_SHADERS_COMMON),1)
+   OBJ += menu/menu_shader.o
+endif
+
 ifeq ($(HAVE_MENU_COMMON), 1)
    OBJ += menu/menu_driver.o \
           menu/menu_content.o \
@@ -824,11 +828,7 @@ ifeq ($(HAVE_MENU_COMMON), 1)
           menu/drivers/menu_generic.o \
           menu/drivers/null.o \
           menu/menu_thumbnail_path.o \
-			 menu/drivers_display/menu_display_null.o
-
-   ifeq ($(HAVE_SHADERS_COMMON),1)
-      OBJ += menu/menu_shader.o
-   endif
+          menu/drivers_display/menu_display_null.o
 
    ifeq ($(HAVE_MENU_WIDGETS), 1)
       OBJ += menu/widgets/menu_widgets.o

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -629,10 +629,8 @@ static bool content_load(content_ctx_info_t *info)
       content_clear_subsystem();
    }
 
-#if defined(HAVE_MENU)
 #if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)
    menu_shader_manager_init();
-#endif
 #endif
 
    command_event(CMD_EVENT_HISTORY_INIT, NULL);


### PR DESCRIPTION
## Description

Correctly fixes `--disable-menu`.

Note that despite its name we want to build `menu_shader.c` with `--disable-menu` and this was done intentionally by @bparker06 when this was first fixed.

## Related Issues

```
LD retroarch
/usr/bin/ld: obj-unix/release/ui/drivers/qt/shaderparamsdialog.o: in function `ShaderParamsDialog::getShaders(video_shader**, video_shader**)':
shaderparamsdialog.cpp:(.text+0xaa3): undefined reference to `menu_shader_get'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/shaderparamsdialog.o: in function `ShaderParamsDialog::onFilterComboBoxIndexChanged(int)':
shaderparamsdialog.cpp:(.text+0xb41): undefined reference to `menu_shader_get'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/shaderparamsdialog.o: in function `ShaderParamsDialog::onScaleComboBoxIndexChanged(int)':
shaderparamsdialog.cpp:(.text+0xd01): undefined reference to `menu_shader_get'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/shaderparamsdialog.o: in function `ShaderParamsDialog::onShaderPassMoveDownClicked()':
shaderparamsdialog.cpp:(.text+0xf08): undefined reference to `menu_shader_get'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/shaderparamsdialog.o: in function `ShaderParamsDialog::onShaderPassMoveUpClicked()':
shaderparamsdialog.cpp:(.text+0x1338): undefined reference to `menu_shader_get'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/shaderparamsdialog.o:shaderparamsdialog.cpp:(.text+0x1743): more undefined references to `menu_shader_get' follow
/usr/bin/ld: obj-unix/release/ui/drivers/qt/shaderparamsdialog.o: in function `ShaderParamsDialog::onShaderLoadPresetClicked()':
shaderparamsdialog.cpp:(.text+0x1b7d): undefined reference to `menu_shader_manager_set_preset'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/shaderparamsdialog.o: in function `ShaderParamsDialog::onShaderResetPass(int)':
shaderparamsdialog.cpp:(.text+0x1de5): undefined reference to `menu_shader_get'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/shaderparamsdialog.o: in function `ShaderParamsDialog::onShaderResetParameter(QString)':
shaderparamsdialog.cpp:(.text+0x20fe): undefined reference to `menu_shader_get'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/shaderparamsdialog.o: in function `ShaderParamsDialog::onShaderResetAllPasses()':
shaderparamsdialog.cpp:(.text+0x22e6): undefined reference to `menu_shader_get'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/shaderparamsdialog.o: in function `ShaderParamsDialog::onShaderAddPassClicked()':
shaderparamsdialog.cpp:(.text+0x2501): undefined reference to `menu_shader_get'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/shaderparamsdialog.o: in function `ShaderParamsDialog::saveShaderPreset(char const*, unsigned int)':
shaderparamsdialog.cpp:(.text+0x2f17): undefined reference to `menu_shader_manager_save_preset'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/shaderparamsdialog.o: in function `ShaderParamsDialog::onShaderClearAllPassesClicked()':
shaderparamsdialog.cpp:(.text+0x2faf): undefined reference to `menu_shader_get'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/shaderparamsdialog.o: in function `ShaderParamsDialog::onShaderRemovePassClicked()':
shaderparamsdialog.cpp:(.text+0x3047): undefined reference to `menu_shader_get'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/shaderparamsdialog.o: in function `ShaderParamsDialog::buildLayout()':
shaderparamsdialog.cpp:(.text+0x31dd): undefined reference to `menu_shader_get'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/shaderparamsdialog.o: in function `ShaderParamsDialog::addShaderParam(video_shader_parameter*, QFormLayout*)':
shaderparamsdialog.cpp:(.text+0x5759): undefined reference to `menu_shader_get'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/shaderparamsdialog.o: in function `ShaderParamsDialog::onGroupBoxContextMenuRequested(QPoint const&)':
shaderparamsdialog.cpp:(.text+0x64eb): undefined reference to `menu_shader_get'
/usr/bin/ld: obj-unix/release/ui/drivers/qt/shaderparamsdialog.o:shaderparamsdialog.cpp:(.text+0x6880): more undefined references to `menu_shader_get' follow
clang-8: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [Makefile:199: retroarch] Error 1
```

## Related Pull Requests

Broken in d2893d991ce06dbb7ff510b29e96e7e13c30abcb.
