### PR TITLE
(gfx_thumbnail) Move globals to a single struct

### DIFF
--- a/gfx/gfx_thumbnail.h
+++ b/gfx/gfx_thumbnail.h
@@ -95,11 +95,13 @@ typedef struct
 
 /* When streaming thumbnails, sets time in ms that an
  * entry must be on screen before an image load is
- * requested */
+ * requested
+ * > if 'delay' is negative, default value is set */
 void gfx_thumbnail_set_stream_delay(float delay);
 
 /* Sets duration in ms of the thumbnail 'fade in'
- * animation */
+ * animation
+ * > If 'duration' is negative, default value is set */
 void gfx_thumbnail_set_fade_duration(float duration);
 
 /* Getters */

--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -5742,6 +5742,9 @@ static void *materialui_init(void **userdata, bool video_is_threaded)
    /* Set initial thumbnail stream delay */
    gfx_thumbnail_set_stream_delay(MUI_THUMBNAIL_STREAM_DELAY_DEFAULT);
 
+   /* Set thumbnail fade duration to default */
+   gfx_thumbnail_set_fade_duration(-1.0f);
+
    /* Ensure that fullscreen thumbnails are inactive */
    mui->show_fullscreen_thumbnails     = false;
    mui->fullscreen_thumbnail_selection = 0;

--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -189,6 +189,9 @@ static void *ozone_init(void **userdata, bool video_is_threaded)
    ozone->fullscreen_thumbnail_selection        = 0;
    ozone->fullscreen_thumbnail_label[0]         = '\0';
 
+   gfx_thumbnail_set_stream_delay(-1.0f);
+   gfx_thumbnail_set_fade_duration(-1.0f);
+
    ozone_sidebar_update_collapse(ozone, false);
 
    ozone->system_tab_end                = 0;

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -5255,6 +5255,9 @@ static void *xmb_init(void **userdata, bool video_is_threaded)
    xmb->fullscreen_thumbnail_selection  = 0;
    xmb->fullscreen_thumbnail_label[0]   = '\0';
 
+   gfx_thumbnail_set_stream_delay(-1.0f);
+   gfx_thumbnail_set_fade_duration(-1.0f);
+
    xmb->use_ps3_layout      = xmb_use_ps3_layout(settings, width, height);
    xmb->last_use_ps3_layout = xmb->use_ps3_layout;
    xmb->last_scale_factor   = xmb_get_scale_factor(settings, xmb->use_ps3_layout, width);


### PR DESCRIPTION
## Description

As requested by twinaphex, this moves the global values in `gfx_thumbnail.c` to a single struct