### PR TITLE
Multiple UWP Fixes

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -97,7 +97,7 @@
 #define DEFAULT_MOUSE_SCALE 1
 #endif
 
-#if defined(RARCH_MOBILE) || defined(HAVE_LIBNX)
+#if defined(RARCH_MOBILE) || defined(HAVE_LIBNX) || defined(__WINRT__)
 #define DEFAULT_POINTER_ENABLE true
 #else
 #define DEFAULT_POINTER_ENABLE false

--- a/frontend/drivers/platform_uwp.c
+++ b/frontend/drivers/platform_uwp.c
@@ -384,7 +384,7 @@ static void frontend_uwp_environment_get(int *argc, char *argv[],
 
 #ifdef HAVE_MENU
 #if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES) || defined(HAVE_OPENGL_CORE)
-   snprintf(g_defaults.settings.menu,
+      snprintf(g_defaults.settings.menu,
          sizeof(g_defaults.settings.menu), "xmb");
 #endif
 #endif
@@ -424,6 +424,16 @@ static uint64_t frontend_uwp_get_mem_used(void)
 #endif
 }
 
+enum retro_language frontend_uwp_get_user_language(void)
+{
+   return uwp_get_language();
+}
+
+static const char* frontend_uwp_get_cpu_model_name(void)
+{
+   return uwp_get_cpu_model_name();
+}
+
 frontend_ctx_driver_t frontend_ctx_uwp = {
    frontend_uwp_environment_get,
    frontend_uwp_init,
@@ -451,7 +461,7 @@ frontend_ctx_driver_t frontend_ctx_uwp = {
    NULL,                            /* watch_path_for_changes */
    NULL,                            /* check_for_path_changes */
    NULL,                            /* set_sustained_performance_mode */
-   NULL,                            /* get_cpu_model_name */
-   NULL,                            /* get_user_language */
+   frontend_uwp_get_cpu_model_name,
+   frontend_uwp_get_user_language,
    "uwp"
 };

--- a/frontend/drivers/platform_uwp.c
+++ b/frontend/drivers/platform_uwp.c
@@ -75,6 +75,9 @@ static void frontend_uwp_get_os(char *s, size_t len, int *major, int *minor)
       case PROCESSOR_ARCHITECTURE_ARM:
          arch = "ARM";
          break;
+      case PROCESSOR_ARCHITECTURE_ARM64:
+         arch = "ARM64";
+         break;
       default:
          break;
    }
@@ -256,6 +259,9 @@ enum frontend_architecture frontend_uwp_get_architecture(void)
          break;
       case PROCESSOR_ARCHITECTURE_ARM:
          return FRONTEND_ARCH_ARM;
+         break;
+      case PROCESSOR_ARCHITECTURE_ARM64:
+         return FRONTEND_ARCH_ARMV8;
          break;
       default:
          break;

--- a/frontend/drivers/platform_uwp.c
+++ b/frontend/drivers/platform_uwp.c
@@ -333,60 +333,60 @@ static void frontend_uwp_environment_get(int *argc, char *argv[],
    /* On UWP, we have to use the writable directory
     * instead of the install directory. */
    fill_pathname_expand_special(g_defaults.dirs[DEFAULT_DIR_ASSETS],
-      "~\\assets", sizeof(g_defaults.dirs[DEFAULT_DIR_ASSETS]));
+      "~\\assets\\", sizeof(g_defaults.dirs[DEFAULT_DIR_ASSETS]));
    fill_pathname_expand_special(g_defaults.dirs[DEFAULT_DIR_AUDIO_FILTER],
-      "~\\filters\\audio", sizeof(g_defaults.dirs[DEFAULT_DIR_AUDIO_FILTER]));
+      "~\\filters\\audio\\", sizeof(g_defaults.dirs[DEFAULT_DIR_AUDIO_FILTER]));
    fill_pathname_expand_special(g_defaults.dirs[DEFAULT_DIR_VIDEO_FILTER],
-      "~\\filters\\video", sizeof(g_defaults.dirs[DEFAULT_DIR_VIDEO_FILTER]));
+      "~\\filters\\video\\", sizeof(g_defaults.dirs[DEFAULT_DIR_VIDEO_FILTER]));
    fill_pathname_expand_special(g_defaults.dirs[DEFAULT_DIR_CHEATS],
-      "~\\cheats", sizeof(g_defaults.dirs[DEFAULT_DIR_CHEATS]));
+      "~\\cheats\\", sizeof(g_defaults.dirs[DEFAULT_DIR_CHEATS]));
    fill_pathname_expand_special(g_defaults.dirs[DEFAULT_DIR_DATABASE],
-      "~\\database\\rdb", sizeof(g_defaults.dirs[DEFAULT_DIR_DATABASE]));
+      "~\\database\\rdb\\", sizeof(g_defaults.dirs[DEFAULT_DIR_DATABASE]));
    fill_pathname_expand_special(g_defaults.dirs[DEFAULT_DIR_CURSOR],
-      "~\\database\\cursors", sizeof(g_defaults.dirs[DEFAULT_DIR_CURSOR]));
+      "~\\database\\cursors\\", sizeof(g_defaults.dirs[DEFAULT_DIR_CURSOR]));
    fill_pathname_expand_special(g_defaults.dirs[DEFAULT_DIR_PLAYLIST],
-      "~\\playlists", sizeof(g_defaults.dirs[DEFAULT_DIR_ASSETS]));
+      "~\\playlists\\", sizeof(g_defaults.dirs[DEFAULT_DIR_ASSETS]));
    fill_pathname_expand_special(g_defaults.dirs[DEFAULT_DIR_RECORD_CONFIG],
-      "~\\config\\record", sizeof(g_defaults.dirs[DEFAULT_DIR_RECORD_CONFIG]));
+      "~\\config\\record\\", sizeof(g_defaults.dirs[DEFAULT_DIR_RECORD_CONFIG]));
    fill_pathname_expand_special(g_defaults.dirs[DEFAULT_DIR_RECORD_OUTPUT],
-      "~\\recordings", sizeof(g_defaults.dirs[DEFAULT_DIR_RECORD_OUTPUT]));
+      "~\\recordings\\", sizeof(g_defaults.dirs[DEFAULT_DIR_RECORD_OUTPUT]));
    fill_pathname_expand_special(g_defaults.dirs[DEFAULT_DIR_MENU_CONFIG],
-      "~\\config", sizeof(g_defaults.dirs[DEFAULT_DIR_MENU_CONFIG]));
+      "~\\config\\", sizeof(g_defaults.dirs[DEFAULT_DIR_MENU_CONFIG]));
    fill_pathname_expand_special(g_defaults.dirs[DEFAULT_DIR_REMAP],
-      "~\\config\\remaps", sizeof(g_defaults.dirs[DEFAULT_DIR_REMAP]));
+      "~\\config\\remaps\\", sizeof(g_defaults.dirs[DEFAULT_DIR_REMAP]));
    fill_pathname_expand_special(g_defaults.dirs[DEFAULT_DIR_WALLPAPERS],
-      "~\\assets\\wallpapers", sizeof(g_defaults.dirs[DEFAULT_DIR_WALLPAPERS]));
+      "~\\assets\\wallpapers\\", sizeof(g_defaults.dirs[DEFAULT_DIR_WALLPAPERS]));
    fill_pathname_expand_special(g_defaults.dirs[DEFAULT_DIR_THUMBNAILS],
-      "~\\thumbnails", sizeof(g_defaults.dirs[DEFAULT_DIR_THUMBNAILS]));
+      "~\\thumbnails\\", sizeof(g_defaults.dirs[DEFAULT_DIR_THUMBNAILS]));
    fill_pathname_expand_special(g_defaults.dirs[DEFAULT_DIR_OVERLAY],
-      "~\\overlays", sizeof(g_defaults.dirs[DEFAULT_DIR_OVERLAY]));
+      "~\\overlays\\", sizeof(g_defaults.dirs[DEFAULT_DIR_OVERLAY]));
 #ifdef HAVE_VIDEO_LAYOUT
    fill_pathname_expand_special(g_defaults.dirs[DEFAULT_DIR_VIDEO_LAYOUT],
-      "~\\layouts", sizeof(g_defaults.dirs[DEFAULT_DIR_VIDEO_LAYOUT]));
+      "~\\layouts\\", sizeof(g_defaults.dirs[DEFAULT_DIR_VIDEO_LAYOUT]));
 #endif
    /* This one is an exception: cores have to be loaded from
     * the install directory,
     * since this is the only place UWP apps can take .dlls from */
    fill_pathname_expand_special(g_defaults.dirs[DEFAULT_DIR_CORE],
-      ":\\cores", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE]));
+      ":\\cores\\", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE]));
    fill_pathname_expand_special(g_defaults.dirs[DEFAULT_DIR_CORE_INFO],
-      "~\\info", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE_INFO]));
+      "~\\info\\", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE_INFO]));
    fill_pathname_expand_special(g_defaults.dirs[DEFAULT_DIR_AUTOCONFIG],
-      "~\\autoconfig", sizeof(g_defaults.dirs[DEFAULT_DIR_AUTOCONFIG]));
+      "~\\autoconfig\\", sizeof(g_defaults.dirs[DEFAULT_DIR_AUTOCONFIG]));
    fill_pathname_expand_special(g_defaults.dirs[DEFAULT_DIR_SHADER],
-      "~\\shaders", sizeof(g_defaults.dirs[DEFAULT_DIR_SHADER]));
+      "~\\shaders\\", sizeof(g_defaults.dirs[DEFAULT_DIR_SHADER]));
    fill_pathname_expand_special(g_defaults.dirs[DEFAULT_DIR_CORE_ASSETS],
-      "~\\downloads", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE_ASSETS]));
+      "~\\downloads\\", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE_ASSETS]));
    fill_pathname_expand_special(g_defaults.dirs[DEFAULT_DIR_SCREENSHOT],
-      "~\\screenshots", sizeof(g_defaults.dirs[DEFAULT_DIR_SCREENSHOT]));
+      "~\\screenshots\\", sizeof(g_defaults.dirs[DEFAULT_DIR_SCREENSHOT]));
    fill_pathname_expand_special(g_defaults.dirs[DEFAULT_DIR_SRAM],
-      "~\\saves", sizeof(g_defaults.dirs[DEFAULT_DIR_SRAM]));
+      "~\\saves\\", sizeof(g_defaults.dirs[DEFAULT_DIR_SRAM]));
    fill_pathname_expand_special(g_defaults.dirs[DEFAULT_DIR_SAVESTATE],
-      "~\\states", sizeof(g_defaults.dirs[DEFAULT_DIR_SAVESTATE]));
+      "~\\states\\", sizeof(g_defaults.dirs[DEFAULT_DIR_SAVESTATE]));
    fill_pathname_expand_special(g_defaults.dirs[DEFAULT_DIR_SYSTEM],
-      "~\\system", sizeof(g_defaults.dirs[DEFAULT_DIR_SYSTEM]));
+      "~\\system\\", sizeof(g_defaults.dirs[DEFAULT_DIR_SYSTEM]));
    fill_pathname_expand_special(g_defaults.dirs[DEFAULT_DIR_LOGS],
-      "~\\logs", sizeof(g_defaults.dirs[DEFAULT_DIR_LOGS]));
+      "~\\logs\\", sizeof(g_defaults.dirs[DEFAULT_DIR_LOGS]));
 
 #ifdef HAVE_MENU
 #if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES) || defined(HAVE_OPENGL_CORE)

