### PR TITLE
Fix implicit conversion warnings

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -1790,7 +1790,7 @@ static int rcheevos_match_value(const char* val, const char* match)
    {
       do
       {
-         int size;
+         size_t size;
          const char* ptr = ++match;
 
          while (*match && *match != ',')

--- a/deps/rcheevos/src/rcheevos/memref.c
+++ b/deps/rcheevos/src/rcheevos/memref.c
@@ -120,7 +120,8 @@ static rc_memref_value_t* rc_alloc_memref_value_constuct_mode(rc_parse_state_t* 
   return memref_value;
 }
 
-rc_memref_value_t* rc_alloc_memref_value(rc_parse_state_t* parse, unsigned address, char size, char is_indirect) {
+rc_memref_value_t* rc_alloc_memref_value(rc_parse_state_t* parse, unsigned address, char size, char is_indirect)
+{
   if (!parse->first_memref)
     return rc_alloc_memref_value_sizing_mode(parse, address, size, is_indirect);
 

--- a/deps/rcheevos/src/rcheevos/operand.c
+++ b/deps/rcheevos/src/rcheevos/operand.c
@@ -66,7 +66,8 @@ static int rc_parse_operand_lua(rc_operand_t* self, const char** memaddr, rc_par
   return RC_OK;
 }
 
-static int rc_parse_operand_memory(rc_operand_t* self, const char** memaddr, rc_parse_state_t* parse, int is_indirect) {
+static int rc_parse_operand_memory(rc_operand_t* self, const char** memaddr, rc_parse_state_t* parse, int is_indirect)
+{
   const char* aux = *memaddr;
   char* end;
   unsigned long address;
@@ -95,13 +96,11 @@ static int rc_parse_operand_memory(rc_operand_t* self, const char** memaddr, rc_
       break;
   }
 
-  if (*aux++ != '0') {
+  if (*aux++ != '0')
     return RC_INVALID_MEMORY_OPERAND;
-  }
 
-  if (*aux != 'x' && *aux != 'X') {
+  if (*aux != 'x' && *aux != 'X')
     return RC_INVALID_MEMORY_OPERAND;
-  }
 
   aux++;
 
@@ -137,13 +136,11 @@ static int rc_parse_operand_memory(rc_operand_t* self, const char** memaddr, rc_
 
   address = strtoul(aux, &end, 16);
 
-  if (end == aux) {
+  if (end == aux)
     return RC_INVALID_MEMORY_OPERAND;
-  }
 
-  if (address > 0xffffffffU) {
+  if (address > 0xffffffffU)
     address = 0xffffffffU;
-  }
 
   self->value.memref = rc_alloc_memref_value(parse, address, size, is_indirect);
   if (parse->offset < 0)

--- a/deps/rcheevos/src/rcheevos/richpresence.c
+++ b/deps/rcheevos/src/rcheevos/richpresence.c
@@ -204,7 +204,7 @@ static const char* rc_parse_richpresence_lookup(rc_richpresence_lookup_t* lookup
   const char* endline;
   const char* defaultlabel = 0;
   char* endptr = 0;
-  unsigned key;
+  size_t key;
   unsigned chars;
 
   next = &lookup->first_item;
@@ -243,7 +243,7 @@ static const char* rc_parse_richpresence_lookup(rc_richpresence_lookup_t* lookup
       }
 
       item = RC_ALLOC(rc_richpresence_lookup_item_t, parse);
-      item->value = key;
+      item->value = (unsigned)key;
       item->label = rc_alloc_str(parse, line, (int)(endline - line));
       *next = item;
       next = &item->next_item;

--- a/gfx/drivers_font_renderer/bitmapfont.c
+++ b/gfx/drivers_font_renderer/bitmapfont.c
@@ -204,7 +204,7 @@ bitmapfont_lut_t *bitmapfont_get_lut(void)
          for (i = 0; i < FONT_WIDTH; i++)
          {
             uint8_t rem     = 1 << ((i + j * FONT_WIDTH) & 7);
-            unsigned offset = (i + j * FONT_WIDTH) >> 3;
+            size_t offset   = (i + j * FONT_WIDTH) >> 3;
 
             /* LUT value is 'true' if specified glyph
              * position contains a pixel */

--- a/gfx/drivers_font_renderer/bitmapfont_10x10.c
+++ b/gfx/drivers_font_renderer/bitmapfont_10x10.c
@@ -181,7 +181,7 @@ bitmapfont_lut_t *bitmapfont_10x10_load(unsigned language)
          for (i = 0; i < FONT_10X10_WIDTH; i++)
          {
             uint8_t rem     = 1 << ((i + j * FONT_10X10_WIDTH) & 7);
-            unsigned offset = (i + j * FONT_10X10_WIDTH) >> 3;
+            size_t offset   = (i + j * FONT_10X10_WIDTH) >> 3;
 
             /* LUT value is 'true' if specified glyph
              * position contains a pixel */

--- a/gfx/gfx_animation.c
+++ b/gfx/gfx_animation.c
@@ -362,13 +362,13 @@ static void gfx_animation_ticker_loop(uint64_t idx,
    *width3    = width;
 }
 
-static unsigned get_ticker_smooth_generic_scroll_offset(
-      uint64_t idx, unsigned str_width, unsigned field_width)
+static size_t get_ticker_smooth_generic_scroll_offset(
+      uint64_t idx, size_t str_width, size_t field_width)
 {
-   unsigned scroll_width   = str_width - field_width;
+   size_t scroll_width     = str_width - field_width;
    unsigned pause_duration = 32;
-   unsigned ticker_period  = 2 * (scroll_width + pause_duration);
-   unsigned phase          = idx % ticker_period;
+   size_t ticker_period    = 2 * (scroll_width + pause_duration);
+   size_t phase            = idx % ticker_period;
 
    /* Determine scroll offset */
    if (phase < pause_duration)
@@ -383,17 +383,17 @@ static unsigned get_ticker_smooth_generic_scroll_offset(
 
 /* 'Fixed width' font version of ticker_smooth_scan_characters() */
 static void ticker_smooth_scan_string_fw(
-      size_t num_chars, unsigned glyph_width,
-      unsigned field_width, unsigned scroll_offset,
-      unsigned *char_offset, unsigned *num_chars_to_copy,
-      unsigned *x_offset)
+      size_t num_chars,    unsigned glyph_width,
+      size_t field_width,  size_t scroll_offset,
+      size_t *char_offset, size_t *num_chars_to_copy,
+      size_t *x_offset)
 {
-   unsigned chars_remaining = 0;
+   size_t chars_remaining = 0;
 
    /* Initialise output variables to 'sane' values */
-   *char_offset       = 0;
-   *num_chars_to_copy = 0;
-   *x_offset          = 0;
+   *char_offset           = 0;
+   *num_chars_to_copy     = 0;
+   *x_offset              = 0;
 
    /* Determine index of first character to copy */
    if (scroll_offset > 0)
@@ -417,18 +417,23 @@ static void ticker_smooth_scan_string_fw(
 }
 
 /* 'Fixed width' font version of gfx_animation_ticker_smooth_generic() */
-static void gfx_animation_ticker_smooth_generic_fw(uint64_t idx,
-      unsigned str_width, size_t num_chars,
-      unsigned glyph_width, unsigned field_width,
-      unsigned *char_offset, unsigned *num_chars_to_copy, unsigned *x_offset)
+static void gfx_animation_ticker_smooth_generic_fw(
+      uint64_t idx,
+      size_t str_width,
+      size_t num_chars,
+      unsigned glyph_width,
+      size_t field_width,
+      size_t *char_offset,
+      size_t *num_chars_to_copy,
+      size_t *x_offset)
 {
-   unsigned scroll_offset = get_ticker_smooth_generic_scroll_offset(
+   size_t scroll_offset = get_ticker_smooth_generic_scroll_offset(
       idx, str_width, field_width);
 
    /* Initialise output variables to 'sane' values */
-   *char_offset       = 0;
-   *num_chars_to_copy = 0;
-   *x_offset          = 0;
+   *char_offset        = 0;
+   *num_chars_to_copy  = 0;
+   *x_offset           = 0;
 
    /* Sanity check */
    if (num_chars < 1)
@@ -441,18 +446,18 @@ static void gfx_animation_ticker_smooth_generic_fw(uint64_t idx,
 
 /* 'Fixed width' font version of gfx_animation_ticker_smooth_loop() */
 static void gfx_animation_ticker_smooth_loop_fw(uint64_t idx,
-      unsigned str_width, size_t num_chars,
-      unsigned spacer_width, size_t num_spacer_chars,
-      unsigned glyph_width, unsigned field_width,
-      unsigned *char_offset1, unsigned *num_chars_to_copy1,
-      unsigned *char_offset2, unsigned *num_chars_to_copy2,
-      unsigned *char_offset3, unsigned *num_chars_to_copy3,
-      unsigned *x_offset)
+      size_t str_width,       size_t num_chars,
+      size_t   spacer_width,  size_t num_spacer_chars,
+      unsigned glyph_width,   size_t field_width,
+      size_t   *char_offset1, size_t   *num_chars_to_copy1,
+      size_t   *char_offset2, size_t   *num_chars_to_copy2,
+      size_t   *char_offset3, size_t   *num_chars_to_copy3,
+      size_t   *x_offset)
 {
-   unsigned ticker_period   = str_width + spacer_width;
-   unsigned phase           = idx % ticker_period;
+   size_t ticker_period     = str_width + spacer_width;
+   size_t phase             = idx % ticker_period;
 
-   unsigned remaining_width = field_width;
+   size_t remaining_width   = field_width;
 
    /* Initialise output variables to 'sane' values */
    *char_offset1       = 0;
@@ -478,7 +483,7 @@ static void gfx_animation_ticker_smooth_loop_fw(uint64_t idx,
    /* String 1 */
    if (phase < str_width)
    {
-      unsigned scroll_offset = phase;
+      size_t scroll_offset = phase;
 
       ticker_smooth_scan_string_fw(
             num_chars, glyph_width, remaining_width, scroll_offset,
@@ -498,8 +503,8 @@ static void gfx_animation_ticker_smooth_loop_fw(uint64_t idx,
    /* String 2 */
    if (remaining_width > glyph_width)
    {
-      unsigned scroll_offset = 0;
-      unsigned x_offset2     = 0;
+      size_t scroll_offset   = 0;
+      size_t x_offset2       = 0;
 
       /* Check whether we've passed the end of string 1 */
       if (phase > str_width)
@@ -535,14 +540,14 @@ static void gfx_animation_ticker_smooth_loop_fw(uint64_t idx,
 
 static void ticker_smooth_scan_characters(
       const unsigned *char_widths, size_t num_chars,
-      unsigned field_width, unsigned scroll_offset,
-      unsigned *char_offset, unsigned *num_chars_to_copy,
-      unsigned *x_offset, unsigned *str_width,
-      unsigned *display_width)
+      size_t field_width,          size_t scroll_offset,
+      size_t *char_offset,         size_t *num_chars_to_copy,
+      size_t *x_offset,            size_t *str_width,
+      size_t *display_width)
 {
-   unsigned i;
+   size_t i;
    unsigned text_width     = 0;
-   unsigned scroll_pos     = scroll_offset;
+   size_t scroll_pos       = scroll_offset;
    bool deferred_str_width = true;
 
    /* Initialise output variables to 'sane' values */
@@ -612,11 +617,11 @@ static void ticker_smooth_scan_characters(
 
 static void gfx_animation_ticker_smooth_generic(uint64_t idx,
       const unsigned *char_widths, size_t num_chars,
-      unsigned str_width, unsigned field_width,
-      unsigned *char_offset, unsigned *num_chars_to_copy,
-      unsigned *x_offset, unsigned *dst_str_width)
+      unsigned str_width,          size_t field_width,
+      size_t *char_offset,         size_t *num_chars_to_copy,
+      size_t *x_offset,            size_t *dst_str_width)
 {
-   unsigned scroll_offset = get_ticker_smooth_generic_scroll_offset(
+   size_t scroll_offset = get_ticker_smooth_generic_scroll_offset(
       idx, str_width, field_width);
 
    /* Initialise output variables to 'sane' values */
@@ -635,20 +640,29 @@ static void gfx_animation_ticker_smooth_generic(uint64_t idx,
       char_offset, num_chars_to_copy, x_offset, dst_str_width, NULL);
 }
 
-static void gfx_animation_ticker_smooth_loop(uint64_t idx,
-      const unsigned *char_widths, size_t num_chars,
-      const unsigned *spacer_widths, size_t num_spacer_chars,
-      unsigned str_width, unsigned spacer_width, unsigned field_width,
-      unsigned *char_offset1, unsigned *num_chars_to_copy1,
-      unsigned *char_offset2, unsigned *num_chars_to_copy2,
-      unsigned *char_offset3, unsigned *num_chars_to_copy3,
-      unsigned *x_offset, unsigned *dst_str_width)
+static void gfx_animation_ticker_smooth_loop(
+      uint64_t idx,
+      const unsigned *char_widths,
+      size_t num_chars,
+      const unsigned *spacer_widths,
+      size_t num_spacer_chars,
+      unsigned str_width,
+      unsigned spacer_width,
+      size_t field_width,
+      size_t *char_offset1,
+      size_t *num_chars_to_copy1,
+      size_t *char_offset2,
+      size_t *num_chars_to_copy2,
+      size_t *char_offset3,
+      size_t *num_chars_to_copy3,
+      size_t *x_offset,
+      size_t *dst_str_width)
 
 {
    unsigned ticker_period   = str_width + spacer_width;
    unsigned phase           = idx % ticker_period;
 
-   unsigned remaining_width = field_width;
+   size_t remaining_width   = field_width;
 
    /* Initialise output variables to 'sane' values */
    *char_offset1       = 0;
@@ -677,8 +691,8 @@ static void gfx_animation_ticker_smooth_loop(uint64_t idx,
    if (phase < str_width)
    {
       unsigned scroll_offset = phase;
-      unsigned display_width = 0;
-      unsigned str1_width    = 0;
+      size_t display_width   = 0;
+      size_t str1_width      = 0;
 
       ticker_smooth_scan_characters(
             char_widths, num_chars, remaining_width, scroll_offset,
@@ -695,10 +709,10 @@ static void gfx_animation_ticker_smooth_loop(uint64_t idx,
    /* String 2 */
    if (remaining_width > 0)
    {
-      unsigned scroll_offset = 0;
-      unsigned display_width = 0;
-      unsigned str2_width    = 0;
-      unsigned x_offset2     = 0;
+      size_t scroll_offset   = 0;
+      size_t display_width   = 0;
+      size_t str2_width      = 0;
+      size_t x_offset2       = 0;
 
       /* Check whether we've passed the end of string 1 */
       if (phase > str_width)
@@ -1457,8 +1471,8 @@ static bool gfx_animation_ticker_smooth_fw(
 {
    size_t spacer_len            = 0;
    unsigned glyph_width         = ticker->glyph_width;
-   unsigned src_str_width       = 0;
-   unsigned spacer_width        = 0;
+   size_t src_str_width         = 0;
+   size_t  spacer_width         = 0;
    bool success                 = false;
    bool is_active               = false;
 
@@ -1490,7 +1504,7 @@ static bool gfx_animation_ticker_smooth_fw(
     * and add '...' suffix */
    if (!ticker->selected)
    {
-      unsigned num_chars    = 0;
+      size_t num_chars      = 0;
       unsigned suffix_len   = 3;
       unsigned suffix_width = suffix_len * glyph_width;
 
@@ -1531,12 +1545,12 @@ static bool gfx_animation_ticker_smooth_fw(
    {
       case TICKER_TYPE_LOOP:
       {
-         unsigned char_offset1 = 0;
-         unsigned num_chars1   = 0;
-         unsigned char_offset2 = 0;
-         unsigned num_chars2   = 0;
-         unsigned char_offset3 = 0;
-         unsigned num_chars3   = 0;
+         size_t   char_offset1 = 0;
+         size_t   num_chars1   = 0;
+         size_t   char_offset2 = 0;
+         size_t   num_chars2   = 0;
+         size_t   char_offset3 = 0;
+         size_t   num_chars3   = 0;
 
          gfx_animation_ticker_smooth_loop_fw(
                ticker->idx,
@@ -1562,10 +1576,10 @@ static bool gfx_animation_ticker_smooth_fw(
       case TICKER_TYPE_BOUNCE:
       default:
       {
-         unsigned char_offset = 0;
-         unsigned num_chars   = 0;
+         size_t char_offset   = 0;
+         size_t num_chars     = 0;
 
-         ticker->dst_str[0] = '\0';
+         ticker->dst_str[0]   = '\0';
 
          gfx_animation_ticker_smooth_generic_fw(
                ticker->idx,
@@ -1677,7 +1691,7 @@ bool gfx_animation_ticker_smooth(gfx_animation_ctx_ticker_smooth_t *ticker)
     * and add '...' suffix */
    if (!ticker->selected)
    {
-      unsigned text_width;
+      size_t text_width;
       unsigned current_width = 0;
       unsigned num_chars     = 0;
       int period_width       =
@@ -1758,12 +1772,12 @@ bool gfx_animation_ticker_smooth(gfx_animation_ctx_ticker_smooth_t *ticker)
    {
       case TICKER_TYPE_LOOP:
       {
-         unsigned char_offset1 = 0;
-         unsigned num_chars1   = 0;
-         unsigned char_offset2 = 0;
-         unsigned num_chars2   = 0;
-         unsigned char_offset3 = 0;
-         unsigned num_chars3   = 0;
+         size_t char_offset1 = 0;
+         size_t num_chars1   = 0;
+         size_t char_offset2 = 0;
+         size_t num_chars2   = 0;
+         size_t char_offset3 = 0;
+         size_t num_chars3   = 0;
 
          gfx_animation_ticker_smooth_loop(
                ticker->idx,
@@ -1787,17 +1801,21 @@ bool gfx_animation_ticker_smooth(gfx_animation_ctx_ticker_smooth_t *ticker)
       case TICKER_TYPE_BOUNCE:
       default:
       {
-         unsigned char_offset = 0;
-         unsigned num_chars   = 0;
+         size_t char_offset = 0;
+         size_t num_chars   = 0;
 
          ticker->dst_str[0] = '\0';
 
          gfx_animation_ticker_smooth_generic(
                ticker->idx,
-               src_char_widths, src_str_len,
-               src_str_width, ticker->field_width,
-               &char_offset, &num_chars,
-               ticker->x_offset, ticker->dst_str_width);
+               src_char_widths,
+               src_str_len,
+               src_str_width,
+               ticker->field_width,
+               &char_offset,
+               &num_chars,
+               ticker->x_offset,
+               ticker->dst_str_width);
 
          /* Copy required substring */
          if (num_chars > 0)

--- a/gfx/gfx_animation.h
+++ b/gfx/gfx_animation.h
@@ -134,13 +134,13 @@ typedef struct gfx_animation_ctx_ticker_smooth
    const char *src_str;
    const char *spacer;
    char *dst_str;
-   unsigned *dst_str_width; /* May be set to NULL 
+   size_t *dst_str_width; /* May be set to NULL 
                                (RGUI + XMB do not require this info) */
-   unsigned *x_offset;
+   size_t *x_offset;
    font_data_t *font;
    size_t dst_str_len;
    unsigned glyph_width; /* Fallback if font == NULL */
-   unsigned field_width;
+   size_t field_width;
    float font_scale;
    enum gfx_animation_ticker_type type_enum;
    bool selected;

--- a/gfx/gfx_display.c
+++ b/gfx/gfx_display.c
@@ -665,7 +665,7 @@ void gfx_display_draw_texture_slice(
       unsigned video_width,
       unsigned video_height,
       int x, int y, unsigned w, unsigned h,
-      unsigned new_w, unsigned new_h,
+      unsigned new_w, size_t new_h,
       unsigned width, unsigned height,
       float *color, unsigned offset, float scale_factor, uintptr_t texture)
 {

--- a/gfx/gfx_display.h
+++ b/gfx/gfx_display.h
@@ -313,7 +313,7 @@ void gfx_display_draw_texture_slice(
       unsigned video_width,
       unsigned video_height,
       int x, int y, unsigned w, unsigned h,
-      unsigned new_w, unsigned new_h,
+      unsigned new_w, size_t new_h,
       unsigned width, unsigned height,
       float *color, unsigned offset, float scale_factor, uintptr_t texture);
 

--- a/libretro-common/formats/json/rjson.c
+++ b/libretro-common/formats/json/rjson.c
@@ -1013,7 +1013,7 @@ bool rjson_check_context(rjson_t *json, unsigned int depth, ...)
 
 unsigned int rjson_get_context_depth(rjson_t *json)
 {
-   return json->stack_top - json->stack;
+   return (unsigned int)(json->stack_top - json->stack);
 }
 
 size_t rjson_get_context_count(rjson_t *json)

--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -1602,8 +1602,8 @@ typedef struct materialui_handle
    unsigned nav_bar_layout_width;
    unsigned nav_bar_layout_height;
 
-   unsigned ticker_x_offset;
-   unsigned ticker_str_width;
+   size_t ticker_x_offset;
+   size_t ticker_str_width;
 
    /* Touch feedback animation parameters */
    unsigned touch_feedback_selection;
@@ -3856,7 +3856,7 @@ static void materialui_render_menu_entry_default(
    const char *entry_label                           = NULL;
    unsigned entry_type                               = 0;
    enum materialui_entry_value_type entry_value_type = MUI_ENTRY_VALUE_NONE;
-   unsigned entry_value_width                        = 0;
+   size_t entry_value_width                          = 0;
    enum msg_file_type entry_file_type                = FILE_TYPE_NONE;
    int entry_x                                       = x_offset + node->x;
    int entry_y                                       = header_height - mui->scroll_y + node->y;

--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -2133,7 +2133,7 @@ static void ozone_draw_header(
    gfx_animation_ctx_ticker_t ticker;
    gfx_animation_ctx_ticker_smooth_t ticker_smooth;
    static const char* const ticker_spacer = OZONE_TICKER_SPACER;
-   unsigned ticker_x_offset  = 0;
+   size_t ticker_x_offset    = 0;
    unsigned timedate_offset  = 0;
    bool use_smooth_ticker    = settings->bools.menu_ticker_smooth;
    float scale_factor        = ozone->last_scale_factor;
@@ -2624,7 +2624,7 @@ static void ozone_draw_footer(
       enum gfx_animation_ticker_type menu_ticker_type =
             (enum gfx_animation_ticker_type)settings->uints.menu_ticker_type;
             static const char* const ticker_spacer    = OZONE_TICKER_SPACER;
-      unsigned ticker_x_offset                        = 0;
+      size_t ticker_x_offset                          = 0;
 
       core_title[0]     = '\0';
       core_title_buf[0] = '\0';

--- a/menu/drivers/ozone/ozone_display.c
+++ b/menu/drivers/ozone/ozone_display.c
@@ -579,7 +579,8 @@ void ozone_draw_messagebox(
 {
    unsigned i, y_position;
    char wrapped_message[MENU_SUBLABEL_MAX_LENGTH];
-   int x, y, longest_width  = 0;
+   size_t y                 = 0;
+   int x, longest_width     = 0;
    int usable_width         = 0;
    struct string_list list  = {0};
    float scale_factor       = 0.0f;
@@ -653,7 +654,7 @@ void ozone_draw_messagebox(
        *   is quite 'loose', and depends upon source image
        *   size, draw size and scale factor... */
       unsigned slice_new_w = longest_width + 48 * 2 * scale_factor;
-      unsigned slice_new_h = ozone->fonts.footer.line_height * (list.size + 2);
+      size_t   slice_new_h = ozone->fonts.footer.line_height * (list.size + 2);
       int slice_x          = x - longest_width/2 - 48 * scale_factor;
       int slice_y          = y - ozone->fonts.footer.line_height +
             ((slice_new_h >= 256) 
@@ -670,7 +671,8 @@ void ozone_draw_messagebox(
             256, 256,
             slice_new_w,
             slice_new_h,
-            width, height,
+            width,
+            height,
             ozone->theme_dynamic.message_background,
             16, scale_factor,
             ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_DIALOG_SLICE]

--- a/menu/drivers/ozone/ozone_entries.c
+++ b/menu/drivers/ozone/ozone_entries.c
@@ -52,7 +52,7 @@ static void ozone_draw_entry_value(
       unsigned video_width,
       unsigned video_height,
       char *value,
-      unsigned x, unsigned y,
+      size_t x, size_t y,
       uint32_t alpha_uint32,
       menu_entry_t *entry)
 {
@@ -224,7 +224,7 @@ static void ozone_content_metadata_line(
       unsigned video_height,
       ozone_handle_t *ozone,
       unsigned *y,
-      unsigned column_x,
+      size_t column_x,
       const char *text,
       uint32_t color,
       unsigned lines_count)
@@ -645,9 +645,9 @@ border_iterate:
       menu_entry_t entry;
       gfx_animation_ctx_ticker_t ticker;
       gfx_animation_ctx_ticker_smooth_t ticker_smooth;
-      unsigned ticker_x_offset     = 0;
-      unsigned ticker_str_width    = 0;
-      int value_x_offset           = 0;
+      size_t   ticker_x_offset     = 0;
+      size_t   ticker_str_width    = 0;
+      size_t value_x_offset        = 0;
       static const char* const 
          ticker_spacer             = OZONE_TICKER_SPACER;
       const char *sublabel_str     = NULL;
@@ -1149,7 +1149,7 @@ void ozone_draw_thumbnail_bar(
       gfx_animation_ctx_ticker_t ticker;
       gfx_animation_ctx_ticker_smooth_t ticker_smooth;
       static const char* const ticker_spacer = OZONE_TICKER_SPACER;
-      unsigned ticker_x_offset               = 0;
+      size_t ticker_x_offset                 = 0;
       bool scroll_content_metadata           = settings->bools.ozone_scroll_content_metadata;
       bool use_smooth_ticker                 = settings->bools.menu_ticker_smooth;
       enum gfx_animation_ticker_type 

--- a/menu/drivers/ozone/ozone_sidebar.c
+++ b/menu/drivers/ozone/ozone_sidebar.c
@@ -176,7 +176,7 @@ void ozone_draw_sidebar(
    gfx_animation_ctx_ticker_smooth_t ticker_smooth;
    static const char* const
       ticker_spacer                  = OZONE_TICKER_SPACER;
-   unsigned ticker_x_offset          = 0;
+   size_t ticker_x_offset            = 0;
    uint32_t text_alpha               = ozone->animations.sidebar_text_alpha 
       * 255.0f;
    bool use_smooth_ticker            = settings->bools.menu_ticker_smooth;

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -1285,17 +1285,17 @@ english:
 
 static void rgui_fill_rect(
       uint16_t *data,
-      unsigned fb_width, unsigned fb_height,
-      unsigned x, unsigned y,
-      unsigned width, unsigned height,
+      size_t fb_width, size_t fb_height,
+      size_t x, size_t y,
+      size_t width, size_t height,
       uint16_t dark_color, uint16_t light_color,
       bool thickness)
 {
-   unsigned x_index, y_index;
-   unsigned x_start = x <= fb_width  ? x : fb_width;
-   unsigned y_start = y <= fb_height ? y : fb_height;
-   unsigned x_end   = x + width;
-   unsigned y_end   = y + height;
+   size_t x_index, y_index;
+   size_t   x_start = x <= fb_width  ? x : fb_width;
+   size_t   y_start = y <= fb_height ? y : fb_height;
+   size_t   x_end   = x + width;
+   size_t   y_end   = y + height;
    size_t x_size;
    uint16_t scanline_even[RGUI_MAX_FB_WIDTH]; /* Initial values don't matter here */
    uint16_t scanline_odd[RGUI_MAX_FB_WIDTH];
@@ -2775,7 +2775,7 @@ static void prepare_rgui_colors(rgui_t *rgui, settings_t *settings)
 
 static void blit_line_regular(
       rgui_t *rgui,
-      unsigned fb_width, int x, int y,
+      size_t fb_width, size_t x, size_t y,
       const char *message, uint16_t color, uint16_t shadow_color)
 {
    uint16_t *frame_buf_data = rgui->frame_buf.data;
@@ -2795,7 +2795,7 @@ static void blit_line_regular(
 
          for (j = 0; j < FONT_HEIGHT; j++)
          {
-            unsigned buff_offset = ((y + j) * fb_width) + x;
+            size_t buff_offset = ((y + j) * fb_width) + x;
 
             for (i = 0; i < FONT_WIDTH; i++)
             {
@@ -2811,7 +2811,7 @@ static void blit_line_regular(
 
 static void blit_line_regular_shadow(
       rgui_t *rgui,
-      unsigned fb_width, int x, int y,
+      size_t fb_width, size_t x, size_t y,
       const char *message, uint16_t color, uint16_t shadow_color)
 {
    uint16_t *frame_buf_data = rgui->frame_buf.data;
@@ -2839,7 +2839,7 @@ static void blit_line_regular_shadow(
 
          for (j = 0; j < FONT_HEIGHT; j++)
          {
-            unsigned buff_offset = ((y + j) * fb_width) + x;
+            size_t buff_offset = ((y + j) * fb_width) + x;
 
             for (i = 0; i < FONT_WIDTH; i++)
             {
@@ -2864,7 +2864,7 @@ static void blit_line_regular_shadow(
 
 static void blit_line_extended(
       rgui_t *rgui,
-      unsigned fb_width, int x, int y,
+      size_t fb_width, size_t x, size_t y,
       const char *message, uint16_t color, uint16_t shadow_color)
 {
    uint16_t *frame_buf_data = rgui->frame_buf.data;
@@ -2898,7 +2898,7 @@ static void blit_line_extended(
 
          for (j = 0; j < FONT_HEIGHT; j++)
          {
-            unsigned buff_offset = ((y + j) * fb_width) + x;
+            size_t buff_offset = ((y + j) * fb_width) + x;
 
             for (i = 0; i < FONT_WIDTH; i++)
             {
@@ -2914,7 +2914,7 @@ static void blit_line_extended(
 
 static void blit_line_extended_shadow(
       rgui_t *rgui,
-      unsigned fb_width, int x, int y,
+      size_t fb_width, size_t x, size_t y,
       const char *message, uint16_t color, uint16_t shadow_color)
 {
    uint16_t *frame_buf_data = rgui->frame_buf.data;
@@ -2956,7 +2956,7 @@ static void blit_line_extended_shadow(
 
          for (j = 0; j < FONT_HEIGHT; j++)
          {
-            unsigned buff_offset = ((y + j) * fb_width) + x;
+            size_t buff_offset = ((y + j) * fb_width) + x;
 
             for (i = 0; i < FONT_WIDTH; i++)
             {
@@ -2982,7 +2982,7 @@ static void blit_line_extended_shadow(
 #ifdef HAVE_LANGEXTRA
 static void blit_line_cjk(
       rgui_t *rgui,
-      unsigned fb_width, int x, int y,
+      size_t fb_width, size_t x, size_t y,
       const char *message, uint16_t color, uint16_t shadow_color)
 {
    uint16_t *frame_buf_data   = rgui->frame_buf.data;
@@ -3021,7 +3021,7 @@ static void blit_line_cjk(
 
          for (j = 0; j < FONT_10X10_HEIGHT; j++)
          {
-            unsigned buff_offset = ((y + j) * fb_width) + x;
+            size_t buff_offset = ((y + j) * fb_width) + x;
 
             for (i = 0; i < FONT_10X10_WIDTH; i++)
             {
@@ -3037,7 +3037,7 @@ static void blit_line_cjk(
 
 static void blit_line_cjk_shadow(
       rgui_t *rgui,
-      unsigned fb_width, int x, int y,
+      size_t fb_width, size_t x, size_t y,
       const char *message, uint16_t color, uint16_t shadow_color)
 {
    uint16_t *frame_buf_data   = rgui->frame_buf.data;
@@ -3084,7 +3084,7 @@ static void blit_line_cjk_shadow(
 
          for (j = 0; j < FONT_10X10_HEIGHT; j++)
          {
-            unsigned buff_offset = ((y + j) * fb_width) + x;
+            size_t buff_offset = ((y + j) * fb_width) + x;
 
             for (i = 0; i < FONT_10X10_WIDTH; i++)
             {
@@ -3109,7 +3109,7 @@ static void blit_line_cjk_shadow(
 
 static void blit_line_rus(
       rgui_t *rgui,
-      unsigned fb_width, int x, int y,
+      size_t fb_width, size_t x, size_t y,
       const char *message, uint16_t color, uint16_t shadow_color)
 {
    uint16_t *frame_buf_data   = rgui->frame_buf.data;
@@ -3142,7 +3142,7 @@ static void blit_line_rus(
 
          for (j = 0; j < FONT_10X10_HEIGHT; j++)
          {
-            unsigned buff_offset = ((y + j) * fb_width) + x;
+            size_t buff_offset = ((y + j) * fb_width) + x;
 
             for (i = 0; i < FONT_10X10_WIDTH; i++)
             {
@@ -3158,7 +3158,7 @@ static void blit_line_rus(
 
 static void blit_line_rus_shadow(
       rgui_t *rgui,
-      unsigned fb_width, int x, int y,
+      size_t fb_width, size_t x, size_t y,
       const char *message, uint16_t color, uint16_t shadow_color)
 {
    uint16_t *frame_buf_data   = rgui->frame_buf.data;
@@ -3199,7 +3199,7 @@ static void blit_line_rus_shadow(
 
          for (j = 0; j < FONT_10X10_HEIGHT; j++)
          {
-            unsigned buff_offset = ((y + j) * fb_width) + x;
+            size_t buff_offset = ((y + j) * fb_width) + x;
 
             for (i = 0; i < FONT_10X10_WIDTH; i++)
             {
@@ -3223,7 +3223,7 @@ static void blit_line_rus_shadow(
 }
 #endif
 
-static void (*blit_line)(rgui_t *rgui, unsigned fb_width, int x, int y,
+static void (*blit_line)(rgui_t *rgui, size_t fb_width, size_t x, size_t y,
       const char *message, uint16_t color, uint16_t shadow_color) = blit_line_regular;
 
 /* blit_symbol() */
@@ -3727,9 +3727,9 @@ static void rgui_render_osk(
    if (!string_is_empty(input_label))
    {
       char input_label_buf[255];
-      unsigned input_label_length;
-      int input_label_x, input_label_y;
-      unsigned ticker_x_offset = 0;
+      size_t input_label_length;
+      size_t input_label_x, input_label_y;
+      size_t ticker_x_offset = 0;
       
       input_label_buf[0] = '\0';
       
@@ -3951,7 +3951,7 @@ static void rgui_render(void *data,
    static const char* const 
       ticker_spacer               = RGUI_TICKER_SPACER;
    int bottom                     = 0;
-   unsigned ticker_x_offset       = 0;
+   size_t ticker_x_offset         = 0;
    size_t entries_end             = 0;
    bool msg_force                 = false;
    bool fb_size_changed           = false;
@@ -4070,14 +4070,14 @@ static void rgui_render(void *data,
       /* Update currently 'highlighted' item */
       if (rgui->pointer.y > rgui->term_layout.start_y)
       {
-         unsigned new_ptr;
+         size_t new_ptr;
          menu_entries_ctl(MENU_ENTRIES_CTL_START_GET, &old_start);
 
          /* Note: It's okay for this to go out of range
           * (limits are checked in rgui_pointer_up()) */
-         new_ptr = (unsigned)((rgui->pointer.y - rgui->term_layout.start_y) / rgui->font_height_stride) + old_start;
+         new_ptr = ((rgui->pointer.y - rgui->term_layout.start_y) / rgui->font_height_stride) + old_start;
 
-         menu_input_set_pointer_selection(new_ptr);
+         menu_input_set_pointer_selection((unsigned)new_ptr);
       }
 
       /* Allow drag-scrolling if items are currently off-screen */
@@ -4154,7 +4154,7 @@ static void rgui_render(void *data,
        * through a list...) */
       const char *thumbnail_title = NULL;
       char thumbnail_title_buf[255];
-      unsigned title_x, title_width;
+      size_t title_x, title_width;
       thumbnail_title_buf[0] = '\0';
 
       /* Draw thumbnail */
@@ -4177,7 +4177,7 @@ static void rgui_render(void *data,
             if (gfx_animation_ticker_smooth(&ticker_smooth))
                title_width            = ticker_smooth.field_width;
             else
-               title_width            = (unsigned)(utf8len(thumbnail_title_buf) * rgui->font_width_stride);
+               title_width            = (utf8len(thumbnail_title_buf) * rgui->font_width_stride);
          }
          else
          {
@@ -4211,7 +4211,7 @@ static void rgui_render(void *data,
       char title_buf[255];
       size_t title_max_len;
       size_t title_len;
-      unsigned title_x;
+      size_t title_x;
       unsigned title_y               = rgui->term_layout.start_y - rgui->font_height_stride;
       unsigned term_end_x            = rgui->term_layout.start_x + (rgui->term_layout.width * rgui->font_width_stride);
       unsigned timedate_x            = term_end_x - (5 * rgui->font_width_stride);
@@ -4401,7 +4401,7 @@ static void rgui_render(void *data,
          /* If showing mini thumbnails, reduce title field length accordingly */
          if (show_mini_thumbnails)
          {
-            unsigned term_offset = rgui_swap_thumbnails 
+            size_t term_offset       = rgui_swap_thumbnails 
                ? (unsigned)(rgui->term_layout.height - (i - new_start) - 1)
                : (i - new_start);
             unsigned thumbnail_width = 0;

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -3064,7 +3064,7 @@ static int xmb_draw_item(
    gfx_animation_ctx_ticker_t ticker;
    gfx_animation_ctx_ticker_smooth_t ticker_smooth;
    char tmp[255];
-   unsigned ticker_x_offset            = 0;
+   size_t ticker_x_offset              = 0;
    const char *ticker_str              = NULL;
    unsigned entry_type                 = 0;
    const float half_size               = xmb->icon_size / 2.0f;
@@ -4508,8 +4508,8 @@ static void xmb_draw_fullscreen_thumbnails(
             char title_buf[255];
             gfx_animation_ctx_ticker_smooth_t ticker_smooth;
             int title_x               = 0;
-            unsigned ticker_x_offset  = 0;
-            unsigned ticker_str_width = 0;
+            size_t ticker_x_offset    = 0;
+            size_t ticker_str_width   = 0;
 
             title_buf[0] = '\0';
 
@@ -7193,7 +7193,7 @@ static int xmb_pointer_up(void *userdata,
              * move selection pointer up by 1 'page' */
             unsigned bottom_idx = (unsigned)selection + 1;
             size_t new_idx      = 0;
-            unsigned step       = 0;
+            size_t step         = 0;
 
             /* Determine index of entry at bottom of screen
              * Note: cannot use xmb_calculate_visible_range()

--- a/menu/menu_explore.c
+++ b/menu/menu_explore.c
@@ -836,7 +836,8 @@ static int explore_action_ok_find(const char *path, const char *label, unsigned 
 unsigned menu_displaylist_explore(file_list_t *list,
       settings_t *settings)
 {
-   unsigned i, cat;
+    size_t i;
+   unsigned cat;
    char tmp[512];
    unsigned depth, current_type, current_cat, previous_cat;
    struct item_file *stack_top  = NULL;
@@ -980,10 +981,10 @@ SKIP_EXPLORE_BY_CATEGORY:;
    {
       /* List all items in a selected explore by category */
       explore_string_t **entries = explore_state->by[current_cat];
-      unsigned i_last            = RBUF_LEN(entries) - 1;
+      size_t i_last            = RBUF_LEN(entries) - 1;
       for (i = 0; i <= i_last; i++)
          explore_menu_entry(list, explore_state,
-               entries[i]->str, EXPLORE_TYPE_FIRSTITEM + i);
+               entries[i]->str, (unsigned)(EXPLORE_TYPE_FIRSTITEM + i));
 
       if (explore_state->has_unknown[current_cat])
       {
@@ -1122,7 +1123,7 @@ SKIP_EXPLORE_BY_CATEGORY:;
          else
             explore_menu_entry(list,
                   explore_state, e->playlist_entry->label,
-                  EXPLORE_TYPE_FIRSTITEM + (e - explore_state->entries));
+                  (unsigned)(EXPLORE_TYPE_FIRSTITEM + (e - explore_state->entries)));
 
 SKIP_ENTRY:;
       }
@@ -1182,7 +1183,7 @@ SKIP_ENTRY:;
       }
    }
 
-   return list->size;
+   return (unsigned)list->size;
 }
 
 uintptr_t menu_explore_get_entry_icon(unsigned type)

--- a/retroarch.c
+++ b/retroarch.c
@@ -10443,13 +10443,13 @@ bool command_get_config_param(command_t *cmd, const char* arg)
 bool command_read_ram(command_t *cmd, const char *arg)
 {
    unsigned i;
-   char *reply                  = NULL;
-   const uint8_t  *data         = NULL;
-   char *reply_at               = NULL;
-   unsigned int nbytes          = 0;
-   unsigned int alloc_size      = 0;
-   unsigned int addr            = -1;
-   unsigned int len             = 0;
+   char *reply             = NULL;
+   const uint8_t  *data    = NULL;
+   char *reply_at          = NULL;
+   unsigned int nbytes     = 0;
+   unsigned int alloc_size = 0;
+   unsigned int addr       = -1;
+   size_t len              = 0;
 
    if (sscanf(arg, "%x %u", &addr, &nbytes) != 2)
       return true;
@@ -10528,7 +10528,7 @@ static const rarch_memory_descriptor_t* command_memory_get_descriptor(const rarc
    return NULL;
 }
 
-static uint8_t* command_memory_get_pointer(unsigned address,
+static uint8_t *command_memory_get_pointer(unsigned address,
       unsigned int* max_bytes, int for_write, char* reply_at, size_t len)
 {
    struct rarch_state       *p_rarch = &rarch_st;
@@ -10547,7 +10547,7 @@ static uint8_t* command_memory_get_pointer(unsigned address,
       else
       {
          const size_t offset = address - desc->core.start;
-         *max_bytes = (desc->core.len - offset);
+         *max_bytes          = (unsigned int)(desc->core.len - offset);
          return (uint8_t*)desc->core.ptr + desc->core.offset + offset;
       }
    }
@@ -10565,7 +10565,7 @@ bool command_read_memory(command_t *cmd, const char *arg)
    unsigned int nbytes          = 0;
    unsigned int alloc_size      = 0;
    unsigned int address         = -1;
-   unsigned int len             = 0;
+   size_t len                   = 0;
    unsigned int max_bytes       = 0;
 
    if (sscanf(arg, "%x %u", &address, &nbytes) != 2)


### PR DESCRIPTION
@jdgleaver Let me know if this is safe to merge and won't cause regressions. Xcode on Mac in particular complains about all these implicit conversions when compiling, so I think it's for the best we make sure implicit conversions in the codebase happen as little as possible.

This cuts total warnings down from 70 to 45.