### PR TITLE
[VITA] Workaround: Increase memory threshold

### DIFF
--- a/bootstrap/vita/sbrk.c
+++ b/bootstrap/vita/sbrk.c
@@ -4,7 +4,6 @@
 #include <psp2/kernel/sysmem.h>
 #include <psp2/kernel/threadmgr.h>
 
-#define RAM_THRESHOLD 0x1000000 // Memory left to the system for threads and other internal stuffs
 
 int _newlib_heap_memblock;
 unsigned _newlib_heap_size;
@@ -57,6 +56,8 @@ void _init_vita_heap(void) {
 	SceKernelFreeMemorySizeInfo info;
 	info.size = sizeof(SceKernelFreeMemorySizeInfo);
 	sceKernelGetFreeMemorySize(&info);
+
+   printf("sceKernelGetFreeMemorySize %x\n", info.size_user);
 
 	if (&_newlib_heap_size_user != NULL) {
 		_newlib_heap_size = _newlib_heap_size_user;

--- a/defines/psp_defines.h
+++ b/defines/psp_defines.h
@@ -45,6 +45,8 @@ int sceClibPrintf ( const char * format, ... );
 #define PSP_FB_HEIGHT       544
 #define PSP_PITCH_PIXELS 1024
 
+#define RAM_THRESHOLD 0x2000000 // Memory left to the system for threads and other internal stuffs
+
 #elif defined(PSP)
 #define DisplaySetFrameBuf(topaddr, bufferwidth, pixelformat, sync) sceDisplaySetFrameBuf(topaddr, bufferwidth, pixelformat, sync)
 

--- a/gfx/drivers/gl1.c
+++ b/gfx/drivers/gl1.c
@@ -57,6 +57,7 @@
 #endif
 
 #ifdef VITA
+#include "../../defines/psp_defines.h"
 static bool vgl_inited = false;
 #endif
 
@@ -280,7 +281,7 @@ static void *gl1_gfx_init(const video_info_t *video,
 #ifdef VITA
    if (!vgl_inited)
    {
-      vglInitExtended(0x1400000, full_x, full_y, 0x100000, SCE_GXM_MULTISAMPLE_4X);
+      vglInitExtended(0x1400000, full_x, full_y, RAM_THRESHOLD, SCE_GXM_MULTISAMPLE_4X);
       vglUseVram(GL_TRUE);
       vglStartRendering();
       vgl_inited = true;


### PR DESCRIPTION
There are some crashes on some combinations of core + rom (e.g. MGBA) due to not enough memory for OS user libraries.

This is a workaround by increasing the size of reserved memory for the OS. It needs further addressing on vitaGL initialization.

PD: Please label the pr as hacktoberfest-accepted