### PR TITLE
(Ozone) Ensure the existence of values used in selection calculation

### DIFF
--- a/menu/drivers/ozone/ozone_entries.c
+++ b/menu/drivers/ozone/ozone_entries.c
@@ -265,6 +265,9 @@ void ozone_update_scroll(ozone_handle_t *ozone, bool allow_animation, ozone_node
 
    video_driver_get_size(NULL, &video_info_height);
 
+   if (!node)
+      return;
+
    current_selection_middle_onscreen    =
       ozone->dimensions.header_height +
       ozone->dimensions.entry_padding_vertical +


### PR DESCRIPTION
## Description

Calculations without proper values leads to crash in certain situations, such as when automatically changed refresh rate is restored on Close Content, depending on `menu_scale_factor` and that the core is launched with "Start Core", not via playlist.


## Related Pull Requests

Revealed by #12795 

