### PR TITLE
Android (Play Store): swap DOSBox-SVN core for DOSBox Pure

### DIFF
--- a/pkg/android/phoenix/module_list.txt
+++ b/pkg/android/phoenix/module_list.txt
@@ -6,7 +6,7 @@ cannonball
 cap32
 crocods
 dinothawr
-dosbox_svn
+dosbox_pure
 ecwolf
 fbneo
 fceumm


### PR DESCRIPTION
## Description

Swaps DOSBox-SVN with DOSBox Pure for the Play Store builds.

## Reviewers

@twinaphex 