### PR TITLE
Reduce gfx_display_rotate_z calls in menu drivers

### DIFF
--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -2370,25 +2370,15 @@ static void materialui_draw_icon(
       uintptr_t texture,
       float x, float y,
       float rotation, float scale_factor,
-      float *color)
+      float *color,
+      math_matrix_4x4 *mymat)
 {
-   gfx_display_ctx_rotate_draw_t rotate_draw;
    gfx_display_ctx_draw_t draw;
    struct video_coords coords;
-   math_matrix_4x4 mymat;
    gfx_display_ctx_driver_t *dispctx = p_disp->dispctx;
 
    if (dispctx && dispctx->blend_begin)
       dispctx->blend_begin(userdata);
-
-   rotate_draw.matrix       = &mymat;
-   rotate_draw.rotation     = rotation;
-   rotate_draw.scale_x      = scale_factor;
-   rotate_draw.scale_y      = scale_factor;
-   rotate_draw.scale_z      = 1;
-   rotate_draw.scale_enable = true;
-
-   gfx_display_rotate_z(p_disp, &rotate_draw, userdata);
 
    coords.vertices      = 4;
    coords.vertex        = NULL;
@@ -2403,7 +2393,7 @@ static void materialui_draw_icon(
    draw.scale_factor    = scale_factor;
    draw.rotation        = rotation;
    draw.coords          = &coords;
-   draw.matrix_data     = &mymat;
+   draw.matrix_data     = mymat;
    draw.texture         = texture;
    draw.prim_type       = GFX_DISPLAY_PRIM_TRIANGLESTRIP;
    draw.pipeline_id     = 0;
@@ -2427,7 +2417,8 @@ static void materialui_draw_thumbnail(
       unsigned video_width,
       unsigned video_height,
       float x, float y,
-      float scale_factor)
+      float scale_factor,
+      math_matrix_4x4 *mymat)
 {
    float bg_x;
    float bg_y;
@@ -2492,7 +2483,8 @@ static void materialui_draw_thumbnail(
                   bg_y + (bg_height - icon_size) / 2.0f,
                   0.0f,
                   1.0f,
-                  mui->colors.missing_thumbnail_icon);
+                  mui->colors.missing_thumbnail_icon,
+                  mymat);
          }
          break;
       case GFX_THUMBNAIL_STATUS_AVAILABLE:
@@ -3875,7 +3867,8 @@ static void materialui_render_switch_icon(
       unsigned video_height,
       float y,
       int x_offset,
-      bool on)
+      bool on,
+      math_matrix_4x4 *mymat)
 {
    unsigned switch_texture_index = on ?
          MUI_TEXTURE_SWITCH_ON : MUI_TEXTURE_SWITCH_OFF;
@@ -3899,7 +3892,8 @@ static void materialui_render_switch_icon(
             y,
             0,
             1,
-            bg_color);
+            bg_color,
+            mymat);
 
    /* Draw switch */
    if (mui->textures.list[switch_texture_index])
