### PR TITLE
Added input_playerX_combine_into for combining controllers

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -2439,6 +2439,8 @@ void config_set_defaults(void *data)
 #endif
       input_config_set_device(i, RETRO_DEVICE_JOYPAD);
       settings->uints.input_mouse_index[i] = 0;
+      settings->uints.input_combine_into[i] = 0;
+      settings->uints.input_combine_from[i][0] = 0;
    }
 
    video_driver_reset_custom_viewport();
@@ -3017,7 +3019,7 @@ static void video_driver_load_settings(global_t *global,
 static bool config_load_file(global_t *global,
       const char *path, settings_t *settings)
 {
-   unsigned i;
+   unsigned i,j;
    char tmp_str[PATH_MAX_LENGTH];
    bool ret                                        = false;
    unsigned tmp_uint                               = 0;
@@ -3162,6 +3164,7 @@ static bool config_load_file(global_t *global,
    for (i = 0; i < MAX_USERS; i++)
    {
       char buf[64];
+      uint16_t into;
 
       buf[0] = '\0';
 
@@ -3176,6 +3179,23 @@ static bool config_load_file(global_t *global,
 
       snprintf(buf, sizeof(buf), "input_libretro_device_p%u", i + 1);
       CONFIG_GET_INT_BASE(conf, settings, uints.input_libretro_device[i], buf);
+
+      snprintf(buf, sizeof(buf), "input_player%u_combine_into", i + 1);
+      CONFIG_GET_INT_BASE(conf, settings, uints.input_combine_into[i], buf);
+      RARCH_DBG("combine port %d into port %d",i+1,settings->uints.input_combine_into[i]);
+
+      into = settings->uints.input_combine_into[i];
+      if((into > 0) && (into < MAX_USERS+1)) {
+         RARCH_DBG("combine port %d into port %d",i+1,into);
+         /* append to the combine_from array */
+         for(j=0;j<MAX_USERS-2;j++) {
+            if(settings->uints.input_combine_from[into-1][j] == 0) {
+               settings->uints.input_combine_from[into-1][j] = i+1;
+               settings->uints.input_combine_from[into-1][j+1] = 0;
+               break;
+            }
+         }
+      }
    }
 
    /* LED map for use by the led driver */
@@ -4200,6 +4220,8 @@ bool config_save_file(const char *path)
       config_set_int(conf, cfg, settings->uints.input_analog_dpad_mode[i]);
       snprintf(cfg, sizeof(cfg), "input_player%u_mouse_index", i + 1);
       config_set_int(conf, cfg, settings->uints.input_mouse_index[i]);
+      snprintf(cfg, sizeof(cfg), "input_player%u_combine_into", i + 1);
+      config_set_int(conf, cfg, settings->uints.input_combine_into[i]);
    }
 
    /* Boolean settings */

--- a/configuration.h
+++ b/configuration.h
@@ -127,6 +127,8 @@ typedef struct settings
        * Does not override main binds. */
       unsigned input_libretro_device[MAX_USERS];
       unsigned input_analog_dpad_mode[MAX_USERS];
+      unsigned input_combine_into[MAX_USERS];
+      unsigned input_combine_from[MAX_USERS][MAX_USERS];
 
       unsigned input_keymapper_ids[MAX_USERS][RARCH_CUSTOM_BIND_LIST_END];
 

--- a/retroarch.c
+++ b/retroarch.c
@@ -22957,6 +22957,33 @@ static int16_t input_state_device(
    return res;
 }
 
+static int16_t _input_state(unsigned port, unsigned device,
+      unsigned idx, unsigned id);
+
+static int16_t input_state(unsigned port, unsigned device,
+      unsigned idx, unsigned id) {
+   struct rarch_state *p_rarch = &rarch_st;
+   settings_t *settings        = p_rarch->configuration_settings;
+   unsigned *from = *(settings->uints.input_combine_from+port);
+   unsigned into = settings->uints.input_combine_into[port];
+   int16_t ret = 0;
+   int i;
+
+   if(into) return 0;
+
+   ret = _input_state(port,device,idx,id);
+
+   if((ret == 0) && (from[0])) {
+      /* check any combined ports */
+      for(i = 0; i < MAX_USERS; i++) {
+        if(!from[i]) break;
+        ret = _input_state(from[i]-1,device,idx,id);
+        if(ret) break;
+      }
+   }
+   return ret;
+}
+
 /**
  * input_state:
  * @port                 : user number.
@@ -22969,7 +22996,7 @@ static int16_t input_state_device(
  * Returns: Non-zero if the given key (identified by @id)
  * was pressed by the user (assigned to @port).
  **/
-static int16_t input_state(unsigned port, unsigned device,
+static int16_t _input_state(unsigned port, unsigned device,
       unsigned idx, unsigned id)
 {
    rarch_joypad_info_t joypad_info;


### PR DESCRIPTION

## Description

This is intended for cases where the user wants to map controls from multiple physical controllers into a single virtual controller.  This is useful for playing dual stick games with two physical joysticks mounted in the same control panel, or driving games where the wheel and the pedals are separate analog controls.

This is accomplished by layering additional retropads on top of a single main retropad.  Each additional retropad is configured with the additional buttons and axis that should be added to the main retropad.  Then each additional retropad is configured with input_playerX_combine_into = "#" where # is the 1 based index of the main retropad.

The additional retropads never report any input, and the main retropad reports the combined input.  If the same button is provided by multiple retropads, then any of the buttons will provide that input.

Example:

input_player1_joypad_index = "1"
input_player1_a_btn = "0"

input_player4_joypad_index = "2"
input_player4_b_btn = "0"
input_player4_combine_into = "1"

retropad 1 has two buttons, A=joypad1/button0, B=joypad2/button0
retropad 4 is unused

## Related Issues

https://github.com/libretro/RetroArch/issues/7830

