### PR TITLE
qt: fix ui "views" menu for drivers without kiosk mode

### DIFF
--- a/ui/drivers/qt/options/ui.cpp
+++ b/ui/drivers/qt/options/ui.cpp
@@ -112,13 +112,14 @@ QWidget *ViewsPage::widget()
       unsigned status_begin = 0;
       file_list_t *list     = (file_list_t*)calloc(1, sizeof(*list));
       menu_displaylist_build_list(list, DISPLAYLIST_MENU_VIEWS_SETTINGS_LIST, true);
+      rarch_setting_t *kioskMode = menu_setting_find_enum(MENU_ENUM_LABEL_MENU_ENABLE_KIOSK_MODE);
 
       for (i = 0; i < list->size; i++)
       {
          menu_file_list_cbs_t *cbs = (menu_file_list_cbs_t*)
             file_list_get_actiondata_at_offset(list, i);
 
-         if (cbs->enum_idx == MENU_ENUM_LABEL_CONTENT_SHOW_SETTINGS)
+         if (cbs->enum_idx == (kioskMode ? MENU_ENUM_LABEL_CONTENT_SHOW_SETTINGS : MENU_ENUM_LABEL_CONTENT_SHOW_FAVORITES))
          {
             tabs_begin = i;
             break;
@@ -180,10 +181,10 @@ QWidget *ViewsPage::widget()
 
    leftLayout->addRow(mainMenu);
    leftLayout->addRow(settings);
-   leftLayout->addRow(tabs);
    leftLayout->addRow(startScreen);
    leftLayout->add(MENU_ENUM_LABEL_MENU_SHOW_SUBLABELS);
 
+   rightLayout->addWidget(tabs);
    rightLayout->addWidget(quickMenu);
    rightLayout->addWidget(status);
    rightLayout->addStretch();


### PR DESCRIPTION
Menu drivers without kiosk mode don't have MENU_ENUM_LABEL_CONTENT_SHOW_SETTINGS
which was in a condition to group items together and causing overflow:
![before](https://user-images.githubusercontent.com/6266038/75096506-6c666680-55a0-11ea-89c7-ab8ebdd11d89.png)

Now we're checking if kiosk mode is present and stop on the next accessible item if not.
And "Tabs" were moved to the right side as that looks better:
![now](https://user-images.githubusercontent.com/6266038/75096526-a5064000-55a0-11ea-8488-8322f3430ae2.png)
