### PR TITLE
(cheevos) explicitly cast to unsigned char for ctype functions

### DIFF
--- a/deps/rcheevos/src/rapi/rc_api_common.c
+++ b/deps/rcheevos/src/rapi/rc_api_common.c
@@ -75,12 +75,12 @@ static int rc_json_parse_field(const char** json_ptr, rc_json_field_t* field) {
       break;
 
     default: /* non-quoted text [true,false,null] */
-      if (!isalpha(**json_ptr))
+      if (!isalpha((unsigned char)**json_ptr))
         return RC_INVALID_JSON;
 
       do {
         ++(*json_ptr);
-      } while (isalnum(**json_ptr));
+      } while (isalnum((unsigned char)**json_ptr));
       break;
   }
 
@@ -101,7 +101,7 @@ static int rc_json_parse_array(const char** json_ptr, rc_json_field_t* field) {
   if (*json != ']') {
     do
     {
-      while (isspace(*json))
+      while (isspace((unsigned char)*json))
         ++json;
 
       result = rc_json_parse_field(&json, &unused_field);
@@ -110,7 +110,7 @@ static int rc_json_parse_array(const char** json_ptr, rc_json_field_t* field) {
 
       ++field->array_size;
 
-      while (isspace(*json))
+      while (isspace((unsigned char)*json))
         ++json;
 
       if (*json != ',')
@@ -149,7 +149,7 @@ static int rc_json_parse_object(const char** json_ptr, rc_json_field_t* fields, 
 
   do
   {
-    while (isspace(*json))
+    while (isspace((unsigned char)*json))
       ++json;
 
     if (*json != '"')
@@ -164,7 +164,7 @@ static int rc_json_parse_object(const char** json_ptr, rc_json_field_t* fields, 
     key_len = json - key_start;
     ++json;
 
-    while (isspace(*json))
+    while (isspace((unsigned char)*json))
       ++json;
 
     if (*json != ':')
@@ -172,7 +172,7 @@ static int rc_json_parse_object(const char** json_ptr, rc_json_field_t* fields, 
 
     ++json;
 
-    while (isspace(*json))
+    while (isspace((unsigned char)*json))
       ++json;
 
     field = &non_matching_field;
@@ -186,7 +186,7 @@ static int rc_json_parse_object(const char** json_ptr, rc_json_field_t* fields, 
     if (rc_json_parse_field(&json, field) < 0)
       return RC_INVALID_JSON;
 
-    while (isspace(*json))
+    while (isspace((unsigned char)*json))
       ++json;
 
     if (*json != ',')
@@ -277,12 +277,12 @@ static int rc_json_get_array_entry_value(rc_json_field_t* field, rc_json_field_t
   if (!iterator->array_size)
     return 0;
 
-  while (isspace(*iterator->value_start))
+  while (isspace((unsigned char)*iterator->value_start))
     ++iterator->value_start;
 
   rc_json_parse_field(&iterator->value_start, field);
 
-  while (isspace(*iterator->value_start))
+  while (isspace((unsigned char)*iterator->value_start))
     ++iterator->value_start;
 
   ++iterator->value_start; /* skip , or ] */
@@ -338,12 +338,12 @@ int rc_json_get_array_entry_object(rc_json_field_t* fields, size_t field_count, 
   if (!iterator->array_size)
     return 0;
 
-  while (isspace(*iterator->value_start))
+  while (isspace((unsigned char)*iterator->value_start))
     ++iterator->value_start;
 
   rc_json_parse_object(&iterator->value_start, fields, field_count);
 
-  while (isspace(*iterator->value_start))
+  while (isspace((unsigned char)*iterator->value_start))
     ++iterator->value_start;
 
   ++iterator->value_start; /* skip , or ] */

--- a/deps/rcheevos/src/rcheevos/operand.c
+++ b/deps/rcheevos/src/rcheevos/operand.c
@@ -29,7 +29,7 @@ static int rc_parse_operand_lua(rc_operand_t* self, const char** memaddr, rc_par
     return RC_INVALID_LUA_OPERAND;
   }
 
-  if (!isalpha(*aux)) {
+  if (!isalpha((unsigned char)*aux)) {
     return RC_INVALID_LUA_OPERAND;
   }
 
@@ -37,7 +37,7 @@ static int rc_parse_operand_lua(rc_operand_t* self, const char** memaddr, rc_par
   id = aux;
 #endif
 
-  while (isalnum(*aux) || *aux == '_') {
+  while (isalnum((unsigned char)*aux) || *aux == '_') {
     aux++;
   }
 

--- a/deps/rcheevos/src/rcheevos/value.c
+++ b/deps/rcheevos/src/rcheevos/value.c
@@ -78,7 +78,7 @@ void rc_parse_legacy_value(rc_value_t* self, const char** memaddr, rc_parse_stat
           }
           else {
             /* if it looks like a floating point number, add the 'f' prefix */
-            while (isdigit(*(unsigned char*)buffer_ptr))
+            while (isdigit((unsigned char)*buffer_ptr))
               ++buffer_ptr;
             if (*buffer_ptr == '.')
               *ptr++ = 'f';

--- a/deps/rcheevos/src/rhash/hash.c
+++ b/deps/rcheevos/src/rhash/hash.c
@@ -58,7 +58,6 @@ static void filereader_seek(void* file_handle, int64_t offset, int origin)
 #elif defined(_LARGEFILE64_SOURCE)
   fseeko64((FILE*)file_handle, offset, origin);
 #else
-#pragma message("Using generic fseek may fail for large files")
   fseek((FILE*)file_handle, offset, origin);
 #endif
 }
@@ -1034,7 +1033,7 @@ static int rc_hash_dreamcast(char hash[33], const char* path)
   /* the boot filename is 96 bytes into the meta information (https://mc.pp.se/dc/ip0000.bin.html) */
   /* remove whitespace from bootfile */
   i = 0;
-  while (!isspace(buffer[96 + i]) && i < 16)
+  while (!isspace((unsigned char)buffer[96 + i]) && i < 16)
     ++i;
 
   /* sometimes boot file isn't present on meta information.
@@ -1101,13 +1100,13 @@ static int rc_hash_find_playstation_executable(void* track_handle, const char* b
     if (strncmp(ptr, boot_key, boot_key_len) == 0)
     {
       ptr += boot_key_len;
-      while (isspace(*ptr))
+      while (isspace((unsigned char)*ptr))
         ++ptr;
 
       if (*ptr == '=')
       {
         ++ptr;
-        while (isspace(*ptr))
+        while (isspace((unsigned char)*ptr))
           ++ptr;
 
         if (strncmp(ptr, cdrom_prefix, cdrom_prefix_len) == 0)
@@ -1116,7 +1115,7 @@ static int rc_hash_find_playstation_executable(void* track_handle, const char* b
           ++ptr;
 
         start = ptr;
-        while (!isspace(*ptr) && *ptr != ';')
+        while (!isspace((unsigned char)*ptr) && *ptr != ';')
           ++ptr;
 
         size = (unsigned)(ptr - start);
@@ -1525,7 +1524,7 @@ static const char* rc_hash_get_first_item_from_playlist(const char* path)
     next = ptr;
 
     /* remove trailing whitespace - especially '\r' */
-    while (ptr > start && isspace(ptr[-1]))
+    while (ptr > start && isspace((unsigned char)ptr[-1]))
       --ptr;
 
     /* if we found a non-empty line, break out of the loop to process it */


### PR DESCRIPTION
## Description

Addresses `array subscript has type 'char' [-Wchar-subscripts]` warning for some ctype implementations. Reported against libnx/switch build.

Google suggests the solution is to explicitly cast the values to `unsigned char` (not `int` as implied by the function signature) as `int` is also a signed type and would sign extend the negative character values, thus not avoiding the array indexing issue implied by the warning.

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@twinaphex 