### PR TITLE
travis: Log configure arguments + use before_script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,7 @@ before_install:
        sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
      fi
 
-script:
+before_script:
   - |
      if [ -n "$CROSS_COMPILE" ]; then
        ARGS="$ARGS --disable-d3d8 --disable-d3d9 --disable-d3d10 --disable-d3d11 --disable-d3d12"
@@ -131,6 +131,9 @@ script:
      if [ -n "$ENABLE_GLES3" ]; then
        ARGS="$ARGS --enable-opengles3"
      fi
+  - echo "Configure arguments = $ARGS"
+
+script:
   - ./configure $ARGS
   - |
      if [ -n "$C89_BUILD" ]; then


### PR DESCRIPTION
## Description

This explicitly prints the configure arguments used by travis in the logs which makes it easier to tell.

I also moved the configure arguments into `before_script` instead of `script` which is more clear and should not be any different in behavior.

## Reviewers

Travis CI should pass.
