### PR TITLE
Shaders fix for duplicate parameters loading bug

### DIFF
--- a/gfx/drivers_shader/shader_gl_core.cpp
+++ b/gfx/drivers_shader/shader_gl_core.cpp
@@ -2236,6 +2236,10 @@ gl_core_filter_chain_t *gl_core_filter_chain_create_from_preset(
             video_shader_parameter *param = &shader->parameters[shader->num_parameters];
             strlcpy(param->id, meta_param.id.c_str(), sizeof(param->id));
             strlcpy(param->desc, meta_param.desc.c_str(), sizeof(param->desc));
+            param->initial = meta_param.initial;
+            param->minimum = meta_param.minimum;
+            param->maximum = meta_param.maximum;
+            param->step    = meta_param.step;
             chain->add_parameter(i, shader->num_parameters, meta_param.id);
             shader->num_parameters++;
          }

--- a/gfx/drivers_shader/shader_vulkan.cpp
+++ b/gfx/drivers_shader/shader_vulkan.cpp
@@ -2646,6 +2646,10 @@ vulkan_filter_chain_t *vulkan_filter_chain_create_from_preset(
             video_shader_parameter *param = &shader->parameters[shader->num_parameters];
             strlcpy(param->id, meta_param.id.c_str(), sizeof(param->id));
             strlcpy(param->desc, meta_param.desc.c_str(), sizeof(param->desc));
+            param->initial = meta_param.initial;
+            param->minimum = meta_param.minimum;
+            param->maximum = meta_param.maximum;
+            param->step    = meta_param.step;
             chain->add_parameter(i, shader->num_parameters, meta_param.id);
             shader->num_parameters++;
          }


### PR DESCRIPTION
## Description

Fixes a bug created in the last Shader Loading PR. 

The bug was causing shaders to report duplicate parameters with different values when the values were actually the same. And causing the shader not to load.

It was fixed by putting back a bit of code which was removed in the last PR.

## Reviewers

@twinaphex 
