### PR TITLE
Make smooth ticker text scroll speed resolution independent

### DIFF
--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -770,7 +770,7 @@ static void materialui_render_label_value(
    /* Initial ticker configuration */
    if (use_smooth_ticker)
    {
-      ticker_smooth.idx           = menu_animation_get_ticker_fast_idx();
+      ticker_smooth.idx           = menu_animation_get_ticker_pixel_idx();
       ticker_smooth.font          = mui->font;
       ticker_smooth.font_scale    = 1.0f;
       ticker_smooth.type_enum     = (enum menu_animation_ticker_type)settings->uints.menu_ticker_type;
@@ -1235,7 +1235,7 @@ static void materialui_frame(void *data, video_frame_info_t *video_info)
    /* Initial ticker configuration */
    if (use_smooth_ticker)
    {
-      ticker_smooth.idx           = menu_animation_get_ticker_fast_idx();
+      ticker_smooth.idx           = menu_animation_get_ticker_pixel_idx();
       ticker_smooth.font          = mui->font;
       ticker_smooth.font_scale    = 1.0f;
       ticker_smooth.type_enum     = (enum menu_animation_ticker_type)settings->uints.menu_ticker_type;

--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -1037,7 +1037,7 @@ static void ozone_draw_header(ozone_handle_t *ozone, video_frame_info_t *video_i
    /* Initial ticker configuration */
    if (use_smooth_ticker)
    {
-      ticker_smooth.idx           = menu_animation_get_ticker_fast_idx();
+      ticker_smooth.idx           = menu_animation_get_ticker_pixel_idx();
       ticker_smooth.font_scale    = 1.0f;
       ticker_smooth.type_enum     = (enum menu_animation_ticker_type)settings->uints.menu_ticker_type;
       ticker_smooth.spacer        = ticker_spacer;

--- a/menu/drivers/ozone/ozone_entries.c
+++ b/menu/drivers/ozone/ozone_entries.c
@@ -494,7 +494,7 @@ border_iterate:
       /* Initial ticker configuration */
       if (use_smooth_ticker)
       {
-         ticker_smooth.idx           = menu_animation_get_ticker_fast_idx();
+         ticker_smooth.idx           = menu_animation_get_ticker_pixel_idx();
          ticker_smooth.font          = ozone->fonts.entries_label;
          ticker_smooth.font_scale    = 1.0f;
          ticker_smooth.type_enum     = (enum menu_animation_ticker_type)settings->uints.menu_ticker_type;

--- a/menu/drivers/ozone/ozone_sidebar.c
+++ b/menu/drivers/ozone/ozone_sidebar.c
@@ -120,7 +120,7 @@ void ozone_draw_sidebar(ozone_handle_t *ozone, video_frame_info_t *video_info)
    /* Initial ticker configuration */
    if (use_smooth_ticker)
    {
-      ticker_smooth.idx           = menu_animation_get_ticker_fast_idx();
+      ticker_smooth.idx           = menu_animation_get_ticker_pixel_idx();
       ticker_smooth.font          = ozone->fonts.sidebar;
       ticker_smooth.font_scale    = 1.0f;
       ticker_smooth.type_enum     = (enum menu_animation_ticker_type)settings->uints.menu_ticker_type;

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -3256,7 +3256,7 @@ static void rgui_render(void *data,
    use_smooth_ticker = settings->bools.menu_ticker_smooth;
    if (use_smooth_ticker)
    {
-      ticker_smooth.idx           = menu_animation_get_ticker_fast_idx();
+      ticker_smooth.idx           = menu_animation_get_ticker_pixel_idx();
       ticker_smooth.font          = NULL;
       ticker_smooth.glyph_width   = FONT_WIDTH_STRIDE;
       ticker_smooth.type_enum     = (enum menu_animation_ticker_type)settings->uints.menu_ticker_type;

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -2863,7 +2863,7 @@ static int xmb_draw_item(
    /* Initial ticker configuration */
    if (use_smooth_ticker)
    {
-      ticker_smooth.idx           = menu_animation_get_ticker_fast_idx();
+      ticker_smooth.idx           = menu_animation_get_ticker_pixel_idx();
       ticker_smooth.font          = xmb->font;
       ticker_smooth.font_scale    = 1.0f;
       ticker_smooth.type_enum     = (enum menu_animation_ticker_type)settings->uints.menu_ticker_type;

--- a/menu/menu_animation.h
+++ b/menu/menu_animation.h
@@ -175,7 +175,7 @@ void menu_timer_start(menu_timer_t *timer, menu_timer_ctx_entry_t *timer_entry);
 
 void menu_timer_kill(menu_timer_t *timer);
 
-bool menu_animation_update(void);
+bool menu_animation_update(unsigned video_width, unsigned video_height);
 
 bool menu_animation_ticker(menu_animation_ctx_ticker_t *ticker);
 
@@ -201,7 +201,7 @@ uint64_t menu_animation_get_ticker_idx(void);
 
 uint64_t menu_animation_get_ticker_slow_idx(void);
 
-uint64_t menu_animation_get_ticker_fast_idx(void);
+uint64_t menu_animation_get_ticker_pixel_idx(void);
 
 RETRO_END_DECLS
 

--- a/retroarch.c
+++ b/retroarch.c
@@ -23988,7 +23988,7 @@ static enum runloop_state runloop_check_state(void)
    }
 
 #if defined(HAVE_MENU)
-   menu_animation_update();
+   menu_animation_update(video_driver_width, video_driver_height);
 
 #ifdef HAVE_MENU_WIDGETS
    if (menu_widgets_inited)


### PR DESCRIPTION
## Description

At present, smooth ticker text scroll speed effectively determines number of pixels scrolled per second - which is of course resolution dependent (i.e. higher display resolutions have more horizontal pixels, so scroll speed is slower).

This PR makes the scroll speed resolution independent.

Note 1: This does not apply to Ozone! Ozone does not implement display scaling, so text is the same size regardless of display resolution - scroll speed must always therefore remain the same. If display scaling is ever implemented, this will have to change.

Note 2: RGUI is itself independent of display resolution, so scroll speed adjustments don't apply. The default smooth scroll speed is set at 1 pixel every 4 frames - this matches almost exactly the default non-smooth scroll speed. Setting the ticker speed multiplier to 2x produces the optimal result here (but this may be too fast for some users - hence we play it safe with the 'slow' default)

This PR also increases the timer resolution in `menu_animation.c` from `ms` to `us`. This should improve general smoothness (particularly on high refresh rate displays)


