### PR TITLE
Explore Menu: Fix heap buffer overflow on initialisation

### DIFF
--- a/menu/menu_explore.c
+++ b/menu/menu_explore.c
@@ -350,6 +350,8 @@ static int explore_check_company_suffix(const char* p, bool search_reverse)
       if (p[-1] != ' ')
          return 0;
    }
+   if (p[0] == '\0' || p[1] == '\0' || p[2] == '\0')
+      return 0;
    p0     = p[0];
    p1     = p[1];
    p2     = p[2];


### PR DESCRIPTION
## Description

This PR fixes a heap buffer overflow when initialising the 'explore' menu. This error was caused by https://github.com/libretro/RetroArch/commit/2e5bfd74ece5def3f0859e7cbc3a9faf5cfaa9fb.
