### PR TITLE
Try to fix the ps2 zlib build.

### DIFF
--- a/Makefile.ps2
+++ b/Makefile.ps2
@@ -31,13 +31,13 @@ ifeq ($(MUTE_WARNINGS), 1)
 endif
 
 INCDIR = -I$(PS2DEV)/gsKit/include -I$(PS2SDK)/ports/include -I$(CDVD_DIR)/ee
-INCDIR += -Ips2 -Ips2/include -Ilibretro-common/include -Ilibretro-common/include/compat/zlib
-INCDIR += -Ideps -Ideps/stb -Ideps/7zip -Ideps/pthreads -Ideps/pthreads/platform/ps2 -Ideps/pthreads/platform/helper
+INCDIR += -Ips2 -Ips2/include -Ilibretro-common/include -Ideps -Ideps/stb -Ideps/7zip
+INCDIR += -Ideps/pthreads -Ideps/pthreads/platform/ps2 -Ideps/pthreads/platform/helper
 GPVAL = -G0
 CFLAGS = $(OPTIMIZE_LV) $(DISABLE_WARNINGS) -ffast-math -fsingle-precision-constant
 ASFLAGS = $(CFLAGS)
 
-RARCH_DEFINES += -DPS2 -DUSE_IOP_CTYPE_MACRO -D_MIPS_ARCH_R5900 -DHAVE_ZLIB -DHAVE_RPNG -DHAVE_RJPEG
+RARCH_DEFINES += -DPS2 -DUSE_IOP_CTYPE_MACRO -D_MIPS_ARCH_R5900 -DHAVE_ZLIB -DHAVE_NO_BUILTINZLIB -DHAVE_RPNG -DHAVE_RJPEG
 RARCH_DEFINES += -DHAVE_GRIFFIN=1 -DRARCH_INTERNAL -DRARCH_CONSOLE -DHAVE_MENU -DHAVE_RGUI -DHAVE_FILTERS_BUILTIN -DHAVE_7ZIP -DHAVE_CC_RESAMPLER
 
 LIBDIR =


### PR DESCRIPTION
## Description

Tries to fix the ps2 zlib build.

This looks like the same issue as android where it wants `HAVE_ZLIB`, but not the builtinzlib and has its own `zlib.h` in the environment.

## Related Issues

```
In file included from griffin/griffin.c:1411:
deps/libz/adler32.c: At top level:
deps/libz/adler32.c:50: conflicting types for `adler32'
/home/buildbot/tools/ps2dev/ps2sdk/ports/include/zlib.h:1569: previous declaration of `adler32'
In file included from deps/libz/gzguts.h:171,
                 from deps/libz/gzclose.c:6,
                 from griffin/griffin.c:1415:
deps/libz/gzfile.h:6: redefinition of `struct gzFile_s'
In file included from griffin/griffin.c:1423:
deps/libz/uncompr.c:25: conflicting types for `uncompress'
/home/buildbot/tools/ps2dev/ps2sdk/ports/include/zlib.h:1198: previous declaration of `uncompress'
/home/buildbot/tools/ps2dev/ps2sdk/samples/Makefile.eeglobal:51: recipe for target 'griffin/griffin.o' failed
make: *** [griffin/griffin.o] Error 1
make: Leaving directory '/home/buildbot/buildbot/ps2/retroarch'
```

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/9196
https://github.com/libretro/RetroArch/pull/9201