### PR TITLE
fix potential double free error

### DIFF
--- a/core_updater_list.c
+++ b/core_updater_list.c
@@ -729,6 +729,7 @@ bool core_updater_list_parse_network_data(
 
    /* Temporary data buffer is no longer required */
    free(data_buf);
+   data_buf = NULL;
 
    /* Loop over lines */
    for (i = 0; i < network_core_list->size; i++)


### PR DESCRIPTION
## Description

Taking this branch https://github.com/libretro/RetroArch/blob/99850df96e0fb4427a604b8eedb0c6eb56f459a9/core_updater_list.c#L756 will lead to `data_buf` being free'd twice. This sets it to NULL after the first free to avoid this potential double free.

## Related Issues

None.

## Related Pull Requests

None.

## Reviewers
@jdgleaver 