### PR TITLE
[VITA] Add system language detection.

### DIFF
--- a/Makefile.vita
+++ b/Makefile.vita
@@ -85,12 +85,10 @@ LD      := $(CXX)
 LIBDIRS := -L.
 
 ARCHFLAGS := -march=armv7-a -mfpu=neon -mfloat-abi=hard -DVITA
-CFLAGS    += $(ARCHFLAGS) -mword-relocations -fno-optimize-sibling-calls
+CFLAGS    += $(ARCHFLAGS) -mword-relocations -fno-optimize-sibling-calls -O2
 
 ifeq ($(DEBUG), 1)
-   CFLAGS += -O2 -g
-else
-   CFLAGS += -O3
+   CFLAGS += -g
 endif
 
 ASFLAGS := $(CFLAGS)
@@ -114,7 +112,7 @@ ifeq ($(WHOLE_ARCHIVE_LINK), 1)
 endif
 CXXFLAGS := $(CFLAGS) -fno-rtti -fno-exceptions
 
-VITA_LIBS := -lSceDisplay_stub -lSceGxm_stub -lSceNet_stub -lSceNetCtl_stub \
+VITA_LIBS := -lSceDisplay_stub -lSceGxm_stub -lSceNet_stub -lSceNetCtl_stub -lSceAppUtil_stub \
 	-lSceSysmodule_stub -lSceCtrl_stub -lSceHid_stub -lSceTouch_stub -lSceAudio_stub \
 	-lScePower_stub -lSceRtc_stub -lSceCommonDialog_stub -lScePgf_stub \
 	-lSceFiber_stub -lSceMotion_stub -lSceAppMgr_stub -lpthread -lpng -lz

--- a/Makefile.vita.salamander
+++ b/Makefile.vita.salamander
@@ -21,7 +21,7 @@ RARCH_DEFINES = -DVITA -DIS_SALAMANDER -DRARCH_CONSOLE
 
 LIBDIR =
 LDFLAGS =
-LIBS = -lSceDisplay_stub -lSceGxm_stub -lSceNet_stub -lSceNetCtl_stub\
+LIBS = -lSceDisplay_stub -lSceGxm_stub -lSceNet_stub -lSceNetCtl_stub -lSceAppUtil_stub\
      -lSceSysmodule_stub -lSceCtrl_stub -lSceHid_stub -lSceAudio_stub -lSceFiber_stub\
      -lScePower_stub -lSceRtc_stub -lSceCommonDialog_stub -lScePgf_stub \
      -lSceMotion_stub -lSceAppMgr_stub -lfreetype -lpng -lm -lc

--- a/configuration.c
+++ b/configuration.c
@@ -1836,7 +1836,11 @@ static struct config_uint_setting *populate_settings_uint(settings_t *settings, 
    SETTING_UINT("netplay_share_analog",         &settings->uints.netplay_share_analog,  true, netplay_share_analog, false);
 #endif
 #ifdef HAVE_LANGEXTRA
+#ifdef VITA
+   SETTING_UINT("user_language",                msg_hash_get_uint(MSG_HASH_USER_LANGUAGE), true, frontend_driver_get_user_language(), false);
+#else
    SETTING_UINT("user_language",                msg_hash_get_uint(MSG_HASH_USER_LANGUAGE), true, DEFAULT_USER_LANGUAGE, false);
+#endif
 #endif
    SETTING_UINT("bundle_assets_extract_version_current", &settings->uints.bundle_assets_extract_version_current, true, 0, false);
    SETTING_UINT("bundle_assets_extract_last_version",    &settings->uints.bundle_assets_extract_last_version, true, 0, false);

--- a/frontend/drivers/platform_psp.c
+++ b/frontend/drivers/platform_psp.c
@@ -23,9 +23,11 @@
 #endif
 
 #ifdef VITA
+#include <psp2/system_param.h>
 #include <psp2/power.h>
 #include <psp2/sysmodule.h>
 #include <psp2/appmgr.h>
+#include <psp2/apputil.h>
 
 #include "../../bootstrap/vita/sbrk.c"
 #include "../../bootstrap/vita/threading.c"
@@ -300,6 +302,12 @@ static void frontend_psp_init(void *data)
    scePowerSetGpuClockFrequency(222);
    scePowerSetGpuXbarClockFrequency(166);
    sceSysmoduleLoadModule(SCE_SYSMODULE_NET);
+   
+   SceAppUtilInitParam appUtilParam;
+   SceAppUtilBootParam appUtilBootParam;
+   memset(&appUtilParam, 0, sizeof(SceAppUtilInitParam));
+   memset(&appUtilBootParam, 0, sizeof(SceAppUtilBootParam));
+   sceAppUtilInit(&appUtilParam, &appUtilBootParam);
 #else
    (void)data;
    /* initialize debug screen */
@@ -506,6 +514,54 @@ static int frontend_psp_parse_drive_list(void *data, bool load_content)
    return 0;
 }
 
