### PR TITLE
(.gitlab-ci.yml) Add windows-msvc10-x64 and windows-msvc10-i686 targets

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -88,6 +88,88 @@ build-retroarch-windows-i686:
         --objdump i686-w64-mingw32.shared-objdump"
     - "rm -f ${MEDIA_PATH}/${CI_PROJECT_NAME}/redist/opengl32.dll"
 
+build-retroarch-windows-msvc10-x64:
+  tags:
+    - msvc2010
+  stage: build
+  variables:
+    MEDIA_PATH:     .media
+    MSYSTEM:        MINGW64
+    ARCH:           x86_64
+    MSYS_BIN_DIR:   C:\msys64\usr\bin
+    SDK_BIN_DIR:    C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin
+    PEDEPS_BIN_DIR: C:\Program Files\pedeps-0.1.9-win64\bin
+  before_script:
+    - $Env:HOME = "."
+    - $Env:Path += -join(";", "$Env:SDK_BIN_DIR", ";", "$Env:PEDEPS_BIN_DIR")
+  artifacts:
+    paths:
+    - retroarch.exe
+    - ${MEDIA_PATH}
+    expire_in: 10 min
+  dependencies: []
+  script:
+    # Build RetroArch
+    - $Script:MakeCmd = "$Env:MSYS_BIN_DIR\env.exe $Env:MSYS_BIN_DIR\bash.exe -l -c 'make -f Makefile.griffin platform=windows_msvc2010_x64'"
+    - Invoke-Expression $Script:MakeCmd
+    - mt.exe -nologo -manifest "retroarch.exe.manifest" -outputresource:"retroarch.exe;#1"
+    # Create .media subdirectories
+    - New-Item -Path "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/filters/audio" -ItemType Directory
+    - New-Item -Path "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/filters/video" -ItemType Directory
+    - New-Item -Path "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/pkg" -ItemType Directory
+    - New-Item -Path "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/redist" -ItemType Directory
+    # Copy audio/video filters
+    - Get-ChildItem -Path "libretro-common/audio/dsp_filters/*" -Include *.dsp | Copy-Item -Destination "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/filters/audio"
+    - Get-ChildItem -Path "gfx/video_filters/*" -Include *.filt | Copy-Item -Destination "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/filters/video"
+    # Copy default config file
+    - Copy-Item -Path "retroarch.cfg" -Destination "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/pkg/retroarch.default.cfg"
+    # Copy dll dependencies
+    # (note that msvc10 build should not have any, but this
+    # may change in the future)
+    - copypedeps.exe -r retroarch.exe "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/redist"
+    - Remove-Item "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/redist/retroarch.exe" -ErrorAction Ignore
+
+build-retroarch-windows-msvc10-i686:
+  tags:
+    - msvc2010
+  stage: build
+  variables:
+    MEDIA_PATH:     .media
+    MSYSTEM:        MINGW32
+    ARCH:           x86
+    MSYS_BIN_DIR:   C:\msys64\usr\bin
+    SDK_BIN_DIR:    C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin
+    PEDEPS_BIN_DIR: C:\Program Files\pedeps-0.1.9-win64\bin
+  before_script:
+    - $Env:HOME = "."
+    - $Env:Path += -join(";", "$Env:SDK_BIN_DIR", ";", "$Env:PEDEPS_BIN_DIR")
+  artifacts:
+    paths:
+    - retroarch.exe
+    - ${MEDIA_PATH}
+    expire_in: 10 min
+  dependencies: []
+  script:
+    # Build RetroArch
+    - $Script:MakeCmd = "$Env:MSYS_BIN_DIR\env.exe $Env:MSYS_BIN_DIR\bash.exe -l -c 'make -f Makefile.griffin platform=windows_msvc2010_x86'"
+    - Invoke-Expression $Script:MakeCmd
+    - mt.exe -nologo -manifest "retroarch.exe.manifest" -outputresource:"retroarch.exe;#1"
+    # Create .media subdirectories
+    - New-Item -Path "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/filters/audio" -ItemType Directory
+    - New-Item -Path "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/filters/video" -ItemType Directory
+    - New-Item -Path "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/pkg" -ItemType Directory
+    - New-Item -Path "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/redist" -ItemType Directory
+    # Copy audio/video filters
+    - Get-ChildItem -Path "libretro-common/audio/dsp_filters/*" -Include *.dsp | Copy-Item -Destination "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/filters/audio"
+    - Get-ChildItem -Path "gfx/video_filters/*" -Include *.filt | Copy-Item -Destination "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/filters/video"
+    # Copy default config file
+    - Copy-Item -Path "retroarch.cfg" -Destination "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/pkg/retroarch.default.cfg"
+    # Copy dll dependencies
+    # (note that msvc10 build should not have any, but this
+    # may change in the future)
+    - copypedeps.exe -r retroarch.exe "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/redist"
+    - Remove-Item "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/redist/retroarch.exe" -ErrorAction Ignore
+
 build-retroarch-linux-x64:
   image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-amd64-ubuntu:xenial-gcc9
   stage: build

