### PR TITLE
Added additional CI test for passing sysroot flags via CC and CXX.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ matrix:
     - compiler: gcc
       env: CC=gcc-8 CXX=g++-8
     - compiler: gcc
+      env: CC="gcc-8 --sysroot=/" CXX="g++-8 --sysroot=/"
+    - compiler: gcc
       env: C89_BUILD=1 CC=gcc-8 CXX=g++-8
     - compiler: gcc
       env: CXX_BUILD=1 CC=gcc-8 CXX=g++-8
@@ -105,7 +107,7 @@ matrix:
 
 before_install:
   - |
-     if [ "$CC" = gcc-8 ]; then
+     if [[ "$CC" =~ ^gcc-8.* ]]; then
        # Install a more recent gcc than the default
        sudo apt-get install -y g++-8
      elif [ "$CC" = clang-6.0 ]; then


### PR DESCRIPTION
## Description

Additional travis build test to check if passing `--sysroot` parameter via `CC` and `CXX` is working correctly. 

## Rationale

It's important to maintain this feature, because some sandboxed environments like Yocto passing `--sysroot` as `CC` and `CXX`.

## Related Issues

Script fixes: #9944, #9959
