### PR TITLE
Only Show Menu Bar Setting on Windows (The Only Supported Platform)

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -15506,6 +15506,7 @@ static bool setting_append_list(
                general_read_handler,
                SD_FLAG_ADVANCED);
 
+#ifdef WIN32
          CONFIG_BOOL(
                list, list_info,
                &settings->bools.ui_menubar_enable,
@@ -15520,6 +15521,7 @@ static bool setting_append_list(
                general_write_handler,
                general_read_handler,
                SD_FLAG_NONE);
+#endif
 
 #ifdef HAVE_QT
          CONFIG_BOOL(


### PR DESCRIPTION
## Description

The `Menu Bar` feature is only implemented on Windows, this PR hides `Settings > User Interface > Menu Bar` on other platforms.