### PR TITLE
Fixed compiler invoke in configure stage.

### DIFF
--- a/qb/qb.comp.sh
+++ b/qb/qb.comp.sh
@@ -20,12 +20,12 @@ printf %s 'Checking for suitable working C compiler ... '
 cc_works=0
 add_opt CC no
 if [ "$CC" ]; then
-	"$CC" -o "$TEMP_EXE" "$TEMP_C" >/dev/null 2>&1 && cc_works=1
+	$CC -o "$TEMP_EXE" "$TEMP_C" >/dev/null 2>&1 && cc_works=1
 else
 	for cc in gcc cc clang; do
 		CC="$(exists "${CROSS_COMPILE}${cc}")" || CC=""
 		if [ "$CC" ]; then
-			"$CC" -o "$TEMP_EXE" "$TEMP_C" >/dev/null 2>&1 && {
+			$CC -o "$TEMP_EXE" "$TEMP_C" >/dev/null 2>&1 && {
 				cc_works=1; break
 			}
 		fi
@@ -59,12 +59,12 @@ printf %s 'Checking for suitable working C++ compiler ... '
 cxx_works=0
 add_opt CXX no
 if [ "$CXX" ]; then
-	"$CXX" -o "$TEMP_EXE" "$TEMP_CXX" >/dev/null 2>&1 && cxx_works=1
+	$CXX -o "$TEMP_EXE" "$TEMP_CXX" >/dev/null 2>&1 && cxx_works=1
 else
 	for cxx in g++ c++ clang++; do
 		CXX="$(exists "${CROSS_COMPILE}${cxx}")" || CXX=""
 		if [ "$CXX" ]; then
-			"$CXX" -o "$TEMP_EXE" "$TEMP_CXX" >/dev/null 2>&1 && {
+			$CXX -o "$TEMP_EXE" "$TEMP_CXX" >/dev/null 2>&1 && {
 				cxx_works=1; break
 			}
 		fi

--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -340,7 +340,7 @@ check_switch()
 	printf %s\\n 'int main(void) { return 0; }' > "$TEMP_CODE"
 	answer='no'
 	printf %s "Checking for availability of switch $3 in $COMPILER ... "
-	"$COMPILER" -o "$TEMP_EXE" "$TEMP_CODE" "$3" >>config.log 2>&1 && answer='yes'
+	$COMPILER -o "$TEMP_EXE" "$TEMP_CODE" "$3" >>config.log 2>&1 && answer='yes'
 	eval "HAVE_$2=\"$answer\""
 	printf %s\\n "$answer"
 	rm -f -- "$TEMP_CODE" "$TEMP_EXE"


### PR DESCRIPTION
## Description

Hi, I'm porting RetroArch to Yocto build system and I encountered a problem with `$CC` `$CXX` and `$CCOMPILER` invocation in configure step.

Yocto passing additional parameters within `$CC` and `$CXX` variables such like `--sysroot` and architecture opts and other parameters. `$CXXFLAGS` and `$CFLAGS` are populated with stuff like `-O2` and specific recipes parameters.

In current situation variables like `$CC` and `$CXX` are used with quotes. So if Yocto or other enviroment passing something like:
`CXX="arm-poky-linux-gnueabi-gcc  -mthumb -mfpu=neon-vfpv4 -mfloat-abi=hard -mcpu=cortex-a7 -fstack-protector-strong  -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security --sysroot=/home/dev/embedded/yocto-build-system/build/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/retroarch/git-r0/recipe-sysroot"`

Build will failed with:
`Checking for suitable working C compiler ... arm-poky-linux-gnueabi-gcc  -mthumb -mfpu=neon-vfpv4 -mfloat-abi=hard -mcpu=cortex-a7 -fstack-protector-strong  -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security --sysroot=/home/dev/embedded/yocto-build-system/build/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/retroarch/git-r0/recipe-sysroot does not work`

`Error: Cannot proceed without a working C compiler`

Fix that I found is to remove quotes from `$CC` `$CXX` and `$CCOMPILER`.