### PR TITLE
OpenDingux: Enable integer scaling when using the 'sdl_dingux' gfx driver

### DIFF
--- a/dingux/dingux_utils.c
+++ b/dingux/dingux_utils.c
@@ -22,6 +22,7 @@
 
 #define DINGUX_ALLOW_DOWNSCALING_FILE "/sys/devices/platform/jz-lcd.0/allow_downscaling"
 #define DINGUX_KEEP_ASPECT_RATIO_FILE "/sys/devices/platform/jz-lcd.0/keep_aspect_ratio"
+#define DINGUX_INTEGER_SCALING_FILE   "/sys/devices/platform/jz-lcd.0/integer_scaling"
 #define DINGUX_BATTERY_CAPACITY_FILE  "/sys/class/power_supply/battery/capacity"
 
 /* Enables/disables downscaling when using
@@ -47,6 +48,22 @@ bool dingux_ipu_set_downscaling_enable(bool enable)
 bool dingux_ipu_set_aspect_ratio_enable(bool enable)
 {
    const char *path       = DINGUX_KEEP_ASPECT_RATIO_FILE;
+   const char *enable_str = enable ? "1" : "0";
+
+   /* Check whether file exists */
+   if (!path_is_valid(path))
+      return false;
+
+   /* Write enable state to file */
+   return filestream_write_file(
+         path, enable_str, 1);
+}
+
+/* Enables/disables integer scaling when
+ * when using the IPU hardware scaler */
+bool dingux_ipu_set_integer_scaling_enable(bool enable)
+{
+   const char *path       = DINGUX_INTEGER_SCALING_FILE;
    const char *enable_str = enable ? "1" : "0";
 
    /* Check whether file exists */

--- a/dingux/dingux_utils.h
+++ b/dingux/dingux_utils.h
@@ -35,6 +35,10 @@ bool dingux_ipu_set_downscaling_enable(bool enable);
  * image to the full screen dimensions) */
 bool dingux_ipu_set_aspect_ratio_enable(bool enable);
 
+/* Enables/disables integer scaling when
+ * when using the IPU hardware scaler */
+bool dingux_ipu_set_integer_scaling_enable(bool enable);
+
 /* Fetches internal battery level */
 int dingux_get_battery_level(void);
 

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -7361,6 +7361,10 @@ unsigned menu_displaylist_build_list(
             if (string_is_equal(settings->arrays.video_driver, "sdl_dingux"))
             {
                if (MENU_DISPLAYLIST_PARSE_SETTINGS_ENUM(list,
+                        MENU_ENUM_LABEL_VIDEO_SCALE_INTEGER,
+                        PARSE_ONLY_BOOL, false) == 0)
+                  count++;
+               if (MENU_DISPLAYLIST_PARSE_SETTINGS_ENUM(list,
                         MENU_ENUM_LABEL_VIDEO_DINGUX_IPU_KEEP_ASPECT,
                         PARSE_ONLY_BOOL, false) == 0)
                   count++;


### PR DESCRIPTION
## Description

This PR enables the `Integer Scale` option for OpenDingux devices using the `sdl_dingux` gfx driver. Integer scaling is performed via the IPU hardware, so there are no additional performance overheads - in fact, turning `Integer Scale` on actually increases performance when using certain high resolution video filters (e.g. GB/GBC content with the Dot_Matrix_3x filter). I don't know why this is the case, but it's a nice side effect.

In addition to making GB/GBC (and GG, NGP, etc.) look fantastic with 3x video filters, integer scaling is important for cores that are too slow to use in conjunction with filters. By default, any content less than 240p is stretched to fit the display using bicubic filtering, which can be rather blurry - a slightly smaller, pin-sharp integer scaled image is often superior.