### PR TITLE
[GLSL SHADERS] let the shader know the game is vertical

### DIFF
--- a/gfx/drivers_shader/shader_glsl.c
+++ b/gfx/drivers_shader/shader_glsl.c
@@ -382,7 +382,7 @@ static bool gl_glsl_compile_program(
       if (!gl_glsl_compile_shader(
                glsl,
                program->vprg,
-               "#define VERTEX\n#define PARAMETER_UNIFORM\n", program_info->vertex))
+               (retroarch_get_rotation() % 2 ? "#define VERTEX\n#define PARAMETER_UNIFORM\n#define VERTICAL\n" : "#define VERTEX\n#define PARAMETER_UNIFORM\n"), program_info->vertex))
       {
          RARCH_ERR("Failed to compile vertex shader #%u\n", idx);
          goto error;
@@ -396,7 +396,7 @@ static bool gl_glsl_compile_program(
       RARCH_LOG("[GLSL]: Found GLSL fragment shader.\n");
       program->fprg = glCreateShader(GL_FRAGMENT_SHADER);
       if (!gl_glsl_compile_shader(glsl, program->fprg,
-               "#define FRAGMENT\n#define PARAMETER_UNIFORM\n", program_info->fragment))
+               (retroarch_get_rotation() % 2 ? "#define FRAGMENT\n#define PARAMETER_UNIFORM\n#define VERTICAL\n" : "#define VERTEX\n#define PARAMETER_UNIFORM\n"), program_info->fragment))
       {
          RARCH_ERR("Failed to compile fragment shader #%u\n", idx);
          goto error;


### PR DESCRIPTION
Test case is 1942 on FBNeo + gl/glcore/vulkan video driver + the zfast-crt shader

It seems those shaders using `gl_FragCoord.y` or `gl_FragCoord.x` are partially broken with 90/180° rotated games, because those variables need to be somehow swapped, this commit adds a define to let the shader know it's a vertical game, so that it can change codepath accordingly. A patched zfast-crt shader is available from https://pastebin.com/F7Wh3DKW

This is more of a POC than an actual merge request, because i think this method is a bit ugly and i certainly hope there is a better way to handle this.