### PR TITLE
(cheevos) don't invalidate out-of-range addresses

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -501,7 +501,9 @@ static unsigned rcheevos_peek(unsigned address, unsigned num_bytes, void* ud)
       }
    }
 
-   rcheevos_invalidate_address(address);
+   if (address < rcheevos_locals.memory.total_size)
+      rcheevos_invalidate_address(address);
+
    return 0;
 }
 


### PR DESCRIPTION
## Description

When a memory lookup fails because the address is out-of-range, avoid attempting to disable any achievements using the address. An out-of-range address should only be requested when evaluating a pointer that has not been initialized. Valid pointers should not be out-of-range, so the achievement disabling code should only be called when the core does not expose some portion of memory, which was the intent of having the achievement disabling code on an failed memory read in the first place.

## Related Issues

fixes #11988

## Related Pull Requests

n/a

## Reviewers

@Sanaki
