### PR TITLE
Implement support for Play Store builds using Play Feature Delivery (Java/Gradle)

### DIFF
--- a/pkg/android/phoenix/.gitignore
+++ b/pkg/android/phoenix/.gitignore
@@ -2,4 +2,10 @@
 .externalNativeBuild
 build
 phoenix.iml
-
+output.json
+keystore.properties
+modules/
+settings.gradle
+dynamic_features.gradle
+res/values/core_names.xml
+res/values/module_names_*.xml

--- a/pkg/android/phoenix/AndroidManifest.xml
+++ b/pkg/android/phoenix/AndroidManifest.xml
@@ -16,12 +16,14 @@
     <uses-permission android:name="android.permission.VIBRATE" />
 
     <application
+        android:name="com.google.android.play.core.splitcompat.SplitCompatApplication"
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:hasCode="true"
         android:isGame="true"
         android:banner="@drawable/banner"
+        android:extractNativeLibs="true"
         tools:ignore="UnusedAttribute">
         <activity android:name="com.retroarch.browser.mainmenu.MainMenuActivity" android:exported="true" android:launchMode="singleInstance">
             <intent-filter>

--- a/pkg/android/phoenix/build.gradle
+++ b/pkg/android/phoenix/build.gradle
@@ -37,12 +37,14 @@ android {
   productFlavors {
     normal {
       resValue "string", "app_name", "RetroArch"
+      buildConfigField "boolean", "PLAY_STORE_BUILD", "false"
 
       dimension "variant"
     }
     aarch64 {
       applicationIdSuffix '.aarch64'
       resValue "string", "app_name", "RetroArch (AArch64)"
+      buildConfigField "boolean", "PLAY_STORE_BUILD", "false"
 
       dimension "variant"
       ndk {
@@ -52,10 +54,27 @@ android {
     ra32 {
       applicationIdSuffix '.ra32'
       resValue "string", "app_name", "RetroArch (32-bit)"
+      buildConfigField "boolean", "PLAY_STORE_BUILD", "false"
 
       dimension "variant"
       ndk {
         abiFilters 'armeabi-v7a', 'x86'
+      }
+    }
+    playStoreNormal {
+      resValue "string", "app_name", "RetroArch"
+      buildConfigField "boolean", "PLAY_STORE_BUILD", "true"
+
+      dimension "variant"
+    }
+    playStoreAarch64 {
+      applicationIdSuffix '.aarch64'
+      resValue "string", "app_name", "RetroArch (AArch64)"
+      buildConfigField "boolean", "PLAY_STORE_BUILD", "true"
+
+      dimension "variant"
+      ndk {
+        abiFilters 'arm64-v8a', 'x86_64'
       }
     }
   }
@@ -67,10 +86,10 @@ android {
       java.srcDirs = ['src', '../phoenix-common/src']
       jniLibs.srcDir '../phoenix-common/libs'
       jni.srcDirs = []
-      res.srcDirs = ['../phoenix-common/res']
+      res.srcDirs = ['res', '../phoenix-common/res']
     }
     aarch64 {
-      res.srcDirs = ['res64']
+      res.srcDirs = ['res', 'res64']
     }
   }
 
@@ -103,4 +122,13 @@ android {
       }
     }
   }
+}
+
+dependencies {
+  implementation 'com.google.android.play:core:1.8.0'
+}
+
+def dynamicFeatures = file("dynamic_features.gradle")
+if(dynamicFeatures.exists()) {
+  apply from: "dynamic_features.gradle"
 }

