### PR TITLE
gcm_gfx.c: compatibility with recent psl1ght sdk

### DIFF
--- a/gfx/drivers/gcm_gfx.c
+++ b/gfx/drivers/gcm_gfx.c
@@ -193,7 +193,13 @@ static gcmContextData *gcm_init_screen(gcm_video_t* gcm)
 
       /* Initialise Reality, which sets up the 
        * command buffer and shared I/O memory */
+#ifdef NV40TCL_RENDER_ENABLE
+      /* There was an api breakage on 2020-07-10, let's
+       * workaround this by using one of the new defines */
       rsxInit (&context, CB_SIZE, HOST_SIZE, host_addr);
+#else
+      context = rsxInit (CB_SIZE, HOST_SIZE, host_addr);
+#endif
       if (!context)
          goto error;
       saved_context = context;

--- a/gfx/drivers/gcm_gfx.c
+++ b/gfx/drivers/gcm_gfx.c
@@ -193,7 +193,7 @@ static gcmContextData *gcm_init_screen(gcm_video_t* gcm)
 
       /* Initialise Reality, which sets up the 
        * command buffer and shared I/O memory */
-      context = rsxInit (CB_SIZE, HOST_SIZE, host_addr);
+      rsxInit (&context, CB_SIZE, HOST_SIZE, host_addr);
       if (!context)
          goto error;
       saved_context = context;


### PR DESCRIPTION
The change happened in https://github.com/ps3dev/PSL1GHT/commit/d0eea6e024a6e86435136b058bc7aaf1cabb0581#diff-10cc460c4e5ebfae8b39fde3215cc5ca

I don't see anything allowing to identify the version of psl1ght installed, so i don't know how to make this code work with any version of the sdk.