### PR TITLE
Make Blargg_snes filter customizable.

### DIFF
--- a/gfx/video_filters/Blargg_NTSC_SNES_Custom.filt
+++ b/gfx/video_filters/Blargg_NTSC_SNES_Custom.filt
@@ -1,0 +1,47 @@
+filter = blargg_ntsc_snes
+
+blargg_ntsc_snes_tvtype = "custom"
+
+# tvtype presets for reference:
+# monochrome = 0,-1, 0, 0, .2,  0, .2,-.2,-.2,-1, 1, 1
+# composite  = 0, 0, 0, 0,  0,  0,  0,  0,  0, 0, 1, 1
+# svideo     = 0, 0, 0, 0, .2,  0, .2, -1, -1, 0, 1, 1
+# rgb        = 0, 0, 0, 0, .2,  0, .7, -1, -1,-1, 1, 1
+
+blargg_ntsc_snes_hue = 0.0
+# -1 = -180 degrees     +1 = +180 degrees
+
+blargg_ntsc_snes_saturation = 0.0
+# -1 = grayscale (0.0)  +1 = oversaturated colors (2.0)
+
+blargg_ntsc_snes_contrast = 0.0
+# -1 = dark (0.5)       +1 = light (1.5)
+
+blargg_ntsc_snes_brightness = 0.0
+# -1 = dark (0.5)       +1 = light (1.5)
+
+blargg_ntsc_snes_sharpness = 0.2
+# edge contrast enhancement/blurring
+
+blargg_ntsc_snes_gamma = 0.0
+# -1 = dark (1.5)       +1 = light (0.5)
+
+blargg_ntsc_snes_resolution = 0.7
+# image resolution (composite 0 - svideo 0.2 - rgb 0.7)
+
+blargg_ntsc_snes_artifacts = 0.0
+# artifacts caused by color changes (-1 is off)
+
+blargg_ntsc_snes_fringing = 0.0
+# color artifacts caused by brightness changes (-1 is off)
+
+blargg_ntsc_snes_bleed = 0.0
+# color bleed (color resolution reduction) (-1 is off)
+
+blargg_ntsc_snes_merge_fields = 0.0
+# if 1, merges even and odd fields together to reduce flicker
+# if 0, alternate fields every frame
+
+blargg_ntsc_snes_hires_blit = 0
+# do hires blitting when set to 1, assuming 512 width for any res >256 (made for SNES 512 mode)
+# set it to 0 for other resolutions such as 320 (even if a bit out of specs for this filter)

--- a/gfx/video_filters/blargg_ntsc_snes.c
+++ b/gfx/video_filters/blargg_ntsc_snes.c
@@ -78,6 +78,21 @@ static void blargg_ntsc_snes_initialize(void *data,
    snes_ntsc_setup_t setup;
    struct filter_data *filt = (struct filter_data*)data;
 
+   float custom_hue, custom_saturation, custom_contrast, custom_brightness, custom_sharpness,
+      custom_gamma, custom_resolution, custom_artifacts, custom_fringing, custom_bleed, custom_merge_fields;
+
+   config->get_float(userdata, "hue", &custom_hue, 0.0f);
+   config->get_float(userdata, "saturation", &custom_saturation, 0.0f);
+   config->get_float(userdata, "contrast", &custom_contrast, 0.0f);
+   config->get_float(userdata, "brightness", &custom_brightness, 0.0f);
+   config->get_float(userdata, "sharpness", &custom_sharpness, 0.0f);
+   config->get_float(userdata, "gamma", &custom_gamma, 0.0f);
+   config->get_float(userdata, "resolution", &custom_resolution, 0.0f);
+   config->get_float(userdata, "artifacts", &custom_artifacts, 0.0f);
+   config->get_float(userdata, "fringing", &custom_fringing, 0.0f);
+   config->get_float(userdata, "bleed", &custom_bleed, 0.0f);
+   config->get_float(userdata, "merge_fields", &custom_merge_fields, 1.0f);
+   
    filt->ntsc = (snes_ntsc_t*)calloc(1, sizeof(*filt->ntsc));
 
    if (config->get_string(userdata, "tvtype", &tvtype, "composite"))
@@ -101,6 +116,22 @@ static void blargg_ntsc_snes_initialize(void *data,
       {
          setup = retroarch_snes_ntsc_svideo;
          setup.merge_fields = 1;
+      }
+      else if (memcmp(tvtype, "custom", 6) == 0)
+      {
+         setup = retroarch_snes_ntsc_composite;
+         setup.hue = custom_hue;
+         setup.saturation = custom_saturation;
+         setup.contrast = custom_contrast;
+         setup.brightness = custom_brightness;
+         setup.sharpness = custom_sharpness;
+         setup.gamma = custom_gamma;
+         setup.resolution = custom_resolution;
+         setup.artifacts = custom_artifacts;
+         setup.fringing = custom_fringing;
+         setup.bleed = custom_bleed;
+         setup.merge_fields = custom_merge_fields;
+         config->get_int(userdata, "hires_blit", &hires_blit, 1);
       }
    }
    else
@@ -169,7 +200,7 @@ static void blargg_ntsc_snes_render_rgb565(void *data, int width, int height,
       uint16_t *input, int pitch, uint16_t *output, int outpitch)
 {
    struct filter_data *filt = (struct filter_data*)data;
-   if(width <= 256)
+   if(width <= 256 || !hires_blit)
       retroarch_snes_ntsc_blit(filt->ntsc, input, pitch, filt->burst,
             width, height, output, outpitch * 2, first, last);
    else

--- a/gfx/video_filters/snes_ntsc/snes_ntsc.c
+++ b/gfx/video_filters/snes_ntsc/snes_ntsc.c
@@ -20,6 +20,8 @@ snes_ntsc_setup_t const retroarch_snes_ntsc_composite  = { 0, 0, 0, 0, 0,  0, 0,
 snes_ntsc_setup_t const retroarch_snes_ntsc_svideo     = { 0, 0, 0, 0,.2,  0,.2, -1, -1, 0,  1, 0, 0 };
 snes_ntsc_setup_t const retroarch_snes_ntsc_rgb        = { 0, 0, 0, 0,.2,  0,.7, -1, -1,-1,  1, 0, 0 };
 
+int hires_blit = 1;
+
 #define alignment_count 3
 #define burst_count     3
 #define rescale_in      8

--- a/gfx/video_filters/snes_ntsc/snes_ntsc.h
+++ b/gfx/video_filters/snes_ntsc/snes_ntsc.h
@@ -39,6 +39,9 @@ extern snes_ntsc_setup_t const retroarch_snes_ntsc_svideo;    /* color bleeding 
 extern snes_ntsc_setup_t const retroarch_snes_ntsc_rgb;       /* crisp image */
 extern snes_ntsc_setup_t const retroarch_snes_ntsc_monochrome;/* desaturated + artifacts */
 
+/* Do hires blitting when set to 1, assuming 512 width for any res >256. Made for SNES 512 mode. */
+extern int hires_blit;
+
 /* Initializes and adjusts parameters. Can be called multiple times on the same
 snes_ntsc_t object. Can pass NULL for either parameter. */
 typedef struct snes_ntsc_t snes_ntsc_t;


### PR DESCRIPTION
Give access to various Blargg filter parameters via a filt file.
(hue/saturation/contrast/brightness/sharpness/gamma/resolution/artifacts/fringing/colorbleed/mergefields)

Also added a parameter to disable the hires mode forcing a 512 width, so that it can run with anything above 256 width.