### PR TITLE
Add retrofw port

### DIFF
--- a/Makefile.retrofw
+++ b/Makefile.retrofw
@@ -1,0 +1,237 @@
+#########################
+## Toolchain variables ##
+#########################
+
+# Default toolchain directory
+TOOLCHAIN_DIR=/opt/retrofw-toolchain
+
+# All toolchain-related variables may be
+# overridden via the command line
+ifdef RETROFW_CC
+CC                    = $(GCW0_CC)
+else
+CC                    = $(TOOLCHAIN_DIR)/usr/bin/mipsel-linux-gcc
+endif
+
+ifdef RETROFW_CXX
+CXX                   = $(GCW0_CXX)
+else
+CXX                   = $(TOOLCHAIN_DIR)/usr/bin/mipsel-linux-g++
+endif
+
+ifdef RETROFW_STRIP
+STRIP                 = $(GCW0_STRIP)
+else
+STRIP                 = $(TOOLCHAIN_DIR)/usr/bin/mipsel-linux-strip
+endif
+
+GCW0_SDL_CONFIG      ?= $(TOOLCHAIN_DIR)/usr/mipsel-buildroot-linux-uclibc/sysroot/usr/bin/sdl-config
+GCW0_FREETYPE_CONFIG ?= $(TOOLCHAIN_DIR)/usr/mipsel-buildroot-linux-uclibc/sysroot/usr/bin/freetype-config
+#GCW0_MK_SQUASH_FS    ?= $(TOOLCHAIN_DIR)/usr/bin/mksquashfs
+GCW0_MK_SQUASH_FS    ?= mksquashfs
+
+GCW0_INC_DIR         ?= $(TOOLCHAIN_DIR)/usr/mipsel-buildroot-linux-uclibc/sysroot/usr/include
+GCW0_LIB_DIR         ?= $(TOOLCHAIN_DIR)/usr/mipsel-buildroot-linux-uclibc/sysroot/usr/lib
+
+#########################
+#########################
+
+PACKAGE_NAME = retroarch
+RETROFW = 1
+
+DEBUG ?= 0
+
+DINGUX = 1
+HAVE_SCREENSHOTS = 0
+HAVE_REWIND = 1
+HAVE_7ZIP = 1
+HAVE_AL = 0
+# ALSA freezes when switching back from menu
+HAVE_ALSA = 0
+HAVE_DSP_FILTER = 1
+HAVE_VIDEO_FILTER = 1
+HAVE_STATIC_VIDEO_FILTERS = 1
+HAVE_STATIC_AUDIO_FILTERS = 1
+HAVE_FILTERS_BUILTIN	= 1
+HAVE_BUILTINMBEDTLS = 0
+HAVE_BUILTINZLIB = 1
+HAVE_C99 = 1
+HAVE_CC = 1
+HAVE_CC_RESAMPLER = 1
+HAVE_CHD = 1
+HAVE_COMMAND = 0
+HAVE_CXX = 1
+HAVE_DR_MP3 = 1
+HAVE_DYNAMIC = 1
+HAVE_EGL = 0
+HAVE_FREETYPE = 0
+HAVE_GDI = 1
+HAVE_GETADDRINFO = 0
+HAVE_GETOPT_LONG = 1
+HAVE_GLSL = 0
+HAVE_HID = 1
+HAVE_IBXM = 1
+HAVE_IMAGEVIEWER = 1
+HAVE_LANGEXTRA = 0
+HAVE_LIBRETRODB = 1
+HAVE_MENU = 1
+HAVE_MENU_COMMON = 1
+HAVE_GFX_WIDGETS = 0
+HAVE_MMAP = 1
+HAVE_OPENDINGUX_FBDEV = 0
+HAVE_OPENGL = 0
+HAVE_OPENGL1 = 0
+HAVE_OPENGLES = 0
+HAVE_OPENGLES3 = 0
+HAVE_OPENGL_CORE = 0
+HAVE_OPENSSL = 1
+HAVE_OVERLAY = 0
+HAVE_RBMP = 1
+HAVE_RJPEG = 1
+HAVE_RPILED = 0
+HAVE_RPNG = 1
+HAVE_RUNAHEAD = 0
+HAVE_SDL_DINGUX = 1
+HAVE_SHADERPIPELINE = 0
+HAVE_STB_FONT = 0
+HAVE_STB_IMAGE = 1
+HAVE_STB_VORBIS = 1
+HAVE_STDIN_CMD = 0
+HAVE_STRCASESTR = 1
+HAVE_THREADS = 1
+HAVE_UDEV = 0
+HAVE_RGUI = 1
+HAVE_MATERIALUI = 0
+HAVE_XMB = 0
+HAVE_OZONE = 0
+HAVE_ZLIB = 1
+HAVE_CONFIGFILE = 1
+HAVE_PATCH = 1
+HAVE_CHEATS = 1
+HAVE_CHEEVOS = 0
+HAVE_LIBSHAKE = 0
+
+#comment out for now not working
+#HAVE_OSS =1
+#HAVE_OSS_LIB =1
+
+OS = Linux
+TARGET = retroarch
+OPK_NAME = retroarch_retrofw.opk
+
+OBJ :=
+LINK := $(CXX)
+DEF_FLAGS := -march=mips32 -mtune=mips32 -mhard-float -ffast-math -fomit-frame-pointer
+DEF_FLAGS += -mplt -mno-shared
+DEF_FLAGS += -ffunction-sections -fdata-sections
+DEF_FLAGS += -I. -Ideps -Ideps/stb -DDINGUX=1 -DRETROFW=1 -MMD
+DEF_FLAGS += -Wall -Wno-unused-variable -flto
+DEF_FLAGS += -std=gnu99 -D_GNU_SOURCE
+LIBS := -ldl -lz -lrt -pthread
+CFLAGS :=
+CXXFLAGS := -fno-exceptions -fno-rtti -std=c++11 -D__STDC_CONSTANT_MACROS
+ASFLAGS :=
+LDFLAGS := -Wl,--gc-sections
+INCLUDE_DIRS = -I$(GCW0_INC_DIR)
+LIBRARY_DIRS = -L$(GCW0_LIB_DIR)
+DEFINES := -DRARCH_INTERNAL -D_FILE_OFFSET_BITS=64 -UHAVE_STATIC_DUMMY
+DEFINES += -DHAVE_C99=1 -DHAVE_CXX=1
+DEFINES += -DHAVE_GETOPT_LONG=1 -DHAVE_STRCASESTR=1 -DHAVE_DYNAMIC=1
+DEFINES += -DHAVE_FILTERS_BUILTIN
+
+SDL_DINGUX_CFLAGS := $(shell $(GCW0_SDL_CONFIG) --cflags)
+SDL_DINGUX_LIBS := $(shell $(GCW0_SDL_CONFIG) --libs)
+FREETYPE_CFLAGS := $(shell $(GCW0_FREETYPE_CONFIG) --cflags)
+FREETYPE_LIBS := $(shell $(GCW0_FREETYPE_CONFIG) --libs)
+MMAP_LIBS = -lc
+
+OBJDIR_BASE := obj-unix
+
+ifeq ($(DEBUG), 1)
+   OBJDIR := $(OBJDIR_BASE)/debug
+   DEF_FLAGS += -O0 -g -DDEBUG -D_DEBUG
+else
+   OBJDIR := $(OBJDIR_BASE)/release
+   DEF_FLAGS += -O2 -DNDEBUG
+endif
+
+include Makefile.common
+
+DEF_FLAGS += $(INCLUDE_DIRS)
+LDFLAGS += $(CFLAGS) $(CXXFLAGS) $(DEF_FLAGS)
+CFLAGS += $(DEF_FLAGS)
+CXXFLAGS += $(DEF_FLAGS)
+
+HEADERS = $(wildcard */*/*.h) $(wildcard */*.h) $(wildcard *.h)
+
+Q := @
+
+RARCH_OBJ := $(addprefix $(OBJDIR)/,$(OBJ))
+
+define DESKTOP_ENTRY
+[Desktop Entry]
+Name=RetroArch
+Comment=Frontend for emulators, game engines
+Exec=retroarch
+Terminal=false
+Type=Application
+StartupNotify=true
+Icon=retroarch
+Categories=emulators;
+X-OD-NeedsDownscaling=true
+endef
+export DESKTOP_ENTRY
+
+
+all: $(TARGET) opk
+
+-include $(RARCH_OBJ:.o=.d)
+
+SYMBOL_MAP := -Wl,-Map=output.map
+
+$(TARGET): $(RARCH_OBJ)
+	@$(if $(Q), $(shell echo echo LD $@),)
+	$(Q)$(LINK) -o $@ $(RARCH_OBJ) $(LIBS) $(LDFLAGS) $(LIBRARY_DIRS)
+
+$(OBJDIR)/%.o: %.c
+	@mkdir -p $(dir $@)
+	@$(if $(Q), $(shell echo echo CC $<),)
+	$(Q)$(CC) $(CPPFLAGS) $(CFLAGS) $(DEFINES) -c -o $@ $<
+
+$(OBJDIR)/%.o: %.cpp
+	@mkdir -p $(dir $@)
+	@$(if $(Q), $(shell echo echo CXX $<),)
+	$(Q)$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(DEFINES) -MMD -c -o $@ $<
+
+$(OBJDIR)/%.o: %.m
+	@mkdir -p $(dir $@)
+	@$(if $(Q), $(shell echo echo OBJC $<),)
+	$(Q)$(CXX) $(OBJCFLAGS) $(DEFINES) -MMD -c -o $@ $<
+
+$(OBJDIR)/%.o: %.S $(HEADERS)
+	@mkdir -p $(dir $@)
+	@$(if $(Q), $(shell echo echo AS $<),)
+	$(Q)$(CC) $(CFLAGS) $(ASFLAGS) $(DEFINES) -c -o $@ $<
+
+clean:
+	rm -rf $(OBJDIR_BASE)
+	rm -f $(TARGET)
+	rm -f *.d
+	rm -rf $(OPK_NAME)
+
+opk: $(TARGET)
+	echo "$$DESKTOP_ENTRY" > default.retrofw.desktop
+	rm -f $(OPK_NAME)
+	cp media/ico_src/icon32.png retroarch.png
+	chmod +x retroarch
+	chmod 777 retroarch
+ifeq ($(STRIP_BIN),1)
+	$(STRIP) --strip-unneeded retroarch
+endif
+	$(GCW0_MK_SQUASH_FS) retroarch default.retrofw.desktop retroarch.png $(OPK_NAME) -all-root -no-xattrs -noappend -no-exports
+	rm -f default.retrofw.desktop retroarch retroarch.png
+
+.PHONY: all clean opk
+
+print-%:
+	@echo '$*=$($*)'

