### PR TITLE
cocoa: fix cursor tracking

### DIFF
--- a/input/drivers/cocoa_input.c
+++ b/input/drivers/cocoa_input.c
@@ -192,35 +192,41 @@ static void cocoa_input_poll(void *data)
       apple->joypad->poll();
    if (apple->sec_joypad)
        apple->sec_joypad->poll();
-
-    apple->mouse_x_last = apple->mouse_rel_x;
-    apple->mouse_y_last = apple->mouse_rel_y;
 }
 
 static int16_t cocoa_mouse_state(cocoa_input_data_t *apple,
       unsigned id)
 {
-   switch (id)
-   {
-      case RETRO_DEVICE_ID_MOUSE_X:
-           return apple->mouse_rel_x - apple->mouse_x_last;
-      case RETRO_DEVICE_ID_MOUSE_Y:
-         return apple->mouse_rel_y - apple->mouse_y_last;
-      case RETRO_DEVICE_ID_MOUSE_LEFT:
-         return apple->mouse_buttons & 1;
-      case RETRO_DEVICE_ID_MOUSE_RIGHT:
-         return apple->mouse_buttons & 2;
-       case RETRO_DEVICE_ID_MOUSE_WHEELUP:
-           return apple->mouse_wu;
-       case RETRO_DEVICE_ID_MOUSE_WHEELDOWN:
-           return apple->mouse_wd;
-       case RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELUP:
-           return apple->mouse_wl;
-       case RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELDOWN:
-           return apple->mouse_wr;
-   }
+  int16_t val;
+  switch (id)
+  {
+     case RETRO_DEVICE_ID_MOUSE_X:
+        val = apple->mouse_rel_x;
+        // NOTE: Because cocoa events are effectively handled async we reset
+        // the delta which we cumulate on each event
+        apple->mouse_rel_x = 0;
+        return val;
+     case RETRO_DEVICE_ID_MOUSE_Y:
+        val = apple->mouse_rel_y;
+        // NOTE: Because cocoa events are effectively handled async we reset
+        // the delta which we cumulate on each event
+        apple->mouse_rel_y = 0;
+        return val;
+     case RETRO_DEVICE_ID_MOUSE_LEFT:
+          return apple->mouse_buttons & 1;
+     case RETRO_DEVICE_ID_MOUSE_RIGHT:
+          return apple->mouse_buttons & 2;
+      case RETRO_DEVICE_ID_MOUSE_WHEELUP:
+          return apple->mouse_wu;
+      case RETRO_DEVICE_ID_MOUSE_WHEELDOWN:
+          return apple->mouse_wd;
+      case RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELUP:
+          return apple->mouse_wl;
+      case RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELDOWN:
+          return apple->mouse_wr;
+  }
 
-   return 0;
+  return 0;
 }
 
 static int16_t cocoa_mouse_state_screen(cocoa_input_data_t *apple,

--- a/ui/drivers/ui_cocoa.m
+++ b/ui/drivers/ui_cocoa.m
@@ -131,26 +131,26 @@ static void app_terminate(void)
             pos.x              = 0;
             pos.y              = 0;
 
-            /* Relative */
-            apple->mouse_rel_x += (int16_t)event.deltaX;
-            apple->mouse_rel_y += (int16_t)event.deltaY;
-
-            /* Absolute */
 #if defined(HAVE_COCOA_METAL)
             pos = [apple_platform.renderView convertPoint:[event locationInWindow] fromView:nil];
 #elif defined(HAVE_COCOA)
             pos = [[CocoaView get] convertPoint:[event locationInWindow] fromView:nil];
 #endif
+
+            NSInteger window_number = [[[NSApplication sharedApplication] keyWindow] windowNumber];
+            if ([NSWindow windowNumberAtPoint:pos belowWindowWithWindowNumber:0] != window_number) {
+              return;
+            }
+
+            /* Relative */
+            apple->mouse_rel_x += (int16_t)event.deltaX;
+            apple->mouse_rel_y += (int16_t)event.deltaY;
+
+            /* Absolute */
             apple->touches[0].screen_x = (int16_t)pos.x;
             apple->touches[0].screen_y = (int16_t)pos.y;
-
-#if defined(HAVE_COCOA_METAL)
-            mouse_pos = [apple_platform.renderView convertPoint:[event locationInWindow]  fromView:nil];
-#elif defined(HAVE_COCOA)
-            mouse_pos = [[CocoaView get] convertPoint:[event locationInWindow]  fromView:nil];
-#endif
-            apple->window_pos_x = (int16_t)mouse_pos.x;
-            apple->window_pos_y = (int16_t)mouse_pos.y;
+            apple->window_pos_x = (int16_t)pos.x;
+            apple->window_pos_y = (int16_t)pos.y;
          }
          break;
 #if defined(HAVE_COCOA_METAL)

--- a/ui/drivers/ui_cocoa.m
+++ b/ui/drivers/ui_cocoa.m
@@ -132,8 +132,8 @@ static void app_terminate(void)
             pos.y              = 0;
 
             /* Relative */
-            apple->mouse_rel_x = (int16_t)event.deltaX;
-            apple->mouse_rel_y = (int16_t)event.deltaY;
+            apple->mouse_rel_x += (int16_t)event.deltaX;
+            apple->mouse_rel_y += (int16_t)event.deltaY;
 
             /* Absolute */
 #if defined(HAVE_COCOA_METAL)


### PR DESCRIPTION
This is a follow up PR for #10168 that fixes cursor positioning not being handled correctly. I also updated cocoa mouse tracking so that events are only handled when we are inside the focused window. Due to the async nature of the current implementation and other drawing bugs, the cursor can come out of sync but I believe that should be addressed in an additional PR as this brings mouse support back to where it should be.