### PR TITLE
(cheevos) reset cached progress each time menu is opened

### DIFF
--- a/cheevos/cheevos_menu.c
+++ b/cheevos/cheevos_menu.c
@@ -42,6 +42,8 @@ enum rcheevos_menuitem_bucket
 
 static void rcheevos_menu_update_bucket(rcheevos_racheevo_t* cheevo)
 {
+   cheevo->menu_progress = 0;
+
    if (!cheevo->memaddr)
    {
       /* non-active unsupported achievement */
@@ -66,7 +68,6 @@ static void rcheevos_menu_update_bucket(rcheevos_racheevo_t* cheevo)
 
       /* active achievement */
       cheevo->menu_bucket = RCHEEVOS_MENUITEM_BUCKET_LOCKED;
-      cheevo->menu_progress = 0;
 
       trigger = rc_runtime_get_achievement(&rcheevos_locals->runtime, cheevo->id);
       if (trigger)


### PR DESCRIPTION
## Description

Fixes an issue where a measured achievement would still appear incomplete after triggering

![image](https://user-images.githubusercontent.com/32680403/123180505-a1aaef00-d448-11eb-8db3-a497ab29bd7c.png)

The measured progress is calculated when the menu is opened, and stored so it doesn't have to be recalculated each time the menu renders. The problem was that it wasn't being cleared out when the achievement transitions to unlocked/hardcore. This moves the zero-ing out code higher in the menu building logic to handle the unlocked cases.

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

[If possible @mention all the people that should review your pull request]
