### PR TITLE
(Database) Fix rtime in db-converter compilation

### DIFF
--- a/libretro-db/Makefile
+++ b/libretro-db/Makefile
@@ -15,6 +15,7 @@ LIBRETRO_COMMON_C = \
 			 $(LIBRETRO_COMM_DIR)/string/stdstring.c \
 			 $(LIBRETRO_COMM_DIR)/streams/file_stream.c \
 			 $(LIBRETRO_COMM_DIR)/compat/compat_strcasestr.c \
+			 $(LIBRETRO_COMM_DIR)/time/rtime.c \
 			 $(LIBRETRO_COMM_DIR)/file/file_path.c \
 			 $(LIBRETRO_COMM_DIR)/file/file_path_io.c \
 			 $(LIBRETRO_COMM_DIR)/vfs/vfs_implementation.c \


### PR DESCRIPTION
Compilation broke for the database.... `file_path.c` needs `rtime`.

To test....
```
git clone https://github.com/libretro/libretro-database.git
cd libretro-database
make build
```