### PR TITLE
(3DS) Add HAVE_OVERLAY

### DIFF
--- a/Makefile.ctr
+++ b/Makefile.ctr
@@ -59,6 +59,7 @@ ifeq ($(GRIFFIN_BUILD), 1)
 	DEFINES += -DHAVE_REWIND
 	DEFINES += -DHAVE_THREADS
 	#DEFINES += -DHAVE_GFX_WIDGETS
+	#DEFINES += -DHAVE_OVERLAY
 	#DEFINES += -DHAVE_SOCKET_LEGACY
 	#-DHAVE_SSL -DHAVE_BUILTINMBEDTLS -DMBEDTLS_SSL_DEBUG_ALL
 	#ssl is currently incompatible with griffin due to use of the "static" flag on repeating functions that will conflict when included in one file

--- a/gfx/common/ctr_common.h
+++ b/gfx/common/ctr_common.h
@@ -109,6 +109,13 @@ typedef struct ctr_video
    bool supports_parallax_disable;
    bool enable_3d;
 
+#ifdef HAVE_OVERLAY
+   struct ctr_overlay_data *overlay;
+   unsigned overlays;
+   bool overlay_enabled;
+   bool overlay_full_screen;
+#endif
+
    void* empty_framebuffer;
 
    aptHookCookie lcd_aptHook;
@@ -138,6 +145,16 @@ typedef struct ctr_texture
    enum texture_filter_type type;
    void* data;
 } ctr_texture_t;
+
+#ifdef HAVE_OVERLAY
+struct ctr_overlay_data
+{
+   ctr_texture_t texture;
+   ctr_vertex_t* frame_coords;
+   ctr_scale_vector_t scale_vector;
+   float alpha_mod;
+};
+#endif
 
 static INLINE void ctr_set_scale_vector(ctr_scale_vector_t* vec,
       int viewport_width, int viewport_height,


### PR DESCRIPTION
Add *limited overlay support on 3DS. Tested with custom 400x240px overlays.
*only single image overlays, max 1024x1024px.

Current issues:
Overlays with multiple textures load with wrong coordinates.
ctr_overlay_set_alpha is not implemented.

Note:
video_driver_set_rgba(); is called to load images RGBA instead of BGRA.


Building with HAVE_OVERLAY is disabled by default.
