### PR TITLE
FFMPEG core frame based color conversion

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1965,7 +1965,9 @@ endif
 
 ifeq ($(HAVE_FFMPEG), 1)
    OBJ += record/drivers/record_ffmpeg.o \
-          cores/libretro-ffmpeg/ffmpeg_core.o
+          cores/libretro-ffmpeg/ffmpeg_core.o \
+          cores/libretro-ffmpeg/swsbuffer.o \
+          cores/libretro-ffmpeg/tpool.o
 
    LIBS += $(AVCODEC_LIBS) $(AVFORMAT_LIBS) $(AVUTIL_LIBS) $(SWSCALE_LIBS) $(SWRESAMPLE_LIBS) $(FFMPEG_LIBS)
    DEFINES += -DHAVE_FFMPEG

--- a/cores/libretro-ffmpeg/Makefile.common
+++ b/cores/libretro-ffmpeg/Makefile.common
@@ -19,6 +19,8 @@ SWRESAMPLE_DIR 	 := $(BASE_DIR)/libswresample
 INCFLAGS           += -I$(BASE_DIR) -I$(CORE_DIR) -I$(LIBRETRO_COMM_DIR)/include -I$(LIBRETRO_COMM_DIR)/include/compat
 
 LIBRETRO_SOURCE    += $(CORE_DIR)/ffmpeg_core.c \
+							 $(CORE_DIR)/swsbuffer.c \
+							 $(CORE_DIR)/tpool.c \
 							 $(LIBRETRO_COMM_DIR)/queues/fifo_queue.c \
 							 $(LIBRETRO_COMM_DIR)/rthreads/rthreads.c
 

