### PR TITLE
Shut up a string truncation warning

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -9740,7 +9740,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                {
                   if (!string_is_empty(cd_info.title))
                   {
-                     char title[256];
+                     char title[sizeof("Title: ")+sizeof(cd_info.title)];
                      snprintf(title, sizeof(title), "Title: %s", cd_info.title);
 
                      if (menu_entries_append_enum(info->list,


### PR DESCRIPTION
```
menu/menu_displaylist.c: In function ‘menu_displaylist_ctl’:
menu/menu_displaylist.c:9744:61: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size 249 [-Wformat-truncation=]
                      snprintf(title, sizeof(title), "Title: %s", cd_info.title);
                                                             ^~   ~~~~~~~
In file included from /usr/include/stdio.h:862:0,
                 from ./libretro-common/include/file/file_path.h:26,
                 from menu/menu_displaylist.c:27:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:64:10: note: ‘__builtin___snprintf_chk’ output between 8 and 263 bytes into a destination of size 256
   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        __bos (__s), __fmt, __va_arg_pack ());
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```