### PR TITLE
[Wayland] Fix window title update

### DIFF
--- a/gfx/drivers_context/wayland_ctx.c
+++ b/gfx/drivers_context/wayland_ctx.c
@@ -249,13 +249,12 @@ static void gfx_ctx_wl_update_title(void *data)
    if (wl && title[0])
    {
       if (wl->deco)
-         {
-            zxdg_toplevel_decoration_v1_set_mode(wl->deco,
-                  ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE);
-         }
+      {
+         zxdg_toplevel_decoration_v1_set_mode(wl->deco,
+            ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE);
       }
-
       xdg_toplevel_set_title(wl->xdg_toplevel, title);
+   }
 }
 
 static bool gfx_ctx_wl_get_metrics(void *data,


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

Wayland was updating the title to a null string every frame.
Is there a reason this project uses 3 spaces for indent? I feel like it forces error.

## Related Issues

None probably

## Related Pull Requests

None

## Reviewers

