### PR TITLE
Add CXX_LINKER to the builtin glslang.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1543,6 +1543,7 @@ ifeq ($(HAVE_SHADERS_COMMON), 1)
 endif
 
 ifeq ($(HAVE_BUILTINGLSLANG), 1)
+   NEED_CXX_LINKER = 1
    HAVE_GLSLANG_COMMON = 1
 
    ifneq ($(findstring Win32,$(OS)),)


### PR DESCRIPTION
## Description

Not sure why this was missing, but glslang is c++ and needs a c++ linker when built which is also enabled by other c++ code so no one noticed until now when @i30817 disabled all that code except for glslang.

## Related Issues

Fixes https://github.com/libretro/RetroArch/issues/10112.