### PR TITLE
Windows long paths fix

### DIFF
--- a/libretro-common/compat/fopen_utf8.c
+++ b/libretro-common/compat/fopen_utf8.c
@@ -38,6 +38,8 @@
 void *fopen_utf8(const char * filename, const char * mode)
 {
    const char * filename_local = NULL;
+   const char* windows_long_prefix = "\\\\?\\";
+   char long_filename[PATH_MAX_LENGTH];
 
 #if defined(LEGACY_WIN32)
    FILE             *ret = NULL;
@@ -51,10 +53,10 @@ void *fopen_utf8(const char * filename, const char * mode)
    return ret;
 #else
 #ifdef _WIN32
-   // prefix to tell Windows to bypass the ~260 characters limit in many I/O APIs
-   // https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file
-   const char * windows_long_prefix = "\\\\?\\";
-   char long_filename[PATH_MAX_LENGTH];
+   /*
+      prefix to tell Windows to bypass the ~260 characters limit in many I/O APIs
+      https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file
+   */
    snprintf(long_filename, PATH_MAX_LENGTH, "%s%s", windows_long_prefix, filename);
    filename_local = long_filename;
 #else

--- a/libretro-common/compat/fopen_utf8.c
+++ b/libretro-common/compat/fopen_utf8.c
@@ -21,6 +21,7 @@
  */
 
 #include <compat/fopen_utf8.h>
+#include <retro_miscellaneous.h>
 #include <encodings/utf.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/libretro-common/compat/fopen_utf8.c
+++ b/libretro-common/compat/fopen_utf8.c
@@ -36,9 +36,11 @@
 
 void *fopen_utf8(const char * filename, const char * mode)
 {
+   const char * filename_local = NULL;
+
 #if defined(LEGACY_WIN32)
    FILE             *ret = NULL;
-   char * filename_local = utf8_to_local_string_alloc(filename);
+   filename_local = utf8_to_local_string_alloc(filename);
 
    if (!filename_local)
       return NULL;
@@ -47,7 +49,17 @@ void *fopen_utf8(const char * filename, const char * mode)
       free(filename_local);
    return ret;
 #else
-   wchar_t * filename_w = utf8_to_utf16_string_alloc(filename);
+#ifdef _WIN32
+   // prefix to tell Windows to bypass the ~260 characters limit in many I/O APIs
+   // https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file
+   const char * windows_long_prefix = "\\\\?\\";
+   char long_filename[PATH_MAX_LENGTH];
+   snprintf(long_filename, PATH_MAX_LENGTH, "%s%s", windows_long_prefix, filename);
+   filename_local = long_filename;
+#else
+   filename_local = filename;
+#endif
+   wchar_t * filename_w = utf8_to_utf16_string_alloc(filename_local);
    wchar_t * mode_w = utf8_to_utf16_string_alloc(mode);
    FILE* ret = _wfopen(filename_w, mode_w);
    free(filename_w);


### PR DESCRIPTION
## Description

This fixes some file I/O failures on Windows when paths is longer than 260 characters.
I've used the prefix trick described in https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file section "Win32 File Namespaces".
The thing is, since I have no idea how RetroArch is designed/supposed to work, if there are places *not* using fopen_utf8, then there are some issues left.
Tested with a couple of cores and roms in deeply nested paths, only on Windows 10. No clue about effect on Windows 7 or 8.

## Related Issues

This fixes probably at least some part of #11704 .