### PR TITLE
Implement the packet buffer for the FFMPEG core

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1965,8 +1965,9 @@ endif
 ifeq ($(HAVE_FFMPEG), 1)
    OBJ += record/drivers/record_ffmpeg.o \
           cores/libretro-ffmpeg/ffmpeg_core.o \
+          cores/libretro-ffmpeg/packet_buffer.o \
           cores/libretro-ffmpeg/video_buffer.o \
-			 $(LIBRETRO_COMM_DIR)/rthreads/tpool.o
+          $(LIBRETRO_COMM_DIR)/rthreads/tpool.o
 
    LIBS += $(AVCODEC_LIBS) $(AVFORMAT_LIBS) $(AVUTIL_LIBS) $(SWSCALE_LIBS) $(SWRESAMPLE_LIBS) $(FFMPEG_LIBS)
    DEFINES += -DHAVE_FFMPEG

--- a/cores/libretro-ffmpeg/Makefile.common
+++ b/cores/libretro-ffmpeg/Makefile.common
@@ -19,6 +19,7 @@ SWRESAMPLE_DIR 	 := $(BASE_DIR)/libswresample
 INCFLAGS           += -I$(BASE_DIR) -I$(CORE_DIR) -I$(LIBRETRO_COMM_DIR)/include -I$(LIBRETRO_COMM_DIR)/include/compat
 
 LIBRETRO_SOURCE    += $(CORE_DIR)/ffmpeg_core.c \
+							 $(CORE_DIR)/packet_buffer.c \
 							 $(CORE_DIR)/video_buffer.c \
 							 $(LIBRETRO_COMM_DIR)/rthreads/tpool.c \
 							 $(LIBRETRO_COMM_DIR)/queues/fifo_queue.c \

--- a/cores/libretro-ffmpeg/ffmpeg_core.c
+++ b/cores/libretro-ffmpeg/ffmpeg_core.c
@@ -1531,7 +1531,7 @@ static void decode_thread_seek(double time)
 }
 
 static bool earlier_or_close_enough(double p1, double p2) {
-   return (p1 <= p2 || (p1-p2) <= 0.1);
+   return (p1 <= p2 || (p1-p2) <= 0.001);
 }
 
 static void decode_thread(void *data)

