### PR TITLE
[iOS] Set default video driver to OpenGL

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -321,7 +321,12 @@ enum midi_driver_enum
 };
 
 #if defined(HAVE_METAL)
+// iOS supports both the OpenGL and Metal video drivers; default to OpenGL since Metal support is preliminary
+#if defined(HAVE_COCOATOUCH) && defined(HAVE_OPENGL)
+static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_GL;
+#else
 static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_METAL;
+#endif
 #elif defined(HAVE_VITA2D)
 static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_VITA2D;
 #elif (defined(HAVE_OPENGL) || defined(HAVE_OPENGLES) || defined(__CELLOS_LV2__)) && !defined(__WINRT__) && !defined(__HAIKU__)

--- a/pkg/apple/RetroArch_iOS11_Metal.xcodeproj/project.pbxproj
+++ b/pkg/apple/RetroArch_iOS11_Metal.xcodeproj/project.pbxproj
@@ -111,6 +111,196 @@
 		926C77EC21FD261600103EDE /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.1.sdk/System/Library/Frameworks/CoreAudio.framework; sourceTree = DEVELOPER_DIR; };
 		926C77EE21FD263800103EDE /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.1.sdk/System/Library/Frameworks/AudioToolbox.framework; sourceTree = DEVELOPER_DIR; };
 		926C77F021FD26E800103EDE /* GameController.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GameController.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.1.sdk/System/Library/Frameworks/GameController.framework; sourceTree = DEVELOPER_DIR; };
+		92B9EB5724E0518700E6CFB2 /* base64.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = base64.h; sourceTree = "<group>"; };
+		92B9EB5824E0518700E6CFB2 /* utf.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = utf.h; sourceTree = "<group>"; };
+		92B9EB5924E0518700E6CFB2 /* win32.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = win32.h; sourceTree = "<group>"; };
+		92B9EB5A24E0518700E6CFB2 /* crc32.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = crc32.h; sourceTree = "<group>"; };
+		92B9EB5B24E0518700E6CFB2 /* memalign.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = memalign.h; sourceTree = "<group>"; };
+		92B9EB5C24E0518700E6CFB2 /* libretro_dspfilter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = libretro_dspfilter.h; sourceTree = "<group>"; };
+		92B9EB5E24E0518700E6CFB2 /* vfs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = vfs.h; sourceTree = "<group>"; };
+		92B9EB5F24E0518700E6CFB2 /* vfs_implementation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = vfs_implementation.h; sourceTree = "<group>"; };
+		92B9EB6024E0518700E6CFB2 /* vfs_implementation_cdrom.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = vfs_implementation_cdrom.h; sourceTree = "<group>"; };
+		92B9EB6224E0518700E6CFB2 /* cdrom.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = cdrom.h; sourceTree = "<group>"; };
+		92B9EB6324E0518700E6CFB2 /* libco.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = libco.h; sourceTree = "<group>"; };
+		92B9EB6524E0518700E6CFB2 /* apple_compat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = apple_compat.h; sourceTree = "<group>"; };
+		92B9EB6624E0518700E6CFB2 /* strl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = strl.h; sourceTree = "<group>"; };
+		92B9EB6724E0518700E6CFB2 /* strcasestr.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = strcasestr.h; sourceTree = "<group>"; };
+		92B9EB6924E0518700E6CFB2 /* stdint.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = stdint.h; sourceTree = "<group>"; };
+		92B9EB6A24E0518700E6CFB2 /* fopen_utf8.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = fopen_utf8.h; sourceTree = "<group>"; };
+		92B9EB6B24E0518700E6CFB2 /* intrinsics.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = intrinsics.h; sourceTree = "<group>"; };
+		92B9EB6C24E0518700E6CFB2 /* posix_string.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = posix_string.h; sourceTree = "<group>"; };
+		92B9EB6E24E0518700E6CFB2 /* zlib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = zlib.h; sourceTree = "<group>"; };
+		92B9EB6F24E0518700E6CFB2 /* zconf.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = zconf.h; sourceTree = "<group>"; };
+		92B9EB7024E0518700E6CFB2 /* getopt.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = getopt.h; sourceTree = "<group>"; };
+		92B9EB7124E0518700E6CFB2 /* fnmatch.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = fnmatch.h; sourceTree = "<group>"; };
+		92B9EB7224E0518700E6CFB2 /* msvc.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = msvc.h; sourceTree = "<group>"; };
+		92B9EB7324E0518700E6CFB2 /* ifaddrs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ifaddrs.h; sourceTree = "<group>"; };
+		92B9EB7424E0518700E6CFB2 /* retro_common_api.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = retro_common_api.h; sourceTree = "<group>"; };
+		92B9EB7624E0518700E6CFB2 /* label_sanitization.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = label_sanitization.h; sourceTree = "<group>"; };
+		92B9EB7824E0518700E6CFB2 /* dylib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = dylib.h; sourceTree = "<group>"; };
+		92B9EB7A24E0518700E6CFB2 /* net_ifinfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = net_ifinfo.h; sourceTree = "<group>"; };
+		92B9EB7B24E0518700E6CFB2 /* net_compat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = net_compat.h; sourceTree = "<group>"; };
+		92B9EB7C24E0518700E6CFB2 /* net_socket.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = net_socket.h; sourceTree = "<group>"; };
+		92B9EB7D24E0518700E6CFB2 /* net_natt.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = net_natt.h; sourceTree = "<group>"; };
+		92B9EB7E24E0518700E6CFB2 /* net_socket_ssl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = net_socket_ssl.h; sourceTree = "<group>"; };
+		92B9EB7F24E0518700E6CFB2 /* net_http.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = net_http.h; sourceTree = "<group>"; };
+		92B9EB8024E0518700E6CFB2 /* net_http_parse.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = net_http_parse.h; sourceTree = "<group>"; };
+		92B9EB8124E0518700E6CFB2 /* retro_timers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = retro_timers.h; sourceTree = "<group>"; };
+		92B9EB8324E0518700E6CFB2 /* m3u_file.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = m3u_file.h; sourceTree = "<group>"; };
+		92B9EB8424E0518700E6CFB2 /* jsonsax.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = jsonsax.h; sourceTree = "<group>"; };
+		92B9EB8524E0518700E6CFB2 /* rxml.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = rxml.h; sourceTree = "<group>"; };
+		92B9EB8624E0518700E6CFB2 /* cdfs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = cdfs.h; sourceTree = "<group>"; };
+		92B9EB8724E0518700E6CFB2 /* rpng.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = rpng.h; sourceTree = "<group>"; };
+		92B9EB8824E0518700E6CFB2 /* rtga.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = rtga.h; sourceTree = "<group>"; };
+		92B9EB8924E0518700E6CFB2 /* image.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = image.h; sourceTree = "<group>"; };
+		92B9EB8A24E0518700E6CFB2 /* logiqx_dat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = logiqx_dat.h; sourceTree = "<group>"; };
+		92B9EB8B24E0518700E6CFB2 /* rbmp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = rbmp.h; sourceTree = "<group>"; };
+		92B9EB8C24E0518700E6CFB2 /* rwav.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = rwav.h; sourceTree = "<group>"; };
+		92B9EB8D24E0518700E6CFB2 /* jsonsax_full.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = jsonsax_full.h; sourceTree = "<group>"; };
+		92B9EB8E24E0518700E6CFB2 /* rjpeg.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = rjpeg.h; sourceTree = "<group>"; };
+		92B9EB9024E0518700E6CFB2 /* rglgen.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = rglgen.h; sourceTree = "<group>"; };
+		92B9EB9124E0518700E6CFB2 /* glsym_es2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = glsym_es2.h; sourceTree = "<group>"; };
+		92B9EB9224E0518700E6CFB2 /* glsym.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = glsym.h; sourceTree = "<group>"; };
+		92B9EB9324E0518700E6CFB2 /* rglgen_headers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = rglgen_headers.h; sourceTree = "<group>"; };
+		92B9EB9524E0518700E6CFB2 /* nx_gl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = nx_gl.h; sourceTree = "<group>"; };
+		92B9EB9624E0518700E6CFB2 /* nx_glsym.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = nx_glsym.h; sourceTree = "<group>"; };
+		92B9EB9724E0518700E6CFB2 /* rglgen_private_headers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = rglgen_private_headers.h; sourceTree = "<group>"; };
+		92B9EB9824E0518700E6CFB2 /* glsym_es3.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = glsym_es3.h; sourceTree = "<group>"; };
+		92B9EB9924E0518700E6CFB2 /* glsym_gl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = glsym_gl.h; sourceTree = "<group>"; };
+		92B9EB9B24E0518700E6CFB2 /* string_list.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = string_list.h; sourceTree = "<group>"; };
+		92B9EB9C24E0518700E6CFB2 /* file_list.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = file_list.h; sourceTree = "<group>"; };
+		92B9EB9D24E0518700E6CFB2 /* dir_list.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = dir_list.h; sourceTree = "<group>"; };
+		92B9EB9F24E0518700E6CFB2 /* nbio.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = nbio.h; sourceTree = "<group>"; };
+		92B9EBA024E0518700E6CFB2 /* config_file.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = config_file.h; sourceTree = "<group>"; };
+		92B9EBA124E0518700E6CFB2 /* archive_file.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = archive_file.h; sourceTree = "<group>"; };
+		92B9EBA224E0518700E6CFB2 /* config_file_userdata.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = config_file_userdata.h; sourceTree = "<group>"; };
+		92B9EBA324E0518700E6CFB2 /* file_path.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = file_path.h; sourceTree = "<group>"; };
+		92B9EBA424E0518700E6CFB2 /* retro_environment.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = retro_environment.h; sourceTree = "<group>"; };
+		92B9EBA624E0518700E6CFB2 /* dynarray.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = dynarray.h; sourceTree = "<group>"; };
+		92B9EBA724E0518700E6CFB2 /* rbuf.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = rbuf.h; sourceTree = "<group>"; };
+		92B9EBA824E0518700E6CFB2 /* retro_dirent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = retro_dirent.h; sourceTree = "<group>"; };
+		92B9EBA924E0518700E6CFB2 /* retro_inline.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = retro_inline.h; sourceTree = "<group>"; };
+		92B9EBAA24E0518700E6CFB2 /* retro_math.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = retro_math.h; sourceTree = "<group>"; };
+		92B9EBAC24E0518700E6CFB2 /* memory_stream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = memory_stream.h; sourceTree = "<group>"; };
+		92B9EBAD24E0518700E6CFB2 /* chd_stream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = chd_stream.h; sourceTree = "<group>"; };
+		92B9EBAE24E0518700E6CFB2 /* trans_stream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = trans_stream.h; sourceTree = "<group>"; };
+		92B9EBAF24E0518700E6CFB2 /* rzip_stream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = rzip_stream.h; sourceTree = "<group>"; };
+		92B9EBB024E0518700E6CFB2 /* file_stream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = file_stream.h; sourceTree = "<group>"; };
+		92B9EBB124E0518700E6CFB2 /* stdin_stream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = stdin_stream.h; sourceTree = "<group>"; };
+		92B9EBB224E0518700E6CFB2 /* file_stream_transforms.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = file_stream_transforms.h; sourceTree = "<group>"; };
+		92B9EBB324E0518700E6CFB2 /* interface_stream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = interface_stream.h; sourceTree = "<group>"; };
+		92B9EBB424E0518700E6CFB2 /* fastcpy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = fastcpy.h; sourceTree = "<group>"; };
+		92B9EBB624E0518700E6CFB2 /* lzma.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = lzma.h; sourceTree = "<group>"; };
+		92B9EBB724E0518700E6CFB2 /* minmax.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = minmax.h; sourceTree = "<group>"; };
+		92B9EBB824E0518700E6CFB2 /* flac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = flac.h; sourceTree = "<group>"; };
+		92B9EBB924E0518700E6CFB2 /* bitstream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bitstream.h; sourceTree = "<group>"; };
+		92B9EBBA24E0518700E6CFB2 /* cdrom.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = cdrom.h; sourceTree = "<group>"; };
+		92B9EBBB24E0518700E6CFB2 /* chd.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = chd.h; sourceTree = "<group>"; };
+		92B9EBBC24E0518700E6CFB2 /* libchdr_zlib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = libchdr_zlib.h; sourceTree = "<group>"; };
+		92B9EBBD24E0518700E6CFB2 /* huffman.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = huffman.h; sourceTree = "<group>"; };
+		92B9EBBE24E0518700E6CFB2 /* coretypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = coretypes.h; sourceTree = "<group>"; };
+		92B9EBC024E0518700E6CFB2 /* features_cpu.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = features_cpu.h; sourceTree = "<group>"; };
+		92B9EBC224E0518700E6CFB2 /* md5.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = md5.h; sourceTree = "<group>"; };
+		92B9EBC324E0518700E6CFB2 /* retro_miscellaneous.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = retro_miscellaneous.h; sourceTree = "<group>"; };
+		92B9EBC424E0518700E6CFB2 /* clamping.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = clamping.h; sourceTree = "<group>"; };
+		92B9EBC624E0518700E6CFB2 /* float_minmax.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = float_minmax.h; sourceTree = "<group>"; };
+		92B9EBC724E0518700E6CFB2 /* fxp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = fxp.h; sourceTree = "<group>"; };
+		92B9EBC824E0518700E6CFB2 /* complex.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = complex.h; sourceTree = "<group>"; };
+		92B9EBCA24E0518700E6CFB2 /* rtime.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = rtime.h; sourceTree = "<group>"; };
+		92B9EBCB24E0518700E6CFB2 /* boolean.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = boolean.h; sourceTree = "<group>"; };
+		92B9EBCC24E0518700E6CFB2 /* libretro_gskit_ps2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = libretro_gskit_ps2.h; sourceTree = "<group>"; };
+		92B9EBCE24E0518700E6CFB2 /* dsp_filter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = dsp_filter.h; sourceTree = "<group>"; };
+		92B9EBCF24E0518700E6CFB2 /* audio_resampler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = audio_resampler.h; sourceTree = "<group>"; };
+		92B9EBD024E0518700E6CFB2 /* audio_mixer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = audio_mixer.h; sourceTree = "<group>"; };
+		92B9EBD224E0518700E6CFB2 /* s16_to_float.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = s16_to_float.h; sourceTree = "<group>"; };
+		92B9EBD324E0518700E6CFB2 /* float_to_s16.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = float_to_s16.h; sourceTree = "<group>"; };
+		92B9EBD424E0518700E6CFB2 /* audio_mix.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = audio_mix.h; sourceTree = "<group>"; };
+		92B9EBD524E0518700E6CFB2 /* memmap.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = memmap.h; sourceTree = "<group>"; };
+		92B9EBD624E0518700E6CFB2 /* rhash.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = rhash.h; sourceTree = "<group>"; };
+		92B9EBD824E0518700E6CFB2 /* tpool.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = tpool.h; sourceTree = "<group>"; };
+		92B9EBD924E0518700E6CFB2 /* rthreads.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = rthreads.h; sourceTree = "<group>"; };
+		92B9EBDA24E0518700E6CFB2 /* async_job.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = async_job.h; sourceTree = "<group>"; };
+		92B9EBDB24E0518700E6CFB2 /* libretro.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = libretro.h; sourceTree = "<group>"; };
+		92B9EBDD24E0518700E6CFB2 /* vulkan_symbol_wrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = vulkan_symbol_wrapper.h; sourceTree = "<group>"; };
+		92B9EBDE24E0518700E6CFB2 /* retro_common.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = retro_common.h; sourceTree = "<group>"; };
+		92B9EBE024E0518700E6CFB2 /* task_queue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = task_queue.h; sourceTree = "<group>"; };
+		92B9EBE124E0518700E6CFB2 /* fifo_queue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = fifo_queue.h; sourceTree = "<group>"; };
+		92B9EBE224E0518700E6CFB2 /* message_queue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = message_queue.h; sourceTree = "<group>"; };
+		92B9EBE324E0518700E6CFB2 /* retro_assert.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = retro_assert.h; sourceTree = "<group>"; };
+		92B9EBE524E0518700E6CFB2 /* stdstring.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = stdstring.h; sourceTree = "<group>"; };
+		92B9EBE624E0518700E6CFB2 /* libretro_d3d.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = libretro_d3d.h; sourceTree = "<group>"; };
+		92B9EBE724E0518700E6CFB2 /* libretro_vulkan.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = libretro_vulkan.h; sourceTree = "<group>"; };
+		92B9EBE924E0518700E6CFB2 /* video_frame.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = video_frame.h; sourceTree = "<group>"; };
+		92B9EBEB24E0518800E6CFB2 /* vector_4.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = vector_4.h; sourceTree = "<group>"; };
+		92B9EBEC24E0518800E6CFB2 /* vector_3.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = vector_3.h; sourceTree = "<group>"; };
+		92B9EBED24E0518800E6CFB2 /* vector_2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = vector_2.h; sourceTree = "<group>"; };
+		92B9EBEE24E0518800E6CFB2 /* matrix_3x3.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = matrix_3x3.h; sourceTree = "<group>"; };
+		92B9EBEF24E0518800E6CFB2 /* matrix_4x4.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = matrix_4x4.h; sourceTree = "<group>"; };
+		92B9EBF124E0518800E6CFB2 /* scaler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = scaler.h; sourceTree = "<group>"; };
+		92B9EBF224E0518800E6CFB2 /* pixconv.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = pixconv.h; sourceTree = "<group>"; };
+		92B9EBF324E0518800E6CFB2 /* scaler_int.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = scaler_int.h; sourceTree = "<group>"; };
+		92B9EBF424E0518800E6CFB2 /* filter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = filter.h; sourceTree = "<group>"; };
+		92B9EBF524E0518800E6CFB2 /* gl_capabilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = gl_capabilities.h; sourceTree = "<group>"; };
+		92B9EBF624E0518800E6CFB2 /* retro_endianness.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = retro_endianness.h; sourceTree = "<group>"; };
+		92B9EBF724E0518800E6CFB2 /* filters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = filters.h; sourceTree = "<group>"; };
+		92B9EBF924E0518800E6CFB2 /* media_detect_cd.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = media_detect_cd.h; sourceTree = "<group>"; };
+		92B9EC7D24E0518900E6CFB2 /* gl_capabilities.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = gl_capabilities.c; sourceTree = "<group>"; };
+		92B9EC7F24E0518900E6CFB2 /* scaler_int.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = scaler_int.c; sourceTree = "<group>"; };
+		92B9EC8024E0518900E6CFB2 /* pixconv.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pixconv.c; sourceTree = "<group>"; };
+		92B9EC8124E0518900E6CFB2 /* scaler_filter.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = scaler_filter.c; sourceTree = "<group>"; };
+		92B9EC8224E0518900E6CFB2 /* scaler.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = scaler.c; sourceTree = "<group>"; };
+		92B9EC9424E0537500E6CFB2 /* command.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = command.h; path = ../../command.h; sourceTree = "<group>"; };
+		92B9EC9524E0537500E6CFB2 /* configuration.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = configuration.c; path = ../../configuration.c; sourceTree = "<group>"; };
+		92B9EC9624E0537500E6CFB2 /* configuration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = configuration.h; path = ../../configuration.h; sourceTree = "<group>"; };
+		92B9EC9724E0537500E6CFB2 /* config.def.keybinds.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = config.def.keybinds.h; path = ../../config.def.keybinds.h; sourceTree = "<group>"; };
+		92B9EC9824E0537500E6CFB2 /* config.def.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = config.def.h; path = ../../config.def.h; sourceTree = "<group>"; };
+		92B9EC9924E0537500E6CFB2 /* config.features.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = config.features.h; path = ../../config.features.h; sourceTree = "<group>"; };
+		92B9EC9A24E0537500E6CFB2 /* content.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = content.h; path = ../../content.h; sourceTree = "<group>"; };
+		92B9EC9B24E0539000E6CFB2 /* core_type.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = core_type.h; path = ../../core_type.h; sourceTree = "<group>"; };
+		92B9EC9C24E0539000E6CFB2 /* core_info.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = core_info.c; path = ../../core_info.c; sourceTree = "<group>"; };
+		92B9EC9D24E0539000E6CFB2 /* core_info.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = core_info.h; path = ../../core_info.h; sourceTree = "<group>"; };
+		92B9EC9E24E0539000E6CFB2 /* core.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = core.h; path = ../../core.h; sourceTree = "<group>"; };
+		92B9EC9F24E053BD00E6CFB2 /* playlist.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = playlist.c; path = ../../playlist.c; sourceTree = "<group>"; };
+		92B9ECA024E053BD00E6CFB2 /* retroarch.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = retroarch.c; path = ../../retroarch.c; sourceTree = "<group>"; };
+		92B9ECA124E053BD00E6CFB2 /* retroarch.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = retroarch.h; path = ../../retroarch.h; sourceTree = "<group>"; };
+		92B9ECA224E053BD00E6CFB2 /* playlist.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = playlist.h; path = ../../playlist.h; sourceTree = "<group>"; };
+		92B9ECA324E053FF00E6CFB2 /* accessibility.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = accessibility.h; path = ../../accessibility.h; sourceTree = "<group>"; };
+		92B9ECA424E053FF00E6CFB2 /* autosave.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = autosave.h; path = ../../autosave.h; sourceTree = "<group>"; };
+		92B9ECA524E054B300E6CFB2 /* performance_counters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = performance_counters.h; path = ../../performance_counters.h; sourceTree = "<group>"; };
+		92B9ECA624E054B300E6CFB2 /* disk_control_interface.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = disk_control_interface.c; path = ../../disk_control_interface.c; sourceTree = "<group>"; };
+		92B9ECA724E054B300E6CFB2 /* file_path_special.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = file_path_special.h; path = ../../file_path_special.h; sourceTree = "<group>"; };
+		92B9ECA824E054B300E6CFB2 /* version_git.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = version_git.h; path = ../../version_git.h; sourceTree = "<group>"; };
+		92B9ECA924E054B400E6CFB2 /* translation_defines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = translation_defines.h; path = ../../translation_defines.h; sourceTree = "<group>"; };
+		92B9ECAA24E054B400E6CFB2 /* paths.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = paths.h; path = ../../paths.h; sourceTree = "<group>"; };
+		92B9ECAB24E054B400E6CFB2 /* manual_content_scan.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = manual_content_scan.c; path = ../../manual_content_scan.c; sourceTree = "<group>"; };
+		92B9ECAC24E054B400E6CFB2 /* verbosity.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = verbosity.c; path = ../../verbosity.c; sourceTree = "<group>"; };
+		92B9ECAD24E054B400E6CFB2 /* lakka.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = lakka.h; path = ../../lakka.h; sourceTree = "<group>"; };
+		92B9ECAE24E054B400E6CFB2 /* msg_hash.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = msg_hash.h; path = ../../msg_hash.h; sourceTree = "<group>"; };
+		92B9ECAF24E054B400E6CFB2 /* runtime_file.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = runtime_file.h; path = ../../runtime_file.h; sourceTree = "<group>"; };
+		92B9ECB024E054B400E6CFB2 /* core_updater_list.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = core_updater_list.c; path = ../../core_updater_list.c; sourceTree = "<group>"; };
+		92B9ECB124E054B400E6CFB2 /* version_git.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = version_git.c; path = ../../version_git.c; sourceTree = "<group>"; };
+		92B9ECB224E054B400E6CFB2 /* dynamic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = dynamic.h; path = ../../dynamic.h; sourceTree = "<group>"; };
+		92B9ECB324E054B400E6CFB2 /* list_special.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = list_special.h; path = ../../list_special.h; sourceTree = "<group>"; };
+		92B9ECB424E054B400E6CFB2 /* setting_list.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = setting_list.h; path = ../../setting_list.h; sourceTree = "<group>"; };
+		92B9ECB524E054B400E6CFB2 /* disk_index_file.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = disk_index_file.c; path = ../../disk_index_file.c; sourceTree = "<group>"; };
+		92B9ECB624E054B500E6CFB2 /* core_updater_list.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = core_updater_list.h; path = ../../core_updater_list.h; sourceTree = "<group>"; };
+		92B9ECB724E054B500E6CFB2 /* switch_performance_profiles.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = switch_performance_profiles.h; path = ../../switch_performance_profiles.h; sourceTree = "<group>"; };
+		92B9ECB824E054B500E6CFB2 /* driver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = driver.h; path = ../../driver.h; sourceTree = "<group>"; };
+		92B9ECB924E054B500E6CFB2 /* version.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = version.h; path = ../../version.h; sourceTree = "<group>"; };
+		92B9ECBA24E054B500E6CFB2 /* file_path_str.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = file_path_str.c; path = ../../file_path_str.c; sourceTree = "<group>"; };
+		92B9ECBB24E054B500E6CFB2 /* disk_index_file.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = disk_index_file.h; path = ../../disk_index_file.h; sourceTree = "<group>"; };
+		92B9ECBC24E054B500E6CFB2 /* core_backup.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = core_backup.c; path = ../../core_backup.c; sourceTree = "<group>"; };
+		92B9ECBD24E054B500E6CFB2 /* database_info.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = database_info.h; path = ../../database_info.h; sourceTree = "<group>"; };
+		92B9ECBE24E054B500E6CFB2 /* manual_content_scan.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = manual_content_scan.h; path = ../../manual_content_scan.h; sourceTree = "<group>"; };
+		92B9ECBF24E054B500E6CFB2 /* core_backup.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = core_backup.h; path = ../../core_backup.h; sourceTree = "<group>"; };
+		92B9ECC024E054B500E6CFB2 /* disk_control_interface.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = disk_control_interface.h; path = ../../disk_control_interface.h; sourceTree = "<group>"; };
+		92B9ECC124E054B600E6CFB2 /* msg_hash.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = msg_hash.c; path = ../../msg_hash.c; sourceTree = "<group>"; };
+		92B9ECC224E054B600E6CFB2 /* nvda_controller.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = nvda_controller.h; path = ../../nvda_controller.h; sourceTree = "<group>"; };
+		92B9ECC324E054B600E6CFB2 /* defaults.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = defaults.h; path = ../../defaults.h; sourceTree = "<group>"; };
+		92B9ECC424E054B600E6CFB2 /* database_info.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = database_info.c; path = ../../database_info.c; sourceTree = "<group>"; };
+		92B9ECC524E054B600E6CFB2 /* runtime_file.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = runtime_file.c; path = ../../runtime_file.c; sourceTree = "<group>"; };
+		92B9ECC624E054B600E6CFB2 /* verbosity.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = verbosity.h; path = ../../verbosity.h; sourceTree = "<group>"; };
+		92B9ECC724E054B600E6CFB2 /* file_path_special.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = file_path_special.c; path = ../../file_path_special.c; sourceTree = "<group>"; };
 		92CC058021FE3C1700FF79F0 /* GCDWebServerFunctions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GCDWebServerFunctions.h; sourceTree = "<group>"; };
 		92CC058121FE3C1700FF79F0 /* GCDWebServerPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GCDWebServerPrivate.h; sourceTree = "<group>"; };
 		92CC058221FE3C1700FF79F0 /* GCDWebServerResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GCDWebServerResponse.m; sourceTree = "<group>"; };
@@ -146,11 +336,6 @@
 		92CC05C121FE3C6D00FF79F0 /* WebServer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WebServer.m; sourceTree = "<group>"; };
 		92CC05C421FEDC9F00FF79F0 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
 		92CC05C621FEDD0B00FF79F0 /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
-		92D3D56B232D86AC001B0D86 /* cocoa_common.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = cocoa_common.h; path = ../../../../../../ui/drivers/cocoa/cocoa_common.h; sourceTree = "<group>"; };
-		92D3D56C232D86AC001B0D86 /* cocoatouch_menu.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = cocoatouch_menu.m; path = ../../../../../../ui/drivers/cocoa/cocoatouch_menu.m; sourceTree = "<group>"; };
-		92D3D56D232D86AC001B0D86 /* cocoa_common.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = cocoa_common.m; path = ../../../../../../ui/drivers/cocoa/cocoa_common.m; sourceTree = "<group>"; };
-		92D3D56F232D86AC001B0D86 /* cocoa_defines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = cocoa_defines.h; path = ../../../../../../ui/drivers/cocoa/cocoa_defines.h; sourceTree = "<group>"; };
-		92D3D572232D8AEF001B0D86 /* ui_cocoatouch.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = ui_cocoatouch.m; path = ../../../../ui/drivers/ui_cocoatouch.m; sourceTree = "<group>"; };
 		92E5DCD3231A5786006491BF /* modules */ = {isa = PBXFileReference; lastKnownFileType = folder; path = modules; sourceTree = "<group>"; };
 		96366C5416C9AC3300D64A22 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
 		96366C5816C9ACF500D64A22 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
