### PR TITLE
save unmodified auto-shaders as a reference instead of a copy

### DIFF
--- a/gfx/common/metal_common.m
+++ b/gfx/common/metal_common.m
@@ -1138,7 +1138,7 @@ typedef struct MTLALIGN(16)
    [self _freeVideoShader:_shader];
    _shader = nil;
 
-   config_file_t         *conf = config_file_new_from_path_to_string(path.UTF8String);
+   config_file_t         *conf = video_shader_read_preset(path.UTF8String);
    struct video_shader *shader = (struct video_shader *)calloc(1, sizeof(*shader));
 
    @try

--- a/gfx/drivers/d3d10.c
+++ b/gfx/drivers/d3d10.c
@@ -360,7 +360,7 @@ static bool d3d10_gfx_set_shader(void* data, enum rarch_shader_type type, const 
       return false;
    }
 
-   if (!(conf = config_file_new_from_path_to_string(path)))
+   if (!(conf = video_shader_read_preset(path)))
       return false;
 
    d3d10->shader_preset = (struct video_shader*)calloc(1, sizeof(*d3d10->shader_preset));

--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -378,7 +378,7 @@ static bool d3d11_gfx_set_shader(void* data, enum rarch_shader_type type, const 
       return false;
    }
 
-   if (!(conf = config_file_new_from_path_to_string(path)))
+   if (!(conf = video_shader_read_preset(path)))
       return false;
 
    d3d11->shader_preset = (struct video_shader*)calloc(1, sizeof(*d3d11->shader_preset));

--- a/gfx/drivers/d3d12.c
+++ b/gfx/drivers/d3d12.c
@@ -359,7 +359,7 @@ static bool d3d12_gfx_set_shader(void* data, enum rarch_shader_type type, const 
       return false;
    }
 
-   if (!(conf = config_file_new_from_path_to_string(path)))
+   if (!(conf = video_shader_read_preset(path)))
       return false;
 
    d3d12->shader_preset = (struct video_shader*)calloc(1, sizeof(*d3d12->shader_preset));

--- a/gfx/drivers/d3d9.c
+++ b/gfx/drivers/d3d9.c
@@ -329,7 +329,7 @@ static bool d3d9_init_multipass(d3d9_video_t *d3d, const char *shader_path)
    unsigned i;
    bool            use_extra_pass = false;
    struct video_shader_pass *pass = NULL;
