### PR TITLE
Add Wii build to .gitlab-ci.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ Release
 ipch
 *.user
 /bootstrap/gx/wii/app_booter/app_booter.bin
+/wii/app_booter/app_booter.bin
 *.zip
 RetroArch-w32/
 RetroArch-w64/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -170,6 +170,40 @@ build-static-retroarch-dummy-ctr:
     - "mv -f retroarch_3ds_salamander.3dsx RetroArch.3dsx"
     - "mv -f retroarch_3ds_salamander.smdh RetroArch.smdh"
 
+build-static-retroarch-wii:
+  image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-devkitpro:latest
+  stage: prepare-for-static-cores
+  before_script:
+    - export NUMPROC=$(($(nproc)/3))
+  artifacts:
+    paths:
+    -  retroarch-precompiled/
+    expire_in: 1 day
+  dependencies: []
+  needs:
+    # Dummy build requires no core
+    - build-static-retroarch-dummy-wii
+  script:
+    # Allow failure since we don't have a core
+    - "make -f Makefile.wii -j$NUMPROC EXTERNAL_LIBOGC=1 GX_PTHREAD_LEGACY=0 ||:"
+    - "mkdir .retroarch-precompiled"
+    - "cp -r ./* .retroarch-precompiled/"
+    - "mv .retroarch-precompiled/ retroarch-precompiled/"
+
+build-static-retroarch-dummy-wii:
+  image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-devkitpro:latest
+  stage: build
+  before_script:
+    - export NUMPROC=$(($(nproc)/3))
+  artifacts:
+    paths:
+    -  boot.dol
+    expire_in: 1 month
+  dependencies: []
+  script:
+    - "make -f Makefile.wii.salamander -j$NUMPROC EXTERNAL_LIBOGC=1 GX_PTHREAD_LEGACY=0"
+    - "mv -f retroarch-salamander_wii.dol boot.dol"
+
 trigger_static-cores:
   stage: trigger-static-cores
   needs:

--- a/Makefile.griffin
+++ b/Makefile.griffin
@@ -116,7 +116,8 @@ else ifeq ($(platform), ps3-cobra)
 
 # NGC/Wii - libogc
 else ifeq ($(libogc_platform), 1)
-   EXTERNAL_LIBOGC=0
+   EXTERNAL_LIBOGC   ?= 0
+   GX_PTHREAD_LEGACY ?= 1
    CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
    CXX = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)
    LD = $(DEVKITPPC)/bin/powerpc-eabi-ld$(EXE_EXT)
@@ -146,6 +147,11 @@ else ifeq ($(libogc_platform), 1)
          LIBDIRS += -Lwii/libogc/libs/wii
       endif
 
+   endif
+
+   ifeq ($(GX_PTHREAD_LEGACY), 1)
+      CFLAGS   += -DGX_PTHREAD_LEGACY
+      CXXFLAGS += -DGX_PTHREAD_LEGACY
    endif
 
    ifeq ($(platform), ngc)

