### PR TITLE
Rewrite 'task_autodetect.c': Ensure thread safety + clean-ups/rationalisation

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -2270,7 +2270,6 @@ void config_set_defaults(void *data)
 #ifdef HAVE_CONFIGFILE
    input_remapping_set_defaults(true);
 #endif
-   input_autoconfigure_reset();
 
    /* Verify that binds are in proper order. */
    for (i = 0; i < MAX_USERS; i++)
@@ -3898,8 +3897,8 @@ bool config_save_autoconf_profile(const char *path, unsigned user)
    config_set_string(conf, "input_device",
          input_config_get_device_name(user));
 
-   pid_user = input_config_get_pid(user);
-   vid_user = input_config_get_vid(user);
+   pid_user = input_config_get_device_pid(user);
+   vid_user = input_config_get_device_vid(user);
 
    if (pid_user && vid_user)
    {

--- a/input/drivers_joypad/linuxraw_joypad.c
+++ b/input/drivers_joypad/linuxraw_joypad.c
@@ -99,7 +99,7 @@ static bool linuxraw_joypad_init_pad(const char *path,
       struct epoll_event event;
 
       ioctl(pad->fd,
-               JSIOCGNAME(sizeof(input_device_names[0])), pad->ident);
+               JSIOCGNAME(input_config_get_device_name_size(0)), pad->ident);
 
       event.events             = EPOLLIN;
       event.data.ptr           = pad;
@@ -234,7 +234,7 @@ static bool linuxraw_joypad_init(void *data)
       path[0]                     = '\0';
 
       pad->fd                     = -1;
-      pad->ident                  = input_device_names[i];
+      pad->ident                  = input_config_get_device_name_ptr(i);
 
       snprintf(path, sizeof(path), "/dev/input/js%u", i);
 

--- a/input/drivers_joypad/parport_joypad.c
+++ b/input/drivers_joypad/parport_joypad.c
@@ -184,7 +184,7 @@ static bool parport_joypad_init_pad(
       if (!set_control)
          RARCH_WARN("[Joypad]: Failed to clear nStrobe and nIRQ bits on %s\n", path);
 
-      strlcpy(pad->ident, path, sizeof(input_device_names[0]));
+      strlcpy(pad->ident, path, input_config_get_device_name_size(0));
 
       for (i = 0; i < PARPORT_NUM_BUTTONS; i++)
          pad->button_enable[i] = true;
@@ -246,7 +246,7 @@ static bool parport_joypad_init(void *data)
       struct parport_joypad *pad = &parport_pads[i];
 
       pad->fd    = -1;
-      pad->ident = input_device_names[i];
+      pad->ident = input_config_get_device_name_ptr(i);
 
       snprintf(path, sizeof(path), "/dev/parport%u", i);
 

--- a/input/drivers_joypad/udev_joypad.c
+++ b/input/drivers_joypad/udev_joypad.c
@@ -161,8 +161,12 @@ static int udev_add_pad(struct udev_device *dev, unsigned p, int fd, const char 
    unsigned long keybit[NBITS(KEY_MAX)] = {0};
    unsigned long absbit[NBITS(ABS_MAX)] = {0};
    unsigned long ffbit[NBITS(FF_MAX)]   = {0};
+   const char *device_name              = input_config_get_device_name(p);
 
-   strlcpy(pad->ident, input_device_names[p], sizeof(pad->ident));
+   if (string_is_empty(device_name))
+      pad->ident[0] = '\0';
+   else
+      strlcpy(pad->ident, device_name, sizeof(pad->ident));
 
    /* Failed to get pad name */
    if (ioctl(fd, EVIOCGNAME(sizeof(pad->ident)), pad->ident) < 0)

--- a/input/input_driver.h
+++ b/input/input_driver.h
@@ -151,6 +151,18 @@ struct rarch_joypad_info
    float axis_threshold;
 };
 
+typedef struct
+{
+   char name[256];
+   char display_name[256];
+   char config_path[PATH_MAX_LENGTH];
+   char config_name[PATH_MAX_LENGTH];
+   uint16_t vid;
+   uint16_t pid;
+   bool autoconfigured;
+   unsigned name_index;
+} input_device_info_t;
+
 struct input_driver
 {
    /* Inits input driver.
@@ -390,7 +402,6 @@ void input_keyboard_event(bool down, unsigned code, uint32_t character,
 
 extern struct retro_keybind input_config_binds[MAX_USERS][RARCH_BIND_LIST_END];
 extern struct retro_keybind input_autoconf_binds[MAX_USERS][RARCH_BIND_LIST_END];
-extern char input_device_names[MAX_USERS][64];
 
 const char *input_config_bind_map_get_base(unsigned i);
 
@@ -428,23 +439,26 @@ unsigned input_config_translate_str_to_bind_id(const char *str);
 
 void config_read_keybinds_conf(void *data);
 
-void input_autoconfigure_joypad_conf(void *data, struct retro_keybind *binds);
+/* Note: 'data' is an object of type config_file_t
+ * > We assume it was done like this to avoid including
+ *   config_file.h... */
+void input_config_set_autoconfig_binds(unsigned port, void *data);
 
+/* Set input_device_info */
 void input_config_set_device_name(unsigned port, const char *name);
-
 void input_config_set_device_display_name(unsigned port, const char *name);
-
-void input_config_set_device_config_name(unsigned port, const char *name);
-
 void input_config_set_device_config_path(unsigned port, const char *path);
+void input_config_set_device_config_name(unsigned port, const char *name);
+void input_config_set_device_vid(unsigned port, uint16_t vid);
+void input_config_set_device_pid(unsigned port, uint16_t pid);
+void input_config_set_device_autoconfigured(unsigned port, bool autoconfigured);
+void input_config_set_device_name_index(unsigned port, unsigned name_index);
 
+/* Clear input_device_info */
 void input_config_clear_device_name(unsigned port);
-
 void input_config_clear_device_display_name(unsigned port);
-
-void input_config_clear_device_config_name(unsigned port);
-
 void input_config_clear_device_config_path(unsigned port);
+void input_config_clear_device_config_name(unsigned port);
 
 unsigned input_config_get_device_count(void);
 
@@ -454,25 +468,24 @@ unsigned input_config_get_device(unsigned port);
 
 void input_config_set_device(unsigned port, unsigned id);
 
+/* Get input_device_info */
 const char *input_config_get_device_name(unsigned port);
-
 const char *input_config_get_device_display_name(unsigned port);
-
-const char *input_config_get_device_config_name(unsigned port);
-
 const char *input_config_get_device_config_path(unsigned port);
+const char *input_config_get_device_config_name(unsigned port);
+uint16_t input_config_get_device_vid(unsigned port);
+uint16_t input_config_get_device_pid(unsigned port);
+bool input_config_get_device_autoconfigured(unsigned port);
+unsigned input_config_get_device_name_index(unsigned port);
 
-const char *input_config_get_device_config_port(unsigned port);
+/* TODO/FIXME: This is required by linuxraw_joypad.c
+ * and parport_joypad.c. These input drivers should
+ * be refactored such that this dubious low-level
+ * access is not required */
+char *input_config_get_device_name_ptr(unsigned port);
+size_t input_config_get_device_name_size(unsigned port);
 
 const struct retro_keybind *input_config_get_bind_auto(unsigned port, unsigned id);
-
-void input_config_set_pid(unsigned port, uint16_t pid);
-
-uint16_t input_config_get_pid(unsigned port);
-
-void input_config_set_vid(unsigned port, uint16_t vid);
-
-uint16_t input_config_get_vid(unsigned port);
 
 void input_config_save_keybinds_user(void *data, unsigned user);
 
@@ -480,6 +493,7 @@ void input_config_save_keybind(void *data, const char *prefix,
       const char *base, const struct retro_keybind *bind,
       bool save_empty);
 
+void input_config_reset_autoconfig_binds(unsigned port);
 void input_config_reset(void);
 
 void set_connection_listener(pad_connection_listener_t *listener);

--- a/menu/cbs/menu_cbs_sublabel.c
+++ b/menu/cbs/menu_cbs_sublabel.c
@@ -866,13 +866,13 @@ static int action_bind_sublabel_systeminfo_controller_entry(
 
    for(controller = 0; controller < MAX_USERS; controller++)
    {
-      if (input_is_autoconfigured(controller))
+      if (input_config_get_device_autoconfigured(controller))
       {
             snprintf(tmp, sizeof(tmp), "%s #%d device name: %s (#%d)",
                msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PORT),
                controller,
                input_config_get_device_name(controller),
-               input_autoconfigure_get_device_name_index(controller));
+               input_config_get_device_name_index(controller));
 
             if (string_is_equal(path, tmp))
                break;
@@ -881,7 +881,7 @@ static int action_bind_sublabel_systeminfo_controller_entry(
    snprintf(tmp, sizeof(tmp), "Device display name: %s\nDevice config name: %s\nDevice identifiers: %d/%d",
       input_config_get_device_display_name(controller) ? input_config_get_device_display_name(controller) : msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE),
       input_config_get_device_display_name(controller) ? input_config_get_device_config_name(controller) : msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE),
-      input_config_get_vid(controller), input_config_get_pid(controller));
+      input_config_get_device_vid(controller), input_config_get_device_pid(controller));
    strlcpy(s, tmp, len);
 
    return 0;

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -1020,13 +1020,13 @@ static unsigned menu_displaylist_parse_system_info(file_list_t *list)
 
    for (controller = 0; controller < MAX_USERS; controller++)
    {
-      if (input_is_autoconfigured(controller))
+      if (input_config_get_device_autoconfigured(controller))
       {
          snprintf(tmp, sizeof(tmp), "%s #%d device name: %s (#%d)",
             msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PORT),
             controller,
             input_config_get_device_name(controller),
-            input_autoconfigure_get_device_name_index(controller));
+            input_config_get_device_name_index(controller));
 
          if (menu_entries_append_enum(list, tmp, "",
             MENU_ENUM_LABEL_SYSTEM_INFO_CONTROLLER_ENTRY,
@@ -1053,8 +1053,8 @@ static unsigned menu_displaylist_parse_system_info(file_list_t *list)
                MENU_SETTINGS_CORE_INFO_NONE, 0, 0))
                count++;
             snprintf(tmp, sizeof(tmp), " Device VID/PID: %d/%d",
-               input_config_get_vid(controller),
-               input_config_get_pid(controller));
+               input_config_get_device_vid(controller),
+               input_config_get_device_pid(controller));
             if (menu_entries_append_enum(list, tmp, "",
                MENU_ENUM_LABEL_SYSTEM_INFO_CONTROLLER_ENTRY,
                MENU_SETTINGS_CORE_INFO_NONE, 0, 0))

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -6627,7 +6627,7 @@ static void get_string_representation_bind_device(rarch_setting_t *setting, char
 
       if (!string_is_empty(device_name))
       {
-         unsigned idx = input_autoconfigure_get_device_name_index(map);
+         unsigned idx = input_config_get_device_name_index(map);
 
          /*if idx is non-zero, it's part of a set*/
          if ( idx > 0)

--- a/retroarch.c
+++ b/retroarch.c
@@ -2137,9 +2137,6 @@ struct rarch_state
    uint8_t *midi_drv_input_buffer;
    uint8_t *midi_drv_output_buffer;
 
-   uint16_t input_config_vid[MAX_USERS];
-   uint16_t input_config_pid[MAX_USERS];
-
    size_t runloop_msg_queue_size;
    size_t recording_gpu_width;
    size_t recording_gpu_height;
@@ -2286,9 +2283,7 @@ struct rarch_state
    char current_savestate_dir[PATH_MAX_LENGTH];
    char dir_savestate[PATH_MAX_LENGTH];
 
-   char input_device_display_names[MAX_INPUT_DEVICES][64];
-   char input_device_config_names [MAX_INPUT_DEVICES][64];
-   char input_device_config_paths [MAX_INPUT_DEVICES][64];
+   input_device_info_t input_device_info[MAX_INPUT_DEVICES];
 
    char *osk_grid[45];
 #if defined(HAVE_RUNAHEAD)
@@ -2712,7 +2707,6 @@ bool discord_is_inited                                          = false;
 #endif
 uint64_t lifecycle_state                                        = 0;
 unsigned subsystem_current_count                                = 0;
-char        input_device_names        [MAX_INPUT_DEVICES][64];
 struct retro_keybind input_config_binds[MAX_USERS][RARCH_BIND_LIST_END];
 struct retro_keybind input_autoconf_binds[MAX_USERS][RARCH_BIND_LIST_END];
 struct retro_subsystem_info subsystem_data[SUBSYSTEM_MAX_SUBSYSTEMS];
@@ -24580,13 +24574,10 @@ static unsigned menu_event(
    bool menu_pointer_enable                        = settings->bools.menu_pointer_enable;
    bool swap_ok_cancel_btns                        = settings->bools.input_menu_swap_ok_cancel_buttons;
    bool menu_scroll_fast                           = settings->bools.menu_scroll_fast;
-   bool input_swap_override                        = input_autoconfigure_get_swap_override();
-   unsigned menu_ok_btn                            =
-         (!input_swap_override && swap_ok_cancel_btns) ?
-               RETRO_DEVICE_ID_JOYPAD_B : RETRO_DEVICE_ID_JOYPAD_A;
-   unsigned menu_cancel_btn                        =
-         (!input_swap_override && swap_ok_cancel_btns) ?
-               RETRO_DEVICE_ID_JOYPAD_A : RETRO_DEVICE_ID_JOYPAD_B;
+   unsigned menu_ok_btn                            = swap_ok_cancel_btns ?
+         RETRO_DEVICE_ID_JOYPAD_B : RETRO_DEVICE_ID_JOYPAD_A;
+   unsigned menu_cancel_btn                        = swap_ok_cancel_btns ?
+         RETRO_DEVICE_ID_JOYPAD_A : RETRO_DEVICE_ID_JOYPAD_B;
    unsigned ok_current                             = BIT256_GET_PTR(p_input, menu_ok_btn);
    unsigned ok_trigger                             = ok_current & ~ok_old;
 #ifdef HAVE_RGUI
@@ -27345,58 +27336,172 @@ void input_config_get_bind_string(char *buf,
       strlcat(buf, "---", size);
 }
 
+/* input_device_info wrappers START */
+
 unsigned input_config_get_device_count(void)
 {
+   struct rarch_state *p_rarch = &rarch_st;
    unsigned num_devices;
    for (num_devices = 0; num_devices < MAX_INPUT_DEVICES; ++num_devices)
    {
-      if (string_is_empty(input_device_names[num_devices]))
+      if (string_is_empty(p_rarch->input_device_info[num_devices].name))
          break;
    }
    return num_devices;
 }
 
+/* Adds an index to devices with the same name,
+ * so they can be uniquely identified in the
+ * frontend */
+static void input_config_reindex_device_names(void)
+{
+   unsigned i;
+   unsigned j;
+   unsigned name_index;
+
+   /* Reset device name indices */
+   for(i = 0; i < MAX_INPUT_DEVICES; i++)
+      input_config_set_device_name_index(i, 0);
+
+   /* Scan device names */
+   for(i = 0; i < MAX_INPUT_DEVICES; i++)
+   {
+      const char *device_name = input_config_get_device_name(i);
+
+      /* If current device name is empty, or a non-zero
+       * name index has already been assigned, continue
+       * to the next device */
+      if (string_is_empty(device_name) ||
+          (input_config_get_device_name_index(i) != 0))
+         continue;
+
+      /* > Uniquely named devices have a name index
+       *   of 0
+       * > Devices with the same name have a name
+       *   index starting from 1 */
+      name_index = 1;
+
+      /* Loop over all devices following the current
+       * selection */
+      for(j = i + 1; j < MAX_INPUT_DEVICES; j++)
+      {
+         const char *next_device_name = input_config_get_device_name(j);
+
+         if (string_is_empty(next_device_name))
+            continue;
+
+         /* Check if names match */
+         if (string_is_equal(device_name, next_device_name))
+         {
+            /* If this is the first match, set a starting
+             * index for the current device selection */
+            if (input_config_get_device_name_index(i) == 0)
+               input_config_set_device_name_index(i, name_index++);
+
+            /* Set name index for the next device
+             * (will keep incrementing as more matches
+             *  are found) */
+            input_config_set_device_name_index(j, name_index++);
+         }
+      }
+   }
+}
+
+/* > Get input_device_info */
+
 const char *input_config_get_device_name(unsigned port)
 {
-   if (string_is_empty(input_device_names[port]))
+   struct rarch_state *p_rarch = &rarch_st;
+   if (string_is_empty(p_rarch->input_device_info[port].name))
       return NULL;
-   return input_device_names[port];
+   return p_rarch->input_device_info[port].name;
 }
 
 const char *input_config_get_device_display_name(unsigned port)
 {
    struct rarch_state *p_rarch = &rarch_st;
-   if (string_is_empty(p_rarch->input_device_display_names[port]))
+   if (string_is_empty(p_rarch->input_device_info[port].display_name))
       return NULL;
-   return p_rarch->input_device_display_names[port];
+   return p_rarch->input_device_info[port].display_name;
 }
 
 const char *input_config_get_device_config_path(unsigned port)
 {
    struct rarch_state *p_rarch = &rarch_st;
-   if (string_is_empty(p_rarch->input_device_config_paths[port]))
+   if (string_is_empty(p_rarch->input_device_info[port].config_path))
       return NULL;
-   return p_rarch->input_device_config_paths[port];
+   return p_rarch->input_device_info[port].config_path;
 }
 
 const char *input_config_get_device_config_name(unsigned port)
 {
    struct rarch_state *p_rarch = &rarch_st;
-   if (string_is_empty(p_rarch->input_device_config_names[port]))
+   if (string_is_empty(p_rarch->input_device_info[port].config_name))
       return NULL;
-   return p_rarch->input_device_config_names[port];
+   return p_rarch->input_device_info[port].config_name;
 }
+
+uint16_t input_config_get_device_vid(unsigned port)
+{
+   struct rarch_state *p_rarch = &rarch_st;
+   return p_rarch->input_device_info[port].vid;
+}
+
+uint16_t input_config_get_device_pid(unsigned port)
+{
+   struct rarch_state *p_rarch = &rarch_st;
+   return p_rarch->input_device_info[port].pid;
+}
+
+bool input_config_get_device_autoconfigured(unsigned port)
+{
+   struct rarch_state *p_rarch = &rarch_st;
+   return p_rarch->input_device_info[port].autoconfigured;
+}
+
+unsigned input_config_get_device_name_index(unsigned port)
+{
+   struct rarch_state *p_rarch = &rarch_st;
+   return p_rarch->input_device_info[port].name_index;
+}
+
+/* TODO/FIXME: This is required by linuxraw_joypad.c
+ * and parport_joypad.c. These input drivers should
+ * be refactored such that this dubious low-level
+ * access is not required */
+char *input_config_get_device_name_ptr(unsigned port)
+{
+   struct rarch_state *p_rarch = &rarch_st;
+   return p_rarch->input_device_info[port].name;
+}
+
+size_t input_config_get_device_name_size(unsigned port)
+{
+   struct rarch_state *p_rarch = &rarch_st;
+   return sizeof(p_rarch->input_device_info[port].name);
+}
+
+/* > Set input_device_info */
 
 void input_config_set_device_name(unsigned port, const char *name)
 {
+   struct rarch_state *p_rarch = &rarch_st;
+
    if (string_is_empty(name))
       return;
 
-   strlcpy(input_device_names[port],
-         name,
-         sizeof(input_device_names[port]));
+   strlcpy(p_rarch->input_device_info[port].name, name,
+         sizeof(p_rarch->input_device_info[port].name));
 
-   input_autoconfigure_joypad_reindex_devices();
+   input_config_reindex_device_names();
+}
+
+void input_config_set_device_display_name(unsigned port, const char *name)
+{
+   struct rarch_state *p_rarch = &rarch_st;
+   if (!string_is_empty(name))
+      strlcpy(p_rarch->input_device_info[port].display_name, name,
+            sizeof(p_rarch->input_device_info[port].display_name));
 }
 
 void input_config_set_device_config_path(unsigned port, const char *path)
@@ -27410,9 +27515,9 @@ void input_config_set_device_config_path(unsigned port, const char *path)
 
       if (fill_pathname_parent_dir_name(parent_dir_name,
                path, sizeof(parent_dir_name)))
-         fill_pathname_join(p_rarch->input_device_config_paths[port],
+         fill_pathname_join(p_rarch->input_device_info[port].config_path,
                parent_dir_name, path_basename(path),
-               sizeof(p_rarch->input_device_config_paths[port]));
+               sizeof(p_rarch->input_device_info[port].config_path));
    }
 }
 
@@ -27420,43 +27525,62 @@ void input_config_set_device_config_name(unsigned port, const char *name)
 {
    struct rarch_state *p_rarch = &rarch_st;
    if (!string_is_empty(name))
-      strlcpy(p_rarch->input_device_config_names[port],
-            name,
-            sizeof(p_rarch->input_device_config_names[port]));
+      strlcpy(p_rarch->input_device_info[port].config_name, name,
+            sizeof(p_rarch->input_device_info[port].config_name));
 }
 
-void input_config_set_device_display_name(unsigned port, const char *name)
+void input_config_set_device_vid(unsigned port, uint16_t vid)
 {
    struct rarch_state *p_rarch = &rarch_st;
-   if (!string_is_empty(name))
-      strlcpy(p_rarch->input_device_display_names[port],
-            name,
-            sizeof(p_rarch->input_device_display_names[port]));
+   p_rarch->input_device_info[port].vid = vid;
 }
+
+void input_config_set_device_pid(unsigned port, uint16_t pid)
+{
+   struct rarch_state *p_rarch = &rarch_st;
+   p_rarch->input_device_info[port].pid = pid;
+}
+
+void input_config_set_device_autoconfigured(unsigned port, bool autoconfigured)
+{
+   struct rarch_state *p_rarch = &rarch_st;
+   p_rarch->input_device_info[port].autoconfigured = autoconfigured;
+}
+
+void input_config_set_device_name_index(unsigned port, unsigned name_index)
+{
+   struct rarch_state *p_rarch = &rarch_st;
+   p_rarch->input_device_info[port].name_index = name_index;
+}
+
+/* > Clear input_device_info */
 
 void input_config_clear_device_name(unsigned port)
 {
-   input_device_names[port][0] = '\0';
-   input_autoconfigure_joypad_reindex_devices();
+   struct rarch_state *p_rarch = &rarch_st;
+   p_rarch->input_device_info[port].name[0] = '\0';
+   input_config_reindex_device_names();
 }
 
 void input_config_clear_device_display_name(unsigned port)
 {
    struct rarch_state *p_rarch = &rarch_st;
-   p_rarch->input_device_display_names[port][0] = '\0';
+   p_rarch->input_device_info[port].display_name[0] = '\0';
 }
 
 void input_config_clear_device_config_path(unsigned port)
 {
    struct rarch_state *p_rarch = &rarch_st;
-   p_rarch->input_device_config_paths[port][0] = '\0';
+   p_rarch->input_device_info[port].config_path[0] = '\0';
 }
 
 void input_config_clear_device_config_name(unsigned port)
 {
    struct rarch_state *p_rarch = &rarch_st;
-   p_rarch->input_device_config_names[port][0] = '\0';
+   p_rarch->input_device_info[port].config_name[0] = '\0';
 }
+
+/* input_device_info wrappers END */
 
 unsigned *input_config_get_device_ptr(unsigned port)
 {
@@ -27482,7 +27606,6 @@ void input_config_set_device(unsigned port, unsigned id)
       settings->uints.input_libretro_device[port], id);
 }
 
-
 const struct retro_keybind *input_config_get_bind_auto(
       unsigned port, unsigned id)
 {
@@ -27495,33 +27618,35 @@ const struct retro_keybind *input_config_get_bind_auto(
    return NULL;
 }
 
-void input_config_set_pid(unsigned port, uint16_t pid)
+void input_config_reset_autoconfig_binds(unsigned port)
 {
-   struct rarch_state *p_rarch = &rarch_st;
-   p_rarch->input_config_pid[port] = pid;
-}
+   unsigned i;
 
-uint16_t input_config_get_pid(unsigned port)
-{
-   struct rarch_state *p_rarch = &rarch_st;
-   return p_rarch->input_config_pid[port];
-}
+   if (port >= MAX_USERS)
+      return;
 
-void input_config_set_vid(unsigned port, uint16_t vid)
-{
-   struct rarch_state *p_rarch = &rarch_st;
-   p_rarch->input_config_vid[port] = vid;
-}
+   for (i = 0; i < RARCH_BIND_LIST_END; i++)
+   {
+      input_autoconf_binds[port][i].joykey  = NO_BTN;
+      input_autoconf_binds[port][i].joyaxis = AXIS_NONE;
 
-uint16_t input_config_get_vid(unsigned port)
-{
-   struct rarch_state *p_rarch = &rarch_st;
-   return p_rarch->input_config_vid[port];
+      if (input_autoconf_binds[port][i].joykey_label)
+      {
+         free(input_autoconf_binds[port][i].joykey_label);
+         input_autoconf_binds[port][i].joykey_label = NULL;
+      }
+
+      if (input_autoconf_binds[port][i].joyaxis_label)
+      {
+         free(input_autoconf_binds[port][i].joyaxis_label);
+         input_autoconf_binds[port][i].joyaxis_label = NULL;
+      }
+   }
 }
 
 void input_config_reset(void)
 {
-   unsigned i, j;
+   unsigned i;
    struct rarch_state *p_rarch = &rarch_st;
 
    retro_assert(sizeof(input_config_binds[0]) >= sizeof(retro_keybinds_1));
@@ -27535,12 +27660,22 @@ void input_config_reset(void)
 
    for (i = 0; i < MAX_USERS; i++)
    {
-      p_rarch->input_config_vid[i]     = 0;
-      p_rarch->input_config_pid[i]     = 0;
-      p_rarch->libretro_input_binds[i] = input_config_binds[i];
+      /* Note: Don't use input_config_clear_device_name()
+       * here, since this will re-index devices each time
+       * (not required - we are setting all 'name indices'
+       * to zero manually) */
+      p_rarch->input_device_info[i].name[0] = '\0';
+      input_config_clear_device_display_name(i);
+      input_config_clear_device_config_path(i);
+      input_config_clear_device_config_name(i);
+      input_config_set_device_vid(i, 0);
+      input_config_set_device_pid(i, 0);
+      input_config_set_device_autoconfigured(i, false);
+      input_config_set_device_name_index(i, 0);
 
-      for (j = 0; j < 64; j++)
-         input_device_names[i][j]      = 0;
+      input_config_reset_autoconfig_binds(i);
+
+      p_rarch->libretro_input_binds[i] = input_config_binds[i];
    }
 }
 
@@ -27577,20 +27712,22 @@ void config_read_keybinds_conf(void *data)
    }
 }
 
