### PR TITLE
Midi: fix MT-32 delay and ALSA off pitch playback

### DIFF
--- a/midi/drivers/alsa_midi.c
+++ b/midi/drivers/alsa_midi.c
@@ -435,7 +435,7 @@ static bool alsa_midi_write(void *p, const midi_event_t *event)
    else if (ev.type == SND_SEQ_EVENT_PITCHBEND)
    {
       ev.data.control.channel = event->data[0] & 0x0F;
-      ev.data.control.value   = event->data[1] | (event->data[2] << 7);
+      ev.data.control.value   = (event->data[1] | (event->data[2] << 7)) - 0x2000;
    }
    else if (ev.type == SND_SEQ_EVENT_SYSEX)
    {

--- a/retroarch.c
+++ b/retroarch.c
@@ -14733,7 +14733,9 @@ bool midi_driver_write(uint8_t byte, uint32_t delta_time)
                midi_drv_output_event.data_size);
 #endif
 
-      midi_drv_output_pending = true;
+      midi_drv_output_pending             = true;
+      midi_drv_output_event.data_size     = 0;
+      midi_drv_output_event.delta_time    = 0;
    }
 
    return true;


### PR DESCRIPTION
## Description
Fix two issues with MIDI :
- a logic error in SysEx processing adds multiple seconds playback delay on most MT-32 games
- pitch bend is incorrectly set by ALSA driver causing music to sound completely wrong