### PR TITLE
(X11) Enable keyboard input when mouse cursor is not inside the RetroArch window but window still has focus

### DIFF
--- a/input/drivers/x11_input.c
+++ b/input/drivers/x11_input.c
@@ -664,6 +664,9 @@ static void x_input_poll(void *data)
       return;
    }
 
+   /* Process keyboard */
+   XQueryKeymap(x11->display, x11->state);
+
    /* If pointer is not inside the application
     * window, ignore mouse input */
    if (!g_x11_entered)
@@ -675,9 +678,6 @@ static void x_input_poll(void *data)
       x11->mouse_r       = 0;
       return;
    }
-
-   /* Process keyboard */
-   XQueryKeymap(x11->display, x11->state);
 
    /* Process mouse */
    if (!XQueryPointer(x11->display,


### PR DESCRIPTION
## Description

As described in issue #11908, PR #11892 introduced a small regression whereby the X11 input driver would ignore keyboard input in windowed mode if the mouse cursor was not inside the RetroArch window. This PR fixes the issue - the keyboard is now processed whenever the window has focus, regardless of cursor position.

## Related Issues

This partially addresses #11892 - the issue remains with the sdl2 and linuxraw input drivers, but these have always been affected and I'm not sure how to fix them...