### PR TITLE
(Ozone) Add missing icon for 'State Slot' option in Quick Menu

### DIFF
--- a/menu/drivers/ozone/ozone_texture.c
+++ b/menu/drivers/ozone/ozone_texture.c
@@ -71,6 +71,8 @@ uintptr_t ozone_entries_icon_get_texture(ozone_handle_t *ozone,
          return ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_ACHIEVEMENT_LIST];
       case MENU_ENUM_LABEL_ACHIEVEMENT_LIST_HARDCORE:
          return ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_ACHIEVEMENT_LIST];
+      case MENU_ENUM_LABEL_STATE_SLOT:
+         return ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_SETTING];
       case MENU_ENUM_LABEL_SAVE_STATE:
       case MENU_ENUM_LABEL_CORE_CREATE_BACKUP:
          return ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_SAVESTATE];


### PR DESCRIPTION
## Description

The *State Slot* option in the Quick Menu seems to be the only option without an icon in the **Ozone** menu driver:

![image](https://user-images.githubusercontent.com/5802993/85182391-6ba8bd00-b280-11ea-94c7-a7798d82897d.png)

Inspired by the current icon in the **XMB** menu driver for the same option:

![xmb](https://user-images.githubusercontent.com/5802993/85182432-9135c680-b280-11ea-8719-15efe753efc2.png)

This PR adds the same type of icon used in XMB for *State Slot* to the **Ozone** menu driver as well for visual consistency:

![image](https://user-images.githubusercontent.com/5802993/85182508-ca6e3680-b280-11ea-9f21-13d23ab2991d.png)
