### PR TITLE
configuration: fix default configuration if --config specified

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -2956,7 +2956,16 @@ static bool config_load_file(global_t *global,
    struct config_size_setting *size_settings       = populate_settings_size  (settings, &size_settings_size);
    struct config_array_setting *array_settings     = populate_settings_array (settings, &array_settings_size);
    struct config_path_setting *path_settings       = populate_settings_path  (settings, &path_settings_size);
-   config_file_t *conf                             = path ? config_file_new_from_path_to_string(path) : open_default_config_file();
+   config_file_t *conf                             = NULL;
+
+   if (path && path_is_valid(path))
+   {
+      conf = config_file_new_from_path_to_string(path);
+   }
+   else
+   {
+      conf = open_default_config_file();
+   }
 
    tmp_str[0] = '\0';
 


### PR DESCRIPTION
```
valadaa48Today at 3:29 PM
is it expected that if one uses --config to specify a particular retroarch.cfg file to use that it doesn't generate a config from the skeleton and instead uses the internal default config?
conversely, if you don't specify --config then it will create a reasonable retroarch.cfg from the skeleton in /etc/retroarch.cfg
I would like to fix this if this is the case
hunterkToday at 3:30 PM
AFAIK, the skeleton config in /etc/ isn't really used for anything but reference
oh?
valadaa48Today at 3:31 PM
we distribute retroarch on an image without a pre-created retroarch.cfg in ~/.config/retroarch
first run it will use our augmented /etc/retroarch.cfg that has settings specific to our image, like custom paths, etc..
we have a use-case where we need a second retroarch.cfg for a different workflow but of course the generated retroarch.cfg when using the --config option does not work for us
hunterkToday at 3:32 PM
i think making it check for one in /etc/ to override the internal seems reasonable
valadaa48Today at 3:32 PM
thanks, I'll fix it and PR
```