### PR TITLE
Only write config files to disk when parameters change

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -4248,6 +4248,7 @@ bool config_save_overrides(enum override_type type, void *data)
    free(override_directory);
    free(core_path);
    free(game_path);
+   free(content_path);
 
    return ret;
 }

--- a/core_info.c
+++ b/core_info.c
@@ -140,15 +140,17 @@ static void core_info_list_resolve_all_firmware(
          snprintf(desc_key, sizeof(desc_key), "firmware%u_desc", c);
          snprintf(opt_key,  sizeof(opt_key),  "firmware%u_opt",  c);
 
-         if (config_get_string(config, path_key, &tmp) && !string_is_empty(tmp))
+         if (config_get_string(config, path_key, &tmp))
          {
-            info->firmware[c].path = strdup(tmp);
+            if (!string_is_empty(tmp))
+               info->firmware[c].path = strdup(tmp);
             free(tmp);
             tmp = NULL;
          }
-         if (config_get_string(config, desc_key, &tmp) && !string_is_empty(tmp))
+         if (config_get_string(config, desc_key, &tmp))
          {
-            info->firmware[c].desc = strdup(tmp);
+            if (!string_is_empty(tmp))
+               info->firmware[c].desc = strdup(tmp);
             free(tmp);
             tmp = NULL;
          }
@@ -315,48 +317,48 @@ static core_info_list_t *core_info_list_new(const char *path,
       {
          char *tmp           = NULL;
 
-         if (config_get_string(conf, "display_name", &tmp)
-               && !string_is_empty(tmp))
+         if (config_get_string(conf, "display_name", &tmp))
          {
-            core_info[i].display_name = strdup(tmp);
+            if (!string_is_empty(tmp))
+               core_info[i].display_name = strdup(tmp);
             free(tmp);
             tmp = NULL;
          }
-         if (config_get_string(conf, "display_version", &tmp)
-               && !string_is_empty(tmp))
+         if (config_get_string(conf, "display_version", &tmp))
          {
-            core_info[i].display_version = strdup(tmp);
+            if (!string_is_empty(tmp))
+               core_info[i].display_version = strdup(tmp);
             free(tmp);
             tmp = NULL;
          }
-         if (config_get_string(conf, "corename", &tmp)
-               && !string_is_empty(tmp))
+         if (config_get_string(conf, "corename", &tmp))
          {
-            core_info[i].core_name = strdup(tmp);
-            free(tmp);
-            tmp = NULL;
-         }
-
-         if (config_get_string(conf, "systemname", &tmp)
-               && !string_is_empty(tmp))
-         {
-            core_info[i].systemname = strdup(tmp);
+            if (!string_is_empty(tmp))
+               core_info[i].core_name = strdup(tmp);
             free(tmp);
             tmp = NULL;
          }
 
-         if (config_get_string(conf, "systemid", &tmp)
-               && !string_is_empty(tmp))
+         if (config_get_string(conf, "systemname", &tmp))
          {
-            core_info[i].system_id = strdup(tmp);
+            if (!string_is_empty(tmp))
+               core_info[i].systemname = strdup(tmp);
             free(tmp);
             tmp = NULL;
          }
 
-         if (config_get_string(conf, "manufacturer", &tmp)
-               && !string_is_empty(tmp))
+         if (config_get_string(conf, "systemid", &tmp))
          {
-            core_info[i].system_manufacturer = strdup(tmp);
+            if (!string_is_empty(tmp))
+               core_info[i].system_id = strdup(tmp);
+            free(tmp);
+            tmp = NULL;
+         }
+
+         if (config_get_string(conf, "manufacturer", &tmp))
+         {
+            if (!string_is_empty(tmp))
+               core_info[i].system_manufacturer = strdup(tmp);
             free(tmp);
             tmp = NULL;
          }
@@ -367,87 +369,103 @@ static core_info_list_t *core_info_list_new(const char *path,
             core_info[i].firmware_count = count;
          }
 
-         if (config_get_string(conf, "supported_extensions", &tmp)
-               && !string_is_empty(tmp))
+         if (config_get_string(conf, "supported_extensions", &tmp))
          {
-            core_info[i].supported_extensions      = strdup(tmp);
-            core_info[i].supported_extensions_list =
-               string_split(core_info[i].supported_extensions, "|");
+            if (!string_is_empty(tmp))
+            {
+               core_info[i].supported_extensions      = strdup(tmp);
+               core_info[i].supported_extensions_list =
+                  string_split(core_info[i].supported_extensions, "|");
+            }
 
             free(tmp);
             tmp = NULL;
          }
 
-         if (config_get_string(conf, "authors", &tmp)
-               && !string_is_empty(tmp))
+         if (config_get_string(conf, "authors", &tmp))
          {
-            core_info[i].authors      = strdup(tmp);
-            core_info[i].authors_list =
-               string_split(core_info[i].authors, "|");
+            if (!string_is_empty(tmp))
+            {
+               core_info[i].authors      = strdup(tmp);
+               core_info[i].authors_list =
+                  string_split(core_info[i].authors, "|");
+            }
 
             free(tmp);
             tmp = NULL;
          }
 
-         if (config_get_string(conf, "permissions", &tmp)
-               && !string_is_empty(tmp))
+         if (config_get_string(conf, "permissions", &tmp))
          {
-            core_info[i].permissions      = strdup(tmp);
-            core_info[i].permissions_list =
-               string_split(core_info[i].permissions, "|");
+            if (!string_is_empty(tmp))
+            {
+               core_info[i].permissions      = strdup(tmp);
+               core_info[i].permissions_list =
+                  string_split(core_info[i].permissions, "|");
+            }
 
             free(tmp);
             tmp = NULL;
          }
 
-         if (config_get_string(conf, "license", &tmp)
-               && !string_is_empty(tmp))
+         if (config_get_string(conf, "license", &tmp))
          {
-            core_info[i].licenses      = strdup(tmp);
-            core_info[i].licenses_list =
-               string_split(core_info[i].licenses, "|");
+            if (!string_is_empty(tmp))
+            {
+               core_info[i].licenses      = strdup(tmp);
+               core_info[i].licenses_list =
+                  string_split(core_info[i].licenses, "|");
+            }
 
             free(tmp);
             tmp = NULL;
          }
 
-         if (config_get_string(conf, "categories", &tmp)
-               && !string_is_empty(tmp))
+         if (config_get_string(conf, "categories", &tmp))
          {
-            core_info[i].categories      = strdup(tmp);
-            core_info[i].categories_list =
-               string_split(core_info[i].categories, "|");
+            if (!string_is_empty(tmp))
+            {
+               core_info[i].categories      = strdup(tmp);
+               core_info[i].categories_list =
+                  string_split(core_info[i].categories, "|");
+            }
 
             free(tmp);
             tmp = NULL;
          }
 
-         if (config_get_string(conf, "database", &tmp)
-               && !string_is_empty(tmp))
+         if (config_get_string(conf, "database", &tmp))
          {
-            core_info[i].databases      = strdup(tmp);
-            core_info[i].databases_list =
-               string_split(core_info[i].databases, "|");
+            if (!string_is_empty(tmp))
+            {
+               core_info[i].databases      = strdup(tmp);
+               core_info[i].databases_list =
+                  string_split(core_info[i].databases, "|");
+            }
 
             free(tmp);
             tmp = NULL;
          }
 
-         if (config_get_string(conf, "notes", &tmp)
-               && !string_is_empty(tmp))
+         if (config_get_string(conf, "notes", &tmp))
          {
-            core_info[i].notes     = strdup(tmp);
-            core_info[i].note_list = string_split(core_info[i].notes, "|");
+            if (!string_is_empty(tmp))
+            {
+               core_info[i].notes     = strdup(tmp);
+               core_info[i].note_list = string_split(core_info[i].notes, "|");
+            }
 
             free(tmp);
             tmp = NULL;
          }
 
-         if (config_get_string(conf, "required_hw_api", &tmp)
-               && !string_is_empty(tmp))
+         if (config_get_string(conf, "required_hw_api", &tmp))
          {
-            core_info[i].required_hw_api = strdup(tmp);
-            core_info[i].required_hw_api_list = string_split(core_info[i].required_hw_api, "|");
+            if (!string_is_empty(tmp))
+            {
+               core_info[i].required_hw_api = strdup(tmp);
+               core_info[i].required_hw_api_list = string_split(core_info[i].required_hw_api, "|");
+            }
 
             free(tmp);
             tmp = NULL;

--- a/gfx/video_shader_parse.c
+++ b/gfx/video_shader_parse.c
@@ -643,6 +643,10 @@ bool video_shader_write_preset(const char *path,
       config_file_t *conf;
       bool ret;
 
+      /* Note: We always create a new/blank config
+       * file here. Loading and updating an existing
+       * file could leave us with unwanted/invalid
+       * parameters. */
       if (!(conf = config_file_new_alloc()))
          return false;
 

--- a/libretro-common/include/file/config_file.h
+++ b/libretro-common/include/file/config_file.h
@@ -59,6 +59,7 @@ struct config_file
    struct config_entry_list *last;
    unsigned include_depth;
    bool guaranteed_no_duplicates;
+   bool modified;
 
    struct config_include_list *includes;
 };

--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -7669,8 +7669,14 @@ static int materialui_pointer_up(void *userdata,
                      menu_navigation_set_selection(ptr);
 
                   /* Perform a MENU_ACTION_SELECT on currently
-                   * active item */
-                  return materialui_menu_entry_action(mui, entry, (size_t)ptr, MENU_ACTION_SELECT);
+                   * active item
+                   * > Note that we still use 'selection'
+                   *   (i.e. old selection value) here. This
+                   *   ensures that materialui_menu_entry_action()
+                   *   registers any change due to the above automatic
+                   *   'pointer item' activation, and thus operates
+                   *   on the correct target entry */
+                  return materialui_menu_entry_action(mui, entry, selection, MENU_ACTION_SELECT);
                }
                else
                {

--- a/retroarch.c
+++ b/retroarch.c
@@ -10592,8 +10592,7 @@ error:
  **/
 static void core_option_manager_flush(
       config_file_t *conf,
-      core_option_manager_t *opt,
-      const char *path)
+      core_option_manager_t *opt)
 {
    size_t i;
 
@@ -28649,21 +28648,30 @@ static void retroarch_deinit_core_options(void)
    if (!runloop_core_options)
       return;
 
-   /* check if game options file was just created and flush
-      to that file instead */
+   /* Check whether game-specific options file is being used */
    if (!path_is_empty(RARCH_PATH_CORE_OPTIONS))
    {
+      const char *path        = path_get(RARCH_PATH_CORE_OPTIONS);
+      config_file_t *conf_tmp = NULL;
+
       /* We only need to save configuration settings for
-       * the current core, so create a temporary config_file
-       * object and populate the required values. */
-      config_file_t *conf_tmp = config_file_new_alloc();
+       * the current core
+       * > If game-specific options file exists, have
+       *   to read it (to ensure file only gets written
+       *   if config values change)
+       * > Otherwise, create a new, empty config_file_t
+       *   object */
+      if (path_is_valid(path))
+         conf_tmp = config_file_new_from_path_to_string(path);
+
+      if (!conf_tmp)
+         conf_tmp = config_file_new_alloc();
 
       if (conf_tmp)
       {
-         const char *path = path_get(RARCH_PATH_CORE_OPTIONS);
          core_option_manager_flush(
                conf_tmp,
-               runloop_core_options, path);
+               runloop_core_options);
          RARCH_LOG("[Core Options]: Saved game-specific core options to \"%s\"\n", path);
          config_file_write(conf_tmp, path, true);
          config_file_free(conf_tmp);
@@ -28676,7 +28684,7 @@ static void retroarch_deinit_core_options(void)
       const char *path = runloop_core_options->conf_path;
       core_option_manager_flush(
             runloop_core_options->conf,
-            runloop_core_options, path);
+            runloop_core_options);
       RARCH_LOG("[Core Options]: Saved core options file to \"%s\"\n", path);
       config_file_write(runloop_core_options->conf, path, true);
    }


### PR DESCRIPTION
## Description

At present, RetroArch continuously overwrites its configuration files:

- `retroarch.cfg` is written every time content is closed, and when closing RetroArch itself

- Core options are written every time content is closed

This represents a large amount of unnecessary disk access, which is quite slow (and also causes wear on solid state drives!)

With this PR, configuration files are only written to disk when the content actually changes.

All types of configuration file should now be 'well behaved' - with the exception of cheat files. These are still overwritten when closing content, since reusing old parameters may cause issues (and since I don't use cheats at all, I didn't feel confident enough to dabble with this)

While making these changes, I discovered and fixed a number of bugs:

- RetroArch no longer crashes when attempting to save a config file after 'unsetting' a parameter (currently, this can be triggered quite easily by manipulating input remaps)

- When using Material UI, RetroArch no longer modifies the wrong setting (or segfaults...) when tapping entries in the Quick Menu > Controls input remapping submenu

- Quite a few real and potential memory leaks have been fixed.

