### PR TITLE
Added support for HDR shaders

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -416,10 +416,10 @@
 #define DEFAULT_VIDEO_HDR_ENABLE false
 
 /* The maximum nunmber of nits the actual display can show - needs to be calibrated */
-#define DEFAULT_VIDEO_HDR_MAX_NITS 1000.0f
+#define DEFAULT_VIDEO_HDR_MAX_NITS 700.0f
 
 /* The number of nits that paper white is at */
-#define DEFAULT_VIDEO_HDR_PAPER_WHITE_NITS 200.0f
+#define DEFAULT_VIDEO_HDR_PAPER_WHITE_NITS 400.0f
 
 /* The contrast setting for hdr used to calculate the display gamma by dividing this value by gamma 2.2  */
 #define DEFAULT_VIDEO_HDR_CONTRAST 5.0f

--- a/gfx/common/d3d12_common.c
+++ b/gfx/common/d3d12_common.c
@@ -405,7 +405,7 @@ bool d3d12_init_swapchain(d3d12_video_t* d3d12,
    d3d12->chain.back_buffer.desc.Width             = width;
    d3d12->chain.back_buffer.desc.Height            = height;
    d3d12->chain.back_buffer.desc.Format            = 
-      DXGI_FORMAT_R8G8B8A8_UNORM;
+      d3d12->shader_preset && d3d12->shader_preset->passes ? glslang_format_to_dxgi(d3d12->pass[d3d12->shader_preset->passes - 1].semantics.format) : DXGI_FORMAT_R8G8B8A8_UNORM;
    d3d12->chain.back_buffer.desc.Flags             = 
       D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
    d3d12->chain.back_buffer.srv_heap               = 

--- a/gfx/common/dxgi_common.h
+++ b/gfx/common/dxgi_common.h
@@ -24,7 +24,8 @@ typedef struct ALIGN(16)
    float             paper_white_nits; /* 200.0f  */
    float             max_nits;         /* 1000.0f */
    float             expand_gamut;     /* 1.0f    */
-   float             inverse_tonemap; /* 1.0f    */
+   float             inverse_tonemap;  /* 1.0f    */
+   float             hdr10;            /* 1.0f    */
 } dxgi_hdr_uniform_t;
 
 enum dxgi_swapchain_bit_depth


### PR DESCRIPTION
Added support for HDR shaders - if we detect a shader that uses SLANG_FORMAT_A2B10G10R10_UNORM_PACK32 or SLANG_FORMAT_R16G16B16A16_SFLOAT as the format for the last render target in the shader chain AND hdr is switched on then this disables the internal HDR shader and allows the shader chain to define an inverse tonemapper and hdr10 shader. The first use of this is for my hdr shader crt\crt-sony-pvm-4k-hdr.slangp - submitted separately in the slang_shaders repository.

## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

if we detect a shader that uses SLANG_FORMAT_A2B10G10R10_UNORM_PACK32 or SLANG_FORMAT_R16G16B16A16_SFLOAT as the format for the last render target in the shader chain AND hdr is switched on then this disables the internal HDR shader and allows the shader chain to define an inverse tonemapper and hdr10 shader. The first use of this is for my hdr shader crt\crt-sony-pvm-4k-hdr.slangp - submitted separately in the slang_shaders repository.

## Related Issues

A long lasting request to allow people to add their own inverse tonemapper

## Related Pull Requests

Not sure of the number but the pull request that added support for HDR

## Reviewers

