### PR TITLE
(core_info) Prevent potential hash collisions when searching for cores

### DIFF
--- a/core_info.c
+++ b/core_info.c
@@ -106,7 +106,8 @@ static core_info_t *core_info_find_internal(
    {
       core_info_t *info = &list->list[i];
 
-      if (info->core_file_id.hash == hash)
+      if ((info->core_file_id.hash == hash) &&
+          string_is_equal(info->core_file_id.str, core_file_id))
          return info;
    }
 


### PR DESCRIPTION
## Description

Forewarned by #12332, this PR makes a trivial change to the `core_info` code in order to prevent any possible hash collisions when looking up info for a particular core (note that this sort of collision is virtually impossible given the fixed set of core IDs that we are working with, but better safe than sorry)