### PR TITLE
report API errors when unlocking achievements or submitting leaderboards

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -446,7 +446,37 @@ static void rcheevos_async_task_callback(retro_task_t* task, void* task_data, vo
 
    if (!error)
    {
-      CHEEVOS_LOG(RCHEEVOS_TAG "%s %u\n", request->success_message, request->id);
+      char buffer[224];
+      const http_transfer_data_t* data = (http_transfer_data_t*)task->task_data;
+      if (rcheevos_get_json_error(data->data, buffer, sizeof(buffer)) == RC_OK)
+      {
+         char errbuf[256];
+         snprintf(errbuf, sizeof(errbuf), "%s %u: %s", request->failure_message, request->id, buffer);
+         CHEEVOS_LOG(RCHEEVOS_TAG "%s\n", errbuf);
+
+         switch (request->type)
+         {
+            case CHEEVOS_ASYNC_RICHPRESENCE:
+               /* don't bother informing user when rich presence update fails */
+               break;
+
+            case CHEEVOS_ASYNC_AWARD_ACHIEVEMENT:
+               /* ignore already unlocked */
+               if (string_starts_with(buffer, "User already has "))
+                  break;
+               /* fallthrough to default */
+
+            default:
+               runloop_msg_queue_push(errbuf, 0, 5 * 60, false, NULL,
+                  MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_ERROR);
+               break;
+         }
+      }
+      else
+      {
+         CHEEVOS_LOG(RCHEEVOS_TAG "%s %u\n", request->success_message, request->id);
+      }
+
       free(request);
    }
    else


### PR DESCRIPTION
## Description

Checks the server response for error messages and reports them to the user if found. Previously, we only checked to make sure a valid response was returned and ignored any error string within.

There are a few cases where the server will return a valid JSON response containing an error string. When an error like this occurs, the player's achievement was most likely not unlocked, so it's beneficial to inform them. Here's one example from the standalone emulator:

![image](https://user-images.githubusercontent.com/32680403/83591553-6ecc4b00-a515-11ea-8c34-2c379e4a2b3e.png)

The equivalent result of this change is that a notification would appear saying "Error unlocking achievement N: Could not connect to database. Please try again later."

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@meleu
