### PR TITLE
Enable SDL2 Support for RG350

### DIFF
--- a/Makefile.rg350_odbeta
+++ b/Makefile.rg350_odbeta
@@ -25,7 +25,7 @@ else
 STRIP                 = $(TOOLCHAIN_DIR)/usr/bin/mipsel-gcw0-linux-uclibc-strip
 endif
 
-GCW0_SDL_CONFIG      ?= $(TOOLCHAIN_DIR)/usr/mipsel-gcw0-linux-uclibc/sysroot/usr/bin/sdl-config
+GCW0_SDL_CONFIG      ?= $(TOOLCHAIN_DIR)/usr/mipsel-gcw0-linux-uclibc/sysroot/usr/bin/sdl2-config
 GCW0_FREETYPE_CONFIG ?= $(TOOLCHAIN_DIR)/usr/mipsel-gcw0-linux-uclibc/sysroot/usr/bin/freetype-config
 GCW0_MK_SQUASH_FS    ?= $(TOOLCHAIN_DIR)/usr/bin/mksquashfs
 
@@ -90,7 +90,7 @@ HAVE_RJPEG = 1
 HAVE_RPILED = 0
 HAVE_RPNG = 1
 HAVE_RUNAHEAD = 1
-HAVE_SDL_DINGUX = 1
+HAVE_SDL2 = 1
 HAVE_SHADERPIPELINE = 0
 HAVE_STB_FONT = 0
 HAVE_STB_IMAGE = 1
@@ -134,9 +134,10 @@ DEFINES += -DHAVE_GETOPT_LONG=1 -DHAVE_STRCASESTR=1 -DHAVE_DYNAMIC=1
 DEFINES += -DHAVE_AL=1
 DEFINES += -DHAVE_FILTERS_BUILTIN
 DEFINES += -DHAVE_UDEV=1
+DEFINES += -DHAVE_SDL2
 
-SDL_DINGUX_CFLAGS := $(shell $(GCW0_SDL_CONFIG) --cflags)
-SDL_DINGUX_LIBS := $(shell $(GCW0_SDL_CONFIG) --libs)
+SDL2_CFLAGS := $(shell $(GCW0_SDL_CONFIG) --cflags)
+SDL2_LIBS := $(shell $(GCW0_SDL_CONFIG) --libs)
 FREETYPE_CFLAGS := $(shell $(GCW0_FREETYPE_CONFIG) --cflags)
 FREETYPE_LIBS := $(shell $(GCW0_FREETYPE_CONFIG) --libs)
 AL_LIBS := -lopenal

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -1494,14 +1494,14 @@ static bool rgui_set_pixel_format_function(void)
 {
    const char *driver_ident    = video_driver_get_ident();
    bool transparency_supported = true;
-   
+
    /* Default fallback... */
    if (string_is_empty(driver_ident))
    {
       argb32_to_pixel_platform_format = argb32_to_rgba4444;
       return transparency_supported;
    }
-   
+
    if (     string_is_equal(driver_ident, "ps2"))        /* PS2 */
    {
       argb32_to_pixel_platform_format = argb32_to_abgr1555;
@@ -1522,7 +1522,7 @@ static bool rgui_set_pixel_format_function(void)
    }
    else
       argb32_to_pixel_platform_format = argb32_to_rgba4444;
-   
+
    return transparency_supported;
 }
 
