### PR TITLE
fix breaking changes from the 3.0.0 libnx release

### DIFF
--- a/audio/drivers/switch_audio_compat.h
+++ b/audio/drivers/switch_audio_compat.h
@@ -17,7 +17,7 @@ typedef Thread compat_thread;
 typedef CondVar compat_condvar;
 
 #define compat_thread_create(thread, func, data, stack_size, prio, cpu) \
-   threadCreate(thread, func, data, stack_size, prio, cpu)
+   threadCreate(thread, func, data, NULL, stack_size, prio, cpu)
 #define compat_thread_start(thread) \
    threadStart(thread)
 #define compat_thread_join(thread) \

--- a/audio/drivers/switch_libnx_audren_thread_audio.c
+++ b/audio/drivers/switch_libnx_audren_thread_audio.c
@@ -232,7 +232,7 @@ static void *libnx_audren_thread_audio_init(const char *device, unsigned rate, u
 
    svcGetThreadPriority(&thread_priority, CUR_THREAD_HANDLE);
    rc = threadCreate(&aud->thread, &thread_job,
-         (void*)aud, thread_stack_size,
+         (void*)aud, NULL, thread_stack_size,
          thread_priority - 1, thread_preferred_cpu);
    if (R_FAILED(rc))
    {

--- a/frontend/drivers/platform_switch.c
+++ b/frontend/drivers/platform_switch.c
@@ -691,7 +691,7 @@ static void frontend_switch_init(void *data)
    uint32_t width                = 0;
    uint32_t height               = 0;
 
-   nifmInitialize();
+   nifmInitialize(NifmServiceType_User);
    
    if(hosversionBefore(8, 0, 0))
       pcvInitialize();


### PR DESCRIPTION
## Description

libnx reached version 3.0.0 a couple weeks back with a redone IPC interface internally, concurrent fs operations and various bugfixes. [Full changelog](https://github.com/switchbrew/libnx/blob/d1e5a5d6c8a597c7b06056b9ee826077ff4ccdc1/Changelog.md)

This PR fixes up after the breaking changes but will break building with previous versions.

NOTE: This PR ***should not*** be merged until the libnx package is updated on all builders.

## Related Issues

None

## Related Pull Requests

None

## Reviewers

@m4xw 
