### PR TITLE
(Win32/DispServer) Improve screen resolution menu

### DIFF
--- a/menu/drivers/ozone/ozone_texture.c
+++ b/menu/drivers/ozone/ozone_texture.c
@@ -191,6 +191,8 @@ uintptr_t ozone_entries_icon_get_texture(ozone_handle_t *ozone,
             return ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_AUDIO];
       case MENU_ENUM_LABEL_AUDIO_MIXER_SETTINGS:
             return ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_MIXER];
+      case MENU_ENUM_LABEL_SCREEN_RESOLUTION:
+         return ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_SUBSETTING];
       case MENU_ENUM_LABEL_INPUT_SETTINGS:
       case MENU_ENUM_LABEL_UPDATE_AUTOCONFIG_PROFILES:
       case MENU_ENUM_LABEL_INPUT_USER_1_BINDS:

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -2594,6 +2594,8 @@ static uintptr_t xmb_icon_get_id(xmb_handle_t *xmb,
          return xmb->textures.list[XMB_TEXTURE_AUDIO];
       case MENU_ENUM_LABEL_AUDIO_MIXER_SETTINGS:
          return xmb->textures.list[XMB_TEXTURE_MIXER];
+      case MENU_ENUM_LABEL_SCREEN_RESOLUTION:
+         return xmb->textures.list[XMB_TEXTURE_SUBSETTING];
       case MENU_ENUM_LABEL_INPUT_SETTINGS:
       case MENU_ENUM_LABEL_UPDATE_AUTOCONFIG_PROFILES:
       case MENU_ENUM_LABEL_INPUT_USER_1_BINDS:


### PR DESCRIPTION
## Description

Currently, the `Settings > Video > Output > Screen Resolution` menu has the following issues in Windows:

(1)  In certain systems, specially in laptops, there are a lot of *seemingly* duplicated entries:

![image](https://user-images.githubusercontent.com/5802993/85236458-fec72b80-b415-11ea-9dd0-c6fb4c1f2f23.png)

In addition, multiple screen resolutions can be seen marked as *active/current* and there are resolutions with swapped width/height values due to different orientations as shown in the screenshot above.

The problem is that, for the same resolution/refresh combination, there are multiple video modes with different bits-per-pixel (bpp), orientation and stretching type. Because these attributes are not shown in the text of the menu entries, these multiple video modes appear as if they were duplicates of the same resolution/refresh, leading to confusion and inconsistent results.

(2) When changing screen resolutions in this menu, the effect of the change can be confusing because the user can (unknowingly) pick a different rotation/stretching than the current setting and get very unexpected results. For example if the user has currently a 90deg screen orientation and picks a resolution with 0deg, the screen will switch resolution AND change orientation at the same time. Moreover if the selected video mode also has a different stretching type, this also will change without any apparent explanation.

This PR fixes both issues by doing the following changes in the Win32 display server code:

(1) Improve building of video resolution list in `win32_display_server_get_resolution_list()`:
* Only use display modes with the same current bit-depth and screen rotation
* Only use display modes with default stretching mode

This makes the `Screen Resolution` menu restricted to only change resolution/refresh without changing current bts-per-pixel, orientation nor stretching type. Screen orientation has its own independent menu in `Settings > Video > Output` and changing bits-per-pixel and stretching type is not currently supported in `win32_display_server_set_resolution()`.

(2) Improve video resolution switching in `win32_display_server_set_resolution()`:
* Only switch to a display mode with the same current bit-depth and screen rotation
* Only switch to a display mode with default stretching mode

This ensures that screen resolution changes remain consistent with the current screen orientation and stretching type and the user always gets the expected result.

Apart from the above changes, this PR also has code cleanups to both affected functions and ensures a consistent icon for the `Screen Resolution` option in both Ozone and XMB as well.

## Screenshots

Screen resolution entries after this PR for a **normal** screen orientation (no duplicates, no inter-mixed swapped width/height and just one active entry). The list is now much cleaner and reduced to only relevant video modes for the current bits-per-pixel, orientation and default stretching type.

![image](https://user-images.githubusercontent.com/5802993/85237082-7fd4f180-b41b-11ea-8883-0ade803559f0.png)

Screen resolution entries after this PR for a **90deg** screen orientation (notice all width/height are now swapped):

![image](https://user-images.githubusercontent.com/5802993/85237095-9d09c000-b41b-11ea-8c68-e6538cf884de.png)

Before this PR, there is a lonely icon for the `Screen Orientation` menu in Ozone and an inconsistent icon in XMB:

![image](https://user-images.githubusercontent.com/5802993/85237116-038ede00-b41c-11ea-958b-ca78663746a6.png)

![image](https://user-images.githubusercontent.com/5802993/85237131-36d16d00-b41c-11ea-9c06-3dbb15c83ef5.png)

After this PR, the icons are now consistent:

![image](https://user-images.githubusercontent.com/5802993/85237159-8021bc80-b41c-11ea-9f03-213e30f0cb7a.png)

![image](https://user-images.githubusercontent.com/5802993/85237153-641e1b00-b41c-11ea-8aba-6fcd6c91413d.png)

## Reviewers

Even though I tested this extensively on my own machine and made the best effort to ensure this doesn't break anything and is as compatible as possible, I would still recommend for other Windows users to also test and give feedback to verify on other configurations than mine.

To make it easier to review, each fundamental change is done in a separate clearly identified commit (3 in total).