### PR TITLE
(OpenDingux Beta) Fix IPU scaling when running 256x224 (SNES/Genesis) content

### DIFF
--- a/gfx/drivers/sdl_dingux_gfx.c
+++ b/gfx/drivers/sdl_dingux_gfx.c
@@ -581,6 +581,12 @@ static void sdl_dingux_sanitize_frame_dimensions(
       /* GB/GBC/GG (x3) @ 480x432 */
       else if ((width == 480) && (height == 432))
          *sanitized_width = 496;
+      /* SNES/Genesis @ 256x224 */
+      else if ((width == 256) && (height == 224))
+         *sanitized_width = 288;
+      /* SNES/Genesis (x2) @ 512x448 */
+      else if ((width == 512) && (height == 448))
+         *sanitized_width = 560;
    }
 #endif
 


### PR DESCRIPTION
## Description

This is a follow-up to #12235. When running content with a resolution of 256x224 (most SNES games, some Genesis games) on the OpenDingux Beta port of retroarch with `Integer Scaling` disabled and `Keep Aspect Ratio` enabled, the right hand side of the image is cropped incorrectly. This PR fixes the issue by adding 256x224 and 2x(256x224) to the resolution blacklists, inserting appropriate horizontal padding.