--- a/pkg/android/phoenix/init_modules.sh
+++ b/pkg/android/phoenix/init_modules.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+# This script generates Gradle modules for each Android core,
+# so that they can be served by Google Play as Dynamic Feature Modules.
+# Run "./init_modules.sh" to generate modules, or "./init_modules.sh clean" to remove them
+
+# These paths assume that this script is running inside libretro-super,
+# and that the compiled Android cores are available while this script is run
+RECIPES_PATH="../../../../recipes/android"
+INFO_PATH="../../../../dist/info"
+CORES_PATH="../../../../dist/android"
+
+# Get the list of Android cores to generate modules for
+CORES_LIST=$(cat module_list.txt)
+
+# The below command would generate a module for every single Android core,
+# but Dynamic Feature Modules enforces a 50-module limit
+#CORES_LIST=$(find $RECIPES_PATH -type f ! -name '*.*' -exec cat {} + | awk '{ split($1, test, " "); print test[1] }' | grep "\S")
+
+# Delete any leftover files from previous script runs
+rm -rf modules
+rm -f res/values/core_names.xml
+rm -f res/values/module_names_*.xml
+rm -f dynamic_features.gradle
+rm -f settings.gradle
+
+if [[ $1 = clean ]] ; then
+  exit 1
+fi
+
+# Make directory for modules to be stored in
+mkdir -p modules
+mkdir -p res/values
+
+# Begin generating files with necessary metadata
+# for compiling Dynamic Feature Modules
+echo "<resources>" >> res/values/core_names.xml
+echo "android {" >> dynamic_features.gradle
+echo "dynamicFeatures = [" >> dynamic_features.gradle
+
+for arch in armeabi-v7a arm64-v8a x86 x86_64
+do
+  SANITIZED_ARCH_NAME=$(echo $arch | sed "s/-/_/g")
+  echo "<resources>" >> res/values/module_names_$arch.xml
+  echo "<string-array name=\"module_names_$SANITIZED_ARCH_NAME\">" >> res/values/module_names_$arch.xml
+done
+
+# Time to generate a module for each core!
+while IFS= read -r core; do
+  SANITIZED_CORE_NAME=$(echo $core | sed "s/-/_/g")
+  DISPLAY_NAME=$(cat $INFO_PATH/${core}_libretro.info | grep "display_name" | cut -d'"' -f 2)
+
+  echo "Generating module for $core..."
+
+  # Make a copy of the template
+  cp -r module_template modules/$SANITIZED_CORE_NAME
+
+  # Write the name of the core into AndroidManifest.xml
+  if [[ "$OSTYPE" == "darwin"* ]]
+  then
+    sed -i '' "s/%CORE_NAME%/$SANITIZED_CORE_NAME/g" modules/$SANITIZED_CORE_NAME/AndroidManifest.xml
+  else
+    sed -i "s/%CORE_NAME%/$SANITIZED_CORE_NAME/g" modules/$SANITIZED_CORE_NAME/AndroidManifest.xml
+  fi
+
+  # Create a libs directory for each architecture,
+  # and copy the libretro core into each directory
+  for arch in armeabi-v7a arm64-v8a x86 x86_64
+  do
+    mkdir -p modules/$SANITIZED_CORE_NAME/libs/$arch
+
+    if [[ -e $CORES_PATH/$arch/${core}_libretro_android.so ]]
+    then
+      ln -s  ../../../../$CORES_PATH/$arch/${core}_libretro_android.so modules/$SANITIZED_CORE_NAME/libs/$arch/lib$core.so
+    else
+      touch modules/$SANITIZED_CORE_NAME/libs/$arch/lib$core.so
+    fi
+
+    if [[ -s "modules/$SANITIZED_CORE_NAME/libs/$arch/lib$core.so" ]]
+    then
+      echo "<item>$core</item>" >> res/values/module_names_$arch.xml
+    fi
+  done
+
+  # Write metadata about the module into the corresponding files
+  echo "<string name=\"core_name_$SANITIZED_CORE_NAME\">$DISPLAY_NAME</string>" >> res/values/core_names.xml
+  echo "':modules:$SANITIZED_CORE_NAME'," >> dynamic_features.gradle
+  echo "include ':modules:$SANITIZED_CORE_NAME'" >> settings.gradle
+done <<< "$CORES_LIST"
+
+# Finish generating the metadata files
+echo "</resources>" >> res/values/core_names.xml
+echo "]" >> dynamic_features.gradle
+echo "}" >> dynamic_features.gradle
+
+for arch in armeabi-v7a arm64-v8a x86 x86_64
+do
+  echo "</string-array>" >> res/values/module_names_$arch.xml
+  echo "</resources>" >> res/values/module_names_$arch.xml
+done

