### PR TITLE
(Audio Mixer) audio_mix.c does not require stdio.h

### DIFF
--- a/libretro-common/audio/audio_mix.c
+++ b/libretro-common/audio/audio_mix.c
@@ -20,7 +20,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <memalign.h>


### PR DESCRIPTION
This change removes the inclusion of stdio.h as it's not needed in this file.