### PR TITLE
[iOS/tvOS] Disable core info caching for iOS

### DIFF
--- a/core_info.c
+++ b/core_info.c
@@ -1809,13 +1809,18 @@ static core_info_list_t *core_info_list_new(const char *path,
    core_info_list->list  = core_info;
    core_info_list->count = path_list->core_list->size;
 
-   /* Read core info cache, if enabled */
+#if !defined(IOS)
+   /* Read core info cache, if enabled
+    * > This functionality is hard disabled on iOS/tvOS,
+    *   where core path changes on every install
+    *   (invalidating any cached parameters) */
    if (enable_cache)
    {
       core_info_cache_list = core_info_cache_read(info_dir);
       if (!core_info_cache_list)
          goto error;
    }
+#endif
 
    for (i = 0; i < path_list->core_list->size; i++)
    {

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -2446,9 +2446,8 @@ static int action_ok_playlist_entry_collection(const char *path,
       }
       else
       {
-#ifndef IOS
          core_info = playlist_entry_get_core_info(entry);
-#endif
+
          if (core_info && !string_is_empty(core_info->path))
             strlcpy(core_path, core_info->path, sizeof(core_path));
          else

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -2446,8 +2446,9 @@ static int action_ok_playlist_entry_collection(const char *path,
       }
       else
       {
+#ifndef IOS
          core_info = playlist_entry_get_core_info(entry);
-
+#endif
          if (core_info && !string_is_empty(core_info->path))
             strlcpy(core_path, core_info->path, sizeof(core_path));
          else

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -9396,6 +9396,11 @@ static bool setting_append_list(
 #endif
             for (i = 0; i < ARRAY_SIZE(bool_entries); i++)
             {
+#if defined(IOS)
+               if (bool_entries[i].name_enum_idx ==
+                     MENU_ENUM_LABEL_CORE_INFO_CACHE_ENABLE)
+                  continue;
+#endif
                CONFIG_BOOL(
                      list, list_info,
                      bool_entries[i].target,


### PR DESCRIPTION
## Description

On iOS, if the user updates the app (or rebuilds it), cores cannot be loaded and content cannot be played when the Core Info Caching feature is enabled (it's enabled by default).

The problem is that the path to the core changes on every install because the cores are included as part of the application bundle. This is a hard requirement because the cores are dylibs that need to be code-signed at build time to be able to run. RetroArch iOS includes all supported cores and does not support the Core Updater (I'd like to address hiding the Core Updater for iOS at some point).

It looks like the absolute path to the core is saved in the cache, so when the core info is fetched the cached path is pointing to the path of the old application bundle path and is invalid.

The core path for iOS is resolved using the `playlist_resolve_path()` method - it has the prefix of `:/modules`, which gets expanded in `fill_pathname_expand_special()`

If we just just always resolve the core path without fetching it from the cache, it resolves the issue.

The other workaround is to go to Settings -> Core -> Enable Core Info Caching -> Disable, save configuration, force quit, open content.

I went with a quick fix using a compiler flag because I'm not really convinced of the benefit Core Info Caching provides for the iOS platform, as there is no slow I/O disk issue and it's an optimization that's not needed for the platform.

Other alternatives include:

1. Always disable the setting for Core Info Caching for iOS and don't show it in Settings -> Core (not sure what the level of effort would be for this)
2. Fix the Core Info Caching so that it can cache the abbreviated core path with the `:/modules` prefix and expand it after loading it from the cache (does not seem worth doing given the dubious benefit it provides for iOS)
3. Introduce a `-DHAVE_COREINFO_CACHING` flag?

Totally open to discussion as to how to fix this properly.

## Reviewers

@jdgleaver @twinaphex 
