### PR TITLE
Honor config_save_on_exit when Reboot/Shutdown is called

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -4722,16 +4722,22 @@ bool command_event(enum event_command cmd, void *data)
          break;
       case CMD_EVENT_SHUTDOWN:
 #if defined(__linux__) && !defined(ANDROID)
-         runloop_msg_queue_push(msg_hash_to_str(MSG_VALUE_SHUTTING_DOWN), 1, 180, true, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
-         command_event(CMD_EVENT_MENU_SAVE_CURRENT_CONFIG, NULL);
+         if (settings->bools.config_save_on_exit)
+         {
+            runloop_msg_queue_push(msg_hash_to_str(MSG_VALUE_SHUTTING_DOWN), 1, 180, true, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
+            command_event(CMD_EVENT_MENU_SAVE_CURRENT_CONFIG, NULL);
+         }
          command_event(CMD_EVENT_QUIT, NULL);
          system("shutdown -P now");
 #endif
          break;
       case CMD_EVENT_REBOOT:
 #if defined(__linux__) && !defined(ANDROID)
-         runloop_msg_queue_push(msg_hash_to_str(MSG_VALUE_REBOOTING), 1, 180, true, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
-         command_event(CMD_EVENT_MENU_SAVE_CURRENT_CONFIG, NULL);
+         if (settings->bools.config_save_on_exit)
+         {
+            runloop_msg_queue_push(msg_hash_to_str(MSG_VALUE_REBOOTING), 1, 180, true, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
+            command_event(CMD_EVENT_MENU_SAVE_CURRENT_CONFIG, NULL);
+         }
          command_event(CMD_EVENT_QUIT, NULL);
          system("shutdown -r now");
 #endif


### PR DESCRIPTION
When Shutdown or Reboot are selected from the main menu, configuration
is saved regardless of checking the user setting. Showing the widget and
saving the configuration should be called only in case user wants to
save configuration on exit.