### PR TITLE
Allow the 8 analog stick directions to be used as keys for core keyboard mappings

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -4664,9 +4664,12 @@ bool input_remapping_load_file(void *data, const char *path)
          else
          {
             char stk_ident[128];
+            char key_ident[128];
             int stk_remap = -1;
+            int key_remap = -1;
             
             stk_ident[0]  = '\0';
+            key_ident[0]  = '\0';
 
             fill_pathname_join_delim(stk_ident, s3,
                   key_string, '$', sizeof(stk_ident));
@@ -4685,6 +4688,15 @@ bool input_remapping_load_file(void *data, const char *path)
                configuration_set_uint(settings,
                      settings->uints.input_remap_ids[i][j], stk_remap);
             }
+
+            fill_pathname_join_delim(key_ident, s2,
+                  key_string, '_', sizeof(key_ident));
+
+            if (!config_get_int(conf, key_ident, &key_remap))
+               key_remap = RETROK_UNKNOWN;
+
+            configuration_set_uint(settings,
+                  settings->uints.input_keymapper_ids[i][j], key_remap);
          }
       }
 
@@ -4782,6 +4794,7 @@ bool input_remapping_save_file(const char *path)
       {
          char stk_ident[128];
          unsigned remap_id      = settings->uints.input_remap_ids[i][j];
+         unsigned keymap_id     = settings->uints.input_keymapper_ids[i][j];
          const char *key_string = key_strings[j];
          stk_ident[0]           = '\0';
          fill_pathname_join_delim(stk_ident, s3,
@@ -4797,6 +4810,16 @@ bool input_remapping_save_file(const char *path)
             else
                config_set_int(conf, stk_ident,
                      settings->uints.input_remap_ids[i][j]);
+         }
+
+         if (keymap_id != RETROK_UNKNOWN)
+         {
+            char key_ident[128];
+            key_ident[0] = '\0';
+            fill_pathname_join_delim(key_ident, s2,
+                  key_string, '_', sizeof(key_ident));
+            config_set_int(conf, key_ident,
+                  settings->uints.input_keymapper_ids[i][j]);
          }
       }
 

