### PR TITLE
(OpenDingux) Add audio/video filters to .gitlab-ci.yml artefacts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,15 +36,22 @@ build-retroarch-linux-x64:
 build-retroarch-dingux-mips32:
   image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-dingux:latest
   stage: build
+  variables:
+    MEDIA_PATH: .media
   before_script:
     - export NUMPROC=$(($(nproc)/3))
   artifacts:
     paths:
     - retroarch_rg350.opk
+    - ${MEDIA_PATH}
     expire_in: 1 month
   dependencies: []
   script:
     - "make -j$NUMPROC -f Makefile.rg350"
+    - "mkdir -p ${MEDIA_PATH}/${CI_PROJECT_NAME}/filters/audio"
+    - "mkdir -p ${MEDIA_PATH}/${CI_PROJECT_NAME}/filters/video"
+    - "cp -f libretro-common/audio/dsp_filters/*.dsp ${MEDIA_PATH}/${CI_PROJECT_NAME}/filters/audio"
+    - "cp -f gfx/video_filters/*.filt ${MEDIA_PATH}/${CI_PROJECT_NAME}/filters/video"
 
 build-static-retroarch-libnx-aarch64:
   image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-libnx-devkitpro:latest


### PR DESCRIPTION
## Description

This PR simply adds audio/video filter preset files to the list of OpenDingux artefacts generated by the new build infrastructure.
