### PR TITLE
(Database) Add support for scanning PSP Korean

### DIFF
--- a/tasks/task_database_cue.c
+++ b/tasks/task_database_cue.c
@@ -261,6 +261,7 @@ int detect_psp_game(intfstream_t *fd, char *game_id)
                || (string_is_equal(game_id, "UCUS-"))
                || (string_is_equal(game_id, "UCJS-"))
                || (string_is_equal(game_id, "UCAS-"))
+               || (string_is_equal(game_id, "UCKS-"))
 
                || (string_is_equal(game_id, "ULKS-"))
                || (string_is_equal(game_id, "ULAS-"))


### PR DESCRIPTION
This adds support for scanning PlayStation Portable Korean region.

Found by @pkos, and fixes #10268