### PR TITLE
qb: Improve the gnu99 compiler check.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,16 @@ ifneq ($(findstring Win32,$(OS)),)
    LDFLAGS += -mwindows
 endif
 
+ifneq ($(CXX_BUILD), 1)
+   ifneq ($(C89_BUILD),)
+      CFLAGS += -std=c89 -ansi -pedantic -Werror=pedantic -Wno-long-long
+   else ifeq ($(HAVE_C99), 1)
+      CFLAGS += $(C99_CFLAGS)
+   endif
+
+   CFLAGS += -D_GNU_SOURCE
+endif
+
 DEF_FLAGS += -Wall $(INCLUDE_DIRS) -I. -Ideps -Ideps/stb
 
 CFLAGS += $(DEF_FLAGS)
@@ -125,20 +135,6 @@ ifeq ($(HAVE_CXX), 1)
    endif
 else
    LINK = $(CC)
-endif
-
-ifneq ($(CXX_BUILD), 1)
-   ifneq ($(GNU90_BUILD), 1)
-      ifneq ($(findstring icc,$(CC)),)
-         CFLAGS += -std=c99 -D_GNU_SOURCE
-      else
-         CFLAGS += -std=gnu99 -D_GNU_SOURCE
-      endif
-   endif
-
-   ifneq ($(C89_BUILD),)
-      CFLAGS += -std=c89 -ansi -pedantic -Werror=pedantic -Wno-long-long
-   endif
 endif
 
 ifeq ($(NOUNUSED), yes)

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -4,7 +4,13 @@
 # Only needed when check_enabled ($2), check_platform, check_lib, check_pkgconf,
 # check_header, check_macro and check_switch are not used.
 
-check_switch '' C99 -std=gnu99 "Cannot find C99 compatible compiler."
+check_switch '' C99 -std=gnu99 ''
+
+if [ "$HAVE_C99" = 'no' ]; then
+   HAVE_C99='auto'
+   check_switch '' C99 -std=c99 'Cannot find a C99 compatible compiler.'
+fi
+
 check_switch cxx CXX11 -std=c++11 ''
 check_switch '' NOUNUSED -Wno-unused-result ''
 add_define MAKEFILE NOUNUSED "$HAVE_NOUNUSED"


### PR DESCRIPTION
## Description

This attempts to improve the `gnu99/c99` compiler check.

## Reviewers

@twinaphex Please read this to make sure you agree with this logic.

Currently RetroArch checks if `-std=gnu99` works or will error during configure when it doesn't. Then in the `Makefile` it will use `-std=gnu99` unless the compiler is `icc` where it will use `-std=c99`. 

With this PR RetroArch will check if `-std=gnu99` works and then will check `-std=c99` if the previous check has failed. If both checks fail it will then error during configure. This allows removing the compiler check in the `Makefile` which will presumably always have the working compiler flag.

This will also remove the `GNU90_BUILD` check in the `Makefile`which is entirely unused elsewhere and doesn't seem all that useful.

First does anyone actually use `icc` to compile RetroArch? Both `gcc` and `clang` are much better choices today.

Second should we be using `-std=gnu99` instead of `-std=c99`? Both seem to compile and work without noticeable difference.