### PR TITLE
Fix database scans

### DIFF
--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -712,10 +712,11 @@ static int database_info_list_iterate_found_match(
     * running out of stack space on systems with a limited stack size.
     * We should use less fullsize paths in the future so that we don't
     * need to have all these big char arrays here */
-   char* db_crc                   = (char*)malloc(PATH_MAX_LENGTH * sizeof(char));
-   char* db_playlist_base_str     = (char*)malloc(PATH_MAX_LENGTH * sizeof(char));
-   char* db_playlist_path         = (char*)malloc(PATH_MAX_LENGTH * sizeof(char));
-   char* entry_path_str           = (char*)malloc(PATH_MAX_LENGTH * sizeof(char));
+   size_t str_len                 = PATH_MAX_LENGTH * sizeof(char);
+   char* db_crc                   = (char*)malloc(str_len);
+   char* db_playlist_base_str     = (char*)malloc(str_len);
+   char* db_playlist_path         = (char*)malloc(str_len);
+   char* entry_path_str           = (char*)malloc(str_len);
    char *hash                     = NULL;
    playlist_t   *playlist         = NULL;
    const char         *db_path    =
@@ -731,25 +732,25 @@ static int database_info_list_iterate_found_match(
    entry_path_str[0]              = '\0';
 
    fill_short_pathname_representation_noext(db_playlist_base_str,
-         db_path, sizeof(db_playlist_base_str));
+         db_path, str_len);
 
-   strlcat(db_playlist_base_str, ".lpl", sizeof(db_playlist_base_str));
+   strlcat(db_playlist_base_str, ".lpl", str_len);
 
    if (!string_is_empty(_db->playlist_directory))
       fill_pathname_join(db_playlist_path, _db->playlist_directory,
-            db_playlist_base_str, sizeof(db_playlist_path));
+            db_playlist_base_str, str_len);
 
    playlist_config_set_path(&_db->playlist_config, db_playlist_path);
    playlist = playlist_init(&_db->playlist_config);
 
-   snprintf(db_crc, sizeof(db_crc), "%08X|crc", db_info_entry->crc32);
+   snprintf(db_crc, str_len, "%08X|crc", db_info_entry->crc32);
 
    if (entry_path)
-      strlcpy(entry_path_str, entry_path, sizeof(entry_path_str));
+      strlcpy(entry_path_str, entry_path, str_len);
 
    if (!string_is_empty(archive_name))
       fill_pathname_join_delim(entry_path_str,
-            entry_path_str, archive_name, '#', sizeof(entry_path_str));
+            entry_path_str, archive_name, '#', str_len);
 
    if (core_info_database_match_archive_member(
          db_state->list->elems[db_state->list_index].data) &&


### PR DESCRIPTION
## Description

#11537 and e58cb3497071609faa42066cf57e3478c1c08d28 broke database scans because they replaced stack-allocated strings with heap-allocated ones but didn't update the rest of the code - as a result, we ended up calling `sizeof()` on a number of pointers (instead of fixed size char arrays), which clearly doesn't work...

This PR fixes the issue.