### PR TITLE
(Ozone) Add DPI-based scaling

### DIFF
--- a/gfx/drivers_context/switch_ctx.c
+++ b/gfx/drivers_context/switch_ctx.c
@@ -303,7 +303,42 @@ bool switch_ctx_get_metrics(void *data,
    switch (type)
    {
       case DISPLAY_METRIC_DPI:
-         *value = 236.87; /* FIXME: Don't hardcode this value */
+         /* FIXME: DPI values should be obtained by querying
+          * the hardware - these hard-coded values are a kludge */
+         switch (appletGetOperationMode())
+         {
+            case AppletOperationMode_Docked:
+               /* Docked mode
+                * > Resolution:  1920x1080
+                * > Screen Size: 39 inch
+                *   - Have to make an assumption here. We select
+                *     a 'default' screen size of 39 inches which
+                *     corresponds to the optimal diagonal screen
+                *     size for HD television as reported in:
+                *       "HDTV displays: subjective effects of scanning
+                *       standards and domestic picture sizes,"
+                *       N. E. Tanton and M. A. Stone,
+                *       BBC Research Department Report 1989/09,
+                *       January 1989
+                *     This agrees with the median recorded TV
+                *     size in:
+                *       "A Survey of UK Television Viewing Conditions,"
+                *       Katy C. Noland and Louise H. Truong,
+                *       BBC R&D White Paper WHP 287 January 2015
+                * > DPI:         sqrt((1920 * 1920) + (1080 * 1080)) / 39
+                */
+               *value = 56.48480f;
+               break;
+            case AppletOperationMode_Handheld:
+            default:
+               /* Handheld mode
+                * > Resolution:  1280x720
+                * > Screen size: 6.2 inch
+                * > DPI:         sqrt((1280 * 1280) + (720 * 720)) / 6.2
+                */
+               *value = 236.8717f;
+               break;
+         }
          return true;
       default:
          break;

--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -150,6 +150,10 @@ static void *ozone_init(void **userdata, bool video_is_threaded)
 
    *userdata = ozone;
 
+   ozone->last_width        = width;
+   ozone->last_height       = height;
+   ozone->last_scale_factor = menu_display_get_dpi_scale(width, height);
+
    ozone->selection_buf_old = (file_list_t*)calloc(1, sizeof(file_list_t));
 
    ozone->draw_sidebar              = true;
@@ -444,101 +448,204 @@ static void ozone_refresh_thumbnail_image(void *data, unsigned i)
       ozone_update_thumbnail_image(ozone);
 }
 
-/* TODO: Scale text */
-static void ozone_context_reset(void *data, bool is_threaded)
+/* Determines the size of all menu elements */
+static void ozone_set_layout(ozone_handle_t *ozone, bool is_threaded)
 {
-   /* Fonts init */
-   unsigned i;
-   unsigned size;
+   int font_size;
+   float scale_factor;
    char font_path[PATH_MAX_LENGTH];
 
-   float scale = 1; /*TODO: compute that from screen resolution and dpi */
+   font_path[0] = '\0';
 
+   if (!ozone)
+      return;
+
+   /* Due to the 'multi-column' menu layout
+    * (i.e. sidebars + entries), actual scale factor
+    * must be capped to a sensible upper limit
+    * > Normal left hand sidebar width must be no
+    *   more than 1/3 of the total screen width,
+    *   otherwise menu becomes unusable */
+   ozone->capped_scale_factor =
+         (SIDEBAR_WIDTH * ozone->last_scale_factor) > (ozone->last_width * 0.3333333f) ?
+               ((float)ozone->last_width * 0.3333333f / (float)SIDEBAR_WIDTH) : ozone->last_scale_factor;
+   scale_factor = ozone->capped_scale_factor;
+
+   /* Calculate dimensions */
+   ozone->dimensions.header_height = HEADER_HEIGHT * scale_factor;
+   ozone->dimensions.footer_height = FOOTER_HEIGHT * scale_factor;
+
+   ozone->dimensions.entry_padding_horizontal_half = ENTRY_PADDING_HORIZONTAL_HALF * scale_factor;
+   ozone->dimensions.entry_padding_horizontal_full = ENTRY_PADDING_HORIZONTAL_FULL * scale_factor;
+   ozone->dimensions.entry_padding_vertical        = ENTRY_PADDING_VERTICAL * scale_factor;
+   ozone->dimensions.entry_height                  = ENTRY_HEIGHT * scale_factor;
+   ozone->dimensions.entry_spacing                 = ENTRY_SPACING * scale_factor;
+   ozone->dimensions.entry_icon_size               = ENTRY_ICON_SIZE * scale_factor;
+   ozone->dimensions.entry_icon_padding            = ENTRY_ICON_PADDING * scale_factor;
+
+   ozone->dimensions.sidebar_entry_height           = SIDEBAR_ENTRY_HEIGHT * scale_factor;
+   ozone->dimensions.sidebar_padding_horizontal     = SIDEBAR_X_PADDING * scale_factor;
+   ozone->dimensions.sidebar_padding_vertical       = SIDEBAR_Y_PADDING * scale_factor;
+   ozone->dimensions.sidebar_entry_padding_vertical = SIDEBAR_ENTRY_Y_PADDING * scale_factor;
+   ozone->dimensions.sidebar_entry_icon_size        = SIDEBAR_ENTRY_ICON_SIZE * scale_factor;
+   ozone->dimensions.sidebar_entry_icon_padding     = SIDEBAR_ENTRY_ICON_PADDING * scale_factor;
+   ozone->dimensions.sidebar_gradient_height        = SIDEBAR_GRADIENT_HEIGHT * scale_factor;
+
+   ozone->dimensions.sidebar_width_normal             = SIDEBAR_WIDTH * scale_factor;
+   ozone->dimensions.sidebar_width_collapsed          =
+         ozone->dimensions.sidebar_entry_icon_size +
+         ozone->dimensions.sidebar_entry_icon_padding * 2 +
+         ozone->dimensions.sidebar_padding_horizontal * 2;
+
+   if (ozone->dimensions.sidebar_width == 0)
+      ozone->dimensions.sidebar_width = (float)ozone->dimensions.sidebar_width_normal;
+
+   ozone->dimensions.thumbnail_bar_width =
+         ozone->dimensions.sidebar_width_normal -
+         ozone->dimensions.sidebar_entry_icon_size -
+         ozone->dimensions.sidebar_entry_icon_padding;
+
+   ozone->dimensions.cursor_size = CURSOR_SIZE * scale_factor;
+
+   ozone->dimensions.fullscreen_thumbnail_padding = FULLSCREEN_THUMBNAIL_PADDING * scale_factor;
+
+   ozone->dimensions.spacer_1px = (scale_factor > 1.0f) ? (unsigned)(scale_factor + 0.5f) : 1;
+   ozone->dimensions.spacer_2px = ozone->dimensions.spacer_1px * 2;
+   ozone->dimensions.spacer_3px = (unsigned)((scale_factor * 3.0f) + 0.5f);
+   ozone->dimensions.spacer_5px = (unsigned)((scale_factor * 5.0f) + 0.5f);
+
+   /* Initialise fonts */
+
+   /* > Free existing */
+   if (ozone->fonts.footer)
+   {
+      menu_display_font_free(ozone->fonts.footer);
+      ozone->fonts.footer = NULL;
+   }
+   if (ozone->fonts.entries_label)
+   {
+      menu_display_font_free(ozone->fonts.entries_label);
+      ozone->fonts.entries_label = NULL;
+   }
+   if (ozone->fonts.entries_sublabel)
+   {
+      menu_display_font_free(ozone->fonts.entries_sublabel);
+      ozone->fonts.entries_sublabel = NULL;
+   }
+   if (ozone->fonts.time)
+   {
+      menu_display_font_free(ozone->fonts.time);
+      ozone->fonts.time = NULL;
+   }
+   if (ozone->fonts.sidebar)
+   {
+      menu_display_font_free(ozone->fonts.sidebar);
+      ozone->fonts.sidebar = NULL;
+   }
+   if (ozone->fonts.title)
+   {
+      menu_display_font_free(ozone->fonts.title);
+      ozone->fonts.title = NULL;
+   }
+
+   /* > Cache 'naive' font heights */
+   ozone->title_font_glyph_height    = FONT_SIZE_TITLE * scale_factor;
+   ozone->entry_font_glyph_height    = FONT_SIZE_ENTRIES_LABEL * scale_factor;
+   ozone->sublabel_font_glyph_height = FONT_SIZE_ENTRIES_SUBLABEL * scale_factor;
+   ozone->footer_font_glyph_height   = FONT_SIZE_FOOTER * scale_factor;
+   ozone->sidebar_font_glyph_height  = FONT_SIZE_SIDEBAR * scale_factor;
+   ozone->time_font_glyph_height     = FONT_SIZE_TIME * scale_factor;
+
+   /* > Create 'bold' font objects */
+   fill_pathname_join(font_path, ozone->assets_path, "bold.ttf", sizeof(font_path));
+   ozone->fonts.title = menu_display_font_file(font_path, ozone->title_font_glyph_height, is_threaded);
+
+   /* > Create 'regular' font objects */
+   fill_pathname_join(font_path, ozone->assets_path, "regular.ttf", sizeof(font_path));
+   ozone->fonts.entries_label    = menu_display_font_file(font_path, ozone->entry_font_glyph_height, is_threaded);
+   ozone->fonts.entries_sublabel = menu_display_font_file(font_path, ozone->sublabel_font_glyph_height, is_threaded);
+   ozone->fonts.footer           = menu_display_font_file(font_path, ozone->footer_font_glyph_height, is_threaded);
+   ozone->fonts.sidebar          = menu_display_font_file(font_path, ozone->sidebar_font_glyph_height, is_threaded);
+   ozone->fonts.time             = menu_display_font_file(font_path, ozone->time_font_glyph_height, is_threaded);
+
+   /* > Check for missing assets */
+      if (!ozone->fonts.title            ||
+          !ozone->fonts.entries_label    ||
+          !ozone->fonts.entries_sublabel ||
+          !ozone->fonts.footer           ||
+          !ozone->fonts.sidebar          ||
+          !ozone->fonts.time)
+         ozone->has_all_assets = false;
+
+   /* > Cache 'naive' font widths */
+   ozone->title_font_glyph_width    = ozone->title_font_glyph_height * 3.0f/4.0f;
+   ozone->entry_font_glyph_width    = ozone->entry_font_glyph_height * 3.0f/4.0f;
+   ozone->sublabel_font_glyph_width = ozone->sublabel_font_glyph_height * 3.0f/4.0f;
+   ozone->footer_font_glyph_width   = ozone->footer_font_glyph_height * 3.0f/4.0f;
+   ozone->sidebar_font_glyph_width  = ozone->sidebar_font_glyph_height * 3.0f/4.0f;
+   ozone->time_font_glyph_width     = ozone->time_font_glyph_height * 3.0f/4.0f;
+
+   /* > Determine more realistic font widths */
+   font_size = font_driver_get_message_width(ozone->fonts.title, "a", 1, 1);
+   if (font_size > 0)
+      ozone->title_font_glyph_width = (unsigned)font_size;
+   font_size = font_driver_get_message_width(ozone->fonts.entries_label, "a", 1, 1);
+   if (font_size > 0)
+      ozone->entry_font_glyph_width = (unsigned)font_size;
+   font_size = font_driver_get_message_width(ozone->fonts.entries_sublabel, "a", 1, 1);
+   if (font_size > 0)
+      ozone->sublabel_font_glyph_width = (unsigned)font_size;
+   font_size = font_driver_get_message_width(ozone->fonts.footer, "a", 1, 1);
+   if (font_size > 0)
+      ozone->footer_font_glyph_width = (unsigned)font_size;
+   font_size = font_driver_get_message_width(ozone->fonts.sidebar, "a", 1, 1);
+   if (font_size > 0)
+      ozone->sidebar_font_glyph_width = (unsigned)font_size;
+   font_size = font_driver_get_message_width(ozone->fonts.time, "a", 1, 1);
+   if (font_size > 0)
+      ozone->time_font_glyph_width = (unsigned)font_size;
+
+   /* > Get actual font heights */
+   font_size = font_driver_get_line_height(ozone->fonts.title, 1.0f);
+   if (font_size > 0)
+      ozone->title_font_glyph_height = (unsigned)font_size;
+   font_size = font_driver_get_line_height(ozone->fonts.entries_label, 1.0f);
+   if (font_size > 0)
+      ozone->entry_font_glyph_height = (unsigned)font_size;
+   font_size = font_driver_get_line_height(ozone->fonts.entries_sublabel, 1.0f);
+   if (font_size > 0)
+      ozone->sublabel_font_glyph_height = (unsigned)font_size;
+   font_size = font_driver_get_line_height(ozone->fonts.footer, 1.0f);
+   if (font_size > 0)
+      ozone->footer_font_glyph_height = (unsigned)font_size;
+   font_size = font_driver_get_line_height(ozone->fonts.sidebar, 1.0f);
+   if (font_size > 0)
+      ozone->sidebar_font_glyph_height = (unsigned)font_size;
+   font_size = font_driver_get_line_height(ozone->fonts.time, 1.0f);
+   if (font_size > 0)
+      ozone->time_font_glyph_height = (unsigned)font_size;
+
+   /* Multiple sidebar parameters are set via animations
+    * > ozone_refresh_sidebars() cancels any existing
+    *   animations and 'force updates' the affected
+    *   variables with newly scaled values */
+   ozone_refresh_sidebars(ozone, ozone->last_height);
+
+   /* Entry dimensions must be recalculated after
+    * updating menu layout */
+   ozone->need_compute = true;
+}
+
+static void ozone_context_reset(void *data, bool is_threaded)
+{
+   unsigned i;
    ozone_handle_t *ozone = (ozone_handle_t*) data;
 
    if (ozone)
    {
       ozone->has_all_assets = true;
 
-      fill_pathname_join(font_path, ozone->assets_path, "regular.ttf", sizeof(font_path));
-      ozone->fonts.footer           = menu_display_font_file(font_path, FONT_SIZE_FOOTER, is_threaded);
-      ozone->fonts.entries_label    = menu_display_font_file(font_path, FONT_SIZE_ENTRIES_LABEL, is_threaded);
-      ozone->fonts.entries_sublabel = menu_display_font_file(font_path, FONT_SIZE_ENTRIES_SUBLABEL, is_threaded);
-      ozone->fonts.time             = menu_display_font_file(font_path, FONT_SIZE_TIME, is_threaded);
-      ozone->fonts.sidebar          = menu_display_font_file(font_path, FONT_SIZE_SIDEBAR, is_threaded);
-
-      fill_pathname_join(font_path, ozone->assets_path, "bold.ttf", sizeof(font_path));
-      ozone->fonts.title = menu_display_font_file(font_path, FONT_SIZE_TITLE, is_threaded);
-
-      if (
-         !ozone->fonts.footer           ||
-         !ozone->fonts.entries_label    ||
-         !ozone->fonts.entries_sublabel ||
-         !ozone->fonts.time             ||
-         !ozone->fonts.sidebar          ||
-         !ozone->fonts.title
-      )
-      {
-         ozone->has_all_assets = false;
-      }
-
-      /* Dimensions */
-      ozone->dimensions.header_height = HEADER_HEIGHT * scale;
-      ozone->dimensions.footer_height = FOOTER_HEIGHT * scale;
-
-      ozone->dimensions.entry_padding_horizontal_half = ENTRY_PADDING_HORIZONTAL_HALF * scale;
-      ozone->dimensions.entry_padding_horizontal_full = ENTRY_PADDING_HORIZONTAL_FULL * scale;
-      ozone->dimensions.entry_padding_vertical        = ENTRY_PADDING_VERTICAL * scale;
-      ozone->dimensions.entry_height                  = ENTRY_HEIGHT * scale;
-      ozone->dimensions.entry_spacing                 = ENTRY_SPACING * scale;
-      ozone->dimensions.entry_icon_size               = ENTRY_ICON_SIZE * scale;
-      ozone->dimensions.entry_icon_padding            = ENTRY_ICON_PADDING * scale;
-
-      ozone->dimensions.sidebar_entry_height             = SIDEBAR_ENTRY_HEIGHT * scale;
-      ozone->dimensions.sidebar_padding_horizontal       = SIDEBAR_X_PADDING * scale;
-      ozone->dimensions.sidebar_padding_vertical         = SIDEBAR_Y_PADDING * scale;
-      ozone->dimensions.sidebar_entry_padding_vertical   = SIDEBAR_ENTRY_Y_PADDING * scale;
-      ozone->dimensions.sidebar_entry_icon_size          = SIDEBAR_ENTRY_ICON_SIZE * scale;
-      ozone->dimensions.sidebar_entry_icon_padding       = SIDEBAR_ENTRY_ICON_PADDING * scale;
-
-      ozone->dimensions.sidebar_width_normal             = SIDEBAR_WIDTH * scale;
-      ozone->dimensions.sidebar_width_collapsed          = ozone->dimensions.sidebar_entry_icon_size 
-         + ozone->dimensions.sidebar_entry_icon_padding * 2
-         + ozone->dimensions.sidebar_padding_horizontal * 2;
-
-      if (ozone->dimensions.sidebar_width == 0)
-         ozone->dimensions.sidebar_width                    = (float) ozone->dimensions.sidebar_width_normal;
-
-      ozone->dimensions.thumbnail_bar_width              = ozone->dimensions.sidebar_width_normal 
-         - ozone->dimensions.sidebar_entry_icon_size
-         - ozone->dimensions.sidebar_entry_icon_padding;
-      ozone->dimensions.cursor_size = CURSOR_SIZE * scale;
-
-      ozone->dimensions.fullscreen_thumbnail_padding = FULLSCREEN_THUMBNAIL_PADDING * scale;
-
-      /* Naive font size */
-      ozone->title_font_glyph_width    = FONT_SIZE_TITLE * 3/4;
-      ozone->entry_font_glyph_width    = FONT_SIZE_ENTRIES_LABEL * 3/4;
-      ozone->sublabel_font_glyph_width = FONT_SIZE_ENTRIES_SUBLABEL * 3/4;
-      ozone->sidebar_font_glyph_width  = FONT_SIZE_SIDEBAR * 3/4;
-      ozone->footer_font_glyph_width   = FONT_SIZE_FOOTER * 3/4;
-
-      /* More realistic font size */
-      size = font_driver_get_message_width(ozone->fonts.title, "a", 1, 1);
-      if (size)
-         ozone->title_font_glyph_width = size;
-      size = font_driver_get_message_width(ozone->fonts.entries_label, "a", 1, 1);
-      if (size)
-         ozone->entry_font_glyph_width = size;
-      size = font_driver_get_message_width(ozone->fonts.entries_sublabel, "a", 1, 1);
-      if (size)
-         ozone->sublabel_font_glyph_width = size;
-      size = font_driver_get_message_width(ozone->fonts.sidebar, "a", 1, 1);
-      if (size)
-         ozone->sidebar_font_glyph_width = size;
-      size = font_driver_get_message_width(ozone->fonts.footer, "a", 1, 1);
-      if (size)
-         ozone->footer_font_glyph_width = size;
+      ozone_set_layout(ozone, is_threaded);
 
       /* Textures init */
       for (i = 0; i < OZONE_TEXTURE_LAST; i++)
@@ -984,10 +1091,29 @@ static void ozone_render(void *data,
       bool is_idle)
 {
    size_t i;
+   float scale_factor;
    unsigned end                     = (unsigned)menu_entries_get_size();
    ozone_handle_t *ozone            = (ozone_handle_t*)data;
-   if (!data)
+   if (!ozone)
       return;
+
+   /* Check whether screen dimensions or menu scale
+    * factor have changed */
+   scale_factor = menu_display_get_dpi_scale(width, height);
+
+   if ((scale_factor != ozone->last_scale_factor) ||
+       (width != ozone->last_width) ||
+       (height != ozone->last_height))
+   {
+      ozone->last_scale_factor = scale_factor;
+      ozone->last_width        = width;
+      ozone->last_height       = height;
+
+      /* Note: We don't need a full context reset here
+       * > Just rescale layout, and reset frame time counter */
+      ozone_set_layout(ozone, video_driver_is_threaded());
+      video_driver_monitor_reset();
+   }
 
    if (ozone->need_compute)
    {
@@ -1016,10 +1142,14 @@ static void ozone_draw_header(ozone_handle_t *ozone, video_frame_info_t *video_i
    menu_animation_ctx_ticker_t ticker;
    menu_animation_ctx_ticker_smooth_t ticker_smooth;
    static const char* const ticker_spacer = OZONE_TICKER_SPACER;
-   unsigned ticker_x_offset = 0;
-   settings_t *settings     = config_get_ptr();
-   unsigned timedate_offset = 0;
-   bool use_smooth_ticker   = settings->bools.menu_ticker_smooth;
+   unsigned ticker_x_offset  = 0;
+   settings_t *settings      = config_get_ptr();
+   unsigned timedate_offset  = 0;
+   bool use_smooth_ticker    = settings->bools.menu_ticker_smooth;
+   float scale_factor        = ozone->capped_scale_factor;
+   unsigned logo_icon_size   = 60 * scale_factor;
+   unsigned status_icon_size = 92 * scale_factor;
+   unsigned seperator_margin = 30 * scale_factor;
 
    /* Initial ticker configuration */
    if (use_smooth_ticker)
@@ -1039,14 +1169,14 @@ static void ozone_draw_header(ozone_handle_t *ozone, video_frame_info_t *video_i
    }
 
    /* Separator */
-   menu_display_draw_quad(video_info, 30, ozone->dimensions.header_height, video_info->width - 60, 1, video_info->width, video_info->height, ozone->theme->header_footer_separator);
+   menu_display_draw_quad(video_info, seperator_margin, ozone->dimensions.header_height, video_info->width - seperator_margin * 2, ozone->dimensions.spacer_1px, video_info->width, video_info->height, ozone->theme->header_footer_separator);
 
    /* Title */
    if (use_smooth_ticker)
    {
       ticker_smooth.font        = ozone->fonts.title;
       ticker_smooth.selected    = true;
-      ticker_smooth.field_width = (video_info->width - 128 - 47 - 180);
+      ticker_smooth.field_width = (video_info->width - (128 + 47 + 180) * scale_factor);
       ticker_smooth.src_str     = ozone->show_fullscreen_thumbnails ? ozone->fullscreen_thumbnail_label : ozone->title;
       ticker_smooth.dst_str     = title;
       ticker_smooth.dst_str_len = sizeof(title);
@@ -1056,23 +1186,41 @@ static void ozone_draw_header(ozone_handle_t *ozone, video_frame_info_t *video_i
    else
    {
       ticker.s        = title;
-      ticker.len      = (video_info->width - 128 - 47 - 180) / ozone->title_font_glyph_width;
+      ticker.len      = (video_info->width - (128 + 47 + 180) * scale_factor) / ozone->title_font_glyph_width;
       ticker.str      = ozone->show_fullscreen_thumbnails ? ozone->fullscreen_thumbnail_label : ozone->title;
       ticker.selected = true;
 
       menu_animation_ticker(&ticker);
    }
 
-   ozone_draw_text(video_info, ozone, title, ticker_x_offset + 128, ozone->dimensions.header_height / 2 + FONT_SIZE_TITLE * 3/8, TEXT_ALIGN_LEFT, video_info->width, video_info->height, ozone->fonts.title, ozone->theme->text_rgba, false);
+   ozone_draw_text(video_info, ozone, title, ticker_x_offset + 128 * scale_factor, ozone->dimensions.header_height / 2 + ozone->title_font_glyph_height * 3.0f/10.0f, TEXT_ALIGN_LEFT, video_info->width, video_info->height, ozone->fonts.title, ozone->theme->text_rgba, false);
 
    /* Icon */
    menu_display_blend_begin(video_info);
 #if 0
    if (discord_avatar_is_ready())
-      ozone_draw_icon(video_info, 60, 60, ozone->textures[OZONE_TEXTURE_DISCORD_OWN_AVATAR], 47, 14, video_info->width, video_info->height, 0, 1, ozone->theme->entries_icon);
+      ozone_draw_icon(
+            video_info,
+            logo_icon_size,
+            logo_icon_size,
+            ozone->textures[OZONE_TEXTURE_DISCORD_OWN_AVATAR],
+            47 * scale_factor,
+            14 * scale_factor, /* Where does this come from...? */
+            video_info->width,
+            video_info->height,
+            0, 1, ozone->theme->entries_icon);
    else
 #endif
-      ozone_draw_icon(video_info, 60, 60, ozone->textures[OZONE_TEXTURE_RETROARCH], 47, (ozone->dimensions.header_height - 60) / 2, video_info->width, video_info->height, 0, 1, ozone->theme->entries_icon);
+      ozone_draw_icon(
+            video_info,
+            logo_icon_size,
+            logo_icon_size,
+            ozone->textures[OZONE_TEXTURE_RETROARCH],
+            47 * scale_factor,
+            (ozone->dimensions.header_height - logo_icon_size) / 2,
+            video_info->width,
+            video_info->height,
+            0, 1, ozone->theme->entries_icon);
    menu_display_blend_end(video_info);
 
    /* Battery */
@@ -1090,12 +1238,21 @@ static void ozone_draw_header(ozone_handle_t *ozone, video_frame_info_t *video_i
 
       if (powerstate.battery_enabled)
       {
-         timedate_offset = 95;
+         timedate_offset = 95 * scale_factor;
 
-         ozone_draw_text(video_info, ozone, msg, video_info->width - 85, ozone->dimensions.header_height / 2 + FONT_SIZE_TIME * 3/8, TEXT_ALIGN_RIGHT, video_info->width, video_info->height, ozone->fonts.time, ozone->theme->text_rgba, false);
+         ozone_draw_text(video_info, ozone, msg, video_info->width - 85 * scale_factor, ozone->dimensions.header_height / 2 + ozone->time_font_glyph_height * 3.0f/10.0f, TEXT_ALIGN_RIGHT, video_info->width, video_info->height, ozone->fonts.time, ozone->theme->text_rgba, false);
 
          menu_display_blend_begin(video_info);
-         ozone_draw_icon(video_info, 92, 92, ozone->icons_textures[powerstate.charging? OZONE_ENTRIES_ICONS_TEXTURE_BATTERY_CHARGING : (powerstate.percent > 80)? OZONE_ENTRIES_ICONS_TEXTURE_BATTERY_FULL : (powerstate.percent > 60)? OZONE_ENTRIES_ICONS_TEXTURE_BATTERY_80 : (powerstate.percent > 40)? OZONE_ENTRIES_ICONS_TEXTURE_BATTERY_60 : (powerstate.percent > 20)? OZONE_ENTRIES_ICONS_TEXTURE_BATTERY_40 : OZONE_ENTRIES_ICONS_TEXTURE_BATTERY_20], video_info->width - 60 - 56, ozone->dimensions.header_height / 2 - 42, video_info->width, video_info->height, 0, 1, ozone->theme->entries_icon);
+         ozone_draw_icon(
+               video_info,
+               status_icon_size,
+               status_icon_size,
+               ozone->icons_textures[powerstate.charging? OZONE_ENTRIES_ICONS_TEXTURE_BATTERY_CHARGING : (powerstate.percent > 80)? OZONE_ENTRIES_ICONS_TEXTURE_BATTERY_FULL : (powerstate.percent > 60)? OZONE_ENTRIES_ICONS_TEXTURE_BATTERY_80 : (powerstate.percent > 40)? OZONE_ENTRIES_ICONS_TEXTURE_BATTERY_60 : (powerstate.percent > 20)? OZONE_ENTRIES_ICONS_TEXTURE_BATTERY_40 : OZONE_ENTRIES_ICONS_TEXTURE_BATTERY_20],
+               video_info->width - (60 + 56) * scale_factor,
+               0,
+               video_info->width,
+               video_info->height,
+               0, 1, ozone->theme->entries_icon);
          menu_display_blend_end(video_info);
       }
    }
@@ -1114,43 +1271,55 @@ static void ozone_draw_header(ozone_handle_t *ozone, video_frame_info_t *video_i
 
       menu_display_timedate(&datetime);
 
-      ozone_draw_text(video_info, ozone, timedate, video_info->width - 85 - timedate_offset, ozone->dimensions.header_height / 2 + FONT_SIZE_TIME * 3/8, TEXT_ALIGN_RIGHT, video_info->width, video_info->height, ozone->fonts.time, ozone->theme->text_rgba, false);
+      ozone_draw_text(video_info, ozone, timedate, video_info->width - (85 * scale_factor) - timedate_offset, ozone->dimensions.header_height / 2 + ozone->time_font_glyph_height * 3.0f/10.0f, TEXT_ALIGN_RIGHT, video_info->width, video_info->height, ozone->fonts.time, ozone->theme->text_rgba, false);
 
       menu_display_blend_begin(video_info);
-      ozone_draw_icon(video_info, 92, 92, ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_CLOCK], video_info->width - 60 - 56 - timedate_offset, ozone->dimensions.header_height / 2 - 42, video_info->width, video_info->height, 0, 1, ozone->theme->entries_icon);
+      ozone_draw_icon(
+            video_info,
+            status_icon_size,
+            status_icon_size,
+            ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_CLOCK],
+            video_info->width - (60 + 56) * scale_factor - timedate_offset,
+            0,
+            video_info->width,
+            video_info->height,
+            0, 1, ozone->theme->entries_icon);
       menu_display_blend_end(video_info);
    }
 }
 
 static void ozone_draw_footer(ozone_handle_t *ozone, video_frame_info_t *video_info, settings_t *settings)
 {
+   float scale_factor        = ozone->capped_scale_factor;
+   unsigned seperator_margin = 30 * scale_factor;
+
    /* Separator */
-   menu_display_draw_quad(video_info, 30, video_info->height - ozone->dimensions.footer_height, video_info->width - 60, 1, video_info->width, video_info->height, ozone->theme->header_footer_separator);
+   menu_display_draw_quad(video_info, seperator_margin, video_info->height - ozone->dimensions.footer_height, video_info->width - seperator_margin * 2, ozone->dimensions.spacer_1px, video_info->width, video_info->height, ozone->theme->header_footer_separator);
 
    /* Core title or Switch icon */
    if (settings->bools.menu_core_enable)
    {
       char core_title[255];
       menu_entries_get_core_title(core_title, sizeof(core_title));
-      ozone_draw_text(video_info, ozone, core_title, 59, video_info->height - ozone->dimensions.footer_height / 2 + FONT_SIZE_FOOTER * 3/8, TEXT_ALIGN_LEFT, video_info->width, video_info->height, ozone->fonts.footer, ozone->theme->text_rgba, false);
+      ozone_draw_text(video_info, ozone, core_title, 59 * scale_factor, video_info->height - ozone->dimensions.footer_height / 2 + ozone->footer_font_glyph_height * 3.0f/10.0f, TEXT_ALIGN_LEFT, video_info->width, video_info->height, ozone->fonts.footer, ozone->theme->text_rgba, false);
    }
    else
-      ozone_draw_icon(video_info, 69, 30, ozone->theme->textures[OZONE_THEME_TEXTURE_SWITCH], 59, video_info->height - ozone->dimensions.footer_height / 2 - 15, video_info->width,video_info->height, 0, 1, NULL);
+      ozone_draw_icon(video_info, 69 * scale_factor, 30 * scale_factor, ozone->theme->textures[OZONE_THEME_TEXTURE_SWITCH], 59 * scale_factor, video_info->height - ozone->dimensions.footer_height / 2 - 15 * scale_factor, video_info->width,video_info->height, 0, 1, NULL);
 
    /* Buttons */
    {
-      unsigned back_width     = 215;
-      unsigned ok_width       = 96;
-      unsigned search_width   = 343;
-      unsigned thumb_width    = 343 + 188 + 80;
-      unsigned icon_size      = 35;
+      unsigned back_width     = 215 * scale_factor;
+      unsigned ok_width       = 96 * scale_factor;
+      unsigned search_width   = 343 * scale_factor;
+      unsigned thumb_width    = (343 + 188 + 80) * scale_factor;
+      unsigned icon_size      = 35 * scale_factor;
       unsigned icon_offset    = icon_size / 2;
       bool do_swap            = video_info->input_menu_swap_ok_cancel_buttons;
 
       if (do_swap)
       {
-         back_width  = 96;
-         ok_width    = 215;
+         back_width  = 96 * scale_factor;
+         ok_width    = 215 * scale_factor;
       }
 
       menu_display_blend_begin(video_info);
@@ -1159,19 +1328,19 @@ static void ozone_draw_footer(ozone_handle_t *ozone, video_frame_info_t *video_i
 
       if (do_swap)
       {
-         ozone_draw_icon(video_info, icon_size, icon_size, ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_D], video_info->width - 138, video_info->height - ozone->dimensions.footer_height / 2 - icon_offset, video_info->width,video_info->height, 0, 1, ozone->theme_dynamic.entries_icon);
-         ozone_draw_icon(video_info, icon_size, icon_size, ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_R], video_info->width - 256, video_info->height - ozone->dimensions.footer_height / 2 - icon_offset, video_info->width,video_info->height, 0, 1, ozone->theme_dynamic.entries_icon);
+         ozone_draw_icon(video_info, icon_size, icon_size, ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_D], video_info->width - 138 * scale_factor, video_info->height - ozone->dimensions.footer_height / 2 - icon_offset, video_info->width,video_info->height, 0, 1, ozone->theme_dynamic.entries_icon);
+         ozone_draw_icon(video_info, icon_size, icon_size, ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_R], video_info->width - 256 * scale_factor, video_info->height - ozone->dimensions.footer_height / 2 - icon_offset, video_info->width,video_info->height, 0, 1, ozone->theme_dynamic.entries_icon);
       }
       else
       {
-         ozone_draw_icon(video_info, icon_size, icon_size, ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_D], video_info->width - 256, video_info->height - ozone->dimensions.footer_height / 2 - icon_offset, video_info->width,video_info->height, 0, 1, ozone->theme_dynamic.entries_icon);
-         ozone_draw_icon(video_info, icon_size, icon_size, ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_R], video_info->width - 138, video_info->height - ozone->dimensions.footer_height / 2 - icon_offset, video_info->width,video_info->height, 0, 1, ozone->theme_dynamic.entries_icon);
+         ozone_draw_icon(video_info, icon_size, icon_size, ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_D], video_info->width - 256 * scale_factor, video_info->height - ozone->dimensions.footer_height / 2 - icon_offset, video_info->width,video_info->height, 0, 1, ozone->theme_dynamic.entries_icon);
+         ozone_draw_icon(video_info, icon_size, icon_size, ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_R], video_info->width - 138 * scale_factor, video_info->height - ozone->dimensions.footer_height / 2 - icon_offset, video_info->width,video_info->height, 0, 1, ozone->theme_dynamic.entries_icon);
       }
 
