### PR TITLE
(cheevos) disable hardcore mode when playing bsv file

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -22501,7 +22501,13 @@ static int16_t input_state(unsigned port, unsigned device,
    {
       int16_t bsv_result;
       if (intfstream_read(p_rarch->bsv_movie_state_handle->file, &bsv_result, 2) == 2)
+      {
+#ifdef HAVE_CHEEVOS
+         rcheevos_pause_hardcore();
+#endif
          return swap_if_big16(bsv_result);
+      }
+
       p_rarch->bsv_movie_state.movie_end = true;
    }
 


### PR DESCRIPTION
## Description

Disables achievements hardcode mode when playing back a .bsv file.

Sets the hardcore_paused flag each time an input is read from the file. Originally, I only disabled when loading the file, but the user can quickly enter the menu and reenable hardcore mode, which resets the emulator and the file continues playing.

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@meleu 