### PR TITLE
[DRAFT] RetroMini RS-90 Support

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -668,7 +668,7 @@ else ifeq ($(HAVE_BUILTINMBEDTLS), 1)
       DEFINES += -DMBEDTLS_SSL_DEBUG_ALL
    endif
 
-   # MinGW requires this for some reason, 
+   # MinGW requires this for some reason,
 	# even though the include paths are relative to the source
    INCLUDE_DIRS += -Ideps/mbedtls
 
@@ -1576,8 +1576,14 @@ else ifeq ($(HAVE_SDL), 1)
 else ifeq ($(HAVE_SDL_DINGUX), 1)
    HAVE_SDL_COMMON = 1
    DEF_FLAGS += -DHAVE_SDL -DHAVE_SDL_DINGUX
-   OBJ += gfx/drivers/sdl_dingux_gfx.o \
-          input/drivers/sdl_dingux_input.o \
+
+   ifeq ($(RS90), 1)
+      OBJ += gfx/drivers/sdl_rs90_gfx.o
+   else
+      OBJ += gfx/drivers/sdl_dingux_gfx.o
+   endif
+
+   OBJ += input/drivers/sdl_dingux_input.o \
           input/drivers_joypad/sdl_dingux_joypad.o
    DEF_FLAGS += $(SDL_DINGUX_CFLAGS)
    LIBS += $(SDL_DINGUX_LIBS)
@@ -2296,9 +2302,9 @@ ifeq ($(HAVE_CRTSWITCHRES), 1)
              $(DEPS_DIR)/switchres/resync_windows.o
    endif
    ifneq ($(findstring Linux,$(OS)),)
-      OBJ += $(DEPS_DIR)/switchres/display_linux.o 
+      OBJ += $(DEPS_DIR)/switchres/display_linux.o
       ifeq ($(HAVE_X11)$(HAVE_XRANDR), 11)
-         OBJ += $(DEPS_DIR)/switchres/custom_video_xrandr.o 
+         OBJ += $(DEPS_DIR)/switchres/custom_video_xrandr.o
          DEFINES += -DSR_WITH_XRANDR
       endif
    endif
@@ -2325,9 +2331,9 @@ ifeq ($(HAVE_COCOA_COMMON),1)
    OBJ += input/drivers/cocoa_input.o \
           ui/drivers/ui_cocoa.o \
           ui/drivers/cocoa/cocoa_common.o
-          
+
    ifeq ($(HAVE_OPENGL), 1)
-           DEFINES += -DGL_SILENCE_DEPRECATION	 
+           DEFINES += -DGL_SILENCE_DEPRECATION
 	   OBJ += gfx/drivers_context/cocoa_gl_ctx.o
    endif
    ifeq ($(HAVE_VULKAN), 1)
@@ -2482,4 +2488,3 @@ ifeq ($(HAVE_ODROIDGO2), 1)
 endif
 
 ##################################
-

