### PR TITLE
Fallback directories for shader presets

### DIFF
--- a/menu/menu_shader.c
+++ b/menu/menu_shader.c
@@ -400,14 +400,13 @@ static bool menu_shader_manager_operate_auto_preset(
          {
             /* remove all supported auto-shaders of given type */
             char *end;
-            size_t i, j;
-            size_t n, m;
-
-            n = m = 0;
+            size_t i, j, n, m;
 
             const char *dirs[3] = {0};
             char config_directory[PATH_MAX_LENGTH];
             char preset_path[PATH_MAX_LENGTH];
+
+            n = m = 0;
 
             config_directory[0] = '\0';
 

--- a/menu/menu_shader.c
+++ b/menu/menu_shader.c
@@ -290,8 +290,8 @@ static bool menu_shader_manager_save_preset_internal(
                path_get(RARCH_PATH_CONFIG),
                sizeof(config_directory));
 
-      dirs[0] = dir_video_shader;
-      dirs[1] = dir_menu_config;
+      dirs[0] = dir_menu_config;
+      dirs[1] = dir_video_shader;
       dirs[2] = config_directory;
 
       for (i = 0; i < ARRAY_SIZE(dirs); i++)
@@ -417,8 +417,8 @@ static bool menu_shader_manager_operate_auto_preset(
                      path_get(RARCH_PATH_CONFIG),
                      sizeof(config_directory));
 
-            dirs[0] = dir_video_shader;
-            dirs[1] = dir_menu_config;
+            dirs[0] = dir_menu_config;
+            dirs[1] = dir_video_shader;
             dirs[2] = config_directory;
 
             for (i = 0; i < ARRAY_SIZE(dirs); i++)
@@ -474,8 +474,8 @@ static bool menu_shader_manager_operate_auto_preset(
                      path_get(RARCH_PATH_CONFIG),
                      sizeof(config_directory));
 
-            dirs[0] = dir_video_shader;
-            dirs[1] = dir_menu_config;
+            dirs[0] = dir_menu_config;
+            dirs[1] = dir_video_shader;
             dirs[2] = config_directory;
 
             for (i = 0; i < ARRAY_SIZE(dirs); i++)

--- a/retroarch.c
+++ b/retroarch.c
@@ -27321,8 +27321,8 @@ static bool retroarch_load_shader_preset_internal(
  * $SHADER_DIR is composed by three different locations which will be searched
  * in the following order (search will stop on first match):
  *
- * 1. The Video Shader directory
- * 2. The Menu Config directory
+ * 1. The Menu Config directory
+ * 2. The Video Shader directory
  * 3. The directory where the configuration file is stored
  *
  * Note: Uses video_shader_is_supported() which only works after
@@ -27376,8 +27376,8 @@ static bool retroarch_load_shader_preset(void)
       fill_pathname_basedir(config_file_directory,
             path_get(RARCH_PATH_CONFIG), PATH_MAX_LENGTH);
 
-   dirs[0] = video_shader_directory;
-   dirs[1] = menu_config_directory;
+   dirs[0] = menu_config_directory;
+   dirs[1] = video_shader_directory;
    dirs[2] = config_file_directory;
 
    for (i = 0; i < ARRAY_SIZE(dirs); i++)


### PR DESCRIPTION
## Description

The first commit of this patch allows to use the Menu Config and config file directories as fallback to store shader presets when the Video Shader directory is not writable by the user, thus following the same behavior shown by the "Save shader as" menu option.

This fixes #8901 and is a potential alternate solution for #7551, allowing users to handle their own presets without having to mess with the directory configuration on distros such as ArchLinux, where shaders (among other assets) are managed through additional packages.

The second commit of this patch goes a bit further and changes the order of the preset directories, searching first on the Menu Config path, then on the Video Shader path, and finally on the directory of the config file.

This would improve the portability of the configuration for Android users, because they cannot explore the default shaders directory without rooting their devices. Moreover, I think it makes more sense, as regular configuration overrides are already being stored on the Menu Config path by default.


## Testing

Assuming these directory values:

- menu_config: /home/johanbcn/.config/retroarch/config/ (non-writable for testing purposes)
- video_shaders: /home/johanbcn/.local/share/libretro/shaders/ (non-writable)
- retroarch.cfg: /home/johanbcn/.config/retroarch/retroarch.cfg

I successfully tested the following menu options (see appended log output).

### Save options

#### Save Shader Preset As

[WARN] Failed writing shader preset to /home/johanbcn/.config/retroarch/config/foobar.glslp.
[WARN] Failed writing shader preset to /home/johanbcn/.local/share/libretro/shaders/foobar.glslp.
[INFO] Saved shader preset to /home/johanbcn/.config/retroarch/foobar.glslp.


#### Save Global Preset

[WARN] Failed to create preset directory /home/johanbcn/.config/retroarch/config/presets/.
[WARN] Failed to create preset directory /home/johanbcn/.local/share/libretro/shaders/presets/.
[INFO] Saved shader preset to /home/johanbcn/.config/retroarch/presets/global.glslp.


#### Save Core Preset

[WARN] Failed to create preset directory /home/johanbcn/.config/retroarch/config/presets/Snes9x/.
[WARN] Failed to create preset directory /home/johanbcn/.local/share/libretro/shaders/presets/Snes9x/.
[INFO] Saved shader preset to /home/johanbcn/.config/retroarch/presets/Snes9x/Snes9x.glslp.


#### Save Content Directory Preset

[WARN] Failed to create preset directory /home/johanbcn/.config/retroarch/config/presets/Snes9x/.
[WARN] Failed to create preset directory /home/johanbcn/.local/share/libretro/shaders/presets/Snes9x/.
[INFO] Saved shader preset to /home/johanbcn/.config/retroarch/presets/Snes9x/SNES.glslp.


#### Save Game Preset

[WARN] Failed to create preset directory /home/johanbcn/.config/retroarch/config/presets/Snes9x/.
[WARN] Failed to create preset directory /home/johanbcn/.local/share/libretro/shaders/presets/Snes9x/.
[INFO] Saved shader preset to /home/johanbcn/.config/retroarch/presets/Snes9x/Legend of Zelda, The - A Link to the Past (USA).glslp.


### Apply Changes option

[WARN] Failed writing shader preset to /home/johanbcn/.config/retroarch/config/retroarch.glslp.
[WARN] Failed writing shader preset to /home/johanbcn/.local/share/libretro/shaders/retroarch.glslp.
[INFO] Saved shader preset to /home/johanbcn/.config/retroarch/retroarch.glslp.


### Run content log output

#### Game specific shader preset found on fallback directory

[INFO] [Shaders]: preset directory: /home/johanbcn/.config/retroarch/config/presets
[INFO] [Shaders]: preset directory: /home/johanbcn/.local/share/libretro/shaders/presets
[INFO] [Shaders]: preset directory: /home/johanbcn/.config/retroarch/presets
[INFO] [Shaders]: Specific shader preset found at /home/johanbcn/.config/retroarch/presets/Snes9x/Legend of Zelda, The - A Link to the Past (USA).glslp.
[INFO] [Shaders]: game-specific shader preset found.


#### Folder specific shader preset found on fallback directory

[INFO] [Shaders]: preset directory: /home/johanbcn/.config/retroarch/config/presets
[INFO] [Shaders]: preset directory: /home/johanbcn/.local/share/libretro/shaders/presets
[INFO] [Shaders]: preset directory: /home/johanbcn/.config/retroarch/presets
[INFO] [Shaders]: Specific shader preset found at /home/johanbcn/.config/retroarch/presets/Snes9x/SNES.glslp.
[INFO] [Shaders]: folder-specific shader preset found.


#### Core specific shader preset found on fallback directory

[INFO] [Shaders]: preset directory: /home/johanbcn/.config/retroarch/config/presets
[INFO] [Shaders]: preset directory: /home/johanbcn/.local/share/libretro/shaders/presets
[INFO] [Shaders]: preset directory: /home/johanbcn/.config/retroarch/presets
[INFO] [Shaders]: Specific shader preset found at /home/johanbcn/.config/retroarch/presets/Snes9x/Snes9x.glslp.
[INFO] [Shaders]: core-specific shader preset found.


#### Global shader preset found on fallback directory

[INFO] [Shaders]: preset directory: /home/johanbcn/.config/retroarch/config/presets
[INFO] [Shaders]: preset directory: /home/johanbcn/.local/share/libretro/shaders/presets
[INFO] [Shaders]: preset directory: /home/johanbcn/.config/retroarch/presets
[INFO] [Shaders]: Specific shader preset found at /home/johanbcn/.config/retroarch/presets/global.glslp.
[INFO] [Shaders]: global shader preset found.


### Remove options

#### Remove Global Preset

[INFO] Deleted shader preset from /home/johanbcn/.config/retroarch/presets/global.glslp.


#### Remove Core Preset

[INFO] Deleted shader preset from /home/johanbcn/.config/retroarch/presets/Snes9x/Snes9x.glslp.


#### Remove Content Directory Preset

[INFO] Deleted shader preset from /home/johanbcn/.config/retroarch/presets/Snes9x/SNES.glslp.


#### Remove Game Preset

[INFO] Deleted shader preset from /home/johanbcn/.config/retroarch/presets/Snes9x/Legend of Zelda, The - A Link to the Past (USA).glslp.
