### PR TITLE
(cheevos) fix double free when rich presence update task fires while game is not loaded

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -570,6 +570,9 @@ bool rcheevos_unload(void)
 {
    settings_t* settings  = config_get_ptr();
 
+   /* immediately mark the game as unloaded so the ping thread will terminate normally */
+   rcheevos_locals.game.id = -1;
+
 #ifdef HAVE_THREADS
    if (rcheevos_locals.load_info.state < RCHEEVOS_LOAD_STATE_DONE &&
        rcheevos_locals.load_info.state != RCHEEVOS_LOAD_STATE_NONE)


### PR DESCRIPTION
## Description

Fixes a crash caused by a double free() when the periodic rich presence update task fires while no game is loaded.

Code added by #13178 to handle the game being unloaded while the load tasks were executing was generically free'ing the `rcheevos_async_io_request` object associated with the HTTP request. The periodic rich presence update task reuses this object, so having the generic code free() it caused later issues when that memory was modified - most frequently a crash when it tried to free() it again when the task was terminated normally.

This PR modifies the generic code to not free() the object for the rich presence update call. It also modifies the unload process so the rich presence update task should not try to make an HTTP request after the game has been unloaded.

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@Sanaki 
