### PR TITLE
Shaders Fix Crash change num shader passes in UI

### DIFF
--- a/gfx/video_shader_parse.c
+++ b/gfx/video_shader_parse.c
@@ -427,6 +427,9 @@ bool video_shader_resolve_current_parameters(config_file_t *conf,
    unsigned i;
    const struct config_entry_list *entry = NULL;
 
+   if (!conf)
+      return false;
+
    /* For all parameters in the shader see if there is any config value set */
    for (i = 0; i < shader->num_parameters; i++)
    {


### PR DESCRIPTION
## Description

Fix for a crash found by @Tatsuya79 which was introduced by commit f0c4343cb97d5d87c3cf0c7017a5b7adc5704a67 Multi-Level Presets where a check for a null config was accidentally removed in the resolve parameters, this adds the check back in and retroarch is happy again.