--- a/Makefile.wii
+++ b/Makefile.wii
@@ -1,0 +1,385 @@
+ROOT_DIR                  := .
+DEPS_DIR                  := $(ROOT_DIR)/deps
+DEBUG                     ?= 0
+HAVE_LOGGER                = 0
+HAVE_FILE_LOGGER           = 0
+HAVE_CC_RESAMPLER          = 1
+WHOLE_ARCHIVE_LINK         = 0
+BIG_STACK                  = 1
+PC_DEVELOPMENT_IP_ADDRESS  = 255.255.255.255
+PC_DEVELOPMENT_UDP_PORT    = 3490
+RARCH_CONSOLE              = 0
+USBGECKO                   = 0
+
+SPACE      :=
+SPACE      := $(SPACE) $(SPACE)
+BACKSLASH  :=
+BACKSLASH  := \$(BACKSLASH)
+filter_out1 = $(filter-out $(firstword $1),$1)
+filter_out2 = $(call filter_out1,$(call filter_out1,$1))
+
+# system platform
+system_platform = unix
+ifeq ($(shell uname -s),)
+   EXE_EXT = .exe
+   system_platform = win
+else ifneq ($(findstring Darwin,$(shell uname -s)),)
+   system_platform = osx
+else ifneq ($(findstring MINGW,$(shell uname -s)),)
+   system_platform = win
+endif
+
+TARGET_NAME        := retroarch
+
+INCLUDE            :=
+LDFLAGS            :=
+LIBDIRS            :=
+
+ifeq ($(LIBRETRO), nxengine)
+   WHOLE_ARCHIVE_LINK = 1
+endif
+
+ifeq ($(WHOLE_ARCHIVE_LINK), 1)
+   WHOLE_START     := -Wl,--whole-archive
+   WHOLE_END       := -Wl,--no-whole-archive
+endif
+
+LIBS               := $(WHOLE_START) -lretro_wii $(WHOLE_END)
+
+libogc_platform    := 1
+
+EXTERNAL_LIBOGC   ?= 0
+GX_PTHREAD_LEGACY ?= 1
+CC                 = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
+CXX                = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)
+LD                 = $(DEVKITPPC)/bin/powerpc-eabi-ld$(EXE_EXT)
+ELF2DOL            = $(DEVKITPPC)/bin/elf2dol$(EXE_EXT)
+EXT_TARGET        := $(TARGET_NAME)_wii.dol
+EXT_INTER_TARGET  := $(TARGET_NAME)_wii.elf
+
+# Check whether ELF2DOL executable exists
+# (path has changed in more recent toolchains)
+ifeq ("$(wildcard $(ELF2DOL))","")
+   ELF2DOL = $(DEVKITPRO)/tools/bin/elf2dol$(EXE_EXT)
+endif
+
+INCLUDE += -I. -I$(DEVKITPRO)/libogc/include -Iwii/libogc/include
+
+ifeq ($(EXTERNAL_LIBOGC), 1)
+   CFLAGS   += -DEXTERNAL_LIBOGC
+   CXXFLAGS += -DEXTERNAL_LIBOGC
+   LIBDIRS += -L$(DEVKITPRO)/libogc/lib/wii
+else
+   CFLAGS   += -DINTERNAL_LIBOGC
+   CXXFLAGS += -DINTERNAL_LIBOGC
+   LIBDIRS += -Lwii/libogc/libs/wii
+endif
+
+ifeq ($(GX_PTHREAD_LEGACY), 1)
+   CFLAGS   += -DGX_PTHREAD_LEGACY
+   CXXFLAGS += -DGX_PTHREAD_LEGACY
+endif
+
+MACHDEP := -DHW_RVL -mrvl
+
+LIBDIRS += -L.
+MACHDEP += -DGEKKO -mcpu=750 -meabi -mhard-float
+
+LDFLAGS += $(MACHDEP) -Wl,-Map,$(notdir $(EXT_INTER_TARGET)).map,-wrap,malloc,-wrap,free,-wrap,memalign,-wrap,calloc,-wrap,realloc,-wrap,strdup,-wrap,strndup,-wrap,malloc_usable_size
+
+ifeq ($(BIG_STACK), 1)
+   LDFLAGS += -T bootstrap/gx/rvl.ld
+endif
+
+ifeq ($(EXTERNAL_LIBOGC), 1)
+   LIBS += -lfat
+endif
+
+LIBS += -lwiiuse -lbte
+
+ifeq ($(USBGECKO), 1)
+  LIBS += -ldb
+endif
+
+LIBS += -logc
+
+CFLAGS += -DGEKKO -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
+
+HAVE_RUNAHEAD            := 1
+HAVE_DSP_FILTER          := 1
+HAVE_VIDEO_FILTER        := 1
+HAVE_FILTERS_BUILTIN     := 1
+HAVE_THREADS             := 1
+HAVE_RPNG                := 1
+HAVE_RJPEG               := 1
+HAVE_RBMP                := 1
+HAVE_RTGA                := 1
+HAVE_IBXM                := 1
+HAVE_OVERLAY             := 1
+HAVE_VIDEO_LAYOUT        := 0
+HAVE_ZLIB                := 1
+HAVE_7ZIP                := 1
+HAVE_CONFIGFILE          := 1
+HAVE_PATCH               := 1
+HAVE_CHEATS              := 1
+HAVE_SCREENSHOTS         := 1
+HAVE_REWIND              := 1
+HAVE_AUDIOMIXER          := 1
+HAVE_RWAV                := 1
+RARCH_CONSOLE             = 1
+
+#HAVE_LANGEXTRA          := 1
+HAVE_WIIUSB_HID          := 1
+HAVE_RARCH_EXEC          := 1
+HAVE_RSOUND              := 1
+
+APP_BOOTER_DIR = wii/app_booter
+PLATOBJS := $(APP_BOOTER_DIR)/app_booter.binobj
+
+ifeq ($(USBGECKO), 1)
+   CFLAGS += -DUSBGECKO
+endif
+
+HAVE_CHEATS              := 1
+
+CFLAGS += -Wall -std=gnu99 $(MACHDEP) $(PLATCFLAGS) $(INCLUDE)
+INCLUDE += -I./libretro-common/include \
+           -Ideps \
+           -Ideps/stb
+
+OBJ = griffin/griffin.o  $(PLATOBJS)
+
+ifeq ($(HAVE_GRIFFIN_CPP), 1)
+   OBJ += griffin/griffin_cpp.o
+endif
+
+ifeq ($(WANT_GLSLANG), 1)
+	OBJ += griffin/griffin_glslang.o
+endif
+
+ifeq ($(HAVE_LOGGER), 1)
+   CFLAGS      += -DHAVE_LOGGER
+   CFLAGS      += -DPC_DEVELOPMENT_IP_ADDRESS=\"$(PC_DEVELOPMENT_IP_ADDRESS)\" -DPC_DEVELOPMENT_UDP_PORT=$(PC_DEVELOPMENT_UDP_PORT)
+endif
+
+CFLAGS      += -DHAVE_SOCKET_LEGACY
+
+ifeq ($(HAVE_KERNEL_PRX), 1)
+   CFLAGS      += -DHAVE_KERNEL_PRX
+endif
+
+ifeq ($(HAVE_WIIUSB_HID), 1)
+   CFLAGS      += -DHAVE_WIIUSB_HID -DHAVE_HID
+endif
+
+ifeq ($(HAVE_LIBRETRODB), 1)
+   CFLAGS      += -DHAVE_LIBRETRODB
+endif
+
+ifeq ($(BIG_STACK),1)
+   CFLAGS      += -DBIG_STACK
+endif
+
+ifeq ($(HAVE_RJPEG), 1)
+   CFLAGS      += -DHAVE_RJPEG
+endif
+
+ifeq ($(HAVE_FILE_LOGGER), 1)
+   CFLAGS      += -DHAVE_FILE_LOGGER
+endif
+
+ifeq ($(HAVE_RARCH_EXEC), 1)
+   CFLAGS      += -DHAVE_RARCH_EXEC
+endif
+
+ifeq ($(HAVE_ZLIB), 1)
+   CFLAGS      += -DHAVE_ZLIB
+   CFLAGS      += -I./libretro-common/include/compat/zlib
+endif
+
+ifeq ($(HAVE_RPNG), 1)
+   CFLAGS      += -DHAVE_RPNG
+endif
+
+ifeq ($(HAVE_RBMP), 1)
+   CFLAGS      += -DHAVE_RBMP
+endif
+
+ifeq ($(HAVE_RTGA), 1)
+   CFLAGS      += -DHAVE_RTGA
+endif
+
+ifeq ($(HAVE_IMAGEVIEWER), 1)
+   CFLAGS      += -DHAVE_IMAGEVIEWER
+endif
+
+ifeq ($(HAVE_BSV_MOVIE), 1)
+   CFLAGS      += -DHAVE_BSV_MOVIE
+endif
+
+ifeq ($(HAVE_RUNAHEAD), 1)
+   CFLAGS      += -DHAVE_RUNAHEAD
+endif
+
+ifeq ($(HAVE_7ZIP), 1)
+   CFLAGS      += -DHAVE_7ZIP
+endif
+
+ifeq ($(HAVE_SCREENSHOTS), 1)
+	CFLAGS      += -DHAVE_SCREENSHOTS
+endif
+
+ifeq ($(HAVE_REWIND), 1)
+	CFLAGS      += -DHAVE_REWIND
+endif
+
+ifeq ($(HAVE_AUDIOMIXER), 1)
+   CFLAGS      += -DHAVE_AUDIOMIXER
+endif
+
+ifeq ($(HAVE_RWAV), 1)
+   CFLAGS      += -DHAVE_RWAV
+endif
+
+ifeq ($(HAVE_OVERLAY), 1)
+   CFLAGS      += -DHAVE_OVERLAY
+endif
+
+ifeq ($(HAVE_VIDEO_LAYOUT), 1)
+   CFLAGS      += -DHAVE_VIDEO_LAYOUT
+endif
+
+ifeq ($(HAVE_NETWORKING), 1)
+   CFLAGS      += -DHAVE_NETWORKING
+endif
+
+ifeq ($(HAVE_NETPLAYDISCOVERY), 1)
+   CFLAGS      += -DHAVE_NETPLAYDISCOVERY
+endif
+
+ifeq ($(RARCH_CONSOLE), 1)
+   CFLAGS += -DRARCH_CONSOLE
+endif
+
+ifeq ($(RARCH_MOBILE), 1)
+   CFLAGS += -DRARCH_MOBILE
+endif
+
+CFLAGS += -std=gnu99 -DHAVE_RGUI -DHAVE_MENU -DHAVE_GRIFFIN=1 -Wno-char-subscripts -DRARCH_INTERNAL
+
+ifeq ($(HAVE_MATERIALUI), 1)
+   CFLAGS += -DHAVE_MATERIALUI
+endif
+
+ifeq ($(HAVE_XMB), 1)
+   CFLAGS += -DHAVE_XMB
+endif
+
+ifeq ($(HAVE_STB_FONT), 1)
+   CFLAGS += -DHAVE_STB_FONT
+endif
+
+ifeq ($(HAVE_LANGEXTRA), 1)
+   CFLAGS += -DHAVE_LANGEXTRA
+endif
+
+ifeq ($(HAVE_DSP_FILTER), 1)
+   CFLAGS += -DHAVE_DSP_FILTER
+endif
+
+ifeq ($(HAVE_VIDEO_FILTER), 1)
+   CFLAGS += -DHAVE_VIDEO_FILTER
+endif
+
+ifeq ($(HAVE_FILTERS_BUILTIN), 1)
+   CFLAGS += -DHAVE_FILTERS_BUILTIN
+endif
+
+ifeq ($(HAVE_THREADS), 1)
+   CFLAGS += -DHAVE_THREADS
+endif
+
+ifeq ($(HAVE_CONFIGFILE), 1)
+   CFLAGS += -DHAVE_CONFIGFILE
+endif
+
+ifeq ($(HAVE_PATCH), 1)
+   CFLAGS += -DHAVE_PATCH
+endif
+
+ifeq ($(HAVE_CHEATS), 1)
+	CFLAGS += -DHAVE_CHEATS
+endif
+
+ifeq ($(HAVE_RSOUND), 1)
+   CFLAGS += -DHAVE_RSOUND
+endif
+
+ifeq ($(HAVE_GETOPT_LONG), 1)
+   CFLAGS += -DHAVE_GETOPT_LONG=1
+endif
+
+ifeq ($(HAVE_DYLIB), 1)
+   CFLAGS += -DHAVE_DYLIB
+endif
+
+ifeq ($(HAVE_NETWORK_CMD), 1)
+   CFLAGS += -DHAVE_NETWORK_CMD
+endif
+
+ifeq ($(HAVE_COMMAND), 1)
+   CFLAGS += -DHAVE_COMMAND
+endif
+
+ifeq ($(HAVE_STDIN_CMD), 1)
+   CFLAGS += -DHAVE_STDIN_CMD
+endif
+
+ifeq ($(HAVE_DYNAMIC), 1)
+   CFLAGS += -DHAVE_DYNAMIC
+endif
+
+ifeq ($(DEBUG), 1)
+   CFLAGS += -O0 -g -DDEBUG
+else
+   CFLAGS += -O3
+endif
+
+OBJOUT   = -o
+LINKOUT  = -o
+LINK = $(CXX)
+
+all: $(EXT_TARGET)
+
+%.dol: %.elf
+	$(ELF2DOL) $< $@
+
+$(EXT_INTER_TARGET): $(OBJ)
+	$(LINK) $(LINKOUT)$@ $(LDFLAGS) $(LIBDIRS) $(OBJ) $(PLATEXTRA) $(LIBS)
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $(OBJOUT)$@ $<
+
+%.o: %.cpp
+	$(CXX) $(CFLAGS) -c $(OBJOUT)$@ $<
+
+%.o: %.S
+	$(CC) $(CFLAGS) -c $(OBJOUT)$@ $<
+
+%.binobj: %.bin
+	$(LD) -r -b binary $(OBJOUT)$@ $<
+
+$(APP_BOOTER_DIR)/app_booter.bin:
+	export EXTERNAL_LIBOGC
+	$(MAKE) -C $(APP_BOOTER_DIR)
+
+clean:
+	rm -f $(EXT_TARGET)
+	rm -f $(EXT_INTER_TARGET)
+	rm -f $(OBJ)
+	$(MAKE) -C $(APP_BOOTER_DIR) clean
+
+.PHONY: clean
+
+print-%:
+	@echo '$*=$($*)'

