### PR TITLE
Prevent runahead from being disabled *permanently* when an error occurs

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -15590,6 +15590,10 @@ static bool input_driver_ungrab_mouse(struct rarch_state *p_rarch)
    return true;
 }
 
+/* Forward declaration */
+#ifdef HAVE_RUNAHEAD
+static void runahead_clear_variables(struct rarch_state *p_rarch);
+#endif
 
 /**
  * command_event:
@@ -16280,6 +16284,19 @@ bool command_event(enum event_command cmd, void *data)
             rcheevos_unload();
 #endif
             command_event_deinit_core(p_rarch, true);
+
+#ifdef HAVE_RUNAHEAD
+            /* If 'runahead_available' is false, then
+             * runahead is enabled by the user but an
+             * error occurred while the core was running
+             * (typically a save state issue). In this
+             * case we have to 'manually' reset the runahead
+             * runtime variables, otherwise runahead will
+             * remain disabled until the user restarts
+             * RetroArch */
+            if (!p_rarch->runahead_available)
+               runahead_clear_variables(p_rarch);
+#endif
 
             if (hwr)
                memset(hwr, 0, sizeof(*hwr));


### PR DESCRIPTION
## Description

As reported in #11116, if runahead fails when running a particular core, runahead gets disabled and remains disabled until the user restarts RetroArch. This is not ideal!

The issue occurs because a runahead failure removes the 'hooks' that would normally get executed when the core closes - so the 'runtime parameter reset' that should occur on close content never happens, and the global state is left reporting that runahead is 'broken'.

This PR fixes the problem by resetting the runahead runtime parameters when a core is unloaded *if* a runahead error occurred while the core was running.

## Related Issues

This closes #11116