### PR TITLE
(cheevos) hash buffered data when available

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -1548,7 +1548,7 @@ static int rcheevos_iterate(rcheevos_coro_t* coro)
          CORO_STOP();
 
       /* iterate over the possible hashes for the file being loaded */
-      rc_hash_initialize_iterator(&coro->iterator, coro->path, NULL, 0);
+      rc_hash_initialize_iterator(&coro->iterator, coro->path, coro->data, coro->len);
 #ifdef CHEEVOS_TIME_HASH
       start = cpu_features_get_time_usec();
 #endif


### PR DESCRIPTION
## Description

The claim in #10811 that the buffered data would still be used for hashing was incorrect. I had forgotten to pass it to the hashing function.

Spot-tested several systems (some that buffered, some that did not)

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@meleu @sanaki
