### PR TITLE
Only attempt to call dir_check_defaults once per runtime session

### DIFF
--- a/frontend/drivers/platform_ctr.c
+++ b/frontend/drivers/platform_ctr.c
@@ -89,37 +89,7 @@ static void get_first_valid_core(char* path_return, size_t len)
       closedir(dir);
    }
 }
-#else
-static void ctr_dir_check_defaults(void)
-{
-   unsigned i;
-   char path[PATH_MAX_LENGTH];
-
-   /* early return for people with a custom folder setup
-      so it doesn't create unnecessary directories
-    */
-   strcpy_literal(path, "custom.ini");
-   if (path_is_valid(path))
-      return;
-
-   for (i = 0; i < DEFAULT_DIR_LAST; i++)
-   {
-      char       new_path[PATH_MAX_LENGTH];
-      const char *dir_path = g_defaults.dirs[i];
-
-      if (string_is_empty(dir_path))
-         continue;
-
-      new_path[0] = '\0';
-      fill_pathname_expand_special(new_path,
-            dir_path, sizeof(new_path));
-
-      if (!path_is_directory(new_path))
-         path_mkdir(new_path);
-   }
-}
 #endif
-
 
 static void frontend_ctr_get_environment_settings(int* argc, char* argv[],
       void* args, void* params_data)
@@ -157,8 +127,9 @@ static void frontend_ctr_get_environment_settings(int* argc, char* argv[],
                       "logs", sizeof(g_defaults.dirs[DEFAULT_DIR_LOGS]));
    fill_pathname_join(g_defaults.path_config, g_defaults.dirs[DEFAULT_DIR_PORT],
                       FILE_PATH_MAIN_CONFIG, sizeof(g_defaults.path_config));
+
 #ifndef IS_SALAMANDER
-   ctr_dir_check_defaults();
+   dir_check_defaults("custom.ini");
 #endif
 }
 

--- a/frontend/drivers/platform_ctr.c
+++ b/frontend/drivers/platform_ctr.c
@@ -89,13 +89,41 @@ static void get_first_valid_core(char* path_return, size_t len)
       closedir(dir);
    }
 }
+#else
+static void ctr_dir_check_defaults(void)
+{
+   unsigned i;
+   char path[PATH_MAX_LENGTH];
+
+   /* early return for people with a custom folder setup
+      so it doesn't create unnecessary directories
+    */
+   strcpy_literal(path, "custom.ini");
+   if (path_is_valid(path))
+      return;
+
+   for (i = 0; i < DEFAULT_DIR_LAST; i++)
+   {
+      char       new_path[PATH_MAX_LENGTH];
+      const char *dir_path = g_defaults.dirs[i];
+
+      if (string_is_empty(dir_path))
+         continue;
+
+      new_path[0] = '\0';
+      fill_pathname_expand_special(new_path,
+            dir_path, sizeof(new_path));
+
+      if (!path_is_directory(new_path))
+         path_mkdir(new_path);
+   }
+}
 #endif
+
 
 static void frontend_ctr_get_environment_settings(int* argc, char* argv[],
       void* args, void* params_data)
 {
-   (void)args;
-
    fill_pathname_basedir(g_defaults.dirs[DEFAULT_DIR_PORT], elf_path_cst, sizeof(g_defaults.dirs[DEFAULT_DIR_PORT]));
    RARCH_LOG("port dir: [%s]\n", g_defaults.dirs[DEFAULT_DIR_PORT]);
 
@@ -129,6 +157,9 @@ static void frontend_ctr_get_environment_settings(int* argc, char* argv[],
                       "logs", sizeof(g_defaults.dirs[DEFAULT_DIR_LOGS]));
    fill_pathname_join(g_defaults.path_config, g_defaults.dirs[DEFAULT_DIR_PORT],
                       FILE_PATH_MAIN_CONFIG, sizeof(g_defaults.path_config));
+#ifndef IS_SALAMANDER
+   ctr_dir_check_defaults();
+#endif
 }
 
 static void frontend_ctr_deinit(void* data)

--- a/frontend/drivers/platform_darwin.m
+++ b/frontend/drivers/platform_darwin.m
@@ -67,6 +67,7 @@
 #include "../../verbosity.h"
 #include "../../msg_hash.h"
 #include "../../ui/ui_companion_driver.h"
+#include "../../paths.h"
 
 #if 1
 #define RELEASE_BUILD
@@ -332,37 +333,6 @@ static void frontend_darwin_get_os(char *s, size_t len, int *major, int *minor)
 #endif
 }
 
-#ifndef IS_SALAMANDER
-static void darwin_dir_check_defaults(void)
-{
-   unsigned i;
-   char path[PATH_MAX_LENGTH];
-
-   /* early return for people with a custom folder setup
-      so it doesn't create unnecessary directories
-    */
-   strcpy_literal(path, "custom.ini");
-   if (path_is_valid(path))
-      return;
-
-   for (i = 0; i < DEFAULT_DIR_LAST; i++)
-   {
-      char       new_path[PATH_MAX_LENGTH];
-      const char *dir_path = g_defaults.dirs[i];
-
-      if (string_is_empty(dir_path))
-         continue;
-
-      new_path[0] = '\0';
-      fill_pathname_expand_special(new_path,
-            dir_path, sizeof(new_path));
-
-      if (!path_is_directory(new_path))
-         path_mkdir(new_path);
-   }
-}
-#endif
-
 static void frontend_darwin_get_environment_settings(int *argc, char *argv[],
       void *args, void *params_data)
 {
@@ -531,8 +501,9 @@ static void frontend_darwin_get_environment_settings(int *argc, char *argv[],
 
    CFRelease(bundle_path);
    CFRelease(bundle_url);
+
 #ifndef IS_SALAMANDER
-   darwin_dir_check_defaults();
+   dir_check_defaults("custom.ini");
 #endif
 }
 

--- a/frontend/drivers/platform_darwin.m
+++ b/frontend/drivers/platform_darwin.m
@@ -332,6 +332,37 @@ static void frontend_darwin_get_os(char *s, size_t len, int *major, int *minor)
 #endif
 }
 
