### PR TITLE
Rewrite commands and add new command type

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -233,6 +233,7 @@ endif
 
 OBJ += frontend/frontend_driver.o \
        retroarch.o \
+       command.o \
        msg_hash.o \
        intl/msg_hash_us.o \
        $(LIBRETRO_COMM_DIR)/queues/task_queue.o \

--- a/command.c
+++ b/command.c
@@ -1,0 +1,514 @@
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stddef.h>
+#ifdef HAVE_NETWORKING
+#include <net/net_compat.h>
+#include <net/net_socket.h>
+#endif
+#include <streams/stdin_stream.h>
+#include <string/stdstring.h>
+
+#include "verbosity.h"
+#include "command.h"
+
+#define CMD_BUF_SIZE           4096
+
+#if defined(HAVE_COMMAND)
+
+/* Generic command parse utilities */
+
+static bool command_get_arg(const char *tok,
+      const char **arg, unsigned *index)
+{
+   unsigned i;
+
+   for (i = 0; i < ARRAY_SIZE(map); i++)
+   {
+      if (string_is_equal(tok, map[i].str))
+      {
+         if (arg)
+            *arg = NULL;
+
+         if (index)
+            *index = i;
+
+         return true;
+      }
+   }
+
+   for (i = 0; i < ARRAY_SIZE(action_map); i++)
+   {
+      const char *str = strstr(tok, action_map[i].str);
+      if (str == tok)
+      {
+         const char *argument = str + strlen(action_map[i].str);
+         if (*argument != ' ' && *argument != '\0')
+            return false;
+
+         if (arg)
+            *arg = argument + 1;
+
+         if (index)
+            *index = i;
+
+         return true;
+      }
+   }
+
+   return false;
+}
+
+static void command_parse_sub_msg(command_t *handle, const char *tok)
+{
+   const char *arg = NULL;
+   unsigned index  = 0;
+
+   if (command_get_arg(tok, &arg, &index))
+   {
+      if (arg)
+      {
+         if (!action_map[index].action(handle, arg))
+            RARCH_ERR("Command \"%s\" failed.\n", arg);
+      }
+      else
+         handle->state[map[index].id] = true;
+   }
+   else
+      RARCH_WARN("%s \"%s\" %s.\n",
+            msg_hash_to_str(MSG_UNRECOGNIZED_COMMAND),
+            tok,
+            msg_hash_to_str(MSG_RECEIVED));
+}
+
+static void command_parse_msg(
+      command_t *handle, char *buf)
+{
+   char *save  = NULL;
+   const char *tok = strtok_r(buf, "\n", &save);
+
+   while (tok)
+   {
+      command_parse_sub_msg(handle, tok);
+      tok = strtok_r(NULL, "\n", &save);
+   }
+}
+
+#if defined(HAVE_NETWORK_CMD)
+
+typedef struct
+{
+   /* Network socket FD */
+   int net_fd;
+   /* Source address for the command received */
+   struct sockaddr_storage cmd_source;
+   /* Size of the previous structure in use */
+   socklen_t cmd_source_len;
+} command_network_t;
+
+static void network_command_reply(
+      command_t *cmd,
+      const char * data, size_t len)
+{
+   command_network_t *netcmd = (command_network_t*)cmd->userptr;
+   /* Respond (fire and forget since it's UDP) */
+   sendto(netcmd->net_fd, data, len, 0,
+      (struct sockaddr*)&netcmd->cmd_source, netcmd->cmd_source_len);
+}
+
+static void network_command_free(command_t *handle)
+{
+   command_network_t *netcmd = (command_network_t*)handle->userptr;
+
+   if (netcmd->net_fd >= 0)
+      socket_close(netcmd->net_fd);
+
+   free(netcmd);
+   free(handle);
+}
+
+static void command_network_poll(command_t *handle)
+{
+   fd_set fds;
+   struct timeval       tmp_tv = {0};
+   command_network_t *netcmd = (command_network_t*)handle->userptr;
+
+   if (netcmd->net_fd < 0)
+      return;
+
+   FD_ZERO(&fds);
+   FD_SET(netcmd->net_fd, &fds);
+
+   if (socket_select(netcmd->net_fd + 1, &fds, NULL, NULL, &tmp_tv) <= 0)
+      return;
+
+   if (!FD_ISSET(netcmd->net_fd, &fds))
+      return;
+
+   for (;;)
+   {
+      ssize_t ret;
+      char buf[1024];
+
+      buf[0] = '\0';
+      ret  = recvfrom(netcmd->net_fd, buf, sizeof(buf) - 1, 0,
+            (struct sockaddr*)&netcmd->cmd_source,
+            &netcmd->cmd_source_len);
+
+      if (ret <= 0)
+         break;
+
+      buf[ret] = '\0';
+
+      command_parse_msg(handle, buf);
+   }
+}
+
+command_t* command_network_new(uint16_t port)
+{
+   struct addrinfo *res  = NULL;
+   command_t *cmd = (command_t*)calloc(1, sizeof(command_t));
+   command_network_t *netcmd = (command_network_t*)calloc(
+                                   1, sizeof(command_network_t));
+   int fd = socket_init((void**)&res, port, NULL, SOCKET_TYPE_DATAGRAM);
+
+   RARCH_LOG("%s %hu.\n",
+         msg_hash_to_str(MSG_BRINGING_UP_COMMAND_INTERFACE_ON_PORT),
+         (unsigned short)port);
+
+   if (fd < 0)
+      goto error;
+
+   netcmd->net_fd = fd;
+   cmd->userptr = netcmd;
+   cmd->poll = command_network_poll;
+   cmd->replier = network_command_reply;
+   cmd->destroy = network_command_free;
+
+   if (!socket_nonblock(netcmd->net_fd))
+      goto error;
+
+   if (!socket_bind(netcmd->net_fd, (void*)res))
+   {
+      RARCH_ERR("%s.\n",
+            msg_hash_to_str(MSG_FAILED_TO_BIND_SOCKET));
+      goto error;
+   }
+
+   freeaddrinfo_retro(res);
+   return cmd;
+
+error:
+   if (res)
+      freeaddrinfo_retro(res);
+   free(netcmd);
+   free(cmd);
+   return NULL;
+}
+#endif
+
+
+#if defined(HAVE_STDIN_CMD)
+typedef struct
+{
+   /* Buffer and pointer for stdin reads */
+   size_t stdin_buf_ptr;
+   char stdin_buf[CMD_BUF_SIZE];
+} command_stdin_t;
+
+static void stdin_command_reply(
+      command_t *cmd,
+      const char * data, size_t len)
+{
+   /* Just write to stdout! */
+   fwrite(data, 1, len, stdout);
+}
+
+static void stdin_command_free(command_t *handle)
+{
+   free(handle->userptr);
+   free(handle);
+}
+
+static void command_stdin_poll(command_t *handle) {
+   ptrdiff_t msg_len;
+   char *last_newline = NULL;
+   command_stdin_t *stdincmd = (command_stdin_t*)handle->userptr;
+   ssize_t        ret = read_stdin(
+         stdincmd->stdin_buf + stdincmd->stdin_buf_ptr,
+         CMD_BUF_SIZE - stdincmd->stdin_buf_ptr - 1);
+
+   if (ret == 0)
+      return;
+
+   stdincmd->stdin_buf_ptr                      += ret;
+   stdincmd->stdin_buf[stdincmd->stdin_buf_ptr]  = '\0';
+
+   last_newline = strrchr(stdincmd->stdin_buf, '\n');
+
+   if (!last_newline)
+   {
+      /* We're receiving bogus data in pipe
+       * (no terminating newline), flush out the buffer. */
+      if (stdincmd->stdin_buf_ptr + 1 >= CMD_BUF_SIZE)
+      {
+         stdincmd->stdin_buf_ptr = 0;
+         stdincmd->stdin_buf[0]  = '\0';
+      }
+
+      return;
+   }
+
+   *last_newline++ = '\0';
+   msg_len         = last_newline - stdincmd->stdin_buf;
+
+   command_parse_msg(handle, stdincmd->stdin_buf);
+
+   memmove(stdincmd->stdin_buf, last_newline,
+         stdincmd->stdin_buf_ptr - msg_len);
+   stdincmd->stdin_buf_ptr -= msg_len;
+}
+
+command_t* command_stdin_new(void)
+{
+   command_t *cmd;
+   command_stdin_t *stdincmd;
+
+#ifndef _WIN32
+#ifdef HAVE_NETWORKING
+   if (!socket_nonblock(STDIN_FILENO))
+      return NULL;
+#endif
+#endif
+
+   cmd = (command_t*)calloc(1, sizeof(command_t));
+   stdincmd = (command_stdin_t*)calloc(1, sizeof(command_stdin_t));
+   cmd->userptr = stdincmd;
+   cmd->poll = command_stdin_poll;
+   cmd->replier = stdin_command_reply;
+   cmd->destroy = stdin_command_free;
+
+   return cmd;
+}
+#endif
+
+#if defined(HAVE_LAKKA)
+#include <sys/un.h>
+#define MAX_USER_CONNECTIONS  4
+typedef struct
+{
+   /* File descriptor for the domain socket */
+   int sfd;
+   /* Client sockets */
+   int userfd[MAX_USER_CONNECTIONS];
+   /* Last received user socket */
+   int last_fd;
+} command_uds_t;
+
+static void uds_command_reply(
+      command_t *cmd,
+      const char * data, size_t len)
+{
+   command_uds_t *subcmd = (command_uds_t*)cmd->userptr;
+   write(subcmd->last_fd, data, len);
+}
+
+static void uds_command_free(command_t *handle)
+{
+   int i;
+   command_uds_t *udscmd = (command_uds_t*)handle->userptr;
+
+   for (i = 0; i < MAX_USER_CONNECTIONS; i++)
+      if (udscmd->userfd[i] >= 0)
+         socket_close(udscmd->userfd[i]);
+   socket_close(udscmd->sfd);
+
+   free(handle->userptr);
+   free(handle);
+}
+
+static void command_uds_poll(command_t *handle) {
+   int i;
+   command_uds_t *udscmd = (command_uds_t*)handle->userptr;
+   int maxfd = udscmd->sfd;
+   fd_set fds;
+   struct timeval       tmp_tv = {0};
+
+   if (udscmd->sfd < 0)
+      return;
+
+   FD_ZERO(&fds);
+   FD_SET(udscmd->sfd, &fds);
+   for (i = 0; i < MAX_USER_CONNECTIONS; i++)
+   {
+      if (udscmd->userfd[i] >= 0)
+      {
+         maxfd = MAX(udscmd->userfd[i], maxfd);
+         FD_SET(udscmd->userfd[i], &fds);
+      }
+   }
+
+   if (socket_select(maxfd + 1, &fds, NULL, NULL, &tmp_tv) <= 0)
+      return;
+
+   /* Read data from clients and process commands */
+   for (i = 0; i < MAX_USER_CONNECTIONS; i++)
+   {
+      if (udscmd->userfd[i] >= 0 && FD_ISSET(udscmd->userfd[i], &fds))
+      {
+         while (1)
+         {
+            char buf[2048];
+            ssize_t ret = recv(udscmd->userfd[i], buf, sizeof(buf) - 1, 0);
+
+            if (ret < 0)
+               break;   /* no more data */
+            if (!ret)
+            {
+               socket_close(udscmd->userfd[i]);
+               udscmd->userfd[i] = -1;
+               break;
+            }
+
+            buf[ret] = 0;
+            udscmd->last_fd = udscmd->userfd[i];
+            command_parse_msg(handle, buf);
+         }
+      }
+   }
+
+   if (FD_ISSET(udscmd->sfd, &fds))
+   {
+      /* Accepts new connections from clients */
+      int cfd = accept(udscmd->sfd, NULL, NULL);
+      if (cfd >= 0) {
+         if (!socket_nonblock(cfd))
+            socket_close(cfd);
+         else {
+            for (i = 0; i < MAX_USER_CONNECTIONS; i++)
+               if (udscmd->userfd[i] < 0)
+               {
+                  udscmd->userfd[i] = cfd;
+                  break;
+               }
+         }
+      }
+   }
+}
+
+command_t* command_uds_new(void)
+{
+   int i;
+   command_t *cmd;
+   command_uds_t *subcmd;
+   struct sockaddr_un addr;
+   const char *sp = "retroarch/cmd";
+   socklen_t addrsz = offsetof(struct sockaddr_un, sun_path) + strlen(sp) + 1;
+   int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+   if (fd < 0)
+      return NULL;
+
+   /* use an abstract socket for simplicity */
+   memset(&addr, 0, sizeof(addr));
+   addr.sun_family = AF_UNIX;
+   strcpy(&addr.sun_path[1], sp);
+
+   if (bind(fd, (struct sockaddr*)&addr, addrsz) < 0 ||
+       listen(fd, MAX_USER_CONNECTIONS) < 0) {
+      socket_close(fd);
+      return NULL;
+   }
+
+   if (!socket_nonblock(fd))
+   {
+      socket_close(fd);
+      return NULL;
+   }
+
+   cmd = (command_t*)calloc(1, sizeof(command_t));
+   subcmd = (command_uds_t*)calloc(1, sizeof(command_uds_t));
+   subcmd->sfd = fd;
+   subcmd->last_fd = -1;
+   for (i = 0; i < MAX_USER_CONNECTIONS; i++)
+      subcmd->userfd[i] = -1;
+
+   cmd->userptr = subcmd;
+   cmd->poll = command_uds_poll;
+   cmd->replier = uds_command_reply;
+   cmd->destroy = uds_command_free;
+
+   return cmd;
+}
+#endif
+
+
+/* Routines used to invoke retroarch command ... */
+
+#ifdef HAVE_NETWORK_CMD
+static bool command_verify(const char *cmd)
+{
+   unsigned i;
+
+   if (command_get_arg(cmd, NULL, NULL))
+      return true;
+
+   RARCH_ERR("Command \"%s\" is not recognized by the program.\n", cmd);
+   RARCH_ERR("\tValid commands:\n");
+   for (i = 0; i < ARRAY_SIZE(map); i++)
+      RARCH_ERR("\t\t%s\n", map[i].str);
+
+   for (i = 0; i < ARRAY_SIZE(action_map); i++)
+      RARCH_ERR("\t\t%s %s\n", action_map[i].str, action_map[i].arg_desc);
+
+   return false;
+}
+
+bool command_network_send(const char *cmd_)
+{
+   char *command        = NULL;
+   char *save           = NULL;
+   const char *cmd      = NULL;
+
+   if (!network_init())
+      return false;
+
+   if (!(command = strdup(cmd_)))
+      return false;
+
+   cmd                  = strtok_r(command, ";", &save);
+   if (cmd)
+   {
+      uint16_t port     = DEFAULT_NETWORK_CMD_PORT;
+      const char *port_ = NULL;
+      const char *host  = strtok_r(NULL, ";", &save);
+      if (host)
+         port_          = strtok_r(NULL, ";", &save);
+      else
+      {
+#ifdef _WIN32
+         host = "127.0.0.1";
+#else
+         host = "localhost";
+#endif
+      }
+
+      if (port_)
+         port = strtoul(port_, NULL, 0);
+
+      RARCH_LOG("%s: \"%s\" to %s:%hu\n",
+            msg_hash_to_str(MSG_SENDING_COMMAND),
+            cmd, host, (unsigned short)port);
+
+      if (command_verify(cmd) && udp_send_packet(host, port, cmd))
+      {
+         free(command);
+         return true;
+      }
+   }
+
+   free(command);
+   return false;
+}
+#endif
+
+#endif

