### PR TITLE
Fix audio/video statistics display flickering in certain Windows platforms

### DIFF
--- a/retroarch.h
+++ b/retroarch.h
@@ -1143,6 +1143,12 @@ typedef struct video_frame_info
    int crt_switch_center_adjust;
    int crt_switch_porch_adjust;
 
+   /* TODO/FIXME - nasty hack needed for struct misalignment in Windows X64 -
+    * otherwise the audio/video statistics display glitches after the recent
+    * addition of the above 'crt_switch_porch_adjust' member
+    */
+   char placeholder;
+
    unsigned hard_sync_frames;
    unsigned aspect_ratio_idx;
    unsigned max_swapchain_images;


### PR DESCRIPTION
## Description

Recently, PR #11093 introduced a new `crt_switch_porch_adjust` member into the `video_frame_info_t` struct. Unfortunately in some cases (seen in Windows x64 + MinGW GCC 10.2.0) this created a struct misalignment that breaks the audio/video statistics display. This trivial PR adds a `char` placeholder member to fix the issue.

## Related Issues

Fixes #11112 
