### PR TITLE
(Ozone) Enable proper vertical text alignment + thumbnail display improvements

### DIFF
--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -56,6 +56,7 @@ ozone_node_t *ozone_alloc_node(void)
    node->icon           = 0;
    node->content_icon   = 0;
    node->fullpath       = NULL;
+   node->sublabel_lines = 0;
 
    return node;
 }
@@ -354,12 +355,12 @@ static void ozone_free(void *data)
 
    if (ozone)
    {
-      video_coord_array_free(&ozone->raster_blocks.footer.carr);
-      video_coord_array_free(&ozone->raster_blocks.title.carr);
-      video_coord_array_free(&ozone->raster_blocks.time.carr);
-      video_coord_array_free(&ozone->raster_blocks.entries_label.carr);
-      video_coord_array_free(&ozone->raster_blocks.entries_sublabel.carr);
-      video_coord_array_free(&ozone->raster_blocks.sidebar.carr);
+      video_coord_array_free(&ozone->fonts.footer.raster_block.carr);
+      video_coord_array_free(&ozone->fonts.title.raster_block.carr);
+      video_coord_array_free(&ozone->fonts.time.raster_block.carr);
+      video_coord_array_free(&ozone->fonts.entries_label.raster_block.carr);
+      video_coord_array_free(&ozone->fonts.entries_sublabel.raster_block.carr);
+      video_coord_array_free(&ozone->fonts.sidebar.raster_block.carr);
 
       font_driver_bind_block(NULL, NULL);
 
@@ -468,11 +469,45 @@ static void ozone_refresh_thumbnail_image(void *data, unsigned i)
       ozone_update_thumbnail_image(ozone);
 }
 
