### PR TITLE
Fix input port assignments

### DIFF
--- a/input/drivers_hid/btstack_hid.c
+++ b/input/drivers_hid/btstack_hid.c
@@ -1411,7 +1411,7 @@ static int16_t btstack_hid_joypad_state(
    unsigned i;
    int16_t ret                          = 0;
    const struct retro_keybind *binds    = (const struct retro_keybind*)binds_data;
-   const struct dinput_joypad_data *pad = &g_pads[port];
+   const struct dinput_joypad_data *pad = &g_pads[joypad_info->joy_idx];
 
    if (!pad || !pad->joypad)
       return 0;
@@ -1426,10 +1426,10 @@ static int16_t btstack_hid_joypad_state(
       if (
                (uint16_t)joykey != NO_BTN 
             && btstack_hid_joypad_button(data,
-               port, (uint16_t)joykey))
+               joypad_info->joy_idx, (uint16_t)joykey))
          ret |= ( 1 << i);
       else if (joyaxis != AXIS_NONE &&
-            ((float)abs(btstack_hid_joypad_axis(data, port, joyaxis)) 
+            ((float)abs(btstack_hid_joypad_axis(data, joypad_info->joy_idx, joyaxis)) 
              / 0x8000) > joypad_info->axis_threshold)
          ret |= (1 << i);
    }

--- a/input/drivers_hid/iohidmanager_hid.c
+++ b/input/drivers_hid/iohidmanager_hid.c
@@ -235,10 +235,10 @@ static int16_t iohidmanager_hid_joypad_state(
       if (
                (uint16_t)joykey != NO_BTN 
             && iohidmanager_hid_joypad_button(data,
-               port, (uint16_t)joykey))
+               joypad_info->joy_idx, (uint16_t)joykey))
          ret |= ( 1 << i);
       else if (joyaxis != AXIS_NONE &&
-            ((float)abs(iohidmanager_hid_joypad_axis(data, port, joyaxis)) 
+            ((float)abs(iohidmanager_hid_joypad_axis(data, joypad_info->joy_idx, joyaxis)) 
              / 0x8000) > joypad_info->axis_threshold)
          ret |= (1 << i);
    }

--- a/input/drivers_hid/libusb_hid.c
+++ b/input/drivers_hid/libusb_hid.c
@@ -524,10 +524,10 @@ static int16_t libusb_hid_joypad_state(
       if (
                (uint16_t)joykey != NO_BTN 
             && libusb_hid_joypad_button(data,
-               port, (uint16_t)joykey))
+               joypad_info->joy_idx, (uint16_t)joykey))
          ret |= ( 1 << i);
       else if (joyaxis != AXIS_NONE &&
-            ((float)abs(libusb_hid_joypad_axis(data, port, joyaxis)) 
+            ((float)abs(libusb_hid_joypad_axis(data, joypad_info->joy_idx, joyaxis)) 
              / 0x8000) > joypad_info->axis_threshold)
          ret |= (1 << i);
    }

--- a/input/drivers_hid/wiiu_hid.c
+++ b/input/drivers_hid/wiiu_hid.c
@@ -92,7 +92,7 @@ static int16_t wiiu_hid_joypad_state(
    int16_t ret                          = 0;
    const struct retro_keybind *binds    = (const struct retro_keybind*)
       binds_data;
-   joypad_connection_t *pad             = get_pad((wiiu_hid_t *)data, port);
+   joypad_connection_t *pad             = get_pad((wiiu_hid_t *)data, joypad_info->joy_idx);
    if (!pad)
       return 0;
 

--- a/input/drivers_hid/wiiusb_hid.c
+++ b/input/drivers_hid/wiiusb_hid.c
@@ -602,10 +602,10 @@ static int16_t wiiusb_hid_joypad_state(
                (uint16_t)joykey != NO_BTN 
             && wiiusb_hid_joypad_button(
                data,
-               port, (uint16_t)joykey))
+               joypad_info->joy_idx, (uint16_t)joykey))
          ret |= ( 1 << i);
       else if (joyaxis != AXIS_NONE &&
-            ((float)abs(wiiusb_hid_joypad_axis(data, port, joyaxis)) 
+            ((float)abs(wiiusb_hid_joypad_axis(data, joypad_info->joy_idx, joyaxis)) 
              / 0x8000) > joypad_info->axis_threshold)
          ret |= (1 << i);
    }

