### PR TITLE
remove unused enum input_device_type from input_driver.h

### DIFF
--- a/input/input_driver.h
+++ b/input/input_driver.h
@@ -43,12 +43,6 @@
 
 RETRO_BEGIN_DECLS
 
-enum input_device_type
-{
-   INPUT_DEVICE_TYPE_NONE = 0,
-   INPUT_DEVICE_TYPE_KEYBOARD,
-   INPUT_DEVICE_TYPE_JOYPAD
-};
 
 enum input_toggle_type
 {


### PR DESCRIPTION
I cannot find any use of these values in the codebase. This seems to be vestigial and can be removed.