### PR TITLE
(Dingux) Fix HAS_ANALOG/HAS_MENU_TOGGLE defines in sdl_dingux joypad driver

### DIFF
--- a/input/drivers_joypad/sdl_dingux_joypad.c
+++ b/input/drivers_joypad/sdl_dingux_joypad.c
@@ -32,12 +32,21 @@
 #include "../../config.def.h"
 #endif
 
-#if defined(RS90) || defined(RETROFW) || defined(MIYOO)
-#define SDL_DINGUX_HAS_ANALOG      0
-#define SDL_DINGUX_HAS_MENU_TOGGLE 0
-#else
+/* RS-90 and RetroFW devices:
+ * - Analog input: No
+ * - Menu button:  No
+ * Miyoo devices:
+ * - Analog input: No
+ * - Menu button:  Yes
+ * All other OpenDingux devices:
+ * - Analog input: Yes
+ * - Menu button:  Yes
+ */
+#if !(defined(RS90) || defined(RETROFW))
+#if !defined(MIYOO)
 #define SDL_DINGUX_HAS_ANALOG      1
-#define SDL_DINGUX_HAS_MENU_TOGGLE 1  
+#endif
+#define SDL_DINGUX_HAS_MENU_TOGGLE 1
 #endif
 
 /* Simple joypad driver designed to rationalise


### PR DESCRIPTION
## Description

Commit https://github.com/libretro/RetroArch/commit/9000e8149879deb8b208046ef182aa1294cf7e0b introduced a small regression in the `sdl_dingux` joypad driver which causes analog input and menu (toggle) button support to be compiled in for OpenDingux devices which do not have the required hardware to enable these features.

This PR fixes the issue by correctly setting the `SDL_DINGUX_HAS_ANALOG` and `SDL_DINGUX_HAS_MENU_TOGGLE` defines based on the current build target.