### PR TITLE
fix discord rich presence

### DIFF
--- a/deps/discord-rpc/include/discord_rpc.h
+++ b/deps/discord-rpc/include/discord_rpc.h
@@ -57,9 +57,7 @@ void Discord_RunCallbacks(void);
 
 /* If you disable the lib starting its own I/O thread, 
  * you'll need to call this from your own */
-#ifdef DISCORD_DISABLE_IO_THREAD
 void Discord_UpdateConnection(void);
-#endif
 
 void Discord_UpdatePresence(const DiscordRichPresence* presence);
 void Discord_ClearPresence(void);

--- a/retroarch.c
+++ b/retroarch.c
@@ -6282,6 +6282,7 @@ void discord_update(enum discord_presence presence)
 #endif
 
    Discord_UpdatePresence(&discord_st->presence);
+   Discord_UpdateConnection();
    discord_st->status = presence;
 }
 
@@ -6303,6 +6304,7 @@ static void discord_init(
    handlers.joinRequest        = handle_discord_join_request;
 
    Discord_Initialize(discord_app_id, &handlers, 0, NULL);
+   Discord_UpdateConnection();
 
 #ifdef _WIN32
    fill_pathname_application_path(full_path, sizeof(full_path));
@@ -6320,6 +6322,7 @@ static void discord_init(
 #endif
    RARCH_LOG("[DISCORD]: Registering startup command: %s\n", command);
    Discord_Register(discord_app_id, command);
+   Discord_UpdateConnection();
    discord_st->ready = true;
 }
 #endif
@@ -35940,6 +35943,7 @@ bool retroarch_main_quit(void)
    if (discord_st->ready)
    {
       Discord_ClearPresence();
+      Discord_UpdateConnection();
       Discord_Shutdown();
       discord_st->ready       = false;
    }
@@ -37359,7 +37363,10 @@ int runloop_iterate(void)
    discord_state_t *discord_st                  = &p_rarch->discord_st;
 
    if (discord_is_inited)
+   {
       Discord_RunCallbacks();
+      Discord_UpdateConnection();
+   }
 #endif
 
    if (p_rarch->runloop_frame_time.callback)


### PR DESCRIPTION
## Description

Fixes #11636 

The changes in https://github.com/libretro/RetroArch/commit/27dc500ed15989ae208a276647743ed2bc2228b5 are effectively the same as defining `DISCORD_DISABLE_IO_THREAD`. However, according to the header, if the thread is disabled, the code has to explicitly call `Discord_UpdateConnection`:
https://github.com/libretro/RetroArch/blob/27dc500ed15989ae208a276647743ed2bc2228b5/deps/discord-rpc/include/discord_rpc.h#L58-L62

I've updated the header to expose the function and added calls to the function after each `Discord_` call in `retroarch.c`. This seems to fix the problem.

I'm not sure why the referenced changes were deemed necessary, or even appropriate, given that they occurred in a deps subdirectory, which are essentially submodules. Any changes made directly in a deps subdirectory cause maintenance headaches in the future if we ever decide to upgrade to a newer version of the submodule.

## Related Issues

#11636 

## Related Pull Requests

n/a

## Reviewers

@twinaphex 