+#ifndef IS_SALAMANDER
+static void darwin_dir_check_defaults(void)
+{
+   unsigned i;
+   char path[PATH_MAX_LENGTH];
+
+   /* early return for people with a custom folder setup
+      so it doesn't create unnecessary directories
+    */
+   strcpy_literal(path, "custom.ini");
+   if (path_is_valid(path))
+      return;
+
+   for (i = 0; i < DEFAULT_DIR_LAST; i++)
+   {
+      char       new_path[PATH_MAX_LENGTH];
+      const char *dir_path = g_defaults.dirs[i];
+
+      if (string_is_empty(dir_path))
+         continue;
+
+      new_path[0] = '\0';
+      fill_pathname_expand_special(new_path,
+            dir_path, sizeof(new_path));
+
+      if (!path_is_directory(new_path))
+         path_mkdir(new_path);
+   }
+}
+#endif
+
 static void frontend_darwin_get_environment_settings(int *argc, char *argv[],
       void *args, void *params_data)
 {
@@ -500,6 +531,9 @@ static void frontend_darwin_get_environment_settings(int *argc, char *argv[],
 
    CFRelease(bundle_path);
    CFRelease(bundle_url);
+#ifndef IS_SALAMANDER
+   darwin_dir_check_defaults();
+#endif
 }
 
 static void frontend_darwin_load_content(void)

--- a/frontend/drivers/platform_dos.c
+++ b/frontend/drivers/platform_dos.c
@@ -22,6 +22,7 @@
 
 #include "../frontend_driver.h"
 #include "../../defaults.h"
+#include "../../paths.h"
 
 static enum frontend_fork dos_fork_mode = FRONTEND_FORK_NONE;
 
@@ -44,37 +45,6 @@ enum frontend_architecture frontend_dos_get_architecture(void)
 {
 	return FRONTEND_ARCH_X86;
 }
-
-#ifndef IS_SALAMANDER
-static void dos_dir_check_defaults(void)
-{
-   unsigned i;
-   char path[PATH_MAX_LENGTH];
-
-   /* early return for people with a custom folder setup
-      so it doesn't create unnecessary directories
-    */
-   strcpy_literal(path, "custom.ini");
-   if (path_is_valid(path))
-      return;
-
-   for (i = 0; i < DEFAULT_DIR_LAST; i++)
-   {
-      char       new_path[PATH_MAX_LENGTH];
-      const char *dir_path = g_defaults.dirs[i];
-
-      if (string_is_empty(dir_path))
-         continue;
-
-      new_path[0] = '\0';
-      fill_pathname_expand_special(new_path,
-            dir_path, sizeof(new_path));
-
-      if (!path_is_directory(new_path))
-         path_mkdir(new_path);
-   }
-}
-#endif
 
 static void frontend_dos_get_env_settings(int *argc, char *argv[],
       void *data, void *params_data)
@@ -137,7 +107,7 @@ static void frontend_dos_get_env_settings(int *argc, char *argv[],
 			   "logs", sizeof(g_defaults.dirs[DEFAULT_DIR_LOGS]));
 
 #ifndef IS_SALAMANDER
-   dos_dir_check_defaults();
+   dir_check_defaults("custom.ini");
 #endif
 }
 

--- a/frontend/drivers/platform_dos.c
+++ b/frontend/drivers/platform_dos.c
@@ -45,6 +45,37 @@ enum frontend_architecture frontend_dos_get_architecture(void)
 	return FRONTEND_ARCH_X86;
 }
 
+#ifndef IS_SALAMANDER
+static void dos_dir_check_defaults(void)
+{
+   unsigned i;
+   char path[PATH_MAX_LENGTH];
+
+   /* early return for people with a custom folder setup
+      so it doesn't create unnecessary directories
+    */
+   strcpy_literal(path, "custom.ini");
+   if (path_is_valid(path))
+      return;
+
+   for (i = 0; i < DEFAULT_DIR_LAST; i++)
+   {
+      char       new_path[PATH_MAX_LENGTH];
+      const char *dir_path = g_defaults.dirs[i];
+
+      if (string_is_empty(dir_path))
+         continue;
+
+      new_path[0] = '\0';
+      fill_pathname_expand_special(new_path,
+            dir_path, sizeof(new_path));
+
+      if (!path_is_directory(new_path))
+         path_mkdir(new_path);
+   }
+}
+#endif
+
 static void frontend_dos_get_env_settings(int *argc, char *argv[],
       void *data, void *params_data)
 {
@@ -105,12 +136,9 @@ static void frontend_dos_get_env_settings(int *argc, char *argv[],
 	fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_LOGS], base_path,
 			   "logs", sizeof(g_defaults.dirs[DEFAULT_DIR_LOGS]));
 
-	for (i = 0; i < DEFAULT_DIR_LAST; i++)
-	{
-		const char *dir_path = g_defaults.dirs[i];
-		if (!string_is_empty(dir_path))
-			path_mkdir(dir_path);
-	}
+#ifndef IS_SALAMANDER
+   dos_dir_check_defaults();
+#endif
 }
 
 static void frontend_dos_exec(const char *path, bool should_load_game)

--- a/frontend/drivers/platform_emscripten.c
+++ b/frontend/drivers/platform_emscripten.c
@@ -69,6 +69,35 @@ void cmd_take_screenshot(void)
    command_event(CMD_EVENT_TAKE_SCREENSHOT, NULL);
 }
 
+static void emscripten_dir_check_defaults(void)
+{
+   unsigned i;
+   char path[PATH_MAX_LENGTH];
+
+   /* early return for people with a custom folder setup
+      so it doesn't create unnecessary directories
+    */
+   strcpy_literal(path, "custom.ini");
+   if (path_is_valid(path))
+      return;
+
+   for (i = 0; i < DEFAULT_DIR_LAST; i++)
+   {
+      char       new_path[PATH_MAX_LENGTH];
+      const char *dir_path = g_defaults.dirs[i];
+
+      if (string_is_empty(dir_path))
+         continue;
+
+      new_path[0] = '\0';
+      fill_pathname_expand_special(new_path,
+            dir_path, sizeof(new_path));
+
+      if (!path_is_directory(new_path))
+         path_mkdir(new_path);
+   }
+}
+
 static void frontend_emscripten_get_env(int *argc, char *argv[],
       void *args, void *params_data)
 {
@@ -150,13 +179,9 @@ static void frontend_emscripten_get_env(int *argc, char *argv[],
          user_path, sizeof(g_defaults.dirs[DEFAULT_DIR_CONTENT_HISTORY]));
    fill_pathname_join(g_defaults.path_config, user_path,
          FILE_PATH_MAIN_CONFIG, sizeof(g_defaults.path_config));
-
-   for (i = 0; i < DEFAULT_DIR_LAST; i++)
-   {
-      const char *dir_path = g_defaults.dirs[i];
-      if (!string_is_empty(dir_path))
-         path_mkdir(dir_path);
-   }
+#ifndef IS_SALAMANDER
+   emscripten_dir_check_defaults();
+#endif
 }
 
 int main(int argc, char *argv[])

--- a/frontend/drivers/platform_emscripten.c
+++ b/frontend/drivers/platform_emscripten.c
@@ -45,6 +45,7 @@
 #include "../../command.h"
 #include "../../tasks/tasks_internal.h"
 #include "../../file_path_special.h"
+#include "../../paths.h"
 
 void dummyErrnoCodes(void);
 void emscripten_mainloop(void);
@@ -67,35 +68,6 @@ void cmd_load_state(void)
 void cmd_take_screenshot(void)
 {
    command_event(CMD_EVENT_TAKE_SCREENSHOT, NULL);
-}
-
-static void emscripten_dir_check_defaults(void)
-{
-   unsigned i;
-   char path[PATH_MAX_LENGTH];
-
-   /* early return for people with a custom folder setup
-      so it doesn't create unnecessary directories
-    */
-   strcpy_literal(path, "custom.ini");
-   if (path_is_valid(path))
-      return;
-
-   for (i = 0; i < DEFAULT_DIR_LAST; i++)
-   {
-      char       new_path[PATH_MAX_LENGTH];
-      const char *dir_path = g_defaults.dirs[i];
-
-      if (string_is_empty(dir_path))
-         continue;
-
-      new_path[0] = '\0';
-      fill_pathname_expand_special(new_path,
-            dir_path, sizeof(new_path));
-
-      if (!path_is_directory(new_path))
-         path_mkdir(new_path);
-   }
 }
 
 static void frontend_emscripten_get_env(int *argc, char *argv[],
@@ -179,8 +151,9 @@ static void frontend_emscripten_get_env(int *argc, char *argv[],
          user_path, sizeof(g_defaults.dirs[DEFAULT_DIR_CONTENT_HISTORY]));
    fill_pathname_join(g_defaults.path_config, user_path,
          FILE_PATH_MAIN_CONFIG, sizeof(g_defaults.path_config));
+
 #ifndef IS_SALAMANDER
-   emscripten_dir_check_defaults();
+   dir_check_defaults("custom.ini");
 #endif
 }
 

