### PR TITLE
(VFS v4) Add function(s) for retrieving file access/creation/modification times (DO NOT MERGE)

### DIFF
--- a/libretro-common/file/file_path_io.c
+++ b/libretro-common/file/file_path_io.c
@@ -114,8 +114,9 @@
 
 #endif
 
-static retro_vfs_stat_t path_stat_cb   = retro_vfs_stat_impl;
-static retro_vfs_mkdir_t path_mkdir_cb = retro_vfs_mkdir_impl;
+static retro_vfs_stat_t path_stat_cb                   = retro_vfs_stat_impl;
+static retro_vfs_mkdir_t path_mkdir_cb                 = retro_vfs_mkdir_impl;
+static retro_vfs_get_timestamp_t path_get_timestamp_cb = retro_vfs_get_timestamp_impl;
 
 void path_vfs_init(const struct retro_vfs_interface_info* vfs_info)
 {
@@ -124,12 +125,14 @@ void path_vfs_init(const struct retro_vfs_interface_info* vfs_info)
 
    path_stat_cb           = retro_vfs_stat_impl;
    path_mkdir_cb          = retro_vfs_mkdir_impl;
+   path_get_timestamp_cb  = retro_vfs_get_timestamp_impl;
 
    if (vfs_info->required_interface_version < PATH_REQUIRED_VFS_VERSION || !vfs_iface)
       return;
 
    path_stat_cb           = vfs_iface->stat;
    path_mkdir_cb          = vfs_iface->mkdir;
+   path_get_timestamp_cb  = vfs_iface->get_timestamp;
 }
 
 int path_stat(const char *path)
@@ -239,4 +242,64 @@ bool path_mkdir(const char *dir)
    }
 
    return sret;
+}
+
+/**
+ * path_get_atime:
+ * @path               : path
+ * @time               : file access time
+ *
+ * Fetches last access time of file
+ *
+ * Returns: true on success, otherwise false.
+ */
+bool path_get_atime(const char *path, struct retro_vfs_time *time)
+{
+   if (!time)
+      return false;
+
+   if (path_get_timestamp_cb(path, time, NULL, NULL) == 0)
+      return true;
+
+   return false;
+}
+
+/**
+ * path_get_ctime:
+ * @path               : path
+ * @time               : file creation time
+ *
+ * Fetches creation time of file
+ *
+ * Returns: true on success, otherwise false.
+ */
+bool path_get_ctime(const char *path, struct retro_vfs_time *time)
+{
+   if (!time)
+      return false;
+
+   if (path_get_timestamp_cb(path, NULL, time, NULL) == 0)
+      return true;
+
+   return false;
+}
+
+/**
+ * path_get_mtime:
+ * @path               : path
+ * @time               : file modification time
+ *
+ * Fetches last modification time of file
+ *
+ * Returns: true on success, otherwise false.
+ */
+bool path_get_mtime(const char *path, struct retro_vfs_time *time)
+{
+   if (!time)
+      return false;
+
+   if (path_get_timestamp_cb(path, NULL, NULL, time) == 0)
+      return true;
+
+   return false;
 }

--- a/libretro-common/include/file/file_path.h
+++ b/libretro-common/include/file/file_path.h
@@ -35,7 +35,7 @@
 
 RETRO_BEGIN_DECLS
 
-#define PATH_REQUIRED_VFS_VERSION 3
+#define PATH_REQUIRED_VFS_VERSION 4
 
 void path_vfs_init(const struct retro_vfs_interface_info* vfs_info);
 
@@ -525,6 +525,39 @@ bool path_is_valid(const char *path);
 int32_t path_get_size(const char *path);
 
 bool is_path_accessible_using_standard_io(const char *path);
+
+/**
+ * path_get_atime:
+ * @path               : path
+ * @time               : file access time
+ *
+ * Fetches last access time of file
+ *
+ * Returns: true on success, otherwise false.
+ */
+bool path_get_atime(const char *path, struct retro_vfs_time *time);
+
+/**
+ * path_get_ctime:
+ * @path               : path
+ * @time               : file creation time
+ *
+ * Fetches creation time of file
+ *
+ * Returns: true on success, otherwise false.
+ */
+bool path_get_ctime(const char *path, struct retro_vfs_time *time);
+
+/**
+ * path_get_mtime:
+ * @path               : path
+ * @time               : file modification time
+ *
+ * Fetches last modification time of file
+ *
+ * Returns: true on success, otherwise false.
+ */
+bool path_get_mtime(const char *path, struct retro_vfs_time *time);
 
 RETRO_END_DECLS
 

--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -1337,6 +1337,19 @@ struct retro_vfs_dir_handle;
 #define RETRO_VFS_STAT_IS_DIRECTORY           (1 << 1)
 #define RETRO_VFS_STAT_IS_CHARACTER_SPECIAL   (1 << 2)
 
+/* Contains all elements of a file
+ * access/creation/modification timestamp
+ * Introduced in VFS API v4 */
+struct retro_vfs_time
+{
+   uint16_t year;
+   uint8_t month;
+   uint8_t day;
+   uint8_t hour;
+   uint8_t minute;
+   uint8_t second;
+};
+
 /* Get path from opaque handle. Returns the exact same path passed to file_open when getting the handle
  * Introduced in VFS API v1 */
 typedef const char *(RETRO_CALLCONV *retro_vfs_get_path_t)(struct retro_vfs_file_handle *stream);
