### PR TITLE
[iOS] Hide the home indicator as it obscures the content too frequently

### DIFF
--- a/ui/drivers/cocoa/cocoa_common.m
+++ b/ui/drivers/cocoa/cocoa_common.m
@@ -178,14 +178,9 @@ void *glkitview_init(void);
     });
 }
 
-- (UIRectEdge)preferredScreenEdgesDeferringSystemGestures
-{
-    return UIRectEdgeBottom;
-}
-
 -(BOOL)prefersHomeIndicatorAutoHidden
 {
-    return NO;
+    return YES;
 }
 
 -(void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {


### PR DESCRIPTION
## Description

Hide the home indicator bar at the bottom of the screen for iPhone X and iPad Pro devices.