### PR TITLE
Remove core path from core info cache

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -9726,11 +9726,6 @@ static bool setting_append_list(
 #endif
             for (i = 0; i < ARRAY_SIZE(bool_entries); i++)
             {
-#if defined(IOS)
-               if (bool_entries[i].name_enum_idx ==
-                     MENU_ENUM_LABEL_CORE_INFO_CACHE_ENABLE)
-                  continue;
-#endif
                CONFIG_BOOL(
                      list, list_info,
                      bool_entries[i].target,


### PR DESCRIPTION
## Description

As described in #12697, the core info cache stores absolute core paths, which breaks portability (i.e. if the cache is enabled and the core directory is moved, cores can no longer be loaded).

In truth, it is a mistake to cache the core path in the first place, since this is already retrieved from the filesystem regardless of whether the cache is enabled. This PR therefore removes core paths from the info cache, so the correct (dynamically determined) path is always used.

## Related Issues

Closes #12697

## Related Pull Requests

This reverts #12431, since the issue addressed there is no longer valid

