### PR TITLE
Bug caused by typo

### DIFF
--- a/input/drivers/switch_input.c
+++ b/input/drivers/switch_input.c
@@ -398,7 +398,7 @@ static int16_t switch_input_state(void *data,
                }
                if (((float)abs(sw->joypad->axis(joypad_info.joy_idx, joyaxis)) / 0x8000) > joypad_info.axis_threshold)
                {
-                  ret |= (1 << 1);
+                  ret |= (1 << i);
                   continue;
                }
             }


### PR DESCRIPTION
This typo causes a bug on the Nintendo switch where every analog direction you press results in the button Y being pressed.

Here is the fix

I opened this issue due to this bug

https://github.com/libretro/RetroArch/issues/9293