### PR TITLE
DO NOT MERGE - Proof of Concept: Changes regarding Quick Menu - Contr..

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -7080,9 +7080,10 @@ static bool setting_append_list_input_player_options(
       snprintf(split_joycon_lbl[user], sizeof(label[user]),
                "%s %u", msg_hash_to_str(MENU_ENUM_LABEL_VALUE_INPUT_SPLIT_JOYCON), user + 1);
 
+      // Changed label MENU_ENUM_LABEL_VALUE_INPUT_DEVICE_INDEX "Device Index" to "Port %u Binds" - useful for label to be visible in Quick Menu
       snprintf(label[user], sizeof(label[user]),
-               "%s",
-               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_INPUT_DEVICE_INDEX));
+               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_INPUT_USER_BINDS), user + 1);
+
       snprintf(label_type[user], sizeof(label_type[user]),
                "%s",
                msg_hash_to_str(MENU_ENUM_LABEL_VALUE_INPUT_DEVICE_TYPE));
@@ -7187,6 +7188,9 @@ static bool setting_append_list_input_player_options(
       (*list)[list_info->index - 1].action_right  = &setting_action_right_bind_device;
       (*list)[list_info->index - 1].action_select = &setting_action_right_bind_device;
       (*list)[list_info->index - 1].get_string_representation = &get_string_representation_bind_device;
+      // Creating list with Device Index menu settings - used in Quick Menu for quick swapping
+      MENU_SETTINGS_LIST_CURRENT_ADD_ENUM_IDX_PTR(list, list_info,
+         (enum msg_hash_enums)(MENU_ENUM_LABEL_VALUE_INPUT_DEVICE_INDEX + user));
 
       CONFIG_ACTION_ALT(
             list, list_info,


### PR DESCRIPTION
…ols and usability

## Description
Background: I am using RetroArch to play fighting games locally with the community for this genre.
In our use case, we often switch controllers/user sides/control schemes between sets of matches.
These changes aim to improve accessibility to these functionalities, also to remove the reliance on User 1 to access the Quick Menu.

This pull request includes the following changes:
1. **All Users** can access **Quick Menu** via Menu Gamepad Toggle Combo hotkey.
A popup notification will display which User has triggered the hotkey: https://i.imgur.com/BQKEby2.png
Before this change, only designated User1 could access Quick Menu.

2. **Switching controller ports** can be done via **Quick Menu**: https://i.imgur.com/2t0VrHF.png
Before this change, it was necessary to navigate all the way to Main Menu - Settings - Input - Port %u Binds

3. Raised Controls placement in Quick Menu order list. Lowered Restart and Quit to the bottom.
This is a trivial change, mostly personal preference. Can safely be ignored.
In my usage I place more emphasis on changing Controls, while Restart or Quit where among the rarer things to do while playing.

Technical notes:
• For distinction, my in-line comments are with double slash //  (instead of the general /* .. */ usage)
• RetroArch has 2 functions that handle inputs, which are almost identical: input_menu_keys_pressed and input_keys_pressed
The main difference between them being **input_keys_pressed** is hardcoded to only declare and take inputs from User1:
`const struct retro_keybind *binds = input_config_binds[0];`
By calling **input_menu_keys_pressed** instead of **input_keys_pressed**, other Users can trigger the hotkeys. 

However I'm sure more experienced contributors can implement a more elegant/unified solution.

## Related issues

From my testing I haven't picked up on any side effects.
Potential issues:
• Locking out controls when swapping controllers directly from Quick Menu, if all are set to Disabled. This can be prevented by not allowing the value Disabled when only 1 active controller is assigned to any User.
• If hotkeys can be triggered during Netplay sessions(?), guest players might not play nice with the host

## Conclusion

Hopefully this PR could inspire similar usability changes within mainline RetroArch.