### PR TITLE
fix netplay UPNP binding for specific router behavior

### DIFF
--- a/libretro-common/formats/xml/rxml.c
+++ b/libretro-common/formats/xml/rxml.c
@@ -197,6 +197,7 @@ rxml_document_t *rxml_load_document_string(const char *str)
             node->name                     = strdup(x.elem);
 
             attr                           = NULL;
+            valptr                         = buf->val;
 
             ++level;
             break;

--- a/libretro-common/net/net_http.c
+++ b/libretro-common/net/net_http.c
@@ -922,7 +922,7 @@ bool net_http_update(struct http_t *state, size_t* progress, size_t* total)
             if (string_starts_with_case_insensitive(state->data, "Content-Length:"))
             {
                char* ptr = state->data + STRLEN_CONST("Content-Length:");
-               while (isspace(*ptr))
+               while (ISSPACE(*ptr))
                   ++ptr;
 
                state->bodytype = T_LEN;

--- a/libretro-common/net/net_http.c
+++ b/libretro-common/net/net_http.c
@@ -919,11 +919,14 @@ bool net_http_update(struct http_t *state, size_t* progress, size_t* total)
          }
          else
          {
-            if (string_starts_with_case_insensitive(state->data, "Content-Length: "))
+            if (string_starts_with_case_insensitive(state->data, "Content-Length:"))
             {
+               char* ptr = state->data + STRLEN_CONST("Content-Length:");
+               while (isspace(*ptr))
+                  ++ptr;
+
                state->bodytype = T_LEN;
-               state->len = strtol(state->data +
-                     STRLEN_CONST("Content-Length: "), NULL, 10);
+               state->len = strtol(ptr, NULL, 10);
             }
             if (string_is_equal_case_insensitive(state->data, "Transfer-Encoding: chunked"))
                state->bodytype = T_CHUNK;


### PR DESCRIPTION
## Description

Fixes a couple library issues found while trying to diagnose why my router wasn't working with UPNP after removing miniupnp.

1) the rxml parser is capturing whitespace between elements:
```
<service>
<serviceType>urn:schemas-upnp-org:service:WANIPConnection:1</serviceType>
<serviceId>urn:upnp-org:serviceId:WANIPConn1</serviceId>
<SCPDURL>/Public_UPNP_WANIPConn.xml</SCPDURL>
<controlURL>/Public_UPNP_C3</controlURL>
<eventSubURL>/Public_UPNP_Event_3</eventSubURL>
</service>
```
Because these elements are nested within the `<service>` element, the newline between each element is added to the value buffer as content for the `<service>` element. The buffer was not being reset upon encountering the nested element, so the value captured for "controlURL" was "`\n/Public_UPNP_C3`". I've modified the code to also reset the buffer when encountering a new element.

2) The http processing code was expecting a space between the header and value when identifying the Content-Length header. My router was not including that space, so the response was discarded as invalid as more data was received than expected.

```
HTTP/1.1 2
CONTENT-TYPE:text/xml; charset="utf-8"
EXT:
SERVER:Linux/2.6.12 UPnP/1.0 NETGEAR-UPNP/1.0
CONTENT-LENGTH:371
```

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@Cthulhu-throwaway @twinaphex 
