### PR TITLE
Simplify glslang_read_shader_file() a bit

### DIFF
--- a/gfx/drivers_shader/glslang_util.cpp
+++ b/gfx/drivers_shader/glslang_util.cpp
@@ -47,25 +47,14 @@ bool glslang_read_shader_file(const char *path, vector<string> *output, bool roo
    char                          *buf = nullptr;
    int64_t                        len = 0;
    const char *basename               = path_basename(path);
-   size_t path_size                   = PATH_MAX_LENGTH * sizeof(char);
-   char *tmp_path                     = (char*)malloc(path_size);
 
    include_path[0] = tmp[0] = '\0';
 
-   strlcpy(tmp_path, path, path_size);
-   path_resolve_realpath(tmp_path, path_size, false);
-
-   if (!path_is_valid(tmp_path))
-      strlcpy(tmp_path, path, path_size);
-
-   if (!filestream_read_file(tmp_path, (void**)&buf, &len))
+   if (!filestream_read_file(path, (void**)&buf, &len))
    {
-      RARCH_ERR("Failed to open shader file: \"%s\".\n", tmp_path);
-      free(tmp_path);
+      RARCH_ERR("Failed to open shader file: \"%s\".\n", path);
       return false;
    }
-
-   free(tmp_path);
 
    /* Remove Windows \r chars if we encounter them.
     * filestream_read_file() allocates one extra for 0 terminator. */


### PR DESCRIPTION
## Description

`glslang_read_shader_file()` contains the same "ancient piece of code" like in #9140 that tries to resolve relative paths with all its problems, i.e. it would rebase on the working directory instead of the shader (preset) directory.

This PR reverts the commit that added it.

This works because `glslang_read_shader_file()` gets called for shader pass paths which are now (after #9140) guaranteed to be absolute after loading and it is also called for (relative) `#include` directives which already get resolved beforehand too.

Tested both those cases.

## Related Commits

https://github.com/libretro/RetroArch/commit/8b0f083a4e4a011dbcbe395f98f980ae948ee2fe

## Related Pull Requests

#9140