### PR TITLE
WIIU: Clean up a bunch of compiler warnings

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -2963,7 +2963,7 @@ static config_file_t *open_default_config_file(void)
    #ifndef RARCH_CONSOLE
    char application_data[PATH_MAX_LENGTH];
    bool has_application_data              = false;
-   application_data[0] = '\0'
+   application_data[0] = '\0';
    #endif
 
    conf_path[0] = app_path[0] = '\0';

--- a/configuration.c
+++ b/configuration.c
@@ -2956,13 +2956,17 @@ static bool check_menu_driver_compatibility(settings_t *settings)
  **/
 static config_file_t *open_default_config_file(void)
 {
-   char application_data[PATH_MAX_LENGTH];
    char conf_path[PATH_MAX_LENGTH];
    char app_path[PATH_MAX_LENGTH];
-   bool has_application_data              = false;
    config_file_t *conf                    = NULL;
 
-   application_data[0] = conf_path[0] = app_path[0] = '\0';
+   #ifndef RARCH_CONSOLE
+   char application_data[PATH_MAX_LENGTH];
+   bool has_application_data              = false;
+   application_data[0] = '\0'
+   #endif
+
+   conf_path[0] = app_path[0] = '\0';
 
 #if defined(_WIN32) && !defined(_XBOX)
 #if defined(__WINRT__) || defined(WINAPI_FAMILY) && WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP

--- a/core_backup.c
+++ b/core_backup.c
@@ -160,7 +160,7 @@ bool core_backup_get_backup_path(
          (unsigned)time_info.tm_hour,
          (unsigned)time_info.tm_min,
          (unsigned)time_info.tm_sec,
-         crc,
+         (unsigned long)crc,
          (unsigned)backup_mode,
          FILE_PATH_CORE_BACKUP_EXTENSION);
 
@@ -748,6 +748,6 @@ bool core_backup_list_get_entry_crc_str(
    if (!entry || (len < 9))
       return false;
 
-   snprintf(crc, len, "%08lx", entry->crc);
+   snprintf(crc, len, "%08lx", (unsigned long)entry->crc);
    return true;
 }

--- a/core_backup.c
+++ b/core_backup.c
@@ -152,7 +152,7 @@ bool core_backup_get_backup_path(
 
    /* Generate backup filename */
    snprintf(backup_filename, sizeof(backup_filename),
-         "%s.%04u%02u%02uT%02u%02u%02u.%08x.%u%s",
+         "%s.%04u%02u%02uT%02u%02u%02u.%08lx.%u%s",
          core_filename,
          (unsigned)time_info.tm_year + 1900,
          (unsigned)time_info.tm_mon + 1,
@@ -449,7 +449,7 @@ static bool core_backup_add_entry(core_backup_list_t *backup_list,
    entry = &backup_list->entries[backup_list->size];
 
    if (sscanf(backup_filename + strlen(core_filename),
-       ".%04u%02u%02uT%02u%02u%02u.%08x.%u",
+       ".%04u%02u%02uT%02u%02u%02u.%08lx.%u",
        &entry->date.year, &entry->date.month, &entry->date.day,
        &entry->date.hour, &entry->date.minute, &entry->date.second,
        &entry->crc, &backup_mode) != 8)
@@ -748,6 +748,6 @@ bool core_backup_list_get_entry_crc_str(
    if (!entry || (len < 9))
       return false;
 
-   snprintf(crc, len, "%08x", entry->crc);
+   snprintf(crc, len, "%08lx", entry->crc);
    return true;
 }

--- a/deps/libfat/fatfile.c
+++ b/deps/libfat/fatfile.c
@@ -149,31 +149,29 @@ int _FAT_open_r (struct _reent *r, void *fileStruct, const char *path, int flags
 		return -1;
 	}
 
-	/* Determine which mode the file is openned for */
-	if ((flags & 0x03) == O_RDONLY)
-   {
-		/* Open the file for read-only access */
-		file->read = true;
-		file->write = false;
-		file->append = false;
-	}
-   else if ((flags & 0x03) == O_WRONLY)
-   {
-		/* Open file for write only access */
-		file->read = false;
-		file->write = true;
-		file->append = false;
-	}
-   else if ((flags & 0x03) == O_RDWR)
-   {
-		/* Open file for read/write access */
-		file->read = true;
-		file->write = true;
-		file->append = false;
-	} else {
-		r->_errno = EACCES;
-		return -1;
-	}
+   switch((flags & 0x03)) {
+      case O_RDONLY:
+         /* Open the file for read-only access */
+         file->read = true;
+         file->write = false;
+         file->append = false;
+         break;
+      case O_WRONLY:
+         /* Open file for write only access */
+         file->read = false;
+         file->write = true;
+         file->append = false;
+         break;
+      case O_RDWR:
+   		/* Open file for read/write access */
+         file->read = true;
+         file->write = true;
+         file->append = false;
+         break;
+      default:
+		   r->_errno = EACCES;
+		   return -1;
+   }
 
 	/* Make sure we aren't trying to write to a read-only disc */
 	if (file->write && partition->readOnly)

--- a/gfx/drivers/gx2_shaders/frame.c
+++ b/gfx/drivers/gx2_shaders/frame.c
@@ -31,7 +31,7 @@ static struct
       CALL_FS NO_BARRIER,
       ALU(32, 18) KCACHE0(CB1, _0_15),
       EXP_DONE(POS0,   _R1, _x, _y, _0, _1),
-      EXP_DONE(PARAM0, _R2, _x, _y, _z, _z) NO_BARRIER
+      (EXP_DONE(PARAM0, _R2, _x, _y, _z, _z) NO_BARRIER)
       END_OF_PROGRAM
    },
    {

--- a/gfx/drivers/gx2_shaders/ribbon.c
+++ b/gfx/drivers/gx2_shaders/ribbon.c
@@ -32,7 +32,7 @@ static struct
       ALU(32, 123) KCACHE0(CB1, _0_15),
       ALU(155, 51),
       EXP_DONE(POS0,   _R7, _x, _y, _z, _w),
-      EXP_DONE(PARAM0, _R7, _x, _y, _z, _w) NO_BARRIER
+      (EXP_DONE(PARAM0, _R7, _x, _y, _z, _w) NO_BARRIER)
       END_OF_PROGRAM
       END_OF_PROGRAM
    },

--- a/gfx/drivers/gx2_shaders/sprite.c
+++ b/gfx/drivers/gx2_shaders/sprite.c
@@ -31,7 +31,7 @@ static struct
       CALL_FS NO_BARRIER,
       ALU(32, 26) KCACHE0(CB1, _0_15) KCACHE1(CB2, _0_15),
       MEM_RING(WRITE( 0), _R1, _xyzw, ARRAY_SIZE(1), ELEM_SIZE(3)) BURSTCNT(1),
-      MEM_RING(WRITE(32), _R0, _xyzw, ARRAY_SIZE(0), ELEM_SIZE(3)) NO_BARRIER
+      (MEM_RING(WRITE(32), _R0, _xyzw, ARRAY_SIZE(0), ELEM_SIZE(3)) NO_BARRIER)
       END_OF_PROGRAM
    },
    {

--- a/gfx/drivers/gx2_shaders/tex.c
+++ b/gfx/drivers/gx2_shaders/tex.c
@@ -32,7 +32,7 @@ static struct
       ALU(32, 16) KCACHE0(CB1, _0_15),
       EXP_DONE(POS0,   _R1, _x, _y, _0, _1),
       EXP(PARAM0, _R2, _x, _y, _0, _0) NO_BARRIER,
-      EXP_DONE(PARAM1, _R3, _x, _y, _z, _w) NO_BARRIER
+      (EXP_DONE(PARAM1, _R3, _x, _y, _z, _w) NO_BARRIER)
       END_OF_PROGRAM
    },
    {

--- a/menu/cbs/menu_cbs_sublabel.c
+++ b/menu/cbs/menu_cbs_sublabel.c
@@ -1345,7 +1345,7 @@ static int action_bind_sublabel_netplay_room(
          msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CONTENT_INFO_CORE_NAME),
          corename, core_ver,
          !string_is_equal(gamename, na) ? gamename : na,
-         gamecrc);
+         (unsigned long)gamecrc);
    }
    else
    {
@@ -1389,7 +1389,7 @@ static int action_bind_sublabel_netplay_room(
             msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CONTENT_INFO_CORE_NAME),
             corename, core_ver, subsystem,
             !string_is_equal(gamename, na) ? gamename : na,
-            gamecrc);
+            (unsigned long)gamecrc);
       }
    }
    return 0;

