### PR TITLE
fix memory map conversion

### DIFF
--- a/runloop.c
+++ b/runloop.c
@@ -2775,9 +2775,6 @@ bool runloop_environment_cb(unsigned cmd, void *data)
             if (!descriptors)
                return false;
 
-            if (log_level != RETRO_LOG_DEBUG)
-               break;
-
             system->mmaps.descriptors     = descriptors;
             system->mmaps.num_descriptors = mmaps->num_descriptors;
 
@@ -2785,6 +2782,9 @@ bool runloop_environment_cb(unsigned cmd, void *data)
                system->mmaps.descriptors[i].core = mmaps->descriptors[i];
 
             mmap_preprocess_descriptors(descriptors, mmaps->num_descriptors);
+
+            if (log_level != RETRO_LOG_DEBUG)
+               break;
 
             if (sizeof(void *) == 8)
                RARCH_LOG("           ndx flags  ptr              offset   start    select   disconn  len      addrspace\n");


### PR DESCRIPTION
## Description

#13370 added a [break](https://github.com/libretro/RetroArch/pull/13370/files#diff-3082ed9563ae0070650b649c04091334e4b144d8af21a52a81c405853ff738f2R2778-R2780) to abort early if logging was not verbose enough, but the break was too early.

## Related Issues

https://discord.com/channels/310192285306454017/353363923333808128/922586044879233124

## Related Pull Requests

n/a

## Reviewers

@Sanaki
