### PR TITLE
(3DS) Enable gfx_widgets / overlays

### DIFF
--- a/Makefile.ctr
+++ b/Makefile.ctr
@@ -58,8 +58,8 @@ ifeq ($(GRIFFIN_BUILD), 1)
 	DEFINES += -DHAVE_SCREENSHOTS
 	DEFINES += -DHAVE_REWIND
 	DEFINES += -DHAVE_THREADS
-	#DEFINES += -DHAVE_GFX_WIDGETS
-	#DEFINES += -DHAVE_OVERLAY
+	DEFINES += -DHAVE_GFX_WIDGETS
+	DEFINES += -DHAVE_OVERLAY
 	#DEFINES += -DHAVE_SOCKET_LEGACY
 	#-DHAVE_SSL -DHAVE_BUILTINMBEDTLS -DMBEDTLS_SSL_DEBUG_ALL
 	#ssl is currently incompatible with griffin due to use of the "static" flag on repeating functions that will conflict when included in one file

--- a/frontend/drivers/platform_ctr.c
+++ b/frontend/drivers/platform_ctr.c
@@ -123,6 +123,8 @@ static void frontend_ctr_get_env(int* argc, char* argv[],
                       "filters/audio", sizeof(g_defaults.dirs[DEFAULT_DIR_AUDIO_FILTER]));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_VIDEO_FILTER], g_defaults.dirs[DEFAULT_DIR_PORT],
                       "filters/video", sizeof(g_defaults.dirs[DEFAULT_DIR_VIDEO_FILTER]));
+   fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_OVERLAY], g_defaults.dirs[DEFAULT_DIR_PORT],
+                      "overlays/ctr", sizeof(g_defaults.dirs[DEFAULT_DIR_OVERLAY]));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_DATABASE], g_defaults.dirs[DEFAULT_DIR_PORT],
                       "database/rdb", sizeof(g_defaults.dirs[DEFAULT_DIR_DATABASE]));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CURSOR], g_defaults.dirs[DEFAULT_DIR_PORT],

--- a/gfx/drivers/ctr_gfx.c
+++ b/gfx/drivers/ctr_gfx.c
@@ -153,7 +153,7 @@ static void ctr_free_overlay(ctr_video_t *ctr)
    for (i = 0; i < ctr->overlays; i++)
    {
       linearFree(ctr->overlay[i].frame_coords);
-	  linearFree(ctr->overlay[i].texture.data);
+      linearFree(ctr->overlay[i].texture.data);
    }
 
    free(ctr->overlay);
@@ -513,7 +513,7 @@ static void* ctr_init(const video_info_t* video,
    ctr->vsync         = video->vsync;
    ctr->current_buffer_top = 0;
 
-#ifdef HAVE_OVERLAY
+#if defined(HAVE_OVERLAY) || defined(HAVE_GFX_WIDGETS)
    video_driver_set_rgba();
 #endif
 
@@ -1295,7 +1295,7 @@ static void ctr_unload_texture(void *data, bool threaded,
 static void ctr_overlay_tex_geom(void *data,
             unsigned image, float x, float y, float w, float h)
 {
-   ctr_video_t             *ctr = (ctr_video_t *)data;
+   ctr_video_t           *ctr = (ctr_video_t *)data;
    struct ctr_overlay_data *o = NULL;
 
    if (ctr)
@@ -1320,7 +1320,7 @@ static void ctr_overlay_tex_geom(void *data,
 static void ctr_overlay_vertex_geom(void *data,
             unsigned image, float x, float y, float w, float h)
 {
-   ctr_video_t             *ctr = (ctr_video_t *)data;
+   ctr_video_t           *ctr = (ctr_video_t *)data;
    struct ctr_overlay_data *o = NULL;
 
    if (ctr)


### PR DESCRIPTION
- Enable graphical widgets and overlay support for 3DS.
- Allow HAVE_GFX_WIDGETS and HAVE_OVERLAY to be enabled individually.

Resolves https://github.com/libretro/RetroArch/issues/12309

Related PR: https://github.com/libretro/common-overlays/pull/63
