### PR TITLE
(cheevos) prevent loading state while achievements are still being fetched from server

### DIFF
--- a/cheevos-new/cheevos.c
+++ b/cheevos-new/cheevos.c
@@ -1450,6 +1450,7 @@ static int rcheevos_iterate(rcheevos_coro_t* coro)
       }
 
       CHEEVOS_LOG(RCHEEVOS_TAG "this game doesn't feature achievements\n");
+      rcheevos_hardcore_paused = true;
       CORO_STOP();
 
 found:
@@ -1502,6 +1503,8 @@ found:
          runloop_msg_queue_push(
                "This game has no achievements.",
                0, 5 * 60, false, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
+
+         rcheevos_hardcore_paused = true;
 
          CORO_STOP();
       }

--- a/retroarch.c
+++ b/retroarch.c
@@ -25719,7 +25719,7 @@ static enum runloop_state runloop_check_state(void)
 #ifdef HAVE_CHEEVOS
    rcheevos_hardcore_active = settings->bools.cheevos_enable
       && settings->bools.cheevos_hardcore_mode_enable
-      && rcheevos_loaded && !rcheevos_hardcore_paused;
+      && !rcheevos_hardcore_paused;
 
    if (rcheevos_hardcore_active && rcheevos_state_loaded_flag)
    {


### PR DESCRIPTION
## Description

Without this change, a player can load a game and quickly load a save state before the achievements have been fetched from the server. This should not be allowed when hardcore mode is enabled.

Modifies the `rcheevos_hardcore_active` flag to not be dependent on `rcheevos_loaded`, which is false until the achievements have been received from the server. For games without achievements, this allowed non-hardcore behavior. I've chosen instead to implement that by automatically setting `rcheevos_hardcore_paused` if no achievements are found.

It looks like the check for `rcheevos_loaded` was originally added in #6667: 
* https://github.com/libretro/RetroArch/commit/504317ac7e7cd13cef31d69b412311fedff01772#diff-d5821156b896ba100e8b06d2be59a508R2990

It's unclear why - probably to make it consistent with the other checks in that diff. All of the other updated lines in that diff now reference `rcheevos_hardcore_active`, but I don't believe any of them should be dependent on having the achievement data.

## Related Issues

#8725 - which deals with savestates in hardcore mode, but doesn't specifically mention this case. All cases described in that ticket appear to be working correctly, and I believe it can be closed.

## Related Pull Requests

n/a

## Reviewers

[If possible @mention all the people that should review your pull request]
