### PR TITLE
(Widgets) Fix serious heap-use-after-free errors

### DIFF
--- a/gfx/gfx_animation.h
+++ b/gfx/gfx_animation.h
@@ -100,12 +100,6 @@ enum gfx_animation_ticker_type
    TICKER_TYPE_LAST
 };
 
-typedef struct gfx_animation_ctx_subject
-{
-   size_t count;
-   const void *data;
-} gfx_animation_ctx_subject_t;
-
 typedef struct gfx_animation_ctx_entry
 {
    enum gfx_animation_easing_type easing_enum;
@@ -218,8 +212,6 @@ float gfx_animation_get_delta_time(void);
 bool gfx_animation_is_active(void);
 
 bool gfx_animation_kill_by_tag(uintptr_t *tag);
-
-void gfx_animation_kill_by_subject(gfx_animation_ctx_subject_t *subject);
 
 bool gfx_animation_push(gfx_animation_ctx_entry_t *entry);
 

--- a/gfx/gfx_widgets.c
+++ b/gfx/gfx_widgets.c
@@ -2252,6 +2252,16 @@ static void gfx_widgets_free(dispgfx_widget_t *p_dispwidget)
          fifo_read(p_dispwidget->msg_queue,
                &msg_widget, sizeof(msg_widget));
 
+         /* Note: gfx_widgets_free() is only called when
+          * main_exit() is invoked. At this stage, we cannot
+          * guarantee that any task pointers are valid (the
+          * task may have been free()'d, but we can't know
+          * that here) - so all we can do is unset the task
+          * pointer associated with each message
+          * > If we don't do this, gfx_widgets_msg_queue_free()
+          *   will generate heap-use-after-free errors */
+         msg_widget->task_ptr = NULL;
+
          gfx_widgets_msg_queue_free(p_dispwidget, msg_widget, false);
          free(msg_widget);
       }
@@ -2267,6 +2277,16 @@ static void gfx_widgets_free(dispgfx_widget_t *p_dispwidget)
       {
          menu_widget_msg_t *msg = (menu_widget_msg_t*)
             p_dispwidget->current_msgs->list[i].userdata;
+
+         /* Note: gfx_widgets_free() is only called when
+          * main_exit() is invoked. At this stage, we cannot
+          * guarantee that any task pointers are valid (the
+          * task may have been free()'d, but we can't know
+          * that here) - so all we can do is unset the task
+          * pointer associated with each message
+          * > If we don't do this, gfx_widgets_msg_queue_free()
+          *   will generate heap-use-after-free errors */
+         msg->task_ptr = NULL;
 
          gfx_widgets_msg_queue_free(p_dispwidget, msg, false);
       }


### PR DESCRIPTION
## Description

At present, there is a serious bug in `gfx_animation_kill_by_tag()`

If both `gfx_animation_push()` and `gfx_animation_kill_by_tag()` are called for an entry with the same tag inside one invocation of `gfx_animation_update()` then the entry *will not be killed*. This is because the entry will be pushed to a 'pending' list, whereas `gfx_animation_kill_by_tag()` only considers the 'active' list (and 'pending' items only get added to the 'active' list at the very end of `gfx_animation_update()`).

Menu drivers and suchlike never trigger this error - but gfx widgets require a complicated sequence of push/kill callbacks, which means this happens *all the time* when widgets are enabled.

The main consequence of this is the following - this code gets invoked regularly:

```c
      *tween->subject       = tween->easing(
            tween->running_since,
            tween->initial_value,
            tween->target_value - tween->initial_value,
            tween->duration);
```

...and when a widget-induced `gfx_animation_kill_by_tag()` fails, it means that `tween->subject` is pointing to free()'d memory. This kind of heap-use-after-free write error is pretty bad - it means widgets have been silently corrupting memory ever since they were first introduced...

This PR fixes the issue, by also scanning the 'pending' animation list where required when `gfx_animation_kill_by_tag()` is called.

The PR also fixes a second heap-use-after-free write error that can happen when closing RetroArch with widgets enabled (this one is much, much harder to trigger, so not a huge issue for most users). Essentially, each task message widget is linked to a task, which is in turn linked back to the widget. In all usual cases everything works fine, but when quitting RetroArch it is possible for a task to be free()'d before its linked widget in such a manner that the widget isn't informed - so when the message widget is free()'d, it tries to unlink itself from the task and ends up writing to a free()'d pointer. With this PR, the widget-to-task pointer is just manually unset when calling `gfx_widgets_free()`, so no write occurs (this is safe, since we're tearing down everything at this point anyway).

Finally, this PR removes the redundant `gfx_animation_kill_by_subject()` function from `gfx_animation.h/.c` - this is not used anywhere, and its functionality is strange, and likely to cause mistakes...