### PR TITLE
Shader_Increase_Max_Textures_Line

### DIFF
--- a/gfx/video_shader_parse.h
+++ b/gfx/video_shader_parse.h
@@ -30,7 +30,7 @@ RETRO_BEGIN_DECLS
 #endif
 
 #ifndef GFX_MAX_TEXTURES
-#define GFX_MAX_TEXTURES 16
+#define GFX_MAX_TEXTURES 64
 #endif
 
 #ifndef GFX_MAX_VARIABLES


### PR DESCRIPTION
## Description

This PR increases the max number of textures which can be defined in the preset file to 64. Because I needed more textures when multiple textures can be used by each passes.

This does not change the max number of bindings per shader pass (SLANG_NUM_BINDINGS which can't be increased because we can't let it go past D3D11's hard limit of 16)

@twinaphex @jdgleaver @hizzlekizzle 