### PR TITLE
[3DS] Allow sideways screen rotation

### DIFF
--- a/gfx/drivers/ctr_gfx.c
+++ b/gfx/drivers/ctr_gfx.c
@@ -773,6 +773,7 @@ static bool ctr_frame(void* data, const void* frame,
       GSPGPU_FlushDataCache(ctr->frame_coords, sizeof(ctr_vertex_t));
    }
 
+   GPUCMD_AddWrite(GPUREG_GSH_BOOLUNIFORM, ctr->rotation & 1);
    ctrGuSetVertexShaderFloatUniform(0, (float*)&ctr->scale_vector, 1);
    ctrGuSetTexture(GPU_TEXUNIT0, VIRT_TO_PHYS(ctr->texture_swizzled), ctr->texture_width, ctr->texture_height,
                   (ctr->smooth? GPU_TEXTURE_MAG_FILTER(GPU_LINEAR)  | GPU_TEXTURE_MIN_FILTER(GPU_LINEAR)
@@ -854,6 +855,7 @@ static bool ctr_frame(void* data, const void* frame,
                         GPU_TEXTURE_WRAP_S(GPU_CLAMP_TO_EDGE) | GPU_TEXTURE_WRAP_T(GPU_CLAMP_TO_EDGE),
                         GPU_RGBA4);
 
+         GPUCMD_AddWrite(GPUREG_GSH_BOOLUNIFORM, 0);
          ctrGuSetVertexShaderFloatUniform(0, (float*)&ctr->menu.scale_vector, 1);
          ctrGuSetAttributeBuffersAddress(VIRT_TO_PHYS(ctr->menu.frame_coords));
 

--- a/gfx/drivers/ctr_shaders/ctr_sprite.gsh
+++ b/gfx/drivers/ctr_shaders/ctr_sprite.gsh
@@ -5,6 +5,7 @@
 .constf  _N1N1   (-1.0, 1.0, -1.0, 1.0)
 
 ; Inputs
+.alias rotate           b0
 .alias sprite_coords    v0
 .alias tex_frame_coords v1    ;(0.0, 1.0, w/tex_w, 1.0 - h/tex_h)
 
@@ -26,25 +27,45 @@
    setemit 0
       mov pos.xy, top_left.xy
       mov pos.zw, _N1N1
-      mov texcoord.xy, tex_top_left.xy
+
+      ifu rotate
+         mov texcoord.xy, tex_top_right.xy
+      .else
+         mov texcoord.xy, tex_top_left.xy
+      .end
    emit
 
    setemit 1
       mov pos.xy, bottom_left.xy
       mov pos.zw, _N1N1
-      mov texcoord.xy, tex_bottom_left.xy
+
+      ifu rotate
+         mov texcoord.xy, tex_top_left.xy
+      .else
+         mov texcoord.xy, tex_bottom_left.xy
+      .end
    emit
 
    setemit 2, prim inv
       mov pos.xy, bottom_right.xy
       mov pos.zw, _N1N1
-      mov texcoord.xy, tex_bottom_right.xy
+
+      ifu rotate
+         mov texcoord.xy, tex_bottom_left.xy
+      .else
+         mov texcoord.xy, tex_bottom_right.xy
+      .end
    emit
 
    setemit 1, prim
       mov pos.xy, top_right.xy
       mov pos.zw, _N1N1
-      mov texcoord.xy, tex_top_right.xy
+
+      ifu rotate
+         mov texcoord.xy, tex_bottom_right.xy
+      .else
+         mov texcoord.xy, tex_top_right.xy
+      .end
    emit
 
    end

--- a/gfx/drivers_display/gfx_display_ctr.c
+++ b/gfx/drivers_display/gfx_display_ctr.c
@@ -49,6 +49,7 @@ static void gfx_display_ctr_draw(gfx_display_ctx_draw_t *draw,
    ctr_set_scale_vector(&scale_vector,
          CTR_TOP_FRAMEBUFFER_WIDTH, CTR_TOP_FRAMEBUFFER_HEIGHT,
          texture->width, texture->height);
+   GPUCMD_AddWrite(GPUREG_GSH_BOOLUNIFORM, 0);
    ctrGuSetVertexShaderFloatUniform(0, (float*)&scale_vector, 1);
 
    if ((ctr->vertex_cache.size - (ctr->vertex_cache.current 

--- a/gfx/drivers_font/ctr_font.c
+++ b/gfx/drivers_font/ctr_font.c
@@ -230,6 +230,7 @@ static void ctr_font_render_line(
    if (v == ctr->vertex_cache.current)
       return;
 
+   GPUCMD_AddWrite(GPUREG_GSH_BOOLUNIFORM, 0);
    ctrGuSetVertexShaderFloatUniform(0, (float*)&font->scale_vector, 1);
    GSPGPU_FlushDataCache(ctr->vertex_cache.current,
          (v - ctr->vertex_cache.current) * sizeof(ctr_vertex_t));


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

Enables 90 and 270 degree rotation on 3ds. Note that because of the 3ds' low resolution this will likely only work well with integer scaling off / bilinear filtering on.

## Related Issues

#9567 #8754

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
