### PR TITLE
(Keyboard Input) Do not try to speak if accessibility is disabled

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -11952,7 +11952,8 @@ bool menu_input_dialog_start(menu_input_ctx_line_t *line)
    input_keyboard_ctl(RARCH_INPUT_KEYBOARD_CTL_LINE_FREE, NULL);
 
 #ifdef HAVE_ACCESSIBILITY
-   accessibility_speak_priority(p_rarch, "Keyboard input:", 10);
+   if (is_accessibility_enabled(p_rarch))
+      accessibility_speak_priority(p_rarch, "Keyboard input:", 10);
 #endif
 
    p_rarch->menu_input_dialog_keyboard_buffer =


### PR DESCRIPTION
## Description

This trivial PR simply makes sure to not call `accessibility_speak_priority()` if accessibility is disabled when opening the on-screen keyboard input dialog. It silences the following spurious log message even though nothing is actually spoken:

    [INFO] Spoke: Keyboard input:
