### PR TITLE
qb: Allow multi argument CC and CXX.

### DIFF
--- a/qb/qb.comp.sh
+++ b/qb/qb.comp.sh
@@ -15,19 +15,43 @@ cat << EOF > "$TEMP_C"
 int main(void) { puts("Hai world!"); return 0; }
 EOF
 
+# test_compiler:
+# Check that the compiler exists in the $PATH and works
+# $1 = compiler
+# $2 = temporary build file
+test_compiler ()
+{
+	compiler=
+
+	for comp in $(printf %s "$1"); do
+		if ! next "$comp"; then
+			compiler="${compiler} $(exists "${comp}")" ||
+				return 1
+		fi
+	done
+
+	$(printf %s "$1") -o "$TEMP_EXE" "$2" >/dev/null 2>&1 || return 1
+
+	compiler="${compiler# }"
+	cc_works=1
+	return 0
+}
+
 printf %s 'Checking for suitable working C compiler ... '
 
 cc_works=0
 add_opt CC no
+
 if [ "$CC" ]; then
-	$CC -o "$TEMP_EXE" "$TEMP_C" >/dev/null 2>&1 && cc_works=1
+	if test_compiler "$CC" "$TEMP_C"; then
+		cc_works=1
+	fi
 else
 	for cc in gcc cc clang; do
-		CC="$(exists "${CROSS_COMPILE}${cc}")" || CC=""
-		if [ "$CC" ]; then
-			$CC -o "$TEMP_EXE" "$TEMP_C" >/dev/null 2>&1 && {
-				cc_works=1; break
-			}
+		if test_compiler "${CROSS_COMPILE}${cc}" "$TEMP_C"; then
+			CC="$compiler"
+			cc_works=1
+			break
 		fi
 	done
 fi
@@ -58,15 +82,17 @@ printf %s 'Checking for suitable working C++ compiler ... '
 
 cxx_works=0
 add_opt CXX no
+
 if [ "$CXX" ]; then
-	$CXX -o "$TEMP_EXE" "$TEMP_CXX" >/dev/null 2>&1 && cxx_works=1
+	if test_compiler "$CXX" "$TEMP_CXX"; then
+		cxx_works=1
+	fi
 else
 	for cxx in g++ c++ clang++; do
-		CXX="$(exists "${CROSS_COMPILE}${cxx}")" || CXX=""
-		if [ "$CXX" ]; then
-			$CXX -o "$TEMP_EXE" "$TEMP_CXX" >/dev/null 2>&1 && {
-				cxx_works=1; break
-			}
+		if test_compiler "${CROSS_COMPILE}${cxx}" "$TEMP_CXX"; then
+			CXX="$compiler"
+			cxx_works=1
+			break
 		fi
 	done
 fi

--- a/qb/qb.init.sh
+++ b/qb/qb.init.sh
@@ -58,3 +58,8 @@ match()
 	done
 	return 1
 }
+
+# next:
+# Check if the next argument starts with a dash
+# $1 = arg
+next () { case "$1" in -*) return 0 ;; *) return 1 ;; esac; }

--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -164,7 +164,8 @@ check_lib()
 	answer='no'
 	printf %s "$MSG $lib ... "
 	eval "set -- $INCLUDE_DIRS $LIBRARY_DIRS $5 $FLAGS $LDFLAGS $lib"
-	$COMPILER -o "$TEMP_EXE" "$TEMP_CODE" "$@" >>config.log 2>&1 && answer='yes'
+	$(printf %s "$COMPILER") -o "$TEMP_EXE" "$TEMP_CODE" "$@" \
+		>>config.log 2>&1 && answer='yes'
 	printf %s\\n "$answer"
 
 	if [ "$answer" = 'yes' ] && [ "$include" ]; then
@@ -282,7 +283,8 @@ check_header()
 	answer='no'
 	printf %s "Checking presence of header file $CHECKHEADER ... "
 	eval "set -- $CFLAGS $INCLUDE_DIRS"
