### PR TITLE
Fix Metal build not being able to load cores

### DIFF
--- a/pkg/apple/RetroArch.entitlements
+++ b/pkg/apple/RetroArch.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.cs.disable-executable-page-protection</key>
 	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

I misread the documentations for entitlements, thinking that the memory protection entitlement incluldes the library checking. It does not, so I added the library entitlement.
Now I'm actually able to load cores on my machine.

## Related Issues

https://github.com/libretro/RetroArch/issues/10995

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/10997
