### PR TITLE
(cheevos) fix hashing of raw bin file for Sega CD

### DIFF
--- a/cheevos-new/cheevos.c
+++ b/cheevos-new/cheevos.c
@@ -1910,11 +1910,27 @@ found:
    CORO_SUB(RCHEEVOS_SEGACD_MD5)
    {
       /* ignore bin files less than 16MB - they're probably a ROM, not a CD */
-      if (coro->ext_hash == 0x0b8861beU && coro->len < CHEEVOS_MB(16))
+      if (coro->ext_hash == 0x0b8861beU)
       {
-         CHEEVOS_LOG(RCHEEVOS_TAG "ignoring small BIN file - assuming not CD\n", coro->gameid);
-         coro->gameid = 0;
-         CORO_RET();
+         to_read = coro->len;
+         if (to_read == 0)
+         {
+            coro->stream = intfstream_open_file(coro->path,
+               RETRO_VFS_FILE_ACCESS_READ, RETRO_VFS_FILE_ACCESS_HINT_NONE);
+            if (coro->stream)
+            {
+               to_read = intfstream_get_size(coro->stream);
+               intfstream_close(coro->stream);
+               CHEEVOS_FREE(coro->stream);
+            }
+         }
+
+         if (to_read < CHEEVOS_MB(16))
+         {
+            CHEEVOS_LOG(RCHEEVOS_TAG "ignoring small BIN file - assuming not CD\n", coro->gameid);
+            coro->gameid = 0;
+            CORO_RET();
+         }
       }
 
       /* find the data track - it should be the first one */


### PR DESCRIPTION
## Description

Fixes a bug introduced by #9785 regarding

> the entire file (up to the first 64MB) is no longer pre-loaded.

A non-buffered `.bin` file was assumed to not be a CD, as its size had not yet been determined and 0 < 16MB. As such, loading a `.bin` without the associated `.cue` (supported by genesis_plus_gx) was generating the wrong hash.

## Related Issues

n/a

## Related Pull Requests

#9785

## Reviewers

@meleu
