### PR TITLE
(cheevos) attempt to silence return-local-addr warning

### DIFF
--- a/deps/rcheevos/src/rcheevos/lboard.c
+++ b/deps/rcheevos/src/rcheevos/lboard.c
@@ -151,6 +151,10 @@ int rc_lboard_size(const char* memaddr) {
 rc_lboard_t* rc_parse_lboard(void* buffer, const char* memaddr, lua_State* L, int funcs_ndx) {
   rc_lboard_t* self;
   rc_parse_state_t parse;
+
+  if (!buffer || !memaddr)
+    return 0;
+
   rc_init_parse_state(&parse, buffer, L, funcs_ndx);
   
   self = RC_ALLOC(rc_lboard_t, &parse);
@@ -159,7 +163,7 @@ rc_lboard_t* rc_parse_lboard(void* buffer, const char* memaddr, lua_State* L, in
   rc_parse_lboard_internal(self, memaddr, &parse);
 
   rc_destroy_parse_state(&parse);
-  return parse.offset >= 0 ? self : 0;
+  return (parse.offset >= 0) ? self : 0;
 }
 
 int rc_evaluate_lboard(rc_lboard_t* self, int* value, rc_peek_t peek, void* peek_ud, lua_State* L) {

--- a/deps/rcheevos/src/rcheevos/richpresence.c
+++ b/deps/rcheevos/src/rcheevos/richpresence.c
@@ -394,6 +394,10 @@ int rc_richpresence_size(const char* script) {
 rc_richpresence_t* rc_parse_richpresence(void* buffer, const char* script, lua_State* L, int funcs_ndx) {
   rc_richpresence_t* self;
   rc_parse_state_t parse;
+
+  if (!buffer || !script)
+    return 0;
+
   rc_init_parse_state(&parse, buffer, L, funcs_ndx);
 
   self = RC_ALLOC(rc_richpresence_t, &parse);
@@ -402,7 +406,7 @@ rc_richpresence_t* rc_parse_richpresence(void* buffer, const char* script, lua_S
   rc_parse_richpresence_internal(self, script, &parse);
 
   rc_destroy_parse_state(&parse);
-  return parse.offset >= 0 ? self : 0;
+  return (parse.offset >= 0) ? self : 0;
 }
 
 int rc_evaluate_richpresence(rc_richpresence_t* richpresence, char* buffer, unsigned buffersize, rc_peek_t peek, void* peek_ud, lua_State* L) {

--- a/deps/rcheevos/src/rcheevos/trigger.c
+++ b/deps/rcheevos/src/rcheevos/trigger.c
@@ -58,6 +58,10 @@ int rc_trigger_size(const char* memaddr) {
 rc_trigger_t* rc_parse_trigger(void* buffer, const char* memaddr, lua_State* L, int funcs_ndx) {
   rc_trigger_t* self;
   rc_parse_state_t parse;
+
+  if (!buffer || !memaddr)
+    return 0;
+
   rc_init_parse_state(&parse, buffer, L, funcs_ndx);
 
   self = RC_ALLOC(rc_trigger_t, &parse);
@@ -66,7 +70,7 @@ rc_trigger_t* rc_parse_trigger(void* buffer, const char* memaddr, lua_State* L, 
   rc_parse_trigger_internal(self, &memaddr, &parse);
 
   rc_destroy_parse_state(&parse);
-  return parse.offset >= 0 ? self : 0;
+  return (parse.offset >= 0) ? self : 0;
 }
 
 static void rc_reset_trigger_hitcounts(rc_trigger_t* self) {

--- a/deps/rcheevos/src/rcheevos/value.c
+++ b/deps/rcheevos/src/rcheevos/value.c
@@ -201,6 +201,10 @@ int rc_value_size(const char* memaddr) {
 rc_value_t* rc_parse_value(void* buffer, const char* memaddr, lua_State* L, int funcs_ndx) {
   rc_value_t* self;
   rc_parse_state_t parse;
+
+  if (!buffer || !memaddr)
+    return 0;
+
   rc_init_parse_state(&parse, buffer, L, funcs_ndx);
 
   self = RC_ALLOC(rc_value_t, &parse);
@@ -209,7 +213,7 @@ rc_value_t* rc_parse_value(void* buffer, const char* memaddr, lua_State* L, int 
   rc_parse_value_internal(self, &memaddr, &parse);
 
   rc_destroy_parse_state(&parse);
-  return parse.offset >= 0 ? self : 0;
+  return (parse.offset >= 0) ? self : 0;
 }
 
 int rc_evaluate_value(rc_value_t* self, rc_peek_t peek, void* ud, lua_State* L) {


### PR DESCRIPTION
## Description

The 3DS toolchain is generating some warnings
```
In file included from griffin/griffin.c:210:
griffin/../deps/rcheevos/src/rcheevos/trigger.c: In function 'rc_parse_trigger':
griffin/../deps/rcheevos/src/rcheevos/trigger.c:69:35: warning: function may return address of local variable [-Wreturn-local-addr]
   69 |   return parse.offset >= 0 ? self : 0;
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~^~~
griffin/../deps/rcheevos/src/rcheevos/trigger.c:60:20: note: declared here
   60 |   rc_parse_state_t parse;
      |                    ^~~~~
In file included from griffin/griffin.c:204:
griffin/../deps/rcheevos/src/rcheevos/lboard.c: In function 'rc_parse_lboard':
griffin/../deps/rcheevos/src/rcheevos/lboard.c:162:35: warning: function may return address of local variable [-Wreturn-local-addr]
  162 |   return parse.offset >= 0 ? self : 0;
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~^~~
griffin/../deps/rcheevos/src/rcheevos/lboard.c:153:20: note: declared here
  153 |   rc_parse_state_t parse;
      |                    ^~~~~
In file included from griffin/griffin.c:207:
griffin/../deps/rcheevos/src/rcheevos/richpresence.c: In function 'rc_parse_richpresence':
griffin/../deps/rcheevos/src/rcheevos/richpresence.c:405:35: warning: function may return address of local variable [-Wreturn-local-addr]
  405 |   return parse.offset >= 0 ? self : 0;
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~^~~
griffin/../deps/rcheevos/src/rcheevos/richpresence.c:396:20: note: declared here
  396 |   rc_parse_state_t parse;
      |                    ^~~~~
In file included from griffin/griffin.c:211:
griffin/../deps/rcheevos/src/rcheevos/value.c: In function 'rc_parse_value':
griffin/../deps/rcheevos/src/rcheevos/value.c:212:35: warning: function may return address of local variable [-Wreturn-local-addr]
  212 |   return parse.offset >= 0 ? self : 0;
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~^~~
griffin/../deps/rcheevos/src/rcheevos/value.c:203:20: note: declared here
  203 |   rc_parse_state_t parse;
      |                    ^~~~~
```
Which seem like false positives. `parse` is not being returned, `self` is, and `self` should be pointing at the `buffer` passed into the function. 

If `buffer` is NULL, it's possible that `self` might be pointing at fields in `parse`, in which case the error is misleading. I've added NULL checks as an attempt to address the warning.

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@twinaphex 
