### PR TITLE
Improve udev logging

### DIFF
--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -1450,7 +1450,7 @@ static void *udev_input_init(const char *joypad_driver)
    /* If using KMS and we forgot this,
     * we could lock ourselves out completely. */
    if (!udev->num_devices)
-      RARCH_WARN("[udev]: Couldn't open any keyboard, mouse or touchpad. Are permissions set correctly for /dev/input/event*?\n");
+      RARCH_WARN("[udev]: Couldn't open any keyboard, mouse or touchpad. Are permissions set correctly for /dev/input/event* and /run/udev/?\n");
 
    input_keymaps_init_keyboard_lut(rarch_key_map_linux);
 

--- a/input/drivers_joypad/udev_joypad.c
+++ b/input/drivers_joypad/udev_joypad.c
@@ -623,12 +623,22 @@ static void *udev_joypad_init(void *data)
    udev_enumerate_add_match_subsystem(enumerate, "input");
    udev_enumerate_scan_devices(enumerate);
    devs = udev_enumerate_get_list_entry(enumerate);
+   if (!devs)
+      RARCH_DBG("[udev]: Couldn't open any joypads. Are permissions set correctly for /dev/input/event* and /run/udev/?\n");
 
    udev_list_entry_foreach(item, devs)
    {
       const char         *name = udev_list_entry_get_name(item);
       struct udev_device  *dev = udev_device_new_from_syspath(udev_joypad_fd, name);
       const char      *devnode = udev_device_get_devnode(dev);
+#if defined(DEBUG)
+      RARCH_DBG("udev_joypad_init entry name=%s devnode=%s\n", name, devnode);
+      struct udev_list_entry *list_entry;
+      udev_list_entry_foreach(list_entry, udev_device_get_properties_list_entry(dev))
+         RARCH_DBG("udev_joypad_init property %s=%s\n",
+                       udev_list_entry_get_name(list_entry),
+                       udev_list_entry_get_value(list_entry));
+#endif
 
       if (devnode)
          udev_check_device(dev, devnode);


### PR DESCRIPTION
## Description

In jailed environment (e.g. webOS) `/run/udev/` directory can be inaccessible and therefore udev devices can't be detected. Reminder about it can be useful.

Also joypad properties logging can be useful sometimes for debugging.