### PR TITLE
Make resolution switching automatic and fix angle output issues [UWP/XBOX]

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -2126,8 +2126,13 @@ static struct config_uint_setting *populate_settings_uint(
    SETTING_UINT("keyboard_gamepad_mapping_type",&settings->uints.input_keyboard_gamepad_mapping_type, true, 1, false);
    SETTING_UINT("input_poll_type_behavior",     &settings->uints.input_poll_type_behavior, true, 2, false);
    SETTING_UINT("video_monitor_index",          &settings->uints.video_monitor_index, true, DEFAULT_MONITOR_INDEX, false);
-   SETTING_UINT("video_fullscreen_x",           &settings->uints.video_fullscreen_x,  true, DEFAULT_FULLSCREEN_X, false);
-   SETTING_UINT("video_fullscreen_y",           &settings->uints.video_fullscreen_y,  true, DEFAULT_FULLSCREEN_Y, false);
+#ifdef __WINRT__
+   SETTING_UINT("video_fullscreen_x", &settings->uints.video_fullscreen_x, true, uwp_get_width(), false);
+   SETTING_UINT("video_fullscreen_y", &settings->uints.video_fullscreen_y, true, uwp_get_height(), false);
+#else
+   SETTING_UINT("video_fullscreen_x", &settings->uints.video_fullscreen_x, true, DEFAULT_FULLSCREEN_X, false);
+   SETTING_UINT("video_fullscreen_y", &settings->uints.video_fullscreen_y, true, DEFAULT_FULLSCREEN_Y, false);
+#endif
    SETTING_UINT("video_window_opacity",         &settings->uints.video_window_opacity, true, DEFAULT_WINDOW_OPACITY, false);
 #ifdef HAVE_VIDEO_LAYOUT
    SETTING_UINT("video_layout_selected_view",   &settings->uints.video_layout_selected_view, true, 0, false);

--- a/gfx/drivers/gl2.c
+++ b/gfx/drivers/gl2.c
@@ -4000,6 +4000,14 @@ static bool gl2_alive(void *data)
    gl->ctx_driver->check_window(gl->ctx_data,
          &quit, &resize, &temp_width, &temp_height);
 
+#ifdef __WINRT__
+   if (is_running_on_xbox())
+   {
+      //we can set it to 1920x1080 as xbox uwp windowsize is guaranteed to be 1920x1080 and currently there is now way to set angle to use a variable resolution swapchain so regardless of the size the window is always 1080p
+      temp_width = 1920;
+      temp_height = 1080;
+   }
+#endif
    if (quit)
       gl->quitting = true;
    else if (resize)

--- a/gfx/drivers/gl3.c
+++ b/gfx/drivers/gl3.c
@@ -54,6 +54,7 @@
 #include "../gfx_widgets.h"
 #endif
 
+
 static const struct video_ortho gl3_default_ortho = {0, 1, 0, 1, -1, 1};
 
 void gl3_build_default_matrix(float *data)
@@ -1564,6 +1565,15 @@ static bool gl3_alive(void *data)
 
    gl->ctx_driver->check_window(gl->ctx_data,
          &quit, &resize, &temp_width, &temp_height);
+
+#ifdef __WINRT__
+   if (is_running_on_xbox())
+   {
+      //we can set it to 1920x1080 as xbox uwp windowsize is guaranteed to be 1920x1080 and currently there is now way to set angle to use a variable resolution swapchain so regardless of the size the window is always 1080p
+      temp_width = 1920;
+      temp_height = 1080;
+   }
+#endif
 
    if (quit)
       gl->quitting = true;

--- a/gfx/drivers_context/uwp_egl_ctx.c
+++ b/gfx/drivers_context/uwp_egl_ctx.c
@@ -146,6 +146,12 @@ static void gfx_ctx_uwp_get_video_size(void *data,
    bool quit;
    bool resize;
    win32_check_window(NULL, &quit, &resize, width, height);
+   if (is_running_on_xbox())
+   {
+      //we can set it to 1920x1080 as xbox uwp windowsize is guaranteed to be 1920x1080 and currently there is now way to set angle to use a variable resolution swapchain so regardless of the size the window is always 1080p
+      width = 1920;
+      height = 1080;
+   }
 }
 
 static void *gfx_ctx_uwp_init(void *video_driver)

--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -3305,8 +3305,8 @@ bool video_driver_init_internal(bool *video_is_threaded, bool verbosity_enabled)
 #ifdef __WINRT__
       if (is_running_on_xbox())
       {
-         width  = settings->uints.video_fullscreen_x != 0 ? settings->uints.video_fullscreen_x : 3840;
-         height = settings->uints.video_fullscreen_y != 0 ? settings->uints.video_fullscreen_y : 2160;
+         width = uwp_get_width();
+         height = uwp_get_height();
       }
       else
 #endif

--- a/uwp/uwp_func.h
+++ b/uwp/uwp_func.h
@@ -30,6 +30,8 @@ void uwp_open_broadfilesystemaccess_settings(void);
 
 void* uwp_get_corewindow(void);
 
+bool is_running_on_xbox(void);
+
 int uwp_get_height(void);
 int uwp_get_width(void);
 

--- a/uwp/uwp_func.h
+++ b/uwp/uwp_func.h
@@ -30,6 +30,9 @@ void uwp_open_broadfilesystemaccess_settings(void);
 
 void* uwp_get_corewindow(void);
 
+int uwp_get_height(void);
+int uwp_get_width(void);
+
 void uwp_input_next_frame(void *data);
 bool uwp_keyboard_pressed(unsigned key);
 int16_t uwp_mouse_state(unsigned port, unsigned id, bool screen);

--- a/uwp/uwp_main.cpp
+++ b/uwp/uwp_main.cpp
@@ -667,10 +667,10 @@ extern "C" {
 		switch (type)
 		{
 		   case DISPLAY_METRIC_PIXEL_WIDTH:
-		      *value                 = DisplayInformation::GetForCurrentView()->ScreenWidthInRawPixels;
+		      *value                 = uwp_get_width();
 		      return true;
 		case DISPLAY_METRIC_PIXEL_HEIGHT:
-		      *value                 = DisplayInformation::GetForCurrentView()->ScreenHeightInRawPixels;
+			  *value				 = uwp_get_height();
 		      return true;
 		case DISPLAY_METRIC_MM_WIDTH:
 		      /* 25.4 mm in an inch. */
@@ -709,8 +709,8 @@ extern "C" {
 		if (is_xbox)
 		{
 			settings_t* settings = config_get_ptr();
-			*width  = settings->uints.video_fullscreen_x  != 0 ? settings->uints.video_fullscreen_x : 3840;
-			*height = settings->uints.video_fullscreen_y  != 0 ? settings->uints.video_fullscreen_y : 2160;
+			*width  = settings->uints.video_fullscreen_x  != 0 ? settings->uints.video_fullscreen_x : uwp_get_width();
+			*height = settings->uints.video_fullscreen_y  != 0 ? settings->uints.video_fullscreen_y : uwp_get_height();
 			return;
 		}
 
@@ -726,6 +726,32 @@ extern "C" {
 	void* uwp_get_corewindow(void)
 	{
 		return (void*)CoreWindow::GetForCurrentThread();
+	}
+
+	int uwp_get_height(void)
+	{
+		if (is_running_on_xbox())
+		{
+			const Windows::Graphics::Display::Core::HdmiDisplayInformation^ hdi = Windows::Graphics::Display::Core::HdmiDisplayInformation::GetForCurrentView();
+			if (hdi)
+				return Windows::Graphics::Display::Core::HdmiDisplayInformation::GetForCurrentView()->GetCurrentDisplayMode()->ResolutionHeightInRawPixels;
+		}
+		const LONG32 resolution_scale = static_cast<LONG32>(Windows::Graphics::Display::DisplayInformation::GetForCurrentView()->ResolutionScale);
+		auto surface_scale = static_cast<float>(resolution_scale) / 100.0f;
+		return static_cast<LONG32>(CoreWindow::GetForCurrentThread()->Bounds.Height * surface_scale);
+	}
+
+	int uwp_get_width(void)
+	{
+		if (is_running_on_xbox())
+		{
+			const Windows::Graphics::Display::Core::HdmiDisplayInformation^ hdi = Windows::Graphics::Display::Core::HdmiDisplayInformation::GetForCurrentView();
+			if (hdi)
+				return Windows::Graphics::Display::Core::HdmiDisplayInformation::GetForCurrentView()->GetCurrentDisplayMode()->ResolutionWidthInRawPixels;
+		}
+		const LONG32 resolution_scale = static_cast<LONG32>(Windows::Graphics::Display::DisplayInformation::GetForCurrentView()->ResolutionScale);
+		auto surface_scale = static_cast<float>(resolution_scale) / 100.0f;
+		return static_cast<LONG32>(CoreWindow::GetForCurrentThread()->Bounds.Width * surface_scale);
 	}
 
 	void uwp_fill_installed_core_packages(struct string_list *list)

--- a/uwp/uwp_main.cpp
+++ b/uwp/uwp_main.cpp
@@ -218,7 +218,6 @@ int main(Platform::Array<Platform::String^>^)
 	Platform::String^ data_dir = Windows::Storage::ApplicationData::Current->LocalFolder->Path + L"\\";
 	wcstombs(uwp_dir_data, data_dir->Data(), sizeof(uwp_dir_data));
 
-
 	// delete vfs cache dir, we do this because this allows a far far more consise implementation than manually implementing a function to do this
 	// this may be a little slower but shouldn't really matter as the cache dir should never have more than a few items
 	Platform::String^ vfs_dir = Windows::Storage::ApplicationData::Current->LocalFolder->Path + L"\\VFSCACHE";
@@ -336,6 +335,22 @@ void App::Load(Platform::String^ entryPoint)
 		return;
 	}
 	m_initialized = true;
+
+	if (is_running_on_xbox())
+	{
+		//reset driver to d3d11 if set to opengl on boot as cores can just set to gl when needed and there is no good reason to use gl for the menus
+		settings_t* settings = config_get_ptr();
+		char* currentdriver = settings->arrays.video_driver;
+		if (strcmpi(currentdriver, "gl")==0)
+		{
+			//set driver to default
+			configuration_set_string(settings,
+				settings->arrays.video_driver,
+				config_get_default_video());
+			//restart driver
+			command_event(CMD_EVENT_REINIT, NULL);
+		}
+	}
 
 	auto catalog = Windows::ApplicationModel::PackageCatalog::OpenForCurrentPackage();
 

--- a/uwp/uwp_main.cpp
+++ b/uwp/uwp_main.cpp
@@ -338,6 +338,9 @@ void App::Load(Platform::String^ entryPoint)
 
 	if (is_running_on_xbox())
 	{
+		bool reset = false;
+		int width = uwp_get_width();
+		int height = uwp_get_height();
 		//reset driver to d3d11 if set to opengl on boot as cores can just set to gl when needed and there is no good reason to use gl for the menus
 		settings_t* settings = config_get_ptr();
 		char* currentdriver = settings->arrays.video_driver;
@@ -347,9 +350,27 @@ void App::Load(Platform::String^ entryPoint)
 			configuration_set_string(settings,
 				settings->arrays.video_driver,
 				config_get_default_video());
+			//reset needed
+			reset = true;
+		}
+		if ((settings->uints.video_fullscreen_x != width) || (settings->uints.video_fullscreen_y != height))
+		{
+			//get width and height from display again
+			configuration_set_int(settings,
+				settings->uints.video_fullscreen_x,
+				width);
+			configuration_set_int(settings,
+				settings->uints.video_fullscreen_y,
+				height);
+			//reset needed
+			reset = true;
+		}
+		if (reset)
+		{
 			//restart driver
 			command_event(CMD_EVENT_REINIT, NULL);
 		}
+		
 	}
 
 	auto catalog = Windows::ApplicationModel::PackageCatalog::OpenForCurrentPackage();


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

Fix an issue where if the resolution was set to anything other than 1080p window scale for angle would be broken. This was due to the fact that the output resolution was locked to 1080p so rendering at 4k would lead to it being zoomed into one corner of the screen. The output is still locked to 1080p but it now also renders at 1080p

Set resolution based on display on app start up (This makes 4k / resolution switching automatic).

If the app starts with opengl reset it to d3d11 as there is no scenario in which the user should be using opengl/angle in the menus.

This was tested by @gamr13 as well as sigare

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
