### PR TITLE
Fix crash on seeking when using HW decoding in some cases.

### DIFF
--- a/cores/libretro-ffmpeg/ffmpeg_core.c
+++ b/cores/libretro-ffmpeg/ffmpeg_core.c
@@ -497,9 +497,6 @@ static void seek_frame(int seek_frames)
    }
    audio_frames = frame_cnt * media.sample_rate / media.interpolate_fps;
 
-   tpool_wait(tpool);
-   video_buffer_clear(video_buffer);
-
    if (audio_decode_fifo)
       fifo_clear(audio_decode_fifo);
    scond_signal(fifo_decode_cond);
@@ -512,7 +509,6 @@ static void seek_frame(int seek_frames)
    }
 
    slock_unlock(fifo_lock);
-
 }
 
 void CORE_PREFIX(retro_run)(void)
@@ -1363,7 +1359,8 @@ static void decode_video(AVCodecContext *ctx, AVPacket *pkt, size_t frame_size)
    {
       if (main_sleeping)
       {
-         log_cb(RETRO_LOG_ERROR, "[FFMPEG] Thread: Video deadlock detected.\n");
+         if (!do_seek)
+            log_cb(RETRO_LOG_ERROR, "[FFMPEG] Thread: Video deadlock detected.\n");
          tpool_wait(tpool);
          video_buffer_clear(video_buffer);
          return;


### PR DESCRIPTION
This fix makes sure that we don't de-allocate the video buffer while the decoding thread is still working. We also don't throw a misleading error when the video decoding thread flushed the buffers on seeking.

@twinaphex please test and merge if this fixes your issue.