### PR TITLE
(Vulkan) Fix incorrect structure type in vulkan_create_buffer

### DIFF
--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -1260,7 +1260,7 @@ struct vk_buffer vulkan_create_buffer(
    VkBufferCreateInfo info;
    VkMemoryAllocateInfo alloc;
 
-   info.sType                 = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+   info.sType                 = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
    info.pNext                 = NULL;
    info.flags                 = 0;
    info.size                  = size;


### PR DESCRIPTION
## Description

Simple one that the validation layers caught. There's another error which trips due to the mirror clamp extension not being enabled, but that's a more complex fix.

I'm actually a little surprised drivers didn't choke on this...