### PR TITLE
libnx: fix touch, mouse and KB input

### DIFF
--- a/input/drivers/switch_input.c
+++ b/input/drivers/switch_input.c
@@ -281,6 +281,8 @@ static void switch_input_poll(void *data)
 
 static int16_t switch_input_state(
       void *data,
+      const input_device_driver_t *joypad,
+      const input_device_driver_t *sec_joypad,
       rarch_joypad_info_t *joypad_info,
       const struct retro_keybind **binds,
       bool keyboard_mapping_blocked,


### PR DESCRIPTION
## Description

This PR means to fix touch, mouse and keyboard input on the switch libnx target.

Regression seems to be caused by 5f08605. It would compile fine with a different prototype, and exit early to the first condition ( `port > DEFAULT_MAX_PADS - 1` ).

Only touch had been reported broken but from the look of it, it also affected mouse and keyboard 