### PR TITLE
Add CTR build to .gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -132,6 +132,44 @@ build-static-retroarch-psp:
     - "cp -r ./* .retroarch-precompiled/"
     - "mv .retroarch-precompiled/ retroarch-precompiled/"
 
+build-static-retroarch-ctr:
+  image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-devkitpro:latest
+  stage: prepare-for-static-cores
+  before_script:
+    - export NUMPROC=$(($(nproc)/3))
+  artifacts:
+    paths:
+    -  retroarch-precompiled/
+    expire_in: 1 day
+  dependencies: []
+  needs:
+    # Salamander build requires no core
+    - build-static-retroarch-salamander-ctr
+  script:
+    # Allow failure since we don't have a core
+    - "make -f Makefile.ctr -j$NUMPROC USE_CTRULIB_2=1 ||:"
+    - "mkdir .retroarch-precompiled"
+    - "cp -r ./* .retroarch-precompiled/"
+    - "mv .retroarch-precompiled/ retroarch-precompiled/"
+
+build-static-retroarch-salamander-ctr:
+  image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-devkitpro:latest
+  stage: build
+  before_script:
+    - export NUMPROC=$(($(nproc)/3))
+  artifacts:
+    paths:
+    -  retroarch_3ds.cia
+    -  RetroArch.3dsx
+    -  RetroArch.smdh
+    expire_in: 1 month
+  dependencies: []
+  script:
+    - "make -f Makefile.ctr.salamander -j$NUMPROC USE_CTRULIB_2=1"
+    - "mv -f retroarch_3ds_salamander.cia retroarch_3ds.cia"
+    - "mv -f retroarch_3ds_salamander.3dsx RetroArch.3dsx"
+    - "mv -f retroarch_3ds_salamander.smdh RetroArch.smdh"
+
 trigger_static-cores:
   stage: trigger-static-cores
   needs:
@@ -139,6 +177,7 @@ trigger_static-cores:
   - build-static-retroarch-vita
   - build-static-retroarch-ps2
   - build-static-retroarch-psp
+  - build-static-retroarch-ctr
   dependencies: []
   script:
     # Dummy for now

--- a/Makefile.ctr
+++ b/Makefile.ctr
@@ -8,7 +8,7 @@ BUILD_3DSX              = 1
 BUILD_3DS               = 0
 BUILD_CIA               = 1
 LIBCTRU_NO_DEPRECATION  = 1
-USE_CTRULIB_2           = 0
+USE_CTRULIB_2          ?= 0
 
 APP_TITLE            = RetroArch 3DS
 APP_DESCRIPTION      = RetroArch 3DS

--- a/Makefile.ctr.salamander
+++ b/Makefile.ctr.salamander
@@ -5,7 +5,7 @@ DEBUG                   = 0
 BUILD_3DSX              = 1
 BUILD_3DS               = 0
 BUILD_CIA               = 1
-USE_CTRULIB_2           = 0
+USE_CTRULIB_2          ?= 0
 
 APP_TITLE            = RetroArch 3DS
 APP_DESCRIPTION      = RetroArch 3DS


### PR DESCRIPTION
## Description

This PR adds the 3DS (CTR) build to `.gitlab-ci.yml`. I have tested the salamander build generated from this, but cannot yet verify that cores are produced correctly (since this PR needs to be merged before we can actually attempt to build a core...)