### PR TITLE
(config_file.c) Only attempt to load config file if it exists

### DIFF
--- a/libretro-common/file/config_file.c
+++ b/libretro-common/file/config_file.c
@@ -603,12 +603,15 @@ config_file_t *config_file_new_from_path_to_string(const char *path)
    uint8_t *ret_buf              = NULL;
    config_file_t *conf           = NULL;
 
-   if (filestream_read_file(path, (void**)&ret_buf, &length))
+   if (path_is_valid(path))
    {
-      if (length >= 0)
-         conf = config_file_new_from_string((const char*)ret_buf, path);
-      if ((void*)ret_buf)
-         free((void*)ret_buf);
+      if (filestream_read_file(path, (void**)&ret_buf, &length))
+      {
+         if (length >= 0)
+            conf = config_file_new_from_string((const char*)ret_buf, path);
+         if ((void*)ret_buf)
+            free((void*)ret_buf);
+      }
    }
 
    return conf;


### PR DESCRIPTION
## Description

At present, `config_file_new_from_path_to_string()` will attempt to load config files whether or not they exist (relying on `filestream_read_file()` to perform the check). This is somewhat wasteful, and causes  `filestream_read_file()` to spam stderr with things like:

```
Failed to open /home/james/.config/retroarch/config/remaps/QuickNES/Metroid (USA).rmp: No such file or directory
Failed to open /home/james/.config/retroarch/config/remaps/QuickNES/NES.rmp: No such file or directory
Failed to open /home/james/.config/retroarch/config/remaps/QuickNES/QuickNES.rmp: No such file or directory
Failed to open /home/james/.config/retroarch/config/remaps/QuickNES/Super Mario Bros. (World).rmp: No such file or directory
Failed to open /home/james/.config/retroarch/config/remaps/QuickNES/NES.rmp: No such file or directory
Failed to open /home/james/.config/retroarch/config/remaps/QuickNES/QuickNES.rmp: No such file or directory
```

This PR just adds a `path_is_valid()` test to `config_file_new_from_path_to_string()`, so `filestream_read_file()` is only called when necessary (and no improper error text is printed).
