### PR TITLE
(Dingux) Fix black screens when triggering gfx driver initialisation via menu actions

### DIFF
--- a/gfx/drivers/sdl_dingux_gfx.c
+++ b/gfx/drivers/sdl_dingux_gfx.c
@@ -761,7 +761,7 @@ static bool sdl_dingux_gfx_frame(void *data, const void *frame,
 {
    sdl_dingux_video_t* vid = (sdl_dingux_video_t*)data;
 
-   if (unlikely(!vid || !frame))
+   if (unlikely(!vid))
       return true;
 
    /* If fast forward is currently active, we may
@@ -805,13 +805,16 @@ static bool sdl_dingux_gfx_frame(void *data, const void *frame,
 
       if (likely(vid->mode_valid))
       {
-         /* Blit frame to SDL surface */
-         if (vid->rgb32)
-            sdl_dingux_blit_frame32(vid, (uint32_t*)frame,
-                  width, height, pitch);
-         else
-            sdl_dingux_blit_frame16(vid, (uint16_t*)frame,
-                  width, height, pitch);
+         if (likely(frame))
+         {
+            /* Blit frame to SDL surface */
+            if (vid->rgb32)
+               sdl_dingux_blit_frame32(vid, (uint32_t*)frame,
+                     width, height, pitch);
+            else
+               sdl_dingux_blit_frame16(vid, (uint16_t*)frame,
+                     width, height, pitch);
+         }
       }
       /* If current display mode is invalid,
        * just display an error message */


### PR DESCRIPTION
## Description

It turns out that PR #12380 inadvertently broke the OpenDingux port.

Previously, the `frame` buffer passed to the video driver's `frame()` function was always valid, but the modification to `video_driver_set_cached_frame_ptr()` in PR #12380 means that the cached frame (drawn when the menu is active while content is running) can be nullified.

The `sdl_dingux` gfx driver returns early (drawing nothing) if the input `frame` buffer is `NULL` - this was never an issue before, but now that the cached frame *can* be set to NULL, the user will get stuck on a black screen whenever this happens. The most obvious instance of this is when a gfx driver reinit is triggered via a menu action while content is running - e.g. if the user attempts to set or clear a video filter while content is running, they will be left with no display until the quick menu is next toggled off.

This PR fixes the problem by modifying the `sdl_dingux` gfx driver to handle `NULL` `frame` buffers in more robust fashion.