### PR TITLE
(cheevos) stop load process if unable to retrieve achievement data

### DIFF
--- a/cheevos/cheevos_client.c
+++ b/cheevos/cheevos_client.c
@@ -1098,6 +1098,10 @@ static void rcheevos_async_fetch_game_data_callback(
          "i%s", runtime_data->game_data.image_name);
       rcheevos_client_fetch_game_badge(runtime_data->game_data.image_name, runtime_data);
    }
+   else
+   {
+      rcheevos_unload();
+   }
 }
 
 void rcheevos_client_initialize_runtime(unsigned game_id,

--- a/deps/rcheevos/src/rapi/rc_api_runtime.c
+++ b/deps/rcheevos/src/rapi/rc_api_runtime.c
@@ -129,7 +129,7 @@ int rc_api_process_fetch_game_data_response(rc_api_fetch_game_data_response_t* r
   rc_buf_init(&response->response.buffer);
 
   result = rc_json_parse_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
-  if (result != RC_OK)
+  if (result != RC_OK || !response->response.succeeded)
     return result;
 
   if (!rc_json_get_required_object(patchdata_fields, sizeof(patchdata_fields) / sizeof(patchdata_fields[0]), &response->response, &fields[2], "PatchData"))

--- a/deps/rcheevos/src/rapi/rc_api_user.c
+++ b/deps/rcheevos/src/rapi/rc_api_user.c
@@ -138,7 +138,7 @@ int rc_api_process_fetch_user_unlocks_response(rc_api_fetch_user_unlocks_respons
   rc_buf_init(&response->response.buffer);
 
   result = rc_json_parse_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
-  if (result != RC_OK)
+  if (result != RC_OK || !response->response.succeeded)
     return result;
 
   result = rc_json_get_required_unum_array(&response->achievement_ids, &response->num_achievement_ids, &response->response, &fields[2], "UserUnlocks");


### PR DESCRIPTION
## Description

When logging in to RetroAchievements with valid credentials for an account that hasn't yet verified their email, some API calls will fail with with a "Credentials Invalid" error. This should stop the loading process instead of generating errors for each failed API call.

## Related Issues

https://discord.com/channels/184109094070779904/469974542299955210/935755324080652359

## Related Pull Requests

n/a

## Reviewers

@Sanaki