--- a/Makefile.rs90
+++ b/Makefile.rs90
@@ -1,0 +1,236 @@
+#########################
+## Toolchain variables ##
+#########################
+
+# Alpha toolchain
+TOOLCHAIN_DIR=/opt/rs90-toolchain
+
+# All toolchain-related variables may be
+# overridden via the command line
+ifdef GCW0_CC
+CC                    = $(GCW0_CC)
+else
+CC                    = $(TOOLCHAIN_DIR)/usr/bin/mipsel-rs90-linux-musl-gcc
+endif
+
+ifdef GCW0_CXX
+CXX                   = $(GCW0_CXX)
+else
+CXX                   = $(TOOLCHAIN_DIR)/usr/bin/mipsel-rs90-linux-musl-g++
+endif
+
+ifdef GCW0_STRIP
+STRIP                 = $(GCW0_STRIP)
+else
+STRIP                 = $(TOOLCHAIN_DIR)/usr/bin/mipsel-rs90-linux-musl-strip
+endif
+
+GCW0_SDL_CONFIG      ?= $(TOOLCHAIN_DIR)/usr/mipsel-rs90-linux-musl/sysroot/usr/bin/sdl-config
+GCW0_FREETYPE_CONFIG ?= $(TOOLCHAIN_DIR)/usr/mipsel-rs90-linux-musl/sysroot/usr/bin/freetype-config
+GCW0_MK_SQUASH_FS    ?= $(TOOLCHAIN_DIR)/usr/bin/mksquashfs
+
+GCW0_INC_DIR         ?= $(TOOLCHAIN_DIR)/usr/mipsel-rs90-linux-musl/sysroot/usr/include
+GCW0_LIB_DIR         ?= $(TOOLCHAIN_DIR)/usr/mipsel-rs90-linux-musl/sysroot/usr/lib
+
+#########################
+#########################
+
+PACKAGE_NAME = retroarch
+
+DEBUG ?= 0
+
+RS90 = 1
+DINGUX = 1
+DINGUX_BETA = 1
+HAVE_SCREENSHOTS = 0
+HAVE_REWIND = 1
+HAVE_7ZIP = 1
+HAVE_AL = 0
+# ALSA freezes when switching back from menu
+HAVE_ALSA = 1
+HAVE_DSP_FILTER = 1
+HAVE_VIDEO_FILTER = 1
+HAVE_STATIC_VIDEO_FILTERS = 1
+HAVE_STATIC_AUDIO_FILTERS = 1
+HAVE_FILTERS_BUILTIN	= 1
+HAVE_BUILTINMBEDTLS = 0
+HAVE_BUILTINZLIB = 1
+HAVE_C99 = 1
+HAVE_CC = 1
+HAVE_CC_RESAMPLER = 1
+
+HAVE_CHD = 1
+HAVE_COMMAND = 0
+HAVE_CXX = 1
+HAVE_DR_MP3 = 1
+HAVE_DYNAMIC = 1
+HAVE_EGL = 0
+HAVE_FREETYPE = 0
+HAVE_GDI = 1
+HAVE_GETADDRINFO = 0
+HAVE_GETOPT_LONG = 1
+HAVE_GLSL = 0
+HAVE_HID = 1
+HAVE_IBXM = 1
+HAVE_IMAGEVIEWER = 1
+HAVE_LANGEXTRA = 0
+HAVE_LIBRETRODB = 1
+HAVE_MENU = 1
+HAVE_MENU_COMMON = 1
+HAVE_GFX_WIDGETS = 0
+HAVE_MMAP = 1
+HAVE_OPENDINGUX_FBDEV = 0
+HAVE_OPENGL = 0
+HAVE_OPENGL1 = 0
+HAVE_OPENGLES = 0
+HAVE_OPENGLES3 = 0
+HAVE_OPENGL_CORE = 0
+HAVE_OPENSSL = 1
+HAVE_OVERLAY = 0
+HAVE_RBMP = 1
+HAVE_RJPEG = 1
+HAVE_RPILED = 0
+HAVE_RPNG = 1
+HAVE_RUNAHEAD = 1
+HAVE_SDL_DINGUX = 1
+HAVE_SHADERPIPELINE = 0
+HAVE_STB_FONT = 0
+HAVE_STB_IMAGE = 1
+HAVE_STB_VORBIS = 1
+HAVE_STDIN_CMD = 0
+HAVE_STRCASESTR = 1
+HAVE_THREADS = 1
+HAVE_UDEV = 1
+HAVE_RGUI = 1
+HAVE_MATERIALUI = 0
+HAVE_XMB = 0
+HAVE_OZONE = 0
+HAVE_ZLIB = 1
+HAVE_CONFIGFILE = 1
+HAVE_PATCH = 1
+HAVE_CHEATS = 1
+HAVE_CHEEVOS = 0
+HAVE_LIBSHAKE = 0
+HAVE_TINYALSA = 1
+HAVE_NEAREST_RESAMPLER = 1
+
+OS = Linux
+TARGET = retroarch
+OPK_NAME = retroarch_rs90_odbeta.opk
+
+OBJ :=
+LINK := $(CXX)
+DEF_FLAGS := -mplt -mno-shared
+DEF_FLAGS += -ffunction-sections -fdata-sections
+DEF_FLAGS += -I. -Ideps -Ideps/stb -DRS90=1 -DDINGUX=1 -DDINGUX_BETA=1 -MMD
+DEF_FLAGS += -Wall -Wno-unused-variable
+DEF_FLAGS += -std=gnu99 -D_GNU_SOURopendinguxCE -flto -lasound
+LIBS := -ldl -lz -lrt -ludev -pthread
+CFLAGS :=
+CXXFLAGS := -fno-exceptions -fno-rtti -std=c++11 -D__STDC_CONSTANT_MACROS
+ASFLAGS :=
+LDFLAGS := -Wl,--gc-sections
+INCLUDE_DIRS = -I$(GCW0_INC_DIR)
+LIBRARY_DIRS = -L$(GCW0_LIB_DIR)
+DEFINES := -DRARCH_INTERNAL -D_FILE_OFFSET_BITS=64 -UHAVE_STATIC_DUMMY
+DEFINES += -DHAVE_C99=1 -DHAVE_CXX=1
+DEFINES += -DHAVE_GETOPT_LONG=1 -DHAVE_STRCASESTR=1 -DHAVE_DYNAMIC=1
+DEFINES += -DHAVE_FILTERS_BUILTIN
+DEFINES += -DHAVE_UDEV=1
+DEFINES += -DHAVE_ALSA
+DEFINES += -DCC_RESAMPLER_PRECISION=0
+
+SDL_DINGUX_CFLAGS := $(shell $(GCW0_SDL_CONFIG) --cflags)
+SDL_DINGUX_LIBS := $(shell $(GCW0_SDL_CONFIG) --libs)
+FREETYPE_CFLAGS := $(shell $(GCW0_FREETYPE_CONFIG) --cflags)
+FREETYPE_LIBS := $(shell $(GCW0_FREETYPE_CONFIG) --libs)
+# AL_LIBS := -lopenal
+MMAP_LIBS = -lc
+
+OBJDIR_BASE := obj-unix
+
+ifeq ($(DEBUG), 1)
+   OBJDIR := $(OBJDIR_BASE)/debug
+   DEF_FLAGS += -O0 -g -DDEBUG -D_DEBUG
+else
+   OBJDIR := $(OBJDIR_BASE)/release
+   DEF_FLAGS += -Ofast -DNDEBUG
+endif
+
+include Makefile.common
+
+DEF_FLAGS += $(INCLUDE_DIRS)
+LDFLAGS += $(CFLAGS) $(CXXFLAGS) $(DEF_FLAGS)
+CFLAGS += $(DEF_FLAGS)
+CXXFLAGS += $(DEF_FLAGS)
+
+HEADERS = $(wildcard */*/*.h) $(wildcard */*.h) $(wildcard *.h)
+
+Q := @
+
+RARCH_OBJ := $(addprefix $(OBJDIR)/,$(OBJ))
+
+define DESKTOP_ENTRY
+[Desktop Entry]
+Name=RetroArch
+Comment=Frontend for emulators, game engines
+Exec=retroarch
+Terminal=false
+Type=Application
+StartupNotify=true
+Icon=retroarch
+Categories=emulators;
+X-OD-NeedsDownscaling=true
+endef
+export DESKTOP_ENTRY
+
+all: $(TARGET) opk
+
+-include $(RARCH_OBJ:.o=.d)
+
+SYMBOL_MAP := -Wl,-Map=output.map
+
+$(TARGET): $(RARCH_OBJ)
+	@$(if $(Q), $(shell echo echo LD $@),)
+	$(Q)$(LINK) -o $@ $(RARCH_OBJ) $(LIBS) $(LDFLAGS) $(LIBRARY_DIRS)
+
+$(OBJDIR)/%.o: %.c
+	@mkdir -p $(dir $@)
+	@$(if $(Q), $(shell echo echo CC $<),)
+	$(Q)$(CC) $(CPPFLAGS) $(CFLAGS) $(DEFINES) -c -o $@ $<
+
+$(OBJDIR)/%.o: %.cpp
+	@mkdir -p $(dir $@)
+	@$(if $(Q), $(shell echo echo CXX $<),)
+	$(Q)$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(DEFINES) -MMD -c -o $@ $<
+
+$(OBJDIR)/%.o: %.m
+	@mkdir -p $(dir $@)
+	@$(if $(Q), $(shell echo echo OBJC $<),)
+	$(Q)$(CXX) $(OBJCFLAGS) $(DEFINES) -MMD -c -o $@ $<
+
+$(OBJDIR)/%.o: %.S $(HEADERS)
+	@mkdir -p $(dir $@)
+	@$(if $(Q), $(shell echo echo AS $<),)
+	$(Q)$(CC) $(CFLAGS) $(ASFLAGS) $(DEFINES) -c -o $@ $<
+
+clean:
+	rm -rf $(OBJDIR_BASE)
+	rm -f $(TARGET)
+	rm -f *.d
+	rm -rf $(OPK_NAME)
+
+opk: $(TARGET)
+	echo "$$DESKTOP_ENTRY" > default.rs90.desktop
+	rm -f $(OPK_NAME)
+	cp media/ico_src/icon32.png retroarch.png
+ifeq ($STRIP_BIN, 1)
+	$(STRIP) --strip-unneeded retroarch
+endif
+	$(GCW0_MK_SQUASH_FS) retroarch default.rs90.desktop retroarch.png $(OPK_NAME) -all-root -no-xattrs -noappend -no-exports
+	rm -f default.rs90.desktop retroarch.png
+
+.PHONY: all clean opk
+
+print-%:
+	@echo '$*=$($*)'

