### PR TITLE
fix pointer comparison to wrong start location

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -3002,7 +3002,7 @@ bool rcheevos_load(const void *data)
             tmp = m3u_contents;
             while (*tmp && *tmp != '\n')
                ++tmp;
-            if (tmp > buffer && tmp[-1] == '\r')
+            if (tmp > m3u_contents && tmp[-1] == '\r')
                --tmp;
             *tmp = '\0';
 


### PR DESCRIPTION
## Description

Fixes a logical error when attempting to determine if a line read from an m3u file ends with CRLF instead of LF. Potential fix for #10732.

## Related Issues

#10732

## Related Pull Requests

n/a

## Reviewers

[If possible @mention all the people that should review your pull request]
