### PR TITLE
fix mouse capture hotkey not working

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -14983,12 +14983,6 @@ static unsigned menu_event(
          ret = MENU_ACTION_TOGGLE;
    }
 
-   if (menu_keyboard_key_state[RETROK_F11])
-   {
-      command_event(CMD_EVENT_GRAB_MOUSE_TOGGLE, NULL);
-      menu_keyboard_key_state[RETROK_F11] = 0;
-   }
-
    /* Get pointer (mouse + touchscreen) input */
 
    /* > If pointer input is disabled, do nothing */


### PR DESCRIPTION
There's a normal binding for this set in your configs/`grab_mouse_toggle`, but there's a second place where it's hardcoded to check the F11 key. Because F11 is the default key, both of these codepaths will run which immediately captures and then uncaptures the mouse cursor, effectively breaking it.

Tested and this fixes the behavior on Linux and Emscripten