@@ -1420,6 +1433,13 @@ typedef bool (RETRO_CALLCONV *retro_vfs_dirent_is_dir_t)(struct retro_vfs_dir_ha
  * Introduced in VFS API v3 */
 typedef int (RETRO_CALLCONV *retro_vfs_closedir_t)(struct retro_vfs_dir_handle *dirstream);
 
+/* Fetches access(atime)/creation(ctime)/modification(mtime) times for the specified file.
+ * Individual retro_vfs_time arguments may be set to NULL if specific value is not required.
+ * Returns 0 on success, -1 on failure.
+ * Introduced in VFS API v4 */
+typedef int (RETRO_CALLCONV *retro_vfs_get_timestamp_t)(const char *path,
+      struct retro_vfs_time *atime, struct retro_vfs_time *ctime, struct retro_vfs_time *mtime);
+
 struct retro_vfs_interface
 {
    /* VFS API v1 */
@@ -1444,6 +1464,8 @@ struct retro_vfs_interface
    retro_vfs_dirent_get_name_t dirent_get_name;
    retro_vfs_dirent_is_dir_t dirent_is_dir;
    retro_vfs_closedir_t closedir;
+   /* VFS API v4 */
+   retro_vfs_get_timestamp_t get_timestamp;
 };
 
 struct retro_vfs_interface_info

--- a/libretro-common/include/streams/file_stream.h
+++ b/libretro-common/include/streams/file_stream.h
@@ -38,13 +38,11 @@
 #include <stdarg.h>
 #include <vfs/vfs_implementation.h>
 
-#define FILESTREAM_REQUIRED_VFS_VERSION 2
-
 RETRO_BEGIN_DECLS
 
-typedef struct RFILE RFILE;
-
 #define FILESTREAM_REQUIRED_VFS_VERSION 2
+
+typedef struct RFILE RFILE;
 
 void filestream_vfs_init(const struct retro_vfs_interface_info* vfs_info);
 

--- a/libretro-common/include/vfs/vfs_implementation.h
+++ b/libretro-common/include/vfs/vfs_implementation.h
@@ -71,6 +71,9 @@ bool retro_vfs_dirent_is_dir_impl(libretro_vfs_implementation_dir *dirstream);
 
 int retro_vfs_closedir_impl(libretro_vfs_implementation_dir *dirstream);
 
+int retro_vfs_get_timestamp_impl(const char *path,
+		struct retro_vfs_time *atime, struct retro_vfs_time *ctime, struct retro_vfs_time *mtime);
+
 RETRO_END_DECLS
 
 #endif

--- a/libretro-common/vfs/vfs_implementation.c
+++ b/libretro-common/vfs/vfs_implementation.c
@@ -1535,8 +1535,7 @@ int retro_vfs_get_timestamp_impl(const char *path,
    path_wide = utf8_to_utf16_string_alloc(path);
    file_info = GetFileAttributesW(path_wide);
 
-   if (!string_is_empty(path_wide))
-      stat_ret = _wstat(path_wide, &stats);
+   stat_ret = _wstat(path_wide, &stats);
 
    if (path_wide)
       free(path_wide);

--- a/retroarch.c
+++ b/retroarch.c
@@ -12402,7 +12402,7 @@ static bool rarch_environment_cb(unsigned cmd, void *data)
 
       case RETRO_ENVIRONMENT_GET_VFS_INTERFACE:
       {
-         const uint32_t supported_vfs_version = 3;
+         const uint32_t supported_vfs_version = 4;
          static struct retro_vfs_interface vfs_iface =
          {
             /* VFS API v1 */
@@ -12426,7 +12426,9 @@ static bool rarch_environment_cb(unsigned cmd, void *data)
             retro_vfs_readdir_impl,
             retro_vfs_dirent_get_name_impl,
             retro_vfs_dirent_is_dir_impl,
-            retro_vfs_closedir_impl
+            retro_vfs_closedir_impl,
+            /* VFS API v4 */
+            retro_vfs_get_timestamp_impl
          };
 
          struct retro_vfs_interface_info *vfs_iface_info = (struct retro_vfs_interface_info *) data;


### PR DESCRIPTION
## Description

This PR bumps the VFS interface to version 4, adding the functionality required for retrieving file access/creation/modification times. This is required for future improvements to the save state interface.

However! The PR is not yet entirely complete, and also needs testing before merging:

- I have implemented this for every platform apart from:

    - PS4 (ORBIS): Not sure if this one actually counts, since the VFS `stat()` function isn't implemented correctly for PS4 either (the ORBIS build currently fails)

   - UWP: I have no idea how UWP is supposed to work, nor can I test it. I've added a placeholder in `vfs_implementation_uwp.cpp`, but this needs to be filled in

- PSP, Vita and PS2 need testing - I based the implementations on the documentation I could find, but can't try these myself on real hardware

- Windows needs testing

I've verified that the Linux build does work correctly.

If there are any problems/issues with this PR and we can't resolve them (i.e. if modification times really don't work on a particular platform), then we can scrap this and I'll come up with an alternative solution for improving save state management...

## Reviewers

@twinaphex 
