### PR TITLE
(sdl_dingux_joypad) Fix typo

### DIFF
--- a/input/drivers_joypad/sdl_dingux_joypad.c
+++ b/input/drivers_joypad/sdl_dingux_joypad.c
@@ -137,7 +137,7 @@ static bool sdl_dingux_rumble_init(dingux_joypad_rumble_t *rumble)
    rumble->strong.effect.u.periodic.magnitude = 0;
    rumble->strong.id                          = Shake_UploadEffect(rumble->device, &rumble->strong.effect);
 
-   if (rumble->weak.id == SHAKE_ERROR)
+   if (rumble->strong.id == SHAKE_ERROR)
       goto error;
    strong_uploaded = true;
 


### PR DESCRIPTION
## Description

This PR fixes a silly copy/paste typo in `sdl_dingux_joypad.c`. It only affected a check for an error that couldn't actually happen, but wrong code must be corrected!
