### PR TITLE
(RGUI) Fix sublabel length when menu clock is disabled

### DIFF
--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -4736,7 +4736,9 @@ static void rgui_render(void *data,
       unsigned title_y               = rgui->term_layout.start_y - rgui->font_height_stride;
       unsigned term_end_x            = rgui->term_layout.start_x + (rgui->term_layout.width * rgui->font_width_stride);
       unsigned timedate_x            = term_end_x - (5 * rgui->font_width_stride);
-      unsigned core_name_len         = ((timedate_x - rgui->term_layout.start_x) / rgui->font_width_stride) - 3;
+      unsigned core_name_len         = menu_timedate_enable ?
+            ((timedate_x - rgui->term_layout.start_x) / rgui->font_width_stride) - 3 :
+                  rgui->term_layout.width - 1;
       bool show_mini_thumbnails      = rgui->is_playlist && rgui_inline_thumbnails;
       bool show_thumbnail            = false;
       bool show_left_thumbnail       = false;


### PR DESCRIPTION
## Description

At present, when using RGUI, the width of the sublabel text field is not set correctly when the menu clock is disabled:

![Screenshot_2021-07-14_14-58-04](https://user-images.githubusercontent.com/38211560/125636853-ea31497b-5acc-4abe-b062-7bc8080e431e.png)

![Screenshot_2021-07-14_15-05-04](https://user-images.githubusercontent.com/38211560/125636862-2400cd45-9778-4841-b7f9-e0f84ba3b830.png)

This trivial PR fixes the issue:

![Screenshot_2021-07-14_14-58-33](https://user-images.githubusercontent.com/38211560/125636900-bb117eda-16ff-4a74-adba-322f719ad606.png)
