### PR TITLE
Avoid overflow when calculating multiplying performance counter

### DIFF
--- a/libretro-common/features/features_cpu.c
+++ b/libretro-common/features/features_cpu.c
@@ -225,7 +225,7 @@ retro_time_t cpu_features_get_time_usec(void)
 
    if (!QueryPerformanceCounter(&count))
       return 0;
-   return count.QuadPart * 1000000 / freq.QuadPart;
+   return (count.QuadPart / freq.QuadPart * 1000000) + (count.QuadPart % freq.QuadPart * 1000000 / freq.QuadPart);
 #elif defined(__CELLOS_LV2__)
    return sys_time_get_system_time();
 #elif defined(GEKKO)


### PR DESCRIPTION
<@Jamiras> I'm having an issue with cpu_features_get_time_usec on Windows. This line: https://github.com/libretro/RetroArch/blob/master/libretro-common/features/features_cpu.c#L228
is causing the returned value to be negative, which is interfering with the usage I recently added for scheduled tasks https://github.com/libretro/RetroArch/pull/10143. When a negative time is used to schedule a task, it is given priority over any tasks that are supposed to be immediate (time = 0). As such, immediate tasks are delayed until the scheduled task completes.
\<Jamiras> QueryPerformanceCounter is currently returning ~11805311708520 on my machine (0x00000ABCA3692D68). When multiplied by 1000000, it becomes 0xA3D4E473A1182A00. Note the high bit of the 64-bit value is set, so the value is now signed. When divided by 1000000, the result becomes 0xFFFFF9F5ABC8777B, which is what gets returned.
\<Jamiras> I have a few possible solutions to address this, but I'm not sure which is most appropriate:
1\) Cast to a uint64_t before doing the math, then back to a retro_time_t when returning.
2\) Cast to a uint64_t when deciding where to insert the item into the queue
3\) make retro_time_t unsigned.
4\) Capture an initial QueryPerformanceCounter value and subtract it from the current value before doing the math.
The first three solutions (and the existing code) will likely still have weird behavior as the number reaches a point where the multiplication results in a value larger than 64-bits, but will guarantee positive values so as not to interfere with the scheduling of immediate tasks.
\<Alcaro> 5) find some tricky mathematical way to make the multiplication not overflow
\<Alcaro> I'll see if I can do exactly that