### PR TITLE
(Makefiles) Use fallback directory in Git version checking

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -161,11 +161,12 @@ endif
 
 GIT_VERSION := $(shell git rev-parse --short HEAD 2>/dev/null)
 ifneq ($(GIT_VERSION),)
-   LAST_GIT_VERSION := $(shell cat "$(OBJDIR)"/last-git-version 2>/dev/null)
-   ifneq ($(GIT_VERSION), $(LAST_GIT_VERSION))
+   _CACHEDIR = $(if $(OBJDIR), $(OBJDIR), $(CURDIR))
+   _LAST_GIT_VERSION := $(shell cat "$(_CACHEDIR)"/last-git-version 2>/dev/null)
+   ifneq ($(GIT_VERSION), $(_LAST_GIT_VERSION))
       $(shell \
-         mkdir -p "$(OBJDIR)"; \
-         echo "$(GIT_VERSION)" > "$(OBJDIR)"/last-git-version; \
+         mkdir -p "$(_CACHEDIR)"; \
+         echo "$(GIT_VERSION)" > "$(_CACHEDIR)"/last-git-version; \
          touch version_git.c)
    endif
    DEFINES += -DHAVE_GIT_VERSION -DGIT_VERSION=$(GIT_VERSION)

--- a/Makefile.dingux
+++ b/Makefile.dingux
@@ -164,13 +164,6 @@ $(OBJDIR)/%.o: %.m
 	@$(if $(Q), $(shell echo echo OBJC $<),)
 	$(CXX) $(OBJCFLAGS) $(DEFINES) -MMD -c -o $@ $<
 
-.FORCE:
-
-$(OBJDIR)/version_git.o: version_git.c .FORCE
-	@mkdir -p $(dir $@)
-	@$(if $(Q), $(shell echo echo CC $<),)
-	$(CC) $(CFLAGS) $(DEFINES) -MMD -c -o $@ $<
-
 $(OBJDIR)/%.o: %.S $(HEADERS)
 	@mkdir -p $(dir $@)
 	@$(if $(Q), $(shell echo echo AS $<),)

--- a/Makefile.msvc
+++ b/Makefile.msvc
@@ -202,8 +202,6 @@ endif
 DEFINES += -DRARCH_INTERNAL -DHAVE_SCREENSHOTS -DHAVE_REWIND -DHAVE_DYNAMIC -DJSON_STATIC
 INCLUDE_DIRS += -I. -Igfx/include
 
-#OBJ := version_git.o
-
 OBJ := $(patsubst %rarch.o,%rarch.res,$(OBJ))
 OBJ := $(addprefix $(BUILD_DIR)/,$(OBJ))
 OBJ := $(OBJ:.o=.obj)

--- a/Makefile.win
+++ b/Makefile.win
@@ -167,13 +167,6 @@ $(OBJDIR)/%.o: %.c
 	@$(if $(Q), $(shell echo echo CC $<),)
 	$(Q)$(CC) $(CFLAGS) $(DEFINES) -MMD -c -o $@ $<
 
-.FORCE:
-
-$(OBJDIR)/version_git.o: version_git.c .FORCE
-	@-mkdir -p $(dir $@) || mkdir $(subst /,\,$(dir $@)) || echo .
-	@$(if $(Q), $(shell echo echo CC $<),)
-	$(Q)$(CC) $(CFLAGS) $(DEFINES) -MMD -c -o $@ $<
-
 $(OBJDIR)/%.o: %.cpp | $(dir $@)
 	@-mkdir -p $(dir $@) || mkdir $(subst /,\,$(dir $@)) || echo .
 	@$(if $(Q), $(shell echo echo CXX $<),)


### PR DESCRIPTION
## Description

This PR fixes Git version checking in the Makefiles for the cases when `OBJDIR` is not defined, e.g. libnx builds.
Also removes related obsolete code.

## Related Pull Requests

Follow-up of #11045 

## Reviewers

@m4xw 
