### PR TITLE
(3DS) Minor makefile clean-ups required for new build infrastructure

### DIFF
--- a/Makefile.ctr
+++ b/Makefile.ctr
@@ -264,7 +264,7 @@ endif
 
 %.vsh:
 
-$(TARGET).smdh: $(APP_ICON)
+$(TARGET).smdh: $(TARGET).elf $(APP_ICON)
 	$(DEVKITTOOLS)/bin/smdhtool --create "$(APP_TITLE)" "$(APP_DESCRIPTION)" "$(APP_AUTHOR)" $(APP_ICON) $@
 
 $(TARGET).3dsx: $(TARGET).elf
@@ -279,10 +279,10 @@ $(TARGET).elf: ctr/3dsx_custom_crt0.o
 	$(LD) $(LDFLAGS) $(OBJ) $(LIBDIRS) $(LIBS) -o $@
 	$(NM) -CSn $@ > $(notdir $*.lst)
 
-$(TARGET).bnr: $(APP_BANNER) $(APP_AUDIO)
+$(TARGET).bnr: $(TARGET).elf $(APP_BANNER) $(APP_AUDIO)
 	$(BANNERTOOL) makebanner -i "$(APP_BANNER)" -a "$(APP_AUDIO)" -o $@
 
-$(TARGET).icn: $(APP_ICON)
+$(TARGET).icn: $(TARGET).elf $(APP_ICON)
 	$(BANNERTOOL) makesmdh -s "$(APP_TITLE)" -l "$(APP_TITLE)" -p "$(APP_AUTHOR)" -i $(APP_ICON) -o $@
 
 $(TARGET).3ds: $(TARGET).elf $(TARGET).bnr $(TARGET).icn $(APP_RSF)

--- a/pkg/ctr/Makefile.cores
+++ b/pkg/ctr/Makefile.cores
@@ -351,6 +351,7 @@ else ifeq ($(LIBRETRO), nxengine)
 	APP_UNIQUE_ID        = 0xBAC05
 	APP_ICON             = pkg/ctr/assets/nxengine.png
 	APP_BANNER           = pkg/ctr/assets/nxengine_banner.png
+	WHOLE_ARCHIVE_LINK   = 1
 
 else ifeq ($(LIBRETRO), o2em)
 	APP_TITLE            = O2EM Libretro


### PR DESCRIPTION
## Description

This PR makes some small changes to the 3DS makefile in order to support the new build infrastructure:

- Auxiliary binaries are now only created if the `$(TARGET).elf` generation was successful

- `WHOLE_ARCHIVE_LINK` is now set via `pkg/ctr/Makefile.cores` (previously this was done by `dist-cores.sh`, which we will no longer be using)