### PR TITLE
Fix 'Content dir-specific overrides' log message

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -3579,7 +3579,7 @@ bool config_load_override(void *data)
       temp_path[0]    = '\0';
 
       RARCH_LOG("[Overrides]: Content dir-specific overrides found at \"%s\".\n",
-            game_path);
+            content_path);
 
       if (should_append)
       {


### PR DESCRIPTION
## Description

As discussed here: https://github.com/libretro/RetroArch/pull/11843#issuecomment-784110862, the `[INFO] [Overrides]: Content dir-specific overrides found at...` log message currently displays the wrong config file path. This trivial PR fixes the issue.