### PR TITLE
Apple Silicon Build Support

### DIFF
--- a/pkg/apple/RetroArch.xcodeproj/project.pbxproj
+++ b/pkg/apple/RetroArch.xcodeproj/project.pbxproj
@@ -573,6 +573,7 @@
 					"-DHAVE_AUDIOMIXER",
 					"-DHAVE_RWAV",
 					"-DHAVE_GETOPT_LONG",
+					"-DDONT_WANT_ARM_OPTIMIZATIONS",
 				);
 				PREBINDING = NO;
 				SDKROOT = macosx;
@@ -655,6 +656,7 @@
 					"-DHAVE_AUDIOMIXER",
 					"-DHAVE_RWAV",
 					"-DHAVE_GETOPT_LONG",
+					"-DDONT_WANT_ARM_OPTIMIZATIONS",
 				);
 				PREBINDING = NO;
 				SDKROOT = macosx;

--- a/pkg/apple/RetroArch_Metal.xcodeproj/project.pbxproj
+++ b/pkg/apple/RetroArch_Metal.xcodeproj/project.pbxproj
@@ -1751,6 +1751,7 @@
 					"-DHAVE_COCOA_METAL",
 					"-UHAVE_GLSL",
 					"-UHAVE_OPENGL",
+					"-DDONT_WANT_ARM_OPTIMIZATIONS",
 				);
 				OTHER_CODE_SIGN_FLAGS = "--deep --timestamp";
 				OTHER_CPLUSPLUSFLAGS = (
@@ -1786,6 +1787,7 @@
 					"-DHAVE_COCOA_METAL",
 					"-UHAVE_GLSL",
 					"-UHAVE_OPENGL",
+					"-DDONT_WANT_ARM_OPTIMIZATIONS",
 				);
 				OTHER_CODE_SIGN_FLAGS = "--deep --timestamp";
 				OTHER_CPLUSPLUSFLAGS = (


### PR DESCRIPTION
## Description

This pull request disables some NEON optimizations as used in libretro-common/audio/conversion which cause failures when building RetroArch natively for Apple Silicon M1 Macs.
RetroArch now builds successfully. Universal fat-binary x86_64/arm64 builds can also be built.

Specifically done on the Metal project variant, but likely to work just as well for the regular OpenGL project.

<img width="1072" alt="Screen Shot 2020-11-25 at 3 27 19 PM" src="https://user-images.githubusercontent.com/26755087/100283466-32f9c780-2f33-11eb-94b0-5866832ce576.png">
