### PR TITLE
Fix directory creation on GEKKO platforms when path contains a trailing slash

### DIFF
--- a/libretro-common/file/file_path_io.c
+++ b/libretro-common/file/file_path_io.c
@@ -197,20 +197,6 @@ bool path_mkdir(const char *dir)
       return false;
    }
 
-#if defined(GEKKO)
-   {
-      size_t len = strlen(basedir);
-
-      /* path_parent_dir() keeps the trailing slash.
-       * On Wii, mkdir() fails if the path has a
-       * trailing slash...
-       * We must therefore remove it. */
-      if (len > 0)
-         if (basedir[len - 1] == '/')
-            basedir[len - 1] = '\0';
-   }
-#endif
-
    if (path_is_directory(basedir))
       norecurse = true;
    else

--- a/libretro-common/vfs/vfs_implementation.c
+++ b/libretro-common/vfs/vfs_implementation.c
@@ -1024,6 +1024,28 @@ int retro_vfs_mkdir_impl(const char *dir)
    int ret = orbisMkdir(dir, 0755);
 #elif defined(__QNX__)
    int ret = mkdir(dir, 0777);
+#elif defined(GEKKO)
+   /* On GEKKO platforms, mkdir() fails if
+    * the path has a trailing slash. We must
+    * therefore remove it. */
+   int ret = -1;
+   if (!string_is_empty(dir))
+   {
+      char *dir_buf = strdup(dir);
+
+      if (dir_buf)
+      {
+         size_t len = strlen(dir_buf);
+
+         if (len > 0)
+            if (dir_buf[len - 1] == '/')
+               dir_buf[len - 1] = '\0';
+
+         ret = mkdir(dir_buf, 0750);
+
+         free(dir_buf);
+      }
+   }
 #else
    int ret = mkdir(dir, 0750);
 #endif


### PR DESCRIPTION
## Description

As reported in https://github.com/libretro/libretro-common/issues/161, directory creation can fail on GEKKO platforms if the path contains a trailing slash. This PR fixes the issue, by ensuring any trailing slash is always removed.

## Related Issues

https://github.com/libretro/libretro-common/issues/161
