### PR TITLE
When extracting content from compressed archive files, set valid extensions to the indicated one in the path instead of the (currently) hardcoded valid extensions in the cores

### DIFF
--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -810,10 +810,19 @@ static bool content_file_extract_from_archive(
 
    RARCH_LOG("[CONTENT LOAD]: Core requires uncompressed content - "
          "extracting archive to temporary directory.\n");
+         
+   /* Set valid_exts if content_path tells the file extension */
+   char valid_exts_tmp[9] = "";
+   const char *valid_exts_final = valid_exts;
+   const char *ext = path_get_extension(*content_path);
+   if (strlen(ext) > 0) {
+      strncpy(valid_exts_tmp, ext, 8);
+      valid_exts_final = valid_exts_tmp;
+   }
 
    /* Attempt to extract file  */
    if (!file_archive_extract_file(
-         *content_path, valid_exts,
+         *content_path, valid_exts_final,
          string_is_empty(content_ctx->directory_cache) ?
                NULL : content_ctx->directory_cache,
          temp_path, sizeof(temp_path)))

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -802,21 +802,24 @@ static bool content_file_extract_from_archive(
       char **error_string)
 {
    const char *temp_path_ptr = NULL;
+   const char *valid_exts_final = NULL;
+   const char *ext = NULL;
    char temp_path[PATH_MAX_LENGTH];
    char msg[1024];
+   char valid_exts_tmp[9];
 
    temp_path[0] = '\0';
    msg[0]       = '\0';
+   valid_exts_tmp[0] = '\0';
 
    RARCH_LOG("[CONTENT LOAD]: Core requires uncompressed content - "
          "extracting archive to temporary directory.\n");
          
    /* Set valid_exts if content_path tells the file extension */
-   char valid_exts_tmp[9] = "";
-   const char *valid_exts_final = valid_exts;
-   const char *ext = path_get_extension(*content_path);
+   valid_exts_final = valid_exts;
+   ext = path_get_extension(*content_path);
    if (strlen(ext) > 0) {
-      strncpy(valid_exts_tmp, ext, 8);
+      strlcpy(valid_exts_tmp, ext, sizeof(valid_exts_tmp));
       valid_exts_final = valid_exts_tmp;
    }
 


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

[Description of the pull request, detail any issues you are fixing or any features you are implementing]
The current behavior does not allow extracting content from compressed archive files whose extrension is not in the hardcoded valid extensions even if the core info file says otherwise. Example:
* Content path: /path/to/archive.zip#mygame.ex3
* Supported extensions from core info file: ex1|ex2|ex3
* Hardcoded valid extensions from the core itself: ex1|ex2 ("ex3" is missing)

If it tries to extract the content with "ex3" file extension, it will fail because it takes precedence from the hardcoded valid extensions and won't extract the content because "ex3" is not valid. This issue doesn't happen if it loads the content from the compressed archive file directly to memory without extracting it (when need_fullpath is false).

This PR changes the behavior by setting the valid extensions to only the writen one in the path, making it able to extract and load the content. Example:
* Content path: /path/to/archive.zip#mygame.ex3
* Valid extensions before: ex1|ex2
* Valid extensions after (on load): ex3

Example 2:
* Content path: /path/to/archive.zip#anothergame.ex1
* Valid extensions before: ex1|ex2
* Valid extensions after (on load): ex1

I mean, i those files can be added to the playlist via "Scan Directory" because the core info file says that the extension is valid, but the core itself says otherwise and prevents RetroArch from extracting it and the content can't be loaded (if need_fullpath is true).

Note: I know I'm limiting the file extension up to 8 characters (see the diff). I just want to know if it's fine or it should allow larger file extensions.

## Related Issues

* #12462 (also opened by me)

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