@@ -3913,7 +3907,8 @@ static void materialui_render_switch_icon(
             y,
             0,
             1,
-            switch_color);
+            switch_color,
+            mymat);
 }
 
 /* Used for standard, non-playlist entries
@@ -3930,6 +3925,8 @@ static void materialui_render_menu_entry_default(
       unsigned header_height,
       int x_offset)
 {
+   math_matrix_4x4 mymat;
+   gfx_display_ctx_rotate_draw_t rotate_draw;
    const char *entry_value                           = NULL;
    const char *entry_label                           = NULL;
    unsigned entry_type                               = 0;
@@ -3946,6 +3943,17 @@ static void materialui_render_menu_entry_default(
    uintptr_t icon_texture                            = 0;
    bool draw_text_outside                            = (x_offset != 0);
    gfx_display_t *p_disp                             = disp_get_ptr();
+
+   {
+      rotate_draw.matrix       = &mymat;
+      rotate_draw.rotation     = 0.0f;
+      rotate_draw.scale_x      = 1.0f;
+      rotate_draw.scale_y      = 1.0f;
+      rotate_draw.scale_z      = 1;
+      rotate_draw.scale_enable = true;
+
+      gfx_display_rotate_z(p_disp, &rotate_draw, userdata);
+   }
 
    /* Initial ticker configuration
     * > Note: ticker is only used for labels/values,
@@ -4025,7 +4033,8 @@ static void materialui_render_menu_entry_default(
             entry_y + (node->entry_height / 2.0f) - (mui->icon_size / 2.0f),
             0,
             1,
-            mui->colors.list_icon);
+            mui->colors.list_icon,
+            &mymat);
 
       entry_margin += mui->icon_size;
       usable_width -= mui->icon_size;
@@ -4165,14 +4174,18 @@ static void materialui_render_menu_entry_default(
       case MUI_ENTRY_VALUE_SWITCH_ON:
          {
             materialui_render_switch_icon(mui, node, p_disp, userdata,
-                  video_width, video_height, value_icon_y, x_offset, true);
+                  video_width, video_height, value_icon_y, x_offset,
+                  true,
+                  &mymat);
             entry_value_width = mui->icon_size;
          }
          break;
       case MUI_ENTRY_VALUE_SWITCH_OFF:
          {
             materialui_render_switch_icon(mui, node, p_disp, userdata,
-                  video_width, video_height, value_icon_y, x_offset, false);
+                  video_width, video_height, value_icon_y, x_offset,
+                  false,
+                  &mymat);
             entry_value_width = mui->icon_size;
          }
          break;
@@ -4190,7 +4203,8 @@ static void materialui_render_menu_entry_default(
                      value_icon_y,
                      0,
                      1,
-                     mui->colors.list_switch_on);
+                     mui->colors.list_switch_on,
+                     &mymat);
 
             entry_value_width = mui->icon_size;
          }
@@ -4268,6 +4282,8 @@ static void materialui_render_menu_entry_playlist_list(
       int x_offset)
 {
    bool draw_divider;
+   math_matrix_4x4 mymat;
+   gfx_display_ctx_rotate_draw_t rotate_draw;
    const char *entry_label    = NULL;
    int entry_x                = x_offset + node->x;
    int entry_y                = header_height - mui->scroll_y + node->y;
@@ -4278,6 +4294,17 @@ static void materialui_render_menu_entry_playlist_list(
    bool draw_text_outside     = (x_offset != 0);
    settings_t *settings       = config_get_ptr();
    gfx_display_t *p_disp      = disp_get_ptr();
+
+   {
+      rotate_draw.matrix       = &mymat;
+      rotate_draw.rotation     = 0.0f;
+      rotate_draw.scale_x      = 1.0f;
+      rotate_draw.scale_y      = 1.0f;
+      rotate_draw.scale_z      = 1;
+      rotate_draw.scale_enable = true;
+
+      gfx_display_rotate_z(p_disp, &rotate_draw, userdata);
+   }
 
    /* Initial ticker configuration
     * > Note: ticker is only used for labels,
@@ -4342,7 +4369,8 @@ static void materialui_render_menu_entry_playlist_list(
             video_height,
             (float)(entry_x + thumbnail_margin),
             thumbnail_y,
-            1.0f);
+            1.0f,
+            &mymat);
 
       entry_margin += mui->thumbnail_width_max + thumbnail_margin;
       usable_width -= mui->thumbnail_width_max + thumbnail_margin;
@@ -4360,7 +4388,8 @@ static void materialui_render_menu_entry_playlist_list(
                video_height,
                (float)(entry_x + node->entry_width - thumbnail_margin - (int)mui->thumbnail_width_max),
                thumbnail_y,
-               1.0f);
+               1.0f,
+               &mymat);
 
          usable_width -= mui->thumbnail_width_max + thumbnail_margin;
       }
@@ -4502,6 +4531,8 @@ static void materialui_render_menu_entry_playlist_dual_icon(
       unsigned header_height,
       int x_offset)
 {
+   math_matrix_4x4 mymat;
+   gfx_display_ctx_rotate_draw_t rotate_draw;
    const char *entry_label = NULL;
    float entry_x           = (float)x_offset + node->x;
    float entry_y           = (float)header_height - mui->scroll_y + node->y;
@@ -4519,6 +4550,17 @@ static void materialui_render_menu_entry_playlist_dual_icon(
                      (video_height - mui->nav_bar_layout_height - mui->status_bar.height));
    gfx_display_t *p_disp   = disp_get_ptr();
    settings_t *settings    = config_get_ptr();
+
+   {
+      rotate_draw.matrix       = &mymat;
+      rotate_draw.rotation     = 0.0f;
+      rotate_draw.scale_x      = 1.0f;
+      rotate_draw.scale_y      = 1.0f;
+      rotate_draw.scale_z      = 1;
+      rotate_draw.scale_enable = true;
+
+      gfx_display_rotate_z(p_disp, &rotate_draw, userdata);
+   }
 
    /* Initial ticker configuration
     * > Note: ticker is only used for labels */
@@ -4551,7 +4593,8 @@ static void materialui_render_menu_entry_playlist_dual_icon(
          video_height,
          entry_x + (float)mui->margin,
          thumbnail_y,
-         1.0f);
+         1.0f,
+         &mymat);
 
    /* > Secondary thumbnail */
    materialui_draw_thumbnail(
@@ -4562,9 +4605,11 @@ static void materialui_render_menu_entry_playlist_dual_icon(
          userdata,
          video_width,
          video_height,
-         entry_x + node->entry_width - (float)mui->margin - (float)mui->thumbnail_width_max,
+         entry_x + node->entry_width 
+         - (float)mui->margin - (float)mui->thumbnail_width_max,
          thumbnail_y,
-         1.0f);
+         1.0f,
+         &mymat);
 
    /* Draw entry label */
    if (!string_is_empty(entry_label))
