### PR TITLE
Improve handling of 'broken' playlists

### DIFF
--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -1211,9 +1211,13 @@ static bool menu_content_playlist_load(playlist_t *playlist, size_t idx)
    char path[PATH_MAX_LENGTH];
    const struct playlist_entry *entry = NULL;
 
+   path[0] = '\0';
+
    playlist_get_index(playlist, idx, &entry);
 
-   path[0] = '\0';
+   if (!entry || string_is_empty(entry->path))
+      return false;
+
    strlcpy(path, entry->path, sizeof(path));
    playlist_resolve_path(PLAYLIST_LOAD, path, sizeof(path));
 
@@ -2074,9 +2078,13 @@ static int action_ok_playlist_entry_collection(const char *path,
       return 1;
    }
 
-   /* Is the core path / name of the playlist entry not yet filled in? */
-   if (     string_is_equal(entry->core_path, "DETECT")
-         && string_is_equal(entry->core_name, "DETECT"))
+   /* Check whether playlist already has core path/name
+    * assignments
+    * > Both core name and core path must be valid */
+   if (     string_is_empty(entry->core_path)
+         || string_is_empty(entry->core_name)
+         || string_is_equal(entry->core_path, "DETECT")
+         || string_is_equal(entry->core_name, "DETECT"))
    {
       core_info_ctx_find_t core_info;
       const char *entry_path                 = NULL;
@@ -2127,7 +2135,7 @@ static int action_ok_playlist_entry_collection(const char *path,
    else
    {
       strlcpy(new_core_path, entry->core_path, sizeof(new_core_path));
-       playlist_resolve_path(PLAYLIST_LOAD, new_core_path, sizeof(new_core_path));
+      playlist_resolve_path(PLAYLIST_LOAD, new_core_path, sizeof(new_core_path));
    }
 
    if (!playlist || !menu_content_playlist_load(playlist, selection_ptr))
@@ -2172,8 +2180,13 @@ static int action_ok_playlist_entry(const char *path,
 
    entry_label = entry->label;
 
-   if (     string_is_equal(entry->core_path, "DETECT")
-         && string_is_equal(entry->core_name, "DETECT"))
+   /* Check whether playlist already has core path/name
+    * assignments
+    * > Both core name and core path must be valid */
+   if (     string_is_empty(entry->core_path)
+         || string_is_empty(entry->core_name)
+         || string_is_equal(entry->core_path, "DETECT")
+         || string_is_equal(entry->core_name, "DETECT"))
    {
       core_info_ctx_find_t core_info;
       const char *default_core_path          =
@@ -2212,7 +2225,7 @@ static int action_ok_playlist_entry(const char *path,
       }
 
    }
-   else if (!string_is_empty(entry->core_path))
+   else
    {
       strlcpy(new_core_path, entry->core_path, sizeof(new_core_path));
       playlist_resolve_path(PLAYLIST_LOAD, new_core_path, sizeof(new_core_path));
@@ -2251,8 +2264,13 @@ static int action_ok_playlist_entry_start_content(const char *path,
 
    playlist_get_index(playlist, selection_ptr, &entry);
 
-   if (     string_is_equal(entry->core_path, "DETECT")
-         && string_is_equal(entry->core_name, "DETECT"))
+   /* Check whether playlist already has core path/name
+    * assignments
+    * > Both core name and core path must be valid */
+   if (     string_is_empty(entry->core_path)
+         || string_is_empty(entry->core_name)
+         || string_is_equal(entry->core_path, "DETECT")
+         || string_is_equal(entry->core_name, "DETECT"))
    {
       core_info_ctx_find_t core_info;
       char new_core_path[PATH_MAX_LENGTH];

--- a/menu/cbs/menu_cbs_right.c
+++ b/menu/cbs/menu_cbs_right.c
@@ -475,7 +475,8 @@ static int action_right_video_resolution(unsigned type, const char *label,
 
 static int playlist_association_right(unsigned type, const char *label,
       bool wraparound)
-{ char core_path[PATH_MAX_LENGTH];
+{
+   char core_path[PATH_MAX_LENGTH];
    size_t i, next, current          = 0;
    core_info_list_t *core_info_list = NULL;
    core_info_t *core_info           = NULL;

--- a/menu/cbs/menu_cbs_sublabel.c
+++ b/menu/cbs/menu_cbs_sublabel.c
@@ -1103,9 +1103,12 @@ static int action_bind_sublabel_playlist_entry(
    /* Read playlist entry */
    playlist_get_index(playlist, i, &entry);
 
-   /* Only add sublabel if a core is currently assigned */
+   /* Only add sublabel if a core is currently assigned
+    * > Both core name and core path must be valid */
    if (  string_is_empty(entry->core_name) || 
-         string_is_equal(entry->core_name, "DETECT"))
+         string_is_equal(entry->core_name, "DETECT") ||
+         string_is_empty(entry->core_path) ||
+         string_is_equal(entry->core_path, "DETECT"))
       return 0;
 
    /* Add core name */

--- a/playlist.c
+++ b/playlist.c
@@ -2450,36 +2450,38 @@ static int playlist_qsort_func(const struct playlist_entry *a,
     * have no other option...) */
    if (string_is_empty(a_str))
    {
-      if (string_is_empty(a->path))
-         goto end;
-
       a_fallback_label = (char*)calloc(PATH_MAX_LENGTH, sizeof(char));
 
       if (!a_fallback_label)
          goto end;
 
-      fill_short_pathname_representation(a_fallback_label, a->path, PATH_MAX_LENGTH * sizeof(char));
+      if (!string_is_empty(a->path))
+         fill_short_pathname_representation(a_fallback_label, a->path, PATH_MAX_LENGTH * sizeof(char));
+      /* If filename is also empty, use core name
+       * instead -> this matches the behaviour of
+       * menu_displaylist_parse_playlist() */
+      else if (!string_is_empty(a->core_name))
+         strlcpy(a_fallback_label, a->core_name, PATH_MAX_LENGTH * sizeof(char));
 
-      if (string_is_empty(a_fallback_label))
-         goto end;
+      /* If both filename and core name are empty,
+       * then have to compare an empty string
+       * -> again, this is to match the behaviour of
+       * menu_displaylist_parse_playlist() */
 
       a_str = a_fallback_label;
    }
 
    if (string_is_empty(b_str))
    {
-      if (string_is_empty(b->path))
-         goto end;
-
       b_fallback_label = (char*)calloc(PATH_MAX_LENGTH, sizeof(char));
 
       if (!b_fallback_label)
          goto end;
 
-      fill_short_pathname_representation(b_fallback_label, b->path, PATH_MAX_LENGTH * sizeof(char));
-
-      if (string_is_empty(b_fallback_label))
-         goto end;
+      if (!string_is_empty(b->path))
+         fill_short_pathname_representation(b_fallback_label, b->path, PATH_MAX_LENGTH * sizeof(char));
+      else if (!string_is_empty(b->core_name))
+         strlcpy(b_fallback_label, b->core_name, PATH_MAX_LENGTH * sizeof(char));
 
       b_str = b_fallback_label;
    }

--- a/runtime_file.c
+++ b/runtime_file.c
@@ -298,14 +298,15 @@ runtime_log_t *runtime_log_init(
       return NULL;
    }
 
+   if (  string_is_empty(core_path) ||
+         string_is_equal(core_path, "builtin") ||
+         string_is_equal(core_path, "DETECT"))
+      return NULL;
+
    core_path_basename = path_basename(core_path);
    
    if (  string_is_empty(content_path) || 
          string_is_empty(core_path_basename))
-      return NULL;
-   
-   if (  string_is_equal(core_path, "builtin") || 
-         string_is_equal(core_path, "DETECT"))
       return NULL;
    
    /* Get core name


### PR DESCRIPTION
## Description

As highlighted in #10379, RetroArch currently falls apart when handling 'broken' playlists - i.e. when playlist entries have missing or invalid `path`/`core path`/`core name` fields. This PR should fix the most significant issues:

- RetroArch will no longer segfault when attempting to run content via a playlist entry with missing `path` or `core path` fields.

- When a playlist entry has either `core path` and/or `core name` set to `NULL`, `DETECT` or an empty string, attempting to load content will fallback to the normal 'core selection' code (currently this happens only if both `core path` and `core name` are `DETECT` - this is wholly inadequate!)

- RetroArch will no longer segfault when attempting to fetch content runtime information when `core path` is `NULL`

- Core name + runtime info will only be displayed on playlists and in the `Information` submenu if both the `core path` and `core name` fields are 'valid' (i.e. not `NULL` or `DETECT`)

- When handling entries with missing `path` fields, the menu sorting order now matches that of the playlist sorting order (at present, everything goes out of sync when `path`s are empty). Moreover, entries with missing `path` fields can now be 'selected', so users can remove them (currently, hitting A on such an entry immediately tries - and fails - to load the content, so the only way to remove the broken entry is via the `Playlist Management > Clean Playlist` feature)

## Related Issues

This closes #10379 

(The issue can be reopened if there are any remaining edge cases...)