### PR TITLE
Fixed bug with touchscreen/lightgun

### DIFF
--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -520,7 +520,7 @@ static bool udev_input_add_device(udev_input_t *udev,
          else
          {
             device->mouse.x_min = absinfo.minimum;
-            device->mouse.x_min = absinfo.maximum;
+            device->mouse.x_max = absinfo.maximum;
          }
       }
 
@@ -534,7 +534,7 @@ static bool udev_input_add_device(udev_input_t *udev,
 	     else
          {
            device->mouse.y_min = absinfo.minimum;
-           device->mouse.y_min = absinfo.maximum;
+           device->mouse.y_max = absinfo.maximum;
          }
       }
    }


### PR DESCRIPTION
From my analysis I "believe" this is a development bug/typo and is causing issues with mouse and touchscreen input, that would affect touchscreen and lightgun APIs.

Pointer functionality stop working when this area was refactored for me and starting working again after this fix.  It looks like a cut and paste mistake.

I'm inexperienced so constructive feedback is welcome if I have gone the wrong way about things. 