### PR TITLE
Improved code quality of retro_assert macro

### DIFF
--- a/libretro-common/include/retro_assert.h
+++ b/libretro-common/include/retro_assert.h
@@ -27,9 +27,7 @@
 
 #ifdef RARCH_INTERNAL
 #include <stdio.h>
-#define retro_assert(cond) do { \
-   if (!(cond)) { printf("Assertion failed at %s:%d.\n", __FILE__, __LINE__); abort(); } \
-} while(0)
+#define retro_assert(cond) ((void)( (cond) || (printf("Assertion failed at %s:%d.\n", __FILE__, __LINE__), abort(), 0) ))
 #else
 #define retro_assert(cond) assert(cond)
 #endif


### PR DESCRIPTION
Leverages comma operator(`,`) and  removes `do{}while()` wrapping from the macro

## rationale

Macros without `do{}while()` wrapping behave more like regular C expressions. The macro can now be nested/embedded inside of a wide variety of other similar compound statements and conditionals without causing syntax errors. This change has no risk of negatively impacting existing code.

## language compatibility notes

This format utilizes ANSI-C standard behavior for the comma (,) operator, which allows compounding statements together into a single expression. The last statement in the comma-delimited sequence returns the 'r-value result'. R-value results of preceding statements are discarded. For example, this is valid C syntax:

```
void foo() { printf("foo!\n"); }

int x = (10, 5);    // x is assigned value 5

int y = (foo(), 5); // prints "foo!", and assigns y=5
```

The is not a widely known feature of C but is valid in C89, C99, and all incarnations of C++. This style of macro is strongly recommended generally for all macros, as it improves macro usability without any drawbacks or caveats. But for now I've applied it only to `retro_assert` mainly as an education and information effort, and hope to see it more widely adopted over time. :)
