### PR TITLE
Fix '--disable-crtswitchres' configure option

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -2274,7 +2274,7 @@ ifeq ($(HAVE_FFMPEG), 1)
 endif
 
 # CRT mode switching
-ifeq ($(HAVE_SR2), 1)
+ifeq ($(HAVE_CRTSWITCHRES), 1)
    INCLUDE_DIRS += -I$(DEPS_DIR)/switchres
    OBJ += gfx/video_crt_switch.o \
           $(DEPS_DIR)/switchres/monitor.o \

--- a/griffin/griffin.c
+++ b/griffin/griffin.c
@@ -971,7 +971,9 @@ MIDI
 /*============================================================
 DRIVERS
 ============================================================ */
-/*#include "../gfx/video_crt_switch.c" */
+#ifdef HAVE_CRTSWITCHRES
+#include "../gfx/video_crt_switch.c"
+#endif
 #include "../gfx/gfx_animation.c"
 #include "../gfx/gfx_display.c"
 #include "../gfx/gfx_thumbnail_path.c"

--- a/qb/config.params.sh
+++ b/qb/config.params.sh
@@ -195,5 +195,5 @@ HAVE_ODROIDGO2=no          # ODROID-GO Advance rotation support (requires librga
 HAVE_LIBSHAKE=no           # libShake haptic feedback support
 HAVE_CHECK=no              # check support for unit tests
 HAVE_WIFI=no               # wifi driver support
-HAVE_CRTSWITCHRES=auto     # CRT mode switching support
+HAVE_CRTSWITCHRES=yes      # CRT mode switching support
 C89_CRTSWITCHRES=no

--- a/retroarch_data.h
+++ b/retroarch_data.h
@@ -1719,9 +1719,9 @@ struct rarch_state
    double audio_source_ratio_original;
    double audio_source_ratio_current;
    struct retro_system_av_info video_driver_av_info; /* double alignment */
-   #ifdef HAVE_SR2
+#ifdef HAVE_CRTSWITCHRES
    videocrt_switch_t crt_switch_st;                  /* double alignment */
-   #endif
+#endif
    retro_time_t frame_limit_minimum_time;
    retro_time_t frame_limit_last_time;
    retro_time_t libretro_core_runtime_last;
@@ -2254,7 +2254,6 @@ struct rarch_state
    bool video_driver_state_out_rgb32;
 #endif
    bool video_driver_crt_switching_active;
-   bool video_driver_crt_dynamic_super_width;
    bool video_driver_threaded;
 
    bool video_started_fullscreen;


### PR DESCRIPTION
## Description

At present, the `--disable-crtswitchres` configure flag is ignored (CRT swtichres support is always enabled). This PR fixes the option, and also performs some (very) minor clean ups.