### PR TITLE
(Makefiles) Re-implement Git version handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.dol
 *.map
 *.swp
+*.cache
 .tmp
 .tmp.c
 .tmp.cxx

--- a/Makefile.common
+++ b/Makefile.common
@@ -158,15 +158,28 @@ ifeq ($(TARGET), retroarch_3ds)
 endif
 
 # Git Version
+GIT_VERSION_CACHEDIR = $(if $(OBJDIR),$(OBJDIR),$(CURDIR))
+GIT_VERSION_CACHEFILE = $(GIT_VERSION_CACHEDIR)/git-version.cache
 
-GIT_VERSION := $(shell git rev-parse --short HEAD 2>/dev/null)
-ifneq ($(GIT_VERSION),)
-   _CACHEDIR = $(if $(OBJDIR),$(OBJDIR),$(CURDIR))
-   _LAST_GIT_VERSION := $(shell cat "$(_CACHEDIR)"/last-git-version 2>/dev/null)
-   ifneq ($(GIT_VERSION),$(_LAST_GIT_VERSION))
+ifneq (,$(wildcard .git/index))  # Building inside a Git repository?
+   GIT_VERSION := $(shell git rev-parse --short HEAD 2>/dev/null)
+endif
+
+ifneq (,$(wildcard $(GIT_VERSION_CACHEFILE)))  # Cached Git version?
+   GIT_VERSION_CACHE = $(shell cat "$(GIT_VERSION_CACHEFILE)" 2>/dev/null)
+endif
+
+ifeq ($(GIT_VERSION),)
+   ifneq ($(GIT_VERSION_CACHE),)  # If no Git version, use cached if found
+      GIT_VERSION = $(GIT_VERSION_CACHE)
+   endif
+endif
+
+ifneq ($(GIT_VERSION),)  # Enable version_git.o?
+   ifneq ($(GIT_VERSION),$(GIT_VERSION_CACHE))  # Update version_git.o?
       $(shell \
-         mkdir -p "$(_CACHEDIR)"; \
-         echo "$(GIT_VERSION)" > "$(_CACHEDIR)"/last-git-version; \
+         mkdir -p "$(GIT_VERSION_CACHEDIR)" && \
+         echo "$(GIT_VERSION)" > "$(GIT_VERSION_CACHEFILE)" && \
          touch version_git.c)
    endif
    DEFINES += -DHAVE_GIT_VERSION -DGIT_VERSION=$(GIT_VERSION)


### PR DESCRIPTION
## Description

This PR is a re-implementation of my previous Git version handling code in `Makefile.common`.
It provides better (more fine-grained) logic for `version_git.o` regeneration. In particular it addresses a small regeneration issue obeserved in the upcoming libretro infrastructure when building with static cores where `version_git.o` was not correctly preserved. This PR fixes the issue.

## Related Pull Requests

This PR is a better implementation of #11062 #11048 #11045

## Reviewers

@m4xw confirmed this fixed the issue on first view.