### PR TITLE
(XMB) entry enumeration

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -17724,8 +17724,9 @@ static bool setting_append_list(
          (*list)[list_info->index - 1].action_right  = setting_bool_action_right_with_refresh;
 
          /* Playlist entry index display is currently
-          * supported only by Ozone */
-         if (string_is_equal(settings->arrays.menu_driver, "ozone"))
+          * supported only by Ozone & XMB */
+         if (string_is_equal(settings->arrays.menu_driver, "xmb") ||
+             string_is_equal(settings->arrays.menu_driver, "ozone"))
          {
             CONFIG_BOOL(
                   list, list_info,


### PR DESCRIPTION
## Description
This PR adds a string to the bottom right corner of the screen in XMB depicting _entry index/number of entries in current list_ :
![entry enumeration xmb](https://user-images.githubusercontent.com/49207524/119189348-7c9f1700-ba6b-11eb-8e7e-b7ab6cb862e8.png)

It is marked WIP because I would like to hear some opinions on the following concern I have:
The lists in XMB, be it the games, the settings or even the quick menu, all look, and for the most part behave, kinda the same. In addition to that, not every list that seems like it should be a 'dedicated' playlist, is (Images is a playlist, but Music and Videos aren't).
Therefore, I think it would make sense to utilise this entry enumeration for all lists in XMB, not just the playlists.

I have implemented an option (Settings -> Playlists -> Show Entry Index For All Lists), which will toggle between enumerating the entries for all lists and only enumerating playlist entries. So please, try it out and let me know your preferences and thoughts on how to handle this.

Thank you.

## Related Pull Requests
This is a continuation of #12398.

## Reviewers
A big thank you to @jdgleaver for providing a great example for creating settings entries.
