### PR TITLE
(Mobile) Set default overlay to 'neo-retropad'

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -2482,10 +2482,20 @@ void config_set_defaults(void *data)
             sizeof(settings->paths.directory_overlay));
 #ifdef RARCH_MOBILE
       if (string_is_empty(settings->paths.path_overlay))
+      {
+         fill_pathname_join(settings->paths.path_overlay,
+               settings->paths.directory_overlay,
+               FILE_PATH_DEFAULT_OVERLAY,
+               sizeof(settings->paths.path_overlay));
+
+         /* Handle the case where old asset files
+          * are installed */
+         if (!path_is_valid(settings->paths.path_overlay))
             fill_pathname_join(settings->paths.path_overlay,
                   settings->paths.directory_overlay,
-                  "gamepads/flat/retropad.cfg",
+                  FILE_PATH_DEFAULT_OVERLAY_FALLBACK,
                   sizeof(settings->paths.path_overlay));
+      }
 #endif
    }
 #endif

--- a/file_path_special.h
+++ b/file_path_special.h
@@ -107,6 +107,10 @@ RETRO_BEGIN_DECLS
 #define FILE_PATH_CORE_BACKUP_EXTENSION_NO_DOT "lcbk"
 #define FILE_PATH_LOCK_EXTENSION ".lck"
 #define FILE_PATH_BACKUP_EXTENSION ".bak"
+#if defined(RARCH_MOBILE)
+#define FILE_PATH_DEFAULT_OVERLAY "gamepads/neo-retropad/neo-retropad.cfg"
+#define FILE_PATH_DEFAULT_OVERLAY_FALLBACK "gamepads/flat/retropad.cfg"
+#endif
 
 enum application_special_type
 {


### PR DESCRIPTION
## Description

This PR changes the default overlay on mobile platforms to `neo-retropad.cfg` - as endorsed by @hizzlekizzle :)

It can be merged before or after https://github.com/libretro/common-overlays/pull/48 - if `neo-retropad.cfg` is not found, it will fall back to the existing default of `flat/retropad.cfg`

## Related Pull Requests

https://github.com/libretro/common-overlays/pull/48

