### PR TITLE
have http tasks clean up after themselves

### DIFF
--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -4123,13 +4123,6 @@ finish:
             subdir_path, 0, 0, 0, ACTION_OK_DL_CORE_CONTENT_DIRS_SUBDIR_LIST);*/
    }
 
-   if (data)
-   {
-      if (data->data)
-         free(data->data);
-      free(data);
-   }
-
    if (user_data)
       free(user_data);
 }
@@ -4167,13 +4160,6 @@ static void cb_net_generic(retro_task_t *task,
 finish:
    refresh = true;
    menu_entries_ctl(MENU_ENTRIES_CTL_UNSET_REFRESH, &refresh);
-
-   if (data)
-   {
-      if (data->data)
-         free(data->data);
-      free(data);
-   }
 
    if (!err && 
          !string_ends_with_size(state->path,
@@ -4484,13 +4470,6 @@ finish:
    else if (transf && transf->enum_idx == MENU_ENUM_LABEL_CB_DISCORD_AVATAR)
       discord_avatar_set_ready(true);
 #endif
-
-   if (data)
-   {
-      if (data->data)
-         free(data->data);
-      free(data);
-   }
 
    if (transf)
       free(transf);
@@ -5548,16 +5527,8 @@ finish:
    if (err)
       RARCH_ERR("%s: %s\n", msg_hash_to_str(MSG_DOWNLOAD_FAILED), err);
 
-   if (data)
-   {
-      if (data->data)
-         free(data->data);
-      free(data);
-   }
-
    if (user_data)
       free(user_data);
-
 }
 
 #ifndef RARCH_CONSOLE

--- a/retroarch.c
+++ b/retroarch.c
@@ -8867,13 +8867,6 @@ finish:
    if (err)
       RARCH_ERR("%s: %s\n", msg_hash_to_str(MSG_DOWNLOAD_FAILED), err);
 
-   if (data)
-   {
-      if (data->data)
-         free(data->data);
-      free(data);
-   }
-
    if (user_data)
       free(user_data);
 }
@@ -9763,10 +9756,7 @@ static void netplay_announce_cb(retro_task_t *task,
       char *host_string              = NULL;
 
       if (data->len == 0)
-      {
-         free(task_data);
          return;
-      }
 
       buf = (char*)calloc(1, data->len + 1);
 
@@ -9778,7 +9768,6 @@ static void netplay_announce_cb(retro_task_t *task,
       {
          string_list_free(lines);
          free(buf);
-         free(task_data);
          return;
       }
 
@@ -9905,7 +9894,7 @@ static void netplay_announce_cb(retro_task_t *task,
 
       string_list_free(lines);
       free(buf);
-      free(task_data);
+
       if (mitm_ip)
          free(mitm_ip);
       if (mitm_port)
@@ -14042,12 +14031,6 @@ finish:
    if (error)
       RARCH_ERR("%s: %s\n", msg_hash_to_str(MSG_DOWNLOAD_FAILED), error);
 
-   if (data)
-   {
-      if (data->data)
-         free(data->data);
-      free(data);
-   }
    if (user_data)
       free(user_data);
 

--- a/tasks/task_core_updater.c
+++ b/tasks/task_core_updater.c
@@ -234,9 +234,12 @@ static void cb_http_task_core_updater_get_list(
    if (!list_handle)
       goto finish;
 
+   task_set_data(task, NULL); /* going to pass ownership to list_handle */
+
    list_handle->http_data          = data;
    list_handle->http_task_complete = true;
    list_handle->http_task_success  = success;
+
 
 finish:
 
@@ -258,6 +261,7 @@ static void free_core_updater_list_handle(
 
    if (list_handle->http_data)
    {
+      /* since we took onwership, we have to destroy it ourself */
       if (list_handle->http_data->data)
          free(list_handle->http_data->data);
 
@@ -643,13 +647,6 @@ finish:
    if (!string_is_empty(err))
       RARCH_ERR("[core updater] Download of '%s' failed: %s\n",
             (transf ? transf->path: "unknown"), err);
-
-   if (data)
-   {
-      if (data->data)
-         free(data->data);
-      free(data);
-   }
 
    if (transf)
       free(transf);

--- a/tasks/task_http.c
+++ b/tasks/task_http.c
@@ -211,6 +211,17 @@ task_finished:
    free(http);
 }
 
+static void task_http_transfer_cleanup(retro_task_t *task)
+{
+   http_transfer_data_t* data = task_get_data(task);
+   if (data)
+   {
+      if (data->data)
+         free(data->data);
+      free(data);
+   }
+}
+
 static bool task_http_finder(retro_task_t *task, void *user_data)
 {
    http_handle_t *http = NULL;
@@ -305,6 +316,7 @@ static void* task_push_http_transfer_generic(
    t->mute                 = mute;
    t->callback             = cb;
    t->progress_cb          = http_transfer_progress_cb;
+   t->cleanup              = task_http_transfer_cleanup;
    t->user_data            = user_data;
    t->progress             = -1;
 

--- a/tasks/task_pl_thumbnail_download.c
+++ b/tasks/task_pl_thumbnail_download.c
@@ -227,13 +227,6 @@ finish:
             (transf ? transf->path: "unknown"), err);
    }
 
-   if (data)
-   {
-      if (data->data)
-         free(data->data);
-      free(data);
-   }
-
    if (transf)
       free(transf);
 }


### PR DESCRIPTION
## Description

Fixes a memory leak in the achievements code where the http response was not being `free`'d. Rather than duplicate the logic yet again, I've registered a cleanup function for the http task, and eliminated all the places previously `free`'ing the http response.

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@twinaphex 
