### PR TITLE
Add API extension to provide cores with finer grained control over environment callback messages

### DIFF
--- a/gfx/gfx_widgets.c
+++ b/gfx/gfx_widgets.c
@@ -339,7 +339,6 @@ unsigned gfx_widgets_get_height(void)
    return simple_widget_height;
 }
 
-
 unsigned gfx_widgets_get_generic_message_height(void)
 {
    return generic_message_height;
@@ -353,6 +352,11 @@ unsigned gfx_widgets_get_last_video_width(void)
 unsigned gfx_widgets_get_last_video_height(void)
 {
    return last_video_height;
+}
+
+size_t gfx_widgets_get_msg_queue_size(void)
+{
+   return current_msgs ? current_msgs->size : 0;
 }
 
 /* Widgets list */
@@ -1500,6 +1504,7 @@ void gfx_widgets_frame(void *data)
    video_frame_info_t *video_info;
    bool framecount_show;
    bool memory_show;
+   bool core_status_msg_show;
    void *userdata;
    unsigned video_width;
    unsigned video_height;
@@ -1521,6 +1526,7 @@ void gfx_widgets_frame(void *data)
    video_info                = (video_frame_info_t*)data;
    framecount_show           = video_info->framecount_show;
    memory_show               = video_info->memory_show;
+   core_status_msg_show      = video_info->core_status_msg_show;
    userdata                  = video_info->userdata;
    video_width               = video_info->width;
    video_height              = video_info->height;
@@ -1705,26 +1711,11 @@ void gfx_widgets_frame(void *data)
    }
 #endif
 
-   /* Draw all messages */
-   for (i = 0; i < current_msgs->size; i++)
-   {
-      menu_widget_msg_t *msg = (menu_widget_msg_t*)current_msgs->list[i].userdata;
-
-      if (!msg)
-         continue;
-
-      if (msg->task_ptr)
-         gfx_widgets_draw_task_msg(msg, userdata,
-               video_width, video_height);
-      else
-         gfx_widgets_draw_regular_msg(msg, userdata,
-               video_width, video_height);
-   }
-
    /* FPS Counter */
    if (     fps_show 
          || framecount_show
          || memory_show
+         || core_status_msg_show
          )
    {
       const char *text      = *gfx_widgets_fps_text == '\0' ? "N/A" : gfx_widgets_fps_text;
@@ -1796,6 +1787,22 @@ void gfx_widgets_frame(void *data)
 
       if (widget->frame)
          widget->frame(data);
+   }
+
+   /* Draw all messages */
+   for (i = 0; i < current_msgs->size; i++)
+   {
+      menu_widget_msg_t *msg = (menu_widget_msg_t*)current_msgs->list[i].userdata;
+
+      if (!msg)
+         continue;
+
+      if (msg->task_ptr)
+         gfx_widgets_draw_task_msg(msg, userdata,
+               video_width, video_height);
+      else
+         gfx_widgets_draw_regular_msg(msg, userdata,
+               video_width, video_height);
    }
 
 #ifdef HAVE_MENU

--- a/gfx/gfx_widgets.h
+++ b/gfx/gfx_widgets.h
@@ -113,6 +113,8 @@ float* gfx_widgets_get_backdrop_orig(void);
 unsigned gfx_widgets_get_last_video_width(void);
 unsigned gfx_widgets_get_last_video_height(void);
 unsigned gfx_widgets_get_generic_message_height(void);
+/* Warning: not thread safe! */
+size_t gfx_widgets_get_msg_queue_size(void);
 
 float gfx_widgets_get_thumbnail_scale_factor(
       const float dst_width, const float dst_height,

--- a/gfx/widgets/gfx_widget_generic_message.c
+++ b/gfx/widgets/gfx_widget_generic_message.c
@@ -95,6 +95,7 @@ static void gfx_widget_generic_message_frame(void* data)
       unsigned height                      = gfx_widgets_get_generic_message_height();
       unsigned text_color                  = COLOR_TEXT_ALPHA(0xffffffff, (unsigned)(state->alpha*255.0f));
       gfx_widget_font_data_t* font_regular = gfx_widgets_get_font_regular();
+      size_t msg_queue_size                = gfx_widgets_get_msg_queue_size();
 
       gfx_display_set_alpha(gfx_widgets_get_backdrop_orig(), state->alpha);
 
@@ -111,6 +112,11 @@ static void gfx_widget_generic_message_frame(void* data)
             video_width, video_height,
             text_color, TEXT_ALIGN_CENTER,
             false);
