### PR TITLE
(Apple/Clang/ARC) Fix ARC (Automatic Reference Counting) for PPC Mac

### DIFF
--- a/ui/drivers/cocoa/cocoa_common.h
+++ b/ui/drivers/cocoa/cocoa_common.h
@@ -85,11 +85,21 @@ extern apple_frontend_settings_t apple_frontend_settings;
 #define BOXUINT(x)   [NSNumber numberWithUnsignedInt:x]
 #define BOXFLOAT(x)  [NSNumber numberWithDouble:x]
 
+#if defined(__clang__)
+/* ARC is only available for Clang */
 #if __has_feature(objc_arc)
 #define RELEASE(x)   x = nil
 #define BRIDGE       __bridge
 #define UNSAFE_UNRETAINED __unsafe_unretained
 #else
+#define RELEASE(x)   [x release]; \
+   x = nil
+#define BRIDGE
+#define UNSAFE_UNRETAINED
+#endif
+#else
+/* On compilers other than Clang (e.g. GCC), assume ARC 
+   is going to be unavailable */
 #define RELEASE(x)   [x release]; \
    x = nil
 #define BRIDGE


### PR DESCRIPTION
ARC (Automatic Reference Counting) has only been available for Mac since Clang (after Mac transitioned from PowerPC to Intel x86).. PowerPC Mac is stuck with GCC and predates the use of ARC, __has_feature() also is a Clang extension, so wrap around this with a conditional so that GCC PowerPC on Mac can still work

## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

[Description of the pull request, detail any issues you are fixing or any features you are implementing]

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
