### PR TITLE
(cheevos) prevent hardcore toggle when emu-handled cheats are active

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -50,6 +50,10 @@
 #include "../network/discord.h"
 #endif
 
+#ifdef HAVE_CHEATS
+#include "../cheat_manager.h"
+#endif
+
 #include "badges.h"
 #include "cheevos.h"
 #include "cheevos_memory.h"
@@ -1496,6 +1500,13 @@ static void rcheevos_toggle_hardcore_active(rcheevos_locals_t* locals)
       rcheevos_validate_config_settings();
       if (!locals->hardcore_active)
          return;
+
+#ifdef HAVE_CHEATS
+      /* if one or more emulator managed cheats is active, abort */
+      cheat_manager_apply_cheats();
+      if (!locals->hardcore_active)
+         return;
+#endif
 
       if (locals->loaded)
       {


### PR DESCRIPTION
## Description

When Emulator-Handled cheats are active, resuming Hardcore mode was not notifying the core, allowing the cheats to remain active. The logic to disable Hardcore mode when activating cheats was working correctly with Emulator-Handled cheats, so I've chosen just to re-activate cheats when attempting to enable Hardcore mode. If Emulator-Handled cheats are enabled, this will immediately pause Hardcore mode again and abort the switch.

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@Sanaki
