### PR TITLE
Stage 1 fix for CrtSwitchres not working 1.9.1 (Crash fix)

### DIFF
--- a/gfx/display_servers/dispserv_x11.c
+++ b/gfx/display_servers/dispserv_x11.c
@@ -579,6 +579,29 @@ static void x11_display_server_destroy(void *data)
             }  
             XRRFreeOutputInfo(outputs);
          }
+         for (m = 0; m < resources->nmode; m++)
+         {
+            for (j = 0; j < res->noutput; j++)
+            {
+               for (i = 1 ; i <= dispserv->crt_name_id; i++ )
+               {
+                  XRROutputInfo *outputs = XRRGetOutputInfo(dpy, res, res->outputs[j]);
+                  if (outputs->connection == RR_Connected)
+                  {
+                     snprintf(dispserv->old_mode, sizeof(dispserv->old_mode),
+                        "CRT%d", i);
+                     if (string_is_equal(resources->modes[m].name,
+                              dispserv->old_mode))
+                     {
+                        swoldmode = &resources->modes[m];
+                        XRRDeleteOutputMode(dpy, res->outputs[j], swoldmode->id);
+                        XRRDestroyMode(dpy, swoldmode->id);
+                        XSync(dpy, False);
+                     }
+                  }
+               }
+            }
+         }
       }
       else
       {
@@ -611,15 +634,13 @@ static void x11_display_server_destroy(void *data)
             XRRFreeCrtcInfo(crtc);
          }
          XRRFreeOutputInfo(outputs);
-      }
 
-      for (m = 0; m < resources->nmode; m++)
-      {
-         for (j = 0; j < res->noutput; j++)
+         for (m = 0; m < resources->nmode; m++)
          {
+
             for (i = 1 ; i <= dispserv->crt_name_id; i++ )
             {
-               XRROutputInfo *outputs = XRRGetOutputInfo(dpy, res, res->outputs[j]);
+               XRROutputInfo *outputs = XRRGetOutputInfo(dpy, res, res->outputs[dispserv->monitor_index]);
                if (outputs->connection == RR_Connected)
                {
                   snprintf(dispserv->old_mode, sizeof(dispserv->old_mode),
@@ -628,14 +649,17 @@ static void x11_display_server_destroy(void *data)
                            dispserv->old_mode))
                   {
                      swoldmode = &resources->modes[m];
-                     XRRDeleteOutputMode(dpy, res->outputs[j], swoldmode->id);
+                     XRRDeleteOutputMode(dpy, res->outputs[dispserv->monitor_index], swoldmode->id);
                      XRRDestroyMode(dpy, swoldmode->id);
                      XSync(dpy, False);
                   }
                }
             }
+            
+         
          }
       }
+
       XRRFreeScreenResources(resources);
       XRRFreeScreenResources(res);
       XCloseDisplay(dpy);


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

This fix allows for the use of multi monitor when using CRTSwitchres. It fixes a bug that causes a crash.
Delete function will no longer try to delete resolutions from outputs that have not had resolutions added.

## Related Issues

Issue number #12244. This fixes the multi monitor issues causing crashes. 

## Related Pull Requests



## Reviewers

@twinaphex 
