### PR TITLE
menu_setting increase run ahead frames range

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -11687,7 +11687,7 @@ static bool setting_append_list(
          (*list)[list_info->index - 1].ui_type   = ST_UI_TYPE_UINT_COMBOBOX;
          (*list)[list_info->index - 1].action_ok = &setting_action_ok_uint;
          (*list)[list_info->index - 1].offset_by = 1;
-         menu_settings_list_current_add_range(list, list_info, 1, 6, 1, true, true);
+         menu_settings_list_current_add_range(list, list_info, 1, 12, 1, true, true);
 
 #if defined(HAVE_DYNAMIC) || defined(HAVE_DYLIB)
          CONFIG_BOOL(


### PR DESCRIPTION
12 frames instead of 6 max.

Can be useful for games running at 30fps or less internally while RA runs at 60hz.