### PR TITLE
(Menu) Analog stick controls menu even if autoconfig disabled

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -15447,9 +15447,11 @@ static void input_menu_keys_pressed(input_bits_t *p_new_state,
    for (i = 0; i < max_users; i++)
    {
       struct retro_keybind *auto_binds          = input_autoconf_binds[i];
+      struct retro_keybind *general_binds       = input_config_binds[i];
       binds[i]                                  = input_config_binds[i];
 
       input_push_analog_dpad(auto_binds, ANALOG_DPAD_LSTICK);
+      input_push_analog_dpad(general_binds, ANALOG_DPAD_LSTICK);
    }
 
    for (port = 0; port < port_max; port++)
@@ -15550,7 +15552,9 @@ static void input_menu_keys_pressed(input_bits_t *p_new_state,
    for (i = 0; i < max_users; i++)
    {
       struct retro_keybind *auto_binds    = input_autoconf_binds[i];
+      struct retro_keybind *general_binds = input_config_binds[i];
       input_pop_analog_dpad(auto_binds);
+      input_pop_analog_dpad(general_binds);
    }
 
    if (!display_kb)


### PR DESCRIPTION
## Description

2091c4cc2f5b added support for controlling the menu with the left analog stick, but it only works when autoconfig is enabled.  This patch allows using the analog stick for navigating the menu even if autoconfig is disabled.

## Related Issues

Fixes #8192 and #9089.

## Reviewers

@twinaphex authored the original patch, so I'd appreciate it if he could take a look.  This is my first time looking at the code, so I'm not certain if this change has any unintended side-effects, but it seems to work fine based on my brief testing.
