### PR TITLE
(RS-90) Move appdata (retroarch) base directory to external microsd card

### DIFF
--- a/dingux/dingux_utils.h
+++ b/dingux/dingux_utils.h
@@ -101,6 +101,10 @@ bool dingux_ipu_reset(void);
 /* Fetches internal battery level */
 int dingux_get_battery_level(void);
 
+/* Fetches the path of the base 'retroarch'
+ * directory */
+void dingux_get_base_path(char *path, size_t len);
+
 RETRO_END_DECLS
 
 #endif

--- a/file_path_special.c
+++ b/file_path_special.c
@@ -37,6 +37,10 @@
 #include <kernel/image.h>
 #endif
 
+#if defined(DINGUX)
+#include "dingux/dingux_utils.h"
+#endif
+
 #include <stdlib.h>
 #include <boolean.h>
 #include <string.h>
@@ -104,13 +108,8 @@ bool fill_pathname_application_data(char *s, size_t len)
       return true;
    }
 #elif defined(DINGUX)
-   const char *appdata = getenv("HOME");
-
-   if (appdata)
-   {
-      fill_pathname_join(s, appdata, "/.retroarch", len);
-      return true;
-   }
+   dingux_get_base_path(s, len);
+   return true;
 #elif !defined(RARCH_CONSOLE)
    const char *xdg     = getenv("XDG_CONFIG_HOME");
    const char *appdata = getenv("HOME");

--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -1792,6 +1792,9 @@ static void frontend_unix_get_env(int *argc,
    }
 #else
    char base_path[PATH_MAX] = {0};
+#if defined(DINGUX)
+   dingux_get_base_path(base_path, sizeof(base_path));
+#else
    const char *xdg          = getenv("XDG_CONFIG_HOME");
    const char *home         = getenv("HOME");
 
@@ -1803,14 +1806,11 @@ static void frontend_unix_get_env(int *argc,
    else if (home)
    {
       strlcpy(base_path, home, sizeof(base_path));
-#if defined(DINGUX)
-      strlcat(base_path, "/.retroarch", sizeof(base_path));
-#else
       strlcat(base_path, "/.config/retroarch", sizeof(base_path));
-#endif
    }
    else
       strcpy_literal(base_path, "retroarch");
+#endif
 
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CORE], base_path,
          "cores", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE]));
@@ -2154,9 +2154,13 @@ static int frontend_unix_parse_drive_list(void *data, bool load_content)
 #else
    char base_path[PATH_MAX] = {0};
    char udisks_media_path[PATH_MAX] = {0};
-   const char *xdg          = getenv("XDG_CONFIG_HOME");
    const char *home         = getenv("HOME");
    const char *user         = getenv("USER");
+
+#if defined(DINGUX)
+   dingux_get_base_path(base_path, sizeof(base_path));
+#else
+   const char *xdg          = getenv("XDG_CONFIG_HOME");
 
    if (xdg)
    {
@@ -2166,12 +2170,9 @@ static int frontend_unix_parse_drive_list(void *data, bool load_content)
    else if (home)
    {
       strlcpy(base_path, home, sizeof(base_path));
-#if defined(DINGUX)
-      strlcat(base_path, "/.retroarch", sizeof(base_path));
-#else
       strlcat(base_path, "/.config/retroarch", sizeof(base_path));
-#endif
    }
+#endif
 
    strlcpy(udisks_media_path, "/run/media", sizeof(udisks_media_path));
    if (user)


### PR DESCRIPTION
## Description

At present, the RS-90 port (like the regular dingux port) sets the appdata directory path to `$HOME/.retroarch`. The RS-90 home directory is located on the device's internal storage, which has very limited space (a total of only 256MB); it is therefore impractical in the long-term to store cores/assets/database files/user files here. This PR therefore modifies the behaviour of the RS-90 port such that the appdata is stored by default on the external microsd card, in `/media/<sd_mount_dir>/retroarch`

This essentially requires the user to copy the `retroarch` folder from the installation package to the root of their microsd card. If a suitable directory is not found, RetroArch will fall back to the old `$HOME/.retroarch` directory.

(Note that an update to the gitlab packaging script is required to fully support the new behaviour - I will deal with this once the PR is merged)

RS-90 users who have symlinked a retroarch folder on external storage to `$HOME/.retroarch` should remove the symlink and additionally delete any existing core info cache file (`retroarch/core_info/core_info.cache`)