--- a/frontend/drivers/platform_gx.c
+++ b/frontend/drivers/platform_gx.c
@@ -154,35 +154,6 @@ static void gx_devthread(void *a)
 
 #ifdef IS_SALAMANDER
 extern char gx_rom_path[PATH_MAX_LENGTH];
-#else
-static void gx_dir_check_defaults(void)
-{
-   unsigned i;
-   char path[PATH_MAX_LENGTH];
-
-   /* early return for people with a custom folder setup
-      so it doesn't create unnecessary directories
-    */
-   strcpy_literal(path, "custom.ini");
-   if (path_is_valid(path))
-      return;
-
-   for (i = 0; i < DEFAULT_DIR_LAST; i++)
-   {
-      char       new_path[PATH_MAX_LENGTH];
-      const char *dir_path = g_defaults.dirs[i];
-
-      if (string_is_empty(dir_path))
-         continue;
-
-      new_path[0] = '\0';
-      fill_pathname_expand_special(new_path,
-            dir_path, sizeof(new_path));
-
-      if (!path_is_directory(new_path))
-         path_mkdir(new_path);
-   }
-}
 #endif
 
 static void frontend_gx_get_environment_settings(
@@ -312,7 +283,7 @@ static void frontend_gx_get_environment_settings(
       }
    }
 #endif
-   gx_dir_check_defaults();
+   dir_check_defaults("custom.ini");
 #endif
 }
 

--- a/frontend/drivers/platform_gx.c
+++ b/frontend/drivers/platform_gx.c
@@ -154,6 +154,35 @@ static void gx_devthread(void *a)
 
 #ifdef IS_SALAMANDER
 extern char gx_rom_path[PATH_MAX_LENGTH];
+#else
+static void gx_dir_check_defaults(void)
+{
+   unsigned i;
+   char path[PATH_MAX_LENGTH];
+
+   /* early return for people with a custom folder setup
+      so it doesn't create unnecessary directories
+    */
+   strcpy_literal(path, "custom.ini");
+   if (path_is_valid(path))
+      return;
+
+   for (i = 0; i < DEFAULT_DIR_LAST; i++)
+   {
+      char       new_path[PATH_MAX_LENGTH];
+      const char *dir_path = g_defaults.dirs[i];
+
+      if (string_is_empty(dir_path))
+         continue;
+
+      new_path[0] = '\0';
+      fill_pathname_expand_special(new_path,
+            dir_path, sizeof(new_path));
+
+      if (!path_is_directory(new_path))
+         path_mkdir(new_path);
+   }
+}
 #endif
 
 static void frontend_gx_get_environment_settings(
@@ -283,6 +312,7 @@ static void frontend_gx_get_environment_settings(
       }
    }
 #endif
+   gx_dir_check_defaults();
 #endif
 }
 

--- a/frontend/drivers/platform_orbis.c
+++ b/frontend/drivers/platform_orbis.c
@@ -95,6 +95,35 @@ int main(int argc, char *argv[])
    return rarch_main(argc, argv, NULL);
 }
 
+static void orbis_dir_check_defaults(void)
+{
+   unsigned i;
+   char path[PATH_MAX_LENGTH];
+
+   /* early return for people with a custom folder setup
+      so it doesn't create unnecessary directories
+    */
+   strcpy_literal(path, "host0:app/custom.ini");
+   if (path_is_valid(path))
+      return;
+
+   for (i = 0; i < DEFAULT_DIR_LAST; i++)
+   {
+      char       new_path[PATH_MAX_LENGTH];
+      const char *dir_path = g_defaults.dirs[i];
+
+      if (string_is_empty(dir_path))
+         continue;
+
+      new_path[0] = '\0';
+      fill_pathname_expand_special(new_path,
+            dir_path, sizeof(new_path));
+
+      if (!path_is_directory(new_path))
+         path_mkdir(new_path);
+   }
+}
+
 static void frontend_orbis_get_environment_settings(int *argc, char *argv[],
       void *args, void *params_data)
 {
@@ -210,14 +239,8 @@ static void frontend_orbis_get_environment_settings(int *argc, char *argv[],
          RARCH_LOG("Auto-start game %s.\n", argv[2]);
       }
    }
+   orbis_dir_check_defaults();
 #endif
-
-   for (i = 0; i < DEFAULT_DIR_LAST; i++)
-   {
-      const char *dir_path = g_defaults.dirs[i];
-      if (!string_is_empty(dir_path))
-         path_mkdir(dir_path);
-   }
 }
 
 static void frontend_orbis_deinit(void *data)

--- a/frontend/drivers/platform_orbis.c
+++ b/frontend/drivers/platform_orbis.c
@@ -95,35 +95,6 @@ int main(int argc, char *argv[])
    return rarch_main(argc, argv, NULL);
 }
 
-static void orbis_dir_check_defaults(void)
-{
-   unsigned i;
-   char path[PATH_MAX_LENGTH];
-
-   /* early return for people with a custom folder setup
-      so it doesn't create unnecessary directories
-    */
-   strcpy_literal(path, "host0:app/custom.ini");
-   if (path_is_valid(path))
-      return;
-
-   for (i = 0; i < DEFAULT_DIR_LAST; i++)
-   {
-      char       new_path[PATH_MAX_LENGTH];
-      const char *dir_path = g_defaults.dirs[i];
-
-      if (string_is_empty(dir_path))
-         continue;
-
-      new_path[0] = '\0';
-      fill_pathname_expand_special(new_path,
-            dir_path, sizeof(new_path));
-
-      if (!path_is_directory(new_path))
-         path_mkdir(new_path);
-   }
-}
-
 static void frontend_orbis_get_environment_settings(int *argc, char *argv[],
       void *args, void *params_data)
 {
@@ -239,7 +210,8 @@ static void frontend_orbis_get_environment_settings(int *argc, char *argv[],
          RARCH_LOG("Auto-start game %s.\n", argv[2]);
       }
    }
-   orbis_dir_check_defaults();
+
+   dir_check_defaults("host0:app/custom.ini");
 #endif
 }
 

--- a/frontend/drivers/platform_ps2.c
+++ b/frontend/drivers/platform_ps2.c
@@ -107,6 +107,37 @@ static void reset_IOP()
    sbv_patch_disable_prefix_check();
 }
 
+#ifndef IS_SALAMANDER
+static void ps2_dir_check_defaults(void)
+{
+   unsigned i;
+   char path[PATH_MAX_LENGTH];
+
+   /* early return for people with a custom folder setup
+      so it doesn't create unnecessary directories
+    */
+   strcpy_literal(path, "custom.ini");
+   if (path_is_valid(path))
+      return;
+
+   for (i = 0; i < DEFAULT_DIR_LAST; i++)
+   {
+      char       new_path[PATH_MAX_LENGTH];
+      const char *dir_path = g_defaults.dirs[i];
+
+      if (string_is_empty(dir_path))
+         continue;
+
+      new_path[0] = '\0';
+      fill_pathname_expand_special(new_path,
+            dir_path, sizeof(new_path));
+
+      if (!path_is_directory(new_path))
+         path_mkdir(new_path);
+   }
+}
+#endif
+
 static void frontend_ps2_get_environment_settings(int *argc, char *argv[],
       void *args, void *params_data)
 {
@@ -140,12 +171,9 @@ static void frontend_ps2_get_environment_settings(int *argc, char *argv[],
       }
    }
 #endif
