### PR TITLE
(3DS) Disable menu screensaver animations in XMB/GLUI

### DIFF
--- a/menu/menu_screensaver.c
+++ b/menu/menu_screensaver.c
@@ -413,6 +413,12 @@ static bool menu_screensaver_update_state(
 {
    bool init_effect = false;
 
+#if defined(_3DS)
+   /* 3DS has an 'incomplete' font driver,
+    * and cannot render screensaver effects */
+   effect = MENU_SCREENSAVER_BLANK;
+#endif
+
    /* Check if dimensions have changed */
    if ((screensaver->last_width  != width) ||
        (screensaver->last_height != height))

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -14383,7 +14383,7 @@ static bool setting_append_list(
                &setting_get_string_representation_uint_menu_screensaver_timeout;
          menu_settings_list_current_add_range(list, list_info, 0, 1800, 10, true, true);
 
-#if defined(HAVE_MATERIALUI) || defined(HAVE_XMB) || defined(HAVE_OZONE)
+#if (defined(HAVE_MATERIALUI) || defined(HAVE_XMB) || defined(HAVE_OZONE)) && !defined(_3DS)
          if (string_is_equal(settings->arrays.menu_driver, "glui") ||
              string_is_equal(settings->arrays.menu_driver, "xmb")  ||
              string_is_equal(settings->arrays.menu_driver, "ozone"))


### PR DESCRIPTION
## Description

It turns out that the 3DS RetroArch port has a troublesome font driver which (a) crashes when attempting to render menu screensaver effects and (b) would be unable to render said effects anyway, since font size is hard coded at 10 px.

This PR therefore disables menu screensaver animations on 3DS when using any menu driver other than RGUI (which does not require a font driver for animations).