### PR TITLE
MSVC2019 project: Set SDK version to 10.0 (latest version)

### DIFF
--- a/pkg/msvc/msvc-2019/RetroArch-msvc2019.vcxproj
+++ b/pkg/msvc/msvc-2019/RetroArch-msvc2019.vcxproj
@@ -134,7 +134,7 @@
     <ProjectGuid>{27FF7CE1-4059-4AA1-8062-FD529560FA54}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>RetroArchmsvc2015</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
One change, VS2019 project file now targets SDK 10.0 (latest available version) instead of 10.0.18362.0.