### PR TITLE
(cheevos) validate hashes for secondary discs in multi-disc games

### DIFF
--- a/cheevos/cheevos.h
+++ b/cheevos/cheevos.h
@@ -26,6 +26,8 @@
 RETRO_BEGIN_DECLS
 
 bool rcheevos_load(const void *data);
+void rcheevos_change_disc(const char* new_disc_path, bool initial_disc);
+
 size_t rcheevos_get_serialize_size(void);
 bool rcheevos_get_serialized_data(void* buffer);
 bool rcheevos_set_serialized_data(void* buffer);

--- a/cheevos/cheevos_client.c
+++ b/cheevos/cheevos_client.c
@@ -610,6 +610,12 @@ static void rcheevos_async_login_callback(
    if (rcheevos_async_succeeded(result, &api_response.response,
             buffer, buffer_size))
    {
+      /* save the token to the config and clear the password on success */
+      settings_t* settings = config_get_ptr();
+      strlcpy(settings->arrays.cheevos_token, api_response.api_token,
+         sizeof(settings->arrays.cheevos_token));
+      settings->arrays.cheevos_password[0] = '\0';
+
       CHEEVOS_LOG(RCHEEVOS_TAG "%s logged in successfully\n",
             api_response.username);
       strlcpy(rcheevos_locals->username, api_response.username,

--- a/cheevos/cheevos_locals.h
+++ b/cheevos/cheevos_locals.h
@@ -120,13 +120,23 @@ typedef struct rcheevos_load_info_t
 #endif
 } rcheevos_load_info_t;
 
+typedef struct rcheevos_hash_entry_t
+{
+   uint32_t                      path_djb2;
+   int                           game_id;
+   struct rcheevos_hash_entry_t* next;
+   char                          hash[33];
+} rcheevos_hash_entry_t;
+
 typedef struct rcheevos_game_info_t
 {
    int   id;
    int   console_id;
    char* title;
    char  badge_name[16];
-   char  hash[33];
+   char* hash;
+
+   rcheevos_hash_entry_t* hashes;
 
    rcheevos_racheevo_t* achievements;
    rcheevos_ralboard_t* leaderboards;

--- a/disk_control_interface.c
+++ b/disk_control_interface.c
@@ -30,6 +30,10 @@
 
 #include "disk_control_interface.h"
 
+#ifdef HAVE_CHEEVOS
+#include "cheevos/cheevos.h"
+#endif
+
 /*****************/
 /* Configuration */
 /*****************/
@@ -324,6 +328,11 @@ bool disk_control_set_eject_state(
                true, NULL,
                MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
    }
+
+#ifdef HAVE_CHEEVOS
+   if (!error && !eject)
+      rcheevos_change_disc(disk_control->index_record.image_path, false);
+#endif
 
    return !error;
 }
@@ -773,6 +782,11 @@ bool disk_control_verify_initial_index(
                0, msg_duration,
                false, NULL,
                MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
+
+#ifdef HAVE_CHEEVOS
+      if (image_index > 0)
+         rcheevos_change_disc(disk_control->index_record.image_path, true);
+#endif
    }
 
    return success;


### PR DESCRIPTION
## Description

Ensures secondary discs of a multi-disc game are recognized by the RetroAchievements service.

When a disc is selected and inserted from the disc control menu, its hash is validated. 
* If the hash is not recognized by the server, we disable hardcore and notify the user.
  - We assume the unrecognized disc is a modified version of a disc supported by the game and could be used for cheating.
* If the hash matches the game, nothing happens.
* If the hash matches another game, nothing happens. 
  - We assume the game will refuse the load the alternate disc, or in the case of something like Vib Ribbon or Monster Rancher will do whatever it needs without unloading the achievement set.
* If the disc does not generate a hash, nothing happens.
  - We make the same assumption about the game doing what is needs without unloading the achievement set. This indicates the disc is not a game disc (audio disc or not for the same system as the primary disc).

Similarly, when a disc is 'remembered' as the last used disc it gets validated. Because the last used disc is booted instead of the primary disc, but the primary disc is still used to fetch achievements, we have to be a bit more strict about the validation.
* If the disc does not generate a hash, or the hash is not recognized by the server, we unload achievements as if the disc were loaded directly.
* If the hash matches another game, we unload achievements. The user must load the disc directly to load the appropriate achievements for the disc.
* If the hash matches the game, nothing happens.

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@Sanaki
