### PR TITLE
Show passworded rooms on lobby

### DIFF
--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -12644,6 +12644,10 @@ MSG_HASH(
    "Show the 'Shutdown' option."
    )
 MSG_HASH(
+   MSG_ROOM_PASSWORDED,
+   "Passworded"
+   )
+MSG_HASH(
    MSG_INTERNET,
    "Internet"
    )

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -9713,10 +9713,21 @@ unsigned menu_displaylist_netplay_refresh_rooms(file_list_t *list)
       for (i = 0; i < net_st->room_count; i++)
       {
          char country[8];
+         char passworded[64];
 
-         if (*net_st->room_list[i].country)
+         if (!net_st->room_list[i].lan &&
+               !string_is_empty(net_st->room_list[i].country))
             snprintf(country, sizeof(country),
                   "(%s)", net_st->room_list[i].country);
+         else
+            *country = '\0';
+
+         if (net_st->room_list[i].has_password ||
+               net_st->room_list[i].has_spectate_password)
+            snprintf(passworded, sizeof(passworded),
+                  "[%s]", msg_hash_to_str(MSG_ROOM_PASSWORDED));
+         else
+            *passworded = '\0';
 
          /* Uncomment this to debug mismatched room parameters*/
 #if 0
@@ -9739,15 +9750,16 @@ unsigned menu_displaylist_netplay_refresh_rooms(file_list_t *list)
                net_st->room_list[i].timestamp);
 #endif
 
-         snprintf(s, sizeof(s), "%s: %s%s",
-            net_st->room_list[i].lan 
-            ? msg_hash_to_str(MSG_LOCAL) 
-            : (net_st->room_list[i].host_method 
-               == NETPLAY_HOST_METHOD_MITM 
-               ? msg_hash_to_str(MSG_INTERNET_RELAY) 
+         snprintf(s, sizeof(s), "%s%s: %s%s",
+            passworded,
+            net_st->room_list[i].lan
+            ? msg_hash_to_str(MSG_LOCAL)
+            : (net_st->room_list[i].host_method
+               == NETPLAY_HOST_METHOD_MITM
+               ? msg_hash_to_str(MSG_INTERNET_RELAY)
                : msg_hash_to_str(MSG_INTERNET)),
             net_st->room_list[i].nickname,
-            net_st->room_list[i].lan ? "" : country
+            country
             );
 
          if (menu_entries_append_enum(list,

--- a/msg_hash.h
+++ b/msg_hash.h
@@ -167,6 +167,7 @@ enum msg_file_type
 enum msg_hash_enums
 {
    MSG_UNKNOWN = 0,
+   MSG_ROOM_PASSWORDED,
    MSG_INTERNET,
    MSG_INTERNET_RELAY,
    MSG_READ_WRITE,


### PR DESCRIPTION
Small improvement to the lobby viewer - it should now make a distinction between passworded rooms and non-passworded rooms.