### PR TITLE
command: initialize netcmd->cmd_source_len before recvfrom()

### DIFF
--- a/command.c
+++ b/command.c
@@ -166,6 +166,7 @@ static void command_network_poll(command_t *handle)
       char buf[1024];
 
       buf[0] = '\0';
+      netcmd->cmd_source_len = sizeof(struct sockaddr_storage);
       ret  = recvfrom(netcmd->net_fd, buf, sizeof(buf) - 1, 0,
             (struct sockaddr*)&netcmd->cmd_source,
             &netcmd->cmd_source_len);


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

Tried `READ_CORE_MEMORY 40FFC0 32\n` command and could not receive a reply back on the UDP socket.

Attached `lldb` debugger in `command.c:174` to see that immediately after `recvfrom()`, the `netcmd->cmd_source` data was always `0`s and the `cmd_source_len` was also `0`.

According to [MacOS man page](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/recvfrom.2.html) for `recvfrom(3)`, the `address_len` parameter must be initialized to the size of the buffer allocated for the `struct sockaddr` to be filled in.

This patch initializes `netcmd->cmd_source_len` to `sizeof(struct sockaddr_storage)` before calling `recvfrom()` so that the `netcmd->cmd_source_len` can be set and `netcmd->cmd_source` can be filled with the reply UDP address.

Tested and confirmed that behavior is broken without this patch and is corrected with this patch on MacOS Mojave 10.14.6.

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
@twinaphex 