### PR TITLE
Add reinit to menubar setting

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -16906,6 +16906,7 @@ static bool setting_append_list(
                general_write_handler,
                general_read_handler,
                SD_FLAG_NONE);
+         MENU_SETTINGS_LIST_CURRENT_ADD_CMD(list, list_info, CMD_EVENT_REINIT);
 
 #ifdef HAVE_QT
          CONFIG_BOOL(


### PR DESCRIPTION
## Description

Menubar-toggle was missing reinit, requiring user to toggle fullscreen or find some other trigger to see changes.