--- a/config.def.h
+++ b/config.def.h
@@ -739,7 +739,9 @@ static const bool default_savefiles_in_content_dir = false;
 static const bool default_systemfiles_in_content_dir = false;
 static const bool default_screenshots_in_content_dir = false;
 
-#if defined(_XBOX1) || defined(__PS3__) || defined(_XBOX360) || defined(DINGUX)
+#if defined(RS90)
+#define DEFAULT_MENU_TOGGLE_GAMEPAD_COMBO INPUT_TOGGLE_START_SELECT
+#elif defined(_XBOX1) || defined(__PS3__) || defined(_XBOX360) || defined(DINGUX)
 #define DEFAULT_MENU_TOGGLE_GAMEPAD_COMBO INPUT_TOGGLE_L3_R3
 #elif defined(PS2) || defined(PSP)
 #define DEFAULT_MENU_TOGGLE_GAMEPAD_COMBO INPUT_TOGGLE_HOLD_START

--- a/configuration.c
+++ b/configuration.c
@@ -70,6 +70,7 @@ enum video_driver_enum
    VIDEO_SDL,
    VIDEO_SDL2,
    VIDEO_SDL_DINGUX,
+   VIDEO_SDL_RS90,
    VIDEO_EXT,
    VIDEO_WII,
    VIDEO_WIIU,