--- a/command.h
+++ b/command.h
@@ -23,11 +23,45 @@
 #include <boolean.h>
 #include <retro_common_api.h>
 
+#include "retroarch.h"
+#include "input/input_defines.h"
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
 
 RETRO_BEGIN_DECLS
+
+#define MAX_CMD_DRIVERS              3
+#define DEFAULT_NETWORK_CMD_PORT 55355
+
+struct cmd_map
+{
+   const char *str;
+   unsigned id;
+};
+
+struct command_handler;
+
+typedef void (*command_poller_t)(struct command_handler *cmd);
+typedef void (*command_replier_t)(struct command_handler *cmd, const char * data, size_t len);
+typedef void (*command_destructor_t)(struct command_handler *cmd);
+
+struct command_handler
+{
+   /* Interface to poll the driver */
+   command_poller_t poll;
+   /* Interface to reply */
+   command_replier_t replier;
+   /* Interface to delete the underlying command */
+   command_destructor_t destroy;
+   /* Underlying command storage */
+   void *userptr;
+   /* State received */
+   bool state[RARCH_BIND_LIST_END];
+};
+
+typedef struct command_handler command_t;
 
 enum event_command
 {
@@ -209,13 +243,20 @@ enum event_command
    CMD_EVENT_CONTROLLER_INIT
 };
 
