### PR TITLE
(udev/linuxraw/wayland) Fix return key keyboard input

### DIFF
--- a/input/common/wayland_common.c
+++ b/input/common/wayland_common.c
@@ -72,24 +72,38 @@ static void keyboard_handle_key(void *data,
 {
    int value                  = 1;
    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
+   uint32_t keysym            = key;
+
+   /* Handle 'duplicate' inputs that correspond
+    * to the same RETROK_* key */
+   switch (key)
+   {
+      case KEY_OK:
+      case KEY_SELECT:
+         keysym = KEY_ENTER;
+      case KEY_EXIT:
+         keysym = KEY_CLEAR;
+      default:
+         break;
+   }
 
    if (state == WL_KEYBOARD_KEY_STATE_PRESSED)
    {
-      BIT_SET(wl->input.key_state, key);
+      BIT_SET(wl->input.key_state, keysym);
       value = 1;
    }
    else if (state == WL_KEYBOARD_KEY_STATE_RELEASED)
    {
-      BIT_CLEAR(wl->input.key_state, key);
+      BIT_CLEAR(wl->input.key_state, keysym);
       value = 0;
    }
 
 #ifdef HAVE_XKBCOMMON
-   if (handle_xkb(key, value) == 0)
+   if (handle_xkb(keysym, value) == 0)
       return;
 #endif
    input_keyboard_event(value,
-			input_keymaps_translate_keysym_to_rk(key),
+			input_keymaps_translate_keysym_to_rk(keysym),
          0, 0, RETRO_DEVICE_KEYBOARD);
 }
 

--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -155,14 +155,22 @@ int handle_xkb(int code, int value);
 static unsigned input_unify_ev_key_code(unsigned code)
 {
    /* input_keymaps_translate_keysym_to_rk does not support the case
-      where multiple keysyms translate to the same RETROK_* code,
-      so unify remote control keysyms to keyboard keysyms here.  */
+    * where multiple keysyms translate to the same RETROK_* code,
+    * so unify remote control keysyms to keyboard keysyms here.
+    *
+    * Addendum: The rarch_keysym_lut lookup table also becomes
+    * unusable if more than one keysym translates to the same
+    * RETROK_* code, so certain keys must be left unmapped in
+    * rarch_key_map_linux and instead be handled here */
    switch (code)
    {
       case KEY_OK:
+      case KEY_SELECT:
          return KEY_ENTER;
       case KEY_BACK:
          return KEY_BACKSPACE;
+      case KEY_EXIT:
+         return KEY_CLEAR;
       default:
          break;
    }

--- a/input/drivers_joypad/udev_joypad.c
+++ b/input/drivers_joypad/udev_joypad.c
@@ -552,7 +552,7 @@ static void *udev_joypad_init(void *data)
 
    udev_joypad_fd = udev_new();
    if (!udev_joypad_fd)
-      return false;
+      return NULL;
 
    udev_joypad_mon = udev_monitor_new_from_netlink(udev_joypad_fd, "udev");
    if (udev_joypad_mon)

--- a/input/input_keymaps.c
+++ b/input/input_keymaps.c
@@ -981,14 +981,18 @@ const struct rarch_key_map rarch_key_map_x11[] = {
 #endif
 
 #if defined(__linux__) || defined(HAVE_WAYLAND)
+/* Note: Only one input can be mapped to each
+ * RETROK_* key. If several physical inputs
+ * correspond to the same key, these inputs
+ * must be merged at the input driver level */
 const struct rarch_key_map rarch_key_map_linux[] = {
    { KEY_BACKSPACE, RETROK_BACKSPACE },
    { KEY_TAB, RETROK_TAB },
    { KEY_CLEAR, RETROK_CLEAR },
-   { KEY_EXIT, RETROK_CLEAR },
+   /* { KEY_EXIT, RETROK_CLEAR }, */     /* Duplicate - Skip */
    { KEY_ENTER, RETROK_RETURN },
-   { KEY_OK, RETROK_RETURN },
-   { KEY_SELECT, RETROK_RETURN },
+   /* { KEY_OK, RETROK_RETURN }, */      /* Duplicate - Skip */
+   /* { KEY_SELECT, RETROK_RETURN }, */  /* Duplicate - Skip */
    { KEY_PAUSE, RETROK_PAUSE },
    { KEY_ESC, RETROK_ESCAPE },
    { KEY_SPACE, RETROK_SPACE },


### PR DESCRIPTION
## Description

At present, when using the udev, linuxraw or wayland input driver, the keyboard `return` (enter) key is not mapped correctly. It cannot be used for menu navigation, nor does it register if bound to a RetroPad input - which is awkward, since it is bound to `start` by default. (This also affects the 'exit' key, but I doubt many users would notice that one...)

This happens because these drivers use the `rarch_key_map_linux` keyboard map, which has multiple inputs connected to the same `RETROK_*` key. We cannot do this - 'duplicate' inputs completely break the keymap lookup table, since the key that is pressed will mistakenly be registered as the last duplicate entry (so `return` in this case is never seen as `return`).

This fairly trivial PR fixes the issue - the `return` key can be used normally with all input drivers.

(Side note: this PR also includes a `udev_joypad.c` CXX build fix, as I couldn't test-compile my changes without doing this!)

## Related Issues

This closes #11374
