### PR TITLE
don't ignore errors from decompress_v5_map

### DIFF
--- a/libretro-common/formats/libchdr/libchdr_chd.c
+++ b/libretro-common/formats/libchdr/libchdr_chd.c
@@ -826,14 +826,13 @@ chd_error chd_open_file(RFILE *file, int mode, chd_file *parent, chd_file **chd)
 	if (newchd->header.version < 5)
 	{
 		err = map_read(newchd);
-		if (err != CHDERR_NONE)
-			EARLY_EXIT(err);
 	}
 	else
 	{
 		err = decompress_v5_map(newchd, &(newchd->header));
-        (void)err;
 	}
+	if (err != CHDERR_NONE)
+		EARLY_EXIT(err);
 
 #ifdef NEED_CACHE_HUNK
 	/* allocate and init the hunk cache */


### PR DESCRIPTION
## Description

Fixes a crash caused by ignoring the return value from one of the CHD library functions. The change is in the CHD library, and was previously fixed in the upstream repository. See https://github.com/libretro/RetroArch/issues/10368#issuecomment-606738255 for more detail. 

FWIW, `decompress_v5_map` was failing because `header->mapoffset` was 0. The related code has not changed in the upstream repository, so I believe the file would still be unsupported even if we did upgrade the entire library.

## Related Issues

fixes #10368

## Related Pull Requests

n/a

## Reviewers

@twinaphex 
