### PR TITLE
(DINPUT) Simultaneous shift sticky fix

### DIFF
--- a/gfx/common/win32_common.c
+++ b/gfx/common/win32_common.c
@@ -1054,6 +1054,13 @@ static LRESULT CALLBACK wnd_proc_common_dinput_internal(HWND hwnd,
                keysym |= 0x80;
 
             keycode = input_keymaps_translate_keysym_to_rk(keysym);
+            switch (keycode)
+            {
+               /* L+R Shift handling done in dinput_poll */
+               case RETROK_LSHIFT:
+               case RETROK_RSHIFT:
+                  return 0;
+            }
 
             input_keyboard_event(keydown, keycode,
                   0, mod, RETRO_DEVICE_KEYBOARD);


### PR DESCRIPTION
## Description

Problem:
- Dinput will not send `WM_KEYUP` for both Shifts if they are pressed together and released, resulting in sticky Shifts
= Pinball games ruined in DOSBox

Solution:
- Relocate `input_keyboard_event()` for Shift keys to `dinput_poll()` using `GetAsyncKeyState()`
- Bonus fix for Alt-Tab resulting in sticky Alt, by allowing LAlt keyup when application not in focus

## Related Issues

Solves the first item in https://github.com/libretro/dosbox-svn/issues/33



