### PR TITLE
 Revert default HDR settings as it broke the stock shader with HDR

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -425,10 +425,10 @@
 #define DEFAULT_VIDEO_HDR_ENABLE false
 
 /* The maximum nunmber of nits the actual display can show - needs to be calibrated */
-#define DEFAULT_VIDEO_HDR_MAX_NITS 700.0f
+#define DEFAULT_VIDEO_HDR_MAX_NITS 1000.0f
 
 /* The number of nits that paper white is at */
-#define DEFAULT_VIDEO_HDR_PAPER_WHITE_NITS 400.0f
+#define DEFAULT_VIDEO_HDR_PAPER_WHITE_NITS 200.0f
 
 /* The contrast setting for hdr used to calculate the display gamma by dividing this value by gamma 2.2  */
 #define DEFAULT_VIDEO_HDR_CONTRAST 5.0f


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

Revert default HDR settings as it broke the stock shader with HDR (and managed to revert the automated crowdin commit)

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers
@DisasterMo Hopefully this reverts the crowdin change - I wasn't quite sure where it came from to be honest
