### PR TITLE
Fix crash in sdl input driver when analogs are bound.

### DIFF
--- a/input/drivers/sdl_input.c
+++ b/input/drivers/sdl_input.c
@@ -142,14 +142,12 @@ static int16_t sdl_input_state(
 
             if (id_plus_valid && id_plus_key < RETROK_LAST)
             {
-               unsigned sym = rarch_keysym_lut[(enum retro_key)id_plus_key];
-               if (sdl_key_pressed(sym))
+               if (sdl_key_pressed(id_plus_key))
                   ret = 0x7fff;
             }
             if (id_minus_valid && id_minus_key < RETROK_LAST)
             {
-               unsigned sym = rarch_keysym_lut[(enum retro_key)id_minus_key];
-               if (sdl_key_pressed(sym))
+               if (sdl_key_pressed(id_minus_key))
                   ret += -0x7fff;
             }
 


### PR DESCRIPTION
## Description

Using SDL input driver, after setting keybindings for port1 analogs, RetroArch crashed with SIGSEGV when I opened any game.

Wrongly SDL keycodes were fed into a function expecting retro_key.
