### PR TITLE
Removed quotation marks from comment (crowdin gets confused otherwise)

### DIFF
--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -87,7 +87,7 @@ MSG_HASH(
    MENU_ENUM_LABEL_VALUE_DUMP_DISC,
    "Dump Disc"
    )
-MSG_HASH( /* FIXME It is not immediately clear what "saved as an image file" means. Is it a specific image type? Determined automatically? User's choice? */
+MSG_HASH( /* FIXME Is a specific image format used? Is it determined automatically? User choice? */
    MENU_ENUM_SUBLABEL_DUMP_DISC,
    "Dump the physical media disc to internal storage. It will be saved as an image file."
    )


### PR DESCRIPTION
## Description
Removed quotation marks from a comment (and rewrote it for good measure) since they confuse Crowdin.

## Related Pull Requests
#11968

## Reviewers
@twinaphex 