### PR TITLE
qb: Use check_val for caca and sixel.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1108,7 +1108,8 @@ endif
 ifeq ($(HAVE_CACA), 1)
    DEFINES += -DHAVE_CACA
    OBJ += gfx/drivers/caca_gfx.o gfx/drivers_font/caca_font.o
-   LIBS += -lcaca
+   LIBS += $(CACA_LIBS)
+   DEF_FLAGS += $(CACA_CFLAGS)
 
    ifeq ($(HAVE_MENU_COMMON), 1)
       OBJ += menu/drivers_display/menu_display_caca.o
@@ -1121,6 +1122,7 @@ ifeq ($(HAVE_SIXEL), 1)
    OBJ += gfx/drivers/sixel_gfx.o gfx/drivers_font/sixel_font.o \
           gfx/drivers_context/sixel_ctx.o
    LIBS += $(SIXEL_LIBS)
+   DEF_FLAGS += $(SIXEL_CFLAGS)
 
    ifeq ($(HAVE_MENU_COMMON), 1)
       OBJ += menu/drivers_display/menu_display_sixel.o

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -196,8 +196,8 @@ if [ "$HAVE_DYLIB" = 'no' ] && [ "$HAVE_DYNAMIC" = 'yes' ]; then
 fi
 
 check_val '' ALSA -lasound alsa alsa '' '' false
-check_lib '' CACA -lcaca
-check_lib '' SIXEL -lsixel
+check_val '' CACA -lcaca '' caca '' '' false
+check_val '' SIXEL -lsixel '' libsixel 1.6.0 '' false
 
 check_macro AUDIOIO AUDIO_SETINFO sys/audioio.h
 


### PR DESCRIPTION
## Description

Small fix, `check_val` will use `check_pkgconf` by default (If available) which is more reliable than `check_lib` and since both `caca` and `libsixel` provide pkgconfig files there is no reason to not do this.

I also fixed some hard coded values.