### PR TITLE
Don't use uname -a.

### DIFF
--- a/gfx/video_filters/Makefile
+++ b/gfx/video_filters/Makefile
@@ -7,20 +7,18 @@ PREFIX      := /usr
 INSTALLDIR  := $(PREFIX)/lib/retroarch/filters/video
 
 ifeq ($(platform),)
-platform = unix
-ifeq ($(shell uname -a),)
-   platform = win
-else ifneq ($(findstring MINGW,$(shell uname -a)),)
-   platform = win
-else ifneq ($(findstring Darwin,$(shell uname -a)),)
-   platform = osx
-   arch = intel
-ifeq ($(shell uname -p),powerpc)
-   arch = ppc
-endif
-else ifneq ($(findstring win,$(shell uname -a)),)
-   platform = win
-endif
+   platform = unix
+   ifeq ($(shell uname -s),)
+      platform = win
+   else ifneq ($(findstring Darwin,$(shell uname -s)),)
+      platform = osx
+      arch     = intel
+      ifeq ($(shell uname -p),powerpc)
+         arch = ppc
+      endif
+   else ifneq ($(findstring MINGW,$(shell uname -s)),)
+      platform = win
+   endif
 endif
 
 ifeq ($(platform),gcc)

--- a/libretro-common/audio/dsp_filters/Makefile
+++ b/libretro-common/audio/dsp_filters/Makefile
@@ -8,17 +8,15 @@ INSTALLDIR  := $(PREFIX)/lib/retroarch/filters/audio
 
 ifeq ($(platform),)
    platform = unix
-   ifeq ($(shell uname -a),)
+   ifeq ($(shell uname -s),)
       platform = win
-   else ifneq ($(findstring MINGW,$(shell uname -a)),)
-      platform = win
-   else ifneq ($(findstring Darwin,$(shell uname -a)),)
+   else ifneq ($(findstring Darwin,$(shell uname -s)),)
       platform = osx
-      arch = intel
+      arch     = intel
       ifeq ($(shell uname -p),powerpc)
          arch = ppc
       endif
-   else ifneq ($(findstring win,$(shell uname -a)),)
+   else ifneq ($(findstring MINGW,$(shell uname -s)),)
       platform = win
    endif
 endif


### PR DESCRIPTION
##  Description

This updates the platform detection in `gfx/video_filters/Makefile` and `libretro-common/audio/dsp_filters/Makefile` with newer versions that do not use `uname -a`.

## Related Issues

`uname -a` will print everything including the user's hostname which can erroneously match one of the platform strings.

This was reported on the Slackware forum where these Makefiles thought the user was on windows.

## Reviewers

@twinaphex Just a heads up that many (Not all) cores also have this issue.