### PR TITLE
Don't report unused input ports to cores

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -144,6 +144,7 @@
 - X11/XSHM: Fix compatibility with X11 input driver
 - XVIDEO: Fix keyboard input initialization
 - XVIDEO/XWAYLAND: Fix XVideo support on xwayland (by supporting I420 and YZ12)
+- INPUT: Don't report unused input ports to cores
 
 # 1.8.7
 - 3DS: Add IDs for Frodo

--- a/retroarch.c
+++ b/retroarch.c
@@ -14501,7 +14501,7 @@ static void command_event_init_controllers(struct rarch_state *p_rarch)
    unsigned i;
    rarch_system_info_t *info     = &p_rarch->runloop_system;
 
-   for (i = 0; i < MAX_USERS; i++)
+   for (i = 0; i < p_rarch->input_driver_max_users; i++)
    {
       retro_ctx_controller_info_t pad;
       const char *ident                               = NULL;
@@ -20913,7 +20913,7 @@ static bool secondary_core_create(struct rarch_state *p_rarch)
    p_rarch->secondary_core.retro_set_input_state(p_rarch->secondary_callbacks.state_cb);
    p_rarch->secondary_core.retro_set_input_poll(p_rarch->secondary_callbacks.poll_cb);
 
-   for (port = 0; port < 16; port++)
+   for (port = 0; port < p_rarch->input_driver_max_users; port++)
    {
       device = p_rarch->port_map[port];
       if (device >= 0)


### PR DESCRIPTION
## Description

RetroArch has the unfortunate behavior of setting unused ports to `RETRO_DEVICE_JOYPAD` in the core through `retro_set_controller_port_device()`. "Unused" meaning ports higher than the "maximum users" amount configured in settings/input in RA. This is unfortunate because some cores (like the dosbox ones) change their behavior depending on the device type assigned to ports. If all unused (and thus invisible and unconfigurable through the UI) ports are set to `RETRO_DEVICE_JOYPAD`, the core changes its behavior because from its point of view there's multiple joypads connected, and there's no way for users to disconnect these bogus joypads.

Fix this by not calling retro_set_controller_port_device() on ports that are not used.


## Related Issues

https://github.com/realnc/dosbox-core/issues/14