### PR TITLE
(RGUI) Enable 'Flux' theme

### DIFF
--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -494,7 +494,6 @@ static const rgui_theme_t rgui_theme_anti_zenburn = {
    0xE0B090B0  /* particle_color */
 };
 
-#if 0
 static const rgui_theme_t rgui_theme_flux = {
    0xFF6FCB9F, /* hover_color */
    0xFF666547, /* normal_color */
@@ -506,7 +505,6 @@ static const rgui_theme_t rgui_theme_flux = {
    0xE0FFE28A, /* shadow_color */
    0xE0FB2E01  /* particle_color */
 };
-#endif
 
 typedef struct
 {
@@ -2169,6 +2167,8 @@ static const rgui_theme_t *get_theme(rgui_t *rgui)
          return &rgui_theme_zenburn;
       case RGUI_THEME_ANTI_ZENBURN:
          return &rgui_theme_anti_zenburn;
+      case RGUI_THEME_FLUX:
+         return &rgui_theme_flux;
       default:
          break;
    }

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -3455,6 +3455,12 @@ static void setting_get_string_representation_uint_rgui_menu_color_theme(
                   MENU_ENUM_LABEL_VALUE_RGUI_MENU_COLOR_THEME_ANTI_ZENBURN),
                len);
          break;
+      case RGUI_THEME_FLUX:
+         strlcpy(s,
+               msg_hash_to_str(
+                  MENU_ENUM_LABEL_VALUE_RGUI_MENU_COLOR_THEME_FLUX),
+               len);
+         break;
    }
 }
 


### PR DESCRIPTION
## Description

This PR enables RGUI's `Flux` theme. It seems this was disabled at some point, but in such a way that it broke RGUI's theme selection drop-down list (I only just noticed this...).