### PR TITLE
Fixed more compiler invokes in configure stage.

### DIFF
--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -164,7 +164,7 @@ check_lib()
 	answer='no'
 	printf %s "$MSG $lib ... "
 	eval "set -- $INCLUDE_DIRS $LIBRARY_DIRS $5 $FLAGS $LDFLAGS $lib"
-	"$COMPILER" -o "$TEMP_EXE" "$TEMP_CODE" "$@" >>config.log 2>&1 && answer='yes'
+	$COMPILER -o "$TEMP_EXE" "$TEMP_CODE" "$@" >>config.log 2>&1 && answer='yes'
 	printf %s\\n "$answer"
 
 	if [ "$answer" = 'yes' ] && [ "$include" ]; then
@@ -282,7 +282,7 @@ check_header()
 	answer='no'
 	printf %s "Checking presence of header file $CHECKHEADER ... "
 	eval "set -- $CFLAGS $INCLUDE_DIRS"
-	"$CC" -o "$TEMP_EXE" "$TEMP_C" "$@" >>config.log 2>&1 && answer='yes'
+	$CC -o "$TEMP_EXE" "$TEMP_C" "$@" >>config.log 2>&1 && answer='yes'
 	eval "HAVE_$val=\"$answer\""
 	printf %s\\n "$answer"
 	rm -f -- "$TEMP_C" "$TEMP_EXE"
@@ -318,7 +318,7 @@ EOF
 	macro="$2"
 	printf %s "Checking presence of predefined macro $macro$ECHOBUF ... "
 	eval "set -- $CFLAGS $INCLUDE_DIRS"
-	"$CC" -o "$TEMP_EXE" "$TEMP_C" "$@" >>config.log 2>&1 && answer='yes'
+	$CC -o "$TEMP_EXE" "$TEMP_C" "$@" >>config.log 2>&1 && answer='yes'
 	eval "HAVE_$val=\"$answer\""
 	printf %s\\n "$answer"
 	rm -f -- "$TEMP_C" "$TEMP_EXE"

--- a/qb/qb.moc.sh
+++ b/qb/qb.moc.sh
@@ -23,8 +23,8 @@ if [ "$HAVE_QT" = "yes" ]; then
 	moc_works=0
 	if [ "$MOC" ]; then
 		QT_SELECT="$QT_VERSION" \
-		"$MOC" -o "$TEMP_CPP" "$TEMP_MOC" >/dev/null 2>&1 &&
-		"$CXX" -o "$TEMP_EXE" $(printf %s "$QT_FLAGS") \
+		$MOC -o "$TEMP_CPP" "$TEMP_MOC" >/dev/null 2>&1 &&
+		$CXX -o "$TEMP_EXE" $(printf %s "$QT_FLAGS") \
 			-fPIC -c "$TEMP_CPP" >/dev/null 2>&1 &&
 		moc_works=1
 	else
@@ -32,9 +32,9 @@ if [ "$HAVE_QT" = "yes" ]; then
 			MOC="$(exists "$moc")" || MOC=""
 			if [ "$MOC" ]; then
 				QT_SELECT="$QT_VERSION" \
-				"$MOC" -o "$TEMP_CPP" "$TEMP_MOC" >/dev/null 2>&1 ||
+				$MOC -o "$TEMP_CPP" "$TEMP_MOC" >/dev/null 2>&1 ||
 					continue
-				"$CXX" -o "$TEMP_EXE" $(printf %s "$QT_FLAGS") \
+				$CXX -o "$TEMP_EXE" $(printf %s "$QT_FLAGS") \
 					-fPIC -c "$TEMP_CPP" >/dev/null 2>&1 && {
 					moc_works=1
 					break


### PR DESCRIPTION
## Description

Hi again, I'm porting RetroArch to Yocto build system and I encountered a problem with $CC $CXX and $CCOMPILER invocation in configure step. There is another patch that fixes `check_lib()` and `check_header()`

## Related Issues
First patches was introduced in #9944

## Question
Is there a way to add additional test to CI? Compilation with `CXX="g++-8 --sysroot=/" ` `CC="gcc-8 --sysroot=/" ` will additionally test compilation process for environments that passing core flags like `--sysroot` by `$CXX` and `$CC`.