--- a/config.def.h
+++ b/config.def.h
@@ -414,7 +414,12 @@
 #define DEFAULT_DINGUX_IPU_KEEP_ASPECT true
 /* Sets image filtering method when using the
  * IPU hardware scaler in Dingux devices */
+#if defined(RETROFW)
+#define DEFAULT_DINGUX_IPU_FILTER_TYPE DINGUX_IPU_FILTER_NEAREST
+#else
 #define DEFAULT_DINGUX_IPU_FILTER_TYPE DINGUX_IPU_FILTER_BICUBIC
+#endif
+
 #if defined(DINGUX_BETA)
 /* Sets refresh rate of integral LCD panel
  * in Dingux devices */
@@ -744,7 +749,7 @@ static const bool default_savefiles_in_content_dir = false;
 static const bool default_systemfiles_in_content_dir = false;
 static const bool default_screenshots_in_content_dir = false;
 
-#if defined(RS90)
+#if defined(RS90) || defined(RETROFW)
 #define DEFAULT_MENU_TOGGLE_GAMEPAD_COMBO INPUT_TOGGLE_START_SELECT
 #elif defined(_XBOX1) || defined(__PS3__) || defined(_XBOX360) || defined(DINGUX)
 #define DEFAULT_MENU_TOGGLE_GAMEPAD_COMBO INPUT_TOGGLE_L3_R3
