### PR TITLE
(menu_thumbnail_path) API clean-up + tiny bug fix

### DIFF
--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -1340,7 +1340,8 @@ static void ozone_set_thumbnail_system(void *data, char*s, size_t len)
    if (!ozone)
       return;
 
-   menu_thumbnail_set_system(ozone->thumbnail_path_data, s);
+   menu_thumbnail_set_system(
+         ozone->thumbnail_path_data, s, playlist_get_cached());
 }
 
 static void ozone_get_thumbnail_system(void *data, char*s, size_t len)

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -4260,7 +4260,8 @@ static void rgui_set_thumbnail_system(void *userdata, char *s, size_t len)
    rgui_t *rgui = (rgui_t*)userdata;
    if (!rgui)
       return;
-   menu_thumbnail_set_system(rgui->thumbnail_path_data, s);
+   menu_thumbnail_set_system(
+         rgui->thumbnail_path_data, s, playlist_get_cached());
 }
 
 static void rgui_get_thumbnail_system(void *userdata, char *s, size_t len)

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -1132,7 +1132,8 @@ static void xmb_set_thumbnail_system(void *data, char*s, size_t len)
    if (!xmb)
       return;
 
-   menu_thumbnail_set_system(xmb->thumbnail_path_data, s);
+   menu_thumbnail_set_system(
+         xmb->thumbnail_path_data, s, playlist_get_cached());
 }
 
 static void xmb_get_thumbnail_system(void *data, char*s, size_t len)

--- a/menu/menu_thumbnail_path.h
+++ b/menu/menu_thumbnail_path.h
@@ -83,9 +83,12 @@ bool menu_thumbnail_is_enabled(menu_thumbnail_path_data_t *path_data, enum menu_
 
 /* Sets current 'system' (default database name).
  * Returns true if 'system' is valid.
+ * If playlist is provided, extracts system-specific
+ * thumbnail assignment metadata (required for accurate
+ * usage of menu_thumbnail_is_enabled())
  * > Used as a fallback when individual content lacks an
  *   associated database name */
-bool menu_thumbnail_set_system(menu_thumbnail_path_data_t *path_data, const char *system);
+bool menu_thumbnail_set_system(menu_thumbnail_path_data_t *path_data, const char *system, playlist_t *playlist);
 
 /* Sets current thumbnail content according to the specified label.
  * Returns true if content is valid */

--- a/tasks/task_pl_thumbnail_download.c
+++ b/tasks/task_pl_thumbnail_download.c
@@ -276,7 +276,8 @@ static void task_pl_thumbnail_download_handler(retro_task_t *task)
             if (!pl_thumb->thumbnail_path_data)
                goto task_finished;
             
-            if (!menu_thumbnail_set_system(pl_thumb->thumbnail_path_data, pl_thumb->system))
+            if (!menu_thumbnail_set_system(
+                  pl_thumb->thumbnail_path_data, pl_thumb->system, pl_thumb->playlist))
                goto task_finished;
             
             /* All good - can start iterating */
@@ -565,7 +566,8 @@ static void task_pl_entry_thumbnail_download_handler(retro_task_t *task)
             if (!pl_thumb->thumbnail_path_data)
                goto task_finished;
             
-            if (!menu_thumbnail_set_system(pl_thumb->thumbnail_path_data, pl_thumb->system))
+            if (!menu_thumbnail_set_system(
+                  pl_thumb->thumbnail_path_data, pl_thumb->system, pl_thumb->playlist))
                goto task_finished;
             
             if (!menu_thumbnail_set_content_playlist(


### PR DESCRIPTION
## Description

With the advent of per-playlist thumbnails (PR #9310), the `menu_thumbnail_set_system()` function in `menu_thumbnail_path.h/.c` now requires access to playlist thumbnail metadata. At present, this is handled internally via `playlist_get_cached()`. This is convenient, but on reflection I think it unnecessarily obfuscates the code - i.e. it 'hides away' something that should be made obvious to developers.

This PR therefore changes the `menu_thumbnail_set_system()` function such that the required playlist is provided via an argument - so devs know exactly which playlist is being accessed, and `menu_thumbnail_path.h/.c` is properly disentangled from any other menu actions.

This PR also fixes a tiny cosmetic bug: when using the Quick Menu `Download Thumbnails` option, the thumbnail display wasn't always immediately refreshed (upon successful download) when using a per-playlist thumbnail override.

## Related Pull Requests

#9310

