### PR TITLE
Prevent xdg-screensaver's "Protocol error" messages

### DIFF
--- a/gfx/common/x11_common.c
+++ b/gfx/common/x11_common.c
@@ -199,10 +199,23 @@ static void xdg_screensaver_inhibit(Window wnd)
 {
    int  ret;
    char cmd[64];
+   char title[128];
 
    cmd[0] = '\0';
+   title[0] = '\0';
 
    RARCH_LOG("[X11]: Suspending screensaver (X11, xdg-screensaver).\n");
+
+   /* Make sure the window has a title, even if it's a bogus one, otherwise
+    * xdg-screensaver will fail and report to stderr, framing RA for its bug.
+    * A single space character is used so that the title bar stays visibly
+    * the same, as if there's no title at all. */
+   video_driver_get_window_title(title, sizeof(title));
+   if (strlen(title) == 0)
+      snprintf(title, sizeof(title), " ");
+   XChangeProperty(g_x11_dpy, g_x11_win, XA_WM_NAME, XA_STRING,
+         8, PropModeReplace, (const unsigned char*) title,
+         strlen(title));
 
    snprintf(cmd, sizeof(cmd), "xdg-screensaver suspend 0x%x", (int)wnd);
 


### PR DESCRIPTION
## Description
This PR provides a workaround for the long-standing issue of "protocol error" messages being written to stderr whenever the "Suspend Screensaver" option is enabled _and the x11 context driver is used_. These messages don't actually come from Retroarch - they're xdg-screensaver's, which is a script for cross-DE screensaver suspending that RA calls to do its job.

It turns out, the script has a problem with title-less windows. See the [related bsnes issue](https://github.com/bsnes-emu/bsnes/issues/102) for analysis - kudos to Screwtapello for figuring this out. The proposed solution is to check if there's already a title, and if there isn't, to set it to a single "space" character, which is surprisingly enough for xdg-screensaver to work. The space character is picked so that there's no visible difference between the bogus title and no title at all. The alternative is to make sure that RA's window has a title at all times - too much of a hassle for something this trivial, I think.

## Related Issues
#9305 "X11 Screensaver Inhibit produces error" this exact issue
#1521 "Protocol error message" is closed, but has some discussion
#8986 "Protocol Error after update" describes separate bug (one long since fixed) misattributed to this
