### PR TITLE
WIIU: Fix keyboard support

### DIFF
--- a/input/drivers_hid/wiiu_hid.c
+++ b/input/drivers_hid/wiiu_hid.c
@@ -889,6 +889,11 @@ static void get_device_name(HIDDevice *device, wiiu_attach_event *event)
 
 static wiiu_attach_event *new_attach_event(HIDDevice *device)
 {
+   if(device->protocol > 0)
+   {
+      /* ignore mice and keyboards as HID devices */
+      return NULL;
+   }
    wiiu_attach_event *event = alloc_zeroed(4, sizeof(wiiu_attach_event));
    
    if (!event)


### PR DESCRIPTION
## Description

The problem was caused by changing the driver lookup point. The deferred
lookup resulted in the WIIU trying to treat the keyboard as a gamepad which ...
didn't work.

This change short-circuits at the connection event by ignoring mouse &
keyboard connection events.

Tested this with a dev build.

## Related Issues

#13198 


## Reviewers

@twinaphex @vaguerant
