### PR TITLE
implement natt fix from void()

### DIFF
--- a/libretro-common/include/net/net_natt.h
+++ b/libretro-common/include/net/net_natt.h
@@ -62,7 +62,8 @@ struct natt_status
 /**
  * Initialize global NAT traversal structures (must be called once to use other
  * functions) */
-void natt_init(void);
+void natt_init(struct natt_status *status,
+      uint16_t port, enum socket_protocol proto);
 
 /** Initialize a NAT traversal status object */
 bool natt_new(struct natt_status *status);

--- a/tasks/task_netplay_nat_traversal.c
+++ b/tasks/task_netplay_nat_traversal.c
@@ -51,11 +51,8 @@ static void task_netplay_nat_traversal_handler(retro_task_t *task)
    struct nat_traversal_state_data *ntsd =
       (struct nat_traversal_state_data *) task->task_data;
 
-   natt_init();
-
    if (natt_new(ntsd->nat_traversal_state))
-      natt_open_port_any(ntsd->nat_traversal_state,
-            ntsd->port, SOCKET_PROTOCOL_TCP);
+      natt_init(ntsd->nat_traversal_state, ntsd->port, SOCKET_PROTOCOL_TCP);
 
    task_set_progress(task, 100);
    task_set_finished(task, true);


### PR DESCRIPTION
This patch was created by void() and submitted on discord because they do not want to create a github account and do not wish for any specific type of attribution for the work.


They have tested it and confirmed it works. I have not. I'm just the messenger.


```
void(): I was trying to see with retroarch always gives me a port mapping failed with nat traversale enabled
[2:24 PM] void(): the problem is this logic
[2:24 PM] void():
if (devlist)
   {
      dev = devlist;
      while (dev)
      {
         if (strstr (dev->st, "InternetGatewayDevice"))
            break;
         dev = dev->pNext;
      }
[2:25 PM] void(): retroarch assumes the first InternetGatewayDevice to respond is "the one"
[2:25 PM] void(): in reality there may be several, particularly if you have a mesh system
[2:25 PM] void(): most will have that descriptor
[2:25 PM] void(): I was trying to fix it
[2:26 PM] void(): but the logic is weird
[2:27 PM] void():
   if (natt_new(ntsd->nat_traversal_state))
      natt_open_port_any(ntsd->nat_traversal_state,
            ntsd->port, SOCKET_PROTOCOL_TCP);
[2:28 PM] void(): the order is weirdly
[2:28 PM] void(): natt_init
natt_new
natt_open_port
[2:28 PM] void(): most of the logic from natt_init should move to open_port
[2:29 PM] void(): and then it should loop over all the IGDs
```
