### PR TITLE
Remove unused variable in core options v2 sample template file

### DIFF
--- a/libretro-common/samples/core_options/example_categories/libretro_core_options.h
+++ b/libretro-common/samples/core_options/example_categories/libretro_core_options.h
@@ -373,8 +373,6 @@ static INLINE void libretro_set_core_options(retro_environment_t environ_cb,
                /* Build values string */
                if (num_values > 0)
                {
-                  size_t j;
-
                   buf_len += num_values - 1;
                   buf_len += strlen(desc);
 


### PR DESCRIPTION
## Description

This trivial PR just removes an unused variable in the core options v2 sample template file (https://github.com/libretro/RetroArch/blob/master/libretro-common/samples/core_options/example_categories/libretro_core_options.h). This is not really a harmful thing, but we don't want it to be copied/pasted everywhere as cores are being updated to options v2...