### PR TITLE
Enhanced core downloader search functionality

### DIFF
--- a/menu/cbs/menu_cbs_cancel.c
+++ b/menu/cbs/menu_cbs_cancel.c
@@ -35,7 +35,6 @@ int action_cancel_pop_default(const char *path,
    size_t new_selection_ptr;
    const char *menu_label                = NULL;
    unsigned menu_type                    = MENU_SETTINGS_NONE;
-   bool menu_has_label                   = false;
    struct string_list *menu_search_terms = menu_driver_search_get_terms();
 #ifdef HAVE_AUDIOMIXER
    settings_t *settings                  = config_get_ptr();
@@ -47,47 +46,29 @@ int action_cancel_pop_default(const char *path,
 #endif
 
    menu_entries_get_last_stack(NULL, &menu_label, &menu_type, NULL, NULL);
-   menu_has_label = !string_is_empty(menu_label);
 
-   /* Check whether search terms have been set */
-   if (menu_search_terms)
+   /* Check whether search terms have been set
+    * > If so, check whether this is a menu list
+    *   with 'search filter' support
+    * > If so, remove the last search term */
+   if (menu_search_terms &&
+       menu_driver_search_filter_enabled(menu_label, menu_type) &&
+       menu_driver_search_pop())
    {
-      bool is_playlist = false;
+      bool refresh = false;
 
-      /* Check whether this is a playlist */
-      is_playlist = (menu_type == MENU_SETTING_HORIZONTAL_MENU) ||
-                    (menu_type == MENU_HISTORY_TAB) ||
-                    (menu_type == MENU_FAVORITES_TAB) ||
-                    (menu_type == MENU_IMAGES_TAB) ||
-                    (menu_type == MENU_MUSIC_TAB) ||
-                    (menu_type == MENU_VIDEO_TAB) ||
-                    (menu_type == FILE_TYPE_PLAYLIST_COLLECTION);
+      /* Reset navigation pointer */
+      menu_navigation_set_selection(0);
+      menu_driver_navigation_set(false);
 
-      if (!is_playlist && menu_has_label)
-         is_playlist = string_is_equal(menu_label, msg_hash_to_str(MENU_ENUM_LABEL_LOAD_CONTENT_HISTORY)) ||
-                       string_is_equal(menu_label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_FAVORITES_LIST)) ||
-                       string_is_equal(menu_label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_IMAGES_LIST)) ||
-                       string_is_equal(menu_label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_MUSIC_LIST)) ||
-                       string_is_equal(menu_label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_VIDEO_LIST));
+      /* Refresh menu */
+      menu_entries_ctl(MENU_ENTRIES_CTL_SET_REFRESH, &refresh);
+      menu_driver_ctl(RARCH_MENU_CTL_SET_PREVENT_POPULATE, NULL);
 
-      /* Remove last search term */
-      if (is_playlist && menu_driver_search_pop())
-      {
-         bool refresh = false;
-
-         /* Reset navigation pointer */
-         menu_navigation_set_selection(0);
-         menu_driver_navigation_set(false);
-
-         /* Refresh menu */
-         menu_entries_ctl(MENU_ENTRIES_CTL_SET_REFRESH, &refresh);
-         menu_driver_ctl(RARCH_MENU_CTL_SET_PREVENT_POPULATE, NULL);
-
-         return 0;
-      }
+      return 0;
    }
 
