### PR TITLE
(Switch) Make the audren threaded audio driver default

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -699,7 +699,7 @@ const char *config_get_default_audio(void)
          return "dsp";
       case AUDIO_SWITCH:
 #if defined(HAVE_LIBNX)
-         return "switch_thread";
+         return "switch_audren_thread";
 #else
          return "switch";
 #endif


### PR DESCRIPTION
## Description

Make the audren driver as default, on the libnx target. Multiple people have been using it for a while including @m4xw and me, it's probably time to make it the default on new installations.

## Reviewers

@m4xw 
