### PR TITLE
Fixed CRTSwitchRes framebuffer bug

### DIFF
--- a/gfx/display_servers/dispserv_x11.c
+++ b/gfx/display_servers/dispserv_x11.c
@@ -261,10 +261,13 @@ static bool x11_display_server_set_resolution(void *data,
             XRRSetCrtcConfig(dpy, res,res->crtcs[i], CurrentTime,
                   0, 0, None, RR_Rotate_0, NULL, 0);
             XSync(dpy, False);
+            XRRSetScreenSize(dpy, window, width, height, (int) ((25.4 * width) / 96.0), (int) ((25.4 * height) / 96.0));
+            XSync(dpy, False);
             XRRSetCrtcConfig(dpy, res, res->crtcs[i], CurrentTime,
                   crtc->x, crtc->y, crtc->mode, crtc->rotation,
                   crtc->outputs, crtc->noutput);   
             XSync(dpy, False);
+
 
             XRRFreeCrtcInfo(crtc);
 
@@ -292,12 +295,12 @@ static bool x11_display_server_set_resolution(void *data,
          XRRSetCrtcConfig(dpy, res,res->crtcs[monitor_index], CurrentTime,
                0, 0, None, RR_Rotate_0, NULL, 0);
          XSync(dpy, False);
+         XRRSetScreenSize(dpy, window, width, height, (int) ((25.4 * width) / 96.0), (int) ((25.4 * height) / 96.0));
+         XSync(dpy, False);
          XRRSetCrtcConfig(dpy, res, res->crtcs[monitor_index], CurrentTime,
                crtc->x, crtc->y, crtc->mode, crtc->rotation,
                crtc->outputs, crtc->noutput);
          XSync(dpy, False);
-
-
 
          XRRFreeCrtcInfo(crtc);
       }


### PR DESCRIPTION
## Description

This PR fixes the final CRTSwirchRes bug in 1.9.1. Framebuffer is now resized before a resolution is changed.

## Related Issues

CRTSwitchres not working 1.9.1 #12244

## Reviewers

@twinaphex 
