### PR TITLE
Clean all the warnings in PS2

### DIFF
--- a/Makefile.ps2
+++ b/Makefile.ps2
@@ -19,7 +19,7 @@ else
 endif
 
 ifeq ($(MUTE_WARNINGS), 1)
-   DISABLE_WARNINGS := -Wno-sign-compare -Wno-unused -Wno-parentheses -Wdiscarded-qualifiers
+   DISABLE_WARNINGS := -Wno-unused -Wno-format -Wno-format-truncation
 endif
 
 INCDIR = -I$(PS2DEV)/gsKit/include -I$(PS2SDK)/ports/include

--- a/audio/drivers/ps2_audio.c
+++ b/audio/drivers/ps2_audio.c
@@ -35,15 +35,13 @@ typedef struct ps2_audio
 
 static void audioConfigure(ps2_audio_t *ps2, unsigned rate)
 {
-   int err;
    struct audsrv_fmt_t format;
 
    format.bits     = AUDIO_BITS;
    format.freq     = rate;
    format.channels = AUDIO_CHANNELS;
 
-   err             = audsrv_set_format(&format);
-
+   audsrv_set_format(&format);
    audsrv_set_volume(MAX_VOLUME);
 }
 

--- a/frontend/drivers/platform_ps2.c
+++ b/frontend/drivers/platform_ps2.c
@@ -218,7 +218,7 @@ static void frontend_ps2_exec(const char *path, bool should_load_game)
    if (should_load_game && !path_is_empty(RARCH_PATH_CONTENT))
    {
       args++;
-      argv[0] = path_get(RARCH_PATH_CONTENT);
+      argv[0] = (char *)path_get(RARCH_PATH_CONTENT);
    }
 #endif
    LoadELFFromFile(path, args, argv);

--- a/gfx/drivers/ps2_gfx.c
+++ b/gfx/drivers/ps2_gfx.c
@@ -274,7 +274,7 @@ static bool ps2_gfx_frame(void *data, const void *frame,
 
 #if defined(DEBUG)
    if (frame_count % 180 == 0)
-      printf("ps2_gfx_frame %lu\n", frame_count);
+      printf("ps2_gfx_frame %llu\n", frame_count);
 #endif
 
    if (frame)


### PR DESCRIPTION
## Description
This PR solve the PS2 specific warnings and silent the ones that belong to generic RA code