### PR TITLE
(GLUI) Optimise list insertion when adding playlist and dropdown list items

### DIFF
--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -9181,6 +9181,39 @@ static void materialui_list_insert(
             node->icon_texture_index = MUI_TEXTURE_LOAD_STATE;
             node->has_icon           = true;
             break;
+         case FILE_TYPE_RPL_ENTRY:
+         case MENU_SETTING_DROPDOWN_ITEM:
+         case MENU_SETTING_DROPDOWN_ITEM_RESOLUTION:
+         case MENU_SETTING_DROPDOWN_ITEM_VIDEO_SHADER_PARAM:
+         case MENU_SETTING_DROPDOWN_ITEM_VIDEO_SHADER_PRESET_PARAM:
+         case MENU_SETTING_DROPDOWN_ITEM_VIDEO_SHADER_NUM_PASS:
+         case MENU_SETTING_DROPDOWN_ITEM_PLAYLIST_DEFAULT_CORE:
+         case MENU_SETTING_DROPDOWN_ITEM_PLAYLIST_LABEL_DISPLAY_MODE:
+         case MENU_SETTING_DROPDOWN_ITEM_PLAYLIST_RIGHT_THUMBNAIL_MODE:
+         case MENU_SETTING_DROPDOWN_ITEM_PLAYLIST_LEFT_THUMBNAIL_MODE:
+         case MENU_SETTING_DROPDOWN_ITEM_PLAYLIST_SORT_MODE:
+         case MENU_SETTING_DROPDOWN_ITEM_MANUAL_CONTENT_SCAN_SYSTEM_NAME:
+         case MENU_SETTING_DROPDOWN_ITEM_MANUAL_CONTENT_SCAN_CORE_NAME:
+         case MENU_SETTING_DROPDOWN_ITEM_DISK_INDEX:
+         case MENU_SETTING_DROPDOWN_SETTING_CORE_OPTIONS_ITEM:
+         case MENU_SETTING_DROPDOWN_SETTING_STRING_OPTIONS_ITEM:
+         case MENU_SETTING_DROPDOWN_SETTING_FLOAT_ITEM:
+         case MENU_SETTING_DROPDOWN_SETTING_INT_ITEM:
+         case MENU_SETTING_DROPDOWN_SETTING_UINT_ITEM:
+         case MENU_SETTING_DROPDOWN_SETTING_CORE_OPTIONS_ITEM_SPECIAL:
+         case MENU_SETTING_DROPDOWN_SETTING_STRING_OPTIONS_ITEM_SPECIAL:
+         case MENU_SETTING_DROPDOWN_SETTING_FLOAT_ITEM_SPECIAL:
+         case MENU_SETTING_DROPDOWN_SETTING_INT_ITEM_SPECIAL:
+         case MENU_SETTING_DROPDOWN_SETTING_UINT_ITEM_SPECIAL:
+         case MENU_SETTINGS_CORE_INFO_NONE:
+         case MENU_SETTING_ITEM_CORE_RESTORE_BACKUP:
+         case MENU_SETTING_ITEM_CORE_DELETE_BACKUP:
+            /* None of these entries have icons - catch them
+             * here (and leave icon_texture_index/has_icon
+             * set to the default 'disabled' state) to avoid
+             * having to process the 'default' case of this
+             * switch */
+            break;
          default:
             if (
                   string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_INFORMATION_LIST))              ||


### PR DESCRIPTION
## Description

Material UI is unusual among menu drivers in that it assigns entry icons when each menu list is being built (the other drivers do this when the entries are being drawn). This provides greater efficiency during the rendering phase, but it means `materialui_list_insert()` has to perform a great many label string comparisons to identify the type (and hence icon) of each item being added.

The issue is that many kinds of entry - in particular playlists and drop-down value selection lists - do not have icons, and at present these just fall-through to an 'icon disabled' state *after* all the string comparisons have been performed.

For these kinds of entry, this means we perform literally *tens of millions* of unnecessary string comparisons within a handful of seconds of normal menu navigation... This is not good.

This PR just 'catches' all playlist and drop-down list entries before the string comparisons begin. This reduces the performance overheads of `materialui_list_insert()` by ~95% when dealing with these entries (and since these inevitably correspond to the longest kinds of menu, this makes a substantial difference to navigation efficiency...)
