### PR TITLE
Remove incorrect ifdef for Wayland on non-Linux - fix #10056

### DIFF
--- a/input/input_keymaps.c
+++ b/input/input_keymaps.c
@@ -50,7 +50,7 @@
 #include "SDL.h"
 #endif
 
-#if defined(__linux__) || defined(__linux__) && defined(HAVE_WAYLAND)
+#if defined(__linux__) || defined(HAVE_WAYLAND)
 #include <linux/input.h>
 #include <linux/kd.h>
 #endif


### PR DESCRIPTION
## Description

`defined(__linux__) || defined(__linux__) && defined(HAVE_WAYLAND)` makes no sense, it's equivalent to `defined(__linux__)`. While the point was to support Wayland on FreeBSD.

## Related Issues

https://github.com/libretro/RetroArch/issues/10056#issuecomment-751846925
