### PR TITLE
fix double free()

### DIFF
--- a/tasks/task_save.c
+++ b/tasks/task_save.c
@@ -171,7 +171,6 @@ static void autosave_thread(void *data)
             filestream_write(file, save->buffer, save->bufsize);
             filestream_flush(file);
             filestream_close(file);
-            free(file);
          }
       }
 


### PR DESCRIPTION
## Description

Under certain conditions retroarch crashes with ` free(): double free detected in tcache 2`.
For me it happened mostly with parallel-n64 and mupen64plus-libretro-nx cores.

gdb backtrace
```
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007f80e7030548 in __GI_abort () at abort.c:79
#2  0x00007f80e7088587 in __libc_message (action=action@entry=do_abort, fmt=fmt@entry=0x7f80e718eeec "%s\n") at ../sysdeps/posix/libc_fatal.c:181
#3  0x00007f80e708faea in malloc_printerr (str=str@entry=0x7f80e7190a88 "free(): double free detected in tcache 2") at malloc.c:5332
#4  0x00007f80e709187d in _int_free (av=0x7f8054000020, p=0x7f8054005760, have_lock=0) at malloc.c:4201
#5  0x0000563dc147935c in autosave_thread (data=0x563dc4839e10) at tasks/task_save.c:174
#6  0x0000563dc16edcb2 in thread_wrap (data_=0x563dc483ba90) at libretro-common/rthreads/rthreads.c:146
#7  0x00007f80e99f3004 in start_thread (arg=<optimized out>) at pthread_create.c:479
#8  0x00007f80e7106b2f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```

The cause is that in https://github.com/libretro/RetroArch/blob/master/tasks/task_save.c#L174 `free(file)` is called but filestream_close() already has freed it here https://github.com/libretro/RetroArch/blob/master/libretro-common/streams/file_stream.c#L474

## Reviewers
@twinaphex 
