### PR TITLE
libretro-common/cdrom: Add missing compatibility header

### DIFF
--- a/libretro-common/cdrom/cdrom.c
+++ b/libretro-common/cdrom/cdrom.c
@@ -29,6 +29,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <compat/strl.h>
+#include <compat/strcasestr.h>
 #include <retro_math.h>
 #include <retro_timers.h>
 #include <streams/file_stream.h>


### PR DESCRIPTION
## Description

`libretro-common/cdrom/cdrom.c` makes use of `strcasestr()`, which is a non-standard extension. This therefore requires the inclusion of the strcasestr compatibility header, which is currently missing. This trivial PR fixes the issue.

## Related Issues

https://github.com/libretro/libretro-common/issues/143

