### PR TITLE
prevent divide by zero error when calculating http transfer percentage

### DIFF
--- a/tasks/task_http.c
+++ b/tasks/task_http.c
@@ -126,7 +126,14 @@ static int task_http_iterate_transfer(retro_task_t *task)
 
    if (!net_http_update(http->handle, &pos, &tot))
    {
-      task_set_progress(task, (tot == 0) ? -1 : (signed)pos / (tot / 100));
+      if (tot == 0)
+         task_set_progress(task, -1);
+      else if (pos < (((size_t)-1) / 100))
+         /* prefer multiply then divide for more accurate results */
+         task_set_progress(task, (signed)(pos * 100 / tot));
+      else
+         /* but invert the logic if it would cause an overflow */
+         task_set_progress(task, MAX((signed)pos / (tot / 100), 100));
       return -1;
    }
 


### PR DESCRIPTION
## Description

Alternate implementation of https://github.com/libretro/RetroArch/commit/ccbb3f096031ca9f11f2ce56e96a5cdd1cf4347d

That referenced commit inverts the math to avoid an overflow when calculating percentage completed, but introduces a divide by zero for very small payloads. If `tot` was more than 0, but less than 100, the integer division of `tot/100` would result in 0, so `pos/(tot/100)` would be `pos/0`, which cannot be computed.

The implementation provided in this PR checks to see if `pos * 100` would overflow a `size_t` and only does the inverted division if an overflow would occur. Additionally, the multiplicative solution is preferred for accuracy, particularly on smaller payloads.

For example, if the payload was 190 bytes, and we had received 128 of them, we'd expect the progress to be 67% (`128 * 100 / 190`), but with the inverted logic and integer math, we get 128% (`128 / (190 / 100)` -> (`128 / 1`)).

## Related Issues

Probably #9533. It was reported in 1.7.7, which is where the referenced change first appeared, and the award achievement response payload is only about 60 bytes.

## Related Pull Requests

n/a

## Reviewers

@twinaphex 
