### PR TITLE
OpenDingux: Enable 'SaveRAM Autosave Interval' by default

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -1010,7 +1010,7 @@ static const bool audio_enable_menu_bgm    = false;
 
 /* Saves non-volatile SRAM at a regular interval.
  * It is measured in seconds. A value of 0 disables autosave. */
-#if defined(__i386__) || defined(__i486__) || defined(__i686__) || defined(__x86_64__) || defined(_M_X64) || defined(_WIN32) || defined(OSX) || defined(ANDROID) || defined(IOS)
+#if defined(__i386__) || defined(__i486__) || defined(__i686__) || defined(__x86_64__) || defined(_M_X64) || defined(_WIN32) || defined(OSX) || defined(ANDROID) || defined(IOS) || defined(DINGUX)
 /* Flush to file every 10 seconds on modern platforms by default */
 #define DEFAULT_AUTOSAVE_INTERVAL 10
 #else


### PR DESCRIPTION
## Description

This PR sets the default `SaveRAM Autosave Interval` to 10 seconds on OpenDingux devices, in line with other 'modern' platforms. The reasons for doing this are outlined here: https://github.com/libretro/RetroArch/pull/7691