### PR TITLE
Enable core info cache by default on all 'console' platforms

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -249,7 +249,7 @@
 /* Specifies whether to cache core info
  * into a single (compressed) file for improved
  * load times on platforms with slow IO */
-#if defined(_3DS)
+#if defined(RARCH_CONSOLE)
 #define DEFAULT_CORE_INFO_CACHE_ENABLE true
 #else
 #define DEFAULT_CORE_INFO_CACHE_ENABLE false


### PR DESCRIPTION
## Description

This PR just enables the new core info cache feature ( #12350, #12363) by default on all 'console' platforms (`-DRARCH_CONSOLE`). These platforms should benefit the most from the reduced file I/O.
