### PR TITLE
qb: Improve the glsl check.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -378,14 +378,8 @@ elif [ "$HAVE_OPENGLES" != 'no' ] && [ "$HAVE_OPENGLES3" != 'yes' ]; then
    HAVE_OPENGL_CORE='no'
 fi
 
-if [ "$HAVE_OPENGL" != 'no' ] || [ "$HAVE_OPENGLES" != 'no' ] || [ "$HAVE_OPENGLES3" != 'no' ]; then
-   HAVE_GLSL='yes'
-else
-if [ "$HAVE_GLSL" != "no" ]; then
-   die : 'Notice: glsl disabled.'
-   HAVE_GLSL='no'
-fi
-fi
+check_enabled 'OPENGL OPENGLES OPENGLES3' GLSL GLSL \
+   'OpenGL and OpenGLES are' false
 
 check_enabled ZLIB BUILTINZLIB 'builtin zlib' 'zlib is' true
 

--- a/qb/config.params.sh
+++ b/qb/config.params.sh
@@ -151,6 +151,7 @@ HAVE_VIDEOCORE=auto        # Broadcom Videocore 4 support
 HAVE_DRMINGW=no            # DrMingw exception handler
 HAVE_EASTEREGG=yes         # Easter egg
 HAVE_CDROM=auto            # CD-ROM support
+HAVE_GLSL=yes              # GLSL shaders support
 HAVE_SLANG=yes             # slang support
 C89_SLANG=no
 HAVE_GLSLANG=yes           # glslang support (requires C++11)


### PR DESCRIPTION
## Description

Improves the recent GLSL shaders check and also adds `--disable-glsl` and `--enable-glsl`. It will default to enabled unless `HAVE_OPENGL`, `HAVE_OPENGLES` and `HAVE_OPENGLES3` are all disabled.