### PR TITLE
qb: Move BUILD_DIRS to the correct function.

### DIFF
--- a/qb/qb.libs.sh
+++ b/qb/qb.libs.sh
@@ -28,6 +28,7 @@ add_dirs()
 		shift
 	done
 	eval "${ADD}_DIRS=\"\${${ADD}_DIRS# }\""
+	BUILD_DIRS="$INCLUDE_DIRS $LIBRARY_DIRS"
 }
 
 # check_compiler:
@@ -45,8 +46,6 @@ check_compiler()
 		TEMP_CODE="$TEMP_C"
 		TEST_C="void $2(void); int main(void) { $2(); return 0; }"
 	fi
-
-	BUILD_DIRS="$INCLUDE_DIRS $LIBRARY_DIRS"
 }
 
 # check_enabled:


### PR DESCRIPTION
## Description

Fixes a small mistake from my previous PR.

## Related Issues

The `BUILD_DIRS` variable may have not been correctly set in all cases, I am not sure if this was a problem in practice?

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/10006
