### PR TITLE
make build all/uninstall scripts work with TARGET renaming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ endif
 
 SYMBOL_MAP := -Wl,-Map=output.map
 
-retroarch: $(RARCH_OBJ)
+$(TARGET): $(RARCH_OBJ)
 	@$(if $(Q), $(shell echo echo LD $@),)
 	$(Q)$(LINK) -o $@ $(RARCH_OBJ) $(LIBS) $(LDFLAGS) $(LIBRARY_DIRS)
 
@@ -280,7 +280,7 @@ install: $(TARGET)
 	fi
 
 uninstall:
-	rm -f $(DESTDIR)$(BIN_DIR)/retroarch
+	rm -f $(DESTDIR)$(BIN_DIR)/$(TARGET)
 	rm -f $(DESTDIR)$(BIN_DIR)/retroarch-cg2glsl
 	rm -f $(DESTDIR)$(GLOBAL_CONFIG_DIR)/retroarch.cfg
 	rm -f $(DESTDIR)$(DATA_DIR)/applications/retroarch.desktop


### PR DESCRIPTION
## Description

It looks like the install script was already updated to use TARGET instead of being hardcoded to 'retroarch', but 'build all' and 'uninstall' would both choke if the name changed. This allows them to use the changed name, which is useful for packaging.

## Related Issues

none that I know of

## Related Pull Requests

none that I know of

## Reviewers

[If possible @mention all the people that should review your pull request]
