### PR TITLE
(cheevos) replace sprintf with snprintf

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -254,9 +254,9 @@ static void rcheevos_get_user_agent(
    if (system && !string_is_empty(system->library_name))
    {
       char* stop = buffer + len - 1;
+      const char* path = path_get(RARCH_PATH_CORE);
       *ptr++ = ' ';
 
-      const char* path = path_get(RARCH_PATH_CORE);
       if (!string_is_empty(path))
       {
          append_no_spaces(ptr, stop, path_basename(path));

--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -199,73 +199,77 @@ void rcheevos_log(const char *fmt, ...)
 }
 #endif
 
+static int append_no_spaces(char* buffer, size_t len, const char* text)
+{
+   char* ptr = buffer;
+   char* stop = buffer + len - 1;
+
+   while (ptr < stop && *text)
+   {
+      if (*text == ' ')
+      {
+         *ptr++ = '_';
+         ++text;
+      }
+      else
+      {
+         *ptr++ = *text++;
+      }
+   }
+
+   *ptr = '\0';
+   return (ptr - buffer);
+}
+
 static void rcheevos_get_user_agent(
       rcheevos_locals_t *locals,
       char *buffer, size_t len)
 {
    struct retro_system_info *system = runloop_get_libretro_system_info();
-   const char* scan;
    char* ptr;
 
+   /* if we haven't calculated the non-changing portion yet, do so now [retroarch version + os version] */
    if (!locals->user_agent_prefix[0])
    {
       const frontend_ctx_driver_t *frontend = frontend_get_ptr();
       int major, minor;
       char tmp[64];
 
-      ptr = locals->user_agent_prefix + snprintf(locals->user_agent_prefix, sizeof(locals->user_agent_prefix), "RetroArch/%s", PACKAGE_VERSION);
+      ptr = locals->user_agent_prefix +
+         strlcpy(locals->user_agent_prefix, "RetroArch/" PACKAGE_VERSION,
+                 sizeof(locals->user_agent_prefix));
 
       if (frontend && frontend->get_os)
       {
          frontend->get_os(tmp, sizeof(tmp), &major, &minor);
-         ptr += sprintf(ptr, " (%s %d.%d)", tmp, major, minor);
-         (void)ptr;
+         snprintf(ptr, len - (ptr - locals->user_agent_prefix), " (%s %d.%d)", tmp, major, minor);
       }
    }
 
-   ptr = buffer + snprintf(buffer, len, "%s", locals->user_agent_prefix);
+   /* append the non-changing portion */
+   ptr = buffer + strlcpy(buffer, locals->user_agent_prefix, len);
 
+   /* if a core is loaded, append its information */
    if (system && !string_is_empty(system->library_name))
    {
+      *ptr++ = ' ';
+
       const char* path = path_get(RARCH_PATH_CORE);
       if (!string_is_empty(path))
       {
-         sprintf(ptr, " %s", path_basename(path));
+         append_no_spaces(ptr, len - (ptr - buffer), path_basename(path));
          path_remove_extension(ptr);
          ptr += strlen(ptr);
       }
       else
       {
-         *ptr++ = ' ';
-
-         scan = system->library_name;
-         while (*scan)
-         {
-            if (*scan == ' ')
-            {
-               *ptr++ = '_';
-               ++scan;
-            }
-            else
-               *ptr++ = *scan++;
-         }
+         ptr += append_no_spaces(ptr, len - (ptr - buffer), system->library_name);
       }
 
       if (system->library_version)
       {
          *ptr++ = '/';
-
-         scan = system->library_version;
-         while (*scan)
-         {
-            if (*scan == ' ')
-            {
-               *ptr++ = '_';
-               ++scan;
-            }
-            else
-               *ptr++ = *scan++;
-         }
+         ptr += append_no_spaces(ptr, len - (ptr - buffer), system->library_version);
       }
    }
 

--- a/deps/rcheevos/src/rurl/url.c
+++ b/deps/rcheevos/src/rurl/url.c
@@ -298,7 +298,7 @@ static int rc_url_append_unum(char* buffer, size_t buffer_size, size_t* buffer_o
   int written = rc_url_append_param_equals(buffer, buffer_size, *buffer_offset, param);
   if (written > 0) {
     char num[16];
-    int chars = sprintf(num, "%u", value);
+    int chars = snprintf(num, sizeof(num), "%u", value);
 
     if (chars + written < (int)buffer_size)
     {


### PR DESCRIPTION
## Description

eliminates `sprintf` calls in `cheevos` and `deps/rcheevos` directories

## Related Issues

https://discord.com/channels/184109094070779904/434759979095031840/844132879214575647

## Related Pull Requests

n/a

## Reviewers

@twinaphex @Alcaro @Sanaki 
