### PR TITLE
Fix building on GNU/Linux because of missing SIGTERM declaration.

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -56,6 +56,7 @@
 #include <setjmp.h>
 #include <math.h>
 #include <locale.h>
+#include <signal.h>
 
 #include <boolean.h>
 #include <clamping.h>


### PR DESCRIPTION
Related to issue https://github.com/libretro/RetroArch/issues/9907
As asked by @RobLoach in that issue.

These are the configure options I used when trying to build this:

`./configure --disable-ibxm --disable-vg --disable-x11 --disable-wayland --disable-sdl2 --disable-al --disable-cheevos --disable-ffmpeg --disable-networking --disable-libretrodb --enable-udev --disable-sdl --disable-pulse --disable-oss --disable-freetype --disable-7zip --disable-imageviewer --disable-rjpeg --disable-rbmp --disable-rtga --disable-flac --disable-qt --disable-materialui --disable-xmb --enable-rgui --disable-ozone --disable-menu_widgets --disable-langextra --disable-cdrom --enable-opengles --enable-egl
`
It builds with the added include in this PR. It does not build without the added include in this PR.