### PR TITLE
Removed check for verbosity level in RARCH_LOG_V

### DIFF
--- a/verbosity.c
+++ b/verbosity.c
@@ -214,8 +214,6 @@ void retro_main_log_file_deinit(void)
 void RARCH_LOG_V(const char *tag, const char *fmt, va_list ap)
 {
    verbosity_state_t *g_verbosity = &main_verbosity_st;
-   if (verbosity_log_level > 1)
-      return;
 
    {
       const char *tag_v = tag ? tag : FILE_PATH_LOG_INFO;


### PR DESCRIPTION
## Description

If HAVE_LOGGER is false, RARCH_LOG_V is currently implemented to check for the verbosity level and to only write to file if it is 1 or smaller.
Since RARCH_LOG_OUTPUT_V, RARCH_WARN_V, and RARCH_ERR_V are just macros to RARCH_LOG_V in the above case, setting the verbosity level to 2 or 3 can (and for me on Ubuntu 20.04: does) result in absolutely nothing being written to log.

Since the verbosity level is always checked before calling RARCH_LOG_V, anyway, the first if statement in that function is unnecessary, so I removed it.
