### PR TITLE
NUL terminate 'fps_text' string

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -22636,6 +22636,9 @@ static void video_driver_frame(const void *data, unsigned width,
    bool widgets_active   = gfx_widgets_active();
 #endif
 
+   fps_text[0]         = '\0';
+   video_driver_msg[0] = '\0';
+
    if (!video_driver_active)
       return;
 
@@ -22786,8 +22789,6 @@ static void video_driver_frame(const void *data, unsigned width,
       height = output_height;
       pitch  = output_pitch;
    }
-
-   video_driver_msg[0] = '\0';
 
    if (runloop_msg_queue_size > 0)
    {


### PR DESCRIPTION
## Description

Just noticed that the `fps_text` string is not properly NUL terminated on initialisation - this breaks the window title display (and anything else that displays the frame rate, when 'show frame rate' is disabled)

This trivial PR fixes the issue

