### PR TITLE
fix over-translating codes for window ClassName, as an additional fix…

### DIFF
--- a/gfx/common/win32_common.c
+++ b/gfx/common/win32_common.c
@@ -1345,7 +1345,7 @@ bool win32_window_create(void *data, unsigned style,
       user_height                = g_win32->pos_height;
    }
    main_window.hwnd              = CreateWindowEx(0,
-         msg_hash_to_str(MSG_PROGRAM), msg_hash_to_str(MSG_PROGRAM),
+         "RetroArch", msg_hash_to_str(MSG_PROGRAM),
          style,
          fullscreen ? mon_rect->left : g_win32->pos_x,
          fullscreen ? mon_rect->top  : g_win32->pos_y,
@@ -1820,7 +1820,7 @@ void win32_window_reset(void)
 void win32_destroy_window(void)
 {
 #ifndef _XBOX
-   UnregisterClass(msg_hash_to_str(MSG_PROGRAM), 
+   UnregisterClass("RetroArch", 
          GetModuleHandle(NULL));
 #if defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x500 /* 2K */
    UnregisterDeviceNotification(notification_handler);

--- a/ui/drivers/ui_win32.c
+++ b/ui/drivers/ui_win32.c
@@ -70,7 +70,7 @@ bool win32_window_init(WNDCLASSEX *wndclass,
    wndclass->style         = CS_HREDRAW | CS_VREDRAW | CS_OWNDC;
    wndclass->hInstance     = GetModuleHandle(NULL);
    wndclass->hCursor       = LoadCursor(NULL, IDC_ARROW);
-   wndclass->lpszClassName = (class_name != NULL) ? class_name : msg_hash_to_str(MSG_PROGRAM);
+   wndclass->lpszClassName = (class_name != NULL) ? class_name : "RetroArch";
    wndclass->hIcon         = LoadIcon(GetModuleHandle(NULL), MAKEINTRESOURCE(IDI_ICON));
    wndclass->hIconSm       = (HICON)LoadImage(GetModuleHandle(NULL),
          MAKEINTRESOURCE(IDI_ICON), IMAGE_ICON, 16, 16, 0);


### PR DESCRIPTION
This is an additional fix to 3c6552b, which could completely fix #10963, fix #11028 and fix #11254 even when MSG_PROGRAM is translated by any other language.

I did not add back removed translations coz UTF-8 encoded CJK strings as window title are not displayed correctly for win32 program.