--- a/frontend/drivers/platform_uwp.c
+++ b/frontend/drivers/platform_uwp.c
@@ -390,8 +390,16 @@ static void frontend_uwp_environment_get(int *argc, char *argv[],
 
 #ifdef HAVE_MENU
 #if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES) || defined(HAVE_OPENGL_CORE)
+   if (string_is_equal(uwp_device_family, "Windows.Mobile"))
+   {
+      snprintf(g_defaults.settings.menu,
+         sizeof(g_defaults.settings.menu), "glui");
+   }
+   else
+   {
       snprintf(g_defaults.settings.menu,
          sizeof(g_defaults.settings.menu), "xmb");
+   }
 #endif
 #endif
 }

--- a/pkg/msvc-uwp/RetroArch-msvc2017-UWP/RetroArch-msvc2017-UWP.vcxproj
+++ b/pkg/msvc-uwp/RetroArch-msvc2017-UWP/RetroArch-msvc2017-UWP.vcxproj
@@ -293,6 +293,7 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\..\uwp\uwp_async.h" />
     <ClInclude Include="..\..\..\uwp\uwp_func.h" />
     <ClInclude Include="..\..\..\uwp\uwp_main.h" />
   </ItemGroup>

--- a/pkg/msvc-uwp/RetroArch-msvc2017-UWP/RetroArch-msvc2017-UWP.vcxproj.filters
+++ b/pkg/msvc-uwp/RetroArch-msvc2017-UWP/RetroArch-msvc2017-UWP.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="uwp">
@@ -27,6 +27,9 @@
       <Filter>uwp</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\uwp\uwp_main.h">
