### PR TITLE
Enable widget persistence across drivers_init()/driver_uninit() events

### DIFF
--- a/gfx/common/metal_common.m
+++ b/gfx/common/metal_common.m
@@ -295,7 +295,7 @@
    {
       bool statistics_show = video_info->statistics_show;
 #ifdef HAVE_GFX_WIDGETS
-      bool widgets_inited  = video_info->widgets_inited;
+      bool widgets_active  = gfx_widgets_active();
 #endif
 
       [self _beginFrame];
@@ -338,7 +338,7 @@
       }
 
 #ifdef HAVE_GFX_WIDGETS
-      if (widgets_inited)
+      if (widgets_active)
       {
          [rce pushDebugGroup:@"menu widgets"];
          gfx_widgets_frame(video_info);

--- a/gfx/drivers/d3d10.c
+++ b/gfx/drivers/d3d10.c
@@ -1206,7 +1206,6 @@ static bool d3d10_gfx_frame(
    D3D10Device       context  = d3d10->device;
    unsigned video_width       = video_info->width;
    unsigned video_height      = video_info->height;
-   bool widgets_inited        = video_info->widgets_inited;
    bool statistics_show       = video_info->statistics_show;
    struct font_params 
       *osd_params             = (struct font_params*)
@@ -1510,8 +1509,7 @@ static bool d3d10_gfx_frame(
 #endif
 
 #ifdef HAVE_GFX_WIDGETS
-   if (widgets_inited)
-      gfx_widgets_frame(video_info);
+   gfx_widgets_frame(video_info);
 #endif
 
    if (msg && *msg)

--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -1285,7 +1285,6 @@ static bool d3d11_gfx_frame(
    d3d11_texture_t*   texture     = NULL;
    d3d11_video_t*     d3d11       = (d3d11_video_t*)data;
    D3D11DeviceContext context     = d3d11->context;
-   bool widgets_inited            = video_info->widgets_inited;
    const char *stat_text          = video_info->stat_text;
    unsigned video_width           = video_info->width;
    unsigned video_height          = video_info->height;
@@ -1583,8 +1582,7 @@ static bool d3d11_gfx_frame(
 #endif
 
 #ifdef HAVE_GFX_WIDGETS
-   if (widgets_inited)
-      gfx_widgets_frame(video_info);
+   gfx_widgets_frame(video_info);
 #endif
 
    if (msg && *msg)

--- a/gfx/drivers/d3d12.c
+++ b/gfx/drivers/d3d12.c
@@ -1170,7 +1170,6 @@ static bool d3d12_gfx_frame(
    d3d12_video_t*   d3d12         = (d3d12_video_t*)data;
    const char *stat_text          = video_info->stat_text;
    bool statistics_show           = video_info->statistics_show;
-   bool widgets_inited            = video_info->widgets_inited;
    unsigned video_width           = video_info->width;
    unsigned video_height          = video_info->height;
    struct font_params *osd_params = (struct font_params*)
@@ -1566,8 +1565,7 @@ static bool d3d12_gfx_frame(
 #endif
 
 #ifdef HAVE_GFX_WIDGETS
-   if (widgets_inited)
-      gfx_widgets_frame(video_info);
+   gfx_widgets_frame(video_info);
 #endif
 
    if (msg && *msg)

--- a/gfx/drivers/d3d9.c
+++ b/gfx/drivers/d3d9.c
@@ -1528,7 +1528,6 @@ static bool d3d9_frame(void *data, const void *frame,
    unsigned width                      = video_info->width;
    unsigned height                     = video_info->height;
    bool statistics_show                = video_info->statistics_show;
-   bool widgets_inited                 = video_info->widgets_inited;
    bool black_frame_insertion          = video_info->black_frame_insertion;
    struct font_params *osd_params      = (struct font_params*)
       &video_info->osd_stat_params;
@@ -1628,8 +1627,7 @@ static bool d3d9_frame(void *data, const void *frame,
 #endif
 
 #ifdef HAVE_GFX_WIDGETS
-   if (widgets_inited)
-      gfx_widgets_frame(video_info);
+   gfx_widgets_frame(video_info);
 #endif
 
    if (msg && *msg)

--- a/gfx/drivers/gl.c
+++ b/gfx/drivers/gl.c
@@ -2813,7 +2813,6 @@ static bool gl2_frame(void *data, const void *frame,
    unsigned height                     = gl->video_height;
    bool use_rgba                       = video_info->use_rgba;
    bool statistics_show                = video_info->statistics_show;
-   bool widgets_inited                 = video_info->widgets_inited;
    bool msg_bgcolor_enable             = video_info->msg_bgcolor_enable;
    bool black_frame_insertion          = video_info->black_frame_insertion;
    bool input_driver_nonblock_state    = video_info->input_driver_nonblock_state; 
@@ -3051,8 +3050,7 @@ static bool gl2_frame(void *data, const void *frame,
 #endif
 
 #ifdef HAVE_GFX_WIDGETS
-   if (widgets_inited)
-      gfx_widgets_frame(video_info);
+   gfx_widgets_frame(video_info);
 #endif
 
    if (!string_is_empty(msg))

--- a/gfx/drivers/gl1.c
+++ b/gfx/drivers/gl1.c
@@ -858,8 +858,7 @@ static bool gl1_gfx_frame(void *data, const void *frame,
 #endif
 
 #ifdef HAVE_GFX_WIDGETS
-   if (video_info->widgets_inited)
-      gfx_widgets_frame(video_info);
+   gfx_widgets_frame(video_info);
 #endif
 
 #ifdef HAVE_OVERLAY

--- a/gfx/drivers/gl_core.c
+++ b/gfx/drivers/gl_core.c
@@ -1843,7 +1843,6 @@ static bool gl_core_frame(void *data, const void *frame,
       &video_info->osd_stat_params;
    const char *stat_text                       = video_info->stat_text;
    bool statistics_show                        = video_info->statistics_show;
-   bool widgets_inited                         = video_info->widgets_inited;
    bool msg_bgcolor_enable                     = video_info->msg_bgcolor_enable;
    bool black_frame_insertion                  = video_info->black_frame_insertion;
    void *context_data                          = video_info->context_data;
@@ -1938,8 +1937,7 @@ static bool gl_core_frame(void *data, const void *frame,
 #endif
 
 #ifdef HAVE_GFX_WIDGETS
-   if (widgets_inited)
-      gfx_widgets_frame(video_info);
+   gfx_widgets_frame(video_info);
 #endif
 
    if (!string_is_empty(msg))

--- a/gfx/drivers/gx2_gfx.c
+++ b/gfx/drivers/gx2_gfx.c
@@ -1348,8 +1348,7 @@ static bool wiiu_gfx_frame(void *data, const void *frame,
    }
 
 #ifdef HAVE_GFX_WIDGETS
-   if (video_info->widgets_inited)
-      gfx_widgets_frame(video_info);
+   gfx_widgets_frame(video_info);
 #endif
 
    if (msg)

--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -1677,7 +1677,6 @@ static bool vulkan_frame(void *data, const void *frame,
    void *context_data                            = video_info->context_data;
    bool statistics_show                          = video_info->statistics_show;
    const char *stat_text                         = video_info->stat_text;
-   bool widgets_inited                           = video_info->widgets_inited;
    bool black_frame_insertion                    = video_info->black_frame_insertion;
    bool input_driver_nonblock_state              = video_info->input_driver_nonblock_state;
    bool runloop_is_slowmotion                    = video_info->runloop_is_slowmotion;
@@ -1988,8 +1987,7 @@ static bool vulkan_frame(void *data, const void *frame,
          font_driver_render_msg(vk, msg, NULL, NULL);
 
 #ifdef HAVE_GFX_WIDGETS
-      if (widgets_inited)
-         gfx_widgets_frame(video_info);
+      gfx_widgets_frame(video_info);
 #endif
 
       /* End the render pass. We're done rendering to backbuffer now. */

--- a/gfx/gfx_widgets.c
+++ b/gfx/gfx_widgets.c
@@ -2077,8 +2077,8 @@ void gfx_widgets_deinit(void)
    if (!widgets_inited)
       return;
 
-   gfx_widgets_context_destroy();
    widgets_active = false;
+   gfx_widgets_context_destroy();
 
    if (!widgets_persisting)
       gfx_widgets_free();
@@ -2232,7 +2232,7 @@ static void gfx_widgets_context_reset(bool is_threaded,
 
    xmb_path[0]            = '\0';
    monochrome_png_path[0] = '\0';
-   gfx_widgets_path[0]   = '\0';
+   gfx_widgets_path[0]    = '\0';
    theme_path[0]          = '\0';
 
    /* Textures paths */
@@ -2371,6 +2371,9 @@ static void gfx_widgets_free(void)
    size_t i;
    gfx_animation_ctx_tag libretro_tag;
 
+   widgets_inited = false;
+   widgets_active = false;
+
    for (i = 0; i < widgets_len; i++)
    {
       const gfx_widget_t* widget = widgets[i];
@@ -2450,9 +2453,6 @@ static void gfx_widgets_free(void)
 
    /* Volume */
    volume_alpha           = 0.0f;
-
-   widgets_inited         = false;
-   widgets_active         = false;
 }
 
 static void gfx_widgets_volume_timer_end(void *userdata)

--- a/gfx/gfx_widgets.c
+++ b/gfx/gfx_widgets.c
@@ -46,7 +46,20 @@
 #include "../cheevos-new/badges.h"
 #endif
 
-/* TODO: Fix context reset freezing everything in place (probably kills animations when it shouldn't anymore) */
+static bool widgets_inited = false;
+static bool widgets_active = false;
+
+bool gfx_widgets_active(void)
+{
+   return widgets_active;
+}
+
+static bool widgets_persisting = false;
+
+void gfx_widgets_set_persistence(bool persist)
+{
+   widgets_persisting = persist;
+}
 
 static float msg_queue_background[16]  = COLOR_HEX_TO_FLOAT(0x3A3A3A, 1.0f);
 static float msg_queue_info[16]        = COLOR_HEX_TO_FLOAT(0x12ACF8, 1.0f);
@@ -228,7 +241,7 @@ static uintptr_t msg_queue_icon_outline          = 0;
 static uintptr_t msg_queue_icon_rect             = 0;
 static bool msg_queue_has_icons                  = false;
 
-extern gfx_animation_ctx_tag gfx_widgets_generic_tag;
+static gfx_animation_ctx_tag gfx_widgets_generic_tag = (uintptr_t)&widgets_active;
 
 gfx_animation_ctx_tag gfx_widgets_get_generic_tag(void)
 {
@@ -409,6 +422,9 @@ void gfx_widgets_msg_queue_push(
       bool menu_is_alive)
 {
    menu_widget_msg_t* msg_widget = NULL;
+
+   if (!widgets_active)
+      return;
 
    if (fifo_write_avail(msg_queue) > 0)
    {
@@ -922,7 +938,12 @@ static void gfx_widgets_hourglass_tick(void *userdata)
    gfx_animation_push(&entry);
 }
 
-/* Forward declaration */
+/* Forward declarations */
+static void gfx_widgets_context_reset(bool is_threaded,
+      unsigned width, unsigned height, bool fullscreen,
+      const char *dir_assets, char *font_path);
+static void gfx_widgets_context_destroy(void);
+static void gfx_widgets_free(void);
 static void gfx_widgets_layout(
       bool is_threaded, const char *dir_assets, char *font_path);
 #ifdef HAVE_MENU
@@ -936,10 +957,14 @@ void gfx_widgets_iterate(
       bool is_threaded)
 {
    size_t i;
+   float scale_factor;
+
+   if (!widgets_active)
+      return;
 
    /* Check whether screen dimensions or menu scale
     * factor have changed */
-   float scale_factor = (gfx_display_get_driver_id() == MENU_DRIVER_ID_XMB) ?
+   scale_factor = (gfx_display_get_driver_id() == MENU_DRIVER_ID_XMB) ?
          gfx_display_get_widget_pixel_scale(width, height, fullscreen) :
                gfx_display_get_widget_dpi_scale(width, height, fullscreen);
 
@@ -1473,20 +1498,42 @@ static void gfx_widgets_draw_load_content_animation(
 
 void gfx_widgets_frame(void *data)
 {
+   /* (Pointless) optimisation: allocating these
+    * costs nothing, so do it *before* the
+    * 'widgets_active' check... */
    size_t i;
-   video_frame_info_t *video_info = (video_frame_info_t*)data;
-   bool framecount_show           = video_info->framecount_show;
-   bool memory_show               = video_info->memory_show;
-   void *userdata                 = video_info->userdata;
-   unsigned video_width           = video_info->width;
-   unsigned video_height          = video_info->height;
-   bool widgets_is_paused         = video_info->widgets_is_paused;
-   bool fps_show                  = video_info->fps_show;
-   bool widgets_is_fastforwarding = video_info->widgets_is_fast_forwarding;
-   bool widgets_is_rewinding      = video_info->widgets_is_rewinding;
-   bool runloop_is_slowmotion     = video_info->runloop_is_slowmotion;
-   int top_right_x_advance        = video_width;
-   int scissor_me_timbers         = 0;
+   video_frame_info_t *video_info;
+   bool framecount_show;
+   bool memory_show;
+   void *userdata;
+   unsigned video_width;
+   unsigned video_height;
+   bool widgets_is_paused;
+   bool fps_show;
+   bool widgets_is_fastforwarding;
+   bool widgets_is_rewinding;
+   bool runloop_is_slowmotion;
+   int top_right_x_advance;
+   int scissor_me_timbers;
+
+   if (!widgets_active)
+      return;
+
+   /* ...but assigning them costs a tiny amount,
+    * so do it *after* the 'widgets_active' check */
+   video_info                = (video_frame_info_t*)data;
+   framecount_show           = video_info->framecount_show;
+   memory_show               = video_info->memory_show;
+   userdata                  = video_info->userdata;
+   video_width               = video_info->width;
+   video_height              = video_info->height;
+   widgets_is_paused         = video_info->widgets_is_paused;
+   fps_show                  = video_info->fps_show;
+   widgets_is_fastforwarding = video_info->widgets_is_fast_forwarding;
+   widgets_is_rewinding      = video_info->widgets_is_rewinding;
+   runloop_is_slowmotion     = video_info->runloop_is_slowmotion;
+   top_right_x_advance       = video_width;
+   scissor_me_timbers        = 0;
 
    gfx_widgets_frame_count++;
 
@@ -1974,50 +2021,67 @@ void gfx_widgets_frame(void *data)
    gfx_display_unset_viewport(video_width, video_height);
 }
 
-bool gfx_widgets_init(bool video_is_threaded, bool fullscreen)
+bool gfx_widgets_init(
+      bool video_is_threaded,
+      unsigned width, unsigned height, bool fullscreen,
+      const char *dir_assets, char *font_path)
 {
-   size_t i;
-
    if (!gfx_display_init_first_driver(video_is_threaded))
       goto error;
 
-   gfx_widgets_frame_count = 0;
-
-   for (i = 0; i < widgets_len; i++)
+   if (!widgets_inited)
    {
-      const gfx_widget_t* widget = widgets[i];
+      size_t i;
 
-      if (widget->init)
-         widget->init(video_is_threaded, fullscreen);
+      gfx_widgets_frame_count = 0;
+
+      for (i = 0; i < widgets_len; i++)
+      {
+         const gfx_widget_t* widget = widgets[i];
+
+         if (widget->init)
+            widget->init(video_is_threaded, fullscreen);
+      }
+
+      msg_queue = fifo_new(MSG_QUEUE_PENDING_MAX * sizeof(menu_widget_msg_t*));
+
+      if (!msg_queue)
+         goto error;
+
+      current_msgs = (file_list_t*)calloc(1, sizeof(file_list_t));
+
+      if (!current_msgs)
+         goto error;
+
+      if (!file_list_reserve(current_msgs, MSG_QUEUE_ONSCREEN_MAX))
+         goto error;
+
+      widgets_inited = true;
    }
 
-   msg_queue = fifo_new(MSG_QUEUE_PENDING_MAX * sizeof(menu_widget_msg_t*));
+   gfx_widgets_context_reset(video_is_threaded,
+         width, height, fullscreen,
+         dir_assets, font_path);
 
-   if (!msg_queue)
-      goto error;
-
-   current_msgs = (file_list_t*)calloc(1, sizeof(file_list_t));
-
-   if (!current_msgs)
-      goto error;
-
-   if (!file_list_reserve(current_msgs, MSG_QUEUE_ONSCREEN_MAX))
-      goto error;
-
-   /* Initialise scaling parameters
-    * NOTE - special cases:
-    * > Ozone has a capped scale factor
-    * > XMB uses pixel based scaling - all other drivers
-    *   use DPI based scaling */
-   video_driver_get_size(&last_video_width, &last_video_height);
-   last_scale_factor = (gfx_display_get_driver_id() == MENU_DRIVER_ID_XMB) ?
-         gfx_display_get_widget_pixel_scale(last_video_width, last_video_height, fullscreen) :
-               gfx_display_get_widget_dpi_scale(last_video_width, last_video_height, fullscreen);
+   widgets_active = true;
 
    return true;
 
 error:
+   gfx_widgets_free();
    return false;
+}
+
+void gfx_widgets_deinit(void)
+{
+   if (!widgets_inited)
+      return;
+
+   gfx_widgets_context_destroy();
+   widgets_active = false;
+
+   if (!widgets_persisting)
+      gfx_widgets_free();
 }
 
 static void gfx_widgets_layout(
@@ -2156,7 +2220,7 @@ static void gfx_widgets_layout(
    }
 }
 
-void gfx_widgets_context_reset(bool is_threaded,
+static void gfx_widgets_context_reset(bool is_threaded,
       unsigned width, unsigned height, bool fullscreen,
       const char *dir_assets, char *font_path)
 {
@@ -2302,12 +2366,10 @@ static void gfx_widgets_achievement_next(void* userdata)
 }
 #endif
 
-void gfx_widgets_free(void)
+static void gfx_widgets_free(void)
 {
    size_t i;
    gfx_animation_ctx_tag libretro_tag;
-
-   gfx_widgets_context_destroy();
 
    for (i = 0; i < widgets_len; i++)
    {
@@ -2388,6 +2450,9 @@ void gfx_widgets_free(void)
 
    /* Volume */
    volume_alpha           = 0.0f;
+
+   widgets_inited         = false;
+   widgets_active         = false;
 }
 
 static void gfx_widgets_volume_timer_end(void *userdata)
@@ -2413,6 +2478,9 @@ void gfx_widgets_volume_update_and_show(float new_volume, bool mute)
 {
    gfx_timer_ctx_entry_t entry;
 
+   if (!widgets_active)
+      return;
+
    gfx_animation_kill_by_tag(&volume_tag);
 
    volume_db         = new_volume;
@@ -2430,6 +2498,9 @@ void gfx_widgets_volume_update_and_show(float new_volume, bool mute)
 
 bool gfx_widgets_set_fps_text(const char *new_fps_text)
 {
+   if (!widgets_active)
+      return false;
+
    strlcpy(gfx_widgets_fps_text,
          new_fps_text, sizeof(gfx_widgets_fps_text));
 
@@ -2501,6 +2572,9 @@ void gfx_widgets_start_load_content_animation(const char *content_name, bool rem
 
    float icon_color[16] = COLOR_HEX_TO_FLOAT(0x0473C9, 1.0f); /* TODO: random color */
    unsigned timing      = 0;
+
+   if (!widgets_active)
+      return;
 
    /* Prepare data */
    load_content_animation_icon         = 0;
@@ -2680,6 +2754,9 @@ void gfx_widgets_push_achievement(const char *title, const char *badge)
 {
    int start_notification = 1;
 
+   if (!widgets_active)
+      return;
+
    if (cheevo_popup_queue_read_index < 0)
    {
       /* queue uninitialized */
@@ -2744,6 +2821,9 @@ void gfx_widgets_set_message(char *msg)
    gfx_timer_ctx_entry_t timer;
    gfx_animation_ctx_tag tag = (uintptr_t) &generic_message_timer;
 
+   if (!widgets_active)
+      return;
+
    strlcpy(generic_message, msg, sizeof(generic_message));
 
    generic_message_alpha = DEFAULT_BACKDROP;
@@ -2780,6 +2860,9 @@ void gfx_widgets_set_libretro_message(const char *msg, unsigned duration)
 {
    gfx_timer_ctx_entry_t timer;
    gfx_animation_ctx_tag tag = (uintptr_t) &libretro_message_timer;
+
+   if (!widgets_active)
+      return;
 
    strlcpy(libretro_message, msg, sizeof(libretro_message));
 

--- a/gfx/gfx_widgets.h
+++ b/gfx/gfx_widgets.h
@@ -115,9 +115,14 @@ typedef struct gfx_widget gfx_widget_t;
 
 extern const gfx_widget_t gfx_widget_screenshot;
 
-bool gfx_widgets_init(bool video_is_threaded, bool fullscreen);
+bool gfx_widgets_active(void);
+void gfx_widgets_set_persistence(bool persist);
 
-void gfx_widgets_free(void);
+bool gfx_widgets_init(
+      bool video_is_threaded,
+      unsigned width, unsigned height, bool fullscreen,
+      const char *dir_assets, char *font_path);
+void gfx_widgets_deinit(void);
 
 void gfx_widgets_msg_queue_push(
       retro_task_t *task, const char *msg,
@@ -154,10 +159,6 @@ void gfx_widgets_start_load_content_animation(
       const char *content_name, bool remove_extension);
 
 void gfx_widgets_cleanup_load_content_animation(void);
-
-void gfx_widgets_context_reset(bool is_threaded,
-      unsigned width, unsigned height, bool fullscreen,
-      const char *dir_assets, char *font_path);
 
 void gfx_widgets_push_achievement(const char *title, const char *badge);
 

--- a/gfx/video_thread_wrapper.c
+++ b/gfx/video_thread_wrapper.c
@@ -1216,7 +1216,7 @@ static void thread_apply_state_changes(void *data)
 static struct video_shader *thread_get_current_shader(void *data)
 {
    thread_video_t *thr = (thread_video_t*)data;
-   if (!thr || !thr->poke)
+   if (!thr || !thr->poke || !thr->poke->get_current_shader)
       return NULL;
    return thr->poke->get_current_shader(thr->driver_data);
 }

--- a/gfx/widgets/gfx_widget_screenshot.c
+++ b/gfx/widgets/gfx_widget_screenshot.c
@@ -106,7 +106,12 @@ static void gfx_widgets_play_screenshot_flash(void)
 
 void gfx_widgets_screenshot_taken(const char *shotname, const char *filename)
 {
-   gfx_widget_screenshot_state_t* state = gfx_widget_screenshot_get_ptr();
+   gfx_widget_screenshot_state_t* state = NULL;
+
+   if (!gfx_widgets_active())
+      return;
+
+   state = gfx_widget_screenshot_get_ptr();
    gfx_widgets_play_screenshot_flash();
    strlcpy(state->filename, filename, sizeof(state->filename));
    strlcpy(state->shotname, shotname, sizeof(state->shotname));

--- a/retroarch.h
+++ b/retroarch.h
@@ -1096,7 +1096,6 @@ typedef struct video_info
 typedef struct video_frame_info
 {
    bool menu_mouse_enable;
-   bool widgets_inited;
    bool widgets_is_paused;
    bool widgets_is_fast_forwarding;
    bool widgets_is_rewinding;


### PR DESCRIPTION
## Description

At present, the GFX widgets 'subsystem' is freed on each call of `driver_uninit()`, and created on each call of `drivers_init()`. This can cause crashes when threaded video is enabled, since the widgets can be freed *while* a frame is in progress on the video thread.

This PR solves the issue by enabling widget persistence - widgets are now created once, and exist for the lifetime of the application.

This PR also fixes a divide by zero error and a null-pointer dereference that were causing the `gl1` video driver to fail.