### PR TITLE
Android: add Gradle task to output Play Store version code

### DIFF
--- a/pkg/android/phoenix/build.gradle
+++ b/pkg/android/phoenix/build.gradle
@@ -169,3 +169,9 @@ String getManifestAttribute(String attribute) {
     ((String) it.key).contains(attribute)
   }.value
 }
+
+tasks.register("outputVersionCode") {
+  doLast {
+    println getPlayStoreVersionCode()
+  }
+}


### PR DESCRIPTION
## Description

This adds a Gradle task to output the Play Store version code to the terminal.  This will be used by a corresponding MR in the packaging repo for preventing Fastlane from uploading Play Store builds without a unique version code.

## Reviewers

@twinaphex @m4xw 