### PR TITLE
Add OpenDingux Beta support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -403,6 +403,27 @@ build-retroarch-dingux-mips32:
     - "cp -f libretro-common/audio/dsp_filters/*.dsp ${MEDIA_PATH}/${CI_PROJECT_NAME}/filters/audio"
     - "cp -f gfx/video_filters/*.filt ${MEDIA_PATH}/${CI_PROJECT_NAME}/filters/video"
 
+build-retroarch-dingux-odbeta-mips32:
+  image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-dingux:odbeta
+  stage: build
+  variables:
+    MEDIA_PATH: .media
+    STRIP_BIN:  1
+  before_script:
+    - export NUMPROC=$(($(nproc)/3))
+  artifacts:
+    paths:
+    - retroarch_rg350_odbeta.opk
+    - ${MEDIA_PATH}
+    expire_in: 10 min
+  dependencies: []
+  script:
+    - "make -j$NUMPROC -f Makefile.rg350_odbeta"
+    - "mkdir -p ${MEDIA_PATH}/${CI_PROJECT_NAME}/filters/audio"
+    - "mkdir -p ${MEDIA_PATH}/${CI_PROJECT_NAME}/filters/video"
+    - "cp -f libretro-common/audio/dsp_filters/*.dsp ${MEDIA_PATH}/${CI_PROJECT_NAME}/filters/audio"
+    - "cp -f gfx/video_filters/*.filt ${MEDIA_PATH}/${CI_PROJECT_NAME}/filters/video"
+
 build-retroarch-android-normal:
   image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-android:latest
   stage: build

--- a/Makefile.rg350_odbeta
+++ b/Makefile.rg350_odbeta
@@ -40,6 +40,7 @@ PACKAGE_NAME = retroarch
 DEBUG ?= 0
 
 DINGUX = 1
+DINGUX_BETA = 1
 HAVE_SCREENSHOTS = 0
 HAVE_REWIND = 1
 HAVE_7ZIP = 1
@@ -111,14 +112,13 @@ HAVE_LIBSHAKE = 1
 
 OS = Linux
 TARGET = retroarch
-OPK_NAME = retroarch_rg350.opk
+OPK_NAME = retroarch_rg350_odbeta.opk
 
 OBJ :=
 LINK := $(CXX)
-DEF_FLAGS := -march=mips32 -mtune=mips32r2 -mhard-float -ffast-math -fomit-frame-pointer
-DEF_FLAGS += -mplt -mno-shared
+DEF_FLAGS := -mplt -mno-shared
 DEF_FLAGS += -ffunction-sections -fdata-sections
-DEF_FLAGS += -I. -Ideps -Ideps/stb -DDINGUX=1 -MMD
+DEF_FLAGS += -I. -Ideps -Ideps/stb -DDINGUX=1 -DDINGUX_BETA=1 -MMD
 DEF_FLAGS += -Wall -Wno-unused-variable
 DEF_FLAGS += -std=gnu99 -D_GNU_SOURCE -flto
 LIBS := -ldl -lz -lrt -ludev -pthread

