### PR TITLE
[WiiU] Warning fixes+devkitPPC updates

### DIFF
--- a/deps/libfat/directory.c
+++ b/deps/libfat/directory.c
@@ -1162,19 +1162,14 @@ void _FAT_directory_entryStat (PARTITION* partition, DIR_ENTRY* entry, struct st
          0,
          u8array_to_u16 (entry->entryData, DIR_ENTRY_aDate)
          );
-   st->st_spare1 = 0;
    st->st_mtime = _FAT_filetime_to_time_t (
          u8array_to_u16 (entry->entryData, DIR_ENTRY_mTime),
          u8array_to_u16 (entry->entryData, DIR_ENTRY_mDate)
          );
-   st->st_spare2 = 0;
    st->st_ctime = _FAT_filetime_to_time_t (
          u8array_to_u16 (entry->entryData, DIR_ENTRY_cTime),
          u8array_to_u16 (entry->entryData, DIR_ENTRY_cDate)
          );
-   st->st_spare3 = 0;
    st->st_blksize = partition->bytesPerSector;				/* Prefered file I/O block size */
    st->st_blocks = (st->st_size + partition->bytesPerSector - 1) / partition->bytesPerSector;	/* File size in blocks */
-   st->st_spare4[0] = 0;
-   st->st_spare4[1] = 0;
 }


### PR DESCRIPTION
Hey folks! Been a while.
This is a small PR to fix two things:
- devkitPro's latest toolchain update changes something in the filesystem ABI; so libfat needs devkitPro/libfat@d6bb60a. I don't think leaving these fields unset has a negative effect for builds on older toolchains, they're spare/unset values.
- Wii U builds emit quite a few warnings about the deprecation of `MSB_FIRST`, so here that gets removed. [gx2_shader_inl.h](https://github.com/libretro/RetroArch/blob/19c4fcda885f7627f55d43e9532254cfc230654c/wiiu/gx2_shader_inl.h) uses `MSB_FIRST`, so it needs to include the endian headers; otherwise the screens stay black... which was fun to debug. I'm not sure if this is the preferred way to include things out of libretro-common, let me know if you prefer a different format.