### PR TITLE
Bug in the Makefile for psl1ght after adding rtime

### DIFF
--- a/Makefile.psl1ght.salamander
+++ b/Makefile.psl1ght.salamander
@@ -70,7 +70,7 @@ OBJ		= frontend/frontend_salamander.o \
 				  libretro-common/streams/file_stream.o \
 				  libretro-common/vfs/vfs_implementation.o \
 				  libretro-common/file/config_file.o \
-				  libretro-common/time/rtime.c \
+				  libretro-common/time/rtime.o \
 				  file_path_str.o \
 				   verbosity.o
 


### PR DESCRIPTION
## Description

A "rtime.c" was added to an OBJ list but it should be an "rtime.o".

## Related Issues

This is also causing that a build step is deleting the rtime.c file.

## Related Pull Requests

The bug was introduced with this commit ("Add time/rtime.c to Salamander builds"): https://github.com/libretro/RetroArch/commit/fce29caff72a0ce6da4c9e8740b0a3858420254c

## Reviewers

@twinaphex 