--- a/audio/drivers/sdl_audio.c
+++ b/audio/drivers/sdl_audio.c
@@ -74,19 +74,24 @@ static void *sdl_audio_init(const char *device,
    int frames;
    size_t bufsize;
    SDL_AudioSpec out;
-   SDL_AudioSpec spec   = {0};
-   void            *tmp = NULL;
-   sdl_audio_t *sdl     = NULL;
+   SDL_AudioSpec spec           = {0};
+   void *tmp                    = NULL;
+   sdl_audio_t *sdl             = NULL;
+   uint32_t sdl_subsystem_flags = SDL_WasInit(0);
 
    (void)device;
 
-   if (SDL_WasInit(0) == 0)
+   /* Initialise audio subsystem, if required */
+   if (sdl_subsystem_flags == 0)
    {
       if (SDL_Init(SDL_INIT_AUDIO) < 0)
          return NULL;
    }
-   else if (SDL_InitSubSystem(SDL_INIT_AUDIO) < 0)
-      return NULL;
+   else if ((sdl_subsystem_flags & SDL_INIT_AUDIO) == 0)
+   {
+      if (SDL_InitSubSystem(SDL_INIT_AUDIO) < 0)
+         return NULL;
+   }
 
    sdl = (sdl_audio_t*)calloc(1, sizeof(*sdl));
    if (!sdl)
@@ -227,7 +232,6 @@ static void sdl_audio_free(void *data)
    sdl_audio_t *sdl = (sdl_audio_t*)data;
 
    SDL_CloseAudio();
-   SDL_QuitSubSystem(SDL_INIT_AUDIO);
 
    if (sdl)
    {

--- a/dingux/dingux_utils.h
+++ b/dingux/dingux_utils.h
@@ -42,19 +42,33 @@ enum dingux_ipu_filter_type
  * the IPU hardware scaler */
 bool dingux_ipu_set_downscaling_enable(bool enable);
 
-/* Enables/disables aspect ratio correction
- * (1:1 PAR) when using the IPU hardware
- * scaler (disabling this will stretch the
- * image to the full screen dimensions) */
-bool dingux_ipu_set_aspect_ratio_enable(bool enable);
-
-/* Enables/disables integer scaling when
- * using the IPU hardware scaler */
-bool dingux_ipu_set_integer_scaling_enable(bool enable);
+/* Sets the video scaling mode when using the
+ * IPU hardware scaler
+ * - keep_aspect: When 'true', aspect ratio correction
+ *   (1:1 PAR) is applied. When 'false', image is
+ *   stretched to full screen dimensions
+ * - integer_scale: When 'true', enables integer
+ *   scaling. This implicitly sets keep_aspect to
+ *   'true' (since integer scaling is by definition
+ *   1:1 PAR)
+ * Note: OpenDingux stock firmware allows keep_aspect
+ * and integer_scale to be set independently, hence
+ * separate boolean values. OpenDingux beta properly
+ * groups the settings into a single scaling type
+ * parameter. When supporting both firmwares, it would
+ * be cleaner to refactor this function to accept one
+ * enum rather than 2 booleans - but this would break
+ * users' existing configs, so we maintain the old
+ * format... */
+bool dingux_ipu_set_scaling_mode(bool keep_aspect, bool integer_scale);
 
 /* Sets the image filtering method when
  * using the IPU hardware scaler */
 bool dingux_ipu_set_filter_type(enum dingux_ipu_filter_type filter_type);
+
+/* Resets the IPU hardware scaler to the
+ * default configuration */
+bool dingux_ipu_reset(void);
 
 /* Fetches internal battery level */
 int dingux_get_battery_level(void);

--- a/gfx/common/sdl2_common.c
+++ b/gfx/common/sdl2_common.c
@@ -25,7 +25,6 @@
 #include "sdl2_common.h"
 #include "../../retroarch.h"
 
-#ifdef HAVE_SDL2
 #include "SDL.h"
 #include "SDL_syswm.h"
 
@@ -77,5 +76,3 @@ void sdl2_set_handles(void *data, enum rarch_display_type display_type)
          break;
    }
 }
-
-#endif

--- a/gfx/common/sdl2_common.h
+++ b/gfx/common/sdl2_common.h
@@ -19,7 +19,47 @@
 #include <stdint.h>
 #include <boolean.h>
 
+#include "SDL.h"
+
 #include "../video_defines.h"
+#include "../font_driver.h"
+#include "../../retroarch.h"
+
+typedef struct sdl2_tex
+{
+   SDL_Texture *tex;
+
+   unsigned w;
+   unsigned h;
+   size_t pitch;
+   bool active;
+   bool rgb32;
+} sdl2_tex_t;
+
+typedef struct _sdl2_video
+{
+   bool gl;
+   bool quitting;
+   bool should_resize;
+
+   uint8_t font_r;
+   uint8_t font_g;
+   uint8_t font_b;
+
+   double rotation;
+
+   struct video_viewport vp;
+   video_info_t video;
+   sdl2_tex_t frame;
+   sdl2_tex_t menu;
+   sdl2_tex_t font;
+
+   SDL_Window *window;
+   SDL_Renderer *renderer;
+
+   void *font_data;
+   const font_renderer_driver_t *font_driver;
+} sdl2_video_t;
 
 void sdl2_set_handles(void *data, enum rarch_display_type 
       display_type);

--- a/gfx/drivers/sdl2_gfx.c
+++ b/gfx/drivers/sdl2_gfx.c
@@ -35,52 +35,13 @@
 
 #include "SDL.h"
 #include "SDL_syswm.h"
-
-#ifdef HAVE_SDL2
 #include "../common/sdl2_common.h"
