### PR TITLE
fix compile error

### DIFF
--- a/libretro-common/cdrom/cdrom.c
+++ b/libretro-common/cdrom/cdrom.c
@@ -1403,9 +1403,9 @@ struct string_list* cdrom_get_available_drives(void)
          
          if (string_split_noalloc(&mods, buf, "\n"))
          {
-            for (i = 0; i < mods->size; i++)
+            for (i = 0; i < mods.size; i++)
             {
-               if (strcasestr(mods->elems[i].data, "sg "))
+               if (strcasestr(mods.elems[i].data, "sg "))
                {
 #ifdef CDROM_DEBUG
                   found = true;


### PR DESCRIPTION
```
libretro-common/cdrom/cdrom.c: In function ‘cdrom_get_available_drives’:
libretro-common/cdrom/cdrom.c:1406:33: error: invalid type argument of ‘->’ (have ‘struct string_list’)
             for (i = 0; i < mods->size; i++)
                                 ^~
libretro-common/cdrom/cdrom.c:1408:35: error: invalid type argument of ‘->’ (have ‘struct string_list’)
                if (strcasestr(mods->elems[i].data, "sg "))
                                   ^~
```

regression introduced by 662e37f67010bbb5c099e4f6d83f108d7f9446c4