### PR TITLE
(cheevos) improve error handling for achievement unlocks

### DIFF
--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -4248,7 +4248,7 @@ static void cb_net_generic(retro_task_t *task,
    menu->core_buf = NULL;
    menu->core_len = 0;
 
-   if (!data || err)
+   if (!data || err || !data->data)
       goto finish;
 
    menu->core_buf = (char*)malloc((data->len+1) * sizeof(char));

--- a/retroarch.c
+++ b/retroarch.c
@@ -5947,7 +5947,7 @@ static void handle_discord_join_cb(retro_task_t *task,
    struct rarch_state *p_rarch       = &rarch_st;
    discord_state_t *discord_st       = &p_rarch->discord_st;
 
-   if (!data || err)
+   if (!data || err || !data->data)
       goto finish;
 
    data->data                        = (char*)realloc(data->data, data->len + 1);
@@ -10648,7 +10648,7 @@ static void handle_translation_cb(
       RARCH_LOG("RESULT FROM AI SERVICE...\n");
 #endif
 
-   if (!data || error)
+   if (!data || error || !data->data)
       goto finish;
 
    json = rjson_open_buffer(data->data, data->len);

--- a/tasks/task_http.c
+++ b/tasks/task_http.c
@@ -191,15 +191,28 @@ task_finished:
             free(tmp);
 
          if (task_get_cancelled(task))
+         {
             task_set_error(task, strdup("Task cancelled."));
-         else if (!task->mute)
-            task_set_error(task, strdup("Download failed."));
+         }
+         else
+         {
+            data = (http_transfer_data_t*)malloc(sizeof(*data));
+            data->data   = NULL;
+            data->len    = 0;
+            data->status = net_http_status(http->handle);
+
+            task_set_data(task, data);
+
+            if (!task->mute)
+               task_set_error(task, strdup("Download failed."));
+         }
       }
       else
       {
-         data       = (http_transfer_data_t*)malloc(sizeof(*data));
-         data->data = tmp;
-         data->len  = len;
+         data = (http_transfer_data_t*)malloc(sizeof(*data));
+         data->data   = tmp;
+         data->len    = len;
+         data->status = net_http_status(http->handle);
 
          task_set_data(task, data);
       }

--- a/tasks/tasks_internal.h
+++ b/tasks/tasks_internal.h
@@ -55,6 +55,7 @@ typedef struct
 {
    char *data;
    size_t len;
+   int status;
 } http_transfer_data_t;
 
 void *task_push_http_transfer(const char *url, bool mute, const char *type,


### PR DESCRIPTION
## Description

Adds more null checks to achievement unlock callback to prevent crashing when the server returns an error.

retroachievements.org had an outage today where it was returning 502 errors instead of valid responses. Because of the way the `task_http` code handles anything that's not a 2xx status code, the callback was being passed a NULL `task_data` object. Trying to extract the JSON response from the NULL `task_data` object resulted in a NULL reference exception, leading to RetroArch crashing for several users.

This PR adds a NULL check to `task_data` and `task_data->data`, as well as adding a `status` field to the `task_data` object, so the HTTP status code can be reported. I was unable to generate a 502 error, but did test with a 404:

![image](https://user-images.githubusercontent.com/32680403/105273878-574fda00-5b59-11eb-82ec-572855113ac5.png)

In order to pass the `status` code back as part of the `task_data` object, other `task_http` requests that result in non-2xx statuses now receive a `task_data` object instead of NULL. As far as I can tell, they were all already checking for a NULL `task_data` object, so I've expanded the related checks to also check for a non-NULL `task_data->data` field.

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@meleu @Sanaki
