### PR TITLE
(video_driver_frame) Cache frame before converting 0RGB1555

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -19638,7 +19638,8 @@ static void video_driver_frame(const void *data, unsigned width,
       return;
 
    if (
-            video_driver_scaler_ptr
+         !menu_driver_alive()
+         && video_driver_scaler_ptr
          && data
          && (video_driver_pix_fmt == RETRO_PIXEL_FORMAT_0RGB1555)
          && (data != RETRO_HW_FRAME_BUFFER_VALID)

--- a/retroarch.c
+++ b/retroarch.c
@@ -19637,9 +19637,14 @@ static void video_driver_frame(const void *data, unsigned width,
    if (!video_driver_active)
       return;
 
+   if (data)
+      frame_cache_data = data;
+   frame_cache_width   = width;
+   frame_cache_height  = height;
+   frame_cache_pitch   = pitch;
+   
    if (
-         !menu_driver_is_alive()
-         && video_driver_scaler_ptr
+         video_driver_scaler_ptr
          && data
          && (video_driver_pix_fmt == RETRO_PIXEL_FORMAT_0RGB1555)
          && (data != RETRO_HW_FRAME_BUFFER_VALID)
@@ -19652,12 +19657,6 @@ static void video_driver_frame(const void *data, unsigned width,
       data                = video_driver_scaler_ptr->scaler_out;
       pitch               = video_driver_scaler_ptr->scaler->out_stride;
    }
-
-   if (data)
-      frame_cache_data = data;
-   frame_cache_width   = width;
-   frame_cache_height  = height;
-   frame_cache_pitch   = pitch;
 
    video_driver_build_info(&video_info);
 

--- a/retroarch.c
+++ b/retroarch.c
@@ -19638,7 +19638,7 @@ static void video_driver_frame(const void *data, unsigned width,
       return;
 
    if (
-         !menu_driver_alive()
+         !menu_driver_is_alive()
          && video_driver_scaler_ptr
          && data
          && (video_driver_pix_fmt == RETRO_PIXEL_FORMAT_0RGB1555)


### PR DESCRIPTION
## Description

Fixes the color cycling that happens when the menu is up and the core's internal pixel format is 0RGB1555.

~~This happened because video_driver_scaler would keep converting from 0RGB1555 to RGB565, even when the core was paused~~

When the runloop is idle/paused, the last cached frame data is reused for rendering. Because the caching is done after pixel format conversion and because video rendering function has no mechanism to check if that was already done, 0RGB1555->RGB565 conversion is done on data that is already RGB565, causing this bug.

## Related Issues
#9615
Affects all cores that use 0RGB1555 when:
- Content is paused and the menu is up;
- Taking screenshots;
- Frame advance mode;

## Reviewers

@Autechre64
@hunterk
@jdgleaver 
@Themaister 
