### PR TITLE
Update Emscripten Docs a bit, Pthreads support in emscripten, Add flag for asset warnings

### DIFF
--- a/Makefile.emscripten
+++ b/Makefile.emscripten
@@ -9,10 +9,9 @@ endif
 EOPT = USE_ZLIB=1 # Emscripten specific options
 EOPTS = $(addprefix -s $(EMPTY), $(EOPT)) # Add '-s ' to each option
 
-PTHREAD = 0
 OS = Emscripten
 OBJ :=
-DEFINES := -DRARCH_INTERNAL -DHAVE_MAIN -s USE_PTHREADS=$(PTHREAD)
+DEFINES := -DRARCH_INTERNAL -DHAVE_MAIN
 DEFINES += -DHAVE_FILTERS_BUILTIN
 
 HAVE_DSP_FILTER = 1
@@ -43,6 +42,7 @@ HAVE_CONFIGFILE = 1
 HAVE_CHEATS = 1
 HAVE_IBXM = 1
 HAVE_CORE_INFO_CACHE = 1
+HAVE_ASSET_WARNING = 1
 
 ASYNC ?= 0
 ifeq ($(LIBRETRO), mupen64plus)
@@ -68,8 +68,9 @@ LDFLAGS := -L. --no-heap-copy -s $(LIBS) -s TOTAL_MEMORY=$(MEMORY) -s NO_EXIT_RU
            --js-library emscripten/library_rwebaudio.js \
            --js-library emscripten/library_rwebcam.js \
            --js-library emscripten/library_errno_codes.js
+
 ifneq ($(PTHREAD), 0)
-   LDFLAGS += -s USE_PTHREADS=$(PTHREAD) -s PTHREAD_POOL_SIZE=2
+   LDFLAGS += -s WASM_MEM_MAX=1073741824 -pthread -s PTHREAD_POOL_SIZE=$(PTHREAD) 
 endif
 
 ifeq ($(ASYNC), 1)
@@ -80,6 +81,10 @@ ifeq ($(HAVE_SDL2), 1)
    LIBS += -s USE_SDL=2
    DEFINES += -DHAVE_SDL2
 endif
+
+ifneq ($(HAVE_ASSET_WARNING), 1)
+   DEFINES += -DNO_MISSING_ASSET_WARNING
+endif 
 
 include Makefile.common
 

--- a/dist-scripts/dist-cores.sh
+++ b/dist-scripts/dist-cores.sh
@@ -200,7 +200,7 @@ for f in `ls -v *_${platform}.${EXT}`; do
    echo Buildbot: building ${name} for ${platform}
    name=`echo "$f" | sed "s/\(_libretro_${platform}\|\).${EXT}$//"`
    async=0
-   pthread=0
+   pthread=${pthread:-0}
    lto=0
    whole_archive=
    big_stack=
@@ -313,7 +313,7 @@ for f in `ls -v *_${platform}.${EXT}`; do
       mv -f ../${name}_libretro.js ../pkg/emscripten/${name}_libretro.js
       mv -f ../${name}_libretro.wasm ../pkg/emscripten/${name}_libretro.wasm
       if [ $pthread != 0 ] ; then
-         mv -f ../pthread-main.js ../pkg/emscripten/pthread-main.js
+         mv -f ../${name}_libretro.worker.js ../pkg/emscripten/${name}_libretro.worker.js
       fi
    fi
 

--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -2355,10 +2355,12 @@ static void materialui_context_reset_textures(materialui_handle_t *mui)
    }
 
    /* Warn user if assets are missing */
