### PR TITLE
Android: Use `mamearcade` core instead of `mame` in Play Store version

### DIFF
--- a/pkg/android/phoenix/module_list_normal.txt
+++ b/pkg/android/phoenix/module_list_normal.txt
@@ -16,7 +16,7 @@ gambatte
 genesis_plus_gx
 gw
 hatari
-mame
+mamearcade
 mame2003_plus
 mednafen_lynx
 mednafen_ngp

--- a/pkg/android/phoenix/module_list_plus.txt
+++ b/pkg/android/phoenix/module_list_plus.txt
@@ -40,7 +40,7 @@ gw
 handy
 hatari
 lutro
-mame
+mamearcade
 mame2000
 mame2003
 mame2003_midway


### PR DESCRIPTION
## Description

Switches the Play Store core to use `mamearcade`.

## Reviewers

@twinaphex 