### PR TITLE
fix: solarized dark ozone theme assets and color tweaks

### DIFF
--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -1282,7 +1282,7 @@ ozone_theme_t ozone_theme_solarized_dark = {
 
    /* Float colors for quads and icons */
    COLOR_HEX_TO_FLOAT(0x839496, 1.0f),                   /* header_footer_separator */
-   COLOR_HEX_TO_FLOAT(0x839496, 1.0f),                   /* text */
+   COLOR_HEX_TO_FLOAT(0x93A1A1, 1.0f),                   /* text */
    COLOR_HEX_TO_FLOAT(0x073642, 1.0f),                   /* selection */
    COLOR_HEX_TO_FLOAT(0x2AA198, 1.0f),                   /* selection_border */
    COLOR_HEX_TO_FLOAT(0x073642, 1.0f),                   /* entries_border */
@@ -1291,9 +1291,9 @@ ozone_theme_t ozone_theme_solarized_dark = {
    COLOR_HEX_TO_FLOAT(0x002B36, 1.0f),                   /* message_background */
 
    /* RGBA colors for text */
-   0x839496FF,                                           /* text_rgba */
+   0x93A1A1FF,                                           /* text_rgba */
    0x2AA198FF,                                           /* text_selected_rgba */
-   0x586E75FF,                                           /* text_sublabel_rgba */
+   0x657B83FF,                                           /* text_sublabel_rgba */
 
    /* Screensaver 'tint' (RGB24) */
    0x073642,                                             /* screensaver_tint */


### PR DESCRIPTION
continuation of https://github.com/libretro/RetroArch/pull/13119

i fixed the name of the theme in ozone.c so it loads assets properly, which as a result exposed a couple colors i hadnt set properly (for some reason, if assets dont load, popup message background colors and the animated cursor dont appear despite their colors being controlled by code and not images)

this doesn't include suggested font changes (brightness) because i want to provide comparison screenshots so we can decide whether or not we should adjust the font. but these fixes need to be in regardless.

thanks!