### PR TITLE
Fix garbled path string

### DIFF
--- a/libretro-common/file/file_path.c
+++ b/libretro-common/file/file_path.c
@@ -640,25 +640,25 @@ char *path_resolve_realpath(char *buf, size_t size, bool resolve_symlinks)
 #if !defined(RARCH_CONSOLE) && defined(RARCH_INTERNAL)
 #ifdef _WIN32
    char *ret = NULL;
-   wchar_t *abs_path = (wchar_t *)malloc(PATH_MAX_LENGTH * sizeof(wchar_t));
+   wchar_t abs_path[PATH_MAX_LENGTH];
    wchar_t *rel_path = utf8_to_utf16_string_alloc(buf);
 
-   if (abs_path && rel_path && _wfullpath(abs_path, rel_path, PATH_MAX_LENGTH))
-   {
-      char *tmp = utf16_to_utf8_string_alloc(abs_path);
-
-      if (tmp)
-      {
-         strlcpy(buf, tmp, size);
-         free(tmp);
-         ret = buf;
-      }
-   }
-
    if (rel_path)
+   {
+      if (_wfullpath(abs_path, rel_path, PATH_MAX_LENGTH))
+      {
+         char *tmp = utf16_to_utf8_string_alloc(abs_path);
+
+         if (tmp)
+         {
+            strlcpy(buf, tmp, size);
+            free(tmp);
+            ret = buf;
+         }
+      }
+
       free(rel_path);
-   if (abs_path)
-      free(abs_path);
+   }
 
    return ret;
 #else


### PR DESCRIPTION
## Description

This PR solves #12103 and #12624.

In the current implementation, path_resolve_realpath() uses _fullpath() when _WIN32 is defined.
As decribed [here](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/fullpath-wfullpath?view=msvc-160),  _fullpath() automatically handles multibyte-character string arguments as appropriate, recognizing multibyte-character sequences according to the multibyte code page currently in use.
When the code page is neither ASCII nor UTF-8, _fullpath() sometimes makes garbled path string because the input string is UTF-8.

I have modified using _wfullpath() instead of _fullpath(). Please let me know if anybody has more better idea to solve.

## Related Issues

#12103, #12624
