### PR TITLE
Prevent crash pointed out by LIJI - primary_joypad can be NULL

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -17877,12 +17877,17 @@ bool input_set_rumble_state(unsigned port,
    input_driver_state_t *input_driver_st  = &(p_rarch->input_driver_state);
    settings_t *settings                   = p_rarch->configuration_settings;
    unsigned joy_idx                       = settings->uints.input_joypad_index[port];
-   unsigned rumble_gain                   = settings->uints.input_rumble_gain;
    uint16_t scaled_strength               = strength;
 
    /* If gain setting is not suported, do software gain control */ 
-   if (!input_driver_st->primary_joypad->set_rumble_gain)
-      scaled_strength = (rumble_gain * strength) / 100.0;
+   if (input_driver_st && input_driver_st->primary_joypad)
+   {
+      if (!input_driver_st->primary_joypad->set_rumble_gain)
+      {
+         unsigned rumble_gain = settings->uints.input_rumble_gain;
+         scaled_strength      = (rumble_gain * strength) / 100.0;
+      }
+   }
 
    return input_driver_set_rumble(
       input_driver_st,


### PR DESCRIPTION
This issue was pointed out by @LIJI32 -

https://discord.com/channels/184109094070779904/469974542299955210/886243980067618866