### PR TITLE
MIYOO: Support battery level

### DIFF
--- a/dingux/dingux_utils.c
+++ b/dingux/dingux_utils.c
@@ -2,6 +2,7 @@
  *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
  *  Copyright (C) 2011-2017 - Daniel De Matteis
  *  Copyright (C) 2019-2020 - James Leaver
+ *  Copyright (C) 2022-2022 - Jahed Ahmed
  *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-
@@ -48,6 +49,9 @@
 #define DINGUX_SCALING_MODE_ENVAR         "SDL_VIDEO_KMSDRM_SCALING_MODE"
 #define DINGUX_SCALING_SHARPNESS_ENVAR    "SDL_VIDEO_KMSDRM_SCALING_SHARPNESS"
 #define DINGUX_VIDEO_REFRESHRATE_ENVAR    "SDL_VIDEO_REFRESHRATE"
+
+/* Miyoo defines */
+#define MIYOO_BATTERY_VOLTAGE_NOW_FILE    "/sys/class/power_supply/miyoo-battery/voltage_now"
 
 /* Enables/disables downscaling when using
  * the IPU hardware scaler */
@@ -307,6 +311,24 @@ int dingux_get_battery_level(void)
       return -1;
 
    return (int)(((voltage_now - voltage_min) * 100) / (voltage_max - voltage_min));
+#elif defined(MIYOO)
+   /* miyoo-battery only provides "voltage_now". Results are based on
+    * value distribution while running a game at max load. */
+   int voltage_now = dingux_read_battery_sys_file(MIYOO_BATTERY_VOLTAGE_NOW_FILE);
+   if (voltage_now < 0) return -1;     // voltage_now not available
+   if (voltage_now > 4300) return 100; // 4320
+   if (voltage_now > 4200) return 90;  // 4230
+   if (voltage_now > 4100) return 80;  // 4140
+   if (voltage_now > 4000) return 70;  // 4050
+   if (voltage_now > 3900) return 60;  // 3960
+   if (voltage_now > 3800) return 50;  // 3870
+   if (voltage_now > 3700) return 40;  // 3780
+   if (voltage_now > 3600) return 30;  // 3690
+   if (voltage_now > 3550) return 20;  // 3600
+   if (voltage_now > 3500) return 10;  // 3510
+   if (voltage_now > 3400) return 5;   // 3420
+   if (voltage_now > 3300) return 1;   // 3330
+   return 0;                           // 3240
 #else
    return dingux_read_battery_sys_file(DINGUX_BATTERY_CAPACITY_FILE);
 #endif


### PR DESCRIPTION
## Description

Currently when using RGUI on MiyooCFW (on a Powkiddy V90), despite enabling "Show Battery Level", nothing is shown. This change fixes that by comparing the correct voltage_now file.

There are no min/max files on the device so they're hardcoded similar to GMenu2X's indicator. Results are based on value distribution while running a game at max load.

GMenu2X battery level logic:
https://github.com/MiyooCFW/gmenunx/blob/7d51f8c22be22066fbaea671a4baf6d0d0ff5c3f/src/gmenu2x.cpp#L2587-L2598

Miyoo battery properties:
https://github.com/MiyooCFW/kernel/blob/f60025f03429ceb3771e5392a7d85c6f1780a42a/drivers/power/supply/miyoo-battery.c#L62-L72

RGUI battery level update:
https://www.libretro.com/index.php/retroarch-1-7-7-ui-updates/

## Testing

Check the battery level on RGUI using a device on MiyooCFW and miyoo-battery (like the Powkiddy V90).

I have not been able to get RetroArch's Miyoo builds compiling locally so I have not tested this myself. If there's an individual or CI that can build this PR and provide the artifact, I can test it out.

Something like the build pipeline on Gitlab CI:
https://git.libretro.com/libretro/RetroArch/-/pipelines?scope=branches&page=1

## Reviewers

Probably @jdgleaver and/or @salvacam going by previous Miyoo-related PRs.