--- a/input/drivers_joypad/android_joypad.c
+++ b/input/drivers_joypad/android_joypad.c
@@ -121,11 +121,11 @@ static int16_t android_joypad_state(
             && android_joypad_button_state(
                android_app,
                buf,
-               port, (uint16_t)joykey))
+               joypad_info->joy_idx, (uint16_t)joykey))
          ret |= ( 1 << i);
       else if (joyaxis != AXIS_NONE &&
             ((float)abs(android_joypad_axis_state(
-                  android_app, port, joyaxis)) 
+                  android_app, joypad_info->joy_idx, joyaxis)) 
              / 0x8000) > joypad_info->axis_threshold)
          ret |= (1 << i);
    }

--- a/input/drivers_joypad/ctr_joypad.c
+++ b/input/drivers_joypad/ctr_joypad.c
@@ -126,7 +126,7 @@ static int16_t ctr_joypad_state(
    unsigned i;
    int16_t ret                          = 0;
 
-   if (port >= DEFAULT_MAX_PADS)
+   if (joypad_info->joy_idx >= DEFAULT_MAX_PADS)
       return 0;
 
    for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)
@@ -141,7 +141,7 @@ static int16_t ctr_joypad_state(
             (pad_state & (1 << (uint16_t)joykey)))
          ret |= ( 1 << i);
       else if (joyaxis != AXIS_NONE &&
-            ((float)abs(ctr_joypad_axis_state(port, joyaxis)) 
+            ((float)abs(ctr_joypad_axis_state(joypad_info->joy_idx, joyaxis)) 
              / 0x8000) > joypad_info->axis_threshold)
          ret |= (1 << i);
    }

