### PR TITLE
fix up logging that can confuse users

### DIFF
--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -1216,8 +1216,8 @@ static bool open_devices(udev_input_t *udev,
    struct udev_list_entry     *devs = NULL;
    struct udev_list_entry     *item = NULL;
    struct udev_enumerate *enumerate = udev_enumerate_new(udev->udev);
-   int device_index                 = 0;
-
+   static int device_keyboard                 = 0;
+   static int device_mouse                    = 0;
    if (!enumerate)
       return false;
 
@@ -1241,19 +1241,33 @@ static bool open_devices(udev_input_t *udev,
          if (fd != -1)
          {
             bool check = udev_input_add_device(udev, type, devnode, cb);
-
+#ifdef DEBUG
             if (!check)
                RARCH_DBG("[udev] udev_input_add_device SKIPPED : %s (%s).\n",
                      devnode, strerror(errno));
-            else
+#endif
+            if (check)
             {
                char ident[255];
                if (ioctl(fd, EVIOCGNAME(sizeof(ident)), ident) < 0)
                   ident[0] = '\0';
-               RARCH_LOG("[udev]: Added Device %s %s (%s).\n",
-                     type == UDEV_INPUT_KEYBOARD ? "Keyboard" : "Mouse",
+               if ( type == UDEV_INPUT_KEYBOARD)
+               {
+                  RARCH_LOG("[udev]: Added Device Keyboard#%d %s (%s) .\n",
+                     device_keyboard,
                      ident,
                      devnode);
+                   device_keyboard++;
+               }                     
+               else
+               {
+                  RARCH_LOG("[udev]: Added Device mouse#%d %s (%s) .\n",
+                     device_mouse,
+                     ident,
+                     devnode);
+                     device_mouse++;
+               }                     
+                  
             }
 
             (void)check;


### PR DESCRIPTION
It seems the udev logging when skipping /dev/input/mouse[x] can confuse users and they think mouse devices arent being added when its the the legacy input interface being skipped.  I have hidden this with is #ifdef debug (we need this info if something goes wrong and testing) and added indexing to the device so people know what to set in the ports. This has no functionality changes its just more user friendly and avoids confusion. Ill add some code at the weekend when I get time to skip the legacy device errors more cleanly and keep the relevant error messages. This skipped mouse can confuse users and cause needless issues on here 

new output looks like this. The legacy mouse code skip errors are skipped now should avoid and future confusion for users

```
[INFO] [udev]: Added Device Keyboard#0 Telink Wireless Receiver (/dev/input/event7) .
[INFO] [udev]: Added Device Keyboard#1 AT Translated Set 2 keyboard (/dev/input/event3) .
[INFO] [udev]: Added Device mouse#0 Telink Wireless Receiver Mouse (/dev/input/event4) .
[INFO] [udev]: Added Device mouse#1 ETPS/2 Elantech Touchpad (/dev/input/event10) .
```
