### PR TITLE
Bluetooth refactor

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -773,10 +773,8 @@ ifeq ($(HAVE_EMSCRIPTEN), 1)
 endif
 
 ifeq ($(HAVE_BLUETOOTH), 1)
+   OBJ += tasks/task_bluetooth.o
    OBJ += bluetooth/drivers/bluetoothctl.o
-endif
-
-ifeq ($(HAVE_BLUETOOTH), 1)
    ifeq ($(HAVE_DBUS), 1)
       OBJ += bluetooth/drivers/bluez.o
    endif
@@ -2085,7 +2083,6 @@ ifeq ($(HAVE_NETWORKING), 1)
           tasks/task_http.o \
           tasks/task_netplay_lan_scan.o \
           tasks/task_netplay_nat_traversal.o \
-          tasks/task_bluetooth.o \
 	  tasks/task_pl_thumbnail_download.o \
           tasks/task_netplay_find_content.o
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -773,8 +773,9 @@ ifeq ($(HAVE_EMSCRIPTEN), 1)
 endif
 
 ifeq ($(HAVE_BLUETOOTH), 1)
-   OBJ += tasks/task_bluetooth.o
+   OBJ += bluetooth/bluetooth_driver.o
    OBJ += bluetooth/drivers/bluetoothctl.o
+   OBJ += tasks/task_bluetooth.o
    ifeq ($(HAVE_DBUS), 1)
       OBJ += bluetooth/drivers/bluez.o
    endif

--- a/bluetooth/bluetooth_driver.c
+++ b/bluetooth/bluetooth_driver.c
@@ -1,0 +1,206 @@
+/*  RetroArch - A frontend for libretro.
+ *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
+ *  Copyright (C) 2011-2021 - Daniel De Matteis
+ *
+ *  RetroArch is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  RetroArch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with RetroArch.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#ifdef HAVE_CONFIG_H
+#include "../config.h"
+#endif
+
+#include "../driver.h"
+#include "../list_special.h"
+#include "../retroarch.h"
+#include "../runloop.h"
+#include "../verbosity.h"
+
+#include "bluetooth_driver.h"
+
+static bluetooth_driver_t bluetooth_null = {
+   NULL, /* init */
+   NULL, /* free */
+   NULL, /* scan */
+   NULL, /* get_devices */
+   NULL, /* device_is_connected */
+   NULL, /* device_get_sublabel */
+   NULL, /* connect_device */
+   NULL, /* remove_device */
+   "null",
+};
+
+const bluetooth_driver_t *bluetooth_drivers[] = {
+#ifdef HAVE_BLUETOOTH
+   &bluetooth_bluetoothctl,
+#ifdef HAVE_DBUS
+   &bluetooth_bluez,
+#endif
+#endif
+   &bluetooth_null,
+   NULL,
+};
+
+static bluetooth_driver_state_t bluetooth_driver_st = {0};
+
+bluetooth_driver_state_t *bluetooth_state_get_ptr(void)
+{
+   return &bluetooth_driver_st;
+}
+
+/**
+ * config_get_bluetooth_driver_options:
+ *
+ * Get an enumerated list of all bluetooth driver names,
+ * separated by '|'.
+ *
+ * Returns: string listing of all bluetooth driver names,
+ * separated by '|'.
+ **/
+const char* config_get_bluetooth_driver_options(void)
+{
+   return char_list_new_special(STRING_LIST_BLUETOOTH_DRIVERS, NULL);
+}
+
+void driver_bluetooth_scan(void)
+{
+   bluetooth_driver_state_t *bt_st = &bluetooth_driver_st;
+   if (     bt_st
+        &&  bt_st->active
+        &&  bt_st->drv->scan )
+      bt_st->drv->scan(bt_st->data);
+}
+
+void driver_bluetooth_get_devices(struct string_list* devices)
+{
+   bluetooth_driver_state_t *bt_st = &bluetooth_driver_st;
+   if (     bt_st
+        &&  bt_st->active
+        &&  bt_st->drv->get_devices )
+      bt_st->drv->get_devices(bt_st->data, devices);
+}
+
+bool driver_bluetooth_device_is_connected(unsigned i)
+{
+   bluetooth_driver_state_t *bt_st = &bluetooth_driver_st;
+   if (    bt_st
+        && bt_st->active
+        && bt_st->drv->device_is_connected )
+      return bt_st->drv->device_is_connected(bt_st->data, i);
+   return false;
+}
+
+void driver_bluetooth_device_get_sublabel(char *s, unsigned i, size_t len)
+{
+   bluetooth_driver_state_t *bt_st = &bluetooth_driver_st;
+   if (     bt_st
+        &&  bt_st->active
+        &&  bt_st->drv->device_get_sublabel )
+      bt_st->drv->device_get_sublabel(bt_st->data, s, i, len);
+}
+
+bool driver_bluetooth_connect_device(unsigned i)
+{
+   bluetooth_driver_state_t *bt_st = &bluetooth_driver_st;
+   if (bt_st->active)
+      return bt_st->drv->connect_device(bt_st->data, i);
+   return false;
+}
+
+bool driver_bluetooth_remove_device(unsigned i)
+{
+   bluetooth_driver_state_t *bt_st = &bluetooth_driver_st;
+   if (bt_st->active)
+      return bt_st->drv->remove_device(bt_st->data, i);
+   return false;
+}
+
+bool bluetooth_driver_ctl(enum rarch_bluetooth_ctl_state state, void *data)
+{
+   bluetooth_driver_state_t *bt_st  = &bluetooth_driver_st;
+   settings_t             *settings = config_get_ptr();
+
+   switch (state)
+   {
+      case RARCH_BLUETOOTH_CTL_DESTROY:
+         bt_st->drv              = NULL;
+         bt_st->data             = NULL;
+         bt_st->active           = false;
+         break;
+      case RARCH_BLUETOOTH_CTL_FIND_DRIVER:
+         {
+            const char *prefix   = "bluetooth driver";
+            int i                = (int)driver_find_index(
+                  "bluetooth_driver",
+                  settings->arrays.bluetooth_driver);
+
+            if (i >= 0)
+               bt_st->drv        = (const bluetooth_driver_t*)bluetooth_drivers[i];
+            else
+            {
+               if (verbosity_is_enabled())
+               {
+                  unsigned d;
+                  RARCH_ERR("Couldn't find any %s named \"%s\"\n", prefix,
+                        settings->arrays.bluetooth_driver);
+                  RARCH_LOG_OUTPUT("Available %ss are:\n", prefix);
+                  for (d = 0; bluetooth_drivers[d]; d++)
+                     RARCH_LOG_OUTPUT("\t%s\n", bluetooth_drivers[d]->ident);
+
+                  RARCH_WARN("Going to default to first %s...\n", prefix);
+               }
+
+               bt_st->drv = (const bluetooth_driver_t*)bluetooth_drivers[0];
+
+               if (!bt_st->drv)
+                  retroarch_fail(1, "find_bluetooth_driver()");
+            }
+         }
+         break;
+      case RARCH_BLUETOOTH_CTL_DEINIT:
+        if (bt_st->data && bt_st->drv)
+        {
+           if (bt_st->drv->free)
+              bt_st->drv->free(bt_st->data);
+        }
+
+        bt_st->data   = NULL;
+        bt_st->active = false;
+        break;
+      case RARCH_BLUETOOTH_CTL_INIT:
+        /* Resource leaks will follow if bluetooth is initialized twice. */
+        if (bt_st->data)
+           return false;
+
+        bluetooth_driver_ctl(RARCH_BLUETOOTH_CTL_FIND_DRIVER, NULL);
+
+        if (bt_st->drv && bt_st->drv->init)
+        {
+           bt_st->active = true;
+           bt_st->data   = bt_st->drv->init();
+
+           if (!bt_st->data)
+           {
+              RARCH_ERR("Failed to initialize bluetooth driver. Will continue without bluetooth.\n");
+              bt_st->active = false;
+           }
+        }
+        else
+           bt_st->active = false;
+        break;
+      default:
+         break;
+   }
+
+   return false;
+}

