### PR TITLE
Get the SDL2 video driver to work in Wayland/KMS

### DIFF
--- a/gfx/drivers/sdl2_gfx.c
+++ b/gfx/drivers/sdl2_gfx.c
@@ -440,10 +440,16 @@ static void *sdl2_gfx_init(const video_info_t *video,
 
 #if defined(_WIN32)
    sdl2_set_handles(vid->window, RARCH_DISPLAY_WIN32);
-#elif defined(HAVE_X11)
-   sdl2_set_handles(vid->window, RARCH_DISPLAY_X11);
 #elif defined(HAVE_COCOA)
    sdl2_set_handles(vid->window, RARCH_DISPLAY_OSX);
+#else
+   const char *video_driver = SDL_GetCurrentVideoDriver();
+   if (strcmp(video_driver, "x11") == 0)
+      sdl2_set_handles(vid->window, RARCH_DISPLAY_X11);
+   else if (strcmp(video_driver, "wayland") == 0)
+      sdl2_set_handles(vid->window, RARCH_DISPLAY_WAYLAND);
+   else
+      sdl2_set_handles(vid->window, RARCH_DISPLAY_NONE);
 #endif
 
    sdl_refresh_viewport(vid);


### PR DESCRIPTION
I noticed that when using the sdl2 video driver in Xwayland-less Wayland or KMS, it doesn't work.  In Xwayland-less Wayland, you get a message: `xdg-screensaver: window <id> not found`.  In KMS, you just get an error about zenity not being able to connect to a display server.

This seems to fix it, by only calling `sdl2_set_handles()` with RARCH_DISPLAY_X11 if the current SDL video driver is actually `x11`.
