### PR TITLE
KMSDRM: better detection for the current video mode

### DIFF
--- a/gfx/common/drm_common.c
+++ b/gfx/common/drm_common.c
@@ -27,7 +27,7 @@ uint32_t g_connector_id               = 0;
 int g_drm_fd                          = 0;
 uint32_t g_crtc_id                    = 0;
 
-static drmModeCrtc *g_orig_crtc       = NULL;
+drmModeCrtc *g_orig_crtc       = NULL;
 
 static drmModeRes *g_drm_resources    = NULL;
 drmModeConnector *g_drm_connector     = NULL;

--- a/gfx/common/drm_common.h
+++ b/gfx/common/drm_common.h
@@ -39,6 +39,7 @@ extern struct pollfd g_drm_fds;
 
 extern drmModeConnector *g_drm_connector;
 extern drmModeModeInfo *g_drm_mode;
+extern drmModeCrtc *g_orig_crtc;
 
 extern drmEventContext g_drm_evctx;
 

--- a/gfx/drivers_context/drm_ctx.c
+++ b/gfx/drivers_context/drm_ctx.c
@@ -388,10 +388,16 @@ nextgpu:
 
    drm_setup(fd);
 
-   /* First mode is assumed to be the "optimal"
-    * one for get_video_size() purposes. */
-   drm->fb_width    = g_drm_connector->modes[0].hdisplay;
-   drm->fb_height   = g_drm_connector->modes[0].vdisplay;
+   /* Choose the optimal video mode for get_video_size():
+     - the current video mode from the CRTC
+     - otherwise pick first connector mode */
+   if (g_orig_crtc->mode_valid) {
+      drm->fb_width  = g_orig_crtc->mode.hdisplay;
+      drm->fb_height = g_orig_crtc->mode.vdisplay;
+   } else {
+      drm->fb_width  = g_drm_connector->modes[0].hdisplay;
+      drm->fb_height = g_drm_connector->modes[0].vdisplay;
+   }
 
    drmSetMaster(g_drm_fd);
 


### PR DESCRIPTION
Instead of using the 1st video mode supported by the DRM connector, try to use the current video mode used by the CRTC - since these video modes could be different. This matters when `video_fullscreen` is set, since it will use a different mode for fullscreen, instead of using the current video mode.

For instance, on a 4k TV, the preferred video mode (as returned by the TV's EDIT) might be a 1080p video mode, but the 1st mode on the connector list is a 4k video mode, so `get_video_size` returns a 4k video mode instead of the current 1080p video mode, forcing a mode set on start-up when `video_fullscreen` is set.

Another instance is when the current (or a custom) video mode is set by kernel parameters (`video=...`) and it's not the 1st mode listed by the DRM connector.
