### PR TITLE
Remove frame limit from audio batch callback

### DIFF
--- a/audio/audio_driver.h
+++ b/audio/audio_driver.h
@@ -374,8 +374,7 @@ void audio_driver_sample(int16_t left, int16_t right);
  *
  * Batched audio sample render callback function.
  *
- * Returns: amount of frames sampled. Will be equal to @frames
- * unless @frames exceeds (AUDIO_CHUNK_SIZE_NONBLOCKING / 2).
+ * Returns: amount of frames sampled.
  **/
 size_t audio_driver_sample_batch(const int16_t *data, size_t frames);
 
@@ -401,8 +400,7 @@ void audio_driver_sample_rewind(int16_t left, int16_t right);
  * This callback function will be used instead of
  * audio_driver_sample_batch when rewinding is activated.
  *
- * Returns: amount of frames sampled. Will be equal to @frames
- * unless @frames exceeds (AUDIO_CHUNK_SIZE_NONBLOCKING / 2).
+ * Returns: amount of frames sampled.
  **/
 size_t audio_driver_sample_batch_rewind(
       const int16_t *data, size_t frames);


### PR DESCRIPTION
## Description

At present, when a core uses the audio batch callback, there is hidden cap of 1024 on the number of audio frames that can be sent. If a core exceeds this value, any excess samples are silently discarded. While this is sufficient for 'normal' samplerates/framerates, it means that e.g. a core using the batch callback to send 44100 Hz audio at 30 fps with have entirely broken sound.

This PR simply removes the audio batch frame limit.