### PR TITLE
Fixing a couple of minor typos related to the HDR PR.

### DIFF
--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -1310,7 +1310,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_VIDEO_HDR_SETTINGS,
-   "Change video hdr settings."
+   "Change video HDR settings."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_VIDEO_SYNCHRONIZATION_SETTINGS,
@@ -1764,7 +1764,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_VIDEO_HDR_ENABLE,
-   "Enable HDR if the display supports it"
+   "Enable HDR if the display supports it."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_VIDEO_HDR_MAX_NITS,


### PR DESCRIPTION
## Description

Adding a couple of typo fixes to the latest HDR text additions. The whole section could use some proper proofreading and/or rewriting of the sublabels.

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/12917

## Reviewers
@DisasterMo @twinaphex
