### PR TITLE
(Travis) Allow OSX to fail until we fix xcode11.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,6 +105,10 @@ matrix:
         - cd pkg/android/phoenix
         - ./gradlew assembleNormalRelease
 
+jobs:
+  allow_failure:
+    - os: osx
+
 before_install:
   - |
      if [[ "$CC" =~ ^gcc-8.* ]]; then


### PR DESCRIPTION
Xcode 11.2 has been failing for a while through the following error. This change ignores that failure until we can fix it properly...

```
0.03s$ echo $OSX_CERT | base64 --decode > dev.p12
The command "echo $OSX_CERT | base64 --decode > dev.p12" exited with 0.
0.04s$ security import dev.p12 -k build.keychain -P $OSX_CERT_PASS -T /usr/bin/codesign
security: SecKeychainItemImport: One or more parameters passed to a function were not valid.
The command "security import dev.p12 -k build.keychain -P $OSX_CERT_PASS -T /usr/bin/codesign" exited with 1.
0.01s$ rm dev.p12
The command "rm dev.p12" exited with 0.
0.05s$ security set-key-partition-list -S "apple-tool:,apple:,codesign:" -s -k travis build.keychain
security: SecItemCopyMatching: The specified item could not be found in the keychain.
The command "security set-key-partition-list -S "apple-tool:,apple:,codesign:" -s -k travis build.keychain" exited with 1.
4.39s$ xcodebuild -target RetroArchQt -configuration Release -project pkg/apple/RetroArch_Metal.xcodeproj
note: Using new build system
note: Planning build
note: Constructing build description
error: No signing certificate "Developer ID Application" found: No "Developer ID Application" signing certificate matching team ID "ZE9XE938Z2" with a private key was found. (in target 'RetroArchQt' from project 'RetroArch_Metal')
** BUILD FAILED **
The command "xcodebuild -target RetroArchQt -configuration Release -project pkg/apple/RetroArch_Metal.xcodeproj" exited with 65.
```

Can see an example of that failure over here:
https://travis-ci.org/github/libretro/RetroArch/jobs/662872602?utm_medium=notification&utm_source=github_status