### PR TITLE
SDL1 buildfix

### DIFF
--- a/gfx/drivers_context/sdl_gl_ctx.c
+++ b/gfx/drivers_context/sdl_gl_ctx.c
@@ -24,6 +24,7 @@
 
 #include "../../configuration.h"
 #include "../../gfx/video_defines.h"
+#include "../../gfx/video_driver.h"
 #include "../../verbosity.h"
 
 #include "SDL.h"


### PR DESCRIPTION
## Description

This PR just adds a currently missing header to `sdl_gl_ctx.c` that is required when building against SDL1