### PR TITLE
(Netplay) Fix dummy notification

### DIFF
--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -8330,7 +8330,7 @@ bool init_netplay(const char *server, unsigned port, const char *mitm_session)
    const char *mitm              = NULL;
 
    if (!net_st->netplay_enabled)
-      goto failure;
+      return false;
 
    core_set_default_callbacks(&cbs);
    if (!core_set_netplay_callbacks())


### PR DESCRIPTION
## Description

No longer shows a netplay initialization failed notification when netplay is not enabled.

## Reviewers

@twinaphex @m4xw 