### PR TITLE
Fix ram states to file when core deinit

### DIFF
--- a/content.h
+++ b/content.h
@@ -60,6 +60,9 @@ bool content_load_state(const char* path, bool load_to_backup_buffer, bool autol
 /* Save a state from memory to disk. */
 bool content_save_state(const char *path, bool save_to_disk, bool autosave);
 
+/* Check a ram state write to disk. */
+bool content_ram_state_pending(void);
+
 /* Gets the number of bytes required to serialize the state. */
 size_t content_get_serialized_size(void);
 

--- a/gfx/common/ctr_common.h
+++ b/gfx/common/ctr_common.h
@@ -149,7 +149,6 @@ typedef struct ctr_video
    bool refresh_bottom_menu;
    bool render_font_bottom;
    bool render_state_from_png_file;
-   bool state_data_on_ram;
    bool state_data_exist;
    char state_date[CTR_STATE_DATE_SIZE];
    int state_slot;

--- a/retroarch.c
+++ b/retroarch.c
@@ -7741,6 +7741,19 @@ static void path_clear_all(void)
    path_clear(RARCH_PATH_BASENAME);
 }
 
+void ram_state_to_file(void)
+{
+   char state_path[PATH_MAX_LENGTH];
+
+   if (!content_ram_state_pending())
+      return;
+
+   state_path[0] = '\0';
+
+   if (retroarch_get_current_savestate_path(state_path, sizeof(state_path)))
+      command_event(CMD_EVENT_RAM_STATE_TO_FILE, state_path);
+}
+
 bool retroarch_get_current_savestate_path(char *path, size_t len)
 {
    struct rarch_state *p_rarch = &rarch_st;
@@ -12107,6 +12120,10 @@ bool command_event(enum event_command cmd, void *data)
 
             runloop_state.core_running   = false;
 
+            /* The platform that uses ram_state_save calls it when the content
+             * ends and writes it to a file */
+            ram_state_to_file();
+
             /* Save last selected disk index, if required */
             if (sys_info)
                disk_control_save_image_index(&sys_info->disk_control);
@@ -12520,12 +12537,10 @@ bool command_event(enum event_command cmd, void *data)
          {
             struct retro_hw_render_callback *hwr = NULL;
             rarch_system_info_t *sys_info        = &runloop_state.system;
-            char state_path[PATH_MAX_LENGTH];
 
             /* The platform that uses ram_state_save calls it when the content
              * ends and writes it to a file */
-            if (retroarch_get_current_savestate_path(state_path, sizeof(state_path)))
-               command_event(CMD_EVENT_RAM_STATE_TO_FILE, state_path);
+            ram_state_to_file();
 
             /* Save last selected disk index, if required */
             if (sys_info)

--- a/retroarch.c
+++ b/retroarch.c
@@ -12768,6 +12768,12 @@ bool command_event(enum event_command cmd, void *data)
          {
             struct retro_hw_render_callback *hwr = NULL;
             rarch_system_info_t *sys_info        = &runloop_state.system;
+            char state_path[PATH_MAX_LENGTH];
+
+            /* The platform that uses ram_state_save calls it when the content
+             * ends and writes it to a file */
+            if (retroarch_get_current_savestate_path(state_path, sizeof(state_path)))
+               command_event(CMD_EVENT_RAM_STATE_TO_FILE, state_path);
 
             /* Save last selected disk index, if required */
             if (sys_info)

--- a/tasks/task_save.c
+++ b/tasks/task_save.c
@@ -86,6 +86,12 @@ struct save_state_buf
    char path[PATH_MAX_LENGTH];
 };
 
+struct ram_save_state_buf
+{
+   struct save_state_buf state_buf;
+   bool to_write_file;
+};
+
 struct sram_block
 {
    void *data;
@@ -153,7 +159,7 @@ static struct save_state_buf undo_load_buf;
 
 /* Buffer that stores state instead of file.
  * This is useful for devices with slow I/O. */
-static struct save_state_buf ram_buf;
+static struct ram_save_state_buf ram_buf;
 
 #ifdef HAVE_THREADS
 /* TODO/FIXME - global state - perhaps move outside this file */
@@ -1673,14 +1679,15 @@ bool content_reset_savestate_backups(void)
    undo_load_buf.path[0] = '\0';
    undo_load_buf.size    = 0;
 
-   if (ram_buf.data)
+   if (ram_buf.state_buf.data)
    {
-      free(ram_buf.data);
-      ram_buf.data       = NULL;
+      free(ram_buf.state_buf.data);
+      ram_buf.state_buf.data = NULL;
    }
 
-   ram_buf.path[0]       = '\0';
-   ram_buf.size          = 0;
+   ram_buf.state_buf.path[0] = '\0';
+   ram_buf.state_buf.size    = 0;
+   ram_buf.to_write_file     = false;
 
    return true;
 }
@@ -1833,15 +1840,18 @@ bool content_load_state_from_ram(void)
    bool ret                  = false;
    void* temp_data           = NULL;
 
+   if (!ram_buf.state_buf.data)
+      return false;
+
    RARCH_LOG("[State]: %s, %u %s.\n",
          msg_hash_to_str(MSG_LOADING_STATE),
-         (unsigned)ram_buf.size,
+         (unsigned)ram_buf.state_buf.size,
          msg_hash_to_str(MSG_BYTES));
 
    /* We need to make a temporary copy of the buffer, to allow the swap below */
-   temp_data              = malloc(ram_buf.size);
-   temp_data_size         = ram_buf.size;
-   memcpy(temp_data, ram_buf.data, ram_buf.size);
+   temp_data              = malloc(ram_buf.state_buf.size);
+   temp_data_size         = ram_buf.state_buf.size;
+   memcpy(temp_data, ram_buf.state_buf.data, ram_buf.state_buf.size);
 
    /* Swap the current state with the backup state. This way, we can undo
    what we're undoing */
@@ -1908,22 +1918,23 @@ bool content_save_state_to_ram(void)
    }
 
    /* If we were holding onto an old state already, clean it up first */
-   if (ram_buf.data)
+   if (ram_buf.state_buf.data)
    {
-      free(ram_buf.data);
-      ram_buf.data = NULL;
+      free(ram_buf.state_buf.data);
+      ram_buf.state_buf.data = NULL;
    }
 
-   ram_buf.data = malloc(serial_size);
-   if (!ram_buf.data)
+   ram_buf.state_buf.data = malloc(serial_size);
+   if (!ram_buf.state_buf.data)
    {
       free(data);
       return false;
    }
 
-   memcpy(ram_buf.data, data, serial_size);
+   memcpy(ram_buf.state_buf.data, data, serial_size);
    free(data);
-   ram_buf.size = serial_size;
+   ram_buf.state_buf.size = serial_size;
+   ram_buf.to_write_file = true;
 
    return true;
 }
