### PR TITLE
Don't stop/start audio when menu toggling

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -35646,7 +35646,11 @@ static void menu_driver_toggle(
       command_event(CMD_EVENT_RUMBLE_STOP, NULL);
 
       if (pause_libretro && !audio_enable_menu)
-         command_event(CMD_EVENT_AUDIO_STOP, NULL);
+      {
+         /* TODO/FIXME - do we need to 'mute' the MIDI driver too? Stopping all
+          * MIDI sounds was done in CMD_EVENT_AUDIO_STOP */
+         p_rarch->audio_driver_mute_enable  = true;
+      }
 
 #if 0
      if (audio_enable_menu && audio_enable_menu_bgm)
@@ -35677,7 +35681,11 @@ static void menu_driver_toggle(
          driver_set_nonblock_state();
 
       if (pause_libretro && !audio_enable_menu)
-         command_event(CMD_EVENT_AUDIO_START, NULL);
+      {
+         /* TODO/FIXME - do we need to 'unmute' the MIDI driver too? 
+            Stopping all MIDI sounds was done in CMD_EVENT_AUDIO_STOP */
+         p_rarch->audio_driver_mute_enable  = false;
+      }
 
 #if 0
       if (audio_enable_menu && audio_enable_menu_bgm)


### PR DESCRIPTION
This is an initial implementation for the new behavior we had discussed -

Right now, RetroArch stops/starts the audio when menu toggling (IF 'Pause Content When Menu Is Active' is ON). 

This PR changes it so that instead it just mutes/unmutes the audio instead.

A couple of considerations:

- Do we actually want this? What is going to be more resource-intensive - stop/starting the audio or just keeping the audio processing running but just muting it? I think previously it was asumed (erroneously perhaps) the entire audio driver was deinitialized/initialized but this is actually not the case, the audio driver instead is just stopped/started. Each audio driver has its own start/stop callback implementations so you can see what the logic is like. But there is no actual tearing down/setting up of the audio driver going on. So, bottom line, I wonder if all the concern over this is actually well founded or if it turned out to be a red herring. I'd like your perspective/take on that @jdgleaver.
- If we do want to go through with this and we feel the advantages outweigh any possible drawbacks, we want to make sure we test it on platforms that are considered more fragile. 3DS, PSP, and game consoles like PS2 should all get a test.

Another couple of considerations:
- Do we want to mute the MIDI sounds too if a MIDI driver is active? I saw this being done in the CMD_EVENT_AUDIO_STOP command before.
- I've made it so that when the audio is muted/unmuted, it shouldn't actually affect the config file. So this won't be written back to the config file accidentally. However, we might want to check the edge case when we mute manually in the menu or turn audio on/off in the menu, and whether or not this impacts the muting/unmuting we're manually doing here.

Attempts to address #12892