### PR TITLE
Fix a couple regressions

### DIFF
--- a/input/drivers_hid/wiiu_hid.c
+++ b/input/drivers_hid/wiiu_hid.c
@@ -733,7 +733,7 @@ static void wiiu_poll_adapters(wiiu_hid_t *hid)
          wiiu_poll_adapter(it);
 
       if (it->state == ADAPTER_STATE_DONE) {
-         RARCH_LOG("poll_adapters: read done, ready for garbage collection");
+         
          it->state = ADAPTER_STATE_GC;
       }
    }

--- a/input/drivers_joypad/wiiu/kpad_driver.c
+++ b/input/drivers_joypad/wiiu/kpad_driver.c
@@ -58,6 +58,7 @@ static void *kpad_init(void *data)
 
    for(int i = 0; i < WIIU_WIIMOTE_CHANNELS; i++) {
       joypad_state.kpad.channel_slot_map[i] = -1;
+      joypad_state.kpad.wiimotes[i].type = WIIMOTE_TYPE_NONE;
    }
 
    kpad_poll();


### PR DESCRIPTION
== DETAILS

- rewrote the HID deregistration algorithm; it should no longer
  cause issues when dealing with multiple pads of the same HID/VID
  combo
- fix initialization bug that caused wiimotes to fail to register
  without an accessory attached

@twinaphex 