### PR TITLE
(cheevos) prevent read past end of buffer

### DIFF
--- a/deps/rcheevos/src/rapi/rc_api_common.c
+++ b/deps/rcheevos/src/rapi/rc_api_common.c
@@ -1021,7 +1021,7 @@ int rc_api_init_fetch_image_request(rc_api_request_t* request, const rc_api_fetc
     case RC_IMAGE_TYPE_USER:
       rc_url_builder_append(&builder, "/UserPic/", 9);
       rc_url_builder_append(&builder, api_params->image_name, strlen(api_params->image_name));
-      rc_url_builder_append(&builder, ".png", 9);
+      rc_url_builder_append(&builder, ".png", 4);
       break;
 
     default:


### PR DESCRIPTION
## Description

Attempts to address the following warning:
```
In function 'rc_url_builder_append',
    inlined from 'rc_url_builder_append' at deps/rcheevos/src/rapi/rc_api_common.c:862:6,
    inlined from 'rc_api_init_fetch_image_request' at deps/rcheevos/src/rapi/rc_api_common.c:1024:7:
deps/rcheevos/src/rapi/rc_api_common.c:864:5: warning: 'memcpy' forming offset [5, 8] is out of the bounds [0, 5] [-Warray-bounds]
  864 |     memcpy(builder->write, data, len);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

I could not reproduce, so this is a speculative fix.

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@twinaphex 