### PR TITLE
[Retroarch] Tiny glitch when displaying version

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -26821,6 +26821,8 @@ static void retroarch_print_version(void)
          PACKAGE_VERSION);
 #ifdef HAVE_GIT_VERSION
    printf(" -- %s --\n", retroarch_git_version);
+#else
+   printf("\n");
 #endif
    retroarch_get_capabilities(RARCH_CAPABILITIES_COMPILER, str, sizeof(str));
    strlcat(str, " Built: " __DATE__, sizeof(str));


### PR DESCRIPTION
Hello,

Just two lines to fix #10445

## Description

I just added a newline to have correct display of the version as explained in the related issue.

#ifdef HAVE_GIT_VERSION
   printf(" -- %s --\n", retroarch_git_version);
#else                 <--------------
   printf("\n");      <--------------
#endif
   retroarch_get_capabilities(RARCH_CAPABILITIES_COMPILER, str, sizeof(str));

## Related Issues

#10445 [Syntax] Adding newline for --version output should be fine