### PR TITLE
(Ozone) Ensure sidebar display status is updated correctly when performing rapid menu navigation

### DIFF
--- a/menu/drivers/ozone/ozone.h
+++ b/menu/drivers/ozone/ozone.h
@@ -298,6 +298,7 @@ struct ozone_handle
    bool cursor_mode;
    bool sidebar_collapsed;
    bool show_thumbnail_bar;
+   bool pending_hide_thumbnail_bar;
    bool fullscreen_thumbnails_available;
    bool show_fullscreen_thumbnails;
    bool selection_core_is_viewer;

--- a/menu/drivers/ozone/ozone_sidebar.c
+++ b/menu/drivers/ozone/ozone_sidebar.c
@@ -752,6 +752,7 @@ void ozone_refresh_sidebars(
       ozone->animations.thumbnail_bar_position = 0.0f;
       ozone->show_thumbnail_bar                = false;
    }
+   ozone->pending_hide_thumbnail_bar           = false;
 
    /* If sidebar is on-screen, update scroll position */
    if (ozone->depth == 1)


### PR DESCRIPTION
## Description

As explained in #12510, navigating rapidly between menu levels in Ozone can cause the left sidebar to disappear. A similar issue affects the thumbnail bar. In both cases, this is due to the mishandling of a mid-animation state change:

- For the left sidebar, existing slide-in/out animations are not killed before triggering a new one. This means the callback for an obsolete slide-out animation (which disables the left sidebar) can occur *after* the next slide-in animation has started - causing breakage of the final menu state
- For the thumbnail bar, existing show/hide animations *are* killed before triggering a new one - but this means the 'hide' callback (which updates the current 'show' status) never fires if a 'show' is triggered while the 'hide' animation is running. The 'show' animation will only take effect if the thumbnail bar is currently hidden - so if the cancelled 'hide' has left the menu in the wrong state, the next 'show' will fail

This PR fixes both issues.

## Related Issues

Closes #12510