### PR TITLE
Fix to calculate character width in word_wrap()

### DIFF
--- a/libretro-common/string/stdstring.c
+++ b/libretro-common/string/stdstring.c
@@ -215,8 +215,8 @@ char *word_wrap(char* buffer, const char *string, int line_width, bool unicode, 
          character = utf8skip(&string[i], 1);
          char_len  = (unsigned)(character - &string[i]);
 
-         if (!unicode)
-            counter += char_len - 1;
+         if (char_len >= 3)
+            counter++;  /* character is probably full-width */
 
          do
          {

--- a/libretro-common/string/stdstring.c
+++ b/libretro-common/string/stdstring.c
@@ -195,11 +195,11 @@ char *word_wrap(char* buffer, const char *string, int line_width, bool unicode, 
 
    while (i < len)
    {
-      unsigned counter;
+      unsigned counter = 0;
       int pos = (int)(&buffer[i] - buffer);
 
       /* copy string until the end of the line is reached */
-      for (counter = 1; counter <= (unsigned)line_width; counter++)
+      while (counter <= (unsigned)line_width * 10)
       {
          const char *character;
          unsigned char_len;
@@ -215,8 +215,8 @@ char *word_wrap(char* buffer, const char *string, int line_width, bool unicode, 
          character = utf8skip(&string[i], 1);
          char_len  = (unsigned)(character - &string[i]);
 
-         if (char_len >= 3)
-            counter++;  /* character is probably full-width */
+         /* the width of CJK-chars is approximately 2.6 times the width of alphabet-chars */
+         counter += (char_len < 2) ? 10 : 26;
 
          do
          {
@@ -230,7 +230,7 @@ char *word_wrap(char* buffer, const char *string, int line_width, bool unicode, 
          if (buffer[j] == '\n')
          {
             lines++;
-            counter = 1;
+            counter = 0;
          }
       }
 


### PR DESCRIPTION
## Description

This PR tries to fix issues #7439 and #9731.
The position of the fold is incorrect when using East Asian language (Chinese, Japanese and Korean) , because current implementation of word_wrap() has two problems below.

1. The method of calculating the character width is wrong.
2. The folding uses only space as delimiter, but it is not usualy used as delimiter in East Asian language.

I try to fix 1 in this PR, and try to fix 2 in #12400.

In current implementation, the character width is calculated as byte length in UTF-8 representation (when 'unicode' parameter is false).
Most of CJK characters are 3 bytes as UTF-8 representation, but their width should be 2 (aka. twice of alphabet width).
So, I changed to the method of calculating below. It is not exact, but I think it will work in many cases.

- If UTF-8 length is 1 (ASCII) or 2 (many Europe languages, Arabia, Hebrew, ...), its width is 1
- If UTF-8 length is 3 (CJK characters) and greater than 3 (surrogate pair, emoji, ...), its width is 2

If this PR is acceptable, I think that the 'unicode' parameter of word_wrap() is unnessary. 


before:
![Honeyview_before](https://user-images.githubusercontent.com/46507724/118344773-0da55800-b56b-11eb-9524-6b588a6cd042.png)

after:
![Honeyview_after](https://user-images.githubusercontent.com/46507724/118344775-1138df00-b56b-11eb-94cb-526fc9708102.png)

## Related Issues

#7439, #9731

## Related Pull Requests

#12400