### PR TITLE
(core_updater_list) Replace static entries array with dynamic array via RBUF library

### DIFF
--- a/core_updater_list.h
+++ b/core_updater_list.h
@@ -32,10 +32,6 @@
 
 RETRO_BEGIN_DECLS
 
-/* Default maximum number of entries in
- * a core updater list */
-#define CORE_UPDATER_LIST_SIZE 9999
-
 /* Holds all date info for a core file
  * on the buildbot */
 typedef struct
@@ -69,11 +65,10 @@ typedef struct core_updater_list core_updater_list_t;
 /* Initialisation / De-Initialisation */
 /**************************************/
 
-/* Creates a new, empty core updater list with a
- * maximum number of 'max_size' entries.
+/* Creates a new, empty core updater list.
  * Returns a handle to a new core_updater_list_t object
  * on success, otherwise returns NULL. */
-core_updater_list_t *core_updater_list_init(size_t max_size);
+core_updater_list_t *core_updater_list_init(void);
 
 /* Resets (removes all entries of) specified core
  * updater list */
@@ -89,7 +84,7 @@ void core_updater_list_free(core_updater_list_t *core_list);
 /* Creates a new, empty cached core updater list
  * (i.e. 'global' list).
  * Returns false in the event of an error. */
-bool core_updater_list_init_cached(size_t max_size);
+bool core_updater_list_init_cached(void);
 
 /* Fetches cached core updater list */
 core_updater_list_t *core_updater_list_get_cached(void);
@@ -103,10 +98,6 @@ void core_updater_list_free_cached(void);
 
 /* Returns number of entries in core updater list */
 size_t core_updater_list_size(core_updater_list_t *core_list);
-
-/* Returns maximum allowed number of entries in core
- * updater list */
-size_t core_updater_list_capacity(core_updater_list_t *core_list);
 
 /* Fetches core updater list entry corresponding
  * to the specified entry index.

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -4003,7 +4003,7 @@ static int action_ok_core_updater_list(const char *path,
 
    if (!core_list)
    {
-      core_updater_list_init_cached(CORE_UPDATER_LIST_SIZE);
+      core_updater_list_init_cached();
       core_list = core_updater_list_get_cached();
 
       if (!core_list)

--- a/tasks/task_core_updater.c
+++ b/tasks/task_core_updater.c
@@ -1422,7 +1422,7 @@ void task_push_update_installed_cores(
    update_installed_handle->path_dir_libretro        = strdup(path_dir_libretro);
    update_installed_handle->path_dir_core_assets     = string_is_empty(path_dir_core_assets) ?
          NULL : strdup(path_dir_core_assets);
-   update_installed_handle->core_list                = core_updater_list_init(CORE_UPDATER_LIST_SIZE);
+   update_installed_handle->core_list                = core_updater_list_init();
    update_installed_handle->list_task                = NULL;
    update_installed_handle->download_task            = NULL;
    update_installed_handle->list_size                = 0;


### PR DESCRIPTION
## Description

When using RetroArch, a `core_updater_list` struct is created the first time the `Core Downloader` menu is accessed after each menu init, and every time the `Update Installed Cores` menu entry is selected. At present, the list is allocated as a static array with `9999` members. There are two downsides to this:

- An array of this size requires ~730 kb of RAM - this is both wasteful of memory (given the actual number of available cores) and slow to allocate

- It means we are limited to maximum of `9999` cores - it is unlikely we will ever exceed this, but artificial limits are harmful :)

This PR removes the static array allocation, and replaces it with a dynamic array (using schellingb's RBUF library). With the current number of cores on the buildbot, this reduces the basic memory consumption of the `core_updater_list` array to ~19 kb, and removes any practical limit on the number of downloadable cores.

(A small note of clarification: The memory usage indicated here is purely for the 'bare' array - this gets populated with a number of dynamically allocated strings, so the total size of the initialised `core_updater_list` is quite a bit larger. This PR just avoids all wasted allocations)
