### PR TITLE
Optimise parsing of configuration files

### DIFF
--- a/libretro-common/include/file/config_file.h
+++ b/libretro-common/include/file/config_file.h
@@ -94,8 +94,11 @@ config_file_t *config_file_new_alloc(void);
  * Includes cb callbacks to run custom code during config file processing.*/
 config_file_t *config_file_new_with_callback(const char *path, config_file_cb_t *cb);
 
-/* Load a config file from a string. */
-config_file_t *config_file_new_from_string(const char *from_string,
+/* Load a config file from a string.
+ * > WARNING: This will modify 'from_string'.
+ *   Pass a copy of source string if original
+ *   contents must be preserved */
+config_file_t *config_file_new_from_string(char *from_string,
       const char *path);
 
 config_file_t *config_file_new_from_path_to_string(const char *path);

--- a/libretro-common/samples/file/config_file/Makefile
+++ b/libretro-common/samples/file/config_file/Makefile
@@ -15,7 +15,8 @@ SOURCES := \
 	$(LIBRETRO_COMM_DIR)/lists/string_list.c \
 	$(LIBRETRO_COMM_DIR)/string/stdstring.c \
 	$(LIBRETRO_COMM_DIR)/streams/file_stream.c \
-	$(LIBRETRO_COMM_DIR)/vfs/vfs_implementation.c
+	$(LIBRETRO_COMM_DIR)/vfs/vfs_implementation.c \
+	$(LIBRETRO_COMM_DIR)/time/rtime.c
 
 OBJS := $(SOURCES:.c=.o)
 

--- a/libretro-common/samples/file/config_file/config_file_test.c
+++ b/libretro-common/samples/file/config_file/config_file_test.c
@@ -29,12 +29,15 @@
 #include <file/config_file.h>
 
 static void test_config_file_parse_contains(
-      const char * cfgtext,
+      const char *cfgtext,
       const char *key, const char *val)
 {
-   config_file_t *cfg = config_file_new_from_string(cfgtext, NULL);
+   char *cfgtext_copy = strdup(cfgtext);
+   config_file_t *cfg = config_file_new_from_string(cfgtext_copy, NULL);
    char          *out = NULL;
    bool            ok = false;
+
+   free(cfgtext_copy);
 
    if (!cfg)
       abort();
@@ -63,14 +66,10 @@ int main(void)
    test_config_file_parse_contains("foo = \"bar\"\r\n", "foo", "bar");
    test_config_file_parse_contains("foo = \"bar\"",     "foo", "bar");
 
-#if 0
-   /* turns out it treats empty as nonexistent -
-    * should probably be fixed */
    test_config_file_parse_contains("foo = \"\"\n",   "foo", "");
    test_config_file_parse_contains("foo = \"\"",     "foo", "");
    test_config_file_parse_contains("foo = \"\"\r\n", "foo", "");
    test_config_file_parse_contains("foo = \"\"",     "foo", "");
-#endif
 
    test_config_file_parse_contains("foo = \"\"\n",   "bar", NULL);
    test_config_file_parse_contains("foo = \"\"",     "bar", NULL);

--- a/tasks/task_autodetect.c
+++ b/tasks/task_autodetect.c
@@ -335,8 +335,16 @@ static bool input_autoconfigure_joypad_from_conf_internal(
    /* Load internal autoconfig files  */
    for (i = 0; input_builtin_autoconfs[i]; i++)
    {
-      config_file_t *conf = config_file_new_from_string(
-            input_builtin_autoconfs[i], NULL);
+      char *autoconf      = NULL;
+      config_file_t *conf = NULL;
+
+      if (string_is_empty(input_builtin_autoconfs[i]))
+         continue;
+
+      autoconf = strdup(input_builtin_autoconfs[i]);
+      conf     = config_file_new_from_string(autoconf, NULL);
+      free(autoconf);
+
       if (conf && input_autoconfigure_joypad_from_conf(conf, params, task))
         return true;
    }


### PR DESCRIPTION
## Description

This PR makes the following optimisations to `config_file.c`:

- When loading a configuration file via `config_file_new_from_path_to_string()`, the file is read into memory and split into lines via `string_split()`. This means we end up making a total of *3* copies of the config file contents before we even start parsing it. This is horribly inefficient. This PR changes things such that the original file buffer is read directly, so no unnecessary copies are made.

- When parsing lines of a config file, the `key` string is copied to dynamically allocated storage with a starting size of 8 characters - this is increased via `realloc()` if the `key` read from the file exceeds this. It turns out that 8 is too small, causing a huge excess of relocations during normal operation (which is slow!). This PR increases the starting size of the key storage to 32 characters, which effectively eliminates reallocations.

- The `extract_value()` function (used to get the value string for each line of a config file) has been rewritten to make use of simple loops instead of the `strtok_r()` tokenisation function. This has a surprisingly large effect on performance.

The net result of this is that the performance overheads of loading/parsing configuration files are reduced by ~40%.
