### PR TITLE
Glcore context switching

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -18912,15 +18912,19 @@ static bool dynamic_verify_hw_context(
          if (!string_is_equal(video_ident, "vulkan"))
             return false;
          break;
+#if defined(HAVE_OPENGL_CORE)
+      case RETRO_HW_CONTEXT_OPENGL_CORE:
+         if (!string_is_equal(video_ident, "glcore"))
+            return false;
+         break;
+#else
+      case RETRO_HW_CONTEXT_OPENGL_CORE:
+#endif
       case RETRO_HW_CONTEXT_OPENGLES2:
       case RETRO_HW_CONTEXT_OPENGLES3:
       case RETRO_HW_CONTEXT_OPENGLES_VERSION:
       case RETRO_HW_CONTEXT_OPENGL:
          if (!string_is_equal(video_ident, "gl"))
-            return false;
-         break;
-      case RETRO_HW_CONTEXT_OPENGL_CORE:
-         if (!string_is_equal(video_ident, "glcore"))
             return false;
          break;
       case RETRO_HW_CONTEXT_DIRECT3D:
@@ -31611,6 +31615,9 @@ static bool hw_render_context_is_gl(enum retro_hw_context_type type)
    switch (type)
    {
       case RETRO_HW_CONTEXT_OPENGL:
+#ifndef HAVE_OPENGL_CORE
+      case RETRO_HW_CONTEXT_OPENGL_CORE:
+#endif
       case RETRO_HW_CONTEXT_OPENGLES2:
       case RETRO_HW_CONTEXT_OPENGLES3:
       case RETRO_HW_CONTEXT_OPENGLES_VERSION:

--- a/retroarch.c
+++ b/retroarch.c
@@ -34089,7 +34089,7 @@ static const gfx_ctx_driver_t *video_context_driver_init(
 {
    struct rarch_state *p_rarch = &rarch_st;
    settings_t       *settings  = p_rarch->configuration_settings;
-   bool  video_shared_context  = settings->bools.video_shared_context;
+   bool  video_shared_context  = settings->bools.video_shared_context || libretro_get_shared_context();
 
    if (!ctx->bind_api(data, api, major, minor))
    {

--- a/retroarch.c
+++ b/retroarch.c
@@ -33102,7 +33102,7 @@ static bool video_driver_find_driver(struct rarch_state *p_rarch)
                sizeof(p_rarch->cached_video_driver));
             configuration_set_string(settings,
                settings->arrays.video_driver,
-               "gl");
+               "glcore");
          }
          p_rarch->current_video = &video_gl_core;
       }


### PR DESCRIPTION
This PR is for cores that don't work properly with "gl" video driver (iirc, several cores using modern opengl, including kronos and dolphin).
It was applied in may 2020 before being reverted because @twinaphex reported unexpected behavior with it.
I was never able to reproduce this unexpected behavior (the content of this PR is pretty straightforward tbh : if `RETRO_HW_CONTEXT_OPENGL_CORE` is requested, use "glcore" video driver; if another gl-based context is requested, use "gl" video driver; it's up to the core to request the right context), and had several positive feedbacks about this when it was first applied.
I want this to be re-evaluated and to have more information about the failure (if it still fails) so that we can work around those issues.

**This is especially important now that kronos has been released on steam, since kronos doesn't work properly with the "gl" video driver which, sadly, is the default video driver for retroarch.**