### PR TITLE
(WiiU) Add RPX compression

### DIFF
--- a/Makefile.wiiu
+++ b/Makefile.wiiu
@@ -338,6 +338,7 @@ clean:
 	$(Q)rm -f $(BUILD_DIR)/$(TARGET).elf $(BUILD_DIR)/$(TARGET).rpx.elf $(BUILD_DIR)/$(TARGET).rpx
 	$(Q)rm -f .$(TARGET).elf.last .$(TARGET).rpx.elf.last .$(TARGET).rpx.last
 	$(Q)rm -f $(OBJ:.o=.depend) $(RPX_OBJ:.o=.depend) $(HBL_ELF_OBJ:.o=.depend)
+	$(Q)$(MAKE) -C wiiu/wut/elf2rpl/ clean
 
 .PHONY: clean all
 .PRECIOUS: %.depend %.last

--- a/Makefile.wiiu
+++ b/Makefile.wiiu
@@ -327,16 +327,21 @@ $(BUILD_DIR)/$(TARGET).rpx.elf: $(OBJ) $(RPX_OBJ) libretro_wiiu.a wiiu/link_elf.
 	@$(if $(Q), echo LD $@,)
 	$(Q)$(LD) $(OBJ) $(RPX_OBJ) $(LDFLAGS) $(RPX_LDFLAGS) $(LIBDIRS)  $(LIBS) -o $@
 
-$(BUILD_DIR)/$(TARGET).rpx: $(BUILD_DIR)/$(TARGET).rpx.elf $(ELF2RPL) .$(TARGET).rpx.last
+$(BUILD_DIR)/$(TARGET).large.rpx: $(BUILD_DIR)/$(TARGET).rpx.elf $(ELF2RPL) .$(TARGET).rpx.large.last
 	@$(if $(Q), echo ELF2RPL $@,)
-	@touch .$(TARGET).rpx.last
+	@touch .$(TARGET).rpx.large.last
 	$(Q)-$(ELF2RPL) $< $@
+
+$(BUILD_DIR)/$(TARGET).rpx: $(BUILD_DIR)/$(TARGET).large.rpx .$(TARGET).rpx.last
+	@$(if $(Q), echo COMPRESS $@,)
+	@touch .$(TARGET).rpx.large.last
+	$(Q)wiiurpxtool -c $< $@
 
 clean:
 	@$(if $(Q), echo $@,)
 	$(Q)rm -f $(OBJ) $(RPX_OBJ) $(HBL_ELF_OBJ) $(TARGET).elf $(TARGET).rpx.elf $(TARGET).rpx
-	$(Q)rm -f $(BUILD_DIR)/$(TARGET).elf $(BUILD_DIR)/$(TARGET).rpx.elf $(BUILD_DIR)/$(TARGET).rpx
-	$(Q)rm -f .$(TARGET).elf.last .$(TARGET).rpx.elf.last .$(TARGET).rpx.last
+	$(Q)rm -f $(BUILD_DIR)/$(TARGET).elf $(BUILD_DIR)/$(TARGET).rpx.elf $(BUILD_DIR)/$(TARGET).large.rpx $(BUILD_DIR)/$(TARGET).rpx
+	$(Q)rm -f .$(TARGET).elf.last .$(TARGET).rpx.elf.last .$(TARGET).rpx.large.last .$(TARGET).rpx.last
 	$(Q)rm -f $(OBJ:.o=.depend) $(RPX_OBJ:.o=.depend) $(HBL_ELF_OBJ:.o=.depend)
 	$(Q)$(MAKE) -C wiiu/wut/elf2rpl/ clean
 


### PR DESCRIPTION
## Description

Compresses Wii U cores using wiiurpxtool. Compression is a feature of the rpx format and should have no compatibility impact.

A random core I had shrunk by nearly a factor of 3:
```
-rw-r--r--. 1 root root  15M Jul 31 00:23 objs/wiiu/retroarch_wiiu.large.rpx
-rw-r--r--. 1 root root 5.8M Jul 31 00:23 objs/wiiu/retroarch_wiiu.rpx
```

[Ploggy on GBATemp saved 800MB](https://gbatemp.net/threads/retroarch-wiiu-wip.447670/page-628#post-9523659)!

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
