### PR TITLE
return false when special track cannot be found

### DIFF
--- a/libretro-common/streams/chd_stream.c
+++ b/libretro-common/streams/chd_stream.c
@@ -167,6 +167,8 @@ chdstream_find_special_track(chd_file *fd, int32_t track, metadata_t *meta)
          }
          else if (track == CHDSTREAM_TRACK_PRIMARY && largest_track != 0)
             return chdstream_find_track_number(fd, largest_track, meta);
+
+         return false;
       }
 
       switch (track)


### PR DESCRIPTION
## Description

ensures that `chdstream_find_special_track` stops looping once it runs out of tracks to examine

## Related Issues

fixes #10651 

## Related Pull Requests

n/a

## Reviewers

@twinaphex 
