### PR TITLE
[cheevos] report non-memorymap gba cores as unsupported

### DIFF
--- a/cheevos-new/fixup.c
+++ b/cheevos-new/fixup.c
@@ -248,6 +248,14 @@ const uint8_t* rcheevos_patch_address(unsigned address, int console)
          }
       }
    }
+   else if (console == RC_CONSOLE_GAMEBOY_ADVANCE)
+   {
+      /* The RetroAchievements implementation of memory access for GBA puts the save RAM first,
+       * so the default looping behavior below is backwards. If the core doesn't expose a
+       * memory map, say it isn't supported.
+       */
+       pointer = NULL;
+   }
    else
    {
       unsigned i;


### PR DESCRIPTION
## Description

Reports achievements as Unsupported for the gpSP core.

One of our users reported not being able to unlock achievements using the gpSP core despite them not being labelled as Unsupported.

There are two issues contributing to this. The first is that the gpSP core is exposing a 512KB block for RETRO_MEMORY_SYSTEM_RAM and another 512KB block for RETRO_MEMORY_SAVE_RAM. We expect 256KB of system ram and 32KB of save ram. The second is that the logic for mapping memory when a memory map is not provided assumes the system ram is first. The GBA implementation actually requires the save ram first. However, as the block sizes are incorrect, switching the order won't actually solve the problem.

As a result, I've added code to disable all GBA achievements if the core doesn't implement a memory map. The other four existing cores (Beetle GBA, mGBA, VBA-M and VBA Next) all expose memory maps and are unaffected by this change.

## Related Issues

Reported in #manual-unlocks channel of RetroAchievements discord server

## Related Pull Requests

n/a

## Reviewers

[If possible @mention all the people that should review your pull request]