--- a/menu/cbs/menu_cbs_get_value.c
+++ b/menu/cbs/menu_cbs_get_value.c
@@ -761,8 +761,8 @@ static void menu_action_setting_disp_set_label_input_desc_kbd(
    if (!settings)
       return;
 
-   user_idx = (type - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN) / RARCH_FIRST_CUSTOM_BIND;
-   btn_idx  = (type - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN) - RARCH_FIRST_CUSTOM_BIND * user_idx;
+   user_idx = (type - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN) / RARCH_ANALOG_BIND_LIST_END;
+   btn_idx  = (type - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN) - RARCH_ANALOG_BIND_LIST_END * user_idx;
    remap_id =
       settings->uints.input_keymapper_ids[user_idx][btn_idx];
 

--- a/menu/cbs/menu_cbs_left.c
+++ b/menu/cbs/menu_cbs_left.c
@@ -194,8 +194,8 @@ static int action_left_input_desc_kbd(unsigned type, const char *label,
    if (!settings)
       return 0;
 
-   user_idx = (type - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN) / RARCH_FIRST_CUSTOM_BIND;
-   btn_idx  = (type - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN) - RARCH_FIRST_CUSTOM_BIND * user_idx;
+   user_idx = (type - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN) / RARCH_ANALOG_BIND_LIST_END;
+   btn_idx  = (type - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN) - RARCH_ANALOG_BIND_LIST_END * user_idx;
 
    remap_id =
       settings->uints.input_keymapper_ids[user_idx][btn_idx];

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -6572,9 +6572,9 @@ static int action_ok_push_dropdown_item_input_description_kbd(
 
    /* Determine user/button indices */
    user_idx = (entry_type - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN) 
-      / RARCH_FIRST_CUSTOM_BIND;
+      / RARCH_ANALOG_BIND_LIST_END;
    btn_idx  = (entry_type - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN) 
-      - RARCH_FIRST_CUSTOM_BIND * user_idx;
+      - RARCH_ANALOG_BIND_LIST_END * user_idx;
 
    if ((user_idx >= MAX_USERS) || (btn_idx >= RARCH_CUSTOM_BIND_LIST_END))
       return menu_cbs_exit();

--- a/menu/cbs/menu_cbs_right.c
+++ b/menu/cbs/menu_cbs_right.c
@@ -149,8 +149,8 @@ static int action_right_input_desc_kbd(unsigned type, const char *label,
    if (!settings)
       return 0;
 
-   user_idx = (type - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN) / RARCH_FIRST_CUSTOM_BIND;
-   btn_idx  = (type - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN) - RARCH_FIRST_CUSTOM_BIND * user_idx;
+   user_idx = (type - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN) / RARCH_ANALOG_BIND_LIST_END;
+   btn_idx  = (type - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN) - RARCH_ANALOG_BIND_LIST_END * user_idx;
 
    remap_id =
       settings->uints.input_keymapper_ids[user_idx][btn_idx];

--- a/menu/cbs/menu_cbs_start.c
+++ b/menu/cbs/menu_cbs_start.c
@@ -230,8 +230,8 @@ static int action_start_input_desc_kbd(
    if (!settings)
       return 0;
 
-   user_idx = (type - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN) / RARCH_FIRST_CUSTOM_BIND;
-   btn_idx  = (type - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN) - RARCH_FIRST_CUSTOM_BIND * user_idx;
+   user_idx = (type - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN) / RARCH_ANALOG_BIND_LIST_END;
+   btn_idx  = (type - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN) - RARCH_ANALOG_BIND_LIST_END * user_idx;
 
    if ((user_idx >= MAX_USERS) || (btn_idx >= RARCH_CUSTOM_BIND_LIST_END))
       return 0;

--- a/menu/cbs/menu_cbs_sublabel.c
+++ b/menu/cbs/menu_cbs_sublabel.c
@@ -1138,7 +1138,7 @@ static int action_bind_sublabel_remap_kbd_sublabel(
       const char *label, const char *path,
       char *s, size_t len)
 {
-   unsigned user_idx = (type - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN) / RARCH_FIRST_CUSTOM_BIND;
+   unsigned user_idx = (type - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN) / RARCH_ANALOG_BIND_LIST_END;
 
    snprintf(s, len, "%s #%d: %s",
          msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PORT),

--- a/menu/drivers/ozone/ozone_texture.c
+++ b/menu/drivers/ozone/ozone_texture.c
@@ -518,17 +518,11 @@ uintptr_t ozone_entries_icon_get_texture(ozone_handle_t *ozone,
          {
             /* Quickmenu controls repeats the same icons for all users*/
             if (type < MENU_SETTINGS_INPUT_DESC_KBD_BEGIN)
-            {
                input_id = MENU_SETTINGS_INPUT_DESC_BEGIN;
-               while (type > (input_id + 23))
-                  input_id = (input_id + 24);
-            }
             else
-            {
                input_id = MENU_SETTINGS_INPUT_DESC_KBD_BEGIN;
-               while (type > (input_id + 15))
-                  input_id = (input_id + 16);
-            }
+            while (type > (input_id + 23))
+               input_id = (input_id + 24);
 
             /* Human readable bind order */
             if (type < (input_id + RARCH_ANALOG_BIND_LIST_END))

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -2963,17 +2963,11 @@ static uintptr_t xmb_icon_get_id(xmb_handle_t *xmb,
          {
             /* Quickmenu controls repeats the same icons for all users */
             if (type < MENU_SETTINGS_INPUT_DESC_KBD_BEGIN)
-            {
                input_id = MENU_SETTINGS_INPUT_DESC_BEGIN;
-               while (type > (input_id + 23))
-                  input_id = (input_id + 24);
-            }
             else
-            {
                input_id = MENU_SETTINGS_INPUT_DESC_KBD_BEGIN;
-               while (type > (input_id + 15))
-                  input_id = (input_id + 16);
-            }
+            while (type > (input_id + 23))
+               input_id = (input_id + 24);
 
             /* Human readable bind order */
             if (type < (input_id + RARCH_ANALOG_BIND_LIST_END))

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -4626,8 +4626,8 @@ static int menu_displaylist_parse_input_description_kbd_list(
       goto end;
 
    /* Determine user/button indices */
-   user_idx = (info->type - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN) / RARCH_FIRST_CUSTOM_BIND;
-   btn_idx  = (info->type - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN) - RARCH_FIRST_CUSTOM_BIND * user_idx;
+   user_idx = (info->type - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN) / RARCH_ANALOG_BIND_LIST_END;
+   btn_idx  = (info->type - MENU_SETTINGS_INPUT_DESC_KBD_BEGIN) - RARCH_ANALOG_BIND_LIST_END * user_idx;
 
    if ((user_idx >= MAX_USERS) || (btn_idx >= RARCH_CUSTOM_BIND_LIST_END))
       goto end;
@@ -9634,7 +9634,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                }
                else if (device == RETRO_DEVICE_KEYBOARD)
                {
-                  for (j = 0; j < RARCH_FIRST_CUSTOM_BIND; j++)
+                  for (j = 0; j < RARCH_ANALOG_BIND_LIST_END; j++)
                   {
                      char desc_label[400];
                      char descriptor[300];
@@ -9679,7 +9679,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                      if (menu_entries_append_enum(list, descriptor, info->path,
                               MSG_UNKNOWN,
                               MENU_SETTINGS_INPUT_DESC_KBD_BEGIN +
-                              (p * RARCH_FIRST_CUSTOM_BIND) + retro_id, 0, 0))
+                              (p * RARCH_ANALOG_BIND_LIST_END) + retro_id, 0, 0))
                         count++;
                   }
                }

--- a/retroarch.c
+++ b/retroarch.c
@@ -22595,8 +22595,18 @@ static void input_driver_poll(void)
                   if (remap_key == RETROK_UNKNOWN)
                      continue;
 
-                  current_button_value =
-                     BIT256_GET_PTR(p_new_state, j);
+                  if (j >= RARCH_FIRST_CUSTOM_BIND && j < RARCH_ANALOG_BIND_LIST_END)
+                  {
+                     int16_t current_axis_value = p_new_state->analogs[j - RARCH_FIRST_CUSTOM_BIND];
+                     current_button_value = abs(current_axis_value) >
+                           p_rarch->input_driver_axis_threshold
+                            * 32767;
+                  }
+                  else
+                  {
+                     current_button_value =
+                        BIT256_GET_PTR(p_new_state, j);
+                  }
 
 #ifdef HAVE_OVERLAY
                   if (poll_overlay && i == 0)


### PR DESCRIPTION
## Description
This PR adds the 8 analog stick directions to the list of inputs when a controller port is set to a device with type type RETRO_DEVICE_KEYBOARD. As far as I know mostly computer cores use this device type.

So before this PR only buttons on the gamepad could be mapped to keyboard keys. With this PR there are 8 more keys that can be set to the stick directions giving players more options for playing complex computer games with a gamepad.

This came from a request on schellingb/dosbox-pure#164

I did test this PR with all menu drivers and loading/saving of remap files and it all seems to work great. But I would prefer if someone who knows the RetroArch input system a bit could go over the code changes before merging. All I did was search for `RETRO_DEVICE_KEYBOARD` and `MENU_SETTINGS_INPUT_DESC_KBD_BEGIN` and try to extend it to include the sticks as well without touching too much.

## Reviewers
@jdgleaver maybe?