### PR TITLE
(runtime_file) Remove settings pointer dependency

### DIFF
--- a/menu/cbs/menu_cbs_sublabel.c
+++ b/menu/cbs/menu_cbs_sublabel.c
@@ -1069,14 +1069,20 @@ static int action_bind_sublabel_playlist_entry(
       const char *label, const char *path,
       char *s, size_t len)
 {
-   playlist_t *playlist               = NULL;
-   const struct playlist_entry *entry = NULL;
-   const char *menu_ident             = menu_driver_ident();
-   settings_t *settings               = config_get_ptr();
-   bool playlist_show_sublabels       = settings->bools.playlist_show_sublabels;
-   unsigned playlist_sublabel_runtime_type = settings->uints.playlist_sublabel_runtime_type;
-   bool content_runtime_log           = settings->bools.content_runtime_log;
-   bool content_runtime_log_aggregate = settings->bools.content_runtime_log_aggregate;
+   playlist_t *playlist                      = NULL;
+   const struct playlist_entry *entry        = NULL;
+   const char *menu_ident                    = menu_driver_ident();
+   settings_t *settings                      = config_get_ptr();
+   bool playlist_show_sublabels              = settings->bools.playlist_show_sublabels;
+   unsigned playlist_sublabel_runtime_type   = settings->uints.playlist_sublabel_runtime_type;
+   bool content_runtime_log                  = settings->bools.content_runtime_log;
+   bool content_runtime_log_aggregate        = settings->bools.content_runtime_log_aggregate;
+   const char *directory_runtime_log         = settings->paths.directory_runtime_log;
+   const char *directory_playlist            = settings->paths.directory_playlist;
+   enum playlist_sublabel_last_played_style_type
+         playlist_sublabel_last_played_style =
+               (enum playlist_sublabel_last_played_style_type)
+                     settings->uints.playlist_sublabel_last_played_style;
 
    if (!playlist_show_sublabels)
       return 0;
@@ -1128,7 +1134,12 @@ static int action_bind_sublabel_playlist_entry(
 
    /* Check whether runtime info should be loaded from log file */
    if (entry->runtime_status == PLAYLIST_RUNTIME_UNKNOWN)
-      runtime_update_playlist(playlist, i);
+      runtime_update_playlist(
+            playlist, i,
+            directory_runtime_log,
+            directory_playlist,
+            (playlist_sublabel_runtime_type == PLAYLIST_RUNTIME_PER_CORE),
+            playlist_sublabel_last_played_style);
 
    /* Check whether runtime info is valid */
    if (entry->runtime_status == PLAYLIST_RUNTIME_VALID)

--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -1787,13 +1787,21 @@ static void ozone_draw_footer(ozone_handle_t *ozone,
 
 void ozone_update_content_metadata(ozone_handle_t *ozone)
 {
-   const char *core_name        = NULL;
-   size_t selection             = menu_navigation_get_selection();
-   playlist_t *playlist         = playlist_get_cached();
-   settings_t *settings         = config_get_ptr();
-   bool scroll_content_metadata = settings->bools.ozone_scroll_content_metadata;
-   bool content_runtime_log     = settings->bools.content_runtime_log;
-   bool content_runtime_log_aggr= settings->bools.content_runtime_log_aggregate;
+   const char *core_name             = NULL;
+   size_t selection                  = menu_navigation_get_selection();
+   playlist_t *playlist              = playlist_get_cached();
+   settings_t *settings              = config_get_ptr();
+   bool scroll_content_metadata      = settings->bools.ozone_scroll_content_metadata;
+   bool content_runtime_log          = settings->bools.content_runtime_log;
+   bool content_runtime_log_aggr     = settings->bools.content_runtime_log_aggregate;
+   const char *directory_runtime_log = settings->paths.directory_runtime_log;
+   const char *directory_playlist    = settings->paths.directory_playlist;
+   unsigned runtime_type             = settings->uints.playlist_sublabel_runtime_type;
+   enum playlist_sublabel_last_played_style_type
+         runtime_last_played_style   =
+               (enum playlist_sublabel_last_played_style_type)
+                     settings->uints.playlist_sublabel_last_played_style;
+
    /* Must check whether core corresponds to 'viewer'
     * content even when not using a playlist, otherwise
     * file browser image updates are mishandled */
@@ -1837,7 +1845,12 @@ void ozone_update_content_metadata(ozone_handle_t *ozone)
          playlist_get_index(playlist, selection, &entry);
 
          if (entry->runtime_status == PLAYLIST_RUNTIME_UNKNOWN)
-            runtime_update_playlist(playlist, selection);
+            runtime_update_playlist(
+                  playlist, selection,
+                  directory_runtime_log,
+                  directory_playlist,
+                  (runtime_type == PLAYLIST_RUNTIME_PER_CORE),
+                  runtime_last_played_style);
 
          if (!string_is_empty(entry->runtime_str))
             strlcpy(ozone->selection_playtime, entry->runtime_str, sizeof(ozone->selection_playtime));

--- a/runtime_file.h
+++ b/runtime_file.h
@@ -182,7 +182,12 @@ void runtime_log_convert_usec2hms(retro_time_t usec, unsigned *hours, unsigned *
 
 /* Updates specified playlist entry runtime values with
  * contents of associated log file */
-void runtime_update_playlist(playlist_t *playlist, size_t idx);
+void runtime_update_playlist(
+      playlist_t *playlist, size_t idx,
+      const char *dir_runtime_log,
+      const char *dir_playlist,
+      bool log_per_core,
+      enum playlist_sublabel_last_played_style_type timedate_style);
 
 RETRO_END_DECLS
 


### PR DESCRIPTION
## Description

As requested by twinaphex, this PR removes the settings pointer dependency from `runtime_file.c`
