### PR TITLE
Support DRC even when using a vsync swap interval higher than 1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,7 @@
 - SCANNER/MANUAL: Add option to scan inside archives
 - SCANNER/MANUAL: Enable automatic naming of arcade content via DAT files. This is compatible with DAT files in either Logiqx XML or MAME List XML format.
 - VIDEO: Do not reinit video driver on SET_SYSTEM_AV_INFO unless needed
+- VIDEO: Support DRC even when using a vsync swap interval higher than 1
 - VIDEO LAYOUT: Fixed XML parsing of attributes with spaces, should fix issues with several video layouts
 - VITA: GL1 driver support
 - WINDOWS/XINPUT: Get rid of 128 byte device name limit for XInput device discover - when device name was too long, it would not be picked up by the XInput driver and would instead fallback to DirectInput

--- a/retroarch.c
+++ b/retroarch.c
@@ -18922,7 +18922,8 @@ static void audio_driver_monitor_adjust_system_rates(void)
 {
    float timing_skew;
    settings_t *settings                   = configuration_settings;
-   float video_refresh_rate               = settings->floats.video_refresh_rate;
+   const float target_video_sync_rate     =
+      settings->floats.video_refresh_rate / settings->uints.video_swap_interval;
    float max_timing_skew                  = settings->floats.audio_max_timing_skew;
    struct retro_system_av_info *av_info   = &video_driver_av_info;
    const struct retro_system_timing *info =
@@ -18931,11 +18932,11 @@ static void audio_driver_monitor_adjust_system_rates(void)
    if (info->sample_rate <= 0.0)
       return;
 
-   timing_skew             = fabs(1.0f - info->fps / video_refresh_rate);
+   timing_skew             = fabs(1.0f - info->fps / target_video_sync_rate);
    audio_driver_input      = info->sample_rate;
 
    if (timing_skew <= max_timing_skew && !settings->bools.vrr_runloop_enable)
-      audio_driver_input *= (video_refresh_rate / info->fps);
+      audio_driver_input *= target_video_sync_rate / info->fps;
 
    RARCH_LOG("[Audio]: Set audio input rate to: %.2f Hz.\n",
          audio_driver_input);


### PR DESCRIPTION
Dynamic Rate Control doesn't work when using a vsync swap interval higher than 1. For example when running a 120Hz mode, you'd normally set swap interval to 2 when targeting 60FPS. We fix this by using the target rate, which is the refresh rate divided by the swap interval, rather than the refresh rate for DRC.