### PR TITLE
(3DS) Disable video filter if upscaled resolution exceeds hardware limits

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -22555,6 +22555,21 @@ static void video_driver_init_filter(enum retro_pixel_format colfmt_int)
    pow2_x                              = next_pow2(width);
    pow2_y                              = next_pow2(height);
    maxsize                             = MAX(pow2_x, pow2_y);
+
+#ifdef _3DS
+   /* On 3DS, video is disabled if the output resolution
+    * exceeds 2048x2048. To avoid the user being presented
+    * with a black screen, we therefore have to check that
+    * the filter upscaling buffer fits within this limit. */
+   if (maxsize >= 2048)
+   {
+      RARCH_ERR("[Video]: Softfilter initialization failed."
+            " Upscaling buffer exceeds hardware limitations.\n");
+      video_driver_filter_free();
+      return;
+   }
+#endif
+
    video_driver_state_scale            = maxsize / RARCH_SCALE_BASE;
    video_driver_state_out_rgb32        = rarch_softfilter_get_output_format(
                                          video_driver_state_filter) ==


### PR DESCRIPTION
## Description

The 3DS has a maximum video buffer size of 2048x2048. This is sufficient for every core that it supports, but when using software video filters the core output resolution is doubled. This is made worse by the fact that the video filter upscaling buffer size is dependent upon the *maximum* output resolution of the core - which in some cases is very large indeed (e.g. pcsx-rearmed sets a maximum width of 1024, for enhanced resolution support). The 3DS has very limited 'linear memory' for graphics buffer purposes, and a large base core buffer + video filter buffer can easily exceed this - which may also disable video output, or cause a crash.

This PR very simply adds a 3DS-specific check to the video filter initialisation: if the resultant upscaling buffer exceeds the hardware limitation, then the filter is automatically disabled.

Notable benefits:

- The nestopia core no longer crashes when launching content with a video filter enabled

- The pcsx-rearmed core no longer produces a black screen when a video filter is enabled
