### PR TITLE
Added new USB gamepad for Wii: Retrode 2

### DIFF
--- a/griffin/griffin.c
+++ b/griffin/griffin.c
@@ -727,6 +727,7 @@ INPUT (HID)
 #include "../input/connect/connect_wiiugca.c"
 #include "../input/connect/connect_ps2adapter.c"
 #include "../input/connect/connect_psxadapter.c"
+#include "../input/connect/connect_retrode.c"
 #endif
 
 /*============================================================

--- a/input/connect/connect_retrode.c
+++ b/input/connect/connect_retrode.c
@@ -97,19 +97,11 @@ static int16_t hidpad_retrode_get_axis(void *data, unsigned axis)
 
    /* map Retrode values to a known gamepad (VID=0x0079, PID=0x0011) */
    if (val == 0x9C)
-   {
-       /* axis=0 left, axis=1 up */
-       val = 0x00;
-   }
+       val = 0x00; /* axis=0 left, axis=1 up */
    else if (val == 0x64)
-   {
-       /* axis=0 right, axis=1 down */
-       val = 0xFF;
-   }
+       val = 0xFF; /* axis=0 right, axis=1 down */
    else
-   {
        val = 0x7F; /* no button pressed */
-   }
 
    val = (val << 8) - 0x8000;
 
