### PR TITLE
Use GenericName correctly in desktop entry

### DIFF
--- a/retroarch.desktop
+++ b/retroarch.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Name=RetroArch
-GenericName=RetroArch
+GenericName=Frontend for the libretro API
 Type=Application
 Comment=Frontend for emulators, game engines and media players
 Comment[ru]=Графический интерфейс для эмуляторов, игровых движков и медиаплееров


### PR DESCRIPTION
## Description

`GenericName` is being used wrongly. This pull request changes what the `GenericName` is in the Linux desktop entry file. The reason is that `GenericName` should be generic, in this case `Frontend for the libretro API` since that's what RetroArch is;

> - The `Name` key should only contain the name, or maybe an abbreviation/acronym if available.
> - `GenericName` should state what you would generally call an application that does what this specific application offers (i.e. Firefox is a "Web Browser").
> - `Comment` is intended to contain any useful additional information.

_[wiki.archlinux.org/Desktop_entries#Key_definition](https://wiki.archlinux.org/index.php/Desktop_entries#Key_definition)_

I am open to other suggestions for `GenericName`. Considering the comment says `Frontend for emulators`, maybe this can be used instead. `Name` and `GenericName` is what for example **rofi** shows