### PR TITLE
Add audio_driver_output_samples_buf checks back

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -30379,8 +30379,8 @@ static void audio_driver_sample(int16_t left, int16_t right)
    }
 
    if (!(p_rarch->runloop_paused           ||
-		   !p_rarch->audio_driver_active
-         ))
+		   !p_rarch->audio_driver_active     ||
+		   !p_rarch->audio_driver_output_samples_buf))
       audio_driver_flush(
             p_rarch,
             p_rarch->configuration_settings->floats.slowmotion_ratio,
@@ -30404,7 +30404,8 @@ static void audio_driver_menu_sample(void)
    unsigned sample_count                  = (info->sample_rate / info->fps) * 2;
    bool check_flush                       = !(
          p_rarch->runloop_paused           ||
-         !p_rarch->audio_driver_active);
+         !p_rarch->audio_driver_active     ||
+         !p_rarch->audio_driver_output_samples_buf);
 
    while (sample_count > 1024)
    {
@@ -30489,7 +30490,8 @@ static size_t audio_driver_sample_batch(const int16_t *data, size_t frames)
 
    if (!(
          p_rarch->runloop_paused           ||
-         !p_rarch->audio_driver_active))
+         !p_rarch->audio_driver_active     ||
+         !p_rarch->audio_driver_output_samples_buf))
       audio_driver_flush(
             p_rarch,
             p_rarch->configuration_settings->floats.slowmotion_ratio,
@@ -31365,7 +31367,8 @@ void audio_driver_frame_is_reverse(void)
 
    if (!(
           p_rarch->runloop_paused          ||
-         !p_rarch->audio_driver_active))
+         !p_rarch->audio_driver_active     ||
+         !p_rarch->audio_driver_output_samples_buf))
       audio_driver_flush(
             p_rarch,
             p_rarch->configuration_settings->floats.slowmotion_ratio,


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

This is a partial revert of the cleanup commit https://github.com/libretro/RetroArch/commit/309357e5b2f

It's possible for `audio_driver_active` to be true after the driver has been uninitialized and before it has been reinitialized, so these checks are still necessary. Without these checks, I was able to semi-consistently cause crashes in `audio_driver_sample_batch` after load content -> close content -> load content.

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
