### PR TITLE
Make alsathread default for all alsa devices with threads.

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -341,7 +341,7 @@ static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_CTR;
 static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_SWITCH;
 #elif defined(HAVE_PULSE)
 static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_PULSE;
-#elif defined(HAVE_ALSA) && defined(HAVE_VIDEOCORE)
+#elif defined(HAVE_ALSA) && defined(HAVE_THREADS)
 static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_ALSATHREAD;
 #elif defined(HAVE_ALSA)
 static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_ALSA;


### PR DESCRIPTION
## Description

The threaded ALSA audio driver seems to be provide performance boosts over the default ALSA audio driver. In the case of duckstation, this can be quite drastic. This has been seen on x86, Raspberry Pi 3 and 4.

The current check for `HAVE_VIDEOCORE` only defaults it for pre-4 Raspberry Pis, but it seems like this should be the default for ALL `HAVE_ALSA` devices (with `HAVE_THREADS`, that is).

I am not aware of any drawbacks to alsathread vs alsa, but I am not familiar with the drivers, other than the performance difference. It would be good to get this reviewed by someone who is!

Tested on Raspberry Pi 4.

## Reviewers

@jdgleaver 
