### PR TITLE
(cheevos) disable slowmotion when enabling hardcore mode

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -14048,6 +14048,9 @@ bool command_event(enum event_command cmd, void *data)
       case CMD_EVENT_CHEEVOS_HARDCORE_MODE_TOGGLE:
 #ifdef HAVE_CHEEVOS
          rcheevos_toggle_hardcore_paused();
+
+         if (rcheevos_hardcore_active())
+            runloop_state.slowmotion = false;
 #endif
          break;
       case CMD_EVENT_REINIT_FROM_TOGGLE:


### PR DESCRIPTION
## Description

There's already code preventing the user from toggling (or otherwise using) slowmotion when achievement hardcore mode is enabled. Slowmotion provides an advantage for the user's reflexes, so we don't allow it in hardcore mode. 

This addresses an issue where the user could enable hardcore mode with slowmotion already toggled on, and it would remain on. The user would be locked in slowmotion as the toggle would be disabled, but with enough patience, it could be worth it. With this change, slowmotion is disabled when enabling hardcore mode.

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@Sanaki 