-      ozone_draw_icon(video_info, icon_size, icon_size, ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_U], video_info->width - 384, video_info->height - ozone->dimensions.footer_height / 2 - icon_offset, video_info->width,video_info->height, 0, 1, ozone->theme_dynamic.entries_icon);
+      ozone_draw_icon(video_info, icon_size, icon_size, ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_U], video_info->width - 384 * scale_factor, video_info->height - ozone->dimensions.footer_height / 2 - icon_offset, video_info->width,video_info->height, 0, 1, ozone->theme_dynamic.entries_icon);
 
       if (ozone->is_playlist && !ozone->cursor_in_sidebar)
-         ozone_draw_icon(video_info, icon_size, icon_size, ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_L], video_info->width - 384 - 118 - 100 - 50, video_info->height - ozone->dimensions.footer_height / 2 - icon_offset, video_info->width,video_info->height, 0, 1, ozone->theme_dynamic.entries_icon);
+         ozone_draw_icon(video_info, icon_size, icon_size, ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_L], video_info->width - (384 + 118 + 100 + 50) * scale_factor, video_info->height - ozone->dimensions.footer_height / 2 - icon_offset, video_info->width,video_info->height, 0, 1, ozone->theme_dynamic.entries_icon);
 
       menu_display_blend_end(video_info);
 
