### PR TITLE
(WINRAW) Keyboard mods fix

### DIFF
--- a/gfx/common/win32_common.c
+++ b/gfx/common/win32_common.c
@@ -961,6 +961,14 @@ static LRESULT CALLBACK wnd_proc_common_internal(HWND hwnd,
             keysym             = (unsigned)wparam;
             /* fix key binding issues on winraw when 
              * DirectInput is not available */
+            switch (keysym)
+            {
+               /* Mod handling done in winraw_callback */
+               case VK_SHIFT:
+               case VK_CONTROL:
+               case VK_MENU:
+                  return 0;
+            }
 
             keycode = input_keymaps_translate_keysym_to_rk(keysym);
 


### PR DESCRIPTION
## Description

- Fixed Shifts+Control+Alts not being passed to the core that uses `retro_keyboard_callback`
- Fixed the same keys from being read while application is unfocused

## Related Issues

Closes #9142


