### PR TITLE
WIIU: Fix L3/R3 buttons

### DIFF
--- a/input/common/hid/device_ds3.c
+++ b/input/common/hid/device_ds3.c
@@ -327,7 +327,7 @@ static int16_t ds3_get_axis(void *data, unsigned axis)
 
 static const char *ds3_get_name(void *data) { return "Sony DualShock 3"; }
 
-static int16_t ds3_button(void *data, uint16_t joykey)
+static int32_t ds3_button(void *data, uint16_t joykey)
 {
    ds3_instance_t *pad = (ds3_instance_t *)data;
    if (!pad || joykey > 31)

--- a/input/common/hid/device_ds4.c
+++ b/input/common/hid/device_ds4.c
@@ -112,7 +112,7 @@ static void ds4_packet_handler(void *data, uint8_t *packet, uint16_t size)
 static void ds4_set_rumble(void *data, enum retro_rumble_effect effect, uint16_t strength) { }
 static int16_t ds4_get_axis(void *data, unsigned axis) { return 0; }
 static const char *ds4_get_name(void *data) { return "Sony DualShock 4"; }
-static int16_t ds4_button(void *data, uint16_t joykey) { return 0; }
+static int32_t ds4_button(void *data, uint16_t joykey) { return 0; }
 static void ds4_pad_deinit(void *data) { }
 static void ds4_get_buttons(void *data, input_bits_t *state) { }
 

--- a/input/common/hid/device_null.c
+++ b/input/common/hid/device_null.c
@@ -182,7 +182,7 @@ static const char *hid_null_get_name(void *data)
 /**
  * Read the state of a single button.
  */
-static int16_t hid_null_button(void *data, uint16_t joykey) { return 0; }
+static int32_t hid_null_button(void *data, uint16_t joykey) { return 0; }
 
 /**
  * Fill in the joypad interface

--- a/input/common/hid/device_wiiu_gca.c
+++ b/input/common/hid/device_wiiu_gca.c
@@ -325,7 +325,7 @@ static const char *wiiu_gca_get_name(void *data)
  * 0x0008 - Y   0x0080 - up      0x0800 - L
  */
 
-static int16_t wiiu_gca_button(void *data, uint16_t joykey)
+static int32_t wiiu_gca_button(void *data, uint16_t joykey)
 {
    gca_pad_t *pad = (gca_pad_t *)data;
    if(!pad || joykey > 31)

--- a/input/connect/joypad_connection.h
+++ b/input/connect/joypad_connection.h
@@ -73,7 +73,7 @@ typedef struct pad_connection_interface
    void			(*get_buttons)(void *data, input_bits_t *state);
    int16_t  	(*get_axis)(void *data, unsigned axis);
    const char*	(*get_name)(void *data);
-   int16_t      (*button)(void *data, uint16_t joykey);
+   int32_t      (*button)(void *data, uint16_t joykey);
 } pad_connection_interface_t;
 
 extern pad_connection_interface_t pad_connection_wii;

--- a/input/drivers_joypad/wiiu/hidpad_driver.c
+++ b/input/drivers_joypad/wiiu/hidpad_driver.c
@@ -56,7 +56,7 @@ static void hidpad_destroy(void)
    hid_deinit(&hid_instance);
 }
 
-static int16_t hidpad_button(unsigned port, uint16_t joykey)
+static int32_t hidpad_button(unsigned port, uint16_t joykey)
 {
    if (!hidpad_query_pad(port))
       return 0;

--- a/input/drivers_joypad/wiiu/kpad_driver.c
+++ b/input/drivers_joypad/wiiu/kpad_driver.c
@@ -92,7 +92,7 @@ static void kpad_destroy(void)
    kpad_ready = false;
 }
 
-static int16_t kpad_button(unsigned port, uint16_t joykey)
+static int32_t kpad_button(unsigned port, uint16_t joykey)
 {
    int channel;
    if (!kpad_query_pad(port))

--- a/input/drivers_joypad/wiiu/wpad_driver.c
+++ b/input/drivers_joypad/wiiu/wpad_driver.c
@@ -277,7 +277,7 @@ static bool wpad_query_pad(unsigned port)
 
 static void wpad_destroy(void) { }
 
-static int16_t wpad_button(unsigned port, uint16_t joykey)
+static int32_t wpad_button(unsigned port, uint16_t joykey)
 {
    VPADChan channel;
    if (!wpad_query_pad(port))

--- a/input/drivers_joypad/wiiu_joypad.c
+++ b/input/drivers_joypad/wiiu_joypad.c
@@ -60,7 +60,7 @@ static void wiiu_joypad_destroy(void)
 #endif
 }
 
-static int16_t wiiu_joypad_button(unsigned port, uint16_t joykey)
+static int32_t wiiu_joypad_button(unsigned port, uint16_t joykey)
 {
    if (!wiiu_joypad_query_pad(port))
       return 0;

--- a/input/input_driver.h
+++ b/input/input_driver.h
@@ -267,7 +267,7 @@ struct rarch_joypad_driver
    void *(*init)(void *data);
    bool (*query_pad)(unsigned);
    void (*destroy)(void);
-   int16_t (*button)(unsigned, uint16_t);
+   int32_t (*button)(unsigned, uint16_t);
    int16_t (*state)(rarch_joypad_info_t *joypad_info,
          const struct retro_keybind *binds, unsigned port);
    void (*get_buttons)(unsigned, input_bits_t *);


### PR DESCRIPTION
## Description

After a bisect, the culprit was changing the gamepad interface from
returing a single button (bool) to multiple (int16).

The issue is that the Wii U gamepad (and presumably the Pro controller too)
have more than 16 buttons, which means some buttons get lost. Notably, L3 (18)
and R3 (17).

The solution: use int32 instead of int16.

I did a test build and confirmed that this change restores L3/R3 functionality
with the gamepad. Don't have a pro controller to test, but it should work too.

## Related Issues
#12747 

## Reviewers

@twinaphex @QuarkTheAwesome 
