### PR TITLE
Add /media/shaders_slang/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ apple/RetroArch_iOS.xcodeproj/project.xcworkspace/*
 /rsound.h
 .pc
 /media/shaders_glsl/
+/media/shaders_slang/
 /obj-w32/
 .cproject
 .settings


### PR DESCRIPTION
May only affect libretro-super builds, but simple enough to exempt nonetheless.