### PR TITLE
Fix loading of archived content with file names containing '#' characters

### DIFF
--- a/libretro-common/file/file_path.c
+++ b/libretro-common/file/file_path.c
@@ -90,38 +90,44 @@ const char *path_get_archive_delim(const char *path)
    if (!last_slash)
       return NULL;
 
-   /* Find delimiter position */
-   delim = strrchr(last_slash, '#');
+   /* Find delimiter position
+    * > Since filenames may contain '#' characters,
+    *   must loop until we find the first '#' that
+    *   is directly *after* a compression extension */
+   delim = strchr(last_slash, '#');
 
-   if (!delim)
-      return NULL;
-
-   /* Check whether this is a known archive type
-    * > Note: The code duplication here is
-    *   deliberate, to maximise performance */
-   if (delim - last_slash > 4)
+   while (delim)
    {
-      strlcpy(buf, delim - 4, sizeof(buf));
-      buf[4] = '\0';
+      /* Check whether this is a known archive type
+       * > Note: The code duplication here is
+       *   deliberate, to maximise performance */
+      if (delim - last_slash > 4)
+      {
+         strlcpy(buf, delim - 4, sizeof(buf));
+         buf[4] = '\0';
 
-      string_to_lower(buf);
+         string_to_lower(buf);
 
-      /* Check if this is a '.zip', '.apk' or '.7z' file */
-      if (string_is_equal(buf,     ".zip") ||
-          string_is_equal(buf,     ".apk") ||
-          string_is_equal(buf + 1, ".7z"))
-         return delim;
-   }
-   else if (delim - last_slash > 3)
-   {
-      strlcpy(buf, delim - 3, sizeof(buf));
-      buf[3] = '\0';
+         /* Check if this is a '.zip', '.apk' or '.7z' file */
+         if (string_is_equal(buf,     ".zip") ||
+             string_is_equal(buf,     ".apk") ||
+             string_is_equal(buf + 1, ".7z"))
+            return delim;
+      }
+      else if (delim - last_slash > 3)
+      {
+         strlcpy(buf, delim - 3, sizeof(buf));
+         buf[3] = '\0';
 
-      string_to_lower(buf);
+         string_to_lower(buf);
 
-      /* Check if this is a '.7z' file */
-      if (string_is_equal(buf, ".7z"))
-         return delim;
+         /* Check if this is a '.7z' file */
+         if (string_is_equal(buf, ".7z"))
+            return delim;
+      }
+
+      delim++;
+      delim = strchr(delim, '#');
    }
 
    return NULL;


### PR DESCRIPTION
## Description

As reported in #12476, RetroArch currently fails to load any compressed content whose filename contains `#` characters. This happens because the `path_get_archive_delim()` function does not work correctly:

- It identifies archive delimiters by searching the file path string backwards until it finds a `#`, and then checks whether this is preceded by an archive file extension...
- ...but it stops after the first search. So if a path-in-archive-file string looks like: `my archive.zip#file containing # characters.gb`, it will find  `# characters.gb`, identify that this is not an archive delimiter, and then give up. It never finds `zip#`, and so the path is not recognised as referring to a file *inside* an archive
- Any further handling of this misidentified path then breaks....

This PR fixes the issue by ensuring that `path_get_archive_delim()` searches exhaustively for all `#` characters in the input path string, until an archive delimiter is actually found.

## Related Issues

Closes #12476

