### PR TITLE
fixes "Save Shader Preset As" dialog immediately popping up again on …

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -23328,10 +23328,9 @@ static enum runloop_state runloop_check_state(void)
    static bool old_focus               = true;
    settings_t *settings                = configuration_settings;
    float fastforward_ratio             = settings->floats.fastforward_ratio;
-   bool is_focused                     = video_has_focus();
-   bool is_alive                       = current_video ?
-      current_video->alive(video_driver_data) : true;
-   uint64_t frame_count                = video_driver_frame_count;
+   bool is_focused                     = false;
+   bool is_alive                       = false;
+   uint64_t frame_count                = 0;
    bool focused                        = true;
    bool pause_nonactive                = settings->bools.pause_nonactive;
    bool rarch_is_initialized           = rarch_is_inited;
@@ -23394,6 +23393,11 @@ static enum runloop_state runloop_check_state(void)
       if (application)
          application->process_events();
    }
+
+   frame_count = video_driver_frame_count;
+   is_alive    = current_video ?
+      current_video->alive(video_driver_data) : true;
+   is_focused  = video_has_focus();
 
 #ifdef HAVE_MENU
    if (menu_driver_binding_state)


### PR DESCRIPTION
## Description

https://github.com/libretro/RetroArch/commit/ee3208ac393ea18e8d5aa62f2366930eef2db1af caused #9141 under Linux.
While the commit is huge, there have only been a really subtle changes.
This is the one change that broke *something*, though I like to not find out what that something is.

## Related Issues

Fixes #9141