### PR TITLE
always return false if rotation can't occur

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -7510,7 +7510,7 @@ bool runloop_environment_cb(unsigned cmd, void *data)
 
          RARCH_LOG("[Environ]: SET_ROTATION: %u\n", rotation);
          if (!video_allow_rotate)
-            break;
+            return false;
 
          if (system)
             system->rotation = rotation;


### PR DESCRIPTION
`RETRO_ENVIRONMENT_SET_ROTATION` should return false when rotation has been forcefully disabled in frontend, that way the core can decide if aspect ratio should be rotated or not for vertical games, and avoid stuff like this : 
![sonicwi-211108-184523](https://user-images.githubusercontent.com/10391265/140791911-a7efb8cb-b3dc-48c4-905f-503ea99f6c8b.png)
(should be 4:3 instead since the rotation couldn't occur)
