### PR TITLE
Non-X11 lightgun support

### DIFF
--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -823,10 +823,16 @@ static int16_t udev_lightgun_aiming_state(
    if (!mouse)
       return 0;
 
+#ifdef HAVE_X11
+   /* udev->pointer_x and y is only set in X11 */
    if (!(video_driver_translate_coord_viewport_wrap(
                &vp, udev->pointer_x, udev->pointer_y,
                &res_x, &res_y, &res_screen_x, &res_screen_y)))
       return 0;
+#else
+   res_x = udev_mouse_get_pointer_x(mouse, false);
+   res_y = udev_mouse_get_pointer_y(mouse, false);
+#endif
 
    inside =    (res_x >= -edge_detect) 
             && (res_y >= -edge_detect)


### PR DESCRIPTION
## Description
Non-X11 retroarch was missing lightgun support, this fixes that.

The current method for getting the lightgun aiming coordinates "udev_lightgun_aiming_state" only work in X11 which is shown if you follow the code through, the required coordinates are not set otherwise. I've added an X11 if statement and left that block of code as it is. For the non-X11 code block I've used the methods from the touchscreen/pointer function which successfully gets absolute coordinates back from the mouse device in non-X11. This update is tested and working on the Raspberry Pi for an absolute mouse based device and it was not working before.

I tried to decrease the amount of changes to a minimum set.

## Related Pull Requests

This is based on https://github.com/libretro/RetroArch/pull/9684 and simply fixes the merge conflict and removes unnecessary ordering or whitespace changes.

Somehow the previous PR, https://github.com/libretro/RetroArch/pull/10919, failed to capture any changes.

## Reviewers
