### PR TITLE
Prevent duplicate key events with hotkeys + keyboard device type

### DIFF
--- a/libretro-common/include/retro_miscellaneous.h
+++ b/libretro-common/include/retro_miscellaneous.h
@@ -134,6 +134,16 @@ static INLINE bool bits_any_set(uint32_t* ptr, uint32_t count)
 #define BIT256_GET_PTR(a, bit)   BIT256_GET(*a, bit)
 #define BIT256_CLEAR_ALL_PTR(a)  BIT256_CLEAR_ALL(*a)
 
+#define BIT512_SET(a, bit)       BIT256_SET(a, bit)
+#define BIT512_CLEAR(a, bit)     BIT256_CLEAR(a, bit)
+#define BIT512_GET(a, bit)       BIT256_GET(a, bit)
+#define BIT512_CLEAR_ALL(a)      BIT256_CLEAR_ALL(a)
+
+#define BIT512_SET_PTR(a, bit)   BIT512_SET(*a, bit)
+#define BIT512_CLEAR_PTR(a, bit) BIT512_CLEAR(*a, bit)
+#define BIT512_GET_PTR(a, bit)   BIT512_GET(*a, bit)
+#define BIT512_CLEAR_ALL_PTR(a)  BIT512_CLEAR_ALL(*a)
+
 #define BITS_COPY16_PTR(a,bits) \
 { \
    BIT128_CLEAR_ALL_PTR(a); \
@@ -159,6 +169,12 @@ typedef struct
 {
    uint32_t data[8];
 } retro_bits_t;
+
+/* This struct has 512 bits. */
+typedef struct
+{
+   uint32_t data[16];
+} retro_bits_512_t;
 
 #ifdef _WIN32
 #  ifdef _WIN64

--- a/menu/cbs/menu_cbs_scan.c
+++ b/menu/cbs/menu_cbs_scan.c
@@ -180,6 +180,9 @@ static int action_scan_input_desc(const char *path,
 
    if (target)
    {
+      /* Clear mapping bit */
+      input_keyboard_mapping_bits(0, target->key);
+
       target->key     = RETROK_UNKNOWN;
       target->joykey  = NO_BTN;
       target->joyaxis = AXIS_NONE;

--- a/menu/menu_cbs.h
+++ b/menu/menu_cbs.h
@@ -242,6 +242,8 @@ int core_setting_right(unsigned type, const char *label,
 int action_right_cheat(unsigned type, const char *label,
       bool wraparound);
 
+void input_keyboard_mapping_bits(unsigned mode, unsigned key);
+
 /* End of function callbacks */
 
 int menu_cbs_init_bind_left(menu_file_list_cbs_t *cbs,

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -561,6 +561,9 @@ static int setting_bind_action_start(rarch_setting_t *setting)
    keybind->joykey  = NO_BTN;
    keybind->joyaxis = AXIS_NONE;
 
+   /* Clear old mapping bit */
+   input_keyboard_mapping_bits(0, keybind->key);
+
    if (setting->index_offset)
       def_binds = (struct retro_keybind*)retro_keybinds_rest;
 
@@ -568,6 +571,9 @@ static int setting_bind_action_start(rarch_setting_t *setting)
    keybind->key = def_binds[bind_type - MENU_SETTINGS_BIND_BEGIN].key;
 
    keybind->mbutton = NO_BTN;
+
+   /* Store new mapping bit */
+   input_keyboard_mapping_bits(1, keybind->key);
 
    return 0;
 }

--- a/retroarch_data.h
+++ b/retroarch_data.h
@@ -2340,6 +2340,7 @@ struct rarch_state
 
    bool main_ui_companion_is_on_foreground;
    bool keyboard_mapping_blocked;
+   retro_bits_512_t keyboard_mapping_bits;
 
 #if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)
    bool shader_presets_need_reload;


### PR DESCRIPTION
## Description

Currently when using the keyboard it is not possible to press frontend hotkeys without also sending the keyboard press event to the core. "Game Focus" allows to disable hotkeys, but nothing disables key events.

To better accomplish the opposite of "Game Focus", these changes add input event blocking where desirable:
- When pressing frontend hotkeys + RetroPad mappings
- When sending events via keyboard device type (Allow only mapped events, and not also triggering events)

The lookup bits are updated at launch, and at bind update/clear/reset. Did I miss anything? (Game Focus indeed might be more suitable as Keyboard Focus..)

Brainstorm credits to @jdgleaver !

## Related Issues

Closes #6344
