### PR TITLE
Fix smooth (vertical) line ticker scroll speed

### DIFF
--- a/gfx/gfx_animation.h
+++ b/gfx/gfx_animation.h
@@ -31,7 +31,7 @@ RETRO_BEGIN_DECLS
 
 typedef void  (*tween_cb)  (void*);
 
-typedef void (*update_time_cb) (float *dst,
+typedef void (*update_time_cb) (float *ticker_pixel_increment,
       unsigned width, unsigned height);
 
 enum gfx_animation_ctl_state
@@ -234,6 +234,8 @@ uint64_t gfx_animation_get_ticker_idx(void);
 uint64_t gfx_animation_get_ticker_slow_idx(void);
 
 uint64_t gfx_animation_get_ticker_pixel_idx(void);
+
+uint64_t gfx_animation_get_ticker_pixel_line_idx(void);
 
 void gfx_animation_set_update_time_cb(update_time_cb cb);
 

--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -5646,10 +5646,16 @@ static void materialui_init_nav_bar(materialui_handle_t *mui)
 }
 
 static void materialui_menu_animation_update_time(
-      float *dst,
+      float *ticker_pixel_increment,
       unsigned video_width, unsigned video_height)
 {
-   *(dst) *= gfx_display_get_dpi_scale(video_width, video_height) * 0.8f;
+   /* MaterialUI uses DPI scaling
+    * > Smooth ticker scaling multiplier is
+    *   gfx_display_get_dpi_scale() multiplied by
+    *   a small correction factor to achieve a
+    *   default scroll speed equal to that of the
+    *   non-smooth ticker */
+   *(ticker_pixel_increment) *= gfx_display_get_dpi_scale(video_width, video_height) * 0.8f;
 }
 
 static void *materialui_init(void **userdata, bool video_is_threaded)

--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -123,12 +123,17 @@ void ozone_free_list_nodes(file_list_t *list, bool actiondata)
 }
 
 static void ozone_menu_animation_update_time(
-      float *dst,
+      float *ticker_pixel_increment,
       unsigned video_width, unsigned video_height)
 {
-   *(dst) *= gfx_display_get_dpi_scale(video_width, video_height) * 0.5f;
+   /* Ozone uses DPI scaling
+    * > Smooth ticker scaling multiplier is
+    *   gfx_display_get_dpi_scale() multiplied by
+    *   a small correction factor to achieve a
+    *   default scroll speed equal to that of the
+    *   non-smooth ticker */
+   *(ticker_pixel_increment) *= gfx_display_get_dpi_scale(video_width, video_height) * 0.5f;
 }
-
 
 static void *ozone_init(void **userdata, bool video_is_threaded)
 {

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -4296,10 +4296,20 @@ static bool rgui_set_aspect_ratio(rgui_t *rgui, bool delay_update)
 }
 
 static void rgui_menu_animation_update_time(
-      float *dst,
-      unsigned video_width, unsigned height)
+      float *ticker_pixel_increment,
+      unsigned video_width, unsigned video_height)
 {
-   *(dst) *= 0.25f;
+   /* RGUI framebuffer size is independent of
+    * display resolution, so have to use a fixed
+    * multiplier for smooth scrolling ticker text.
+    * We choose a value such that text is scrolled
+    * 1 pixel every 4 frames when ticker speed is 1x,
+    * which matches almost exactly the scroll speed
+    * of non-smooth ticker text (scrolling 1 pixel
+    * every 2 frames is optimal, but may be too fast
+    * for some users - so play it safe. Users can always
+    * set ticker speed to 2x if they prefer) */
+   *(ticker_pixel_increment) *= 0.25f;
 }
 
 static void *rgui_init(void **userdata, bool video_is_threaded)


### PR DESCRIPTION
## Description

It turns out that the smooth (horizontal) line ticker (used for sublabel text in XMB) was using the wrong parameter for its 'ticker index' value. This was not apparent in normal use, but at extreme scales it led to incorrect scrolling speeds - for example, on very small displays the text would scroll so slowly the user might mistakenly think it had stopped.

This PR fixes the issue.

The PR also fixes some general scaling-related nonsense in XMB - there were several cases where the wrong scale factor was used (PS3 layout vs PSP layout), and instances where the user-set menu scale factor was ignored.