--- a/Makefile.wii.salamander
+++ b/Makefile.wii.salamander
@@ -3,10 +3,11 @@
 # Makefile for RetroArch Wii.
 ##
 
-DEBUG			= 0
-HAVE_LOGGER		= 0
-HAVE_FILE_LOGGER	= 0
-EXTERNAL_LIBOGC = 0
+DEBUG              = 0
+HAVE_LOGGER        = 0
+HAVE_FILE_LOGGER   = 0
+EXTERNAL_LIBOGC   ?= 0
+GX_PTHREAD_LEGACY ?= 1
 
 # system platform
 system_platform = unix
@@ -27,6 +28,12 @@ CXX = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)
 LD = $(DEVKITPPC)/bin/powerpc-eabi-ld$(EXE_EXT)
 ELF2DOL = $(DEVKITPPC)/bin/elf2dol$(EXE_EXT)
 
+# Check whether ELF2DOL executable exists
+# (path has changed in more recent toolchains)
+ifeq ("$(wildcard $(ELF2DOL))","")
+   ELF2DOL = $(DEVKITPRO)/tools/bin/elf2dol$(EXE_EXT)
+endif
+
 DOL_TARGET := retroarch-salamander_wii.dol
 ELF_TARGET := retroarch-salamander_wii.elf
 