@@ -4779,6 +4824,8 @@ static void materialui_render_selected_entry_aux_playlist_desktop(
       unsigned header_height, int x_offset,
       file_list_t *list, size_t selection)
 {
+   math_matrix_4x4 mymat;
+   gfx_display_ctx_rotate_draw_t rotate_draw;
    materialui_node_t *node    = (materialui_node_t*)list->list[selection].userdata;
    float background_x         = (float)(x_offset + (int)mui->landscape_optimization.border_width);
    float background_y         = (float)header_height;
@@ -4800,6 +4847,17 @@ static void materialui_render_selected_entry_aux_playlist_desktop(
    if ((background_width <= 0) ||
        (background_height <= 0))
       return;
+
+   {
+      rotate_draw.matrix       = &mymat;
+      rotate_draw.rotation     = 0.0f;
+      rotate_draw.scale_x      = 1.0f;
+      rotate_draw.scale_y      = 1.0f;
+      rotate_draw.scale_z      = 1;
+      rotate_draw.scale_enable = true;
+
+      gfx_display_rotate_z(p_disp, &rotate_draw, userdata);
+   }
 
    /* Draw sidebar background
     * > Surface */
@@ -4883,7 +4941,8 @@ static void materialui_render_selected_entry_aux_playlist_desktop(
             video_height,
             thumbnail_x,
             thumbnail_y,
-            1.0f);
+            1.0f,
+            &mymat);
 
       /* Draw secondary */
       materialui_draw_thumbnail(
@@ -4895,8 +4954,10 @@ static void materialui_render_selected_entry_aux_playlist_desktop(
             video_width,
             video_height,
             thumbnail_x,
-            thumbnail_y + (float)mui->thumbnail_height_max + (float)mui->margin,
-            1.0f);
+            thumbnail_y 
+            + (float)mui->thumbnail_height_max + (float)mui->margin,
+            1.0f,
+            &mymat);
    }
 
    /* Draw status bar */
@@ -5462,7 +5523,8 @@ static void materialui_render_header(
       settings_t *settings,
       gfx_display_t *p_disp,
       void *userdata,
-      unsigned video_width, unsigned video_height)
+      unsigned video_width, unsigned video_height,
+      math_matrix_4x4 *mymat)
 {
    char menu_title_buf[255];
    size_t menu_title_margin              = 0;
@@ -5613,7 +5675,8 @@ static void materialui_render_header(
                   0,
                   0,
                   1,
-                  mui->colors.sys_bar_icon);
+                  mui->colors.sys_bar_icon,
+                  mymat);
 
             /* Draw percent text */
             gfx_display_draw_text(mui->font_data.hint.font,
@@ -5655,7 +5718,8 @@ static void materialui_render_header(
                MUI_TIMEDATE_MAX_LENGTH * sizeof(char));
 
          /* Cache width */
-         mui->sys_bar_cache.timedate_width = font_driver_get_message_width(
+         mui->sys_bar_cache.timedate_width 
+            = font_driver_get_message_width(
                mui->font_data.hint.font,
                mui->sys_bar_cache.timedate_str,
                (unsigned)strlen(mui->sys_bar_cache.timedate_str),
@@ -5748,7 +5812,8 @@ static void materialui_render_header(
             (int)mui->sys_bar_height,
             0,
             1,
-            mui->colors.header_icon);
+            mui->colors.header_icon,
+            mymat);
    }
 
    usable_title_bar_width -= menu_title_margin;
@@ -5766,7 +5831,8 @@ static void materialui_render_header(
             (int)mui->sys_bar_height,
             0,
             1,
-            mui->colors.header_icon);
+            mui->colors.header_icon,
+            mymat);
 
       usable_title_bar_width -= mui->icon_size;
 
@@ -5782,11 +5848,13 @@ static void materialui_render_header(
                video_height,
                mui->icon_size,
                mui->textures.list[MUI_TEXTURE_SWITCH_VIEW],
-               (int)video_width - (2 * (int)mui->icon_size) - (int)mui->nav_bar_layout_width,
+               (int)video_width - (2 * (int)mui->icon_size) 
+               - (int)mui->nav_bar_layout_width,
                (int)mui->sys_bar_height,
                0,
                1,
-               mui->colors.header_icon);
+               mui->colors.header_icon,
+               mymat);
 
          usable_title_bar_width -= mui->icon_size;
       }
@@ -5882,7 +5950,8 @@ static void materialui_render_nav_bar_bottom(
       materialui_handle_t *mui,
       gfx_display_t *p_disp,
       void *userdata,
-      unsigned video_width, unsigned video_height)
+      unsigned video_width, unsigned video_height,
+      math_matrix_4x4 *mymat)
 {
    unsigned i;
    unsigned nav_bar_width           = video_width;
@@ -5941,8 +6010,10 @@ static void materialui_render_nav_bar_bottom(
          nav_bar_y,
          0,
          1,
-         mui->nav_bar.back_tab.enabled ?
-               mui->colors.nav_bar_icon_passive : mui->colors.nav_bar_icon_disabled);
+         mui->nav_bar.back_tab.enabled 
+         ? mui->colors.nav_bar_icon_passive
+         : mui->colors.nav_bar_icon_disabled,
+         mymat);
 
    /* > Resume - right hand side */
    materialui_draw_icon(
@@ -5955,8 +6026,10 @@ static void materialui_render_nav_bar_bottom(
          nav_bar_y,
          0,
          1,
-         mui->nav_bar.resume_tab.enabled ?
-               mui->colors.nav_bar_icon_passive : mui->colors.nav_bar_icon_disabled);
+         mui->nav_bar.resume_tab.enabled 
+         ? mui->colors.nav_bar_icon_passive
+         : mui->colors.nav_bar_icon_disabled,
+         mymat);
 
    /* Menu tabs - in the centre, left to right */
    for (i = 0; i < mui->nav_bar.num_menu_tabs; i++)
