### PR TITLE
Fix 'Thumbnail Upscaling Threshold' setting drop-down list

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -13516,7 +13516,7 @@ static bool setting_append_list(
                   parent_group,
                   general_write_handler,
                   general_read_handler);
-            (*list)[list_info->index - 1].action_ok = &setting_action_ok_uint;
+            (*list)[list_info->index - 1].action_ok = &setting_action_ok_uint_special;
             menu_settings_list_current_add_range(list, list_info, 0, 1024, 256, true, true);
          }
 


### PR DESCRIPTION
## Description

I just noticed that the drop-down list for the `Thumbnail Upscaling Threshold` setting doesn't work any more. You can change the value correctly by pressing (or swiping) left/right, but selecting a value from the drop-down list returns the value *index* instead of the value (which essentially disables the setting entirely). This did work when I added the option many moons ago, so I guess a refactor must have changed something...

This trivial PR fixes the issue.