--- a/menu/cbs/menu_cbs_sublabel.c
+++ b/menu/cbs/menu_cbs_sublabel.c
@@ -1338,7 +1338,7 @@ static int action_bind_sublabel_netplay_room(
             msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE)))
    {
       snprintf(s, len,
-         "%s: %s (%s)\n%s: %s (%s)\nGame: %s (%08x)",
+         "%s: %s (%s)\n%s: %s (%s)\nGame: %s (%08lx)",
          msg_hash_to_str(MSG_PROGRAM),
          string_is_empty(ra_version)    ? na : ra_version,
          string_is_empty(frontend)      ? na : frontend,
@@ -1382,7 +1382,7 @@ static int action_bind_sublabel_netplay_room(
       else
       {
          snprintf(s, len,
-            "%s: %s (%s)\n%s: %s (%s)\nSubsystem: %s\nGame: %s (%08x)",
+            "%s: %s (%s)\n%s: %s (%s)\nSubsystem: %s\nGame: %s (%08lx)",
             msg_hash_to_str(MSG_PROGRAM),
             string_is_empty(ra_version)    ? na : ra_version,
             string_is_empty(frontend)      ? na : frontend,

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -2149,7 +2149,7 @@ static int menu_displaylist_parse_database_entry(menu_handle_t *menu,
 
       crc_str[0] = tmp[0] = thumbnail_content[0] = '\0';
 
-      snprintf(crc_str, sizeof(crc_str), "%08lX", db_info_entry->crc32);
+      snprintf(crc_str, sizeof(crc_str), "%08lX", (unsigned long)db_info_entry->crc32);
 
       /* This allows thumbnails to be shown while viewing database
        * entries...

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -2149,7 +2149,7 @@ static int menu_displaylist_parse_database_entry(menu_handle_t *menu,
 
       crc_str[0] = tmp[0] = thumbnail_content[0] = '\0';
 
-      snprintf(crc_str, sizeof(crc_str), "%08X", db_info_entry->crc32);
+      snprintf(crc_str, sizeof(crc_str), "%08lX", db_info_entry->crc32);
 
       /* This allows thumbnails to be shown while viewing database
        * entries...
@@ -5594,7 +5594,6 @@ unsigned menu_displaylist_build_list(
       case DISPLAYLIST_INPUT_HAPTIC_FEEDBACK_SETTINGS_LIST:
          {
             const char *input_driver_id  = settings->arrays.input_driver;
-            const char *joypad_driver_id = settings->arrays.input_joypad_driver;
 
             if (string_is_equal(input_driver_id, "android"))
             {

--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -623,7 +623,7 @@ bool netplay_lan_ad_server(netplay_t *netplay)
                         NETPLAY_HOST_STR_LEN);
                   }
 
-                  snprintf(s, sizeof(s), "%ld", content_crc);
+                  snprintf(s, sizeof(s), "%ld", (long)content_crc);
                   strlcpy(ad_packet_buffer.content_crc, s,
                      NETPLAY_HOST_STR_LEN);
 
@@ -851,7 +851,7 @@ static void handshake_password(void *ignore, const char *line)
    netplay_t *netplay                    = handshake_password_netplay;
    struct netplay_connection *connection = &netplay->connections[0];
 
-   snprintf(password, sizeof(password), "%08lX", connection->salt);
+   snprintf(password, sizeof(password), "%08lX", (unsigned long)connection->salt);
    if (!string_is_empty(line))
       strlcpy(password + 8, line, sizeof(password)-8);
 
@@ -1363,7 +1363,7 @@ static bool netplay_handshake_pre_password(netplay_t *netplay,
 
    /* Calculate the correct password hash(es) and compare */
    correct = false;
-   snprintf(password, sizeof(password), "%08lX", connection->salt);
+   snprintf(password, sizeof(password), "%08lX", (unsigned long)connection->salt);
 
    if (settings->paths.netplay_password[0])
    {

--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -623,7 +623,7 @@ bool netplay_lan_ad_server(netplay_t *netplay)
                         NETPLAY_HOST_STR_LEN);
                   }
 
-                  snprintf(s, sizeof(s), "%d", content_crc);
+                  snprintf(s, sizeof(s), "%ld", content_crc);
                   strlcpy(ad_packet_buffer.content_crc, s,
                      NETPLAY_HOST_STR_LEN);
 
@@ -851,7 +851,7 @@ static void handshake_password(void *ignore, const char *line)
    netplay_t *netplay                    = handshake_password_netplay;
    struct netplay_connection *connection = &netplay->connections[0];
 
-   snprintf(password, sizeof(password), "%08X", connection->salt);
+   snprintf(password, sizeof(password), "%08lX", connection->salt);
    if (!string_is_empty(line))
       strlcpy(password + 8, line, sizeof(password)-8);
 
@@ -1363,7 +1363,7 @@ static bool netplay_handshake_pre_password(netplay_t *netplay,
 
    /* Calculate the correct password hash(es) and compare */
    correct = false;
-   snprintf(password, sizeof(password), "%08X", connection->salt);
+   snprintf(password, sizeof(password), "%08lX", connection->salt);
 
    if (settings->paths.netplay_password[0])
    {

--- a/retroarch.c
+++ b/retroarch.c
@@ -2966,7 +2966,7 @@ static void netplay_announce(struct rarch_state *p_rarch)
    buf[0] = '\0';
 
    snprintf(buf, sizeof(buf), "username=%s&core_name=%s&core_version=%s&"
-      "game_name=%s&game_crc=%08X&port=%d&mitm_server=%s"
+      "game_name=%s&game_crc=%08lX&port=%d&mitm_server=%s"
       "&has_password=%d&has_spectate_password=%d&force_mitm=%d"
       "&retroarch_version=%s&frontend=%s&subsystem_name=%s",
       username, corename, coreversion, gamename, content_crc,
@@ -4906,9 +4906,9 @@ bool menu_input_dialog_start(menu_input_ctx_line_t *line)
 
 bool menu_input_dialog_get_display_kb(void)
 {
-   struct rarch_state *p_rarch = &rarch_st;
    struct menu_state *menu_st  = menu_state_get_ptr();
 #ifdef HAVE_LIBNX
+   struct rarch_state *p_rarch = &rarch_st;
    SwkbdConfig kbd;
    Result rc;
    /* Indicates that we are "typing" from the swkbd
@@ -4983,7 +4983,7 @@ bool menu_input_dialog_get_display_kb(void)
       return false;
    }
    libnx_apply_overclock();
-#endif
+#endif /* HAVE_LIBNX */
    return menu_st->input_dialog_kb_display;
 }
 
@@ -19633,7 +19633,7 @@ bool audio_driver_mixer_add_stream(audio_mixer_stream_params_t *params)
           * so have to do it here */
          free(buf);
          buf = NULL;
-         break;
+         break; 
       case AUDIO_MIXER_TYPE_OGG:
          handle = audio_mixer_load_ogg(buf, (int32_t)params->bufsize);
          break;
@@ -22096,6 +22096,7 @@ void video_driver_hide_mouse(void)
       p_rarch->video_driver_poke->show_mouse(p_rarch->video_driver_data, false);
 }
 
+#if defined(HAVE_VULKAN) || defined(HAVE_D3D11) || defined(HAVE_D3D9) || defined(HAVE_OPENGL_CORE)
 static void video_driver_save_as_cached(struct rarch_state *p_rarch,
       settings_t *settings, const char *rdr_context_name)
 {
@@ -22108,6 +22109,7 @@ static void video_driver_save_as_cached(struct rarch_state *p_rarch,
          settings->arrays.video_driver,
          rdr_context_name);
 }
+#endif
 
 static void video_driver_restore_cached(struct rarch_state *p_rarch,
       settings_t *settings)

--- a/retroarch.c
+++ b/retroarch.c
@@ -2969,7 +2969,7 @@ static void netplay_announce(struct rarch_state *p_rarch)
       "game_name=%s&game_crc=%08lX&port=%d&mitm_server=%s"
       "&has_password=%d&has_spectate_password=%d&force_mitm=%d"
       "&retroarch_version=%s&frontend=%s&subsystem_name=%s",
-      username, corename, coreversion, gamename, content_crc,
+      username, corename, coreversion, gamename, (unsigned long)content_crc,
       settings->uints.netplay_port,
       settings->arrays.netplay_mitm_server,
       *settings->paths.netplay_password ? 1 : 0,

--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -743,7 +743,7 @@ static int database_info_list_iterate_found_match(
    playlist_config_set_path(&_db->playlist_config, db_playlist_path);
    playlist = playlist_init(&_db->playlist_config);
 
-   snprintf(db_crc, str_len, "%08lX|crc", db_info_entry->crc32);
+   snprintf(db_crc, str_len, "%08lX|crc", (unsigned long)db_info_entry->crc32);
 
    if (entry_path)
       strlcpy(entry_path_str, entry_path, str_len);
@@ -904,7 +904,7 @@ static int task_database_iterate_crc_lookup(
 
       snprintf(query, sizeof(query),
             "{crc:or(b\"%08lX\",b\"%08lX\")}",
-            db_state->crc, db_state->archive_crc);
+            (unsigned long)db_state->crc, (unsigned long)db_state->archive_crc);
 
       database_info_list_iterate_new(db_state, query);
    }

--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -743,7 +743,7 @@ static int database_info_list_iterate_found_match(
    playlist_config_set_path(&_db->playlist_config, db_playlist_path);
    playlist = playlist_init(&_db->playlist_config);
 
-   snprintf(db_crc, str_len, "%08X|crc", db_info_entry->crc32);
+   snprintf(db_crc, str_len, "%08lX|crc", db_info_entry->crc32);
 
    if (entry_path)
       strlcpy(entry_path_str, entry_path, str_len);
@@ -903,7 +903,7 @@ static int task_database_iterate_crc_lookup(
       }
 
       snprintf(query, sizeof(query),
-            "{crc:or(b\"%08X\",b\"%08X\")}",
+            "{crc:or(b\"%08lX\",b\"%08lX\")}",
             db_state->crc, db_state->archive_crc);
 
       database_info_list_iterate_new(db_state, query);

--- a/tasks/task_netplay_find_content.c
+++ b/tasks/task_netplay_find_content.c
@@ -241,7 +241,7 @@ static void task_netplay_crc_scan_handler(retro_task_t *task)
 
       RARCH_LOG("[Lobby]: Testing CRC matching for: %s\n", state->content_crc);
 
-      snprintf(current, sizeof(current), "%X|crc", content_get_crc());
+      snprintf(current, sizeof(current), "%lX|crc", content_get_crc());
       RARCH_LOG("[Lobby]: Current content CRC: %s\n", current);
 
       if (string_is_equal(current, state->content_crc))
@@ -448,7 +448,7 @@ bool task_push_netplay_crc_scan(uint32_t crc, char* name,
 
    snprintf(state->content_crc,
          sizeof(state->content_crc),
-         "%08X|crc", crc);
+         "%08lX|crc", crc);
 
    strlcpy(state->content_path,
          name, sizeof(state->content_path));

--- a/tasks/task_netplay_find_content.c
+++ b/tasks/task_netplay_find_content.c
@@ -241,7 +241,7 @@ static void task_netplay_crc_scan_handler(retro_task_t *task)
 
       RARCH_LOG("[Lobby]: Testing CRC matching for: %s\n", state->content_crc);
 
-      snprintf(current, sizeof(current), "%lX|crc", content_get_crc());
+      snprintf(current, sizeof(current), "%lX|crc", (unsigned long)content_get_crc());
       RARCH_LOG("[Lobby]: Current content CRC: %s\n", current);
 
       if (string_is_equal(current, state->content_crc))
@@ -448,7 +448,7 @@ bool task_push_netplay_crc_scan(uint32_t crc, char* name,
 
    snprintf(state->content_crc,
          sizeof(state->content_crc),
-         "%08lX|crc", crc);
+         "%08lX|crc", (unsigned long)crc);
 
    strlcpy(state->content_path,
          name, sizeof(state->content_path));

--- a/wiiu/gx2_shader_inl.h
+++ b/wiiu/gx2_shader_inl.h
@@ -22,6 +22,7 @@
 #define to_QWORD(w0, w1) (((u64)(w0) << 32ull) | (w1))
 #define to_LE(x) (__builtin_bswap32(x))
 #else
+printf("broke the build");
 #define to_QWORD(w0, w1) (((u64)(w1) << 32ull) | (w0))
 #define to_LE(x) (x)
 #endif
@@ -59,7 +60,7 @@
 #define KC0(x) (x + ALU_SRC_KCACHE0_BASE)
 #define KC1(x) (x + ALU_SRC_KCACHE1_BASE)
 
-#define NO_BARRIER      & ~to_QWORD(0,to_LE(1 << 31))
+#define NO_BARRIER      & (~to_QWORD(0,to_LE(1 << 31)))
 #define END_OF_PROGRAM  | to_QWORD(0,to_LE(1 << 21))
 #define VALID_PIX       | to_QWORD(0,to_LE(1 << 22))
 #define WHOLE_QUAD_MODE | to_QWORD(0,to_LE(1 << 30))

--- a/wiiu/include/sys/socket.h
+++ b/wiiu/include/sys/socket.h
@@ -30,8 +30,18 @@ extern "C" {
 
 /* return codes */
 #define SO_SUCCESS      0
+
+
 #define SO_EWOULDBLOCK  6
 #define SO_EINVAL      11
+
+#ifdef EWOULDBLOCK
+#undef EWOULDBLOCK
+#endif
+
+#ifdef EAGAIN
+#undef EAGAIN
+#endif
 
 #define EWOULDBLOCK SO_EWOULDBLOCK
 #define EAGAIN SO_EWOULDBLOCK

--- a/wiiu/shader_utils.c
+++ b/wiiu/shader_utils.c
@@ -209,11 +209,11 @@ void check_shader_verbose(u32 *shader, u32 shader_size, u32 *org, u32 org_size, 
    DEBUG_VAR(org_size);
 
    if (shader_size != org_size)
-      printf("size mismatch : 0x%08X should be 0x%08X\n", shader_size, org_size);
+      printf("size mismatch : 0x%08lX should be 0x%08lX\n", shader_size, org_size);
 
    for (i = 0; i < shader_size / 4; i += 4)
    {
-      printf("0x%08X 0x%08X 0x%08X 0x%08X          0x%08X 0x%08X 0x%08X 0x%08X\n",
+      printf("0x%08lX 0x%08lX 0x%08lX 0x%08lX          0x%08lX 0x%08lX 0x%08lX 0x%08lX\n",
              shader[i], shader[i + 1], shader[i + 2], shader[i + 3],
              org[i], org[i + 1], org[i + 2], org[i + 3]);
    }
@@ -221,7 +221,7 @@ void check_shader_verbose(u32 *shader, u32 shader_size, u32 *org, u32 org_size, 
    for (i = 0; i < shader_size / 4; i++)
    {
       if (shader[i] != org[i])
-         printf("%i(%X): 0x%08X(0x%08X) should be 0x%08X(0x%08X) \n", i, i, shader[i], __builtin_bswap32(shader[i]), org[i],
+         printf("%i(%X): 0x%08lX(0x%08lX) should be 0x%08lX(0x%08lX) \n", i, i, shader[i], __builtin_bswap32(shader[i]), org[i],
                 __builtin_bswap32(org[i]));
    }
 }
@@ -237,7 +237,7 @@ void check_shader(const void *shader_, u32 shader_size, const void *org_, u32 or
    if (shader_size != org_size)
    {
       different = true;
-      printf("\nsize mismatch : 0x%08X should be 0x%08X", shader_size, org_size);
+      printf("\nsize mismatch : 0x%08lX should be 0x%08lX", shader_size, org_size);
    }
 
    for (i = 0; i < shader_size / 4; i++)
@@ -245,7 +245,7 @@ void check_shader(const void *shader_, u32 shader_size, const void *org_, u32 or
       if (shader[i] != org[i])
       {
          different = true;
-         printf("\n%i(%X): 0x%08X(0x%08X) should be 0x%08X(0x%08X)", i, i, shader[i], __builtin_bswap32(shader[i]), org[i],
+         printf("\n%i(%X): 0x%08lX(0x%08lX) should be 0x%08lX(0x%08lX)", i, i, shader[i], __builtin_bswap32(shader[i]), org[i],
                 __builtin_bswap32(org[i]));
       }
    }


### PR DESCRIPTION
## Description
The wiiu build has a ton of annoying compiler warnings that make things harder when
trying to write new code. So I spent some time to resolve them.

**Important** we need to watch the CI/CD pipeline for this PR in case there's build breakage.

These changes fall into a few broad categories:

1. Explicitly undefine things we want to re-define due to conflicts with
   the version of devkitpro we're using
2. Clean up hex format specifiers to use `%lx` or `%lX` when working with
   long integers
3. Move variables inside the ifdef they're used in to squelch "unused variable"
   messages
4. Add parenthesis to make Wii U shader declarations stop complaining

And then there's a weird "misleading indent" warning that I fixed by just
rewriting a block of code to use a switch statement instead of if-then-else.

These changes work fine on Wii U, but we'll need to keep an eye on CI/CD to see
if other platform builds break.

## Reviewers
@twinaphex 