### PR TITLE
Issue when argv[0] is usb1:/... on Wii

### DIFF
--- a/frontend/drivers/platform_gx.c
+++ b/frontend/drivers/platform_gx.c
@@ -192,6 +192,12 @@ static void frontend_gx_get_env(
     * as a result the cfg file is not found. */
    if (*argc > 2 && argv[1] != NULL && argv[2] != NULL)
    {
+      if (strncmp("usb1", argv[0], 4) == 0 || strncmp("usb2", argv[0], 4) == 0)
+      {
+         strncpy(g_defaults.dirs[DEFAULT_DIR_CORE],argv[0], strlen(argv[0]));
+         strncpy(g_defaults.dirs[DEFAULT_DIR_CORE]," usb", 4);
+         memmove(g_defaults.dirs[DEFAULT_DIR_CORE], g_defaults.dirs[DEFAULT_DIR_CORE]+1, strlen(g_defaults.dirs[DEFAULT_DIR_CORE]));
+      }
       if(gx_devices[GX_DEVICE_SD].mounted)
       {
          chdir("sd:/");


### PR DESCRIPTION
When RA dol file launched from Wiiflow, getcwd return nothing, dirs[DEFAULT_DIR_CORE] is empty and RA "info", "autoconfig",.... dirs are on root /
This seems to be because argv[0] is starting with "usb1://...dol" (maybe incompatible libfat)
This patch allow to default dirs[DEFAULT_DIR_CORE]  on Wii to the dirname of the DOL in such cases.

## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

[Description of the pull request, detail any issues you are fixing or any features you are implementing]

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
