### PR TITLE
Fix the single breaking change from libnx 3.1.0

### DIFF
--- a/audio/drivers/switch_audio.c
+++ b/audio/drivers/switch_audio.c
@@ -106,7 +106,7 @@ static ssize_t switch_audio_write(void *data, const void *buf, size_t size)
             num                 = 0;
 
 #ifdef HAVE_LIBNX
-            if (audoutWaitPlayFinish(&swa->current_buffer, &num, U64_MAX) != 0) { }
+            if (audoutWaitPlayFinish(&swa->current_buffer, &num, UINT64_MAX) != 0) { }
 #else
             svcWaitSynchronization(&handle_idx, &swa->event, 1, 33333333);
             svcResetSignal(swa->event);

--- a/audio/drivers/switch_audio_compat.h
+++ b/audio/drivers/switch_audio_compat.h
@@ -46,6 +46,10 @@ typedef AudioOutBuffer compat_audio_out_buffer;
 #define switch_audio_ipc_output_stop(a) audoutStopAudioOut()
 #define switch_audio_ipc_output_start(a) audoutStartAudioOut()
 
+#ifndef UINT64_MAX
+#define UINT64_MAX U64_MAX
+#endif
+
 #else
 
 /* libtransistor definitions */

--- a/audio/drivers/switch_thread_audio.c
+++ b/audio/drivers/switch_thread_audio.c
@@ -86,7 +86,7 @@ static void mainLoop(void* data)
       if (!released_out_buffer)
       {
 #ifdef HAVE_LIBNX
-         rc = audoutWaitPlayFinish(&released_out_buffer, &released_out_count, U64_MAX);
+         rc = audoutWaitPlayFinish(&released_out_buffer, &released_out_count, UINT64_MAX);
 #else
          uint32_t handle_idx = 0;
          svcWaitSynchronization(&handle_idx, &swa->event, 1, 33333333);


### PR DESCRIPTION
## Description

Comparing to previous updates the only breaking change impacting the RA codebase was the constant U64_MAX being renamed to UINT64_MAX.

I've already done a fresh build of RA + a core and there seems to be no issues.

## Reviewers

@m4xw 

**DO NOT MERGE UNTIL THE LIBNX IS UPDATED ON THE BUILDBOT BUILDERS**