### PR TITLE
(Ozone) Add fullscreen thumbnail viewer

### DIFF
--- a/menu/drivers/ozone/ozone.h
+++ b/menu/drivers/ozone/ozone.h
@@ -60,6 +60,8 @@ typedef struct ozone_handle ozone_handle_t;
 #define SIDEBAR_ENTRY_ICON_SIZE     46
 #define SIDEBAR_ENTRY_ICON_PADDING  15
 
+#define FULLSCREEN_THUMBNAIL_PADDING 48
+
 #define CURSOR_SIZE 64
 
 #define INTERVAL_OSK_CURSOR            (0.5f * 1000000)
@@ -127,6 +129,8 @@ struct ozone_handle
 
       float sidebar_text_alpha;
       float thumbnail_bar_position;
+
+      float fullscreen_thumbnail_alpha;
    } animations;
 
    bool fade_direction; /* false = left to right, true = right to left */
@@ -213,6 +217,7 @@ struct ozone_handle
       int cursor_size;
 
       int thumbnail_bar_width;
+      int fullscreen_thumbnail_padding;
    } dimensions;
 
    bool show_cursor;
@@ -233,6 +238,11 @@ struct ozone_handle
       menu_thumbnail_t left;
    } thumbnails;
 
+   bool fullscreen_thumbnails_available;
+   bool show_fullscreen_thumbnails;
+   size_t fullscreen_thumbnail_selection;
+   char fullscreen_thumbnail_label[255];
+
    char selection_core_name[255];
    char selection_playtime[255];
    char selection_lastplayed[255];
@@ -241,6 +251,8 @@ struct ozone_handle
    bool selection_core_is_viewer;
 
    bool is_db_manager_list;
+   bool is_file_list;
+   bool is_quick_menu;
    bool first_frame;
 };
 
@@ -307,6 +319,9 @@ void ozone_sidebar_update_collapse(ozone_handle_t *ozone, bool allow_animation);
 void ozone_entries_update_thumbnail_bar(ozone_handle_t *ozone, bool is_playlist, bool allow_animation);
 
 void ozone_draw_thumbnail_bar(ozone_handle_t *ozone, video_frame_info_t *video_info);
+
+void ozone_hide_fullscreen_thumbnails(ozone_handle_t *ozone, bool animate);
+void ozone_show_fullscreen_thumbnails(ozone_handle_t *ozone);
 
 unsigned ozone_count_lines(const char *str);
 

--- a/menu/drivers/ozone/ozone_display.h
+++ b/menu/drivers/ozone/ozone_display.h
@@ -58,3 +58,6 @@ void ozone_draw_osk(ozone_handle_t *ozone,
 void ozone_draw_messagebox(ozone_handle_t *ozone,
       video_frame_info_t *video_info,
       const char *message);
+
+void ozone_draw_fullscreen_thumbnails(
+      ozone_handle_t *ozone, video_frame_info_t *video_info);


### PR DESCRIPTION
## Description

This PR adds a fullscreen thumbnail viewer to Ozone. It is functionally identical to the one in XMB (added in PR #9847):

- When an entry with thumbnails is selected, pressing RetroPad `start`, keyboard `space` or long pressing the entry (via a touchscreen) opens the fullscreen viewer.

- Pressing anything while the viewer is open will close it. Most input is otherwise ignored, but when viewing playlists with the viewer open, RetroPad `A` or keyboard `return` will open the associated quick menu.

The viewer should work everywhere, including database lists, and when browsing images via 'load content'. *However*: Note that the thumbnail sidebar is not displayed when navigating database lists or 'load content' (i.e. you can use the fullscreen viewer, but not see a little thumbnail in the list itself) - I didn't want to mess about with that part of the code, so I'll let @natinusala decide if he wants to make any additions here :)

The viewer looks something like this:

![Screenshot_2019-12-17_11-05-57](https://user-images.githubusercontent.com/38211560/70993198-64cba280-20c3-11ea-904a-0e2a84241f60.png)

![Screenshot_2019-12-17_11-08-49](https://user-images.githubusercontent.com/38211560/70993206-69905680-20c3-11ea-96c8-70186e8fa152.png)

![Screenshot_2019-12-17_11-09-20](https://user-images.githubusercontent.com/38211560/70993211-6c8b4700-20c3-11ea-9173-a6e92500d826.png)

![Screenshot_2019-12-17_11-10-36](https://user-images.githubusercontent.com/38211560/70993216-701ece00-20c3-11ea-990a-53e5a0674888.png)

![Screenshot_2019-12-17_11-13-17](https://user-images.githubusercontent.com/38211560/70993226-7319be80-20c3-11ea-8aea-3dd4dabf3717.png)

![Screenshot_2019-12-17_11-14-02](https://user-images.githubusercontent.com/38211560/70993231-7614af00-20c3-11ea-94b7-634dd728b8db.png)

## Reviewers

@natinusala 
