### PR TITLE
add defs and includes from Makefile.common to the Makefile.libnx build params

### DIFF
--- a/Makefile.libnx
+++ b/Makefile.libnx
@@ -133,6 +133,10 @@ ifeq ($(HAVE_OPENGL), 1)
   LIBS := -lEGL -lglapi -ldrm_nouveau $(LIBS)
 endif
 
+# add things from Makefile.common
+CFLAGS += $(DEF_FLAGS)
+INCLUDES += $(INCLUDE_DIRS)
+
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing
 # include and lib


### PR DESCRIPTION
## Description
Defines and includes in the Makefile.common is not appended to the build parameters in Makefile.libnx

This causes things like GL_DEBUG=1 to not work

It seems to build fine, so I assume nothing is broken. But I've not done much testing.

## Reviewers

@m4xw 