+
+      /* If the message queue is active, must flush the
+       * text here to avoid overlaps */
+      if (msg_queue_size > 0)
+         gfx_widgets_flush_text(video_width, video_height, font_regular);
    }
 }
 

--- a/gfx/widgets/gfx_widget_libretro_message.c
+++ b/gfx/widgets/gfx_widget_libretro_message.c
@@ -103,6 +103,7 @@ static void gfx_widget_libretro_message_frame(void *data)
       float* backdrop_orign                = gfx_widgets_get_backdrop_orig();
       unsigned text_color                  = COLOR_TEXT_ALPHA(0xffffffff, (unsigned)(state->alpha*255.0f));
       gfx_widget_font_data_t* font_regular = gfx_widgets_get_font_regular();
+      size_t msg_queue_size                = gfx_widgets_get_msg_queue_size();
 
       gfx_display_set_alpha(backdrop_orign, state->alpha);
 
@@ -119,6 +120,11 @@ static void gfx_widget_libretro_message_frame(void *data)
             video_width, video_height,
             text_color, TEXT_ALIGN_LEFT,
             false);
+
+      /* If the message queue is active, must flush the
+       * text here to avoid overlaps */
+      if (msg_queue_size > 0)
+         gfx_widgets_flush_text(video_width, video_height, font_regular);
    }
 }
 

--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -2544,13 +2544,72 @@ enum retro_message_target
    RETRO_MESSAGE_TARGET_LOG
 };
 
