### PR TITLE
Limit udev device scan to subsystem 'input'

### DIFF
--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -1234,6 +1234,7 @@ static bool open_devices(udev_input_t *udev,
       return false;
 
    udev_enumerate_add_match_property(enumerate, type_str, "1");
+   udev_enumerate_add_match_subsystem(enumerate, "input");
    udev_enumerate_scan_devices(enumerate);
    devs = udev_enumerate_get_list_entry(enumerate);
 

--- a/input/drivers_joypad/udev_joypad.c
+++ b/input/drivers_joypad/udev_joypad.c
@@ -574,6 +574,7 @@ static void *udev_joypad_init(void *data)
       goto error;
 
    udev_enumerate_add_match_property(enumerate, "ID_INPUT_JOYSTICK", "1");
+   udev_enumerate_add_match_subsystem(enumerate, "input");
    udev_enumerate_scan_devices(enumerate);
    devs = udev_enumerate_get_list_entry(enumerate);
 


### PR DESCRIPTION
## Description

This change makes the call to `udev_enumerate_scan_devices` much faster.
In particular, for some bluetooth devices, this function may implicitly
read its battery's virtual file `uevent`, e.g.

```
/sys/devices/*/usb1/1-1/*/bluetooth/hci0/*/power_supply/hid-*-battery/uevent
```

Reading this file may (for unknown reasons) block up to 10 seconds.
Since `udev_enumerate_scan_devices` is called 4 times (for keyboard,
mouse, touchpad, and joypad) during startup this may cause a
considerable delay.

Limiting the scan to subsystem `input` yields the same devices but makes
the scan faster and does not read `uevent` of the input controller's
power_supply.

## Related Issues

#10408

## Related Pull Requests

N/A

## Reviewers

?
