### PR TITLE
(cheevos) sync menu reset value to default

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -16759,7 +16759,7 @@ static bool setting_append_list(
                &settings->bools.cheevos_test_unofficial,
                MENU_ENUM_LABEL_CHEEVOS_TEST_UNOFFICIAL,
                MENU_ENUM_LABEL_VALUE_CHEEVOS_TEST_UNOFFICIAL,
-               true,
+               false,
                MENU_ENUM_LABEL_VALUE_OFF,
                MENU_ENUM_LABEL_VALUE_ON,
                &group_info,


### PR DESCRIPTION
## Description

The default value for `cheevos_test_unofficial` is false (second boolean here): https://github.com/libretro/RetroArch/blob/f1d0de85fdf6121bc1c58786a280553349678147/configuration.c#L1654

But using the "reset to default" feature (pressing space when the menu option is selected) resets the value to true. This updates the menu item definition to reset the value to false when pressing space.

The other `cheevos_` settings appear to be in sync between the initial defaults and the "reset to default" values. I wonder if any other non-cheevos settings have a similar issue. 

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers
@Sanaki
