### PR TITLE
prevent NULL reference exception when scanning some directories

### DIFF
--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -1255,6 +1255,8 @@ static void task_database_handler(retro_task_t *task)
          {
             const char *name     = database_info_get_current_element_name(
                   dbinfo);
+            if (name == NULL)
+               goto task_finished;
 
             if (dbinfo->type == DATABASE_TYPE_ITERATE)
                if (path_contains_compressed_file(name))


### PR DESCRIPTION
## Description

Prevents a NULL reference exception when scanning an empty directory or a directory where the last item in the list has been pruned.

If `database_info_get_current_element_name` returned NULL, `path_contains_compressed_file` would throw an error trying to dereference it. I believe NULL to mean there's nothing left to scan, so my solution is to jump out of the loop when its encountered.

## Related Issues

Reported in RetroAchievements discord server.

## Related Pull Requests

n/a

## Reviewers

@twinaphex 
