### PR TITLE
(Wii U) Fix Ozone rendering error

### DIFF
--- a/gfx/drivers_display/gfx_display_wiiu.c
+++ b/gfx/drivers_display/gfx_display_wiiu.c
@@ -283,7 +283,7 @@ static void gfx_display_wiiu_scissor_begin(
       int x, int y,
       unsigned width, unsigned height)
 {
-   GX2SetScissor(MAX(x, 0), MAX(video_height - y - height, 0), MIN(width, video_width), MIN(height, video_height));
+   GX2SetScissor(MAX(x, 0), MAX(y, 0), MIN(width, video_width), MIN(height, video_height));
 }
 
 static void gfx_display_wiiu_scissor_end(


### PR DESCRIPTION
## Description

Ozone is mis-rendered slightly on Wii U due to miscalculating scissor coordinates. While the callback for drawing polygons and textures uses a bottom-up coordinate system, the scissor callback does *not*, but the Wii U was converting anyway. The only reason this worked at all previously was because Ozone happens to use quite tall scissor windows.

Fixes a rendering error in the Wii U menus.

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
