### PR TITLE
(cheevos) ensure placard is initialized on main thread

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -1357,12 +1357,21 @@ static void rcheevos_start_session_async(retro_task_t* task)
    }
 #endif
 
-   rcheevos_show_game_placard();
-
    task_set_finished(task, true);
 
    if (rcheevos_end_load_state() == 0)
       rcheevos_fetch_badges();
+}
+
+static void rcheevos_start_session_finish(retro_task_t* task, void* data, void* userdata, const char* error)
+{
+   (void)task;
+   (void)data;
+   (void)userdata;
+   (void)error;
+
+   /* this must be called on the main thread */
+   rcheevos_show_game_placard();
 }
 
 static void rcheevos_start_session(void)
@@ -1391,6 +1400,7 @@ static void rcheevos_start_session(void)
    /* this is called on the primary thread. use a task to do the initialization on a background thread */
    task = task_init();
    task->handler = rcheevos_start_session_async;
+   task->callback = rcheevos_start_session_finish;
    task_queue_push(task);
 }
 

--- a/cheevos/cheevos_menu.c
+++ b/cheevos/cheevos_menu.c
@@ -657,6 +657,9 @@ uintptr_t rcheevos_get_badge_texture(const char *badge, bool locked)
    if (!badge)
       return 0;
 
+   /* OpenGL driver crashes if gfx_display_reset_textures_list is called on a background thread */
+   retro_assert(task_is_on_main_thread());
+
    snprintf(badge_file, sizeof(badge_file), "%s%s%s", badge,
       locked ? "_lock" : "", FILE_PATH_PNG_EXTENSION);
 

--- a/cheevos/cheevos_menu.c
+++ b/cheevos/cheevos_menu.c
@@ -28,6 +28,7 @@
 #include "../menu/menu_entries.h"
 
 #include <features/features_cpu.h>
+#include <retro_assert.h>
 
 enum rcheevos_menuitem_bucket
 {


### PR DESCRIPTION
## Description

Fixes a crash that occurs when the placard (#13246) is launched from the background thread when using the gl/glcore driver.

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

n/a
