### PR TITLE
(cheevos) ensure badge textures are released before video driver is deinitialized

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -1311,6 +1311,9 @@ bool rcheevos_unload(void)
       CHEEVOS_FREE(rcheevos_locals.richpresence.richpresence);
       rcheevos_free_patchdata(&rcheevos_locals.patchdata);
       rcheevos_memory_destroy(&rcheevos_locals.memory);
+#ifdef HAVE_MENU
+      cheevos_reset_menu_badges();
+#endif
 
       rcheevos_locals.core                      = NULL;
       rcheevos_locals.unofficial                = NULL;

--- a/gfx/widgets/gfx_widget_achievement_popup.c
+++ b/gfx/widgets/gfx_widget_achievement_popup.c
@@ -75,10 +75,8 @@ static bool gfx_widget_achievement_popup_init(bool video_is_threaded, bool fulls
    return true;
 }
 
-static void gfx_widget_achievement_popup_free(void)
+static void gfx_widget_achievement_popup_free_all(gfx_widget_achievement_popup_state_t* state)
 {
-   gfx_widget_achievement_popup_state_t* state = gfx_widget_achievement_popup_get_ptr();
-
    if (state->queue_read_index >= 0)
    {
       SLOCK_LOCK(state->queue_lock);
@@ -88,11 +86,25 @@ static void gfx_widget_achievement_popup_free(void)
 
       SLOCK_UNLOCK(state->queue_lock);
    }
+}
+
+static void gfx_widget_achievement_popup_free(void)
+{
+   gfx_widget_achievement_popup_state_t* state = gfx_widget_achievement_popup_get_ptr();
+
+   gfx_widget_achievement_popup_free_all(state);
 
 #ifdef HAVE_THREADS
    slock_free(state->queue_lock);
    state->queue_lock = NULL;
 #endif
+}
+
+static void gfx_widget_achievement_popup_context_destroy(void)
+{
+   gfx_widget_achievement_popup_state_t* state = gfx_widget_achievement_popup_get_ptr();
+
+   gfx_widget_achievement_popup_free_all(state);
 }
 
 static void gfx_widget_achievement_popup_frame(void* data, void* userdata)
@@ -405,7 +417,7 @@ const gfx_widget_t gfx_widget_achievement_popup = {
    &gfx_widget_achievement_popup_init,
    &gfx_widget_achievement_popup_free,
    NULL, /* context_reset*/
-   NULL, /* context_destroy */
+   &gfx_widget_achievement_popup_context_destroy,
    NULL, /* layout */
    NULL, /* iterate */
    &gfx_widget_achievement_popup_frame


### PR DESCRIPTION
## Description

Ensures textures associated with achievement badges are released before the video driver is deinitialized. Attempting to do so at a later time (at least in Vulkan) causes a crash.

I've made two changes. The first (and more directly related to the provided steps to reproduce) is to release the textures associated to the achievements menu when the game is unloaded. Previously, they would be released just prior to fetching the badges for the newly loaded game. That is what led to the crash. Attempting to release the textures at a point after the video driver was deinitialized (and reinitialized) caused some invalid memory address references.

The second change is a similar issue and deals with the on-screen popups. If the player happens to close the game while a popup is being displayed, the texture there has to be similarly cleaned up. To simplify things, the entire popup is discarded mid-animation.

However, as the forum post makes no mention of viewing the achievements list, there may still be another issue occurring. I was unable to generate a crash using the `crt-geom` slang shader and repeatedly opening and closing a variety of games without viewing the achievements list. That doesn't mean that it's not possible. There isn't enough information in the forum post to determine exactly what the users were doing.

The forum post also says that using GLSL shaders seems to prevent the crash, but comments that doing so also disables Vulkan. Opening the achievement list did not cause the same crash using GL or D3D11 drivers. As this seems to be limited to Vulkan, I'm going to treat that comment as misleading.

## Related Issues

https://forums.libretro.com/t/changing-content-crashes-retroarch/28588/5

## Related Pull Requests

n/a

## Reviewers

@twinaphex @hunterk @Sanaki

