### PR TITLE
fix loading arcade dat files

### DIFF
--- a/libretro-common/vfs/vfs_implementation_uwp.cpp
+++ b/libretro-common/vfs/vfs_implementation_uwp.cpp
@@ -851,6 +851,7 @@ int retro_vfs_stat_impl(const char *path, int32_t *size)
                {
                    sz.HighPart = attribdata.nFileSizeHigh;
                    sz.LowPart = attribdata.nFileSizeLow;
+                   *size = sz.QuadPart;
                }
            }
            return (file_info & FILE_ATTRIBUTE_DIRECTORY) ? RETRO_VFS_STAT_IS_VALID | RETRO_VFS_STAT_IS_DIRECTORY : RETRO_VFS_STAT_IS_VALID;
@@ -863,7 +864,7 @@ int retro_vfs_stat_impl(const char *path, int32_t *size)
    /* Fallback to WinRT */
    item = LocateStorageFileOrFolder(path_str);
    if (!item)
-      return 0;
+       return 0;
 
    return RunAsyncAndCatchErrors<int>([&]() {
          return concurrency::create_task(item->GetBasicPropertiesAsync()).then([&](BasicProperties^ properties) {


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

fix issue where file sizes where not returned properly, this fixes loading arcade dat files.
By arcade dat files this does not mean roms but the file used to enable automatic naming of scanned arcade content.
![image](https://user-images.githubusercontent.com/26260613/129410922-3de9f0e8-1ac2-4dd8-ae66-111288cc0a14.png)

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
