### PR TITLE
Stop logging fps statistics twice on quit

### DIFF
--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -1528,7 +1528,8 @@ VIDEO_DRIVER_IS_THREADED_INTERNAL(video_st);
       return;
 #endif
 
-   video_monitor_compute_fps_statistics(video_st->frame_time_count);
+   if (video_st->data)
+      video_monitor_compute_fps_statistics(video_st->frame_time_count);
 }
 
 void video_driver_set_viewport_config(


### PR DESCRIPTION
## Description

Video uninit outputs statistics, and on quit uninit happens twice, therefore prevent logging the same line after video is already freed.
