### PR TITLE
(cheevos) reset token when username or password changes

### DIFF
--- a/cheevos-new/parser.h
+++ b/cheevos-new/parser.h
@@ -58,6 +58,7 @@ typedef struct {
 
 typedef void (*rcheevos_unlock_cb_t)(unsigned id, void* userdata);
 
+int rcheevos_get_json_error(const char* json, char* token, size_t length);
 int rcheevos_get_token(const char* json, char* token, size_t length);
 
 int  rcheevos_get_patchdata(const char* json, rcheevos_rapatchdata_t* patchdata);

--- a/menu/cbs/menu_cbs_get_value.c
+++ b/menu/cbs/menu_cbs_get_value.c
@@ -1854,7 +1854,7 @@ int menu_cbs_init_bind_get_string_representation(menu_file_list_cbs_t *cbs,
       }
    }
 
-   if (cbs->setting)
+   if (cbs->setting && !cbs->setting->get_string_representation)
    {
       switch (setting_get_type(cbs->setting))
       {

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -2828,7 +2828,13 @@ static void setting_get_string_representation_cheevos_password(
    if (!string_is_empty(setting->value.target.string))
       strlcpy(s, "********", len);
    else
-      *setting->value.target.string = '\0';
+   {
+      settings_t *settings = config_get_ptr();
+      if (settings->arrays.cheevos_token[0])
+         strlcpy(s, "********", len);
+      else
+         *setting->value.target.string = '\0';
+   }
 }
 #endif
 
@@ -6807,6 +6813,15 @@ void general_write_handler(rarch_setting_t *setting)
                /* No action required */
                break;
          }
+         break;
+      case MENU_ENUM_LABEL_CHEEVOS_USERNAME:
+         /* when changing the username, clear out the password and token */
+         settings->arrays.cheevos_password[0] = '\0';
+         settings->arrays.cheevos_token[0] = '\0';
+         break;
+      case MENU_ENUM_LABEL_CHEEVOS_PASSWORD:
+         /* when changing the password, clear out the token */
+         settings->arrays.cheevos_token[0] = '\0';
          break;
       default:
          break;


### PR DESCRIPTION
## Description

Clears out the user's retroachievements login token when they change either their username or password.

https://github.com/libretro/RetroArch/commit/212d7bfbe1084ac7a1bc62be3833750a3971f1cc changed the code to store the login token and clear out the password after a successful login, but the login token remains after the username or password is changed, so it will continue to be used until the user manually removes it from their cfg file.

Also reports the authorization failure if the username/token don't match when trying to retrieve the achievement data.

## Related Issues

https://www.reddit.com/r/RetroAchievements/comments/f7h4ez/cant_change_user_on_retroarch/

## Related Pull Requests

n/a

## Reviewers

@leiradel @celerizer 
