### PR TITLE
Fix Qt plugin path detection when using Qt < 5.6.0

### DIFF
--- a/ui/drivers/qt/ui_qt_application.cpp
+++ b/ui/drivers/qt/ui_qt_application.cpp
@@ -101,9 +101,10 @@ static void* ui_application_qt_initialize(void)
    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
 
-   QApplication::setStyle("fusion");
-
+   /* Create QApplication() before calling QApplication::setStyle()
+    * to ensure that plugin path is determined correctly */
    ui_application.app = new QApplication(app_argc, app_argv);
+   QApplication::setStyle("fusion");
    ui_application.app->setOrganizationName("libretro");
    ui_application.app->setApplicationName("RetroArch");
    ui_application.app->setApplicationVersion(PACKAGE_VERSION);


### PR DESCRIPTION
## Description

As reported here: https://bugreports.qt.io/browse/QTBUG-38598, when using Qt version lower than 5.6.0, calling `QApplication::setStyle()` before creating the `QApplication()` itself breaks Qt plugin detection. Since the existing `ui_qt_application.cpp` code does exactly this, it means that Qt support must be disabled in our official Linux AppImages (build using Ubuntu Xenial, with Qt 5.5.1)

This PR fixes the issue, by calling `setStyle()` and `QApplication()` in the correct order.