### PR TITLE
(Wii U) Network speed optimisations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,7 +94,6 @@ database
 overlays
 playlists
 states
-system
 shaders/shaders_cg
 shaders/shaders_glsl
 shaders/shaders_slang
@@ -220,7 +219,6 @@ libretro-common/samples/streams/rzip/rzip
 
 #VITA
 param.sfo
-*.S
 *.wo
 *.elf
 *.self

--- a/libretro-common/include/net/net_compat.h
+++ b/libretro-common/include/net/net_compat.h
@@ -158,6 +158,11 @@ static INLINE bool isagain(int bytes)
 #endif
 }
 
+#ifdef WIIU
+#define WIIU_RCVBUF (128 * 2 * 1024)
+#define WIIU_SNDBUF (128 * 2 * 1024)
+#endif
+
 #ifdef _XBOX
 #define socklen_t int
 

--- a/libretro-common/net/net_socket.c
+++ b/libretro-common/net/net_socket.c
@@ -257,6 +257,20 @@ int socket_connect(int fd, void *data, bool timeout_enable)
       setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, (char*)&timeout, sizeof timeout);
    }
 #endif
+#if defined(WIIU)
+   int op = 1;
+   setsockopt(fd, SOL_SOCKET, SO_WINSCALE, &op, sizeof(op));
+   if (addr->ai_socktype == SOCK_STREAM) {
+      setsockopt(fd, SOL_SOCKET, SO_TCPSACK, &op, sizeof(op));
+
+      setsockopt(fd, SOL_SOCKET, 0x10000, &op, sizeof(op));
+      int recvsz = WIIU_RCVBUF;
+      setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &recvsz, sizeof(recvsz));
+      int sendsz = WIIU_SNDBUF;
+      setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &sendsz, sizeof(sendsz));
+   }
+
+#endif
 
    return connect(fd, addr->ai_addr, addr->ai_addrlen);
 }

--- a/wiiu/include/sys/socket.h
+++ b/wiiu/include/sys/socket.h
@@ -21,6 +21,10 @@ extern "C" {
 /* #define MSG_DONTWAIT    0x0004 */
 
 #define SO_REUSEADDR    0x0004
+#define SO_WINSCALE     0x0400
+#define SO_TCPSACK      0x0200
+#define SO_SNDBUF       0x1001
+#define SO_RCVBUF       0x1002
 #define SO_NBIO         0x1014
 #define SO_NONBLOCK     0x1016
 
@@ -70,6 +74,7 @@ int setsockopt(int sockfd, int level, int optname, const void *optval, socklen_t
 int shutdown(int sockfd, int how);
 int socket(int domain, int type, int protocol);
 int select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds, struct timeval *timeout);
+int somemopt (int req_type, char* mem, unsigned int memlen, int flags);
 
 int socketlasterr(void);
 

--- a/wiiu/include/wiiu/os/thread.h
+++ b/wiiu/include/wiiu/os/thread.h
@@ -133,7 +133,7 @@ typedef struct
 
 #define OS_THREAD_TAG 0x74487244u
 #pragma pack(push, 1)
-typedef struct OSThread
+typedef struct __attribute__ ((aligned (8))) OSThread
 {
    OSContext context;
 

--- a/wiiu/system/imports.h
+++ b/wiiu/system/imports.h
@@ -32,6 +32,7 @@ IMPORT(OSIsThreadTerminated);
 IMPORT(OSSetThreadPriority);
 IMPORT(OSCreateThread);
 IMPORT(OSSetThreadCleanupCallback);
+IMPORT(OSSetThreadDeallocator);
 IMPORT(OSResumeThread);
 IMPORT(OSIsThreadSuspended);
 IMPORT(OSSuspendThread);
@@ -39,6 +40,7 @@ IMPORT(OSGetCurrentThread);
 IMPORT(OSExitThread);
 IMPORT(OSJoinThread);
 IMPORT(OSYieldThread);
+IMPORT(OSSetThreadName);
 IMPORT(OSGetCoreId);
 IMPORT(OSIsMainCore);
 IMPORT(OSGetSystemTime);
@@ -150,6 +152,12 @@ IMPORT(shutdown);
 IMPORT(socket);
 IMPORT(select);
 IMPORT(socketlasterr);
+
+IMPORT_END();
+
+IMPORT_BEGIN(nn_nets2);
+
+IMPORT(somemopt);
 
 IMPORT_END();
 


### PR DESCRIPTION
## Description

A few homebrew have come out for Wii U recently featuring significant network speed improvements over what's been seen recently. Thanks to the wonders of open source, this PR brings those same improvements to RetroArch. Sources in the commit message, all GPL.

I'm on an Australian connection, so it's hard to get hard numbers of what kind of improvements this makes, but Vague Rant on discord tells me it's "at least a factor of 10".

Bonus .gitignore fix - some of the Wii U's sources were being ignored.

## Related Issues

Likely one of several issues contributing to #7278 - more patches incoming.

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

@gblues - you still reviewing Wii U stuff?
