### PR TITLE
(IOHIDManager) Fix enumeration value 'kIOHIDElementTypeInput_NULL' not handled in switch warning

### DIFF
--- a/input/drivers_hid/iohidmanager_hid.c
+++ b/input/drivers_hid/iohidmanager_hid.c
@@ -731,6 +731,7 @@ static void iohidmanager_hid_device_add_device(
                case kIOHIDElementTypeInput_Button:
                case kIOHIDElementTypeOutput:
                case kIOHIDElementTypeInput_Axis:
+               case kIOHIDElementTypeInput_NULL:
                   /* TODO/FIXME */
                   break;
                case kIOHIDElementTypeInput_Misc:
@@ -795,6 +796,7 @@ static void iohidmanager_hid_device_add_device(
                case kIOHIDElementTypeInput_ScanCodes:
                case kIOHIDElementTypeInput_Axis:
                case kIOHIDElementTypeOutput:
+               case kIOHIDElementTypeInput_NULL:
                   /* TODO/FIXME */
                   break;
                case kIOHIDElementTypeInput_Misc:


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

[Description of the pull request, detail any issues you are fixing or any features you are implementing]

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
