### PR TITLE
travis: Try to fix the code signing issue for osx.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,7 @@ matrix:
         - xcodebuild -target RetroArch -configuration Release -project pkg/apple/RetroArch.xcodeproj
     - os: osx
       osx_image: xcode11.2
+      env: CSA_LINK='https://repository.certum.pl/cscasha2.cer'
       script:
         - brew update-reset
         - brew install --force-bottle qt5


### PR DESCRIPTION
## Description

Just a test to fix the osx travis job, wait for travis in case this doesn't work.

See: https://github.com/cncjs/cncjs/commit/25810b46a157d510feb33e624a9110ad48938146

## Related Issues

```
error: No signing certificate "Developer ID Application" found: No "Developer ID Application" signing certificate matching team ID "ZE9XE938Z2" with a private key was found. (in target 'RetroArchQt' from project 'RetroArch_Metal')
```