### PR TITLE
Add rescap for run full trust (needed to make broadFileSystemAccess work on Xbox)

### DIFF
--- a/pkg/msvc-uwp/RetroArch-msvc2017-UWP/Package.appxmanifest
+++ b/pkg/msvc-uwp/RetroArch-msvc2017-UWP/Package.appxmanifest
@@ -25,6 +25,7 @@
   <Capabilities>
     <Capability Name="internetClient" />
     <Capability Name="internetClientServer" />
+    <rescap:Capability Name="runFullTrust"/>
     <rescap:Capability Name="broadFileSystemAccess" />
   </Capabilities>
 </Package>


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

Add the runFullTrust rescap in order to make the broadFileSystemAccess capability work on Xbox instead of being disabled as suggested by MS UWP docs
