### PR TITLE
(Windows) Mouse grabbing/clipping with alt-tab

### DIFF
--- a/gfx/common/win32_common.c
+++ b/gfx/common/win32_common.c
@@ -1019,7 +1019,12 @@ static LRESULT CALLBACK wnd_proc_common_internal(HWND hwnd,
 #endif
          break;
       case WM_SETFOCUS:
-         win32_clip_window(input_mouse_grabbed());
+         if (input_mouse_grabbed())
+            win32_clip_window(true);
+         break;
+      case WM_KILLFOCUS:
+         if (input_mouse_grabbed())
+            win32_clip_window(false);
          break;
    }
 
@@ -1128,7 +1133,12 @@ static LRESULT CALLBACK wnd_proc_common_dinput_internal(HWND hwnd,
 #endif
          break;
       case WM_SETFOCUS:
-         win32_clip_window(input_mouse_grabbed());
+         if (input_mouse_grabbed())
+            win32_clip_window(true);
+         break;
+      case WM_KILLFOCUS:
+         if (input_mouse_grabbed())
+            win32_clip_window(false);
          break;
    }
 

--- a/input/drivers/dinput.c
+++ b/input/drivers/dinput.c
@@ -1003,9 +1003,13 @@ static void dinput_grab_mouse(void *data, bool state)
    IDirectInputDevice8_Unacquire(di->mouse);
    IDirectInputDevice8_SetCooperativeLevel(di->mouse,
       (HWND)video_driver_window_get(),
+#if 0
       state ?
       (DISCL_EXCLUSIVE    | DISCL_FOREGROUND) :
       (DISCL_NONEXCLUSIVE | DISCL_FOREGROUND));
+#else
+      (DISCL_NONEXCLUSIVE | DISCL_FOREGROUND));
+#endif
    IDirectInputDevice8_Acquire(di->mouse);
 
 #ifndef _XBOX

--- a/input/drivers/winraw_input.c
+++ b/input/drivers/winraw_input.c
@@ -228,10 +228,16 @@ static BOOL winraw_set_mouse_input(HWND window, bool grab)
 {
    RAWINPUTDEVICE rid;
 
+#if 0
    if (window)
       rid.dwFlags  = grab ? RIDEV_CAPTUREMOUSE | RIDEV_NOLEGACY : 0;
    else
       rid.dwFlags  = RIDEV_REMOVE;
+#else
+   rid.dwFlags     = 0;
+   if (!window)
+      rid.dwFlags  = RIDEV_REMOVE;
+#endif
 
    rid.hwndTarget  = window;
    rid.usUsagePage = 0x01; /* generic desktop */


### PR DESCRIPTION
## Description

Sorted issues with dinput+raw regarding entering/leaving with alt-tab while in grabbed state.

`DISCL_EXCLUSIVE` in dinput prevented clicking other windows. Same thing with `RIDEV_CAPTUREMOUSE` in raw. Simply disabled them both for now, since the current clipping method makes them useless anyway. 

@Tatsuya79 Please check if I missed something