-   for (i = 0; i < DEFAULT_DIR_LAST; i++)
-   {
-      const char *dir_path = g_defaults.dirs[i];
-      if (!string_is_empty(dir_path))
-         path_mkdir(dir_path);
-   }
+#ifndef IS_SALAMANDER
+   ps2_dir_check_defaults();
+#endif
 }
 
 static void frontend_ps2_init(void *data)

--- a/frontend/drivers/platform_ps2.c
+++ b/frontend/drivers/platform_ps2.c
@@ -33,6 +33,7 @@
 #include "../../defaults.h"
 #include "../../file_path_special.h"
 #include "../../verbosity.h"
+#include "../../paths.h"
 #include <elf-loader.h>
 
 
@@ -107,37 +108,6 @@ static void reset_IOP()
    sbv_patch_disable_prefix_check();
 }
 
-#ifndef IS_SALAMANDER
-static void ps2_dir_check_defaults(void)
-{
-   unsigned i;
-   char path[PATH_MAX_LENGTH];
-
-   /* early return for people with a custom folder setup
-      so it doesn't create unnecessary directories
-    */
-   strcpy_literal(path, "custom.ini");
-   if (path_is_valid(path))
-      return;
-
-   for (i = 0; i < DEFAULT_DIR_LAST; i++)
-   {
-      char       new_path[PATH_MAX_LENGTH];
-      const char *dir_path = g_defaults.dirs[i];
-
-      if (string_is_empty(dir_path))
-         continue;
-
-      new_path[0] = '\0';
-      fill_pathname_expand_special(new_path,
-            dir_path, sizeof(new_path));
-
-      if (!path_is_directory(new_path))
-         path_mkdir(new_path);
-   }
-}
-#endif
-
 static void frontend_ps2_get_environment_settings(int *argc, char *argv[],
       void *args, void *params_data)
 {
@@ -171,8 +141,9 @@ static void frontend_ps2_get_environment_settings(int *argc, char *argv[],
       }
    }
 #endif
+
 #ifndef IS_SALAMANDER
-   ps2_dir_check_defaults();
+   dir_check_defaults("custom.ini");
 #endif
 }
 

--- a/frontend/drivers/platform_ps3.c
+++ b/frontend/drivers/platform_ps3.c
@@ -176,6 +176,37 @@ static void use_app_path(char *content_info_path)
 		       "USRDIR", sizeof(g_defaults.dirs[DEFAULT_DIR_PORT]));
 }
 
+#ifndef IS_SALAMANDER
+static void dir_check_defaults(void)
+{
+   unsigned i;
+   char path[PATH_MAX_LENGTH];
+
+   /* early return for people with a custom folder setup
+      so it doesn't create unnecessary directories
+    */
+   strcpy_literal(path, "custom.ini");
+   if (path_is_valid(path))
+      return;
+
+   for (i = 0; i < DEFAULT_DIR_LAST; i++)
+   {
+      char       new_path[PATH_MAX_LENGTH];
+      const char *dir_path = g_defaults.dirs[i];
+
+      if (string_is_empty(dir_path))
+         continue;
+
+      new_path[0] = '\0';
+      fill_pathname_expand_special(new_path,
+            dir_path, sizeof(new_path));
+
+      if (!path_is_directory(new_path))
+         path_mkdir(new_path);
+   }
+}
+#endif
+
 #ifdef __PSL1GHT__
 static void frontend_ps3_get_environment_settings(int *argc, char *argv[],
       void *args, void *params_data)
@@ -206,6 +237,7 @@ static void frontend_ps3_get_environment_settings(int *argc, char *argv[],
       verbosity_enable();
    else
       verbosity_disable();
+   ps3_dir_check_defaults();
 #endif
 }
 
@@ -329,6 +361,7 @@ static void frontend_ps3_get_environment_settings(int *argc, char *argv[],
       verbosity_enable();
    else
       verbosity_disable();
+   ps3_dir_check_defaults();
 #endif
 }
 #endif

--- a/frontend/drivers/platform_ps3.c
+++ b/frontend/drivers/platform_ps3.c
@@ -49,6 +49,7 @@
 #include "../../defines/ps3_defines.h"
 #include "../../defaults.h"
 #include "../../verbosity.h"
+#include "../../paths.h"
 
 #ifdef __PSL1GHT__
 #define EMULATOR_CONTENT_DIR "SSNE10001"
@@ -176,37 +177,6 @@ static void use_app_path(char *content_info_path)
 		       "USRDIR", sizeof(g_defaults.dirs[DEFAULT_DIR_PORT]));
 }
 
-#ifndef IS_SALAMANDER
-static void dir_check_defaults(void)
-{
-   unsigned i;
-   char path[PATH_MAX_LENGTH];
-
-   /* early return for people with a custom folder setup
-      so it doesn't create unnecessary directories
-    */
-   strcpy_literal(path, "custom.ini");
-   if (path_is_valid(path))
-      return;
-
-   for (i = 0; i < DEFAULT_DIR_LAST; i++)
-   {
-      char       new_path[PATH_MAX_LENGTH];
-      const char *dir_path = g_defaults.dirs[i];
-
-      if (string_is_empty(dir_path))
-         continue;
-
-      new_path[0] = '\0';
-      fill_pathname_expand_special(new_path,
-            dir_path, sizeof(new_path));
-
-      if (!path_is_directory(new_path))
-         path_mkdir(new_path);
-   }
-}
-#endif
-
 #ifdef __PSL1GHT__
 static void frontend_ps3_get_environment_settings(int *argc, char *argv[],
       void *args, void *params_data)
@@ -237,7 +207,8 @@ static void frontend_ps3_get_environment_settings(int *argc, char *argv[],
       verbosity_enable();
    else
       verbosity_disable();
-   ps3_dir_check_defaults();
+
+   dir_check_defaults("custom.ini");
 #endif
 }
 

--- a/frontend/drivers/platform_psp.c
+++ b/frontend/drivers/platform_psp.c
@@ -80,6 +80,37 @@ char user_path[512];
 
 static enum frontend_fork psp_fork_mode = FRONTEND_FORK_NONE;
 
+#ifndef IS_SALAMANDER
+static void psp_dir_check_defaults(void)
+{
+   unsigned i;
+   char path[PATH_MAX_LENGTH];
+
+   /* early return for people with a custom folder setup
+      so it doesn't create unnecessary directories
+    */
+   strcpy_literal(path, "custom.ini");
+   if (path_is_valid(path))
+      return;
+
+   for (i = 0; i < DEFAULT_DIR_LAST; i++)
+   {
+      char       new_path[PATH_MAX_LENGTH];
+      const char *dir_path = g_defaults.dirs[i];
+
+      if (string_is_empty(dir_path))
+         continue;
+
+      new_path[0] = '\0';
+      fill_pathname_expand_special(new_path,
+            dir_path, sizeof(new_path));
+
+      if (!path_is_directory(new_path))
+         path_mkdir(new_path);
+   }
+}
+#endif
+
 static void frontend_psp_get_environment_settings(int *argc, char *argv[],
       void *args, void *params_data)
 {
@@ -217,14 +248,8 @@ static void frontend_psp_get_environment_settings(int *argc, char *argv[],
          RARCH_LOG("Auto-start game %s.\n", argv[1]);
       }
    }
+   psp_dir_check_defaults();
 #endif
