### PR TITLE
add header for cpufreq

### DIFF
--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -62,6 +62,7 @@
 #include "../input/input_remapping.h"
 #include "../performance_counters.h"
 #include "../version.h"
+#include "../misc/cpufreq/cpufreq.h"
 
 #ifdef HAVE_LIBNX
 #include <switch.h>


### PR DESCRIPTION
## Description
Functions using `set_cpu_scaling_signal()` (used by Lakka) have been moved (from `retroarch.c` to `menu/menu_driver.c`, but the header was not added to `menu/menu_driver.c`
