### PR TITLE
Option to play sound on achievement unlock.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # Future
 - BLUETOOTH: Add a Bluetooth driver (Lakka-only for now)
+- CHEEVOS: Option to play sound on achievement unlock.
 - CHEEVOS: Upgrade to rcheevos 9.1
 - CHEEVOS: Restore display of unlocked achievements across hardcore modes
 - CHEEVOS: Hash buffered data when available


### PR DESCRIPTION
Logged #11010 in CHANGES.md

Suggestion for an annoucement:

## Cheevos: option to play a sound on achievement unlock

You can now play a little sound on achievement unlock.

Enable it in the Achievements menu:

![unlock-sound](https://user-images.githubusercontent.com/8508804/87250675-ed81a580-c43c-11ea-8c2e-dfb25e98b6c6.png)

You can also customize the sound by replacing the `{RETROARCH_DIR}/assets/sounds/unlock.ogg` file.

Accepted formats: `ogg`, `mod`, `xm`, `s3m`, `mp3`, `flac`, `wav`.


## Related Pull Requests

#11010 