### PR TITLE
(XMB) Use new 'menu_thumbnail' library for loading/rendering thumbnails

### DIFF
--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -1862,7 +1862,7 @@ static void materialui_draw_thumbnail(
             video_info, thumbnail,
             x, y, mui->thumbnail_width_max, mui->thumbnail_height_max,
             MENU_THUMBNAIL_ALIGN_CENTRE,
-            mui->transition_alpha, scale_factor);
+            mui->transition_alpha, scale_factor, NULL);
    }
 }
 
@@ -4662,7 +4662,8 @@ static void materialui_render_fullscreen_thumbnails(
                (unsigned)thumbnail_box_height,
                MENU_THUMBNAIL_ALIGN_CENTRE,
                mui->fullscreen_thumbnail_alpha,
-               1.0f);
+               1.0f,
+               NULL);
       }
 
       /* > Secondary */
@@ -4691,7 +4692,8 @@ static void materialui_render_fullscreen_thumbnails(
                (unsigned)thumbnail_box_height,
                MENU_THUMBNAIL_ALIGN_CENTRE,
                mui->fullscreen_thumbnail_alpha,
-               1.0f);
+               1.0f,
+               NULL);
       }
    }
 

--- a/menu/drivers/ozone/ozone_entries.c
+++ b/menu/drivers/ozone/ozone_entries.c
@@ -798,7 +798,7 @@ void ozone_draw_thumbnail_bar(ozone_handle_t *ozone, video_frame_info_t *video_i
             thumbnail_width,
             thumbnail_height,
             alignment,
-            1.0f, 1.0f);
+            1.0f, 1.0f, NULL);
    }
    else
    {
@@ -826,7 +826,7 @@ void ozone_draw_thumbnail_bar(ozone_handle_t *ozone, video_frame_info_t *video_i
             thumbnail_width,
             thumbnail_height,
             MENU_THUMBNAIL_ALIGN_TOP,
-            1.0f, 1.0f);
+            1.0f, 1.0f, NULL);
    }
    else if (!ozone->selection_core_is_viewer)
    {

--- a/menu/menu_thumbnail.h
+++ b/menu/menu_thumbnail.h
@@ -53,6 +53,15 @@ enum menu_thumbnail_alignment
    MENU_THUMBNAIL_ALIGN_RIGHT
 };
 
+/* Defines all possible thumbnail shadow
+ * effect types */
+enum menu_thumbnail_shadow_type
+{
+   MENU_THUMBNAIL_SHADOW_NONE = 0,
+   MENU_THUMBNAIL_SHADOW_DROP,
+   MENU_THUMBNAIL_SHADOW_OUTLINE
+};
+
 /* Holds all runtime parameters associated with
  * an entry thumbnail */
 typedef struct
@@ -64,6 +73,23 @@ typedef struct
    float alpha;
    float delay_timer;
 } menu_thumbnail_t;
+
+/* Holds all configuration parameters associated
+ * with a thumbnail shadow effect */
+typedef struct
+{
+   enum menu_thumbnail_shadow_type type;
+   float alpha;
+   struct
+   {
+      float x_offset;
+      float y_offset;
+   } drop;
+   struct
+   {
+      unsigned width;
+   } outline;
+} menu_thumbnail_shadow_t;
 
 /* Setters */
 
@@ -109,6 +135,17 @@ void menu_thumbnail_cancel_pending_requests(void);
 void menu_thumbnail_request(
       menu_thumbnail_path_data_t *path_data, enum menu_thumbnail_id thumbnail_id,
       playlist_t *playlist, size_t idx, menu_thumbnail_t *thumbnail);
+
+/* Requests loading of a specific thumbnail image file
+ * (may be used, for example, to load savestate images)
+ * - If operation fails, 'thumbnail->status' will be set to
+ *   MUI_THUMBNAIL_STATUS_MISSING
+ * - If operation is successful, 'thumbnail->status' will be
+ *   set to MUI_THUMBNAIL_STATUS_PENDING
+ * 'thumbnail' will be populated with texture info/metadata
+ * once the image load is complete */
+void menu_thumbnail_request_file(
+      const char *file_path, menu_thumbnail_t *thumbnail);
 
 /* Resets (and free()s the current texture of) the
  * specified thumbnail */
@@ -162,7 +199,9 @@ void menu_thumbnail_get_draw_dimensions(
 
 /* Draws specified thumbnail with specified alignment
  * (and aspect correct scaling) within a rectangle of
- * (width x height)
+ * (width x height).
+ * 'shadow' defines an optional shadow effect (may be
+ * set to NULL if a shadow effect is not required).
  * NOTE: Setting scale_factor > 1.0f will increase the
  *       size of the thumbnail beyond the limits of the
  *       (width x height) rectangle (alignment + aspect
@@ -171,7 +210,8 @@ void menu_thumbnail_draw(
       video_frame_info_t *video_info, menu_thumbnail_t *thumbnail,
       float x, float y, unsigned width, unsigned height,
       enum menu_thumbnail_alignment alignment,
-      float alpha, float scale_factor);
+      float alpha, float scale_factor,
+      menu_thumbnail_shadow_t *shadow);
 
 RETRO_END_DECLS
 


### PR DESCRIPTION
## Description

This 'housekeeping' PR updates XMB to make use of the new `menu_thumbnail.h/.c` code for loading and drawing thumbnails. This finishes the job of standardising thumbnails across all the menu drivers (apart from RGUI, which is a special case). It also sanitises a heap of old legacy code in XMB (the existing thumbnail-related stuff was disgusting).

This is a precursor to adding a fullscreen thumbnail viewer - but an immediate benefit is that XMB thumbnails now have a subtle 'fade in' animation. (There are also a few bug fixes/optimisations included)