### PR TITLE
libretro-db: Fix stdstring undefined in c_converter

### DIFF
--- a/libretro-db/Makefile
+++ b/libretro-db/Makefile
@@ -12,6 +12,7 @@ CFLAGS               = -g -O2 -Wall -DNDEBUG
 endif
 
 LIBRETRO_COMMON_C = \
+			 $(LIBRETRO_COMM_DIR)/string/stdstring.c \
 			 $(LIBRETRO_COMM_DIR)/streams/file_stream.c \
 			 $(LIBRETRO_COMM_DIR)/compat/compat_strcasestr.c \
 			 $(LIBRETRO_COMM_DIR)/file/file_path.c \
@@ -30,7 +31,6 @@ C_CONVERTER_C = \
 			 $(LIBRETRODB_DIR)/c_converter.c \
 			 $(LIBRETRO_COMM_DIR)/hash/rhash.c \
 			 $(LIBRETRO_COMM_DIR)/compat/compat_fnmatch.c \
-			 $(LIBRETRO_COMM_DIR)/string/stdstring.c \
 			 $(LIBRETRO_COMMON_C)
 
 C_CONVERTER_OBJS := $(C_CONVERTER_C:.c=.o)
@@ -43,7 +43,6 @@ RARCHDB_TOOL_C = \
 			 $(LIBRETRODB_DIR)/query.c \
 			 $(LIBRETRODB_DIR)/libretrodb.c \
 			 $(LIBRETRO_COMM_DIR)/compat/compat_fnmatch.c \
-			 $(LIBRETRO_COMM_DIR)/string/stdstring.c \
 			 $(LIBRETRO_COMMON_C)
 
 RARCHDB_TOOL_OBJS := $(RARCHDB_TOOL_C:.c=.o)


### PR DESCRIPTION
This fixes c_converter not getting undefined stdstring dependencies in the libretro-db c_converter, since it's required in file_path.