### PR TITLE
(cheevos) audit achievement settings defaults and visibility

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -1641,6 +1641,8 @@ bool rcheevos_load(const void *data)
 
    /* reset hardcore mode and leaderboard settings based on configs */
    rcheevos_hardcore_enabled_changed();
+   CHEEVOS_LOG(RCHEEVOS_TAG "Load started, hardcore %sactive\n", rcheevos_hardcore_active() ? "" : "not ");
+
    rcheevos_validate_config_settings();
    rcheevos_leaderboards_enabled_changed();
 

--- a/cheevos/cheevos_menu.c
+++ b/cheevos/cheevos_menu.c
@@ -271,7 +271,6 @@ static void rcheevos_menu_update_badge(rcheevos_racheevo_t* cheevo)
 static void rcheevos_menu_append_items(rcheevos_locals_t* rcheevos_locals,
       enum rcheevos_menuitem_bucket bucket)
 {
-   const settings_t *settings = config_get_ptr();
    rcheevos_racheevo_t* cheevo = rcheevos_locals->game.achievements;
    rcheevos_racheevo_t* stop   = cheevo + rcheevos_locals->game.achievement_count;
    const unsigned first_index  = rcheevos_locals->menuitem_count;
@@ -345,9 +344,14 @@ static void rcheevos_menu_append_items(rcheevos_locals_t* rcheevos_locals,
                break;
          }
 
-         if (cheevo->badge && cheevo->badge[0] && settings &&
-               settings->bools.cheevos_badges_enable)
-            rcheevos_menu_update_badge(cheevo);
+         if (cheevo->badge && cheevo->badge[0])
+         {
+#ifndef HAVE_GFX_WIDGETS
+            const settings_t* settings = config_get_ptr();
+            if (settings && settings->bools.cheevos_badges_enable)
+#endif
+               rcheevos_menu_update_badge(cheevo);
+         }
       }
 
       ++cheevo;

