### PR TITLE
default rich presence on; better handling of special characters

### DIFF
--- a/cheevos-new/parser.c
+++ b/cheevos-new/parser.c
@@ -3,6 +3,7 @@
 #include "hash.h"
 #include "util.h"
 
+#include <encodings/utf.h>
 #include <formats/jsonsax.h>
 #include <string/stdstring.h>
 #include <compat/strl.h>
@@ -263,6 +264,7 @@ typedef struct
    int      in_cheevos;
    int      in_lboards;
    int      is_game_id;
+   int      is_title;
    int      is_console_id;
    int      is_richpresence;
    unsigned core_count;
@@ -276,16 +278,77 @@ typedef struct
    rcheevos_rapatchdata_t* patchdata;
 } rcheevos_readud_t;
 
-static const char* rcheevos_dupstr(const rcheevos_field_t* field)
+static char* rcheevos_unescape_string(const char* string, size_t length)
 {
-   char* string = (char*)malloc(field->length + 1);
+   const char* end = string + length;
+   char* buffer = (char*)malloc(length + 1);
+   char* buffer_it = buffer;
 
-   if (!string)
+   if (buffer == NULL)
       return NULL;
 
-   memcpy((void*)string, (void*)field->string, field->length);
-   string[field->length] = 0;
-   return string;
+   while (string < end)
+   {
+      if (*string == '\\')
+      {
+         char escaped_char = string[1];
+         switch (escaped_char)
+         {
+            case 'r': /* Ignore carriage return */
+               string += 2;
+               break;
+
+            case 'n': /* Accept newlines */
+               *buffer_it++ = '\n';
+               string += 2;
+               break;
+
+            case 'u': /* Accept UTF-16 unicode characters */
+            {
+#define MAX_SEQUENCES 16
+               uint16_t  utf16[MAX_SEQUENCES];
+               char      utf8[MAX_SEQUENCES * 4];
+               uint8_t   i, j;
+
+               for (i = 1; i < MAX_SEQUENCES - 1; i++)
+                  if (strncmp((string + 6 * i), "\\u", 2))
+                     break;
+
+               /* Get escaped hex values and add them to the string */
+               for (j = 0; j < i; j++)
+               {
+                  char temp[5];
+
+                  string += 2;
+                  memcpy(temp, string, 4);
+                  temp[4] = '\0';
+                  utf16[j] = string_hex_to_unsigned(temp);
+                  string += 4;
+               }
+               utf16[j] = 0;
+
+               if (utf16_to_char_string(utf16, utf8, sizeof(utf8)))
+               {
+                  memcpy(buffer_it, utf8, strlen(utf8));
+                  buffer_it += strlen(utf8);
+               }
+            }
+            break;
+
+            default:
+               *buffer_it++ = escaped_char;
+               string += 2;
+               break;
+         };
+      }
+      else
+      {
+         *buffer_it++ = *string++;
+      }
+   }
+   *buffer_it = '\0';
+
+   return buffer;
 }
 
 static int rcheevos_new_cheevo(rcheevos_readud_t* ud)
@@ -300,10 +363,10 @@ static int rcheevos_new_cheevo(rcheevos_readud_t* ud)
    else
       return 0;
 
-   cheevo->title       = rcheevos_dupstr(&ud->title);
-   cheevo->description = rcheevos_dupstr(&ud->desc);
-   cheevo->badge       = rcheevos_dupstr(&ud->badge);
-   cheevo->memaddr     = rcheevos_dupstr(&ud->memaddr);
+   cheevo->title       = rcheevos_unescape_string(ud->title.string, ud->title.length);
+   cheevo->description = rcheevos_unescape_string(ud->desc.string, ud->desc.length);
+   cheevo->badge       = rcheevos_unescape_string(ud->badge.string, ud->badge.length);
+   cheevo->memaddr     = rcheevos_unescape_string(ud->memaddr.string, ud->memaddr.length);
    cheevo->points      = (unsigned)strtol(ud->points.string, NULL, 10);
    cheevo->id          = (unsigned)strtol(ud->id.string, NULL, 10);
 
