### PR TITLE
(X11/udev) Input fixes

### DIFF
--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -790,10 +790,10 @@ static bool udev_pointer_is_off_window(const udev_input_t *udev)
    bool r = video_driver_get_viewport_info(&view);
 
    if (r)
-      r = udev->pointer_x < view.x ||
-          udev->pointer_x >= view.x + view.width ||
-          udev->pointer_y < view.y ||
-          udev->pointer_y >= view.y + view.height;
+      r = udev->pointer_x < 0 ||
+          udev->pointer_x >= view.full_width ||
+          udev->pointer_y < 0 ||
+          udev->pointer_y >= view.full_height;
    return r;
 #else
    return false;
@@ -1028,14 +1028,19 @@ static int16_t udev_input_state(void *data,
             {
                for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)
                {
-                  if ( (binds[port][i].key < RETROK_LAST) && 
-                        udev_keyboard_pressed(udev, binds[port][i].key) )
-                        return 1;
+                  bool keyboard_pressed = false;
+                  bool joypad_pressed   = false;
+
                   if (binds[port][i].valid)
-                     if (udev_is_pressed(
-                              udev, udev->joypad,
-                              joypad_info, binds[port], port, i))
-                        ret |= (1 << i);
+                  {
+                     keyboard_pressed = (binds[port][i].key < RETROK_LAST) ?
+                           udev_keyboard_pressed(udev, binds[port][i].key) : false;
+                     joypad_pressed   = udev_is_pressed(udev, udev->joypad,
+                           joypad_info, binds[port], port, i);
+                  }
+
+                  if (keyboard_pressed || joypad_pressed)
+                     ret |= (1 << i);
                }
             }
 

--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -1028,19 +1028,19 @@ static int16_t udev_input_state(void *data,
             {
                for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)
                {
-                  bool keyboard_pressed = false;
-                  bool joypad_pressed   = false;
-
                   if (binds[port][i].valid)
                   {
-                     keyboard_pressed = (binds[port][i].key < RETROK_LAST) ?
-                           udev_keyboard_pressed(udev, binds[port][i].key) : false;
-                     joypad_pressed   = udev_is_pressed(udev, udev->joypad,
-                           joypad_info, binds[port], port, i);
-                  }
+                     if (udev_is_pressed(udev, udev->joypad,
+                           joypad_info, binds[port], port, i))
+                     {
+                        ret |= (1 << i);
+                        continue;
+                     }
 
-                  if (keyboard_pressed || joypad_pressed)
-                     ret |= (1 << i);
+                     if ((binds[port][i].key < RETROK_LAST) &&
+                           udev_keyboard_pressed(udev, binds[port][i].key))
+                        ret |= (1 << i);
+                  }
                }
             }
 

--- a/input/drivers/x11_input.c
+++ b/input/drivers/x11_input.c
@@ -329,14 +329,19 @@ static int16_t x_input_state(void *data,
             {
                for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)
                {
-                  if ((binds[port][i].key < RETROK_LAST) && 
-                        x_keyboard_pressed(x11, binds[port][i].key) )
-                     return 1;
+                  bool keyboard_pressed = false;
+                  bool joypad_pressed   = false;
+
                   if (binds[port][i].valid)
-                     if (x_is_pressed(
-                              x11, x11->joypad,
-                              joypad_info, binds[port], port, i))
-                        ret |= (1 << i);
+                  {
+                     keyboard_pressed = (binds[port][i].key < RETROK_LAST) ?
+                           x_keyboard_pressed(x11, binds[port][i].key) : false;
+                     joypad_pressed   = x_is_pressed(x11, x11->joypad,
+                           joypad_info, binds[port], port, i);
+                  }
+
+                  if (keyboard_pressed || joypad_pressed)
+                     ret |= (1 << i);
                }
             }
 