--- a/cores/libretro-ffmpeg/packet_buffer.c
+++ b/cores/libretro-ffmpeg/packet_buffer.c
@@ -38,10 +38,10 @@ void packet_buffer_destroy(packet_buffer_t *packet_buffer)
    if (packet_buffer->head)
    {
       node = packet_buffer->head;
-      while (node->next)
+      while (node)
       {
          AVPacketNode_t *next = node->next;
-         av_packet_unref(node->data);
+         av_packet_free(&node->data);
          free(node);
          node = next;
       }

--- a/cores/libretro-ffmpeg/packet_buffer.c
+++ b/cores/libretro-ffmpeg/packet_buffer.c
@@ -1,0 +1,138 @@
+#include "packet_buffer.h"
+
+
+struct AVPacketNode {
+   AVPacket *data;
+   struct AVPacketNode *next;
+   struct AVPacketNode *previous;
+};
+typedef struct AVPacketNode AVPacketNode_t;
+
+struct packet_buffer
+{
+   AVPacketNode_t *head;
+   AVPacketNode_t *tail;
+
+   size_t capacity;
+   size_t size;
+};
+
+packet_buffer_t *packet_buffer_create()
+{
+   packet_buffer_t *b = malloc(sizeof(packet_buffer_t));
+   if (!b)
+      return NULL;
+
+   memset(b, 0, sizeof(packet_buffer_t));
+
+   return b;
+}
+
+void packet_buffer_destroy(packet_buffer_t *packet_buffer)
+{
+   AVPacketNode_t *node;
+
+   if (!packet_buffer)
+      return;
+
+   if (packet_buffer->head)
+   {
+      node = packet_buffer->head;
+      while (node->next)
+      {
+         AVPacketNode_t *next = node->next;
+         av_packet_unref(node->data);
+         free(node);
+         node = next;
+      }
+   }
+
+   free(packet_buffer);
+}
+
+void packet_buffer_clear(packet_buffer_t **packet_buffer)
+{
+   if (!packet_buffer)
+      return;
+
+   packet_buffer_destroy(*packet_buffer);
+   *packet_buffer = packet_buffer_create();
+}
+
+bool packet_buffer_empty(packet_buffer_t *packet_buffer)
+{
+   if (!packet_buffer)
+      return true;
+
+   return packet_buffer->size == 0;
+}
+
+size_t packet_buffer_size(packet_buffer_t *packet_buffer)
+{
+   if (!packet_buffer)
+      return 0;
+
+   return packet_buffer->size;
+}
+
+void packet_buffer_add_packet(packet_buffer_t *packet_buffer, AVPacket *pkt)
+{
+   AVPacketNode_t *new_head = (AVPacketNode_t *) malloc(sizeof(AVPacketNode_t));
+   new_head->data = av_packet_alloc();
+
+   av_packet_move_ref(new_head->data, pkt);
+
+   if (packet_buffer->head)
+   {
+      new_head->next = packet_buffer->head;
+      packet_buffer->head->previous = new_head;
+   }
+   else
+   {
+      new_head->next = NULL;
+      packet_buffer->tail = new_head;
+   }
+
+   packet_buffer->head = new_head;
+   packet_buffer->head->previous = NULL;
+   packet_buffer->size++;
+}
+
+void packet_buffer_get_packet(packet_buffer_t *packet_buffer, AVPacket *pkt)
+{
+   AVPacketNode_t *new_tail = NULL;
+
+   if (packet_buffer->tail == NULL)
+      return;
+
+   av_packet_move_ref(pkt, packet_buffer->tail->data);
+   if (packet_buffer->tail->previous)
+   {
+      new_tail = packet_buffer->tail->previous;
+      new_tail->next = NULL;
+   }
+   else
+      packet_buffer->head = NULL;
+
+   av_packet_free(&packet_buffer->tail->data);
+   free(packet_buffer->tail);
+
+   packet_buffer->tail = new_tail;
+   packet_buffer->size--;
+}
+
+int64_t packet_buffer_peek_start_pts(packet_buffer_t *packet_buffer)
+{
+   if (!packet_buffer->tail)
+      return 0;
+
+   return packet_buffer->tail->data->pts;
+}
+
+int64_t packet_buffer_peek_end_pts(packet_buffer_t *packet_buffer)
+{
+   if (!packet_buffer->tail)
+      return 0;
+
+   return packet_buffer->tail->data->pts + packet_buffer->tail->data->duration;
+}

--- a/cores/libretro-ffmpeg/packet_buffer.c
+++ b/cores/libretro-ffmpeg/packet_buffer.c
@@ -1,6 +1,5 @@
 #include "packet_buffer.h"
 
-
 struct AVPacketNode {
    AVPacket *data;
    struct AVPacketNode *next;
@@ -12,8 +11,6 @@ struct packet_buffer
 {
    AVPacketNode_t *head;
    AVPacketNode_t *tail;
-
-   size_t capacity;
    size_t size;
 };
 

--- a/cores/libretro-ffmpeg/packet_buffer.h
+++ b/cores/libretro-ffmpeg/packet_buffer.h
@@ -1,0 +1,110 @@
+#ifndef __LIBRETRO_SDK_PACKETBUFFER_H__
+#define __LIBRETRO_SDK_PACKETBUFFER_H__
+
+#include <retro_common_api.h>
+
+#include <boolean.h>
+#include <stdint.h>
+
+#include <libavcodec/avcodec.h>
+
+#include <retro_miscellaneous.h>
+
+RETRO_BEGIN_DECLS
+
+/**
+ * packet_buffer
+ *
+ * Just a simple double linked list for AVPackets.
+ *
+ */
+struct packet_buffer;
+typedef struct packet_buffer packet_buffer_t;
+
+/**
+ * packet_buffer_create:
+ *
+ * Create a packet_buffer.
+ *
+ * Returns: A packet buffer.
+ */
+packet_buffer_t *packet_buffer_create();
+
+/**
+ * packet_buffer_destroy:
+ * @packet_buffer      : packet buffer
+ *
+ * Destroys a packet buffer.
+ *
+ **/
+void packet_buffer_destroy(packet_buffer_t *packet_buffer);
+
+/**
+ * packet_buffer_clear:
+ * @packet_buffer      : packet buffer
+ *
+ * Clears a packet buffer by re-creating it.
+ *
+ **/
+void packet_buffer_clear(packet_buffer_t **packet_buffer);
+
+/**
+ * packet_buffer_empty:
+ * @packet_buffer      : packet buffer
+ *
+ * Return true if the buffer is empty;
+ *
+ **/
+bool packet_buffer_empty(packet_buffer_t *packet_buffer);
+
+/**
+ * packet_buffer_size:
+ * @packet_buffer      : packet buffer
+ *
+ * Returns the number of AVPackets the buffer currently
+ * holds.
+ *
+ **/
+size_t packet_buffer_size(packet_buffer_t *packet_buffer);
+
+/**
+ * packet_buffer_add_packet:
+ * @packet_buffer      : packet buffer
+ * @pkt                : packet
+ *
+ * Copies the given packet into the selected buffer.
+ *
+ **/
+void packet_buffer_add_packet(packet_buffer_t *packet_buffer, AVPacket *pkt);
+
+/**
+ * packet_buffer_get_packet:
+ * @packet_buffer      : packet buffer
+ * @pkt                : packet
+ *
+ * Get the next packet. User needs to unref the packet with av_packet_unref().
+ *
+ **/
+void packet_buffer_get_packet(packet_buffer_t *packet_buffer, AVPacket *pkt);
+
+/**
+ * packet_buffer_peek_start_pts:
+ * @packet_buffer      : packet buffer
+ *
+ * Returns the start pts of the next packet in the buffer.
+ *
+ **/
+int64_t packet_buffer_peek_start_pts(packet_buffer_t *packet_buffer);
+
+/**
+ * packet_buffer_peek_end_pts:
+ * @packet_buffer      : packet buffer
+ *
+ * Returns the end pts of the next packet in the buffer.
+ *
+ **/
+int64_t packet_buffer_peek_end_pts(packet_buffer_t *packet_buffer);
+
+RETRO_END_DECLS
+
+#endif

--- a/cores/libretro-ffmpeg/video_buffer.h
+++ b/cores/libretro-ffmpeg/video_buffer.h
@@ -1,5 +1,5 @@
-#ifndef __LIBRETRO_SDK_SWSBUFFER_H__
-#define __LIBRETRO_SDK_SWSBUFFER_H__
+#ifndef __LIBRETRO_SDK_VIDEOBUFFER_H__
+#define __LIBRETRO_SDK_VIDEOBUFFER_H__
 
 #include <retro_common_api.h>
 
@@ -47,7 +47,7 @@ typedef struct video_decoder_context video_decoder_context_t;
 /**
  * video_buffer
  * 
- * The video_buffer is a ring buffer, that can be used as a 
+ * The video buffer is a ring buffer, that can be used as a 
  * buffer for many workers while keeping the order.
  * 
  * It is thread safe in a sensem that it is designed to work
@@ -61,26 +61,26 @@ typedef struct video_buffer video_buffer_t;
 
 /**
  * video_buffer_create:
- * @num           : Size of the buffer.
+ * @capacity      : Size of the buffer.
  * @frame_size    : Size of the target frame.
  * @width         : Width of the target frame.
  * @height        : Height of the target frame.
  *
- * Create a video_buffer.
+ * Create a video buffer.
  * 
  * Returns: A video buffer.
  */
-video_buffer_t *video_buffer_create(size_t num, int frame_size, int width, int height);
+video_buffer_t *video_buffer_create(size_t capacity, int frame_size, int width, int height);
 
 /** 
  * video_buffer_destroy:
  * @video_buffer      : video buffer.
  * 
- * Destory a video_buffer.
+ * Destroys a video buffer.
  * 
  * Does also free the buffer allocated with video_buffer_create().
  * User has to shut down any external worker threads that may have
- * a reference to this video_buffer.
+ * a reference to this video buffer.
  * 
  **/
 void video_buffer_destroy(video_buffer_t *video_buffer);
@@ -89,7 +89,7 @@ void video_buffer_destroy(video_buffer_t *video_buffer);
  * video_buffer_clear:
  * @video_buffer      : video buffer.
  * 
- * Clears a video_buffer.
+ * Clears a video buffer.
  * 
  **/
 void video_buffer_clear(video_buffer_t *video_buffer);
@@ -97,7 +97,7 @@ void video_buffer_clear(video_buffer_t *video_buffer);
 /** 
  * video_buffer_get_open_slot:
  * @video_buffer     : video buffer.
- * @contex        : sws context.
+ * @context          : sws context.
  * 
  * Returns the next open context inside the ring buffer
  * and it's index. The status of the slot will be marked as
@@ -110,7 +110,7 @@ void video_buffer_get_open_slot(video_buffer_t *video_buffer, video_decoder_cont
 /** 
  * video_buffer_return_open_slot:
  * @video_buffer     : video buffer.
- * @contex        : sws context.
+ * @context          : sws context.
  * 
  * Marks the given sws context that is "in progress" as "open" again.
  *
@@ -120,7 +120,7 @@ void video_buffer_return_open_slot(video_buffer_t *video_buffer, video_decoder_c
 /** 
  * video_buffer_open_slot:
  * @video_buffer     : video buffer.
- * @context       : sws context.
+ * @context          : sws context.
  * 
  * Sets the status of the given context from "finished" to "open".
  * The slot is then available for producers to claim again with video_buffer_get_open_slot().
@@ -130,21 +130,20 @@ void video_buffer_open_slot(video_buffer_t *video_buffer, video_decoder_context_
 /**
  * video_buffer_get_finished_slot:
  * @video_buffer     : video buffer.
- * @context       : sws context.
+ * @context          : sws context.
  * 
  * Returns a reference for the next context inside
  * the ring buffer. User needs to use video_buffer_open_slot()
  * to open the slot in the ringbuffer for the next
  * work assignment. User is free to re-allocate or
  * re-use the context.
- *
  */
 void video_buffer_get_finished_slot(video_buffer_t *video_buffer, video_decoder_context_t **context);
 
 /**
  * video_buffer_finish_slot:
  * @video_buffer     : video buffer.
- * @context       : sws context.
+ * @context          : sws context.
  * 
  * Sets the status of the given context from "in progress" to "finished".
  * This is normally done by a producer. User can then retrieve the finished work


### PR DESCRIPTION
This PR is open for testing.

Simply use two packet_buffers that are double-linked lists of AVPacket structs. This way we can control which packets to feed to the decoders at the right time.

This solves the playback problem with the MP4 files. It also greately reduced memory consumption, since we can greatly reduce the amount of frame buffers needed.

**Open Issues**

~~ASAN reports two small memory leaks, one in the decode_thread() and one inside the packet_buffer() functions. I haven't found the issue yet, so as long as I haven't found the cause of the leaks, this PR should be considered WIP.~~ **FIXED**