### PR TITLE
(.gitlab-ci.yml) Add 'raw' retroarch binary to OpenDingux (+Beta) job artifacts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -392,6 +392,7 @@ build-retroarch-dingux-mips32:
     - export NUMPROC=$(($(nproc)/3))
   artifacts:
     paths:
+    - retroarch
     - retroarch_rg350.opk
     - ${MEDIA_PATH}
     expire_in: 10 min
@@ -413,6 +414,7 @@ build-retroarch-dingux-odbeta-mips32:
     - export NUMPROC=$(($(nproc)/3))
   artifacts:
     paths:
+    - retroarch
     - retroarch_rg350_odbeta.opk
     - ${MEDIA_PATH}
     expire_in: 10 min


### PR DESCRIPTION
## Description

A number of OpenDingux users have expressed a desire to launch RetroArch via an external frontend. This requires command line usage which is incompatible with the standard RetroArch OPK file. This PR therefore adds the 'raw' RetroArch binary to the OpenDingux/OpenDingux Beta GitLab job artifacts - this can then be included as an option for advanced users at the packaging stage.