-	$CC -o "$TEMP_EXE" "$TEMP_C" "$@" >>config.log 2>&1 && answer='yes'
+	$(printf %s "$CC") -o "$TEMP_EXE" "$TEMP_C" "$@" >>config.log 2>&1 &&
+		answer='yes'
 	eval "HAVE_$val=\"$answer\""
 	printf %s\\n "$answer"
 	rm -f -- "$TEMP_C" "$TEMP_EXE"
@@ -318,7 +320,8 @@ EOF
 	macro="$2"
 	printf %s "Checking presence of predefined macro $macro$ECHOBUF ... "
 	eval "set -- $CFLAGS $INCLUDE_DIRS"
-	$CC -o "$TEMP_EXE" "$TEMP_C" "$@" >>config.log 2>&1 && answer='yes'
+	$(printf %s "$CC") -o "$TEMP_EXE" "$TEMP_C" "$@" >>config.log 2>&1 &&
+		answer='yes'
 	eval "HAVE_$val=\"$answer\""
 	printf %s\\n "$answer"
 	rm -f -- "$TEMP_C" "$TEMP_EXE"
@@ -340,7 +343,8 @@ check_switch()
 	printf %s\\n 'int main(void) { return 0; }' > "$TEMP_CODE"
 	answer='no'
 	printf %s "Checking for availability of switch $3 in $COMPILER ... "
-	$COMPILER -o "$TEMP_EXE" "$TEMP_CODE" "$3" >>config.log 2>&1 && answer='yes'
+	$(printf %s "$COMPILER") -o "$TEMP_EXE" "$TEMP_CODE" "$3" \
+		>>config.log 2>&1 && answer='yes'
 	eval "HAVE_$2=\"$answer\""
 	printf %s\\n "$answer"
 	rm -f -- "$TEMP_CODE" "$TEMP_EXE"

--- a/qb/qb.moc.sh
+++ b/qb/qb.moc.sh
@@ -23,22 +23,24 @@ if [ "$HAVE_QT" = "yes" ]; then
 	moc_works=0
 	if [ "$MOC" ]; then
 		QT_SELECT="$QT_VERSION" \
-		$MOC -o "$TEMP_CPP" "$TEMP_MOC" >/dev/null 2>&1 &&
-		$CXX -o "$TEMP_EXE" $(printf %s "$QT_FLAGS") \
-			-fPIC -c "$TEMP_CPP" >/dev/null 2>&1 &&
+		"$MOC" -o "$TEMP_CPP" "$TEMP_MOC" >/dev/null 2>&1 &&
+			$(printf %s "$CXX") -o "$TEMP_EXE" \
+			$(printf %s "$QT_FLAGS") -fPIC -c "$TEMP_CPP" \
+			>/dev/null 2>&1 &&
 		moc_works=1
 	else
 		for moc in "moc-$QT_VERSION" moc; do
 			MOC="$(exists "$moc")" || MOC=""
 			if [ "$MOC" ]; then
 				QT_SELECT="$QT_VERSION" \
-				$MOC -o "$TEMP_CPP" "$TEMP_MOC" >/dev/null 2>&1 ||
+				"$MOC" -o "$TEMP_CPP" "$TEMP_MOC" >/dev/null 2>&1 ||
 					continue
-				$CXX -o "$TEMP_EXE" $(printf %s "$QT_FLAGS") \
-					-fPIC -c "$TEMP_CPP" >/dev/null 2>&1 && {
+				if $(printf %s "$CXX") -o "$TEMP_EXE" \
+						$(printf %s "$QT_FLAGS") -fPIC -c \
+						"$TEMP_CPP" >/dev/null 2>&1; then
 					moc_works=1
 					break
-				}
+				fi
 			fi
 		done
 	fi


### PR DESCRIPTION
## Description

Correctly fixes the issues raised in PR https://github.com/libretro/RetroArch/pull/9995.

This allows setting `CC` and `CXX` with multiple arguments, for example:
```
CC='ccache gcc'
```
or
```
CC='gcc --sysroot=/`
```

## Reviewers

@dev-0x7C6 and @rpurdie

Does the `MOC` environment variable really need similar treatment?
