### PR TITLE
fix name of RetroArch's log file

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -26208,7 +26208,7 @@ void rarch_log_file_init(void)
       fill_pathname_join(log_file_path, settings->paths.log_dir,
             log_to_file_timestamp 
             ? timestamped_log_file_name 
-            : ".log",
+            : "retroarch.log",
             sizeof(log_file_path));
    }
    


### PR DESCRIPTION
## Description

https://github.com/libretro/RetroArch/commit/ab515daa0cef9f035a7549cfbe2b57ebf18d0d33 caused RetroArch's log file to be called `.log` instead of `retroarch.log`