@@ -1948,17 +1959,23 @@ bool content_ram_state_to_file(const char *path)
    if (!path)
       return false;
 
-   if (!ram_buf.data)
+   if (!ram_buf.state_buf.data)
+      return false;
+
+   if (!ram_buf.to_write_file)
       return false;
 
 #if defined(HAVE_ZLIB)
    if (compress_files)
       write_success = rzipstream_write_file(
-         path, ram_buf.data, ram_buf.size);
+         path, ram_buf.state_buf.data, ram_buf.state_buf.size);
    else
 #endif
       write_success = filestream_write_file(
-         path, ram_buf.data, ram_buf.size);
+         path, ram_buf.state_buf.data, ram_buf.state_buf.size);
+
+   if (write_success)
+      ram_buf.to_write_file = false;
 
    return write_success;
 }

--- a/tasks/task_save.c
+++ b/tasks/task_save.c
@@ -1556,6 +1556,17 @@ bool content_save_state(const char *path, bool save_to_disk, bool autosave)
    return true;
 }
 
+/**
+ * content_ram_state_pending:
+ * Check a ram state write to disk.
+ *
+ * Returns: true if need to write, false otherwise.
+ **/
+bool content_ram_state_pending(void)
+{
+   return ram_buf.to_write_file;
+}
+
 static bool task_save_state_finder(retro_task_t *task, void *user_data)
 {
    if (!task)


### PR DESCRIPTION
## Description
 Removed `state_data_on_ram` from ctr_common.h
 -> Set flag for write file on `ram_save_state_buf`'s `to_write_file`

 Call `CMD_EVENT_RAM_STATE_TO_FILE` when `CMD_EVENT_CORE_DEINIT`
 -> This should also be called when using ram_state on other platforms.


## Related Issues
https://github.com/libretro/RetroArch/issues/12950

## Reviewers
@MrHuu 
@jdgleaver 
