### PR TITLE
(Menu) Ensure pointer input is handled correctly when showing message boxes

### DIFF
--- a/menu/menu_input.h
+++ b/menu/menu_input.h
@@ -171,6 +171,7 @@ typedef struct menu_input
    menu_input_pointer_t pointer;
    unsigned ptr;
    bool select_inhibit;
+   bool cancel_inhibit;
 } menu_input_t;
 
 typedef struct menu_input_ctx_hitbox
@@ -200,6 +201,10 @@ void menu_input_set_pointer_selection(unsigned selection);
  * (typically want to set acceleration to zero when
  * calling populate entries) */
 void menu_input_set_pointer_y_accel(float y_accel);
+
+/* Inhibits pointer 'select' and 'cancel' actions
+ * (until the next time 'select'/'cancel' are released) */
+void menu_input_set_pointer_inhibit(bool inhibit);
 
 void menu_input_reset(void);
 

--- a/menu/widgets/menu_input_bind_dialog.c
+++ b/menu/widgets/menu_input_bind_dialog.c
@@ -21,6 +21,7 @@
 #include "menu_input_bind_dialog.h"
 
 #include "../menu_driver.h"
+#include "../menu_input.h"
 
 #include "../../input/input_driver.h"
 
@@ -284,6 +285,13 @@ bool menu_input_key_bind_set_mode(
    keys.cb       = menu_input_key_bind_custom_bind_keyboard_cb;
 
    input_keyboard_ctl(RARCH_INPUT_KEYBOARD_CTL_START_WAIT_KEYS, &keys);
+
+   /* Upon triggering an input bind operation,
+    * pointer input must be inhibited - otherwise
+    * attempting to bind mouse buttons will cause
+    * spurious menu actions */
+   menu_input_set_pointer_inhibit(true);
+
    return true;
 }
 
@@ -658,6 +666,12 @@ bool menu_input_key_bind_iterate(menu_input_ctx_bind_t *bind)
 
       menu_input_binds = binds;
    }
+
+   /* Pointer input must be inhibited on each
+    * frame that the bind operation is active -
+    * otherwise attempting to bind mouse buttons
+    * will cause spurious menu actions */
+   menu_input_set_pointer_inhibit(true);
 
    return false;
 }


### PR DESCRIPTION
## Description

Due to the rather convoluted way that menu input is handled, gamepad/keyboard input is properly inhibited/handled when showing message boxes (help/info/input binds), but pointer input is not.

This has been an issue forever, but we've been lucky so far in that it's difficult to trigger a message box using only pointer input (i.e. only mobile device users touching the menu help entries would normally encounter this) - but now that Material UI has a place on the desktop, it was only a matter of time before the bug reports started coming! Regardless, it really is a serious issue: at best it can lead to unexpected menu navigation; at worst it can cause all kinds of undefined behaviour, including segfaults - and it affects all menu drivers.

This PR solves the problem:

- All 'normal' pointer input is now inhibited when showing message boxes

- The pointer actions 'select' and 'cancel' both now properly close a message box if it is currently being shown

- Pointer 'select' and 'cancel' actions are now inhibited when an input bind dialog is active
