### PR TITLE
Explore: Fix freeing of cached playlist

### DIFF
--- a/menu/menu_explore.c
+++ b/menu/menu_explore.c
@@ -486,8 +486,7 @@ static void explore_free(explore_state_t *state)
    EX_BUF_FREE(state->entries);
 
    for (i = 0; i != EX_BUF_LEN(state->playlists); i++)
-      if (state->playlists[i] != state->cached_playlist)
-         playlist_free(state->playlists[i]);
+      playlist_free(state->playlists[i]);
    EX_BUF_FREE(state->playlists);
    ex_arena_free(&state->arena);
 }
@@ -968,16 +967,6 @@ unsigned menu_displaylist_explore(file_list_t *list)
                " '%s'", explore_state->find_string);
    }
 
-   if (current_type == MENU_EXPLORE_TAB)
-   {
-      /* free any existing playlist 
-       * when entering the explore view */
-      playlist_free_cached();
-   }
-
-   playlist_set_cached(NULL);
-   explore_state->cached_playlist = NULL;
-
    if (     current_type == MENU_EXPLORE_TAB 
          || current_type == EXPLORE_TYPE_ADDITIONALFILTER)
    {
@@ -1218,8 +1207,7 @@ SKIP_ENTRY:;
 
          /* Fake all the state so the content screen 
           * and information screen think we're viewing via playlist */
-         playlist_set_cached(pl);
-         explore_state->cached_playlist = pl;
+         playlist_set_cached_external(pl);
          menu->rpl_entry_selection_ptr = (pl_entry - pl_first);
          strlcpy(menu->deferred_path,
                pl_entry->path, sizeof(menu->deferred_path));

--- a/playlist.c
+++ b/playlist.c
@@ -111,8 +111,11 @@ typedef int (playlist_sort_fun_t)(
 void playlist_set_cached_external(playlist_t* pl)
 {
    playlist_free_cached();
-   playlist_cached = pl;
-   playlist_cached->cached_external = true;
+   if (pl)
+   {
+      playlist_cached = pl;
+      playlist_cached->cached_external = true;
+   }
 }
 
 /* Convenience function: copies specified playlist
@@ -1392,7 +1395,6 @@ void playlist_write_runtime_file(playlist_t *playlist)
    playlist->modified        = false;
    playlist->old_format      = false;
    playlist->compressed      = false;
-   playlist->cached_external = false;
 
    RARCH_LOG("[Playlist]: Written to playlist file: %s\n", playlist->config.path);
 end:

--- a/playlist.h
+++ b/playlist.h
@@ -351,7 +351,7 @@ core_info_t *playlist_entry_get_core_info(const struct playlist_entry* entry);
  * default core association */
 core_info_t *playlist_get_default_core_info(playlist_t* playlist);
 
-void playlist_set_cached(playlist_t* pl);
+void playlist_set_cached_external(playlist_t* pl);
 
 RETRO_END_DECLS
 


### PR DESCRIPTION
## Description

Without this fix there is a possible crash in glui menu when jumping back multiple menu lists skipping over cleanup code in `menu_displaylist_explore`.

Now `playlist_free_cached` knows not to free a playlist that is from an external source (the explore view) and everything is a bit more correct and less of a hack.

## Related Issues

## Related Pull Requests

## Reviewers
