### PR TITLE
Added a hotkey delay option to fix issue #9080

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -1075,6 +1075,8 @@ static const unsigned input_bind_timeout = 5;
 
 static const unsigned input_bind_hold = 2;
 
+static const unsigned input_hotkey_block_delay = 0;
+
 static const unsigned gfx_thumbnails_default = 3;
 
 static const unsigned menu_left_thumbnails_default = 0;

--- a/config.def.h
+++ b/config.def.h
@@ -1075,7 +1075,7 @@ static const unsigned input_bind_timeout = 5;
 
 static const unsigned input_bind_hold = 2;
 
-static const unsigned input_hotkey_block_delay = 0;
+static const unsigned input_hotkey_block_delay = 5;
 
 static const unsigned gfx_thumbnails_default = 3;
 

--- a/configuration.c
+++ b/configuration.c
@@ -1754,6 +1754,7 @@ static struct config_uint_setting *populate_settings_uint(settings_t *settings, 
    SETTING_UINT("input_max_users",              input_driver_get_uint(INPUT_ACTION_MAX_USERS),        true, input_max_users, false);
    SETTING_UINT("fps_update_interval",          &settings->uints.fps_update_interval, true, DEFAULT_FPS_UPDATE_INTERVAL, false);
    SETTING_UINT("input_menu_toggle_gamepad_combo", &settings->uints.input_menu_toggle_gamepad_combo, true, menu_toggle_gamepad_combo, false);
+   SETTING_UINT("input_hotkey_block_delay",     &settings->uints.input_hotkey_block_delay, true, input_hotkey_block_delay, false);
 #ifdef GEKKO
    SETTING_UINT("input_mouse_scale",            &settings->uints.input_mouse_scale, true, DEFAULT_MOUSE_SCALE, false);
 #endif

--- a/configuration.h
+++ b/configuration.h
@@ -492,6 +492,7 @@ typedef struct settings
 #ifdef GEKKO
       unsigned input_mouse_scale;
 #endif
+      unsigned input_hotkey_block_delay;
       unsigned input_menu_toggle_gamepad_combo;
       unsigned input_keyboard_gamepad_mapping_type;
       unsigned input_poll_type_behavior;

--- a/retroarch.c
+++ b/retroarch.c
@@ -2011,6 +2011,7 @@ struct rarch_state
    unsigned osk_last_codepoint_len;
    unsigned input_driver_flushing_input;
    unsigned input_driver_max_users;
+   unsigned input_hotkey_block_counter;
 #ifdef HAVE_ACCESSIBILITY
    unsigned gamepad_input_override;
 #endif
@@ -21089,6 +21090,7 @@ static void input_menu_keys_pressed(
    unsigned i, port;
    settings_t     *settings                     = p_rarch->configuration_settings;
    bool input_all_users_control_menu            = settings->bools.input_all_users_control_menu;
+   int input_hotkey_block_delay                 = settings->uints.input_hotkey_block_delay;
    uint8_t max_users                            = (uint8_t)p_rarch->input_driver_max_users;
    uint8_t port_max                             = input_all_users_control_menu
       ? max_users : 1;
@@ -21123,11 +21125,17 @@ static void input_menu_keys_pressed(
                   &binds[0], port, RETRO_DEVICE_JOYPAD, 0,
                   RARCH_ENABLE_HOTKEY))
          {
-            p_rarch->input_driver_block_libretro_input = true;
-            break;
+            if (p_rarch->input_hotkey_block_counter < input_hotkey_block_delay)
+               p_rarch->input_hotkey_block_counter++;
+            else
+            {
+               p_rarch->input_driver_block_libretro_input = true;
+               break;
+            }
          }
          else
          {
+            p_rarch->input_hotkey_block_counter = 0;
             p_rarch->input_driver_block_hotkey         = true;
             break;
          }
@@ -21231,6 +21239,7 @@ static void input_keys_pressed(
 {
    unsigned i, port                       = 0;
    settings_t              *settings      = p_rarch->configuration_settings;
+   int input_hotkey_block_delay           = settings->uints.input_hotkey_block_delay;
    const struct retro_keybind *binds      = input_config_binds[0];
    const struct retro_keybind *binds_norm = &input_config_binds[port][RARCH_ENABLE_HOTKEY];
    const struct retro_keybind *binds_auto = &input_autoconf_binds[port][RARCH_ENABLE_HOTKEY];
@@ -21245,13 +21254,21 @@ static void input_keys_pressed(
          &input_config_binds[port][RARCH_ENABLE_HOTKEY];
 
       if (     enable_hotkey && enable_hotkey->valid
-            && p_rarch->current_input->input_state(
-               p_rarch->current_input_data, joypad_info,
-               &binds, port,
-               RETRO_DEVICE_JOYPAD, 0, RARCH_ENABLE_HOTKEY))
-         p_rarch->input_driver_block_libretro_input = true;
+         && p_rarch->current_input->input_state(
+            p_rarch->current_input_data, joypad_info,
+            &binds, port,
+            RETRO_DEVICE_JOYPAD, 0, RARCH_ENABLE_HOTKEY))
+      {
+         if (p_rarch->input_hotkey_block_counter < input_hotkey_block_delay)
+            p_rarch->input_hotkey_block_counter++;
+         else
+            p_rarch->input_driver_block_libretro_input = true;         
+      }
       else
+      {
+         p_rarch->input_hotkey_block_counter = 0;
          p_rarch->input_driver_block_hotkey         = true;
+      }
    }
 
    if (binds[RARCH_GAME_FOCUS_TOGGLE].valid)

--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -606,6 +606,10 @@
 # Alternatively, all hotkeys for keyboard could be disabled by the user.
 # input_enable_hotkey_btn =
 
+# Adds a delay in frames before the assigned hotkey blocks input.  Useful if the the
+# hotkey input is mapped to another action.
+# input_hotkey_block_delay = "0"
+
 # Increases audio volume.
 # input_volume_up = kp_plus
 # Decreases audio volume.

--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -608,7 +608,7 @@
 
 # Adds a delay in frames before the assigned hotkey blocks input.  Useful if the the
 # hotkey input is mapped to another action.
-# input_hotkey_block_delay = "0"
+# input_hotkey_block_delay = "5"
 
 # Increases audio volume.
 # input_volume_up = kp_plus


### PR DESCRIPTION
Fixes #9080.

Added a hotkey delay option to allow hotkey input to work properly when it is assigned to another action.  Original pull request from issue #9080 by paradadf was taken and modified to be configuration based.

Delay can be controlled by setting input_hotkey_block_delay = <frame delay> in configuration options.  Setting value to 0 (default) will effectively disable the functionality.