### PR TITLE
Ensure RARCH_CTL_CORE_OPTIONS_LIST_GET returns false if no core options are available

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -35742,7 +35742,7 @@ bool rarch_ctl(enum rarch_ctl_state state, void *data)
       case RARCH_CTL_CORE_OPTIONS_LIST_GET:
          {
             core_option_manager_t **coreopts = (core_option_manager_t**)data;
-            if (!coreopts)
+            if (!coreopts || !p_rarch->runloop_core_options)
                return false;
             *coreopts = p_rarch->runloop_core_options;
          }


### PR DESCRIPTION
## Description

At present, a call to `RARCH_CTL_CORE_OPTIONS_LIST_GET` will return true even if no core options are available. This is a bug, but the effects of it have only come to light with the addition of the new `Manage Core Options` menu, which uses `RARCH_CTL_CORE_OPTIONS_LIST_GET` to fetch the currently active options file name. As such, a segfault will occur under the following conditions:

1) The `XMB` or `Ozone` menu drivers are active
2) The user does not have an active core options override
3) The user opens the `Manage Core Options` menu
4) The user toggles off the Quick Menu
5) The user closes the current content using the 'close content' hotkey

What happens in this case is that `XMB` or `Ozone` will display the 'old' `Manage Core Options` menu for a split second during the animated menu transition, which calls `RARCH_CTL_CORE_OPTIONS_LIST_GET` - the function returns true, but at this point the core options have already been unloaded, so we end up operating on a NULL pointer...

This PR fixes the issue by ensuring `RARCH_CTL_CORE_OPTIONS_LIST_GET` returns false if the core options pointer is NULL.