### PR TITLE
(Vulkan) Reduce log spam

### DIFF
--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -584,7 +584,9 @@ struct vk_texture vulkan_create_texture(vk_t *vk,
           VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) == 0)
    {
       /* Recreate texture but for STAGING this time ... */
+#ifdef VULKAN_DEBUG
       RARCH_LOG("[Vulkan]: GPU supports linear images as textures, but not DEVICE_LOCAL. Falling back to copy path.\n");
+#endif
       type = VULKAN_TEXTURE_STAGING;
       vkDestroyImage(device, tex.image, NULL);
       tex.image          = (VkImage)NULL;
@@ -2956,7 +2958,9 @@ bool vulkan_create_swapchain(gfx_ctx_vulkan_data_t *vk,
          vk->context.swap_interval == swap_interval)
    {
       /* Do not bother creating a swapchain redundantly. */
+#ifdef VULKAN_DEBUG
       RARCH_LOG("[Vulkan]: Do not need to re-create swapchain.\n");
+#endif
       vulkan_create_wait_fences(vk);
 
       if (     vk->emulating_mailbox 

--- a/gfx/drivers_shader/shader_vulkan.cpp
+++ b/gfx/drivers_shader/shader_vulkan.cpp
@@ -1063,7 +1063,9 @@ bool vulkan_filter_chain::init_history()
 
    if (required_images < 2)
    {
+#ifdef VULKAN_DEBUG
       RARCH_LOG("[Vulkan filter chain]: Not using frame history.\n");
+#endif
       return true;
    }
 
@@ -1077,7 +1079,9 @@ bool vulkan_filter_chain::init_history()
       original_history.emplace_back(new Framebuffer(device, memory_properties,
                max_input_size, original_format, 1));
 
+#ifdef VULKAN_DEBUG
    RARCH_LOG("[Vulkan filter chain]: Using history of %u frames.\n", unsigned(required_images));
+#endif
 
    /* On first frame, we need to clear the textures to
     * a known state, but we need
@@ -1121,7 +1125,9 @@ bool vulkan_filter_chain::init_feedback()
 
    if (!use_feedbacks)
    {
+#ifdef VULKAN_DEBUG
       RARCH_LOG("[Vulkan filter chain]: Not using framebuffer feedback.\n");
+#endif
       return true;
    }
 
@@ -1264,10 +1270,12 @@ bool vulkan_filter_chain::init()
    for (i = 0; i < passes.size(); i++)
    {
       const string name = passes[i]->get_name();
+#ifdef VULKAN_DEBUG
       RARCH_LOG("[slang]: Building pass #%u (%s)\n", i,
             name.empty() ?
             msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE) :
             name.c_str());
+#endif
 
       source = passes[i]->set_pass_info(max_input_size,
             source, swapchain_info, pass_info[i]);
@@ -1621,7 +1629,9 @@ bool Pass::init_pipeline_layout()
       if (reflection.push_constant_stage_mask & SLANG_STAGE_FRAGMENT_MASK)
          push_range.stageFlags |= VK_SHADER_STAGE_FRAGMENT_BIT;
 
+#ifdef VULKAN_DEBUG
       RARCH_LOG("[Vulkan]: Push Constant Block: %u bytes.\n", (unsigned int)reflection.push_constant_size);
+#endif
 
       layout_info.pushConstantRangeCount = 1;
       layout_info.pPushConstantRanges    = &push_range;


### PR DESCRIPTION
## Description

Make the log output a bit more readable for the average user by hiding some Vulkan logging under `#ifdef VULKAN_DEBUG` that happens on fastforward etc.

Before:
```
[INFO] [Vulkan]: VSync => off
[INFO] [Vulkan]: Do not need to re-create swapchain.
[INFO] [Vulkan]: GPU supports linear images as textures, but not DEVICE_LOCAL. Falling back to copy path.
[INFO] [Vulkan]: GPU supports linear images as textures, but not DEVICE_LOCAL. Falling back to copy path.
[INFO] [slang]: Building pass #0 (N/A)
[INFO] [Vulkan]: Push Constant Block: 68 bytes.
[INFO] [Vulkan filter chain]: Not using frame history.
[INFO] [Vulkan filter chain]: Not using framebuffer feedback.
[INFO] [Vulkan]: VSync => on
[INFO] [Vulkan]: Do not need to re-create swapchain.
[INFO] [Vulkan]: GPU supports linear images as textures, but not DEVICE_LOCAL. Falling back to copy path.
[INFO] [Vulkan]: GPU supports linear images as textures, but not DEVICE_LOCAL. Falling back to copy path.
[INFO] [slang]: Building pass #0 (N/A)
[INFO] [Vulkan]: Push Constant Block: 68 bytes.
[INFO] [Vulkan filter chain]: Not using frame history.
[INFO] [Vulkan filter chain]: Not using framebuffer feedback.
[INFO] Content ran for a total of: 00 hours, 00 minutes, 09 seconds.
```

After:
```
[INFO] [Vulkan]: VSync => off
[INFO] [Vulkan]: VSync => on
[INFO] Content ran for a total of: 00 hours, 00 minutes, 07 seconds.
```