--- a/input/drivers_joypad/dinput_joypad.c
+++ b/input/drivers_joypad/dinput_joypad.c
@@ -575,7 +575,7 @@ static int16_t dinput_joypad_state(
 {
    unsigned i;
    int16_t ret                          = 0;
-   const struct dinput_joypad_data *pad = &g_pads[port];
+   const struct dinput_joypad_data *pad = &g_pads[joypad_info->joy_idx];
 
    if (!pad || !pad->joypad)
       return 0;

--- a/input/drivers_joypad/dos_joypad.c
+++ b/input/drivers_joypad/dos_joypad.c
@@ -210,9 +210,9 @@ static int16_t dos_joypad_state(
 {
    unsigned i;
    int16_t ret   = 0;
-   uint16_t *buf = dos_keyboard_state_get(port);
+   uint16_t *buf = dos_keyboard_state_get(joypad_info->joy_idx);
 
-   if (port >= DEFAULT_MAX_PADS)
+   if (joypad_info->joy_idx >= DEFAULT_MAX_PADS)
       return 0;
 
    for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)

--- a/input/drivers_joypad/gx_joypad.c
+++ b/input/drivers_joypad/gx_joypad.c
@@ -316,7 +316,7 @@ static int16_t gx_joypad_state(
    unsigned i;
    int16_t ret                          = 0;
 
-   if (port >= DEFAULT_MAX_PADS)
+   if (joypad_info->joy_idx >= DEFAULT_MAX_PADS)
       return 0;
 
    for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)
@@ -328,11 +328,11 @@ static int16_t gx_joypad_state(
          ? binds[i].joyaxis : joypad_info->auto_binds[i].joyaxis;
       if (
             (uint16_t)joykey != NO_BTN && 
-            (pad_state[port] & (UINT64_C(1) << joykey))
+            (pad_state[joypad_info->joy_idx] & (UINT64_C(1) << joykey))
          )
          ret |= ( 1 << i);
       else if (joyaxis != AXIS_NONE &&
-            ((float)abs(gx_joypad_axis_state(port, joyaxis)) 
+            ((float)abs(gx_joypad_axis_state(joypad_info->joy_idx, joyaxis)) 
              / 0x8000) > joypad_info->axis_threshold)
          ret |= (1 << i);
    }

--- a/input/drivers_joypad/hid_joypad.c
+++ b/input/drivers_joypad/hid_joypad.c
@@ -78,10 +78,10 @@ static int16_t hid_joypad_state(
       const uint32_t joyaxis = (binds[i].joyaxis != AXIS_NONE)
          ? binds[i].joyaxis : joypad_info->auto_binds[i].joyaxis;
       if ((uint16_t)joykey != NO_BTN && hid_joypad_button(
-               port, (uint16_t)joykey))
+               joypad_info->joy_idx, (uint16_t)joykey))
          ret |= ( 1 << i);
       else if (joyaxis != AXIS_NONE &&
-            ((float)abs(hid_joypad_axis(port, joyaxis)) 
+            ((float)abs(hid_joypad_axis(joypad_info->joy_idx, joyaxis)) 
              / 0x8000) > joypad_info->axis_threshold)
          ret |= (1 << i);
    }

--- a/input/drivers_joypad/linuxraw_joypad.c
+++ b/input/drivers_joypad/linuxraw_joypad.c
@@ -360,9 +360,9 @@ static int16_t linuxraw_joypad_state(
    unsigned i;
    int16_t ret                          = 0;
    const struct linuxraw_joypad    *pad = (const struct linuxraw_joypad*)
-      &linuxraw_pads[port];
+      &linuxraw_pads[joypad_info->joy_idx];
 
-   if (port >= DEFAULT_MAX_PADS)
+   if (joypad_info->joy_idx >= DEFAULT_MAX_PADS)
       return 0;
 
    for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)
@@ -377,7 +377,7 @@ static int16_t linuxraw_joypad_state(
             (BIT32_GET(pad->buttons, joykey)))
          ret |= ( 1 << i);
       else if (joyaxis != AXIS_NONE &&
-            ((float)abs(linuxraw_joypad_axis_state(pad, port, joyaxis)) 
+            ((float)abs(linuxraw_joypad_axis_state(pad, joypad_info->joy_idx, joyaxis)) 
              / 0x8000) > joypad_info->axis_threshold)
          ret |= (1 << i);
    }

--- a/input/drivers_joypad/mfi_joypad.m
+++ b/input/drivers_joypad/mfi_joypad.m
@@ -390,7 +390,7 @@ static int16_t apple_gamecontroller_joypad_state(
    unsigned i;
    int16_t ret                          = 0;
 
-   if (port >= DEFAULT_MAX_PADS)
+   if (joypad_info->joy_idx >= DEFAULT_MAX_PADS)
       return 0;
 
    for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)
@@ -403,11 +403,11 @@ static int16_t apple_gamecontroller_joypad_state(
       if (     (uint16_t)joykey != NO_BTN 
             && !GET_HAT_DIR(i)
             && (i < 32)
-            && ((mfi_buttons[port] & (1 << i)) != 0)
+            && ((mfi_buttons[joypad_info->joy_idx] & (1 << i)) != 0)
          )
          ret |= ( 1 << i);
       else if (joyaxis != AXIS_NONE &&
-            ((float)abs(apple_gamecontroller_joypad_axis(port, joyaxis)) 
+            ((float)abs(apple_gamecontroller_joypad_axis(joypad_info->joy_idx, joyaxis)) 
              / 0x8000) > joypad_info->axis_threshold)
          ret |= (1 << i);
    }

--- a/input/drivers_joypad/parport_joypad.c
+++ b/input/drivers_joypad/parport_joypad.c
@@ -354,9 +354,9 @@ static int16_t parport_joypad_state(
    unsigned i;
    int16_t ret                          = 0;
    const struct parport_joypad     *pad = (const struct parport_joypad*)
-      &parport_pads[port];
+      &parport_pads[joypad_info->joy_idx];
 
-   if (port >= DEFAULT_MAX_PADS)
+   if (joypad_info->joy_idx >= DEFAULT_MAX_PADS)
       return 0;
 
    for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)

--- a/input/drivers_joypad/ps2_joypad.c
+++ b/input/drivers_joypad/ps2_joypad.c
@@ -138,7 +138,7 @@ static int16_t ps2_joypad_state(
    unsigned i;
    int16_t ret                          = 0;
 
-   if (port >= DEFAULT_MAX_PADS)
+   if (joypad_info->joy_idx >= DEFAULT_MAX_PADS)
       return 0;
 
    for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)
@@ -150,11 +150,11 @@ static int16_t ps2_joypad_state(
          ? binds[i].joyaxis : joypad_info->auto_binds[i].joyaxis;
       if (
                (uint16_t)joykey != NO_BTN 
-            && pad_state[port] & (UINT64_C(1) << joykey)
+            && pad_state[joypad_info->joy_idx] & (UINT64_C(1) << joykey)
          )
          ret |= ( 1 << i);
       else if (joyaxis != AXIS_NONE &&
-            ((float)abs(ps2_joypad_axis_state(port, joyaxis)) 
+            ((float)abs(ps2_joypad_axis_state(joypad_info->joy_idx, joyaxis)) 
              / 0x8000) > joypad_info->axis_threshold)
          ret |= (1 << i);
    }

--- a/input/drivers_joypad/ps3_joypad.c
+++ b/input/drivers_joypad/ps3_joypad.c
@@ -132,7 +132,7 @@ static int16_t ps3_joypad_state(
    unsigned i;
    int16_t ret                          = 0;
 
-   if (port >= DEFAULT_MAX_PADS)
+   if (joypad_info->joy_idx >= DEFAULT_MAX_PADS)
       return 0;
 
    for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)
@@ -144,11 +144,11 @@ static int16_t ps3_joypad_state(
          ? binds[i].joyaxis : joypad_info->auto_binds[i].joyaxis;
       if (
                (uint16_t)joykey != NO_BTN 
-            && pad_state[port] & (UINT64_C(1) << (uint16_t)joykey)
+            && pad_state[joypad_info->joy_idx] & (UINT64_C(1) << (uint16_t)joykey)
          )
          ret |= ( 1 << i);
       else if (joyaxis != AXIS_NONE &&
-            ((float)abs(ps3_joypad_axis_state(port, joyaxis)) 
+            ((float)abs(ps3_joypad_axis_state(joypad_info->joy_idx, joyaxis)) 
              / 0x8000) > joypad_info->axis_threshold)
          ret |= (1 << i);
    }

--- a/input/drivers_joypad/ps4_joypad.c
+++ b/input/drivers_joypad/ps4_joypad.c
@@ -151,7 +151,7 @@ static int16_t ps4_joypad_state(
    unsigned i;
    int16_t ret                          = 0;
 
-   if (port >= PS4_MAX_ORBISPADS)
+   if (joypad_info->joy_idx >= PS4_MAX_ORBISPADS)
       return 0;
 
    for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)
@@ -161,7 +161,7 @@ static int16_t ps4_joypad_state(
          ? binds[i].joykey  : joypad_info->auto_binds[i].joykey;
       if (
                (uint16_t)joykey != NO_BTN 
-            && pad_state[port] & (UINT64_C(1) << (uint16_t)joykey)
+            && pad_state[joypad_info->joy_idx] & (UINT64_C(1) << (uint16_t)joykey)
          )
          ret |= ( 1 << i);
    }

--- a/input/drivers_joypad/psp_joypad.c
+++ b/input/drivers_joypad/psp_joypad.c
@@ -185,7 +185,7 @@ static int16_t psp_joypad_state(
    unsigned i;
    int16_t ret                          = 0;
 
-   if (port >= DEFAULT_MAX_PADS)
+   if (joypad_info->joy_idx >= DEFAULT_MAX_PADS)
       return 0;
 
    for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)
@@ -197,11 +197,11 @@ static int16_t psp_joypad_state(
          ? binds[i].joyaxis : joypad_info->auto_binds[i].joyaxis;
       if (
                (uint16_t)joykey != NO_BTN 
-            && (pad_state[port] & (UINT64_C(1) << (uint16_t)joykey))
+            && (pad_state[joypad_info->joy_idx] & (UINT64_C(1) << (uint16_t)joykey))
          )
          ret |= ( 1 << i);
       else if (joyaxis != AXIS_NONE &&
-            ((float)abs(psp_joypad_axis_state(port, joyaxis)) 
+            ((float)abs(psp_joypad_axis_state(joypad_info->joy_idx, joyaxis)) 
              / 0x8000) > joypad_info->axis_threshold)
          ret |= (1 << i);
    }

--- a/input/drivers_joypad/qnx_joypad.c
+++ b/input/drivers_joypad/qnx_joypad.c
@@ -116,9 +116,9 @@ static int16_t qnx_joypad_state(
    int16_t ret                    = 0;
    qnx_input_t            *qnx    = (qnx_input_t*)input_driver_get_data();
    qnx_input_device_t* controller = NULL;
-   if (!qnx || port >= DEFAULT_MAX_PADS)
+   if (!qnx || joypad_info->joy_idx >= DEFAULT_MAX_PADS)
       return 0;
-   controller                     = (qnx_input_device_t*)&qnx->devices[port];
+   controller                     = (qnx_input_device_t*)&qnx->devices[joypad_info->joy_idx];
 
    for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)
    {
@@ -134,7 +134,7 @@ static int16_t qnx_joypad_state(
          )
          ret |= ( 1 << i);
       else if (joyaxis != AXIS_NONE &&
-            ((float)abs(qnx_joypad_axis_state(qnx, controller, port, joyaxis)) 
+            ((float)abs(qnx_joypad_axis_state(qnx, controller, joypad_info->joy_idx, joyaxis)) 
              / 0x8000) > joypad_info->axis_threshold)
          ret |= (1 << i);
    }

--- a/input/drivers_joypad/rwebpad_joypad.c
+++ b/input/drivers_joypad/rwebpad_joypad.c
@@ -173,10 +173,10 @@ static int16_t rwebpad_joypad_state(
    EmscriptenGamepadEvent gamepad_state;
    int16_t ret                          = 0;
    EMSCRIPTEN_RESULT r                  = emscripten_get_gamepad_status(
-         port, &gamepad_state);
+         joypad_info->joy_idx, &gamepad_state);
    if (r != EMSCRIPTEN_RESULT_SUCCESS)
       return 0;
-   if (port >= DEFAULT_MAX_PADS)
+   if (joypad_info->joy_idx >= DEFAULT_MAX_PADS)
       return 0;
 
    for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)
@@ -194,7 +194,7 @@ static int16_t rwebpad_joypad_state(
          ret |= ( 1 << i);
       else if (joyaxis != AXIS_NONE &&
             ((float)abs(rwebpad_joypad_axis_state(
-                  &gamepad_state, port, joyaxis)) 
+                  &gamepad_state, joypad_info->joy_idx, joyaxis)) 
              / 0x8000) > joypad_info->axis_threshold)
          ret |= (1 << i);
    }

--- a/input/drivers_joypad/sdl_joypad.c
+++ b/input/drivers_joypad/sdl_joypad.c
@@ -379,11 +379,11 @@ static int16_t sdl_joypad_state(
 {
    unsigned i;
    int16_t ret                          = 0;
-   sdl_joypad_t *pad                    = (sdl_joypad_t*)&sdl_pads[port];
+   sdl_joypad_t *pad                    = (sdl_joypad_t*)&sdl_pads[joypad_info->joy_idx];
 
    if (!pad || !pad->joypad)
       return 0;
-   if (port >= DEFAULT_MAX_PADS)
+   if (joypad_info->joy_idx >= DEFAULT_MAX_PADS)
       return 0;
 
    for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)
@@ -395,11 +395,11 @@ static int16_t sdl_joypad_state(
          ? binds[i].joyaxis : joypad_info->auto_binds[i].joyaxis;
       if (
                (uint16_t)joykey != NO_BTN 
-            && sdl_joypad_button_state(pad, port, (uint16_t)joykey)
+            && sdl_joypad_button_state(pad, joypad_info->joy_idx, (uint16_t)joykey)
          )
          ret |= ( 1 << i);
       else if (joyaxis != AXIS_NONE &&
-            ((float)abs(sdl_joypad_axis_state(pad, port, joyaxis)) 
+            ((float)abs(sdl_joypad_axis_state(pad, joypad_info->joy_idx, joyaxis)) 
              / 0x8000) > joypad_info->axis_threshold)
          ret |= (1 << i);
    }

--- a/input/drivers_joypad/switch_joypad.c
+++ b/input/drivers_joypad/switch_joypad.c
@@ -156,7 +156,7 @@ static int16_t switch_joypad_state(
    unsigned i;
    int16_t ret                          = 0;
 
-   if (port >= DEFAULT_MAX_PADS)
+   if (joypad_info->joy_idx >= DEFAULT_MAX_PADS)
       return 0;
 
    for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)
@@ -168,11 +168,11 @@ static int16_t switch_joypad_state(
          ? binds[i].joyaxis : joypad_info->auto_binds[i].joyaxis;
       if (
                (uint16_t)joykey != NO_BTN 
-            && (pad_state[port] & (1 << (uint16_t)joykey))
+            && (pad_state[joypad_info->joy_idx] & (1 << (uint16_t)joykey))
          )
          ret |= ( 1 << i);
       else if (joyaxis != AXIS_NONE &&
-            ((float)abs(switch_joypad_axis_state(port, joyaxis)) 
+            ((float)abs(switch_joypad_axis_state(joypad_info->joy_idx, joyaxis)) 
              / 0x8000) > joypad_info->axis_threshold)
          ret |= (1 << i);
    }

--- a/input/drivers_joypad/udev_joypad.c
+++ b/input/drivers_joypad/udev_joypad.c
@@ -690,9 +690,9 @@ static int16_t udev_joypad_state(
    unsigned i;
    int16_t ret                          = 0;
    const struct udev_joypad *pad        = (const struct udev_joypad*)
-      &udev_pads[port];
+      &udev_pads[joypad_info->joy_idx];
 
-   if (port >= DEFAULT_MAX_PADS)
+   if (joypad_info->joy_idx >= DEFAULT_MAX_PADS)
       return 0;
 
    for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)
@@ -704,11 +704,11 @@ static int16_t udev_joypad_state(
          ? binds[i].joyaxis : joypad_info->auto_binds[i].joyaxis;
       if (
                (uint16_t)joykey != NO_BTN 
-            && udev_joypad_button_state(pad, port, (uint16_t)joykey)
+            && udev_joypad_button_state(pad, joypad_info->joy_idx, (uint16_t)joykey)
          )
          ret |= ( 1 << i);
       else if (joyaxis != AXIS_NONE &&
-            ((float)abs(udev_joypad_axis_state(pad, port, joyaxis)) 
+            ((float)abs(udev_joypad_axis_state(pad, joypad_info->joy_idx, joyaxis)) 
              / 0x8000) > joypad_info->axis_threshold)
          ret |= (1 << i);
    }

--- a/input/drivers_joypad/wiiu_joypad.c
+++ b/input/drivers_joypad/wiiu_joypad.c
@@ -92,9 +92,9 @@ static int16_t wiiu_joypad_state(
    unsigned i;
    int16_t ret                          = 0;
 
-   if (!wiiu_joypad_query_pad(port))
+   if (!wiiu_joypad_query_pad(joypad_info->joy_idx))
       return 0;
-   if (port >= DEFAULT_MAX_PADS)
+   if (joypad_info->joy_idx >= DEFAULT_MAX_PADS)
       return 0;
 
    for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)
@@ -106,11 +106,11 @@ static int16_t wiiu_joypad_state(
          ? binds[i].joyaxis : joypad_info->auto_binds[i].joyaxis;
       if (
                (uint16_t)joykey != NO_BTN 
-            && (pad_drivers[port]->button(port, (uint16_t)joykey))
+            && (pad_drivers[port]->button(joypad_info->joy_idx, (uint16_t)joykey))
          )
          ret |= ( 1 << i);
       else if (joyaxis != AXIS_NONE &&
-            ((float)abs(pad_drivers[port]->axis(port, joyaxis)) 
+            ((float)abs(pad_drivers[port]->axis(joypad_info->joy_idx, joyaxis)) 
              / 0x8000) > joypad_info->axis_threshold)
          ret |= (1 << i);
    }

--- a/input/drivers_joypad/xdk_joypad.c
+++ b/input/drivers_joypad/xdk_joypad.c
@@ -240,10 +240,10 @@ static int16_t xdk_joypad_state(
    XINPUT_GAMEPAD *pad = NULL;
    uint16_t btn_word   = 0;
 
-   if (port >= DEFAULT_MAX_PADS)
+   if (joypad_info->joy_idx >= DEFAULT_MAX_PADS)
       return 0;
 
-   pad                 = &(g_xinput_states[port].xstate.Gamepad);
+   pad                 = &(g_xinput_states[joypad_info->joy_idx].xstate.Gamepad);
    btn_word            = pad->wButtons;
 
    for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)
@@ -256,10 +256,10 @@ static int16_t xdk_joypad_state(
       if (
                (uint16_t)joykey != NO_BTN 
             && xdk_joypad_button_state(
-               pad, btn_word, port, (uint16_t)joykey))
+               pad, btn_word, joypad_info->joy_idx, (uint16_t)joykey))
          ret |= ( 1 << i);
       else if (joyaxis != AXIS_NONE &&
-            ((float)abs(xdk_joypad_axis_state(pad, port, joyaxis)) 
+            ((float)abs(xdk_joypad_axis_state(pad, joypad_info->joy_idx, joyaxis)) 
              / 0x8000) > joypad_info->axis_threshold)
          ret |= (1 << i);
    }

--- a/input/drivers_joypad/xinput_joypad.c
+++ b/input/drivers_joypad/xinput_joypad.c
@@ -524,11 +524,11 @@ static int16_t xinput_joypad_state_func(
    unsigned i;
    uint16_t btn_word;
    int16_t ret         = 0;
-   int xuser           = pad_index_to_xuser_index(port);
+   int xuser           = pad_index_to_xuser_index(joypad_info->joy_idx);
    XINPUT_GAMEPAD *pad = &(g_xinput_states[xuser].xstate.Gamepad);
 #ifdef HAVE_DINPUT
    if (xuser == -1)
-      return dinput_joypad.state(joypad_info, binds, port);
+      return dinput_joypad.state(joypad_info, binds, joypad_info->joy_idx);
 #endif
    if (!(g_xinput_states[xuser].connected))
       return 0;
@@ -544,10 +544,10 @@ static int16_t xinput_joypad_state_func(
       if (
                (uint16_t)joykey != NO_BTN 
             && xinput_joypad_button_state(
-               xuser, btn_word, port, (uint16_t)joykey))
+               xuser, btn_word, joypad_info->joy_idx, (uint16_t)joykey))
          ret |= ( 1 << i);
       else if (joyaxis != AXIS_NONE &&
-            ((float)abs(xinput_joypad_axis_state(pad, port, joyaxis)) 
+            ((float)abs(xinput_joypad_axis_state(pad, joypad_info->joy_idx, joyaxis)) 
              / 0x8000) > joypad_info->axis_threshold)
          ret |= (1 << i);
    }


### PR DESCRIPTION
## Description

Fixes #11088 correctly (I hope). Looking at the old function `button_is_pressed`:
```c
int16_t button_is_pressed(
      const input_device_driver_t *joypad,
      rarch_joypad_info_t *joypad_info,
      const struct retro_keybind *binds,
      unsigned port, unsigned id)
{
    /* Auto-binds are per joypad, not per user. */
    const uint64_t joykey  = (binds[id].joykey != NO_BTN)
    ? binds[id].joykey  : joypad_info->auto_binds[id].joykey;
    const uint32_t joyaxis = (binds[id].joyaxis != AXIS_NONE)
    ? binds[id].joyaxis : joypad_info->auto_binds[id].joyaxis;
    if ((uint16_t)joykey != NO_BTN && joypad->button(
            joypad_info->joy_idx, (uint16_t)joykey))
        return 1;
    if (joyaxis != AXIS_NONE &&
          ((float)abs(joypad->axis(joypad_info->joy_idx, joyaxis)) 
           / 0x8000) > joypad_info->axis_threshold)
        return 1;
    return 0;
}
```
we see that port remapping is done correctly, by passing the variable `joypad_info->joy_idx` to the driver instead of `port`. 

In the new `xxx_state` functions, `port` was used erroneously when `joypad_info->joy_idx` should been used instead.

Tested on Switch.
