### PR TITLE
correct vscode gitignore typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,4 +227,4 @@ param.sfo
 /deps/SPIRV-Cross/out/build/x64-Debug
 
 # Visual Studio Code
-./vscode/
+.vscode/


### PR DESCRIPTION
I used this copy of the git man (https://git-scm.com/docs/gitignore) as a reference on the syntax here, since you can exclude folders a few different ways