### PR TITLE
(freetype/stb_unicode/bitmapfont) Prevent texture bleed when rendering text at non-integer scales

### DIFF
--- a/gfx/drivers_font_renderer/bitmapfont.c
+++ b/gfx/drivers_font_renderer/bitmapfont.c
@@ -28,6 +28,11 @@
 #define BMP_ATLAS_ROWS 16
 #define BMP_ATLAS_SIZE (BMP_ATLAS_COLS * BMP_ATLAS_ROWS)
 
+/* Padding is required between each glyph in
+ * the atlas to prevent texture bleed when
+ * drawing with linear filtering enabled */
+#define BMP_ATLAS_PADDING 1
+
 typedef struct bm_renderer
 {
    unsigned scale_factor;
@@ -96,16 +101,16 @@ static void *font_renderer_bmp_init(const char *font_path, float font_size)
    if (!handle->scale_factor)
       handle->scale_factor = 1;
 
-   handle->atlas.width  = FONT_WIDTH * handle->scale_factor * BMP_ATLAS_COLS;
-   handle->atlas.height = FONT_HEIGHT * handle->scale_factor * BMP_ATLAS_ROWS;
+   handle->atlas.width  = (BMP_ATLAS_PADDING + (FONT_WIDTH  * handle->scale_factor)) * BMP_ATLAS_COLS;
+   handle->atlas.height = (BMP_ATLAS_PADDING + (FONT_HEIGHT * handle->scale_factor)) * BMP_ATLAS_ROWS;
    handle->atlas.buffer = (uint8_t*)calloc(handle->atlas.width * handle->atlas.height, 1);
 
    for (i = 0; i < BMP_ATLAS_SIZE; i++)
    {
       unsigned x                       = (i % BMP_ATLAS_COLS) *
-         handle->scale_factor * FONT_WIDTH;
+         (BMP_ATLAS_PADDING + (handle->scale_factor * FONT_WIDTH));
       unsigned y                       = (i / BMP_ATLAS_COLS) *
-         handle->scale_factor * FONT_HEIGHT;
+         (BMP_ATLAS_PADDING + (handle->scale_factor * FONT_HEIGHT));
 
       char_to_texture(handle, i, x, y);
 

--- a/gfx/drivers_font_renderer/stb.c
+++ b/gfx/drivers_font_renderer/stb.c
@@ -86,6 +86,9 @@ static bool font_renderer_stb_create_atlas(stb_font_renderer_t *self,
    if (!self->atlas.buffer)
       goto error;
 
+   /* Note: 1 pixel of padding is added to
+    * prevent texture bleed when drawing with
+    * linear filtering enabled */
    stbtt_PackBegin(&pc, self->atlas.buffer,
          self->atlas.width, self->atlas.height,
          self->atlas.width, 1, NULL);

--- a/gfx/drivers_font_renderer/stb_unicode.c
+++ b/gfx/drivers_font_renderer/stb_unicode.c
@@ -42,6 +42,10 @@
 #define STB_UNICODE_ATLAS_ROWS 16
 #define STB_UNICODE_ATLAS_COLS 16
 #define STB_UNICODE_ATLAS_SIZE (STB_UNICODE_ATLAS_ROWS * STB_UNICODE_ATLAS_COLS)
+/* Padding is required between each glyph in
+ * the atlas to prevent texture bleed when
+ * drawing with linear filtering enabled */
+#define STB_UNICODE_ATLAS_PADDING 1
 
 typedef struct stb_unicode_atlas_slot
 {
@@ -195,8 +199,8 @@ static bool font_renderer_stb_unicode_create_atlas(
    self->max_glyph_width  = font_size < 0 ? -font_size : font_size;
    self->max_glyph_height = font_size < 0 ? -font_size : font_size;
 
-   self->atlas.width      = self->max_glyph_width  * STB_UNICODE_ATLAS_COLS;
-   self->atlas.height     = self->max_glyph_height * STB_UNICODE_ATLAS_ROWS;
+   self->atlas.width      = (self->max_glyph_width  + STB_UNICODE_ATLAS_PADDING) * STB_UNICODE_ATLAS_COLS;
+   self->atlas.height     = (self->max_glyph_height + STB_UNICODE_ATLAS_PADDING) * STB_UNICODE_ATLAS_ROWS;
 
    self->atlas.buffer     = (uint8_t*)
       calloc(self->atlas.width * self->atlas.height, sizeof(uint8_t));
@@ -210,8 +214,8 @@ static bool font_renderer_stb_unicode_create_atlas(
    {
       for (x = 0; x < STB_UNICODE_ATLAS_COLS; x++)
       {
-         slot->glyph.atlas_offset_x = x * self->max_glyph_width;
-         slot->glyph.atlas_offset_y = y * self->max_glyph_height;
+         slot->glyph.atlas_offset_x = x * (self->max_glyph_width  + STB_UNICODE_ATLAS_PADDING);
+         slot->glyph.atlas_offset_y = y * (self->max_glyph_height + STB_UNICODE_ATLAS_PADDING);
          slot++;
       }
    }


### PR DESCRIPTION
## Description

At present, whenever text is drawn in RetroArch at a non-integer scale using either the `freetype`, `stb_unicode` or `bitmapfont` renderers, garbage will often be displayed at the edges of each glyph. This problem has existed forever, and it occurs due to texture bleeding.

This PR fixes the issue:

- 1 pixel of padding has been added between each glyph in the `freetype`, `stb_unicode` and `bitmapfont` texture atlases (this is the main element of the fix)
- When populating the `freetype` texture atlas, unused pixels are now zeroed out. Previously, these would be populated with leftovers from that last set glyph (i.e. the active glyph would be bordered by garbage - a second source of texture bleed)
