### PR TITLE
Qt shader fix

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -461,10 +461,10 @@ ifeq ($(HAVE_QT), 1)
           ui/drivers/qt/thumbnaildownload.o \
           ui/drivers/qt/thumbnailpackdownload.o \
           ui/drivers/qt/playlistthumbnaildownload.o
+    ifeq ($(HAVE_SHADERS_COMMON), 1)
+       OBJ += ui/drivers/qt/shaderparamsdialog.o
+    endif
     ifeq ($(HAVE_MENU), 1)
-       ifeq ($(HAVE_SHADERS_COMMON), 1)
-           OBJ += ui/drivers/qt/shaderparamsdialog.o
-       endif
        OBJ += ui/drivers/qt/settingswidgets.o \
               ui/drivers/qt/options/achievements.o \
               ui/drivers/qt/options/audio.o \
@@ -489,10 +489,10 @@ ifeq ($(HAVE_QT), 1)
                   ui/drivers/qt/coreinfodialog.h \
                   ui/drivers/qt/playlistentrydialog.h \
                   ui/drivers/qt/viewoptionsdialog.h
+   ifeq ($(HAVE_SHADERS_COMMON), 1)
+      MOC_HEADERS += ui/drivers/qt/shaderparamsdialog.h
+   endif
    ifeq ($(HAVE_MENU), 1)
-      ifeq ($(HAVE_SHADERS_COMMON), 1)
-         MOC_HEADERS += ui/drivers/qt/shaderparamsdialog.h
-      endif
       MOC_HEADERS += ui/drivers/qt/settingswidgets.h \
                      ui/drivers/qt/options/options.h
    endif

--- a/ui/drivers/qt/shaderparamsdialog.cpp
+++ b/ui/drivers/qt/shaderparamsdialog.cpp
@@ -489,6 +489,10 @@ void ShaderParamsDialog::onShaderLoadPresetClicked()
    struct video_shader *video_shader = NULL;
    const char *pathData              = NULL;
    enum rarch_shader_type type       = RARCH_SHADER_NONE;
+#if !defined(HAVE_MENU)
+   settings_t *settings              = config_get_ptr();
+   const char *path_dir_video_shader = settings->paths.directory_video_shader;
+#endif
 
    getShaders(&menu_shader, &video_shader);
 
@@ -512,7 +516,11 @@ void ShaderParamsDialog::onShaderLoadPresetClicked()
    path       = QFileDialog::getOpenFileName(
          this,
          msg_hash_to_str(MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET),
+#if defined(HAVE_MENU)
          menu_driver_get_last_shader_preset_dir(),
+#else
+         path_dir_video_shader,
+#endif
          filter);
 
    if (path.isEmpty())
@@ -522,8 +530,10 @@ void ShaderParamsDialog::onShaderLoadPresetClicked()
    pathData   = pathArray.constData();
    type       = video_shader_parse_type(pathData);
 
+#if defined(HAVE_MENU)
    /* Cache selected shader parent directory */
    menu_driver_set_last_shader_preset_dir(pathData);
+#endif
 
    menu_shader_manager_set_preset(menu_shader, type, pathData, true);
 }
@@ -630,6 +640,10 @@ void ShaderParamsDialog::onShaderAddPassClicked()
    struct video_shader *video_shader     = NULL;
    struct video_shader_pass *shader_pass = NULL;
    const char *pathData                  = NULL;
+#if !defined(HAVE_MENU)
+   settings_t *settings                  = config_get_ptr();
+   const char *path_dir_video_shader     = settings->paths.directory_video_shader;
+#endif
 
    getShaders(&menu_shader, &video_shader);
 
@@ -654,7 +668,11 @@ void ShaderParamsDialog::onShaderAddPassClicked()
    path = QFileDialog::getOpenFileName(
          this,
          msg_hash_to_str(MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET),
+#if defined(HAVE_MENU)
          menu_driver_get_last_shader_pass_dir(),
+#else
+         path_dir_video_shader,
+#endif
          filter);
 
    if (path.isEmpty())
@@ -684,8 +702,10 @@ void ShaderParamsDialog::onShaderAddPassClicked()
          pathData,
          sizeof(shader_pass->source.path));
 
+#if defined(HAVE_MENU)
    /* Cache selected shader parent directory */
    menu_driver_set_last_shader_pass_dir(pathData);
+#endif
 
    video_shader_resolve_parameters(NULL, menu_shader);
 
