### PR TITLE
Silence log spam for remap configs.

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -3455,7 +3455,7 @@ bool config_load_remap(void)
          path_size);
 
    /* Create a new config file from game_path */
-   new_conf = config_file_new_from_path_to_string(game_path);
+   new_conf = config_file_new(game_path);
 
    /* If a game remap file exists, load it. */
    if (new_conf)
@@ -3477,7 +3477,7 @@ bool config_load_remap(void)
    }
 
    /* Create a new config file from content_path */
-   new_conf = config_file_new_from_path_to_string(content_path);
+   new_conf = config_file_new(content_path);
 
    /* If a content-dir remap file exists, load it. */
    if (new_conf)
@@ -3499,7 +3499,7 @@ bool config_load_remap(void)
    }
 
    /* Create a new config file from core_path */
-   new_conf = config_file_new_from_path_to_string(core_path);
+   new_conf = config_file_new(core_path);
 
    /* If a core remap file exists, load it. */
    if (new_conf)


### PR DESCRIPTION
## Description

This silences very annoying log spam for anyone that doesn't use core remaps.

## Related Issues

Every time I load any core I get this spam...
```
Failed to open /home/orbea/.config/retroarch/config/remaps/image display/Ophiocordyceps ravenelii-vjp.rmp: No such file or directory
Failed to open /home/orbea/.config/retroarch/config/remaps/image display/images.rmp: No such file or directory
Failed to open /home/orbea/.config/retroarch/config/remaps/image display/image display.rmp: No such file or directory
```

## Related Pull Requests

Partially reverts 0cdfd4c5420d6cf848c709053dbd2b020065ea07.
