### PR TITLE
Revert "Fixed compiler invoke in configure stage."

### DIFF
--- a/qb/qb.comp.sh
+++ b/qb/qb.comp.sh
@@ -20,12 +20,12 @@ printf %s 'Checking for suitable working C compiler ... '
 cc_works=0
 add_opt CC no
 if [ "$CC" ]; then
-	$CC -o "$TEMP_EXE" "$TEMP_C" >/dev/null 2>&1 && cc_works=1
+	"$CC" -o "$TEMP_EXE" "$TEMP_C" >/dev/null 2>&1 && cc_works=1
 else
 	for cc in gcc cc clang; do
 		CC="$(exists "${CROSS_COMPILE}${cc}")" || CC=""
 		if [ "$CC" ]; then
-			$CC -o "$TEMP_EXE" "$TEMP_C" >/dev/null 2>&1 && {
+			"$CC" -o "$TEMP_EXE" "$TEMP_C" >/dev/null 2>&1 && {
 				cc_works=1; break
 			}
 		fi
@@ -59,12 +59,12 @@ printf %s 'Checking for suitable working C++ compiler ... '
 cxx_works=0
 add_opt CXX no
 if [ "$CXX" ]; then
-	$CXX -o "$TEMP_EXE" "$TEMP_CXX" >/dev/null 2>&1 && cxx_works=1
+	"$CXX" -o "$TEMP_EXE" "$TEMP_CXX" >/dev/null 2>&1 && cxx_works=1
 else
 	for cxx in g++ c++ clang++; do
 		CXX="$(exists "${CROSS_COMPILE}${cxx}")" || CXX=""
 		if [ "$CXX" ]; then
-			$CXX -o "$TEMP_EXE" "$TEMP_CXX" >/dev/null 2>&1 && {
+			"$CXX" -o "$TEMP_EXE" "$TEMP_CXX" >/dev/null 2>&1 && {
 				cxx_works=1; break
 			}
 		fi

--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -340,7 +340,7 @@ check_switch()
 	printf %s\\n 'int main(void) { return 0; }' > "$TEMP_CODE"
 	answer='no'
 	printf %s "Checking for availability of switch $3 in $COMPILER ... "
-	$COMPILER -o "$TEMP_EXE" "$TEMP_CODE" "$3" >>config.log 2>&1 && answer='yes'
+	"$COMPILER" -o "$TEMP_EXE" "$TEMP_CODE" "$3" >>config.log 2>&1 && answer='yes'
 	eval "HAVE_$2=\"$answer\""
 	printf %s\\n "$answer"
 	rm -f -- "$TEMP_CODE" "$TEMP_EXE"


### PR DESCRIPTION
Reverts libretro/RetroArch#9944

Just wrong, these quotes are intentional and prevent shellcheck warnings and maybe some bugs. Unquoting variables does not mean they will automatically split in all shells anyways...