### PR TITLE
[3DS] Free memory in 1MB blocks

### DIFF
--- a/ctr/ctr_memory.c
+++ b/ctr/ctr_memory.c
@@ -141,9 +141,12 @@ void* _sbrk_r(struct _reent *ptr, ptrdiff_t incr)
 
    __heap_size += diff;
 
-   if (diff < 0)
-      svcControlMemory(&tmp, __heapBase + __heap_size,
-            0x0, -diff, MEMOP_FREE, MEMPERM_READ | MEMPERM_WRITE);
+   while (diff < 0) {
+      int size = -diff < 0x100000 ? -diff : 0x100000;
+      diff += size;
+      svcControlMemory(&tmp, __heapBase + __heap_size - diff,
+            0x0, size, MEMOP_FREE, 0);
+   }
 
    sbrk_top += incr;
 


### PR DESCRIPTION
## Description

When freeing large blocks of memory, the 3DS will occasionally kernel panic. Freeing in smaller blocks seems to avoid the crashes. There is an upstream issue for investigation here: https://github.com/LumaTeam/Luma3DS/issues/1504

## Reviewers

[If possible @mention all the people that should review your pull request]
