### PR TITLE
(X11) Fix mouse input when mouse is grabbed

### DIFF
--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -6606,6 +6606,7 @@ static void materialui_frame(void *data, video_frame_info_t *video_info)
    unsigned 
       materialui_color_theme      = video_info->materialui_color_theme;
    bool video_fullscreen          = video_info->fullscreen;
+   bool mouse_grabbed             = video_info->input_driver_grab_mouse_state;
    bool menu_mouse_enable         = video_info->menu_mouse_enable;
    gfx_animation_t *p_anim        = anim_get_ptr();
 
@@ -6791,14 +6792,14 @@ static void materialui_frame(void *data, video_frame_info_t *video_info)
    /* Draw mouse cursor */
    if (mui->mouse_show && (mui->pointer.type != MENU_POINTER_DISABLED))
    {
-      float color_white[16]  = {
+      float color_white[16] = {
          1.0f, 1.0f, 1.0f, 1.0f,
          1.0f, 1.0f, 1.0f, 1.0f,
          1.0f, 1.0f, 1.0f, 1.0f,
          1.0f, 1.0f, 1.0f, 1.0f
       };
-      bool cursor_visible   = video_fullscreen 
-         && menu_mouse_enable;
+      bool cursor_visible   = (video_fullscreen || mouse_grabbed) &&
+            menu_mouse_enable;
 
       if (cursor_visible)
          gfx_display_draw_cursor(

--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -2780,6 +2780,7 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
    float menu_framebuffer_opacity         = video_info->menu_framebuffer_opacity;
    bool libretro_running                  = video_info->libretro_running;
    bool video_fullscreen                  = video_info->fullscreen;
+   bool mouse_grabbed                     = video_info->input_driver_grab_mouse_state;
    bool menu_mouse_enable                 = video_info->menu_mouse_enable;
    bool input_menu_swap_ok_cancel_buttons = video_info->input_menu_swap_ok_cancel_buttons;
    bool battery_level_enable              = video_info->battery_level_enable;
@@ -3032,7 +3033,8 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
    /* Cursor */
    if (ozone->show_cursor && (ozone->pointer.type != MENU_POINTER_DISABLED))
    {
-      bool cursor_visible   = video_fullscreen && menu_mouse_enable;
+      bool cursor_visible = (video_fullscreen || mouse_grabbed) &&
+            menu_mouse_enable;
 
       gfx_display_set_alpha(ozone->pure_white, 1.0f);
       if (cursor_visible)

--- a/menu/drivers/stripes.c
+++ b/menu/drivers/stripes.c
@@ -2791,6 +2791,7 @@ static void stripes_frame(void *data, video_frame_info_t *video_info)
    float xmb_alpha_factor                  = video_info->xmb_alpha_factor;
    bool xmb_shadows_enable                 = video_info->xmb_shadows_enable;
    bool video_fullscreen                   = video_info->fullscreen;
+   bool mouse_grabbed                      = video_info->input_driver_grab_mouse_state;
    bool menu_mouse_enable                  = video_info->menu_mouse_enable;
    const float under_thumb_margin          = 0.96;
    float scale_factor                      = 0.0f;
@@ -3029,8 +3030,8 @@ static void stripes_frame(void *data, video_frame_info_t *video_info)
    if (stripes->mouse_show)
    {
       menu_input_pointer_t pointer;
-      bool cursor_visible   = video_fullscreen 
-         && menu_mouse_enable;
+      bool cursor_visible = (video_fullscreen || mouse_grabbed) &&
+            menu_mouse_enable;
 
       menu_input_get_pointer_state(&pointer);
 

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -4653,6 +4653,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
    bool timedate_enable                    = video_info->timedate_enable;
    bool battery_level_enable               = video_info->battery_level_enable;
    bool video_fullscreen                   = video_info->fullscreen;
+   bool mouse_grabbed                      = video_info->input_driver_grab_mouse_state;
    bool menu_mouse_enable                  = video_info->menu_mouse_enable;
    unsigned xmb_color_theme                = video_info->xmb_color_theme;
    bool libretro_running                   = video_info->libretro_running;
@@ -5286,8 +5287,8 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
    /* Cursor image */
    if (xmb->mouse_show)
    {
-      bool cursor_visible   = video_fullscreen 
-         && menu_mouse_enable;
+      bool cursor_visible = (video_fullscreen || mouse_grabbed) &&
+            menu_mouse_enable;
 
       gfx_display_set_alpha(coord_white, MIN(xmb->alpha, 1.00f));
       if (cursor_visible)

--- a/retroarch.h
+++ b/retroarch.h
@@ -1182,6 +1182,7 @@ typedef struct video_frame_info
    bool widgets_is_rewinding;
    bool input_menu_swap_ok_cancel_buttons;
    bool input_driver_nonblock_state;
+   bool input_driver_grab_mouse_state;
    bool hard_sync;
    bool fps_show;
    bool memory_show;
@@ -1980,6 +1981,8 @@ unsigned int retroarch_get_rotation(void);
 void retroarch_init_task_queue(void);
 
 bool input_key_pressed(int key, bool keyboard_pressed);
+
+bool input_mouse_grabbed(void);
 
 const char *joypad_driver_name(unsigned i);
 void joypad_driver_reinit(void *data, const char *joypad_driver_name);

--- a/ui/drivers/ui_qt.cpp
+++ b/ui/drivers/ui_qt.cpp
@@ -656,6 +656,7 @@ static void ui_companion_qt_toggle(void *data, bool force)
    settings_t *settings        = config_get_ptr();
    bool ui_companion_toggle    = settings->bools.ui_companion_toggle;
    bool video_fullscreen       = settings->bools.video_fullscreen;
+   bool mouse_grabbed          = input_mouse_grabbed();
 
    if (ui_companion_toggle || force)
    {
@@ -664,7 +665,11 @@ static void ui_companion_qt_toggle(void *data, bool force)
 
       win_handle->qtWindow->activateWindow();
       win_handle->qtWindow->raise();
+
+      if (mouse_grabbed)
+         command_event(CMD_EVENT_GRAB_MOUSE_TOGGLE, NULL);
       video_driver_show_mouse();
+
       win_handle->qtWindow->show();
 
       if (video_driver_started_fullscreen())


### PR DESCRIPTION
## Description

At present, if the the X11 input driver is selected, mouse input is somewhat broken whenever the mouse pointer is grabbed. The most obvious manifestation of this is in the menu - the hack used to enable relative pointer movement in-game means that the pointer cannot reach the edges of the menu screen (this is most troublesome when running GLUI in fullscreen mode, where the limited pointer range renders some on-screen buttons almost unusable).

This PR rewrites the X11 mouse polling code to properly handle both 'un-grabbed' absolute mouse coordinates and 'grabbed' relative mouse motion. The pointer now behaves correctly in all cases.

The PR also fixes a number of more general mouse-grab-related bugs:

- The cursor is now shown correctly when mouse grab is enabled in-menu when not using fullscreen mode
- The current mouse grab state is preserved when re-initialising the video driver
- The hardware cursor is no longer incorrectly shown on-top of the software cursor in a couple of edge cases
- Opening the Qt companion interface now un-grabs the mouse (previously it didn't - if the companion interface was opened while mouse grab was active, the whole application became unusable...)