### PR TITLE
Refactor word_wrap()

### DIFF
--- a/libretro-common/include/string/stdstring.h
+++ b/libretro-common/include/string/stdstring.h
@@ -149,7 +149,7 @@ char *string_trim_whitespace_right(char *const s);
 char *string_trim_whitespace(char *const s);
 
 /* max_lines == 0 means no limit */
-char *word_wrap(char *buffer, const char *string,
+void word_wrap(char *dst, const char *src,
       int line_width, bool unicode, unsigned max_lines);
 
 /* Splits string into tokens seperated by 'delim'


### PR DESCRIPTION
## Description

This PR is refactoring word_wrap().
Since I am currently reimplementing #12399 and #12400, which require a modification of word_wrap(), I first reviewed and refactored the current implementation.

This has improved the performance a bit.

I think that the return value of word_wrap() should be 'void' rather than 'char *', because it is same of first argument and any callers doesn't use it.
What do you think about?

## Reviewers

@jdgleaver