### PR TITLE
(cheevos) allow submission of 0 for leaderboard values

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -999,14 +999,6 @@ static void rcheevos_lboard_submit(rcheevos_lboard_t* lboard)
    /* Deactivate the leaderboard. */
    lboard->active = 0;
 
-   /* Failsafe for improper leaderboards. */
-   if (lboard->last_value == 0)
-   {
-      CHEEVOS_ERR(RCHEEVOS_TAG "Leaderboard %s tried to submit 0\n", lboard->info->title);
-      runloop_msg_queue_push("Leaderboard attempt cancelled!", 0, 2 * 60, false, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
-      return;
-   }
-
    /* Show the OSD message. */
    rc_format_value(value, sizeof(value), lboard->last_value, lboard->format);
 


### PR DESCRIPTION
## Description

Removes code that was added [three years ago](https://github.com/libretro/RetroArch/commit/6e8cb62cb89cc8cfd9ac16879eeed6e9746f38a9) as a "failsafe to prevent LBs from submitting 0".

While typically not a valid leaderboard value (it's a terrible high score, and an impossible time for speed runs), there are situations where 0 would be a reasonable submission (least debt at game completion, fewest continues used).

I believe the code was originally added to address either an incompatibility between RetroArch and the RetroAchievements toolkit, or to overcome poorly written achievement triggers. The first should no longer be an issue due to the shared rcheevos library. The second should be fixed, rather than hidden behind a bandage. At a minimum, the bandage only exists in RetroArch, so this change makes it behave the same as the standalone RetroAchievements emulators.

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@meleu
