### PR TITLE
(Windows) Mouse grab fixes

### DIFF
--- a/gfx/common/win32_common.c
+++ b/gfx/common/win32_common.c
@@ -1018,6 +1018,9 @@ static LRESULT CALLBACK wnd_proc_common_internal(HWND hwnd,
             taskbar_is_created = true;
 #endif
          break;
+      case WM_SETFOCUS:
+         win32_clip_window(input_mouse_grabbed());
+         break;
    }
 
    return DefWindowProc(hwnd, message, wparam, lparam);
@@ -1123,6 +1126,9 @@ static LRESULT CALLBACK wnd_proc_common_dinput_internal(HWND hwnd,
          if (g_win32->taskbar_message && message == g_win32->taskbar_message)
             taskbar_is_created = true;
 #endif
+         break;
+      case WM_SETFOCUS:
+         win32_clip_window(input_mouse_grabbed());
          break;
    }
 
@@ -1528,6 +1534,30 @@ void win32_check_window(void *data,
       *height             = g_win32_resize_height;
       g_win32->resized    = false;
    }
+#endif
+}
+
+void win32_clip_window(bool state)
+{
+#if !defined(_XBOX)
+   RECT clip_rect;
+
+   if (state && main_window.hwnd)
+   {
+      PWINDOWINFO info;
+      info = malloc(sizeof(*info));
+      info->cbSize = sizeof(PWINDOWINFO);
+
+      if (GetWindowInfo(main_window.hwnd, info))
+         clip_rect = info->rcClient;
+
+      free(info);
+      info = NULL;
+   }
+   else
+      GetWindowRect(GetDesktopWindow(), &clip_rect);
+
+   ClipCursor(&clip_rect);
 #endif
 }
 

--- a/gfx/common/win32_common.h
+++ b/gfx/common/win32_common.h
@@ -98,6 +98,8 @@ HWND win32_get_window(void);
 
 bool win32_has_focus(void *data);
 
+void win32_clip_window(bool grab);
+
 void win32_check_window(void *data,
       bool *quit,
       bool *resize, unsigned *width, unsigned *height);

--- a/input/drivers/dinput.c
+++ b/input/drivers/dinput.c
@@ -1007,6 +1007,10 @@ static void dinput_grab_mouse(void *data, bool state)
       (DISCL_EXCLUSIVE    | DISCL_FOREGROUND) :
       (DISCL_NONEXCLUSIVE | DISCL_FOREGROUND));
    IDirectInputDevice8_Acquire(di->mouse);
+
+#ifndef _XBOX
+   win32_clip_window(state);
+#endif
 }
 
 static uint64_t dinput_get_capabilities(void *data)

--- a/input/drivers/winraw_input.c
+++ b/input/drivers/winraw_input.c
@@ -25,6 +25,10 @@ extern "C" {
 }
 #endif
 
+#ifndef _XBOX
+#include "../../gfx/common/win32_common.h"
+#endif
+
 #include "../input_keymaps.h"
 
 #include "../../configuration.h"
@@ -874,17 +878,21 @@ static uint64_t winraw_get_capabilities(void *u)
           (1 << RETRO_DEVICE_LIGHTGUN);
 }
 
-static void winraw_grab_mouse(void *d, bool grab)
+static void winraw_grab_mouse(void *d, bool state)
 {
    winraw_input_t *wr = (winraw_input_t*)d;
 
-   if (grab == wr->mouse_grab)
+   if (state == wr->mouse_grab)
       return;
 
-   if (!winraw_set_mouse_input(wr->window, grab))
+   if (!winraw_set_mouse_input(wr->window, state))
       return;
 
-   wr->mouse_grab = grab;
+   wr->mouse_grab = state;
+
+#ifndef _XBOX
+   win32_clip_window(state);
+#endif
 }
 
 input_driver_t input_winraw = {

--- a/input/drivers/winraw_input.c
+++ b/input/drivers/winraw_input.c
@@ -225,7 +225,7 @@ static BOOL winraw_set_mouse_input(HWND window, bool grab)
    RAWINPUTDEVICE rid;
 
    if (window)
-      rid.dwFlags  = grab ? RIDEV_CAPTUREMOUSE : 0;
+      rid.dwFlags  = grab ? RIDEV_CAPTUREMOUSE | RIDEV_NOLEGACY : 0;
    else
       rid.dwFlags  = RIDEV_REMOVE;
 


### PR DESCRIPTION
## Description

Fixes for grabbings, though the latter one kinda makes the first one obsolete, but it will make the behavior the same with current `dinput`, regardless of global clipping.

- WINRAW: Added `RIDEV_NOLEGACY` to prevent mouse clicks outside the window
- WINRAW+DINPUT: Added `ClipCursor()` to keep cursor inside the window 
- Renamed `winraw_grab_mouse()` `grab` to `state` for consistency with other drivers
## Related Issues

Closes #11932 
