### PR TITLE
(Ozone) Use Ozone icons instead of XMB Monochrome

### DIFF
--- a/file_path_special.c
+++ b/file_path_special.c
@@ -304,6 +304,21 @@ void fill_pathname_application_special(char *s,
             strlcpy(s, dir_assets, len);
             fill_pathname_slash(s, len);
 
+#if defined(WIIU) || defined(VITA)
+            /* Smaller 46x46 icons look better on low-dpi devices */
+            /* ozone */
+            strlcat(s, "ozone", len);
+            fill_pathname_slash(s, len);
+
+            /* png */
+            strlcat(s, "png", len);
+            fill_pathname_slash(s, len);
+
+            /* Icons path */
+            strlcat(s, "icons", len);
+            fill_pathname_slash(s, len);
+#else
+            /* Otherwise, use large 256x256 icons */
             /* xmb */
             strlcat(s, "xmb", len);
             fill_pathname_slash(s, len);
@@ -315,6 +330,7 @@ void fill_pathname_application_special(char *s,
             /* Icons path */
             strlcat(s, "png", len);
             fill_pathname_slash(s, len);
+#endif
          }
 #endif
          break;


### PR DESCRIPTION
## Description

This PR changes the Ozone menu to stop using icons from `assets/xmb/monochrome/png`, and instead pull from `assets/ozone/png/icons`. The XMB icons are 256x256, which when scaled down to the sizes they're actually displayed at on low DPI devices, causes all the feathering around the edges to be lost and the icons to look pretty poor.

Here's a comparison with a Wii U rendering at 720p, with a 1.57x menu scale (seemingly the largest allowed):

![Screenshot 2021-07-19 21-11-31](https://user-images.githubusercontent.com/8533313/126154219-e0d80fcd-81be-4bce-bcee-02f5a2e74123.png)
*Existing setup, using XMB Monochrome 256x256 icons. Note the jagged circle on the Information icon, the button indicators in the bottom-right, and the mangled small gear on the Configuration File icon.*

![Screenshot 2021-07-19 21-10-15](https://user-images.githubusercontent.com/8533313/126154212-4ecca4c3-251c-44ae-9da9-a089ebe0832d.png)
*Same screen using Ozone 42x42 icons.*

This effect is even more pronounced at lower menu scales and lower render resolutions. While this appears to be the intended purpose of the icons in `assets/ozone/png/icons`, this change could cause HiDPI setups to look worse, so testing from outside my bubble of low-resolution consoles is probably needed. If it turns out to be an issue, perhaps this change could be put behind an ifdef, or RetroArch could introduce 2x and 3x icon sets for those users.

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

Anyone running RetroArch on higher resolution displays should probably confirm this change is sensible. I don't know who deals with Ozone or the asset graphics, if someone could @ them for review that'd be great.
