### PR TITLE
US msg label tweaks

### DIFF
--- a/intl/msg_hash_us.c
+++ b/intl/msg_hash_us.c
@@ -148,7 +148,7 @@ int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
              snprintf(s, len,
                    "Toggles eject for disks. \n"
                    " \n"
-                   "Used for multiple-disk content. ");
+                   "Used for multiple-disk content.");
              break;
           case RARCH_DISK_NEXT:
           case RARCH_DISK_PREV:
@@ -171,7 +171,7 @@ int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
                    "Toggles game focus.\n"
                    " \n"
                    "When a game has focus, RetroArch will both disable \n"
-                   "hotkeys and keep/warp the mouse pointer inside the window.");
+                   "hotkeys and keep/wrap the mouse pointer inside the window.");
              break;
           case RARCH_MENU_TOGGLE:
              snprintf(s, len, "Toggles menu.");
@@ -408,7 +408,7 @@ int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
                              " \n"
                              "If this option is disabled, \n"
                              "it will try to load even if such \n"
-                             "firmware is missing. \n");
+                             "firmware is missing.");
             break;
         case MENU_ENUM_LABEL_PARENT_DIRECTORY:
             snprintf(s, len,
@@ -534,8 +534,7 @@ int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Setting it to 'Early' or 'Late' can result \n"
                              "in less latency, \n"
                              "depending on your configuration.\n\n"
-                             "Will be ignored when using netplay."
-            );
+                             "Will be ignored when using netplay.");
             break;
         case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_HIDE_UNBOUND:
             snprintf(s, len,
@@ -680,8 +679,7 @@ int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
                      "Set to true if hardware-rendered cores \n"
                              "should get their private context. \n"
                              "Avoids having to assume hardware state changes \n"
-                             "inbetween frames."
-            );
+                             "inbetween frames.");
             break;
         case MENU_ENUM_LABEL_CORE_LIST:
             snprintf(s, len,
@@ -702,43 +700,42 @@ int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
                      "You can use the following controls below \n"
                              "on either your gamepad or keyboard in order\n"
                              "to control the menu: \n"
-                             " \n"
-            );
+                             " \n");
             break;
         case MENU_ENUM_LABEL_WELCOME_TO_RETROARCH:
             snprintf(s, len,
-                     "Welcome to RetroArch\n"
-            );
+                     "Welcome to RetroArch\n");
             break;
