### PR TITLE
Fix 3DS screen flickering when OSD is enabled

### DIFF
--- a/gfx/drivers/ctr_gfx.c
+++ b/gfx/drivers/ctr_gfx.c
@@ -747,9 +747,9 @@ static bool ctr_frame(void* data, const void* frame,
       ctr->frame_coords->u1 = width;
       ctr->frame_coords->v1 = height;
       GSPGPU_FlushDataCache(ctr->frame_coords, sizeof(ctr_vertex_t));
-      ctrGuSetVertexShaderFloatUniform(0, (float*)&ctr->scale_vector, 1);
    }
 
+   ctrGuSetVertexShaderFloatUniform(0, (float*)&ctr->scale_vector, 1);
    ctrGuSetTexture(GPU_TEXUNIT0, VIRT_TO_PHYS(ctr->texture_swizzled), ctr->texture_width, ctr->texture_height,
                   (ctr->smooth? GPU_TEXTURE_MAG_FILTER(GPU_LINEAR)  | GPU_TEXTURE_MIN_FILTER(GPU_LINEAR)
                               : GPU_TEXTURE_MAG_FILTER(GPU_NEAREST) | GPU_TEXTURE_MIN_FILTER(GPU_NEAREST)) |


### PR DESCRIPTION

## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

On the 3DS, for some cores, the screen will flicker if OSD is enabled, and sometimes when going in and out of the menu.

As far as I can tell, this happens when a frame is dup'd, and we send 0x0 as the frame to the gfx driver. When that happens, we still draw the OSD, using a vertex shader to transform and render it at the right size.

When the frame is 0x0, though, the vertex shader uniforms are never _reset_ to redraw the previous frame, so it's drawn with different params, and gets drawn the wrong size. It will draw as the correct size when the correct vertex shader uniforms are set, and the incorrect size when the incorrect uniforms are set, causing flickering.

At least, that's what I think is happening -- I'm not too familiar with graphics dev. Forcing the vertex shader to be set regardless of whether the frame data is set fixes it, at least during some light testing with PCSX.

## Reviewers

