### PR TITLE
(task_http.c) Fix progress indication for large files on 32-bit systems

### DIFF
--- a/tasks/task_http.c
+++ b/tasks/task_http.c
@@ -133,7 +133,7 @@ static int task_http_iterate_transfer(retro_task_t *task)
          task_set_progress(task, (signed)(pos * 100 / tot));
       else
          /* but invert the logic if it would cause an overflow */
-         task_set_progress(task, MAX((signed)pos / (tot / 100), 100));
+         task_set_progress(task, MIN((signed)pos / (tot / 100), 100));
       return -1;
    }
 


### PR DESCRIPTION
## Description

When downloading a large file on a 32-bit platform, the progress indicator will get pinned to 100% after downloading roughly 40MiB. This causes a lot of stress for assets.zip, where the 40MiB mark is about halfway.

This is caused by a simple bug - using `max(progress, 100)` instead of `min(progress, 100)` in the overflow-avoiding version of the progress calculation. Thus, when the overflow path is hit, the task will always report 100%.

## Related Issues

Likely one of several issues contributing to #7278 - more patches incoming.

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
