### PR TITLE
(RS-90) Disable menu clock by default

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -1324,6 +1324,14 @@ static const unsigned menu_left_thumbnails_default = 0;
 static const unsigned gfx_thumbnail_upscale_threshold = 0;
 
 #ifdef HAVE_MENU
+#if defined(RS90)
+/* The RS-90 has a hardware clock that is neither
+ * configurable nor persistent, rendering it useless.
+ * We therefore hide it in the menu by default. */
+#define DEFAULT_MENU_TIMEDATE_ENABLE false
+#else
+#define DEFAULT_MENU_TIMEDATE_ENABLE true
+#endif
 #define DEFAULT_MENU_TIMEDATE_STYLE          MENU_TIMEDATE_STYLE_DDMM_HM
 #define DEFAULT_MENU_TIMEDATE_DATE_SEPARATOR MENU_TIMEDATE_DATE_SEPARATOR_HYPHEN
 #endif

--- a/configuration.c
+++ b/configuration.c
@@ -1627,7 +1627,7 @@ static struct config_bool_setting *populate_settings_bool(
    SETTING_BOOL("menu_insert_disk_resume",       &settings->bools.menu_insert_disk_resume, true, DEFAULT_MENU_INSERT_DISK_RESUME, false);
    SETTING_BOOL("menu_mouse_enable",             &settings->bools.menu_mouse_enable, true, DEFAULT_MOUSE_ENABLE, false);
    SETTING_BOOL("menu_pointer_enable",           &settings->bools.menu_pointer_enable, true, DEFAULT_POINTER_ENABLE, false);
-   SETTING_BOOL("menu_timedate_enable",          &settings->bools.menu_timedate_enable, true, true, false);
+   SETTING_BOOL("menu_timedate_enable",          &settings->bools.menu_timedate_enable, true, DEFAULT_MENU_TIMEDATE_ENABLE, false);
    SETTING_BOOL("menu_battery_level_enable",     &settings->bools.menu_battery_level_enable, true, true, false);
    SETTING_BOOL("menu_core_enable",              &settings->bools.menu_core_enable, true, true, false);
    SETTING_BOOL("menu_show_sublabels",           &settings->bools.menu_show_sublabels, true, menu_show_sublabels, false);

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -16430,7 +16430,7 @@ static bool setting_append_list(
                &settings->bools.menu_timedate_enable,
                MENU_ENUM_LABEL_TIMEDATE_ENABLE,
                MENU_ENUM_LABEL_VALUE_TIMEDATE_ENABLE,
-               true,
+               DEFAULT_MENU_TIMEDATE_ENABLE,
                MENU_ENUM_LABEL_VALUE_OFF,
                MENU_ENUM_LABEL_VALUE_ON,
                &group_info,


### PR DESCRIPTION
## Description

The RS-90 handheld has a hardware clock that is neither configurable nor persistent; it is therefore always incorrect, and there is no purpose in showing it in the menu. This trivial PR just hides the menu clock by default on this platform.
