### PR TITLE
Fix invalid calls to dinput_handle_message when input driver is not set to dinput

### DIFF
--- a/gfx/common/win32_common.c
+++ b/gfx/common/win32_common.c
@@ -1092,6 +1092,7 @@ LRESULT CALLBACK WndProcWGL(HWND hwnd, UINT message,
             taskbar_is_created = true;
 #endif
 #ifdef HAVE_DINPUT
+         if (input_get_ptr() == &input_dinput)
          {
             void* input_data = input_get_data();
             if (input_data && dinput_handle_message(input_data,
@@ -1155,6 +1156,7 @@ LRESULT CALLBACK WndProcGDI(HWND hwnd, UINT message,
             taskbar_is_created = true;
 #endif
 #ifdef HAVE_DINPUT
+         if (input_get_ptr() == &input_dinput)
          {
             void* input_data = input_get_data();
             if (input_data && dinput_handle_message(input_data,


### PR DESCRIPTION
## Description

I got an error regarding heap corruption around the input driver data when using the Windows raw input driver and traced it back to dinput_handle_message still writing data to something that belongs to the raw input driver.
The same check `if (input_get_ptr() == &input_dinput)` is already in use in 2 other places in the same file, this PR fixes the remaining 2 locations.

## Related Issues

## Related Pull Requests

## Reviewers