-   if (menu_has_label)
+   if (!string_is_empty(menu_label))
    {
       if (
          string_is_equal(menu_label,
@@ -127,7 +108,29 @@ static int action_cancel_core_content(const char *path,
    menu_entries_get_last_stack(NULL, &menu_label, NULL, NULL, NULL);
 
    if (string_is_equal(menu_label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_CORE_UPDATER_LIST)))
+   {
+      struct string_list *menu_search_terms = menu_driver_search_get_terms();
+
+      /* Check whether search terms have been set
+       * > If so, remove the last search term */
+      if (menu_search_terms &&
+          menu_driver_search_pop())
+      {
+         bool refresh = false;
+
+         /* Reset navigation pointer */
+         menu_navigation_set_selection(0);
+         menu_driver_navigation_set(false);
+
+         /* Refresh menu */
+         menu_entries_ctl(MENU_ENTRIES_CTL_SET_REFRESH, &refresh);
+         menu_driver_ctl(RARCH_MENU_CTL_SET_PREVENT_POPULATE, NULL);
+
+         return 0;
+      }
+
       menu_entries_flush_stack(msg_hash_to_str(MENU_ENUM_LABEL_ONLINE_UPDATER), 0);
+   }
    else if (string_is_equal(menu_label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_CORE_CONTENT_DIRS_LIST)))
       menu_entries_flush_stack(msg_hash_to_str(MENU_ENUM_LABEL_ONLINE_UPDATER), 0);
    else if (string_is_equal(menu_label, msg_hash_to_str(MENU_ENUM_LABEL_DOWNLOAD_CORE_CONTENT_DIRS)))

--- a/menu/cbs/menu_cbs_title.c
+++ b/menu/cbs/menu_cbs_title.c
@@ -74,20 +74,20 @@
    return 1; \
 }
 
-static void action_get_title_fill_playlist_default(
+static void action_get_title_fill_search_filter_default(
       char *s, enum msg_hash_enums lbl, size_t len)
 {
-   /* Copy playlist name */
+   /* Copy label value */
    strlcpy(s, msg_hash_to_str(lbl), len);
 
    /* Add current search terms */
    menu_driver_search_append_terms_string(s, len);
 }
 
-#define DEFAULT_TITLE_PLAYLIST_MACRO(func_name, lbl) \
+#define DEFAULT_TITLE_SEARCH_FILTER_MACRO(func_name, lbl) \
   static int (func_name)(const char *path, const char *label, unsigned menu_type, char *s, size_t len) \
 { \
-   action_get_title_fill_playlist_default(s, lbl, len); \
+   action_get_title_fill_search_filter_default(s, lbl, len); \
    return 0; \
 }
 
@@ -506,7 +506,6 @@ DEFAULT_TITLE_MACRO(action_get_online_updater_list,             MENU_ENUM_LABEL_
 DEFAULT_TITLE_MACRO(action_get_netplay_list,                    MENU_ENUM_LABEL_VALUE_NETPLAY)
 DEFAULT_TITLE_MACRO(action_get_online_thumbnails_updater_list,  MENU_ENUM_LABEL_VALUE_THUMBNAILS_UPDATER_LIST)
 DEFAULT_TITLE_MACRO(action_get_online_pl_thumbnails_updater_list, MENU_ENUM_LABEL_VALUE_PL_THUMBNAILS_UPDATER_LIST)
-DEFAULT_TITLE_MACRO(action_get_core_updater_list,               MENU_ENUM_LABEL_VALUE_CORE_UPDATER_LIST)
 DEFAULT_TITLE_MACRO(action_get_core_manager_list,               MENU_ENUM_LABEL_VALUE_CORE_MANAGER_LIST)
 DEFAULT_TITLE_MACRO(action_get_add_content_list,                MENU_ENUM_LABEL_VALUE_ADD_CONTENT_LIST)
 DEFAULT_TITLE_MACRO(action_get_configurations_list,             MENU_ENUM_LABEL_VALUE_CONFIGURATIONS_LIST)
@@ -671,11 +670,12 @@ DEFAULT_TITLE_MACRO(action_get_title_switch_gpu_profile,          MENU_ENUM_LABE
 DEFAULT_TITLE_MACRO(action_get_title_switch_backlight_control,    MENU_ENUM_LABEL_VALUE_SWITCH_BACKLIGHT_CONTROL)
 #endif
 
-DEFAULT_TITLE_PLAYLIST_MACRO(action_get_title_deferred_history_list,   MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_HISTORY)
-DEFAULT_TITLE_PLAYLIST_MACRO(action_get_title_deferred_favorites_list, MENU_ENUM_LABEL_VALUE_GOTO_FAVORITES)
-DEFAULT_TITLE_PLAYLIST_MACRO(action_get_title_deferred_images_list,    MENU_ENUM_LABEL_VALUE_GOTO_IMAGES)
-DEFAULT_TITLE_PLAYLIST_MACRO(action_get_title_deferred_music_list,     MENU_ENUM_LABEL_VALUE_GOTO_MUSIC)
-DEFAULT_TITLE_PLAYLIST_MACRO(action_get_title_deferred_video_list,     MENU_ENUM_LABEL_VALUE_GOTO_VIDEO)
+DEFAULT_TITLE_SEARCH_FILTER_MACRO(action_get_title_deferred_history_list,   MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_HISTORY)
+DEFAULT_TITLE_SEARCH_FILTER_MACRO(action_get_title_deferred_favorites_list, MENU_ENUM_LABEL_VALUE_GOTO_FAVORITES)
+DEFAULT_TITLE_SEARCH_FILTER_MACRO(action_get_title_deferred_images_list,    MENU_ENUM_LABEL_VALUE_GOTO_IMAGES)
+DEFAULT_TITLE_SEARCH_FILTER_MACRO(action_get_title_deferred_music_list,     MENU_ENUM_LABEL_VALUE_GOTO_MUSIC)
+DEFAULT_TITLE_SEARCH_FILTER_MACRO(action_get_title_deferred_video_list,     MENU_ENUM_LABEL_VALUE_GOTO_VIDEO)
+DEFAULT_TITLE_SEARCH_FILTER_MACRO(action_get_core_updater_list,             MENU_ENUM_LABEL_VALUE_CORE_UPDATER_LIST)
 
 static int action_get_title_generic(char *s, size_t len, const char *path,
       const char *text)
@@ -780,7 +780,7 @@ static int action_get_title_group_settings(const char *path, const char *label,
       if (string_is_equal(label, msg_hash_to_str(info_list[i].type)))
       {
          if (info_list[i].is_playlist_tab)
-            action_get_title_fill_playlist_default(
+            action_get_title_fill_search_filter_default(
                   s, info_list[i].val, len);
          else
             strlcpy(s, msg_hash_to_str(info_list[i].val), len);

--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -5124,7 +5124,7 @@ static void materialui_render_header(
    int sys_bar_text_y                    = (int)(((float)mui->sys_bar_height / 2.0f) + (float)mui->font_data.hint.line_centre_offset);
    int title_x                           = 0;
    bool show_back_icon                   = menu_entries_ctl(MENU_ENTRIES_CTL_SHOW_BACK, NULL);
-   bool show_search_icon                 = mui->is_playlist || mui->is_file_list;
+   bool show_search_icon                 = mui->is_playlist || mui->is_file_list || mui->is_core_updater_list;
    bool show_switch_view_icon            = mui->is_playlist && mui->primary_thumbnail_available;
    bool use_landscape_layout             = !mui->is_portrait &&
          (mui->last_landscape_layout_optimization != MATERIALUI_LANDSCAPE_LAYOUT_OPTIMIZATION_DISABLED);
@@ -9197,9 +9197,9 @@ static int materialui_pointer_up(void *userdata,
             /* Tap/press header: Menu back/cancel, or search/switch view */
             else if (y < header_height)
             {
-               /* If this is a playlist or file list, enable
-                * search functionality */
-               if (mui->is_playlist || mui->is_file_list)
+               /* If this is a playlist, file list or core
+                * updater list, enable search functionality */
+               if (mui->is_playlist || mui->is_file_list || mui->is_core_updater_list)
                {
                   bool switch_view_enabled  =
                         mui->is_playlist && mui->primary_thumbnail_available;

--- a/menu/menu_driver.h
+++ b/menu/menu_driver.h
@@ -487,6 +487,9 @@ void menu_explore_context_deinit(void);
 void menu_explore_free(void);
 #endif
 
+/* Returns true if search filter is enabled
+ * for the specified menu list */
+bool menu_driver_search_filter_enabled(const char *label, unsigned type);
 bool menu_driver_search_push(const char *search_term);
 bool menu_driver_search_pop(void);
 void menu_driver_search_clear(void);

--- a/retroarch.c
+++ b/retroarch.c
@@ -7285,6 +7285,33 @@ static void menu_driver_list_free(
    }
 }
 
+/* Returns true if search filter is enabled
+ * for the specified menu list */
+bool menu_driver_search_filter_enabled(const char *label, unsigned type)
+{
+   bool filter_enabled = false;
+
+   /* > Check for playlists */
+   filter_enabled = (type == MENU_SETTING_HORIZONTAL_MENU) ||
+                    (type == MENU_HISTORY_TAB) ||
+                    (type == MENU_FAVORITES_TAB) ||
+                    (type == MENU_IMAGES_TAB) ||
+                    (type == MENU_MUSIC_TAB) ||
+                    (type == MENU_VIDEO_TAB) ||
+                    (type == FILE_TYPE_PLAYLIST_COLLECTION);
+
+   if (!filter_enabled && !string_is_empty(label))
+      filter_enabled = string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_LOAD_CONTENT_HISTORY)) ||
+                       string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_FAVORITES_LIST)) ||
+                       string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_IMAGES_LIST)) ||
+                       string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_MUSIC_LIST)) ||
+                       string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_VIDEO_LIST)) ||
+                       /* > Check for core updater */
+                       string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_CORE_UPDATER_LIST));
+
+   return filter_enabled;
+}
+
 bool menu_driver_search_push(const char *search_term)
 {
    struct rarch_state *p_rarch = &rarch_st;
@@ -12035,33 +12062,18 @@ static void menu_input_search_cb(void *userdata, const char *str)
 {
    const char *label = NULL;
    unsigned type     = MENU_SETTINGS_NONE;
-   bool is_playlist  = false;
 
    if (string_is_empty(str))
       goto end;
 
    /* Determine whether we are currently
-    * viewing a playlist */
+    * viewing a menu list with 'search
+    * filter' support */
    menu_entries_get_last_stack(NULL,
          &label, &type,
          NULL, NULL);
 
-   is_playlist = (type == MENU_SETTING_HORIZONTAL_MENU) ||
-                 (type == MENU_HISTORY_TAB) ||
-                 (type == MENU_FAVORITES_TAB) ||
-                 (type == MENU_IMAGES_TAB) ||
-                 (type == MENU_MUSIC_TAB) ||
-                 (type == MENU_VIDEO_TAB) ||
-                 (type == FILE_TYPE_PLAYLIST_COLLECTION);
-
-   if (!is_playlist && !string_is_empty(label))
-      is_playlist = string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_LOAD_CONTENT_HISTORY)) ||
-                    string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_FAVORITES_LIST)) ||
-                    string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_IMAGES_LIST)) ||
-                    string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_MUSIC_LIST)) ||
-                    string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_VIDEO_LIST));
-
-   if (is_playlist)
+   if (menu_driver_search_filter_enabled(label, type))
    {
       /* Add search term */
       if (menu_driver_search_push(str))


### PR DESCRIPTION
## Description

This is a small follow-up to #11117. It adds the same search filter functionality that currently exists for playlists to the `Core Downloader` menu. This means:

- When viewing the `Core Downloader` menu, the user can press RetroPad X (or /, etc.), and enter a search term
- This becomes a filter - all matching entries will be displayed
- The user can then perform another search to further refine the results. An arbitrary number of filters may be stacked in this fashion
- Pressing 'cancel' clears the last entered filter

Here's an example:

![screen_record__2020_08_14__17_43_48](https://user-images.githubusercontent.com/38211560/90274057-d0832c80-de57-11ea-93cc-c0b032d80756.gif)

(I was doing some other core-updater-related work this morning, and it only just dawned on me how annoying it is to keep scrolling through the 170 cores available on the buildbot. This PR should aid navigation somewhat...)