-#endif
 
 #include "../font_driver.h"
 
 #include "../../configuration.h"
 #include "../../retroarch.h"
 #include "../../verbosity.h"
-
-typedef struct sdl2_tex
-{
-   SDL_Texture *tex;
-
-   unsigned w;
-   unsigned h;
-   size_t pitch;
-   bool active;
-   bool rgb32;
-} sdl2_tex_t;
-
-typedef struct _sdl2_video
-{
-   bool gl;
-   bool quitting;
-   bool should_resize;
-
-   uint8_t font_r;
-   uint8_t font_g;
-   uint8_t font_b;
-
-   double rotation;
-
-   struct video_viewport vp;
-   video_info_t video;
-   sdl2_tex_t frame;
-   sdl2_tex_t menu;
-   sdl2_tex_t font;
-
-   SDL_Window *window;
-   SDL_Renderer *renderer;
-
-   void *font_data;
-   const font_renderer_driver_t *font_driver;
-} sdl2_video_t;
 
 static void sdl2_gfx_free(void *data);
 
@@ -358,7 +319,12 @@ static void sdl_refresh_input_size(sdl2_video_t *vid, bool menu, bool rgb32,
       target->h = height;
       target->pitch = pitch;
       target->rgb32 = rgb32;
-      target->active = true;
+
+      /* If target is menu, do not override 'active'
+       * state (this should only be set by
+       * sdl2_poke_texture_enable()) */
+      if (!menu)
+         target->active = true;
    }
 }
 
