### PR TITLE
[Android] Minor fixes for Play Feature Delivery

### DIFF
--- a/pkg/android/phoenix-common/src/com/retroarch/browser/retroactivity/RetroActivityCommon.java
+++ b/pkg/android/phoenix-common/src/com/retroarch/browser/retroactivity/RetroActivityCommon.java
@@ -47,6 +47,10 @@ import java.util.Locale;
  */
 public class RetroActivityCommon extends NativeActivity
 {
+  static {
+    System.loadLibrary("retroarch-activity");
+  }
+
   public static int FRONTEND_POWERSTATE_NONE = 0;
   public static int FRONTEND_POWERSTATE_NO_SOURCE = 1;
   public static int FRONTEND_POWERSTATE_CHARGING = 2;

--- a/pkg/android/phoenix/build.gradle
+++ b/pkg/android/phoenix/build.gradle
@@ -14,6 +14,12 @@ allprojects {
         google()
         jcenter()
     }
+
+    Properties props = new Properties()
+    props.load(new FileInputStream(new File(project.rootDir, "retroarch.properties")))
+    props.each { prop ->
+        project.ext.set(prop.key, prop.value)
+    }
 }
 
 apply plugin: 'com.android.application'

--- a/pkg/android/phoenix/retroarch.properties
+++ b/pkg/android/phoenix/retroarch.properties
@@ -1,0 +1,1 @@
+android.bundle.enableUncompressedNativeLibs=false


### PR DESCRIPTION
## Description

This includes a couple of minor fixes that came up while I was testing #11255:

* The app would crash whenever it called one of the JNI methods that I added inside RetroActivityCommon.  This is fixed by asking the system to load the `retroarch-activity` library so that the system can successfully call into C code from Java.
* The `android:extractNativeLibs` attribute inside AndroidManifest.xml was not being respected when building the app as an Android App Bundle.  This is fixed by applying the `android.bundle.enableUncompressedNativeLibs` Gradle property.