### PR TITLE
Silence gcc compiler warnings

### DIFF
--- a/deps/discord-rpc/thirdparty/rapidjson-1.1.0/include/rapidjson/document.h
+++ b/deps/discord-rpc/thirdparty/rapidjson-1.1.0/include/rapidjson/document.h
@@ -1936,7 +1936,7 @@ private:
         if (count) {
             GenericValue* e = static_cast<GenericValue*>(allocator.Malloc(count * sizeof(GenericValue)));
             SetElementsPointer(e);
-            std::memcpy(e, values, count * sizeof(GenericValue));
+            std::memcpy(static_cast<void*>(e), static_cast<void*>(values), count * sizeof(GenericValue));
         }
         else
             SetElementsPointer(0);
@@ -1949,7 +1949,7 @@ private:
         if (count) {
             Member* m = static_cast<Member*>(allocator.Malloc(count * sizeof(Member)));
             SetMembersPointer(m);
-            std::memcpy(m, members, count * sizeof(Member));
+            std::memcpy(static_cast<void*>(m), static_cast<void*>(members), count * sizeof(Member));
         }
         else
             SetMembersPointer(0);

--- a/deps/glslang/glslang/SPIRV/bitutils.h
+++ b/deps/glslang/glslang/SPIRV/bitutils.h
@@ -26,7 +26,7 @@ Dest BitwiseCast(Src source) {
   Dest dest;
   static_assert(sizeof(source) == sizeof(dest),
                 "BitwiseCast: Source and destination must have the same size");
-  std::memcpy(&dest, &source, sizeof(dest));
+  std::memcpy(static_cast<void*>(&dest), static_cast<void*>(&source), sizeof(dest));
   return dest;
 }
 

--- a/libretro-common/cdrom/cdrom.c
+++ b/libretro-common/cdrom/cdrom.c
@@ -175,7 +175,7 @@ static void cdrom_print_sense_data(const unsigned char *sense, size_t len)
          break;
    }
 
-   printf("[CDROM] Sense Key: %02X (%s)\n", key, sense_key_text);
+   printf("[CDROM] Sense Key: %02X (%s)\n", key, sense_key_text ? sense_key_text : "null");
    printf("[CDROM] ASC: %02X\n", asc);
    printf("[CDROM] ASCQ: %02X\n", ascq);
 


### PR DESCRIPTION
## Description

