### PR TITLE
DO NOT MERGE - Try to fix xcode10.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,50 +6,6 @@ dist: xenial
 
 matrix:
   include:
-    - compiler: mingw-x86
-      addons: true
-      env: CROSS_COMPILE=i686-w64-mingw32- CFLAGS="-D_WIN32_WINNT=0x0501"
-    - compiler: mingw-x86
-      addons: true
-      env: C89_BUILD=1 CROSS_COMPILE=i686-w64-mingw32- CFLAGS="-D_WIN32_WINNT=0x0501"
-    - compiler: mingw-x86
-      addons: true
-      env: CXX_BUILD=1 CROSS_COMPILE=i686-w64-mingw32- CFLAGS="-D_WIN32_WINNT=0x0501"
-    - compiler: mingw-x64
-      addons: true
-      env: CROSS_COMPILE=x86_64-w64-mingw32- CFLAGS="-D_WIN32_WINNT=0x0501"
-    - compiler: mingw-x64
-      addons: true
-      env: C89_BUILD=1 CROSS_COMPILE=x86_64-w64-mingw32- CFLAGS="-D_WIN32_WINNT=0x0501"
-    - compiler: mingw-x64
-      addons: true
-      env: CXX_BUILD=1 CROSS_COMPILE=x86_64-w64-mingw32- CFLAGS="-D_WIN32_WINNT=0x0501"
-    - compiler: gcc
-      env: CC=gcc-8 CXX=g++-8
-    - compiler: gcc
-      env: C89_BUILD=1 CC=gcc-8 CXX=g++-8
-    - compiler: gcc
-      env: CXX_BUILD=1 CC=gcc-8 CXX=g++-8
-    - compiler: gcc
-      env: DISABLE_MENU=1 CC=gcc-8 CXX=g++-8
-    - compiler: gcc
-      env: DISABLE_OVERLAY=1 CC=gcc-8 CXX=g++-8
-    - compiler: gcc
-      env: ENABLE_GLES=1 CC=gcc-8 CXX=g++-8
-    - compiler: gcc
-      env: ENABLE_GLES=1 ENABLE_GLES3=1 CC=gcc-8 CXX=g++-8
-    - compiler: clang
-      env: CC=clang-6.0 CXX=clang++-6.0
-    - compiler: clang
-      env: C89_BUILD=1 CC=clang-6.0 CXX=clang++-6.0
-    - compiler: clang
-      env: CXX_BUILD=1 CC=clang-6.0 CXX=clang++-6.0
-    - os: osx
-      env: CC=clang CXX=clang++
-    - os: osx
-      osx_image: xcode8
-      script:
-        - xcodebuild -target RetroArch -configuration Release -project pkg/apple/RetroArch.xcodeproj
     - os: osx
       osx_image: xcode10.1
       script:

--- a/griffin/griffin_cpp.cpp
+++ b/griffin/griffin_cpp.cpp
@@ -48,9 +48,7 @@ UI
 #include "../ui/drivers/qt/ui_qt_msg_window.cpp"
 #include "../ui/drivers/qt/ui_qt_application.cpp"
 #include "../ui/drivers/qt/gridview.cpp"
-#if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)
 #include "../ui/drivers/qt/shaderparamsdialog.cpp"
-#endif
 #include "../ui/drivers/qt/coreoptionsdialog.cpp"
 #include "../ui/drivers/qt/filedropwidget.cpp"
 #include "../ui/drivers/qt/coreinfodialog.cpp"
@@ -86,9 +84,7 @@ UI
 #include "../ui/drivers/qt/moc_filedropwidget.cpp"
 #include "../ui/drivers/qt/moc_gridview.cpp"
 #include "../ui/drivers/qt/moc_playlistentrydialog.cpp"
-#if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)
 #include "../ui/drivers/qt/moc_shaderparamsdialog.cpp"
-#endif
 #include "../ui/drivers/qt/moc_ui_qt_load_core_window.cpp"
 #include "../ui/drivers/qt/moc_viewoptionsdialog.cpp"
 #endif

--- a/ui/drivers/qt/ui_qt_window.cpp
+++ b/ui/drivers/qt/ui_qt_window.cpp
@@ -41,6 +41,7 @@
 #include "ui_qt_load_core_window.h"
 #include "ui_qt_themes.h"
 #include "gridview.h"
+#include "shaderparamsdialog.h"
 #include "coreoptionsdialog.h"
 #include "filedropwidget.h"
 #include "coreinfodialog.h"
@@ -89,7 +90,6 @@ extern "C" {
 }
 #endif
 
-#include "shaderparamsdialog.h"
 #include "../../../AUTHORS.h"
 
 #define TIMER_MSEC 1000 /* periodic timer for gathering statistics */


### PR DESCRIPTION
## Description

DO NOT MERGE THIS

This attempts to fix the xcode 10.1 travis build.

## Related Issues

```
/Users/travis/build/libretro/RetroArch/griffin/griffin_cpp.cpp:90:10: fatal error: '../ui/drivers/qt/moc_shaderparamsdialog.cpp' file not found
#include "../ui/drivers/qt/moc_shaderparamsdialog.cpp"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

## Related Pull Requests

https://github.com/libretro/RetroArch/commit/b6b22a9a3244e44b06389103d508f3b0085e4ffd

## Reviewers

DO NOT MERGE THIS until both travis passes and I remove the second commit where I deleted all the travis builds except xcode10.1 to make this faster to test.
