### PR TITLE
(Load Content Animation) Fix detection of 'favourites' playlist

### DIFF
--- a/gfx/widgets/gfx_widget_load_content_animation.c
+++ b/gfx/widgets/gfx_widget_load_content_animation.c
@@ -412,10 +412,10 @@ bool gfx_widget_start_load_content_animation(void)
                   sizeof(state->system_name));
 
             /* Exclude history and favourites playlists */
-            if (string_is_equal(state->system_name, "history")   ||
-                string_is_equal(state->system_name, "favorites") ||
-                string_ends_with_size(state->system_name, "_history",
-                     strlen(state->system_name), STRLEN_CONST("_history")))
+            if (string_ends_with_size(state->system_name, "_history",
+                     strlen(state->system_name), STRLEN_CONST("_history")) ||
+                string_ends_with_size(state->system_name, "_favorites",
+                     strlen(state->system_name), STRLEN_CONST("_favorites")))
                state->system_name[0] = '\0';
 
             /* Check whether a valid system name was found */


### PR DESCRIPTION
## Description

This PR fixes a silly mistake in the new 'load content' animation...

I used the wrong string comparison to detect the 'favourites' playlist, so launching content via a 'favourites' playlist entry with missing `db_name` information would display an incorrect 'system name' string in the animation. This PR fixes the string comparison.