### PR TITLE
(WiiU/3DS) Fix font driver horizontal text alignment

### DIFF
--- a/gfx/drivers_font/ctr_font.c
+++ b/gfx/drivers_font/ctr_font.c
@@ -369,8 +369,8 @@ static void ctr_font_render_msg(
             alpha, r_dark, g_dark, b_dark, alpha_dark;
    ctr_font_t                * font = (ctr_font_t*)data;
    ctr_video_t                *ctr  = (ctr_video_t*)userdata;
-   unsigned width                   = ctr->vp.width;
-   unsigned height                  = ctr->vp.height;
+   unsigned width                   = ctr->vp.full_width;
+   unsigned height                  = ctr->vp.full_height;
    settings_t *settings             = config_get_ptr();
    float video_msg_pos_x            = settings->floats.video_msg_pos_x;
    float video_msg_pos_y            = settings->floats.video_msg_pos_y;

--- a/gfx/drivers_font/wiiu_font.c
+++ b/gfx/drivers_font/wiiu_font.c
@@ -299,8 +299,8 @@ static void wiiu_font_render_msg(
             alpha, r_dark, g_dark, b_dark, alpha_dark;
    wiiu_video_t              *wiiu  = (wiiu_video_t*)userdata;
    wiiu_font_t                *font = (wiiu_font_t*)data;
-   unsigned width                   = wiiu->vp.width;
-   unsigned height                  = wiiu->vp.height;
+   unsigned width                   = wiiu->vp.full_width;
+   unsigned height                  = wiiu->vp.full_height;
    settings_t *settings             = config_get_ptr();
    float video_msg_pos_x            = settings->floats.video_msg_pos_x;
    float video_msg_pos_y            = settings->floats.video_msg_pos_y;


### PR DESCRIPTION
## Description

As reported in #10476, menu text on the WiiU is currently broken. The first bad commit was isolated to this range: https://github.com/libretro/RetroArch/compare/ee2f25b1dc8a0c6c4399c251e8947401b8587c16...e2a703896f2043e34e52020297155567df5c9796

I don't have a WiiU (and so cannot test anything...), but that diff contains a very obvious error - when drawing text via the WiiU font driver, the current viewport width/height is used instead of the screen width/height.

(The bug was copy/pasted to the 3DS font driver too, but since most people use RGUI on that platform it has gone unnoticed)

This PR should fix the issue (I hope) - it does on 3DS, anyway.

## Related Issues

#10476