--- a/bluetooth/bluetooth_driver.h
+++ b/bluetooth/bluetooth_driver.h
@@ -51,6 +51,13 @@ typedef struct bluetooth_driver
 extern bluetooth_driver_t bluetooth_bluetoothctl;
 extern bluetooth_driver_t bluetooth_bluez;
 
+typedef struct
+{
+   const bluetooth_driver_t *drv;
+   void *data;
+   bool active;
+} bluetooth_driver_state_t;
+
 /**
  * config_get_bluetooth_driver_options:
  *
@@ -75,6 +82,8 @@ bool driver_bluetooth_connect_device(unsigned i);
 bool driver_bluetooth_remove_device(unsigned i);
 
 bool bluetooth_driver_ctl(enum rarch_bluetooth_ctl_state state, void *data);
+
+bluetooth_driver_state_t *bluetooth_state_get_ptr(void);
 
 extern const bluetooth_driver_t *bluetooth_drivers[];
 

--- a/driver.c
+++ b/driver.c
@@ -26,7 +26,9 @@
 #include "runloop.h"
 #include "verbosity.h"
 
+#ifdef HAVE_BLUETOOTH
 #include "bluetooth/bluetooth_driver.h"
+#endif
 #ifdef HAVE_NETWORKING
 #ifdef HAVE_WIFI
 #include "network/wifi_driver.h"
@@ -49,6 +51,7 @@
 #include "menu/menu_driver.h"
 #endif
 
+#ifdef HAVE_BLUETOOTH
 static bluetooth_driver_t bluetooth_null = {
    NULL, /* init */
    NULL, /* free */
@@ -71,6 +74,7 @@ const bluetooth_driver_t *bluetooth_drivers[] = {
    &bluetooth_null,
    NULL,
 };
+#endif
 
 static void retro_frame_null(const void *data, unsigned width,
       unsigned height, size_t pitch) { }
@@ -195,6 +199,7 @@ static const void *find_driver_nonempty(
          return audio_resampler_driver_find_handle(i);
       }
    }
+#ifdef HAVE_BLUETOOTH
    else if (string_is_equal(label, "bluetooth_driver"))
    {
       if (bluetooth_drivers[i])
@@ -205,6 +210,7 @@ static const void *find_driver_nonempty(
          return bluetooth_drivers[i];
       }
    }
+#endif
 #ifdef HAVE_WIFI
    else if (string_is_equal(label, "wifi_driver"))
    {
@@ -556,9 +562,10 @@ void drivers_init(
       }
    }
 
