### PR TITLE
Cleanup accessibility_speak_priority

### DIFF
--- a/retroarch_fwd_decls.h
+++ b/retroarch_fwd_decls.h
@@ -87,7 +87,7 @@ static bool driver_camera_start(void);
 #ifdef HAVE_ACCESSIBILITY
 static bool is_accessibility_enabled(bool accessibility_enable,
       bool accessibility_enabled);
-static bool accessibility_speak_priority(
+static void accessibility_speak_priority(
       struct rarch_state *p_rarch,
       bool accessibility_enable,
       unsigned accessibility_narrator_speech_speed,


### PR DESCRIPTION
Changes the return type of accessibility_speak_priority to void (since it wasn't used before), and also reduces the amount of calls to accessibility_speak_priority in general.