### PR TITLE
Allow mobile touch screen devices to use emscripten.

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -75,7 +75,7 @@
 
 #define DEFAULT_TOUCH_SCALE 1
 
-#if defined(RARCH_MOBILE) || defined(HAVE_LIBNX) || defined(__WINRT__)
+#if defined(RARCH_MOBILE) || defined(HAVE_LIBNX) || defined(__WINRT__) || defined(EMSCRIPTEN)
 #define DEFAULT_POINTER_ENABLE true
 #else
 #define DEFAULT_POINTER_ENABLE false


### PR DESCRIPTION
## Description

Sets up the default config to allow touch screen input when using emscripten

## Related Issues

Mobile touchscreen users are not able to use emscripten