### PR TITLE
add define for HAVE_LAKKA_NIGHTLY when used as option

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1041,6 +1041,10 @@ ifeq ($(HAVE_LAKKA_SWITCH), 1)
    DEFINES += -DHAVE_LAKKA_SWITCH
 endif
 
+ifeq ($(HAVE_LAKKA_NIGHTLY), 1)
+   DEFINES += -DHAVE_LAKKA_NIGHTLY
+endif
+
 ifeq ($(HAVE_MENU_COMMON), 1)
    OBJ += menu/menu_setting.o \
           menu/menu_driver.o \


### PR DESCRIPTION
This patch is from Lakka.

Patch is used to build Lakka, adds a define in Makefile in case RetroArch is built with make ... HAVE_LAKKA_NIGHTLY=1 (to use different URL for updater - this code is already present).

https://github.com/libretro/RetroArch/blob/d75127e9c24bd8b3c5e586afb4f79db9cd0452a9/file_path_special.h#L78-L82