### PR TITLE
Allow 'Custom Aspect Ratio (X Position)/(Y Position)/(Width)/(Height)' to be entered manually via keyboard

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -24537,6 +24537,10 @@ static int menu_input_pointer_post_iterate(
       /* If currently showing a message box, close it */
       if (messagebox_active)
          menu_input_pointer_close_messagebox(&p_rarch->menu_driver_state);
+      /* If onscreen keyboard is shown, send a 'backspace' */
+      else if (osk_active)
+         input_keyboard_event(true, '\x7f', '\x7f',
+               0, RETRO_DEVICE_KEYBOARD);
       /* ...otherwise, invoke standard MENU_ACTION_CANCEL
        * action */
       else


### PR DESCRIPTION
## Description

This is a small follow-up to the discussion in #12859.

At present, selecting any of the `Custom Aspect Ratio (X Position)/(Y Position)/(Width)/(Height)` options opens a drop-down list of values. Setting these parameters via a list is highly cumbersome and user-unfriendly. In addition, these drop-down lists can take many seconds to open on the weakest platforms, due to the huge numbers of entries they contain.

This PR modifies the `Custom Aspect Ratio` options such that when they are selected, a new value can be entered via the OSK or physical keyboard. I believe that this should be an improvement on all platforms, but if we find any where drop-down lists are preferable, they can easily be reinstated for said platform via a trivial `#ifdef`.

In addition, several bugs were fixed while implementing this functionality:

- Previously, the internal `aspectratio_lut[ASPECT_RATIO_CUSTOM].value` record *was not updated* whenever  `Custom Aspect Ratio` width/height were set via the drop-down lists. Now this is recalculated correctly regardless of how the width/height values are set.
- All unsigned/signed values entered via the keyboard are now sanitised (previously any garbage strings would be accepted - e.g. negative values could be entered for unsigned ints...)
- At present, pressing the second mouse button while the OSK is open sends a menu 'cancel' (back) event. This is drastically incorrect - going back a level in the menu while the OSK is displayed can potentially break everything... It seems this issue has existed for a very long time - but with this PR, pressing the second mouse button while the OSK is open now sends a proper keyboard 'backspace' event (with no changes to the menu)