### PR TITLE
Fix crash on Pixelbook

### DIFF
--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -673,7 +673,7 @@ static INLINE void android_mouse_calculate_deltas(android_input_t *android,
 {
    /* Adjust mouse speed based on ratio
     * between core resolution and system resolution */
-   float x, y;
+   float x = 0, y = 0;
    float                        x_scale = 1;
    float                        y_scale = 1;
    struct retro_system_av_info *av_info = video_viewport_get_system_av_info();
@@ -687,15 +687,18 @@ static INLINE void android_mouse_calculate_deltas(android_input_t *android,
    }
 
    /* This axis is only available on Android Nougat and on Android devices with NVIDIA extensions */
-   x = AMotionEvent_getAxisValue(event,AMOTION_EVENT_AXIS_RELATIVE_X, motion_ptr);
-   y = AMotionEvent_getAxisValue(event,AMOTION_EVENT_AXIS_RELATIVE_Y, motion_ptr);
+   if (AMotionEvent_getAxisValue)
+   {
+     x = AMotionEvent_getAxisValue(event,AMOTION_EVENT_AXIS_RELATIVE_X, motion_ptr);
+     y = AMotionEvent_getAxisValue(event,AMOTION_EVENT_AXIS_RELATIVE_Y, motion_ptr);
+   }
 
    /* If AXIS_RELATIVE had 0 values it might be because we're not running Android Nougat or on a device
     * with NVIDIA extension, so re-calculate deltas based on AXIS_X and AXIS_Y. This has limitations
     * compared to AXIS_RELATIVE because once the Android mouse cursor hits the edge of the screen it is
     * not possible to move the in-game mouse any further in that direction.
     */
-   if (!x && !y)
+   if (!x && !y && AMotionEvent_getX && AMotionEvent_getX)
    {
       x = (AMotionEvent_getX(event, motion_ptr) - android->mouse_x_prev);
       y = (AMotionEvent_getY(event, motion_ptr) - android->mouse_y_prev);


### PR DESCRIPTION
AMotionEvent_getAxisValue is a weak symbol and we need
to check for its presence before calling it.
