### PR TITLE
(.gitlab-ci.yml) Detect MSVC build errors

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -104,9 +104,10 @@ build-retroarch-windows-msvc10-x64:
     SDK_BIN_DIR:    C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin
     RCEDIT_BIN_DIR: C:\Program Files\rcedit
     PEDEPS_BIN_DIR: C:\Program Files\pedeps-0.1.9-win64\bin
+    MSVC_PLATFORM:  windows_msvc2010_x64
   before_script:
     - $Env:HOME = "."
-    - $Env:Path += -join(";", "$Env:SDK_BIN_DIR", ";", "$Env:RCEDIT_BIN_DIR", ";", "$Env:PEDEPS_BIN_DIR")
+    - $Env:Path += -join(";", "$Env:MSYS_BIN_DIR", ";", "$Env:SDK_BIN_DIR", ";", "$Env:RCEDIT_BIN_DIR", ";", "$Env:PEDEPS_BIN_DIR")
   artifacts:
     paths:
     - retroarch.exe
@@ -114,26 +115,32 @@ build-retroarch-windows-msvc10-x64:
     expire_in: 10 min
   dependencies: []
   script:
-    # Build RetroArch
-    - $Script:MakeCmd = "$Env:MSYS_BIN_DIR\env.exe $Env:MSYS_BIN_DIR\bash.exe -l -c 'make -f Makefile.griffin platform=windows_msvc2010_x64'"
-    - Invoke-Expression $Script:MakeCmd
-    - mt.exe -nologo -manifest "retroarch.exe.manifest" -outputresource:"retroarch.exe;#1"
-    - rcedit-x64.exe "retroarch.exe" --set-icon "media\retroarch.ico"
-    # Create .media subdirectories
-    - New-Item -Path "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/filters/audio" -ItemType Directory
-    - New-Item -Path "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/filters/video" -ItemType Directory
-    - New-Item -Path "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/pkg" -ItemType Directory
-    - New-Item -Path "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/redist" -ItemType Directory
-    # Copy audio/video filters
-    - Get-ChildItem -Path "libretro-common/audio/dsp_filters/*" -Include *.dsp | Copy-Item -Destination "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/filters/audio"
-    - Get-ChildItem -Path "gfx/video_filters/*" -Include *.filt | Copy-Item -Destination "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/filters/video"
-    # Copy default config file
-    - Copy-Item -Path "retroarch.cfg" -Destination "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/pkg/retroarch.default.cfg"
-    # Copy dll dependencies
-    # (note that msvc10 build should not have any, but this
-    # may change in the future)
-    - copypedeps.exe -r retroarch.exe "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/redist"
-    - Remove-Item "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/redist/retroarch.exe" -ErrorAction Ignore
+    - |
+      $ErrorActionPreference = 'Stop'
+      # Build RetroArch
+      env.exe
+      bash.exe -l -c "make -f Makefile.griffin platform=$Env:MSVC_PLATFORM"
+      if ($LastExitCode -ne 0){throw "Failed to build RetroArch"}
+      mt.exe -nologo -manifest "retroarch.exe.manifest" -outputresource:"retroarch.exe;#1"
+      if ($LastExitCode -ne 0){throw "Failed to add manifest to RetroArch binary"}
+      rcedit-x64.exe "retroarch.exe" --set-icon "media\retroarch.ico"
+      if ($LastExitCode -ne 0){throw "Failed to set icon of RetroArch binary"}
+      # Create .media subdirectories
+      New-Item -Path "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/filters/audio" -ItemType Directory
+      New-Item -Path "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/filters/video" -ItemType Directory
+      New-Item -Path "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/pkg" -ItemType Directory
+      New-Item -Path "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/redist" -ItemType Directory
+      # Copy audio/video filters
+      Get-ChildItem -Path "libretro-common/audio/dsp_filters/*" -Include *.dsp | Copy-Item -Destination "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/filters/audio"
+      Get-ChildItem -Path "gfx/video_filters/*" -Include *.filt | Copy-Item -Destination "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/filters/video"
+      # Copy default config file
+      Copy-Item -Path "retroarch.cfg" -Destination "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/pkg/retroarch.default.cfg"
+      # Copy dll dependencies
+      # (note that msvc builds should not have any, but this
+      # may change in the future)
+      copypedeps.exe -r retroarch.exe "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/redist"
+      if ($LastExitCode -ne 0){throw "Failed to copy RetroArch dependencies"}
+      Remove-Item "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/redist/retroarch.exe" -ErrorAction Ignore
 
 build-retroarch-windows-msvc10-i686:
   tags:
