### PR TITLE
Fix 3DS build

### DIFF
--- a/gfx/drivers/ctr_gfx.c
+++ b/gfx/drivers/ctr_gfx.c
@@ -523,7 +523,6 @@ static bool ctr_frame(void* data, const void* frame,
       uint64_t frame_count,
       unsigned pitch, const char* msg, video_frame_info_t *video_info)
 {
-   extern bool select_pressed;
    static uint64_t currentTick,lastTick;
    touchPosition state_tmp_touch;
    extern GSPGPU_FramebufferInfo topFramebufferInfo;
@@ -555,12 +554,6 @@ static bool ctr_frame(void* data, const void* frame,
    }
 
    if(!aptMainLoop())
-   {
-      command_event(CMD_EVENT_QUIT, NULL);
-      return true;
-   }
-
-   if (select_pressed)
    {
       command_event(CMD_EVENT_QUIT, NULL);
       return true;


### PR DESCRIPTION
## Description

Commit https://github.com/libretro/RetroArch/commit/41ffca2b6fcf9bca6826a6d04630685ab0df83e2 broke the 3DS build, This trivial PR fixes it.