### PR TITLE
Fix udev rumble

### DIFF
--- a/input/drivers_joypad/udev_joypad.c
+++ b/input/drivers_joypad/udev_joypad.c
@@ -653,7 +653,7 @@ static int16_t udev_joypad_axis_state(
       int16_t val = pad->axes[AXIS_NEG_GET(joyaxis)];
       /* Deal with analog triggers that report -32767 to 32767 */
       if ((
-               (AXIS_NEG_GET(joyaxis) == ABS_Z) || 
+               (AXIS_NEG_GET(joyaxis) == ABS_Z) ||
                (AXIS_NEG_GET(joyaxis) == ABS_RZ))
             && (pad->neg_trigger[AXIS_NEG_GET(joyaxis)]))
          val = (val + 0x7fff) / 2;
@@ -665,7 +665,7 @@ static int16_t udev_joypad_axis_state(
       int16_t val = pad->axes[AXIS_POS_GET(joyaxis)];
       /* Deal with analog triggers that report -32767 to 32767 */
       if ((
-               (AXIS_POS_GET(joyaxis) == ABS_Z) || 
+               (AXIS_POS_GET(joyaxis) == ABS_Z) ||
                (AXIS_POS_GET(joyaxis) == ABS_RZ))
             && (pad->neg_trigger[AXIS_POS_GET(joyaxis)]))
          val = (val + 0x7fff) / 2;
@@ -704,12 +704,12 @@ static int16_t udev_joypad_state(
       const uint32_t joyaxis = (binds[i].joyaxis != AXIS_NONE)
          ? binds[i].joyaxis : joypad_info->auto_binds[i].joyaxis;
       if (
-               (uint16_t)joykey != NO_BTN 
+               (uint16_t)joykey != NO_BTN
             && udev_joypad_button_state(pad, port_idx, (uint16_t)joykey)
          )
          ret |= ( 1 << i);
       else if (joyaxis != AXIS_NONE &&
-            ((float)abs(udev_joypad_axis_state(pad, port_idx, joyaxis)) 
+            ((float)abs(udev_joypad_axis_state(pad, port_idx, joyaxis))
              / 0x8000) > joypad_info->axis_threshold)
          ret |= (1 << i);
    }

--- a/input/drivers_joypad/udev_joypad.c
+++ b/input/drivers_joypad/udev_joypad.c
@@ -386,9 +386,16 @@ static bool udev_set_rumble(unsigned i,
    {
       /* Create new or update old playing state. */
       struct ff_effect e = {0};
+      /* This defines the length of the effect and
+         the delay before playing it. This means there
+         is a limit on the maximum vibration time, but
+         it's hopefully sufficient for most cases. Maybe
+         there's a better way? */
+      struct ff_replay replay = {0xffff, 0};
 
       e.type = FF_RUMBLE;
       e.id   = old_effect;
+      e.replay = replay;
 
       switch (effect)
       {


### PR DESCRIPTION
Rumble was not working for me. I learnt a bit about how evdev works and it seems like you need to set a replay which defines how long the effect is (previously we set it to 0). This means there's a maximum length to the rumble effect which feels wrong.
    
When we do `play.value = !!strength;` we're setting the number of times for the effect to repeat, which works fine because the effect stops when we set it to 0.
    
It doesn't feel quite right to me playing e.g. Goldeneye but I've not played on real hardware for a while.
    
I'm hoping someone is more familiar with evdev and can suggest a better approach.