### PR TITLE
add task_push_http_transfer_file

### DIFF
--- a/discord/discord.c
+++ b/discord/discord.c
@@ -149,7 +149,7 @@ static bool discord_download_avatar(
    strlcpy(transf->path, buf, sizeof(transf->path));
 
    RARCH_LOG("[discord] downloading avatar from: %s\n", url_encoded);
-   task_push_http_transfer(url_encoded, true, NULL, cb_generic_download, transf);
+   task_push_http_transfer_file(url_encoded, true, NULL, cb_generic_download, transf);
 
    return false;
 }

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -3991,7 +3991,7 @@ static int generic_action_ok_network(const char *path,
    strlcpy(transf->path, url_path, sizeof(transf->path));
 
    net_http_urlencode_full(url_path_encoded, url_path, sizeof(url_path_encoded));
-   task_push_http_transfer(url_path_encoded, suppress_msg, url_label, callback, transf);
+   task_push_http_transfer_file(url_path_encoded, suppress_msg, url_label, callback, transf);
 
    return generic_action_ok_displaylist_push(path, NULL,
          label, type, idx, entry_idx, type_id2);
@@ -4293,7 +4293,7 @@ static int action_ok_download_generic(const char *path,
    else
       net_http_urlencode_full(s3, s2, sizeof(s3));
 
-   task_push_http_transfer(s3, suppress_msg, msg_hash_to_str(enum_idx), cb, transf);
+   task_push_http_transfer_file(s3, suppress_msg, msg_hash_to_str(enum_idx), cb, transf);
 #endif
    return 0;
 }

--- a/menu/menu_networking.c
+++ b/menu/menu_networking.c
@@ -241,7 +241,7 @@ finish:
       strlcpy(transf->path, parent_dir, sizeof(transf->path));
 
       net_http_urlencode_full(parent_dir_encoded, parent_dir, PATH_MAX_LENGTH * sizeof(char));
-      task_push_http_transfer(parent_dir_encoded, true,
+      task_push_http_transfer_file(parent_dir_encoded, true,
             "index_dirs", cb_net_generic_subdir, transf);
 
       free(parent_dir);

--- a/tasks/task_core_updater.c
+++ b/tasks/task_core_updater.c
@@ -260,7 +260,7 @@ static void task_core_updater_get_list_handler(retro_task_t *task)
             transf->user_data = (void*)list_handle;
 
             /* Push HTTP transfer task */
-            list_handle->http_task = (retro_task_t*)task_push_http_transfer(
+            list_handle->http_task = (retro_task_t*)task_push_http_transfer_file(
                   buildbot_url, true, NULL,
                   cb_http_task_core_updater_get_list, transf);
 
@@ -288,7 +288,7 @@ static void task_core_updater_get_list_handler(retro_task_t *task)
                      task, task_get_progress(list_handle->http_task));
             }
 
-            /* Wait for task_push_http_transfer()
+            /* Wait for task_push_http_transfer_file()
              * callback to trigger */
             if (list_handle->http_task_complete)
                list_handle->status = CORE_UPDATER_LIST_END;
@@ -626,7 +626,7 @@ static void task_core_updater_download_handler(retro_task_t *task)
             transf->user_data = (void*)download_handle;
 
             /* Push HTTP transfer task */
-            download_handle->http_task = (retro_task_t*)task_push_http_transfer(
+            download_handle->http_task = (retro_task_t*)task_push_http_transfer_file(
                   download_handle->remote_core_path, true, NULL,
                   cb_http_task_core_updater_download, transf);
 
@@ -673,7 +673,7 @@ static void task_core_updater_download_handler(retro_task_t *task)
                }
             }
 
-            /* Wait for task_push_http_transfer()
+            /* Wait for task_push_http_transfer_file()
              * callback to trigger */
             if (download_handle->http_task_complete)
                download_handle->status = CORE_UPDATER_DOWNLOAD_WAIT_DECOMPRESS;

--- a/tasks/task_file_transfer.h
+++ b/tasks/task_file_transfer.h
@@ -77,6 +77,9 @@ typedef struct
    void *user_data;
 } file_transfer_t;
 
+void* task_push_http_transfer_file(const char* url, bool mute, const char* type,
+      retro_task_callback_t cb, file_transfer_t* transfer_data);
+
 RETRO_END_DECLS
 
 #endif

--- a/tasks/task_file_transfer.h
+++ b/tasks/task_file_transfer.h
@@ -21,6 +21,7 @@
 #include <retro_miscellaneous.h>
 
 #include <queues/message_queue.h>
+#include <queues/task_queue.h>
 
 #include "../msg_hash.h"
 

--- a/tasks/task_pl_thumbnail_download.c
+++ b/tasks/task_pl_thumbnail_download.c
@@ -269,7 +269,7 @@ static void download_pl_thumbnail(pl_thumb_handle_t *pl_thumb)
          /* Note: We don't actually care if this fails since that
           * just means the file is missing from the server, so it's
           * not something we can handle here... */
-         pl_thumb->http_task = (retro_task_t*)task_push_http_transfer(
+         pl_thumb->http_task = (retro_task_t*)task_push_http_transfer_file(
                url, true, NULL, cb_http_task_download_pl_thumbnail, transf);
 
          /* ...if it does fail, however, we can immediately
@@ -411,7 +411,7 @@ static void task_pl_thumbnail_download_handler(retro_task_t *task)
             if (!pl_thumb->http_task)
                pl_thumb->http_task_complete = true;
             
-            /* > Wait for task_push_http_transfer()
+            /* > Wait for task_push_http_transfer_file()
              *   callback to trigger */
             if (pl_thumb->http_task_complete)
                pl_thumb->http_task = NULL;
@@ -726,7 +726,7 @@ static void task_pl_entry_thumbnail_download_handler(retro_task_t *task)
             if (!pl_thumb->http_task)
                pl_thumb->http_task_complete = true;
             
-            /* > Wait for task_push_http_transfer()
+            /* > Wait for task_push_http_transfer_file()
              *   callback to trigger */
             if (pl_thumb->http_task_complete)
                pl_thumb->http_task = NULL;


### PR DESCRIPTION
## Description

Decouples the dependency on `file_transfer_t` that is baked into `task_push_http_transfer_generic` and moves it to new function `task_push_http_transfer_file`. Updates all calls to `task_push_http_transfer` that pass a `file_transfer_t` to call `task_push_http_transfer_file` instead. The calls to `task_push_http_post_transfer` (which is the other entry point to `task_push_http_transfer_generic`) did not pass a `file_transfer_t` and weren't updated.

Dependency originally added here: https://github.com/libretro/RetroArch/commit/c52fdc469fab8a30fd12c7947ea80d393fecb3b5#diff-1fa77422340388277921587608f6fe20R301

Discovered while debugging an issue in the achievement code, which calls `task_push_http_transfer_generic` with its own `user_data` (that's not a `file_transfer_t`). The dependent code attempts to read a text string within the `file_transfer_t`, but finds raw binary data instead. This could potentially end up in a out-of-bounds read, but normally just results in garbage characters being appended to the `task->title`. Since the achievement request is "muted", the title doesn't seem to be used anywhere and _probably_ wasn't causing any issues.

Tested downloading/updating cores, downloading assets/databases/thumbnails. Messages appear as expected. Did not test downloading discord avatar (not sure how, but its muted anyway).

Achievement use case still calls original function with its custom `user_data` and no longer generates the (unused) garbage string.

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

[If possible @mention all the people that should review your pull request]