@@ -954,7 +959,7 @@ static const bool audio_enable_menu_bgm    = false;
 /* Output samplerate. */
 #ifdef GEKKO
 #define DEFAULT_OUTPUT_RATE 32000
-#elif defined(_3DS)
+#elif defined(_3DS) || defined(RETROFW)
 #define DEFAULT_OUTPUT_RATE 32730
 #else
 #define DEFAULT_OUTPUT_RATE 48000
@@ -965,7 +970,7 @@ static const bool audio_enable_menu_bgm    = false;
 
 /* Desired audio latency in milliseconds. Might not be honored
  * if driver can't provide given latency. */
-#if defined(ANDROID) || defined(EMSCRIPTEN)
+#if defined(ANDROID) || defined(EMSCRIPTEN) || defined(RETROFW)
 /* For most Android devices, 64ms is way too low. */
 #define DEFAULT_OUT_LATENCY 128
 #else
@@ -1038,6 +1043,13 @@ static const bool audio_enable_menu_bgm    = false;
 /* When set, all enabled cheats are auto-applied when a game is loaded. */
 #define DEFAULT_APPLY_CHEATS_AFTER_LOAD false
 
+
+#if defined(RETROFW)
+/*RETROFW jz4760 has signficant slowdown with default settings */
+#define DEFAULT_REWIND_BUFFER_SIZE (1 << 20)
+#define DEFAULT_REWIND_BUFFER_SIZE_STEP 1 
+#define DEFAULT_REWIND_GRANULARITY 6
+#else
 /* The buffer size for the rewind buffer. This needs to be about
  * 15-20MB per minute. Very game dependant. */
 #define DEFAULT_REWIND_BUFFER_SIZE (20 << 20) /* 20MiB */
