### PR TITLE
International: Language translations fix

### DIFF
--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -6759,7 +6759,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_LANG_ARABIC,
-   "Arabic - اَلْعَرَبِيَّةُ‎ (Restart Required)"
+   "Arabic -  اَلْعَرَبِيَّةُ  (Restart Required)"
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_LANG_ASTURIAN,
@@ -6859,7 +6859,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_LANG_HEBREW,
-   "Hebrew - עִבְרִית‎"
+   "Hebrew - עִבְרִית"
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_LANG_HINDI,
@@ -6927,7 +6927,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_LANG_PERSIAN,
-   "Persian - فارسی (Restart Required)"
+   "Persian -  فارسی  (Restart Required)"
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_LANG_POLISH,
@@ -6995,7 +6995,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_LANG_URDU,
-   "Urdu - اُردُو (Restart Required)"
+   "Urdu -  اُردُو  (Restart Required)"
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_LANG_VIETNAMESE,


### PR DESCRIPTION
## Description

International: Language translations fix:

- Fixes right to left language names appearing with unrecognized characters, and misplaced parenthesis and hyphen in the menu
**The extra spaces are not actual spaces but invisible break characters to separate the right to left languages from the hyphen and parenthesis**

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/11128

## Reviewers

@twinaphex