### PR TITLE
(GLUI) Navigation improvements

### DIFF
--- a/menu/cbs/menu_cbs_select.c
+++ b/menu/cbs/menu_cbs_select.c
@@ -103,7 +103,7 @@ static int action_select_default(const char *path, const char *label, unsigned t
    }
 
    if (action != MENU_ACTION_NOOP)
-       ret = menu_entry_action(&entry, (unsigned)idx, action);
+       ret = menu_entry_action(&entry, idx, action);
 
    task_queue_check();
 

--- a/menu/drivers/menu_generic.c
+++ b/menu/drivers/menu_generic.c
@@ -242,7 +242,7 @@ int generic_menu_iterate(void *data, void *userdata, enum menu_action action)
             entry.sublabel_enabled   = false;
             menu_entry_get(&entry, 0, selection, NULL, false);
             ret = menu_entry_action(&entry,
-                  (unsigned)selection, (enum menu_action)action);
+                  selection, (enum menu_action)action);
             if (ret)
                goto end;
 
@@ -299,4 +299,89 @@ bool generic_menu_init_list(void *data)
    menu_displaylist_info_free(&info);
 
    return true;
+}
+
+int generic_menu_entry_action(
+      void *userdata, menu_entry_t *entry, size_t i, enum menu_action action)
+{
+   int ret                    = 0;
+   file_list_t *selection_buf = menu_entries_get_selection_buf_ptr(0);
+   menu_file_list_cbs_t *cbs  = selection_buf ?
+      (menu_file_list_cbs_t*)selection_buf->list[i].actiondata : NULL;
+
+   switch (action)
+   {
+      case MENU_ACTION_UP:
+         if (cbs && cbs->action_up)
+            ret = cbs->action_up(entry->type, entry->label);
+         break;
+      case MENU_ACTION_DOWN:
+         if (cbs && cbs->action_down)
+            ret = cbs->action_down(entry->type, entry->label);
+         break;
+      case MENU_ACTION_SCROLL_UP:
+         menu_driver_ctl(MENU_NAVIGATION_CTL_DESCEND_ALPHABET, NULL);
+         break;
+      case MENU_ACTION_SCROLL_DOWN:
+         menu_driver_ctl(MENU_NAVIGATION_CTL_ASCEND_ALPHABET, NULL);
+         break;
+      case MENU_ACTION_CANCEL:
+         if (cbs && cbs->action_cancel)
+            ret = cbs->action_cancel(entry->path,
+                  entry->label, entry->type, i);
+         break;
+      case MENU_ACTION_OK:
+         if (cbs && cbs->action_ok)
+            ret = cbs->action_ok(entry->path,
+                  entry->label, entry->type, i, entry->entry_idx);
+         break;
+      case MENU_ACTION_START:
+         if (cbs && cbs->action_start)
+            ret = cbs->action_start(entry->type, entry->label);
+         break;
+      case MENU_ACTION_LEFT:
+         if (cbs && cbs->action_left)
+            ret = cbs->action_left(entry->type, entry->label, false);
+         break;
+      case MENU_ACTION_RIGHT:
+         if (cbs && cbs->action_right)
+            ret = cbs->action_right(entry->type, entry->label, false);
+         break;
+      case MENU_ACTION_INFO:
+         if (cbs && cbs->action_info)
+            ret = cbs->action_info(entry->type, entry->label);
+         break;
+      case MENU_ACTION_SELECT:
+         if (cbs && cbs->action_select)
+            ret = cbs->action_select(entry->path,
+                  entry->label, entry->type, i);
+         break;
+      case MENU_ACTION_SEARCH:
+         menu_input_dialog_start_search();
+         break;
+      case MENU_ACTION_SCAN:
+         if (cbs && cbs->action_scan)
+            ret = cbs->action_scan(entry->path,
+                  entry->label, entry->type, i);
+         break;
+      default:
+         break;
+   }
+
+   cbs = selection_buf ? (menu_file_list_cbs_t*)
+      selection_buf->list[i].actiondata : NULL;
+
+   if (cbs && cbs->action_refresh)
+   {
+      if (menu_entries_ctl(MENU_ENTRIES_CTL_NEEDS_REFRESH, NULL))
+      {
+         bool refresh            = false;
+         file_list_t *menu_stack = menu_entries_get_menu_stack_ptr(0);
+
+         cbs->action_refresh(selection_buf, menu_stack);
+         menu_entries_ctl(MENU_ENTRIES_CTL_UNSET_REFRESH, &refresh);
+      }
+   }
+
+   return ret;
 }

