### PR TITLE
(gfx_thumbnail) Fix heap-use-after-free error

### DIFF
--- a/gfx/gfx_thumbnail.h
+++ b/gfx/gfx_thumbnail.h
@@ -72,6 +72,7 @@ typedef struct
    unsigned height;
    float alpha;
    float delay_timer;
+   bool fade_active;
 } gfx_thumbnail_t;
 
 /* Holds all configuration parameters associated


### PR DESCRIPTION
## Description

While using ASAN, I noticed a possible heap-use-after-free error that can occur if a thumbnail is deleted while it's 'fade in' animation is in progress.

This PR fixes the issue. It also slightly increases performance when navigating playlist thumbnail views in Material UI (since we now only cancel fade animations when actually necessary, rather than always doing so whenever freeing a thumbnail with a valid texture)