### PR TITLE
Fix typo in menu_cbs_ok.c

### DIFF
--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -2972,7 +2972,7 @@ static int action_ok_video_filter_remove(const char *path,
    settings_t *settings = config_get_ptr();
 
    if (!settings)
-      menu_cbs_exit();
+      return menu_cbs_exit();
 
    if (!string_is_empty(settings->paths.path_softfilter_plugin))
    {


### PR DESCRIPTION
## Description

This trivial PR fixes a tiny typo in #11398 (thanks to the lgtm-com bot!)

It was actually harmless, since the condition can never be true - but it's still a mistake...