### PR TITLE
Fix --disable-hid.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -39,10 +39,6 @@ ifeq ($(HAVE_SOCKET_LEGACY), 1)
    DEFINES += -DHAVE_SOCKET_LEGACY
 endif
 
-ifeq ($(HAVE_HID), 1)
-   DEFINES += -DHAVE_HID
-endif
-
 ifeq ($(HAVE_LIBRETRODB), 1)
    DEFINES += -DHAVE_LIBRETRODB
 endif
@@ -1014,17 +1010,10 @@ ifeq ($(HAVE_UDEV), 1)
 endif
 
 ifeq ($(HAVE_LIBUSB), 1)
-   ifeq ($(HAVE_THREADS), 1)
-      ifeq ($(HAVE_HID), 1)
-         DEFINES += -DHAVE_LIBUSB
-         OBJ += input/drivers_hid/libusb_hid.o
-         ifneq ($(findstring BSD,$(OS)),)
-            LIBS += -lusb
-         else
-            LIBS += -lusb-1.0
-         endif
-      endif
-   endif
+   DEFINES += -DHAVE_LIBUSB
+   OBJ += input/drivers_hid/libusb_hid.o
+   DEF_FLAGS += $(LIBUSB_CFLAGS)
+   LIBS += $(LIBUSB_LIBS)
 endif
 
 ifeq ($(HAVE_IOHIDMANAGER), 1)

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -300,6 +300,7 @@ if [ "$HAVE_SSL" != 'no' ]; then
 fi
 
 check_enabled THREADS LIBUSB libusb 'Threads are' false
+check_enabled HID LIBUSB libusb 'HID is' false
 check_val '' LIBUSB -lusb-1.0 libusb-1.0 libusb-1.0 1.0.13 '' false
 
 check_lib '' DINPUT -ldinput8


### PR DESCRIPTION
## Description

This fixes `--disable-hid`. The problem is that libusb has a dependency on HID support which was not being handled correctly in `Makefile.common`. Its much better to handle these in qb with `check_enabled` so I did that.

This also has some related cleanup.

* Removes a duplicate `-DHAVE_HID`.
* Removes `HAVE_THREADS` and `HAVE_HID` conditionals in `Makefile.common` that are both handled in qb with `check_enabled`.
* Uses `$(LIBUSB_LIBS)` instead of a hard coded library name.
* Adds a missing `$(LIBUSB_CFLAGS)` from `config.mk`.

## Related Issues

```
LD retroarch
/usr/bin/ld: obj-unix/release/tasks/task_autodetect.o: in function `input_autoconfigure_connect':
task_autodetect.c:(.text+0xb1d): undefined reference to `libusb_init'
/usr/bin/ld: task_autodetect.c:(.text+0xb33): undefined reference to `libusb_open_device_with_vid_pid'
/usr/bin/ld: task_autodetect.c:(.text+0xb4d): undefined reference to `libusb_detach_kernel_driver'
/usr/bin/ld: task_autodetect.c:(.text+0xb5e): undefined reference to `libusb_set_configuration'
/usr/bin/ld: task_autodetect.c:(.text+0xb74): undefined reference to `libusb_claim_interface'
/usr/bin/ld: task_autodetect.c:(.text+0xba9): undefined reference to `libusb_control_transfer'
/usr/bin/ld: task_autodetect.c:(.text+0xbcf): undefined reference to `libusb_release_interface'
/usr/bin/ld: task_autodetect.c:(.text+0xbdd): undefined reference to `libusb_attach_kernel_driver'
/usr/bin/ld: task_autodetect.c:(.text+0xbe9): undefined reference to `libusb_close'
/usr/bin/ld: task_autodetect.c:(.text+0xbf0): undefined reference to `libusb_exit'
/usr/bin/ld: task_autodetect.c:(.text+0xc9e): undefined reference to `libusb_close'
/usr/bin/ld: task_autodetect.c:(.text+0xca5): undefined reference to `libusb_exit'
clang-8: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [Makefile:199: retroarch] Error 1
```

## Reviewers

Wait for travis please.