### PR TITLE
always show advanced sync options in Qt

### DIFF
--- a/ui/drivers/qt/options/latency.cpp
+++ b/ui/drivers/qt/options/latency.cpp
@@ -26,6 +26,7 @@ QWidget *LatencyPage::widget()
    QWidget                         *widget = new QWidget;
    FormLayout                      *layout = new FormLayout;
    CheckableSettingsGroup *runAheadGpuSync = new CheckableSettingsGroup(MENU_ENUM_LABEL_RUN_AHEAD_ENABLED);
+
    rarch_setting_t *hardSyncSetting        = menu_setting_find_enum(MENU_ENUM_LABEL_VIDEO_HARD_SYNC);
 
    if (hardSyncSetting)
@@ -36,6 +37,8 @@ QWidget *LatencyPage::widget()
 
       layout->addRow(hardSyncGroup);
    }
+
+   layout->add(MENU_ENUM_LABEL_VIDEO_MAX_SWAPCHAIN_IMAGES);
 
    layout->add(MENU_ENUM_LABEL_VIDEO_FRAME_DELAY);
    layout->add(MENU_ENUM_LABEL_AUDIO_LATENCY);

--- a/ui/drivers/qt/options/video.cpp
+++ b/ui/drivers/qt/options/video.cpp
@@ -123,17 +123,15 @@ QWidget *VideoPage::widget()
    vSyncGroup->add(MENU_ENUM_LABEL_VIDEO_FRAME_DELAY);
    syncGroup->addRow(vSyncGroup);
 
+   rarch_setting_t *hardSyncSetting = menu_setting_find_enum(MENU_ENUM_LABEL_VIDEO_HARD_SYNC);
+
+   if (hardSyncSetting)
    {
-      rarch_setting_t *hardSyncSetting = menu_setting_find_enum(MENU_ENUM_LABEL_VIDEO_HARD_SYNC);
+      CheckableSettingsGroup *hardSyncGroup = new CheckableSettingsGroup(hardSyncSetting);
 
-      if (hardSyncSetting)
-      {
-         CheckableSettingsGroup *hardSyncGroup = new CheckableSettingsGroup(hardSyncSetting);
+      hardSyncGroup->add(MENU_ENUM_LABEL_VIDEO_HARD_SYNC_FRAMES);
 
-         hardSyncGroup->add(MENU_ENUM_LABEL_VIDEO_HARD_SYNC_FRAMES);
-
-         syncGroup->addRow(hardSyncGroup);
-      }
+      syncGroup->addRow(hardSyncGroup);
    }
 
    syncGroup->add(MENU_ENUM_LABEL_VIDEO_MAX_SWAPCHAIN_IMAGES);


### PR DESCRIPTION
Always show hard sync and image swapchain options in Qt as we don't know how to refresh (filtering the right one according to the video driver) after a driver switching.

Add image swapchain option that was missing in the Latency section.



jdgleaver filtering patch that works at start but isn't refresh after a driver switching:
[qt_fix.txt](https://github.com/libretro/RetroArch/files/3720657/qt_fix.txt)