+enum retro_message_type
+{
+   RETRO_MESSAGE_TYPE_NOTIFICATION = 0,
+   RETRO_MESSAGE_TYPE_NOTIFICATION_ALT,
+   RETRO_MESSAGE_TYPE_STATUS
+};
+
 struct retro_message_ext
 {
-   const char                *msg;     /* Message to be displayed/logged */
-   unsigned                  frames;   /* Duration in frames of message when targeting OSD */
-   unsigned                  priority; /* Message priority when targeting OSD */
-   enum retro_log_level      level;    /* Message logging level (info, warn, etc.) */
-   enum retro_message_target target;   /* Message destination: OSD, logging interface or both */
+   /* Message string to be displayed/logged */
+   const char *msg;
+   /* Duration (in ms) of message when targeting the OSD */
+   unsigned duration;
+   /* Message priority when targeting the OSD
+    * > When multiple concurrent messages are sent to
+    *   the frontend and the frontend does not have the
+    *   capacity to display them all, messages with the
+    *   *highest* priority value should be shown
+    * > There is no upper limit to a message priority
+    *   value (within the bounds of the unsigned data type)
+    * > In the reference frontend (RetroArch), the same
+    *   priority values are used for frontend-generated
+    *   notifications, which are typically assigned values
+    *   between 0 and 3 depending upon importance */
+   unsigned priority;
+   /* Message logging level (info, warn, error, etc.) */
+   enum retro_log_level level;
+   /* Message destination: OSD, logging interface or both */
+   enum retro_message_target target;
+   /* Message 'type' when targeting the OSD
+    * > RETRO_MESSAGE_TYPE_NOTIFICATION: Specifies that a
+    *   message should be handled in identical fashion to
+    *   a standard frontend-generated notification
+    * > RETRO_MESSAGE_TYPE_NOTIFICATION_ALT: Specifies that
+    *   message is a notification that requires user attention
+    *   or action, but that it should be displayed in a manner
+    *   that differs from standard frontend-generated notifications.
+    *   This would typically correspond to messages that should be
+    *   displayed immediately (independently from any internal
+    *   frontend message queue), and/or which should be visually
+    *   distinguishable from frontend-generated notifications.
+    *   For example, a core may wish to inform the user of
+    *   information related to a disk-change event. It is
+    *   expected that the frontend itself may provide a
+    *   notification in this case; if the core sends a
+    *   message of type RETRO_MESSAGE_TYPE_NOTIFICATION, an
+    *   uncomfortable 'double-notification' may occur. A message
+    *   of RETRO_MESSAGE_TYPE_NOTIFICATION_ALT should therefore
+    *   be presented such that visual conflict with regular
+    *   notifications does not occur
+    * > RETRO_MESSAGE_TYPE_STATUS: Indicates that message
+    *   is not a standard notification. This typically
+    *   corresponds to 'status' indicators, such as a core's
+    *   internal FPS, which are intended to be displayed
+    *   either permanently while a core is running, or in
+    *   a manner that does not suggest user attention or action
+    *   is required. 'Status' type messages should therefore be
+    *   displayed in a different on-screen location and in a manner
+    *   easily distinguishable from both standard frontend-generated
+    *   notifications and messages of type RETRO_MESSAGE_TYPE_NOTIFICATION_ALT
+    * NOTE: Message type is a *hint*, and may be ignored
+    * by the frontend. If a frontend lacks support for
+    * displaying messages via alternate means than standard
+    * frontend-generated notifications, it will treat *all*
+    * messages as having the type RETRO_MESSAGE_TYPE_NOTIFICATION */
+   enum retro_message_type type;
 };
 
 /* Describes how the libretro implementation maps a libretro input bind

--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -2548,7 +2548,8 @@ enum retro_message_type
 {
    RETRO_MESSAGE_TYPE_NOTIFICATION = 0,
    RETRO_MESSAGE_TYPE_NOTIFICATION_ALT,
-   RETRO_MESSAGE_TYPE_STATUS
+   RETRO_MESSAGE_TYPE_STATUS,
+   RETRO_MESSAGE_TYPE_PROGRESS
 };
 
 struct retro_message_ext
@@ -2604,12 +2605,34 @@ struct retro_message_ext
     *   displayed in a different on-screen location and in a manner
     *   easily distinguishable from both standard frontend-generated
     *   notifications and messages of type RETRO_MESSAGE_TYPE_NOTIFICATION_ALT
+    * > RETRO_MESSAGE_TYPE_PROGRESS: Indicates that message reports
+    *   the progress of an internal core task. For example, in cases
+    *   where a core itself handles the loading of content from a file,
+    *   this may correspond to the percentage of the file that has been
+    *   read. Alternatively, an audio/video playback core may use a
+    *   message of type RETRO_MESSAGE_TYPE_PROGRESS to display the current
+    *   playback position as a percentage of the runtime. 'Progress' type
+    *   messages should therefore be displayed as a literal progress bar,
+    *   where:
+    *   - 'retro_message_ext.msg' is the progress bar title/label
+    *   - 'retro_message_ext.progress' determines the length of
+    *     the progress bar
     * NOTE: Message type is a *hint*, and may be ignored
     * by the frontend. If a frontend lacks support for
     * displaying messages via alternate means than standard
     * frontend-generated notifications, it will treat *all*
     * messages as having the type RETRO_MESSAGE_TYPE_NOTIFICATION */
    enum retro_message_type type;
+   /* Task progress when targeting the OSD and message is
+    * of type RETRO_MESSAGE_TYPE_PROGRESS
+    * > -1:    Unmetered/indeterminate
+    * > 0-100: Current progress percentage
+    * NOTE: Since message type is a hint, a frontend may ignore
+    * progress values. Where relevant, a core should therefore
+    * include progress percentage within the message string,
+    * such that the message intent remains clear when displayed
+    * as a standard frontend-generated notification */
+   int8_t progress;
 };
 
 /* Describes how the libretro implementation maps a libretro input bind

--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -1288,6 +1288,36 @@ enum retro_mod
                                             * based systems).
                                             */
 
