### PR TITLE
Fix --enable-debug build

### DIFF
--- a/libretro-common/audio/audio_mixer.c
+++ b/libretro-common/audio/audio_mixer.c
@@ -20,6 +20,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "../../config.h"
+#endif
+
 #include <audio/audio_mixer.h>
 #include <audio/audio_resampler.h>
 
@@ -32,10 +36,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
-
-#ifdef HAVE_CONFIG_H
-#include "../../config.h"
-#endif
 
 #ifdef HAVE_STB_VORBIS
 #define STB_VORBIS_NO_PUSHDATA_API


### PR DESCRIPTION
libretro-common/audio/audio_mixer.c:195:32: error: unknown type name ‘rwav_t’
 static bool wav_to_float(const rwav_t* wav, float** pcm, size_t samples_out)
                                ^~~~~~

plus about 500 errors when trying to use that struct

I have no idea why it works without --enable-debug.