### PR TITLE
(cheevos) use SSL host when available

### DIFF
--- a/cheevos/cheevos_client.c
+++ b/cheevos/cheevos_client.c
@@ -591,8 +591,25 @@ static bool rcheevos_async_succeeded(int result,
 
 void rcheevos_client_initialize(void)
 {
-   /* force non-HTTPS until everything uses RAPI */
-   rc_api_set_host("http://retroachievements.org");
+   const settings_t* settings = config_get_ptr();
+   const char* host = settings->arrays.cheevos_custom_host;
+   if (!host[0])
+   {
+#ifdef HAVE_SSL
+      host = "https://retroachievements.org";
+#else
+      host = "http://retroachievements.org";
+#endif
+   }
+
+   CHEEVOS_LOG(RCHEEVOS_TAG "Using host: %s\n", host);
+   if (!string_is_equal(host, "https://retroachievements.org"))
+   {
+      rc_api_set_host(host);
+
+      if (!string_is_equal(host, "http://retroachievements.org"))
+         rc_api_set_image_host(host);
+   }
 }
 
 /****************************

--- a/configuration.c
+++ b/configuration.c
@@ -1394,6 +1394,7 @@ static struct config_array_setting *populate_settings_array(settings_t *settings
    SETTING_ARRAY("audio_device",             settings->arrays.audio_device,   false, NULL, true);
    SETTING_ARRAY("camera_device",            settings->arrays.camera_device,  false, NULL, true);
 #ifdef HAVE_CHEEVOS
+   SETTING_ARRAY("cheevos_custom_host",      settings->arrays.cheevos_custom_host, false, NULL, true);
    SETTING_ARRAY("cheevos_username",         settings->arrays.cheevos_username, false, NULL, true);
    SETTING_ARRAY("cheevos_password",         settings->arrays.cheevos_password, false, NULL, true);
    SETTING_ARRAY("cheevos_token",            settings->arrays.cheevos_token, false, NULL, true);

--- a/configuration.h
+++ b/configuration.h
@@ -409,6 +409,7 @@ typedef struct settings
       char cheevos_password[256];
       char cheevos_token[32];
       char cheevos_leaderboards_enable[32];
+      char cheevos_custom_host[64];
       char video_context_driver[32];
       char audio_driver[32];
       char audio_resampler[32];


### PR DESCRIPTION
## Description

Switches to `https://retroachievements.org` when `HAVE_SSL` is defined, which closes #11551. `http://retroachievements.org` is still used when `HAVE_SSL` is not defined.

Also provides a new config setting (`cheevos_custom_host`) which can be used to explicitly set the host to use, including other hosts (like localhost). `cheevos_custom_host` is not exposed to the UI. It can only be set by editing the `retroarch.cfg`. If the switch to SSL causes problems (the server expects a TLS1.2 connection and older OSes may not support that), a user could use `cheevos_custom_host` to explicitly force the non-https site.

Tested on Windows (the MSVC build apparently doesn't define HAVE_SSL, and trying to force the application to use the https site generates 400 errors) and on Linux (which did define HAVE_SSL, and did work when using the https site).

## Related Issues

Closes #11551

## Related Pull Requests

n/a

## Reviewers

@Sanaki
