### PR TITLE
Fix config file appending and 'including'

### DIFF
--- a/libretro-common/file/config_file.c
+++ b/libretro-common/file/config_file.c
@@ -330,10 +330,11 @@ static void config_file_add_child_list(config_file_t *parent, config_file_t *chi
          uint32_t child_hash   = RHMAP_KEY(child->entries_map, i);
          const char *child_key = RHMAP_KEY_STR(child->entries_map, i);
 
-         if (!RHMAP_HAS_FULL(parent->entries_map, child_hash, child_key))
+         if (child_hash &&
+             child_key &&
+             !RHMAP_HAS_FULL(parent->entries_map, child_hash, child_key))
          {
-            struct config_entry_list *entry =
-                  RHMAP_GET_FULL(child->entries_map, child_hash, child_key);
+            struct config_entry_list *entry = child->entries_map[i];
 
             if (entry)
                RHMAP_SET_FULL(parent->entries_map, child_hash, child_key, entry);
@@ -795,12 +796,16 @@ bool config_append_file(config_file_t *conf, const char *path)
    /* Update hash map */
    for (i = 0, cap = RHMAP_CAP(new_conf->entries_map); i != cap; i++)
    {
-      uint32_t new_hash               = RHMAP_KEY(new_conf->entries_map, i);
-      const char *new_key             = RHMAP_KEY_STR(new_conf->entries_map, i);
-      struct config_entry_list *entry = RHMAP_GET_FULL(new_conf->entries_map, new_hash, new_key);
+      uint32_t new_hash   = RHMAP_KEY(new_conf->entries_map, i);
+      const char *new_key = RHMAP_KEY_STR(new_conf->entries_map, i);
 
-      if (entry)
-         RHMAP_SET_FULL(conf->entries_map, new_hash, new_key, entry);
+      if (new_hash && new_key)
+      {
+         struct config_entry_list *entry = new_conf->entries_map[i];
+
+         if (entry)
+            RHMAP_SET_FULL(conf->entries_map, new_hash, new_key, entry);
+      }
    }
 
    if (new_conf->tail)


### PR DESCRIPTION
## Description

Following PR #12295, whenever a config file is appended to an existing one (or whenever a config file references an external one via an `#include` directive), the parent config is updated by merging the `RHMAP` hash maps of both parent and child. This involves looping over all elements of the child config, like so:

```c
for (i = 0, cap = RHMAP_CAP(new_conf->entries_map); i != cap; i++)
```

Inside this loop, the child config entry is extracted using `RHMAP_GET_FULL()` - e.g.:

```c
      uint32_t new_hash               = RHMAP_KEY(new_conf->entries_map, i);
      const char *new_key             = RHMAP_KEY_STR(new_conf->entries_map, i);
      struct config_entry_list *entry = RHMAP_GET_FULL(new_conf->entries_map, new_hash, new_key);
```

While this *seems* to work, it turns out that there is a nasty caveat here: calling `RHMAP_GET_FULL()` can actually resize and reorder the hash map that is passed to it (this is dependent upon the current size of the map when the macro is used - it is something of an edge case, and is therefore difficult to detect...). When this happens, the `RHMAP_CAP()` for-loop becomes invalidated, and we can end up skipping entries in the child map.

This small PR refactors the hash map merging code such that the child hash map cannot be modified while we are iterating over it. This ensures that config append/include operations are always applied correctly.
