### PR TITLE
Fix rotation on 3DS and Wii U

### DIFF
--- a/gfx/drivers/ctr_gfx.c
+++ b/gfx/drivers/ctr_gfx.c
@@ -138,10 +138,10 @@ static INLINE void ctr_set_screen_coords(ctr_video_t * ctr)
    }
    else if (ctr->rotation == 1) /* 90° */
    {
-      ctr->frame_coords->x0 = ctr->vp.x;
-      ctr->frame_coords->y0 = ctr->vp.y;
-      ctr->frame_coords->x1 = ctr->vp.x + ctr->vp.width;
-      ctr->frame_coords->y1 = ctr->vp.y + ctr->vp.height;
+      ctr->frame_coords->x1 = ctr->vp.x;
+      ctr->frame_coords->y1 = ctr->vp.y;
+      ctr->frame_coords->x0 = ctr->vp.x + ctr->vp.width;
+      ctr->frame_coords->y0 = ctr->vp.y + ctr->vp.height;
    }
    else if (ctr->rotation == 2) /* 180° */
    {
@@ -152,10 +152,10 @@ static INLINE void ctr_set_screen_coords(ctr_video_t * ctr)
    }
    else /* 270° */
    {
-      ctr->frame_coords->x1 = ctr->vp.x;
-      ctr->frame_coords->y1 = ctr->vp.y;
-      ctr->frame_coords->x0 = ctr->vp.x + ctr->vp.width;
-      ctr->frame_coords->y0 = ctr->vp.y + ctr->vp.height;
+      ctr->frame_coords->x0 = ctr->vp.x;
+      ctr->frame_coords->y0 = ctr->vp.y;
+      ctr->frame_coords->x1 = ctr->vp.x + ctr->vp.width;
+      ctr->frame_coords->y1 = ctr->vp.y + ctr->vp.height;
    }
 }
 
@@ -193,9 +193,6 @@ static void ctr_update_viewport(
    float desired_aspect      = video_driver_get_aspect_ratio();
    bool video_scale_integer  = settings->bools.video_scale_integer;
    unsigned aspect_ratio_idx = settings->uints.video_aspect_ratio_idx;
-
-   if (ctr->rotation & 0x1)
-      desired_aspect = 1.0 / desired_aspect;
 
    if (video_scale_integer)
    {

--- a/gfx/drivers/gx2_gfx.c
+++ b/gfx/drivers/gx2_gfx.c
@@ -88,7 +88,7 @@ static void wiiu_set_projection(wiiu_video_t *wiiu)
 {
    math_matrix_4x4 proj, rot;
    matrix_4x4_ortho(proj, 0, 1, 1, 0, -1, 1);
-   matrix_4x4_rotate_z(rot, wiiu->rotation * -M_PI_2);
+   matrix_4x4_rotate_z(rot, wiiu->rotation * M_PI_2);
    matrix_4x4_multiply((*wiiu->ubo_mvp), rot, proj);
    GX2Invalidate(GX2_INVALIDATE_MODE_CPU_UNIFORM_BLOCK, wiiu->ubo_mvp, sizeof(*wiiu->ubo_mvp));
 }


### PR DESCRIPTION
## Description

This fixes two issues around rotation on 3DS. Firstly, 90 and 270 are inverted, so any vertical games run upside down. Whoops. Secondly, aspect ratios adjustments are calculated *twice* for rotated games--once in the core, as expected, and then again in the `ctr` driver, not expected. This is an issue for any core which uses rotation, but particularly noticeable on WonderSwan, a platform where some games require rotation mid-game. When rotating, the core passes RetroArch the rotated aspect ratio, but then the `ctr` driver *also* inverts the aspect ratio.

Behavior in this area is confusing in general: should manual rotation automatically adjust the Core Provided aspect ratio or not? The `gl` driver doesn't, while `ctr` does. We had some discussion about this in #programming-frontend on the libretro Discord if anybody wishes to add on. What's clear is that the frontend *always* trying to be in charge of aspect ratio rotation, as happen currently on `ctr`, is very wrong and results in bad aspect ratios for any core-requested rotation.

As long as we're talking about rotation, are the manual rotation names right in general (not on 3DS specifically)? Setting rotation to 90 degrees rotates the image counter-clockwise and 270 degrees rotates the image clockwise. This seems to be the opposite of what's intuitive to me (and probably explains why the `ctr` rotations were inverted in the first place), but I don't think it actually rises to being incorrect. It's just not rotating in the obvious direction.

## Related Issues

Fixes #13018

## Reviewers

@jdgleaver 
