### PR TITLE
(libretro-common/file_stream) Restore missing 'filestream_scanf()' function

### DIFF
--- a/libretro-common/include/streams/file_stream.h
+++ b/libretro-common/include/streams/file_stream.h
@@ -83,6 +83,8 @@ int filestream_getc(RFILE *stream);
 
 int filestream_vscanf(RFILE *stream, const char* format, va_list *args);
 
+int filestream_scanf(RFILE *stream, const char* format, ...);
+
 int filestream_eof(RFILE *stream);
 
 bool filestream_write_file(const char *path, const void *data, int64_t size);

--- a/libretro-common/streams/file_stream.c
+++ b/libretro-common/streams/file_stream.c
@@ -339,6 +339,16 @@ int filestream_vscanf(RFILE *stream, const char* format, va_list *args)
    return ret;
 }
 
+int filestream_scanf(RFILE *stream, const char* format, ...)
+{
+   int result;
+   va_list vl;
+   va_start(vl, format);
+   result = filestream_vscanf(stream, format, &vl);
+   va_end(vl);
+   return result;
+}
+
 int64_t filestream_seek(RFILE *stream, int64_t offset, int seek_position)
 {
    int64_t output;


### PR DESCRIPTION
## Description

#13023 removed the `filestream_scanf()` function in libretro-common/file_stream, since it wasn't used anywhere in the RetroArch codebase - but this neglected to account for cores which may have need of it.

This PR restores the function, by adding a simple wrapper for `filestream_vscanf()`
