### PR TITLE
Fix refresh rate 59Hz rounding

### DIFF
--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -6207,7 +6207,16 @@ int action_cb_push_dropdown_item_resolution(const char *path,
    {
       settings_t *settings = config_get_ptr();
 
-      video_monitor_set_refresh_rate((float)refreshrate);
+      unsigned refresh_mod = round(refreshrate / 60.0f);
+      float refresh_exact  = refreshrate;
+
+      /* 59 Hz is an inaccurate representation of the real value (59.94).
+       * And since we at this point only have the integer to work with,
+       * the exact float needs to be calculated for 'video_refresh_rate' */
+      if (refreshrate == (60.0f * refresh_mod) - 1)
+         refresh_exact = 59.94f * refresh_mod;
+
+      video_monitor_set_refresh_rate(refresh_exact);
 
       settings->uints.video_fullscreen_x = width;
       settings->uints.video_fullscreen_y = height;


### PR DESCRIPTION
## Description

Currently the "Screen Resolution" list wrongly alters also `video_refresh_rate` to the rounded value, as in 59.940 Hz becomes 59.000.

This change makes sure all the 59.94 multiples (59/119 etc) result in the proper float value instead of integer.  


## Related Issues

Closes #11066
