### PR TITLE
input_keyboard_event(): Add NULL check (prevents potential segfault when input remaps are disabled)

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -25709,19 +25709,19 @@ void input_keyboard_event(bool down, unsigned code,
    else
    {
       retro_keyboard_event_t *key_event = &p_rarch->runloop_key_event;
-      input_mapper_t            *handle = p_rarch->input_driver_mapper;
       bool block                        = false;
 
-      if (code == RETROK_UNKNOWN ||
-            key_event == NULL)
+      if ((code == RETROK_UNKNOWN) || !key_event)
          return;
 
       /* Block hotkey+RetroPad mapped keyboard key events,
        * but not with game focus and from keyboard device type */
       if (!p_rarch->game_focus_state.enabled)
       {
+         input_mapper_t *handle = p_rarch->input_driver_mapper;
+
          block = BIT512_GET(p_rarch->keyboard_mapping_bits, code);
-         if (block && MAPPER_GET_KEY(handle, code))
+         if (block && handle && MAPPER_GET_KEY(handle, code))
             block = false;
       }
 


### PR DESCRIPTION
## Description

This PR fixes a potential edge case segfault when reinitialising drivers with input remaps disabled by adding a `p_rarch->input_driver_mapper == NULL` check to `input_keyboard_event()`
