### PR TITLE
Logging level adjustments

### DIFF
--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -3004,7 +3004,7 @@ bool vulkan_create_swapchain(gfx_ctx_vulkan_data_t *vk,
 
    for (i = 0; i < present_mode_count; i++)
    {
-      RARCH_LOG("[Vulkan]: Swapchain supports present mode: %u.\n",
+      RARCH_DBG("[Vulkan]: Swapchain supports present mode: %u.\n",
             present_modes[i]);
    }
 

--- a/retroarch.c
+++ b/retroarch.c
@@ -16919,7 +16919,7 @@ static bool rarch_environment_cb(unsigned cmd, void *data)
          break;
 
       case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY:
-         RARCH_LOG("[Environ]: RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY.\n");
+         RARCH_DBG("[Environ]: RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY.\n");
 
          {
             const struct retro_core_option_display *core_options_display = (const struct retro_core_option_display *)data;
@@ -16930,7 +16930,6 @@ static bool rarch_environment_cb(unsigned cmd, void *data)
                      core_options_display->key,
                      core_options_display->visible);
          }
-
          break;
 
       case RETRO_ENVIRONMENT_GET_MESSAGE_INTERFACE_VERSION:


### PR DESCRIPTION
## Description

Some rather useless noise dropped to debug level. Cores that use core option visibilities get spammed with this per option, which can be a bunch (especially in the Commodore cores).
```
[INFO] [Environ]: RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY.
```