+#ifdef HAVE_BLUETOOTH
    if (flags & DRIVER_BLUETOOTH_MASK)
       bluetooth_driver_ctl(RARCH_BLUETOOTH_CTL_INIT, NULL);
-
+#endif
 #ifdef HAVE_WIFI
    if ((flags & DRIVER_WIFI_MASK))
       wifi_driver_ctl(RARCH_WIFI_CTL_INIT, NULL);
@@ -707,9 +714,10 @@ void driver_uninit(int flags)
       camera_st->data = NULL;
    }
 
+#ifdef HAVE_BLUETOOTH
    if ((flags & DRIVER_BLUETOOTH_MASK))
       bluetooth_driver_ctl(RARCH_BLUETOOTH_CTL_DEINIT, NULL);
-
+#endif
 #ifdef HAVE_WIFI
    if ((flags & DRIVER_WIFI_MASK))
       wifi_driver_ctl(RARCH_WIFI_CTL_DEINIT, NULL);
@@ -823,7 +831,9 @@ void retroarch_deinit_drivers(struct retro_callbacks *cbs)
    camera_st->driver                                = NULL;
    camera_st->data                                  = NULL;
 
+#ifdef HAVE_BLUETOOTH
    bluetooth_driver_ctl(RARCH_BLUETOOTH_CTL_DESTROY, NULL);
+#endif
 #ifdef HAVE_WIFI
    wifi_driver_ctl(RARCH_WIFI_CTL_DESTROY, NULL);
 #endif

--- a/driver.c
+++ b/driver.c
@@ -51,31 +51,6 @@
 #include "menu/menu_driver.h"
 #endif
 
-#ifdef HAVE_BLUETOOTH
-static bluetooth_driver_t bluetooth_null = {
-   NULL, /* init */
-   NULL, /* free */
-   NULL, /* scan */
-   NULL, /* get_devices */
-   NULL, /* device_is_connected */
-   NULL, /* device_get_sublabel */
-   NULL, /* connect_device */
-   NULL, /* remove_device */
-   "null",
-};
-
-const bluetooth_driver_t *bluetooth_drivers[] = {
-#ifdef HAVE_BLUETOOTH
-   &bluetooth_bluetoothctl,
-#ifdef HAVE_DBUS
-   &bluetooth_bluez,
-#endif
-#endif
-   &bluetooth_null,
-   NULL,
-};
-#endif
-
 static void retro_frame_null(const void *data, unsigned width,
       unsigned height, size_t pitch) { }
 void retro_input_poll_null(void) { }

--- a/griffin/griffin.c
+++ b/griffin/griffin.c
@@ -1318,7 +1318,9 @@ NETPLAY
 #include "../tasks/task_http.c"
 #include "../tasks/task_netplay_lan_scan.c"
 #include "../tasks/task_netplay_nat_traversal.c"
+#ifdef HAVE_BLUETOOTH
 #include "../tasks/task_bluetooth.c"
+#endif
 #include "../tasks/task_netplay_find_content.c"
 #include "../tasks/task_pl_thumbnail_download.c"
 #endif

--- a/griffin/griffin.c
+++ b/griffin/griffin.c
@@ -1257,6 +1257,7 @@ RETROARCH
 BLUETOOTH
 ============================================================ */
 #ifdef HAVE_BLUETOOTH
+#include "../bluetooth/bluetooth_driver.c"
 #include "../bluetooth/drivers/bluetoothctl.c"
 #ifdef HAVE_DBUS
 #include "../bluetooth/drivers/bluez.c"

--- a/menu/cbs/menu_cbs_get_value.c
+++ b/menu/cbs/menu_cbs_get_value.c
@@ -42,7 +42,9 @@
 #include "../../performance_counters.h"
 #include "../../paths.h"
 #include "../../verbosity.h"
+#ifdef HAVE_BLUETOOTH
 #include "../../bluetooth/bluetooth_driver.h"
+#endif
 #include "../../playlist.h"
 #include "../../manual_content_scan.h"
 #include "../misc/cpufreq/cpufreq.h"
@@ -967,6 +969,7 @@ static void menu_action_setting_disp_set_label_entry(
    strlcpy(s2, path, len2);
 }
 
+#ifdef HAVE_BLUETOOTH
 static void menu_action_setting_disp_set_label_bluetooth_is_connected(
       file_list_t* list,
       unsigned *w, unsigned type, unsigned i,
@@ -981,6 +984,7 @@ static void menu_action_setting_disp_set_label_bluetooth_is_connected(
    if (driver_bluetooth_device_is_connected(i))
       strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_BT_CONNECTED), len);
 }
