### PR TITLE
(Makefiles) Fix version_git.o regeneration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ $(OBJDIR)/%.o: %.m
 
 .FORCE:
 
-$(OBJDIR)/git_version.o: git_version.c .FORCE
+$(OBJDIR)/version_git.o: version_git.c .FORCE
 	@mkdir -p $(dir $@)
 	@$(if $(Q), $(shell echo echo CC $<),)
 	$(Q)$(CC) $(CFLAGS) $(DEFINES) -MMD -c -o $@ $<
@@ -233,7 +233,7 @@ $(OBJDIR)/%.o: %.rc $(HEADERS)
 	$(Q)$(WINDRES) -o $@ $<
 
 install: $(TARGET)
-	rm -f $(OBJDIR)/git_version.o
+	rm -f $(OBJDIR)/version_git.o
 	mkdir -p $(DESTDIR)$(BIN_DIR) 2>/dev/null || /bin/true
 	mkdir -p $(DESTDIR)$(GLOBAL_CONFIG_DIR) 2>/dev/null || /bin/true
 	mkdir -p $(DESTDIR)$(DATA_DIR)/applications 2>/dev/null || /bin/true

--- a/Makefile.dingux
+++ b/Makefile.dingux
@@ -160,7 +160,7 @@ $(OBJDIR)/%.o: %.m
 
 .FORCE:
 
-$(OBJDIR)/git_version.o: git_version.c .FORCE
+$(OBJDIR)/version_git.o: version_git.c .FORCE
 	@mkdir -p $(dir $@)
 	@$(if $(Q), $(shell echo echo CC $<),)
 	$(CC) $(CFLAGS) $(DEFINES) -MMD -c -o $@ $<

--- a/Makefile.win
+++ b/Makefile.win
@@ -162,7 +162,7 @@ $(OBJDIR)/%.o: %.c
 
 .FORCE:
 
-$(OBJDIR)/git_version.o: git_version.c .FORCE
+$(OBJDIR)/version_git.o: version_git.c .FORCE
 	@-mkdir -p $(dir $@) || mkdir $(subst /,\,$(dir $@)) || echo .
 	@$(if $(Q), $(shell echo echo CC $<),)
 	$(Q)$(CC) $(CFLAGS) $(DEFINES) -MMD -c -o $@ $<


### PR DESCRIPTION
## Description

Forgotten references to `git_version.c` (nowadays named `version_git.c`) were causing the git version object to not be rebuilt every time.