@@ -311,7 +312,11 @@ static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_SDL;
 #elif defined(HAVE_SDL2)
 static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_SDL2;
 #elif defined(HAVE_SDL_DINGUX)
+#if defined(RS90)
+static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_SDL_RS90;
+#else
 static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_SDL_DINGUX;
+#endif
 #elif defined(_WIN32) && !defined(_XBOX)
 static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_GDI;
 #elif defined(DJGPP)
@@ -388,7 +393,9 @@ static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_EXT;
 static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_NULL;
 #endif
 
-#if defined(PSP) || defined(EMSCRIPTEN)
+#if defined(RS90)
+static const enum audio_resampler_driver_enum AUDIO_DEFAULT_RESAMPLER_DRIVER = AUDIO_RESAMPLER_NEAREST;
+#elif defined(PSP) || defined(EMSCRIPTEN)
 static const enum audio_resampler_driver_enum AUDIO_DEFAULT_RESAMPLER_DRIVER = AUDIO_RESAMPLER_CC;
 #else
 static const enum audio_resampler_driver_enum AUDIO_DEFAULT_RESAMPLER_DRIVER = AUDIO_RESAMPLER_SINC;
@@ -852,6 +859,8 @@ const char *config_get_default_video(void)
          return "xvideo";
       case VIDEO_SDL_DINGUX:
          return "sdl_dingux";
+      case VIDEO_SDL_RS90:
+         return "sdl_rs90";
       case VIDEO_SDL:
          return "sdl";
       case VIDEO_SDL2:

--- a/griffin/griffin.c
+++ b/griffin/griffin.c
@@ -467,6 +467,14 @@ VIDEO DRIVER
 #include "../gfx/common/sdl2_common.c"
 #endif
 
+#if defined(DINGUX) && defined(HAVE_SDL_DINGUX)
+#if defined(RS90)
+#include "../gfx/drivers/sdl_rs90_gfx.c"
+#else
+#include "../gfx/drivers/sdl_dingux_gfx.c"
+#endif
+#endif
+
 #ifdef HAVE_VG
 #include "../gfx/drivers/vg.c"
 #endif

--- a/libretro-common/rthreads/rthreads.c
+++ b/libretro-common/rthreads/rthreads.c
@@ -872,7 +872,7 @@ bool scond_wait_timeout(scond_t *cond, slock_t *lock, int64_t timeout_us)
    int tickms = ps2_clock();
    now.tv_sec = tickms/1000;
    now.tv_nsec = tickms * 1000;
