### PR TITLE
(cheevos) simplify badge handling; remember enablement if XMB not available

### DIFF
--- a/cheevos-new/badges.c
+++ b/cheevos-new/badges.c
@@ -14,60 +14,63 @@
  */
 
 #include <file/file_path.h>
-#include <string/stdstring.h>
-
-#ifdef HAVE_MENU
-#include "../menu/menu_driver.h"
-#endif
 
 #include "../file_path_special.h"
 #include "../configuration.h"
-#include "../verbosity.h"
-#include "../network/net_http_special.h"
+#include "../gfx/gfx_display.h"
 
 #include "badges.h"
 
-badges_ctx_t badges_ctx;
-
-bool badge_exists(const char* filepath)
-{
-  return path_is_valid(filepath);
-}
-
-void set_badge_menu_texture(badges_ctx_t * badges, int i)
-{
-   char badge_file[16];
-   char fullpath[PATH_MAX_LENGTH];
-
-   snprintf(badge_file, sizeof(badge_file), "%s%s", badges->badge_id_list[i],
-         badges->badge_locked[i] ? "_lock.png" : ".png");
-
-   fill_pathname_application_special(fullpath,
-         PATH_MAX_LENGTH * sizeof(char),
-         APPLICATION_SPECIAL_DIRECTORY_THUMBNAILS_CHEEVOS_BADGES);
-
 #ifdef HAVE_MENU
-   gfx_display_reset_textures_list(badge_file, fullpath,
-         &badges->menu_texture_list[i],TEXTURE_FILTER_MIPMAP_LINEAR, NULL, NULL);
-#endif
-}
 
-void set_badge_info (badges_ctx_t *badge_struct, int id,
-      const char *badge_id, bool active)
+#define CHEEVOS_MENU_BADGE_LIMIT 256
+static uintptr_t cheevos_badge_menu_texture_list[CHEEVOS_MENU_BADGE_LIMIT] = { 0 };
+
+void cheevos_reset_menu_badges(void)
 {
-   if (!badge_struct)
-      return;
-
-   badge_struct->badge_id_list[id] = badge_id;
-   badge_struct->badge_locked[id]  = active;
-   set_badge_menu_texture(badge_struct, id);
+   memset(&cheevos_badge_menu_texture_list, 0, sizeof(cheevos_badge_menu_texture_list));
 }
 
-uintptr_t get_badge_texture(int id)
+void cheevos_set_menu_badge(int index, const char *badge, bool locked)
 {
    settings_t *settings = config_get_ptr();
-   if (!settings || !settings->bools.cheevos_badges_enable)
-      return (uintptr_t)NULL;
 
-   return badges_ctx.menu_texture_list[id];
+   if (index >= CHEEVOS_MENU_BADGE_LIMIT)
+      return;
+
+   if (!settings || !settings->bools.cheevos_badges_enable)
+      cheevos_badge_menu_texture_list[index] = 0;
+   else
+      cheevos_badge_menu_texture_list[index] = cheevos_get_badge_texture(badge, locked);
+}
+
+uintptr_t cheevos_get_menu_badge_texture(int index)
+{
+   if (index < CHEEVOS_MENU_BADGE_LIMIT)
+       return cheevos_badge_menu_texture_list[index];
+
+   return 0;
+}
+
+#endif
+
+uintptr_t cheevos_get_badge_texture(const char *badge, bool locked)
+{
+   char badge_file[24];
+   char fullpath[PATH_MAX_LENGTH];
+   uintptr_t tex;
+
+   if (!badge)
+      return 0;
+
+   snprintf(badge_file, sizeof(badge_file), "%s%s.png", badge, locked ? "_lock" : "");
+
+   fill_pathname_application_special(fullpath,
+      PATH_MAX_LENGTH * sizeof(char),
+      APPLICATION_SPECIAL_DIRECTORY_THUMBNAILS_CHEEVOS_BADGES);
+
+   gfx_display_reset_textures_list(badge_file, fullpath,
+      &tex, TEXTURE_FILTER_MIPMAP_LINEAR, NULL, NULL);
+
+   return tex;
 }

--- a/cheevos-new/badges.h
+++ b/cheevos-new/badges.h
@@ -22,26 +22,13 @@
 
 RETRO_BEGIN_DECLS
 
-#define CHEEVOS_BADGE_LIMIT 256
+#ifdef HAVE_MENU
+void cheevos_reset_menu_badges(void);
+void cheevos_set_menu_badge(int index, const char *badge, bool locked);
+uintptr_t cheevos_get_menu_badge_texture(int index);
+#endif
 
