### PR TITLE
Re-enable alsa on opendingux beta

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -829,7 +829,9 @@ ifeq ($(HAVE_ALSA), 1)
 
    ifneq ($(HAVE_HAKCHI), 1)
       ifneq ($(HAVE_SEGAM), 1)
-         OBJ += midi/drivers/alsa_midi.o
+         ifneq ($(DINGUX), 1)
+            OBJ += midi/drivers/alsa_midi.o
+         endif
       endif
    endif
 

--- a/Makefile.rg350_odbeta
+++ b/Makefile.rg350_odbeta
@@ -45,8 +45,7 @@ HAVE_SCREENSHOTS = 0
 HAVE_REWIND = 1
 HAVE_7ZIP = 1
 HAVE_AL = 1
-# ALSA freezes when switching back from menu
-HAVE_ALSA = 0
+HAVE_ALSA = 1
 HAVE_DSP_FILTER = 1
 HAVE_VIDEO_FILTER = 1
 HAVE_STATIC_VIDEO_FILTERS = 1
@@ -121,6 +120,7 @@ DEF_FLAGS += -ffunction-sections -fdata-sections
 DEF_FLAGS += -I. -Ideps -Ideps/stb -DDINGUX=1 -DDINGUX_BETA=1 -MMD
 DEF_FLAGS += -Wall -Wno-unused-variable
 DEF_FLAGS += -std=gnu99 -D_GNU_SOURCE -flto
+DEF_FLAGS += -lasound
 LIBS := -ldl -lz -lrt -ludev -pthread
 CFLAGS :=
 CXXFLAGS := -fno-exceptions -fno-rtti -std=c++11 -D__STDC_CONSTANT_MACROS
@@ -134,6 +134,7 @@ DEFINES += -DHAVE_GETOPT_LONG=1 -DHAVE_STRCASESTR=1 -DHAVE_DYNAMIC=1
 DEFINES += -DHAVE_AL=1
 DEFINES += -DHAVE_FILTERS_BUILTIN
 DEFINES += -DHAVE_UDEV=1
+DEFINES += -DHAVE_ALSA
 
 SDL_DINGUX_CFLAGS := $(shell $(GCW0_SDL_CONFIG) --cflags)
 SDL_DINGUX_LIBS := $(shell $(GCW0_SDL_CONFIG) --libs)

--- a/configuration.c
+++ b/configuration.c
@@ -339,6 +339,8 @@ static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_PS3;
 static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_CTR;
 #elif defined(SWITCH)
 static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_SWITCH;
+#elif defined(DINGUX) && defined(HAVE_AL)
+static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_AL;
 #elif defined(HAVE_PULSE)
 static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_PULSE;
 #elif defined(HAVE_ALSA) && defined(HAVE_THREADS)
@@ -397,7 +399,7 @@ static const enum record_driver_enum RECORD_DEFAULT_DRIVER = RECORD_NULL;
 
 #ifdef HAVE_WINMM
 static const enum midi_driver_enum MIDI_DEFAULT_DRIVER = MIDI_WINMM;
-#elif defined(HAVE_ALSA) && !defined(HAVE_HAKCHI) && !defined(HAVE_SEGAM)
+#elif defined(HAVE_ALSA) && !defined(HAVE_HAKCHI) && !defined(HAVE_SEGAM) && !defined(DINGUX)
 static const enum midi_driver_enum MIDI_DEFAULT_DRIVER = MIDI_ALSA;
 #else
 static const enum midi_driver_enum MIDI_DEFAULT_DRIVER = MIDI_NULL;

--- a/retroarch_data.h
+++ b/retroarch_data.h
@@ -1190,7 +1190,7 @@ static midi_driver_t midi_null = {
 };
 
 static midi_driver_t *midi_drivers[] = {
-#if defined(HAVE_ALSA) && !defined(HAVE_HAKCHI) && !defined(HAVE_SEGAM)
+#if defined(HAVE_ALSA) && !defined(HAVE_HAKCHI) && !defined(HAVE_SEGAM) && !defined(DINGUX)
    &midi_alsa,
 #endif
 #ifdef HAVE_WINMM


### PR DESCRIPTION
## Description

I found a comment in Makefile.rg350_odbeta suggesting that alsa was broken. (freezes when switching back to menu). It appears that this bug was fixed in the OpenDingux beta, so I re-enabled alsa.

Compiled and  ran on my RG350M. Both alsa and alsathread work without any apparent issues.

## Reviewers

I suspect @jdgleaver might have something to say/suggest.

### Edit

I just realized this enables the alsa MIDI driver as well. I'm not sure how that would even work with the RG350, so I don't know how to test it. But I thought that was worth mentioning.
