### PR TITLE
Gblues/default asset directory

### DIFF
--- a/frontend/drivers/platform_wiiu.c
+++ b/frontend/drivers/platform_wiiu.c
@@ -69,6 +69,28 @@
 static enum frontend_fork wiiu_fork_mode = FRONTEND_FORK_NONE;
 static const char *elf_path_cst = WIIU_SD_PATH "retroarch/retroarch.elf";
 
+static bool exists(char *path) {
+   struct stat stat_buf = {0};
+
+   if(!path)
+      return false;
+
+   return (stat(path, &stat_buf) == 0);
+}
+
+static void fix_asset_directory(void) {
+   char src_path_buf[PATH_MAX_LENGTH] = {0};
+   char dst_path_buf[PATH_MAX_LENGTH] = {0};
+
+   fill_pathname_join(src_path_buf, g_defaults.dirs[DEFAULT_DIR_PORT], "media", sizeof(g_defaults.dirs[DEFAULT_DIR_PORT]));
+   fill_pathname_join(dst_path_buf, g_defaults.dirs[DEFAULT_DIR_PORT], "assets", sizeof(g_defaults.dirs[DEFAULT_DIR_PORT]));
+
+   if(exists(dst_path_buf) || !exists(src_path_buf))
+      return;
+
+   rename(src_path_buf, dst_path_buf);
+}
+
 static void frontend_wiiu_get_environment_settings(int *argc, char *argv[],
       void *args, void *params_data)
 {
@@ -79,6 +101,7 @@ static void frontend_wiiu_get_environment_settings(int *argc, char *argv[],
 
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CORE_ASSETS], g_defaults.dirs[DEFAULT_DIR_PORT],
          "downloads", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE_ASSETS]));
+   fix_asset_directory();
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_ASSETS], g_defaults.dirs[DEFAULT_DIR_PORT],
          "assets", sizeof(g_defaults.dirs[DEFAULT_DIR_ASSETS]));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CORE], g_defaults.dirs[DEFAULT_DIR_PORT],

--- a/frontend/drivers/platform_wiiu.c
+++ b/frontend/drivers/platform_wiiu.c
@@ -80,7 +80,7 @@ static void frontend_wiiu_get_environment_settings(int *argc, char *argv[],
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CORE_ASSETS], g_defaults.dirs[DEFAULT_DIR_PORT],
          "downloads", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE_ASSETS]));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_ASSETS], g_defaults.dirs[DEFAULT_DIR_PORT],
-         "media", sizeof(g_defaults.dirs[DEFAULT_DIR_ASSETS]));
+         "assets", sizeof(g_defaults.dirs[DEFAULT_DIR_ASSETS]));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CORE], g_defaults.dirs[DEFAULT_DIR_PORT],
          "cores", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE]));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CORE_INFO], g_defaults.dirs[DEFAULT_DIR_CORE],


### PR DESCRIPTION
## Description

Make the wiiu port use the same asset directory name as the other versions.

Most RA distributions use `retroarch/assets` as the assets path, but for unknown reasons the wiiu port has used `retroarch/media` instead. This makes setting up the WiiU version tricky because if you do the obvious thing and just copy the assets/ directory from the PC version, it doesn't work.

What this change does:
- updates the default asset dir to retroarch/assets
- does a test to see if the media/ directory exists and the assets/ directory exists. if both tests are true, automatically rename the media/ directory to assets/

Known issues:
- does not override the "asset_directory" directive in the config file, so users will need to delete that line to find the assets directory (RA is still usable, and I'm pretty sure the UI lets you set the assets dir)
  * LMK if this is a dealbreaker--adding a config override is a bit more involved.
- users who don't update all their cores simultaneously are going to have some strange behavior switching among their cores.

## Related Issues

#9581 

## Reviewers

@QuarkTheAwesome @twinaphex 
