### PR TITLE
Fix DBUS screensaver inhibit function

### DIFF
--- a/gfx/common/dbus_common.c
+++ b/gfx/common/dbus_common.c
@@ -74,7 +74,7 @@ bool dbus_screensaver_inhibit(void)
       return true; /* Already inhibited */
 
    msg = dbus_message_new_method_call("org.freedesktop.ScreenSaver",
-         "/org/freedesktop/ScreenSaver",
+         "/ScreenSaver",
          "org.freedesktop.ScreenSaver",
          "Inhibit");
 
@@ -133,7 +133,7 @@ void dbus_screensaver_uninhibit(void)
       return;
 
    msg = dbus_message_new_method_call("org.freedesktop.ScreenSaver",
-         "/org/freedesktop/ScreenSaver",
+         "/ScreenSaver",
          "org.freedesktop.ScreenSaver",
          "UnInhibit");
    if (!msg)


### PR DESCRIPTION
The code is copied from Firefox:
https://dxr.mozilla.org/mozilla-central/source/widget/gtk/WakeLockListener.cpp#101
Also VLC:
https://github.com/videolan/vlc/blob/721c216bf8faaf2205aacf744ab20b1c5e3ec82f/modules/misc/inhibit/dbus.c#L58

Should fix #7472 

## Description

The DBus object name seems wrong and not working in KDE. I looked Firefox and VLC's code, which works nicely in all Linux desktops, and copied its code.

RetroArch's code was correct according to freedesktop.org specification. However, some DE's implementation is out-dated. [Here](https://specifications.freedesktop.org/idle-inhibit-spec/latest/ch04.html) says it was fixed by latest KDE. But it actually didn't. That's why most applications still use the old object name `/ScreenSaver` instead of the standard `/org/freedesktop/ScreenSaver`.

## Related Issues

#7472 

## Reviewers

