### PR TITLE
Prevent 'Rewind Frames' from being set to '1' incorrectly on load content

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -20117,6 +20117,8 @@ static bool bsv_movie_init(struct rarch_state *p_rarch)
             2, 180, false,
             NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
       RARCH_LOG("%s.\n", msg_hash_to_str(MSG_STARTING_MOVIE_PLAYBACK));
+
+      return true;
    }
    else if (p_rarch->bsv_movie_state.movie_start_recording)
    {
@@ -20145,9 +20147,11 @@ static bool bsv_movie_init(struct rarch_state *p_rarch)
       RARCH_LOG("%s \"%s\".\n",
             msg_hash_to_str(MSG_STARTING_MOVIE_RECORD_TO),
             p_rarch->bsv_movie_state.movie_start_path);
+
+      return true;
    }
 
-   return true;
+   return false;
 }
 
 static void bsv_movie_deinit(struct rarch_state *p_rarch)


### PR DESCRIPTION
## Description

At present, the rewind granularity setting is always reset to `1` when loading content. This is a bug - it should only happen when content is loaded while BSV movie recording/playback is enabled, but the `bsv_movie_init()` function (called on content load) always returns `true`, so the frontend incorrectly assumes BSV recording/playback is active in all cases.

This trivial PR fixes the `bsv_movie_init()` function such that it returns the correct value - thus rewind granularity is no longer reset unnecessarily.