### PR TITLE
fix building against ffmpeg 5.0

### DIFF
--- a/cores/libretro-ffmpeg/video_buffer.c
+++ b/cores/libretro-ffmpeg/video_buffer.c
@@ -2,6 +2,7 @@
 extern "C" {
 #endif
 #include <libavformat/avformat.h>
+#include <libavutil/imgutils.h>
 #ifdef __cplusplus
 }
 #endif
@@ -74,8 +75,9 @@ video_buffer_t *video_buffer_create(
 #endif
       b->buffer[i].target    = av_frame_alloc();
 
-      avpicture_alloc((AVPicture*)b->buffer[i].target,
-            PIX_FMT_RGB32, width, height);
+      AVFrame* frame = b->buffer[i].target;
+      av_image_alloc(frame->data, frame->linesize,
+            width, height, PIX_FMT_RGB32, 1);
 
       if (!b->buffer[i].sws       ||
           !b->buffer[i].source    ||
@@ -110,7 +112,7 @@ void video_buffer_destroy(video_buffer_t *video_buffer)
          av_frame_free(&video_buffer->buffer[i].hw_source);
 #endif
          av_frame_free(&video_buffer->buffer[i].source);
-         avpicture_free((AVPicture*)video_buffer->buffer[i].target);
+         av_freep((AVFrame*)video_buffer->buffer[i].target);
          av_frame_free(&video_buffer->buffer[i].target);
          sws_freeContext(video_buffer->buffer[i].sws);
       }


### PR DESCRIPTION
## Description

Adds compatibility with ffmpeg 5.0, still builds fine against ffmpeg 4.4.

Disclaimer: I don't speak C/C++, please consider this experimental, and I'd welcome pointers on how to test the changes, never looked into what purpose ffmpeg serves in retroarch.

## Related Issues

https://github.com/libretro/RetroArch/issues/13530
