### PR TITLE
(WiiU) Add option for running without core info (emscripten-style)

### DIFF
--- a/Makefile.wiiu
+++ b/Makefile.wiiu
@@ -11,6 +11,7 @@ HAVE_RUNAHEAD              = 1
 WIIU_LOG_RPX               = 0
 BUILD_DIR                  = objs/wiiu
 PC_DEVELOPMENT_TCP_PORT    ?=
+LOAD_WITHOUT_CORE_INFO     ?= 0
 
 ifeq ($(SALAMANDER_BUILD),1)
    BUILD_DIR := $(BUILD_DIR)-salamander
@@ -84,6 +85,9 @@ else
 
 ifeq ($(HAVE_RUNAHEAD),1)
    DEFINES += -DHAVE_RUNAHEAD
+endif
+ifeq ($(LOAD_WITHOUT_CORE_INFO),1)
+   DEFINES += -DLOAD_WITHOUT_CORE_INFO
 endif
 
    OBJ += wiiu/shader_utils.o

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -1235,8 +1235,10 @@ static unsigned menu_displaylist_parse_supported_cores(menu_displaylist_info_t *
        * the core file extension - if there is none, then
        * it is impossible for RetroArch to populate a
        * core_info list */
+#if !defined(LOAD_WITHOUT_CORE_INFO)
       if (!frontend_driver_get_core_extension(exts, sizeof(exts)) ||
           string_is_empty(exts))
+#endif
       {
          struct retro_system_info *system = runloop_get_libretro_system_info();
          const char *core_path            = core_path_current;


### PR DESCRIPTION
## Description

Dev-specific hack to bypass the checks related to core info files. This is very helpful when network-loading a test core or running RetroArch in emulation, since the RA binary and the content is all you need (rather than having to update retroarch/cores on SD). Not super important - it's disabled for all except some narrow dev builds - but it's convenient at least.

I did think about putting this in Makefile.common since it's not platform-specific, but everything in there started with HAVE_ and I couldn't settle on a decent way to make this fit that convention.

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

@jdgleaver (told me to do this on Discord)
