### PR TITLE
only add mouse if it has buttons and add vebose device friendly names

### DIFF
--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -1060,7 +1060,7 @@ static int16_t udev_input_state(
                      (binds[port][id].key < RETROK_LAST) && 
                      udev_keyboard_pressed(udev, binds[port][id].key)
                      && ((    id == RARCH_GAME_FOCUS_TOGGLE) 
-                        && !keyboard_mapping_blocked)
+                        || !keyboard_mapping_blocked)
                      )
                   return 1;
                else if (udev_mouse_button_pressed(udev, port,

--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -1060,7 +1060,7 @@ static int16_t udev_input_state(
                      (binds[port][id].key < RETROK_LAST) && 
                      udev_keyboard_pressed(udev, binds[port][id].key)
                      && ((    id == RARCH_GAME_FOCUS_TOGGLE) 
-                        || !keyboard_mapping_blocked)
+                        && !keyboard_mapping_blocked)
                      )
                   return 1;
                else if (udev_mouse_button_pressed(udev, port,

--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -1060,14 +1060,13 @@ static int16_t udev_input_state(
                      (binds[port][id].key < RETROK_LAST) && 
                      udev_keyboard_pressed(udev, binds[port][id].key)
                      && ((    id != RARCH_GAME_FOCUS_TOGGLE) 
-                        || !keyboard_mapping_blocked)
+                        && !keyboard_mapping_blocked)
                      )
                   return 1;
                else if ( 
                      (binds[port][id].key < RETROK_LAST) && 
                      udev_keyboard_pressed(udev, binds[port][id].key)
-                     && ((    id == RARCH_GAME_FOCUS_TOGGLE) 
-                        || !keyboard_mapping_blocked)
+                     && (    id == RARCH_GAME_FOCUS_TOGGLE)
                      )
                   return 1;
                else if (udev_mouse_button_pressed(udev, port,

--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -1059,6 +1059,13 @@ static int16_t udev_input_state(
                if ( 
                      (binds[port][id].key < RETROK_LAST) && 
                      udev_keyboard_pressed(udev, binds[port][id].key)
+                     && ((    id != RARCH_GAME_FOCUS_TOGGLE) 
+                        || !keyboard_mapping_blocked)
+                     )
+                  return 1;
+               else if ( 
+                     (binds[port][id].key < RETROK_LAST) && 
+                     udev_keyboard_pressed(udev, binds[port][id].key)
                      && ((    id == RARCH_GAME_FOCUS_TOGGLE) 
                         || !keyboard_mapping_blocked)
                      )


### PR DESCRIPTION
Udev is adding two devices per mice this fixes that issue there is also no udev logging when a device is added that was removed at some point. Ive also added the device friendly name to the logging. Note I do have two mice and keyboards plugged in for testing. 

```
[INFO] [udev]: Added Device Keyboard Telink Wireless Receiver (/dev/input/event7).
[INFO] [udev]: Added Device Keyboard AT Translated Set 2 keyboard (/dev/input/event3).
[INFO] [udev]: Added Device Mouse Telink Wireless Receiver Mouse (/dev/input/event4).
[INFO] [udev]: Added Device Mouse ETPS/2 Elantech Touchpad (/dev/input/event10).
```

also fixed game focus mode in udev not working. I looked at dinput driver for windows seems like it will need updated as well is using the same logic that didnt work on this driver.