### PR TITLE
Add API extension for overriding frontend audio latency

### DIFF
--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -1344,6 +1344,36 @@ enum retro_mod
                                             * in the frontend.
                                             */
 
+#define RETRO_ENVIRONMENT_SET_MINIMUM_AUDIO_LATENCY 63
+                                           /* const unsigned * --
+                                            * Sets minimum frontend audio latency in milliseconds.
+                                            * Resultant audio latency may be larger than set value,
+                                            * or smaller if a hardware limit is encountered. A frontend
+                                            * is expected to honour requests up to 512 ms.
+                                            *
+                                            * - If value is less than current frontend
+                                            *   audio latency, callback has no effect
+                                            * - If value is zero, default frontend audio
+                                            *   latency is set
+                                            *
+                                            * May be used by a core to increase audio latency and
+                                            * therefore decrease the probability of buffer under-runs
+                                            * (crackling) when performing 'intensive' operations.
+                                            * A core utilising RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK
+                                            * to implement audio-buffer-based frame skipping may achieve
+                                            * optimal results by setting the audio latency to a 'high'
+                                            * (typically 6x or 8x) integer multiple of the expected
+                                            * frame time.
+                                            *
+                                            * WARNING: This can only be called from within retro_run().
+                                            * Calling this can require a full reinitialization of audio
+                                            * drivers in the frontend, so it is important to call it very
+                                            * sparingly, and usually only with the users explicit consent.
+                                            * An eventual driver reinitialize will happen so that audio
+                                            * callbacks happening after this call within the same retro_run()
+                                            * call will target the newly initialized driver.
+                                            */
+
 /* VFS functionality */
 
 /* File paths:


### PR DESCRIPTION
## Description

This PR adds a new `RETRO_ENVIRONMENT_SET_MINIMUM_AUDIO_LATENCY` environment callback which allows a core to override the current frontend audio latency.

The callback is defined as follows:

```c
#define RETRO_ENVIRONMENT_SET_MINIMUM_AUDIO_LATENCY 63
                                           /* const unsigned * --
                                            * Sets minimum frontend audio latency in milliseconds.
                                            * Resultant audio latency may be larger than set value,
                                            * or smaller if a hardware limit is encountered. A frontend
                                            * is expected to honour requests up to 512 ms.
                                            *
                                            * - If value is less than current frontend
                                            *   audio latency, callback has no effect
                                            * - If value is zero, default frontend audio
                                            *   latency is set
                                            *
                                            * May be used by a core to increase audio latency and
                                            * therefore decrease the probability of buffer under-runs
                                            * (crackling) when performing 'intensive' operations.
                                            * A core utilising RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK
                                            * to implement audio-buffer-based frame skipping may achieve
                                            * optimal results by setting the audio latency to a 'high'
                                            * (typically 6x or 8x) integer multiple of the expected
                                            * frame time.
                                            *
                                            * WARNING: This can only be called from within retro_run().
                                            * Calling this can require a full reinitialization of audio
                                            * drivers in the frontend, so it is important to call it very
                                            * sparingly, and usually only with the users explicit consent.
                                            * An eventual driver reinitialize will happen so that audio
                                            * callbacks happening after this call within the same retro_run()
                                            * call will target the newly initialized driver.
                                            */
```

This is mostly intended for cores that implement automatic frame skipping based on the current audio buffer occupancy (c.f. PR #11451). Successful frame skipping of this type requires an audio buffer size equivalent to multiple (x6-x8) times the nominal frame duration - on most platforms, the default audio latency is 64 ms, and this simply isn't enough. The new callback allows a core to temporary increase the audio buffer size to an appropriate value while frame skipping is active, without requiring any manual intervention from the user.

I have added this functionality to the Snes9x2005 core (PR incoming).