+static bool ozone_init_font(
+      ozone_font_data_t *font_data,
+      bool is_threaded, char *font_path, float font_size)
+{
+   int glyph_width = 0;
+
+   /* Free existing */
+   if (font_data->font)
+   {
+      gfx_display_font_free(font_data->font);
+      font_data->font = NULL;
+   }
+
+   /* Cache approximate dimensions */
+   font_data->line_height = (int)(font_size + 0.5f);
+   font_data->glyph_width = (int)((font_size * (3.0f / 4.0f)) + 0.5f);
+
+   /* Create font */
+   font_data->font = gfx_display_font_file(font_path, font_size, is_threaded);
+
+   if (!font_data->font)
+      return false;
+
+   /* Get font metadata */
+   glyph_width = font_driver_get_message_width(font_data->font, "a", 1, 1.0f);
+   if (glyph_width > 0)
+      font_data->glyph_width     = glyph_width;
+   font_data->line_height        = font_driver_get_line_height(font_data->font, 1.0f);
+   font_data->line_ascender      = font_driver_get_line_ascender(font_data->font, 1.0f);
+   font_data->line_centre_offset = font_driver_get_line_centre_offset(font_data->font, 1.0f);
+
+   return true;
+}
+
 /* Determines the size of all menu elements */
 static void ozone_set_layout(ozone_handle_t *ozone, bool is_threaded)
 {
-   int font_size;
    float scale_factor;
+   bool font_inited;
    char font_path[PATH_MAX_LENGTH];
 
    font_path[0] = '\0';
@@ -531,115 +566,33 @@ static void ozone_set_layout(ozone_handle_t *ozone, bool is_threaded)
    ozone->pointer_active_delta = CURSOR_ACTIVE_DELTA * scale_factor;
 
    /* Initialise fonts */
-
-   /* > Free existing */
-   if (ozone->fonts.footer)
-   {
-      gfx_display_font_free(ozone->fonts.footer);
-      ozone->fonts.footer = NULL;
-   }
-   if (ozone->fonts.entries_label)
-   {
-      gfx_display_font_free(ozone->fonts.entries_label);
-      ozone->fonts.entries_label = NULL;
-   }
-   if (ozone->fonts.entries_sublabel)
-   {
-      gfx_display_font_free(ozone->fonts.entries_sublabel);
-      ozone->fonts.entries_sublabel = NULL;
-   }
-   if (ozone->fonts.time)
-   {
-      gfx_display_font_free(ozone->fonts.time);
-      ozone->fonts.time = NULL;
-   }
-   if (ozone->fonts.sidebar)
-   {
-      gfx_display_font_free(ozone->fonts.sidebar);
-      ozone->fonts.sidebar = NULL;
-   }
-   if (ozone->fonts.title)
-   {
-      gfx_display_font_free(ozone->fonts.title);
-      ozone->fonts.title = NULL;
-   }
-
-   /* > Cache 'naive' font heights */
-   ozone->title_font_glyph_height    = FONT_SIZE_TITLE * scale_factor;
-   ozone->entry_font_glyph_height    = FONT_SIZE_ENTRIES_LABEL * scale_factor;
-   ozone->sublabel_font_glyph_height = FONT_SIZE_ENTRIES_SUBLABEL * scale_factor;
-   ozone->footer_font_glyph_height   = FONT_SIZE_FOOTER * scale_factor;
-   ozone->sidebar_font_glyph_height  = FONT_SIZE_SIDEBAR * scale_factor;
-   ozone->time_font_glyph_height     = FONT_SIZE_TIME * scale_factor;
-
-   /* > Create 'bold' font objects */
    fill_pathname_join(font_path, ozone->assets_path, "bold.ttf", sizeof(font_path));
-   ozone->fonts.title = gfx_display_font_file(font_path, ozone->title_font_glyph_height, is_threaded);
 
-   /* > Create 'regular' font objects */
+   font_inited = ozone_init_font(&ozone->fonts.title,
+         is_threaded, font_path, FONT_SIZE_TITLE * scale_factor);
+   ozone->has_all_assets = ozone->has_all_assets && font_inited;
+
    fill_pathname_join(font_path, ozone->assets_path, "regular.ttf", sizeof(font_path));
-   ozone->fonts.entries_label    = gfx_display_font_file(font_path, ozone->entry_font_glyph_height, is_threaded);
-   ozone->fonts.entries_sublabel = gfx_display_font_file(font_path, ozone->sublabel_font_glyph_height, is_threaded);
-   ozone->fonts.footer           = gfx_display_font_file(font_path, ozone->footer_font_glyph_height, is_threaded);
-   ozone->fonts.sidebar          = gfx_display_font_file(font_path, ozone->sidebar_font_glyph_height, is_threaded);
-   ozone->fonts.time             = gfx_display_font_file(font_path, ozone->time_font_glyph_height, is_threaded);
 
-   /* > Check for missing assets */
-      if (!ozone->fonts.title            ||
-          !ozone->fonts.entries_label    ||
-          !ozone->fonts.entries_sublabel ||
-          !ozone->fonts.footer           ||
-          !ozone->fonts.sidebar          ||
-          !ozone->fonts.time)
-         ozone->has_all_assets = false;
+   font_inited = ozone_init_font(&ozone->fonts.footer,
+         is_threaded, font_path, FONT_SIZE_FOOTER * scale_factor);
+   ozone->has_all_assets = ozone->has_all_assets && font_inited;
 
-   /* > Cache 'naive' font widths */
-   ozone->title_font_glyph_width    = ozone->title_font_glyph_height * 3.0f/4.0f;
-   ozone->entry_font_glyph_width    = ozone->entry_font_glyph_height * 3.0f/4.0f;
-   ozone->sublabel_font_glyph_width = ozone->sublabel_font_glyph_height * 3.0f/4.0f;
-   ozone->footer_font_glyph_width   = ozone->footer_font_glyph_height * 3.0f/4.0f;
-   ozone->sidebar_font_glyph_width  = ozone->sidebar_font_glyph_height * 3.0f/4.0f;
-   ozone->time_font_glyph_width     = ozone->time_font_glyph_height * 3.0f/4.0f;
+   font_inited = ozone_init_font(&ozone->fonts.time,
+         is_threaded, font_path, FONT_SIZE_TIME * scale_factor);
+   ozone->has_all_assets = ozone->has_all_assets && font_inited;
 
-   /* > Determine more realistic font widths */
-   font_size = font_driver_get_message_width(ozone->fonts.title, "a", 1, 1);
-   if (font_size > 0)
-      ozone->title_font_glyph_width = (unsigned)font_size;
-   font_size = font_driver_get_message_width(ozone->fonts.entries_label, "a", 1, 1);
-   if (font_size > 0)
-      ozone->entry_font_glyph_width = (unsigned)font_size;
-   font_size = font_driver_get_message_width(ozone->fonts.entries_sublabel, "a", 1, 1);
-   if (font_size > 0)
-      ozone->sublabel_font_glyph_width = (unsigned)font_size;
-   font_size = font_driver_get_message_width(ozone->fonts.footer, "a", 1, 1);
-   if (font_size > 0)
-      ozone->footer_font_glyph_width = (unsigned)font_size;
-   font_size = font_driver_get_message_width(ozone->fonts.sidebar, "a", 1, 1);
-   if (font_size > 0)
-      ozone->sidebar_font_glyph_width = (unsigned)font_size;
-   font_size = font_driver_get_message_width(ozone->fonts.time, "a", 1, 1);
-   if (font_size > 0)
-      ozone->time_font_glyph_width = (unsigned)font_size;
+   font_inited = ozone_init_font(&ozone->fonts.entries_label,
+         is_threaded, font_path, FONT_SIZE_ENTRIES_LABEL * scale_factor);
+   ozone->has_all_assets = ozone->has_all_assets && font_inited;
 
-   /* > Get actual font heights */
-   font_size = font_driver_get_line_height(ozone->fonts.title, 1.0f);
-   if (font_size > 0)
-      ozone->title_font_glyph_height = (unsigned)font_size;
-   font_size = font_driver_get_line_height(ozone->fonts.entries_label, 1.0f);
-   if (font_size > 0)
-      ozone->entry_font_glyph_height = (unsigned)font_size;
-   font_size = font_driver_get_line_height(ozone->fonts.entries_sublabel, 1.0f);
-   if (font_size > 0)
-      ozone->sublabel_font_glyph_height = (unsigned)font_size;
-   font_size = font_driver_get_line_height(ozone->fonts.footer, 1.0f);
-   if (font_size > 0)
-      ozone->footer_font_glyph_height = (unsigned)font_size;
-   font_size = font_driver_get_line_height(ozone->fonts.sidebar, 1.0f);
-   if (font_size > 0)
-      ozone->sidebar_font_glyph_height = (unsigned)font_size;
-   font_size = font_driver_get_line_height(ozone->fonts.time, 1.0f);
-   if (font_size > 0)
-      ozone->time_font_glyph_height = (unsigned)font_size;
+   font_inited = ozone_init_font(&ozone->fonts.entries_sublabel,
+         is_threaded, font_path, FONT_SIZE_ENTRIES_SUBLABEL * scale_factor);
+   ozone->has_all_assets = ozone->has_all_assets && font_inited;
+
+   font_inited = ozone_init_font(&ozone->fonts.sidebar,
+         is_threaded, font_path, FONT_SIZE_SIDEBAR * scale_factor);
+   ozone->has_all_assets = ozone->has_all_assets && font_inited;
 
    /* Multiple sidebar parameters are set via animations
     * > ozone_refresh_sidebars() cancels any existing
@@ -783,6 +736,14 @@ static void ozone_unload_thumbnail_textures(void *data)
    gfx_thumbnail_reset(&ozone->thumbnails.left);
 }
 
+static void INLINE ozone_font_free(ozone_font_data_t *font_data)
+{
+   if (font_data->font)
+      gfx_display_font_free(font_data->font);
+
+   font_data->font = NULL;
+}
+
 static void ozone_context_destroy(void *data)
 {
    unsigned i;
@@ -812,19 +773,13 @@ static void ozone_context_destroy(void *data)
 
    video_driver_texture_unload(&gfx_display_white_texture);
 
-   gfx_display_font_free(ozone->fonts.footer);
-   gfx_display_font_free(ozone->fonts.title);
-   gfx_display_font_free(ozone->fonts.time);
-   gfx_display_font_free(ozone->fonts.entries_label);
-   gfx_display_font_free(ozone->fonts.entries_sublabel);
-   gfx_display_font_free(ozone->fonts.sidebar);
-
-   ozone->fonts.footer = NULL;
-   ozone->fonts.title = NULL;
-   ozone->fonts.time = NULL;
-   ozone->fonts.entries_label = NULL;
-   ozone->fonts.entries_sublabel = NULL;
-   ozone->fonts.sidebar = NULL;
+   /* Fonts */
+   ozone_font_free(&ozone->fonts.footer);
+   ozone_font_free(&ozone->fonts.title);
+   ozone_font_free(&ozone->fonts.time);
+   ozone_font_free(&ozone->fonts.entries_label);
+   ozone_font_free(&ozone->fonts.entries_sublabel);
+   ozone_font_free(&ozone->fonts.sidebar);
 
    tag = (uintptr_t) &ozone_default_theme;
    gfx_animation_kill_by_tag(&tag);
@@ -1530,7 +1485,7 @@ static void ozone_draw_header(ozone_handle_t *ozone,
    /* Title */
    if (use_smooth_ticker)
    {
-      ticker_smooth.font        = ozone->fonts.title;
+      ticker_smooth.font        = ozone->fonts.title.font;
       ticker_smooth.selected    = true;
       ticker_smooth.field_width = (video_width - (128 + 47 + 180) * scale_factor);
       ticker_smooth.src_str     = ozone->show_fullscreen_thumbnails ? ozone->fullscreen_thumbnail_label : ozone->title;
@@ -1542,14 +1497,17 @@ static void ozone_draw_header(ozone_handle_t *ozone,
    else
    {
       ticker.s        = title;
-      ticker.len      = (video_width - (128 + 47 + 180) * scale_factor) / ozone->title_font_glyph_width;
+      ticker.len      = (video_width - (128 + 47 + 180) * scale_factor) / ozone->fonts.title.glyph_width;
       ticker.str      = ozone->show_fullscreen_thumbnails ? ozone->fullscreen_thumbnail_label : ozone->title;
       ticker.selected = true;
 
       gfx_animation_ticker(&ticker);
    }
 
-   ozone_draw_text(ozone, title, ticker_x_offset + 128 * scale_factor, ozone->dimensions.header_height / 2 + ozone->title_font_glyph_height * 3.0f/10.0f, TEXT_ALIGN_LEFT, video_width, video_height, ozone->fonts.title, ozone->theme->text_rgba, false);
+   ozone_draw_text(ozone, title,
+         ticker_x_offset + 128 * scale_factor,
+         ozone->dimensions.header_height / 2 + ozone->fonts.title.line_centre_offset,
+         TEXT_ALIGN_LEFT, video_width, video_height, &ozone->fonts.title, ozone->theme->text_rgba, false);
 
    /* Icon */
    gfx_display_blend_begin(userdata);
@@ -1600,7 +1558,10 @@ static void ozone_draw_header(ozone_handle_t *ozone,
       {
          timedate_offset = 95 * scale_factor;
 
-         ozone_draw_text(ozone, msg, video_width - 85 * scale_factor, ozone->dimensions.header_height / 2 + ozone->time_font_glyph_height * 3.0f/10.0f, TEXT_ALIGN_RIGHT, video_width, video_height, ozone->fonts.time, ozone->theme->text_rgba, false);
+         ozone_draw_text(ozone, msg,
+               video_width - 85 * scale_factor,
+               ozone->dimensions.header_height / 2 + ozone->fonts.time.line_centre_offset,
+               TEXT_ALIGN_RIGHT, video_width, video_height, &ozone->fonts.time, ozone->theme->text_rgba, false);
 
          gfx_display_blend_begin(userdata);
          ozone_draw_icon(
@@ -1633,7 +1594,10 @@ static void ozone_draw_header(ozone_handle_t *ozone,
 
       menu_display_timedate(&datetime);
 
-      ozone_draw_text(ozone, timedate, video_width - (85 * scale_factor) - timedate_offset, ozone->dimensions.header_height / 2 + ozone->time_font_glyph_height * 3.0f/10.0f, TEXT_ALIGN_RIGHT, video_width, video_height, ozone->fonts.time, ozone->theme->text_rgba, false);
+      ozone_draw_text(ozone, timedate,
+            video_width - (85 * scale_factor) - timedate_offset,
+            ozone->dimensions.header_height / 2 + ozone->fonts.time.line_centre_offset,
+            TEXT_ALIGN_RIGHT, video_width, video_height, &ozone->fonts.time, ozone->theme->text_rgba, false);
 
       gfx_display_blend_begin(userdata);
       ozone_draw_icon(
@@ -1681,7 +1645,10 @@ static void ozone_draw_footer(ozone_handle_t *ozone,
    {
       char core_title[255];
       menu_entries_get_core_title(core_title, sizeof(core_title));
-      ozone_draw_text(ozone, core_title, 59 * scale_factor, video_height - ozone->dimensions.footer_height / 2 + ozone->footer_font_glyph_height * 3.0f/10.0f, TEXT_ALIGN_LEFT, video_width, video_height, ozone->fonts.footer, ozone->theme->text_rgba, false);
+      ozone_draw_text(ozone, core_title,
+            59 * scale_factor,
+            video_height - ozone->dimensions.footer_height / 2 + ozone->fonts.footer.line_centre_offset,
+            TEXT_ALIGN_LEFT, video_width, video_height, &ozone->fonts.footer, ozone->theme->text_rgba, false);
    }
    else
       ozone_draw_icon(
@@ -1764,21 +1731,30 @@ static void ozone_draw_footer(ozone_handle_t *ozone,
             (input_menu_swap_ok_cancel_buttons) ?
             msg_hash_to_str(MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_OK) :
             msg_hash_to_str(MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_BACK),
-            video_width - back_width, video_height - ozone->dimensions.footer_height / 2 + ozone->footer_font_glyph_height * 3.0f/10.0f, TEXT_ALIGN_LEFT, video_width, video_height, ozone->fonts.footer, ozone->theme->text_rgba, false);
+            video_width - back_width,
+            video_height - ozone->dimensions.footer_height / 2 + ozone->fonts.footer.line_centre_offset,
+            TEXT_ALIGN_LEFT, video_width, video_height, &ozone->fonts.footer, ozone->theme->text_rgba, false);
+
       ozone_draw_text(ozone,
             (input_menu_swap_ok_cancel_buttons) ?
             msg_hash_to_str(MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_BACK) :
             msg_hash_to_str(MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_OK),
-            video_width - ok_width, video_height - ozone->dimensions.footer_height / 2 + ozone->footer_font_glyph_height * 3.0f/10.0f, TEXT_ALIGN_LEFT, video_width, video_height, ozone->fonts.footer, ozone->theme->text_rgba, false);
+            video_width - ok_width,
+            video_height - ozone->dimensions.footer_height / 2 + ozone->fonts.footer.line_centre_offset,
+            TEXT_ALIGN_LEFT, video_width, video_height, &ozone->fonts.footer, ozone->theme->text_rgba, false);
 
       ozone_draw_text(ozone,
             msg_hash_to_str(MENU_ENUM_LABEL_VALUE_SEARCH),
-            video_width - search_width, video_height - ozone->dimensions.footer_height / 2 + ozone->footer_font_glyph_height * 3.0f/10.0f, TEXT_ALIGN_LEFT, video_width, video_height, ozone->fonts.footer, ozone->theme->text_rgba, false);
+            video_width - search_width,
+            video_height - ozone->dimensions.footer_height / 2 + ozone->fonts.footer.line_centre_offset,
+            TEXT_ALIGN_LEFT, video_width, video_height, &ozone->fonts.footer, ozone->theme->text_rgba, false);
 
       if (ozone->is_playlist && !ozone->cursor_in_sidebar)
          ozone_draw_text(ozone,
                msg_hash_to_str(MSG_CHANGE_THUMBNAIL_TYPE),
-               video_width - thumb_width, video_height - ozone->dimensions.footer_height / 2 + ozone->footer_font_glyph_height * 3.0f/10.0f, TEXT_ALIGN_LEFT, video_width, video_height, ozone->fonts.footer, ozone->theme->text_rgba, false);
+               video_width - thumb_width,
+               video_height - ozone->dimensions.footer_height / 2 + ozone->fonts.footer.line_centre_offset,
+               TEXT_ALIGN_LEFT, video_width, video_height, &ozone->fonts.footer, ozone->theme->text_rgba, false);
 
    }
 
@@ -1830,7 +1806,7 @@ void ozone_update_content_metadata(ozone_handle_t *ozone)
       {
          unsigned metadata_len =
                (ozone->dimensions.thumbnail_bar_width - ((ozone->dimensions.sidebar_entry_icon_padding * 2) * 2)) /
-                     ozone->footer_font_glyph_width;
+                     ozone->fonts.footer.glyph_width;
          word_wrap(ozone->selection_core_name, ozone->selection_core_name, metadata_len, true, 0);
          ozone->selection_core_name_lines = ozone_count_lines(ozone->selection_core_name);
       }
@@ -2087,6 +2063,31 @@ static void ozone_messagebox_fadeout_cb(void *userdata)
    ozone->should_draw_messagebox = false;
 }
 
+static void INLINE ozone_font_bind(ozone_font_data_t *font_data)
+{
+   font_driver_bind_block(font_data->font, &font_data->raster_block);
+   font_data->raster_block.carr.coords.vertices = 0;
+}
+
+static void INLINE ozone_font_unbind(ozone_font_data_t *font_data)
+{
+   font_driver_bind_block(font_data->font, NULL);
+}
+
+void ozone_font_flush(
+      unsigned video_width, unsigned video_height,
+      ozone_font_data_t *font_data)
+{
+   /* Flushing is slow - only do it if font
+    * has actually been used */
+   if (!font_data ||
+       (font_data->raster_block.carr.coords.vertices == 0))
+      return;
+
+   font_driver_flush(video_width, video_height, font_data->font);
+   font_data->raster_block.carr.coords.vertices = 0;
+}
+
 static void ozone_frame(void *data, video_frame_info_t *video_info)
 {
    gfx_animation_ctx_entry_t entry;
@@ -2165,19 +2166,12 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
    gfx_display_set_viewport(video_width, video_height);
 
    /* Clear text */
-   font_driver_bind_block(ozone->fonts.footer,  &ozone->raster_blocks.footer);
-   font_driver_bind_block(ozone->fonts.title,  &ozone->raster_blocks.title);
-   font_driver_bind_block(ozone->fonts.time,  &ozone->raster_blocks.time);
-   font_driver_bind_block(ozone->fonts.entries_label,  &ozone->raster_blocks.entries_label);
-   font_driver_bind_block(ozone->fonts.entries_sublabel,  &ozone->raster_blocks.entries_sublabel);
-   font_driver_bind_block(ozone->fonts.sidebar,  &ozone->raster_blocks.sidebar);
-
-   ozone->raster_blocks.footer.carr.coords.vertices = 0;
-   ozone->raster_blocks.title.carr.coords.vertices = 0;
-   ozone->raster_blocks.time.carr.coords.vertices = 0;
-   ozone->raster_blocks.entries_label.carr.coords.vertices = 0;
-   ozone->raster_blocks.entries_sublabel.carr.coords.vertices = 0;
-   ozone->raster_blocks.sidebar.carr.coords.vertices = 0;
+   ozone_font_bind(&ozone->fonts.footer);
+   ozone_font_bind(&ozone->fonts.title);
+   ozone_font_bind(&ozone->fonts.time);
+   ozone_font_bind(&ozone->fonts.entries_label);
+   ozone_font_bind(&ozone->fonts.entries_sublabel);
+   ozone_font_bind(&ozone->fonts.sidebar);
 
    /* Background */
    if (libretro_running &&
@@ -2274,14 +2268,12 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
          video_height);
 
    /* Flush first layer of text */
-   font_driver_flush(video_width, video_height, ozone->fonts.footer);
-   font_driver_flush(video_width, video_height, ozone->fonts.title);
-   font_driver_flush(video_width, video_height, ozone->fonts.time);
-
-   font_driver_bind_block(ozone->fonts.footer, NULL);
-   font_driver_bind_block(ozone->fonts.title, NULL);
-   font_driver_bind_block(ozone->fonts.time, NULL);
-   font_driver_bind_block(ozone->fonts.entries_label, NULL);
+   ozone_font_flush(video_width, video_height, &ozone->fonts.footer);
+   ozone_font_flush(video_width, video_height, &ozone->fonts.title);
+   ozone_font_flush(video_width, video_height, &ozone->fonts.time);
+   ozone_font_flush(video_width, video_height, &ozone->fonts.entries_label);
+   ozone_font_flush(video_width, video_height, &ozone->fonts.entries_sublabel);
+   ozone_font_flush(video_width, video_height, &ozone->fonts.sidebar);
 
    /* Draw fullscreen thumbnails, if required */
    ozone_draw_fullscreen_thumbnails(ozone,
@@ -2290,9 +2282,6 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
          video_height);
 
    /* Message box & OSK - second layer of text */
-   ozone->raster_blocks.footer.carr.coords.vertices = 0;
-   ozone->raster_blocks.entries_label.carr.coords.vertices = 0;
-
    if (ozone->should_draw_messagebox || draw_osk)
    {
       /* Fade in animation */
@@ -2356,10 +2345,11 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
                video_width,
                video_height,
                ozone->pending_message);
-   }
 
-   font_driver_flush(video_width, video_height, ozone->fonts.footer);
-   font_driver_flush(video_width, video_height, ozone->fonts.entries_label);
+      /* Flush second layer of text */
+      ozone_font_flush(video_width, video_height, &ozone->fonts.footer);
+      ozone_font_flush(video_width, video_height, &ozone->fonts.entries_label);
+   }
 
    /* Cursor */
    if (ozone->show_cursor && (ozone->pointer.type != MENU_POINTER_DISABLED))
@@ -2381,6 +2371,14 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
          video_height
       );
    }
+
+   /* Unbind fonts */
+   ozone_font_unbind(&ozone->fonts.footer);
+   ozone_font_unbind(&ozone->fonts.title);
+   ozone_font_unbind(&ozone->fonts.time);
+   ozone_font_unbind(&ozone->fonts.entries_label);
+   ozone_font_unbind(&ozone->fonts.entries_sublabel);
+   ozone_font_unbind(&ozone->fonts.sidebar);
 
    gfx_display_unset_viewport(video_width, video_height);
 }

--- a/menu/drivers/ozone/ozone.h
+++ b/menu/drivers/ozone/ozone.h
@@ -86,27 +86,29 @@ enum ozone_onscreen_entry_position_type
    OZONE_ONSCREEN_ENTRY_CENTRE
 };
 
