### PR TITLE
Play Store: download cores at app install time on Android TV devices

### DIFF
--- a/pkg/android/phoenix/AndroidManifest.xml
+++ b/pkg/android/phoenix/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
     package="com.retroarch"
-    android:versionCode="1597175230"
+    android:versionCode="1597175231"
     android:versionName="1.9.0"
     android:installLocation="internalOnly">
     <uses-feature android:glEsVersion="0x00020000" />

--- a/pkg/android/phoenix/module_template/AndroidManifest.xml
+++ b/pkg/android/phoenix/module_template/AndroidManifest.xml
@@ -6,6 +6,11 @@
     <dist:module dist:title="@string/%CORE_NAME%">
         <dist:delivery>
             <dist:on-demand />
+            <dist:install-time>
+                <dist:conditions>
+                    <dist:device-feature dist:name="android.software.leanback"/>
+                </dist:conditions>
+            </dist:install-time>
         </dist:delivery>
         <dist:fusing dist:include="true" />
     </dist:module>


### PR DESCRIPTION
## Description

Fixes issues with downloading cores on Android TV. On-demand module downloads are apparently unsupported on Android TV, so we need to fetch modules at install-time instead on those devices.

## Reviewers

@twinaphex 