### PR TITLE
(XMB/Ozone/GLUI) Prevent display of main menu 'Quick Menu' entry when dummy core is loaded

### DIFF
--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -2069,8 +2069,11 @@ static int materialui_list_push(void *data, void *userdata,
                   !string_is_equal(system->info.library_name,
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NO_CORE)))
             {
-               entry.enum_idx      = MENU_ENUM_LABEL_CONTENT_SETTINGS;
-               menu_displaylist_setting(&entry);
+               if (!rarch_ctl(RARCH_CTL_IS_DUMMY_CORE, NULL))
+               {
+                  entry.enum_idx      = MENU_ENUM_LABEL_CONTENT_SETTINGS;
+                  menu_displaylist_setting(&entry);
+               }
             }
 
             if (system->load_no_content)

--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -837,8 +837,11 @@ static int ozone_list_push(void *data, void *userdata,
                   !string_is_equal(system->info.library_name,
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NO_CORE)))
             {
-               entry.enum_idx      = MENU_ENUM_LABEL_CONTENT_SETTINGS;
-               menu_displaylist_setting(&entry);
+               if (!rarch_ctl(RARCH_CTL_IS_DUMMY_CORE, NULL))
+               {
+                  entry.enum_idx      = MENU_ENUM_LABEL_CONTENT_SETTINGS;
+                  menu_displaylist_setting(&entry);
+               }
             }
 
             if (system->load_no_content)

--- a/menu/drivers/stripes.c
+++ b/menu/drivers/stripes.c
@@ -4199,8 +4199,11 @@ static int stripes_list_push(void *data, void *userdata,
                   !string_is_equal(system->info.library_name,
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NO_CORE)))
             {
-               entry.enum_idx      = MENU_ENUM_LABEL_CONTENT_SETTINGS;
-               menu_displaylist_setting(&entry);
+               if (!rarch_ctl(RARCH_CTL_IS_DUMMY_CORE, NULL))
+               {
+                  entry.enum_idx      = MENU_ENUM_LABEL_CONTENT_SETTINGS;
+                  menu_displaylist_setting(&entry);
+               }
             }
 
             if (system->load_no_content)

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -5683,8 +5683,11 @@ static int xmb_list_push(void *data, void *userdata,
                   !string_is_equal(system->info.library_name,
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NO_CORE)))
             {
-               entry.enum_idx      = MENU_ENUM_LABEL_CONTENT_SETTINGS;
-               menu_displaylist_setting(&entry);
+               if (!rarch_ctl(RARCH_CTL_IS_DUMMY_CORE, NULL))
+               {
+                  entry.enum_idx      = MENU_ENUM_LABEL_CONTENT_SETTINGS;
+                  menu_displaylist_setting(&entry);
+               }
             }
 
             if (system->load_no_content)


### PR DESCRIPTION
## Description

At present, `XMB`, `Ozone` and `GLUI` show an erroneous `Quick Menu` entry on the main menu on Switch (and perhaps other platforms?) when no core or content is loaded. This is due to a missing `if (!rarch_ctl(RARCH_CTL_IS_DUMMY_CORE, NULL))` check in the main menu display list override code in each of these menu drivers.

This trivial PR fixes the issue.