### PR TITLE
improve handling of line endings when calculating CD hashes for retroachievements

### DIFF
--- a/cheevos-new/cheevos.c
+++ b/cheevos-new/cheevos.c
@@ -1583,8 +1583,9 @@ found:
             char disc_path[PATH_MAX_LENGTH];
             char* tmp;
 
-            intfstream_read(m3u_stream, buffer, sizeof(buffer));
+            num_read = intfstream_read(m3u_stream, buffer, sizeof(buffer));
             intfstream_close(m3u_stream);
+            buffer[num_read] = '\0';
 
             tmp = buffer;
             while (*tmp && *tmp != '\n')
@@ -1640,7 +1641,7 @@ found:
             if (exe_name)
             {
                scan = exe_name;
-               while (*scan != '\n' && *scan != ';' && *scan != ' ')
+               while (*scan != '\n' && *scan != '\r' && *scan != ';' && *scan != ' ')
                   ++scan;
                *scan = '\0';
 

--- a/libretro-common/formats/cdfs/cdfs.c
+++ b/libretro-common/formats/cdfs/cdfs.c
@@ -344,8 +344,6 @@ static intfstream_t* cdfs_open_cue_track(const char* path, unsigned int track_in
 
       while (*cue && *cue != '\n')
          ++cue;
-      if (cue == line)
-         continue;
       if (*cue)
          *cue++ = '\0';
 


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

Fixes #9493, as well as two other minor issues regarding m3u and cue parsing - see PR comments for descriptions of each

## Related Issues

#9493

## Related Pull Requests

#9405 

## Reviewers
