### PR TITLE
Vulkan max swapchain images option adjustments

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -2854,7 +2854,7 @@ static int setting_action_ok_uint(
          enum_idx, /* we will pass the enumeration index of the string as a path */
          NULL, NULL, 0, idx, 0,
          ACTION_OK_DL_DROPDOWN_BOX_LIST);
-   return 0;
+   return 1;
 }
 
 static int setting_action_ok_libretro_device_type(
@@ -12180,9 +12180,10 @@ static bool setting_append_list(
                   general_write_handler,
                   general_read_handler);
             (*list)[list_info->index - 1].action_ok = &setting_action_ok_uint;
-            (*list)[list_info->index - 1].offset_by = 1;
-            menu_settings_list_current_add_range(list, list_info, 1, 4, 1, true, true);
+            (*list)[list_info->index - 1].offset_by = 2;
+            menu_settings_list_current_add_range(list, list_info, (*list)[list_info->index - 1].offset_by, 4, 1, true, true);
             SETTINGS_DATA_LIST_CURRENT_ADD_FLAGS(list, list_info, SD_FLAG_CMD_APPLY_AUTO);
+            MENU_SETTINGS_LIST_CURRENT_ADD_CMD(list, list_info, CMD_EVENT_REINIT);
 
             CONFIG_BOOL(
                   list, list_info,


### PR DESCRIPTION
## Description

A few usability improvements to the swapchain setting:
- Removed value 1, since it won't be used anyway
- Video reinit on change, so that there is no need to restart or toggle fullscreen

Also changed `setting_action_ok_uint` to return 1 instead of 0, so that write handler is called only after selecting the value and not also when entering the dropdown. Otherwise reinit would be called twice for no reason at all. Any possible downsides to this, or is there a better way to accomplish this? All similar uints seems to work just fine with it.