@@ -147,9 +154,10 @@ build-retroarch-windows-msvc10-i686:
     SDK_BIN_DIR:    C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin
     RCEDIT_BIN_DIR: C:\Program Files\rcedit
     PEDEPS_BIN_DIR: C:\Program Files\pedeps-0.1.9-win64\bin
+    MSVC_PLATFORM:  windows_msvc2010_x86
   before_script:
     - $Env:HOME = "."
-    - $Env:Path += -join(";", "$Env:SDK_BIN_DIR", ";", "$Env:RCEDIT_BIN_DIR", ";", "$Env:PEDEPS_BIN_DIR")
+    - $Env:Path += -join(";", "$Env:MSYS_BIN_DIR", ";", "$Env:SDK_BIN_DIR", ";", "$Env:RCEDIT_BIN_DIR", ";", "$Env:PEDEPS_BIN_DIR")
   artifacts:
     paths:
     - retroarch.exe
@@ -157,26 +165,32 @@ build-retroarch-windows-msvc10-i686:
     expire_in: 10 min
   dependencies: []
   script:
-    # Build RetroArch
-    - $Script:MakeCmd = "$Env:MSYS_BIN_DIR\env.exe $Env:MSYS_BIN_DIR\bash.exe -l -c 'make -f Makefile.griffin platform=windows_msvc2010_x86'"
-    - Invoke-Expression $Script:MakeCmd
-    - mt.exe -nologo -manifest "retroarch.exe.manifest" -outputresource:"retroarch.exe;#1"
-    - rcedit-x64.exe "retroarch.exe" --set-icon "media\retroarch.ico"
-    # Create .media subdirectories
-    - New-Item -Path "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/filters/audio" -ItemType Directory
-    - New-Item -Path "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/filters/video" -ItemType Directory
-    - New-Item -Path "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/pkg" -ItemType Directory
-    - New-Item -Path "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/redist" -ItemType Directory
-    # Copy audio/video filters
-    - Get-ChildItem -Path "libretro-common/audio/dsp_filters/*" -Include *.dsp | Copy-Item -Destination "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/filters/audio"
-    - Get-ChildItem -Path "gfx/video_filters/*" -Include *.filt | Copy-Item -Destination "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/filters/video"
-    # Copy default config file
-    - Copy-Item -Path "retroarch.cfg" -Destination "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/pkg/retroarch.default.cfg"
-    # Copy dll dependencies
-    # (note that msvc10 build should not have any, but this
-    # may change in the future)
-    - copypedeps.exe -r retroarch.exe "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/redist"
-    - Remove-Item "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/redist/retroarch.exe" -ErrorAction Ignore
+    - |
+      $ErrorActionPreference = 'Stop'
+      # Build RetroArch
+      env.exe
+      bash.exe -l -c "make -f Makefile.griffin platform=$Env:MSVC_PLATFORM"
+      if ($LastExitCode -ne 0){throw "Failed to build RetroArch"}
+      mt.exe -nologo -manifest "retroarch.exe.manifest" -outputresource:"retroarch.exe;#1"
+      if ($LastExitCode -ne 0){throw "Failed to add manifest to RetroArch binary"}
+      rcedit-x64.exe "retroarch.exe" --set-icon "media\retroarch.ico"
+      if ($LastExitCode -ne 0){throw "Failed to set icon of RetroArch binary"}
+      # Create .media subdirectories
+      New-Item -Path "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/filters/audio" -ItemType Directory
+      New-Item -Path "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/filters/video" -ItemType Directory
+      New-Item -Path "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/pkg" -ItemType Directory
+      New-Item -Path "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/redist" -ItemType Directory
+      # Copy audio/video filters
+      Get-ChildItem -Path "libretro-common/audio/dsp_filters/*" -Include *.dsp | Copy-Item -Destination "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/filters/audio"
+      Get-ChildItem -Path "gfx/video_filters/*" -Include *.filt | Copy-Item -Destination "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/filters/video"
+      # Copy default config file
+      Copy-Item -Path "retroarch.cfg" -Destination "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/pkg/retroarch.default.cfg"
+      # Copy dll dependencies
+      # (note that msvc builds should not have any, but this
+      # may change in the future)
+      copypedeps.exe -r retroarch.exe "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/redist"
+      if ($LastExitCode -ne 0){throw "Failed to copy RetroArch dependencies"}
+      Remove-Item "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/redist/retroarch.exe" -ErrorAction Ignore
 
 build-retroarch-windows-msvc05-i686:
   tags:
@@ -191,9 +205,10 @@ build-retroarch-windows-msvc05-i686:
     RCEDIT_BIN_DIR: C:\Program Files\rcedit
     PEDEPS_BIN_DIR: C:\Program Files\pedeps-0.1.9-win64\bin
     VS80COMNTOOLS:  C:\Program Files (x86)\Microsoft Visual Studio 8\Common7\Tools\
