### PR TITLE
Add enhanced search functionality to the 'Cheats' menu

### DIFF
--- a/menu/cbs/menu_cbs_title.c
+++ b/menu/cbs/menu_cbs_title.c
@@ -654,7 +654,6 @@ DEFAULT_TITLE_MACRO(action_get_audio_mixer_settings_list,           MENU_ENUM_LA
 #endif
 DEFAULT_TITLE_MACRO(action_get_input_settings_list,             MENU_ENUM_LABEL_VALUE_INPUT_SETTINGS)
 DEFAULT_TITLE_MACRO(action_get_latency_settings_list,           MENU_ENUM_LABEL_VALUE_LATENCY_SETTINGS)
-DEFAULT_TITLE_MACRO(action_get_core_cheat_options_list,         MENU_ENUM_LABEL_VALUE_CORE_CHEAT_OPTIONS)
 DEFAULT_TITLE_MACRO(action_get_load_content_list,               MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_LIST)
 DEFAULT_TITLE_MACRO(action_get_load_content_special,            MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_SPECIAL)
 DEFAULT_TITLE_MACRO(action_get_cursor_manager_list,             MENU_ENUM_LABEL_VALUE_CURSOR_MANAGER)
@@ -753,6 +752,7 @@ DEFAULT_TITLE_SEARCH_FILTER_MACRO(action_get_title_deferred_music_list,     MENU
 DEFAULT_TITLE_SEARCH_FILTER_MACRO(action_get_title_deferred_video_list,     MENU_ENUM_LABEL_VALUE_GOTO_VIDEO)
 DEFAULT_TITLE_SEARCH_FILTER_MACRO(action_get_core_updater_list,             MENU_ENUM_LABEL_VALUE_CORE_UPDATER_LIST)
 DEFAULT_TITLE_SEARCH_FILTER_MACRO(action_get_core_manager_list,             MENU_ENUM_LABEL_VALUE_CORE_MANAGER_LIST)
+DEFAULT_TITLE_SEARCH_FILTER_MACRO(action_get_core_cheat_options_list,       MENU_ENUM_LABEL_VALUE_CORE_CHEAT_OPTIONS)
 
 DEFAULT_FILL_TITLE_SEARCH_FILTER_MACRO(action_get_title_video_shader_preset,    MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_TWO)
 DEFAULT_FILL_TITLE_SEARCH_FILTER_MACRO(action_get_title_cheat_file_load,        MENU_ENUM_LABEL_VALUE_CHEAT_FILE)

--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -8379,6 +8379,7 @@ static void materialui_populate_entries(
                           string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_VIDEO_SHADER_PASS)) ||
                           string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_FILE_LOAD)) ||
                           string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_FILE_LOAD_APPEND)) ||
