### PR TITLE
(Ozone) Use new 'menu_thumbnail' library for loading/rendering thumbnails

### DIFF
--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -1861,6 +1861,7 @@ static void materialui_draw_thumbnail(
       menu_thumbnail_draw(
             video_info, thumbnail,
             x, y, mui->thumbnail_width_max, mui->thumbnail_height_max,
+            MENU_THUMBNAIL_ALIGN_CENTRE,
             mui->transition_alpha, scale_factor);
    }
 }
@@ -4645,6 +4646,7 @@ static void materialui_render_fullscreen_thumbnails(
                primary_thumbnail_y,
                (unsigned)thumbnail_box_width,
                (unsigned)thumbnail_box_height,
+               MENU_THUMBNAIL_ALIGN_CENTRE,
                mui->fullscreen_thumbnail_alpha,
                1.0f);
       }
@@ -4673,6 +4675,7 @@ static void materialui_render_fullscreen_thumbnails(
                secondary_thumbnail_y,
                (unsigned)thumbnail_box_width,
                (unsigned)thumbnail_box_height,
+               MENU_THUMBNAIL_ALIGN_CENTRE,
                mui->fullscreen_thumbnail_alpha,
                1.0f);
       }

--- a/menu/drivers/ozone/ozone.h
+++ b/menu/drivers/ozone/ozone.h
@@ -25,6 +25,7 @@ typedef struct ozone_handle ozone_handle_t;
 #include <retro_miscellaneous.h>
 
 #include "../../menu_thumbnail_path.h"
+#include "../../menu_thumbnail.h"
 #include "../../menu_driver.h"
 
 #include "../../../retroarch.h"
@@ -212,11 +213,6 @@ struct ozone_handle
       int cursor_size;
 
       int thumbnail_bar_width;
-
-      float thumbnail_width; /* set at layout time */
-      float thumbnail_height; /* set later to thumbnail_width * image aspect ratio */
-      float left_thumbnail_width; /* set at layout time */
-      float left_thumbnail_height; /* set later to left_thumbnail_width * image aspect ratio */
    } dimensions;
 
    bool show_cursor;
@@ -230,10 +226,12 @@ struct ozone_handle
    /* Thumbnails data */
    bool show_thumbnail_bar;
 
-   uintptr_t thumbnail;
-   uintptr_t left_thumbnail;
-
    menu_thumbnail_path_data_t *thumbnail_path_data;
+
+   struct {
+      menu_thumbnail_t right;
+      menu_thumbnail_t left;
+   } thumbnails;
 
    char selection_core_name[255];
    char selection_playtime[255];

--- a/menu/menu_thumbnail.h
+++ b/menu/menu_thumbnail.h
@@ -42,6 +42,17 @@ enum menu_thumbnail_status
    MENU_THUMBNAIL_STATUS_MISSING
 };
 
+/* Defines thumbnail alignment within
+ * menu_thumbnail_draw() bounding box */
+enum menu_thumbnail_alignment
+{
+   MENU_THUMBNAIL_ALIGN_CENTRE = 0,
+   MENU_THUMBNAIL_ALIGN_TOP,
+   MENU_THUMBNAIL_ALIGN_BOTTOM,
+   MENU_THUMBNAIL_ALIGN_LEFT,
+   MENU_THUMBNAIL_ALIGN_RIGHT
+};
+
 /* Holds all runtime parameters associated with
  * an entry thumbnail */
 typedef struct
@@ -149,15 +160,17 @@ void menu_thumbnail_get_draw_dimensions(
       unsigned width, unsigned height, float scale_factor,
       float *draw_width, float *draw_height);
 
-/* Draws specified thumbnail centred (with aspect correct
- * scaling) within a rectangle of (width x height)
+/* Draws specified thumbnail with specified alignment
+ * (and aspect correct scaling) within a rectangle of
+ * (width x height)
  * NOTE: Setting scale_factor > 1.0f will increase the
  *       size of the thumbnail beyond the limits of the
- *       (width x height) rectangle (centring + aspect
+ *       (width x height) rectangle (alignment + aspect
  *       correct scaling is preserved). Use with caution */
 void menu_thumbnail_draw(
       video_frame_info_t *video_info, menu_thumbnail_t *thumbnail,
       float x, float y, unsigned width, unsigned height,
+      enum menu_thumbnail_alignment alignment,
       float alpha, float scale_factor);
 
 RETRO_END_DECLS


### PR DESCRIPTION
## Description

This small 'housekeeping' PR just updates Ozone to make use of the new `menu_thumbnail.h/.c` code for loading and drawing thumbnails. This standardises a few things and should hopefully facilitate future development.

One immediate benefit is that Ozone thumbnails now have a subtle 'fade in' animation.

The PR also adds some alignment options to the `menu_thumbnail_draw()` function (these are required for Ozone, but should be useful elsewhere)

## Reviewers

@natinusala
