### PR TITLE
WIIU: Fix touchscreen mouse emulation

### DIFF
--- a/input/common/input_hid_common.c
+++ b/input/common/input_hid_common.c
@@ -22,6 +22,8 @@ enum gamepad_pad_axes
    AXIS_LEFT_ANALOG_Y,
    AXIS_RIGHT_ANALOG_X,
    AXIS_RIGHT_ANALOG_Y,
+   AXIS_TOUCH_X,
+   AXIS_TOUCH_Y,
    AXIS_INVALID
 };
 


### PR DESCRIPTION
## Description

The way the mouse emulation worked was to simply return a 3rd axis from the
gamepad, which the polling code updates with the touch state in real time.

Well, the code that figures out if it's a positive or negative axis was
failing because it didn't see that 3rd axis as valid. So, I added values
which allow it to be seen as valid, and voila! the touch screen input
works again.

## Related Issues

resolves #10819 

## Reviewers

@QuarkTheAwesome 
