### PR TITLE
Remove bash-ism which was preventing strip from working on OpenDingux

### DIFF
--- a/Makefile.rg350
+++ b/Makefile.rg350
@@ -219,7 +219,9 @@ opk: $(TARGET)
 	echo "$$DESKTOP_ENTRY" > default.gcw0.desktop
 	rm -f $(OPK_NAME)
 	cp media/ico_src/icon32.png retroarch.png
-	if [ $$STRIP_BIN -eq 1 ]; then $(STRIP) --strip-unneeded retroarch; fi
+ifeq ($(STRIP_BIN),1)
+	$(STRIP) --strip-unneeded retroarch
+endif
 	$(GCW0_MK_SQUASH_FS) retroarch default.gcw0.desktop retroarch.png $(OPK_NAME) -all-root -no-xattrs -noappend -no-exports
 	rm -f default.gcw0.desktop retroarch.png
 

--- a/Makefile.rg350_odbeta
+++ b/Makefile.rg350_odbeta
@@ -219,7 +219,9 @@ opk: $(TARGET)
 	echo "$$DESKTOP_ENTRY" > default.gcw0.desktop
 	rm -f $(OPK_NAME)
 	cp media/ico_src/icon32.png retroarch.png
-	if [ $$STRIP_BIN -eq 1 ]; then $(STRIP) --strip-unneeded retroarch; fi
+ifeq ($(STRIP_BIN),1)
+	$(STRIP) --strip-unneeded retroarch
+endif
 	$(GCW0_MK_SQUASH_FS) retroarch default.gcw0.desktop retroarch.png $(OPK_NAME) -all-root -no-xattrs -noappend -no-exports
 	rm -f default.gcw0.desktop retroarch.png
 


### PR DESCRIPTION
Resolves https://github.com/libretro/RetroArch/issues/12570 with **correct** white space in the Makefiles.

![Screenshot from 2021-06-26 21-08-45](https://user-images.githubusercontent.com/2071543/123530692-f194ea80-d6c2-11eb-82a4-c9459a90e973.png)

Side-note: Is there a way to enable a "show invisibles" setting in GitHub?
