### PR TITLE
(Wayland) Initial drag and drop (wl_data_offer) support

### DIFF
--- a/input/common/wayland_common.h
+++ b/input/common/wayland_common.h
@@ -112,6 +112,15 @@ typedef struct input_ctx_wayland_data
    bool blocked;
 } input_ctx_wayland_data_t;
 
+typedef struct data_offer_ctx
+{
+  struct wl_data_offer *offer;
+  struct wl_data_device *data_device;
+  bool is_file_mime_type;
+  bool dropped;
+  enum wl_data_device_manager_dnd_action supported_actions;
+} data_offer_ctx;
+
 typedef struct gfx_ctx_wayland_data
 {
 #ifdef HAVE_EGL
@@ -129,6 +138,9 @@ typedef struct gfx_ctx_wayland_data
    struct wl_touch *wl_touch;
    struct wl_seat *seat;
    struct wl_shm *shm;
+   struct wl_data_device_manager *data_device_manager;
+   struct wl_data_device *data_device;
+   data_offer_ctx *current_drag_offer;
 #ifdef HAVE_LIBDECOR
    struct libdecor *libdecor_context;
    struct libdecor_frame *libdecor_frame;
@@ -224,5 +236,9 @@ extern const struct wl_output_listener output_listener;
 extern const struct wl_registry_listener registry_listener;
 
 extern const struct wl_buffer_listener shm_buffer_listener;
+
+extern const struct wl_data_device_listener data_device_listener;
+
+extern const struct wl_data_offer_listener data_offer_listener;
 
 #endif


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

This MR implements drag and drop on wayland with `wl_data_offer`.
At this point it only prints the file URIs to the log.
Much of the implementation is based on code from SDL2. The functions `read_pipe` and `ioready` may duplicate that already exists in this project, and should probably not be in `wayland_common.c`.

I have a non functional full DnD implementation based on the win32_common code.
https://github.com/libretro/RetroArch/blob/0a888f786840e338d7b28b99cd6ee8c2011edc8c/gfx/common/win32_common.c#L900-L903
However it pulls in glib for file URI decoding and triggers a mutex deadlock from the wayland gfx code so needs further work.

## Related Issues

#6336

## Related Pull Requests

## Reviewers

