### PR TITLE
(Drivers/Video) Implement frontend signal handling in null video driver

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -410,6 +410,8 @@ static void *video_null_init(const video_info_t *video,
    *input       = NULL;
    *input_data = NULL;
 
+   frontend_driver_install_signal_handler();
+
    return (void*)-1;
 }
 
@@ -422,7 +424,7 @@ static bool video_null_frame(void *data, const void *frame,
 
 static void video_null_free(void *data) { }
 static void video_null_set_nonblock_state(void *a, bool b, bool c, unsigned d) { }
-static bool video_null_alive(void *data) { return true; }
+static bool video_null_alive(void *data) { return frontend_driver_get_signal_handler_state() != 1; }
 static bool video_null_focus(void *data) { return true; }
 static bool video_null_has_windowed(void *data) { return true; }
 static bool video_null_suppress_screensaver(void *data, bool enable) { return false; }


### PR DESCRIPTION
## Description

Currently, the null video driver in RetroArch does not setup any signal handling in the frontend driver. This means that - for example in Unix-based systems - using <kbd>CTRL</kbd>+<kbd>C</kbd> (or sending a `TERM` signal) causes RetroArch to not exit gracefully, i.e. properly closing the loaded content and saving the configuration file. See issue #10987.

This PR fixes the issue by implementing frontend signal handling in the null video driver.

## Related Issues

Fixes #10987 

## Reviewers

@barbudreadmon 
