### PR TITLE
AI Service fixes

### DIFF
--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -2631,7 +2631,7 @@ static bool accessibility_speak_unix(int speed,
    {
       /* check if old pid is running */
       if (is_narrator_running_unix())
-         return true;
+         goto end;
    }
 
    if (speak_pid > 0)
@@ -2665,6 +2665,12 @@ static bool accessibility_speak_unix(int speed,
       cmd[3] = (char*)speak_text;
       execvp("espeak", cmd);
    }
+
+end:
+   if (voice_out)
+      free(voice_out);
+   if (speed_out)
+      free(speed_out);
    return true;
 }
 #endif

--- a/libretro-common/formats/png/rpng_encode.c
+++ b/libretro-common/formats/png/rpng_encode.c
@@ -413,7 +413,7 @@ uint8_t* rpng_save_image_bgr24_string(const uint8_t *data,
    buf        = (uint8_t*)malloc(buf_length*sizeof(uint8_t));
    if (!buf)
       GOTO_END_ERROR(); 
-   
+
    intf_s = intfstream_open_writable_memory(buf, 
          RETRO_VFS_FILE_ACCESS_WRITE,
          RETRO_VFS_FILE_ACCESS_HINT_NONE,
@@ -433,7 +433,10 @@ end:
    if (buf)
       free(buf);
    if (intf_s)
+   {
+      intfstream_close(intf_s);
       free(intf_s);
+   }
    if (ret == false)
    {
       if (output)

--- a/libretro-common/formats/wav/rwav.c
+++ b/libretro-common/formats/wav/rwav.c
@@ -95,7 +95,8 @@ enum rwav_state rwav_iterate(rwav_iterator_t *iter)
 
          rwav->subchunk2size = data[40] | data[41] << 8 | data[42] << 16 | data[43] << 24;
 
-         if (rwav->subchunk2size > iter->size - 44)
+         if ((rwav->subchunk2size < 1) ||
+             (rwav->subchunk2size > iter->size - 44))
             return RWAV_ITERATE_ERROR; /* too few bytes in buffer */
 
          samples = malloc(rwav->subchunk2size);


### PR DESCRIPTION
## Description

This PR fixes the following issues related to the AI Service:

- Fix crash when triggering the AI Service (via hotkey) due to a heap buffer overflow

- Fix crash when no text is found (another heap buffer overflow, but this one didn't happen every time...)

- Fix hang when attempting to playback an empty audio buffer (`rwav.c` was missing an error check, leading to an 'infinite' sample rate)

- Fix memory leak when 'speaking' text (RetroArch was leaking the entire audio buffer every time this happened... and in fact, it was leaking two copies of the buffer...)

- Fix memory leak when processing the PNG files used for text translation displays

- Fix two other string-related memory leaks when triggering the AI Service

- Unix: Fix memory leak when calling `accessibility_speak_unix()` to speak text via the OS narrator

## Related Issues

This closes #11199
