### PR TITLE
(3DS) Update error applet

### DIFF
--- a/ctr/ctr_debug.h
+++ b/ctr/ctr_debug.h
@@ -8,6 +8,7 @@
 extern "C" {
 #endif
 void wait_for_input(void);
+void error_and_quit(const char* errorStr);
 void dump_result_value(Result val);
 #ifdef __cplusplus
 }

--- a/ctr/ctr_system.c
+++ b/ctr/ctr_system.c
@@ -322,6 +322,20 @@ void wait_for_input(void)
    }
 }
 
+void error_and_quit(const char* errorStr)
+{
+   errorConf error;
+
+   gfxInitDefault();
+
+   errorInit(&error, ERROR_TEXT, CFG_LANGUAGE_EN);
+   errorText(&error, errorStr);
+   errorDisp(&error);
+
+   gfxExit();
+   exit(0);
+}
+
 long sysconf(int name)
 {
    switch (name)

--- a/ctr/exec-3dsx/exec_cia.c
+++ b/ctr/exec-3dsx/exec_cia.c
@@ -3,6 +3,7 @@
 #include <errno.h>
 #include <sys/stat.h>
 #include <3ds.h>
+#include "ctr/ctr_debug.h"
 
 #define FILE_CHUNK_SIZE 4096
 
@@ -13,16 +14,6 @@ typedef struct
 }ciaParam;
 
 char argvHmac[0x20] = {0x1d, 0x78, 0xff, 0xb9, 0xc5, 0xbc, 0x78, 0xb7, 0xac, 0x29, 0x1d, 0x3e, 0x16, 0xd0, 0xcf, 0x53, 0xef, 0x12, 0x58, 0x83, 0xb6, 0x9e, 0x2f, 0x79, 0x47, 0xf9, 0x35, 0x61, 0xeb, 0x50, 0xd7, 0x67};
-
-static void errorAndQuit(const char* errorStr)
-{
-   errorConf error;
-
-   errorInit(&error, ERROR_TEXT, CFG_LANGUAGE_EN);
-   errorText(&error, errorStr);
-   errorDisp(&error);
-   exit(0);
-}
 
 static int isCiaInstalled(u64 titleId, u16 version)
 {
@@ -164,30 +155,30 @@ int exec_cia(const char* path, const char** args)
             ARCHIVE_SDMC, fsMakePath(PATH_EMPTY, ""));
 
       if (R_FAILED(res))
-         errorAndQuit("Cant open SD FS archive.");
+         error_and_quit("Cant open SD FS archive.");
 
       res = FSUSER_OpenFile(&ciaFile,
             ciaArchive, fsMakePath(PATH_ASCII, path + 5/*skip "sdmc:"*/),
             FS_OPEN_READ, 0);
       if (R_FAILED(res))
-         errorAndQuit("Cant open CIA file.");
+         error_and_quit("Cant open CIA file.");
 
       res = AM_GetCiaFileInfo(MEDIATYPE_SD, &ciaInfo, ciaFile);
       if (R_FAILED(res))
-         errorAndQuit("Cant get CIA file info.");
+         error_and_quit("Cant get CIA file info.");
 
       ciaInstalled = isCiaInstalled(ciaInfo.titleID, ciaInfo.version);
       if (ciaInstalled == -1)
       {
          /* error */
-         errorAndQuit("Could not read title ID list.");
+         error_and_quit("Could not read title ID list.");
       }
       else if (ciaInstalled == 0)
       {
          /* not installed */
          int error = installCia(ciaFile);
          if (error == -1)
-            errorAndQuit("Cant install CIA.");
+            error_and_quit("Cant install CIA.");
       }
 
       FSFILE_Close(ciaFile);
@@ -207,12 +198,12 @@ int exec_cia(const char* path, const char** args)
 
       res = APT_PrepareToDoApplicationJump(0, ciaInfo.titleID, 0x1);
       if (R_FAILED(res))
-         errorAndQuit("CIA cant run, cant prepare.");
+         error_and_quit("CIA cant run, cant prepare.");
 
       res = APT_DoApplicationJump(&param, sizeof(param.argc) 
             + argsLength, argvHmac);
       if (R_FAILED(res))
-         errorAndQuit("CIA cant run, cant jump.");
+         error_and_quit("CIA cant run, cant jump.");
 
       /* wait for application jump, for some reason its not instant */
       while(1);

--- a/frontend/drivers/platform_ctr.c
+++ b/frontend/drivers/platform_ctr.c
@@ -244,10 +244,7 @@ static void frontend_ctr_exec(const char* path, bool should_load_game)
 
          if (core_path[0] == '\0')
          {
-            errorInit(&error_dialog, ERROR_TEXT, CFG_LANGUAGE_EN);
-            errorText(&error_dialog, "There are no cores installed, install a core to continue.");
-            errorDisp(&error_dialog);
-            exit(0);
+            error_and_quit("There are no cores installed, install a core to continue.");
          }
       }
 #endif
@@ -268,13 +265,11 @@ static void frontend_ctr_exec(const char* path, bool should_load_game)
          exec_cia(path, arg_data);
       }
 
-      errorInit(&error_dialog, ERROR_TEXT, CFG_LANGUAGE_EN);
+      /* couldnt launch new core, but context
+      is corrupt so we have to quit */
       snprintf(error_string, sizeof(error_string),
             "Can't launch core:%s", path);
-      errorText(&error_dialog, error_string);
-      errorDisp(&error_dialog);
-      exit(0); /* couldnt launch new core, but context 
-                  is corrupt so we have to quit */
+      error_and_quit(error_string);
    }
 }
 


### PR DESCRIPTION
This prevents crashes caused by calling the system error applet without graphics being initialized.
It will show the 3DS system error with information than quit.

- It handles critical errors during .cia installation
and
- Launching the `salamander`/`dummy` build without having any core available to load

_Note:_
Launching the applet without graphics being initialized did not crash using `libctru` <= v1.6