### PR TITLE
Remove OpenBSD/macppc specific quirk

### DIFF
--- a/libretro-common/features/features_cpu.c
+++ b/libretro-common/features/features_cpu.c
@@ -43,7 +43,7 @@
 #include <lv2/systime.h>
 #endif
 
-#if defined(__CELLOS_LV2__) || ( defined(__OpenBSD__) && defined(__powerpc__) )
+#if defined(__CELLOS_LV2__)
 #ifndef _PPU_INTRINSICS_H
 #include <ppu_intrinsics.h>
 #endif


### PR DESCRIPTION
Hi,

OpenBSD/macppc moved to clang where `__mftb() ` is not available anymore,
leading to undefined references errors.

The build is fixed with #10383 already :+1: 
