### PR TITLE
Manual Content Scan: Auto select last used 'Content Directory' and 'Arcade DAT File' when opening file browser

### DIFF
--- a/manual_content_scan.c
+++ b/manual_content_scan.c
@@ -93,6 +93,20 @@ static scan_settings_t scan_settings = {
 /* Pointer access */
 
 /* Returns a pointer to the internal
+ * 'content_dir' string */
+char *manual_content_scan_get_content_dir_ptr(void)
+{
+   return scan_settings.content_dir;
+}
+
+/* Returns size of the internal
+ * 'content_dir' string */
+size_t manual_content_scan_get_content_dir_size(void)
+{
+   return sizeof(scan_settings.content_dir);
+}
+
+/* Returns a pointer to the internal
  * 'system_name_custom' string */
 char *manual_content_scan_get_system_name_custom_ptr(void)
 {

--- a/manual_content_scan.h
+++ b/manual_content_scan.h
@@ -95,6 +95,14 @@ typedef struct
  *   implementing unnecessary custom menu entries) */
 
 /* Returns a pointer to the internal
+ * 'content_dir' string */
+char *manual_content_scan_get_content_dir_ptr(void);
+
+/* Returns size of the internal
+ * 'content_dir' string */
+size_t manual_content_scan_get_content_dir_size(void);
+
+/* Returns a pointer to the internal
  * 'system_name_custom' string */
 char *manual_content_scan_get_system_name_custom_ptr(void);
 


### PR DESCRIPTION
## Description

At present, when using the manual content scanner, selecting either the `Content Directory` or `Arcade DAT File` menu entries will open the file browser at the path configured in `Settings > Directory > File Browser`, with the selection marker on the first entry of the list. This makes it incredibly tedious to scan a full collection of ROMs for different platforms, since each time `Content Directory` is selected, the user has to navigate all the way down to the required folder.

With this PR, choosing `Content Directory` or `Arcade DAT File` will automatically open the file browser in the last used directory, with the selection marker highlighting the last selected sub directory or file. This greatly facilitates the scanning process.

(I will do the same for other file path menu entries as time permits...)