### PR TITLE
Return failure on set_audio_callback without threads

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -11568,9 +11568,10 @@ static bool rarch_environment_cb(unsigned cmd, void *data)
             return false;
          if (cb)
             audio_callback = *cb;
+	 return true;
       }
 #endif
-      break;
+      return false;
 
       case RETRO_ENVIRONMENT_SET_FRAME_TIME_CALLBACK:
       {


### PR DESCRIPTION
Current code returns success even though it's actually a failure
