### PR TITLE
[DRM] set the correct video mode

### DIFF
--- a/gfx/common/drm_common.c
+++ b/gfx/common/drm_common.c
@@ -121,6 +121,12 @@ bool drm_get_connector(int fd, unsigned monitor_index)
    return true;
 }
 
+float drm_calc_refresh_rate(drmModeModeInfo *mode)
+{
+   float refresh_rate = (mode->clock * 1000.0f) / (mode->htotal * mode->vtotal);
+   return refresh_rate;
+}
+
 bool drm_get_encoder(int fd)
 {
    unsigned i;
@@ -147,12 +153,12 @@ bool drm_get_encoder(int fd)
 
    for (i = 0; (int)i < g_drm_connector->count_modes; i++)
    {
-      RARCH_LOG("[DRM]: Mode %d: (%s) %d x %d, %u Hz\n",
+      RARCH_LOG("[DRM]: Mode %d: (%s) %d x %d, %f Hz\n",
             i,
             g_drm_connector->modes[i].name,
             g_drm_connector->modes[i].hdisplay,
             g_drm_connector->modes[i].vdisplay,
-            g_drm_connector->modes[i].vrefresh);
+            drm_calc_refresh_rate(&g_drm_connector->modes[i]));
    }
 
    return true;
@@ -173,7 +179,7 @@ float drm_get_refresh_rate(void *data)
 
    if (g_drm_mode)
    {
-      refresh_rate = g_drm_mode->clock * 1000.0f / g_drm_mode->htotal / g_drm_mode->vtotal;
+      refresh_rate = drm_calc_refresh_rate(g_drm_mode);
    }
 
    return refresh_rate;

--- a/gfx/common/drm_common.h
+++ b/gfx/common/drm_common.h
@@ -43,6 +43,8 @@ extern drmModeCrtc *g_orig_crtc;
 
 extern drmEventContext g_drm_evctx;
 
+float drm_calc_refresh_rate(drmModeModeInfo *mode);
+
 bool drm_get_encoder(int fd);
 
 /* Restore the original CRTC. */

--- a/gfx/drivers_context/drm_ctx.c
+++ b/gfx/drivers_context/drm_ctx.c
@@ -733,19 +733,24 @@ static bool gfx_ctx_drm_set_video_mode(void *data,
           * refresh rates as well.
           */
          float minimum_fps_diff = 0.0f;
+         float mode_vrefresh    = 0.0f;
+         drmModeModeInfo *mode;
 
          /* Find best match. */
          for (i = 0; i < g_drm_connector->count_modes; i++) {
+            mode = &g_drm_connector->modes[i];
+
             float diff;
-            if (width != g_drm_connector->modes[i].hdisplay ||
-               height != g_drm_connector->modes[i].vdisplay)
+            if (width != mode->hdisplay ||
+               height != mode->vdisplay)
                continue;
 
-            diff = fabsf(refresh_mod * g_drm_connector->modes[i].vrefresh
-                            - video_refresh_rate);
+            mode_vrefresh = drm_calc_refresh_rate(mode);
+
+            diff = fabsf(refresh_mod * mode_vrefresh - video_refresh_rate);
 
             if (!g_drm_mode || diff < minimum_fps_diff) {
-               g_drm_mode = &g_drm_connector->modes[i];
+               g_drm_mode = mode;
                minimum_fps_diff = diff;
             }
          }


### PR DESCRIPTION
## Description

the DRM context is now able to differentiate between, for example, 640x480@60.00 and 640x480@59.92 when setting the video mode