### PR TITLE
Replace uwp dir handling with win32 io

### DIFF
--- a/libretro-common/vfs/vfs_implementation_uwp.cpp
+++ b/libretro-common/vfs/vfs_implementation_uwp.cpp
@@ -1099,151 +1099,106 @@ int retro_vfs_stat_impl(const char *path, int32_t *size)
    return 0;
 }
 
-
-
-
 #ifdef VFS_FRONTEND
 struct retro_vfs_dir_handle
 #else
 struct libretro_vfs_implementation_dir
 #endif
 {
-   IVectorView<IStorageItem^>^ directory;
-   IIterator<IStorageItem^>^ entry;
-   char *entry_name;
+    char* orig_path;
+    WIN32_FIND_DATAW entry;
+    HANDLE directory;
+    bool next;
+    char path[PATH_MAX_LENGTH];
 };
 
-libretro_vfs_implementation_dir* retro_vfs_opendir_impl(const char* name, bool include_hidden)
+libretro_vfs_implementation_dir* retro_vfs_opendir_impl(
+    const char* name, bool include_hidden)
 {
-    wchar_t* name_wide;
-    Platform::String^ name_str;
+    unsigned path_len;
+    char path_buf[1024];
+    size_t copied = 0;
+    wchar_t* path_wide = NULL;
     libretro_vfs_implementation_dir* rdir;
 
-    if (!name || !*name)
+    /*Reject null or empty string paths*/
+    if (!name || (*name == 0))
         return NULL;
 
+    /*Allocate RDIR struct. Tidied later with retro_closedir*/
     rdir = (libretro_vfs_implementation_dir*)calloc(1, sizeof(*rdir));
     if (!rdir)
         return NULL;
 
-    name_wide = utf8_to_utf16_string_alloc(name);
-    windowsize_path(name_wide);
-    name_str = ref new Platform::String(name_wide);
-    free(name_wide);
+    rdir->orig_path = strdup(name);
 
+    path_buf[0] = '\0';
+    path_len = strlen(name);
 
-    WIN32_FILE_ATTRIBUTE_DATA lpFileInfo;
-    std::filesystem::path dir(name);
+    copied = strlcpy(path_buf, name, sizeof(path_buf));
 
-    if (dir.empty())
-        return NULL;
+    /* Non-NT platforms don't like extra slashes in the path */
+    if (name[path_len - 1] != '\\')
+        path_buf[copied++] = '\\';
 
-   if (!(rdir->directory))
-   {
-       //check if file attributes can be gotten successfully 
-       if (GetFileAttributesExFromAppW(dir.parent_path().wstring().c_str(), GetFileExInfoStandard, &lpFileInfo))
-       {
-           //check that the files attributes are not null or empty
-           if (lpFileInfo.dwFileAttributes != INVALID_FILE_ATTRIBUTES && lpFileInfo.dwFileAttributes != 0)
-           {
-               if (lpFileInfo.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
-               {
-                   std::wstring filteredPath(dir.wstring().c_str());
-                   WIN32_FIND_DATA findDataResult;
-                   if (filteredPath[filteredPath.size() - 1] == '\\')
-                       filteredPath.erase(filteredPath.size() - 1);
-                   filteredPath += L"\\*.*";
-                   HANDLE searchResults = FindFirstFileExFromAppW(filteredPath.c_str(), FindExInfoBasic, &findDataResult, FindExSearchNameMatch, nullptr, FIND_FIRST_EX_LARGE_FETCH);
-                   if (searchResults != INVALID_HANDLE_VALUE)
-                   {
-                       Platform::Collections::Vector<IStorageItem^>^ result = ref new Platform::Collections::Vector<IStorageItem^>();
-                       do
-                       {
-                           if (wcscmp(findDataResult.cFileName, L".") != 0 && wcscmp(findDataResult.cFileName, L"..") != 0)
-                           {
-                               if (!((findDataResult.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN) || (findDataResult.dwFileAttributes & FILE_ATTRIBUTE_SYSTEM)))
-                               {
-                                   std::filesystem::path temp_new = dir;
-                                   temp_new /= findDataResult.cFileName;
+    path_buf[copied] = '*';
+    path_buf[copied + 1] = '\0';
 
-                                   std::wstring temp_path = temp_new.generic_wstring();
-                                   while (true) {
-                                       size_t p = temp_path.find(L"/");
-                                       if (p == std::wstring::npos) break;
-                                       temp_path.replace(p, 1, L"\\");
-                                   }
-                                   IStorageItem^ item;
-                                   if (findDataResult.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
-                                   {
-                                       item = RunAsyncAndCatchErrors<StorageFolder^>([&]() {
-                                           return concurrency::create_task(LocateStorageItem<StorageFolder>(ref new Platform::String(temp_path.c_str())));
-                                       }, nullptr);
-                                   }
-                                   else
-                                   {
-                                       item = RunAsyncAndCatchErrors<StorageFile^>([&]() {
-                                           return concurrency::create_task(LocateStorageItem<StorageFile>(ref new Platform::String(temp_path.c_str())));
-                                       }, nullptr);
-                                   }
+    path_wide = utf8_to_utf16_string_alloc(path_buf);
+    rdir->directory = FindFirstFileExFromAppW(path_wide, FindExInfoStandard, &rdir->entry, FindExSearchNameMatch, nullptr, FIND_FIRST_EX_LARGE_FETCH);
 
-                                   if (item)
-                                       if (result)
-                                           result->Append(item);
-                               }
-                           }
-                       } while (FindNextFile(searchResults, &findDataResult));
-                       FindClose(searchResults);
-                       if (result)
-                           rdir->directory = result->GetView();
-                   }
-               }
-           }
-       }
-   }
-   if (rdir->directory)
-      return rdir;
+    if (path_wide)
+        free(path_wide);
 
-   free(rdir);
-   return NULL;
+    if (include_hidden)
+        rdir->entry.dwFileAttributes |= FILE_ATTRIBUTE_HIDDEN;
+    else
+        rdir->entry.dwFileAttributes &= ~FILE_ATTRIBUTE_HIDDEN;
+
+    if (rdir->directory && rdir != INVALID_HANDLE_VALUE)
+        return rdir;
+
+    retro_vfs_closedir_impl(rdir);
+    return NULL;
 }
 
-bool retro_vfs_readdir_impl(libretro_vfs_implementation_dir *rdir)
+bool retro_vfs_readdir_impl(libretro_vfs_implementation_dir* rdir)
 {
-   if (!rdir->entry)
-   {
-      rdir->entry = rdir->directory->First();
-      return rdir->entry->HasCurrent;
-   }
-   return rdir->entry->MoveNext();
+    if (rdir->next)
+        return (FindNextFileW(rdir->directory, &rdir->entry) != 0);
+
+    rdir->next = true;
+    return (rdir->directory != INVALID_HANDLE_VALUE);
 }
 
-const char *retro_vfs_dirent_get_name_impl(
-      libretro_vfs_implementation_dir *rdir)
+const char* retro_vfs_dirent_get_name_impl(libretro_vfs_implementation_dir* rdir)
 {
-   if (rdir->entry_name)
-      free(rdir->entry_name);
-   rdir->entry_name = utf16_to_utf8_string_alloc(
-         rdir->entry->Current->Name->Data());
-   return rdir->entry_name;
+    char* name = utf16_to_utf8_string_alloc(rdir->entry.cFileName);
+    memset(rdir->entry.cFileName, 0, sizeof(rdir->entry.cFileName));
+    strlcpy((char*)rdir->entry.cFileName, name, sizeof(rdir->entry.cFileName));
+    if (name)
+        free(name);
+    return (char*)rdir->entry.cFileName;
 }
 
-bool retro_vfs_dirent_is_dir_impl(libretro_vfs_implementation_dir *rdir)
+bool retro_vfs_dirent_is_dir_impl(libretro_vfs_implementation_dir* rdir)
 {
-   return rdir->entry->Current->IsOfType(StorageItemTypes::Folder);
+    const WIN32_FIND_DATA* entry = (const WIN32_FIND_DATA*)&rdir->entry;
+    return entry->dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY;
 }
 
-int retro_vfs_closedir_impl(libretro_vfs_implementation_dir *rdir)
+int retro_vfs_closedir_impl(libretro_vfs_implementation_dir* rdir)
 {
-   if (!rdir)
-      return -1;
+    if (!rdir)
+        return -1;
 
-   if (rdir->entry_name)
-      free(rdir->entry_name);
-   rdir->entry     = nullptr;
-   rdir->directory = nullptr;
+    if (rdir->directory != INVALID_HANDLE_VALUE)
+        FindClose(rdir->directory);
 
-   free(rdir);
-   return 0;
+    if (rdir->orig_path)
+        free(rdir->orig_path);
+    free(rdir);
+    return 0;
 }
 
 char* uwp_trigger_picker(void)


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

This almost entirely strips out all usage of the uwp storagefolder object for dir handling in favour of a modified version of the normal win32 file io code. This means that sorting hidden files and folders now works properly and it should be faster.
I have tested folder navigation on both desktop and on console and have not experienced any issues.
@GABO1423 has helped test more comprehensively and has not experienced any issues.

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
