### PR TITLE
Add history/favourites to 'Playlist Management' menu

### DIFF
--- a/menu/cbs/menu_cbs_label.c
+++ b/menu/cbs/menu_cbs_label.c
@@ -56,17 +56,43 @@ static int action_bind_label_playlist_collection_entry(
       const char *label, const char *path,
       char *s, size_t len)
 {
-   if (string_is_equal_noncase(path_get_extension(path),
+   const char *playlist_file = NULL;
+
+   if (string_is_empty(path))
+      return 0;
+
+   playlist_file = path_basename(path);
+
+   if (string_is_empty(playlist_file))
+      return 0;
+
+   if (string_is_equal_noncase(path_get_extension(playlist_file),
             file_path_str(FILE_PATH_LPL_EXTENSION_NO_DOT)))
    {
-      char path_base[PATH_MAX_LENGTH];
-      path_base[0] = '\0';
+      /* Handle content history */
+      if (string_is_equal(playlist_file, file_path_str(FILE_PATH_CONTENT_HISTORY)))
+         strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_HISTORY_TAB), len);
+      /* Handle favourites */
+      else if (string_is_equal(playlist_file, file_path_str(FILE_PATH_CONTENT_FAVORITES)))
+         strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_FAVORITES_TAB), len);
+      /* Handle collection playlists */
+      else
+      {
+         char playlist_name[PATH_MAX_LENGTH];
 
-      fill_short_pathname_representation_noext(path_base, path,
-            sizeof(path_base));
+         playlist_name[0] = '\0';
 
-      strlcpy(s, path_base, len);
+         strlcpy(playlist_name, playlist_file, sizeof(playlist_name));
+         path_remove_extension(playlist_name);
+
+         strlcpy(s, playlist_name, len);
+      }
    }
+   /* This should never happen, but if it does just set
+    * the label to the file name (it's better than nothing...) */
+   else
+      strlcpy(s, playlist_file, len);
+
    return 0;
 }
 

--- a/menu/cbs/menu_cbs_title.c
+++ b/menu/cbs/menu_cbs_title.c
@@ -90,8 +90,43 @@ static int action_get_title_mixer_stream_actions(const char *path, const char *l
 
 static int action_get_title_deferred_playlist_list(const char *path, const char *label, unsigned menu_type, char *s, size_t len)
 {
-   if (!string_is_empty(path))
-      fill_pathname_base_noext(s, path, len);
+   const char *playlist_file = NULL;
+
+   if (string_is_empty(path))
+      return 0;
+
+   playlist_file = path_basename(path);
+
+   if (string_is_empty(playlist_file))
+      return 0;
+
+   if (string_is_equal_noncase(path_get_extension(playlist_file),
+            file_path_str(FILE_PATH_LPL_EXTENSION_NO_DOT)))
+   {
+      /* Handle content history */
+      if (string_is_equal(playlist_file, file_path_str(FILE_PATH_CONTENT_HISTORY)))
+         strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_HISTORY_TAB), len);
+      /* Handle favourites */
+      else if (string_is_equal(playlist_file, file_path_str(FILE_PATH_CONTENT_FAVORITES)))
+         strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_FAVORITES_TAB), len);
+      /* Handle collection playlists */
+      else
+      {
+         char playlist_name[PATH_MAX_LENGTH];
+
+         playlist_name[0] = '\0';
+
+         strlcpy(playlist_name, playlist_file, sizeof(playlist_name));
+         path_remove_extension(playlist_name);
+
+         strlcpy(s, playlist_name, len);
+      }
+   }
+   /* This should never happen, but if it does just set
+    * the label to the file name (it's better than nothing...) */
+   else
+      strlcpy(s, playlist_file, len);
+
    return 0;
 }
 


### PR DESCRIPTION
## Description

At present, the `Playlist Management` interface only includes 'collection' playlists. This means it is impossible to set the 'Label Display Mode` (PR #9214) for history/favourites playlists. It also means there is no way to bulk-reset core associations for history/favourites.

This PR simply adds entries for history/favourites to the `Playlist Management` menu. They can now be managed like any other playlist - but note that the `Default Core` option is omitted when configuring history/favourites, since this is irrelevant for mixed content playlists.

This PR also fixes two unrelated bugs:

- RetroArch would previously show non-playlist files in the `Playlists` menu *if* they contained `.lpl` *anywhere* in the filename. We now correctly filter based upon `.lpl` file *extensions*.

- The 'Label Display Mode` was previously ignored for playlist entries without labels. It now always applies even when using the content file name as the display name.

## Related Issues

This closes #9235
