### PR TITLE
(glcore) Ensure correct scaling of menu texture (RGUI)

### DIFF
--- a/gfx/drivers/gl_core.c
+++ b/gfx/drivers/gl_core.c
@@ -1593,6 +1593,8 @@ static void gl_core_draw_menu_texture(gl_core_t *gl, video_frame_info_t *video_i
 
    if (gl->menu_texture_full_screen)
       glViewport(0, 0, video_info->width, video_info->height);
+   else
+      glViewport(gl->vp.x, gl->vp.y, gl->vp.width, gl->vp.height);
 
    glActiveTexture(GL_TEXTURE0 + 1);
    glBindTexture(GL_TEXTURE_2D, gl->menu_texture);


### PR DESCRIPTION
## Description

As reported in issue #9420, the combination of `glcore` + `RGUI` + any slang shader that uses `OriginalHistory` textures results in RGUI being drawn at native resolution (i.e. tiny) in the corner of the screen.

This PR changes the `gl_core_draw_menu_texture` function such that menu textures (i.e. RGUI) are always drawn with the current viewport settings. This ensures RGUI is correctly scaled, regardless of shader usage, etc.

## Related Issues

This closes #9420

