### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,9 @@ convert_rumble.awk
 *~
 assets
 info
+content_history.lpl
 content_image_history.lpl
+content_music_history.lpl
 saves
 screenshots
 


### PR DESCRIPTION
## Description

This trivial PR just adds two missing RetroArch-generated files to the `.gitignore` file in the repository.