+    MSVC_PLATFORM:  windows_msvc2005_x86
   before_script:
     - $Env:HOME = "."
-    - $Env:Path += -join(";", "$Env:SDK_BIN_DIR", ";", "$Env:RCEDIT_BIN_DIR", ";", "$Env:PEDEPS_BIN_DIR")
+    - $Env:Path += -join(";", "$Env:MSYS_BIN_DIR", ";", "$Env:SDK_BIN_DIR", ";", "$Env:RCEDIT_BIN_DIR", ";", "$Env:PEDEPS_BIN_DIR")
   artifacts:
     paths:
     - retroarch.exe
@@ -201,26 +216,32 @@ build-retroarch-windows-msvc05-i686:
     expire_in: 10 min
   dependencies: []
   script:
-    # Build RetroArch
-    - $Script:MakeCmd = "$Env:MSYS_BIN_DIR\env.exe $Env:MSYS_BIN_DIR\bash.exe -l -c 'make -f Makefile.griffin platform=windows_msvc2005_x86'"
-    - Invoke-Expression $Script:MakeCmd
-    - mt.exe -nologo -manifest "retroarch.exe.manifest" -outputresource:"retroarch.exe;#1"
-    - rcedit-x64.exe "retroarch.exe" --set-icon "media\retroarch.ico"
-    # Create .media subdirectories
-    - New-Item -Path "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/filters/audio" -ItemType Directory
-    - New-Item -Path "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/filters/video" -ItemType Directory
-    - New-Item -Path "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/pkg" -ItemType Directory
-    - New-Item -Path "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/redist" -ItemType Directory
-    # Copy audio/video filters
-    - Get-ChildItem -Path "libretro-common/audio/dsp_filters/*" -Include *.dsp | Copy-Item -Destination "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/filters/audio"
-    - Get-ChildItem -Path "gfx/video_filters/*" -Include *.filt | Copy-Item -Destination "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/filters/video"
-    # Copy default config file
-    - Copy-Item -Path "retroarch.cfg" -Destination "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/pkg/retroarch.default.cfg"
-    # Copy dll dependencies
-    # (note that msvc05 build should not have any, but this
-    # may change in the future)
-    - copypedeps.exe -r retroarch.exe "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/redist"
-    - Remove-Item "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/redist/retroarch.exe" -ErrorAction Ignore
+    - |
+      $ErrorActionPreference = 'Stop'
+      # Build RetroArch
+      env.exe
+      bash.exe -l -c "make -f Makefile.griffin platform=$Env:MSVC_PLATFORM"
+      if ($LastExitCode -ne 0){throw "Failed to build RetroArch"}
+      mt.exe -nologo -manifest "retroarch.exe.manifest" -outputresource:"retroarch.exe;#1"
+      if ($LastExitCode -ne 0){throw "Failed to add manifest to RetroArch binary"}
+      rcedit-x64.exe "retroarch.exe" --set-icon "media\retroarch.ico"
+      if ($LastExitCode -ne 0){throw "Failed to set icon of RetroArch binary"}
+      # Create .media subdirectories
+      New-Item -Path "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/filters/audio" -ItemType Directory
+      New-Item -Path "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/filters/video" -ItemType Directory
+      New-Item -Path "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/pkg" -ItemType Directory
+      New-Item -Path "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/redist" -ItemType Directory
+      # Copy audio/video filters
+      Get-ChildItem -Path "libretro-common/audio/dsp_filters/*" -Include *.dsp | Copy-Item -Destination "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/filters/audio"
+      Get-ChildItem -Path "gfx/video_filters/*" -Include *.filt | Copy-Item -Destination "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/filters/video"
+      # Copy default config file
+      Copy-Item -Path "retroarch.cfg" -Destination "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/pkg/retroarch.default.cfg"
+      # Copy dll dependencies
+      # (note that msvc builds should not have any, but this
+      # may change in the future)
+      copypedeps.exe -r retroarch.exe "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/redist"
+      if ($LastExitCode -ne 0){throw "Failed to copy RetroArch dependencies"}
+      Remove-Item "$Env:MEDIA_PATH/$Env:CI_PROJECT_NAME/redist/retroarch.exe" -ErrorAction Ignore
 
 build-retroarch-linux-x64:
   image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-amd64-ubuntu:xenial-gcc9


### PR DESCRIPTION
## Description

At present, gitlab will silently ignore any errors in the MSVC (2010, 2005) builds, leading to reports of successful pipeline jobs even in the event of failure. This PR fixes the issue.
