### PR TITLE
When remembering last selected shader preset/shader pass directories, also remember selected files

### DIFF
--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -836,22 +836,34 @@ int generic_action_ok_displaylist_push(const char *path,
          break;
       case ACTION_OK_DL_SHADER_PASS:
 #if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)
-         filebrowser_clear_type();
-         info.type          = type;
-         info.directory_ptr = idx;
-         info_path          = menu_driver_get_last_shader_pass_dir();
-         info_label         = label;
-         dl_type            = DISPLAYLIST_FILE_BROWSER_SELECT_FILE;
+         {
+            const char *shader_file_name = NULL;
+
+            filebrowser_clear_type();
+            info.type          = type;
+            info.directory_ptr = idx;
+            info_label         = label;
+            dl_type            = DISPLAYLIST_FILE_BROWSER_SELECT_FILE;
+
+            menu_driver_get_last_shader_pass_path(&info_path, &shader_file_name);
+            menu_driver_set_pending_selection(shader_file_name);
+         }
 #endif
          break;
       case ACTION_OK_DL_SHADER_PRESET:
 #if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)
-         filebrowser_clear_type();
-         info.type          = type;
-         info.directory_ptr = idx;
-         info_path          = menu_driver_get_last_shader_preset_dir();
-         info_label         = label;
-         dl_type            = DISPLAYLIST_FILE_BROWSER_SELECT_FILE;
+         {
+            const char *shader_file_name = NULL;
+
+            filebrowser_clear_type();
+            info.type          = type;
+            info.directory_ptr = idx;
+            info_label         = label;
+            dl_type            = DISPLAYLIST_FILE_BROWSER_SELECT_FILE;
+
+            menu_driver_get_last_shader_preset_path(&info_path, &shader_file_name);
+            menu_driver_set_pending_selection(shader_file_name);
+         }
 #endif
          break;
       case ACTION_OK_DL_CONTENT_LIST:
@@ -1762,8 +1774,8 @@ static int generic_action_ok(const char *path,
             struct video_shader      *shader  = menu_shader_get();
             flush_char = msg_hash_to_str(flush_id);
 
-            /* Cache selected shader parent directory */
-            menu_driver_set_last_shader_preset_dir(action_path);
+            /* Cache selected shader parent directory/file name */
+            menu_driver_set_last_shader_preset_path(action_path);
 
             menu_shader_manager_set_preset(shader,
                   menu_driver_get_last_shader_preset_type(),
@@ -1781,8 +1793,8 @@ static int generic_action_ok(const char *path,
 
             if (shader_pass)
             {
-               /* Cache selected shader parent directory */
-               menu_driver_set_last_shader_pass_dir(action_path);
+               /* Cache selected shader parent directory/file name */
+               menu_driver_set_last_shader_pass_path(action_path);
 
                strlcpy(
                      shader_pass->source.path,

--- a/menu/menu_driver.h
+++ b/menu/menu_driver.h
@@ -38,6 +38,10 @@
 
 #include "../gfx/font_driver.h"
 
+#ifdef HAVE_CONFIG_H
+#include "../config.h"
+#endif
+
 RETRO_BEGIN_DECLS
 
 #ifndef MAX_COUNTERS
@@ -338,6 +342,7 @@ typedef struct
    } scratchpad;
    unsigned rpl_entry_selection_ptr;
 
+#if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)
    /* Used to cache the type and directory
     * of the last shader preset/pass loaded
     * via the menu file browser */
@@ -347,8 +352,12 @@ typedef struct
       enum rarch_shader_type pass_type;
 
       char preset_dir[PATH_MAX_LENGTH];
+      char preset_file_name[PATH_MAX_LENGTH];
+
       char pass_dir[PATH_MAX_LENGTH];
+      char pass_file_name[PATH_MAX_LENGTH];
    } last_shader_selection;
+#endif
 
    /* Used to cache the last start content
     * loaded via the menu file browser */
@@ -529,12 +538,14 @@ struct string_list *menu_driver_search_get_terms(void);
 void menu_driver_search_append_terms_string(char *s, size_t len);
 
 #if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)
-void menu_driver_set_last_shader_preset_dir(const char *shader_path);
-void menu_driver_set_last_shader_pass_dir(const char *shader_pass_path);
+void menu_driver_set_last_shader_preset_path(const char *path);
+void menu_driver_set_last_shader_pass_path(const char *path);
 enum rarch_shader_type menu_driver_get_last_shader_preset_type(void);
 enum rarch_shader_type menu_driver_get_last_shader_pass_type(void);
-const char *menu_driver_get_last_shader_preset_dir(void);
-const char *menu_driver_get_last_shader_pass_dir(void);
+void menu_driver_get_last_shader_preset_path(
+      const char **directory, const char **file_name);
+void menu_driver_get_last_shader_pass_path(
+      const char **directory, const char **file_name);
 #endif
 
 const char *menu_driver_get_last_start_directory(void);

--- a/ui/drivers/qt/shaderparamsdialog.cpp
+++ b/ui/drivers/qt/shaderparamsdialog.cpp
@@ -491,7 +491,11 @@ void ShaderParamsDialog::onShaderLoadPresetClicked()
    enum rarch_shader_type type       = RARCH_SHADER_NONE;
 #if !defined(HAVE_MENU)
    settings_t *settings              = config_get_ptr();
-   const char *path_dir_video_shader = settings->paths.directory_video_shader;
+   const char *shader_preset_dir     = settings->paths.directory_video_shader;
+#else
+   const char *shader_preset_dir     = NULL;
+
+   menu_driver_get_last_shader_preset_path(&shader_preset_dir, NULL);
 #endif
 
    getShaders(&menu_shader, &video_shader);
@@ -516,12 +520,7 @@ void ShaderParamsDialog::onShaderLoadPresetClicked()
    path       = QFileDialog::getOpenFileName(
          this,
          msg_hash_to_str(MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET),
-#if defined(HAVE_MENU)
-         menu_driver_get_last_shader_preset_dir(),
-#else
-         path_dir_video_shader,
-#endif
-         filter);
+         shader_preset_dir, filter);
 
    if (path.isEmpty())
       return;
@@ -532,7 +531,7 @@ void ShaderParamsDialog::onShaderLoadPresetClicked()
 
 #if defined(HAVE_MENU)
    /* Cache selected shader parent directory */
-   menu_driver_set_last_shader_preset_dir(pathData);
+   menu_driver_set_last_shader_preset_path(pathData);
 #endif
 
    menu_shader_manager_set_preset(menu_shader, type, pathData, true);
@@ -642,7 +641,11 @@ void ShaderParamsDialog::onShaderAddPassClicked()
    const char *pathData                  = NULL;
 #if !defined(HAVE_MENU)
    settings_t *settings                  = config_get_ptr();
-   const char *path_dir_video_shader     = settings->paths.directory_video_shader;
+   const char *shader_pass_dir           = settings->paths.directory_video_shader;
+#else
+   const char *shader_pass_dir           = NULL;
+
+   menu_driver_get_last_shader_pass_path(&shader_pass_dir, NULL);
 #endif
 
    getShaders(&menu_shader, &video_shader);
@@ -668,12 +671,7 @@ void ShaderParamsDialog::onShaderAddPassClicked()
    path = QFileDialog::getOpenFileName(
          this,
          msg_hash_to_str(MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET),
-#if defined(HAVE_MENU)
-         menu_driver_get_last_shader_pass_dir(),
-#else
-         path_dir_video_shader,
-#endif
-         filter);
+         shader_pass_dir, filter);
 
    if (path.isEmpty())
       return;
@@ -704,7 +702,7 @@ void ShaderParamsDialog::onShaderAddPassClicked()
 
 #if defined(HAVE_MENU)
    /* Cache selected shader parent directory */
-   menu_driver_set_last_shader_pass_dir(pathData);
+   menu_driver_set_last_shader_pass_path(pathData);
 #endif
 
    video_shader_resolve_parameters(menu_shader);


### PR DESCRIPTION
## Description

PR #11222 added a `Remember Last Used Shader Directory` option to the shaders quick menu. When enabled, the file browser opens at the last used directory when loading shader presets and shader pass files. There is a caveat, however: when the file browser opens, the selection marker is always reset to the first item in the list - this makes it very cumbersome to iterate through consecutive shaders when a directory contains a large number of files.

With this PR, when opening the file browser at the last used directory, the last used shader preset/pass *file* will also be selected automatically.

In addition, the shader preset file loaded when using the previous/next hotkeys is properly synchronised with the quick menu selection (previously, this too would always start iterating from the first item in the 'remembered' shader directory rather than the current menu-selected file)