### PR TITLE
(cheevos) support for more than 64 memory regions

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -197,22 +197,28 @@ static int rcheevos_init_memory(rcheevos_locals_t* locals)
 {
    rarch_system_info_t* system = runloop_get_system_info();
    rarch_memory_map_t* mmaps = &system->mmaps;
-   struct retro_memory_descriptor descriptors[64];
+   struct retro_memory_descriptor* descriptors;
    struct retro_memory_map mmap;
    unsigned i;
+   int result;
+
+   descriptors = (struct retro_memory_descriptor*)malloc(mmaps->num_descriptors * sizeof(*descriptors));
+   if (!descriptors)
+      return 0;
 
    mmap.descriptors = &descriptors[0];
-   mmap.num_descriptors = sizeof(descriptors) / sizeof(descriptors[0]);
-   if (mmaps->num_descriptors < mmap.num_descriptors)
-      mmap.num_descriptors = mmaps->num_descriptors;
+   mmap.num_descriptors = mmaps->num_descriptors;
 
    /* RetroArch wraps the retro_memory_descriptor's in rarch_memory_descriptor_t's, pull them back out */
    for (i = 0; i < mmap.num_descriptors; ++i)
       memcpy(&descriptors[i], &mmaps->descriptors[i].core, sizeof(descriptors[0]));
 
    rc_libretro_init_verbose_message_callback(rcheevos_handle_log_message);
-   return rc_libretro_memory_init(&locals->memory, &mmap,
+   result = rc_libretro_memory_init(&locals->memory, &mmap,
          rcheevos_get_core_memory_info, locals->patchdata.console_id);
+
+   free(descriptors);
+   return result;
 }
 
 uint8_t* rcheevos_patch_address(unsigned address)


### PR DESCRIPTION
## Description

Replaces a static array with a dynamically allocated one to support cores that expose more than 64 memory regions (i.e. mesen for nes, which exposes over 160!).

## Related Issues

https://retroachievements.org/viewtopic.php?t=2800&c=91622#91622

## Related Pull Requests

n/a

## Reviewers

@Sanaki 
