### PR TITLE
(.gitlab-ci.yml) Use correct architecture label for OpenDingux build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,7 @@ build-retroarch-linux-x64:
     - "./configure"
     - "make -j$NUMPROC"
 
-build-retroarch-dingux-i386:
+build-retroarch-dingux-mips32:
   image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-dingux:latest
   stage: build
   before_script:


### PR DESCRIPTION
## Description

This PR fixes a typo in the `.gitlab-ci.yml` job name for OpenDingux builds. OpenDingux is `mips32`, not `i386`.