### PR TITLE
fix video_driver_get_ident for thread wrapper

### DIFF
--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -1567,12 +1567,7 @@ static bool menu_display_check_compatibility(
       enum menu_display_driver_type type,
       bool video_is_threaded)
 {
-   const char *video_driver =
-#ifdef HAVE_THREADS
-      (video_is_threaded) ?
-      video_thread_get_ident() :
-#endif
-      video_driver_get_ident();
+   const char *video_driver = video_driver_get_ident();
 
    switch (type)
    {

--- a/retroarch.c
+++ b/retroarch.c
@@ -17309,7 +17309,15 @@ void video_driver_set_threaded(bool val)
 
 const char *video_driver_get_ident(void)
 {
-   return (current_video) ? current_video->ident : NULL;
+   if (!current_video)
+      return NULL;
+
+#ifdef HAVE_THREADS
+   if (video_driver_is_threaded_internal())
+      return video_thread_get_ident();
+#endif
+
+   return current_video->ident;
 }
 
 static void video_context_driver_reset(void)
@@ -25461,12 +25469,7 @@ static bool rarch_write_debug_info(void)
                ? settings->arrays.menu_driver 
                : "n/a");
 #endif
-      driver =
-#ifdef HAVE_THREADS
-      (video_driver_is_threaded_internal()) ?
-      video_thread_get_ident() :
-#endif
-      video_driver_get_ident();
+      driver = video_driver_get_ident();
 
       if (string_is_equal(driver, settings->arrays.video_driver))
          filestream_printf(file, "  - Video: %s\n",


### PR DESCRIPTION
## Description

When threaded video is used, `video_driver_get_ident()` returns "Thread wrapper" instead of the ident of the underlying video driver, causing e.g. the wrong shader flags being set from the context drivers.
In this case, `video_thread_get_ident()` should be called instead.

## Changes

This changes ``video_driver_get_ident()`` to use `video_thread_get_ident()` whenever threaded video is used.

## Related Issues

Fixes https://github.com/libretro/RetroArch/issues/9376
