### PR TITLE
(Wayland) Show window early to get screen info

### DIFF
--- a/gfx/drivers_context/wayland_ctx.c
+++ b/gfx/drivers_context/wayland_ctx.c
@@ -59,6 +59,9 @@ static enum gfx_ctx_api wl_api   = GFX_CTX_NONE;
 #define EGL_PLATFORM_WAYLAND_KHR 0x31D8
 #endif
 
+#define DEFAULT_WINDOWED_WIDTH 640
+#define DEFAULT_WINDOWED_HEIGHT 480
+
 static void handle_toplevel_config_common(void *data,
       void *toplevel,
       int32_t width, int32_t height, struct wl_array *states)
@@ -126,7 +129,8 @@ static void gfx_ctx_wl_get_video_size(void *data,
 {
    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
 
-   if (wl->surface == NULL) {
+   if (!wl->reported_display_size) {
+      wl->reported_display_size = true;
       output_info_t *oi, *tmp;
       oi = wl->current_output;
 
@@ -409,9 +413,6 @@ static struct libdecor_frame_interface libdecor_frame_interface = {
 };
 #endif
 
-#define DEFAULT_WINDOWED_WIDTH 640
-#define DEFAULT_WINDOWED_HEIGHT 480
-
 #ifdef HAVE_EGL
 #define WL_EGL_ATTRIBS_BASE \
    EGL_SURFACE_TYPE,    EGL_WINDOW_BIT, \
@@ -509,6 +510,8 @@ static void *gfx_ctx_wl_init(void *video_driver)
    wl->input.dpy         = wl_display_connect(NULL);
    wl->last_buffer_scale = 1;
    wl->buffer_scale      = 1;
+   wl->width             = DEFAULT_WINDOWED_WIDTH;
+   wl->height            = DEFAULT_WINDOWED_HEIGHT;
 
    if (!wl->input.dpy)
    {
@@ -542,13 +545,76 @@ static void *gfx_ctx_wl_init(void *video_driver)
 
    if (!wl->idle_inhibit_manager)
    {
-	   RARCH_WARN("[Wayland]: Compositor doesn't support zwp_idle_inhibit_manager_v1 protocol!\n");
+      RARCH_LOG("[Wayland]: Compositor doesn't support zwp_idle_inhibit_manager_v1 protocol\n");
    }
 
    if (!wl->deco_manager)
    {
-	   RARCH_WARN("[Wayland]: Compositor doesn't support zxdg_decoration_manager_v1 protocol!\n");
+      RARCH_LOG("[Wayland]: Compositor doesn't support zxdg_decoration_manager_v1 protocol\n");
    }
+
+   wl->surface                = wl_compositor_create_surface(wl->compositor);
+
+   wl_surface_set_buffer_scale(wl->surface, wl->buffer_scale);
+   wl_surface_add_listener(wl->surface, &wl_surface_listener, wl);
+
+#ifdef HAVE_LIBDECOR
+   wl->libdecor_context = libdecor_new(wl->input.dpy, &libdecor_interface);
+   if (wl->libdecor_context)
+   {
+      wl->libdecor_frame = libdecor_decorate(wl->libdecor_context, wl->surface, &libdecor_frame_interface, wl);
+      if (!wl->libdecor_frame)
+      {
+         RARCH_ERR("[Wayland]: Failed to crate libdecor frame\n");
+         goto error;
+      }
+
+      libdecor_frame_set_app_id(wl->libdecor_frame, "retroarch");
+      libdecor_frame_set_title(wl->libdecor_frame, "RetroArch");
+      libdecor_frame_map(wl->libdecor_frame);
+   }
+
+   /* Waiting for libdecor to be configured before starting to draw */
+   wl_surface_commit(wl->surface);
+   wl->configured = true;
+
+   while (wl->configured)
+   {
+      if (libdecor_dispatch(wl->libdecor_context, 0) < 0)
+      {
+         RARCH_ERR("[Wayland]: libdecor failed to dispatch\n");
+         goto error;
+      }
+   }
+#else
+   wl->xdg_surface = xdg_wm_base_get_xdg_surface(wl->xdg_shell, wl->surface);
+   xdg_surface_add_listener(wl->xdg_surface, &xdg_surface_listener, wl);
+
+   wl->xdg_toplevel = xdg_surface_get_toplevel(wl->xdg_surface);
+   xdg_toplevel_add_listener(wl->xdg_toplevel, &xdg_toplevel_listener, wl);
+
+   xdg_toplevel_set_app_id(wl->xdg_toplevel, "retroarch");
+   xdg_toplevel_set_title(wl->xdg_toplevel, "RetroArch");
+
+   if (wl->deco_manager)
+      wl->deco = zxdg_decoration_manager_v1_get_toplevel_decoration(
+            wl->deco_manager, wl->xdg_toplevel);
+
+   /* Waiting for xdg_toplevel to be configured before starting to draw */
+   wl_surface_commit(wl->surface);
+   wl->configured = true;
+
+   while (wl->configured)
+      wl_display_dispatch(wl->input.dpy);
+#endif
+
+   wl_display_roundtrip(wl->input.dpy);
+   xdg_wm_base_add_listener(wl->xdg_shell, &xdg_shell_listener, NULL);
+
+   /* Bind SHM based wl_buffer to wl_surface until the vulkan surface is ready.
+    * This shows the window which assigns us a display (wl_output)
+    *  which is usefull for HiDPI and auto selecting a display for fullscreen. */
+   draw_splash_screen(wl);
 
    wl->input.fd = wl_display_get_fd(wl->input.dpy);
 
@@ -703,71 +769,23 @@ static bool gfx_ctx_wl_set_video_mode(void *data,
          (gfx_ctx_wayland_data_t*)data, egl_attribs);
 #endif
    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
+   settings_t *settings      = config_get_ptr();
+   unsigned video_monitor_index = settings->uints.video_monitor_index;
 
    wl->width                  = width  ? width  : DEFAULT_WINDOWED_WIDTH;
    wl->height                 = height ? height : DEFAULT_WINDOWED_HEIGHT;
 
-   wl->surface                = wl_compositor_create_surface(wl->compositor);
-
    wl_surface_set_buffer_scale(wl->surface, wl->buffer_scale);
-   wl_surface_add_listener(wl->surface, &wl_surface_listener, wl);
+
+#ifdef HAVE_LIBDECOR
+   struct libdecor_state *state = libdecor_state_new( width, height);
+   libdecor_frame_commit(wl->libdecor_frame, state, NULL);
+   libdecor_state_free(state);
+#endif
 
 #ifdef HAVE_EGL
    wl->win        = wl_egl_window_create(wl->surface, wl->width * wl->buffer_scale, wl->height * wl->buffer_scale);
 #endif
-
-#ifdef HAVE_LIBDECOR
-   wl->libdecor_context = libdecor_new(wl->input.dpy, &libdecor_interface);
-   if (wl->libdecor_context)
-   {
-      wl->libdecor_frame = libdecor_decorate(wl->libdecor_context, wl->surface, &libdecor_frame_interface, wl);
-      if (!wl->libdecor_frame)
-      {
-         RARCH_ERR("[Wayland]: Failed to crate libdecor frame\n");
-         goto error;
-      }
-
-      libdecor_frame_set_app_id(wl->libdecor_frame, "retroarch");
-      libdecor_frame_set_title(wl->libdecor_frame, "RetroArch");
-      libdecor_frame_map(wl->libdecor_frame);
-   }
-
-   /* Waiting for libdecor to be configured before starting to draw */
-   wl_surface_commit(wl->surface);
-   wl->configured = true;
-
-   while (wl->configured)
-   {
-      if (libdecor_dispatch(wl->libdecor_context, 0) < 0)
-      {
-         RARCH_ERR("[Wayland]: libdecor failed to dispatch\n");
-         goto error;
-      }
-   }
-#else
-   wl->xdg_surface = xdg_wm_base_get_xdg_surface(wl->xdg_shell, wl->surface);
-   xdg_surface_add_listener(wl->xdg_surface, &xdg_surface_listener, wl);
-
-   wl->xdg_toplevel = xdg_surface_get_toplevel(wl->xdg_surface);
-   xdg_toplevel_add_listener(wl->xdg_toplevel, &xdg_toplevel_listener, wl);
-
-   xdg_toplevel_set_app_id(wl->xdg_toplevel, "retroarch");
-   xdg_toplevel_set_title(wl->xdg_toplevel, "RetroArch");
-
-   if (wl->deco_manager)
-      wl->deco = zxdg_decoration_manager_v1_get_toplevel_decoration(
-            wl->deco_manager, wl->xdg_toplevel);
-
-   /* Waiting for xdg_toplevel to be configured before starting to draw */
-   wl_surface_commit(wl->surface);
-   wl->configured = true;
-
-   while (wl->configured)
-      wl_display_dispatch(wl->input.dpy);
-#endif
-
-   wl_display_roundtrip(wl->input.dpy);
-   xdg_wm_base_add_listener(wl->xdg_shell, &xdg_shell_listener, NULL);
 
 #ifdef HAVE_EGL
    if (!egl_create_context(&wl->egl, (attr != egl_attribs)
@@ -784,12 +802,35 @@ static bool gfx_ctx_wl_set_video_mode(void *data,
 
    if (fullscreen)
    {
+      struct wl_output *output = NULL;
+      int output_i = 0;
+      output_info_t *oi, *tmp;
+
+      if (video_monitor_index <= 0 && wl->current_output != NULL)
+      {
+         oi = wl->current_output;
+         output = oi->output;
+         RARCH_LOG("[Wayland/Vulkan]: Auto fullscreen on display \"%s\" \"%s\"\n", oi->make, oi->model);
+      }
+      else wl_list_for_each_safe(oi, tmp, &wl->all_outputs, link)
+      {
+         if (++output_i == video_monitor_index)
+         {
+            output = oi->output;
+            RARCH_LOG("[Wayland/Vulkan]: Fullscreen on display %i \"%s\" \"%s\"\n", output_i, oi->make, oi->model);
+            break;
+         }
+      }
+
+      if (output == NULL)
+         RARCH_LOG("[Wayland/Vulkan] Failed to specify monitor for fullscreen, letting compositor decide\n");
+
 #ifdef HAVE_LIBDECOR
-      libdecor_frame_set_fullscreen(wl->libdecor_frame, NULL);
+      libdecor_frame_set_fullscreen(wl->libdecor_frame, output);
 #else
-	   xdg_toplevel_set_fullscreen(wl->xdg_toplevel, NULL);
+      xdg_toplevel_set_fullscreen(wl->xdg_toplevel, output);
 #endif
-	}
+   }
 
    flush_wayland_fd(&wl->input);
 

--- a/gfx/drivers_context/wayland_vk_ctx.c
+++ b/gfx/drivers_context/wayland_vk_ctx.c
@@ -52,6 +52,9 @@
 #define EGL_PLATFORM_WAYLAND_KHR 0x31D8
 #endif
 
+#define DEFAULT_WINDOWED_WIDTH 640
+#define DEFAULT_WINDOWED_HEIGHT 480
+
 static void handle_toplevel_config_common(void *data,
       void *toplevel,
       int32_t width, int32_t height, struct wl_array *states)
@@ -109,7 +112,8 @@ static void gfx_ctx_wl_get_video_size(void *data,
 {
    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
 
-   if (wl->surface == NULL) {
+   if (!wl->reported_display_size) {
+      wl->reported_display_size = true;
       output_info_t *oi, *tmp;
       oi = wl->current_output;
 
@@ -389,9 +393,6 @@ static struct libdecor_frame_interface libdecor_frame_interface = {
 };
 #endif
 
-#define DEFAULT_WINDOWED_WIDTH 640
-#define DEFAULT_WINDOWED_HEIGHT 480
-
 static void *gfx_ctx_wl_init(void *video_driver)
 {
    int i;
@@ -408,6 +409,8 @@ static void *gfx_ctx_wl_init(void *video_driver)
    wl->input.dpy         = wl_display_connect(NULL);
    wl->last_buffer_scale = 1;
    wl->buffer_scale      = 1;
+   wl->width             = DEFAULT_WINDOWED_WIDTH;
+   wl->height            = DEFAULT_WINDOWED_HEIGHT;
 
    if (!wl->input.dpy)
    {
@@ -441,13 +444,76 @@ static void *gfx_ctx_wl_init(void *video_driver)
 
    if (!wl->idle_inhibit_manager)
    {
-	   RARCH_WARN("[Wayland]: Compositor doesn't support zwp_idle_inhibit_manager_v1 protocol!\n");
+      RARCH_LOG("[Wayland]: Compositor doesn't support zwp_idle_inhibit_manager_v1 protocol\n");
    }
 
    if (!wl->deco_manager)
    {
-	   RARCH_WARN("[Wayland]: Compositor doesn't support zxdg_decoration_manager_v1 protocol!\n");
+      RARCH_LOG("[Wayland]: Compositor doesn't support zxdg_decoration_manager_v1 protocol\n");
    }
+
+   wl->surface                = wl_compositor_create_surface(wl->compositor);
+
+   wl_surface_set_buffer_scale(wl->surface, wl->buffer_scale);
+   wl_surface_add_listener(wl->surface, &wl_surface_listener, wl);
+
+#ifdef HAVE_LIBDECOR
+   wl->libdecor_context = libdecor_new(wl->input.dpy, &libdecor_interface);
+   if (wl->libdecor_context)
+   {
+      wl->libdecor_frame = libdecor_decorate(wl->libdecor_context, wl->surface, &libdecor_frame_interface, wl);
+      if (!wl->libdecor_frame)
+      {
+         RARCH_ERR("[Wayland/Vulkan]: Failed to crate libdecor frame\n");
+         goto error;
+      }
+
+      libdecor_frame_set_app_id(wl->libdecor_frame, "retroarch");
+      libdecor_frame_set_title(wl->libdecor_frame, "RetroArch");
+      libdecor_frame_map(wl->libdecor_frame);
+   }
+
+   /* Waiting for libdecor to be configured before starting to draw */
+   wl_surface_commit(wl->surface);
+   wl->configured = true;
+
+   while (wl->configured)
+   {
+      if (libdecor_dispatch(wl->libdecor_context, 0) < 0)
+      {
+         RARCH_ERR("[Wayland/Vulkan]: libdecor failed to dispatch\n");
+         goto error;
+      }
+   }
+#else
+   wl->xdg_surface  = xdg_wm_base_get_xdg_surface(wl->xdg_shell, wl->surface);
+   xdg_surface_add_listener(wl->xdg_surface, &xdg_surface_listener, wl);
+
+   wl->xdg_toplevel = xdg_surface_get_toplevel(wl->xdg_surface);
+   xdg_toplevel_add_listener(wl->xdg_toplevel, &xdg_toplevel_listener, wl);
+
+   xdg_toplevel_set_app_id(wl->xdg_toplevel, "retroarch");
+   xdg_toplevel_set_title(wl->xdg_toplevel, "RetroArch");
+
+   if (wl->deco_manager)
+      wl->deco = zxdg_decoration_manager_v1_get_toplevel_decoration(
+            wl->deco_manager, wl->xdg_toplevel);
+
+   /* Waiting for xdg_toplevel to be configured before starting to draw */
+   wl_surface_commit(wl->surface);
+   wl->configured = true;
+
+   while (wl->configured)
+      wl_display_dispatch(wl->input.dpy);
+#endif
+
+   wl_display_roundtrip(wl->input.dpy);
+   xdg_wm_base_add_listener(wl->xdg_shell, &xdg_shell_listener, NULL);
+
+   /* Bind SHM based wl_buffer to wl_surface until the vulkan surface is ready.
+    * This shows the window which assigns us a display (wl_output)
+    *  which is usefull for HiDPI and auto selecting a display for fullscreen. */
+   draw_splash_screen(wl);
 
    wl->input.fd = wl_display_get_fd(wl->input.dpy);
 
@@ -518,74 +584,49 @@ static bool gfx_ctx_wl_set_video_mode(void *data,
       bool fullscreen)
 {
    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
+   settings_t *settings      = config_get_ptr();
+   unsigned video_monitor_index = settings->uints.video_monitor_index;
 
    wl->width                  = width  ? width  : DEFAULT_WINDOWED_WIDTH;
    wl->height                 = height ? height : DEFAULT_WINDOWED_HEIGHT;
 
-   wl->surface                = wl_compositor_create_surface(wl->compositor);
-
    wl_surface_set_buffer_scale(wl->surface, wl->buffer_scale);
-   wl_surface_add_listener(wl->surface, &wl_surface_listener, wl);
 
 #ifdef HAVE_LIBDECOR
-   wl->libdecor_context = libdecor_new(wl->input.dpy, &libdecor_interface);
-   if (wl->libdecor_context)
-   {
-      wl->libdecor_frame = libdecor_decorate(wl->libdecor_context, wl->surface, &libdecor_frame_interface, wl);
-      if (!wl->libdecor_frame)
-      {
-         RARCH_ERR("[Wayland/Vulkan]: Failed to crate libdecor frame\n");
-         goto error;
-      }
-
-      libdecor_frame_set_app_id(wl->libdecor_frame, "retroarch");
-      libdecor_frame_set_title(wl->libdecor_frame, "RetroArch");
-      libdecor_frame_map(wl->libdecor_frame);
-   }
-
-   /* Waiting for libdecor to be configured before starting to draw */
-   wl_surface_commit(wl->surface);
-   wl->configured = true;
-
-   while (wl->configured)
-   {
-      if (libdecor_dispatch(wl->libdecor_context, 0) < 0)
-      {
-         RARCH_ERR("[Wayland/Vulkan]: libdecor failed to dispatch\n");
-         goto error;
-      }
-   }
-#else
-   wl->xdg_surface  = xdg_wm_base_get_xdg_surface(wl->xdg_shell, wl->surface);
-   xdg_surface_add_listener(wl->xdg_surface, &xdg_surface_listener, wl);
-
-   wl->xdg_toplevel = xdg_surface_get_toplevel(wl->xdg_surface);
-   xdg_toplevel_add_listener(wl->xdg_toplevel, &xdg_toplevel_listener, wl);
-
-   xdg_toplevel_set_app_id(wl->xdg_toplevel, "retroarch");
-   xdg_toplevel_set_title(wl->xdg_toplevel, "RetroArch");
-
-   if (wl->deco_manager)
-      wl->deco = zxdg_decoration_manager_v1_get_toplevel_decoration(
-            wl->deco_manager, wl->xdg_toplevel);
-
-   /* Waiting for xdg_toplevel to be configured before starting to draw */
-   wl_surface_commit(wl->surface);
-   wl->configured = true;
-
-   while (wl->configured)
-      wl_display_dispatch(wl->input.dpy);
+   struct libdecor_state *state = libdecor_state_new( width, height);
+   libdecor_frame_commit(wl->libdecor_frame, state, NULL);
+   libdecor_state_free(state);
 #endif
-
-   wl_display_roundtrip(wl->input.dpy);
-   xdg_wm_base_add_listener(wl->xdg_shell, &xdg_shell_listener, NULL);
 
    if (fullscreen)
    {
+      struct wl_output *output = NULL;
+      int output_i = 0;
+      output_info_t *oi, *tmp;
+
+      if (video_monitor_index <= 0 && wl->current_output != NULL)
+      {
+         oi = wl->current_output;
+         output = oi->output;
+         RARCH_LOG("[Wayland/Vulkan]: Auto fullscreen on display \"%s\" \"%s\"\n", oi->make, oi->model);
+      }
+      else wl_list_for_each_safe(oi, tmp, &wl->all_outputs, link)
+      {
+         if (++output_i == video_monitor_index)
+         {
+            output = oi->output;
+            RARCH_LOG("[Wayland/Vulkan]: Fullscreen on display %i \"%s\" \"%s\"\n", output_i, oi->make, oi->model);
+            break;
+         }
+      }
+
+      if (output == NULL)
+         RARCH_LOG("[Wayland/Vulkan] Failed to specify monitor for fullscreen, letting compositor decide\n");
+
 #ifdef HAVE_LIBDECOR
-      libdecor_frame_set_fullscreen(wl->libdecor_frame, NULL);
+      libdecor_frame_set_fullscreen(wl->libdecor_frame, output);
 #else
-      xdg_toplevel_set_fullscreen(wl->xdg_toplevel, NULL);
+      xdg_toplevel_set_fullscreen(wl->xdg_toplevel, output);
 #endif
    }
 

--- a/input/common/wayland_common.c
+++ b/input/common/wayland_common.c
@@ -16,6 +16,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/mman.h>
 #include <poll.h>
 #include <unistd.h>
 
@@ -513,6 +516,8 @@ static void display_handle_geometry(void *data,
    output_info_t *oi          = (output_info_t*)data;
    oi->physical_width         = physical_width;
    oi->physical_height        = physical_height;
+   oi->make                   = strdup(make);
+   oi->model                  = strdup(model);
 }
 
 static void display_handle_mode(void *data,
@@ -548,9 +553,11 @@ static void registry_handle_global(void *data, struct wl_registry *reg,
 {
    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
 
+   RARCH_DBG("[Wayland]: Add global %u, interface %s, version %u\n", id, interface, version);
+
    if (string_is_equal(interface, "wl_compositor"))
       wl->compositor = (struct wl_compositor*)wl_registry_bind(reg,
-            id, &wl_compositor_interface, 3);
+            id, &wl_compositor_interface, MIN(version, 4));
    else if (string_is_equal(interface, "wl_output"))
    {
       output_info_t *oi = (output_info_t*)
@@ -558,27 +565,27 @@ static void registry_handle_global(void *data, struct wl_registry *reg,
 
       oi->global_id     = id;
       oi->output        = (struct wl_output*)wl_registry_bind(reg,
-            id, &wl_output_interface, 2);
+            id, &wl_output_interface, MIN(version, 2));
       wl_output_add_listener(oi->output, &output_listener, oi);
       wl_list_insert(&wl->all_outputs, &oi->link);
       wl_display_roundtrip(wl->input.dpy);
    }
    else if (string_is_equal(interface, "xdg_wm_base"))
       wl->xdg_shell = (struct xdg_wm_base*)
-         wl_registry_bind(reg, id, &xdg_wm_base_interface, 1);
+         wl_registry_bind(reg, id, &xdg_wm_base_interface, MIN(version, 3));
    else if (string_is_equal(interface, "wl_shm"))
-      wl->shm = (struct wl_shm*)wl_registry_bind(reg, id, &wl_shm_interface, 1);
+      wl->shm = (struct wl_shm*)wl_registry_bind(reg, id, &wl_shm_interface, MIN(version, 1));
    else if (string_is_equal(interface, "wl_seat"))
    {
-      wl->seat = (struct wl_seat*)wl_registry_bind(reg, id, &wl_seat_interface, 2);
+      wl->seat = (struct wl_seat*)wl_registry_bind(reg, id, &wl_seat_interface, MIN(version, 2));
       wl_seat_add_listener(wl->seat, &seat_listener, wl);
    }
    else if (string_is_equal(interface, "zwp_idle_inhibit_manager_v1"))
       wl->idle_inhibit_manager = (struct zwp_idle_inhibit_manager_v1*)wl_registry_bind(
-                                  reg, id, &zwp_idle_inhibit_manager_v1_interface, 1);
+                                  reg, id, &zwp_idle_inhibit_manager_v1_interface, MIN(version, 1));
    else if (string_is_equal(interface, "zxdg_decoration_manager_v1"))
       wl->deco_manager = (struct zxdg_decoration_manager_v1*)wl_registry_bind(
-                                  reg, id, &zxdg_decoration_manager_v1_interface, 1);
+                                  reg, id, &zxdg_decoration_manager_v1_interface, MIN(version, 1));
 }
 
 static void registry_handle_global_remove(void *data,
@@ -596,6 +603,16 @@ static void registry_handle_global_remove(void *data,
          break;
       }
    }
+}
+
+static void shm_buffer_handle_release(void *data,
+   struct wl_buffer *wl_buffer)
+{
+   shm_buffer_t *buffer = data;
+
+   wl_buffer_destroy(buffer->wl_buffer);
+   munmap(buffer->data, buffer->data_size);
+   free(buffer);
 }
 
 const struct wl_registry_listener registry_listener = {
@@ -654,6 +671,10 @@ const struct wl_pointer_listener pointer_listener = {
    pointer_handle_axis,
 };
 
+const struct wl_buffer_listener shm_buffer_listener = {
+   shm_buffer_handle_release,
+};
+
 void flush_wayland_fd(void *data)
 {
    struct pollfd fd = {0};
@@ -679,3 +700,118 @@ void flush_wayland_fd(void *data)
          wl_display_flush(wl->dpy);
    }
 }
+
+int create_anonymous_file(off_t size)
+{
+   int fd;
+
+   int ret;
+
+   fd = memfd_create("retroarch-wayland-vk-splash", MFD_CLOEXEC | MFD_ALLOW_SEALING);
+
+   if (fd < 0)
+      return -1;
+
+   fcntl(fd, F_ADD_SEALS, F_SEAL_SHRINK);
+
+   do {
+      ret = posix_fallocate(fd, 0, size);
+   } while (ret == EINTR);
+   if (ret != 0) {
+      close(fd);
+      errno = ret;
+      return -1;
+   }
+
+   return fd;
+}
+
+shm_buffer_t *create_shm_buffer(gfx_ctx_wayland_data_t *wl, int width,
+   int height,
+   uint32_t format)
+{
+   struct wl_shm_pool *pool;
+   int fd, size, stride;
+   void *data;
+   shm_buffer_t *buffer;
+
+   stride = width * 4;
+   size = stride * height;
+
+   fd = create_anonymous_file(size);
+   if (fd < 0) {
+      RARCH_ERR("[Wayland] [SHM]: Creating a buffer file for %d B failed: %s\n",
+         size, strerror(errno));
+      return NULL;
+   }
+
+   data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+   if (data == MAP_FAILED) {
+      RARCH_ERR("[Wayland] [SHM]: mmap failed: %s\n", strerror(errno));
+      close(fd);
+      return NULL;
+   }
+
+   buffer = calloc(1, sizeof *buffer);
+
+   pool = wl_shm_create_pool(wl->shm, fd, size);
+   buffer->wl_buffer = wl_shm_pool_create_buffer(pool, 0,
+      width, height,
+      stride, format);
+   wl_buffer_add_listener(buffer->wl_buffer, &shm_buffer_listener, buffer);
+   wl_shm_pool_destroy(pool);
+   close(fd);
+
+   buffer->data = data;
+   buffer->data_size = size;
+
+   return buffer;
+}
+
+
+void shm_buffer_paint_checkerboard(shm_buffer_t *buffer,
+      int width, int height, int scale,
+      size_t chk, uint32_t bg, uint32_t fg)
+{
+   uint32_t *pixels = buffer->data;
+   uint32_t color;
+   int y, x, sx, sy;
+   size_t off;
+   int stride = width * scale;
+
+   for (y = 0; y < height; y++) {
+      for (x = 0; x < width; x++) {
+         color = (x & chk) ^ (y & chk) ? fg : bg;
+         for (sx = 0; sx < scale; sx++) {
+            for (sy = 0; sy < scale; sy++) {
+               off = x * scale + sx
+                     + (y * scale + sy) * stride;
+               pixels[off] = color;
+            }
+         }
+      }
+   }
+}
+
+
+void draw_splash_screen(gfx_ctx_wayland_data_t *wl)
+{
+   shm_buffer_t *buffer;
+
+   buffer = create_shm_buffer(wl,
+      wl->width * wl->buffer_scale,
+      wl->height * wl->buffer_scale,
+      WL_SHM_FORMAT_XRGB8888);
+   shm_buffer_paint_checkerboard(buffer, wl->width,
+      wl->height, wl->buffer_scale,
+      16, 0xffbcbcbc, 0xff8e8e8e);
+
+   wl_surface_attach(wl->surface, buffer->wl_buffer, 0, 0);
+   wl_surface_set_buffer_scale(wl->surface, wl->buffer_scale);
+   if (wl_surface_get_version(wl->surface) >= WL_SURFACE_DAMAGE_BUFFER_SINCE_VERSION)
+      wl_surface_damage_buffer(wl->surface, 0, 0,
+         wl->width * wl->buffer_scale,
+         wl->height * wl->buffer_scale);
+   wl_surface_commit(wl->surface);
+}
+

--- a/input/common/wayland_common.h
+++ b/input/common/wayland_common.h
@@ -77,6 +77,8 @@ typedef struct output_info
    unsigned physical_width;
    unsigned physical_height;
    unsigned scale;
+   char *make;
+   char *model;
    struct wl_list link; /* wl->all_outputs */
 } output_info_t;
 
@@ -96,7 +98,7 @@ typedef struct input_ctx_wayland_data
 
    struct
    {
-      struct wl_pointer *surface;
+      struct wl_surface *surface;
       int last_x, last_y;
       int x, y;
       int delta_x, delta_y;
@@ -167,7 +169,14 @@ typedef struct gfx_ctx_wayland_data
    bool resize;
    bool configured;
    bool activated;
+   bool reported_display_size;
 } gfx_ctx_wayland_data_t;
+
+typedef struct shm_buffer {
+   struct wl_buffer *wl_buffer;
+   void *data;
+   size_t data_size;
+} shm_buffer_t;
 
 #ifdef HAVE_XKBCOMMON
 /* FIXME: Move this into a header? */
@@ -184,6 +193,17 @@ void handle_toplevel_close(void *data,
       struct xdg_toplevel *xdg_toplevel);
 
 void flush_wayland_fd(void *data);
+
+int create_anonymous_file(off_t size);
+
+shm_buffer_t *create_shm_buffer(gfx_ctx_wayland_data_t *wl,
+   int width, int height, uint32_t format);
+
+void shm_buffer_paint_checkerboard(shm_buffer_t *buffer,
+      int width, int height, int scale,
+      size_t chk, uint32_t bg, uint32_t fg);
+
+void draw_splash_screen(gfx_ctx_wayland_data_t *wl);
 
 extern const struct wl_keyboard_listener keyboard_listener;
 
@@ -202,5 +222,7 @@ extern const struct xdg_surface_listener xdg_surface_listener;
 extern const struct wl_output_listener output_listener;
 
 extern const struct wl_registry_listener registry_listener;
+
+extern const struct wl_buffer_listener shm_buffer_listener;
 
 #endif


### PR DESCRIPTION
## Description

Wayland doesn't gives hints about a which display a window will be assigned. This info is useful for reporting the display size on the initial call to `get_video_size` and for selecting the correct monitor for fullscreen.

This MR shows a window as soon as possible in order to get info about the display it as been assigned to. It also makes window appear on the correct display when fullscreen.

This allows:
* Current monitor size to be reported correctly on initial `get_video_size` call
* The monitor selected in settings to be the one used when the window is fullscreen
* The current monitor to be used for fullscreen when automatic monitor selection is set

As far as I understand wayland only allows fullscreen windows to select a display.

## Related Issues

#12635
