### PR TITLE
(cheevos) fix hash calculation for some PCEngine CHD files

### DIFF
--- a/libretro-common/streams/chd_stream.c
+++ b/libretro-common/streams/chd_stream.c
@@ -246,7 +246,7 @@ chdstream_t *chdstream_open(const char *path, int32_t track)
    }
 
    /* Only include pregap data if it was in the track file */
-   if (!strcmp(meta.type, meta.pgtype))
+   if (meta.pgtype[0] != 'V')
       pregap = meta.pregap;
    else
       pregap = 0;


### PR DESCRIPTION
## Description

Fixes an issue where some CHD files were not being read properly because the pregap offset was being miscalculated.

Extension of observations documented here: https://github.com/libretro/RetroArch/pull/9638#discussion_r339280476

The 'V' prefix seems to be a better indicator for actually having pregap data in the file:
https://github.com/mamedev/mame/blob/13247311f650d2190ca50f05f2879c63a3ad0b6b/src/lib/util/cdrom.cpp#L1316-L1320

Tested with several CHD files.

| File | pgtype | pregap |
| ---- | ------ | ------ |
| PCE-CD - Akumajou Dracula X | VMODE1_RAW | 225 |
| PCE-CD - Buster Bros | VMODE1_RAW | 225 |
| PCE-CD - Dragon Slayer | VMODE1_RAW | 225 |
| PCE-CD - Loom | VMODE1_RAW | 225|
| PCE-CD - Steam Hearts | MODE1 | 225 |
| PCE-CD - Sylphia | MODE1 | 225 |
| PCE-CD - Ys I & II | VMODE1_RAW | 228 |
| PSX - Darkstalkers 3 | MODE1 | 0 |
| PSX - Tekken 3 | MODE1 | 0 |
| SegaCD - TimeGal | MODE1 | 0 |
| SegaCD - Popful Mail | MODE1 | 0 |

In all cases where there was no pregap, `MODE1` was used, but was unimportant because pregap remained 0 regardless of the value.

In cases where a pregap exists and `VMODE1_RAW` was used, the pregap data _is_ in the CHD and the logic implemented in #9638 is correct. 

In cases where the pregap exists and `MODE1` is used, the pregap data _is not_ in the CHD, so adjusting the offset for the pregap was causing the wrong data to be fetched. This is what is fixed by this PR.

## Related Issues

#9638

## Related Pull Requests

n/a

## Reviewers

[If possible @mention all the people that should review your pull request]