### PR TITLE
input_driver refactor

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -302,6 +302,7 @@ OBJ += \
        $(LIBRETRO_COMM_DIR)/file/file_path_io.o \
        file_path_special.o \
        $(LIBRETRO_COMM_DIR)/hash/lrc_hash.o \
+       input/input_driver.o \
        input/common/input_hid_common.o \
        led/led_driver.o \
        gfx/video_coord_array.o \

--- a/cheat_manager.c
+++ b/cheat_manager.c
@@ -1341,8 +1341,8 @@ void cheat_manager_apply_rumble(struct item_cheat *cheat, unsigned int curr_valu
       {
          cheat->rumble_primary_end_time   = current_time + (cheat->rumble_primary_duration * 1000);
          cheat->rumble_secondary_end_time = current_time + (cheat->rumble_secondary_duration * 1000);
-         input_driver_set_rumble_state(cheat->rumble_port, RETRO_RUMBLE_STRONG, cheat->rumble_primary_strength);
-         input_driver_set_rumble_state(cheat->rumble_port, RETRO_RUMBLE_WEAK, cheat->rumble_secondary_strength);
+         input_set_rumble_state(cheat->rumble_port, RETRO_RUMBLE_STRONG, cheat->rumble_primary_strength);
+         input_set_rumble_state(cheat->rumble_port, RETRO_RUMBLE_WEAK, cheat->rumble_secondary_strength);
       }
    }
    else
