### PR TITLE
this function is called more than once dont use static

### DIFF
--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -1228,8 +1228,8 @@ static bool open_devices(udev_input_t *udev,
    struct udev_list_entry     *devs = NULL;
    struct udev_list_entry     *item = NULL;
    struct udev_enumerate *enumerate = udev_enumerate_new(udev->udev);
-   static int device_keyboard                 = 0;
-   static int device_mouse                    = 0;
+   int device_keyboard                 = 0;
+   int device_mouse                    = 0;
    if (!enumerate)
       return false;
 


### PR DESCRIPTION
this will fix an issue found this function is called more than once so the static has to be removed. It was originally added for udev logging only.  fixes https://github.com/libretro/RetroArch/issues/12959 

