### PR TITLE
qb: Don't set cc_works in test_compiler.

### DIFF
--- a/qb/qb.comp.sh
+++ b/qb/qb.comp.sh
@@ -33,7 +33,6 @@ test_compiler ()
 	$(printf %s "$1") -o "$TEMP_EXE" "$2" >/dev/null 2>&1 || return 1
 
 	compiler="${compiler# }"
-	cc_works=1
 	return 0
 }
 


### PR DESCRIPTION
## Description

This should not be set in the `test_compiler` function and is already set correctly based on the return status of the function.

## Related Issues

In practice this is not a problem, but it was setting `cc_works=1` when the `c++` compiler test succeeded which is wrong.

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/10000