+/* This structure holds all objects + metadata
+ * corresponding to a particular font */
+typedef struct
+{
+   font_data_t *font;
+   video_font_raster_block_t raster_block;
+   int glyph_width;
+   int line_height;
+   int line_ascender;
+   int line_centre_offset;
+} ozone_font_data_t;
+
 struct ozone_handle
 {
    struct
    {
-      font_data_t *footer;
-      font_data_t *title;
-      font_data_t *time;
-      font_data_t *entries_label;
-      font_data_t *entries_sublabel;
-      font_data_t *sidebar;
+      ozone_font_data_t footer;
+      ozone_font_data_t title;
+      ozone_font_data_t time;
+      ozone_font_data_t entries_label;
+      ozone_font_data_t entries_sublabel;
+      ozone_font_data_t sidebar;
    } fonts;
-
-   struct
-   {
-      video_font_raster_block_t footer;
-      video_font_raster_block_t title;
-      video_font_raster_block_t time;
-      video_font_raster_block_t entries_label;
-      video_font_raster_block_t entries_sublabel;
-      video_font_raster_block_t sidebar;
-   } raster_blocks;
 
    uintptr_t textures[OZONE_THEME_TEXTURE_LAST];
    uintptr_t icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_LAST];
@@ -156,20 +158,6 @@ struct ozone_handle
 
    bool draw_sidebar;
    float sidebar_offset;