-typedef struct command command_t;
-
 typedef struct command_handle
 {
    command_t *handle;
    unsigned id;
 } command_handle_t;
+
+enum cmd_source_t
+{
+   CMD_NONE = 0,
+   CMD_STDIN,
+   CMD_NETWORK
+};
+
+struct rarch_state;
 
 /**
  * command_event:
@@ -226,6 +267,107 @@ typedef struct command_handle
  * Returns: true (1) on success, otherwise false (0).
  **/
 bool command_event(enum event_command action, void *data);
+
+/* Constructors for the supported drivers */
+command_t* command_network_new(uint16_t port);
+command_t* command_stdin_new(void);
+command_t* command_uds_new(void);
+
+bool command_network_send(const char *cmd_);
+
+/* These forward declarations need to be declared before
+ * the global state is declared */
+#if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)
+bool command_set_shader(command_t *cmd, const char *arg);
+#endif
+#if defined(HAVE_COMMAND)
+bool command_version(command_t *cmd, const char* arg);
+bool command_get_status(command_t *cmd, const char* arg);
+bool command_get_config_param(command_t *cmd, const char* arg);
+bool command_show_osd_msg(command_t *cmd, const char* arg);
+#ifdef HAVE_CHEEVOS
+bool command_read_ram(command_t *cmd, const char *arg);
+bool command_write_ram(command_t *cmd, const char *arg);
+#endif
+bool command_read_memory(command_t *cmd, const char *arg);
+bool command_write_memory(command_t *cmd, const char *arg);
+
+struct cmd_action_map
+{
+   const char *str;
+   bool (*action)(command_t* cmd, const char *arg);
+   const char *arg_desc;
+};
+
+static const struct cmd_action_map action_map[] = {
+#if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)
+   { "SET_SHADER",       command_set_shader,       "<shader path>" },
+#endif
+   { "VERSION",          command_version,          "No argument"},
+   { "GET_STATUS",       command_get_status,       "No argument" },
+   { "GET_CONFIG_PARAM", command_get_config_param, "<param name>" },
+   { "SHOW_MSG",         command_show_osd_msg,     "No argument" },
+#if defined(HAVE_CHEEVOS)
+   /* These functions use achievement addresses and only work if a game with achievements is
+    * loaded. READ_CORE_MEMORY and WRITE_CORE_MEMORY are preferred and use system addresses. */
+   { "READ_CORE_RAM",    command_read_ram,         "<address> <number of bytes>" },
+   { "WRITE_CORE_RAM",   command_write_ram,        "<address> <byte1> <byte2> ..." },
+#endif
+   { "READ_CORE_MEMORY", command_read_memory,      "<address> <number of bytes>" },
+   { "WRITE_CORE_MEMORY",command_write_memory,     "<address> <byte1> <byte2> ..." },
+};
+
+static const struct cmd_map map[] = {
+   { "FAST_FORWARD",           RARCH_FAST_FORWARD_KEY },
+   { "FAST_FORWARD_HOLD",      RARCH_FAST_FORWARD_HOLD_KEY },
+   { "SLOWMOTION",             RARCH_SLOWMOTION_KEY },
+   { "SLOWMOTION_HOLD",        RARCH_SLOWMOTION_HOLD_KEY },
+   { "LOAD_STATE",             RARCH_LOAD_STATE_KEY },
+   { "SAVE_STATE",             RARCH_SAVE_STATE_KEY },
+   { "FULLSCREEN_TOGGLE",      RARCH_FULLSCREEN_TOGGLE_KEY },
+   { "CLOSE_CONTENT",          RARCH_CLOSE_CONTENT_KEY },
+   { "QUIT",                   RARCH_QUIT_KEY },
+   { "STATE_SLOT_PLUS",        RARCH_STATE_SLOT_PLUS },
+   { "STATE_SLOT_MINUS",       RARCH_STATE_SLOT_MINUS },
+   { "REWIND",                 RARCH_REWIND },
+   { "BSV_RECORD_TOGGLE",      RARCH_BSV_RECORD_TOGGLE },
+   { "PAUSE_TOGGLE",           RARCH_PAUSE_TOGGLE },
+   { "FRAMEADVANCE",           RARCH_FRAMEADVANCE },
+   { "RESET",                  RARCH_RESET },
+   { "SHADER_NEXT",            RARCH_SHADER_NEXT },
+   { "SHADER_PREV",            RARCH_SHADER_PREV },
+   { "CHEAT_INDEX_PLUS",       RARCH_CHEAT_INDEX_PLUS },
+   { "CHEAT_INDEX_MINUS",      RARCH_CHEAT_INDEX_MINUS },
+   { "CHEAT_TOGGLE",           RARCH_CHEAT_TOGGLE },
+   { "SCREENSHOT",             RARCH_SCREENSHOT },
+   { "MUTE",                   RARCH_MUTE },
+   { "OSK",                    RARCH_OSK },
+   { "FPS_TOGGLE",             RARCH_FPS_TOGGLE },
+   { "SEND_DEBUG_INFO",        RARCH_SEND_DEBUG_INFO },
+   { "NETPLAY_HOST_TOGGLE",    RARCH_NETPLAY_HOST_TOGGLE },
+   { "NETPLAY_GAME_WATCH",     RARCH_NETPLAY_GAME_WATCH },
+   { "VOLUME_UP",              RARCH_VOLUME_UP },
+   { "VOLUME_DOWN",            RARCH_VOLUME_DOWN },
+   { "OVERLAY_NEXT",           RARCH_OVERLAY_NEXT },
+   { "DISK_EJECT_TOGGLE",      RARCH_DISK_EJECT_TOGGLE },
+   { "DISK_NEXT",              RARCH_DISK_NEXT },
+   { "DISK_PREV",              RARCH_DISK_PREV },
+   { "GRAB_MOUSE_TOGGLE",      RARCH_GRAB_MOUSE_TOGGLE },
+   { "UI_COMPANION_TOGGLE",    RARCH_UI_COMPANION_TOGGLE },
+   { "GAME_FOCUS_TOGGLE",      RARCH_GAME_FOCUS_TOGGLE },
+   { "MENU_TOGGLE",            RARCH_MENU_TOGGLE },
+   { "RECORDING_TOGGLE",       RARCH_RECORDING_TOGGLE },
+   { "STREAMING_TOGGLE",       RARCH_STREAMING_TOGGLE },
+   { "RUNAHEAD_TOGGLE",        RARCH_RUNAHEAD_TOGGLE },
+   { "MENU_UP",                RETRO_DEVICE_ID_JOYPAD_UP },
+   { "MENU_DOWN",              RETRO_DEVICE_ID_JOYPAD_DOWN },
+   { "MENU_LEFT",              RETRO_DEVICE_ID_JOYPAD_LEFT },
+   { "MENU_RIGHT",             RETRO_DEVICE_ID_JOYPAD_RIGHT },
+   { "MENU_A",                 RETRO_DEVICE_ID_JOYPAD_A },
+   { "MENU_B",                 RETRO_DEVICE_ID_JOYPAD_B },
+   { "AI_SERVICE",             RARCH_AI_SERVICE },
+};
+#endif
 
 RETRO_END_DECLS
 

