### PR TITLE
workaround for glcore crash with Mesa

### DIFF
--- a/gfx/drivers_context/wgl_ctx.c
+++ b/gfx/drivers_context/wgl_ctx.c
@@ -290,11 +290,18 @@ static void create_gl_context(HWND hwnd, bool *quit)
          versions = gl_versions;
          version_rows = gl_version_rows;
 
-         /* try each version, starting with the highest first */
+         /* only try higher versions when core_context is true */
+         if (!core_context)
+            version_rows = 1;
+
+         /* try versions from highest down to requested version */
          for (i = 0; i < version_rows; i++)
          {
-            attribs[1] = versions[i][0];
-            attribs[3] = versions[i][1];
+            if (core_context)
+            {
+               attribs[1] = versions[i][0];
+               attribs[3] = versions[i][1];
+            }
 
             context = pcreate_context(win32_hdc, NULL, attribs);
 

--- a/gfx/drivers_context/x_ctx.c
+++ b/gfx/drivers_context/x_ctx.c
@@ -923,6 +923,9 @@ static bool gfx_ctx_x_set_video_mode(void *data,
                         break;
                      }
 
+                     glXMakeContextCurrent(g_x11_dpy, None, None, NULL);
+                     glXDestroyContext(g_x11_dpy, x->g_ctx);
+
                      RARCH_LOG("[GLX]: Not running Mesa, trying higher versions...\n");
                   }
                   else


### PR DESCRIPTION
## (Updated) Description

#9250 caused glcore to break on Mesa drivers because of
 - an `exit` call in the error handler
 - a [2 year old bug](https://bugs.freedesktop.org/show_bug.cgi?id=99781)

This PR fixes the first part and works around the second by trying the requested version first, detecting Mesa and only searching for higher versions for non-Mesa drivers.

Mesa seems to always return the highest compatible version anyways, so it doesn't lose out.
Ideally the workaround will be removed in the future, which is why I didn't fiddle it into the loop but wrote it as a perfectly select-and-deletable block of code.

I also added all the verbose error logging @bparker06 requested and fixed an issue where `attribs` could be garbled.

## Related Issues

Fixes #9277

## Related Pull Requests

#9250

## Reviewers
@bparker06 @asavah