### PR TITLE
Allows hosting in a subfolder instead of only root

### DIFF
--- a/pkg/emscripten/libretro/libretro.js
+++ b/pkg/emscripten/libretro/libretro.js
@@ -96,10 +96,10 @@ function setupFileSystem(backend)
 
    /* create an XmlHttpRequest filesystem for the bundled data */
    var xfs1 =  new BrowserFS.FileSystem.XmlHttpRequest
-      (".index-xhr", "/assets/frontend/bundle/");
+      (".index-xhr", "assets/frontend/bundle/");
    /* create an XmlHttpRequest filesystem for core assets */
    var xfs2 =  new BrowserFS.FileSystem.XmlHttpRequest
-      (".index-xhr", "/assets/cores/");
+      (".index-xhr", "assets/cores/");
 
    console.log("WEBPLAYER: initializing filesystem: " + backend);
    mfs.mount('/home/web_user/retroarch/userdata', afs);


### PR DESCRIPTION
# Guidelines

...Followed

## Description

The emscripten .js, as it stands, is loading asset files from the root of a site ONLY.  This change allows for hosting in a subfolder but will not break hosting in a root either, unless the user has the asset folders in a wildly different location.  (At which point it's on them to configure this correctly anyway...)