--- a/cores/libretro-ffmpeg/swsbuffer.c
+++ b/cores/libretro-ffmpeg/swsbuffer.c
@@ -1,0 +1,185 @@
+#include <libavformat/avformat.h>
+
+#include <rthreads/rthreads.h>
+
+#include "swsbuffer.h"
+
+enum kbStatus
+{
+  KB_OPEN,
+  KB_IN_PROGRESS,
+  KB_FINISHED
+};
+
+struct swsbuffer
+{
+   sws_context_t *buffer;
+   enum kbStatus *status;
+   size_t size;
+   slock_t *lock;
+   int64_t head;
+   int64_t tail;
+};
+
+swsbuffer_t *swsbuffer_create(size_t num, int frame_size, int width, int height)
+{
+   swsbuffer_t *b = malloc(sizeof (swsbuffer_t));
+   if (b == NULL)
+      return NULL;
+
+   b->status = malloc(sizeof(enum kbStatus) * num);
+   if (b->status == NULL)
+      return NULL;
+   for (int i = 0; i < num; i++)
+      b->status[i] = KB_OPEN;
+
+   b->lock = slock_new();
+   if (b->lock == NULL)
+      return NULL;
+
+   b->buffer = malloc(sizeof(sws_context_t) * num);
+   if (b->buffer == NULL)
+      return NULL;
+   for (int i = 0; i < num; i++)
+   {
+      b->buffer[i].index = i;
+      b->buffer[i].sws = sws_alloc_context();
+      b->buffer[i].source = av_frame_alloc();
+#if LIBAVUTIL_VERSION_MAJOR > 55
+      b->buffer[i].hw_source = av_frame_alloc();
+#endif
+      b->buffer[i].target = av_frame_alloc();
+      b->buffer[i].frame_buf = av_malloc(frame_size);
+
+      avpicture_fill((AVPicture*)b->buffer[i].target, (const uint8_t*)b->buffer[i].frame_buf,
+            PIX_FMT_RGB32, width, height);
+   }
+
+   b->size = num;
+   b->head = 0;
+   b->tail = 0;
+   return b;
+}
+
+void swsbuffer_destroy(swsbuffer_t *swsbuffer)
+{
+   if (swsbuffer != NULL) {
+      slock_free(swsbuffer->lock);
+      free(swsbuffer->status);
+      for (int i = 0; i < swsbuffer->size; i++)
+      {
+#if LIBAVUTIL_VERSION_MAJOR > 55
+         av_frame_free(&swsbuffer->buffer[i].hw_source);
+#endif
+         av_frame_free(&swsbuffer->buffer[i].source);
+         av_frame_free(&swsbuffer->buffer[i].target);
+         av_freep(&swsbuffer->buffer[i].frame_buf);
+         sws_freeContext(swsbuffer->buffer[i].sws);
+      }
+      free(swsbuffer->buffer);
+      free(swsbuffer);
+   }
+}
+
+void swsbuffer_clear(swsbuffer_t *swsbuffer)
+{
+   slock_lock(swsbuffer->lock);
+
+   swsbuffer->head = 0;
+   swsbuffer->tail = 0;
+   for (int i = 0; i < swsbuffer->size; i++)
+      swsbuffer->status[i] = KB_OPEN;
+
+   slock_unlock(swsbuffer->lock);
+}
+
+void swsbuffer_get_open_slot(swsbuffer_t *swsbuffer, sws_context_t **context)
+{
+   slock_lock(swsbuffer->lock);
+
+   if (swsbuffer->status[swsbuffer->head] == KB_OPEN)
+   {
+      *context = &swsbuffer->buffer[swsbuffer->head];
+      swsbuffer->status[swsbuffer->head] = KB_IN_PROGRESS;
+      swsbuffer->head++;
+      swsbuffer->head %= swsbuffer->size;
+   }
+
+   slock_unlock(swsbuffer->lock);
+}
+
+void swsbuffer_return_open_slot(swsbuffer_t *swsbuffer, sws_context_t *context)
+{
+   slock_lock(swsbuffer->lock);
+
+   if (swsbuffer->status[context->index] == KB_IN_PROGRESS)
+   {
+      swsbuffer->status[context->index] = KB_OPEN;
+      swsbuffer->head--;
+      swsbuffer->head %= swsbuffer->size;
+   }
+
+   slock_unlock(swsbuffer->lock);
+}
+
+void swsbuffer_open_slot(swsbuffer_t *swsbuffer, sws_context_t *context)
+{
+   slock_lock(swsbuffer->lock);
+
+   if (swsbuffer->status[context->index] == KB_FINISHED)
+   {
+      swsbuffer->status[context->index] = KB_OPEN;
+      swsbuffer->tail++;
+      swsbuffer->tail %= (swsbuffer->size);
+   }
+
+   slock_unlock(swsbuffer->lock);
+}
+
+void swsbuffer_get_finished_slot(swsbuffer_t *swsbuffer, sws_context_t **context)
+{
+   slock_lock(swsbuffer->lock);
+
+   if (swsbuffer->status[swsbuffer->tail] == KB_FINISHED)
+      *context = &swsbuffer->buffer[swsbuffer->tail];
+
+   slock_unlock(swsbuffer->lock);
+}
+
+void swsbuffer_finish_slot(swsbuffer_t *swsbuffer, sws_context_t *context)
+{
+   slock_lock(swsbuffer->lock);
+
+   if (swsbuffer->status[context->index] == KB_IN_PROGRESS)
+      swsbuffer->status[context->index] = KB_FINISHED;
+
+   slock_unlock(swsbuffer->lock);
+}
+
+bool swsbuffer_has_open_slot(swsbuffer_t *swsbuffer)
+{
+   bool ret = false;
+
+   slock_lock(swsbuffer->lock);
+
+   if (swsbuffer->status[swsbuffer->head] == KB_OPEN)
+      ret = true;
+
+   slock_unlock(swsbuffer->lock);
+
+   return ret;
+}
+
+bool swsbuffer_has_finished_slot(swsbuffer_t *swsbuffer)
+{
+   bool ret = false;
+
+   slock_lock(swsbuffer->lock);
+
+   if (swsbuffer->status[swsbuffer->tail] == KB_FINISHED)
+      ret = true;
+
+   slock_unlock(swsbuffer->lock);
+
+   return ret;
+}

