### PR TITLE
Fix issue detected by valgrind

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -3719,7 +3719,7 @@ bool config_unload_override(void)
 bool config_load_remap(const char *directory_input_remapping,
       void *data)
 {
-   char content_dir_name[PATH_MAX_LENGTH];
+   char content_dir_name[PATH_MAX_LENGTH] = { 0 };
    /* path to the directory containing retroarch.cfg (prefix)    */
    char remap_directory[PATH_MAX_LENGTH];
    /* final path for core-specific configuration (prefix+suffix) */


### PR DESCRIPTION
==27741== Conditional jump or move depends on uninitialised value(s)
==27741==    at 0x6080F5: strlcpy_retro__ (compat_strl.c:38)
==27741==    by 0x60818A: strlcat_retro__ (compat_strl.c:60)
==27741==    by 0x49EDD7: fill_pathname_join_special_ext (file_path.c:843)
==27741==    by 0x4C78C8: config_load_remap (configuration.c:3765)
==27741==    by 0x4386FF: command_event_init_core (retroarch.c:12601)
==27741==    by 0x43B15E: command_event (retroarch.c:14000)
==27741==    by 0x468863: retroarch_main_init (retroarch.c:35231)
==27741==    by 0x487AED: content_load (task_content.c:607)
==27741==    by 0x48A3D3: task_load_content_internal (task_content.c:2068)
==27741==    by 0x48A6AD: task_push_load_content_from_cli (task_content.c:2162)
==27741==    by 0x43D66E: rarch_main (retroarch.c:15300)
==27741==    by 0x43D6ED: main (retroarch.c:15398)
==27741==  Uninitialised value was created by a stack allocation
==27741==    at 0x4C7730: config_load_remap (configuration.c:3721)

## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

[Description of the pull request, detail any issues you are fixing or any features you are implementing]

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
