### PR TITLE
Miscellaneous overlay fixes

### DIFF
--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -2788,6 +2788,9 @@ static void vulkan_overlay_free(vk_t *vk)
                vk->context->device,
                &vk->overlay.images[i]);
 
+   if (vk->overlay.images)
+      free(vk->overlay.images);
+
    memset(&vk->overlay, 0, sizeof(vk->overlay));
 }
 

--- a/gfx/video_thread_wrapper.c
+++ b/gfx/video_thread_wrapper.c
@@ -439,8 +439,6 @@ static bool video_thread_handle_packet(
 
       case CMD_OVERLAY_LOAD:
          {
-            float *tmp_alpha_mod = NULL;
-
             if (thr->overlay && thr->overlay->load)
                ret = thr->overlay->load(thr->driver_data,
                      pkt.data.image.data,
@@ -448,11 +446,21 @@ static bool video_thread_handle_packet(
 
             pkt.data.b         = ret;
             thr->alpha_mods    = pkt.data.image.num;
-            tmp_alpha_mod      = (float*)realloc(thr->alpha_mod,
-                  thr->alpha_mods * sizeof(float));
 
-            if (tmp_alpha_mod)
-               thr->alpha_mod  = tmp_alpha_mod;
+            if (thr->alpha_mods > 0)
+            {
+               float *tmp_alpha_mod = (float*)realloc(thr->alpha_mod,
+                     thr->alpha_mods * sizeof(float));
+
+               if (tmp_alpha_mod)
+                  thr->alpha_mod = tmp_alpha_mod;
+            }
+            else
+            {
+               if (thr->alpha_mod)
+                  free(thr->alpha_mod);
+               thr->alpha_mod = NULL;
+            }
 
             /* Avoid temporary garbage data. */
             for (i = 0; i < thr->alpha_mods; i++)

--- a/retroarch.c
+++ b/retroarch.c
@@ -24368,7 +24368,9 @@ static int16_t input_state_device(
                res = 1;
 
          /* Don't allow turbo for D-pad. */
-         if ((id < RETRO_DEVICE_ID_JOYPAD_UP || id > RETRO_DEVICE_ID_JOYPAD_RIGHT))
+         if ((id < RETRO_DEVICE_ID_JOYPAD_UP) ||
+             ((id > RETRO_DEVICE_ID_JOYPAD_RIGHT) &&
+                  (id <= RETRO_DEVICE_ID_JOYPAD_R3)))
          {
             /*
              * Apply turbo button if activated.


### PR DESCRIPTION
## Description

While working on this: https://github.com/libretro/common-overlays/pull/48, I noticed several (relatively minor) issues related to the handling of overlays:

- When using the Vulkan gfx driver, memory is leaked every time an overlay is freed

- When threaded video is enabled, loading overlays with no images (i.e. utility-type overlays, where everything is hidden until the screen is touched) can generate segfaults due to improper usage of `realloc()`

- When `Show Inputs on Overlay` is enabled, ASAN reports bit shift errors due to an incorrect range check when handling turbo inputs - essentially, there is no upper limit to the considered input id range, which means overlay hotkeys (menu toggle, etc.) are incorrectly treated as having turbo support, causing bit shifts using wildly inappropriate id indices

This simple PR fixes all of these issues.
