### PR TITLE
Add Brazil relay server in Sao Paulo.

### DIFF
--- a/network/netplay/netplay.h
+++ b/network/netplay/netplay.h
@@ -38,6 +38,7 @@ static const mitm_server_t netplay_mitm_server_list[] = {
    { "nyc", "New York City, USA" },
    { "madrid", "Madrid, Spain" },
    { "montreal", "Montreal, Canada" },
+   { "saopaulo", "Sao Paulo, Brazil" },
 };
 
 enum rarch_netplay_ctl_state


### PR DESCRIPTION
This adds the relay option "Sao Paulo, Brazil". Server is already deployed and configured in the lobby, so users could start using this relay once this PR has been deployed.