### PR TITLE
Explore: Disable undocumented original_title field

### DIFF
--- a/menu/menu_explore.c
+++ b/menu/menu_explore.c
@@ -103,7 +103,7 @@ typedef struct
    const struct playlist_entry* playlist_entry;
    explore_string_t *by[EXPLORE_CAT_COUNT];
    explore_string_t **split;
-#if 0
+#ifdef EXPLORE_SHOW_ORIGINAL_TITLE
    char* original_title;
 #endif
 } explore_entry_t;
@@ -742,7 +742,7 @@ static explore_state_t *explore_build_list(void)
          const struct playlist_entry *entry = NULL;
          uint32_t crc32                     = 0;
          char *name                         = NULL;
-#if 0
+#ifdef EXPLORE_SHOW_ORIGINAL_TITLE
          char *original_title               = NULL;
 #endif
 
@@ -771,7 +771,7 @@ static explore_state_t *explore_build_list(void)
                name = val->val.string.buff;
                continue;
             }
-#if 0
+#ifdef EXPLORE_SHOW_ORIGINAL_TITLE
             else if (string_is_equal(key_str, "original_title"))
             {
                original_title = val->val.string.buff;
@@ -818,7 +818,7 @@ static explore_state_t *explore_build_list(void)
          for (l = 0; l < EXPLORE_CAT_COUNT; l++)
             e.by[l]        = NULL;
          e.split           = NULL;
-#if 0
+#ifdef EXPLORE_SHOW_ORIGINAL_TITLE
          e.original_title  = NULL;
 #endif
 
@@ -831,7 +831,7 @@ static explore_state_t *explore_build_list(void)
                   fields[cat], &split_buf);
          }
 
-#if 0
+#ifdef EXPLORE_SHOW_ORIGINAL_TITLE
          if (original_title && *original_title)
          {
             size_t len       = strlen(original_title) + 1;
@@ -1266,7 +1266,7 @@ SKIP_EXPLORE_BY_CATEGORY:;
                   str->str,
                   EXPLORE_TYPE_FIRSTITEM + str->idx);
          }
-#if 0
+#ifdef EXPLORE_SHOW_ORIGINAL_TITLE
          else if (e->original_title)
             explore_menu_entry(list,
                   explore_state, e->original_title,

--- a/menu/menu_explore.c
+++ b/menu/menu_explore.c
@@ -103,7 +103,9 @@ typedef struct
    const struct playlist_entry* playlist_entry;
    explore_string_t *by[EXPLORE_CAT_COUNT];
    explore_string_t **split;
+#if 0
    char* original_title;
+#endif
 } explore_entry_t;
 
 typedef struct 
@@ -740,7 +742,9 @@ static explore_state_t *explore_build_list(void)
          const struct playlist_entry *entry = NULL;
          uint32_t crc32                     = 0;
          char *name                         = NULL;
+#if 0
          char *original_title               = NULL;
+#endif
 
          if (item.type != RDT_MAP)
             continue;
@@ -767,11 +771,13 @@ static explore_state_t *explore_build_list(void)
                name = val->val.string.buff;
                continue;
             }
+#if 0
             else if (string_is_equal(key_str, "original_title"))
             {
                original_title = val->val.string.buff;
                continue;
             }
+#endif
 
             for (cat = 0; cat != EXPLORE_CAT_COUNT; cat++)
             {
@@ -812,7 +818,9 @@ static explore_state_t *explore_build_list(void)
          for (l = 0; l < EXPLORE_CAT_COUNT; l++)
             e.by[l]        = NULL;
          e.split           = NULL;
+#if 0
          e.original_title  = NULL;
+#endif
 
          fields[EXPLORE_BY_SYSTEM] = rdb->systemname;
 
@@ -823,6 +831,7 @@ static explore_state_t *explore_build_list(void)
                   fields[cat], &split_buf);
          }
 
+#if 0
          if (original_title && *original_title)
          {
             size_t len       = strlen(original_title) + 1;
@@ -830,6 +839,7 @@ static explore_state_t *explore_build_list(void)
                ex_arena_alloc(&explore->arena, len);
             memcpy(e.original_title, original_title, len);
          }
+#endif
 
          if (EX_BUF_LEN(split_buf))
          {
@@ -1256,15 +1266,16 @@ SKIP_EXPLORE_BY_CATEGORY:;
                   str->str,
                   EXPLORE_TYPE_FIRSTITEM + str->idx);
          }
-         else
-         {
+#if 0
+         else if (e->original_title)
             explore_menu_entry(list,
-                  explore_state,
-                  (e->original_title 
-                   ? e->original_title 
-                   : e->playlist_entry->label),
+                  explore_state, e->original_title,
                   EXPLORE_TYPE_FIRSTITEM + (e - explore_state->entries));
-         }
+#endif
+         else
+            explore_menu_entry(list,
+                  explore_state, e->playlist_entry->label,
+                  EXPLORE_TYPE_FIRSTITEM + (e - explore_state->entries));
 
 SKIP_ENTRY:;
       }


### PR DESCRIPTION
## Description

A while ago (before the first explore PR even), as a test, I added support for a new RDB field called "original_title".
Explore would show the content of the field instead of the playlist item label if it existed.
The field is undocumented and no existing RDB uses it, I envisioned it primarily as a means to store game titles in their original language (i.e. "スーパーマリオカート" for "Super Mario Kart (Japan)").

But to properly support this, there would need to be an option added to RetroArch which would allow a user to set which type of title they want to see (Playlist Label, Name in Database, Original Name in Database). Such a setting does not exist so this PR comments out support for the field entirely for now.

## Related Issues

## Related Pull Requests

## Reviewers