### PR TITLE
(3DS) Fix font driver

### DIFF
--- a/gfx/drivers_font/ctr_font.c
+++ b/gfx/drivers_font/ctr_font.c
@@ -243,7 +243,7 @@ static void ctr_font_render_line(
                  GPU_TEVSOURCES(GPU_TEXTURE0, GPU_CONSTANT, 0),
                  GPU_TEVSOURCES(GPU_TEXTURE0, GPU_CONSTANT, 0),
                  0,
-                 GPU_TEVOPERANDS(GPU_TEVOP_RGB_SRC_R, GPU_TEVOP_RGB_SRC_ALPHA, 0),
+                 GPU_TEVOPERANDS(GPU_TEVOP_RGB_SRC_ALPHA, 0, 0),
                  GPU_MODULATE, GPU_MODULATE,
                  color);
 
@@ -329,7 +329,7 @@ static void ctr_font_render_message(
       return;
    }
 
-   line_height = scale / line_metrics->height;
+   line_height = (float)line_metrics->height * scale / (float)height;
 
    for (;;)
    {
@@ -397,7 +397,7 @@ static void ctr_font_render_msg(
       b                    = FONT_COLOR_GET_BLUE(params->color);
       alpha                = FONT_COLOR_GET_ALPHA(params->color);
 
-      color                = params->color;
+      color                = COLOR_ABGR(r, g, b, alpha);
    }
    else
    {
@@ -412,10 +412,10 @@ static void ctr_font_render_msg(
       alpha          = 255;
       color          = COLOR_ABGR(r, g, b, alpha);
 
-      drop_x         = -2;
-      drop_y         = -2;
-      drop_mod       = 0.3f;
-      drop_alpha     = 1.0f;
+      drop_x         = 1;
+      drop_y         = -1;
+      drop_mod       = 0.0f;
+      drop_alpha     = 0.75f;
    }
 
    max_glyphs        = strlen(msg);


### PR DESCRIPTION
## Description

The 3DS font driver is currently somewhat broken:

- Text colour is wrong: the `RGBA` channels are muddled, and `R` is always set to `255`

- When drawing multiline strings, the line spacing is completely incorrect

This PR fixes both issues, and also improves the appearance of the drop shadow effect on notification text.