### PR TITLE
sdl_gl_ctx: fix focus detection on webOS

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -1144,7 +1144,7 @@ static const bool audio_enable_menu_bgm    = false;
 #define DEFAULT_REWIND_GRANULARITY 1
 #endif
 /* Pause gameplay when gameplay loses focus. */
-#if defined(EMSCRIPTEN) || defined(WEBOS)
+#if defined(EMSCRIPTEN)
 #define DEFAULT_PAUSE_NONACTIVE false
 #else
 #define DEFAULT_PAUSE_NONACTIVE true

--- a/gfx/drivers_context/sdl_gl_ctx.c
+++ b/gfx/drivers_context/sdl_gl_ctx.c
@@ -377,7 +377,12 @@ static bool sdl_ctx_has_focus(void *data)
 
 #ifdef HAVE_SDL2
    gfx_ctx_sdl_data_t *sdl = (gfx_ctx_sdl_data_t*)data;
+#ifdef WEBOS
+   // We do not receive mouse focus when non-magic remote is used.
+   flags = (SDL_WINDOW_INPUT_FOCUS);
+#else
    flags = (SDL_WINDOW_INPUT_FOCUS | SDL_WINDOW_MOUSE_FOCUS);
+#endif
    return (SDL_GetWindowFlags(sdl->win) & flags) == flags;
 #else
    flags = (SDL_APPINPUTFOCUS | SDL_APPACTIVE);


### PR DESCRIPTION
## Description

webOS devices without a "Magic Remote" (bluetooth-based mouse-style remote) do not receive mouse focus. This was causing RetroArch to stay paused. As a workaround we had "Pause when not active" set to false by default.

This properly fixes the underlying issue and reenables "Pause when not active" on this platform. RetroArch will now properly pause when Home view/Input selector is opened, or a current app is changed.

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
