### PR TITLE
fix garbled text in logging on Windows

### DIFF
--- a/gfx/drivers_context/wgl_ctx.c
+++ b/gfx/drivers_context/wgl_ctx.c
@@ -357,12 +357,14 @@ static void create_gl_context(HWND hwnd, bool *quit)
       wglGetExtensionsStringARB = (const char *(WINAPI *) (HDC))
          gfx_ctx_wgl_get_proc_address("wglGetExtensionsStringARB");
       if (wglGetExtensionsStringARB)
-         extensions = wglGetExtensionsStringARB(win32_hdc);
-      RARCH_LOG("[WGL] extensions: %s\n", extensions);
-      if (wgl_has_extension("WGL_EXT_swap_control_tear", extensions))
       {
-         RARCH_LOG("[WGL]: Adaptive VSync supported.\n");
-         wgl_adaptive_vsync = true;
+         extensions = wglGetExtensionsStringARB(win32_hdc);
+         RARCH_LOG("[WGL] extensions: %s\n", extensions);
+         if (wgl_has_extension("WGL_EXT_swap_control_tear", extensions))
+         {
+            RARCH_LOG("[WGL]: Adaptive VSync supported.\n");
+            wgl_adaptive_vsync = true;
+         }
       }
    }
 }

--- a/verbosity.c
+++ b/verbosity.c
@@ -218,9 +218,27 @@ void RARCH_LOG_V(const char *tag, const char *fmt, va_list ap)
 #else
    FILE *fp = (FILE*)log_file_fp;
 #if defined(HAVE_QT) || defined(__WINRT__)
+   int ret;
    char buffer[256];
    buffer[0] = '\0';
-   vsnprintf(buffer, sizeof(buffer), fmt, ap);
+   ret = vsnprintf(buffer, sizeof(buffer), fmt, ap);
+
+   /* ensure null termination and line break in error case */
+   if (ret < 0)
+   {
+      int end;
+      buffer[sizeof buffer - 1]  = '\0';
+      end = strlen(buffer) - 1;
+      if (end >= 0)
+      {
+         buffer[end] = '\n';
+      }
+      else
+      {
+         buffer[0] = '\n';
+         buffer[1] = '\0';
+      }
+   }
 
    if (fp)
    {


### PR DESCRIPTION
##  Issue Description
I always wondered why the WGL extension output looked garbled and was missing a line break:
`
[INFO] [WGL] extensions: WGL_ARB_buffer_region WGL_ARB_create_context WGL_ARB_create_context_no_error WGL_ARB_create_context_profile WGL_ARB_create_context_robustness WGL_ARB_context_flush_control WGL_ARB_extensions_string WGL_ARB_make_current_read WGL_ARB_multisxÛ"[INFO] [WGL]: Adaptive VSync supported.
`

The `xÛ"` is random garbled text, this entry is really `WGL_ARB_multisample` followed by a whole bunch of other extensions.

`RARCH_LOG_V` logging on Windows is limited to 256 characters (though I don't know why) and there's a `vsnprintf` call which fills the buffer.
`vsnprintf` is supposed to trim and null-terminate, but in this very case it errors out for an unknown reason.

## Changes

Add newline and null-termination in the error case, so the output looks like this:
`[INFO] [WGL] extensions: WGL_ARB_buffer_region WGL_ARB_create_context WGL_ARB_create_context_no_error WGL_ARB_create_context_profile WGL_ARB_create_context_robustness WGL_ARB_context_flush_control WGL_ARB_extensions_string WGL_ARB_make_current_read WGL_ARB_mult`
`[INFO] [WGL]: Adaptive VSync supported.`

The change in `wgl_ctx.c` simply prevents a potential null pointer dereference if for some reason `wglGetExtensionsStringARB` does not exist (really not necessary, but it helps clean up static analyzer output).