@@ -222,6 +407,492 @@
 				926C77E421FD1E6700103EDE /* Info.plist */,
 			);
 			path = tvOS;
+			sourceTree = "<group>";
+		};
+		92B9EAE024E04F8800E6CFB2 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EC9324E0536200E6CFB2 /* core */,
+				92B9EAE524E0518600E6CFB2 /* libretro-common */,
+			);
+			name = Sources;
+			sourceTree = "<group>";
+		};
+		92B9EAE524E0518600E6CFB2 /* libretro-common */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EC7C24E0518900E6CFB2 /* gfx */,
+				92B9EB5524E0518700E6CFB2 /* include */,
+			);
+			name = "libretro-common";
+			path = "../../libretro-common";
+			sourceTree = "<group>";
+		};
+		92B9EB5524E0518700E6CFB2 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EBA524E0518700E6CFB2 /* array */,
+				92B9EBCD24E0518700E6CFB2 /* audio */,
+				92B9EBCB24E0518700E6CFB2 /* boolean.h */,
+				92B9EB6124E0518700E6CFB2 /* cdrom */,
+				92B9EBC424E0518700E6CFB2 /* clamping.h */,
+				92B9EB6424E0518700E6CFB2 /* compat */,
+				92B9EB7724E0518700E6CFB2 /* dynamic */,
+				92B9EB5624E0518700E6CFB2 /* encodings */,
+				92B9EBB424E0518700E6CFB2 /* fastcpy.h */,
+				92B9EBBF24E0518700E6CFB2 /* features */,
+				92B9EB9E24E0518700E6CFB2 /* file */,
+				92B9EBF724E0518800E6CFB2 /* filters.h */,
+				92B9EB8224E0518700E6CFB2 /* formats */,
+				92B9EBE824E0518700E6CFB2 /* gfx */,
+				92B9EB8F24E0518700E6CFB2 /* glsym */,
+				92B9EBB524E0518700E6CFB2 /* libchdr */,
+				92B9EB6324E0518700E6CFB2 /* libco.h */,
+				92B9EBE624E0518700E6CFB2 /* libretro_d3d.h */,
+				92B9EB5C24E0518700E6CFB2 /* libretro_dspfilter.h */,
+				92B9EBCC24E0518700E6CFB2 /* libretro_gskit_ps2.h */,
+				92B9EBE724E0518700E6CFB2 /* libretro_vulkan.h */,
+				92B9EBDB24E0518700E6CFB2 /* libretro.h */,
+				92B9EB9A24E0518700E6CFB2 /* lists */,
+				92B9EBC524E0518700E6CFB2 /* math */,
+				92B9EBF824E0518800E6CFB2 /* media */,
+				92B9EB5B24E0518700E6CFB2 /* memalign.h */,
+				92B9EBD524E0518700E6CFB2 /* memmap.h */,
+				92B9EB7924E0518700E6CFB2 /* net */,
+				92B9EB7524E0518700E6CFB2 /* playlists */,
+				92B9EBDF24E0518700E6CFB2 /* queues */,
+				92B9EBE324E0518700E6CFB2 /* retro_assert.h */,
+				92B9EB7424E0518700E6CFB2 /* retro_common_api.h */,
+				92B9EBDE24E0518700E6CFB2 /* retro_common.h */,
+				92B9EBA824E0518700E6CFB2 /* retro_dirent.h */,
+				92B9EBF624E0518800E6CFB2 /* retro_endianness.h */,
+				92B9EBA424E0518700E6CFB2 /* retro_environment.h */,
+				92B9EBA924E0518700E6CFB2 /* retro_inline.h */,
+				92B9EBAA24E0518700E6CFB2 /* retro_math.h */,
+				92B9EBC324E0518700E6CFB2 /* retro_miscellaneous.h */,
+				92B9EB8124E0518700E6CFB2 /* retro_timers.h */,
+				92B9EBD624E0518700E6CFB2 /* rhash.h */,
+				92B9EBD724E0518700E6CFB2 /* rthreads */,
+				92B9EBAB24E0518700E6CFB2 /* streams */,
+				92B9EBE424E0518700E6CFB2 /* string */,
+				92B9EBC924E0518700E6CFB2 /* time */,
+				92B9EBC124E0518700E6CFB2 /* utils */,
+				92B9EB5D24E0518700E6CFB2 /* vfs */,
+				92B9EBDC24E0518700E6CFB2 /* vulkan */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
+		92B9EB5624E0518700E6CFB2 /* encodings */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EB5724E0518700E6CFB2 /* base64.h */,
+				92B9EB5824E0518700E6CFB2 /* utf.h */,
+				92B9EB5924E0518700E6CFB2 /* win32.h */,
+				92B9EB5A24E0518700E6CFB2 /* crc32.h */,
+			);
+			path = encodings;
+			sourceTree = "<group>";
+		};
+		92B9EB5D24E0518700E6CFB2 /* vfs */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EB5E24E0518700E6CFB2 /* vfs.h */,
+				92B9EB5F24E0518700E6CFB2 /* vfs_implementation.h */,
+				92B9EB6024E0518700E6CFB2 /* vfs_implementation_cdrom.h */,
+			);
+			path = vfs;
+			sourceTree = "<group>";
+		};
+		92B9EB6124E0518700E6CFB2 /* cdrom */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EB6224E0518700E6CFB2 /* cdrom.h */,
+			);
+			path = cdrom;
+			sourceTree = "<group>";
+		};
+		92B9EB6424E0518700E6CFB2 /* compat */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EB6524E0518700E6CFB2 /* apple_compat.h */,
+				92B9EB6624E0518700E6CFB2 /* strl.h */,
+				92B9EB6724E0518700E6CFB2 /* strcasestr.h */,
+				92B9EB6824E0518700E6CFB2 /* msvc */,
+				92B9EB6A24E0518700E6CFB2 /* fopen_utf8.h */,
+				92B9EB6B24E0518700E6CFB2 /* intrinsics.h */,
+				92B9EB6C24E0518700E6CFB2 /* posix_string.h */,
+				92B9EB6D24E0518700E6CFB2 /* zlib */,
+				92B9EB7024E0518700E6CFB2 /* getopt.h */,
+				92B9EB7124E0518700E6CFB2 /* fnmatch.h */,
+				92B9EB7224E0518700E6CFB2 /* msvc.h */,
+				92B9EB7324E0518700E6CFB2 /* ifaddrs.h */,
+			);
+			path = compat;
+			sourceTree = "<group>";
+		};
+		92B9EB6824E0518700E6CFB2 /* msvc */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EB6924E0518700E6CFB2 /* stdint.h */,
+			);
+			path = msvc;
+			sourceTree = "<group>";
+		};
+		92B9EB6D24E0518700E6CFB2 /* zlib */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EB6E24E0518700E6CFB2 /* zlib.h */,
+				92B9EB6F24E0518700E6CFB2 /* zconf.h */,
+			);
+			path = zlib;
+			sourceTree = "<group>";
+		};
+		92B9EB7524E0518700E6CFB2 /* playlists */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EB7624E0518700E6CFB2 /* label_sanitization.h */,
+			);
+			path = playlists;
+			sourceTree = "<group>";
+		};
+		92B9EB7724E0518700E6CFB2 /* dynamic */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EB7824E0518700E6CFB2 /* dylib.h */,
+			);
+			path = dynamic;
+			sourceTree = "<group>";
+		};
+		92B9EB7924E0518700E6CFB2 /* net */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EB7A24E0518700E6CFB2 /* net_ifinfo.h */,
+				92B9EB7B24E0518700E6CFB2 /* net_compat.h */,
+				92B9EB7C24E0518700E6CFB2 /* net_socket.h */,
+				92B9EB7D24E0518700E6CFB2 /* net_natt.h */,
+				92B9EB7E24E0518700E6CFB2 /* net_socket_ssl.h */,
+				92B9EB7F24E0518700E6CFB2 /* net_http.h */,
+				92B9EB8024E0518700E6CFB2 /* net_http_parse.h */,
+			);
+			path = net;
+			sourceTree = "<group>";
+		};
+		92B9EB8224E0518700E6CFB2 /* formats */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EB8324E0518700E6CFB2 /* m3u_file.h */,
+				92B9EB8424E0518700E6CFB2 /* jsonsax.h */,
+				92B9EB8524E0518700E6CFB2 /* rxml.h */,
+				92B9EB8624E0518700E6CFB2 /* cdfs.h */,
+				92B9EB8724E0518700E6CFB2 /* rpng.h */,
+				92B9EB8824E0518700E6CFB2 /* rtga.h */,
+				92B9EB8924E0518700E6CFB2 /* image.h */,
+				92B9EB8A24E0518700E6CFB2 /* logiqx_dat.h */,
+				92B9EB8B24E0518700E6CFB2 /* rbmp.h */,
+				92B9EB8C24E0518700E6CFB2 /* rwav.h */,
+				92B9EB8D24E0518700E6CFB2 /* jsonsax_full.h */,
+				92B9EB8E24E0518700E6CFB2 /* rjpeg.h */,
+			);
+			path = formats;
+			sourceTree = "<group>";
+		};
+		92B9EB8F24E0518700E6CFB2 /* glsym */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EB9024E0518700E6CFB2 /* rglgen.h */,
+				92B9EB9124E0518700E6CFB2 /* glsym_es2.h */,
+				92B9EB9224E0518700E6CFB2 /* glsym.h */,
+				92B9EB9324E0518700E6CFB2 /* rglgen_headers.h */,
+				92B9EB9424E0518700E6CFB2 /* switch */,
+				92B9EB9724E0518700E6CFB2 /* rglgen_private_headers.h */,
+				92B9EB9824E0518700E6CFB2 /* glsym_es3.h */,
+				92B9EB9924E0518700E6CFB2 /* glsym_gl.h */,
+			);
+			path = glsym;
+			sourceTree = "<group>";
+		};
+		92B9EB9424E0518700E6CFB2 /* switch */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EB9524E0518700E6CFB2 /* nx_gl.h */,
+				92B9EB9624E0518700E6CFB2 /* nx_glsym.h */,
+			);
+			path = switch;
+			sourceTree = "<group>";
+		};
+		92B9EB9A24E0518700E6CFB2 /* lists */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EB9B24E0518700E6CFB2 /* string_list.h */,
+				92B9EB9C24E0518700E6CFB2 /* file_list.h */,
+				92B9EB9D24E0518700E6CFB2 /* dir_list.h */,
+			);
+			path = lists;
+			sourceTree = "<group>";
+		};
+		92B9EB9E24E0518700E6CFB2 /* file */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EB9F24E0518700E6CFB2 /* nbio.h */,
+				92B9EBA024E0518700E6CFB2 /* config_file.h */,
+				92B9EBA124E0518700E6CFB2 /* archive_file.h */,
+				92B9EBA224E0518700E6CFB2 /* config_file_userdata.h */,
+				92B9EBA324E0518700E6CFB2 /* file_path.h */,
+			);
+			path = file;
+			sourceTree = "<group>";
+		};
+		92B9EBA524E0518700E6CFB2 /* array */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EBA624E0518700E6CFB2 /* dynarray.h */,
+				92B9EBA724E0518700E6CFB2 /* rbuf.h */,
+			);
+			path = array;
+			sourceTree = "<group>";
+		};
+		92B9EBAB24E0518700E6CFB2 /* streams */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EBAC24E0518700E6CFB2 /* memory_stream.h */,
+				92B9EBAD24E0518700E6CFB2 /* chd_stream.h */,
+				92B9EBAE24E0518700E6CFB2 /* trans_stream.h */,
+				92B9EBAF24E0518700E6CFB2 /* rzip_stream.h */,
+				92B9EBB024E0518700E6CFB2 /* file_stream.h */,
+				92B9EBB124E0518700E6CFB2 /* stdin_stream.h */,
+				92B9EBB224E0518700E6CFB2 /* file_stream_transforms.h */,
+				92B9EBB324E0518700E6CFB2 /* interface_stream.h */,
+			);
+			path = streams;
+			sourceTree = "<group>";
+		};
+		92B9EBB524E0518700E6CFB2 /* libchdr */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EBB624E0518700E6CFB2 /* lzma.h */,
+				92B9EBB724E0518700E6CFB2 /* minmax.h */,
+				92B9EBB824E0518700E6CFB2 /* flac.h */,
+				92B9EBB924E0518700E6CFB2 /* bitstream.h */,
+				92B9EBBA24E0518700E6CFB2 /* cdrom.h */,
+				92B9EBBB24E0518700E6CFB2 /* chd.h */,
+				92B9EBBC24E0518700E6CFB2 /* libchdr_zlib.h */,
+				92B9EBBD24E0518700E6CFB2 /* huffman.h */,
+				92B9EBBE24E0518700E6CFB2 /* coretypes.h */,
+			);
+			path = libchdr;
+			sourceTree = "<group>";
+		};
+		92B9EBBF24E0518700E6CFB2 /* features */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EBC024E0518700E6CFB2 /* features_cpu.h */,
+			);
+			path = features;
+			sourceTree = "<group>";
+		};
+		92B9EBC124E0518700E6CFB2 /* utils */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EBC224E0518700E6CFB2 /* md5.h */,
+			);
+			path = utils;
+			sourceTree = "<group>";
+		};
+		92B9EBC524E0518700E6CFB2 /* math */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EBC624E0518700E6CFB2 /* float_minmax.h */,
+				92B9EBC724E0518700E6CFB2 /* fxp.h */,
+				92B9EBC824E0518700E6CFB2 /* complex.h */,
+			);
+			path = math;
+			sourceTree = "<group>";
+		};
+		92B9EBC924E0518700E6CFB2 /* time */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EBCA24E0518700E6CFB2 /* rtime.h */,
+			);
+			path = time;
+			sourceTree = "<group>";
+		};
+		92B9EBCD24E0518700E6CFB2 /* audio */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EBCE24E0518700E6CFB2 /* dsp_filter.h */,
+				92B9EBCF24E0518700E6CFB2 /* audio_resampler.h */,
+				92B9EBD024E0518700E6CFB2 /* audio_mixer.h */,
+				92B9EBD124E0518700E6CFB2 /* conversion */,
+				92B9EBD424E0518700E6CFB2 /* audio_mix.h */,
+			);
+			path = audio;
+			sourceTree = "<group>";
+		};
+		92B9EBD124E0518700E6CFB2 /* conversion */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EBD224E0518700E6CFB2 /* s16_to_float.h */,
+				92B9EBD324E0518700E6CFB2 /* float_to_s16.h */,
+			);
+			path = conversion;
+			sourceTree = "<group>";
+		};
+		92B9EBD724E0518700E6CFB2 /* rthreads */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EBD824E0518700E6CFB2 /* tpool.h */,
+				92B9EBD924E0518700E6CFB2 /* rthreads.h */,
+				92B9EBDA24E0518700E6CFB2 /* async_job.h */,
+			);
+			path = rthreads;
+			sourceTree = "<group>";
+		};
+		92B9EBDC24E0518700E6CFB2 /* vulkan */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EBDD24E0518700E6CFB2 /* vulkan_symbol_wrapper.h */,
+			);
+			path = vulkan;
+			sourceTree = "<group>";
+		};
+		92B9EBDF24E0518700E6CFB2 /* queues */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EBE024E0518700E6CFB2 /* task_queue.h */,
+				92B9EBE124E0518700E6CFB2 /* fifo_queue.h */,
+				92B9EBE224E0518700E6CFB2 /* message_queue.h */,
+			);
+			path = queues;
+			sourceTree = "<group>";
+		};
+		92B9EBE424E0518700E6CFB2 /* string */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EBE524E0518700E6CFB2 /* stdstring.h */,
+			);
+			path = string;
+			sourceTree = "<group>";
+		};
+		92B9EBE824E0518700E6CFB2 /* gfx */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EBE924E0518700E6CFB2 /* video_frame.h */,
+				92B9EBEA24E0518700E6CFB2 /* math */,
+				92B9EBF024E0518800E6CFB2 /* scaler */,
+				92B9EBF524E0518800E6CFB2 /* gl_capabilities.h */,
+			);
+			path = gfx;
+			sourceTree = "<group>";
+		};
+		92B9EBEA24E0518700E6CFB2 /* math */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EBEB24E0518800E6CFB2 /* vector_4.h */,
+				92B9EBEC24E0518800E6CFB2 /* vector_3.h */,
+				92B9EBED24E0518800E6CFB2 /* vector_2.h */,
+				92B9EBEE24E0518800E6CFB2 /* matrix_3x3.h */,
+				92B9EBEF24E0518800E6CFB2 /* matrix_4x4.h */,
+			);
+			path = math;
+			sourceTree = "<group>";
+		};
+		92B9EBF024E0518800E6CFB2 /* scaler */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EBF124E0518800E6CFB2 /* scaler.h */,
+				92B9EBF224E0518800E6CFB2 /* pixconv.h */,
+				92B9EBF324E0518800E6CFB2 /* scaler_int.h */,
+				92B9EBF424E0518800E6CFB2 /* filter.h */,
+			);
+			path = scaler;
+			sourceTree = "<group>";
+		};
+		92B9EBF824E0518800E6CFB2 /* media */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EBF924E0518800E6CFB2 /* media_detect_cd.h */,
+			);
+			path = media;
+			sourceTree = "<group>";
+		};
+		92B9EC7C24E0518900E6CFB2 /* gfx */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EC7D24E0518900E6CFB2 /* gl_capabilities.c */,
+				92B9EC7E24E0518900E6CFB2 /* scaler */,
+			);
+			path = gfx;
+			sourceTree = "<group>";
+		};
+		92B9EC7E24E0518900E6CFB2 /* scaler */ = {
+			isa = PBXGroup;
+			children = (
+				92B9EC7F24E0518900E6CFB2 /* scaler_int.c */,
+				92B9EC8024E0518900E6CFB2 /* pixconv.c */,
+				92B9EC8124E0518900E6CFB2 /* scaler_filter.c */,
+				92B9EC8224E0518900E6CFB2 /* scaler.c */,
+			);
+			path = scaler;
+			sourceTree = "<group>";
+		};
+		92B9EC9324E0536200E6CFB2 /* core */ = {
+			isa = PBXGroup;
+			children = (
+				92B9ECA324E053FF00E6CFB2 /* accessibility.h */,
+				92B9ECA424E053FF00E6CFB2 /* autosave.h */,
+				92B9EC9424E0537500E6CFB2 /* command.h */,
+				92B9EC9824E0537500E6CFB2 /* config.def.h */,
+				92B9EC9724E0537500E6CFB2 /* config.def.keybinds.h */,
+				92B9EC9924E0537500E6CFB2 /* config.features.h */,
+				92B9EC9524E0537500E6CFB2 /* configuration.c */,
+				92B9EC9624E0537500E6CFB2 /* configuration.h */,
+				92B9EC9A24E0537500E6CFB2 /* content.h */,
+				92B9ECBC24E054B500E6CFB2 /* core_backup.c */,
+				92B9ECBF24E054B500E6CFB2 /* core_backup.h */,
+				92B9EC9C24E0539000E6CFB2 /* core_info.c */,
+				92B9EC9D24E0539000E6CFB2 /* core_info.h */,
+				92B9EC9B24E0539000E6CFB2 /* core_type.h */,
+				92B9ECB024E054B400E6CFB2 /* core_updater_list.c */,
+				92B9ECB624E054B500E6CFB2 /* core_updater_list.h */,
+				92B9EC9E24E0539000E6CFB2 /* core.h */,
+				92B9ECC424E054B600E6CFB2 /* database_info.c */,
+				92B9ECBD24E054B500E6CFB2 /* database_info.h */,
+				92B9ECC324E054B600E6CFB2 /* defaults.h */,
+				92B9ECA624E054B300E6CFB2 /* disk_control_interface.c */,
+				92B9ECC024E054B500E6CFB2 /* disk_control_interface.h */,
+				92B9ECB524E054B400E6CFB2 /* disk_index_file.c */,
+				92B9ECBB24E054B500E6CFB2 /* disk_index_file.h */,
+				92B9ECB824E054B500E6CFB2 /* driver.h */,
+				92B9ECB224E054B400E6CFB2 /* dynamic.h */,
+				92B9ECC724E054B600E6CFB2 /* file_path_special.c */,
+				92B9ECA724E054B300E6CFB2 /* file_path_special.h */,
+				92B9ECBA24E054B500E6CFB2 /* file_path_str.c */,
+				92B9ECAD24E054B400E6CFB2 /* lakka.h */,
+				92B9ECB324E054B400E6CFB2 /* list_special.h */,
+				92B9ECAB24E054B400E6CFB2 /* manual_content_scan.c */,
+				92B9ECBE24E054B500E6CFB2 /* manual_content_scan.h */,
+				92B9ECC124E054B600E6CFB2 /* msg_hash.c */,
+				92B9ECAE24E054B400E6CFB2 /* msg_hash.h */,
+				92B9ECC224E054B600E6CFB2 /* nvda_controller.h */,
+				92B9ECAA24E054B400E6CFB2 /* paths.h */,
+				92B9ECA524E054B300E6CFB2 /* performance_counters.h */,
+				92B9EC9F24E053BD00E6CFB2 /* playlist.c */,
+				92B9ECA224E053BD00E6CFB2 /* playlist.h */,
+				92B9ECA024E053BD00E6CFB2 /* retroarch.c */,
+				92B9ECA124E053BD00E6CFB2 /* retroarch.h */,
+				92B9ECC524E054B600E6CFB2 /* runtime_file.c */,
+				92B9ECAF24E054B400E6CFB2 /* runtime_file.h */,
+				92B9ECB424E054B400E6CFB2 /* setting_list.h */,
+				92B9ECB724E054B500E6CFB2 /* switch_performance_profiles.h */,
+				92B9ECA924E054B400E6CFB2 /* translation_defines.h */,
+				92B9ECAC24E054B400E6CFB2 /* verbosity.c */,
+				92B9ECC624E054B600E6CFB2 /* verbosity.h */,
+				92B9ECB124E054B400E6CFB2 /* version_git.c */,
+				92B9ECA824E054B300E6CFB2 /* version_git.h */,
+				92B9ECB924E054B500E6CFB2 /* version.h */,
+			);
+			name = core;
 			sourceTree = "<group>";
 		};
 		92CC057E21FE3C1700FF79F0 /* GCDWebServer */ = {
@@ -304,53 +975,17 @@
 			path = WebServer;
 			sourceTree = "<group>";
 		};
