### PR TITLE
Avoid system freez on PS3/PSL1GHT when a wrong roms set is started

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -35332,6 +35332,9 @@ bool retroarch_main_init(int argc, char *argv[])
 #ifdef HAVE_MENU
           || p_rarch->menu_driver_alive
 #endif
+#if defined(__PS3__) || defined(__PSL1GHT__)
+          || 1
+#endif
          )
       {
          /* Attempt initializing dummy core */


### PR DESCRIPTION
Always attempt initializing dummy core when init_failed on PS3/PSL1GHT system when a wrong rom set is started that, cause a system freez