### PR TITLE
(WINRAW) Add missing analog keybinds

### DIFF
--- a/input/drivers/winraw_input.c
+++ b/input/drivers/winraw_input.c
@@ -771,6 +771,35 @@ static int16_t winraw_input_state(
          }
          break;
       case RETRO_DEVICE_ANALOG:
+         if (binds[port])
+         {
+            int id_minus_key      = 0;
+            int id_plus_key       = 0;
+            unsigned id_minus     = 0;
+            unsigned id_plus      = 0;
+            int16_t ret           = 0;
+            bool id_plus_valid    = false;
+            bool id_minus_valid   = false;
+
+            input_conv_analog_id_to_bind_id(idx, id, id_minus, id_plus);
+
+            id_minus_valid        = binds[port][id_minus].valid;
+            id_plus_valid         = binds[port][id_plus].valid;
+            id_minus_key          = binds[port][id_minus].key;
+            id_plus_key           = binds[port][id_plus].key;
+
+            if (id_plus_valid && id_plus_key < RETROK_LAST)
+            {
+               if (WINRAW_KEYBOARD_PRESSED(wr, id_plus_key))
+                  ret = 0x7fff;
+            }
+            if (id_minus_valid && id_minus_key < RETROK_LAST)
+            {
+               if (WINRAW_KEYBOARD_PRESSED(wr, id_minus_key))
+                  ret += -0x7fff;
+            }
+            return ret;
+         }
          break;
       case RETRO_DEVICE_KEYBOARD:
          return (id < RETROK_LAST) && WINRAW_KEYBOARD_PRESSED(wr, id);


### PR DESCRIPTION
## Description

More copypasta from dinput, this time enabling the use of keyboard for analog sticks. For some reason the case was empty.
