### PR TITLE
(QB) MacOS X 10.5's toolchain does not support extra languages,

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -644,6 +644,10 @@ check_macro NEON __ARM_NEON__
 
 add_define MAKEFILE OS "$OS"
 
+if [ "$ARCHITECTURE_NAME" = 'Power Macintosh' ]; then
+   HAVE_LANGEXTRA='no'
+fi
+
 if [ "$HAVE_DEBUG" = 'yes' ]; then
    add_define MAKEFILE DEBUG 1
    if [ "$HAVE_OPENGL" = 'yes' ] ||

--- a/qb/qb.system.sh
+++ b/qb/qb.system.sh
@@ -1,4 +1,5 @@
 PLATFORM_NAME="$(uname -s)"
+ARCHITECTURE_NAME="$(uname -m)"
 
 if [ -n "${CROSS_COMPILE:=}" ]; then
 	case "$CROSS_COMPILE" in


### PR DESCRIPTION
MacOS X 10.5's toolchain does not support extra languages,
HAVE_LANGEXTRA support, but this will do for now
so disable HAVE_LANGEXTRA. We can later make this more generic
by checking for specific GCC versions as a cutoff point for
HAVE_LANGEXTRA support, but this will do for now

## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

[Description of the pull request, detail any issues you are fixing or any features you are implementing]

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
