### PR TITLE
(cheevos) support for less common file extensions

### DIFF
--- a/deps/rcheevos/src/rhash/hash.c
+++ b/deps/rcheevos/src/rhash/hash.c
@@ -1390,6 +1390,15 @@ void rc_hash_initialize_iterator(struct rc_hash_iterator* iterator, const char* 
     const char* ext = rc_path_get_extension(path);
     switch (tolower(*ext))
     {
+      case '7':
+        if (rc_path_compare_extension(ext, "7z"))
+        {
+          /* decompressing zip file not supported */
+          iterator->consoles[0] = RC_CONSOLE_ARCADE;
+          need_path = 1;
+        }
+        break;
+
       case 'a':
         if (rc_path_compare_extension(ext, "a78"))
         {
@@ -1414,12 +1423,14 @@ void rc_hash_initialize_iterator(struct rc_hash_iterator* iterator, const char* 
 
                  if (size > 32 * 1024 * 1024)
                  {
-                    /* 3DO and Sega CD are the only cores that supports directly opening the bin file. */
-                    iterator->consoles[0] = RC_CONSOLE_3DO;
-                    iterator->consoles[1] = RC_CONSOLE_SEGA_CD;
+                    iterator->consoles[0] = RC_CONSOLE_3DO; /* 4DO supports directly opening the bin file */
+                    iterator->consoles[1] = RC_CONSOLE_PLAYSTATION; /* PCSX ReARMed supports directly opening the bin file*/
 
-                    /* fallback to megadrive - see comment below */
-                    iterator->consoles[2] = RC_CONSOLE_MEGA_DRIVE;
+                    /* SEGA CD hash doesn't have any logic to ensure it's being used against a SEGA CD, so it should always be last */
+                    iterator->consoles[2] = RC_CONSOLE_SEGA_CD; /* Genesis Plus GX supports directly opening the bin file*/
+
+                    /* fallback to megadrive - will only be checked if SEGA CD hash does not match */
+                    iterator->consoles[3] = RC_CONSOLE_MEGA_DRIVE;
                     break;
                  }
               }
@@ -1428,6 +1439,10 @@ void rc_hash_initialize_iterator(struct rc_hash_iterator* iterator, const char* 
           /* bin is associated with MegaDrive, Sega32X and Atari 2600. Since they all use the same
            * hashing algorithm, only specify one of them */
           iterator->consoles[0] = RC_CONSOLE_MEGA_DRIVE;
+        }
+        else if (rc_path_compare_extension(ext, "bs"))
+        {
+           iterator->consoles[0] = RC_CONSOLE_SUPER_NINTENDO;
         }
         break;
 
@@ -1581,7 +1596,9 @@ void rc_hash_initialize_iterator(struct rc_hash_iterator* iterator, const char* 
         break;
 
       case 's':
-        if (rc_path_compare_extension(ext, "smc") || rc_path_compare_extension(ext, "sfc"))
+        if (rc_path_compare_extension(ext, "smc") ||
+            rc_path_compare_extension(ext, "sfc") ||
+            rc_path_compare_extension(ext, "swc"))
         {
           iterator->consoles[0] = RC_CONSOLE_SUPER_NINTENDO;
         }


### PR DESCRIPTION
## Description

Followup to #10811. Adds support for some less common file extensions.
* `.7z` for arcade
* `.bs` and `.swc` for SNES
* `.bin` for PSX (PCSX-rearmed supports loading the bin directly, but it's still preferable to use the cue)

## Related Issues

n/a

## Related Pull Requests

#10811

## Reviewers

@meleu
