### PR TITLE
Fix winmm midi driver hanging on content closing

### DIFF
--- a/midi/drivers/winmm_midi.c
+++ b/midi/drivers/winmm_midi.c
@@ -17,7 +17,7 @@
 
 #include <libretro.h>
 #include <lists/string_list.h>
-#include <verbosity.h>
+#include "../../verbosity.h"
 #include <string/stdstring.h>
 
 #include "../midi_driver.h"
@@ -481,7 +481,6 @@ static void winmm_midi_free(void *p)
 
    if (d->out_dev)
    {
-      midiStreamStop(d->out_dev);
       winmm_midi_free_output_buffers(d->out_dev, d->out_bufs);
       midiStreamClose(d->out_dev);
    }


### PR DESCRIPTION
## Description

midiStreamStop can freeze the process when there has been a NOTE-ON message without a corresponding NOTE-OFF.
Just removing the call to midiStreamStop and letting the midiStreamClose below it do the entire stopping and closing fixes that.

Tested on Windows 10 with winmm MIDI driver and the OS default "Microsoft GS Wavetable Synth" software MIDI output device in an in-development version of DOSBox Pure core which can optionally use the frontend MIDI driver.

## Related Issues

## Related Pull Requests

## Reviewers