### PR TITLE
Fix CXX_BUILD=1 with libsixel.

### DIFF
--- a/gfx/drivers/sixel_gfx.c
+++ b/gfx/drivers/sixel_gfx.c
@@ -549,7 +549,7 @@ static void sixel_set_osd_msg(void *data,
       const char *msg,
       const void *params, void *font)
 {
-   font_driver_render_msg(video_info, font, msg, params);
+   font_driver_render_msg(video_info, font, msg, (const struct font_params*)params);
 }
 
 static void sixel_get_video_output_size(void *data,


### PR DESCRIPTION
## Description

Fixes `CXX_BUILD=1` with libsixel. Also adds `libsixel-dev` for travis to help catch issues like this in the future.

## Related Issues

```
gfx/drivers/sixel_gfx.c:552:4: error: no matching function for call to 'font_driver_render_msg'
   font_driver_render_msg(video_info, font, msg, params);
   ^~~~~~~~~~~~~~~~~~~~~~
gfx/drivers/../font_driver.h:133:6: note: candidate function not viable: cannot convert argument of incomplete type 'const void *' to 'const struct font_params *' for 4th argument
void font_driver_render_msg(video_frame_info_t *video_info,
     ^
1 error generated.
make: *** [Makefile:204: obj-unix/release/gfx/drivers/sixel_gfx.o] Error 1
```

## Reviewers

Wait for travis to make sure I have the right libsixel dependency, ubuntu doesn't document these well...