### PR TITLE
Put local include paths first to prevent system headers from interfering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,8 @@ ifneq ($(CXX_BUILD), 1)
    CFLAGS += -D_GNU_SOURCE
 endif
 
-DEF_FLAGS += $(INCLUDE_DIRS) -I. -Ideps -Ideps/stb
+# local includes must go first
+DEF_FLAGS := $(INCLUDE_DIRS) -I. -Ideps -Ideps/stb $(DEF_FLAGS)
 
 CFLAGS += $(DEF_FLAGS)
 CXXFLAGS += $(DEF_FLAGS) -D__STDC_CONSTANT_MACROS

--- a/Makefile.common
+++ b/Makefile.common
@@ -101,7 +101,8 @@ ifeq ($(HAVE_SHADERPIPELINE), 1)
    DEFINES += -DHAVE_SHADERPIPELINE
 endif
 
-INCLUDE_DIRS += -I$(LIBRETRO_COMM_DIR)/include -I$(DEPS_DIR)
+# local includes must go first
+INCLUDE_DIRS := -I$(LIBRETRO_COMM_DIR)/include -I$(DEPS_DIR) $(INCLUDE_DIRS)
 
 # Switches
 #


### PR DESCRIPTION
## Description

For example, a popular package 'librhash' (dependency of CMake) installs a header called 'rhash.h' which collides with a local header of the same name. A system include path provided by the user would end up in config.mk, which would be the first -I argument, and that library's header would be included instead of what we expect.

To avoid this problem, prepend local include paths instead of appending.

## Related Issues

#10056