### PR TITLE
Fix issue where files over 2.5gb approx would fail to load on uwp/xbox

### DIFF
--- a/libretro-common/vfs/vfs_implementation_uwp.cpp
+++ b/libretro-common/vfs/vfs_implementation_uwp.cpp
@@ -158,9 +158,16 @@ int64_t retro_vfs_file_truncate_impl(libretro_vfs_implementation_file* stream, i
 
 int64_t retro_vfs_file_tell_impl(libretro_vfs_implementation_file* stream)
 {
-    if (!stream)
+    if (!stream || (!stream->fp && stream->fh == INVALID_HANDLE_VALUE))
         return -1;
 
+    if (stream->fh != INVALID_HANDLE_VALUE)
+    {
+        LARGE_INTEGER sz;
+        if (GetFileSizeEx(stream->fh, &sz))
+            return sz.QuadPart;
+        return 0;
+    }
     if ((stream->hints & RFILE_HINT_UNBUFFERED) == 0)
     {
         return ftell(stream->fp);


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

Fix issue where roms over 2.5 gb (approx) would fail to load on uwp/xbox.
This was caused by cstyle/posix style (idk what to call them) functions being unable to get the file size of large files.
(I think this is due them only supporting 32 bit int size limits internally, which would be a 2.147483647 gb max file size)
These would error and return -1.  So we implement the proper Windows method. This has been tested by @gamr13 to confirm that the error is fixed.

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
