### PR TITLE
Fix 'content launched from command line' detection

### DIFF
--- a/retroarch.h
+++ b/retroarch.h
@@ -227,6 +227,7 @@ typedef struct rarch_resolution
 typedef struct global
 {
    bool launched_from_cli;
+   bool cli_load_menu_on_error;
    struct
    {
       char savefile[8192];


### PR DESCRIPTION
## Description

As reported in issue #11020, commit https://github.com/libretro/RetroArch/commit/b74b8b6a6cacf1b09dba850b727b2d7279c4f753 'broke' the detection of whether content is being launched via the command line (in truth, this never actually worked properly - but it was broken in a way that did no harm...). As a result, if a core or content fails to load, RetroArch currently always returns to the menu - which breaks compatibility with all external launchers/frontends.

This PR fixes the detection of command line interface usage, such that RetroArch properly quits if content launched via the command line fails in some way. In addition:

- Since there is a valid use case for returning to the menu in the event of a 'load content' error (it allows on-screen error notifications to be displayed) a new command line option `--load-menu-on-error` has been added.

- The buffer size for the string output by `./retroarch --help` has been increased, since at present the help message is truncated.

## Related Issues

This closes  #11020