-        case MENU_ENUM_LABEL_VALUE_HELP_AUDIO_VIDEO_TROUBLESHOOTING_DESC: {
-            /* Work around C89 limitations */
-            char u[501];
-            const char *t =
-                    "RetroArch relies on an unique form of\n"
-                            "audio/video synchronization where it needs to be\n"
-                            "calibrated against the refresh rate of your\n"
-                            "display for best performance results.\n"
-                            " \n"
-                            "If you experience any audio crackling or video\n"
-                            "tearing, usually it means that you need to\n"
-                            "calibrate the settings. Some choices below:\n"
-                            " \n";
-            snprintf(u, sizeof(u), /* can't inline this due to the printf arguments */
-                     "a) Go to '%s' -> '%s', and enable\n"
-                             "'Threaded Video'. Refresh rate will not matter\n"
-                             "in this mode, framerate will be higher,\n"
-                             "but video might be less smooth.\n"
-                             "b) Go to '%s' -> '%s', and look at\n"
-                             "'%s'. Let it run for\n"
-                             "2048 frames, then press 'OK'.",
-                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_SETTINGS),
-                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_VIDEO_SETTINGS),
-                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_SETTINGS),
-                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_VIDEO_SETTINGS),
-                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE_AUTO));
-            strlcpy(s, t, len);
-            strlcat(s, u, len);
-        }
+        case MENU_ENUM_LABEL_VALUE_HELP_AUDIO_VIDEO_TROUBLESHOOTING_DESC:
+            {
+                /* Work around C89 limitations */
+                char u[501];
+                const char *t =
+                        "RetroArch relies on an unique form of\n"
+                                "audio/video synchronization where it needs to be\n"
+                                "calibrated against the refresh rate of your\n"
+                                "display for best performance results.\n"
+                                " \n"
+                                "If you experience any audio crackling or video\n"
+                                "tearing, usually it means that you need to\n"
+                                "calibrate the settings. Some choices below:\n"
+                                " \n";
+                snprintf(u, sizeof(u), /* can't inline this due to the printf arguments */
+                         "a) Go to '%s' -> '%s', and enable\n"
+                                 "'Threaded Video'. Refresh rate will not matter\n"
+                                 "in this mode, framerate will be higher,\n"
+                                 "but video might be less smooth.\n"
+                                 "b) Go to '%s' -> '%s', and look at\n"
+                                 "'%s'. Let it run for\n"
+                                 "2048 frames, then press 'OK'.",
+                         msg_hash_to_str(MENU_ENUM_LABEL_VALUE_SETTINGS),
+                         msg_hash_to_str(MENU_ENUM_LABEL_VALUE_VIDEO_SETTINGS),
+                         msg_hash_to_str(MENU_ENUM_LABEL_VALUE_SETTINGS),
+                         msg_hash_to_str(MENU_ENUM_LABEL_VALUE_VIDEO_SETTINGS),
+                         msg_hash_to_str(MENU_ENUM_LABEL_VALUE_VIDEO_REFRESH_RATE_AUTO));
+                strlcpy(s, t, len);
+                strlcat(s, u, len);
+            }
             break;
         case MENU_ENUM_LABEL_VALUE_HELP_SCANNING_CONTENT_DESC:
             snprintf(s, len,
@@ -761,16 +758,14 @@ int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_SCAN_DIRECTORY),
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_SCAN_FILE),
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_LIST),
-                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLISTS_TAB)
-            );
+                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLISTS_TAB));
             break;
         case MENU_ENUM_LABEL_VALUE_EXTRACTING_PLEASE_WAIT:
             snprintf(s, len,
                      "Welcome to RetroArch\n"
                              "\n"
                              "Extracting assets, please wait.\n"
-                             "This might take a while...\n"
-            );
+                             "This might take a while...\n");
             break;
         case MENU_ENUM_LABEL_INPUT_DRIVER:
             {
@@ -790,8 +785,7 @@ int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
                            " \n"
                            "By default in most distros, /dev/input nodes \n"
                            "are root-only (mode 600). You can set up a udev \n"
-                           "rule which makes these accessible to non-root."
-                           );
+                           "rule which makes these accessible to non-root.");
                else if (string_is_equal(lbl,
                         msg_hash_to_str(MENU_ENUM_LABEL_INPUT_DRIVER_LINUXRAW)))
                      snprintf(s, len,
@@ -827,8 +821,7 @@ int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "The browser will filter out \n"
                              "extensions for the last core set \n"
                              "in 'Load Core', and use that core \n"
-                             "when content is loaded."
-            );
+                             "when content is loaded.");
             break;
         case MENU_ENUM_LABEL_LOAD_CONTENT_HISTORY:
             snprintf(s, len,
@@ -841,8 +834,7 @@ int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "directory as the RetroArch config file. If \n"
                              "no config file was loaded in startup, history \n"
                              "will not be saved or loaded, and will not exist \n"
-                             "in the main menu."
-            );
+                             "in the main menu.");
             break;
         case MENU_ENUM_LABEL_VIDEO_DRIVER:
             {
@@ -932,8 +924,7 @@ int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
             snprintf(s, len,
                      "Audio DSP plugin.\n"
                              " Processes audio before it's sent to \n"
-                             "the driver."
-            );
+                             "the driver.");
             break;
         case MENU_ENUM_LABEL_AUDIO_RESAMPLER_DRIVER:
             {
@@ -968,8 +959,7 @@ int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "If the CGP uses scaling methods which are not \n"
                              "simple, (i.e. source scaling, same scaling \n"
                              "factor for X/Y), the scaling factor displayed \n"
-                             "in the menu might not be correct."
-            );
+                             "in the menu might not be correct.");
             break;
         case MENU_ENUM_LABEL_VIDEO_SHADER_SCALE_PASS:
             snprintf(s, len,
@@ -987,8 +977,7 @@ int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "If 'Don't Care' is set, either 1x \n"
                              "scale or stretch to fullscreen will \n"
                              "be used depending if it's not the last \n"
-                             "pass or not."
-            );
+                             "pass or not.");
             break;
         case MENU_ENUM_LABEL_VIDEO_SHADER_NUM_PASSES:
             snprintf(s, len,
@@ -1016,8 +1005,7 @@ int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
             snprintf(s, len,
                      "Shader Preset Parameters. \n"
                              " \n"
-                             "Modifies shader preset currently in menu."
-            );
+                             "Modifies shader preset currently in menu.");
             break;
         case MENU_ENUM_LABEL_VIDEO_SHADER_PASS:
             snprintf(s, len,
@@ -1028,8 +1016,7 @@ int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
                              " \n"
                              "Set Shader Directory to set where \n"
                              "the browser starts to look for \n"
-                             "shaders."
-            );
+                             "shaders.");
             break;
         case MENU_ENUM_LABEL_CONFIGURATION_SETTINGS:
             snprintf(s, len,
@@ -1070,8 +1057,7 @@ int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
                      "Hardware filter for this pass. \n"
                              " \n"
                              "If 'Don't Care' is set, 'Default \n"
-                             "Filter' will be used."
-            );
+                             "Filter' will be used.");
             break;
         case MENU_ENUM_LABEL_AUTOSAVE_INTERVAL:
             snprintf(s, len,
@@ -1089,8 +1075,7 @@ int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
                      "Input Device Type. \n"
                              " \n"
                              "Picks which device type to use. This is \n"
-                             "relevant for the libretro core itself."
-            );
+                             "relevant for the libretro core itself.");
             break;
         case MENU_ENUM_LABEL_LIBRETRO_LOG_LEVEL:
             snprintf(s, len,
@@ -1107,8 +1092,7 @@ int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
                              " DEBUG = 0\n"
                              " INFO  = 1\n"
                              " WARN  = 2\n"
-                             " ERROR = 3"
-            );
+                             " ERROR = 3");
             break;
         case MENU_ENUM_LABEL_STATE_SLOT_INCREASE:
         case MENU_ENUM_LABEL_STATE_SLOT_DECREASE:
