### PR TITLE
Fix issues when opening file with extra long path name

### DIFF
--- a/libretro-common/vfs/vfs_implementation_uwp.cpp
+++ b/libretro-common/vfs/vfs_implementation_uwp.cpp
@@ -403,7 +403,7 @@ libretro_vfs_implementation_file *retro_vfs_file_open_impl(
       creationDisposition = (mode & RETRO_VFS_FILE_ACCESS_UPDATE_EXISTING) != 0 ?
           OPEN_ALWAYS : CREATE_ALWAYS;
    }
-
+   path_str = "\\\\?\\" + path_str;
    file_handle = CreateFile2FromAppW(path_str->Data(), desireAccess, FILE_SHARE_READ, creationDisposition, NULL);
 
    if (file_handle != INVALID_HANDLE_VALUE)


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

Fix issue where it would fail to get a handle for a file as the path was too long. This was primarily an issue with extracting cheats as some of the filenames can be uber long.

Most wide string file io functions let you prepend \\?\ to bump up the max path length from 256 to over 11 thousand characters.
However it has the caveat of disabling string parsing/formatting but since the normal uwp fileio stuff didn't support the parsing/formatting stuff we have already been doing all that in app so it should just be good to go.

This has been tested by me and @gamr13 on both pc and console

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
