### PR TITLE
Fix to correctly set header.metadata_offset

### DIFF
--- a/libretro-db/libretrodb.c
+++ b/libretro-db/libretrodb.c
@@ -173,8 +173,7 @@ int libretrodb_create(RFILE *fd, libretrodb_value_provider value_provider,
    if ((rv = rmsgpack_dom_write(fd, &sentinal)) < 0)
       goto clean;
 
-   header.metadata_offset = swap_if_little64(filestream_seek(
-            fd, 0, RETRO_VFS_SEEK_POSITION_CURRENT));
+   header.metadata_offset = swap_if_little64(filestream_tell(fd));
    md.count = item_count;
    libretrodb_write_metadata(fd, &md);
    filestream_seek(fd, root, RETRO_VFS_SEEK_POSITION_START);


### PR DESCRIPTION
This fix will correctly set ``header.metadata_offset`` in ``libretrodb_create`` instead of always setting it to zero.

The main problem was using ``filestream_seek`` when ``filestream_tell`` should be used to get the actual offset.

See issue #10140

## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

[Description of the pull request, detail any issues you are fixing or any features you are implementing]

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
