### PR TITLE
Improve horizontal mouse wheel (tilt) navigation

### DIFF
--- a/menu/menu_input.h
+++ b/menu/menu_input.h
@@ -29,6 +29,11 @@
 
 RETRO_BEGIN_DECLS
 
+/* Mouse wheel tilt actions repeat at a very high
+ * frequency - we ignore any input that occurs
+ * with a period less than MENU_INPUT_HORIZ_WHEEL_DELAY */
+#define MENU_INPUT_HORIZ_WHEEL_DELAY 250000  /* 250 ms */
+
 #define MENU_INPUT_HIDE_CURSOR_DELAY 4000000 /* 4 seconds */
 
 #define MENU_INPUT_PRESS_TIME_SHORT 250000   /* 250 ms */

--- a/retroarch.c
+++ b/retroarch.c
@@ -12910,6 +12910,8 @@ static int menu_input_pointer_post_iterate(
    static bool last_cancel_pressed                 = false;
    static bool last_left_pressed                   = false;
    static bool last_right_pressed                  = false;
+   static retro_time_t last_left_action_time       = 0;
+   static retro_time_t last_right_action_time      = 0;
    bool attenuate_y_accel                          = true;
    bool osk_active                                 = menu_input_dialog_get_display_kb_internal();
    int ret                                         = 0;
@@ -13118,40 +13120,57 @@ static int menu_input_pointer_post_iterate(
    }
    last_cancel_pressed = pointer_hw_state->cancel_pressed;
 
-   /* Up
-    * Note: This always corresponds to a mouse wheel, which
+   /* Up/Down
+    * Note: These always correspond to a mouse wheel, which
     * handles differently from other inputs - i.e. we don't
     * want a 'last pressed' check */
+
+   /* > Up */
    if (pointer_hw_state->up_pressed)
    {
       size_t selection = menu_navigation_get_selection();
       ret = menu_entry_action(entry, (unsigned)selection, MENU_ACTION_UP);
    }
 
-   /* Down
-    * Note: This always corresponds to a mouse wheel, which
-    * handles differently from other inputs - i.e. we don't
-    * want a 'last pressed' check */
+   /* > Down */
    if (pointer_hw_state->down_pressed)
    {
       size_t selection = menu_navigation_get_selection();
       ret = menu_entry_action(entry, (unsigned)selection, MENU_ACTION_DOWN);
    }
 
-   /* Left */
+   /* Left/Right
+    * Note: These also always correspond to a mouse wheel...
+    * In this case, it's a mouse wheel *tilt* operation, which
+    * is incredibly annoying because holding a tilt direction
+    * rapidly toggles the input state. The repeat speed is so
+    * high that any sort of useable control is impossible - so
+    * we have to apply a 'low pass' filter by ignoring inputs
+    * that occur below a certain frequency... */
+
+   /* > Left */
    if (pointer_hw_state->left_pressed && !last_left_pressed)
    {
-      size_t selection = menu_navigation_get_selection();
-      ret = menu_entry_action(entry, (unsigned)selection, MENU_ACTION_LEFT);
+      if (current_time - last_left_action_time > MENU_INPUT_HORIZ_WHEEL_DELAY)
+      {
+         size_t selection      = menu_navigation_get_selection();
+         last_left_action_time = current_time;
+         ret = menu_entry_action(entry, (unsigned)selection, MENU_ACTION_LEFT);
+      }
    }
    last_left_pressed = pointer_hw_state->left_pressed;
 
-   /* Right */
+   /* > Right */
    if (pointer_hw_state->right_pressed && !last_right_pressed)
    {
-      size_t selection = menu_navigation_get_selection();
-      ret = menu_entry_action(entry, (unsigned)selection, MENU_ACTION_RIGHT);
+      if (current_time - last_right_action_time > MENU_INPUT_HORIZ_WHEEL_DELAY)
+      {
+         size_t selection       = menu_navigation_get_selection();
+         last_right_action_time = current_time;
+         ret = menu_entry_action(entry, (unsigned)selection, MENU_ACTION_RIGHT);
+      }
    }
+   last_right_pressed = pointer_hw_state->right_pressed;
 
    menu_input_set_pointer_visibility(current_time);
 


### PR DESCRIPTION
## Description

This is another small follow-up to PR #9485.

On platforms (and when using input drivers) with 'horizontal' mouse wheel support, tilting the mouse wheel left/right triggers normal menu left/right navigation events. Well, I was finally able to test this with a supported driver, and it works poorly - this is because tilting a mouse wheel actually generates a high frequency pulse train of input, so the end result is the same as mashing the left/right cursor keys (i.e. input is so fast as to be uncontrollable).

This PR fixes the issue by applying a sort of low pass filter to horizontal mouse wheel input - now left/right events can only occur with a minimum period of 250 ms. This makes horizontal mouse wheel navigation very comfortable in XMB/MaterialUI/RGUI (note that things don't work quite right in Ozone, because it handles input differently - I'll look at this later)