### PR TITLE
(cheevos) queue multiple popups

### DIFF
--- a/cheevos-new/badges.c
+++ b/cheevos-new/badges.c
@@ -28,6 +28,13 @@ static uintptr_t cheevos_badge_menu_texture_list[CHEEVOS_MENU_BADGE_LIMIT] = { 0
 
 void cheevos_reset_menu_badges(void)
 {
+   int index;
+   for (index = 0; index < CHEEVOS_MENU_BADGE_LIMIT; ++index)
+   {
+      if (cheevos_badge_menu_texture_list[index])
+         video_driver_texture_unload(&cheevos_badge_menu_texture_list[index]);
+   }
+
    memset(&cheevos_badge_menu_texture_list, 0, sizeof(cheevos_badge_menu_texture_list));
 }
 


### PR DESCRIPTION
## Description

Implements a popup queue for achievement unlock notifications. If a popup is visible (or being animated) while another is pushed, it will be queued and immediately start animating when the first completes.

The queue has a fixed maximum size of 8 items. If more than 8 items unlock at the same time, only the first 8 will be displayed.

## Related Issues

implements #9450

## Related Pull Requests

n/a

## Reviewers

@natinusala
