### PR TITLE
OpenDingux: Update desktop entry name/comment

### DIFF
--- a/Makefile.dingux
+++ b/Makefile.dingux
@@ -129,8 +129,8 @@ RARCH_OBJ := $(addprefix $(OBJDIR)/,$(OBJ))
 
 define DESKTOP_ENTRY
 [Desktop Entry]
-Name=retroarch
-Comment=Retroarch
+Name=RetroArch
+Comment=Frontend for emulators, game engines
 Exec=retroarch
 Terminal=false
 Type=Application

--- a/Makefile.rg350
+++ b/Makefile.rg350
@@ -130,8 +130,8 @@ RARCH_OBJ := $(addprefix $(OBJDIR)/,$(OBJ))
 
 define DESKTOP_ENTRY
 [Desktop Entry]
-Name=retroarch
-Comment=Retroarch
+Name=RetroArch
+Comment=Frontend for emulators, game engines
 Exec=retroarch
 Terminal=false
 Type=Application


### PR DESCRIPTION
At present, the RetroArch desktop icon on OpenDingux platforms has the name `retroarch`. This PR just changes this to the standard name of `RetroArch`, and also updates the desktop entry 'comment' to an actual description of the application.