### PR TITLE
[Android] Move to targetSdkVersion 29

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,8 +99,8 @@ matrix:
       android:
         components:
           - tools
-          - build-tools-28.0.3
-          - android-28
+          - build-tools-29.0.3
+          - android-29
       install:
         - echo y | sdkmanager "ndk-bundle"
       before_script:

--- a/pkg/android/phoenix/AndroidManifest.xml
+++ b/pkg/android/phoenix/AndroidManifest.xml
@@ -24,6 +24,7 @@
         android:isGame="true"
         android:banner="@drawable/banner"
         android:extractNativeLibs="true"
+        android:requestLegacyExternalStorage="true"
         tools:ignore="UnusedAttribute">
         <activity android:name="com.retroarch.browser.mainmenu.MainMenuActivity" android:exported="true" android:launchMode="singleInstance">
             <intent-filter>

--- a/pkg/android/phoenix/build.gradle
+++ b/pkg/android/phoenix/build.gradle
@@ -25,8 +25,8 @@ allprojects {
 apply plugin: 'com.android.application'
 
 android {
-  compileSdkVersion 28
-  buildToolsVersion "28.0.3"
+  compileSdkVersion 29
+  buildToolsVersion "29.0.3"
 
   flavorDimensions "variant"
 
@@ -37,7 +37,7 @@ android {
         arguments "-j${Runtime.runtime.availableProcessors()}"
       }
     }
-    targetSdkVersion 28
+    targetSdkVersion 29
   }
 
   productFlavors {

--- a/pkg/android/phoenix/module_template/build.gradle
+++ b/pkg/android/phoenix/module_template/build.gradle
@@ -1,10 +1,10 @@
 apply plugin: 'com.android.dynamic-feature'
 
 android {
-  compileSdkVersion 28
+  compileSdkVersion 29
   defaultConfig {
     minSdkVersion 21
-    targetSdkVersion 28
+    targetSdkVersion 29
   }
 
   flavorDimensions "variant"


### PR DESCRIPTION
## Description

This PR moves the Android app to targetSdkVersion 29.  This is required for Play Store updates due to Google's yearly enforcement of a minimum targetSdkVersion, which is 29 as of November 2nd.

`android:requestLegacyExternalStorage="true"` is required in order to opt-out of Scoped Storage on Android 10, which takes effect on apps that target API 29.

## Reviewers

@twinaphex 
