### PR TITLE
Core option improvements

### DIFF
--- a/menu/cbs/menu_cbs_get_value.c
+++ b/menu/cbs/menu_cbs_get_value.c
@@ -1325,28 +1325,18 @@ static void menu_action_setting_disp_set_label_core_options(
       char *s2, size_t len2)
 {
    core_option_manager_t *coreopts = NULL;
-   const char *core_opt = NULL;
+   const char *coreopt_label       = NULL;
 
    *s = '\0';
    *w = 19;
 
    if (rarch_ctl(RARCH_CTL_CORE_OPTIONS_LIST_GET, &coreopts))
    {
-      core_opt = core_option_manager_get_val_label(coreopts,
+      coreopt_label = core_option_manager_get_val_label(coreopts,
             type - MENU_SETTINGS_CORE_OPTION_START);
 
-      strlcpy(s, "", len);
-
-      if (core_opt)
-      {
-         if (string_is_equal(core_opt,
-                  msg_hash_to_str(MENU_ENUM_LABEL_ENABLED)))
-            core_opt = msg_hash_to_str(MENU_ENUM_LABEL_VALUE_ON);
-         else if (string_is_equal(core_opt,
-                  msg_hash_to_str(MENU_ENUM_LABEL_DISABLED)))
-            core_opt = msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF);
-         strlcpy(s, core_opt, len);
-      }
+      if (!string_is_empty(coreopt_label))
+         strlcpy(s, coreopt_label, len);
    }
 
    strlcpy(s2, path, len2);

--- a/retroarch.c
+++ b/retroarch.c
@@ -17387,6 +17387,7 @@ static const char *core_option_manager_parse_value_label(
     *   no harm */
    if (string_is_equal_noncase(label, msg_hash_to_str(MENU_ENUM_LABEL_ENABLED)) ||
        string_is_equal_noncase(label, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_ENABLED)) ||
+       string_is_equal_noncase(label, "enable") ||
        string_is_equal_noncase(label, "on") ||
        string_is_equal_noncase(label, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_ON)) ||
        string_is_equal_noncase(label, "true") ||
@@ -17394,6 +17395,7 @@ static const char *core_option_manager_parse_value_label(
       label = msg_hash_to_str(MENU_ENUM_LABEL_VALUE_ON);
    else if (string_is_equal_noncase(label, msg_hash_to_str(MENU_ENUM_LABEL_DISABLED)) ||
             string_is_equal_noncase(label, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_DISABLED)) ||
+            string_is_equal_noncase(label, "disable") ||
             string_is_equal_noncase(label, "off") ||
             string_is_equal_noncase(label, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF)) ||
             string_is_equal_noncase(label, "false") ||

--- a/retroarch.c
+++ b/retroarch.c
@@ -17354,11 +17354,62 @@ int main(int argc, char *argv[])
 #endif
 
 /* CORE OPTIONS */
+static const char *core_option_manager_parse_value_label(
+      const char *value, const char *value_label)
+{
+   /* 'value_label' may be NULL */
+   const char *label = string_is_empty(value_label) ?
+         value : value_label;
+
+   if (string_is_empty(label))
+      return NULL;
+
+   /* Any label starting with a digit (or +/-)
+    * cannot be a boolean string, and requires
+    * no further processing */
+   if (isdigit((unsigned char)*label) ||
+       (*label == '+') ||
+       (*label == '-'))
+      return label;
+
+   /* Core devs have a habit of using arbitrary
+    * strings to label boolean values (i.e. enabled,
+    * Enabled, on, On, ON, true, True, TRUE, disabled,
+    * Disabled, off, Off, OFF, false, False, FALSE).
+    * These should all be converted to standard ON/OFF
+    * strings
+    * > Note: We require some duplication here
+    *   (e.g. MENU_ENUM_LABEL_ENABLED *and*
+    *    MENU_ENUM_LABEL_VALUE_ENABLED) in order
+    *   to match both localised and non-localised
+    *   strings. This function is not performance
+    *   critical, so these extra comparisons do
+    *   no harm */
+   if (string_is_equal_noncase(label, msg_hash_to_str(MENU_ENUM_LABEL_ENABLED)) ||
+       string_is_equal_noncase(label, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_ENABLED)) ||
+       string_is_equal_noncase(label, "on") ||
+       string_is_equal_noncase(label, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_ON)) ||
+       string_is_equal_noncase(label, "true") ||
+       string_is_equal_noncase(label, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_TRUE)))
+      label = msg_hash_to_str(MENU_ENUM_LABEL_VALUE_ON);
+   else if (string_is_equal_noncase(label, msg_hash_to_str(MENU_ENUM_LABEL_DISABLED)) ||
+            string_is_equal_noncase(label, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_DISABLED)) ||
+            string_is_equal_noncase(label, "off") ||
+            string_is_equal_noncase(label, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF)) ||
+            string_is_equal_noncase(label, "false") ||
+            string_is_equal_noncase(label, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_FALSE)))
+      label = msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF);
+
+   return label;
+}
+
 static bool core_option_manager_parse_variable(
       core_option_manager_t *opt, size_t idx,
       const struct retro_variable *var,
       config_file_t *config_src)
 {
+   size_t i;
+   union string_list_elem_attr attr;
    const char *val_start      = NULL;
    char *value                = NULL;
    char *desc_end             = NULL;
@@ -17391,12 +17442,29 @@ static bool core_option_manager_parse_variable(
    if (!option->vals)
       goto error;
 
-   /* Legacy core option interface has no concept of
-    * value labels - use actual values for display purposes */
-   option->val_labels = string_list_clone(option->vals);
+   /* Legacy core option interface has no concept
+    * of value labels
+    * > Use actual values for display purposes */
+   attr.i             = 0;
+   option->val_labels = string_list_new();
 
    if (!option->val_labels)
       goto error;
+
+   /* > Loop over values and 'extract' labels */
+   for (i = 0; i < option->vals->size; i++)
+   {
+      const char *value       = option->vals->elems[i].data;
+      const char *value_label = core_option_manager_parse_value_label(
+            value, NULL);
+
+      /* Redundant safely check... */
+      value_label = string_is_empty(value_label) ?
+            value : value_label;
+
+      /* Append value label string */
+      string_list_append(option->val_labels, value_label, attr);
+   }
 
    /* Legacy core option interface always uses first
     * defined value as the default */
@@ -17411,8 +17479,6 @@ static bool core_option_manager_parse_variable(
    /* Set current config value */
    if (entry && !string_is_empty(entry->value))
    {
-      size_t i;
-
       for (i = 0; i < option->vals->size; i++)
       {
          if (string_is_equal(option->vals->elems[i].data, entry->value))
@@ -17475,26 +17541,35 @@ static bool core_option_manager_parse_option(
    if (!option->vals || !option->val_labels)
       return false;
 
-   /* Initialse default value */
+   /* Initialise default value */
    option->default_index = 0;
    option->index         = 0;
 
    /* Extract value/label pairs */
    for (i = 0; i < num_vals; i++)
    {
-      /* We know that 'value' is valid */
-      string_list_append(option->vals, values[i].value, attr);
+      const char *value       = values[i].value;
+      const char *value_label = values[i].label;
 
-      /* Value 'label' may be NULL */
-      if (!string_is_empty(values[i].label))
-         string_list_append(option->val_labels, values[i].label, attr);
-      else
-         string_list_append(option->val_labels, values[i].value, attr);
+      /* Append value string
+       * > We know that 'value' is always valid */
+      string_list_append(option->vals, value, attr);
+
+      /* Value label requires additional processing */
+      value_label = core_option_manager_parse_value_label(
+            value, value_label);
+
+      /* > Redundant safely check... */
+      value_label = string_is_empty(value_label) ?
+            value : value_label;
+
+      /* Append value label string */
+      string_list_append(option->val_labels, value_label, attr);
 
       /* Check whether this value is the default setting */
       if (!string_is_empty(option_def->default_value))
       {
-         if (string_is_equal(option_def->default_value, values[i].value))
+         if (string_is_equal(option_def->default_value, value))
          {
             option->default_index = i;
             option->index         = i;


### PR DESCRIPTION
## Description

This PR makes the following small changes/improvement to the core options interface:

- Pressing OK (or clicking/tapping) on a 'boolean toggle' core option no longer opens a drop-down list. The value now toggles directly, just like boolean options everywhere else in the menu

- Toggling an option that changes the number of core options being displayed (i.e. things like `Show Advanced Audio/Video Settings) no longer resets the navigation pointer to the start of the list

- At present, RetroArch identifies core option values as being 'boolean' if they have labels matching the specific strings `enabled` or `disabled`. Most core devs abide by this, but not always... As a result, we sometimes end up with misidentified values, with all kinds of `Enabled`, `Off`, `True`, etc. strings littering the menu, in place of proper toggle switches. With this PR, all boolean-type value labels are now detected, and replaced with standard `ON`/`OFF` strings. As an example, instead of this confusion:

![Screenshot_2020-07-24_15-39-41](https://user-images.githubusercontent.com/38211560/88403673-bf994b00-cdc4-11ea-8989-c82fc5029d8f.png)

...the menu is now rendered as follows:

![Screenshot_2020-07-24_15-40-57](https://user-images.githubusercontent.com/38211560/88403733-cf189400-cdc4-11ea-86f4-6ed37bb259b1.png)