-
-   for (i = 0; i < DEFAULT_DIR_LAST; i++)
-   {
-      const char *dir_path = g_defaults.dirs[i];
-      if (!string_is_empty(dir_path))
-         path_mkdir(dir_path);
-   }
 }
 
 static void frontend_psp_deinit(void *data)

--- a/frontend/drivers/platform_psp.c
+++ b/frontend/drivers/platform_psp.c
@@ -80,37 +80,6 @@ char user_path[512];
 
 static enum frontend_fork psp_fork_mode = FRONTEND_FORK_NONE;
 
-#ifndef IS_SALAMANDER
-static void psp_dir_check_defaults(void)
-{
-   unsigned i;
-   char path[PATH_MAX_LENGTH];
-
-   /* early return for people with a custom folder setup
-      so it doesn't create unnecessary directories
-    */
-   strcpy_literal(path, "custom.ini");
-   if (path_is_valid(path))
-      return;
-
-   for (i = 0; i < DEFAULT_DIR_LAST; i++)
-   {
-      char       new_path[PATH_MAX_LENGTH];
-      const char *dir_path = g_defaults.dirs[i];
-
-      if (string_is_empty(dir_path))
-         continue;
-
-      new_path[0] = '\0';
-      fill_pathname_expand_special(new_path,
-            dir_path, sizeof(new_path));
-
-      if (!path_is_directory(new_path))
-         path_mkdir(new_path);
-   }
-}
-#endif
-
 static void frontend_psp_get_environment_settings(int *argc, char *argv[],
       void *args, void *params_data)
 {
@@ -248,7 +217,8 @@ static void frontend_psp_get_environment_settings(int *argc, char *argv[],
          RARCH_LOG("Auto-start game %s.\n", argv[1]);
       }
    }
-   psp_dir_check_defaults();
+
+   dir_check_defaults("custom.ini");
 #endif
 }
 

--- a/frontend/drivers/platform_qnx.c
+++ b/frontend/drivers/platform_qnx.c
@@ -30,6 +30,7 @@
 #include "../../defaults.h"
 #include "../../dynamic.h"
 #include "../../verbosity.h"
+#include "../../paths.h"
 
 static void frontend_qnx_init(void *data)
 {
@@ -50,37 +51,6 @@ static int frontend_qnx_get_rating(void)
     * determine rating for some */
    return -1;
 }
-
-#ifndef IS_SALAMANDER
-static void qnx_dir_check_defaults(void)
-{
-   unsigned i;
-   char path[PATH_MAX_LENGTH];
-
-   /* early return for people with a custom folder setup
-      so it doesn't create unnecessary directories
-    */
-   strcpy_literal(path, "custom.ini");
-   if (path_is_valid(path))
-      return;
-
-   for (i = 0; i < DEFAULT_DIR_LAST; i++)
-   {
-      char       new_path[PATH_MAX_LENGTH];
-      const char *dir_path = g_defaults.dirs[i];
-
-      if (string_is_empty(dir_path))
-         continue;
-
-      new_path[0] = '\0';
-      fill_pathname_expand_special(new_path,
-            dir_path, sizeof(new_path));
-
-      if (!path_is_directory(new_path))
-         path_mkdir(new_path);
-   }
-}
-#endif
 
 static void frontend_qnx_get_environment_settings(int *argc, char *argv[],
       void *data, void *params_data)
@@ -195,8 +165,9 @@ static void frontend_qnx_get_environment_settings(int *argc, char *argv[],
 
    /* set GLUI as default menu */
    snprintf(g_defaults.settings_menu, sizeof(g_defaults.settings_menu), "glui");
+
 #ifndef IS_SALAMANDER
-   qnx_dir_check_defaults();
+   dir_check_defaults("custom.ini");
 #endif
 }
 

--- a/frontend/drivers/platform_qnx.c
+++ b/frontend/drivers/platform_qnx.c
@@ -51,6 +51,37 @@ static int frontend_qnx_get_rating(void)
    return -1;
 }
 
+#ifndef IS_SALAMANDER
+static void qnx_dir_check_defaults(void)
+{
+   unsigned i;
+   char path[PATH_MAX_LENGTH];
+
+   /* early return for people with a custom folder setup
+      so it doesn't create unnecessary directories
+    */
+   strcpy_literal(path, "custom.ini");
+   if (path_is_valid(path))
+      return;
+
+   for (i = 0; i < DEFAULT_DIR_LAST; i++)
+   {
+      char       new_path[PATH_MAX_LENGTH];
+      const char *dir_path = g_defaults.dirs[i];
+
+      if (string_is_empty(dir_path))
+         continue;
+
+      new_path[0] = '\0';
+      fill_pathname_expand_special(new_path,
+            dir_path, sizeof(new_path));
+
+      if (!path_is_directory(new_path))
+         path_mkdir(new_path);
+   }
+}
+#endif
+
 static void frontend_qnx_get_environment_settings(int *argc, char *argv[],
       void *data, void *params_data)
 {
@@ -162,15 +193,11 @@ static void frontend_qnx_get_environment_settings(int *argc, char *argv[],
          RARCH_LOG( "Asset copy successful.\n");
    }
 
-   for (i = 0; i < DEFAULT_DIR_LAST; i++)
-   {
-      const char *dir_path = g_defaults.dirs[i];
-      if (!string_is_empty(dir_path))
-         path_mkdir(dir_path);
-   }
-
-   /* set glui as default menu */
+   /* set GLUI as default menu */
    snprintf(g_defaults.settings_menu, sizeof(g_defaults.settings_menu), "glui");
+#ifndef IS_SALAMANDER
+   qnx_dir_check_defaults();
+#endif
 }
 
 enum frontend_architecture frontend_qnx_get_architecture(void)

--- a/frontend/drivers/platform_switch.c
+++ b/frontend/drivers/platform_switch.c
@@ -175,6 +175,35 @@ static void get_first_valid_core(char *path_return, size_t len)
       closedir(dir);
    }
 }
+#else
+static void switch_dir_check_defaults(void)
+{
+   unsigned i;
+   char path[PATH_MAX_LENGTH];
+
+   /* early return for people with a custom folder setup
+      so it doesn't create unnecessary directories
+    */
+   strcpy_literal(path, "custom.ini");
+   if (path_is_valid(path))
+      return;
+
+   for (i = 0; i < DEFAULT_DIR_LAST; i++)
+   {
+      char       new_path[PATH_MAX_LENGTH];
+      const char *dir_path = g_defaults.dirs[i];
+
+      if (string_is_empty(dir_path))
+         continue;
+
+      new_path[0] = '\0';
+      fill_pathname_expand_special(new_path,
+            dir_path, sizeof(new_path));
+
+      if (!path_is_directory(new_path))
+         path_mkdir(new_path);
+   }
+}
 #endif
 
 static void frontend_switch_get_environment_settings(
@@ -276,6 +305,9 @@ static void frontend_switch_get_environment_settings(
          g_defaults.dirs[DEFAULT_DIR_PORT],
          FILE_PATH_MAIN_CONFIG,
          sizeof(g_defaults.path_config));
+#ifndef IS_SALAMANDER
+   switch_dir_check_defaults();
+#endif
 }
 
 static void frontend_switch_deinit(void *data)

--- a/frontend/drivers/platform_switch.c
+++ b/frontend/drivers/platform_switch.c
@@ -175,35 +175,6 @@ static void get_first_valid_core(char *path_return, size_t len)
       closedir(dir);
    }
 }
