### PR TITLE
support for extended PC-Engine memory map

### DIFF
--- a/cheevos-new/fixup.c
+++ b/cheevos-new/fixup.c
@@ -168,9 +168,30 @@ const uint8_t* rcheevos_patch_address(unsigned address, int console)
       }
       else if (console == RC_CONSOLE_PC_ENGINE)
       {
-         /* RAM. */
-         CHEEVOS_LOG(RCHEEVOS_TAG "PCE memory address %X adjusted to %X\n", address, address + 0x1f0000);
-         address += 0x1f0000;
+         if (address < 0x002000)
+         {
+            /* RAM. */
+            CHEEVOS_LOG(RCHEEVOS_TAG "PCE memory address %X adjusted to %X\n", address, address + 0x1f0000);
+            address += 0x1f0000;
+         }
+         else if (address < 0x012000)
+         {
+            /* CD-ROM RAM. */
+            CHEEVOS_LOG(RCHEEVOS_TAG "PCE memory address %X adjusted to %X\n", address, address + 0x100000 - 0x002000);
+            address += 0x100000 - 0x002000;
+         }
+         else if (address < 0x042000)
+         {
+            /* Super System Card RAM. */
+            CHEEVOS_LOG(RCHEEVOS_TAG "PCE memory address %X adjusted to %X\n", address, address + 0x0d0000 - 0x012000);
+            address += 0x0d0000 - 0x012000;
+         }
+         else
+         {
+            /* CD-ROM battery backed RAM. */
+            CHEEVOS_LOG(RCHEEVOS_TAG "PCE memory address %X adjusted to %X\n", address, address + 0x1ee000 - 0x042000);
+            address += 0x1ee000 - 0x042000;
+         }
       }
       else if (console == RC_CONSOLE_SUPER_NINTENDO)
       {


### PR DESCRIPTION
## Description

Updates the memory mapping code to support the new blocks of memory exposed by the mednafen_pce_fast core.

Additionally, disables any achievements trying to use those blocks of memory on cores that don't expose the additional memory.

## Related Issues

https://github.com/libretro/beetle-pce-fast-libretro/issues/133

## Related Pull Requests

https://github.com/libretro/beetle-pce-fast-libretro/pull/134

## Reviewers

[If possible @mention all the people that should review your pull request]