@@ -1179,21 +1348,21 @@ static void ozone_draw_footer(ozone_handle_t *ozone, video_frame_info_t *video_i
             do_swap ?
             msg_hash_to_str(MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_OK) :
             msg_hash_to_str(MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_BACK),
-            video_info->width - back_width, video_info->height - ozone->dimensions.footer_height / 2 + FONT_SIZE_FOOTER * 3/8, TEXT_ALIGN_LEFT, video_info->width, video_info->height, ozone->fonts.footer, ozone->theme->text_rgba, false);
+            video_info->width - back_width, video_info->height - ozone->dimensions.footer_height / 2 + ozone->footer_font_glyph_height * 3.0f/10.0f, TEXT_ALIGN_LEFT, video_info->width, video_info->height, ozone->fonts.footer, ozone->theme->text_rgba, false);
       ozone_draw_text(video_info, ozone,
             do_swap ?
             msg_hash_to_str(MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_BACK) :
             msg_hash_to_str(MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_OK),
-            video_info->width - ok_width, video_info->height - ozone->dimensions.footer_height / 2 + FONT_SIZE_FOOTER * 3/8, TEXT_ALIGN_LEFT, video_info->width, video_info->height, ozone->fonts.footer, ozone->theme->text_rgba, false);
+            video_info->width - ok_width, video_info->height - ozone->dimensions.footer_height / 2 + ozone->footer_font_glyph_height * 3.0f/10.0f, TEXT_ALIGN_LEFT, video_info->width, video_info->height, ozone->fonts.footer, ozone->theme->text_rgba, false);
 
       ozone_draw_text(video_info, ozone,
             msg_hash_to_str(MENU_ENUM_LABEL_VALUE_SEARCH),
-            video_info->width - search_width, video_info->height - ozone->dimensions.footer_height / 2 + FONT_SIZE_FOOTER * 3/8, TEXT_ALIGN_LEFT, video_info->width, video_info->height, ozone->fonts.footer, ozone->theme->text_rgba, false);
+            video_info->width - search_width, video_info->height - ozone->dimensions.footer_height / 2 + ozone->footer_font_glyph_height * 3.0f/10.0f, TEXT_ALIGN_LEFT, video_info->width, video_info->height, ozone->fonts.footer, ozone->theme->text_rgba, false);
 
       if (ozone->is_playlist && !ozone->cursor_in_sidebar)
          ozone_draw_text(video_info, ozone,
                msg_hash_to_str(MSG_CHANGE_THUMBNAIL_TYPE),
-               video_info->width - thumb_width, video_info->height - ozone->dimensions.footer_height / 2 + FONT_SIZE_FOOTER * 3/8, TEXT_ALIGN_LEFT, video_info->width, video_info->height, ozone->fonts.footer, ozone->theme->text_rgba, false);
+               video_info->width - thumb_width, video_info->height - ozone->dimensions.footer_height / 2 + ozone->footer_font_glyph_height * 3.0f/10.0f, TEXT_ALIGN_LEFT, video_info->width, video_info->height, ozone->fonts.footer, ozone->theme->text_rgba, false);
 
    }
 
