### PR TITLE
(Wayland) Use any display for initial metrics

### DIFF
--- a/gfx/drivers_context/wayland_vk_ctx.c
+++ b/gfx/drivers_context/wayland_vk_ctx.c
@@ -109,8 +109,21 @@ static void gfx_ctx_wl_get_video_size(void *data,
 {
    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
 
-   *width  = wl->width  * wl->buffer_scale;
-   *height = wl->height * wl->buffer_scale;
+   if (wl->surface == NULL) {
+      output_info_t *oi, *tmp;
+      oi = wl->current_output;
+
+      // If window is not ready get any monitor
+      if (!oi)
+          wl_list_for_each_safe(oi, tmp, &wl->all_outputs, link)
+              break;
+
+      *width  = oi->width;
+      *height = oi->height;
+   } else {
+      *width  = wl->width  * wl->buffer_scale;
+      *height = wl->height * wl->buffer_scale;
+   }
 }
 
 static void gfx_ctx_wl_destroy_resources(gfx_ctx_wayland_data_t *wl)
@@ -264,21 +277,26 @@ static bool gfx_ctx_wl_get_metrics(void *data,
 {
    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
 
-   if (!wl || !wl->current_output || wl->current_output->physical_width == 0 || wl->current_output->physical_height == 0)
-      return false;
+   output_info_t *oi, *tmp;
+   oi = wl->current_output;
+
+   if (!oi)
+      wl_list_for_each_safe(oi, tmp, &wl->all_outputs, link)
+         break;
 
    switch (type)
    {
       case DISPLAY_METRIC_MM_WIDTH:
-         *value = (float)wl->current_output->physical_width;
+         *value = (float)oi->physical_width;
          break;
 
       case DISPLAY_METRIC_MM_HEIGHT:
-         *value = (float)wl->current_output->physical_height;
+         *value = (float)oi->physical_height;
          break;
 
       case DISPLAY_METRIC_DPI:
-         *value = (float)wl->current_output->width * 25.4f / (float)wl->current_output->physical_width;
+         *value = (float)oi->width * 25.4f /
+                  (float)oi->physical_width;
          break;
 
       default:


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

The UI is scaled incorrectly until the window is resized.
This is because we don't know which monitor the window will be placed on before it is created.
This MR returns metrics for the first enumerated display (`wl_output`) until the window has been created.

## Related Issues


## Related Pull Requests


## Reviewers

