### PR TITLE
qb: Don't create config.log with ./configure --help.

### DIFF
--- a/configure
+++ b/configure
@@ -2,13 +2,11 @@
 
 PACKAGE_NAME=retroarch
 
-cat /dev/null > config.log
-
 . qb/qb.init.sh
 
-. qb/qb.system.sh
-
 . qb/qb.params.sh
+
+. qb/qb.system.sh
 
 . qb/qb.comp.sh
 


### PR DESCRIPTION
## Description

Small bug fix that only affects `./configure --help`.

## Related Issues

This fixes two minor issues with `./configure --help`.

1. This no longer creates an empty `config.log` file when using `./configure --help`. This line is not needed anymore anyways and the `config.log` file is only used with `./configure`.
2. It  removes a extraneous line from the top of `./configure --help` which should only be printed with `./configure`.
```
Checking operating system ... Linux
```
