### PR TITLE
cocoa: disable clipping cursor to window

### DIFF
--- a/input/drivers/cocoa_input.c
+++ b/input/drivers/cocoa_input.c
@@ -201,16 +201,12 @@ static int16_t cocoa_mouse_state(cocoa_input_data_t *apple,
   switch (id)
   {
      case RETRO_DEVICE_ID_MOUSE_X:
-        val = apple->mouse_rel_x;
-        // NOTE: Because cocoa events are effectively handled async we reset
-        // the delta which we cumulate on each event
-        apple->mouse_rel_x = 0;
+        val = apple->window_pos_x - apple->mouse_x_last;
+        apple->mouse_x_last = apple->window_pos_x;
         return val;
      case RETRO_DEVICE_ID_MOUSE_Y:
-        val = apple->mouse_rel_y;
-        // NOTE: Because cocoa events are effectively handled async we reset
-        // the delta which we cumulate on each event
-        apple->mouse_rel_y = 0;
+        val = apple->window_pos_y - apple->mouse_y_last;
+        apple->mouse_y_last = apple->window_pos_y;
         return val;
      case RETRO_DEVICE_ID_MOUSE_LEFT:
           return apple->mouse_buttons & 1;

--- a/ui/drivers/ui_cocoa.m
+++ b/ui/drivers/ui_cocoa.m
@@ -137,10 +137,11 @@ static void app_terminate(void)
             pos = [[CocoaView get] convertPoint:[event locationInWindow] fromView:nil];
 #endif
 
-            NSInteger window_number = [[[NSApplication sharedApplication] keyWindow] windowNumber];
-            if ([NSWindow windowNumberAtPoint:pos belowWindowWithWindowNumber:0] != window_number) {
-              return;
-            }
+            // FIXME: Disable clipping until graphical offset issues are fixed
+            //NSInteger window_number = [[[NSApplication sharedApplication] keyWindow] windowNumber];
+            //if ([NSWindow windowNumberAtPoint:pos belowWindowWithWindowNumber:0] != window_number) {
+            //  return;
+            //}
 
             /* Relative */
             apple->mouse_rel_x += (int16_t)event.deltaX;


### PR DESCRIPTION
Apologies for the quick follow up to the previous PR, but due to how RetroArch is manipulating elements in the NSWindow which I am unable to deduce right now, clipping is actually causing more problems then it is solve. Thus this PR disables it.