### PR TITLE
OpenDingux: Add '-mplt -mno-shared' compiler optimisation flags

### DIFF
--- a/Makefile.dingux
+++ b/Makefile.dingux
@@ -78,6 +78,7 @@ OPK_NAME = retroarch.opk
 OBJ :=
 LINK := $(CXX)
 DEF_FLAGS := -march=mips32 -mtune=mips32r2 -mhard-float -ffast-math -fomit-frame-pointer
+DEF_FLAGS += -mplt -mno-shared
 DEF_FLAGS += -ffunction-sections -fdata-sections
 DEF_FLAGS += -I. -Ideps -Ideps/stb -DDINGUX=1 -MMD
 DEF_FLAGS += -Wall -Wno-unused-variable

--- a/Makefile.rg350
+++ b/Makefile.rg350
@@ -82,6 +82,7 @@ OPK_NAME = retroarch_rg350.opk
 OBJ :=
 LINK := $(CXX)
 DEF_FLAGS := -march=mips32 -mtune=mips32r2 -mhard-float -ffast-math -fomit-frame-pointer
+DEF_FLAGS += -mplt -mno-shared
 DEF_FLAGS += -ffunction-sections -fdata-sections
 DEF_FLAGS += -I. -Ideps -Ideps/stb -DDINGUX=1 -MMD
 DEF_FLAGS += -Wall -Wno-unused-variable


### PR DESCRIPTION
## Description

This PR adds the following compiler optimisation flags when building for OpenDingux targets:

- `-mno-shared`: This reduces the size of the retroarch binary by ~12%, and improves performance

- `-mplt`: According to common benchmarks (https://elinux.org/images/1/1f/New-tricks-mips-linux.pdf, https://cobalt.googlesource.com/cobalt/+/RELEASE_9/src/cobalt/doc/performance_tuning.md) this increases performance by ~5-20%. It is difficult to quantify RetroArch performance on OpenDingux, and the effect varies with the code path - but there is a noticeable improvement. The magnitude of this is somewhat surprising, since only the frontend itself is affected (i.e. cores are not) yet the benefit is felt everywhere. In particular, when running content with the fbalpha2012_cps2 core with frameskipping enabled, the number of dropped frames is reduced dramatically (visually by at least 50%)