+      <Filter>uwp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\uwp\uwp_async.h">
       <Filter>uwp</Filter>
     </ClInclude>
   </ItemGroup>

--- a/retroarch.c
+++ b/retroarch.c
@@ -2259,6 +2259,10 @@ void dir_check_defaults(void)
     */
 #if defined(ORBIS) || defined(ANDROID)
    if (path_is_valid("host0:app/custom.ini"))
+#elif defined(__WINRT__)
+   char path[MAX_PATH];
+   fill_pathname_expand_special(path, "~\\custom.ini", MAX_PATH);
+   if (path_is_valid(path))
 #else
    if (path_is_valid("custom.ini"))
 #endif

--- a/uwp/uwp_async.h
+++ b/uwp/uwp_async.h
@@ -1,0 +1,86 @@
+/* Copyright  (C) 2018-2019 The RetroArch team
+*
+* ---------------------------------------------------------------------------------------
+* The following license statement only applies to this file (uwp_async.h).
+* ---------------------------------------------------------------------------------------
+*
+* Permission is hereby granted, free of charge,
+* to any person obtaining a copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation the rights to
+* use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+* and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+* INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+* WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include <ppl.h>
+#include <ppltasks.h>
+#include "uwp_main.h"
+#include "uwp_func.h"
+
+#ifdef __cplusplus
+#ifdef __cplusplus_winrt
+namespace
+{
+   /* Dear Microsoft
+      * I really appreciate all the effort you took to not provide any
+      * synchronous file APIs and block all attempts to synchronously
+      * wait for the results of async tasks for "smooth user experience",
+      * but I'm not going to run and rewrite all RetroArch cores for
+      * async I/O. I hope you like this hack I made instead.
+      */
+   template<typename T>
+   T RunAsync(std::function<concurrency::task<T>()> func)
+   {
+      volatile bool finished = false;
+      Platform::Exception^ exception = nullptr;
+      T result;
+
+      func().then([&finished, &exception, &result](concurrency::task<T> t) {
+         try
+         {
+            result = t.get();
+         }
+         catch (Platform::Exception ^ exception_)
+         {
+            exception = exception_;
+         }
+         finished = true;
+         });
+
+      /* Don't stall the UI thread - prevents a deadlock */
+      Windows::UI::Core::CoreWindow^ corewindow = Windows::UI::Core::CoreWindow::GetForCurrentThread();
+      while (!finished)
+      {
+         if (corewindow) {
+            corewindow->Dispatcher->ProcessEvents(Windows::UI::Core::CoreProcessEventsOption::ProcessAllIfPresent);
+         }
+      }
+
+      if (exception != nullptr)
+         throw exception;
+      return result;
+   }
+
+   template<typename T>
+   T RunAsyncAndCatchErrors(std::function<concurrency::task<T>()> func, T valueOnError)
+   {
+      try
+      {
+         return RunAsync<T>(func);
+      }
+      catch (Platform::Exception ^ e)
+      {
+         return valueOnError;
+      }
+   }
+}
+#endif
+#endif

