### PR TITLE
add --set-shader and overhaul shader loading logic

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -1204,8 +1204,6 @@ static struct config_path_setting *populate_settings_path(settings_t *settings, 
          settings->paths.path_core_options, false, NULL, true);
    SETTING_PATH("libretro_info_path",
          settings->paths.path_libretro_info, false, NULL, true);
-   SETTING_PATH("video_shader",
-         settings->paths.path_shader, false, NULL, true);
    SETTING_PATH("content_database_path",
          settings->paths.path_content_database, false, NULL, true);
    SETTING_PATH("cheat_database_path",
@@ -2179,7 +2177,6 @@ void config_set_defaults(void)
    *settings->paths.path_content_image_history   = '\0';
    *settings->paths.path_content_video_history   = '\0';
    *settings->paths.path_cheat_settings    = '\0';
-   *settings->paths.path_shader            = '\0';
 #ifndef IOS
    *settings->arrays.bundle_assets_src = '\0';
    *settings->arrays.bundle_assets_dst = '\0';
@@ -4102,11 +4099,6 @@ bool config_save_overrides(int override_type)
 
       for (i = 0; i < (unsigned)path_settings_size; i++)
       {
-
-         /* blacklist video_shader, better handled by shader presets*/
-         /* to-do: add setting to control blacklisting */
-         if (string_is_equal(path_settings[i].ident, "video_shader"))
-            continue;
          if (!string_is_equal(path_settings[i].ptr, path_overrides[i].ptr))
          {
             RARCH_LOG("   original: %s=%s\n",

--- a/configuration.h
+++ b/configuration.h
@@ -625,7 +625,6 @@ typedef struct settings
       char path_content_video_history[PATH_MAX_LENGTH];
       char path_libretro_info[PATH_MAX_LENGTH];
       char path_cheat_settings[PATH_MAX_LENGTH];
-      char path_shader[PATH_MAX_LENGTH];
       char path_font[PATH_MAX_LENGTH];
       char path_rgui_theme_preset[PATH_MAX_LENGTH];
 

--- a/frontend/frontend_salamander.c
+++ b/frontend/frontend_salamander.c
@@ -156,7 +156,7 @@ static void salamander_init(char *s, size_t len)
 
    if (!config_exists)
    {
-      config_file_t *conf = (config_file_t*)config_file_new_alloc();
+      config_file_t *conf = config_file_new_alloc();
 
       if (conf)
       {

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -1586,7 +1586,8 @@ static int generic_action_ok(const char *path,
             flush_char = msg_hash_to_str(flush_id);
             menu_shader_manager_set_preset(shader,
                   video_shader_parse_type(action_path),
-                  action_path);
+                  action_path,
+                  true);
          }
 #endif
          break;

--- a/menu/menu_shader.h
+++ b/menu/menu_shader.h
@@ -40,11 +40,12 @@ bool menu_shader_manager_init(void);
  * @shader                   : Shader handle.
  * @type                     : Type of shader.
  * @preset_path              : Preset path to load from.
+ * @apply                    : Whether to apply the shader or just update shader information
  *
  * Sets shader preset.
  **/
 bool menu_shader_manager_set_preset(
-      void *data, enum rarch_shader_type type, const char *preset_path);
+      void *data, enum rarch_shader_type type, const char *preset_path, bool apply);
 
 /**
  * menu_shader_manager_save_preset:

--- a/retroarch.c
+++ b/retroarch.c
@@ -786,7 +786,8 @@ enum
    RA_OPT_LOG_FILE,
    RA_OPT_MAX_FRAMES,
    RA_OPT_MAX_FRAMES_SCREENSHOT,
-   RA_OPT_MAX_FRAMES_SCREENSHOT_PATH
+   RA_OPT_MAX_FRAMES_SCREENSHOT_PATH,
+   RA_OPT_SET_SHADER
 };
 
 enum  runloop_state
@@ -897,7 +898,9 @@ static bool shader_presets_need_reload                          = true;
 #endif
 
 #if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)
-static char runtime_shader_preset[255]                          = {0};
+static char cli_shader[PATH_MAX_LENGTH]                         = {0};
+static bool cli_shader_disable                                  = false;
+static char runtime_shader_preset[PATH_MAX_LENGTH]              = {0};
 #endif
 static char runloop_max_frames_screenshot_path[PATH_MAX_LENGTH] = {0};
 static char runtime_content_path[PATH_MAX_LENGTH]               = {0};
@@ -1300,8 +1303,17 @@ static bool wifi_driver_active                   = false;
 
 /* VIDEO GLOBAL VARIABLES */
 
-/* unset a runtime shader preset */
-static void retroarch_unset_shader_preset(void)
+static void retroarch_set_runtime_shader_preset(const char *arg)
+{
+#if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)
+   if (!string_is_empty(arg))
+      strlcpy(runtime_shader_preset, arg, sizeof(runtime_shader_preset));
+   else
+      runtime_shader_preset[0] = '\0';
+#endif
+}
+
+static void retroarch_unset_runtime_shader_preset(void)
 {
 #if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)
    runtime_shader_preset[0] = '\0';
@@ -2186,44 +2198,87 @@ static const struct cmd_map map[] = {
 };
 #endif
 
+bool retroarch_apply_shader(enum rarch_shader_type type, const char *preset_path)
+{
+#if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)
+   settings_t *settings = configuration_settings;
+   bool ret;
+   bool refresh;
+   char msg[256];
+   const char *preset_file = NULL;
+
+   if (!string_is_empty(preset_path))
+      preset_file = path_basename(preset_path);
+
+   ret = video_driver_set_shader(type, preset_path);
+
+   if (ret)
+   {
+      configuration_set_bool(settings, settings->bools.video_shader_enable, true);
+      retroarch_set_runtime_shader_preset(preset_path);
+
+      /* reflect in shader manager */
+      menu_shader_manager_set_preset(menu_shader_get(), type, preset_path, false);
+
+      /* Display message */
+      snprintf(msg, sizeof(msg),
+            "Shader: \"%s\"", preset_file ? preset_file : "(null)");
+#ifdef HAVE_MENU_WIDGETS
+      if (menu_widgets_inited)
+         menu_widgets_set_message(msg);
+      else
+#endif
+         runloop_msg_queue_push(msg, 1, 120, true, NULL,
+               MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
+      RARCH_LOG("%s \"%s\".\n",
+            msg_hash_to_str(MSG_APPLYING_SHADER),
+            preset_path);
+   }
+   else
+   {
+      retroarch_set_runtime_shader_preset(NULL);
+
+      /* reflect in shader manager */
+      menu_shader_manager_set_preset(menu_shader_get(), type, NULL, false);
+
+      /* Display error message */
+      snprintf(msg, sizeof(msg), "%s %s",
+            msg_hash_to_str(MSG_FAILED_TO_APPLY_SHADER_PRESET),
+            preset_file ? preset_file : "(null)");
+
+      runloop_msg_queue_push(
+            msg, 1, 180, true, NULL,
+            MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_ERROR);
+   }
+
+   return ret;
+#else
+   return false;
+#endif
+}
+
 bool command_set_shader(const char *arg)
 {
 #if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)
-   char msg[256];
-   bool is_preset                  = false;
-   settings_t *settings            = configuration_settings;
-   enum rarch_shader_type     type = video_shader_get_type_from_ext(
-         path_get_extension(arg), &is_preset);
+   enum rarch_shader_type type = video_shader_parse_type(arg);
 
-   if (type == RARCH_SHADER_NONE || !video_shader_is_supported(type))
-      return false;
+   if (!string_is_empty(arg))
+   {
+      if (!video_shader_is_supported(type))
+         return false;
 
-   snprintf(msg, sizeof(msg),
-         "Shader: \"%s\"", arg ? path_basename(arg) : "null");
-#ifdef HAVE_MENU_WIDGETS
-   if (menu_widgets_inited)
-      menu_widgets_set_message(msg);
-   else
-#endif
-      runloop_msg_queue_push(msg, 1, 120, true, NULL,
-            MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
-   RARCH_LOG("%s \"%s\".\n",
-         msg_hash_to_str(MSG_APPLYING_SHADER),
-         arg);
+      /* rebase on shader directory */
+      if (!path_is_absolute(arg))
+      {
+         char abs_arg[PATH_MAX_LENGTH];
+         const char *ref_path = configuration_settings->paths.directory_video_shader;
+         fill_pathname_join(abs_arg,
+               ref_path, arg, sizeof(abs_arg));
+         arg = abs_arg;
+      }
+   }
 
-#if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)
-      if (!string_is_empty(arg))
-         strlcpy(runtime_shader_preset, arg, sizeof(runtime_shader_preset));
-      else
-         runtime_shader_preset[0] = '\0';
-#ifdef HAVE_MENU
-   if (!menu_shader_manager_set_preset(menu_shader_get(), type, arg))
-      return false;
-#endif
-#endif
-   if (settings && !settings->bools.video_shader_enable)
-      settings->bools.video_shader_enable = true;
-   return true;
+   return retroarch_apply_shader(type, arg);
 #else
    return false;
 #endif
@@ -3021,7 +3076,7 @@ static void command_event_deinit_core(bool reinit)
       driver_uninit(DRIVERS_CMD_ALL);
 
    command_event_disable_overrides();
-   retroarch_unset_shader_preset();
+   retroarch_unset_runtime_shader_preset();
 
    if (     runloop_remaps_core_active
          || runloop_remaps_content_dir_active
@@ -4110,7 +4165,7 @@ bool command_event(enum event_command cmd, void *data)
             command_event_runtime_log_deinit();
             command_event_save_auto_state();
             command_event_disable_overrides();
-            retroarch_unset_shader_preset();
+            retroarch_unset_runtime_shader_preset();
 
             if (     runloop_remaps_core_active
                   || runloop_remaps_content_dir_active
@@ -20836,6 +20891,9 @@ static void retroarch_print_help(const char *arg0)
 #endif
    puts("  -s, --save=PATH       Path for save files (*.srm).");
    puts("  -S, --savestate=PATH  Path for the save state files (*.state).");
+   puts("      --set-shader PATH Path to a shader (preset) that will be loaded each time content is loaded.\n"
+        "                        Effectively overrides core shader presets.\n"
+        "                        An empty argument \"\" will disable shader core presets.");
    puts("  -f, --fullscreen      Start the program in fullscreen regardless "
          "of config settings.");
    puts("  -c, --config=FILE     Path for config file."
@@ -20990,6 +21048,7 @@ static void retroarch_parse_input_and_config(int argc, char *argv[])
       { "dualanalog",         1, NULL, 'A' },
       { "device",             1, NULL, 'd' },
       { "savestate",          1, NULL, 'S' },
+      { "set-shader",         1, NULL, RA_OPT_SET_SHADER },
       { "bsvplay",            1, NULL, 'P' },
       { "bsvrecord",          1, NULL, 'R' },
       { "sram-mode",          1, NULL, 'M' },
@@ -21253,6 +21312,26 @@ static void retroarch_parse_input_and_config(int argc, char *argv[])
                      sizeof(global->record.path));
                if (recording_enable)
                   recording_enable = true;
+               break;
+
+            case RA_OPT_SET_SHADER:
+               /* disable auto-shaders */
+               if (string_is_empty(optarg))
+               {
+                  cli_shader_disable = true;
+                  break;
+               }
+
+               /* rebase on shader directory */
+               if (!path_is_absolute(optarg))
+               {
+                  char *ref_path = configuration_settings->paths.directory_video_shader;
+                  fill_pathname_join(cli_shader,
+                        ref_path, optarg, sizeof(cli_shader));
+                  break;
+               }
+
+               strlcpy(cli_shader, optarg, sizeof(cli_shader));
                break;
 
    #ifdef HAVE_DYNAMIC
@@ -22649,12 +22728,8 @@ static bool retroarch_load_shader_preset_internal(
       /* Shader preset exists, load it. */
       RARCH_LOG("[Shaders]: Specific shader preset found at %s.\n",
             shader_path);
-#if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)
-      if (!string_is_empty(shader_path))
-         strlcpy(runtime_shader_preset, shader_path, sizeof(runtime_shader_preset));
-      else
-         runtime_shader_preset[0] = '\0';
-#endif
+      retroarch_set_runtime_shader_preset(shader_path);
+
       free(shader_path);
       return true;
    }
@@ -22743,24 +22818,26 @@ success:
 #endif
 
 /* get the name of the current shader preset */
-char* retroarch_get_shader_preset(void)
+const char* retroarch_get_shader_preset(void)
 {
 #if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)
    settings_t *settings = configuration_settings;
    if (!settings->bools.video_shader_enable)
       return NULL;
 
-   if (shader_presets_need_reload)
-   {
-      retroarch_load_shader_preset();
-      shader_presets_need_reload = false;
-   }
-
    if (!string_is_empty(runtime_shader_preset))
       return runtime_shader_preset;
 
-   if (!string_is_empty(settings->paths.path_shader))
-      return settings->paths.path_shader;
+   /* load auto-shader once, --set-shader works like a global auto-shader */
+   if (shader_presets_need_reload && !cli_shader_disable)
+   {
+      shader_presets_need_reload = false;
+      if (video_shader_is_supported(video_shader_parse_type(cli_shader)))
+         strlcpy(runtime_shader_preset, cli_shader, sizeof(runtime_shader_preset));
+      else
+         retroarch_load_shader_preset(); /* sets runtime_shader_preset */
+      return runtime_shader_preset;
+   }
 #endif
 
    return NULL;
@@ -22951,7 +23028,7 @@ bool retroarch_main_quit(void)
    {
       command_event_save_auto_state();
       command_event_disable_overrides();
-      retroarch_unset_shader_preset();
+      retroarch_unset_runtime_shader_preset();
 
       if (     runloop_remaps_core_active
             || runloop_remaps_content_dir_active
@@ -24752,10 +24829,10 @@ static bool rarch_write_debug_info(void)
 
       if (shader_info.data)
       {
-         if (string_is_equal(shader_info.data->path, settings->paths.path_shader))
-            filestream_printf(file, "      - Video Shader: %s\n", !string_is_empty(settings->paths.path_shader) ? settings->paths.path_shader : "n/a");
+         if (string_is_equal(shader_info.data->path, runtime_shader_preset))
+            filestream_printf(file, "      - Video Shader: %s\n", !string_is_empty(runtime_shader_preset) ? runtime_shader_preset : "n/a");
          else
-            filestream_printf(file, "      - Video Shader: %s (configured for %s)\n", !string_is_empty(shader_info.data->path) ? shader_info.data->path : "n/a", !string_is_empty(settings->paths.path_shader) ? settings->paths.path_shader : "n/a");
+            filestream_printf(file, "      - Video Shader: %s (configured for %s)\n", !string_is_empty(shader_info.data->path) ? shader_info.data->path : "n/a", !string_is_empty(runtime_shader_preset) ? runtime_shader_preset : "n/a");
       }
       else
          filestream_printf(file, "      - Video Shader: n/a\n");

--- a/retroarch.h
+++ b/retroarch.h
@@ -38,6 +38,7 @@
 #endif
 
 #include "audio/audio_defines.h"
+#include "gfx/video_shader_parse.h"
 
 #include "core_type.h"
 #include "core.h"
@@ -306,7 +307,9 @@ bool retroarch_is_forced_fullscreen(void);
 void retroarch_set_current_core_type(
       enum rarch_core_type type, bool explicitly_set);
 
-char* retroarch_get_shader_preset(void);
+bool retroarch_apply_shader(enum rarch_shader_type type, const char *preset_path);
+
+const char* retroarch_get_shader_preset(void);
 
 bool retroarch_is_switching_display_mode(void);
 
@@ -762,7 +765,6 @@ void recording_driver_update_streaming_url(void);
 #include "gfx/video_defines.h"
 #include "gfx/video_coord_array.h"
 #include "gfx/video_filter.h"
-#include "gfx/video_shader_parse.h"
 
 #include "input/input_driver.h"
 #include "input/input_types.h"

--- a/ui/drivers/qt/shaderparamsdialog.cpp
+++ b/ui/drivers/qt/shaderparamsdialog.cpp
@@ -510,7 +510,7 @@ void ShaderParamsDialog::onShaderLoadPresetClicked()
 
    type = video_shader_parse_type(pathData);
 
-   menu_shader_manager_set_preset(menu_shader, type, pathData);
+   menu_shader_manager_set_preset(menu_shader, type, pathData, true);
 }
 
 void ShaderParamsDialog::onShaderResetPass(int pass)


### PR DESCRIPTION
## Issue Description

The way shaders were set and persist had a lot of inherent issues and was very unintuitive.

When loading a core, core shader presets (aka auto-shaders) would be loaded, if there are none, the `video_shader` setting would be used.

The main issue of the `video_shader` setting is how easily it is set and how persistent it is

 - If "Load Shader" in the shader menu was used, it would persist via the `video_shader` setting
 - This also happens when using "Apply Shader"
 - Because it is a setting, it will persist even on restarting RetroArch
 - There is *no way* to clear `video_shader` without editing the config manually

Historically this setting has been causing many issues because incompatible shaders would be loaded, it became so bad the setting had to be cleared via a rudimentary compatibility check (which was later replaced) and it had to be blacklisted from config overrides.

It sounded useful for setting shaders via the `--append-config` CLI option but because core presets had higher priority, it failed to deliver.

### Smaller Issues being adressed

 - There were many cases where the two shader menus weren't syncing up properly
 - If an auto-shader failed loading, the shader menus would still show it
 - Shader presets loaded via the menu don't persist through video reinit if an auto-shader exists
 - The network command interface `SET_SHADER` command wouldn't set the shader if compiled without menu

## Changes

The `video_shader` setting is completely removed.
It's place takes the `--set-shader` CLI option, which acts as a global auto-shader with highest priority (unaffected by the `auto_shaders_enable` setting)

Shaders that are loaded
 - as an auto-shader
 - through the shader menus
 - via the network command interface `SET_SHADER` command

persist until a core is unloaded.

This means they now have to be saved *explicitly*.

If a shader could not be set, it will basically disable shaders (without touching the `video_shader_enable` setting).

Both loaded and "disabled" shaders always persist through video reinit.

### Further Changes

menu_shader.c would save an applied preset to `<configname>.<type>p` (e.g. retroarch.slangp) or `menu.<type>p` as a fallback.
This looks like a remnant of the pre-auto-shaders era and has thus been removed, it will now always write to `retroarch.<type>p`

menu_shader.c would load `menu.<type>p` as a fallback when an auto-shader is not supported - but without testing if those are supported.
This logic has been completely removed.

`video_shader_read_conf_preset` contained a `command_event(CMD_EVENT_SHADER_PRESET_LOADED, NULL)` which ultimately informs the UI of updates.
This is highly unintuive and has been moved to the appropriate sections.

 - Remove old shader type fall-back logic in `menu_shader_manager_apply_changes` (superseeded by #8910)
 - Optimize `video_shader_any_supported`
 - `video_shader_get_type_from_ext` can be called with `is_preset` = `NULL`


### CLI Use

Using an absolute path:
`retroarch -L <core> --set-shader "D:\RetroArch\shaders\shaders_glsl\blurs\kawase_blur_5pass.glslp" <content>`

Or relative to `video_shader_dir`:
`retroarch -L <core> --set-shader "shaders_glsl\blurs\kawase_blur_5pass.glslp" <content>`

Turning off auto-shaders:
`retroarch -L <core> --set-shader "" <content>`

Note: Won't work due to CLI syntax:
`retroarch -L <core> --set-shader <content>`

### Network Command Interface Use

Using an absolute path:
`retroarch --command "SET_SHADER D:\RetroArch\shaders\shaders_glsl\blurs\kawase_blur_5pass.glslp"`

Relative to `video_shader_dir`:
`retroarch --command "SET_SHADER shaders_glsl\blurs\kawase_blur_5pass.glslp"`

Clears current shader:
`retroarch --command SET_SHADER`

## Related Issues

Fixes https://github.com/libretro/RetroArch/issues/5398

## Unresolved Issues

The desktop shader menu can crash when closing content sometime after

> [INFO] [Qt]: Reloading shader parameters.

## Future Plans

Currently, because of the design of video driver `set_shader` and the shader menu, every loaded shader is actually read and parsed twice, once in the shader backend and a second time in the shader menu.
Similarly, when a shader is set from the menu, it'll be writen to a preset file which will then be immediately parsed again by the shader backend.

The video driver `set_shader` should really take a shader (preset) object, so we'd need to read and parse only once.
This is easier said than done however.