### PR TITLE
Silence discord warnings without visual studio.

### DIFF
--- a/deps/discord-rpc/src/serialization.h
+++ b/deps/discord-rpc/src/serialization.h
@@ -2,7 +2,7 @@
 
 #include <stdint.h>
 
-#ifndef __MINGW32__
+#ifdef _MSC_VER
 #pragma warning(push)
 
 #pragma warning(disable : 4061) // enum is not explicitly handled by a case label
@@ -10,15 +10,15 @@
 #pragma warning(disable : 4464) // relative include path contains
 #pragma warning(disable : 4668) // is not defined as a preprocessor macro
 #pragma warning(disable : 6313) // Incorrect operator
-#endif                          // __MINGW32__
+#endif                          // _MSC_VER
 
 #include "rapidjson/document.h"
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"
 
-#ifndef __MINGW32__
+#ifdef _MSC_VER
 #pragma warning(pop)
-#endif // __MINGW32__
+#endif // _MSC_VER
 
 // if only there was a standard library function for this
 template <size_t Len>


### PR DESCRIPTION
## Description

Since we are already silencing warnings in discord-rpc we might as well finish the job. These pragmas seem to be only relevant for visual studio.

## Related Issues

```
CXX deps/discord-rpc/src/discord_rpc.cpp
In file included from deps/discord-rpc/src/discord_rpc.cpp:6:
In file included from deps/discord-rpc/src/rpc_connection.h:4:
deps/discord-rpc/src/serialization.h:6:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma warning(push)
        ^
deps/discord-rpc/src/serialization.h:8:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma warning(disable : 4061) // enum is not explicitly handled by a case label
        ^
deps/discord-rpc/src/serialization.h:9:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma warning(disable : 4365) // signed/unsigned mismatch
        ^
deps/discord-rpc/src/serialization.h:10:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma warning(disable : 4464) // relative include path contains
        ^
deps/discord-rpc/src/serialization.h:11:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma warning(disable : 4668) // is not defined as a preprocessor macro
        ^
deps/discord-rpc/src/serialization.h:12:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma warning(disable : 6313) // Incorrect operator
        ^
deps/discord-rpc/src/serialization.h:20:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma warning(pop)
        ^
7 warnings generated.
CXX deps/discord-rpc/src/rpc_connection.cpp
In file included from deps/discord-rpc/src/rpc_connection.cpp:1:
In file included from deps/discord-rpc/src/rpc_connection.h:4:
deps/discord-rpc/src/serialization.h:6:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma warning(push)
        ^
deps/discord-rpc/src/serialization.h:8:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma warning(disable : 4061) // enum is not explicitly handled by a case label
        ^
deps/discord-rpc/src/serialization.h:9:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma warning(disable : 4365) // signed/unsigned mismatch
        ^
deps/discord-rpc/src/serialization.h:10:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma warning(disable : 4464) // relative include path contains
        ^
deps/discord-rpc/src/serialization.h:11:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma warning(disable : 4668) // is not defined as a preprocessor macro
        ^
deps/discord-rpc/src/serialization.h:12:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma warning(disable : 6313) // Incorrect operator
        ^
deps/discord-rpc/src/serialization.h:20:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma warning(pop)
        ^
7 warnings generated.
CXX deps/discord-rpc/src/serialization.cpp
In file included from deps/discord-rpc/src/serialization.cpp:1:
deps/discord-rpc/src/serialization.h:6:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma warning(push)
        ^
deps/discord-rpc/src/serialization.h:8:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma warning(disable : 4061) // enum is not explicitly handled by a case label
        ^
deps/discord-rpc/src/serialization.h:9:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma warning(disable : 4365) // signed/unsigned mismatch
        ^
deps/discord-rpc/src/serialization.h:10:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma warning(disable : 4464) // relative include path contains
        ^
deps/discord-rpc/src/serialization.h:11:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma warning(disable : 4668) // is not defined as a preprocessor macro
        ^
deps/discord-rpc/src/serialization.h:12:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma warning(disable : 6313) // Incorrect operator
        ^
deps/discord-rpc/src/serialization.h:20:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma warning(pop)
        ^
7 warnings generated.
```
