### PR TITLE
bind lightgun trigger to first mouse button by default

### DIFF
--- a/config.def.keybinds.h
+++ b/config.def.keybinds.h
@@ -195,7 +195,7 @@ static const struct retro_keybind retro_keybinds_1[] = {
       NULL, NULL,
       AXIS_NONE, AXIS_NONE, AXIS_NONE,
       MENU_ENUM_LABEL_VALUE_INPUT_LIGHTGUN_TRIGGER, RETROK_UNKNOWN,
-      RARCH_LIGHTGUN_TRIGGER, NO_BTN, NO_BTN, 0,
+      RARCH_LIGHTGUN_TRIGGER, RETRO_DEVICE_ID_MOUSE_LEFT, NO_BTN, 0,
       true
    },
    {
@@ -750,7 +750,7 @@ static const struct retro_keybind retro_keybinds_1[] = {
       NULL, NULL,
       AXIS_NONE, AXIS_NONE, AXIS_NONE,
       MENU_ENUM_LABEL_VALUE_INPUT_LIGHTGUN_TRIGGER, RETROK_UNKNOWN,
-      RARCH_LIGHTGUN_TRIGGER, NO_BTN, NO_BTN, 0,
+      RARCH_LIGHTGUN_TRIGGER, RETRO_DEVICE_ID_MOUSE_LEFT, NO_BTN, 0,
       true
    },
    {
@@ -1304,7 +1304,7 @@ static const struct retro_keybind retro_keybinds_1[] = {
       NULL, NULL,
       AXIS_NONE, AXIS_NONE, AXIS_NONE,
       MENU_ENUM_LABEL_VALUE_INPUT_LIGHTGUN_TRIGGER, RETROK_UNKNOWN,
-      RARCH_LIGHTGUN_TRIGGER, NO_BTN, NO_BTN, 0,
+      RARCH_LIGHTGUN_TRIGGER, RETRO_DEVICE_ID_MOUSE_LEFT, NO_BTN, 0,
       true
    },
    {
@@ -1872,7 +1872,7 @@ static const struct retro_keybind retro_keybinds_rest[] = {
       NULL, NULL,
       AXIS_NONE, AXIS_NONE, AXIS_NONE,
       MENU_ENUM_LABEL_VALUE_INPUT_LIGHTGUN_TRIGGER, RETROK_UNKNOWN,
-      RARCH_LIGHTGUN_TRIGGER, NO_BTN, NO_BTN, 0,
+      RARCH_LIGHTGUN_TRIGGER, RETRO_DEVICE_ID_MOUSE_LEFT, NO_BTN, 0,
       true
    },
    {


### PR DESCRIPTION
At the moment, there are no default bindings for the lightgun abstraction.

This PR adds only a default for the most important binding, the trigger, which is bound to the first mouse button.

It would resolve this issue: https://github.com/libretro/RetroArch/issues/7904