### PR TITLE
extend cheevos password length to 255 characters

### DIFF
--- a/configuration.h
+++ b/configuration.h
@@ -335,7 +335,7 @@ typedef struct settings
       char location_driver[32];
       char menu_driver[32];
       char cheevos_username[32];
-      char cheevos_password[32];
+      char cheevos_password[256];
       char cheevos_token[32];
       char video_context_driver[32];
       char audio_driver[32];

--- a/deps/rcheevos/src/rurl/url.c
+++ b/deps/rcheevos/src/rurl/url.c
@@ -167,7 +167,7 @@ int rc_url_get_badge_image(char* buffer, size_t size, const char* badge_name) {
 
 int rc_url_login_with_password(char* buffer, size_t size, const char* user_name, const char* password) {
   char urle_user_name[64];
-  char urle_password[64];
+  char urle_password[256];
   int written;
 
   if (rc_url_encode(urle_user_name, sizeof(urle_user_name), user_name) != 0) {

--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -5252,7 +5252,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_CHEEVOS_PASSWORD,
-   "Input the password of your RetroAchievements account."
+   "Input the password of your RetroAchievements account. Max length: 255 characters."
    )
 
 /* Settings > User > Accounts > YouTube */


### PR DESCRIPTION
## Description

Currently the Cheevos password entered in the menu or stored temporarily in the config file is limited to 31 characters. The RetroAchievements website actually doesn't have a password character limit. This PR will increase the password character limit in RetroArch to 255 characters and make a small note in the menu help text for the password to indicate the character limit to the user.

Hopefully this is long enough for the vast majority of peoples' passwords.

## Related Issues

This should fix issue #11169

## Related Pull Requests

None

## Reviewers

[If possible @mention all the people that should review your pull request]
