### PR TITLE
Regression fixes

### DIFF
--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -3826,7 +3826,9 @@ static int xmb_menu_entry_action(
 static void xmb_render(void *data, 
       unsigned width, unsigned height, bool is_idle)
 {
-   unsigned i;
+   /* 'i' must be of 'size_t', since it is passed
+    * by reference to menu_entries_ctl() */
+   size_t i;
    float scale_factor;
    xmb_handle_t *xmb        = (xmb_handle_t*)data;
    settings_t *settings     = config_get_ptr();
@@ -3881,7 +3883,7 @@ static void xmb_render(void *data,
             xmb_calculate_visible_range(xmb, height,
                   end, (unsigned)selection, &first, &last);
 
-         for (i = first; i <= last; i++)
+         for (i = (size_t)first; i <= (size_t)last; i++)
          {
             float entry_size      = (i == (unsigned)selection) ?
                   xmb->icon_spacing_vertical * xmb->active_item_factor : xmb->icon_spacing_vertical;


### PR DESCRIPTION
## Description

This PR fixes two rather serious regressions:

- Commit fd17661e021eeee362b297fb3a7d9f5723a81273 entirely broke non-smooth ticker text, such that using it caused an instant segfault. Since 'smooth' ticker text is enabled by default, most users would not notice this. However - the screenshot widget always uses non-smooth ticker text, so any attempt to take a screenshot from content with a file name longer than the screen width would cause a segfault. This essentially happens every time on Android...
- Commit 41a8661bdfb728cc747988a056df791104d8efe3 incorrectly changed the data type (and thus width) of an important variable in XMB. Since this is passed to another function by reference as a void pointer and subsequently cast to the correct type, this produces a stack buffer overflow. Some platforms 'ignore' this, but on many it results in a 'segfault-on-launch' when using XMB

The PR also removes some pointlessly duplicated code in `gfx/gfx_animation.c`