### PR TITLE
Move frontend code to frontend_driver.c

### DIFF
--- a/frontend/frontend_driver.h
+++ b/frontend/frontend_driver.h
@@ -119,6 +119,11 @@ typedef struct frontend_ctx_driver
    const struct video_driver *(*get_video_driver)(void);
 } frontend_ctx_driver_t;
 
+typedef struct
+{
+   frontend_ctx_driver_t *current_frontend_ctx; /* ptr alignment */
+} frontend_state_t;
+
 extern frontend_ctx_driver_t frontend_ctx_gx;
 extern frontend_ctx_driver_t frontend_ctx_wiiu;
 extern frontend_ctx_driver_t frontend_ctx_ps3;
@@ -225,6 +230,8 @@ void frontend_driver_set_sustained_performance_mode(bool on);
 const char* frontend_driver_get_cpu_model_name(void);
 
 enum retro_language frontend_driver_get_user_language(void);
+
+frontend_state_t *frontend_state_get_ptr(void);
 
 RETRO_END_DECLS
 

--- a/retroarch.c
+++ b/retroarch.c
@@ -5230,7 +5230,8 @@ static bool is_narrator_running(struct rarch_state *p_rarch,
             accessibility_enable,
             p_rarch->accessibility_enabled))
    {
-      frontend_ctx_driver_t *frontend = p_rarch->current_frontend_ctx;
+      frontend_ctx_driver_t *frontend = 
+         frontend_state_get_ptr()->current_frontend_ctx;
       if (frontend && frontend->is_narrator_running)
          return frontend->is_narrator_running();
    }
@@ -8427,14 +8428,14 @@ int rarch_main(int argc, char *argv[], void *data)
 
    runloop_msg_queue_init();
 
