### PR TITLE
Silence clang warning.

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -4971,7 +4971,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
 #ifdef HAVE_CDROM
       case DISPLAYLIST_CDROM_DETAIL_INFO:
       {
-         media_detect_cd_info_t cd_info = {0};
+         media_detect_cd_info_t cd_info = {{0}};
          char file_path[PATH_MAX_LENGTH];
          RFILE *file;
          char drive = info->path[0];


### PR DESCRIPTION
## Description

Silences one warning with `clang-8.0.1`.

## Related Issues

```
menu/menu_displaylist.c:4974:44: warning: suggest braces around initialization of subobject [-Wmissing-braces]
         media_detect_cd_info_t cd_info = {0};
                                           ^
                                           {}
1 warning generated.
```