### PR TITLE
Fix playlist history size

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -16398,7 +16398,8 @@ static bool setting_append_list(
                general_write_handler,
                general_read_handler);
          (*list)[list_info->index - 1].action_ok     = &setting_action_ok_uint;
-         menu_settings_list_current_add_range(list, list_info, 1.0f, (float)COLLECTION_SIZE, 1.0f, true, false);
+         (*list)[list_info->index - 1].offset_by     = 1;
+         menu_settings_list_current_add_range(list, list_info, 1.0f, 9999.0f, 1.0f, true, true);
 
          END_SUB_GROUP(list, list_info, parent_group);
 


### PR DESCRIPTION
##  Description

Fixes and sanitizes playlist history size option from selecting the wrong value and from wrapping around left to an insane and unusable value. Maximum value of 9999 copied from maximum favorites size.

## Related Issues

Closes #11317 
