### PR TITLE
[WIP] Refactor how xinput driver gets controller names

### DIFF
--- a/input/drivers_joypad/xinput_joypad.c
+++ b/input/drivers_joypad/xinput_joypad.c
@@ -163,27 +163,15 @@ static const char* const XBOX_CONTROLLER_NAMES[4] =
    "XInput Controller (User 4)"
 };
 
-static const char* const XBOX_ONE_CONTROLLER_NAMES[4] =
-{
-   "XBOX One Controller (User 1)",
-   "XBOX One Controller (User 2)",
-   "XBOX One Controller (User 3)",
-   "XBOX One Controller (User 4)"
-};
-
 static const char *xinput_joypad_name(unsigned pad)
 {
-   int xuser = pad_index_to_xuser_index(pad);
 #ifdef HAVE_DINPUT
-   /* Use the real controller name for XBOX One controllers since
-      they are slightly different  */
-   if (xuser < 0)
+   /* If we have dinput, we are able to get a name from the device itself */
       return dinput_joypad.name(pad);
-
-   if (strstr(dinput_joypad.name(pad), "Xbox One For Windows"))
-      return XBOX_ONE_CONTROLLER_NAMES[xuser];
 #endif
 
+   /* Systems like the XBox 360 don't have dinput, so we use generic names instead */
+   int xuser = pad_index_to_xuser_index(pad);
    if (xuser < 0)
       return NULL;
 

--- a/input/input_autodetect_builtin.c
+++ b/input/input_autodetect_builtin.c
@@ -669,10 +669,6 @@ const char* const input_builtin_autoconfs[] =
    DECL_AUTOCONF_DEVICE("XInput Controller (User 2)", "xinput", XINPUT_DEFAULT_BINDS),
    DECL_AUTOCONF_DEVICE("XInput Controller (User 3)", "xinput", XINPUT_DEFAULT_BINDS),
    DECL_AUTOCONF_DEVICE("XInput Controller (User 4)", "xinput", XINPUT_DEFAULT_BINDS),
-   DECL_AUTOCONF_DEVICE("XBOX One Controller (User 1)", "xinput", XINPUT_DEFAULT_BINDS),
-   DECL_AUTOCONF_DEVICE("XBOX One Controller (User 2)", "xinput", XINPUT_DEFAULT_BINDS),
-   DECL_AUTOCONF_DEVICE("XBOX One Controller (User 3)", "xinput", XINPUT_DEFAULT_BINDS),
-   DECL_AUTOCONF_DEVICE("XBOX One Controller (User 4)", "xinput", XINPUT_DEFAULT_BINDS),
 #endif
 #endif
 #ifdef HAVE_SDL2


### PR DESCRIPTION
## Description

The current behavior in the master branch when using the xinput controller driver is that controllers will always be given generic "XInput Controller (User X)" names hardcoded inside RA. There is also a special case for XBox One controllers.

For systems where dinput is also available, we can query the device's real name and this will allow the autoconfigure system to find autoconfig files faster due to the dinput-provided name potentially being unique.

## Related Issues

Some work will have to be done to the autoconfig files too because several of them are using RA's generic names as their device name. To help people correct the autoconfig files, extra logging could be added such that it always reports the device's vid/pid and devname (as provided by a system driver and not some RA generic name).

## Related Pull Requests
None

## Reviewers

@twinaphex 
@jdgleaver
@hunterk

---
Before this gets merged, ideally this change would be tested in these conditions:

- [x] Test xinput controller driver with an XBox One gamepad;
- [ ] Test on an XBox One;
- [ ] Test the built-in autoconf profiles (e.g. use a 360 pad when the autoconfig folder is empty)
 
