### PR TITLE
(Ozone) Ensure all members are initialised when allocating nodes

### DIFF
--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -3790,6 +3790,7 @@ ozone_node_t *ozone_alloc_node(void)
    node->content_icon   = 0;
    node->fullpath       = NULL;
    node->sublabel_lines = 0;
+   node->wrap           = false;
 
    return node;
 }


### PR DESCRIPTION
## Description

This trivial PR ensures that the Ozone node member `wrap` is properly initialised on node creation, fixing ASAN errors such as: `menu/drivers/ozone/ozone_entries.c:748:18: runtime error: load of value 190, which is not a valid value for type '_Bool'`
