### PR TITLE
Default to d3d11 on UWP builds

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -260,6 +260,9 @@ static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_GL;
 #else
 static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_METAL;
 #endif
+#elif defined(__WINRT__) || defined(WINAPI_FAMILY) && WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
+/* Lets default to D3D11 in UWP, even when its compiled with ANGLE, since ANGLE is just calling D3D anyway.*/
+static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_D3D11;
 #elif defined(HAVE_OPENGL1) && defined(_MSC_VER) && (_MSC_VER <= 1600)
 /* On Windows XP and earlier, use gl1 by default
  * (regular opengl has compatibility issues with


### PR DESCRIPTION
Even if compiled with ANGLE, lets default to d3d11 since ANGLE is calling D3D anyway. 
That makes cores like PCSX2 and Duckstation boot proper with default settings, ANGLE cores still switching automatically.
Should prevent user issues which are often coming up.

@twinaphex 
