### PR TITLE
ekeeke's solution to force loading of content into RAM if soft-patchi…

### DIFF
--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -924,7 +924,9 @@ static bool content_file_load(
       if (!path_empty)
          info[i].path = path;
 
-      if (!need_fullpath && !path_empty)
+      bool has_patch = !content_ctx->patch_is_blocked && ((!string_is_empty(content_ctx->name_ips) && path_is_valid(content_ctx->name_ips)) || (!string_is_empty(content_ctx->name_ups) && path_is_valid(content_ctx->name_ups)) || (!string_is_empty(content_ctx->name_bps) && path_is_valid(content_ctx->name_bps)));
+      
+      if ((!need_fullpath || have_patch) && !path_empty)
       {
          /* Load the content into memory. */
 


### PR DESCRIPTION
…ng is required by the user and still provide a valid *data pointer in this case that the core can use, even if need_fullpath is set to True

## Description

This patch comes from ekeeke's suggestion from here https://github.com/libretro/Genesis-Plus-GX/issues/54 to solve https://github.com/libretro/Genesis-Plus-GX/issues/211. In short, this should allow needs_fullpath cores that also support files that shouldn't need fullpath to apply softpatches to valid files.

## Related Issues

already linked above

## Related Pull Requests

none AFAIK

## Reviewers

@twinaphex @m4xw @jdgleaver 