--- a/cores/libretro-ffmpeg/swsbuffer.h
+++ b/cores/libretro-ffmpeg/swsbuffer.h
@@ -1,0 +1,166 @@
+#ifndef __LIBRETRO_SDK_SWSBUFFER_H__
+#define __LIBRETRO_SDK_SWSBUFFER_H__
+
+#include <retro_common_api.h>
+
+#include <boolean.h>
+
+#include <libavutil/frame.h>
+#include <libswscale/swscale.h>
+
+#include <retro_inline.h>
+#include <retro_miscellaneous.h>
+
+RETRO_BEGIN_DECLS
+
+#ifndef PIX_FMT_RGB32
+#define PIX_FMT_RGB32 AV_PIX_FMT_RGB32
+#endif
+
+/**
+ * sws_context
+ * 
+ * Context object for the sws worker threads.
+ * 
+ */
+struct sws_context
+{
+   int index;
+   struct SwsContext *sws;
+   AVFrame *source;
+#if LIBAVUTIL_VERSION_MAJOR > 55
+   AVFrame *hw_source;
+#endif
+   AVFrame *target;
+   void *frame_buf;
+};
+typedef struct sws_context sws_context_t;
+
+/**
+ * swsbuffer
+ * 
+ * The swsbuffer is a ring buffer, that can be used as a 
+ * buffer for many workers while keeping the order.
+ * 
+ * It is thread safe in a sensem that it is designed to work
+ * with one work coordinator, that allocates work slots for
+ * workers threads to work on and later collect the work
+ * product in the same order, as the slots were allocated.
+ * 
+ */
+struct swsbuffer;
+typedef struct swsbuffer swsbuffer_t;
+
+/**
+ * swsbuffer_create:
+ * @num           : Size of the buffer.
+ * @frame_size    : Size of the target frame.
+ * @width         : Width of the target frame.
+ * @height        : Height of the target frame.
+ *
+ * Create a swsbuffer.
+ * 
+ * Returns: swsbuffer.
+ */
+swsbuffer_t *swsbuffer_create(size_t num, int frame_size, int width, int height);
+
+/** 
+ * swsbuffer_destroy:
+ * @swsbuffer      : sswsbuffer.
+ * 
+ * Destory a swsbuffer.
+ * 
+ * Does also free the buffer allocated with swsbuffer_create().
+ * User has to shut down any external worker threads that may have
+ * a reference to this swsbuffer.
+ * 
+ **/
+void swsbuffer_destroy(swsbuffer_t *swsbuffer);
+
+/** 
+ * swsbuffer_clear:
+ * @swsbuffer      : sswsbuffer.
+ * 
+ * Clears a swsbuffer.
+ * 
+ **/
+void swsbuffer_clear(swsbuffer_t *swsbuffer);
+
+/** 
+ * swsbuffer_get_open_slot:
+ * @swsbuffer     : sswsbuffer.
+ * @contex        : sws context.
+ * 
+ * Returns the next open context inside the ring buffer
+ * and it's index. The status of the slot will be marked as
+ * 'in progress' until slot is marked as finished with
+ * swsbuffer_finish_slot();
+ *
+ **/
+void swsbuffer_get_open_slot(swsbuffer_t *swsbuffer, sws_context_t **context);
+
+/** 
+ * swsbuffer_return_open_slot:
+ * @swsbuffer     : sswsbuffer.
+ * @contex        : sws context.
+ * 
+ * Marks the given sws context that is "in progress" as "open" again.
+ *
+ **/
+void swsbuffer_return_open_slot(swsbuffer_t *swsbuffer, sws_context_t *context);
+
+/** 
+ * swsbuffer_open_slot:
+ * @swsbuffer     : sswsbuffer.
+ * @context       : sws context.
+ * 
+ * Sets the status of the given context from "finished" to "open".
+ * The slot is then available for producers to claim again with swsbuffer_get_open_slot().
+ **/
+void swsbuffer_open_slot(swsbuffer_t *swsbuffer, sws_context_t *context);
+
+/**
+ * swsbuffer_get_finished_slot:
+ * @swsbuffer     : sswsbuffer.
+ * @context       : sws context.
+ * 
+ * Returns a reference for the next context inside
+ * the ring buffer. User needs to use swsbuffer_open_slot()
+ * to open the slot in the ringbuffer for the next
+ * work assignment. User is free to re-allocate or
+ * re-use the context.
+ *
+ */
+void swsbuffer_get_finished_slot(swsbuffer_t *swsbuffer, sws_context_t **context);
+
+/**
+ * swsbuffer_finish_slot:
+ * @swsbuffer     : sswsbuffer.
+ * @context       : sws context.
+ * 
+ * Sets the status of the given context from "in progress" to "finished".
+ * This is normally done by a producer. User can then retrieve the finished work
+ * context by calling swsbuffer_get_finished_slot().
+ */
+void swsbuffer_finish_slot(swsbuffer_t *swsbuffer, sws_context_t *context);
+
+/**
+ * swsbuffer_has_open_slot:
+ * @swsbuffer      : sswsbuffer.
+ * 
+ * Returns true if the buffer has a open slot available.
+ */
+bool swsbuffer_has_open_slot(swsbuffer_t *swsbuffer);
+
+/**
+ * swsbuffer_has_finished_slot:
+ * @swsbuffer      : sswsbuffer.
+ * 
+ * Returns true if the buffers next slot is finished and a
+ * context available.
+ */
+bool swsbuffer_has_finished_slot(swsbuffer_t *swsbuffer);
+
+RETRO_END_DECLS
+
+#endif