@@ -5972,11 +6045,13 @@ static void materialui_render_nav_bar_bottom(
             video_height,
             mui->icon_size,
             mui->textures.list[tab->texture_index],
-            (((float)i + 1.5f) * tab_width) - ((float)mui->icon_size / 2.0f),
+            (((float)i + 1.5f) * tab_width) 
+            - ((float)mui->icon_size / 2.0f),
             nav_bar_y,
             0,
             1,
-            draw_color);
+            draw_color,
+            mymat);
 
       /* Draw selection marker */
       gfx_display_draw_quad(
@@ -6000,7 +6075,8 @@ static void materialui_render_nav_bar_right(
       gfx_display_t *p_disp,
       void *userdata,
       unsigned video_width,
-      unsigned video_height)
+      unsigned video_height,
+      math_matrix_4x4 *mymat)
 {
    unsigned i;
    unsigned nav_bar_width           = mui->nav_bar.width;
@@ -6059,8 +6135,10 @@ static void materialui_render_nav_bar_right(
          (int)((((float)num_tabs - 0.5f) * tab_height) - ((float)mui->icon_size / 2.0f)),
          0,
          1,
-         mui->nav_bar.back_tab.enabled ?
-               mui->colors.nav_bar_icon_passive : mui->colors.nav_bar_icon_disabled);
+         mui->nav_bar.back_tab.enabled 
+         ? mui->colors.nav_bar_icon_passive
+         : mui->colors.nav_bar_icon_disabled,
+         mymat);
 
    /* > Resume - top */
    materialui_draw_icon(
@@ -6070,11 +6148,14 @@ static void materialui_render_nav_bar_right(
          mui->icon_size,
          mui->textures.list[mui->nav_bar.resume_tab.texture_index],
          nav_bar_x,
-         (int)((0.5f * tab_height) - ((float)mui->icon_size / 2.0f)),
+         (int)((0.5f * tab_height) 
+            - ((float)mui->icon_size / 2.0f)),
          0,
          1,
-         mui->nav_bar.resume_tab.enabled ?
-               mui->colors.nav_bar_icon_passive : mui->colors.nav_bar_icon_disabled);
+         mui->nav_bar.resume_tab.enabled
+         ? mui->colors.nav_bar_icon_passive 
+         : mui->colors.nav_bar_icon_disabled,
+         mymat);
 
    /* Menu tabs - in the centre, top to bottom */
    for (i = 0; i < mui->nav_bar.num_menu_tabs; i++)
@@ -6091,10 +6172,12 @@ static void materialui_render_nav_bar_right(
             mui->icon_size,
             mui->textures.list[tab->texture_index],
             nav_bar_x,
-            (((float)i + 1.5f) * tab_height) - ((float)mui->icon_size / 2.0f),
+            (((float)i + 1.5f) * tab_height) 
+            - ((float)mui->icon_size / 2.0f),
             0,
             1,
-            draw_color);
+            draw_color,
+            mymat);
 
       /* Draw selection marker */
       gfx_display_draw_quad(
@@ -6118,13 +6201,15 @@ static void materialui_render_nav_bar(
       gfx_display_t *p_disp,
       void *userdata,
       unsigned video_width,
-      unsigned video_height)
+      unsigned video_height,
+      math_matrix_4x4 *mymat)
 {
    switch (mui->nav_bar.location)
    {
       case MUI_NAV_BAR_LOCATION_RIGHT:
          materialui_render_nav_bar_right(
-            mui, p_disp, userdata, video_width, video_height);
+            mui, p_disp, userdata, video_width, video_height,
+            mymat);
          break;
       case MUI_NAV_BAR_LOCATION_HIDDEN:
          /* Draw nothing */
@@ -6133,7 +6218,8 @@ static void materialui_render_nav_bar(
       case MUI_NAV_BAR_LOCATION_BOTTOM:
       default:
          materialui_render_nav_bar_bottom(
-            mui, p_disp, userdata, video_width, video_height);
+            mui, p_disp, userdata, video_width, video_height,
+            mymat);
          break;
    }
 }
