### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -61,7 +61,8 @@ representative at an online or offline event.
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at:
 
- * Via E-Mail to <libretro@gmail.com>.
+ * Via E-Mail to <libretro@gmail.com>, please include in the subject line
+   `RETROARCH COC` so that your e-mail may reach the correct party.
 
 All complaints will be reviewed and investigated promptly and fairly.
 


### PR DESCRIPTION
## Description

Adds the Contributor Covenant Code of Conduct. Is the standard document with the contact information filled out, routing to: e-mail.

## Related Issues

None.

## Related Pull Requests

None.

## Reviewers

@twinaphex 
