### PR TITLE
Fix frame delay limit in conf read

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -296,6 +296,7 @@
  * Can reduce latency at cost of higher risk of stuttering.
  */
 #define DEFAULT_FRAME_DELAY 0
+#define MAXIMUM_FRAME_DELAY 19
 
 /* Inserts black frame(s) inbetween frames.
  * Useful for Higher Hz monitors (set to multiples of 60 Hz) who want to play 60 Hz 

--- a/configuration.c
+++ b/configuration.c
@@ -3280,8 +3280,8 @@ static bool config_load_file(global_t *global,
    if (settings->uints.video_hard_sync_frames > 3)
       settings->uints.video_hard_sync_frames = 3;
 
-   if (settings->uints.video_frame_delay > 15)
-      settings->uints.video_frame_delay = 15;
+   if (settings->uints.video_frame_delay > MAXIMUM_FRAME_DELAY)
+      settings->uints.video_frame_delay = MAXIMUM_FRAME_DELAY;
 
    settings->uints.video_swap_interval = MAX(settings->uints.video_swap_interval, 1);
    settings->uints.video_swap_interval = MIN(settings->uints.video_swap_interval, 4);

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -11496,7 +11496,7 @@ static bool setting_append_list(
                   general_write_handler,
                   general_read_handler);
             (*list)[list_info->index - 1].action_ok = &setting_action_ok_uint;
-            menu_settings_list_current_add_range(list, list_info, 0, 19, 1, true, true);
+            menu_settings_list_current_add_range(list, list_info, 0, MAXIMUM_FRAME_DELAY, 1, true, true);
             SETTINGS_DATA_LIST_CURRENT_ADD_FLAGS(list, list_info, SD_FLAG_LAKKA_ADVANCED);
 
             /* Unlike all other shader-related menu entries


### PR DESCRIPTION
## Description

The previous frame delay PR did not notice that there was a limit in `configuration.c` too, affecting startup configuration, oops..