### PR TITLE
Fixing UWP builds

### DIFF
--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -1666,7 +1666,9 @@ static bool d3d11_gfx_frame(
    }
    d3d11->sprites.enabled = false;
 
+#if defined(_WIN32) && !defined(__WINRT__)
    win32_update_title();
+#endif
    DXGIPresent(d3d11->swapChain, !!vsync, present_flags);
    Release(rtv);
 

--- a/gfx/drivers/d3d12.c
+++ b/gfx/drivers/d3d12.c
@@ -1612,8 +1612,10 @@ static bool d3d12_gfx_frame(
    D3D12CloseGraphicsCommandList(d3d12->queue.cmd);
 
    D3D12ExecuteGraphicsCommandLists(d3d12->queue.handle, 1, &d3d12->queue.cmd);
-
+   
+#if defined(_WIN32) && !defined(__WINRT__)
    win32_update_title();
+#endif
 #if 1
    DXGIPresent(d3d12->chain.handle, !!vsync, present_flags);
 #else


### PR DESCRIPTION
## Description

UWP builds are broken

## Related Pull Requests

As described here: https://github.com/libretro/RetroArch/commit/caf3f3dadd30f0f7e9ad975b2a6101d5713b6641#commitcomment-51813931

The above commit broke UWP builds, that small fix here makes UWP buildable again

## Reviewers
@twinaphex 
