### PR TITLE
tweak to ensure that current versions of emsdk do not break the web player

### DIFF
--- a/pkg/emscripten/libretro/libretro.js
+++ b/pkg/emscripten/libretro/libretro.js
@@ -151,6 +151,7 @@ function startRetroArch()
    document.getElementById("btnFullscreen").disabled = false;
 
    Module['callMain'](Module['arguments']);
+   Module['resumeMainLoop']();
    document.getElementById('canvas').focus();
 }
 


### PR DESCRIPTION
closes #13252

With this change it should be safe to up 2.0.34 emsdk (current latest). I was digging into Safari support and stumbled across this problem building with current emsdk versions. I have no idea why it needs the resume to run the loop, but this works. Even better it does not effect current deployed cores built against 1.39.5. 
Tested against the following cores built with 2.0.34: 
81- [https://github.com/libretro/81-libretro](https://github.com/libretro/81-libretro)
bluemsx- [https://github.com/libretro/blueMSX-libretro](https://github.com/libretro/blueMSX-libretro)
fceumm- [https://github.com/libretro/libretro-fceumm](https://github.com/libretro/libretro-fceumm)
fuse- [https://github.com/libretro/fuse-libretro](https://github.com/libretro/fuse-libretro)
gambatte- [https://github.com/libretro/gambatte-libretro](https://github.com/libretro/gambatte-libretro)
gearboy- [https://github.com/libretro/Gearboy](https://github.com/libretro/Gearboy)
genesis_plus_gx- [https://github.com/libretro/Genesis-Plus-GX](https://github.com/libretro/Genesis-Plus-GX)
gw- [https://github.com/libretro/gw-libretro](https://github.com/libretro/gw-libretro)
handy- [https://github.com/libretro/libretro-handy](https://github.com/libretro/libretro-handy)
mame2003_plus- [https://github.com/libretro/mame2003-plus-libretro](https://github.com/libretro/mame2003-plus-libretro)
mednafen_ngp- [https://github.com/libretro/beetle-ngp-libretro](https://github.com/libretro/beetle-ngp-libretro)
mednafen_pce_fast- [https://github.com/libretro/beetle-pce-fast-libretro](https://github.com/libretro/beetle-pce-fast-libretro)
mednafen_psx- [https://github.com/libretro/beetle-psx-libretro](https://github.com/libretro/beetle-psx-libretro)
mednafen_vb- [https://github.com/libretro/beetle-vb-libretro](https://github.com/libretro/beetle-vb-libretro)
mednafen_wswan- [https://github.com/libretro/beetle-wswan-libretro](https://github.com/libretro/beetle-wswan-libretro)
melonds- [https://github.com/libretro/melonDS](https://github.com/libretro/melonDS)
o2em- [https://github.com/libretro/libretro-o2em](https://github.com/libretro/libretro-o2em)
prboom- [https://github.com/libretro/libretro-prboom](https://github.com/libretro/libretro-prboom)
prosystem- [https://github.com/libretro/prosystem-libretro](https://github.com/libretro/prosystem-libretro)
snes9x- [https://github.com/libretro/snes9x](https://github.com/libretro/snes9x)
stella2014- [https://github.com/libretro/stella2014-libretro](https://github.com/libretro/stella2014-libretro)
tyrquake- [https://github.com/libretro/libretro-tyrquake](https://github.com/libretro/libretro-tyrquake)
vba_next- [https://github.com/libretro/vba-next](https://github.com/libretro/vba-next)
vecx- [https://github.com/libretro/libretro-vecx](https://github.com/libretro/libretro-vecx)
virtualjaguar- [https://github.com/libretro/virtualjaguar-libretro](https://github.com/libretro/virtualjaguar-libretro)
yabause- [https://github.com/libretro/yabause](https://github.com/libretro/yabause)