-   if (p_rarch->current_frontend_ctx)
+   if (frontend_state_get_ptr()->current_frontend_ctx)
    {
       content_ctx_info_t info;
 
       info.argc            = argc;
       info.argv            = argv;
       info.args            = data;
-      info.environ_get     = p_rarch->current_frontend_ctx->environment_get;
+      info.environ_get     = frontend_state_get_ptr()->current_frontend_ctx->environment_get;
 
       if (!task_push_load_content_from_cli(
                NULL,
@@ -20789,7 +20790,8 @@ static bool accessibility_speak_priority(
             accessibility_enable,
             p_rarch->accessibility_enabled))
    {
-      frontend_ctx_driver_t *frontend = p_rarch->current_frontend_ctx;
+      frontend_ctx_driver_t *frontend = 
+         frontend_state_get_ptr()->current_frontend_ctx;
 
       RARCH_LOG("Spoke: %s\n", speak_text);
 
@@ -21191,313 +21193,4 @@ void menu_content_environment_get(int *argc, char *argv[],
    if (!retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_LIBRETRO, NULL))
       wrap_args->libretro_path = string_is_empty(path_get(RARCH_PATH_CORE)) ? NULL :
          path_get(RARCH_PATH_CORE);
-}
-
-frontend_ctx_driver_t *frontend_get_ptr(void)
-{
-   struct rarch_state *p_rarch = &rarch_st;
-   return p_rarch->current_frontend_ctx;
-}
-
-int frontend_driver_parse_drive_list(void *data, bool load_content)
-{
-   struct rarch_state     *p_rarch = &rarch_st;
-   frontend_ctx_driver_t *frontend = p_rarch->current_frontend_ctx;
-
-   if (!frontend || !frontend->parse_drive_list)
-      return -1;
-   return frontend->parse_drive_list(data, load_content);
-}
-
-void frontend_driver_content_loaded(void)
-{
-   struct rarch_state     *p_rarch = &rarch_st;
-   frontend_ctx_driver_t *frontend = p_rarch->current_frontend_ctx;
-
-   if (!frontend || !frontend->content_loaded)
-      return;
-   frontend->content_loaded();
-}
-
-bool frontend_driver_has_fork(void)
-{
-   struct rarch_state     *p_rarch = &rarch_st;
-   frontend_ctx_driver_t *frontend = p_rarch->current_frontend_ctx;
-
-   if (!frontend || !frontend->set_fork)
-      return false;
-   return true;
-}
-
-bool frontend_driver_set_fork(enum frontend_fork fork_mode)
-{
-   struct rarch_state     *p_rarch = &rarch_st;
-   frontend_ctx_driver_t *frontend = p_rarch->current_frontend_ctx;
-
-   if (!frontend_driver_has_fork())
-      return false;
-   return frontend->set_fork(fork_mode);
-}
-
-void frontend_driver_process_args(int *argc, char *argv[])
-{
-   struct rarch_state     *p_rarch = &rarch_st;
-   frontend_ctx_driver_t *frontend = p_rarch->current_frontend_ctx;
-
-   if (frontend && frontend->process_args)
-      frontend->process_args(argc, argv);
-}
-
-bool frontend_driver_is_inited(void)
-{
-   struct rarch_state     *p_rarch = &rarch_st;
-   frontend_ctx_driver_t *frontend = p_rarch->current_frontend_ctx;
-   return frontend != NULL;
-}
-
-void frontend_driver_init_first(void *args)
-{
-   struct rarch_state *p_rarch   = &rarch_st;
-   p_rarch->current_frontend_ctx = (frontend_ctx_driver_t*)
-      frontend_ctx_init_first();
-
-   if (p_rarch->current_frontend_ctx && p_rarch->current_frontend_ctx->init)
-      p_rarch->current_frontend_ctx->init(args);
-}
-
-void frontend_driver_free(void)
-{
-   struct rarch_state *p_rarch      = &rarch_st;
-
-   if (p_rarch)
-      p_rarch->current_frontend_ctx = NULL;
-}
-
-bool frontend_driver_has_get_video_driver_func(void)
-{
-   struct rarch_state     *p_rarch = &rarch_st;
-   frontend_ctx_driver_t *frontend = p_rarch->current_frontend_ctx;
-   if (!frontend || !frontend->get_video_driver)
-      return false;
-   return true;
-}
-
-const struct video_driver *frontend_driver_get_video_driver(void)
-{
-   struct rarch_state     *p_rarch = &rarch_st;
-   frontend_ctx_driver_t *frontend = p_rarch->current_frontend_ctx;
-   if (!frontend || !frontend->get_video_driver)
-      return NULL;
-   return frontend->get_video_driver();
-}
-
-void frontend_driver_exitspawn(char *s, size_t len, char *args)
-{
-   struct rarch_state     *p_rarch = &rarch_st;
-   frontend_ctx_driver_t *frontend = p_rarch->current_frontend_ctx;
-   if (frontend && frontend->exitspawn)
-      frontend->exitspawn(s, len, args);
-}
-
-void frontend_driver_deinit(void *args)
-{
-   struct rarch_state     *p_rarch = &rarch_st;
-   frontend_ctx_driver_t *frontend = p_rarch->current_frontend_ctx;
-   if (frontend && frontend->deinit)
-      frontend->deinit(args);
-}
-
-void frontend_driver_shutdown(bool a)
-{
-   struct rarch_state     *p_rarch = &rarch_st;
-   frontend_ctx_driver_t *frontend = p_rarch->current_frontend_ctx;
-   if (frontend && frontend->shutdown)
-      frontend->shutdown(a);
-}
-
-enum frontend_architecture frontend_driver_get_cpu_architecture(void)
-{
-   struct rarch_state     *p_rarch = &rarch_st;
-   frontend_ctx_driver_t *frontend = p_rarch->current_frontend_ctx;
-   if (!frontend || !frontend->get_architecture)
-      return FRONTEND_ARCH_NONE;
-   return frontend->get_architecture();
-}
-
-const void *frontend_driver_get_cpu_architecture_str(
-      char *architecture, size_t size)
-{
-   struct rarch_state     *p_rarch = &rarch_st;
-   frontend_ctx_driver_t *frontend = p_rarch->current_frontend_ctx;
-   enum frontend_architecture arch = frontend_driver_get_cpu_architecture();
-
-   switch (arch)
-   {
-      case FRONTEND_ARCH_X86:
-         strcpy_literal(architecture, "x86");
-         break;
-      case FRONTEND_ARCH_X86_64:
-         strcpy_literal(architecture, "x64");
-         break;
-      case FRONTEND_ARCH_PPC:
-         strcpy_literal(architecture, "PPC");
-         break;
-      case FRONTEND_ARCH_ARM:
-         strcpy_literal(architecture, "ARM");
-         break;
-      case FRONTEND_ARCH_ARMV7:
-         strcpy_literal(architecture, "ARMv7");
-         break;
-      case FRONTEND_ARCH_ARMV8:
-         strcpy_literal(architecture, "ARMv8");
-         break;
-      case FRONTEND_ARCH_MIPS:
-         strcpy_literal(architecture, "MIPS");
-         break;
-      case FRONTEND_ARCH_TILE:
-         strcpy_literal(architecture, "Tilera");
-         break;
-      case FRONTEND_ARCH_NONE:
-      default:
-         strcpy_literal(architecture, "N/A");
-         break;
-   }
-
-   return frontend;
-}
-
-uint64_t frontend_driver_get_total_memory(void)
-{
-   struct rarch_state     *p_rarch = &rarch_st;
-   frontend_ctx_driver_t *frontend = p_rarch->current_frontend_ctx;
-   if (!frontend || !frontend->get_total_mem)
-      return 0;
-   return frontend->get_total_mem();
-}
-
-uint64_t frontend_driver_get_free_memory(void)
-{
-   struct rarch_state     *p_rarch = &rarch_st;
-   frontend_ctx_driver_t *frontend = p_rarch->current_frontend_ctx;
-   if (!frontend || !frontend->get_free_mem)
-      return 0;
-   return frontend->get_free_mem();
-}
-
-void frontend_driver_install_signal_handler(void)
-{
-   struct rarch_state     *p_rarch = &rarch_st;
-   frontend_ctx_driver_t *frontend = p_rarch->current_frontend_ctx;
-   if (frontend && frontend->install_signal_handler)
-      frontend->install_signal_handler();
-}
-
-int frontend_driver_get_signal_handler_state(void)
-{
-   struct rarch_state     *p_rarch = &rarch_st;
-   frontend_ctx_driver_t *frontend = p_rarch->current_frontend_ctx;
-   if (!frontend || !frontend->get_signal_handler_state)
-      return -1;
-   return frontend->get_signal_handler_state();
-}
-
-void frontend_driver_set_signal_handler_state(int value)
-{
-   struct rarch_state     *p_rarch = &rarch_st;
-   frontend_ctx_driver_t *frontend = p_rarch->current_frontend_ctx;
-   if (frontend && frontend->set_signal_handler_state)
-      frontend->set_signal_handler_state(value);
-}
-
-void frontend_driver_attach_console(void)
-{
-   struct rarch_state     *p_rarch = &rarch_st;
-   frontend_ctx_driver_t *frontend = p_rarch->current_frontend_ctx;
-   if (frontend && frontend->attach_console)
-      frontend->attach_console();
-}
-
-void frontend_driver_set_screen_brightness(int value)
-{
-   struct rarch_state     *p_rarch = &rarch_st;
-   frontend_ctx_driver_t *frontend = p_rarch->current_frontend_ctx;
-   if (frontend && frontend->set_screen_brightness)
-      frontend->set_screen_brightness(value);
-}
-
-bool frontend_driver_can_set_screen_brightness(void)
-{
-   struct rarch_state     *p_rarch = &rarch_st;
-   frontend_ctx_driver_t *frontend = p_rarch->current_frontend_ctx;
-   return (frontend && frontend->set_screen_brightness);
-}
-
-void frontend_driver_detach_console(void)
-{
-   struct rarch_state     *p_rarch = &rarch_st;
-   frontend_ctx_driver_t *frontend = p_rarch->current_frontend_ctx;
-   if (frontend && frontend->detach_console)
-      frontend->detach_console();
-}
-
-void frontend_driver_destroy_signal_handler_state(void)
-{
-   struct rarch_state     *p_rarch = &rarch_st;
-   frontend_ctx_driver_t *frontend = p_rarch->current_frontend_ctx;
-   if (frontend && frontend->destroy_signal_handler_state)
-      frontend->destroy_signal_handler_state();
-}
-
-bool frontend_driver_can_watch_for_changes(void)
-{
-   struct rarch_state     *p_rarch = &rarch_st;
-   frontend_ctx_driver_t *frontend = p_rarch->current_frontend_ctx;
-   if (!frontend || !frontend->watch_path_for_changes)
-      return false;
-   return true;
-}
-
-void frontend_driver_watch_path_for_changes(
-      struct string_list *list, int flags,
-      path_change_data_t **change_data)
-{
-   struct rarch_state     *p_rarch = &rarch_st;
-   frontend_ctx_driver_t *frontend = p_rarch->current_frontend_ctx;
-   if (frontend && frontend->watch_path_for_changes)
-      frontend->watch_path_for_changes(list, flags, change_data);
-}
-
-bool frontend_driver_check_for_path_changes(path_change_data_t *change_data)
-{
-   struct rarch_state     *p_rarch = &rarch_st;
-   frontend_ctx_driver_t *frontend = p_rarch->current_frontend_ctx;
-   if (!frontend || !frontend->check_for_path_changes)
-      return false;
-   return frontend->check_for_path_changes(change_data);
-}
-
-void frontend_driver_set_sustained_performance_mode(bool on)
-{
-   struct rarch_state     *p_rarch = &rarch_st;
-   frontend_ctx_driver_t *frontend = p_rarch->current_frontend_ctx;
-   if (frontend && frontend->set_sustained_performance_mode)
-      frontend->set_sustained_performance_mode(on);
-}
-
-const char* frontend_driver_get_cpu_model_name(void)
-{
-   struct rarch_state     *p_rarch = &rarch_st;
-   frontend_ctx_driver_t *frontend = p_rarch->current_frontend_ctx;
-   if (!frontend || !frontend->get_cpu_model_name)
-      return NULL;
-   return frontend->get_cpu_model_name();
-}
-
-enum retro_language frontend_driver_get_user_language(void)
-{
-   struct rarch_state     *p_rarch = &rarch_st;
-   frontend_ctx_driver_t *frontend = p_rarch->current_frontend_ctx;
-   if (!frontend || !frontend->get_user_language)
-      return RETRO_LANGUAGE_ENGLISH;
-   return frontend->get_user_language();
 }

--- a/retroarch_data.h
+++ b/retroarch_data.h
@@ -552,7 +552,6 @@ struct rarch_state
    /* Used while Netplay is running */
    netplay_t *netplay_data;
 #endif
-   frontend_ctx_driver_t *current_frontend_ctx;
 
    struct retro_perf_counter *perf_counters_rarch[MAX_COUNTERS];
 


### PR DESCRIPTION
Move frontend code out of retroarch.c and into frontend_driver.c. retroarch.c is now 694kb after this change.

@jdgleaver I'd appreciate a review before merging this.