### PR TITLE
Default aspect ratio + sublabel correction

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -66,7 +66,7 @@
 #elif defined(_XBOX1) || defined(GEKKO) || defined(ANDROID)
 #define DEFAULT_ASPECT_RATIO 1.3333f
 #else
-#define DEFAULT_ASPECT_RATIO -1.0f
+#define DEFAULT_ASPECT_RATIO 1.3333f
 #endif
 
 #if defined(GEKKO)

--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -1691,7 +1691,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_VIDEO_ASPECT_RATIO,
-   "Floating point value for video aspect ratio (width / height), used if the Aspect Ratio is set to 'Custom Aspect Ratio'."
+   "Floating point value for video aspect ratio (width / height), used if 'Aspect Ratio' is set to 'Config'."
    )
 #if defined(DINGUX)
 MSG_HASH(

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -11169,7 +11169,7 @@ static bool setting_append_list(
                   &settings->floats.video_aspect_ratio,
                   MENU_ENUM_LABEL_VIDEO_ASPECT_RATIO,
                   MENU_ENUM_LABEL_VALUE_VIDEO_ASPECT_RATIO,
-                  1.33,
+                  DEFAULT_ASPECT_RATIO,
                   "%.2f",
                   &group_info,
                   &subgroup_info,


### PR DESCRIPTION
## Description

The current clean config value of `-1` makes no sense in practice, therefore reseted the config default to the option reset default.

Also corrected the sublabel to match actual behavior, as in when the option is visible and used.
