### PR TITLE
(Qt) Fix default core detection when playlist file name does not match 'db_name'

### DIFF
--- a/ui/drivers/qt/qt_playlist.cpp
+++ b/ui/drivers/qt/qt_playlist.cpp
@@ -1401,12 +1401,12 @@ void MainWindow::deleteCurrentPlaylistItem()
    reloadPlaylists();
 }
 
-QString MainWindow::getPlaylistDefaultCore(QString dbName)
+QString MainWindow::getPlaylistDefaultCore(QString plName)
 {
    playlist_config_t playlist_config;
    char playlistPath[PATH_MAX_LENGTH];
-   QByteArray dbNameByteArray          = dbName.toUtf8();
-   const char *dbNameCString           = dbNameByteArray.data();
+   QByteArray plNameByteArray          = plName.toUtf8();
+   const char *plNameCString           = plNameByteArray.data();
    playlist_t *cachedPlaylist          = playlist_get_cached();
    playlist_t *playlist                = NULL;
    bool loadPlaylist                   = true;
@@ -1421,13 +1421,13 @@ QString MainWindow::getPlaylistDefaultCore(QString dbName)
 
    playlistPath[0] = '\0';
 
-   if (!settings || string_is_empty(dbNameCString))
+   if (!settings || string_is_empty(plNameCString))
       return corePath;
 
    /* Get playlist path */
    fill_pathname_join(
       playlistPath,
-      settings->paths.directory_playlist, dbNameCString,
+      settings->paths.directory_playlist, plNameCString,
       sizeof(playlistPath));
    strlcat(playlistPath, ".lpl", sizeof(playlistPath));
 
@@ -1479,6 +1479,7 @@ void PlaylistModel::getPlaylistItems(QString path)
    QByteArray pathArray;
    playlist_config_t playlist_config;
    const char *pathData                = NULL;
+   const char *playlistName            = NULL;
    playlist_t *playlist                = NULL;
    unsigned playlistSize               = 0;
    unsigned            i               = 0;
@@ -1492,6 +1493,8 @@ void PlaylistModel::getPlaylistItems(QString path)
 
    pathArray.append(path);
    pathData              = pathArray.constData();
+   if (!string_is_empty(pathData))
+      playlistName       = path_basename(pathData);
 
    playlist_config_set_path(&playlist_config, pathData);
    playlist              = playlist_init(&playlist_config);
@@ -1534,6 +1537,12 @@ void PlaylistModel::getPlaylistItems(QString path)
       {
          hash["db_name"]     = entry->db_name;
          hash["db_name"].remove(".lpl");
+      }
+
+      if (!string_is_empty(playlistName))
+      {
+         hash["pl_name"]     = playlistName;
+         hash["pl_name"].remove(".lpl");
       }
 
       m_contents.append(hash);

--- a/ui/drivers/ui_qt.cpp
+++ b/ui/drivers/ui_qt.cpp
@@ -2731,12 +2731,19 @@ QHash<QString, QString> MainWindow::getSelectedCore()
          break;
       case CORE_SELECTION_PLAYLIST_DEFAULT:
       {
+         QString plName;
          QString defaultCorePath;
 
-         if (contentHash.isEmpty() || contentHash["db_name"].isEmpty())
+         if (contentHash.isEmpty())
             break;
 
-         defaultCorePath = getPlaylistDefaultCore(contentHash["db_name"]);
+         plName = contentHash["pl_name"].isEmpty() ?
+               contentHash["db_name"] : contentHash["pl_name"];
+
+         if (plName.isEmpty())
+            break;
+
+         defaultCorePath = getPlaylistDefaultCore(plName);
 
          if (!defaultCorePath.isEmpty())
             coreHash["core_path"] = defaultCorePath;
@@ -2845,7 +2852,10 @@ void MainWindow::loadContent(const QHash<QString, QString> &contentHash)
          break;
       case CORE_SELECTION_PLAYLIST_DEFAULT:
       {
-         QString defaultCorePath = getPlaylistDefaultCore(contentHash["db_name"]);
+         QString plName = contentHash["pl_name"].isEmpty() ?
+               contentHash["db_name"] : contentHash["pl_name"];
+
+         QString defaultCorePath = getPlaylistDefaultCore(plName);
 
          if (!defaultCorePath.isEmpty())
          {
@@ -3034,7 +3044,8 @@ void MainWindow::setCoreActions()
    switch(m_currentBrowser)
    {
       case BROWSER_TYPE_PLAYLISTS:
-         currentPlaylistFileName = hash["db_name"];
+         currentPlaylistFileName = hash["pl_name"].isEmpty() ?
+               hash["db_name"] : hash["pl_name"];
          break;
       case BROWSER_TYPE_FILES:
          currentPlaylistFileName = m_fileModel->rootDirectory().dirName();

--- a/ui/drivers/ui_qt.h
+++ b/ui/drivers/ui_qt.h
@@ -368,7 +368,7 @@ public:
    QToolButton* runPushButton();
    QToolButton* stopPushButton();
    QTabWidget* browserAndPlaylistTabWidget();
-   QString getPlaylistDefaultCore(QString dbName);
+   QString getPlaylistDefaultCore(QString plName);
    ViewOptionsDialog* viewOptionsDialog();
    QSettings* settings();
    QVector<QHash<QString, QString> > getCoreInfo();


### PR DESCRIPTION
## Description

At present, when content is loaded from a playlist via the Qt interface and the core path for the current entry is set to `DEFAULT`, RetroArch attempts to read the playlist-specific default core path - but the actual playlist file from which this path is extracted is derived from the `db_name` (database name) field of the current entry. In most cases, 'playlist name' and `db_name` are identical - but if a user creates custom playlists, there need be no connection at all between the two values. When dealing with these types of playlist, the Qt interface will determine the default core path incorrectly.

This PR fixes the issue by always using the 'real' playlist file name for the current entry when fetching the default core path.