### PR TITLE
Improved shader preset dirs

### DIFF
--- a/menu/menu_shader.c
+++ b/menu/menu_shader.c
@@ -220,8 +220,9 @@ clear:
 static bool menu_shader_manager_save_preset_internal(
       const struct video_shader *shader, const char *basename,
       const char *dir_video_shader,
-      const char *dir_menu_config,
-      bool apply, bool save_reference)
+      bool apply, bool save_reference,
+      const char **target_dirs,
+      size_t num_target_dirs)
 {
    bool ret                       = false;
    enum rarch_shader_type type    = RARCH_SHADER_NONE;
@@ -278,28 +279,14 @@ static bool menu_shader_manager_save_preset_internal(
    }
    else
    {
-      const char *dirs[3] = {0};
-      char config_directory[PATH_MAX_LENGTH];
       char basedir[PATH_MAX_LENGTH];
 
-      config_directory[0] = '\0';
-
-      if (!path_is_empty(RARCH_PATH_CONFIG))
-         fill_pathname_basedir(
-               config_directory,
-               path_get(RARCH_PATH_CONFIG),
-               sizeof(config_directory));
-
-      dirs[0] = dir_menu_config;
-      dirs[1] = dir_video_shader;
-      dirs[2] = config_directory;
-
-      for (i = 0; i < ARRAY_SIZE(dirs); i++)
+      for (i = 0; i < num_target_dirs; i++)
       {
-         if (string_is_empty(dirs[i]))
+         if (string_is_empty(target_dirs[i]))
             continue;
 
-         fill_pathname_join(buffer, dirs[i],
+         fill_pathname_join(buffer, target_dirs[i],
                fullname, sizeof(buffer));
 
          strlcpy(basedir, buffer, sizeof(basedir));
@@ -348,31 +335,50 @@ static bool menu_shader_manager_operate_auto_preset(
       const char *dir_menu_config,
       enum auto_shader_type type, bool apply)
 {
+   char old_presets_directory[PATH_MAX_LENGTH];
+   char config_directory[PATH_MAX_LENGTH];
    char tmp[PATH_MAX_LENGTH];
-   char directory[PATH_MAX_LENGTH];
    char file[PATH_MAX_LENGTH];
-   struct retro_system_info *system  = runloop_get_libretro_system_info();
-   const char *core_name             = system ? system->library_name : NULL;
+   struct retro_system_info *system = runloop_get_libretro_system_info();
+   const char *core_name            = system ? system->library_name : NULL;
+   const char *auto_preset_dirs[3]  = {0};
 
-   tmp[0] = directory[0] = file[0] = '\0';
+   old_presets_directory[0] = config_directory[0] = tmp[0] = file[0] = '\0';
 
    if (type != SHADER_PRESET_GLOBAL && string_is_empty(core_name))
       return false;
 
+   if (!path_is_empty(RARCH_PATH_CONFIG))
+      fill_pathname_basedir(
+            config_directory,
+            path_get(RARCH_PATH_CONFIG),
+            sizeof(config_directory));
+
+   /* We are only including this directory for compatibility purposes with
+    * versions 1.8.7 and older. */
+   if (op != AUTO_SHADER_OP_SAVE && !string_is_empty(dir_video_shader))
+      fill_pathname_join(
+            old_presets_directory,
+            dir_video_shader,
+            "presets",
+            sizeof(old_presets_directory));
+
+   auto_preset_dirs[0] = dir_menu_config;
+   auto_preset_dirs[1] = config_directory;
+   auto_preset_dirs[2] = old_presets_directory;
+
    switch (type)
    {
       case SHADER_PRESET_GLOBAL:
-         fill_pathname_join(file, "presets", "global", sizeof(file));
+         strlcpy(file, "global", sizeof(file));
          break;
       case SHADER_PRESET_CORE:
-         fill_pathname_join(directory, "presets", core_name, sizeof(directory));
-         fill_pathname_join(file, directory, core_name, sizeof(file));
+         fill_pathname_join(file, core_name, core_name, sizeof(file));
          break;
       case SHADER_PRESET_PARENT:
-         fill_pathname_join(directory, "presets", core_name, sizeof(directory));
          fill_pathname_parent_dir_name(tmp,
                path_get(RARCH_PATH_BASENAME), sizeof(tmp));
-         fill_pathname_join(file, directory, tmp, sizeof(file));
+         fill_pathname_join(file, core_name, tmp, sizeof(file));
          break;
       case SHADER_PRESET_GAME:
          {
@@ -380,8 +386,7 @@ static bool menu_shader_manager_operate_auto_preset(
                path_basename(path_get(RARCH_PATH_BASENAME));
             if (string_is_empty(game_name))
                return false;
-            fill_pathname_join(directory, "presets", core_name, sizeof(directory));
-            fill_pathname_join(file, directory, game_name, sizeof(file));
+            fill_pathname_join(file, core_name, game_name, sizeof(file));
             break;
          }
       default:
@@ -394,38 +399,28 @@ static bool menu_shader_manager_operate_auto_preset(
          return menu_shader_manager_save_preset_internal(
                shader, file,
                dir_video_shader,
-               dir_menu_config,
-               apply, true);
+               apply, true,
+               auto_preset_dirs,
+               ARRAY_SIZE(auto_preset_dirs));
       case AUTO_SHADER_OP_REMOVE:
          {
             /* remove all supported auto-shaders of given type */
             char *end;
             size_t i, j, n, m;
 
-            const char *dirs[3] = {0};
-            char config_directory[PATH_MAX_LENGTH];
             char preset_path[PATH_MAX_LENGTH];
 
+            /* n = amount of relevant shader presets found
+             * m = amount of successfully deleted shader presets */
             n = m = 0;
 
-            config_directory[0] = '\0';
-
-            if (!path_is_empty(RARCH_PATH_CONFIG))
-               fill_pathname_basedir(
-                     config_directory,
-                     path_get(RARCH_PATH_CONFIG),
-                     sizeof(config_directory));
-
-            dirs[0] = dir_menu_config;
-            dirs[1] = dir_video_shader;
-            dirs[2] = config_directory;
-
-            for (i = 0; i < ARRAY_SIZE(dirs); i++)
+            for (i = 0; i < ARRAY_SIZE(auto_preset_dirs); i++)
             {
-               if (string_is_empty(dirs[i]))
+               if (string_is_empty(auto_preset_dirs[i]))
                   continue;
 
-               fill_pathname_join(preset_path, dirs[i], file, sizeof(preset_path));
+               fill_pathname_join(preset_path,
+                     auto_preset_dirs[i], file, sizeof(preset_path));
                end = preset_path + strlen(preset_path);
 
                for (j = 0; j < ARRAY_SIZE(shader_types); j++)
@@ -461,28 +456,15 @@ static bool menu_shader_manager_operate_auto_preset(
             char *end;
             size_t i, j;
 
-            const char *dirs[3] = {0};
-            char config_directory[PATH_MAX_LENGTH];
             char preset_path[PATH_MAX_LENGTH];
 
-            config_directory[0] = '\0';
-
-            if (!path_is_empty(RARCH_PATH_CONFIG))
-               fill_pathname_basedir(
-                     config_directory,
-                     path_get(RARCH_PATH_CONFIG),
-                     sizeof(config_directory));
-
-            dirs[0] = dir_menu_config;
-            dirs[1] = dir_video_shader;
-            dirs[2] = config_directory;
-
-            for (i = 0; i < ARRAY_SIZE(dirs); i++)
+            for (i = 0; i < ARRAY_SIZE(auto_preset_dirs); i++)
             {
-               if (string_is_empty(dirs[i]))
+               if (string_is_empty(auto_preset_dirs[i]))
                   continue;
 
-               fill_pathname_join(preset_path, dirs[i], file, sizeof(preset_path));
+               fill_pathname_join(preset_path,
+                     auto_preset_dirs[i], file, sizeof(preset_path));
                end = preset_path + strlen(preset_path);
 
                for (j = 0; j < ARRAY_SIZE(shader_types); j++)
@@ -513,10 +495,10 @@ static bool menu_shader_manager_operate_auto_preset(
  * @apply                    : immediately set preset after saving
  *
  * Save a shader as an auto-shader to it's appropriate path:
- *    SHADER_PRESET_GLOBAL: <shader dir>/presets/global
- *    SHADER_PRESET_CORE:   <shader dir>/presets/<core name>/<core name>
- *    SHADER_PRESET_PARENT: <shader dir>/presets/<core name>/<parent>
- *    SHADER_PRESET_GAME:   <shader dir>/presets/<core name>/<game name>
+ *    SHADER_PRESET_GLOBAL: <target dir>/global
+ *    SHADER_PRESET_CORE:   <target dir>/<core name>/<core name>
+ *    SHADER_PRESET_PARENT: <target dir>/<core name>/<parent>
+ *    SHADER_PRESET_GAME:   <target dir>/<core name>/<game name>
  * Needs to be consistent with retroarch_load_shader_preset()
  * Auto-shaders will be saved as a reference if possible
  **/
@@ -549,11 +531,27 @@ bool menu_shader_manager_save_preset(const struct video_shader *shader,
       const char *dir_menu_config,
       bool apply)
 {
+   char config_directory[PATH_MAX_LENGTH];
+   const char *preset_dirs[3] = {0};
+
+   config_directory[0] = '\0';
+
+   if (!path_is_empty(RARCH_PATH_CONFIG))
+      fill_pathname_basedir(
+            config_directory,
+            path_get(RARCH_PATH_CONFIG),
+            sizeof(config_directory));
+
+   preset_dirs[0] = dir_video_shader;
+   preset_dirs[1] = dir_menu_config;
+   preset_dirs[2] = config_directory;
+
    return menu_shader_manager_save_preset_internal(
          shader, basename,
          dir_video_shader,
-         dir_menu_config,
-         apply, false);
+         apply, false,
+         preset_dirs,
+         ARRAY_SIZE(preset_dirs));
 }
 
 /**

--- a/retroarch.c
+++ b/retroarch.c
@@ -2452,8 +2452,10 @@ struct string_list *dir_list_new_special(const char *input_dir,
             string_list_free(str_list);
             exts = ext_shaders;
          }
-#endif
          break;
+#else
+         return NULL;
+#endif
       case DIR_LIST_COLLECTIONS:
          exts = "lpl";
          break;
@@ -21668,6 +21670,7 @@ static bool video_driver_init_internal(bool *video_is_threaded)
 
    dir_free_shader();
 
+#if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)
    if (!string_is_empty(settings->paths.directory_video_shader))
       dir_list_is_free = !dir_init_shader(
             settings->paths.directory_video_shader,
@@ -21680,18 +21683,18 @@ static bool video_driver_init_internal(bool *video_is_threaded)
 
    if (dir_list_is_free && !path_is_empty(RARCH_PATH_CONFIG))
    {
-      config_file_directory = (char*)malloc(PATH_MAX_LENGTH);
-
-      fill_pathname_basedir(config_file_directory,
-            path_get(RARCH_PATH_CONFIG), PATH_MAX_LENGTH);
+      config_file_directory = strdup(path_get(RARCH_PATH_CONFIG));
+      path_basedir(config_file_directory);
 
       if (config_file_directory)
       {
          dir_list_is_free = !dir_init_shader(
                config_file_directory,
                settings->bools.show_hidden_files);
+         free(config_file_directory);
       }
    }
+#endif
 
    return true;
 

--- a/retroarch.c
+++ b/retroarch.c
@@ -21465,6 +21465,8 @@ static bool video_driver_init_internal(bool *video_is_threaded)
    settings_t *settings                   = configuration_settings;
    struct retro_game_geometry *geom       = &video_driver_av_info.geometry;
    const char *path_softfilter_plugin     = settings->paths.path_softfilter_plugin;
+   char *config_file_directory            = NULL;
+   bool dir_list_is_free                  = true;
 
    if (!string_is_empty(path_softfilter_plugin))
       video_driver_init_filter(video_driver_pix_fmt);
@@ -21667,8 +21669,29 @@ static bool video_driver_init_internal(bool *video_is_threaded)
    dir_free_shader();
 
    if (!string_is_empty(settings->paths.directory_video_shader))
-      dir_init_shader(settings->paths.directory_video_shader,
+      dir_list_is_free = !dir_init_shader(
+            settings->paths.directory_video_shader,
             settings->bools.show_hidden_files);
+
+   if (dir_list_is_free && !string_is_empty(settings->paths.directory_menu_config))
+      dir_list_is_free = !dir_init_shader(
+            settings->paths.directory_menu_config,
+            settings->bools.show_hidden_files);
+
+   if (dir_list_is_free && !path_is_empty(RARCH_PATH_CONFIG))
+   {
+      config_file_directory = (char*)malloc(PATH_MAX_LENGTH);
+
+      fill_pathname_basedir(config_file_directory,
+            path_get(RARCH_PATH_CONFIG), PATH_MAX_LENGTH);
+
+      if (config_file_directory)
+      {
+         dir_list_is_free = !dir_init_shader(
+               config_file_directory,
+               settings->bools.show_hidden_files);
+      }
+   }
 
    return true;
 


### PR DESCRIPTION
## Description

Cleanup of the auto-shader presets, closing #10641.
It also restores the original behavior of the "Save Shader Preset As" option, and improves the cycling of shaders by allowing to cycle the shaders on fallback directories if the Video Shader directory does not contain any preset.

## Reviewers

I would like to request a review from:
@jdgleaver 
@hizzlekizzle 
@Tatsuya79 
