### PR TITLE
Clarify usage of 'RETRO_ENVIRONMENT_GET_RUMBLE_INTERFACE' callback

### DIFF
--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -712,6 +712,9 @@ enum retro_mod
                                             * state of rumble motors in controllers.
                                             * A strong and weak motor is supported, and they can be
                                             * controlled indepedently.
+                                            * Should be called from either retro_init() or retro_load_game().
+                                            * Should not be called from retro_set_environment().
+                                            * Returns false if rumble functionality is unavailable.
                                             */
 #define RETRO_ENVIRONMENT_GET_INPUT_DEVICE_CAPABILITIES 24
                                            /* uint64_t * --


### PR DESCRIPTION
## Description

This PR just clarifies proper usage of the `RETRO_ENVIRONMENT_GET_RUMBLE_INTERFACE` environment callback, by updating the relevant API comment in `libretro.h`

At present, no guidance is given as to when the callback should be used. It in fact only produces well defined results when called from either `retro_init()` or `retro_load_game()`