-
-   unsigned title_font_glyph_width;
-   unsigned entry_font_glyph_width;
-   unsigned sublabel_font_glyph_width;
-   unsigned footer_font_glyph_width;
-   unsigned sidebar_font_glyph_width;
-   unsigned time_font_glyph_width;
-
-   unsigned title_font_glyph_height;
-   unsigned entry_font_glyph_height;
-   unsigned sublabel_font_glyph_height;
-   unsigned footer_font_glyph_height;
-   unsigned sidebar_font_glyph_height;
-   unsigned time_font_glyph_height;
 
    ozone_theme_t *theme;
 
@@ -304,6 +292,7 @@ typedef struct ozone_node
    unsigned height;
    unsigned position_y;
    bool wrap;
+   unsigned sublabel_lines;
    char *fullpath;
 
    /* Console tabs */
@@ -387,5 +376,9 @@ void ozone_show_fullscreen_thumbnails(ozone_handle_t *ozone);
 unsigned ozone_count_lines(const char *str);
 
 void ozone_update_content_metadata(ozone_handle_t *ozone);
+
+void ozone_font_flush(
+      unsigned video_width, unsigned video_height,
+      ozone_font_data_t *font_data);
 
 #endif

--- a/menu/drivers/ozone/ozone_display.c
+++ b/menu/drivers/ozone/ozone_display.c
@@ -100,11 +100,11 @@ void ozone_draw_text(
       const char *str, float x,
       float y,
       enum text_alignment text_align,
-      unsigned width, unsigned height, font_data_t* font,
+      unsigned width, unsigned height, ozone_font_data_t *font_data,
       uint32_t color,
       bool draw_outside)
 {
-   gfx_display_draw_text(font, str, x, y,
+   gfx_display_draw_text(font_data->font, str, x, y,
          width, height, color, text_align, 1.0f,
          false,
          1.0, draw_outside);
@@ -443,7 +443,7 @@ void ozone_draw_osk(ozone_handle_t *ozone,
       text_color  = ozone_theme_light.text_sublabel_rgba;
    }
 
-   word_wrap(message, text, (video_width - margin*2 - padding*2) / ozone->entry_font_glyph_width, true, 0);
+   word_wrap(message, text, (video_width - margin*2 - padding*2) / ozone->fonts.entries_label.glyph_width, true, 0);
 
    list = string_split(message, "\n");
 
@@ -451,14 +451,17 @@ void ozone_draw_osk(ozone_handle_t *ozone,
    {
       const char *msg = list->elems[i].data;
 
-      ozone_draw_text(ozone, msg, margin + padding * 2, margin + padding + ozone->sublabel_font_glyph_height + y_offset, TEXT_ALIGN_LEFT, video_width, video_height, ozone->fonts.entries_label, text_color, false);
+      ozone_draw_text(ozone, msg,
+            margin + padding * 2,
+            margin + padding + ozone->fonts.entries_label.line_height + y_offset,
+            TEXT_ALIGN_LEFT, video_width, video_height, &ozone->fonts.entries_label, text_color, false);
 
       /* Cursor */
       if (i == list->size - 1)
       {
          if (ozone->osk_cursor)
          {
-            unsigned cursor_x = draw_placeholder ? 0 : font_driver_get_message_width(ozone->fonts.entries_label, msg, (unsigned)strlen(msg), 1);
+            unsigned cursor_x = draw_placeholder ? 0 : font_driver_get_message_width(ozone->fonts.entries_label.font, msg, (unsigned)strlen(msg), 1);
             gfx_display_draw_quad(
                   userdata,
                   video_width,
@@ -484,7 +487,7 @@ void ozone_draw_osk(ozone_handle_t *ozone,
          video_width,
          video_height,
          ozone->theme->textures[OZONE_THEME_TEXTURE_CURSOR_STATIC],
-         ozone->fonts.entries_label,
+         ozone->fonts.entries_label.font,
          input_event_get_osk_grid(),
          input_event_get_osk_ptr(),
          ozone->theme->text_rgba);
@@ -507,7 +510,7 @@ void ozone_draw_messagebox(
    unsigned width           = video_width;
    unsigned height          = video_height;
 
-   if (!list || !ozone || !ozone->fonts.footer)
+   if (!list || !ozone || !ozone->fonts.footer.font)
    {
       if (list)
          string_list_free(list);
@@ -522,7 +525,7 @@ void ozone_draw_messagebox(
       y_position    = height / 4;
 
    x                = width  / 2;
-   y                = y_position - (list->size * ozone->footer_font_glyph_height) / 2;
+   y                = y_position - (list->size * ozone->fonts.footer.line_height) / 2;
 
    /* find the longest line width */
    for (i = 0; i < list->size; i++)
@@ -534,7 +537,7 @@ void ozone_draw_messagebox(
       {
          longest       = len;
          longest_width = font_driver_get_message_width(
-               ozone->fonts.footer, msg, (unsigned)strlen(msg), 1);
+               ozone->fonts.footer.font, msg, (unsigned)strlen(msg), 1);
       }
    }
 
@@ -542,12 +545,19 @@ void ozone_draw_messagebox(
 
    gfx_display_blend_begin(userdata);
 
-   if (ozone->has_all_assets) /* avoid drawing a black box if there's no assets */
+   /* Avoid drawing a black box if there's no assets */
+   if (ozone->has_all_assets)
    {
-      int slice_x          = x - longest_width/2 - 48 * scale_factor;
-      int slice_y          = (list->size > 1) ? y : y - (ozone->footer_font_glyph_height / 2);
+      /* Note: The fact that we use a texture slice here
+       * makes things very messy
+       * > The actual size and offset of a texture slice
+       *   is quite 'loose', and depends upon source image
+       *   size, draw size and scale factor... */
       unsigned slice_new_w = longest_width + 48 * 2 * scale_factor;
-      unsigned slice_new_h = ozone->footer_font_glyph_height * (list->size + 2);
+      unsigned slice_new_h = ozone->fonts.footer.line_height * (list->size + 2);
+      int slice_x          = x - longest_width/2 - 48 * scale_factor;
+      int slice_y          = y - ozone->fonts.footer.line_height +
+            ((slice_new_h >= 256) ? (16.0f * scale_factor) : (16.0f * ((float)slice_new_h / 256.0f)));
 
       gfx_display_draw_texture_slice(
             userdata,
@@ -573,10 +583,10 @@ void ozone_draw_messagebox(
          ozone_draw_text(ozone,
             msg,
             x - longest_width/2.0,
-            y + (i + 1) * ozone->footer_font_glyph_height,
+            y + (i * ozone->fonts.footer.line_height) + ozone->fonts.footer.line_ascender,
             TEXT_ALIGN_LEFT,
             width, height,
-            ozone->fonts.footer,
+            &ozone->fonts.footer,
             COLOR_TEXT_ALPHA(ozone->theme->text_rgba, (uint32_t)(ozone->animations.messagebox_alpha*255.0f)),
             false
          );

--- a/menu/drivers/ozone/ozone_display.h
+++ b/menu/drivers/ozone/ozone_display.h
@@ -26,7 +26,7 @@ void ozone_draw_text(
       const char *str, float x,
       float y,
       enum text_alignment text_align,
-      unsigned width, unsigned height, font_data_t* font,
+      unsigned width, unsigned height, ozone_font_data_t *font_data,
       uint32_t color,
       bool draw_outside);
 

--- a/menu/drivers/ozone/ozone_sidebar.c
+++ b/menu/drivers/ozone/ozone_sidebar.c
@@ -132,7 +132,7 @@ void ozone_draw_sidebar(
    if (use_smooth_ticker)
    {
       ticker_smooth.idx           = gfx_animation_get_ticker_pixel_idx();
-      ticker_smooth.font          = ozone->fonts.sidebar;
+      ticker_smooth.font          = ozone->fonts.sidebar.font;
       ticker_smooth.font_scale    = 1.0f;
       ticker_smooth.type_enum     = menu_ticker_type;
       ticker_smooth.spacer        = ticker_spacer;
@@ -285,8 +285,10 @@ void ozone_draw_sidebar(
 
       /* Text */
       if (!ozone->sidebar_collapsed)
-         ozone_draw_text(ozone, title, ozone->sidebar_offset + ozone->dimensions.sidebar_padding_horizontal + ozone->dimensions.sidebar_entry_icon_padding * 2 + ozone->dimensions.sidebar_entry_icon_size,
-            y + ozone->dimensions.sidebar_entry_height / 2 + ozone->sidebar_font_glyph_height * 3.0f/10.0f + ozone->animations.scroll_y_sidebar, TEXT_ALIGN_LEFT, video_width, video_height, ozone->fonts.sidebar, text_color, true);
+         ozone_draw_text(ozone, title,
+               ozone->sidebar_offset + ozone->dimensions.sidebar_padding_horizontal + ozone->dimensions.sidebar_entry_icon_padding * 2 + ozone->dimensions.sidebar_entry_icon_size,
+               y + ozone->dimensions.sidebar_entry_height / 2.0f + ozone->fonts.sidebar.line_centre_offset + ozone->animations.scroll_y_sidebar,
+               TEXT_ALIGN_LEFT, video_width, video_height, &ozone->fonts.sidebar, text_color, true);
 
       y += ozone->dimensions.sidebar_entry_height + ozone->dimensions.sidebar_entry_padding_vertical;
    }
@@ -359,7 +361,7 @@ void ozone_draw_sidebar(
          }
          else
          {
-            ticker.len      = (entry_width - ozone->dimensions.sidebar_entry_icon_size - 40 * scale_factor) / ozone->sidebar_font_glyph_width;
+            ticker.len      = (entry_width - ozone->dimensions.sidebar_entry_icon_size - 40 * scale_factor) / ozone->fonts.sidebar.glyph_width;
             ticker.s        = console_title;
             ticker.selected = selected;
             ticker.str      = node->console_name;
@@ -367,9 +369,11 @@ void ozone_draw_sidebar(
             gfx_animation_ticker(&ticker);
          }
 
-         ozone_draw_text(ozone, console_title, ticker_x_offset + ozone->sidebar_offset + ozone->dimensions.sidebar_padding_horizontal + ozone->dimensions.sidebar_entry_icon_padding * 2 + ozone->dimensions.sidebar_entry_icon_size,
-               y + ozone->dimensions.sidebar_entry_height / 2 + ozone->sidebar_font_glyph_height * 3.0f/10.0f + ozone->animations.scroll_y_sidebar, TEXT_ALIGN_LEFT,
-               video_width, video_height, ozone->fonts.sidebar, text_color, true);
+         ozone_draw_text(ozone, console_title,
+               ticker_x_offset + ozone->sidebar_offset + ozone->dimensions.sidebar_padding_horizontal + ozone->dimensions.sidebar_entry_icon_padding * 2 + ozone->dimensions.sidebar_entry_icon_size,
+               y + ozone->dimensions.sidebar_entry_height / 2 + ozone->fonts.sidebar.line_centre_offset + ozone->animations.scroll_y_sidebar,
+               TEXT_ALIGN_LEFT,
+               video_width, video_height, &ozone->fonts.sidebar, text_color, true);
 
 console_iterate:
          y += ozone->dimensions.sidebar_entry_height + ozone->dimensions.sidebar_entry_padding_vertical;
@@ -378,8 +382,7 @@ console_iterate:
       gfx_display_blend_end(userdata);
    }
 
-   font_driver_flush(video_width, video_height, ozone->fonts.sidebar);
-   ozone->raster_blocks.sidebar.carr.coords.vertices = 0;
+   ozone_font_flush(video_width, video_height, &ozone->fonts.sidebar);
 
    gfx_display_scissor_end(userdata, video_width,
          video_height);

--- a/menu/drivers/ozone/ozone_theme.c
+++ b/menu/drivers/ozone/ozone_theme.c
@@ -100,9 +100,9 @@ ozone_theme_t ozone_theme_nord = {
    0x8FBCBBFF,                             /* text_sublabel_rgba */
 
    /* Sidebar color */
-   ozone_sidebar_background_nord,          /* <TODO> sidebar_background */
-   ozone_sidebar_gradient_top_nord,        /* <TODO> sidebar_top_gradient */
-   ozone_sidebar_gradient_bottom_nord,     /* <TODO> sidebar_bottom_gradient */
+   ozone_sidebar_background_nord,          /* sidebar_background */
+   ozone_sidebar_gradient_top_nord,        /* sidebar_top_gradient */
+   ozone_sidebar_gradient_bottom_nord,     /* sidebar_bottom_gradient */
 
    /* Fancy cursor colors */
    ozone_border_0_nord,                    /* cursor_border_0 */


### PR DESCRIPTION
## Description

This PR adds font metrics support to Ozone (c.f. https://github.com/libretro/RetroArch/pull/10375), enabling 'pixel perfect' vertical alignment of all text. It also fixes the alignment of message boxes, removes a couple of unnecessary 'font flush' operations and cleans up the font handling in general.

While tweaking alignments, I also noticed a long-standing annoyance with the way thumbnails are displayed - I didn't think this warranted a separate PR, so I added the improvements here :)

The issue is this: when *two* thumbnails are enabled, if the *first* thumbnail is missing then Ozone displays nothing at all - no second thumbnail, no content metadata. With this PR, the thumbnail sidebar is now laid out as follows:

- If the first type of thumbnail is available, it gets displayed at the top

- If the first type of thumbnail is unavailable but the second type *is*, then the second type gets displayed at the top

- If no thumbnails are available, the 'no thumbnail' message gets displayed at the top

- If both types of thumbnail are available, then the second type gets displayed at the bottom

- If one or no thumbnails are available, content metadata gets displayed at the bottom

This makes scrolling thought playlists with missing thumbnails a little more pleasant - for example:

![window_record__2020_04_08__15_02_48](https://user-images.githubusercontent.com/38211560/78796546-62f95800-79ae-11ea-84a7-08b4c8188e4f.gif)
