### PR TITLE
(AI Service) Disable AI Service by default

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -1628,7 +1628,7 @@ static const bool enable_device_vibration    = false;
 
 #define DEFAULT_AI_SERVICE_TARGET_LANG 0
 
-#define DEFAULT_AI_SERVICE_ENABLE true
+#define DEFAULT_AI_SERVICE_ENABLE false
 
 #define DEFAULT_AI_SERVICE_PAUSE false
 


### PR DESCRIPTION
Currently, the AI Service is enabled by default. In the majority of RetroArch installs, users won't be using the AI Service. Given this, it would make sense to have the AI Service disabled by default.