### PR TITLE
Prevent segfault when accessing 'Explore' menu

### DIFF
--- a/menu/menu_explore.c
+++ b/menu/menu_explore.c
@@ -597,7 +597,22 @@ static explore_state_t *explore_build_list(void)
             key_str                         = key->val.string.buff;
             if (string_is_equal(key_str, "crc"))
             {
-               crc32 = swap_if_little32(*(uint32_t*)val->val.binary.buff);
+               switch (strlen(val->val.binary.buff))
+               {
+                  case 1:
+                     crc32 = *(uint8_t*)val->val.binary.buff;
+                     break;
+                  case 2:
+                     crc32 = swap_if_little16(*(uint16_t*)val->val.binary.buff);
+                     break;
+                  case 4:
+                     crc32 = swap_if_little32(*(uint32_t*)val->val.binary.buff);
+                     break;
+                  default:
+                     crc32 = 0;
+                     break;
+               }
+
                continue;
             }
             else if (string_is_equal(key_str, "name"))


### PR DESCRIPTION
## Description

At present, the `menu_explore` code does the following:

```c
crc32 = swap_if_little32(*(uint32_t*)val->val.binary.buff);
```

This will generate a heap buffer overflow on many platforms if the size of the `val.binary.buff` array is not a multiple of 4. Unfortunately, this is sometimes the case - leading to a segfault when accessing the 'Explore' menu.

This PR fixes the issue.
