### PR TITLE
Android: fix crash on latest nightlies (non-Play Store)

### DIFF
--- a/pkg/android/phoenix-common/src/com/retroarch/browser/retroactivity/RetroActivityCommon.java
+++ b/pkg/android/phoenix-common/src/com/retroarch/browser/retroactivity/RetroActivityCommon.java
@@ -545,6 +545,8 @@ public class RetroActivityCommon extends NativeActivity
    * are installed to.
    */
   private void updateSymlinks() {
+    if(!isPlayStoreBuild()) return;
+
     traverseFilesystem(getFilesDir());
     traverseFilesystem(new File(getApplicationInfo().nativeLibraryDir));
   }


### PR DESCRIPTION
## Description

The last couple of Android nightlies are crashing on startup.  This is due to the symlinking logic for Play Store cores being run on non-Play Store builds unintentionally, which is expecting a resources that the non-Play Store builds don't include.

This PR fixes the issue by not running the symlinking logic on non-Play Store builds.

## Reviewers

@twinaphex 
