### PR TITLE
Add API extension for cores to monitor frontend audio buffer occupancy

### DIFF
--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -1335,6 +1335,15 @@ enum retro_mod
                                             * should be considered active.
                                             */
 
+#define RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK 62
+                                           /* const struct retro_audio_buffer_status_callback * --
+                                            * Lets the core know the occupancy level of the frontend
+                                            * audio buffer. Can be used by a core to attempt frame
+                                            * skipping in order to avoid buffer under-runs.
+                                            * A core may pass NULL to disable buffer status reporting
+                                            * in the frontend.
+                                            */
+
 /* VFS functionality */
 
 /* File paths:
@@ -2222,6 +2231,30 @@ struct retro_frame_time_callback
     * 1000000 / fps, but the implementation will resolve the
     * rounding to ensure that framestepping, etc is exact. */
    retro_usec_t reference;
+};
+
+/* Notifies a libretro core of the current occupancy
+ * level of the frontend audio buffer.
+ *
+ * - active: 'true' if audio buffer is currently
+ *           in use. Will be 'false' if audio is
+ *           disabled in the frontend
+ *
+ * - occupancy: Given as a value in the range [0,100],
+ *              corresponding to the occupancy percentage
+ *              of the audio buffer
+ *
+ * - underrun_likely: 'true' if the frontend expects an
+ *                    audio buffer underrun during the
+ *                    next frame (indicates that a core
+ *                    should attempt frame skipping)
+ *
+ * It will be called right before retro_run() every frame. */
+typedef void (RETRO_CALLCONV *retro_audio_buffer_status_callback_t)(
+      bool active, unsigned occupancy, bool underrun_likely);
+struct retro_audio_buffer_status_callback
+{
+   retro_audio_buffer_status_callback_t callback;
 };
 
 /* Pass this to retro_video_refresh_t if rendering to hardware.


### PR DESCRIPTION
## Description

This PR adds a new environment callback which allows a core to monitor the occupancy of the frontend audio buffer. The idea here is that cores which support frame skipping can use the audio buffer level to determine automatically *when* a frame should be skipped in order to avoid buffer underrun (i.e. crackling).

At present, all cores implement frame skipping by one of two methods:

- A manually set interval: This works, but *permanently* reduces framerate by a factor of 2 or 4, etc. Content becomes 'jerky' all the time.

- Dropping frames if the frame time exceeds the nominal value: This doesn't work *at all* - reported frame time fluctuates at a level that renders all such checks worthless, and since we want to avoid audio crackling it's the wrong metric anyway

By querying the audio buffer we can skip frames only when actually required, while maintaining a high probability of consistent sound quality.

I have used this callback to implement auto frame skipping in Snes9x2005 (PR incoming). With an audio buffer of sufficient size (i.e. with `Audio Latency` set to a high enough value - 128 ms is typically sufficient), this proves highly effective on weak hardware.

The new callback is defined as follows:

```c
#define RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK 62
                                           /* const struct retro_audio_buffer_status_callback * --
                                            * Lets the core know the occupancy level of the frontend
                                            * audio buffer. Can be used by a core to attempt frame
                                            * skipping in order to avoid buffer under-runs.
                                            * A core may pass NULL to disable buffer status reporting
                                            * in the frontend.
                                            */


/* Notifies a libretro core of the current occupancy
 * level of the frontend audio buffer.
 *
 * - active: 'true' if audio buffer is currently
 *           in use. Will be 'false' if audio is
 *           disabled in the frontend
 *
 * - occupancy: Given as a value in the range [0,100],
 *              corresponding to the occupancy percentage
 *              of the audio buffer
 *
 * - underrun_likely: 'true' if the frontend expects an
 *                    audio buffer underrun during the
 *                    next frame (indicates that a core
 *                    should attempt frame skipping)
 *
 * It will be called right before retro_run() every frame. */
typedef void (RETRO_CALLCONV *retro_audio_buffer_status_callback_t)(
      bool active, unsigned occupancy, bool underrun_likely);
struct retro_audio_buffer_status_callback
{
   retro_audio_buffer_status_callback_t callback;
};
```