### PR TITLE
Screen Resolution option fixes

### DIFF
--- a/gfx/drivers_context/w_vk_ctx.c
+++ b/gfx/drivers_context/w_vk_ctx.c
@@ -249,6 +249,10 @@ static bool gfx_ctx_w_vk_set_video_mode(void *data,
       RARCH_ERR("[WGL]: win32_set_video_mode failed.\n");
       goto error;
    }
+   else
+      /* This is required for fullscreen mailbox
+       * not to crash after refresh rate change */
+      vulkan_create_swapchain(&win32_vk, width, height, win32_vk_interval);
 
    gfx_ctx_w_vk_swap_interval(data, win32_vk_interval);
    return true;

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -6036,7 +6036,7 @@ int action_cb_push_dropdown_item_resolution(const char *path,
       settings->uints.video_fullscreen_x = width;
       settings->uints.video_fullscreen_y = height;
 
-      return 1;
+      return action_cancel_pop_default(NULL, NULL, 0, 0);
    }
 
    return 0;

--- a/retroarch.c
+++ b/retroarch.c
@@ -30469,6 +30469,11 @@ void video_monitor_set_refresh_rate(float hz)
    configuration_set_float(settings,
          settings->floats.video_refresh_rate,
          hz);
+
+   /* Without CMD_EVENT_REINIT vulkan will not switch rate properly,
+    * and with other drivers it prevents switching properly.. */
+   if (string_is_equal(settings->arrays.video_driver, "vulkan"))
+      command_event(CMD_EVENT_REINIT, NULL);
 }
 
 /**


### PR DESCRIPTION
## Description

Few changes to Video > Output > Screen Resolution dropdown:
- Go back to parent menu after selecting instead of toggling menu off
- Reinit after selecting, which fixes Vulkan not changing Hz in fullscreen
- Stop Vulkan from crashing after successfully changing Hz below the current running core fps (60 -> 50), or when no core is running, by creating a new swapchain on mode change
