### PR TITLE
(Ozone) Fix entry height calculation

### DIFF
--- a/menu/drivers/ozone/ozone_entries.c
+++ b/menu/drivers/ozone/ozone_entries.c
@@ -273,10 +273,12 @@ void ozone_compute_entries_position(ozone_handle_t *ozone)
                entry_padding * 2 - ozone->dimensions.entry_icon_padding * 2;
 
             if (ozone->depth == 1)
+            {
                sublabel_max_width -= (unsigned) ozone->dimensions.sidebar_width;
 
-            if (ozone->show_thumbnail_bar)
-               sublabel_max_width -= ozone->dimensions.thumbnail_bar_width;
+               if (ozone->show_thumbnail_bar)
+                  sublabel_max_width -= ozone->dimensions.thumbnail_bar_width;
+            }
 
             word_wrap(wrapped_sublabel_str, sublabel_str, sublabel_max_width / ozone->sublabel_font_glyph_width, false, 0);
 


### PR DESCRIPTION
## Description

I noticed that Ozone has a small bug in its entry height calculation, which causes incorrect sublabel spacing in some circumstances - e.g. if you load content, open the quick menu, go back to the previous level and then return to the quick menu, you get something like this:

![Screenshot_2020-02-27_17-08-17](https://user-images.githubusercontent.com/38211560/75468327-f473b400-5984-11ea-92a4-51e329ba0233.png)

Note the errant spacing under `Resume` and `Close Content`.

This trivial PR fixes the issue.