### PR TITLE
Some minor qb changes.

### DIFF
--- a/qb/qb.comp.sh
+++ b/qb/qb.comp.sh
@@ -15,6 +15,8 @@ cat << EOF > "$TEMP_C"
 int main(void) { puts("Hai world!"); return 0; }
 EOF
 
+printf %s 'Checking for suitable working C compiler ... '
+
 cc_works=0
 add_opt CC no
 if [ "$CC" ]; then
@@ -40,7 +42,7 @@ elif [ -z "$CC" ]; then
 	cc_status='not found'
 fi
 
-printf %s\\n "Checking for suitable working C compiler ... $CC $cc_status"
+printf %s\\n "$CC $cc_status"
 
 if [ "$cc_works" = '0' ] && [ "$USE_LANG_C" = 'yes' ]; then
 	die 1 'Error: Cannot proceed without a working C compiler.'
@@ -51,6 +53,8 @@ cat << EOF > "$TEMP_CXX"
 #include <iostream>
 int main() { std::cout << "Hai guise" << std::endl; return 0; }
 EOF
+
+printf %s 'Checking for suitable working C++ compiler ... '
 
 cxx_works=0
 add_opt CXX no
@@ -77,7 +81,7 @@ elif [ -z "$CXX" ]; then
 	cxx_status='not found'
 fi
 
-printf %s\\n "Checking for suitable working C++ compiler ... $CXX $cxx_status"
+printf %s\\n "$CXX $cxx_status"
 
 if [ "$cxx_works" = '0' ] && [ "$USE_LANG_CXX" = 'yes' ]; then
 	die : 'Warning: A working C++ compiler was not found, C++ features will be disabled.'

--- a/qb/qb.comp.sh
+++ b/qb/qb.comp.sh
@@ -92,14 +92,12 @@ if [ "$OS" = "Win32" ]; then
 	printf %s\\n "$echobuf ... $WINDRES"
 fi
 
-if [ -z "$PKG_CONF_PATH" ]; then
-	PKGCONF="$(exists "${CROSS_COMPILE}pkgconf" ||
-			exists "${CROSS_COMPILE}pkg-config" || :)"
+printf %s 'Checking for pkg-config ... '
 
-	PKG_CONF_PATH="${PKGCONF:-none}"
-fi
+PKG_CONF_PATH="${PKG_CONF_PATH:-$(exists "${CROSS_COMPILE}pkgconf" ||
+	exists "${CROSS_COMPILE}pkg-config" || :)}"
 
-printf %s\\n "Checking for pkg-config ... $PKG_CONF_PATH"
+printf %s\\n "${PKG_CONF_PATH:=none}"
 
 if [ "$PKG_CONF_PATH" = "none" ]; then
 	die : 'Warning: pkg-config not found, package checks will fail.'

--- a/qb/qb.comp.sh
+++ b/qb/qb.comp.sh
@@ -84,12 +84,15 @@ if [ "$cxx_works" = '0' ] && [ "$USE_LANG_CXX" = 'yes' ]; then
 fi
 
 if [ "$OS" = "Win32" ]; then
-	echobuf="Checking for windres"
-	if [ -z "$WINDRES" ]; then
-		WINDRES="$(exists "${CROSS_COMPILE}windres")" || WINDRES=""
-		[ -z "$WINDRES" ] && die 1 "$echobuf ... Not found. Exiting."
+	printf %s 'Checking for windres ... '
+
+	WINDRES="${WINDRES:-$(exists "${CROSS_COMPILE}windres" || :)}"
+
+	printf %s\\n "${WINDRES:=none}"
+
+	if [ "$WINDRES" = none ]; then
+		die 1 'Error: Cannot proceed without windres.'
 	fi
-	printf %s\\n "$echobuf ... $WINDRES"
 fi
 
 printf %s 'Checking for pkg-config ... '

--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -162,22 +162,22 @@ check_lib()
 	include="${7:-}"
 	error="${8:-}"
 	answer='no'
-	printf %s "$MSG $lib"
+	printf %s "$MSG $lib ... "
 	eval "set -- $INCLUDE_DIRS $LIBRARY_DIRS $5 $FLAGS $LDFLAGS $lib"
 	"$COMPILER" -o "$TEMP_EXE" "$TEMP_CODE" "$@" >>config.log 2>&1 && answer='yes'
-	printf %s\\n " ... $answer"
+	printf %s\\n "$answer"
 
 	if [ "$answer" = 'yes' ] && [ "$include" ]; then
 		answer='no'
 		eval "set -- $INCLUDES"
 		for dir do
 			[ "$answer" = 'yes' ] && break
-			printf %s "Checking existence of /$dir/$include"
+			printf %s "Checking existence of /$dir/$include ... "
 			if [ -d "/$dir/$include" ]; then
 				eval "${val}_CFLAGS=\"-I/$dir/$include\""
 				answer='yes'
 			fi
