### PR TITLE
Netplay Stuff - Addendum

### DIFF
--- a/AUTHORS.h
+++ b/AUTHORS.h
@@ -350,6 +350,7 @@ reztek
 Richard Howell (rmaz)
 rlnilsen
 Rob Loach (RobLoach)
+Roberto V. Rampim (Cthulhu)
 Robin de Rooij (rrooij)
 Romain Gay (vikbez)
 Romain Graillot (notnotme)

--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -5842,6 +5842,11 @@ static bool netplay_get_cmd(netplay_t *netplay,
                if (connection->mode != NETPLAY_CONNECTION_PLAYING)
                   break;
 
+               /* If the client does not honor our setting,
+                  refuse to globally pause. */
+               if (!netplay->allow_pausing)
+                  break;
+
                /* Inform peers */
                snprintf(msg, sizeof(msg),
                      msg_hash_to_str(MSG_NETPLAY_PEER_PAUSED),

--- a/tasks/task_netplay_nat_traversal.c
+++ b/tasks/task_netplay_nat_traversal.c
@@ -1,5 +1,6 @@
 /*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2017 - Gregor Richards
+ *  Copyright (C) 2021 - Roberto V. Rampim
  *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-


### PR DESCRIPTION
## Description

Prevents long-term pausing from clients dishonoring allow pausing.
Missing crediting.

## Related Issues

Older clients can still indefinitely pause a host's game, even if allow pausing is false.

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/13375

## Reviewers

@twinaphex 
