### PR TITLE
Fix overlay input when analog to digital mapping is enabled

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -22037,7 +22037,7 @@ static void input_driver_poll(void)
             p_rarch->overlay_ptr,
             input_overlay_opacity,
             input_analog_dpad_mode,
-            settings->floats.input_analog_deadzone);
+            settings->floats.input_axis_threshold);
    }
 #endif
 


### PR DESCRIPTION
## Description

A typo in #12823 broke input when overlays and analog to digital mapping are enabled, as described here: https://forums.libretro.com/t/overlay-d-pad-stuck/34711

This trivial PR fixes the issue.
