### PR TITLE
Fix core-initiated D3D9/D3D11 driver switches

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -30151,6 +30151,20 @@ static bool hw_render_context_is_vulkan(enum retro_hw_context_type type)
 }
 #endif
 
+#ifdef HAVE_D3D9
+static bool hw_render_context_is_d3d9(const struct retro_hw_render_callback* hwr)
+{
+   return hwr->context_type == RETRO_HW_CONTEXT_DIRECT3D && hwr->version_major == 9;
+}
+#endif
+
+#ifdef HAVE_D3D11
+static bool hw_render_context_is_d3d11(const struct retro_hw_render_callback* hwr)
+{
+   return hwr->context_type == RETRO_HW_CONTEXT_DIRECT3D && hwr->version_major == 11;
+}
+#endif
+
 #if defined(HAVE_OPENGL) || defined(HAVE_OPENGL_CORE)
 static bool hw_render_context_is_gl(enum retro_hw_context_type type)
 {
@@ -31600,6 +31614,42 @@ static bool video_driver_find_driver(struct rarch_state *p_rarch)
                   "vulkan");
          }
          p_rarch->current_video = &video_vulkan;
+      }
+#endif
+
+#if defined(HAVE_D3D9)
+      if (hwr && hw_render_context_is_d3d9(hwr))
+      {
+         RARCH_LOG("[Video]: Using HW render, D3D9 driver forced.\n");
+         if (!string_is_equal(settings->arrays.video_driver, "d3d9"))
+         {
+            RARCH_LOG("[Video]: \"%s\" saved as cached driver.\n", settings->arrays.video_driver);
+            strlcpy(p_rarch->cached_video_driver,
+               settings->arrays.video_driver,
+               sizeof(p_rarch->cached_video_driver));
+            configuration_set_string(settings,
+               settings->arrays.video_driver,
+               "d3d9");
+         }
+         p_rarch->current_video = &video_d3d9;
+      }
+#endif
+
+#if defined(HAVE_D3D11)
+      if (hwr && hw_render_context_is_d3d11(hwr))
+      {
+         RARCH_LOG("[Video]: Using HW render, D3D11 driver forced.\n");
+         if (!string_is_equal(settings->arrays.video_driver, "d3d11"))
+         {
+            RARCH_LOG("[Video]: \"%s\" saved as cached driver.\n", settings->arrays.video_driver);
+            strlcpy(p_rarch->cached_video_driver,
+               settings->arrays.video_driver,
+               sizeof(p_rarch->cached_video_driver));
+            configuration_set_string(settings,
+               settings->arrays.video_driver,
+               "d3d11");
+         }
+         p_rarch->current_video = &video_d3d11;
       }
 #endif
 


### PR DESCRIPTION
## Description

Currently, RetroArch only does this for GL and Vulkan hardware render contexts. Requesting a D3D11 context would result in the frontend creating a GL context instead (or whatever was set in frontend config), and then eventually crashing when it tried to render the UI.

I was hitting this when porting my emulator to libretro - it has a D3D11 renderer which performs better than OpenGL, so it would be nice for auto switching to work here, rather than nagging the user to manually change their driver :)

Added D3D9 as well because it was also missing (but does anything use it?). As best I can tell from a quick look at the hw render request call path, the other video drivers aren't supported for hw render contexts, so no need to handle them?

Switching hw renderers after the core is booted still seems to do nothing, but I'm guessing that's a separate issue.