### PR TITLE
(Input Mapping/Remapping) Restore broken 'reset to default' functionality

### DIFF
--- a/menu/cbs/menu_cbs_scan.c
+++ b/menu/cbs/menu_cbs_scan.c
@@ -194,7 +194,6 @@ static int action_scan_input_desc(const char *path,
 static int menu_cbs_init_bind_scan_compare_type(menu_file_list_cbs_t *cbs,
       unsigned type)
 {
-
    switch (type)
    {
 #ifdef HAVE_LIBRETRODB
@@ -208,7 +207,7 @@ static int menu_cbs_init_bind_scan_compare_type(menu_file_list_cbs_t *cbs,
 #endif
       case FILE_TYPE_RPL_ENTRY:
          BIND_ACTION_SCAN(cbs, action_switch_thumbnail);
-         break;
+         return 0;
 
       case FILE_TYPE_NONE:
       default:

--- a/menu/cbs/menu_cbs_start.c
+++ b/menu/cbs/menu_cbs_start.c
@@ -549,7 +549,7 @@ static int menu_cbs_init_bind_start_compare_label(menu_file_list_cbs_t *cbs)
       }
    }
 
-   return 0;
+   return -1;
 }
 
 static int menu_cbs_init_bind_start_compare_type(menu_file_list_cbs_t *cbs,

--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -8049,10 +8049,22 @@ static enum menu_action materialui_parse_menu_entry_action(
             materialui_auto_select_onscreen_entry(mui, MUI_ONSCREEN_ENTRY_FIRST);
          break;
       case MENU_ACTION_SCAN:
-         /* 'Scan' command is used to cycle current
-          * thumbnail view mode */
-         materialui_switch_list_view(mui);
-         new_action = MENU_ACTION_NOOP;
+         /* - If this is a playlist, 'scan' command is used
+          *   to cycle current thumbnail view
+          * - If this is not a playlist, perform default
+          *   'scan' action *if* current selection is
+          *   on screen */
+         {
+            size_t selection = menu_navigation_get_selection();
+
+            if (mui->is_playlist)
+            {
+               materialui_switch_list_view(mui);
+               new_action = MENU_ACTION_NOOP;
+            }
+            else if (!materialui_entry_onscreen(mui, selection))
+               new_action = MENU_ACTION_NOOP;
+         }
          break;
       case MENU_ACTION_START:
          /* - If this is a playlist, attempt to show

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -5403,10 +5403,13 @@ static enum menu_action rgui_parse_menu_entry_action(
    switch (action)
    {
       case MENU_ACTION_SCAN:
-         /* 'Scan' command is used to toggle
-          * fullscreen thumbnail view */
-         rgui_toggle_fs_thumbnail(rgui);
-         new_action = MENU_ACTION_NOOP;
+         /* If this is a playlist, 'scan' command is
+          * used to toggle fullscreen thumbnail view */
+         if (rgui->is_playlist)
+         {
+            rgui_toggle_fs_thumbnail(rgui);
+            new_action = MENU_ACTION_NOOP;
+         }
          break;
       default:
          /* In all other cases, pass through input


### PR DESCRIPTION
## Description

- When viewing either the global `Settings > Inputs > Port N Binds` / `Settings > Inputs > Hotkey Binds` input mapping menus or the `Quick Menu > Controls > Port N Controls` input remapping menu, pressing RetroPad `Start` is meant to reset the selected input mapping to its default value.

- When viewing the global `Settings > Inputs > Port N Binds` / `Settings > Inputs > Hotkey Binds` input mapping menus, pressing RetroPad `Y` is meant to 'unset' the selected input mapping entry.

It seems this functionality was lost some time ago due to various refactors...

This PR re-enables these RetroPad shortcuts for all menu drivers.