### PR TITLE
(GLUI) Menu improvements (Round 2)

### DIFF
--- a/menu/menu_animation.c
+++ b/menu/menu_animation.c
@@ -33,6 +33,7 @@
 #undef DG_DYNARR_IMPLEMENTATION
 
 #include "menu_animation.h"
+#include "menu_driver.h"
 #include "../configuration.h"
 #include "../performance_counters.h"
 
@@ -1255,13 +1256,20 @@ static void menu_animation_update_time(bool timedate_enable, unsigned video_widt
        *   any kind of DPI scaling - i.e. text gets smaller
        *   as resolution increases. This is annoying. It
        *   means we have to use a fixed multiplier for
-       *   Ozone as well... */
+       *   Ozone as well...
+       *   Note 3: GLUI uses the new DPI scaling system,
+       *   so scaling multiplier is menu_display_get_dpi_scale()
+       *   multiplied by a small correction factor (since the
+       *   default 1.0x speed is just a little faster than the
+       *   non-smooth ticker) */
       if (string_is_equal(settings->arrays.menu_driver, "rgui"))
          ticker_pixel_increment *= 0.25f;
       /* TODO/FIXME: Remove this Ozone special case if/when
        * Ozone gets proper DPI scaling */
       else if (string_is_equal(settings->arrays.menu_driver, "ozone"))
          ticker_pixel_increment *= 0.5f;
+      else if (string_is_equal(settings->arrays.menu_driver, "glui"))
+         ticker_pixel_increment *= (menu_display_get_dpi_scale(video_width, video_height) * 0.8f);
       else if (video_width > 0)
          ticker_pixel_increment *= ((float)video_width / 1920.0f);
 

--- a/retroarch.c
+++ b/retroarch.c
@@ -13283,6 +13283,8 @@ static int menu_input_pointer_post_iterate(
             {
                point.x       = x;
                point.y       = y;
+               /* Note: menu_input->ptr is meaningless here when
+                * using a touchscreen... */
                point.ptr     = menu_input->ptr;
                point.cbs     = cbs;
                point.entry   = entry;


### PR DESCRIPTION
## Description

This is a follow up to PR #9607. It contains another batch of small improvements to the Material UI menu driver (still many more to come!):

- The menu entry rendering code has been completely rewritten and optimised. There is no longer any duplicated/wasted effort, label widths have been corrected, and the code is actually intelligible now :)

- The system bar has been optimised. The width of the clock and battery status strings is now cached, and only recalculated when the strings change (this is quite an expensive operation, and now we only do it once every ~30 seconds rather than every frame)

- Smooth ticker text speed is now set correctly, and consistently regardless of screen size/orientation. We were previously basing this on screen width, which is incorrect, since Material UI uses DPI scaling.

- A subtle 'fade in' animation is now used to provide user feedback when 'short pressing' a menu entry to highlight (but not select) it. This sounds like a very trivial thing, but it makes quite a difference to the 'feel' of the menu:

![window_record__2019_10_18__17_51_18](https://user-images.githubusercontent.com/38211560/67113874-76cbba80-f1d2-11e9-8932-06729db8881c.gif)
