### PR TITLE
Android Play Store builds: remove predefined environment variables in init_modules.sh

### DIFF
--- a/pkg/android/phoenix/init_modules.sh
+++ b/pkg/android/phoenix/init_modules.sh
@@ -3,12 +3,7 @@
 # This script generates Gradle modules for each Android core,
 # so that they can be served by Google Play as Dynamic Feature Modules.
 # Run "./init_modules.sh" to generate modules, or "./init_modules.sh clean" to remove them
-
-# These paths assume that this script is running inside libretro-super,
-# and that the compiled Android cores are available while this script is run
-RECIPES_PATH="../../../../recipes/android"
-INFO_PATH="../../../../dist/info"
-CORES_PATH="../../../../dist/android"
+# NOTE: Requires RECIPES_PATH, INFO_PATH, and CORES_PATH variables to be set previously
 
 # Get the list of Android cores to generate modules for
 CORES_LIST=$(cat module_list.txt)


### PR DESCRIPTION
## Description

This removes predefined environment variables in init_modules.sh (used when building the Play Store variant of the Android app).  These will instead be set inside the .gitlab-ci.yml file.

## Reviewers

@twinaphex 