### PR TITLE
Fix typo in HAVE_LAKKA_SWITCH stuff that is breaking HAVE_LAKKA build…

### DIFF
--- a/menu/cbs/menu_cbs_right.c
+++ b/menu/cbs/menu_cbs_right.c
@@ -789,7 +789,7 @@ static int manual_content_scan_core_name_right(unsigned type, const char *label,
    return 0;
 }
 
-#ifdef HAVE_LAKKA_SWITCH
+#ifndef HAVE_LAKKA_SWITCH
 #ifdef HAVE_LAKKA
 static int cpu_policy_freq_tweak(unsigned type, const char *label,
       bool wraparound)


### PR DESCRIPTION
Fixes a typo in my previous patch for HAVE_LAKKA_SWITCH builds that was breaking the normal HAVE_LAKKA builds.