### PR TITLE
Upstream OGA patch for vertical screen

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1372,11 +1372,10 @@ OBJ += gfx/drivers_context/gfx_null_ctx.o
 
 ifeq ($(HAVE_KMS), 1)
    HAVE_AND_WILL_USE_DRM = 1
+   OBJ += gfx/drivers_context/drm_ctx.o
 
 ifeq ($(HAVE_ODROIDGO2), 1)
    OBJ += gfx/drivers_context/drm_go2_ctx.o
-else
-   OBJ += gfx/drivers_context/drm_ctx.o
 endif
    DEF_FLAGS += $(GBM_CFLAGS) $(DRM_CFLAGS)
    LIBS += $(GBM_LIBS) $(DRM_LIBS)

--- a/gfx/drivers_context/drm_go2_ctx.c
+++ b/gfx/drivers_context/drm_go2_ctx.c
@@ -119,11 +119,21 @@ static void *gfx_ctx_go2_drm_init(void *video_driver)
       return NULL;
 
    drm->display       = go2_display_create();
-   drm->presenter     = go2_presenter_create(drm->display,
-         DRM_FORMAT_RGB565, 0xff000000, true);
 
    drm->native_width  = go2_display_height_get(drm->display);
    drm->native_height = go2_display_width_get(drm->display);
+
+   /* This driver should only be used on rotated screens */
+   if (drm->native_width < drm->native_height)
+   {
+      /* This should be fixed by using wayland/weston... */
+      go2_display_destroy(drm->display);
+      free(drm);
+      return NULL;
+   }
+
+   drm->presenter     = go2_presenter_create(drm->display,
+         DRM_FORMAT_RGB565, 0xff000000, true);
 
    return drm;
 }

--- a/retroarch_data.h
+++ b/retroarch_data.h
@@ -795,9 +795,8 @@ static const gfx_ctx_driver_t *gfx_ctx_gl_drivers[] = {
 #if defined(HAVE_KMS)
 #if defined(HAVE_ODROIDGO2)
    &gfx_ctx_go2_drm,
-#else
-   &gfx_ctx_drm,
 #endif
+   &gfx_ctx_drm,
 #endif
 #if defined(ANDROID)
    &gfx_ctx_android,


### PR DESCRIPTION
This keeps the tradition DRM driver along with the OGA one. The probe
function skips the driver if the screen is non rotated to fall back to
the regular DRM driver. This is being upstreamed from the Lakka repo.

