### PR TITLE
Fix missing time.h header in wifi_driver.h

### DIFF
--- a/wifi/wifi_driver.h
+++ b/wifi/wifi_driver.h
@@ -19,6 +19,7 @@
 #define __WIFI_DRIVER__H
 
 #include <stdint.h>
+#include <time.h>
 
 #include <boolean.h>
 #include <retro_common_api.h>


### PR DESCRIPTION
## Description

On musl which is much stricter C library, the `time_t` typedef isn't available because the header `time.h` isn't included in wifi_driver.h

```
In file included from tasks/task_wifi.c:27:
tasks/../wifi/wifi_driver.h:55:4: error: unknown type name 'time_t'
   55 |    time_t scan_time;
      |    ^~~~~~
make: *** [Makefile:206: obj-unix/release/tasks/task_wifi.o] Error 1
make: *** Waiting for unfinished jobs....
```
