### PR TITLE
(Filebrowser) Fix file selection issues when starting from (or navigating to) the top level directory

### DIFF
--- a/frontend/drivers/platform_ctr.c
+++ b/frontend/drivers/platform_ctr.c
@@ -483,7 +483,7 @@ static int frontend_ctr_parse_drive_list(void* data, bool load_content)
    file_list_t* list = (file_list_t*)data;
    enum msg_hash_enums enum_idx = load_content
       ? MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR
-      : MSG_UNKNOWN;
+      : MENU_ENUM_LABEL_FILE_BROWSER_DIRECTORY;
 
    if (!list)
       return -1;

--- a/frontend/drivers/platform_darwin.m
+++ b/frontend/drivers/platform_darwin.m
@@ -734,7 +734,7 @@ static int frontend_darwin_parse_drive_list(void *data, bool load_content)
    CFBundleRef bundle = CFBundleGetMainBundle();
    enum msg_hash_enums enum_idx = load_content ?
       MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR :
-      MSG_UNKNOWN;
+      MENU_ENUM_LABEL_FILE_BROWSER_DIRECTORY;
 
    bundle_url  = CFBundleCopyBundleURL(bundle);
    bundle_path = CFURLCopyPath(bundle_url);

--- a/frontend/drivers/platform_gx.c
+++ b/frontend/drivers/platform_gx.c
@@ -481,7 +481,7 @@ static int frontend_gx_parse_drive_list(void *data, bool load_content)
    file_list_t *list = (file_list_t*)data;
    enum msg_hash_enums enum_idx = load_content ?
       MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR :
-      MSG_UNKNOWN;
+      MENU_ENUM_LABEL_FILE_BROWSER_DIRECTORY;
 #ifdef HW_RVL
    menu_entries_append_enum(list,
          "sd:/",

--- a/frontend/drivers/platform_orbis.c
+++ b/frontend/drivers/platform_orbis.c
@@ -329,7 +329,7 @@ static int frontend_orbis_parse_drive_list(void *data, bool load_content)
    file_list_t *list = (file_list_t*)data;
    enum msg_hash_enums enum_idx = load_content ?
       MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR :
-      MSG_UNKNOWN;
+      MENU_ENUM_LABEL_FILE_BROWSER_DIRECTORY;
 
    menu_entries_append_enum(list,
          "host0:app",

--- a/frontend/drivers/platform_ps2.c
+++ b/frontend/drivers/platform_ps2.c
@@ -341,7 +341,7 @@ static int frontend_ps2_parse_drive_list(void *data, bool load_content)
    file_list_t *list = (file_list_t*)data;
    enum msg_hash_enums enum_idx = load_content ?
       MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR :
-      MSG_UNKNOWN;
+      MENU_ENUM_LABEL_FILE_BROWSER_DIRECTORY;
 
    menu_entries_append_enum(list,
          rootDevicePath(BOOT_DEVICE_MC0),

--- a/frontend/drivers/platform_ps3.c
+++ b/frontend/drivers/platform_ps3.c
@@ -528,7 +528,7 @@ static int frontend_ps3_parse_drive_list(void *data, bool load_content)
    file_list_t *list = (file_list_t*)data;
    enum msg_hash_enums enum_idx = load_content ?
       MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR :
-      MSG_UNKNOWN;
+      MENU_ENUM_LABEL_FILE_BROWSER_DIRECTORY;
 
    menu_entries_append_enum(list,
          "/app_home/",

--- a/frontend/drivers/platform_psp.c
+++ b/frontend/drivers/platform_psp.c
@@ -449,7 +449,7 @@ static int frontend_psp_parse_drive_list(void *data, bool load_content)
    file_list_t *list = (file_list_t*)data;
    enum msg_hash_enums enum_idx = load_content ?
       MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR :
-      MSG_UNKNOWN;
+      MENU_ENUM_LABEL_FILE_BROWSER_DIRECTORY;
 
 #ifdef VITA
    menu_entries_append_enum(list,

--- a/frontend/drivers/platform_switch.c
+++ b/frontend/drivers/platform_switch.c
@@ -801,7 +801,7 @@ static int frontend_switch_parse_drive_list(void *data, bool load_content)
    file_list_t *list = (file_list_t *)data;
    enum msg_hash_enums enum_idx = load_content 
       ? MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR 
-      : MSG_UNKNOWN;
+      : MENU_ENUM_LABEL_FILE_BROWSER_DIRECTORY;
 
    if (!list)
       return -1;

--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -1923,7 +1923,7 @@ static int frontend_unix_parse_drive_list(void *data, bool load_content)
    file_list_t *list = (file_list_t*)data;
    enum msg_hash_enums enum_idx = load_content ?
       MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR :
-      MSG_UNKNOWN;
+      MENU_ENUM_LABEL_FILE_BROWSER_DIRECTORY;
 
 #ifdef ANDROID
    if (!string_is_empty(internal_storage_path))

--- a/frontend/drivers/platform_uwp.c
+++ b/frontend/drivers/platform_uwp.c
@@ -277,7 +277,7 @@ static int frontend_uwp_parse_drive_list(void *data, bool load_content)
    file_list_t            *list = (file_list_t*)data;
    enum msg_hash_enums enum_idx = load_content ?
          MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR :
-         MSG_UNKNOWN;
+         MENU_ENUM_LABEL_FILE_BROWSER_DIRECTORY;
    char drive[]                 = " :\\";
    char *home_dir               = (char*)malloc(PATH_MAX_LENGTH * sizeof(char));
    bool have_any_drives         = false;

--- a/frontend/drivers/platform_wiiu.c
+++ b/frontend/drivers/platform_wiiu.c
@@ -173,7 +173,7 @@ static int frontend_wiiu_parse_drive_list(void *data, bool load_content)
    file_list_t *list = (file_list_t *)data;
    enum msg_hash_enums enum_idx = load_content ?
       MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR :
-      MSG_UNKNOWN;
+      MENU_ENUM_LABEL_FILE_BROWSER_DIRECTORY;
 
    if (!list)
       return -1;

--- a/frontend/drivers/platform_win32.c
+++ b/frontend/drivers/platform_win32.c
@@ -475,7 +475,7 @@ static int frontend_win32_parse_drive_list(void *data, bool load_content)
    file_list_t *list = (file_list_t*)data;
    enum msg_hash_enums enum_idx = load_content ?
          MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR :
-         MSG_UNKNOWN;
+         MENU_ENUM_LABEL_FILE_BROWSER_DIRECTORY;
    size_t i          = 0;
    unsigned drives   = GetLogicalDrives();
    char    drive[]   = " :\\";

--- a/frontend/drivers/platform_xdk.c
+++ b/frontend/drivers/platform_xdk.c
@@ -368,7 +368,7 @@ static int frontend_xdk_parse_drive_list(void *data, bool load_content)
    file_list_t *list = (file_list_t*)data;
    enum msg_hash_enums enum_idx = load_content ?
       MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR :
-      MSG_UNKNOWN;
+      MENU_ENUM_LABEL_FILE_BROWSER_DIRECTORY;
 
 #if defined(_XBOX1)
    menu_entries_append_enum(list,

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -900,9 +900,14 @@ int generic_action_ok_displaylist_push(const char *path,
          dl_type            = DISPLAYLIST_GENERIC;
          break;
       case ACTION_OK_DL_DIRECTORY_PUSH:
-         if (path && menu_path)
-            fill_pathname_join(tmp,
-                  menu_path, path, sizeof(tmp));
+         if (!string_is_empty(path))
+         {
+            if (!string_is_empty(menu_path))
+               fill_pathname_join(
+                     tmp, menu_path, path, sizeof(tmp));
+            else
+               strlcpy(tmp, path, sizeof(tmp));
+         }
 
          info.type          = type;
          info.directory_ptr = idx;

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -2393,7 +2393,7 @@ static unsigned menu_displaylist_parse_playlists(
          count++;
       else
          if (menu_entries_append_enum(info->list, "/", "",
-               MSG_UNKNOWN, FILE_TYPE_DIRECTORY, 0, 0))
+               MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR, FILE_TYPE_DIRECTORY, 0, 0))
             count++;
       return count;
    }
@@ -2540,7 +2540,7 @@ static unsigned menu_displaylist_parse_cores(
    {
       if (frontend_driver_parse_drive_list(info->list, true) != 0)
          menu_entries_append_enum(info->list, "/", "",
-               MSG_UNKNOWN, FILE_TYPE_DIRECTORY, 0, 0);
+               MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR, FILE_TYPE_DIRECTORY, 0, 0);
       items_found++;
       return items_found;
    }
@@ -10828,7 +10828,10 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
       {
          if (frontend_driver_parse_drive_list(info->list, load_content) != 0)
             if (menu_entries_append_enum(info->list, "/", "",
-                  MSG_UNKNOWN, FILE_TYPE_DIRECTORY, 0, 0))
+                  load_content ?
+                        MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR :
+                        MENU_ENUM_LABEL_FILE_BROWSER_DIRECTORY,
+                  FILE_TYPE_DIRECTORY, 0, 0))
                count++;
       }
       else


### PR DESCRIPTION
## Description

At present, any non-load-content file browser activity is affected by the following bug: if the user starts from the top level (system) parent directory, or navigates to this location, the file browser 'loses track' of what it is mean to be doing.

A prime example of this is highlighted in issue #9894: If the user does not have a default browser directory set (or tries to navigate to a different physical drive), it becomes impossible to select an arcade DAT file when performing a manual scan. The file browser 'forgets' that it's looking for a DAT, and instead tries to load the selected file as core content.

This PR fixes the issue by ensuring that top level (system) parent directory entries have the correct 'menu entry type' configuration.

## Related Issues

This closes  #9894
