### PR TITLE
(core_info) Performance optimisations + code clean-ups/refactors

### DIFF
--- a/core_info.h
+++ b/core_info.h
@@ -45,25 +45,19 @@ typedef struct
 
 /* Simple container/convenience struct for
  * holding the 'id' of a core file
- * > 'id' is the filename without extension or
+ * > 'str' is the filename without extension or
  *   platform-specific suffix
- * > 'id' is used for core info searches - enables
- *   matching regardless of core file base path,
- *   and is platform-independent (e.g. an Android
- *   core file will be correctly identified on Linux)
- * > 'len' is used to cache the length of 'str', for
- *   improved performance when performing string
- *   comparisons */
+ * > 'hash' is a hash key used for efficient core
+ *   list searches */
 typedef struct
 {
    char *str;
-   size_t len;
+   uint32_t hash;
 } core_file_id_t;
 
 typedef struct
 {
    char *path;
-   void *config_data;
    char *display_name;
    char *display_version;
    char *core_name;
@@ -89,8 +83,8 @@ typedef struct
    struct string_list *required_hw_api_list;
    core_info_firmware_t *firmware;
    core_file_id_t core_file_id; /* ptr alignment */
-   void *userdata;
    size_t firmware_count;
+   bool has_info;
    bool supports_no_game;
    bool database_match_archive_member;
    bool is_experimental;
@@ -112,6 +106,7 @@ typedef struct
    core_info_t *list;
    char *all_ext;
    size_t count;
+   size_t info_count;
 } core_info_list_t;
 
 typedef struct core_info_ctx_firmware
@@ -122,12 +117,6 @@ typedef struct core_info_ctx_firmware
       const char *system;
    } directory;
 } core_info_ctx_firmware_t;
-
-typedef struct core_info_ctx_find
-{
-   core_info_t *inf;
-   const char *path;
-} core_info_ctx_find_t;
 
 struct core_info_state
 {
@@ -141,29 +130,20 @@ struct core_info_state
 
 typedef struct core_info_state core_info_state_t;
 
-size_t core_info_list_num_info_files(core_info_list_t *list);
-
 /* Non-reentrant, does not allocate. Returns pointer to internal state. */
 void core_info_list_get_supported_cores(core_info_list_t *list,
       const char *path, const core_info_t **infos, size_t *num_infos);
 
 bool core_info_list_get_display_name(core_info_list_t *list,
-      const char *path, char *s, size_t len);
-
-bool core_info_get_display_name(const char *path, char *s, size_t len);
+      const char *core_path, char *s, size_t len);
 
 /* Returns core_info parameters required for
  * core updater tasks, read from specified file.
  * Returned core_updater_info_t object must be
  * freed using core_info_free_core_updater_info().
  * Returns NULL if 'path' is invalid. */
-core_updater_info_t *core_info_get_core_updater_info(const char *path);
+core_updater_info_t *core_info_get_core_updater_info(const char *info_path);
 void core_info_free_core_updater_info(core_updater_info_t *info);
-
-void core_info_get_name(const char *path, char *s, size_t len,
-      const char *path_info, const char *dir_cores,
-      const char *exts, bool show_hidden_files,
-      bool get_display_name);
 
 core_info_t *core_info_get(core_info_list_t *list, size_t i);
 
@@ -186,22 +166,20 @@ size_t core_info_count(void);
 bool core_info_list_update_missing_firmware(core_info_ctx_firmware_t *info,
       bool *set_missing_bios);
 
-bool core_info_find(core_info_ctx_find_t *info);
+bool core_info_find(const char *core_path,
+      core_info_t **core_info);
 
-bool core_info_load(
-      core_info_ctx_find_t *info,
+bool core_info_load(const char *core_path,
       core_info_state_t *p_coreinfo);
 
 bool core_info_database_supports_content_path(const char *database_path, const char *path);
 
 bool core_info_database_match_archive_member(const char *database_path);
 
-bool core_info_unsupported_content_path(const char *path);
-
 void core_info_qsort(core_info_list_t *core_info_list, enum core_info_list_qsort_type qsort_type);
 
 bool core_info_list_get_info(core_info_list_t *core_info_list,
-      core_info_t *out_info, const char *path);
+      core_info_t *out_info, const char *core_path);
 
 bool core_info_hw_api_supported(core_info_t *info);
 
