### PR TITLE
Android: Sync versionCode with actual value in the Play Store

### DIFF
--- a/pkg/android/phoenix/AndroidManifest.xml
+++ b/pkg/android/phoenix/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
     package="com.retroarch"
-    android:versionCode="1556806359"
+    android:versionCode="1597175229"
     android:versionName="1.9.0"
     android:installLocation="internalOnly">
     <uses-feature android:glEsVersion="0x00020000" />


### PR DESCRIPTION
## Description

The versionCode inside the Android manifest is currently out of sync with what the versionCode actually is inside the APK currently on the Play Store.  Because we are no longer running the `version_increment.py` script for Play Store builds, this will result in an upload error once the next stable version is deployed.  This PR syncs the versionCode with the actual value so that stable release uploads will succeed.

## Reviewers

@twinaphex 