### PR TITLE
Added gl1 video driver support to Vita build

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1160,6 +1160,7 @@ ifeq ($(HAVE_VITAGL), 1)
    DEFINES += -DHAVE_OPENGL1
    OBJ += gfx/drivers/gl1.o \
           gfx/drivers_font/gl1_raster_font.o \
+          gfx/drivers_context/vita_ctx.o \
           menu/drivers_display/menu_display_gl1.o
 endif
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -1156,6 +1156,13 @@ ifeq ($(HAVE_PLAIN_DRM), 1)
    LIBS += -ldrm
 endif
 
+ifeq ($(HAVE_VITAGL), 1)
+   DEFINES += -DHAVE_OPENGL1
+   OBJ += gfx/drivers/gl1.o \
+          gfx/drivers_font/gl1_raster_font.o \
+          menu/drivers_display/menu_display_gl1.o
+endif
+
 ifeq ($(HAVE_GL_CONTEXT), 1)
    ifeq ($(HAVE_GL_MODERN), 1)
       DEFINES += -DHAVE_OPENGL

--- a/Makefile.vita
+++ b/Makefile.vita
@@ -35,6 +35,7 @@ else
 	HAVE_ZLIB		:= 1
 	HAVE_7ZIP		:= 1
 	HAVE_VITA2D		:= 1
+	HAVE_VITAGL		:= 1
 	HAVE_NETWORKING		:= 1
 	HAVE_SOCKET_LEGACY	:= 1
 	HAVE_MENU		:= 1
@@ -115,7 +116,8 @@ CXXFLAGS := $(CFLAGS) -fno-rtti -fno-exceptions
 VITA_LIBS := -lSceDisplay_stub -lSceGxm_stub -lSceNet_stub -lSceNetCtl_stub -lSceAppUtil_stub \
 	-lSceSysmodule_stub -lSceCtrl_stub -lSceHid_stub -lSceTouch_stub -lSceAudio_stub \
 	-lScePower_stub -lSceRtc_stub -lSceCommonDialog_stub -lScePgf_stub -lSceMotion_stub \
-	-lSceFiber_stub -lSceMotion_stub -lSceAppMgr_stub -lpthread -lpng -lz
+	-lSceFiber_stub -lSceMotion_stub -lSceAppMgr_stub -lpthread -lpng -lz -lvitagl \
+	-lmathneon
 
 LIBS	:= $(WHOLE_START) -lretro_vita $(WHOLE_END) $(VITA_LIBS) -lm -lc
 

--- a/bootstrap/vita/sbrk.c
+++ b/bootstrap/vita/sbrk.c
@@ -6,8 +6,8 @@
 
 #define RAM_THRESHOLD 0xA00000 // Memory left to the system for threads and other internal stuffs
 
-static int _newlib_heap_memblock;
-static unsigned _newlib_heap_size;
+int _newlib_heap_memblock;
+unsigned _newlib_heap_size;
 char *_newlib_heap_base, *_newlib_heap_end, *_newlib_heap_cur;
 static char _newlib_sbrk_mutex[32] __attribute__ ((aligned (8)));
 

--- a/bootstrap/vita/sbrk.c
+++ b/bootstrap/vita/sbrk.c
@@ -4,7 +4,7 @@
 #include <psp2/kernel/sysmem.h>
 #include <psp2/kernel/threadmgr.h>
 
-#define RAM_THRESHOLD 0xA00000 // Memory left to the system for threads and other internal stuffs
+#define RAM_THRESHOLD 0x1000000 // Memory left to the system for threads and other internal stuffs
 
 int _newlib_heap_memblock;
 unsigned _newlib_heap_size;

--- a/frontend/drivers/platform_psp.c
+++ b/frontend/drivers/platform_psp.c
@@ -89,18 +89,6 @@ static void frontend_psp_get_environment_settings(int *argc, char *argv[],
 
    (void)args;
 
-#ifndef IS_SALAMANDER
-#if defined(HAVE_LOGGER)
-   logger_init();
-#elif defined(HAVE_FILE_LOGGER)
-#ifndef VITA
-   retro_main_log_file_init("ms0:/temp/retroarch-log.txt", false);
-#else
-   retro_main_log_file_init("ux0:/temp/retroarch-log.txt", false);
-#endif
-#endif
-#endif
-
 #ifdef VITA
    strlcpy(eboot_path, "app0:/", sizeof(eboot_path));
    strlcpy(g_defaults.dirs[DEFAULT_DIR_PORT], eboot_path, sizeof(g_defaults.dirs[DEFAULT_DIR_PORT]));
@@ -245,10 +233,6 @@ static void frontend_psp_deinit(void *data)
    (void)data;
 #ifndef IS_SALAMANDER
    verbosity_disable();
-#ifdef HAVE_FILE_LOGGER
-   command_event(CMD_EVENT_LOG_FILE_DEINIT, NULL);
-#endif
-
 #endif
 }
 

--- a/gfx/common/gl1_common.h
+++ b/gfx/common/gl1_common.h
@@ -30,11 +30,22 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif
+#ifdef VITA
+#include <vitaGL.h>
+#else
 #include <GL/gl.h>
 #include <GL/glext.h>
 #endif
+#endif
 
 #include "../../retroarch.h"
+
+#ifdef VITA
+#define GL_RGBA8     GL_RGBA
+#define GL_RGB8      GL_RGB
+#define GL_BGRA_EXT  GL_RGBA // Currently unsupported in vitaGL
+#define GL_CLAMP     GL_CLAMP_TO_EDGE
+#endif
 
 #define RARCH_GL1_INTERNAL_FORMAT32 GL_RGBA8
 #define RARCH_GL1_TEXTURE_TYPE32 GL_BGRA_EXT

--- a/gfx/drivers/gl1.c
+++ b/gfx/drivers/gl1.c
@@ -595,7 +595,7 @@ static void draw_tex(gl1_t *gl1, int pot_width, int pot_height, int width, int h
          frame = frame_rgba;
       }
    }
-   RARCH_LOG("draw_tex\n");
+
    glTexImage2D(GL_TEXTURE_2D, 0, internalFormat, pot_width, pot_height, 0, format, type, frame);
    if (frame_rgba)
        free(frame_rgba);
