### PR TITLE
travis: Try to fix xcode10.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ matrix:
     - os: osx
       osx_image: xcode10.1
       script:
+        - brew update-reset
         - brew install --force-bottle qt5
         - xcodebuild -target RetroArchQt -configuration Release -project pkg/apple/RetroArch_Metal.xcodeproj
       deploy:


### PR DESCRIPTION
## Description

Source: https://stackoverflow.com/questions/54888582/ruby-cannot-load-such-file-active-support-core-ext-object-blank

## Related Issues

```
/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- active_support/core_ext/object/blank (LoadError)
	from /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/local/Homebrew/Library/Homebrew/global.rb:12:in `<top (required)>'
	from /usr/local/Homebrew/Library/Homebrew/brew.rb:23:in `require_relative'
	from /usr/local/Homebrew/Library/Homebrew/brew.rb:23:in `<main>'

The command "brew install --force-bottle qt5" exited with 1.
```

## Reviewers

Travis CI must pass.
