### PR TITLE
Fix heap-use-after-free found when using asan

### DIFF
--- a/libretro-common/formats/libchdr/libchdr_lzma.c
+++ b/libretro-common/formats/libchdr/libchdr_lzma.c
@@ -238,8 +238,8 @@ void lzma_codec_free(void* codec)
 	lzma_allocator* alloc = &lzma_codec->allocator;
 
 	/* free memory */
-	lzma_allocator_free(alloc);
 	LzmaDec_Free(&lzma_codec->decoder, (ISzAlloc*)&lzma_codec->allocator);
+	lzma_allocator_free(alloc);
 }
 
 /*-------------------------------------------------


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

Fix heap-use-after-free found when retroarch + compatible core is compiled with -fsanitize and loading CHD images with cheevos enabled.

## Related Issues

https://github.com/libretro/RetroArch/issues/9871

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
@twinaphex @Jamiras  
