### PR TITLE
qt: attempt to fix memory leak in shader panel

### DIFF
--- a/ui/drivers/qt/shaderparamsdialog.cpp
+++ b/ui/drivers/qt/shaderparamsdialog.cpp
@@ -166,7 +166,7 @@ void ShaderParamsDialog::clearLayout()
    if (m_scrollArea)
    {
       foreach (QObject *obj, children())
-         obj->deleteLater();
+         delete obj;
    }
 
    m_layout = new QVBoxLayout();


### PR DESCRIPTION
This seems to fix the huge slowdown and memory usage that happens after loading many shaders in succession with the shader panel left opened in qt.
https://github.com/libretro/RetroArch/issues/11646

Memory usage goes up a bit, but now it stabilizes a lot lower than before and doesn't cause huge slowdowns on shader change or panel window resizing.

tested on win7 x64