@@ -1135,8 +1119,7 @@ int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "settings are saved to a temporary file (either \n"
                              "menu.cgp or menu.glslp) and loaded. The file \n"
                              "persists after RetroArch exits. The file is \n"
-                             "saved to Shader Directory."
-            );
+                             "saved to Shader Directory.");
             break;
         case MENU_ENUM_LABEL_SHADER_WATCH_FOR_CHANGES:
             snprintf(s, len,
@@ -1144,8 +1127,7 @@ int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
                      " \n"
                      "After saving changes to a shader on disk, \n"
                      "it will automatically be recompiled \n"
-                     "and applied to the running content."
-            );
+                     "and applied to the running content.");
             break;
         case MENU_ENUM_LABEL_MENU_TOGGLE:
             snprintf(s, len,
@@ -1165,7 +1147,7 @@ int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
                      "Toggles game focus.\n"
                              " \n"
                              "When a game has focus, RetroArch will both disable \n"
-                             "hotkeys and keep/warp the mouse pointer inside the window.");
+                             "hotkeys and keep/wrap the mouse pointer inside the window.");
             break;
         case MENU_ENUM_LABEL_DISK_NEXT:
             snprintf(s, len,
@@ -1555,8 +1537,7 @@ int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
             snprintf(s, len,
                      "Screenshot Directory. \n"
                              " \n"
-                             "Directory to dump screenshots to."
-            );
+                             "Directory to dump screenshots to.");
             break;
         case MENU_ENUM_LABEL_VIDEO_SWAP_INTERVAL:
             snprintf(s, len,
@@ -1624,22 +1605,19 @@ int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Describes the period of which turbo-enabled\n"
                              "buttons toggle.\n"
                              " \n"
-                             "Numbers are described in frames."
-            );
+                             "Numbers are described in frames.");
             break;
         case MENU_ENUM_LABEL_INPUT_TURBO_MODE:
             snprintf(s, len,
                   "Turbo Mode.\n"
                   " \n"
-                  "Selects the general behavior of turbo mode."
-                  );
+                  "Selects the general behavior of turbo mode.");
             break;
         case MENU_ENUM_LABEL_INPUT_TURBO_DEFAULT_BUTTON:
             snprintf(s, len,
                   "Turbo Default Button.\n"
                   " \n"
-                  "Default active button for Turbo Mode 'Single Button'.\n"
-                  );
+                  "Default active button for Turbo Mode 'Single Button'.\n");
             break;
         case MENU_ENUM_LABEL_INPUT_DUTY_CYCLE:
             snprintf(s, len,
@@ -1648,8 +1626,7 @@ int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Describes how long the period of a turbo-enabled\n"
                              "should be.\n"
                              " \n"
-                             "Numbers are described in frames."
-            );
+                             "Numbers are described in frames.");
             break;
         case MENU_ENUM_LABEL_INPUT_TOUCH_ENABLE:
             snprintf(s, len, "Enable touch support.");
