### PR TITLE
(XMB+OZONE) Use correct icons in Quick Menu control ports with keyboard device type

### DIFF
--- a/menu/drivers/ozone/ozone_texture.c
+++ b/menu/drivers/ozone/ozone_texture.c
@@ -458,7 +458,7 @@ uintptr_t ozone_entries_icon_get_texture(ozone_handle_t *ozone,
 
    if (
          (type >= MENU_SETTINGS_INPUT_BEGIN) &&
-         (type <= MENU_SETTINGS_INPUT_DESC_END)
+         (type <= MENU_SETTINGS_INPUT_DESC_KBD_END)
       )
       {
          /* This part is only utilized by Input User # Binds */
@@ -492,9 +492,18 @@ uintptr_t ozone_entries_icon_get_texture(ozone_handle_t *ozone,
          else
          {
             /* Quickmenu controls repeats the same icons for all users*/
-            input_id = MENU_SETTINGS_INPUT_DESC_BEGIN;
-            while (type > (input_id + 23))
-               input_id = (input_id + 24);
+            if (type < MENU_SETTINGS_INPUT_DESC_KBD_BEGIN)
+            {
+               input_id = MENU_SETTINGS_INPUT_DESC_BEGIN;
+               while (type > (input_id + 23))
+                  input_id = (input_id + 24);
+            }
+            else
+            {
+               input_id = MENU_SETTINGS_INPUT_DESC_KBD_BEGIN;
+               while (type > (input_id + 15))
+                  input_id = (input_id + 16);
+            }
          }
          /* This is utilized for both Input Binds and Quickmenu controls*/
          if (type == input_id )

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -2889,7 +2889,7 @@ static uintptr_t xmb_icon_get_id(xmb_handle_t *xmb,
 
    if (
          (type >= MENU_SETTINGS_INPUT_BEGIN) &&
-         (type <= MENU_SETTINGS_INPUT_DESC_END)
+         (type <= MENU_SETTINGS_INPUT_DESC_KBD_END)
       )
       {
          unsigned input_id;
@@ -2923,10 +2923,17 @@ static uintptr_t xmb_icon_get_id(xmb_handle_t *xmb,
          else
          {
             /* Quickmenu controls repeats the same icons for all users */
-            input_id = MENU_SETTINGS_INPUT_DESC_BEGIN;
-            while (type > (input_id + 23))
+            if (type < MENU_SETTINGS_INPUT_DESC_KBD_BEGIN)
             {
-               input_id = (input_id + 24) ;
+               input_id = MENU_SETTINGS_INPUT_DESC_BEGIN;
+               while (type > (input_id + 23))
+                  input_id = (input_id + 24);
+            }
+            else
+            {
+               input_id = MENU_SETTINGS_INPUT_DESC_KBD_BEGIN;
+               while (type > (input_id + 15))
+                  input_id = (input_id + 16);
             }
          }
          /* This is utilized for both Input # Binds and Quickmenu controls */


### PR DESCRIPTION
Keyboard device type is currently showing generic icons on all binds instead of descriptive icons like the other types.

Identical fix applied to both menu drivers.

Did try to change the "Analog to Digital Type" icon too like it is in the main input menu, but did not figure it out..
