### PR TITLE
(Database) Fix heap-buffer-overflow when fetching CRC values

### DIFF
--- a/database_info.c
+++ b/database_info.c
@@ -281,8 +281,23 @@ static int database_cursor_iterate(libretrodb_cursor_t *cur,
       else if (string_is_equal(str, "size"))
          db_info->size                    = (unsigned)val->val.uint_;
       else if (string_is_equal(str, "crc"))
-         db_info->crc32 = swap_if_little32(
-               *(uint32_t*)val->val.binary.buff);
+      {
+         switch (val->val.binary.len)
+         {
+            case 1:
+               db_info->crc32 = *(uint8_t*)val->val.binary.buff;
+               break;
+            case 2:
+               db_info->crc32 = swap_if_little16(*(uint16_t*)val->val.binary.buff);
+               break;
+            case 4:
+               db_info->crc32 = swap_if_little32(*(uint32_t*)val->val.binary.buff);
+               break;
+            default:
+               db_info->crc32 = 0;
+               break;
+         }
+      }
       else if (string_is_equal(str, "sha1"))
          db_info->sha1 = bin_to_hex_alloc(
                (uint8_t*)val->val.binary.buff, val->val.binary.len);


### PR DESCRIPTION
## Description

As pointed out by @schellingb (https://github.com/libretro/RetroArch/pull/12733), the function `database_cursor_iterate()` in `database_info.c` assumes a 4 byte buffer when fetching/converting CRC values. This is not always the case. If the buffer is less than 4 bytes long, then a heap-buffer-overflow will occur. This can be triggered by e.g. viewing the TIC-80 database via `Information > Database Manger` - causing RetroArch to crash.

This PR fixes the issue by handling the buffer safely according to its actual size, as we currently do in the `menu_explore` code.

Many thanks to @schellingb for spotting this error :)