### PR TITLE
Fix CRC32 reading in explore menu

### DIFF
--- a/menu/menu_explore.c
+++ b/menu/menu_explore.c
@@ -596,7 +596,7 @@ static explore_state_t *explore_build_list(settings_t *settings)
             key_str                         = key->val.string.buff;
             if (string_is_equal(key_str, "crc"))
             {
-               switch (strlen(val->val.binary.buff))
+               switch (val->val.binary.len)
                {
                   case 1:
                      crc32 = *(uint8_t*)val->val.binary.buff;


### PR DESCRIPTION
## Description

This is a fix for a bug introduced in 523e37e which would fail to read CRC32 values that contain a zero byte (i.e. 0x11002233).

## Related Pull Requests

#12164

## Reviewers
@jdgleaver The function `database_cursor_iterate` in database_info.c probably also needs updating then? It contains this which also assumes the field crc to always be 4 bytes long.
```c
      else if (string_is_equal(str, "crc"))
         db_info->crc32 = swap_if_little32(
               *(uint32_t*)val->val.binary.buff);
```
Also sorry for noticing this so late!