### PR TITLE
connmanctl: display more chars from SSID

### DIFF
--- a/wifi/drivers/connmanctl.c
+++ b/wifi/drivers/connmanctl.c
@@ -195,7 +195,7 @@ static void connmanctl_get_ssids(struct string_list* ssids)
 
    for (i = 0; i < lines->size; i++)
    {
-      char ssid[20];
+      char ssid[32];
       const char *line = lines->elems[i].data;
 
       strlcpy(ssid, line+4, sizeof(ssid));


### PR DESCRIPTION
## Description
Currently only 20 chars of the SSID are shown in the list of available access points. Some users have APs with longer names where as the first X characters are same and only differ by the last couple of chars (e.g. Very_Long_Name_For_AP_2G vs Very_Long_Name_For_AP_5G would both show up as Very_Long_Name_For_AP). With this change first 32 characters will be shown.

## Related Issues
See https://github.com/libretro/Lakka-LibreELEC/issues/890