### PR TITLE
Support GLDirect (D3D9 to OGL1.1 wrapper) in gl1 driver

### DIFF
--- a/gfx/drivers/gl1.c
+++ b/gfx/drivers/gl1.c
@@ -568,28 +568,27 @@ static void draw_tex(gl1_t *gl1, int pot_width, int pot_height, int width, int h
       so we send the frame as dummy data */
    glTexImage2D(GL_TEXTURE_2D, 0, internalFormat, pot_width, pot_height, 0, format, type, frame_to_copy);
 
+   uint8_t *frame = (uint8_t*)frame_to_copy;
+   uint8_t *frame_rgba = NULL;
    if (!gl1->supports_bgra) {
-      uint8_t* frame_rgba = malloc(pot_width * pot_height * 4);
-      uint8_t* frame_bgra = frame_to_copy;
-      int x, y;
-      for (y = 0; y < pot_height; y++) {
-         for (x = 0; x < pot_width; x++) {
-            int index = (y * pot_width + x) * 4;
-            frame_rgba[index + 2] = frame_bgra[index + 0];
-            frame_rgba[index + 1] = frame_bgra[index + 1];
-            frame_rgba[index + 0] = frame_bgra[index + 2];
-            frame_rgba[index + 3] = 255;
+      frame_rgba = (uint8_t*)malloc(pot_width * pot_height * 4);
+      if (frame_rgba) {
+         int x, y;
+         for (y = 0; y < pot_height; y++) {
+            for (x = 0; x < pot_width; x++) {
+               int index = (y * pot_width + x) * 4;
+               frame_rgba[index + 2] = frame[index + 0];
+               frame_rgba[index + 1] = frame[index + 1];
+               frame_rgba[index + 0] = frame[index + 2];
+               frame_rgba[index + 3] = frame[index + 3];
+            }
          }
+         frame = frame_rgba;
       }
-
-      glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height, GL_RGBA, type, frame_rgba);
-      free(frame_rgba);
-   }
-   else {
-      glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height, format, type, frame_to_copy);
    }
 
-   
+   glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height, format, type, frame);
+   free(frame_rgba);
 
    if (tex == gl1->tex)
    {

--- a/gfx/drivers/gl1.c
+++ b/gfx/drivers/gl1.c
@@ -571,8 +571,9 @@ static void draw_tex(gl1_t *gl1, int pot_width, int pot_height, int width, int h
    if (!gl1->supports_bgra) {
       uint8_t* frame_rgba = malloc(pot_width * pot_height * 4);
       uint8_t* frame_bgra = frame_to_copy;
-      for (int y = 0; y < pot_height; y++) {
-         for (int x = 0; x < pot_width; x++) {
+      int x, y;
+      for (y = 0; y < pot_height; y++) {
+         for (x = 0; x < pot_width; x++) {
             int index = (y * pot_width + x) * 4;
             frame_rgba[index + 2] = frame_bgra[index + 0];
             frame_rgba[index + 1] = frame_bgra[index + 1];


### PR DESCRIPTION
## Description

SciTech GLDirect is an old D3D9 to OpenGL 1.1 wrapper based on Mesa 5.x, usually used to provide OpenGL acceleration on old graphics cards that do not natively support OpenGL.

https://sourceforge.net/projects/gldirect/

It is also ported to Windows RT years ago to provide OpenGL support there (the other solution is to port Mesa itself, but that is software-only).

GLDirect assert fails when glTexImage2D() NULL, and it does not support BGRA, therefore some fixes have to be made.

It might be a workaround for those who need a D3D9 driver without CG?

Note:
Aside from HAVE_OPENGL1, GL_DEBUG is needed too, otherwise it will crash with "[WGL]: Failed to share contexts."