### PR TITLE
(cheevos) don't queue rewind re-init if already on main thread

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -823,13 +823,16 @@ static void rcheevos_toggle_hardcore_active(rcheevos_locals_t* locals)
       if (rewind_enable)
       {
 #ifdef HAVE_THREADS
-         /* have to "schedule" this. 
-          * CMD_EVENT_REWIND_DEINIT should 
-          * only be called on the main thread */
-         rcheevos_locals.queued_command = CMD_EVENT_REWIND_DEINIT;
-#else
-         command_event(CMD_EVENT_REWIND_DEINIT, NULL);
+         if (!task_is_on_main_thread())
+         {
+            /* have to "schedule" this.
+             * CMD_EVENT_REWIND_DEINIT should
+             * only be called on the main thread */
+            rcheevos_locals.queued_command = CMD_EVENT_REWIND_DEINIT;
+         }
+         else
 #endif
+            command_event(CMD_EVENT_REWIND_DEINIT, NULL);
       }
    }
    else
@@ -849,13 +852,16 @@ static void rcheevos_toggle_hardcore_active(rcheevos_locals_t* locals)
       if (rewind_enable)
       {
 #ifdef HAVE_THREADS
-         /* have to "schedule" this. 
-          * CMD_EVENT_REWIND_INIT should 
-          * only be called on the main thread */
-         rcheevos_locals.queued_command = CMD_EVENT_REWIND_INIT;
-#else
-         command_event(CMD_EVENT_REWIND_INIT, NULL);
+         if (!task_is_on_main_thread())
+         {
+            /* have to "schedule" this.
+             * CMD_EVENT_REWIND_INIT should
+             * only be called on the main thread */
+            rcheevos_locals.queued_command = CMD_EVENT_REWIND_INIT;
+         }
+         else
 #endif
+            command_event(CMD_EVENT_REWIND_INIT, NULL);
       }
    }
 
@@ -1343,12 +1349,15 @@ static void rcheevos_start_session(void)
       if (settings->bools.rewind_enable)
       {
 #ifdef HAVE_THREADS
-         /* Have to "schedule" this. CMD_EVENT_REWIND_INIT should 
-          * only be called on the main thread */
-         rcheevos_locals.queued_command = CMD_EVENT_REWIND_INIT;
-#else
-         command_event(CMD_EVENT_REWIND_INIT, NULL);
+         if (!task_is_on_main_thread())
+         {
+            /* Have to "schedule" this. CMD_EVENT_REWIND_INIT should
+             * only be called on the main thread */
+            rcheevos_locals.queued_command = CMD_EVENT_REWIND_INIT;
+         }
+         else
 #endif
+            command_event(CMD_EVENT_REWIND_INIT, NULL);
       }
    }
 #endif
@@ -1422,15 +1431,18 @@ static void rcheevos_fetch_game_data(void)
       if (settings->bools.rewind_enable)
       {
 #ifdef HAVE_THREADS
-         /* have to "schedule" this. CMD_EVENT_REWIND_DEINIT should only be called on the main thread */
-         rcheevos_locals.queued_command = CMD_EVENT_REWIND_DEINIT;
+         if (!task_is_on_main_thread())
+         {
+            /* have to "schedule" this. CMD_EVENT_REWIND_DEINIT should only be called on the main thread */
+            rcheevos_locals.queued_command = CMD_EVENT_REWIND_DEINIT;
 
-         /* wait for rewind to be disabled */
-         while (rcheevos_locals.queued_command != CMD_EVENT_NONE)
-            retro_sleep(1);
-#else
-         command_event(CMD_EVENT_REWIND_DEINIT, NULL);
+            /* wait for rewind to be disabled */
+            while (rcheevos_locals.queued_command != CMD_EVENT_NONE)
+               retro_sleep(1);
+         }
+         else
 #endif
+            command_event(CMD_EVENT_REWIND_DEINIT, NULL);
       }
    }
 #endif

--- a/libretro-common/include/queues/task_queue.h
+++ b/libretro-common/include/queues/task_queue.h
@@ -191,6 +191,8 @@ char* task_get_title(retro_task_t *task);
 
 void* task_get_data(retro_task_t *task);
 
+bool task_is_on_main_thread(void);
+
 void task_queue_set_threaded(void);
 
 void task_queue_unset_threaded(void);

--- a/libretro-common/queues/task_queue.c
+++ b/libretro-common/queues/task_queue.c
@@ -66,6 +66,7 @@ static struct retro_task_impl *impl_current = NULL;
 static bool task_threaded_enable            = false;
 
 #ifdef HAVE_THREADS
+static uintptr_t main_thread_id             = NULL;
 static slock_t *running_lock                = NULL;
 static slock_t *finished_lock               = NULL;
 static slock_t *property_lock               = NULL;
@@ -614,6 +615,7 @@ void task_queue_init(bool threaded, retro_task_queue_msg_t msg_push)
    impl_current = &impl_regular;
 
 #ifdef HAVE_THREADS
+   main_thread_id = sthread_get_current_thread_id();
    if (threaded)
    {
       task_threaded_enable = true;
@@ -748,6 +750,15 @@ void task_queue_retriever_info_free(task_retriever_info_t *list)
       free(list);
       list = info;
    }
+}
+
+bool task_is_on_main_thread(void)
+{
+#ifdef HAVE_THREADS
+   return sthread_get_current_thread_id() == main_thread_id;
+#else
+   return true;
+#endif
 }
 
 void task_set_finished(retro_task_t *task, bool finished)


### PR DESCRIPTION
## Description

Fixes #13202 

Something in moving from one long-running task to several shorter lived ones (#13178) moved the rewind reinitialization code such that it's being called from the main thread now. To prevent an exception reinitializing the rewind code, we offload that to the main thread and wait for it to complete. If we're already on the main thread, it will never complete while we're waiting, and we end up with a deadlock.

This adds a new function to the task code to detect if the currently executing code is in the main thread. If it is, then we just reinitialize rewind immediately instead of trying to offload and wait.

## Related Issues

#13202

## Related Pull Requests

n/a

## Reviewers

@twinaphex 
