### PR TITLE
(RGUI) Add support for CJK punctuation glyphs

### DIFF
--- a/gfx/drivers_font_renderer/bitmapfont_10x10.c
+++ b/gfx/drivers_font_renderer/bitmapfont_10x10.c
@@ -45,8 +45,8 @@
 #define FONT_10X10_GLYPH_MAX_CHN 0x9FFF
 
 #define FONT_10X10_FILE_JPN      "bitmap10x10_jpn.bin"
-#define FONT_10X10_SIZE_JPN      2496
-#define FONT_10X10_GLYPH_MIN_JPN 0x3040
+#define FONT_10X10_SIZE_JPN      3328
+#define FONT_10X10_GLYPH_MIN_JPN 0x3000
 #define FONT_10X10_GLYPH_MAX_JPN 0x30FF
 
 #define FONT_10X10_FILE_KOR      "bitmap10x10_kor.bin"
@@ -132,7 +132,7 @@ bitmapfont_lut_t *bitmapfont_10x10_load(unsigned language)
 
    /* Ensure that we have the correct number
     * of bytes */
-   if (len < font_size)
+   if (len != font_size)
    {
       RARCH_WARN("[bitmap 10x10] Font file has invalid size: %s\n", font_path);
       goto error;


### PR DESCRIPTION
## Description

This PR updates the Japanese Unicode bitmap font range to enable support for CJK punctuation glyphs in RGUI. It requires the new binaries added here: https://github.com/libretro/retroarch-assets/pull/395

Many thanks to @trngaje for creating the fonts. RGUI should now have full CJK Unicode coverage.