### PR TITLE
(WiiU) Slight filesystem optimisation

### DIFF
--- a/wiiu/fs/sd_fat_devoptab.c
+++ b/wiiu/fs/sd_fat_devoptab.c
@@ -292,8 +292,8 @@ static ssize_t sd_fat_write_r (struct _reent *r, void* fd, const char *ptr, size
         }
     } else {
         size_t len_aligned = FS_ALIGN(len);
-        if(len_aligned > 0x4000)
-            len_aligned = 0x4000;
+        if(len_aligned > 128*1024)
+            len_aligned = 128*1024;
 
         unsigned char *tmpBuf = (unsigned char *)memalign(FS_ALIGNMENT, len_aligned);
         if(!tmpBuf) {
@@ -362,8 +362,8 @@ static ssize_t sd_fat_read_r (struct _reent *r, void* fd, char *ptr, size_t len)
         }
     } else {
         size_t len_aligned = FS_ALIGN(len);
-        if(len_aligned > 0x4000)
-            len_aligned = 0x4000;
+        if(len_aligned > 128*1024)
+            len_aligned = 128*1024;
 
         unsigned char *tmpBuf = (unsigned char *)memalign(FS_ALIGNMENT, len_aligned);
         if(!tmpBuf) {


### PR DESCRIPTION
## Description

The filesystem slow path on Wii U for unaligned buffers needs to have a limit to how much it will malloc at a time - this PR raises the limit from 16k to 128k, allowing a single syscall to fill the entire vbuf. This is much better than the previous behaviour, where stdio would attempt to refill the vbuf and end up with 8 IPC calls on its hands.

This means that an open file handle on Wii U could, in the worst case, use up to 256KiB of memory, but RetroArch is pretty good about closing files and this arrangement doesn't cause any issues for other Wii U apps.

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
