### PR TITLE
Gameboy/Dot_Matrix video filters: Add XRGB8888 support

### DIFF
--- a/gfx/video_filters/dot_matrix_3x.c
+++ b/gfx/video_filters/dot_matrix_3x.c
@@ -33,9 +33,20 @@
 
 typedef struct
 {
-   uint16_t r;
-   uint16_t g;
-   uint16_t b;
+   struct
+   {
+      uint32_t r;
+      uint32_t g;
+      uint32_t b;
+   } xrgb8888;
+
+   struct
+   {
+      uint16_t r;
+      uint16_t g;
+      uint16_t b;
+   } rgb565;
+
 } dot_matrix_3x_grid_color_t;
 
 struct softfilter_thread_data
@@ -61,7 +72,7 @@ struct filter_data
 
 static unsigned dot_matrix_3x_generic_input_fmts(void)
 {
-   return SOFTFILTER_FMT_RGB565;
+   return SOFTFILTER_FMT_RGB565 | SOFTFILTER_FMT_XRGB8888;
 }
 
 static unsigned dot_matrix_3x_generic_output_fmts(unsigned input_fmts)
@@ -86,9 +97,14 @@ static void dot_matrix_3x_initialize(struct filter_data *filt,
          DOT_MATRIX_3X_DEFAULT_GRID_COLOR);
 
    /* Split into 5bit RGB components */
