### PR TITLE
database: Add scanning Korea and Asia discs

### DIFF
--- a/tasks/task_database_cue.c
+++ b/tasks/task_database_cue.c
@@ -262,6 +262,9 @@ int detect_psp_game(intfstream_t *fd, char *game_id)
                || (string_is_equal(game_id, "UCJS-"))
                || (string_is_equal(game_id, "UCAS-"))
 
+               || (string_is_equal(game_id, "ULKS-"))
+               || (string_is_equal(game_id, "ULAS-"))
+
                || (string_is_equal(game_id, "NPEH-"))
                || (string_is_equal(game_id, "NPUH-"))
                || (string_is_equal(game_id, "NPJH-"))


### PR DESCRIPTION
This change adds support for scanning Korean and Asian media discs to task_database_cue.c.

Found by @pkos, and fixes #10241 .