### PR TITLE
(Vulkan) Fix CPU usage when minimized

### DIFF
--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -2787,7 +2787,10 @@ retry:
       if (!vulkan_create_swapchain(vk, vk->context.swapchain_width,
                vk->context.swapchain_height, vk->context.swap_interval))
       {
+#ifdef VULKAN_DEBUG
          RARCH_ERR("[Vulkan]: Failed to create new swapchain.\n");
+#endif
+         retro_sleep(20);
          return;
       }
 
@@ -2941,6 +2944,14 @@ bool vulkan_create_swapchain(gfx_ctx_vulkan_data_t *vk,
    vkDeviceWaitIdle(vk->context.device);
    vulkan_acquire_clear_fences(vk);
 
+   vkGetPhysicalDeviceSurfaceCapabilitiesKHR(vk->context.gpu,
+         vk->vk_surface, &surface_properties);
+
+   /* Skip creation when window is minimized */
+   if (!surface_properties.currentExtent.width &&
+       !surface_properties.currentExtent.height)
+      return false;
+
    if (swap_interval == 0 && vk->emulate_mailbox)
    {
       swap_interval          = 1;
@@ -3055,8 +3066,6 @@ bool vulkan_create_swapchain(gfx_ctx_vulkan_data_t *vk,
    RARCH_LOG("[Vulkan]: Creating swapchain with present mode: %u\n",
          (unsigned)swapchain_present_mode);
 
-   vkGetPhysicalDeviceSurfaceCapabilitiesKHR(vk->context.gpu,
-         vk->vk_surface, &surface_properties);
    vkGetPhysicalDeviceSurfaceFormatsKHR(vk->context.gpu,
          vk->vk_surface, &format_count, NULL);
    vkGetPhysicalDeviceSurfaceFormatsKHR(vk->context.gpu,


### PR DESCRIPTION
##  Description

Currently when minimizing the window while using Vulkan - core running or not - CPU usage will be insane and log gets spammed endlessly and relentlessly with:

```
[INFO] [Vulkan]: Swapchain supports present mode: 2.
[INFO] [Vulkan]: Swapchain supports present mode: 3.
[INFO] [Vulkan]: Swapchain supports present mode: 1.
[INFO] [Vulkan]: Swapchain supports present mode: 0.
[INFO] [Vulkan]: Creating swapchain with present mode: 2
[INFO] [Vulkan]: Cannot create a swapchain yet. Will try again later ...
[INFO] [Vulkan]: Swapchain supports present mode: 2.
[INFO] [Vulkan]: Swapchain supports present mode: 3.
[INFO] [Vulkan]: Swapchain supports present mode: 1.
[INFO] [Vulkan]: Swapchain supports present mode: 0.
[INFO] [Vulkan]: Creating swapchain with present mode: 2
[INFO] [Vulkan]: Cannot create a swapchain yet. Will try again later ...
```

Relocated `surface_properties` fetching and prevented further processing as soon as possible. Also added moderate sleeping and hid rather useless failure logging under `VULKAN_DEBUG` to bring the idle usage down even more. Please test and confirm! I haven't found nastier surprises yet.

