### PR TITLE
(D3D10/11) Add vsync swap interval

### DIFF
--- a/gfx/common/d3d10_common.h
+++ b/gfx/common/d3d10_common.h
@@ -1152,6 +1152,7 @@ typedef struct
    D3D10_VIEWPORT        viewport;
    DXGI_FORMAT           format;
    float                 clearcolor[4];
+   unsigned              swap_interval;
    bool                  vsync;
    bool                  resize_chain;
    bool                  keep_aspect;

--- a/gfx/common/d3d11_common.h
+++ b/gfx/common/d3d11_common.h
@@ -2543,6 +2543,7 @@ typedef struct
    D3D11_RECT            scissor;
    DXGI_FORMAT           format;
    float                 clearcolor[4];
+   unsigned              swap_interval;
    bool                  vsync;
    bool                  resize_chain;
    bool                  keep_aspect;

--- a/gfx/drivers/d3d10.c
+++ b/gfx/drivers/d3d10.c
@@ -1560,7 +1560,7 @@ static bool d3d10_gfx_frame(
 #ifndef __WINRT__
    win32_update_title();
 #endif
-   DXGIPresent(d3d10->swapChain, !!d3d10->vsync, 0);
+   DXGIPresent(d3d10->swapChain, d3d10->swap_interval, 0);
 
    return true;
 }
@@ -1575,6 +1575,7 @@ static void d3d10_gfx_set_nonblock_state(void* data, bool toggle,
       return;
 
    d3d10->vsync         = !toggle;
+   d3d10->swap_interval = (!toggle) ? swap_interval : 0;
 }
 
 static bool d3d10_gfx_alive(void* data)

--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -2199,7 +2199,7 @@ static bool d3d11_gfx_frame(
    }
 #endif
 
-   DXGIPresent(d3d11->swapChain, !!vsync, present_flags);
+   DXGIPresent(d3d11->swapChain, d3d11->swap_interval, present_flags);
    Release(rtv);
 
    return true;
@@ -2215,7 +2215,8 @@ static void d3d11_gfx_set_nonblock_state(void* data,
    if (!d3d11)
       return;
 
-   d3d11->vsync = !toggle;
+   d3d11->vsync         = !toggle;
+   d3d11->swap_interval = (!toggle) ? swap_interval : 0;
 }
 
 static bool d3d11_gfx_alive(void* data)


### PR DESCRIPTION
## Description

Swap/sync interval was merely on/off based on vsync, leaving the existing option unused.

## Related Issues

Closes #6219