-#else
-static void switch_dir_check_defaults(void)
-{
-   unsigned i;
-   char path[PATH_MAX_LENGTH];
-
-   /* early return for people with a custom folder setup
-      so it doesn't create unnecessary directories
-    */
-   strcpy_literal(path, "custom.ini");
-   if (path_is_valid(path))
-      return;
-
-   for (i = 0; i < DEFAULT_DIR_LAST; i++)
-   {
-      char       new_path[PATH_MAX_LENGTH];
-      const char *dir_path = g_defaults.dirs[i];
-
-      if (string_is_empty(dir_path))
-         continue;
-
-      new_path[0] = '\0';
-      fill_pathname_expand_special(new_path,
-            dir_path, sizeof(new_path));
-
-      if (!path_is_directory(new_path))
-         path_mkdir(new_path);
-   }
-}
 #endif
 
 static void frontend_switch_get_environment_settings(
@@ -305,8 +276,9 @@ static void frontend_switch_get_environment_settings(
          g_defaults.dirs[DEFAULT_DIR_PORT],
          FILE_PATH_MAIN_CONFIG,
          sizeof(g_defaults.path_config));
+
 #ifndef IS_SALAMANDER
-   switch_dir_check_defaults();
+   dir_check_defaults("custom.ini");
 #endif
 }
 

--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -1327,41 +1327,6 @@ static void frontend_unix_get_lakka_version(char *s,
 }
 #endif
 
-#ifndef IS_SALAMANDER
-static void unix_dir_check_defaults(void)
-{
-   unsigned i;
-   char path[PATH_MAX_LENGTH];
-
-   /* early return for people with a custom folder setup
-      so it doesn't create unnecessary directories
-    */
-#if defined(ANDROID)
-   strcpy_literal(path, "host0:app/custom.ini");
-#else
-   strcpy_literal(path, "custom.ini");
-#endif
-   if (path_is_valid(path))
-      return;
-
-   for (i = 0; i < DEFAULT_DIR_LAST; i++)
-   {
-      char       new_path[PATH_MAX_LENGTH];
-      const char *dir_path = g_defaults.dirs[i];
-
-      if (string_is_empty(dir_path))
-         continue;
-
-      new_path[0] = '\0';
-      fill_pathname_expand_special(new_path,
-            dir_path, sizeof(new_path));
-
-      if (!path_is_directory(new_path))
-         path_mkdir(new_path);
-   }
-}
-#endif
-
 static void frontend_unix_get_env(int *argc,
       char *argv[], void *data, void *params_data)
 {
@@ -1889,7 +1854,11 @@ static void frontend_unix_get_env(int *argc,
 #endif
 
 #ifndef IS_SALAMANDER
-   unix_dir_check_defaults();
+#if defined(ANDROID)
+   dir_check_defaults("host0:app/custom.ini");
+#else
+   dir_check_defaults("custom.ini");
+#endif
 #endif
 }
 

--- a/frontend/drivers/platform_uwp.c
+++ b/frontend/drivers/platform_uwp.c
@@ -323,6 +323,37 @@ static int frontend_uwp_parse_drive_list(void *data, bool load_content)
    return 0;
 }
 
+#ifndef IS_SALAMANDER
+static void uwp_dir_check_defaults(void)
+{
+   unsigned i;
+   char path[PATH_MAX_LENGTH];
+
+   /* early return for people with a custom folder setup
+      so it doesn't create unnecessary directories
+    */
+   fill_pathname_expand_special(path, "~\\custom.ini", MAX_PATH);
+   if (path_is_valid(path))
+      return;
+
+   for (i = 0; i < DEFAULT_DIR_LAST; i++)
+   {
+      char       new_path[PATH_MAX_LENGTH];
+      const char *dir_path = g_defaults.dirs[i];
+
+      if (string_is_empty(dir_path))
+         continue;
+
+      new_path[0] = '\0';
+      fill_pathname_expand_special(new_path,
+            dir_path, sizeof(new_path));
+
+      if (!path_is_directory(new_path))
+         path_mkdir(new_path);
+   }
+}
+#endif
+
 static void frontend_uwp_environment_get(int *argc, char *argv[],
       void *args, void *params_data)
 {
@@ -389,6 +420,9 @@ static void frontend_uwp_environment_get(int *argc, char *argv[],
    if (string_is_equal(uwp_device_family, "Windows.Mobile"))
       strcpy_literal(g_defaults.settings_menu, "glui");
 #endif
+#endif
+#ifndef IS_SALAMANDER
+   uwp_dir_check_defaults();
 #endif
 }
 

--- a/frontend/drivers/platform_uwp.c
+++ b/frontend/drivers/platform_uwp.c
@@ -42,6 +42,7 @@
 #include "../../retroarch.h"
 #include "../../verbosity.h"
 #include "../../ui/drivers/ui_win32.h"
+#include "../../paths.h"
 
 #include "../../uwp/uwp_func.h"
 
@@ -323,37 +324,6 @@ static int frontend_uwp_parse_drive_list(void *data, bool load_content)
    return 0;
 }
 
-#ifndef IS_SALAMANDER
-static void uwp_dir_check_defaults(void)
-{
-   unsigned i;
-   char path[PATH_MAX_LENGTH];
-
-   /* early return for people with a custom folder setup
-      so it doesn't create unnecessary directories
-    */
-   fill_pathname_expand_special(path, "~\\custom.ini", MAX_PATH);
-   if (path_is_valid(path))
-      return;
-
-   for (i = 0; i < DEFAULT_DIR_LAST; i++)
-   {
-      char       new_path[PATH_MAX_LENGTH];
-      const char *dir_path = g_defaults.dirs[i];
-
-      if (string_is_empty(dir_path))
-         continue;
-
-      new_path[0] = '\0';
-      fill_pathname_expand_special(new_path,
-            dir_path, sizeof(new_path));
-
-      if (!path_is_directory(new_path))
-         path_mkdir(new_path);
-   }
-}
-#endif
-
 static void frontend_uwp_environment_get(int *argc, char *argv[],
       void *args, void *params_data)
 {
@@ -421,8 +391,14 @@ static void frontend_uwp_environment_get(int *argc, char *argv[],
       strcpy_literal(g_defaults.settings_menu, "glui");
 #endif
 #endif
+
 #ifndef IS_SALAMANDER
-   uwp_dir_check_defaults();
+   {
+      char custom_ini_path[PATH_MAX_LENGTH];
+      fill_pathname_expand_special(custom_ini_path,
+            "~\\custom.ini", sizeof(custom_ini_path));
+      dir_check_defaults(custom_ini_path);
+   }
 #endif
 }
 

--- a/frontend/drivers/platform_wiiu.c
+++ b/frontend/drivers/platform_wiiu.c
@@ -96,37 +96,6 @@ static void fix_asset_directory(void)
    rename(src_path_buf, dst_path_buf);
 }
 
