### PR TITLE
(Menu Input) Add mouse/touchscreen gesture support + full gesture support for XMB

### DIFF
--- a/gfx/common/x11_common.c
+++ b/gfx/common/x11_common.c
@@ -554,6 +554,8 @@ bool x11_alive(void *data)
                case 4: /* Grabbed  */
                        /* Scroll up */
                case 5: /* Scroll down */
+               case 6: /* Scroll wheel left */
+               case 7: /* Scroll wheel right */
                   x_input_poll_wheel(&event.xbutton, true);
                   break;
             }

--- a/input/common/input_x11_common.c
+++ b/input/common/input_x11_common.c
@@ -20,6 +20,8 @@
 
 static bool x11_mouse_wu;
 static bool x11_mouse_wd;
+static bool x11_mouse_hwu;
+static bool x11_mouse_hwd;
 
 int16_t x_mouse_state_wheel(unsigned id)
 {
@@ -35,6 +37,14 @@ int16_t x_mouse_state_wheel(unsigned id)
          ret = x11_mouse_wd;
          x11_mouse_wd = 0;
          return ret;
+      case RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELUP:
+         ret = x11_mouse_hwu;
+         x11_mouse_hwu = 0;
+         return ret;
+      case RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELDOWN:
+         ret = x11_mouse_hwd;
+         x11_mouse_hwd = 0;
+         return ret;
    }
 
    return 0;
@@ -49,6 +59,14 @@ void x_input_poll_wheel(XButtonEvent *event, bool latch)
          break;
       case 5:
          x11_mouse_wd = 1;
+         break;
+      case 6:
+         /* Scroll wheel left == HORIZ_WHEELDOWN */
+         x11_mouse_hwd = 1;
+         break;
+      case 7:
+         /* Scroll wheel right == HORIZ_WHEELUP */
+         x11_mouse_hwu = 1;
          break;
    }
 }

--- a/input/drivers/x11_input.c
+++ b/input/drivers/x11_input.c
@@ -106,18 +106,9 @@ static bool x_mouse_button_pressed(
 
    case RETRO_DEVICE_ID_MOUSE_WHEELUP:
    case RETRO_DEVICE_ID_MOUSE_WHEELDOWN:
-      return x_mouse_state_wheel( key );
-
-/*   case RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELUP:
-      result = x11->mouse_hwu;
-      x11->mouse_hwu = false;
-      return result;
-
+   case RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELUP:
    case RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELDOWN:
-      result = x11->mouse_hwd;
-      x11->mouse_hwd = false;
-      return result;
-*/
+      return x_mouse_state_wheel( key );
    }
 
    return false;
@@ -237,6 +228,8 @@ static int16_t x_mouse_state(x11_input_t *x11, unsigned id)
          return x11->mouse_r;
       case RETRO_DEVICE_ID_MOUSE_WHEELUP:
       case RETRO_DEVICE_ID_MOUSE_WHEELDOWN:
+      case RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELUP:
+      case RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELDOWN:
          return x_mouse_state_wheel(id);
       case RETRO_DEVICE_ID_MOUSE_MIDDLE:
          return x11->mouse_m;