@@ -6781,6 +6867,8 @@ static void materialui_update_scrollbar(
 static void materialui_frame(void *data, video_frame_info_t *video_info)
 {
    int list_x_offset;
+   math_matrix_4x4 mymat;
+   gfx_display_ctx_rotate_draw_t rotate_draw;
    materialui_handle_t *mui       = (materialui_handle_t*)data;
    settings_t *settings           = config_get_ptr();
    gfx_display_t *p_disp          = disp_get_ptr();
@@ -6812,6 +6900,17 @@ static void materialui_frame(void *data, video_frame_info_t *video_info)
       menu_screensaver_frame(mui->screensaver,
             video_info, p_disp);
       return;
+   }
+
+   {
+      rotate_draw.matrix       = &mymat;
+      rotate_draw.rotation     = 0.0f;
+      rotate_draw.scale_x      = 1.0f;
+      rotate_draw.scale_y      = 1.0f;
+      rotate_draw.scale_z      = 1;
+      rotate_draw.scale_enable = true;
+
+      gfx_display_rotate_z(p_disp, &rotate_draw, userdata);
    }
 
    video_driver_set_viewport(video_width, video_height, true, false);
@@ -6900,7 +6999,8 @@ static void materialui_frame(void *data, video_frame_info_t *video_info)
     *   like this because we need to track its
     *   position in order to enable fast navigation
     *   via scrollbar 'dragging' */
-   materialui_update_scrollbar(mui, video_width, video_height, header_height, list_x_offset);
+   materialui_update_scrollbar(mui, video_width, video_height,
+         header_height, list_x_offset);
    materialui_render_menu_list(mui, p_disp,
          userdata,
          video_width, video_height, list_x_offset);
@@ -6918,16 +7018,18 @@ static void materialui_frame(void *data, video_frame_info_t *video_info)
 
    /* Draw title + system bar */
    materialui_render_header(mui, settings, p_disp, userdata,
-         video_width, video_height);
+         video_width, video_height, &mymat);
 
    /* Draw navigation bar */
    materialui_render_nav_bar(mui, p_disp, userdata, 
-         video_width, video_height);
+         video_width, video_height, &mymat);
 
    /* Flush second layer of text
     * > Title + system bar only use title and hint fonts */
-   materialui_font_flush(video_width, video_height, &mui->font_data.title);
-   materialui_font_flush(video_width, video_height, &mui->font_data.hint);
+   materialui_font_flush(video_width,
+         video_height, &mui->font_data.title);
+   materialui_font_flush(video_width,
+         video_height, &mui->font_data.hint);
 
    /* Handle onscreen keyboard */
    if (menu_input_dialog_get_display_kb())

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -2393,23 +2393,14 @@ static void ozone_draw_icon(
       float x, float y,
       unsigned width, unsigned height,
       float rotation, float scale_factor,
-      float *color)
+      float *color,
+      math_matrix_4x4 *mymat)
 {
-   gfx_display_ctx_rotate_draw_t rotate_draw;
    gfx_display_ctx_draw_t draw;
    struct video_coords coords;
-   math_matrix_4x4 mymat;
    gfx_display_ctx_driver_t 
       *dispctx              = p_disp->dispctx;
 
-   rotate_draw.matrix       = &mymat;
-   rotate_draw.rotation     = rotation;
-   rotate_draw.scale_x      = scale_factor;
-   rotate_draw.scale_y      = scale_factor;
-   rotate_draw.scale_z      = 1;
-   rotate_draw.scale_enable = true;
-
-   gfx_display_rotate_z(p_disp, &rotate_draw, userdata);
 
    coords.vertices      = 4;
    coords.vertex        = NULL;
@@ -2424,7 +2415,7 @@ static void ozone_draw_icon(
    draw.scale_factor    = scale_factor;
    draw.rotation        = rotation;
    draw.coords          = &coords;
-   draw.matrix_data     = &mymat;
+   draw.matrix_data     = mymat;
    draw.texture         = texture;
    draw.prim_type       = GFX_DISPLAY_PRIM_TRIANGLESTRIP;
    draw.pipeline_id     = 0;
@@ -2700,6 +2691,7 @@ static void ozone_draw_sidebar(
    int entry_width;
    char console_title[255];
    unsigned i, sidebar_height;
+   math_matrix_4x4 mymat;
    gfx_animation_ctx_ticker_t ticker;
    gfx_animation_ctx_ticker_smooth_t ticker_smooth;
    static const char* const
@@ -2852,6 +2844,18 @@ static void ozone_draw_sidebar(
    if (dispctx && dispctx->blend_begin)
       dispctx->blend_begin(userdata);
 
+   {
+      gfx_display_ctx_rotate_draw_t rotate_draw;
+      rotate_draw.matrix       = &mymat;
+      rotate_draw.rotation     = 0.0f;
+      rotate_draw.scale_x      = 1.0f;
+      rotate_draw.scale_y      = 1.0f;
+      rotate_draw.scale_z      = 1.0f;
+      rotate_draw.scale_enable = true;
+
+      gfx_display_rotate_z(p_disp, &rotate_draw, userdata);
+   }
+
    for (i = 0; i < (unsigned)(ozone->system_tab_end+1); i++)
    {
       enum msg_hash_enums value_idx;
@@ -2878,9 +2882,10 @@ static void ozone_draw_sidebar(
             y + ozone->dimensions.sidebar_entry_height / 2 - ozone->dimensions.sidebar_entry_icon_size / 2 + ozone->animations.scroll_y_sidebar,
             video_width,
             video_height,
-            0,
-            1,
-            col);
+            0.0f,
+            1.0f,
+            col,
+            &mymat);
 
       value_idx = ozone_system_tabs_value[ozone->tabs[i]];
       title     = msg_hash_to_str(value_idx);
@@ -2962,9 +2967,10 @@ static void ozone_draw_sidebar(
                y + ozone->dimensions.sidebar_entry_height / 2 - ozone->dimensions.sidebar_entry_icon_size / 2 + ozone->animations.scroll_y_sidebar,
                video_width,
                video_height,
-               0,
-               1,
-               col);
+               0.0f,
+               1.0f,
+               col,
+               &mymat);
 
          /* Text */
          if (ozone->sidebar_collapsed)
@@ -4011,7 +4017,8 @@ static void ozone_draw_entry_value(
       char *value,
       unsigned x, unsigned y,
       uint32_t alpha_uint32,
-      menu_entry_t *entry)
+      menu_entry_t *entry,
+      math_matrix_4x4 *mymat)
 {
    bool switch_is_on                 = true;
    bool do_draw_text                 = false;
@@ -4036,9 +4043,10 @@ static void ozone_draw_entry_value(
             y - 22 * scale_factor,
             video_width,
             video_height,
-            0,
-            1,
-            col);
+            0.0f,
+            1.0f,
+            col,
+            mymat);
       if (dispctx && dispctx->blend_end)
          dispctx->blend_end(userdata);
       return;
@@ -4124,7 +4132,8 @@ static void ozone_draw_no_thumbnail_available(
       unsigned video_height,
       unsigned x_position,
       unsigned sidebar_width,
-      unsigned y_offset)
+      unsigned y_offset,
+      math_matrix_4x4 *mymat)
 {
    unsigned icon                     = OZONE_ENTRIES_ICONS_TEXTURE_CORE_INFO;
    unsigned icon_size                = (unsigned)((float)
@@ -4149,7 +4158,10 @@ static void ozone_draw_no_thumbnail_available(
                video_height/2 - icon_size/2 - y_offset,
                video_width,
                video_height,
-               0, 1, col);
+               0.0f,
+               1.0f,
+               col,
+               mymat);
       if (dispctx->blend_end)
          dispctx->blend_end(userdata);
    }
@@ -4393,7 +4405,8 @@ static void ozone_draw_entries(
       file_list_t *selection_buf,
       float alpha,
       float scroll_y,
-      bool is_playlist)
+      bool is_playlist,
+      math_matrix_4x4 *mymat)
 {
    uint32_t alpha_uint32;
    size_t i;
@@ -4727,9 +4740,10 @@ border_iterate:
                      / 2 - ozone->dimensions.entry_icon_size / 2,
                      video_width,
                      video_height,
-                     0,
-                     1,
-                     icon_color);
+                     0.0f,
+                     1.0f,
+                     icon_color,
+                     mymat);
             if (dispctx->blend_end)
                dispctx->blend_end(userdata);
          }
