### PR TITLE
(RXML) Fix memory leak

### DIFF
--- a/libretro-common/formats/xml/rxml.c
+++ b/libretro-common/formats/xml/rxml.c
@@ -143,16 +143,6 @@ rxml_document_t *rxml_load_document_string(const char *str)
    if (!doc)
       goto error;
 
-   doc->root_node                = (struct rxml_node *)malloc(
-         sizeof(*doc->root_node));
-   
-   doc->root_node->name          = NULL;
-   doc->root_node->data          = NULL;
-   doc->root_node->attrib        = NULL;
-
-   doc->root_node->children      = NULL;
-   doc->root_node->next          = NULL;
-
    yxml_init(&x, buf->xml, BUFSIZE);
 
    for (; *str; ++str)
@@ -256,30 +246,14 @@ rxml_document_t *rxml_load_document_string(const char *str)
 
          case YXML_ATTRSTART:
             if (attr)
-            {
-               struct rxml_attrib_node 
-                  *new_node = (struct rxml_attrib_node*)
-                  calloc(1, sizeof(*attr));
-               attr         = new_node;
-               attr->next   = new_node ;
-            }
+               attr = attr->next   = (struct rxml_attrib_node*)
+                     calloc(1, sizeof(*attr));
             else
-            {
-               struct rxml_attrib_node 
-                  *new_node    = (struct rxml_attrib_node*)
-                  calloc(1, sizeof(*attr));
-               attr            = new_node;
-               
-               if (node)
-                  node->attrib = new_node;
-            }
+               attr = node->attrib = (struct rxml_attrib_node*)calloc(1, sizeof(*attr));
 
-            if (attr)
-            {
-               if (attr->attrib)
-                  free(attr->attrib);
-               attr->attrib = strdup(x.attr);
-            }
+            if (attr->attrib)
+               free(attr->attrib);
+            attr->attrib = strdup(x.attr);
 
             valptr       = buf->val;
             break;


### PR DESCRIPTION
## Description

It seems that some recent ill-advised 'fixes' have broken the `RXML` code, resulting in *titanic* memory leaks whenever a manual content scan is performed using an arcade DAT file...

This PR fixes the issue.