### PR TITLE
Prevent out of bounds array acces when using left/right to remap 'Keyboard' device type inputs

### DIFF
--- a/menu/cbs/menu_cbs_left.c
+++ b/menu/cbs/menu_cbs_left.c
@@ -183,7 +183,7 @@ static int action_left_input_desc_kbd(unsigned type, const char *label,
    remap_id =
       settings->uints.input_keymapper_ids[user_idx][btn_idx];
 
-   for (key_id = 0; key_id < RARCH_MAX_KEYS - 1; key_id++)
+   for (key_id = 0; key_id < RARCH_MAX_KEYS; key_id++)
    {
       if (remap_id == key_descriptors[key_id].key)
          break;
@@ -192,7 +192,7 @@ static int action_left_input_desc_kbd(unsigned type, const char *label,
    if (key_id > 0)
       key_id--;
    else
-      key_id = (RARCH_MAX_KEYS - 1) + MENU_SETTINGS_INPUT_DESC_KBD_BEGIN;
+      key_id = RARCH_MAX_KEYS - 1;
 
    settings->uints.input_keymapper_ids[user_idx][btn_idx] = key_descriptors[key_id].key;
 

--- a/menu/cbs/menu_cbs_right.c
+++ b/menu/cbs/menu_cbs_right.c
@@ -154,13 +154,13 @@ static int action_right_input_desc_kbd(unsigned type, const char *label,
    remap_id =
       settings->uints.input_keymapper_ids[user_idx][btn_idx];
 
-   for (key_id = 0; key_id < RARCH_MAX_KEYS - 1; key_id++)
+   for (key_id = 0; key_id < RARCH_MAX_KEYS; key_id++)
    {
       if (remap_id == key_descriptors[key_id].key)
          break;
    }
 
-   if (key_id < (RARCH_MAX_KEYS - 1) + MENU_SETTINGS_INPUT_DESC_KBD_BEGIN)
+   if (key_id < (RARCH_MAX_KEYS - 1))
       key_id++;
    else
       key_id = 0;


### PR DESCRIPTION
## Description

At present, if content is launched with a core that supports 'Keyboard' device types, the following actions will cause out of bounds array access - leading either to an immediate crash, or a silent error that can later cause undefined behaviour:

- Go to `Quick Menu > Controls > Port N Controls`

- Set `Device Type` to `Keyboard`

- Scroll down to any input, then use left/right to wrap around from the first to the last keyboard key (or last to first)

This happens because an array index is set incorrectly on wrap-around (looks like a simple typo, to be honest...).

This trivial PR fixes the issue.