+#ifndef NO_MISSING_ASSET_WARNING
    if (!has_all_assets)
       runloop_msg_queue_push(
             msg_hash_to_str(MSG_MISSING_ASSETS), 1, 256, false, NULL,
             MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
+#endif
 }
 
 static void materialui_draw_icon(

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -7693,8 +7693,10 @@ static void ozone_context_reset(void *data, bool is_threaded)
       ozone->animations.list_alpha     = 1.0f;
 
       /* Missing assets message */
+#ifndef NO_MISSING_ASSET_WARNING
       if (!ozone->has_all_assets)
          runloop_msg_queue_push(msg_hash_to_str(MSG_MISSING_ASSETS), 1, 256, false, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
+#endif
 
       /* Thumbnails */
       ozone_update_thumbnail_image(ozone);

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -6348,7 +6348,9 @@ static void xmb_context_reset_textures(
                   && !(settings->uints.menu_xmb_theme == XMB_ICON_THEME_CUSTOM)
                )
             {
+#ifndef NO_MISSING_ASSET_WARNING
                runloop_msg_queue_push(msg_hash_to_str(MSG_MISSING_ASSETS), 1, 256, false, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
+#endif
                /* Do not draw icons if subsetting is missing */
                goto error;
             }

--- a/pkg/emscripten/README.md
+++ b/pkg/emscripten/README.md
@@ -92,7 +92,7 @@ Build and move output to the frontend:
 
 ```
 emmake make -f Makefile platform=emscripten
-cp fceumm_libretro_emscripten.bc ~/retroarch/RetroArch/dist-scripts/fceumm_libretro_emscripten.bc
+cp melonds_libretro_emscripten.bc ~/retroarch/RetroArch/dist-scripts/melonds_libretro_emscripten.bc
 ```
 
 Now build the frontend with the pthreads env variable: (2 is the number of workers this can be any integer)

--- a/pkg/emscripten/README.md
+++ b/pkg/emscripten/README.md
@@ -4,7 +4,19 @@ The RetroArch Web Player is RetroArch compiled through [Emscripten](http://kripk
 
 ## Compiling
 
-To compile RetroArch with Emscripten, you'll first have to [download and install the Emscripten SDK](http://kripken.github.io/emscripten-site/docs/getting_started/downloads.html). Once it's loaded in your shell, you'll run something like the following...
+To compile RetroArch with Emscripten, you'll first have to [download and install the Emscripten SDK](http://kripken.github.io/emscripten-site/docs/getting_started/downloads.html) at 1.39.5:
+
+```
+git clone https://github.com/emscripten-core/emsdk.git
+cd emsdk
+./emsdk install 1.39.5
+./emsdk activate 1.39.5
+source emsdk_env.sh
+```
+
+Other later versions of emsdk will function and may be needed (like Async support), but in general emscripten is in a constant state of development and you may run into other problems by not pinning to 1.39.5. This is currently the version [https://web.libretro.com/](https://web.libretro.com/) is built against.
+
+After emsdk is installed you will need to build an emulator core, move that output into Retroarch, and use helper scripts to produce web ready assets, in this example we will be building [https://github.com/libretro/libretro-fceumm](https://github.com/libretro/libretro-fceumm):
 
 ```
 mkdir ~/retroarch
@@ -16,6 +28,13 @@ git clone https://github.com/libretro/RetroArch.git ~/retroarch/RetroArch
 cp ~/retroarch/libretro-fceumm/fceumm_libretro_emscripten.bc ~/retroarch/RetroArch/dist-scripts/fceumm_libretro_emscripten.bc
 cd ~/retroarch/RetroArch/dist-scripts
 emmake ./dist-cores.sh emscripten
+```
+
+The resulting build output will be located in `~/retroarch/RetroArch/pkg/emscripten` as:
+
+```
+fceumm_libretro.js
+fceumm_libretro.wasm
 ```
 
 ## Usage
@@ -40,3 +59,74 @@ cd ${ROOT_WWW_PATH}/assets/cores
 ```
 
 That should be it, you can add more cores to the list by editing index.html
+
+# Threaded emulators
+
+Some emulators can be compiled with `pthreads` support to increase performance. You will need to compile the core and frontend with special flags to support this and also serve the content from an HTTPS endpoint with specific headers.
+
+## Compiling the code (Threaded)
+
+In this example we will be building [melonDS](https://github.com/libretro/melonDS) with pthreads support. We assume you allready have emsdk setup and are familiar with the build process.
+
+First clone the repo:
+
+```
+git clone https://github.com/libretro/melonDS.git
+cd melonDS
+```
+
+Next modify the Makefile to enable threads:
+
+```
+else ifeq ($(platform), emscripten)
+   TARGET := $(TARGET_NAME)_libretro_emscripten.bc
+   fpic := -fPIC
+   SHARED := -shared -Wl,--version-script=$(CORE_DIR)/link.T -Wl
+   HAVE_THREADS = 1
+   CFLAGS += -pthread
+   LDFLAGS += -pthread
+   CXXFLAGS += -pthread
+```
+
+Build and move output to the frontend:
+
+```
+emmake make -f Makefile platform=emscripten
+cp fceumm_libretro_emscripten.bc ~/retroarch/RetroArch/dist-scripts/fceumm_libretro_emscripten.bc
+```
+
+Now build the frontend with the pthreads env variable: (2 is the number of workers this can be any integer)
+
+```
+cd ~/retroarch/RetroArch/dist-scripts
+pthread=2 emmake ./dist-cores.sh emscripten
+```
+
+Your resulting output will be located in:
+
+```
+~/retroarch/RetroArch/pkg/emscripten/melonds_libretro.js
+~/retroarch/RetroArch/pkg/emscripten/melonds_libretro.wasm
+~/retroarch/RetroArch/pkg/emscripten/melonds_libretro.worker.js
+```
+
+## Setting up your webserver (Threaded)
+
+Unless loading from `localhost` you will need to server the content from an HTTPS endpoint with a valid SSL certificate. This is a security limitation imposed by the browser. Along with that you will need to set content control policies with special headers in your server: 
+
+In Nodejs with express:
+
+```
+app.use(function(req, res, next) {
+  res.header("Cross-Origin-Embedder-Policy", "require-corp");
+  res.header("Cross-Origin-Opener-Policy", "same-origin");
+  next();
+});
+```
+
+In NGINX: (site config under `server {`)
+
+```
+  add_header Cross-Origin-Opener-Policy same-origin;
+  add_header Cross-Origin-Embedder-Policy require-corp;
+```


### PR DESCRIPTION
The doc updates are from what I ran into early when trying to compile using the latest emsdk, also added a section on building with pthread support.

The pthread support needs new flags, despite the warnings memory growth and threading does not have any significant performance impact that I can tell.

The missing asset flag is due to the ability to shave down the minimum asset bundle needed for emscripten cores, this can be reduced down to a 3 meg zip file with just the needed skin assets. 
https://ipfs.infura.io/ipfs/QmUKXSZhhrTrUp4b49ykfvNJC1TyiqMENv4hmV21ntpGUQ?filename=frontend.zip

All of these changes are unobtrusive and would only really be used by someone that knows what they are doing building cores. 