### PR TITLE
(Emscripten) Fix input code to ignore unknown keys

### DIFF
--- a/input/drivers/rwebinput_input.c
+++ b/input/drivers/rwebinput_input.c
@@ -636,10 +636,12 @@ static void rwebinput_process_keyboard_events(rwebinput_input_t *rwebinput,
    else if (translated_keycode == RETROK_TAB)
       character = '\t';
 
-   input_keyboard_event(keydown, translated_keycode, character, mod,
-      RETRO_DEVICE_KEYBOARD);
-
-   if (translated_keycode < RETROK_LAST)
+   if (translated_keycode != RETROK_UNKNOWN) {
+      input_keyboard_event(keydown, translated_keycode, character, mod,
+         RETRO_DEVICE_KEYBOARD);
+   }
+   
+   if (translated_keycode < RETROK_LAST && translated_keycode != RETROK_UNKNOWN)
    {
       rwebinput->keys[translated_keycode] = keydown;
    }


### PR DESCRIPTION
## Description
Fixes a bug in the Emscripten input driver which causes the RetroArch Web Player to map unknown key presses to random hotkeys. This can cause undesirable behavior like the web player crashing when a user presses the command or volume keys (trys to start streaming/recording, which isn't implemented). This is fixed by having the input driver ignore unknown inputs instead of sending them into RetroArch.

## Related Issues
#10320 #10041 #8167


