### PR TITLE
Switch/Vita: Set default aspect to core provided instead of 4:3

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -297,12 +297,7 @@
 
 #if defined(__CELLOS_LV2) || defined(_XBOX360)
 #define DEFAULT_ASPECT_RATIO_IDX ASPECT_RATIO_16_9
-#elif defined(PSP)
-#define DEFAULT_ASPECT_RATIO_IDX ASPECT_RATIO_CORE
-#elif defined(_3DS)
-/* Previously defaulted to ASPECT_RATIO_4_3.
- * Non-4:3 content looks dreadful when stretched
- * to 4:3 on the 3DS screen... */
+#elif defined(PSP) || defined(_3DS) || defined(HAVE_LIBNX) || defined(VITA)
 #define DEFAULT_ASPECT_RATIO_IDX ASPECT_RATIO_CORE
 #elif defined(RARCH_CONSOLE)
 #define DEFAULT_ASPECT_RATIO_IDX ASPECT_RATIO_4_3


### PR DESCRIPTION
## Description

Many cores look horrible on Switch and Vita screens when forced to 4:3 aspect ratio. This PR sets the default aspect ratio to `core provided`, same as on desktop platforms and 3DS. 

## Related Issues

This also fixes the distortions when using the `zoom mode` in PUAE Amiga core or the `disable borders` option in Vice C64 core.

## Reviewers

@m4xw 