### PR TITLE
Buildfix for some platforms

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -264,10 +264,10 @@ OBJ += \
        tasks/task_manual_content_scan.o \
        tasks/task_core_backup.o \
        $(LIBRETRO_COMM_DIR)/encodings/encoding_utf.o \
-       $(LIBRETRO_COMM_DIR)/encodings/encoding_crc32.o
+       $(LIBRETRO_COMM_DIR)/encodings/encoding_crc32.o \
+       $(LIBRETRO_COMM_DIR)/encodings/encoding_base64.o
 
 ifeq ($(HAVE_TRANSLATE), 1)
-   OBJ += $(LIBRETRO_COMM_DIR)/encodings/encoding_base64.o
    OBJ += tasks/task_translation.o
 endif
 


### PR DESCRIPTION
## Description

Buildfix for some platforms that do not have HAVE_TRANSLATE defined aswell as platforms that define sockaddr_storage as sockaddr/sockaddr_in.

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/13375

## Reviewers

@twinaphex @m4xw 
