### PR TITLE
(.gitlab-ci.yml) windows-x64/windows-i686/linux-x64/linux-i686/dingux-mips32: Strip generated RA binaries by default

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,7 @@ build-retroarch-windows-x64:
   stage: build
   variables:
     MEDIA_PATH: .media
+    STRIP_BIN:  1
   before_script:
     - export NUMPROC=$(($(nproc)/3))
   artifacts:
@@ -22,6 +23,7 @@ build-retroarch-windows-x64:
   script:
     - "MOC=/usr/lib/mxe/usr/x86_64-w64-mingw32.shared/qt5/bin/moc ./configure --host=x86_64-w64-mingw32.shared"
     - "make -j$NUMPROC"
+    - if [ $STRIP_BIN -eq 1 ]; then strip --strip-unneeded retroarch.exe; fi
     - "mkdir -p ${MEDIA_PATH}/${CI_PROJECT_NAME}/filters/audio"
     - "mkdir -p ${MEDIA_PATH}/${CI_PROJECT_NAME}/filters/video"
     - "mkdir -p ${MEDIA_PATH}/${CI_PROJECT_NAME}/pkg"
@@ -52,6 +54,7 @@ build-retroarch-windows-i686:
   stage: build
   variables:
     MEDIA_PATH: .media
+    STRIP_BIN:  1
   before_script:
     - export NUMPROC=$(($(nproc)/3))
   artifacts:
@@ -63,6 +66,7 @@ build-retroarch-windows-i686:
   script:
     - "MOC=/usr/lib/mxe/usr/i686-w64-mingw32.shared/qt5/bin/moc ./configure --host=i686-w64-mingw32.shared"
     - "make -j$NUMPROC"
+    - if [ $STRIP_BIN -eq 1 ]; then strip --strip-unneeded retroarch.exe; fi
     - "mkdir -p ${MEDIA_PATH}/${CI_PROJECT_NAME}/filters/audio"
     - "mkdir -p ${MEDIA_PATH}/${CI_PROJECT_NAME}/filters/video"
     - "mkdir -p ${MEDIA_PATH}/${CI_PROJECT_NAME}/pkg"
@@ -217,6 +221,7 @@ build-retroarch-linux-x64:
   stage: build
   variables:
     MEDIA_PATH: .media
+    STRIP_BIN:  1
   before_script:
     - export NUMPROC=$(($(nproc)/3))
   artifacts:
@@ -231,6 +236,7 @@ build-retroarch-linux-x64:
     - "mkdir -p ${MEDIA_PATH}/${CI_PROJECT_NAME}/AppDirQt"
     - "./configure --prefix=/usr"
     - "make -j$NUMPROC"
+    - if [ $STRIP_BIN -eq 1 ]; then strip --strip-unneeded retroarch; fi
     - "make install DESTDIR=${MEDIA_PATH}/${CI_PROJECT_NAME}/AppDirQt prefix=/usr"
     - "rm -rf ${MEDIA_PATH}/${CI_PROJECT_NAME}/AppDirQt/etc"
     - "cd ${MEDIA_PATH}/${CI_PROJECT_NAME}/ && tar -czf AppDirQt.tar.gz AppDirQt && rm -rf AppDirQt && cd -"
@@ -240,6 +246,7 @@ build-retroarch-linux-x64:
     - "make clean"
     - "./configure --disable-qt --prefix=/usr"
     - "make -j$NUMPROC"
+    - if [ $STRIP_BIN -eq 1 ]; then strip --strip-unneeded retroarch; fi
     - "make install DESTDIR=${MEDIA_PATH}/${CI_PROJECT_NAME}/AppDir prefix=/usr"
     - "rm -rf ${MEDIA_PATH}/${CI_PROJECT_NAME}/AppDir/etc"
     - "cd ${MEDIA_PATH}/${CI_PROJECT_NAME}/ && tar -czf AppDir.tar.gz AppDir && rm -rf AppDir && cd -"
@@ -258,6 +265,7 @@ build-retroarch-linux-i686:
   stage: build
   variables:
     MEDIA_PATH: .media