--- a/menu/drivers/menu_generic.h
+++ b/menu/drivers/menu_generic.h
@@ -22,6 +22,7 @@
 
 #include "../menu_driver.h"
 #include "../menu_input.h"
+#include "../menu_entries.h"
 
 enum action_iterate_type
 {
@@ -34,5 +35,7 @@ enum action_iterate_type
 int generic_menu_iterate(void *data, void *userdata, enum menu_action action);
 
 bool generic_menu_init_list(void *data);
+
+int generic_menu_entry_action(void *userdata, menu_entry_t *entry, size_t i, enum menu_action action);
 
 #endif

--- a/menu/drivers/null.c
+++ b/menu/drivers/null.c
@@ -100,4 +100,5 @@ menu_ctx_driver_t menu_ctx_null = {
   NULL,  /* pointer_down */
   NULL,  /* pointer_up   */
   NULL,  /* get_load_content_animation_data */
+  NULL   /* entry_action */
 };

--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -2308,7 +2308,7 @@ static int ozone_pointer_up(void *userdata,
       case MENU_INPUT_GESTURE_SHORT_PRESS:
          /* Normal pointer input */
          if (ptr == selection)
-            return (unsigned)menu_entry_action(entry, (unsigned)selection, MENU_ACTION_SELECT);
+            return menu_entry_action(entry, selection, MENU_ACTION_SELECT);
 
          menu_navigation_set_selection(ptr);
          menu_driver_navigation_set(false);
@@ -2317,7 +2317,7 @@ static int ozone_pointer_up(void *userdata,
          /* 'Reset to default' action */
          if ((ptr <= (menu_entries_get_size() - 1)) &&
              (ptr == selection))
-            return menu_entry_action(entry, (unsigned)selection, MENU_ACTION_START);
+            return menu_entry_action(entry, selection, MENU_ACTION_START);
          break;
       default:
          /* Ignore input */
@@ -2490,8 +2490,9 @@ menu_ctx_driver_t menu_ctx_ozone = {
    NULL,                         /* pointer_down */
    ozone_pointer_up,
 #ifdef HAVE_MENU_WIDGETS
-   ozone_get_load_content_animation_data
+   ozone_get_load_content_animation_data,
 #else
-   NULL
+   NULL,
 #endif
+   generic_menu_entry_action
 };

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -4885,18 +4885,18 @@ static int rgui_pointer_up(void *data,
                if (y < header_height)
                   rgui_update_thumbnail_image(rgui);
                else
-                  return menu_entry_action(entry, (unsigned)selection, MENU_ACTION_SELECT);
+                  return menu_entry_action(entry, selection, MENU_ACTION_SELECT);
             }
             else
             {
                if (y < header_height)
-                  return menu_entry_action(entry, (unsigned)selection, MENU_ACTION_CANCEL);
+                  return menu_entry_action(entry, selection, MENU_ACTION_CANCEL);
                else if (ptr <= (menu_entries_get_size() - 1))
                {
                   /* If currently selected item matches 'pointer' value,
                    * perform a MENU_ACTION_SELECT on it */
                   if (ptr == selection)
-                     return menu_entry_action(entry, (unsigned)selection, MENU_ACTION_SELECT);
+                     return menu_entry_action(entry, selection, MENU_ACTION_SELECT);
 
                   /* Otherwise, just move the current selection to the
                    * 'pointer' value */
@@ -4910,7 +4910,7 @@ static int rgui_pointer_up(void *data,
          /* 'Reset to default' action */
          if ((ptr <= (menu_entries_get_size() - 1)) &&
              (ptr == selection))
-            return menu_entry_action(entry, (unsigned)selection, MENU_ACTION_START);
+            return menu_entry_action(entry, selection, MENU_ACTION_START);
          break;
       default:
          /* Ignore input */
@@ -5201,4 +5201,5 @@ menu_ctx_driver_t menu_ctx_rgui = {
    NULL,                               /* pointer_down */
    rgui_pointer_up,
    NULL,                               /* get_load_content_animation_data */
+   generic_menu_entry_action
 };

--- a/menu/drivers/stripes.c
+++ b/menu/drivers/stripes.c
@@ -4403,11 +4403,11 @@ static int stripes_pointer_up(void *userdata,
             unsigned header_height = menu_display_get_header_height();
 
             if (y < header_height)
-               return (unsigned)menu_entry_action(entry, (unsigned)selection, MENU_ACTION_CANCEL);
+               return (unsigned)menu_entry_action(entry, selection, MENU_ACTION_CANCEL);
             else if (ptr <= (menu_entries_get_size() - 1))
             {
                if (ptr == selection && cbs && cbs->action_select)
-                  return (unsigned)menu_entry_action(entry, (unsigned)selection, MENU_ACTION_SELECT);
+                  return (unsigned)menu_entry_action(entry, selection, MENU_ACTION_SELECT);
 
                menu_navigation_set_selection(ptr);
                menu_driver_navigation_set(false);
@@ -4418,7 +4418,7 @@ static int stripes_pointer_up(void *userdata,
          /* 'Reset to default' action */
          if ((ptr <= (menu_entries_get_size() - 1)) &&
              (ptr == selection))
-            return menu_entry_action(entry, (unsigned)selection, MENU_ACTION_START);
+            return menu_entry_action(entry, selection, MENU_ACTION_START);
          break;
       default:
          /* Ignore input */
@@ -4473,5 +4473,6 @@ menu_ctx_driver_t menu_ctx_stripes = {
    stripes_update_savestate_thumbnail_image,
    NULL,                                     /* pointer_down */
    stripes_pointer_up,                       /* pointer_up   */
-   NULL                                      /* get_load_content_animation_data   */
+   NULL,                                     /* get_load_content_animation_data   */
+   generic_menu_entry_action
 };

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -3426,13 +3426,13 @@ static void xmb_render(void *data,
                /* Note: Direction is inverted, since 'up' should
                 * move list upwards */
                if (pointer_x > margin_right)
-                  menu_entry_action(&entry, (unsigned)selection, MENU_ACTION_DOWN);
+                  menu_entry_action(&entry, selection, MENU_ACTION_DOWN);
                break;
             case MENU_INPUT_PRESS_DIRECTION_DOWN:
                /* Note: Direction is inverted, since 'down' should
                 * move list downwards */
                if (pointer_x > margin_right)
-                  menu_entry_action(&entry, (unsigned)selection, MENU_ACTION_UP);
+                  menu_entry_action(&entry, selection, MENU_ACTION_UP);
                break;
             case MENU_INPUT_PRESS_DIRECTION_LEFT:
                /* Navigate left
@@ -3441,7 +3441,7 @@ static void xmb_render(void *data,
                 * which is actually a movement to the *right* */
                if (pointer_y < margin_top)
                   menu_entry_action(
-                        &entry, (unsigned)selection, (xmb->depth == 1) ? MENU_ACTION_RIGHT : MENU_ACTION_LEFT);
+                        &entry, selection, (xmb->depth == 1) ? MENU_ACTION_RIGHT : MENU_ACTION_LEFT);
                break;
             case MENU_INPUT_PRESS_DIRECTION_RIGHT:
                /* Navigate right
@@ -3450,7 +3450,7 @@ static void xmb_render(void *data,
                 * which is actually a movement to the *left* */
                if (pointer_y < margin_top)
                   menu_entry_action(
-                        &entry, (unsigned)selection, (xmb->depth == 1) ? MENU_ACTION_LEFT : MENU_ACTION_RIGHT);
+                        &entry, selection, (xmb->depth == 1) ? MENU_ACTION_LEFT : MENU_ACTION_RIGHT);
                break;
             default:
                /* Do nothing */
@@ -6105,17 +6105,17 @@ static int xmb_pointer_up(void *userdata,
          if (x < margin_left)
          {
             if (y >= margin_top)
-               return menu_entry_action(entry, (unsigned)selection, MENU_ACTION_CANCEL);
+               return menu_entry_action(entry, selection, MENU_ACTION_CANCEL);
             else
                return menu_input_dialog_start_search() ? 0 : -1;
          }
          else if (x > margin_right)
-            return menu_entry_action(entry, (unsigned)selection, MENU_ACTION_SELECT);
+            return menu_entry_action(entry, selection, MENU_ACTION_SELECT);
          else if (ptr <= (end - 1))
          {
             /* If pointer item is already 'active', perform 'select' action */
             if (ptr == selection)
-               return menu_entry_action(entry, (unsigned)selection, MENU_ACTION_SELECT);
+               return menu_entry_action(entry, selection, MENU_ACTION_SELECT);
 
             /* ...otherwise navigate to the current pointer item */
             menu_navigation_set_selection(ptr);
@@ -6125,7 +6125,7 @@ static int xmb_pointer_up(void *userdata,
       case MENU_INPUT_GESTURE_LONG_PRESS:
          /* 'Reset to default' action */
          if ((ptr <= end - 1) && (ptr == selection))
-            return menu_entry_action(entry, (unsigned)selection, MENU_ACTION_START);
+            return menu_entry_action(entry, selection, MENU_ACTION_START);
          break;
       case MENU_INPUT_GESTURE_SWIPE_LEFT:
          /* Navigate left
@@ -6134,7 +6134,7 @@ static int xmb_pointer_up(void *userdata,
           * which is actually a movement to the *right* */
          if (y > margin_top)
             menu_entry_action(
-                  entry, (unsigned)selection, (xmb->depth == 1) ? MENU_ACTION_RIGHT : MENU_ACTION_LEFT);
+                  entry, selection, (xmb->depth == 1) ? MENU_ACTION_RIGHT : MENU_ACTION_LEFT);
          break;
       case MENU_INPUT_GESTURE_SWIPE_RIGHT:
          /* Navigate right
@@ -6143,12 +6143,12 @@ static int xmb_pointer_up(void *userdata,
           * which is actually a movement to the *left* */
          if (y > margin_top)
             menu_entry_action(
-                  entry, (unsigned)selection, (xmb->depth == 1) ? MENU_ACTION_LEFT : MENU_ACTION_RIGHT);
+                  entry, selection, (xmb->depth == 1) ? MENU_ACTION_LEFT : MENU_ACTION_RIGHT);
          break;
       case MENU_INPUT_GESTURE_SWIPE_UP:
          /* Swipe up in left margin: ascend alphabet */
          if (x < margin_left)
-            menu_entry_action(entry, (unsigned)selection, MENU_ACTION_SCROLL_DOWN);
+            menu_entry_action(entry, selection, MENU_ACTION_SCROLL_DOWN);
          else if (x < margin_right)
          {
             /* Swipe up between left and right margins:
@@ -6172,7 +6172,7 @@ static int xmb_pointer_up(void *userdata,
       case MENU_INPUT_GESTURE_SWIPE_DOWN:
          /* Swipe down in left margin: descend alphabet */
          if (x < margin_left)
-            menu_entry_action(entry, (unsigned)selection, MENU_ACTION_SCROLL_UP);
+            menu_entry_action(entry, selection, MENU_ACTION_SCROLL_UP);
          else if (x < margin_right)
          {
             /* Swipe down between left and right margins:
@@ -6294,8 +6294,9 @@ menu_ctx_driver_t menu_ctx_xmb = {
    NULL, /* pointer_down */
    xmb_pointer_up,
 #ifdef HAVE_MENU_WIDGETS
-   xmb_get_load_content_animation_data
+   xmb_get_load_content_animation_data,
 #else
-   NULL
+   NULL,
 #endif
+   generic_menu_entry_action
 };

--- a/menu/drivers/xui.cpp
+++ b/menu/drivers/xui.cpp
@@ -732,5 +732,6 @@ menu_ctx_driver_t menu_ctx_xui = {
    NULL,          /* update_savestate_thumbnail_image */
    NULL,          /* pointer_down */
    NULL,          /* pointer_up */
-   NULL           /* get_load_content_animation_data */
+   NULL,          /* get_load_content_animation_data */
+   generic_menu_entry_action
 };

--- a/menu/menu_driver.h
+++ b/menu/menu_driver.h
@@ -324,6 +324,9 @@ typedef struct menu_ctx_driver
          menu_file_list_cbs_t *cbs,
          menu_entry_t *entry, unsigned action);
    bool (*get_load_content_animation_data)(void *userdata, menu_texture_item *icon, char **playlist_name);
+   /* This will be invoked whenever a menu entry action
+    * (menu_entry_action()) is performed */
+   int (*entry_action)(void *userdata, menu_entry_t *entry, size_t i, enum menu_action action);
 } menu_ctx_driver_t;
 
 

--- a/menu/menu_entries.h
+++ b/menu/menu_entries.h
@@ -276,8 +276,8 @@ void menu_entry_get(menu_entry_t *entry, size_t stack_idx,
 
 int menu_entry_select(uint32_t i);
 
-int menu_entry_action(menu_entry_t *entry,
-                      unsigned i, enum menu_action action);
+int menu_entry_action(
+      menu_entry_t *entry, size_t i, enum menu_action action);
 
 void menu_entry_init(menu_entry_t *entry);
 

--- a/menu/menu_thumbnail.c
+++ b/menu/menu_thumbnail.c
@@ -378,9 +378,12 @@ void menu_thumbnail_process_stream(
    {
       /* Entry is off-screen
        * > If status is MENU_THUMBNAIL_STATUS_UNKNOWN,
-       *   thumbnail is already in a blank state - do nothing
-       * In all other cases, reset thumbnail */
-      if (thumbnail->status != MENU_THUMBNAIL_STATUS_UNKNOWN)
+       *   thumbnail is already in a blank state - but we
+       *   must ensure that delay timer is set to zero */
+      if (thumbnail->status == MENU_THUMBNAIL_STATUS_UNKNOWN)
+         thumbnail->delay_timer = 0.0f;
+      /* In all other cases, reset thumbnail */
+      else
          menu_thumbnail_reset(thumbnail);
    }
 }
@@ -477,12 +480,17 @@ void menu_thumbnail_process_streams(
    {
       /* Entry is off-screen
        * > If status is MENU_THUMBNAIL_STATUS_UNKNOWN,
-       *   thumbnail is already in a blank state - do nothing
-       * In all other cases, reset thumbnail */
-      if (right_thumbnail->status != MENU_THUMBNAIL_STATUS_UNKNOWN)
+       *   thumbnail is already in a blank state - but we
+       *   must ensure that delay timer is set to zero
+       * > In all other cases, reset thumbnail */
+      if (right_thumbnail->status == MENU_THUMBNAIL_STATUS_UNKNOWN)
+         right_thumbnail->delay_timer = 0.0f;
+      else
          menu_thumbnail_reset(right_thumbnail);
 
-      if (left_thumbnail->status != MENU_THUMBNAIL_STATUS_UNKNOWN)
+      if (left_thumbnail->status == MENU_THUMBNAIL_STATUS_UNKNOWN)
+         left_thumbnail->delay_timer = 0.0f;
+      else
          menu_thumbnail_reset(left_thumbnail);
    }
 }

--- a/retroarch.c
+++ b/retroarch.c
@@ -13827,7 +13827,7 @@ static int menu_input_pointer_post_iterate(
    if (pointer_hw_state->cancel_pressed && !last_cancel_pressed)
    {
       size_t selection = menu_navigation_get_selection();
-      ret = menu_entry_action(entry, (unsigned)selection, MENU_ACTION_CANCEL);
+      ret = menu_entry_action(entry, selection, MENU_ACTION_CANCEL);
    }
    last_cancel_pressed = pointer_hw_state->cancel_pressed;
 
@@ -13840,14 +13840,14 @@ static int menu_input_pointer_post_iterate(
    if (pointer_hw_state->up_pressed)
    {
       size_t selection = menu_navigation_get_selection();
-      ret = menu_entry_action(entry, (unsigned)selection, MENU_ACTION_UP);
+      ret = menu_entry_action(entry, selection, MENU_ACTION_UP);
    }
 
    /* > Down */
    if (pointer_hw_state->down_pressed)
    {
       size_t selection = menu_navigation_get_selection();
-      ret = menu_entry_action(entry, (unsigned)selection, MENU_ACTION_DOWN);
+      ret = menu_entry_action(entry, selection, MENU_ACTION_DOWN);
    }
 
    /* Left/Right
@@ -13866,7 +13866,7 @@ static int menu_input_pointer_post_iterate(
       {
          size_t selection      = menu_navigation_get_selection();
          last_left_action_time = current_time;
-         ret = menu_entry_action(entry, (unsigned)selection, MENU_ACTION_LEFT);
+         ret = menu_entry_action(entry, selection, MENU_ACTION_LEFT);
       }
    }
    last_left_pressed = pointer_hw_state->left_pressed;
@@ -13878,7 +13878,7 @@ static int menu_input_pointer_post_iterate(
       {
          size_t selection       = menu_navigation_get_selection();
          last_right_action_time = current_time;
-         ret = menu_entry_action(entry, (unsigned)selection, MENU_ACTION_RIGHT);
+         ret = menu_entry_action(entry, selection, MENU_ACTION_RIGHT);
       }
    }
    last_right_pressed = pointer_hw_state->right_pressed;

--- a/ui/drivers/cocoa/cocoatouch_menu.m
+++ b/ui/drivers/cocoa/cocoatouch_menu.m
@@ -805,7 +805,7 @@ didSelectRowAtIndexPath:(NSIndexPath *)indexPath
    size_t selection   = menu_navigation_get_selection();
 
    menu_entry_get(&entry, 0, selection, NULL, false);
-   menu_entry_action(&entry, (unsigned int)selection, MENU_ACTION_CANCEL);
+   menu_entry_action(&entry, selection, MENU_ACTION_CANCEL);
 #endif
 }
 


### PR DESCRIPTION
## Description

Material UI has a long standing navigation issue. The problem is that standard menu navigation actions are always interpreted relative to the currently selected list item. For other menu drivers this is absolutely fine, but Material UI is unique in that its focus on pointer-driven input means the currently selected item is very often off-screen. Whenever this is the case, performing *any* kind of gamepad/keyboard (or mouse wheel) navigation bounces the user back to the position of the last selected item - which is ridiculous and infuriating. It basically means that you can't make effective use of mixed-mode keyboard/gamepad/pointer input, since you end up scrolling to unexpected locations all over the place. As a side note, this 'random' off screen scrolling also occurs whenever the window dimensions change, which is a real nuisance when rotating the screen of mobile devices.

This PR resolves these problems.

- When using a keyboard/gamepad/mouse wheel to navigate, the menu scroll position is always maintained and updated in a consistent (and expected) fashion

- When resizing the window, or changing the orientation of a mobile device, the current scroll position is correctly preserved

While doing this, I added a new way for menu drivers to specify their own `menu_entry_action()` function. This is a far cleaner and more consistent method for menu drivers to intercept/override input commands than the existing `menu_iterate()` shenanigans (which fail completely when dealing with pointer-based input). This also enabled me to remove a very old and dirty hack from Material UI, pertaining to the way that tabs are switched using the keyboard/gamepad.

In addition, this PR adds the ability to scroll rapidly through lists by pressing and dragging the scrollbar. This is a small but fairly significant usability improvement  :)