### PR TITLE
Fix playlist label sanitisation

### DIFF
--- a/libretro-common/playlists/label_sanitization.c
+++ b/libretro-common/playlists/label_sanitization.c
@@ -136,7 +136,7 @@ static bool left_exclusion(char *left,
       strlcpy(comparison_string, strings[i], sizeof(comparison_string));
       string_to_upper(comparison_string);
 
-      if (string_is_equal(exclusion_string,
+      if (string_starts_with(exclusion_string,
                comparison_string))
          return true;
    }


### PR DESCRIPTION
## Description

Commit e2c277d2ea804638e6764a942b1c0522a6fc1a61 broke the playlist label sanitisation code such that the `Settings > Playlists > Manage Playlists > ??? > Label Display Mode`: `Keep Disc Index`, `Keep Region`, and `Keep Region and Disc Index` options are no longer functional.

This trivial PR fixes the issue.

## Related Issues

Closes #12169

