### PR TITLE
(Vulkan/GL) goto error without HAVE_EGL

### DIFF
--- a/gfx/drivers_context/wayland_ctx.c
+++ b/gfx/drivers_context/wayland_ctx.c
@@ -803,11 +803,9 @@ static bool gfx_ctx_wl_set_video_mode(void *data,
 
    return true;
 
-#if defined(HAVE_EGL)
 error:
    gfx_ctx_wl_destroy(data);
    return false;
-#endif
 }
 
 bool input_wl_init(void *data, const char *joypad_name);


### PR DESCRIPTION
## Description

The label `error` in the function `gfx_ctx_wl_set_video_mode` is dependant on `HAVE_EGL`. `goto error` is used regardless of `EGL_HAVE`.
This means that compilation fails if configured with `--disable-egl`.

This MR makes errors no longer dependent of EGL.

https://github.com/libretro/RetroArch/blob/22df09885eab162cf4aa6247cf408eff57c8c866/gfx/drivers_context/wayland_ctx.c#L806-L810

## Related Issues

#13566