### PR TITLE
Revert "Added additional CI test for passing sysroot flags via CC and CXX."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,6 @@ matrix:
     - compiler: gcc
       env: CC=gcc-8 CXX=g++-8
     - compiler: gcc
-      env: CC="gcc-8 --sysroot=/" CXX="g++-8 --sysroot=/"
-    - compiler: gcc
       env: C89_BUILD=1 CC=gcc-8 CXX=g++-8
     - compiler: gcc
       env: CXX_BUILD=1 CC=gcc-8 CXX=g++-8
@@ -107,7 +105,7 @@ matrix:
 
 before_install:
   - |
-     if [[ "$CC" =~ ^gcc-8.* ]]; then
+     if [ "$CC" = gcc-8 ]; then
        # Install a more recent gcc than the default
        sudo apt-get install -y g++-8
      elif [ "$CC" = clang-6.0 ]; then


### PR DESCRIPTION
Reverts libretro/RetroArch#9978

Bogus check and user error, `--sysroot` should not be passed via `CC` or `CXX`, but part of `CFLAGS` and `CXXFLAGS`.

Reference: https://stackoverflow.com/questions/25112834/arm-cross-compilation-unrecognized-sysroot-option-eclipse/25147539#25147539