### PR TITLE
fix(udev): max/min calculation reworked for lightgun/mouse/touchscreen

### DIFF
--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -626,7 +626,7 @@ static int udev_input_add_device(udev_input_t *udev,
       device->mouse.x_max = 0;
       device->mouse.y_max = 0;
 
-      if (device->mouse.abs)
+      if (device->mouse.abs == 1)
       {
 
          if (ioctl(fd, EVIOCGABS(ABS_X), &absinfo) == -1)
@@ -646,7 +646,36 @@ static int udev_input_add_device(udev_input_t *udev,
          device->mouse.y_min = absinfo.minimum;
          device->mouse.y_max = absinfo.maximum;
       }
+	  else if (device->mouse.abs == 2)
+	  {
+		  if (ioctl(fd, EVIOCGABS(ABS_X), &absinfo) >= 0)
+		  {
+			 if (absinfo.minimum >= absinfo.maximum )
+			 {
+				device->mouse.x_min = -1;
+				device->mouse.x_max = -1;
+			 }
+			 else
+			 {
+				device->mouse.x_min = absinfo.minimum;
+				device->mouse.x_max = absinfo.maximum;
+			 }
+		  }
 
+		  if (ioctl(fd, EVIOCGABS(ABS_Y), &absinfo) >= 0)
+		  {
+			 if (absinfo.minimum >= absinfo.maximum )
+			 {
+				device->mouse.y_min = -1;
+				device->mouse.y_max = -1;
+			 }
+			 else
+			 {
+			   device->mouse.y_min = absinfo.minimum;
+			   device->mouse.y_max = absinfo.maximum;
+			 }
+		  }
+	  } 
       if (!mouse)
          goto end;
 


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

As identified by recalbox team during beta testing of 1.9.8 and investigation, we identified that "lightgun" area is reduced.
See issue here for more details/screenshots : https://gitlab.com/recalbox/recalbox/-/issues/1885
Please find the commit to correct the issue and some little mistake in code.

## Related Issues

https://github.com/libretro/RetroArch/issues/12973

## Related Pull Requests

N/A

## Reviewers

@pjft is know this file as contributors in the past on udev and lightgun