+#endif
 
 #if defined(HAVE_NETWORKING) && defined(HAVE_WIFI)
 static void menu_action_setting_disp_set_label_wifi_is_online(
@@ -1767,8 +1771,10 @@ static int menu_cbs_init_bind_get_string_representation_compare_label(
             BIND_ACTION_GET_VALUE(cbs, menu_action_setting_disp_set_label);
             break;
          case MENU_ENUM_LABEL_CONNECT_BLUETOOTH:
+#ifdef HAVE_BLUETOOTH
             BIND_ACTION_GET_VALUE(cbs,
                   menu_action_setting_disp_set_label_bluetooth_is_connected);
+#endif
             break;
          case MENU_ENUM_LABEL_CONNECT_WIFI:
 #if defined(HAVE_NETWORKING) && defined(HAVE_WIFI)

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -23,6 +23,10 @@
 #include <streams/file_stream.h>
 #include <lists/string_list.h>
 
+#ifdef HAVE_NETWORKING
+#include <net/net_http.h>
+#endif
+
 #ifdef HAVE_CONFIG_H
 #include "../../config.h"
 #endif
@@ -74,11 +78,11 @@
 #include "../../retroarch.h"
 #include "../../verbosity.h"
 #include "../../lakka.h"
+#ifdef HAVE_BLUETOOTH
 #include "../../bluetooth/bluetooth_driver.h"
+#endif
 #include "../../gfx/video_display_server.h"
 #include "../../manual_content_scan.h"
-
-#include <net/net_http.h>
 
 #ifdef HAVE_NETWORKING
 #include "../../network/netplay/netplay.h"
@@ -2892,6 +2896,7 @@ int  generic_action_ok_help(const char *path,
          entry_idx, ACTION_OK_DL_HELP);
 }
 
+#ifdef HAVE_BLUETOOTH
 static int action_ok_bluetooth(const char *path, const char *label,
          unsigned type, size_t idx, size_t entry_idx)
 {
@@ -2899,6 +2904,7 @@ static int action_ok_bluetooth(const char *path, const char *label,
 
    return 0;
 }
+#endif
 
 #ifdef HAVE_NETWORKING
 #ifdef HAVE_WIFI
@@ -5551,7 +5557,9 @@ DEFAULT_ACTION_OK_FUNC(action_ok_network_list, ACTION_OK_DL_NETWORK_SETTINGS_LIS
 DEFAULT_ACTION_OK_FUNC(action_ok_network_hosting_list, ACTION_OK_DL_NETWORK_HOSTING_SETTINGS_LIST)
 DEFAULT_ACTION_OK_FUNC(action_ok_subsystem_list, ACTION_OK_DL_SUBSYSTEM_SETTINGS_LIST)
 DEFAULT_ACTION_OK_FUNC(action_ok_database_manager_list, ACTION_OK_DL_DATABASE_MANAGER_LIST)
+#ifdef HAVE_BLUETOOTH
 DEFAULT_ACTION_OK_FUNC(action_ok_bluetooth_list, ACTION_OK_DL_BLUETOOTH_SETTINGS_LIST)
+#endif
 #ifdef HAVE_NETWORKING
 #ifdef HAVE_WIFI
 DEFAULT_ACTION_OK_FUNC(action_ok_wifi_list, ACTION_OK_DL_WIFI_SETTINGS_LIST)
@@ -7971,7 +7979,9 @@ static int menu_cbs_init_bind_ok_compare_label(menu_file_list_cbs_t *cbs,
          {MENU_ENUM_LABEL_FILE_BROWSER_OPEN_PICKER,            action_ok_open_picker},
          {MENU_ENUM_LABEL_RETRO_ACHIEVEMENTS_SETTINGS,         action_ok_retro_achievements_list},
          {MENU_ENUM_LABEL_UPDATER_SETTINGS,                    action_ok_updater_list},
+#ifdef HAVE_BLUETOOTH
          {MENU_ENUM_LABEL_BLUETOOTH_SETTINGS,                  action_ok_bluetooth_list},
+#endif
 #ifdef HAVE_NETWORKING
 #ifdef HAVE_WIFI
          {MENU_ENUM_LABEL_WIFI_SETTINGS,                       action_ok_wifi_list},
@@ -8448,7 +8458,9 @@ static int menu_cbs_init_bind_ok_compare_type(menu_file_list_cbs_t *cbs,
             BIND_ACTION_OK(cbs, action_ok_rdb_entry);
             break;
          case MENU_BLUETOOTH:
+#ifdef HAVE_BLUETOOTH
             BIND_ACTION_OK(cbs, action_ok_bluetooth);
+#endif
             break;
          case MENU_WIFI:
 #ifdef HAVE_NETWORKING

--- a/menu/cbs/menu_cbs_sublabel.c
+++ b/menu/cbs/menu_cbs_sublabel.c
@@ -32,7 +32,9 @@
 #include "../../audio/audio_driver.h"
 #include "../../core_info.h"
 #include "../../verbosity.h"
+#ifdef HAVE_BLUETOOTH
 #include "../../bluetooth/bluetooth_driver.h"
+#endif
 #include "../../misc/cpufreq/cpufreq.h"
 
 #ifdef HAVE_NETWORKING
@@ -226,7 +228,9 @@ DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_input_menu_settings_list,           
 DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_input_turbo_fire_settings_list,     MENU_ENUM_SUBLABEL_INPUT_TURBO_FIRE_SETTINGS)
 DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_input_haptic_feedback_settings_list,MENU_ENUM_SUBLABEL_INPUT_HAPTIC_FEEDBACK_SETTINGS)
 DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_latency_settings_list,         MENU_ENUM_SUBLABEL_LATENCY_SETTINGS)
+#ifdef HAVE_BLUETOOTH
 DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_bluetooth_settings_list,       MENU_ENUM_SUBLABEL_BLUETOOTH_SETTINGS)
+#endif
 DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_wifi_settings_list,            MENU_ENUM_SUBLABEL_WIFI_SETTINGS)
 DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_netplay_lan_scan_settings_list,MENU_ENUM_SUBLABEL_NETPLAY_LAN_SCAN_SETTINGS)
 DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_help_list,                     MENU_ENUM_SUBLABEL_HELP_LIST)
