### PR TITLE
(QT) Populate 'db_name' and 'crc32' fields when adding entries to content history

### DIFF
--- a/gfx/common/win32_common.c
+++ b/gfx/common/win32_common.c
@@ -514,7 +514,7 @@ bool win32_load_content_from_gui(const char *szFilename)
       if (info)
       {
          task_push_load_content_with_new_core_from_companion_ui(
-            info->path, NULL, NULL, &content_info, NULL, NULL);
+            info->path, NULL, NULL, NULL, NULL, &content_info, NULL, NULL);
          return true;
       }
    }

--- a/tasks/task_content.h
+++ b/tasks/task_content.h
@@ -77,6 +77,8 @@ bool task_push_load_content_with_new_core_from_companion_ui(
       const char *core_path,
       const char *fullpath,
       const char *label,
+      const char *db_name,
+      const char *crc32,
       content_ctx_info_t *content_info,
       retro_task_callback_t cb,
       void *user_data);


### PR DESCRIPTION
## Description

This PR ensures that the playlist `db_name` and `crc32` fields are populated for content history entries generated via the QT companion interface. This enables thumbnails for said entries.

## Related Issues

This PR closes #8702

## Reviewers

@Tatsuya79 Please test!
