### PR TITLE
qb: Allow --enable-metal for osx only.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -210,6 +210,8 @@ fi
 check_platform Linux TINYALSA 'Tinyalsa is' true
 check_platform Linux RPILED 'The RPI led driver is' true
 
+check_platform Darwin METAL 'Metal is' true
+
 if [ "$OS" = 'Darwin' ]; then
    check_lib '' COREAUDIO "-framework AudioUnit" AudioUnitInitialize
    check_lib '' CORETEXT "-framework CoreText" CTFontCreateWithName


### PR DESCRIPTION
## Description

Self explanatory, `--enable-metal` should be used only on osx.
