### PR TITLE
(Dingux Beta) Use ALSA audio driver by default

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -342,6 +342,8 @@ static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_PS3;
 static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_CTR;
 #elif defined(SWITCH)
 static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_SWITCH;
+#elif defined(DINGUX_BETA) && defined(HAVE_ALSA)
+static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_ALSA;
 #elif defined(DINGUX) && defined(HAVE_AL)
 static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_AL;
 #elif defined(HAVE_PULSE)


### PR DESCRIPTION
## Description

This PR just sets the default audio driver to ALSA on platforms running OpenDingux Beta. For CPU-limited content that struggles to run at full speed, ALSA improves overall performance by ~10% vs the current default OpenAL audio driver (there is no discernable difference in sound quality).

(Note that the threaded ALSA audio driver has worse performance than regular ALSA on dingux platforms, since these devices only have single core/single thread CPUs)