### PR TITLE
Widget text improvements

### DIFF
--- a/gfx/gfx_widgets.h
+++ b/gfx/gfx_widgets.h
@@ -88,14 +88,27 @@ struct gfx_widget
    void (*frame)(void* data);
 };
 
+/* This structure holds all objects + metadata
+ * corresponding to a particular font */
+typedef struct
+{
+   font_data_t *font;
+   video_font_raster_block_t raster_block;
+   unsigned glyph_width;
+   float line_height;
+   float line_ascender;
+   float line_descender;
+   float line_centre_offset;
+   size_t usage_count;
+} gfx_widget_font_data_t;
+
 gfx_animation_ctx_tag gfx_widgets_get_generic_tag(void);
 float* gfx_widgets_get_pure_white(void);
 unsigned gfx_widgets_get_padding(void);
 unsigned gfx_widgets_get_height(void);
-unsigned gfx_widgets_get_glyph_width(void);
-float gfx_widgets_get_font_size(void);
-font_data_t* gfx_widgets_get_font_regular(void);
-font_data_t* gfx_widgets_get_font_bold(void);
+gfx_widget_font_data_t* gfx_widgets_get_font_regular(void);
+gfx_widget_font_data_t* gfx_widgets_get_font_bold(void);
+gfx_widget_font_data_t* gfx_widgets_get_font_msg_queue(void);
 float* gfx_widgets_get_backdrop_orig(void);
 unsigned gfx_widgets_get_last_video_width(void);
 unsigned gfx_widgets_get_last_video_height(void);
@@ -116,6 +129,19 @@ void gfx_widgets_draw_icon(
       unsigned width, unsigned height,
       float rotation, float scale_factor,
       float *color);
+
+void gfx_widgets_draw_text(
+      gfx_widget_font_data_t* font_data,
+      const char *text,
+      float x, float y,
+      int width, int height,
+      uint32_t color,
+      enum text_alignment text_align,
+      bool draw_outside);
+
+void gfx_widgets_flush_text(
+      unsigned video_width, unsigned video_height,
+      gfx_widget_font_data_t* font_data);
 
 typedef struct gfx_widget gfx_widget_t;
 

--- a/gfx/widgets/gfx_widget_generic_message.c
+++ b/gfx/widgets/gfx_widget_generic_message.c
@@ -88,14 +88,14 @@ static void gfx_widget_generic_message_frame(void* data)
 
    if (state->alpha > 0.0f)
    {
-      video_frame_info_t* video_info      = (video_frame_info_t*)data;
-      void* userdata                      = video_info->userdata;
-      unsigned video_width                = video_info->width;
-      unsigned video_height               = video_info->height;
+      video_frame_info_t* video_info       = (video_frame_info_t*)data;
+      void* userdata                       = video_info->userdata;
+      unsigned video_width                 = video_info->width;
+      unsigned video_height                = video_info->height;
+      unsigned height                      = gfx_widgets_get_generic_message_height();
+      unsigned text_color                  = COLOR_TEXT_ALPHA(0xffffffff, (unsigned)(state->alpha*255.0f));
+      gfx_widget_font_data_t* font_regular = gfx_widgets_get_font_regular();
 
-      unsigned height = gfx_widgets_get_generic_message_height();
-
-      unsigned text_color = COLOR_TEXT_ALPHA(0xffffffff, (unsigned)(state->alpha*255.0f));
       gfx_display_set_alpha(gfx_widgets_get_backdrop_orig(), state->alpha);
 
       gfx_display_draw_quad(userdata,
@@ -105,12 +105,12 @@ static void gfx_widget_generic_message_frame(void* data)
             video_width, video_height,
             gfx_widgets_get_backdrop_orig());
 
-      gfx_display_draw_text(gfx_widgets_get_font_regular(), state->message,
-         video_width/2,
-         video_height - height/2 + gfx_widgets_get_font_size()/4,
-         video_width, video_height,
-         text_color, TEXT_ALIGN_CENTER,
-         1, false, 0, false);
+      gfx_widgets_draw_text(font_regular, state->message,
+            video_width/2,
+            video_height - height/2.0f + font_regular->line_centre_offset,
+            video_width, video_height,
+            text_color, TEXT_ALIGN_CENTER,
+            false);
    }
 }
 