@@ -1865,15 +1865,15 @@ static void rgui_render_border(rgui_t *rgui, uint16_t *data,
    uint16_t dark_color;
    uint16_t light_color;
    bool thickness;
-   
+
    /* Sanity check */
    if (!rgui || !data)
       return;
-   
+
    dark_color   = rgui->colors.border_dark_color;
    light_color  = rgui->colors.border_light_color;
    thickness    = rgui->border_thickness;
-   
+
    /* Draw border */
    rgui_fill_rect(data, fb_width, fb_height,
          5, 5, fb_width - 10, 5,
@@ -1887,12 +1887,12 @@ static void rgui_render_border(rgui_t *rgui, uint16_t *data,
    rgui_fill_rect(data, fb_width, fb_height,
          fb_width - 10, 5, 5, fb_height - 10,
          dark_color, light_color, thickness);
-   
+
    /* Draw drop shadow, if required */
    if (rgui->shadow_enable)
    {
       uint16_t shadow_color = rgui->colors.shadow_color;
-      
+
       rgui_color_rect(data, fb_width, fb_height,
             10, 10, 1, fb_height - 20, shadow_color);
       rgui_color_rect(data, fb_width, fb_height,
@@ -1913,7 +1913,7 @@ static bool INLINE rgui_draw_particle(
       uint16_t color)
 {
    unsigned x_index, y_index;
-   
+
    /* This great convoluted mess just saves us
     * having to perform comparisons on every
     * iteration of the for loops... */
@@ -1921,23 +1921,23 @@ static bool INLINE rgui_draw_particle(
    int y_start = y > 0 ? y : 0;
    int x_end = x + width;
    int y_end = y + height;
-   
+
    x_start = x_start <= (int)fb_width  ? x_start : fb_width;
    y_start = y_start <= (int)fb_height ? y_start : fb_height;
-   
+
    x_end = x_end >  0        ? x_end : 0;
    x_end = x_end <= (int)fb_width ? x_end : fb_width;
-   
+
    y_end = y_end >  0         ? y_end : 0;
    y_end = y_end <= (int)fb_height ? y_end : fb_height;
-   
+
    for (y_index = (unsigned)y_start; y_index < (unsigned)y_end; y_index++)
    {
       uint16_t *data_ptr = data + (y_index * fb_width);
       for (x_index = (unsigned)x_start; x_index < (unsigned)x_end; x_index++)
          *(data_ptr + x_index) = color;
    }
-   
+
    return (x_end > x_start) && (y_end > y_start);
 }
 
@@ -1947,7 +1947,7 @@ static void rgui_init_particle_effect(rgui_t *rgui,
    size_t i;
    unsigned fb_width  = p_disp->framebuf_width;
    unsigned fb_height = p_disp->framebuf_height;
-   
+
    switch (rgui->particle_effect)
    {
       case RGUI_PARTICLE_EFFECT_SNOW:
@@ -1956,7 +1956,7 @@ static void rgui_init_particle_effect(rgui_t *rgui,
             for (i = 0; i < RGUI_NUM_PARTICLES; i++)
             {
                rgui_particle_t *particle = &rgui->particles[i];
-               
+
                particle->a = (float)(rand() % fb_width);
                particle->b = (float)(rand() % fb_height);
                particle->c = (float)(rand() % 64 - 16) * 0.1f;
@@ -1977,13 +1977,13 @@ static void rgui_init_particle_effect(rgui_t *rgui,
                9, 9,
                10};
             unsigned num_drops = (unsigned)(0.85f * ((float)fb_width / (float)RGUI_MAX_FB_WIDTH) * (float)RGUI_NUM_PARTICLES);
-            
+
             num_drops = num_drops < RGUI_NUM_PARTICLES ? num_drops : RGUI_NUM_PARTICLES;
-            
+
             for (i = 0; i < num_drops; i++)
             {
                rgui_particle_t *particle = &rgui->particles[i];
-               
+
                /* x pos */
                particle->a = (float)(rand() % (fb_width / 3)) * 3.0f;
                /* y pos */
@@ -1999,11 +1999,11 @@ static void rgui_init_particle_effect(rgui_t *rgui,
          {
             float max_radius         = (float)sqrt((double)((fb_width * fb_width) + (fb_height * fb_height))) / 2.0f;
             float one_degree_radians = PI / 360.0f;
-            
+
             for (i = 0; i < RGUI_NUM_PARTICLES; i++)
             {
                rgui_particle_t *particle = &rgui->particles[i];
-               
+
                /* radius */
                particle->a = 1.0f + (((float)rand() / (float)RAND_MAX) * max_radius);
                /* theta */
@@ -2020,7 +2020,7 @@ static void rgui_init_particle_effect(rgui_t *rgui,
             for (i = 0; i < RGUI_NUM_PARTICLES; i++)
             {
                rgui_particle_t *particle = &rgui->particles[i];
-               
+
                /* x pos */
                particle->a = (float)(rand() % fb_width);
                /* y pos */
@@ -2054,19 +2054,19 @@ static void rgui_render_particle_effect(
    float particle_effect_speed      = 0.0f;
    bool particle_effect_screensaver = false;
    uint16_t *frame_buf_data         = NULL;
-   
+
    if (settings)
    {
       particle_effect_speed         = settings->floats.menu_rgui_particle_effect_speed;
       particle_effect_screensaver   = settings->bools.menu_rgui_particle_effect_screensaver;
    }
-   
+
    /* Sanity check */
    if (!rgui || !rgui->frame_buf.data)
       return;
-   
+
    frame_buf_data = rgui->frame_buf.data;
-   
+
    /* Check whether screensaver is currently active */
    if (rgui->show_screensaver)
    {
@@ -2078,17 +2078,17 @@ static void rgui_render_particle_effect(
    }
    else
       particle_color = rgui->colors.particle_color;
-   
+
    /* Adjust global animation speed */
    /* > Apply user configured speed multiplier */
-   if (particle_effect_speed > 0.0001f) 
+   if (particle_effect_speed > 0.0001f)
       global_speed_factor = particle_effect_speed;
 
    /* > Account for non-standard frame times
     *   (high/low refresh rates, or frame drops) */
    global_speed_factor   *= p_anim->delta_time
       / particle_effect_period;
-   
+
    /* Note: It would be more elegant to have 'update' and 'draw'
     * as separate functions, since 'update' is the part that
     * varies with particle effect whereas 'draw' is always
@@ -2106,7 +2106,7 @@ static void rgui_render_particle_effect(
     * update/draw sequence here. This results in some code
     * repetition, but it has better performance and allows for
     * complete flexibility */
-   
+
    switch (rgui->particle_effect)
    {
       case RGUI_PARTICLE_EFFECT_SNOW:
@@ -2114,25 +2114,25 @@ static void rgui_render_particle_effect(
          {
             unsigned particle_size;
             bool on_screen;
-            
+
             for (i = 0; i < RGUI_NUM_PARTICLES; i++)
             {
                rgui_particle_t *particle = &rgui->particles[i];
-               
+
                /* Update particle 'speed' */
                particle->c = particle->c + (float)(rand() % 16 - 9) * 0.01f;
                particle->d = particle->d + (float)(rand() % 16 - 7) * 0.01f;
-               
+
                particle->c = (particle->c < -0.4f) ? -0.4f : particle->c;
                particle->c = (particle->c >  0.1f) ?  0.1f : particle->c;
-               
+
                particle->d = (particle->d < -0.1f) ? -0.1f : particle->d;
                particle->d = (particle->d >  0.4f) ?  0.4f : particle->d;
-               
+
                /* Update particle location */
                particle->a = fmod(particle->a + (global_speed_factor * particle->c), fb_width);
                particle->b = fmod(particle->b + (global_speed_factor * particle->d), fb_height);
-               
+
                /* Get particle size */
                particle_size = 1;
                if (rgui->particle_effect == RGUI_PARTICLE_EFFECT_SNOW_ALT)
@@ -2146,12 +2146,12 @@ static void rgui_render_particle_effect(
                   else if ((i & 0x7) == 0x7)
                      particle_size = 3;
                }
-               
+
                /* Draw particle */
                on_screen = rgui_draw_particle(frame_buf_data, fb_width, fb_height,
                                  (int)particle->a, (int)particle->b,
                                  particle_size, particle_size, particle_color);
-               
+
                /* Reset particle if it has fallen off screen */
                if (!on_screen)
                {
@@ -2175,21 +2175,21 @@ static void rgui_render_particle_effect(
                10};
             unsigned num_drops = (unsigned)(0.85f * ((float)fb_width / (float)RGUI_MAX_FB_WIDTH) * (float)RGUI_NUM_PARTICLES);
             bool on_screen;
-            
+
             num_drops = num_drops < RGUI_NUM_PARTICLES ? num_drops : RGUI_NUM_PARTICLES;
-            
+
             for (i = 0; i < num_drops; i++)
             {
                rgui_particle_t *particle = &rgui->particles[i];
-               
+
                /* Draw particle */
                on_screen = rgui_draw_particle(frame_buf_data, fb_width, fb_height,
                                  (int)particle->a, (int)particle->b,
                                  2, (unsigned)particle->c, particle_color);
-               
+
                /* Update y pos */
                particle->b += particle->d * global_speed_factor;
-               
+
                /* Reset particle if it has fallen off the bottom of the screen */
                if (!on_screen)
                {
@@ -2214,22 +2214,22 @@ static void rgui_render_particle_effect(
             unsigned particle_size;
             float r_speed, theta_speed;
             int x, y;
-            
+
             for (i = 0; i < RGUI_NUM_PARTICLES; i++)
             {
                rgui_particle_t *particle = &rgui->particles[i];
-               
+
                /* Get particle location */
                x = (int)(particle->a * cos(particle->b)) + x_centre;
                y = (int)(particle->a * sin(particle->b)) + y_centre;
-               
+
                /* Get particle size */
                particle_size = 1 + (unsigned)(((1.0f - ((max_radius - particle->a) / max_radius)) * 3.5f) + 0.5f);
-               
+
                /* Draw particle */
                rgui_draw_particle(frame_buf_data, fb_width, fb_height,
                      x, y, particle_size, particle_size, particle_color);
-               
+
                /* Update particle speed */
                r_speed     = particle->c * global_speed_factor;
                theta_speed = particle->d * global_speed_factor;
@@ -2241,7 +2241,7 @@ static void rgui_render_particle_effect(
                }
                particle->a -= r_speed;
                particle->b += theta_speed;
-               
+
                /* Reset particle if it has reached the centre of the screen */
                if (particle->a < 0.0f)
                {
@@ -2269,30 +2269,30 @@ static void rgui_render_particle_effect(
             unsigned particle_size;
             int x, y;
             bool on_screen;
-            
+
             /* Based on an example found here:
              * https://codepen.io/nodws/pen/pejBNb */
             for (i = 0; i < RGUI_NUM_PARTICLES; i++)
             {
                rgui_particle_t *particle = &rgui->particles[i];
-               
+
                /* Get particle location */
                x = (int)((particle->a - (float)x_centre) * (focal_length / particle->c));
                x += x_centre;
-               
+
                y = (int)((particle->b - (float)y_centre) * (focal_length / particle->c));
                y += y_centre;
-               
+
                /* Get particle size */
                particle_size = (unsigned)(focal_length / (2.0f * particle->c));
-               
+
                /* Draw particle */
                on_screen = rgui_draw_particle(frame_buf_data, fb_width, fb_height,
                                  x, y, particle_size, particle_size, particle_color);
-               
+
                /* Update depth */
                particle->c -= particle->d * global_speed_factor;
-               
+
                /* Reset particle if it has:
                 * - Dropped off the edge of the screen
                 * - Reached the screen depth
@@ -2318,7 +2318,7 @@ static void rgui_render_particle_effect(
          /* Do nothing... */
          break;
    }
-   
+
    /* If border is enabled, it must be drawn *above*
     * particle effect
     * (Wastes CPU cycles, but nothing we can do about it...) */
@@ -2403,7 +2403,7 @@ static bool request_thumbnail(
          if (task_push_image_load(thumbnail->path,
                   video_driver_supports_rgba(), 0,
                   (thumbnail_id == GFX_THUMBNAIL_LEFT) ?
-            menu_display_handle_left_thumbnail_upload 
+            menu_display_handle_left_thumbnail_upload
             : menu_display_handle_thumbnail_upload, NULL))
          {
             *queue_size = *queue_size + 1;
@@ -2423,7 +2423,7 @@ static bool downscale_thumbnail(rgui_t *rgui,
 {
    /* Determine output dimensions */
    float display_aspect_ratio    = (float)max_width / (float)max_height;
-   float         aspect_ratio    = (float)image_src->width 
+   float         aspect_ratio    = (float)image_src->width
       / (float)image_src->height;
    settings_t       *settings    = config_get_ptr();
    unsigned thumbnail_downscaler = settings->uints.menu_rgui_thumbnail_downscaler;
@@ -2620,7 +2620,7 @@ static bool rgui_load_image(void *userdata, void *data, enum menu_image_type typ
       case MENU_IMAGE_THUMBNAIL:
          {
             struct texture_image *image = (struct texture_image*)data;
-            
+
             if (rgui->show_fs_thumbnail)
                process_thumbnail(rgui, &rgui->fs_thumbnail, &rgui->thumbnail_queue_size, image);
             else if (settings->bools.menu_rgui_inline_thumbnails)
@@ -2685,7 +2685,7 @@ static void rgui_render_fs_thumbnail(rgui_t *rgui,
 {
    uint16_t *frame_buf_data    = rgui->frame_buf.data;
    uint16_t *fs_thumbnail_data = rgui->fs_thumbnail.data;
-   
+
    if (rgui->fs_thumbnail.is_valid && frame_buf_data && fs_thumbnail_data)
    {
       unsigned y;
@@ -2732,7 +2732,7 @@ static void rgui_render_fs_thumbnail(rgui_t *rgui,
       {
          src = fs_thumbnail_data + thumb_x_offset + ((y + thumb_y_offset) * fs_thumbnail_width);
          dst = frame_buf_data + (y + fb_y_offset) * (fb_pitch >> 1) + fb_x_offset;
-         
+
          memcpy(dst, src, width * sizeof(uint16_t));
       }
 
@@ -2805,13 +2805,13 @@ static void rgui_render_mini_thumbnail(
 
       /* Sanity check (this can never, ever happen, so just return
        * instead of trying to crop the thumbnail image...) */
-      if (     (thumbnail_fullwidth > term_width) 
+      if (     (thumbnail_fullwidth > term_width)
             || (thumbnail->height   > term_height))
          return;
 
       fb_x_offset = (rgui->term_layout.start_x + term_width) -
             (thumbnail->width + ((thumbnail_fullwidth - thumbnail->width) >> 1));
-      
+
       if (((thumbnail_id == GFX_THUMBNAIL_RIGHT) && !settings->bools.menu_rgui_swap_thumbnails) ||
           ((thumbnail_id == GFX_THUMBNAIL_LEFT)  && settings->bools.menu_rgui_swap_thumbnails))
          fb_y_offset = rgui->term_layout.start_y + ((thumbnail->max_height - thumbnail->height) >> 1);
@@ -2825,7 +2825,7 @@ static void rgui_render_mini_thumbnail(
          src = thumbnail->data + (y * thumbnail->width);
          dst = frame_buf_data + (y + fb_y_offset) *
                (fb_pitch >> 1) + fb_x_offset;
-         
+
          memcpy(dst, src, thumbnail->width * sizeof(uint16_t));
       }
 
@@ -3005,7 +3005,7 @@ static void load_custom_theme(rgui_t *rgui, rgui_theme_t *theme_colors, const ch
    config_file_t *conf         = NULL;
    const char *wallpaper_key   = NULL;
    bool success                = false;
-#if defined(DINGUX)
+#if defined(DINGUX) && !defined(HAVE_SDL2)
    unsigned aspect_ratio       = RGUI_ASPECT_RATIO_4_3;
 #else
    settings_t *settings        = config_get_ptr();
@@ -3859,7 +3859,7 @@ static void rgui_set_blit_functions(unsigned language,
       else
          blit_line = blit_line_regular_shadow;
 #endif
-      
+
       blit_symbol = blit_symbol_shadow;
    }
    else
@@ -3889,7 +3889,7 @@ static void rgui_set_blit_functions(unsigned language,
       else
          blit_line = blit_line_regular;
 #endif
-      
+
       blit_symbol = blit_symbol_regular;
    }
 }
@@ -4098,33 +4098,33 @@ static void rgui_render_osk(
       unsigned fb_width, unsigned fb_height)
 {
    size_t key_index;
-   
+
    unsigned input_label_max_length;
    unsigned input_str_max_length;
    unsigned input_offset_x, input_offset_y;
-   
+
    unsigned key_width, key_height;
    unsigned key_text_offset_x, key_text_offset_y;
    unsigned ptr_width, ptr_height;
    unsigned ptr_offset_x, ptr_offset_y;
-   
+
    unsigned keyboard_width, keyboard_height;
    unsigned keyboard_offset_x, keyboard_offset_y;
-   
+
    unsigned osk_width, osk_height;
    unsigned osk_x, osk_y;
-   
+
    int osk_ptr              = input_event_get_osk_ptr();
    char **osk_grid          = input_event_get_osk_grid();
    const char *input_str    = menu_input_dialog_get_buffer();
    const char *input_label  = menu_input_dialog_get_label_buffer();
-   
+
    uint16_t *frame_buf_data = rgui->frame_buf.data;
-   
+
    /* Sanity check 1 */
    if (!frame_buf_data || osk_ptr < 0 || osk_ptr >= 44 || !osk_grid[0])
       return;
-   
+
    key_text_offset_x      = 8;
    key_text_offset_y      = 6;
    key_width              = rgui->font_width  + (key_text_offset_x * 2);
@@ -4145,7 +4145,7 @@ static void rgui_render_osk(
    osk_height             = keyboard_offset_y + keyboard_height + 10;
    osk_x                  = (fb_width - osk_width) / 2;
    osk_y                  = (fb_height - osk_height) / 2;
-   
+
    /* Sanity check 2 */
    if ((osk_width + 2 > fb_width) || (osk_height + 2 > fb_height))
    {
@@ -4154,30 +4154,30 @@ static void rgui_render_osk(
        * fallback to old style 'message box' implementation */
       char msg[255];
       msg[0] = '\0';
-      
+
       snprintf(msg, sizeof(msg), "%s\n%s", input_label, input_str);
       rgui_render_messagebox(rgui, msg, fb_width, fb_height);
-      
+
       return;
    }
-   
+
    /* Draw background */
    rgui_fill_rect(frame_buf_data, fb_width, fb_height,
          osk_x + 5, osk_y + 5, osk_width - 10, osk_height - 10,
          rgui->colors.bg_dark_color, rgui->colors.bg_light_color, rgui->bg_thickness);
-   
+
    /* Draw border */
    if (rgui->border_enable)
    {
       uint16_t border_dark_color  = rgui->colors.border_dark_color;
       uint16_t border_light_color = rgui->colors.border_light_color;
       bool border_thickness       = rgui->border_thickness;
-      
+
       /* Draw drop shadow, if required */
       if (rgui->shadow_enable)
       {
          uint16_t shadow_color = rgui->colors.shadow_color;
-         
+
          /* Frame */
          rgui_color_rect(frame_buf_data, fb_width, fb_height,
                osk_x + 5, osk_y + 5, osk_width - 10, 1, shadow_color);
@@ -4191,7 +4191,7 @@ static void rgui_render_osk(
          rgui_color_rect(frame_buf_data, fb_width, fb_height,
                osk_x + 5, osk_y + keyboard_offset_y - 5, osk_width - 10, 1, shadow_color);
       }
-      
+
       /* Frame */
       rgui_fill_rect(frame_buf_data, fb_width, fb_height,
             osk_x, osk_y, osk_width - 5, 5,
@@ -4210,7 +4210,7 @@ static void rgui_render_osk(
             osk_x + 5, osk_y + keyboard_offset_y - 10, osk_width - 10, 5,
             border_dark_color, border_light_color, border_thickness);
    }
-   
+
    /* Draw input label text */
    if (!string_is_empty(input_label))
    {
@@ -4218,9 +4218,9 @@ static void rgui_render_osk(
       unsigned input_label_length;
       int input_label_x, input_label_y;
       unsigned ticker_x_offset = 0;
-      
+
       input_label_buf[0] = '\0';
-      
+
       if (use_smooth_ticker)
       {
          ticker_smooth->selected    = true;
@@ -4229,7 +4229,7 @@ static void rgui_render_osk(
          ticker_smooth->dst_str     = input_label_buf;
          ticker_smooth->dst_str_len = sizeof(input_label_buf);
          ticker_smooth->x_offset    = &ticker_x_offset;
-         
+
          gfx_animation_ticker_smooth(ticker_smooth);
       }
       else
@@ -4238,18 +4238,18 @@ static void rgui_render_osk(
          ticker->len      = input_label_max_length;
          ticker->str      = input_label;
          ticker->selected = true;
-         
+
          gfx_animation_ticker(ticker);
       }
 
       input_label_length = (unsigned)(utf8len(input_label_buf) * rgui->font_width_stride);
       input_label_x      = ticker_x_offset + osk_x + input_offset_x + ((input_label_max_length * rgui->font_width_stride) - input_label_length) / 2;
       input_label_y      = osk_y + input_offset_y;
-      
+
       blit_line(rgui, fb_width, input_label_x, input_label_y, input_label_buf,
             rgui->colors.normal_color, rgui->colors.shadow_color);
    }
-   
+
    /* Draw input buffer text */
    {
       unsigned input_str_char_offset;
@@ -4257,7 +4257,7 @@ static void rgui_render_osk(
       int text_cursor_x;
       unsigned input_str_length     = (unsigned)utf8len(input_str);
       const char *input_str_visible = NULL;
-      
+
       if (input_str_length > input_str_max_length)
       {
          input_str_char_offset = input_str_length - input_str_max_length;
@@ -4265,34 +4265,34 @@ static void rgui_render_osk(
       }
       else
          input_str_char_offset = 0;
-      
+
       input_str_x = osk_x + input_offset_x;
       input_str_y = osk_y + input_offset_y + rgui->font_height_stride;
-      
+
       input_str_visible = utf8skip(input_str, input_str_char_offset);
-      
+
       if (!string_is_empty(input_str_visible))
          blit_line(rgui, fb_width, input_str_x, input_str_y, input_str_visible,
                rgui->colors.hover_color, rgui->colors.shadow_color);
-      
+
       /* Draw text cursor */
       text_cursor_x = osk_x + input_offset_x + (input_str_length * rgui->font_width_stride);
-      
+
       blit_symbol(rgui, fb_width, text_cursor_x, input_str_y, RGUI_SYMBOL_TEXT_CURSOR,
             rgui->colors.normal_color, rgui->colors.shadow_color);
    }
-   
+
    /* Draw keyboard 'keys' */
    for (key_index = 0; key_index < 44; key_index++)
    {
       unsigned key_row     = (unsigned)(key_index / OSK_CHARS_PER_LINE);
       unsigned key_column  = (unsigned)(key_index - (key_row * OSK_CHARS_PER_LINE));
-      
+
       int key_text_x       = osk_x + keyboard_offset_x + key_text_offset_x + (key_column * key_width);
       int key_text_y       = osk_y + keyboard_offset_y + key_text_offset_y + (key_row    * key_height);
-      
+
       const char *key_text = osk_grid[key_index];
-      
+
       /* 'Command' keys use custom symbols - have to
        * detect them and use blit_symbol(). Everything
        * else is plain text, and can be drawn directly
@@ -4333,13 +4333,13 @@ static void rgui_render_osk(
       else
          blit_line(rgui, fb_width, key_text_x, key_text_y, key_text,
                rgui->colors.normal_color, rgui->colors.shadow_color);
-      
+
       /* Draw selection pointer */
       if (key_index == osk_ptr)
       {
          unsigned osk_ptr_x = osk_x + keyboard_offset_x + ptr_offset_x + (key_column * key_width);
          unsigned osk_ptr_y = osk_y + keyboard_offset_y + ptr_offset_y + (key_row    * key_height);
-         
+
          /* Draw drop shadow, if required */
          if (rgui->shadow_enable)
          {
@@ -4352,7 +4352,7 @@ static void rgui_render_osk(
             rgui_color_rect(frame_buf_data, fb_width, fb_height,
                   osk_ptr_x + 1, osk_ptr_y + ptr_height, ptr_width, 1, rgui->colors.shadow_color);
          }
-         
+
          /* Draw selection rectangle */
          rgui_color_rect(frame_buf_data, fb_width, fb_height,
                osk_ptr_x, osk_ptr_y, 1, ptr_height, rgui->colors.hover_color);
@@ -4436,7 +4436,7 @@ static void rgui_render(void *data,
    size_t i, end, fb_pitch, old_start, new_start;
    unsigned fb_width, fb_height;
    static bool display_kb         = false;
-   static const char* const 
+   static const char* const
       ticker_spacer               = RGUI_TICKER_SPACER;
    int bottom                     = 0;
    unsigned ticker_x_offset       = 0;
@@ -4505,8 +4505,8 @@ static void rgui_render(void *data,
             && !msg_force)
          return;
 
-      if (  !display_kb && 
-            !current_display_cb && 
+      if (  !display_kb &&
+            !current_display_cb &&
             (is_idle || !GFX_DISPLAY_GET_UPDATE_PENDING(p_anim, p_disp)))
          return;
    }
@@ -4518,7 +4518,7 @@ static void rgui_render(void *data,
 
    /* If the framebuffer changed size, or the background config has
     * changed, recache the background buffer */
-   fb_size_changed = (rgui->last_width  != fb_width) || 
+   fb_size_changed = (rgui->last_width  != fb_width) ||
                      (rgui->last_height != fb_height);
 
 #if defined(GEKKO)
@@ -4535,7 +4535,7 @@ static void rgui_render(void *data,
       rgui_cache_background(rgui, fb_width, fb_height, fb_pitch);
 
       /* Reinitialise particle effect, if required */
-      if (fb_size_changed && 
+      if (fb_size_changed &&
             (rgui->particle_effect != RGUI_PARTICLE_EFFECT_NONE))
          rgui_init_particle_effect(rgui, p_disp);
 
@@ -4772,8 +4772,8 @@ static void rgui_render(void *data,
             {
                unsigned powerstate_x;
                enum rgui_symbol_type powerstate_symbol;
-               uint16_t powerstate_color = (powerstate.percent > RGUI_BATTERY_WARN_THRESHOLD || powerstate.charging) 
-                  ? rgui->colors.title_color 
+               uint16_t powerstate_color = (powerstate.percent > RGUI_BATTERY_WARN_THRESHOLD || powerstate.charging)
+                  ? rgui->colors.title_color
                   : rgui->colors.hover_color;
 
                if (powerstate.charging)
@@ -4905,7 +4905,7 @@ static void rgui_render(void *data,
          /* If showing mini thumbnails, reduce title field length accordingly */
          if (show_mini_thumbnails)
          {
-            unsigned term_offset = rgui_swap_thumbnails 
+            unsigned term_offset = rgui_swap_thumbnails
                ? (unsigned)(rgui->term_layout.height - (i - new_start) - 1)
                : (i - new_start);
             unsigned thumbnail_width = 0;
@@ -5087,7 +5087,7 @@ static void rgui_render(void *data,
          if (show_thumbnail)
             rgui_render_mini_thumbnail(rgui, &rgui->mini_thumbnail, GFX_THUMBNAIL_RIGHT,
                   fb_width, fb_height, fb_pitch);
-         
+
          if (show_left_thumbnail)
             rgui_render_mini_thumbnail(rgui, &rgui->mini_left_thumbnail, GFX_THUMBNAIL_LEFT,
                   fb_width, fb_height, fb_pitch);
@@ -5197,7 +5197,7 @@ static void rgui_render(void *data,
 
    if (rgui->show_mouse)
    {
-      bool cursor_visible   = video_fullscreen 
+      bool cursor_visible   = video_fullscreen
          && menu_mouse_enable;
 
       /* Blit cursor */
@@ -5216,7 +5216,7 @@ static void rgui_framebuffer_free(frame_buf_t *framebuffer)
 
    framebuffer->width  = 0;
    framebuffer->height = 0;
-   
+
    if (framebuffer->data)
       free(framebuffer->data);
    framebuffer->data   = NULL;
@@ -5226,14 +5226,14 @@ static void rgui_thumbnail_free(thumbnail_t *thumbnail)
 {
    if (!thumbnail)
       return;
-   
+
    thumbnail->max_width = 0;
    thumbnail->max_height = 0;
    thumbnail->width = 0;
    thumbnail->height = 0;
    thumbnail->is_valid = false;
    thumbnail->path[0] = '\0';
-   
+
    if (thumbnail->data)
       free(thumbnail->data);
    thumbnail->data = NULL;
@@ -5255,10 +5255,10 @@ static void rgui_get_video_config(rgui_video_settings_t *video_settings)
    /* Could use settings->video_viewport_custom directly,
     * but this seems to be the standard way of doing it... */
    video_viewport_t *custom_vp = video_viewport_get_custom();
-   
+
    if (!settings)
       return;
-   
+
    video_settings->aspect_ratio_idx = settings->uints.video_aspect_ratio_idx;
    video_settings->viewport.width   = custom_vp->width;
    video_settings->viewport.height  = custom_vp->height;
@@ -5273,19 +5273,19 @@ static void rgui_set_video_config(rgui_t *rgui,
    /* Could use settings->video_viewport_custom directly,
     * but this seems to be the standard way of doing it... */
    video_viewport_t *custom_vp = video_viewport_get_custom();
-   
+
    if (!settings)
       return;
-   
+
    settings->uints.video_aspect_ratio_idx = video_settings->aspect_ratio_idx;
    custom_vp->width                       = video_settings->viewport.width;
    custom_vp->height                      = video_settings->viewport.height;
    custom_vp->x                           = video_settings->viewport.x;
    custom_vp->y                           = video_settings->viewport.y;
-   
+
    aspectratio_lut[ASPECT_RATIO_CUSTOM].value =
       (float)custom_vp->width / custom_vp->height;
-   
+
    if (delay_update)
       rgui->aspect_update_pending = true;
    else
@@ -5305,25 +5305,25 @@ static void rgui_update_menu_viewport(rgui_t *rgui,
 #if !defined(GEKKO)
    bool do_integer_scaling    = false;
    settings_t       *settings = config_get_ptr();
-#if defined(DINGUX)
+#if defined(DINGUX) && !defined(HAVE_SDL2)
    unsigned aspect_ratio_lock = RGUI_ASPECT_RATIO_LOCK_NONE;
 #else
    unsigned aspect_ratio_lock = settings ? settings->uints.menu_rgui_aspect_ratio_lock : 0;
 #endif
-   
+
    if (!settings)
       return;
 #endif
-   
+
    fb_width                   = p_disp->framebuf_width;
    fb_height                  = p_disp->framebuf_height;
 
    video_driver_get_viewport_info(&vp);
-   
+
    /* Could do this once in rgui_init(), but seems cleaner to
     * handle all video config in one place... */
    rgui->menu_video_settings.aspect_ratio_idx = ASPECT_RATIO_CUSTOM;
-   
+
    /* Determine custom viewport layout */
    if (fb_width > 0 && fb_height > 0 && vp.full_width > 0 && vp.full_height > 0)
    {
@@ -5339,7 +5339,7 @@ static void rgui_update_menu_viewport(rgui_t *rgui,
       float device_aspect  = (4.0f / 3.0f);
 #endif
       float desired_aspect = (float)fb_width / (float)fb_height;
-      
+
       if (device_aspect > desired_aspect)
       {
          delta = (desired_aspect / device_aspect - 1.0f) / 2.0f + 0.5f;
@@ -5354,17 +5354,17 @@ static void rgui_update_menu_viewport(rgui_t *rgui,
       }
 #else
       /* Check whether we need to perform integer scaling */
-      do_integer_scaling = (aspect_ratio_lock 
+      do_integer_scaling = (aspect_ratio_lock
             == RGUI_ASPECT_RATIO_LOCK_INTEGER);
-      
+
       if (do_integer_scaling)
       {
          unsigned width_scale  = (vp.full_width / fb_width);
          unsigned height_scale = (vp.full_height / fb_height);
-         unsigned        scale = (width_scale <= height_scale) 
-            ? width_scale 
+         unsigned        scale = (width_scale <= height_scale)
+            ? width_scale
             : height_scale;
-         
+
          if (scale > 0)
          {
             rgui->menu_video_settings.viewport.width = scale * fb_width;
@@ -5373,7 +5373,7 @@ static void rgui_update_menu_viewport(rgui_t *rgui,
          else
             do_integer_scaling = false;
       }
-      
+
       /* Check whether menu should be stretched to
        * fill the screen, regardless of internal
        * aspect ratio */
@@ -5385,11 +5385,11 @@ static void rgui_update_menu_viewport(rgui_t *rgui,
       /* Normal non-integer aspect-ratio-correct scaling */
       else if (!do_integer_scaling)
       {
-         float display_aspect_ratio = (float)vp.full_width 
+         float display_aspect_ratio = (float)vp.full_width
             / (float)vp.full_height;
-         float         aspect_ratio = (float)fb_width 
+         float         aspect_ratio = (float)fb_width
             / (float)fb_height;
-         
+
          if (aspect_ratio > display_aspect_ratio)
          {
             rgui->menu_video_settings.viewport.width  = vp.full_width;
@@ -5402,15 +5402,15 @@ static void rgui_update_menu_viewport(rgui_t *rgui,
          }
       }
 #endif
-      
+
       /* Sanity check */
-      rgui->menu_video_settings.viewport.width = 
-         (rgui->menu_video_settings.viewport.width < 1) 
-         ? 1 
+      rgui->menu_video_settings.viewport.width =
+         (rgui->menu_video_settings.viewport.width < 1)
+         ? 1
          : rgui->menu_video_settings.viewport.width;
-      rgui->menu_video_settings.viewport.height = 
-         (rgui->menu_video_settings.viewport.height < 1) 
-         ? 1 
+      rgui->menu_video_settings.viewport.height =
+         (rgui->menu_video_settings.viewport.height < 1)
+         ? 1
          : rgui->menu_video_settings.viewport.height;
    }
    else
@@ -5418,7 +5418,7 @@ static void rgui_update_menu_viewport(rgui_t *rgui,
       rgui->menu_video_settings.viewport.width  = 1;
       rgui->menu_video_settings.viewport.height = 1;
    }
-   
+
    rgui->menu_video_settings.viewport.x = (vp.full_width - rgui->menu_video_settings.viewport.width) / 2;
    rgui->menu_video_settings.viewport.y = (vp.full_height - rgui->menu_video_settings.viewport.height) / 2;
 }
@@ -5434,7 +5434,7 @@ static bool rgui_set_aspect_ratio(rgui_t *rgui,
     * the usual 426, since the last two bits of the
     * width value must be zero... */
    unsigned max_frame_buf_width = 424;
-#elif defined(DINGUX)
+#elif defined(DINGUX) && !defined(HAVE_SDL2)
    /* Dingux devices use a fixed framebuffer size
     * of 320x240 */
    unsigned max_frame_buf_width = 320;
@@ -5442,7 +5442,7 @@ static bool rgui_set_aspect_ratio(rgui_t *rgui,
    struct video_viewport vp;
    unsigned max_frame_buf_width = RGUI_MAX_FB_WIDTH;
 #endif
-#if defined(DINGUX)
+#if defined(DINGUX) && !defined(HAVE_SDL2)
    unsigned aspect_ratio        = RGUI_ASPECT_RATIO_4_3;
    unsigned aspect_ratio_lock   = RGUI_ASPECT_RATIO_LOCK_NONE;
 #else
@@ -5450,25 +5450,25 @@ static bool rgui_set_aspect_ratio(rgui_t *rgui,
    unsigned aspect_ratio        = settings->uints.menu_rgui_aspect_ratio;
    unsigned aspect_ratio_lock   = settings->uints.menu_rgui_aspect_ratio_lock;
 #endif
-   
+
    rgui_framebuffer_free(&rgui->frame_buf);
    rgui_framebuffer_free(&rgui->background_buf);
    rgui_thumbnail_free(&rgui->fs_thumbnail);
    rgui_thumbnail_free(&rgui->mini_thumbnail);
    rgui_thumbnail_free(&rgui->mini_left_thumbnail);
-   
+
    /* Cache new aspect ratio */
    rgui->menu_aspect_ratio = aspect_ratio;
-   
+
    /* Set frame buffer dimensions: */
-   
+
    /* Frame buffer height */
 #if defined(GEKKO)
    /* Since Wii graphics driver can change frame buffer
     * dimensions at will, have to read currently set
     * values */
    rgui->frame_buf.height = p_disp->framebuf_height;
-#elif defined(DINGUX)
+#elif defined(DINGUX) && !defined(HAVE_SDL2)
    /* Dingux devices use a fixed framebuffer size
     * of 320x240 */
    rgui->frame_buf.height = 240;
@@ -5482,7 +5482,7 @@ static bool rgui_set_aspect_ratio(rgui_t *rgui,
       rgui->frame_buf.height = (vp.full_height > RGUI_MIN_FB_HEIGHT) ?
             vp.full_height : RGUI_MIN_FB_HEIGHT;
 #endif
-   
+
    /* Frame buffer width */
    switch (rgui->menu_aspect_ratio)
    {
@@ -5584,7 +5584,7 @@ static bool rgui_set_aspect_ratio(rgui_t *rgui,
          base_term_width = rgui->frame_buf.width;
          break;
    }
-   
+
    /* Ensure frame buffer/terminal width is sane
     * - Must be less than max_frame_buf_width
     *   (note that this is a redundant safety
@@ -5596,12 +5596,12 @@ static bool rgui_set_aspect_ratio(rgui_t *rgui,
          max_frame_buf_width : rgui->frame_buf.width;
    base_term_width = (base_term_width > rgui->frame_buf.width) ?
          rgui->frame_buf.width : base_term_width;
-#if !(defined(GEKKO) || defined(DINGUX))
+#if !defined(GEKKO) && !defined(DINGUX) && !defined(HAVE_SDL2)
    if (vp.full_width < rgui->frame_buf.width)
    {
       rgui->frame_buf.width = (vp.full_width > RGUI_MIN_FB_WIDTH) ?
             RGUI_ROUND_FB_WIDTH(vp.full_width) : RGUI_MIN_FB_WIDTH;
-      
+
       /* An annoyance: have to rescale the frame buffer
        * height and terminal width to maintain the correct
        * aspect ratio... */
@@ -5669,39 +5669,39 @@ static bool rgui_set_aspect_ratio(rgui_t *rgui,
       }
    }
 #endif
-   
+
    /* Allocate frame buffer */
    rgui->frame_buf.data = (uint16_t*)calloc(
          rgui->frame_buf.width * rgui->frame_buf.height, sizeof(uint16_t));
-   
+
    if (!rgui->frame_buf.data)
       return false;
-   
+
    /* Configure 'menu display' settings */
    gfx_display_set_width(rgui->frame_buf.width);
    gfx_display_set_height(rgui->frame_buf.height);
    gfx_display_set_framebuffer_pitch(rgui->frame_buf.width * sizeof(uint16_t));
-   
+
    /* Determine terminal layout */
    rgui->term_layout.start_x  = (3 * 5) + 1;
    rgui->term_layout.start_y  = (3 * 5) + rgui->font_height_stride;
    rgui->term_layout.width    = (base_term_width - (2 * rgui->term_layout.start_x)) / rgui->font_width_stride;
    rgui->term_layout.height   = (rgui->frame_buf.height - (2 * rgui->term_layout.start_y)) / rgui->font_height_stride;
    rgui->term_layout.value_maxlen = (unsigned)((RGUI_ENTRY_VALUE_MAXLEN_FRACTION * (float)rgui->term_layout.width) + 1.0f);
-   
+
    /* > 'Start X/Y' adjustments */
    rgui->term_layout.start_x  = (rgui->frame_buf.width - (rgui->term_layout.width * rgui->font_width_stride)) / 2;
    rgui->term_layout.start_y  = (rgui->frame_buf.height - (rgui->term_layout.height * rgui->font_height_stride)) / 2;
-   
+
    /* Allocate background buffer */
    rgui->background_buf.width = rgui->frame_buf.width;
    rgui->background_buf.height= rgui->frame_buf.height;
    rgui->background_buf.data  = (uint16_t*)calloc(
          rgui->background_buf.width * rgui->background_buf.height, sizeof(uint16_t));
-   
+
    if (!rgui->background_buf.data)
       return false;
-   
+
    /* Allocate thumbnail buffer */
    rgui->fs_thumbnail.max_width    = rgui->frame_buf.width;
    rgui->fs_thumbnail.max_height   = rgui->frame_buf.height;
@@ -5709,13 +5709,13 @@ static bool rgui_set_aspect_ratio(rgui_t *rgui,
          rgui->fs_thumbnail.max_width * rgui->fs_thumbnail.max_height, sizeof(uint16_t));
    if (!rgui->fs_thumbnail.data)
       return false;
-   
+
    /* Allocate mini thumbnail buffers */
    mini_thumbnail_term_width       = (unsigned)((float)rgui->term_layout.width * (2.0f / 5.0f));
    mini_thumbnail_term_width       = mini_thumbnail_term_width > 19 ? 19 : mini_thumbnail_term_width;
    rgui->mini_thumbnail_max_width  = mini_thumbnail_term_width * rgui->font_width_stride;
    rgui->mini_thumbnail_max_height = (unsigned)((rgui->term_layout.height * rgui->font_height_stride) * 0.5f) - 2;
-   
+
    rgui->mini_thumbnail.max_width  = rgui->mini_thumbnail_max_width;
    rgui->mini_thumbnail.max_height = rgui->mini_thumbnail_max_height;
    rgui->mini_thumbnail.data       = (uint16_t*)calloc(
@@ -5723,7 +5723,7 @@ static bool rgui_set_aspect_ratio(rgui_t *rgui,
          sizeof(uint16_t));
    if (!rgui->mini_thumbnail.data)
       return false;
-   
+
    rgui->mini_left_thumbnail.max_width  = rgui->mini_thumbnail_max_width;
    rgui->mini_left_thumbnail.max_height = rgui->mini_thumbnail_max_height;
    rgui->mini_left_thumbnail.data       = (uint16_t*)calloc(
@@ -5731,12 +5731,12 @@ static bool rgui_set_aspect_ratio(rgui_t *rgui,
          sizeof(uint16_t));
    if (!rgui->mini_left_thumbnail.data)
       return false;
-   
+
    /* Trigger background/display update */
    rgui->theme_preset_path[0] = '\0';
    rgui->bg_modified          = true;
    rgui->force_redraw         = true;
-   
+
    /* If aspect ratio lock is enabled, notify
     * video driver of change */
    if ((aspect_ratio_lock != RGUI_ASPECT_RATIO_LOCK_NONE) &&
@@ -5745,7 +5745,7 @@ static bool rgui_set_aspect_ratio(rgui_t *rgui,
       rgui_update_menu_viewport(rgui, p_disp);
       rgui_set_video_config(rgui, &rgui->menu_video_settings, delay_update);
    }
-   
+
    return true;
 }
 
@@ -5775,7 +5775,7 @@ static void *rgui_init(void **userdata, bool video_is_threaded)
    settings_t *settings       = config_get_ptr();
    gfx_display_t    *p_disp   = disp_get_ptr();
    gfx_animation_t *p_anim    = anim_get_ptr();
-#if defined(DINGUX)
+#if defined(DINGUX) && !defined(HAVE_SDL2)
    unsigned aspect_ratio_lock = RGUI_ASPECT_RATIO_LOCK_NONE;
 #else
    unsigned aspect_ratio_lock = settings->uints.menu_rgui_aspect_ratio_lock;
@@ -5882,7 +5882,7 @@ static void *rgui_init(void **userdata, bool video_is_threaded)
     * values (shoult not be necessary, but some platforms may
     * not handle struct initialisation correctly...) */
    memset(&rgui->pointer, 0, sizeof(menu_input_pointer_t));
-   
+
    p_anim->updatetime_cb = rgui_menu_animation_update_time;
 
    return menu;
@@ -5935,7 +5935,7 @@ static void rgui_set_texture(void *data)
    unsigned fb_width, fb_height;
    settings_t            *settings = config_get_ptr();
    gfx_display_t          *p_disp  = disp_get_ptr();
-#if defined(DINGUX)
+#if defined(DINGUX) && !defined(HAVE_SDL2)
    unsigned internal_upscale_level = RGUI_UPSCALE_NONE;
 #else
    unsigned internal_upscale_level = settings->uints.menu_rgui_internal_upscale_level;
@@ -5959,10 +5959,10 @@ static void rgui_set_texture(void *data)
    else
    {
       struct video_viewport vp;
-      
+
       /* Get viewport dimensions */
       video_driver_get_viewport_info(&vp);
-      
+
       /* If viewport is currently the same size (or smaller)
        * than the menu framebuffer, no scaling is required */
       if ((vp.width <= fb_width) && (vp.height <= fb_height))
@@ -5979,7 +5979,7 @@ static void rgui_set_texture(void *data)
          unsigned x_dst, y_dst;
          frame_buf_t *frame_buf   = &rgui->frame_buf;
          frame_buf_t *upscale_buf = &rgui->upscale_buf;
-         
+
          /* Determine output size */
          if (internal_upscale_level == RGUI_UPSCALE_AUTO)
          {
@@ -5991,7 +5991,7 @@ static void rgui_set_texture(void *data)
             out_width  = internal_upscale_level * fb_width;
             out_height = internal_upscale_level * fb_height;
          }
-         
+
          /* Allocate upscaling buffer, if required */
          if (  (upscale_buf->width  != out_width)  ||
                (upscale_buf->height != out_height) ||
@@ -5999,13 +5999,13 @@ static void rgui_set_texture(void *data)
          {
             upscale_buf->width = out_width;
             upscale_buf->height = out_height;
-            
+
             if (upscale_buf->data)
             {
                free(upscale_buf->data);
                upscale_buf->data = NULL;
             }
-            
+
             upscale_buf->data = (uint16_t*)
                   calloc(out_width * out_height, sizeof(uint16_t));
             if (!upscale_buf->data)
@@ -6021,7 +6021,7 @@ static void rgui_set_texture(void *data)
                return;
             }
          }
-         
+
          /* Perform nearest neighbour upscaling
           * NB: We're duplicating code here, but trying to handle
           * this with a polymorphic function is too much of a drag... */
@@ -6037,7 +6037,7 @@ static void rgui_set_texture(void *data)
                upscale_buf->data[(y_dst * out_width) + x_dst] = frame_buf->data[(y_src * fb_width) + x_src];
             }
          }
-         
+
          /* Draw upscaled texture */
          video_driver_set_texture_frame(upscale_buf->data,
             false, out_width, out_height, 1.0f);
@@ -6080,7 +6080,7 @@ static void rgui_load_current_thumbnails(rgui_t *rgui, bool download_missing)
    const char *thumbnail_path      = NULL;
    const char *left_thumbnail_path = NULL;
    bool thumbnails_missing         = false;
-   
+
    /* Right (or fullscreen) thumbnail */
    if (gfx_thumbnail_get_path(rgui->thumbnail_path_data,
          GFX_THUMBNAIL_RIGHT, &thumbnail_path))
@@ -6092,7 +6092,7 @@ static void rgui_load_current_thumbnails(rgui_t *rgui, bool download_missing)
             thumbnail_path,
             &thumbnails_missing);
    }
-   
+
    /* Left thumbnail
     * (Note: there is no need to load this when viewing
     * fullscreen thumbnails) */
@@ -6109,14 +6109,14 @@ static void rgui_load_current_thumbnails(rgui_t *rgui, bool download_missing)
                &thumbnails_missing);
       }
    }
-   
+
    /* Reset 'load pending' state */
    rgui->thumbnail_load_pending = false;
-   
+
    /* Force a redraw (so 'entry_has_thumbnail' values are
     * applied immediately) */
    rgui->force_redraw           = true;
-   
+
 #ifdef HAVE_NETWORKING
    /* On demand thumbnail downloads */
    if (thumbnails_missing && download_missing)
@@ -6143,7 +6143,7 @@ static void rgui_scan_selected_entry_thumbnail(rgui_t *rgui, bool force_load)
    rgui->thumbnail_load_pending      = false;
 
    /* Update thumbnail content/path */
-   if ((rgui->show_fs_thumbnail || rgui_inline_thumbnails) 
+   if ((rgui->show_fs_thumbnail || rgui_inline_thumbnails)
          && rgui->is_playlist)
    {
       size_t selection      = menu_navigation_get_selection();
@@ -6167,7 +6167,7 @@ static void rgui_scan_selected_entry_thumbnail(rgui_t *rgui, bool force_load)
       {
          if (gfx_thumbnail_is_enabled(rgui->thumbnail_path_data, GFX_THUMBNAIL_RIGHT))
             has_thumbnail = gfx_thumbnail_update_path(rgui->thumbnail_path_data, GFX_THUMBNAIL_RIGHT);
-         
+
          if (rgui_inline_thumbnails &&
              gfx_thumbnail_is_enabled(rgui->thumbnail_path_data, GFX_THUMBNAIL_LEFT))
             has_thumbnail = gfx_thumbnail_update_path(rgui->thumbnail_path_data, GFX_THUMBNAIL_LEFT) ||
@@ -6273,33 +6273,33 @@ static void rgui_update_menu_sublabel(rgui_t *rgui)
    size_t     selection     = menu_navigation_get_selection();
    settings_t *settings     = config_get_ptr();
    bool menu_show_sublabels = settings->bools.menu_show_sublabels;
-   
+
    rgui->menu_sublabel[0] = '\0';
-   
+
    if (menu_show_sublabels && selection < menu_entries_get_size())
    {
       menu_entry_t entry;
-      
+
       MENU_ENTRY_INIT(entry);
       entry.path_enabled       = false;
       entry.label_enabled      = false;
       entry.rich_label_enabled = false;
       entry.value_enabled      = false;
       menu_entry_get(&entry, 0, (unsigned)selection, NULL, true);
-      
+
       if (!string_is_empty(entry.sublabel))
       {
          size_t line_index;
-         static const char* const 
+         static const char* const
             sublabel_spacer       = RGUI_TICKER_SPACER;
          bool prev_line_empty     = true;
          /* Sanitise sublabel
           * > Replace newline characters with standard delimiter
           * > Remove whitespace surrounding each sublabel line */
          struct string_list list  = {0};
-         
+
          string_list_initialize(&list);
-         
+
          if (string_split_noalloc(&list, entry.sublabel, "\n"))
          {
             for (line_index = 0; line_index < list.size; line_index++)
@@ -6384,7 +6384,7 @@ static void rgui_populate_entries(void *data,
       const char *label, unsigned k)
 {
    rgui_t       *rgui         = (rgui_t*)data;
-#if defined(DINGUX)
+#if defined(DINGUX) && !defined(HAVE_SDL2)
    unsigned aspect_ratio_lock = RGUI_ASPECT_RATIO_LOCK_NONE;
 #else
    settings_t       *settings = config_get_ptr();
@@ -6393,7 +6393,7 @@ static void rgui_populate_entries(void *data,
 #ifdef HAVE_LANGEXTRA
    gfx_display_t *p_disp  = disp_get_ptr();
 #endif
-   
+
    if (!rgui)
       return;
 
@@ -6417,20 +6417,20 @@ static void rgui_populate_entries(void *data,
       rgui_set_aspect_ratio(rgui, p_disp, true);
    }
 #endif
-   
+
    /* Check whether we are currently viewing a playlist */
    rgui->is_playlist = string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_PLAYLIST_LIST)) ||
                        string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_LOAD_CONTENT_HISTORY)) ||
                        string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_FAVORITES_LIST));
-   
+
    /* Set menu title */
    menu_entries_get_title(rgui->menu_title, sizeof(rgui->menu_title));
-   
+
    /* Cancel any pending thumbnail load operations */
    rgui->thumbnail_load_pending = false;
-   
+
    rgui_navigation_set(data, true);
-   
+
    /* If aspect ratio lock is enabled, must restore
     * content video settings when accessing the video
     * scaling settings menu... */
@@ -6586,7 +6586,7 @@ static void rgui_frame(void *data, video_frame_info_t *video_info)
    settings_t *settings                = config_get_ptr();
    bool bg_filler_thickness_enable     = settings->bools.menu_rgui_background_filler_thickness_enable;
    bool border_filler_thickness_enable = settings->bools.menu_rgui_border_filler_thickness_enable;
-#if defined(DINGUX)
+#if defined(DINGUX) && !defined(HAVE_SDL2)
    unsigned aspect_ratio               = RGUI_ASPECT_RATIO_4_3;
    unsigned aspect_ratio_lock          = RGUI_ASPECT_RATIO_LOCK_NONE;
 #else
@@ -6802,29 +6802,29 @@ static void rgui_toggle(void *userdata, bool menu_on)
    rgui_t               *rgui = (rgui_t*)userdata;
    settings_t       *settings = config_get_ptr();
    gfx_display_t    *p_disp   = disp_get_ptr();
-#if defined(DINGUX)
+#if defined(DINGUX) && !defined(HAVE_SDL2)
    unsigned aspect_ratio_lock = RGUI_ASPECT_RATIO_LOCK_NONE;
 #else
    unsigned aspect_ratio_lock = settings ? settings->uints.menu_rgui_aspect_ratio_lock : 0;
 #endif
-   
+
    /* TODO/FIXME - when we close RetroArch, this function
-    * gets called and settings is NULL at this point. 
+    * gets called and settings is NULL at this point.
     * Maybe fundamentally change control flow so that on RetroArch
     * exit, this doesn't get called. */
    if (!rgui || !settings)
       return;
-   
+
    if (aspect_ratio_lock != RGUI_ASPECT_RATIO_LOCK_NONE)
    {
       if (menu_on)
       {
          /* Cache content video settings */
          rgui_get_video_config(&rgui->content_video_settings);
-         
+
          /* Update menu viewport */
          rgui_update_menu_viewport(rgui, p_disp);
-         
+
          /* Apply menu video settings */
          rgui_set_video_config(rgui, &rgui->menu_video_settings, false);
       }
@@ -6835,17 +6835,17 @@ static void rgui_toggle(void *userdata, bool menu_on)
           * last toggled on */
          rgui_video_settings_t current_video_settings = {{0}};
          rgui_get_video_config(&current_video_settings);
-         
+
          if (rgui_is_video_config_equal(&current_video_settings, &rgui->menu_video_settings))
             rgui_set_video_config(rgui, &rgui->content_video_settings, false);
-         
+
          /* Any modified video scaling settings have now been
           * registered, so it is again 'safe' to respond to window
           * resize events */
          rgui->ignore_resize_events = false;
       }
    }
-   
+
    /* Upscaling buffer is only required while menu is on. Save
     * memory by freeing it whenever we switch back to the current
     * content */


### PR DESCRIPTION
## Description

The gcw0 OpenDingux beta buildroot ships with SDL2.

Makes the following changes:

* The display driver changes from sdl_dingux to sdl
* The controller driver changes from sdl_dingux_joypad to sdl_joypad

## What works (that I have tested so far)

* rgui starts
* Input auto-configures and works correctly
* Core and games start. I have tested a few Genesis and GBA games as a sanity test

## What doesn't work

- The menu button no longer works.
- Can't set the refresh rate to 50 hz
- Can't set the IPU filter type
- Can't set the IPU scaling mode
- [Update] Rumble doesn't work. I used Drill Dozer on the mGBA core on nightly and I had haptic, but not on this experimental branch. Ideally the SDLHaptic_* function would work properly on this platform, and we wouldn't have to do anything. Could have a workaround using LibShake

## What might work

- The SDL1 code had some complex "Video Frame sanitization" logic. I'm not sure how much of that is necessary under SDL2
- Performance may or may not be better. I should probably benchmark a few different games. It doesn't appear to be significant in either direction from my limited testing
