### PR TITLE
Fix undeclared compile error

### DIFF
--- a/retroarch_data.h
+++ b/retroarch_data.h
@@ -2665,7 +2665,9 @@ static bool command_write_ram(const char *arg);
 #endif
 
 static const struct cmd_action_map action_map[] = {
+#if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)
    { "SET_SHADER",       command_set_shader,       "<shader path>" },
+#endif
    { "VERSION",          command_version,          "No argument"},
    { "GET_STATUS",       command_get_status,       "No argument" },
    { "GET_CONFIG_PARAM", command_get_config_param, "<param name>" },


### PR DESCRIPTION
Retroarch_data_h:2668:26: error: 'command_set_shader' undeclared here (not in function); do you mean 'command_get_ststus'?
    { "SET_SHADER",         command_set_shader,        "<shader path>" }

@twinaphex 
@hunterk 

## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

[Description of the pull request, detail any issues you are fixing or any features you are implementing]

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
