### PR TITLE
(3DS) Ensure parallax barrier is disabled when '3DS Display Mode' is '2D'

### DIFF
--- a/gfx/drivers/ctr_gfx.c
+++ b/gfx/drivers/ctr_gfx.c
@@ -120,6 +120,8 @@ static INLINE void ctr_check_3D_slider(ctr_video_t* ctr, ctr_video_mode_enum vid
       case CTR_VIDEO_MODE_2D:
       default:
          ctr->video_mode = CTR_VIDEO_MODE_2D;
+         if (ctr->supports_parallax_disable)
+            ctr_set_parallax_layer(false);
          ctr->enable_3d = false;
          break;
    }


### PR DESCRIPTION
## Description

It seems a regression has appeared in the 3DS build: when launching content with `3DS Display Mode` set to `2D`, the top screen's parallax barrier is now enabled - which is the exact opposite of what should happen.

This trivial PR fixes the issue.