@@ -223,7 +201,7 @@ bool core_info_get_core_lock(const char *core_path, bool validate_path);
 
 core_info_state_t *coreinfo_get_ptr(void);
 
-bool core_info_core_file_id_is_equal(const char* core_path_a, const char* core_path_b);
+bool core_info_core_file_id_is_equal(const char *core_path_a, const char *core_path_b);
 
 RETRO_END_DECLS
 

--- a/gfx/widgets/gfx_widget_load_content_animation.c
+++ b/gfx/widgets/gfx_widget_load_content_animation.c
@@ -284,13 +284,13 @@ bool gfx_widget_start_load_content_animation(void)
    const char *content_path                         = path_get(RARCH_PATH_CONTENT);
    const char *core_path                            = path_get(RARCH_PATH_CORE);
    playlist_t *playlist                             = playlist_get_cached();
+   core_info_t *core_info                           = NULL;
 
    bool playlist_entry_found                        = false;
    bool has_content                                 = false;
    bool has_system                                  = false;
    bool has_db_name                                 = false;
 
-   core_info_ctx_find_t core_info_finder;
    char icon_path[PATH_MAX_LENGTH];
 
    icon_path[0] = '\0';
@@ -314,13 +314,10 @@ bool gfx_widget_start_load_content_animation(void)
       return false;
 
    /* Check core validity */
-   core_info_finder.inf  = NULL;
-   core_info_finder.path = core_path;
-
-   if (!core_info_find(&core_info_finder))
+   if (!core_info_find(core_path, &core_info))
       return false;
 
-   core_path = core_info_finder.inf->path;
+   core_path = core_info->path;
 
    /* Parse content path
     * > If we have a cached playlist, attempt to find
@@ -357,10 +354,8 @@ bool gfx_widget_start_load_content_animation(void)
 
             /* Check whether core matches... */
             if (string_is_empty(entry_core_file) ||
-                !string_starts_with_size(
-                     entry_core_file,
-                     core_info_finder.inf->core_file_id.str,
-                     core_info_finder.inf->core_file_id.len))
+                !string_starts_with(entry_core_file,
+                     core_info->core_file_id.str))
                entry = NULL;
          }
       }