@@ -367,23 +333,28 @@ static void *sdl2_gfx_init(const video_info_t *video,
 {
    int i;
    unsigned flags;
-   sdl2_video_t *vid        = NULL;
-   settings_t *settings     = config_get_ptr();
+   sdl2_video_t *vid            = NULL;
+   uint32_t sdl_subsystem_flags = SDL_WasInit(0);
+   settings_t *settings         = config_get_ptr();
 #if defined(HAVE_X11) || defined(HAVE_WAYLAND)
-   const char *video_driver = NULL;
+   const char *video_driver     = NULL;
 #endif
 
 #ifdef HAVE_X11
    XInitThreads();
 #endif
 
-   if (SDL_WasInit(0) == 0)
+   /* Initialise graphics subsystem, if required */
+   if (sdl_subsystem_flags == 0)
    {
       if (SDL_Init(SDL_INIT_VIDEO) < 0)
          return NULL;
    }
-   else if (SDL_InitSubSystem(SDL_INIT_VIDEO) < 0)
-      return NULL;
+   else if ((sdl_subsystem_flags & SDL_INIT_VIDEO) == 0)
+   {
+      if (SDL_InitSubSystem(SDL_INIT_VIDEO) < 0)
+         return NULL;
+   }
 
    vid = (sdl2_video_t*)calloc(1, sizeof(*vid));
    if (!vid)
@@ -602,8 +573,6 @@ static void sdl2_gfx_free(void *data)
 
    if (vid->window)
       SDL_DestroyWindow(vid->window);
-
-   SDL_QuitSubSystem(SDL_INIT_VIDEO);
 
    if (vid->font_data)
       vid->font_driver->free(vid->font_data);

--- a/gfx/drivers/sdl_gfx.c
+++ b/gfx/drivers/sdl_gfx.c
@@ -75,8 +75,6 @@ static void sdl_gfx_free(void *data)
    if (vid->menu.frame)
       SDL_FreeSurface(vid->menu.frame);
 
-   SDL_QuitSubSystem(SDL_INIT_VIDEO);
-
    if (vid->font)
       vid->font_driver->free(vid->font);
 
@@ -248,6 +246,7 @@ static void *sdl_gfx_init(const video_info_t *video,
    const SDL_VideoInfo *video_info = NULL;
    sdl_video_t                *vid = NULL;
    settings_t            *settings = config_get_ptr();
+   uint32_t sdl_subsystem_flags    = SDL_WasInit(0);
    const char *path_font           = settings->paths.path_font;
    float video_font_size           = settings->floats.video_font_size;
    bool video_font_enable          = settings->bools.video_font_enable;
@@ -259,13 +258,17 @@ static void *sdl_gfx_init(const video_info_t *video,
    XInitThreads();
 #endif
 
-   if (SDL_WasInit(0) == 0)
+   /* Initialise graphics subsystem, if required */
+   if (sdl_subsystem_flags == 0)
    {
       if (SDL_Init(SDL_INIT_VIDEO) < 0)
          return NULL;
    }
-   else if (SDL_InitSubSystem(SDL_INIT_VIDEO) < 0)
-      return NULL;
+   else if ((sdl_subsystem_flags & SDL_INIT_VIDEO) == 0)
+   {
+      if (SDL_InitSubSystem(SDL_INIT_VIDEO) < 0)
+         return NULL;
+   }
 
    vid = (sdl_video_t*)calloc(1, sizeof(*vid));
    if (!vid)

--- a/gfx/drivers_context/sdl_gl_ctx.c
+++ b/gfx/drivers_context/sdl_gl_ctx.c
@@ -71,14 +71,13 @@ static void sdl_ctx_destroy_resources(gfx_ctx_sdl_data_t *sdl)
       SDL_FreeSurface(sdl->win);
 #endif
    sdl->win = NULL;
-
-   SDL_QuitSubSystem(SDL_INIT_VIDEO);
 }
 
 static void *sdl_ctx_init(void *video_driver)
 {
-   gfx_ctx_sdl_data_t *sdl = (gfx_ctx_sdl_data_t*)
+   gfx_ctx_sdl_data_t *sdl      = (gfx_ctx_sdl_data_t*)
       calloc(1, sizeof(gfx_ctx_sdl_data_t));
+   uint32_t sdl_subsystem_flags = SDL_WasInit(0);
 
    if (!sdl)
       return NULL;
@@ -87,13 +86,17 @@ static void *sdl_ctx_init(void *video_driver)
    XInitThreads();
 #endif
 
-   if (SDL_WasInit(0) == 0)
+   /* Initialise graphics subsystem, if required */
+   if (sdl_subsystem_flags == 0)
    {
       if (SDL_Init(SDL_INIT_VIDEO) < 0)
          goto error;
    }
-   else if (SDL_InitSubSystem(SDL_INIT_VIDEO) < 0)
-      goto error;
+   else if ((sdl_subsystem_flags & SDL_INIT_VIDEO) == 0)
+   {
+      if (SDL_InitSubSystem(SDL_INIT_VIDEO) < 0)
+         goto error;
+   }
 
    RARCH_LOG("[SDL_GL] SDL %i.%i.%i gfx context driver initialized.\n",
          SDL_MAJOR_VERSION, SDL_MINOR_VERSION, SDL_PATCHLEVEL);

--- a/input/drivers/sdl_input.c
+++ b/input/drivers/sdl_input.c
@@ -31,6 +31,10 @@
 #include "../../verbosity.h"
 #include "../../tasks/tasks_internal.h"
 
+#ifdef HAVE_SDL2
+#include "../../gfx/common/sdl2_common.h"
+#endif
+
 /* TODO/FIXME -
  * fix game focus toggle */
 
@@ -278,17 +282,17 @@ static void sdl_input_free(void *data)
 #ifdef HAVE_SDL2
 static void sdl2_grab_mouse(void *data, bool state)
 {
-   struct temp
-   {
-      SDL_Window *w;
-   };
+   sdl2_video_t *video_ptr = NULL;
 
    if (string_is_not_equal(video_driver_get_ident(), "sdl2"))
       return;
 
-   /* First member of sdl2_video_t is the window */
-   SDL_SetWindowGrab(((struct temp*)video_driver_get_ptr())->w,
-         state ? SDL_TRUE : SDL_FALSE);
+   video_ptr = (sdl2_video_t*)video_driver_get_ptr();
+
+   if (!video_ptr)
+      return;
+
+   SDL_SetWindowGrab(video_ptr->window, state ? SDL_TRUE : SDL_FALSE);
 }
 #endif
 

--- a/input/drivers_joypad/sdl_dingux_joypad.c
+++ b/input/drivers_joypad/sdl_dingux_joypad.c
@@ -321,9 +321,6 @@ static void sdl_dingux_joypad_destroy(void)
    /* Disconnect joypad */
    sdl_dingux_joypad_disconnect();
 
-   /* De-initialise joystick subsystem */
-   SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
-
    /* Flush out all pending events */
    while (SDL_PollEvent(&event));
 
@@ -337,19 +334,23 @@ static void sdl_dingux_joypad_destroy(void)
 
 static void *sdl_dingux_joypad_init(void *data)
 {
-   dingux_joypad_t *joypad = (dingux_joypad_t*)&dingux_joypad;
+   dingux_joypad_t *joypad      = (dingux_joypad_t*)&dingux_joypad;
+   uint32_t sdl_subsystem_flags = SDL_WasInit(0);
 
    memset(joypad, 0, sizeof(dingux_joypad_t));
    BIT64_CLEAR(lifecycle_state, RARCH_MENU_TOGGLE);
 
-   /* Initialise joystick subsystem */
-   if (SDL_WasInit(0) == 0)
+   /* Initialise joystick subsystem, if required */
+   if (sdl_subsystem_flags == 0)
    {
       if (SDL_Init(SDL_INIT_JOYSTICK) < 0)
          return NULL;
    }
-   else if (SDL_InitSubSystem(SDL_INIT_JOYSTICK) < 0)
-      return NULL;
+   else if ((sdl_subsystem_flags & SDL_INIT_JOYSTICK) == 0)
+   {
+      if (SDL_InitSubSystem(SDL_INIT_JOYSTICK) < 0)
+         return NULL;
+   }
 
 #if defined(HAVE_LIBSHAKE)
    /* Initialise rumble interface */

--- a/retroarch.c
+++ b/retroarch.c
@@ -269,6 +269,10 @@
 #include "input/input_osk_utf8_pages.h"
 #endif
 
+#if defined(HAVE_SDL) || defined(HAVE_SDL2) || defined(HAVE_SDL_DINGUX)
+#include "SDL.h"
+#endif
+
 /* RetroArch global state / macros */
 #include "retroarch_data.h"
 /* Forward declarations */
@@ -15337,6 +15341,21 @@ static void global_free(struct rarch_state *p_rarch)
    retroarch_override_setting_free_state();
 }
 
+#if defined(HAVE_SDL) || defined(HAVE_SDL2) || defined(HAVE_SDL_DINGUX)
+static void sdl_exit(void)
+{
+   /* Quit any SDL subsystems, then quit
+    * SDL itself */
+   uint32_t sdl_subsystem_flags = SDL_WasInit(0);
+
+   if (sdl_subsystem_flags != 0)
+   {
+      SDL_QuitSubSystem(sdl_subsystem_flags);
+      SDL_Quit();
+   }
+}
+#endif
+
 /**
  * main_exit:
  *
@@ -15421,6 +15440,10 @@ void main_exit(void *args)
 
 #if defined(_WIN32) && !defined(_XBOX) && !defined(__WINRT__)
    CoUninitialize();
+#endif
+
+#if defined(HAVE_SDL) || defined(HAVE_SDL2) || defined(HAVE_SDL_DINGUX)
+   sdl_exit();
 #endif
 }
 


### PR DESCRIPTION
## Description

This PR adds support for the latest OpenDingux Beta releases: https://zcrc.me/opendingux/2020/10/13/we-have-nighties.html

The OpenDingux Beta build requires the latest gcw0 toolchain (http://od.abstraction.se/opendingux/toolchain/) and can be compiled with the `Makefile.rg350_odbeta` makefile.

RetroArch on OpenDingux Beta has significantly better performance than on stock firmwares. As of tomorrow's OpenDingux Beta release, all regular RetroArch functionality will be available - including full IPU hardware scaler configuration (I believe RetroArch is the first OpenDingux application to support this!)

In order to make this work, some fundamental changes were required to RetroArch's method of handling SDL-based drivers. At present, RetroArch initialises/quits SDL subsystems each time that drivers are (re-)initialised. This is in fact bad practice - subsystems should only be initialised/quitted once during the lifetime of the application (RetroArch also makes the mistake of omitting a final call to `SDL_Quit()`, so SDL itself is never cleaned up....). With this PR, SDL subsystems are only initialised on first use, and the relevant quit functions are called only on program termination.

While I was working with the SDL drivers, I also noticed two serious bugs, which I have fixed:

- When using the sdl2 gfx driver, `sdl2_grab_mouse()` will no longer generate a segfault (this would happen under many conditions - e.g. toggling threaded video, toggling fullscreen - because a pointer was being cast to the wrong type...)
- When using the sdl2 gfx driver with RGUI, launching content will no longer leave a static menu image overlayed upon the game screen (there was a bizarre bug there which flagged the menu as active every time content was loaded...)

## Related Issues

Closes #9853
Closes #11904
