### PR TITLE
Menu drop-down lists: Add proper titles, and remember last postion when navigating core options

### DIFF
--- a/libretro-common/include/string/stdstring.h
+++ b/libretro-common/include/string/stdstring.h
@@ -135,7 +135,7 @@ void string_remove_all_chars(char *str, char c);
 
 /* Converts string to unsigned integer.
  * Returns 0 if string is invalid  */
-unsigned string_to_unsigned(char *str);
+unsigned string_to_unsigned(const char *str);
 
 RETRO_END_DECLS
 

--- a/libretro-common/string/stdstring.c
+++ b/libretro-common/string/stdstring.c
@@ -321,9 +321,9 @@ void string_remove_all_chars(char *str, char c)
 
 /* Converts string to unsigned integer.
  * Returns 0 if string is invalid  */
-unsigned string_to_unsigned(char *str)
+unsigned string_to_unsigned(const char *str)
 {
-   char *ptr = NULL;
+   const char *ptr = NULL;
 
    if (string_is_empty(str))
       return 0;

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -3223,7 +3223,7 @@ int action_ok_core_option_dropdown_list(const char *path,
 
    generic_action_ok_displaylist_push(
          core_option_lbl, NULL,
-         core_option_idx, 0, 0, 0,
+         core_option_idx, 0, idx, 0,
          ACTION_OK_DL_DROPDOWN_BOX_LIST);
    return 0;
 }
@@ -4198,7 +4198,7 @@ static int action_ok_set_core_association(const char *path,
       return menu_cbs_exit();
 
    return generic_action_ok_displaylist_push(path, NULL,
-         NULL, 0, menu->rpl_entry_selection_ptr, entry_idx,
+         NULL, 0, idx, entry_idx,
          ACTION_OK_DL_DEFERRED_CORE_LIST_SET);
 }
 
@@ -5701,7 +5701,7 @@ static int action_ok_video_resolution(const char *path,
 #else
    generic_action_ok_displaylist_push(
          NULL,
-         NULL, NULL, 0, 0, 0,
+         NULL, NULL, 0, idx, 0,
          ACTION_OK_DL_DROPDOWN_BOX_LIST_RESOLUTION);
 #endif
 
@@ -5713,7 +5713,7 @@ static int action_ok_playlist_default_core(const char *path,
 {
    generic_action_ok_displaylist_push(
          NULL,
-         NULL, NULL, 0, 0, 0,
+         NULL, NULL, 0, idx, 0,
          ACTION_OK_DL_DROPDOWN_BOX_LIST_PLAYLIST_DEFAULT_CORE);
    return 0;
 }
@@ -5723,7 +5723,7 @@ static int action_ok_playlist_label_display_mode(const char *path,
 {
    generic_action_ok_displaylist_push(
          NULL,
-         NULL, NULL, 0, 0, 0,
+         NULL, NULL, 0, idx, 0,
          ACTION_OK_DL_DROPDOWN_BOX_LIST_PLAYLIST_LABEL_DISPLAY_MODE);
    return 0;
 }
@@ -5733,7 +5733,7 @@ static int action_ok_playlist_right_thumbnail_mode(const char *path,
 {
    generic_action_ok_displaylist_push(
          NULL,
-         NULL, NULL, 0, 0, 0,
+         NULL, NULL, 0, idx, 0,
          ACTION_OK_DL_DROPDOWN_BOX_LIST_PLAYLIST_RIGHT_THUMBNAIL_MODE);
    return 0;
 }
@@ -5743,7 +5743,7 @@ static int action_ok_playlist_left_thumbnail_mode(const char *path,
 {
    generic_action_ok_displaylist_push(
          NULL,
-         NULL, NULL, 0, 0, 0,
+         NULL, NULL, 0, idx, 0,
          ACTION_OK_DL_DROPDOWN_BOX_LIST_PLAYLIST_LEFT_THUMBNAIL_MODE);
    return 0;
 }

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -6922,11 +6922,15 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
              * toggles the Quick Menu off and on again (returning
              * to the Core Options menu) the menu must be refreshed
              * (or undefined behaviour occurs).
-             * The only way to check whether the number of visible
-             * options has changed is to cache the last set menu size,
+             * We therefore have to cache the last set menu size,
              * and compare this with the new size after processing
-             * the current core_option_manager_t struct */
-            size_t prev_count = info->list->size;
+             * the current core_option_manager_t struct.
+             * Note: It would be 'nicer' to only refresh the menu
+             * if the selection marker is at an index higher than
+             * the new size, but we don't really have access that
+             * information at this stage (i.e. the selection can
+             * change after this function is called) */
+            static size_t prev_count = 0;
 
             menu_entries_ctl(MENU_ENTRIES_CTL_CLEAR, info->list);
 
@@ -6992,6 +6996,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
             {
                info->need_refresh          = true;
                info->need_navigation_clear = true;
+               prev_count                  = count;
             }
             info->need_push                = true;
          }


### PR DESCRIPTION
## Description

This PR makes the following menu improvements:

- All drop-down lists now have proper titles. Previously these were unset (so selecting any option that used a drop-down list would just keep the title for the last displayed menu).

- When navigating backwards from a core options drop-down list (i.e. pressing select or cancel), the last menu position is remembered (instead of resetting back to the first core option item each time).

With this PR, the correct 'last selected' position is also remembered when navigating backwards from `Playlist Management` drop-down lists.

Unfortunately, remembering the 'last selected' position for *all* drop-down lists is not possible at this time (the current code for generic lists is highly inscrutable - I honestly don't know why it even works...). I'll try to investigate this further when I have time...

## Related Issues

This addresses a small part of #9492
