### PR TITLE
Optimise core option/core option category look-ups using hash tables

### DIFF
--- a/core_option_manager.h
+++ b/core_option_manager.h
@@ -45,6 +45,7 @@ struct core_option
     * option *value* indices */
    size_t default_index;
    size_t index;
+   uint32_t key_hash;
    bool visible;
 };
 
@@ -53,6 +54,7 @@ struct core_catagory
    char *key;
    char *desc;
    char *info;
+   uint32_t key_hash;
 };
 
 /* TODO/FIXME: This struct should be made


### PR DESCRIPTION
## Description

At present, a number of core-option-related operations (looking up options and categories) involve looping through option lists while searching for a particular key string. This is somewhat slow.

This PR optimises these searches by using hash tables to minimise string comparisons. Tested using the PUAE core (which has an unusually large number of options: 109) this reduces the performance overheads of the `RETRO_ENVIRONMENT` callback functions in the 'standard' core-side `update_variables()` routine by 56%.
