### PR TITLE
RZIP command line tool fixes

### DIFF
--- a/libretro-common/samples/streams/rzip/Makefile
+++ b/libretro-common/samples/streams/rzip/Makefile
@@ -3,6 +3,24 @@ TARGET := rzip
 LIBRETRO_COMM_DIR := ../../..
 LIBRETRO_DEPS_DIR := ../../../../deps
 
+# Attempt to detect target platform
+ifeq '$(findstring ;,$(PATH))' ';'
+	UNAME := Windows
+else
+	UNAME := $(shell uname 2>/dev/null || echo Unknown)
+	UNAME := $(patsubst CYGWIN%,Cygwin,$(UNAME))
+	UNAME := $(patsubst MSYS%,MSYS,$(UNAME))
+	UNAME := $(patsubst MINGW%,MSYS,$(UNAME))
+endif
+
+# Add '.exe' extension on Windows platforms
+ifeq ($(UNAME), Windows)
+	TARGET := rzip.exe
+endif
+ifeq ($(UNAME), MSYS)
+	TARGET := rzip.exe
+endif
+
 SOURCES := \
 	rzip.c \
 	$(LIBRETRO_COMM_DIR)/compat/fopen_utf8.c \
@@ -54,6 +72,15 @@ endif
 OBJS := $(SOURCES:.c=.o)
 INCLUDE_DIRS += -I$(LIBRETRO_COMM_DIR)/include
 CFLAGS += -DHAVE_ZLIB -Wall -pedantic -std=gnu99 $(INCLUDE_DIRS)
+
+# Silence "ISO C does not support the 'I64' ms_printf length modifier"
+# warnings when using MinGW
+ifeq ($(UNAME), Windows)
+	CFLAGS += -Wno-format
+endif
+ifeq ($(UNAME), MSYS)
+	CFLAGS += -Wno-format
+endif
 
 ifeq ($(DEBUG), 1)
 	CFLAGS += -O0 -g -DDEBUG -D_DEBUG

--- a/libretro-common/samples/streams/rzip/Makefile
+++ b/libretro-common/samples/streams/rzip/Makefile
@@ -1,8 +1,7 @@
 TARGET := rzip
 
 LIBRETRO_COMM_DIR := ../../..
-
-LDFLAGS += -lz
+LIBRETRO_DEPS_DIR := ../../../../deps
 
 SOURCES := \
 	rzip.c \
@@ -27,14 +26,39 @@ SOURCES := \
 	$(LIBRETRO_COMM_DIR)/vfs/vfs_implementation.c \
 	$(LIBRETRO_COMM_DIR)/time/rtime.c
 
-OBJS := $(SOURCES:.c=.o)
+ifneq ($(wildcard $(LIBRETRO_DEPS_DIR)/*),)
+	# If we are building from inside the RetroArch
+	# directory (i.e. if an 'external' deps directory
+	# is avaiable), bake in zlib support
+	SOURCES += \
+		$(LIBRETRO_DEPS_DIR)/libz/adler32.c \
+		$(LIBRETRO_DEPS_DIR)/libz/libz-crc32.c \
+		$(LIBRETRO_DEPS_DIR)/libz/deflate.c \
+		$(LIBRETRO_DEPS_DIR)/libz/gzclose.c \
+		$(LIBRETRO_DEPS_DIR)/libz/gzlib.c \
+		$(LIBRETRO_DEPS_DIR)/libz/gzread.c \
+		$(LIBRETRO_DEPS_DIR)/libz/gzwrite.c \
+		$(LIBRETRO_DEPS_DIR)/libz/inffast.c \
+		$(LIBRETRO_DEPS_DIR)/libz/inflate.c \
+		$(LIBRETRO_DEPS_DIR)/libz/inftrees.c \
+		$(LIBRETRO_DEPS_DIR)/libz/trees.c \
+		$(LIBRETRO_DEPS_DIR)/libz/zutil.c
+	INCLUDE_DIRS := -I$(LIBRETRO_COMM_DIR)/include/compat/zlib
+else
+	# If this is a stand-alone libretro-common directory,
+	# rely on system zlib library (note: only likely to
+	# work on Unix-based platforms...)
+	LDFLAGS += -lz
+endif
 
-CFLAGS += -DHAVE_ZLIB -Wall -pedantic -std=gnu99 -I$(LIBRETRO_COMM_DIR)/include
+OBJS := $(SOURCES:.c=.o)
+INCLUDE_DIRS += -I$(LIBRETRO_COMM_DIR)/include
+CFLAGS += -DHAVE_ZLIB -Wall -pedantic -std=gnu99 $(INCLUDE_DIRS)
 
 ifeq ($(DEBUG), 1)
-   CFLAGS += -O0 -g -DDEBUG -D_DEBUG
+	CFLAGS += -O0 -g -DDEBUG -D_DEBUG
 else
-   CFLAGS += -O2 -DNDEBUG
+	CFLAGS += -O2 -DNDEBUG
 endif
 
 all: $(TARGET)

--- a/libretro-common/samples/streams/rzip/rzip.c
+++ b/libretro-common/samples/streams/rzip/rzip.c
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <ctype.h>
+#include <inttypes.h>
 #include <errno.h>
 #include <time.h>
 
@@ -216,9 +217,9 @@ int main(int argc, char *argv[])
       printf("%s: %s\n",
             in_file_compressed ? "File is in RZIP format" : "File is NOT in RZIP format",
             in_file_path);
-      printf("   Size on disk:      %li bytes\n", in_file_size);
+      printf("   Size on disk:      %" PRIi64 " bytes\n", in_file_size);
       if (in_file_compressed)
-         printf("   Uncompressed size: %li bytes\n", in_file_raw_size);
+         printf("   Uncompressed size: %" PRIi64 " bytes\n", in_file_raw_size);
       goto end;
    }
 
@@ -311,7 +312,7 @@ int main(int argc, char *argv[])
       }
 
       /* Update progress */
-      printf("\rProgress: %li %%", total_data_read * 100 / in_file_raw_size);
+      printf("\rProgress: %" PRIi64 " %%", total_data_read * 100 / in_file_raw_size);
       fflush(stdout);
    }
    printf("\rProgress: 100 %%\n");
@@ -324,7 +325,7 @@ int main(int argc, char *argv[])
          (in_file_size - out_file_size) :
                (out_file_size - in_file_size);
 
-   printf("   %li -> %li bytes [%li %% %s]\n",
+   printf("   %" PRIi64 " -> %" PRIi64 " bytes [%" PRIi64 " %% %s]\n",
          in_file_size, out_file_size,
                file_size_diff * 100 / in_file_size,
                (out_file_size >= in_file_size) ?


### PR DESCRIPTION
## Description

This PR makes the following changes to the RZIP command line tool (#11644):

- A potential segfault on 32bit platforms has been fixed by using the 'proper' `printf()` specifier for `int64_t` variables

- When building from inside the RetroArch directory, zlib is baked into the executable. This should fix build issues on platforms where a system zlib library is unavailable (e.g. Windows), and makes the executable as 'stand alone' as possible