### PR TITLE
Fix --disable-overlay.

### DIFF
--- a/command.c
+++ b/command.c
@@ -74,7 +74,6 @@
 
 #include "defaults.h"
 #include "driver.h"
-#include "input/input_driver.h"
 #include "frontend/frontend_driver.h"
 #include "file_path_special.h"
 #include "autosave.h"

--- a/configuration.c
+++ b/configuration.c
@@ -33,7 +33,6 @@
 #endif
 
 #include "file_path_special.h"
-#include "input/input_driver.h"
 #include "configuration.h"
 #include "content.h"
 #include "config.def.h"

--- a/gfx/common/win32_common.c
+++ b/gfx/common/win32_common.c
@@ -57,7 +57,6 @@
 
 #include <commdlg.h>
 #include <dbt.h>
-#include "../../input/input_driver.h"
 #include "../../input/input_keymaps.h"
 #include "../video_thread_wrapper.h"
 #include "../video_display_server.h"

--- a/gfx/drivers_context/gdi_ctx.c
+++ b/gfx/drivers_context/gdi_ctx.c
@@ -36,7 +36,6 @@
 
 #include "../../dynamic.h"
 #include "../../configuration.h"
-#include "../../input/input_driver.h"
 #include "../../retroarch.h"
 #include "../../verbosity.h"
 #include "../../frontend/frontend_driver.h"

--- a/gfx/drivers_context/wgl_ctx.c
+++ b/gfx/drivers_context/wgl_ctx.c
@@ -41,7 +41,6 @@
 
 #include "../../configuration.h"
 #include "../../dynamic.h"
-#include "../../input/input_driver.h"
 #include "../../retroarch.h"
 #include "../../verbosity.h"
 #include "../../frontend/frontend_driver.h"

--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -35,7 +35,6 @@
 #include "../../menu/menu_driver.h"
 #endif
 
-#include "../input_driver.h"
 
 #include "../../command.h"
 #include "../../frontend/drivers/platform_unix.h"

--- a/input/drivers/cocoa_input.c
+++ b/input/drivers/cocoa_input.c
@@ -23,7 +23,6 @@
 #include "../../config.h"
 #endif
 
-#include "../input_driver.h"
 #include "../input_keymaps.h"
 
 #include "cocoa_input.h"

--- a/input/drivers/cocoa_input.h
+++ b/input/drivers/cocoa_input.h
@@ -20,6 +20,8 @@
 #include <stdint.h>
 #include <boolean.h>
 
+#include "../input_driver.h"
+
 /* Input responder */
 #define MAX_TOUCHES  16
 

--- a/input/drivers/dinput.c
+++ b/input/drivers/dinput.c
@@ -45,7 +45,6 @@
 
 #include <string/stdstring.h>
 
-#include "../input_driver.h"
 #include "../input_keymaps.h"
 
 #include "../../configuration.h"

--- a/input/drivers/qnx_input.c
+++ b/input/drivers/qnx_input.c
@@ -29,7 +29,6 @@
 
 #include "../../config.def.h"
 
-#include "../input_driver.h"
 
 #include "../../retroarch.h"
 #include "../../tasks/tasks_internal.h"

--- a/input/drivers/rwebinput_input.c
+++ b/input/drivers/rwebinput_input.c
@@ -26,7 +26,6 @@
 
 #include <emscripten/html5.h>
 
-#include "../input_driver.h"
 #include "../input_keymaps.h"
 
 #include "../../tasks/tasks_internal.h"

--- a/input/drivers/sdl_input.c
+++ b/input/drivers/sdl_input.c
@@ -24,7 +24,6 @@
 
 #include "SDL.h"
 
-#include "../input_driver.h"
 #include "../input_keymaps.h"
 
 #include "../../retroarch.h"

--- a/input/drivers/switch_input.c
+++ b/input/drivers/switch_input.c
@@ -80,7 +80,6 @@ typedef struct
 /* end of touch mouse defines and types */
 #endif
 
