### PR TITLE
Fix 'Auto-Shader Delay' functionality

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -10753,8 +10753,6 @@ static bool retroarch_apply_shader(
    if (!string_is_empty(preset_path))
       preset_file = path_basename_nocompression(preset_path);
 
-   p_rarch->runtime_shader_preset[0] = '\0';
-
    /* TODO/FIXME - This loads the shader into the video driver
     * But then we load the shader from disk twice more to put it in the menu
     * We need to reconfigure this at some point to only load it once */
@@ -10775,6 +10773,8 @@ static bool retroarch_apply_shader(
                shader->modified = false;
 #endif
          }
+         else
+            p_rarch->runtime_shader_preset[0] = '\0';
 
          if (message)
          {


### PR DESCRIPTION
## Description

The `Auto-Shader Delay` option is currently non-functional, due to an error in 4516d6626b4f16a51f384c2e7ba0a555986be673.  This PR fixes the issue.

## Related Issues

Closes #12314