+    STRIP_BIN:  1
   before_script:
     - export NUMPROC=$(($(nproc)/3))
   artifacts:
@@ -271,6 +279,7 @@ build-retroarch-linux-i686:
     - "mkdir -p ${MEDIA_PATH}/${CI_PROJECT_NAME}/AppDirQt"
     - "./configure --prefix=/usr"
     - "make -j$NUMPROC"
+    - if [ $STRIP_BIN -eq 1 ]; then strip --strip-unneeded retroarch; fi
     - "make install DESTDIR=${MEDIA_PATH}/${CI_PROJECT_NAME}/AppDirQt prefix=/usr"
     - "rm -rf ${MEDIA_PATH}/${CI_PROJECT_NAME}/AppDirQt/etc"
     - "cd ${MEDIA_PATH}/${CI_PROJECT_NAME}/ && tar -czf AppDirQt.tar.gz AppDirQt && rm -rf AppDirQt && cd -"
@@ -280,6 +289,7 @@ build-retroarch-linux-i686:
     - "make clean"
     - "./configure --disable-qt --prefix=/usr"
     - "make -j$NUMPROC"
+    - if [ $STRIP_BIN -eq 1 ]; then strip --strip-unneeded retroarch; fi
     - "make install DESTDIR=${MEDIA_PATH}/${CI_PROJECT_NAME}/AppDir prefix=/usr"
     - "rm -rf ${MEDIA_PATH}/${CI_PROJECT_NAME}/AppDir/etc"
     - "cd ${MEDIA_PATH}/${CI_PROJECT_NAME}/ && tar -czf AppDir.tar.gz AppDir && rm -rf AppDir && cd -"
@@ -500,6 +510,7 @@ build-retroarch-dingux-mips32:
   stage: build
   variables:
     MEDIA_PATH: .media
+    STRIP_BIN:  1
   before_script:
     - export NUMPROC=$(($(nproc)/3))
   artifacts:

--- a/Makefile.rg350
+++ b/Makefile.rg350
@@ -19,6 +19,12 @@ else
 CXX                   = $(TOOLCHAIN_DIR)/usr/bin/mipsel-gcw0-linux-uclibc-g++
 endif
 
+ifdef GCW0_STRIP
+STRIP                 = $(GCW0_STRIP)
+else
+STRIP                 = $(TOOLCHAIN_DIR)/usr/bin/mipsel-gcw0-linux-uclibc-strip
+endif
+
 GCW0_SDL_CONFIG      ?= $(TOOLCHAIN_DIR)/usr/mipsel-gcw0-linux-uclibc/sysroot/usr/bin/sdl-config
 GCW0_FREETYPE_CONFIG ?= $(TOOLCHAIN_DIR)/usr/mipsel-gcw0-linux-uclibc/sysroot/usr/bin/freetype-config
 GCW0_MK_SQUASH_FS    ?= $(TOOLCHAIN_DIR)/usr/bin/mksquashfs
@@ -212,6 +218,7 @@ opk: $(TARGET)
 	echo "$$DESKTOP_ENTRY" > default.gcw0.desktop
 	rm -f $(OPK_NAME)
 	cp media/ico_src/icon32.png retroarch.png
+	if [ $$STRIP_BIN -eq 1 ]; then $(STRIP) --strip-unneeded retroarch; fi
 	$(GCW0_MK_SQUASH_FS) retroarch default.gcw0.desktop retroarch.png $(OPK_NAME) -all-root -no-xattrs -noappend -no-exports
 	rm -f default.gcw0.desktop retroarch.png
 


### PR DESCRIPTION
## Description

With this PR, generated `windows-x64`/`windows-i686`/`linux-x64`/`linux-i686`/`dingux-mips32` RetroArch binaries are automatically stripped when built via gitlab. We already do this for cores, so it seems appropriate to do it for RetroArch as well. This reduces binary size by 10-20%.

Stripping can be disabled by setting `STRIP_BIN` to `0` in the build pipeline.