### PR TITLE
Improve message wrapping with CJK languages

### DIFF
--- a/gfx/gfx_widgets.c
+++ b/gfx/gfx_widgets.c
@@ -361,7 +361,8 @@ void gfx_widgets_msg_queue_push(
             /* Single line text > two lines text > two lines 
              * text with expanded width */
             unsigned title_length               = (unsigned)strlen(title);
-            char *msg                           = strdup(title);
+            char *msg                           = NULL;
+            size_t msg_len                      = 0;
             unsigned width                      = menu_is_alive 
                ? p_dispwidget->msg_queue_default_rect_width_menu_alive 
                : p_dispwidget->msg_queue_default_rect_width;
@@ -372,6 +373,12 @@ void gfx_widgets_msg_queue_push(
                   1);
             msg_widget->text_height             = p_dispwidget->gfx_widget_fonts.msg_queue.line_height;
 
+            msg_len = title_length + 1 + 1; /* 1 byte uses for inserting '\n' */
+            msg = (char *)malloc(msg_len);
+            if (!msg)
+               return;
+            msg[0] = '\0';
+
             /* Text is too wide, split it into two lines */
             if (text_width > width)
             {
@@ -381,13 +388,16 @@ void gfx_widgets_msg_queue_push(
                if ((text_width - (text_width >> 2)) < width)
                   width = text_width - (text_width >> 2);
 
-               word_wrap(msg, msg, (title_length * width) / text_width,
-                     false, 2);
+               word_wrap(msg, msg_len, title, (title_length * width) / text_width,
+                     100, 2);
 
                msg_widget->text_height *= 2;
             }
             else
+            {
                width                            = text_width;
+               strlcpy(msg, title, msg_len);
+            }
 
             msg_widget->msg                     = msg;
             msg_widget->msg_len                 = (unsigned)strlen(msg);

--- a/intl/msg_hash_chs.c
+++ b/intl/msg_hash_chs.c
@@ -1811,3 +1811,8 @@ const char *msg_hash_to_str_chs(enum msg_hash_enums msg)
 
    return "null";
 }
+
+const char *msg_hash_get_wideglyph_str_chs(void)
+{
+   return "菜";
+}

--- a/intl/msg_hash_cht.c
+++ b/intl/msg_hash_cht.c
@@ -1867,3 +1867,8 @@ const char *msg_hash_to_str_cht(enum msg_hash_enums msg)
 
    return "null";
 }
+
+const char *msg_hash_get_wideglyph_str_cht(void)
+{
+   return "主";
+}

--- a/intl/msg_hash_ja.c
+++ b/intl/msg_hash_ja.c
@@ -2319,3 +2319,8 @@ const char *msg_hash_to_str_jp(enum msg_hash_enums msg) {
 
    return "null";
 }
+
+const char *msg_hash_get_wideglyph_str_jp(void)
+{
+   return "漢";
+}

--- a/intl/msg_hash_ko.c
+++ b/intl/msg_hash_ko.c
@@ -2320,3 +2320,8 @@ const char *msg_hash_to_str_ko(enum msg_hash_enums msg) {
 
     return "null";
 }
+
+const char *msg_hash_get_wideglyph_str_ko(void)
+{
+   return "메";
+}

--- a/libretro-common/include/string/stdstring.h
+++ b/libretro-common/include/string/stdstring.h
@@ -148,9 +148,61 @@ char *string_trim_whitespace_right(char *const s);
 /* Remove leading and trailing whitespaces */
 char *string_trim_whitespace(char *const s);
 
