### PR TITLE
Build fix.

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -260,7 +260,7 @@ static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_METAL;
 #endif
 #elif defined(HAVE_VITA2D)
 static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_VITA2D;
-#elif (defined(HAVE_OPENGL) || defined(HAVE_OPENGLES)
+#elif defined(HAVE_OPENGL) || defined(HAVE_OPENGLES)
 static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_GL;
 #elif defined(HAVE_OPENGL_CORE) && !defined(__HAIKU__)
 static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_GL_CORE;


### PR DESCRIPTION
Currently giving this error:
```
configuration.c:263:7: error: missing ')' in expression
  263 | #elif (defined(HAVE_OPENGL) || defined(HAVE_OPENGLES)
      |       ^
make: *** [Makefile:206: obj-unix/release/configuration.o] Error 1
```