### PR TITLE
(cheevos) address warning when using -fno-signed-char

### DIFF
--- a/deps/rcheevos/src/rcheevos/condition.c
+++ b/deps/rcheevos/src/rcheevos/condition.c
@@ -2,7 +2,7 @@
 
 #include <stdlib.h>
 
-char rc_parse_operator(const char** memaddr) {
+static int rc_parse_operator(const char** memaddr) {
   const char* oper = *memaddr;
 
   switch (*oper) {
@@ -63,7 +63,7 @@ char rc_parse_operator(const char** memaddr) {
 rc_condition_t* rc_parse_condition(const char** memaddr, rc_parse_state_t* parse, int is_indirect) {
   rc_condition_t* self;
   const char* aux;
-  int ret2;
+  int result;
   int can_modify = 0;
 
   aux = *memaddr;
@@ -95,10 +95,9 @@ rc_condition_t* rc_parse_condition(const char** memaddr, rc_parse_state_t* parse
     self->type = RC_CONDITION_STANDARD;
   }
 
-  ret2 = rc_parse_operand(&self->operand1, &aux, 1, is_indirect, parse);
-
-  if (ret2 < 0) {
-    parse->offset = ret2;
+  result = rc_parse_operand(&self->operand1, &aux, 1, is_indirect, parse);
+  if (result < 0) {
+    parse->offset = result;
     return 0;
   }
 
@@ -107,8 +106,13 @@ rc_condition_t* rc_parse_condition(const char** memaddr, rc_parse_state_t* parse
     return 0;
   }
 
-  self->oper = rc_parse_operator(&aux);
+  result = rc_parse_operator(&aux);
+  if (result < 0) {
+    parse->offset = result;
+    return 0;
+  }
 
+  self->oper = (char)result;
   switch (self->oper) {
     case RC_OPERATOR_NONE:
       /* non-modifying statements must have a second operand */
@@ -135,10 +139,6 @@ rc_condition_t* rc_parse_condition(const char** memaddr, rc_parse_state_t* parse
         break;
       /* fallthrough */
 
-    case RC_INVALID_OPERATOR:
-      parse->offset = RC_INVALID_OPERATOR;
-      return 0;
-
     default:
       /* comparison operators are not valid on modifying statements */
       if (can_modify) {
@@ -158,10 +158,9 @@ rc_condition_t* rc_parse_condition(const char** memaddr, rc_parse_state_t* parse
       break;
   }
 
-  ret2 = rc_parse_operand(&self->operand2, &aux, 1, is_indirect, parse);
-
-  if (ret2 < 0) {
-    parse->offset = ret2;
+  result = rc_parse_operand(&self->operand2, &aux, 1, is_indirect, parse);
+  if (result < 0) {
+    parse->offset = result;
     return 0;
   }
 

--- a/deps/rcheevos/src/rcheevos/rc_internal.h
+++ b/deps/rcheevos/src/rcheevos/rc_internal.h
@@ -133,7 +133,6 @@ int rc_evaluate_condition_value(rc_condition_t* self, rc_eval_state_t* eval_stat
 
 int rc_parse_operand(rc_operand_t* self, const char** memaddr, int is_trigger, int is_indirect, rc_parse_state_t* parse);
 unsigned rc_evaluate_operand(rc_operand_t* self, rc_eval_state_t* eval_state);
-char rc_parse_operator(const char** memaddr);
 
 void rc_parse_value_internal(rc_value_t* self, const char** memaddr, rc_parse_state_t* parse);
 void rc_reset_value(rc_value_t* self);


### PR DESCRIPTION
## Description

Fixes an error reported by the 3DS build of RetroArch:

```
griffin/../deps/rcheevos/src/rcheevos/condition.c: In function 'rc_parse_condition':
griffin/../deps/rcheevos/src/rcheevos/condition.c:138:5: warning: case label value is less than minimum value for type
     case RC_INVALID_OPERATOR:
     ^~~~
```

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@twinaphex 