### PR TITLE
Ensure correct directory is used when saving autoconfig profiles

### DIFF
--- a/configuration.h
+++ b/configuration.h
@@ -904,11 +904,11 @@ bool config_load_remap(const char *directory_input_remapping,
 
 /**
  * config_save_autoconf_profile:
- * @path            : Path that shall be written to.
+ * @device_name       : Input device name
  * @user              : Controller number to save
  * Writes a controller autoconf file to disk.
  **/
-bool config_save_autoconf_profile(const char *path, unsigned user);
+bool config_save_autoconf_profile(const char *device_name, unsigned user);
 
 /**
  * config_save_file:

--- a/input/input_driver.h
+++ b/input/input_driver.h
@@ -157,6 +157,7 @@ typedef struct
    char display_name[256];
    char config_path[PATH_MAX_LENGTH];
    char config_name[PATH_MAX_LENGTH];
+   char joypad_driver[32];
    uint16_t vid;
    uint16_t pid;
    bool autoconfigured;
@@ -493,6 +494,7 @@ void input_config_set_device_name(unsigned port, const char *name);
 void input_config_set_device_display_name(unsigned port, const char *name);
 void input_config_set_device_config_path(unsigned port, const char *path);
 void input_config_set_device_config_name(unsigned port, const char *name);
+void input_config_set_device_joypad_driver(unsigned port, const char *driver);
 void input_config_set_device_vid(unsigned port, uint16_t vid);
 void input_config_set_device_pid(unsigned port, uint16_t pid);
 void input_config_set_device_autoconfigured(unsigned port, bool autoconfigured);
@@ -503,6 +505,7 @@ void input_config_clear_device_name(unsigned port);
 void input_config_clear_device_display_name(unsigned port);
 void input_config_clear_device_config_path(unsigned port);
 void input_config_clear_device_config_name(unsigned port);
+void input_config_clear_device_joypad_driver(unsigned port);
 
 unsigned input_config_get_device_count(void);
 
@@ -517,6 +520,7 @@ const char *input_config_get_device_name(unsigned port);
 const char *input_config_get_device_display_name(unsigned port);
 const char *input_config_get_device_config_path(unsigned port);
 const char *input_config_get_device_config_name(unsigned port);
+const char *input_config_get_device_joypad_driver(unsigned port);
 uint16_t input_config_get_device_vid(unsigned port);
 uint16_t input_config_get_device_pid(unsigned port);
 bool input_config_get_device_autoconfigured(unsigned port);

--- a/retroarch.c
+++ b/retroarch.c
@@ -27787,6 +27787,14 @@ const char *input_config_get_device_config_name(unsigned port)
    return p_rarch->input_device_info[port].config_name;
 }
 
+const char *input_config_get_device_joypad_driver(unsigned port)
+{
+   struct rarch_state *p_rarch = &rarch_st;
+   if (string_is_empty(p_rarch->input_device_info[port].joypad_driver))
+      return NULL;
+   return p_rarch->input_device_info[port].joypad_driver;
+}
+
 uint16_t input_config_get_device_vid(unsigned port)
 {
    struct rarch_state *p_rarch = &rarch_st;
@@ -27875,6 +27883,14 @@ void input_config_set_device_config_name(unsigned port, const char *name)
             sizeof(p_rarch->input_device_info[port].config_name));
 }
 
+void input_config_set_device_joypad_driver(unsigned port, const char *driver)
+{
+   struct rarch_state *p_rarch = &rarch_st;
+   if (!string_is_empty(driver))
+      strlcpy(p_rarch->input_device_info[port].joypad_driver, driver,
+            sizeof(p_rarch->input_device_info[port].joypad_driver));
+}
+
 void input_config_set_device_vid(unsigned port, uint16_t vid)
 {
    struct rarch_state *p_rarch = &rarch_st;
@@ -27924,6 +27940,12 @@ void input_config_clear_device_config_name(unsigned port)
 {
    struct rarch_state *p_rarch = &rarch_st;
    p_rarch->input_device_info[port].config_name[0] = '\0';
+}
+
+void input_config_clear_device_joypad_driver(unsigned port)
+{
+   struct rarch_state *p_rarch = &rarch_st;
+   p_rarch->input_device_info[port].joypad_driver[0] = '\0';
 }
 
 /* input_device_info wrappers END */
@@ -28014,6 +28036,7 @@ void input_config_reset(void)
       input_config_clear_device_display_name(i);
       input_config_clear_device_config_path(i);
       input_config_clear_device_config_name(i);
+      input_config_clear_device_joypad_driver(i);
       input_config_set_device_vid(i, 0);
       input_config_set_device_pid(i, 0);
       input_config_set_device_autoconfigured(i, false);


### PR DESCRIPTION
## Description

At present, when saving autoconfig profiles, RetroArch chooses the output driver subdirectory based on the current 'controller driver' menu setting. If the user changes this setting without restarting RetroArch, then the wrong directory will be selected. More importantly (as described in #11103), when the `xinput` driver is set via the menu, the *actual* driver is auto-selected depending upon the connected hardware (i.e. `xinput` or `dinput`) - this means it is very easy to save profiles to the wrong location when using Windows.

This PR solves the issue by always using the *currently active* driver for the selected input device when determining the output autconfig file path.

## Related Issues

This closes #11103
