### PR TITLE
Android: move non-Play Store builds back to targetSdkVersion 29

### DIFF
--- a/pkg/android/phoenix/build.gradle
+++ b/pkg/android/phoenix/build.gradle
@@ -38,7 +38,7 @@ android {
         arguments "-j${Runtime.runtime.availableProcessors()}"
       }
     }
-    targetSdkVersion 28
+    targetSdkVersion 29
     versionCode System.currentTimeSeconds().toInteger()
     versionName "${getManifestAttribute("versionName")}_GIT"
   }
@@ -72,7 +72,6 @@ android {
     }
     playStoreNormal {
       minSdkVersion 21
-      targetSdkVersion 29
       versionCode getPlayStoreVersionCode()
       versionName getPlayStoreVersionName()
 
@@ -83,7 +82,6 @@ android {
     }
     playStorePlus {
       minSdkVersion 26
-      targetSdkVersion 29
       versionCode getPlayStoreVersionCode()
       versionName getPlayStoreVersionName()
 


### PR DESCRIPTION
## Description

We moved non-Play Store builds back to targetSdkVersion 28 in hopes that it would fix SD card access on certain devices, but that doesn't appear to be the case.

## Reviewers

@twinaphex 