### PR TITLE
Fixed web player bug with filesystem and runtime

### DIFF
--- a/pkg/emscripten/libretro/libretro.js
+++ b/pkg/emscripten/libretro/libretro.js
@@ -5,6 +5,7 @@
  */
 var BrowserFS = BrowserFS;
 var afs;
+var initializationCount = 0;
 
 function cleanupStorage()
 {
@@ -42,7 +43,7 @@ function idbfsInit()
             afs = new BrowserFS.FileSystem.InMemory();
             console.log("WEBPLAYER: error: " + e + " falling back to in-memory filesystem");
             setupFileSystem("browser");
-            preLoadingComplete();
+            appInitialized();
          }
          else
          {
@@ -54,7 +55,7 @@ function idbfsInit()
                   afs = new BrowserFS.FileSystem.InMemory();
                   console.log("WEBPLAYER: error: " + e + " falling back to in-memory filesystem");
                   setupFileSystem("browser");
-                  preLoadingComplete();
+                  appInitialized();
                }
                else
                {
@@ -74,8 +75,19 @@ function idbfsSyncComplete()
    console.log("WEBPLAYER: idbfs setup successful");
 
    setupFileSystem("browser");
-   preLoadingComplete();
+   appInitialized();
 }
+
+function appInitialized()
+{
+     /* Need to wait for both the file system and the wasm runtime 
+        to complete before enabling the Run button. */
+     initializationCount++;
+     if (initializationCount == 2)
+     {
+         preLoadingComplete();
+     }
+ }
 
 function preLoadingComplete()
 {
@@ -184,6 +196,10 @@ var Module =
   arguments: ["-v", "--menu"],
   preRun: [],
   postRun: [],
+  onRuntimeInitialized: function()
+  {
+     appInitialized();
+  }, 
   print: function(text)
   {
      console.log(text);


### PR DESCRIPTION
## Description

This fixes a bug with the web player where sometimes it would fail after you click the Run button and a JavaScript error is displayed in the console. This was happening because we need to wait for both the web assembly runtime and the file system to finish initializing before allowing the user to click Run. Example of such error in this screenshot -

![retroarch_bug](https://user-images.githubusercontent.com/10982154/130374771-35ea7f16-e936-4a1f-a29a-c56c6823454f.JPG)

## Related Issues

This may also fix this issue but I'm not 100% sure - https://github.com/libretro/RetroArch/issues/9230

