### PR TITLE
Mark function possibly unused to suppress warning

### DIFF
--- a/libretro-common/include/array/rbuf.h
+++ b/libretro-common/include/array/rbuf.h
@@ -85,6 +85,12 @@ struct rbuf__hdr
    size_t cap;
 };
 
+#ifdef __GNUC__
+__attribute__((__unused__))
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable:4505) //unreferenced local function has been removed
+#endif
 static void *rbuf__grow(void *buf,
       size_t new_len, size_t elem_size)
 {
@@ -107,5 +113,8 @@ static void *rbuf__grow(void *buf,
    new_hdr->cap    = new_cap;
    return new_hdr + 1;
 }
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 #endif


### PR DESCRIPTION
## Description

To avoid the warning
```c
./libretro-common/include/array/rbuf.h:88:14: warning: 'rbuf__grow' defined but not used [-Wunused-function]
   88 | static void *rbuf__grow(void *buf,
      |              ^~~~~~~~~~
```
mark the function `rbuf__grow` with the unused attribute as supported by gcc and clang. This also adds #pragma directives to suppress the MSVC warning "unreferenced local function has been removed" if someone were to ever compile on warning level 4. The attribute only marks the function as possibly unused and only serves to suppress the warning.

The warning only gets logged when rbuf.h is included but no rbuf is ever created or modified. Which is possible when for example only the `RBUF_LEN` macro is used (as done so by menu_displaylist.c).

We don't want to mark the function as INLINE because it would be inlined for every use of `RBUF_PUSH` which is a lot.
Another solution would be to create a rbuf.c file with the function body but personally I like it as just this small header.

## Related Issues

## Related Pull Requests

## Reviewers