### PR TITLE
remove test for standard mapping in controller detection

### DIFF
--- a/input/drivers_joypad/rwebpad_joypad.c
+++ b/input/drivers_joypad/rwebpad_joypad.c
@@ -30,16 +30,8 @@
 static EM_BOOL rwebpad_gamepad_cb(int event_type,
    const EmscriptenGamepadEvent *gamepad_event, void *user_data)
 {
-   unsigned vid = 0;
-   unsigned pid = 0;
-
-   if (strncmp(gamepad_event->mapping, "standard",
-       sizeof(gamepad_event->mapping)) == 0)
-   {
-      /* give a dummy vid/pid for automapping */
-      vid = 1;
-      pid = 1;
-   }
+   unsigned vid = 1;
+   unsigned pid = 1;
 
    switch (event_type)
    {


### PR DESCRIPTION
## Description

When using mobile chrome based browsers (Brave, Chrome) the "mapping" return for a gamepad can be blank from navigator.getGamepads. As it is it this will completely block any controller that does not return this string from functioning at all. Even if a controller needs to be remapped it should be passed and the user can then remap from the options menu gives them a manual way out when using emscripten without joypad-autoconfig files being leveraged.

I have tested this change on Desktop Chrome/Brave and Android Chrome/Brave with the following controllers: 

Desktop: 
Xbox one controller- works before and after change
Xbox 360 wireless- works before and after change

Android:
Xbox one controller- works before and after change
Razer Kishi- Only works with this change otherwise gets `0/0 not configured`

iOS: (Safari)
Xbox one controller- works before and after change
Razer Kishi- works before and after change

(listing all these as it does not seem to regress anything on any platform)

## Related Issues
https://github.com/libretro/RetroArch/issues/13363

## Reviewers

@ToadKing 