### PR TITLE
(X11) Remove useless XGrabs

### DIFF
--- a/input/drivers/x11_input.c
+++ b/input/drivers/x11_input.c
@@ -786,15 +786,6 @@ static void x_grab_mouse(void *data, bool state)
       return;
 
    x11->mouse_grabbed = state;
-
-   if (state)
-   {
-      XGrabPointer(x11->display, x11->win, False,
-                   ButtonPressMask | ButtonReleaseMask | PointerMotionMask,
-                   GrabModeAsync, GrabModeAsync, x11->win, None, CurrentTime);
-   }
-   else
-      XUngrabPointer(x11->display, CurrentTime);
 }
 
 static uint64_t x_input_get_capabilities(void *data)


### PR DESCRIPTION
## Description

As it turned out, mouse grab works fine without these functions, and they actually cause trouble with Alt-Tabbing.

`XWarpPointer()` alone seems to keep the cursor confined in the window area just like it should.

`udev` still has them, so it probably needs a makeover too.
