### PR TITLE
Silence -Wstring-plus-int with clang.

### DIFF
--- a/cores/libretro-imageviewer/image_core.c
+++ b/cores/libretro-imageviewer/image_core.c
@@ -72,7 +72,7 @@ static struct string_list *image_file_list;
 static const char* IMAGE_CORE_PREFIX(valid_extensions) = "jpg|jpeg|png|bmp|psd|tga|gif|hdr|pic|ppm|pgm";
 #else
 
-static const char* IMAGE_CORE_PREFIX(valid_extensions) = 1+ /* to remove the first |, the alternative is 25 extra lines of ifdef/etc */
+static const char image_formats[] =
 
 #ifdef HAVE_RJPEG
 "|jpg|jpeg"
@@ -94,6 +94,9 @@ static const char* IMAGE_CORE_PREFIX(valid_extensions) = 1+ /* to remove the fir
 #error "can't build this core with no image formats"
 #endif
 ;
+
+/* to remove the first |, the alternative is 25 extra lines of ifdef/etc */
+static const char* IMAGE_CORE_PREFIX(valid_extensions) = image_formats + 1;
 
 #endif
 


### PR DESCRIPTION
## Description

Silences one `-Wstring-plus-int` warning with `clang-8.0.1`. I confirmed with `printf` that the value is the same before and after.

## Related Issues

```
cores/libretro-imageviewer/image_core.c:75:59: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
static const char* IMAGE_CORE_PREFIX(valid_extensions) = 1+ /* to remove the first |, the alternative is 25 extra lines of ifdef/etc */
                                                         ~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cores/libretro-imageviewer/image_core.c:75:59: note: use array indexing to silence this warning
1 warning generated.
```
