### PR TITLE
Fix BSV recording/playback

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -12290,7 +12290,7 @@ static int16_t input_state(unsigned port, unsigned device,
    if (BSV_MOVIE_IS_PLAYBACK_ON())
    {
       int16_t bsv_result;
-      if (intfstream_read(bsv_movie_state_handle->file, &bsv_result, 1) == 1)
+      if (intfstream_read(bsv_movie_state_handle->file, &bsv_result, 2) == 2)
          return swap_if_big16(bsv_result);
       bsv_movie_state.movie_end = true;
    }
@@ -12321,7 +12321,7 @@ static int16_t input_state(unsigned port, unsigned device,
    if (BSV_MOVIE_IS_PLAYBACK_OFF())
    {
       result = swap_if_big16(result);
-      intfstream_write(bsv_movie_state_handle->file, &result, 1);
+      intfstream_write(bsv_movie_state_handle->file, &result, 2);
    }
 
    return result;


### PR DESCRIPTION
## Description

Inputs are 16-bit numbers, but the file writing routines were called with just one byte lengths.  This change fixes BSV recording and playback for me, which previously was acting incoherently (e.g. on playback the first byte of each input would be `fff0`).

I tested this by printf-ing each input recorded or played back (in hex) along with the frame number, recording an input trace with fceumm in Super Mario, and then playing it back.  I diffed the text produced by recording with the text produced by playback.  After this patch the two texts were identical, where before they differed on every line.