### PR TITLE
(cheevos) traverse list in reverse order in case items are removed by callback

### DIFF
--- a/deps/rcheevos/src/rcheevos/runtime.c
+++ b/deps/rcheevos/src/rcheevos/runtime.c
@@ -442,13 +442,13 @@ const char* rc_runtime_get_richpresence(const rc_runtime_t* self)
 
 void rc_runtime_do_frame(rc_runtime_t* self, rc_runtime_event_handler_t event_handler, rc_peek_t peek, void* ud, lua_State* L) {
   rc_runtime_event_t runtime_event;
-  unsigned i;
+  int i;
 
   runtime_event.value = 0;
 
   rc_update_memref_values(self->memrefs, peek, ud);
 
-  for (i = 0; i < self->trigger_count; ++i) {
+  for (i = self->trigger_count - 1; i >= 0; --i) {
     rc_trigger_t* trigger = self->triggers[i].trigger;
     int trigger_state;
 
@@ -497,7 +497,7 @@ void rc_runtime_do_frame(rc_runtime_t* self, rc_runtime_event_handler_t event_ha
     }
   }
 
-  for (i = 0; i < self->lboard_count; ++i) {
+  for (i = self->lboard_count - 1; i >= 0; --i) {
     rc_lboard_t* lboard = self->lboards[i].lboard;
     int lboard_state;
 


### PR DESCRIPTION
## Description

Fixes an issue where an achievement relying on a delta check may not unlock if it triggers in the same frame as another achievement. More detail is available in the upstream fix [here](https://github.com/RetroAchievements/rcheevos/pull/111).

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@Sanaki @meleu