@@ -166,7 +158,7 @@ static void hidpad_retrode_packet_handler(void *data, uint8_t *packet, uint16_t 
     */
    device1234 = port_device[packet[1] - 1];
 
-   if (device1234 == NULL)
+   if (!device1234)
       return;
 
    memcpy(device1234->data, packet, size);

--- a/input/connect/connect_retrode.c
+++ b/input/connect/connect_retrode.c
@@ -1,0 +1,206 @@
+/*  RetroArch - A frontend for libretro.
+ *  Copyright (C) 2013-2014 - Jason Fetters
+ *  Copyright (C) 2011-2017 - Daniel De Matteis
+ *
+ *  RetroArch is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  RetroArch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with RetroArch.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include <boolean.h>
+#include "joypad_connection.h"
+
+#include "../input_defines.h"
+
+static int port_count = 0;
+
+/* store device for each port */
+static struct hidpad_retrode_data* port_device[4];
+
+struct hidpad_retrode_data
+{
+   struct pad_connection* connection;
+   uint8_t data[64];
+   uint32_t slot;
+   uint32_t buttons;
+};
+
+static void* hidpad_retrode_init(void *data, uint32_t slot, hid_driver_t *driver)
+{
+   struct pad_connection* connection = (struct pad_connection*)data;
+   struct hidpad_retrode_data* device    = (struct hidpad_retrode_data*)
+      calloc(1, sizeof(struct hidpad_retrode_data));
+
+   if (!device)
+      return NULL;
+
+   if (!connection)
+   {
+      free(device);
+      return NULL;
+   }
+
+   device->connection   = connection;
+   device->slot         = slot;
+
+   port_device[port_count] = device;
+   port_count++;
+
+   return device;
+}
+
+static void hidpad_retrode_deinit(void *data)
+{
+   struct hidpad_retrode_data *device = (struct hidpad_retrode_data*)data;
+
+   if (device)
+      free(device);
+
+   port_count = 0;
+   port_device[0] = NULL;
+   port_device[1] = NULL;
+   port_device[2] = NULL;
+   port_device[3] = NULL;
+}
+
+static void hidpad_retrode_get_buttons(void *data, input_bits_t *state)
+{
+    struct hidpad_retrode_data *device = (struct hidpad_retrode_data*)data;
+    if (device)
+    {
+        BITS_COPY16_PTR(state, device->buttons);
+    }
+    else
+        BIT256_CLEAR_ALL_PTR(state);
+}
+
+static int16_t hidpad_retrode_get_axis(void *data, unsigned axis)
+{
+   int val;
+   struct hidpad_retrode_data *device = (struct hidpad_retrode_data*)data;
+
+   if (!device || axis >= 2)
+      return 0;
+
+   val = device->data[2 + axis];
+
+   /* map Retrode values to a known gamepad (VID=0x0079, PID=0x0011) */
+   if (val == 0x9C)
+   {
+       /* axis=0 left, axis=1 up */
+       val = 0x00;
+   }
+   else if (val == 0x64)
+   {
+       /* axis=0 right, axis=1 down */
+       val = 0xFF;
+   }
+   else
+   {
+       val = 0x7F; /* no button pressed */
+   }
+
+   val = (val << 8) - 0x8000;
+
+   return (abs(val) > 0x1000) ? val : 0;
+}
+
+static void hidpad_retrode_packet_handler(void *data, uint8_t *packet, uint16_t size)
+{
+   uint32_t i, pressed_keys;
+   static const uint32_t button_mapping[8] =
+   {
+           RETRO_DEVICE_ID_JOYPAD_B,
+           RETRO_DEVICE_ID_JOYPAD_Y,
+           RETRO_DEVICE_ID_JOYPAD_SELECT,
+           RETRO_DEVICE_ID_JOYPAD_START,
+           RETRO_DEVICE_ID_JOYPAD_A,
+           RETRO_DEVICE_ID_JOYPAD_X,
+           RETRO_DEVICE_ID_JOYPAD_L,
+           RETRO_DEVICE_ID_JOYPAD_R
+   };
+   struct hidpad_retrode_data *device = (struct hidpad_retrode_data*)data;
+   struct hidpad_retrode_data *device1234;
+
+   if (!device)
+      return;
+
+   /*
+    * packet[1] contains Retrode port number
+    * 1 = left SNES
+    * 2 = right SNES
+    * 3 = left Genesis/MD
+    * 4 = right Genesis/MD
+    */
+
+   /* for port 1 only */
+   /*
+   if (packet[1] != 1)
+          return;
+
+   memcpy(device->data, packet, size);
+
+   device->buttons = 0;
+
+   pressed_keys = device->data[4];
+
+   for (i = 0; i < 8; i ++)
+      if (button_mapping[i] != NO_BTN)
+         device->buttons |= (pressed_keys & (1 << i)) ? (1 << button_mapping[i]) : 0;
+   */
+
+   /*
+    * find instance which handles specific port
+    * (wiiusb_hid_read_cb calls first instance only, so need to delegate)
+    */
+   device1234 = port_device[packet[1] - 1];
+
+   if (device1234 == NULL)
+      return;
+
+   memcpy(device1234->data, packet, size);
+
+   device1234->buttons = 0;
+
+   pressed_keys = device1234->data[4];
+
+   for (i = 0; i < 8; i ++)
+      if (button_mapping[i] != NO_BTN)
+          device1234->buttons |= (pressed_keys & (1 << i)) ? (1 << button_mapping[i]) : 0;
+}
+
+static void hidpad_retrode_set_rumble(void *data,
+      enum retro_rumble_effect effect, uint16_t strength)
+{
+    (void)data;
+    (void)effect;
+    (void)strength;
+}
+
+const char * hidpad_retrode_get_name(void *data)
+{
+    (void)data;
+    /* For now we return a single static name */
+    return "Retrode";
+}
+
+pad_connection_interface_t pad_connection_retrode = {
+   hidpad_retrode_init,
+   hidpad_retrode_deinit,
+   hidpad_retrode_packet_handler,
+   hidpad_retrode_set_rumble,
+   hidpad_retrode_get_buttons,
+   hidpad_retrode_get_axis,
+   hidpad_retrode_get_name,
+};

--- a/input/connect/joypad_connection.c
+++ b/input/connect/joypad_connection.c
@@ -114,6 +114,7 @@ int32_t pad_connection_pad_init(joypad_connection_t *joyconn,
       { "PS2/PSX Controller Adapter",    0,     0,  &pad_connection_ps2adapter },
       { "PSX to PS3 Controller Adapter", 0,     0,  &pad_connection_psxadapter },
       { "Mayflash DolphinBar",           0,     0,  &pad_connection_wii },
+      { "Retrode",                       0,     0,  &pad_connection_retrode },
       { 0, 0}
    };
    joypad_connection_t *s = NULL;
@@ -146,6 +147,8 @@ int32_t pad_connection_pad_init(joypad_connection_t *joyconn,
    pad_map[9].pid         = PID_PCS_PSX2PS3;
    pad_map[10].vid        = 1406;
    pad_map[10].pid        = 774;
+   pad_map[11].vid        = VID_RETRODE;
+   pad_map[11].pid        = PID_RETRODE;
 
    if (s)
    {

--- a/input/connect/joypad_connection.h
+++ b/input/connect/joypad_connection.h
@@ -39,6 +39,7 @@
 #define VID_PCS           SWAP_IF_BIG(0x0810)
 #define VID_PS3_CLONE     SWAP_IF_BIG(0x0313)
 #define VID_SNES_CLONE    SWAP_IF_BIG(0x081f)
+#define VID_RETRODE       SWAP_IF_BIG(0x0403)
 
 #define PID_NONE          0x0000
 #define PID_NINTENDO_PRO  SWAP_IF_BIG(0x0330)
@@ -50,6 +51,7 @@
 #define PID_NINTENDO_GCA  SWAP_IF_BIG(0x0337)
 #define PID_PCS_PS2PSX    SWAP_IF_BIG(0x0001)
 #define PID_PCS_PSX2PS3   SWAP_IF_BIG(0x0003)
+#define PID_RETRODE       SWAP_IF_BIG(0x97c1)
 
 struct joypad_connection
 {
@@ -80,6 +82,7 @@ extern pad_connection_interface_t pad_connection_nesusb;
 extern pad_connection_interface_t pad_connection_wiiugca;
 extern pad_connection_interface_t pad_connection_ps2adapter;
 extern pad_connection_interface_t pad_connection_psxadapter;
+extern pad_connection_interface_t pad_connection_retrode;
 
 int32_t pad_connection_pad_init(joypad_connection_t *joyconn,
    const char* name, uint16_t vid, uint16_t pid,


### PR DESCRIPTION
## Description
I added Retrode 2 support for the Wii version. Retrode 2 is a USB adapter that allows you to attach 4 classic gamepads (2x SNES, 2x Genesis/MD)

To support all 4 gamepads it was necessary to modify: input/drivers_hid/wiiusb_hid.c
This way four gamepads appear in RA's device list.

input/connect/connect_retrode.c:
Only the first instance is called by the USB handler, so it has to delegate to the other instances.
This is either very clever or a hack.

It works fine with the cores snes9x2010 and genesis_plus_gx.
I can also still use my standard USB gamepad at the same time:
VID=0x0079, PID=0x0011 (not unqiue ID, mine is a Speedlink Hornet)

## Related Issues

## Related Pull Requests

## Reviewers
@netux79 Thanks for the USB Wii support. Hope I modified the right places.