### PR TITLE
libretro.h: Fix contradictory comment

### DIFF
--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -2672,7 +2672,7 @@ struct retro_input_descriptor
 struct retro_system_info
 {
    /* All pointers are owned by libretro implementation, and pointers must
-    * remain valid until retro_deinit() is called. */
+    * remain valid until it is unloaded. */
 
    const char *library_name;      /* Descriptive name of library. Should not
                                    * contain any version numbers, etc. */


### PR DESCRIPTION
retro_get_system_info() says it can be called even before retro_init(), which means retro_deinit() doesn't need to be called at all. Mentioning deinit() in the struct definition is misleading and incorrect.

## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

[Description of the pull request, detail any issues you are fixing or any features you are implementing]

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
