### PR TITLE
(cheevos) disallow achievements when spectating netplay

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -1971,3 +1971,42 @@ void rcheevos_change_disc(const char* new_disc_path, bool initial_disc)
       initial_disc ? rcheevos_identify_initial_disc_callback :
          rcheevos_identify_game_disc_callback, hash_entry);
 }
+
+void rcheevos_validate_netplay(int player_num)
+{
+   const char* msg = NULL;
+
+   if (rcheevos_locals.load_info.state == RCHEEVOS_LOAD_STATE_NONE)
+   {
+       /* already disabled or game doesn't have achievements, nothing to do */
+       return;
+   }
+
+   if (player_num == 1)
+   {
+       /* always allow player 1 */
+       return;
+   }
+   else if (player_num == 0)
+   {
+       /* spectating, never allow achievements */
+       msg = "Disabling achievements for netplay spectator mode.";
+   }
+   else
+   {
+       /* non-primary player, only allow for multi sets (TODO) */
+       return;
+   }
+
+   /* if there are active achievements, inform the user about the deactivation */
+   if (rcheevos_locals.loaded && rcheevos_locals.game.achievement_count > 0)
+   {
+       runloop_msg_queue_push(msg, 0, 3 * 60, false, NULL,
+            MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
+   }
+
+   /* disable the achievement runtime */
+   CHEEVOS_LOG(RCHEEVOS_TAG "%s\n", msg);
+   rcheevos_unload();
+}
+

--- a/cheevos/cheevos.h
+++ b/cheevos/cheevos.h
@@ -44,6 +44,7 @@ void rcheevos_toggle_hardcore_paused(void);
 bool rcheevos_hardcore_active(void);
 
 void rcheevos_validate_config_settings(void);
+void rcheevos_validate_netplay(int player_number);
 
 void rcheevos_leaderboards_enabled_changed(void);
 

--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -71,6 +71,10 @@
 #include "../discord.h"
 #endif
 
+#ifdef HAVE_CHEEVOS
+#include "../cheevos/cheevos.h"
+#endif
+
 #include "netplay.h"
 #include "netplay_private.h"
 
@@ -1127,7 +1131,7 @@ static void netplay_handshake_ready(netplay_t *netplay,
       netplay_log_connection(&connection->addr,
             slot, connection->nick, msg, sizeof(msg));
 
-      RARCH_LOG("%s %u\n", msg_hash_to_str(MSG_CONNECTION_SLOT), slot);
+      RARCH_LOG("[Netplay] %s %u\n", msg_hash_to_str(MSG_CONNECTION_SLOT), slot);
 
       /* Send them the savestate */
       if (!(netplay->quirks &
@@ -1142,7 +1146,7 @@ static void netplay_handshake_ready(netplay_t *netplay,
             connection->nick);
    }
 
-   RARCH_LOG("%s\n", msg);
+   RARCH_LOG("[Netplay] %s\n", msg);
    /* Useful notification to the client in figuring out if a connection was successfully made before an error,
       but not as useful to the server.
       Let it be optional if server. */
@@ -1750,7 +1754,7 @@ static bool netplay_handshake_pre_sync(netplay_t *netplay,
       strlcpy(netplay->nick, new_nick, NETPLAY_NICK_LEN);
       snprintf(msg, sizeof(msg),
             msg_hash_to_str(MSG_NETPLAY_CHANGED_NICK), netplay->nick);
-      RARCH_LOG("%s\n", msg);
+      RARCH_LOG("[Netplay] %s\n", msg);
       runloop_msg_queue_push(msg, 1, 180, false, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
    }
 
@@ -1816,6 +1820,10 @@ static bool netplay_handshake_pre_sync(netplay_t *netplay,
       settings_t *settings = config_get_ptr();
       if (!settings->bools.netplay_start_as_spectator)
          return netplay_cmd_mode(netplay, NETPLAY_CONNECTION_PLAYING);
+#ifdef HAVE_CHEEVOS
+      else /* staying in SPECTATING mode, disable achievements */
+         rcheevos_validate_netplay(0);
+#endif
    }
 
    return true;
@@ -3620,7 +3628,7 @@ void netplay_hangup(netplay_t *netplay,
 #endif
       netplay->is_connected = false;
    }
-   RARCH_LOG("%s\n", dmsg);
+   RARCH_LOG("[Netplay] %s\n", dmsg);
    /* This notification is really only important to the server if the client was playing.
     * Let it be optional if server and the client wasn't playing. */
    if (!netplay->is_server || was_playing || extra_notifications)
@@ -4064,7 +4072,13 @@ static void announce_play_spectate(netplay_t *netplay,
             dmsg = msg;
          }
          else
+         {
             dmsg = msg_hash_to_str(MSG_NETPLAY_YOU_HAVE_LEFT_THE_GAME);
+
+#ifdef HAVE_CHEEVOS
+            rcheevos_validate_netplay(0);
+#endif
+         }
          break;
 
       case NETPLAY_CONNECTION_PLAYING:
@@ -4101,6 +4115,10 @@ static void announce_play_spectate(netplay_t *netplay,
                      msg_hash_to_str(
                         MSG_NETPLAY_YOU_HAVE_JOINED_AS_PLAYER_N),
                      one_device + 1);
+
+#ifdef HAVE_CHEEVOS
+            rcheevos_validate_netplay(one_device + 1);
+#endif
          }
          else
          {
@@ -4111,11 +4129,17 @@ static void announce_play_spectate(netplay_t *netplay,
             for (device = 0; device < MAX_INPUT_DEVICES; device++)
             {
                if (devices & (1<<device))
+               {
                   pdevice_str += snprintf(pdevice_str,
                         sizeof(device_str) - (size_t)
                         (pdevice_str - device_str),
                         "%u, ",
 			(unsigned) (device+1));
+
+#ifdef HAVE_CHEEVOS
+                  rcheevos_validate_netplay(device + 1);
+#endif
+              }
             }
 
             if (pdevice_str > device_str)
@@ -4145,7 +4169,7 @@ static void announce_play_spectate(netplay_t *netplay,
          return;
    }
 
-   RARCH_LOG("%s\n", dmsg);
+   RARCH_LOG("[Netplay] %s\n", dmsg);
    runloop_msg_queue_push(dmsg, 1, 180, false, NULL,
          MESSAGE_QUEUE_ICON_DEFAULT,
          MESSAGE_QUEUE_CATEGORY_INFO);
@@ -4983,9 +5007,15 @@ static bool netplay_get_cmd(netplay_t *netplay,
                   dmsg = msg_hash_to_str(MSG_NETPLAY_CANNOT_PLAY);
             }
 
-            RARCH_LOG("%s\n", dmsg);
+            RARCH_LOG("[Netplay] %s\n", dmsg);
             runloop_msg_queue_push(dmsg, 1, 180, false, NULL,
                   MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
+
+#ifdef HAVE_CHEEVOS
+            /* unable to switch to PLAY mode, disable achievements while spectating */
+            if (netplay->self_mode == NETPLAY_CONNECTION_SPECTATING)
+                rcheevos_validate_netplay(0);
+#endif
          }
          break;
 


### PR DESCRIPTION
## Description

Fixes #13290

Any time the player becomes a spectator, disable locally active achievements.

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@Sanaki 
