### PR TITLE
[Android / Play Store] Implement MANAGE_EXTERNAL_STORAGE permission

### DIFF
--- a/pkg/android/phoenix/.gitignore
+++ b/pkg/android/phoenix/.gitignore
@@ -1,5 +1,6 @@
 .gradle
 .externalNativeBuild
+.cxx
 build
 phoenix.iml
 output.json

--- a/pkg/android/phoenix/AndroidManifest.xml
+++ b/pkg/android/phoenix/AndroidManifest.xml
@@ -12,6 +12,7 @@
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.VIBRATE" />
 

--- a/pkg/android/phoenix/build.gradle
+++ b/pkg/android/phoenix/build.gradle
@@ -25,8 +25,8 @@ allprojects {
 apply plugin: 'com.android.application'
 
 android {
-  compileSdkVersion 29
-  buildToolsVersion "29.0.3"
+  compileSdkVersion 30
+  buildToolsVersion "30.0.3"
   ndkVersion "22.0.7026061"
 
   flavorDimensions "variant"
@@ -72,7 +72,7 @@ android {
     }
     playStoreNormal {
       minSdkVersion 21
-      targetSdkVersion 29
+      targetSdkVersion 30
       versionCode getPlayStoreVersionCode()
       versionName getPlayStoreVersionName()
 
@@ -83,7 +83,7 @@ android {
     }
     playStorePlus {
       minSdkVersion 26
-      targetSdkVersion 29
+      targetSdkVersion 30
       versionCode getPlayStoreVersionCode()
       versionName getPlayStoreVersionName()
 


### PR DESCRIPTION
## Description

This implements the `MANAGE_EXTERNAL_STORAGE` permission for the Play Store builds, in the hopes that Google will approve our usage of it.

## Related Issues

#12181

## Reviewers

@twinaphex 