### PR TITLE
(Vulkan) Emulate mailbox only with vsync

### DIFF
--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -2907,6 +2907,7 @@ bool vulkan_create_swapchain(gfx_ctx_vulkan_data_t *vk,
    VkPresentModeKHR swapchain_present_mode = VK_PRESENT_MODE_FIFO_KHR;
    settings_t                    *settings = config_get_ptr();
    VkCompositeAlphaFlagBitsKHR composite   = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
+   bool vsync                              = settings->bools.video_vsync;
 
    vkDeviceWaitIdle(vk->context.device);
    vulkan_acquire_clear_fences(vk);
@@ -2919,7 +2920,7 @@ bool vulkan_create_swapchain(gfx_ctx_vulkan_data_t *vk,
        !surface_properties.currentExtent.height)
       return false;
 
-   if (swap_interval == 0 && vk->emulate_mailbox)
+   if (swap_interval == 0 && vk->emulate_mailbox && vsync)
    {
       swap_interval          = 1;
       vk->emulating_mailbox  = true;


### PR DESCRIPTION
## Description

Allow mailbox emulation on Windows only when vsync is enabled. This should remove the need of creating a separate option for it, and fixes the framerate halving when vsync is disabled.
