### PR TITLE
(3DS) Theodore buildfix

### DIFF
--- a/pkg/ctr/Makefile.cores
+++ b/pkg/ctr/Makefile.cores
@@ -380,7 +380,7 @@ else ifeq ($(LIBRETRO), theodore)
 	APP_PRODUCT_CODE     = RARCH-THEODORE
 	APP_UNIQUE_ID        = 0xBAC2E
 	APP_ICON             = pkg/ctr/assets/ThomsonMOTO.png
-	APP_BANNER           = pkg/ctr/assets/ThomsonMOTO_banner.png	
+	APP_BANNER           = pkg/ctr/assets/ThomsonMOTO_banner.png
 
 else ifeq ($(LIBRETRO), vecx)
 	APP_TITLE            = VecX Libretro


### PR DESCRIPTION
## Description

The 3DS build file `Makefile.cores` currently has some errant whitespace. This prevents the `theodore` core from building, which in turn borks the whole 3DS build sequence.

This PR fixes the issue.
