### PR TITLE
fix path_relative_to()

### DIFF
--- a/libretro-common/file/file_path.c
+++ b/libretro-common/file/file_path.c
@@ -913,15 +913,8 @@ size_t path_relative_to(char *out,
    /* Each segment of base turns into ".." */
    out[0] = '\0';
    for (i = 0; trimmed_base[i]; i++)
-   {
       if (trimmed_base[i] == path_default_slash_c())
-      {
-         out[written++] = '.';
-         out[written++] = '.';
-         out[written++] = path_default_slash_c();
-         out[written++] = '\0';
-      }
-   }
+         STRLCAT_CONST_INCR(out, written, ".." path_default_slash(), size);
 
    return strlcat(out, trimmed_path, size);
 }

--- a/libretro-common/include/string/stdstring.h
+++ b/libretro-common/include/string/stdstring.h
@@ -56,8 +56,8 @@ static INLINE bool string_is_equal(const char *a, const char *b)
    STRLCPY_CONST((buf) + MIN((strlcpy_ret), (buf_size)-1 - STRLEN_CONST((str))), (str))
 
 #define STRLCAT_CONST_INCR(buf, strlcpy_ret, str, buf_size) \
-   STRLCAT_CONST(buf, strlcpy_ret, str, buf_size); \
-   (strlcpy_ret) += STRLEN_CONST((str))
+   do { STRLCAT_CONST(buf, strlcpy_ret, str, buf_size); \
+   (strlcpy_ret) += STRLEN_CONST((str)); } while(0)
 
 #define string_is_not_equal_fast(a, b, size) (memcmp(a, b, size) != 0)
 #define string_is_equal_fast(a, b, size)     (memcmp(a, b, size) == 0)


### PR DESCRIPTION
## Description

https://github.com/libretro/RetroArch/commit/f4c6b06b494fb9ee97a9abced2649481a630af97 broke `path_relative_to` by terminating the string after the very first `../`.

## Related Issues

Fixes https://github.com/libretro/RetroArch/issues/9498