--- a/griffin/griffin.c
+++ b/griffin/griffin.c
@@ -1195,6 +1195,7 @@ GIT
 RETROARCH
 ============================================================ */
 #include "../retroarch.c"
+#include "../command.c"
 #include "../libretro-common/queues/task_queue.c"
 
 #include "../msg_hash.c"

--- a/pkg/apple/RetroArch.xcodeproj/project.pbxproj
+++ b/pkg/apple/RetroArch.xcodeproj/project.pbxproj
@@ -94,6 +94,8 @@
 		8D1107320486CEB800E47090 /* RetroArch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RetroArch.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9254B2F825F5A94300A1E0DA /* OpenGL_GitLabCI.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = OpenGL_GitLabCI.xcconfig; sourceTree = "<group>"; };
 		9254B33325FA72ED00A1E0DA /* assets.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; name = assets.zip; path = OSX/assets.zip; sourceTree = "<group>"; };
+		D47B69E92618DCB2005F7A3C /* RetroArchCg.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RetroArchCg.entitlements; sourceTree = "<group>"; };
+		D47B69EA2618DCB7005F7A3C /* RetroArch.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RetroArch.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -168,6 +170,8 @@
 		29B97314FDCFA39411CA2CEA /* RetroArch */ = {
 			isa = PBXGroup;
 			children = (
+				D47B69EA2618DCB7005F7A3C /* RetroArch.entitlements */,
+				D47B69E92618DCB2005F7A3C /* RetroArchCg.entitlements */,
 				9254B2F825F5A94300A1E0DA /* OpenGL_GitLabCI.xcconfig */,
 				840222FA1A889EA2009AB261 /* Core */,
 				080E96DDFE201D6D7F000001 /* Classes */,
@@ -368,11 +372,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CODE_SIGN_ENTITLEMENTS = RetroArchCg.entitlements;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEVELOPMENT_TEAM = UK699V5ZS8;
+				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(LOCAL_LIBRARY_DIR)/Frameworks",
@@ -410,11 +416,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CODE_SIGN_ENTITLEMENTS = RetroArchCg.entitlements;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = UK699V5ZS8;
+				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(LOCAL_LIBRARY_DIR)/Frameworks",
@@ -451,11 +459,13 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = x86_64;
+				CODE_SIGN_ENTITLEMENTS = RetroArch.entitlements;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEVELOPMENT_TEAM = UK699V5ZS8;
+				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(LOCAL_LIBRARY_DIR)/Frameworks",
@@ -490,11 +500,13 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = x86_64;
+				CODE_SIGN_ENTITLEMENTS = RetroArch.entitlements;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = UK699V5ZS8;
+				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(LOCAL_LIBRARY_DIR)/Frameworks",

--- a/pkg/apple/RetroArchCg.entitlements
+++ b/pkg/apple/RetroArchCg.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.disable-executable-page-protection</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+</dict>
+</plist>

--- a/qb/config.params.sh
+++ b/qb/config.params.sh
@@ -62,6 +62,7 @@ HAVE_NETWORKING=auto       # Networking features (recommended)
 HAVE_NETWORKGAMEPAD=auto   # Networked game pad (plus baked-in core)
 C89_NETWORKGAMEPAD=no
 HAVE_NETPLAYDISCOVERY=yes  # Add netplay discovery (room creation, etc.)
+HAVE_COMMAND=no            # Network command interface, to remote control RA
 HAVE_MINIUPNPC=auto        # Mini UPnP client library (for NAT traversal)
 HAVE_BUILTINMINIUPNPC=auto # Bake in Mini UPnP client library (for NAT traversal)
 C89_BUILTINMINIUPNPC=no

--- a/retroarch_data.h
+++ b/retroarch_data.h
@@ -107,9 +107,6 @@
 #define DECLARE_BIND(base, bind, desc) { #base, desc, 0, bind, true }
 #define DECLARE_META_BIND(level, base, bind, desc) { #base, desc, level, bind, true }
 
-#define DEFAULT_NETWORK_CMD_PORT 55355
-#define STDIN_BUF_SIZE           4096
-
 #ifdef HAVE_THREADS
 #define VIDEO_DRIVER_IS_THREADED_INTERNAL() ((!video_driver_is_hw_context() && p_rarch->video_driver_threaded) ? true : false)
 #else
@@ -1301,13 +1298,6 @@ enum rarch_movie_type
    RARCH_MOVIE_RECORD
 };
 
-enum cmd_source_t
-{
-   CMD_NONE = 0,
-   CMD_STDIN,
-   CMD_NETWORK
-};
-
 enum poll_type_override_t
 {
    POLL_TYPE_OVERRIDE_DONTCARE = 0,
@@ -1484,36 +1474,6 @@ struct input_overlay
    bool alive;
 };
 #endif
-
-struct cmd_map
-{
-   const char *str;
-   unsigned id;
-};
-
-#if defined(HAVE_COMMAND)
-struct cmd_action_map
-{
-   const char *str;
-   bool (*action)(const char *arg);
-   const char *arg_desc;
-};
-#endif
-
-struct command
-{
-#ifdef HAVE_STDIN_CMD
-   size_t stdin_buf_ptr;
-#endif
-#ifdef HAVE_NETWORK_CMD
-   int net_fd;
-#endif
-#ifdef HAVE_STDIN_CMD
-   char stdin_buf[STDIN_BUF_SIZE];
-#endif
-   bool stdin_enable;
-   bool state[RARCH_BIND_LIST_END];
-};
 
 /* Input config. */
 struct input_bind_map
@@ -1751,11 +1711,6 @@ struct rarch_state
 #ifdef HAVE_MENU
    struct menu_state menu_driver_state;         /* int64_t alignment */
 #endif
-#if defined(HAVE_COMMAND)
-#ifdef HAVE_NETWORK_CMD
-   struct sockaddr_storage lastcmd_net_source;  /* int64_t alignment */
-#endif
-#endif
 #ifdef HAVE_GFX_WIDGETS
    dispgfx_widget_t dispwidget_st;              /* uint64_t alignment */
 #endif
@@ -1883,7 +1838,7 @@ struct rarch_state
    void *keyboard_press_data;
 
 #ifdef HAVE_COMMAND
-   command_t *input_driver_command;
+   command_t *input_driver_command[MAX_CMD_DRIVERS];
 #endif
 #ifdef HAVE_NETWORKGAMEPAD
    input_remote_t *input_driver_remote;
@@ -2133,11 +2088,6 @@ struct rarch_state
     * TODO - Dirty hack, fix it better
     */
    gfx_ctx_flags_t deferred_flag_data;          /* uint32_t alignment */
-#if defined(HAVE_COMMAND)
-#ifdef HAVE_NETWORK_CMD
-   socklen_t lastcmd_net_source_len;            /* uint32_t alignment */
-#endif
-#endif
    retro_bits_t has_set_libretro_device;        /* uint32_t alignment */
    input_mapper_t input_driver_mapper;          /* uint32_t alignment */
 
@@ -2688,93 +2638,6 @@ struct key_desc key_descriptors[RARCH_MAX_KEYS] =
 static enum rarch_shader_type shader_types[] =
 {
    RARCH_SHADER_GLSL, RARCH_SHADER_SLANG, RARCH_SHADER_CG
-};
-#endif
-
-/* These forward declarations need to be declared before
- * the global state is declared */
-#if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)
-static bool command_set_shader(const char *arg);
-#endif
-#if defined(HAVE_COMMAND)
-static bool command_version(const char* arg);
-static bool command_get_status(const char* arg);
-static bool command_get_config_param(const char* arg);
-static bool command_show_osd_msg(const char* arg);
-#ifdef HAVE_CHEEVOS
-static bool command_read_ram(const char *arg);
-static bool command_write_ram(const char *arg);
-#endif
-static bool command_read_memory(const char *arg);
-static bool command_write_memory(const char *arg);
-
-static const struct cmd_action_map action_map[] = {
-#if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)
-   { "SET_SHADER",       command_set_shader,       "<shader path>" },
-#endif
-   { "VERSION",          command_version,          "No argument"},
-   { "GET_STATUS",       command_get_status,       "No argument" },
-   { "GET_CONFIG_PARAM", command_get_config_param, "<param name>" },
-   { "SHOW_MSG",         command_show_osd_msg,     "No argument" },
-#if defined(HAVE_CHEEVOS)
-   /* These functions use achievement addresses and only work if a game with achievements is
-    * loaded. READ_CORE_MEMORY and WRITE_CORE_MEMORY are preferred and use system addresses. */
-   { "READ_CORE_RAM",    command_read_ram,         "<address> <number of bytes>" },
-   { "WRITE_CORE_RAM",   command_write_ram,        "<address> <byte1> <byte2> ..." },
-#endif
-   { "READ_CORE_MEMORY", command_read_memory,      "<address> <number of bytes>" },
-   { "WRITE_CORE_MEMORY",command_write_memory,     "<address> <byte1> <byte2> ..." },
-};
-
-static const struct cmd_map map[] = {
-   { "FAST_FORWARD",           RARCH_FAST_FORWARD_KEY },
-   { "FAST_FORWARD_HOLD",      RARCH_FAST_FORWARD_HOLD_KEY },
-   { "SLOWMOTION",             RARCH_SLOWMOTION_KEY },
-   { "SLOWMOTION_HOLD",        RARCH_SLOWMOTION_HOLD_KEY },
-   { "LOAD_STATE",             RARCH_LOAD_STATE_KEY },
-   { "SAVE_STATE",             RARCH_SAVE_STATE_KEY },
-   { "FULLSCREEN_TOGGLE",      RARCH_FULLSCREEN_TOGGLE_KEY },
-   { "CLOSE_CONTENT",          RARCH_CLOSE_CONTENT_KEY },
-   { "QUIT",                   RARCH_QUIT_KEY },
-   { "STATE_SLOT_PLUS",        RARCH_STATE_SLOT_PLUS },
-   { "STATE_SLOT_MINUS",       RARCH_STATE_SLOT_MINUS },
-   { "REWIND",                 RARCH_REWIND },
-   { "BSV_RECORD_TOGGLE",      RARCH_BSV_RECORD_TOGGLE },
-   { "PAUSE_TOGGLE",           RARCH_PAUSE_TOGGLE },
-   { "FRAMEADVANCE",           RARCH_FRAMEADVANCE },
-   { "RESET",                  RARCH_RESET },
-   { "SHADER_NEXT",            RARCH_SHADER_NEXT },
-   { "SHADER_PREV",            RARCH_SHADER_PREV },
-   { "CHEAT_INDEX_PLUS",       RARCH_CHEAT_INDEX_PLUS },
-   { "CHEAT_INDEX_MINUS",      RARCH_CHEAT_INDEX_MINUS },
-   { "CHEAT_TOGGLE",           RARCH_CHEAT_TOGGLE },
-   { "SCREENSHOT",             RARCH_SCREENSHOT },
-   { "MUTE",                   RARCH_MUTE },
-   { "OSK",                    RARCH_OSK },
-   { "FPS_TOGGLE",             RARCH_FPS_TOGGLE },
-   { "SEND_DEBUG_INFO",        RARCH_SEND_DEBUG_INFO },
-   { "NETPLAY_HOST_TOGGLE",    RARCH_NETPLAY_HOST_TOGGLE },
-   { "NETPLAY_GAME_WATCH",     RARCH_NETPLAY_GAME_WATCH },
-   { "VOLUME_UP",              RARCH_VOLUME_UP },
-   { "VOLUME_DOWN",            RARCH_VOLUME_DOWN },
-   { "OVERLAY_NEXT",           RARCH_OVERLAY_NEXT },
-   { "DISK_EJECT_TOGGLE",      RARCH_DISK_EJECT_TOGGLE },
-   { "DISK_NEXT",              RARCH_DISK_NEXT },
-   { "DISK_PREV",              RARCH_DISK_PREV },
-   { "GRAB_MOUSE_TOGGLE",      RARCH_GRAB_MOUSE_TOGGLE },
-   { "UI_COMPANION_TOGGLE",    RARCH_UI_COMPANION_TOGGLE },
-   { "GAME_FOCUS_TOGGLE",      RARCH_GAME_FOCUS_TOGGLE },
-   { "MENU_TOGGLE",            RARCH_MENU_TOGGLE },
-   { "RECORDING_TOGGLE",       RARCH_RECORDING_TOGGLE },
-   { "STREAMING_TOGGLE",       RARCH_STREAMING_TOGGLE },
-   { "RUNAHEAD_TOGGLE",        RARCH_RUNAHEAD_TOGGLE },
-   { "MENU_UP",                RETRO_DEVICE_ID_JOYPAD_UP },
-   { "MENU_DOWN",              RETRO_DEVICE_ID_JOYPAD_DOWN },
-   { "MENU_LEFT",              RETRO_DEVICE_ID_JOYPAD_LEFT },
-   { "MENU_RIGHT",             RETRO_DEVICE_ID_JOYPAD_RIGHT },
-   { "MENU_A",                 RETRO_DEVICE_ID_JOYPAD_A },
-   { "MENU_B",                 RETRO_DEVICE_ID_JOYPAD_B },
-   { "AI_SERVICE",             RARCH_AI_SERVICE },
 };
 #endif
 


### PR DESCRIPTION
This moves commands to a separate file and creates a consistent
interface for them. It is now possible to use multiple command
interfaces simultaneously (stdin, network and UDS).
Implemented a new interface for Lakka, UDS based (so Linux only). This
allow other Lakka servies to send certain commands to Retroarch in a
secure and reliable way.
