### PR TITLE
(GLUI) Halt scrolling when pointer is pressed/stationary

### DIFF
--- a/menu/menu_input.h
+++ b/menu/menu_input.h
@@ -55,6 +55,13 @@ RETRO_BEGIN_DECLS
  * a touchscreen) */
 #define MENU_INPUT_SWIPE_TIMEOUT 500000              /* 500 ms */
 
+/* Standard behaviour (on Android, at least) is to stop
+ * scrolling when the user touches the screen. To prevent
+ * jerky stop/start scrolling, we wait MENU_INPUT_Y_ACCEL_RESET_DELAY
+ * ms before resetting y acceleration after a stationary
+ * pointer down event is detected */
+#define MENU_INPUT_Y_ACCEL_RESET_DELAY 50000         /* 50 ms */
+
 #define MENU_INPUT_Y_ACCEL_DECAY_FACTOR 0.96f
 
 /* Pointer is considered stationary if dx/dy remain

--- a/retroarch.c
+++ b/retroarch.c
@@ -13606,6 +13606,28 @@ static int menu_input_pointer_post_iterate(
                   menu_input->pointer.dx              = 0;
                   menu_input->pointer.dy              = 0;
                   menu_input->pointer.press_direction = MENU_INPUT_PRESS_DIRECTION_NONE;
+
+                  /* Standard behaviour (on Android, at least) is to stop
+                   * scrolling when the user touches the screen. We should
+                   * therefore 'reset' y acceleration whenever the pointer
+                   * is stationary - with two caveats:
+                   * - We only disable scrolling if the pointer *remains*
+                   *   stationary. If the pointer is held down then
+                   *   subsequently moves, normal scrolling should resume
+                   * - Halting the scroll immediately produces a very
+                   *   unpleasant 'jerky' user experience. To avoid this,
+                   *   we add a small delay between detecting a pointer
+                   *   down event and forcing y acceleration to zero */
+                  if (!menu_input->pointer.dragged)
+                  {
+                     if (menu_input->pointer.press_duration > MENU_INPUT_Y_ACCEL_RESET_DELAY)
+                     {
+                        menu_input->pointer.y_accel = 0.0f;
+                        accel0                      = 0.0f;
+                        accel1                      = 0.0f;
+                        attenuate_y_accel           = false;
+                     }
+                  }
                }
             }
             else
@@ -13615,6 +13637,9 @@ static int menu_input_pointer_post_iterate(
                menu_input->pointer.dy              = 0;
                menu_input->pointer.y_accel         = 0.0f;
                menu_input->pointer.press_direction = MENU_INPUT_PRESS_DIRECTION_NONE;
+               accel0                              = 0.0f;
+               accel1                              = 0.0f;
+               attenuate_y_accel                   = false;
             }
 
             /* > Update remaining variables */


### PR DESCRIPTION
## Description

At present, when using a touchscreen/pointer to scroll in Material UI, the menu list will continue to move (with decaying acceleration) until a touch/pointer motion is detected in a different direction - i.e. merely touching/pressing (and holding) the screen has no effect on scrolling; the list will continue to move beneath the user's finger/pointer.

This is non-standard behaviour in the world of mobile devices, where touching the screen always halts the current scroll action.

This PR modifies scrolling such that it mimics a normal Android app. Touching/pressing the screen now stops any scroll motion. This is done in such a way as to have no negative impact on scroll speed or responsiveness.