### PR TITLE
(Disk Control) Add disk labels to 'disk inserted' notifications

### DIFF
--- a/disk_control_interface.c
+++ b/disk_control_interface.c
@@ -243,6 +243,61 @@ error:
 /* Setters */
 /***********/
 
+/* Generates an appropriate log/notification message
+ * for a disk index change event */
+static void disk_control_get_index_set_msg(
+      disk_control_interface_t *disk_control,
+      unsigned num_images, unsigned index, bool success,
+      unsigned *msg_duration, char *msg, size_t len)
+{
+   bool has_label = false;
+   char image_label[PATH_MAX_LENGTH];
+
+   image_label[0] = '\0';
+
+   if (!disk_control || !msg_duration || !msg || len < 1)
+      return;
+
+   /* Attempt to get image label */
+   if (index < num_images)
+   {
+      disk_control_get_image_label(
+            disk_control, index, image_label, sizeof(image_label));
+      has_label = !string_is_empty(image_label);
+   }
+
+   /* Get message duration
+    * > Default is 60
+    * > If a label is shown, then increase duration by 50%
+    * > For errors, duration is always 180 */
+   *msg_duration = success ?
+         (has_label ? 90 : 60) :
+         180;
+
+   /* Check whether image was inserted or removed */
+   if (index < num_images)
+   {
+      if (has_label)
+         snprintf(
+               msg, len, "%s: %u/%u - %s",
+               success ? msg_hash_to_str(MSG_SETTING_DISK_IN_TRAY) :
+                     msg_hash_to_str(MSG_FAILED_TO_SET_DISK),
+               index + 1, num_images, image_label);
+      else
+         snprintf(
+               msg, len, "%s: %u/%u",
+               success ? msg_hash_to_str(MSG_SETTING_DISK_IN_TRAY) :
+                     msg_hash_to_str(MSG_FAILED_TO_SET_DISK),
+               index + 1, num_images);
+   }
+   else
+      strlcpy(
+            msg,
+            success ? msg_hash_to_str(MSG_REMOVED_DISK_FROM_TRAY) :
+                  msg_hash_to_str(MSG_FAILED_TO_REMOVE_DISK_FROM_TRAY),
+            len);
+}
+
 /* Sets the eject state of the virtual disk tray */
 bool disk_control_set_eject_state(
       disk_control_interface_t *disk_control,
@@ -301,9 +356,10 @@ bool disk_control_set_index(
       disk_control_interface_t *disk_control,
       unsigned index, bool verbose)
 {
-   bool error          = false;
-   unsigned num_images = 0;
-   char msg[128];
+   bool error            = false;
+   unsigned num_images   = 0;
+   unsigned msg_duration = 0;
+   char msg[PATH_MAX_LENGTH];
 
    msg[0] = '\0';
 
@@ -319,37 +375,18 @@ bool disk_control_set_index(
    if (!disk_control->cb.get_eject_state())
       return false;
 
+   /* Get current number of disk images */
    num_images = disk_control->cb.get_num_images();
 
-   if (disk_control->cb.set_image_index(index))
-   {
-      if (index < num_images)
-         snprintf(
-               msg, sizeof(msg), "%s: %u/%u",
-               msg_hash_to_str(MSG_SETTING_DISK_IN_TRAY),
-               index + 1, num_images);
-      else
-         strlcpy(
-               msg,
-               msg_hash_to_str(MSG_REMOVED_DISK_FROM_TRAY),
-               sizeof(msg));
-   }
-   else
-   {
-      error = true;
+   /* Perform 'set index' action */
+   error = !disk_control->cb.set_image_index(index);
 
-      if (index < num_images)
-         snprintf(
-               msg, sizeof(msg), "%s %u/%u",
-               msg_hash_to_str(MSG_FAILED_TO_SET_DISK),
-               index + 1, num_images);
-      else
-         strlcpy(
-               msg,
-               msg_hash_to_str(MSG_FAILED_TO_REMOVE_DISK_FROM_TRAY),
-               sizeof(msg));
-   }
+   /* Get log/notification message */
+   disk_control_get_index_set_msg(
+         disk_control, num_images, index, !error,
+         &msg_duration, msg, sizeof(msg));
 
+   /* Output log/notification message */
    if (!string_is_empty(msg))
    {
       if (error)
@@ -360,7 +397,7 @@ bool disk_control_set_index(
       /* Errors should always be displayed */
       if (verbose || error)
          runloop_msg_queue_push(
-               msg, 1, error ? 180 : 60,
+               msg, 1, msg_duration,
                true, NULL,
                MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
    }
@@ -724,20 +761,20 @@ bool disk_control_verify_initial_index(disk_control_interface_t *disk_control)
     * is available */
    if (disk_control->initial_num_images > 1)
    {
-      char msg[128];
+      unsigned msg_duration = 0;
+      char msg[PATH_MAX_LENGTH];
 
       msg[0] = '\0';
 
-      snprintf(
-            msg, sizeof(msg), "%s: %u/%u",
-            msg_hash_to_str(MSG_SETTING_DISK_IN_TRAY),
-            image_index + 1, disk_control->initial_num_images);
+      disk_control_get_index_set_msg(
+            disk_control, disk_control->initial_num_images, image_index, true,
+            &msg_duration, msg, sizeof(msg));
 
       RARCH_LOG("%s\n", msg);
 
       runloop_msg_queue_push(
             msg,
-            0, 60,
+            0, msg_duration,
             true, NULL,
             MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
    }


### PR DESCRIPTION
## Description

This PR very simply adds disk labels to disk swap notification messages. This is for the benefit of users who change disks via hotkeys (at present, labels can only be viewed via the `Current Disk Index` drop-down list of the `Disk Control` menu - so users who forego the menu are out of luck). The notifications look something like this:

![Screenshot_2020-02-04_14-49-07](https://user-images.githubusercontent.com/38211560/73761422-beb52400-4766-11ea-982f-ebfeb60f51b3.png)

![Screenshot_2020-02-04_14-47-54](https://user-images.githubusercontent.com/38211560/73761435-c2e14180-4766-11ea-84bb-528e7cc07f82.png)

![Screenshot_2020-02-04_13-48-03](https://user-images.githubusercontent.com/38211560/73761456-c8d72280-4766-11ea-84c7-1f579c234029.png)
