### PR TITLE
(Qt) Fix segfault when accessing Video Options menu on non-Windows platforms

### DIFF
--- a/ui/drivers/qt/qt_options.cpp
+++ b/ui/drivers/qt/qt_options.cpp
@@ -1228,7 +1228,11 @@ QWidget *VideoPage::widget()
    QHBoxLayout *windowedCustomSizeLayout   = new QHBoxLayout;
    FormLayout *leftWindowedCustomSizeForm  = new FormLayout;
    FormLayout *rightWindowedCustomSizeForm = new FormLayout;
+#if defined(_WIN32) && !defined(_XBOX) && !defined(__WINRT__)
    CheckableSettingsGroup *savePosGroup    = new CheckableSettingsGroup(MENU_ENUM_LABEL_VIDEO_WINDOW_SAVE_POSITION);
+#else
+   CheckableSettingsGroup *savePosGroup    = new CheckableSettingsGroup(MENU_ENUM_LABEL_VIDEO_WINDOW_CUSTOM_SIZE_ENABLE);
+#endif
 
    SettingsGroup *syncGroup            = new SettingsGroup("Synchronization");
    CheckableSettingsGroup *vSyncGroup  = new CheckableSettingsGroup(MENU_ENUM_LABEL_VIDEO_VSYNC);


### PR DESCRIPTION
## Description

#12809 causes a segfault when attempting to access the Video Options menu of the Qt interface on non-Windows platforms. This trivial PR fixes the issue.

