### PR TITLE
Change URL for Lakka online updater - nightlies

### DIFF
--- a/file_path_str.c
+++ b/file_path_str.c
@@ -171,7 +171,11 @@ const char *file_path_str(enum file_path_enum enum_idx)
          str = "http://thumbnailpacks.libretro.com";
          break;
       case FILE_PATH_LAKKA_URL:
+#ifdef HAVE_LAKKA_NIGHTLY
+         str = "http://nightly.builds.lakka.tv/.updater";
+#else
          str = "http://le.builds.lakka.tv";
+#endif
          break;
       case FILE_PATH_SHADERS_GLSL_ZIP:
          str = "shaders_glsl.zip";


### PR DESCRIPTION
## Description
currently, if users try to update a nightly build, they are offered latest stable release, which in fact is a downgrade. with correct URL the users will be pointed to the latest nightly build in case they are running a nightly build - it does not affect users running a stable/rc release of Lakka.

## Related Pull Requests
originally we wanted to patch RA locally (https://github.com/libretro/Lakka-LibreELEC/pull/752), but it seems patching upstream and just adding a make flag is more sane.

## Reviewers
@twinaphex @natinusala @kivutar 