Silences all of these massive warnings:
```
In file included from deps/glslang/glslang/SPIRV/hex_float.h:39,
                 from deps/glslang/glslang/SPIRV/SpvBuilder.cpp:49:
deps/glslang/glslang/SPIRV/bitutils.h: In instantiation of 'Dest spvutils::BitwiseCast(Src) [with Dest = spvutils::Float16; Src = short unsigned int]':
deps/glslang/glslang/SPIRV/hex_float.h:138:47:   required from 'T spvutils::FloatProxy<T>::getAsFloat() const [with T = spvutils::Float16]'
deps/glslang/glslang/SPIRV/hex_float.h:821:52:   required from here
deps/glslang/glslang/SPIRV/bitutils.h:29:14: warning: 'void* memcpy(void*, const void*, size_t)' writing to an object of non-trivially copyable type 'class spvutils::Float16'; use copy-assignment or copy-initialization instead [-Wclass-memaccess]
   29 |   std::memcpy(&dest, &source, sizeof(dest));
      |   ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from deps/glslang/glslang/SPIRV/SpvBuilder.cpp:49:
deps/glslang/glslang/SPIRV/hex_float.h:43:7: note: 'class spvutils::Float16' declared here
   43 | class Float16 {
      |       ^~~~~~~
In file included from deps/glslang/glslang/SPIRV/hex_float.h:39,
                 from deps/glslang/glslang/SPIRV/SpvBuilder.cpp:49:
deps/glslang/glslang/SPIRV/bitutils.h: In instantiation of 'Dest spvutils::BitwiseCast(Src) [with Dest = spvutils::FloatProxy<spvutils::Float16>; Src = short unsigned int]':
deps/glslang/glslang/SPIRV/hex_float.h:431:28:   required from 'void spvutils::HexFloat<T, Traits>::setFromSignUnbiasedExponentAndNormalizedSignificand(bool, spvutils::HexFloat<T, Traits>::int_type, spvutils::HexFloat<T, Traits>::uint_type, bool) [with T = spvutils::FloatProxy<spvutils::Float16>; Traits = spvutils::HexFloatTraits<spvutils::FloatProxy<spvutils::Float16> >; spvutils::HexFloat<T, Traits>::int_type = short int; spvutils::HexFloat<T, Traits>::uint_type = short unsigned int]'
deps/glslang/glslang/SPIRV/hex_float.h:633:5:   required from 'void spvutils::HexFloat<T, Traits>::castTo(other_T&, spvutils::round_direction) [with other_T = spvutils::HexFloat<spvutils::FloatProxy<spvutils::Float16>, spvutils::HexFloatTraits<spvutils::FloatProxy<spvutils::Float16> > >; T = spvutils::FloatProxy<float>; Traits = spvutils::HexFloatTraits<spvutils::FloatProxy<float> >]'
deps/glslang/glslang/SPIRV/hex_float.h:817:39:   required from here
deps/glslang/glslang/SPIRV/bitutils.h:29:14: warning: 'void* memcpy(void*, const void*, size_t)' copying an object of non-trivial type 'class spvutils::FloatProxy<spvutils::Float16>' from an array of 'short unsigned int' [-Wclass-memaccess]
   29 |   std::memcpy(&dest, &source, sizeof(dest));
      |   ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from deps/glslang/glslang/SPIRV/SpvBuilder.cpp:49:
deps/glslang/glslang/SPIRV/hex_float.h:115:7: note: 'class spvutils::FloatProxy<spvutils::Float16>' declared here
  115 | class FloatProxy {
      |       ^~~~~~~~~~
libretro-common/cdrom/cdrom.c: In function 'cdrom_print_sense_data.part.0':
libretro-common/cdrom/cdrom.c:178:4: warning: '%s' directive argument is null [-Wformat-overflow=]
  178 |    printf("[CDROM] Sense Key: %02X (%s)\n", key, sense_key_text);
      |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from deps/discord-rpc/src/serialization.h:15,
                 from deps/discord-rpc/src/rpc_connection.h:4,
                 from deps/discord-rpc/src/rpc_connection.cpp:1:
deps/discord-rpc/thirdparty/rapidjson-1.1.0/include/rapidjson/document.h: In instantiation of 'void rapidjson::GenericValue<Encoding, Allocator>::SetObjectRaw(rapidjson::GenericValue<Encoding, Allocator>::Member*, rapidjson::SizeType, Allocator&) [with Encoding = rapidjson::UTF8<>; Allocator = rapidjson::MemoryPoolAllocator<>; rapidjson::GenericValue<Encoding, Allocator>::Member = rapidjson::GenericMember<rapidjson::UTF8<>, rapidjson::MemoryPoolAllocator<> >; rapidjson::SizeType = unsigned int]':
deps/discord-rpc/thirdparty/rapidjson-1.1.0/include/rapidjson/document.h:2363:9:   required from 'bool rapidjson::GenericDocument<Encoding, Allocator, StackAllocator>::EndObject(rapidjson::SizeType) [with Encoding = rapidjson::UTF8<>; Allocator = rapidjson::MemoryPoolAllocator<>; StackAllocator = FixedLinearAllocator<2048>; rapidjson::SizeType = unsigned int]'
deps/discord-rpc/thirdparty/rapidjson-1.1.0/include/rapidjson/reader.h:1736:18:   required from 'rapidjson::GenericReader<SourceEncoding, TargetEncoding, StackAllocator>::IterativeParsingState rapidjson::GenericReader<SourceEncoding, TargetEncoding, StackAllocator>::Transit(rapidjson::GenericReader<SourceEncoding, TargetEncoding, StackAllocator>::IterativeParsingState, rapidjson::GenericReader<SourceEncoding, TargetEncoding, StackAllocator>::Token, rapidjson::GenericReader<SourceEncoding, TargetEncoding, StackAllocator>::IterativeParsingState, InputStream&, Handler&) [with unsigned int parseFlags = 1; InputStream = rapidjson::GenericInsituStringStream<rapidjson::UTF8<> >; Handler = rapidjson::GenericDocument<rapidjson::UTF8<>, rapidjson::MemoryPoolAllocator<>, FixedLinearAllocator<2048> >; SourceEncoding = rapidjson::UTF8<>; TargetEncoding = rapidjson::UTF8<>; StackAllocator = FixedLinearAllocator<2048>]'
deps/discord-rpc/thirdparty/rapidjson-1.1.0/include/rapidjson/reader.h:1832:35:   required from 'rapidjson::ParseResult rapidjson::GenericReader<SourceEncoding, TargetEncoding, StackAllocator>::IterativeParse(InputStream&, Handler&) [with unsigned int parseFlags = 1; InputStream = rapidjson::GenericInsituStringStream<rapidjson::UTF8<> >; Handler = rapidjson::GenericDocument<rapidjson::UTF8<>, rapidjson::MemoryPoolAllocator<>, FixedLinearAllocator<2048> >; SourceEncoding = rapidjson::UTF8<>; TargetEncoding = rapidjson::UTF8<>; StackAllocator = FixedLinearAllocator<2048>]'
deps/discord-rpc/thirdparty/rapidjson-1.1.0/include/rapidjson/reader.h:487:58:   required from 'rapidjson::ParseResult rapidjson::GenericReader<SourceEncoding, TargetEncoding, StackAllocator>::Parse(InputStream&, Handler&) [with unsigned int parseFlags = 1; InputStream = rapidjson::GenericInsituStringStream<rapidjson::UTF8<> >; Handler = rapidjson::GenericDocument<rapidjson::UTF8<>, rapidjson::MemoryPoolAllocator<>, FixedLinearAllocator<2048> >; SourceEncoding = rapidjson::UTF8<>; TargetEncoding = rapidjson::UTF8<>; StackAllocator = FixedLinearAllocator<2048>]'
deps/discord-rpc/thirdparty/rapidjson-1.1.0/include/rapidjson/document.h:2159:22:   required from 'rapidjson::GenericDocument<Encoding, Allocator, StackAllocator>& rapidjson::GenericDocument<Encoding, Allocator, StackAllocator>::ParseStream(InputStream&) [with unsigned int parseFlags = 1; SourceEncoding = rapidjson::UTF8<>; InputStream = rapidjson::GenericInsituStringStream<rapidjson::UTF8<> >; Encoding = rapidjson::UTF8<>; Allocator = rapidjson::MemoryPoolAllocator<>; StackAllocator = FixedLinearAllocator<2048>]'
deps/discord-rpc/thirdparty/rapidjson-1.1.0/include/rapidjson/document.h:2175:65:   required from 'rapidjson::GenericDocument<Encoding, Allocator, StackAllocator>& rapidjson::GenericDocument<Encoding, Allocator, StackAllocator>::ParseStream(InputStream&) [with unsigned int parseFlags = 1; InputStream = rapidjson::GenericInsituStringStream<rapidjson::UTF8<> >; Encoding = rapidjson::UTF8<>; Allocator = rapidjson::MemoryPoolAllocator<>; StackAllocator = FixedLinearAllocator<2048>]'
deps/discord-rpc/thirdparty/rapidjson-1.1.0/include/rapidjson/document.h:2200:60:   required from 'rapidjson::GenericDocument<Encoding, Allocator, StackAllocator>& rapidjson::GenericDocument<Encoding, Allocator, StackAllocator>::ParseInsitu(rapidjson::GenericDocument<Encoding, Allocator, StackAllocator>::Ch*) [with unsigned int parseFlags = 0; Encoding = rapidjson::UTF8<>; Allocator = rapidjson::MemoryPoolAllocator<>; StackAllocator = FixedLinearAllocator<2048>; rapidjson::GenericDocument<Encoding, Allocator, StackAllocator>::Ch = char]'
deps/discord-rpc/thirdparty/rapidjson-1.1.0/include/rapidjson/document.h:2208:51:   required from 'rapidjson::GenericDocument<Encoding, Allocator, StackAllocator>& rapidjson::GenericDocument<Encoding, Allocator, StackAllocator>::ParseInsitu(rapidjson::GenericDocument<Encoding, Allocator, StackAllocator>::Ch*) [with Encoding = rapidjson::UTF8<>; Allocator = rapidjson::MemoryPoolAllocator<>; StackAllocator = FixedLinearAllocator<2048>; rapidjson::GenericDocument<Encoding, Allocator, StackAllocator>::Ch = char]'
deps/discord-rpc/src/rpc_connection.cpp:115:50:   required from here
deps/discord-rpc/thirdparty/rapidjson-1.1.0/include/rapidjson/document.h:1952:24: warning: 'void* memcpy(void*, const void*, size_t)' writing to an object of type 'rapidjson::GenericValue<rapidjson::UTF8<> >::Member' {aka 'struct rapidjson::GenericMember<rapidjson::UTF8<>, rapidjson::MemoryPoolAllocator<> >'} with no trivial copy-assignment; use copy-assignment instead [-Wclass-memaccess]
 1952 |             std::memcpy(m, members, count * sizeof(Member));
      |             ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from deps/discord-rpc/src/serialization.h:15,
                 from deps/discord-rpc/src/rpc_connection.h:4,
                 from deps/discord-rpc/src/rpc_connection.cpp:1:
deps/discord-rpc/thirdparty/rapidjson-1.1.0/include/rapidjson/document.h:71:8: note: 'rapidjson::GenericValue<rapidjson::UTF8<> >::Member' {aka 'struct rapidjson::GenericMember<rapidjson::UTF8<>, rapidjson::MemoryPoolAllocator<> >'} declared here
   71 | struct GenericMember {
      |        ^~~~~~~~~~~~~
In file included from deps/discord-rpc/src/serialization.h:15,
                 from deps/discord-rpc/src/rpc_connection.h:4,
                 from deps/discord-rpc/src/rpc_connection.cpp:1:
deps/discord-rpc/thirdparty/rapidjson-1.1.0/include/rapidjson/document.h: In instantiation of 'void rapidjson::GenericValue<Encoding, Allocator>::SetArrayRaw(rapidjson::GenericValue<Encoding, Allocator>*, rapidjson::SizeType, Allocator&) [with Encoding = rapidjson::UTF8<>; Allocator = rapidjson::MemoryPoolAllocator<>; rapidjson::SizeType = unsigned int]':
deps/discord-rpc/thirdparty/rapidjson-1.1.0/include/rapidjson/document.h:2371:9:   required from 'bool rapidjson::GenericDocument<Encoding, Allocator, StackAllocator>::EndArray(rapidjson::SizeType) [with Encoding = rapidjson::UTF8<>; Allocator = rapidjson::MemoryPoolAllocator<>; StackAllocator = FixedLinearAllocator<2048>; rapidjson::SizeType = unsigned int]'
deps/discord-rpc/thirdparty/rapidjson-1.1.0/include/rapidjson/reader.h:1766:18:   required from 'rapidjson::GenericReader<SourceEncoding, TargetEncoding, StackAllocator>::IterativeParsingState rapidjson::GenericReader<SourceEncoding, TargetEncoding, StackAllocator>::Transit(rapidjson::GenericReader<SourceEncoding, TargetEncoding, StackAllocator>::IterativeParsingState, rapidjson::GenericReader<SourceEncoding, TargetEncoding, StackAllocator>::Token, rapidjson::GenericReader<SourceEncoding, TargetEncoding, StackAllocator>::IterativeParsingState, InputStream&, Handler&) [with unsigned int parseFlags = 1; InputStream = rapidjson::GenericInsituStringStream<rapidjson::UTF8<> >; Handler = rapidjson::GenericDocument<rapidjson::UTF8<>, rapidjson::MemoryPoolAllocator<>, FixedLinearAllocator<2048> >; SourceEncoding = rapidjson::UTF8<>; TargetEncoding = rapidjson::UTF8<>; StackAllocator = FixedLinearAllocator<2048>]'
deps/discord-rpc/thirdparty/rapidjson-1.1.0/include/rapidjson/reader.h:1832:35:   required from 'rapidjson::ParseResult rapidjson::GenericReader<SourceEncoding, TargetEncoding, StackAllocator>::IterativeParse(InputStream&, Handler&) [with unsigned int parseFlags = 1; InputStream = rapidjson::GenericInsituStringStream<rapidjson::UTF8<> >; Handler = rapidjson::GenericDocument<rapidjson::UTF8<>, rapidjson::MemoryPoolAllocator<>, FixedLinearAllocator<2048> >; SourceEncoding = rapidjson::UTF8<>; TargetEncoding = rapidjson::UTF8<>; StackAllocator = FixedLinearAllocator<2048>]'
deps/discord-rpc/thirdparty/rapidjson-1.1.0/include/rapidjson/reader.h:487:58:   required from 'rapidjson::ParseResult rapidjson::GenericReader<SourceEncoding, TargetEncoding, StackAllocator>::Parse(InputStream&, Handler&) [with unsigned int parseFlags = 1; InputStream = rapidjson::GenericInsituStringStream<rapidjson::UTF8<> >; Handler = rapidjson::GenericDocument<rapidjson::UTF8<>, rapidjson::MemoryPoolAllocator<>, FixedLinearAllocator<2048> >; SourceEncoding = rapidjson::UTF8<>; TargetEncoding = rapidjson::UTF8<>; StackAllocator = FixedLinearAllocator<2048>]'
deps/discord-rpc/thirdparty/rapidjson-1.1.0/include/rapidjson/document.h:2159:22:   required from 'rapidjson::GenericDocument<Encoding, Allocator, StackAllocator>& rapidjson::GenericDocument<Encoding, Allocator, StackAllocator>::ParseStream(InputStream&) [with unsigned int parseFlags = 1; SourceEncoding = rapidjson::UTF8<>; InputStream = rapidjson::GenericInsituStringStream<rapidjson::UTF8<> >; Encoding = rapidjson::UTF8<>; Allocator = rapidjson::MemoryPoolAllocator<>; StackAllocator = FixedLinearAllocator<2048>]'
deps/discord-rpc/thirdparty/rapidjson-1.1.0/include/rapidjson/document.h:2175:65:   required from 'rapidjson::GenericDocument<Encoding, Allocator, StackAllocator>& rapidjson::GenericDocument<Encoding, Allocator, StackAllocator>::ParseStream(InputStream&) [with unsigned int parseFlags = 1; InputStream = rapidjson::GenericInsituStringStream<rapidjson::UTF8<> >; Encoding = rapidjson::UTF8<>; Allocator = rapidjson::MemoryPoolAllocator<>; StackAllocator = FixedLinearAllocator<2048>]'
deps/discord-rpc/thirdparty/rapidjson-1.1.0/include/rapidjson/document.h:2200:60:   required from 'rapidjson::GenericDocument<Encoding, Allocator, StackAllocator>& rapidjson::GenericDocument<Encoding, Allocator, StackAllocator>::ParseInsitu(rapidjson::GenericDocument<Encoding, Allocator, StackAllocator>::Ch*) [with unsigned int parseFlags = 0; Encoding = rapidjson::UTF8<>; Allocator = rapidjson::MemoryPoolAllocator<>; StackAllocator = FixedLinearAllocator<2048>; rapidjson::GenericDocument<Encoding, Allocator, StackAllocator>::Ch = char]'
deps/discord-rpc/thirdparty/rapidjson-1.1.0/include/rapidjson/document.h:2208:51:   required from 'rapidjson::GenericDocument<Encoding, Allocator, StackAllocator>& rapidjson::GenericDocument<Encoding, Allocator, StackAllocator>::ParseInsitu(rapidjson::GenericDocument<Encoding, Allocator, StackAllocator>::Ch*) [with Encoding = rapidjson::UTF8<>; Allocator = rapidjson::MemoryPoolAllocator<>; StackAllocator = FixedLinearAllocator<2048>; rapidjson::GenericDocument<Encoding, Allocator, StackAllocator>::Ch = char]'
deps/discord-rpc/src/rpc_connection.cpp:115:50:   required from here
deps/discord-rpc/thirdparty/rapidjson-1.1.0/include/rapidjson/document.h:1939:24: warning: 'void* memcpy(void*, const void*, size_t)' writing to an object of type 'class rapidjson::GenericValue<rapidjson::UTF8<> >' with no trivial copy-assignment; use copy-assignment or copy-initialization instead [-Wclass-memaccess]
 1939 |             std::memcpy(e, values, count * sizeof(GenericValue));
      |             ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
deps/discord-rpc/thirdparty/rapidjson-1.1.0/include/rapidjson/document.h:540:7: note: 'class rapidjson::GenericValue<rapidjson::UTF8<> >' declared here
  540 | class GenericValue {
      |       ^~~~~~~~~~~~
```
(Yes, that are just 4 warnings.)