### PR TITLE
Fix Ps3 build.

### DIFF
--- a/frontend/drivers/platform_ps3.c
+++ b/frontend/drivers/platform_ps3.c
@@ -332,7 +332,7 @@ static void frontend_ps3_get_environment_settings(int *argc, char *argv[],
       verbosity_enable();
    else
       verbosity_disable();
-   ps3_dir_check_defaults();
+   dir_check_defaults("custom.ini");
 #endif
 }
 #endif


### PR DESCRIPTION
```
Unknown source file(1) : error: L0039: reference to undefined symbol `.ps3_dir_check_defaults' in file "C:\PSDK3v2\MinGW\msys\1.0\home\crystal\tmpwork\RetroArch\objs\snc\griffin\griffin.ppu.o"
make: *** [retroarch_ps3.elf] Error 1
```