--- a/cores/libretro-ffmpeg/tpool.c
+++ b/cores/libretro-ffmpeg/tpool.c
@@ -1,0 +1,264 @@
+/* The MIT License
+ * 
+ * Copyright (c) 2010-2019 The RetroArch team
+ * Copyright (c) 2017 John Schember <john@nachtimwald.com>
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE
+ */
+
+#include <stdlib.h>
+#include <rthreads/rthreads.h>
+
+#include "tpool.h"
+
+/* Work object which will sit in a queue
+ * waiting for the pool to process it.
+ *
+ * It is a singly linked list acting as a FIFO queue. */
+struct tpool_work {
+   thread_func_t      func;  /* Function to be called. */
+   void              *arg;   /* Data to be passed to func. */
+   struct tpool_work *next;  /* Next work item in the queue. */
+};
+typedef struct tpool_work tpool_work_t;
+
+struct tpool {
+   tpool_work_t    *work_first;   /* First work item in the work queue. */
+   tpool_work_t    *work_last;    /* Last work item in the work queue. */
+   slock_t         *work_mutex;   /* Mutex protecting inserting and removing work from the work queue. */
+   scond_t         *work_cond;    /* Conditional to signal when there is work to process. */
+   scond_t         *working_cond; /* Conditional to signal when there is no work processing.
+                                       This will also signal when there are no threads running. */
+   size_t           working_cnt;  /* The number of threads processing work (Not waiting for work). */
+   size_t           thread_cnt;   /* Total number of threads within the pool. */
+   bool             stop;         /* Marker to tell the work threads to exit. */
+};
+
+static tpool_work_t *tpool_work_create(thread_func_t func, void *arg)
+{
+   tpool_work_t *work;
+
+   if (func == NULL)
+      return NULL;
+
+   work = calloc(1, sizeof(*work));
+   work->func = func;
+   work->arg = arg;
+   work->next = NULL;
+   return work;
+}
+
+static void tpool_work_destroy(tpool_work_t *work)
+{
+   if (work == NULL)
+      return;
+   free(work);
+}
+
+/* Pull the first work item out of the queue. */
+static tpool_work_t *tpool_work_get(tpool_t *tp)
+{
+   tpool_work_t *work;
+
+   if (tp == NULL)
+      return NULL;
+
+   work = tp->work_first;
+   if (work == NULL)
+      return NULL;
+
+   if (work->next == NULL)
+   {
+      tp->work_first = NULL;
+      tp->work_last  = NULL;
+   } else {
+      tp->work_first = work->next;
+   }
+
+   return work;
+}
+
+static void tpool_worker(void *arg)
+{
+   tpool_t      *tp = arg;
+   tpool_work_t *work;
+
+   while (true)
+   {
+      slock_lock(tp->work_mutex);
+      /* Keep running until told to stop. */
+      if (tp->stop)
+         break;
+
+      /* If there is no work in the queue wait in the conditional until
+       * there is work to take. */
+      if (tp->work_first == NULL)
+         scond_wait(tp->work_cond, tp->work_mutex);
+
+      /* Try to pull work from the queue. */
+      work = tpool_work_get(tp);
+      tp->working_cnt++;
+      slock_unlock(tp->work_mutex);
+
+      /* Call the work function and let it process.
+       *
+       * work can legitimately be NULL. Since multiple threads from the pool
+       * will wake when there is work, a thread might not get any work. 1
+       * piece of work and 2 threads, both will wake but with 1 only work 1
+       * will get the work and the other won't.
+       *
+       * working_cnt has been increment and work could be NULL. While it's
+       * not true there is work processing the thread is considered working
+       * because it's not waiting in the conditional. Pedantic but...
+       */
+      if (work != NULL)
+      {
+         work->func(work->arg);
+         tpool_work_destroy(work);
+      }
+
+      slock_lock(tp->work_mutex);
+      tp->working_cnt--;
+      /* Since we're in a lock no work can be added or removed form the queue.
+       * Also, the working_cnt can't be changed (except the thread holding the lock).
+       * At this point if there isn't any work processing and if there is no work
+       * signal this is the case. */
+      if (!tp->stop && tp->working_cnt == 0 && tp->work_first == NULL)
+         scond_signal(tp->working_cond);
+      slock_unlock(tp->work_mutex);
+   }
+
+   tp->thread_cnt--;
+   if (tp->thread_cnt == 0)
+      scond_signal(tp->working_cond);
+   slock_unlock(tp->work_mutex);
+}
+
+tpool_t *tpool_create(size_t num)
+{
+   tpool_t   *tp;
+   sthread_t *thread;
+   size_t     i;
+
+   if (num == 0)
+      num = 2;
+
+   tp = calloc(1, sizeof(*tp));
+   tp->thread_cnt = num;
+
+   tp->work_mutex = slock_new();
+   tp->work_cond = scond_new();
+   tp->working_cond = scond_new();
+
+   tp->work_first = NULL;
+   tp->work_last  = NULL;
+
+   /* Create the requested number of thread and detach them. */
+   for (i = 0; i < num; i++)
+   {
+      thread = sthread_create(tpool_worker, tp);
+      sthread_detach(thread);
+   }
+
+   return tp;
+}
+
+void tpool_destroy(tpool_t *tp)
+{
+   tpool_work_t *work;
+   tpool_work_t *work2;
+
+   if (tp == NULL)
+      return;
+
+   /* Take all work out of the queue and destroy it. */
+   slock_lock(tp->work_mutex);
+   work = tp->work_first;
+   while (work != NULL)
+   {
+      work2 = work->next;
+      tpool_work_destroy(work);
+      work = work2;
+   }
+   /* Tell the worker threads to stop. */
+   tp->stop = true;
+   scond_broadcast(tp->work_cond);
+   slock_unlock(tp->work_mutex);
+
+   /* Wait for all threads to stop. */
+   tpool_wait(tp);
+
+   slock_free(tp->work_mutex);
+   scond_free(tp->work_cond);
+   scond_free(tp->working_cond);
+
+   free(tp);
+}
+
+bool tpool_add_work(tpool_t *tp, thread_func_t func, void *arg)
+{
+   tpool_work_t *work;
+
+   if (tp == NULL)
+      return false;
+
+   work = tpool_work_create(func, arg);
+   if (work == NULL)
+      return false;
+
+   slock_lock(tp->work_mutex);
+   if (tp->work_first == NULL)
+   {
+      tp->work_first = work;
+      tp->work_last  = tp->work_first;
+   }
+   else
+   {
+      tp->work_last->next = work;
+      tp->work_last       = work;
+   }
+
+   scond_broadcast(tp->work_cond);
+   slock_unlock(tp->work_mutex);
+
+   return true;
+}
+
+void tpool_wait(tpool_t *tp)
+{
+   if (tp == NULL)
+      return;
+
+   slock_lock(tp->work_mutex);
+   while (true)
+   {
+      /* working_cond is dual use. It signals when we're not stopping but the
+      * working_cnt is 0 indicating there isn't any work processing. If we
+      * are stopping it will trigger when there aren't any threads running. */
+      if ((!tp->stop && tp->working_cnt != 0) || (tp->stop && tp->thread_cnt != 0))
+      {
+         scond_wait(tp->working_cond, tp->work_mutex);
+      }
+      else
+      {
+         break;
+      }
+   }
+   slock_unlock(tp->work_mutex);
+}

