### PR TITLE
(RGUI) Add Russian language support

### DIFF
--- a/gfx/drivers_font_renderer/bitmapfont_10x10.c
+++ b/gfx/drivers_font_renderer/bitmapfont_10x10.c
@@ -54,6 +54,11 @@
 #define FONT_10X10_GLYPH_MIN_KOR 0xAC00
 #define FONT_10X10_GLYPH_MAX_KOR 0xD7A3
 
+#define FONT_10X10_FILE_RUS      "bitmap10x10_rus.bin"
+#define FONT_10X10_SIZE_RUS      1248
+#define FONT_10X10_GLYPH_MIN_RUS 0x400
+#define FONT_10X10_GLYPH_MAX_RUS 0x45F
+
 #define FONT_10X10_OFFSET(x) ((x) * ((FONT_10X10_HEIGHT * FONT_10X10_WIDTH + 7) / 8))
 
 /* Loads a font of the specified language
@@ -106,6 +111,12 @@ bitmapfont_lut_t *bitmapfont_10x10_load(unsigned language)
          font_size = FONT_10X10_SIZE_KOR;
          glyph_min = FONT_10X10_GLYPH_MIN_KOR;
          glyph_max = FONT_10X10_GLYPH_MAX_KOR;
+         break;
+      case RETRO_LANGUAGE_RUSSIAN:
+         font_file = FONT_10X10_FILE_RUS;
+         font_size = FONT_10X10_SIZE_RUS;
+         glyph_min = FONT_10X10_GLYPH_MIN_RUS;
+         glyph_max = FONT_10X10_GLYPH_MAX_RUS;
          break;
       default:
          break;

--- a/intl/msg_hash_ru.c
+++ b/intl/msg_hash_ru.c
@@ -12,10 +12,15 @@
  *  You should have received a copy of the GNU General Public License along with RetroArch.
  *  If not, see <http://www.gnu.org/licenses/>.
  */
+#include <stdio.h>
 #include <stdint.h>
-#include <string.h>
+#include <stddef.h>
+
+#include <compat/strl.h>
+#include <string/stdstring.h>
 
 #include "../msg_hash.h"
+#include "../verbosity.h"
 
 #if defined(_MSC_VER) && !defined(_XBOX) && (_MSC_VER >= 1500 && _MSC_VER < 1900)
 #if (_MSC_VER >= 1700)
@@ -40,12 +45,51 @@ int msg_hash_get_help_ru_enum(enum msg_hash_enums msg, char *s, size_t len)
    return ret;
 }
 
+#ifdef HAVE_MENU
+static const char *menu_hash_to_str_ru_label_enum(enum msg_hash_enums msg)
+{
+   if (msg <= MENU_ENUM_LABEL_INPUT_HOTKEY_BIND_END &&
+         msg >= MENU_ENUM_LABEL_INPUT_HOTKEY_BIND_BEGIN)
+   {
+      static char hotkey_lbl[128] = {0};
+      unsigned idx = msg - MENU_ENUM_LABEL_INPUT_HOTKEY_BIND_BEGIN;
+      snprintf(hotkey_lbl, sizeof(hotkey_lbl), "input_hotkey_binds_%d", idx);
+      return hotkey_lbl;
+   }
+
+   switch (msg)
+   {
+#include "msg_hash_lbl.h"
+      default:
+#if 0
+         RARCH_LOG("Unimplemented: [%d]\n", msg);
+#endif
+         break;
+   }
+
+   return "null";
+}
+#endif
+
 const char *msg_hash_to_str_ru(enum msg_hash_enums msg)
 {
+#ifdef HAVE_MENU
+   const char *ret = menu_hash_to_str_ru_label_enum(msg);
+
+   if (ret && !string_is_equal(ret, "null"))
+      return ret;
+#endif
+
    switch (msg)
    {
 #include "msg_hash_ru.h"
       default:
+#if 0
+         RARCH_LOG("Unimplemented: [%d]\n", msg);
+         {
+            RARCH_LOG("[%d] : %s\n", msg - 1, msg_hash_to_str(((enum msg_hash_enums)(msg - 1))));
+         }
+#endif
          break;
    }
 


### PR DESCRIPTION
## Description

This PR adds Russian language support to RGUI:

![Screenshot_2021-01-13_15-23-58](https://user-images.githubusercontent.com/38211560/104471996-652eb980-55b3-11eb-8c15-06558db28683.png)

It requires the Cyrillic bitmap font created by @trngaje: https://github.com/libretro/retroarch-assets/pull/400

All credit goes to trngaje. The code changes here were trivial - making the font was the difficult part!

The PR also fixes a bug in `intl/msg_hash_ru.c` which caused the wrong string to be displayed in certain circumstances.