### PR TITLE
(gfx/d3d11) Don't use allow tearing flag with blit swap chains (1.9.5 regression)

### DIFF
--- a/gfx/common/d3d11_common.h
+++ b/gfx/common/d3d11_common.h
@@ -2547,6 +2547,7 @@ typedef struct
    bool                  resize_render_targets;
    bool                  init_history;
    bool                  has_flip_model;
+   bool                  has_allow_tearing;
    d3d11_shader_t        shaders[GFX_MAX_SHADERS];
 #ifdef __WINRT__
    DXGIFactory2 factory;


### PR DESCRIPTION
This is a regression from 1.9.5.

When falling back to blit swap chains, the create tearing flag was being set, which caused it to fail. This would happen on Windows 7 systems, as well as older drivers on Windows 10.

The driver also was not checking whether the flag was supported before trying to use it, resulting in failed present and resize calls.

Lastly, this PR also disables the flip model if the allow tearing flag is not supported. Since we want to present at more than 2x the vsync rate for fast forwarding, it's not much use having flip model if we can't run at an uncapped frame rate.