### PR TITLE
[SWITCH] Fix input bind icons being off by one line

### DIFF
--- a/menu/drivers/ozone/ozone_texture.c
+++ b/menu/drivers/ozone/ozone_texture.c
@@ -468,6 +468,10 @@ uintptr_t ozone_entries_icon_get_texture(ozone_handle_t *ozone,
             input_id = MENU_SETTINGS_INPUT_BEGIN;
             if (type == input_id + 1)
                return ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_ADC];
+#ifdef HAVE_LIBNX
+            // account for the additional split joycon option in Input User # Binds
+            input_id++;
+#endif
             if (type == input_id + 2)
                return ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_SETTINGS];
             if (type == input_id + 3)

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -2899,6 +2899,10 @@ static uintptr_t xmb_icon_get_id(xmb_handle_t *xmb,
             input_id = MENU_SETTINGS_INPUT_BEGIN;
             if ( type == input_id + 1)
                return xmb->textures.list[XMB_TEXTURE_INPUT_ADC];
+#ifdef HAVE_LIBNX
+            // account for the additional split joycon option in Input # Binds
+            input_id++;
+#endif
             if ( type == input_id + 2)
                return xmb->textures.list[XMB_TEXTURE_INPUT_SETTINGS];
             if ( type == input_id + 3)


### PR DESCRIPTION
## Description

On Switch xmb and ozone menus, the dpad and button icons in Settings->Input->Port Controls are off by one, because of the additional Split Joycon option. This simple PR finally fixes that issue. 

Before this PR (notice icons off by one):
![before](https://user-images.githubusercontent.com/13071547/89851825-0754fc00-db53-11ea-860f-992cc0ebe23d.jpg)

After this PR (notice icons are now correct):
![after](https://user-images.githubusercontent.com/13071547/89851836-1176fa80-db53-11ea-9bcb-673c50cf282e.jpg)

## Related Issues

Fixes #10059
