### PR TITLE
standardize include paths for config.h

### DIFF
--- a/audio/drivers/audioio.c
+++ b/audio/drivers/audioio.c
@@ -24,7 +24,7 @@
 #include <sys/audioio.h>
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+#include "../../config.h"
 #endif
 
 #include "../../retroarch.h"

--- a/audio/drivers/oss.c
+++ b/audio/drivers/oss.c
@@ -30,7 +30,7 @@
 #include <retro_endianness.h>
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+#include "../../config.h"
 #endif
 
 #include "../../retroarch.h"

--- a/cores/libretro-ffmpeg/ffmpeg_core.c
+++ b/cores/libretro-ffmpeg/ffmpeg_core.c
@@ -8,7 +8,7 @@
 
 #ifdef RARCH_INTERNAL
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+#include "../../config.h"
 #endif
 #endif
 

--- a/cores/libretro-ffmpeg/video_buffer.h
+++ b/cores/libretro-ffmpeg/video_buffer.h
@@ -8,7 +8,7 @@
 
 #ifdef RARCH_INTERNAL
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+#include "../../config.h"
 #endif
 #endif
 

--- a/gfx/common/dxgi_common.c
+++ b/gfx/common/dxgi_common.c
@@ -20,7 +20,7 @@
 #include <assert.h>
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+#include "../../config.h"
 #endif
 
 #include "dxgi_common.h"

--- a/gfx/drivers/gl.c
+++ b/gfx/drivers/gl.c
@@ -34,7 +34,7 @@
 #include <string.h>
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+#include "../../config.h"
 #endif
 
 #include <compat/strl.h>

--- a/gfx/drivers/gl_core.c
+++ b/gfx/drivers/gl_core.c
@@ -20,7 +20,7 @@
  */
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+#include "../../config.h"
 #endif
 
 #include "../common/gl_core_common.h"

--- a/gfx/drivers_context/ps3_ctx.c
+++ b/gfx/drivers_context/ps3_ctx.c
@@ -17,7 +17,7 @@
 #include <stdint.h>
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+#include "../../config.h"
 #endif
 
 #include <sys/spu_initialize.h>

--- a/gfx/drivers_context/psl1ght_ctx.c
+++ b/gfx/drivers_context/psl1ght_ctx.c
@@ -17,7 +17,7 @@
 #include <stdint.h>
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+#include "../../config.h"
 #endif
 
 #include <compat/strl.h>

--- a/gfx/drivers_display/gfx_display_d3d10.c
+++ b/gfx/drivers_display/gfx_display_d3d10.c
@@ -19,7 +19,7 @@
 #include <retro_miscellaneous.h>
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+#include "../../config.h"
 #endif
 
 #include "../gfx_display.h"

--- a/gfx/drivers_display/gfx_display_d3d11.c
+++ b/gfx/drivers_display/gfx_display_d3d11.c
@@ -18,7 +18,7 @@
 #include <retro_miscellaneous.h>
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+#include "../../config.h"
 #endif
 
 #include "../gfx_display.h"

--- a/gfx/drivers_display/gfx_display_d3d12.c
+++ b/gfx/drivers_display/gfx_display_d3d12.c
@@ -18,7 +18,7 @@
 #include <retro_miscellaneous.h>
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+#include "../../config.h"
 #endif
 
 #include "../gfx_display.h"

--- a/gfx/drivers_display/gfx_display_wiiu.c
+++ b/gfx/drivers_display/gfx_display_wiiu.c
@@ -17,7 +17,7 @@
 #include <retro_miscellaneous.h>
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+#include "../../config.h"
 #endif
 
 #include "../gfx_display.h"

--- a/gfx/drivers_shader/glslang_util.c
+++ b/gfx/drivers_shader/glslang_util.c
@@ -22,7 +22,7 @@
 #include <string/stdstring.h>
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+#include "../../config.h"
 #endif
 
 #include "glslang_util.h"

--- a/gfx/drivers_shader/glslang_util_cxx.cpp
+++ b/gfx/drivers_shader/glslang_util_cxx.cpp
@@ -25,7 +25,7 @@
 #include <string/stdstring.h>
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+#include "../../config.h"
 #endif
 
 #include "glslang_util.h"

--- a/input/input_driver.h
+++ b/input/input_driver.h
@@ -25,7 +25,7 @@
 #include "input_types.h"
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+#include "../config.h"
 #endif /* HAVE_CONFIG_H */
 
 #include <boolean.h>


### PR DESCRIPTION
This PR standardizes the include paths for `config.h`, which helps keep the build process consistent across the Makefile and griffin.

Only this sprinkling of files throughout the repository included plain `"config.h"` from subfolders. The vast majority of the RA source already specified the relative path to config.h, this was a matter of updating the handful of outliers to match.