-#ifndef IS_SALAMANDER
-static void wiiu_dir_check_defaults(void)
-{
-   unsigned i;
-   char path[PATH_MAX_LENGTH];
-
-   /* early return for people with a custom folder setup
-      so it doesn't create unnecessary directories
-    */
-   strcpy_literal(path, "custom.ini");
-   if (path_is_valid(path))
-      return;
-
-   for (i = 0; i < DEFAULT_DIR_LAST; i++)
-   {
-      char       new_path[PATH_MAX_LENGTH];
-      const char *dir_path = g_defaults.dirs[i];
-
-      if (string_is_empty(dir_path))
-         continue;
-
-      new_path[0] = '\0';
-      fill_pathname_expand_special(new_path,
-            dir_path, sizeof(new_path));
-
-      if (!path_is_directory(new_path))
-         path_mkdir(new_path);
-   }
-}
-#endif
-
 static void frontend_wiiu_get_environment_settings(int *argc, char *argv[],
       void *args, void *params_data)
 {
@@ -168,7 +137,7 @@ static void frontend_wiiu_get_environment_settings(int *argc, char *argv[],
          FILE_PATH_MAIN_CONFIG, sizeof(g_defaults.path_config));
 
 #ifndef IS_SALAMANDER
-   wiiu_dir_check_defaults();
+   dir_check_defaults("custom.ini");
 #endif
 }
 

--- a/frontend/drivers/platform_wiiu.c
+++ b/frontend/drivers/platform_wiiu.c
@@ -96,6 +96,37 @@ static void fix_asset_directory(void)
    rename(src_path_buf, dst_path_buf);
 }
 
+#ifndef IS_SALAMANDER
+static void wiiu_dir_check_defaults(void)
+{
+   unsigned i;
+   char path[PATH_MAX_LENGTH];
+
+   /* early return for people with a custom folder setup
+      so it doesn't create unnecessary directories
+    */
+   strcpy_literal(path, "custom.ini");
+   if (path_is_valid(path))
+      return;
+
+   for (i = 0; i < DEFAULT_DIR_LAST; i++)
+   {
+      char       new_path[PATH_MAX_LENGTH];
+      const char *dir_path = g_defaults.dirs[i];
+
+      if (string_is_empty(dir_path))
+         continue;
+
+      new_path[0] = '\0';
+      fill_pathname_expand_special(new_path,
+            dir_path, sizeof(new_path));
+
+      if (!path_is_directory(new_path))
+         path_mkdir(new_path);
+   }
+}
+#endif
+
 static void frontend_wiiu_get_environment_settings(int *argc, char *argv[],
       void *args, void *params_data)
 {
@@ -136,12 +167,9 @@ static void frontend_wiiu_get_environment_settings(int *argc, char *argv[],
    fill_pathname_join(g_defaults.path_config, g_defaults.dirs[DEFAULT_DIR_PORT],
          FILE_PATH_MAIN_CONFIG, sizeof(g_defaults.path_config));
 
-   for (i = 0; i < DEFAULT_DIR_LAST; i++)
-   {
-      const char *dir_path = g_defaults.dirs[i];
-      if (!string_is_empty(dir_path))
-         path_mkdir(dir_path);
-   }
+#ifndef IS_SALAMANDER
+   wiiu_dir_check_defaults();
+#endif
 }
 
 static void frontend_wiiu_deinit(void *data)

--- a/frontend/drivers/platform_win32.c
+++ b/frontend/drivers/platform_win32.c
@@ -565,6 +565,37 @@ static int frontend_win32_parse_drive_list(void *data, bool load_content)
    return 0;
 }
 
+#ifndef IS_SALAMANDER
+static void win32_dir_check_defaults(void)
+{
+   unsigned i;
+   char path[PATH_MAX_LENGTH];
+
+   /* early return for people with a custom folder setup
+      so it doesn't create unnecessary directories
+    */
+   strcpy_literal(path, "custom.ini");
+   if (path_is_valid(path))
+      return;
+
+   for (i = 0; i < DEFAULT_DIR_LAST; i++)
+   {
+      char       new_path[PATH_MAX_LENGTH];
+      const char *dir_path = g_defaults.dirs[i];
+
+      if (string_is_empty(dir_path))
+         continue;
+
+      new_path[0] = '\0';
+      fill_pathname_expand_special(new_path,
+            dir_path, sizeof(new_path));
+
+      if (!path_is_directory(new_path))
+         path_mkdir(new_path);
+   }
+}
+#endif
+
 static void frontend_win32_environment_get(int *argc, char *argv[],
       void *args, void *params_data)
 {
@@ -627,6 +658,10 @@ static void frontend_win32_environment_get(int *argc, char *argv[],
       ":\\system", sizeof(g_defaults.dirs[DEFAULT_DIR_SYSTEM]));
    fill_pathname_expand_special(g_defaults.dirs[DEFAULT_DIR_LOGS],
       ":\\logs", sizeof(g_defaults.dirs[DEFAULT_DIR_LOGS]));
+
+#ifndef IS_SALAMANDER
+   win32_dir_check_defaults();
+#endif
 }
 
 static uint64_t frontend_win32_get_total_mem(void)

--- a/frontend/drivers/platform_win32.c
+++ b/frontend/drivers/platform_win32.c
@@ -565,37 +565,6 @@ static int frontend_win32_parse_drive_list(void *data, bool load_content)
    return 0;
 }
 
-#ifndef IS_SALAMANDER
-static void win32_dir_check_defaults(void)
-{
-   unsigned i;
-   char path[PATH_MAX_LENGTH];
-
-   /* early return for people with a custom folder setup
-      so it doesn't create unnecessary directories
-    */
-   strcpy_literal(path, "custom.ini");
-   if (path_is_valid(path))
-      return;
-
-   for (i = 0; i < DEFAULT_DIR_LAST; i++)
-   {
-      char       new_path[PATH_MAX_LENGTH];
-      const char *dir_path = g_defaults.dirs[i];
-
-      if (string_is_empty(dir_path))
-         continue;
-
-      new_path[0] = '\0';
-      fill_pathname_expand_special(new_path,
-            dir_path, sizeof(new_path));
-
-      if (!path_is_directory(new_path))
-         path_mkdir(new_path);
-   }
-}
-#endif
-
 static void frontend_win32_environment_get(int *argc, char *argv[],
       void *args, void *params_data)
 {
@@ -660,7 +629,7 @@ static void frontend_win32_environment_get(int *argc, char *argv[],
       ":\\logs", sizeof(g_defaults.dirs[DEFAULT_DIR_LOGS]));
 
 #ifndef IS_SALAMANDER
-   win32_dir_check_defaults();
+   dir_check_defaults("custom.ini");
 #endif
 }
 

--- a/frontend/drivers/platform_xdk.c
+++ b/frontend/drivers/platform_xdk.c
@@ -50,6 +50,37 @@
 
 static enum frontend_fork xdk_fork_mode = FRONTEND_FORK_NONE;
 
+#ifndef IS_SALAMANDER
+static void xdk_dir_check_defaults(void)
+{
+   unsigned i;
+   char path[PATH_MAX_LENGTH];
+
+   /* early return for people with a custom folder setup
+      so it doesn't create unnecessary directories
+    */
+   strcpy_literal(path, "custom.ini");
+   if (path_is_valid(path))
+      return;
+
+   for (i = 0; i < DEFAULT_DIR_LAST; i++)
+   {
+      char       new_path[PATH_MAX_LENGTH];
+      const char *dir_path = g_defaults.dirs[i];
+
+      if (string_is_empty(dir_path))
+         continue;
+
+      new_path[0] = '\0';
+      fill_pathname_expand_special(new_path,
+            dir_path, sizeof(new_path));
+
+      if (!path_is_directory(new_path))
+         path_mkdir(new_path);
+   }
+}
+#endif
+
 static void frontend_xdk_get_environment_settings(int *argc, char *argv[],
       void *args, void *params_data)
 {
@@ -227,6 +258,7 @@ exit:
    else
       verbosity_disable();
 #endif
+   xdk_dir_check_defaults();
 #endif
 }
 

