### PR TITLE
(XAudio+DSound) Fail instead of crash

### DIFF
--- a/audio/drivers/dsound.c
+++ b/audio/drivers/dsound.c
@@ -546,7 +546,8 @@ static ssize_t dsound_write(void *data, const void *buf_, size_t size)
             break;
 
          if (avail == 0)
-            WaitForSingleObject(ds->event, INFINITE);
+            if (!(WaitForSingleObject(ds->event, 50) == WAIT_OBJECT_0))
+               return -1;
       }
    }
 

--- a/audio/drivers/xaudio.c
+++ b/audio/drivers/xaudio.c
@@ -371,7 +371,8 @@ static ssize_t xa_write(void *data, const void *buf, size_t size)
          XAUDIO2_BUFFER xa2buffer;
 
          while (handle->buffers == MAX_BUFFERS - 1)
-            WaitForSingleObject(handle->hEvent, INFINITE);
+            if (!(WaitForSingleObject(handle->hEvent, 50) == WAIT_OBJECT_0))
+               return -1;
 
          xa2buffer.Flags      = 0;
          xa2buffer.AudioBytes = handle->bufsize;


### PR DESCRIPTION
## Description

Graceful failure instead of crashing for xaudio+dsound. Settled to timeout of 50 because dsound did not work at all with 20.

## Related Issues

Closes #10571 

