### PR TITLE
VITA: don't fail if vm_memblock can't be allocated

### DIFF
--- a/bootstrap/vita/sbrk.c
+++ b/bootstrap/vita/sbrk.c
@@ -43,7 +43,6 @@ void _init_vita_heap(void) {
 
 	  if (_newlib_vm_memblock < 0){
 	    //sceClibPrintf("sceKernelAllocMemBlockForVM failed\n");
-			goto failure;
 		}
 	}else{
 		_newlib_vm_memblock = 0;
@@ -99,8 +98,8 @@ void _free_vita_heap(void) {
 	// Free the heap memblock to avoid memory leakage.
 	sceKernelFreeMemBlock(_newlib_heap_memblock);
 
-	if(_newlib_vm_memblock)
-  	sceKernelFreeMemBlock(_newlib_vm_memblock);
+	if (_newlib_vm_memblock > 0)
+		sceKernelFreeMemBlock(_newlib_vm_memblock);
 
 	_newlib_vm_memblock = 0;
 	_newlib_heap_memblock = 0;


### PR DESCRIPTION
Failing here is catastrophic because we get no heap, the whole thing
just crashes and leaves nothing in the logs. vm_memblock is not even
used by RetroArch, it's just used by cores with dynarecs, so let the
cores themselves deal with problems if they arise.
