### PR TITLE
[WIP] add kor jpn chn font for rgui

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -2394,4 +2394,8 @@ ifeq ($(HAVE_ODROIDGO2), 1)
          $(DEPS_DIR)/libgo2/src/queue.o \
          gfx/drivers/oga_gfx.o
 endif
+
+ifeq ($(HAVE_CKJ_BITMAP_FONTS), 1)
+   DEFINES      += -DHAVE_CKJ_BITMAP_FONTS
+endif
 ##################################

--- a/gfx/drivers_font_renderer/bitmapchn10x10.h
+++ b/gfx/drivers_font_renderer/bitmapchn10x10.h
@@ -1,0 +1,27 @@
+/* 이 폰트는 PixelMPlus 입니다.
+ * 입수 경로:http://itouhiro.hatenablog.com/entry/20130602/font
+ * 생성일 : 2020.11.10
+ * These fonts are free software.
+ * Unlimited permission is granted to use, copy, and distribute them, with
+ * or without modification, either commercially or noncommercially.
+ * THESE FONTS ARE PROVIDED "AS IS" WITHOUT WARRANTY.
+ * http://mplus-fonts.sourceforge.jp/mplus-outline-fonts/
+ */
+
+#ifndef __RARCH_FONT_BITMAPCHN_H
+#define __RARCH_FONT_BITMAPCHN_H
+
+#define FONT_CHN_WIDTH 10
+#define FONT_CHN_HEIGHT 10
+/* FONT_HEIGHT_BASELINE_OFFSET:
+ * Distance in pixels from top of character
+ * to baseline */
+#define FONT_CHN_HEIGHT_BASELINE_OFFSET 8
+#define FONT_CHN_WIDTH_STRIDE (FONT_CHN_WIDTH + 1)
+#define FONT_CHN_HEIGHT_STRIDE (FONT_CHN_HEIGHT + 1)
+
+#define FONT_CHN_OFFSET(x) ((x) * ((FONT_CHN_HEIGHT * FONT_CHN_WIDTH+7) / 8))
+
+static unsigned char *rgui_bitmap_chn_bin = NULL;
+
+#endif

--- a/gfx/drivers_font_renderer/bitmapeng10x10.h
+++ b/gfx/drivers_font_renderer/bitmapeng10x10.h
@@ -1,0 +1,23 @@
+/*  
+ * 폰트명 : 갈무리(galmuri)
+ * 입수 경로 : https://tbh.kr/galmuri
+ * 갈무리는 SIL 오픈 폰트 라이선스 1.1에 따라 이용할 수 있으며 그 자체로 판매되지 않는 한 자유롭게 사용, 연구, 수정, 재배포할 수 있습니다.
+ */
+
+#ifndef __RARCH_FONT_BITMAPENG10X10_H
+#define __RARCH_FONT_BITMAPENG10X10_H
+
+#define FONT_ENG_WIDTH 10
+#define FONT_ENG_HEIGHT 10
+/* FONT_HEIGHT_BASELINE_OFFSET:
+ * Distance in pixels from top of character
+ * to baseline */
+#define FONT_ENG_HEIGHT_BASELINE_OFFSET 8
+#define FONT_ENG_WIDTH_STRIDE (FONT_ENG_WIDTH + 1)
+#define FONT_ENG_HEIGHT_STRIDE (FONT_ENG_HEIGHT + 1)
+
+#define FONT_ENG_OFFSET(x) ((x) * ((FONT_ENG_HEIGHT * FONT_ENG_WIDTH + 7) / 8))
+
+static unsigned char *rgui_bitmap_eng_bin = NULL;
+
+#endif

