### PR TITLE
(vfs_implementation.c) Place 'memmap.h' include behind '#if defined(HAVE_MMAP)' guard

### DIFF
--- a/libretro-common/vfs/vfs_implementation.c
+++ b/libretro-common/vfs/vfs_implementation.c
@@ -165,7 +165,9 @@
 
 #include <vfs/vfs_implementation.h>
 #include <libretro.h>
+#if defined(HAVE_MMAP)
 #include <memmap.h>
+#endif
 #include <encodings/utf.h>
 #include <compat/fopen_utf8.h>
 #include <file/file_path.h>


### PR DESCRIPTION
## Description

While working on https://github.com/libretro/snes9x2005/pull/89, I noticed that `vfs_implementation.c` includes `memmap.h` regardless of whether the `HAVE_MMAP` flag is set. This creates an unnecessary header dependency - and since some cores have a tendency to implement their own `memmap.h` libraries, this can lead to conflicts/headaches.

This trivial PR just places the `memmap.h` include behind an `#if defined(HAVE_MMAP)` guard, so cores that implement VFS functionality can have one less dependency to worry about.