### PR TITLE
winmm_midi: Recover from MIDI messages not handled by the device

### DIFF
--- a/midi/drivers/winmm_midi.c
+++ b/midi/drivers/winmm_midi.c
@@ -605,6 +605,10 @@ static bool winmm_midi_flush(void *p)
 #ifdef DEBUG
          RARCH_ERR("[MIDI]: midiStreamOut failed with error %d.\n", mmr);
 #endif
+         // Core sent MIDI message not understood by the MIDI driver
+         // Make this buffer available to be used again
+         buf->header.dwFlags |= MHDR_DONE;
+         buf->header.dwFlags &= ~MHDR_INQUEUE;
          return false;
       }
 


### PR DESCRIPTION
## Description

When an underlying MIDI device does not understand/support a MIDI message it returns an error code. This can be very common with sysex (hardware specific) messages.
With this fix MIDI output can continue gracefully even after an emulated game sends such an unsupported message.

Before this, after just one unsupported message output would completely stop with the winmm MIDI driver.

Tested with DOSBox Pure core. Related issue: schellingb/dosbox-pure/issues/70

## Related Issues

## Related Pull Requests

## Reviewers