### PR TITLE
(Menu+Widgets) Add workaround for FPU bug that breaks scale factor comparisons on certain platforms (fixes XMB thumbnails on 32bit Linux/Windows)

### DIFF
--- a/gfx/gfx_widgets.c
+++ b/gfx/gfx_widgets.c
@@ -1037,9 +1037,15 @@ void gfx_widgets_iterate(
 {
    size_t i;
    dispgfx_widget_t *p_dispwidget   = (dispgfx_widget_t*)data;
-   /* Check whether screen dimensions or menu scale
-    * factor have changed */
-   float scale_factor               = 0.0f;
+   /* c.f. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=323
+    * On some platforms (e.g. 32-bit x86 without SSE),
+    * gcc can produce inconsistent floating point results
+    * depending upon optimisation level. This can break
+    * floating point variable comparisons. A workaround is
+    * to declare the affected variable as 'volatile', which
+    * disables optimisations and removes excess precision
+    * (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=323#c87) */
+   volatile float scale_factor      = 0.0f;
    gfx_display_t *p_disp            = (gfx_display_t*)data_disp;
    settings_t *settings             = (settings_t*)settings_data;
 #ifdef HAVE_XMB
@@ -1051,6 +1057,8 @@ void gfx_widgets_iterate(
       scale_factor                  = gfx_display_get_widget_dpi_scale(p_disp,
             settings, width, height, fullscreen);
 
+   /* Check whether screen dimensions or menu scale
+    * factor have changed */
    if ((scale_factor != p_dispwidget->last_scale_factor) ||
        (width        != p_dispwidget->last_video_width) ||
        (height       != p_dispwidget->last_video_height))

--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -3512,7 +3512,15 @@ static void materialui_render(void *data,
 {
    size_t i;
    float bottom;
-   float scale_factor;
+   /* c.f. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=323
+    * On some platforms (e.g. 32-bit x86 without SSE),
+    * gcc can produce inconsistent floating point results
+    * depending upon optimisation level. This can break
+    * floating point variable comparisons. A workaround is
+    * to declare the affected variable as 'volatile', which
+    * disables optimisations and removes excess precision
+    * (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=323#c87) */
+   volatile float scale_factor;
    settings_t *settings     = config_get_ptr();
    materialui_handle_t *mui = (materialui_handle_t*)data;
    gfx_display_t *p_disp    = disp_get_ptr();

--- a/menu/drivers/ozone/ozone.c
+++ b/menu/drivers/ozone/ozone.c
@@ -1750,7 +1750,15 @@ static void ozone_render(void *data,
       bool is_idle)
 {
    size_t i;
-   float scale_factor;
+   /* c.f. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=323
+    * On some platforms (e.g. 32-bit x86 without SSE),
+    * gcc can produce inconsistent floating point results
+    * depending upon optimisation level. This can break
+    * floating point variable comparisons. A workaround is
+    * to declare the affected variable as 'volatile', which
+    * disables optimisations and removes excess precision
+    * (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=323#c87) */
+   volatile float scale_factor;
    unsigned entries_end             = (unsigned)menu_entries_get_size();
    bool pointer_enabled             = false;
    unsigned language                = *msg_hash_get_uint(MSG_HASH_USER_LANGUAGE);

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -3971,7 +3971,15 @@ static void xmb_render(void *data,
    /* 'i' must be of 'size_t', since it is passed
     * by reference to menu_entries_ctl() */
    size_t i;
-   float scale_factor;
+   /* c.f. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=323
+    * On some platforms (e.g. 32-bit x86 without SSE),
+    * gcc can produce inconsistent floating point results
+    * depending upon optimisation level. This can break
+    * floating point variable comparisons. A workaround is
+    * to declare the affected variable as 'volatile', which
+    * disables optimisations and removes excess precision
+    * (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=323#c87) */
+   volatile float scale_factor;
    xmb_handle_t *xmb        = (xmb_handle_t*)data;
    settings_t *settings     = config_get_ptr();
    size_t      end          = menu_entries_get_size();


### PR DESCRIPTION
## Description

As reported in #12626, XMB does not display thumbnails on 32bit Windows - and I have verified that the same error occurs on 32bit Linux.

The lack of thumbnails is just a symptom of a more serious issue. It turns out that this comparison:

https://github.com/libretro/RetroArch/blob/32ed7ed1d77e9ff93f57f4b4d083d46460a97b95/menu/drivers/xmb.c#L3988

always evaluates to `true`, which means the menu context is being reset *on every single frame*. This breaks thumbnails and animations, and is catastrophic in terms of performance...

It seems that we are in fact encountering a known GCC/FPU bug which causes inconsistent floating point behaviour on certain platforms depending upon the compiler optimisation level: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=323. Essentially, the internal precision can be higher than it should be, which means calculations do not give expected results and comparisons of the 'same' values can fail.

As described in the GCC bug report (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=323#c87), the simplest/least invasive workaround is to declare affected variables as `volatile`, which disables optimisations for these variables and discards excess precision. This PR adds the workaround to all once-per-frame 'scale factor' comparisons in the menu and widget code, where erroneous comparison results can lead to unnecessary (and expensive) 'reset-type' operations.

This fixes the display of XMB thumbnails on 32bit Linux.

## Related Issues

This should resolve #12626 - but I can only test Linux, so correct operation on Windows should be verified before closing the issue.
