### PR TITLE
(Android) Play Store builds: Do not resolve symlinks when handling core paths

### DIFF
--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -2168,7 +2168,7 @@ static int action_ok_playlist_entry_collection(const char *path,
    if (!string_is_empty(entry->path))
    {
       strlcpy(content_path, entry->path, sizeof(content_path));
-      playlist_resolve_path(PLAYLIST_LOAD, content_path, sizeof(content_path));
+      playlist_resolve_path(PLAYLIST_LOAD, false, content_path, sizeof(content_path));
    }
 
    /* Cache entry label */
@@ -2239,7 +2239,7 @@ static int action_ok_playlist_entry_collection(const char *path,
             /* Core path is invalid - just copy what we have
              * and hope for the best... */
             strlcpy(core_path, entry->core_path, sizeof(core_path));
-            playlist_resolve_path(PLAYLIST_LOAD, core_path, sizeof(core_path));
+            playlist_resolve_path(PLAYLIST_LOAD, true, core_path, sizeof(core_path));
          }
       }
    }
@@ -3284,7 +3284,7 @@ static int action_ok_core_deferred_set(const char *new_core_path,
          true);
 
    strlcpy(resolved_core_path, new_core_path, sizeof(resolved_core_path));
-   playlist_resolve_path(PLAYLIST_SAVE, resolved_core_path, sizeof(resolved_core_path));
+   playlist_resolve_path(PLAYLIST_SAVE, true, resolved_core_path, sizeof(resolved_core_path));
 
    /* the update function reads our entry
     * as const, so these casts are safe */

--- a/playlist.h
+++ b/playlist.h
@@ -223,7 +223,8 @@ void playlist_delete_by_path(playlist_t *playlist,
 /**
  * playlist_resolve_path:
  * @mode      : PLAYLIST_LOAD or PLAYLIST_SAVE
- * @path        : The path to be modified
+ * @is_core   : Set true if path to be resolved is a core file
+ * @path      : The path to be modified
  *
  * Resolves the path of an item, such as the content path or path to the core, to a format
  * appropriate for saving or loading depending on the @mode parameter
@@ -233,7 +234,7 @@ void playlist_delete_by_path(playlist_t *playlist,
  * install (iOS)
  **/
 void playlist_resolve_path(enum playlist_file_mode mode,
-      char *path, size_t len);
+      bool is_core, char *path, size_t len);
 
 /**
  * playlist_push:

--- a/retroarch.c
+++ b/retroarch.c
@@ -20305,6 +20305,17 @@ static bool load_dynamic_core(
       struct rarch_state *p_rarch,
       const char *path, char *buf, size_t size)
 {
+#if defined(ANDROID)
+   /* Can't resolve symlinks when dealing with cores
+    * installed via play feature delivery, because the
+    * source files have non-standard file names (which
+    * will not be recognised by regular core handling
+    * routines) */
+   bool resolve_symlinks = !play_feature_delivery_enabled();
+#else
+   bool resolve_symlinks = true;
+#endif
+
    /* Can't lookup symbols in itself on UWP */
 #if !(defined(__WINRT__) || defined(WINAPI_FAMILY) && WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP)
    if (dylib_proc(NULL, "retro_init"))
@@ -20323,7 +20334,7 @@ static bool load_dynamic_core(
    /* Need to use absolute path for this setting. It can be
     * saved to content history, and a relative path would
     * break in that scenario. */
-   path_resolve_realpath(buf, size, true);
+   path_resolve_realpath(buf, size, resolve_symlinks);
    if ((p_rarch->lib_handle = dylib_load(path)))
       return true;
    return false;


### PR DESCRIPTION
## Description

When handling core file paths. RetroArch typically resolves symbolic links - this is done (mainly) to prevent duplicate playlist entries when running on a symlinked filesystem (i.e. when using symbolic links, it is very easy to end up in situations where the same core is referenced by multiple different path text strings, which confuses the detection of identical entries in the playlist code).

This, however, fails completely when using the Android Play Store builds. In this case, the core shared object files installed via play feature delivery are placed in arbitrary filesystem locations and then symlinked into RetroArch's `cores` folder - but these feature delivery files have non-standard names, with the format `lib<core_name>.so`.

On Android, RetroArch expects core files with the name `<core_name>_libretro_android.so` - and the core symlinks respect this. But as soon as we resolve one of these symlinks, we end up with the 'invalid' source file name, which breaks several aspects of the core file handling code.

This PR very simply modifies the code such that core file symlinks *are not* resolved when using the Android Play Store builds, so core names are detected/handled correctly.

In addition, since we are now calling `play_feature_delivery_enabled()` (to identify Play Store builds) with greater frequency, the function has been optimised - instead of calling a (very slow) Java method, we now cache the result on first use, and return the cached value (with appropriate mutex locking).