### PR TITLE
Ensure core info is always initialised when calling 'drivers_init()'

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -23170,6 +23170,17 @@ static void drivers_init(int flags)
          if (!menu_driver_init(video_is_threaded))
              RARCH_ERR("Unable to init menu driver.\n");
    }
+
+   /* Initialising the menu driver will also initialise
+    * core info - if we are not initialising the menu
+    * driver, must initialise core info 'by hand' */
+   if (!(flags & DRIVER_VIDEO_MASK) ||
+       !(flags & DRIVER_MENU_MASK))
+   {
+      command_event(CMD_EVENT_CORE_INFO_INIT, NULL);
+      command_event(CMD_EVENT_LOAD_CORE_PERSIST, NULL);
+   }
+
 #else
    /* Qt uses core info, even if the menu is disabled */
    command_event(CMD_EVENT_CORE_INFO_INIT, NULL);


### PR DESCRIPTION
## Description

At present, calling `drivers_init()` will only initialise core info if the `DRIVER_VIDEO_MASK` and `DRIVER_MENU_MASK` flags are set. This is true in most cases, but if a core invokes `RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO` *without* changing the video configuration (e.g. if it just changes audio sample rate) then core info is de-initialised and left that way until the core is closed.

This breaks a fair amount of frontend functionality while the core is running, but I guess most users wouldn't notice (since most people close content before doing anything special with the menu). One obvious consequence, however, is that it disables content runtime logging (I only noticed the issue myself because the `beetle-wswan-libretro` core was refusing to log runtime...).

This PR fixes the problem by ensuring core info is always initialised when calling `drivers_init()`.