### PR TITLE
(cheevos) make sure texture pointer is null when load fails

### DIFF
--- a/cheevos-new/badges.c
+++ b/cheevos-new/badges.c
@@ -54,7 +54,7 @@ void cheevos_set_menu_badge(int index, const char *badge, bool locked)
 uintptr_t cheevos_get_menu_badge_texture(int index)
 {
    if (index < CHEEVOS_MENU_BADGE_LIMIT)
-       return cheevos_badge_menu_texture_list[index];
+      return cheevos_badge_menu_texture_list[index];
 
    return 0;
 }
@@ -65,7 +65,7 @@ uintptr_t cheevos_get_badge_texture(const char *badge, bool locked)
 {
    char badge_file[24];
    char fullpath[PATH_MAX_LENGTH];
-   uintptr_t tex;
+   uintptr_t tex = 0;
 
    if (!badge)
       return 0;
@@ -76,8 +76,9 @@ uintptr_t cheevos_get_badge_texture(const char *badge, bool locked)
       PATH_MAX_LENGTH * sizeof(char),
       APPLICATION_SPECIAL_DIRECTORY_THUMBNAILS_CHEEVOS_BADGES);
 
-   gfx_display_reset_textures_list(badge_file, fullpath,
-      &tex, TEXTURE_FILTER_MIPMAP_LINEAR, NULL, NULL);
+   if (!gfx_display_reset_textures_list(badge_file, fullpath,
+      &tex, TEXTURE_FILTER_MIPMAP_LINEAR, NULL, NULL))
+      tex = 0;
 
    return tex;
 }


### PR DESCRIPTION
## Description

Fixes #10616 . When the badge texture file is not available, the `tex` variable was left uninitialized. While generally not good, this was actually causing the vulkan driver to crash if the user tried to view the achievements list before the images were fully downloaded.

## Related Issues

#10616

## Related Pull Requests

n/a

## Reviewers

[If possible @mention all the people that should review your pull request]
