### PR TITLE
(ffmpeg) Fix memory leak/struct member issue

### DIFF
--- a/cores/libretro-ffmpeg/video_buffer.c
+++ b/cores/libretro-ffmpeg/video_buffer.c
@@ -73,11 +73,8 @@ video_buffer_t *video_buffer_create(
       b->buffer[i].hw_source = av_frame_alloc();
 #endif
       b->buffer[i].target    = av_frame_alloc();
-      b->buffer[i].frame_buf = (uint8_t*)av_malloc(frame_size);
 
-      avpicture_fill((AVPicture*)
-            b->buffer[i].target,
-            (const uint8_t*)b->buffer[i].frame_buf,
+      avpicture_alloc((AVPicture*)b->buffer[i].target,
             PIX_FMT_RGB32, width, height);
 
       if (!b->buffer[i].sws       ||
@@ -85,8 +82,7 @@ video_buffer_t *video_buffer_create(
 #if LIBAVUTIL_VERSION_MAJOR > 55
           !b->buffer[i].hw_source ||
 #endif
-          !b->buffer[i].target    ||
-          !b->buffer[i].frame_buf)
+          !b->buffer[i].target)
          goto fail;
    }
    return b;
@@ -114,8 +110,8 @@ void video_buffer_destroy(video_buffer_t *video_buffer)
          av_frame_free(&video_buffer->buffer[i].hw_source);
 #endif
          av_frame_free(&video_buffer->buffer[i].source);
+         avpicture_free((AVPicture*)video_buffer->buffer[i].target);
          av_frame_free(&video_buffer->buffer[i].target);
-         av_freep(&video_buffer->buffer[i].frame_buf);
          sws_freeContext(video_buffer->buffer[i].sws);
       }
    }

--- a/cores/libretro-ffmpeg/video_buffer.h
+++ b/cores/libretro-ffmpeg/video_buffer.h
@@ -6,6 +6,12 @@
 #include <boolean.h>
 #include <stdint.h>
 
+#ifdef RARCH_INTERNAL
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+#endif
+
 #ifdef HAVE_SSA
 #include <ass/ass.h>
 #endif


### PR DESCRIPTION
## Description

At present, the ffmpeg core leaks vast amounts of memory (tens of megabytes) every time a video is opened. This happens due to a highly obnoxious struct mismatch error:

- In `video_buffer.h` we have:

```c
struct video_decoder_context
{
   int index;
   int64_t pts;
   struct SwsContext *sws;
   AVFrame *source;
#if LIBAVUTIL_VERSION_MAJOR > 55
   AVFrame *hw_source;
#endif
   AVFrame *target;
#ifdef HAVE_SSA
   ASS_Track *ass_track_active;
#endif
   uint8_t *frame_buf;
};
```

- `HAVE_SSA` is defined in `config.h`

- `config.h` is included in `ffmpeg_core.c` but not in `video_buffer.h` - so in the two files, the same struct has different members

- It just so happens that the core sets `ass_track_active` to NULL - but due to the struct mismatch, `frame_buf` gets set to NULL instead. This means the memory that was pointed to by `frame_buf` never gets freed when the core is closed...

This PR fixes the struct mismatch by including `config.h` in `video_buffer.h`.

In addition (almost as a side note), it replaces the calls to `avpicture_fill()` with `avpicture_alloc()` - this reduces code complexity by removing the need for us to create/track our own intermediary data buffers.