### PR TITLE
Change default mouse index to port index

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -2495,7 +2495,7 @@ void config_set_defaults(void *data)
       settings->uints.input_analog_dpad_mode[i] = ANALOG_DPAD_NONE;
 #endif
       input_config_set_device(i, RETRO_DEVICE_JOYPAD);
-      settings->uints.input_mouse_index[i] = 0;
+      settings->uints.input_mouse_index[i] = i;
    }
 
    video_driver_reset_custom_viewport();

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -7072,7 +7072,7 @@ static int setting_action_start_mouse_index(rarch_setting_t *setting)
    if (!setting)
       return -1;
 
-   settings->uints.input_mouse_index[setting->index_offset] = 0;
+   settings->uints.input_mouse_index[setting->index_offset] = setting->index_offset;
    settings->modified = true;
    return 0;
 }
@@ -8473,7 +8473,7 @@ static bool setting_append_list_input_player_options(
             &settings->uints.input_mouse_index[user],
             mouse_index[user],
             label_mouse_index[user],
-            0,
+            user,
             &group_info,
             &subgroup_info,
             parent_group,


### PR DESCRIPTION
## Description

By default mouse index is 0 in all ports (first mouse will move all ports), which means users are forced to manually change them even in the lucky incident where mice would be in the correct order already regarding ports.

Any reasons not to default mouse index to the port index like joypads? This change covers the initial fresh config and the option reset.
