### PR TITLE
Update version number to 1.7.7.

### DIFF
--- a/pkg/apple/tvOS/Info.plist
+++ b/pkg/apple/tvOS/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.6</string>
+	<string>1.7.7</string>
 	<key>CFBundleVersion</key>
-	<string>1.7.6</string>
+	<string>1.7.7</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
## Description

Seems it was forgotten to update these version strings from `1.7.6` to `1.7.7`.

## Related Issues

Might be related to this comment.

> With retroarch 1.7.7 (the about box says 1.7.6 but the menu says 1.7.7) on macOS 10.13.6 on a MacBook 6.1

https://github.com/libretro/RetroArch/issues/3954#issuecomment-515661601