### PR TITLE
(d3d11) Fix non-vsynced output without flip, black screens in fullscreen

### DIFF
--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -1611,9 +1611,8 @@ static bool d3d11_gfx_frame(
       D3D11SetPShaderSamplers(
             context, 0, 1, &d3d11->samplers[RARCH_FILTER_UNSPEC][RARCH_WRAP_DEFAULT]);
       D3D11SetVShaderConstantBuffers(context, 0, 1, &d3d11->frame.ubo);
+      D3D11Draw(context, 4, 0);
    }
-
-   D3D11Draw(context, 4, 0);
 
    D3D11SetRasterizerState(context, d3d11->scissor_enabled);
    D3D11SetScissorRects(d3d11->context, 1, &d3d11->scissor);

--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -1370,8 +1370,7 @@ static bool d3d11_gfx_frame(
    d3d11_video_t* d3d11           = (d3d11_video_t*)data;
    D3D11DeviceContext context     = d3d11->context;
    bool vsync                     = d3d11->vsync;
-   /* TODO/FIXME - setting the conditional to (vsync || !d3d11->has_allow_tearing) causes a black screen on startup in fullscreen mode */
-   unsigned present_flags         = (vsync) ? 0 : DXGI_PRESENT_ALLOW_TEARING;
+   unsigned present_flags         = (vsync || !d3d11->has_allow_tearing) ? 0 : DXGI_PRESENT_ALLOW_TEARING;
    const char *stat_text          = video_info->stat_text;
    unsigned video_width           = video_info->width;
    unsigned video_height          = video_info->height;

--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -766,7 +766,18 @@ static bool d3d11_init_swapchain(d3d11_video_t* d3d11,
                   &desc, (IDXGISwapChain**)&d3d11->swapChain)))
          return false;
    }
+
+#ifdef HAVE_WINDOW
+   /* Don't let DXGI mess with the full screen state, because otherwise we end up with a mismatch
+    * between the window size and the buffers. RetroArch only uses windowed mode (see above). */
+   if (FAILED(dxgiFactory->lpVtbl->MakeWindowAssociation(dxgiFactory, desc.OutputWindow,
+                                                         DXGI_MWA_NO_ALT_ENTER)))
+   {
+      RARCH_ERR("[D3D11]: Failed to make disable DXGI ALT+ENTER handling.\n");
+   }
 #endif
+
+#endif    // __WINRT__
 
    dxgiFactory->lpVtbl->Release(dxgiFactory);
    adapter->lpVtbl->Release(adapter);

--- a/gfx/gfx_display.c
+++ b/gfx/gfx_display.c
@@ -1055,6 +1055,8 @@ void gfx_display_draw_cursor(
    draw.texture         = texture;
    draw.prim_type       = GFX_DISPLAY_PRIM_TRIANGLESTRIP;
    draw.pipeline_id     = 0;
+   draw.scale_factor    = 1.0f;
+   draw.rotation        = 0.0f;
 
    if (dispctx->blend_begin)
       dispctx->blend_begin(userdata);


### PR DESCRIPTION
Few changes here:

1. Initializes scale/rotation in `gfx_display_draw_cursor`

This was causing black screens in fullscreen when the cursor was enabled, most noticeable in debug builds, since it was pulling from uninitialized memory which resulted in the cursor being drawn over the entire viewport (and beyond). This only affected D3D11 because the other drivers don't seem to use this field...

2. Disables DXGI's ALT+ENTER handling for desktop builds.

RetroArch does not use exclusive fullscreen in desktop builds (see earlier in d3d11.c). DXGI's ALT+ENTER handling conflicts with RetroArch's full screen switch, causing it to double up and conflict.

3. Don't draw content texture when it's not bound.

Doesn't seem to be that big of a deal since there's always a texture?, but it's a stray draw without a texture/shader bound and that's not a good idea.

4. Revert the ALLOW_TEARING behavior for non-vsynced present.

Reverting this from before would've broken non-vsynced presents on drivers which do not support the flag (e.g. Win7, Win8, older drivers on Win10).