### PR TITLE
Make Notification Font option visible when Graphics Widgets are enabled

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -7502,6 +7502,10 @@ unsigned menu_displaylist_build_list(
 #endif
 #endif
                   case MENU_ENUM_LABEL_VIDEO_FONT_PATH:
+                     if (video_font_enable ||
+                         (widgets_supported && menu_enable_widgets))
+                        build_list[i].checked = true;
+                     break;
                   case MENU_ENUM_LABEL_VIDEO_FONT_SIZE:
                   case MENU_ENUM_LABEL_VIDEO_MESSAGE_POS_X:
                   case MENU_ENUM_LABEL_VIDEO_MESSAGE_POS_Y:


### PR DESCRIPTION
## Description

As of the current RA code, the Notification Font option is visible only when "On-Screen Notifications" is set to ON and "Graphics Widgets" is set to **OFF**.

However, all widget-style notifications make use of the customizable font and use it for all their text. They just ignore the other stylistic options available, such as font size, color, background, etc.

This small PR makes it so that the Notification Font path setting is visible when Graphics Widgets are enabled as well.

![Annotation 2020-07-23 183554](https://user-images.githubusercontent.com/17614150/88313311-a2f10a80-cd13-11ea-9ab5-2aff6d11a9a3.png)