### PR TITLE
allow rcheevos_patch_address to be called on game without achievements

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -491,6 +491,12 @@ static void rcheevos_invalidate_address(unsigned address)
 
 uint8_t* rcheevos_patch_address(unsigned address)
 {
+   if (rcheevos_locals.memory.count == 0)
+   {
+      /* memory map was not previously initialized (no achievements for this game?) try now */
+      rcheevos_memory_init(&rcheevos_locals.memory, rcheevos_locals.patchdata.console_id);
+   }
+
    return rcheevos_memory_find(&rcheevos_locals.memory, address);
 }
 
@@ -1476,10 +1482,12 @@ bool rcheevos_unload(void)
 #endif
    }
 
+   if (rcheevos_locals.memory.count > 0)
+      rcheevos_memory_destroy(&rcheevos_locals.memory);
+
    if (rcheevos_locals.loaded)
    {
       rcheevos_free_patchdata(&rcheevos_locals.patchdata);
-      rcheevos_memory_destroy(&rcheevos_locals.memory);
 #ifdef HAVE_MENU
       cheevos_reset_menu_badges();
 #endif


### PR DESCRIPTION
## Description

Allows `READ_CORE_RAM` and `WRITE_CORE_RAM` to be called when a game does not have any achievements, or when achievements are disabled.

#11183 changed the achievement RAM mapping logic to occur once after achievements for a game have been loaded. Previously, it was dynamically populated as achievements requested memory values. This was much slower, used more memory, and was not thread safe.

However, the change also made it impossible to use `READ_CORE_RAM` and `WRITE_CORE_RAM` without having a game with achievements loaded. Since `READ_CORE_RAM` and `WRITE_CORE_RAM` leverage the achievement addressing scheme, this was determined to be of little consequence. After releasing 1.9.1, there were complaints that this was a breaking change (see #12262). While the approved solution is to migrate to the `READ_CORE_MEMORY` and `WRITE_CORE_MEMORY` network commands (which use hardware addressing instead of achievement addressing), it's reasonably simple to initialize the achievement memory map when `READ_CORE_RAM` or `WRITE_CORE_RAM` is called if it hasn't already been initialized.

## Related Issues

fixes #12262

## Related Pull Requests

n/a

## Reviewers

@Sanaki 
