### PR TITLE
(Dingux) Fix display when cores 'drop' frames

### DIFF
--- a/gfx/drivers/sdl_dingux_gfx.c
+++ b/gfx/drivers/sdl_dingux_gfx.c
@@ -761,7 +761,13 @@ static bool sdl_dingux_gfx_frame(void *data, const void *frame,
 {
    sdl_dingux_video_t* vid = (sdl_dingux_video_t*)data;
 
-   if (unlikely(!vid))
+   /* Return early if:
+    * - Input sdl_dingux_video_t struct is NULL
+    *   (cannot realistically happen)
+    * - Menu is inactive and input 'content' frame
+    *   data is NULL (may happen when e.g. a running
+    *   core skips a frame) */
+   if (unlikely(!vid || (!frame && !vid->menu_active)))
       return true;
 
    /* If fast forward is currently active, we may
@@ -805,16 +811,13 @@ static bool sdl_dingux_gfx_frame(void *data, const void *frame,
 
       if (likely(vid->mode_valid))
       {
-         if (likely(frame))
-         {
-            /* Blit frame to SDL surface */
-            if (vid->rgb32)
-               sdl_dingux_blit_frame32(vid, (uint32_t*)frame,
-                     width, height, pitch);
-            else
-               sdl_dingux_blit_frame16(vid, (uint16_t*)frame,
-                     width, height, pitch);
-         }
+         /* Blit frame to SDL surface */
+         if (vid->rgb32)
+            sdl_dingux_blit_frame32(vid, (uint32_t*)frame,
+                  width, height, pitch);
+         else
+            sdl_dingux_blit_frame16(vid, (uint16_t*)frame,
+                  width, height, pitch);
       }
       /* If current display mode is invalid,
        * just display an error message */


### PR DESCRIPTION
## Description

It turns out that #12521 introduced an unfortunate regression on OpenDingux platforms. Essentially, when content is running and a core 'drops' a frame (either due to frame skipping, or frame duping), the `sdl_dingux_gfx_frame()` function should be a NOOP - but with #12521 the only part omitted in this case is the blitting of the frame data to screen. This is wasteful in terms of performance overheads, but it has a more serious consequence when video filters are being used: when a frame is dropped, the video filter is disabled for that frame - which means the frame dimensions change (i.e. they return to the source image dimensions, not the filter output size). This change triggers OpenDingux devices to switch video modes (a very slow operation), and when a core is frame skipping this may cause a feedback loop where frames are continuously dropped and the video mode continually changes, effectively breaking the display and rendering the core unusable.

This PR fixes the problem by restoring the correct NOOP behaviour when frames are dropped (while still addressing the issue highlighted in #12521)