### PR TITLE
(3DS) guard threading

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -792,8 +792,10 @@ endif
 
 ifeq ($(TARGET), retroarch_3ds)
    OBJ += audio/drivers/ctr_csnd_audio.o \
-          audio/drivers/ctr_dsp_audio.o \
-          audio/drivers/ctr_dsp_thread_audio.o
+          audio/drivers/ctr_dsp_audio.o
+ifeq ($(HAVE_THREADS), 1)
+   OBJ += audio/drivers/ctr_dsp_thread_audio.o
+endif
 endif
 
 ifeq ($(HAVE_ALSA), 1)

--- a/frontend/drivers/platform_ctr.c
+++ b/frontend/drivers/platform_ctr.c
@@ -487,7 +487,9 @@ static void frontend_ctr_init(void* data)
    ctr_check_dspfirm();
    if (ndspInit() != 0) {
       audio_ctr_dsp = audio_null;
+#ifdef HAVE_THREADS
       audio_ctr_dsp_thread = audio_null;
+#endif
    }
    cfguInit();
    ptmuInit();

--- a/griffin/griffin.c
+++ b/griffin/griffin.c
@@ -919,7 +919,9 @@ AUDIO
 #elif defined(_3DS)
 #include "../audio/drivers/ctr_csnd_audio.c"
 #include "../audio/drivers/ctr_dsp_audio.c"
+#ifdef HAVE_THREADS
 #include "../audio/drivers/ctr_dsp_thread_audio.c"
+#endif
 #endif
 
 #ifdef HAVE_XAUDIO

--- a/retroarch.h
+++ b/retroarch.h
@@ -605,7 +605,9 @@ extern audio_driver_t audio_psp;
 extern audio_driver_t audio_ps2;
 extern audio_driver_t audio_ctr_csnd;
 extern audio_driver_t audio_ctr_dsp;
+#ifdef HAVE_THREADS
 extern audio_driver_t audio_ctr_dsp_thread;
+#endif
 extern audio_driver_t audio_switch;
 extern audio_driver_t audio_switch_thread;
 extern audio_driver_t audio_switch_libnx_audren;

--- a/retroarch_data.h
+++ b/retroarch_data.h
@@ -113,7 +113,9 @@ static const audio_driver_t *audio_drivers[] = {
 #ifdef _3DS
    &audio_ctr_csnd,
    &audio_ctr_dsp,
+#ifdef HAVE_THREADS
    &audio_ctr_dsp_thread,
+#endif
 #endif
 #ifdef SWITCH
    &audio_switch,


### PR DESCRIPTION
Building with ```HAVE_THREADS``` and ```HAVE_CHEEVOS``` enabled results in undefined behavior, often causing the controls to become unresponsive. Achievements won't get loaded and are not functional.

This PR adds guards to the remaining threading related code, which allows us to build without ```HAVE_THREADS``` enabled.

Building without ```HAVE_THREADS``` results in CHEEVOS working properly again.