### PR TITLE
French: qt: expose dropped thumbnal size limit

### DIFF
--- a/intl/msg_hash_fr.h
+++ b/intl/msg_hash_fr.h
@@ -8973,6 +8973,10 @@ MSG_HASH(
     "Limite du cache des miniatures :"
     )
 MSG_HASH(
+    MENU_ENUM_LABEL_VALUE_QT_MENU_VIEW_OPTIONS_THUMBNAIL_DROP_SIZE_LIMIT,
+    "Limite de taille des miniatures glissées-déposées :"
+    )
+MSG_HASH(
     MENU_ENUM_LABEL_VALUE_QT_DOWNLOAD_ALL_THUMBNAILS,
     "Télécharger toutes les miniatures"
     )


### PR DESCRIPTION
## Description

French translation update:

- qt: expose dropped thumbnal size limit

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/10273

## Reviewers

@twinaphex 
