### PR TITLE
Add API extension for cores to query the number of active inputs provided by the frontend

### DIFF
--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -1324,7 +1324,9 @@ enum retro_mod
 #define RETRO_ENVIRONMENT_GET_INPUT_MAX_USERS 61
                                            /* unsigned * --
                                             * Unsigned value is the number of active input devices
-                                            * provided by the frontend. This may change at any time.
+                                            * provided by the frontend. This may change between
+                                            * frames, but will remain constant for the duration
+                                            * of each frame.
                                             * If callback returns true, a core need not poll any
                                             * input device with an index greater than or equal to
                                             * the number of active devices.

--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -1321,6 +1321,18 @@ enum retro_mod
                                             * fallback, stderr).
                                             */
 
+#define RETRO_ENVIRONMENT_GET_INPUT_MAX_USERS 61
+                                           /* unsigned * --
+                                            * Unsigned value is the number of active input devices
+                                            * provided by the frontend. This may change at any time.
+                                            * If callback returns true, a core need not poll any
+                                            * input device with an index greater than or equal to
+                                            * the number of active devices.
+                                            * If callback returns false, the number of active input
+                                            * devices is unknown. In this case, all input devices
+                                            * should be considered active.
+                                            */
+
 /* VFS functionality */
 
 /* File paths:


### PR DESCRIPTION
## Description

This trivial PR adds a new environment callback: `RETRO_ENVIRONMENT_GET_INPUT_MAX_USERS`

This may be used by cores to query the number of 'active' input devices provided by the frontend. This allows a core to skip the polling of inputs which the frontend cannot provide (at present, all inputs must be polled regardless of whether they exist).

In addition, this PR performs the following (very minor) clean-ups:

- Core input initialisation in `secondary_core_create()` has been tweaked to match the existing behaviour in `command_event_init_controllers()` (in the original code, ports may have been set unnecessarily)

- Several hard-coded 'magic numbers' have been replaced with the correct `MAX_USERS` define