### PR TITLE
fix rewind crash on MSVC build when using SSE2

### DIFF
--- a/libretro-common/include/compat/intrinsics.h
+++ b/libretro-common/include/compat/intrinsics.h
@@ -66,17 +66,31 @@ static INLINE int compat_ctz(unsigned x)
    _BitScanForward((unsigned long*)&r, x);
    return (int)r;
 #else
-/* Only checks at nibble granularity,
- * because that's what we need. */
-   if (x & 0x000f)
-      return 0;
-   if (x & 0x00f0)
-      return 4;
-   if (x & 0x0f00)
-      return 8;
-   if (x & 0xf000)
-      return 12;
-   return 16;
+   int count = 0;
+   if (!(x & 0xffff))
+   {
+      x >>= 16;
+      count |= 16;
+   }
+   if (!(x & 0xff))
+   {
+      x >>= 8;
+      count |= 8;
+   }
+   if (!(x & 0xf))
+   {
+      x >>= 4;
+      count |= 4;
+   }
+   if (!(x & 0x3))
+   {
+      x >>= 2;
+      count |= 2;
+   }
+   if (!(x & 0x1))
+      count |= 1;
+
+   return count;
 #endif
 }
 

--- a/libretro-common/include/compat/intrinsics.h
+++ b/libretro-common/include/compat/intrinsics.h
@@ -63,7 +63,7 @@ static INLINE int compat_ctz(unsigned x)
    return __builtin_ctz(x);
 #elif _MSC_VER >= 1400 && !defined(_XBOX) && !defined(__WINRT__)
    unsigned long r = 0;
-   _BitScanReverse((unsigned long*)&r, x);
+   _BitScanForward((unsigned long*)&r, x);
    return (int)r;
 #else
 /* Only checks at nibble granularity,

--- a/state_manager.c
+++ b/state_manager.c
@@ -94,14 +94,17 @@ static size_t find_change(const uint16_t *a, const uint16_t *b)
    {
       __m128i v0    = _mm_loadu_si128(a128);
       __m128i v1    = _mm_loadu_si128(b128);
-      __m128i c     = _mm_cmpeq_epi32(v0, v1);
+      __m128i c     = _mm_cmpeq_epi8(v0, v1);
       uint32_t mask = _mm_movemask_epi8(c);
 
       if (mask != 0xffff) /* Something has changed, figure out where. */
       {
+         /* calculate the real offset to the differing byte */
          size_t ret = (((uint8_t*)a128 - (uint8_t*)a) |
-               (compat_ctz(~mask))) >> 1;
-         return ret | (a[ret] == b[ret]);
+               (compat_ctz(~mask)));
+
+         /* and convert that to the uint16_t offset */
+         return (ret >> 1);
       }
 
       a128++;


### PR DESCRIPTION
## Description

Fixes a crash using rewind on Windows with SSE2 enabled.

`state_manager_raw_compress` writes out three 16-bit values when it detects no changes in more than 64KB https://github.com/libretro/RetroArch/blob/2520337ddcc9923acbd50473f0a7ea473f8f1e2b/state_manager.c#L258-L260

but only two 16-bit values when it does find a change https://github.com/libretro/RetroArch/blob/2520337ddcc9923acbd50473f0a7ea473f8f1e2b/state_manager.c#L268-L269

The problem is that the `find_change` logic was not returning the correct offset, so it would sometimes write a `0` for the number of changed items in a sequence, and then one 16-bit value for the number of non-changed items. 

Having a `0` for the number of changed items tells `state_manager_raw_decompress` to read two 16-bit values to determine the number of non-changed items. Since only one was output, when two values are read, the count is often much larger than the size of the save state buffer and the next pair of values causes memory access violations and the application crashes.

This is caused by `compat_ctz` (count trailing zeroes) calling the wrong function. `_BitScanReverse` returns the number of leading zeros, not the number of trailing zeroes. 

https://docs.microsoft.com/en-us/cpp/intrinsics/bitscanreverse-bitscanreverse64?view=msvc-160
> Search the mask data from most significant bit (MSB) to least significant bit (LSB) for a set bit (1).

Trailing zeroes are the least significant bits, so the code should be calling `_BitScanForward`.

I've also made a minor change in `find_change` itself. By calling `_mm_cmpeq_epi8` instead of `_mm_cmpeq_epi32`, we can leverage the SIMD instructions for finding the exact byte that changed instead of just identifying which 32-bit value changed and doing an additional check to see if it was the high or low 16-bit value that changed. For completeness, I've updated the fallback implementation of `compat_ctz` to support full granularity of all 32-bits, whereas it previously only supported 0, 4, 8, 12, and 16.

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@twinaphex 
