### PR TITLE
Add StartupWMClass to retroarch.desktop file

### DIFF
--- a/retroarch.desktop
+++ b/retroarch.desktop
@@ -11,5 +11,6 @@ Icon=retroarch
 Exec=retroarch
 Terminal=false
 StartupNotify=false
+StartupWMClass=retroarch
 Keywords=multi;engine;emulator;xmb;
 Categories=Game;Emulator;


### PR DESCRIPTION
## Description
In some Linux Desktop Environments, like Budgie, task bar feature is unable to pin applications. With `StartupWMClass=` present in `.desktop` file, it is possible to pin the application.

## Related Issues
https://github.com/flathub/org.libretro.RetroArch/issues/191

## Related Pull Requests
None

## Reviewers
Will leave this up to retroarch maintainers
