### PR TITLE
Get the WIIU GCA working on Mac OSX

### DIFF
--- a/input/connect/connect_wiiugca.c
+++ b/input/connect/connect_wiiugca.c
@@ -215,6 +215,14 @@ static void hidpad_wiiugca_packet_handler(void *device_data, uint8_t *packet, ui
    if (!device)
       return;
 
+/* Mac OSX reads a 39-byte packet which has both a leading and trailing byte from
+ * the actual packet data.
+ */
+#if defined(__APPLE__) && defined(HAVE_IOHIDMANAGER)
+   packet++;
+   size = 37;
+#endif
+
    memcpy(device->data, packet, size);
 
    for (i = 1; i < 37; i += 9)

--- a/input/drivers_hid/iohidmanager_hid.c
+++ b/input/drivers_hid/iohidmanager_hid.c
@@ -1021,6 +1021,8 @@ static int iohidmanager_hid_manager_set_device_matching(
    iohidmanager_hid_append_matching_dictionary(matcher,
       kHIDPage_GenericDesktop,
       kHIDUsage_GD_GamePad);
+   /* The GameCube Adapter reports usage id 0x00 */
+   iohidmanager_hid_append_matching_dictionary(matcher, kHIDPage_Game, 0x00);
    
    IOHIDManagerSetDeviceMatchingMultiple(hid->ptr, matcher);
    IOHIDManagerRegisterDeviceMatchingCallback(hid->ptr,iohidmanager_hid_device_matched, 0);


### PR DESCRIPTION
## Description

The GCA uses a weird HID class that our current filters don't
catch, so we add it.

Needed to do a small amount of tweaking on the GCA driver to
account for iohidmanager weirdness.

## Reviewers

@twinaphex 
