### PR TITLE
(3DS) Enable basic networking / cheevos

### DIFF
--- a/Makefile.ctr
+++ b/Makefile.ctr
@@ -52,7 +52,8 @@ ifeq ($(GRIFFIN_BUILD), 1)
 	OBJ += griffin/griffin.o
 	DEFINES += -DHAVE_GRIFFIN=1 -DHAVE_MENU -DHAVE_CONFIGFILE -DHAVE_RGUI -DHAVE_XMB -DHAVE_MATERIALUI -DHAVE_LIBRETRODB -DHAVE_CC_RESAMPLER
 	DEFINES += -DHAVE_ZLIB -DHAVE_7ZIP -DHAVE_RPNG -DHAVE_RJPEG -DHAVE_RBMP -DHAVE_RTGA
-	#DEFINES += -DHAVE_NETWORKING -DHAVE_CHEEVOS -DRC_DISABLE_LUA -DHAVE_SOCKET_LEGACY -DHAVE_THREADS
+	DEFINES += -DHAVE_NETWORKING -DHAVE_CHEEVOS -DRC_DISABLE_LUA
+	#DEFINES += -DHAVE_SOCKET_LEGACY -DHAVE_THREADS
 	#-DHAVE_SSL -DHAVE_BUILTINMBEDTLS -DMBEDTLS_SSL_DEBUG_ALL
 	#ssl is currently incompatible with griffin due to use of the "static" flag on repeating functions that will conflict when included in one file
 else
@@ -135,6 +136,7 @@ CFLAGS += -I. \
 			 -Ideps \
 			 -Ideps/7zip \
 			 -Ideps/stb \
+			 -Ideps/rcheevos/include \
 			 -Ilibretro-common/include \
 			 -Ilibretro-common/include/compat/zlib
 

--- a/config.def.h
+++ b/config.def.h
@@ -539,11 +539,15 @@ static const bool content_show_music        = true;
 #if defined(HAVE_FFMPEG) || defined(HAVE_MPV)
 static const bool content_show_video        = true;
 #endif
-#ifdef HAVE_NETWORKING
+#if defined(HAVE_NETWORKING)
+#if defined(_3DS)
+static const bool content_show_netplay      = false;
+#else
 static const bool content_show_netplay      = true;
 #endif
+#endif
 static const bool content_show_history      = true;
-static const bool content_show_add     	  = true;
+static const bool content_show_add     	    = true;
 static const bool content_show_playlists    = true;
 
 #ifdef HAVE_XMB

--- a/libretro-common/include/net/net_natt.h
+++ b/libretro-common/include/net/net_natt.h
@@ -50,7 +50,7 @@ struct natt_status
    /** True if we've resolved an external IPv6 address */
    bool have_inet6;
 
-#if defined(AF_INET6) && !defined(HAVE_SOCKET_LEGACY)
+#if defined(AF_INET6) && !defined(HAVE_SOCKET_LEGACY) && !defined(_3DS)
    /** External IPv6 address */
    struct sockaddr_in6 ext_inet6_addr;
 #endif

--- a/libretro-common/net/net_ifinfo.c
+++ b/libretro-common/net/net_ifinfo.c
@@ -38,7 +38,7 @@
 #ifdef WANT_IFADDRS
 #include <compat/ifaddrs.h>
 #else
-#ifndef HAVE_LIBNX
+#if !defined HAVE_LIBNX && !defined(_3DS)
 #include <ifaddrs.h>
 #endif
 #endif
@@ -73,7 +73,7 @@ void net_ifinfo_free(net_ifinfo_t *list)
    free(list->entries);
 }
 
-#ifdef HAVE_LIBNX
+#if defined(HAVE_LIBNX) || defined(_3DS)
 static void convert_ip(char *dst, size_t size, uint32_t ip, bool inverted)
 {
    unsigned char bytes[4];
@@ -92,7 +92,7 @@ static void convert_ip(char *dst, size_t size, uint32_t ip, bool inverted)
 bool net_ifinfo_new(net_ifinfo_t *list)
 {
    unsigned k              = 0;
-#ifdef HAVE_LIBNX
+#if defined(HAVE_LIBNX) || defined(_3DS)
    uint32_t id;
    Result rc;
 
@@ -123,12 +123,16 @@ bool net_ifinfo_new(net_ifinfo_t *list)
       can be wlan or eth (with a wiiu adapter)
       so we just use "switch" as a name
    */
+#if defined(_3DS)
+   convert_ip(hostname, sizeof(hostname), gethostid(), true);
+#else
    rc = nifmGetCurrentIpAddress(&id);
 
    if (!R_SUCCEEDED(rc)) /* not connected to any network */
       return true;
 
    convert_ip(hostname, sizeof(hostname), id, true);
+#endif
 
    ptr = (struct net_ifinfo_entry*)
          realloc(list->entries, (k+1) * sizeof(struct net_ifinfo_entry));
@@ -137,8 +141,11 @@ bool net_ifinfo_new(net_ifinfo_t *list)
       goto error;
 
    list->entries          = ptr;
-
+#if defined(_3DS)
+   list->entries[k].name  = strdup("wlan");
+#else
    list->entries[k].name  = strdup("switch");
+#endif
    list->entries[k].host  = strdup(hostname);
    list->size             = k + 1;
 
@@ -242,7 +249,7 @@ error:
 #ifdef _WIN32
    if (adapter_addresses)
       free(adapter_addresses);
-#elif !defined(HAVE_LIBNX)
+#elif !defined(HAVE_LIBNX) && !defined(_3DS)
    freeifaddrs(ifaddr);
 #endif
    net_ifinfo_free(list);

--- a/network/netplay/netplay_discovery.c
+++ b/network/netplay/netplay_discovery.c
@@ -51,7 +51,7 @@
 #include "netplay_discovery.h"
 #include "netplay_private.h"
 
-#if defined(AF_INET6) && !defined(HAVE_SOCKET_LEGACY)
+#if defined(AF_INET6) && !defined(HAVE_SOCKET_LEGACY) && !defined(_3DS)
 #define HAVE_INET6 1
 #endif
 

--- a/network/netplay/netplay_handshake.c
+++ b/network/netplay/netplay_handshake.c
@@ -42,7 +42,7 @@ const uint32_t netplay_magic = 0x52414E50; /* RANP */
 /* TODO/FIXME - replace netplay_log_connection with calls
  * to inet_ntop_compat and move runloop message queue pushing
  * outside */
-#if !defined(HAVE_SOCKET_LEGACY) && !defined(WIIU)
+#if !defined(HAVE_SOCKET_LEGACY) && !defined(WIIU) && !defined(_3DS)
 /* Custom inet_ntop. Win32 doesn't seem to support this ... */
 void netplay_log_connection(const struct sockaddr_storage *their_addr,
       unsigned slot, const char *nick, char *s, size_t len)

--- a/network/netplay/netplay_init.c
+++ b/network/netplay/netplay_init.c
@@ -33,7 +33,7 @@
 #include "../../autosave.h"
 #include "../../retroarch.h"
 
-#if defined(AF_INET6) && !defined(HAVE_SOCKET_LEGACY)
+#if defined(AF_INET6) && !defined(HAVE_SOCKET_LEGACY) && !defined(_3DS)
 #define HAVE_INET6 1
 #endif
 


### PR DESCRIPTION
Enable basic networking on the 3DS.

Current implementation allows us to:
- earn achievements (CHEEVOS)
- download thumbnails / boxart for playlists
- display basic ip info

Netplay is not functional.
- Netplay menu is disabled by default