@@ -622,21 +622,6 @@ static void draw_tex(gl1_t *gl1, int pot_width, int pot_height, int width, int h
    glPushMatrix();
    glLoadIdentity();
 
-   /* stock coord set does not handle POT, disable for now */
-   /*glEnableClientState(GL_COLOR_ARRAY);
-   glEnableClientState(GL_VERTEX_ARRAY);
-   glEnableClientState(GL_TEXTURE_COORD_ARRAY);
-
-   glColorPointer(4, GL_FLOAT, 0, gl1->coords.color);
-   glVertexPointer(2, GL_FLOAT, 0, gl1->coords.vertex);
-   glTexCoordPointer(2, GL_FLOAT, 0, gl1->coords.tex_coord);
-
-   glDrawArrays(GL_TRIANGLES, 0, gl1->coords.vertices);
-
-   glDisableClientState(GL_TEXTURE_COORD_ARRAY);
-   glDisableClientState(GL_VERTEX_ARRAY);
-   glDisableClientState(GL_COLOR_ARRAY);*/
-
    if (gl1->rotation && tex == gl1->tex)
       glRotatef(gl1->rotation, 0.0f, 0.0f, 1.0f);
    
@@ -660,8 +645,8 @@ static void draw_tex(gl1_t *gl1, int pot_width, int pot_height, int width, int h
    float texcoords[] = {
       0.0f, norm_height,
       0.0f, 0.0f,
-	  norm_width, 1.0f,
-	  norm_width, norm_height
+      norm_width, 1.0f,
+      norm_width, norm_height
    };
    
    glEnableClientState(GL_COLOR_ARRAY);
@@ -922,10 +907,7 @@ static bool gl1_gfx_frame(void *data, const void *frame,
       glClear(GL_COLOR_BUFFER_BIT);
       glFinish();
    }
-#ifdef VITA
-   vglStopRendering();
-   vglStartRendering();
-#endif   
+ 
    gl1_context_bind_hw_render(gl1, true);
 
    return true;
@@ -1270,7 +1252,7 @@ static void gl1_load_texture_data(
 #ifndef VITA
    glPixelStorei(GL_UNPACK_ALIGNMENT, alignment);
 #endif
-   RARCH_LOG("gl1_load_texture_data\n");
+
    glTexImage2D(GL_TEXTURE_2D,
          0,
          (use_rgba || !rgb32) ? GL_RGBA : RARCH_GL1_INTERNAL_FORMAT32,

--- a/gfx/drivers/gl1.c
+++ b/gfx/drivers/gl1.c
@@ -286,14 +286,16 @@ static void *gl1_gfx_init(const video_info_t *video,
    mode.width  = 0;
    mode.height = 0;
 #ifdef VITA
-   vglInitExtended(0x100000, 960, 544, 0x1000000, SCE_GXM_MULTISAMPLE_4X);
+   vglInitExtended(0x1400000, full_x, full_y, 0x1000000, SCE_GXM_MULTISAMPLE_4X);
+   vglUseVram(GL_TRUE);
+   vglStartRendering();
 #endif
    /* Clear out potential error flags in case we use cached context. */
    glGetError();
-
+#ifndef VITA
    if (string_is_equal(ctx_driver->ident, "null"))
       goto error;
-
+#endif
    RARCH_LOG("[GL1]: Detecting screen resolution %ux%u.\n", full_x, full_y);
 
    win_width   = video->width;
@@ -718,9 +720,7 @@ static bool gl1_gfx_frame(void *data, const void *frame,
    unsigned pot_height       = 0;
 
    gl1_context_bind_hw_render(gl1, false);
-#ifdef VITA   
-   vglStartRendering();
-#endif   
+   
    /* FIXME: Force these settings off as they interfere with the rendering */
    video_info->xmb_shadows_enable   = false;
    video_info->menu_shader_pipeline = 0;
@@ -927,9 +927,10 @@ static bool gl1_gfx_frame(void *data, const void *frame,
       glClear(GL_COLOR_BUFFER_BIT);
       glFinish();
    }
-#ifdef VITA  
+#ifdef VITA
    vglStopRendering();
-#endif
+   vglStartRendering();
+#endif   
    gl1_context_bind_hw_render(gl1, true);
 
    return true;

--- a/gfx/drivers/gl1.c
+++ b/gfx/drivers/gl1.c
@@ -285,7 +285,9 @@ static void *gl1_gfx_init(const video_info_t *video,
    full_y      = mode.height;
    mode.width  = 0;
    mode.height = 0;
-
+#ifdef VITA
+   vglInitExtended(0x100000, 960, 544, 0x1000000, SCE_GXM_MULTISAMPLE_4X);
+#endif
    /* Clear out potential error flags in case we use cached context. */
    glGetError();
 
@@ -395,7 +397,9 @@ static void *gl1_gfx_init(const video_info_t *video,
    glDisable(GL_CULL_FACE);
    glDisable(GL_STENCIL_TEST);
    glDisable(GL_SCISSOR_TEST);
+#ifndef VITA
    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+#endif
    glGenTextures(1, &gl1->tex);
    glGenTextures(1, &gl1->menu_tex);
 
@@ -562,9 +566,12 @@ static void draw_tex(gl1_t *gl1, int pot_width, int pot_height, int width, int h
    /* Multi-texture not part of GL 1.1 */
    /*glActiveTexture(GL_TEXTURE0);*/
 
+#ifndef VITA
    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
    glPixelStorei(GL_UNPACK_ROW_LENGTH, pot_width);
+#endif
    glBindTexture(GL_TEXTURE_2D, tex);
+
 
    /* For whatever reason you can't send NULL in GLDirect,
       so we send the frame as dummy data */
@@ -686,10 +693,11 @@ static void gl1_readback(
       unsigned fmt, unsigned type,
       void *src)
 {
+#ifndef VITA
    glPixelStorei(GL_PACK_ALIGNMENT, alignment);
    glPixelStorei(GL_PACK_ROW_LENGTH, 0);
    glReadBuffer(GL_BACK);
-
+#endif
    glReadPixels(gl1->vp.x, gl1->vp.y,
          gl1->vp.width, gl1->vp.height,
          (GLenum)fmt, (GLenum)type, (GLvoid*)src);
@@ -710,7 +718,9 @@ static bool gl1_gfx_frame(void *data, const void *frame,
    unsigned pot_height       = 0;
 
    gl1_context_bind_hw_render(gl1, false);
-
+#ifdef VITA   
+   vglStartRendering();
+#endif   
    /* FIXME: Force these settings off as they interfere with the rendering */
    video_info->xmb_shadows_enable   = false;
    video_info->menu_shader_pipeline = 0;
@@ -917,7 +927,9 @@ static bool gl1_gfx_frame(void *data, const void *frame,
       glClear(GL_COLOR_BUFFER_BIT);
       glFinish();
    }
-
+#ifdef VITA  
+   vglStopRendering();
+#endif
    gl1_context_bind_hw_render(gl1, true);
 
    return true;
@@ -1259,7 +1271,9 @@ static void gl1_load_texture_data(
 
    gl1_bind_texture(id, wrap, mag_filter, min_filter);
 
+#ifndef VITA
    glPixelStorei(GL_UNPACK_ALIGNMENT, alignment);
+#endif
    glTexImage2D(GL_TEXTURE_2D,
          0,
          (use_rgba || !rgb32) ? GL_RGBA : RARCH_GL1_INTERNAL_FORMAT32,

--- a/gfx/drivers/gl1.c
+++ b/gfx/drivers/gl1.c
@@ -566,6 +566,33 @@ static void draw_tex(gl1_t *gl1, int pot_width, int pot_height, int width, int h
    GLenum format        = gl1->supports_bgra ? GL_BGRA_EXT : GL_RGBA;
    GLenum type          = GL_UNSIGNED_BYTE;
 
+   float vertices[] = {
+	   -1.0f, -1.0f, 0.0f,
+	   -1.0f, 1.0f, 0.0f,
+	   1.0f, -1.0f, 0.0f,
+	   1.0f, 1.0f, 0.0f,
+   };
+
+   float colors[] = {
+      1.0f, 1.0f, 1.0f, 1.0f,
+      1.0f, 1.0f, 1.0f, 1.0f,
+      1.0f, 1.0f, 1.0f, 1.0f,
+      1.0f, 1.0f, 1.0f, 1.0f
+   };
+
+   float norm_width     = (1.0f / (float)pot_width) * (float)width;
+   float norm_height    = (1.0f / (float)pot_height) * (float)height;
+   
+   float texcoords[] = {
+      0.0f, 0.0f,
+      0.0f, 0.0f,
+      0.0f, 0.0f,
+      0.0f, 0.0f
+   };
+   
+   texcoords[1] = texcoords[5] = norm_height;
+   texcoords[4] = texcoords[6] = norm_width;
+
    glDisable(GL_DEPTH_TEST);
    glDisable(GL_CULL_FACE);
    glDisable(GL_STENCIL_TEST);
@@ -631,30 +658,6 @@ static void draw_tex(gl1_t *gl1, int pot_width, int pot_height, int width, int h
 
    if (gl1->rotation && tex == gl1->tex)
       glRotatef(gl1->rotation, 0.0f, 0.0f, 1.0f);
-   
-   float vertices[] = {
-	   -1.0f, -1.0f, 0.0f,
-	   -1.0f, 1.0f, 0.0f,
-	   1.0f, -1.0f, 0.0f,
-	   1.0f, 1.0f, 0.0f,
-   };
-   
-   float colors[] = {
-      1.0f, 1.0f, 1.0f, 1.0f,
-      1.0f, 1.0f, 1.0f, 1.0f,
-      1.0f, 1.0f, 1.0f, 1.0f,
-      1.0f, 1.0f, 1.0f, 1.0f
-   };
-   
-   float norm_width     = (1.0f / (float)pot_width) * (float)width;
-   float norm_height    = (1.0f / (float)pot_height) * (float)height;
-   
-   float texcoords[] = {
-      0.0f, norm_height,
-      0.0f, 0.0f,
-      norm_width, norm_height,
-      norm_width, 0.0f
-   };
    
    glEnableClientState(GL_COLOR_ARRAY);
    glEnableClientState(GL_VERTEX_ARRAY);

--- a/gfx/drivers/gl1.c
+++ b/gfx/drivers/gl1.c
@@ -299,10 +299,10 @@ static void *gl1_gfx_init(const video_info_t *video,
 #endif
    /* Clear out potential error flags in case we use cached context. */
    glGetError();
-#ifndef VITA
+
    if (string_is_equal(ctx_driver->ident, "null"))
       goto error;
-#endif
+
    RARCH_LOG("[GL1]: Detecting screen resolution %ux%u.\n", full_x, full_y);
 
    win_width   = video->width;

--- a/gfx/drivers/gl1.c
+++ b/gfx/drivers/gl1.c
@@ -56,6 +56,10 @@
 #include "../video_thread_wrapper.h"
 #endif
 
+#ifdef VITA
+static bool vgl_inited = false;
+#endif
+
 static unsigned char *gl1_menu_frame = NULL;
 static unsigned gl1_menu_width       = 0;
 static unsigned gl1_menu_height      = 0;
@@ -286,9 +290,12 @@ static void *gl1_gfx_init(const video_info_t *video,
    mode.width  = 0;
    mode.height = 0;
 #ifdef VITA
-   vglInitExtended(0x1400000, full_x, full_y, 0x100000, SCE_GXM_MULTISAMPLE_4X);
-   vglUseVram(GL_TRUE);
-   vglStartRendering();
+   if (!vgl_inited) {
+      vglInitExtended(0x1400000, full_x, full_y, 0x100000, SCE_GXM_MULTISAMPLE_4X);
+      vglUseVram(GL_TRUE);
+      vglStartRendering();
+      vgl_inited = true;
+   }
 #endif
    /* Clear out potential error flags in case we use cached context. */
    glGetError();
@@ -628,8 +635,8 @@ static void draw_tex(gl1_t *gl1, int pot_width, int pot_height, int width, int h
    float vertices[] = {
 	   -1.0f, -1.0f, 0.0f,
 	   -1.0f, 1.0f, 0.0f,
+	   1.0f, -1.0f, 0.0f,
 	   1.0f, 1.0f, 0.0f,
-	   1.0f, -1.0f, 0.0f
    };
    
    float colors[] = {
@@ -645,8 +652,8 @@ static void draw_tex(gl1_t *gl1, int pot_width, int pot_height, int width, int h
    float texcoords[] = {
       0.0f, norm_height,
       0.0f, 0.0f,
-      norm_width, 1.0f,
-      norm_width, norm_height
+      norm_width, norm_height,
+      norm_width, 0.0f
    };
    
    glEnableClientState(GL_COLOR_ARRAY);

--- a/gfx/drivers_context/gfx_null_ctx.c
+++ b/gfx/drivers_context/gfx_null_ctx.c
@@ -42,8 +42,13 @@ static void gfx_ctx_null_swap_buffers(void *data, void *data2)
 static void gfx_ctx_null_get_video_size(void *data, unsigned *width, unsigned *height)
 {
    (void)data;
+#ifdef VITA
+   *width  = 960;
+   *height = 544;
+#else
    *width  = 320;
    *height = 240;
+#endif
 }
 
 static bool gfx_ctx_null_set_video_mode(void *data,

--- a/gfx/drivers_context/vita_ctx.c
+++ b/gfx/drivers_context/vita_ctx.c
@@ -121,7 +121,7 @@ static void *vita_init(video_frame_info_t *video_info, void *video_driver)
 {
    (void)video_driver;
 
-   return (void*)"null";
+   return (void*)"vita";
 }
 
 static uint32_t vita_get_flags(void *data)

--- a/gfx/drivers_context/vita_ctx.c
+++ b/gfx/drivers_context/vita_ctx.c
@@ -21,7 +21,9 @@
 static void vita_swap_interval(void *data, int interval)
 {
    (void)data;
-   (void)interval;
+#ifdef VITA
+   vglWaitVblankStart(interval);
+#endif
 }
 
 static void vita_check_window(void *data, bool *quit,

--- a/gfx/drivers_context/vita_ctx.c
+++ b/gfx/drivers_context/vita_ctx.c
@@ -1,0 +1,321 @@
+/*  RetroArch - A frontend for libretro.
+ *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
+ *  Copyright (C) 2018      - M4xw
+ *
+ *  RetroArch is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  RetroArch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with RetroArch.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdlib.h>
+
+#include <compat/strl.h>
+
+#ifdef HAVE_CONFIG_H
+#include "../../config.h"
+#endif
+
+#include "../common/orbis_common.h"
+#include "../../frontend/frontend_driver.h"
+#include "../../configuration.h"
+
+static enum gfx_ctx_api ctx_orbis_api = GFX_CTX_OPENGL_API;
+
+orbis_ctx_data_t *nx_ctx_ptr = NULL;
+
+extern bool platform_orbis_has_focus;
+
+void orbis_ctx_destroy(void *data)
+{
+    orbis_ctx_data_t *ctx_orbis = (orbis_ctx_data_t *)data;
+
+    if (ctx_orbis)
+    {
+#ifdef HAVE_EGL
+        egl_destroy(&ctx_orbis->egl);
+#endif
+        ctx_orbis->resize = false;
+        free(ctx_orbis);
+    }
+}
+
+static void orbis_ctx_get_video_size(void *data,
+                                      unsigned *width, unsigned *height)
+{
+    orbis_ctx_data_t *ctx_orbis = (orbis_ctx_data_t *)data;
+
+    *width = ATTR_ORBISGL_WIDTH;
+    *height = ATTR_ORBISGL_HEIGHT;
+}
+
+static void *orbis_ctx_init(video_frame_info_t *video_info, void *video_driver)
+{
+#ifdef HAVE_EGL
+    int ret;
+    EGLint n;
+    EGLint major, minor;
+    static const EGLint attribs[] = {
+        EGL_RED_SIZE, 8,
+         EGL_GREEN_SIZE, 8,
+         EGL_BLUE_SIZE, 8,
+         EGL_ALPHA_SIZE, 8,
+         EGL_DEPTH_SIZE, 16,
+         EGL_STENCIL_SIZE, 0,
+         EGL_SAMPLE_BUFFERS, 0,
+         EGL_SAMPLES, 0,
+         EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+         EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
+         EGL_NONE};
+#endif
+
+    orbis_ctx_data_t *ctx_orbis = (orbis_ctx_data_t *)calloc(1, sizeof(*ctx_orbis));
+
+    if (!ctx_orbis)
+        return NULL;
+
+    nx_ctx_ptr = ctx_orbis;
+
+#ifdef HAVE_EGL
+
+   memset(&ctx_orbis->pgl_config, 0, sizeof(ctx_orbis->pgl_config));
+   {
+      ctx_orbis->pgl_config.size=sizeof(ctx_orbis->pgl_config);
+      ctx_orbis->pgl_config.flags=SCE_PGL_FLAGS_USE_COMPOSITE_EXT | SCE_PGL_FLAGS_USE_FLEXIBLE_MEMORY | 0x60;
+      ctx_orbis->pgl_config.processOrder=1;
+      ctx_orbis->pgl_config.systemSharedMemorySize=0x200000;
+      ctx_orbis->pgl_config.videoSharedMemorySize=0x2400000;
+      ctx_orbis->pgl_config.maxMappedFlexibleMemory=0xAA00000;
+      ctx_orbis->pgl_config.drawCommandBufferSize=0xC0000;
+      ctx_orbis->pgl_config.lcueResourceBufferSize=0x10000;
+      ctx_orbis->pgl_config.dbgPosCmd_0x40=ATTR_ORBISGL_WIDTH;
+      ctx_orbis->pgl_config.dbgPosCmd_0x44=ATTR_ORBISGL_HEIGHT;
+      ctx_orbis->pgl_config.dbgPosCmd_0x48=0;
+      ctx_orbis->pgl_config.dbgPosCmd_0x4C=0;
+      ctx_orbis->pgl_config.unk_0x5C=2;
+   }
+    ret = scePigletSetConfigurationVSH(&ctx_orbis->pgl_config);
+    if (!ret)
+    {
+		  printf("[ORBISGL] scePigletSetConfigurationVSH failed 0x%08X.\n",ret);
+        goto error;
+    }
+
+    if (!egl_init_context(&ctx_orbis->egl, EGL_NONE, EGL_DEFAULT_DISPLAY,
+                          &major, &minor, &n, attribs, NULL))
+    {
+        egl_report_error();
+        printf("[ORBIS]: EGL error: %d.\n", eglGetError());
+        goto error;
+    }
+#endif
+
+    return ctx_orbis;
+
+error:
+    orbis_ctx_destroy(video_driver);
+    return NULL;
+}
+
+static void orbis_ctx_check_window(void *data, bool *quit,
+                                    bool *resize, unsigned *width, unsigned *height, bool is_shutdown)
+{
+    unsigned new_width, new_height;
+
+    orbis_ctx_get_video_size(data, &new_width, &new_height);
+
+    if (new_width != *width || new_height != *height)
+    {
+        *width = new_width;
+        *height = new_height;
+        *resize = true;
+    }
+
+    *quit = (bool)false;
+}
+
+static bool orbis_ctx_set_video_mode(void *data,
+                                      video_frame_info_t *video_info,
+                                      unsigned width, unsigned height,
+                                      bool fullscreen)
+{
+    /* Create an EGL rendering context */
+    static const EGLint contextAttributeList[] =
+        {
+            EGL_CONTEXT_CLIENT_VERSION, 2,
+            EGL_NONE};
+
+    orbis_ctx_data_t *ctx_orbis = (orbis_ctx_data_t *)data;
+
+    ctx_orbis->width = ATTR_ORBISGL_WIDTH;
+    ctx_orbis->height = ATTR_ORBISGL_HEIGHT;
+
+    ctx_orbis->native_window.width = ctx_orbis->width;
+    ctx_orbis->native_window.height = ctx_orbis->height;
+
+    ctx_orbis->refresh_rate = 60;
+
+#ifdef HAVE_EGL
+    if (!egl_create_context(&ctx_orbis->egl, contextAttributeList))
+    {
+        egl_report_error();
+        goto error;
+    }
+#endif
+
+#ifdef HAVE_EGL
+    if (!egl_create_surface(&ctx_orbis->egl, &ctx_orbis->native_window))
+        goto error;
+#endif
+
+    return true;
+
+error:
+    printf("[ctx_orbis]: EGL error: %d.\n", eglGetError());
+    orbis_ctx_destroy(data);
+
+    return false;
+}
+
+static void orbis_ctx_input_driver(void *data,
+      const char *name,
+      input_driver_t **input, void **input_data)
+{
+    *input      = NULL;
+    *input_data = NULL;
+}
+
+static enum gfx_ctx_api orbis_ctx_get_api(void *data)
+{
+    return ctx_orbis_api;
+}
+
+static bool orbis_ctx_bind_api(void *data,
+                                enum gfx_ctx_api api, unsigned major, unsigned minor)
+{
+    (void)data;
+    ctx_orbis_api = api;
+
+    if (api == GFX_CTX_OPENGL_ES_API)
+        if (eglBindAPI(EGL_OPENGL_ES_API) != EGL_FALSE)
+            return true;
+
+    return false;
+}
+
+static bool orbis_ctx_has_focus(void *data)
+{
+    (void)data;
+    return true;
+}
+
+static bool orbis_ctx_suppress_screensaver(void *data, bool enable)
+{
+    (void)data;
+    (void)enable;
+    return false;
+}
+
+static void orbis_ctx_set_swap_interval(void *data,
+                                         int swap_interval)
+{
+    orbis_ctx_data_t *ctx_orbis = (orbis_ctx_data_t *)data;
+
+#ifdef HAVE_EGL
+    egl_set_swap_interval(&ctx_orbis->egl, 0);
+#endif
+}
+
+static void orbis_ctx_swap_buffers(void *data, void *data2)
+{
+    orbis_ctx_data_t *ctx_orbis = (orbis_ctx_data_t *)data;
+
+#ifdef HAVE_EGL
+    egl_swap_buffers(&ctx_orbis->egl);
+#endif
+}
+
+static gfx_ctx_proc_t orbis_ctx_get_proc_address(const char *symbol)
+{
+#ifdef HAVE_EGL
+    return egl_get_proc_address(symbol);
+#endif
+}
+
+static void orbis_ctx_bind_hw_render(void *data, bool enable)
+{
+    orbis_ctx_data_t *ctx_orbis = (orbis_ctx_data_t *)data;
+
+#ifdef HAVE_EGL
+    egl_bind_hw_render(&ctx_orbis->egl, enable);
+#endif
+}
+
+static uint32_t orbis_ctx_get_flags(void *data)
+{
+   uint32_t flags = 0;
+
+   if (string_is_equal(video_driver_get_ident(), "glcore"))
+   {
+#if defined(HAVE_SLANG) && defined(HAVE_SPIRV_CROSS)
+      BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_SLANG);
+#endif
+   }
+   else
+   {
+      BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_GLSL);
+   }
+
+   return flags;
+}
+
+static void orbis_ctx_set_flags(void *data, uint32_t flags)
+{
+    (void)data;
+}
+
+static float orbis_ctx_get_refresh_rate(void *data)
+{
+    orbis_ctx_data_t *ctx_orbis = (orbis_ctx_data_t *)data;
+
+    return ctx_orbis->refresh_rate;
+}
+
+const gfx_ctx_driver_t orbis_ctx = {
+    orbis_ctx_init,
+    orbis_ctx_destroy,
+    orbis_ctx_get_api,
+    orbis_ctx_bind_api,
+    orbis_ctx_set_swap_interval,
+    orbis_ctx_set_video_mode,
+    orbis_ctx_get_video_size,
+    orbis_ctx_get_refresh_rate,
+    NULL, /* get_video_output_size */
+    NULL, /* get_video_output_prev */
+    NULL, /* get_video_output_next */
+    NULL, /* get_metrics */
+    NULL,
+    NULL, /* update_title */
+    orbis_ctx_check_window,
+    NULL, /* set_resize */
+    orbis_ctx_has_focus,
+    orbis_ctx_suppress_screensaver,
+    false, /* has_windowed */
+    orbis_ctx_swap_buffers,
+    orbis_ctx_input_driver,
+    orbis_ctx_get_proc_address,
+    NULL,
+    NULL,
+    NULL,
+    "orbis",
+    orbis_ctx_get_flags,
+    orbis_ctx_set_flags,
+    orbis_ctx_bind_hw_render,
+    NULL,
+    NULL};

--- a/gfx/drivers_context/vita_ctx.c
+++ b/gfx/drivers_context/vita_ctx.c
@@ -21,28 +21,7 @@
 static void vita_swap_interval(void *data, int interval)
 {
    (void)data;
-#ifdef VITA
    vglWaitVblankStart(interval);
-#endif
-}
-
-static void vita_check_window(void *data, bool *quit,
-      bool *resize, unsigned *width, unsigned *height, bool is_shutdown)
-{
-   (void)data;
-   (void)quit;
-   (void)width;
-   (void)height;
-   (void)resize;
-}
-
-static void vita_swap_buffers(void *data, void *data2)
-{
-   (void)data;
-#ifdef VITA
-   vglStopRendering();
-   vglStartRendering();
-#endif
 }
 
 static void vita_get_video_size(void *data, unsigned *width, unsigned *height)
@@ -50,6 +29,30 @@ static void vita_get_video_size(void *data, unsigned *width, unsigned *height)
    (void)data;
    *width  = 960;
    *height = 544;
+}
+
+static void vita_check_window(void *data, bool *quit,
+      bool *resize, unsigned *width, unsigned *height, bool is_shutdown)
+{
+   unsigned new_width, new_height;
+
+   vita_get_video_size(data, &new_width, &new_height);
+
+   if (new_width != *width || new_height != *height)
+   {
+      *width = new_width;
+      *height = new_height;
+      *resize = true;
+   }
+
+   *quit = (bool)false;
+}
+
+static void vita_swap_buffers(void *data, void *data2)
+{
+   (void)data;
+   vglStopRendering();
+   vglStartRendering();
 }
 
 static bool vita_set_video_mode(void *data,

--- a/gfx/drivers_context/vita_ctx.c
+++ b/gfx/drivers_context/vita_ctx.c
@@ -1,6 +1,6 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
- *  Copyright (C) 2018      - M4xw
+ *  Copyright (C) 2011-2017 - Daniel De Matteis
  *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-
@@ -14,308 +14,158 @@
  *  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <stdlib.h>
+/* Vita context. */
 
-#include <compat/strl.h>
+#include "../../retroarch.h"
 
-#ifdef HAVE_CONFIG_H
-#include "../../config.h"
-#endif
-
-#include "../common/orbis_common.h"
-#include "../../frontend/frontend_driver.h"
-#include "../../configuration.h"
-
-static enum gfx_ctx_api ctx_orbis_api = GFX_CTX_OPENGL_API;
-
-orbis_ctx_data_t *nx_ctx_ptr = NULL;
-
-extern bool platform_orbis_has_focus;
-
-void orbis_ctx_destroy(void *data)
+static void vita_swap_interval(void *data, int interval)
 {
-    orbis_ctx_data_t *ctx_orbis = (orbis_ctx_data_t *)data;
-
-    if (ctx_orbis)
-    {
-#ifdef HAVE_EGL
-        egl_destroy(&ctx_orbis->egl);
-#endif
-        ctx_orbis->resize = false;
-        free(ctx_orbis);
-    }
+   (void)data;
+   (void)interval;
 }
 
-static void orbis_ctx_get_video_size(void *data,
-                                      unsigned *width, unsigned *height)
+static void vita_check_window(void *data, bool *quit,
+      bool *resize, unsigned *width, unsigned *height, bool is_shutdown)
 {
-    orbis_ctx_data_t *ctx_orbis = (orbis_ctx_data_t *)data;
-
-    *width = ATTR_ORBISGL_WIDTH;
-    *height = ATTR_ORBISGL_HEIGHT;
+   (void)data;
+   (void)quit;
+   (void)width;
+   (void)height;
+   (void)resize;
 }
 
-static void *orbis_ctx_init(video_frame_info_t *video_info, void *video_driver)
+static void vita_swap_buffers(void *data, void *data2)
 {
-#ifdef HAVE_EGL
-    int ret;
-    EGLint n;
-    EGLint major, minor;
-    static const EGLint attribs[] = {
-        EGL_RED_SIZE, 8,
-         EGL_GREEN_SIZE, 8,
-         EGL_BLUE_SIZE, 8,
-         EGL_ALPHA_SIZE, 8,
-         EGL_DEPTH_SIZE, 16,
-         EGL_STENCIL_SIZE, 0,
-         EGL_SAMPLE_BUFFERS, 0,
-         EGL_SAMPLES, 0,
-         EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
-         EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
-         EGL_NONE};
+   (void)data;
+#ifdef VITA
+   vglStopRendering();
+   vglStartRendering();
 #endif
-
-    orbis_ctx_data_t *ctx_orbis = (orbis_ctx_data_t *)calloc(1, sizeof(*ctx_orbis));
-
-    if (!ctx_orbis)
-        return NULL;
-
-    nx_ctx_ptr = ctx_orbis;
-
-#ifdef HAVE_EGL
-
-   memset(&ctx_orbis->pgl_config, 0, sizeof(ctx_orbis->pgl_config));
-   {
-      ctx_orbis->pgl_config.size=sizeof(ctx_orbis->pgl_config);
-      ctx_orbis->pgl_config.flags=SCE_PGL_FLAGS_USE_COMPOSITE_EXT | SCE_PGL_FLAGS_USE_FLEXIBLE_MEMORY | 0x60;
-      ctx_orbis->pgl_config.processOrder=1;
-      ctx_orbis->pgl_config.systemSharedMemorySize=0x200000;
-      ctx_orbis->pgl_config.videoSharedMemorySize=0x2400000;
-      ctx_orbis->pgl_config.maxMappedFlexibleMemory=0xAA00000;
-      ctx_orbis->pgl_config.drawCommandBufferSize=0xC0000;
-      ctx_orbis->pgl_config.lcueResourceBufferSize=0x10000;
-      ctx_orbis->pgl_config.dbgPosCmd_0x40=ATTR_ORBISGL_WIDTH;
-      ctx_orbis->pgl_config.dbgPosCmd_0x44=ATTR_ORBISGL_HEIGHT;
-      ctx_orbis->pgl_config.dbgPosCmd_0x48=0;
-      ctx_orbis->pgl_config.dbgPosCmd_0x4C=0;
-      ctx_orbis->pgl_config.unk_0x5C=2;
-   }
-    ret = scePigletSetConfigurationVSH(&ctx_orbis->pgl_config);
-    if (!ret)
-    {
-		  printf("[ORBISGL] scePigletSetConfigurationVSH failed 0x%08X.\n",ret);
-        goto error;
-    }
-
-    if (!egl_init_context(&ctx_orbis->egl, EGL_NONE, EGL_DEFAULT_DISPLAY,
-                          &major, &minor, &n, attribs, NULL))
-    {
-        egl_report_error();
-        printf("[ORBIS]: EGL error: %d.\n", eglGetError());
-        goto error;
-    }
-#endif
-
-    return ctx_orbis;
-
-error:
-    orbis_ctx_destroy(video_driver);
-    return NULL;
 }
 
-static void orbis_ctx_check_window(void *data, bool *quit,
-                                    bool *resize, unsigned *width, unsigned *height, bool is_shutdown)
+static void vita_get_video_size(void *data, unsigned *width, unsigned *height)
 {
-    unsigned new_width, new_height;
-
-    orbis_ctx_get_video_size(data, &new_width, &new_height);
-
-    if (new_width != *width || new_height != *height)
-    {
-        *width = new_width;
-        *height = new_height;
-        *resize = true;
-    }
-
-    *quit = (bool)false;
+   (void)data;
+   *width  = 960;
+   *height = 544;
 }
 
-static bool orbis_ctx_set_video_mode(void *data,
-                                      video_frame_info_t *video_info,
-                                      unsigned width, unsigned height,
-                                      bool fullscreen)
+static bool vita_set_video_mode(void *data,
+      video_frame_info_t *video_info,
+      unsigned width, unsigned height,
+      bool fullscreen)
 {
-    /* Create an EGL rendering context */
-    static const EGLint contextAttributeList[] =
-        {
-            EGL_CONTEXT_CLIENT_VERSION, 2,
-            EGL_NONE};
+   (void)data;
+   (void)width;
+   (void)height;
+   (void)fullscreen;
 
-    orbis_ctx_data_t *ctx_orbis = (orbis_ctx_data_t *)data;
-
-    ctx_orbis->width = ATTR_ORBISGL_WIDTH;
-    ctx_orbis->height = ATTR_ORBISGL_HEIGHT;
-
-    ctx_orbis->native_window.width = ctx_orbis->width;
-    ctx_orbis->native_window.height = ctx_orbis->height;
-
-    ctx_orbis->refresh_rate = 60;
-
-#ifdef HAVE_EGL
-    if (!egl_create_context(&ctx_orbis->egl, contextAttributeList))
-    {
-        egl_report_error();
-        goto error;
-    }
-#endif
-
-#ifdef HAVE_EGL
-    if (!egl_create_surface(&ctx_orbis->egl, &ctx_orbis->native_window))
-        goto error;
-#endif
-
-    return true;
-
-error:
-    printf("[ctx_orbis]: EGL error: %d.\n", eglGetError());
-    orbis_ctx_destroy(data);
-
-    return false;
+   return true;
 }
 
-static void orbis_ctx_input_driver(void *data,
+static void vita_destroy(void *data)
+{
+   (void)data;
+}
+
+static void vita_input_driver(void *data,
       const char *name,
       input_driver_t **input, void **input_data)
 {
-    *input      = NULL;
-    *input_data = NULL;
+   (void)data;
+   (void)input;
+   (void)input_data;
 }
 
-static enum gfx_ctx_api orbis_ctx_get_api(void *data)
+static bool vita_has_focus(void *data)
 {
-    return ctx_orbis_api;
+   (void)data;
+   return true;
 }
 
-static bool orbis_ctx_bind_api(void *data,
-                                enum gfx_ctx_api api, unsigned major, unsigned minor)
+static bool vita_suppress_screensaver(void *data, bool enable)
 {
-    (void)data;
-    ctx_orbis_api = api;
-
-    if (api == GFX_CTX_OPENGL_ES_API)
-        if (eglBindAPI(EGL_OPENGL_ES_API) != EGL_FALSE)
-            return true;
-
-    return false;
+   (void)data;
+   (void)enable;
+   return false;
 }
 
-static bool orbis_ctx_has_focus(void *data)
+static enum gfx_ctx_api vita_get_api(void *data)
 {
-    (void)data;
-    return true;
+   return GFX_CTX_NONE;
 }
 
-static bool orbis_ctx_suppress_screensaver(void *data, bool enable)
+static bool vita_bind_api(void *data, enum gfx_ctx_api api, unsigned major, unsigned minor)
 {
-    (void)data;
-    (void)enable;
-    return false;
+   (void)data;
+   (void)api;
+   (void)major;
+   (void)minor;
+
+   return true;
 }
 
-static void orbis_ctx_set_swap_interval(void *data,
-                                         int swap_interval)
+static void vita_show_mouse(void *data, bool state)
 {
-    orbis_ctx_data_t *ctx_orbis = (orbis_ctx_data_t *)data;
-
-#ifdef HAVE_EGL
-    egl_set_swap_interval(&ctx_orbis->egl, 0);
-#endif
+   (void)data;
+   (void)state;
 }
 
-static void orbis_ctx_swap_buffers(void *data, void *data2)
+static void vita_bind_hw_render(void *data, bool enable)
 {
-    orbis_ctx_data_t *ctx_orbis = (orbis_ctx_data_t *)data;
-
-#ifdef HAVE_EGL
-    egl_swap_buffers(&ctx_orbis->egl);
-#endif
+   (void)data;
+   (void)enable;
 }
 
-static gfx_ctx_proc_t orbis_ctx_get_proc_address(const char *symbol)
+static void *vita_init(video_frame_info_t *video_info, void *video_driver)
 {
-#ifdef HAVE_EGL
-    return egl_get_proc_address(symbol);
-#endif
+   (void)video_driver;
+
+   return (void*)"null";
 }
 
-static void orbis_ctx_bind_hw_render(void *data, bool enable)
-{
-    orbis_ctx_data_t *ctx_orbis = (orbis_ctx_data_t *)data;
-
-#ifdef HAVE_EGL
-    egl_bind_hw_render(&ctx_orbis->egl, enable);
-#endif
-}
-
-static uint32_t orbis_ctx_get_flags(void *data)
+static uint32_t vita_get_flags(void *data)
 {
    uint32_t flags = 0;
-
-   if (string_is_equal(video_driver_get_ident(), "glcore"))
-   {
-#if defined(HAVE_SLANG) && defined(HAVE_SPIRV_CROSS)
-      BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_SLANG);
-#endif
-   }
-   else
-   {
-      BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_GLSL);
-   }
 
    return flags;
 }
 
-static void orbis_ctx_set_flags(void *data, uint32_t flags)
+static void vita_set_flags(void *data, uint32_t flags)
 {
-    (void)data;
+   (void)data;
 }
 
-static float orbis_ctx_get_refresh_rate(void *data)
-{
-    orbis_ctx_data_t *ctx_orbis = (orbis_ctx_data_t *)data;
-
-    return ctx_orbis->refresh_rate;
-}
-
-const gfx_ctx_driver_t orbis_ctx = {
-    orbis_ctx_init,
-    orbis_ctx_destroy,
-    orbis_ctx_get_api,
-    orbis_ctx_bind_api,
-    orbis_ctx_set_swap_interval,
-    orbis_ctx_set_video_mode,
-    orbis_ctx_get_video_size,
-    orbis_ctx_get_refresh_rate,
-    NULL, /* get_video_output_size */
-    NULL, /* get_video_output_prev */
-    NULL, /* get_video_output_next */
-    NULL, /* get_metrics */
-    NULL,
-    NULL, /* update_title */
-    orbis_ctx_check_window,
-    NULL, /* set_resize */
-    orbis_ctx_has_focus,
-    orbis_ctx_suppress_screensaver,
-    false, /* has_windowed */
-    orbis_ctx_swap_buffers,
-    orbis_ctx_input_driver,
-    orbis_ctx_get_proc_address,
-    NULL,
-    NULL,
-    NULL,
-    "orbis",
-    orbis_ctx_get_flags,
-    orbis_ctx_set_flags,
-    orbis_ctx_bind_hw_render,
-    NULL,
-    NULL};
+const gfx_ctx_driver_t vita_ctx = {
+   vita_init,
+   vita_destroy,
+   vita_get_api,
+   vita_bind_api,
+   vita_swap_interval,
+   vita_set_video_mode,
+   vita_get_video_size,
+   NULL, /* get_refresh_rate */
+   NULL, /* get_video_output_size */
+   NULL, /* get_video_output_prev */
+   NULL, /* get_video_output_next */
+   NULL, /* get_metrics */
+   NULL,
+   NULL, /* update_title */
+   vita_check_window,
+   NULL, /* set_resize */
+   vita_has_focus,
+   vita_suppress_screensaver,
+   false, /* has_windowed */
+   vita_swap_buffers,
+   vita_input_driver,
+   NULL,
+   NULL,
+   NULL,
+   vita_show_mouse,
+   "vita",
+   vita_get_flags,
+   vita_set_flags,
+   vita_bind_hw_render,
+   NULL,
+   NULL
+};

--- a/gfx/drivers_font/gl1_raster_font.c
+++ b/gfx/drivers_font/gl1_raster_font.c
@@ -82,7 +82,7 @@ static void gl1_raster_font_free_font(void *data,
    free(font);
 }
 
-#ifdef VITA
+#if 0
 static bool gl1_raster_font_upload_atlas(gl1_raster_t *font)
 {
    unsigned i, j;
@@ -115,7 +115,8 @@ static bool gl1_raster_font_upload_atlas(gl1_raster_t *font)
 
    return true;
 }
-#else
+#endif
+
 static bool gl1_raster_font_upload_atlas(gl1_raster_t *font)
 {
    unsigned i, j;
@@ -159,7 +160,7 @@ static bool gl1_raster_font_upload_atlas(gl1_raster_t *font)
 
    return true;
 }
-#endif
+
 static void *gl1_raster_font_init_font(void *data,
       const char *font_path, float font_size,
       bool is_threaded)

--- a/gfx/drivers_font/gl1_raster_font.c
+++ b/gfx/drivers_font/gl1_raster_font.c
@@ -43,6 +43,10 @@
 
 #define MAX_MSG_LEN_CHUNK 64
 
+#ifdef VITA
+static float *vertices3 = NULL;
+#endif
+
 typedef struct
 {
    gl1_t *gl;
@@ -78,8 +82,8 @@ static void gl1_raster_font_free_font(void *data,
    free(font);
 }
 
-#if 0
-static bool gl1_raster_font_upload_atlas_components_4(gl1_raster_t *font)
+#ifdef VITA
+static bool gl1_raster_font_upload_atlas(gl1_raster_t *font)
 {
    unsigned i, j;
    GLint  gl_internal                   = GL_RGBA;
@@ -111,8 +115,7 @@ static bool gl1_raster_font_upload_atlas_components_4(gl1_raster_t *font)
 
    return true;
 }
-#endif
-
+#else
 static bool gl1_raster_font_upload_atlas(gl1_raster_t *font)
 {
    unsigned i, j;
@@ -156,7 +159,7 @@ static bool gl1_raster_font_upload_atlas(gl1_raster_t *font)
 
    return true;
 }
-
+#endif
 static void *gl1_raster_font_init_font(void *data,
       const char *font_path, float font_size,
       bool is_threaded)
@@ -263,8 +266,21 @@ static void gl1_raster_font_draw_vertices(gl1_raster_t *font,
    glEnableClientState(GL_VERTEX_ARRAY);
    glEnableClientState(GL_TEXTURE_COORD_ARRAY);
 
-   glColorPointer(4, GL_FLOAT, 0, coords->color);
+#ifdef VITA
+   if (vertices3)
+      free(vertices3);
+   vertices3 = (float*)malloc(sizeof(float) * 3 * coords->vertices);
+   int i;
+   for (i = 0; i < coords->vertices; i++) {
+      memcpy(&vertices3[i*3], &coords->vertex[i*2], sizeof(float) * 2);
+      vertices3[i*3+2] = 0.0f;
+   }
+   glVertexPointer(3, GL_FLOAT, 0, vertices3);   
+#else
    glVertexPointer(2, GL_FLOAT, 0, coords->vertex);
+#endif
+
+   glColorPointer(4, GL_FLOAT, 0, coords->color);
    glTexCoordPointer(2, GL_FLOAT, 0, coords->tex_coord);
 
    glDrawArrays(GL_TRIANGLES, 0, coords->vertices);

--- a/gfx/drivers_font/gl1_raster_font.c
+++ b/gfx/drivers_font/gl1_raster_font.c
@@ -274,6 +274,7 @@ static void gl1_raster_font_draw_vertices(gl1_raster_t *font,
    int i;
    for (i = 0; i < coords->vertices; i++) {
       memcpy(&vertices3[i*3], &coords->vertex[i*2], sizeof(float) * 2);
+      vertices3[i*3] -= 0.5f;
       vertices3[i*3+2] = 0.0f;
    }
    glVertexPointer(3, GL_FLOAT, 0, vertices3);   

--- a/menu/drivers_display/menu_display_gl1.c
+++ b/menu/drivers_display/menu_display_gl1.c
@@ -26,6 +26,10 @@
 
 #include "../menu_driver.h"
 
+#ifdef VITA
+static float *vertices3 = NULL;
+#endif
+
 static const GLfloat gl1_menu_vertexes[] = {
    0, 0,
    1, 0,
@@ -133,8 +137,21 @@ static void menu_display_gl1_draw(menu_display_ctx_draw_t *draw,
    glEnableClientState(GL_VERTEX_ARRAY);
    glEnableClientState(GL_TEXTURE_COORD_ARRAY);
 
-   glColorPointer(4, GL_FLOAT, 0, draw->coords->color);
+#ifdef VITA
+   if (vertices3)
+      free(vertices3);
+   vertices3 = (float*)malloc(sizeof(float) * 3 * draw->coords->vertices);
+   int i;
+   for (i = 0; i < draw->coords->vertices; i++) {
+      memcpy(&vertices3[i*3], &draw->coords->vertex[i*2], sizeof(float) * 2);
+      vertices3[i*3+2] = 0.0f;
+   }
+   glVertexPointer(3, GL_FLOAT, 0, vertices3);   
+#else
    glVertexPointer(2, GL_FLOAT, 0, draw->coords->vertex);
+#endif
+
+   glColorPointer(4, GL_FLOAT, 0, draw->coords->color);
    glTexCoordPointer(2, GL_FLOAT, 0, draw->coords->tex_coord);
 
    glDrawArrays(menu_display_prim_to_gl1_enum(

--- a/menu/drivers_display/menu_display_gl1.c
+++ b/menu/drivers_display/menu_display_gl1.c
@@ -144,6 +144,7 @@ static void menu_display_gl1_draw(menu_display_ctx_draw_t *draw,
    int i;
    for (i = 0; i < draw->coords->vertices; i++) {
       memcpy(&vertices3[i*3], &draw->coords->vertex[i*2], sizeof(float) * 2);
+      vertices3[i*3] -= 0.5f;
       vertices3[i*3+2] = 0.0f;
    }
    glVertexPointer(3, GL_FLOAT, 0, vertices3);   

--- a/retroarch.c
+++ b/retroarch.c
@@ -340,6 +340,9 @@ static const audio_driver_t *audio_drivers[] = {
 
 
 static const video_driver_t *video_drivers[] = {
+#ifdef HAVE_VITA2D
+   &video_vita2d,
+#endif
 #ifdef HAVE_OPENGL
    &video_gl2,
 #endif
@@ -372,9 +375,6 @@ static const video_driver_t *video_drivers[] = {
 #endif
 #if defined(HAVE_D3D8)
    &video_d3d8,
-#endif
-#ifdef HAVE_VITA2D
-   &video_vita2d,
 #endif
 #ifdef PSP
    &video_psp1,

--- a/retroarch.c
+++ b/retroarch.c
@@ -452,6 +452,9 @@ static const gfx_ctx_driver_t *gfx_ctx_drivers[] = {
 #if defined(ORBIS)
    &orbis_ctx,
 #endif
+#if defined(VITA)
+   &vita_ctx,
+#endif
 #if defined(HAVE_LIBNX) && defined(HAVE_OPENGL)
    &switch_ctx,
 #endif

--- a/retroarch.h
+++ b/retroarch.h
@@ -1980,6 +1980,7 @@ extern const gfx_ctx_driver_t gfx_ctx_sixel;
 extern const gfx_ctx_driver_t gfx_ctx_network;
 extern const gfx_ctx_driver_t switch_ctx;
 extern const gfx_ctx_driver_t orbis_ctx;
+extern const gfx_ctx_driver_t vita_ctx;
 extern const gfx_ctx_driver_t gfx_ctx_null;
 
 extern const shader_backend_t gl_glsl_backend;


### PR DESCRIPTION
This PR adds gl1 video driver support to Vita build using vitaGL.

In order to compile it, libmathneon is required (part of vdpm libraries) and libvitaGL compiled with -DTRANSPOSE_MATRICES. (https://github.com/Rinnegatamante/vitaGL).

This PR also fixes logging to file for PSP and VITA builds as well as replacing old glBegin/glEnd code in gl1 video driver with the better performing glDrawArrays.