-   config_file_t            *conf = config_file_new_from_path_to_string(shader_path);
+   config_file_t            *conf = video_shader_read_preset(shader_path);
 
    if (!conf)
    {

--- a/gfx/drivers/gx2_gfx.c
+++ b/gfx/drivers/gx2_gfx.c
@@ -1425,7 +1425,7 @@ static bool wiiu_gfx_set_shader(void *data,
       return false;
    }
 
-   if (!(conf = config_file_new_from_path_to_string(path)))
+   if (!(conf = video_shader_read_preset(path)))
       return false;
 
    wiiu->shader_preset = calloc(1, sizeof(*wiiu->shader_preset));

--- a/gfx/drivers_shader/shader_gl_cg.c
+++ b/gfx/drivers_shader/shader_gl_cg.c
@@ -678,7 +678,7 @@ static bool gl_cg_load_preset(void *data, const char *path)
       return false;
 
    RARCH_LOG("[CG]: Loading Cg meta-shader: %s\n", path);
-   conf = config_file_new_from_path_to_string(path);
+   conf = video_shader_read_preset(path);
    if (!conf)
    {
       RARCH_ERR("Failed to load preset.\n");

--- a/gfx/drivers_shader/shader_gl_core.cpp
+++ b/gfx/drivers_shader/shader_gl_core.cpp
@@ -2406,7 +2406,7 @@ gl_core_filter_chain_t *gl_core_filter_chain_create_from_preset(
    if (!shader)
       return nullptr;
 
-   unique_ptr<config_file_t, gl_core::ConfigDeleter> conf{ config_file_new_from_path_to_string(path) };
+   unique_ptr<config_file_t, gl_core::ConfigDeleter> conf{ video_shader_read_preset(path) };
    if (!conf)
       return nullptr;
 

--- a/gfx/drivers_shader/shader_glsl.c
+++ b/gfx/drivers_shader/shader_glsl.c
@@ -900,7 +900,7 @@ static void *gl_glsl_init(void *data, const char *path)
 
          if (is_preset)
          {
-            conf = config_file_new_from_path_to_string(path);
+            conf = video_shader_read_preset(path);
             if (conf)
             {
                ret = video_shader_read_conf_preset(conf, glsl->shader);

--- a/gfx/drivers_shader/shader_vulkan.cpp
+++ b/gfx/drivers_shader/shader_vulkan.cpp
@@ -2887,7 +2887,7 @@ vulkan_filter_chain_t *vulkan_filter_chain_create_from_preset(
    if (!shader)
       return nullptr;
 
-   unique_ptr<config_file_t, ConfigDeleter> conf{ config_file_new_from_path_to_string(path) };
+   unique_ptr<config_file_t, ConfigDeleter> conf{ video_shader_read_preset(path) };
    if (!conf)
       return nullptr;
 

--- a/gfx/video_shader_parse.h
+++ b/gfx/video_shader_parse.h
@@ -160,6 +160,43 @@ struct video_shader
 };
 
 /**
+ * video_shader_write_preset:
+ * @path              : File to write to
+ * @shader            : Shader preset to write
+ * @reference         : Whether a reference preset should be written
+ *
+ * Writes a preset to disk. Can be written as a reference preset.
+ * See: video_shader_read_preset
+ **/
+bool video_shader_write_preset(const char *path,
+      const struct video_shader *shader, bool reference);
+
+/**
+ * video_shader_read_reference_path:
+ * @path              : File to read
+ *
+ * Returns: the reference path of a preset if it exists,
+ * otherwise returns NULL.
+ *
+ * The returned string needs to be freed.
+ */
+char *video_shader_read_reference_path(const char *path);
+
+/**
+ * video_shader_read_preset:
+ * @path              : File to read
+ *
+ * Reads a preset from disk.
+ * If the preset is a reference preset, the referenced preset
+ * is loaded instead.
+ *
+ * Returns: the read preset as a config object.
+ *
+ * The returned config object needs to be freed.
+ **/
+config_file_t *video_shader_read_preset(const char *path);
+
+/**
  * video_shader_read_conf_preset:
  * @conf              : Preset file to read from.
  * @shader            : Shader passes handle.
@@ -183,7 +220,7 @@ bool video_shader_read_conf_preset(config_file_t *conf,
  * relative to it.
  **/
 void video_shader_write_conf_preset(config_file_t *conf,
-      struct video_shader *shader, const char *preset_path);
+      const struct video_shader *shader, const char *preset_path);
 
 /**
  * video_shader_resolve_parameters:

--- a/menu/cbs/menu_cbs_left.c
+++ b/menu/cbs/menu_cbs_left.c
@@ -84,6 +84,8 @@ static int shader_action_parameter_left(unsigned type, const char *label, bool w
 
    param_menu->current = param_prev->current;
 
+   menu_shader_set_modified(true);
+
    return ret;
 }
 #endif
@@ -292,6 +294,9 @@ static int action_left_shader_scale_pass(unsigned type, const char *label,
    shader_pass->fbo.valid   = current_scale;
    shader_pass->fbo.scale_x = current_scale;
    shader_pass->fbo.scale_y = current_scale;
+
+   menu_shader_set_modified(true);
+
    return 0;
 }
 
@@ -307,6 +312,9 @@ static int action_left_shader_filter_pass(unsigned type, const char *label,
       return menu_cbs_exit();
 
    shader_pass->filter = ((shader_pass->filter + delta) % 3);
+
+   menu_shader_set_modified(true);
+
    return 0;
 }
 
@@ -354,6 +362,8 @@ static int action_left_shader_num_passes(unsigned type, const char *label,
    menu_entries_ctl(MENU_ENTRIES_CTL_SET_REFRESH, &refresh);
    menu_driver_ctl(RARCH_MENU_CTL_SET_PREVENT_POPULATE, NULL);
    video_shader_resolve_parameters(NULL, shader);
+
+   menu_shader_set_modified(true);
 
    return 0;
 }

--- a/menu/cbs/menu_cbs_right.c
+++ b/menu/cbs/menu_cbs_right.c
@@ -84,6 +84,8 @@ int shader_action_parameter_right(unsigned type, const char *label, bool wraparo
 
    param_menu->current = param_prev->current;
 
+   menu_shader_set_modified(true);
+
    return ret;
 }
 #endif
@@ -315,6 +317,9 @@ static int action_right_shader_scale_pass(unsigned type, const char *label,
 
    shader_pass->fbo.valid   = current_scale;
    shader_pass->fbo.scale_x = shader_pass->fbo.scale_y = current_scale;
+
+   menu_shader_set_modified(true);
+
    return 0;
 }
 
@@ -330,6 +335,9 @@ static int action_right_shader_filter_pass(unsigned type, const char *label,
       return menu_cbs_exit();
 
    shader_pass->filter = ((shader_pass->filter + delta) % 3);
+
+   menu_shader_set_modified(true);
+
    return 0;
 }
 
@@ -376,6 +384,8 @@ static int action_right_shader_num_passes(unsigned type, const char *label,
    menu_entries_ctl(MENU_ENTRIES_CTL_SET_REFRESH, &refresh);
    menu_driver_ctl(RARCH_MENU_CTL_SET_PREVENT_POPULATE, NULL);
    video_shader_resolve_parameters(NULL, shader);
+
+   menu_shader_set_modified(true);
 
    return 0;
 }

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -5690,6 +5690,7 @@ void general_write_handler(rarch_setting_t *setting)
                struct video_shader *shader = menu_shader_get();
 
                shader->passes = 0;
+               menu_shader_set_modified(true);
 
                menu_entries_ctl(MENU_ENTRIES_CTL_SET_REFRESH, &refresh);
                menu_driver_ctl(RARCH_MENU_CTL_SET_PREVENT_POPULATE, NULL);

--- a/menu/menu_shader.c
+++ b/menu/menu_shader.c
@@ -37,6 +37,13 @@
 /* Menu shader */
 
 static struct video_shader *menu_driver_shader = NULL;
+/* indicative of whether shader was modified from the menus: */
+static bool menu_driver_shader_modified = true;
+
+void menu_shader_set_modified(bool modified)
+{
+   menu_driver_shader_modified = modified;
+}
 
 struct video_shader *menu_shader_get(void)
 {
@@ -62,7 +69,6 @@ bool menu_shader_manager_init(void)
    enum rarch_shader_type type      = RARCH_SHADER_NONE;
    bool ret                         = true;
    bool is_preset                   = false;
-   config_file_t *conf              = NULL;
    const char *path_shader          = NULL;
    struct video_shader *menu_shader = NULL;
 
@@ -104,8 +110,22 @@ bool menu_shader_manager_init(void)
 
    if (is_preset)
    {
-      if (path_is_valid(path_shader))
-         conf = config_file_new_from_path_to_string(path_shader);
+      config_file_t *conf = NULL;
+
+      conf = video_shader_read_preset(path_shader);
+
+      if (!conf)
+      {
+         ret = false;
+         goto end;
+      }
+
+      if (video_shader_read_conf_preset(conf, menu_shader))
+         video_shader_resolve_parameters(conf, menu_shader);
+
+      menu_driver_shader_modified = false;
+
+      config_file_free(conf);
    }
    else
    {
@@ -113,12 +133,6 @@ bool menu_shader_manager_init(void)
             sizeof(menu_shader->pass[0].source.path));
       menu_shader->passes = 1;
    }
-
-   if (conf && video_shader_read_conf_preset(conf, menu_shader))
-      video_shader_resolve_parameters(conf, menu_shader);
-
-   if (conf)
-      config_file_free(conf);
 
 end:
    menu_driver_shader = menu_shader;
@@ -173,7 +187,7 @@ bool menu_shader_manager_set_preset(struct video_shader *shader,
     * Used when a preset is directly loaded.
     * No point in updating when the Preset was
     * created from the menu itself. */
-   if (!(conf = config_file_new_from_path_to_string(preset_path)))
+   if (!(conf = video_shader_read_preset(preset_path)))
    {
       ret = false;
       goto end;
@@ -197,31 +211,20 @@ end:
    return ret;
 }
 
-/**
- * menu_shader_manager_save_preset:
- * @basename                 : basename of preset
- * @apply                    : immediately set preset after saving
- *
- * Save a shader preset to disk.
- **/
-bool menu_shader_manager_save_preset(
-      struct video_shader *shader,
-      const char *basename, bool apply, bool fullpath)
+static bool menu_shader_manager_save_preset_internal(
+      const struct video_shader *shader, const char *basename,
+      bool apply, bool save_reference)
 {
+   bool ret                       = false;
+   enum rarch_shader_type type    = RARCH_SHADER_NONE;
+   char *preset_path              = NULL;
+   size_t i                       = 0;
+   char fullname[PATH_MAX_LENGTH];
    char buffer[PATH_MAX_LENGTH];
-   char preset_path[PATH_MAX_LENGTH];
-   char config_directory[PATH_MAX_LENGTH];
-   bool ret                               = false;
-   unsigned d;
-   enum rarch_shader_type type            = RARCH_SHADER_NONE;
-   const char *dirs[3]                    = {0};
-   config_file_t *conf                    = NULL;
 
-   config_directory[0]                    = '\0';
-   buffer[0]                              = '\0';
-   preset_path[0]                         = '\0';
+   fullname[0] = buffer[0] = '\0';
 
-   if (!shader)
+   if (!shader || !shader->passes)
       return false;
 
    type = menu_shader_manager_get_type(shader);
@@ -229,33 +232,47 @@ bool menu_shader_manager_save_preset(
    if (type == RARCH_SHADER_NONE)
       return false;
 
-   if (basename)
+   if (menu_driver_shader_modified)
+      save_reference = false;
+
+   if (!string_is_empty(basename))
    {
-      strlcpy(buffer, basename, sizeof(buffer));
+      strlcpy(fullname, basename, sizeof(fullname));
 
       /* Append extension automatically as appropriate. */
-      if (     !strstr(basename,
-               file_path_str(FILE_PATH_CGP_EXTENSION))
-            && !strstr(basename,
-               file_path_str(FILE_PATH_GLSLP_EXTENSION))
-            && !strstr(basename,
-               file_path_str(FILE_PATH_SLANGP_EXTENSION)))
+      if (     !strstr(basename, file_path_str(FILE_PATH_CGP_EXTENSION))
+            && !strstr(basename, file_path_str(FILE_PATH_GLSLP_EXTENSION))
+            && !strstr(basename, file_path_str(FILE_PATH_SLANGP_EXTENSION)))
       {
          const char *preset_ext = video_shader_get_preset_extension(type);
-         if (!string_is_empty(preset_ext))
-            strlcat(buffer, preset_ext, sizeof(buffer));
+         strlcat(fullname, preset_ext, sizeof(fullname));
       }
    }
    else
    {
       const char *preset_ext = video_shader_get_preset_extension(type);
-      strlcpy(buffer, "retroarch", sizeof(buffer));
-      strlcat(buffer, preset_ext, sizeof(buffer));
+      strlcpy(fullname, "retroarch", sizeof(fullname));
+      strlcat(fullname, preset_ext, sizeof(fullname));
    }
 
-   if (!fullpath)
+   if (path_is_absolute(fullname))
    {
+      preset_path = fullname;
+
+      ret = video_shader_write_preset(preset_path, shader, save_reference);
+
+      if (ret)
+         RARCH_LOG("Saved shader preset to %s.\n", preset_path);
+      else
+         RARCH_ERR("Failed writing shader preset to %s.\n", preset_path);
+   }
+   else
+   {
+      const char *dirs[3]  = {0};
       settings_t *settings = config_get_ptr();
+      char config_directory[PATH_MAX_LENGTH];
+
+      config_directory[0] = '\0';
 
       if (!path_is_empty(RARCH_PATH_CONFIG))
          fill_pathname_basedir(
@@ -263,63 +280,137 @@ bool menu_shader_manager_save_preset(
                path_get(RARCH_PATH_CONFIG),
                sizeof(config_directory));
 
-      dirs[0]              = settings->paths.directory_video_shader;
-      dirs[1]              = settings->paths.directory_menu_config;
-      dirs[2]              = config_directory;
-   }
+      dirs[0] = settings->paths.directory_video_shader;
+      dirs[1] = settings->paths.directory_menu_config;
+      dirs[2] = config_directory;
 
-   if (!(conf = config_file_new_alloc()))
-      return false;
-
-   if (fullpath)
-   {
-      if (!string_is_empty(basename))
-         strlcpy(preset_path, buffer, sizeof(preset_path));
-
-      video_shader_write_conf_preset(conf, shader, preset_path);
-
-      if (config_file_write(conf, preset_path, false))
+      for (i = 0; i < ARRAY_SIZE(dirs); i++)
       {
-         RARCH_LOG("Saved shader preset to %s.\n", preset_path);
-         if (apply)
-            menu_shader_manager_set_preset(NULL, type, preset_path, true);
-         ret = true;
-      }
-      else
-         RARCH_LOG("Failed writing shader preset to %s.\n", preset_path);
-   }
-   else
-   {
-      for (d = 0; d < ARRAY_SIZE(dirs); d++)
-      {
-         if (!*dirs[d])
+         if (string_is_empty(dirs[i]))
             continue;
 
-         fill_pathname_join(preset_path, dirs[d],
-               buffer, sizeof(preset_path));
+         fill_pathname_join(buffer, dirs[i],
+               fullname, sizeof(buffer));
 
-         video_shader_write_conf_preset(conf, shader, preset_path);
+         preset_path = buffer;
 
-         if (config_file_write(conf, preset_path, false))
+         ret = video_shader_write_preset(preset_path, shader, save_reference);
+
+         if (ret)
          {
             RARCH_LOG("Saved shader preset to %s.\n", preset_path);
-            if (apply)
-               menu_shader_manager_set_preset(NULL, type, preset_path, true);
-            ret = true;
             break;
          }
          else
-            RARCH_LOG("Failed writing shader preset to %s.\n", preset_path);
+            RARCH_WARN("Failed writing shader preset to %s.\n", preset_path);
       }
+
+      if (!ret)
+         RARCH_ERR("Failed to write shader preset. Make sure shader directory"
+               " and/or config directory are writable.\n");
    }
 
-   config_file_free(conf);
-   if (ret)
-      return true;
+   if (ret && apply)
+      menu_shader_manager_set_preset(NULL, type, preset_path, true);
 
-   RARCH_ERR("Failed to save shader preset. Make sure config directory"
-         " and/or shader dir are writable.\n");
-   return false;
+   return ret;
+}
+
+/**
+ * menu_shader_manager_save_auto_preset:
+ * @shader                   : shader to save
+ * @type                     : type of shader preset which determines save path
+ * @apply                    : immediately set preset after saving
+ *
+ * Save a shader as an auto-shader to it's appropriate path:
+ *    SHADER_PRESET_GLOBAL: <shader dir>/presets/global
+ *    SHADER_PRESET_CORE:   <shader dir>/presets/<core name>/<core name>
+ *    SHADER_PRESET_PARENT: <shader dir>/presets/<core name>/<parent>
+ *    SHADER_PRESET_GAME:   <shader dir>/presets/<core name>/<game name>
+ * Needs to be consistent with retroarch_load_shader_preset()
+ * Auto-shaders will be saved as a reference if possible
+ **/
+bool menu_shader_manager_save_auto_preset(const struct video_shader *shader,
+      enum auto_shader_type type, bool apply)
+{
+   char tmp[PATH_MAX_LENGTH];
+   char directory[PATH_MAX_LENGTH];
+   char file[PATH_MAX_LENGTH];
+   settings_t *settings             = config_get_ptr();
+   struct retro_system_info *system = runloop_get_libretro_system_info();
+   const char *core_name            = system ? system->library_name : NULL;
+
+   tmp[0] = directory[0] = file[0] = '\0';
+
+   if (type == SHADER_PRESET_GLOBAL)
+   {
+      fill_pathname_join(
+            directory,
+            settings->paths.directory_video_shader,
+            "presets",
+            sizeof(directory));
+   }
+   else if (string_is_empty(core_name))
+   {
+      return false;
+   }
+   else
+   {
+      fill_pathname_join(
+            tmp,
+            settings->paths.directory_video_shader,
+            "presets",
+            sizeof(tmp));
+      fill_pathname_join(
+            directory,
+            tmp,
+            core_name,
+            sizeof(directory));
+   }
+
+   switch (type)
+   {
+      case SHADER_PRESET_GLOBAL:
+         fill_pathname_join(file, directory, "global", sizeof(file));
+         break;
+      case SHADER_PRESET_CORE:
+         fill_pathname_join(file, directory, core_name, sizeof(file));
+         break;
+      case SHADER_PRESET_PARENT:
+         {
+            fill_pathname_parent_dir_name(tmp, path_get(RARCH_PATH_BASENAME), sizeof(tmp));
+            fill_pathname_join(file, directory, tmp, sizeof(file));
+            break;
+         }
+      case SHADER_PRESET_GAME:
+         {
+            const char *game_name = path_basename(path_get(RARCH_PATH_BASENAME));
+            fill_pathname_join(file, directory, game_name, sizeof(file));
+            break;
+         }
+      default:
+         return false;
+   }
+
+   if (!path_is_directory(directory))
+       path_mkdir(directory);
+
+   return menu_shader_manager_save_preset_internal(shader, file, apply, true);
+}
+
+/**
+ * menu_shader_manager_save_preset:
+ * @shader                   : shader to save
+ * @type                     : type of shader preset which determines save path
+ * @basename                 : basename of preset
+ * @apply                    : immediately set preset after saving
+ *
+ * Save a shader preset to disk.
+ **/
+bool menu_shader_manager_save_preset(const struct video_shader *shader,
+      const char *basename, bool apply)
+{
+   return menu_shader_manager_save_preset_internal(shader, basename, apply, false);
 }
 
 int menu_shader_manager_clear_num_passes(struct video_shader *shader)
@@ -336,6 +427,8 @@ int menu_shader_manager_clear_num_passes(struct video_shader *shader)
 #endif
 
    video_shader_resolve_parameters(NULL, shader);
+
+   menu_driver_shader_modified = true;
 
    return 0;
 }
@@ -367,6 +460,8 @@ int menu_shader_manager_clear_pass_filter(struct video_shader *shader,
 
    shader_pass->filter = RARCH_FILTER_UNSPEC;
 
+   menu_driver_shader_modified = true;
+
    return 0;
 }
 
@@ -382,6 +477,8 @@ void menu_shader_manager_clear_pass_scale(struct video_shader *shader,
    shader_pass->fbo.scale_x = 0;
    shader_pass->fbo.scale_y = 0;
    shader_pass->fbo.valid   = false;
+
+   menu_driver_shader_modified = true;
 }
 
 void menu_shader_manager_clear_pass_path(struct video_shader *shader,
@@ -392,6 +489,8 @@ void menu_shader_manager_clear_pass_path(struct video_shader *shader,
 
    if (shader_pass)
       *shader_pass->source.path = '\0';
+
+   menu_driver_shader_modified = true;
 }
 
 /**
@@ -460,7 +559,7 @@ void menu_shader_manager_apply_changes(struct video_shader *shader)
 
    if (shader->passes && type != RARCH_SHADER_NONE)
    {
-      menu_shader_manager_save_preset(shader, NULL, true, false);
+      menu_shader_manager_save_preset(shader, NULL, true);
       return;
    }
 

--- a/menu/menu_shader.c
+++ b/menu/menu_shader.c
@@ -446,6 +446,8 @@ int menu_shader_manager_clear_parameter(struct video_shader *shader,
    param->current = MIN(MAX(param->minimum,
             param->current), param->maximum);
 
+   menu_driver_shader_modified = true;
+
    return 0;
 }
 

--- a/menu/menu_shader.h
+++ b/menu/menu_shader.h
@@ -24,6 +24,14 @@
 
 RETRO_BEGIN_DECLS
 
+enum auto_shader_type
+{
+   SHADER_PRESET_GLOBAL,
+   SHADER_PRESET_CORE,
+   SHADER_PRESET_PARENT,
+   SHADER_PRESET_GAME
+};
+
 struct video_shader *menu_shader_get(void);
 
 void menu_shader_manager_free(void);
@@ -49,15 +57,32 @@ bool menu_shader_manager_set_preset(
       enum rarch_shader_type type, const char *preset_path, bool apply);
 
 /**
+ * menu_shader_manager_save_auto_preset:
+ * @shader                   : shader to save
+ * @type                     : type of shader preset which determines save path
+ * @apply                    : immediately set preset after saving
+ *
+ * Save a shader as an auto-shader to it's appropriate path:
+ *    SHADER_PRESET_GLOBAL: <shader dir>/presets/global
+ *    SHADER_PRESET_CORE:   <shader dir>/presets/<core name>/<core name>
+ *    SHADER_PRESET_PARENT: <shader dir>/presets/<core name>/<parent>
+ *    SHADER_PRESET_GAME:   <shader dir>/presets/<core name>/<game name>
+ * Needs to be consistent with retroarch_load_shader_preset()
+ * Auto-shaders will be saved as a reference if possible
+ **/
+bool menu_shader_manager_save_auto_preset(const struct video_shader *shader,
+      enum auto_shader_type type, bool apply);
+
+/**
  * menu_shader_manager_save_preset:
+ * @shader                   : shader to save
  * @basename                 : basename of preset
  * @apply                    : immediately set preset after saving
  *
  * Save a shader preset to disk.
  **/
-bool menu_shader_manager_save_preset(
-      struct video_shader *shader,
-      const char *basename, bool apply, bool fullpath);
+bool menu_shader_manager_save_preset(const struct video_shader *shader,
+      const char *basename, bool apply);
 
 /**
  * menu_shader_manager_get_type:
@@ -90,6 +115,8 @@ void menu_shader_manager_clear_pass_scale(struct video_shader *shader,
 
 void menu_shader_manager_clear_pass_path(struct video_shader *shader,
       unsigned i);
+
+void menu_shader_set_modified(bool modified);
 
 RETRO_END_DECLS
 

--- a/retroarch.c
+++ b/retroarch.c
@@ -2222,11 +2222,14 @@ bool retroarch_apply_shader(enum rarch_shader_type type, const char *preset_path
       retroarch_set_runtime_shader_preset(preset_path);
 
       /* reflect in shader manager */
-      menu_shader_manager_set_preset(menu_shader_get(), type, preset_path, false);
+      if (menu_shader_manager_set_preset(menu_shader_get(), type, preset_path, false))
+         if (!string_is_empty(preset_path))
+            menu_shader_set_modified(false);
 
       /* Display message */
       snprintf(msg, sizeof(msg),
-            "Shader: \"%s\"", preset_file ? preset_file : "(null)");
+            preset_file ? "Shader: \"%s\"" : "Shader: %s",
+            preset_file ? preset_file : "None");
 #ifdef HAVE_MENU_WIDGETS
       if (menu_widgets_inited)
          menu_widgets_set_message(msg);
@@ -2236,7 +2239,7 @@ bool retroarch_apply_shader(enum rarch_shader_type type, const char *preset_path
                MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
       RARCH_LOG("%s \"%s\".\n",
             msg_hash_to_str(MSG_APPLYING_SHADER),
-            preset_path);
+            preset_path ? preset_path : "null");
    }
    else
    {
@@ -2248,7 +2251,7 @@ bool retroarch_apply_shader(enum rarch_shader_type type, const char *preset_path
       /* Display error message */
       snprintf(msg, sizeof(msg), "%s %s",
             msg_hash_to_str(MSG_FAILED_TO_APPLY_SHADER_PRESET),
-            preset_file ? preset_file : "(null)");
+            preset_file ? preset_file : "null");
 
       runloop_msg_queue_push(
             msg, 1, 180, true, NULL,

--- a/ui/drivers/qt/shaderparamsdialog.cpp
+++ b/ui/drivers/qt/shaderparamsdialog.cpp
@@ -558,6 +558,8 @@ void ShaderParamsDialog::onShaderResetPass(int pass)
       }
    }
 
+   menu_shader_set_modified(true);
+
    reload();
 }
 
@@ -601,6 +603,8 @@ void ShaderParamsDialog::onShaderResetParameter(QString parameter)
       if (param)
          param->current = param->initial;
    }
+
+   menu_shader_set_modified(true);
 
    reload();
 }


### PR DESCRIPTION
## Description

Automatic shader presets are currently always saved as copies, which has some disadvantages:
 - If an 'official' shader preset changes, a saved auto-shader won't change with it
 - If you have a custom preset that you often adjust, you'd need to adjust all auto-shaders manually each time

The idea is to allow (auto-shader) presets to refer to other (non-auto-shader) presets.

This is done by adding a custom
`#reference "<reference path>"`
or
`#reference <reference path>`
directive, which will act as if the referenced preset was loaded instead.
(The `config_file_t` or `video_shader` object's `path` will be \<reference path\>).

This directive is non-recursive and the menu shader saving code will only let auto-shaders refer to non-auto-shaders, which ensures that we never get references to references or self-referential presets.

References to the `retroarch.<ext>` preset are not permitted.

## How To Use

Load any shader in any way, save as an auto-shader without modifying and it will be saved as a reference (with the mentioned exceptions above).

If a shader is modified and then "Saved As", it will act as if it was freshly loaded, which allows to create auto-shaders pointing to custom presets.

## Changes

 - implement `#reference` directive for auto-shaders
 - replace usual preset saving and loading functions with `video_shader_read_preset()` and `video_shader_write_preset()`
 - apply saved presets automatically for console menus
 - move auto-shader saving logic from menus into menu_shader.c `menu_shader_manager_save_auto_preset()`
 - refactor `menu_shader_manager_save_preset()` into `menu_shader_manager_save_preset_internal()`

## Drawbacks

Currently, the detection of shader modifications is done via the UI elements.

This adds a small maintenance burden if new ways of modifications are added.

If the modification detection fails, a reference preset will be written instead of a needed copy, thus effectively saving the wrong shader.

## Tests

### Console Menus:
Changing one of these counts as a modification:
 - Shader Passes
 - Shader #i (loading a pass)
 - Shader #i Filter
 - Shader #i Scale
 - Shader Parameters

Load -> Save <global/core/content/game> => reference
Load -> Modify -> Save As -> Save <global/core/content/game> => reference (to the saved as)
Load -> Modify -> Save <global/core/content/game> => copy

### Desktop/Qt Menu:
Changing one of these counts as a modification:
 - Add Pass
 - Remove Pass
 - Clear All Passes
 - 'Filter'
 - 'Scale'
 - Moving Passes
 - Shader Parameters

Load -> Save <global/core/content/game> => reference
Load -> Modify -> Save As -> Save <global/core/content/game> => reference (to the saved as)
Load -> Modify -> Save <global/core/content/game> => copy

### Loading

Loading through the console or desktop menu is a "Load", setting a shader via the network interface is a "Load" and loading an auto-shader is a "Load".
If the auto-shader is itself a reference, it behaves as if the referenced preset was loaded.