### PR TITLE
(Wayland) Show window early to get screen info

### DIFF
--- a/gfx/drivers_context/wayland_ctx.c
+++ b/gfx/drivers_context/wayland_ctx.c
@@ -59,6 +59,9 @@ static enum gfx_ctx_api wl_api   = GFX_CTX_NONE;
 #define EGL_PLATFORM_WAYLAND_KHR 0x31D8
 #endif
 
+#define DEFAULT_WINDOWED_WIDTH 640
+#define DEFAULT_WINDOWED_HEIGHT 480
+
 static void handle_toplevel_config_common(void *data,
       void *toplevel,
       int32_t width, int32_t height, struct wl_array *states)
@@ -126,7 +129,8 @@ static void gfx_ctx_wl_get_video_size(void *data,
 {
    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
 
-   if (wl->surface == NULL) {
+   if (!wl->reported_display_size) {
+      wl->reported_display_size = true;
       output_info_t *oi, *tmp;
       oi = wl->current_output;
 
@@ -409,9 +413,6 @@ static struct libdecor_frame_interface libdecor_frame_interface = {
 };
 #endif
 
-#define DEFAULT_WINDOWED_WIDTH 640
-#define DEFAULT_WINDOWED_HEIGHT 480
-
 #ifdef HAVE_EGL
 #define WL_EGL_ATTRIBS_BASE \
    EGL_SURFACE_TYPE,    EGL_WINDOW_BIT, \
@@ -509,6 +510,8 @@ static void *gfx_ctx_wl_init(void *video_driver)
    wl->input.dpy         = wl_display_connect(NULL);
    wl->last_buffer_scale = 1;
    wl->buffer_scale      = 1;
+   wl->width             = DEFAULT_WINDOWED_WIDTH;
+   wl->height            = DEFAULT_WINDOWED_HEIGHT;
 
    if (!wl->input.dpy)
    {
@@ -542,13 +545,76 @@ static void *gfx_ctx_wl_init(void *video_driver)
 
    if (!wl->idle_inhibit_manager)
    {
-	   RARCH_WARN("[Wayland]: Compositor doesn't support zwp_idle_inhibit_manager_v1 protocol!\n");
+      RARCH_LOG("[Wayland]: Compositor doesn't support zwp_idle_inhibit_manager_v1 protocol\n");
    }
 
    if (!wl->deco_manager)
    {
-	   RARCH_WARN("[Wayland]: Compositor doesn't support zxdg_decoration_manager_v1 protocol!\n");
+      RARCH_LOG("[Wayland]: Compositor doesn't support zxdg_decoration_manager_v1 protocol\n");
    }
+
+   wl->surface                = wl_compositor_create_surface(wl->compositor);
+
+   wl_surface_set_buffer_scale(wl->surface, wl->buffer_scale);
+   wl_surface_add_listener(wl->surface, &wl_surface_listener, wl);
+
+#ifdef HAVE_LIBDECOR
+   wl->libdecor_context = libdecor_new(wl->input.dpy, &libdecor_interface);
+   if (wl->libdecor_context)
+   {
+      wl->libdecor_frame = libdecor_decorate(wl->libdecor_context, wl->surface, &libdecor_frame_interface, wl);
+      if (!wl->libdecor_frame)
+      {
+         RARCH_ERR("[Wayland]: Failed to crate libdecor frame\n");
+         goto error;
+      }
+
+      libdecor_frame_set_app_id(wl->libdecor_frame, "retroarch");
+      libdecor_frame_set_title(wl->libdecor_frame, "RetroArch");
+      libdecor_frame_map(wl->libdecor_frame);
+   }
+
+   /* Waiting for libdecor to be configured before starting to draw */
+   wl_surface_commit(wl->surface);
+   wl->configured = true;
+
+   while (wl->configured)
+   {
+      if (libdecor_dispatch(wl->libdecor_context, 0) < 0)
+      {
+         RARCH_ERR("[Wayland]: libdecor failed to dispatch\n");
+         goto error;
+      }
+   }
+#else
+   wl->xdg_surface = xdg_wm_base_get_xdg_surface(wl->xdg_shell, wl->surface);
+   xdg_surface_add_listener(wl->xdg_surface, &xdg_surface_listener, wl);
+
+   wl->xdg_toplevel = xdg_surface_get_toplevel(wl->xdg_surface);
+   xdg_toplevel_add_listener(wl->xdg_toplevel, &xdg_toplevel_listener, wl);
+
+   xdg_toplevel_set_app_id(wl->xdg_toplevel, "retroarch");
+   xdg_toplevel_set_title(wl->xdg_toplevel, "RetroArch");
+
+   if (wl->deco_manager)
+      wl->deco = zxdg_decoration_manager_v1_get_toplevel_decoration(
+            wl->deco_manager, wl->xdg_toplevel);
+
+   /* Waiting for xdg_toplevel to be configured before starting to draw */
+   wl_surface_commit(wl->surface);
+   wl->configured = true;
+
+   while (wl->configured)
+      wl_display_dispatch(wl->input.dpy);
+#endif
+
+   wl_display_roundtrip(wl->input.dpy);
+   xdg_wm_base_add_listener(wl->xdg_shell, &xdg_shell_listener, NULL);
+
+   /* Bind SHM based wl_buffer to wl_surface until the vulkan surface is ready.
+    * This shows the window which assigns us a display (wl_output)
+    *  which is usefull for HiDPI and auto selecting a display for fullscreen. */
+   draw_splash_screen(wl);
 
    wl->input.fd = wl_display_get_fd(wl->input.dpy);
 
@@ -703,71 +769,23 @@ static bool gfx_ctx_wl_set_video_mode(void *data,
          (gfx_ctx_wayland_data_t*)data, egl_attribs);
 #endif
    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
+   settings_t *settings      = config_get_ptr();
+   unsigned video_monitor_index = settings->uints.video_monitor_index;
 
    wl->width                  = width  ? width  : DEFAULT_WINDOWED_WIDTH;
    wl->height                 = height ? height : DEFAULT_WINDOWED_HEIGHT;
 
-   wl->surface                = wl_compositor_create_surface(wl->compositor);
-
    wl_surface_set_buffer_scale(wl->surface, wl->buffer_scale);
-   wl_surface_add_listener(wl->surface, &wl_surface_listener, wl);
+
+#ifdef HAVE_LIBDECOR
+   struct libdecor_state *state = libdecor_state_new( width, height);
+   libdecor_frame_commit(wl->libdecor_frame, state, NULL);
+   libdecor_state_free(state);
+#endif
 
 #ifdef HAVE_EGL
    wl->win        = wl_egl_window_create(wl->surface, wl->width * wl->buffer_scale, wl->height * wl->buffer_scale);
 #endif
-
-#ifdef HAVE_LIBDECOR
-   wl->libdecor_context = libdecor_new(wl->input.dpy, &libdecor_interface);
-   if (wl->libdecor_context)
-   {
-      wl->libdecor_frame = libdecor_decorate(wl->libdecor_context, wl->surface, &libdecor_frame_interface, wl);
-      if (!wl->libdecor_frame)
-      {
-         RARCH_ERR("[Wayland]: Failed to crate libdecor frame\n");
-         goto error;
-      }
-
-      libdecor_frame_set_app_id(wl->libdecor_frame, "retroarch");
-      libdecor_frame_set_title(wl->libdecor_frame, "RetroArch");
-      libdecor_frame_map(wl->libdecor_frame);
-   }
-
-   /* Waiting for libdecor to be configured before starting to draw */
-   wl_surface_commit(wl->surface);
-   wl->configured = true;
-
-   while (wl->configured)
-   {
-      if (libdecor_dispatch(wl->libdecor_context, 0) < 0)
-      {
-         RARCH_ERR("[Wayland]: libdecor failed to dispatch\n");
-         goto error;
-      }
-   }
-#else
-   wl->xdg_surface = xdg_wm_base_get_xdg_surface(wl->xdg_shell, wl->surface);
-   xdg_surface_add_listener(wl->xdg_surface, &xdg_surface_listener, wl);
-
-   wl->xdg_toplevel = xdg_surface_get_toplevel(wl->xdg_surface);
-   xdg_toplevel_add_listener(wl->xdg_toplevel, &xdg_toplevel_listener, wl);
-
-   xdg_toplevel_set_app_id(wl->xdg_toplevel, "retroarch");
-   xdg_toplevel_set_title(wl->xdg_toplevel, "RetroArch");
-
-   if (wl->deco_manager)
-      wl->deco = zxdg_decoration_manager_v1_get_toplevel_decoration(
-            wl->deco_manager, wl->xdg_toplevel);
-
-   /* Waiting for xdg_toplevel to be configured before starting to draw */
-   wl_surface_commit(wl->surface);
-   wl->configured = true;
-
-   while (wl->configured)
-      wl_display_dispatch(wl->input.dpy);
-#endif
-
-   wl_display_roundtrip(wl->input.dpy);
-   xdg_wm_base_add_listener(wl->xdg_shell, &xdg_shell_listener, NULL);
 
 #ifdef HAVE_EGL
    if (!egl_create_context(&wl->egl, (attr != egl_attribs)
@@ -784,12 +802,35 @@ static bool gfx_ctx_wl_set_video_mode(void *data,
 
    if (fullscreen)
    {
+      struct wl_output *output = NULL;
+      int output_i = 0;
+      output_info_t *oi, *tmp;
+
+      if (video_monitor_index <= 0 && wl->current_output != NULL)
+      {
+         oi = wl->current_output;
+         output = oi->output;
+         RARCH_LOG("[Wayland/Vulkan]: Auto fullscreen on display \"%s\" \"%s\"\n", oi->make, oi->model);
+      }
+      else wl_list_for_each_safe(oi, tmp, &wl->all_outputs, link)
+      {
+         if (++output_i == video_monitor_index)
+         {
+            output = oi->output;
+            RARCH_LOG("[Wayland/Vulkan]: Fullscreen on display %i \"%s\" \"%s\"\n", output_i, oi->make, oi->model);
+            break;
+         }
+      }
+
+      if (output == NULL)
+         RARCH_LOG("[Wayland/Vulkan] Failed to specify monitor for fullscreen, letting compositor decide\n");
+
 #ifdef HAVE_LIBDECOR
-      libdecor_frame_set_fullscreen(wl->libdecor_frame, NULL);
+      libdecor_frame_set_fullscreen(wl->libdecor_frame, output);
 #else
-	   xdg_toplevel_set_fullscreen(wl->xdg_toplevel, NULL);
+      xdg_toplevel_set_fullscreen(wl->xdg_toplevel, output);
 #endif
-	}
+   }
 
    flush_wayland_fd(&wl->input);
 

--- a/gfx/drivers_context/wayland_vk_ctx.c
+++ b/gfx/drivers_context/wayland_vk_ctx.c
@@ -52,6 +52,9 @@
 #define EGL_PLATFORM_WAYLAND_KHR 0x31D8
 #endif
 
+#define DEFAULT_WINDOWED_WIDTH 640
+#define DEFAULT_WINDOWED_HEIGHT 480
+
 static void handle_toplevel_config_common(void *data,
       void *toplevel,
       int32_t width, int32_t height, struct wl_array *states)
@@ -109,7 +112,8 @@ static void gfx_ctx_wl_get_video_size(void *data,
 {
    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
 
-   if (wl->surface == NULL) {
+   if (!wl->reported_display_size) {
+      wl->reported_display_size = true;
       output_info_t *oi, *tmp;
       oi = wl->current_output;
 
@@ -389,9 +393,6 @@ static struct libdecor_frame_interface libdecor_frame_interface = {
 };
 #endif
 
-#define DEFAULT_WINDOWED_WIDTH 640
-#define DEFAULT_WINDOWED_HEIGHT 480
-
 static void *gfx_ctx_wl_init(void *video_driver)
 {
    int i;
@@ -408,6 +409,8 @@ static void *gfx_ctx_wl_init(void *video_driver)
    wl->input.dpy         = wl_display_connect(NULL);
    wl->last_buffer_scale = 1;
    wl->buffer_scale      = 1;
+   wl->width             = DEFAULT_WINDOWED_WIDTH;
+   wl->height            = DEFAULT_WINDOWED_HEIGHT;
 
    if (!wl->input.dpy)
    {
@@ -441,13 +444,76 @@ static void *gfx_ctx_wl_init(void *video_driver)
 
    if (!wl->idle_inhibit_manager)
    {
-	   RARCH_WARN("[Wayland]: Compositor doesn't support zwp_idle_inhibit_manager_v1 protocol!\n");
+      RARCH_LOG("[Wayland]: Compositor doesn't support zwp_idle_inhibit_manager_v1 protocol\n");
    }
 
    if (!wl->deco_manager)
    {
-	   RARCH_WARN("[Wayland]: Compositor doesn't support zxdg_decoration_manager_v1 protocol!\n");
+      RARCH_LOG("[Wayland]: Compositor doesn't support zxdg_decoration_manager_v1 protocol\n");
    }
+
+   wl->surface                = wl_compositor_create_surface(wl->compositor);
+
+   wl_surface_set_buffer_scale(wl->surface, wl->buffer_scale);
+   wl_surface_add_listener(wl->surface, &wl_surface_listener, wl);
+
+#ifdef HAVE_LIBDECOR
+   wl->libdecor_context = libdecor_new(wl->input.dpy, &libdecor_interface);
+   if (wl->libdecor_context)
+   {
+      wl->libdecor_frame = libdecor_decorate(wl->libdecor_context, wl->surface, &libdecor_frame_interface, wl);
+      if (!wl->libdecor_frame)
+      {
+         RARCH_ERR("[Wayland/Vulkan]: Failed to crate libdecor frame\n");
+         goto error;
+      }
+
+      libdecor_frame_set_app_id(wl->libdecor_frame, "retroarch");
+      libdecor_frame_set_title(wl->libdecor_frame, "RetroArch");
+      libdecor_frame_map(wl->libdecor_frame);
+   }
+
+   /* Waiting for libdecor to be configured before starting to draw */
+   wl_surface_commit(wl->surface);
+   wl->configured = true;
+
+   while (wl->configured)
+   {
+      if (libdecor_dispatch(wl->libdecor_context, 0) < 0)
+      {
+         RARCH_ERR("[Wayland/Vulkan]: libdecor failed to dispatch\n");
+         goto error;
+      }
+   }
+#else
+   wl->xdg_surface  = xdg_wm_base_get_xdg_surface(wl->xdg_shell, wl->surface);
+   xdg_surface_add_listener(wl->xdg_surface, &xdg_surface_listener, wl);
+
+   wl->xdg_toplevel = xdg_surface_get_toplevel(wl->xdg_surface);
+   xdg_toplevel_add_listener(wl->xdg_toplevel, &xdg_toplevel_listener, wl);
+
+   xdg_toplevel_set_app_id(wl->xdg_toplevel, "retroarch");
+   xdg_toplevel_set_title(wl->xdg_toplevel, "RetroArch");
+
+   if (wl->deco_manager)
+      wl->deco = zxdg_decoration_manager_v1_get_toplevel_decoration(
+            wl->deco_manager, wl->xdg_toplevel);
+
+   /* Waiting for xdg_toplevel to be configured before starting to draw */
+   wl_surface_commit(wl->surface);
+   wl->configured = true;
+
+   while (wl->configured)
+      wl_display_dispatch(wl->input.dpy);
+#endif
+
+   wl_display_roundtrip(wl->input.dpy);
+   xdg_wm_base_add_listener(wl->xdg_shell, &xdg_shell_listener, NULL);
+
+   /* Bind SHM based wl_buffer to wl_surface until the vulkan surface is ready.
+    * This shows the window which assigns us a display (wl_output)
+    *  which is usefull for HiDPI and auto selecting a display for fullscreen. */
+   draw_splash_screen(wl);
 
    wl->input.fd = wl_display_get_fd(wl->input.dpy);
 
@@ -518,74 +584,49 @@ static bool gfx_ctx_wl_set_video_mode(void *data,
       bool fullscreen)
 {
    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
+   settings_t *settings      = config_get_ptr();
+   unsigned video_monitor_index = settings->uints.video_monitor_index;
 
    wl->width                  = width  ? width  : DEFAULT_WINDOWED_WIDTH;
    wl->height                 = height ? height : DEFAULT_WINDOWED_HEIGHT;
 
-   wl->surface                = wl_compositor_create_surface(wl->compositor);
-
    wl_surface_set_buffer_scale(wl->surface, wl->buffer_scale);
-   wl_surface_add_listener(wl->surface, &wl_surface_listener, wl);
 
 #ifdef HAVE_LIBDECOR
-   wl->libdecor_context = libdecor_new(wl->input.dpy, &libdecor_interface);
-   if (wl->libdecor_context)
-   {
-      wl->libdecor_frame = libdecor_decorate(wl->libdecor_context, wl->surface, &libdecor_frame_interface, wl);
-      if (!wl->libdecor_frame)
-      {
-         RARCH_ERR("[Wayland/Vulkan]: Failed to crate libdecor frame\n");
-         goto error;
-      }
-
-      libdecor_frame_set_app_id(wl->libdecor_frame, "retroarch");
-      libdecor_frame_set_title(wl->libdecor_frame, "RetroArch");
-      libdecor_frame_map(wl->libdecor_frame);
-   }
-
-   /* Waiting for libdecor to be configured before starting to draw */
-   wl_surface_commit(wl->surface);
-   wl->configured = true;
-
-   while (wl->configured)
-   {
-      if (libdecor_dispatch(wl->libdecor_context, 0) < 0)
-      {
-         RARCH_ERR("[Wayland/Vulkan]: libdecor failed to dispatch\n");
-         goto error;
-      }
-   }
-#else
-   wl->xdg_surface  = xdg_wm_base_get_xdg_surface(wl->xdg_shell, wl->surface);
-   xdg_surface_add_listener(wl->xdg_surface, &xdg_surface_listener, wl);
-
-   wl->xdg_toplevel = xdg_surface_get_toplevel(wl->xdg_surface);
-   xdg_toplevel_add_listener(wl->xdg_toplevel, &xdg_toplevel_listener, wl);
-
-   xdg_toplevel_set_app_id(wl->xdg_toplevel, "retroarch");
-   xdg_toplevel_set_title(wl->xdg_toplevel, "RetroArch");
-
-   if (wl->deco_manager)
-      wl->deco = zxdg_decoration_manager_v1_get_toplevel_decoration(
-            wl->deco_manager, wl->xdg_toplevel);
-
-   /* Waiting for xdg_toplevel to be configured before starting to draw */
-   wl_surface_commit(wl->surface);
-   wl->configured = true;
-
-   while (wl->configured)
-      wl_display_dispatch(wl->input.dpy);
+   struct libdecor_state *state = libdecor_state_new( width, height);
+   libdecor_frame_commit(wl->libdecor_frame, state, NULL);
+   libdecor_state_free(state);
 #endif
-
-   wl_display_roundtrip(wl->input.dpy);
-   xdg_wm_base_add_listener(wl->xdg_shell, &xdg_shell_listener, NULL);
 
    if (fullscreen)
    {
+      struct wl_output *output = NULL;
+      int output_i = 0;
+      output_info_t *oi, *tmp;
+
+      if (video_monitor_index <= 0 && wl->current_output != NULL)
+      {
+         oi = wl->current_output;
+         output = oi->output;
+         RARCH_LOG("[Wayland/Vulkan]: Auto fullscreen on display \"%s\" \"%s\"\n", oi->make, oi->model);
+      }
+      else wl_list_for_each_safe(oi, tmp, &wl->all_outputs, link)
+      {
+         if (++output_i == video_monitor_index)
+         {
+            output = oi->output;
+            RARCH_LOG("[Wayland/Vulkan]: Fullscreen on display %i \"%s\" \"%s\"\n", output_i, oi->make, oi->model);
+            break;
+         }
+      }
+
+      if (output == NULL)
+         RARCH_LOG("[Wayland/Vulkan] Failed to specify monitor for fullscreen, letting compositor decide\n");
+
 #ifdef HAVE_LIBDECOR
-      libdecor_frame_set_fullscreen(wl->libdecor_frame, NULL);
+      libdecor_frame_set_fullscreen(wl->libdecor_frame, output);
 #else
-      xdg_toplevel_set_fullscreen(wl->xdg_toplevel, NULL);
+      xdg_toplevel_set_fullscreen(wl->xdg_toplevel, output);
 #endif
    }
 

--- a/input/common/wayland_common.h
+++ b/input/common/wayland_common.h
@@ -77,6 +77,8 @@ typedef struct output_info
    unsigned physical_width;
    unsigned physical_height;
    unsigned scale;
+   char *make;
+   char *model;
    struct wl_list link; /* wl->all_outputs */
 } output_info_t;
 
@@ -96,7 +98,7 @@ typedef struct input_ctx_wayland_data
 
    struct
    {
-      struct wl_pointer *surface;
+      struct wl_surface *surface;
       int last_x, last_y;
       int x, y;
       int delta_x, delta_y;
@@ -167,7 +169,14 @@ typedef struct gfx_ctx_wayland_data
    bool resize;
    bool configured;
    bool activated;
+   bool reported_display_size;
 } gfx_ctx_wayland_data_t;
+
+typedef struct shm_buffer {
+   struct wl_buffer *wl_buffer;
+   void *data;
+   size_t data_size;
+} shm_buffer_t;
 
 #ifdef HAVE_XKBCOMMON
 /* FIXME: Move this into a header? */
@@ -184,6 +193,17 @@ void handle_toplevel_close(void *data,
       struct xdg_toplevel *xdg_toplevel);
 
 void flush_wayland_fd(void *data);
+
+int create_anonymous_file(off_t size);
+
+shm_buffer_t *create_shm_buffer(gfx_ctx_wayland_data_t *wl,
+   int width, int height, uint32_t format);
+
+void shm_buffer_paint_checkerboard(shm_buffer_t *buffer,
+      int width, int height, int scale,
+      size_t chk, uint32_t bg, uint32_t fg);
+
+void draw_splash_screen(gfx_ctx_wayland_data_t *wl);
 
 extern const struct wl_keyboard_listener keyboard_listener;
 
@@ -202,5 +222,7 @@ extern const struct xdg_surface_listener xdg_surface_listener;
 extern const struct wl_output_listener output_listener;
 
 extern const struct wl_registry_listener registry_listener;
+
+extern const struct wl_buffer_listener shm_buffer_listener;
 
 #endif

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -550,6 +550,7 @@ fi
 
 check_lib '' STRCASESTR "$CLIB" strcasestr
 check_lib '' MMAP "$CLIB" mmap
+check_lib '' MEMFD_CREATE "$CLIB" memfd_create
 
 check_enabled CXX VULKAN vulkan 'The C++ compiler is' false
 check_enabled CXX OPENGL_CORE 'OpenGL core' 'The C++ compiler is' false

--- a/qb/config.params.sh
+++ b/qb/config.params.sh
@@ -195,4 +195,5 @@ HAVE_LIBSHAKE=no           # libShake haptic feedback support
 HAVE_CHECK=no              # check support for unit tests
 HAVE_WIFI=no               # wifi driver support
 HAVE_CRTSWITCHRES=auto     # CRT mode switching support (requires C++11)
+HAVE_MEMFD_CREATE=auto     # libc supports memfd_create
 C89_CRTSWITCHRES=no


### PR DESCRIPTION
Corrected version of #13582 adding a fallback to `shm_open` when `memfd_create` is not present in libc.

The build bot version of Ubuntu is 16.04 LTS (Xenial Xerus) from 2015 which a few LTS releases behind.
`memfd_create` was introduced in glibc 2.27 first included in Ubuntu 18.04 LTS (Bionic Beaver) in 2018.

Is it possible to bump the linux build image?
Ubuntu 18.04 LTS (Bionic Beaver) appears to be the final LTS to support 32-bit if that's of concern.

## Description

Wayland doesn't gives hints about a which display a window will be assigned. This info is useful for reporting the display size on the initial call to `get_video_size` and for selecting the correct monitor for fullscreen.

This MR shows a window as soon as possible in order to get info about the display it as been assigned to. It also makes window appear on the correct display when fullscreen.

This allows:
* Current monitor size to be reported correctly on initial `get_video_size` call
* The monitor selected in settings to be the one used when the window is fullscreen
* The current monitor to be used for fullscreen when automatic monitor selection is set

As far as I understand wayland only allows fullscreen windows to select a display.

## Related Issues

#12635