### PR TITLE
fix crash when viewing information shortly after starting content

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -4015,6 +4015,7 @@ static unsigned menu_displaylist_parse_content_information(
       content_path   = loaded_content_path;
       core_path      = loaded_core_path;
 
+      if (core_info_find(core_path, &core_info))
          if (!string_is_empty(core_info->display_name))
             strlcpy(core_name, core_info->display_name, sizeof(core_name));
    }


### PR DESCRIPTION
## Description

Fixes a crash that occurs if the Quick Menu > Information menu is opened shortly after loading new content. 

If `playlist_index_is_valid` returns false, then the code proceeds into the else portion of the logic in `menu_displaylist_parse_content_information`. When [this line](https://github.com/libretro/RetroArch/commit/e34c84d7918c092fc351fc07d352de841a093c49#diff-733037f59245081b3fe7ec8e483116f419f476094b20402dbe34a38683342e79L4018) was removed, it prevents `core_info` from being initialized, and a null reference exception occurs.

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@twinaphex
