### PR TITLE
Enable save state compression by default

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -917,7 +917,7 @@ static const bool savestate_thumbnail_enable = false;
 
 /* When creating save state files, compress
  * written data */
-#define DEFAULT_SAVESTATE_FILE_COMPRESSION false
+#define DEFAULT_SAVESTATE_FILE_COMPRESSION true
 
 /* Slowmotion ratio. */
 #define DEFAULT_SLOWMOTION_RATIO 3.0


### PR DESCRIPTION
## Description

This PR just enables save state file compression by default. After testing on a variety of hardware, it seems to improve performance in all cases - so there's no benefit in leaving it turned off.
