### PR TITLE
Add missing header (for non griffin builds)

### DIFF
--- a/gfx/drivers_context/x_ctx.c
+++ b/gfx/drivers_context/x_ctx.c
@@ -37,6 +37,7 @@
 #endif
 
 #include <string/stdstring.h>
+#include <compat/strcasestr.h>
 #include <X11/Xatom.h>
 
 #include "../../configuration.h"


### PR DESCRIPTION
## Description
Without it I get a warning when building on Linux without griffin:
```
gfx/drivers_context/x_ctx.c: In function ‘gfx_ctx_x_set_video_mode’:
gfx/drivers_context/x_ctx.c:653:24: warning: implicit declaration of function ‘strcasestr’; did you mean ‘strcasecmp’? [-Wimplicit-function-declaration]
       if (true_full && strcasestr(wm_name, "xfwm"))
                        ^~~~~~~~~~
                        strcasecmp
```

## Related Issues

## Related Pull Requests

## Reviewers
