### PR TITLE
[3DS] Fix achievement widget

### DIFF
--- a/gfx/gfx_display.c
+++ b/gfx/gfx_display.c
@@ -464,40 +464,43 @@ void gfx_display_scissor_begin(
       int x, int y, unsigned width, unsigned height)
 {
    gfx_display_ctx_driver_t *dispctx = p_disp->dispctx;
-   if (y < 0)
+   if (dispctx && dispctx->scissor_begin)
    {
-      if (height < (unsigned)(-y))
-         height  = 0;
-      else
-         height += y;
-      y          = 0;
-   }
-   if (x < 0)
-   {
-      if (width < (unsigned)(-x))
-         width   = 0;
-      else
-         width  += x;
-      x          = 0;
-   }
-   if (y >= (int)video_height)
-   {
-      height     = 0;
-      y          = 0;
-   }
-   if (x >= (int)video_width)
-   {
-      width      = 0;
-      x          = 0;
-   }
-   if ((y + height) > video_height)
-      height     = video_height - y;
-   if ((x + width) > video_width)
-      width      = video_width - x;
+      if (y < 0)
+      {
+         if (height < (unsigned)(-y))
+            height  = 0;
+         else
+            height += y;
+         y          = 0;
+      }
+      if (x < 0)
+      {
+         if (width < (unsigned)(-x))
+            width   = 0;
+         else
+            width  += x;
+         x          = 0;
+      }
+      if (y >= (int)video_height)
+      {
+         height     = 0;
+         y          = 0;
+      }
+      if (x >= (int)video_width)
+      {
+         width      = 0;
+         x          = 0;
+      }
+      if ((y + height) > video_height)
+         height     = video_height - y;
+      if ((x + width) > video_width)
+         width      = video_width - x;
 
-   dispctx->scissor_begin(userdata,
-         video_width, video_height,
-         x, y, width, height);
+      dispctx->scissor_begin(userdata,
+            video_width, video_height,
+            x, y, width, height);
+   }
 }
 
 font_data_t *gfx_display_font_file(

--- a/gfx/gfx_widgets.c
+++ b/gfx/gfx_widgets.c
@@ -1262,11 +1262,10 @@ static void gfx_widgets_draw_task_msg(
       gfx_widgets_flush_text(video_width, video_height,
             &p_dispwidget->gfx_widget_fonts.msg_queue);
 
-      if (p_disp->dispctx && p_disp->dispctx->scissor_begin)
-         gfx_display_scissor_begin(p_disp,
-               userdata,
-               video_width, video_height,
-               rect_x, rect_y, rect_width, rect_height);
+      gfx_display_scissor_begin(p_disp,
+            userdata,
+            video_width, video_height,
+            rect_x, rect_y, rect_width, rect_height);
 
       gfx_widgets_draw_text(&p_dispwidget->gfx_widget_fonts.msg_queue,
             msg->msg_new,
@@ -1348,14 +1347,14 @@ static void gfx_widgets_draw_regular_msg(
       gfx_widgets_flush_text(video_width, video_height,
             &p_dispwidget->gfx_widget_fonts.msg_queue);
 
-      if (p_disp->dispctx && p_disp->dispctx->scissor_begin)
-         gfx_display_scissor_begin(p_disp,
-               userdata,
-               video_width, video_height,
-               p_dispwidget->msg_queue_scissor_start_x, 0,
-               (p_dispwidget->msg_queue_scissor_start_x + msg->width - 
-                p_dispwidget->simple_widget_padding * 2) 
-               * msg->unfold, video_height);
+
+     gfx_display_scissor_begin(p_disp,
+           userdata,
+           video_width, video_height,
+           p_dispwidget->msg_queue_scissor_start_x, 0,
+           (p_dispwidget->msg_queue_scissor_start_x + msg->width - 
+            p_dispwidget->simple_widget_padding * 2) 
+           * msg->unfold, video_height);
    }
 
    /* Background */


### PR DESCRIPTION
This reverts a specific change made in 6eeebeab25642b09c567551294dc7987a07e523d, which causes an ARM prefetch abort on the 3DS upon earning an achievement.

Related issue: https://github.com/libretro/RetroArch/issues/13139

