### PR TITLE
Makefile.vita: Try to fix the build.

### DIFF
--- a/Makefile.vita
+++ b/Makefile.vita
@@ -32,7 +32,6 @@ else
 	HAVE_RJPEG		:= 1
 	HAVE_RBMP		:= 1
 	HAVE_RTGA		:= 1
-	HAVE_BUILTINZLIB        := 1
 	HAVE_ZLIB		:= 1
 	HAVE_7ZIP		:= 1
 	HAVE_VITA2D		:= 1


### PR DESCRIPTION
## Description

Tries to fix multiple definition errors.

I think the problem is that I made the wrong assumption about vita using the builtin zlib when they already have their own static `libz.a`

## Related Issues

```
/home/buildbot/tools/vita/bin/../lib/gcc/arm-vita-eabi/8.2.0/../../../../arm-vita-eabi/bin/ld: /home/buildbot/tools/vita/bin/../lib/gcc/arm-vita-eabi/8.2.0/../../../../arm-vita-eabi/lib/libz.a(inflate.o): in function `inflateResetKeep':
(.text+0xc0): multiple definition of `inflateResetKeep'; ./deps/libz/inflate.o:inflate.c:(.text+0xc0): first defined here
/home/buildbot/tools/vita/bin/../lib/gcc/arm-vita-eabi/8.2.0/../../../../arm-vita-eabi/bin/ld: /home/buildbot/tools/vita/bin/../lib/gcc/arm-vita-eabi/8.2.0/../../../../arm-vita-eabi/lib/libz.a(inflate.o): in function `inflateReset':
(.text+0x148): multiple definition of `inflateReset'; ./deps/libz/inflate.o:inflate.c:(.text+0x128): first defined here
/home/buildbot/tools/vita/bin/../lib/gcc/arm-vita-eabi/8.2.0/../../../../arm-vita-eabi/bin/ld: /home/buildbot/tools/vita/bin/../lib/gcc/arm-vita-eabi/8.2.0/../../../../arm-vita-eabi/lib/libz.a(inflate.o): in function `inflateReset2':
(.text+0x1e0): multiple definition of `inflateReset2'; ./deps/libz/inflate.o:inflate.c:(.text+0x1a0): first defined here
/home/buildbot/tools/vita/bin/../lib/gcc/arm-vita-eabi/8.2.0/../../../../arm-vita-eabi/bin/ld: /home/buildbot/tools/vita/bin/../lib/gcc/arm-vita-eabi/8.2.0/../../../../arm-vita-eabi/lib/libz.a(inflate.o): in function `inflateInit2_':
(.text+0x268): multiple definition of `inflateInit2_'; ./deps/libz/inflate.o:inflate.c:(.text+0x278): first defined here
/home/buildbot/tools/vita/bin/../lib/gcc/arm-vita-eabi/8.2.0/../../../../arm-vita-eabi/bin/ld: /home/buildbot/tools/vita/bin/../lib/gcc/arm-vita-eabi/8.2.0/../../../../arm-vita-eabi/lib/libz.a(inflate.o): in function `inflateInit_':
(.text+0x2f8): multiple definition of `inflateInit_'; ./deps/libz/inflate.o:inflate.c:(.text+0x2fc): first defined here
/home/buildbot/tools/vita/bin/../lib/gcc/arm-vita-eabi/8.2.0/../../../../arm-vita-eabi/bin/ld: /home/buildbot/tools/vita/bin/../lib/gcc/arm-vita-eabi/8.2.0/../../../../arm-vita-eabi/lib/libz.a(inflate.o): in function `inflatePrime':
(.text+0x3a8): multiple definition of `inflatePrime'; ./deps/libz/inflate.o:inflate.c:(.text+0x3d0): first defined here
/home/buildbot/tools/vita/bin/../lib/gcc/arm-vita-eabi/8.2.0/../../../../arm-vita-eabi/bin/ld: /home/buildbot/tools/vita/bin/../lib/gcc/arm-vita-eabi/8.2.0/../../../../arm-vita-eabi/lib/libz.a(inflate.o): in function `inflate':
(.text+0x414): multiple definition of `inflate'; ./deps/libz/inflate.o:inflate.c:(.text+0x420): first defined here
/home/buildbot/tools/vita/bin/../lib/gcc/arm-vita-eabi/8.2.0/../../../../arm-vita-eabi/bin/ld: /home/buildbot/tools/vita/bin/../lib/gcc/arm-vita-eabi/8.2.0/../../../../arm-vita-eabi/lib/libz.a(inflate.o): in function `inflateEnd':
(.text+0x1e44): multiple definition of `inflateEnd'; ./deps/libz/inflate.o:inflate.c:(.text+0x1ce8): first defined here
/home/buildbot/tools/vita/bin/../lib/gcc/arm-vita-eabi/8.2.0/../../../../arm-vita-eabi/bin/ld: /home/buildbot/tools/vita/bin/../lib/gcc/arm-vita-eabi/8.2.0/../../../../arm-vita-eabi/lib/libz.a(inflate.o): in function `inflateGetDictionary':
(.text+0x1e88): multiple definition of `inflateGetDictionary'; ./deps/libz/inflate.o:inflate.c:(.text+0x1d14): first defined here
/home/buildbot/tools/vita/bin/../lib/gcc/arm-vita-eabi/8.2.0/../../../../arm-vita-eabi/bin/ld: /home/buildbot/tools/vita/bin/../lib/gcc/arm-vita-eabi/8.2.0/../../../../arm-vita-eabi/lib/libz.a(inflate.o): in function `inflateSetDictionary':
(.text+0x1ef4): multiple definition of `inflateSetDictionary'; ./deps/libz/inflate.o:inflate.c:(.text+0x1d64): first defined here
/home/buildbot/tools/vita/bin/../lib/gcc/arm-vita-eabi/8.2.0/../../../../arm-vita-eabi/bin/ld: /home/buildbot/tools/vita/bin/../lib/gcc/arm-vita-eabi/8.2.0/../../../../arm-vita-eabi/lib/libz.a(inflate.o): in function `inflateGetHeader':
(.text+0x1f7c): multiple definition of `inflateGetHeader'; ./deps/libz/inflate.o:inflate.c:(.text+0x1dc8): first defined here
/home/buildbot/tools/vita/bin/../lib/gcc/arm-vita-eabi/8.2.0/../../../../arm-vita-eabi/bin/ld: /home/buildbot/tools/vita/bin/../lib/gcc/arm-vita-eabi/8.2.0/../../../../arm-vita-eabi/lib/libz.a(inflate.o): in function `inflateSync':
(.text+0x1fb4): multiple definition of `inflateSync'; ./deps/libz/inflate.o:inflate.c:(.text+0x1de4): first defined here
/home/buildbot/tools/vita/bin/../lib/gcc/arm-vita-eabi/8.2.0/../../../../arm-vita-eabi/bin/ld: /home/buildbot/tools/vita/bin/../lib/gcc/arm-vita-eabi/8.2.0/../../../../arm-vita-eabi/lib/libz.a(inflate.o): in function `inflateSyncPoint':
(.text+0x2174): multiple definition of `inflateSyncPoint'; ./deps/libz/inflate.o:inflate.c:(.text+0x2000): first defined here
/home/buildbot/tools/vita/bin/../lib/gcc/arm-vita-eabi/8.2.0/../../../../arm-vita-eabi/bin/ld: /home/buildbot/tools/vita/bin/../lib/gcc/arm-vita-eabi/8.2.0/../../../../arm-vita-eabi/lib/libz.a(inflate.o): in function `inflateCopy':
(.text+0x21b0): multiple definition of `inflateCopy'; ./deps/libz/inflate.o:inflate.c:(.text+0x2020): first defined here
/home/buildbot/tools/vita/bin/../lib/gcc/arm-vita-eabi/8.2.0/../../../../arm-vita-eabi/bin/ld: /home/buildbot/tools/vita/bin/../lib/gcc/arm-vita-eabi/8.2.0/../../../../arm-vita-eabi/lib/libz.a(inflate.o): in function `inflateUndermine':
(.text+0x2334): multiple definition of `inflateUndermine'; ./deps/libz/inflate.o:inflate.c:(.text+0x2194): first defined here
/home/buildbot/tools/vita/bin/../lib/gcc/arm-vita-eabi/8.2.0/../../../../arm-vita-eabi/bin/ld: /home/buildbot/tools/vita/bin/../lib/gcc/arm-vita-eabi/8.2.0/../../../../arm-vita-eabi/lib/libz.a(inflate.o): in function `inflateMark':
(.text+0x23a8): multiple definition of `inflateMark'; ./deps/libz/inflate.o:inflate.c:(.text+0x21b0): first defined here
collect2: error: ld returned 1 exit status
Makefile.vita:155: recipe for target 'retroarch_vita.elf' failed
make: *** [retroarch_vita.elf] Error 1
make: Leaving directory '/home/buildbot/buildbot/vita/retroarch'
```

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/9196
