### PR TITLE
(Salamander/static builds) Move 'libretro_path' value from 'retroarch.cfg' to independent config file

### DIFF
--- a/configuration.h
+++ b/configuration.h
@@ -951,6 +951,16 @@ void config_set_defaults(void *data);
 
 void config_load(void *data);
 
+#if !defined(HAVE_DYNAMIC)
+/* Salamander config file contains a single
+ * entry (libretro_path), which is linked to
+ * RARCH_PATH_CORE
+ * > Used to select which core to load
+ *   when launching a salamander build */
+void config_load_file_salamander(void);
+void config_save_file_salamander(void);
+#endif
+
 settings_t *config_get_ptr(void);
 
 RETRO_END_DECLS

--- a/defaults.h
+++ b/defaults.h
@@ -85,7 +85,6 @@ struct defaults
 
    char dirs [DEFAULT_DIR_LAST + 1][PATH_MAX_LENGTH];
    char path_config[PATH_MAX_LENGTH];
-   char path_core  [PATH_MAX_LENGTH];
    char path_buildbot_server_url[255];
    char settings_menu[32];
 

--- a/file_path_special.h
+++ b/file_path_special.h
@@ -96,6 +96,7 @@ RETRO_BEGIN_DECLS
 #define FILE_PATH_CONTENT_IMAGE_HISTORY "content_image_history.lpl"
 #define FILE_PATH_CORE_OPTIONS_CONFIG "retroarch-core-options.cfg"
 #define FILE_PATH_MAIN_CONFIG "retroarch.cfg"
+#define FILE_PATH_SALAMANDER_CONFIG "retroarch-salamander.cfg"
 #define FILE_PATH_BACKGROUND_IMAGE "bg.png"
 #define FILE_PATH_TTF_FONT "font.ttf"
 #define FILE_PATH_RUNTIME_EXTENSION ".lrtl"

--- a/frontend/frontend_driver.c
+++ b/frontend/frontend_driver.c
@@ -22,12 +22,12 @@
 #include <retro_miscellaneous.h>
 #include <libretro.h>
 
-#if defined(_3DS)
-#include <3ds.h>
-#endif
-
 #ifdef HAVE_CONFIG_H
 #include "../config.h"
+#endif
+
+#if defined(_3DS)
+#include <3ds.h>
 #endif
 
 #include "frontend_driver.h"

--- a/retroarch.c
+++ b/retroarch.c
@@ -16528,6 +16528,9 @@ bool command_event(enum event_command cmd, void *data)
          config_set_defaults(&p_rarch->g_extern);
          break;
       case CMD_EVENT_MENU_SAVE_CURRENT_CONFIG:
+#if !defined(HAVE_DYNAMIC)
+         config_save_file_salamander();
+#endif
 #ifdef HAVE_CONFIGFILE
          command_event_save_current_config(p_rarch, OVERRIDE_NONE);
 #endif
@@ -36260,7 +36263,14 @@ static void retroarch_parse_input_and_config(
 #ifdef HAVE_CONFIGFILE
    if (!p_rarch->rarch_block_config_read)
 #endif
+   {
+      /* If this is a static build, load salamander
+       * config file first (sets RARCH_PATH_CORE) */
+#if !defined(HAVE_DYNAMIC)
+      config_load_file_salamander();
+#endif
       config_load(&p_rarch->g_extern);
+   }
 
    /* Second pass: All other arguments override the config file */
    optind = 1;


### PR DESCRIPTION
## Description

When running salamader/static RetroArch builds, the main application launcher is essentially a kind of bootloader which selects and runs the last used core. In order to keep track of the last used core, a `libretro_path` config parameter is recorded in `retroarch.cfg`. This has two major shortcomings:

- Every time a salamander build is launched, we end up reading `retroarch.cfg` *twice* - once to find which core to load, and then once again as part of the normal core startup process. Reading `retroarch.cfg` is a very slow operation...

- Every time we close content or quit RetroArch, the `libretro_path` field gets updated - so whenever we change cores (or load content on startup with a different core from the one last used), `retroarch.cfg` gets marked as dirty and is rewritten. This means static builds keep writing the entire ~100kb main config file to disk again and again and again, all the time (needlessly, since all other config parameters remain the same, unless manually changed by the user)

These two issues would have little significance on the desktop, but platforms that run static builds typically have weak hardware, bad file I/O transfer rates and small, low quality flash storage devices. On these platforms, unnecessary performance overheads and disk wear and tear are a non-trivial concern...

This PR addresses the problem by moving the `libretro_path` record from the main `retroarch.cfg` config file to a new `retroarch-salamander.cfg` file (residing in the same directory). As a result, salamander/static builds now have the overhead of reading/writing just a handful of bytes on every startup/shutdown, instead of the full 100kb of global config data.

Tested on o3DS, this reduces initial launch, load content, and quit times by a little over 1 second. Perhaps more importantly, it saves a great deal of wear on crummy sd cards.