### PR TITLE
Fix analog inputs on HID devices

### DIFF
--- a/input/common/input_hid_common.c
+++ b/input/common/input_hid_common.c
@@ -52,12 +52,16 @@ int16_t gamepad_get_axis_value(int16_t state[3][2], axis_data *data)
    switch (data->axis)
    {
       case AXIS_LEFT_ANALOG_X:
+         value = state[RETRO_DEVICE_INDEX_ANALOG_LEFT][1];
+         break;
       case AXIS_LEFT_ANALOG_Y:
-         value = state[RETRO_DEVICE_INDEX_ANALOG_LEFT][data->axis];
+         value = state[RETRO_DEVICE_INDEX_ANALOG_LEFT][0];
          break;
       case AXIS_RIGHT_ANALOG_X:
+         value = state[RETRO_DEVICE_INDEX_ANALOG_RIGHT][1];
+         break;
       case AXIS_RIGHT_ANALOG_Y:
-         value = state[RETRO_DEVICE_INDEX_ANALOG_RIGHT][data->axis];
+         value = state[RETRO_DEVICE_INDEX_ANALOG_RIGHT][0];
          break;
    }
 

--- a/input/input_autodetect_builtin.c
+++ b/input/input_autodetect_builtin.c
@@ -295,14 +295,14 @@ DECL_BTN_EX(start,  3, "Start/Pause") \
 DECL_BTN_EX(select, 2, "Z") \
 DECL_BTN_EX(r,      10, "R Trigger") \
 DECL_BTN_EX(l,      11, "L Trigger") \
-DECL_AXIS_EX(l_x_plus,  +1, "Analog right") \
-DECL_AXIS_EX(l_x_minus, -1, "Analog left") \
-DECL_AXIS_EX(l_y_plus,  +0, "Analog up") \
-DECL_AXIS_EX(l_y_minus, -0, "Analog down") \
-DECL_AXIS_EX(r_x_plus,  +3, "C-stick right") \
-DECL_AXIS_EX(r_x_minus, -3, "C-stick left") \
-DECL_AXIS_EX(r_y_plus,  +2, "C-stick up") \
-DECL_AXIS_EX(r_y_minus, -2, "C-stick down")
+DECL_AXIS_EX(l_x_plus,  +0, "Analog right") \
+DECL_AXIS_EX(l_x_minus, -0, "Analog left") \
+DECL_AXIS_EX(l_y_plus,  +1, "Analog up") \
+DECL_AXIS_EX(l_y_minus, -1, "Analog down") \
+DECL_AXIS_EX(r_x_plus,  +2, "C-stick right") \
+DECL_AXIS_EX(r_x_minus, -2, "C-stick left") \
+DECL_AXIS_EX(r_y_plus,  +3, "C-stick up") \
+DECL_AXIS_EX(r_y_minus, -3, "C-stick down")
 
 #define WIIUINPUT_DS3_DEFAULT_BINDS \
 DECL_BTN_EX(menu_toggle, 16, "Playstation") \
@@ -322,14 +322,14 @@ DECL_BTN_EX(left, 6, "D-Pad left") \
 DECL_BTN_EX(right, 7, "D-Pad Right") \
 DECL_BTN_EX(r3, 15, "R3") \
 DECL_BTN_EX(l3, 14, "L3") \
-DECL_AXIS_EX(l_x_plus,  +1, "L Analog right") \
-DECL_AXIS_EX(l_x_minus, -1, "L Analog left") \
-DECL_AXIS_EX(l_y_plus,  +0, "L Analog up") \
-DECL_AXIS_EX(l_y_minus, -0, "L Analog down") \
-DECL_AXIS_EX(r_x_plus,  +3, "R Analog right") \
-DECL_AXIS_EX(r_x_minus, -3, "R Analog left") \
-DECL_AXIS_EX(r_y_plus,  +2, "R Analog up") \
-DECL_AXIS_EX(r_y_minus, -2, "R Analog down")
+DECL_AXIS_EX(l_x_plus,  +0, "L Analog right") \
+DECL_AXIS_EX(l_x_minus, -0, "L Analog left") \
+DECL_AXIS_EX(l_y_plus,  +1, "L Analog up") \
+DECL_AXIS_EX(l_y_minus, -1, "L Analog down") \
+DECL_AXIS_EX(r_x_plus,  +2, "R Analog right") \
+DECL_AXIS_EX(r_x_minus, -2, "R Analog left") \
+DECL_AXIS_EX(r_y_plus,  +3, "R Analog up") \
+DECL_AXIS_EX(r_y_minus, -3, "R Analog down")
 
 #define WIIUINPUT_GAMEPAD_DEFAULT_BINDS \
 DECL_BTN_EX(menu_toggle,  1, "Home") \


### PR DESCRIPTION
# Description

    File this one under "I'm not sure how this ever worked."

    I mean, it did (in 1.8.8). I'm not sure what changed, but ultimately what I did was
    a bunch of comparative testing against 1.8.8:

    - I confirmed the packet data was still being read successfully
    - I confirmed that the axis value being passed into pad->get_axis() had
      not changed
    - I confirmed the work done in `gamepad_read_axis_data()` was working the same
      between 1.8.8 and master

    With the only difference between 1.8.8 and current being the return value from
    `gamepad_read_axis_data()`, I just rewrote the method to work properly, and
    also fixed up the default axis mapping.

    I tested this with a sixaxis controller and GCA, configuring the analog-to-digital
    control override to use the right stick.

## Related Issues
#12964 
[Any issues this pull request may be addressing]

## Reviewers
@twinaphex @QuarkTheAwesome 
