### PR TITLE
[VITA] Default menu scale 1.5x to improve readability

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -1142,7 +1142,11 @@ static const int default_content_favorites_size = 200;
 
 /* Default scale factor for non-frambuffer-based display
  * drivers and display widgets */
+#if defined(VITA)
+#define DEFAULT_MENU_SCALE_FACTOR 1.5f
+#else
 #define DEFAULT_MENU_SCALE_FACTOR 1.0f
+#endif
 /* Specifies whether display widgets should be scaled
  * automatically using the default menu scale factor */
 #define DEFAULT_MENU_WIDGET_SCALE_AUTO true


### PR DESCRIPTION
## Description

Set default menu scale to 1.5x on Vita for much better readability on the small Vita screen.

Before this PR:
![2020-10-31-171209](https://user-images.githubusercontent.com/13071547/97807315-b7537600-1c25-11eb-89dc-a432ac1aae15.jpg)

After this PR:
![2020-10-31-171323](https://user-images.githubusercontent.com/13071547/97807330-c89c8280-1c25-11eb-942e-bfbf58862175.jpg)
