### PR TITLE
Log font rendering backend only once

### DIFF
--- a/gfx/font_driver.c
+++ b/gfx/font_driver.c
@@ -67,8 +67,9 @@ int font_renderer_create_default(
       *handle = font_backends[i]->init(path, font_size);
       if (*handle)
       {
-         RARCH_LOG("[Font]: Using font rendering backend: \"%s\".\n",
-               font_backends[i]->ident);
+         if (!video_font_driver)
+            RARCH_LOG("[Font]: Using font rendering backend: \"%s\".\n",
+                  font_backends[i]->ident);
          *drv = font_backends[i];
          return 1;
       }


### PR DESCRIPTION
## Description

Surely only one line of ```[INFO] [Font]: Using font rendering backend: "freetype".``` is enough instead of n^2.
