### PR TITLE
(cheevos) core options blacklist

### DIFF
--- a/cheevos/cheevos.h
+++ b/cheevos/cheevos.h
@@ -57,6 +57,8 @@ bool rcheevos_unload(void);
 void rcheevos_hardcore_enabled_changed(void);
 void rcheevos_toggle_hardcore_paused(void);
 
+void rcheevos_validate_config_settings(void);
+
 void rcheevos_leaderboards_enabled_changed(void);
 
 void rcheevos_test(void);


### PR DESCRIPTION
## Description

Disables hardcore mode when certain core options are set. 

Primarily `fbneo-cheat-*` and `genesis_plus_gx_lock_on`, but we've also flagged a few settings for currently unsupported cores (`dolphin_cheats_enabled`, `ppsspp_cheats`, and `ecwolf-invulnerability`), and one setting being actively worked on (`fbneo-allow-patched-romsets`).

All of these settings potentially allow the player an advantage they otherwise wouldn't have. To keep the playing field level, if any of these settings are set to anything but preapproved values, hardcore mode is paused for the session and the user is informed of the offending setting so they can remedy it. The player can then re-enable hardcore mode in the standard way, which will restart the session and revalidate the settings.

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@Sanaki @meleu