-		92D3D565232D8661001B0D86 /* Sources */ = {
-			isa = PBXGroup;
-			children = (
-				92D3D566232D867C001B0D86 /* ui */,
-			);
-			path = Sources;
-			sourceTree = "<group>";
-		};
-		92D3D566232D867C001B0D86 /* ui */ = {
-			isa = PBXGroup;
-			children = (
-				92D3D567232D8688001B0D86 /* drivers */,
-				92D3D572232D8AEF001B0D86 /* ui_cocoatouch.m */,
-			);
-			path = ui;
-			sourceTree = "<group>";
-		};
-		92D3D567232D8688001B0D86 /* drivers */ = {
-			isa = PBXGroup;
-			children = (
-				92D3D568232D868E001B0D86 /* cocoa */,
-			);
-			path = drivers;
-			sourceTree = "<group>";
-		};
-		92D3D568232D868E001B0D86 /* cocoa */ = {
-			isa = PBXGroup;
-			children = (
-				92D3D56B232D86AC001B0D86 /* cocoa_common.h */,
-				92D3D56D232D86AC001B0D86 /* cocoa_common.m */,
-				92D3D56F232D86AC001B0D86 /* cocoa_defines.h */,
-				92D3D56C232D86AC001B0D86 /* cocoatouch_menu.m */,
-			);
-			path = cocoa;
-			sourceTree = "<group>";
-		};
 		96AFAE1A16C1D4EA009DE44C = {
 			isa = PBXGroup;
 			children = (
+				96AFAE9C16C1D976009DE44C /* Main Entry Core */,
+				92B9EAE024E04F8800E6CFB2 /* Sources */,
 				9222F2082315DAD50097C0FD /* Launch Screen.storyboard */,
 				9222F1FE2314BA7C0097C0FD /* assets.zip */,
-				96AFAE9C16C1D976009DE44C /* core */,
 				9210C2FA24B4CB4900E6FE7C /* menu_pipeline.metal */,
 				9210C2FB24B4CB4900E6FE7C /* Shaders.metal */,
 				83D632D719ECFCC4009E3161 /* iOS */,
 				926C77D821FD1E6500103EDE /* tvOS */,
-				92D3D565232D8661001B0D86 /* Sources */,
 				92CC05CC21FF782C00FF79F0 /* WebServer */,
 				96AFAE2816C1D4EA009DE44C /* Frameworks */,
 				96AFAE2616C1D4EA009DE44C /* Products */,
@@ -407,12 +1042,12 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
-		96AFAE9C16C1D976009DE44C /* core */ = {
+		96AFAE9C16C1D976009DE44C /* Main Entry Core */ = {
 			isa = PBXGroup;
 			children = (
 				D48581DC16F823E2004BEB17 /* griffin */,
 			);
-			name = core;
+			name = "Main Entry Core";
 			sourceTree = "<group>";
 		};
 		D48581DC16F823E2004BEB17 /* griffin */ = {


### PR DESCRIPTION
## Description

Set the default video driver to OpenGL for iOS since Metal support is still early.

Also, start adding references to RA sources to Xcode project file to make code searchable.
