### PR TITLE
[Android] Miscellaneous fixes for Play Feature Delivery

### DIFF
--- a/pkg/android/phoenix-common/src/com/retroarch/browser/retroactivity/RetroActivityCommon.java
+++ b/pkg/android/phoenix-common/src/com/retroarch/browser/retroactivity/RetroActivityCommon.java
@@ -388,7 +388,7 @@ public class RetroActivityCommon extends NativeActivity
    * @return the list of available cores
    */
   public String[] getAvailableCores() {
-    int id = getResources().getIdentifier("module_names_" + sanitizeCoreName(Build.CPU_ABI), "array", getPackageName());
+    int id = getResources().getIdentifier("module_names_" + Build.CPU_ABI.replace('-', '_'), "array", getPackageName());
 
     String[] returnVal = getResources().getStringArray(id);
     Log.i("RetroActivity", "getAvailableCores: " + Arrays.toString(returnVal));
@@ -512,7 +512,7 @@ public class RetroActivityCommon extends NativeActivity
    * @return The sanitized core name.
    */
   private String sanitizeCoreName(String coreName) {
-    return coreName.replace('-', '_');
+    return "core_" + coreName.replace('-', '_');
   }
 
   /**
@@ -522,11 +522,11 @@ public class RetroActivityCommon extends NativeActivity
    * @return The unsanitized core name.
    */
   private String unsanitizeCoreName(String coreName) {
-    if(coreName.equals("mesen_s")) {
+    if(coreName.equals("core_mesen_s")) {
       return "mesen-s";
     }
 
-    return coreName;
+    return coreName.substring(5);
   }
 
   /**

--- a/pkg/android/phoenix/build.gradle
+++ b/pkg/android/phoenix/build.gradle
@@ -68,12 +68,16 @@ android {
       }
     }
     playStoreNormal {
+      minSdkVersion 21
+
       resValue "string", "app_name", "RetroArch"
       buildConfigField "boolean", "PLAY_STORE_BUILD", "true"
 
       dimension "variant"
     }
     playStoreAarch64 {
+      minSdkVersion 21
+
       applicationIdSuffix '.aarch64'
       resValue "string", "app_name", "RetroArch (AArch64)"
       buildConfigField "boolean", "PLAY_STORE_BUILD", "true"

--- a/pkg/android/phoenix/init_modules.sh
+++ b/pkg/android/phoenix/init_modules.sh
@@ -47,7 +47,7 @@ done
 
 # Time to generate a module for each core!
 while IFS= read -r core; do
-  SANITIZED_CORE_NAME=$(echo $core | sed "s/-/_/g")
+  SANITIZED_CORE_NAME="core_$(echo $core | sed "s/-/_/g")"
   DISPLAY_NAME=$(cat $INFO_PATH/${core}_libretro.info | grep "display_name" | cut -d'"' -f 2)
 
   echo "Generating module for $core..."
@@ -83,7 +83,7 @@ while IFS= read -r core; do
   done
 
   # Write metadata about the module into the corresponding files
-  echo "<string name=\"core_name_$SANITIZED_CORE_NAME\">$DISPLAY_NAME</string>" >> res/values/core_names.xml
+  echo "<string name=\"$SANITIZED_CORE_NAME\">$DISPLAY_NAME</string>" >> res/values/core_names.xml
   echo "':modules:$SANITIZED_CORE_NAME'," >> dynamic_features.gradle
   echo "include ':modules:$SANITIZED_CORE_NAME'" >> settings.gradle
 done <<< "$CORES_LIST"

--- a/pkg/android/phoenix/module_template/AndroidManifest.xml
+++ b/pkg/android/phoenix/module_template/AndroidManifest.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:dist="http://schemas.android.com/apk/distribution"
-    package="com.retroarch.core_modules.%CORE_NAME%">
+    package="com.retroarch.modules.%CORE_NAME%">
 
-    <dist:module dist:title="@string/core_name_%CORE_NAME%">
+    <dist:module dist:title="@string/%CORE_NAME%">
         <dist:delivery>
             <dist:on-demand />
         </dist:delivery>

--- a/pkg/android/phoenix/module_template/build.gradle
+++ b/pkg/android/phoenix/module_template/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.dynamic-feature'
 android {
   compileSdkVersion 28
   defaultConfig {
-    minSdkVersion 16
+    minSdkVersion 21
     targetSdkVersion 28
   }
 


### PR DESCRIPTION
## Description

This adds a couple of miscellaneous fixes for Play Feature Delivery:

* Min API level is bumped up to 21 (Android 5.0) for Play Store builds.  This is required for Play Feature delivery to actually work.  Standalone builds will continue to use a min API level of 16 (Android 4.1)

* Gradle module names are now prefixed with `core_` in order to work around a restriction where modules such as `2048` cannot start with a number.