### PR TITLE
menu_animation: don't update deleted tweens

### DIFF
--- a/menu/menu_animation.c
+++ b/menu/menu_animation.c
@@ -667,7 +667,7 @@ bool menu_animation_update(void)
    {
       struct tween *tween   = da_getptr(anim.list, i);
 
-      if (!tween)
+      if (!tween || tween->deleted)
          continue;
 
       tween->running_since += delta_time;


### PR DESCRIPTION
Removing the tween N from the tween N-1 callback resulted in the tween N still being updated, which is unsafe because the subject might have been freed. This will hopefully fix some more widgets write-after-free errors.