### PR TITLE
Add compile time option to make the unix platform use cwd as the base path for the env

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -188,6 +188,10 @@ endif
 
 ifeq ($(HAVE_UNIX), 1)
    OBJ += frontend/drivers/platform_unix.o
+
+	ifeq ($(UNIX_CWD_ENV), 1)
+		DEF_FLAGS += -DRARCH_UNIX_CWD_ENV
+	endif
 endif
 
 ifeq ($(TARGET), retroarch_3ds)

--- a/file_path_special.c
+++ b/file_path_special.c
@@ -107,6 +107,9 @@ bool fill_pathname_application_data(char *s, size_t len)
             "Library/Application Support/RetroArch", len);
       return true;
    }
+#elif defined(RARCH_UNIX_CWD_ENV)
+   getcwd(s, len);
+   return true;
 #elif defined(DINGUX)
    dingux_get_base_path(s, len);
    return true;

--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -1792,7 +1792,10 @@ static void frontend_unix_get_env(int *argc,
    }
 #else
    char base_path[PATH_MAX] = {0};
-#if defined(DINGUX)
+#if defined(RARCH_UNIX_CWD_ENV)
+   /* The entire path is zero initialized. */
+   base_path[0] = '.';
+#elif defined(DINGUX)
    dingux_get_base_path(base_path, sizeof(base_path));
 #else
    const char *xdg          = getenv("XDG_CONFIG_HOME");


### PR DESCRIPTION
## Description

Setting UNIX_CWD_ENV when compiling with the unix platform will make
the base path for the env the cwd. This is to be able to match the behavior on
Windows for targets where this behavior is desirable.

## Reviewers
@twinaphex @m4xw 