### PR TITLE
Starting logging and verbose mode before first config load

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -3067,6 +3067,7 @@ static bool config_load_file(global_t *global,
    bool ret                                        = false;
    unsigned tmp_uint                               = 0;
    bool tmp_bool                                   = false;
+   static bool first_load                          = true;
    unsigned msg_color                              = 0;
    char *save                                      = NULL;
    char *override_username                         = NULL;
@@ -3158,12 +3159,23 @@ static bool config_load_file(global_t *global,
                settings->bools.network_remote_enable_user[i], tmp_bool);
    }
 #endif
-   if (config_get_bool(conf, "log_verbosity", &tmp_bool))
+   /* Set verbosity according to config only if the 'v' command line argument was not used
+    * or if it is not the first config load. */
+   if (config_get_bool(conf, "log_verbosity", &tmp_bool) &&
+      (!retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_VERBOSITY, NULL) ||
+      !first_load))
    {
       if (tmp_bool)
          verbosity_enable();
       else
          verbosity_disable();
+   }
+   /* On first config load, make sure log_to_file is true if 'log-file' command line 
+    * argument was used. */
+   if (retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_LOG_TO_FILE, NULL) &&
+      first_load)
+   {
+      configuration_set_bool(settings,settings->bools.log_to_file,true);
    }
    if (config_get_uint(conf, "frontend_log_level", &tmp_uint))
    {
@@ -3595,6 +3607,7 @@ end:
       free(path_settings);
    if (size_settings)
       free(size_settings);
+   first_load = false;
    return ret;
 }
 
@@ -3941,15 +3954,15 @@ success:
  */
 static void config_parse_file(global_t *global)
 {
+   const char *config_path = path_get(RARCH_PATH_CONFIG);
    if (path_is_empty(RARCH_PATH_CONFIG))
    {
       RARCH_LOG("[Config]: Loading default config.\n");
    }
+   else
+       RARCH_LOG("[Config]: Loading config from: \"%s\".\n", config_path);
 
    {
-      const char *config_path = path_get(RARCH_PATH_CONFIG);
-      RARCH_LOG("[Config]: Loading config from: \"%s\".\n", config_path);
-
       if (!config_load_file(global, config_path, config_get_ptr()))
       {
          RARCH_ERR("[Config]: Couldn't find config at path: \"%s\".\n",

--- a/retroarch.c
+++ b/retroarch.c
@@ -35184,6 +35184,22 @@ static bool retroarch_parse_input_and_config(
                retroarch_override_setting_set(
                      RARCH_OVERRIDE_SETTING_STATE_PATH, NULL);
                break;
+            case 'v':
+               verbosity_enable();
+               retroarch_override_setting_set(
+                     RARCH_OVERRIDE_SETTING_VERBOSITY, NULL);
+               break;
+            case RA_OPT_LOG_FILE:
+               /* Enable 'log to file' */
+               configuration_set_bool(p_rarch->configuration_settings,
+                     p_rarch->configuration_settings->bools.log_to_file, true);
+
+               retroarch_override_setting_set(
+                     RARCH_OVERRIDE_SETTING_LOG_TO_FILE, NULL);
+
+               /* Cache log file path override */
+               rarch_log_file_set_override(optarg);
+               break;
 
             /* Must handle '?' otherwise you get an infinite loop */
             case '?':
@@ -35194,6 +35210,13 @@ static bool retroarch_parse_input_and_config(
          }
       }
    }
+   verbosity_enabled = verbosity_is_enabled();
+   /* Enable logging to file if verbosity and log-file arguments were passed.
+    * RARCH_OVERRIDE_SETTING_LOG_TO_FILE is set by the RA_OPT_LOG_FILE case above
+    * The parameters passed to rarch_log_file_init are hardcoded as the config
+    * has not yet been initialized at this point. */
+   if (verbosity_enabled && retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_LOG_TO_FILE, NULL))
+      rarch_log_file_init(true,false,'\0');
 
    /* Flush out some states that could have been set
     * by core environment variables. */
@@ -35213,6 +35236,15 @@ static bool retroarch_parse_input_and_config(
       config_load(&p_rarch->g_extern);
    }
 
+   verbosity_enabled = verbosity_is_enabled();
+   /* Init logging after config load only if not overridden by command line argument. 
+    * This handles when logging is set in the config but not via the --log-file option. */
+   if (verbosity_enabled && !retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_LOG_TO_FILE, NULL))
+      rarch_log_file_init(
+            p_rarch->configuration_settings->bools.log_to_file,
+            p_rarch->configuration_settings->bools.log_to_file_timestamp,
+            p_rarch->configuration_settings->paths.log_dir);
+            
    /* Second pass: All other arguments override the config file */
    optind = 1;
 
@@ -35277,12 +35309,6 @@ static bool retroarch_parse_input_and_config(
 
             case 'f':
                p_rarch->rarch_force_fullscreen = true;
-               break;
-
-            case 'v':
-               verbosity_enable();
-               retroarch_override_setting_set(
-                     RARCH_OVERRIDE_SETTING_VERBOSITY, NULL);
                break;
 
             case 'N':
@@ -35589,18 +35615,6 @@ static bool retroarch_parse_input_and_config(
                retroarch_print_version();
                exit(0);
 
-            case RA_OPT_LOG_FILE:
-               /* Enable 'log to file' */
-               configuration_set_bool(p_rarch->configuration_settings,
-                     p_rarch->configuration_settings->bools.log_to_file, true);
-
-               retroarch_override_setting_set(
-                     RARCH_OVERRIDE_SETTING_LOG_TO_FILE, NULL);
-
-               /* Cache log file path override */
-               rarch_log_file_set_override(optarg);
-               break;
-
             case 'h':
 #ifdef HAVE_CONFIGFILE
             case 'c':
@@ -35608,6 +35622,8 @@ static bool retroarch_parse_input_and_config(
 #endif
             case 's':
             case 'S':
+            case 'v':
+            case RA_OPT_LOG_FILE:
                break; /* Handled in the first pass */
 
             case '?':
@@ -35627,14 +35643,6 @@ static bool retroarch_parse_input_and_config(
          }
       }
    }
-
-   verbosity_enabled = verbosity_is_enabled();
-
-   if (verbosity_enabled)
-      rarch_log_file_init(
-            p_rarch->configuration_settings->bools.log_to_file,
-            p_rarch->configuration_settings->bools.log_to_file_timestamp,
-            p_rarch->configuration_settings->paths.log_dir);
 
 #ifdef HAVE_GIT_VERSION
    RARCH_LOG("RetroArch %s (Git %s)\n",


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

This change is to allow verbosity and file logging to begin before the configuration file is first loaded in retroarch.c. I made this change since I noticed when troubleshooting an unrelated issue that the console didn't start logging messages until after the config was loaded, even though there are many instances of useful logging in the code which were essentially being ignored during first config load. My hope is this change could make it easier for folks to troubleshoot any issues during the initial retroarch.cfg load.

This was done by moving the cases for command line switches 'v' and 'log-file' into the first pass of command line argument checking, and making a couple changes to also make sure those switches will still override the (initial) config file settings, as they did before when they were applied in the first pass.

## Related Issues

None

## Related Pull Requests

None

## Reviewers

[If possible @mention all the people that should review your pull request]
