### PR TITLE
WiiU: gfx_display: fix non-vertex coordinates in draws using tex shader 

### DIFF
--- a/Makefile.wiiu
+++ b/Makefile.wiiu
@@ -184,7 +184,7 @@ CFLAGS  := -mcpu=750 -meabi -mhard-float
 CFLAGS  += -ffast-math -Werror=implicit-function-declaration
 CFLAGS  += -ffunction-sections -fdata-sections
 #CFLAGS += -fomit-frame-pointer -mword-relocations
-#CFLAGS += -Wall
+CFLAGS += -Wall
 
 ifeq ($(DEBUG), 1)
    CFLAGS += -O0 -g

--- a/gfx/drivers_display/gfx_display_wiiu.c
+++ b/gfx/drivers_display/gfx_display_wiiu.c
@@ -89,6 +89,7 @@ static void gfx_display_wiiu_draw(gfx_display_ctx_draw_t *draw,
       }
 
    }
+   /* TODO come up with a better check for "not all vertexes are the same color" */
    else if (draw->coords->vertex || draw->coords->color[0] != draw->coords->color[12])
    {
       if (wiiu->vertex_cache_tex.current + 4 > wiiu->vertex_cache_tex.size)
@@ -106,14 +107,20 @@ static void gfx_display_wiiu_draw(gfx_display_ctx_draw_t *draw,
 
       if (!draw->coords->vertex)
       {
-         v[0].pos.x = 0.0f;
-         v[0].pos.y = 1.0f;
-         v[1].pos.x = 1.0f;
-         v[1].pos.y = 1.0f;
-         v[2].pos.x = 0.0f;
-         v[2].pos.y = 0.0f;
-         v[3].pos.x = 1.0f;
-         v[3].pos.y = 0.0f;
+         /* Convert the libretro bottom-up coordinate system to GX2 - low y at
+            the top of the screen, large y at the bottom
+            The compiler will optimise 90% of this out anyway */
+         float y = -(draw->y + draw->height - video_height);
+         /* Remember: this is a triangle strip, not a quad, draw in a Z shape
+            Bottom-left, right, top-left, right */
+         v[0].pos.x = (draw->x               ) / video_width;
+         v[0].pos.y = (y       + draw->height) / video_height;
+         v[1].pos.x = (draw->x + draw->width ) / video_width;
+         v[1].pos.y = (y       + draw->height) / video_height;
+         v[2].pos.x = (draw->x               ) / video_width;
+         v[2].pos.y = (y                     ) / video_height;
+         v[3].pos.x = (draw->x + draw->width ) / video_width;
+         v[3].pos.y = (y                     ) / video_height;
       }
       else
       {


### PR DESCRIPTION
Fixes #8519, see the commit for technical details. The old code defaulted to filling the screen when a non-trivially coloured quad didn't use coords->vertex, which isn't ideal. This made the tiny gradient parts of the sidebar in Ozone become quite large indeed, leading to the bug this addresses.

Bonus: I switched on -Wall, since I lost at least an hour to corruption after giving floats to `%d` format strings. devkitPPC issues a warning for these if you have -Wall on! Besides, it's the standard in CONTRIBUTING.md.