### PR TITLE
(Ozone) Enable configuration of background opacity when content is running

### DIFF
--- a/menu/drivers/ozone/ozone_entries.c
+++ b/menu/drivers/ozone/ozone_entries.c
@@ -747,7 +747,7 @@ void ozone_draw_thumbnail_bar(ozone_handle_t *ozone, video_frame_info_t *video_i
    bool show_left_thumbnail;
 
    /* Background */
-   if (!video_info->libretro_running)
+   if (!video_info->libretro_running || (video_info->menu_framebuffer_opacity >= 1.0f))
    {
       gfx_display_draw_quad(video_info, x_position, ozone->dimensions.header_height + ozone->dimensions.spacer_1px, (unsigned) ozone->animations.thumbnail_bar_position, ozone->dimensions.sidebar_gradient_height, video_info->width, video_info->height, ozone->theme->sidebar_top_gradient);
       gfx_display_draw_quad(video_info, x_position, ozone->dimensions.header_height + ozone->dimensions.spacer_1px + ozone->dimensions.sidebar_gradient_height, (unsigned) ozone->animations.thumbnail_bar_position, sidebar_height, video_info->width, video_info->height, ozone->theme->sidebar_background);

--- a/menu/drivers/ozone/ozone_sidebar.c
+++ b/menu/drivers/ozone/ozone_sidebar.c
@@ -151,7 +151,7 @@ void ozone_draw_sidebar(ozone_handle_t *ozone, video_frame_info_t *video_info)
    /* Background */
    sidebar_height = video_info->height - ozone->dimensions.header_height - ozone->dimensions.sidebar_gradient_height * 2 - ozone->dimensions.footer_height;
 
-   if (!video_info->libretro_running)
+   if (!video_info->libretro_running || (video_info->menu_framebuffer_opacity >= 1.0f))
    {
       gfx_display_draw_quad(video_info, ozone->sidebar_offset, ozone->dimensions.header_height + ozone->dimensions.spacer_1px, (unsigned) ozone->dimensions.sidebar_width, ozone->dimensions.sidebar_gradient_height, video_info->width, video_info->height, ozone->theme->sidebar_top_gradient);
       gfx_display_draw_quad(video_info, ozone->sidebar_offset, ozone->dimensions.header_height + ozone->dimensions.spacer_1px + ozone->dimensions.sidebar_gradient_height, (unsigned) ozone->dimensions.sidebar_width, sidebar_height, video_info->width, video_info->height, ozone->theme->sidebar_background);

--- a/menu/drivers/ozone/ozone_theme.h
+++ b/menu/drivers/ozone/ozone_theme.h
@@ -151,8 +151,10 @@ extern unsigned ozone_themes_count;
 extern unsigned last_color_theme;
 extern bool last_use_preferred_system_color_theme;
 extern ozone_theme_t *ozone_default_theme;
+extern float last_framebuffer_opacity;
 
 void ozone_set_color_theme(ozone_handle_t *ozone, unsigned color_theme);
 unsigned ozone_get_system_theme(void);
+void ozone_set_background_running_opacity(ozone_handle_t *ozone, float framebuffer_opacity);
 
 #endif

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -12294,7 +12294,8 @@ static bool setting_append_list(
 
          START_SUB_GROUP(list, list_info, "State", &group_info, &subgroup_info, parent_group);
 
-         if (string_is_not_equal(settings->arrays.menu_driver, "rgui"))
+         if (string_is_not_equal(settings->arrays.menu_driver, "rgui") &&
+             string_is_not_equal(settings->arrays.menu_driver, "ozone"))
          {
             CONFIG_PATH(
                   list, list_info,
@@ -12325,7 +12326,10 @@ static bool setting_append_list(
             (*list)[list_info->index - 1].action_ok = &setting_action_ok_uint;
             menu_settings_list_current_add_range(list, list_info, 0.0, 1.0, 0.010, true, true);
             SETTINGS_DATA_LIST_CURRENT_ADD_FLAGS(list, list_info, SD_FLAG_LAKKA_ADVANCED);
+         }
 
+         if (string_is_not_equal(settings->arrays.menu_driver, "rgui"))
+         {
             CONFIG_FLOAT(
                   list, list_info,
                   &settings->floats.menu_framebuffer_opacity,


### PR DESCRIPTION
## Description

This PR simply allows the opacity of the Ozone menu background (while content is running) to be adjusted via the `Framebuffer Opacity` setting under `User Interface > Appearance`. This brings Ozone in line with XMB and MaterialUI.

- At the default `Framebuffer Opacity` of `0.9`, the visual appearance of the background is identical to that at present

- The PR also fixes a small bug which caused the theme to be updated on every frame (!) if `Use preferred system color theme` was enabled, and the system theme did not match `Menu Color Theme`