### PR TITLE
(cheevos) include achievement runtime state in save states

### DIFF
--- a/cheevos/cheevos.h
+++ b/cheevos/cheevos.h
@@ -42,6 +42,9 @@ enum
 };
 
 bool rcheevos_load(const void *data);
+size_t rcheevos_get_serialize_size(void);
+bool rcheevos_get_serialized_data(void* buffer);
+bool rcheevos_set_serialized_data(void* buffer);
 
 void rcheevos_reset_game(void);
 

--- a/content.h
+++ b/content.h
@@ -52,7 +52,7 @@ bool content_load_state(const char* path, bool load_to_backup_buffer, bool autol
 bool content_save_state(const char *path, bool save_to_disk, bool autosave);
 
 /* Gets the number of bytes required to serialize the state. */
-size_t content_get_serialized_size();
+size_t content_get_serialized_size(void);
 
 /* Serializes the current state. buffer must be at least content_get_serialized_size bytes */
 bool content_serialize_state(void* buffer, size_t buffer_size);

--- a/content.h
+++ b/content.h
@@ -51,6 +51,15 @@ bool content_load_state(const char* path, bool load_to_backup_buffer, bool autol
 /* Save a state from memory to disk. */
 bool content_save_state(const char *path, bool save_to_disk, bool autosave);
 
+/* Gets the number of bytes required to serialize the state. */
+size_t content_get_serialized_size();
+
+/* Serializes the current state. buffer must be at least content_get_serialized_size bytes */
+bool content_serialize_state(void* buffer, size_t buffer_size);
+
+/* Deserializes the current state. */
+bool content_deserialize_state(const void* serialized_data, size_t serialized_size);
+
 /* Waits for any in-progress save state tasks to finish */
 void content_wait_for_save_state_task(void);
 

--- a/deps/rcheevos/include/rcheevos.h
+++ b/deps/rcheevos/include/rcheevos.h
@@ -392,6 +392,7 @@ typedef struct rc_runtime_trigger_t {
   rc_trigger_t* trigger;
   void* buffer;
   unsigned char md5[16];
+  int serialized_size;
   char owns_memrefs;
 }
 rc_runtime_trigger_t;

--- a/deps/rcheevos/src/rcheevos/runtime.c
+++ b/deps/rcheevos/src/rcheevos/runtime.c
@@ -172,6 +172,7 @@ int rc_runtime_activate_achievement(rc_runtime_t* self, unsigned id, const char*
   self->triggers[self->trigger_count].id = id;
   self->triggers[self->trigger_count].trigger = trigger;
   self->triggers[self->trigger_count].buffer = trigger_buffer;
+  self->triggers[self->trigger_count].serialized_size = 0;
   memcpy(self->triggers[self->trigger_count].md5, md5, 16);
   self->triggers[self->trigger_count].owns_memrefs = owns_memref;
   ++self->trigger_count;

--- a/tasks/task_save.c
+++ b/tasks/task_save.c
@@ -46,6 +46,10 @@
 #include "../network/netplay/netplay.h"
 #endif
 
+#ifdef HAVE_CHEEVOS
+#include "../cheevos/cheevos.h"
+#endif
+
 #include "../content.h"
 #include "../core.h"
 #include "../file_path_special.h"
@@ -63,6 +67,11 @@
 #else
 #define SAVE_STATE_CHUNK 4096
 #endif
+
+#define RASTATE_VERSION 1
+#define RASTATE_MEM_BLOCK "MEM "
+#define RASTATE_CHEEVOS_BLOCK "ACHV"
+#define RASTATE_END_BLOCK "END "
 
 struct ram_type
 {
@@ -150,6 +159,15 @@ static struct autosave_st autosave_state;
 /* TODO/FIXME - global state - perhaps move outside this file */
 static bool save_state_in_background       = false;
 static struct string_list *task_save_files = NULL;
+
+typedef struct rastate_size_info
+{
+   size_t total_size;
+   size_t coremem_size;
+#ifdef HAVE_CHEEVOS
+   size_t cheevos_size;
+#endif
+} rastate_size_info_t;
 
 #ifdef HAVE_THREADS
 /**
@@ -575,13 +593,106 @@ static void task_save_handler_finished(retro_task_t *task,
    free(state);
 }
 
-static void *get_serialized_data(const char *path, size_t serial_size)
+static size_t content_align_size(size_t size)
+{
+   /* align to 8-byte boundary */
+   return ((size + 7) & ~7);
+}
+
+static bool content_get_rastate_size(rastate_size_info_t* size)
+{
+   retro_ctx_size_info_t info;
+
+   core_serialize_size(&info);
+   if (!info.size)
+      return false;
+
+   size->coremem_size = info.size;
+   /* 8-byte identifier, 8-byte block header, content, 8-byte terminator */
+   size->total_size = 8 + 8 + content_align_size(info.size) + 8;
+
+#ifdef HAVE_CHEEVOS
+   size->cheevos_size = rcheevos_get_serialize_size();
+   if (size->cheevos_size > 0)
+      size->total_size += 8 + content_align_size(size->cheevos_size); /* 8-byte block header + content */
+#endif
+
+   return true;
+}
+
+size_t content_get_serialized_size()
+{
+   rastate_size_info_t size;
+   if (!content_get_rastate_size(&size))
+      return 0;
+
+   return size.total_size;
+}
+
+static void content_write_block_header(unsigned char* output, const char* header, size_t size)
+{
+   memcpy(output, header, 4);
+   output[4] = ((size) & 0xFF);
+   output[5] = ((size >> 8) & 0xFF);
+   output[6] = ((size >> 16) & 0xFF);
+   output[7] = ((size >> 24) & 0xFF);
+}
+
+static bool content_write_serialized_state(void* buffer, rastate_size_info_t* size)
 {
    retro_ctx_serialize_info_t serial_info;
-   bool ret    = false;
-   void *data  = NULL;
+   unsigned char* output = (unsigned char*)buffer;
 
-   if (!serial_size)
+   /* 8-byte identifier "RASTATE1" where 1 is the version */
+   memcpy(output, "RASTATE", 7);
+   output[7] = RASTATE_VERSION;
+   output += 8;
+
+   /* important - write the unaligned size - some cores fail if they aren't passed the exact right size. */
+   content_write_block_header(output, RASTATE_MEM_BLOCK, size->coremem_size);
+   output += 8;
+
+   /* important - pass the unaligned size to the core. some fail if it isn't exactly what they're expecting. */
+   serial_info.size = size->coremem_size;
+   serial_info.data = (void*)output;
+   if (!core_serialize(&serial_info))
+      return false;
+
+   output += content_align_size(size->coremem_size);
+
+#ifdef HAVE_CHEEVOS
+   if (size->cheevos_size)
+   {
+      content_write_block_header(output, RASTATE_CHEEVOS_BLOCK, size->cheevos_size);
+
+      if (rcheevos_get_serialized_data(output + 8))
+         output += content_align_size(size->cheevos_size) + 8;
+   }
+#endif
+
+   content_write_block_header(output, RASTATE_END_BLOCK, 0);
+
+   return true;
+}
+
+bool content_serialize_state(void* buffer, size_t buffer_size)
+{
+   rastate_size_info_t size;
+   if (!content_get_rastate_size(&size))
+      return false;
+
+   if (size.total_size > buffer_size)
+      return false;
+
+   return content_write_serialized_state(buffer, &size);
+}
+
+static void *content_get_serialized_data(size_t* serial_size)
+{
+   void* data;
+
+   rastate_size_info_t size;
+   if (!content_get_rastate_size(&size))
       return NULL;
 
    /* Ensure buffer is initialised to zero
@@ -589,21 +700,17 @@ static void *get_serialized_data(const char *path, size_t serial_size)
     *   sizes when core requests a larger buffer
     *   than it needs (and leaves the excess
     *   as uninitialised garbage) */
-   data = calloc(serial_size, 1);
-
+   data = calloc(size.total_size, 1);
    if (!data)
       return NULL;
 
-   serial_info.data = data;
-   serial_info.size = serial_size;
-   ret              = core_serialize(&serial_info);
-
-   if (!ret)
+   if (!content_write_serialized_state(data, &size))
    {
       free(data);
       return NULL;
    }
 
+   *serial_size = size.total_size;
    return data;
 }
 
@@ -634,7 +741,11 @@ static void task_save_handler(retro_task_t *task)
    }
 
    if (!state->data)
-      state->data  = get_serialized_data(state->path, state->size);
+   {
+      size_t size;
+      state->data = content_get_serialized_data(&size);
+      state->size = (ssize_t)size;
+   }
 
    remaining       = MIN(state->size - state->written, SAVE_STATE_CHUNK);
 
@@ -921,6 +1032,91 @@ error:
    task_load_handler_finished(task, state);
 }
 
+static bool content_load_rastate1(unsigned char* input, size_t size)
+{
+   unsigned char* stop = input + size;
+   unsigned char* marker;
+   bool seen_core = false;
+#ifdef HAVE_CHEEVOS
+   bool seen_cheevos = false;
+#endif
+
+   input += 8;
+   while (input < stop)
+   {
+      size_t block_size = (input[7] << 24 | input[6] << 16 | input[5] << 8 | input[4]);
+      marker = input;
+      input += 8;
+
+      if (memcmp(marker, RASTATE_MEM_BLOCK, 4) == 0)
+      {
+         retro_ctx_serialize_info_t serial_info;
+         serial_info.data_const = (void*)input;
+         serial_info.size = block_size;
+         if (!core_unserialize(&serial_info))
+            return false;
+
+         seen_core = true;
+      }
+#ifdef HAVE_CHEEVOS
+      else if (memcmp(marker, RASTATE_CHEEVOS_BLOCK, 4) == 0)
+      {
+         if (rcheevos_set_serialized_data((void*)input))
+            seen_cheevos = true;
+      }
+#endif
+      else if (memcmp(marker, RASTATE_END_BLOCK, 4) == 0)
+      {
+         break;
+      }
+
+      input += content_align_size(block_size);
+   }
+
+   if (!seen_core)
+      return false;
+
+#ifdef HAVE_CHEEVOS
+   if (!seen_cheevos)
+      rcheevos_set_serialized_data(NULL);
+#endif
+
+   return true;
+}
+
+bool content_deserialize_state(const void* serialized_data, size_t serialized_size)
+{
+   if (memcmp(serialized_data, "RASTATE", 7) != 0)
+   {
+      /* old format is just core data, load it directly */
+      retro_ctx_serialize_info_t serial_info;
+      serial_info.data_const = serialized_data;
+      serial_info.size = serialized_size;
+      if (!core_unserialize(&serial_info))
+         return false;
+
+#ifdef HAVE_CHEEVOS
+      rcheevos_set_serialized_data(NULL);
+#endif
+   }
+   else
+   {
+      unsigned char* input = (unsigned char*)serialized_data;
+      switch (input[7]) /* version */
+      {
+         case 1:
+            if (!content_load_rastate1(input, serialized_size))
+               return false;
+            break;
+
+         default:
+            return false;
+      }
+   }
+
+   return true;
+}
+
 /**
  * content_load_state_cb:
  * @path      : path that state will be loaded from.
@@ -931,7 +1127,6 @@ static void content_load_state_cb(retro_task_t *task,
       void *task_data,
       void *user_data, const char *error)
 {
-   retro_ctx_serialize_info_t serial_info;
    unsigned i;
    bool ret;
    load_task_data_t *load_data = (load_task_data_t*)task_data;
@@ -1024,15 +1219,12 @@ static void content_load_state_cb(retro_task_t *task,
       }
    }
 
-   serial_info.data_const = buf;
-   serial_info.size       = size;
-
    /* Backup the current state so we can undo this load */
    content_save_state("RAM", false, false);
 
-   ret                    = core_unserialize(&serial_info);
+   ret = content_deserialize_state(buf, size);
 
-    /* Flush back. */
+   /* Flush back. */
    for (i = 0; i < num_blocks; i++)
    {
       if (blocks[i].data)
@@ -1266,15 +1458,17 @@ bool content_save_state(const char *path, bool save_to_disk, bool autosave)
 {
    retro_ctx_size_info_t info;
    void *data  = NULL;
+   size_t serial_size;
 
    core_serialize_size(&info);
 
    if (info.size == 0)
       return false;
+   serial_size = info.size;
 
    if (!save_state_in_background)
    {
-      data = get_serialized_data(path, info.size);
+      data = content_get_serialized_data(&serial_size);
 
       if (!data)
       {
@@ -1287,7 +1481,7 @@ bool content_save_state(const char *path, bool save_to_disk, bool autosave)
       RARCH_LOG("[State]: %s \"%s\", %u %s.\n",
             msg_hash_to_str(MSG_SAVING_STATE),
             path,
-            (unsigned)info.size,
+            (unsigned)serial_size,
             msg_hash_to_str(MSG_BYTES));
    }
 
@@ -1301,15 +1495,15 @@ bool content_save_state(const char *path, bool save_to_disk, bool autosave)
          RARCH_LOG("[State]: %s ...\n",
                msg_hash_to_str(MSG_FILE_ALREADY_EXISTS_SAVING_TO_BACKUP_BUFFER));
 
-         task_push_load_and_save_state(path, data, info.size, true, autosave);
+         task_push_load_and_save_state(path, data, serial_size, true, autosave);
       }
       else
-         task_push_save_state(path, data, info.size, autosave);
+         task_push_save_state(path, data, serial_size, autosave);
    }
    else
    {
       if (!data)
-         data = get_serialized_data(path, info.size);
+         data = content_get_serialized_data(&serial_size);
 
       if (!data)
       {
@@ -1328,16 +1522,16 @@ bool content_save_state(const char *path, bool save_to_disk, bool autosave)
          undo_load_buf.data = NULL;
       }
 
-      undo_load_buf.data = malloc(info.size);
+      undo_load_buf.data = malloc(serial_size);
       if (!undo_load_buf.data)
       {
          free(data);
          return false;
       }
 
-      memcpy(undo_load_buf.data, data, info.size);
+      memcpy(undo_load_buf.data, data, serial_size);
       free(data);
-      undo_load_buf.size = info.size;
+      undo_load_buf.size = serial_size;
       strlcpy(undo_load_buf.path, path, sizeof(undo_load_buf.path));
    }
 

--- a/tasks/task_save.c
+++ b/tasks/task_save.c
@@ -620,7 +620,7 @@ static bool content_get_rastate_size(rastate_size_info_t* size)
    return true;
 }
 
-size_t content_get_serialized_size()
+size_t content_get_serialized_size(void)
 {
    rastate_size_info_t size;
    if (!content_get_rastate_size(&size))


### PR DESCRIPTION
## Description

Creates a wrapper object that contains the core state and achievement state and uses that for save states and rewind states. The wrapper is created before applying RZIP if enabled. Netplay and runahead still use the raw unwrapped core state.

The basic structure of the wrapper object is an 8 byte marker followed by one or more chunks. Each chunk has an 8 byte header identifying the chunk type and its size. This adds 32 bytes plus the achievement state size to each save state (before compression).

If the 8 byte marker is not seen when loading a state, the state is assumed to be the old format (raw core state) and passed directly to the core. New states cannot be loaded by the old code as the entire wrapper object would be passed to the core and the core would not accept it.

To address the fact that rewind uses a fixed state size, it must be stopped and restarted once the achievements are loaded to account for the additional space required for the achievement state data. As achievements are unlocked, the achievement state shrinks, but the rewind buffer size is not further modified. The wrapper object simply won't fill the entire allocated space.

## Related Issues

fixes #11894

## Related Pull Requests

n/a

## Reviewers

@twinaphex @Alcaro @Sanaki 
