### PR TITLE
(WINRAW) Fix crash when overlay is enabled

### DIFF
--- a/input/drivers/winraw_input.c
+++ b/input/drivers/winraw_input.c
@@ -876,9 +876,12 @@ static int16_t winraw_input_state(
             if (!check_pos && idx > 0) /* idx = 0 has mouse fallback. */
                return 0;
 
-            x               = mouse->x;
-            y               = mouse->y;
-            pointer_down    = mouse->btn_l;
+            if (mouse)
+            {
+               x            = mouse->x;
+               y            = mouse->y;
+               pointer_down = mouse->btn_l;
+            }
 
             if (check_pos)
             {


### PR DESCRIPTION
## Description

Whoops, the pointer copypasta requires a bit of checking, because otherwise raw crashes with overlays.

