### PR TITLE
OpenDingux: Cap 'State Slot' drop-down list to a maximum of 100 (+Auto) entries

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -8044,7 +8044,11 @@ static bool setting_append_list(
          (*list)[list_info->index - 1].offset_by     = -1;
          (*list)[list_info->index - 1].get_string_representation =
             &setting_get_string_representation_state_slot;
+#if defined(DINGUX)
+         menu_settings_list_current_add_range(list, list_info, -1, 99, 1, true, true);
+#else
          menu_settings_list_current_add_range(list, list_info, -1, 0, 1, true, false);
+#endif
 
          CONFIG_ACTION(
                list, list_info,


### PR DESCRIPTION
## Description

Selecting the Quick Menu `State Slot` entry opens a drop-down list with an 'unlimited' number of entries (actually ~100k). This is not a problem on the desktop, but on an RG350M this drop-down list takes over *15 seconds* to open, during which time the menu is completely frozen. Since users are quite likely to select the `State Slot` entry, this is not really acceptable.

This PR just limits the `State Slot` drop-down list to a maximum of 99 (100+1 entries total) on OpenDingux devices, which prevents any performance issues.