### PR TITLE
emscripten: only report back one screen pointer for rwebinput

### DIFF
--- a/input/drivers/rwebinput_input.c
+++ b/input/drivers/rwebinput_input.c
@@ -515,6 +515,7 @@ static int16_t rwebinput_input_state(
                device == RARCH_DEVICE_MOUSE_SCREEN);
       case RETRO_DEVICE_POINTER:
       case RARCH_DEVICE_POINTER_SCREEN:
+         if (idx == 0)
          {
             struct video_viewport vp;
             rwebinput_mouse_state_t 


### PR DESCRIPTION
fixes lockup when clicking on an overlay