### PR TITLE
GLUI: Fix main menu 'History' entry

### DIFF
--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -8950,7 +8950,7 @@ static int materialui_list_push(void *data, void *userdata,
             {
                MENU_DISPLAYLIST_PARSE_SETTINGS_ENUM(
                      info->list,
-                     MENU_ENUM_LABEL_SUBSYSTEM_SETTINGS,
+                     MENU_ENUM_LABEL_LOAD_CONTENT_HISTORY,
                      PARSE_ACTION,
                      false);
             }


### PR DESCRIPTION
## Description

Commit https://github.com/libretro/RetroArch/commit/4e883c4568e70d2ff357c8f717d847e105759c34 contains a typo which replaces the 'History' menu entry in GLUI with 'Subsystems'. This PR fixes the issue.

## Related Issues

This closes #12158

