### PR TITLE
(glcore/slang) Set filter and wrap mode correctly when intialising shader textures

### DIFF
--- a/libretro-common/formats/image_texture.c
+++ b/libretro-common/formats/image_texture.c
@@ -90,8 +90,13 @@ bool image_texture_color_convert(unsigned r_shift,
          uint8_t r    = (uint8_t)(col >> 16);
          uint8_t g    = (uint8_t)(col >>  8);
          uint8_t b    = (uint8_t)(col >>  0);
-         pixels[i]    = (a << a_shift) |
-            (r << r_shift) | (g << g_shift) | (b << b_shift);
+         /* Explicitly cast these to uint32_t to prevent
+          * ASAN runtime error: left shift of 255 by 24 places
+          * cannot be represented in type 'int' */
+         pixels[i]    = ((uint32_t)a << a_shift) |
+                        ((uint32_t)r << r_shift) |
+                        ((uint32_t)g << g_shift) |
+                        ((uint32_t)b << b_shift);
       }
 
       return true;


### PR DESCRIPTION
## Description

At present, the `glcore` shader driver does not correctly initialise loaded textures. The texture filtering and wrap mode are forced on texture creation, but these settings are not recorded - subsequent updates set garbage values, that resolve to linear filtering OFF and wrap mode = `CLAMP_TO_EDGE`.

The wrap mode seems to work regardless - perhaps once this is set the first time, it cannot change? (I don't understand the inner workings of OpenGL...) But the texture filtering is certainly wrong. For example, this is what a background image with linear filtering enabled looks like:

![original](https://user-images.githubusercontent.com/38211560/80733589-d6057280-8b05-11ea-8da8-73c5da76e563.png)

...what you actually get is nearest neighbour.

This PR fixes texture initialisation so the filtering and wrap mode are recorded correctly. A linear filtered background image now looks like this:

![fixed](https://user-images.githubusercontent.com/38211560/80733740-ffbe9980-8b05-11ea-9f54-08e9eb1a4bab.png)

In addition, this PR fixes a bit-shift related ASAN runtime error in `image_texture.c` that was discovered while debugging the `glcore` shader driver.