### PR TITLE
Fix 'gfx_display_draw_texture_slice()' (i.e. prevent glitches when rendering Ozone's selection cursor)

### DIFF
--- a/menu/drivers/ozone/ozone_display.c
+++ b/menu/drivers/ozone/ozone_display.c
@@ -120,9 +120,9 @@ static void ozone_draw_cursor_slice(
       size_t y, float alpha)
 {
    float scale_factor    = ozone->last_scale_factor;
-   int slice_x           = x_offset - 14 * scale_factor;
+   int slice_x           = x_offset - 12 * scale_factor;
    int slice_y           = (int)y + 8 * scale_factor;
-   unsigned slice_new_w  = width + (3 + 28 - 4) * scale_factor;
+   unsigned slice_new_w  = width + (24 + 1) * scale_factor;
    unsigned slice_new_h  = height + 20 * scale_factor;
 
    gfx_display_set_alpha(ozone->theme_dynamic.cursor_alpha, alpha);
@@ -185,7 +185,7 @@ static void ozone_draw_cursor_fallback(
          x_offset,
          (int)y,
          width,
-         height - ozone->dimensions.spacer_5px,
+         height - ozone->dimensions.spacer_3px,
          video_width,
          video_height,
          ozone->theme_dynamic.selection);
@@ -211,7 +211,7 @@ static void ozone_draw_cursor_fallback(
          video_width,
          video_height,
          x_offset - ozone->dimensions.spacer_3px,
-         (int)(y + height - ozone->dimensions.spacer_5px),
+         (int)(y + height - ozone->dimensions.spacer_3px),
          width + ozone->dimensions.spacer_3px * 2,
          ozone->dimensions.spacer_3px,
          video_width,
@@ -226,7 +226,7 @@ static void ozone_draw_cursor_fallback(
          (int)(x_offset - ozone->dimensions.spacer_3px),
          (int)y,
          ozone->dimensions.spacer_3px,
-         height - ozone->dimensions.spacer_5px,
+         height - ozone->dimensions.spacer_3px,
          video_width,
          video_height,
          ozone->theme_dynamic.selection_border);
@@ -239,7 +239,7 @@ static void ozone_draw_cursor_fallback(
          x_offset + width,
          (int)y,
          ozone->dimensions.spacer_3px,
-         height - ozone->dimensions.spacer_5px,
+         height - ozone->dimensions.spacer_3px,
          video_width,
          video_height,
          ozone->theme_dynamic.selection_border);
@@ -545,6 +545,7 @@ void ozone_draw_messagebox(
    if (ozone->has_all_assets) /* avoid drawing a black box if there's no assets */
    {
       int slice_x          = x - longest_width/2 - 48 * scale_factor;
+      int slice_y          = (list->size > 1) ? y : y - (ozone->footer_font_glyph_height / 2);
       unsigned slice_new_w = longest_width + 48 * 2 * scale_factor;
       unsigned slice_new_h = ozone->footer_font_glyph_height * (list->size + 2);
 
@@ -553,7 +554,7 @@ void ozone_draw_messagebox(
             video_width,
             video_height,
             slice_x,
-            y,
+            slice_y,
             256, 256,
             slice_new_w,
             slice_new_h,

--- a/menu/drivers/ozone/ozone_entries.c
+++ b/menu/drivers/ozone/ozone_entries.c
@@ -502,8 +502,8 @@ border_iterate:
             video_height,
             (unsigned) ozone->dimensions.sidebar_width + x_offset + entry_padding + ozone->dimensions.spacer_3px,
             entry_width - ozone->dimensions.spacer_5px,
-            button_height + ozone->dimensions.spacer_2px,
-            selection_y + scroll_y + ozone->dimensions.spacer_1px,
+            button_height + ozone->dimensions.spacer_1px,
+            selection_y + scroll_y,
             ozone->animations.cursor_alpha * alpha);
 
    /* Old*/
@@ -519,8 +519,8 @@ border_iterate:
              of type 'unsigned int'
              * */
             entry_width - ozone->dimensions.spacer_5px,
-            button_height + ozone->dimensions.spacer_2px,
-            old_selection_y + scroll_y + ozone->dimensions.spacer_1px,
+            button_height + ozone->dimensions.spacer_1px,
+            old_selection_y + scroll_y,
             (1-ozone->animations.cursor_alpha) * alpha);
 
    /* Icons + text */

--- a/menu/drivers/ozone/ozone_sidebar.c
+++ b/menu/drivers/ozone/ozone_sidebar.c
@@ -235,8 +235,8 @@ void ozone_draw_sidebar(
             video_height,
             ozone->sidebar_offset + ozone->dimensions.sidebar_padding_horizontal + ozone->dimensions.spacer_3px,
             entry_width - ozone->dimensions.spacer_5px,
-            ozone->dimensions.sidebar_entry_height + ozone->dimensions.spacer_2px,
-            selection_y + ozone->dimensions.spacer_2px + ozone->animations.scroll_y_sidebar,
+            ozone->dimensions.sidebar_entry_height + ozone->dimensions.spacer_1px,
+            selection_y + ozone->animations.scroll_y_sidebar,
             ozone->animations.cursor_alpha);
 
    if (ozone->cursor_in_sidebar_old)
@@ -246,9 +246,10 @@ void ozone_draw_sidebar(
             video_width,
             video_height,
             ozone->sidebar_offset + ozone->dimensions.sidebar_padding_horizontal + ozone->dimensions.spacer_3px,
-         entry_width - ozone->dimensions.spacer_5px,
-         ozone->dimensions.sidebar_entry_height + ozone->dimensions.spacer_2px, selection_old_y + ozone->dimensions.spacer_2px + ozone->animations.scroll_y_sidebar,
-         1-ozone->animations.cursor_alpha);
+				entry_width - ozone->dimensions.spacer_5px,
+				ozone->dimensions.sidebar_entry_height + ozone->dimensions.spacer_1px,
+				selection_old_y + ozone->animations.scroll_y_sidebar,
+				1-ozone->animations.cursor_alpha);
 
    /* Menu tabs */
    y = ozone->dimensions.header_height + ozone->dimensions.spacer_1px + ozone->dimensions.sidebar_padding_vertical;

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -930,7 +930,7 @@ static void xmb_render_messagebox_internal(
          line_height * list->size + xmb->margins_dialog * 2,
          video_width, video_height,
          NULL,
-         xmb->margins_slice, 1.0,
+         xmb->margins_slice, xmb->last_scale_factor,
          xmb->textures.list[XMB_TEXTURE_DIALOG_SLICE]);
 
    for (i = 0; i < list->size; i++)
@@ -5050,7 +5050,7 @@ static void xmb_layout_ps3(xmb_handle_t *xmb, int width)
    xmb->margins_setting_left     = 600.0 * scale_factor * scale_mod[6];
    xmb->margins_dialog           = 48 * scale_factor;
 
-   xmb->margins_slice            = 16;
+   xmb->margins_slice            = 16 * scale_factor;
 
    xmb->icon_size                = 128.0 * scale_factor;
    xmb->font_size                = new_font_size;
@@ -5098,7 +5098,7 @@ static void xmb_layout_psp(xmb_handle_t *xmb, int width)
    xmb->margins_label_top        = new_font_size / 3.0;
    xmb->margins_setting_left     = 600.0 * scale_factor;
    xmb->margins_dialog           = 48 * scale_factor;
-   xmb->margins_slice            = 16;
+   xmb->margins_slice            = 16 * scale_factor;
    xmb->icon_size                = 128.0 * scale_factor;
    xmb->font_size                = new_font_size;
 


### PR DESCRIPTION
## Description

At present, Ozone's selection cursor exhibits ugly rendering glitches at certain scales/window sizes. For example:

![Screenshot_2020-03-26_11-45-10](https://user-images.githubusercontent.com/38211560/77644771-7beb1d80-6f59-11ea-8823-0a0a37da47bd.png)

This occurs due to an intrinsic shortcoming in the way that textures are rendered - and the fact that the `gfx_display_draw_texture_slice()` function does not account for this annoyance.

The `gfx_display_draw_texture_slice()` function is used to render 'textured' boxes. It does this by splitting a source texture into 8 segments: the corners are nominally rendered at the native texture resolution, while the middle sections are 'stretched' to fill a box of the requested size. This allows for nice border effects, expanded to arbitrary dimensions while retaining aspect-ratio-correct corner pieces.

The problem here is that the pixel values of any scaled texture get interpolated. This means that scaled images get blurred - and also, at any transparent edges, the colours of the transparent pixels themselves bleed into the visible area (this is a side issue, noted later), Since `gfx_display_draw_texture_slice()` nominally draws corners at native resolution, and only scales the middle sections, we end up with sharp corners and blurry middles. Whenever the middle segments are *upscaled*, the effects of this are essentially imperceptible, and harmless. But when the middle segments are *downscaled*, the transition between corners and middles is obvious and nasty - hence the dirty shadowing seen at the right hand edge of Ozone's cursor in the above image.

We can't really do anything about the interpolation (that's just how textures are rendered...), but this PR implements a simple/effective workaround: when drawing a box via `gfx_display_draw_texture_slice()` that is smaller than the source texture size, we force downscaling of the entire texture image (including corners). This blurs everything sufficiently that the transitions between corners and middle sections are basically invisible:

![Screenshot_2020-03-26_11-48-15](https://user-images.githubusercontent.com/38211560/77646386-59a6cf00-6f5c-11ea-93e1-d05198855a40.png)

**IMPORTANT NOTE:** While debugging this, I discovered a related issue with the formatting of Ozone's PNG asset files. They have transparent pixels of the wrong colour, causing dark borders at all transparent edges. This also messes up the rendering of Ozone's cursor, so in order for this PR to work as intended, this asset update must also be merged: https://github.com/libretro/retroarch-assets/pull/347

*Less important note:* After updating `gfx_display_draw_texture_slice()`, I checked each instance where it is used. This revealed some minor bugs in Ozone's and XMB's message box rendering code, which this PR also fixes.

## Related Issues

Along with https://github.com/libretro/retroarch-assets/pull/347, this PR closes #10317

## Related Pull Requests

This PR requires https://github.com/libretro/retroarch-assets/pull/347
