### PR TITLE
Added Aspect Ratio Full

### DIFF
--- a/gfx/video_defines.h
+++ b/gfx/video_defines.h
@@ -55,6 +55,7 @@ enum aspect_ratio
    ASPECT_RATIO_SQUARE,
    ASPECT_RATIO_CORE,
    ASPECT_RATIO_CUSTOM,
+   ASPECT_RATIO_FULL,
 
    ASPECT_RATIO_END
 };
@@ -116,7 +117,7 @@ enum text_alignment
 #define COLOR_ABGR(r, g, b, a) (((unsigned)(a) << 24) | ((b) << 16) | ((g) << 8) | ((r) << 0))
 #endif
 
-#define LAST_ASPECT_RATIO ASPECT_RATIO_CUSTOM
+#define LAST_ASPECT_RATIO ASPECT_RATIO_FULL
 
 /* ABGR color format defines */
 

--- a/retroarch.h
+++ b/retroarch.h
@@ -1567,6 +1567,8 @@ bool video_driver_supports_read_frame_raw(void);
 
 void video_driver_set_viewport_core(void);
 
+void video_driver_set_viewport_full(void);
+
 void video_driver_reset_custom_viewport(void);
 
 void video_driver_set_rgba(void);

--- a/retroarch_data.h
+++ b/retroarch_data.h
@@ -2373,7 +2373,8 @@ struct aspect_ratio_elem aspectratio_lut[ASPECT_RATIO_END] = {
    { 0.0f,            "Config"        },
    { 1.0f,            "Square pixel"  },
    { 1.0f,            "Core provided" },
-   { 0.0f,            "Custom"        }
+   { 0.0f,            "Custom"        },
+   { 1.3333f,         "Full" }
 };
 
 static gfx_api_gpu_map gpu_map[] = {

--- a/ui/drivers/qt/qt_options.cpp
+++ b/ui/drivers/qt/qt_options.cpp
@@ -1352,6 +1352,7 @@ AspectRatioGroup::AspectRatioGroup(const QString &title, QWidget *parent) :
    QHBoxLayout *custom         = new QHBoxLayout;
    QVBoxLayout *customRadio    = new QVBoxLayout;
    QHBoxLayout *config         = new QHBoxLayout;
+   QHBoxLayout *full           = new QHBoxLayout;
    QHBoxLayout *aspectL        = new QHBoxLayout;
    FormLayout *leftAspectForm  = new FormLayout;
    FormLayout *rightAspectForm = new FormLayout;
@@ -1382,6 +1383,8 @@ AspectRatioGroup::AspectRatioGroup(const QString &title, QWidget *parent) :
    config->setStretch(1, 1);
    config->setSizeConstraint(QLayout::SetMinimumSize);
 
+   full->addWidget(new UIntRadioButton(MENU_ENUM_LABEL_VIDEO_ASPECT_RATIO_INDEX, ASPECT_RATIO_FULL));
+
    leftAspect->addRow(new UIntRadioButton(MENU_ENUM_LABEL_VIDEO_ASPECT_RATIO_INDEX, ASPECT_RATIO_CORE));
    leftAspect->addRow(preset);
 
@@ -1394,6 +1397,7 @@ AspectRatioGroup::AspectRatioGroup(const QString &title, QWidget *parent) :
    aspectL->addLayout(rightAspect);
 
    addRow(aspectL);
+   addRow(full);
    addRow(custom);
 
    connect(m_radioButton, SIGNAL(clicked(bool)), this, SLOT(onAspectRadioClicked(bool)));


### PR DESCRIPTION
## Description

New 'Full' aspect ratio added. This aspect ratio is useful when used with a shader which has a border in it. The aspect ratio is set to the full window area, so that the viewport spans the whole viewport. When using a border type shader like the Mega Bezel this allows the graphics to span the whole window regardless of the user's monitor aspect ratio

## Reviewers

@jdgleaver if you can take a look when you have a chance that would be awesome!

@hunterk, just in case you want to try it out :)


