### PR TITLE
[cheevos] prevent null reference rendering achievement list while closing application

### DIFF
--- a/cheevos-new/cheevos.c
+++ b/cheevos-new/cheevos.c
@@ -1133,12 +1133,12 @@ void rcheevos_get_achievement_state(unsigned index, char *buffer, size_t buffer_
    if (index < rcheevos_locals.patchdata.core_count)
    {
       enum_idx = MENU_ENUM_LABEL_VALUE_CHEEVOS_LOCKED_ENTRY;
-      cheevo = &rcheevos_locals.core[index];
+      cheevo = rcheevos_locals.core ? &rcheevos_locals.core[index] : NULL;
    }
    else
    {
       enum_idx = MENU_ENUM_LABEL_VALUE_CHEEVOS_UNOFFICIAL_ENTRY;
-      cheevo = &rcheevos_locals.unofficial[index - rcheevos_locals.patchdata.core_count];
+      cheevo = rcheevos_locals.unofficial ? &rcheevos_locals.unofficial[index - rcheevos_locals.patchdata.core_count] : NULL;
    }
 
    if (!cheevo || !cheevo->trigger)


### PR DESCRIPTION
## Description

Fixes a crash that occurs if the user closes the application with the achievement list open (pressing Esc twice).

## Related Issues

#10179 - the dynamic labels cannot be generated once the achievements are unloaded, but the menu screen is still visible and rendering while the shutdown is occurring.

## Related Pull Requests

n/a

## Reviewers

[If possible @mention all the people that should review your pull request]
