### PR TITLE
(WASAPI) Stop deactivating audio on fast forward

### DIFF
--- a/audio/drivers/wasapi.c
+++ b/audio/drivers/wasapi.c
@@ -736,7 +736,7 @@ static ssize_t wasapi_write_ex(wasapi_t *w, const void * data, size_t size, DWOR
    if (!write_avail)
    {
       if (WaitForSingleObject(w->write_event, ms) != WAIT_OBJECT_0)
-         return -1;
+         return 0;
 
       if (!wasapi_flush_buffer(w, w->engine_buffer_size))
          return -1;


### PR DESCRIPTION
## Description

Almost too simple to be true, but works fine here. Because driver write returning `-1` will permanently disable audio driver. Affects only exclusive mode.

Closes #11891 

