### PR TITLE
ozone: implement wiggling for main menu when wrap-around is disabled

### DIFF
--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -3736,7 +3736,7 @@ enum materialui_entry_value_type materialui_get_entry_value_type(
                 * since the 'manual content scan - file extensions'
                 * setting may have a value of 'zip' or '7z' etc, which
                 * means it would otherwise get incorreclty identified as
-                * an achive file... */
+                * an archive file... */
                if (entry_type != FILE_TYPE_CARCHIVE)
                   value_type = MUI_ENTRY_VALUE_TEXT;
                break;


### PR DESCRIPTION
Followup of my last PR - implement wiggling for main menu when wrap-around is disabled.

I don't know if users can disable the "right goes down" and "left goes up" feature, in which case please let me know because I'll have to change the wiggle direction if that setting is disabled.

I also don't like using `config_get_ptr()` everywhere but it seems I don't have a choice here, unless you see a better solution.

Reviewers: @jdgleaver @twinaphex 