### PR TITLE
Make http header parsing case insensitive

### DIFF
--- a/libretro-common/include/string/stdstring.h
+++ b/libretro-common/include/string/stdstring.h
@@ -130,6 +130,25 @@ static INLINE bool string_is_equal_case_insensitive(const char *a,
    return (result == 0);
 }
 
+static INLINE bool string_starts_with_case_insensitive(const char *str,
+      const char *prefix)
+{
+   int result              = 0;
+   const unsigned char *p1 = (const unsigned char*)str;
+   const unsigned char *p2 = (const unsigned char*)prefix;
+
+   if (!str || !prefix)
+      return false;
+   if (p1 == p2)
+      return true;
+
+   while ((result = tolower (*p1++) - tolower (*p2)) == 0)
+      if (*p2++ == '\0')
+         break;
+
+   return (result == 0 || *p2 == '\0');
+}
+
 char *string_to_upper(char *s);
 
 char *string_to_lower(char *s);

--- a/libretro-common/net/net_http.c
+++ b/libretro-common/net/net_http.c
@@ -898,14 +898,13 @@ bool net_http_update(struct http_t *state, size_t* progress, size_t* total)
          }
          else
          {
-            if (!strncmp(state->data, "Content-Length: ",
-                     STRLEN_CONST("Content-Length: ")))
+            if (string_starts_with_case_insensitive(state->data, "Content-Length: "))
             {
                state->bodytype = T_LEN;
                state->len = strtol(state->data +
                      STRLEN_CONST("Content-Length: "), NULL, 10);
             }
-            if (string_is_equal(state->data, "Transfer-Encoding: chunked"))
+            if (string_is_equal_case_insensitive(state->data, "Transfer-Encoding: chunked"))
                state->bodytype = T_CHUNK;
 
             /* TODO: save headers somewhere */


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

HTTP 1 headers are supposed to be case insensitive, but the parsing in libretro/retroarch is case sensitive. This patch fixes this. In the future with HTTP 2, many servers are enforcing lower-case headers, so this change should be made eventually.
