### PR TITLE
(cheevos) pass RetroArch and core versions through User-Agent HTTP header

### DIFF
--- a/libretro-common/include/net/net_http.h
+++ b/libretro-common/include/net/net_http.h
@@ -42,6 +42,8 @@ bool net_http_connection_done(struct http_connection_t *conn);
 
 void net_http_connection_free(struct http_connection_t *conn);
 
+void net_http_connection_set_user_agent(struct http_connection_t* conn, const char* user_agent);
+
 const char *net_http_connection_url(struct http_connection_t *conn);
 
 struct http_t *net_http_new(struct http_connection_t *conn);

--- a/tasks/tasks_internal.h
+++ b/tasks/tasks_internal.h
@@ -52,6 +52,9 @@ typedef struct
 void *task_push_http_transfer(const char *url, bool mute, const char *type,
       retro_task_callback_t cb, void *userdata);
 
+void *task_push_http_transfer_with_user_agent(const char *url, bool mute, const char *type,
+      const char* user_agent, retro_task_callback_t cb, void *userdata);
+
 void *task_push_http_post_transfer(const char *url, const char *post_data, bool mute, const char *type,
       retro_task_callback_t cb, void *userdata);
 


### PR DESCRIPTION
## Description

Updates `libretro-common/net/net_http.c` and `tasks/tast_http.c` to pass through a User-Agent string that's generated from within the cheevos code. We intend to consume this on the server to track compatibility.

Example User-Agent strings:
```
User-Agent: RetroArch/1.8.1 (Windows 10 x64 Build 18362 10.0) quicknes_libretro/1.0-WIP_7c0796d
```
```
User-Agent: RetroArch/1.8.1 (Linux 5.0) mednafen_psx_libretro/0.9.44.1_fc06bbe
```
If no core is loaded, the core information will be excluded.

OS information comes from the `runloop_get_libretro_system_info` function and mostly matches the string displayed in the System Information menu:
![image](https://user-images.githubusercontent.com/32680403/68080053-63ffdb00-fdb9-11e9-9b86-0b45918001b0.png)

Presumably this functionality will be compatible on all available systems. Let me know if this assumption is wrong, or if there's an alternate method that might be preferred.

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

?
