### PR TITLE
Input robustness for threaded cores

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -478,8 +478,9 @@ static int16_t input_state_wrap(
    {
       if (id == RETRO_DEVICE_ID_JOYPAD_MASK)
       {
-         ret                       |= joypad->state(
-               joypad_info, binds[port], port);
+         if (joypad)
+            ret                    |= joypad->state(
+                  joypad_info, binds[port], port);
 #ifdef HAVE_MFI
          if (sec_joypad)
             ret                    |= sec_joypad->state(
@@ -504,27 +505,33 @@ static int16_t input_state_wrap(
             const uint32_t joyaxis         = (bind_joyaxis != AXIS_NONE)
                ? bind_joyaxis : autobind_joyaxis;
 
-            if ((uint16_t)joykey != NO_BTN && joypad->button(
-                     port, (uint16_t)joykey))
-               return 1;
-            if (joyaxis != AXIS_NONE &&
-                  ((float)abs(joypad->axis(port, joyaxis))
-                   / 0x8000) > axis_threshold)
-               return 1;
+            if (joypad)
+            {
+               if ((uint16_t)joykey != NO_BTN && joypad->button(
+                        port, (uint16_t)joykey))
+                  return 1;
+               if (joyaxis != AXIS_NONE &&
+                     ((float)abs(joypad->axis(port, joyaxis))
+                      / 0x8000) > axis_threshold)
+                  return 1;
+            }
 #ifdef HAVE_MFI
-            if ((uint16_t)joykey != NO_BTN && sec_joypad->button(
-                     port, (uint16_t)joykey))
-               return 1;
-            if (joyaxis != AXIS_NONE &&
-                  ((float)abs(sec_joypad->axis(port, joyaxis))
-                   / 0x8000) > axis_threshold)
-               return 1;
+            if (sec_joypad)
+            {
+               if ((uint16_t)joykey != NO_BTN && sec_joypad->button(
+                        port, (uint16_t)joykey))
+                  return 1;
+               if (joyaxis != AXIS_NONE &&
+                     ((float)abs(sec_joypad->axis(port, joyaxis))
+                      / 0x8000) > axis_threshold)
+                  return 1;
+            }
 #endif
          }
       }
    }
 
-   if (current_input->input_state)
+   if (current_input && current_input->input_state)
       ret |= current_input->input_state(
             data,
             joypad,

--- a/retroarch.c
+++ b/retroarch.c
@@ -22077,8 +22077,6 @@ static void input_driver_poll(void)
       bool poll_overlay                = (p_rarch->overlay_ptr && p_rarch->overlay_ptr->alive);
 #endif
       input_mapper_t *handle           = &p_rarch->input_driver_mapper;
-      const input_device_driver_t 
-         *joypad                       = input_driver_st->primary_joypad;
       float input_analog_deadzone      = settings->floats.input_analog_deadzone;
       float input_analog_sensitivity   = settings->floats.input_analog_sensitivity;
 
@@ -23099,63 +23097,67 @@ static int16_t menu_input_read_mouse_hw(
       struct rarch_state *p_rarch,
       enum menu_input_mouse_hw_id id)
 {
-   rarch_joypad_info_t joypad_info;
-   unsigned type                          = 0;
-   unsigned device                        = RETRO_DEVICE_MOUSE;
    input_driver_state_t *input_driver_st  = &p_rarch->input_driver_state;
    input_driver_t         *current_input  = input_driver_st->current_driver;
+
+   if (current_input->input_state)
+   {
+      rarch_joypad_info_t joypad_info;
+      unsigned type                       = 0;
+      unsigned device                     = RETRO_DEVICE_MOUSE;
+      const input_device_driver_t
+         *joypad                          = input_driver_st->primary_joypad;
 #ifdef HAVE_MFI
-   const input_device_driver_t
-      *sec_joypad                  = input_driver_st->secondary_joypad;
+      const input_device_driver_t
+         *sec_joypad                      = input_driver_st->secondary_joypad;
 #else
-   const input_device_driver_t
-      *sec_joypad                  = NULL;
+      const input_device_driver_t
+         *sec_joypad                      = NULL;
 #endif
 
-   joypad_info.joy_idx             = 0;
-   joypad_info.auto_binds          = NULL;
-   joypad_info.axis_threshold      = 0.0f;
+      joypad_info.joy_idx                 = 0;
+      joypad_info.auto_binds              = NULL;
+      joypad_info.axis_threshold          = 0.0f;
 
-   switch (id)
-   {
-      case MENU_MOUSE_X_AXIS:
-         device = RARCH_DEVICE_MOUSE_SCREEN;
-         type   = RETRO_DEVICE_ID_MOUSE_X;
-         break;
-      case MENU_MOUSE_Y_AXIS:
-         device = RARCH_DEVICE_MOUSE_SCREEN;
-         type   = RETRO_DEVICE_ID_MOUSE_Y;
-         break;
-      case MENU_MOUSE_LEFT_BUTTON:
-         type   = RETRO_DEVICE_ID_MOUSE_LEFT;
-         break;
-      case MENU_MOUSE_RIGHT_BUTTON:
-         type   = RETRO_DEVICE_ID_MOUSE_RIGHT;
-         break;
-      case MENU_MOUSE_WHEEL_UP:
-         type   = RETRO_DEVICE_ID_MOUSE_WHEELUP;
-         break;
-      case MENU_MOUSE_WHEEL_DOWN:
-         type   = RETRO_DEVICE_ID_MOUSE_WHEELDOWN;
-         break;
-      case MENU_MOUSE_HORIZ_WHEEL_UP:
-         type   = RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELUP;
-         break;
-      case MENU_MOUSE_HORIZ_WHEEL_DOWN:
-         type   = RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELDOWN;
-         break;
+      switch (id)
+      {
+         case MENU_MOUSE_X_AXIS:
+            device = RARCH_DEVICE_MOUSE_SCREEN;
+            type   = RETRO_DEVICE_ID_MOUSE_X;
+            break;
+         case MENU_MOUSE_Y_AXIS:
+            device = RARCH_DEVICE_MOUSE_SCREEN;
+            type   = RETRO_DEVICE_ID_MOUSE_Y;
+            break;
+         case MENU_MOUSE_LEFT_BUTTON:
+            type   = RETRO_DEVICE_ID_MOUSE_LEFT;
+            break;
+         case MENU_MOUSE_RIGHT_BUTTON:
+            type   = RETRO_DEVICE_ID_MOUSE_RIGHT;
+            break;
+         case MENU_MOUSE_WHEEL_UP:
+            type   = RETRO_DEVICE_ID_MOUSE_WHEELUP;
+            break;
+         case MENU_MOUSE_WHEEL_DOWN:
+            type   = RETRO_DEVICE_ID_MOUSE_WHEELDOWN;
+            break;
+         case MENU_MOUSE_HORIZ_WHEEL_UP:
+            type   = RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELUP;
+            break;
+         case MENU_MOUSE_HORIZ_WHEEL_DOWN:
+            type   = RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELDOWN;
+            break;
+      }
+      return current_input->input_state(
+            input_driver_st->current_data,
+            joypad,
+            sec_joypad,
+            &joypad_info,
+            NULL,
+            p_rarch->keyboard_mapping_blocked,
+            0, device, 0, type);
    }
-
-   if (!current_input->input_state)
-      return 0;
-   return current_input->input_state(
-         input_driver_st->current_data,
-         input_driver_st->primary_joypad,
-         sec_joypad,
-         &joypad_info,
-         NULL,
-         p_rarch->keyboard_mapping_blocked,
-         0, device, 0, type);
+   return 0;
 }
 
 static void menu_input_get_mouse_hw_state(

--- a/retroarch.c
+++ b/retroarch.c
@@ -23175,6 +23175,8 @@ static void menu_input_get_mouse_hw_state(
       (menu &&
        menu->driver_ctx &&
        menu->driver_ctx->set_texture);
+   bool state_inited               = current_input &&
+      current_input->input_state;
 #ifdef HAVE_OVERLAY
    bool overlay_enable             = settings->bools.input_overlay_enable;
    /* Menu pointer controls are ignored when overlays are enabled. */
@@ -23183,8 +23185,6 @@ static void menu_input_get_mouse_hw_state(
    if (overlay_active)
       mouse_enabled                = false;
 #endif
-   bool state_inited               = current_input &&
-      current_input->input_state;
 
    /* Easiest to set inactive by default, and toggle
     * when input is detected */

--- a/retroarch.c
+++ b/retroarch.c
@@ -21921,16 +21921,24 @@ void joypad_driver_reinit(void *data, const char *joypad_driver_name)
       return;
 
    if (input_driver_st->primary_joypad)
-      input_driver_st->primary_joypad->destroy();
-   input_driver_st->primary_joypad = NULL;
+   {
+      const input_device_driver_t *tmp   = input_driver_st->primary_joypad;
+      input_driver_st->primary_joypad    = NULL;
+      tmp->destroy();
+   }
 #ifdef HAVE_MFI
    if (input_driver_st->secondary_joypad)
-      input_driver_st->secondary_joypad->destroy();
-   input_driver_st->secondary_joypad = NULL;
+   {
+      const input_device_driver_t *tmp   = input_driver_st->secondary_joypad;
+      input_driver_st->secondary_joypad  = NULL;
+      tmp->destroy();
+   }
 #endif
-   input_driver_st->primary_joypad     = input_joypad_init_driver(joypad_driver_name, data);
+   if (!input_driver_st->primary_joypad)
+      input_driver_st->primary_joypad    = input_joypad_init_driver(joypad_driver_name, data);
 #ifdef HAVE_MFI
-   input_driver_st->secondary_joypad = input_joypad_init_driver("mfi", data);
+   if (!input_driver_st->secondary_joypad)
+      input_driver_st->secondary_joypad  = input_joypad_init_driver("mfi", data);
 #endif
 }
 
@@ -24840,16 +24848,18 @@ static void input_keys_pressed(
 
 void input_driver_init_joypads(void)
 {
-   struct rarch_state            *p_rarch = &rarch_st;
-   input_driver_state_t  *input_driver_st = &p_rarch->input_driver_state;
-   settings_t                   *settings = p_rarch->configuration_settings;
-   input_driver_st->primary_joypad        = input_joypad_init_driver(
+   struct rarch_state            *p_rarch    = &rarch_st;
+   input_driver_state_t  *input_driver_st    = &p_rarch->input_driver_state;
+   settings_t                   *settings    = p_rarch->configuration_settings;
+   if (!input_driver_st->primary_joypad)
+      input_driver_st->primary_joypad        = input_joypad_init_driver(
          settings->arrays.input_joypad_driver,
          input_driver_st->current_data);
 #ifdef HAVE_MFI
-   input_driver_st->secondary_joypad         = input_joypad_init_driver(
-         "mfi",
-         input_driver_st->current_data);
+   if (!input_driver_st->secondary_joypad)
+      input_driver_st->secondary_joypad      = input_joypad_init_driver(
+            "mfi",
+            input_driver_st->current_data);
 #endif
 }
 
@@ -29808,10 +29818,10 @@ static void video_driver_free_hw_context(struct rarch_state *p_rarch)
 
 static void video_driver_free_internal(struct rarch_state *p_rarch)
 {
-   input_driver_state_t *input_driver_st = &p_rarch->input_driver_state;
+   input_driver_state_t *input_driver_st    = &p_rarch->input_driver_state;
 
 #ifdef HAVE_THREADS
-   bool        is_threaded     = VIDEO_DRIVER_IS_THREADED_INTERNAL();
+   bool        is_threaded                  = VIDEO_DRIVER_IS_THREADED_INTERNAL();
 #endif
 
 #ifdef HAVE_VIDEO_LAYOUT
@@ -29829,12 +29839,18 @@ static void video_driver_free_internal(struct rarch_state *p_rarch)
          if (input_driver_st->current_driver->free)
             input_driver_st->current_driver->free(input_driver_st->current_data);
       if (input_driver_st->primary_joypad)
-         input_driver_st->primary_joypad->destroy();
-      input_driver_st->primary_joypad                                     = NULL;
+      {
+         const input_device_driver_t *tmp   = input_driver_st->primary_joypad;
+         input_driver_st->primary_joypad    = NULL;
+         tmp->destroy();
+      }
 #ifdef HAVE_MFI
       if (input_driver_st->secondary_joypad)
-         input_driver_st->secondary_joypad->destroy();
-      input_driver_st->secondary_joypad                                 = NULL;
+      {
+         const input_device_driver_t *tmp   = input_driver_st->sec_joypad;
+         input_driver_st->secondary_joypad  = NULL;
+         tmp->destroy();
+      }
 #endif
       p_rarch->keyboard_mapping_blocked                   = false;
       p_rarch->input_driver_state.current_data                         = NULL;


### PR DESCRIPTION
Some cores like Flycast (when they use their built-in threaded rendering mode) tend to use the libretro input callbacks on a non-main thread. We are attempting to make the input code in RetroArch more robust so that there is less chance of a crash when state is being brought down and setup again.

Attempts to adress #12882