### PR TITLE
qt: fix mouse cursor limited by window range on F5 press

### DIFF
--- a/ui/drivers/ui_qt.cpp
+++ b/ui/drivers/ui_qt.cpp
@@ -660,16 +660,15 @@ static void ui_companion_qt_toggle(void *data, bool force)
 
    if (ui_companion_toggle || force)
    {
+      if (mouse_grabbed)
+         command_event(CMD_EVENT_GRAB_MOUSE_TOGGLE, NULL);
+      video_driver_show_mouse();
+
       if (video_fullscreen)
          command_event(CMD_EVENT_FULLSCREEN_TOGGLE, NULL);
 
       win_handle->qtWindow->activateWindow();
       win_handle->qtWindow->raise();
-
-      if (mouse_grabbed)
-         command_event(CMD_EVENT_GRAB_MOUSE_TOGGLE, NULL);
-      video_driver_show_mouse();
-
       win_handle->qtWindow->show();
 
       if (video_driver_started_fullscreen())


### PR DESCRIPTION
The recent mouse changes (this one I think https://github.com/libretro/RetroArch/pull/11970) made the cursor movement be limited by RA window after hitting F5 to go back to qt from RA fullscreen.

Ungrabbing the mouse before going back to windowed mode fixes that behaviour.