### PR TITLE
Disable 'Use Global Core Options File' by default

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -614,7 +614,7 @@ static const bool rgui_extended_ascii = false;
 static const bool default_game_specific_options = true;
 static const bool default_auto_overrides_enable = true;
 static const bool default_auto_remaps_enable = true;
-static const bool default_global_core_options = true;
+static const bool default_global_core_options = false;
 static const bool default_auto_shaders_enable = true;
 
 static const bool default_sort_savefiles_enable = false;


### PR DESCRIPTION
## Description

This PR just changes the default setting of `Use Global Core Options File` to `OFF`.

This was only set to `ON` by default for consistency with legacy setups. There is no material benefit to this - in fact, a global core options file has the following downsides:

- More file IO - *all* options have to be read/written every time content is loaded or options are saved

- Difficultly in editing option values by hand - e.g. sometimes this is necessary if a particular setting causes a core to crash, and if options for all cores are bundled together then sifting through them to find the one you need becomes a chore

- Obsolescence - settings for old/unused/outdated cores hang around forever, and bloat the global options file without purpose. With per-core options, it is easy to remove settings for unwanted cores

Since settings are automatically imported from the legacy global file on first run when per-core files are enabled, changing the default behaviour will not harm any existing installation.

