### PR TITLE
Input port label adjustments

### DIFF
--- a/menu/cbs/menu_cbs_title.c
+++ b/menu/cbs/menu_cbs_title.c
@@ -287,6 +287,11 @@ static int action_get_title_dropdown_item(
                      path, label, menu_type, s, len);
             default:
                {
+                  /* Analog to Digital Type -submenus do not have labels */
+                  if ((enum_idx > MENU_ENUM_LABEL_INPUT_PLAYER_ANALOG_DPAD_MODE) &&
+                      (enum_idx < MENU_ENUM_LABEL_INPUT_PLAYER_ANALOG_DPAD_MODE_LAST))
+                     enum_idx = MENU_ENUM_LABEL_VALUE_INPUT_ADC_TYPE;
+
                   const char *title = msg_hash_to_str(enum_idx);
 
                   if (s && !string_is_empty(title))
@@ -474,7 +479,7 @@ static int action_get_title_dropdown_input_description_common(
             sizeof(input_label));
 
    /* Build title string */
-   snprintf(s, len, "%s #%u -  %s",
+   snprintf(s, len, "%s %u - %s",
          msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PORT),
          port + 1,
          input_label);


### PR DESCRIPTION
## Description

"Analog to Digital Type" submenu titles are currently "null". No better way to use the only available hash than this?

Also finetuned button submenu titles to match menu labels.


