### PR TITLE
(XMB/Ozone) Fix 'quick menu' detection

### DIFF
--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -1812,7 +1812,8 @@ static void ozone_populate_entries(void *data, const char *path, const char *lab
    ozone->is_playlist         = ozone_is_playlist(ozone, true);
    ozone->is_db_manager_list  = string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_DATABASE_MANAGER_LIST));
    ozone->is_file_list        = string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_FAVORITES));
-   ozone->is_quick_menu       = string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_RPL_ENTRY_ACTIONS));
+   ozone->is_quick_menu       = string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_RPL_ENTRY_ACTIONS)) ||
+                                string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_CONTENT_SETTINGS));
 
    if (ozone->categories_selection_ptr == ozone->categories_active_idx_old)
    {

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -2252,7 +2252,8 @@ static void xmb_populate_entries(void *data,
    xmb->is_file_list = string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_FAVORITES));
 
    /* Determine whether this is the quick menu */
-   xmb->is_quick_menu = string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_RPL_ENTRY_ACTIONS));
+   xmb->is_quick_menu = string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_RPL_ENTRY_ACTIONS)) ||
+                        string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_CONTENT_SETTINGS));
 
    if (menu_driver_ctl(RARCH_MENU_CTL_IS_PREVENT_POPULATE, NULL))
    {


### PR DESCRIPTION
## Description

At present, XMB and Ozone only recognise the quick menu if it is accessed via a playlist - i.e. when `Quick Menu` is selected from the main menu, any special quick menu handling is omitted.

This is almost entirely harmless, but it has the consequence that XMB will not display savestate thumbnails in the quick menu if it is accessed via the main menu.

This trivial PR fixes the issue.
