### PR TITLE
(cheevos) Fix crash when setting sublabel of achievement

### DIFF
--- a/menu/cbs/menu_cbs_sublabel.c
+++ b/menu/cbs/menu_cbs_sublabel.c
@@ -735,10 +735,13 @@ static int action_bind_sublabel_cheevos_entry(
       char *s, size_t len)
 {
 #ifdef HAVE_CHEEVOS
+   char fetched_sublabel[MENU_SUBLABEL_MAX_LENGTH];
+   fetched_sublabel[0] = '\0';
+
    rcheevos_ctx_desc_t desc_info;
    unsigned new_id = type - MENU_SETTINGS_CHEEVOS_START;
    desc_info.idx   = new_id;
-   desc_info.s     = s;
+   desc_info.s     = fetched_sublabel;
    desc_info.len   = len;
    rcheevos_get_description((rcheevos_ctx_desc_t*) &desc_info);
 


### PR DESCRIPTION
This prevents an unintended pointer reassignment and can cause a crash on strlcpy on some platforms.

Probably addresses #7158 maybe?