### PR TITLE
(cheevos) fix identification of chd inside m3u

### DIFF
--- a/deps/rcheevos/include/rc_hash.h
+++ b/deps/rcheevos/include/rc_hash.h
@@ -120,6 +120,7 @@ extern "C" {
     rc_hash_cdreader_first_track_sector_handler      first_track_sector;
   };
 
+  void rc_hash_get_default_cdreader(struct rc_hash_cdreader* cdreader);
   void rc_hash_init_default_cdreader(void);
   void rc_hash_init_custom_cdreader(struct rc_hash_cdreader* reader);
 

--- a/deps/rcheevos/src/rhash/cdreader.c
+++ b/deps/rcheevos/src/rhash/cdreader.c
@@ -836,14 +836,17 @@ static uint32_t cdreader_first_track_sector(void* track_handle)
   return 0;
 }
 
+void rc_hash_get_default_cdreader(struct rc_hash_cdreader* cdreader)
+{
+  cdreader->open_track = cdreader_open_track;
+  cdreader->read_sector = cdreader_read_sector;
+  cdreader->close_track = cdreader_close_track;
+  cdreader->first_track_sector = cdreader_first_track_sector;
+}
+
 void rc_hash_init_default_cdreader()
 {
   struct rc_hash_cdreader cdreader;
-
-  cdreader.open_track = cdreader_open_track;
-  cdreader.read_sector = cdreader_read_sector;
-  cdreader.close_track = cdreader_close_track;
-  cdreader.first_track_sector = cdreader_first_track_sector;
-
+  rc_hash_get_default_cdreader(&cdreader);
   rc_hash_init_custom_cdreader(&cdreader);
 }


### PR DESCRIPTION
## Description

Fixes #13584

Changes made to support RetroAchievements game identification for Dreamcast broke support for processing a `chd` inside an `m3u`. They still worked as top level entities. This PR updates the logic to delay determining when to add the `chd` hooks so they can still be leveraged within an `m3u`.

## Related Issues

#13584

## Related Pull Requests

n/a

## Reviewers

@Sanaki
