### PR TITLE
Cap 'State Slot' drop-down list to a maximum of 1000 (+Auto) entries

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -8065,7 +8065,7 @@ static bool setting_append_list(
          (*list)[list_info->index - 1].offset_by     = -1;
          (*list)[list_info->index - 1].get_string_representation =
             &setting_get_string_representation_state_slot;
-         menu_settings_list_current_add_range(list, list_info, -1, 0, 1, true, false);
+         menu_settings_list_current_add_range(list, list_info, -1, 999, 1, true, true);
 
          CONFIG_ACTION(
                list, list_info,


### PR DESCRIPTION
## Description

This PR replaces the now-defunct #11463.

It limits the `State Slot` drop-down list to a maximum of 999 (1000+Auto entries total) globally, since the current 'unlimited' range makes the menu very slow to open on all platforms (and can hang the menu for many seconds on weak devices).

This only changes the menu display - a 'proper' refactor of save state handling will be implemented in a future PR :)