### PR TITLE
Wii/GC: free memory instead of used memory

### DIFF
--- a/frontend/drivers/platform_gx.c
+++ b/frontend/drivers/platform_gx.c
@@ -527,10 +527,9 @@ static uint64_t frontend_gx_get_mem_total(void)
 
 static uint64_t frontend_gx_get_mem_free(void)
 {
-   uint64_t total = SYSMEM1_SIZE - SYS_GetArena1Size();
+   uint64_t total = SYSMEM1_SIZE - (SYSMEM1_SIZE - SYS_GetArena1Size());
 #if defined(HW_RVL) && !defined(IS_SALAMANDER)
-   /* TODO/FIXME - this needs to change */
-   total += gx_mem2_used();
+   total += (gx_mem2_total() - gx_mem2_used());
 #endif
    return total;
 }

--- a/retroarch.c
+++ b/retroarch.c
@@ -11365,15 +11365,11 @@ static void retroarch_overlay_init(void)
 {
    settings_t *settings      = configuration_settings;
 
-#if 0
 #if defined(GEKKO)
-   /* TODO/FIXME - Wiimpathy - behavior here has changed - can you
-    * rewrite this? */
    /* Avoid a crash at startup or even when toggling overlay in rgui */
    uint64_t memory_free       = frontend_driver_get_free_memory();
-   if (memory_free > (72 * 1024 * 1024))
+   if (memory_free < (3 * 1024 * 1024))
       return;
-#endif
 #endif
 
    retroarch_overlay_deinit();


### PR DESCRIPTION


## Description

The frontend wants the remaining memory now according to https://github.com/libretro/RetroArch/commit/ed29c6f59c24478bfaa6e25ddf097be539d7735f