--- a/gfx/drivers_font_renderer/bitmapjpn10x10.h
+++ b/gfx/drivers_font_renderer/bitmapjpn10x10.h
@@ -1,0 +1,27 @@
+/* 이 폰트는 PixelMPlus 입니다.
+ * 입수 경로:http://itouhiro.hatenablog.com/entry/20130602/font
+ * 생성일 : 2020.11.10
+ * These fonts are free software.
+ * Unlimited permission is granted to use, copy, and distribute them, with
+ * or without modification, either commercially or noncommercially.
+ * THESE FONTS ARE PROVIDED "AS IS" WITHOUT WARRANTY.
+ * http://mplus-fonts.sourceforge.jp/mplus-outline-fonts/
+ */
+
+#ifndef __RARCH_FONT_BITMAPJPN_H
+#define __RARCH_FONT_BITMAPJPN_H
+
+#define FONT_JPN_WIDTH 10
+#define FONT_JPN_HEIGHT 10
+/* FONT_HEIGHT_BASELINE_OFFSET:
+ * Distance in pixels from top of character
+ * to baseline */
+#define FONT_JPN_HEIGHT_BASELINE_OFFSET 8
+#define FONT_JPN_WIDTH_STRIDE (FONT_JPN_WIDTH + 1)
+#define FONT_JPN_HEIGHT_STRIDE (FONT_JPN_HEIGHT + 1)
+
+#define FONT_JPN_OFFSET(x) ((x) * ((FONT_JPN_HEIGHT * FONT_JPN_WIDTH + 7) / 8))
+
+static unsigned char *rgui_bitmap_jpn_bin = NULL;
+
+#endif

--- a/gfx/drivers_font_renderer/bitmapkor10x10.h
+++ b/gfx/drivers_font_renderer/bitmapkor10x10.h
@@ -1,0 +1,23 @@
+/*  
+ * 폰트명 : 갈무리(galmuri)
+ * 입수 경로 : https://tbh.kr/galmuri
+ * 갈무리는 SIL 오픈 폰트 라이선스 1.1에 따라 이용할 수 있으며 그 자체로 판매되지 않는 한 자유롭게 사용, 연구, 수정, 재배포할 수 있습니다.
+ */
+
+#ifndef __RARCH_FONT_BITMAPKOR10X10_H
+#define __RARCH_FONT_BITMAPKOR10X10_H
+
+#define FONT_KOR_WIDTH 10
+#define FONT_KOR_HEIGHT 10
+/* FONT_HEIGHT_BASELINE_OFFSET:
+ * Distance in pixels from top of character
+ * to baseline */
+#define FONT_KOR_HEIGHT_BASELINE_OFFSET 8
+#define FONT_KOR_WIDTH_STRIDE (FONT_KOR_WIDTH + 1)
+#define FONT_KOR_HEIGHT_STRIDE (FONT_KOR_HEIGHT + 1)
+
+#define FONT_KOR_OFFSET(x) ((x) * ((FONT_KOR_HEIGHT * FONT_KOR_WIDTH + 7) / 8))
+
+static unsigned char *rgui_bitmap_kor_bin = NULL;
+
+#endif

--- a/gfx/gfx_animation.c
+++ b/gfx/gfx_animation.c
@@ -42,6 +42,92 @@
 
 /* from https://github.com/kikito/tween.lua/blob/master/tween.lua */
 
