### PR TITLE
(RGUI) Ensure display is always refreshed when pointer input is active

### DIFF
--- a/menu/menu_input.h
+++ b/menu/menu_input.h
@@ -74,6 +74,7 @@ typedef struct menu_input_pointer_hw_state
 typedef struct menu_input_pointer
 {
    enum menu_pointer_type type;
+   bool active;
    bool pressed;
    bool dragged;
    retro_time_t press_duration;

--- a/retroarch.c
+++ b/retroarch.c
@@ -12781,12 +12781,14 @@ static unsigned menu_event(
     * Note: dx, dy, ptr, accel entries are set elsewhere */
    if (menu_input->select_inhibit)
    {
+      menu_input->pointer.active  = false;
       menu_input->pointer.pressed = false;
       menu_input->pointer.x       = 0;
       menu_input->pointer.y       = 0;
    }
    else
    {
+      menu_input->pointer.active  = pointer_hw_state->active;
       menu_input->pointer.pressed = pointer_hw_state->select_pressed;
       menu_input->pointer.x       = pointer_hw_state->x;
       menu_input->pointer.y       = pointer_hw_state->y;


### PR DESCRIPTION
## Description

This is tiny bug fix follow-up to PR #9485

When using the mouse/touchscreen to navigate RGUI, the display needs to be redrawn on each frame that the pointer device is 'active', otherwise the screen can appear to hang. I neglected to ensure that this happens, and didn't notice because I always run with a background animation (which forces the display to update every frame regardless of input)...

This PR fixes the issue.


