### PR TITLE
(cheevos) delay subsequent unlock attempts on failure

### DIFF
--- a/libretro-common/include/queues/task_queue.h
+++ b/libretro-common/include/queues/task_queue.h
@@ -30,6 +30,8 @@
 #include <retro_common.h>
 #include <retro_common_api.h>
 
+#include <libretro.h>
+
 RETRO_BEGIN_DECLS
 
 enum task_type
@@ -125,6 +127,9 @@ struct retro_task
 
    /* don't touch this. */
    retro_task_t *next;
+
+   /* when the task should run (0 for as soon as possible) */
+   retro_time_t when;
 };
 
 typedef struct task_finder_data

--- a/libretro-common/queues/task_queue.c
+++ b/libretro-common/queues/task_queue.c
@@ -115,6 +115,10 @@ static void task_queue_put(task_queue_t *queue, retro_task_t *task)
 
    if (queue->front)
    {
+      /* Make sure to insert in order - the queue is sorted by 'when' so items that aren't scheduled
+       * to run immediately are at the back of the queue. Items with the same 'when' are inserted after
+       * all the other items with the same 'when'. This primarily affects items with a 'when' of 0.
+       */
       if (queue->back->when > task->when)
       {
          retro_task_t** prev = &queue->front;
@@ -341,6 +345,7 @@ static void task_queue_remove(task_queue_t *queue, retro_task_t *task)
          t->next    = task->next;
          task->next = NULL;
 
+         /* When removing the tail of the queue, update the tail pointer */
          if (queue->back == task)
          {
             slock_lock(queue_lock);


### PR DESCRIPTION
## Description

Adds a `when` property to `retro_task_t`. When processing the queue in threaded mode, the thread will sleep until the next scheduled task via `scond_wait_timeout`. In non-threaded mode, tasks that shouldn't run yet are ignored. If `when` is left at 0, the task will run as soon as possible.

This fuctionality has been hooked up to the achievement unlock retry code. The first retry will be scheduled with a 250ms delay. Each additional retry will double the wait until the retries are spaced two minutes apart.

When investigating #10138, I noticed that the retry loop was very tight. As soon as the failure occurred, the request would be immediately requeued, and this would continue over and over again until the request finally went through. It's a very busy loop, as the network failure would return an error almost immediately. 

The trade-off to this implementation is that once network connectivity is restored, it may still take up to two minutes before the unlocks are sent. It seems unlikely that users are accustomed to playing "offline" and reconnecting for a brief moment to flush their unlocks before shutting down the application, but if they do, they could be impacted.

Additionally, the rich presence functionality has been moved to a two-minute scheduled task. This ensures the rich presence information is sent to the server even if the user is in the RetroArch menu or another application, which ensures they remain on the Active Users list on retroachievements.org.

A similar change should be made for leaderboard submits as well, but I wanted approval on the approach/implementation first.

## Related Issues

#10138 - this addresses the busy loop. I do not claim that it fixes the original problem, which I have not been able to reproduce.

## Related Pull Requests

n/a

## Reviewers

@twinaphex 