-#include "../input_driver.h"
 #include "../input_keymaps.h"
 
 /* TODO/FIXME -

--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -66,7 +66,6 @@
 #include <string/stdstring.h>
 #include <retro_miscellaneous.h>
 
-#include "../input_driver.h"
 #include "../input_keymaps.h"
 
 #include "../common/linux_common.h"

--- a/input/drivers/wayland_input.c
+++ b/input/drivers/wayland_input.c
@@ -37,7 +37,6 @@
 #include <string/stdstring.h>
 #include <retro_miscellaneous.h>
 
-#include "../input_driver.h"
 #include "../input_keymaps.h"
 
 #include "../common/linux_common.h"

--- a/input/drivers/winraw_input.c
+++ b/input/drivers/winraw_input.c
@@ -15,7 +15,6 @@
 
 #include <windows.h>
 
-#include "../input_driver.h"
 #include "../input_keymaps.h"
 
 #include "../../configuration.h"

--- a/input/drivers/x11_input.c
+++ b/input/drivers/x11_input.c
@@ -24,7 +24,6 @@
 #include <compat/strl.h>
 #include <retro_inline.h>
 
-#include "../input_driver.h"
 #include "../input_keymaps.h"
 
 #include "../common/input_x11_common.h"

--- a/input/drivers_joypad/ctr_joypad.c
+++ b/input/drivers_joypad/ctr_joypad.c
@@ -20,7 +20,6 @@
 
 #include "../../config.def.h"
 
-#include "../input_driver.h"
 
 #include "../../tasks/tasks_internal.h"
 

--- a/input/drivers_joypad/dinput_joypad.c
+++ b/input/drivers_joypad/dinput_joypad.c
@@ -30,7 +30,6 @@
 #endif
 
 #include "../../tasks/tasks_internal.h"
-#include "../input_driver.h"
 #include "../input_keymaps.h"
 #include "../../retroarch.h"
 #include "../../verbosity.h"

--- a/input/drivers_joypad/switch_joypad.c
+++ b/input/drivers_joypad/switch_joypad.c
@@ -11,7 +11,6 @@
 #endif
 
 #include "../configuration.h"
-#include "../input_driver.h"
 
 #include "../../tasks/tasks_internal.h"
 

--- a/input/drivers_keyboard/keyboard_event_apple.c
+++ b/input/drivers_keyboard/keyboard_event_apple.c
@@ -22,7 +22,6 @@
 #endif
 
 #include "../input_keymaps.h"
-#include "../input_driver.h"
 
 #include "../../driver.h"
 #include "../../retroarch.h"

--- a/input/include/wiiu/input.h
+++ b/input/include/wiiu/input.h
@@ -31,7 +31,6 @@
 #include <wiiu/pad_strings.h>
 #include "hid.h"
 
-#include "../../input_driver.h"
 #include "../../common/hid/hid_device_driver.h"
 #include "../../connect/joypad_connection.h"
 #include "../../../retroarch.h"

--- a/input/input_remapping.c
+++ b/input/input_remapping.c
@@ -20,7 +20,6 @@
 #include <streams/file_stream.h>
 #include <string/stdstring.h>
 
-#include "input_driver.h"
 #include "input_remapping.h"
 #include "../configuration.h"
 #include "../retroarch.h"

--- a/list_special.c
+++ b/list_special.c
@@ -38,7 +38,6 @@
 #include "list_special.h"
 #include "frontend/frontend_driver.h"
 #include "core_info.h"
-#include "input/input_driver.h"
 #include "midi/midi_driver.h"
 #include "configuration.h"
 #include "retroarch.h"

--- a/managers/cheat_manager.c
+++ b/managers/cheat_manager.c
@@ -49,7 +49,6 @@
 #include "../dynamic.h"
 #include "../core.h"
 #include "../verbosity.h"
-#include "../input/input_driver.h"
 #include "../configuration.h"
 
 cheat_manager_t cheat_manager_state;

--- a/menu/cbs/menu_cbs_get_value.c
+++ b/menu/cbs/menu_cbs_get_value.c
@@ -30,13 +30,11 @@
 #endif
 
 #include "../../tasks/tasks_internal.h"
-#include "../../input/input_driver.h"
 
 #include "../../core.h"
 #include "../../core_info.h"
 #include "../../configuration.h"
 #include "../../file_path_special.h"
-#include "../../input/input_driver.h"
 #include "../../managers/core_option_manager.h"
 #include "../../managers/cheat_manager.h"
 #include "../../performance_counters.h"

--- a/menu/cbs/menu_cbs_start.c
+++ b/menu/cbs/menu_cbs_start.c
@@ -39,7 +39,6 @@
 #include "../../performance_counters.h"
 #include "../../playlist.h"
 
-#include "../../input/input_driver.h"
 #include "../../input/input_remapping.h"
 
 #include "../../config.def.h"

--- a/menu/cbs/menu_cbs_sublabel.c
+++ b/menu/cbs/menu_cbs_sublabel.c
@@ -47,7 +47,6 @@
 #include "../../dynamic.h"
 #include "../../configuration.h"
 #include "../../managers/cheat_manager.h"
-#include "../input/input_driver.h"
 #include "../tasks/tasks_internal.h"
 
 #include "../../playlist.h"

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -90,7 +90,6 @@
 #include "../gfx/video_display_server.h"
 #include "../config.features.h"
 #include "../version_git.h"
-#include "../input/input_driver.h"
 #include "../list_special.h"
 #include "../performance_counters.h"
 #include "../core_info.h"

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -80,7 +80,6 @@
 #include "../dynamic.h"
 #include "../list_special.h"
 #include "../wifi/wifi_driver.h"
-#include "../input/input_driver.h"
 #include "../midi/midi_driver.h"
 #include "../tasks/tasks_internal.h"
 #include "../config.def.h"

--- a/menu/widgets/menu_dialog.c
+++ b/menu/widgets/menu_dialog.c
@@ -33,7 +33,6 @@
 #include "../../configuration.h"
 
 #include "../../tasks/tasks_internal.h"
-#include "../../input/input_driver.h"
 #include "../../performance_counters.h"
 
 static bool                  menu_dialog_pending_push   = false;

--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -37,7 +37,6 @@
 
 #include "../../configuration.h"
 #include "../../frontend/frontend_driver.h"
-#include "../../input/input_driver.h"
 #include "../../tasks/task_content.h"
 #include "../../tasks/tasks_internal.h"
 #include "../../file_path_special.h"

--- a/network/netplay/netplay_init.c
+++ b/network/netplay/netplay_init.c
@@ -32,7 +32,6 @@
 
 #include "../../autosave.h"
 #include "../../retroarch.h"
-#include "../../input/input_driver.h"
 
 #if defined(AF_INET6) && !defined(HAVE_SOCKET_LEGACY)
 #define HAVE_INET6 1

--- a/retroarch.c
+++ b/retroarch.c
@@ -119,7 +119,6 @@
 #include "menu/widgets/menu_osk.h"
 #endif
 
-#include "input/input_driver.h"
 #include "input/input_mapper.h"
 #include "input/input_keymaps.h"
 #include "input/input_remapping.h"
@@ -155,7 +154,6 @@
 #include "core_info.h"
 #include "dynamic.h"
 #include "driver.h"
-#include "input/input_driver.h"
 #include "msg_hash.h"
 #include "paths.h"
 #include "file_path_special.h"

--- a/retroarch.h
+++ b/retroarch.h
@@ -822,6 +822,7 @@ void recording_driver_update_streaming_url(void);
 #include "gfx/video_filter.h"
 #include "gfx/video_shader_parse.h"
 
+#include "input/input_driver.h"
 #include "input/input_types.h"
 
 #define RARCH_SCALE_BASE 256

--- a/tasks/task_autodetect.c
+++ b/tasks/task_autodetect.c
@@ -69,7 +69,6 @@ const GUID GUID_NULL = {0, 0, 0, {0, 0, 0, 0, 0, 0, 0, 0}};
 #endif
 #endif
 
-#include "../input/input_driver.h"
 #include "../input/include/blissbox.h"
 
 #include "../configuration.h"

--- a/ui/drivers/cocoa/cocoa_common.m
+++ b/ui/drivers/cocoa/cocoa_common.m
@@ -23,7 +23,6 @@
 
 #include "../../../verbosity.h"
 
-#include "../../../input/input_driver.h"
 #include "../../../input/drivers/cocoa_input.h"
 #include "../../../retroarch.h"
 

--- a/ui/drivers/cocoa/cocoatouch_menu.m
+++ b/ui/drivers/cocoa/cocoatouch_menu.m
@@ -25,7 +25,6 @@
 #include <queues/task_queue.h>
 
 #include "cocoa_common.h"
-#include "../../../input/input_driver.h"
 #include "../../../input/input_keymaps.h"
 #include "../../../input/drivers/cocoa_input.h"
 

--- a/uwp/uwp_main.cpp
+++ b/uwp/uwp_main.cpp
@@ -19,7 +19,6 @@
 #include "../retroarch.h"
 #include "../frontend/frontend.h"
 #include "../input/input_keymaps.h"
-#include "../input/input_driver.h"
 #include "../verbosity.h"
 #include "../libretro-common/include/encodings/utf.h"
 #include "../libretro-common/include/lists/string_list.h"


### PR DESCRIPTION
## Description

Fixes the build with `--disable-overlay`.

The problem is that `input/input_driver.h` was included `input/input_overlay.h` which is included in `retroarch.h` and then hidden behind `HAVE_OVERLAY`. Now that `--disable-overlay` is an option this breaks several parts of the code base when `input/input_driver.h` is not included in `retroarch.h`.

Based on my testing and grepping this allows to remove `input/input_overlay.h` from several other files.

## Related Issues

```
gfx/drivers_context/drm_ctx.c:771:38: error: called object type '<dependent type>' is not a function or function pointer
         void *udev = input_udev.init(joypad_name);
                                     ^
gfx/drivers_context/drm_ctx.c:774:29: error: use of undeclared identifier 'input_udev'; did you mean 'input_data'?
            *input       = &input_udev;
                            ^~~~~~~~~~
                            input_data
gfx/drivers_context/drm_ctx.c:760:44: note: 'input_data' declared here
      const input_driver_t **input, void **input_data)
                                           ^
gfx/drivers_context/drm_ctx.c:774:26: warning: incompatible pointer types assigning to 'const input_driver_t *' (aka 'const struct input_driver *') from 'void ***' [-Wincompatible-pointer-types]
            *input       = &input_udev;
                         ^ ~~~~~~~~~~~
gfx/drivers_context/drm_ctx.c:783:46: error: called object type '<dependent type>' is not a function or function pointer
         void *linuxraw = input_linuxraw.init(joypad_name);
                                             ^
gfx/drivers_context/drm_ctx.c:786:29: error: use of undeclared identifier 'input_linuxraw'
            *input       = &input_linuxraw;
                            ^
1 warning and 4 errors generated.
make: *** [Makefile:204: obj-unix/release/gfx/drivers_context/drm_ctx.o] Error 1
```

## Reviewers

Wait for travis all builds excluding the still broken xcode10.1 should pass.
