### PR TITLE
(WiiU) Use -wiiu build image rather than -devkitpro for salamander

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -783,7 +783,7 @@ build-static-retroarch-wiiu:
     - "mv .retroarch-precompiled/ retroarch-precompiled/"
 
 build-static-retroarch-dummy-wiiu:
-  image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-devkitpro:latest
+  image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-wiiu:latest
   stage: build
   variables:
     MEDIA_PATH: .media


### PR DESCRIPTION
## Description

An attempt to fix [this build failure](https://git.libretro.com/libretro/RetroArch/-/jobs/674598). In addition, using a current version of devkitPPC [creates silently broken binaries](https://gbatemp.net/threads/retroarch-wii-u-devkitpro-r38-and-wut.581160/page-4#post-9476586) at the moment, which is why a [wiiu-specific image](https://git.libretro.com/libretro-infrastructure/libretro-build-wiiu) exists with the appropriate legacy toolchain. This PR switches the salamader build to use this image.

Might actually fix the salamander binaries (which I'm told don't work), not sure.

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
