### PR TITLE
Add support for 64 buttons in udev gamepads

### DIFF
--- a/input/drivers_joypad/udev_joypad.c
+++ b/input/drivers_joypad/udev_joypad.c
@@ -49,7 +49,7 @@
  * Code adapted from SDL 2.0's implementation.
  */
 
-#define UDEV_NUM_BUTTONS 32
+#define UDEV_NUM_BUTTONS 64
 #define NUM_AXES 32
 
 #ifndef NUM_HATS
@@ -638,7 +638,7 @@ static void udev_joypad_get_buttons(unsigned port, input_bits_t *state)
 
 	if (pad)
    {
-		BITS_COPY16_PTR( state, pad->buttons );
+		BITS_COPY64_PTR( state, pad->buttons );
 	}
    else
       BIT256_CLEAR_ALL_PTR(state);

--- a/libretro-common/include/retro_miscellaneous.h
+++ b/libretro-common/include/retro_miscellaneous.h
@@ -152,6 +152,13 @@ static INLINE bool bits_any_set(uint32_t* ptr, uint32_t count)
    BITS_GET_ELEM_PTR(a, 0) = (bits); \
 }
 
+#define BITS_COPY64_PTR(a,bits) \
+{ \
+   BIT128_CLEAR_ALL_PTR(a); \
+   BITS_GET_ELEM_PTR(a, 0) = (bits); \
+   BITS_GET_ELEM_PTR(a, 1) = (bits >> 32); \
+}
+
 /* Helper macros and struct to keep track of many booleans. */
 /* This struct has 256 bits. */
 typedef struct


### PR DESCRIPTION
It seems only 16 were only really supported anyway due to the
usage of BITS_COPY16_PTR (which only copies 16 bit states)?
