### PR TITLE
Put scaler_ctx back in screenshot_state

### DIFF
--- a/tasks/task_screenshot.c
+++ b/tasks/task_screenshot.c
@@ -29,7 +29,6 @@
 #include <file/file_path.h>
 #include <compat/strl.h>
 #include <string/stdstring.h>
-#include <gfx/scaler/scaler.h>
 #include <gfx/video_frame.h>
 
 #ifdef HAVE_RBMP
@@ -59,26 +58,26 @@
 
 static bool screenshot_dump_direct(screenshot_task_state_t *state)
 {
-   struct scaler_ctx scaler;
-   bool ret                       = false;
+   struct scaler_ctx *scaler     = (struct scaler_ctx*)&state->scaler;
+   bool ret                      = false;
 
 #if defined(HAVE_RPNG)
    if (state->bgr24)
-      scaler.in_fmt              = SCALER_FMT_BGR24;
+      scaler->in_fmt             = SCALER_FMT_BGR24;
    else if (state->pixel_format_type == RETRO_PIXEL_FORMAT_XRGB8888)
-      scaler.in_fmt              = SCALER_FMT_ARGB8888;
+      scaler->in_fmt             = SCALER_FMT_ARGB8888;
    else
-      scaler.in_fmt              = SCALER_FMT_RGB565;
+      scaler->in_fmt             = SCALER_FMT_RGB565;
 
    video_frame_convert_to_bgr24(
-         &scaler,
+         scaler,
          state->out_buffer,
          (const uint8_t*)state->frame + ((int)state->height - 1)
          * state->pitch,
          state->width, state->height,
          -state->pitch);
 
-   scaler_ctx_gen_reset(&scaler);
+   scaler_ctx_gen_reset(&state->scaler);
 
    ret = rpng_save_image_bgr24(
          state->filename,

--- a/tasks/tasks_internal.h
+++ b/tasks/tasks_internal.h
@@ -23,6 +23,7 @@
 #include <retro_miscellaneous.h>
 
 #include <queues/task_queue.h>
+#include <gfx/scaler/scaler.h>
 
 #ifdef HAVE_CONFIG_H
 #include "../config.h"
@@ -210,6 +211,7 @@ typedef struct screenshot_task_state screenshot_task_state_t;
 
 struct screenshot_task_state
 {
+   struct scaler_ctx scaler;
    uint8_t *out_buffer;
    const void *frame;
    void *userbuf;


### PR DESCRIPTION
Hopefully resolves the regressions pointed out by ofry (could not reproduce myself) - 

fixes https://github.com/libretro/RetroArch/issues/13058