### PR TITLE
Image file type detection fixes/optimisations

### DIFF
--- a/libretro-common/formats/image_texture.c
+++ b/libretro-common/formats/image_texture.c
@@ -28,26 +28,51 @@
 #include <boolean.h>
 #include <formats/image.h>
 #include <file/nbio.h>
-
+#include <string/stdstring.h>
 
 enum image_type_enum image_texture_get_type(const char *path)
 {
-#ifdef HAVE_RTGA
-   if (strstr(path, ".tga"))
-      return IMAGE_TYPE_TGA;
-#endif
+   /* We are comparing against a fixed list of file
+    * extensions, the longest (jpeg) being 4 characters
+    * in length. We therefore only need to extract the first
+    * 5 characters from the extension of the input path
+    * to correctly validate a match */
+   const char *ext = NULL;
+   char ext_lower[6];
+
+   ext_lower[0] = '\0';
+
+   if (string_is_empty(path))
+      return IMAGE_TYPE_NONE;
+
+   /* Get file extension */
+   ext = strrchr(path, '.');
+
+   if (!ext || (*(++ext) == '\0'))
+      return IMAGE_TYPE_NONE;
+
+   /* Copy and convert to lower case */
+   strlcpy(ext_lower, ext, sizeof(ext_lower));
+   string_to_lower(ext_lower);
+
 #ifdef HAVE_RPNG
-   if (strstr(path, ".png"))
+   if (string_is_equal(ext_lower, "png"))
       return IMAGE_TYPE_PNG;
 #endif
 #ifdef HAVE_RJPEG
-   if (strstr(path, ".jpg") || strstr(path, ".jpeg"))
+   if (string_is_equal(ext_lower, "jpg") ||
+       string_is_equal(ext_lower, "jpeg"))
       return IMAGE_TYPE_JPEG;
 #endif
 #ifdef HAVE_RBMP
-   if (strstr(path, ".bmp"))
+   if (string_is_equal(ext_lower, "bmp"))
       return IMAGE_TYPE_BMP;
 #endif
+#ifdef HAVE_RTGA
+   if (string_is_equal(ext_lower, "tga"))
+      return IMAGE_TYPE_TGA;
+#endif
+
    return IMAGE_TYPE_NONE;
 }
 

--- a/libretro-common/include/string/stdstring.h
+++ b/libretro-common/include/string/stdstring.h
@@ -50,6 +50,21 @@ static INLINE bool string_starts_with(const char *str, const char *prefix)
    return (str && prefix) ? !strncmp(prefix, str, strlen(prefix)) : false;
 }
 
+static INLINE bool string_ends_with(const char *str, const char *suffix)
+{
+   size_t str_len;
+   size_t suffix_len;
+
+   if (!str || !suffix)
+      return false;
+
+   str_len    = strlen(str);
+   suffix_len = strlen(suffix);
+
+   return (str_len < suffix_len) ? false :
+         !memcmp(suffix, str + (str_len - suffix_len), suffix_len);
+}
+
 #define STRLEN_CONST(x)                   ((sizeof((x))-1))
 
 #define string_is_not_equal(a, b)         !string_is_equal((a), (b))

--- a/tasks/task_image.c
+++ b/tasks/task_image.c
@@ -422,7 +422,7 @@ bool task_push_image_load(const char *fullpath,
 
    nbio->path                        = strdup(fullpath);
 
-   image->type                       = IMAGE_TYPE_NONE;
+   image->type                       = image_texture_get_type(fullpath);
    image->status                     = IMAGE_STATUS_WAIT;
    image->is_blocking                = false;
    image->is_blocking_on_processing  = false;
@@ -439,26 +439,23 @@ bool task_push_image_load(const char *fullpath,
    /* TODO/FIXME - shouldn't we set this ? */
    image->ti.supports_rgba           = false;
 
-   if (strstr(fullpath, ".png"))
+   switch (image->type)
    {
-      nbio->type       = NBIO_TYPE_PNG;
-      image->type      = IMAGE_TYPE_PNG;
-   }
-   else if (strstr(fullpath, ".jpeg")
-         || strstr(fullpath, ".jpg"))
-   {
-      nbio->type       = NBIO_TYPE_JPEG;
-      image->type      = IMAGE_TYPE_JPEG;
-   }
-   else if (strstr(fullpath, ".bmp"))
-   {
-      nbio->type       = NBIO_TYPE_BMP;
-      image->type      = IMAGE_TYPE_BMP;
-   }
-   else if (strstr(fullpath, ".tga"))
-   {
-      nbio->type       = NBIO_TYPE_TGA;
-      image->type      = IMAGE_TYPE_TGA;
+      case IMAGE_TYPE_PNG:
+         nbio->type = NBIO_TYPE_PNG;
+         break;
+      case IMAGE_TYPE_JPEG:
+         nbio->type = NBIO_TYPE_JPEG;
+         break;
+      case IMAGE_TYPE_BMP:
+         nbio->type = NBIO_TYPE_BMP;
+         break;
+      case IMAGE_TYPE_TGA:
+         nbio->type = NBIO_TYPE_TGA;
+         break;
+      default:
+         nbio->type = NBIO_TYPE_NONE;
+         break;
    }
 
    nbio->data          = (struct nbio_image_handle*)image;


### PR DESCRIPTION
## Description

At present the logic used to detect image file type from file path is very slow, and also error prone. This trivial PR reduces the performance overheads of `image_texture_get_type()` by ~78% and uses the function in `task_push_image_load()` to remove existing code duplication. It also fixes 2 issues:

- We no longer detect the wrong file type when an extension has erroneous trailing characters (e.g. before, `.jpgx` would be treated as a JPEG)

- We can now detect the correct file type for images with uppercase file extensions

In addition, this PR adds a generic `string_ends_with()` function to `stdstring.h` - I ended up not using it, but it should be handy elsewhere :)
