### PR TITLE
Ensure {set,unset}_runtime_shader_preset are always defined

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -1332,6 +1332,9 @@ static void retroarch_unset_runtime_shader_preset(void)
 {
    runtime_shader_preset[0] = '\0';
 }
+#else
+static void retroarch_set_runtime_shader_preset(const char *arg) {}
+static void retroarch_unset_runtime_shader_preset(void) {}
 #endif
 
 #define MEASURE_FRAME_TIME_SAMPLES_COUNT (2 * 1024)


### PR DESCRIPTION

## Description

These functions are used elsewhere, so they need to be defined. (Or we
could guard every place they're called instead)

This was causing compile errors on platforms without `defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)`
