### PR TITLE
CHEEVOS: relabel 'Start Active' with 'Encore Mode'

### DIFF
--- a/intl/msg_hash_es.h
+++ b/intl/msg_hash_es.h
@@ -4898,7 +4898,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_CHEEVOS_START_ACTIVE,
-   "Empezar con los logros activos"
+   "Modo Jugar de Nuevo"
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_CHEEVOS_START_ACTIVE,
@@ -6784,7 +6784,7 @@ MSG_HASH(
    MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_REFERENCE,
    "Preajustes sencillos"
    )
-   
+
 MSG_HASH(
    MENU_ENUM_SUBLABEL_VIDEO_SHADER_PRESET_SAVE_REFERENCE,
    "Guarda un preajuste de shaders con un enlace al preajuste original ya cargado e incluye únicamente los cambios que hayas hecho en sus parámetros."

--- a/intl/msg_hash_pt_br.h
+++ b/intl/msg_hash_pt_br.h
@@ -4870,7 +4870,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_CHEEVOS_START_ACTIVE,
-   "Iniciar ativo"
+   "Modo Jogar de Novo"
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_CHEEVOS_START_ACTIVE,
@@ -6756,7 +6756,7 @@ MSG_HASH(
    MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_REFERENCE,
    "Predefinições simples"
    )
-   
+
 MSG_HASH(
    MENU_ENUM_SUBLABEL_VIDEO_SHADER_PRESET_SAVE_REFERENCE,
    "Salva uma predefinição do Shader com um link para a predefinição original que já está carregada e inclui apenas as alterações que você fez no parâmetro."

--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -4974,7 +4974,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_CHEEVOS_START_ACTIVE,
-   "Start Active"
+   "Encore Mode" /* suggestion for translators: translate as "Play Again Mode" */
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_CHEEVOS_START_ACTIVE,
@@ -6956,7 +6956,7 @@ MSG_HASH(
    MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_REFERENCE,
    "Simple Presets"
    )
-   
+
 MSG_HASH(
    MENU_ENUM_SUBLABEL_VIDEO_SHADER_PRESET_SAVE_REFERENCE,
    "Save a shader preset which has a link to the original preset loaded and includes only the parameter changes you made."


### PR DESCRIPTION
## Description

Last year I implemented `cheevos_start_active` option (#10637), to allow players to start a gaming session with all achievements active (even the ones they already have registered as unlocked on RetroAchievements.org).

In the UI the option was originally named `Start Active`, but apparently many users think that the option must be enabled to make the achievements feature to work (active). And some of them are reporting the intended behavior as a bug: "I'm unlocking achievements I already have"

After some discussion we found a better name: `Encore Mode`

As the term `Encore` isn't easily "translatable" (at least for the languages I'm comfortable with) I left in the comments a suggestion for translators to consider the translation of the term `Play Again Mode`.


## Related Pull Requests

#10637


## Reviewers

@Jamiras 

Also pinging the guy who seems to be currently involved in most of the translations: @guoyunhe 