-#elif defined(__mips__) || defined(VITA) || defined(_3DS)
+#elif !defined(DINGUX_BETA) && (defined(__mips__) || defined(VITA) || defined(_3DS))
    struct timeval tm;
 
    gettimeofday(&tm, NULL);

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -7768,7 +7768,8 @@ unsigned menu_displaylist_build_list(
       case DISPLAYLIST_VIDEO_SCALING_SETTINGS_LIST:
          {
 #if defined(DINGUX)
-            if (string_is_equal(settings->arrays.video_driver, "sdl_dingux"))
+            if (string_is_equal(settings->arrays.video_driver, "sdl_dingux") ||
+                string_is_equal(settings->arrays.video_driver, "sdl_rs90"))
             {
                if (MENU_DISPLAYLIST_PARSE_SETTINGS_ENUM(list,
                         MENU_ENUM_LABEL_VIDEO_SCALE_INTEGER,

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -10954,7 +10954,8 @@ static bool setting_append_list(
             }
 
 #if defined(DINGUX) && defined(DINGUX_BETA)
-            if (string_is_equal(settings->arrays.video_driver, "sdl_dingux"))
+            if (string_is_equal(settings->arrays.video_driver, "sdl_dingux") ||
+                string_is_equal(settings->arrays.video_driver, "sdl_rs90"))
             {
                CONFIG_UINT(
                      list, list_info,
@@ -11209,7 +11210,8 @@ static bool setting_append_list(
             SETTINGS_DATA_LIST_CURRENT_ADD_FLAGS(list, list_info, SD_FLAG_LAKKA_ADVANCED);
 
 #if defined(DINGUX)
-            if (string_is_equal(settings->arrays.video_driver, "sdl_dingux"))
+            if (string_is_equal(settings->arrays.video_driver, "sdl_dingux") ||
+                string_is_equal(settings->arrays.video_driver, "sdl_rs90"))
             {
                CONFIG_BOOL(
                      list, list_info,
@@ -14935,10 +14937,11 @@ static bool setting_append_list(
                   general_read_handler);
             MENU_SETTINGS_LIST_CURRENT_ADD_VALUES(list, list_info, "cfg");
 
-            /* ps2 and sdl_dingux gfx drivers do not support
-             * menu framebuffer transparency */
+            /* ps2 and sdl_dingux/sdl_rs90 gfx drivers do
+             * not support menu framebuffer transparency */
             if (!string_is_equal(settings->arrays.video_driver, "ps2") &&
-                !string_is_equal(settings->arrays.video_driver, "sdl_dingux"))
+                !string_is_equal(settings->arrays.video_driver, "sdl_dingux") &&
+                !string_is_equal(settings->arrays.video_driver, "sdl_rs90"))
             {
                CONFIG_BOOL(
                      list, list_info,

--- a/retroarch.h
+++ b/retroarch.h
@@ -1874,6 +1874,7 @@ extern video_driver_t video_xvideo;
 extern video_driver_t video_sdl;
 extern video_driver_t video_sdl2;
 extern video_driver_t video_sdl_dingux;
+extern video_driver_t video_sdl_rs90;
 extern video_driver_t video_vg;
 extern video_driver_t video_omap;
 extern video_driver_t video_exynos;

--- a/retroarch_data.h
+++ b/retroarch_data.h
@@ -645,7 +645,11 @@ static const video_driver_t *video_drivers[] = {
    &video_sdl2,
 #endif
 #ifdef HAVE_SDL_DINGUX
+#if defined(RS90)
+   &video_sdl_rs90,
+#else
    &video_sdl_dingux,
+#endif
 #endif
 #ifdef HAVE_XVIDEO
    &video_xvideo,
@@ -995,7 +999,7 @@ static input_device_driver_t *joypad_drivers[] = {
 };
 
 #ifdef HAVE_HID
-static bool null_hid_joypad_query(void *data, unsigned pad) { 
+static bool null_hid_joypad_query(void *data, unsigned pad) {
    return pad < MAX_USERS; }
 static const char *null_hid_joypad_name(
       void *data, unsigned pad) { return NULL; }
@@ -1665,7 +1669,7 @@ typedef struct discord_state discord_state_t;
 #endif
 
 struct runloop
-{ 
+{
    retro_usec_t frame_time_last;        /* int64_t alignment */
 
    msg_queue_t msg_queue;                        /* ptr alignment */
@@ -1733,7 +1737,7 @@ struct rarch_state
    menu_input_t menu_input_state;               /* retro_time_t alignment */
 #endif
 
-   
+
 
 #if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)
    rarch_timer_t shader_delay_timer;            /* int64_t alignment */
@@ -1911,7 +1915,7 @@ struct rarch_state
    struct retro_subsystem_rom_info
       subsystem_data_roms[SUBSYSTEM_MAX_SUBSYSTEMS]
       [SUBSYSTEM_MAX_SUBSYSTEM_ROMS];                    /* ptr alignment */
-   
+
    gfx_ctx_driver_t current_video_context;               /* ptr alignment */
    content_state_t            content_st;                /* ptr alignment */
    midi_event_t midi_drv_input_event;                    /* ptr alignment */
@@ -1989,7 +1993,7 @@ struct rarch_state
    size_t runahead_save_state_size;
 #endif
 
-   jmp_buf error_sjlj_context;              /* 4-byte alignment, 
+   jmp_buf error_sjlj_context;              /* 4-byte alignment,
                                                put it right before long */
 
    turbo_buttons_t input_driver_turbo_btns; /* int32_t alignment */
@@ -2017,7 +2021,7 @@ struct rarch_state
    int reannounce;
 #endif
 
-   input_device_info_t input_device_info[MAX_INPUT_DEVICES]; 
+   input_device_info_t input_device_info[MAX_INPUT_DEVICES];
                                           /* unsigned alignment */
 #ifdef HAVE_MENU
    menu_dialog_t dialog_st;               /* unsigned alignment */
@@ -2093,7 +2097,7 @@ struct rarch_state
 #endif
 
 #ifdef HAVE_MENU
-   menu_input_pointer_hw_state_t menu_input_pointer_hw_state;  
+   menu_input_pointer_hw_state_t menu_input_pointer_hw_state;
                                                 /* int16_t alignment */
 #endif
 


### PR DESCRIPTION
## Description

This is the early **draft** work to add support for the RS-90. https://github.com/libretro/RetroArch/issues/12569

### Still needs to be done

* ~There is no scaling. If the emulated system has a smaller screen, it's padded. If it's larger, it's cropped~ Scaling is done.
* ~Need to optimize the nearest neighbor scalar slightly. Can replace multiplication with addition in a loop~ Replaced inner loop with a do-while and inner multiplication with accumulating addition
* ~Need to copy the implementation of the `*_blit16_*` functions and make appropriate corresponding `*_blit32_*` functions~ Done, but not fully tested
* Code is somewhat messy. 
* ~Lots of white space changes my IDE made accidentally (I have fixed the setting since then)~
* There may be some easy performance wins I'm missing
* There are quite a few cores that work well on the RG350 that could work. Many of them require more buttons or more horsepower overall. There may also be some other MIPS32-compatible cores which could be ported to the RG350/RS90.
* ~I need to delete `retroarch.cfg` and make sure the buttons are automatically mapped correctly~ Done

### Working

* rgui opens and appears to be working exactly correctly
* Gambatte runs at full speed with working sound
* QuickNES runs at full speed with working sound
* Device doesn't have any hardware RGB scalers. Nearest-neighbor scaling is implemented in sortware with integer math and bit shifts. "Keep Aspect" is honored/implemented
* Controls work and are automatically bound correctly
* The default menu hotkey is START + SELECT
* Default resampler is nearest neighbor (set correctly on startup)

### Cores / Related Pull Requests

- [x] gambatte-libretro https://github.com/libretro/gambatte-libretro/pull/191
- [x] picodrive https://github.com/libretro/picodrive/pull/165
- [x] QuickNES https://github.com/libretro/QuickNES_Core/pull/82
- [x] Mame 2003 https://github.com/libretro/mame2003-libretro/pull/483
- [x] Mame 2003 Plus https://github.com/libretro/mame2003-plus-libretro/commit/2a029c0f1414cd1441a4a84ea18278f9def94619
- [ ] gpsp (dynarec broken currently) https://github.com/libretro/gpsp/pull/139
- [x] libretro-handy https://github.com/libretro/libretro-handy/pull/91
- [x] potator https://github.com/libretro/potator/pull/6
- [x] pokemini https://github.com/libretro/PokeMini/pull/46
- [x] Genesis-Plus-GX https://github.com/libretro/Genesis-Plus-GX/pull/252#issuecomment-877720706
- [x] RACE https://github.com/libretro/RACE/pull/23
- [ ] prosystem https://github.com/libretro/prosystem-libretro/pull/60
- [x] stella2014 https://github.com/libretro/stella2014-libretro/pull/80

### Broken Cores / Need More Work

- [ ] vice_x64 (compiles, but crashes when loading core)
- [ ] tic80 (can't figure out how to cross-compile)

#### More Cores that might work

- a doom engine if I can find one that will work with the limited controls
- o2em_libretro
- a vectrix emulator (?)

I think that's probably close to all of the cores that this thing has enough buttons, screen resolution and horse power to run.
