### PR TITLE
(Vulkan) Fix font driver 'vulkan_get_message_width()' function

### DIFF
--- a/gfx/drivers_font/vulkan_raster_font.c
+++ b/gfx/drivers_font/vulkan_raster_font.c
@@ -125,17 +125,21 @@ static int vulkan_get_message_width(void *data, const char *msg,
       unsigned msg_len, float scale)
 {
    vulkan_raster_t *font = (vulkan_raster_t*)data;
+   const char* msg_end   = msg + msg_len;
+   int delta_x           = 0;
 
-   unsigned i;
-   int delta_x = 0;
-
-   if (!font)
+   if (     !font
+         || !font->font_driver
+         || !font->font_driver->get_glyph
+         || !font->font_data )
       return 0;
 
-   for (i = 0; i < msg_len; i++)
+   while (msg < msg_end)
    {
-      const struct font_glyph *glyph =
-         font->font_driver->get_glyph(font->font_data, (uint8_t)msg[i]);
+      uint32_t code                  = utf8_walk(&msg);
+      const struct font_glyph *glyph = font->font_driver->get_glyph(
+            font->font_data, code);
+
       if (!glyph) /* Do something smarter here ... */
          glyph = font->font_driver->get_glyph(font->font_data, '?');
 


### PR DESCRIPTION
## Description

I just noticed that the Vulkan font renderer fails to handle Unicode characters when determining the display length of text strings. This breaks scrolling ticker text (i.e. if the text or spacer contains Unicode characters, it jumps randomly left and right while scrolling - this affects all scrolling text in Ozone and Material UI).

This PR resolves the issue by fixing the `vulkan_get_message_width()` function - it now behaves exactly the same as the `gl`/`glcore` versions.