### PR TITLE
(Mobile) Fix default overlay assignemnt

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -2490,14 +2490,6 @@ void config_set_defaults(void *data)
                settings->paths.directory_overlay,
                FILE_PATH_DEFAULT_OVERLAY,
                sizeof(settings->paths.path_overlay));
-
-         /* Handle the case where old asset files
-          * are installed */
-         if (!path_is_valid(settings->paths.path_overlay))
-            fill_pathname_join(settings->paths.path_overlay,
-                  settings->paths.directory_overlay,
-                  FILE_PATH_DEFAULT_OVERLAY_FALLBACK,
-                  sizeof(settings->paths.path_overlay));
       }
 #endif
    }

--- a/file_path_special.h
+++ b/file_path_special.h
@@ -109,7 +109,6 @@ RETRO_BEGIN_DECLS
 #define FILE_PATH_BACKUP_EXTENSION ".bak"
 #if defined(RARCH_MOBILE)
 #define FILE_PATH_DEFAULT_OVERLAY "gamepads/neo-retropad/neo-retropad.cfg"
-#define FILE_PATH_DEFAULT_OVERLAY_FALLBACK "gamepads/flat/retropad.cfg"
 #endif
 
 enum application_special_type


### PR DESCRIPTION
## Description

In PR #11325 I changed the default mobile controller overlay from `retropad` to `neo-retropad`. In an attempt to support old asset installations, I included a `neo-retropad` 'file exists' check, with a fallback to `retropad` in the event that the new overly wasn't found.

Unfortunately, I overlooked the fact that on the first run of a fresh RetroArch install on Anddroid, no asset files exist at all (since they are only extracted *after* the app opens). Thus the `neo-retropad` 'file exists' check always fails, and the fallback `retropad` is always set...

This trivial PR fixes the issue - now `neo-retropad` is always set on first launch.