### PR TITLE
[VITA] Memory related improvements

### DIFF
--- a/Makefile.vita
+++ b/Makefile.vita
@@ -158,7 +158,7 @@ $(TARGET).elf: $(OBJ) libretro_vita.a
 	vita-make-fself -c -s $< $@
 
 %.vpk: %.self
-	vita-mksfoex -s TITLE_ID=$(VITA_TITLE_ID) "$(VITA_TITLE_NAME)" param.sfo
+	vita-mksfoex -s TITLE_ID=$(VITA_TITLE_ID) "$(VITA_TITLE_NAME)" -d ATTRIBUTE2=12 param.sfo
 	vita-pack-vpk -s param.sfo -b $< $@
 
 clean:

--- a/Makefile.vita.salamander
+++ b/Makefile.vita.salamander
@@ -55,7 +55,7 @@ OBJS = frontend/frontend_salamander.o \
 all: $(TARGET).vpk
 
 %.vpk: eboot.bin
-	vita-mksfoex -s TITLE_ID=$(TITLE_ID) "$(TARGET)" param.sfo
+	vita-mksfoex -s TITLE_ID=$(TITLE_ID) "$(TARGET)" -d ATTRIBUTE2=12 param.sfo
 	vita-pack-vpk -s param.sfo -b eboot.bin $@
 
 eboot.bin: $(TARGET).velf

--- a/frontend/drivers/platform_psp.c
+++ b/frontend/drivers/platform_psp.c
@@ -560,6 +560,16 @@ enum retro_language frontend_psp_get_user_language(void)
    sceAppUtilSystemParamGetInt(SCE_SYSTEM_PARAM_ID_LANG, &langid);
    return psp_get_retro_lang_from_langid(langid);
 }
+
+static uint64_t frontend_psp_get_mem_total(void)
+{
+   return _newlib_heap_end - _newlib_heap_base;
+}
+
+static uint64_t frontend_psp_get_mem_used(void)
+{
+   return _newlib_heap_end - _newlib_heap_cur;
+}
 #endif
 
 frontend_ctx_driver_t frontend_ctx_psp = {
@@ -582,8 +592,13 @@ frontend_ctx_driver_t frontend_ctx_psp = {
    frontend_psp_get_architecture,
    frontend_psp_get_powerstate,
    frontend_psp_parse_drive_list,
+#ifdef VITA
+   frontend_psp_get_mem_total,
+   frontend_psp_get_mem_used,
+#else
    NULL,                         /* get_mem_total */
    NULL,                         /* get_mem_free */
+#endif
    NULL,                         /* install_signal_handler */
    NULL,                         /* get_sighandler_state */
    NULL,                         /* set_sighandler_state */


### PR DESCRIPTION
- First commit implements get_mem_total and get_mem_free functions for Vita frontend.
- Second commit makes the newlib heap being allocated dynamically depending on system free mem. (We get approximately 60 extra MBs compared to @frangarcj last PR)