### PR TITLE
(Audio Mixer) Pad sample buffers to prevent potential heap-buffer-overflows when resampling (fixes crash when using 30 kHz menu audio files)

### DIFF
--- a/libretro-common/audio/audio_mixer.c
+++ b/libretro-common/audio/audio_mixer.c
@@ -279,17 +279,15 @@ static bool one_shot_resample(const float* in, size_t samples_in,
          resampler_ident, quality, ratio))
       return false;
 
-   /*
-    * Allocate on a 16-byte boundary, and pad to a multiple of 16 bytes. We
+   /* Allocate on a 16-byte boundary, and pad to a multiple of 16 bytes. We
     * add four more samples in the formula below just as safeguard, because
     * resampler->process sometimes reports more output samples than the
     * formula below calculates. Ideally, audio resamplers should have a
     * function to return the number of samples they will output given a
-    * count of input samples.
-    */
-   *samples_out                       = samples_in * ratio + 4;
+    * count of input samples. */
+   *samples_out                       = (size_t)(samples_in * ratio);
    *out                               = (float*)memalign_alloc(16,
-         ((*samples_out + 15) & ~15) * sizeof(float));
+         (((*samples_out + 4) + 15) & ~15) * sizeof(float));
 
    if (*out == NULL)
       return false;
@@ -547,9 +545,15 @@ static bool audio_mixer_play_ogg(
          goto error;
    }
 
+   /* Allocate on a 16-byte boundary, and pad to a multiple of 16 bytes. We
+    * add four more samples in the formula below just as safeguard, because
+    * resampler->process sometimes reports more output samples than the
+    * formula below calculates. Ideally, audio resamplers should have a
+    * function to return the number of samples they will output given a
+    * count of input samples. */
    samples                         = (unsigned)(AUDIO_MIXER_TEMP_BUFFER * ratio);
    ogg_buffer                      = (float*)memalign_alloc(16,
-         ((samples + 15) & ~15) * sizeof(float));
+         (((samples + 4) + 15) & ~15) * sizeof(float));
 
    if (!ogg_buffer)
    {
@@ -690,9 +694,15 @@ static bool audio_mixer_play_flac(
          goto error;
    }
 
+   /* Allocate on a 16-byte boundary, and pad to a multiple of 16 bytes. We
+    * add four more samples in the formula below just as safeguard, because
+    * resampler->process sometimes reports more output samples than the
+    * formula below calculates. Ideally, audio resamplers should have a
+    * function to return the number of samples they will output given a
+    * count of input samples. */
    samples                         = (unsigned)(AUDIO_MIXER_TEMP_BUFFER * ratio);
-   flac_buffer                      = (float*)memalign_alloc(16,
-         ((samples + 15) & ~15) * sizeof(float));
+   flac_buffer                     = (float*)memalign_alloc(16,
+         (((samples + 4) + 15) & ~15) * sizeof(float));
 
    if (!flac_buffer)
    {
@@ -762,9 +772,15 @@ static bool audio_mixer_play_mp3(
          goto error;
    }
 
+   /* Allocate on a 16-byte boundary, and pad to a multiple of 16 bytes. We
+    * add four more samples in the formula below just as safeguard, because
+    * resampler->process sometimes reports more output samples than the
+    * formula below calculates. Ideally, audio resamplers should have a
+    * function to return the number of samples they will output given a
+    * count of input samples. */
    samples                         = (unsigned)(AUDIO_MIXER_TEMP_BUFFER * ratio);
    mp3_buffer                      = (float*)memalign_alloc(16,
-         ((samples + 15) & ~15) * sizeof(float));
+         (((samples + 4) + 15) & ~15) * sizeof(float));
 
    if (!mp3_buffer)
    {


### PR DESCRIPTION
## Description

As reported in #12593, RetroArch will crash when using a 30 kHz audio sample as an achievement unlock sound, because the `sinc` resampler overflows the output audio buffer.

Upon further investigation, I came across this comment:

https://github.com/libretro/RetroArch/blob/868a4bf3fcbdee97a88b096d6b6ee01a2fcd3e22/libretro-common/audio/audio_mixer.c#L282-L289

...so it seems that this was already a known issue, and a previous developer had 'solved' the problem by padding the output buffer. Unfortunately this was only done for `wav` files.

This trivial PR applies the same padding to the mixer output buffer for `ogg`, `flac` and `mp3` file types (i.e. all data sources that undergo resampling).

Note that while this fixes the heap-buffer-overflow issue when mixing audio with 'non-standard' sample rates, a correct robust solution would be to implement what the above comment suggests: `Ideally, audio resamplers should have a function to return the number of samples they will output given a count of input samples.` This, however, is not very easy to do....

## Related Issues

#12593

