### PR TITLE
Fix incorrect file names for remap files when the content path doesn't t have a preceding slash.

### DIFF
--- a/libretro-common/file/file_path.c
+++ b/libretro-common/file/file_path.c
@@ -407,15 +407,29 @@ bool fill_pathname_parent_dir_name(char *out_dir,
       last      = find_last_slash(temp);
    }
 
+   /* Cut the last part of the string (the filename) after the slash,
+      leaving the directory name (or nested directory names) only. */
    if (last)
       *last     = '\0';
 
+   /* Point in_dir to the address of the last slash. */
    in_dir       = find_last_slash(temp);
+
+   /* If find_last_slash returns NULL, it means there was no slash in temp,
+      so use temp as-is. */
+   if (!in_dir)
+       in_dir   = temp;
 
    success      = in_dir && in_dir[1];
 
    if (success)
-      strlcpy(out_dir, in_dir + 1, size);
+   {
+       /* If path starts with an slash, eliminate it. */
+       if (path_is_absolute(in_dir))
+           strlcpy(out_dir, in_dir + 1, size);
+       else
+           strlcpy(out_dir, in_dir, size);
+   }
 
    free(temp);
    return success;


### PR DESCRIPTION
This fixes a bug where passing a content filename with no preceding slash would lead to a remap file being created with a nonsense filename.

For example, doing this and hitting "Save content directory remap file" would work, creating `~/.config/retroarch/config/remaps/Genesis\ Plus\ GX/sms.rmp`:

`retroarch -L ~/.config/retroarch/cores/genesis_plus_gx_libretro.so ./sms/alex.sms`

...but doing this and hitting "Save content directory remap file" would create a file in `~/.config/retroarch/config/remaps/Genesis\ Plus\ GX/` with a garbled filename:

`retroarch -L ~/.config/retroarch/cores/genesis_plus_gx_libretro.so sms/alex.sms`

This is because this would return `false` and everything would go downhill from there, leading to a garbled filename:

https://github.com/libretro/RetroArch/blob/77e202fbf78a9787b0da42d2cbfc00d2202ca0ec/libretro-common/file/file_path.c#L413
 
So, this fixes the issue, a long standing one for me. Yay!