### PR TITLE
Core run init failure forces return to menu

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -34536,7 +34536,7 @@ bool retroarch_main_init(int argc, char *argv[])
    {
       RARCH_ERR("%s: \"%s\"\n",
             msg_hash_to_str(MSG_FATAL_ERROR_RECEIVED_IN), p_rarch->error_string);
-      return false;
+      goto error;
    }
 
    p_rarch->rarch_error_on_init = true;
@@ -36799,7 +36799,15 @@ static enum runloop_state runloop_check_state(
       }
 
       if (!menu_driver_iterate(&iter, current_time))
-         retroarch_menu_running_finished(false);
+      {
+         if (p_rarch->rarch_error_on_init)
+         {
+            content_ctx_info_t content_info = {0};
+            task_push_start_dummy_core(&content_info);
+         }
+         else
+            retroarch_menu_running_finished(false);
+      }
 
       if (focused || !p_rarch->runloop_idle)
       {


### PR DESCRIPTION
## Description

Gracefully loads dummy core instead of continuing running and performs lots of unexpected bad behavior.

ex. Run a threaded audio core (ChaiLove) with bad driver (wasapi). Although code triggers a sjlj exception and log claims to throw a fatal error, core continues running anyway and starts doing lots of crazy weird stuff. Going back to menu can crash RA while doing more amazing amount of evil damage.

## Reviewers

@SimpleTease, @twinaphex