### PR TITLE
(3DS) Allow control bindings for multiple players

### DIFF
--- a/input/drivers/ctr_input.c
+++ b/input/drivers/ctr_input.c
@@ -51,7 +51,7 @@ static int16_t ctr_input_state(void *data,
 {
    ctr_input_t *ctr                   = (ctr_input_t*)data;
 
-   if (port > 0)
+   if (port >= MENU_ENUM_LABEL_VALUE_INPUT_MAX_USERS)
       return 0;
 
    switch (device)


### PR DESCRIPTION
With the current input driver, button presses are ignored for players (ports) other than the first one (0).

We are able to set 'Max Users' in the input settings menu which disables the binds for users higher than the maximum.

This setting is ignored for all axis (c-stick, circlepad). They always register for any user.
The button presses are always ignored for any user but the first (port 0).

This change allows the 3DS to bind and use controls for users up to the maximum set by 'Max Users' in the input settings menu.

Related issue: https://github.com/libretro/RetroArch/issues/3284