### PR TITLE
Support building both universal and x64 open gl builds for macos

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -457,21 +457,34 @@ build-retroarch-osx-arm64-metal:
     - tar -czf RetroArch.tar.gz RetroArch.app
     - rm -rf RetroArch.app
 
-# Mac OS Universal, Metal
-build-retroarch-osx-universal-metal:
+.build-retroarch-macos-xcode:
+  # Metal/Universal x86_64 arm64 is default
   tags:
     - macosx-packaging
   stage: build
   variables:
-    XCARCHIVE_PATH: pkg/apple/build/RetroArch
+    XCARCHIVE_PATH: pkg/apple/build/RetroArchUniversal
+    XCPROJECT_NAME: RetroArch_Metal
+    XCCONFIG: GitLabCI.xcconfig
   artifacts:
     paths:
-    - RetroArch.zip
+    - ${XCPROJECT_NAME}.zip
     expire_in: 10 min
   dependencies: []
   script:
-    - xcodebuild -project pkg/apple/RetroArch_Metal.xcodeproj -config Release -scheme RetroArch -archivePath ${XCARCHIVE_PATH} -xcconfig pkg/apple/GitLabCI.xcconfig archive
-    - zip -qr RetroArch.zip ${XCARCHIVE_PATH}.xcarchive/Products/Users/gitlab/Applications/RetroArch.app
+    - xcodebuild -project pkg/apple/${XCPROJECT_NAME}.xcodeproj -config Release -scheme RetroArch -archivePath ${XCARCHIVE_PATH} -xcconfig pkg/apple/${XCCONFIG} archive
+    - zip -qr ${XCPROJECT_NAME}.zip ${XCARCHIVE_PATH}.xcarchive/Products/Users/gitlab/Applications/RetroArch.app
+
+# Mac OS Universal, Metal
+build-retroarch-osx-universal-metal:
+  extends: .build-retroarch-macos-xcode
+
+build-retroarch-osx-opengl-x64:
+  extends: .build-retroarch-macos-xcode
+  variables:
+    XCARCHIVE_PATH: pkg/apple/build/RetroArchOpenGL
+    XCPROJECT_NAME: RetroArch
+    XCCONFIG: OpenGL_GitLabCI.xcconfig
 
 build-retroarch-dingux-mips32:
   image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-dingux:latest

--- a/pkg/apple/OpenGL_GitLabCI.xcconfig
+++ b/pkg/apple/OpenGL_GitLabCI.xcconfig
@@ -1,0 +1,11 @@
+//
+//  OpenGL_GitLabCI.xcconfig
+//  RetroArch
+//
+//  Created by Yoshi Sugawara on 3/7/21.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+DEVELOPMENT_TEAM=UK699V5ZS8

--- a/pkg/apple/RetroArch.xcodeproj/project.pbxproj
+++ b/pkg/apple/RetroArch.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		84DD5EB71A89F1C7007336C1 /* retroarch.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = retroarch.icns; path = ../../media/retroarch.icns; sourceTree = "<group>"; };
 		8D1107310486CEB800E47090 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = OSX/Info.plist; sourceTree = "<group>"; };
 		8D1107320486CEB800E47090 /* RetroArch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RetroArch.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		9254B2F825F5A94300A1E0DA /* OpenGL_GitLabCI.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = OpenGL_GitLabCI.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -164,6 +165,7 @@
 		29B97314FDCFA39411CA2CEA /* RetroArch */ = {
 			isa = PBXGroup;
 			children = (
+				9254B2F825F5A94300A1E0DA /* OpenGL_GitLabCI.xcconfig */,
 				840222FA1A889EA2009AB261 /* Core */,
 				080E96DDFE201D6D7F000001 /* Classes */,
 				29B97315FDCFA39411CA2CEA /* Other Sources */,
@@ -279,6 +281,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 1;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 29B97314FDCFA39411CA2CEA /* RetroArch */;
@@ -433,6 +436,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = x86_64;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -467,6 +471,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = x86_64;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				FRAMEWORK_SEARCH_PATHS = (
@@ -540,7 +545,7 @@
 					"-DHAVE_SCREENSHOTS",
 					"-DHAVE_CHEATS",
 					"-DHAVE_MENU",
-               "-DHAVE_GFX_WIDGETS",
+					"-DHAVE_GFX_WIDGETS",
 					"-DOSX",
 					"-DHAVE_OPENGL",
 					"-DHAVE_CC_RESAMPLER",
@@ -625,7 +630,7 @@
 					"-DHAVE_SCREENSHOTS",
 					"-DHAVE_CHEATS",
 					"-DHAVE_MENU",
-               "-DHAVE_GFX_WIDGETS",
+					"-DHAVE_GFX_WIDGETS",
 					"-DOSX",
 					"-DHAVE_OPENGL",
 					"-DHAVE_CC_RESAMPLER",


### PR DESCRIPTION
Modified the supported architectures to be x86_64 only (as opposed to universal as it wouldn't compile under arm64) for the RetroArch.xcodeproj, and added a xcconfig so that it can be built in gitlab.