### PR TITLE
simplify video_shader_read_conf_preset() calls

### DIFF
--- a/gfx/common/metal_common.m
+++ b/gfx/common/metal_common.m
@@ -1144,7 +1144,7 @@ typedef struct MTLALIGN(16)
    {
       unsigned i;
       texture_t *source = NULL;
-      if (!video_shader_read_conf_preset(conf, shader, path.UTF8String))
+      if (!video_shader_read_conf_preset(conf, shader))
          return NO;
 
       source = &_engine.frame.texture[0];

--- a/gfx/drivers/d3d10.c
+++ b/gfx/drivers/d3d10.c
@@ -365,7 +365,7 @@ static bool d3d10_gfx_set_shader(void* data, enum rarch_shader_type type, const 
 
    d3d10->shader_preset = (struct video_shader*)calloc(1, sizeof(*d3d10->shader_preset));
 
-   if (!video_shader_read_conf_preset(conf, d3d10->shader_preset, path))
+   if (!video_shader_read_conf_preset(conf, d3d10->shader_preset))
       goto error;
 
    source = &d3d10->frame.texture[0];

--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -383,7 +383,7 @@ static bool d3d11_gfx_set_shader(void* data, enum rarch_shader_type type, const 
 
    d3d11->shader_preset = (struct video_shader*)calloc(1, sizeof(*d3d11->shader_preset));
 
-   if (!video_shader_read_conf_preset(conf, d3d11->shader_preset, path))
+   if (!video_shader_read_conf_preset(conf, d3d11->shader_preset))
       goto error;
 
    source = &d3d11->frame.texture[0];

--- a/gfx/drivers/d3d12.c
+++ b/gfx/drivers/d3d12.c
@@ -364,7 +364,7 @@ static bool d3d12_gfx_set_shader(void* data, enum rarch_shader_type type, const 
 
    d3d12->shader_preset = (struct video_shader*)calloc(1, sizeof(*d3d12->shader_preset));
 
-   if (!video_shader_read_conf_preset(conf, d3d12->shader_preset, path))
+   if (!video_shader_read_conf_preset(conf, d3d12->shader_preset))
       goto error;
 
    source = &d3d12->frame.texture[0];

--- a/gfx/drivers/d3d9.c
+++ b/gfx/drivers/d3d9.c
@@ -339,7 +339,7 @@ static bool d3d9_init_multipass(d3d9_video_t *d3d, const char *shader_path)
 
    memset(&d3d->shader, 0, sizeof(d3d->shader));
 
-   if (!video_shader_read_conf_preset(conf, &d3d->shader, shader_path))
+   if (!video_shader_read_conf_preset(conf, &d3d->shader))
    {
       config_file_free(conf);
       RARCH_ERR("[D3D9]: Failed to parse shader preset.\n");

--- a/gfx/drivers/gx2_gfx.c
+++ b/gfx/drivers/gx2_gfx.c
@@ -1458,7 +1458,7 @@ static bool wiiu_gfx_set_shader(void *data,
 
    wiiu->shader_preset = calloc(1, sizeof(*wiiu->shader_preset));
 
-   if (!video_shader_read_conf_preset(conf, wiiu->shader_preset, path))
+   if (!video_shader_read_conf_preset(conf, wiiu->shader_preset))
    {
       free(wiiu->shader_preset);
       wiiu->shader_preset = NULL;

--- a/gfx/drivers_shader/shader_gl_cg.c
+++ b/gfx/drivers_shader/shader_gl_cg.c
@@ -692,7 +692,7 @@ static bool gl_cg_load_preset(void *data, const char *path)
       return false;
    }
 
-   if (!video_shader_read_conf_preset(conf, cg->shader, path))
+   if (!video_shader_read_conf_preset(conf, cg->shader))
    {
       RARCH_ERR("Failed to parse CGP file.\n");
       config_file_free(conf);

--- a/gfx/drivers_shader/shader_gl_core.cpp
+++ b/gfx/drivers_shader/shader_gl_core.cpp
@@ -2413,7 +2413,7 @@ gl_core_filter_chain_t *gl_core_filter_chain_create_from_preset(
    if (!conf)
       return nullptr;
 
-   if (!video_shader_read_conf_preset(conf.get(), shader.get(), path))
+   if (!video_shader_read_conf_preset(conf.get(), shader.get()))
       return nullptr;
 
    bool last_pass_is_fbo = shader->pass[shader->passes - 1].fbo.valid;

--- a/gfx/drivers_shader/shader_glsl.c
+++ b/gfx/drivers_shader/shader_glsl.c
@@ -903,7 +903,7 @@ static void *gl_glsl_init(void *data, const char *path)
             conf = config_file_new_from_path_to_string(path);
             if (conf)
             {
-               ret = video_shader_read_conf_preset(conf, glsl->shader, path);
+               ret = video_shader_read_conf_preset(conf, glsl->shader);
                glsl->shader->modern = true;
             }
          }

--- a/gfx/drivers_shader/shader_vulkan.cpp
+++ b/gfx/drivers_shader/shader_vulkan.cpp
@@ -2890,7 +2890,7 @@ vulkan_filter_chain_t *vulkan_filter_chain_create_from_preset(
    if (!conf)
       return nullptr;
 
-   if (!video_shader_read_conf_preset(conf.get(), shader.get(), path))
+   if (!video_shader_read_conf_preset(conf.get(), shader.get()))
       return nullptr;
 
    bool last_pass_is_fbo = shader->pass[shader->passes - 1].fbo.valid;

--- a/gfx/video_shader_parse.c
+++ b/gfx/video_shader_parse.c
@@ -102,14 +102,13 @@ static enum gfx_wrap_type wrap_str_to_mode(const char *wrap_mode)
  * @conf              : Preset file to read from.
  * @pass              : Shader passes handle.
  * @i                 : Index of shader pass.
- * @ref_path          : Base path used to resolve relative paths
  *
  * Parses shader pass from preset file.
  *
  * Returns: true (1) if successful, otherwise false (0).
  **/
 static bool video_shader_parse_pass(config_file_t *conf,
-      struct video_shader_pass *pass, unsigned i, const char *ref_path)
+      struct video_shader_pass *pass, unsigned i)
 {
    char shader_name[64];
    char filter_name_buf[64];
@@ -152,7 +151,7 @@ static bool video_shader_parse_pass(config_file_t *conf,
    }
 
    fill_pathname_resolve_relative(pass->source.path,
-         ref_path, tmp_path, sizeof(pass->source.path));
+         conf->path, tmp_path, sizeof(pass->source.path));
    free(tmp_path);
 
    /* Smooth */
@@ -307,14 +306,13 @@ static bool video_shader_parse_pass(config_file_t *conf,
  * video_shader_parse_textures:
  * @conf              : Preset file to read from.
  * @shader            : Shader pass handle.
- * @ref_path          : Base path used to resolve relative paths
  *
  * Parses shader textures.
  *
  * Returns: true (1) if successful, otherwise false (0).
  **/
 static bool video_shader_parse_textures(config_file_t *conf,
-      struct video_shader *shader, const char *ref_path)
+      struct video_shader *shader)
 {
    size_t path_size     = PATH_MAX_LENGTH;
    const char *id       = NULL;
@@ -354,7 +352,7 @@ static bool video_shader_parse_textures(config_file_t *conf,
       }
 
       fill_pathname_resolve_relative(shader->lut[shader->luts].path,
-            ref_path, tmp_path, sizeof(shader->lut[shader->luts].path));
+            conf->path, tmp_path, sizeof(shader->lut[shader->luts].path));
 
 
       strlcpy(shader->lut[shader->luts].id, id,
@@ -563,7 +561,6 @@ bool video_shader_resolve_parameters(config_file_t *conf,
  * video_shader_read_conf_preset:
  * @conf              : Preset file to read from.
  * @shader            : Shader passes handle.
- * @ref_path          : Base path used to resolve relative paths
  *
  * Loads preset file and all associated state (passes,
  * textures, imports, etc).
@@ -571,7 +568,7 @@ bool video_shader_resolve_parameters(config_file_t *conf,
  * Returns: true (1) if successful, otherwise false (0).
  **/
 bool video_shader_read_conf_preset(config_file_t *conf,
-      struct video_shader *shader, const char* ref_path)
+      struct video_shader *shader)
 {
    unsigned i;
    union string_list_elem_attr attr;
@@ -618,7 +615,7 @@ bool video_shader_read_conf_preset(config_file_t *conf,
 
    for (i = 0; i < shader->passes; i++)
    {
-      if (!video_shader_parse_pass(conf, &shader->pass[i], i, ref_path))
+      if (!video_shader_parse_pass(conf, &shader->pass[i], i))
       {
          if (file_list)
          {
@@ -648,7 +645,7 @@ bool video_shader_read_conf_preset(config_file_t *conf,
 
    command_event(CMD_EVENT_SHADER_PRESET_LOADED, NULL);
 
-   if (!video_shader_parse_textures(conf, shader, ref_path))
+   if (!video_shader_parse_textures(conf, shader))
       return false;
 
    return true;

--- a/gfx/video_shader_parse.h
+++ b/gfx/video_shader_parse.h
@@ -163,14 +163,13 @@ struct video_shader
  * video_shader_read_conf_preset:
  * @conf              : Preset file to read from.
  * @shader            : Shader passes handle.
- * @ref_path          : Base path used to resolve relative paths
  * Loads preset file and all associated state (passes,
  * textures, imports, etc).
  *
  * Returns: true (1) if successful, otherwise false (0).
  **/
 bool video_shader_read_conf_preset(config_file_t *conf,
-      struct video_shader *shader, const char* ref_path);
+      struct video_shader *shader);
 
 /**
  * video_shader_write_conf_preset:

--- a/menu/menu_shader.c
+++ b/menu/menu_shader.c
@@ -61,7 +61,6 @@ bool menu_shader_manager_init(void)
 {
    bool is_preset              = false;
    config_file_t *conf         = NULL;
-   char *new_path              = NULL;
    const char *path_shader     = retroarch_get_shader_preset();
    enum rarch_shader_type type = RARCH_SHADER_NONE;
 
@@ -80,8 +79,6 @@ bool menu_shader_manager_init(void)
    {
       if (path_is_valid(path_shader))
          conf = config_file_new_from_path_to_string(path_shader);
-
-      new_path = strdup(path_shader);
    }
    else
    {
@@ -131,19 +128,12 @@ bool menu_shader_manager_init(void)
                conf = config_file_new_from_path_to_string(preset_path);
          }
 #endif
-
-         new_path = strdup(preset_path);
       }
    }
 
-   if (
-         !string_is_empty(new_path) && conf &&
-         video_shader_read_conf_preset(conf, menu_driver_shader, new_path)
-      )
+   if (conf && video_shader_read_conf_preset(conf, menu_driver_shader))
       video_shader_resolve_parameters(conf, menu_driver_shader);
 
-   if (new_path)
-      free(new_path);
    if (conf)
       config_file_free(conf);
 
@@ -191,7 +181,7 @@ bool menu_shader_manager_set_preset(void *data,
 
    RARCH_LOG("Setting Menu shader: %s.\n", preset_path);
 
-   if (video_shader_read_conf_preset(conf, shader, preset_path))
+   if (video_shader_read_conf_preset(conf, shader))
       video_shader_resolve_parameters(conf, shader);
 
    config_file_free(conf);


### PR DESCRIPTION
## Description

It turns out that `conf->path` already contains the shader preset path, no need to pass it twice.
(`video_shader_write_conf_preset()` does need it though.)

## Related Pull Requests

#9140
