### PR TITLE
(cheevos) eliminate exposed variables for tracking hardcore

### DIFF
--- a/cheevos/cheevos.h
+++ b/cheevos/cheevos.h
@@ -53,7 +53,8 @@ void rcheevos_pause_hardcore();
 
 bool rcheevos_unload(void);
 
-bool rcheevos_toggle_hardcore_mode(void);
+void rcheevos_hardcore_enabled_changed(void);
+void rcheevos_toggle_hardcore_paused(void);
 
 void rcheevos_test(void);
 
@@ -67,10 +68,7 @@ const char *rcheevos_get_richpresence(void);
 
 uint8_t* rcheevos_patch_address(unsigned address);
 
-extern bool rcheevos_loaded;
-extern bool rcheevos_hardcore_active;
-extern bool rcheevos_hardcore_paused;
-extern bool rcheevos_state_loaded_flag;
+bool rcheevos_hardcore_active(void);
 
 RETRO_END_DECLS
 

--- a/managers/cheat_manager.c
+++ b/managers/cheat_manager.c
@@ -108,11 +108,8 @@ void cheat_manager_apply_cheats(void)
    }
 
 #ifdef HAVE_CHEEVOS
-   if (idx != 0)
-      if (     rcheevos_hardcore_active 
-            && rcheevos_loaded 
-            && !rcheevos_hardcore_paused)
-         cheat_manager_pause_cheevos();
+   if (idx != 0 && rcheevos_hardcore_active())
+      cheat_manager_pause_cheevos();
 #endif
 }
 
@@ -1568,11 +1565,8 @@ void cheat_manager_apply_retro_cheats(void)
    }
 
 #ifdef HAVE_CHEEVOS
-   if (cheat_applied)
-      if (     rcheevos_hardcore_active 
-            && rcheevos_loaded 
-            && !rcheevos_hardcore_paused)
-         cheat_manager_pause_cheevos();
+   if (cheat_applied && rcheevos_hardcore_active())
+      cheat_manager_pause_cheevos();
 #endif
 }
 

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -85,10 +85,6 @@
 #include "../../network/netplay/netplay_discovery.h"
 #endif
 
-#ifdef HAVE_CHEEVOS
-#include "../../cheevos/cheevos.h"
-#endif
-
 #ifdef __WINRT__
 #include "../../uwp/uwp_func.h"
 #endif
@@ -3965,9 +3961,6 @@ static int action_ok_save_state(const char *path,
 static int action_ok_cheevos_toggle_hardcore_mode(const char *path,
       const char *label, unsigned type, size_t idx, size_t entry_idx)
 {
-#ifdef HAVE_CHEEVOS
-   rcheevos_hardcore_paused = !rcheevos_hardcore_paused;
-#endif
    generic_action_ok_command(CMD_EVENT_CHEEVOS_HARDCORE_MODE_TOGGLE);
    return generic_action_ok_command(CMD_EVENT_RESUME);
 }

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -2509,7 +2509,7 @@ static int menu_displaylist_parse_load_content_settings(
             count++;
 
 #ifdef HAVE_CHEEVOS
-         if (!rcheevos_hardcore_active)
+         if (!rcheevos_hardcore_active())
 #endif
          {
             if (menu_entries_append_enum(list,
@@ -2525,7 +2525,7 @@ static int menu_displaylist_parse_load_content_settings(
           settings->bools.quick_menu_show_undo_save_load_state)
       {
 #ifdef HAVE_CHEEVOS
-         if (!rcheevos_hardcore_active)
+         if (!rcheevos_hardcore_active())
 #endif
          {
             if (menu_entries_append_enum(list,

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -7389,16 +7389,7 @@ static void change_handler_video_layout_selected_view(rarch_setting_t *setting)
 #ifdef HAVE_CHEEVOS
 static void achievement_hardcore_mode_write_handler(rarch_setting_t *setting)
 {
-   settings_t *settings  = config_get_ptr();
-
-   if (!setting)
-      return;
-
-   if (settings && settings->bools.cheevos_enable && settings->bools.cheevos_hardcore_mode_enable)
-   {
-      rcheevos_toggle_hardcore_mode();
-      command_event(CMD_EVENT_RESET, NULL);
-   }
+   rcheevos_hardcore_enabled_changed();
 }
 #endif
 

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -1059,10 +1059,10 @@ static bool content_file_load(
       if (type == RARCH_CONTENT_NONE && !string_is_empty(content_path))
          rcheevos_load(info);
       else
-         rcheevos_hardcore_paused = true;
+         rcheevos_pause_hardcore();
    }
    else
-      rcheevos_hardcore_paused = true;
+      rcheevos_pause_hardcore();
 #endif
 
    return true;


### PR DESCRIPTION
## Description

This is primarily addressing a TODO in the code: `/* TODO/FIXME - public global variables */`

The associated variables have been moved into the `rcheevos_locals` statically-scoped structure. A new method `rcheevos_hardcore_active()` has been added, which allows any external code the ability to determine if hardcore is currently being enforced. This replaces several places that were checking for a combination of the previously exposed variables.

Additionally, the logic for toggling enabled/disabled/paused has been modified to better track state. This eliminates the "spams duplicate notifications" noted in #10710:
> * Settings > Achievements > Hardcore Mode
>   * Spams duplicate notifications

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@Sanaki @meleu 
