### PR TITLE
Fix 'Power Management' menu

### DIFF
--- a/intl/msg_hash_lbl.h
+++ b/intl/msg_hash_lbl.h
@@ -877,6 +877,10 @@ MSG_HASH(
    "deferred_accessibility_settings_list"
    )
 MSG_HASH(
+   MENU_ENUM_LABEL_DEFERRED_POWER_MANAGEMENT_SETTINGS_LIST,
+   "deferred_power_management_settings_list"
+   )
+MSG_HASH(
    MENU_ENUM_LABEL_DEFERRED_LAKKA_LIST,
    "deferred_lakka_list"
    )


### PR DESCRIPTION
## Description

I just noticed that the `Power Management` menu is broken in current master. It turns out that this is because the `DEFERRED_POWER_MANAGEMENT_SETTINGS_LIST` enum was never given a label - so all this time the menu has worked purely by chance, via a fall-through! Recent code changes have inadvertently exposed this bug.

This trivial PR just assigns `DEFERRED_POWER_MANAGEMENT_SETTINGS_LIST` a proper label, fixing the issue.