### PR TITLE
convert abs mouse from screen to viewport coordinates; fix relative m…

### DIFF
--- a/gfx/video_crt_switch.c
+++ b/gfx/video_crt_switch.c
@@ -130,8 +130,10 @@ static void set_aspect(videocrt_switch_t *p_switch, unsigned int width,
       srm_yscale = (float)srm_height/height;
       RARCH_LOG("[CRT]: Resolution is stretched. Fractal scaling @ X:%f Y:%f \n", srm_xscale, srm_yscale);
    }
+#if !defined(HAVE_VIDEOCORE)
    else
       RARCH_LOG("[CRT]: SR integer scaled  X:%d Y:%d \n",srm.x_scale, srm.y_scale);
+#endif
 
    scaled_width = roundf(patched_width*srm_xscale);
    scaled_height = roundf(patched_height*srm_yscale);

--- a/gfx/video_crt_switch.c
+++ b/gfx/video_crt_switch.c
@@ -130,10 +130,8 @@ static void set_aspect(videocrt_switch_t *p_switch, unsigned int width,
       srm_yscale = (float)srm_height/height;
       RARCH_LOG("[CRT]: Resolution is stretched. Fractal scaling @ X:%f Y:%f \n", srm_xscale, srm_yscale);
    }
-#if !defined(HAVE_VIDEOCORE)
    else
       RARCH_LOG("[CRT]: SR integer scaled  X:%d Y:%d \n",srm.x_scale, srm.y_scale);
-#endif
 
    scaled_width = roundf(patched_width*srm_xscale);
    scaled_height = roundf(patched_height*srm_yscale);

--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -378,19 +378,28 @@ static int16_t udev_mouse_get_pointer_x(const udev_input_mouse_t *mouse, bool sc
 
    if (mouse->abs) /* mouse coords are absolute */
    {
+      /* mouse coordinates are relative to the screen; convert them
+       * to be relative to the viewport */
       src_min = mouse->x_min;
       src_width = mouse->x_max - mouse->x_min + 1;
+      double scaled_x = vp.full_width * (mouse->x_abs - src_min) / src_width;
+      x = -32767.0 + 65535.0 / vp.width * (scaled_x - vp.x);
    }
    else /* mouse coords are viewport relative */
    {
-      src_min = vp.x;
-      if (screen)
+      if (screen) 
+      {
+         src_min = 0.0;
          src_width = vp.full_width;
-      else
+      }
+      else 
+      {
+         src_min = vp.x;
          src_width = vp.width;
+      }
+      x  = -32767.0 + 65535.0 / src_width * (mouse->x_abs - src_min);
    }
 
-   x  = -32767.0 + 65535.0 / src_width * (mouse->x_abs - src_min);
    x += (x < 0 ? -0.5 : 0.5);
 
    if (x < -0x7fff)
@@ -413,16 +422,25 @@ static int16_t udev_mouse_get_pointer_y(const udev_input_mouse_t *mouse, bool sc
 
    if (mouse->abs) /* mouse coords are absolute */
    {
+      /* mouse coordinates are relative to the screen; convert them
+       * to be relative to the viewport */
       src_min = mouse->y_min;
       src_height = mouse->y_max - mouse->y_min + 1;
+      double scaled_y = vp.full_height * (mouse->y_abs - src_min) / src_height;
+      y = -32767.0 + 65535.0 / vp.height * (scaled_y - vp.y);
    }
    else /* mouse coords are viewport relative */
    {
-      src_min = vp.y;
       if (screen)
+      {
+         src_min = 0.0;
          src_height = vp.full_height;
+      }
       else
+      {
+         src_min = vp.y;
          src_height = vp.height;
+      }
    }
 
    y = -32767.0 + 65535.0 / src_height * (mouse->y_abs - src_min);

--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -380,9 +380,10 @@ static int16_t udev_mouse_get_pointer_x(const udev_input_mouse_t *mouse, bool sc
    {
       /* mouse coordinates are relative to the screen; convert them
        * to be relative to the viewport */
+      double scaled_x;
       src_min = mouse->x_min;
       src_width = mouse->x_max - mouse->x_min + 1;
-      double scaled_x = vp.full_width * (mouse->x_abs - src_min) / src_width;
+      scaled_x = vp.full_width * (mouse->x_abs - src_min) / src_width;
       x = -32767.0 + 65535.0 / vp.width * (scaled_x - vp.x);
    }
    else /* mouse coords are viewport relative */
@@ -422,11 +423,12 @@ static int16_t udev_mouse_get_pointer_y(const udev_input_mouse_t *mouse, bool sc
 
    if (mouse->abs) /* mouse coords are absolute */
    {
+      double scaled_y;
       /* mouse coordinates are relative to the screen; convert them
        * to be relative to the viewport */
       src_min = mouse->y_min;
       src_height = mouse->y_max - mouse->y_min + 1;
-      double scaled_y = vp.full_height * (mouse->y_abs - src_min) / src_height;
+      scaled_y = vp.full_height * (mouse->y_abs - src_min) / src_height;
       y = -32767.0 + 65535.0 / vp.height * (scaled_y - vp.y);
    }
    else /* mouse coords are viewport relative */


### PR DESCRIPTION
## Description

1. The coordinates of a typical absolute mouse (e.g., a lightgun) range over the whole physical screen. The prior code scaled these coordinates to fit within the content viewport. The result broke line-of-sight aiming on lightguns and made 45 degree physical movements of an absolute mouse result in different angles on screen. This is fixed (with pointing outside the viewport resulting in off-screen registration).
2. Fixed the relative mouse code which didn't set `src_min` correctly in `screen` mode.

## Related Issues

#13255 #13227 #13256

## Reviewers

@grant2258
