### PR TITLE
Retro arch lakka switch fixes

### DIFF
--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -1114,11 +1114,7 @@ static bool frontend_unix_powerstate_check_acpi_sysfs(
    {
       const char *node = retro_dirent_get_name(entry);
 
-#ifdef HAVE_LAKKA_SWITCH
-      if (node && strstr(node, "max170xx_battery"))
-#else
       if (node && (strstr(node, "BAT") || strstr(node, "battery")))
-#endif
          check_proc_acpi_sysfs_battery(node,
                &have_battery, &charging, seconds, percent);
    }

--- a/intl/msg_hash_ar.h
+++ b/intl/msg_hash_ar.h
@@ -9084,10 +9084,6 @@ MSG_HASH(
    MENU_ENUM_SUBLABEL_SWITCH_GPU_PROFILE,
    "تبديل GPU على مدار الساعة أو تحت الساعة."
    )
-MSG_HASH(
-   MENU_ENUM_LABEL_VALUE_REBOOT_RCM,
-   "إعادة التشغيل إلى RCM"
-   )
 #endif
 #if defined(HAVE_LAKKA_SWITCH) || defined(HAVE_LIBNX)
 MSG_HASH(

--- a/intl/msg_hash_chs.h
+++ b/intl/msg_hash_chs.h
@@ -11304,10 +11304,6 @@ MSG_HASH(
    MENU_ENUM_SUBLABEL_SWITCH_GPU_PROFILE,
    "超频或降频 Switch 的 GPU。"
    )
-MSG_HASH(
-   MENU_ENUM_LABEL_VALUE_REBOOT_RCM,
-   "重启到 RCM"
-   )
 #endif
 #if defined(HAVE_LAKKA_SWITCH) || defined(HAVE_LIBNX)
 MSG_HASH(

--- a/intl/msg_hash_de.h
+++ b/intl/msg_hash_de.h
@@ -10504,10 +10504,6 @@ MSG_HASH(
    MENU_ENUM_SUBLABEL_SWITCH_GPU_PROFILE,
    "Über- oder Untertakten der Switch GPU."
    )
-MSG_HASH(
-   MENU_ENUM_LABEL_VALUE_REBOOT_RCM,
-   "Neu starten im RCM"
-   )
 #endif
 #if defined(HAVE_LAKKA_SWITCH) || defined(HAVE_LIBNX)
 MSG_HASH(

--- a/intl/msg_hash_es.h
+++ b/intl/msg_hash_es.h
@@ -11336,10 +11336,6 @@ MSG_HASH(
    MENU_ENUM_SUBLABEL_SWITCH_GPU_PROFILE,
    "Aumenta o reduce la velocidad de la GPU de Switch."
    )
-MSG_HASH(
-   MENU_ENUM_LABEL_VALUE_REBOOT_RCM,
-   "Reiniciar al RCM"
-   )
 #endif
 #if defined(HAVE_LAKKA_SWITCH) || defined(HAVE_LIBNX)
 MSG_HASH(

--- a/intl/msg_hash_fi.h
+++ b/intl/msg_hash_fi.h
@@ -11216,10 +11216,6 @@ MSG_HASH(
    MENU_ENUM_SUBLABEL_SWITCH_GPU_PROFILE,
    "Ylikellota tai alikellota Switchin näytönohjain."
    )
-MSG_HASH(
-   MENU_ENUM_LABEL_VALUE_REBOOT_RCM,
-   "Käynnistä uudelleen RCM:ään"
-   )
 #endif
 #if defined(HAVE_LAKKA_SWITCH) || defined(HAVE_LIBNX)
 MSG_HASH(

--- a/intl/msg_hash_fr.h
+++ b/intl/msg_hash_fr.h
@@ -11336,10 +11336,6 @@ MSG_HASH(
    MENU_ENUM_SUBLABEL_SWITCH_GPU_PROFILE,
    "Overclocker ou underclocker le processeur graphique de la Switch."
    )
-MSG_HASH(
-   MENU_ENUM_LABEL_VALUE_REBOOT_RCM,
-   "Redémarrer en mode RCM"
-   )
 #endif
 #if defined(HAVE_LAKKA_SWITCH) || defined(HAVE_LIBNX)
 MSG_HASH(

--- a/intl/msg_hash_it.h
+++ b/intl/msg_hash_it.h
@@ -11256,10 +11256,6 @@ MSG_HASH(
    MENU_ENUM_SUBLABEL_SWITCH_GPU_PROFILE,
    "Overclocca o underclocca la GPU del Nintendo Switch."
    )
-MSG_HASH(
-   MENU_ENUM_LABEL_VALUE_REBOOT_RCM,
-   "Riavvia in RCM"
-   )
 #endif
 #if defined(HAVE_LAKKA_SWITCH) || defined(HAVE_LIBNX)
 MSG_HASH(

--- a/intl/msg_hash_ko.h
+++ b/intl/msg_hash_ko.h
@@ -11468,10 +11468,6 @@ MSG_HASH(
    MENU_ENUM_SUBLABEL_SWITCH_GPU_PROFILE,
    "스위치 GPU를 오버클럭 또는 언더클럭합니다."
    )
-MSG_HASH(
-   MENU_ENUM_LABEL_VALUE_REBOOT_RCM,
-   "RCM 으로 다시 시작"
-   )
 #endif
 #if defined(HAVE_LAKKA_SWITCH) || defined(HAVE_LIBNX)
 MSG_HASH(

--- a/intl/msg_hash_pl.h
+++ b/intl/msg_hash_pl.h
@@ -9976,10 +9976,6 @@ MSG_HASH(
    MENU_ENUM_SUBLABEL_SWITCH_GPU_PROFILE,
    "Podkręcanie lub obniżanie GPU."
    )
-MSG_HASH(
-   MENU_ENUM_LABEL_VALUE_REBOOT_RCM,
-   "Uruchom ponownie do RCM"
-   )
 #endif
 #if defined(HAVE_LAKKA_SWITCH) || defined(HAVE_LIBNX)
 MSG_HASH(

--- a/intl/msg_hash_pt_br.h
+++ b/intl/msg_hash_pt_br.h
@@ -11292,10 +11292,6 @@ MSG_HASH(
    MENU_ENUM_SUBLABEL_SWITCH_GPU_PROFILE,
    "Faz um overclock ou underclock na CPU do Switch."
    )
-MSG_HASH(
-   MENU_ENUM_LABEL_VALUE_REBOOT_RCM,
-   "Reiniciar em RCM"
-   )
 #endif
 #if defined(HAVE_LAKKA_SWITCH) || defined(HAVE_LIBNX)
 MSG_HASH(

--- a/intl/msg_hash_ru.h
+++ b/intl/msg_hash_ru.h
@@ -11448,10 +11448,6 @@ MSG_HASH(
    MENU_ENUM_SUBLABEL_SWITCH_GPU_PROFILE,
    "Разгон или замедление графического процессора Switch."
    )
-MSG_HASH(
-   MENU_ENUM_LABEL_VALUE_REBOOT_RCM,
-   "Перезагрузка в RCM"
-   )
 #endif
 #if defined(HAVE_LAKKA_SWITCH) || defined(HAVE_LIBNX)
 MSG_HASH(

--- a/intl/msg_hash_tr.h
+++ b/intl/msg_hash_tr.h
@@ -10332,10 +10332,6 @@ MSG_HASH(
    MENU_ENUM_SUBLABEL_SWITCH_GPU_PROFILE,
    "GPU hızını arttır yada düşür."
    )
-MSG_HASH(
-   MENU_ENUM_LABEL_VALUE_REBOOT_RCM,
-   "RCM içinde yeniden başlat"
-   )
 #endif
 #if defined(HAVE_LAKKA_SWITCH) || defined(HAVE_LIBNX)
 MSG_HASH(

--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -12202,10 +12202,6 @@ MSG_HASH(
    MENU_ENUM_SUBLABEL_SWITCH_GPU_PROFILE,
    "Overclock or underclock the Switch GPU."
    )
-MSG_HASH(
-   MENU_ENUM_LABEL_VALUE_REBOOT_RCM,
-   "Reboot into RCM"
-   )
 #endif
 #if defined(HAVE_LAKKA_SWITCH) || defined(HAVE_LIBNX)
 MSG_HASH(

--- a/menu/cbs/menu_cbs_get_value.c
+++ b/menu/cbs/menu_cbs_get_value.c
@@ -516,6 +516,7 @@ static void menu_action_setting_disp_set_label_core_manager_entry(
    }
 }
 
+#ifndef HAVE_LAKKA_SWITCH
 #ifdef HAVE_LAKKA
 static void menu_action_setting_disp_set_label_cpu_policy(
       file_list_t* list,
@@ -588,6 +589,7 @@ static void menu_action_cpu_governor_label(
       MENU_ENUM_LABEL_VALUE_CPU_POLICY_GOVERNOR), len2);
    strlcpy(s, d->scaling_governor, len);
 }
+#endif
 #endif
 
 static void menu_action_setting_disp_set_label_core_lock(
@@ -1782,6 +1784,7 @@ static int menu_cbs_init_bind_get_string_representation_compare_label(
             BIND_ACTION_GET_VALUE(cbs,
                   menu_action_setting_disp_set_label_core_option_override_info);
             break;
+         #ifndef HAVE_LAKKA_SWITCH
          #ifdef HAVE_LAKKA
          case MENU_ENUM_LABEL_CPU_POLICY_ENTRY:
             BIND_ACTION_GET_VALUE(cbs,
@@ -1794,6 +1797,7 @@ static int menu_cbs_init_bind_get_string_representation_compare_label(
          case MENU_ENUM_LABEL_CPU_POLICY_GOVERNOR:
             BIND_ACTION_GET_VALUE(cbs, menu_action_cpu_governor_label);
             break;
+         #endif
          #endif
          default:
             return -1;

--- a/menu/cbs/menu_cbs_left.c
+++ b/menu/cbs/menu_cbs_left.c
@@ -1010,12 +1010,14 @@ static int menu_cbs_init_bind_left_compare_label(menu_file_list_cbs_t *cbs,
             case MENU_ENUM_LABEL_MANUAL_CONTENT_SCAN_CORE_NAME:
                BIND_ACTION_LEFT(cbs, manual_content_scan_core_name_left);
                break;
+            #ifndef HAVE_LAKKA_SWITCH
             #ifdef HAVE_LAKKA
             case MENU_ENUM_LABEL_CPU_POLICY_MAX_FREQ:
             case MENU_ENUM_LABEL_CPU_POLICY_MIN_FREQ:
             case MENU_ENUM_LABEL_CPU_POLICY_GOVERNOR:
                BIND_ACTION_LEFT(cbs, cpu_policy_freq_tweak);
                break;
+            #endif
             #endif
             default:
                return -1;

--- a/menu/cbs/menu_cbs_right.c
+++ b/menu/cbs/menu_cbs_right.c
@@ -789,6 +789,7 @@ static int manual_content_scan_core_name_right(unsigned type, const char *label,
    return 0;
 }
 
+#ifdef HAVE_LAKKA_SWITCH
 #ifdef HAVE_LAKKA
 static int cpu_policy_freq_tweak(unsigned type, const char *label,
       bool wraparound)
@@ -827,7 +828,7 @@ static int cpu_policy_freq_tweak(unsigned type, const char *label,
    return 0;
 }
 #endif
-
+#endif
 int core_setting_right(unsigned type, const char *label,
       bool wraparound)
 {
@@ -1129,12 +1130,14 @@ static int menu_cbs_init_bind_right_compare_label(menu_file_list_cbs_t *cbs,
             case MENU_ENUM_LABEL_MANUAL_CONTENT_SCAN_CORE_NAME:
                BIND_ACTION_RIGHT(cbs, manual_content_scan_core_name_right);
                break;
+            #ifndef HAVE_LAKKA_SWITCH
             #ifdef HAVE_LAKKA
             case MENU_ENUM_LABEL_CPU_POLICY_MAX_FREQ:
             case MENU_ENUM_LABEL_CPU_POLICY_MIN_FREQ:
             case MENU_ENUM_LABEL_CPU_POLICY_GOVERNOR:
                BIND_ACTION_RIGHT(cbs, cpu_policy_freq_tweak);
                break;
+            #endif
             #endif
             default:
                return -1;

--- a/menu/cbs/menu_cbs_sublabel.c
+++ b/menu/cbs/menu_cbs_sublabel.c
@@ -1010,6 +1010,7 @@ static int action_bind_sublabel_bluetooth_list(
    return 0;
 }
 
+#ifndef HAVE_LAKKA_SWITCH
 #ifdef HAVE_LAKKA
 static int action_bind_sublabel_cpu_policy_entry_list(
       file_list_t *list,
@@ -1029,7 +1030,7 @@ static int action_bind_sublabel_cpu_policy_entry_list(
    return -1;
 }
 #endif
-
+#endif
 #ifdef HAVE_CHEEVOS
 static int action_bind_sublabel_cheevos_entry(
       file_list_t *list,
@@ -3942,9 +3943,11 @@ int menu_cbs_init_bind_sublabel(menu_file_list_cbs_t *cbs,
          case MENU_ENUM_LABEL_TIMEZONE:
             BIND_ACTION_SUBLABEL(cbs, action_bind_sublabel_timezone);
             break;
+#ifndef HAVE_LAKKA_SWITCH
          case MENU_ENUM_LABEL_CPU_POLICY_ENTRY:
             BIND_ACTION_SUBLABEL(cbs, action_bind_sublabel_cpu_policy_entry_list);
             break;
+#endif
 #endif
          case MENU_ENUM_LABEL_USER_LANGUAGE:
             BIND_ACTION_SUBLABEL(cbs, action_bind_sublabel_user_language);

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -9834,6 +9834,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
          /* No-op */
          break;
 #endif
+#ifndef HAVE_LAKKA_SWITCH
 #ifdef HAVE_LAKKA
       case DISPLAYLIST_CPU_POLICY_LIST:
          menu_entries_ctl(MENU_ENTRIES_CTL_CLEAR, info->list);
@@ -9886,6 +9887,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
          info->need_clear   = true;
          break;
       }
+#endif
 #endif
 #if defined(HAVE_LAKKA_SWITCH) || defined(HAVE_LIBNX)
       case DISPLAYLIST_SWITCH_CPU_PROFILE:

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -8753,15 +8753,6 @@ static bool setting_append_list(
                &subgroup_info,
                parent_group);
 #endif
-#ifdef HAVE_LAKKA_SWITCH
-         CONFIG_ACTION(
-               list, list_info,
-               MENU_ENUM_LABEL_REBOOT,
-               MENU_ENUM_LABEL_VALUE_REBOOT_RCM,
-               &group_info,
-               &subgroup_info,
-               parent_group);
-#else
          CONFIG_ACTION(
                list, list_info,
                MENU_ENUM_LABEL_REBOOT,
@@ -8769,7 +8760,7 @@ static bool setting_append_list(
                &group_info,
                &subgroup_info,
                parent_group);
-#endif
+
          MENU_SETTINGS_LIST_CURRENT_ADD_CMD(list, list_info, CMD_EVENT_REBOOT);
 
          CONFIG_ACTION(
@@ -16359,6 +16350,7 @@ static bool setting_append_list(
 #endif
 
 #ifdef HAVE_LAKKA
+#ifndef HAVE_LAKKA_SWITCH
          CONFIG_ACTION(
                list, list_info,
                MENU_ENUM_LABEL_CPU_PERFPOWER,
@@ -16366,6 +16358,7 @@ static bool setting_append_list(
                &group_info,
                &subgroup_info,
                parent_group);
+#endif
 #endif
 
          END_SUB_GROUP(list, list_info, parent_group);


### PR DESCRIPTION
This fixes a few build issues due to rcm stuff in LAKKA_SWITCH patches. The RCM stuff isnt needed anymore, as we reboot to payload, so remove it. Also this patches out new clock speed menus for lakka when building for switch, in favor of the switch tailored clock speed menus which already existed in the source. Finally we remove a battery work around, as we have fixed that in upstream Switch L4T kernel already, so mitigating it actually broke battery, as the node changed to match mainline for app compatibility.