### PR TITLE
(D3D11+12) Allow fastforward in fullscreen

### DIFF
--- a/gfx/common/d3d12_common.c
+++ b/gfx/common/d3d12_common.c
@@ -315,10 +315,11 @@ bool d3d12_init_swapchain(d3d12_video_t* d3d12,
    desc.Windowed     = TRUE;
 #endif
 #if 0
-   desc.SwapEffect                         = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
+   desc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
 #else
    desc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
 #endif
+   desc.Flags      = DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;
 
 #ifdef __WINRT__
    hr = DXGICreateSwapChainForCoreWindow(d3d12->factory, d3d12->queue.handle, corewindow, &desc, NULL, &d3d12->chain.handle);

--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -679,6 +679,7 @@ static bool d3d11_init_swapchain(d3d11_video_t* d3d11,
 #else
    desc.SwapEffect                         = DXGI_SWAP_EFFECT_FLIP_DISCARD;
 #endif
+   desc.Flags                              = DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;
 
 #ifdef DEBUG
    flags                                  |= D3D11_CREATE_DEVICE_DEBUG;
@@ -1325,6 +1326,8 @@ static bool d3d11_gfx_frame(
    D3D11RenderTargetView rtv      = NULL;
    d3d11_video_t* d3d11           = (d3d11_video_t*)data;
    D3D11DeviceContext context     = d3d11->context;
+   bool vsync                     = d3d11->vsync;
+   unsigned present_flags         = (vsync) ? 0 : DXGI_PRESENT_ALLOW_TEARING;
    const char *stat_text          = video_info->stat_text;
    unsigned video_width           = video_info->width;
    unsigned video_height          = video_info->height;
@@ -1337,7 +1340,7 @@ static bool d3d11_gfx_frame(
 
    if (d3d11->resize_chain)
    {
-      DXGIResizeBuffers(d3d11->swapChain, 0, 0, 0, DXGI_FORMAT_UNKNOWN, 0);
+      DXGIResizeBuffers(d3d11->swapChain, 0, 0, 0, DXGI_FORMAT_UNKNOWN, DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING);
 
       d3d11->viewport.Width  = video_width;
       d3d11->viewport.Height = video_height;
@@ -1663,7 +1666,7 @@ static bool d3d11_gfx_frame(
    }
    d3d11->sprites.enabled = false;
 
-   DXGIPresent(d3d11->swapChain, !!d3d11->vsync, 0);
+   DXGIPresent(d3d11->swapChain, !!vsync, present_flags);
    Release(rtv);
 
    return true;

--- a/gfx/drivers/d3d12.c
+++ b/gfx/drivers/d3d12.c
@@ -1169,6 +1169,8 @@ static bool d3d12_gfx_frame(
    unsigned         i;
    d3d12_texture_t* texture       = NULL;
    d3d12_video_t*   d3d12         = (d3d12_video_t*)data;
+   bool vsync                     = d3d12->chain.vsync;
+   unsigned present_flags         = (vsync) ? 0 : DXGI_PRESENT_ALLOW_TEARING;
    const char *stat_text          = video_info->stat_text;
    bool statistics_show           = video_info->statistics_show;
    unsigned video_width           = video_info->width;
@@ -1189,7 +1191,7 @@ static bool d3d12_gfx_frame(
       for (i = 0; i < countof(d3d12->chain.renderTargets); i++)
          Release(d3d12->chain.renderTargets[i]);
 
-      DXGIResizeBuffers(d3d12->chain.handle, 0, 0, 0, DXGI_FORMAT_UNKNOWN, 0);
+      DXGIResizeBuffers(d3d12->chain.handle, 0, 0, 0, DXGI_FORMAT_UNKNOWN, DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING);
 
       for (i = 0; i < countof(d3d12->chain.renderTargets); i++)
       {
@@ -1612,7 +1614,7 @@ static bool d3d12_gfx_frame(
    D3D12ExecuteGraphicsCommandLists(d3d12->queue.handle, 1, &d3d12->queue.cmd);
 
 #if 1
-   DXGIPresent(d3d12->chain.handle, !!d3d12->chain.vsync, 0);
+   DXGIPresent(d3d12->chain.handle, !!vsync, present_flags);
 #else
    DXGI_PRESENT_PARAMETERS pp = { 0 };
    DXGIPresent1(d3d12->swapchain, 0, 0, &pp);


### PR DESCRIPTION
## Description

Simple flag additions for both drivers that are having the same problem. 

## Related Issues

Closes #12475 

