### PR TITLE
[PS2] Fixed Folder creation issues

### DIFF
--- a/Makefile.ps2
+++ b/Makefile.ps2
@@ -21,7 +21,7 @@ else
 endif
 
 ifeq ($(MUTE_WARNINGS), 1)
-   DISABLE_WARNINGS := -Wno-sign-compare -Wno-unused -Wno-parentheses
+   DISABLE_WARNINGS := -Wno-sign-compare -Wno-unused -Wno-parentheses -Wdiscarded-qualifiers
 endif
 
 INCDIR = -I$(PS2DEV)/gsKit/include -I$(PS2SDK)/ports/include

--- a/frontend/drivers/platform_ps2.c
+++ b/frontend/drivers/platform_ps2.c
@@ -47,7 +47,7 @@ static void create_path_names(void)
 
    /* TODO/FIXME - third parameter here needs to be size of
     * rootDevicePath(bootDeviceID) */
-   strlcpy(user_path, rootDevicePath(bootDeviceID), rootDevicePath(bootDeviceID));
+   strlcpy(user_path, rootDevicePath(bootDeviceID), sizeof(user_path));
    strlcat(user_path, "RETROARCH", sizeof(user_path));
    
    /* Content in the same folder */
@@ -192,7 +192,7 @@ static void frontend_ps2_init(void *data)
 
 #if defined(BUILD_FOR_PCSX2)
    bootDeviceID = BOOT_DEVICE_MC0;
-   strlcpy(cwd, rootDevicePath(bootDeviceID), sizeof(rootDevicePath(bootDeviceID)));
+   strlcpy(cwd, rootDevicePath(bootDeviceID), sizeof(cwd));
 #else
    getcwd(cwd, sizeof(cwd));
    bootDeviceID = getBootDeviceID(cwd);

--- a/ps2/compat_files/ps2_devices.c
+++ b/ps2/compat_files/ps2_devices.c
@@ -164,7 +164,7 @@ bool waitUntilDeviceIsReady(enum BootDeviceIDs device_id)
 {
    struct stat buffer;   
    int ret = -1;
-   int retries = 10;
+   int retries = 100;
    char *rootDevice = rootDevicePath(device_id);
 
    while(ret != 0 && retries > 0)


### PR DESCRIPTION
## Guidelines

This PR solves a legacy issue about the `RETROARCH` directories creation for PS2 platform.

