### PR TITLE
retroarch.cfg: add cheevos related configs

### DIFF
--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -845,6 +845,41 @@
 # will be extracted to this directory.
 # cache_directory =
 
+#### RetroAchievements
+
+# Enable the RetroAchievements feature.
+# cheevos_enable = false
+
+# RetroAchievements.org credentials.
+# cheevos_username = 
+# cheevos_password = 
+
+# The hardcore mode disables savestates and cheating features, but it
+# makes the achievements points double.
+# cheevos_hardcore_mode_enable = false
+
+# Show RetroAchievements related messages right after loading a game, such as
+# successfull login and the number of cheevos you have unlocked for the game.
+# cheevos_verbose_enable = false
+
+# Show achievements' badges in Quick Menu > Achievements List.
+# (note: has no effect if menu_driver = rgui).
+# cheevos_badges_enable = false
+
+# Take a screenshot when an achievement is triggered.
+# cheevos_auto_screenshot = false
+
+# Besides achievements, some games also have leaderboards, where you can
+# compete for high-scores, speedruns, etc.
+# cheevos_leaderboards_enable = false
+
+# Send some messages to the RetroAchievements.org saying, for example,
+# where you are in the game, how many lives you have, your score, etc.
+# cheevos_richpresence_enable = false
+
+# Unnoficial achievements are used only for achievement creators and testers.
+# cheevos_test_unofficial = false
+
 #### Misc
 
 # Enable rewinding. This will take a performance hit when playing, so it is disabled by default.
@@ -913,3 +948,4 @@
 
 # Enable device vibration for supported cores
 # enable_device_vibration = false
+


### PR DESCRIPTION
Nothing being actually changed.

Just added all the cheevos related configs currently available and a brief explanation of what they do, for those who like to edit the `retroarch.cfg` by hand.