@@ -1724,16 +1701,16 @@ int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
                      "Whether to disallow connections not in slave mode. \n"
                              " \n"
                              "Not recommended except for very fast networks \n"
-                             "with very weak machines. \n");
+                             "with very weak machines.");
             break;
         case MENU_ENUM_LABEL_NETPLAY_STATELESS_MODE:
             snprintf(s, len,
-                     "Whether to run netplay in a mode not requiring\n"
+                     "Whether to run netplay in a mode not requiring"
                              "save states. \n"
                              " \n"
-                             "If set to true, a very fast network is required,\n"
-                             "but no rewinding is performed, so there will be\n"
-                             "no netplay jitter.\n");
+                             "If set to true, a very fast network is required, \n"
+                             "but no rewinding is performed, so there will be \n"
+                             "no netplay jitter. \n");
             break;
         case MENU_ENUM_LABEL_NETPLAY_CHECK_FRAMES:
             snprintf(s, len,
@@ -2034,11 +2011,11 @@ int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
             break;
         case MENU_ENUM_LABEL_CHEAT_INDEX_PLUS:
             snprintf(s, len,
-                     "Increment cheat index.\n");
+                     "Increase cheat index.");
             break;
         case MENU_ENUM_LABEL_CHEAT_INDEX_MINUS:
             snprintf(s, len,
-                     "Decrement cheat index.\n");
+                     "Decrease cheat index.");
             break;
         case MENU_ENUM_LABEL_SHADER_PREV:
             snprintf(s, len,
@@ -2050,7 +2027,7 @@ int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
             break;
         case MENU_ENUM_LABEL_RESET:
             snprintf(s, len,
-                     "Reset the content.\n");
+                     "Reset the content.");
             break;
         case MENU_ENUM_LABEL_PAUSE_TOGGLE:
             snprintf(s, len,
@@ -2058,15 +2035,15 @@ int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
             break;
         case MENU_ENUM_LABEL_CHEAT_TOGGLE:
             snprintf(s, len,
-                     "Toggle cheat index.\n");
+                     "Toggle cheat index.");
             break;
         case MENU_ENUM_LABEL_CHEAT_IDX:
             snprintf(s, len,
-                     "Index position in list.\n");
+                     "Index position in list.");
             break;
         case MENU_ENUM_LABEL_CHEAT_ADDRESS_BIT_POSITION:
             snprintf(s, len,
-                     "Address bitmask when Memory Search Size < 8-bit.\n");
+                     "Address bitmask when Memory Search Size < 8-bit.");
             break;
         case MENU_ENUM_LABEL_CHEAT_REPEAT_COUNT:
             snprintf(s, len,
@@ -2086,15 +2063,15 @@ int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
             break;
         case MENU_ENUM_LABEL_CHEAT_START_OR_CONT:
             snprintf(s, len,
-                     "Scan memory to create new cheats");
+                     "Scan memory to create new cheats.");
             break;
         case MENU_ENUM_LABEL_CHEAT_START_OR_RESTART:
             snprintf(s, len,
-                     "Left/Right to change bit-size\n");
+                     "Left/Right to change bit-size.");
             break;
         case MENU_ENUM_LABEL_CHEAT_SEARCH_EXACT:
             snprintf(s, len,
-                     "Left/Right to change value\n");
+                     "Left/Right to change value.");
             break;
         case MENU_ENUM_LABEL_CHEAT_SEARCH_LT:
             snprintf(s, len,
@@ -2114,11 +2091,11 @@ int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
             break;
         case MENU_ENUM_LABEL_CHEAT_SEARCH_EQPLUS:
             snprintf(s, len,
-                     "Left/Right to change value\n");
+                     "Left/Right to change value.");
             break;
         case MENU_ENUM_LABEL_CHEAT_SEARCH_EQMINUS:
             snprintf(s, len,
-                     "Left/Right to change value\n");
+                     "Left/Right to change value.");
             break;
         case MENU_ENUM_LABEL_CHEAT_ADD_MATCHES:
             snprintf(s, len,
@@ -2235,8 +2212,7 @@ int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "you can set '%s' to false.",
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_SETTINGS),
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OVERLAY_SETTINGS),
-                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_HIDE_IN_MENU)
-            );
+                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_HIDE_IN_MENU));
             break;
         case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_ENABLE:
             snprintf(s, len,
@@ -2330,7 +2306,8 @@ static const char *menu_hash_to_str_us_label_enum(enum msg_hash_enums msg)
 }
 #endif
 
