### PR TITLE
changes to support upgraded emscripten SDK

### DIFF
--- a/Makefile.emscripten
+++ b/Makefile.emscripten
@@ -17,7 +17,6 @@ HAVE_CC_RESAMPLER = 1
 HAVE_EGL    = 1
 HAVE_OPENGLES = 1
 HAVE_RJPEG  = 0
-HAVE_RPNG   = 1
 HAVE_EMSCRIPTEN = 1
 HAVE_MENU = 1
 HAVE_MENU_WIDGETS = 1
@@ -30,7 +29,7 @@ HAVE_STATIC_VIDEO_FILTERS = 1
 HAVE_STATIC_AUDIO_FILTERS = 1
 HAVE_STB_FONT = 1
 
-MEMORY = 536870912
+MEMORY = 134217728
 
 PRECISE_F32 = 1
 
@@ -38,9 +37,9 @@ OBJDIR := obj-emscripten
 
 #if you compile with SDL2 flag add this Emscripten flag "-s USE_SDL=2" to LDFLAGS:
 
-LIBS    := -s USE_ZLIB=1
-LDFLAGS := -L. --no-heap-copy -s USE_ZLIB=1 -s TOTAL_MEMORY=$(MEMORY) -s NO_EXIT_RUNTIME=0 -s FULL_ES2=1 \
-           -s EXPORTED_FUNCTIONS="['_main', '_malloc', '_cmd_savefiles', '_cmd_save_state', '_cmd_load_state', '_cmd_take_screenshot']" \
+LIBS    := -s USE_ZLIB=1 -s USE_LIBPNG=1
+LDFLAGS := -L. --no-heap-copy -s $(LIBS) -s TOTAL_MEMORY=$(MEMORY) -s NO_EXIT_RUNTIME=0 -s FULL_ES2=1 -s "EXTRA_EXPORTED_RUNTIME_METHODS=['callMain']" \
+           -s ALLOW_MEMORY_GROWTH=1 -s EXPORTED_FUNCTIONS="['_main', '_malloc', '_cmd_savefiles', '_cmd_save_state', '_cmd_load_state', '_cmd_take_screenshot']" \
            --js-library emscripten/library_rwebaudio.js \
            --js-library emscripten/library_rwebcam.js \
            --js-library emscripten/library_errno_codes.js
@@ -70,16 +69,16 @@ ifeq ($(DEBUG), 1)
    LDFLAGS += -O0 -g
    CFLAGS += -O0 -g
 else
-   LDFLAGS += -O2 -s WASM=1
+   LDFLAGS += -O3 -s WASM=1
    # WARNING: some optimizations can break some cores (ex: LTO breaks tyrquake)
    LDFLAGS += -s PRECISE_F32=$(PRECISE_F32)
    ifeq ($(LTO), 1)
       LDFLAGS += --llvm-lto 3
    endif
-   CFLAGS += -O2
+   CFLAGS += -O3
 endif
 
-CFLAGS += -DHAVE_RPNG -Wall -I. -Ilibretro-common/include -std=gnu99 -s USE_ZLIB=1 \
+CFLAGS += -Wall -I. -Ilibretro-common/include -std=gnu99 $(LIBS) \
           -s EXPORTED_FUNCTIONS="['_main', '_malloc', '_cmd_savefiles', '_cmd_save_state', '_cmd_take_screenshot']"
 
 RARCH_OBJ := $(addprefix $(OBJDIR)/,$(OBJ))

--- a/pkg/emscripten/libretro/index.html
+++ b/pkg/emscripten/libretro/index.html
@@ -165,7 +165,7 @@
    <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0-alpha.3/js/bootstrap.min.js"></script>
    <script src="analytics.js"></script>
    <!--script src="//wzrd.in/standalone/browserfs@0.6.1"></script-->
-   <script src="//web.libretro.com/browserfs.min.js"></script>
+   <script src="browserfs.min.js"></script>
    <script src="libretro.js"></script>
    <div align="center">
    <a href="https://www.patreon.com/libretro">


### PR DESCRIPTION
* Compile with `-O3`, actually has a noticeable effect in emscripten.
* Drop the starting memory size and enable `ALLOW_MEMORY_GROWTH`. It used to hurt asm.js build a lot but it has a negligible performance hit when using wasm.
* Use the built-in libpng library instead of rpng. Needed for cores that also use libpng (like mupen64plus-libretro-nx)
* Explicitly export `callMain` runtime method, needed in newer emscripten SDKs.