### PR TITLE
Fix for mayflash N64 adapter

### DIFF
--- a/input/drivers_hid/iohidmanager_hid.c
+++ b/input/drivers_hid/iohidmanager_hid.c
@@ -290,7 +290,7 @@ static void iohidmanager_hid_device_input_callback(void *data, IOReturn result,
                         while (tmp && tmp->cookie != (IOHIDElementCookie)cookie)
                            tmp = tmp->next;
 
-                        if (tmp->cookie == (IOHIDElementCookie)cookie)
+                        if (tmp && tmp->cookie == (IOHIDElementCookie)cookie)
                         {
                            CFIndex min = IOHIDElementGetLogicalMin(element);
                            CFIndex range = IOHIDElementGetLogicalMax(element) - min;


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

For the mayflash N64 adapter, I was getting a BAD EXC ADDRESS (in mac OS 10.13) for this line (tmp was NULL). Retroarch would crash in the gui if I pressed a button from the DPAD on controller 2. With this change, it no longer crashes in the gui and still registers the button push.

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
