### PR TITLE
(XMB) Icon opacity fix

### DIFF
--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -5156,7 +5156,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
          size_t x_pos      = xmb->icon_size / 6;
          size_t x_pos_icon = xmb->margins_title_left;
 
-         if (xmb_coord_white[3] != 0 &&  !xmb->assets_missing)
+         if (!xmb->assets_missing)
          {
             if (dispctx && dispctx->blend_begin)
                dispctx->blend_begin(userdata);
@@ -5207,7 +5207,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
       char timedate[255];
       int x_pos = 0;
 
-      if (xmb_coord_white[3] != 0 && !xmb->assets_missing)
+      if (!xmb->assets_missing)
       {
          int x_pos = 0;
 
@@ -5261,7 +5261,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
    gfx_display_set_alpha(item_color,
          MIN(xmb->textures_arrow_alpha, xmb->alpha));
 
-   if (xmb_coord_white[3] != 0 && !xmb->assets_missing)
+   if (!xmb->assets_missing)
    {
       if (dispctx && dispctx->blend_begin)
          dispctx->blend_begin(userdata);


### PR DESCRIPTION
## Description

Some icons are not there when `menu_wallpaper_opacity` is 0, such as the clock in the upper right corner and the main menu submenu arrow:

![retroarch_2021_06_21_16_16_23_644](https://user-images.githubusercontent.com/45124675/122801840-50c2bb80-d2cd-11eb-948f-e074500f8c73.png)

![retroarch_2021_06_21_16_16_28_132](https://user-images.githubusercontent.com/45124675/122801858-54eed900-d2cd-11eb-8a5a-619e597c7357.png)




All appears well with these small cuts. Any ideas what those removed parts are exactly trying to accomplish..?