+#ifdef HAVE_CKJ_BITMAP_FONTS
+size_t utf8cpy4ML(char *d, size_t d_len, const char *s, size_t maxchars)
+{
+   const char *sb     = (const char*)s;
+   const char *sb_org = sb;
+   size_t chars=0;
+
+   if (!s)
+      return 0;
+
+   while (*sb && chars < maxchars)
+   {
+      uint32_t symbol = utf8_walk(&sb);
+      if ((symbol >= 0xac00 && symbol <= 0xd7a3) || /* for kor */
+          (symbol >= 0x3040 && symbol <= 0x30ff) || /* for jpn */
+          (symbol >= 0x4e00 && symbol <= 0x9fff))   /* for cjk */
+      {
+         if ((maxchars - chars) > 1)
+            chars+=2;
+         else
+            break;
+      }
+      else
+         chars++;
+   }
+
+   memcpy(d, sb_org, sb-sb_org);
+   d[sb-sb_org] = '\0';
+
+   return sb-sb_org;
+}
+
+uint16_t getstrlen(const char *s, uint16_t maxwidth)
+{
+   uint16_t chars=0;
+   uint16_t strwidth=0;
+
+   if (!s)
+      return 0;
+
+   while (*s && strwidth < maxwidth)
+   {
+      uint32_t symbol = utf8_walk(&s);
+      if ((symbol >= 0xac00 && symbol <= 0xd7a3) || /* for kor */
+          (symbol >= 0x3040 && symbol <= 0x30ff) || /* for jpn */
+          (symbol >= 0x4e00 && symbol <= 0x9fff))   /* for cjk */
+      {
+         chars+=2;
+         strwidth+=11;
+      }
+      else
+      {
+         chars++;
+         strwidth+=6;
+      }
+   }
+
+   return chars;
+}
+
+uint16_t getstrwidth(const char *s)
+{
+   uint16_t strwidth=0;
+
+   if (!s)
+      return 0;
+
+   while (*s)
+   {
+      uint32_t symbol = utf8_walk(&s);
+      if ((symbol >= 0xac00 && symbol <= 0xd7a3) || /* for kor */
+          (symbol >= 0x3040 && symbol <= 0x30ff) || /* for jpn */
+          (symbol >= 0x4e00 && symbol <= 0x9fff))   /* for cjk */
+      {
+         strwidth+=11;
+      }
+      else
+      {
+         strwidth+=6;
+      }
+   }
+
+   return strwidth;
+}
+#endif
+
 static float easing_linear(float t, float b, float c, float d)
 {
    return c * t / d + b;
@@ -1325,6 +1411,33 @@ static void build_ticker_loop_string(
    tmp[0]      = '\0';
    dest_str[0] = '\0';
 
+#ifdef HAVE_CKJ_BITMAP_FONTS
+   /* Copy 'trailing' chunk of source string, if required */
+   if (num_chars1 > 0)
+      utf8cpy4ML(
+            dest_str, dest_str_len,
+            utf8skip(src_str, char_offset1), num_chars1);
+
+   /* Copy chunk of spacer string, if required */
+   if (num_chars2 > 0)
+   {
+      utf8cpy4ML(
+            tmp, sizeof(tmp),
+            utf8skip(spacer, char_offset2), num_chars2);
+
+      strlcat(dest_str, tmp, dest_str_len);
+   }
+
+   /* Copy 'leading' chunk of source string, if required */
+   if (num_chars3 > 0)
+   {
+      utf8cpy4ML(
+            tmp, sizeof(tmp),
+            utf8skip(src_str, char_offset3), num_chars3);
+
+      strlcat(dest_str, tmp, dest_str_len);
+   }
+#else
    /* Copy 'trailing' chunk of source string, if required */
    if (num_chars1 > 0)
       utf8cpy(
@@ -1350,6 +1463,7 @@ static void build_ticker_loop_string(
 
       strlcat(dest_str, tmp, dest_str_len);
    }
+#endif
 }
 
 static void build_line_ticker_string(
@@ -1383,7 +1497,24 @@ bool gfx_animation_ticker(gfx_animation_ctx_ticker_t *ticker)
 
    if (!ticker->spacer)
       ticker->spacer       = TICKER_SPACER_DEFAULT;
+#ifdef HAVE_CKJ_BITMAP_FONTS
+   if ((size_t)str_len <= ticker->len)
+   {
+      utf8cpy4ML(ticker->s,
+            PATH_MAX_LENGTH,
+            ticker->str,
+            ticker->len);
+      return false;
+   }
 
+   if (!ticker->selected)
+   {
+      utf8cpy4ML(ticker->s,
+            PATH_MAX_LENGTH, ticker->str, ticker->len - 3);
+      strlcat(ticker->s, "...", ticker->len);
+      return false;
+   }
+#else
    if ((size_t)str_len <= ticker->len)
    {
       utf8cpy(ticker->s,
@@ -1400,7 +1531,7 @@ bool gfx_animation_ticker(gfx_animation_ctx_ticker_t *ticker)
       strlcat(ticker->s, "...", ticker->len);
       return false;
    }
-
+#endif
    /* Note: If we reach this point then str_len > ticker->len
     * (previously had an unecessary 'if (str_len > ticker->len)'
     * check here...) */
@@ -1434,12 +1565,19 @@ bool gfx_animation_ticker(gfx_animation_ctx_ticker_t *ticker)
                   ticker->idx,
                   ticker->len,
                   &str_len);
-
+#ifdef HAVE_CKJ_BITMAP_FONTS
+            utf8cpy4ML(
+                  ticker->s,
+                  PATH_MAX_LENGTH,
+                  utf8skip(ticker->str, offset),
+                  str_len);
+#else
             utf8cpy(
                   ticker->s,
                   PATH_MAX_LENGTH,
                   utf8skip(ticker->str, offset),
                   str_len);
+#endif
          }
          break;
    }
@@ -1470,14 +1608,24 @@ static bool gfx_animation_ticker_smooth_fw(
    if (src_str_len < 1)
       goto end;
 
+#ifdef HAVE_CKJ_BITMAP_FONTS   
+   src_str_width = getstrwidth(ticker->src_str);
+   /* field_width = 240 */
+#else
    src_str_width = src_str_len * glyph_width;
+#endif   
 
    /* If src string width is <= text field width, we
     * can just copy the entire string */
    if (src_str_width <= ticker->field_width)
    {
+#ifdef HAVE_CKJ_BITMAP_FONTS 
+      utf8cpy4ML(ticker->dst_str, ticker->dst_str_len,
+            ticker->src_str, src_str_len);
+#else
       utf8cpy(ticker->dst_str, ticker->dst_str_len,
             ticker->src_str, src_str_len);
+#endif
       if (ticker->dst_str_width)
          *ticker->dst_str_width = src_str_width;
       *ticker->x_offset = 0;
@@ -1498,10 +1646,18 @@ static bool gfx_animation_ticker_smooth_fw(
          goto end;
 
       /* Determine number of characters to copy */
+#ifdef HAVE_CKJ_BITMAP_FONTS
+      num_chars = getstrlen(ticker->src_str, ticker->field_width) - 3;
+
+      /* Copy string segment + add suffix */
+      utf8cpy4ML(ticker->dst_str, ticker->dst_str_len, ticker->src_str, num_chars); 
+#else
       num_chars = (ticker->field_width - suffix_width) / glyph_width;
 
       /* Copy string segment + add suffix */
       utf8cpy(ticker->dst_str, ticker->dst_str_len, ticker->src_str, num_chars);
+#endif
+
       strlcat(ticker->dst_str, "...", ticker->dst_str_len);
 
       if (ticker->dst_str_width)
@@ -1573,10 +1729,15 @@ static bool gfx_animation_ticker_smooth_fw(
 
          /* Copy required substring */
          if (num_chars > 0)
+#ifdef HAVE_CKJ_BITMAP_FONTS         
+            utf8cpy4ML(
+                  ticker->dst_str, ticker->dst_str_len,
+                  utf8skip(ticker->src_str, char_offset), num_chars);
+#else
             utf8cpy(
                   ticker->dst_str, ticker->dst_str_len,
                   utf8skip(ticker->src_str, char_offset), num_chars);
-
+#endif
          if (ticker->dst_str_width)
             *ticker->dst_str_width = num_chars * glyph_width;
 
@@ -1662,9 +1823,13 @@ bool gfx_animation_ticker_smooth(gfx_animation_ctx_ticker_smooth_t *ticker)
     * can just copy the entire string */
    if (src_str_width <= ticker->field_width)
    {
+#ifdef HAVE_CKJ_BITMAP_FONTS
+      utf8cpy4ML(ticker->dst_str, ticker->dst_str_len,
+            ticker->src_str, src_str_len);
+#else
       utf8cpy(ticker->dst_str, ticker->dst_str_len,
             ticker->src_str, src_str_len);
-
+#endif
       if (ticker->dst_str_width)
          *ticker->dst_str_width = src_str_width;
       *ticker->x_offset = 0;
@@ -1709,8 +1874,13 @@ bool gfx_animation_ticker_smooth(gfx_animation_ctx_ticker_smooth_t *ticker)
       }
 
       /* Copy string segment + add suffix */
+#ifdef HAVE_CKJ_BITMAP_FONTS
+      utf8cpy4ML(ticker->dst_str, ticker->dst_str_len,
+            ticker->src_str, num_chars);
+#else
       utf8cpy(ticker->dst_str, ticker->dst_str_len,
             ticker->src_str, num_chars);
+#endif
       strlcat(ticker->dst_str, "...", ticker->dst_str_len);
 
       if (ticker->dst_str_width)
@@ -1800,10 +1970,16 @@ bool gfx_animation_ticker_smooth(gfx_animation_ctx_ticker_smooth_t *ticker)
 
          /* Copy required substring */
          if (num_chars > 0)
+#ifdef HAVE_CKJ_BITMAP_FONTS         
+            utf8cpy4ML(
+                  ticker->dst_str, ticker->dst_str_len,
+                  utf8skip(ticker->src_str, char_offset), num_chars);
+#else
             utf8cpy(
                   ticker->dst_str, ticker->dst_str_len,
                   utf8skip(ticker->src_str, char_offset), num_chars);
 
+#endif
          break;
       }
    }

--- a/libretro-common/encodings/encoding_utf.c
+++ b/libretro-common/encodings/encoding_utf.c
@@ -212,23 +212,10 @@ size_t utf8len(const char *string)
       return 0;
 
    while (*string)
-   {
-#ifdef HAVE_CKJ_BITMAP_FONTS
-      uint32_t symbol = utf8_walk(&string);
-
-      if (symbol >= 0xac00 && symbol <= 0xd7a3) /* kor */
-         ret+=2;
-      else if (symbol >= 0x3040 && symbol <= 0x30ff) /* jpn */
-         ret+=2;
-      else if (symbol >= 0x4e00 && symbol <= 0x9fff) /* chn */
-         ret+=2;
-      else
-         ret++;
-#else         
+   {        
       if ((*string & 0xC0) != 0x80)
          ret++;
       string++;         
-#endif
    }
    return ret;
 }

--- a/libretro-common/encodings/encoding_utf.c
+++ b/libretro-common/encodings/encoding_utf.c
@@ -213,9 +213,22 @@ size_t utf8len(const char *string)
 
    while (*string)
    {
+#ifdef HAVE_CKJ_BITMAP_FONTS
+      uint32_t symbol = utf8_walk(&string);
+
+      if (symbol >= 0xac00 && symbol <= 0xd7a3) /* kor */
+         ret+=2;
+      else if (symbol >= 0x3040 && symbol <= 0x30ff) /* jpn */
+         ret+=2;
+      else if (symbol >= 0x4e00 && symbol <= 0x9fff) /* chn */
+         ret+=2;
+      else
+         ret++;
+#else         
       if ((*string & 0xC0) != 0x80)
          ret++;
-      string++;
+      string++;         
+#endif
    }
    return ret;
 }

--- a/qb/config.params.sh
+++ b/qb/config.params.sh
@@ -193,3 +193,4 @@ HAVE_ODROIDGO2=no          # ODROID-GO Advance rotation support (requires librga
 HAVE_LIBSHAKE=no           # libShake haptic feedback support
 HAVE_GIT_VERSION=yes       # Git version support
 HAVE_CKJ_BITMAP_FONTS=yes  # CKJ bitmap font support
+

--- a/qb/config.params.sh
+++ b/qb/config.params.sh
@@ -192,3 +192,4 @@ HAVE_STEAM=no              # Enable Steam build
 HAVE_ODROIDGO2=no          # ODROID-GO Advance rotation support (requires librga)
 HAVE_LIBSHAKE=no           # libShake haptic feedback support
 HAVE_GIT_VERSION=yes       # Git version support
+HAVE_CKJ_BITMAP_FONTS=yes  # CKJ bitmap font support


### PR DESCRIPTION

## Description

created Korean, Japanese, and Chinese fonts for rgui drivers.The font size is 10 pixels * 10 pixels.
tested in rpi3,4 and oga.Corrected static analysis errors as well.
Previous PR is as follows
- https://github.com/libretro/RetroArch/pull/11589

Added definition HAVE_CKJ_BITMAP_FONTS
Transferring code implemented in blit_line_regular() to blit_line_extended()
Font bin files must exist in the path below
~/.config/retroarch/assets/rgui/font/
rgui_font_kor10x10.bin
rgui_font_jpn10x10.bin
rgui_font_chn10x10.bin

## Related Pull Requests

libretro/retroarch-assets#389

## Reviewers

@jdgleaver 
