### PR TITLE
(Makefile.griffin) Fix windows_msvc2010 makefile target(s)

### DIFF
--- a/Makefile.griffin
+++ b/Makefile.griffin
@@ -529,6 +529,9 @@ else ifneq (,$(findstring windows_msvc2010,$(platform)))
    HAVE_CONFIGFILE          := 1
    HAVE_PATCH               := 1
    HAVE_CHEATS              := 1
+   HAVE_DSP_FILTER          := 1
+   HAVE_VIDEO_FILTER        := 1
+   HAVE_FILTERS_BUILTIN     := 1
 
    EXT_TARGET := $(TARGET_NAME).exe
    EXT_INTER_TARGET := $(TARGET_NAME).exe
@@ -537,7 +540,9 @@ else ifneq (,$(findstring windows_msvc2010,$(platform)))
    LD = link.exe
 
    PLATCFLAGS += -D_WIN32 -D__STDC_CONSTANT_MACROS -D_MBCS
-   PLATCFLAGS += -D__i686__ -D__MMX__ -D__SSE__ -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS -D_WINDOWS -DHAVE_CC_RESAMPLER -DHAVE_GL_SYNC -DHAVE_GLSL -DHAVE_IMAGEVIEWER -DHAVE_LANGEXTRA -DHAVE_OPENGL -DHAVE_SHADERPIPELINE -DHAVE_ONLINE_UPDATER -DHAVE_UPDATE_ASSETS -DHAVE_UPDATE_CORES -DWIN32 -DHAVE_CDROM
+   PLATCFLAGS += -D__i686__ -D__SSE__ -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS -D_WINDOWS -DHAVE_CC_RESAMPLER -DHAVE_GL_SYNC -DHAVE_GLSL -DHAVE_IMAGEVIEWER -DHAVE_LANGEXTRA -DHAVE_OPENGL -DHAVE_SHADERPIPELINE -DHAVE_ONLINE_UPDATER -DHAVE_UPDATE_ASSETS -DHAVE_UPDATE_CORES -DWIN32 -DHAVE_CDROM
+   PLATCFLAGS += -bigobj
+
    LDFLAGS += shell32.lib user32.lib gdi32.lib comdlg32.lib winmm.lib ole32.lib iphlpapi.lib msimg32.lib
 
    PlatformSuffix = $(subst windows_msvc2010_,,$(platform))
@@ -563,8 +568,8 @@ else ifneq (,$(findstring windows_msvc2010,$(platform)))
    PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../IDE")
    INCLUDE := $(shell IFS=$$'\n'; cygpath -w "$(VS100COMNTOOLS)../../VC/include")
 
-   WindowsSdkDir ?= $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A" -v "InstallationFolder" | grep -io '[A-Z]:\\.*')
    WindowsSdkDir ?= $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.1A" -v "InstallationFolder" | grep -io '[A-Z]:\\.*')
+   WindowsSdkDir ?= $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A" -v "InstallationFolder" | grep -io '[A-Z]:\\.*')
    WindowsSdkDir := $(WindowsSdkDir:\=)
 
    ifeq ($(HAVE_DIRECTX), 1)


### PR DESCRIPTION
## Description

This PR fixes the 32 and 64 bit `windows_msvc2010` builds:

- We have to compile with `-bigobj`, due to the large size of `griffin.c`
- The `__MMX__` define has been removed, due to compatibility issues with `libretro-common/gfx/scaler/pixconv.c`
    - On 64bit platforms, the `__m64` data type is unavailable
    - On 32bit platforms, the `pixconv` code compiles, but produces warnings of the type `warning C4799: function 'foo' has no EMMS instruction`. This is a serious warning that must not be ignored. I don't know anything about MMX extensions, and the code seems to be handled correctly with newer toolchains, so I felt it best to simply disable the code path for MSVC 2010...
- Detection of the Windows SDK directory has been corrected

In addition, I have enabled built-in audio/video filters for the MSVC 2010 builds (because why not...)