### PR TITLE
Don't perform unnecessary cheevos initialisation when cheevos are disabled

### DIFF
--- a/cheevos-new/cheevos.c
+++ b/cheevos-new/cheevos.c
@@ -2921,11 +2921,13 @@ bool rcheevos_load(const void *data)
    retro_task_t *task                 = NULL;
    const struct retro_game_info *info = NULL;
    rcheevos_coro_t *coro              = NULL;
+   settings_t *settings               = config_get_ptr();
+   bool cheevos_enable                = settings && settings->bools.cheevos_enable;
 
    rcheevos_loaded                    = false;
    rcheevos_hardcore_paused           = false;
 
-   if (!rcheevos_locals.core_supports || !data)
+   if (!cheevos_enable || !rcheevos_locals.core_supports || !data)
    {
       rcheevos_hardcore_paused        = true;
       return false;


### PR DESCRIPTION
## Description

At present, on all platforms with cheevos support `rcheevos_load()` is called each time content is loaded. This means the following happens *even when cheevos are disabled*:

- If the core does not require the full content path (i.e. if RetroArch passes a data buffer directly), then a copy of the content data is made (up to 64 MB in size)

- If the content is an m3u file, the file is opened and parsed to get the extension of the first file listed inside

- A checksum is calculated for the content file extension

- A task is pushed

- A mutex is locked/unlocked several times

When cheevos are disabled, all these things are unnecessary work, causing increased loading times and memory usage. On platforms with low memory (i.e. consoles) the unnecessary content data duplication is potentially harmful and may cause crashes.

This PR very simply adds an 'early out' to `rcheevos_load()` which prevents the above unnecessary work when cheevos are disabled.