### PR TITLE
add mame2003 / mame2003-plus to web.libretro

### DIFF
--- a/pkg/emscripten/libretro/index.html
+++ b/pkg/emscripten/libretro/index.html
@@ -49,6 +49,8 @@
                            <a class="dropdown-item" href="." data-core="handy">Handy</a>
                            <a class="dropdown-item" href="." data-core="lutro">Lutro</a>
                            <a class="dropdown-item" href="." data-core="mame2000">MAME 2000</a>
+                           <a class="dropdown-item" href="." data-core="mame2003">MAME 2003</a>
+                           <a class="dropdown-item" href="." data-core="mame2003_plus">MAME 2003-Plus</a>
                            <a class="dropdown-item" href="." data-core="mednafen_lynx">Mednafen Lynx</a>
                            <a class="dropdown-item" href="." data-core="mednafen_ngp">Mednafen Neo Geo Pocket</a>
                            <a class="dropdown-item" href="." data-core="mednafen_pce_fast">Mednafen PC Engine Fast</a>


### PR DESCRIPTION
https://github.com/libretro/RetroArch/issues/9502 should be re-evaluated after officially adding support with our latest builds.