### PR TITLE
Allow controllers with no/empty names to work.

### DIFF
--- a/input/connect/joypad_connection.c
+++ b/input/connect/joypad_connection.c
@@ -159,10 +159,12 @@ int32_t pad_connection_pad_init(joypad_connection_t *joyconn,
    if (s)
    {
       unsigned i;
+      
+      const bool has_name = !string_is_empty(name);
 
       for (i = 0; name && pad_map[i].name; i++)
       {
-         const char *name_match = strstr(pad_map[i].name, name);
+         const char *name_match = has_name ? strstr(pad_map[i].name, name) : NULL;
 
          /* Never change, Nintendo. */
          if(pad_map[i].vid == 1406 && pad_map[i].pid == 816)

--- a/input/drivers_hid/iohidmanager_hid.c
+++ b/input/drivers_hid/iohidmanager_hid.c
@@ -684,9 +684,8 @@ static void iohidmanager_hid_device_add_device(
    if (adapter->slot == -1)
       goto error;
 
-   if (string_is_empty(adapter->name)) {
+   if (string_is_empty(adapter->name))
       strcpy(adapter->name, "Unknown Controller With No Name");
-   }
    
    if (pad_connection_has_interface(hid->slots, adapter->slot))
       IOHIDDeviceRegisterInputReportCallback(device,

--- a/input/drivers_hid/iohidmanager_hid.c
+++ b/input/drivers_hid/iohidmanager_hid.c
@@ -684,6 +684,10 @@ static void iohidmanager_hid_device_add_device(
    if (adapter->slot == -1)
       goto error;
 
+   if (string_is_empty(adapter->name)) {
+      strcpy(adapter->name, "Unknown Controller With No Name");
+   }
+   
    if (pad_connection_has_interface(hid->slots, adapter->slot))
       IOHIDDeviceRegisterInputReportCallback(device,
             adapter->data + 1, sizeof(adapter->data) - 1,
@@ -691,9 +695,6 @@ static void iohidmanager_hid_device_add_device(
    else
       IOHIDDeviceRegisterInputValueCallback(device,
             iohidmanager_hid_device_input_callback, adapter);
-
-   if (string_is_empty(adapter->name))
-      goto error;
 
    /* scan for buttons, axis, hats */
    elements_raw = IOHIDDeviceCopyMatchingElements(device, NULL, kIOHIDOptionsTypeNone);


### PR DESCRIPTION
## Description

Previously, if a USB controller with no name was attached to my Mac, RetroArch would crash soon after startup (crash trace below).

This patch allows controllers with no, or empty, names to work. Contains one Mac-specific change, and one all-platform change.

I guess that controllers like this are unusual (or perhaps even not to spec?), but it's simple to be robust to them. The controller I have that's like this is a "XK-PC2004" PSX -> USB convertor. 

It contains two main changes.

**Mac change (`input/drivers_hid/iohidmanager_hid`)**:  If there's no name, use a default name ("Unknown Controller With No Name"). Previously we'd error out - but the IOHID callbacks would still have been set up with a data structure that was freed in the error handling as context. We'd access this structure in the IOHID callbacks. This caused the crash.

**Cross-platform change (`input/connect/joypad_connection.c`)**: Even after this fix, the controller didn't work. The problem was that, in `pad_connection_pad_init(...)`, we'd compare the name to a known controller name with `strstr(...)`, and treat any non-NULL return value (indicating a match was found within the string) as 'matching'. But if you call strstr with an _empty_ string, it always finds a match at position 0. This caused the code to believe that the controller was a PS4 controller - which it is not.  This in turn caused none of the buttons to work. With this change, controllers with empty names will be treated as not matching any of the strings.


The crash that this fixes:

```
Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   libretro.RetroArch            	0x0000000102d4d6f0 iohidmanager_hid_device_report + 43
1   com.apple.framework.IOKit     	0x00007fff3646f6db __IOHIDDeviceInputReportApplier + 72
2   com.apple.CoreFoundation      	0x00007fff3368a51e __CFSetApplyFunction_block_invoke + 18
3   com.apple.CoreFoundation      	0x00007fff3368a38f CFBasicHashApply + 115
4   com.apple.CoreFoundation      	0x00007fff3368a304 CFSetApplyFunction + 129
5   com.apple.framework.IOKit     	0x00007fff3646f5de __IOHIDDeviceInputReportWithTimeStampCallback + 135
6   com.apple.iokit.IOHIDLib      	0x000000010858aac0 0x10857d000 + 56000
7   com.apple.CoreFoundation      	0x00007fff336f0b2b __CFMachPortPerform + 288
8   com.apple.CoreFoundation      	0x00007fff336c2304 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE1_PERFORM_FUNCTION__ + 41
9   com.apple.CoreFoundation      	0x00007fff336c2250 __CFRunLoopDoSource1 + 541
10  com.apple.CoreFoundation      	0x00007fff336c0d79 __CFRunLoopRun + 2270
11  com.apple.CoreFoundation      	0x00007fff336bfe3e CFRunLoopRunSpecific + 462
12  libretro.RetroArch            	0x0000000102b40339 -[RetroArch_OSX rarch_main] + 58
13  com.apple.Foundation          	0x00007fff35d960dd __NSThreadPerformPerform + 204
14  com.apple.CoreFoundation      	0x00007fff336c1d52 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 17
15  com.apple.CoreFoundation      	0x00007fff336c1cf1 __CFRunLoopDoSource0 + 103
16  com.apple.CoreFoundation      	0x00007fff336c1b0b __CFRunLoopDoSources0 + 209
17  com.apple.CoreFoundation      	0x00007fff336c083a __CFRunLoopRun + 927
18  com.apple.CoreFoundation      	0x00007fff336bfe3e CFRunLoopRunSpecific + 462
19  com.apple.HIToolbox           	0x00007fff322ecabd RunCurrentEventLoopInMode + 292
20  com.apple.HIToolbox           	0x00007fff322ec6f4 ReceiveNextEventCommon + 359
21  com.apple.HIToolbox           	0x00007fff322ec579 _BlockUntilNextEventMatchingListInModeWithFilter + 64
22  com.apple.AppKit              	0x00007fff30932039 _DPSNextEvent + 883
23  com.apple.AppKit              	0x00007fff30930880 -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 1352
24  com.apple.AppKit              	0x00007fff3092258e -[NSApplication run] + 658
25  com.apple.AppKit              	0x00007fff308f4396 NSApplicationMain + 777
26  libretro.RetroArch            	0x0000000102b3ce78 start + 52
```
