### PR TITLE
Fix memory leak in retroarch_validate_per_core_options()

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -34398,6 +34398,7 @@ static bool retroarch_validate_per_core_options(char *s,
       free(new_path);
    }
 
+   free(config_directory);
    return true;
 }
 


### PR DESCRIPTION
## Description

Commit 0a3306a7b44797b60b44552e0a678429c7b98a0e introduced a memory leak in `retroarch_validate_per_core_options()`. This PR fixes the issue.
