### PR TITLE
Add remap clearing ability under Quick Menu controls

### DIFF
--- a/menu/cbs/menu_cbs_scan.c
+++ b/menu/cbs/menu_cbs_scan.c
@@ -164,6 +164,23 @@ static int action_scan_input_desc(const char *path,
    menu_entries_get_last_stack(NULL, &menu_label, NULL, NULL, NULL);
 
    if (string_is_equal(menu_label,
+            msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_REMAPPINGS_PORT_LIST)))
+   {
+      settings_t *settings = config_get_ptr();
+      inp_desc_user        = atoi(label);
+      /* Skip 'Device Type' and 'Analog to Digital Type' */
+      key                  = (unsigned)(idx - 2);
+
+      if (type >= MENU_SETTINGS_INPUT_DESC_BEGIN
+            && type <= MENU_SETTINGS_INPUT_DESC_END)
+         settings->uints.input_remap_ids[inp_desc_user][key] = RARCH_UNMAPPED;
+      else if (type >= MENU_SETTINGS_INPUT_DESC_KBD_BEGIN
+            && type <= MENU_SETTINGS_INPUT_DESC_KBD_END)
+         settings->uints.input_keymapper_ids[inp_desc_user][key] = RETROK_UNKNOWN;
+
+      return 0;
+   }
+   else if (string_is_equal(menu_label,
             msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_USER_BINDS_LIST)))
    {
       unsigned char player_no_str = atoi(&label[1]);
@@ -213,6 +230,17 @@ static int menu_cbs_init_bind_scan_compare_type(menu_file_list_cbs_t *cbs,
       case FILE_TYPE_NONE:
       default:
          break;
+   }
+
+   if (type >= MENU_SETTINGS_INPUT_DESC_BEGIN
+         && type <= MENU_SETTINGS_INPUT_DESC_END)
+   {
+      BIND_ACTION_SCAN(cbs, action_scan_input_desc);
+   }
+   else if (type >= MENU_SETTINGS_INPUT_DESC_KBD_BEGIN
+         && type <= MENU_SETTINGS_INPUT_DESC_KBD_END)
+   {
+      BIND_ACTION_SCAN(cbs, action_scan_input_desc);
    }
 
    return -1;

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -9526,7 +9526,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                         strlcpy(descriptor, desc_label, sizeof(descriptor));
                      }
 
-                     if (menu_entries_append_enum(list, descriptor, "",
+                     if (menu_entries_append_enum(list, descriptor, info->path,
                               MSG_UNKNOWN,
                               MENU_SETTINGS_INPUT_DESC_BEGIN +
                               (p * (RARCH_FIRST_CUSTOM_BIND + 8)) +  retro_id, 0, 0))
@@ -9570,7 +9570,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                         strlcpy(descriptor, desc_label, sizeof(descriptor));
                      }
 
-                     if (menu_entries_append_enum(list, descriptor, "",
+                     if (menu_entries_append_enum(list, descriptor, info->path,
                               MSG_UNKNOWN,
                               MENU_SETTINGS_INPUT_DESC_KBD_BEGIN +
                               (p * RARCH_FIRST_CUSTOM_BIND) + retro_id, 0, 0))


### PR DESCRIPTION
## Description

Currently input nulling only works under Settings controls, so let's add it under Quick Menu too.
