### PR TITLE
(RGUI) Add marker for currently selected item in drop down lists

### DIFF
--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -598,7 +598,8 @@ enum rgui_symbol_type
    RGUI_SYMBOL_BATTERY_80,
    RGUI_SYMBOL_BATTERY_60,
    RGUI_SYMBOL_BATTERY_40,
-   RGUI_SYMBOL_BATTERY_20
+   RGUI_SYMBOL_BATTERY_20,
+   RGUI_SYMBOL_CHECKMARK
 };
 
 /* All custom symbols must have dimensions
@@ -745,6 +746,21 @@ static const uint8_t rgui_symbol_data_battery_20[FONT_WIDTH * FONT_HEIGHT] = {
       0, 1, 0, 0, 1,
       0, 1, 1, 1, 1, /* Baseline */
       0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0};
+
+/* Note: This is not actually a 'checkmark' - we don't
+ * have enough pixels to draw one effectively. The 'icon'
+ * is merely named according to its function... */
+static const uint8_t rgui_symbol_data_checkmark[FONT_WIDTH * FONT_HEIGHT] = {
+      0, 1, 1, 0, 0,
+      0, 1, 1, 0, 0,
+      0, 1, 1, 0, 0,
+      0, 1, 1, 0, 0,
+      0, 1, 1, 0, 0,
+      0, 1, 1, 0, 0,
+      0, 1, 1, 0, 0,
+      0, 1, 1, 0, 0, /* Baseline */
+      0, 1, 1, 0, 0,
       0, 0, 0, 0, 0};
 
 /* ==============================
@@ -2547,6 +2563,8 @@ static const uint8_t *rgui_get_symbol_data(enum rgui_symbol_type symbol)
          return rgui_symbol_data_battery_40;
       case RGUI_SYMBOL_BATTERY_20:
          return rgui_symbol_data_battery_20;
+      case RGUI_SYMBOL_CHECKMARK:
+         return rgui_symbol_data_checkmark;
       default:
          break;
    }
@@ -3519,6 +3537,11 @@ static void rgui_render(void *data,
                   type_str_buf,
                   entry_color, rgui->colors.shadow_color);
          }
+         /* Print marker for currently selected item in
+          * drop down lists, if required */
+         else if (entry.checked)
+            blit_symbol(fb_width, x + FONT_WIDTH_STRIDE, y, RGUI_SYMBOL_CHECKMARK,
+                  entry_color, rgui->colors.shadow_color);
 
          /* Print selection marker, if required */
          if (entry_selected)


### PR DESCRIPTION
## Description

This is a trivial thing, but it's bothered me for a while now...

When choosing option values via a drop down list, XMB and Ozone display a marker for the currently selected item - e.g.:

![Screenshot_2019-08-13_15-26-17](https://user-images.githubusercontent.com/38211560/62950538-243fdd80-bde0-11e9-951e-e3e8d4fa0c33.png)

![Screenshot_2019-08-13_13-38-24](https://user-images.githubusercontent.com/38211560/62950544-273ace00-bde0-11e9-8866-24e03391cf18.png)

RGUI does not.

This PR simply adds one - it's not a checkmark (we don't have enough pixels for this), but it's quite workable:

![Screenshot_2019-08-13_14-35-25](https://user-images.githubusercontent.com/38211560/62950606-46396000-bde0-11e9-857c-8fcaab43825a.png)

![Screenshot_2019-08-13_14-35-53](https://user-images.githubusercontent.com/38211560/62950614-49345080-bde0-11e9-828e-ca32d8ca92db.png)
