### PR TITLE
Fix roms over 4gb (approx) failing to load, improve copy times, fix scanning for playlists  [UWP/XBOX]

### DIFF
--- a/libretro-common/vfs/vfs_implementation_uwp.cpp
+++ b/libretro-common/vfs/vfs_implementation_uwp.cpp
@@ -158,19 +158,12 @@ int64_t retro_vfs_file_truncate_impl(libretro_vfs_implementation_file* stream, i
 
 int64_t retro_vfs_file_tell_impl(libretro_vfs_implementation_file* stream)
 {
-    if (!stream || (!stream->fp && stream->fh == INVALID_HANDLE_VALUE))
+    if (!stream)
         return -1;
 
-    if (stream->fh != INVALID_HANDLE_VALUE)
-    {
-        LARGE_INTEGER sz;
-        if (GetFileSizeEx(stream->fh, &sz))
-            return sz.QuadPart;
-        return 0;
-    }
     if ((stream->hints & RFILE_HINT_UNBUFFERED) == 0)
     {
-        return ftell(stream->fp);
+        return _ftelli64(stream->fp);
     }
     if (lseek(stream->fd, 0, SEEK_CUR) < 0)
         return -1;


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

Fixed roms over 4.294967295gb failing to copy to the Xbox cache (local state) folder, this happened because the winapi readfile function takes the number of bytes to read as a dword which has a max length of 4294967295 bytes so a file size larger than this lead to an overflow, so only the first chunk would be copied. This was fixed by using copyfilefromapp. This has the unintentional side effect of making ps2 and other large roms load faster due to improved copy times. In @gamr13 's testing this had a particularly large impact on persona 3 FES which loaded in 15s instead of 13mins lol. 

Also fixed scanning for playlists

These fixes have been tested and validated by @gamr13

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
