### PR TITLE
Android (Play Store): ensure that `cores` directory exists before attempting to create symlinks

### DIFF
--- a/pkg/android/phoenix-common/src/com/retroarch/browser/retroactivity/RetroActivityCommon.java
+++ b/pkg/android/phoenix-common/src/com/retroarch/browser/retroactivity/RetroActivityCommon.java
@@ -537,7 +537,10 @@ public class RetroActivityCommon extends NativeActivity
    * @return The path to the RetroArch cores directory
    */
   private String getCorePath() {
-    return getApplicationInfo().dataDir + "/cores/";
+    String path = getApplicationInfo().dataDir + "/cores/";
+    new File(path).mkdirs();
+
+    return path;
   }
 
   /**


### PR DESCRIPTION
## Description

In situations where core modules are already downloaded and the app is going through an initial start (such as: after clearing app data, or on Android TV devices where cores are downloaded at install time), the app would fail to create symlinks due to the `cores` directory not having been created yet.  This PR ensures that the directory exists, and creates it if needed, before creating symlinks.

## Reviewers

@twinaphex 