### PR TITLE
Remove '_OSX' suffix from RetroArch window title

### DIFF
--- a/pkg/apple/OSX/en.lproj/MainMenu.xib
+++ b/pkg/apple/OSX/en.lproj/MainMenu.xib
@@ -323,7 +323,7 @@
                 </menuItem>
             </items>
         </menu>
-        <window title="RetroArch_OSX" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="371">
+        <window title="RetroArch" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="371">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="335" y="390" width="480" height="360"/>

--- a/pkg/apple/OSX/en.lproj/MainMenu_Metal.xib
+++ b/pkg/apple/OSX/en.lproj/MainMenu_Metal.xib
@@ -323,7 +323,7 @@
                 </menuItem>
             </items>
         </menu>
-        <window title="RetroArch_OSX" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="371" customClass="RAWindow">
+        <window title="RetroArch" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="371" customClass="RAWindow">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="335" y="390" width="480" height="360"/>

--- a/pkg/apple/OSX/en.lproj/PPC/MainMenu.xib
+++ b/pkg/apple/OSX/en.lproj/PPC/MainMenu.xib
@@ -657,7 +657,7 @@
 				<int key="NSWindowBacking">2</int>
 				<string key="NSWindowRect">{{335, 390}, {480, 360}}</string>
 				<int key="NSWTFlags">1954021376</int>
-				<string key="NSWindowTitle">RetroArch_OSX</string>
+				<string key="NSWindowTitle">RetroArch</string>
 				<string key="NSWindowClass">NSWindow</string>
 				<nil key="NSViewClass"/>
 				<nil key="NSUserInterfaceItemIdentifier"/>


### PR DESCRIPTION
There's no need for a platform-specific window title, and if there
was it should be macOS nowadays, not OS 