### PR TITLE
(GL) Fix NULL pointer dereference in gl2_init()

### DIFF
--- a/gfx/drivers/gl.c
+++ b/gfx/drivers/gl.c
@@ -3671,12 +3671,19 @@ static void *gl2_init(const video_info_t *video,
 
       device_str[0] = '\0';
 
-      strlcpy(device_str, vendor, sizeof(device_str));
-      strlcat(device_str, " ", sizeof(device_str));
-      strlcat(device_str, renderer, sizeof(device_str));
+      if (!string_is_empty(vendor))
+      {
+        strlcpy(device_str, vendor, sizeof(device_str));
+        strlcat(device_str, " ", sizeof(device_str));
+      }
+
+      if (!string_is_empty(renderer))
+        strlcat(device_str, renderer, sizeof(device_str));
 
       video_driver_set_gpu_device_string(device_str);
-      video_driver_set_gpu_api_version_string(version);
+
+      if (!string_is_empty(version))
+        video_driver_set_gpu_api_version_string(version);
    }
 
 #ifdef _WIN32


### PR DESCRIPTION
## Description

Commit 10df615d141 ("add "Send Debug Info" option under Help") added some
debug information that contains the GL_VENDOR, GL_RENDERER and GL_VERSION
strings that are returned by the glGetString() function, and is used by
algorithms to recognize the platform.

But in some GL contexts, these may be NULL which leads to a NULL pointer
dereference when trying to copy the returned strings. Commit 97247dbaecc
("gl1: check for vender/renderer was in the wrong place") later fixed it
for the GL1 driver, but it missed doing the same for the GL driver.

For example, on an Exynos Odroid XU4 with a mali-fdev GL context I get:

$ retroarch -v
[INFO] RetroArch 1.8.5 (Git 8d3f25f)
[INFO] === Build =======================================
[INFO] Capabilities:  NEON VFPv3 VFPv4
[INFO] Built: Mar 18 2020
[INFO] Version: 1.8.5
[INFO] Git: 8d3f25f
[INFO] =================================================
[INFO] [Environ]: SET_PIXEL_FORMAT: RGB565.
[INFO] Version of libretro API: 1
[INFO] Compiled against API: 1
[INFO] [Audio]: Set audio input rate to: 30000.00 Hz.
[INFO] [Video]: Video @ 960x720
[INFO] [EGL] Falling back to eglGetDisplay
[INFO] [EGL]: EGL version: 1.4
[INFO] [GL]: Found GL context: mali-fbdev
[INFO] [GL]: Detecting screen resolution 0x0.
[INFO] [EGL]: Current context: 0xf08e20.
[INFO] [GL]: Vendor: (null), Renderer: (null).
[INFO] [GL]: Version: (null).
Segmentation fault (core dumped)