### PR TITLE
(video/d3d11): Fix shaders with scaled framebuffers

### DIFF
--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -1522,6 +1522,7 @@ static bool d3d11_gfx_frame(
 #if 0
          D3D11ClearRenderTargetView(context, d3d11->pass[i].rt.rt_view, d3d11->clearcolor);
 #endif
+         d3d11_clear_scissor(d3d11, d3d11->pass[i].rt.desc.Width, d3d11->pass[i].rt.desc.Height);
          D3D11SetViewports(context, 1, &d3d11->pass[i].viewport);
 
          D3D11Draw(context, 4, 0);


### PR DESCRIPTION
Follow-up to #11392.

The scissor rectangle was left as whatever the core last used. Fixes shaders which use scaled framebuffers such as aa level 2, xsoft4, crt-royale, etc.