### PR TITLE
Fix display of core-generated messages when load content fails

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -14833,9 +14833,16 @@ bool command_event(enum event_command cmd, void *data)
             break;
          }
       case CMD_EVENT_CORE_INIT:
-         content_reset_savestate_backups();
          {
-            enum rarch_core_type *type = (enum rarch_core_type*)data;
+            enum rarch_core_type *type    = (enum rarch_core_type*)data;
+            rarch_system_info_t *sys_info = &p_rarch->runloop_system;
+
+            content_reset_savestate_backups();
+
+            /* Ensure that disk control interface is reset */
+            if (sys_info)
+               disk_control_set_ext_callback(&sys_info->disk_control, NULL);
+
             if (!type || !command_event_init_core(p_rarch, *type))
                return false;
          }
@@ -17175,7 +17182,7 @@ static void runloop_core_msg_queue_push(
    }
 
    /* Get duration in frames */
-   fps             = av_info ? av_info->timing.fps : 60.0;
+   fps             = (av_info && (av_info->timing.fps > 0)) ? av_info->timing.fps : 60.0;
    duration_frames = (unsigned)((fps * (float)msg->duration / 1000.0f) + 0.5f);
 
    runloop_msg_queue_push(msg->msg,

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -2579,7 +2579,10 @@ bool content_init(void)
       {
          RARCH_ERR("[CONTENT LOAD]: %s\n", error_string);
       }
-      runloop_msg_queue_push(error_string, 2, ret ? 1 : 180, true, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
+      /* Do not flush the message queue here
+       * > This allows any core-generated error messages
+       *   to propagate through to the frontend */
+      runloop_msg_queue_push(error_string, 2, ret ? 1 : 180, false, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
       free(error_string);
    }
 


### PR DESCRIPTION
## Description

At present, it is impossible for cores to generate an on-screen notification when content fails to load - i.e.if a core detects that content is invalid (or bios files are missing, etc.) inside `retro_load_game()`, then tries to inform the user via the `RETRO_ENVIRONMENT_SET_MESSAGE_EXT` callback and subsequently returns `false`, the message will be 'lost' (nothing will be shown on-screen).

There are actually three issues here:

- The frontend-generated 'failed to load content' error message flushes the notification queue - so the previous core-generated message is wiped

- If the core has disk control interface support, the current disk control callback mapping *is not reset* when the failed core closes and the dummy core is subsequently loaded. This means spurious disk-related error notifications are generated, which also flush the notification queue...

- When loading content from the command line, the core-generated message duration is set to zero. This happens because the duration is dependent upon frame rate, and the initial recorded FPS when launching from the command line is invalid (0).

This PR fixes these issues.