### PR TITLE
(3DS) Load overlay texture images as BGR colors

### DIFF
--- a/gfx/drivers/ctr_gfx.c
+++ b/gfx/drivers/ctr_gfx.c
@@ -513,10 +513,6 @@ static void* ctr_init(const video_info_t* video,
    ctr->vsync         = video->vsync;
    ctr->current_buffer_top = 0;
 
-#if defined(HAVE_OVERLAY) || defined(HAVE_GFX_WIDGETS)
-   video_driver_set_rgba();
-#endif
-
    /* Only O3DS and O3DSXL support running in 'dual-framebuffer'
     * mode with the parallax barrier disabled
     * (i.e. these are the only platforms that can use
@@ -1398,11 +1394,11 @@ static bool ctr_overlay_load(void *data,
 
       for (j = 0; j < images[i].width * images[i].height; j++)
       {
-         *dst =
-              ((*src >> 8)  & 0x00FF00)
-            | ((*src >> 24) & 0xFF)
-            | ((*src << 8)  & 0xFF0000)
-            | ((*src << 24) & 0xFF000000);
+         *dst = 
+              ((*src << 8)  & 0xFF000000) 
+            | ((*src << 8)  & 0x00FF0000)
+            | ((*src << 8)  & 0x0000FF00)
+            | ((*src >> 24) & 0x000000FF);
          dst++;
          src++;
       }


### PR DESCRIPTION
## Description
When reading a bgr image using video_driver_set_rgba(), the color of the menu icon becomes strange as below screenshot.
![image](https://user-images.githubusercontent.com/15259720/116389192-a5126780-a857-11eb-8873-49034b79a3d0.png)

As previously modified, the overlay file was changed to read as a bgr image, and video_driver_set_rgba() was deleted.
![image](https://user-images.githubusercontent.com/15259720/116389687-34b81600-a858-11eb-956c-b0b573ec9e74.png)

## Related Pull Requests
https://github.com/libretro/RetroArch/pull/12313
https://github.com/libretro/RetroArch/pull/12323
