### PR TITLE
Android: Apply "AArch64" and "32-bit" suffixes to app label

### DIFF
--- a/pkg/android/phoenix/AndroidManifest.xml
+++ b/pkg/android/phoenix/AndroidManifest.xml
@@ -18,7 +18,7 @@
     <application
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
-        android:label="RetroArch"
+        android:label="@string/app_name"
         android:hasCode="true"
         android:isGame="true"
         android:banner="@drawable/banner"

--- a/pkg/android/phoenix/build.gradle
+++ b/pkg/android/phoenix/build.gradle
@@ -36,6 +36,8 @@ android {
 
   productFlavors {
     normal {
+      resValue "string", "app_name", "RetroArch"
+
       dimension "variant"
     }
     aarch64 {


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

Inside the `build.gradle` for the Android app, we define separate `app_name` resources for each build variant (normal, aarch64 and ra32) that add an appropriate suffix to the app name ("AArch64" and "32-bit").  The generated name isn't surfaced to the user, however, since in `AndroidManifest.xml` the `android:label` is hardcoded to "RetroArch".

Because we are hardcoding the app name to "RetroArch" and not using the suffixed versions of the app name, it's impossible to distinguish between multiple versions of the app installed on the same device.  This PR wires up the generated `app_name` to the `android:label`, allowing the user to distinguish between multiple versions of RetroArch.

## Related Issues

None

## Related Pull Requests

None

## Reviewers

[If possible @mention all the people that should review your pull request]