@@ -1354,24 +1354,24 @@ void cheat_manager_apply_rumble(struct item_cheat *cheat, unsigned int curr_valu
    if (cheat->rumble_primary_end_time <= current_time)
    {
       if (cheat->rumble_primary_end_time != 0)
-         input_driver_set_rumble_state(cheat->rumble_port,
+         input_set_rumble_state(cheat->rumble_port,
                RETRO_RUMBLE_STRONG, 0);
       cheat->rumble_primary_end_time = 0;
    }
    else
    {
-      input_driver_set_rumble_state(cheat->rumble_port,
+      input_set_rumble_state(cheat->rumble_port,
             RETRO_RUMBLE_STRONG, cheat->rumble_primary_strength);
    }
 
    if (cheat->rumble_secondary_end_time <= current_time)
    {
       if (cheat->rumble_secondary_end_time != 0)
-         input_driver_set_rumble_state(cheat->rumble_port, RETRO_RUMBLE_WEAK, 0);
+         input_set_rumble_state(cheat->rumble_port, RETRO_RUMBLE_WEAK, 0);
       cheat->rumble_secondary_end_time = 0;
    }
    else
-      input_driver_set_rumble_state(cheat->rumble_port, RETRO_RUMBLE_WEAK, cheat->rumble_secondary_strength);
+      input_set_rumble_state(cheat->rumble_port, RETRO_RUMBLE_WEAK, cheat->rumble_secondary_strength);
 }
 
 void cheat_manager_apply_retro_cheats(void)

--- a/configuration.c
+++ b/configuration.c
@@ -1946,7 +1946,7 @@ static struct config_float_setting *populate_settings_float(
    SETTING_FLOAT("video_font_size",          &settings->floats.video_font_size,      true, DEFAULT_FONT_SIZE, false);
    SETTING_FLOAT("fastforward_ratio",        &settings->floats.fastforward_ratio,    true, DEFAULT_FASTFORWARD_RATIO, false);
    SETTING_FLOAT("slowmotion_ratio",         &settings->floats.slowmotion_ratio,     true, DEFAULT_SLOWMOTION_RATIO, false);
-   SETTING_FLOAT("input_axis_threshold",     input_driver_get_float(INPUT_ACTION_AXIS_THRESHOLD), true, DEFAULT_AXIS_THRESHOLD, false);
+   SETTING_FLOAT("input_axis_threshold",     &settings->floats.input_axis_threshold, true, DEFAULT_AXIS_THRESHOLD, false);
    SETTING_FLOAT("input_analog_deadzone",    &settings->floats.input_analog_deadzone, true, DEFAULT_ANALOG_DEADZONE, false);
    SETTING_FLOAT("input_analog_sensitivity",    &settings->floats.input_analog_sensitivity, true, DEFAULT_ANALOG_SENSITIVITY, false);
    SETTING_FLOAT("video_msg_bgcolor_opacity", &settings->floats.video_msg_bgcolor_opacity, true, message_bgcolor_opacity, false);
@@ -1977,7 +1977,7 @@ static struct config_uint_setting *populate_settings_uint(
    SETTING_UINT("input_duty_cycle",             &settings->uints.input_turbo_duty_cycle, true, turbo_duty_cycle, false);
    SETTING_UINT("input_turbo_mode",             &settings->uints.input_turbo_mode, true, turbo_mode, false);
    SETTING_UINT("input_turbo_default_button",   &settings->uints.input_turbo_default_button, true, turbo_default_btn, false);
-   SETTING_UINT("input_max_users",              input_driver_get_uint(INPUT_ACTION_MAX_USERS),        true, input_max_users, false);
+   SETTING_UINT("input_max_users",              &settings->uints.input_max_users,          true, input_max_users, false);
    SETTING_UINT("fps_update_interval",          &settings->uints.fps_update_interval, true, DEFAULT_FPS_UPDATE_INTERVAL, false);
    SETTING_UINT("memory_update_interval",       &settings->uints.memory_update_interval, true, DEFAULT_MEMORY_UPDATE_INTERVAL, false);
    SETTING_UINT("input_menu_toggle_gamepad_combo", &settings->uints.input_menu_toggle_gamepad_combo, true, DEFAULT_MENU_TOGGLE_GAMEPAD_COMBO, false);
@@ -4787,8 +4787,8 @@ bool input_remapping_save_file(const char *path)
       "a", "x", "l", "r", "l2", "r2",
       "l3", "r3", "l_x+", "l_x-", "l_y+", "l_y-", "r_x+", "r_x-", "r_y+", "r_y-" };
    config_file_t               *conf = NULL;
-   unsigned max_users                = *(input_driver_get_uint(INPUT_ACTION_MAX_USERS));
    settings_t              *settings = config_get_ptr();
+   unsigned max_users                = settings->uints.input_max_users;
    const char *dir_input_remapping   = settings->paths.directory_input_remapping;
 
    remap_file[0]                     = '\0';

--- a/configuration.h
+++ b/configuration.h
@@ -165,6 +165,7 @@ typedef struct settings
       unsigned input_poll_type_behavior;
       unsigned input_dingux_rumble_gain;
       unsigned input_auto_game_focus;
+      unsigned input_max_users;
 
       unsigned netplay_port;
       unsigned netplay_input_latency_frames_min;
@@ -352,6 +353,7 @@ typedef struct settings
       float slowmotion_ratio;
       float fastforward_ratio;
       float input_analog_deadzone;
+      float input_axis_threshold;
       float input_analog_sensitivity;
    } floats;
 

--- a/griffin/griffin.c
+++ b/griffin/griffin.c
@@ -664,14 +664,19 @@ FONTS
 /*============================================================
 INPUT
 ============================================================ */
+
+#include "../input/input_driver.c"
+#include "../input/input_keymaps.c"
 #include "../tasks/task_autodetect.c"
+#include "../input/input_autodetect_builtin.c"
+
 #ifdef HAVE_BLISSBOX
 #include "../tasks/task_autodetect_blissbox.c"
 #endif
+
 #ifdef HAVE_AUDIOMIXER
 #include "../tasks/task_audio_mixer.c"
 #endif
-#include "../input/input_keymaps.c"
 
 #ifdef HAVE_OVERLAY
 #include "../led/drivers/led_overlay.c"
@@ -688,8 +693,6 @@ INPUT
 #include "../input/drivers/winraw_input.c"
 #endif
 #endif
-
-#include "../input/input_autodetect_builtin.c"
 
 #if defined(SN_TARGET_PSP2) || defined(PSP) || defined(VITA)
 #include "../input/drivers/psp_input.c"

--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -385,12 +385,12 @@ static void android_input_poll_main_cmd(void)
             video_driver_unset_stub_frame();
 
             if (enable_accelerometer)
-               input_sensor_set_state(0,
+               input_set_sensor_state(0,
                      RETRO_SENSOR_ACCELEROMETER_ENABLE,
                      android_app->accelerometer_event_rate);
 
             if (enable_gyroscope)
-               input_sensor_set_state(0,
+               input_set_sensor_state(0,
                      RETRO_SENSOR_GYROSCOPE_ENABLE,
                      android_app->gyroscope_event_rate);
          }
@@ -415,12 +415,12 @@ static void android_input_poll_main_cmd(void)
 
             /* Avoid draining battery while app is not being used. */
             if (disable_accelerometer)
-               input_sensor_set_state(0,
+               input_set_sensor_state(0,
                      RETRO_SENSOR_ACCELEROMETER_DISABLE,
                      android_app->accelerometer_event_rate);
 
             if (disable_gyroscope)
-               input_sensor_set_state(0,
+               input_set_sensor_state(0,
                      RETRO_SENSOR_GYROSCOPE_DISABLE,
                      android_app->gyroscope_event_rate);
          }

--- a/input/input_defines.h
+++ b/input/input_defines.h
@@ -174,13 +174,6 @@ enum input_turbo_default_button
    INPUT_TURBO_DEFAULT_BUTTON_LAST
 };
 
-enum input_action
-{
-   INPUT_ACTION_NONE = 0,
-   INPUT_ACTION_AXIS_THRESHOLD,
-   INPUT_ACTION_MAX_USERS
-};
-
 /* Specialized _MOUSE that targets the full screen regardless of viewport.
  */
 #define RARCH_DEVICE_MOUSE_SCREEN      (RETRO_DEVICE_MOUSE | 0x10000)

--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -1,0 +1,444 @@
+/**
+ *  RetroArch - A frontend for libretro.
+ *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
+ *  Copyright (C) 2011-2017 - Daniel De Matteis
+ *
+ *  RetroArch is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or (at your option)
+ *  any later version.
+ *
+ *  RetroArch is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ *  more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with RetroArch. If not, see <http://www.gnu.org/licenses/>.
+ **/
+
+#include <string/stdstring.h>
+
+#include "input_driver.h"
+
+#include "../retroarch.h"
+#include "../verbosity.h"
+#include "../configuration.h"
+#include "../list_special.h"
+
+/**************************************/
+
+static void *input_null_init(const char *joypad_driver) { return (void*)-1; }
+static void input_null_poll(void *data) { }
+static int16_t input_null_input_state(
+      void *data,
+      const input_device_driver_t *joypad,
+      const input_device_driver_t *sec_joypad,
+      rarch_joypad_info_t *joypad_info,
+      const struct retro_keybind **retro_keybinds,
+      bool keyboard_mapping_blocked,
+      unsigned port, unsigned device, unsigned index, unsigned id) { return 0; }
+static void input_null_free(void *data) { }
+static bool input_null_set_sensor_state(void *data, unsigned port,
+         enum retro_sensor_action action, unsigned rate) { return false; }
+static float input_null_get_sensor_input(void *data, unsigned port, unsigned id) { return 0.0; }
+static uint64_t input_null_get_capabilities(void *data) { return 0; }
+static void input_null_grab_mouse(void *data, bool state) { }
+static bool input_null_grab_stdin(void *data) { return false; }
+
+static input_driver_t input_null = {
+   input_null_init,
+   input_null_poll,
+   input_null_input_state,
+   input_null_free,
+   input_null_set_sensor_state,
+   input_null_get_sensor_input,
+   input_null_get_capabilities,
+   "null",
+   input_null_grab_mouse,
+   input_null_grab_stdin
+};
+
+static input_device_driver_t null_joypad = {
+   NULL, /* init */
+   NULL, /* query_pad */
+   NULL, /* destroy */
+   NULL, /* button */
+   NULL, /* state */
+   NULL, /* get_buttons */
+   NULL, /* axis */
+   NULL, /* poll */
+   NULL,
+   NULL, /* name */
+   "null",
+};
+
+
+#ifdef HAVE_HID
+static bool null_hid_joypad_query(void *data, unsigned pad) {
+   return pad < MAX_USERS; }
+static const char *null_hid_joypad_name(
+      void *data, unsigned pad) { return NULL; }
+static void null_hid_joypad_get_buttons(void *data,
+      unsigned port, input_bits_t *state) { BIT256_CLEAR_ALL_PTR(state); }
+static int16_t null_hid_joypad_button(
+      void *data, unsigned port, uint16_t joykey) { return 0; }
+static bool null_hid_joypad_rumble(void *data, unsigned pad,
+      enum retro_rumble_effect effect, uint16_t strength) { return false; }
+static int16_t null_hid_joypad_axis(
+      void *data, unsigned port, uint32_t joyaxis) { return 0; }
+static void *null_hid_init(void) { return (void*)-1; }
+static void null_hid_free(const void *data) { }
+static void null_hid_poll(void *data) { }
+static int16_t null_hid_joypad_state(
+      void *data,
+      rarch_joypad_info_t *joypad_info,
+      const void *binds_data,
+      unsigned port) { return 0; }
+
+static hid_driver_t null_hid = {
+   null_hid_init,               /* init */
+   null_hid_joypad_query,       /* joypad_query */
+   null_hid_free,               /* free */
+   null_hid_joypad_button,      /* button */
+   null_hid_joypad_state,       /* state */
+   null_hid_joypad_get_buttons, /* get_buttons */
+   null_hid_joypad_axis,        /* axis */
+   null_hid_poll,               /* poll */
+   null_hid_joypad_rumble,      /* rumble */
+   null_hid_joypad_name,        /* joypad_name */
+   "null",
+};
+#endif
+
+input_device_driver_t *joypad_drivers[] = {
+#ifdef HAVE_XINPUT
+   &xinput_joypad,
+#endif
+#ifdef GEKKO
+   &gx_joypad,
+#endif
+#ifdef WIIU
+   &wiiu_joypad,
+#endif
+#ifdef _XBOX1
+   &xdk_joypad,
+#endif
+#if defined(ORBIS)
+   &ps4_joypad,
+#endif
+#if defined(__PSL1GHT__) || defined(__PS3__)
+   &ps3_joypad,
+#endif
+#if defined(PSP) || defined(VITA)
+   &psp_joypad,
+#endif
+#if defined(PS2)
+   &ps2_joypad,
+#endif
+#ifdef _3DS
+   &ctr_joypad,
+#endif
+#ifdef SWITCH
+   &switch_joypad,
+#endif
+#ifdef HAVE_DINPUT
+   &dinput_joypad,
+#endif
+#ifdef HAVE_UDEV
+   &udev_joypad,
+#endif
+#if defined(__linux) && !defined(ANDROID)
+   &linuxraw_joypad,
+#endif
+#ifdef HAVE_PARPORT
+   &parport_joypad,
+#endif
+#ifdef ANDROID
+   &android_joypad,
+#endif
+#if defined(HAVE_SDL) || defined(HAVE_SDL2)
+   &sdl_joypad,
+#endif
+#if defined(DINGUX) && defined(HAVE_SDL_DINGUX)
+   &sdl_dingux_joypad,
+#endif
+#ifdef __QNX__
+   &qnx_joypad,
+#endif
+#ifdef HAVE_MFI
+   &mfi_joypad,
+#endif
+#ifdef DJGPP
+   &dos_joypad,
+#endif
+/* Selecting the HID gamepad driver disables the Wii U gamepad. So while
+ * we want the HID code to be compiled & linked, we don't want the driver
+ * to be selectable in the UI. */
+#if defined(HAVE_HID) && !defined(WIIU)
+   &hid_joypad,
+#endif
+#ifdef EMSCRIPTEN
+   &rwebpad_joypad,
+#endif
+   &null_joypad,
+   NULL,
+};
+
+input_driver_t *input_drivers[] = {
+#ifdef ORBIS
+   &input_ps4,
+#endif
+#if defined(__PSL1GHT__) || defined(__PS3__)
+   &input_ps3,
+#endif
+#if defined(SN_TARGET_PSP2) || defined(PSP) || defined(VITA)
+   &input_psp,
+#endif
+#if defined(PS2)
+   &input_ps2,
+#endif
+#if defined(_3DS)
+   &input_ctr,
+#endif
+#if defined(SWITCH)
+   &input_switch,
+#endif
+#if defined(HAVE_SDL) || defined(HAVE_SDL2)
+   &input_sdl,
+#endif
+#if defined(DINGUX) && defined(HAVE_SDL_DINGUX)
+   &input_sdl_dingux,
+#endif
+#ifdef HAVE_DINPUT
+   &input_dinput,
+#endif
+#ifdef HAVE_X11
+   &input_x,
+#endif
+#ifdef __WINRT__
+   &input_uwp,
+#endif
+#ifdef XENON
+   &input_xenon360,
+#endif
+#if defined(HAVE_XINPUT2) || defined(HAVE_XINPUT_XBOX1) || defined(__WINRT__)
+   &input_xinput,
+#endif
+#ifdef GEKKO
+   &input_gx,
+#endif
+#ifdef WIIU
+   &input_wiiu,
+#endif
+#ifdef ANDROID
+   &input_android,
+#endif
+#ifdef HAVE_UDEV
+   &input_udev,
+#endif
+#if defined(__linux__) && !defined(ANDROID)
+   &input_linuxraw,
+#endif
+#if defined(HAVE_COCOA) || defined(HAVE_COCOATOUCH) || defined(HAVE_COCOA_METAL)
+   &input_cocoa,
+#endif
+#ifdef __QNX__
+   &input_qnx,
+#endif
+#ifdef EMSCRIPTEN
+   &input_rwebinput,
+#endif
+#ifdef DJGPP
+   &input_dos,
+#endif
+#if defined(_WIN32) && !defined(_XBOX) && _WIN32_WINNT >= 0x0501 && !defined(__WINRT__)
+#ifdef HAVE_WINRAWINPUT
+   /* winraw only available since XP */
+   &input_winraw,
+#endif
+#endif
+   &input_null,
+   NULL,
+};
+
+#ifdef HAVE_HID
+hid_driver_t *hid_drivers[] = {
+#if defined(HAVE_BTSTACK)
+   &btstack_hid,
+#endif
+#if defined(__APPLE__) && defined(HAVE_IOHIDMANAGER)
+   &iohidmanager_hid,
+#endif
+#if defined(HAVE_LIBUSB) && defined(HAVE_THREADS)
+   &libusb_hid,
+#endif
+#ifdef HW_RVL
+   &wiiusb_hid,
+#endif
+   &null_hid,
+   NULL,
+};
+#endif
+
+/**************************************/
+
+/* private function prototypes */
+
+static const input_device_driver_t *input_joypad_init_first(void *data);
+
+
+/**************************************/
+
+bool input_driver_set_rumble(
+         input_driver_state_t *driver_state, unsigned port, unsigned joy_idx, 
+         enum retro_rumble_effect effect, uint16_t strength)
+{
+   const input_device_driver_t  *primary_joypad;
+   const input_device_driver_t      *sec_joypad;
+   bool rumble_state   = false;
+
+   if (!driver_state || (joy_idx >= MAX_USERS))
+      return false;
+
+   primary_joypad = driver_state->primary_joypad;
+   sec_joypad     = driver_state->secondary_joypad;
+
+   if (primary_joypad && primary_joypad->set_rumble)
+      rumble_state = primary_joypad->set_rumble(joy_idx, effect, strength);
+   
+   /* if sec_joypad exists, this set_rumble() return value will replace primary_joypad's return */
+   if (sec_joypad     && sec_joypad->set_rumble)
+      rumble_state = sec_joypad->set_rumble(joy_idx, effect, strength);
+
+   return rumble_state;
+}
+
+/**************************************/
+
+bool input_driver_set_sensor(
+         input_driver_state_t *driver_state, unsigned port, bool sensors_enable,
+         enum retro_sensor_action action, unsigned rate)
+{
+   const input_driver_t *current_driver;
+   void *current_data;
+
+   if (!driver_state || !driver_state->current_data)
+      return false;
+
+   current_driver = driver_state->current_driver;
+   current_data = driver_state->current_data;
+
+   /* If sensors are disabled, inhibit any enable
+    * actions (but always allow disable actions) */
+   if (!sensors_enable &&
+       ((action == RETRO_SENSOR_ACCELEROMETER_ENABLE) ||
+        (action == RETRO_SENSOR_GYROSCOPE_ENABLE) ||
+        (action == RETRO_SENSOR_ILLUMINANCE_ENABLE)))
+      return false;
+
+   if (current_driver && current_driver->set_sensor_state)
+      return current_driver->set_sensor_state(current_data,
+            port, action, rate);
+
+   return false;
+}
+
+/**************************************/
+
+float input_driver_get_sensor(
+         input_driver_state_t *driver_state,
+         unsigned port, bool sensors_enable, unsigned id)
+{
+   const input_driver_t *current_driver;
+   void *current_data;
+
+   if (!driver_state || !driver_state->current_data)
+      return 0.0f;
+
+   current_driver = driver_state->current_driver;
+   current_data = driver_state->current_data;
+
+   if (sensors_enable && current_driver->get_sensor_input)
+      return current_driver->get_sensor_input(current_data, port, id);
+
+   return 0.0f;
+}
+
+/**************************************/
+
+bool input_driver_get_nonblocking(input_driver_state_t *driver_state)
+{
+   if (!driver_state)
+      return false;
+
+   return driver_state->nonblocking_flag;
+}
+
+void input_driver_set_nonblocking(input_driver_state_t *driver_state,
+                                 bool new_value)
+{
+   if (!driver_state)
+      return;
+
+   driver_state->nonblocking_flag = new_value;
+}
+
+/**************************************/
+
+const input_device_driver_t *input_joypad_init_driver(
+      const char *ident, void *data)
+{
+   unsigned i;
+
+   if (ident && *ident)
+   {
+      for (i = 0; joypad_drivers[i]; i++)
+      {
+         if (string_is_equal(ident, joypad_drivers[i]->ident)
+               && joypad_drivers[i]->init)
+         {
+            void *ptr = joypad_drivers[i]->init(data);
+            if (ptr)
+            {
+               RARCH_LOG("[Joypad]: Found joypad driver: \"%s\".\n",
+                     joypad_drivers[i]->ident);
+               return joypad_drivers[i];
+            }
+         }
+      }
+   }
+
+   return input_joypad_init_first(data); /* fall back to first available driver */
+}
+
+/**
+ * Finds first suitable joypad driver and initializes. Used as a fallback by
+ * input_joypad_init_driver when no matching driver is found.
+ *
+ * @param data  joypad state data pointer, which can be NULL and will be
+ *              initialized by the new joypad driver, if one is found.
+ *
+ * @return joypad driver if found and initialized, otherwise NULL.
+ **/
+static const input_device_driver_t *input_joypad_init_first(void *data)
+{
+   unsigned i;
+
+   for (i = 0; joypad_drivers[i]; i++)
+   {
+      if (     joypad_drivers[i]
+            && joypad_drivers[i]->init)
+      {
+         void *ptr = joypad_drivers[i]->init(data);
+         if (ptr)
+         {
+            RARCH_LOG("[Joypad]: Found joypad driver: \"%s\".\n",
+                  joypad_drivers[i]->ident);
+            return joypad_drivers[i];
+         }
+      }
+   }
+
+   return NULL;
+}

--- a/input/input_driver.h
+++ b/input/input_driver.h
@@ -22,8 +22,6 @@
 #include <stddef.h>
 #include <sys/types.h>
 
-#include "input_types.h"
-
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
@@ -35,11 +33,13 @@
 #include <retro_miscellaneous.h>
 
 #include "input_defines.h"
+#include "input_types.h"
 
 #include "../msg_hash.h"
 #include "include/hid_types.h"
 #include "include/hid_driver.h"
 #include "include/gamepad.h"
+#include "../configuration.h"
 
 RETRO_BEGIN_DECLS
 
@@ -279,6 +279,21 @@ struct rarch_joypad_driver
    const char *ident;
 };
 
+typedef struct
+{
+   /* pointers */
+   input_driver_t                *current_driver;
+   void                          *current_data;
+   const input_device_driver_t   *primary_joypad;        /* ptr alignment */
+   const input_device_driver_t   *secondary_joypad;      /* ptr alignment */
+
+   /* primitives */
+   bool        nonblocking_flag;
+} input_driver_state_t;
+
+
+void input_driver_init_joypads(void);
+
 /**
  * Get an enumerated list of all input driver names
  *
@@ -287,73 +302,54 @@ struct rarch_joypad_driver
 const char* config_get_input_driver_options(void);
 
 /**
- * Sets the rumble state. Used by RETRO_ENVIRONMENT_GET_RUMBLE_INTERFACE.
+ * Sets the rumble state.
  * 
- * @param port      User number.
- * @param effect    Rumble effect.
- * @param strength  Strength of rumble effect.
+ * @param driver_state
+ * @param port          User number.
+ * @param joy_idx
+ * @param effect        Rumble effect.
+ * @param strength      Strength of rumble effect.
  *
  * @return true if the rumble state has been successfully set
  **/
-bool input_driver_set_rumble_state(unsigned port,
-      enum retro_rumble_effect effect, uint16_t strength);
+bool input_driver_set_rumble(
+         input_driver_state_t *driver_state, unsigned port, unsigned joy_idx, 
+         enum retro_rumble_effect effect, uint16_t strength);
 
 /**
- * Sets the sensor state. Used by RETRO_ENVIRONMENT_GET_SENSOR_INTERFACE.
+ * Sets the sensor state.
  * 
+ * @param driver_state
  * @param port
- * @param effect  Sensor action
- * @param rate    Sensor rate update
+ * @param sensors_enable
+ * @param effect        Sensor action
+ * @param rate          Sensor rate update
  *
  * @return true if the sensor state has been successfully set
  **/
-bool input_sensor_set_state(unsigned port,
-      enum retro_sensor_action action, unsigned rate);
+bool input_driver_set_sensor(
+         input_driver_state_t *driver_state, unsigned port, bool sensors_enable,
+         enum retro_sensor_action action, unsigned rate);
 
 /**
  * Retrieves the sensor state associated with the provided port and ID. 
  * 
+ * @param driver_state
  * @param port
- * @param id    Sensor ID
+ * @param sensors_enable
+ * @param id            Sensor ID
  *
  * @return The current state associated with the port and ID as a float
  **/
-float input_sensor_get_input(unsigned port, unsigned id);
+float input_driver_get_sensor(
+         input_driver_state_t *driver_state,
+         unsigned port, bool sensors_enable, unsigned id);
 
-/**
- * Retrieves the input driver state struct
- * 
- * @return The input state struct
- **/
-void *input_driver_get_data(void);
 
-/**
- * Sets the input_driver_nonblock_state flag to true
- **/
-void input_driver_set_nonblock_state(void);
+bool input_driver_get_nonblocking(input_driver_state_t *driver_state);
 
-/**
- * Sets the input_driver_nonblock_state flag to false
- **/
-void input_driver_unset_nonblock_state(void);
-
-/**
- * If the action is INPUT_ACTION_AXIS_THRESHOLD, return the current
- * input_driver_axis_threshold.
- * 
- * @return value of input_driver_axis_threshold or NULL for actions other than
- *          INPUT_ACTION_AXIS_THRESHOLD
-**/
-float *input_driver_get_float(enum input_action action);
-
-/**
- * If the action is INPUT_ACTION_MAX_USERS, return the current
- * input_driver_max_users.
- * 
- * @return value of input_driver_axis_threshold or NULL for actions other than
- *          INPUT_ACTION_AXIS_THRESHOLD
-**/
-unsigned *input_driver_get_uint(enum input_action action);
+void input_driver_set_nonblocking(input_driver_state_t *driver_state,
+                                 bool new_value);
 
 /**
  * Get an enumerated list of all joypad driver names
@@ -367,6 +363,8 @@ const char* config_get_joypad_driver_options(void);
  * zero-length string, equivalent to calling input_joypad_init_first().
  *
  * @param ident  identifier of driver to initialize.
+ * @param data   joypad state data pointer, which can be NULL and will be
+ *               initialized by the new joypad driver, if one is found.
  *
  * @return The joypad driver if found, otherwise NULL.
  **/
@@ -728,28 +726,11 @@ void input_config_reset(void);
 #define DEFAULT_MAX_PADS 16
 #endif /* defined(ANDROID) */
 
-extern input_device_driver_t dinput_joypad;
-extern input_device_driver_t linuxraw_joypad;
-extern input_device_driver_t parport_joypad;
-extern input_device_driver_t udev_joypad;
-extern input_device_driver_t xinput_joypad;
-extern input_device_driver_t sdl_joypad;
-extern input_device_driver_t sdl_dingux_joypad;
-extern input_device_driver_t ps4_joypad;
-extern input_device_driver_t ps3_joypad;
-extern input_device_driver_t psp_joypad;
-extern input_device_driver_t ps2_joypad;
-extern input_device_driver_t ctr_joypad;
-extern input_device_driver_t switch_joypad;
-extern input_device_driver_t xdk_joypad;
-extern input_device_driver_t gx_joypad;
-extern input_device_driver_t wiiu_joypad;
-extern input_device_driver_t hid_joypad;
-extern input_device_driver_t android_joypad;
-extern input_device_driver_t qnx_joypad;
-extern input_device_driver_t mfi_joypad;
-extern input_device_driver_t dos_joypad;
-extern input_device_driver_t rwebpad_joypad;
+extern input_device_driver_t *joypad_drivers[];
+extern input_driver_t *input_drivers[];
+#ifdef HAVE_HID
+extern hid_driver_t *hid_drivers[];
+#endif
 
 extern input_driver_t input_android;
 extern input_driver_t input_sdl;
@@ -775,6 +756,29 @@ extern input_driver_t input_rwebinput;
 extern input_driver_t input_dos;
 extern input_driver_t input_winraw;
 extern input_driver_t input_wayland;
+
+extern input_device_driver_t dinput_joypad;
+extern input_device_driver_t linuxraw_joypad;
+extern input_device_driver_t parport_joypad;
+extern input_device_driver_t udev_joypad;
+extern input_device_driver_t xinput_joypad;
+extern input_device_driver_t sdl_joypad;
+extern input_device_driver_t sdl_dingux_joypad;
+extern input_device_driver_t ps4_joypad;
+extern input_device_driver_t ps3_joypad;
+extern input_device_driver_t psp_joypad;
+extern input_device_driver_t ps2_joypad;
+extern input_device_driver_t ctr_joypad;
+extern input_device_driver_t switch_joypad;
+extern input_device_driver_t xdk_joypad;
+extern input_device_driver_t gx_joypad;
+extern input_device_driver_t wiiu_joypad;
+extern input_device_driver_t hid_joypad;
+extern input_device_driver_t android_joypad;
+extern input_device_driver_t qnx_joypad;
+extern input_device_driver_t mfi_joypad;
+extern input_device_driver_t dos_joypad;
+extern input_device_driver_t rwebpad_joypad;
 
 #ifdef HAVE_HID
 extern hid_driver_t iohidmanager_hid;

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -6152,7 +6152,7 @@ unsigned menu_displaylist_build_list(
       case DISPLAYLIST_OPTIONS_REMAPPINGS:
          {
             unsigned p;
-            unsigned max_users          = *(input_driver_get_uint(INPUT_ACTION_MAX_USERS));
+            unsigned max_users          = settings->uints.input_max_users;
 
 #ifdef HAVE_CONFIGFILE
             if (menu_entries_append_enum(list,
@@ -6488,7 +6488,7 @@ unsigned menu_displaylist_build_list(
 
          {
             unsigned user;
-            unsigned max_users          = *(input_driver_get_uint(INPUT_ACTION_MAX_USERS));
+            unsigned max_users          = settings->uints.input_max_users;
             for (user = 0; user < max_users; user++)
             {
                if (MENU_DISPLAYLIST_PARSE_SETTINGS_ENUM(list,
@@ -7245,7 +7245,7 @@ unsigned menu_displaylist_build_list(
 
             {
                unsigned user;
-               unsigned max_users          = *(input_driver_get_uint(INPUT_ACTION_MAX_USERS));
+               unsigned max_users          = settings->uints.input_max_users;
                for (user = 0; user < max_users; user++)
                {
                   if (MENU_DISPLAYLIST_PARSE_SETTINGS_ENUM(list,
@@ -9740,7 +9740,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
          break;
       case DISPLAYLIST_OPTIONS_REMAPPINGS_PORT:
          {
-            unsigned max_users          = *(input_driver_get_uint(INPUT_ACTION_MAX_USERS));
+            unsigned max_users          = settings->uints.input_max_users;
             const char *menu_driver     = menu_driver_ident();
             bool is_rgui                = string_is_equal(menu_driver, "rgui");
             file_list_t *list           = info->list;

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -7986,11 +7986,11 @@ static void general_write_handler(rarch_setting_t *setting)
             {
                /* Event rate does not matter when disabling
                 * sensors - set to zero */
-               input_sensor_set_state(i,
+               input_set_sensor_state(i,
                      RETRO_SENSOR_ACCELEROMETER_DISABLE, 0);
-               input_sensor_set_state(i,
+               input_set_sensor_state(i,
                      RETRO_SENSOR_GYROSCOPE_DISABLE, 0);
-               input_sensor_set_state(i,
+               input_set_sensor_state(i,
                      RETRO_SENSOR_ILLUMINANCE_DISABLE, 0);
             }
          }
@@ -12579,7 +12579,7 @@ static bool setting_append_list(
 
             CONFIG_UINT(
                   list, list_info,
-                  input_driver_get_uint(INPUT_ACTION_MAX_USERS),
+                  &settings->uints.input_max_users,
                   MENU_ENUM_LABEL_INPUT_MAX_USERS,
                   MENU_ENUM_LABEL_VALUE_INPUT_MAX_USERS,
                   input_max_users,
@@ -13005,7 +13005,7 @@ static bool setting_append_list(
 
             CONFIG_FLOAT(
                   list, list_info,
-                  input_driver_get_float(INPUT_ACTION_AXIS_THRESHOLD),
+                  &settings->floats.input_axis_threshold,
                   MENU_ENUM_LABEL_INPUT_BUTTON_AXIS_THRESHOLD,
                   MENU_ENUM_LABEL_VALUE_INPUT_BUTTON_AXIS_THRESHOLD,
                   DEFAULT_AXIS_THRESHOLD,
@@ -18973,7 +18973,7 @@ static bool setting_append_list(
             /* TODO/FIXME - add enum_idx */
 
             {
-               unsigned max_users        = *(input_driver_get_uint(INPUT_ACTION_MAX_USERS));
+               unsigned max_users        = settings->uints.input_max_users;
                for (user = 0; user < max_users; user++)
                {
                   char s1[64], s2[64];

--- a/network/netplay/netplay_io.c
+++ b/network/netplay/netplay_io.c
@@ -1452,7 +1452,7 @@ void netplay_sync_post_frame(netplay_t *netplay, bool stalled)
       if (netplay->catch_up)
       {
          netplay->catch_up = false;
-         input_driver_unset_nonblock_state();
+         input_unset_nonblock_state();
          driver_set_nonblock_state();
       }
       return;
@@ -1645,7 +1645,7 @@ void netplay_sync_post_frame(netplay_t *netplay, bool stalled)
       if (netplay->self_frame_count + 1 >= lo_frame_count)
       {
          netplay->catch_up = false;
-         input_driver_unset_nonblock_state();
+         input_unset_nonblock_state();
          driver_set_nonblock_state();
       }
 
@@ -1674,7 +1674,7 @@ void netplay_sync_post_frame(netplay_t *netplay, bool stalled)
                /* We're definitely falling behind! */
                netplay->catch_up      = true;
                netplay->catch_up_time = 0;
-               input_driver_set_nonblock_state();
+               input_set_nonblock_state();
                driver_set_nonblock_state();
             }
             else

--- a/retroarch.c
+++ b/retroarch.c
@@ -1069,12 +1069,13 @@ static void menu_input_key_bind_poll_bind_state(
 {
    unsigned b;
    rarch_joypad_info_t joypad_info;
-   input_driver_t *current_input           = p_rarch->current_input;
-   void *input_data                        = p_rarch->current_input_data;
+   input_driver_state_t *input_driver_st   = &p_rarch->input_driver_state;
+   input_driver_t *current_input           = input_driver_st->current_driver;
+   void *input_data                        = input_driver_st->current_data;
    unsigned port                           = state->port;
-   const input_device_driver_t *joypad     = p_rarch->joypad;
+   const input_device_driver_t *joypad     = input_driver_st->primary_joypad;
 #ifdef HAVE_MFI
-   const input_device_driver_t *sec_joypad = p_rarch->sec_joypad;
+   const input_device_driver_t *sec_joypad = input_driver_st->secondary_joypad;
 #else
    const input_device_driver_t *sec_joypad = NULL;
 #endif
@@ -1357,8 +1358,9 @@ bool menu_input_key_bind_set_mode(
 {
    uint64_t current_usec;
    unsigned index_offset;
-   rarch_setting_t  *setting      = (rarch_setting_t*)data;
-   struct rarch_state *p_rarch    = &rarch_st;
+   rarch_setting_t  *setting             = (rarch_setting_t*)data;
+   struct rarch_state *p_rarch           = &rarch_st;
+   input_driver_state_t *input_driver_st = &p_rarch->input_driver_state;
    menu_handle_t       *menu      = p_rarch->menu_driver_data;
    menu_input_t *menu_input       = &p_rarch->menu_input_state;
    settings_t     *settings       = p_rarch->configuration_settings;
@@ -1378,9 +1380,9 @@ bool menu_input_key_bind_set_mode(
    binds->port              = settings->uints.input_joypad_index[index_offset];
 
    menu_input_key_bind_poll_bind_get_rested_axes(
-         p_rarch->joypad,
+         input_driver_st->primary_joypad,
 #ifdef HAVE_MFI
-         p_rarch->sec_joypad,
+         input_driver_st->secondary_joypad,
 #else
          NULL,
 #endif
@@ -1507,7 +1509,7 @@ static bool menu_input_key_bind_iterate(
       new_binds.buffer                     = *(new_binds.output);
 
       if (menu_input_key_bind_poll_find_hold(
-               p_rarch->input_driver_max_users,
+               settings->uints.input_max_users,
                &new_binds, &new_binds.buffer))
       {
          uint64_t current_usec = cpu_features_get_time_usec();
@@ -1541,7 +1543,7 @@ static bool menu_input_key_bind_iterate(
 #else
       if ((new_binds.skip && !_binds->skip) ||
             menu_input_key_bind_poll_find_trigger(
-               p_rarch->input_driver_max_users,
+               settings->uints.input_max_users,
                _binds, &new_binds, &(new_binds.buffer)))
          complete = true;
 #endif
@@ -13377,20 +13379,20 @@ void input_remapping_set_defaults(bool clear_cache)
 
 static bool input_driver_grab_mouse(struct rarch_state *p_rarch)
 {
-   if (!p_rarch->current_input || !p_rarch->current_input->grab_mouse)
+   if (!p_rarch->input_driver_state.current_driver || !p_rarch->input_driver_state.current_driver->grab_mouse)
       return false;
 
-   p_rarch->current_input->grab_mouse(p_rarch->current_input_data, true);
+   p_rarch->input_driver_state.current_driver->grab_mouse(p_rarch->input_driver_state.current_data, true);
    p_rarch->input_driver_grab_mouse_state = true;
    return true;
 }
 
 static bool input_driver_ungrab_mouse(struct rarch_state *p_rarch)
 {
-   if (!p_rarch->current_input || !p_rarch->current_input->grab_mouse)
+   if (!p_rarch->input_driver_state.current_driver || !p_rarch->input_driver_state.current_driver->grab_mouse)
       return false;
 
-   p_rarch->current_input->grab_mouse(p_rarch->current_input_data, false);
+   p_rarch->input_driver_state.current_driver->grab_mouse(p_rarch->input_driver_state.current_data, false);
    p_rarch->input_driver_grab_mouse_state = false;
    return true;
 }
@@ -13398,7 +13400,9 @@ static bool input_driver_ungrab_mouse(struct rarch_state *p_rarch)
 static void command_event_reinit(struct rarch_state *p_rarch,
       const int flags)
 {
-   settings_t *settings        = p_rarch->configuration_settings;
+   settings_t *settings                  = p_rarch->configuration_settings;
+   input_driver_state_t *input_driver_st = &p_rarch->input_driver_state;
+
 #ifdef HAVE_MENU
    bool video_fullscreen       = settings->bools.video_fullscreen;
    bool adaptive_vsync         = settings->bools.video_adaptive_vsync;
@@ -13408,17 +13412,17 @@ static void command_event_reinit(struct rarch_state *p_rarch,
 
    video_driver_reinit(flags);
    /* Poll input to avoid possibly stale data to corrupt things. */
-   if (  p_rarch->joypad &&
-         p_rarch->joypad->poll)
-      p_rarch->joypad->poll();
+   if (  input_driver_st->primary_joypad &&
+         input_driver_st->primary_joypad->poll)
+      input_driver_st->primary_joypad->poll();
 #ifdef HAVE_MFI
-   if (  p_rarch->sec_joypad &&
-         p_rarch->sec_joypad->poll)
-      p_rarch->sec_joypad->poll();
+   if (  input_driver_st->secondary_joypad &&
+         input_driver_st->secondary_joypad->poll)
+      input_driver_st->secondary_joypad->poll();
 #endif
-   if (  p_rarch->current_input &&
-         p_rarch->current_input->poll)
-      p_rarch->current_input->poll(p_rarch->current_input_data);
+   if (  p_rarch->input_driver_state.current_driver &&
+         p_rarch->input_driver_state.current_driver->poll)
+      p_rarch->input_driver_state.current_driver->poll(p_rarch->input_driver_state.current_data);
    command_event(CMD_EVENT_GAME_FOCUS_TOGGLE, &game_focus_cmd);
 
 #ifdef HAVE_MENU
@@ -15066,11 +15070,13 @@ bool command_event(enum event_command cmd, void *data)
          break;
       case CMD_EVENT_RUMBLE_STOP:
          {
+            input_driver_state_t *input_driver_st = &(p_rarch->input_driver_state);
             unsigned i;
             for (i = 0; i < MAX_USERS; i++)
             {
-               input_driver_set_rumble_state(i, RETRO_RUMBLE_STRONG, 0);
-               input_driver_set_rumble_state(i, RETRO_RUMBLE_WEAK, 0);
+               unsigned joy_idx = settings->uints.input_joypad_index[i];
+               input_driver_set_rumble(input_driver_st, i, joy_idx, RETRO_RUMBLE_STRONG, 0);
+               input_driver_set_rumble(input_driver_st, i, joy_idx, RETRO_RUMBLE_WEAK, 0);
             }
          }
          break;
@@ -15321,7 +15327,7 @@ bool command_event(enum event_command cmd, void *data)
             rarch_system_info_t *info = &runloop_state.system;
             if (info)
                command_event_init_controllers(info, settings,
-                     p_rarch->input_driver_max_users);
+                     settings->uints.input_max_users);
          }
          break;
       case CMD_EVENT_NONE:
@@ -15777,8 +15783,9 @@ void emscripten_mainloop(void)
    static unsigned emscripten_frame_count = 0;
    struct rarch_state *p_rarch            = &rarch_st;
    settings_t        *settings            = p_rarch->configuration_settings;
+   input_driver_state_t *input_driver_st  = &(p_rarch->input_driver_state);
    bool black_frame_insertion             = settings->uints.video_black_frame_insertion;
-   bool input_driver_nonblock_state       = p_rarch->input_driver_nonblock_state;
+   bool input_driver_nonblock_state       = input_driver_get_nonblocking(input_driver_st);
    bool runloop_is_slowmotion             = runloop_state.slowmotion;
    bool runloop_is_paused                 = runloop_state.paused;
 
@@ -16476,10 +16483,11 @@ static const char *hw_render_context_name(enum retro_hw_context_type type, int m
 static bool rarch_environment_cb(unsigned cmd, void *data)
 {
    unsigned p;
-   struct rarch_state *p_rarch  = &rarch_st;
-   settings_t         *settings = p_rarch->configuration_settings;
-   rarch_system_info_t *system  = &runloop_state.system;
-   bool ignore_environment_cb   = p_rarch->ignore_environment_cb;
+   struct rarch_state *p_rarch            = &rarch_st;
+   settings_t         *settings           = p_rarch->configuration_settings;
+   input_driver_state_t *input_driver_st  = &(p_rarch->input_driver_state);
+   rarch_system_info_t *system            = &runloop_state.system;
+   bool ignore_environment_cb             = p_rarch->ignore_environment_cb;
 
    if (ignore_environment_cb)
       return false;
@@ -17074,7 +17082,7 @@ static bool rarch_environment_cb(unsigned cmd, void *data)
                if (log_level == RETRO_LOG_DEBUG)
                {
                   unsigned input_driver_max_users =
-                     p_rarch->input_driver_max_users;
+                     settings->uints.input_max_users;
                   for (p = 0; p < input_driver_max_users; p++)
                   {
                      unsigned mapped_port = settings->uints.input_remap_ports[p];
@@ -17407,7 +17415,7 @@ static bool rarch_environment_cb(unsigned cmd, void *data)
             (struct retro_rumble_interface*)data;
 
          RARCH_LOG("[Environ]: GET_RUMBLE_INTERFACE.\n");
-         iface->set_rumble_state = input_driver_set_rumble_state;
+         iface->set_rumble_state = input_set_rumble_state;
          break;
       }
 
@@ -17416,7 +17424,7 @@ static bool rarch_environment_cb(unsigned cmd, void *data)
          uint64_t *mask = (uint64_t*)data;
 
          RARCH_LOG("[Environ]: GET_INPUT_DEVICE_CAPABILITIES.\n");
-         if (!p_rarch->current_input->get_capabilities || !p_rarch->current_input_data)
+         if (!p_rarch->input_driver_state.current_driver->get_capabilities || !p_rarch->input_driver_state.current_data)
             return false;
          *mask = input_driver_get_capabilities();
          break;
@@ -17433,8 +17441,8 @@ static bool rarch_environment_cb(unsigned cmd, void *data)
          if (!input_sensors_enable)
             return false;
 
-         iface->set_sensor_state = input_sensor_set_state;
-         iface->get_sensor_input = input_sensor_get_input;
+         iface->set_sensor_state = input_set_sensor_state;
+         iface->get_sensor_input = input_get_sensor_state;
          break;
       }
       case RETRO_ENVIRONMENT_GET_CAMERA_INTERFACE:
@@ -17986,7 +17994,7 @@ static bool rarch_environment_cb(unsigned cmd, void *data)
       }
 
       case RETRO_ENVIRONMENT_GET_INPUT_MAX_USERS:
-         *(unsigned *)data = p_rarch->input_driver_max_users;
+         *(unsigned *)data = settings->uints.input_max_users;
          break;
 
       /* Private environment callbacks.
@@ -18866,7 +18874,7 @@ static bool secondary_core_create(struct rarch_state *p_rarch,
    const enum rarch_core_type
       last_core_type           = p_rarch->last_core_type;
    rarch_system_info_t *info   = &runloop_state.system;
-   unsigned num_active_users   = p_rarch->input_driver_max_users;
+   unsigned num_active_users   = settings->uints.input_max_users;
 
    if (   last_core_type != CORE_TYPE_PLAIN          ||
          !p_rarch->load_content_info                 ||
@@ -21403,9 +21411,10 @@ static void input_poll_overlay(
    uint16_t key_mod                        = 0;
    bool polled                             = false;
    bool button_pressed                     = false;
-   void *input_data                        = p_rarch->current_input_data;
+   input_driver_state_t *input_driver_st   = &p_rarch->input_driver_state;
+   void *input_data                        = input_driver_st->current_data;
    input_overlay_state_t *ol_state         = &ol->overlay_state;
-   input_driver_t *current_input           = p_rarch->current_input;
+   input_driver_t *current_input           = input_driver_st->current_driver;
    enum overlay_show_input_type
          input_overlay_show_inputs         = (enum overlay_show_input_type)
                settings->uints.input_overlay_show_inputs;
@@ -21427,7 +21436,7 @@ static void input_poll_overlay(
          : RETRO_DEVICE_POINTER;
 #ifdef HAVE_MFI
       const input_device_driver_t
-         *sec_joypad                  = p_rarch->sec_joypad;
+         *sec_joypad                  = input_driver_st->secondary_joypad;
 #else
       const input_device_driver_t
          *sec_joypad                  = NULL;
@@ -21440,7 +21449,7 @@ static void input_poll_overlay(
       for (i = 0;
             current_input->input_state(
                input_data,
-               p_rarch->joypad,
+               input_driver_st->primary_joypad,
                sec_joypad,
                &joypad_info,
                NULL,
@@ -21454,7 +21463,7 @@ static void input_poll_overlay(
          input_overlay_state_t polled_data;
          int16_t x = current_input->input_state(
                input_data,
-               p_rarch->joypad,
+               input_driver_st->primary_joypad,
                sec_joypad,
                &joypad_info,
                NULL,
@@ -21465,7 +21474,7 @@ static void input_poll_overlay(
                RETRO_DEVICE_ID_POINTER_X);
          int16_t y = current_input->input_state(
                input_data,
-               p_rarch->joypad,
+               input_driver_st->primary_joypad,
                sec_joypad,
                &joypad_info,
                NULL,
@@ -21788,119 +21797,141 @@ const char* config_get_input_driver_options(void)
    return char_list_new_special(STRING_LIST_INPUT_DRIVERS, NULL);
 }
 
+/******************************************************************************
+ * BEGIN helper functions for input_driver refactoring
+ * 
+ * These functions have similar names and signatures to functions that now require
+ * an input_driver_state_t pointer to be passed to them. They essentially wrap
+ * the newer functions by grabbing pointer to the driver state struct and the
+ * settings struct.
+ ******************************************************************************/
+
 /**
- * input_driver_set_rumble_state:
- * @port               : User number.
- * @effect             : Rumble effect.
- * @strength           : Strength of rumble effect.
+ * Retrieves the sensor state associated with the provided port and ID. 
+ * 
+ * @param port
+ * @param id    Sensor ID
  *
- * Sets the rumble state.
- * Used by RETRO_ENVIRONMENT_GET_RUMBLE_INTERFACE.
+ * @return The current state associated with the port and ID as a float
  **/
-bool input_driver_set_rumble_state(unsigned port,
+float input_get_sensor_state(unsigned port, unsigned id)
+{
+   struct rarch_state *p_rarch            = &rarch_st;
+   input_driver_state_t *input_driver_st  = &p_rarch->input_driver_state;
+   settings_t *settings                   = p_rarch->configuration_settings;
+   bool input_sensors_enable              = settings->bools.input_sensors_enable;
+
+   return input_driver_get_sensor(input_driver_st, port, input_sensors_enable, id);
+}
+
+/**
+ * Sets the rumble state. Used by RETRO_ENVIRONMENT_GET_RUMBLE_INTERFACE.
+ * 
+ * @param port      User number.
+ * @param effect    Rumble effect.
+ * @param strength  Strength of rumble effect.
+ *
+ * @return true if the rumble state has been successfully set
+ **/
+bool input_set_rumble_state(unsigned port,
       enum retro_rumble_effect effect, uint16_t strength)
 {
-   struct rarch_state *p_rarch             = &rarch_st;
-   settings_t *settings                    = p_rarch->configuration_settings;
-#ifdef HAVE_MFI
-   const input_device_driver_t *sec_joypad = p_rarch->sec_joypad;
-#else
-   const input_device_driver_t *sec_joypad = NULL;
-#endif
-   bool rumble_state                       = false;
-   unsigned  joy_idx                       = settings->uints.input_joypad_index[port];
+   struct rarch_state *p_rarch            = &rarch_st;
+   input_driver_state_t *input_driver_st  = &(p_rarch->input_driver_state);
+   settings_t *settings                   = p_rarch->configuration_settings;
+   unsigned joy_idx                       = settings->uints.input_joypad_index[port];
 
-   if (joy_idx >= MAX_USERS)
-      return false;
-   if (p_rarch->joypad && p_rarch->joypad->set_rumble)
-      rumble_state = p_rarch->joypad->set_rumble(
-            joy_idx, effect, strength);
-   if (sec_joypad      && sec_joypad->set_rumble)
-      rumble_state = sec_joypad->set_rumble(
-            joy_idx, effect, strength);
-   return rumble_state;
+   return input_driver_set_rumble(
+      input_driver_st,
+      port, joy_idx, effect, strength);
 }
+
+/**
+ * Sets the sensor state. Used by RETRO_ENVIRONMENT_GET_SENSOR_INTERFACE.
+ *
+ * @param port
+ * @param action
+ * @param rate
+ *
+ * @return true if the sensor state has been successfully set
+ **/
+bool input_set_sensor_state(unsigned port,
+      enum retro_sensor_action action, unsigned rate)
+{
+   struct rarch_state *p_rarch = &rarch_st;
+   settings_t *settings        = p_rarch->configuration_settings;
+   bool input_sensors_enable   = settings->bools.input_sensors_enable;
+   return input_driver_set_sensor(
+      &p_rarch->input_driver_state,
+      port, input_sensors_enable, action, rate);
+}
+
+void input_set_nonblock_state(void)
+{
+   struct rarch_state           *p_rarch = &rarch_st;
+   input_driver_state_t *input_driver_st = &p_rarch->input_driver_state;
+
+   input_driver_set_nonblocking(input_driver_st, true);
+}
+
+void input_unset_nonblock_state(void)
+{
+   struct rarch_state     *p_rarch = &rarch_st;
+   input_driver_state_t *input_driver_st = &p_rarch->input_driver_state;
+
+   input_driver_set_nonblocking(input_driver_st, false);
+}
+
+void *input_driver_get_data(void)
+{
+   struct rarch_state     *p_rarch = &rarch_st;
+   input_driver_state_t *input_driver_st = &p_rarch->input_driver_state;
+   return input_driver_st->current_data;
+}
+
+/******************************************************************************
+ * END helper functions for input_driver refactoring
+ ******************************************************************************/
 
 const char *joypad_driver_name(unsigned i)
 {
-   struct rarch_state     *p_rarch = &rarch_st;
-   if (!p_rarch || !p_rarch->joypad || !p_rarch->joypad->name)
+   struct rarch_state           *p_rarch = &rarch_st;
+   input_driver_state_t *input_driver_st = &p_rarch->input_driver_state;
+   if (!p_rarch || !input_driver_st->primary_joypad || !input_driver_st->primary_joypad->name)
       return NULL;
-   return p_rarch->joypad->name(i);
+   return input_driver_st->primary_joypad->name(i);
 }
 
 void joypad_driver_reinit(void *data, const char *joypad_driver_name)
 {
-   struct rarch_state     *p_rarch = &rarch_st;
+   struct rarch_state           *p_rarch = &rarch_st;
+   input_driver_state_t *input_driver_st = &p_rarch->input_driver_state;
+
    if (!p_rarch)
       return;
 
-   if (p_rarch->joypad)
-      p_rarch->joypad->destroy();
-   p_rarch->joypad = NULL;
+   if (input_driver_st->primary_joypad)
+      input_driver_st->primary_joypad->destroy();
+   input_driver_st->primary_joypad = NULL;
 #ifdef HAVE_MFI
-   if (p_rarch->sec_joypad)
-      p_rarch->sec_joypad->destroy();
-   p_rarch->sec_joypad = NULL;
+   if (input_driver_st->secondary_joypad)
+      input_driver_st->secondary_joypad->destroy();
+   input_driver_st->secondary_joypad = NULL;
 #endif
-   p_rarch->joypad     = input_joypad_init_driver(joypad_driver_name, data);
+   input_driver_st->primary_joypad     = input_joypad_init_driver(joypad_driver_name, data);
 #ifdef HAVE_MFI
-   p_rarch->sec_joypad = input_joypad_init_driver("mfi", data);
+   input_driver_st->secondary_joypad = input_joypad_init_driver("mfi", data);
 #endif
 }
 
 static uint64_t input_driver_get_capabilities(void)
 {
    struct rarch_state *p_rarch = &rarch_st;
-   if (!p_rarch->current_input || !p_rarch->current_input->get_capabilities)
+   if (!p_rarch->input_driver_state.current_driver || !p_rarch->input_driver_state.current_driver->get_capabilities)
       return 0;
-   return p_rarch->current_input->get_capabilities(p_rarch->current_input_data);
+   return p_rarch->input_driver_state.current_driver->get_capabilities(p_rarch->input_driver_state.current_data);
 }
 
-/**
- * input_sensor_set_state:
- * @port               : User number.
- * @effect             : Sensor action.
- * @rate               : Sensor rate update.
- *
- * Sets the sensor state.
- * Used by RETRO_ENVIRONMENT_GET_SENSOR_INTERFACE.
- **/
-bool input_sensor_set_state(unsigned port,
-      enum retro_sensor_action action, unsigned rate)
-{
-   struct rarch_state *p_rarch = &rarch_st;
-   settings_t *settings        = p_rarch->configuration_settings;
-   bool input_sensors_enable   = settings->bools.input_sensors_enable;
-
-   /* If sensors are disabled, inhibit any enable
-    * actions (but always allow disable actions) */
-   if (!input_sensors_enable &&
-       ((action == RETRO_SENSOR_ACCELEROMETER_ENABLE) ||
-        (action == RETRO_SENSOR_GYROSCOPE_ENABLE) ||
-        (action == RETRO_SENSOR_ILLUMINANCE_ENABLE)))
-      return false;
-
-   if (p_rarch->current_input_data &&
-         p_rarch->current_input->set_sensor_state)
-      return p_rarch->current_input->set_sensor_state(p_rarch->current_input_data,
-            port, action, rate);
-   return false;
-}
-
-float input_sensor_get_input(unsigned port, unsigned id)
-{
-   struct rarch_state *p_rarch = &rarch_st;
-   settings_t *settings        = p_rarch->configuration_settings;
-   bool input_sensors_enable   = settings->bools.input_sensors_enable;
-
-   if (input_sensors_enable &&
-       p_rarch->current_input_data &&
-       p_rarch->current_input->get_sensor_input)
-      return p_rarch->current_input->get_sensor_input(p_rarch->current_input_data,
-            port, id);
-   return 0.0f;
-}
 
 /**
  * input_poll:
@@ -21912,10 +21943,11 @@ static void input_driver_poll(void)
    size_t i, j;
    rarch_joypad_info_t joypad_info[MAX_USERS];
    struct rarch_state    *p_rarch = &rarch_st;
+   input_driver_state_t *input_driver_st = &p_rarch->input_driver_state;
    settings_t *settings           = p_rarch->configuration_settings;
 #ifdef HAVE_MFI
    const input_device_driver_t
-      *sec_joypad                 = p_rarch->sec_joypad;
+      *sec_joypad                 = input_driver_st->secondary_joypad;
 #else
    const input_device_driver_t
       *sec_joypad                 = NULL;
@@ -21924,19 +21956,19 @@ static void input_driver_poll(void)
    float input_overlay_opacity    = settings->floats.input_overlay_opacity;
 #endif
    bool input_remap_binds_enable  = settings->bools.input_remap_binds_enable;
-   uint8_t max_users              = (uint8_t)p_rarch->input_driver_max_users;
+   uint8_t max_users              = (uint8_t)settings->uints.input_max_users;
 
-   if (     p_rarch->joypad
-         && p_rarch->joypad->poll)
-      p_rarch->joypad->poll();
+   if (     input_driver_st->primary_joypad
+         && input_driver_st->primary_joypad->poll)
+      input_driver_st->primary_joypad->poll();
 #ifdef HAVE_MFI
-   if (     p_rarch->sec_joypad
-         && p_rarch->sec_joypad->poll)
-      p_rarch->sec_joypad->poll();
+   if (     input_driver_st->secondary_joypad
+         && input_driver_st->secondary_joypad->poll)
+      input_driver_st->secondary_joypad->poll();
 #endif
-   if (     p_rarch->current_input
-         && p_rarch->current_input->poll)
-      p_rarch->current_input->poll(p_rarch->current_input_data);
+   if (     p_rarch->input_driver_state.current_driver
+         && p_rarch->input_driver_state.current_driver->poll)
+      p_rarch->input_driver_state.current_driver->poll(p_rarch->input_driver_state.current_data);
 
    p_rarch->input_driver_turbo_btns.count++;
 
@@ -21952,15 +21984,15 @@ static void input_driver_poll(void)
     * when mapping analog stick to dpad input. */
    for (i = 0; i < max_users; i++)
    {
-      joypad_info[i].axis_threshold              = p_rarch->input_driver_axis_threshold;
+      joypad_info[i].axis_threshold              = settings->floats.input_axis_threshold;
       joypad_info[i].joy_idx                     = settings->uints.input_joypad_index[i];
       joypad_info[i].auto_binds                  = input_autoconf_binds[joypad_info[i].joy_idx];
 
       p_rarch->input_driver_turbo_btns.frame_enable[i] = p_rarch->libretro_input_binds[i][RARCH_TURBO_ENABLE].valid ?
          input_state_wrap(
-               p_rarch->current_input,
-               p_rarch->current_input_data,
-               p_rarch->joypad,
+               p_rarch->input_driver_state.current_driver,
+               p_rarch->input_driver_state.current_data,
+               input_driver_st->primary_joypad,
                sec_joypad,
                &joypad_info[i],
                p_rarch->libretro_input_binds,
@@ -22002,7 +22034,7 @@ static void input_driver_poll(void)
             p_rarch->overlay_ptr,
             input_overlay_opacity,
             input_analog_dpad_mode,
-            p_rarch->input_driver_axis_threshold);
+            settings->floats.input_analog_deadzone);
    }
 #endif
 
@@ -22017,7 +22049,7 @@ static void input_driver_poll(void)
 #endif
       input_mapper_t *handle           = &p_rarch->input_driver_mapper;
       const input_device_driver_t *joypad_driver
-                                       = p_rarch->joypad;
+                                       = input_driver_st->primary_joypad;
       float input_analog_deadzone      = settings->floats.input_analog_deadzone;
       float input_analog_sensitivity   = settings->floats.input_analog_sensitivity;
 
@@ -22057,9 +22089,9 @@ static void input_driver_poll(void)
                {
                   unsigned k, j;
                   int16_t ret = input_state_wrap(
-                        p_rarch->current_input,
-                        p_rarch->current_input_data,
-                        p_rarch->joypad,
+                        p_rarch->input_driver_state.current_driver,
+                        p_rarch->input_driver_state.current_data,
+                        input_driver_st->primary_joypad,
                         sec_joypad,
                         &joypad_info[i],
                         p_rarch->libretro_input_binds,
@@ -22140,7 +22172,7 @@ static void input_driver_poll(void)
                   {
                      int16_t current_axis_value = p_new_state->analogs[j - RARCH_FIRST_CUSTOM_BIND];
                      current_button_value = abs(current_axis_value) >
-                           p_rarch->input_driver_axis_threshold
+                           settings->floats.input_axis_threshold
                             * 32767;
                   }
                   else
@@ -22270,7 +22302,7 @@ static void input_driver_poll(void)
                   {
                      if (remap_axis < RARCH_FIRST_CUSTOM_BIND &&
                            abs(current_axis_value) >
-                           p_rarch->input_driver_axis_threshold
+                           settings->floats.input_axis_threshold
                             * 32767)
                      {
                         BIT256_SET(handle->buttons[i], remap_axis);
@@ -22712,27 +22744,28 @@ static int16_t input_state_internal(unsigned port, unsigned device,
    rarch_joypad_info_t joypad_info;
    unsigned mapped_port;
    struct rarch_state *p_rarch             = &rarch_st;
+   input_driver_state_t *input_driver_st = &p_rarch->input_driver_state;
    settings_t *settings                    = p_rarch->configuration_settings;
    float input_analog_deadzone             = settings->floats.input_analog_deadzone;
    float input_analog_sensitivity          = settings->floats.input_analog_sensitivity;
    unsigned *input_remap_port_map          = settings->uints.input_remap_port_map[port];
    bool input_driver_analog_requested      = p_rarch->input_driver_analog_requested[port];
-   const input_device_driver_t *joypad     = p_rarch->joypad;
+   const input_device_driver_t *joypad     = input_driver_st->primary_joypad;
 #ifdef HAVE_MFI
-   const input_device_driver_t *sec_joypad = p_rarch->sec_joypad;
+   const input_device_driver_t *sec_joypad = input_driver_st->secondary_joypad;
 #else
    const input_device_driver_t *sec_joypad = NULL;
 #endif
    bool input_blocked                      = (p_rarch->input_driver_flushing_input > 0) ||
                                              p_rarch->input_driver_block_libretro_input;
    bool bitmask_enabled                    = false;
-   unsigned max_users                      = p_rarch->input_driver_max_users;
+   unsigned max_users                      = settings->uints.input_max_users;
    int16_t result                          = 0;
 
    device                                 &= RETRO_DEVICE_MASK;
    bitmask_enabled                         = (device == RETRO_DEVICE_JOYPAD) &&
                                              (id == RETRO_DEVICE_ID_JOYPAD_MASK);
-   joypad_info.axis_threshold              = p_rarch->input_driver_axis_threshold;
+   joypad_info.axis_threshold              = settings->floats.input_axis_threshold;
 
    /* Loop over all 'physical' ports mapped to specified
     * 'virtual' port index */
@@ -22773,8 +22806,8 @@ static int16_t input_state_internal(unsigned port, unsigned device,
        * thing needs to be rewritten from scratch... */
 
       ret = input_state_wrap(
-            p_rarch->current_input,
-            p_rarch->current_input_data,
+            p_rarch->input_driver_state.current_driver,
+            p_rarch->input_driver_state.current_data,
             joypad,
             sec_joypad,
             &joypad_info,
@@ -23037,12 +23070,13 @@ static int16_t menu_input_read_mouse_hw(
       enum menu_input_mouse_hw_id id)
 {
    rarch_joypad_info_t joypad_info;
-   unsigned type                   = 0;
-   unsigned device                 = RETRO_DEVICE_MOUSE;
-   input_driver_t *current_input   = p_rarch->current_input;
+   unsigned type                          = 0;
+   unsigned device                        = RETRO_DEVICE_MOUSE;
+   input_driver_state_t *input_driver_st  = &p_rarch->input_driver_state;
+   input_driver_t         *current_input  = input_driver_st->current_driver;
 #ifdef HAVE_MFI
    const input_device_driver_t
-      *sec_joypad                  = p_rarch->sec_joypad;
+      *sec_joypad                  = input_driver_st->secondary_joypad;
 #else
    const input_device_driver_t
       *sec_joypad                  = NULL;
@@ -23085,8 +23119,8 @@ static int16_t menu_input_read_mouse_hw(
    if (!current_input->input_state)
       return 0;
    return current_input->input_state(
-         p_rarch->current_input_data,
-         p_rarch->joypad,
+         input_driver_st->current_data,
+         input_driver_st->primary_joypad,
          sec_joypad,
          &joypad_info,
          NULL,
@@ -23224,8 +23258,9 @@ static void menu_input_get_touchscreen_hw_state(
    int pointer_y                                = 0;
    settings_t *settings                         =
       p_rarch->configuration_settings;
+   input_driver_state_t *input_driver_st        = &p_rarch->input_driver_state;
    const struct retro_keybind *binds[MAX_USERS] = {NULL};
-   input_driver_t *current_input                = p_rarch->current_input;
+   input_driver_t *current_input                = p_rarch->input_driver_state.current_driver;
    menu_handle_t             *menu              = p_rarch->menu_driver_data;
    /* Is a background texture set for the current menu driver?
     * Checks if the menu framebuffer is set.
@@ -23243,7 +23278,7 @@ static void menu_input_get_touchscreen_hw_state(
    unsigned input_touch_scale                   = settings->uints.input_touch_scale;
 #ifdef HAVE_MFI
    const input_device_driver_t
-      *sec_joypad                               = p_rarch->sec_joypad;
+      *sec_joypad                               = input_driver_st->secondary_joypad;
 #else
    const input_device_driver_t
       *sec_joypad                               = NULL;
@@ -23293,8 +23328,8 @@ static void menu_input_get_touchscreen_hw_state(
    /* X pos */
    if (current_input->input_state)
       pointer_x                  = current_input->input_state(
-            p_rarch->current_input_data,
-            p_rarch->joypad,
+            p_rarch->input_driver_state.current_data,
+            input_driver_st->primary_joypad,
             sec_joypad,
             &joypad_info, binds,
             p_rarch->keyboard_mapping_blocked,
@@ -23324,8 +23359,8 @@ static void menu_input_get_touchscreen_hw_state(
    /* Y pos */
    if (current_input->input_state)
       pointer_y = current_input->input_state(
-            p_rarch->current_input_data,
-            p_rarch->joypad,
+            p_rarch->input_driver_state.current_data,
+            input_driver_st->primary_joypad,
             sec_joypad,
             &joypad_info, binds,
             p_rarch->keyboard_mapping_blocked,
@@ -23351,8 +23386,8 @@ static void menu_input_get_touchscreen_hw_state(
     * Note that releasing select also counts as activity */
    if (current_input->input_state)
       hw_state->select_pressed = (bool)current_input->input_state(
-            p_rarch->current_input_data,
-            p_rarch->joypad,
+            p_rarch->input_driver_state.current_data,
+            input_driver_st->primary_joypad,
             sec_joypad,
             &joypad_info, binds,
             p_rarch->keyboard_mapping_blocked,
@@ -23366,8 +23401,8 @@ static void menu_input_get_touchscreen_hw_state(
     * Note that releasing cancel also counts as activity */
    if (current_input->input_state)
       hw_state->cancel_pressed = (bool)current_input->input_state(
-            p_rarch->current_input_data,
-            p_rarch->joypad,
+            p_rarch->input_driver_state.current_data,
+            input_driver_st->primary_joypad,
             sec_joypad,
             &joypad_info, binds,
             p_rarch->keyboard_mapping_blocked,
@@ -24664,9 +24699,10 @@ static void input_keys_pressed(
       rarch_joypad_info_t *joypad_info)
 {
    unsigned i;
+   input_driver_state_t *input_driver_st = &p_rarch->input_driver_state;
 #ifdef HAVE_MFI
    const input_device_driver_t
-      *sec_joypad                               = p_rarch->sec_joypad;
+      *sec_joypad                               = input_driver_st->secondary_joypad;
 #else
    const input_device_driver_t
       *sec_joypad                               = NULL;
@@ -24675,9 +24711,9 @@ static void input_keys_pressed(
    if (CHECK_INPUT_DRIVER_BLOCK_HOTKEY(binds_norm, binds_auto))
    {
       if (  input_state_wrap(
-               p_rarch->current_input,
-               p_rarch->current_input_data,
-               p_rarch->joypad,
+               input_driver_st->current_driver,
+               input_driver_st->current_data,
+               input_driver_st->primary_joypad,
                sec_joypad,
                joypad_info,
                &binds[port],
@@ -24711,9 +24747,9 @@ static void input_keys_pressed(
                focus_normal, focus_binds_auto))
       {
          if (input_state_wrap(
-                  p_rarch->current_input,
-                  p_rarch->current_input_data,
-                  p_rarch->joypad,
+                  p_rarch->input_driver_state.current_driver,
+                  p_rarch->input_driver_state.current_data,
+                  input_driver_st->primary_joypad,
                   sec_joypad,
                   joypad_info,
                   &binds[port],
@@ -24730,9 +24766,9 @@ static void input_keys_pressed(
       /* Check the libretro input first */
       if (!p_rarch->input_driver_block_libretro_input)
          ret = input_state_wrap(
-               p_rarch->current_input,
-               p_rarch->current_input_data,
-               p_rarch->joypad,
+               p_rarch->input_driver_state.current_driver,
+               p_rarch->input_driver_state.current_data,
+               input_driver_st->primary_joypad,
                sec_joypad,
                joypad_info, &binds[port],
                p_rarch->keyboard_mapping_blocked,
@@ -24770,9 +24806,9 @@ static void input_keys_pressed(
       {
          bool bit_pressed = binds[port][i].valid
             && input_state_wrap(
-                  p_rarch->current_input,
-                  p_rarch->current_input_data,
-                  p_rarch->joypad,
+                  p_rarch->input_driver_state.current_driver,
+                  p_rarch->input_driver_state.current_data,
+                  input_driver_st->primary_joypad,
                   sec_joypad,
                   joypad_info,
                   &binds[port],
@@ -24788,23 +24824,18 @@ static void input_keys_pressed(
    }
 }
 
-void *input_driver_get_data(void)
-{
-   struct rarch_state  *p_rarch   = &rarch_st;
-   return p_rarch->current_input_data;
-}
-
 void input_driver_init_joypads(void)
 {
-   struct rarch_state *p_rarch = &rarch_st;
-   settings_t *settings        = p_rarch->configuration_settings;
-   p_rarch->joypad             = input_joypad_init_driver(
+   struct rarch_state            *p_rarch = &rarch_st;
+   input_driver_state_t  *input_driver_st = &p_rarch->input_driver_state;
+   settings_t                   *settings = p_rarch->configuration_settings;
+   input_driver_st->primary_joypad        = input_joypad_init_driver(
          settings->arrays.input_joypad_driver,
-         p_rarch->current_input_data);
+         input_driver_st->current_data);
 #ifdef HAVE_MFI
-   p_rarch->sec_joypad         = input_joypad_init_driver(
+   input_driver_st->secondary_joypad         = input_joypad_init_driver(
          "mfi",
-         p_rarch->current_input_data);
+         input_driver_st->current_data);
 #endif
 }
 
@@ -24824,11 +24855,11 @@ void *input_driver_init_wrap(input_driver_t *input, const char *name)
 static bool input_driver_init(struct rarch_state *p_rarch,
       settings_t *settings)
 {
-   if (p_rarch->current_input)
-      p_rarch->current_input_data = input_driver_init_wrap(
-            p_rarch->current_input, settings->arrays.input_joypad_driver);
+   if (p_rarch->input_driver_state.current_driver)
+      p_rarch->input_driver_state.current_data = input_driver_init_wrap(
+            p_rarch->input_driver_state.current_driver, settings->arrays.input_joypad_driver);
 
-   return (p_rarch->current_input_data != NULL);
+   return (p_rarch->input_driver_state.current_data != NULL);
 }
 
 static bool input_driver_find_driver(
@@ -24843,9 +24874,9 @@ static bool input_driver_find_driver(
 
    if (i >= 0)
    {
-      p_rarch->current_input = (input_driver_t*)input_drivers[i];
+      p_rarch->input_driver_state.current_driver = (input_driver_t*)input_drivers[i];
       RARCH_LOG("[Input]: Found %s: \"%s\".\n", prefix,
-            p_rarch->current_input->ident);
+            p_rarch->input_driver_state.current_driver->ident);
    }
    else
    {
@@ -24860,9 +24891,9 @@ static bool input_driver_find_driver(
          RARCH_WARN("Going to default to first %s...\n", prefix);
       }
 
-      p_rarch->current_input = (input_driver_t*)input_drivers[0];
+      p_rarch->input_driver_state.current_driver = (input_driver_t*)input_drivers[0];
 
-      if (!p_rarch->current_input)
+      if (!p_rarch->input_driver_state.current_driver)
       {
          retroarch_fail(p_rarch, 1, "find_input_driver()");
          return false;
@@ -24870,18 +24901,6 @@ static bool input_driver_find_driver(
    }
 
    return true;
-}
-
-void input_driver_set_nonblock_state(void)
-{
-   struct rarch_state *p_rarch = &rarch_st;
-   p_rarch->input_driver_nonblock_state = true;
-}
-
-void input_driver_unset_nonblock_state(void)
-{
-   struct rarch_state *p_rarch = &rarch_st;
-   p_rarch->input_driver_nonblock_state = false;
 }
 
 #ifdef HAVE_COMMAND
@@ -24895,8 +24914,8 @@ static void input_driver_init_command(struct rarch_state *p_rarch,
 
    if (input_stdin_cmd_enable)
    {
-      bool grab_stdin               = p_rarch->current_input->grab_stdin &&
-         p_rarch->current_input->grab_stdin(p_rarch->current_input_data);
+      bool grab_stdin               = p_rarch->input_driver_state.current_driver->grab_stdin &&
+         p_rarch->input_driver_state.current_driver->grab_stdin(p_rarch->input_driver_state.current_data);
       if (grab_stdin)
       {
          RARCH_WARN("stdin command interface is desired, "
@@ -24955,38 +24974,6 @@ static input_remote_t *input_driver_init_remote(
 }
 #endif
 
-float *input_driver_get_float(enum input_action action)
-{
-   struct rarch_state           *p_rarch = &rarch_st;
-
-   switch (action)
-   {
-      case INPUT_ACTION_AXIS_THRESHOLD:
-         return &p_rarch->input_driver_axis_threshold;
-      default:
-      case INPUT_ACTION_NONE:
-         break;
-   }
-
-   return NULL;
-}
-
-unsigned *input_driver_get_uint(enum input_action action)
-{
-   struct rarch_state           *p_rarch = &rarch_st;
-
-   switch (action)
-   {
-      case INPUT_ACTION_MAX_USERS:
-         return &p_rarch->input_driver_max_users;
-      default:
-      case INPUT_ACTION_NONE:
-         break;
-   }
-
-   return NULL;
-}
-
 /**
  * config_get_joypad_driver_options:
  *
@@ -24999,70 +24986,6 @@ const char* config_get_joypad_driver_options(void)
    return char_list_new_special(STRING_LIST_INPUT_JOYPAD_DRIVERS, NULL);
 }
 
-/**
- * input_joypad_init_first:
- *
- * Finds first suitable joypad driver and initializes.
- *
- * Returns: joypad driver if found, otherwise NULL.
- **/
-static const input_device_driver_t *input_joypad_init_first(void *data)
-{
-   unsigned i;
-
-   for (i = 0; joypad_drivers[i]; i++)
-   {
-      if (     joypad_drivers[i]
-            && joypad_drivers[i]->init)
-      {
-         void *ptr = joypad_drivers[i]->init(data);
-         if (ptr)
-         {
-            RARCH_LOG("[Joypad]: Found joypad driver: \"%s\".\n",
-                  joypad_drivers[i]->ident);
-            return joypad_drivers[i];
-         }
-      }
-   }
-
-   return NULL;
-}
-
-/**
- * input_joypad_init_driver:
- * @ident                           : identifier of driver to initialize.
- *
- * Initialize a joypad driver of name @ident.
- *
- * If ident points to NULL or a zero-length string,
- * equivalent to calling input_joypad_init_first().
- *
- * Returns: joypad driver if found, otherwise NULL.
- **/
-const input_device_driver_t *input_joypad_init_driver(
-      const char *ident, void *data)
-{
-   unsigned i;
-   if (ident && *ident)
-   {
-      for (i = 0; joypad_drivers[i]; i++)
-      {
-         if (string_is_equal(ident, joypad_drivers[i]->ident)
-               && joypad_drivers[i]->init)
-         {
-            void *ptr = joypad_drivers[i]->init(data);
-            if (ptr)
-            {
-               RARCH_LOG("[Joypad]: Found joypad driver: \"%s\".\n",
-                     joypad_drivers[i]->ident);
-               return joypad_drivers[i];
-            }
-         }
-      }
-   }
-
-   return input_joypad_init_first(data);
-}
 
 bool input_key_pressed(int key, bool keyboard_pressed)
 {
@@ -25075,16 +24998,18 @@ bool input_key_pressed(int key, bool keyboard_pressed)
         )
       )
    {
-      struct rarch_state *p_rarch    = &rarch_st;
+      struct rarch_state           *p_rarch = &rarch_st;
+      input_driver_state_t *input_driver_st = &p_rarch->input_driver_state;
+      settings_t                  *settings = p_rarch->configuration_settings;
       const input_device_driver_t
          *joypad                     = (const input_device_driver_t*)
-         p_rarch->joypad;
+         input_driver_st->primary_joypad;
       const uint64_t bind_joykey     = input_config_binds[0][key].joykey;
       const uint64_t bind_joyaxis    = input_config_binds[0][key].joyaxis;
       const uint64_t autobind_joykey = input_autoconf_binds[0][key].joykey;
       const uint64_t autobind_joyaxis= input_autoconf_binds[0][key].joyaxis;
       uint16_t port                  = 0;
-      float axis_threshold           = p_rarch->input_driver_axis_threshold;
+      float axis_threshold           = settings->floats.input_axis_threshold;
       const uint64_t joykey          = (bind_joykey != NO_BTN)
          ? bind_joykey  : autobind_joykey;
       const uint32_t joyaxis         = (bind_joyaxis != AXIS_NONE)
@@ -25331,9 +25256,11 @@ static bool input_mouse_button_raw(
       unsigned port, unsigned id)
 {
    rarch_joypad_info_t joypad_info;
+   input_driver_state_t *input_driver_st = &p_rarch->input_driver_state;
+   settings_t                  *settings = p_rarch->configuration_settings;
 #ifdef HAVE_MFI
    const input_device_driver_t
-      *sec_joypad                    = p_rarch->sec_joypad;
+      *sec_joypad                    = input_driver_st->secondary_joypad;
 #else
    const input_device_driver_t
       *sec_joypad                    = NULL;
@@ -25343,14 +25270,14 @@ static bool input_mouse_button_raw(
    if (id == RETRO_DEVICE_ID_MOUSE_X || id == RETRO_DEVICE_ID_MOUSE_Y)
       return false;
 
-   joypad_info.axis_threshold        = p_rarch->input_driver_axis_threshold;
+   joypad_info.axis_threshold        = settings->floats.input_axis_threshold;
    joypad_info.joy_idx               = joy_idx;
    joypad_info.auto_binds            = input_autoconf_binds[joy_idx];
 
    if (current_input->input_state)
       return current_input->input_state(
-            p_rarch->current_input_data,
-            p_rarch->joypad,
+            p_rarch->input_driver_state.current_data,
+            input_driver_st->primary_joypad,
             sec_joypad,
             &joypad_info,
             p_rarch->libretro_input_binds,
@@ -29777,7 +29704,7 @@ static void video_driver_init_input(
       bool verbosity_enabled)
 {
    struct rarch_state *p_rarch = &rarch_st;
-   input_driver_t      **input = &p_rarch->current_input;
+   input_driver_t      **input = &p_rarch->input_driver_state.current_driver;
    if (*input)
       return;
 
@@ -29795,7 +29722,7 @@ static void video_driver_init_input(
    /* This should never really happen as tmp (driver.input) is always
     * found before this in find_driver_input(), or we have aborted
     * in a similar fashion anyways. */
-   if (!p_rarch->current_input || !input_driver_init(p_rarch, settings))
+   if (!p_rarch->input_driver_state.current_driver || !input_driver_init(p_rarch, settings))
    {
       RARCH_ERR("[Video]: Cannot initialize input driver. Exiting ...\n");
       retroarch_fail(p_rarch, 1, "video_driver_init_input()");
@@ -29867,6 +29794,8 @@ static void video_driver_free_hw_context(struct rarch_state *p_rarch)
 
 static void video_driver_free_internal(struct rarch_state *p_rarch)
 {
+   input_driver_state_t *input_driver_st = &p_rarch->input_driver_state;
+
 #ifdef HAVE_THREADS
    bool        is_threaded     = VIDEO_DRIVER_IS_THREADED_INTERNAL();
 #endif
@@ -29880,21 +29809,21 @@ static void video_driver_free_internal(struct rarch_state *p_rarch)
    if (!video_driver_is_video_cache_context())
       video_driver_free_hw_context(p_rarch);
 
-   if (!(p_rarch->current_input_data == p_rarch->video_driver_data))
+   if (!(input_driver_st->current_data == p_rarch->video_driver_data))
    {
-      if (p_rarch->current_input)
-         if (p_rarch->current_input->free)
-            p_rarch->current_input->free(p_rarch->current_input_data);
-      if (p_rarch->joypad)
-         p_rarch->joypad->destroy();
-      p_rarch->joypad                                     = NULL;
+      if (input_driver_st->current_driver)
+         if (input_driver_st->current_driver->free)
+            input_driver_st->current_driver->free(input_driver_st->current_data);
+      if (input_driver_st->primary_joypad)
+         input_driver_st->primary_joypad->destroy();
+      input_driver_st->primary_joypad                                     = NULL;
 #ifdef HAVE_MFI
-      if (p_rarch->sec_joypad)
-         p_rarch->sec_joypad->destroy();
-      p_rarch->sec_joypad                                 = NULL;
+      if (input_driver_st->secondary_joypad)
+         input_driver_st->secondary_joypad->destroy();
+      input_driver_st->secondary_joypad                                 = NULL;
 #endif
       p_rarch->keyboard_mapping_blocked                   = false;
-      p_rarch->current_input_data                         = NULL;
+      p_rarch->input_driver_state.current_data                         = NULL;
    }
 
    if (p_rarch->video_driver_data
@@ -30252,7 +30181,7 @@ static bool video_driver_init_internal(
    /* Reset video frame count */
    p_rarch->video_driver_frame_count = 0;
 
-   tmp                               = p_rarch->current_input;
+   tmp                               = p_rarch->input_driver_state.current_driver;
    /* Need to grab the "real" video driver interface on a reinit. */
    video_driver_find_driver(p_rarch, settings,
          "video driver", verbosity_enabled);
@@ -30269,8 +30198,8 @@ static bool video_driver_init_internal(
 
       ret = video_init_thread((const video_driver_t**)&p_rarch->current_video,
                &p_rarch->video_driver_data,
-               &p_rarch->current_input,
-               (void**)&p_rarch->current_input_data,
+               &p_rarch->input_driver_state.current_driver,
+               (void**)&p_rarch->input_driver_state.current_data,
                p_rarch->current_video,
                video);
       if (!ret)
@@ -30283,8 +30212,8 @@ static bool video_driver_init_internal(
 #endif
       p_rarch->video_driver_data = p_rarch->current_video->init(
             &video,
-            &p_rarch->current_input,
-            (void**)&p_rarch->current_input_data);
+            &p_rarch->input_driver_state.current_driver,
+            (void**)&p_rarch->input_driver_state.current_data);
 
    if (!p_rarch->video_driver_data)
    {
@@ -31883,6 +31812,7 @@ void video_driver_build_info(video_frame_info_t *video_info)
    video_viewport_t *custom_vp             = NULL;
    struct rarch_state       *p_rarch       = &rarch_st;
    settings_t *settings                    = p_rarch->configuration_settings;
+   input_driver_state_t *input_driver_st   = &p_rarch->input_driver_state;
 #ifdef HAVE_THREADS
    bool is_threaded                        =
       VIDEO_DRIVER_IS_THREADED_INTERNAL();
@@ -31998,9 +31928,9 @@ void video_driver_build_info(video_frame_info_t *video_info)
    video_info->runloop_is_paused           = runloop_state.paused;
    video_info->runloop_is_slowmotion       = runloop_state.slowmotion;
 
-   video_info->input_driver_nonblock_state = p_rarch->input_driver_nonblock_state;
+   video_info->input_driver_nonblock_state   = input_driver_get_nonblocking(input_driver_st);
    video_info->input_driver_grab_mouse_state = p_rarch->input_driver_grab_mouse_state;
-   video_info->disp_userdata               = &p_rarch->dispgfx;
+   video_info->disp_userdata                 = &p_rarch->dispgfx;
 
    video_info->userdata                    = VIDEO_DRIVER_GET_PTR_INTERNAL(p_rarch);
 
@@ -32941,8 +32871,9 @@ static void driver_adjust_system_rates(
  **/
 void driver_set_nonblock_state(void)
 {
-   struct rarch_state *p_rarch = &rarch_st;
-   bool                 enable = p_rarch->input_driver_nonblock_state;
+   struct rarch_state *p_rarch            = &rarch_st;
+   input_driver_state_t *input_driver_st  = &p_rarch->input_driver_state;
+   bool                 enable = input_driver_get_nonblocking(input_driver_st);
    settings_t       *settings  = p_rarch->configuration_settings;
    bool audio_sync             = settings->bools.audio_sync;
    bool video_vsync            = settings->bools.video_vsync;
@@ -32989,6 +32920,7 @@ static void drivers_init(struct rarch_state *p_rarch,
       int flags,
       bool verbosity_enabled)
 {
+   input_driver_state_t *input_driver_st = &p_rarch->input_driver_state;
 #ifdef HAVE_MENU
    struct menu_state  *menu_st = &p_rarch->menu_driver_state;
 #endif
@@ -33170,7 +33102,7 @@ static void drivers_init(struct rarch_state *p_rarch,
    if (flags & (DRIVER_VIDEO_MASK | DRIVER_AUDIO_MASK))
    {
       /* Keep non-throttled state as good as possible. */
-      if (p_rarch->input_driver_nonblock_state)
+      if (input_driver_get_nonblocking(input_driver_st))
          driver_set_nonblock_state();
    }
 
@@ -33270,7 +33202,7 @@ static void driver_uninit(struct rarch_state *p_rarch, int flags)
       p_rarch->video_driver_data = NULL;
 
    if ((flags & DRIVER_INPUT_MASK))
-      p_rarch->current_input_data = NULL;
+      p_rarch->input_driver_state.current_data = NULL;
 
    if ((flags & DRIVER_AUDIO_MASK))
       p_rarch->audio_driver_context_audio_data = NULL;
@@ -33286,6 +33218,8 @@ static void driver_uninit(struct rarch_state *p_rarch, int flags)
 static void retroarch_deinit_drivers(
       struct rarch_state *p_rarch, struct retro_callbacks *cbs)
 {
+   input_driver_state_t *input_driver_st  = &(p_rarch->input_driver_state);
+
 #if defined(HAVE_GFX_WIDGETS)
    /* Tear down display widgets no matter what
     * in case the handle is lost in the threaded
@@ -33330,12 +33264,13 @@ static void retroarch_deinit_drivers(
    p_rarch->input_driver_keyboard_linefeed_enable   = false;
    p_rarch->input_driver_block_hotkey               = false;
    p_rarch->input_driver_block_libretro_input       = false;
-   p_rarch->input_driver_nonblock_state             = false;
+   input_driver_set_nonblocking(input_driver_st, false);
+
    p_rarch->input_driver_flushing_input             = 0;
    memset(&p_rarch->input_driver_turbo_btns, 0, sizeof(turbo_buttons_t));
    memset(&p_rarch->input_driver_analog_requested, 0,
          sizeof(p_rarch->input_driver_analog_requested));
-   p_rarch->current_input                           = NULL;
+   p_rarch->input_driver_state.current_driver                           = NULL;
 
 #ifdef HAVE_MENU
    menu_driver_destroy(p_rarch,
@@ -35540,12 +35475,12 @@ bool retroarch_main_init(int argc, char *argv[])
 #ifdef HAVE_NETWORKGAMEPAD
    if (p_rarch->input_driver_remote)
       input_remote_free(p_rarch->input_driver_remote,
-            p_rarch->input_driver_max_users);
+            settings->uints.input_max_users);
    p_rarch->input_driver_remote    = NULL;
    if (settings->bools.network_remote_enable)
       p_rarch->input_driver_remote = input_driver_init_remote(
             settings,
-            p_rarch->input_driver_max_users);
+            settings->uints.input_max_users);
 #endif
    input_mapper_reset(&p_rarch->input_driver_mapper);
 #ifdef HAVE_REWIND
@@ -36130,6 +36065,7 @@ void retroarch_init_task_queue(void)
 bool rarch_ctl(enum rarch_ctl_state state, void *data)
 {
    struct rarch_state *p_rarch = &rarch_st;
+   settings_t *settings        = p_rarch->configuration_settings;
 
    switch(state)
    {
@@ -36193,7 +36129,7 @@ bool rarch_ctl(enum rarch_ctl_state state, void *data)
 #ifdef HAVE_NETWORKGAMEPAD
          if (p_rarch->input_driver_remote)
             input_remote_free(p_rarch->input_driver_remote,
-                  p_rarch->input_driver_max_users);
+                  settings->uints.input_max_users);
          p_rarch->input_driver_remote = NULL;
 #endif
          input_mapper_reset(&p_rarch->input_driver_mapper);
@@ -37209,10 +37145,10 @@ static void runloop_apply_fastmotion_override(
             p_runloop->fastmotion_override.current.fastforward;
 
       if (p_runloop->fastmotion)
-         p_rarch->input_driver_nonblock_state = true;
+         input_driver_set_nonblocking(&p_rarch->input_driver_state, true);
       else
       {
-         p_rarch->input_driver_nonblock_state = false;
+         input_driver_set_nonblocking(&p_rarch->input_driver_state, false);
          p_rarch->fastforward_after_frames    = 1;
       }
 
@@ -37253,6 +37189,8 @@ static enum runloop_state runloop_check_state(
 #ifdef HAVE_MENU
    static input_bits_t last_input      = {{0}};
 #endif
+   input_driver_state_t *input_driver_st = &(p_rarch->input_driver_state);
+
    static bool old_focus               = true;
    struct retro_callbacks *cbs         = &p_rarch->retro_ctx;
    bool is_focused                     = false;
@@ -37309,7 +37247,7 @@ static enum runloop_state runloop_check_state(
       rarch_joypad_info_t joypad_info;
       unsigned port                                = 0;
       int input_hotkey_block_delay                 = settings->uints.input_hotkey_block_delay;
-      input_driver_t *current_input                = p_rarch->current_input;
+      input_driver_t *current_input                = p_rarch->input_driver_state.current_driver;
       const struct retro_keybind *binds_norm       = &input_config_binds[port][RARCH_ENABLE_HOTKEY];
       const struct retro_keybind *binds_auto       = &input_autoconf_binds[port][RARCH_ENABLE_HOTKEY];
       const struct retro_keybind *binds            = input_config_binds[port];
@@ -37322,7 +37260,7 @@ static enum runloop_state runloop_check_state(
 #endif
 #ifdef HAVE_MFI
    const input_device_driver_t
-      *sec_joypad                                  = p_rarch->sec_joypad;
+      *sec_joypad                                  = input_driver_st->secondary_joypad;
 #else
    const input_device_driver_t
       *sec_joypad                                  = NULL;
@@ -37330,7 +37268,7 @@ static enum runloop_state runloop_check_state(
 
       joypad_info.joy_idx                          = settings->uints.input_joypad_index[port];
       joypad_info.auto_binds                       = input_autoconf_binds[joypad_info.joy_idx];
-      joypad_info.axis_threshold                   = p_rarch->input_driver_axis_threshold;
+      joypad_info.axis_threshold                   = settings->floats.input_axis_threshold;
 
 #ifdef HAVE_MENU
       if (menu_input_active)
@@ -37427,8 +37365,8 @@ static enum runloop_state runloop_check_state(
             for (i = 0; i < ARRAY_SIZE(ids); i++)
             {
                if (current_input->input_state(
-                        p_rarch->current_input_data,
-                        p_rarch->joypad,
+                        p_rarch->input_driver_state.current_data,
+                        input_driver_st->primary_joypad,
                         sec_joypad,
                         &joypad_info, &binds,
                         p_rarch->keyboard_mapping_blocked,
@@ -38190,9 +38128,9 @@ static enum runloop_state runloop_check_state(
 
       if (check2)
       {
-         bool check1                          = p_rarch->input_driver_nonblock_state;
-         p_rarch->input_driver_nonblock_state = !check1;
-         runloop_state.fastmotion             = !check1;
+         bool check1 = input_driver_get_nonblocking(input_driver_st);
+         input_driver_set_nonblocking(input_driver_st, !check1);
+         runloop_state.fastmotion = !check1;
          if (check1)
             p_rarch->fastforward_after_frames = 1;
 
@@ -38471,10 +38409,11 @@ int runloop_iterate(void)
    unsigned i;
    enum analog_dpad_mode dpad_mode[MAX_USERS];
    struct rarch_state                  *p_rarch = &rarch_st;
+   input_driver_state_t        *input_driver_st = &(p_rarch->input_driver_state);
    settings_t *settings                         = p_rarch->configuration_settings;
    unsigned video_frame_delay                   = settings->uints.video_frame_delay;
    bool vrr_runloop_enable                      = settings->bools.vrr_runloop_enable;
-   unsigned max_users                           = p_rarch->input_driver_max_users;
+   unsigned max_users                           = settings->uints.input_max_users;
    retro_time_t current_time                    = cpu_features_get_time_usec();
 #ifdef HAVE_MENU
    bool menu_pause_libretro                     = settings->bools.menu_pause_libretro;
@@ -38508,7 +38447,7 @@ int runloop_iterate(void)
       retro_usec_t runloop_last_frame_time = runloop_state.frame_time_last;
       retro_time_t current                 = current_time;
       bool is_locked_fps                   = (runloop_state.paused
-            || p_rarch->input_driver_nonblock_state)
+            || input_driver_st->nonblocking_flag)
             | !!p_rarch->recording_data;
       retro_time_t delta                   = (!runloop_last_frame_time || is_locked_fps)
          ? runloop_state.frame_time.reference
@@ -38699,7 +38638,7 @@ int runloop_iterate(void)
       }
    }
 
-   if ((video_frame_delay > 0) && !p_rarch->input_driver_nonblock_state)
+   if ((video_frame_delay > 0) && !input_driver_get_nonblocking(input_driver_st))
       retro_sleep(video_frame_delay);
 
    {
@@ -40092,3 +40031,4 @@ enum retro_language frontend_driver_get_user_language(void)
       return RETRO_LANGUAGE_ENGLISH;
    return frontend->get_user_language();
 }
+

--- a/retroarch.h
+++ b/retroarch.h
@@ -44,6 +44,9 @@
 #include "core_type.h"
 #include "core.h"
 
+#include "input/input_driver.h"
+#include "input/input_types.h"
+
 #ifdef HAVE_MENU
 #include "menu/menu_defines.h"
 #endif
@@ -786,9 +789,6 @@ void recording_driver_update_streaming_url(void);
 
 #include "gfx/video_defines.h"
 #include "gfx/video_coord_array.h"
-
-#include "input/input_driver.h"
-#include "input/input_types.h"
 
 #define RARCH_SCALE_BASE 256
 
@@ -2011,14 +2011,39 @@ unsigned int retroarch_get_rotation(void);
 
 void retroarch_init_task_queue(void);
 
+/******************************************************************************
+ * BEGIN helper functions for input_driver refactoring
+ * 
+ * These functions have similar names and signatures to functions that now require
+ * an input_driver_state_t pointer to be passed to them. They essentially wrap
+ * the newer functions by grabbing pointer to the driver state struct and the
+ * settings struct.
+ ******************************************************************************/
+bool input_set_rumble_state(unsigned port,
+      enum retro_rumble_effect effect, uint16_t strength);
+
+float input_get_sensor_state(unsigned port, unsigned id);
+
+bool input_set_sensor_state(unsigned port,
+      enum retro_sensor_action action, unsigned rate);
+
+void input_set_nonblock_state(void);
+
+void input_unset_nonblock_state(void);
+
+void *input_driver_get_data(void);
+
+/******************************************************************************
+ * END helper functions for input_driver refactoring
+ ******************************************************************************/
+
+
 bool input_key_pressed(int key, bool keyboard_pressed);
 
 bool input_mouse_grabbed(void);
 
 const char *joypad_driver_name(unsigned i);
 void joypad_driver_reinit(void *data, const char *joypad_driver_name);
-
-void input_driver_init_joypads(void);
 
 void *input_driver_init_wrap(input_driver_t *input, const char *name);
 

--- a/retroarch_data.h
+++ b/retroarch_data.h
@@ -802,256 +802,6 @@ static const gfx_ctx_driver_t *gfx_ctx_gl_drivers[] = {
    NULL
 };
 
-static void *input_null_init(const char *joypad_driver) { return (void*)-1; }
-static void input_null_poll(void *data) { }
-static int16_t input_null_input_state(
-      void *data,
-      const input_device_driver_t *joypad,
-      const input_device_driver_t *sec_joypad,
-      rarch_joypad_info_t *joypad_info,
-      const struct retro_keybind **retro_keybinds,
-      bool keyboard_mapping_blocked,
-      unsigned port, unsigned device, unsigned index, unsigned id) { return 0; }
-static void input_null_free(void *data) { }
-static bool input_null_set_sensor_state(void *data, unsigned port,
-         enum retro_sensor_action action, unsigned rate) { return false; }
-static float input_null_get_sensor_input(void *data, unsigned port, unsigned id) { return 0.0; }
-static uint64_t input_null_get_capabilities(void *data) { return 0; }
-static void input_null_grab_mouse(void *data, bool state) { }
-static bool input_null_grab_stdin(void *data) { return false; }
-
-static input_driver_t input_null = {
-   input_null_init,
-   input_null_poll,
-   input_null_input_state,
-   input_null_free,
-   input_null_set_sensor_state,
-   input_null_get_sensor_input,
-   input_null_get_capabilities,
-   "null",
-   input_null_grab_mouse,
-   input_null_grab_stdin
-};
-
-static input_driver_t *input_drivers[] = {
-#ifdef ORBIS
-   &input_ps4,
-#endif
-#if defined(__PSL1GHT__) || defined(__PS3__)
-   &input_ps3,
-#endif
-#if defined(SN_TARGET_PSP2) || defined(PSP) || defined(VITA)
-   &input_psp,
-#endif
-#if defined(PS2)
-   &input_ps2,
-#endif
-#if defined(_3DS)
-   &input_ctr,
-#endif
-#if defined(SWITCH)
-   &input_switch,
-#endif
-#if defined(HAVE_SDL) || defined(HAVE_SDL2)
-   &input_sdl,
-#endif
-#if defined(DINGUX) && defined(HAVE_SDL_DINGUX)
-   &input_sdl_dingux,
-#endif
-#ifdef HAVE_DINPUT
-   &input_dinput,
-#endif
-#ifdef HAVE_X11
-   &input_x,
-#endif
-#ifdef __WINRT__
-   &input_uwp,
-#endif
-#ifdef XENON
-   &input_xenon360,
-#endif
-#if defined(HAVE_XINPUT2) || defined(HAVE_XINPUT_XBOX1) || defined(__WINRT__)
-   &input_xinput,
-#endif
-#ifdef GEKKO
-   &input_gx,
-#endif
-#ifdef WIIU
-   &input_wiiu,
-#endif
-#ifdef ANDROID
-   &input_android,
-#endif
-#ifdef HAVE_UDEV
-   &input_udev,
-#endif
-#if defined(__linux__) && !defined(ANDROID)
-   &input_linuxraw,
-#endif
-#if defined(HAVE_COCOA) || defined(HAVE_COCOATOUCH) || defined(HAVE_COCOA_METAL)
-   &input_cocoa,
-#endif
-#ifdef __QNX__
-   &input_qnx,
-#endif
-#ifdef EMSCRIPTEN
-   &input_rwebinput,
-#endif
-#ifdef DJGPP
-   &input_dos,
-#endif
-#if defined(_WIN32) && !defined(_XBOX) && _WIN32_WINNT >= 0x0501 && !defined(__WINRT__)
-#ifdef HAVE_WINRAWINPUT
-   /* winraw only available since XP */
-   &input_winraw,
-#endif
-#endif
-   &input_null,
-   NULL,
-};
-
-static input_device_driver_t null_joypad = {
-   NULL, /* init */
-   NULL, /* query_pad */
-   NULL, /* destroy */
-   NULL, /* button */
-   NULL, /* state */
-   NULL, /* get_buttons */
-   NULL, /* axis */
-   NULL, /* poll */
-   NULL,
-   NULL, /* name */
-   "null",
-};
-
-static input_device_driver_t *joypad_drivers[] = {
-#ifdef HAVE_XINPUT
-   &xinput_joypad,
-#endif
-#ifdef GEKKO
-   &gx_joypad,
-#endif
-#ifdef WIIU
-   &wiiu_joypad,
-#endif
-#ifdef _XBOX1
-   &xdk_joypad,
-#endif
-#if defined(ORBIS)
-   &ps4_joypad,
-#endif
-#if defined(__PSL1GHT__) || defined(__PS3__)
-   &ps3_joypad,
-#endif
-#if defined(PSP) || defined(VITA)
-   &psp_joypad,
-#endif
-#if defined(PS2)
-   &ps2_joypad,
-#endif
-#ifdef _3DS
-   &ctr_joypad,
-#endif
-#ifdef SWITCH
-   &switch_joypad,
-#endif
-#ifdef HAVE_DINPUT
-   &dinput_joypad,
-#endif
-#ifdef HAVE_UDEV
-   &udev_joypad,
-#endif
-#if defined(__linux) && !defined(ANDROID)
-   &linuxraw_joypad,
-#endif
-#ifdef HAVE_PARPORT
-   &parport_joypad,
-#endif
-#ifdef ANDROID
-   &android_joypad,
-#endif
-#if defined(HAVE_SDL) || defined(HAVE_SDL2)
-   &sdl_joypad,
-#endif
-#if defined(DINGUX) && defined(HAVE_SDL_DINGUX)
-   &sdl_dingux_joypad,
-#endif
-#ifdef __QNX__
-   &qnx_joypad,
-#endif
-#ifdef HAVE_MFI
-   &mfi_joypad,
-#endif
-#ifdef DJGPP
-   &dos_joypad,
-#endif
-/* Selecting the HID gamepad driver disables the Wii U gamepad. So while
- * we want the HID code to be compiled & linked, we don't want the driver
- * to be selectable in the UI. */
-#if defined(HAVE_HID) && !defined(WIIU)
-   &hid_joypad,
-#endif
-#ifdef EMSCRIPTEN
-   &rwebpad_joypad,
-#endif
-   &null_joypad,
-   NULL,
-};
-
-#ifdef HAVE_HID
-static bool null_hid_joypad_query(void *data, unsigned pad) {
-   return pad < MAX_USERS; }
-static const char *null_hid_joypad_name(
-      void *data, unsigned pad) { return NULL; }
-static void null_hid_joypad_get_buttons(void *data,
-      unsigned port, input_bits_t *state) { BIT256_CLEAR_ALL_PTR(state); }
-static int16_t null_hid_joypad_button(
-      void *data, unsigned port, uint16_t joykey) { return 0; }
-static bool null_hid_joypad_rumble(void *data, unsigned pad,
-      enum retro_rumble_effect effect, uint16_t strength) { return false; }
-static int16_t null_hid_joypad_axis(
-      void *data, unsigned port, uint32_t joyaxis) { return 0; }
-static void *null_hid_init(void) { return (void*)-1; }
-static void null_hid_free(const void *data) { }
-static void null_hid_poll(void *data) { }
-static int16_t null_hid_joypad_state(
-      void *data,
-      rarch_joypad_info_t *joypad_info,
-      const void *binds_data,
-      unsigned port) { return 0; }
-
-static hid_driver_t null_hid = {
-   null_hid_init,               /* init */
-   null_hid_joypad_query,       /* joypad_query */
-   null_hid_free,               /* free */
-   null_hid_joypad_button,      /* button */
-   null_hid_joypad_state,       /* state */
-   null_hid_joypad_get_buttons, /* get_buttons */
-   null_hid_joypad_axis,        /* axis */
-   null_hid_poll,               /* poll */
-   null_hid_joypad_rumble,      /* rumble */
-   null_hid_joypad_name,        /* joypad_name */
-   "null",
-};
-
-static hid_driver_t *hid_drivers[] = {
-#if defined(HAVE_BTSTACK)
-   &btstack_hid,
-#endif
-#if defined(__APPLE__) && defined(HAVE_IOHIDMANAGER)
-   &iohidmanager_hid,
-#endif
-#if defined(HAVE_LIBUSB) && defined(HAVE_THREADS)
-   &libusb_hid,
-#endif
-#ifdef HW_RVL
-   &wiiusb_hid,
-#endif
-   &null_hid,
-   NULL,
-};
-#endif
-
 static bluetooth_driver_t bluetooth_null = {
    NULL, /* init */
    NULL, /* free */
@@ -1747,6 +1497,8 @@ typedef struct runloop runloop_state_t;
 
 struct rarch_state
 {
+   input_driver_state_t input_driver_state;
+
    double audio_source_ratio_original;
    double audio_source_ratio_current;
    struct retro_system_av_info video_driver_av_info; /* double alignment */
@@ -1905,8 +1657,6 @@ struct rarch_state
 #ifdef HAVE_NETWORKGAMEPAD
    input_remote_t *input_driver_remote;
 #endif
-   input_driver_t *current_input;
-   void *current_input_data;
 
 #ifdef HAVE_HID
    const void *hid_data;
@@ -1949,10 +1699,6 @@ struct rarch_state
    midi_event_t midi_drv_output_event;                   /* ptr alignment */
    core_info_state_t core_info_st;                       /* ptr alignment */
    struct retro_hw_render_callback hw_render;            /* ptr alignment */
-   const input_device_driver_t *joypad;                  /* ptr alignment */
-#ifdef HAVE_MFI
-   const input_device_driver_t *sec_joypad;              /* ptr alignment */
-#endif
 #ifdef HAVE_BSV_MOVIE
    bsv_movie_t     *bsv_movie_state_handle;              /* ptr alignment */
 #endif
@@ -2078,7 +1824,6 @@ struct rarch_state
    unsigned osk_last_codepoint;
    unsigned osk_last_codepoint_len;
    unsigned input_driver_flushing_input;
-   unsigned input_driver_max_users;
    unsigned input_hotkey_block_counter;
 #ifdef HAVE_ACCESSIBILITY
    unsigned gamepad_input_override;
@@ -2103,8 +1848,6 @@ struct rarch_state
    float audio_driver_rate_control_delta;
    float audio_driver_input;
    float audio_driver_volume_gain;
-
-   float input_driver_axis_threshold;
 
    enum osk_type osk_idx;
    enum rarch_core_type current_core_type;
@@ -2317,7 +2060,6 @@ struct rarch_state
 
    bool input_driver_block_hotkey;
    bool input_driver_block_libretro_input;
-   bool input_driver_nonblock_state;
    bool input_driver_grab_mouse_state;
    bool input_driver_analog_requested[MAX_USERS];
 

--- a/ui/drivers/qt/qt_options.cpp
+++ b/ui/drivers/qt/qt_options.cpp
@@ -264,7 +264,8 @@ UserBindsPage::UserBindsPage(QObject *parent) :
 QWidget *UserBindsPage::widget()
 {
    unsigned p, retro_id;
-   unsigned max_users    = *(input_driver_get_uint(INPUT_ACTION_MAX_USERS));
+   settings_t *settings      = config_get_ptr();
+   unsigned max_users    = settings->uints.input_max_users;
    QWidget *widget       = new QWidget;
    QGridLayout *layout   = new QGridLayout;
    QComboBox *userCombo  = new QComboBox;


### PR DESCRIPTION
This PR addresses the issues specific to input_driver which arose from trying to merge the previous iteration of the patch here: https://github.com/libretro/RetroArch/pull/12703

Specifically, the PR now:
 * Uses the correct relative paths to includes in the root folder like `retroarch.h` and `verbosity.h`
 * Adds `input_autodetect_builtin.c` to `griffin.c`, a MSVC buildfix pointed out by @schellingb
 * Provides a transitional `void *input_driver_get_data(void)` for the remaining functions that use it

I'm not sure how I missed those remaining `input_driver_get_data()` calls in the apple codepaths, but eliminating that function completely is a goal of this effort. I've looked at where it is used, and eliminating it will require some refactoring of the joypad driver code. There are other joypad drivers which need the same refactoring to access that struct, but they grab its pointer in more sneaky ways.

That will need to be in a follow-up PR though, the scope of this is large already in my opinion! 🤪 