### PR TITLE
Fix archive delimiter detection when file path contains no slashes

### DIFF
--- a/libretro-common/file/file_path.c
+++ b/libretro-common/file/file_path.c
@@ -87,8 +87,14 @@ const char *path_get_archive_delim(const char *path)
 
    buf[0] = '\0';
 
+   /* We search for delimiters after the last slash
+    * in the file path to avoid capturing delimiter
+    * characters in any parent directory names.
+    * If there are no slashes in the file name, then
+    * the path is just the file basename - in this
+    * case we search the path in its entirety */
    if (!last_slash)
-      return NULL;
+      last_slash = path;
 
    /* Find delimiter position
     * > Since filenames may contain '#' characters,


### PR DESCRIPTION
## Description

As reported in  #12577, RetroArch fails to load archived content when the content path contains no slashes. This is due to a bug/oversight in `path_get_archive_delim()`, whereby paths are effectively ignored if `find_last_slash()` returns `NULL`. This trivial PR fixes the issue.

## Related Issues

Closes  #12577