### PR TITLE
(3DS) On error, only init gfx on salamander build

### DIFF
--- a/ctr/ctr_system.c
+++ b/ctr/ctr_system.c
@@ -325,9 +325,9 @@ void wait_for_input(void)
 void error_and_quit(const char* errorStr)
 {
    errorConf error;
-
+#ifdef IS_SALAMANDER
    gfxInitDefault();
-
+#endif
    errorInit(&error, ERROR_TEXT, CFG_LANGUAGE_EN);
    errorText(&error, errorStr);
    errorDisp(&error);


### PR DESCRIPTION
This prevents graphical issues if the gfx is already initialized.
Which should always be the case if called from a running core.