@@ -1581,7 +1750,7 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
    ozone_draw_sidebar(ozone, video_info);
 
    /* Menu entries */
-   menu_display_scissor_begin(video_info, ozone->sidebar_offset + (unsigned) ozone->dimensions.sidebar_width, ozone->dimensions.header_height + 1, video_info->width - (unsigned) ozone->dimensions.sidebar_width + (-ozone->sidebar_offset), video_info->height - ozone->dimensions.header_height - ozone->dimensions.footer_height - 1);
+   menu_display_scissor_begin(video_info, ozone->sidebar_offset + (unsigned) ozone->dimensions.sidebar_width, ozone->dimensions.header_height + ozone->dimensions.spacer_1px, video_info->width - (unsigned) ozone->dimensions.sidebar_width + (-ozone->sidebar_offset), video_info->height - ozone->dimensions.header_height - ozone->dimensions.footer_height - ozone->dimensions.spacer_1px);
 
    /* Current list */
    ozone_draw_entries(ozone,
@@ -1733,6 +1902,7 @@ static void ozone_animation_end(void *userdata)
 
 static void ozone_list_open(ozone_handle_t *ozone)
 {
+   menu_animation_ctx_tag sidebar_tag = (uintptr_t)&ozone->sidebar_offset;
    struct menu_animation_ctx_entry entry;
 
    ozone->draw_old_list = true;
@@ -1761,7 +1931,7 @@ static void ozone_list_open(ozone_handle_t *ozone)
       entry.duration = ANIMATION_PUSH_ENTRY_DURATION;
       entry.easing_enum = EASING_OUT_QUAD;
       entry.subject = &ozone->sidebar_offset;
-      entry.tag = (uintptr_t) NULL;
+      entry.tag = sidebar_tag;
       entry.target_value = 0.0f;
       entry.userdata = NULL;
 
@@ -1775,7 +1945,7 @@ static void ozone_list_open(ozone_handle_t *ozone)
       entry.duration = ANIMATION_PUSH_ENTRY_DURATION;
       entry.easing_enum = EASING_OUT_QUAD;
       entry.subject = &ozone->sidebar_offset;
-      entry.tag = (uintptr_t) NULL;
+      entry.tag = sidebar_tag;
       entry.target_value = -ozone->dimensions.sidebar_width;
       entry.userdata = (void*) ozone;
 
@@ -2017,6 +2187,7 @@ static void ozone_list_cache(void *data,
    unsigned video_info_height;
    float bottom_boundary;
    ozone_node_t *first_node;
+   float scale_factor;
    unsigned first             = 0;
    unsigned last              = 0;
    file_list_t *selection_buf = NULL;
@@ -2025,6 +2196,7 @@ static void ozone_list_cache(void *data,
    if (!ozone)
       return;
 
+   scale_factor               = ozone->capped_scale_factor;
    ozone->need_compute        = true;
    ozone->selection_old_list  = ozone->selection;
    ozone->scroll_old          = ozone->animations.scroll_y;
@@ -2044,12 +2216,12 @@ static void ozone_list_cache(void *data,
       if (!node)
          continue;
 
-      if (y + ozone->animations.scroll_y + node->height + 20 < ozone->dimensions.header_height + ozone->dimensions.entry_padding_vertical)
+      if (y + ozone->animations.scroll_y + node->height + 20 * scale_factor < ozone->dimensions.header_height + ozone->dimensions.entry_padding_vertical)
       {
          first++;
          goto text_iterate;
       }
-      else if (y + ozone->animations.scroll_y - node->height - 20 > bottom_boundary)
+      else if (y + ozone->animations.scroll_y - node->height - 20 * scale_factor > bottom_boundary)
          goto text_iterate;
 
       last++;
@@ -2405,7 +2577,6 @@ static enum menu_action ozone_parse_menu_entry_action(
          if (!ozone->cursor_in_sidebar)
             break;
 
-         tag           = (uintptr_t)ozone;
          new_selection = (int)(ozone->categories_selection_ptr + 1);
 
          if (new_selection >= (int)(ozone->system_tab_end + horizontal_list_size + 1))
@@ -2420,7 +2591,6 @@ static enum menu_action ozone_parse_menu_entry_action(
          if (!ozone->cursor_in_sidebar)
             break;
 
-         tag           = (uintptr_t)ozone;
          new_selection = (int)ozone->categories_selection_ptr - 1;
 
          if (new_selection < 0)

--- a/menu/drivers/ozone/ozone.h
+++ b/menu/drivers/ozone/ozone.h
@@ -59,6 +59,7 @@ typedef struct ozone_handle ozone_handle_t;
 #define SIDEBAR_ENTRY_Y_PADDING     10
 #define SIDEBAR_ENTRY_ICON_SIZE     46
 #define SIDEBAR_ENTRY_ICON_PADDING  15
+#define SIDEBAR_GRADIENT_HEIGHT     28
 
 #define FULLSCREEN_THUMBNAIL_PADDING 48
 
@@ -151,6 +152,14 @@ struct ozone_handle
    unsigned sublabel_font_glyph_width;
    unsigned footer_font_glyph_width;
    unsigned sidebar_font_glyph_width;
+   unsigned time_font_glyph_width;
+
+   unsigned title_font_glyph_height;
+   unsigned entry_font_glyph_height;
+   unsigned sublabel_font_glyph_height;
+   unsigned footer_font_glyph_height;
+   unsigned sidebar_font_glyph_height;
+   unsigned time_font_glyph_height;
 
    ozone_theme_t *theme;
 
@@ -166,6 +175,11 @@ struct ozone_handle
       float cursor_border[16];
       float message_background[16];
    } theme_dynamic;
+
+   unsigned last_width;
+   unsigned last_height;
+   float last_scale_factor;
+   float capped_scale_factor;
 
    bool need_compute;
 
@@ -213,11 +227,17 @@ struct ozone_handle
       int sidebar_entry_height;
       int sidebar_entry_icon_size;
       int sidebar_entry_icon_padding;
+      int sidebar_gradient_height;
 
       int cursor_size;
 
       int thumbnail_bar_width;
       int fullscreen_thumbnail_padding;
+
+      int spacer_1px;
+      int spacer_2px;
+      int spacer_3px;
+      int spacer_5px;
    } dimensions;
 
    bool show_cursor;
@@ -315,6 +335,8 @@ void ozone_compute_entries_position(ozone_handle_t *ozone);
 void ozone_update_scroll(ozone_handle_t *ozone, bool allow_animation, ozone_node_t *node);
 
 void ozone_sidebar_update_collapse(ozone_handle_t *ozone, bool allow_animation);
+
+void ozone_refresh_sidebars(ozone_handle_t *ozone, unsigned video_height);
 
 void ozone_entries_update_thumbnail_bar(ozone_handle_t *ozone, bool is_playlist, bool allow_animation);
 

--- a/menu/drivers/ozone/ozone_display.c
+++ b/menu/drivers/ozone/ozone_display.c
@@ -118,6 +118,12 @@ static void ozone_draw_cursor_slice(ozone_handle_t *ozone,
       unsigned width, unsigned height,
       size_t y, float alpha)
 {
+   float scale_factor   = ozone->capped_scale_factor;
+   int slice_x          = x_offset - 14 * scale_factor;
+   int slice_y          = (int)y + 8 * scale_factor;
+   unsigned slice_new_w = width + (3 + 28 - 4) * scale_factor;
+   unsigned slice_new_h = height + 20 * scale_factor;
+
    menu_display_set_alpha(ozone->theme_dynamic.cursor_alpha, alpha);
    menu_display_set_alpha(ozone->theme_dynamic.cursor_border, alpha);
 
@@ -126,28 +132,28 @@ static void ozone_draw_cursor_slice(ozone_handle_t *ozone,
    /* Cursor without border */
    menu_display_draw_texture_slice(
       video_info,
-      x_offset - 14,
-      (int)(y + 8),
+      slice_x,
+      slice_y,
       80, 80,
-      width + 3 + 28 - 4,
-      height + 20,
+      slice_new_w,
+      slice_new_h,
       video_info->width, video_info->height,
       ozone->theme_dynamic.cursor_alpha,
-      20, 1.0,
+      20, scale_factor,
       ozone->theme->textures[OZONE_THEME_TEXTURE_CURSOR_NO_BORDER]
    );
 
    /* Tainted border */
    menu_display_draw_texture_slice(
       video_info,
-      x_offset - 14,
-      (int)(y + 8),
+      slice_x,
+      slice_y,
       80, 80,
-      width + 3 + 28 - 4,
-      height + 20,
+      slice_new_w,
+      slice_new_h,
       video_info->width, video_info->height,
       ozone->theme_dynamic.cursor_border,
-      20, 1.0,
+      20, scale_factor,
       ozone->textures[OZONE_TEXTURE_CURSOR_BORDER]
    );
 
@@ -164,21 +170,21 @@ static void ozone_draw_cursor_fallback(ozone_handle_t *ozone,
    menu_display_set_alpha(ozone->theme_dynamic.selection, alpha);
 
    /* Fill */
-   menu_display_draw_quad(video_info, x_offset, (int)y, width, height - 5, video_info->width, video_info->height, ozone->theme_dynamic.selection);
+   menu_display_draw_quad(video_info, x_offset, (int)y, width, height - ozone->dimensions.spacer_5px, video_info->width, video_info->height, ozone->theme_dynamic.selection);
 
    /* Borders (can't do one single quad because of alpha) */
 
    /* Top */
-   menu_display_draw_quad(video_info, x_offset - 3, (int)(y - 3), width + 6, 3, video_info->width, video_info->height, ozone->theme_dynamic.selection_border);
+   menu_display_draw_quad(video_info, x_offset - ozone->dimensions.spacer_3px, (int)(y - ozone->dimensions.spacer_3px), width + ozone->dimensions.spacer_3px * 2, ozone->dimensions.spacer_3px, video_info->width, video_info->height, ozone->theme_dynamic.selection_border);
 
    /* Bottom */
-   menu_display_draw_quad(video_info, x_offset - 3, (int)(y + height - 5), width + 6, 3, video_info->width, video_info->height, ozone->theme_dynamic.selection_border);
+   menu_display_draw_quad(video_info, x_offset - ozone->dimensions.spacer_3px, (int)(y + height - ozone->dimensions.spacer_5px), width + ozone->dimensions.spacer_3px * 2, ozone->dimensions.spacer_3px, video_info->width, video_info->height, ozone->theme_dynamic.selection_border);
 
    /* Left */
-   menu_display_draw_quad(video_info, (int)(x_offset - 3), (int)y, 3, height - 5, video_info->width, video_info->height, ozone->theme_dynamic.selection_border);
+   menu_display_draw_quad(video_info, (int)(x_offset - ozone->dimensions.spacer_3px), (int)y, ozone->dimensions.spacer_3px, height - ozone->dimensions.spacer_5px, video_info->width, video_info->height, ozone->theme_dynamic.selection_border);
 
    /* Right */
-   menu_display_draw_quad(video_info, x_offset + width, (int)y, 3, height - 5, video_info->width, video_info->height, ozone->theme_dynamic.selection_border);
+   menu_display_draw_quad(video_info, x_offset + width, (int)y, ozone->dimensions.spacer_3px, height - ozone->dimensions.spacer_5px, video_info->width, video_info->height, ozone->theme_dynamic.selection_border);
 }
 
 void ozone_draw_cursor(ozone_handle_t *ozone,
@@ -255,8 +261,9 @@ void ozone_draw_osk(ozone_handle_t *ozone,
    unsigned text_color;
    struct string_list *list;
 
-   unsigned margin         = 75;
-   unsigned padding        = 10;
+   float scale_factor      = ozone->capped_scale_factor;
+   unsigned margin         = 75 * scale_factor;
+   unsigned padding        = 10 * scale_factor;
    unsigned bottom_end     = video_info->height/2;
    unsigned y_offset       = 0;
    bool draw_placeholder   = string_is_empty(str);
@@ -272,20 +279,20 @@ void ozone_draw_osk(ozone_handle_t *ozone,
 
    /* Border */
    /* Top */
-   menu_display_draw_quad(video_info, margin, margin, video_info->width - margin*2, 1, video_info->width, video_info->height, ozone->theme->entries_border);
+   menu_display_draw_quad(video_info, margin, margin, video_info->width - margin*2, ozone->dimensions.spacer_1px, video_info->width, video_info->height, ozone->theme->entries_border);
 
    /* Bottom */
-   menu_display_draw_quad(video_info, margin, bottom_end - margin, video_info->width - margin*2, 1, video_info->width, video_info->height, ozone->theme->entries_border);
+   menu_display_draw_quad(video_info, margin, bottom_end - margin, video_info->width - margin*2, ozone->dimensions.spacer_1px, video_info->width, video_info->height, ozone->theme->entries_border);
 
    /* Left */
-   menu_display_draw_quad(video_info, margin, margin, 1, bottom_end - margin*2, video_info->width, video_info->height, ozone->theme->entries_border);
+   menu_display_draw_quad(video_info, margin, margin, ozone->dimensions.spacer_1px, bottom_end - margin*2, video_info->width, video_info->height, ozone->theme->entries_border);
 
    /* Right */
-   menu_display_draw_quad(video_info, video_info->width - margin, margin, 1, bottom_end - margin*2, video_info->width, video_info->height, ozone->theme->entries_border);
+   menu_display_draw_quad(video_info, video_info->width - margin, margin, ozone->dimensions.spacer_1px, bottom_end - margin*2, video_info->width, video_info->height, ozone->theme->entries_border);
 
    /* Backdrop */
    /* TODO: Remove the backdrop if blur shader is available */
-   menu_display_draw_quad(video_info, margin + 1, margin + 1, video_info->width - margin*2 - 2, bottom_end - margin*2 - 2, video_info->width, video_info->height, ozone_osk_backdrop);
+   menu_display_draw_quad(video_info, margin + ozone->dimensions.spacer_1px, margin + ozone->dimensions.spacer_1px, video_info->width - margin*2 - ozone->dimensions.spacer_2px, bottom_end - margin*2 - ozone->dimensions.spacer_2px, video_info->width, video_info->height, ozone_osk_backdrop);
 
    /* Placeholder & text*/
    if (!draw_placeholder)
@@ -307,7 +314,7 @@ void ozone_draw_osk(ozone_handle_t *ozone,
    {
       const char *msg = list->elems[i].data;
 
-      ozone_draw_text(video_info, ozone, msg, margin + padding * 2, margin + padding + FONT_SIZE_ENTRIES_LABEL + y_offset, TEXT_ALIGN_LEFT, video_info->width, video_info->height, ozone->fonts.entries_label, text_color, false);
+      ozone_draw_text(video_info, ozone, msg, margin + padding * 2, margin + padding + ozone->sublabel_font_glyph_height + y_offset, TEXT_ALIGN_LEFT, video_info->width, video_info->height, ozone->fonts.entries_label, text_color, false);
 
       /* Cursor */
       if (i == list->size - 1)
@@ -315,12 +322,12 @@ void ozone_draw_osk(ozone_handle_t *ozone,
          if (ozone->osk_cursor)
          {
             unsigned cursor_x = draw_placeholder ? 0 : font_driver_get_message_width(ozone->fonts.entries_label, msg, (unsigned)strlen(msg), 1);
-            menu_display_draw_quad(video_info, margin + padding*2 + cursor_x, margin + padding + y_offset + 3, 1, 25, video_info->width, video_info->height, ozone_pure_white);
+            menu_display_draw_quad(video_info, margin + padding*2 + cursor_x, margin + padding + y_offset + ozone->dimensions.spacer_3px, ozone->dimensions.spacer_1px, 25 * scale_factor, video_info->width, video_info->height, ozone_pure_white);
          }
       }
       else
       {
-         y_offset += 25;
+         y_offset += 25 * scale_factor;
       }
    }
 
@@ -342,11 +349,11 @@ void ozone_draw_messagebox(ozone_handle_t *ozone,
 {
    unsigned i, y_position;
    int x, y, longest = 0, longest_width = 0;
-   float line_height        = 0;
    unsigned width           = video_info->width;
    unsigned height          = video_info->height;
    struct string_list *list = !string_is_empty(message)
       ? string_split(message, "\n") : NULL;
+   float scale_factor       = ozone->capped_scale_factor;
 
    if (!list || !ozone || !ozone->fonts.footer)
    {
@@ -358,14 +365,12 @@ void ozone_draw_messagebox(ozone_handle_t *ozone,
    if (list->elems == 0)
       goto end;
 
-   line_height      = 25;
-
    y_position       = height / 2;
    if (menu_input_dialog_get_display_kb())
       y_position    = height / 4;
 
    x                = width  / 2;
-   y                = y_position - (list->size-1) * line_height / 2;
+   y                = y_position - (list->size * ozone->footer_font_glyph_height) / 2;
 
    /* find the longest line width */
    for (i = 0; i < list->size; i++)
@@ -386,18 +391,24 @@ void ozone_draw_messagebox(ozone_handle_t *ozone,
    menu_display_blend_begin(video_info);
 
    if (ozone->has_all_assets) /* avoid drawing a black box if there's no assets */
+   {
+      int slice_x          = x - longest_width/2 - 48 * scale_factor;
+      unsigned slice_new_w = longest_width + 48 * 2 * scale_factor;
+      unsigned slice_new_h = ozone->footer_font_glyph_height * (list->size + 2);
+
       menu_display_draw_texture_slice(
          video_info,
-         x - longest_width/2 - 48,
-         y + 16 - 48,
+         slice_x,
+         y,
          256, 256,
-         longest_width + 48 * 2,
-         line_height * list->size + 48 * 2,
+         slice_new_w,
+         slice_new_h,
          width, height,
          ozone->theme_dynamic.message_background,
-         16, 1.0,
+         16, scale_factor,
          ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_DIALOG_SLICE]
       );
+   }
 
    for (i = 0; i < list->size; i++)
    {
@@ -407,7 +418,7 @@ void ozone_draw_messagebox(ozone_handle_t *ozone,
          ozone_draw_text(video_info, ozone,
             msg,
             x - longest_width/2.0,
-            y + (i+0.75) * line_height,
+            y + (i + 1) * ozone->footer_font_glyph_height,
             TEXT_ALIGN_LEFT,
             width, height,
             ozone->fonts.footer,
@@ -434,7 +445,7 @@ void ozone_draw_fullscreen_thumbnails(
       unsigned width                    = video_info->width;
       unsigned height                   = video_info->height;
       int view_width                    = (int)width;
-      int view_height                   = (int)height - ozone->dimensions.header_height - ozone->dimensions.footer_height - 1;
+      int view_height                   = (int)height - ozone->dimensions.header_height - ozone->dimensions.footer_height - ozone->dimensions.spacer_1px;
       int thumbnail_margin              = ozone->dimensions.fullscreen_thumbnail_padding;
       bool show_right_thumbnail         = false;
       bool show_left_thumbnail          = false;
@@ -506,7 +517,7 @@ void ozone_draw_fullscreen_thumbnails(
       /* > Thumbnail bounding box height + y position
        *   are fixed */
       thumbnail_box_height = view_height - (thumbnail_margin * 2);
-      thumbnail_y          = ozone->dimensions.header_height + thumbnail_margin + 1;
+      thumbnail_y          = ozone->dimensions.header_height + thumbnail_margin + ozone->dimensions.spacer_1px;
 
       /* Thumbnail bounding box width and x position
        * depend upon number of active thumbnails */
@@ -597,7 +608,7 @@ void ozone_draw_fullscreen_thumbnails(
       menu_display_draw_quad(
             video_info,
             0,
-            ozone->dimensions.header_height + 1,
+            ozone->dimensions.header_height + ozone->dimensions.spacer_1px,
             width,
             (unsigned)view_height,
             width,
@@ -610,7 +621,7 @@ void ozone_draw_fullscreen_thumbnails(
             0,
             ozone->dimensions.header_height,
             width,
-            1,
+            ozone->dimensions.spacer_1px,
             width,
             height,
             separator_color);
@@ -620,7 +631,7 @@ void ozone_draw_fullscreen_thumbnails(
             0,
             height - ozone->dimensions.footer_height,
             width,
-            1,
+            ozone->dimensions.spacer_1px,
             width,
             height,
             separator_color);

--- a/menu/drivers/ozone/ozone_sidebar.c
+++ b/menu/drivers/ozone/ozone_sidebar.c
@@ -116,6 +116,7 @@ void ozone_draw_sidebar(ozone_handle_t *ozone, video_frame_info_t *video_info)
    settings_t *settings = config_get_ptr();
    uint32_t text_alpha  = ozone->animations.sidebar_text_alpha * 255.0f;
    bool use_smooth_ticker = settings->bools.menu_ticker_smooth;
+   float scale_factor = ozone->capped_scale_factor;
 
    /* Initial ticker configuration */
    if (use_smooth_ticker)
@@ -148,32 +149,32 @@ void ozone_draw_sidebar(ozone_handle_t *ozone, video_frame_info_t *video_info)
    menu_display_scissor_begin(video_info, 0, ozone->dimensions.header_height, (unsigned) ozone->dimensions.sidebar_width, video_info->height - ozone->dimensions.header_height - ozone->dimensions.footer_height);
 
    /* Background */
-   sidebar_height = video_info->height - ozone->dimensions.header_height - 55 - ozone->dimensions.footer_height;
+   sidebar_height = video_info->height - ozone->dimensions.header_height - ozone->dimensions.sidebar_gradient_height * 2 - ozone->dimensions.footer_height;
 
    if (!video_info->libretro_running)
    {
-      menu_display_draw_quad(video_info, ozone->sidebar_offset, ozone->dimensions.header_height + 1, (unsigned) ozone->dimensions.sidebar_width, 55/2, video_info->width, video_info->height, ozone->theme->sidebar_top_gradient);
-      menu_display_draw_quad(video_info, ozone->sidebar_offset, ozone->dimensions.header_height + 1 + 55/2, (unsigned) ozone->dimensions.sidebar_width, sidebar_height, video_info->width, video_info->height, ozone->theme->sidebar_background);
-      menu_display_draw_quad(video_info, ozone->sidebar_offset, video_info->height - ozone->dimensions.footer_height - 55/2 - 1, (unsigned) ozone->dimensions.sidebar_width, 55/2 + 1, video_info->width, video_info->height, ozone->theme->sidebar_bottom_gradient);
+      menu_display_draw_quad(video_info, ozone->sidebar_offset, ozone->dimensions.header_height + ozone->dimensions.spacer_1px, (unsigned) ozone->dimensions.sidebar_width, ozone->dimensions.sidebar_gradient_height, video_info->width, video_info->height, ozone->theme->sidebar_top_gradient);
+      menu_display_draw_quad(video_info, ozone->sidebar_offset, ozone->dimensions.header_height + ozone->dimensions.spacer_1px + ozone->dimensions.sidebar_gradient_height, (unsigned) ozone->dimensions.sidebar_width, sidebar_height, video_info->width, video_info->height, ozone->theme->sidebar_background);
+      menu_display_draw_quad(video_info, ozone->sidebar_offset, video_info->height - ozone->dimensions.footer_height - ozone->dimensions.sidebar_gradient_height - ozone->dimensions.spacer_1px, (unsigned) ozone->dimensions.sidebar_width, ozone->dimensions.sidebar_gradient_height + ozone->dimensions.spacer_1px, video_info->width, video_info->height, ozone->theme->sidebar_bottom_gradient);
    }
 
    /* Tabs */
    /* y offset computation */
-   y = ozone->dimensions.header_height + 1 + ozone->dimensions.sidebar_padding_vertical;
+   y = ozone->dimensions.header_height + ozone->dimensions.spacer_1px + ozone->dimensions.sidebar_padding_vertical;
    for (i = 0; i < ozone->system_tab_end + horizontal_list_size + 1; i++)
    {
       if (i == ozone->categories_selection_ptr)
       {
          selection_y = (unsigned)y;
          if (ozone->categories_selection_ptr > ozone->system_tab_end)
-            selection_y += ozone->dimensions.sidebar_entry_padding_vertical + 1;
+            selection_y += ozone->dimensions.sidebar_entry_padding_vertical + ozone->dimensions.spacer_1px;
       }
 
       if (i == ozone->categories_active_idx_old)
       {
          selection_old_y = (unsigned)y;
          if (ozone->categories_active_idx_old > ozone->system_tab_end)
-            selection_old_y += ozone->dimensions.sidebar_entry_padding_vertical + 1;
+            selection_old_y += ozone->dimensions.sidebar_entry_padding_vertical + ozone->dimensions.spacer_1px;
       }
 
       y += ozone->dimensions.sidebar_entry_height + ozone->dimensions.sidebar_entry_padding_vertical;
@@ -183,15 +184,15 @@ void ozone_draw_sidebar(ozone_handle_t *ozone, video_frame_info_t *video_info)
 
    /* Cursor */
    if (ozone->cursor_in_sidebar)
-      ozone_draw_cursor(ozone, video_info, ozone->sidebar_offset + ozone->dimensions.sidebar_padding_horizontal + 3,
-         entry_width - 5, ozone->dimensions.sidebar_entry_height + 2, selection_y + 1 + ozone->animations.scroll_y_sidebar, ozone->animations.cursor_alpha);
+      ozone_draw_cursor(ozone, video_info, ozone->sidebar_offset + ozone->dimensions.sidebar_padding_horizontal + ozone->dimensions.spacer_3px,
+         entry_width - ozone->dimensions.spacer_5px, ozone->dimensions.sidebar_entry_height + ozone->dimensions.spacer_2px, selection_y + ozone->dimensions.spacer_2px + ozone->animations.scroll_y_sidebar, ozone->animations.cursor_alpha);
 
    if (ozone->cursor_in_sidebar_old)
-      ozone_draw_cursor(ozone, video_info, ozone->sidebar_offset + ozone->dimensions.sidebar_padding_horizontal + 3,
-         entry_width - 5, ozone->dimensions.sidebar_entry_height + 2, selection_old_y + 1 + ozone->animations.scroll_y_sidebar, 1-ozone->animations.cursor_alpha);
+      ozone_draw_cursor(ozone, video_info, ozone->sidebar_offset + ozone->dimensions.sidebar_padding_horizontal + ozone->dimensions.spacer_3px,
+         entry_width - ozone->dimensions.spacer_5px, ozone->dimensions.sidebar_entry_height + ozone->dimensions.spacer_2px, selection_old_y + ozone->dimensions.spacer_2px + ozone->animations.scroll_y_sidebar, 1-ozone->animations.cursor_alpha);
 
    /* Menu tabs */
-   y = ozone->dimensions.header_height + 1 + ozone->dimensions.sidebar_padding_vertical;
+   y = ozone->dimensions.header_height + ozone->dimensions.spacer_1px + ozone->dimensions.sidebar_padding_vertical;
    menu_display_blend_begin(video_info);
 
    for (i = 0; i < (unsigned)(ozone->system_tab_end+1); i++)
@@ -214,7 +215,7 @@ void ozone_draw_sidebar(ozone_handle_t *ozone, video_frame_info_t *video_info)
       /* Text */
       if (!ozone->sidebar_collapsed)
          ozone_draw_text(video_info, ozone, title, ozone->sidebar_offset + ozone->dimensions.sidebar_padding_horizontal + ozone->dimensions.sidebar_entry_icon_padding * 2 + ozone->dimensions.sidebar_entry_icon_size,
-            y + ozone->dimensions.sidebar_entry_height / 2 + FONT_SIZE_SIDEBAR  * 3/8 + ozone->animations.scroll_y_sidebar, TEXT_ALIGN_LEFT, video_info->width, video_info->height, ozone->fonts.sidebar, text_color, true);
+            y + ozone->dimensions.sidebar_entry_height / 2 + ozone->sidebar_font_glyph_height * 3.0f/10.0f + ozone->animations.scroll_y_sidebar, TEXT_ALIGN_LEFT, video_info->width, video_info->height, ozone->fonts.sidebar, text_color, true);
 
       y += ozone->dimensions.sidebar_entry_height + ozone->dimensions.sidebar_entry_padding_vertical;
    }
@@ -224,9 +225,9 @@ void ozone_draw_sidebar(ozone_handle_t *ozone, video_frame_info_t *video_info)
    /* Console tabs */
    if (horizontal_list_size > 0)
    {
-      menu_display_draw_quad(video_info, ozone->sidebar_offset + ozone->dimensions.sidebar_padding_horizontal, y + ozone->animations.scroll_y_sidebar, entry_width, 1, video_info->width, video_info->height, ozone->theme->entries_border);
+      menu_display_draw_quad(video_info, ozone->sidebar_offset + ozone->dimensions.sidebar_padding_horizontal, y + ozone->animations.scroll_y_sidebar, entry_width, ozone->dimensions.spacer_1px, video_info->width, video_info->height, ozone->theme->entries_border);
 
-      y += ozone->dimensions.sidebar_entry_padding_vertical + 1;
+      y += ozone->dimensions.sidebar_entry_padding_vertical + ozone->dimensions.spacer_1px;
 
       menu_display_blend_begin(video_info);
 
@@ -253,7 +254,7 @@ void ozone_draw_sidebar(ozone_handle_t *ozone, video_frame_info_t *video_info)
          if (use_smooth_ticker)
          {
             ticker_smooth.selected    = selected;
-            ticker_smooth.field_width = (entry_width - ozone->dimensions.sidebar_entry_icon_size - 40);
+            ticker_smooth.field_width = (entry_width - ozone->dimensions.sidebar_entry_icon_size - 40 * scale_factor);
             ticker_smooth.src_str     = node->console_name;
             ticker_smooth.dst_str     = console_title;
             ticker_smooth.dst_str_len = sizeof(console_title);
@@ -262,7 +263,7 @@ void ozone_draw_sidebar(ozone_handle_t *ozone, video_frame_info_t *video_info)
          }
          else
          {
-            ticker.len      = (entry_width - ozone->dimensions.sidebar_entry_icon_size - 40) / ozone->sidebar_font_glyph_width;
+            ticker.len      = (entry_width - ozone->dimensions.sidebar_entry_icon_size - 40 * scale_factor) / ozone->sidebar_font_glyph_width;
             ticker.s        = console_title;
             ticker.selected = selected;
             ticker.str      = node->console_name;
@@ -271,7 +272,7 @@ void ozone_draw_sidebar(ozone_handle_t *ozone, video_frame_info_t *video_info)
          }
 
          ozone_draw_text(video_info, ozone, console_title, ticker_x_offset + ozone->sidebar_offset + ozone->dimensions.sidebar_padding_horizontal + ozone->dimensions.sidebar_entry_icon_padding * 2 + ozone->dimensions.sidebar_entry_icon_size,
-            y + ozone->dimensions.sidebar_entry_height / 2 + FONT_SIZE_SIDEBAR * 3/8 + ozone->animations.scroll_y_sidebar, TEXT_ALIGN_LEFT,
+            y + ozone->dimensions.sidebar_entry_height / 2 + ozone->sidebar_font_glyph_height * 3.0f/10.0f + ozone->animations.scroll_y_sidebar, TEXT_ALIGN_LEFT,
             video_info->width, video_info->height, ozone->fonts.sidebar, text_color, true);
 
 console_iterate:
@@ -344,14 +345,14 @@ unsigned ozone_get_selected_sidebar_y_position(ozone_handle_t *ozone)
 {
    return ozone->categories_selection_ptr * ozone->dimensions.sidebar_entry_height +
          (ozone->categories_selection_ptr - 1) * ozone->dimensions.sidebar_entry_padding_vertical + ozone->dimensions.sidebar_padding_vertical +
-         (ozone->categories_selection_ptr > ozone->system_tab_end ? ozone->dimensions.sidebar_entry_padding_vertical + 1 : 0);
+         (ozone->categories_selection_ptr > ozone->system_tab_end ? ozone->dimensions.sidebar_entry_padding_vertical + ozone->dimensions.spacer_1px : 0);
 }
 
 unsigned ozone_get_sidebar_height(ozone_handle_t *ozone)
 {
    int entries = (int)(ozone->system_tab_end + 1 + (ozone->horizontal_list ? ozone->horizontal_list->size : 0));
    return entries * ozone->dimensions.sidebar_entry_height + (entries - 1) * ozone->dimensions.sidebar_entry_padding_vertical + ozone->dimensions.sidebar_padding_vertical +
-         (ozone->horizontal_list && ozone->horizontal_list->size > 0 ? ozone->dimensions.sidebar_entry_padding_vertical + 1 : 0);
+         (ozone->horizontal_list && ozone->horizontal_list->size > 0 ? ozone->dimensions.sidebar_entry_padding_vertical + ozone->dimensions.spacer_1px : 0);
 }
 
 static void ozone_sidebar_collapse_end(void *userdata)
@@ -435,6 +436,33 @@ void ozone_sidebar_update_collapse(ozone_handle_t *ozone, bool allow_animation)
    ozone_entries_update_thumbnail_bar(ozone, is_playlist, allow_animation);
 }
 
+static float ozone_sidebar_get_scroll_y(ozone_handle_t *ozone, unsigned video_height)
+{
+   float scroll_y = ozone->animations.scroll_y_sidebar;
+   float selected_position_y;
+   float current_selection_middle_onscreen;
+   float bottom_boundary;
+   float entries_middle;
+   float entries_height;
+
+   selected_position_y               = ozone_get_selected_sidebar_y_position(ozone);
+   current_selection_middle_onscreen = ozone->dimensions.header_height + ozone->dimensions.spacer_1px + ozone->animations.scroll_y_sidebar + selected_position_y + ozone->dimensions.sidebar_entry_height / 2.0f;
+   bottom_boundary                   = (float)video_height - (ozone->dimensions.header_height + ozone->dimensions.spacer_1px) - ozone->dimensions.footer_height;
+   entries_middle                    = (float)video_height / 2.0f;
+   entries_height                    = ozone_get_sidebar_height(ozone);
+
+   if (current_selection_middle_onscreen != entries_middle)
+      scroll_y = ozone->animations.scroll_y_sidebar - (current_selection_middle_onscreen - entries_middle);
+
+   if (scroll_y + entries_height < bottom_boundary)
+      scroll_y = bottom_boundary - entries_height - ozone->dimensions.sidebar_padding_vertical;
+
+   if (scroll_y > 0.0f)
+      scroll_y = 0.0f;
+
+   return scroll_y;
+}
+
 void ozone_sidebar_goto(ozone_handle_t *ozone, unsigned new_selection)
 {
    unsigned video_info_height;
@@ -442,13 +470,6 @@ void ozone_sidebar_goto(ozone_handle_t *ozone, unsigned new_selection)
    struct menu_animation_ctx_entry entry;
 
    menu_animation_ctx_tag tag;
-
-   float new_scroll;
-   float selected_position_y;
-   float current_selection_middle_onscreen;
-   float bottom_boundary;
-   float entries_middle;
-   float entries_height;
 
    video_driver_get_size(NULL, &video_info_height);
 
@@ -478,29 +499,13 @@ void ozone_sidebar_goto(ozone_handle_t *ozone, unsigned new_selection)
    menu_animation_push(&entry);
 
    /* Scroll animation */
-   new_scroll                             = 0;
-   selected_position_y                    = ozone_get_selected_sidebar_y_position(ozone);
-   current_selection_middle_onscreen      = ozone->dimensions.header_height + 1 + ozone->animations.scroll_y_sidebar + selected_position_y + ozone->dimensions.sidebar_entry_height / 2;
-   bottom_boundary                        = video_info_height - (ozone->dimensions.header_height + 1) - ozone->dimensions.footer_height;
-   entries_middle                         = video_info_height/2;
-   entries_height                         = ozone_get_sidebar_height(ozone);
-
-   if (current_selection_middle_onscreen != entries_middle)
-      new_scroll = ozone->animations.scroll_y_sidebar - (current_selection_middle_onscreen - entries_middle);
-
-   if (new_scroll + entries_height < bottom_boundary)
-      new_scroll = bottom_boundary - entries_height - ozone->dimensions.sidebar_padding_vertical;
-
-   if (new_scroll > 0)
-      new_scroll = 0;
-
-   entry.cb = NULL;
-   entry.duration = ANIMATION_CURSOR_DURATION;
-   entry.easing_enum = EASING_OUT_QUAD;
-   entry.subject = &ozone->animations.scroll_y_sidebar;
-   entry.tag = tag;
-   entry.target_value = new_scroll;
-   entry.userdata = NULL;
+   entry.cb           = NULL;
+   entry.duration     = ANIMATION_CURSOR_DURATION;
+   entry.easing_enum  = EASING_OUT_QUAD;
+   entry.subject      = &ozone->animations.scroll_y_sidebar;
+   entry.tag          = tag;
+   entry.target_value = ozone_sidebar_get_scroll_y(ozone, video_info_height);
+   entry.userdata     = NULL;
 
    menu_animation_push(&entry);
 
@@ -511,6 +516,68 @@ void ozone_sidebar_goto(ozone_handle_t *ozone, unsigned new_selection)
    else
    {
       ozone_change_tab(ozone, ozone_system_tabs_idx[ozone->tabs[new_selection]], ozone_system_tabs_type[ozone->tabs[new_selection]]);
+   }
+}
+
+void ozone_refresh_sidebars(ozone_handle_t *ozone, unsigned video_height)
+{
+   settings_t *settings                 = config_get_ptr();
+   menu_animation_ctx_tag collapsed_tag = (uintptr_t)&ozone->sidebar_collapsed;
+   menu_animation_ctx_tag offset_tag    = (uintptr_t)&ozone->sidebar_offset;
+   menu_animation_ctx_tag thumbnail_tag = (uintptr_t)&ozone->show_thumbnail_bar;
+   menu_animation_ctx_tag scroll_tag    = (uintptr_t)ozone;
+   bool is_playlist                     = ozone_is_playlist(ozone, false);
+
+   /* Kill any existing animations */
+   menu_animation_kill_by_tag(&collapsed_tag);
+   menu_animation_kill_by_tag(&offset_tag);
+   menu_animation_kill_by_tag(&thumbnail_tag);
+   if (ozone->depth == 1)
+      menu_animation_kill_by_tag(&scroll_tag);
+
+   /* Set sidebar width */
+   if (settings->bools.ozone_collapse_sidebar || (is_playlist && !ozone->cursor_in_sidebar))
+   {
+      ozone->animations.sidebar_text_alpha = 0.0f;
+      ozone->dimensions.sidebar_width      = ozone->dimensions.sidebar_width_collapsed;
+      ozone->sidebar_collapsed             = true;
+   }
+   else if (ozone->cursor_in_sidebar || (!is_playlist && !settings->bools.ozone_collapse_sidebar))
+   {
+      ozone->animations.sidebar_text_alpha = 1.0f;
+      ozone->dimensions.sidebar_width      = ozone->dimensions.sidebar_width_normal;
+      ozone->sidebar_collapsed             = false;
+   }
+
+   /* Set sidebar offset */
+   if (ozone->depth == 1)
+   {
+      ozone->sidebar_offset = 0.0f;
+      ozone->draw_sidebar   = true;
+   }
+   else if (ozone->depth > 1)
+   {
+      ozone->sidebar_offset = -ozone->dimensions.sidebar_width;
+      ozone->draw_sidebar   = false;
+   }
+
+   /* Set thumbnail bar position */
+   if (is_playlist && !ozone->cursor_in_sidebar && ozone->depth == 1)
+   {
+      ozone->animations.thumbnail_bar_position = ozone->dimensions.thumbnail_bar_width;
+      ozone->show_thumbnail_bar                = true;
+   }
+   else
+   {
+      ozone->animations.thumbnail_bar_position = 0.0f;
+      ozone->show_thumbnail_bar                = false;
+   }
+
+   /* If sidebar is on-screen, update scroll position */
+   if (ozone->depth == 1)
+   {
+      ozone->animations.cursor_alpha     = 1.0f;
+      ozone->animations.scroll_y_sidebar = ozone_sidebar_get_scroll_y(ozone, video_height);
    }
 }
 

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -12844,9 +12844,10 @@ static bool setting_append_list(
 
          START_SUB_GROUP(list, list_info, "Display", &group_info, &subgroup_info, parent_group);
 
-         /* Only implemented for GLUI and XMB at present */
+         /* Only implemented for GLUI, XMB and Ozone at present */
          if (string_is_equal(settings->arrays.menu_driver, "glui") ||
-             string_is_equal(settings->arrays.menu_driver, "xmb"))
+             string_is_equal(settings->arrays.menu_driver, "xmb") ||
+             string_is_equal(settings->arrays.menu_driver, "ozone"))
             CONFIG_FLOAT(
                   list, list_info,
                   &settings->floats.menu_scale_factor,


### PR DESCRIPTION
## Description

This PR adds DPI-based scaling to the Ozone menu driver. The menu should now scale appropriately regardless of display size/resolution. The scale may also be adjusted manually via the `Menu Scale Factor` setting under `User Interface > Appearance`.

**Important note:** Due to the manner in which Ozone is laid out, the menu scale is capped such that the width of the left sidebar cannot be larger than 1/3 of the total window width. This prevents the menu from becoming unusable when increasing the scale. This should not affect normal operation!

## Reviewers

@natinusala 
