### PR TITLE
Add support for core and directory overrides of switchres.ini files

### DIFF
--- a/gfx/video_crt_switch.h
+++ b/gfx/video_crt_switch.h
@@ -54,7 +54,6 @@ typedef struct videocrt_switch
 
    bool sr2_active;
    bool menu_active;
-   char* core_name;
    bool hh_core;
 
 


### PR DESCRIPTION
## Description

This pull request adds support for core and directory overrides of `switchres.ini` files. These files are used by the new SR2 SwitchRes functionality that was recently merged on [this PR](https://github.com/libretro/RetroArch/pull/12403) and updated on [this one](https://github.com/libretro/RetroArch/pull/12493). This was being developed and discussed over [this other PR](https://github.com/alphanu1/MME_SR2/pull/3) but is now being moved here directly since the SR2 functionality has been merged. Credits go to @alphanu1 for helping me get this implementation going.

The documentation for this feature has already been added to the recent [CRT SwitchRes guide](https://docs.libretro.com/guides/crtswitchres/) at the end, on the section "Core and directory overrides", where its usage is explained.

The justification for this additional feature is that some users might want to override certain settings, such as `user_mode` for specific systems. For example, the user might want to use NATIVE resolution for everything, but super resolutions for handheld cores, or have a fixed resolution for a particular system. The main reason the feature has been extended to directory overrides as well is that some cores support multiple systems. Discussions regarding this feature have concluded that per-game overrides are not useful and are possibly a misuse of SwitchRes, so that feature is not implemented nor planned.

## Related Pull Requests

[Recently merged PR for the new SR2 SwitchRes](https://github.com/libretro/RetroArch/pull/12403)
[Recently merged PR for SR2 updates, including the SwitchRes library dependency](https://github.com/libretro/RetroArch/pull/12493)
[Previously merged PR of the SwitchRes library, included in the above PR, that added some required functionality](https://github.com/antonioginer/switchres/pull/88)
[Original PR for this functionality while the SR2 one was not merged](https://github.com/alphanu1/MME_SR2/pull/3)

## Reviewers

People who have followed this implementation on the previous PR include @alphanu1 and @substring
