### PR TITLE
qb: Update the die function.

### DIFF
--- a/qb/qb.init.sh
+++ b/qb/qb.init.sh
@@ -7,11 +7,12 @@
 die()
 {	ret="$1"
 	shift 1
-	printf %s\\n "$@" >&2
 	case "$ret" in
-		: ) return 0 ;;
-		* ) exit "$ret" ;;
+		: ) printf %s\\n "$@" >&2; return 0 ;;
+		0 ) printf %s\\n "$@" ;;
+		* ) printf %s\\n "$@" >&2 ;;
 	esac
+	exit "$ret"
 }
 
 # exists:


### PR DESCRIPTION
## Description

This updates the `die` function to not print exit messages to `stderr` when they are not errors. This can be done with `die 0 'Some exit message'` which is not currently used, but should be fixed regardless.
