### PR TITLE
Remove the path_is_valid() call when loading textures

### DIFF
--- a/gfx/gfx_display.c
+++ b/gfx/gfx_display.c
@@ -1489,9 +1489,6 @@ bool gfx_display_reset_textures_list(
 
    fill_pathname_join(texpath, iconpath, texture_path, sizeof(texpath));
 
-   if (!path_is_valid(texpath))
-      return false;
-
    if (!image_texture_load(&ti, texpath))
       return false;
 


### PR DESCRIPTION
## Description

The `path_is_valid()` call ends up invoking `stat()`, which is unpredictable.
It's practically free when implemented by an operating system (Linux, Windows),
but on embedded systems it can be problematic.

In the case of the Wii U, the stat() call actually ends up taking longer than
the file I/O. And `image_texture_load()` already handles a "file not found"
case, so the stat() call ends up just being a waste of time.

Removing this reduces the texture load time from ~210-250ms down to 60-65ms
on average.

## Reviewers

@twinaphex 
