### PR TITLE
(cheevos) display measured progress on locked achievements

### DIFF
--- a/cheevos-new/cheevos.h
+++ b/cheevos-new/cheevos.h
@@ -45,6 +45,7 @@ bool rcheevos_load(const void *data);
 void rcheevos_reset_game(void);
 
 void rcheevos_populate_menu(void *data);
+void rcheevos_get_achievement_state(unsigned index, char* buffer, size_t buffer_size);
 
 bool rcheevos_get_description(rcheevos_ctx_desc_t *desc);
 

--- a/menu/cbs/menu_cbs_get_value.c
+++ b/menu/cbs/menu_cbs_get_value.c
@@ -48,6 +48,10 @@
 #include "../../network/netplay/netplay.h"
 #endif
 
+#ifdef HAVE_CHEEVOS
+#include "../../cheevos-new/cheevos.h"
+#endif
+
 #ifndef BIND_ACTION_GET_VALUE
 #define BIND_ACTION_GET_VALUE(cbs, name) \
    cbs->action_get_value = name; \
@@ -109,7 +113,7 @@ static void menu_action_setting_disp_set_label_cheat_num_passes(
    snprintf(s, len, "%u", cheat_manager_get_buf_size());
 }
 
-static void menu_action_setting_disp_set_label_cheevos_unsupported_entry(
+static void menu_action_setting_disp_set_label_cheevos_entry(
    file_list_t* list,
    unsigned *w, unsigned type, unsigned i,
    const char *label,
@@ -119,64 +123,8 @@ static void menu_action_setting_disp_set_label_cheevos_unsupported_entry(
 {
    *w = 19;
    strlcpy(s2, path, len2);
-   strlcpy(s,
-      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEEVOS_UNSUPPORTED_ENTRY), len);
-}
 
-static void menu_action_setting_disp_set_label_cheevos_unofficial_entry(
-   file_list_t* list,
-   unsigned *w, unsigned type, unsigned i,
-   const char *label,
-   char *s, size_t len,
-   const char *path,
-   char *s2, size_t len2)
-{
-   *w = 19;
-   strlcpy(s2, path, len2);
-   strlcpy(s,
-      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEEVOS_UNOFFICIAL_ENTRY), len);
-}
-
-static void menu_action_setting_disp_set_label_cheevos_locked_entry(
-      file_list_t* list,
-      unsigned *w, unsigned type, unsigned i,
-      const char *label,
-      char *s, size_t len,
-      const char *path,
-      char *s2, size_t len2)
-{
-   *w = 19;
-   strlcpy(s2, path, len2);
-   strlcpy(s,
-         msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEEVOS_LOCKED_ENTRY), len);
-}
-
-static void menu_action_setting_disp_set_label_cheevos_unlocked_entry(
-      file_list_t* list,
-      unsigned *w, unsigned type, unsigned i,
-      const char *label,
-      char *s, size_t len,
-      const char *path,
-      char *s2, size_t len2)
-{
-   *w = 19;
-   strlcpy(s2, path, len2);
-   strlcpy(s,
-         msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEEVOS_UNLOCKED_ENTRY), len);
-}
-
-static void menu_action_setting_disp_set_label_cheevos_unlocked_entry_hardcore(
-      file_list_t* list,
-      unsigned *w, unsigned type, unsigned i,
-      const char *label,
-      char *s, size_t len,
-      const char *path,
-      char *s2, size_t len2)
-{
-   *w = 19;
-   strlcpy(s2, path, len2);
-   strlcpy(s,
-         msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEEVOS_UNLOCKED_ENTRY_HARDCORE), len);
+   rcheevos_get_achievement_state(type - MENU_SETTINGS_CHEEVOS_START, s, len);
 }
 
 static void menu_action_setting_disp_set_label_remap_file_load(
@@ -1810,25 +1758,9 @@ int menu_cbs_init_bind_get_string_representation(menu_file_list_cbs_t *cbs,
    {
       switch (cbs->enum_idx)
       {
-         case MENU_ENUM_LABEL_CHEEVOS_UNLOCKED_ENTRY:
-            BIND_ACTION_GET_VALUE(cbs,
-                  menu_action_setting_disp_set_label_cheevos_unlocked_entry);
-            return 0;
-         case MENU_ENUM_LABEL_CHEEVOS_UNLOCKED_ENTRY_HARDCORE:
-            BIND_ACTION_GET_VALUE(cbs,
-                  menu_action_setting_disp_set_label_cheevos_unlocked_entry_hardcore);
-            return 0;
          case MENU_ENUM_LABEL_CHEEVOS_LOCKED_ENTRY:
             BIND_ACTION_GET_VALUE(cbs,
-                  menu_action_setting_disp_set_label_cheevos_locked_entry);
-            return 0;
-         case MENU_ENUM_LABEL_CHEEVOS_UNSUPPORTED_ENTRY:
-            BIND_ACTION_GET_VALUE(cbs,
-               menu_action_setting_disp_set_label_cheevos_unsupported_entry);
-            return 0;
-         case MENU_ENUM_LABEL_CHEEVOS_UNOFFICIAL_ENTRY:
-            BIND_ACTION_GET_VALUE(cbs,
-               menu_action_setting_disp_set_label_cheevos_unofficial_entry);
+                  menu_action_setting_disp_set_label_cheevos_entry);
             return 0;
          case MENU_ENUM_LABEL_LOAD_CONTENT_HISTORY:
          case MENU_ENUM_LABEL_SYSTEM_INFORMATION:
@@ -1836,9 +1768,6 @@ int menu_cbs_init_bind_get_string_representation(menu_file_list_cbs_t *cbs,
                   menu_action_setting_disp_set_label_menu_more);
             return 0;
          case MENU_ENUM_LABEL_ACHIEVEMENT_LIST:
-            BIND_ACTION_GET_VALUE(cbs,
-                  menu_action_setting_disp_set_label_achievement_information);
-            return 0;
          case MENU_ENUM_LABEL_ACHIEVEMENT_LIST_HARDCORE:
             BIND_ACTION_GET_VALUE(cbs,
                   menu_action_setting_disp_set_label_achievement_information);


### PR DESCRIPTION
## Description

Adds progress tracking to the achievements list for achievements that support it.
![image](https://user-images.githubusercontent.com/32680403/75600487-15afcf80-5a6d-11ea-8a51-90ee145ad290.png)

Several of the helper methods in `menu_cbs_get_value.c` were eliminated as the value string is now being dynamically generated.

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@meleu @leiradel 
