### PR TITLE
(Linux) Set default saves/save states/system paths

### DIFF
--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -1768,6 +1768,12 @@ static void frontend_unix_get_env(int *argc,
          "thumbnails", sizeof(g_defaults.dirs[DEFAULT_DIR_THUMBNAILS]));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_LOGS], base_path,
          "logs", sizeof(g_defaults.dirs[DEFAULT_DIR_LOGS]));
+   fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_SRAM], base_path,
+         "saves", sizeof(g_defaults.dirs[DEFAULT_DIR_SRAM]));
+   fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_SAVESTATE], base_path,
+         "states", sizeof(g_defaults.dirs[DEFAULT_DIR_SAVESTATE]));
+   fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_SYSTEM], base_path,
+         "system", sizeof(g_defaults.dirs[DEFAULT_DIR_SYSTEM]));
 #endif
 
    for (i = 0; i < DEFAULT_DIR_LAST; i++)


### PR DESCRIPTION
## Description

Due to a historical oversight, the default `save`, `save state` and `system` paths are unset when using Linux. This means that, unless the user enters these paths manually, the content directory itself is used in each case - which is incredibly untidy and unmanageable.

This trivial PR just configures sane defaults. In most case, the base user RetroArch directory on Linux is `~/.config/retroarch` - the new `save`, `save state` and `system` paths are in the following subdirectories:

```
retroarch/
|- saves/
|- states/
`- system/
```

(Note that this does not affect any users who already have manually configured paths)