### PR TITLE
Do not reinit video driver on SET_SYSTEM_AV_INFO unless needed

### DIFF
--- a/retroarch.h
+++ b/retroarch.h
@@ -1813,7 +1813,7 @@ bool video_driver_texture_unload(uintptr_t *id);
 
 void video_driver_build_info(video_frame_info_t *video_info);
 
-void video_driver_reinit(void);
+void video_driver_reinit(int flags);
 
 void video_driver_get_window_title(char *buf, unsigned len);
 


### PR DESCRIPTION
## Description

Video reinit causes the core to freeze momentarily, freezing audio and flashing the window. Cores like dosbox-svn need to change fps quite often (some DOS games even change fps mid-gameplay) and the video reinit becomes very annoying.

Change this to not reinit the video driver unless CRT SwitchRes is enabled or a max width/height change was requested.

## Related Issues

https://github.com/libretro/dosbox-svn/issues/10