@@ -1047,7 +1059,7 @@ static const bool audio_enable_menu_bgm    = false;
 
 /* How many frames to rewind at a time. */
 #define DEFAULT_REWIND_GRANULARITY 1
-
+#endif
 /* Pause gameplay when gameplay loses focus. */
 #ifdef EMSCRIPTEN
 #define DEFAULT_PAUSE_NONACTIVE false

--- a/input/drivers_joypad/sdl_dingux_joypad.c
+++ b/input/drivers_joypad/sdl_dingux_joypad.c
@@ -31,9 +31,12 @@
 #include "../../configuration.h"
 #endif
 
-#if !defined(RS90)
-#define SDL_DINGUX_HAS_ANALOG      1
-#define SDL_DINGUX_HAS_MENU_TOGGLE 1
+#if defined(RS90) || defined (RETROFW)
+   #define SDL_DINGUX_HAS_ANALOG      0
+   #define SDL_DINGUX_HAS_MENU_TOGGLE 0
+#else
+   #define SDL_DINGUX_HAS_ANALOG      1
+   #define SDL_DINGUX_HAS_MENU_TOGGLE 1  
 #endif
 
 /* Simple joypad driver designed to rationalise


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

This is to add the retrofw firmware supported devices to retroarch.

Retrofw is a dingoo based firmware runnin on the mips 4760 which is around 50% the speed compared to the devices running Opendingux

## Related Issues

None, new target

## Related Pull Requests

None

## Reviewers

@jdgleaver 
