### PR TITLE
(cheevos) ignore unofficial achievements unless setting is enabled

### DIFF
--- a/cheevos/cheevos_client.c
+++ b/cheevos/cheevos_client.c
@@ -720,15 +720,16 @@ static void rcheevos_client_copy_achievements(
 
       if (definition->category != 3)
       {
-         achievement->active = RCHEEVOS_ACTIVE_UNOFFICIAL;
+         if (!settings->bools.cheevos_test_unofficial)
+            continue;
 
-         if (settings->bools.cheevos_test_unofficial)
-            achievement->active |=  RCHEEVOS_ACTIVE_SOFTCORE 
-                                  | RCHEEVOS_ACTIVE_HARDCORE;
+         achievement->active =  RCHEEVOS_ACTIVE_UNOFFICIAL
+                              | RCHEEVOS_ACTIVE_SOFTCORE
+                              | RCHEEVOS_ACTIVE_HARDCORE;
       }
       else
       {
-         achievement->active =  RCHEEVOS_ACTIVE_SOFTCORE 
+         achievement->active =  RCHEEVOS_ACTIVE_SOFTCORE
                               | RCHEEVOS_ACTIVE_HARDCORE;
 
          for (j = 0; j < 


### PR DESCRIPTION
## Description

The changes in #13178 store both official and unofficial achievements in the same array. When "Test Unofficial Achievements" setting is off, the unofficial achievements are left inactive but not removed from the array, so they appear in the achievements list as unlocked. This PR removes them from the list so they don't appear at all.

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@Sanaki 
