### PR TITLE
(RS-90) Hide 'Bilinear Filtering' video option

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -11466,7 +11466,7 @@ static bool setting_append_list(
                menu_settings_list_current_add_range(list, list_info, 0, DINGUX_IPU_FILTER_LAST - 1, 1, true, true);
                (*list)[list_info->index - 1].ui_type   = ST_UI_TYPE_UINT_COMBOBOX;
             }
-            else
+            else if (!string_is_equal(settings->arrays.video_driver, "sdl_rs90"))
 #endif
             {
                CONFIG_BOOL(


### PR DESCRIPTION
## Description

This trivial PR just hides the `Bilinear Filtering` video option for RS-90 devices (since filtering is currently unsupported)