### PR TITLE
Simplify gfx_animation by switching from dynarray to rbuf

### DIFF
--- a/libretro-common/include/array/rbuf.h
+++ b/libretro-common/include/array/rbuf.h
@@ -33,6 +33,9 @@
  * The first time an element is added, memory for 16 elements are allocated.
  * Then every time length is about to exceed capacity, capacity is doubled.
  *
+ * Be careful not to supply modifying statements to the macro arguments.
+ * Something like RBUF_REMOVE(buf, i--); would have unintended results.
+ *
  * Sample usage:
  *
  * mytype_t* buf = NULL;
@@ -74,6 +77,7 @@
 #define RBUF_RESIZE(b, sz) (RBUF_FIT((b), (sz)), ((b) ? RBUF__HDR(b)->len = (sz) : 0))
 #define RBUF_CLEAR(b) ((b) ? RBUF__HDR(b)->len = 0 : 0)
 #define RBUF_TRYFIT(b, n) (RBUF_FIT((b), (n)), (((b) && RBUF_CAP(b) >= (size_t)(n)) || !(n)))
+#define RBUF_REMOVE(b, idx) memmove((b) + (idx), (b) + (idx) + 1, (--RBUF__HDR(b)->len - (idx)) * sizeof(*(b)))
 
 struct rbuf__hdr
 {


### PR DESCRIPTION
## Description

This replaces the last usage of dynarray.h with the simpler rbuf.h.

I took the liberty to clean up `case MENU_ANIMATION_CTL_DEINIT:` in `gfx_animation_ctl` because some of the code there was nonsense. I contemplated to remove the memset completely but I think it makes sense to put things back like they were at program start.

Not completely happy with the `RBUF_REMOVE` macro but I added a warning to rbuf.h, to avoid supplying modifying statements to the macro arguments. Maybe an inline function would serve better. Though it applies to other macros (like resize) as well. Also most macros in dynarray.h suffer from the same possible caveat. As usual one has to be somewhat careful with C macros.

## Related Issues
## Related Pull Requests
## Reviewers