--- a/gfx/widgets/gfx_widget_libretro_message.c
+++ b/gfx/widgets/gfx_widget_libretro_message.c
@@ -64,8 +64,9 @@ static void gfx_widget_libretro_message_fadeout(void *userdata)
 void gfx_widget_set_libretro_message(const char *msg, unsigned duration)
 {
    gfx_widget_libretro_message_state_t* state = gfx_widget_libretro_message_get_state();
+   gfx_animation_ctx_tag tag                  = (uintptr_t) &state->timer;
+   gfx_widget_font_data_t* font_regular       = gfx_widgets_get_font_regular();
    gfx_timer_ctx_entry_t timer;
-   gfx_animation_ctx_tag tag = (uintptr_t) &state->timer;
 
    if (!gfx_widgets_active())
       return;
@@ -85,7 +86,7 @@ void gfx_widget_set_libretro_message(const char *msg, unsigned duration)
    gfx_timer_start(&state->timer, &timer);
 
    /* Compute text width */
-   state->width = font_driver_get_message_width(gfx_widgets_get_font_regular(), msg, (unsigned)strlen(msg), 1) + gfx_widgets_get_padding() * 2;
+   state->width = font_driver_get_message_width(font_regular->font, msg, (unsigned)strlen(msg), 1) + gfx_widgets_get_padding() * 2;
 }
 
 static void gfx_widget_libretro_message_frame(void *data)
@@ -94,15 +95,14 @@ static void gfx_widget_libretro_message_frame(void *data)
 
    if (state->alpha > 0.0f)
    {
-      video_frame_info_t* video_info  = (video_frame_info_t*)data;
-      void* userdata                  = video_info->userdata;
-      unsigned video_width            = video_info->width;
-      unsigned video_height           = video_info->height;
-
-      unsigned height = gfx_widgets_get_generic_message_height();
-
-      float* backdrop_orign   = gfx_widgets_get_backdrop_orig();
-      unsigned text_color     = COLOR_TEXT_ALPHA(0xffffffff, (unsigned)(state->alpha*255.0f));
+      video_frame_info_t* video_info       = (video_frame_info_t*)data;
+      void* userdata                       = video_info->userdata;
+      unsigned video_width                 = video_info->width;
+      unsigned video_height                = video_info->height;
+      unsigned height                      = gfx_widgets_get_generic_message_height();
+      float* backdrop_orign                = gfx_widgets_get_backdrop_orig();
+      unsigned text_color                  = COLOR_TEXT_ALPHA(0xffffffff, (unsigned)(state->alpha*255.0f));
+      gfx_widget_font_data_t* font_regular = gfx_widgets_get_font_regular();
 
       gfx_display_set_alpha(backdrop_orign, state->alpha);
 
@@ -113,12 +113,12 @@ static void gfx_widget_libretro_message_frame(void *data)
             video_width, video_height,
             backdrop_orign);
 
-      gfx_display_draw_text(gfx_widgets_get_font_regular(), state->message,
-         gfx_widgets_get_padding(),
-         video_height - height/2 + gfx_widgets_get_font_size()/4,
-         video_width, video_height,
-         text_color, TEXT_ALIGN_LEFT,
-         1, false, 0, false);
+      gfx_widgets_draw_text(font_regular, state->message,
+            gfx_widgets_get_padding(),
+            video_height - height/2 + font_regular->line_centre_offset,
+            video_width, video_height,
+            text_color, TEXT_ALIGN_LEFT,
+            false);
    }
 }
 

--- a/gfx/widgets/gfx_widget_screenshot.c
+++ b/gfx/widgets/gfx_widget_screenshot.c
@@ -150,19 +150,14 @@ static void gfx_widget_screenshot_free(void)
 
 static void gfx_widget_screenshot_frame(void* data)
 {
-   video_frame_info_t *video_info = (video_frame_info_t*)data;
-   void *userdata                 = video_info->userdata;
-   unsigned video_width           = video_info->width;
-   unsigned video_height          = video_info->height;
-
-   unsigned padding  = gfx_widgets_get_padding();
-   float font_size   = gfx_widgets_get_font_size();
-
-   font_data_t* font_regular = gfx_widgets_get_font_regular();
-
-   float* pure_white = gfx_widgets_get_pure_white();
-
+   video_frame_info_t *video_info       = (video_frame_info_t*)data;
+   void *userdata                       = video_info->userdata;
+   unsigned video_width                 = video_info->width;
+   unsigned video_height                = video_info->height;
+   gfx_widget_font_data_t* font_regular = gfx_widgets_get_font_regular();
+   float* pure_white                    = gfx_widgets_get_pure_white();
    gfx_widget_screenshot_state_t* state = gfx_widget_screenshot_get_ptr();
+   int padding                          = (state->height - (font_regular->line_height * 2.0f)) / 2.0f;
 
    /* Screenshot */
    if (state->loaded)
@@ -193,14 +188,14 @@ static void gfx_widget_screenshot_frame(void* data)
          0, 1, pure_white
       );
 