@@ -4817,7 +4831,8 @@ border_iterate:
             + entry_width - ozone->dimensions.entry_icon_padding,
             y + ozone->dimensions.entry_height / 2 + ozone->fonts.entries_label.line_centre_offset + scroll_y,
             alpha_uint32,
-            &entry);
+            &entry,
+            mymat);
 
       y += node->height;
    }
@@ -4838,7 +4853,8 @@ static void ozone_draw_thumbnail_bar(
       unsigned video_width,
       unsigned video_height,
       bool libretro_running,
-      float menu_framebuffer_opacity)
+      float menu_framebuffer_opacity,
+      math_matrix_4x4 *mymat)
 {
    enum gfx_thumbnail_alignment right_thumbnail_alignment;
    enum gfx_thumbnail_alignment left_thumbnail_alignment;
@@ -4920,7 +4936,8 @@ static void ozone_draw_thumbnail_bar(
             userdata,
             video_width,
             video_height,
-            x_position, sidebar_width, 0);
+            x_position, sidebar_width, 0,
+            mymat);
       return;
    }
 
@@ -4977,7 +4994,8 @@ static void ozone_draw_thumbnail_bar(
             video_height,
             x_position,
             sidebar_width,
-            thumbnail_height / 2);
+            thumbnail_height / 2,
+            mymat);
 
    /* Bottom row
     * > Displays one item, with the following order
@@ -5316,7 +5334,10 @@ static void ozone_draw_thumbnail_bar(
                      video_height - ozone->dimensions.footer_height - ozone->dimensions.sidebar_entry_icon_padding - icon_size,
                      video_width,
                      video_height,
-                     0, 1, col);
+                     0.0f,
+                     1.0f,
+                     col,
+                     mymat);
             if (dispctx->blend_end)
                dispctx->blend_end(userdata);
          }
@@ -8274,7 +8295,8 @@ static void ozone_draw_header(
       unsigned video_width,
       unsigned video_height,
       bool battery_level_enable,
-      bool timedate_enable)
+      bool timedate_enable,
+      math_matrix_4x4 *mymat)
 {
    char title[255];
    gfx_animation_ctx_ticker_t ticker;
@@ -8382,7 +8404,10 @@ static void ozone_draw_header(
                   14 * scale_factor, /* Where does this come from...? */
                   video_width,
                   video_height,