--- a/Makefile.griffin
+++ b/Makefile.griffin
@@ -515,6 +515,7 @@ else ifneq (,$(findstring windows_msvc2010,$(platform)))
    HAVE_VIDEO_LAYOUT        := 0
    HAVE_MATERIALUI          := 1
    HAVE_XMB                 := 1
+   HAVE_OZONE               := 1
    HAVE_STB_FONT            := 1
    HAVE_THREADS             := 1
    HAVE_LIBRETRODB          := 1
@@ -526,6 +527,8 @@ else ifneq (,$(findstring windows_msvc2010,$(platform)))
    HAVE_GRIFFIN_CPP         := 1
    HAVE_RUNAHEAD            := 1
    HAVE_DIRECTX             ?= 1
+   HAVE_OPENGL              := 1
+   HAVE_OPENGL1             := 1
    HAVE_CONFIGFILE          := 1
    HAVE_PATCH               := 1
    HAVE_CHEATS              := 1
@@ -540,10 +543,13 @@ else ifneq (,$(findstring windows_msvc2010,$(platform)))
    LD = link.exe
 
    PLATCFLAGS += -D_WIN32 -D__STDC_CONSTANT_MACROS -D_MBCS
-   PLATCFLAGS += -D__i686__ -D__SSE__ -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS -D_WINDOWS -DHAVE_CC_RESAMPLER -DHAVE_GL_SYNC -DHAVE_GLSL -DHAVE_IMAGEVIEWER -DHAVE_LANGEXTRA -DHAVE_OPENGL -DHAVE_SHADERPIPELINE -DHAVE_ONLINE_UPDATER -DHAVE_UPDATE_ASSETS -DHAVE_UPDATE_CORES -DWIN32 -DHAVE_CDROM
+   PLATCFLAGS += -D__i686__ -D__SSE__ -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS -D_WINDOWS
+   PLATCFLAGS += -DHAVE_CC_RESAMPLER -DHAVE_GL_SYNC -DHAVE_GLSL -DHAVE_IMAGEVIEWER -DHAVE_LANGEXTRA
+   PLATCFLAGS += -DHAVE_OPENGL -DHAVE_OPENGL1 -DHAVE_OZONE
+   PLATCFLAGS += -DHAVE_ONLINE_UPDATER -DHAVE_UPDATE_ASSETS -DHAVE_UPDATE_CORES -DWIN32 -DHAVE_CDROM
    PLATCFLAGS += -bigobj
 
-   LDFLAGS += shell32.lib user32.lib gdi32.lib comdlg32.lib winmm.lib ole32.lib iphlpapi.lib msimg32.lib
+   LDFLAGS += -MANIFEST shell32.lib user32.lib gdi32.lib comdlg32.lib winmm.lib ole32.lib iphlpapi.lib msimg32.lib
 
    PlatformSuffix = $(subst windows_msvc2010_,,$(platform))
 
@@ -573,7 +579,7 @@ else ifneq (,$(findstring windows_msvc2010,$(platform)))
    WindowsSdkDir := $(WindowsSdkDir:\=)
 
    ifeq ($(HAVE_DIRECTX), 1)
-      PLATCFLAGS += -DHAVE_DINPUT -DHAVE_DSOUND -DHAVE_D3D -DHAVE_D3D9 -DHAVE_XAUDIO -DHAVE_XINPUT
+      PLATCFLAGS += -DHAVE_DINPUT -DHAVE_DSOUND -DHAVE_D3D -DHAVE_D3D8 -DHAVE_XAUDIO -DHAVE_XINPUT
       DXSDK_DIR := $(DXSDK_DIR:\=)
       export INCLUDE := $(INCLUDE);$(WindowsSdkDir)\Include;$(DXSDK_DIR)\Include;libretro-common\include;libretro-common\include\compat\msvc;gfx\include;deps;deps\stb
       export LIB := $(LIB);$(WindowsSdkDir)\$(PlatLib);$(DXSDK_DIR)\Lib\$(WinArch)

--- a/configuration.c
+++ b/configuration.c
@@ -258,6 +258,11 @@ static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_GL;
 #else
 static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_METAL;
 #endif
+#elif defined(HAVE_OPENGL1) && defined(_MSC_VER) && (_MSC_VER <= 1600)
+/* On Windows XP and earlier, use gl1 by default
+ * (regular opengl has compatibility issues with
+ * obsolete hardware drivers...) */
+static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_GL1;
 #elif defined(HAVE_VITA2D)
 static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_VITA2D;
 #elif defined(HAVE_OPENGL) || defined(HAVE_OPENGLES) || defined(HAVE_PSGL)


### PR DESCRIPTION
## Description

This PR adds `windows-msvc10-x64` and `windows-msvc10-i686` targets to the `.gitlab-ci.yml` file. In addition, it makes the following changes to the MSVC 2010 builds:

- `gl1` gfx driver support is enabled
- `ozone` is enabled
- xmb shader pipeline is disabled (due to compatibility issues)
- `d3d9` support is replaced with `d3d8` (due to the fact that `d3d9` is currently non-functional)
- The default gfx driver has been set to `gl`, since this offers the best compatibility (this default has also been applied to MSVC versions earlier than 2010)
