### PR TITLE
[iOS][tvOS] Fix declaration of input driver init method

### DIFF
--- a/input/drivers_joypad/mfi_joypad.m
+++ b/input/drivers_joypad/mfi_joypad.m
@@ -230,7 +230,7 @@ static void apple_gamecontroller_joypad_register(GCGamepad *gamepad)
            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
                  mfi_buttons[slot] &= ~(1 << RETRO_DEVICE_ID_JOYPAD_START);
                  });
-        }
+        };
     }
 }
 
@@ -319,7 +319,7 @@ static void apple_gamecontroller_joypad_disconnect(GCController* controller)
     }
 }
 
-void *apple_gamecontroller_joypad_init(void *data)
+bool apple_gamecontroller_joypad_init(void *data)
 {
    static bool inited = false;
    if (inited)


### PR DESCRIPTION
## Description

Project was not compiling - made a fix to the input driver init declaration.

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