-                  0, 1, col);
+                  0.0f,
+                  1.0f,
+                  col,
+                  &mymat);
          else
 #endif
             ozone_draw_icon(
@@ -8397,7 +8422,10 @@ static void ozone_draw_header(
                   (ozone->dimensions.header_height - logo_icon_size) / 2,
                   video_width,
                   video_height,
-                  0, 1, col);
+                  0.0f,
+                  1.0f,
+                  col,
+                  mymat);
       }
       if (dispctx->blend_end)
          dispctx->blend_end(userdata);
@@ -8452,7 +8480,10 @@ static void ozone_draw_header(
                      0,
                      video_width,
                      video_height,
-                     0, 1, col);
+                     0.0f,
+                     1.0f,
+                     col,
+                     mymat);
             if (dispctx->blend_end)
                dispctx->blend_end(userdata);
          }
@@ -8506,7 +8537,10 @@ static void ozone_draw_header(
                   0,
                   video_width,
                   video_height,
-                  0, 1, col);
+                  0.0f,
+                  1.0f,
+                  col,
+                  mymat);
          if (dispctx->blend_end)
             dispctx->blend_end(userdata);
       }
@@ -8521,7 +8555,8 @@ static void ozone_draw_footer(
       unsigned video_width,
       unsigned video_height,
       bool input_menu_swap_ok_cancel_buttons,
-      settings_t *settings)
+      settings_t *settings,
+      math_matrix_4x4 *mymat)
 {
    bool menu_core_enable                  = settings->bools.menu_core_enable;
    float scale_factor                     = ozone->last_scale_factor;
@@ -8614,7 +8649,10 @@ static void ozone_draw_footer(
                icon_y,
                video_width,
                video_height,
-               0, 1, col);
+               0.0f,
+               1.0f,
+               col,
+               mymat);
 
          /* > back */
          ozone_draw_icon(
@@ -8630,7 +8668,10 @@ static void ozone_draw_footer(
                back_x,
                icon_y,
                video_width,video_height,
-               0, 1, col);
+               0.0f,
+               1.0f,
+               col,
+               mymat);
 
          /* > search */
          ozone_draw_icon(
@@ -8644,7 +8685,10 @@ static void ozone_draw_footer(
                search_x,
                icon_y,
                video_width,video_height,
-               0, 1, col);
+               0.0f,
+               1.0f,
+               col,
+               mymat);
 
          /* > fullscreen_thumbs */
          if (fullscreen_thumbnails_available)
@@ -8659,7 +8703,10 @@ static void ozone_draw_footer(
                   fullscreen_thumbs_x,
                   icon_y,
                   video_width,video_height,
-                  0, 1, col);
+                  0.0f,
+                  1.0f,
+                  col,
+                  mymat);
 
          /* > metadata_toggle */
          if (metadata_override_available)
@@ -8674,7 +8721,10 @@ static void ozone_draw_footer(
                   metadata_toggle_x,
                   icon_y,
                   video_width,video_height,
-                  0, 1, col);
+                  0.0f,
+                  1.0f,
+                  col,
+                  mymat);
       }
 
       if (dispctx->blend_end)
@@ -8861,9 +8911,10 @@ static void ozone_draw_footer(
                   video_height - ozone->dimensions.footer_height / 2 - 15 * scale_factor,
                   video_width,
                   video_height,
-                  0,
-                  1,
-                  ozone->pure_white);
+                  0.0f,
+                  1.0f,
+                  ozone->pure_white,
+                  &mymat);
          if (dispctx->blend_end)
             dispctx->blend_end(userdata);
       }
@@ -9047,6 +9098,7 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
    gfx_display_t            *p_disp       = (gfx_display_t*)video_info->disp_userdata;
    gfx_animation_t *p_anim                = anim_get_ptr();
    gfx_display_ctx_driver_t *dispctx      = p_disp->dispctx;
+   math_matrix_4x4 mymat;
 
 #if 0
    static bool reset                      = false;
@@ -9142,6 +9194,18 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
          background_color,
          NULL);
 
+   {
+      gfx_display_ctx_rotate_draw_t rotate_draw;
+      rotate_draw.matrix       = &mymat;
+      rotate_draw.rotation     = 0.0f;
+      rotate_draw.scale_x      = 1.0f;
+      rotate_draw.scale_y      = 1.0f;
+      rotate_draw.scale_z      = 1.0f;
+      rotate_draw.scale_enable = true;
+
+      gfx_display_rotate_z(p_disp, &rotate_draw, userdata);
+   }
+
    /* Header, footer */
    ozone_draw_header(
          ozone,
@@ -9152,14 +9216,15 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
          video_width,
          video_height,
          battery_level_enable,
-         timedate_enable);
+         timedate_enable,
+         &mymat);
    ozone_draw_footer(ozone,
          p_disp, p_anim,
          userdata,
          video_width,
          video_height,
          input_menu_swap_ok_cancel_buttons,
-         settings);
+         settings, &mymat);
 
    /* Sidebar */
    if (ozone->draw_sidebar)
