### PR TITLE
(3DS) Load texture images as BGR colors

### DIFF
--- a/gfx/drivers/ctr_gfx.c
+++ b/gfx/drivers/ctr_gfx.c
@@ -1218,10 +1218,10 @@ static uintptr_t ctr_load_texture(void *video_data, void *data,
          {
             ((uint32_t*)texture->data)[ctrgu_swizzle_coords(i, j,
                texture->width)] =
-                    ((*src >> 8)  & 0x00FF00) 
-                  | ((*src >> 24) & 0xFF)
-                  | ((*src << 8)  & 0xFF0000)
-                  | ((*src << 24) & 0xFF000000);
+                    ((*src << 8)  & 0xFF000000) 
+                  | ((*src << 8)  & 0x00FF0000)
+                  | ((*src << 8)  & 0x0000FF00)
+                  | ((*src >> 24) & 0x000000FF);
             src++;
          }
       GSPGPU_FlushDataCache(texture->data, texture->width 
@@ -1248,10 +1248,10 @@ static uintptr_t ctr_load_texture(void *video_data, void *data,
       for (i = 0; i < image->width * image->height; i++)
       {
          *dst = 
-              ((*src >> 8)  & 0x00FF00) 
-            | ((*src >> 24) & 0xFF)
-            | ((*src << 8)  & 0xFF0000)
-            | ((*src << 24) & 0xFF000000);
+              ((*src << 8)  & 0xFF000000) 
+            | ((*src << 8)  & 0x00FF0000)
+            | ((*src << 8)  & 0x0000FF00)
+            | ((*src >> 24) & 0x000000FF);
          dst++;
          src++;
       }


### PR DESCRIPTION
## Description

There is a problem with 3DS reading thumbnail image files as RGB.
![image](https://user-images.githubusercontent.com/15259720/116122240-78960880-a6fc-11eb-8fd2-c8bfb7a3f4f9.png)

This PR allows thumbnail image files to be read as BGR.
![image](https://user-images.githubusercontent.com/15259720/116122198-6ddb7380-a6fc-11eb-9f20-90b1d05d26f5.png)

## Related Issues
https://github.com/libretro/RetroArch/issues/6832
-> I have reported a issue here before.
https://github.com/libretro/RetroArch/issues/7718
-> There must be a similar problem with raspberry pi.
-> I don't have a raspberry pi, so I can't test this problem.

## Related Pull Requests
https://github.com/libretro/RetroArch/pull/11628
-> I don't know why I did this. I'm shy and want to erase it.
https://github.com/libretro/RetroArch/pull/12232
-> BGR processing is done here through video_driver_set_rgba().
-> So I didn't modify the image file that read in ctr_overlay_load.

