### PR TITLE
Optimise 'path_is_absolute()'

### DIFF
--- a/libretro-common/file/file_path.c
+++ b/libretro-common/file/file_path.c
@@ -621,19 +621,29 @@ const char *path_basename(const char *path)
  **/
 bool path_is_absolute(const char *path)
 {
+#if defined(__wiiu__) || defined(VITA)
+   const char *seperator = NULL;
+#endif
+
+   if (string_is_empty(path))
+      return false;
+
    if (path[0] == '/')
       return true;
-#ifdef _WIN32
-   /* Many roads lead to Rome ... */
-   if ((    strstr(path, "\\\\") == path)
-         || strstr(path, ":/")
-         || strstr(path, ":\\")
-         || strstr(path, ":\\\\"))
+
+#if defined(_WIN32)
+   /* Many roads lead to Rome...
+    * Note: Drive letter can only be 1 character long */
+   if (string_starts_with(path,     "\\\\") ||
+       string_starts_with(path + 1, ":/")   ||
+       string_starts_with(path + 1, ":\\"))
       return true;
 #elif defined(__wiiu__) || defined(VITA)
-   if (strstr(path, ":/"))
+   seperator = strchr(path, ':');
+   if (seperator && (seperator[1] == '/'))
       return true;
 #endif
+
    return false;
 }
 


### PR DESCRIPTION
## Description

This is a small follow-up to PR #10672. It optimises the `path_is_absolute()` function in `file_path.h/.c`. Some statistics:

- On Windows, the performance overheads of `path_is_absolute()` are reduced by ~94%

- On WiiU/VITA, the performance overheads of `path_is_absolute()` are reduced by ~83%

(Note: On all other platforms, the function already has effectively zero performance impact)
