### PR TITLE
[VITA] Fix input driver for PSTV

### DIFF
--- a/input/drivers_joypad/psp_joypad.c
+++ b/input/drivers_joypad/psp_joypad.c
@@ -89,10 +89,8 @@ static void *psp_joypad_init(void *data)
    unsigned players_count = DEFAULT_MAX_PADS;
 
 #if defined(VITA)
-   if (!sceCtrlIsMultiControllerSupported())
-      psp2_model = SCE_KERNEL_MODEL_VITA;
-   else if(sceCtrlIsMultiControllerSupported() > 0)
-      psp2_model = SCE_KERNEL_MODEL_VITATV;
+   psp2_model = sceCtrlIsMultiControllerSupported()? SCE_KERNEL_MODEL_VITATV : SCE_KERNEL_MODEL_VITA;
+
    if (psp2_model != SCE_KERNEL_MODEL_VITATV)
       players_count = 1;
    if (sceKernelGetModelForCDialog() != SCE_KERNEL_MODEL_VITATV)
@@ -378,7 +376,8 @@ static bool psp_joypad_rumble(unsigned pad,
 #ifdef VITA
    if (psp2_model != SCE_KERNEL_MODEL_VITATV)
       return false;
-
+   if(pad >= DEFAULT_MAX_PADS)
+      return false;
    switch (effect)
    {
       case RETRO_RUMBLE_WEAK:


### PR DESCRIPTION
The pad value was not checked and some static variables were overwritten.

e.g. PSTV was not able to "Load Content" if specific optimizations were applied