### PR TITLE
(cheevos) support for Sega CD/Saturn; reduce hash calls to server

### DIFF
--- a/libretro-common/include/formats/cdfs.h
+++ b/libretro-common/include/formats/cdfs.h
@@ -45,6 +45,10 @@ typedef struct cdfs_file_t
    uint8_t sector_buffer[2048];
 } cdfs_file_t;
 
+/* opens the specified file within the CD or virtual CD.
+ * if path is NULL, will open the raw CD (useful for reading CD without having to worry about sector sizes,
+ * headers, or checksum data)
+ */
 int cdfs_open_file(cdfs_file_t* file, intfstream_t* stream, const char* path);
 
 void cdfs_close_file(cdfs_file_t* file);


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

* Adds support for generating RetroAchievements hashes for Sega CD and Sega Saturn.
  - Similar to PSX, it's impractical to hash the entire CD. Unfortunately, these platforms don't provide an easy way to find the primary executable (and several games have multiple executables), so we just hash the SEGA-specified header data on each disc (first 512 bytes of sector 0). This is much more prone to user-modifications than the PSX solution, but still more reliable than just using the volume name.
* Reduces the number of hashes checked, particularly when matches were not found. 
  - A failed match on the entire file would also try just the filename (for arcade support). Similarly, arcade checks would always try the entire file first before matching on just the filename. Now it's an either/or - if the file has a .zip extension, only the filename is checked, otherwise only the contents are checked.
  - Removed the Genesis/Mega Drive hashing algorithm that was never used (see https://github.com/RetroAchievements/docs/issues/20).

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@leiradel @meleu 
