### PR TITLE
Revert "Update msg_hash_pl.h"

### DIFF
--- a/intl/msg_hash_pl.h
+++ b/intl/msg_hash_pl.h
@@ -3294,6 +3294,10 @@ MSG_HASH(
 MSG_HASH(MENU_ENUM_SUBLABEL_CHEAT_APPLY_CHANGES,
       "Zmiany kodu odniosą skutek natychmiast.")
 MSG_HASH(
+      MENU_ENUM_SUBLABEL_CHEAT_FILE_LOAD,
+      "Załaduj plik oszukiwać."
+      )
+MSG_HASH(
       MENU_ENUM_SUBLABEL_CHEAT_FILE_SAVE_AS,
       "Zapisz bieżące kody jako plik składowania."
       )
@@ -4223,39 +4227,3 @@ MSG_HASH(
     MENU_ENUM_SUBLABEL_QUIT_PRESS_TWICE,
     "Naciśnij dwukrotnie klawisz skrótu, aby wyjść z RetroArch."
      )
-MSG_HASH(
-    MENU_ENUM_LABEL_VALUE_GLOBAL_CORE_OPTIONS,
-    "Użyj pliku globalnych opcji podstawowych"
-    )
-MSG_HASH(
-    MENU_ENUM_SUBLABEL_GLOBAL_CORE_OPTIONS,
-    "Zapisz wszystkie opcje rdzenia w pliku wspólnych ustawień (retroarch-core-options.cfg). Po wyłączeniu opcje dla każdego rdzenia zostaną zapisane w osobnym folderze/pliku specyficznym dla rdzenia w katalogu „Config” RetroArch."
-    )
-MSG_HASH(
-    MENU_ENUM_SUBLABEL_REWIND_BUFFER_SIZE_STEP,
-    "Za każdym razem, gdy zwiększysz lub zmniejszysz wartość rozmiaru bufora przewijania za pomocą tego interfejsu, zmieni się on o tę wartość"
-    )
-MSG_HASH(
-    MENU_ENUM_SUBLABEL_REWIND_BUFFER_SIZE,
-    "Ilość pamięci (w MB) do zarezerwowania dla bufora przewijania. Zwiększenie tego zwiększy ilość historii przewijania."
-    )
-MSG_HASH(
-    MENU_ENUM_SUBLABEL_INPUT_OVERLAY_SHOW_MOUSE_CURSOR,
-    "Pokaż kursor myszy podczas korzystania z nakładki ekranowej."
-    )
-MSG_HASH(
-    MENU_ENUM_LABEL_VALUE_CHEAT_START_OR_CONT,
-    "Rozpocznij lub kontynuuj wyszukiwanie kodów"
-    )
- MSG_HASH(
-    MENU_ENUM_SUBLABEL_CHEAT_FILE_LOAD,
-    "Załaduj plik kodów i zastąp istniejące kody."
-    )
- MSG_HASH(
-    MENU_ENUM_SUBLABEL_CHEAT_APPLY_AFTER_LOAD,
-    "Automatyczne stosowanie kodów podczas ładowania gry."
-    )
-MSG_HASH(
-    MENU_ENUM_SUBLABEL_CHEAT_APPLY_AFTER_TOGGLE,
-    "Zastosuj kody natychmiast po przełączeniu."
-    )


### PR DESCRIPTION
Reverts libretro/RetroArch#9270

It could use a correction of many things, because some texts cannot be logically translated into Polish, just stupid. Google Translator helped me a lot in translating some non-translatable technical words that are not present in PL IT nomenclature.

