### PR TITLE
(DINPUT) Prevent Win-key from opening Start Menu

### DIFF
--- a/input/drivers/dinput.c
+++ b/input/drivers/dinput.c
@@ -161,7 +161,7 @@ static void *dinput_init(const char *joypad_driver)
    {
       IDirectInputDevice8_SetDataFormat(di->keyboard, &c_dfDIKeyboard);
       IDirectInputDevice8_SetCooperativeLevel(di->keyboard,
-            (HWND)video_driver_window_get(), DISCL_NONEXCLUSIVE | DISCL_FOREGROUND);
+            (HWND)video_driver_window_get(), DISCL_NONEXCLUSIVE | DISCL_FOREGROUND | DISCL_NOWINKEY);
       IDirectInputDevice8_Acquire(di->keyboard);
    }
 


### PR DESCRIPTION
## Description

Looks like I discovered the proper way of keeping Win-keys inside the application when application is active.