+#define RETRO_ENVIRONMENT_GET_MESSAGE_INTERFACE_VERSION 59
+                                           /* unsigned * --
+                                            * Unsigned value is the API version number of the message
+                                            * interface supported by the frontend. If callback returns
+                                            * false, API version is assumed to be 0.
+                                            *
+                                            * In legacy code, messages may be displayed in an
+                                            * implementation-specific manner by passing a struct
+                                            * of type retro_message to RETRO_ENVIRONMENT_SET_MESSAGE.
+                                            * This may be still be done regardless of the message
+                                            * interface version.
+                                            *
+                                            * If version is >= 1 however, messages may instead be
+                                            * displayed by passing a struct of type retro_message_ext
+                                            * to RETRO_ENVIRONMENT_SET_MESSAGE_EXT. This allows the
+                                            * core to specify message logging level, priority and
+                                            * destination (OSD, logging interface or both).
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_MESSAGE_EXT 60
+                                           /* const struct retro_message_ext * --
+                                            * Sets a message to be displayed in an implementation-specific
+                                            * manner for a certain amount of 'frames'. Additionally allows
+                                            * the core to specify message logging level, priority and
+                                            * destination (OSD, logging interface or both).
+                                            * Should not be used for trivial messages, which should simply be
+                                            * logged via RETRO_ENVIRONMENT_GET_LOG_INTERFACE (or as a
+                                            * fallback, stderr).
+                                            */
+
 /* VFS functionality */
 
 /* File paths:
@@ -2505,6 +2535,22 @@ struct retro_message
 {
    const char *msg;        /* Message to be displayed. */
    unsigned    frames;     /* Duration in frames of message. */
+};
+
+enum retro_message_target
+{
+   RETRO_MESSAGE_TARGET_ALL = 0,
+   RETRO_MESSAGE_TARGET_OSD,
+   RETRO_MESSAGE_TARGET_LOG
+};
+
+struct retro_message_ext
+{
+   const char                *msg;     /* Message to be displayed/logged */
+   unsigned                  frames;   /* Duration in frames of message when targeting OSD */
+   unsigned                  priority; /* Message priority when targeting OSD */
+   enum retro_log_level      level;    /* Message logging level (info, warn, etc.) */
+   enum retro_message_target target;   /* Message destination: OSD, logging interface or both */
 };
 
 /* Describes how the libretro implementation maps a libretro input bind

--- a/retroarch.h
+++ b/retroarch.h
@@ -1098,6 +1098,7 @@ typedef struct video_frame_info
    bool memory_show;
    bool statistics_show;
    bool framecount_show;
+   bool core_status_msg_show;
    bool post_filter_record;
    bool windowed_fullscreen;
    bool fullscreen;


### PR DESCRIPTION
## Description

At present, cores may send simple messages to the frontend by passing a `retro_message` struct to the `RETRO_ENVIRONMENT_SET_MESSAGE` environment callback. This contains just a string and a 'duration to display' setting. When a message it sent in this way, it is displayed via the OSD and logged via the standard logging interface.

For some cores, this is inadequate: for example, pcsx-rearmed uses these messages to display internal FPS - and when this feature is enabled, the log is spammed with endless text (making any sort of debugging very difficult).

This PR adds an 'extended' messaging interface. There are 2 new environment callbacks:

- `RETRO_ENVIRONMENT_GET_MESSAGE_INTERFACE_VERSION`: Returns the version of the messaging interface supported by the frontend. When this is `0`, `RETRO_ENVIRONMENT_SET_MESSAGE` is supported. When this is `>= 1`, the extended interface may be used.

- `RETRO_ENVIRONMENT_SET_MESSAGE_EXT`: This accepts a new struct of type `retro_message_ext`:

```c
enum retro_message_target
{
   RETRO_MESSAGE_TARGET_ALL = 0,
   RETRO_MESSAGE_TARGET_OSD,
   RETRO_MESSAGE_TARGET_LOG
};

struct retro_message_ext
{
   const char                *msg;     /* Message to be displayed/logged */
   unsigned                  frames;   /* Duration in frames of message when targeting OSD */
   unsigned                  priority; /* Message priority when targeting OSD */
   enum retro_log_level      level;    /* Message logging level (info, warn, etc.) */
   enum retro_message_target target;   /* Message destination: OSD, logging interface or both */
};
```

As can be seen, this allows the message string and OSD duration to be set the same as usual, but it also allows the core to specify:

- Priority, when displaying messages via the OSD (note that 'priority' values are not recognised by the widget system at present - so this only works with old-style notifications. Widget priority support may be added later...)

- Log level: primarily used for selecting which of the `RARCH_LOG()`, `RARCH_WARN()` and `RARCH_ERR()` family to use when outputting via the normal logging interface, but also passed as a category when outputting via the OSD (again, the OSD doesn't do much with this at present, but the setting is there for the future)

- Message target: used to specify whether message should be output via the OSD, logging interface or both. So for 'permanent' messages like pcsx-rearmed's FPS text, logging can easily be disabled.
