### PR TITLE
(3DS) Enable CHD support / Disable richpresence by default

### DIFF
--- a/Makefile.ctr
+++ b/Makefile.ctr
@@ -63,6 +63,7 @@ ifeq ($(GRIFFIN_BUILD), 1)
 	DEFINES += -DHAVE_GFX_WIDGETS
 	DEFINES += -DHAVE_OVERLAY
 	DEFINES += -DHAVE_CORE_INFO_CACHE
+	DEFINES += -DHAVE_CHD
 	#DEFINES += -DHAVE_SOCKET_LEGACY
 	#-DHAVE_SSL -DHAVE_BUILTINMBEDTLS -DMBEDTLS_SSL_DEBUG_ALL
 	#ssl is currently incompatible with griffin due to use of the "static" flag on repeating functions that will conflict when included in one file

--- a/configuration.c
+++ b/configuration.c
@@ -1898,7 +1898,11 @@ static struct config_bool_setting *populate_settings_bool(
    SETTING_BOOL("cheevos_test_unofficial",      &settings->bools.cheevos_test_unofficial, true, false, false);
    SETTING_BOOL("cheevos_hardcore_mode_enable", &settings->bools.cheevos_hardcore_mode_enable, true, true, false);
    SETTING_BOOL("cheevos_challenge_indicators", &settings->bools.cheevos_challenge_indicators, true, true, false);
+#ifdef _3DS
+   SETTING_BOOL("cheevos_richpresence_enable",  &settings->bools.cheevos_richpresence_enable, true, false, false);
+#else
    SETTING_BOOL("cheevos_richpresence_enable",  &settings->bools.cheevos_richpresence_enable, true, true, false);
+#endif
    SETTING_BOOL("cheevos_unlock_sound_enable",  &settings->bools.cheevos_unlock_sound_enable, true, false, false);
    SETTING_BOOL("cheevos_verbose_enable",       &settings->bools.cheevos_verbose_enable, true, true, false);
    SETTING_BOOL("cheevos_auto_screenshot",      &settings->bools.cheevos_auto_screenshot, true, false, false);


### PR DESCRIPTION
## Description

- Enable .CHD support for the frontend.
  This definition is only used to enable .chd streaming support for retroarch in regards to cheevos, independent of the core's .chd implementation.
Note: While the implementation is functional, i haven't tested this with all supported cores.


- Disable CHEEVOS: ```Rich Presence``` by default on the 3DS platform.
  While fully functional, this feature is quite demanding. Depending on the game, this can cause noticeable slowdowns on emulated systems such as snes and newer.
This should offer a better 'out-of-the-box' experience and enabling this manually helps users with determining possible causes of frames being dropped.


## Related Issues

- https://github.com/libretro/pcsx_rearmed/issues/554

## Reviewers

@jdgleaver @Jamiras