### PR TITLE
(Menu/DisplayList) Make notification font size option visible when graphics widgets are enabled

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -7722,11 +7722,11 @@ unsigned menu_displaylist_build_list(
 #endif
 #endif
                   case MENU_ENUM_LABEL_VIDEO_FONT_PATH:
+                  case MENU_ENUM_LABEL_VIDEO_FONT_SIZE:
                      if (video_font_enable ||
                          (widgets_supported && menu_enable_widgets))
                         build_list[i].checked = true;
                      break;
-                  case MENU_ENUM_LABEL_VIDEO_FONT_SIZE:
                   case MENU_ENUM_LABEL_VIDEO_MESSAGE_POS_X:
                   case MENU_ENUM_LABEL_VIDEO_MESSAGE_POS_Y:
                   case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_RED:


### PR DESCRIPTION
## Description

At present, when the graphics widgets are enabled, the `Notification Font Size` setting is not visible. This is because the graphics widgets do not make use of this setting. However, this font size setting *is* used when rendering the Audio/Video statistics (enabled in `Settings > On-Screen Display > On-Screen Notifications > Notifications Visibility > Display Statistics`). Therefore it is currently impossible to change these statistics text font size without first disabling the graphics widgets, then changing the font size (now visible) and finally re-enabling the graphics widgets.

This trivial PR fixes the issue by making the `Notification Font Size` setting also visible when graphics widgets are enabled.

## Related Pull Requests

This PR is a follow-up of #11070 which addressed a similiar issue for the `Notification Font` setting.

## Reviewers

[If possible @mention all the people that should review your pull request]