@@ -234,7 +238,9 @@ DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_help_list,                     MENU_
 DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_services_settings_list,        MENU_ENUM_SUBLABEL_SERVICES_SETTINGS)
 DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_ssh_enable,                    MENU_ENUM_SUBLABEL_SSH_ENABLE)
 DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_samba_enable,                  MENU_ENUM_SUBLABEL_SAMBA_ENABLE )
+#ifdef HAVE_BLUETOOTH
 DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_bluetooth_enable,              MENU_ENUM_SUBLABEL_BLUETOOTH_ENABLE )
+#endif
 DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_localap_enable,                MENU_ENUM_SUBLABEL_LOCALAP_ENABLE )
 DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_timezone,                      MENU_ENUM_SUBLABEL_TIMEZONE)
 #endif
@@ -568,7 +574,9 @@ DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_location_driver,               MENU_
 DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_menu_driver,                   MENU_ENUM_SUBLABEL_MENU_DRIVER)
 DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_record_driver,                 MENU_ENUM_SUBLABEL_RECORD_DRIVER)
 DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_midi_driver,                   MENU_ENUM_SUBLABEL_MIDI_DRIVER)
+#ifdef HAVE_BLUETOOTH
 DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_bluetooth_driver,              MENU_ENUM_SUBLABEL_BLUETOOTH_DRIVER)
+#endif
 DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_wifi_driver,                   MENU_ENUM_SUBLABEL_WIFI_DRIVER)
 DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_filter_supported_extensions,   MENU_ENUM_SUBLABEL_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE)
 DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_wallpaper,                     MENU_ENUM_SUBLABEL_MENU_WALLPAPER)
@@ -1040,6 +1048,7 @@ static int action_bind_sublabel_systeminfo_controller_entry(
    return 0;
 }
 
