### PR TITLE
Small Lakka fixes (fd leak and build issue)

### DIFF
--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -1328,13 +1328,14 @@ static void frontend_unix_get_lakka_version(char *s,
 
 static void frontend_unix_set_screen_brightness(int value)
 {
+   int brightness = 0;
    char svalue[16] = {0};
    #if defined(HAVE_LAKKA_SWITCH)
    /* Values from 0 to 100 */
-   int brightness = value;
+   brightness = value;
    #elif defined(HAVE_ODROIDGO2)
    /* GOA screen PWM value does not linearly relate to perceived brightness */
-   int brightness = (pow(1.0369f, value) - 1) * 7;
+   brightness = (pow(1.0369f, value) - 1) * 7;
    #endif
 
    snprintf(svalue, sizeof(svalue), "%d\n", brightness);

--- a/wifi/drivers/connmanctl.c
+++ b/wifi/drivers/connmanctl.c
@@ -29,7 +29,7 @@
 
 typedef struct
 {
-   bool connman_cache[256];
+   bool connman_cache[64];
    unsigned connman_counter;
    struct string_list* lines;
    char command[256];
@@ -232,7 +232,7 @@ static bool connmanctl_ssid_is_online(void *data, unsigned i)
    const char *line   = connman->lines->elems[i].data;
    FILE *command_file = NULL;
 
-   if (connman->connman_counter == 60)
+   if (connman->connman_counter >= 64)
    {
       static struct string_list* list = NULL;
       connman->connman_counter = 0;
@@ -254,22 +254,15 @@ static bool connmanctl_ssid_is_online(void *data, unsigned i)
             service);
 
       command_file = popen(connman->command, "r");
-
-      while (fgets(ln, 512, command_file))
-      {
-         connman->connman_cache[i] = true;
-         return true;
-      }
+      connman->connman_cache[i] = (fgets(ln, 512, command_file));
       pclose(command_file);
-      connman->connman_cache[i] = false;
    }
    else
    {
       connman->connman_counter++;
-      return connman->connman_cache[i];
    }
 
-   return false;
+   return connman->connman_cache[i];
 }
 
 static bool connmanctl_connect_ssid(


### PR DESCRIPTION
This fixes a file descriptor leak in the Wifi code (causes RA to potentially run out of FDs if Wifi menu is left open for too long).
Also fixes building RA for Lakka in platforms that are not OGA or Switch (a var is not defined). Missed it in previous PR.