### PR TITLE
Restore missing 'Cache Core Info Files' menu entry

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -10006,7 +10006,7 @@ static bool setting_append_list(
 #endif
             for (i = 0; i < ARRAY_SIZE(bool_entries); i++)
             {
-#if defined(HAVE_CORE_INFO_CACHE)
+#if !defined(HAVE_CORE_INFO_CACHE)
                if (bool_entries[i].name_enum_idx ==
                      MENU_ENUM_LABEL_CORE_INFO_CACHE_ENABLE)
                   continue;


### PR DESCRIPTION
## Description

It seems that the `Cache Core Info Files` menu entry was mistakenly disabled during refactors some time ago... This trivial PR fixes the issue.
