### PR TITLE
Fix xcode10.1.

### DIFF
--- a/pkg/apple/RetroArch_Metal.xcodeproj/project.pbxproj
+++ b/pkg/apple/RetroArch_Metal.xcodeproj/project.pbxproj
@@ -1633,7 +1633,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "make -C ${SRCBASE} -f Makefile.apple HAVE_MENU=1 HAVE_MENU_WIDGETS=1 HAVE_QT=1 MOC=${QT_INSTALL}/bin/moc generate\n";
+			shellScript = "make -C ${SRCBASE} -f Makefile.apple HAVE_MENU=1 HAVE_MENU_WIDGETS=1 HAVE_QT=1 HAVE_HLSL=1 MOC=${QT_INSTALL}/bin/moc generate\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
## Description

This fixes the xcode 10.1 travis build.

## Related Issues

```
/Users/travis/build/libretro/RetroArch/griffin/griffin_cpp.cpp:90:10: fatal error: '../ui/drivers/qt/moc_shaderparamsdialog.cpp' file not found
#include "../ui/drivers/qt/moc_shaderparamsdialog.cpp"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

## Related Pull Requests

https://github.com/libretro/RetroArch/commit/b6b22a9a3244e44b06389103d508f3b0085e4ffd

