### PR TITLE
(Wii U) Font rendering fixes

### DIFF
--- a/gfx/drivers_font/wiiu_font.c
+++ b/gfx/drivers_font/wiiu_font.c
@@ -258,7 +258,7 @@ static void wiiu_font_render_message(
       return;
    }
 
-   line_height = scale / line_metrics->height;
+   line_height = line_metrics->height * scale / wiiu->vp.height;
 
    for (;;)
    {

--- a/gfx/drivers_font/wiiu_font.c
+++ b/gfx/drivers_font/wiiu_font.c
@@ -65,7 +65,7 @@ static void* wiiu_font_init_font(void* data, const char* font_path,
    font->texture.viewNumSlices       = 1;
 
    font->texture.surface.format   = GX2_SURFACE_FORMAT_UNORM_R8;
-   font->texture.compMap          = GX2_COMP_SEL(_R, _R, _R, _R);
+   font->texture.compMap          = GX2_COMP_SEL(_1, _1, _1, _R);
 
    GX2CalcSurfaceSizeAndAlignment(&font->texture.surface);
    GX2InitTextureRegs(&font->texture);


### PR DESCRIPTION
## Description

Two fixes for the Wii U's font rendering - one that treats the alpha channel of a glyph correctly and fixes aliasing issues, and one to render multi-line text with the correct spacing. See commit messages for details.

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

Combined with #12681 and #12678, Ozone on Wii U is starting to look pretty good!

## Reviewers

[If possible @mention all the people that should review your pull request]