--- a/cores/libretro-ffmpeg/tpool.h
+++ b/cores/libretro-ffmpeg/tpool.h
@@ -1,0 +1,93 @@
+/* The MIT License
+ * 
+ * Copyright (c) 2010-2019 The RetroArch team
+ * Copyright (c) 2017 John Schember <john@nachtimwald.com>
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE
+ */
+
+#ifndef __LIBRETRO_SDK_TPOOL_H__
+#define __LIBRETRO_SDK_TPOOL_H__
+
+#include <retro_common_api.h>
+
+#include <boolean.h>
+
+#include <retro_inline.h>
+#include <retro_miscellaneous.h>
+
+RETRO_BEGIN_DECLS
+
+struct tpool;
+typedef struct tpool tpool_t;
+
+/** 
+ * (*thread_func_t):
+ * @arg           : Argument.
+ * 
+ * Callback function that the pool will call to do work.
+ **/
+typedef void (*thread_func_t)(void *arg);
+
+/**
+ * tpool_create:
+ * @num           : Number of threads the pool should have.
+ *                  If 0 defaults to 2.
+ *
+ * Create a thread pool.
+ * 
+ * Returns: pool.
+ */
+tpool_t *tpool_create(size_t num);
+
+/** 
+ * tpool_destroy:
+ * @tp            : Thread pool.
+ * 
+ * Destory a thread pool
+ * The pool can be destroyed while there is outstanding work to process. All
+ * outstanding unprocessed work will be discareded. There may be a delay before
+ * this function returns because it will block for work that is processing to
+ * complete.
+ **/
+void tpool_destroy(tpool_t *tp);
+
+/** 
+ * tpool_add_work:
+ * @tp         : Thread pool.
+ * @func       : Function the pool should call.
+ * @arg        : Argument to pass to func.
+ * 
+ * Add work to a thread pool.
+ *
+ * Returns: true if work was added, otherwise false.
+ **/
+bool tpool_add_work(tpool_t *tp, thread_func_t func, void *arg);
+
+/**
+ * tpool_wait:
+ * @tp Thread pool.
+ * 
+ * Wait for all work in the pool to be completed.
+ */
+void tpool_wait(tpool_t *tp);
+
+RETRO_END_DECLS
+
+#endif

--- a/libretro-common/rthreads/rthreads.c
+++ b/libretro-common/rthreads/rthreads.c
@@ -268,7 +268,9 @@ int sthread_detach(sthread_t *thread)
    free(thread);
    return 0;
 #else
-   return pthread_detach(thread->id);
+   int ret = pthread_detach(thread->id);
+   free(thread);
+   return ret;
 #endif
 }
 


### PR DESCRIPTION
## Description

Using an ordered ring buffer and a thread pool, the color space
conversion is now multi-threaded based on frames. I tried
to implement slice based threading, but libswscale did produced
corrupted pictures without obvious reason.

This approach introduces some more "lag" when decoding,
but shouldn't be affect the user negatively, since movie
watching is not lag sensitive, as long as the A/V is synchronized.

This PR will also change the default encoder to the software decoder
for now, since it's the most robust decoder and should produce
the best results for most users right now (Embedded systems
aren't particuarly well supported yet by the ffmpeg hw decodign backend).