### PR TITLE
pass correct userdata object to gfx_display functions

### DIFF
--- a/gfx/widgets/gfx_widget_achievement_popup.c
+++ b/gfx/widgets/gfx_widget_achievement_popup.c
@@ -134,7 +134,7 @@ static void gfx_widget_achievement_popup_frame(void* data, void* userdata)
          /* Icon */
          if (p_dispwidget->gfx_widgets_icons_textures[MENU_WIDGETS_ICON_ACHIEVEMENT])
          {
-            gfx_display_blend_begin(userdata);
+            gfx_display_blend_begin(video_info->userdata);
             gfx_widgets_draw_icon(
                video_info->userdata,
                video_width,
@@ -145,7 +145,7 @@ static void gfx_widget_achievement_popup_frame(void* data, void* userdata)
                0,
                state->y,
                video_width, video_height, 0, 1, gfx_widgets_get_pure_white());
-            gfx_display_blend_end(userdata);
+            gfx_display_blend_end(video_info->userdata);
          }
       }
       /* Badge */
@@ -220,7 +220,7 @@ static void gfx_widget_achievement_popup_frame(void* data, void* userdata)
       {
          gfx_widgets_flush_text(video_width, video_height,
             &p_dispwidget->gfx_widget_fonts.regular);
-         gfx_display_scissor_end(userdata,
+         gfx_display_scissor_end(video_info->userdata,
             video_width, video_height);
       }
    }


### PR DESCRIPTION
## Description

When I moved the achievements widget into its own file (#10870), the userdata variable got a new meaning. In `gfx_widgets_frame`, it's assigned to `video_info->userdata`. In `gfx_widget_achievement_popup_frame`, `userdata` is passed in as a parameter (and points at different memory). Since both are void pointers, they're interchangable. One of the `userdata` references wasn't changed to `video_info->userdata` in the new file, so when the void pointer is cast to a driver-specific implementation, the fields are incorrect.

This audits the `userdata` references to ensure they've all been updated to use `video_info->userdata`.

## Related Issues

#10966

## Related Pull Requests

n/a

## Reviewers

@natinusala 
