### PR TITLE
[Android input driver] do not duplicate port 0 mouse and gun inputs to other ports

### DIFF
--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -1407,6 +1407,7 @@ static int16_t android_input_state(
       case RETRO_DEVICE_MOUSE:
          {
             int val = 0;
+            if(port > 0) return 0; /* TODO: implement mouse for additional ports/players */
             switch (id)
             {
                case RETRO_DEVICE_ID_MOUSE_LEFT:
@@ -1439,6 +1440,7 @@ static int16_t android_input_state(
       case RETRO_DEVICE_LIGHTGUN:
          {
             int val = 0;
+            if(port > 0) return 0; /* TODO: implement lightgun for additional ports/players */
             switch (id)
             {
                case RETRO_DEVICE_ID_LIGHTGUN_X:


### PR DESCRIPTION
At present, the Android input driver is limited to supporting a single mouse and a single lightgun. The most immediate bug is that rather than returning 0 for ports above the first one for the mouse, lightgun, and screen, the Android input driver returns the input polling for the first port always. This bug results in the first port's input to be duplicated to additional ports/users.

I would like to implement support for additional mice and lightguns next, but this at least will solve the immediate bug. It addresses this issue: https://github.com/libretro/RetroArch/issues/12495

I would be glad to test this on Android, but I would need help building it, for example by creating a branch in the RA repository so that gitlab will build this code.