### PR TITLE
add READ/WRITE_CORE_MEMORY network commands

### DIFF
--- a/retroarch_data.h
+++ b/retroarch_data.h
@@ -2691,6 +2691,8 @@ static bool command_show_osd_msg(const char* arg);
 static bool command_read_ram(const char *arg);
 static bool command_write_ram(const char *arg);
 #endif
+static bool command_read_memory(const char *arg);
+static bool command_write_memory(const char *arg);
 
 static const struct cmd_action_map action_map[] = {
 #if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)
@@ -2701,9 +2703,13 @@ static const struct cmd_action_map action_map[] = {
    { "GET_CONFIG_PARAM", command_get_config_param, "<param name>" },
    { "SHOW_MSG",         command_show_osd_msg,     "No argument" },
 #if defined(HAVE_CHEEVOS)
-   { "READ_CORE_RAM",   command_read_ram,    "<address> <number of bytes>" },
-   { "WRITE_CORE_RAM",  command_write_ram,   "<address> <byte1> <byte2> ..." },
+   /* These functions use achievement addresses and only work if a game with achievements is
+    * loaded. READ_CORE_MEMORY and WRITE_CORE_MEMORY are preferred and use system addresses. */
+   { "READ_CORE_RAM",    command_read_ram,         "<address> <number of bytes>" },
+   { "WRITE_CORE_RAM",   command_write_ram,        "<address> <byte1> <byte2> ..." },
 #endif
+   { "READ_CORE_MEMORY", command_read_memory,      "<address> <number of bytes>" },
+   { "WRITE_CORE_MEMORY",command_write_memory,     "<address> <byte1> <byte2> ..." },
 };
 
 static const struct cmd_map map[] = {


### PR DESCRIPTION
## Description

Adds `READ_CORE_MEMORY` and `WRITE_CORE_MEMORY` network commands as replacements for `READ_CORE_RAM` and `WRITE_CORE_RAM` (#3068), which are misleading as they only work when achievements are active and use the achievement addressing scheme, which is usually just `RETRO_MEMORY_SYSTEM_RAM` at $000000 and `RETRO_MEMORY_SAVE_RAM` immediately following the system RAM.

The parameters to these functions are identical to the functions they're replacing. 
* `READ_CORE_MEMORY` takes an address (in hex) and a number of bytes to read (in decimal). The response is the address followed by a sequence of hex values representing the bytes of memory that were read. If the memory cannot be read, the first byte is "-1" and an error message follows. (`READ_CORE_RAM` returned "-1" as the first byte, but did not include an error message).
* `WRITE_CORE_MEMORY` takes an address (in hex) and a series of hex values representing the bytes of memory to write. The response is the address followed by the number of bytes written. If the memory cannot be written, the number of bytes written is "-1" and an error message follows (`WRITE_CORE_RAM` did not return anything).

These functions require the core to implement `RETRO_ENVIRONMENT_SET_MEMORY_MAPS`. If the core does not implement `RETRO_ENVIRONMENT_SET_MEMORY_MAPS`, they will fail with a "-1 no memory map defined" error.

Because these commands use the `RETRO_ENVIRONMENT_SET_MEMORY_MAPS` definitions, read/write operations are limited to one memory descriptor at a time. Attempting to read more bytes than are remaining in the descriptor will stop dumping at the end of the descriptor. Attempting to write more bytes than are remaining in the descriptor will stop writing at the end of the descriptor and return the number of bytes actually written.

-----

The system RAM on a SNES is addressed from $7E0000-$7FFFFF, but the achievement mapping accesses it from $000000-$01FFFF.

Here's an example comparing the two commands using the bsnes-mercury core:
```
$ echo -n "READ_CORE_RAM 0004ee 1" | nc -u -w1 localhost 55355
READ_CORE_RAM 4ee 09
$ echo -n "READ_CORE_MEMORY 7e04ee 1" | nc -u -w1 localhost 55355
READ_CORE_MEMORY 7e04ee 09
```
As the Snes9x core does not currently implement `RETRO_ENVIRONMENT_SET_MEMORY_MAPS`, `READ_CORE_MEMORY` returns an error, but `READ_CORE_RAM` can still access the data through the `RETRO_MEMORY_SYSTEM_RAM`:
```
$ echo -n "READ_CORE_RAM 0004ee 1" | nc -u -w1 localhost 55355
READ_CORE_RAM 4ee 09
$ echo -n "READ_CORE_MEMORY 7e04ee 1" | nc -u -w1 localhost 55355
READ_CORE_MEMORY 7e04ee -1 no memory map defined
```

On the other hand, with achievements disabled, `READ_CORE_MEMORY` is still functional (in bsnes-mercury):
```
$ echo -n "READ_CORE_RAM 0004ee 1" | nc -u -w1 localhost 55355
READ_CORE_RAM 4ee -1
$ echo -n "READ_CORE_MEMORY 7e04ee 1" | nc -u -w1 localhost 55355
READ_CORE_MEMORY 7e04ee 09
```

## Related Issues

Requested by @chris062689
https://discord.com/channels/184109094070779904/434759979095031840/817604884068171796 

Requested by jsd1982:
https://discord.com/channels/184109094070779904/434759979095031840/793186696744271912

## Related Pull Requests

n/a

## Reviewers

@Alcaro