@@ -955,7 +975,9 @@ void ShaderParamsDialog::buildLayout()
 {
    unsigned i;
    bool hasPasses                           = false;
+#if defined(HAVE_MENU)
    CheckableSettingsGroup *topSettingsGroup = NULL;
+#endif
    QPushButton *loadButton                  = NULL;
    QPushButton *saveButton                  = NULL;
    QPushButton *removeButton                = NULL;
@@ -1094,9 +1116,11 @@ void ShaderParamsDialog::buildLayout()
 
    connect(applyButton, SIGNAL(clicked()), this, SLOT(onShaderApplyClicked()));
 
+#if defined(HAVE_MENU)
    topSettingsGroup = new CheckableSettingsGroup(MENU_ENUM_LABEL_VIDEO_SHADERS_ENABLE);
    topSettingsGroup->add(MENU_ENUM_LABEL_SHADER_WATCH_FOR_CHANGES);
    topSettingsGroup->add(MENU_ENUM_LABEL_VIDEO_SHADER_REMEMBER_LAST_DIR);
+#endif
 
    topButtonLayout = new QHBoxLayout();
    topButtonLayout->addWidget(loadButton);
@@ -1105,7 +1129,9 @@ void ShaderParamsDialog::buildLayout()
    topButtonLayout->addWidget(removePassButton);
    topButtonLayout->addWidget(applyButton);
 
+#if defined(HAVE_MENU)
    m_layout->addWidget(topSettingsGroup);
+#endif
    m_layout->addLayout(topButtonLayout);
 
    /* NOTE: We assume that parameters are always grouped in order by the pass number, e.g., all parameters for pass 0 come first, then params for pass 1, etc. */

--- a/ui/drivers/qt/ui_qt_window.cpp
+++ b/ui/drivers/qt/ui_qt_window.cpp
@@ -323,9 +323,7 @@ MainWindow::MainWindow(QWidget *parent) :
    ,m_playlistEntryDialog(NULL)
    ,m_statusMessageElapsedTimer()
 #if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)
-#ifdef HAVE_MENU
    ,m_shaderParamsDialog(new ShaderParamsDialog())
-#endif
 #endif
    ,m_coreOptionsDialog(new CoreOptionsDialog())
    ,m_networkManager(new QNetworkAccessManager(this))
@@ -685,9 +683,7 @@ MainWindow::MainWindow(QWidget *parent) :
    connect(this, SIGNAL(gotStatusMessage(QString,unsigned,unsigned,bool)), this, SLOT(onGotStatusMessage(QString,unsigned,unsigned,bool)), Qt::AutoConnection);
    connect(this, SIGNAL(gotReloadPlaylists()), this, SLOT(onGotReloadPlaylists()), Qt::AutoConnection);
 #if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)
-#ifdef HAVE_MENU
    connect(this, SIGNAL(gotReloadShaderParams()), this, SLOT(onGotReloadShaderParams()), Qt::AutoConnection);
-#endif
 #endif
    connect(this, SIGNAL(gotReloadCoreOptions()), this, SLOT(onGotReloadCoreOptions()), Qt::AutoConnection);
 
@@ -1132,7 +1128,6 @@ void MainWindow::onGotStatusMessage(
    }
 }
 
-#ifdef HAVE_MENU
 void MainWindow::deferReloadShaderParams()
 {
 #if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)
@@ -1159,7 +1154,6 @@ void MainWindow::onGotReloadShaderParams()
       m_shaderParamsDialog->reload();
 #endif
 }
-#endif
 
 void MainWindow::onCoreOptionsClicked()
 {

--- a/ui/drivers/ui_qt.cpp
+++ b/ui/drivers/ui_qt.cpp
@@ -693,11 +693,9 @@ static void ui_companion_qt_event_command(void *data, enum event_command cmd)
    {
       case CMD_EVENT_SHADERS_APPLY_CHANGES:
       case CMD_EVENT_SHADER_PRESET_LOADED:
-#ifdef HAVE_MENU
 #if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)
          RARCH_LOG("[Qt]: Reloading shader parameters.\n");
          win_handle->qtWindow->deferReloadShaderParams();
-#endif
 #endif
          break;
       default:
@@ -710,12 +708,10 @@ static void ui_companion_qt_notify_list_pushed(void *data, file_list_t *list,
 
 static void ui_companion_qt_notify_refresh(void *data)
 {
-#ifdef HAVE_MENU
    ui_companion_qt_t *handle  = (ui_companion_qt_t*)data;
    ui_window_qt_t *win_handle = (ui_window_qt_t*)handle->window;
 
    win_handle->qtWindow->deferReloadPlaylists();
-#endif
 }
 
 static void ui_companion_qt_log_msg(void *data, const char *msg)

--- a/ui/drivers/ui_qt.h
+++ b/ui/drivers/ui_qt.h
@@ -449,9 +449,7 @@ public slots:
    void reloadPlaylists();
    void deferReloadPlaylists();
    void onGotReloadPlaylists();
-#ifdef HAVE_MENU
    void onGotReloadShaderParams();
-#endif
    void onGotReloadCoreOptions();
    void showWelcomeScreen();
    void onIconViewClicked();
@@ -467,9 +465,7 @@ public slots:
    void updateRetroArchNightly();
    void onUpdateRetroArchFinished(bool success);
    void onThumbnailPackExtractFinished(bool success);
-#ifdef HAVE_MENU
    void deferReloadShaderParams();
-#endif
    void downloadThumbnail(QString system, QString title, QUrl url = QUrl());
    void downloadAllThumbnails(QString system, QUrl url = QUrl());
    void downloadPlaylistThumbnails(QString playlistPath);
@@ -501,9 +497,7 @@ private slots:
    void onStopClicked();
    void onZoomValueChanged(int value);
    void onPlaylistFilesDropped(QStringList files);
-#ifdef HAVE_MENU
    void onShaderParamsClicked();
-#endif
    void onCoreOptionsClicked();
    void onShowErrorMessage(QString msg);
    void onShowInfoMessage(QString msg);


### PR DESCRIPTION
## Description

This PR fixes a regression caused by dd6924a9403472b9c705106805933c018337158d.

It reverts dd6924a9403472b9c705106805933c018337158d and fixes the `--disable-menu` build error with more appropriate ifdefs.