-/* max_lines == 0 means no limit */
-void word_wrap(char *dst, const char *src,
-      int line_width, bool unicode, unsigned max_lines);
+/*
+ * Wraps string specified by 'src' to destination buffer
+ * specified by 'dst' and 'dst_size'.
+ * This function assumes that all glyphs in the string
+ * have an on-screen pixel width similar to that of
+ * regular Latin characters - i.e. it will not wrap
+ * correctly any text containing so-called 'wide' Unicode
+ * characters (e.g. CJK languages, emojis, etc.).
+ *
+ * @param dst             pointer to destination buffer.
+ * @param dst_size        size of destination buffer.
+ * @param src             pointer to input string.
+ * @param line_width      max number of characters per line.
+ * @param wideglyph_width not used, but is necessary to keep
+ *                        compatibility with word_wrap_wideglyph().
+ * @param max_lines       max lines of destination string.
+ *                        0 means no limit.
+ */
+void word_wrap(char *dst, size_t dst_size, const char *src,
+      int line_width, int wideglyph_width, unsigned max_lines);
+
+/*
+ * Wraps string specified by 'src' to destination buffer
+ * specified by 'dst' and 'dst_size'.
+ * This function assumes that all glyphs in the string
+ * are:
+ * - EITHER 'non-wide' Unicode glyphs, with an on-screen
+ *   pixel width similar to that of regular Latin characters
+ * - OR 'wide' Unicode glyphs (e.g. CJK languages, emojis, etc.)
+ *   with an on-screen pixel width defined by 'wideglyph_width'
+ * Note that wrapping may occur in inappropriate locations
+ * if 'src' string contains 'wide' Unicode characters whose
+ * on-screen pixel width deviates greatly from the set
+ * 'wideglyph_width' value.
+ *
+ * @param dst             pointer to destination buffer.
+ * @param dst_size        size of destination buffer.
+ * @param src             pointer to input string.
+ * @param line_width      max number of characters per line.
+ * @param wideglyph_width effective width of 'wide' Unicode glyphs.
+ *                        the value here is normalised relative to the
+ *                        typical on-screen pixel width of a regular
+ *                        Latin character:
+ *                        - a regular Latin character is defined to
+ *                          have an effective width of 100
+ *                        - wideglyph_width = 100 * (wide_character_pixel_width / latin_character_pixel_width)
+ *                        - e.g. if 'wide' Unicode characters in 'src'
+ *                          have an on-screen pixel width twice that of
+ *                          regular Latin characters, wideglyph_width
+ *                          would be 200
+ * @param max_lines       max lines of destination string.
+ *                        0 means no limit.
+ */
+void word_wrap_wideglyph(char *dst, size_t dst_size, const char *src,
+      int line_width, int wideglyph_width, unsigned max_lines);
 
 /* Splits string into tokens seperated by 'delim'
  * > Returned token string must be free()'d

--- a/libretro-common/test/string/test_stdstring.c
+++ b/libretro-common/test/string/test_stdstring.c
@@ -196,7 +196,7 @@ START_TEST (test_word_wrap)
 
    char output[1024];
 
-   word_wrap(output, testtxt, 40, true, 10);
+   word_wrap(output, sizeof(output), testtxt, 40, 100, 10);
    ck_assert(!strcmp(output, expected));
 }
 END_TEST

--- a/menu/drivers/ozone/ozone.h
+++ b/menu/drivers/ozone/ozone.h
@@ -99,6 +99,7 @@ typedef struct
    font_data_t *font;
    video_font_raster_block_t raster_block; /* ptr alignment */
    int glyph_width;
+   int wideglyph_width;
    int line_height;
    int line_ascender;
    int line_centre_offset;
@@ -131,6 +132,9 @@ struct ozone_handle
       ozone_font_data_t entries_sublabel;
       ozone_font_data_t sidebar;
    } fonts;
