### PR TITLE
qb: Remove deprecated arguments.

### DIFF
--- a/qb/config.params.sh
+++ b/qb/config.params.sh
@@ -1,7 +1,5 @@
 HAVE_LIBRETRO=             # Libretro library used
 HAVE_ASSETS_DIR=           # Assets install directory
-HAVE_BIN_DIR=              # Binary install directory (Deprecated)
-HAVE_MAN_DIR=              # Manpage install directory (Deprecated)
 HAVE_GDI=yes               # GDI support (Win32-only)
 HAVE_OPENGLES_LIBS=        # Link flags for custom GLES library
 HAVE_OPENGLES_CFLAGS=      # C-flags for custom GLES library

--- a/qb/qb.params.sh
+++ b/qb/qb.params.sh
@@ -46,7 +46,6 @@ EOF
 	print_help_option "--datarootdir=PATH"       "Read-only data install directory"
 	print_help_option "--docdir=PATH"            "Documentation install directory"
 	print_help_option "--mandir=PATH"            "Manpage install directory"
-	print_help_option "--global-config-dir=PATH" "System wide config file prefix (Deprecated)"
 	print_help_option "--build=BUILD"            "The build system (no-op)"
 	print_help_option "--host=HOST"              "Cross-compile with HOST-gcc instead of gcc"
 	print_help_option "--help"                   "Show this help"
@@ -105,7 +104,7 @@ parse_input() # Parse stuff :V
 		config_opts="${config_opts} $1"
 		case "$1" in
 			--prefix=*) PREFIX=${1##--prefix=};;
-			--global-config-dir=*|--sysconfdir=*) GLOBAL_CONFIG_DIR="${1#*=}";;
+			--sysconfdir=*) GLOBAL_CONFIG_DIR="${1#*=}";;
 			--bindir=*) BIN_DIR="${1#*=}";;
 			--build=*) BUILD="${1#*=}";;
 			--datarootdir=*) SHARE_DIR="${1#*=}";;


### PR DESCRIPTION
## Description

This removes `--global-config-dir`, `--with-bin_dir` and `--with-man_dir` which were deprecated long ago and planned for removal around `1.8.0`.

Please use `--bindir`, `--mandir` and `--sysconfdir` now which were added when the above options were deprecated.

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/6259