### PR TITLE
Update and fix meta.xml file for the WiiU release

### DIFF
--- a/pkg/wiiu/meta.xml
+++ b/pkg/wiiu/meta.xml
@@ -5,7 +5,7 @@
   <version>&version;</version>
   <release_date>20200505133000</release_date>
   <short_description>Front-end for emulators, game engines and media players.</short_description>
-  <long_description>Open-source and free cross-platform Front-end of the libretro API for videogame emulators, game engines, media players and other applications, handled as cores by the Front-end.
+  <long_description>Open-source and free cross-platform front-end of the libretro API for videogame emulators, game engines, media players and other applications, handled as cores by the Front-end.
 
   </long_description>
 

--- a/pkg/wiiu/meta.xml
+++ b/pkg/wiiu/meta.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<!DOCTYPE app [ <!ENTITY % versionDTD SYSTEM "../../version.dtd"> %versionDTD; ]>
 <app version="1">
   <name>Retroarch</name>
   <coder>Libretro</coder>
   <version>&version;</version>
   <release_date>20200505133000</release_date>
-  <short_description></short_description>
-  <long_description>RetroArch
+  <short_description>Front-end for emulators, game engines and media players.</short_description>
+  <long_description>Open-source and free cross-platform Front-end of the libretro API for videogame emulators, game engines, media players and other applications, handled as cores by the Front-end.
+
   </long_description>
 
 </app>


### PR DESCRIPTION
This change makes it so the information from the meta.xml file parsed for the WiiU's Homebrew Launcher is displayed properly.