### PR TITLE
(cheevos) correctly report unlocked non-hardcore achievements when hardcore is paused

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -1153,7 +1153,7 @@ void rcheevos_get_achievement_state(unsigned index, char *buffer, size_t buffer_
    else
    {
       settings_t* settings = config_get_ptr();
-      bool hardcore        = settings->bools.cheevos_hardcore_mode_enable;
+      bool hardcore        = settings->bools.cheevos_hardcore_mode_enable && !rcheevos_hardcore_paused;
       if (hardcore && !(cheevo->active & RCHEEVOS_ACTIVE_HARDCORE))
          enum_idx = MENU_ENUM_LABEL_VALUE_CHEEVOS_UNLOCKED_ENTRY_HARDCORE;
       else if (!hardcore && !(cheevo->active & RCHEEVOS_ACTIVE_SOFTCORE))


### PR DESCRIPTION
## Description

Modifies the hardcore mode check used to display "Locked/Unlocked/Hardcore" in the quick menu to also check the hardcore-paused state.

When a player unlocks an achievement and they're not in hardcore, the achievement is still flagged as locked in hardcode. The menu was only checking for hardcore-enabled to determine if it should look at the locked state for hardcore or non-hardcore. When hardcore is paused, it was still looking at the hardcore locked state, so unlocking the non-hardcore version of the achievement didn't update the menu.

## Related Issues

fixes #10857

## Related Pull Requests

n/a

## Reviewers

@meleu
