### PR TITLE
(cheevos) attempt to fix corrupted User-Agent string

### DIFF
--- a/cheevos-new/cheevos.c
+++ b/cheevos-new/cheevos.c
@@ -210,7 +210,7 @@ static void rcheevos_get_user_agent(char* buffer)
       int major, minor;
       char tmp[64];
 
-      ptr = rcheevos_user_agent_prefix + sprintf(rcheevos_user_agent_prefix, "RetroArch/" PACKAGE_VERSION);
+      ptr = rcheevos_user_agent_prefix + sprintf(rcheevos_user_agent_prefix, "RetroArch/%s", PACKAGE_VERSION);
 
       if (frontend && frontend->get_os)
       {
@@ -2486,8 +2486,6 @@ found:
     *************************************************************************/
    CORO_SUB(RCHEEVOS_HTTP_GET)
 
-      rcheevos_get_user_agent(buffer);
-
       for (coro->k = 0; coro->k < 5; coro->k++)
       {
          if (coro->k != 0)
@@ -2513,6 +2511,7 @@ found:
             continue;
          }
 
+         rcheevos_get_user_agent(buffer);
          net_http_connection_set_user_agent(coro->conn, buffer);
 
          coro->http = net_http_new(coro->conn);


### PR DESCRIPTION
## Description

Moves the initialization of the User-Agent string so it occurs for each loop of the iteration. As it's being stored in a stack variable, CORO jumps could result in it being uninitialized or overwritten in between iterations.

## Related Issues

Presumptive fix for captured User-Agent strings that appear to be corrupt:

```User-Agent: \xD8\xFF\xFF\xFF\x80\xFF\xFF\xFFh/1.8.2 (Android 9.0)```
```User-Agent: \x01```
```User-Agent: x\xE5c\xABt```

## Related Pull Requests

n/a

## Reviewers

[If possible @mention all the people that should review your pull request]
