### PR TITLE
[Android] Fix possible crashes from AudioManger properties returning null

### DIFF
--- a/pkg/android/phoenix-common/src/com/retroarch/browser/preferences/util/UserPreferences.java
+++ b/pkg/android/phoenix-common/src/com/retroarch/browser/preferences/util/UserPreferences.java
@@ -129,7 +129,11 @@ public final class UserPreferences
 		final SharedPreferences prefs = getPreferences(ctx);
 
 		config.setString("libretro_directory", coreDir);
-		config.setInt("audio_out_rate", getOptimalSamplingRate(ctx));
+
+		int samplingRate = getOptimalSamplingRate(ctx);
+		if (samplingRate != -1) {
+			config.setInt("audio_out_rate", samplingRate);
+		}
 
 		try
 		{
@@ -152,7 +156,10 @@ public final class UserPreferences
 		// Refactor this entire mess and make this usable for per-core config
 		if (Build.VERSION.SDK_INT >= 17 && prefs.getBoolean("audio_latency_auto", true))
 		{
-			config.setInt("audio_block_frames", getLowLatencyBufferSize(ctx));
+			int bufferSize = getLowLatencyBufferSize(ctx);
+			if (bufferSize != -1) {
+				config.setInt("audio_block_frames", bufferSize);
+			}
 		}
 
 		try
@@ -250,9 +257,13 @@ public final class UserPreferences
 	private static int getLowLatencyOptimalSamplingRate(Context ctx)
 	{
 		AudioManager manager = (AudioManager) ctx.getSystemService(Context.AUDIO_SERVICE);
+		String value = manager.getProperty(AudioManager.PROPERTY_OUTPUT_SAMPLE_RATE);
 
-		return Integer.parseInt(manager
-				.getProperty(AudioManager.PROPERTY_OUTPUT_SAMPLE_RATE));
+		if(value == null || value.isEmpty()) {
+			return -1;
+		}
+
+		return Integer.parseInt(value);
 	}
 
 	/**
@@ -266,8 +277,13 @@ public final class UserPreferences
 	private static int getLowLatencyBufferSize(Context ctx)
 	{
 		AudioManager manager = (AudioManager) ctx.getSystemService(Context.AUDIO_SERVICE);
-		int buffersize = Integer.parseInt(manager
-				.getProperty(AudioManager.PROPERTY_OUTPUT_FRAMES_PER_BUFFER));
+		String value = manager.getProperty(AudioManager.PROPERTY_OUTPUT_FRAMES_PER_BUFFER);
+
+		if(value == null || value.isEmpty()) {
+			return -1;
+		}
+
+		int buffersize = Integer.parseInt(value);
 		Log.i(TAG, "Queried ideal buffer size (frames): " + buffersize);
 		return buffersize;
 	}


### PR DESCRIPTION
## Description

This fixes crashes that may occur when querying properties from the AudioManager when determining the optimal sampling rate or low latency buffer size.