### PR TITLE
'comparison of integer expressions of different signedness' warning fix

### DIFF
--- a/gfx/gfx_animation.c
+++ b/gfx/gfx_animation.c
@@ -1756,7 +1756,7 @@ bool gfx_animation_ticker_smooth(gfx_animation_ctx_ticker_smooth_t *ticker)
       if (period_width < 0)
          goto end;
 
-      if (ticker->field_width < (3 * period_width))
+      if (ticker->field_width < (3 * (unsigned)period_width))
          goto end;
 
       /* Determine number of characters to copy */

--- a/gfx/gfx_thumbnail.c
+++ b/gfx/gfx_thumbnail.c
@@ -43,7 +43,7 @@
 typedef struct
 {
    gfx_thumbnail_t *thumbnail;
-   retro_time_t list_id;
+   uint64_t list_id;
 } gfx_thumbnail_tag_t;
 
 /* Setters */


### PR DESCRIPTION
## Description

This trivial PR just fixes two `comparison of integer expressions of different signedness` compiler warnings, in `gfx_animation.c` and `gfx_thumbnail.c`