### PR TITLE
[PSP] Solving issue Exiting RetroArch by HOME button

### DIFF
--- a/frontend/drivers/platform_psp.c
+++ b/frontend/drivers/platform_psp.c
@@ -233,8 +233,8 @@ static void frontend_psp_deinit(void *data)
    (void)data;
 #ifndef IS_SALAMANDER
    verbosity_disable();
-#endif
    pthread_terminate();
+#endif
 }
 
 static void frontend_psp_shutdown(bool unused)

--- a/frontend/drivers/platform_psp.c
+++ b/frontend/drivers/platform_psp.c
@@ -234,6 +234,7 @@ static void frontend_psp_deinit(void *data)
 #ifndef IS_SALAMANDER
    verbosity_disable();
 #endif
+   pthread_terminate();
 }
 
 static void frontend_psp_shutdown(bool unused)


### PR DESCRIPTION
This PR is just calling to the terminate function for the pthread on the deinit of the PSP platform driver

The issue it-self was that the RetroArch freezes the PSP when the user clicks in the physical HOME button of the PSP to go to the main menu.

This code could affect Vita as well (because they are reusing the same codebase), pinging @frangarcj for security check.

@Autechre64 now the function is just called for NO SALAMANDER builds

Thanks!