-typedef struct
-{
-  bool badge_locked[CHEEVOS_BADGE_LIMIT];
-  const char * badge_id_list[CHEEVOS_BADGE_LIMIT];
-  uintptr_t menu_texture_list[CHEEVOS_BADGE_LIMIT];
-} badges_ctx_t;
-
-bool badge_exists(const char* filepath);
-
-void set_badge_menu_texture(badges_ctx_t * badges, int i);
-
-void set_badge_info(badges_ctx_t *badge_struct,
-      int id, const char *badge_id, bool active);
-
-uintptr_t get_badge_texture(int id);
-
-extern badges_ctx_t badges_ctx;
-static badges_ctx_t new_badges_ctx;
+uintptr_t cheevos_get_badge_texture(const char* badge, bool locked);
 
 RETRO_END_DECLS
 

--- a/cheevos-new/cheevos.c
+++ b/cheevos-new/cheevos.c
@@ -1147,7 +1147,7 @@ static void rcheevos_append_menu_achievement(menu_displaylist_info_t* info, size
       cheevo->info->description, enum_idx,
       MENU_SETTINGS_CHEEVOS_START + idx, 0, 0);
 
-   set_badge_info(&badges_ctx, idx, cheevo->info->badge, active);
+   cheevos_set_menu_badge(idx, cheevo->info->badge, active);
 }
 #endif
 
@@ -2473,8 +2473,6 @@ found:
     *************************************************************************/
    CORO_SUB(RCHEEVOS_GET_BADGES)
 
-      badges_ctx = new_badges_ctx;
-
 #if defined(HAVE_GFX_WIDGETS)
       if (false) /* we always want badges if menu widgets are enabled */
 #endif
@@ -2487,6 +2485,10 @@ found:
                !settings->bools.cheevos_badges_enable)
             CORO_RET();
       }
+
+#ifdef HAVE_MENU
+      cheevos_reset_menu_badges();
+#endif
 
       for (coro->i = 0; coro->i < 2; coro->i++)
       {
@@ -2533,7 +2535,7 @@ found:
                      coro->badge_name,
                      sizeof(coro->badge_fullpath));
 
