### PR TITLE
(cheevos) fix achievements sometimes not loading when multi-disc starts on secondary disc

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -1682,6 +1682,7 @@ static bool rcheevos_identify_game(const struct retro_game_info* info)
    if (iterator.consoles[iterator.index] == 0)
    {
       /* no more potential matches, just try the one hash */
+      rcheevos_begin_load_state(RCHEEVOS_LOAD_STATE_IDENTIFYING_GAME);
       rcheevos_client_identify_game(hash,
             rcheevos_identify_game_callback, NULL);
       return true;
@@ -1714,6 +1715,8 @@ static bool rcheevos_identify_game(const struct retro_game_info* info)
    }
 
    memcpy(&data->iterator, &iterator, sizeof(iterator));
+
+   rcheevos_begin_load_state(RCHEEVOS_LOAD_STATE_IDENTIFYING_GAME);
    rcheevos_client_identify_game(hash,
          rcheevos_identify_game_callback, data);
    return true;

--- a/cheevos/cheevos_client.c
+++ b/cheevos/cheevos_client.c
@@ -746,7 +746,6 @@ void rcheevos_client_identify_game(const char* hash,
       request->callback      = callback;
       request->callback_data = userdata;
 
-      rcheevos_begin_load_state(RCHEEVOS_LOAD_STATE_IDENTIFYING_GAME);
       rcheevos_async_begin_request(request, result,
          rcheevos_async_resolve_hash_callback,
          CHEEVOS_ASYNC_RESOLVE_HASH, 0,


### PR DESCRIPTION
## Description

Fixes an issue introduced by #13283 when loading a game and the selected disc is remembered. The secondary disc check was incrementing the outstanding request counter, but not decrementing it when done. If the secondary disc check starts before the load process completes, the load process would stall waiting for the outstanding request to complete.

As the secondary disc check is not meant to be part of the loading process, I've moved the code that increments the outstanding request counter out of the function that makes the API call. This way, the secondary disc check does not increment the counter.

## Related Issues

https://discord.com/channels/310192285306454017/310195854642249728/936626929992364072
> Today when I load up a m3u file to play disc 2 of FF7 Retroarch says there are no achievements to display.  Last night when I was on disc 1 and changed to disc 2 I earned achievements for disc 2 during that session.  Retroarch recognizes the achievements when I load the .cue file directly, so it seems like it doesn't load achievements when I load a m3u file and I'm passed disc one of a game.

## Related Pull Requests

n/a

## Reviewers

[If possible @mention all the people that should review your pull request]
