### PR TITLE
Fix task deadlocks

### DIFF
--- a/libretro-common/queues/task_queue.c
+++ b/libretro-common/queues/task_queue.c
@@ -313,6 +313,7 @@ static scond_t *worker_cond     = NULL;
 static sthread_t *worker_thread = NULL;
 static bool worker_continue     = true; /* use running_lock when touching it */
 
+/* 'queue_lock' must be held for the duration of this function */
 static void task_queue_remove(task_queue_t *queue, retro_task_t *task)
 {
    retro_task_t     *t = NULL;


### PR DESCRIPTION
## Description

PR #10399 broke the task system by introducing a deadlock in `threaded_worker()`. This PR fixes the issue.

## Related Issues

This closes #10409