### PR TITLE
Fix 'Set Core Association' regression

### DIFF
--- a/core_info.c
+++ b/core_info.c
@@ -911,7 +911,7 @@ void core_info_get_name(const char *path, char *s, size_t len,
       bool get_display_name)
 {
    size_t i;
-   struct string_list contents;
+   struct string_list contents      = {0};
    const char       *path_basedir   = !string_is_empty(path_info) ?
       path_info : dir_cores;
    const char *core_path_basename   = path_basename(path);

--- a/libretro-common/include/lists/dir_list.h
+++ b/libretro-common/include/lists/dir_list.h
@@ -64,6 +64,9 @@ bool dir_list_append(struct string_list *list, const char *dir, const char *ext,
 struct string_list *dir_list_new(const char *dir, const char *ext,
       bool include_dirs, bool include_hidden, bool include_compressed, bool recursive);
 
+/* Warning: 'list' must zero initialised before
+ * calling this function, otherwise memory leaks/
+ * undefined behaviour will occur */
 bool dir_list_initialize(struct string_list *list,
       const char *dir,
       const char *ext, bool include_dirs,

--- a/libretro-common/lists/dir_list.c
+++ b/libretro-common/lists/dir_list.c
@@ -264,14 +264,17 @@ struct string_list *dir_list_new(const char *dir,
    return list;
 }
 
+/* Warning: 'list' must zero initialised before
+ * calling this function, otherwise memory leaks/
+ * undefined behaviour will occur */
 bool dir_list_initialize(struct string_list *list,
       const char *dir,
       const char *ext, bool include_dirs,
       bool include_hidden, bool include_compressed,
       bool recursive)
 {
-   if (!list)
-      return NULL;
+   if (!list || !string_list_initialize(list))
+      return false;
    return dir_list_append(list, dir, ext, include_dirs,
             include_hidden, include_compressed, recursive);
 }

--- a/libretro-common/lists/string_list.c
+++ b/libretro-common/lists/string_list.c
@@ -168,8 +168,15 @@ bool string_list_append(struct string_list *list, const char *elem,
 {
    char *data_dup = NULL;
 
+   /* Note: If 'list' is incorrectly initialised
+    * (i.e. if struct is zero initialised and
+    * string_list_initialize() is not called on
+    * it) capacity will be zero. This will cause
+    * a segfault. Handle this case by forcing the new
+    * capacity to a fixed size of 32 */
    if (list->size >= list->cap &&
-         !string_list_capacity(list, list->cap * 2))
+         !string_list_capacity(list,
+               (list->cap > 0) ? (list->cap * 2) : 32))
       return false;
 
    data_dup = strdup(elem);

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -4623,12 +4623,15 @@ static int action_ok_reset_core_association(const char *path,
       const char *label, unsigned type, size_t idx, size_t entry_idx)
 {
    menu_handle_t *menu                 = menu_driver_get_ptr();
+   size_t playlist_index;
 
    if (!menu)
       return menu_cbs_exit();
 
+   playlist_index = (size_t)menu->rpl_entry_selection_ptr;
+
    if (!command_event(CMD_EVENT_RESET_CORE_ASSOCIATION,
-            (void *)&menu->rpl_entry_selection_ptr))
+            (void *)&playlist_index))
       return menu_cbs_exit();
    return 0;
 }


### PR DESCRIPTION
## Description

This PR fixes a recent regression that caused a segfault when attempting to set the core association of any playlist entry.

It also fixes an alignment issue in `action_ok_reset_core_association()` (not sure why this never showed up before...)

## Related Issues

This closes  #11244