-      gfx_display_draw_text(font_regular,
-         msg_hash_to_str(MSG_SCREENSHOT_SAVED),
-         state->thumbnail_width + padding, font_size * 1.9f + state->y,
-         video_width, video_height,
-         TEXT_COLOR_FAINT,
-         TEXT_ALIGN_LEFT,
-         1, false, 0, true
-      );
+      gfx_widgets_draw_text(font_regular,
+            msg_hash_to_str(MSG_SCREENSHOT_SAVED),
+            state->thumbnail_width + padding,
+            padding + font_regular->line_ascender + state->y,
+            video_width, video_height,
+            TEXT_COLOR_FAINT,
+            TEXT_ALIGN_LEFT,
+            true);
 
       ticker.idx        = gfx_animation_get_ticker_idx();
       ticker.len        = state->shotname_length;
@@ -210,14 +205,14 @@ static void gfx_widget_screenshot_frame(void* data)
 
       gfx_animation_ticker(&ticker);
 
-      gfx_display_draw_text(font_regular,
-         shotname,
-         state->thumbnail_width + padding, font_size * 2.9f + state->y,
-         video_width, video_height,
-         TEXT_COLOR_INFO,
-         TEXT_ALIGN_LEFT,
-         1, false, 0, true
-      );
+      gfx_widgets_draw_text(font_regular,
+            shotname,
+            state->thumbnail_width + padding,
+            state->height - padding - font_regular->line_descender + state->y,
+            video_width, video_height,
+            TEXT_COLOR_INFO,
+            TEXT_ALIGN_LEFT,
+            true);
    }
 
    /* Flash effect */
@@ -240,10 +235,8 @@ static void gfx_widget_screenshot_iterate(unsigned width, unsigned height, bool 
       bool is_threaded)
 {
    gfx_widget_screenshot_state_t* state = gfx_widget_screenshot_get_ptr();
-
-   float font_size      = gfx_widgets_get_font_size();
-   unsigned padding     = gfx_widgets_get_padding();
-   unsigned glyph_width = gfx_widgets_get_glyph_width();
+   unsigned padding                     = gfx_widgets_get_padding();
+   gfx_widget_font_data_t* font_regular = gfx_widgets_get_font_regular();
 
    /* Load screenshot and start its animation */
    if (state->filename[0] != '\0')
@@ -258,7 +251,7 @@ static void gfx_widget_screenshot_iterate(unsigned width, unsigned height, bool 
             "", &state->texture, TEXTURE_FILTER_MIPMAP_LINEAR,
             &state->texture_width, &state->texture_height);
 
-      state->height = font_size * 4;
+      state->height = font_regular->line_height * 4;
       state->width  = width;
 
       state->scale_factor = gfx_widgets_get_thumbnail_scale_factor(
@@ -269,7 +262,7 @@ static void gfx_widget_screenshot_iterate(unsigned width, unsigned height, bool 
       state->thumbnail_width  = state->texture_width * state->scale_factor;
       state->thumbnail_height = state->texture_height * state->scale_factor;
 
-      state->shotname_length  = (width - state->thumbnail_width - padding*2) / glyph_width;
+      state->shotname_length  = (width - state->thumbnail_width - padding*2) / font_regular->glyph_width;
 
       state->y = 0.0f;
 


### PR DESCRIPTION
## Description

This PR makes the following improvements to widget text rendering:

- The font ascender/descender metrics added in #10375 are now used to achieve 'pixel perfect' vertical text alignment

- Message queue text now uses its own dedicated font. Previously, a single (larger) font was used for all active widgets, and this was scaled down for message queue items. This 'squished' the text a little; more importantly, when using the `stb` font renderers (on Android. etc.) it caused ugly artefacts around the edges of glyphs due to pixel interpolation errors. Now that a correctly sized font is used, the message queue is always rendered cleanly.

- Previously, each widget font was 'flushed' (`font_driver_flush()`) at least once a frame. This is quite a slow operation. Now we only flush fonts if they have actually been used.
