### PR TITLE
Runahead instance windows fix

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -18460,6 +18460,13 @@ static char *get_temp_directory_alloc(const char *override_dir)
    path = utf16_to_utf8_string_alloc(wide_str);
    free(wide_str);
 #endif
+   /*
+     Windows seems to be adding (back)slash at the end of the path...
+     This can cause issues when concatenating path separators and some I/O apis, so we get rid of it
+   */
+   path_length = strlen(path);
+   if (path[path_length - 1] == '\\')
+      path[path_length - 1] = 0;
 #else
 #if defined ANDROID
    src     = override_dir;


### PR DESCRIPTION
## Description

This fixes #11746.

In get_temp_directory_alloc, Windows seems to be the only OS ending the path with (back)slashes...
Unfortunately then in copy_core_to_temp_file we concatenate the path separator to the end and this break things...
So, for Windows, I simply removed the ending backslash.


