### PR TITLE
Ensure save file and playlist compression is disabled by default

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -1044,11 +1044,7 @@ static const bool savestate_thumbnail_enable = false;
 
 /* When creating save (srm) files, compress
  * written data */
-#if defined(__WINRT__) || defined(WINAPI_FAMILY) && WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
-#define DEFAULT_SAVE_FILE_COMPRESSION true
-#else
 #define DEFAULT_SAVE_FILE_COMPRESSION false
-#endif
 
 /* When creating save state files, compress
  * written data */
@@ -1121,11 +1117,7 @@ static const int default_content_favorites_size = 200;
 #define DEFAULT_PLAYLIST_USE_OLD_FORMAT false
 
 /* When creating/updating playlists, compress written data */
-#if defined(__WINRT__) || defined(WINAPI_FAMILY) && WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
-#define DEFAULT_PLAYLIST_COMPRESSION true
-#else
 #define DEFAULT_PLAYLIST_COMPRESSION false
-#endif
 
 #ifdef HAVE_MENU
 /* Specify when to display 'core name' inline on playlist entries */


### PR DESCRIPTION
## Description

This PR ensures that save file and playlist compression is disabled by default on all platforms. Previously these we erroneously *enabled* by default on UWP platforms (where zlib compression is currently non-functional...).