### PR TITLE
[gitlab][macOS] Updated artifact zip to not include subdirs for packaging step

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -473,7 +473,10 @@ build-retroarch-osx-arm64-metal:
   dependencies: []
   script:
     - xcodebuild -project pkg/apple/${XCPROJECT_NAME}.xcodeproj -config Release -scheme RetroArch -archivePath ${XCARCHIVE_PATH} -xcconfig pkg/apple/${XCCONFIG} archive
-    - zip -qr ${XCPROJECT_NAME}.zip ${XCARCHIVE_PATH}.xcarchive/Products/Users/gitlab/Applications/RetroArch.app
+    - pushd ${XCARCHIVE_PATH}.xcarchive/Products/Users/gitlab/Applications/
+    - zip -qr RetroArch.zip RetroArch.app
+    - popd
+    - mv ${XCARCHIVE_PATH}.xcarchive/Products/Users/gitlab/Applications/RetroArch.zip ${XCPROJECT_NAME}.zip
 
 # Mac OS Universal, Metal
 build-retroarch-osx-universal-metal:


### PR DESCRIPTION
Fixing the artifact zip to not include all the subdirectory paths so packaging step can work with the RetroArch.app directory structure directly.