### PR TITLE
Update ffmpeg dependency requirements

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -387,13 +387,12 @@ check_lib '' DRMINGW -lexchndl
 check_enabled THREADS FFMPEG FFmpeg 'Threads are' false
 
 if [ "$HAVE_FFMPEG" != 'no' ]; then
-   check_val '' AVCODEC -lavcodec '' libavcodec 54 '' false
-   check_val '' AVFORMAT -lavformat '' libavformat 54 '' false
-   check_val '' AVDEVICE -lavdevice '' libavdevice '' '' false
-   check_val '' SWRESAMPLE -lswresample '' libswresample '' '' false
-   check_val '' AVRESAMPLE -lavresample '' libavresample '' '' false
-   check_val '' AVUTIL -lavutil '' libavutil 51 '' false
-   check_val '' SWSCALE -lswscale '' libswscale 2.1 '' false
+   check_val '' AVCODEC -lavcodec '' libavcodec 58 '' false
+   check_val '' AVFORMAT -lavformat '' libavformat 58 '' false
+   check_val '' AVDEVICE -lavdevice '' libavdevice 58 '' false
+   check_val '' SWRESAMPLE -lswresample '' libswresample 3 '' false
+   check_val '' AVUTIL -lavutil '' libavutil 56 '' false
+   check_val '' SWSCALE -lswscale '' libswscale 5 '' false
 
    check_header AV_CHANNEL_LAYOUT libavutil/channel_layout.h
 


### PR DESCRIPTION
The ffmpeg core currently needs at least version 4.0 of ffmpeg. This updated the configuration script to reflect this change.

I also removed the lavresample  dependency, since we don't use it and it's marked as deprecated by ffmpeg.