-const char *msg_hash_to_str_us(enum msg_hash_enums msg) {
+const char *msg_hash_to_str_us(enum msg_hash_enums msg)
+{
 #ifdef HAVE_MENU
     const char *ret = menu_hash_to_str_us_label_enum(msg);
 
@@ -2338,7 +2315,8 @@ const char *msg_hash_to_str_us(enum msg_hash_enums msg) {
        return ret;
 #endif
 
-    switch (msg) {
+    switch (msg)
+    {
 #include "msg_hash_us.h"
         default:
 #if 0

--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -1517,7 +1517,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_VIDEO_FULLSCREEN,
-   "Start in fullscreen. Can be changed at runtime. Can be overridden by a command line switch"
+   "Start in fullscreen. Can be changed at runtime. Can be overridden by a command line switch."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_VIDEO_WINDOWED_FULLSCREEN,
@@ -1568,7 +1568,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_VIDEO_WINDOW_SAVE_POSITION,
-   "Remember window size and position, enabling this has precedence over Windowed Scale"
+   "Remember window size and position, enabling this has precedence over Windowed Scale."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_VIDEO_WINDOW_WIDTH,
@@ -2417,7 +2417,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_INPUT_META_OSK,
-   "Switches on-screen keyboard on/off"
+   "Switches on-screen keyboard on/off."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_INPUT_META_FPS_TOGGLE,
@@ -3170,7 +3170,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_REWIND_BUFFER_SIZE,
-   "The amount of memory (in MB) to reserve for the rewind buffer.  Increasing this will increase the amount of rewind history."
+   "The amount of memory (in MB) to reserve for the rewind buffer. Increasing this will increase the amount of rewind history."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_REWIND_BUFFER_SIZE_STEP,
@@ -3178,7 +3178,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_REWIND_BUFFER_SIZE_STEP,
-   "Each time you increase or decrease the rewind buffer size value via this UI it will change by this amount"
+   "Each time you increase or decrease the rewind buffer size value it will change by this amount."
    )
 
 /* Settings > Frame Throttle > Frame Time Counter */
@@ -3271,7 +3271,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_ONSCREEN_OVERLAY_SETTINGS,
-   "Adjust bezels and on-screen controls"
+   "Adjust bezels and on-screen controls."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_ONSCREEN_VIDEO_LAYOUT_SETTINGS,
@@ -3279,7 +3279,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_ONSCREEN_VIDEO_LAYOUT_SETTINGS,
-   "Adjust Video Layout"
+   "Adjust Video Layout."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_ONSCREEN_NOTIFICATIONS_SETTINGS,
@@ -3287,7 +3287,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_ONSCREEN_NOTIFICATIONS_SETTINGS,
-   "Adjust On-Screen Notifications"
+   "Adjust On-Screen Notifications."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_ONSCREEN_NOTIFICATIONS_VIEWS_SETTINGS,
@@ -3306,7 +3306,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_INPUT_OVERLAY_ENABLE,
-   "Overlays are used for borders and on-screen controls"
+   "Overlays are used for borders and on-screen controls."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_HIDE_IN_MENU,
@@ -3626,7 +3626,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_NOTIFICATION_SHOW_CHEATS_APPLIED,
-   "Display an on-screen message when cheat codes are applied"
+   "Display an on-screen message when cheat codes are applied."
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_NOTIFICATION_SHOW_AUTOCONFIG,
@@ -4331,11 +4331,11 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_CONTENT_SHOW_REWIND,
-   "Show or hide the Rewind options."
+   "Show or hide the 'Rewind' options."
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_CONTENT_SHOW_LATENCY,
-   "Show or hide the Latency options."
+   "Show or hide the 'Latency' options."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_CONTENT_SHOW_LATENCY,
@@ -4343,7 +4343,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_CONTENT_SHOW_OVERLAYS,
-   "Show or hide the Overlay options."
+   "Show or hide the 'Overlay' options."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_CONTENT_SHOW_OVERLAYS,
@@ -4355,7 +4355,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_CONTENT_SHOW_VIDEO_LAYOUT,
-   "Show or hide Video Layout options."
+   "Show or hide 'Video Layout' options."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_QUICK_MENU_SHOW_SAVE_CORE_OVERRIDES,
@@ -4660,7 +4660,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_AI_SERVICE_MODE,
-   "Show translation as a text overlay (Image mode), or play as Text-To-Speech (Speech mode)"
+   "Show translation as a text overlay (Image mode), or play as Text-To-Speech (Speech mode)."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_AI_SERVICE_URL,
@@ -4732,7 +4732,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_CHEEVOS_ENABLE,
-   "Earn achievements in classic games. For more information, visit https://retroachievements.org"
+   "Earn achievements in classic games. For more information, visit 'https://retroachievements.org'."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_CHEEVOS_HARDCORE_MODE_ENABLE,
@@ -5297,7 +5297,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_ACCOUNTS_RETRO_ACHIEVEMENTS,
-   "Earn achievements in classic games. For more information, visit http://retroachievements.org"
+   "Earn achievements in classic games. For more information, visit 'https://retroachievements.org'."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_ACCOUNTS_YOUTUBE,
@@ -6266,7 +6266,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_CHEAT_START_OR_RESTART,
-   "Left/Right to change bit-size"
+   "Left/Right to change bit-size."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_CHEAT_BIG_ENDIAN,
@@ -6282,7 +6282,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_CHEAT_SEARCH_EXACT,
-   "Press Left or Right to change value"
+   "Press Left or Right to change value."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_CHEAT_SEARCH_EXACT_VAL,
@@ -6366,7 +6366,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_CHEAT_SEARCH_EQPLUS,
-   "Left/Right to change value"
+   "Left/Right to change value."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_CHEAT_SEARCH_EQPLUS_VAL,
@@ -6378,7 +6378,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_CHEAT_SEARCH_EQMINUS,
-   "Left/Right to change value"
+   "Left/Right to change value."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_CHEAT_SEARCH_EQMINUS_VAL,
@@ -6800,7 +6800,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_ACHIEVEMENT_PAUSE,
-   "Pause achievements for current session (This action will enable save states, cheats, rewind, pause, and slow-motion)."
+   "Pause achievements for current session. (This action will enable save states, cheats, rewind, pause, and slow-motion)"
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_ACHIEVEMENT_RESUME,
@@ -6808,7 +6808,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_ACHIEVEMENT_RESUME,
-   "Resume achievements for current session (This action will disable save states, cheats, rewind, pause, and slow-motion and reset the current game)."
+   "Resume achievements for current session. (This action will disable save states, cheats, rewind, pause, and slow-motion and reset the current game)"
    )
 
 /* Quick Menu > Information */
@@ -6823,7 +6823,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_RDB_ENTRY_DETAIL,
-   "Show database information for current content"
+   "Show database information for current content."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_NO_ENTRIES_TO_DISPLAY,
@@ -9807,7 +9807,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_CHEAT_START_SEARCH,
-   "Start search for a new cheat.  Number of bits can be changed."
+   "Start search for a new cheat. Number of bits can be changed."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_CHEAT_CONTINUE_SEARCH,
@@ -11760,7 +11760,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_SWITCH_GPU_PROFILE,
-   "Overclock or underclock the Switch GPU"
+   "Overclock or underclock the Switch GPU."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_SWITCH_BACKLIGHT_CONTROL,
@@ -11768,7 +11768,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_SWITCH_BACKLIGHT_CONTROL,
-   "Increase or decrease the Switch screen brightness"
+   "Increase or decrease the Switch screen brightness."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_REBOOT_RCM,
@@ -11782,7 +11782,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_SWITCH_CPU_PROFILE,
-   "Overclock the Switch CPU"
+   "Overclock the Switch CPU."
    )
 #endif
 #ifdef HAVE_LAKKA


### PR DESCRIPTION
## Description

Typo corrections, conformities and cleanups:
- "warp" => "wrap"
- Ending dot for sublabels
- Line breaks
- Quotes where relevant
