### PR TITLE
Savestate logging cleanup

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -15752,7 +15752,9 @@ static bool command_event_main_state(
 
    if (push_msg)
       runloop_msg_queue_push(msg, 2, 180, true, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
-   RARCH_LOG("%s\n", msg);
+
+   if (!string_is_empty(msg))
+      RARCH_LOG("%s\n", msg);
 
    return ret;
 }

--- a/tasks/task_save.c
+++ b/tasks/task_save.c
@@ -413,13 +413,11 @@ bool content_undo_load_state(void)
    settings_t *settings      = config_get_ptr();
    bool block_sram_overwrite = settings->bools.block_sram_overwrite;
 
-   RARCH_LOG("%s: \"%s\".\n",
+   RARCH_LOG("%s: \"%s\", %s: %u %s.\n",
          msg_hash_to_str(MSG_LOADING_STATE),
-         undo_load_buf.path);
-
-   RARCH_LOG("%s: %u %s.\n",
+         undo_load_buf.path,
          msg_hash_to_str(MSG_STATE_SIZE),
-         (unsigned int)undo_load_buf.size,
+         (unsigned)undo_load_buf.size,
          msg_hash_to_str(MSG_BYTES));
 
    /* TODO/FIXME - This checking of SRAM overwrite,
@@ -596,11 +594,6 @@ static void *get_serialized_data(const char *path, size_t serial_size)
 
    if (!data)
       return NULL;
-
-   RARCH_LOG("%s: %d %s.\n",
-         msg_hash_to_str(MSG_STATE_SIZE),
-         (int)serial_size,
-         msg_hash_to_str(MSG_BYTES));
 
    serial_info.data = data;
    serial_info.size = serial_size;
@@ -949,17 +942,15 @@ static void content_load_state_cb(retro_task_t *task,
    settings_t *settings        = config_get_ptr();
    bool block_sram_overwrite   = settings->bools.block_sram_overwrite;
 
-   RARCH_LOG("%s: \"%s\".\n",
+   RARCH_LOG("%s: \"%s\", %s: %u %s.\n",
          msg_hash_to_str(MSG_LOADING_STATE),
-         load_data->path);
-
-   if (size < 0 || !buf)
-      goto error;
-
-   RARCH_LOG("%s: %u %s.\n",
+         load_data->path,
          msg_hash_to_str(MSG_STATE_SIZE),
          (unsigned)size,
          msg_hash_to_str(MSG_BYTES));
+
+   if (size < 0 || !buf)
+      goto error;
 
    /* This means we're backing up the file in memory, 
     * so content_undo_save_state()
@@ -1284,10 +1275,6 @@ bool content_save_state(const char *path, bool save_to_disk, bool autosave)
 
    if (!save_state_in_background)
    {
-      RARCH_LOG("%s: \"%s\".\n",
-            msg_hash_to_str(MSG_SAVING_STATE),
-            path);
-
       data = get_serialized_data(path, info.size);
 
       if (!data)
@@ -1298,9 +1285,11 @@ bool content_save_state(const char *path, bool save_to_disk, bool autosave)
          return false;
       }
 
-      RARCH_LOG("%s: %d %s.\n",
+      RARCH_LOG("%s: \"%s\", %s: %u %s.\n",
+            msg_hash_to_str(MSG_SAVING_STATE),
+            path,
             msg_hash_to_str(MSG_STATE_SIZE),
-            (int)info.size,
+            (unsigned)info.size,
             msg_hash_to_str(MSG_BYTES));
    }
 


### PR DESCRIPTION
## Description

- Removed empty rows
- Removed duplicate size information
- Combined path and size rows

Saving before:
```
[INFO] Saving state: "x.state".
[INFO] State size: 5089 bytes.
[INFO] State size: 5089 bytes.
[INFO]
```

Saving after:
```
[INFO] Saving state: "x.state", State size: 5089 bytes.
```

Loading before:
```
[INFO]
[INFO] Loading state: "x.state".
[INFO] State size: 5089 bytes.
[INFO] Saving state: "RAM".
[INFO] State size: 5089 bytes.
[INFO] State size: 5089 bytes.
```

Loading after:
```
[INFO] Loading state: "x.state", State size: 5089 bytes.
[INFO] Saving state: "RAM", State size: 5089 bytes.
```


Undo save rows could be more clear perhaps, but maybe later.
