### PR TITLE
(.gitlab-ci.yml) Remove unnecessary 'env.exe' commands from MSVC builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -118,7 +118,6 @@ build-retroarch-windows-msvc10-x64:
     - |
       $ErrorActionPreference = 'Stop'
       # Build RetroArch
-      env.exe
       bash.exe -l -c "make -f Makefile.griffin platform=$Env:MSVC_PLATFORM"
       if ($LastExitCode -ne 0){throw "Failed to build RetroArch"}
       mt.exe -nologo -manifest "retroarch.exe.manifest" -outputresource:"retroarch.exe;#1"
@@ -168,7 +167,6 @@ build-retroarch-windows-msvc10-i686:
     - |
       $ErrorActionPreference = 'Stop'
       # Build RetroArch
-      env.exe
       bash.exe -l -c "make -f Makefile.griffin platform=$Env:MSVC_PLATFORM"
       if ($LastExitCode -ne 0){throw "Failed to build RetroArch"}
       mt.exe -nologo -manifest "retroarch.exe.manifest" -outputresource:"retroarch.exe;#1"
@@ -219,7 +217,6 @@ build-retroarch-windows-msvc05-i686:
     - |
       $ErrorActionPreference = 'Stop'
       # Build RetroArch
-      env.exe
       bash.exe -l -c "make -f Makefile.griffin platform=$Env:MSVC_PLATFORM"
       if ($LastExitCode -ne 0){throw "Failed to build RetroArch"}
       mt.exe -nologo -manifest "retroarch.exe.manifest" -outputresource:"retroarch.exe;#1"


### PR DESCRIPTION
## Description

This PR just removes some unnecessary `env.exe` commands from the gitlab MSVC build jobs. These were a copy/paste leftover, and may cause potentially sensitive information to leak into the build logs. 
