### PR TITLE
Android NDK R22 Build Fix

### DIFF
--- a/deps/glslang/glslang/glslang/Include/PoolAlloc.h
+++ b/deps/glslang/glslang/glslang/Include/PoolAlloc.h
@@ -304,7 +304,6 @@ public:
     size_type max_size() const { return static_cast<size_type>(-1) / sizeof(T); }
     size_type max_size(int size) const { return static_cast<size_type>(-1) / size; }
 
-    void setAllocator(TPoolAllocator* a) { allocator = *a; }
     TPoolAllocator& getAllocator() const { return allocator; }
 
 protected:


### PR DESCRIPTION
The newer clang enforces things gcc and older versions of clang do not. See the commit message for more details.