--- a/frontend/drivers/platform_xdk.c
+++ b/frontend/drivers/platform_xdk.c
@@ -50,37 +50,6 @@
 
 static enum frontend_fork xdk_fork_mode = FRONTEND_FORK_NONE;
 
-#ifndef IS_SALAMANDER
-static void xdk_dir_check_defaults(void)
-{
-   unsigned i;
-   char path[PATH_MAX_LENGTH];
-
-   /* early return for people with a custom folder setup
-      so it doesn't create unnecessary directories
-    */
-   strcpy_literal(path, "custom.ini");
-   if (path_is_valid(path))
-      return;
-
-   for (i = 0; i < DEFAULT_DIR_LAST; i++)
-   {
-      char       new_path[PATH_MAX_LENGTH];
-      const char *dir_path = g_defaults.dirs[i];
-
-      if (string_is_empty(dir_path))
-         continue;
-
-      new_path[0] = '\0';
-      fill_pathname_expand_special(new_path,
-            dir_path, sizeof(new_path));
-
-      if (!path_is_directory(new_path))
-         path_mkdir(new_path);
-   }
-}
-#endif
-
 static void frontend_xdk_get_environment_settings(int *argc, char *argv[],
       void *args, void *params_data)
 {
@@ -258,7 +227,8 @@ exit:
    else
       verbosity_disable();
 #endif
-   xdk_dir_check_defaults();
+
+   dir_check_defaults("custom.ini");
 #endif
 }
 

--- a/frontend/drivers/platform_xenon.c
+++ b/frontend/drivers/platform_xenon.c
@@ -33,6 +33,7 @@
 #include <boolean.h>
 
 #include "../../dynamic.h"
+#include "../../paths.h"
 
 static void frontend_xenon_init(void *data)
 {

--- a/frontend/frontend_salamander.c
+++ b/frontend/frontend_salamander.c
@@ -123,8 +123,10 @@ static void salamander_init(char *s, size_t len)
    const char *rarch_config_path = g_defaults.path_config;
    bool config_valid             = false;
    char config_path[PATH_MAX_LENGTH];
+   char config_dir[PATH_MAX_LENGTH];
 
    config_path[0] = '\0';
+   config_dir[0]  = '\0';
 
    /* Get salamander config file path */
    if (!string_is_empty(rarch_config_path))
@@ -134,6 +136,12 @@ static void salamander_init(char *s, size_t len)
             sizeof(config_path));
    else
       strcpy_literal(config_path, FILE_PATH_SALAMANDER_CONFIG);
+
+   /* Ensure that config directory exists */
+   fill_pathname_parent_dir(config_dir, config_path, sizeof(config_dir));
+   if (!string_is_empty(config_dir) &&
+       !path_is_directory(config_dir))
+      path_mkdir(config_dir);
 
    /* Attempt to open config file */
    config = config_file_new_from_path_to_string(config_path);

--- a/paths.h
+++ b/paths.h
@@ -65,8 +65,6 @@ char *dir_get_ptr(enum rarch_dir_type type);
 
 void dir_set(enum rarch_dir_type type, const char *path);
 
-void dir_check_defaults(void);
-
 void path_deinit_savefile(void);
 
 bool path_set(enum rarch_path_type type, const char *path);

--- a/paths.h
+++ b/paths.h
@@ -65,6 +65,8 @@ char *dir_get_ptr(enum rarch_dir_type type);
 
 void dir_set(enum rarch_dir_type type, const char *path);
 
+void dir_check_defaults(const char *custom_ini_path);
+
 void path_deinit_savefile(void);
 
 bool path_set(enum rarch_path_type type, const char *path);

--- a/retroarch.c
+++ b/retroarch.c
@@ -9424,6 +9424,33 @@ void dir_set(enum rarch_dir_type type, const char *path)
    }
 }
 
+void dir_check_defaults(const char *custom_ini_path)
+{
+   size_t i;
+
+   /* Early return for people with a custom folder setup
+    * so it doesn't create unnecessary directories */
+   if (!string_is_empty(custom_ini_path) &&
+       path_is_valid(custom_ini_path))
+      return;
+
+   for (i = 0; i < DEFAULT_DIR_LAST; i++)
+   {
+      const char *dir_path = g_defaults.dirs[i];
+      char new_path[PATH_MAX_LENGTH];
+
+      if (string_is_empty(dir_path))
+         continue;
+
+      new_path[0] = '\0';
+      fill_pathname_expand_special(new_path,
+            dir_path, sizeof(new_path));
+
+      if (!path_is_directory(new_path))
+         path_mkdir(new_path);
+   }
+}
+
 #ifdef HAVE_ACCESSIBILITY
 static bool is_accessibility_enabled(struct rarch_state *p_rarch)
 {

--- a/retroarch.c
+++ b/retroarch.c
@@ -9424,41 +9424,6 @@ void dir_set(enum rarch_dir_type type, const char *path)
    }
 }
 
-void dir_check_defaults(void)
-{
-   unsigned i;
-   char path[PATH_MAX_LENGTH];
-
-   /* early return for people with a custom folder setup
-      so it doesn't create unnecessary directories
-    */
-#if defined(ORBIS) || defined(ANDROID)
-   strcpy_literal(path, "host0:app/custom.ini");
-#elif defined(__WINRT__)
-   fill_pathname_expand_special(path, "~\\custom.ini", MAX_PATH);
-#else
-   strcpy_literal(path, "custom.ini");
-#endif
-   if (path_is_valid(path))
-      return;
-
-   for (i = 0; i < DEFAULT_DIR_LAST; i++)
-   {
-      char       new_path[PATH_MAX_LENGTH];
-      const char *dir_path = g_defaults.dirs[i];
-
-      if (string_is_empty(dir_path))
-         continue;
-
-      new_path[0] = '\0';
-      fill_pathname_expand_special(new_path,
-            dir_path, sizeof(new_path));
-
-      if (!path_is_directory(new_path))
-         path_mkdir(new_path);
-   }
-}
-
 #ifdef HAVE_ACCESSIBILITY
 static bool is_accessibility_enabled(struct rarch_state *p_rarch)
 {

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -648,8 +648,6 @@ static bool content_load(content_ctx_info_t *info,
    command_event(CMD_EVENT_RESUME, NULL);
    command_event(CMD_EVENT_VIDEO_SET_ASPECT_RATIO, NULL);
 
-   dir_check_defaults();
-
    frontend_driver_process_args(rarch_argc_ptr, rarch_argv_ptr);
    frontend_driver_content_loaded();
 


### PR DESCRIPTION
when calling the frontend environment get callback - we want to
look at the 'default' directories, and then if they don't yet exist,
auto-create them so we can store files in them.

@jdgleaver If you could review this, I'd be grateful. Similarly, if you know of any ways to improve upon this, that is very welcome as well.

The aim here is:
* We assume g_defaults.dirs is only changed once for the entire duration of the runtime, so it doesn't make sense for us to continue checking these default dirs and attempting to recreate them for every time we load content. Therefore, we save on a loop iteration, and we save on potential file I/O calls (even if it's only an fstat-esque call). The assumption is that by changing it like this, that we call upon this loop less often than before. Let me know if that is indeed the case. If not, we might have to rethink things a bit.
* Another plus is that we no longer need to have all these ifdefs. Each platform gets its own specific implementation inside the frontend driver.
* They are put behind #ifndef IS_SALAMANDER defines for now just to be safe. Let me know if that has unintentional consequences.