### PR TITLE
Enable correct vertical alignment of text (+ font rendering fixes)

### DIFF
--- a/gfx/drivers_font/caca_font.c
+++ b/gfx/drivers_font/caca_font.c
@@ -143,5 +143,6 @@ font_renderer_t caca_font = {
    caca_font_get_glyph,       /* get_glyph */
    NULL,                      /* bind_block */
    NULL,                      /* flush */
-   caca_get_message_width     /* get_message_width */
+   caca_get_message_width,    /* get_message_width */
+   NULL                       /* get_line_metrics */
 };

--- a/gfx/drivers_font/d3d10_font.c
+++ b/gfx/drivers_font/d3d10_font.c
@@ -237,14 +237,16 @@ static void d3d10_font_render_message(
       unsigned            height,
       unsigned            text_align)
 {
-   int   lines = 0;
+   struct font_line_metrics *line_metrics = NULL;
+   int lines                              = 0;
    float line_height;
 
    if (!msg || !*msg)
       return;
 
-   /* If the font height is not supported just draw as usual */
-   if (!font->font_driver->get_line_height)
+   /* If font line metrics are not supported just draw as usual */
+   if (!font->font_driver->get_line_metrics ||
+       !font->font_driver->get_line_metrics(font->font_data, &line_metrics))
    {
       d3d10_font_render_line(d3d10,
             font, msg, strlen(msg), scale, color, pos_x, pos_y,
@@ -252,8 +254,7 @@ static void d3d10_font_render_message(
       return;
    }
 
-   line_height = font->font_driver->get_line_height(font->font_data) 
-      * scale / height;
+   line_height = line_metrics->height * scale / height;
 
    for (;;)
    {
@@ -377,14 +378,14 @@ static const struct font_glyph* d3d10_font_get_glyph(void *data, uint32_t code)
    return font->font_driver->get_glyph((void*)font->font_driver, code);
 }
 
-static int d3d10_font_get_line_height(void *data)
+static bool d3d10_font_get_line_metrics(void* data, struct font_line_metrics **metrics)
 {
    d3d10_font_t* font = (d3d10_font_t*)data;
 
    if (!font || !font->font_driver || !font->font_data)
       return -1;
 
-   return font->font_driver->get_line_height(font->font_data);
+   return font->font_driver->get_line_metrics(font->font_data, metrics);
 }
 
 font_renderer_t d3d10_font = {
@@ -396,5 +397,5 @@ font_renderer_t d3d10_font = {
    NULL, /* bind_block */
    NULL, /* flush */
    d3d10_font_get_message_width,
-   d3d10_font_get_line_height
+   d3d10_font_get_line_metrics
 };

--- a/gfx/drivers_font/d3d12_font.c
+++ b/gfx/drivers_font/d3d12_font.c
@@ -248,14 +248,16 @@ static void d3d12_font_render_message(
       unsigned            height,
       unsigned            text_align)
 {
-   int   lines = 0;
+   struct font_line_metrics *line_metrics = NULL;
+   int lines                              = 0;
    float line_height;
 
    if (!msg || !*msg)
       return;
 
-   /* If the font height is not supported just draw as usual */
-   if (!font->font_driver->get_line_height)
+   /* If font line metrics are not supported just draw as usual */
+   if (!font->font_driver->get_line_metrics ||
+       !font->font_driver->get_line_metrics(font->font_data, &line_metrics))
    {
       d3d12_font_render_line(d3d12,
             font, msg, strlen(msg),
@@ -263,8 +265,7 @@ static void d3d12_font_render_message(
       return;
    }
 
-   line_height = font->font_driver->get_line_height(font->font_data)
-      * scale / height;
+   line_height = line_metrics->height * scale / height;
 
    for (;;)
    {
@@ -386,14 +387,14 @@ static const struct font_glyph* d3d12_font_get_glyph(
    return font->font_driver->get_glyph((void*)font->font_driver, code);
 }
 
-static int d3d12_font_get_line_height(void *data)
+static bool d3d12_font_get_line_metrics(void* data, struct font_line_metrics **metrics)
 {
    d3d12_font_t* font = (d3d12_font_t*)data;
 
    if (!font || !font->font_driver || !font->font_data)
       return -1;
 
-   return font->font_driver->get_line_height(font->font_data);
+   return font->font_driver->get_line_metrics(font->font_data, metrics);
 }
 
 font_renderer_t d3d12_font = {
@@ -405,5 +406,5 @@ font_renderer_t d3d12_font = {
    NULL, /* bind_block */
    NULL, /* flush */
    d3d12_font_get_message_width,
-   d3d12_font_get_line_height
+   d3d12_font_get_line_metrics
 };

--- a/gfx/drivers_font/d3d_w32_font.c
+++ b/gfx/drivers_font/d3d_w32_font.c
@@ -236,5 +236,6 @@ font_renderer_t d3d_win32_font = {
    NULL,                      /* get_glyph */
    NULL,                      /* bind_block */
    NULL,                      /* flush */
-   d3dfonts_w32_get_message_width
+   d3dfonts_w32_get_message_width,
+   NULL                       /* get_line_metrics */
 };

--- a/gfx/drivers_font/gdi_font.c
+++ b/gfx/drivers_font/gdi_font.c
@@ -209,8 +209,9 @@ font_renderer_t gdi_font = {
    gdi_render_free_font,
    gdi_render_msg,
    "gdi font",
-   gdi_font_get_glyph,       /* get_glyph */
-   NULL,      /* bind_block */
-   NULL,     /* flush */
-   gdi_get_message_width     /* get_message_width */
+   gdi_font_get_glyph,        /* get_glyph */
+   NULL,                      /* bind_block */
+   NULL,                      /* flush */
+   gdi_get_message_width,     /* get_message_width */
+   NULL                       /* get_line_metrics */
 };

--- a/gfx/drivers_font/gl1_raster_font.c
+++ b/gfx/drivers_font/gl1_raster_font.c
@@ -383,11 +383,13 @@ static void gl1_raster_font_render_message(
       const GLfloat color[4], GLfloat pos_x, GLfloat pos_y,
       unsigned text_align)
 {
+   struct font_line_metrics *line_metrics = NULL;
+   int lines                              = 0;
    float line_height;
-   int lines = 0;
 
-   /* If the font height is not supported just draw as usual */
-   if (!font->font_driver->get_line_height)
+   /* If font line metrics are not supported just draw as usual */
+   if (!font->font_driver->get_line_metrics ||
+       !font->font_driver->get_line_metrics(font->font_data, &line_metrics))
    {
       gl1_raster_font_render_line(font,
             msg, (unsigned)strlen(msg), scale, color, pos_x,
@@ -395,8 +397,7 @@ static void gl1_raster_font_render_message(
       return;
    }
 
-   line_height = (float) font->font_driver->get_line_height(font->font_data) *
-                     scale / font->gl->vp.height;
+   line_height = line_metrics->height * scale / font->gl->vp.height;
 
    for (;;)
    {
@@ -576,14 +577,14 @@ static void gl1_raster_font_bind_block(void *data, void *userdata)
       font->block = block;
 }
 
-static int gl1_get_line_height(void *data)
+static bool gl1_get_line_metrics(void* data, struct font_line_metrics **metrics)
 {
    gl1_raster_t *font = (gl1_raster_t*)data;
 
    if (!font || !font->font_driver || !font->font_data)
       return -1;
 
-   return font->font_driver->get_line_height(font->font_data);
+   return font->font_driver->get_line_metrics(font->font_data, metrics);
 }
 
 font_renderer_t gl1_raster_font = {
@@ -595,5 +596,5 @@ font_renderer_t gl1_raster_font = {
    gl1_raster_font_bind_block,
    gl1_raster_font_flush_block,
    gl1_get_message_width,
-   gl1_get_line_height
+   gl1_get_line_metrics
 };

--- a/gfx/drivers_font/gl_core_raster_font.c
+++ b/gfx/drivers_font/gl_core_raster_font.c
@@ -293,11 +293,13 @@ static void gl_core_raster_font_render_message(
       const GLfloat color[4], GLfloat pos_x, GLfloat pos_y,
       unsigned text_align)
 {
+   struct font_line_metrics *line_metrics = NULL;
+   int lines                              = 0;
    float line_height;
-   int lines = 0;
 
-   /* If the font height is not supported just draw as usual */
-   if (!font->font_driver->get_line_height)
+   /* If font line metrics are not supported just draw as usual */
+   if (!font->font_driver->get_line_metrics ||
+       !font->font_driver->get_line_metrics(font->font_data, &line_metrics))
    {
       gl_core_raster_font_render_line(font,
             msg, (unsigned)strlen(msg), scale, color, pos_x,
@@ -305,8 +307,7 @@ static void gl_core_raster_font_render_message(
       return;
    }
 
-   line_height = (float) font->font_driver->get_line_height(font->font_data) *
-                     scale / font->gl->vp.height;
+   line_height = line_metrics->height * scale / font->gl->vp.height;
 
    for (;;)
    {
@@ -477,14 +478,14 @@ static void gl_core_raster_font_bind_block(void *data, void *userdata)
       font->block = block;
 }
 
-static int gl_core_get_line_height(void *data)
+static bool gl_core_get_line_metrics(void* data, struct font_line_metrics **metrics)
 {
    gl_core_raster_t *font   = (gl_core_raster_t*)data;
 
    if (!font || !font->font_driver || !font->font_data)
       return -1;
 
-   return font->font_driver->get_line_height(font->font_data);
+   return font->font_driver->get_line_metrics(font->font_data, metrics);
 }
 
 font_renderer_t gl_core_raster_font = {
@@ -496,5 +497,5 @@ font_renderer_t gl_core_raster_font = {
    gl_core_raster_font_bind_block,
    gl_core_raster_font_flush_block,
    gl_core_get_message_width,
-   gl_core_get_line_height
+   gl_core_get_line_metrics
 };

--- a/gfx/drivers_font/gl_raster_font.c
+++ b/gfx/drivers_font/gl_raster_font.c
@@ -362,11 +362,13 @@ static void gl_raster_font_render_message(
       const GLfloat color[4], GLfloat pos_x, GLfloat pos_y,
       unsigned text_align)
 {
+   struct font_line_metrics *line_metrics = NULL;
+   int lines                              = 0;
    float line_height;
-   int lines = 0;
 
-   /* If the font height is not supported just draw as usual */
-   if (!font->font_driver->get_line_height)
+   /* If font line metrics are not supported just draw as usual */
+   if (!font->font_driver->get_line_metrics ||
+       !font->font_driver->get_line_metrics(font->font_data, &line_metrics))
    {
       gl_raster_font_render_line(font,
             msg, (unsigned)strlen(msg), scale, color, pos_x,
@@ -374,8 +376,7 @@ static void gl_raster_font_render_message(
       return;
    }
 
-   line_height = (float) font->font_driver->get_line_height(font->font_data) *
-                     scale / font->gl->vp.height;
+   line_height = line_metrics->height * scale / font->gl->vp.height;
 
    for (;;)
    {
@@ -557,14 +558,14 @@ static void gl_raster_font_bind_block(void *data, void *userdata)
       font->block = block;
 }
 
-static int gl_get_line_height(void *data)
+static bool gl_get_line_metrics(void* data, struct font_line_metrics **metrics)
 {
    gl_raster_t *font   = (gl_raster_t*)data;
 
    if (!font || !font->font_driver || !font->font_data)
       return -1;
 
-   return font->font_driver->get_line_height(font->font_data);
+   return font->font_driver->get_line_metrics(font->font_data, metrics);
 }
 
 font_renderer_t gl_raster_font = {
@@ -576,5 +577,5 @@ font_renderer_t gl_raster_font = {
    gl_raster_font_bind_block,
    gl_raster_font_flush_block,
    gl_get_message_width,
-   gl_get_line_height
+   gl_get_line_metrics
 };

--- a/gfx/drivers_font/metal_raster_font.m
+++ b/gfx/drivers_font/metal_raster_font.m
@@ -350,15 +350,18 @@ static INLINE void write_quad6(SpriteVertex *pv,
                  posY:(float)posY
               aligned:(unsigned)aligned
 {
-   /* If the font height is not supported just draw as usual */
-   if (!_font_driver->get_line_height)
+   struct font_line_metrics *line_metrics = NULL;
+
+   /* If font line metrics are not supported just draw as usual */
+   if (!_font_driver->get_line_metrics ||
+       !_font_driver->get_line_metrics(_font_data, &line_metrics))
    {
       [self _renderLine:msg length:strlen(msg) scale:scale color:color posX:posX posY:posY aligned:aligned];
       return;
    }
 
    int lines = 0;
-   float line_height = _font_driver->get_line_height(_font_data) * scale / height;
+   float line_height = line_metrics->height * scale / height;
 
    for (;;)
    {
@@ -545,5 +548,6 @@ font_renderer_t metal_raster_font = {
    .get_glyph         = metal_raster_font_get_glyph,
    NULL, /* bind_block  */
    NULL, /* flush_block */
-   .get_message_width = metal_get_message_width
+   .get_message_width = metal_get_message_width,
+   NULL  /* get_line_metrics */
 };

--- a/gfx/drivers_font/ps2_font.c
+++ b/gfx/drivers_font/ps2_font.c
@@ -165,4 +165,5 @@ font_renderer_t ps2_font = {
    NULL,                      /* bind_block */
    NULL,                      /* flush */
    NULL,                      /* get_message_width */
+   NULL                       /* get_line_metrics */
 };

--- a/gfx/drivers_font/sixel_font.c
+++ b/gfx/drivers_font/sixel_font.c
@@ -141,5 +141,6 @@ font_renderer_t sixel_font = {
    sixel_font_get_glyph,       /* get_glyph */
    NULL,                       /* bind_block */
    NULL,                       /* flush */
-   sixel_get_message_width     /* get_message_width */
+   sixel_get_message_width,    /* get_message_width */
+   NULL                        /* get_line_metrics */
 };

--- a/gfx/drivers_font/switch_font.c
+++ b/gfx/drivers_font/switch_font.c
@@ -193,14 +193,16 @@ static void switch_font_render_message(
       const unsigned int color, float pos_x, float pos_y,
       unsigned text_align)
 {
+   struct font_line_metrics *line_metrics = NULL;
+   int lines                              = 0;
    float line_height;
-   int lines          = 0;
 
    if (!msg || !*msg)
       return;
 
-   /* If the font height is not supported just draw as usual */
-   if (!font->font_driver->get_line_height)
+   /* If font line metrics are not supported just draw as usual */
+   if (!font->font_driver->get_line_metrics ||
+       !font->font_driver->get_line_metrics(font->font_data, &line_metrics))
    {
       int msgLen = strlen(msg);
       if (msgLen <= AVG_GLPYH_LIMIT)
@@ -211,7 +213,7 @@ static void switch_font_render_message(
       }
       return;
    }
-   line_height = scale / font->font_driver->get_line_height(font->font_data);
+   line_height = scale / line_metrics->height;
 
    for (;;)
    {
@@ -312,13 +314,13 @@ static const struct font_glyph *switch_font_get_glyph(
    return font->font_driver->get_glyph((void *)font->font_driver, code);
 }
 
-static int switch_font_get_line_height(void *data)
+static bool switch_font_get_line_metrics(void* data, struct font_line_metrics **metrics)
 {
    switch_font_t *font = (switch_font_t *)data;
    if (!font || !font->font_driver || !font->font_data)
       return -1;
 
-   return font->font_driver->get_line_height(font->font_data);
+   return font->font_driver->get_line_metrics(font->font_data, metrics);
 }
 
 font_renderer_t switch_font =
@@ -331,5 +333,5 @@ font_renderer_t switch_font =
    NULL, /* bind_block  */
    NULL, /* flush_block */
    switch_font_get_message_width,
-   switch_font_get_line_height
+   switch_font_get_line_metrics
 };

--- a/gfx/drivers_font/vga_font.c
+++ b/gfx/drivers_font/vga_font.c
@@ -141,5 +141,6 @@ font_renderer_t vga_font = {
    vga_font_get_glyph,       /* get_glyph */
    NULL,                     /* bind_block */
    NULL,                     /* flush */
-   vga_get_message_width     /* get_message_width */
+   vga_get_message_width,    /* get_message_width */
+   NULL                      /* get_line_metrics */
 };

--- a/gfx/drivers_font/vita2d_font.c
+++ b/gfx/drivers_font/vita2d_font.c
@@ -225,22 +225,23 @@ static void vita2d_font_render_message(
       const unsigned int color, float pos_x, float pos_y,
       unsigned width, unsigned height, unsigned text_align)
 {
+   struct font_line_metrics *line_metrics = NULL;
+   int lines                              = 0;
    float line_height;
-   int lines = 0;
 
    if (!msg || !*msg)
       return;
 
-   /* If the font height is not supported just draw as usual */
-   if (!font->font_driver->get_line_height)
+   /* If font line metrics are not supported just draw as usual */
+   if (!font->font_driver->get_line_metrics ||
+       !font->font_driver->get_line_metrics(font->font_data, &line_metrics))
    {
       vita2d_font_render_line(font, msg, strlen(msg),
             scale, color, pos_x, pos_y, width, height, text_align);
       return;
    }
 
-   line_height = font->font_driver->get_line_height(font->font_data) *
-                     scale / font->vita->vp.height;
+   line_height = line_metrics->height * scale / font->vita->vp.height;
 
    for (;;)
    {
@@ -358,14 +359,14 @@ static const struct font_glyph *vita2d_font_get_glyph(
    return font->font_driver->get_glyph((void*)font->font_driver, code);
 }
 
-static int vita2d_font_get_line_height(void *data)
+static bool vita2d_font_get_line_metrics(void* data, struct font_line_metrics **metrics)
 {
    vita_font_t *font = (vita_font_t*)data;
 
    if (!font || !font->font_driver || !font->font_data)
       return -1;
 
-   return font->font_driver->get_line_height(font->font_data);
+   return font->font_driver->get_line_metrics(font->font_data, metrics);
 }
 
 font_renderer_t vita2d_vita_font = {
@@ -377,5 +378,5 @@ font_renderer_t vita2d_vita_font = {
    NULL,                      /* bind_block */
    NULL,                      /* flush */
    vita2d_font_get_message_width,
-   vita2d_font_get_line_height
+   vita2d_font_get_line_metrics
 };

--- a/gfx/drivers_font/xdk1_xfonts.c
+++ b/gfx/drivers_font/xdk1_xfonts.c
@@ -118,5 +118,6 @@ font_renderer_t d3d_xdk1_font = {
    NULL,                      /* get_glyph */
    NULL,                      /* bind_block */
    NULL,                      /* flush */
-   NULL                       /* get_message_width */
+   NULL,                      /* get_message_width */
+   NULL                       /* get_line_metrics */
 };

--- a/gfx/drivers_font_renderer/bitmap.h
+++ b/gfx/drivers_font_renderer/bitmap.h
@@ -19,7 +19,10 @@
 
 #define FONT_WIDTH 5
 #define FONT_HEIGHT 10
-#define FONT_HEIGHT_BASELINE 8
+/* FONT_HEIGHT_BASELINE_OFFSET:
+ * Distance in pixels from top of character
+ * to baseline */
+#define FONT_HEIGHT_BASELINE_OFFSET 8
 #define FONT_WIDTH_STRIDE (FONT_WIDTH + 1)
 #define FONT_HEIGHT_STRIDE (FONT_HEIGHT + 1)
 

--- a/gfx/drivers_font_renderer/bitmapfont.c
+++ b/gfx/drivers_font_renderer/bitmapfont.c
@@ -33,6 +33,7 @@ typedef struct bm_renderer
    unsigned scale_factor;
    struct font_glyph glyphs[BMP_ATLAS_SIZE];
    struct font_atlas atlas;
+   struct font_line_metrics line_metrics;
 } bm_renderer_t;
 
 static struct font_atlas *font_renderer_bmp_get_atlas(void *data)
@@ -113,10 +114,14 @@ static void *font_renderer_bmp_init(const char *font_path, float font_size)
       handle->glyphs[i].atlas_offset_x = x;
       handle->glyphs[i].atlas_offset_y = y;
       handle->glyphs[i].draw_offset_x  = 0;
-      handle->glyphs[i].draw_offset_y  = -FONT_HEIGHT_BASELINE * (int)handle->scale_factor;
-      handle->glyphs[i].advance_x      = (FONT_WIDTH + 1) * handle->scale_factor;
+      handle->glyphs[i].draw_offset_y  = -FONT_HEIGHT_BASELINE_OFFSET * handle->scale_factor;
+      handle->glyphs[i].advance_x      = FONT_WIDTH_STRIDE * handle->scale_factor;
       handle->glyphs[i].advance_y      = 0;
    }
+
+   handle->line_metrics.ascender       = (float)FONT_HEIGHT_BASELINE_OFFSET * handle->scale_factor;
+   handle->line_metrics.descender      = (float)(FONT_HEIGHT - FONT_HEIGHT_BASELINE_OFFSET) * handle->scale_factor;
+   handle->line_metrics.height         = (float)FONT_HEIGHT_STRIDE * handle->scale_factor;
 
    return handle;
 }
@@ -135,14 +140,16 @@ static const char *font_renderer_bmp_get_default_font(void)
    return "";
 }
 
-static int font_renderer_bmp_get_line_height(void* data)
+static bool font_renderer_bmp_get_line_metrics(
+      void* data, struct font_line_metrics **metrics)
 {
-    bm_renderer_t *handle = (bm_renderer_t*)data;
+   bm_renderer_t *handle = (bm_renderer_t*)data;
 
-    if (!handle)
-      return FONT_HEIGHT;
+   if (!handle)
+      return false;
 
-    return FONT_HEIGHT * handle->scale_factor;
+   *metrics = &handle->line_metrics;
+   return true;
 }
 
 font_renderer_driver_t bitmap_font_renderer = {
@@ -152,5 +159,5 @@ font_renderer_driver_t bitmap_font_renderer = {
    font_renderer_bmp_free,
    font_renderer_bmp_get_default_font,
    "bitmap",
-   font_renderer_bmp_get_line_height,
+   font_renderer_bmp_get_line_metrics
 };

--- a/gfx/drivers_font_renderer/freetype.c
+++ b/gfx/drivers_font_renderer/freetype.c
@@ -54,6 +54,7 @@ typedef struct freetype_renderer
    freetype_atlas_slot_t atlas_slots[FT_ATLAS_SIZE];
    freetype_atlas_slot_t* uc_map[0x100];
    unsigned usage_counter;
+   struct font_line_metrics line_metrics;
 } ft_font_renderer_t;
 
 static struct font_atlas *font_renderer_ft_get_atlas(void *data)
@@ -261,6 +262,10 @@ static void *font_renderer_ft_init(const char *font_path, float font_size)
    if (!font_renderer_create_atlas(handle, font_size))
       goto error;
 
+   handle->line_metrics.ascender  = (float)handle->face->size->metrics.ascender / 64.0f;
+   handle->line_metrics.descender = (float)(-handle->face->size->metrics.descender) / 64.0f;
+   handle->line_metrics.height    = (float)handle->face->size->metrics.height / 64.0f;
+
    return handle;
 
 error:
@@ -315,12 +320,15 @@ static const char *font_renderer_ft_get_default_font(void)
 #endif
 }
 
-static int font_renderer_ft_get_line_height(void* data)
+static bool font_renderer_ft_get_line_metrics(
+      void* data, struct font_line_metrics **metrics)
 {
    ft_font_renderer_t *handle = (ft_font_renderer_t*)data;
-   if (!handle || !handle->face)
-      return 0;
-   return handle->face->size->metrics.height/64;
+   if (!handle)
+      return false;
+
+   *metrics = &handle->line_metrics;
+   return true;
 }
 
 font_renderer_driver_t freetype_font_renderer = {
@@ -330,5 +338,5 @@ font_renderer_driver_t freetype_font_renderer = {
    font_renderer_ft_free,
    font_renderer_ft_get_default_font,
    "freetype",
-   font_renderer_ft_get_line_height,
+   font_renderer_ft_get_line_metrics
 };

--- a/gfx/font_driver.c
+++ b/gfx/font_driver.c
@@ -1083,16 +1083,67 @@ int font_driver_get_message_width(void *font_data,
 
 int font_driver_get_line_height(void *font_data, float scale)
 {
-   int line_height;
+   struct font_line_metrics *metrics = NULL;
    font_data_t *font = (font_data_t*)(font_data ? font_data : video_font_driver);
 
-   /* First try the line height implementation */
-   if (font && font->renderer && font->renderer->get_line_height)
-      if ((line_height = font->renderer->get_line_height(font->renderer_data)) != -1)
-         return (int)(line_height * roundf(scale));
+   /* First try the line metrics implementation */
+   if (font && font->renderer && font->renderer->get_line_metrics)
+      if ((font->renderer->get_line_metrics(font->renderer_data, &metrics)))
+         return (int)roundf(metrics->height * scale);
 
-   /* Else return an approximation (width of 'a') */
-   return font_driver_get_message_width(font_data, "a", 1, scale);
+   /* Else return an approximation
+    * (uses a fudge of standard font metrics - mostly garbage...)
+    * > font_size = (width of 'a') / 0.6
+    * > line_height = font_size * 1.7f */
+   return (int)roundf(1.7f * (float)font_driver_get_message_width(font_data, "a", 1, scale) / 0.6f);
+}
+
+int font_driver_get_line_ascender(void *font_data, float scale)
+{
+   struct font_line_metrics *metrics = NULL;
+   font_data_t *font = (font_data_t*)(font_data ? font_data : video_font_driver);
+
+   /* First try the line metrics implementation */
+   if (font && font->renderer && font->renderer->get_line_metrics)
+      if ((font->renderer->get_line_metrics(font->renderer_data, &metrics)))
+         return (int)roundf(metrics->ascender * scale);
+
+   /* Else return an approximation
+    * (uses a fudge of standard font metrics - mostly garbage...)
+    * > font_size = (width of 'a') / 0.6
+    * > ascender = 1.58 * font_size * 0.75 */
+   return (int)roundf(1.58f * 0.75f * (float)font_driver_get_message_width(font_data, "a", 1, scale) / 0.6f);
+}
+
+int font_driver_get_line_descender(void *font_data, float scale)
+{
+   struct font_line_metrics *metrics = NULL;
+   font_data_t *font = (font_data_t*)(font_data ? font_data : video_font_driver);
+
+   /* First try the line metrics implementation */
+   if (font && font->renderer && font->renderer->get_line_metrics)
+      if ((font->renderer->get_line_metrics(font->renderer_data, &metrics)))
+         return (int)roundf(metrics->descender * scale);
+
+   /* Else return an approximation
+    * (uses a fudge of standard font metrics - mostly garbage...)
+    * > font_size = (width of 'a') / 0.6
+    * > descender = 1.58 * font_size * 0.25 */
+   return (int)roundf(1.58f * 0.25f * (float)font_driver_get_message_width(font_data, "a", 1, scale) / 0.6f);
+}
+
+int font_driver_get_line_centre_offset(void *font_data, float scale)
+{
+   struct font_line_metrics *metrics = NULL;
+   font_data_t *font = (font_data_t*)(font_data ? font_data : video_font_driver);
+
+   /* First try the line metrics implementation */
+   if (font && font->renderer && font->renderer->get_line_metrics)
+      if ((font->renderer->get_line_metrics(font->renderer_data, &metrics)))
+         return (int)roundf((metrics->ascender - metrics->descender) * 0.5f * scale);
+
+   /* Else return an approximation... */
+   return (int)roundf((1.58f * 0.5f * (float)font_driver_get_message_width(font_data, "a", 1, scale) / 0.6f) / 2.0f);
 }
 
 void font_driver_free(void *font_data)

--- a/gfx/font_driver.h
+++ b/gfx/font_driver.h
@@ -81,6 +81,13 @@ struct font_params
    enum text_alignment text_align;
 };
 
+struct font_line_metrics
+{
+   float height;
+   float ascender;
+   float descender;
+};
+
 typedef struct font_renderer
 {
    void *(*init)(void *data, const char *font_path,
@@ -96,7 +103,7 @@ typedef struct font_renderer
    void (*flush)(unsigned width, unsigned height, void *data);
 
    int (*get_message_width)(void *data, const char *msg, unsigned msg_len_full, float scale);
-   int (*get_line_height)(void* data);
+   bool (*get_line_metrics)(void* data, struct font_line_metrics **metrics);
 } font_renderer_t;
 
 typedef struct font_renderer_driver
@@ -114,7 +121,7 @@ typedef struct font_renderer_driver
 
    const char *ident;
 
-   int (*get_line_height)(void* data);
+   bool (*get_line_metrics)(void* data, struct font_line_metrics **metrics);
 } font_renderer_driver_t;
 
 typedef struct
@@ -159,6 +166,9 @@ void font_driver_init_osd(
 void font_driver_free_osd(void);
 
 int font_driver_get_line_height(void *font_data, float scale);
+int font_driver_get_line_ascender(void *font_data, float scale);
+int font_driver_get_line_descender(void *font_data, float scale);
+int font_driver_get_line_centre_offset(void *font_data, float scale);
 
 extern font_renderer_t gl_raster_font;
 extern font_renderer_t gl_core_raster_font;


### PR DESCRIPTION
## Description

At present, all frontend text (excluding that in RGUI) is drawn relative to the font baseline. This is fine in principle, but there is currently no way to access any (vertical) font metrics other than line height - so the baseline is fairly meaningless. As a result. *not one single line of text in RetroArch has correct vertical alignment*. Things mostly look okay, but this is a result of hacks and magic numbers wherever text is rendered, This is not the way to do things.

The main aim of this PR is to fix this issue by providing access to font ascender/descender metrics, so text can be handled properly:

- The old font renderer `get_line_height()` function has been removed, and replaced with a `get_line_metrics()` function. This is used to fetch a struct containing line height, ascender and descender heights for the specified font.

- All font renderers/drivers have been updated with this (note that some drivers didn't have  `get_line_height()` support - I haven't touched these, because I cannot test or compile them....)

- The font driver code now has the following functions:

    - `font_driver_get_line_height(void *font_data, float scale)`: This is same as before, but the returned value is more accurate, and so too is the fallback value (when a driver doesn't support metrics)

    - `font_driver_get_line_ascender(void *font_data, float scale)`: Returns font ascender. Add this to the text y position to draw relative to the top of the font.

    - `font_driver_get_line_descender(void *font_data, float scale)`: Returns font descender. Subtract this from the text y position to draw relative to the bottom of the font.

    - `font_driver_get_line_centre_offset(void *font_data, float scale)`: Convenience function - add this to the text y position to draw relative to the vertical centre of the font.

To demonstrate this functionality, the following improvements have been made to Material UI:

- *All* text now has 'pixel perfect' vertical alignment

- Message boxes now have proper vertical layout/margins

- Entry dividers are now displayed in all thumbnail list views. These were previously excluded from the 'small' thumbnail view because it looked kinda ugly (due to uneven spacing) - but now that the entry text is properly aligned, it looks good (to my eye, at least)

The other menu drivers and widgets need a similar update - I will do this in due course.

In addition, while working on this, I fixed a number of more general font renderer issues:

- `stb`/`stb_unicode`: Use correct metric for line height (at present this is completely wrong - I can't believe no one has noticed this before!)

- `stb_unicode`: Fix horizontal character spacing (at present, characters are spaced too far apart)

- `bitmapfont`: Use correct metric for line height

**Important note:** In doing this, I had to modify every font driver and renderer. I have tested everything that can run on Linux + Android, but I can't check (or compile) the Windows, Mac and other esoteric ports. I believe the various font *drivers* are okay (it's just a simple copy/paste edit in each case), and the *renderers* seem to be fine - with the exception of `coretext`, which I cannot test at all. Hopefully this one can be tried before merging...