--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -2294,15 +2294,33 @@ static bool ozone_get_load_content_animation_data(void *userdata, menu_texture_i
 
 static int ozone_pointer_up(void *userdata,
       unsigned x, unsigned y, unsigned ptr,
+      enum menu_input_pointer_gesture gesture,
       menu_file_list_cbs_t *cbs,
       menu_entry_t *entry, unsigned action)
 {
    size_t selection         = menu_navigation_get_selection();
-   if (ptr == selection)
-      return (unsigned)menu_entry_action(entry, (unsigned)selection, MENU_ACTION_SELECT);
 
-   menu_navigation_set_selection(ptr);
-   menu_driver_navigation_set(false);
+   switch (gesture)
+   {
+      case MENU_INPUT_GESTURE_TAP:
+      case MENU_INPUT_GESTURE_SHORT_PRESS:
+         /* Normal pointer input */
+         if (ptr == selection)
+            return (unsigned)menu_entry_action(entry, (unsigned)selection, MENU_ACTION_SELECT);
+
+         menu_navigation_set_selection(ptr);
+         menu_driver_navigation_set(false);
+         break;
+      case MENU_INPUT_GESTURE_LONG_PRESS:
+         /* 'Reset to default' action */
+         if ((ptr <= (menu_entries_get_size() - 1)) &&
+             (ptr == selection))
+            return menu_entry_action(entry, (unsigned)selection, MENU_ACTION_START);
+         break;
+      default:
+         /* Ignore input */
+         break;
+   }
 
    return 0;
 }

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -2712,7 +2712,6 @@ void menu_display_draw_cursor(
    settings_t *settings = config_get_ptr();
    bool cursor_visible  = settings->bools.video_fullscreen ||
        !menu_display_has_windowed;
-
    if (!settings->bools.menu_mouse_enable || !cursor_visible)
       return;
 
@@ -3568,6 +3567,7 @@ bool menu_driver_ctl(enum rarch_menu_ctl_state state, void *data)
             }
             point->retcode = menu_driver_ctx->pointer_up(menu_userdata,
                   point->x, point->y, point->ptr,
+                  point->gesture,
                   point->cbs, point->entry, point->action);
          }
          break;

--- a/menu/menu_driver.h
+++ b/menu/menu_driver.h
@@ -319,6 +319,7 @@ typedef struct menu_ctx_driver
          menu_file_list_cbs_t *cbs,
          menu_entry_t *entry, unsigned action);
    int (*pointer_up)(void *data, unsigned x, unsigned y, unsigned ptr,
+         enum menu_input_pointer_gesture gesture,
          menu_file_list_cbs_t *cbs,
          menu_entry_t *entry, unsigned action);
    bool (*get_load_content_animation_data)(void *userdata, menu_texture_item *icon, char **playlist_name);
@@ -458,6 +459,7 @@ typedef struct menu_ctx_pointer
    unsigned y;
    unsigned ptr;
    unsigned action;
+   enum menu_input_pointer_gesture gesture;
    int retcode;
    menu_file_list_cbs_t *cbs;
    menu_entry_t *entry;


### PR DESCRIPTION
## Description

This PR updates the menu 'pointer' (mouse/touchscreen) code with the concept of gestures. Pointer input can now trigger the following signals on a 'pointer up' (released) event:

- Tap: A momentary press, of duration less than 200 ms

- Short press: A 'normal'-type press of duration between 200 ms and 1.5 s

- Long press: A press of duration longer than 1.5s

- Swipe up/down/left/right

In addition, pressing, holding and dragging a pointer generates 'press direction' signals with a frequency proportional to drag distance. This basically implements a virtual analog directional pad.

These signals are 'universal' - menu devs can access/use them however they please.

To showcase this, full gesture support has been added to XMB. This has the following functionality:

- Swipe up/down in the left margin: scroll through current menu list by ascending/descending the alphabet

- Swipe up/down in the middle region of the screen:  scroll up/down through current menu list by one 'page' (i.e. one screen's worth of entries)

- Swipe left/right: navigate left right, or change the setting value of the currently active item

- Tap left margin *below* top margin: Back/cancel action

- Tap left margin *above* top margin (top left corner): Open search interface

- Tap right margin: select currently active item

- Tap menu list in middle region of screen: activate item, or select it if already active

- Long press active menu item in middle region of screen: reset item to default setting value

- Press and drag up/down in the right margin: scroll up/down through menu list (the further you drag, the faster it goes - up to a limit corresponding to keeping a cursor key held down)

- Press and drag left/right in the top margin: navigate left/right, or change the setting value of the currently active item (again - the further you drag, the faster it goes)

Other menu drivers will be updated with gesture support in subsequent PRs.

Note: As a small bonus, this PR also adds horizontal mouse wheel support to the X11 input driver (the default input driver under Linux)
