### PR TITLE
Fix for wrong number of remaining cheat search matches on some machines

### DIFF
--- a/managers/cheat_manager.c
+++ b/managers/cheat_manager.c
@@ -865,8 +865,7 @@ int cheat_manager_initialize_memory(rarch_setting_t *setting, size_t idx, bool w
 
    }
 
-   cheat_st->num_matches = (cheat_st->total_memory_size * 8) 
-      / ((int)pow(2, cheat_st->search_bit_size));
+   cheat_st->num_matches = (cheat_st->total_memory_size * 8) / (1 << cheat_st->search_bit_size);
 
 #if 0
    /* Ensure we're aligned on 4-byte boundary */


### PR DESCRIPTION
## Description

Seems pow returns 2^x-1 on some systems when cast to int from double, resulting in the matched number being far higher than it should be. Fixed by making it a pure int bitwise shift.

## Related Issues

NA

## Related Pull Requests

NA

