### PR TITLE
udev_input.c: Look for "ID_INPUT_KEY", not "ID_INPUT_KEYBOARD"

### DIFF
--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -96,7 +96,7 @@ enum udev_input_dev_type
 /* NOTE: must be in sync with enum udev_input_dev_type */
 static const char *g_dev_type_str[] =
 {
-   "ID_INPUT_KEYBOARD",
+   "ID_INPUT_KEY",
    "ID_INPUT_MOUSE",
    "ID_INPUT_TOUCHPAD"
 };


### PR DESCRIPTION
## Description

This fixes programs using /dev/uinput to create a virtual keyboard failing to be detected on startup. Usual symptom is some sort of GPIO-based controller on a Raspberry Pi that looks like a keyboard to the OS and can control EmulationStation, but fails to work in-game unless you restart the controller's program while the game is running (in which case udev_input.c's hotplug code, which was using the correct string, would pick it up).

The gist is that udev lists the device's type as `ID_INPUT_KEY`, but the initial udev query from RetroArch looks for `ID_INPUT_KEYBOARD` ... I seem to recall that udev (or Python's uinput module) _used_ to export both of these strings, but I could be misremembering. It definitely isn't now.

The hotplug code in RetroArch looks for the correct string already, which is why restarting the controller program while the game is running fixes things. This PR just makes initial detection use the same string.

udevadm reports my virtual keyboard as such:

```
P: /devices/virtual/input/input3
L: 0
E: DEVPATH=/devices/virtual/input/input3
E: SUBSYSTEM=input
E: PRODUCT=3/1/1/1
E: NAME="retrogame"
E: PHYS="py-evdev-uinput"
E: PROP=0
E: EV=200003
E: KEY=1680 0 3000400 30000000
E: FF=0
E: MODALIAS=input:b0003v0001p0001e0001-e0,1,15,kramlsfw
E: USEC_INITIALIZED=1677443599
E: ID_INPUT=1
E: ID_INPUT_KEY=1
E: TAGS=:seat:
```

I don't know what changed recently to cause this; I set up [an AdaFruit joy bonnet](https://learn.adafruit.com/adafruit-joy-bonnet-for-raspberry-pi/overview) on a Pi Zero W a few months ago with the latest RetroPie image at the time and did _not_ have this problem. It's possible that the Python uinput module changed, or something about udev on the underlying Raspberry Pi OS changed, I don't know.

## Related Issues

This is likely the root of the problem in https://github.com/libretro/RetroArch/issues/4780 and https://github.com/libretro/RetroArch/issues/5033, and over in https://github.com/RetroPie/RetroPie-Setup/issues/1936, and probably several other issues with sentiments like "input works in EmulationStation but not when I start a game."

