### PR TITLE
[PS2] [PSP] Remove not needed logger configuration

### DIFF
--- a/Makefile.ps2
+++ b/Makefile.ps2
@@ -1,10 +1,8 @@
 BUILD_FOR_PCSX2    = 0
 DEBUG              = 0
-HAVE_LOGGER        = 0
-HAVE_FILE_LOGGER   = 0
 HAVE_THREADS       = 0
 MUTE_WARNINGS      = 1
-PS2_IP = 192.168.1.150
+PS2_IP = 192.168.1.10
 
 TARGET = retroarchps2-debug.elf
 TARGET_RELEASE = retroarchps2.elf
@@ -45,10 +43,6 @@ endif
 
 ifeq ($(HAVE_THREADS), 1)
 RARCH_DEFINES += -DHAVE_THREADS
-endif
-
-ifeq ($(HAVE_FILE_LOGGER), 1)
-CFLAGS += -DHAVE_FILE_LOGGER
 endif
 
 CFLAGS += $(RARCH_DEFINES)

--- a/Makefile.ps2.salamander
+++ b/Makefile.ps2.salamander
@@ -1,6 +1,5 @@
 BUILD_FOR_PCSX2   = 0
 DEBUG             = 0
-HAVE_FILE_LOGGER  = 0
 MUTE_WARNINGS     = 1
 PS2_IP = 192.168.1.150
 
@@ -35,10 +34,6 @@ LIBS = -lelf-loader -lpatches
 
 ifeq ($(BUILD_FOR_PCSX2), 1)
 RARCH_DEFINES += -DBUILD_FOR_PCSX2
-endif
-
-ifeq ($(HAVE_FILE_LOGGER), 1)
-CFLAGS		+= -DHAVE_FILE_LOGGER
 endif
 
 CFLAGS += $(RARCH_DEFINES)

--- a/Makefile.psp1
+++ b/Makefile.psp1
@@ -2,8 +2,6 @@ BUILD_PRX          = 0
 PSP_LARGE_MEMORY   = 1
 DEBUG              = 0
 HAVE_KERNEL_PRX    = 1
-HAVE_LOGGER        = 0
-HAVE_FILE_LOGGER   = 0
 HAVE_THREADS       = 1
 BIG_STACK          = 0
 WHOLE_ARCHIVE_LINK = 0
@@ -33,10 +31,6 @@ LIBS = $(WHOLE_START) -lretro_psp1 $(WHOLE_END) -lstdc++ -lpspgu -lpspgum -lm -l
 
 ifeq ($(HAVE_THREADS), 1)
 RARCH_DEFINES += -DHAVE_THREADS
-endif
-
-ifeq ($(HAVE_FILE_LOGGER), 1)
-CFLAGS += -DHAVE_FILE_LOGGER
 endif
 
 ifeq ($(HAVE_KERNEL_PRX), 1)

--- a/Makefile.psp1.salamander
+++ b/Makefile.psp1.salamander
@@ -1,6 +1,5 @@
 BUILD_PRX         = 0
 PSP_LARGE_MEMORY  = 1
-HAVE_FILE_LOGGER  = 0
 DEBUG             = 0
 
 TARGET = retroarchpsp_salamander
@@ -20,10 +19,6 @@ RARCH_DEFINES = -DPSP -DIS_SALAMANDER -DRARCH_CONSOLE
 LIBDIR =
 LDFLAGS =
 LIBS = -lstdc++ -lm -lpsppower
-
-ifeq ($(HAVE_FILE_LOGGER), 1)
-CFLAGS		+= -DHAVE_FILE_LOGGER
-endif
 
 CFLAGS += $(RARCH_DEFINES)
 

--- a/frontend/drivers/platform_ps2.c
+++ b/frontend/drivers/platform_ps2.c
@@ -195,14 +195,6 @@ static void frontend_ps2_init(void *data)
 #endif
 #endif
 
-#if defined(HAVE_FILE_LOGGER)
-   char fileLog[FILENAME_MAX];
-   strlcpy(fileLog, rootDevicePath(bootDeviceID), sizeof(fileLog));
-   strcat(fileLog, "retroarch.log");
-   retro_main_log_file_init(fileLog, false);
-   verbosity_enable();
-#endif
-
 #if !defined(DEBUG)
    waitUntilDeviceIsReady(bootDeviceID);
 #endif
@@ -210,10 +202,6 @@ static void frontend_ps2_init(void *data)
 
 static void frontend_ps2_deinit(void *data)
 {
-#if defined(HAVE_FILE_LOGGER)
-   verbosity_disable();
-   retro_main_log_file_deinit();
-#endif
 }
 
 static void frontend_ps2_exec(const char *path, bool should_load_game)

--- a/frontend/drivers/platform_psp.c
+++ b/frontend/drivers/platform_psp.c
@@ -234,7 +234,6 @@ static void frontend_psp_deinit(void *data)
 {
    (void)data;
 #ifndef IS_SALAMANDER
-   verbosity_disable();
    pthread_terminate();
 #endif
 }


### PR DESCRIPTION
## Description

This PR just remove the legacy way of using LOGGER for PS2 and PSP.

Thanks!