### PR TITLE
(D3D) Add common window title for D3D9+

### DIFF
--- a/gfx/common/win32_common.c
+++ b/gfx/common/win32_common.c
@@ -2378,3 +2378,22 @@ bool win32_window_init(WNDCLASSEX *wndclass,
    return true;
 }
 #endif
+
+void win32_update_title(void)
+{
+#ifndef _XBOX
+   const ui_window_t *window      = ui_companion_driver_get_window_ptr();
+
+   if (window)
+   {
+      char title[128];
+
+      title[0] = '\0';
+
+      video_driver_get_window_title(title, sizeof(title));
+
+      if (title[0])
+         window->set_title(&main_window, title);
+   }
+#endif
+}

--- a/gfx/common/win32_common.h
+++ b/gfx/common/win32_common.h
@@ -162,6 +162,8 @@ void win32_unset_input_userdata(void);
 
 void win32_set_input_userdata(void *data);
 
+void win32_update_title(void);
+
 RETRO_END_DECLS
 
 #endif

--- a/gfx/drivers/d3d10.c
+++ b/gfx/drivers/d3d10.c
@@ -1547,6 +1547,7 @@ static bool d3d10_gfx_frame(
    }
    d3d10->sprites.enabled = false;
 
+   win32_update_title();
    DXGIPresent(d3d10->swapChain, !!d3d10->vsync, 0);
 
    return true;

--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -1666,6 +1666,7 @@ static bool d3d11_gfx_frame(
    }
    d3d11->sprites.enabled = false;
 
+   win32_update_title();
    DXGIPresent(d3d11->swapChain, !!vsync, present_flags);
    Release(rtv);
 

--- a/gfx/drivers/d3d12.c
+++ b/gfx/drivers/d3d12.c
@@ -1613,6 +1613,7 @@ static bool d3d12_gfx_frame(
 
    D3D12ExecuteGraphicsCommandLists(d3d12->queue.handle, 1, &d3d12->queue.cmd);
 
+   win32_update_title();
 #if 1
    DXGIPresent(d3d12->chain.handle, !!vsync, present_flags);
 #else

--- a/gfx/drivers/d3d9.c
+++ b/gfx/drivers/d3d9.c
@@ -1492,25 +1492,6 @@ static void d3d9_get_overlay_interface(void *data,
 }
 #endif
 
-static void d3d9_update_title(void)
-{
-#ifndef _XBOX
-   const ui_window_t *window      = ui_companion_driver_get_window_ptr();
-
-   if (window)
-   {
-      char title[128];
-
-      title[0] = '\0';
-
-      video_driver_get_window_title(title, sizeof(title));
-
-      if (title[0])
-         window->set_title(&main_window, title);
-   }
-#endif
-}
-
 static bool d3d9_frame(void *data, const void *frame,
       unsigned frame_width, unsigned frame_height,
       uint64_t frame_count, unsigned pitch,
@@ -1638,7 +1619,7 @@ static bool d3d9_frame(void *data, const void *frame,
       d3d9_end_scene(d3d->dev);
    }
 
-   d3d9_update_title();
+   win32_update_title();
    d3d9_swap(d3d, d3d->dev);
 
    return true;


### PR DESCRIPTION
## Description

- Moved `d3d9_update_title()` to common `win32_update_title()`
- Added missing window titles for D3D10+