+#ifdef VITA
+enum retro_language psp_get_retro_lang_from_langid(int langid)
+{
+   switch (langid)
+   {
+   case SCE_SYSTEM_PARAM_LANG_JAPANESE:
+      return RETRO_LANGUAGE_JAPANESE;
+   case SCE_SYSTEM_PARAM_LANG_FRENCH:
+      return RETRO_LANGUAGE_FRENCH;
+   case SCE_SYSTEM_PARAM_LANG_SPANISH:
+      return RETRO_LANGUAGE_SPANISH;
+   case SCE_SYSTEM_PARAM_LANG_GERMAN:
+      return RETRO_LANGUAGE_GERMAN;
+   case SCE_SYSTEM_PARAM_LANG_ITALIAN:
+      return RETRO_LANGUAGE_ITALIAN;
+   case SCE_SYSTEM_PARAM_LANG_DUTCH:
+      return RETRO_LANGUAGE_DUTCH;
+   case SCE_SYSTEM_PARAM_LANG_PORTUGUESE_PT:
+      return RETRO_LANGUAGE_PORTUGUESE_PORTUGAL;
+   case SCE_SYSTEM_PARAM_LANG_RUSSIAN:
+      return RETRO_LANGUAGE_RUSSIAN;
+   case SCE_SYSTEM_PARAM_LANG_KOREAN:
+      return RETRO_LANGUAGE_KOREAN;
+   case SCE_SYSTEM_PARAM_LANG_CHINESE_T:
+      return RETRO_LANGUAGE_CHINESE_TRADITIONAL;
+   case SCE_SYSTEM_PARAM_LANG_CHINESE_S:
+      return RETRO_LANGUAGE_CHINESE_SIMPLIFIED;
+   case SCE_SYSTEM_PARAM_LANG_POLISH:
+      return RETRO_LANGUAGE_POLISH;
+   case SCE_SYSTEM_PARAM_LANG_PORTUGUESE_BR:
+      return RETRO_LANGUAGE_PORTUGUESE_BRAZIL;
+   case SCE_SYSTEM_PARAM_LANG_TURKISH:
+      return RETRO_LANGUAGE_TURKISH;
+   case SCE_SYSTEM_PARAM_LANG_ENGLISH_US:
+   case SCE_SYSTEM_PARAM_LANG_ENGLISH_GB:
+   default:
+      return RETRO_LANGUAGE_ENGLISH;
+   }
+}
+
+enum retro_language frontend_psp_get_user_language(void)
+{ 
+   int langid;
+   sceAppUtilSystemParamGetInt(SCE_SYSTEM_PARAM_ID_LANG, &langid);
+   return psp_get_retro_lang_from_langid(langid);
+}
+#endif
+
 frontend_ctx_driver_t frontend_ctx_psp = {
    frontend_psp_get_environment_settings,
    frontend_psp_init,
@@ -538,10 +594,11 @@ frontend_ctx_driver_t frontend_ctx_psp = {
    NULL,                         /* check_for_path_changes */
    NULL,                         /* set_sustained_performance_mode */
    NULL,                         /* get_cpu_model_name */
-   NULL,                         /* get_user_language */
 #ifdef VITA
+   frontend_psp_get_user_language,
    "vita",
 #else
+   NULL,                         /* get_user_language */
    "psp",
 #endif
 };


### PR DESCRIPTION
Adds system language detection to Vita build.
Switched from O3 to O2 since O3 was causing some issues with config_entry_exists (from my testings with vitaGL and idTech 3, O2 is generally always faster than O3 on Vita so there's no reason to stick with O3).

I've added the ifdef in configuration.c so that system language's properly applied at first boot too when retroarch.cfg doesn't exist (which is the standard installation case on Vita).