### PR TITLE
proper calculation of offset to track 2 when sector sizes vary

### DIFF
--- a/libretro-common/include/formats/cdfs.h
+++ b/libretro-common/include/formats/cdfs.h
@@ -36,7 +36,7 @@ typedef struct cdfs_track_t
    intfstream_t* stream;
    unsigned int stream_sector_size;
    unsigned int stream_sector_header_size;
-   unsigned int pregap_sectors;
+   unsigned int first_sector_offset;
 } cdfs_track_t;
 
 typedef struct cdfs_file_t

--- a/libretro-common/include/streams/chd_stream.h
+++ b/libretro-common/include/streams/chd_stream.h
@@ -57,7 +57,9 @@ int64_t chdstream_seek(chdstream_t *stream, int64_t offset, int whence);
 
 ssize_t chdstream_get_size(chdstream_t *stream);
 
-uint32_t chdstream_get_pregap(chdstream_t* stream);
+uint32_t chdstream_get_track_start(chdstream_t* stream);
+
+uint32_t chdstream_get_frame_size(chdstream_t* stream);
 
 RETRO_END_DECLS
 

--- a/libretro-common/include/streams/interface_stream.h
+++ b/libretro-common/include/streams/interface_stream.h
@@ -96,7 +96,9 @@ int64_t intfstream_get_size(intfstream_internal_t *intf);
 
 int intfstream_flush(intfstream_internal_t *intf);
 
-uint32_t intfstream_get_chd_pregap(intfstream_internal_t *intf);
+uint32_t intfstream_get_offset_to_start(intfstream_internal_t *intf);
+
+uint32_t intfstream_get_frame_size(intfstream_internal_t *intf);
 
 intfstream_t* intfstream_open_file(const char *path,
       unsigned mode, unsigned hints);

--- a/libretro-common/streams/chd_stream.c
+++ b/libretro-common/streams/chd_stream.c
@@ -254,9 +254,8 @@ chdstream_t *chdstream_open(const char *path, int32_t track)
    stream->chd             = chd;
    stream->frames_per_hunk = hd->hunkbytes / hd->unitbytes;
    stream->track_frame     = meta.frame_offset;
-   stream->track_start     = (size_t) pregap * stream->frame_size;
-   stream->track_end       = stream->track_start +
-      (size_t) meta.frames * stream->frame_size;
+   stream->track_start     = (size_t)pregap * stream->frame_size;
+   stream->track_end       = stream->track_start + (size_t)meta.frames * stream->frame_size;
    stream->offset          = 0;
    stream->hunknum         = -1;
 
@@ -426,10 +425,10 @@ int64_t chdstream_seek(chdstream_t *stream, int64_t offset, int whence)
 
 ssize_t chdstream_get_size(chdstream_t *stream)
 {
-   return stream->track_end;
+   return stream->track_end - stream->track_start;
 }
 
-uint32_t chdstream_get_pregap(chdstream_t *stream)
+uint32_t chdstream_get_track_start(chdstream_t *stream)
 {
    metadata_t meta;
    uint32_t frame_offset = 0;
@@ -438,10 +437,15 @@ uint32_t chdstream_get_pregap(chdstream_t *stream)
    for (i = 0; chdstream_get_meta(stream->chd, i, &meta); ++i)
    {
       if (stream->track_frame == frame_offset)
-         return meta.pregap;
+         return meta.pregap * stream->frame_size;
 
       frame_offset += meta.frames + meta.extra;
    }
 
    return 0;
+}
+
+uint32_t chdstream_get_frame_size(chdstream_t *stream)
+{
+   return stream->frame_size;
 }

--- a/libretro-common/streams/interface_stream.c
+++ b/libretro-common/streams/interface_stream.c
@@ -421,12 +421,28 @@ void intfstream_putc(intfstream_internal_t *intf, int c)
    }
 }
 
-uint32_t intfstream_get_chd_pregap(intfstream_internal_t *intf)
+uint32_t intfstream_get_offset_to_start(intfstream_internal_t *intf)
 {
+   if (intf)
+   {
 #ifdef HAVE_CHD
-   if (intf->type == INTFSTREAM_CHD)
-      return chdstream_get_pregap(intf->chd.fp);
+      if (intf->type == INTFSTREAM_CHD)
+         return chdstream_get_track_start(intf->chd.fp);
 #endif
+   }
+
+   return 0;
+}
+
+uint32_t intfstream_get_frame_size(intfstream_internal_t *intf)
+{
+   if (intf)
+   {
+#ifdef HAVE_CHD
+      if (intf->type == INTFSTREAM_CHD)
+         return chdstream_get_frame_size(intf->chd.fp);
+#endif
+   }
 
    return 0;
 }


### PR DESCRIPTION
## Description

Extension of #9638. For bin/cue pairs where a single bin is used for multiple tracks with different sector sizes, the offset to the secondary tracks was not being calculated correctly. For example:
```
FILE "game.bin" BINARY
  TRACK 01 AUDIO
    INDEX 01 00:00:00
  TRACK 02 MODE1/2048
    PREGAP 00:03:00
    INDEX 01 00:44:65
```
In this case, the AUDIO track has 2352 byte sectors, but the data track has 2048 byte sectors. Attempting to locate the track by only using 2048 * (44:65) results in the incorrect location.

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

[If possible @mention all the people that should review your pull request]
