### PR TITLE
fix null check in video_display_server

### DIFF
--- a/gfx/video_display_server.c
+++ b/gfx/video_display_server.c
@@ -74,7 +74,7 @@ void* video_display_server_init(void)
          break;
    }
 
-   if (current_display_server->init && current_display_server->init)
+   if (current_display_server && current_display_server->init)
        current_display_server_data = current_display_server->init();
 
    RARCH_LOG("[Video]: Found display server: %s\n",


### PR DESCRIPTION
the manually remade fix in #9957 was incorrect, it was just doing the same check twice