+                          string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_CORE_CHEAT_OPTIONS)) ||
                           string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_INPUT_OVERLAY)) ||
                           string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_CORE_MANAGER_LIST));
 

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -6652,62 +6652,89 @@ unsigned menu_displaylist_build_list(
 #ifdef HAVE_CHEATS
          if (cheat_manager_alloc_if_empty())
          {
-            if (menu_entries_append_enum(list,
-                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_START_OR_CONT),
-                     msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_START_OR_CONT),
-                     MENU_ENUM_LABEL_CHEAT_START_OR_CONT,
-                     MENU_SETTING_ACTION, 0, 0))
-               count++;
-            if (menu_entries_append_enum(list,
-                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_FILE_LOAD),
-                     msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_FILE_LOAD),
-                     MENU_ENUM_LABEL_CHEAT_FILE_LOAD,
-                     MENU_SETTING_ACTION, 0, 0))
-               count++;
-            if (menu_entries_append_enum(list,
-                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_FILE_LOAD_APPEND),
-                     msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_FILE_LOAD_APPEND),
-                     MENU_ENUM_LABEL_CHEAT_FILE_LOAD_APPEND,
-                     MENU_SETTING_ACTION, 0, 0))
-               count++;
-            if (menu_entries_append_enum(list,
-                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_RELOAD_CHEATS),
-                     msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_RELOAD_CHEATS),
-                     MENU_ENUM_LABEL_CHEAT_RELOAD_CHEATS,
-                     MENU_SETTING_ACTION, 0, 0))
-               count++;
-            if (menu_entries_append_enum(list,
-                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_FILE_SAVE_AS),
-                     msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_FILE_SAVE_AS),
-                     MENU_ENUM_LABEL_CHEAT_FILE_SAVE_AS,
-                     MENU_SETTING_ACTION, 0, 0))
-               count++;
-            if (menu_entries_append_enum(list,
-                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_ADD_NEW_TOP),
-                     msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_ADD_NEW_TOP),
-                     MENU_ENUM_LABEL_CHEAT_ADD_NEW_TOP,
-                     MENU_SETTING_ACTION, 0, 0))
-               count++;
-            if (menu_entries_append_enum(list,
-                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_ADD_NEW_BOTTOM),
-                     msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_ADD_NEW_BOTTOM),
-                     MENU_ENUM_LABEL_CHEAT_ADD_NEW_BOTTOM,
-                     MENU_SETTING_ACTION, 0, 0))
-               count++;
-            if (menu_entries_append_enum(list,
-                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_DELETE_ALL),
-                     msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_DELETE_ALL),
-                     MENU_ENUM_LABEL_CHEAT_DELETE_ALL,
-                     MENU_SETTING_ACTION, 0, 0))
-               count++;
-            if (MENU_DISPLAYLIST_PARSE_SETTINGS_ENUM(list,
-                     MENU_ENUM_LABEL_CHEAT_APPLY_AFTER_LOAD,
-                     PARSE_ONLY_BOOL, false) == 0)
-               count++;
-            if (MENU_DISPLAYLIST_PARSE_SETTINGS_ENUM(list,
-                     MENU_ENUM_LABEL_CHEAT_APPLY_AFTER_TOGGLE,
-                     PARSE_ONLY_BOOL, false) == 0)
-               count++;
+            menu_serch_terms_t *search_terms = menu_entries_search_get_terms();
+            bool search_active               = search_terms && (search_terms->size > 0);
+            unsigned num_cheats              = cheat_manager_get_size();
+            unsigned num_cheats_shown        = 0;
+            unsigned i;
+            char on_string[32];
+            char off_string[32];
+
+            on_string[0]  = '\0';
+            off_string[0] = '\0';
+
+            /* If a search is active, all options are
+             * omitted apart from 'apply changes' */
+            if (search_active)
+            {
+               /* On/off key strings may be required,
+                * so populate them... */
+               snprintf(on_string, sizeof(on_string), ".%s",
+                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_ON));
+
+               snprintf(off_string, sizeof(off_string), ".%s",
+                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF));
+            }
+            else
+            {
+               if (menu_entries_append_enum(list,
+                        msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_START_OR_CONT),
+                        msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_START_OR_CONT),
+                        MENU_ENUM_LABEL_CHEAT_START_OR_CONT,
+                        MENU_SETTING_ACTION, 0, 0))
+                  count++;
+               if (menu_entries_append_enum(list,
+                        msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_FILE_LOAD),
+                        msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_FILE_LOAD),
+                        MENU_ENUM_LABEL_CHEAT_FILE_LOAD,
+                        MENU_SETTING_ACTION, 0, 0))
+                  count++;
+               if (menu_entries_append_enum(list,
+                        msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_FILE_LOAD_APPEND),
+                        msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_FILE_LOAD_APPEND),
+                        MENU_ENUM_LABEL_CHEAT_FILE_LOAD_APPEND,
+                        MENU_SETTING_ACTION, 0, 0))
+                  count++;
+               if (menu_entries_append_enum(list,
+                        msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_RELOAD_CHEATS),
+                        msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_RELOAD_CHEATS),
+                        MENU_ENUM_LABEL_CHEAT_RELOAD_CHEATS,
+                        MENU_SETTING_ACTION, 0, 0))
+                  count++;
+               if (menu_entries_append_enum(list,
+                        msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_FILE_SAVE_AS),
+                        msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_FILE_SAVE_AS),
+                        MENU_ENUM_LABEL_CHEAT_FILE_SAVE_AS,
+                        MENU_SETTING_ACTION, 0, 0))
+                  count++;
+               if (menu_entries_append_enum(list,
+                        msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_ADD_NEW_TOP),
+                        msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_ADD_NEW_TOP),
+                        MENU_ENUM_LABEL_CHEAT_ADD_NEW_TOP,
+                        MENU_SETTING_ACTION, 0, 0))
+                  count++;
+               if (menu_entries_append_enum(list,
+                        msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_ADD_NEW_BOTTOM),
+                        msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_ADD_NEW_BOTTOM),
+                        MENU_ENUM_LABEL_CHEAT_ADD_NEW_BOTTOM,
+                        MENU_SETTING_ACTION, 0, 0))
+                  count++;
+               if (menu_entries_append_enum(list,
+                        msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_DELETE_ALL),
+                        msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_DELETE_ALL),
+                        MENU_ENUM_LABEL_CHEAT_DELETE_ALL,
+                        MENU_SETTING_ACTION, 0, 0))
+                  count++;
+               if (MENU_DISPLAYLIST_PARSE_SETTINGS_ENUM(list,
+                        MENU_ENUM_LABEL_CHEAT_APPLY_AFTER_LOAD,
+                        PARSE_ONLY_BOOL, false) == 0)
+                  count++;
+               if (MENU_DISPLAYLIST_PARSE_SETTINGS_ENUM(list,
+                        MENU_ENUM_LABEL_CHEAT_APPLY_AFTER_TOGGLE,
+                        PARSE_ONLY_BOOL, false) == 0)
+                  count++;
+            }
+
             if (menu_entries_append_enum(list,
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_APPLY_CHANGES),
                      msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_APPLY_CHANGES),
