### PR TITLE
Use BDM for increasing up USB stability

### DIFF
--- a/Makefile.ps2
+++ b/Makefile.ps2
@@ -50,7 +50,7 @@ CFLAGS += $(RARCH_DEFINES)
 # All the IRX objects
 EE_OBJS += $(IRX_DIR)/sio2man_irx.o $ $(IRX_DIR)/iomanX_irx.o $(IRX_DIR)/fileXio_irx.o
 EE_OBJS += $(IRX_DIR)/mcman_irx.o $(IRX_DIR)/mcserv_irx.o
-EE_OBJS += $(IRX_DIR)/usbd_irx.o $(IRX_DIR)/usbhdfsd_irx.o
+EE_OBJS += $(IRX_DIR)/usbd_irx.o $(IRX_DIR)/bdm_irx.o $(IRX_DIR)/bdmfs_vfat_irx.o $(IRX_DIR)/usbmass_bd_irx.o
 EE_OBJS += $(IRX_DIR)/libsd_irx.o $(IRX_DIR)/audsrv_irx.o
 EE_OBJS += $(IRX_DIR)/cdfs_irx.o
 EE_OBJS += $(IRX_DIR)/mtapman_irx.o $(IRX_DIR)/padman_irx.o

--- a/Makefile.ps2.salamander
+++ b/Makefile.ps2.salamander
@@ -61,7 +61,8 @@ EE_OBJS = frontend/frontend_salamander.o \
 
 # Needed IRX objects
 EE_OBJS += $(IRX_DIR)/sio2man_irx.o $ $(IRX_DIR)/iomanX_irx.o $(IRX_DIR)/fileXio_irx.o 
-EE_OBJS += $(IRX_DIR)/mcman_irx.o $(IRX_DIR)/mcserv_irx.o $(IRX_DIR)/usbd_irx.o $(IRX_DIR)/usbhdfsd_irx.o
+EE_OBJS += $(IRX_DIR)/mcman_irx.o $(IRX_DIR)/mcserv_irx.o 
+EE_OBJS += $(IRX_DIR)/usbd_irx.o $(IRX_DIR)/bdm_irx.o $(IRX_DIR)/bdmfs_vfat_irx.o $(IRX_DIR)/usbmass_bd_irx.o
 EE_OBJS += $(IRX_DIR)/cdfs_irx.o
 
 EE_CFLAGS = $(CFLAGS)

--- a/frontend/drivers/platform_ps2.c
+++ b/frontend/drivers/platform_ps2.c
@@ -127,7 +127,9 @@ static void load_modules()
 
    /* USB */
    SifExecModuleBuffer(&usbd_irx, size_usbd_irx, 0, NULL, NULL);
-   SifExecModuleBuffer(&usbhdfsd_irx, size_usbhdfsd_irx, 0, NULL, NULL);
+   SifExecModuleBuffer(&bdm_irx, size_bdm_irx, 0, NULL, NULL);
+   SifExecModuleBuffer(&bdmfs_vfat_irx, size_bdmfs_vfat_irx, 0, NULL, NULL);
+   SifExecModuleBuffer(&usbmass_bd_irx, size_usbmass_bd_irx, 0, NULL, NULL);
 
 #if !defined(DEBUG)
    /* CDFS */

--- a/ps2/include/ps2_irx_variables.h
+++ b/ps2/include/ps2_irx_variables.h
@@ -51,8 +51,14 @@ extern unsigned int size_ps2fs_irx;
 extern unsigned char usbd_irx;
 extern unsigned int size_usbd_irx;
 
-extern unsigned char usbhdfsd_irx;
-extern unsigned int size_usbhdfsd_irx;
+extern unsigned char bdm_irx;
+extern unsigned int size_bdm_irx;
+
+extern unsigned char bdmfs_vfat_irx;
+extern unsigned int size_bdmfs_vfat_irx;
+
+extern unsigned char usbmass_bd_irx;
+extern unsigned int size_usbmass_bd_irx;
 
 extern unsigned char cdfs_irx;
 extern unsigned int size_cdfs_irx;

--- a/ps2/irx/Makefile
+++ b/ps2/irx/Makefile
@@ -4,7 +4,8 @@ IRX_DIR = $(PS2SDK)/iop/irx
 
 #IRX modules
 # IRX modules - modules have to be in IRX_DIR
-IRX_FILES += iomanX.irx fileXio.irx sio2man.irx mtapman.irx padman.irx mcman.irx mcserv.irx usbd.irx usbhdfsd.irx
+IRX_FILES += iomanX.irx fileXio.irx sio2man.irx mtapman.irx padman.irx mcman.irx mcserv.irx
+IRX_FILES += usbd.irx bdm.irx bdmfs_vfat.irx usbmass_bd.irx
 IRX_FILES += libsd.irx audsrv.irx cdfs.irx
 IRX_C_FILES = $(IRX_FILES:.irx=_irx.c) 
 


### PR DESCRIPTION
## Description
This PR just basically change IRX drivers used in the PS2 port for USB drivers