@@ -9199,7 +9264,8 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
          menu_entries_get_selection_buf_ptr(0),
          ozone->animations.list_alpha,
          ozone->animations.scroll_y,
-         ozone->is_playlist
+         ozone->is_playlist,
+         &mymat
          );
 
    /* Old list */
@@ -9217,7 +9283,8 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
             &ozone->selection_buf_old,
             ozone->animations.list_alpha,
             ozone->scroll_old,
-            ozone->is_playlist_old
+            ozone->is_playlist_old,
+            &mymat
       );
 
    /* Thumbnail bar */
@@ -9230,7 +9297,8 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
             video_width,
             video_height,
             libretro_running,
-            menu_framebuffer_opacity);
+            menu_framebuffer_opacity,
+            &mymat);
 
    if (dispctx && dispctx->scissor_end)
       dispctx->scissor_end(userdata,

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -844,7 +844,6 @@ static void xmb_draw_icon(
       unsigned video_height,
       bool xmb_shadows_enable,
       int icon_size,
-      math_matrix_4x4 *mymat,
       uintptr_t texture,
       float x,
       float y,
@@ -854,7 +853,8 @@ static void xmb_draw_icon(
       float rotation,
       float scale_factor,
       float *color,
-      float shadow_offset)
+      float shadow_offset,
+      math_matrix_4x4 *mymat)
 {
    gfx_display_ctx_draw_t draw;
    struct video_coords coords;
@@ -3551,7 +3551,6 @@ static int xmb_draw_item(
             video_height,
             xmb_shadows_enable,
             xmb->icon_size,
-            &mymat_tmp,
             texture,
             x,
             y,
@@ -3561,7 +3560,8 @@ static int xmb_draw_item(
             rotation,
             scale_factor,
             &color[0],
-            xmb->shadow_offset);
+            xmb->shadow_offset,
+            &mymat_tmp);
    }
 
    gfx_display_set_alpha(color, MIN(node->alpha, xmb->alpha));
@@ -3575,7 +3575,6 @@ static int xmb_draw_item(
             video_height,
             xmb_shadows_enable,
             xmb->icon_size,
-            mymat,
             texture_switch,
             node->x + xmb->margins_screen_left
             + xmb->icon_spacing_horizontal
@@ -3586,7 +3585,8 @@ static int xmb_draw_item(
             0,
             1,
             &color[0],
-            xmb->shadow_offset);
+            xmb->shadow_offset,
+            mymat);
 
    return 0;
 }
@@ -5183,7 +5183,6 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
                   video_height,
                   xmb_shadows_enable,
                   xmb->icon_size,
-                  &mymat,
                   xmb->textures.list[
                   powerstate.charging? XMB_TEXTURE_BATTERY_CHARGING   :
                   (powerstate.percent > 80)? XMB_TEXTURE_BATTERY_FULL :
@@ -5200,7 +5199,8 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
                   0,
                   1,
                   &item_color[0],
-                  xmb->shadow_offset);
+                  xmb->shadow_offset,
+                  &mymat);
                   if (dispctx && dispctx->blend_end)
                      dispctx->blend_end(userdata);
          }
@@ -5239,7 +5239,6 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
                video_height,
                xmb_shadows_enable,
                xmb->icon_size,
-               &mymat,
                xmb->textures.list[XMB_TEXTURE_CLOCK],
                video_width - xmb->icon_size - x_pos,
                xmb->icon_size,
@@ -5249,7 +5248,8 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
                0,
                1,
                &item_color[0],
-               xmb->shadow_offset);
+               xmb->shadow_offset,
+               &mymat);
          if (dispctx && dispctx->blend_end)
             dispctx->blend_end(userdata);
       }
@@ -5288,7 +5288,6 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
             video_height,
             xmb_shadows_enable,
             xmb->icon_size,
-            &mymat,
             xmb->textures.list[XMB_TEXTURE_ARROW],
             xmb->x + xmb->margins_screen_left +
             xmb->icon_spacing_horizontal -
@@ -5302,7 +5301,8 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
             0,
             1,
             &item_color[0],
-            xmb->shadow_offset);
+            xmb->shadow_offset,
+            &mymat);
       if (dispctx && dispctx->blend_end)
          dispctx->blend_end(userdata);
    }
@@ -5375,7 +5375,6 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
                   video_height,
                   xmb_shadows_enable,
                   xmb->icon_size,
-                  &mymat,
                   texture,
                   x,
                   y,
@@ -5385,7 +5384,8 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
                   rotation,
                   scale_factor,
                   &item_color[0],
-                  xmb->shadow_offset);
+                  xmb->shadow_offset,
+                  &mymat);
          }
       }
 


### PR DESCRIPTION
An unnecessary amount of calls to gfx_display_rotate_z were made as a result of calling the menu drivers' local 'draw_icon' function. This PR vastly reduces the amount of times we build this matrix, it's no longer done per function call but instead we pass the pointer to the function and call it once per function call instead.