### PR TITLE
sdl_gl_ctx: advertise GLSL support

### DIFF
--- a/gfx/drivers_context/sdl_gl_ctx.c
+++ b/gfx/drivers_context/sdl_gl_ctx.c
@@ -407,6 +407,8 @@ static uint32_t sdl_ctx_get_flags(void *data)
 {
    uint32_t flags = 0;
 
+   BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_GLSL);
+
    return flags;
 }
 


### PR DESCRIPTION
sdl_gl_ctx is pretty unusable with the gl2 driver without this.

loading non-menu glsl shaders works.