### PR TITLE
clarify netplay upnp port mapping status messages

### DIFF
--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -10536,11 +10536,11 @@ MSG_HASH(
    )
 MSG_HASH(
    MSG_PUBLIC_ADDRESS,
-   "Port Mapping Successful"
+   "Netplay Port Mapping Successful"
    )
 MSG_HASH(
    MSG_UPNP_FAILED,
-   "Port Mapping Failed"
+   "Netplay UPNP Port Mapping Failed"
    )
 MSG_HASH(
    MSG_NO_ARGUMENTS_SUPPLIED_AND_NO_MENU_BUILTIN,


### PR DESCRIPTION
This clarifies the existing messages, which only refer to a "port" without clarifying that the status message pertains to netplay and upnp ports.