### PR TITLE
Explicitly specify NDK version in build.gradle

### DIFF
--- a/pkg/android/phoenix/build.gradle
+++ b/pkg/android/phoenix/build.gradle
@@ -27,6 +27,7 @@ apply plugin: 'com.android.application'
 android {
   compileSdkVersion 29
   buildToolsVersion "29.0.3"
+  ndkVersion '21.3.6528147'
 
   flavorDimensions "variant"
 


### PR DESCRIPTION
## Description

This prevents CI from redownloading the NDK on each build.

## Reviewers

@twinaphex @webgeek1234 