### PR TITLE
Small buffer optimizations

### DIFF
--- a/gfx/gfx_animation.c
+++ b/gfx/gfx_animation.c
@@ -1706,9 +1706,15 @@ bool gfx_animation_ticker_smooth(gfx_animation_ctx_ticker_smooth_t *ticker)
    if (src_str_len < 1)
       goto end;
 
-   src_char_widths = (unsigned*)calloc(src_str_len, sizeof(unsigned));
-   if (!src_char_widths)
-      goto end;
+   unsigned small_src_char_widths[64] = {0};
+   src_char_widths = small_src_char_widths;
+
+   if (src_str_len > ARRAY_SIZE(small_src_char_widths))
+   {
+      src_char_widths = (unsigned*)calloc(src_str_len, sizeof(unsigned));
+      if (!src_char_widths)
+         goto end;
+   }
 
    str_ptr = ticker->src_str;
    for (i = 0; i < src_str_len; i++)
@@ -1881,7 +1887,7 @@ bool gfx_animation_ticker_smooth(gfx_animation_ctx_ticker_smooth_t *ticker)
 
 end:
 
-   if (src_char_widths)
+   if (src_char_widths != small_src_char_widths && src_char_widths)
    {
       free(src_char_widths);
       src_char_widths = NULL;


### PR DESCRIPTION
This PR implements small buffer optimizations in some functions that get called **very** frequently when the menu is visible. The preallocated stack buffers are very small, the one in `gfx_animation_ticker_smooth()` can even be halved without noticeable effects in my tests.

I picked 64 bytes/entries because that's more than enough for most languages currently supported (check the commit message of the first commit). Distribution of strings sizes:

![image](https://user-images.githubusercontent.com/59172/82743743-ecd66800-9d45-11ea-9a2b-bf62bf54f858.png)


See http://www.framecompare.com/image-compare/screenshotcomparison/9999MNNU for before/after allocation graphs when the menu runs for 600 frames.

