### PR TITLE
qt: move gfx widget option to OSD

### DIFF
--- a/ui/drivers/qt/options/osd.cpp
+++ b/ui/drivers/qt/options/osd.cpp
@@ -52,6 +52,7 @@ QWidget *NotificationsPage::widget()
 
    notificationsGroup->addRow(bgGroup);
 
+   notificationsGroup->add(MENU_ENUM_LABEL_MENU_WIDGETS_ENABLE);
    notificationsGroup->add(MENU_ENUM_LABEL_MENU_WIDGET_SCALE_AUTO);
    notificationsGroup->add(MENU_ENUM_LABEL_MENU_WIDGET_SCALE_FACTOR);
 

--- a/ui/drivers/qt/options/ui.cpp
+++ b/ui/drivers/qt/options/ui.cpp
@@ -45,7 +45,6 @@ QWidget *UserInterfacePage::widget()
    rarch_setting_t           *kioskMode = menu_setting_find_enum(MENU_ENUM_LABEL_MENU_ENABLE_KIOSK_MODE);
 
    menuGroup->add(MENU_ENUM_LABEL_SHOW_ADVANCED_SETTINGS);
-   menuGroup->add(MENU_ENUM_LABEL_MENU_WIDGETS_ENABLE);
 
    /* only on XMB and Ozone*/
    if (kioskMode)


### PR DESCRIPTION
Move "enable gfx widgets" from UI to OSD for qt to be like other menus.