### PR TITLE
Adjust ffmpeg dependencies in the build requirements.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -407,7 +407,7 @@ check_enabled THREADS FFMPEG FFmpeg 'Threads are' false
 
 if [ "$HAVE_FFMPEG" != 'no' ]; then
    check_val '' AVCODEC -lavcodec '' libavcodec 57 '' false
-   check_val '' AVFORMAT -lavformat '' libavformat 57 '' false
+   check_val '' AVFORMAT -lavformat '' libavformat 57.80.100 '' false
    check_val '' AVDEVICE -lavdevice '' libavdevice 57 '' false
    check_val '' SWRESAMPLE -lswresample '' libswresample 2 '' false
    check_val '' AVUTIL -lavutil '' libavutil 55 '' false


### PR DESCRIPTION
After the recent improvements regarding the `ffmpeg` core in RetroArch (thanks to @hasenbanck), the dependency on the `avcodec` library needs to be bumped, since the new additions require a more recent version of it. In particular, this fixes building RetroArch on the _oldstable_ Debian (and derivatives).

Trying to build on Debian Stretch, `ffmpeg` is enabled automatically if all required libraries are installed
```
...
 Checking presence of package libavcodec >= 57 ... 57.64.101
 Checking presence of package libavformat >= 57 ... 57.56.101
 Checking presence of package libavdevice >= 57 ... 57.1.100
 Checking presence of package libswresample >= 2 ... 2.3.100
 Checking presence of package libavutil >= 55 ... 55.34.101
 Checking presence of package libswscale >= 4 ... 4.2.100
 Checking presence of header file libavutil/channel_layout.h ... yes
```

However, building fails with 
```
CC cores/libretro-ffmpeg/ffmpeg_core.c
cores/libretro-ffmpeg/ffmpeg_core.c: In function ‘decode_thread’:
cores/libretro-ffmpeg/ffmpeg_core.c:1736:20: error: ‘AVCodecContext {aka struct AVCodecContext}’ has no member named ‘hw_device_ctx’; did you mean ‘hw_frames_ctx’?
    if (vctx && vctx->hw_device_ctx)
                    ^~
cores/libretro-ffmpeg/ffmpeg_core.c:1737:28: error: ‘AVCodecContext {aka struct AVCodecContext}’ has no member named ‘hw_device_ctx’; did you mean ‘hw_frames_ctx’?
       av_buffer_unref(&vctx->hw_device_ctx);
                            ^~
```

Following the error, the offending package is `libavcodec-dev`. The `hw_device_ctx` was introduced in `lavc`  in [57.80.100](https://github.com/FFmpeg/FFmpeg/commit/c1a5fca06f75cc0e7b9b2808fecaa0c1b424da50), so add a minimum requirement to this version during configuration to enable `ffmpeg` for the build.

NOTE: Ubuntu 18.04 is not affected by this, it ships `lavc` version 57.107.100, while Debian Buster ships with 58.35.100. 