### PR TITLE
Enhanced playlist search functionality

### DIFF
--- a/gfx/gfx_thumbnail.c
+++ b/gfx/gfx_thumbnail.c
@@ -482,17 +482,16 @@ void gfx_thumbnail_process_stream(
 
          if (thumbnail->delay_timer > p_gfx_thumb->stream_delay)
          {
-            /* Sanity check */
-            if (!path_data || !playlist)
-               return;
-
             /* Update thumbnail content */
-            if (!gfx_thumbnail_set_content_playlist(path_data, playlist, idx))
+            if (!path_data ||
+                !playlist ||
+                !gfx_thumbnail_set_content_playlist(path_data, playlist, idx))
             {
                /* Content is invalid
                 * > Reset thumbnail and set missing status */
                gfx_thumbnail_reset(thumbnail);
                thumbnail->status = GFX_THUMBNAIL_STATUS_MISSING;
+               thumbnail->alpha  = 1.0f;
                return;
             }
 
@@ -576,12 +575,10 @@ void gfx_thumbnail_process_streams(
          /* Check if one or more thumbnails should be requested */
          if (request_right || request_left)
          {
-            /* Sanity check */
-            if (!path_data || !playlist)
-               return;
-
             /* Update thumbnail content */
-            if (!gfx_thumbnail_set_content_playlist(path_data, playlist, idx))
+            if (!path_data ||
+                !playlist ||
+                !gfx_thumbnail_set_content_playlist(path_data, playlist, idx))
             {
                /* Content is invalid
                 * > Reset thumbnail and set missing status */
@@ -589,12 +586,14 @@ void gfx_thumbnail_process_streams(
                {
                   gfx_thumbnail_reset(right_thumbnail);
                   right_thumbnail->status = GFX_THUMBNAIL_STATUS_MISSING;
+                  right_thumbnail->alpha  = 1.0f;
                }
 
                if (request_left)
                {
                   gfx_thumbnail_reset(left_thumbnail);
                   left_thumbnail->status  = GFX_THUMBNAIL_STATUS_MISSING;
+                  left_thumbnail->alpha   = 1.0f;
                }
 
                return;

--- a/menu/cbs/menu_cbs_contentlist_switch.c
+++ b/menu/cbs/menu_cbs_contentlist_switch.c
@@ -25,6 +25,15 @@ static int deferred_push_content_list(void *data, void *userdata,
       const char *label, unsigned type)
 {
    file_list_t *selection_buf = menu_entries_get_selection_buf_ptr(0);
+
+   /* Must clear any existing menu search terms
+    * when switching 'tabs', since doing so
+    * bypasses standard backwards navigation
+    * (i.e. 'cancel' actions would normally
+    * pop the search stack - this will not
+    * happen if we jump to a new list directly) */
+   menu_driver_search_clear();
+
    menu_navigation_set_selection(0);
    return action_refresh_default((file_list_t*)data, selection_buf);
 }

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -760,7 +760,7 @@ int generic_action_ok_displaylist_push(const char *path,
          info_label = msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_RPL_ENTRY_ACTIONS);
          info.enum_idx                 = MENU_ENUM_LABEL_DEFERRED_RPL_ENTRY_ACTIONS;
          info.directory_ptr            = idx;
-         menu->rpl_entry_selection_ptr = (unsigned)idx;
+         menu->rpl_entry_selection_ptr = (unsigned)entry_idx;
          dl_type                       = DISPLAYLIST_GENERIC;
          break;
       case ACTION_OK_DL_AUDIO_DSP_PLUGIN:

--- a/menu/cbs/menu_cbs_sublabel.c
+++ b/menu/cbs/menu_cbs_sublabel.c
@@ -1211,8 +1211,10 @@ static int action_bind_sublabel_playlist_entry(
       const char *label, const char *path,
       char *s, size_t len)
 {
+   size_t list_size                          = menu_entries_get_size();
    playlist_t *playlist                      = NULL;
    const struct playlist_entry *entry        = NULL;
+   size_t playlist_index                     = i;
 #ifdef HAVE_OZONE
    const char *menu_ident                    = menu_driver_ident();
 #endif
@@ -1239,17 +1241,24 @@ static int action_bind_sublabel_playlist_entry(
       return 0;
 #endif
 
+   /* Get playlist index corresponding
+    * to the current entry */
+   if (!list || (i >= list_size))
+      return 0;
+
+   playlist_index = list->list[i].entry_idx;
+
    /* Get current playlist */
    playlist = playlist_get_cached();
 
    if (!playlist)
       return 0;
 
-   if (i >= playlist_get_size(playlist))
+   if (playlist_index >= playlist_get_size(playlist))
       return 0;
 
    /* Read playlist entry */
-   playlist_get_index(playlist, i, &entry);
+   playlist_get_index(playlist, playlist_index, &entry);
 
    /* Only add sublabel if a core is currently assigned
     * > Both core name and core path must be valid */
@@ -1286,7 +1295,7 @@ static int action_bind_sublabel_playlist_entry(
    /* Check whether runtime info should be loaded from log file */
    if (entry->runtime_status == PLAYLIST_RUNTIME_UNKNOWN)
       runtime_update_playlist(
-            playlist, i,
+            playlist, playlist_index,
             directory_runtime_log,
             directory_playlist,
             (playlist_sublabel_runtime_type == PLAYLIST_RUNTIME_PER_CORE),

--- a/menu/drivers/ozone/ozone.h
+++ b/menu/drivers/ozone/ozone.h
@@ -209,6 +209,7 @@ struct ozone_handle
 
    bool is_playlist;
    bool is_playlist_old;
+   size_t num_search_terms_old;
 
    bool empty_playlist;
 

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -4959,13 +4959,29 @@ static void rgui_scan_selected_entry_thumbnail(rgui_t *rgui, bool force_load)
    rgui->entry_has_thumbnail         = false;
    rgui->entry_has_left_thumbnail    = false;
    rgui->thumbnail_load_pending      = false;
-   
+
    /* Update thumbnail content/path */
    if ((rgui->show_fs_thumbnail || rgui_inline_thumbnails) 
          && rgui->is_playlist)
    {
+      size_t selection      = menu_navigation_get_selection();
+      size_t list_size      = menu_entries_get_size();
+      file_list_t *list     = menu_entries_get_selection_buf_ptr(0);
+      bool playlist_valid   = false;
+      size_t playlist_index = selection;
+
+      /* Get playlist index corresponding
+       * to the selected entry */
+      if (list &&
+          (selection < list_size) &&
+          (list->list[selection].type == FILE_TYPE_RPL_ENTRY))
+      {
+         playlist_valid = true;
+         playlist_index = list->list[selection].entry_idx;
+      }
+
       if (gfx_thumbnail_set_content_playlist(rgui->thumbnail_path_data,
-            playlist_get_cached(), menu_navigation_get_selection()))
+            playlist_valid ? playlist_get_cached() : NULL, playlist_index))
       {
          if (gfx_thumbnail_is_enabled(rgui->thumbnail_path_data, GFX_THUMBNAIL_RIGHT))
             has_thumbnail = gfx_thumbnail_update_path(rgui->thumbnail_path_data, GFX_THUMBNAIL_RIGHT);
@@ -4976,7 +4992,7 @@ static void rgui_scan_selected_entry_thumbnail(rgui_t *rgui, bool force_load)
                             has_thumbnail;
       }
    }
-   
+
    /* Check whether thumbnails should be loaded */
    if (has_thumbnail)
    {

--- a/menu/menu_driver.h
+++ b/menu/menu_driver.h
@@ -28,6 +28,7 @@
 #include <retro_common_api.h>
 #include <formats/image.h>
 #include <queues/task_queue.h>
+#include <lists/string_list.h>
 
 #include "menu_defines.h"
 #include "menu_input.h"
@@ -330,6 +331,12 @@ typedef struct
    {
       unsigned                unsigned_var;
    } scratchpad;
+
+   /* Holds a list of search terms that may be
+    * used to filter the currently displayed
+    * menu list */
+   struct string_list *search_terms;
+
    const menu_ctx_driver_t *driver_ctx;
    void *userdata;
 } menu_handle_t;
@@ -477,6 +484,14 @@ void menu_display_handle_wallpaper_upload(retro_task_t *task,
 #if defined(HAVE_LIBRETRODB)
 void menu_explore_free(void);
 #endif
+
+bool menu_driver_search_push(const char *search_term);
+bool menu_driver_search_pop(void);
+void menu_driver_search_clear(void);
+struct string_list *menu_driver_search_get_terms(void);
+/* Convenience function: Appends list of current
+ * search terms to specified string */
+void menu_driver_search_append_terms_string(char *s, size_t len);
 
 menu_handle_t *menu_driver_get_ptr(void);
 

--- a/playlist.c
+++ b/playlist.c
@@ -379,7 +379,7 @@ void playlist_get_index(playlist_t *playlist,
       size_t idx,
       const struct playlist_entry **entry)
 {
-   if (!playlist || !entry)
+   if (!playlist || !entry || (idx >= playlist->size))
       return;
 
    *entry = &playlist->entries[idx];


### PR DESCRIPTION
## Description

At present, RetroArch's inbuilt 'search' function is woefully inadequate:

- User presses RetroPad 'X' (or keyboard '/', or Material UI's search icon), and enters a search term

- The navigation pointer jumps to the first match

- That's it. There is no way to continue searching from that point, or to do much of anything, really. It's mostly a non-feature...

This PR enhances the search functionality as follows:

- When viewing a playlist, the user presses RetroPad `X` (or `/`, etc.) as normal, and enters a search term

- This becomes a *filter* - all matching entries will be displayed

- The user can then perform another search to further refine the results. An arbitrary number of filters may be stacked in this fashion

- Pressing 'cancel' clears the last entered filter

Here's an example of the search feature in action:

![screen_record__2020_07_31__14_56_51](https://user-images.githubusercontent.com/38211560/89044429-dc43fe80-d341-11ea-9260-9515411663e9.gif)

Known limitations:

- The selection marker will always be reset to the top of the list when 'cancelling' a search. Too many hacks are required to restore the last selected entry, and XMB in particular is entirely unable to set the marker to a non-zero position during a menu refresh (needs a rewrite...). This did not affect usability to any real degree during testing, however, so I think it's fine.

- This only works for playlists. I will try to enable the same functionality for the file browser as well (i.e. load content), but this is quite fiddly...