### PR TITLE
Make get_lakka_version available in all builds

### DIFF
--- a/frontend/drivers/platform_ctr.c
+++ b/frontend/drivers/platform_ctr.c
@@ -670,6 +670,7 @@ frontend_ctx_driver_t frontend_ctx_ctr =
    NULL,                         /* destroy_signal_handler_state */
    NULL,                         /* attach_console */
    NULL,                         /* detach_console */
+   NULL,                         /* get_lakka_version */
    NULL,                         /* watch_path_for_changes */
    NULL,                         /* check_for_path_changes */
    NULL,                         /* set_sustained_performance_mode */

--- a/frontend/drivers/platform_darwin.m
+++ b/frontend/drivers/platform_darwin.m
@@ -972,6 +972,7 @@ frontend_ctx_driver_t frontend_ctx_darwin = {
    NULL,                         /* destroy_signal_handler_state */
    NULL,                         /* attach_console */
    NULL,                         /* detach_console */
+   NULL,                         /* get_lakka_version */
    NULL,                         /* watch_path_for_changes */
    NULL,                         /* check_for_path_changes */
    NULL,                         /* set_sustained_performance_mode */

--- a/frontend/drivers/platform_dos.c
+++ b/frontend/drivers/platform_dos.c
@@ -201,6 +201,7 @@ frontend_ctx_driver_t frontend_ctx_dos = {
 	NULL,                         /* destroy_sighandler_state */
 	NULL,                         /* attach_console */
 	NULL,                         /* detach_console */
+	NULL,                         /* get_lakka_version */
 	NULL,                         /* watch_path_for_changes */
 	NULL,                         /* check_for_path_changes */
 	NULL,                         /* set_sustained_performance_mode */

--- a/frontend/drivers/platform_emscripten.c
+++ b/frontend/drivers/platform_emscripten.c
@@ -193,6 +193,7 @@ frontend_ctx_driver_t frontend_ctx_emscripten = {
    NULL,                         /* destroy_signal_handler_state */
    NULL,                         /* attach_console */
    NULL,                         /* detach_console */
+   NULL,                         /* get_lakka_version */
    NULL,                         /* watch_path_for_changes */
    NULL,                         /* check_for_path_changes */
    NULL,                         /* set_sustained_performance_mode */

--- a/frontend/drivers/platform_gx.c
+++ b/frontend/drivers/platform_gx.c
@@ -563,6 +563,7 @@ frontend_ctx_driver_t frontend_ctx_gx = {
    NULL,                            /* destroy_signal_handler_state */
    NULL,                            /* attach_console */
    NULL,                            /* detach_console */
+   NULL,                            /* get_lakka_version */
    NULL,                            /* watch_path_for_changes */
    NULL,                            /* check_for_path_changes */
    NULL,                            /* set_sustained_performance_mode */

--- a/frontend/drivers/platform_orbis.c
+++ b/frontend/drivers/platform_orbis.c
@@ -364,6 +364,7 @@ frontend_ctx_driver_t frontend_ctx_orbis = {
    NULL,                         /* destroy_sighandler_state */
    NULL,                         /* attach_console */
    NULL,                         /* detach_console */
+   NULL,                         /* get_lakka_version */
    NULL,                         /* watch_path_for_changes */
    NULL,                         /* check_for_path_changes */
    NULL,                         /* set_sustained_performance_mode */

--- a/frontend/drivers/platform_ps2.c
+++ b/frontend/drivers/platform_ps2.c
@@ -382,9 +382,7 @@ frontend_ctx_driver_t frontend_ctx_ps2 = {
    NULL,                         /* destroy_sighandler_state */
    NULL,                         /* attach_console */
    NULL,                         /* detach_console */
-#ifdef HAVE_LAKKA
    NULL,                         /* get_lakka_version */
-#endif
    NULL,                         /* watch_path_for_changes */
    NULL,                         /* check_for_path_changes */
    NULL,                         /* set_sustained_performance_mode */

--- a/frontend/drivers/platform_ps3.c
+++ b/frontend/drivers/platform_ps3.c
@@ -706,6 +706,7 @@ frontend_ctx_driver_t frontend_ctx_ps3 = {
    NULL,                         /* destroy_sighandler_state */
    NULL,                         /* attach_console */
    NULL,                         /* detach_console */
+   NULL,                         /* get_lakka_version */
    NULL,                         /* watch_path_for_changes */
    NULL,                         /* check_for_path_changes */
    NULL,                         /* set_sustained_performance_mode */

--- a/frontend/drivers/platform_psp.c
+++ b/frontend/drivers/platform_psp.c
@@ -640,6 +640,7 @@ frontend_ctx_driver_t frontend_ctx_psp = {
    NULL,                         /* destroy_sighandler_state */
    NULL,                         /* attach_console */
    NULL,                         /* detach_console */
+   NULL,                         /* get_lakka_version */
    NULL,                         /* watch_path_for_changes */
    NULL,                         /* check_for_path_changes */
    NULL,                         /* set_sustained_performance_mode */

--- a/frontend/drivers/platform_qnx.c
+++ b/frontend/drivers/platform_qnx.c
@@ -200,6 +200,7 @@ frontend_ctx_driver_t frontend_ctx_qnx = {
    NULL,                         /* destroy_sighandler_state */
    NULL,                         /* attach_console */
    NULL,                         /* detach_console */
+   NULL,                         /* get_lakka_version */
    NULL,                         /* watch_path_for_changes */
    NULL,                         /* check_for_path_changes */
    NULL,                         /* set_sustained_performance_mode */

--- a/frontend/drivers/platform_switch.c
+++ b/frontend/drivers/platform_switch.c
@@ -927,6 +927,7 @@ frontend_ctx_driver_t frontend_ctx_switch =
         NULL, /* destroy_signal_handler_state */
         NULL, /* attach_console */
         NULL, /* detach_console */
+        NULL, /* get_lakka_version */
         NULL, /* watch_path_for_changes */
         NULL, /* check_for_path_changes */
         NULL, /* set_sustained_performance_mode */

--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -2716,6 +2716,8 @@ frontend_ctx_driver_t frontend_ctx_unix = {
    NULL,                         /* detach_console */
 #ifdef HAVE_LAKKA
    frontend_unix_get_lakka_version,    /* get_lakka_version */
+#else
+   NULL,                         /* get_lakka_version */
 #endif
    frontend_unix_watch_path_for_changes,
    frontend_unix_check_for_path_changes,

--- a/frontend/drivers/platform_uwp.c
+++ b/frontend/drivers/platform_uwp.c
@@ -470,6 +470,7 @@ frontend_ctx_driver_t frontend_ctx_uwp = {
    NULL,                            /* destroy_sighandler_state */
    NULL,                            /* attach_console */
    NULL,                            /* detach_console */
+   NULL,                            /* get_lakka_version */
    NULL,                            /* watch_path_for_changes */
    NULL,                            /* check_for_path_changes */
    NULL,                            /* set_sustained_performance_mode */

--- a/frontend/drivers/platform_wiiu.c
+++ b/frontend/drivers/platform_wiiu.c
@@ -325,6 +325,7 @@ frontend_ctx_driver_t frontend_ctx_wiiu =
    NULL,                         /* destroy_signal_handler_state */
    NULL,                         /* attach_console */
    NULL,                         /* detach_console */
+   NULL,                         /* get_lakka_version */
    NULL,                         /* watch_path_for_changes */
    NULL,                         /* check_for_path_changes */
    NULL,                         /* set_sustained_performance_mode */

--- a/frontend/drivers/platform_win32.c
+++ b/frontend/drivers/platform_win32.c
@@ -1145,6 +1145,7 @@ frontend_ctx_driver_t frontend_ctx_win32 = {
    NULL,                            /* destroy_sighandler_state */
    frontend_win32_attach_console,   /* attach_console */
    frontend_win32_detach_console,   /* detach_console */
+   NULL,                            /* get_lakka_version */
    NULL,                            /* watch_path_for_changes */
    NULL,                            /* check_for_path_changes */
    NULL,                            /* set_sustained_performance_mode */

--- a/frontend/drivers/platform_xdk.c
+++ b/frontend/drivers/platform_xdk.c
@@ -436,6 +436,7 @@ frontend_ctx_driver_t frontend_ctx_xdk = {
    NULL,                         /* destroy_sighandler_state */
    NULL,                         /* attach_console */
    NULL,                         /* detach_console */
+   NULL,                         /* get_lakka_version */
    NULL,                         /* watch_path_for_changes */
    NULL,                         /* check_for_path_changes */
    NULL,                         /* set_sustained_performance_mode */

--- a/frontend/drivers/platform_xenon.c
+++ b/frontend/drivers/platform_xenon.c
@@ -92,6 +92,7 @@ frontend_ctx_driver_t frontend_ctx_qnx = {
    NULL,                         /* destroy_sighandler_state */
    NULL,                         /* attach_console */
    NULL,                         /* detach_console */
+   NULL,                         /* get_lakka_version */
    NULL,                         /* watch_path_for_changes */
    NULL,                         /* check_for_path_changes */
    NULL,                         /* set_sustained_performance_mode */

--- a/frontend/frontend_driver.c
+++ b/frontend/frontend_driver.c
@@ -62,9 +62,7 @@ static frontend_ctx_driver_t frontend_ctx_null = {
    NULL,                         /* destroy_sighandler_state */
    NULL,                         /* attach_console */
    NULL,                         /* detach_console */
-#ifdef HAVE_LAKKA
    NULL,                         /* get_lakka_version */
-#endif
    NULL,                         /* watch_path_for_changes */
    NULL,                         /* check_for_path_changes */
    NULL,                         /* set_sustained_performance_mode */

--- a/frontend/frontend_driver.h
+++ b/frontend/frontend_driver.h
@@ -102,9 +102,7 @@ typedef struct frontend_ctx_driver
    void (*destroy_signal_handler_state)(void);
    void (*attach_console)(void);
    void (*detach_console)(void);
-#ifdef HAVE_LAKKA
    void (*get_lakka_version)(char *, size_t);
-#endif
    void (*watch_path_for_changes)(struct string_list *list, int flags, path_change_data_t **change_data);
    bool (*check_for_path_changes)(path_change_data_t *change_data);
    void (*set_sustained_performance_mode)(bool on);

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -1094,7 +1094,6 @@ static unsigned menu_displaylist_parse_system_info(file_list_t *list)
             MENU_SETTINGS_CORE_INFO_NONE, 0, 0))
          count++;
 
-#ifdef HAVE_LAKKA
       if (frontend->get_lakka_version)
       {
          frontend->get_lakka_version(tmp2, sizeof(tmp2));
@@ -1109,7 +1108,6 @@ static unsigned menu_displaylist_parse_system_info(file_list_t *list)
                MENU_SETTINGS_CORE_INFO_NONE, 0, 0))
             count++;
       }
-#endif
 
       if (frontend->get_name)
       {


### PR DESCRIPTION
This simplifies a bit the code, for some new lakka patches to come.
