### PR TITLE
'Automatic Frame Delay' improvements

### DIFF
--- a/gfx/video_driver.h
+++ b/gfx/video_driver.h
@@ -958,6 +958,14 @@ typedef struct
 #endif
 } video_driver_state_t;
 
+typedef struct video_frame_delay_auto {
+   float refresh_rate;
+   unsigned frame_time_interval;
+   unsigned decrease;
+   unsigned target;
+   unsigned time;
+} video_frame_delay_auto_t;
+
 extern struct aspect_ratio_elem aspectratio_lut[ASPECT_RATIO_END];
 
 bool video_driver_has_windowed(void);
@@ -1226,6 +1234,8 @@ void video_driver_get_window_title(char *buf, unsigned len);
 bool *video_driver_get_threaded(void);
 
 void video_driver_set_threaded(bool val);
+
+void video_frame_delay_auto(video_driver_state_t *video_st, video_frame_delay_auto_t *vfda);
 
 /**
  * video_context_driver_init:

--- a/retroarch.c
+++ b/retroarch.c
@@ -1813,6 +1813,10 @@ bool command_event(enum event_command cmd, void *data)
 #if HAVE_NETWORKING
          netplay_driver_ctl(RARCH_NETPLAY_CTL_RESET, NULL);
 #endif
+         /* Recalibrate frame delay target */
+         if (settings->bools.video_frame_delay_auto)
+            video_st->frame_delay_target = 0;
+
          return false;
       case CMD_EVENT_SAVE_STATE:
       case CMD_EVENT_SAVE_STATE_TO_RAM:


### PR DESCRIPTION
## Description

Notable changes:
- swap interval handling
- d3dx handling
- delay target resets also on core restart
- moved most of the code to `video_driver.c` due to becoming too complex

In other words: It should now work with high refresh rates and also with d3d1x drivers.

## Related Pull Requests

#13190 

## Reviewers

@realnc Please test how swap interval behaves
@Ryunam Please test that nothing got worse


