### PR TITLE
qb: Update the exists function.

### DIFF
--- a/qb/qb.init.sh
+++ b/qb/qb.init.sh
@@ -23,22 +23,29 @@ exists()
 	while [ $# -gt 0 ]; do
 		arg="$1"
 		shift 1
-		case "$arg" in ''|*/) continue ;; esac
-		x="${arg##*/}"
-		z="${arg%/*}"
-		[ ! -f "$z/$x" ] || [ ! -x "$z/$x" ] && [ "$z/$x" = "$arg" ] &&
-			continue
-		[ "$x" = "$z" ] && [ -x "$z/$x" ] && [ ! -f "$arg" ] && z=
-		p=":$z:$PATH"
-		while [ "$p" != "${p#*:}" ]; do
-			p="${p#*:}"
-			d="${p%%:*}"
-			if [ -f "$d/$x" ] && [ -x "$d/$x" ]; then
-				printf %s\\n "$d/$x"
-				v=0
-				break
-			fi
-		done
+		case "$arg" in
+			''|*/ )
+				:
+			;;
+			*/* )
+				if [ -f "$arg" ] && [ -x "$arg" ]; then
+					printf %s\\n "$arg"
+					v=0
+				fi
+			;;
+			* )
+				p=":$PATH"
+				while [ "$p" != "${p#*:}" ]; do
+					p="${p#*:}"
+					d="${p%%:*}/$arg"
+					if [ -f "$d" ] && [ -x "$d" ]; then
+						printf %s\\n "$d"
+						v=0
+						break
+					fi
+				done
+			;;
+		esac
 	done
 	return $v
 }


### PR DESCRIPTION
## Description

This updates the `exists` function in the `qb/qb.init.sh` file to fix an obscure bug people are not likely to run into and to make it easier to understand.

I wrote a test CI for this function which can be found in the below link and appears to work better than both `GNU which` and `command -v` (Excluding zsh).

https://notabug.org/orbea/exists

## Related Issues

Before if someone tried to do something like `CC=/path/to:/gcc` where the file path contains a literal `:` it would fail.