### PR TITLE
Fix PSP audio conversion code

### DIFF
--- a/libretro-common/audio/conversion/s16_to_float.c
+++ b/libretro-common/audio/conversion/s16_to_float.c
@@ -113,7 +113,11 @@ void convert_s16_to_float(float *out,
       i       = 0;
    }
 
-#elif defined(_MIPS_ARCH_ALLEGREX)
+#endif
+
+   gain = gain / 0x8000;
+
+#if defined(_MIPS_ARCH_ALLEGREX)
 #ifdef DEBUG
    /* Make sure the buffer is 16 byte aligned, this should be the
     * default behaviour of malloc in the PSPSDK.
@@ -121,7 +125,6 @@ void convert_s16_to_float(float *out,
    retro_assert(((uintptr_t)out & 0xf) == 0);
 #endif
 
-   gain = gain / 0x8000;
    __asm__ (
          ".set    push                    \n"
          ".set    noreorder               \n"
@@ -166,7 +169,6 @@ void convert_s16_to_float(float *out,
    }
 
 #endif
-   gain    = gain / 0x8000;
 
    for (; i < samples; i++)
       out[i] = (float)in[i] * gain;


### PR DESCRIPTION
Feel free to edit the code as needed. Thanks!

Fixes https://github.com/libretro/QuickNES_Core/issues/72

## Description

As a result of this commit: https://github.com/libretro/RetroArch/commit/ed3d75738ca07f376960a373ee4e6cefd37b17f3

This gets called twice for the PSP (previously it was only called once):
```
gain = gain / 0x8000;
```

This ended up causing crackling audio for the QuickNES core on the PSP.

## Related Issues

https://github.com/libretro/QuickNES_Core/issues/72

## Reviewers

@twinaphex 
