### PR TITLE
Increase maximum fast-forward ratio

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -1252,6 +1252,7 @@ static const bool savestate_thumbnail_enable = false;
 
 /* Maximum fast forward ratio. */
 #define DEFAULT_FASTFORWARD_RATIO 0.0
+#define MAXIMUM_FASTFORWARD_RATIO 50.0
 
 /* Skip frames when fast forwarding. */
 #define DEFAULT_FASTFORWARD_FRAMESKIP true

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -13948,7 +13948,7 @@ static bool setting_append_list(
                general_read_handler);
          (*list)[list_info->index - 1].action_ok = &setting_action_ok_uint;
          MENU_SETTINGS_LIST_CURRENT_ADD_CMD(list, list_info, CMD_EVENT_SET_FRAME_LIMIT);
-         menu_settings_list_current_add_range(list, list_info, 0, 10, 1.0, true, true);
+         menu_settings_list_current_add_range(list, list_info, 0, MAXIMUM_FASTFORWARD_RATIO, 1.0, true, true);
 
          CONFIG_BOOL(
                list, list_info,


### PR DESCRIPTION
## Description

Now that the fast-forwarding speed is somewhat faster with the frame skipping, let's bridge the gap between unlimited and maximum by raising the cap limit to a nice arbitrary roundish number.
