### PR TITLE
Add API extension for cores to override frontend fast-forward state

### DIFF
--- a/gfx/common/egl_common.c
+++ b/gfx/common/egl_common.c
@@ -349,10 +349,9 @@ void egl_set_swap_interval(egl_ctx_data_t *egl, int interval)
    if (!_egl_get_current_context())
       return;
 
-   RARCH_LOG("[EGL]: eglSwapInterval(%u)\n", interval);
    if (!_egl_swap_interval(egl->dpy, interval))
    {
-      RARCH_ERR("[EGL]: eglSwapInterval() failed.\n");
+      RARCH_ERR("[EGL]: eglSwapInterval(%i) failed.\n", interval);
       egl_report_error();
    }
 }

--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -3002,11 +3002,13 @@ bool vulkan_create_swapchain(gfx_ctx_vulkan_data_t *vk,
          vk->context.gpu, vk->vk_surface,
          &present_mode_count, present_modes);
 
+#ifdef VULKAN_DEBUG
    for (i = 0; i < present_mode_count; i++)
    {
-      RARCH_DBG("[Vulkan]: Swapchain supports present mode: %u.\n",
+      RARCH_LOG("[Vulkan]: Swapchain supports present mode: %u.\n",
             present_modes[i]);
    }
+#endif
 
    vk->context.swap_interval = swap_interval;
    for (i = 0; i < present_mode_count; i++)
@@ -3030,8 +3032,10 @@ bool vulkan_create_swapchain(gfx_ctx_vulkan_data_t *vk,
       }
    }
 
+#ifdef VULKAN_DEBUG
    RARCH_LOG("[Vulkan]: Creating swapchain with present mode: %u\n",
          (unsigned)swapchain_present_mode);
+#endif
 
    vkGetPhysicalDeviceSurfaceFormatsKHR(vk->context.gpu,
          vk->vk_surface, &format_count, NULL);
@@ -3108,8 +3112,10 @@ bool vulkan_create_swapchain(gfx_ctx_vulkan_data_t *vk,
       return true;
    }
 
+#ifdef VULKAN_DEBUG
    RARCH_LOG("[Vulkan]: Using swapchain size %u x %u.\n",
          swapchain_size.width, swapchain_size.height);
+#endif
 
    /* Unless we have other reasons to clamp, we should prefer 3 images.
     * We hard sync against the swapchain, so if we have 2 images,
@@ -3214,8 +3220,10 @@ bool vulkan_create_swapchain(gfx_ctx_vulkan_data_t *vk,
    vkGetSwapchainImagesKHR(vk->context.device, vk->swapchain,
          &vk->context.num_swapchain_images, vk->context.swapchain_images);
 
+#ifdef VULKAN_DEBUG
    RARCH_LOG("[Vulkan]: Got %u swapchain images.\n",
          vk->context.num_swapchain_images);
+#endif
 
    /* Force driver to reset swapchain image handles. */
    vk->context.invalid_swapchain      = true;

