### PR TITLE
(cheevos) report Unknown Game instead of Not Logged In when no hash is generated

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -1581,6 +1581,14 @@ static bool rcheevos_identify_game(const struct retro_game_info* info)
    size_t len;
    char hash[33];
 
+#ifndef HAVE_CHD
+   if (string_is_equal_noncase(path_get_extension(info->path), "chd"))
+   {
+      CHEEVOS_LOG(RCHEEVOS_TAG "CHD not supported without HAVE_CHD compile flag\n");
+      return false;
+   }
+#endif
+
    rc_hash_initialize_iterator(&iterator,
          info->path, (uint8_t*)info->data, info->size);
    if (!rc_hash_iterate(hash, &iterator))
@@ -1802,6 +1810,7 @@ bool rcheevos_load(const void *data)
    {
       /* No hashes could be generated for the game, 
        * disable hardcore and bail */
+      rcheevos_locals.game.id = 0;
       rcheevos_end_load_state();
       rcheevos_pause_hardcore();
       return false;


### PR DESCRIPTION
## Description

When a hash cannot be generated for game, we don't try to log in the RetroAchievements user. When the user tries to view the Achievements for the game, they'll see a "Not Logged In" message. It's much more informative to display an "Unknown Game" message.

Additionally, aborts game identification and logs an error message for CHDs if HAVE_CHD is not defined. I considered making it an on-screen message, but couldn't come up with a good way to tell users that they needed a different set of compilation flags.

## Related Issues

#13430

## Related Pull Requests

n/a

## Reviewers

[If possible @mention all the people that should review your pull request]
