### PR TITLE
(.gitlab-ci.yml) Use MXE build container for windows-x64 builds (WIP)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,7 @@ stages:
   - trigger-static-cores
 
 build-retroarch-windows-x64:
+  image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-mxe-win64-cross:gcc10
   stage: build
   variables:
     MEDIA_PATH: .media
@@ -19,16 +20,15 @@ build-retroarch-windows-x64:
     expire_in: 1 month
   dependencies: []
   script:
-    - "./configure --host=x86_64-w64-mingw32"
+    - "MOC=/usr/lib/mxe/usr/x86_64-w64-mingw32.shared/qt5/bin/moc ./configure --host=x86_64-w64-mingw32.shared"
     - "make -j$NUMPROC"
-    - "mv retroarch retroarch.exe"
     - "mkdir -p ${MEDIA_PATH}/${CI_PROJECT_NAME}/filters/audio"
     - "mkdir -p ${MEDIA_PATH}/${CI_PROJECT_NAME}/filters/video"
     - "mkdir -p ${MEDIA_PATH}/${CI_PROJECT_NAME}/pkg"
-    - "cd libretro-common/audio/dsp_filters && make -j$NUMPROC platform=win compiler=x86_64-w64-mingw32-gcc build=release && make -j$NUMPROC platform=win compiler=x86_64-w64-mingw32-gcc build=release strip && cd -"
+    - "cd libretro-common/audio/dsp_filters && make -j$NUMPROC platform=win compiler=x86_64-w64-mingw32.static-gcc build=release && make -j$NUMPROC platform=win compiler=x86_64-w64-mingw32.static-gcc build=release strip && cd -"
     - "cp -f libretro-common/audio/dsp_filters/*.dll ${MEDIA_PATH}/${CI_PROJECT_NAME}/filters/audio"
     - "cp -f libretro-common/audio/dsp_filters/*.dsp ${MEDIA_PATH}/${CI_PROJECT_NAME}/filters/audio"
-    - "cd gfx/video_filters && make -j$NUMPROC platform=win compiler=x86_64-w64-mingw32-gcc build=release && make -j$NUMPROC platform=win compiler=x86_64-w64-mingw32-gcc build=release strip && cd -"
+    - "cd gfx/video_filters && make -j$NUMPROC platform=win compiler=x86_64-w64-mingw32.static-gcc build=release && make -j$NUMPROC platform=win compiler=x86_64-w64-mingw32.static-gcc build=release strip && cd -"
     - "cp -f gfx/video_filters/*.dll ${MEDIA_PATH}/${CI_PROJECT_NAME}/filters/video"
     - "cp -f gfx/video_filters/*.filt ${MEDIA_PATH}/${CI_PROJECT_NAME}/filters/video"
     - "cp -f retroarch.cfg ${MEDIA_PATH}/${CI_PROJECT_NAME}/pkg/retroarch.default.cfg"

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -136,7 +136,7 @@ if [ "$HAVE_EGL" = 'yes' ]; then
    EGL_LIBS="$EGL_LIBS $EXTRA_GL_LIBS"
 fi
 
-check_lib '' SSA -lass ass_library_init
+check_lib '' SSA '-lfribidi -lass' ass_library_init
 check_lib '' SSE '-msse -msse2'
 check_pkgconf EXYNOS libdrm_exynos
 


### PR DESCRIPTION
## Description

This PR switches the gitlab CI windows-x64 build over to the new MXE build container (this provides the additional required RetroArch dependencies that are currently missing from the regular mingw container).

DO NOT MERGE until the MXE container itself (https://git.libretro.com/libretro-infrastructure/libretro-build-mxe-win64-cross) has finished building, and has been tested.