### PR TITLE
(cheevos) pause hardcore if core doesn't support achievements

### DIFF
--- a/cheevos-new/cheevos.c
+++ b/cheevos-new/cheevos.c
@@ -2560,7 +2560,10 @@ bool rcheevos_load(const void *data)
    rcheevos_hardcore_paused = false;
 
    if (!rcheevos_locals.core_supports || !data)
+   {
+      rcheevos_hardcore_paused = true;
       return false;
+   }
 
    coro = (rcheevos_coro_t*)calloc(1, sizeof(*coro));
 

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -1087,6 +1087,12 @@ static bool content_file_load(
 
       if (type == RARCH_CONTENT_NONE && !string_is_empty(content_path))
          rcheevos_load(info);
+      else
+         rcheevos_hardcore_paused = true;
+   }
+   else
+   {
+      rcheevos_hardcore_paused = true;
    }
 #endif
 


### PR DESCRIPTION
## Description

Extension of #9739 - which removes the `rcheevos_loaded` flag in favor of the `rcheevos_hardcore_paused` flag. Cores that don't support achievements intrinsically wouldn't have achievements loaded, so should automatically have hardcore paused.

This is a speculative change. I couldn't find any cores that set `RETRO_ENVIRONMENT_SET_SUPPORT_ACHIEVEMENTS` to false, and I'm not sure what would a subsystem represents for triggering the `special != NULL` logic.

## Related Issues

#9739

## Related Pull Requests

n/a

## Reviewers

[If possible @mention all the people that should review your pull request]
