### PR TITLE
(Wii U) Fix inputs breaking when connecting/disconnecting remotes

### DIFF
--- a/input/drivers_joypad/wiiu/kpad_driver.c
+++ b/input/drivers_joypad/wiiu/kpad_driver.c
@@ -251,6 +251,12 @@ static void kpad_poll(void)
       }
       poll_failures[channel] = 0;
 
+      /* Several reads when a device is connected or an attachment added give */
+      /* bogus results, try to weed them out */
+      if (kpad.wpad_error || kpad.device_type == 255) {
+         continue;
+      }
+
       kpad_poll_one_channel(channel, &kpad);
    }
 }


### PR DESCRIPTION
## Description

When a KPAD controller (Wiimote, Pro Controller, etc.) gets disconnected or has its accessory changed, the Wii U's API gives nonsensical results for a little while, even while claiming these results have no errors whatsoever. This was wreaking havoc in the input system and ended up leaving the controllers useless.
This PR attempts to work around the console's API by filtering out some of the unknown results.

## Related Issues

[Flagged by Vague Rant on GBATemp](https://gbatemp.net/posts/9524336), I'm unsure if a GitHub issue was ever filed

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

@gblues
