### PR TITLE
drm_go2: Dynamic resolution support

### DIFF
--- a/gfx/drivers_context/drm_go2_ctx.c
+++ b/gfx/drivers_context/drm_go2_ctx.c
@@ -118,12 +118,12 @@ static void *gfx_ctx_go2_drm_init(void *video_driver)
    if (!drm)
       return NULL;
 
-   drm->native_width  = 480;
-   drm->native_height = 320;
-
    drm->display       = go2_display_create();
    drm->presenter     = go2_presenter_create(drm->display,
          DRM_FORMAT_RGB565, 0xff000000, true);
+
+   drm->native_width  = go2_display_height_get(drm->display);
+   drm->native_height = go2_display_width_get(drm->display);
 
    return drm;
 }
@@ -311,8 +311,8 @@ static void gfx_ctx_go2_drm_swap_buffers(void *data)
    if (out_w != src_w || out_h != src_h)
    {
        out_w = out_h * video_driver_get_aspect_ratio();
-       out_w = (out_w > 480) ? 480 : out_w;
-       out_x = (480 - out_w) / 2;
+       out_w = (out_w > drm->native_width) ? drm->native_width : out_w;
+       out_x = (drm->native_width - out_w) / 2;
        if (out_x < 0)
            out_x = 0;
     }


### PR DESCRIPTION
- Remove hardcoded values for width and height and query from drm
  context instead
