### PR TITLE
Fix tautological comparison

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -4884,7 +4884,7 @@ static int setting_string_action_left_netplay_mitm_server(
       if (string_is_equal(setting->value.target.string, netplay_mitm_server_list[i].name))
       {
          /* move to the previous one in the list, wrap around if necessary */
-         if (i - 1 >= 0)
+         if (i >= 1)
          {
             found  = true;
             offset = i - 1;


### PR DESCRIPTION
Was looking at Travis output because $reason and found something interesting.

/Users/travis/build/libretro/RetroArch/griffin/../menu/menu_setting.c:4887:20: warning: comparison of unsigned expression >= 0 is always true [-Wtautological-compare]
         if (i - 1 >= 0)

Didn't investigate whether it actually can cause trouble, but even if not, this patch gets rid of the warning.