### PR TITLE
Minor cleanup (screenshot notifications)

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -829,12 +829,6 @@ static const bool audio_enable_menu_bgm    = false;
 #define DEFAULT_NOTIFICATION_SHOW_AUTOCONFIG true
 #endif
 
-#if defined(HAVE_SCREENSHOTS)
-#define DEFAULT_NOTIFICATION_SHOW_SCREENSHOT_TAKEN true
-#else
-#define DEFAULT_NOTIFICATION_SHOW_SCREENSHOT_TAKEN false
-#endif
-
 /* Display a notification when cheats are being
  * applied */
 #define DEFAULT_NOTIFICATION_SHOW_CHEATS_APPLIED true
@@ -855,6 +849,7 @@ static const bool audio_enable_menu_bgm    = false;
  * content */
 #define DEFAULT_NOTIFICATION_SHOW_FAST_FORWARD true
 
+#if defined(HAVE_SCREENSHOTS)
 /*Display a notification when taking a screenshot*/
 #define DEFAULT_NOTIFICATION_SHOW_SCREENSHOT true
 
@@ -864,6 +859,7 @@ static const bool audio_enable_menu_bgm    = false;
 /* Display a white flashing effect with the desired 
  * duration when taking a screenshot*/
 #define DEFAULT_NOTIFICATION_SHOW_SCREENSHOT_FLASH 0
+#endif
 
 /*Display a notification when setting the refresh rate*/
 #define DEFAULT_NOTIFICATION_SHOW_REFRESH_RATE true

--- a/configuration.h
+++ b/configuration.h
@@ -207,8 +207,10 @@ typedef struct settings
       unsigned video_overscan_correction_bottom;
 #endif
       unsigned video_shader_delay;
+#ifdef HAVE_SCREENSHOTS
       unsigned notification_show_screenshot_duration;
       unsigned notification_show_screenshot_flash;
+#endif
 
       /* Accessibility */
       unsigned accessibility_narrator_speech_speed;
@@ -544,7 +546,9 @@ typedef struct settings
       bool notification_show_config_override_load;
       bool notification_show_set_initial_disk;
       bool notification_show_fast_forward;
+#ifdef HAVE_SCREENSHOTS
       bool notification_show_screenshot;
+#endif
       bool notification_show_refresh_rate;
       bool menu_widget_scale_auto;
       bool menu_show_start_screen;


### PR DESCRIPTION
## Description

While working on the PR for the Refresh Rate onscreen message, I noticed a few leftovers dating back to when I added the toggles for the Screenshot-related notifications. 

This PR provides a minor cleanup:

- `DEFAULT_NOTIFICATION_SHOW_SCREENSHOT_TAKEN` (unused) was removed from `config.def.h`;
- I also added a few more `#ifdef HAVE_SCREENSHOTS`.
