### PR TITLE
replace win32 functions with UWP safe variants in UWP vfs driver

### DIFF
--- a/libretro-common/vfs/vfs_implementation_uwp.cpp
+++ b/libretro-common/vfs/vfs_implementation_uwp.cpp
@@ -31,6 +31,7 @@
 #include <robuffer.h>
 #include <collection.h>
 #include <functional>
+#include <fileapifromapp.h>
 
 using namespace Windows::Foundation;
 using namespace Windows::Foundation::Collections;
@@ -388,7 +389,7 @@ libretro_vfs_implementation_file *retro_vfs_file_open_impl(
          OPEN_ALWAYS : CREATE_ALWAYS;
    }
 
-   file_handle = CreateFile2(path_str->Data(), desireAccess, FILE_SHARE_READ, creationDisposition, NULL);
+   file_handle = CreateFile2FromAppW(path_str->Data(), desireAccess, FILE_SHARE_READ, creationDisposition, NULL);
 
    if (file_handle != INVALID_HANDLE_VALUE)
    {
@@ -744,7 +745,7 @@ int retro_vfs_file_remove_impl(const char *path)
    free(path_wide);
 
    /* Try Win32 first, this should work in AppData */
-   result = DeleteFileW(path_str->Data());
+   result = DeleteFileFromAppW(path_str->Data());
    if (result)
       return 0;
 
@@ -827,6 +828,7 @@ int retro_vfs_stat_impl(const char *path, int32_t *size)
    Platform::String^ path_str;
    IStorageItem^ item;
    DWORD file_info;
+   _WIN32_FILE_ATTRIBUTE_DATA attribdata;
 
    if (!path || !*path)
       return 0;
@@ -837,10 +839,11 @@ int retro_vfs_stat_impl(const char *path, int32_t *size)
    free(path_wide);
 
    /* Try Win32 first, this should work in AppData */
-   file_info = GetFileAttributesW(path_str->Data());
+   GetFileAttributesExFromAppW(path_str->Data(), GetFileExInfoStandard, &attribdata);
+   file_info = attribdata.dwFileAttributes;
    if (file_info != INVALID_FILE_ATTRIBUTES)
    {
-      HANDLE file_handle = CreateFile2(path_str->Data(), GENERIC_READ, FILE_SHARE_READ, OPEN_ALWAYS, NULL);
+      HANDLE file_handle = CreateFile2FromAppW(path_str->Data(), GENERIC_READ, FILE_SHARE_READ, OPEN_ALWAYS, NULL);
       if (file_handle != INVALID_HANDLE_VALUE)
       {
          LARGE_INTEGER sz;
@@ -848,9 +851,10 @@ int retro_vfs_stat_impl(const char *path, int32_t *size)
          {
             if (size)
                *size = sz.QuadPart;
-         }
+         }  
          CloseHandle(file_handle);
       }
+      //*size = attribdata.nFileSizeLow;
       return (file_info & FILE_ATTRIBUTE_DIRECTORY) ? RETRO_VFS_STAT_IS_VALID | RETRO_VFS_STAT_IS_DIRECTORY : RETRO_VFS_STAT_IS_VALID;
    }
 
@@ -917,7 +921,7 @@ int retro_vfs_mkdir_impl(const char *dir)
    free(dir_local);
 
    /* Try Win32 first, this should work in AppData */
-   result = CreateDirectoryW(dir_str->Data(), NULL);
+   result = CreateDirectoryFromAppW(dir_str->Data(), NULL);
    if (result)
       return 0;
    


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

Replace Win32 functions with UWP safe variants in UWP vfs driver, this means that folders outside of the apps appdata folder can be accessed using the faster Win32 file apis.

## Related Issues

N/A

## Related Pull Requests

N/A

## Reviewers

[If possible @mention all the people that should review your pull request]
