### PR TITLE
(3DS) Rework buildbot url

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -1401,7 +1401,7 @@ static const bool enable_device_vibration    = false;
 #elif defined(HAVE_LIBNX)
 #define DEFAULT_BUILDBOT_SERVER_URL "http://buildbot.libretro.com/nightly/nintendo/switch/libnx/latest/"
 #elif defined(_3DS)
-#define DEFAULT_BUILDBOT_SERVER_URL "http://buildbot.libretro.com/nightly/nintendo/3ds/latest/"
+#define DEFAULT_BUILDBOT_SERVER_URL envIsHomebrew() ? "http://buildbot.libretro.com/nightly/nintendo/3ds/latest/3dsx/" : "http://buildbot.libretro.com/nightly/nintendo/3ds/latest/cia/"
 #else
 #define DEFAULT_BUILDBOT_SERVER_URL ""
 #endif

--- a/configuration.c
+++ b/configuration.c
@@ -2351,13 +2351,10 @@ void config_set_defaults(void *data)
             retro_assert(j == keyval->id);
       }
    }
-#ifdef _3DS
-   configuration_set_string(settings,
-         settings->paths.network_buildbot_url, envIsHomebrew() ? DEFAULT_BUILDBOT_SERVER_URL"3dsx/" : DEFAULT_BUILDBOT_SERVER_URL"cia/");
-#else
+
    configuration_set_string(settings,
          settings->paths.network_buildbot_url, DEFAULT_BUILDBOT_SERVER_URL);
-#endif
+
    configuration_set_string(settings,
          settings->paths.network_buildbot_assets_url,
          DEFAULT_BUILDBOT_ASSETS_SERVER_URL);

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -17361,20 +17361,7 @@ static bool setting_append_list(
          if (!play_feature_delivery_enabled())
 #endif
          {
-#if defined(_3DS)
-            CONFIG_STRING(
-                  list, list_info,
-                  settings->paths.network_buildbot_url,
-                  sizeof(settings->paths.network_buildbot_url),
-                  MENU_ENUM_LABEL_CORE_UPDATER_BUILDBOT_URL,
-                  MENU_ENUM_LABEL_VALUE_CORE_UPDATER_BUILDBOT_URL,
-                  envIsHomebrew() ? DEFAULT_BUILDBOT_SERVER_URL"3dsx/" : DEFAULT_BUILDBOT_SERVER_URL"cia/",
-                  &group_info,
-                  &subgroup_info,
-                  parent_group,
-                  general_write_handler,
-                  general_read_handler);
-#else
+
             CONFIG_STRING(
                   list, list_info,
                   settings->paths.network_buildbot_url,
@@ -17387,7 +17374,7 @@ static bool setting_append_list(
                   parent_group,
                   general_write_handler,
                   general_read_handler);
-#endif
+
             SETTINGS_DATA_LIST_CURRENT_ADD_FLAGS(list, list_info, SD_FLAG_ALLOW_INPUT);
             (*list)[list_info->index - 1].ui_type       = ST_UI_TYPE_STRING_LINE_EDIT;
             (*list)[list_info->index - 1].action_start  = setting_generic_action_start_default;


### PR DESCRIPTION
Set `DEFAULT_BUILDBOT_SERVER_URL' based on the running environment.

Related PR: https://github.com/libretro/RetroArch/pull/11806