### PR TITLE
Fixed WiiU compilation randomly failing

### DIFF
--- a/wiiu/main.c
+++ b/wiiu/main.c
@@ -84,12 +84,7 @@ void _start(int argc, char **argv)
    fsdev_init();
    main(argc, argv);
    fsdev_exit();
-
-   /* TODO: fix elf2rpl so it doesn't error with "Could not find matching symbol
-      for relocation" then uncomment this */
-#if 0
    __fini();
-#endif
    memoryRelease();
    SYSRelaunchTitle(0, 0);
    exit(0);


### PR DESCRIPTION
## Description

Fixing problem which caused WiiU compilation fail randomly (especially Travis CI build and
especially vice-libretro build)
 
- Fixed elf2rpl referencing deleted symbols in relocations
- Added some diagnostics to elf2rpl (activated with -v switch)

## Related Issues

[Any issues this pull request may be addressing?]
