### PR TITLE
Fix database entry display

### DIFF
--- a/menu/cbs/menu_cbs_deferred_push.c
+++ b/menu/cbs/menu_cbs_deferred_push.c
@@ -719,7 +719,6 @@ static int menu_cbs_init_bind_deferred_push_compare_label(
       {MENU_ENUM_LABEL_CORE_INFORMATION, deferred_push_core_information},
       {MENU_ENUM_LABEL_DISC_INFORMATION, deferred_push_disc_information},
       {MENU_ENUM_LABEL_SYSTEM_INFORMATION, deferred_push_system_information},
-      {MENU_ENUM_LABEL_DEFERRED_RDB_ENTRY_DETAIL, deferred_push_rdb_entry_detail},
       {MENU_ENUM_LABEL_DEFERRED_RPL_ENTRY_ACTIONS, deferred_push_rpl_entry_actions},
       {MENU_ENUM_LABEL_DEFERRED_NETPLAY, deferred_push_netplay_sublist},
       {MENU_ENUM_LABEL_DEFERRED_DRIVER_SETTINGS_LIST, deferred_push_driver_settings_list},
@@ -764,6 +763,15 @@ static int menu_cbs_init_bind_deferred_push_compare_label(
          BIND_ACTION_DEFERRED_PUSH(cbs, info_list[i].cb);
          return 0;
       }
+   }
+
+   /* MENU_ENUM_LABEL_DEFERRED_RDB_ENTRY_DETAIL requires special
+    * treatment, since the label has the format:
+    *   <MENU_ENUM_LABEL_DEFERRED_RDB_ENTRY_DETAIL>|<entry_name>
+    * i.e. cannot use a normal string_is_equal() */
+   if (strstr(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_RDB_ENTRY_DETAIL)))
+   {
+      BIND_ACTION_DEFERRED_PUSH(cbs, deferred_push_rdb_entry_detail);
    }
 
    if (cbs->enum_idx != MSG_UNKNOWN)

--- a/menu/cbs/menu_cbs_title.c
+++ b/menu/cbs/menu_cbs_title.c
@@ -1434,7 +1434,6 @@ int menu_cbs_init_bind_title(menu_file_list_cbs_t *cbs,
       {MENU_ENUM_LABEL_DEFERRED_RPL_ENTRY_ACTIONS, action_get_quick_menu_views_settings_list},
       {MENU_ENUM_LABEL_DEFERRED_PLAYLIST_LIST, action_get_title_deferred_playlist_list},
       {MENU_ENUM_LABEL_DEFERRED_PLAYLIST_MANAGER_SETTINGS, action_get_title_deferred_playlist_list},
-      {MENU_ENUM_LABEL_DEFERRED_RDB_ENTRY_DETAIL, action_get_title_list_rdb_entry_database_info},
       {MENU_ENUM_LABEL_PLAYLISTS_TAB, action_get_title_collection},
       {MENU_ENUM_LABEL_DEFERRED_MANUAL_CONTENT_SCAN_LIST, action_get_title_manual_content_scan_list},
    };
@@ -1458,6 +1457,16 @@ int menu_cbs_init_bind_title(menu_file_list_cbs_t *cbs,
          BIND_ACTION_GET_TITLE(cbs, info_list[i].cb);
          return 0;
       }
+   }
+
+   /* MENU_ENUM_LABEL_DEFERRED_RDB_ENTRY_DETAIL requires special
+    * treatment, since the label has the format:
+    *   <MENU_ENUM_LABEL_DEFERRED_RDB_ENTRY_DETAIL>|<entry_name>
+    * i.e. cannot use a normal string_is_equal() */
+   if (strstr(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_RDB_ENTRY_DETAIL)))
+   {
+      BIND_ACTION_GET_TITLE(cbs, action_get_title_list_rdb_entry_database_info);
+      return 0;
    }
 
    return -1;


### PR DESCRIPTION
## Description

Commits https://github.com/libretro/RetroArch/commit/cfc2a15d415ecfba48828068d48de053c51cd86a and https://github.com/libretro/RetroArch/commit/c9a97d255cd1c6ce15f49e98b8cba3a82854e075 broke the display of database entries.

This PR fixes the issue.

## Related Issues

This closes #9862
