### PR TITLE
OpenBSD/powerpc: fix "undefined reference to __mftb"

### DIFF
--- a/libretro-common/features/features_cpu.c
+++ b/libretro-common/features/features_cpu.c
@@ -39,7 +39,7 @@
 #include <windows.h>
 #endif
 
-#if defined(__CELLOS_LV2__)
+#if defined(__CELLOS_LV2__) || ( defined(__OpenBSD__) && defined(__powerpc__) )
 #ifndef _PPU_INTRINSICS_H
 #include <ppu_intrinsics.h>
 #endif


### PR DESCRIPTION
(cc @pkubaj for FreeBSD/powerpc64, and @bentley for the OpenBSD port)

Retroarch fails to build on OpenBSD/powerpc (using GCC-8.3.0): while linking it misses some references to `__mftb()`

It appears that `<ppu_intrinsics.h>` is needed to find `__mftb()`, and without further changes it builds and runs fine on this platform. 

Obviously, the OS should be checked as well, as RetroArch supports other PowerPC platforms that don't need the header.