### PR TITLE
ui_cocoa: fix mouse input for cocoa

### DIFF
--- a/ui/drivers/ui_cocoa.m
+++ b/ui/drivers/ui_cocoa.m
@@ -139,6 +139,7 @@ static void app_terminate(void)
 #if defined(HAVE_COCOA_METAL)
             pos = [apple_platform.renderView convertPoint:[event locationInWindow] fromView:nil];
 #elif defined(HAVE_COCOA)
+            pos = [[CocoaView get] convertPoint:[event locationInWindow] fromView:nil];
 #endif
             apple->touches[0].screen_x = (int16_t)pos.x;
             apple->touches[0].screen_y = (int16_t)pos.y;
@@ -172,6 +173,7 @@ static void app_terminate(void)
            if (!apple || pos.y < 0)
                return;
            apple->mouse_buttons |= (1 << event.buttonNumber);
+           apple->touch_count = 1;
        }
            break;
       case NSEventTypeLeftMouseUp:
@@ -431,10 +433,10 @@ static char** waiting_argv;
 
 - (void)application:(NSApplication *)sender openFiles:(NSArray *)filenames
 {
-	if ((filenames.count == 1) && [filenames objectAtIndex:0])
+  if ((filenames.count == 1) && [filenames objectAtIndex:0])
    {
       struct retro_system_info *system = runloop_get_libretro_system_info();
-	  NSString *__core                 = [filenames objectAtIndex:0];
+    NSString *__core                 = [filenames objectAtIndex:0];
       const char *core_name            = system->library_name;
 
       if (core_name)
@@ -483,7 +485,7 @@ static void open_core_handler(ui_browser_window_state_t *state, bool result)
    path_set(RARCH_PATH_CORE, state->result);
    ui_companion_event_command(CMD_EVENT_LOAD_CORE);
 
-   if (info 
+   if (info
          && info->load_no_content
          && set_supports_no_game_enable)
    {
@@ -554,7 +556,7 @@ static void open_document_handler(
 
     if (browser)
     {
-       ui_browser_window_state_t 
+       ui_browser_window_state_t
           browser_state                  = {{0}};
        bool result                       = false;
        settings_t *settings              = config_get_ptr();


### PR DESCRIPTION
## Description

This should fix the mouse input issue on macOS, by bringing in some lost code from 1.7.6. 

In builds after 1.7.6 mouse/touch input no longer appeared to work in emulators. I acknowledge that these changes may not be the preferred method but they appear to fix the issue.

## Related Issues

https://github.com/libretro/RetroArch/issues/10168