--- a/configuration.c
+++ b/configuration.c
@@ -1398,7 +1398,7 @@ static struct config_array_setting *populate_settings_array(settings_t *settings
    SETTING_ARRAY("cheevos_username",         settings->arrays.cheevos_username, false, NULL, true);
    SETTING_ARRAY("cheevos_password",         settings->arrays.cheevos_password, false, NULL, true);
    SETTING_ARRAY("cheevos_token",            settings->arrays.cheevos_token, false, NULL, true);
-   SETTING_ARRAY("cheevos_leaderboards_enable", settings->arrays.cheevos_leaderboards_enable, true, "false", true);
+   SETTING_ARRAY("cheevos_leaderboards_enable", settings->arrays.cheevos_leaderboards_enable, true, "true", true);
 #endif
    SETTING_ARRAY("video_context_driver",     settings->arrays.video_context_driver,   false, NULL, true);
    SETTING_ARRAY("audio_driver",             settings->arrays.audio_driver,           false, NULL, true);
@@ -1881,11 +1881,11 @@ static struct config_bool_setting *populate_settings_bool(
 #ifdef HAVE_CHEEVOS
    SETTING_BOOL("cheevos_enable",               &settings->bools.cheevos_enable, true, DEFAULT_CHEEVOS_ENABLE, false);
    SETTING_BOOL("cheevos_test_unofficial",      &settings->bools.cheevos_test_unofficial, true, false, false);
-   SETTING_BOOL("cheevos_hardcore_mode_enable", &settings->bools.cheevos_hardcore_mode_enable, true, false, false);
+   SETTING_BOOL("cheevos_hardcore_mode_enable", &settings->bools.cheevos_hardcore_mode_enable, true, true, false);
    SETTING_BOOL("cheevos_challenge_indicators", &settings->bools.cheevos_challenge_indicators, true, true, false);
    SETTING_BOOL("cheevos_richpresence_enable",  &settings->bools.cheevos_richpresence_enable, true, true, false);
    SETTING_BOOL("cheevos_unlock_sound_enable",  &settings->bools.cheevos_unlock_sound_enable, true, false, false);
-   SETTING_BOOL("cheevos_verbose_enable",       &settings->bools.cheevos_verbose_enable, true, false, false);
+   SETTING_BOOL("cheevos_verbose_enable",       &settings->bools.cheevos_verbose_enable, true, true, false);
    SETTING_BOOL("cheevos_auto_screenshot",      &settings->bools.cheevos_auto_screenshot, true, false, false);
    SETTING_BOOL("cheevos_badges_enable",        &settings->bools.cheevos_badges_enable, true, false, false);
    SETTING_BOOL("cheevos_start_active",         &settings->bools.cheevos_start_active, true, false, false);
@@ -2531,6 +2531,11 @@ void config_set_defaults(void *data)
          settings->arrays.ai_service_url,
          DEFAULT_AI_SERVICE_URL);
 
+#ifdef HAVE_CHEEVOS
+   configuration_set_string(settings,
+         settings->arrays.cheevos_leaderboards_enable,
+         "true");
+#endif
 
 #ifdef HAVE_MATERIALUI
    if (g_defaults.menu_materialui_menu_color_theme_enable)

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -7667,13 +7667,17 @@ unsigned menu_displaylist_build_list(
                {MENU_ENUM_LABEL_CHEEVOS_LEADERBOARDS_ENABLE,                           PARSE_ONLY_STRING_OPTIONS,   false  },
                {MENU_ENUM_LABEL_CHEEVOS_CHALLENGE_INDICATORS,                          PARSE_ONLY_BOOL,   false  },
                {MENU_ENUM_LABEL_CHEEVOS_RICHPRESENCE_ENABLE,                           PARSE_ONLY_BOOL,   false  },
+#ifndef HAVE_GFX_WIDGETS
                {MENU_ENUM_LABEL_CHEEVOS_BADGES_ENABLE,                                 PARSE_ONLY_BOOL,   false  },
+#endif
                {MENU_ENUM_LABEL_CHEEVOS_TEST_UNOFFICIAL,                               PARSE_ONLY_BOOL,   false  },
 #ifdef HAVE_AUDIOMIXER
                {MENU_ENUM_LABEL_CHEEVOS_UNLOCK_SOUND_ENABLE,                           PARSE_ONLY_BOOL,   false  },
 #endif
-               {MENU_ENUM_LABEL_CHEEVOS_VERBOSE_ENABLE,                                PARSE_ONLY_BOOL,   false  },
+#ifdef HAVE_SCREENSHOTS
                {MENU_ENUM_LABEL_CHEEVOS_AUTO_SCREENSHOT,                               PARSE_ONLY_BOOL,   false  },
+#endif
+               {MENU_ENUM_LABEL_CHEEVOS_VERBOSE_ENABLE,                                PARSE_ONLY_BOOL,   false  },
                {MENU_ENUM_LABEL_CHEEVOS_START_ACTIVE,                                  PARSE_ONLY_BOOL,   false  },
             };
 

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -18688,7 +18688,7 @@ static bool setting_append_list(
                sizeof(settings->arrays.cheevos_leaderboards_enable),
                MENU_ENUM_LABEL_CHEEVOS_LEADERBOARDS_ENABLE,
                MENU_ENUM_LABEL_VALUE_CHEEVOS_LEADERBOARDS_ENABLE,
-               "false",
+               "true",
                "false|true",
                &group_info,
                &subgroup_info,
@@ -18735,9 +18735,10 @@ static bool setting_append_list(
                parent_group,
                general_write_handler,
                general_read_handler,
-               SD_FLAG_NONE
+               SD_FLAG_ADVANCED
                );
 
+#ifndef HAVE_GFX_WIDGETS
          if (string_is_equal(settings->arrays.menu_driver, "xmb") || string_is_equal(settings->arrays.menu_driver, "ozone"))
             CONFIG_BOOL(
                   list, list_info,
@@ -18752,8 +18753,9 @@ static bool setting_append_list(
                   parent_group,
                   general_write_handler,
                   general_read_handler,
-                  SD_FLAG_NONE
+                  SD_FLAG_ADVANCED
                   );
+#endif
 
 #ifdef HAVE_AUDIOMIXER
          CONFIG_BOOL(
@@ -18778,7 +18780,7 @@ static bool setting_append_list(
                &settings->bools.cheevos_verbose_enable,
                MENU_ENUM_LABEL_CHEEVOS_VERBOSE_ENABLE,
                MENU_ENUM_LABEL_VALUE_CHEEVOS_VERBOSE_ENABLE,
-               false,
+               true,
                MENU_ENUM_LABEL_VALUE_OFF,
                MENU_ENUM_LABEL_VALUE_ON,
                &group_info,
@@ -18786,7 +18788,7 @@ static bool setting_append_list(
                parent_group,
                general_write_handler,
                general_read_handler,
-               SD_FLAG_NONE
+               SD_FLAG_ADVANCED
                );
 
          CONFIG_BOOL(
@@ -18818,7 +18820,7 @@ static bool setting_append_list(
                parent_group,
                general_write_handler,
                general_read_handler,
-               SD_FLAG_NONE
+               SD_FLAG_ADVANCED
                );
 
          CONFIG_BOOL(
@@ -18826,7 +18828,7 @@ static bool setting_append_list(
                &settings->bools.cheevos_hardcore_mode_enable,
                MENU_ENUM_LABEL_CHEEVOS_HARDCORE_MODE_ENABLE,
                MENU_ENUM_LABEL_VALUE_CHEEVOS_HARDCORE_MODE_ENABLE,
-               false,
+               true,
                MENU_ENUM_LABEL_VALUE_OFF,
                MENU_ENUM_LABEL_VALUE_ON,
                &group_info,


### PR DESCRIPTION
## Description

Hides several achievement-related settings unless View Advanced Settings is ON. Also changes the defaults of a few settings.

* Rich Presence, Verbose Mode, and Encore Mode are now hidden unless View Advanced Settings is ON.
* Download Badges is now hidden if widgets are available as the badges are always downloaded for widgets. If widgets are not available, it is now hidden unless View Advanced Settings is ON.
* The default value of Hardcore Mode has been changed to ON. We want to encourage players to play in Hardcore. It's easy enough to disable (or pause) if they don't find it to their liking.
* The default value of Verbose Mode has been changed to ON. This setting currently only provides more information during the startup process (particularly the "Logged in as XXX" and "You have X of Y achievements unlocked").

Changes to default values are not forced upon users. Any settings already in the retroarch.cfg will be honored.

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@Sanaki
