### PR TITLE
Refresh rate switch addition on startup

### DIFF
--- a/gfx/video_display_server.h
+++ b/gfx/video_display_server.h
@@ -87,6 +87,8 @@ bool video_display_server_can_set_screen_orientation(void);
 
 bool video_display_server_has_resolution_list(void);
 
+void video_switch_refresh_rate_maybe(float *refresh_rate, bool *video_switch_refresh_rate);
+
 bool video_display_server_set_refresh_rate(float hz);
 
 bool video_display_server_has_refresh_rate(float hz);


### PR DESCRIPTION
## Description

Currently the temporary refresh rate switching based on content only works when cores announces SET_SYSTEM_AV_INFO, and some don't at startup, leaving the rate at the wrong default speed. This separates and reuses the same existing decision logic also when initing.

Maybe there is a better place for  doing it..? Next stop would be making the switching completely optional.

## Related Pull Requests

#12795