--- a/gfx/drivers/gl.c
+++ b/gfx/drivers/gl.c
@@ -3252,8 +3252,6 @@ static void gl2_set_nonblock_state(
    if (!gl)
       return;
 
-   RARCH_LOG("[GL]: VSync => %s\n", state ? "OFF" : "ON");
-
    gl2_context_bind_hw_render(gl, false);
 
    if (!state)

--- a/gfx/drivers/gl1.c
+++ b/gfx/drivers/gl1.c
@@ -974,8 +974,6 @@ static void gl1_gfx_set_nonblock_state(void *data, bool state,
    if (!gl1)
       return;
 
-   RARCH_LOG("[GL1]: VSync => %s\n", state ? "OFF" : "ON");
-
    gl1_context_bind_hw_render(gl1, false);
 
    if (!state)

--- a/gfx/drivers/gl_core.c
+++ b/gfx/drivers/gl_core.c
@@ -1590,8 +1590,6 @@ static void gl_core_set_nonblock_state(void *data, bool state,
    if (!gl)
       return;
 
-   RARCH_LOG("[GLCore]: VSync => %s\n", state ? "OFF" : "ON");
-
    gl_core_context_bind_hw_render(gl, false);
    if (!state)
       interval = swap_interval;

--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -1345,8 +1345,6 @@ static void vulkan_set_nonblock_state(void *data, bool state,
    if (!vk)
       return;
 
-   RARCH_LOG("[Vulkan]: VSync => %s\n", state ? "OFF" : "ON");
-
    if (!state)
       interval = swap_interval;
 

--- a/gfx/drivers_context/wgl_ctx.c
+++ b/gfx/drivers_context/wgl_ctx.c
@@ -451,9 +451,8 @@ static void gfx_ctx_wgl_swap_interval(void *data, int interval)
          if (!win32_hrc || !p_swap_interval)
             return;
 
-         RARCH_LOG("[WGL]: wglSwapInterval(%i)\n", win32_interval);
          if (!p_swap_interval(win32_interval))
-            RARCH_WARN("[WGL]: wglSwapInterval() failed.\n");
+            RARCH_WARN("[WGL]: wglSwapInterval(%i) failed.\n", win32_interval);
 #endif
          break;
 

--- a/gfx/drivers_context/x_ctx.c
+++ b/gfx/drivers_context/x_ctx.c
@@ -258,40 +258,30 @@ static void gfx_ctx_x_swap_interval(void *data, int interval)
    {
       if (g_pglSwapInterval)
       {
-         RARCH_LOG("[GLX]: glXSwapInterval(%i)\n", x->interval);
          if (g_pglSwapInterval(x->interval) != 0)
-            RARCH_WARN("[GLX]: glXSwapInterval() failed.\n");
+            RARCH_WARN("[GLX]: glXSwapInterval(%i) failed.\n", x->interval);
       }
       else if (g_pglSwapIntervalEXT)
-      {
-         RARCH_LOG("[GLX]: glXSwapIntervalEXT(%i)\n", x->interval);
          g_pglSwapIntervalEXT(g_x11_dpy, x->glx_win, x->interval);
-      }
       else if (g_pglSwapIntervalSGI)
       {
-         RARCH_LOG("[GLX]: glXSwapIntervalSGI(%i)\n", x->interval);
          if (g_pglSwapIntervalSGI(x->interval) != 0)
-            RARCH_WARN("[GLX]: glXSwapIntervalSGI() failed.\n");
+            RARCH_WARN("[GLX]: glXSwapIntervalSGI(%i) failed.\n", x->interval);
       }
    }
    else
    {
       if (g_pglSwapIntervalEXT)
-      {
-         RARCH_LOG("[GLX]: glXSwapIntervalEXT(%i)\n", x->interval);
          g_pglSwapIntervalEXT(g_x11_dpy, x->glx_win, x->interval);
-      }
       else if (g_pglSwapInterval)
       {
-         RARCH_LOG("[GLX]: glXSwapInterval(%i)\n", x->interval);
          if (g_pglSwapInterval(x->interval) != 0)
-            RARCH_WARN("[GLX]: glXSwapInterval() failed.\n");
+            RARCH_WARN("[GLX]: glXSwapInterval(%i) failed.\n", x->interval);
       }
       else if (g_pglSwapIntervalSGI)
       {
-         RARCH_LOG("[GLX]: glXSwapIntervalSGI(%i)\n", x->interval);
          if (g_pglSwapIntervalSGI(x->interval) != 0)
-            RARCH_WARN("[GLX]: glXSwapIntervalSGI() failed.\n");
+            RARCH_WARN("[GLX]: glXSwapIntervalSGI(%i) failed.\n", x->interval);
       }
    }
 #endif

--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -1378,6 +1378,16 @@ enum retro_mod
                                             * call will target the newly initialized driver.
                                             */
 
+#define RETRO_ENVIRONMENT_SET_FASTFORWARDING_OVERRIDE 64
+                                           /* const struct retro_fastforwarding_override * --
+                                            * Used by a libretro core to override the current
+                                            * fastforwarding mode of the frontend.
+                                            * If NULL is passed to this function, the frontend
+                                            * will return true if fastforwarding override
+                                            * functionality is supported (no change in
+                                            * fastforwarding state will occur in this case).
+                                            */
+
 /* VFS functionality */
 
 /* File paths:
@@ -2936,6 +2946,47 @@ struct retro_framebuffer
    unsigned memory_flags;           /* Flags telling core how the memory has been mapped.
                                        RETRO_MEMORY_TYPE_* flags.
                                        Set by frontend in GET_CURRENT_SOFTWARE_FRAMEBUFFER. */
+};
+
+/* Used by a libretro core to override the current
+ * fastforwarding mode of the frontend */
+struct retro_fastforwarding_override
+{
+   /* Specifies the runtime speed multiplier that
+    * will be applied when 'fastforward' is true.
+    * For example, a value of 5.0 when running 60 FPS
+    * content will cap the fast-forward rate at 300 FPS.
+    * Note that the target multiplier may not be achieved
+    * if the host hardware has insufficient processing
+    * power.
+    * Setting a value of 0.0 (or greater than 0.0 but
+    * less than 1.0) will result in an uncapped
+    * fast-forward rate (limited only by hardware
+    * capacity).
+    * If the value is negative, it will be ignored
+    * (i.e. the frontend will use a runtime speed
+    * multiplier of its own choosing) */
+   float ratio;
+
+   /* If true, fastforwarding mode will be enabled.
+    * If false, fastforwarding mode will be disabled. */
+   bool fastforward;
+
+   /* If true, and if supported by the frontend, an
+    * on-screen notification will be displayed while
+    * 'fastforward' is true.
+    * If false, and if supported by the frontend, any
+    * on-screen fast-forward notifications will be
+    * suppressed */
+   bool notification;
+
+   /* If true, the core will have sole control over
+    * when fastforwarding mode is enabled/disabled;
+    * the frontend will not be able to change the
+    * state set by 'fastforward' until either
+    * 'inhibit_toggle' is set to false, or the core
+    * is unloaded */
+   bool inhibit_toggle;
 };
 
 /* Callbacks */

--- a/retroarch_data.h
+++ b/retroarch_data.h
@@ -1682,6 +1682,8 @@ struct runloop
    unsigned max_frames;
    unsigned audio_latency;
 
+   struct retro_fastforwarding_override fastmotion_override; /* float alignment */
+
    bool missing_bios;
    bool force_nonblock;
    bool paused;


### PR DESCRIPTION
## Description

This PR adds a new environment callback which can be used by a core to override the frontend fast-forward state. It is defined as follows:

```c
#define RETRO_ENVIRONMENT_SET_FASTFORWARDING_OVERRIDE 64
                                           /* const struct retro_fastforwarding_override * --
                                            * Used by a libretro core to override the current
                                            * fastforwarding mode of the frontend.
                                            * If NULL is passed to this function, the frontend
                                            * will return true if fastforwarding override
                                            * functionality is supported (no change in
                                            * fastforwarding state will occur in this case).
                                            */

/* Used by a libretro core to override the current
 * fastforwarding mode of the frontend */
struct retro_fastforwarding_override
{
   /* Specifies the runtime speed multiplier that
    * will be applied when 'fastforward' is true.
    * For example, a value of 5.0 when running 60 FPS
    * content will cap the fast-forward rate at 300 FPS.
    * Note that the target multiplier may not be achieved
    * if the host hardware has insufficient processing
    * power.
    * Setting a value of 0.0 will result in an uncapped
    * fast-forward rate (limited only by hardware
    * capacity).
    * If the value is negative, it will be ignored
    * (i.e. the frontend will use a runtime speed
    * multiplier of its own choosing) */
   float ratio;

   /* If true, fastforwarding mode will be enabled.
    * If false, fastforwarding mode will be disabled. */
   bool fastforward;

   /* If true, and if supported by the frontend, an
    * on-screen notification will be displayed while
    * 'fastforward' is true.
    * If false, and if supported by the frontend, any
    * on-screen fast-forward notifications will be
    * suppressed */
   bool notification;

   /* If true, the core will have sole control over
    * when fastforwarding mode is enabled/disabled;
    * the frontend will not be able to change the
    * state set by 'fastforward' until either
    * 'inhibit_toggle' is set to false, or the core
    * is unloaded */
   bool inhibit_toggle;
};
```

This is mostly special-case functionality, implemented specifically to enable netplay in the mupen64plus core (where fast-forward 
must be enabled core-side to enable 'catch up' if a player desyncs and falls behind).

More generally, it can be used by a core to implement a dedicated fast-forward button (a convenient alternative to regular frontend hotkeys). I have used the API extension to add this feature to the gpSP core - PR incoming.