### PR TITLE
Resolution dropdown pop

### DIFF
--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -6211,7 +6211,7 @@ int action_cb_push_dropdown_item_resolution(const char *path,
       settings->uints.video_fullscreen_x = width;
       settings->uints.video_fullscreen_y = height;
 
-      return 1;
+      action_cancel_pop_default(NULL, NULL, 0, 0);
    }
 
    return 0;


### PR DESCRIPTION
## Description

Make Screen Resolution option act like other dropdowns, as in return on select.

This does not only have usability benefits, but it also makes the option work properly in some cases..
