### PR TITLE
fix not being able to apply shader if none was loaded before

### DIFF
--- a/menu/menu_shader.c
+++ b/menu/menu_shader.c
@@ -403,17 +403,26 @@ void menu_shader_manager_clear_pass_path(unsigned i)
  **/
 enum rarch_shader_type menu_shader_manager_get_type(const void *data)
 {
-   unsigned type                     = RARCH_SHADER_NONE;
+   enum rarch_shader_type type       = RARCH_SHADER_NONE;
    const struct video_shader *shader = (const struct video_shader*)data;
    /* All shader types must be the same, or we cannot use it. */
-   unsigned i                        = 0;
+   size_t i                         = 0;
 
    if (!shader)
       return RARCH_SHADER_NONE;
 
    type = video_shader_parse_type(shader->path);
 
-   for (i = 0; i < shader->passes; i++)
+   if (!shader->passes)
+      return type;
+
+   if (type == RARCH_SHADER_NONE)
+   {
+      type = video_shader_parse_type(shader->pass[0].source.path);
+      i = 1;
+   }
+
+   for (; i < shader->passes; i++)
    {
       enum rarch_shader_type pass_type =
          video_shader_parse_type(shader->pass[i].source.path);
@@ -424,14 +433,14 @@ enum rarch_shader_type menu_shader_manager_get_type(const void *data)
          case RARCH_SHADER_GLSL:
          case RARCH_SHADER_SLANG:
             if (type != pass_type)
-               return (enum rarch_shader_type)RARCH_SHADER_NONE;
+               return RARCH_SHADER_NONE;
             break;
          default:
             break;
       }
    }
 
-   return (enum rarch_shader_type)type;
+   return type;
 }
 
 /**


### PR DESCRIPTION
## Description

If no shader preset was loaded previously in the shader menu and a preset is constructed manually (by setting passes ≥ 1 and choosing a shader file), "Apply Changes" does not save and apply the preset.

This is because it's `shader_path` is used to determine the type of the preset, but since it was `NULL`, the type was NONE.

## Changes

If the type of the `shader_path` is NONE, the type of the shader passes is used.

---

I think I flubbed this one in this refactor https://github.com/libretro/RetroArch/commit/692dc9f6a902d53048b5edcb8a314d41bd927184, just fixing my mistake.