### PR TITLE
Fix --disable-overlay.

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -1665,11 +1665,13 @@ static void video_driver_gpu_record_deinit(void);
 
 static void video_driver_set_nonblock_state(bool toggle);
 
+#ifdef HAVE_OVERLAY
 static void input_overlay_set_alpha_mod(input_overlay_t *ol, float mod);
 static void input_overlay_set_scale_factor(input_overlay_t *ol, float scale);
 static void input_overlay_load_active(input_overlay_t *ol, float opacity);
 static void retroarch_overlay_init(void);
 static void retroarch_overlay_deinit(void);
+#endif
 
 static void bsv_movie_deinit(void);
 static bool bsv_movie_init(void);


### PR DESCRIPTION
## Description

Fixes `--disable-overlay`.

## Related Issues

```
retroarch.c:1668:41: error: unknown type name 'input_overlay_t'
static void input_overlay_set_alpha_mod(input_overlay_t *ol, float mod);
                                        ^
retroarch.c:1669:44: error: unknown type name 'input_overlay_t'
static void input_overlay_set_scale_factor(input_overlay_t *ol, float scale);
                                           ^
retroarch.c:1670:39: error: unknown type name 'input_overlay_t'
static void input_overlay_load_active(input_overlay_t *ol, float opacity);
                                      ^
3 errors generated.
make: *** [Makefile:204: obj-unix/release/retroarch.o] Error 1
```

## Related Pull Requests

https://github.com/libretro/RetroArch/commit/d36f6d8a1d4f877ff12816dcc72e4811b0ed9071
