### PR TITLE
(Ozone) Add rudimentary pointer support

### DIFF
--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -1206,10 +1206,19 @@ static void ozone_render(void *data,
       bool last_category_found      = false;
 
       /* Check whether pointer is operating on entries
-       * or sidebar */
+       * or sidebar
+       * > Note: Since touchscreens effectively 'lose their
+       *   place' when a touch is released, we can only perform
+       *   this this check if the pointer is currently
+       *   pressed - i.e. we must preserve the values set the
+       *   last time the screen was touched.
+       *   With mouse input we have a permanent cursor, so this
+       *   is not an issue */
       ozone->last_pointer_in_sidebar = ozone->pointer_in_sidebar;
-      ozone->pointer_in_sidebar      = ozone->pointer.x <
-            ozone->dimensions.sidebar_width + ozone->sidebar_offset;
+      if ((ozone->pointer.type == MENU_POINTER_MOUSE) ||
+           ozone->pointer.pressed)
+         ozone->pointer_in_sidebar   = ozone->pointer.x <
+               ozone->dimensions.sidebar_width + ozone->sidebar_offset;
 
       /* If pointer has switched from entries to sidebar
        * or vice versa, must reset pointer acceleration */

--- a/menu/drivers/ozone/ozone.h
+++ b/menu/drivers/ozone/ozone.h
@@ -66,6 +66,10 @@ typedef struct ozone_handle ozone_handle_t;
 #define FULLSCREEN_THUMBNAIL_PADDING 48
 
 #define CURSOR_SIZE 64
+/* Cursor becomes active when it moves more
+ * than CURSOR_ACTIVE_DELTA pixels (adjusted
+ * by current scale factor) */
+#define CURSOR_ACTIVE_DELTA 3
 
 #define INTERVAL_OSK_CURSOR            (0.5f * 1000000)
 
@@ -77,6 +81,13 @@ typedef struct ozone_handle ozone_handle_t;
  * UCN equivalent: "\u2003\u2022\u2003" */
 #define OZONE_TICKER_SPACER "\xE2\x80\x83\xE2\x80\xA2\xE2\x80\x83"
 #endif
+
+enum ozone_onscreen_entry_position_type
+{
+   OZONE_ONSCREEN_ENTRY_FIRST = 0,
+   OZONE_ONSCREEN_ENTRY_LAST,
+   OZONE_ONSCREEN_ENTRY_CENTRE
+};
 
 struct ozone_handle
 {
@@ -240,6 +251,16 @@ struct ozone_handle
       int spacer_3px;
       int spacer_5px;
    } dimensions;
+
+   menu_input_pointer_t pointer;
+   int16_t pointer_active_delta;
+   bool pointer_in_sidebar;
+   bool last_pointer_in_sidebar;
+   size_t pointer_categories_selection;
+   size_t first_onscreen_entry;
+   size_t last_onscreen_entry;
+   size_t first_onscreen_category;
+   size_t last_onscreen_category;
 
    bool show_cursor;
    bool cursor_mode;

--- a/menu/drivers/ozone/ozone_entries.c
+++ b/menu/drivers/ozone/ozone_entries.c
@@ -157,6 +157,14 @@ void ozone_update_scroll(ozone_handle_t *ozone, bool allow_animation, ozone_node
    if (new_scroll > 0)
       new_scroll = 0;
 
+   /* Kill any existing scroll animation */
+   gfx_animation_kill_by_tag(&tag);
+
+   /* ozone->animations.scroll_y will be modified
+    * > Set scroll acceleration to zero to minimise
+    *   potential conflicts */
+   menu_input_set_pointer_y_accel(0.0f);
+
    if (allow_animation)
    {
       /* Cursor animation */
@@ -352,7 +360,6 @@ void ozone_draw_entries(ozone_handle_t *ozone, video_frame_info_t *video_info,
    size_t i, y, entries_end;
    float sidebar_offset, bottom_boundary, invert, alpha_anim;
    unsigned video_info_height, video_info_width, entry_width, button_height;
-   menu_input_pointer_t pointer;
    settings_t *settings = config_get_ptr();
 
    bool old_list           = selection_buf == ozone->selection_buf_old;
@@ -361,29 +368,7 @@ void ozone_draw_entries(ozone_handle_t *ozone, video_frame_info_t *video_info,
    size_t old_selection_y  = 0;
    int entry_padding       = ozone_get_entries_padding(ozone, old_list);
 
-   int16_t cursor_x        = 0;
-   int16_t cursor_y        = 0;
-
    float scale_factor      = ozone->last_scale_factor;
-
-   menu_input_get_pointer_state(&pointer);
-
-   if (pointer.type != MENU_POINTER_DISABLED)
-   {
-      cursor_x = pointer.x;
-      cursor_y = pointer.y;
-
-      /* Not sure why it's done like this - best to leave well alone for now... */
-      if (settings->bools.menu_mouse_enable && !ozone->cursor_mode && (cursor_x != ozone->cursor_x_old || cursor_y != ozone->cursor_y_old))
-         ozone->cursor_mode = true;
-      else if (!settings->bools.menu_mouse_enable)
-         ozone->cursor_mode = false; /* we need to disable it on the fly */
-   }
-   else
-      ozone->cursor_mode = false;
-
-   ozone->cursor_x_old = cursor_x;
-   ozone->cursor_y_old = cursor_y;
 
    menu_entries_ctl(MENU_ENTRIES_CTL_START_GET, &i);
 
@@ -450,12 +435,6 @@ void ozone_draw_entries(ozone_handle_t *ozone, video_frame_info_t *video_info,
          border_start_y, entry_width, ozone->dimensions.spacer_1px, video_info->width, video_info->height, ozone->theme_dynamic.entries_border);
       gfx_display_draw_quad(video_info, border_start_x,
          border_start_y + button_height, entry_width, ozone->dimensions.spacer_1px, video_info->width, video_info->height, ozone->theme_dynamic.entries_border);
-
-      /* Cursor */
-      if (!old_list && ozone->cursor_mode)
-         if (  cursor_x >= border_start_x && (cursor_x <= border_start_x + (int)entry_width) &&
-               cursor_y >= border_start_y && (cursor_y <= border_start_y + (int)button_height))
-            menu_input_set_pointer_selection(i);
 
 border_iterate:
       if (node)

--- a/menu/drivers/ozone/ozone_sidebar.c
+++ b/menu/drivers/ozone/ozone_sidebar.c
@@ -146,7 +146,7 @@ void ozone_draw_sidebar(ozone_handle_t *ozone, video_frame_info_t *video_info)
    if (ozone->horizontal_list)
       horizontal_list_size = (unsigned)ozone->horizontal_list->size;
 
-   gfx_display_scissor_begin(video_info, 0, ozone->dimensions.header_height, (unsigned) ozone->dimensions.sidebar_width, video_info->height - ozone->dimensions.header_height - ozone->dimensions.footer_height);
+   gfx_display_scissor_begin(video_info, 0, ozone->dimensions.header_height + ozone->dimensions.spacer_1px, (unsigned) ozone->dimensions.sidebar_width, video_info->height - ozone->dimensions.header_height - ozone->dimensions.footer_height - ozone->dimensions.spacer_1px);
 
    /* Background */
    sidebar_height = video_info->height - ozone->dimensions.header_height - ozone->dimensions.sidebar_gradient_height * 2 - ozone->dimensions.footer_height;
@@ -485,6 +485,11 @@ void ozone_sidebar_goto(ozone_handle_t *ozone, unsigned new_selection)
 
       gfx_animation_kill_by_tag(&tag);
    }
+
+   /* ozone->animations.scroll_y_sidebar will be modified
+    * > Set scroll acceleration to zero to minimise
+    *   potential conflicts */
+   menu_input_set_pointer_y_accel(0.0f);
 
    /* Cursor animation */
    ozone->animations.cursor_alpha = 0.0f;


### PR DESCRIPTION
## Description

At present, it is impossible to control the Ozone menu driver using only a mouse or touchscreen. This PR remedies the issue by adding rudimentary pointer support:

- Pointer can be used to switch between sidebar and entries list

- Pointer can be used to select sidebar and entries list items

- Both sidebar and entries list can be scrolled by dragging

- Clicking/pressing the header or footer produces a 'cancel' action

**Mouse-specific notes:**

- Cursor focus follows mouse pointer from sidebar to entries list (and vice versa)

- In entries list, item under cursor is automatically selected (with some fudging to ensure this doesn't break mouse wheel scrolling) 

- In sidebar, item under cursor *is not* automatically selected (this is too jarring)

**Touchscreen-specific notes:**

- Touch screen input is a little clunky, since we can't automatically switch from sidebar to entries list (there is no 'cursor focus' to follow, and it's not possible to cross the boundary *and* action an item in one go - this breaks the menu, so some internal changes would be required to support this...)

- So at present: if the cursor is in the entries list, the sidebar must be touched once before a sidebar item can be selected - and likewise, if the cursor is in the sidebar, the entries list must be pressed once before an entry can be selected (in the latter case, the touched entry will only be highlighted on the first press)

- *If the cursor is in the entries list*, short pressing an item will highlight it without actually selecting it; tapping the entry (i.e. instantaneous press) will always select and action it.

- When viewing playlists, swiping left/right will descend/ascend the alphabet (same as pressing PgUp/PgDn on a keyboard). Note: We cannot enable this when using a mouse, since it conflicts with the automatic 'entry under cursor' selection

Note that this really is just a starting point for 'proper' pointer control. This PR makes Ozone fully functional with a mouse/touchscreen, but there is great deal left to add and improve.

## Reviewers

@natinusala 