--- a/pkg/android/phoenix/module_list.txt
+++ b/pkg/android/phoenix/module_list.txt
@@ -1,0 +1,5 @@
+genesis_plus_gx
+mesen-s
+dolphin
+mupen64plus_next_gles3
+flycast

--- a/pkg/android/phoenix/module_template/AndroidManifest.xml
+++ b/pkg/android/phoenix/module_template/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:dist="http://schemas.android.com/apk/distribution"
+    package="com.retroarch.core_modules.%CORE_NAME%">
+
+    <dist:module dist:title="@string/core_name_%CORE_NAME%">
+        <dist:delivery>
+            <dist:on-demand />
+        </dist:delivery>
+        <dist:fusing dist:include="true" />
+    </dist:module>
+
+    <application
+      android:hasCode="false"
+      android:extractNativeLibs="true" />
+
+</manifest>

--- a/pkg/android/phoenix/module_template/build.gradle
+++ b/pkg/android/phoenix/module_template/build.gradle
@@ -1,0 +1,49 @@
+apply plugin: 'com.android.dynamic-feature'
+
+android {
+  compileSdkVersion 28
+  defaultConfig {
+    minSdkVersion 16
+    targetSdkVersion 28
+  }
+
+  flavorDimensions "variant"
+
+  productFlavors {
+    normal {
+      dimension "variant"
+    }
+    aarch64 {
+      dimension "variant"
+      ndk {
+        abiFilters 'arm64-v8a', 'x86_64'
+      }
+    }
+    ra32 {
+      dimension "variant"
+      ndk {
+        abiFilters 'armeabi-v7a', 'x86'
+      }
+    }
+    playStoreNormal {
+      dimension "variant"
+    }
+    playStoreAarch64 {
+      dimension "variant"
+      ndk {
+        abiFilters 'arm64-v8a', 'x86_64'
+      }
+    }
+  }
+
+  sourceSets {
+    main {
+      manifest.srcFile 'AndroidManifest.xml'
+      jniLibs.srcDirs = ['libs']
+    }
+  }
+}
+
+dependencies {
+  implementation rootProject
+}


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

(I know the libretro team has bigger fish to fry right now, but just wanted to get this out there for when you guys are done with the buildbot mess...)

