### PR TITLE
[3DS] Increase file buffer size and savestate chunk size

### DIFF
--- a/libretro-common/vfs/vfs_implementation.c
+++ b/libretro-common/vfs/vfs_implementation.c
@@ -446,7 +446,14 @@ libretro_vfs_implementation_file *retro_vfs_file_open_impl(
        */
       /* TODO: this is only useful for a few platforms, 
        * find which and add ifdef */
-#if !defined(PSP)
+#if defined(_3DS)
+      if (stream->scheme != VFS_SCHEME_CDROM)
+      {
+         stream->buf = (char*)calloc(1, 0x10000);
+         if (stream->fp)
+            setvbuf(stream->fp, stream->buf, _IOFBF, 0x10000);
+      }
+#elif !defined(PSP)
       if (stream->scheme != VFS_SCHEME_CDROM)
       {
          stream->buf = (char*)calloc(1, 0x4000);

--- a/tasks/task_save.c
+++ b/tasks/task_save.c
@@ -58,7 +58,7 @@
 #include "../managers/cheat_manager.h"
 #endif
 
-#ifdef HAVE_LIBNX
+#if defined(HAVE_LIBNX) || defined(_3DS)
 #define SAVE_STATE_CHUNK 4096 * 10
 #else
 #define SAVE_STATE_CHUNK 4096


### PR DESCRIPTION
## Description

This bumps the file buffer size to 64k and the savestate chunk size to 40k on 3DS. This seems to help with saving large savestates.