### PR TITLE
only wait for save task to complete

### DIFF
--- a/content.h
+++ b/content.h
@@ -51,8 +51,8 @@ bool content_load_state(const char* path, bool load_to_backup_buffer, bool autol
 /* Save a state from memory to disk. */
 bool content_save_state(const char *path, bool save_to_disk, bool autosave);
 
-/* Returns true if a save state task is in progress */
-bool content_save_state_in_progress(void);
+/* Waits for any in-progress save state tasks to finish */
+void content_wait_for_save_state_task(void);
 
 /* Copy a save state. */
 bool content_rename_state(const char *origin, const char *dest);

--- a/libretro-common/include/queues/task_queue.h
+++ b/libretro-common/include/queues/task_queue.h
@@ -224,8 +224,8 @@ void task_queue_check(void);
  * and the task will be ignored. */
 bool task_queue_push(retro_task_t *task);
 
-/* Blocks until all tasks have finished
- * will return early if cond is not NULL
+/* Blocks until all non-scheduled tasks have finished.
+ * Will return early if cond is not NULL
  * and cond(data) returns false.
  * This must only be called from the main thread. */
 void task_queue_wait(retro_task_condition_fn_t cond, void* data);

--- a/libretro-common/queues/task_queue.c
+++ b/libretro-common/queues/task_queue.c
@@ -235,7 +235,7 @@ static void retro_task_regular_gather(void)
 
 static void retro_task_regular_wait(retro_task_condition_fn_t cond, void* data)
 {
-   while (tasks_running.front && (!cond || cond(data)))
+   while ((tasks_running.front && !tasks_running.front->when) && (!cond || cond(data)))
       retro_task_regular_gather();
 }
 
@@ -420,10 +420,9 @@ static void retro_task_threaded_wait(retro_task_condition_fn_t cond, void* data)
       retro_task_threaded_gather();
 
       slock_lock(running_lock);
-      wait = (tasks_running.front) &&
-             (!cond || cond(data));
+      wait = (tasks_running.front && !tasks_running.front->when);
       slock_unlock(running_lock);
-   } while (wait);
+   } while (wait && (!cond || cond(data)));
 }
 
 static void retro_task_threaded_reset(void)

--- a/retroarch.c
+++ b/retroarch.c
@@ -37605,8 +37605,7 @@ bool retroarch_main_quit(void)
       /* If any save states are in progress, wait
        * until all tasks are complete (otherwise
        * save state file may be truncated) */
-      if (content_save_state_in_progress())
-         task_queue_wait(NULL, NULL);
+      content_wait_for_save_state_task();
 
 #ifdef HAVE_CONFIGFILE
       if (p_rarch->runloop_overrides_active)

--- a/tasks/task_save.c
+++ b/tasks/task_save.c
@@ -1372,7 +1372,7 @@ static bool task_save_state_finder(retro_task_t *task, void *user_data)
 }
 
 /* Returns true if a save state task is in progress */
-bool content_save_state_in_progress(void)
+static bool content_save_state_in_progress(void* data)
 {
    task_finder_data_t find_data;
 
@@ -1383,6 +1383,11 @@ bool content_save_state_in_progress(void)
       return true;
 
    return false;
+}
+
+void content_wait_for_save_state_task(void)
+{
+   task_queue_wait(content_save_state_in_progress, NULL);
 }
 
 /**


### PR DESCRIPTION
## Description

Reimplements https://github.com/libretro/RetroArch/commit/6083450d4e2c49da74d0c4a4a1a4833a2a6a66fa such that it only waits for the save task to complete instead of all tasks. Waiting for all tasks with achievements enabled would cause it to wait indefinitely as there was always a task scheduled to send rich presence information to the server. I've also updated the wait for all tasks logic to ignore scheduled tasks.

## Related Issues

fixes #10943
fixes #11004

## Related Pull Requests

n/a

## Reviewers

@twinaphex 