### PR TITLE
Move MENU_ENUM_LABEL_VALUE_ACHIEVEMENT_PAUSE_MENU to lbl.h

### DIFF
--- a/intl/msg_hash_lbl.h
+++ b/intl/msg_hash_lbl.h
@@ -23,6 +23,10 @@ MSG_HASH(
    "retro_achievements"
    )
 MSG_HASH(
+   MENU_ENUM_LABEL_VALUE_ACHIEVEMENT_PAUSE_MENU,
+   "toggle_cheevos_hardcore"
+   )
+MSG_HASH(
    MENU_ENUM_LABEL_ACCOUNTS_TWITCH,
    "twitch"
    )
@@ -3641,10 +3645,6 @@ MSG_HASH(
 MSG_HASH(
    MSG_DISCONNECT_DEVICE_FROM_A_VALID_PORT,
    "disconnect_device_from_a_valid_port"
-   )
-MSG_HASH(
-   MSG_FAILED_TO_SET_DISK,
-   "Failed to set disk"
    )
 MSG_HASH(
    MSG_FAILED_TO_START_AUDIO_DRIVER,

--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -7099,10 +7099,6 @@ MSG_HASH(
    "No Achievements to Display"
    )
 MSG_HASH(
-   MENU_ENUM_LABEL_VALUE_ACHIEVEMENT_PAUSE_MENU,
-   "ToggleCheevosHardcore" /* not-displayed - needed to resolve submenu */
-   )
-MSG_HASH(
    MENU_ENUM_LABEL_VALUE_ACHIEVEMENT_PAUSE_CANCEL,
    "Cancel Pause Achievements Hardcore Mode"
    )


### PR DESCRIPTION
## Description

So, good news: the updated python scripts (#12532) were useful, the GitHub -> Crowdin sync completely ignores commets now.
Bad news: the string that verified this was located in the wrong file - it is not meant to be translated.

I moved the MENU_ENUM_LABEL_VALUE_ACHIEVEMENT_PAUSE_MENU key & text to lbl.h and changed the text to fit the rest of them better. Also removed a useless double.
