### PR TITLE
Replace [[ ]] with [ ] for POSIX compatibility

### DIFF
--- a/pkg/apple/code-sign-cores.sh
+++ b/pkg/apple/code-sign-cores.sh
@@ -26,7 +26,7 @@ echo "Cores dir: ${CORES_DIR}"
 if [ -d "$CORES_DIR" ] ; then
     CORES=$(find "${CORES_DIR}" -depth -type d -name "*.framework" -or -name "*.dylib" -or -name "*.bundle" | sed -e "s/\(.*framework\)/\1\/Versions\/A\//")
     RESULT=$?
-    if [[ $RESULT != 0 ]] ; then
+    if [ "$RESULT" != 0 ] ; then
         exit 1
     fi
 
@@ -58,7 +58,7 @@ do
     echo "Signing '${ITEM}'"
     codesign --force --verbose --sign "${CODE_SIGN_IDENTITY_FOR_ITEMS}" "${ITEM}"
     RESULT=$?
-    if [[ $RESULT != 0 ]] ; then
+    if [ "$RESULT" != 0 ] ; then
         echo "Failed to sign '${ITEM}'."
         IFS=$SAVED_IFS
         exit 1


### PR DESCRIPTION
Double brackets are not compatible with all POSIX compliant shells. Replaced with single brackets.

http://mywiki.wooledge.org/BashFAQ/031