### PR TITLE
(cheevos) don't write achievement credentials to overrides

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -4513,8 +4513,26 @@ bool config_save_overrides(enum override_type type, void *data)
       for (i = 0; i < (unsigned)array_settings_size; i++)
       {
          if (!string_is_equal(array_settings[i].ptr, array_overrides[i].ptr))
+         {
+#ifdef HAVE_CHEEVOS
+            /* As authentication doesn't occur until after content is loaded,
+             * the achievement authentication token might only exist in the
+             * override set, and therefore differ from the master config set.
+             * Storing the achievement authentication token in an override
+             * is a recipe for disaster. If it expires and the user generates
+             * a new token, then the override will be out of date and the
+             * user will have to reauthenticate for each override (and also
+             * remember to update each override). Also exclude the username
+             * as it's directly tied to the token and password.
+             */
+            if (string_is_equal(array_settings[i].ident, "cheevos_token") ||
+                string_is_equal(array_settings[i].ident, "cheevos_password") ||
+                string_is_equal(array_settings[i].ident, "cheevos_username"))
+               continue;
+#endif
             config_set_string(conf, array_overrides[i].ident,
                   array_overrides[i].ptr);
+         }
       }
 
       for (i = 0; i < (unsigned)path_settings_size; i++)


### PR DESCRIPTION
## Description

Ignores changes to `cheevos_token`, `cheevos_password`, and `cheevos_username` when generating config override files.

While this is particularly important for not remembering a stale authentication token, not entering any credentials until after loading content, and then saving the override could lead to the actual password being stored in the override even after the authentication token is generated and put in the master settings file.

Since neither the authentication token nor the password should be stored in the override file, I believe it also makes sense to exclude the username, as having a per-override username would also require a per-override authentication token or password. If a players wants to have a separate retroachievements user for a specific core, they can still manually add the entries to the override file, but those will be cleared out any time they update the override file from within the application. A better solution would be to use separate master configs and launch using the --config option.

## Related Issues

closes #12953, probably #10353, possibly #11664

## Related Pull Requests

n/a

## Reviewers

@Sanaki 
