### PR TITLE
Get rid of 128 byte device name limit for XInput device discover

### DIFF
--- a/input/drivers_joypad/dinput_joypad.c
+++ b/input/drivers_joypad/dinput_joypad.c
@@ -255,9 +255,9 @@ static bool guid_is_xinput_device(const GUID* product_guid)
    for (i = 0; i < num_raw_devs; i++)
    {
       RID_DEVICE_INFO rdi;
-      char devName[128]   = {0};
-      UINT rdiSize        = sizeof(rdi);
-      UINT nameSize       = sizeof(devName);
+      char *devName   = NULL;
+      UINT rdiSize    = sizeof(rdi);
+      UINT nameSize   = 0;
 
       rdi.cbSize = sizeof (rdi);
 
@@ -266,12 +266,19 @@ static bool guid_is_xinput_device(const GUID* product_guid)
                                   RIDI_DEVICEINFO, &rdi, &rdiSize) != ((UINT)-1)) &&
           (MAKELONG(rdi.hid.dwVendorId, rdi.hid.dwProductId)
            == ((LONG)product_guid->Data1)) &&
+          (GetRawInputDeviceInfoA(raw_devs[i].hDevice, RIDI_DEVICENAME, NULL, &nameSize) != ((UINT)-1)) &&
+          ((devName = malloc(nameSize)) != NULL) &&
           (GetRawInputDeviceInfoA(raw_devs[i].hDevice, RIDI_DEVICENAME, devName, &nameSize) != ((UINT)-1)) &&
           (strstr(devName, "IG_") != NULL) )
       {
+         free(devName);
          free(raw_devs);
          raw_devs = NULL;
          return true;
+      }
+
+      if (devName) {
+         free(devName);
       }
    }
 


### PR DESCRIPTION
## Description

I've had a problem with my XBox One Gamepad connected through Bluetooth (Windows 10 1909): the axes were all mixed up and the Guide button did not work.

After some digging through the code, I've found that Retroach fails to detect the gamepad as XInput device and resorts to using DInput. This happens because the device name is too long:
```
\\?\HID#{00001124-0000-1000-8000-00805f9b34fb}&VID_045e&PID_02e0&IG_00#b&37d27b84&16&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}
```
You need 129 bytes to store this name, but `devName` buffer is limited to 128 bytes and the call to `GetRawInputDeviceInfoA` result in a failure. 

This pull request removes the limit.