@@ -37,6 +44,11 @@ LIBDIRS := -L$(DEVKITPRO)/libogc/lib/wii -L.
 else
 INCLUDE += -Iwii/libogc/include
 LIBDIRS := -Lwii/libogc/libs/wii -L.
+endif
+
+ifeq ($(GX_PTHREAD_LEGACY), 1)
+   CFLAGS   += -DGX_PTHREAD_LEGACY
+   CXXFLAGS += -DGX_PTHREAD_LEGACY
 endif
 
 MACHDEP := -DGEKKO -DHW_RVL -mrvl -mcpu=750 -meabi -mhard-float
@@ -127,6 +139,7 @@ $(ELF_TARGET): $(OBJ)
 	$(LD) -r -b binary -o $@ $<
 
 $(APP_BOOTER_DIR)/app_booter.bin:
+	export EXTERNAL_LIBOGC
 	$(MAKE) -C $(APP_BOOTER_DIR)
 
 pkg: all

--- a/libretro-common/rthreads/gx_pthread.h
+++ b/libretro-common/rthreads/gx_pthread.h
@@ -84,10 +84,13 @@
 
 typedef OSThread pthread_t;
 typedef mutex_t pthread_mutex_t;
+typedef OSCond pthread_cond_t;
+
+#if defined(GX_PTHREAD_LEGACY)
 typedef void* pthread_mutexattr_t;
 typedef int pthread_attr_t;
-typedef OSCond pthread_cond_t;
 typedef OSCond pthread_condattr_t;
+#endif
 
 static INLINE int pthread_create(pthread_t *thread,
       const pthread_attr_t *attr, void *(*start_routine)(void*), void *arg)

--- a/wii/app_booter/Makefile
+++ b/wii/app_booter/Makefile
@@ -14,7 +14,7 @@ else ifneq ($(findstring MINGW,$(shell uname -a)),)
    system_platform = win
 endif
 
-EXTERNAL_LIBOGC = 0
+EXTERNAL_LIBOGC ?= 0
 CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
 LD = $(DEVKITPPC)/bin/powerpc-eabi-ld$(EXE_EXT)
 OBJCOPY = $(DEVKITPPC)/bin/powerpc-eabi-objcopy$(EXE_EXT)


### PR DESCRIPTION
## Description

This PR adds support for Wii builds via `.gitlab-ci.yml`

There were a number of incompatibilities with the latest toolchain here, which I have attempted to work around. I cannot verify that the binaries actually run until the first core is built (which cannot happen until after this is merged...)