### PR TITLE
Fix Polish translation

### DIFF
--- a/intl/msg_hash_de.c
+++ b/intl/msg_hash_de.c
@@ -2047,7 +2047,7 @@ static const char *menu_hash_to_str_de_label_enum(enum msg_hash_enums msg)
    {
       static char hotkey_lbl[128] = {0};
       unsigned idx = msg - MENU_ENUM_LABEL_INPUT_HOTKEY_BIND_BEGIN;
-      snprintf(hotkey_lbl, sizeof(hotkey_lbl), "input_hotkey_binds_%d", idx);
+      snprintf(hotkey_lbl, sizeof(hotkey_lbl), "input_hotkey_binds_%u", idx);
       return hotkey_lbl;
    }
 

--- a/intl/msg_hash_pl.c
+++ b/intl/msg_hash_pl.c
@@ -12,10 +12,17 @@
  *  You should have received a copy of the GNU General Public License along with RetroArch.
  *  If not, see <http://www.gnu.org/licenses/>.
  */
+
+#include <stdio.h>
 #include <stdint.h>
-#include <string.h>
+#include <stddef.h>
+
+#include <compat/strl.h>
+#include <string/stdstring.h>
 
 #include "../msg_hash.h"
+#include "../configuration.h"
+#include "../verbosity.h"
 
 #if defined(_MSC_VER) && !defined(_XBOX) && (_MSC_VER >= 1500 && _MSC_VER < 1900)
 #if (_MSC_VER >= 1700)

--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -7661,7 +7661,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_LANG_ARABIC,
-   "Arabic -  اَلْعَرَبِيَّةُ  (Restart Required)"
+   "Arabic - اَلْعَرَبِيَّةُ (Restart Required)"
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_LANG_ASTURIAN,
@@ -7829,7 +7829,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_LANG_PERSIAN,
-   "Persian -  فارسی  (Restart Required)"
+   "Persian - فارسی (Restart Required)"
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_LANG_POLISH,
@@ -7897,7 +7897,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_LANG_URDU,
-   "Urdu -  اُردُو  (Restart Required)"
+   "Urdu - اُردُو (Restart Required)"
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_LANG_VIETNAMESE,


### PR DESCRIPTION
## Description

The Polish translations were all messed up, displaying `Main Menu` as `Input`, `Settings` as `History`, etc.
This was fixed by simply copying over the `#include` statements from a working localization's `msg_hash_*.c`.

(For those that might be curious about the changes in `msg_hash_us.h`: Apparently those lines contained "strange terminators", or something like that; VS Code got rid of them - shouldn't matter much, really)

## Related Issues

This should resolve #11974
