### PR TITLE
Fix gamepad disconnect on unrecognized HID device

### DIFF
--- a/input/drivers_hid/wiiu_hid.c
+++ b/input/drivers_hid/wiiu_hid.c
@@ -469,7 +469,10 @@ static void synchronized_process_adapters(wiiu_hid_t *hid)
                else
                   prev->next = adapter->next;
 
-               pad_connection_pad_deregister(joypad_state.pads, adapter->pad_driver, adapter->pad_driver_data);
+               if(adapter->pad_driver && adapter->pad_driver_data)
+               {
+                  pad_connection_pad_deregister(joypad_state.pads, adapter->pad_driver, adapter->pad_driver_data);
+               }
                /* adapter is no longer valid after this point */
                delete_adapter(adapter);
                /* signal not to update prev ptr since adapter is now invalid */


### PR DESCRIPTION
## Description

== DETAILS
So, the reason the gamepad was getting deregistered was
because adapter free code wasn't properly handling null-interface
adapters, causing the gamepad to match erroneously and get
deregistered.

This doesn't fix the weird "Generic SNES USB" detection behavior, but it should make the gamepad remain functional.

## Related Issues

#13309 

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

@twinaphex @vaguerant