--- a/uwp/uwp_func.h
+++ b/uwp/uwp_func.h
@@ -36,6 +36,8 @@ void uwp_input_next_frame(void);
 bool uwp_keyboard_pressed(unsigned key);
 int16_t uwp_mouse_state(unsigned port, unsigned id, bool screen);
 int16_t uwp_pointer_state(unsigned idx, unsigned id, bool screen);
+const char* uwp_get_cpu_model_name();
+enum retro_language uwp_get_language();
 
 void uwp_fill_installed_core_packages(struct string_list *list);
 

--- a/uwp/uwp_main.cpp
+++ b/uwp/uwp_main.cpp
@@ -621,7 +621,8 @@ extern "C" {
 
 	bool uwp_keyboard_pressed(unsigned key)
 	{
-		unsigned sym = rarch_keysym_lut[(enum retro_key)key];
+		VirtualKey sym = (VirtualKey)rarch_keysym_lut[(enum retro_key)key];
+		if (sym == VirtualKey::None) return false;
 		CoreWindow^ window = CoreWindow::GetForCurrentThread();
 		if (!window)
 		{
@@ -629,7 +630,7 @@ extern "C" {
 			// Dolphin core runs on its own CPU thread separate from the UI-thread and so we must do a check for this.
 			return false;
 		}
-		return (window->GetKeyState((VirtualKey)sym) & CoreVirtualKeyStates::Down) == CoreVirtualKeyStates::Down;
+		return (window->GetKeyState(sym) & CoreVirtualKeyStates::Down) == CoreVirtualKeyStates::Down;
 	}
 
 	int16_t uwp_mouse_state(unsigned port, unsigned id, bool screen)


### PR DESCRIPTION
## Description
- Fixes: Crashes on startup / prompt for folder permissions when trying to load custom.ini
- Fixes: Mouse input is offset on high DPI monitors
- Fixes: Keyboard input hangs sometimes
- Add: Multi-touch support
- Add: Enable menu touch input by default
- Add: Get user language
- Add: Get CPU model name
- Add: Use GLUI instead of XMB on Windows Mobile
