### PR TITLE
OpenDingux: Update default directory paths

### DIFF
--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -1772,8 +1772,17 @@ static void frontend_unix_get_env(int *argc,
 
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CORE], base_path,
          "cores", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE]));
+#if defined(DINGUX)
+   /* On platforms that require manual core installation/
+    * removal, placing core info files in the same directory
+    * as the cores themselves makes file management highly
+    * inconvenient. Use a dedicated core info directory instead */
+   fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CORE_INFO], base_path,
+         "core_info", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE_INFO]));
+#else
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CORE_INFO], base_path,
          "cores", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE_INFO]));
+#endif
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_AUTOCONFIG], base_path,
          "autoconfig", sizeof(g_defaults.dirs[DEFAULT_DIR_AUTOCONFIG]));
 
@@ -1814,6 +1823,12 @@ static void frontend_unix_get_env(int *argc,
          "database/rdb", sizeof(g_defaults.dirs[DEFAULT_DIR_DATABASE]));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_SHADER], base_path,
          "shaders", sizeof(g_defaults.dirs[DEFAULT_DIR_SHADER]));
+#if defined(DINGUX)
+   fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_AUDIO_FILTER], base_path,
+         "filters/audio", sizeof(g_defaults.dirs[DEFAULT_DIR_AUDIO_FILTER]));
+   fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_VIDEO_FILTER], base_path,
+         "filters/video", sizeof(g_defaults.dirs[DEFAULT_DIR_VIDEO_FILTER]));
+#endif
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CHEATS], base_path,
          "cheats", sizeof(g_defaults.dirs[DEFAULT_DIR_CHEATS]));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_OVERLAY], base_path,


### PR DESCRIPTION
## Description

This trivial PR makes the following changes to the default directory paths on OpenDingux devices:

- Core info directory has been changed to `~/.retroarch/core_info`. Previously, info files defaulted to the same directory as the cores themselves; since cores have to be installed/removed manually on OpenDingux devices, grouping everything together makes file management very cumbersome.

- Audio filter directory has been set to `~/.retroarch/filters/audio`

- Video filter directory has been set to `~/.retroarch/filters/video`