### PR TITLE
Fix a segfault when starting the qt menu with the null menu driver.

### DIFF
--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -1340,6 +1340,8 @@ bool menu_entries_append_enum(file_list_t *list, const char *path,
    size_t idx;
    const char *menu_path           = NULL;
    menu_file_list_cbs_t *cbs       = NULL;
+   settings_t *settings            = config_get_ptr();
+
    if (!list || !label)
       return false;
 
@@ -1377,7 +1379,8 @@ bool menu_entries_append_enum(file_list_t *list, const char *path,
        && enum_idx != MENU_ENUM_LABEL_RDB_ENTRY)
       cbs->setting  = menu_setting_find_enum(enum_idx);
 
-   menu_cbs_init(list, cbs, path, label, type, idx);
+   if (!string_is_equal(settings->arrays.menu_driver, "null"))
+      menu_cbs_init(list, cbs, path, label, type, idx);
 
    return true;
 }


### PR DESCRIPTION
## Description

Fixes a segfault when starting the Qt menu with the `null` menu driver.

## Related Issues

```
Thread 1 "retroarch" received signal SIGSEGV, Segmentation fault.
0x000000000070ddb2 in menu_entries_get_last_stack (path=0x0, 
    label=0x7fffffff5520, file_type=0x0, enum_idx=0x7fffffff5514, entry_idx=0x0)
    at menu/menu_driver.c:1448
1448	         list->list[list->size - 1].actiondata;
(gdb) bt
#0  0x000000000070ddb2 in menu_entries_get_last_stack (path=0x0, 
    label=0x7fffffff5520, file_type=0x0, enum_idx=0x7fffffff5514, entry_idx=0x0)
    at menu/menu_driver.c:1448
#1  0x0000000000757efe in menu_cbs_init (data=0x2837760, cbs=0x2837810, 
    path=0xda080d "Input", label=0xee4723 "input_driver", type=156, idx=0)
    at menu/menu_cbs.c:220
#2  0x000000000070e863 in menu_entries_append_enum (list=0x2837760, 
    path=0xda080d "Input", label=0xee4723 "input_driver", 
    enum_idx=MENU_ENUM_LABEL_INPUT_DRIVER, type=156, directory_ptr=0, 
    entry_idx=0) at menu/menu_driver.c:1380
#3  0x00000000007a2b08 in menu_displaylist_parse_settings_internal_enum (
    info_list=0x2837760, parse_type=PARSE_ONLY_STRING_OPTIONS, 
    add_empty_entry=false, setting=0x25e5090, entry_type=2658, is_enum=true)
    at menu/menu_displaylist.c:1632
#4  0x00000000007ab3d7 in menu_displaylist_build_list (list=0x2837760, 
    type=DISPLAYLIST_DRIVER_SETTINGS_LIST, include_everything=true)
    at menu/menu_displaylist.c:7028
#5  0x000000000067cd49 in create_widget (name=DISPLAYLIST_DRIVER_SETTINGS_LIST)
    at ui/drivers/qt/options/options.h:562
#6  0x000000000067cc96 in DriversPage::widget (this=0x28352b0)
    at ui/drivers/qt/options/generic.cpp:29
#7  0x0000000000647d0c in ViewOptionsDialog::addCategory (this=0x282f4f0, 
    category=0x2810070) at ui/drivers/qt/viewoptionsdialog.cpp:206
#8  0x0000000000646f68 in ViewOptionsDialog::ViewOptionsDialog (this=0x282f4f0, 
    mainwindow=0x2216c50, parent=0x0) at ui/drivers/qt/viewoptionsdialog.cpp:154
#9  0x000000000060c7ae in MainWindow::MainWindow (this=0x2216c50, parent=0x0)
    at ui/drivers/qt/ui_qt_window.cpp:512
#10 0x000000000062356a in ui_window_qt_init ()
    at ui/drivers/qt/ui_qt_window.cpp:3110
#11 0x00000000006001bf in ui_companion_qt_init () at ui/drivers/ui_qt.cpp:296
#12 0x000000000045e4b3 in ui_companion_driver_toggle (force=true)
    at retroarch.c:11549
#13 0x000000000045b398 in command_event (cmd=CMD_EVENT_UI_COMPANION_TOGGLE, 
    data=0x0) at retroarch.c:7677
#14 0x00000000004749b7 in runloop_check_state () at retroarch.c:27432
#15 0x00000000004616a8 in runloop_iterate () at retroarch.c:27866
#16 0x00000000004612b0 in rarch_main (argc=1, argv=0x7fffffffe298, data=0x0)
    at retroarch.c:8147
#17 0x0000000000608956 in main (argc=1, argv=0x7fffffffe298)
    at ui/drivers/qt/ui_qt_application.cpp:150

```

## Related Pull Requests

Broke between `v1.7.6` and `v1.7.7` in commit 085f25e81f2c3eea8a4b8f2215cbeba3c5144f54.

## Reviewers

@twinaphex Maybe you can think of a better way of fixing this?