### PR TITLE
Move roms copied to localstate to a dedicated dir and clear on start up [XBOX/UWP]

### DIFF
--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -1053,8 +1053,6 @@ static bool content_file_load(
                // I am genuinely really proud of these work arounds
                wchar_t wcontent_path[MAX_PATH];
                mbstowcs(wcontent_path, content_path, MAX_PATH);
-               wchar_t wuwp_dir_data[MAX_PATH];
-               mbstowcs(wuwp_dir_data, uwp_dir_data, MAX_PATH);
                uwp_set_acl(wcontent_path, L"S-1-15-2-1");
                if (!is_path_accessible_using_standard_io(content_path))
                {
@@ -1080,6 +1078,15 @@ static bool content_file_load(
                         "but cache directory was not set or found. "
                         "Setting cache directory to root of writable app directory...\n");
                      strlcpy(new_basedir, uwp_dir_data, sizeof(new_basedir));
+                     strcat(new_basedir, "VFSCACHE\\");
+                     DWORD dwAttrib = GetFileAttributes(new_basedir);
+                     if ((dwAttrib == INVALID_FILE_ATTRIBUTES) || (!(dwAttrib & FILE_ATTRIBUTE_DIRECTORY)))
+                     {
+                        if (!CreateDirectoryA(new_basedir, NULL))
+                        {
+                           strlcpy(new_basedir, uwp_dir_data, sizeof(new_basedir));
+                        }
+                     }
                   }
                   fill_pathname_join(new_path, new_basedir,
                      path_basename(content_path), sizeof(new_path));


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description
Roms copied to the app's localstate folder are moved to a dedicated folder called VFSCACHE rather than just being dumped in the root of the localstate folder. This also means that this folder can be cleared on start up in order to avoid taking up extraneous amounts of space.

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
