### PR TITLE
(Makefiles) Improve version_git.o regeneration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,13 +215,6 @@ $(OBJDIR)/%.o: %.m
 	@$(if $(Q), $(shell echo echo OBJC $<),)
 	$(Q)$(CXX) $(OBJCFLAGS) $(DEFINES) -MMD -c -o $@ $<
 
-.FORCE:
-
-$(OBJDIR)/version_git.o: version_git.c .FORCE
-	@mkdir -p $(dir $@)
-	@$(if $(Q), $(shell echo echo CC $<),)
-	$(Q)$(CC) $(CFLAGS) $(DEFINES) -MMD -c -o $@ $<
-
 $(OBJDIR)/%.o: %.S config.h config.mk $(HEADERS)
 	@mkdir -p $(dir $@)
 	@$(if $(Q), $(shell echo echo AS $<),)
@@ -233,7 +226,6 @@ $(OBJDIR)/%.o: %.rc $(HEADERS)
 	$(Q)$(WINDRES) -o $@ $<
 
 install: $(TARGET)
-	rm -f $(OBJDIR)/version_git.o
 	mkdir -p $(DESTDIR)$(BIN_DIR) 2>/dev/null || /bin/true
 	mkdir -p $(DESTDIR)$(GLOBAL_CONFIG_DIR) 2>/dev/null || /bin/true
 	mkdir -p $(DESTDIR)$(DATA_DIR)/applications 2>/dev/null || /bin/true

--- a/Makefile.common
+++ b/Makefile.common
@@ -157,10 +157,17 @@ ifeq ($(TARGET), retroarch_3ds)
    OBJ += frontend/drivers/platform_ctr.o
 endif
 
-# Git
+# Git Version
 
 GIT_VERSION := $(shell git rev-parse --short HEAD 2>/dev/null)
 ifneq ($(GIT_VERSION),)
+   LAST_GIT_VERSION := $(shell cat "$(OBJDIR)"/last-git-version 2>/dev/null)
+   ifneq ($(GIT_VERSION), $(LAST_GIT_VERSION))
+      $(shell \
+         mkdir -p "$(OBJDIR)"; \
+         echo "$(GIT_VERSION)" > "$(OBJDIR)"/last-git-version; \
+         touch version_git.c)
+   endif
    DEFINES += -DHAVE_GIT_VERSION -DGIT_VERSION=$(GIT_VERSION)
    OBJ += version_git.o
 endif


### PR DESCRIPTION
## Description

At the moment, the `version_git.o` object is forcedly built on every `make` invocation, regardless if the Git hash of `HEAD` has actually changed or not. Moreover, non-build invocations such as `make install` also always rebuild `version_git.o` unnecessarily.

This PR fixes the issue by keeping track of the last Git hash used to build `version_git.o` and only rebuild it if the hash changed.

## Reviewers

@Alcaro @realnc 
