### PR TITLE
Refactors - moves dispwidget_get_ptr to gfx_widgets

### DIFF
--- a/gfx/gfx_widgets.c
+++ b/gfx/gfx_widgets.c
@@ -32,6 +32,7 @@
 #include "../msg_hash.h"
 
 #include "../tasks/task_content.h"
+#include "../tasks/tasks_internal.h"
 
 #ifdef HAVE_THREADS
 #define SLOCK_LOCK(x) slock_lock(x)
@@ -60,6 +61,8 @@ static const char
 
    "menu_achievements.png"
 };
+
+static dispgfx_widget_t dispwidget_st = {0}; /* uint64_t alignment */
 
 static void INLINE gfx_widgets_font_free(gfx_widget_font_data_t *font_data)
 {
@@ -182,7 +185,6 @@ static void msg_widget_msg_transition_animation_done(void *userdata)
 }
 
 void gfx_widgets_msg_queue_push(
-      void *data,
       retro_task_t *task,
       const char *msg,
       unsigned duration,
@@ -193,7 +195,7 @@ void gfx_widgets_msg_queue_push(
       bool menu_is_alive)
 {
    disp_widget_msg_t    *msg_widget = NULL;
-   dispgfx_widget_t *p_dispwidget   = (dispgfx_widget_t*)data;
+   dispgfx_widget_t *p_dispwidget   = &dispwidget_st;
 
    if (FIFO_WRITE_AVAIL_NONPTR(p_dispwidget->msg_queue) > 0)
    {
@@ -399,7 +401,7 @@ void gfx_widgets_msg_queue_push(
 static void gfx_widgets_unfold_end(void *userdata)
 {
    disp_widget_msg_t *unfold        = (disp_widget_msg_t*)userdata;
-   dispgfx_widget_t *p_dispwidget   = (dispgfx_widget_t*)dispwidget_get_ptr();
+   dispgfx_widget_t *p_dispwidget   = &dispwidget_st;
 
    unfold->unfolding                = false;
    p_dispwidget->widgets_moving     = false;
@@ -407,7 +409,7 @@ static void gfx_widgets_unfold_end(void *userdata)
 
 static void gfx_widgets_move_end(void *userdata)
 {
-   dispgfx_widget_t *p_dispwidget   = (dispgfx_widget_t*)dispwidget_get_ptr();
+   dispgfx_widget_t *p_dispwidget   = &dispwidget_st;
 
    if (userdata)
    {
@@ -526,7 +528,7 @@ static void gfx_widgets_msg_queue_kill_end(void *userdata)
 {
    unsigned i;
    disp_widget_msg_t* msg;
-   dispgfx_widget_t *p_dispwidget   = (dispgfx_widget_t*)dispwidget_get_ptr();
+   dispgfx_widget_t *p_dispwidget   = &dispwidget_st;
 
    SLOCK_LOCK(p_dispwidget->current_msgs_lock);
 
@@ -896,7 +898,6 @@ static void gfx_widgets_layout(
 
 
 void gfx_widgets_iterate(
-      void *data,
       void *data_disp,
       void *settings_data,
       unsigned width, unsigned height, bool fullscreen,
@@ -904,7 +905,7 @@ void gfx_widgets_iterate(
       bool is_threaded)
 {
    size_t i;
-   dispgfx_widget_t *p_dispwidget   = (dispgfx_widget_t*)data;
+   dispgfx_widget_t *p_dispwidget   = &dispwidget_st;
    /* c.f. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=323
     * On some platforms (e.g. 32-bit x86 without SSE),
     * gcc can produce inconsistent floating point results
@@ -1951,7 +1952,6 @@ static void gfx_widgets_context_reset(
 }
 
 bool gfx_widgets_init(
-      void *data,
       void *data_disp,
       void *data_anim,
       void *settings_data,
@@ -1962,7 +1962,7 @@ bool gfx_widgets_init(
 {
    unsigned i;
    unsigned color                              = 0x222222;
-   dispgfx_widget_t *p_dispwidget              = (dispgfx_widget_t*)data;
+   dispgfx_widget_t *p_dispwidget              = &dispwidget_st;
    gfx_display_t *p_disp                       = (gfx_display_t*)data_disp;
    gfx_animation_t *p_anim                     = (gfx_animation_t*)data_anim;
    settings_t *settings                        = (settings_t*)settings_data;
@@ -2068,9 +2068,9 @@ static void gfx_widgets_context_destroy(dispgfx_widget_t *p_dispwidget)
 }
 
 
-void gfx_widgets_deinit(void *data, bool widgets_persisting)
+void gfx_widgets_deinit(bool widgets_persisting)
 {
-   dispgfx_widget_t *p_dispwidget = (dispgfx_widget_t*)data;
+   dispgfx_widget_t *p_dispwidget = &dispwidget_st;
 
    gfx_widgets_context_destroy(p_dispwidget);
 
@@ -2109,10 +2109,10 @@ static bool gfx_widgets_reset_textures_list_buffer(
 }
 
 bool gfx_widgets_ai_service_overlay_load(
-      dispgfx_widget_t *p_dispwidget,
       char* buffer, unsigned buffer_len,
       enum image_type_enum image_type)
 {
+   dispgfx_widget_t *p_dispwidget   = &dispwidget_st;
    if (p_dispwidget->ai_service_overlay_state == 0)
    {
       if (!gfx_widgets_reset_textures_list_buffer(
@@ -2127,8 +2127,9 @@ bool gfx_widgets_ai_service_overlay_load(
    return true;
 }
 
-void gfx_widgets_ai_service_overlay_unload(dispgfx_widget_t *p_dispwidget)
+void gfx_widgets_ai_service_overlay_unload(void)
 {
+   dispgfx_widget_t *p_dispwidget   = &dispwidget_st;
    if (p_dispwidget->ai_service_overlay_state == 1)
    {
       video_driver_texture_unload(&p_dispwidget->ai_service_overlay_texture);
@@ -2137,3 +2138,33 @@ void gfx_widgets_ai_service_overlay_unload(dispgfx_widget_t *p_dispwidget)
    }
 }
 #endif
+
+void task_screenshot_callback(retro_task_t *task,
+      void *task_data,
+      void *user_data, const char *error)
+{
+   screenshot_task_state_t *state = NULL;
+
+   if (!task)
+      return;
+
+   state = (screenshot_task_state_t*)task->state;
+
+   if (!state)
+      return;
+
+   if (!state->silence && state->widgets_ready)
+      gfx_widget_screenshot_taken(&dispwidget_st,
+            state->shotname, state->filename);
+
+   free(state);
+   /* Must explicitly set task->state to NULL here,
+    * to avoid potential heap-use-after-free errors */
+   state       = NULL;
+   task->state = NULL;
+}
+
+dispgfx_widget_t *dispwidget_get_ptr(void)
+{
+   return &dispwidget_st;
+}

--- a/gfx/gfx_widgets.c
+++ b/gfx/gfx_widgets.c
@@ -18,6 +18,10 @@
 #include <retro_miscellaneous.h>
 #include <retro_inline.h>
 
+#ifdef HAVE_CONFIG_H
+#include "../config.h"
+#endif
+
 #include <queues/fifo_queue.h>
 #include <file/file_path.h>
 #include <streams/file_stream.h>
@@ -2139,6 +2143,7 @@ void gfx_widgets_ai_service_overlay_unload(void)
 }
 #endif
 
+#ifdef HAVE_SCREENSHOTS
 void task_screenshot_callback(retro_task_t *task,
       void *task_data,
       void *user_data, const char *error)
@@ -2163,6 +2168,7 @@ void task_screenshot_callback(retro_task_t *task,
    state       = NULL;
    task->state = NULL;
 }
+#endif
 
 dispgfx_widget_t *dispwidget_get_ptr(void)
 {

--- a/gfx/gfx_widgets.h
+++ b/gfx/gfx_widgets.h
@@ -306,7 +306,6 @@ void gfx_widgets_flush_text(
 typedef struct gfx_widget gfx_widget_t;
 
 bool gfx_widgets_init(
-      void *data,
       void *data_disp,
       void *data_anim,
       void *settings_data,
@@ -315,10 +314,9 @@ bool gfx_widgets_init(
       unsigned width, unsigned height, bool fullscreen,
       const char *dir_assets, char *font_path);
 
-void gfx_widgets_deinit(void *data, bool widgets_persisting);
+void gfx_widgets_deinit(bool widgets_persisting);
 
 void gfx_widgets_msg_queue_push(
-      void *data,
       retro_task_t *task, const char *msg,
       unsigned duration,
       char *title,
@@ -331,7 +329,6 @@ void gfx_widget_volume_update_and_show(float new_volume,
       bool mute);
 
 void gfx_widgets_iterate(
-      void *data,
       void *data_disp,
       void *settings_data,
       unsigned width, unsigned height, bool fullscreen,
@@ -344,11 +341,10 @@ void gfx_widget_screenshot_taken(void *data,
 /* AI Service functions */
 #ifdef HAVE_TRANSLATE
 bool gfx_widgets_ai_service_overlay_load(
-      dispgfx_widget_t *p_dispwidget,
       char* buffer, unsigned buffer_len,
       enum image_type_enum image_type);
 
-void gfx_widgets_ai_service_overlay_unload(dispgfx_widget_t *p_dispwidget);
+void gfx_widgets_ai_service_overlay_unload(void);
 #endif
 
 #ifdef HAVE_CHEEVOS
@@ -357,22 +353,14 @@ void gfx_widgets_set_leaderboard_display(unsigned id, const char* value);
 void gfx_widgets_set_challenge_display(unsigned id, const char* badge);
 #endif
 
-/* Warning: not thread safe! */
+/* TODO/FIXME/WARNING: Not thread safe! */
 void gfx_widget_set_generic_message(
-      void *data,
       const char *message, unsigned duration);
-
-/* Warning: not thread safe! */
 void gfx_widget_set_libretro_message(
-      void *data,
       const char *message, unsigned duration);
-
-/* Warning: not thread safe! */
-void gfx_widget_set_progress_message(void *data,
+void gfx_widget_set_progress_message(
       const char *message, unsigned duration,
       unsigned priority, int8_t progress);
-
-/* Warning: not thread safe! */
 bool gfx_widget_start_load_content_animation(void);
 
 /* All the functions below should be called in
@@ -380,7 +368,7 @@ bool gfx_widget_start_load_content_animation(void);
  * enable_menu_widgets to true for that driver */
 void gfx_widgets_frame(void *data);
 
-void *dispwidget_get_ptr(void);
+dispgfx_widget_t *dispwidget_get_ptr(void);
 
 extern const gfx_widget_t gfx_widget_screenshot;
 extern const gfx_widget_t gfx_widget_volume;

--- a/gfx/gfx_widgets.h
+++ b/gfx/gfx_widgets.h
@@ -20,6 +20,7 @@
 #include "../config.h"
 #endif
 
+#include <retro_common_api.h>
 #include <formats/image.h>
 #include <queues/task_queue.h>
 #include <queues/message_queue.h>
@@ -50,6 +51,8 @@
 #define TEXT_COLOR_ERROR 0xC23B22FF
 #endif
 #define TEXT_COLOR_FAINT 0x878787FF
+
+RETRO_BEGIN_DECLS
 
 enum gfx_widgets_icon
 {
@@ -381,5 +384,7 @@ extern const gfx_widget_t gfx_widget_load_content_animation;
 extern const gfx_widget_t gfx_widget_achievement_popup;
 extern const gfx_widget_t gfx_widget_leaderboard_display;
 #endif
+
+RETRO_END_DECLS
 
 #endif

--- a/gfx/widgets/gfx_widget_achievement_popup.c
+++ b/gfx/widgets/gfx_widget_achievement_popup.c
@@ -38,6 +38,7 @@ struct gfx_widget_achievement_popup_state
    slock_t* queue_lock;
 #endif
    cheevo_popup queue[CHEEVO_QUEUE_SIZE]; /* ptr alignment */
+   const dispgfx_widget_t *dispwidget_ptr;
    int queue_read_index;
    int queue_write_index;
    unsigned width;
@@ -64,6 +65,8 @@ static bool gfx_widget_achievement_popup_init(
 {
    gfx_widget_achievement_popup_state_t* state = &p_w_achievement_popup_st;
    memset(state, 0, sizeof(*state));
+   state->dispwidget_ptr   = (const dispgfx_widget_t*)
+      dispwidget_get_ptr();
 
    state->queue_read_index = -1;
 
@@ -81,6 +84,8 @@ static void gfx_widget_achievement_popup_free_all(gfx_widget_achievement_popup_s
 
       SLOCK_UNLOCK(state->queue_lock);
    }
+
+   state->dispwidget_ptr = NULL;
 }
 
 static void gfx_widget_achievement_popup_free(void)
@@ -91,8 +96,9 @@ static void gfx_widget_achievement_popup_free(void)
 
 #ifdef HAVE_THREADS
    slock_free(state->queue_lock);
-   state->queue_lock = NULL;
+   state->queue_lock     = NULL;
 #endif
+   state->dispwidget_ptr = NULL;
 }
 
 static void gfx_widget_achievement_popup_context_destroy(void)
@@ -293,9 +299,9 @@ static void gfx_widget_achievement_popup_next(void* userdata)
 static void gfx_widget_achievement_popup_dismiss(void *userdata)
 {
    gfx_animation_ctx_entry_t entry;
-   const dispgfx_widget_t        *p_dispwidget = (const dispgfx_widget_t*)
-      dispwidget_get_ptr();
    gfx_widget_achievement_popup_state_t *state = &p_w_achievement_popup_st;
+   const dispgfx_widget_t        *p_dispwidget = (const dispgfx_widget_t*)
+      state->dispwidget_ptr;
 
    /* Slide up animation */
    entry.cb             = gfx_widget_achievement_popup_next;
@@ -312,9 +318,9 @@ static void gfx_widget_achievement_popup_dismiss(void *userdata)
 static void gfx_widget_achievement_popup_fold(void *userdata)
 {
    gfx_animation_ctx_entry_t entry;
-   const dispgfx_widget_t        *p_dispwidget = (const dispgfx_widget_t*)
-      dispwidget_get_ptr();
    gfx_widget_achievement_popup_state_t *state = &p_w_achievement_popup_st;
+   const dispgfx_widget_t        *p_dispwidget = (const dispgfx_widget_t*)
+      state->dispwidget_ptr;
 
    /* Fold */
    entry.cb             = gfx_widget_achievement_popup_dismiss;
@@ -332,9 +338,9 @@ static void gfx_widget_achievement_popup_unfold(void *userdata)
 {
    gfx_timer_ctx_entry_t timer;
    gfx_animation_ctx_entry_t entry;
-   const dispgfx_widget_t        *p_dispwidget = (const dispgfx_widget_t*)
-      dispwidget_get_ptr();
    gfx_widget_achievement_popup_state_t *state = &p_w_achievement_popup_st;
+   const dispgfx_widget_t        *p_dispwidget = (const dispgfx_widget_t*)
+      state->dispwidget_ptr;
 
    /* Unfold */
    entry.cb             = NULL;
@@ -358,8 +364,9 @@ static void gfx_widget_achievement_popup_unfold(void *userdata)
 static void gfx_widget_achievement_popup_start(
    gfx_widget_achievement_popup_state_t* state)
 {
-   const dispgfx_widget_t* p_dispwidget = (const dispgfx_widget_t*)dispwidget_get_ptr();
    gfx_animation_ctx_entry_t entry;
+   const dispgfx_widget_t *p_dispwidget = (const dispgfx_widget_t*)
+      state->dispwidget_ptr;
 
    state->height = p_dispwidget->gfx_widget_fonts.regular.line_height * 4;
    state->width  = MAX(

--- a/gfx/widgets/gfx_widget_generic_message.c
+++ b/gfx/widgets/gfx_widget_generic_message.c
@@ -158,11 +158,10 @@ static void gfx_widget_generic_message_slide_in_cb(void *userdata)
 }
 
 /* Widget interface */
-
-void gfx_widget_set_generic_message(void *data,
+void gfx_widget_set_generic_message(
       const char *msg, unsigned duration)
 {
-   dispgfx_widget_t *p_dispwidget            = (dispgfx_widget_t*)data;
+   dispgfx_widget_t *p_dispwidget            = dispwidget_get_ptr();
    gfx_widget_generic_message_state_t *state = &p_w_generic_message_st;
    unsigned last_video_width                 = p_dispwidget->last_video_width;
    int text_width                            = 0;

--- a/gfx/widgets/gfx_widget_leaderboard_display.c
+++ b/gfx/widgets/gfx_widget_leaderboard_display.c
@@ -51,6 +51,7 @@ struct gfx_widget_leaderboard_display_state
 #ifdef HAVE_THREADS
    slock_t* array_lock;
 #endif
+   const dispgfx_widget_t *dispwidget_ptr;
    struct leaderboard_display_info tracker_info[CHEEVO_LBOARD_ARRAY_SIZE];
    unsigned tracker_count;
    struct challenge_display_info challenge_info[CHEEVO_CHALLENGE_ARRAY_SIZE];
@@ -69,6 +70,8 @@ static bool gfx_widget_leaderboard_display_init(
    gfx_widget_leaderboard_display_state_t *state = 
       &p_w_leaderboard_display_st;
    memset(state, 0, sizeof(*state));
+   state->dispwidget_ptr   = (const dispgfx_widget_t*)
+      dispwidget_get_ptr();
 
    return true;
 }
@@ -81,8 +84,9 @@ static void gfx_widget_leaderboard_display_free(void)
    state->challenge_count = 0;
 #ifdef HAVE_THREADS
    slock_free(state->array_lock);
-   state->array_lock = NULL;
+   state->array_lock      = NULL;
 #endif
+   state->dispwidget_ptr  = NULL;
 }
 
 static void gfx_widget_leaderboard_display_context_destroy(void)
@@ -228,14 +232,12 @@ void gfx_widgets_set_leaderboard_display(unsigned id, const char* value)
       else
       {
          /* show or update display */
-         const dispgfx_widget_t* p_dispwidget = (const dispgfx_widget_t*)dispwidget_get_ptr();
-
          if (i == state->tracker_count)
             state->tracker_info[state->tracker_count++].id = id;
 
          strncpy(state->tracker_info[i].display, value, sizeof(state->tracker_info[i].display));
          state->tracker_info[i].width = font_driver_get_message_width(
-               p_dispwidget->gfx_widget_fonts.regular.font,
+               state->dispwidget_ptr->gfx_widget_fonts.regular.font,
                state->tracker_info[i].display, 0, 1);
          state->tracker_info[i].width += CHEEVO_LBOARD_DISPLAY_PADDING * 2;
       }

--- a/gfx/widgets/gfx_widget_libretro_message.c
+++ b/gfx/widgets/gfx_widget_libretro_message.c
@@ -153,10 +153,10 @@ static void gfx_widget_libretro_message_slide_in_cb(void *userdata)
 
 /* Widget interface */
 
-void gfx_widget_set_libretro_message(void *data,
+void gfx_widget_set_libretro_message(
       const char *msg, unsigned duration)
 {
-   dispgfx_widget_t *p_dispwidget             = (dispgfx_widget_t*)data;
+   dispgfx_widget_t *p_dispwidget             = dispwidget_get_ptr();
    gfx_widget_libretro_message_state_t *state = &p_w_libretro_message_st;
    gfx_widget_font_data_t *font_msg_queue     = &p_dispwidget->gfx_widget_fonts.msg_queue;
 

--- a/gfx/widgets/gfx_widget_progress_message.c
+++ b/gfx/widgets/gfx_widget_progress_message.c
@@ -122,12 +122,12 @@ static void gfx_widget_progress_message_fadeout(void *userdata)
 
 /* Widget interface */
 
-void gfx_widget_set_progress_message(void *data,
+void gfx_widget_set_progress_message(
       const char *message, unsigned duration,
       unsigned priority, int8_t progress)
 {
    gfx_timer_ctx_entry_t timer;
-   dispgfx_widget_t *p_dispwidget             = (dispgfx_widget_t*)data;
+   dispgfx_widget_t *p_dispwidget             = dispwidget_get_ptr();
    gfx_widget_progress_message_state_t *state = &p_w_progress_message_st;
    gfx_widget_font_data_t *font_regular       = &p_dispwidget->gfx_widget_fonts.regular;
    uintptr_t alpha_tag                        = (uintptr_t)&state->alpha;

--- a/retroarch_data.h
+++ b/retroarch_data.h
@@ -843,9 +843,6 @@ struct rarch_state
 #ifdef HAVE_DISCORD
    discord_state_t discord_st;                  /* int64_t alignment */
 #endif
-#ifdef HAVE_GFX_WIDGETS
-   dispgfx_widget_t dispwidget_st;              /* uint64_t alignment */
-#endif
    struct retro_core_t        current_core;     /* uint64_t alignment */
 #if defined(HAVE_RUNAHEAD)
 #if defined(HAVE_DYNAMIC) || defined(HAVE_DYLIB)

--- a/tasks/task_screenshot.c
+++ b/tasks/task_screenshot.c
@@ -57,30 +57,6 @@
 
 #include "tasks_internal.h"
 
-typedef struct screenshot_task_state screenshot_task_state_t;
-
-struct screenshot_task_state
-{
-   uint8_t *out_buffer;
-   const void *frame;
-   void *userbuf;
-
-   int pitch;
-   unsigned width;
-   unsigned height;
-   unsigned pixel_format_type;
-
-   char filename[PATH_MAX_LENGTH];
-   char shotname[256];
-
-   bool bgr24;
-   bool silence;
-   bool is_idle;
-   bool is_paused;
-   bool history_list_enable;
-   bool widgets_ready;
-};
-
 static bool screenshot_dump_direct(screenshot_task_state_t *state)
 {
    struct scaler_ctx scaler;
@@ -220,30 +196,9 @@ task_finished:
 }
 
 #if defined(HAVE_GFX_WIDGETS)
-static void task_screenshot_callback(retro_task_t *task,
+void task_screenshot_callback(retro_task_t *task,
       void *task_data,
-      void *user_data, const char *error)
-{
-   screenshot_task_state_t *state = NULL;
-
-   if (!task)
-      return;
-
-   state = (screenshot_task_state_t*)task->state;
-
-   if (!state)
-      return;
-
-   if (!state->silence && state->widgets_ready)
-      gfx_widget_screenshot_taken(dispwidget_get_ptr(),
-            state->shotname, state->filename);
-
-   free(state);
-   /* Must explicitly set task->state to NULL here,
-    * to avoid potential heap-use-after-free errors */
-   state       = NULL;
-   task->state = NULL;
-}
+      void *user_data, const char *error);
 #endif
 
 /* Take frame bottom-up. */

--- a/tasks/task_screenshot.c
+++ b/tasks/task_screenshot.c
@@ -61,7 +61,6 @@ typedef struct screenshot_task_state screenshot_task_state_t;
 
 struct screenshot_task_state
 {
-   struct scaler_ctx scaler;
    uint8_t *out_buffer;
    const void *frame;
    void *userbuf;
@@ -84,26 +83,26 @@ struct screenshot_task_state
 
 static bool screenshot_dump_direct(screenshot_task_state_t *state)
 {
-   struct scaler_ctx *scaler      = (struct scaler_ctx*)&state->scaler;
+   struct scaler_ctx scaler;
    bool ret                       = false;
 
 #if defined(HAVE_RPNG)
    if (state->bgr24)
-      scaler->in_fmt              = SCALER_FMT_BGR24;
+      scaler.in_fmt              = SCALER_FMT_BGR24;
    else if (state->pixel_format_type == RETRO_PIXEL_FORMAT_XRGB8888)
-      scaler->in_fmt              = SCALER_FMT_ARGB8888;
+      scaler.in_fmt              = SCALER_FMT_ARGB8888;
    else
-      scaler->in_fmt              = SCALER_FMT_RGB565;
+      scaler.in_fmt              = SCALER_FMT_RGB565;
 
    video_frame_convert_to_bgr24(
-         scaler,
+         &scaler,
          state->out_buffer,
          (const uint8_t*)state->frame + ((int)state->height - 1)
          * state->pitch,
          state->width, state->height,
          -state->pitch);
 
-   scaler_ctx_gen_reset(&state->scaler);
+   scaler_ctx_gen_reset(&scaler);
 
    ret = rpng_save_image_bgr24(
          state->filename,

--- a/tasks/tasks_internal.h
+++ b/tasks/tasks_internal.h
@@ -206,6 +206,30 @@ void *task_push_decompress(
 
 void task_file_load_handler(retro_task_t *task);
 
+typedef struct screenshot_task_state screenshot_task_state_t;
+
+struct screenshot_task_state
+{
+   uint8_t *out_buffer;
+   const void *frame;
+   void *userbuf;
+
+   int pitch;
+   unsigned width;
+   unsigned height;
+   unsigned pixel_format_type;
+
+   char filename[PATH_MAX_LENGTH];
+   char shotname[256];
+
+   bool bgr24;
+   bool silence;
+   bool is_idle;
+   bool is_paused;
+   bool history_list_enable;
+   bool widgets_ready;
+};
+
 bool take_screenshot(
       const char *screenshot_dir,
       const char *path, bool silence,


### PR DESCRIPTION
Moves display widget state to gfx_widgets.c.

Another big change - in task_screenshot.c, I found out that it was unnecessary to have the scaler state in the userdata struct, so I took it out and only used it for the one function it was used in.