### PR TITLE
Fix beetle cores on UWP and clean up the method in which drives are listed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,3 +224,4 @@ param.sfo
 *.self
 *.vpk
 /.vs
+/deps/SPIRV-Cross/out/build/x64-Debug

--- a/frontend/drivers/platform_uwp.c
+++ b/frontend/drivers/platform_uwp.c
@@ -276,19 +276,19 @@ static int frontend_uwp_parse_drive_list(void *data, bool load_content)
    enum msg_hash_enums enum_idx = load_content ?
          MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR :
          MENU_ENUM_LABEL_FILE_BROWSER_DIRECTORY;
-   char drive[]                 = " :\\";
    bool have_any_drives         = false;
-
    home_dir[0]                  = '\0';
 
    fill_pathname_home_dir(home_dir, sizeof(home_dir));
 
-   for (drive[0] = 'A'; drive[0] <= 'Z'; drive[0]++)
+   DWORD drives = GetLogicalDrives();
+   for (int i = 0; i < 26; i++)
    {
-      if (uwp_drive_exists(drive))
+      if (drives & (1 << i))
       {
+         TCHAR driveName[] = { TEXT('A') + i, TEXT(':'), TEXT('\\'), TEXT('\0') };
          menu_entries_append_enum(list,
-            drive,
+            driveName,
             msg_hash_to_str(MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR),
             enum_idx,
             FILE_TYPE_DIRECTORY, 0, 0);

--- a/libretro-common/vfs/vfs_implementation_uwp.cpp
+++ b/libretro-common/vfs/vfs_implementation_uwp.cpp
@@ -380,7 +380,7 @@ libretro_vfs_implementation_file *retro_vfs_file_open_impl(
    if (mode == RETRO_VFS_FILE_ACCESS_READ)
    {
       desireAccess        = GENERIC_READ;
-      creationDisposition = OPEN_ALWAYS;
+      creationDisposition = OPEN_EXISTING;
    }
    else
    {


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

Fix bugs with beetle cores not loading files, also clean up the way in which drives are listed. This has been tested by myself and @GABO1423

what follows is my best attempt of a description of what is the problem with with the beetle cores.

Beetlepsx tries to check if table of contents exists next to bin cue files, uses vfs.
VFS first tries to load the file using win32 fileio functions, fails using standard win32 fileio functions as they cannot read outside of appdata and defaults to UWP specific fileio functions. This fails if the file does not exist.

However when reading files with the win32 function the creation disposition is set to open the for read file always, creating it if it doesn't exist, this means that an empty file would be passed to beetlepsx. Whilst passing this empty file to beetle psx would normally cause it to crash the standard win32 file io  functions fail as they cannot access outside of appdata. So the UWP specific file io which fails as the file does not exist and beetlepsx is not given the empty file.

However using the UWP variants of the win32 file io functions allows drives outside of the app's local state folder to be accessed, the incorrect creationdisposition flag is passed to it and beetlepsx is given an empty file, this causes the crash.

tl;dr; creationdisposition is misset for RETRO_VFS_FILE_ACCESS_READ as OPEN_ALWAYS instead of OPEN_EXISTING, this is masked by the fact that standard win32 file io api set cannot read outside of appdata, this becomes an issue when using the UWP variants.

solution: change
```cpp
  if (mode == RETRO_VFS_FILE_ACCESS_READ)
   {
      desireAccess        = GENERIC_READ;
      creationDisposition = OPEN_ALWAYS;
   }
```  
to
```cpp
  if (mode == RETRO_VFS_FILE_ACCESS_READ)
   {
      desireAccess        = GENERIC_READ;
      creationDisposition = OPEN_EXISTING;
   }
``` 

## Related Issues

#12782

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
