### PR TITLE
Memalign audio buffers to 64 bytes

### DIFF
--- a/retroarch_data.h
+++ b/retroarch_data.h
@@ -2070,7 +2070,7 @@ struct rarch_state
    unsigned perf_ptr_rarch;
    unsigned perf_ptr_libretro;
 
-   float audio_driver_input_data[AUDIO_CHUNK_SIZE_NONBLOCKING * 2];
+   float *audio_driver_input_data;
    float video_driver_core_hz;
    float video_driver_aspect_ratio;
 


### PR DESCRIPTION
This is the most common cache line size, helps with performance.
Also fixes issues with platforms like PSP that wrongly assume that
malloc returns aligned buffers (to 16bytes). This recently broke the PSP
builds.
