### PR TITLE
(Vulkan) Double combined image sampler descriptor pool size

### DIFF
--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -668,7 +668,7 @@ static void vulkan_init_descriptor_pool(vk_t *vk)
    unsigned i;
    static const VkDescriptorPoolSize pool_sizes[2] = {
       { VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, VULKAN_DESCRIPTOR_MANAGER_BLOCK_SETS },
-      { VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VULKAN_DESCRIPTOR_MANAGER_BLOCK_SETS },
+      { VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VULKAN_DESCRIPTOR_MANAGER_BLOCK_SETS * 2 },
    };
 
    for (i = 0; i < vk->num_swapchain_images; i++)


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description


On linux with an AMD gpu, using RADV I'm getting segfaults since #13456.

gdb says that the crash is happening in `radv_update_descriptor_sets` resulting from the call to `vulkan_write_quad_descriptors` listed below.

https://github.com/libretro/RetroArch/blob/aa642e5786c8483dc36ee8900cdfc64fae0769d2/gfx/common/vulkan_common.c#L989-L1000

It appears the 9th call to `vulkan_descriptor_manager_alloc` returns a null pointer. This is around half of `VULKAN_DESCRIPTOR_MANAGER_BLOCK_SETS` regardless of what it is set to.

I assume it's due to the addition of a second `VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER`

https://github.com/libretro/RetroArch/blob/1a228a4e789b00bb9eb1237286b5a0a9cfbc7f7f/gfx/drivers/vulkan.c#L204-L208

This MR sets the pool size for  `VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER` to double `VULKAN_DESCRIPTOR_MANAGER_BLOCK_SETS`. Though quadrupling `VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER` also "fixes" the problem.

I don't fully understand any of this, seems to fix the problem.

## Related Issues

## Related Pull Requests

#13456

## Reviewers

@MajorPainTheCactus
