### PR TITLE
[3DS] Keep the bottom screen hidden on sleep/wakeup

### DIFF
--- a/gfx/drivers/ctr_gfx.c
+++ b/gfx/drivers/ctr_gfx.c
@@ -273,7 +273,7 @@ static void ctr_lcd_aptHook(APT_HookType hook, void* param)
    if ((hook == APTHOOK_ONSUSPEND) && ctr->supports_parallax_disable)
       ctr_set_parallax_layer(*(float*)0x1FF81080 != 0.0);
 
-   if((hook == APTHOOK_ONSUSPEND) || (hook == APTHOOK_ONRESTORE))
+   if((hook == APTHOOK_ONSUSPEND) || (hook == APTHOOK_ONRESTORE) || (hook == APTHOOK_ONWAKEUP))
    {
       Handle lcd_handle;
       u8 not_2DS;


### PR DESCRIPTION
## Description

When the 3DS wakes back up after being closed, the bottom screen needs to be reinitialized. Adding the condition here will cause the screen to be turned on or off based on the state of `ctr_bottom_screen_enabled`, as you'd expect.

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