-void input_autoconfigure_joypad_conf(void *data,
-      struct retro_keybind *binds)
+void input_config_set_autoconfig_binds(unsigned port, void *data)
 {
+   config_file_t *config       = (config_file_t*)data;
+   struct retro_keybind *binds = NULL;
    unsigned i;
-   config_file_t *conf = (config_file_t*)data;
 
-   if (!conf)
+   if ((port >= MAX_USERS) || !config)
       return;
+
+   binds = input_autoconf_binds[port];
 
    for (i = 0; i < RARCH_BIND_LIST_END; i++)
    {
-      input_config_parse_joy_button(conf, "input",
+      input_config_parse_joy_button(config, "input",
             input_config_bind_map_get_base(i), &binds[i]);
-      input_config_parse_joy_axis(conf, "input",
+      input_config_parse_joy_axis(config, "input",
             input_config_bind_map_get_base(i), &binds[i]);
    }
 }

--- a/tasks/task_autodetect_blissbox.c
+++ b/tasks/task_autodetect_blissbox.c
@@ -504,39 +504,36 @@ static const blissbox_pad_type_t* input_autoconfigure_get_blissbox_pad_type(int 
 #endif
 }
 
-void input_autoconfigure_override_handler(void *data)
+void input_autoconfigure_blissbox_override_handler(
+      int vid, int pid, char *device_name, size_t len)
 {
-   autoconfig_params_t *params = (autoconfig_params_t*)data;
-
-   if (params->pid == BLISSBOX_UPDATE_MODE_PID)
+   if (pid == BLISSBOX_UPDATE_MODE_PID)
       RARCH_LOG("[Autoconf]: Bliss-Box in update mode detected. Ignoring.\n");
-   else if (params->pid == BLISSBOX_OLD_PID)
+   else if (pid == BLISSBOX_OLD_PID)
       RARCH_LOG("[Autoconf]: Bliss-Box 1.0 firmware detected. Please update to 2.0 or later.\n");
-   else if (params->pid >= BLISSBOX_PID && params->pid <= BLISSBOX_PID + BLISSBOX_MAX_PAD_INDEX)
+   else if (pid >= BLISSBOX_PID && pid <= BLISSBOX_PID + BLISSBOX_MAX_PAD_INDEX)
    {
       const blissbox_pad_type_t *pad;
-      char name[255] = {0};
-      int index      = params->pid - BLISSBOX_PID;
+      int index      = pid - BLISSBOX_PID;
 
       RARCH_LOG("[Autoconf]: Bliss-Box detected. Getting pad type...\n");
 
       if (blissbox_pads[index])
          pad = blissbox_pads[index];
       else
-         pad = input_autoconfigure_get_blissbox_pad_type(params->vid, params->pid);
+         pad = input_autoconfigure_get_blissbox_pad_type(vid, pid);
 
       if (pad && !string_is_empty(pad->name))
       {
          RARCH_LOG("[Autoconf]: Found Bliss-Box pad type: %s (%d) in port#%d\n", pad->name, pad->index, index);
 
-         if (params->name)
-            free(params->name);
-
          /* override name given to autoconfig so it knows what kind of pad this is */
-         strlcat(name, "Bliss-Box 4-Play ", sizeof(name));
-         strlcat(name, pad->name, sizeof(name));
-
-         params->name = strdup(name);
+         if (len > 0)
+         {
+            device_name[0] = '\0';
+            strlcpy(device_name, "Bliss-Box 4-Play ", len);
+            strlcat(device_name, pad->name, len);
+         }
 
          blissbox_pads[index] = pad;
       }

--- a/tasks/tasks_internal.h
+++ b/tasks/tasks_internal.h
@@ -46,20 +46,6 @@ typedef struct nbio_buf
    char *path;
 } nbio_buf_t;
 
-typedef struct autoconfig_params     autoconfig_params_t;
-
-struct autoconfig_params
-{
-   int32_t vid;
-   int32_t pid;
-   unsigned idx;
-   uint32_t max_users;
-   char  *name;
-   char  *autoconfig_directory;
-   bool show_hidden_files;
-};
-
-
 #ifdef HAVE_NETWORKING
 typedef struct
 {
@@ -220,35 +206,25 @@ void *savefile_ptr_get(void);
 
 void path_init_savefile_new(void);
 
-bool input_is_autoconfigured(unsigned i);
-
-unsigned input_autoconfigure_get_device_name_index(unsigned i);
-
-void input_autoconfigure_reset(void);
-
-void input_autoconfigure_override_handler(void *data);
-
+/* Autoconfigure tasks */
+extern const char* const input_builtin_autoconfs[];
+void input_autoconfigure_blissbox_override_handler(
+      int vid, int pid, char *device_name, size_t len);
 void input_autoconfigure_connect(
       const char *name,
       const char *display_name,
       const char *driver,
-      unsigned idx,
+      unsigned port,
       unsigned vid,
       unsigned pid);
-
-bool input_autoconfigure_disconnect(unsigned i, const char *ident);
-
-bool input_autoconfigure_get_swap_override(void);
-
-void input_autoconfigure_joypad_reindex_devices(void);
+bool input_autoconfigure_disconnect(
+      unsigned port, const char *name);
 
 void set_save_state_in_background(bool state);
 
 #ifdef HAVE_CDROM
 void task_push_cdrom_dump(const char *drive);
 #endif
-
-extern const char* const input_builtin_autoconfs[];
 
 RETRO_END_DECLS
 


### PR DESCRIPTION
## Description

At present, the controller autodetect task (used to handle the connection and automatic configuration of controllers) reads and writes global state across multiple threads, with no precautions. This means it is 100% *thread unsafe*. In addition, the code itself is quite messy and confusing, and difficult to maintain.

As requested by twinaphex, this PR rewrites the autodetect task to ensure thread safety. It also cleans up everything, and should thus facilitate future work.

As a side bonus, it fixes the detection of 'controller reconnection' events, which means task messages should no longer be spammed to screen every time a user launches content or quits to the menu.

(I will add the option to disable autoconfig messages - and some other types of notification - permanently in a separate PR. This one has already grown large enough...)