### PR TITLE
Correct Droid Sans Fallback font path in Linux

### DIFF
--- a/gfx/drivers_font_renderer/freetype.c
+++ b/gfx/drivers_font_renderer/freetype.c
@@ -289,7 +289,9 @@ static const char *font_paths[] = {
    "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf",
    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
    "/usr/share/fonts/TTF/Vera.ttf",
-   "/usr/share/fonts/truetype/droid/DroidSansFallbackFull.ttf",
+   "/usr/share/fonts/google-droid/DroidSansFallback.ttf", /* Fedora, RHEL, CentOS */
+   "/usr/share/fonts/truetype/DroidSansFallbackFull.ttf", /* openSUSE, SLE */
+   "/usr/share/fonts/truetype/droid/DroidSansFallbackFull.ttf", /* Arch Linux, Debian, Ubuntu */
 #endif
    "osd-font.ttf", /* Magic font to search for, useful for distribution. */
 };


### PR DESCRIPTION
## Description

RetroArch looks for fonts in exact path that is hard coded in the software. But different Linux distributions place fonts in different paths.

In Chinese and Korean system, when it didn't find the Droid Sans Fallback font at the given path, it uses to system default fonts which are not supported by RetroArch (Droid Sans Fallback is the only CJK font that works with RetroArch). The result is a lot of squares in the menu.

This PR should fix Chinese/Korean font display issues on Fedora/RHEL/CentOS/openSUSE/SLE. 

## Related Issues

## Related Pull Requests

## Reviewers
