### PR TITLE
Prevent unnecessary extraction (to disk) of compressed content files + task_content.c clean-ups

### DIFF
--- a/libretro-common/file/archive_file.c
+++ b/libretro-common/file/archive_file.c
@@ -370,8 +370,7 @@ int file_archive_parse_file_progress(file_archive_transfer_t *state)
 
 /**
  * file_archive_extract_file:
- * @archive_path                    : filename path to archive.
- * @archive_path_size               : size of archive.
+ * @archive_path                : filename path to archive.
  * @valid_exts                  : valid extensions for the file.
  * @extraction_directory        : the directory to extract temporary
  *                                file to.
@@ -382,8 +381,7 @@ int file_archive_parse_file_progress(file_archive_transfer_t *state)
  * Returns : true (1) on success, otherwise false (0).
  **/
 bool file_archive_extract_file(
-      char *archive_path,
-      size_t archive_path_size,
+      const char *archive_path,
       const char *valid_exts,
       const char *extraction_directory,
       char *out_path, size_t len)
@@ -396,7 +394,6 @@ bool file_archive_extract_file(
    userdata.current_file_path[0]            = '\0';
    userdata.first_extracted_file_path       = NULL;
    userdata.extraction_directory            = extraction_directory;
-   userdata.archive_path_size               = archive_path_size;
    userdata.ext                             = list;
    userdata.list                            = NULL;
    userdata.found_file                      = false;
@@ -454,7 +451,6 @@ bool file_archive_get_file_list_noalloc(struct string_list *list,
    userdata.current_file_path[0]            = '\0';
    userdata.first_extracted_file_path       = NULL;
    userdata.extraction_directory            = NULL;
-   userdata.archive_path_size               = 0;
    userdata.ext                             = NULL;
    userdata.list                            = list;
    userdata.found_file                      = false;
@@ -484,7 +480,6 @@ struct string_list *file_archive_get_file_list(const char *path,
    userdata.current_file_path[0]            = '\0';
    userdata.first_extracted_file_path       = NULL;
    userdata.extraction_directory            = NULL;
-   userdata.archive_path_size               = 0;
    userdata.ext                             = NULL;
    userdata.list                            = string_list_new();
    userdata.found_file                      = false;

--- a/libretro-common/file/archive_file_zlib.c
+++ b/libretro-common/file/archive_file_zlib.c
@@ -297,7 +297,8 @@ static int zip_file_decompressed(
             /* Called in case core has need_fullpath enabled. */
             bool success = filestream_write_file(decomp_state->opt_file, handle.data, size);
 
-            free(handle.data);
+            /* Note: Do not free handle.data here - this
+             * will be done when stream is deinitialised */
             handle.data = NULL;
 
             decomp_state->size = 0;
@@ -310,10 +311,50 @@ static int zip_file_decompressed(
             /* Called in case core has need_fullpath disabled.
              * Will move decompressed content directly into
              * RetroArch's ROM buffer. */
-            *decomp_state->buf = handle.data;
-            handle.data = NULL;
+            zip_context_t *zip_context = (zip_context_t *)userdata->transfer->context;
 
-            decomp_state->size = size;
+            decomp_state->size = 0;
+
+            /* Unlink data buffer from context (otherwise
+             * it will be freed when the stream is deinitialised) */
+            if (handle.data == zip_context->compressed_data)
+            {
+               /* Well this is fun...
+                * If this is 'compressed' data (if the zip
+                * file was created with the '-0   store only'
+                * flag), and the origin file is mmapped, then
+                * the context compressed_data buffer cannot be
+                * reassigned (since it is not a traditional
+                * block of user-assigned memory). We have to
+                * create a copy of it instead... */
+#ifdef HAVE_MMAP
+               if (zip_context->state->archive_mmap_data)
+               {
+                  uint8_t *temp_buf = (uint8_t*)malloc(csize);
+
+                  if (temp_buf)
+                  {
+                     memcpy(temp_buf, handle.data, csize);
+                     *decomp_state->buf        = temp_buf;
+                     decomp_state->size        = csize;
+                  }
+               }
+               else
+#endif
+               {
+                  *decomp_state->buf           = handle.data;
+                  decomp_state->size           = csize;
+                  zip_context->compressed_data = NULL;
+               }
+            }
+            else if (handle.data == zip_context->decompressed_data)
+            {
+               *decomp_state->buf             = handle.data;
+               decomp_state->size             = size;
+               zip_context->decompressed_data = NULL;
+            }
+
+            handle.data = NULL;
          }
       }
 

--- a/libretro-common/include/file/archive_file.h
+++ b/libretro-common/include/file/archive_file.h
@@ -96,7 +96,6 @@ struct archive_extract_userdata
    /* Not used by the processing, free to use outside or in iterate callback */
    decompress_state_t *dec;
    void* cb_data;
-   size_t archive_path_size;
    uint32_t crc;
    char archive_path[PATH_MAX_LENGTH];
    char current_file_path[PATH_MAX_LENGTH];
@@ -149,8 +148,7 @@ int file_archive_parse_file_progress(file_archive_transfer_t *state);
 
 /**
  * file_archive_extract_file:
- * @archive_path                    : filename path to ZIP archive.
- * @archive_path_size               : size of ZIP archive.
+ * @archive_path                : filename path to ZIP archive.
  * @valid_exts                  : valid extensions for a file.
  * @extraction_directory        : the directory to extract the temporary
  *                                file to.
@@ -160,7 +158,7 @@ int file_archive_parse_file_progress(file_archive_transfer_t *state);
  *
  * Returns : true (1) on success, otherwise false (0).
  **/
-bool file_archive_extract_file(char *archive_path, size_t archive_path_size,
+bool file_archive_extract_file(const char *archive_path,
       const char *valid_exts, const char *extraction_dir,
       char *out_path, size_t len);
 


### PR DESCRIPTION
## Description

At present, when loading content from compressed files, RetroArch *always* extracts the archive to a temporary file - even when cores specify `need_fullpath = false`. This is incorrect behaviour. If a core does not explicitly need to load a file from disk via some internal mechanism, the frontend should merely provide it with a data buffer. RetroArch is doing this, but in absurd fashion, i.e.:

- Content is extracted to a temporary file on disk
- Temporary file is loaded into a memory buffer and passed to the core
- Temporary file is deleted when core is unloaded

This is a huge unnecessary performance overhead, and it causes significant unnecessary wear on flash storage devices...

This PR fixes the issue. Now if compressed content is loaded into a core that sets `need_fullpath = false`, the file will be loaded directly into memory - no disk writes will occur.

Additional notes:

- Previously, it was in fact impossible to load content inside zip files directly into RAM, because the `file_archive_extract_file()` function in `archive_file.c` was entirely broken when using the zlib backend. I guess no one has ever tested this function in the last 6 years... :)
- The PR also represents a (small) first stage clean up of `task_content.c`, which is currently in a shocking state. We will hopefully manage to get this properly refactored over several follow-up PRs
- During the `task_content.c` clean up, a significant number of small bugs have been fixed (too many to mention, really....)