-			printf %s\\n " ... $answer"
+			printf %s\\n "$answer"
 		done
 	fi
 
@@ -234,7 +234,7 @@ check_pkgconf()
 	eval "set -- ${2#* }"
 	for pkgnam do
 		[ "$answer" = 'yes' ] && break
-		printf %s "$MSG $pkgnam$ECHOBUF"
+		printf %s "$MSG $pkgnam$ECHOBUF ... "
 		eval "set -- $ver"
 		for pkgver do
 			if "$PKG_CONF_PATH" --atleast-version="$pkgver" "$pkgnam"; then
@@ -246,7 +246,7 @@ check_pkgconf()
 				break
 			fi
 		done
-		printf %s\\n " ... $version"
+		printf %s\\n "$version"
 	done
 
 	eval "HAVE_$val=\"$answer\""
@@ -280,11 +280,11 @@ check_header()
 	done
 	printf %s\\n "int main(void) { return 0; }" >> "$TEMP_C"
 	answer='no'
-	printf %s "Checking presence of header file $CHECKHEADER"
+	printf %s "Checking presence of header file $CHECKHEADER ... "
 	eval "set -- $CFLAGS $INCLUDE_DIRS"
 	"$CC" -o "$TEMP_EXE" "$TEMP_C" "$@" >>config.log 2>&1 && answer='yes'
 	eval "HAVE_$val=\"$answer\""
-	printf %s\\n " ... $answer"
+	printf %s\\n "$answer"
 	rm -f -- "$TEMP_C" "$TEMP_EXE"
 	setval="$(eval "printf %s \"\$USER_$val\"")"
 	if [ "$setval" = 'yes' ] && [ "$answer" = 'no' ]; then
@@ -316,11 +316,11 @@ EOF
 	answer='no'
 	val="$1"
 	macro="$2"
-	printf %s "Checking presence of predefined macro $macro$ECHOBUF"
+	printf %s "Checking presence of predefined macro $macro$ECHOBUF ... "
 	eval "set -- $CFLAGS $INCLUDE_DIRS"
 	"$CC" -o "$TEMP_EXE" "$TEMP_C" "$@" >>config.log 2>&1 && answer='yes'
 	eval "HAVE_$val=\"$answer\""
-	printf %s\\n " ... $answer"
+	printf %s\\n "$answer"
 	rm -f -- "$TEMP_C" "$TEMP_EXE"
 	setval="$(eval "printf %s \"\$USER_$val\"")"
 	if [ "$setval" = 'yes' ] && [ "$answer" = 'no' ]; then
@@ -339,10 +339,10 @@ check_switch()
 
 	printf %s\\n 'int main(void) { return 0; }' > "$TEMP_CODE"
 	answer='no'
-	printf %s "Checking for availability of switch $3 in $COMPILER"
+	printf %s "Checking for availability of switch $3 in $COMPILER ... "
 	"$COMPILER" -o "$TEMP_EXE" "$TEMP_CODE" "$3" >>config.log 2>&1 && answer='yes'
 	eval "HAVE_$2=\"$answer\""
-	printf %s\\n " ... $answer"
+	printf %s\\n "$answer"
 	rm -f -- "$TEMP_CODE" "$TEMP_EXE"
 	if [ "$answer" = 'no' ] && [ "${4:-}" ]; then
 		die 1 "$4"

--- a/qb/qb.moc.sh
+++ b/qb/qb.moc.sh
@@ -18,6 +18,8 @@ EOF
 
 add_opt MOC no
 if [ "$HAVE_QT" = "yes" ]; then
+	printf %s 'Checking for moc ... '
+
 	moc_works=0
 	if [ "$MOC" ]; then
 		QT_SELECT="$QT_VERSION" \
@@ -49,7 +51,7 @@ if [ "$HAVE_QT" = "yes" ]; then
 		moc_status='not found'
 	fi
 
-	printf %s\\n "Checking for moc ... $MOC $moc_status"
+	printf %s\\n "$MOC $moc_status"
 
 	if [ "$HAVE_MOC" != 'yes' ]; then
 		HAVE_QT='no'


### PR DESCRIPTION
## Description

This has four semi-related commits.

1. This fixes a small cosmetic mistake I made a while ago where it will print `Checking for foo ... ` earlier instead of only `Checking for foo`. Making sure the `...` is printed before the check rather than after helps the configure output look more readable in case of unexpected errors.
2. Further makes the pkg-config check more simple, there are no changes in behavior.
3. Much like the previous pkg-config commit this improves the windres check, there are no changes in behavior excluding an improved error message.
4. This should update the rest of the configure checks to print `Checking for foo ... ` before the check and the result after, this greatly helps debugging in case the check just hangs or exits unexpectedly as can happen due to compiler bugs for example. 

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/9672