### PR TITLE
Core info search optimisations + improved core selection logic + clean-ups

### DIFF
--- a/core_info.h
+++ b/core_info.h
@@ -35,6 +35,23 @@ typedef struct
    bool optional;
 } core_info_firmware_t;
 
+/* Simple container/convenience struct for
+ * holding the 'id' of a core file
+ * > 'id' is the filename without extension or
+ *   platform-specific suffix
+ * > 'id' is used for core info searches - enables
+ *   matching regardless of core file base path,
+ *   and is platform-independent (e.g. an Android
+ *   core file will be correctly identified on Linux)
+ * > 'len' is used to cache the length of 'str', for
+ *   improved performance when performing string
+ *   comparisons */
+typedef struct
+{
+   char *str;
+   size_t len;
+} core_file_id_t;
+
 typedef struct
 {
    bool supports_no_game;
@@ -67,6 +84,7 @@ typedef struct
    struct string_list *licenses_list;
    struct string_list *required_hw_api_list;
    core_info_firmware_t *firmware;
+   core_file_id_t core_file_id;
    void *userdata;
 } core_info_t;
 
@@ -152,7 +170,7 @@ bool core_info_get_list(core_info_list_t **core);
 bool core_info_list_update_missing_firmware(core_info_ctx_firmware_t *info,
       bool *set_missing_bios);
 
-bool core_info_find(core_info_ctx_find_t *info, const char *name);
+bool core_info_find(core_info_ctx_find_t *info);
 
 bool core_info_load(core_info_ctx_find_t *info);
 

