### PR TITLE
Adjusted menu defaults

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -517,8 +517,8 @@ static const bool menu_show_sublabels          = true;
 
 static const bool menu_scroll_fast             = false;
 
-#define DEFAULT_MENU_TICKER_TYPE                 (TICKER_TYPE_BOUNCE)
-static const float menu_ticker_speed           = 1.0f;
+#define DEFAULT_MENU_TICKER_TYPE                 (TICKER_TYPE_LOOP)
+static const float menu_ticker_speed           = 2.0f;
 
 #define DEFAULT_MENU_TICKER_SMOOTH true
 

--- a/configuration.c
+++ b/configuration.c
@@ -1454,7 +1454,7 @@ static struct config_bool_setting *populate_settings_bool(settings_t *settings, 
 #ifdef HAVE_MENU
    SETTING_BOOL("menu_unified_controls",         &settings->bools.menu_unified_controls, true, false, false);
    SETTING_BOOL("menu_throttle_framerate",       &settings->bools.menu_throttle_framerate, true, true, false);
-   SETTING_BOOL("menu_linear_filter",            &settings->bools.menu_linear_filter, true, true, false);
+   SETTING_BOOL("menu_linear_filter",            &settings->bools.menu_linear_filter, true, DEFAULT_VIDEO_SMOOTH, false);
    SETTING_BOOL("menu_horizontal_animation",     &settings->bools.menu_horizontal_animation, true, DEFAULT_MENU_HORIZONTAL_ANIMATION, false);
    SETTING_BOOL("menu_pause_libretro",           &settings->bools.menu_pause_libretro, true, true, false);
    SETTING_BOOL("menu_savestate_resume",         &settings->bools.menu_savestate_resume, true, menu_savestate_resume, false);


### PR DESCRIPTION
## Description

I have adjusted the menu defaults:
```
menu_ticker_type = TICKER_TYPE_LOOP
```
the current default of `TICKER_TYPE_BOUNCE` bounces the text from left to right, which is basically unreadable during its return journey, especially on RGUI where you don't see a lot of the string at once. `TICKER_TYPE_LOOP` scrolls from left-to-right in a loop, which is much more readable. ideally there would be a `TICKER_TYPE_LOOP_REVERSE` which defaulted for languages that read right-to-left, but i see that is a to-do: https://github.com/libretro/RetroArch/blob/master/gfx/gfx_animation.h#L93
```
menu_ticker_speed = 2
```
this increases the speed of the scrolling from the default of 1, which was painfully slow on RGUI. i've tested it in XMB and 2 seems fine there, also.
```
menu_linear_filter= DEFAULT_VIDEO_SMOOTH
```
this setting only affects RGUI. instead of defaulting to true, now it uses the default for `video_smooth`, making it consistent in appearance to the content. `DEFAULT_VIDEO_SMOOTH` is normally false apart from on certain low resolution devices: https://github.com/libretro/RetroArch/blob/7b8983a0e0ad0b250ef5a3b8bdf514eaa2dd0a2c/config.def.h#L337

## Reviewers

@jdgleaver 
