### PR TITLE
Add missing labels for 'VIDEO_SHADER_PRESET_SAVE' enums

### DIFF
--- a/intl/msg_hash_lbl.h
+++ b/intl/msg_hash_lbl.h
@@ -3087,6 +3087,22 @@ MSG_HASH(
    "video_shader_preset_save_as"
    )
 MSG_HASH(
+   MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_SAVE_GLOBAL,
+   "video_shader_preset_save_global"
+   )
+MSG_HASH(
+   MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_SAVE_CORE,
+   "video_shader_preset_save_core"
+   )
+MSG_HASH(
+   MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_SAVE_PARENT,
+   "video_shader_preset_save_parent"
+   )
+MSG_HASH(
+   MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_SAVE_GAME,
+   "video_shader_preset_save_game"
+   )
+MSG_HASH(
    MENU_ENUM_LABEL_VIDEO_SHADER_SCALE_PASS,
    "video_shader_scale_pass"
    )


### PR DESCRIPTION
## Description

I just noticed that several of the `VIDEO_SHADER_PRESET_SAVE` menu enums are missing labels (in `msg_hash_lbl.h`). This is mostly harmless (in this particular case...), but it causes the corresponding menu entries to have the wrong icons in Material UI.

This trivial PR fixes the issue.