@@ -326,11 +389,11 @@ static int rcheevos_new_lboard(rcheevos_readud_t* ud)
 {
    rcheevos_ralboard_t* lboard = ud->patchdata->lboards + ud->lboard_count++;
 
-   lboard->title              = rcheevos_dupstr(&ud->title);
-   lboard->description        = rcheevos_dupstr(&ud->desc);
-   lboard->format             = rcheevos_dupstr(&ud->format);
-   lboard->mem                = rcheevos_dupstr(&ud->memaddr);
-   lboard->id                 = (unsigned)strtol(ud->id.string, NULL, 10);
+   lboard->title       = rcheevos_unescape_string(ud->title.string, ud->title.length);
+   lboard->description = rcheevos_unescape_string(ud->desc.string, ud->desc.length);
+   lboard->format      = rcheevos_unescape_string(ud->format.string, ud->format.length);
+   lboard->mem         = rcheevos_unescape_string(ud->memaddr.string, ud->memaddr.length);
+   lboard->id          = (unsigned)strtol(ud->id.string, NULL, 10);
 
    if (   !lboard->title
        || !lboard->description
@@ -409,6 +472,8 @@ static int rcheevos_read_key(void* userdata,
       case CHEEVOS_JSON_KEY_TITLE:
          if (common)
             ud->field = &ud->title;
+         else
+            ud->is_title = 1;
          break;
       case CHEEVOS_JSON_KEY_DESCRIPTION:
          if (common)
@@ -459,11 +524,14 @@ static int rcheevos_read_string(void* userdata,
       ud->field->string = string;
       ud->field->length = length;
    }
+   else if (ud->is_title)
+   {
+      ud->patchdata->title = rcheevos_unescape_string(string, length);
+      ud->is_title = 0;
+   }
    else if (ud->is_richpresence)
    {
-      ud->patchdata->richpresence_script = (char*)malloc(length + 1);
-      memcpy(ud->patchdata->richpresence_script, string, length);
-      ud->patchdata->richpresence_script[length] = '\0';
+      ud->patchdata->richpresence_script = rcheevos_unescape_string(string, length);
       ud->is_richpresence = 0;
    }
 
@@ -544,10 +612,14 @@ int rcheevos_get_patchdata(const char* json, rcheevos_rapatchdata_t* patchdata)
       return -1;
    }
 
+   patchdata->richpresence_script = NULL;
+   patchdata->title = NULL;
+
    /* Load the achievements. */
    ud.in_cheevos       = 0;
    ud.in_lboards       = 0;
    ud.is_game_id       = 0;
+   ud.is_title         = 0;
    ud.is_console_id    = 0;
    ud.is_richpresence  = 0;
    ud.field            = NULL;
@@ -609,6 +681,7 @@ void rcheevos_free_patchdata(rcheevos_rapatchdata_t* patchdata)
    CHEEVOS_FREE(patchdata->unofficial);
    CHEEVOS_FREE(patchdata->lboards);
    CHEEVOS_FREE(patchdata->richpresence_script);
+   CHEEVOS_FREE(patchdata->title);
 
    patchdata->game_id          = 0;
    patchdata->console_id       = 0;

--- a/cheevos-new/parser.h
+++ b/cheevos-new/parser.h
@@ -44,6 +44,7 @@ typedef struct {
 typedef struct {
    unsigned game_id;
    unsigned console_id;
+   char* title;
 
    rcheevos_racheevo_t* core;
    rcheevos_racheevo_t* unofficial;

--- a/configuration.c
+++ b/configuration.c
@@ -1583,7 +1583,7 @@ static struct config_bool_setting *populate_settings_bool(settings_t *settings, 
    SETTING_BOOL("cheevos_test_unofficial",      &settings->bools.cheevos_test_unofficial, true, false, false);
    SETTING_BOOL("cheevos_hardcore_mode_enable", &settings->bools.cheevos_hardcore_mode_enable, true, false, false);
    SETTING_BOOL("cheevos_leaderboards_enable",  &settings->bools.cheevos_leaderboards_enable, true, false, false);
-   SETTING_BOOL("cheevos_richpresence_enable",  &settings->bools.cheevos_richpresence_enable, true, false, false);
+   SETTING_BOOL("cheevos_richpresence_enable",  &settings->bools.cheevos_richpresence_enable, true, true, false);
    SETTING_BOOL("cheevos_verbose_enable",       &settings->bools.cheevos_verbose_enable, true, false, false);
    SETTING_BOOL("cheevos_auto_screenshot",      &settings->bools.cheevos_auto_screenshot, true, false, false);
 #ifdef HAVE_XMB

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -15419,7 +15419,7 @@ static bool setting_append_list(
                &settings->bools.cheevos_richpresence_enable,
                MENU_ENUM_LABEL_CHEEVOS_RICHPRESENCE_ENABLE,
                MENU_ENUM_LABEL_VALUE_CHEEVOS_RICHPRESENCE_ENABLE,
-               false,
+               true,
                MENU_ENUM_LABEL_VALUE_OFF,
                MENU_ENUM_LABEL_VALUE_ON,
                &group_info,

--- a/tasks/task_http.c
+++ b/tasks/task_http.c
@@ -393,6 +393,27 @@ void* task_push_http_post_transfer(const char *url,
          url, mute, type, cb, user_data);
 }
 
+void* task_push_http_post_transfer_with_user_agent(const char *url,
+   const char *post_data, bool mute,
+   const char *type, const char* user_agent,
+   retro_task_callback_t cb, void *user_data)
+{
+   struct http_connection_t* conn;
+
+   if (string_is_empty(url))
+      return NULL;
+
+   conn = net_http_connection_new(url, "POST", post_data);
+   if (!conn)
+      return NULL;
+
+   if (user_agent != NULL)
+      net_http_connection_set_user_agent(conn, user_agent);
+
+   /* assert: task_push_http_transfer_generic will free conn on failure */
+   return task_push_http_transfer_generic(conn, url, mute, type, cb, user_data);
+}
+
 task_retriever_info_t *http_task_get_transfer_list(void)
 {
    task_retriever_data_t retrieve_data;

--- a/tasks/tasks_internal.h
+++ b/tasks/tasks_internal.h
@@ -76,6 +76,9 @@ void *task_push_http_transfer_with_user_agent(const char *url, bool mute, const 
 void *task_push_http_post_transfer(const char *url, const char *post_data, bool mute, const char *type,
       retro_task_callback_t cb, void *userdata);
 
+void *task_push_http_post_transfer_with_user_agent(const char* url, const char* post_data, bool mute,
+   const char* type, const char* user_agent, retro_task_callback_t cb, void* user_data);
+
 task_retriever_info_t *http_task_get_transfer_list(void);
 
 bool task_push_wifi_scan(retro_task_callback_t cb);


### PR DESCRIPTION
## Description

Follow-up for #9948 (which implements #9814)

Made the following changes:
* Change default value for `cheevos_richpresence_enable` to true. Users already have to opt-in to achievements, and there's a certain level of expectation that doing so is enough to show up in the player activity list.
* Proper handling of error codes returned by `rc_richpresence_size`
* Moved the string unescaping logic into the patchdata parser
  * Fixed handling of escaped quotes
* If game does not provide a rich presence script, use "Playing [gamename]" as the rich presence
* Url-encode rich presence string when sending to server. `&` and `+` are valid url characters and needed to be escaped.
* Include custom User-Agent in rich presence update server call

## Related Issues

Most of the changes listed were provided as unaddressed feedback in #9948. 

## Related Pull Requests

n/a

## Reviewers

@meleu @leiradel 
