### PR TITLE
Vulkan: Refactor WSI handling

### DIFF
--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -1675,10 +1675,6 @@ static bool vulkan_context_init_device(gfx_ctx_vulkan_data_t *vk)
       "VK_KHR_sampler_mirror_clamp_to_edge",
    };
 
-#ifdef VULKAN_DEBUG
-   static const char *device_layers[] = { "VK_LAYER_LUNARG_standard_validation" };
-#endif
-
    struct retro_hw_render_context_negotiation_interface_vulkan *iface =
       (struct retro_hw_render_context_negotiation_interface_vulkan*)video_driver_get_context_negotiation_interface();
 
@@ -1705,13 +1701,8 @@ static bool vulkan_context_init_device(gfx_ctx_vulkan_data_t *vk)
             vulkan_symbol_wrapper_instance_proc_addr(),
             device_extensions,
             ARRAY_SIZE(device_extensions),
-#ifdef VULKAN_DEBUG
-            device_layers,
-            ARRAY_SIZE(device_layers),
-#else
             NULL,
             0,
-#endif
             &features);
 
       if (!ret)
@@ -1861,10 +1852,6 @@ static bool vulkan_context_init_device(gfx_ctx_vulkan_data_t *vk)
       device_info.enabledExtensionCount   = enabled_device_extension_count;
       device_info.ppEnabledExtensionNames = enabled_device_extension_count ? enabled_device_extensions : NULL;
       device_info.pEnabledFeatures        = &features;
-#ifdef VULKAN_DEBUG
-      device_info.enabledLayerCount       = ARRAY_SIZE(device_layers);
-      device_info.ppEnabledLayerNames     = device_layers;
-#endif
 
       if (cached_device_vk)
       {
@@ -1917,7 +1904,7 @@ bool vulkan_context_init(gfx_ctx_vulkan_data_t *vk,
 
 #ifdef VULKAN_DEBUG
    instance_extensions[ext_count++] = "VK_EXT_debug_report";
-   static const char *instance_layers[] = { "VK_LAYER_LUNARG_standard_validation" };
+   static const char *instance_layers[] = { "VK_LAYER_KHRONOS_validation" };
 #endif
 
    bool use_instance_ext;

--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -42,7 +42,7 @@
 #define VENDOR_ID_NV 0x10DE
 #define VENDOR_ID_INTEL 0x8086
 
-#if defined(_WIN32) || defined(ANDROID)
+#if defined(_WIN32)
 #define VULKAN_EMULATE_MAILBOX
 #endif
 

--- a/gfx/common/vulkan_common.h
+++ b/gfx/common/vulkan_common.h
@@ -118,6 +118,11 @@ typedef struct vulkan_context
    VkSemaphore swapchain_semaphores[VULKAN_MAX_SWAPCHAIN_IMAGES];
    VkFormat swapchain_format;
 
+   VkSemaphore swapchain_acquire_semaphore;
+   unsigned num_recycled_acquire_semaphores;
+   VkSemaphore swapchain_recycled_semaphores[VULKAN_MAX_SWAPCHAIN_IMAGES];
+   VkSemaphore swapchain_wait_semaphores[VULKAN_MAX_SWAPCHAIN_IMAGES];
+
    slock_t *queue_lock;
    retro_vulkan_destroy_device_t destroy_device;
 
@@ -154,6 +159,10 @@ typedef struct gfx_ctx_vulkan_data
    bool created_new_swapchain;
    bool emulate_mailbox;
    bool emulating_mailbox;
+   /* If set, prefer a path where we use
+    * semaphores instead of fences for vkAcquireNextImageKHR.
+    * Helps workaround certain performance issues on some drivers. */
+   bool use_wsi_semaphore;
    vulkan_context_t context;
    VkSurfaceKHR vk_surface;
    VkSwapchainKHR swapchain;
@@ -421,7 +430,7 @@ typedef struct vk
 
       struct retro_hw_render_interface_vulkan iface;
       const struct retro_vulkan_image *image;
-      const VkSemaphore *semaphores;
+      VkSemaphore *semaphores;
       VkSemaphore signal_semaphore;
       VkPipelineStageFlags *wait_dst_stages;
       VkCommandBuffer *cmd;

--- a/gfx/common/vulkan_common.h
+++ b/gfx/common/vulkan_common.h
@@ -102,6 +102,7 @@ typedef struct vulkan_context
    uint32_t graphics_queue_index;
    uint32_t num_swapchain_images;
    uint32_t current_swapchain_index;
+   uint32_t current_frame_index;
 
    VkInstance instance;
    VkPhysicalDevice gpu;
@@ -285,7 +286,6 @@ struct vk_descriptor_manager
 
 struct vk_per_frame
 {
-   struct vk_image backbuffer;
    struct vk_texture texture;
    struct vk_texture texture_optimal;
    struct vk_buffer_chain vbo;
@@ -344,7 +344,9 @@ typedef struct vk
    VkRenderPass render_pass;
    struct video_viewport vp;
    struct vk_per_frame *chain;
+   struct vk_image *backbuffer;
    struct vk_per_frame swapchain[VULKAN_MAX_SWAPCHAIN_IMAGES];
+   struct vk_image backbuffers[VULKAN_MAX_SWAPCHAIN_IMAGES];
    struct vk_texture default_texture;
 
    /* Currently active command buffer. */


### PR DESCRIPTION
There are some problem platforms with WSI currently, which this PR partly addresses.

- Intel Mesa is broken when using Fences, we have to use Semaphores to acquire the swapchain or the entire GPU stalls.
- Add support for either using fences or semaphores when syncing.
- Prefer using semaphores for integrated GPUs as it promotes better throughput over fences.
- Do not use mailbox emulation on Android.

Also, to make this work, decouple frame index from swapchain index w.r.t. CPU-side synchronization. Before, swapchain index would be coupled with frame context, which is somewhat naive.
