### PR TITLE
Fix RETRO_ENVIRONMENT_SET_FASTFORWARDING_OVERRIDE callback when runahead is enabled

### DIFF
--- a/retroarch_data.h
+++ b/retroarch_data.h
@@ -1682,6 +1682,16 @@ typedef struct core_options_callbacks
    retro_core_options_update_display_callback_t update_display;
 } core_options_callbacks_t;
 
+/* Contains the current retro_fastforwarding_override
+ * parameters along with any pending updates triggered
+ * by RETRO_ENVIRONMENT_SET_FASTFORWARDING_OVERRIDE */
+typedef struct fastmotion_overrides
+{
+   struct retro_fastforwarding_override current;
+   struct retro_fastforwarding_override next;
+   bool pending;
+} fastmotion_overrides_t;
+
 struct runloop
 {
    retro_usec_t frame_time_last;        /* int64_t alignment */
@@ -1705,7 +1715,7 @@ struct runloop
    unsigned max_frames;
    unsigned audio_latency;
 
-   struct retro_fastforwarding_override fastmotion_override; /* float alignment */
+   fastmotion_overrides_t fastmotion_override; /* float alignment */
 
    bool missing_bios;
    bool force_nonblock;

--- a/retroarch_fwd_decls.h
+++ b/retroarch_fwd_decls.h
@@ -70,6 +70,9 @@ static void retro_frame_null(const void *data, unsigned width,
       unsigned height, size_t pitch);
 static void retro_run_null(void);
 static void retro_input_poll_null(void);
+static void runloop_apply_fastmotion_override(
+      struct rarch_state *p_rarch, runloop_state_t *p_runloop,
+      settings_t *settings);
 
 static uint64_t input_driver_get_capabilities(void);
 


### PR DESCRIPTION
## Description

As described in https://github.com/libretro/gambatte-libretro/issues/197, the `RETRO_ENVIRONMENT_SET_FASTFORWARDING_OVERRIDE` callback fails when runahead is enabled - more specifically, it is impossible for a core to turn fast forward on via the callback when using either single or second instance runahead.

This error occurs as follows: Due to the way runahead is implemented, the `RETRO_ENVIRONMENT_SET_FASTFORWARDING_OVERRIDE` callback always ends up being used by the core while video output is disabled; when video is disabled, any attempt to put the video driver in a non-blocking state silently fails - so RetroArch ends up in a broken half-state where it thinks it's fast-forwarding but the video driver remains blocking with VSYNC enabled.

This PR redesigns the `RETRO_ENVIRONMENT_SET_FASTFORWARDING_OVERRIDE` callback implementation such that using it enqueues a request to set an override, with the actual application occurring in `runloop_check_state()` in the same place that regular fast forward hotkeys are handled. This ensures correct operation of the callback in all cases.

## Related Issues

Closes https://github.com/libretro/gambatte-libretro/issues/197