### PR TITLE
Android: switch non-Play Store variants back to targetSdkVersion 28

### DIFF
--- a/pkg/android/phoenix/build.gradle
+++ b/pkg/android/phoenix/build.gradle
@@ -38,7 +38,7 @@ android {
         arguments "-j${Runtime.runtime.availableProcessors()}"
       }
     }
-    targetSdkVersion 29
+    targetSdkVersion 28
     versionCode System.currentTimeSeconds().toInteger()
     versionName "${getManifestAttribute("versionName")}_GIT"
   }
@@ -72,6 +72,7 @@ android {
     }
     playStoreNormal {
       minSdkVersion 21
+      targetSdkVersion 29
       versionCode getPlayStoreVersionCode()
       versionName getPlayStoreVersionName()
 
@@ -82,6 +83,7 @@ android {
     }
     playStorePlus {
       minSdkVersion 26
+      targetSdkVersion 29
       versionCode getPlayStoreVersionCode()
       versionName getPlayStoreVersionName()
 


### PR DESCRIPTION
## Description

Potential band-aid fix for issues with certain Android 11 devices not being able to access data from the SD card.

## Reviewers

@twinaphex 