This adds the Java/Gradle portion of the work needed to bring RetroArch into Play Store compliance.  This implementation uses [Play Feature Delivery](https://developer.android.com/guide/playcore/dynamic-delivery), which I believe is the best solution with the fewest drawbacks.

Under this model, cores will be downloaded directly from Google Play as extra features for the RetroArch app.  These features are known as "dynamic feature modules".

None of the C work has been done yet since I'm not a C developer :) But hopefully these changes make it very simple for the C portion of the work to be picked up easily.

### Setup

Play Feature Delivery requires the Gradle project be split up into multiple modules, in this case, one for each core.  To keep things simple and less-burdensome to the RetroArch maintainers, I've written a Bash script that must be run in order to generate these modules using a set of precompiled cores and the core info files from libretro-super.  Because there is a limit of 50 cores allowed to be served via Play Feature Delivery, the Bash script works off of a predetermined list of cores.

(As I mentioned a few days ago, we can certainly bundle multiple cores into one module, but the work in this PR assumes one core per module for simplicity's sake.  Let me know if we do decide to go down the multiple cores per module route and I can make the necessary modifications to this PR.)

Basically, in order to set up these Gradle modules:

* Ensure that the build environment has access to both the precompiled Android cores as well as the core info files.  I'm assuming that the RetroArch checkout is located inside the libretro-super checkout, and that precompiled cores are located inside `dist/android`.  (I don't know the details on how the buildbot works (worked?), so please let me know if something needs to change)

* Inside `pkg/android/phoenix`, edit the `modules_list.txt` file with each core that you are wanting to generate a module for.  (There are already a few example modules listed in that file, but those were purely for my testing purposes.  The list of ~50 modules will still need to be come up with)

* Run the `./init_modules.sh` script to generate the modules themselves.

Once the modules have been set up, the app will need to be built as an Android App Bundle instead of as an APK, by running `./gradlew bundlePlayStoreNormalRelease` (or `./gradlew bundlePlayStoreAarch64Release`). Using the Android App Bundle format is a requirement for Play Feature Delivery.

To build the non-Play Store variants of the app (for distribution on the website and via F-Droid), you would first call `./init_modules.sh clean` before building standard APKs via `./gradlew assembleNormalRelease`, etc.

Running the `init_modules.sh` script needs to be done manually right now, but I can certainly automate running it via Gradle if desired, based off of which app variant is being built.

### Java APIs

I've added a set of Java APIs to RetroActivityCommon that should be easily accessible from NDK-land, so that the C portion of this work can more easily be done.

* `isPlayStoreBuild()` - This returns true if the app was built as a Play Store variant.  Two new Gradle build variants were added with this PR, `playStoreNormal` and `playStoreAarch64`.  The only difference between these variants and the others is setting the `PLAY_STORE_BUILD` flag to true inside of the BuildConfig.  This could be used to determine whether to disable or enable the standard Core Updater.

* `getAvailableCores()` - This returns a string array with a list of all cores available for download via Play Feature Delivery.  This list would replace the standard list of cores from the buildbot (RIP).

* `getInstalledCores()` - This gets the list of installed cores that were downloaded using Play Feature Delivery.  It does not include any cores that were downloaded via the standard Core Updater before an app upgrade.

* `downloadCore()` - This asks Google Play to download a specific core as a dynamic feature module.

* `deleteCore()` - This asks Google Play to delete a module that has already been downloaded.

There are also a couple of JNI callbacks that will need to be implemented inside the C code so that RetroArch can monitor the status of downloaded cores:

* `coreInstallInitiated()` - This will signify to RetroArch that a core install was successfully initiated (or failed).

* `coreInstallStatusChanged()` - Called whenever a status update on a core download occurs, passing in the number of bytes currently downloaded and the total amount of bytes to download.

I have no idea how the main C portion of RetroArch's code actually works, so if any of these details needs to change, please let me know.

### Symlinking installed cores

Play Feature Delivery downloads cores into one of two different locations (one temporary and the other more permanent), each of which is different from where RetroArch normally installs cores.  In addition, this location is subject to change by the Android system at different points in time.  Because of this, I added some code inside RetroActivityCommon that scans the filesystem for `.so` files kept inside these locations and symlinks them inside the RetroArch `cores` folder.  This code runs once at RetroArch startup and again whenever a core has finished downloading.

Another thing to note is that when the app requests that a module is deleted, the system will actually defer the module uninstallation to a later point in time.  Because there is no way to ask the system to delete a module immediately, we instead delete the symlink inside the `cores` folder and then add the core to a list of deleted cores kept inside `SharedPreferences`.  That way, when the filesystem scan runs, it checks each `.so` file it finds against this list of deleted cores, and if a core is on the list, it will decide not to create the symlink.

### Testing

Unfortunately, the only real way to test Play Feature Delivery is to upload builds to the Play Store itself.  I can help set up an internal test track for RetroArch's Play Store listing if needed, or I can also just mock the actual Play Feature Delivery stuff out if that'd be easier.  Just let me know what you'd like help with :)

## Related Issues

None, but see https://www.libretro.com/index.php/retroarch-1-9-0-wont-be-releasing-on-google-play-store-for-now/

## Related Pull Requests

None

## Reviewers

@twinaphex 
