### PR TITLE
Fix Encore Mode on Github, minor English change

### DIFF
--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -1443,7 +1443,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_CRT_SWITCH_HIRES_MENU,
-   "Switch to high resolution modeline when no content is loaded for use with high-resolution menus."
+   "Switch to high resolution modeline for use with high-resolution menus when no content is loaded."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_CRT_SWITCH_RESOLUTION_USE_CUSTOM_REFRESH_RATE,
@@ -4980,7 +4980,7 @@ MSG_HASH(
    MENU_ENUM_SUBLABEL_CHEEVOS_AUTO_SCREENSHOT,
    "Automatically take a screenshot when an achievement is earned."
    )
-MSG_HASH( /* suggestion for translators: translate as "Play Again Mode" */
+MSG_HASH( /* suggestion for translators: translate as 'Play Again Mode' */
    MENU_ENUM_LABEL_VALUE_CHEEVOS_START_ACTIVE,
    "Encore Mode"
    )


### PR DESCRIPTION
## Description

 - Fixes the Encore Mode string being misread by the Crowdin scripts.
 - Minor change on MENU_ENUM_SUBLABEL_CRT_SWITCH_HIRES_MENU's structure (by @DisasterMo, he asked me to do so).

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

The second change attempts to improve https://github.com/libretro/RetroArch/pull/12526 .

## Reviewers

@DisasterMo 