### PR TITLE
GDI: Fix non-ASCII text rendering

### DIFF
--- a/gfx/drivers_font/gdi_font.c
+++ b/gfx/drivers_font/gdi_font.c
@@ -142,9 +142,11 @@ static void gdi_render_msg(
       blue       = video_msg_color_b * 255.0f;
    }
 
-   msg_strlen = strlen(msg);
+   char* msg_local = utf8_to_local_string_alloc(msg);
 
-   GetTextExtentPoint32(font->gdi->memDC, msg, msg_strlen, &textSize);
+   msg_strlen = strlen(msg_local);
+
+   GetTextExtentPoint32(font->gdi->memDC, msg_local, msg_strlen, &textSize);
 
    switch (align)
    {
@@ -174,7 +176,7 @@ static void gdi_render_msg(
    SetBkMode(font->gdi->memDC, TRANSPARENT);
 
    string_list_initialize(&msg_list);
-   string_split_noalloc(&msg_list, msg, "\n");
+   string_split_noalloc(&msg_list, msg_local, "\n");
 
    if (drop_x || drop_y)
    {
@@ -188,7 +190,7 @@ static void gdi_render_msg(
       for (i = 0; i < msg_list.size; i++)
          TextOut(font->gdi->memDC, newDropX, newDropY + (textSize.cy * i),
                msg_list.elems[i].data,
-               utf8len(msg_list.elems[i].data));
+               strlen(msg_list.elems[i].data));
    }
 
    SetTextColor(font->gdi->memDC, RGB(red, green, blue));
@@ -196,9 +198,10 @@ static void gdi_render_msg(
    for (i = 0; i < msg_list.size; i++)
       TextOut(font->gdi->memDC, newX, newY + (textSize.cy * i),
             msg_list.elems[i].data,
-            utf8len(msg_list.elems[i].data));
+            strlen(msg_list.elems[i].data));
 
    string_list_deinitialize(&msg_list);
+   free(msg_local);
 
    SelectObject(font->gdi->memDC, font->gdi->bmp_old);
 }


### PR DESCRIPTION
## Description

I found out that GDI video driver didn't handle non-ASCII characters correctly, so I made a small change to fix that.
I know that GDI driver is basically a busted driver and is not recommended to use, but it bugged me enough to care so here it is.
This is my first pull request (beside translation thing), so please let me know if there is something wrong.

![gdi](https://user-images.githubusercontent.com/1446561/115710044-e06eeb00-a3ac-11eb-88d6-9fcd95fa3cdc.png)