### PR TITLE
Add distinct mouse #0 index label for drivers without multimouse

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -7406,11 +7406,15 @@ static void get_string_representation_mouse_index(rarch_setting_t *setting, char
 
       if (!string_is_empty(device_name))
          strlcpy(s, device_name, len);
-      else
+      else if (map > 0)
          snprintf(s, len,
                "%s (#%u)",
                msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE),
                map);
+      else
+         snprintf(s, len,
+               "%s",
+               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_DONT_CARE);
    }
    else
       snprintf(s, len,


### PR DESCRIPTION
## Description

Current "N/A" label for every mouse index is no bueno for drivers that can only handle one common mouse, therefore the first working index shall be "Default" instead.

Closes #12975 