+
+   void (*word_wrap)(char *dst, size_t dst_size, const char *src,
+      int line_width, int wideglyph_width, unsigned max_lines);
 
    struct
    {

--- a/menu/drivers/ozone/ozone_display.c
+++ b/menu/drivers/ozone/ozone_display.c
@@ -495,7 +495,9 @@ void ozone_draw_osk(ozone_handle_t *ozone,
       text_color  = ozone_theme_light.text_sublabel_rgba;
    }
 
-   word_wrap(message, text, (video_width - margin*2 - padding*2) / ozone->fonts.entries_label.glyph_width, true, 0);
+   (ozone->word_wrap)(message, sizeof(message), text,
+         (video_width - margin*2 - padding*2) / ozone->fonts.entries_label.glyph_width,
+         ozone->fonts.entries_label.wideglyph_width, 0);
 
    string_list_initialize(&list);
    string_split_noalloc(&list, message, "\n");
@@ -602,10 +604,10 @@ void ozone_draw_messagebox(
       return;
 
    /* Split message into lines */
-   word_wrap(
-         wrapped_message, message,
+   (ozone->word_wrap)(
+         wrapped_message, sizeof(wrapped_message), message,
          usable_width / (int)ozone->fonts.footer.glyph_width,
-         true, 0);
+         ozone->fonts.footer.wideglyph_width, 0);
 
    string_list_initialize(&list);
    if (

--- a/menu/drivers/ozone/ozone_entries.c
+++ b/menu/drivers/ozone/ozone_entries.c
@@ -400,9 +400,10 @@ void ozone_compute_entries_position(
                   sublabel_max_width -= ozone->dimensions.thumbnail_bar_width;
             }
 
-            word_wrap(wrapped_sublabel_str, entry.sublabel,
+            (ozone->word_wrap)(wrapped_sublabel_str, sizeof(wrapped_sublabel_str), entry.sublabel,
                   sublabel_max_width / 
-                  ozone->fonts.entries_sublabel.glyph_width, false, 0);
+                  ozone->fonts.entries_sublabel.glyph_width,
+                  ozone->fonts.entries_sublabel.wideglyph_width, 0);
 
             node->sublabel_lines = ozone_count_lines(wrapped_sublabel_str);
 
@@ -763,7 +764,9 @@ border_iterate:
             }
 
             wrapped_sublabel_str[0] = '\0';
-            word_wrap(wrapped_sublabel_str, sublabel_str, sublabel_max_width / ozone->fonts.entries_sublabel.glyph_width, false, 0);
+            (ozone->word_wrap)(wrapped_sublabel_str, sizeof(wrapped_sublabel_str),
+                  sublabel_str, sublabel_max_width / ozone->fonts.entries_sublabel.glyph_width,
+                  ozone->fonts.entries_sublabel.wideglyph_width, 0);
             sublabel_str = wrapped_sublabel_str;
          }
       }

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -3932,9 +3932,9 @@ static void rgui_render_messagebox(rgui_t *rgui, const char *message,
 
    /* Split message into lines */
    word_wrap(
-         wrapped_message, message,
+         wrapped_message, sizeof(wrapped_message), message,
          rgui->term_layout.width,
-         true, 0);
+         100, 0);
 
    string_list_initialize(&list);
    if (     !string_split_noalloc(&list, wrapped_message, "\n")

--- a/menu/drivers/stripes.c
+++ b/menu/drivers/stripes.c
@@ -286,6 +286,9 @@ typedef struct stripes_handle
    font_data_t *font2;
    video_font_raster_block_t raster_block;
    video_font_raster_block_t raster_block2;
+
+   void (*word_wrap)(char *dst, size_t dst_size, const char *src,
+      int line_width, int wideglyph_width, unsigned max_lines);
 } stripes_handle_t;
 
 float stripes_scale_mod[8] = {
@@ -2406,7 +2409,8 @@ static int stripes_draw_item(
 
       label_offset      = - stripes->margins_label_top;
 
-      word_wrap(entry_sublabel, entry->sublabel, 50 * stripes_scale_mod[3], true, 0);
+      (stripes->word_wrap)(entry_sublabel, sizeof(entry_sublabel),
+            entry->sublabel, 50 * stripes_scale_mod[3], 100, 0);
 
       stripes_draw_text(xmb_shadows_enable, stripes, entry_sublabel,
             node->x + stripes->margins_screen_left +
@@ -3373,6 +3377,9 @@ static void *stripes_init(void **userdata, bool video_is_threaded)
 
    file_list_initialize(&stripes->horizontal_list);
    stripes_init_horizontal_list(stripes);
+
+   /* set word_wrap function pointer */
+   stripes->word_wrap = msg_hash_get_wideglyph_str() ? word_wrap_wideglyph : word_wrap;
 
    return menu;
 

--- a/msg_hash.c
+++ b/msg_hash.c
@@ -536,3 +536,22 @@ void msg_hash_set_uint(enum msg_hash_action type, unsigned val)
          break;
    }
 }
+
+const char *msg_hash_get_wideglyph_str(void)
+{
+   switch (uint_user_language)
+   {
+      case RETRO_LANGUAGE_CHINESE_SIMPLIFIED:
+         return msg_hash_get_wideglyph_str_chs();
+      case RETRO_LANGUAGE_CHINESE_TRADITIONAL:
+         return msg_hash_get_wideglyph_str_cht();
+      case RETRO_LANGUAGE_JAPANESE:
+         return msg_hash_get_wideglyph_str_jp();
+      case RETRO_LANGUAGE_KOREAN:
+         return msg_hash_get_wideglyph_str_ko();
+      default:
+         break;
+   }
+   
+   return NULL;
+}

--- a/msg_hash.h
+++ b/msg_hash.h
@@ -3269,6 +3269,37 @@ unsigned *msg_hash_get_uint(enum msg_hash_action type);
 
 void msg_hash_set_uint(enum msg_hash_action type, unsigned val);
 
+/* Latin languages typically consist of regular
+ * alpha numeric characters with a 'standard'
+ * on-screen pixel width.
+ * Non-Latin languages (e.g. CJK) typically consist
+ * of so-called 'wide' Unicode glyphs, which may have
+ * an on-screen pixel width several times that of Latin
+ * characters.
+ * In order to determine efficiently the on-screen width
+ * of a text string (e.g. when word wrapping), it is
+ * therefore necessary to:
+ * - Identify which languages make use of 'wide' Unicode
+ *   glyphs
+ * - For each of these languages, provide a mechanism for
+ *   measuring the typical on-screen pixel width of
+ *   language-specific 'wide' Unicode glyphs
+ * As such, msg_hash_get_wideglyph_str() returns a pointer
+ * to a 'wide' Unicode character of typical on-screen pixel
+ * width for the currently set user language.
+ * - If msg_hash_get_wideglyph_str() returns NULL, the current
+ *   language is assumed to be Latin-based, with no usage
+ *   of 'wide' Unicode glyphs
+ * - If msg_hash_get_wideglyph_str() returns a valid pointer,
+ *   actual 'wide' glyph width for the current language may
+ *   be found by passing said pointer to the current font
+ *   rendering implementation */
+const char *msg_hash_get_wideglyph_str(void);
+const char *msg_hash_get_wideglyph_str_chs(void);
+const char *msg_hash_get_wideglyph_str_cht(void);
+const char *msg_hash_get_wideglyph_str_jp(void);
+const char *msg_hash_get_wideglyph_str_ko(void);
+
 uint32_t msg_hash_calculate(const char *s);
 
 const char *get_user_language_iso639_1(bool limit);

--- a/ui/drivers/qt/qt_dialogs.cpp
+++ b/ui/drivers/qt/qt_dialogs.cpp
@@ -1195,8 +1195,15 @@ void CoreOptionsDialog::buildLayout()
 
                if (!string_is_empty(option->info))
                {
-                  char *new_info = strdup(option->info);
-                  word_wrap(new_info, new_info, 50, true, 0);
+                  char *new_info;
+                  size_t new_info_len = strlen(option->info) + 1;
+
+                  new_info = (char *)malloc(new_info_len);
+                  if (!new_info)
+                     return;
+                  new_info[0] = '\0';
+
+                  word_wrap(new_info, new_info_len, option->info, 50, 100, 0);
                   descLabel->setToolTip(new_info);
                   combo_box->setToolTip(new_info);
                   free(new_info);


### PR DESCRIPTION
## Description

This PR combines #12399 and #12400.
I have reimplemented it based on the comments and suggestions I received in above PRs.

- When using with languages their fonts contain wider glyph than alphabet (e.g. CJK), use the width for message wrapping.
- The process above is separated from word_wrap() and implemented as word_wrap_wideglyph(), to prevent performance overhead when using with languages other than above.

## Related Issues

#7439, #9731

## Related Pull Requests

#12399, #12400, #12435
