### PR TITLE
(GLUI) Improve tab icon colours for 'Dark Blue' theme

### DIFF
--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -211,8 +211,8 @@ static const materialui_theme_t materialui_theme_dark_blue = {
    0x4b636e, /* list_switch_off */
    0x607d8b, /* list_switch_off_background */
    /* Navigation bar icon colours */
-   0x90caf9, /* nav_bar_icon_active */
-   0x8eacbb, /* nav_bar_icon_passive */
+   0x6ec6ff, /* nav_bar_icon_active */
+   0xA5B4BB, /* nav_bar_icon_passive */
    0x000000, /* nav_bar_icon_disabled */
    /* Misc. colours */
    0x000000, /* header_shadow */


### PR DESCRIPTION
## Description

This PR just tweaks the navigation bar icon colours for the Material UI `Dark Blue` theme for better clarity:

![Screenshot_2019-10-25_17-56-04](https://user-images.githubusercontent.com/38211560/67589668-e270d300-f750-11e9-904e-93c242d1089d.png)
