### PR TITLE
(GLUI) Add fullscreen thumbnail viewer

### DIFF
--- a/menu/menu_input.h
+++ b/menu/menu_input.h
@@ -46,7 +46,7 @@ RETRO_BEGIN_DECLS
 #define MENU_INPUT_HIDE_CURSOR_DELAY 4000000         /* 4 seconds */
 
 #define MENU_INPUT_PRESS_TIME_SHORT 200000           /* 200 ms */
-#define MENU_INPUT_PRESS_TIME_LONG 1500000           /* 1.5 second */
+#define MENU_INPUT_PRESS_TIME_LONG 1000000           /* 1 second */
 /* (Anything less than 'short' is considered a tap) */
 
 /* Swipe gestures must be completed within a duration

--- a/menu/menu_thumbnail.h
+++ b/menu/menu_thumbnail.h
@@ -141,6 +141,14 @@ void menu_thumbnail_process_streams(
 
 /* Thumbnail rendering */
 
+/* Determines the actual screen dimensions of a
+ * thumbnail when centred with aspect correct
+ * scaling within a rectangle of (width x height) */
+void menu_thumbnail_get_draw_dimensions(
+      menu_thumbnail_t *thumbnail,
+      unsigned width, unsigned height, float scale_factor,
+      float *draw_width, float *draw_height);
+
 /* Draws specified thumbnail centred (with aspect correct
  * scaling) within a rectangle of (width x height)
  * NOTE: Setting scale_factor > 1.0f will increase the


### PR DESCRIPTION
## Description

This PR adds a fullscreen thumbnail viewer to Material UI (analogous to RGUI's fullscreen thumbnail view mode).

When viewing any playlist thumbnail view, fullscreen thumbnails may be shown for the selected entry by:

- Long pressing the entry (mouse or touchscreen)

- Pressing `start` on a gamepad

- Pressing `space` on a keyboard

When fullscreen thumbnails are shown, *any* menu action will disable them again.

Here are some random example screenshots of fullscreen thumbnails in action:

![Screenshot_2019-11-20_14-47-37](https://user-images.githubusercontent.com/38211560/69255896-8020bc00-0bb0-11ea-8b23-4819855af656.png)

![Screenshot_2019-11-20_14-47-49](https://user-images.githubusercontent.com/38211560/69255908-84e57000-0bb0-11ea-85e8-f4c08ba451c9.png)

![Screenshot_2019-11-20_14-49-35](https://user-images.githubusercontent.com/38211560/69255925-8a42ba80-0bb0-11ea-93ea-c8edcf1f72fe.png)

![Screenshot_2019-11-20_14-49-48](https://user-images.githubusercontent.com/38211560/69255934-8e6ed800-0bb0-11ea-8ae6-936ff8d27be5.png)

![Screenshot_2019-11-20_14-50-51](https://user-images.githubusercontent.com/38211560/69255946-929af580-0bb0-11ea-82dd-80f6c09a3520.png)

![Screenshot_2019-11-20_14-51-01](https://user-images.githubusercontent.com/38211560/69255953-962e7c80-0bb0-11ea-8502-b29ad6caf842.png)

![Screenshot_2019-11-20_14-54-30](https://user-images.githubusercontent.com/38211560/69255967-99c20380-0bb0-11ea-8baf-566f308b01de.png)

![Screenshot_2019-11-20_14-54-41](https://user-images.githubusercontent.com/38211560/69255973-9d558a80-0bb0-11ea-8200-02529e1a28c4.png)

- **NOTE 1**: To avoid blurry thumbnails when running Material UI on desktop platforms with large high resolution displays, it is recommended to set `Thumbnail Upscaling Threshold` to `512` or higher (this is under `User Interface > Appearance`). On mobile devices, the screen is usually small enough that this is not required.

- **NOTE 2**: This PR reduces the 'long press' duration from 1.5 seconds to 1 second. Now that users might want to use long press functionality more often, 1.5 seconds just felt uncomfortable.

- **NOTE 3**: In the worst case scenario at 1080p, enabling fullscreen thumbnails increases the performance overheads of `materialui_frame()` by only 0.5%. I was quite surprised by this!

----------

This PR also makes three other tiny Material UI changes that did not warrant separate PRs:

- The menu actions `START`, `INFO`, `SELECT` and `OK` have been added to the list of actions that are ignored when the currently selected entry is off screen. This removes all remaining possibility of unexpected user action.

- The `INFO` menu action has been disabled when viewing playlists - this is because it breaks the playlist layout, due to very odd and annoying shenanigans in the underlying menu code. Since playlists cannot have info text anyway, simply disabling the functionality is the cleanest/easiest solution.

- I've fixed a very subtle bug that caused the menu `CANCEL` action to be temporarily disabled (until another entry was selected) when changing the `Menu Scale Factor` via its drop down list.

## Related Issues

This closes #9737


