### PR TITLE
Fix blargg warning + some cleanups

### DIFF
--- a/gfx/video_filters/blargg_ntsc_snes.c
+++ b/gfx/video_filters/blargg_ntsc_snes.c
@@ -74,78 +74,85 @@ static void blargg_ntsc_snes_initialize(void *data,
       const struct softfilter_config *config,
       void *userdata)
 {
-   char *tvtype = NULL;
-   snes_ntsc_setup_t setup;
+   char *tvtype             = NULL;
+   snes_ntsc_setup_t setup  = retroarch_snes_ntsc_composite;
    struct filter_data *filt = (struct filter_data*)data;
 
-   float custom_hue, custom_saturation, custom_contrast, custom_brightness, custom_sharpness,
-      custom_gamma, custom_resolution, custom_artifacts, custom_fringing, custom_bleed, custom_merge_fields;
-
-   config->get_float(userdata, "hue", &custom_hue, 0.0f);
-   config->get_float(userdata, "saturation", &custom_saturation, 0.0f);
-   config->get_float(userdata, "contrast", &custom_contrast, 0.0f);
-   config->get_float(userdata, "brightness", &custom_brightness, 0.0f);
-   config->get_float(userdata, "sharpness", &custom_sharpness, 0.0f);
-   config->get_float(userdata, "gamma", &custom_gamma, 0.0f);
-   config->get_float(userdata, "resolution", &custom_resolution, 0.0f);
-   config->get_float(userdata, "artifacts", &custom_artifacts, 0.0f);
-   config->get_float(userdata, "fringing", &custom_fringing, 0.0f);
-   config->get_float(userdata, "bleed", &custom_bleed, 0.0f);
-   config->get_float(userdata, "merge_fields", &custom_merge_fields, 1.0f);
-   
-   filt->ntsc = (snes_ntsc_t*)calloc(1, sizeof(*filt->ntsc));
+   filt->ntsc               = (snes_ntsc_t*)
+      calloc(1, sizeof(*filt->ntsc));
+   setup.merge_fields       = 1;
 
    if (config->get_string(userdata, "tvtype", &tvtype, "composite"))
    {
-      if (memcmp(tvtype, "composite", 9) == 0)
-      {
-         setup = retroarch_snes_ntsc_composite;
-         setup.merge_fields = 1;
-      }
-      else if (memcmp(tvtype, "rf", 2) == 0)
-      {
-         setup = retroarch_snes_ntsc_composite;
+      /* NOTE: SNES composite is being set by default,
+         merge_fields should only be set to 0 for RF output */
+
+      if (memcmp(tvtype, "rf", 2) == 0)
          setup.merge_fields = 0;
-      }
       else if (memcmp(tvtype, "rgb", 3) == 0)
-      {
-         setup = retroarch_snes_ntsc_rgb;
-         setup.merge_fields = 1;
-      }
+         setup              = retroarch_snes_ntsc_rgb;
       else if (memcmp(tvtype, "svideo", 6) == 0)
-      {
-         setup = retroarch_snes_ntsc_svideo;
-         setup.merge_fields = 1;
-      }
+         setup              = retroarch_snes_ntsc_svideo;
       else if (memcmp(tvtype, "custom", 6) == 0)
       {
-         setup = retroarch_snes_ntsc_composite;
-         setup.hue = custom_hue;
-         setup.saturation = custom_saturation;
-         setup.contrast = custom_contrast;
-         setup.brightness = custom_brightness;
-         setup.sharpness = custom_sharpness;
-         setup.gamma = custom_gamma;
-         setup.resolution = custom_resolution;
-         setup.artifacts = custom_artifacts;
-         setup.fringing = custom_fringing;
-         setup.bleed = custom_bleed;
-         setup.merge_fields = custom_merge_fields;
+         float custom_merge_fields = 1.0f;
+         float custom_bleed        = 0.0f;
+         float custom_fringing     = 0.0f;
+         float custom_artifacts    = 0.0f;
+         float custom_resolution   = 0.0f;
+         float custom_gamma        = 0.0f;
+         float custom_sharpness    = 0.0f;
+         float custom_brightness   = 0.0f;
+         float custom_hue          = 0.0f;
+         float custom_saturation   = 0.0f;
+         float custom_contrast     = 0.0f;
+
+         config->get_float(userdata, "merge_fields",
+               &custom_merge_fields, 1.0f);
+         config->get_float(userdata, "bleed",
+               &custom_bleed, 0.0f);
+         config->get_float(userdata, "fringing",
+               &custom_fringing, 0.0f);
+         config->get_float(userdata, "artifacts",
+               &custom_artifacts, 0.0f);
+         config->get_float(userdata, "resolution",
+               &custom_resolution, 0.0f);
+         config->get_float(userdata, "gamma",
+               &custom_gamma, 0.0f);
+         config->get_float(userdata, "brightness",
+               &custom_brightness, 0.0f);
+         config->get_float(userdata, "sharpness",
+               &custom_sharpness, 0.0f);
+         config->get_float(userdata, "hue",
+               &custom_hue, 0.0f);
+         config->get_float(userdata, "saturation",
+               &custom_saturation, 0.0f);
+         config->get_float(userdata, "contrast",
+               &custom_contrast, 0.0f);
+
+         setup                     = retroarch_snes_ntsc_composite;
+
+         setup.hue                 = custom_hue;
+         setup.saturation          = custom_saturation;
+         setup.contrast            = custom_contrast;
+         setup.brightness          = custom_brightness;
+         setup.sharpness           = custom_sharpness;
+         setup.gamma               = custom_gamma;
+         setup.resolution          = custom_resolution;
+         setup.artifacts           = custom_artifacts;
+         setup.fringing            = custom_fringing;
+         setup.bleed               = custom_bleed;
+         setup.merge_fields        = custom_merge_fields;
          config->get_int(userdata, "hires_blit", &hires_blit, 1);
       }
    }
-   else
-   {
-      setup = retroarch_snes_ntsc_composite;
-      setup.merge_fields = 1;
-   }
 
    config->free(tvtype);
-   tvtype = NULL;
+   tvtype             = NULL;
 
    retroarch_snes_ntsc_init(filt->ntsc, &setup);
 
-   filt->burst = 0;
+   filt->burst        = 0;
    filt->burst_toggle = (setup.merge_fields ? 0 : 1);
 }
 


### PR DESCRIPTION
Does the following:

* Tries to get rid of a long-standing warning on some compilers/toolchains:

```
In function 'blargg_ntsc_snes_initialize',
    inlined from 'blargg_ntsc_snes_generic_create' at gfx/video_filters/blargg_ntsc_snes.c:171:4:
gfx/video_filters/blargg_ntsc_snes.c:149:31: warning: 'setup.merge_fields' may be used uninitialized [-Wmaybe-uninitialized]
  149 |    filt->burst_toggle = (setup.merge_fields ? 0 : 1);
      |                          ~~~~~^~~~~~~~~~~~~
gfx/video_filters/blargg_ntsc_snes.c: In function 'blargg_ntsc_snes_generic_create':
gfx/video_filters/blargg_ntsc_snes.c:78:22: note: 'setup' declared here
   78 |    snes_ntsc_setup_t setup;
      |                      ^~~~~
```

* Also takes the opportunity to refactor some parts. We only try to read certain 'custom' values from the config file handle now if we really need them instead of always like before. We also don't set merge_fields unnecessarily now when the new default for merge_fields is already 1, and it should only be set to '0' for RF output anyway.