### PR TITLE
(Qt) Add support for 'Remember Last Used Shader Directory' option

### DIFF
--- a/ui/drivers/qt/options/video.cpp
+++ b/ui/drivers/qt/options/video.cpp
@@ -143,7 +143,6 @@ QWidget *VideoPage::widget()
    miscGroup->add(MENU_ENUM_LABEL_VIDEO_SMOOTH);
    miscGroup->add(MENU_ENUM_LABEL_VIDEO_CTX_SCALING);
    miscGroup->add(MENU_ENUM_LABEL_VIDEO_SHADER_DELAY);
-   miscGroup->add(MENU_ENUM_LABEL_VIDEO_SHADER_REMEMBER_LAST_DIR);
 
    syncMiscLayout->addWidget(syncGroup);
    syncMiscLayout->addWidget(miscGroup);


### PR DESCRIPTION
## Description

At present, the `Remember Last Used Shader Directory` functionality added in #11222 and #11269 only applies when using the raster menus. This PR also enables said functionally when using the Qt WIMP menu.

In addition, two other missing shader options have been added to the Qt shader dialog:

![Screenshot_2020-09-03_11-21-14](https://user-images.githubusercontent.com/38211560/92104118-ce6a1900-edd8-11ea-9f3b-a7e7f1479c0b.png)

