### PR TITLE
SEGA Mini/SNESC update/MM LZMA/QB fix

### DIFF
--- a/Makefile.classic_sega_mini
+++ b/Makefile.classic_sega_mini
@@ -1,0 +1,49 @@
+# This build was put together and is maintained by ModMyClassic.com for Libretro.
+# The purpose is to give Libretro a proper "official" build platform for classic consoles.
+# If you need any help in building for the classics or have any questions then please visit
+# https://modmyclassic.com and we will help in any way possible!
+
+# Building Prerequisites ##############
+# arm-linux-gnueabihf-strip
+
+include version.all
+
+# General Shared Variables ############
+TARGET := retroarch
+
+# Libretro Defines ####################
+#HAVE_CLASSIC = Classic Hook, disable some features
+#HAVE_C_A7A7 = Classic Armv7 Cortex A7 optimisation override
+#HAVE_SEGAM = Sega Mini Hook, change default configurations etc (TODO)
+
+all: $(TARGET)
+
+retroarch:
+	#Build the RetroArch Binary for cross platform classics (ARMv7 Cortex A7)
+	patchelf --version #Check if you have patchelf installed... (sudo apt-get install patchelf)
+	CFLAGS="-marm -mtune=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard" ./configure --host=arm-linux-gnueabihf --disable-wayland --disable-x11 --disable-opengl --disable-opengl1 --disable-opengl_core --enable-mali_fbdev --disable-freetype --enable-opengles --enable-udev --enable-alsa --enable-neon --enable-floathard --disable-discord
+	make HAVE_CLASSIC=1 HAVE_C_A7A7=1 HAVE_SEGAM=1 -j #Cook it
+	arm-linux-gnueabihf-strip -v retroarch
+	@echo "*********************************************************************"
+	@echo "***   SEGA Mega Drive Mini RetroArch binary built successfully!   ***"
+	@echo "*********************************************************************"
+clean:
+	rm -rf obj-unix
+	rm -f *.d
+	rm -f *.o
+	rm -f audio/*.o
+	rm -f conf/*.o
+	rm -f gfx/*.o
+	rm -f gfx/drivers_font/*.o
+	rm -f gfx/drivers_font_renderer/*.o
+	rm -f gfx/drivers_context/*.o
+	rm -f gfx/py_state/*.o
+	rm -f compat/*.o
+	rm -f record/*.o
+	rm -f input/*.o
+	rm -f tools/*.o
+	rm -f $(BINDIR)/retroarch
+	rm -f $(BINDIR)/retroarch-joyconfig
+	rm -f $(PNDDIR)/readme.html
+	rm -f retroarch
+

--- a/Makefile.classic_snesc
+++ b/Makefile.classic_snesc
@@ -1,0 +1,53 @@
+# This build was put together and is maintained by ModMyClassic.com for Libretro.
+# The purpose is to give Libretro a proper "official" build platform for classic consoles.
+# If you need any help in building for the classics or have any questions then please visit
+# https://modmyclassic.com and we will help in any way possible!
+
+# INFO: THIS BUILD TARGET ALSO COVERS THE NESC!!!
+
+# Building Prerequisites ##############
+# arm-linux-gnueabihf-strip
+# patchelf
+
+include version.all
+
+# General Shared Variables ############
+TARGET := retroarch
+
+# Libretro Defines ####################
+#HAVE_CLASSIC = Classic Hook, disable some features
+#HAVE_C_A7A7 = Classic Armv7 Cortex A7 optimisation override
+#HAVE_HAKCHI = Hakchi Hook, change default configurations etc (TODO)
+
+all: $(TARGET)
+
+retroarch:
+	#Build the RetroArch Binary for cross platform classics (ARMv7 Cortex A7)
+	patchelf --version #Check if you have patchelf installed... (sudo apt-get install patchelf)
+	CFLAGS="-marm -mtune=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard" ./configure --host=arm-linux-gnueabihf --disable-wayland --disable-x11 --disable-opengl --disable-opengl1 --disable-opengl_core --enable-mali_fbdev --disable-freetype --enable-opengles --enable-udev --enable-alsa --enable-neon --enable-floathard --disable-discord
+	make HAVE_CLASSIC=1 HAVE_C_A7A7=1 HAVE_HAKCHI=1 -j #Cook it
+	arm-linux-gnueabihf-strip -v retroarch
+	patchelf --replace-needed libSDL2-2.0.so.0 libSDL2.so retroarch #libSDL2-2.0.so.0 sym link doesn't exist on native build. Just patch the binary...
+	@echo "*********************************************************************"
+	@echo "***     NES/SNES Classic RetroArch binary built successfully!     ***"
+	@echo "*********************************************************************"
+clean:
+	rm -rf obj-unix
+	rm -f *.d
+	rm -f *.o
+	rm -f audio/*.o
+	rm -f conf/*.o
+	rm -f gfx/*.o
+	rm -f gfx/drivers_font/*.o
+	rm -f gfx/drivers_font_renderer/*.o
+	rm -f gfx/drivers_context/*.o
+	rm -f gfx/py_state/*.o
+	rm -f compat/*.o
+	rm -f record/*.o
+	rm -f input/*.o
+	rm -f tools/*.o
+	rm -f $(BINDIR)/retroarch
+	rm -f $(BINDIR)/retroarch-joyconfig
+	rm -f $(PNDDIR)/readme.html
+	rm -f retroarch
+

--- a/Makefile.common
+++ b/Makefile.common
@@ -595,7 +595,9 @@ ifeq ($(HAVE_ALSA), 1)
    OBJ += audio/drivers/alsa.o
 
    ifneq ($(HAVE_HAKCHI), 1)
-      OBJ += midi/drivers/alsa_midi.o
+      ifneq ($(HAVE_SEGAM), 1)
+         OBJ += midi/drivers/alsa_midi.o
+      endif
    endif
 
    ifeq ($(HAVE_THREADS), 1)
@@ -2036,7 +2038,7 @@ endif
 ##################################
 ### Classic Platform specifics ###
 ###############WIP################
-# Help at https://modmyclassic.com/comp
+# Help at https://modmyclassic.com
 
 ifeq ($(HAVE_CLASSIC), 1)
   DEFINES += -DHAVE_CLASSIC
@@ -2065,5 +2067,9 @@ endif
 
 ifeq ($(HAVE_HAKCHI), 1)
    DEFINES += -DHAVE_HAKCHI
+endif
+
+ifeq ($(HAVE_SEGAM), 1)
+   DEFINES += -DHAVE_SEGAM
 endif
 ##################################

--- a/configuration.c
+++ b/configuration.c
@@ -447,7 +447,7 @@ static enum record_driver_enum RECORD_DEFAULT_DRIVER = RECORD_NULL;
 
 #ifdef HAVE_WINMM
 static enum midi_driver_enum MIDI_DEFAULT_DRIVER = MIDI_WINMM;
-#elif defined(HAVE_ALSA) && !defined(HAVE_HAKCHI)
+#elif defined(HAVE_ALSA) && !defined(HAVE_HAKCHI) && !defined(HAVE_SEGAM)
 static enum midi_driver_enum MIDI_DEFAULT_DRIVER = MIDI_ALSA;
 #else
 static enum midi_driver_enum MIDI_DEFAULT_DRIVER = MIDI_NULL;

--- a/libretro-common/dynamic/dylib.c
+++ b/libretro-common/dynamic/dylib.c
@@ -34,6 +34,281 @@
 #include <dlfcn.h>
 #endif
 
+/* MadMonkey's original LZMA .so file support push, still needs reviewing
+ * so assigning against CLASSIC platform only for now */
+#if defined(HAVE_CLASSIC) && defined(__GLIBC__) && defined(__GLIBC_PREREQ)
+#if __GLIBC_PREREQ(2, 2) /* shm_open */
+#define soramLoader
+#endif
+#endif
+
+#ifdef soramLoader
+/* stolen from here: https://x-c3ll.github.io/posts/fileless-memfd_create/ */
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/utsname.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <arpa/inet.h>
+#include <errno.h>
+#include <link.h>
+#include <pthread.h>
+
+#if 0
+#define debug_printf(...) printf(__VA_ARGS__)
+#else
+static int debug_printf(const char *format, ...) { return 0; }
+#endif
+
+typedef struct _soramHandle
+{
+   dylib_t handle;
+   char *soname;
+   int32_t ref;
+} soramHandle_t;
+
+#define VECTOR_LIST_TYPE soramHandle_t
+#define VECTOR_LIST_NAME soram
+#include <../lists/vector_list.c>
+typedef struct TYPE_NAME() soramList_t;
+#undef VECTOR_LIST_TYPE
+#undef VECTOR_LIST_NAME
+
+static soramList_t *soramList = 0;
+static pthread_mutex_t soramMutex = PTHREAD_MUTEX_INITIALIZER;
+
+static soramHandle_t* soramFindName(const char *soname)
+{
+   size_t i;
+   if (soramList == 0)
+      return 0;
+   for (i = 0; i < soramList->count; ++i)
+      if (strcmp(soname, soramList->data[i].soname) == 0)
+         return &soramList->data[i];
+   return 0;
+}
+
+static soramHandle_t* soramFindHandle(dylib_t handle)
+{
+   size_t i;
+   if (soramList == 0)
+      return 0;
+   for (i = 0; i < soramList->count; ++i)
+      if (handle == soramList->data[i].handle)
+         return &soramList->data[i];
+   return 0;
+}
+
+static void soramAdd(const char *soname, dylib_t handle)
+{
+   soramHandle_t *so, _so;
+   if (soramList == 0)
+      soramList = soram_vector_list_new();
+   so = soramFindHandle(0);
+   if (so == 0)
+      so = &_so;
+   so->handle = handle;
+   so->soname = strdup(soname);
+   so->ref = 1;
+   soram_vector_list_append(soramList, *so);
+}
+
+static bool soramRemove(dylib_t handle)
+{
+   size_t i, count;
+   soramHandle_t *so = soramFindHandle(handle);
+   if (so == 0)
+      return 0;
+   if (--so->ref > 0)
+      return 1;
+#ifndef NO_DLCLOSE
+   dlclose(so->handle);
+   free(so->soname);
+   so->handle = 0;
+   so->soname = 0;
+   count = 0;
+   for (i = 0; i < soramList->count; ++i)
+      if (soramList->data[i].ref > 0)
+         ++count;
+   if (count)
+      return 1;
+   soram_vector_list_free(soramList);
+   soramList = 0;
+#endif
+   return 1;
+}
+
+static void soramLock()
+{
+   pthread_mutex_lock(&soramMutex);
+}
+
+static void soramUnlock()
+{
+   pthread_mutex_unlock(&soramMutex);
+}
+
+/* Wrapper to call memfd_create syscall */
+static int ra_memfd_create(const char *pathname, int flags)
+{
+   return syscall(319, pathname, flags);
+}
+
+/* Returns a file descriptor where we can write our shared object */
+static int open_ramfs(const char *bname, int *shm)
+{
+   int fd = ra_memfd_create(bname, 1);
+   if (shm) *shm = 0;
+   if (fd < 0)
+   {
+      fd = shm_open(bname, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
+      if (shm) *shm = 1;
+   }
+   return fd;
+}
+
+static int is_xz(const char *pathname)
+{
+   uint32_t buffer[2];
+   FILE *hf = fopen(pathname, "rb");
+   buffer[0] = 0;
+   if (hf)
+   {
+      if (fread(buffer, 1, 4, hf) != 4)
+      {
+         buffer[0] = 0;
+      }
+      fclose(hf);
+   }
+   return (ntohl(buffer[0]) == 0xfd377a58) ? 0 : -1;
+}
+
+static int open_xz(const char *pathname, const char *bname, int *shm)
+{
+   int status = -1;
+   size_t size = 0x1000, rchunk = 0, wchunk = 0;
+   char *buffer;
+   FILE *fp;
+   int fd;
+
+   fd = open_ramfs(bname, shm);
+   if (fd < 0)
+      return fd;
+
+   buffer = (char*)malloc(size + 8);
+   if (buffer)
+   {
+      snprintf(buffer, size, "xz -cd '%s'", pathname);
+      fp = popen(buffer, "re");
+      if (fp != 0)
+      {
+         while (!feof(fp) && !ferror(fp))
+         {
+            rchunk=TEMP_FAILURE_RETRY(fread(buffer, 1, size, fp));
+            if (rchunk > 0)
+            {
+               wchunk=TEMP_FAILURE_RETRY(write(fd, buffer, rchunk));
+               if (wchunk != rchunk)
+                  break;
+            }
+         }
+         status = pclose(fp);
+      }
+
+      free(buffer);
+      if ((status == 0) && (wchunk == rchunk))
+         return fd;
+   }
+
+   close(fd);
+   return -1;
+}
+
+#ifdef DEBUG
+static int dlcallback(struct dl_phdr_info *info, size_t size, void *data)
+{
+   if (info && info->dlpi_name)
+      debug_printf("\t[+] %s\n", info->dlpi_name);
+   return 0;
+}
+#endif
+
+/* Load the shared object */
+static dylib_t soramLoad(const char *pathname, int flag)
+{
+   char path[128];
+   void *handle;
+   char *dname, *bname;
+   soramHandle_t *so;
+   int fd, shm;
+
+   if (is_xz(pathname) < 0)
+      return 0;
+
+   dname = strdup(pathname);
+   if (dname == 0)
+      return 0;
+   bname = basename(dname);
+
+   soramLock();
+   so = soramFindName(bname);
+   if (so)
+   {
+      ++so->ref;
+      soramUnlock();
+      free(dname);
+      return so->handle;
+   }
+
+   debug_printf("[INFO] [dylib] soramLoad(%s)\n", pathname);
+   fd = open_xz(pathname, bname, &shm);
+   if (fd < 0)
+   {
+      soramUnlock();
+      free(dname);
+      return 0;
+   }
+
+   snprintf(path, sizeof(path), "/proc/self/fd/%d", fd);
+   handle = dlopen(path, flag);
+   close(fd);
+#ifdef DEBUG
+   dl_iterate_phdr(dlcallback, 0);
+#endif
+   if (shm)
+   {
+#ifdef DEBUG
+      debug_printf("\t\tshm_unlink(%s) - ", bname);
+      errno = 0;
+      shm_unlink(bname);
+      debug_printf("%d\n", errno);
+#else
+      shm_unlink(bname);
+#endif
+   }
+   soramAdd(bname, handle);
+   soramUnlock();
+   free(dname);
+   debug_printf("[INFO] [dylib] soramLoad(%s) - %s\n", pathname, handle?"ok":"fail");
+   return handle;
+}
+
+static bool soramUnload(dylib_t handle)
+{
+   bool ret;
+   soramLock();
+   ret = soramRemove(handle);
+   soramUnlock();
+   return ret;
+}
+#endif /* soramLoader */
+
 /* Assume W-functions do not work below Win2K and Xbox platforms */
 #if defined(_WIN32_WINNT) && _WIN32_WINNT < 0x0500 || defined(_XBOX)
 
@@ -120,7 +395,12 @@ dylib_t dylib_load(const char *path)
    }
    last_dyn_error[0] = 0;
 #else
