### PR TITLE
(cheevos) ensure hardcore remains disabled through load process

### DIFF
--- a/tasks/task_save.c
+++ b/tasks/task_save.c
@@ -954,6 +954,11 @@ static void task_load_handler(retro_task_t *task)
          goto error;
    }
 
+#ifdef HAVE_CHEEVOS
+   if (rcheevos_hardcore_active())
+      task_set_cancelled(task, true);
+#endif
+
    remaining          = MIN(state->size - state->bytes_read, SAVE_STATE_CHUNK);
    bytes_read         = intfstream_read(state->file,
          (uint8_t*)state->data + state->bytes_read, remaining);
@@ -1132,6 +1137,11 @@ static void content_load_state_cb(retro_task_t *task,
    struct sram_block *blocks   = NULL;
    settings_t *settings        = config_get_ptr();
    bool block_sram_overwrite   = settings->bools.block_sram_overwrite;
+
+#ifdef HAVE_CHEEVOS
+   if (rcheevos_hardcore_active())
+      goto error;
+#endif
 
    RARCH_LOG("[State]: %s \"%s\", %u %s.\n",
          msg_hash_to_str(MSG_LOADING_STATE),


### PR DESCRIPTION
## Description

When loading a state, the state file is buffered into memory asynchronously. If this is slow enough, it may possible to re-enable hardcore before the load finishes.

I was only able to test this behavior by adding sleeps to the code, but it should still be protected against.

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@Sanaki