-               if (!badge_exists(coro->badge_fullpath))
+               if (!path_is_valid(coro->badge_fullpath))
                {
 #ifdef CHEEVOS_LOG_BADGES
                   CHEEVOS_LOG(

--- a/configuration.c
+++ b/configuration.c
@@ -1588,9 +1588,7 @@ static struct config_bool_setting *populate_settings_bool(settings_t *settings, 
    SETTING_BOOL("cheevos_richpresence_enable",  &settings->bools.cheevos_richpresence_enable, true, true, false);
    SETTING_BOOL("cheevos_verbose_enable",       &settings->bools.cheevos_verbose_enable, true, false, false);
    SETTING_BOOL("cheevos_auto_screenshot",      &settings->bools.cheevos_auto_screenshot, true, false, false);
-#ifdef HAVE_XMB
    SETTING_BOOL("cheevos_badges_enable",        &settings->bools.cheevos_badges_enable, true, false, false);
-#endif
 #endif
 #ifdef HAVE_OVERLAY
    SETTING_BOOL("input_overlay_enable",         &settings->bools.input_overlay_enable, true, config_overlay_enable_default(), false);

--- a/gfx/gfx_widgets.c
+++ b/gfx/gfx_widgets.c
@@ -34,6 +34,10 @@
 
 #include "../tasks/task_content.h"
 
+#ifdef HAVE_CHEEVOS
+#include "../cheevos-new/badges.h"
+#endif
+
 /* TODO: Fix context reset freezing everything in place (probably kills animations when it shouldn't anymore) */
 
 static float msg_queue_background[16]  = COLOR_HEX_TO_FLOAT(0x3A3A3A, 1.0f);
@@ -2540,28 +2544,6 @@ static void gfx_widgets_start_achievement_notification(void)
    gfx_animation_push(&entry);
 }
 
-static void gfx_widgets_get_badge_texture(
-      uintptr_t *tex, const char *badge)
-{
-   char badge_file[16];
-   char fullpath[PATH_MAX_LENGTH];
-
-   if (!badge)
-   {
-      *tex = 0;
-      return;
-   }
-
-   strlcpy(badge_file, badge, sizeof(badge_file));
-   strlcat(badge_file, ".png", sizeof(badge_file));
-   fill_pathname_application_special(fullpath,
-         PATH_MAX_LENGTH * sizeof(char),
-         APPLICATION_SPECIAL_DIRECTORY_THUMBNAILS_CHEEVOS_BADGES);
-
-   gfx_display_reset_textures_list(badge_file, fullpath,
-         tex, TEXTURE_FILTER_MIPMAP_LINEAR, NULL, NULL);
-}
-
 void gfx_widgets_push_achievement(const char *title, const char *badge)
 {
    gfx_widgets_achievement_free(NULL);
@@ -2569,7 +2551,7 @@ void gfx_widgets_push_achievement(const char *title, const char *badge)
    /* TODO: Make a queue of notifications to display */
 
    cheevo_title = strdup(title);
-   gfx_widgets_get_badge_texture(&cheevo_badge, badge);
+   cheevo_badge = cheevos_get_badge_texture(badge, 0);
 
    gfx_widgets_start_achievement_notification();
 }

--- a/menu/drivers/ozone/ozone_texture.c
+++ b/menu/drivers/ozone/ozone_texture.c
@@ -412,9 +412,10 @@ uintptr_t ozone_entries_icon_get_texture(ozone_handle_t *ozone,
          (type < MENU_SETTINGS_NETPLAY_ROOMS_START)
       )
    {
-      int new_id = type - MENU_SETTINGS_CHEEVOS_START;
-      if (get_badge_texture(new_id) != 0)
-         return get_badge_texture(new_id);
+      int index = type - MENU_SETTINGS_CHEEVOS_START;
+      uintptr_t badge_texture = cheevos_get_menu_badge_texture(index);
+      if (badge_texture)
+         return badge_texture;
       /* Should be replaced with placeholder badge icon. */
       return ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_ACHIEVEMENTS];
    }

--- a/menu/drivers/stripes.c
+++ b/menu/drivers/stripes.c
@@ -2270,9 +2270,10 @@ static uintptr_t stripes_icon_get_id(stripes_handle_t *stripes,
          (type < MENU_SETTINGS_NETPLAY_ROOMS_START)
       )
    {
-      int new_id = type - MENU_SETTINGS_CHEEVOS_START;
-      if (get_badge_texture(new_id) != 0)
-         return get_badge_texture(new_id);
+      int index = type - MENU_SETTINGS_CHEEVOS_START;
+      uintptr_t badge_texture = cheevos_get_menu_badge_texture(index);
+      if (badge_texture)
+         return badge_texture;
       /* Should be replaced with placeholder badge icon. */
       return stripes->textures.list[STRIPES_TEXTURE_SUBSETTING];
    }

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -2711,9 +2711,10 @@ static uintptr_t xmb_icon_get_id(xmb_handle_t *xmb,
          (type < MENU_SETTINGS_NETPLAY_ROOMS_START)
       )
    {
-      int new_id = type - MENU_SETTINGS_CHEEVOS_START;
-      if (get_badge_texture(new_id) != 0)
-         return get_badge_texture(new_id);
+      int index = type - MENU_SETTINGS_CHEEVOS_START;
+      uintptr_t badge_texture = cheevos_get_menu_badge_texture(index);
+      if (badge_texture)
+         return badge_texture;
       /* Should be replaced with placeholder badge icon. */
       return xmb->textures.list[XMB_TEXTURE_ACHIEVEMENTS];
    }


### PR DESCRIPTION
## Description

* Eliminates some unused fields from the static badge_ctx structure and a secondary static instance used to reset the structure. 
* Eliminates the duplicated code for loading the badge texture in the popup widget. 
* Adds bounds checking in case a game ever has more than 256 achievements.
* Allows the `cheevos_badges_enabled` configuration to be read if `HAVE_XMB` is not defined.

I believe the last change addresses #10053. 

However, because `HAVE_GFX_WIDGETS` forces the badges to be downloaded https://github.com/libretro/RetroArch/blob/c356e71b0a1e16303d98836bdb02b3b0f99acfcb/cheevos-new/cheevos.c#L2478-L2480 it might be better to remove the menu option (and related config) entirely when `HAVE_GFX_WIDGETS` is enabled - in that case, it only affects whether or not the badges are shown in the menu. Since they've already been downloaded, why not show them?

Alternately, we could make the popup widgets honor the `cheevos_badges_enabled` setting, not download the badges, and show the default trophy icon.

## Related Issues

#10053

## Related Pull Requests

n/a

## Reviewers

@leiradel