-   filt->grid_color.r = (grid_color >> 19) & 0x1F;
-   filt->grid_color.g = (grid_color >> 11) & 0x1F;
-   filt->grid_color.b = (grid_color >>  3) & 0x1F;
+   filt->grid_color.rgb565.r = (grid_color >> 19) & 0x1F;
+   filt->grid_color.rgb565.g = (grid_color >> 11) & 0x1F;
+   filt->grid_color.rgb565.b = (grid_color >>  3) & 0x1F;
+
+   /* Split into 8bit RGB components */
+   filt->grid_color.xrgb8888.r = (grid_color >> 16) & 0xFF;
+   filt->grid_color.xrgb8888.g = (grid_color >>  8) & 0xFF;
+   filt->grid_color.xrgb8888.b =  grid_color        & 0xFF;
 }
 
 static void *dot_matrix_3x_generic_create(const struct softfilter_config *config,
@@ -143,12 +159,12 @@ static void dot_matrix_3x_work_cb_rgb565(void *data, void *thread_data)
    struct softfilter_thread_data *thr = (struct softfilter_thread_data*)thread_data;
    const uint16_t *input              = (const uint16_t*)thr->in_data;
    uint16_t *output                   = (uint16_t*)thr->out_data;
-   unsigned in_stride                 = (unsigned)(thr->in_pitch >> 1);
-   unsigned out_stride                = (unsigned)(thr->out_pitch >> 1);
-   uint16_t base_grid_r                = filt->grid_color.r;
-   uint16_t base_grid_g                = filt->grid_color.g;
-   uint16_t base_grid_b                = filt->grid_color.b;
-   unsigned x, y;
+   uint16_t in_stride                 = (uint16_t)(thr->in_pitch >> 1);
+   uint16_t out_stride                = (uint16_t)(thr->out_pitch >> 1);
+   uint16_t base_grid_r               = filt->grid_color.rgb565.r;
+   uint16_t base_grid_g               = filt->grid_color.rgb565.g;
+   uint16_t base_grid_b               = filt->grid_color.rgb565.b;
+   uint16_t x, y;
 
    for (y = 0; y < thr->height; ++y)
    {
@@ -167,6 +183,69 @@ static void dot_matrix_3x_work_cb_rgb565(void *data, void *thread_data)
          uint16_t grid_g        = DOT_MATRIX_3X_WEIGHT_10_6(pixel_g, base_grid_g);
          uint16_t grid_b        = DOT_MATRIX_3X_WEIGHT_10_6(pixel_b, base_grid_b);
          uint16_t grid_color    = (grid_r << 11) | (grid_g << 6) | grid_b;
+
+         /* - Pixel layout (p = pixel, g = grid) -
+          * Before:  After:
+          * (p)      (g)(p)(p)
+          *          (g)(p)(p)
+          *          (g)(g)(g)
+          */
+
+         /* Row 1: (g)(p)(p) */
+         *out_line_ptr       = grid_color;
+         *(out_line_ptr + 1) = pixel_color;
+         *(out_line_ptr + 2) = pixel_color;
+         out_line_ptr       += out_stride;
+
+         /* Row 2: (g)(p)(p) */
+         *out_line_ptr       = grid_color;
+         *(out_line_ptr + 1) = pixel_color;
+         *(out_line_ptr + 2) = pixel_color;
+         out_line_ptr       += out_stride;
+
+         /* Row 3: (g)(g)(g) */
+         *out_line_ptr       = grid_color;
+         *(out_line_ptr + 1) = grid_color;
+         *(out_line_ptr + 2) = grid_color;
+
+         out_ptr += 3;
+      }
+
+      input  += in_stride;
+      output += out_stride * 3;
+   }
+}
+
+static void dot_matrix_3x_work_cb_xrgb8888(void *data, void *thread_data)
+{
+   struct filter_data *filt           = (struct filter_data*)data;
+   struct softfilter_thread_data *thr = (struct softfilter_thread_data*)thread_data;
+   const uint32_t *input              = (const uint32_t*)thr->in_data;
+   uint32_t *output                   = (uint32_t*)thr->out_data;
+   uint32_t in_stride                 = (uint32_t)(thr->in_pitch >> 2);
+   uint32_t out_stride                = (uint32_t)(thr->out_pitch >> 2);
+   uint32_t base_grid_r               = filt->grid_color.xrgb8888.r;
+   uint32_t base_grid_g               = filt->grid_color.xrgb8888.g;
+   uint32_t base_grid_b               = filt->grid_color.xrgb8888.b;
+   uint32_t x, y;
+
+   for (y = 0; y < thr->height; ++y)
+   {
+      uint32_t *out_ptr = output;
+
+      for (x = 0; x < thr->width; ++x)
+      {
+         uint32_t *out_line_ptr = out_ptr;
+         uint32_t pixel_color   = *(input + x);
+         uint32_t pixel_r       = (pixel_color >> 16 & 0xFF);
+         uint32_t pixel_g       = (pixel_color >>  8 & 0xFF);
+         uint32_t pixel_b       = (pixel_color       & 0xFF);
+         /* Get grid colour
+          * > 10:6 mix of pixel_color:base_grid_color */
+         uint32_t grid_r        = DOT_MATRIX_3X_WEIGHT_10_6(pixel_r, base_grid_r);
+         uint32_t grid_g        = DOT_MATRIX_3X_WEIGHT_10_6(pixel_g, base_grid_g);
+         uint32_t grid_b        = DOT_MATRIX_3X_WEIGHT_10_6(pixel_b, base_grid_b);
+         uint32_t grid_color    = (grid_r << 16) | (grid_g << 8) | grid_b;
 
          /* - Pixel layout (p = pixel, g = grid) -
           * Before:  After:
@@ -220,6 +299,8 @@ static void dot_matrix_3x_generic_packets(void *data,
 
    if (filt->in_fmt == SOFTFILTER_FMT_RGB565)
       packets[0].work = dot_matrix_3x_work_cb_rgb565;
+   else if (filt->in_fmt == SOFTFILTER_FMT_XRGB8888)
+      packets[0].work = dot_matrix_3x_work_cb_xrgb8888;
 
    packets[0].thread_data = thr;
 }

--- a/gfx/video_filters/gameboy4x.c
+++ b/gfx/video_filters/gameboy4x.c
@@ -38,9 +38,20 @@
 
 typedef struct
 {
-   uint16_t pixel_lut[4];
-   uint16_t shadow_lut[4];
-   uint16_t grid_lut[4];
+   struct
+   {
+      uint32_t pixel_lut[4];
+      uint32_t shadow_lut[4];
+      uint32_t grid_lut[4];
+   } xrgb8888;
+
+   struct
+   {
+      uint16_t pixel_lut[4];
+      uint16_t shadow_lut[4];
+      uint16_t grid_lut[4];
+   } rgb565;
+
 } gameboy4x_colors_t;
 
 struct softfilter_thread_data
@@ -66,7 +77,7 @@ struct filter_data
 
 static unsigned gameboy4x_generic_input_fmts(void)
 {
-   return SOFTFILTER_FMT_RGB565;
+   return SOFTFILTER_FMT_RGB565 | SOFTFILTER_FMT_XRGB8888;
 }
 
 static unsigned gameboy4x_generic_output_fmts(unsigned input_fmts)
@@ -128,15 +139,18 @@ static void gameboy4x_initialize(struct filter_data *filt,
       uint32_t shadow_color;
       uint32_t grid_color;
 
-      /* Populate pixel lookup table */
-      filt->colors.pixel_lut[i] = GAMEBOY_4X_RGB24_TO_RGB565(palette[i]);
+      /* Populate pixel lookup tables */
+      filt->colors.rgb565.pixel_lut[i]   = GAMEBOY_4X_RGB24_TO_RGB565(palette[i]);
+      filt->colors.xrgb8888.pixel_lut[i] = palette[i];
 
-      /* Populate pixel shadow lookup table
+      /* Populate pixel shadow lookup tables
        * > 4:3 mix of palette:grid */
       shadow_color = gameboy4x_get_weighted_colour(palette[i], palette_grid, 4, 3);
-      filt->colors.shadow_lut[i] = GAMEBOY_4X_RGB24_TO_RGB565(shadow_color);
 
-      /* Populate grid lookup table
+      filt->colors.rgb565.shadow_lut[i]   = GAMEBOY_4X_RGB24_TO_RGB565(shadow_color);
+      filt->colors.xrgb8888.shadow_lut[i] = shadow_color;
+
+      /* Populate grid lookup tables
        * > 2:3 mix of palette:grid
        * > Would like to set this to the pure grid
        *   colour (to highlight the pixel shadow
@@ -144,7 +158,9 @@ static void gameboy4x_initialize(struct filter_data *filt,
        *   2:3 is about as light as we can make this
        *   without producing ugly optical illusions */
       grid_color = gameboy4x_get_weighted_colour(palette[i], palette_grid, 2, 3);
-      filt->colors.grid_lut[i] = GAMEBOY_4X_RGB24_TO_RGB565(grid_color);
+
+      filt->colors.rgb565.grid_lut[i]   = GAMEBOY_4X_RGB24_TO_RGB565(grid_color);
+      filt->colors.xrgb8888.grid_lut[i] = grid_color;
    }
 }
 
@@ -200,12 +216,12 @@ static void gameboy4x_work_cb_rgb565(void *data, void *thread_data)
    struct softfilter_thread_data *thr = (struct softfilter_thread_data*)thread_data;
    const uint16_t *input              = (const uint16_t*)thr->in_data;
    uint16_t *output                   = (uint16_t*)thr->out_data;
-   unsigned in_stride                 = (unsigned)(thr->in_pitch >> 1);
-   unsigned out_stride                = (unsigned)(thr->out_pitch >> 1);
-   uint16_t *pixel_lut                = filt->colors.pixel_lut;
-   uint16_t *shadow_lut               = filt->colors.shadow_lut;
-   uint16_t *grid_lut                 = filt->colors.grid_lut;
-   unsigned x, y;
+   uint16_t in_stride                 = (uint16_t)(thr->in_pitch >> 1);
+   uint16_t out_stride                = (uint16_t)(thr->out_pitch >> 1);
+   uint16_t *pixel_lut                = filt->colors.rgb565.pixel_lut;
+   uint16_t *shadow_lut               = filt->colors.rgb565.shadow_lut;
+   uint16_t *grid_lut                 = filt->colors.rgb565.grid_lut;
+   uint16_t x, y;
 
    for (y = 0; y < thr->height; ++y)
    {
@@ -222,7 +238,7 @@ static void gameboy4x_work_cb_rgb565(void *data, void *thread_data)
          uint16_t out_pixel_color;
          uint16_t out_shadow_color;
          uint16_t out_grid_color;
-         uint8_t  lut_index;
+         uint16_t lut_index;
 
          /* Calculate mean value of the 3 RGB
           * colour components */
@@ -235,6 +251,97 @@ static void gameboy4x_work_cb_rgb565(void *data, void *thread_data)
           * > This can never be greater than 3,
           *   but check anyway... */
          lut_index = in_rgb_mean >> 3;
+         lut_index = (lut_index > 3) ? 3 : lut_index;
+
+         /* Get output pixel, pixel shadow and grid colours */
+         out_pixel_color  = *(pixel_lut + lut_index);
+         out_shadow_color = *(shadow_lut + lut_index);
+         out_grid_color   = *(grid_lut + lut_index);
+
+         /* - Pixel layout (p = pixel, s = shadow, g = grid) -
+          * Before:  After:
+          * (p)      (g)(p)(p)(p)
+          *          (s)(p)(p)(p)
+          *          (s)(p)(p)(p)
+          *          (s)(s)(s)(g)
+          */
+
+         /* Row 1: (g)(p)(p)(p) */
+         *out_line_ptr       = out_grid_color;
+         *(out_line_ptr + 1) = out_pixel_color;
+         *(out_line_ptr + 2) = out_pixel_color;
+         *(out_line_ptr + 3) = out_pixel_color;
+         out_line_ptr       += out_stride;
+
+         /* Row 2: (s)(p)(p)(p) */
+         *out_line_ptr       = out_shadow_color;
+         *(out_line_ptr + 1) = out_pixel_color;
+         *(out_line_ptr + 2) = out_pixel_color;
+         *(out_line_ptr + 3) = out_pixel_color;
+         out_line_ptr       += out_stride;
+
+         /* Row 3: (s)(p)(p)(p) */
+         *out_line_ptr       = out_shadow_color;
+         *(out_line_ptr + 1) = out_pixel_color;
+         *(out_line_ptr + 2) = out_pixel_color;
+         *(out_line_ptr + 3) = out_pixel_color;
+         out_line_ptr       += out_stride;
+
+         /* Row 4: (s)(s)(s)(g) */
+         *out_line_ptr       = out_shadow_color;
+         *(out_line_ptr + 1) = out_shadow_color;
+         *(out_line_ptr + 2) = out_shadow_color;
+         *(out_line_ptr + 3) = out_grid_color;
+
+         out_ptr += 4;
+      }
+
+      input  += in_stride;
+      output += out_stride << 2;
+   }
+}
+
+static void gameboy4x_work_cb_xrgb8888(void *data, void *thread_data)
+{
+   struct filter_data *filt           = (struct filter_data*)data;
+   struct softfilter_thread_data *thr = (struct softfilter_thread_data*)thread_data;
+   const uint32_t *input              = (const uint32_t*)thr->in_data;
+   uint32_t *output                   = (uint32_t*)thr->out_data;
+   uint32_t in_stride                 = (uint32_t)(thr->in_pitch >> 2);
+   uint32_t out_stride                = (uint32_t)(thr->out_pitch >> 2);
+   uint32_t *pixel_lut                = filt->colors.xrgb8888.pixel_lut;
+   uint32_t *shadow_lut               = filt->colors.xrgb8888.shadow_lut;
+   uint32_t *grid_lut                 = filt->colors.xrgb8888.grid_lut;
+   uint32_t x, y;
+
+   for (y = 0; y < thr->height; ++y)
+   {
+      uint32_t *out_ptr = output;
+
+      for (x = 0; x < thr->width; ++x)
+      {
+         uint32_t *out_line_ptr = out_ptr;
+         uint32_t in_color      = *(input + x);
+         uint32_t in_rgb_mean   =
+               (in_color >> 16 & 0xFF) +
+               (in_color >>  8 & 0xFF) +
+               (in_color       & 0xFF);
+         uint32_t out_pixel_color;
+         uint32_t out_shadow_color;
+         uint32_t out_grid_color;
+         uint32_t lut_index;
+
+         /* Calculate mean value of the 3 RGB
+          * colour components */
+         in_rgb_mean += (in_rgb_mean +   2) >> 2;
+         in_rgb_mean += (in_rgb_mean +   8) >> 4;
+         in_rgb_mean += (in_rgb_mean + 128) >> 8;
+         in_rgb_mean >>= 2;
+
+         /* Convert to lookup table index
+          * > This can never be greater than 3,
+          *   but check anyway... */
+         lut_index = in_rgb_mean >> 6;
          lut_index = (lut_index > 3) ? 3 : lut_index;
 
          /* Get output pixel, pixel shadow and grid colours */
@@ -305,6 +412,8 @@ static void gameboy4x_generic_packets(void *data,
 
    if (filt->in_fmt == SOFTFILTER_FMT_RGB565)
       packets[0].work = gameboy4x_work_cb_rgb565;
+   else if (filt->in_fmt == SOFTFILTER_FMT_XRGB8888)
+      packets[0].work = gameboy4x_work_cb_xrgb8888;
 
    packets[0].thread_data = thr;
 }

--- a/gfx/video_filters/grid2x.c
+++ b/gfx/video_filters/grid2x.c
@@ -108,11 +108,11 @@ static void grid2x_generic_destroy(void *data)
 static void grid2x_work_cb_xrgb8888(void *data, void *thread_data)
 {
    struct softfilter_thread_data *thr = (struct softfilter_thread_data*)thread_data;
-   const uint32_t *input = (const uint32_t*)thr->in_data;
-   uint32_t *output = (uint32_t*)thr->out_data;
-   unsigned in_stride = (unsigned)(thr->in_pitch >> 2);
-   unsigned out_stride = (unsigned)(thr->out_pitch >> 2);
-   unsigned x, y;
+   const uint32_t *input              = (const uint32_t*)thr->in_data;
+   uint32_t *output                   = (uint32_t*)thr->out_data;
+   uint32_t in_stride                 = (uint32_t)(thr->in_pitch >> 2);
+   uint32_t out_stride                = (uint32_t)(thr->out_pitch >> 2);
+   uint32_t x, y;
 
    for (y = 0; y < thr->height; ++y)
    {
@@ -124,10 +124,10 @@ static void grid2x_work_cb_xrgb8888(void *data, void *thread_data)
           * byte swapping issues */
          uint32_t *out_line_ptr  = out_ptr;
          uint32_t color          = *(input + x);
-         uint8_t  p              = (color >> 24 & 0xFF); /* Padding bits */
-         uint8_t  r              = (color >> 16 & 0xFF);
-         uint8_t  g              = (color >>  8 & 0xFF);
-         uint8_t  b              = (color       & 0xFF);
+         uint32_t p              = (color >> 24 & 0xFF); /* Padding bits */
+         uint32_t r              = (color >> 16 & 0xFF);
+         uint32_t g              = (color >>  8 & 0xFF);
+         uint32_t b              = (color       & 0xFF);
          uint32_t scanline_color =
                ((p - (p >> 2)) << 24) |
                ((r - (r >> 2)) << 16) |
@@ -154,11 +154,11 @@ static void grid2x_work_cb_xrgb8888(void *data, void *thread_data)
 static void grid2x_work_cb_rgb565(void *data, void *thread_data)
 {
    struct softfilter_thread_data *thr = (struct softfilter_thread_data*)thread_data;
-   const uint16_t *input = (const uint16_t*)thr->in_data;
-   uint16_t *output = (uint16_t*)thr->out_data;
-   unsigned in_stride = (unsigned)(thr->in_pitch >> 1);
-   unsigned out_stride = (unsigned)(thr->out_pitch >> 1);
-   unsigned x, y;
+   const uint16_t *input              = (const uint16_t*)thr->in_data;
+   uint16_t *output                   = (uint16_t*)thr->out_data;
+   uint16_t in_stride                 = (uint16_t)(thr->in_pitch >> 1);
+   uint16_t out_stride                = (uint16_t)(thr->out_pitch >> 1);
+   uint16_t x, y;
 
    for (y = 0; y < thr->height; ++y)
    {
@@ -167,9 +167,9 @@ static void grid2x_work_cb_rgb565(void *data, void *thread_data)
       {
          uint16_t *out_line_ptr  = out_ptr;
          uint16_t color          = *(input + x);
-         uint8_t  r              = (color >> 11 & 0x1F);
-         uint8_t  g              = (color >>  6 & 0x1F);
-         uint8_t  b              = (color       & 0x1F);
+         uint16_t r              = (color >> 11 & 0x1F);
+         uint16_t g              = (color >>  6 & 0x1F);
+         uint16_t b              = (color       & 0x1F);
          uint16_t scanline_color =
                ((r - (r >> 2)) << 11) |
                ((g - (g >> 2)) <<  6) |

--- a/gfx/video_filters/normal2x.c
+++ b/gfx/video_filters/normal2x.c
@@ -108,11 +108,11 @@ static void normal2x_generic_destroy(void *data)
 static void normal2x_work_cb_xrgb8888(void *data, void *thread_data)
 {
    struct softfilter_thread_data *thr = (struct softfilter_thread_data*)thread_data;
-   const uint32_t *input = (const uint32_t*)thr->in_data;
-   uint32_t *output = (uint32_t*)thr->out_data;
-   unsigned in_stride = (unsigned)(thr->in_pitch >> 2);
-   unsigned out_stride = (unsigned)(thr->out_pitch >> 2);
-   unsigned x, y;
+   const uint32_t *input              = (const uint32_t*)thr->in_data;
+   uint32_t *output                   = (uint32_t*)thr->out_data;
+   uint32_t in_stride                 = (uint32_t)(thr->in_pitch >> 2);
+   uint32_t out_stride                = (uint32_t)(thr->out_pitch >> 2);
+   uint32_t x, y;
 
    for (y = 0; y < thr->height; ++y)
    {
@@ -142,11 +142,11 @@ static void normal2x_work_cb_xrgb8888(void *data, void *thread_data)
 static void normal2x_work_cb_rgb565(void *data, void *thread_data)
 {
    struct softfilter_thread_data *thr = (struct softfilter_thread_data*)thread_data;
-   const uint16_t *input = (const uint16_t*)thr->in_data;
-   uint16_t *output = (uint16_t*)thr->out_data;
-   unsigned in_stride = (unsigned)(thr->in_pitch >> 1);
-   unsigned out_stride = (unsigned)(thr->out_pitch >> 1);
-   unsigned x, y;
+   const uint16_t *input              = (const uint16_t*)thr->in_data;
+   uint16_t *output                   = (uint16_t*)thr->out_data;
+   uint16_t in_stride                 = (uint16_t)(thr->in_pitch >> 1);
+   uint16_t out_stride                = (uint16_t)(thr->out_pitch >> 1);
+   uint16_t x, y;
 
    for (y = 0; y < thr->height; ++y)
    {

--- a/gfx/video_filters/scanline2x.c
+++ b/gfx/video_filters/scanline2x.c
@@ -108,11 +108,11 @@ static void scanline2x_generic_destroy(void *data)
 static void scanline2x_work_cb_xrgb8888(void *data, void *thread_data)
 {
    struct softfilter_thread_data *thr = (struct softfilter_thread_data*)thread_data;
-   const uint32_t *input = (const uint32_t*)thr->in_data;
-   uint32_t *output = (uint32_t*)thr->out_data;
-   unsigned in_stride = (unsigned)(thr->in_pitch >> 2);
-   unsigned out_stride = (unsigned)(thr->out_pitch >> 2);
-   unsigned x, y;
+   const uint32_t *input              = (const uint32_t*)thr->in_data;
+   uint32_t *output                   = (uint32_t*)thr->out_data;
+   uint32_t in_stride                 = (uint32_t)(thr->in_pitch >> 2);
+   uint32_t out_stride                = (uint32_t)(thr->out_pitch >> 2);
+   uint32_t x, y;
 
    for (y = 0; y < thr->height; ++y)
    {
@@ -124,10 +124,10 @@ static void scanline2x_work_cb_xrgb8888(void *data, void *thread_data)
           * byte swapping issues */
          uint32_t *out_line_ptr  = out_ptr;
          uint32_t color          = *(input + x);
-         uint8_t  p              = (color >> 24 & 0xFF); /* Padding bits */
-         uint8_t  r              = (color >> 16 & 0xFF);
-         uint8_t  g              = (color >>  8 & 0xFF);
-         uint8_t  b              = (color       & 0xFF);
+         uint32_t  p             = (color >> 24 & 0xFF); /* Padding bits */
+         uint32_t  r             = (color >> 16 & 0xFF);
+         uint32_t  g             = (color >>  8 & 0xFF);
+         uint32_t  b             = (color       & 0xFF);
          uint32_t scanline_color =
                ((p - (p >> 2)) << 24) |
                ((r - (r >> 2)) << 16) |
@@ -154,11 +154,11 @@ static void scanline2x_work_cb_xrgb8888(void *data, void *thread_data)
 static void scanline2x_work_cb_rgb565(void *data, void *thread_data)
 {
    struct softfilter_thread_data *thr = (struct softfilter_thread_data*)thread_data;
-   const uint16_t *input = (const uint16_t*)thr->in_data;
-   uint16_t *output = (uint16_t*)thr->out_data;
-   unsigned in_stride = (unsigned)(thr->in_pitch >> 1);
-   unsigned out_stride = (unsigned)(thr->out_pitch >> 1);
-   unsigned x, y;
+   const uint16_t *input              = (const uint16_t*)thr->in_data;
+   uint16_t *output                   = (uint16_t*)thr->out_data;
+   uint16_t in_stride                 = (uint16_t)(thr->in_pitch >> 1);
+   uint16_t out_stride                = (uint16_t)(thr->out_pitch >> 1);
+   uint16_t x, y;
 
    for (y = 0; y < thr->height; ++y)
    {
@@ -167,9 +167,9 @@ static void scanline2x_work_cb_rgb565(void *data, void *thread_data)
       {
          uint16_t *out_line_ptr  = out_ptr;
          uint16_t color          = *(input + x);
-         uint8_t  r              = (color >> 11 & 0x1F);
-         uint8_t  g              = (color >>  6 & 0x1F);
-         uint8_t  b              = (color       & 0x1F);
+         uint16_t r              = (color >> 11 & 0x1F);
+         uint16_t g              = (color >>  6 & 0x1F);
+         uint16_t b              = (color       & 0x1F);
          uint16_t scanline_color =
                ((r - (r >> 2)) << 11) |
                ((g - (g >> 2)) <<  6) |


### PR DESCRIPTION
## Description

This is a follow-up to PR #11371. It adds XRGB8888 support to the `Gameboy3x`, `Gameboy4x`, `Dot_Matrix_3x` and `Dot_Matrix_4x` video filters. They can now be used with the SameBoy core :)

![Screenshot_2020-09-25_16-24-24](https://user-images.githubusercontent.com/38211560/94286764-57deb800-ff4d-11ea-9317-4238118a6449.png)
 
![Screenshot_2020-09-25_16-26-06](https://user-images.githubusercontent.com/38211560/94286774-5b723f00-ff4d-11ea-9665-c54225d81c6f.png)

(While doing this, I also removed some unnecessary implicit typecasts from the `Normal2x`, `Scanline2x` and `Grid2x` filters - this has no real performance impact, but typecasts can potentially waste a few instructions, and it bothered me...)