### PR TITLE
do not sort FILE_TYPE_DOWNLOAD_LAKKA type list

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -9811,7 +9811,7 @@ static unsigned print_buf_lines(file_list_t *list, char *buf,
       line_start     = buf + i + 1;
    }
 
-   if (append)
+   if (append && type != FILE_TYPE_DOWNLOAD_LAKKA)
       file_list_sort_on_alt(list);
    /* If the buffer was completely full, and didn't end
     * with a newline, just ignore the partial last line. */


### PR DESCRIPTION
Another patch from Lakka.

The Lakka updater pulls `.index` file from a given location. This file includes list of downloadable system (update) images. This list is already sorted from latest to oldest available image (as this order is also expected by a script for manual invocation of the update).

In case `print_buf_lines()` is called with `type = FILE_TYPE_DOWNLOAD_LAKKA`, the call to `file_list_sort_on_alt()` has to be skipped, so the list is shown in original order.