### PR TITLE
(video) fix "Allow Cores to Switch the Video Driver OFF" behavior

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -9907,9 +9907,11 @@ static bool dynamic_verify_hw_context(enum retro_hw_context_type type,
       case RETRO_HW_CONTEXT_OPENGLES3:
       case RETRO_HW_CONTEXT_OPENGLES_VERSION:
       case RETRO_HW_CONTEXT_OPENGL:
+         if (!string_is_equal(video_ident, "gl"))
+            return false;
+         break;
       case RETRO_HW_CONTEXT_OPENGL_CORE:
-         if (!string_is_equal(video_ident, "gl") &&
-             !string_is_equal(video_ident, "glcore"))
+         if (!string_is_equal(video_ident, "glcore"))
             return false;
          break;
       case RETRO_HW_CONTEXT_DIRECT3D:
@@ -22303,42 +22305,27 @@ static bool video_driver_find_driver(void)
       }
 #endif
 
-#if defined(HAVE_OPENGL) || defined(HAVE_OPENGL_CORE)
+#if defined(HAVE_OPENGL)
       if (hwr && hw_render_context_is_gl(hwr->context_type))
       {
          RARCH_LOG("[Video]: Using HW render, OpenGL driver forced.\n");
-
-         /* If we have configured one of the HW render capable GL drivers, go with that. */
-         if (  !string_is_equal(settings->arrays.video_driver, "gl") &&
-               !string_is_equal(settings->arrays.video_driver, "glcore"))
+         if (!string_is_equal(settings->arrays.video_driver, "gl"))
          {
             RARCH_LOG("[Video]: \"%s\" saved as cached driver.\n", settings->arrays.video_driver);
             strlcpy(cached_video_driver, settings->arrays.video_driver,
                   sizeof(cached_video_driver));
-#if defined(HAVE_OPENGL_CORE)
-            RARCH_LOG("[Video]: Forcing \"glcore\" driver.\n");
             configuration_set_string(settings,
-                  settings->arrays.video_driver, "glcore");
-            current_video = &video_gl_core;
-#else
-            RARCH_LOG("[Video]: Forcing \"gl\" driver.\n");
-            configuration_set_string(settings,
-                  settings->arrays.video_driver, "gl");
-            current_video = &video_gl2;
-#endif
+                  settings->arrays.video_driver,
+                  "gl");
          }
-         else
-         {
-            RARCH_LOG("[Video]: Using configured \"%s\" driver for GL HW render.\n",
-                  settings->arrays.video_driver);
-         }
+         current_video = &video_gl2;
       }
 #endif
 
 #if defined(HAVE_OPENGL_CORE)
       if (hwr && hw_render_context_is_glcore(hwr->context_type))
       {
-         RARCH_LOG("[Video]: Using HW render, OpenGL core driver forced.\n");
+         RARCH_LOG("[Video]: Using HW render, core OpenGL driver forced.\n");
          if (!string_is_equal(settings->arrays.video_driver, "glcore"))
          {
             RARCH_LOG("[Video]: \"%s\" saved as cached driver.\n", settings->arrays.video_driver);


### PR DESCRIPTION
fix #10677 : video driver must never be switched when this setting is set to OFF, it is the job of the core to request the right context

This PR will require cores able to run on both gl and glcore context to request **one or the other** after using the `RETRO_ENVIRONMENT_GET_PREFERRED_HW_RENDER` callback