### PR TITLE
(Qt) Fix display of settings icons

### DIFF
--- a/ui/drivers/qt/viewoptionsdialog.cpp
+++ b/ui/drivers/qt/viewoptionsdialog.cpp
@@ -27,6 +27,11 @@
 extern "C" {
 #endif
 
+#ifdef HAVE_CONFIG_H
+#include "../../../config.h"
+#endif
+
+#include "../../../configuration.h"
 #include "../../../msg_hash.h"
 
 #ifndef CXX_BUILD


### PR DESCRIPTION
## Description

As reported in #11079, the display of 'settings' icons in the Qt interface is broken on some platforms. This is due to `configuration.h` being included with improper defines set in `viewoptionsdialog.cpp` - as a result, the settings struct has the wrong layout, and the assets path is read from the wrong offset... (producing garbage)

This trivial PR fixes the issue by adding `config.h` where appropriate, to ensure the relevant system defines are set correctly.

## Related Issues

This closes #11079