-   dylib_t lib = dlopen(path, RTLD_LAZY | RTLD_LOCAL);
+   dylib_t lib;
+  #ifdef soramLoader
+    lib = soramLoad(path, RTLD_LAZY);
+    if (!lib)
+  #endif
+   lib = dlopen(path, RTLD_LAZY);
 #endif
    return lib;
 }
@@ -198,8 +478,13 @@ void dylib_close(dylib_t lib)
       set_dl_error();
    last_dyn_error[0] = 0;
 #else
+#ifdef soramLoader
+   if (soramUnload(lib) == 0)
+#endif
 #ifndef NO_DLCLOSE
-   dlclose(lib);
+      dlclose(lib);
+#else
+      ;
 #endif
 #endif
 }

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -436,9 +436,9 @@ check_val '' UDEV "-ludev" '' libudev '' '' false
 check_val '' V4L2 -lv4l2 '' libv4l2 '' '' false
 check_val '' FREETYPE -lfreetype freetype2 freetype2 '' '' false
 check_val '' X11 -lX11 '' x11 '' '' false
-check_val '' XCB -lxcb '' xcb '' '' false
 
 if [ "$HAVE_X11" != 'no' ]; then
+   check_val '' XCB -lxcb '' xcb '' '' false
    check_val '' XEXT -lXext '' xext '' '' false
    check_val '' XF86VM -lXxf86vm '' xxf86vm '' '' false
 else

--- a/retroarch.c
+++ b/retroarch.c
@@ -733,7 +733,7 @@ extern midi_driver_t midi_winmm;
 extern midi_driver_t midi_alsa;
 
 static midi_driver_t *midi_drivers[] = {
-#if defined(HAVE_ALSA) && !defined(HAVE_HAKCHI)
+#if defined(HAVE_ALSA) && !defined(HAVE_HAKCHI) && !defined(HAVE_SEGAM)
    &midi_alsa,
 #endif
 #ifdef HAVE_WINMM


### PR DESCRIPTION
- Replaced crap A7A7 make
- Added better targets and clean targets for Sega Mega Drive Mini and (S)NES Classic
- Fixed bug with QB. (Now doesn't look for the x11 client library headers (lxcb) if --disable-x11 is true)
- Added MadMonkey's original .so LZMA commit again as was lost in time
(squashed)