@@ -430,8 +425,8 @@ bool gfx_widget_start_load_content_animation(void)
    if (!has_system)
    {
       /* Use core display name, if available */
-      if (!string_is_empty(core_info_finder.inf->display_name))
-         strlcpy(state->system_name, core_info_finder.inf->display_name,
+      if (!string_is_empty(core_info->display_name))
+         strlcpy(state->system_name, core_info->display_name,
                sizeof(state->system_name));
       /* Otherwise, just use 'RetroArch' as a fallback */
       else
@@ -466,7 +461,7 @@ bool gfx_widget_start_load_content_animation(void)
    {
       const char *core_db_name           = NULL;
       struct string_list *databases_list =
-            core_info_finder.inf->databases_list;
+            core_info->databases_list;
 
       /* We can only use the core db_name if the
        * core is associated with exactly one database */

--- a/menu/cbs/menu_cbs_get_value.c
+++ b/menu/cbs/menu_cbs_get_value.c
@@ -451,19 +451,16 @@ static void menu_action_setting_disp_set_label_core_updater_entry(
        core_updater_list_get_filename(core_list, path, &entry) &&
        !string_is_empty(entry->local_core_path))
    {
-      core_info_ctx_find_t core_info;
+      core_info_t *core_info = NULL;
 
       /* Check whether core is installed
        * > Note: We search core_info here instead
        *   of calling path_is_valid() since we don't
        *   want to perform disk access every frame */
-      core_info.inf  = NULL;
-      core_info.path = entry->local_core_path;
-
-      if (core_info_find(&core_info))
+      if (core_info_find(entry->local_core_path, &core_info))
       {
          /* Highlight locked cores */
-         if (core_info.inf->is_locked)
+         if (core_info->is_locked)
          {
             s[0] = '[';
             s[1] = '#';
@@ -493,12 +490,12 @@ static void menu_action_setting_disp_set_label_core_manager_entry(
       const char *path,
       char *s2, size_t len2)
 {
-   core_info_ctx_find_t core_info;
-   const char *alt = list->list[i].alt
-      ? list->list[i].alt
-      : list->list[i].path;
-   *s              = '\0';
-   *w              = 0;
+   core_info_t *core_info = NULL;
+   const char *alt        = list->list[i].alt
+         ? list->list[i].alt
+         : list->list[i].path;
+   *s                     = '\0';
+   *w                     = 0;
 
    if (alt)
       strlcpy(s2, alt, len2);
@@ -507,11 +504,8 @@ static void menu_action_setting_disp_set_label_core_manager_entry(
     * > Note: We search core_info here instead of
     *   calling core_info_get_core_lock() since we
     *   don't want to perform disk access every frame */
-   core_info.inf  = NULL;
-   core_info.path = path;
-
-   if (core_info_find(&core_info) &&
-       core_info.inf->is_locked)
+   if (core_info_find(path, &core_info) &&
+       core_info->is_locked)
    {
       s[0] = '[';
       s[1] = '!';
@@ -529,12 +523,12 @@ static void menu_action_setting_disp_set_label_core_lock(
       const char *path,
       char *s2, size_t len2)
 {
-   core_info_ctx_find_t core_info;
-   const char *alt = list->list[i].alt
-      ? list->list[i].alt
-      : list->list[i].path;
-   *s              = '\0';
-   *w              = 0;
+   core_info_t *core_info = NULL;
+   const char *alt        = list->list[i].alt
+         ? list->list[i].alt
+         : list->list[i].path;
+   *s                     = '\0';
+   *w                     = 0;
 
    if (alt)
       strlcpy(s2, alt, len2);
@@ -543,11 +537,8 @@ static void menu_action_setting_disp_set_label_core_lock(
     * > Note: We search core_info here instead of
     *   calling core_info_get_core_lock() since we
     *   don't want to perform disk access every frame */
-   core_info.inf  = NULL;
-   core_info.path = path;
-
-   if (core_info_find(&core_info) &&
-       core_info.inf->is_locked)
+   if (core_info_find(path, &core_info) &&
+       core_info->is_locked)
       strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_ON), len);
    else
       strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF), len);

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -3556,44 +3556,36 @@ static int action_ok_path_manual_scan_directory(const char *path,
 static int action_ok_core_deferred_set(const char *new_core_path,
       const char *content_label, unsigned type, size_t idx, size_t entry_idx)
 {
-   char ext_name[255];
-   char core_display_name[PATH_MAX_LENGTH];
+   size_t selection              = menu_navigation_get_selection();
+   struct playlist_entry entry   = {0};
+   menu_handle_t *menu           = menu_driver_get_ptr();
+   core_info_t *core_info        = NULL;
+   const char *core_display_name = NULL;
    char resolved_core_path[PATH_MAX_LENGTH];
    char msg[PATH_MAX_LENGTH];
-   size_t selection                        = menu_navigation_get_selection();
-   struct playlist_entry entry             = {0};
-   menu_handle_t            *menu          = menu_driver_get_ptr();
-   settings_t *settings                    = config_get_ptr();
-   const char *path_libretro_info          = settings->paths.path_libretro_info;
-   const char *path_dir_libretro           = settings->paths.directory_libretro;
-   bool show_hidden_files                  = settings->bools.show_hidden_files;
 
-   ext_name[0]                             = '\0';
-   core_display_name[0]                    = '\0';
-   resolved_core_path[0]                   = '\0';
-   msg[0]                                  = '\0';
+   resolved_core_path[0] = '\0';
+   msg[0]                = '\0';
 
-   if (!menu)
+   if (!menu ||
+       string_is_empty(new_core_path))
       return menu_cbs_exit();
 
-   if (!frontend_driver_get_core_extension(ext_name, sizeof(ext_name)))
-      return menu_cbs_exit();
+   /* Get core display name */
+   if (core_info_find(new_core_path, &core_info))
+      core_display_name = core_info->display_name;
 
-   core_info_get_name(new_core_path,
-         core_display_name, sizeof(core_display_name),
-         path_libretro_info,
-         path_dir_libretro,
-         ext_name,
-         show_hidden_files,
-         true);
+   if (string_is_empty(core_display_name))
+      core_display_name = path_basename_nocompression(new_core_path);
 
+   /* Get 'real' core path */
    strlcpy(resolved_core_path, new_core_path, sizeof(resolved_core_path));
    playlist_resolve_path(PLAYLIST_SAVE, true, resolved_core_path, sizeof(resolved_core_path));
 
    /* the update function reads our entry
     * as const, so these casts are safe */
    entry.core_path = (char*)resolved_core_path;
-   entry.core_name = core_display_name;
+   entry.core_name = (char*)core_display_name;
 
    command_playlist_update_write(
          NULL,
@@ -5200,19 +5192,16 @@ static int action_ok_add_to_favorites(const char *path,
       {
          if (!string_is_empty(path_get(RARCH_PATH_CORE)))
          {
-            core_info_ctx_find_t core_info;
+            core_info_t *core_info = NULL;
 
             /* >> core_path */
             strlcpy(core_path, path_get(RARCH_PATH_CORE), sizeof(core_path));
 
             /* >> core_name
              * (always use display name, if available) */
-            core_info.inf  = NULL;
-            core_info.path = core_path;
-
-            if (core_info_find(&core_info))
-               if (!string_is_empty(core_info.inf->display_name))
-                  strlcpy(core_name, core_info.inf->display_name,
+            if (core_info_find(core_path, &core_info))
+               if (!string_is_empty(core_info->display_name))
+                  strlcpy(core_name, core_info->display_name,
                         sizeof(core_name));
          }
 
@@ -5336,19 +5325,16 @@ static int action_ok_add_to_favorites_playlist(const char *path,
       /* > core_path + core_name */
       if (!string_is_empty(entry->core_path) && !string_is_empty(entry->core_name))
       {
-         core_info_ctx_find_t core_info;
+         core_info_t *core_info = NULL;
 
          /* >> core_path */
          string_list_append(str_list, entry->core_path, attr);
 
          /* >> core_name
           * (always use display name, if available) */
-         core_info.inf  = NULL;
-         core_info.path = entry->core_path;
-
-         if (core_info_find(&core_info))
-            if (!string_is_empty(core_info.inf->display_name))
-               strlcpy(core_display_name, core_info.inf->display_name, sizeof(core_display_name));
+         if (core_info_find(entry->core_path, &core_info))
+            if (!string_is_empty(core_info->display_name))
+               strlcpy(core_display_name, core_info->display_name, sizeof(core_display_name));
 
          if (!string_is_empty(core_display_name))
             string_list_append(str_list, core_display_name, attr);
@@ -7181,19 +7167,17 @@ int action_ok_core_lock(const char *path,
    if (!core_info_set_core_lock(core_path, lock))
    {
       const char *core_name = NULL;
-      core_info_ctx_find_t core_info;
+      core_info_t *core_info = NULL;
       char msg[PATH_MAX_LENGTH];
 
       msg[0] = '\0';
 
       /* Need to fetch core name for error message */
-      core_info.inf  = NULL;
-      core_info.path = core_path;
 
       /* If core is found, use display name */
-      if (core_info_find(&core_info) &&
-          core_info.inf->display_name)
-         core_name = core_info.inf->display_name;
+      if (core_info_find(core_path, &core_info) &&
+          core_info->display_name)
+         core_name = core_info->display_name;
       /* If not, use core file name */
       else
          core_name = path_basename_nocompression(core_path);
@@ -7240,20 +7224,18 @@ static int action_ok_core_delete(const char *path,
    /* Check whether core is locked */
    if (core_info_get_core_lock(core_path, true))
    {
-      const char *core_name = NULL;
-      core_info_ctx_find_t core_info;
+      const char *core_name  = NULL;
+      core_info_t *core_info = NULL;
       char msg[PATH_MAX_LENGTH];
 
       msg[0] = '\0';
 
       /* Need to fetch core name for notification */
-      core_info.inf  = NULL;
-      core_info.path = core_path;
 
       /* If core is found, use display name */
-      if (core_info_find(&core_info) &&
-          core_info.inf->display_name)
-         core_name = core_info.inf->display_name;
+      if (core_info_find(core_path, &core_info) &&
+          core_info->display_name)
+         core_name = core_info->display_name;
       /* If not, use core file name */
       else
          core_name = path_basename_nocompression(core_path);

--- a/menu/cbs/menu_cbs_start.c
+++ b/menu/cbs/menu_cbs_start.c
@@ -571,20 +571,18 @@ static int action_start_core_lock(
    /* ...Otherwise, attempt to unlock it */
    if (!core_info_set_core_lock(core_path, false))
    {
-      const char *core_name = NULL;
-      core_info_ctx_find_t core_info;
+      const char *core_name  = NULL;
+      core_info_t *core_info = NULL;
       char msg[PATH_MAX_LENGTH];
 
       msg[0] = '\0';
 
       /* Need to fetch core name for error message */
-      core_info.inf  = NULL;
-      core_info.path = core_path;
 
       /* If core is found, use display name */
-      if (core_info_find(&core_info) &&
-          core_info.inf->display_name)
-         core_name = core_info.inf->display_name;
+      if (core_info_find(core_path, &core_info) &&
+          core_info->display_name)
+         core_name = core_info->display_name;
       /* If not, use core file name */
       else
          core_name = path_basename(core_path);

--- a/menu/cbs/menu_cbs_sublabel.c
+++ b/menu/cbs/menu_cbs_sublabel.c
@@ -65,25 +65,23 @@
 
 static int menu_action_sublabel_file_browser_core(file_list_t *list, unsigned type, unsigned i, const char *label, const char *path, char *s, size_t len)
 {
-   core_info_ctx_find_t core_info;
+   core_info_t *core_info = NULL;
 
    /* Set sublabel prefix */
    strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CORE_INFO_LICENSES), len);
    strlcat(s, ": ", len);
 
    /* Search for specified core */
-   core_info.inf  = NULL;
-   core_info.path = path;
 
-   if (core_info_find(&core_info) &&
-       core_info.inf->licenses_list)
+   if (core_info_find(path, &core_info) &&
+       core_info->licenses_list)
    {
       char tmp[MENU_SUBLABEL_MAX_LENGTH];
       tmp[0]  = '\0';
 
       /* Add license text */
       string_list_join_concat(tmp, sizeof(tmp),
-            core_info.inf->licenses_list, ", ");
+            core_info->licenses_list, ", ");
       strlcat(s, tmp, len);
       return 1;
    }

--- a/menu/cbs/menu_cbs_title.c
+++ b/menu/cbs/menu_cbs_title.c
@@ -408,7 +408,7 @@ static int action_get_title_deferred_playlist_list(const char *path, const char 
 static int action_get_title_deferred_core_backup_list(
       const char *core_path, const char *prefix, char *s, size_t len)
 {
-   core_info_ctx_find_t core_info;
+   core_info_t *core_info = NULL;
 
    if (string_is_empty(core_path) || string_is_empty(prefix))
       return 0;
@@ -417,17 +417,14 @@ static int action_get_title_deferred_core_backup_list(
    strlcpy(s, prefix, len);
    strlcat(s, ": ", len);
 
-   /* Search for specified core */
-   core_info.inf  = NULL;
-   core_info.path = core_path;
-
-   /* If core is found, add display name */
-   if (core_info_find(&core_info) &&
-       core_info.inf->display_name)
-      strlcat(s, core_info.inf->display_name, len);
+   /* Search for specified core
+    * > If core is found, add display name */
+   if (core_info_find(core_path, &core_info) &&
+       core_info->display_name)
+      strlcat(s, core_info->display_name, len);
    else
    {
-      /* If not, use core file name */
+      /* > If not, use core file name */
       const char *core_filename = path_basename_nocompression(core_path);
 
       if (!string_is_empty(core_filename))
@@ -463,19 +460,15 @@ static int action_get_core_information_list(
    if ((menu_type == FILE_TYPE_DOWNLOAD_CORE) ||
        (menu_type == MENU_SETTING_ACTION_CORE_MANAGER_OPTIONS))
    {
-      const char *core_path = path;
-      core_info_ctx_find_t core_info_finder;
+      core_info_t *core_info_menu = NULL;
 
-      if (string_is_empty(core_path))
+      if (string_is_empty(path))
          goto error;
 
       /* Core updater/manager entry - search for
        * corresponding core info */
-      core_info_finder.inf  = NULL;
-      core_info_finder.path = core_path;
-
-      if (core_info_find(&core_info_finder))
-         core_info = core_info_finder.inf;
+      if (core_info_find(path, &core_info_menu))
+         core_info = core_info_menu;
    }
    else
       core_info_get_current_core(&core_info);

--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -9066,7 +9066,7 @@ static int materialui_list_push(void *data, void *userdata,
                   MENU_SETTING_ACTION_FAVORITES_DIR, 0, 0);
 
             core_info_get_list(&list);
-            if (core_info_list_num_info_files(list))
+            if (list->info_count > 0)
             {
                menu_entries_append_enum(info->list,
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_DOWNLOADED_FILE_DETECT_CORE_LIST),

--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -1456,7 +1456,7 @@ static int ozone_list_push(void *data, void *userdata,
                   MENU_SETTING_ACTION_FAVORITES_DIR, 0, 0);
 
             core_info_get_list(&list);
-            if (core_info_list_num_info_files(list))
+            if (list->info_count > 0)
             {
                menu_entries_append_enum(info->list,
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_DOWNLOADED_FILE_DETECT_CORE_LIST),

--- a/menu/drivers/stripes.c
+++ b/menu/drivers/stripes.c
@@ -4144,7 +4144,7 @@ static int stripes_list_push(void *data, void *userdata,
                   MENU_SETTING_ACTION_FAVORITES_DIR, 0, 0);
 
             core_info_get_list(&list);
-            if (core_info_list_num_info_files(list))
+            if (list->info_count > 0)
             {
                menu_entries_append_enum(info->list,
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_DOWNLOADED_FILE_DETECT_CORE_LIST),

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -6799,7 +6799,7 @@ static int xmb_list_push(void *data, void *userdata,
                MENU_SETTING_ACTION_FAVORITES_DIR, 0, 0);
 
          core_info_get_list(&list);
-         if (core_info_list_num_info_files(list))
+         if (list->info_count > 0)
             menu_entries_append_enum(info->list,
                   msg_hash_to_str(MENU_ENUM_LABEL_VALUE_DOWNLOADED_FILE_DETECT_CORE_LIST),
                   msg_hash_to_str(MENU_ENUM_LABEL_DOWNLOADED_FILE_DETECT_CORE_LIST),

--- a/playlist.c
+++ b/playlist.c
@@ -2866,17 +2866,14 @@ bool playlist_entry_has_core(const struct playlist_entry *entry)
  * core association */
 core_info_t *playlist_entry_get_core_info(const struct playlist_entry* entry)
 {
-   core_info_ctx_find_t core_info;
+   core_info_t *core_info = NULL;
 
    if (!playlist_entry_has_core(entry))
       return NULL;
 
    /* Search for associated core */
-   core_info.inf  = NULL;
-   core_info.path = entry->core_path;
-
-   if (core_info_find(&core_info))
-      return core_info.inf;
+   if (core_info_find(entry->core_path, &core_info))
+      return core_info;
 
    return NULL;
 }
@@ -2888,7 +2885,7 @@ core_info_t *playlist_entry_get_core_info(const struct playlist_entry* entry)
  * default core association */
 core_info_t *playlist_get_default_core_info(playlist_t* playlist)
 {
-   core_info_ctx_find_t core_info;
+   core_info_t *core_info = NULL;
 
    if (!playlist ||
        string_is_empty(playlist->default_core_path) ||
@@ -2898,11 +2895,8 @@ core_info_t *playlist_get_default_core_info(playlist_t* playlist)
       return NULL;
 
    /* Search for associated core */
-   core_info.inf  = NULL;
-   core_info.path = playlist->default_core_path;
-
-   if (core_info_find(&core_info))
-      return core_info.inf;
+   if (core_info_find(playlist->default_core_path, &core_info))
+      return core_info;
 
    return NULL;
 }

--- a/retroarch.c
+++ b/retroarch.c
@@ -1986,17 +1986,15 @@ static int generic_menu_iterate(
 #endif
                   case MENU_ENUM_LABEL_CORE_MANAGER_ENTRY:
                      {
-                        core_info_ctx_find_t core_info;
-                        const char *path = selection_buf->list[selection].path;
-                        /* Search for specified core */
-                        core_info.inf    = NULL;
-                        core_info.path   = path;
+                        core_info_t *core_info = NULL;
+                        const char *path       = selection_buf->list[selection].path;
 
+                        /* Search for specified core */
                         if (     path 
-                              && core_info_find(&core_info)
-                              && !string_is_empty(core_info.inf->description))
+                              && core_info_find(path, &core_info)
+                              && !string_is_empty(core_info->description))
                            strlcpy(menu->menu_state_msg,
-                                 core_info.inf->description,
+                                 core_info->description,
                                  sizeof(menu->menu_state_msg));
                         else
                            strlcpy(menu->menu_state_msg,
@@ -13618,7 +13616,6 @@ bool command_event(enum event_command cmd, void *data)
          break;
       case CMD_EVENT_LOAD_CORE_PERSIST:
          {
-            core_info_ctx_find_t info_find;
             rarch_system_info_t *system_info = &p_rarch->runloop_system;
             struct retro_system_info *system = &system_info->info;
             const char *core_path            = path_get(RARCH_PATH_CORE);
@@ -13634,9 +13631,8 @@ bool command_event(enum event_command cmd, void *data)
                      system,
                      &system_info->load_no_content))
                return false;
-            info_find.path = core_path;
 
-            if (!core_info_load(&info_find, &p_rarch->core_info_st))
+            if (!core_info_load(core_path, &p_rarch->core_info_st))
             {
 #ifdef HAVE_DYNAMIC
                return false;

--- a/runtime_file.c
+++ b/runtime_file.c
@@ -238,7 +238,7 @@ runtime_log_t *runtime_log_init(
    char log_file_dir[PATH_MAX_LENGTH];
    char log_file_path[PATH_MAX_LENGTH];
    char tmp_buf[PATH_MAX_LENGTH];
-   core_info_ctx_find_t core_info;
+   core_info_t *core_info     = NULL;
    runtime_log_t *runtime_log = NULL;
 
    content_name[0]            = '\0';
@@ -266,12 +266,9 @@ runtime_log_t *runtime_log_init(
     * we are performing aggregate (not per core) logging,
     * since content name is sometimes dependent upon core
     * (e.g. see TyrQuake below) */
-   core_info.inf  = NULL;
-   core_info.path = core_path;
-
-   if (core_info_find(&core_info) &&
-       core_info.inf->core_name)
-      strlcpy(core_name, core_info.inf->core_name, sizeof(core_name));
+   if (core_info_find(core_path, &core_info) &&
+       core_info->core_name)
+      strlcpy(core_name, core_info->core_name, sizeof(core_name));
 
    if (string_is_empty(core_name))
       return NULL;

--- a/tasks/task_core_backup.c
+++ b/tasks/task_core_backup.c
@@ -556,15 +556,12 @@ void *task_push_core_backup(
       core_name = core_display_name;
    else
    {
-      core_info_ctx_find_t core_info;
-
-      core_info.inf  = NULL;
-      core_info.path = core_path;
+      core_info_t *core_info = NULL;
 
       /* If core is found, use display name */
-      if (core_info_find(&core_info) &&
-          core_info.inf->display_name)
-         core_name = core_info.inf->display_name;
+      if (core_info_find(core_path, &core_info) &&
+          core_info->display_name)
+         core_name = core_info->display_name;
       else
       {
          /* If not, use core file name */
@@ -926,8 +923,8 @@ bool task_push_core_restore(const char *backup_path, const char *dir_libretro,
       bool *core_loaded)
 {
    task_finder_data_t find_data;
-   core_info_ctx_find_t core_info;
    enum core_backup_type backup_type;
+   core_info_t *core_info              = NULL;
    const char *core_name               = NULL;
    retro_task_t *task                  = NULL;
    core_backup_handle_t *backup_handle = NULL;
@@ -974,17 +971,14 @@ bool task_push_core_restore(const char *backup_path, const char *dir_libretro,
       goto error;
    }
 
-   /* Get core name */
-   core_info.inf  = NULL;
-   core_info.path = core_path;
-
-   /* If core is found, use display name */
-   if (core_info_find(&core_info) &&
-       core_info.inf->display_name)
-      core_name = core_info.inf->display_name;
+   /* Get core name
+    * > If core is found, use display name */
+   if (core_info_find(core_path, &core_info) &&
+       core_info->display_name)
+      core_name = core_info->display_name;
    else
    {
-      /* If not, use core file name */
+      /* > If not, use core file name */
       core_name = path_basename(core_path);
 
       if (string_is_empty(core_name))

--- a/tasks/task_playlist_manager.c
+++ b/tasks/task_playlist_manager.c
@@ -474,17 +474,14 @@ static void pl_manager_validate_core_association(
    else
    {
       char core_display_name[PATH_MAX_LENGTH];
-      core_info_ctx_find_t core_info;
+      core_info_t *core_info = NULL;
       
       core_display_name[0] = '\0';
       
       /* Search core info */
-      core_info.inf  = NULL;
-      core_info.path = core_path;
-      
-      if (core_info_find(&core_info) &&
-          !string_is_empty(core_info.inf->display_name))
-         strlcpy(core_display_name, core_info.inf->display_name,
+      if (core_info_find(core_path, &core_info) &&
+          !string_is_empty(core_info->display_name))
+         strlcpy(core_display_name, core_info->display_name,
                sizeof(core_display_name));
       
       /* If core_display_name string is empty, it means the

--- a/ui/drivers/qt/qt_playlist.cpp
+++ b/ui/drivers/qt/qt_playlist.cpp
@@ -981,7 +981,7 @@ void MainWindow::onPlaylistWidgetContextMenuRequested(const QPoint&)
 
    if (!specialPlaylist && selectedAction->parent() == associateMenu.data())
    {
-      core_info_ctx_find_t coreInfo;
+      core_info_t *coreInfo                   = NULL;
       playlist_t *cachedPlaylist              = playlist_get_cached();
       playlist_t *playlist                    = NULL;
       bool loadPlaylist                       = true;
@@ -1010,14 +1010,11 @@ void MainWindow::onPlaylistWidgetContextMenuRequested(const QPoint&)
       if (playlist)
       {
          /* Get core info */
-         coreInfo.inf  = NULL;
-         coreInfo.path = corePath;
-
-         if (core_info_find(&coreInfo))
+         if (core_info_find(corePath, &coreInfo))
          {
             /* Set new core association */
-            playlist_set_default_core_path(playlist, coreInfo.inf->path);
-            playlist_set_default_core_name(playlist, coreInfo.inf->display_name);
+            playlist_set_default_core_path(playlist, coreInfo->path);
+            playlist_set_default_core_name(playlist, coreInfo->display_name);
          }
          else
          {


### PR DESCRIPTION
## Description

This PR makes a number of changes to the 'core info' handling code:

- Hash keys are now used instead of costly string comparisons when searching the global core info list. This reduces the performance overheads of `core_info_find()` by ~93%, and makes search operations essentially 'free' (useful, since some menu screens preform a large number of searches per frame, and some playlist view modes in GLUI require a search for every playlist entry when building the menu list)
- When loading core info files, we no longer unnecessarily `strdup()` every config file value. We also no longer keep an unnecessary copy of the config file data. This reduces memory consumption of the core info list by more than half
- Searching the core info list no longer requires a `core_info_ctx_find_t` struct (this unnecessary code obfuscation has been a long-standing annoyance...). Searches are now performed directly using just the core path
- The `core_info` code has been extensively refactored and 'cleaned up' to aid future maintainability. All unnecessary functions have also been removed, along with old platform-specific hacks.