### PR TITLE
Add environment callback to get the rate retro_run is called

### DIFF
--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -1722,6 +1722,12 @@ enum retro_mod
                                             * Must be called in retro_set_environment().
                                             */
 
+#define RETRO_ENVIRONMENT_GET_THROTTLE_STATE (70 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+                                           /* struct retro_throttle_state * --
+                                            * Allows an implementation to get details on the actual rate
+                                            * the frontend is attempting to call retro_run().
+                                            */
+
 /* VFS functionality */
 
 /* File paths:
@@ -3665,6 +3671,42 @@ struct retro_fastforwarding_override
     * 'inhibit_toggle' is set to false, or the core
     * is unloaded */
    bool inhibit_toggle;
+};
+
+enum retro_throttle_mode
+{
+   /* During normal operation, rate will be equal to the core's FPS. */
+   RETRO_THROTTLE_NONE              = 0,
+
+   /* While paused or stepping single frames, rate will be 0. */
+   RETRO_THROTTLE_FRAME_STEPPING    = 1,
+
+   /* During fast forwarding.
+    * Rate will be 0 if not specifically limited to a maximum speed. */
+   RETRO_THROTTLE_FAST_FORWARD      = 2,
+
+   /* During slow motion. Rate will be less than the core's internal FPS. */
+   RETRO_THROTTLE_SLOW_MOTION       = 3,
+
+   /* Rewinding recorded save states. Rate can vary depending on the rewind
+    * speed or be 0 if the frontend is not aiming for a specific rate. */
+   RETRO_THROTTLE_REWINDING         = 4,
+
+   /* While vsync is active in the video driver and the target refresh rate is
+    * lower than the core's internal FPS. Rate is the target refresh rate. */
+   RETRO_THROTTLE_VSYNC             = 5,
+};
+
+struct retro_throttle_state
+{
+   /* The current throttling mode. */
+   enum retro_throttle_mode mode;
+
+   /* How many times per second the frontend tries calls retro_run.
+    * Depending on the mode, it can be 0 if there is no known fixed rate.
+    * This won't be accurate if the total processing time of the core and
+    * the frontend is longer than what is available for one frame. */
+   float rate;
 };
 
 /* Callbacks */


### PR DESCRIPTION
## Description

In my endeavor to add automatic performance scaling to a non-multi-threaded DOSBox core I ran into the problem that a core cannot feasibly distinct between these 3 scenarios:
- The core uses too much CPU time
- The user has activated slow-motion
- VSync is active and limiting the call-rate of retro_run

Only the first of these scenarios actually require the core to lower it's automatically scaling performance requirements. Without this extension I cannot properly support the features used in the other two scenarios while automatic performance scaling is active.

So this PR adds a new environment callback `RETRO_ENVIRONMENT_GET_THROTTLE_STATE` to ask the frontend about some details on what the actual rate it tries to call retro_run() and why.

The relevant sections of the API are as follows:

```c
#define RETRO_ENVIRONMENT_GET_THROTTLE_STATE (70 | RETRO_ENVIRONMENT_EXPERIMENTAL)
                                           /* struct retro_throttle_state * --
                                            * Allows an implementation to get details on the actual rate
                                            * the frontend is attempting to call retro_run().
                                            */

enum retro_throttle_mode
{
   /* During normal operation, rate will be equal to the core's FPS. */
   RETRO_THROTTLE_NONE              = 0,

   /* While paused or stepping single frames, rate will be 0. */
   RETRO_THROTTLE_FRAME_STEPPING    = 1,

   /* During fast forwarding.
    * Rate will be 0 if not specifically limited to a maximum speed. */
   RETRO_THROTTLE_FAST_FORWARD      = 2,

   /* During slow motion. Rate will be less than the core's internal FPS. */
   RETRO_THROTTLE_SLOW_MOTION       = 3,

   /* Rewinding recorded save states. Rate can vary depending on the rewind
    * speed or be 0 if the frontend is not aiming for a specific rate. */
   RETRO_THROTTLE_REWINDING         = 4,

   /* While vsync is active in the video driver and the target refresh rate is
    * lower than the core's internal FPS. Rate is the target refresh rate. */
   RETRO_THROTTLE_VSYNC             = 5,
};

struct retro_throttle_state
{
   /* The current throttling mode. */
   enum retro_throttle_mode mode;

   /* How many times per second the frontend tries calls retro_run.
    * Depending on the mode, it can be 0 if there is no known fixed rate.
    * This won't be accurate if the total processing time of the core and
    * the frontend is longer than what is available for one frame. */
   float rate;
};
```
(I appended `| RETRO_ENVIRONMENT_EXPERIMENTAL` because `RETRO_ENVIRONMENT_GET_FASTFORWARDING` also has it, not sure if that is needed or not)

If this environment callback is available, it can be used instead of `RETRO_ENVIRONMENT_GET_FASTFORWARDING`. A core can be backwards compatible by using something like this:

```c
	retro_throttle_state throttle = { RETRO_THROTTLE_NONE };
	if (!environ_cb(RETRO_ENVIRONMENT_GET_THROTTLE_STATE, &throttle))
	{
		bool fast_forward = false;
		if (environ_cb(RETRO_ENVIRONMENT_GET_FASTFORWARDING, &fast_forward) && fast_forward)
			dbp_throttle.mode = RETRO_THROTTLE_FAST_FORWARD;
	}
```

This is my first PR that modifies libretro.h so I'm open to any feedback or request for change.

## Reviewers
@jdgleaver