### PR TITLE
(Ozone) Hide 'Menu Color Theme' setting when 'Use preferred system color theme' is enabled

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -406,6 +406,8 @@
 #endif
 
 #ifdef HAVE_OZONE
+/* Ozone colour theme: 1 == Basic Black */
+#define DEFAULT_OZONE_COLOR_THEME 1
 #define DEFAULT_OZONE_COLLAPSE_SIDEBAR false
 #define DEFAULT_OZONE_TRUNCATE_PLAYLIST_NAME true
 #define DEFAULT_OZONE_SCROLL_CONTENT_METADATA false

--- a/configuration.c
+++ b/configuration.c
@@ -1826,7 +1826,7 @@ static struct config_uint_setting *populate_settings_uint(settings_t *settings, 
    SETTING_UINT("materialui_landscape_layout_optimization", &settings->uints.menu_materialui_landscape_layout_optimization, true, DEFAULT_MATERIALUI_LANDSCAPE_LAYOUT_OPTIMIZATION, false);
    SETTING_UINT("menu_shader_pipeline",         &settings->uints.menu_xmb_shader_pipeline, true, DEFAULT_MENU_SHADER_PIPELINE, false);
 #ifdef HAVE_OZONE
-   SETTING_UINT("ozone_menu_color_theme",       &settings->uints.menu_ozone_color_theme, true, 1, false);
+   SETTING_UINT("ozone_menu_color_theme",       &settings->uints.menu_ozone_color_theme, true, DEFAULT_OZONE_COLOR_THEME, false);
 #endif
 #endif
    SETTING_UINT("audio_out_rate",               &settings->uints.audio_out_rate, true, DEFAULT_OUTPUT_RATE, false);

--- a/menu/drivers/ozone/ozone_theme.c
+++ b/menu/drivers/ozone/ozone_theme.c
@@ -14,6 +14,9 @@
  *  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/* Required for default theme setting */
+#include "../../../config.def.h"
+
 #include "ozone.h"
 #include "ozone_theme.h"
 #include "ozone_display.h"
@@ -222,7 +225,7 @@ unsigned ozone_get_system_theme(void)
 
    return ret;
 #else
-   return 0;
+   return DEFAULT_OZONE_COLOR_THEME;
 #endif
 }
 

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -7288,9 +7288,10 @@ unsigned menu_displaylist_build_list(
          break;
       case DISPLAYLIST_MENU_SETTINGS_LIST:
          {
-            settings_t      *settings         = config_get_ptr();
-            bool menu_horizontal_animation    = settings->bools.menu_horizontal_animation;
-            bool menu_materialui_show_nav_bar = settings->bools.menu_materialui_show_nav_bar;
+            settings_t      *settings                  = config_get_ptr();
+            bool menu_horizontal_animation             = settings->bools.menu_horizontal_animation;
+            bool menu_materialui_show_nav_bar          = settings->bools.menu_materialui_show_nav_bar;
+            bool menu_use_preferred_system_color_theme = settings->bools.menu_use_preferred_system_color_theme;
 
             menu_displaylist_build_info_selective_t build_list[] = {
                {MENU_ENUM_LABEL_MENU_SCALE_FACTOR,                            PARSE_ONLY_FLOAT,  true},
@@ -7325,7 +7326,6 @@ unsigned menu_displaylist_build_list(
                {MENU_ENUM_LABEL_XMB_SHADOWS_ENABLE,                           PARSE_ONLY_BOOL,   true},
                {MENU_ENUM_LABEL_XMB_RIBBON_ENABLE,                            PARSE_ONLY_UINT,   true},
                {MENU_ENUM_LABEL_XMB_MENU_COLOR_THEME,                         PARSE_ONLY_UINT,   true},
-               {MENU_ENUM_LABEL_OZONE_MENU_COLOR_THEME,                       PARSE_ONLY_UINT,   true},
                {MENU_ENUM_LABEL_OZONE_COLLAPSE_SIDEBAR,                       PARSE_ONLY_BOOL,   true},
                {MENU_ENUM_LABEL_OZONE_TRUNCATE_PLAYLIST_NAME,                 PARSE_ONLY_BOOL,   true},
                {MENU_ENUM_LABEL_MATERIALUI_ICONS_ENABLE,                      PARSE_ONLY_BOOL,   true},
@@ -7337,6 +7337,7 @@ unsigned menu_displaylist_build_list(
                {MENU_ENUM_LABEL_MATERIALUI_MENU_HEADER_OPACITY,               PARSE_ONLY_FLOAT,  true},
                {MENU_ENUM_LABEL_MATERIALUI_MENU_FOOTER_OPACITY,               PARSE_ONLY_FLOAT,  true},
                {MENU_ENUM_LABEL_MENU_USE_PREFERRED_SYSTEM_COLOR_THEME,        PARSE_ONLY_BOOL,   true},
+               {MENU_ENUM_LABEL_OZONE_MENU_COLOR_THEME,                       PARSE_ONLY_UINT,   false},
                {MENU_ENUM_LABEL_MENU_RGUI_INLINE_THUMBNAILS,                  PARSE_ONLY_BOOL,   true},
                {MENU_ENUM_LABEL_MATERIALUI_MENU_THUMBNAIL_VIEW_PORTRAIT,      PARSE_ONLY_UINT,   true},
                {MENU_ENUM_LABEL_MATERIALUI_MENU_THUMBNAIL_VIEW_LANDSCAPE,     PARSE_ONLY_UINT,   true},
@@ -7367,6 +7368,10 @@ unsigned menu_displaylist_build_list(
                      break;
                   case MENU_ENUM_LABEL_MATERIALUI_AUTO_ROTATE_NAV_BAR:
                      if (menu_materialui_show_nav_bar)
+                        build_list[i].checked = true;
+                     break;
+                  case MENU_ENUM_LABEL_OZONE_MENU_COLOR_THEME:
+                     if (!menu_use_preferred_system_color_theme)
                         build_list[i].checked = true;
                      break;
                   default:

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -13314,6 +13314,9 @@ static bool setting_append_list(
                   general_write_handler,
                   general_read_handler,
                   SD_FLAG_NONE);
+            (*list)[list_info->index - 1].action_ok     = &setting_bool_action_left_with_refresh;
+            (*list)[list_info->index - 1].action_left   = &setting_bool_action_left_with_refresh;
+            (*list)[list_info->index - 1].action_right  = &setting_bool_action_right_with_refresh;
          }
 
             CONFIG_BOOL(
@@ -13943,7 +13946,7 @@ static bool setting_append_list(
                   &settings->uints.menu_ozone_color_theme,
                   MENU_ENUM_LABEL_OZONE_MENU_COLOR_THEME,
                   MENU_ENUM_LABEL_VALUE_OZONE_MENU_COLOR_THEME,
-                  0,
+                  DEFAULT_OZONE_COLOR_THEME,
                   &group_info,
                   &subgroup_info,
                   parent_group,


### PR DESCRIPTION
## Description

At present, Ozone always displays the `Menu Color Theme` setting - despite the fact that this is ignored when `Use preferred system color theme` is enabled. This can be confusing for users.

With this PR, the `Menu Color Theme` setting is only shown when `Use preferred system color theme` is disabled.

This PR also cleans up the handling of Ozone's default theme setting - this is currently a mixture of hardcoded `0` and `1` values (so you get a different default depending on configuration...), but it is now set everywhere via a single `DEFAULT_OZONE_COLOR_THEME` define.

## Related Issues

This should help with #10331

