### PR TITLE
switch to nearest neighbor scaling as default

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -317,7 +317,7 @@
 #endif
 
 /* Smooths picture. */
-#define DEFAULT_VIDEO_SMOOTH true
+#define DEFAULT_VIDEO_SMOOTH false
 
 /* On resize and fullscreen, rendering area will stay 4:3 */
 #define DEFAULT_FORCE_ASPECT true

--- a/config.def.h
+++ b/config.def.h
@@ -317,7 +317,11 @@
 #endif
 
 /* Smooths picture. */
+#if defined(_3DS) || defined(GEKKO) || defined(HW_RVL) || defined(PSP) || defined(VITA) || defined(SN_TARGET_PSP2) || defined(PS2) || defined(_XBOX)
+#define DEFAULT_VIDEO_SMOOTH true
+#else
 #define DEFAULT_VIDEO_SMOOTH false
+#endif
 
 /* On resize and fullscreen, rendering area will stay 4:3 */
 #define DEFAULT_FORCE_ASPECT true


### PR DESCRIPTION
## Description

This switches the default filtering method from bilinear to nearest neighbor except for targets with fixed sub-720p resolution.

As monitors have gotten larger, bilinear scaling becomes blurrier and many users have become accustomed to sharp, NN scaling as the default for pixel art. We get a lot of confused new/young users who complain about the default visual fidelity, so this would keep up with the times.

I excluded consoles whose output is always low-res, as they need bilinear filtering to avoid nasty scaling artifacts.

## Related Issues

none

## Related Pull Requests

none

## Reviewers

[If possible @mention all the people that should review your pull request]
