### PR TITLE
Friendly names for mice where available

### DIFF
--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -1262,23 +1262,24 @@ static bool open_devices(udev_input_t *udev,
                char ident[255];
                if (ioctl(fd, EVIOCGNAME(sizeof(ident)), ident) < 0)
                   ident[0] = '\0';
-               if ( type == UDEV_INPUT_KEYBOARD)
+               if (type == UDEV_INPUT_KEYBOARD)
                {
-                  RARCH_LOG("[udev]: Added Device Keyboard#%d %s (%s) .\n",
+                  RARCH_LOG("[udev]: Keyboard #%u: \"%s\" (%s).\n",
                      device_keyboard,
                      ident,
                      devnode);
                    device_keyboard++;
                }                     
-               else if (type == UDEV_INPUT_MOUSE || type== UDEV_INPUT_TOUCHPAD)
+               else if (type == UDEV_INPUT_MOUSE || type == UDEV_INPUT_TOUCHPAD)
                {
-                  RARCH_LOG("[udev]: Added Device mouse#%d %s (%s) .\n",
+                  input_config_set_mouse_display_name(device_mouse, ident);
+
+                  RARCH_LOG("[udev]: Mouse #%u: \"%s\" (%s).\n",
                      device_mouse,
                      ident,
                      devnode);
                      device_mouse++;
                }                     
-                  
             }
 
             (void)check;

--- a/input/drivers/winraw_input.c
+++ b/input/drivers/winraw_input.c
@@ -164,6 +164,8 @@ static void winraw_log_mice_info(winraw_mouse_t *mice, unsigned mouse_cnt)
       if (!name[0])
          snprintf(name, sizeof(name), "%s", "<name not found>");
 
+      input_config_set_mouse_display_name(i, name);
+
       RARCH_LOG("[WINRAW]: Mouse #%u: \"%s\".\n", i, name);
    }
 }

--- a/input/input_driver.h
+++ b/input/input_driver.h
@@ -120,6 +120,11 @@ typedef struct
    bool autoconfigured;
 } input_device_info_t;
 
+typedef struct
+{
+   char display_name[256];
+} input_mouse_info_t;
+
 /**
  * Organizes the functions and data structures of each driver that are accessed
  * by other parts of the input code. The input_driver structs are the "interface"
@@ -491,6 +496,7 @@ void input_config_set_device_name(unsigned port, const char *name);
  * @param port
  */
 void input_config_set_device_display_name(unsigned port, const char *name);
+void input_config_set_mouse_display_name(unsigned port, const char *name);
 
 /**
  * Set the configuration path for the device in the specified port
@@ -580,6 +586,7 @@ unsigned input_config_get_device(unsigned port);
 /* Get input_device_info */
 const char *input_config_get_device_name(unsigned port);
 const char *input_config_get_device_display_name(unsigned port);
+const char *input_config_get_mouse_display_name(unsigned port);
 const char *input_config_get_device_config_path(unsigned port);
 const char *input_config_get_device_config_name(unsigned port);
 const char *input_config_get_device_joypad_driver(unsigned port);

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -7298,6 +7298,36 @@ static void get_string_representation_bind_device(rarch_setting_t *setting, char
       strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_DISABLED), len);
 }
 
+static void get_string_representation_mouse_index(rarch_setting_t *setting, char *s,
+      size_t len)
+{
+   unsigned index_offset, map = 0;
+   unsigned max_devices       = MAX_USERS;
+   settings_t      *settings  = config_get_ptr();
+
+   if (!setting)
+      return;
+
+   index_offset = setting->index_offset;
+   map          = settings->uints.input_mouse_index[index_offset];
+
+   if (map < max_devices)
+   {
+      const char *device_name = input_config_get_mouse_display_name(map);
+
+      if (!string_is_empty(device_name))
+         strlcpy(s, device_name, len);
+      else
+         snprintf(s, len,
+               "%s (#%u)",
+               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE),
+               map);
+   }
+   else
+      snprintf(s, len,
+         "#%u", map);
+}
+
 static void read_handler_audio_rate_control_delta(rarch_setting_t *setting)
 {
    settings_t      *settings = config_get_ptr();
@@ -8456,6 +8486,8 @@ static bool setting_append_list_input_player_options(
       (*list)[list_info->index - 1].action_right  = &setting_action_right_mouse_index;
       (*list)[list_info->index - 1].action_select = &setting_action_right_mouse_index;
       (*list)[list_info->index - 1].action_ok     = &setting_action_ok_uint;
+      (*list)[list_info->index - 1].get_string_representation =
+         &get_string_representation_mouse_index;
       menu_settings_list_current_add_range(list, list_info, 0, MAX_USERS - 1, 1.0, true, true);
       MENU_SETTINGS_LIST_CURRENT_ADD_ENUM_IDX_PTR(list, list_info,
             (enum msg_hash_enums)(MENU_ENUM_LABEL_INPUT_MOUSE_INDEX + user));

--- a/retroarch.c
+++ b/retroarch.c
@@ -27161,6 +27161,14 @@ const char *input_config_get_device_display_name(unsigned port)
    return p_rarch->input_device_info[port].display_name;
 }
 
+const char *input_config_get_mouse_display_name(unsigned port)
+{
+   struct rarch_state *p_rarch = &rarch_st;
+   if (string_is_empty(p_rarch->input_mouse_info[port].display_name))
+      return NULL;
+   return p_rarch->input_mouse_info[port].display_name;
+}
+
 const char *input_config_get_device_config_path(unsigned port)
 {
    struct rarch_state *p_rarch = &rarch_st;
@@ -27246,6 +27254,14 @@ void input_config_set_device_display_name(unsigned port, const char *name)
    if (!string_is_empty(name))
       strlcpy(p_rarch->input_device_info[port].display_name, name,
             sizeof(p_rarch->input_device_info[port].display_name));
+}
+
+void input_config_set_mouse_display_name(unsigned port, const char *name)
+{
+   struct rarch_state *p_rarch = &rarch_st;
+   if (!string_is_empty(name))
+      strlcpy(p_rarch->input_mouse_info[port].display_name, name,
+            sizeof(p_rarch->input_mouse_info[port].display_name));
 }
 
 void input_config_set_device_config_path(unsigned port, const char *path)

--- a/retroarch_data.h
+++ b/retroarch_data.h
@@ -2023,6 +2023,7 @@ struct rarch_state
 #endif
 
    input_device_info_t input_device_info[MAX_INPUT_DEVICES];
+   input_mouse_info_t input_mouse_info[MAX_INPUT_DEVICES];
                                           /* unsigned alignment */
 #ifdef HAVE_MENU
    menu_dialog_t dialog_st;               /* unsigned alignment */


### PR DESCRIPTION
## Description

A crude initial support for human readable mice display names. Since winraw and udev are the only ones being able to use multiple mice, they get to display the same names they luckily already log.


