### PR TITLE
(3DS) Disable CHD support

### DIFF
--- a/Makefile.ctr
+++ b/Makefile.ctr
@@ -63,7 +63,6 @@ ifeq ($(GRIFFIN_BUILD), 1)
 	DEFINES += -DHAVE_GFX_WIDGETS
 	DEFINES += -DHAVE_OVERLAY
 	DEFINES += -DHAVE_CORE_INFO_CACHE
-	DEFINES += -DHAVE_CHD
 	#DEFINES += -DHAVE_SOCKET_LEGACY
 	#-DHAVE_SSL -DHAVE_BUILTINMBEDTLS -DMBEDTLS_SSL_DEBUG_ALL
 	#ssl is currently incompatible with griffin due to use of the "static" flag on repeating functions that will conflict when included in one file


### PR DESCRIPTION
## Description

PR  #13486 enabled frontend CHD support for the 3DS build. Unfortunately it is not possible to do this for *any* static platform, due to `libretro-common` and `libchdr` conflicts between various cores. For example, PR #13486 has broken compilation of the mame2003 and mame2003-plus cores.

This PR therefore reverts the change, disabling frontend CHD support for the 3DS build.