@@ -6715,24 +6742,77 @@ unsigned menu_displaylist_build_list(
                      MENU_SETTING_ACTION, 0, 0))
                count++;
 
+            for (i = 0; i < num_cheats; i++)
             {
-               unsigned i;
-               for (i = 0; i < cheat_manager_get_size(); i++)
+               const char *cheat_description = cheat_manager_get_desc(i);
+               char cheat_label[128];
+
+               cheat_label[0] = '\0';
+
+               snprintf(cheat_label, sizeof(cheat_label),
+                     "%s #%u: ", msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT), i);
+               if (!string_is_empty(cheat_description))
+                  strlcat(cheat_label, cheat_description, sizeof(cheat_label));
+
+               /* If a search is active, skip non-matching
+                * entries */
+               if (search_active)
                {
-                  char cheat_label[64];
+                  bool entry_valid = true;
+                  size_t j;
 
-                  cheat_label[0] = '\0';
+                  for (j = 0; j < search_terms->size; j++)
+                  {
+                     const char *search_term = search_terms->terms[j];
 
-                  snprintf(cheat_label, sizeof(cheat_label),
-                        "%s #%u: ", msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT), i);
-                  if (cheat_manager_get_desc(i))
-                     strlcat(cheat_label, cheat_manager_get_desc(i), sizeof(cheat_label));
-                  if (menu_entries_append_enum(list,
-                           cheat_label, "", MSG_UNKNOWN,
-                           MENU_SETTINGS_CHEAT_BEGIN + i, 0, 0))
-                     count++;
+                     if (!string_is_empty(search_term))
+                     {
+                        bool cheat_on = cheat_manager_get_code_state(i);
+
+                        /* Check for 'on' keyword */
+                        if (string_is_equal_noncase(search_term, on_string))
+                        {
+                           if (!cheat_on)
+                              entry_valid = false;
+                        }
+                        /* Check for 'off' keyword */
+                        else if (string_is_equal_noncase(search_term, off_string))
+                        {
+                           if (cheat_on)
+                              entry_valid = false;
+                        }
+                        /* Normal label comparison */
+                        else if (!strcasestr(cheat_label, search_term))
+                           entry_valid = false;
+                     }
+
+                     if (!entry_valid)
+                        break;
+                  }
+
+                  if (!entry_valid)
+                     continue;
+               }
+
+               if (menu_entries_append_enum(list,
+                     cheat_label, "", MSG_UNKNOWN,
+                     MENU_SETTINGS_CHEAT_BEGIN + i, 0, 0))
+               {
+                  num_cheats_shown++;
+                  count++;
                }
             }
+
+            /* If a search is active and no results are
+             * found, show a 'no entries available' item */
+            if (search_active &&
+                (num_cheats_shown < 1) &&
+                menu_entries_append_enum(list,
+                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NO_ENTRIES_TO_DISPLAY),
+                     msg_hash_to_str(MENU_ENUM_LABEL_NO_ENTRIES_TO_DISPLAY),
+                     MENU_ENUM_LABEL_NO_ENTRIES_TO_DISPLAY,
+                     FILE_TYPE_NONE, 0, 0))
+               count++;
          }
 #endif
          break;

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -1779,6 +1779,8 @@ bool menu_driver_search_filter_enabled(const char *label, unsigned type)
                        /* > Cheat files */
                        string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_FILE_LOAD)) ||
                        string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_CHEAT_FILE_LOAD_APPEND)) ||
+                       /* > Cheats */
+                       string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_CORE_CHEAT_OPTIONS)) ||
                        /* > Overlays */
                        string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_INPUT_OVERLAY)) ||
                        /* > Manage Cores */


### PR DESCRIPTION
## Description

This PR adds enhanced search functionality to the `Quick Menu > Cheats` menu, similar to that in the core downloader and core manager menus:

![screen_record__2021_09_03__14_47_20](https://user-images.githubusercontent.com/38211560/132017847-3d7654ff-5f82-47b3-8b53-d81fe2d7e965.gif)

In addition, the search feature may be used to filter cheats that are currently on or off: this is done by searching for the 'key' string `.on` or `.off`

- The key string is case insensitive
- The actual on/off text is localised - it matches whatever is currently shown as the cheat value (i.e. if the user language is set to French, the on key is `.Activé`
- The leading period was chosen because (a) it should be available on most keyboard layouts, (b) it is available on the first 'page' of RetroArch's OSK and (c) it is easier to type than enclosing the string with brackets, as it is displayed in the cheat value text

![screen_record__2021_09_03__14_42_17](https://user-images.githubusercontent.com/38211560/132018722-56a56c65-1b3d-40c7-a3b1-0da23052407e.gif)

## Related Issues

Closes #12925