### PR TITLE
Prevent improper display of (old style) OSD text when widgets are enabled

### DIFF
--- a/disk_control_interface.c
+++ b/disk_control_interface.c
@@ -752,10 +752,14 @@ bool disk_control_verify_initial_index(disk_control_interface_t *disk_control)
 
       RARCH_LOG("%s\n", msg);
 
+      /* Note: Do not flush message queue here, since
+       * it is likely other notifications will be
+       * generated before setting the disk index, and
+       * we do not want to 'overwrite' them */
       runloop_msg_queue_push(
             msg,
             0, msg_duration,
-            true, NULL,
+            false, NULL,
             MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
    }
 

--- a/libretro-common/include/queues/message_queue.h
+++ b/libretro-common/include/queues/message_queue.h
@@ -44,6 +44,16 @@ enum message_queue_category
 
 typedef struct msg_queue msg_queue_t;
 
+typedef struct
+{
+   char msg[1024];
+   char title[1024];
+   unsigned duration;
+   unsigned prio;
+   enum message_queue_icon icon;
+   enum message_queue_category category;
+} msg_queue_entry_t;
+
 /**
  * msg_queue_new:
  * @size              : maximum size of message
@@ -81,6 +91,28 @@ void msg_queue_push(msg_queue_t *queue, const char *msg,
  * containing the message.
  **/
 const char *msg_queue_pull(msg_queue_t *queue);
+
+/**
+ * msg_queue_extract:
+ * @queue             : pointer to queue object
+ * @queue_entry       : pointer to external queue entry struct
+ *
+ * Removes highest priority message from queue, copying
+ * contents into queue_entry struct.
+ *
+ * Returns: false if no messages in queue, otherwise true
+ **/
+bool msg_queue_extract(msg_queue_t *queue, msg_queue_entry_t *queue_entry);
+
+/**
+ * msg_queue_size:
+ * @queue             : pointer to queue object
+ *
+ * Fetches number of messages in queue.
+ *
+ * Returns: Number of messages in queue.
+ **/
+size_t msg_queue_size(msg_queue_t *queue);
 
 /**
  * msg_queue_clear:


### PR DESCRIPTION
## Description

Widgets (by necessity) are initialised quite late in the startup (or load content) sequence. If anything generates notifications *before* widgets are initialised, the output is presented using the old OSD (yellow text) method. This leads to much ugliness when loading content under certain conditions - e.g. the user expects all output via widgets, but config/remap overrides, certain cheevos messages, auto disk selection, etc. dump yellow text to screen - and sometimes we get simultaneous yellow text *and* widgets...

This PR changes how the internal non-widget message queue is handled. Pre-widget initialisation messages still get pushed in the old way, but if widgets are subsequently enabled at the point where notifications are drawn, anything in the 'old' message queue is extracted and instead re-pushed as a widget notification.

This should ensure that widgets are always used when appropriate.

Side bonus: We no longer have to lock/unlock a mutex every frame - this is now only done when notification messages are actually being displayed.
