### PR TITLE
libretro-db: hash.c is now lrc_hash.c

### DIFF
--- a/libretro-db/Makefile
+++ b/libretro-db/Makefile
@@ -30,7 +30,7 @@ C_CONVERTER_C = \
 			 $(LIBRETRODB_DIR)/bintree.c \
 			 $(LIBRETRODB_DIR)/query.c \
 			 $(LIBRETRODB_DIR)/c_converter.c \
-			 $(LIBRETRO_COMM_DIR)/hash/rhash.c \
+			 $(LIBRETRO_COMM_DIR)/hash/lrc_hash.c \
 			 $(LIBRETRO_COMM_DIR)/compat/compat_fnmatch.c \
 			 $(LIBRETRO_COMMON_C)
 


### PR DESCRIPTION
This fixes libretro-db c_converter.