### PR TITLE
(WINRAW) Key position fixes

### DIFF
--- a/gfx/common/win32_common.c
+++ b/gfx/common/win32_common.c
@@ -965,10 +965,22 @@ static LRESULT CALLBACK wnd_proc_common_internal(HWND hwnd,
              * DirectInput is not available */
             switch (keysym)
             {
-               /* Mod handling done in winraw_callback */
+               /* Mod & Keypad handling done in winraw_callback */
                case VK_SHIFT:
                case VK_CONTROL:
                case VK_MENU:
+               case VK_INSERT:
+               case VK_DELETE:
+               case VK_HOME:
+               case VK_END:
+               case VK_PRIOR:
+               case VK_NEXT:
+               case VK_UP:
+               case VK_DOWN:
+               case VK_LEFT:
+               case VK_RIGHT:
+               case VK_CLEAR:
+               case VK_RETURN:
                   return 0;
             }
 

--- a/input/input_keymaps.c
+++ b/input/input_keymaps.c
@@ -1795,7 +1795,7 @@ const struct rarch_key_map rarch_key_map_winraw[] = {
    { VK_RCONTROL, RETROK_RCTRL },
    { VK_LMENU, RETROK_LALT },
    { VK_RMENU, RETROK_RALT },
-   { VK_RETURN, RETROK_KP_ENTER },
+   { 0xE0, RETROK_KP_ENTER },
    { VK_CAPITAL, RETROK_CAPSLOCK },
    { VK_OEM_1, RETROK_SEMICOLON },
    { VK_OEM_PLUS, RETROK_EQUALS },
@@ -1808,6 +1808,7 @@ const struct rarch_key_map rarch_key_map_winraw[] = {
    { VK_OEM_5, RETROK_BACKSLASH },
    { VK_OEM_6, RETROK_RIGHTBRACKET },
    { VK_OEM_7, RETROK_QUOTE },
+   { VK_OEM_102, RETROK_OEM_102 },
    { 0, RETROK_UNKNOWN }
 };
 #endif


### PR DESCRIPTION
## Description

Those currently used virtual keycodes should probably be changed at some point to proper keycodes, so that these shenanigans are not required, but in the meantime this batch addresses a few crucial usability issues:

- Return and Keypad Enter are differentiated
  - Currently both press Keypad Enter
  -  Also separated Ins/Del/Home/End/PgUp/PgDn and their keypad counterparts
- Alt can be used in RetroPad binds
  - Currently Alt down will eat cursor keys, which is no bueno for default MAME binds
- Numlock no longer sends ninja Left Shift with cursor keys
- OEM 102 key added