--- a/menu/cbs/menu_cbs_get_value.c
+++ b/menu/cbs/menu_cbs_get_value.c
@@ -462,7 +462,7 @@ static void menu_action_setting_disp_set_label_core_updater_entry(
       core_info.inf  = NULL;
       core_info.path = entry->local_core_path;
 
-      if (core_info_find(&core_info, entry->local_core_path))
+      if (core_info_find(&core_info))
       {
          strlcpy(s, "[#]", len);
          *w = (unsigned)STRLEN_CONST("[#]");

--- a/menu/cbs/menu_cbs_right.c
+++ b/menu/cbs/menu_cbs_right.c
@@ -474,16 +474,18 @@ static int action_right_video_resolution(unsigned type, const char *label,
 static int playlist_association_right(unsigned type, const char *label,
       bool wraparound)
 {
-   char core_path[PATH_MAX_LENGTH];
+   char core_filename[PATH_MAX_LENGTH];
    size_t i, next, current          = 0;
    core_info_list_t *core_info_list = NULL;
    core_info_t *core_info           = NULL;
    settings_t *settings             = config_get_ptr();
    playlist_t *playlist             = playlist_get_cached();
+   const char *default_core_path    = playlist_get_default_core_path(playlist);
+   bool default_core_set            = false;
    bool playlist_use_old_format     = settings->bools.playlist_use_old_format;
    bool playlist_compression        = settings->bools.playlist_compression;
 
-   core_path[0]     = '\0';
+   core_filename[0] = '\0';
 
    if (!playlist)
       return -1;
@@ -493,59 +495,65 @@ static int playlist_association_right(unsigned type, const char *label,
       return menu_cbs_exit();
 
    /* Get current core path association */
-   if (string_is_empty(playlist_get_default_core_path(playlist)))
+   if (!string_is_empty(default_core_path) &&
+       !string_is_equal(default_core_path, "DETECT"))
    {
-      core_path[0] = 'D';
-      core_path[1] = 'E';
-      core_path[2] = 'T';
-      core_path[3] = 'E';
-      core_path[4] = 'C';
-      core_path[5] = 'T';
-      core_path[6] = '\0';
+      const char *default_core_filename = path_basename(default_core_path);
+      if (!string_is_empty(default_core_filename))
+      {
+         strlcpy(core_filename, default_core_filename, sizeof(core_filename));
+         default_core_set = true;
+      }
    }
-   else
-      strlcpy(core_path, playlist_get_default_core_path(playlist), sizeof(core_path));
 
    /* Sort cores alphabetically */
    core_info_qsort(core_info_list, CORE_INFO_LIST_SORT_DISPLAY_NAME);
 
-   /* Get the index of the currently associated core */
-   for (i = 0; i < core_info_list->count; i++)
+   /* If a core is currently associated... */
+   if (default_core_set)
    {
-      core_info = NULL;
-      core_info = core_info_get(core_info_list, i);
-      if (!core_info)
-         return -1;
-      if (string_is_equal(core_info->path, core_path))
-         current = i;
-   }
-
-   /* Increment core index */
-   next = current + 1;
-   if (next >= core_info_list->count)
-   {
-      if (wraparound)
-         next = 0;
-      else
+      /* ...get its index */
+      for (i = 0; i < core_info_list->count; i++)
       {
-         if (core_info_list->count > 0)
-            next = core_info_list->count - 1;
+         core_info = NULL;
+         core_info = core_info_get(core_info_list, i);
+         if (!core_info)
+            continue;
+         if (string_starts_with(core_filename, core_info->core_file_id.str))
+            current = i;
+      }
+
+      /* ...then increment it */
+      next = current + 1;
+      if (next >= core_info_list->count)
+      {
+         if (wraparound || (core_info_list->count < 1))
+         {
+            /* Unset core association (DETECT) */
+            next             = 0;
+            default_core_set = false;
+         }
          else
-            next = 0;
+            next = core_info_list->count - 1;
       }
    }
+   /* If a core is *not* currently associated,
+    * select first core in the list */
+   else
+   {
+      next             = 0;
+      default_core_set = true;
+   }
 
-   /* Get new core info */
+   /* If a core is now associated, get new core info */
    core_info = NULL;
-   core_info = core_info_get(core_info_list, next);
-   if (!core_info)
-      return -1;
+   if (default_core_set)
+      core_info = core_info_get(core_info_list, next);
 
    /* Update playlist */
-   playlist_set_default_core_path(playlist, core_info->path);
-   playlist_set_default_core_name(playlist, core_info->display_name);
-   playlist_write_file(
-         playlist, playlist_use_old_format, playlist_compression);
+   playlist_set_default_core_path(playlist, core_info ? core_info->path         : "DETECT");
+   playlist_set_default_core_name(playlist, core_info ? core_info->display_name : "DETECT");
+   playlist_write_file(playlist, playlist_use_old_format, playlist_compression);
 
    return 0;
 }

--- a/menu/cbs/menu_cbs_sublabel.c
+++ b/menu/cbs/menu_cbs_sublabel.c
@@ -72,7 +72,7 @@ static int menu_action_sublabel_file_browser_core(file_list_t *list, unsigned ty
    core_info.inf  = NULL;
    core_info.path = path;
 
-   if (core_info_find(&core_info, path) &&
+   if (core_info_find(&core_info) &&
        core_info.inf->licenses_list)
    {
       char tmp[MENU_SUBLABEL_MAX_LENGTH];

--- a/menu/cbs/menu_cbs_title.c
+++ b/menu/cbs/menu_cbs_title.c
@@ -347,7 +347,7 @@ static int action_get_title_deferred_core_backup_list(
    core_info.path = core_path;
 
    /* If core is found, add display name */
-   if (core_info_find(&core_info, core_path) &&
+   if (core_info_find(&core_info) &&
        core_info.inf->display_name)
       strlcat(s, core_info.inf->display_name, len);
    else

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -157,7 +157,7 @@ static int menu_displaylist_parse_core_info(menu_displaylist_info_t *info)
       core_info_finder.inf  = NULL;
       core_info_finder.path = core_path;
 
-      if (core_info_find(&core_info_finder, core_path))
+      if (core_info_find(&core_info_finder))
          core_info = core_info_finder.inf;
    }
    else if (core_info_get_current_core(&core_info) && core_info)
@@ -3282,7 +3282,7 @@ static unsigned menu_displaylist_parse_content_information(
       core_info.inf  = NULL;
       core_info.path = core_path;
 
-      if (core_info_find(&core_info, core_path))
+      if (core_info_find(&core_info))
          if (!string_is_empty(core_info.inf->display_name))
             strlcpy(core_name, core_info.inf->display_name, sizeof(core_name));
    }

--- a/playlist.c
+++ b/playlist.c
@@ -2898,3 +2898,66 @@ void playlist_set_sort_mode(playlist_t *playlist, enum playlist_sort_mode sort_m
       playlist->modified  = true;
    }
 }
+
+/* Returns true if specified entry has a valid
+ * core association (i.e. a non-empty string
+ * other than DETECT) */
+bool playlist_entry_has_core(const struct playlist_entry *entry)
+{
+   if (!entry ||
+       string_is_empty(entry->core_path) ||
+       string_is_empty(entry->core_name) ||
+       string_is_equal(entry->core_path, "DETECT") ||
+       string_is_equal(entry->core_name, "DETECT"))
+      return false;
+
+   return true;
+}
+
+/* Fetches core info object corresponding to the
+ * currently associated core of the specified
+ * playlist entry.
+ * Returns NULL if entry does not have a valid
+ * core association */
+core_info_t *playlist_entry_get_core_info(const struct playlist_entry* entry)
+{
+   core_info_ctx_find_t core_info;
+
+   if (!playlist_entry_has_core(entry))
+      return NULL;
+
+   /* Search for associated core */
+   core_info.inf  = NULL;
+   core_info.path = entry->core_path;
+
+   if (core_info_find(&core_info))
+      return core_info.inf;
+
+   return NULL;
+}
+
+/* Fetches core info object corresponding to the
+ * currently associated default core of the
+ * specified playlist.
+ * Returns NULL if playlist does not have a valid
+ * default core association */
+core_info_t *playlist_get_default_core_info(playlist_t* playlist)
+{
+   core_info_ctx_find_t core_info;
+
+   if (!playlist ||
+       string_is_empty(playlist->default_core_path) ||
+       string_is_empty(playlist->default_core_name) ||
+       string_is_equal(playlist->default_core_path, "DETECT") ||
+       string_is_equal(playlist->default_core_name, "DETECT"))
+      return NULL;
+
+   /* Search for associated core */
+   core_info.inf  = NULL;
+   core_info.path = playlist->default_core_path;
+
+   if (core_info_find(&core_info))
+      return core_info.inf;
+
+   return NULL;
+}

--- a/playlist.h
+++ b/playlist.h
@@ -24,6 +24,8 @@
 #include <boolean.h>
 #include <lists/string_list.h>
 
+#include "core_info.h"
+
 RETRO_BEGIN_DECLS
 
 /* Default maximum playlist size */
@@ -316,6 +318,25 @@ void playlist_set_label_display_mode(playlist_t *playlist, enum playlist_label_d
 void playlist_set_thumbnail_mode(
       playlist_t *playlist, enum playlist_thumbnail_id thumbnail_id, enum playlist_thumbnail_mode thumbnail_mode);
 void playlist_set_sort_mode(playlist_t *playlist, enum playlist_sort_mode sort_mode);
+
+/* Returns true if specified entry has a valid
+ * core association (i.e. a non-empty string
+ * other than DETECT) */
+bool playlist_entry_has_core(const struct playlist_entry *entry);
+
+/* Fetches core info object corresponding to the
+ * currently associated core of the specified
+ * playlist entry.
+ * Returns NULL if entry does not have a valid
+ * core association */
+core_info_t *playlist_entry_get_core_info(const struct playlist_entry* entry);
+
+/* Fetches core info object corresponding to the
+ * currently associated default core of the
+ * specified playlist.
+ * Returns NULL if playlist does not have a valid
+ * default core association */
+core_info_t *playlist_get_default_core_info(playlist_t* playlist);
 
 RETRO_END_DECLS
 

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -1992,8 +1992,6 @@ static bool task_load_content_callback(content_ctx_info_t *content_info,
 
       content_ctx.set_supports_no_game_enable = set_supports_no_game_enable;
 
-      if (!string_is_empty(path_dir_system))
-         content_ctx.directory_system         = strdup(path_dir_system);
       if (!string_is_empty(path_dir_cache))
          content_ctx.directory_cache          = strdup(path_dir_cache);
       if (!string_is_empty(system->valid_extensions))

--- a/tasks/task_core_backup.c
+++ b/tasks/task_core_backup.c
@@ -442,7 +442,7 @@ void *task_push_core_backup(const char *core_path,
    core_info.path = core_path;
 
    /* If core is found, use display name */
-   if (core_info_find(&core_info, core_path) &&
+   if (core_info_find(&core_info) &&
        core_info.inf->display_name)
       core_name = core_info.inf->display_name;
    else
@@ -881,7 +881,7 @@ bool task_push_core_restore(const char *backup_path, const char *dir_libretro,
    core_info.path = core_path;
 
    /* If core is found, use display name */
-   if (core_info_find(&core_info, core_path) &&
+   if (core_info_find(&core_info) &&
        core_info.inf->display_name)
       core_name = core_info.inf->display_name;
    else

--- a/tasks/task_playlist_manager.c
+++ b/tasks/task_playlist_manager.c
@@ -463,35 +463,19 @@ static void pl_manager_validate_core_association(
       goto reset_core;
    else
    {
-      const char *core_path_basename = path_basename(core_path);
-      core_info_list_t *core_info    = NULL;
       char core_display_name[PATH_MAX_LENGTH];
-      size_t i;
+      core_info_ctx_find_t core_info;
       
       core_display_name[0] = '\0';
       
-      if (string_is_empty(core_path_basename))
-         goto reset_core;
+      /* Search core info */
+      core_info.inf  = NULL;
+      core_info.path = core_path;
       
-      /* Final check - search core info */
-      core_info_get_list(&core_info);
-      
-      if (core_info)
-      {
-         for (i = 0; i < core_info->count; i++)
-         {
-            const char *info_display_name = core_info->list[i].display_name;
-            
-            if (!string_is_equal(
-                  path_basename(core_info->list[i].path), core_path_basename))
-               continue;
-            
-            if (!string_is_empty(info_display_name))
-               strlcpy(core_display_name, info_display_name, sizeof(core_display_name));
-            
-            break;
-         }
-      }
+      if (core_info_find(&core_info) &&
+          !string_is_empty(core_info.inf->display_name))
+         strlcpy(core_display_name, core_info.inf->display_name,
+               sizeof(core_display_name));
       
       /* If core_display_name string is empty, it means the
        * core wasn't found -> reset association */

--- a/ui/drivers/qt/qt_playlist.cpp
+++ b/ui/drivers/qt/qt_playlist.cpp
@@ -988,7 +988,7 @@ void MainWindow::onPlaylistWidgetContextMenuRequested(const QPoint&)
          coreInfo.inf  = NULL;
          coreInfo.path = corePath;
 
-         if (core_info_find(&coreInfo, corePath))
+         if (core_info_find(&coreInfo))
          {
             /* Set new core association */
             playlist_set_default_core_path(playlist, coreInfo.inf->path);


### PR DESCRIPTION
## Description

RetroArch maintains a list of metadata for all installed cores in a `core_info` struct. Cores are referenced internally by their file path - any time metadata is required, the `core_info` struct is searched for a file match. This happens very frequently, and the current search method is highly inefficient.

This PR optimises core info searches, reducing the performance overheads of `core_info_find()` by ~73%. It also ensures that `core_info_find()` is used consistently - at present, there are several instances of 'manual' searches (looping through the core info struct 'by hand'); these have been replaced where possible.

In addition, the improved core matching/selection logic from pending PR  #10615 has been reimplemented here (the original PR was fine, but it turned out that there were issues with existing code *not* changed by  #10615, and I didn't think is was fair/appropriate to ask a new contributor to deal with all the associated unpleasantness...):

- Core info searches are now platform independent, ignoring file extensions and custom suffixes - e.g. searching with a core path from a Windows install will return the correct info entry on Android

- When launching content via a playlist, if the recorded core path was set on a different platform, the corresponding equivalent *local* core path will be used

All credit for the improved core logic idea and implementation goes to @francescotintori - many thanks!

Finally, this PR cleans up a fair amount of redundant, bizarre and broken code. (Of particular note: it removes the `action_ok_playlist_entry()` and `action_ok_playlist_entry_start_content()` functions, and properly sanitises the remaining `action_ok_playlist_entry_collection()`)

## Related Pull Requests

This PR replaces  #10615
