### PR TITLE
(cheevos) calculate leaderboard widget spacing based on video resolution

### DIFF
--- a/gfx/widgets/gfx_widget_leaderboard_display.c
+++ b/gfx/widgets/gfx_widget_leaderboard_display.c
@@ -28,7 +28,6 @@
 
 #define CHEEVO_LBOARD_ARRAY_SIZE 4
 
-#define CHEEVO_LBOARD_DISPLAY_SPACING 6
 #define CHEEVO_LBOARD_DISPLAY_PADDING 3
 
 struct leaderboard_display_info
@@ -96,7 +95,8 @@ static void gfx_widget_leaderboard_display_frame(void* data, void* userdata)
       const video_frame_info_t* video_info = (const video_frame_info_t*)data;
       const unsigned video_width = video_info->width;
       const unsigned video_height = video_info->height;
-      const unsigned widget_height = p_dispwidget->gfx_widget_fonts.regular.line_height + CHEEVO_LBOARD_DISPLAY_PADDING * 2;
+      const unsigned spacing = MIN(video_width, video_height) / 64;
+      const unsigned widget_height = p_dispwidget->gfx_widget_fonts.regular.line_height + (CHEEVO_LBOARD_DISPLAY_PADDING - 1) * 2;
       unsigned y = video_height;
       unsigned x;
       int i;
@@ -107,8 +107,8 @@ static void gfx_widget_leaderboard_display_frame(void* data, void* userdata)
       for (i = 0; i < state->count; ++i)
       {
          const unsigned widget_width = state->info[i].width;
-         x = video_width - widget_width - CHEEVO_LBOARD_DISPLAY_SPACING;
-         y -= (widget_height + CHEEVO_LBOARD_DISPLAY_SPACING);
+         x = video_width - widget_width - spacing;
+         y -= (widget_height + spacing);
 
          /* Backdrop */
          gfx_display_draw_quad(video_info->userdata,
@@ -121,7 +121,7 @@ static void gfx_widget_leaderboard_display_frame(void* data, void* userdata)
          gfx_widgets_draw_text(&p_dispwidget->gfx_widget_fonts.regular,
             state->info[i].display,
             (float)(x + CHEEVO_LBOARD_DISPLAY_PADDING),
-            (float)(y + p_dispwidget->gfx_widget_fonts.regular.line_height),
+            (float)(y + widget_height - (CHEEVO_LBOARD_DISPLAY_PADDING - 1) - p_dispwidget->gfx_widget_fonts.regular.line_descender),
             video_width, video_height,
             TEXT_COLOR_INFO,
             TEXT_ALIGN_LEFT,


### PR DESCRIPTION
## Description

The leaderboard widget added in #11373 had a hard-coded margin of 6 pixels, which is fine at the default windowed resolution and acceptable at 1080p fullscreen, but when displayed on a 4K device, 6 pixels is barely noticeable. Additionally, many phones run at very high resolutions, so the 6 pixel margin is also insufficient there - particularly if the corners of the screen are rounded.

This changes the hard-coded 6 pixels to be calculated as roughly 1.5% of the smaller of the screen's width or height, so for a 4K display, the margin would be ~20 pixels. At 1080p it would be ~15 pixels, and at 640x480 it would be ~7 pixels.

## Related Issues

A user mentioned the leaderboard widget was being partially obscured by their phone's bezel.

## Related Pull Requests

n/a

## Reviewers

@Sanaki @meleu
