### PR TITLE
Re-enable Gyroscope & Accelerometer when RetroArch resumes or regains focus. 

### DIFF
--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -374,11 +374,9 @@ static void android_input_poll_main_cmd(void)
          {
             bool boolean              = false;
             bool enable_accelerometer = (android_app->sensor_state_mask &
-                  (UINT64_C(1) << RETRO_SENSOR_ACCELEROMETER_ENABLE)) &&
-                        !android_app->accelerometerSensor;
+                  (UINT64_C(1) << RETRO_SENSOR_ACCELEROMETER_DISABLE));
             bool enable_gyroscope     = (android_app->sensor_state_mask &
-                  (UINT64_C(1) << RETRO_SENSOR_GYROSCOPE_ENABLE)) &&
-                        !android_app->gyroscopeSensor;
+                  (UINT64_C(1) << RETRO_SENSOR_GYROSCOPE_DISABLE));
 
             retroarch_ctl(RARCH_CTL_SET_PAUSED, &boolean);
             retroarch_ctl(RARCH_CTL_SET_IDLE,   &boolean);


### PR DESCRIPTION
## Description

This fixes an issue in the RetroArch Android app where the Gyroscope & Accelerometer would not be re-enabled when app regains focus or is resumed. 

When the Gyro/Accelerometer is disabled the sensor_state_mask is updated to RETRO_SENSOR_ACCELEROMETER_DISABLE, so this needs to be accounted for when attempting to enable the sensors upon the app gaining focus. 

## Related Issues

https://github.com/libretro/RetroArch/issues/13244