+#ifdef HAVE_BLUETOOTH
 static int action_bind_sublabel_bluetooth_list(
       file_list_t *list,
       unsigned type, unsigned i,
@@ -1049,6 +1058,7 @@ static int action_bind_sublabel_bluetooth_list(
    driver_bluetooth_device_get_sublabel(s, i, len);
    return 0;
 }
+#endif
 
 #ifndef HAVE_LAKKA_SWITCH
 #ifdef HAVE_LAKKA
@@ -3080,7 +3090,9 @@ int menu_cbs_init_bind_sublabel(menu_file_list_cbs_t *cbs,
             BIND_ACTION_SUBLABEL(cbs, action_bind_sublabel_filter_supported_extensions);
             break;
          case MENU_ENUM_LABEL_BLUETOOTH_DRIVER:
+#ifdef HAVE_BLUETOOTH
             BIND_ACTION_SUBLABEL(cbs, action_bind_sublabel_bluetooth_driver);
+#endif
             break;
          case MENU_ENUM_LABEL_WIFI_DRIVER:
             BIND_ACTION_SUBLABEL(cbs, action_bind_sublabel_wifi_driver);
@@ -3702,7 +3714,9 @@ int menu_cbs_init_bind_sublabel(menu_file_list_cbs_t *cbs,
             BIND_ACTION_SUBLABEL(cbs, action_bind_sublabel_video_shared_context);
             break;
          case MENU_ENUM_LABEL_CONNECT_BLUETOOTH:
+#ifdef HAVE_BLUETOOTH
             BIND_ACTION_SUBLABEL(cbs, action_bind_sublabel_bluetooth_list);
+#endif
             break;
 #ifdef HAVE_NETWORKING
          case MENU_ENUM_LABEL_CONNECT_NETPLAY_ROOM:
@@ -4147,7 +4161,9 @@ int menu_cbs_init_bind_sublabel(menu_file_list_cbs_t *cbs,
             BIND_ACTION_SUBLABEL(cbs, action_bind_sublabel_input_haptic_feedback_settings_list);
             break;
          case MENU_ENUM_LABEL_BLUETOOTH_SETTINGS:
+#ifdef HAVE_BLUETOOTH
             BIND_ACTION_SUBLABEL(cbs, action_bind_sublabel_bluetooth_settings_list);
+#endif
             break;
          case MENU_ENUM_LABEL_WIFI_SETTINGS:
             BIND_ACTION_SUBLABEL(cbs, action_bind_sublabel_wifi_settings_list);
@@ -4169,7 +4185,9 @@ int menu_cbs_init_bind_sublabel(menu_file_list_cbs_t *cbs,
             BIND_ACTION_SUBLABEL(cbs, action_bind_sublabel_samba_enable);
             break;
          case MENU_ENUM_LABEL_BLUETOOTH_ENABLE:
+#ifdef HAVE_BLUETOOTH
             BIND_ACTION_SUBLABEL(cbs, action_bind_sublabel_bluetooth_enable);
+#endif
             break;
          case MENU_ENUM_LABEL_LOCALAP_ENABLE:
             BIND_ACTION_SUBLABEL(cbs, action_bind_sublabel_localap_enable);

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -81,7 +81,9 @@
 #include "../dynamic.h"
 #include "../list_special.h"
 #include "../audio/audio_driver.h"
+#ifdef HAVE_BLUETOOTH
 #include "../bluetooth/bluetooth_driver.h"
+#endif
 #include "../midi_driver.h"
 #include "../location_driver.h"
 #include "../record/record_driver.h"
@@ -8424,11 +8426,15 @@ static void samba_enable_toggle_change_handler(rarch_setting_t *setting)
          *setting->value.target.boolean);
 }
 
-static void bluetooth_enable_toggle_change_handler(rarch_setting_t *setting)
+#ifdef HAVE_BLUETOOTH
+static void bluetooth_enable_toggle_change_handler(
+      rarch_setting_t *setting)
 {
-   systemd_service_toggle(LAKKA_BLUETOOTH_PATH, (char*)"bluetooth.service",
+   systemd_service_toggle(LAKKA_BLUETOOTH_PATH,
+         (char*)"bluetooth.service",
          *setting->value.target.boolean);
 }
+#endif
 
 #ifdef HAVE_WIFI
 static void localap_enable_toggle_change_handler(rarch_setting_t *setting)
@@ -9598,7 +9604,8 @@ static bool setting_append_list(
 #endif
 
 #ifdef HAVE_BLUETOOTH
-         if (string_is_not_equal(settings->arrays.bluetooth_driver, "null"))
+         if (string_is_not_equal(
+                  settings->arrays.bluetooth_driver, "null"))
          {
             CONFIG_ACTION(
                   list, list_info,
@@ -9739,7 +9746,7 @@ static bool setting_append_list(
             string_options_entries[j].default_value  = config_get_default_input();
             string_options_entries[j].values         = config_get_input_driver_options();
 
-	    j++;
+            j++;
 
             string_options_entries[j].target         = settings->arrays.input_joypad_driver;
             string_options_entries[j].len            = sizeof(settings->arrays.input_joypad_driver);
@@ -9748,7 +9755,7 @@ static bool setting_append_list(
             string_options_entries[j].default_value  = config_get_default_joypad();
             string_options_entries[j].values         = config_get_joypad_driver_options();
 
-	    j++;
+            j++;
 
             string_options_entries[j].target         = settings->arrays.video_driver;
             string_options_entries[j].len            = sizeof(settings->arrays.video_driver);
@@ -9757,7 +9764,7 @@ static bool setting_append_list(
             string_options_entries[j].default_value  = config_get_default_video();
             string_options_entries[j].values         = config_get_video_driver_options();
 
-	    j++;
+            j++;
 
             string_options_entries[j].target         = settings->arrays.audio_driver;
             string_options_entries[j].len            = sizeof(settings->arrays.audio_driver);
@@ -9766,7 +9773,7 @@ static bool setting_append_list(
             string_options_entries[j].default_value  = config_get_default_audio();
             string_options_entries[j].values         = config_get_audio_driver_options();
 
-	    j++;
+            j++;
 
             string_options_entries[j].target         = settings->arrays.audio_resampler;
             string_options_entries[j].len            = sizeof(settings->arrays.audio_resampler);
@@ -9775,7 +9782,7 @@ static bool setting_append_list(
             string_options_entries[j].default_value  = config_get_default_audio_resampler();
             string_options_entries[j].values         = config_get_audio_resampler_driver_options();
 
-	    j++;
+            j++;
 
             string_options_entries[j].target         = settings->arrays.camera_driver;
             string_options_entries[j].len            = sizeof(settings->arrays.camera_driver);
@@ -9784,8 +9791,9 @@ static bool setting_append_list(
             string_options_entries[j].default_value  = config_get_default_camera();
             string_options_entries[j].values         = config_get_camera_driver_options();
 
-	    j++;
+            j++;
 
+#ifdef HAVE_BLUETOOTH
             string_options_entries[j].target         = settings->arrays.bluetooth_driver;
             string_options_entries[j].len            = sizeof(settings->arrays.bluetooth_driver);
             string_options_entries[j].name_enum_idx  = MENU_ENUM_LABEL_BLUETOOTH_DRIVER;
@@ -9794,6 +9802,7 @@ static bool setting_append_list(
             string_options_entries[j].values         = config_get_bluetooth_driver_options();
 
             j++;
+#endif
 
 #ifdef HAVE_WIFI
             string_options_entries[j].target         = settings->arrays.wifi_driver;
@@ -9803,7 +9812,7 @@ static bool setting_append_list(
             string_options_entries[j].default_value  = config_get_default_wifi();
             string_options_entries[j].values         = config_get_wifi_driver_options();
 
-	    j++;
+            j++;
 #endif
 
             string_options_entries[j].target         = settings->arrays.location_driver;
@@ -9813,7 +9822,7 @@ static bool setting_append_list(
             string_options_entries[j].default_value  = config_get_default_location();
             string_options_entries[j].values         = config_get_location_driver_options();
 
-	    j++;
+            j++;
 
             string_options_entries[j].target         = settings->arrays.menu_driver;
             string_options_entries[j].len            = sizeof(settings->arrays.menu_driver);
@@ -9822,7 +9831,7 @@ static bool setting_append_list(
             string_options_entries[j].default_value  = config_get_default_menu();
             string_options_entries[j].values         = config_get_menu_driver_options();
 
-	    j++;
+            j++;
 
             string_options_entries[j].target          = settings->arrays.record_driver;
             string_options_entries[j].len             = sizeof(settings->arrays.record_driver);
@@ -9831,7 +9840,7 @@ static bool setting_append_list(
             string_options_entries[j].default_value   = config_get_default_record();
             string_options_entries[j].values          = config_get_record_driver_options();
 
-	    j++;
+            j++;
 
             string_options_entries[j].target          = settings->arrays.midi_driver;
             string_options_entries[j].len             = sizeof(settings->arrays.midi_driver);

--- a/network/wifi_driver.h
+++ b/network/wifi_driver.h
@@ -121,6 +121,8 @@ void driver_wifi_tether_start_stop(bool start, char* configfile);
 
 bool wifi_driver_ctl(enum rarch_wifi_ctl_state state, void *data);
 
+wifi_driver_state_t *wifi_state_get_ptr(void);
+
 extern const wifi_driver_t *wifi_drivers[];
 
 RETRO_END_DECLS

--- a/qb/config.params.sh
+++ b/qb/config.params.sh
@@ -1,6 +1,7 @@
 HAVE_LIBRETRO=             # Libretro library used
 HAVE_ASSETS_DIR=           # Assets install directory
 HAVE_CORE_INFO_CACHE=yes   # Core info cache support
+HAVE_BLUETOOTH=no          # Bluetooth support
 HAVE_NVDA=yes              # NVDA support
 HAVE_PATCH=yes             # Softpatching support (BPS/IPS/UPS)
 HAVE_SAPI=no               # SAPI support

--- a/retroarch.c
+++ b/retroarch.c
@@ -213,7 +213,9 @@
 #ifdef HAVE_CRTSWITCHRES
 #include "gfx/video_crt_switch.h"
 #endif
+#ifdef HAVE_BLUETOOTH
 #include "bluetooth/bluetooth_driver.h"
+#endif
 #include "misc/cpufreq/cpufreq.h"
 #include "led/led_driver.h"
 #include "midi_driver.h"
@@ -392,8 +394,9 @@
 #endif
 
 /* DRIVERS */
-
+#ifdef HAVE_BLUETOOTH
 extern const bluetooth_driver_t *bluetooth_drivers[];
+#endif
 
 static ui_companion_driver_t ui_companion_null = {
    NULL, /* init */
@@ -436,9 +439,10 @@ struct rarch_state
 #ifdef HAVE_QT
    void *ui_companion_qt_data;
 #endif
-
+#ifdef HAVE_BLUETOOTH
    const bluetooth_driver_t *bluetooth_driver;
    void *bluetooth_data;
+#endif
 
    char *connect_host; /* Netplay hostname passed from CLI */
 
@@ -485,7 +489,9 @@ struct rarch_state
 #ifdef HAVE_CONFIGFILE
    bool rarch_block_config_read;
 #endif
+#ifdef HAVE_BLUETOOTH
    bool bluetooth_driver_active;
+#endif
    bool main_ui_companion_is_on_foreground;
 };
 
@@ -9920,7 +9926,7 @@ static void clear_controller_port_map(void)                         { }
 #endif
 
 /* BLUETOOTH DRIVER  */
-
+#ifdef HAVE_BLUETOOTH
 /**
  * config_get_bluetooth_driver_options:
  *
@@ -10064,6 +10070,7 @@ bool bluetooth_driver_ctl(enum rarch_bluetooth_ctl_state state, void *data)
 
    return false;
 }
+#endif
 
 /* UI COMPANION */
 
@@ -12333,7 +12340,9 @@ bool retroarch_main_init(int argc, char *argv[])
    if (!camera_driver_find_driver("camera driver", verbosity_enabled))
       retroarch_fail(1, "find_camera_driver()");
 
+#ifdef HAVE_BLUETOOTH
    bluetooth_driver_ctl(RARCH_BLUETOOTH_CTL_FIND_DRIVER, NULL);
+#endif
 #ifdef HAVE_WIFI
    wifi_driver_ctl(RARCH_WIFI_CTL_FIND_DRIVER, NULL);
 #endif

--- a/retroarch.c
+++ b/retroarch.c
@@ -439,10 +439,6 @@ struct rarch_state
 #ifdef HAVE_QT
    void *ui_companion_qt_data;
 #endif
-#ifdef HAVE_BLUETOOTH
-   const bluetooth_driver_t *bluetooth_driver;
-   void *bluetooth_data;
-#endif
 
    char *connect_host; /* Netplay hostname passed from CLI */
 
@@ -488,9 +484,6 @@ struct rarch_state
 
 #ifdef HAVE_CONFIGFILE
    bool rarch_block_config_read;
-#endif
-#ifdef HAVE_BLUETOOTH
-   bool bluetooth_driver_active;
 #endif
    bool main_ui_companion_is_on_foreground;
 };
@@ -9923,153 +9916,6 @@ static void remember_controller_port_device(long port, long device) { }
 static void clear_controller_port_map(void)                         { }
 #endif
 
-#endif
-
-/* BLUETOOTH DRIVER  */
-#ifdef HAVE_BLUETOOTH
-/**
- * config_get_bluetooth_driver_options:
- *
- * Get an enumerated list of all bluetooth driver names,
- * separated by '|'.
- *
- * Returns: string listing of all bluetooth driver names,
- * separated by '|'.
- **/
-const char* config_get_bluetooth_driver_options(void)
-{
-   return char_list_new_special(STRING_LIST_BLUETOOTH_DRIVERS, NULL);
-}
-
-void driver_bluetooth_scan(void)
-{
-   struct rarch_state       *p_rarch = &rarch_st;
-   if ( (p_rarch->bluetooth_driver_active) &&
-        (p_rarch->bluetooth_driver->scan) )
-      p_rarch->bluetooth_driver->scan(p_rarch->bluetooth_data);
-}
-
-void driver_bluetooth_get_devices(struct string_list* devices)
-{
-   struct rarch_state       *p_rarch = &rarch_st;
-   if ( (p_rarch->bluetooth_driver_active) &&
-        (p_rarch->bluetooth_driver->get_devices) )
-      p_rarch->bluetooth_driver->get_devices(p_rarch->bluetooth_data, devices);
-}
-
-bool driver_bluetooth_device_is_connected(unsigned i)
-{
-   struct rarch_state       *p_rarch = &rarch_st;
-   if ( (p_rarch->bluetooth_driver_active) &&
-        (p_rarch->bluetooth_driver->device_is_connected) )
-      return p_rarch->bluetooth_driver->device_is_connected(p_rarch->bluetooth_data, i);
-   return false;
-}
-
-void driver_bluetooth_device_get_sublabel(char *s, unsigned i, size_t len)
-{
-   struct rarch_state       *p_rarch = &rarch_st;
-   if ( (p_rarch->bluetooth_driver_active) &&
-        (p_rarch->bluetooth_driver->device_get_sublabel) )
-      p_rarch->bluetooth_driver->device_get_sublabel(p_rarch->bluetooth_data, s, i, len);
-}
-
-bool driver_bluetooth_connect_device(unsigned i)
-{
-   struct rarch_state       *p_rarch = &rarch_st;
-   if (p_rarch->bluetooth_driver_active)
-      return p_rarch->bluetooth_driver->connect_device(p_rarch->bluetooth_data, i);
-   return false;
-}
-
-bool driver_bluetooth_remove_device(unsigned i)
-{
-   struct rarch_state       *p_rarch = &rarch_st;
-   if (p_rarch->bluetooth_driver_active)
-      return p_rarch->bluetooth_driver->remove_device(p_rarch->bluetooth_data, i);
-   return false;
-}
-
-bool bluetooth_driver_ctl(enum rarch_bluetooth_ctl_state state, void *data)
-{
-   struct rarch_state     *p_rarch  = &rarch_st;
-   settings_t             *settings = config_get_ptr();
-
-   switch (state)
-   {
-      case RARCH_BLUETOOTH_CTL_DESTROY:
-         p_rarch->bluetooth_driver          = NULL;
-         p_rarch->bluetooth_data            = NULL;
-         p_rarch->bluetooth_driver_active   = false;
-         break;
-      case RARCH_BLUETOOTH_CTL_FIND_DRIVER:
-         {
-            const char *prefix   = "bluetooth driver";
-            int i                = (int)driver_find_index(
-                  "bluetooth_driver",
-                  settings->arrays.bluetooth_driver);
-
-            if (i >= 0)
-               p_rarch->bluetooth_driver = (const bluetooth_driver_t*)bluetooth_drivers[i];
-            else
-            {
-               if (verbosity_is_enabled())
-               {
-                  unsigned d;
-                  RARCH_ERR("Couldn't find any %s named \"%s\"\n", prefix,
-                        settings->arrays.bluetooth_driver);
-                  RARCH_LOG_OUTPUT("Available %ss are:\n", prefix);
-                  for (d = 0; bluetooth_drivers[d]; d++)
-                     RARCH_LOG_OUTPUT("\t%s\n", bluetooth_drivers[d]->ident);
-
-                  RARCH_WARN("Going to default to first %s...\n", prefix);
-               }
-
-               p_rarch->bluetooth_driver = (const bluetooth_driver_t*)bluetooth_drivers[0];
-
-               if (!p_rarch->bluetooth_driver)
-                  retroarch_fail(1, "find_bluetooth_driver()");
-            }
-         }
-         break;
-      case RARCH_BLUETOOTH_CTL_DEINIT:
-        if (p_rarch->bluetooth_data && p_rarch->bluetooth_driver)
-        {
-           if (p_rarch->bluetooth_driver->free)
-              p_rarch->bluetooth_driver->free(p_rarch->bluetooth_data);
-        }
-
-        p_rarch->bluetooth_data = NULL;
-        p_rarch->bluetooth_driver_active = false;
-        break;
-      case RARCH_BLUETOOTH_CTL_INIT:
-        /* Resource leaks will follow if bluetooth is initialized twice. */
-        if (p_rarch->bluetooth_data)
-           return false;
-
-        bluetooth_driver_ctl(RARCH_BLUETOOTH_CTL_FIND_DRIVER, NULL);
-
-        if (p_rarch->bluetooth_driver && p_rarch->bluetooth_driver->init)
-        {
-           p_rarch->bluetooth_driver_active = true;
-           p_rarch->bluetooth_data = p_rarch->bluetooth_driver->init();
-
-           if (!p_rarch->bluetooth_data)
-           {
-              RARCH_ERR("Failed to initialize bluetooth driver. Will continue without bluetooth.\n");
-              p_rarch->bluetooth_driver_active = false;
-           }
-        } else {
-           p_rarch->bluetooth_driver_active = false;
-        }
-
-        break;
-      default:
-         break;
-   }
-
-   return false;
-}
 #endif
 
 /* UI COMPANION */


### PR DESCRIPTION
* Use HAVE_BLUETOOTH ifdef to strip out this code when not defined
* Split up bluetooth code into its own file, reducing retroarch.c's size