### PR TITLE
Ensure proper detection of 'threaded video' state when calling 'drivers_init()'

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -25281,7 +25281,7 @@ void driver_set_nonblock_state(void)
  **/
 static void drivers_init(int flags)
 {
-   bool video_is_threaded   = false;
+   bool video_is_threaded   = video_driver_is_threaded_internal();
    settings_t *settings     = configuration_settings;
    bool menu_enable_widgets = settings->bools.menu_enable_widgets;
 


### PR DESCRIPTION
## Description

At present, whenever `drivers_init()` is called *without* the `DRIVER_VIDEO_MASK` flag, threaded video is assumed to be disabled. If threaded video *is* enabled, this of course causes havoc. A notable example is the corruption of menu widgets when running some cores (e.g. VICE) with threaded video enabled.

This PR fixes the issue.