### PR TITLE
(.gitlab-ci.yml) Restore mistakenly deleted linux-i686 target

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -129,6 +129,46 @@ build-retroarch-linux-x64:
     - "cp -f gfx/video_filters/*.so ${MEDIA_PATH}/${CI_PROJECT_NAME}/filters/video"
     - "cp -f gfx/video_filters/*.filt ${MEDIA_PATH}/${CI_PROJECT_NAME}/filters/video"
 
+build-retroarch-linux-i686:
+  image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-i386-ubuntu:xenial-gcc9
+  stage: build
+  variables:
+    MEDIA_PATH: .media
+  before_script:
+    - export NUMPROC=$(($(nproc)/3))
+  artifacts:
+    paths:
+    - retroarch
+    - ${MEDIA_PATH}
+    expire_in: 10 min
+  dependencies: []
+  script:
+    # Qt build
+    - "mkdir -p ${MEDIA_PATH}/${CI_PROJECT_NAME}/AppDirQt"
+    - "./configure --prefix=/usr"
+    - "make -j$NUMPROC"
+    - "make install DESTDIR=${MEDIA_PATH}/${CI_PROJECT_NAME}/AppDirQt prefix=/usr"
+    - "rm -rf ${MEDIA_PATH}/${CI_PROJECT_NAME}/AppDirQt/etc"
+    - "cd ${MEDIA_PATH}/${CI_PROJECT_NAME}/ && tar -czf AppDirQt.tar.gz AppDirQt && rm -rf AppDirQt && cd -"
+    - "mv -f retroarch retroarch_qt"
+    # Non-Qt build
+    - "mkdir -p ${MEDIA_PATH}/${CI_PROJECT_NAME}/AppDir"
+    - "make clean"
+    - "./configure --disable-qt --prefix=/usr"
+    - "make -j$NUMPROC"
+    - "make install DESTDIR=${MEDIA_PATH}/${CI_PROJECT_NAME}/AppDir prefix=/usr"
+    - "rm -rf ${MEDIA_PATH}/${CI_PROJECT_NAME}/AppDir/etc"
+    - "cd ${MEDIA_PATH}/${CI_PROJECT_NAME}/ && tar -czf AppDir.tar.gz AppDir && rm -rf AppDir && cd -"
+    # Filters
+    - "mkdir -p ${MEDIA_PATH}/${CI_PROJECT_NAME}/filters/audio"
+    - "mkdir -p ${MEDIA_PATH}/${CI_PROJECT_NAME}/filters/video"
+    - "cd libretro-common/audio/dsp_filters && make -j$NUMPROC build=release && make -j$NUMPROC build=release strip && cd -"
+    - "cp -f libretro-common/audio/dsp_filters/*.so ${MEDIA_PATH}/${CI_PROJECT_NAME}/filters/audio"
+    - "cp -f libretro-common/audio/dsp_filters/*.dsp ${MEDIA_PATH}/${CI_PROJECT_NAME}/filters/audio"
+    - "cd gfx/video_filters && make -j$NUMPROC build=release && make -j$NUMPROC build=release strip && cd -"
+    - "cp -f gfx/video_filters/*.so ${MEDIA_PATH}/${CI_PROJECT_NAME}/filters/video"
+    - "cp -f gfx/video_filters/*.filt ${MEDIA_PATH}/${CI_PROJECT_NAME}/filters/video"
+
 # Mac OS x86: RetroArch Unsigned DMG
 build-retroarch-osx-x64:
   tags:


### PR DESCRIPTION
This PR restores the `linux-i686` gitlab-ci target erroneously removed by d5c127309ed8cd5122dc4ed7d4b9d9651ae4d30b