--- a/input/drivers/x11_input.c
+++ b/input/drivers/x11_input.c
@@ -329,19 +329,19 @@ static int16_t x_input_state(void *data,
             {
                for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)
                {
-                  bool keyboard_pressed = false;
-                  bool joypad_pressed   = false;
-
                   if (binds[port][i].valid)
                   {
-                     keyboard_pressed = (binds[port][i].key < RETROK_LAST) ?
-                           x_keyboard_pressed(x11, binds[port][i].key) : false;
-                     joypad_pressed   = x_is_pressed(x11, x11->joypad,
-                           joypad_info, binds[port], port, i);
-                  }
+                     if (x_is_pressed(x11, x11->joypad,
+                           joypad_info, binds[port], port, i))
+                     {
+                        ret |= (1 << i);
+                        continue;
+                     }
 
-                  if (keyboard_pressed || joypad_pressed)
-                     ret |= (1 << i);
+                     if ((binds[port][i].key < RETROK_LAST) &&
+                           x_keyboard_pressed(x11, binds[port][i].key))
+                        ret |= (1 << i);
+                  }
                }
             }
 

--- a/libretro-common/include/retro_miscellaneous.h
+++ b/libretro-common/include/retro_miscellaneous.h
@@ -106,8 +106,8 @@ static INLINE bool bits_any_set(uint32_t* ptr, uint32_t count)
 #define BIT16_GET(a, bit)    (((a) >> ((bit) & 15)) & 1)
 #define BIT16_CLEAR_ALL(a)   ((a) = 0)
 
-#define BIT32_SET(a, bit)    ((a) |=  (1 << ((bit) & 31)))
-#define BIT32_CLEAR(a, bit)  ((a) &= ~(1 << ((bit) & 31)))
+#define BIT32_SET(a, bit)    ((a) |=  (UINT32_C(1) << ((bit) & 31)))
+#define BIT32_CLEAR(a, bit)  ((a) &= ~(UINT32_C(1) << ((bit) & 31)))
 #define BIT32_GET(a, bit)    (((a) >> ((bit) & 31)) & 1)
 #define BIT32_CLEAR_ALL(a)   ((a) = 0)
 
@@ -116,8 +116,8 @@ static INLINE bool bits_any_set(uint32_t* ptr, uint32_t count)
 #define BIT64_GET(a, bit)    (((a) >> ((bit) & 63)) & 1)
 #define BIT64_CLEAR_ALL(a)   ((a) = 0)
 
-#define BIT128_SET(a, bit)   ((a).data[(bit) >> 5] |=  (1 << ((bit) & 31)))
-#define BIT128_CLEAR(a, bit) ((a).data[(bit) >> 5] &= ~(1 << ((bit) & 31)))
+#define BIT128_SET(a, bit)   ((a).data[(bit) >> 5] |=  (UINT32_C(1) << ((bit) & 31)))
+#define BIT128_CLEAR(a, bit) ((a).data[(bit) >> 5] &= ~(UINT32_C(1) << ((bit) & 31)))
 #define BIT128_GET(a, bit)   (((a).data[(bit) >> 5] >> ((bit) & 31)) & 1)
 #define BIT128_CLEAR_ALL(a)  memset(&(a), 0, sizeof(a))
 


### PR DESCRIPTION
## Description

The recent input clean-ups caused a regression when using the `X11` or `udev` input drivers - when pressing keyboard keys mapped to gamepad inputs, every button would register as RetroPad 'A'.

This PR fixes the issue.

It also fixes mouse input when using the `udev` input driver - this was mistakenly being disabled when the cursor was outside the current *viewport* instead of the actual display window, which basically meant that trying to click anything on the left or right hand edges of the menu made the input fallback to touchscreen mode, which in turn caused the pointer to jump to random locations (such that the click would register in the wrong place)

Finally, it fixes the following input-related runtime error, detected using ASAN:

```
retroarch.c:24198:13: runtime error: left shift of 1 by 31 places cannot be represented in type 'int'
```

There remains one issue when using the `udev` input driver - it is impossible to bind keyboard inputs correctly. Once they are bound, either by using a different driver or by editing the config file, they work fine - but they cannot be bound via the menu. This seems to be due to a conflict between the usage of `input_keyboard_event()` in both `udev_input.c` *and* `x11_common.c` (it ends up getting called twice when trying to bind anything, and one of them uses the wrong keyboard mapping). Unfortunately, I have no idea how to fix this...  :(

Thus it is currently recommended that Linux users set input driver to `x`, and only set the controller driver to `udev`.

## Related Issues

This should address #10840
