### PR TITLE
Fix menu sounds (audio mixing) when using the 'sinc' resampler with quality lower than 'normal'

### DIFF
--- a/libretro-common/audio/audio_mix.c
+++ b/libretro-common/audio/audio_mix.c
@@ -114,7 +114,8 @@ void audio_mix_free_chunk(audio_chunk_t *chunk)
    free(chunk);
 }
 
-audio_chunk_t* audio_mix_load_wav_file(const char *path, int sample_rate)
+audio_chunk_t* audio_mix_load_wav_file(const char *path, int sample_rate,
+      const char *resampler_ident, enum resampler_quality quality)
 {
 #ifdef HAVE_RWAV
    int sample_size;
@@ -233,8 +234,8 @@ audio_chunk_t* audio_mix_load_wav_file(const char *path, int sample_rate)
 
       retro_resampler_realloc(&chunk->resampler_data,
             &chunk->resampler,
-            NULL,
-            RESAMPLER_QUALITY_DONTCARE,
+            resampler_ident,
+            quality,
             chunk->ratio);
 
       if (chunk->resampler && chunk->resampler_data)

--- a/libretro-common/include/audio/audio_mix.h
+++ b/libretro-common/include/audio/audio_mix.h
@@ -68,7 +68,8 @@ void audio_mix_volume_C(float *dst, const float *src, float vol, size_t samples)
 
 void audio_mix_free_chunk(audio_chunk_t *chunk);
 
-audio_chunk_t* audio_mix_load_wav_file(const char *path, int sample_rate);
+audio_chunk_t* audio_mix_load_wav_file(const char *path, int sample_rate,
+      const char *resampler_ident, enum resampler_quality quality);
 
 size_t audio_mix_get_chunk_num_samples(audio_chunk_t *chunk);
 

--- a/libretro-common/include/audio/audio_mixer.h
+++ b/libretro-common/include/audio/audio_mixer.h
@@ -34,6 +34,8 @@
 #include <boolean.h>
 #include <retro_common_api.h>
 
+#include <audio/audio_resampler.h>
+
 RETRO_BEGIN_DECLS
 
 enum audio_mixer_type
@@ -60,7 +62,8 @@ void audio_mixer_init(unsigned rate);
 
 void audio_mixer_done(void);
 
-audio_mixer_sound_t* audio_mixer_load_wav(void *buffer, int32_t size);
+audio_mixer_sound_t* audio_mixer_load_wav(void *buffer, int32_t size,
+      const char *resampler_ident, enum resampler_quality quality);
 audio_mixer_sound_t* audio_mixer_load_ogg(void *buffer, int32_t size);
 audio_mixer_sound_t* audio_mixer_load_mod(void *buffer, int32_t size);
 audio_mixer_sound_t* audio_mixer_load_flac(void *buffer, int32_t size);
@@ -69,7 +72,10 @@ audio_mixer_sound_t* audio_mixer_load_mp3(void *buffer, int32_t size);
 void audio_mixer_destroy(audio_mixer_sound_t* sound);
 
 audio_mixer_voice_t* audio_mixer_play(audio_mixer_sound_t* sound,
-      bool repeat, float volume, audio_mixer_stop_cb_t stop_cb);
+      bool repeat, float volume,
+      const char *resampler_ident,
+      enum resampler_quality quality,
+      audio_mixer_stop_cb_t stop_cb);
 
 void audio_mixer_stop(audio_mixer_voice_t* voice);
 

--- a/retroarch_data.h
+++ b/retroarch_data.h
@@ -1713,6 +1713,7 @@ struct rarch_state
 #ifdef HAVE_OVERLAY
    enum overlay_visibility *overlay_visibility;
 #endif
+   enum resampler_quality audio_driver_resampler_quality;
 
 #ifdef HAVE_MENU
    menu_input_pointer_hw_state_t menu_input_pointer_hw_state;
@@ -1775,6 +1776,7 @@ struct rarch_state
    char current_savefile_dir[PATH_MAX_LENGTH];
    char current_savestate_dir[PATH_MAX_LENGTH];
    char dir_savestate[PATH_MAX_LENGTH];
+   char audio_driver_resampler_ident[64];
 
 #ifdef HAVE_GFX_WIDGETS
    bool widgets_active;


### PR DESCRIPTION
## Description

As reported in #12869 and #12543, if the `sinc` resampler is used with a quality of `lower` or `lowest`, then enabling any 'menu sounds' (including cheevos notifications) will completely break in-game audio.

This occurs due to a misconfigured audio mixing process. The main resampler used for in-game audio uses the system-wide quality setting, whereas the resamplers used for audio mixing use a hard coded `RESAMPLER_QUALITY_DONTCARE` value (equivalent to `normal`). The problem here is that the `lower` and `lowest` quality `sinc` settings use a lanczos windowing function, whereas all other qualities use kaiser - and kaiser outputs to a buffer that is twice the size of the lanczos buffer. So when naive mixing is attempted between kaiser-generated output and lanczos-generated output, the samples are entirely misaligned and the result is garbage (noise).

This PR fixes the issue by ensuring that all audio mixer resamplers use the same quality setting as the main one. In addition, we ensure that the same backend driver is used.

The PR also fixes a memory leak when loading system sounds without a driver reinit (i.e. when toggling menu sounds via the menu)

## Related Issues

Closes #12869
Closes #12543