### PR TITLE
(cheevos) prevent double free

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -718,14 +718,6 @@ static void rcheevos_async_task_callback(
       CHEEVOS_ERR(RCHEEVOS_TAG "%s %u: %s\n", request->failure_message,
             request->id, error);
    }
-
-   if (data)
-   {
-      if (data->data)
-         free(data->data);
-
-      free(data);
-   }
 }
 
 static void rcheevos_validate_memrefs(rcheevos_locals_t* locals)


### PR DESCRIPTION
## Description

The cleanup changes made in #12157 were addressing a memory leak that was apparently fixed in #11916. I must not have done my upstream update correctly. This resulted in a double free. As I feel the solution in #12157 is the better implementation, I've made the same change to the achievement code as I did to all the other uses of the http task functions - allowing the http task to clean up after itself instead of requiring every use of the http task to know to do the cleanup.

## Related Issues

fixes #12170

## Related Pull Requests

n/a

## Reviewers

@twinaphex 
