### PR TITLE
Expand functionality of 'rzip_stream' interface

### DIFF
--- a/libretro-common/include/streams/interface_stream.h
+++ b/libretro-common/include/streams/interface_stream.h
@@ -75,6 +75,9 @@ int64_t intfstream_read(intfstream_internal_t *intf,
 int64_t intfstream_write(intfstream_internal_t *intf,
       const void *s, uint64_t len);
 
+int intfstream_printf(intfstream_internal_t *intf,
+      const char* format, ...);
+
 int64_t intfstream_get_ptr(intfstream_internal_t *intf);
 
 char *intfstream_gets(intfstream_internal_t *intf,
@@ -100,6 +103,8 @@ int intfstream_flush(intfstream_internal_t *intf);
 uint32_t intfstream_get_offset_to_start(intfstream_internal_t *intf);
 
 uint32_t intfstream_get_frame_size(intfstream_internal_t *intf);
+
+bool intfstream_is_compressed(intfstream_internal_t *intf);
 
 intfstream_t* intfstream_open_file(const char *path,
       unsigned mode, unsigned hints);


### PR DESCRIPTION
## Description

This PR expands the functionality of the new `rzip_stream` archived stream interface such that it now has almost complete feature parity with the standard `file_stream` interface, and can therefore be used as a drop-in replacement in most situations.

The only thing missing is arbitrary file 'seeking' - this could be implemented, but it would be very slow (so I'd rather discourage its use). 'Rewind' is supported, however.

The additional functions have also been wired up in the higher level `interface_stream` code.

This is not a very exciting PR, but I need these additions for my future plans  :)