### PR TITLE
Change VS Code settings to add a ruler at line width 80

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
    "editor.renderWhitespace": "all",
    "editor.insertSpaces": true,
    "editor.formatOnSave": false,
+   "editor.ruler": [80],
    "files.associations": {
       "*.h": "c",
       "*.in": "c",


### PR DESCRIPTION
## Description

See title. The ruler is just a guide and does not enforce anything.