### PR TITLE
Fix segfault when launching content with cores that do not have serialized savestate support when rewind and cheevos hardcore mode are enabled

### DIFF
--- a/cheevos/cheevos_menu.c
+++ b/cheevos/cheevos_menu.c
@@ -401,7 +401,7 @@ void rcheevos_menu_populate_hardcore_pause_submenu(void* data)
       {
          menu_entries_append_enum(info->list,
                msg_hash_to_str(MENU_ENUM_LABEL_VALUE_ACHIEVEMENT_PAUSE_CANCEL),
-               msg_hash_to_str(MENU_ENUM_SUBLABEL_ACHIEVEMENT_PAUSE_CANCEL),
+               msg_hash_to_str(MENU_ENUM_LABEL_ACHIEVEMENT_PAUSE_CANCEL),
                MENU_ENUM_LABEL_ACHIEVEMENT_PAUSE_CANCEL,
                MENU_SETTING_ACTION_CLOSE, 0, 0);
          menu_entries_append_enum(info->list,
@@ -414,7 +414,7 @@ void rcheevos_menu_populate_hardcore_pause_submenu(void* data)
       {
          menu_entries_append_enum(info->list,
                msg_hash_to_str(MENU_ENUM_LABEL_VALUE_ACHIEVEMENT_RESUME_CANCEL),
-               msg_hash_to_str(MENU_ENUM_SUBLABEL_ACHIEVEMENT_RESUME_CANCEL),
+               msg_hash_to_str(MENU_ENUM_LABEL_ACHIEVEMENT_RESUME_CANCEL),
                MENU_ENUM_LABEL_ACHIEVEMENT_RESUME_CANCEL,
                MENU_SETTING_ACTION_CLOSE, 0, 0);
          menu_entries_append_enum(info->list,
@@ -451,13 +451,13 @@ void rcheevos_menu_populate(void* data)
          if (rcheevos_locals->hardcore_active)
             menu_entries_append_enum(info->list,
                   msg_hash_to_str(MENU_ENUM_LABEL_VALUE_ACHIEVEMENT_PAUSE),
-                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_ACHIEVEMENT_PAUSE_MENU),
+                  msg_hash_to_str(MENU_ENUM_LABEL_ACHIEVEMENT_PAUSE_MENU),
                   MENU_ENUM_LABEL_ACHIEVEMENT_PAUSE_MENU,
                   MENU_SETTING_ACTION_PAUSE_ACHIEVEMENTS, 0, 0);
          else
             menu_entries_append_enum(info->list,
                   msg_hash_to_str(MENU_ENUM_LABEL_VALUE_ACHIEVEMENT_RESUME),
-                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_ACHIEVEMENT_PAUSE_MENU),
+                  msg_hash_to_str(MENU_ENUM_LABEL_ACHIEVEMENT_PAUSE_MENU),
                   MENU_ENUM_LABEL_ACHIEVEMENT_PAUSE_MENU,
                   MENU_SETTING_ACTION_RESUME_ACHIEVEMENTS, 0, 0);
       }

--- a/intl/msg_hash_lbl.h
+++ b/intl/msg_hash_lbl.h
@@ -23,8 +23,24 @@ MSG_HASH(
    "retro_achievements"
    )
 MSG_HASH(
-   MENU_ENUM_LABEL_VALUE_ACHIEVEMENT_PAUSE_MENU,
-   "toggle_cheevos_hardcore"
+   MENU_ENUM_LABEL_ACHIEVEMENT_PAUSE_MENU,
+   "achievement_pause_menu"
+   )
+MSG_HASH(
+   MENU_ENUM_LABEL_ACHIEVEMENT_PAUSE_CANCEL,
+   "achievement_pause_cancel"
+   )
+MSG_HASH(
+   MENU_ENUM_LABEL_ACHIEVEMENT_RESUME_CANCEL,
+   "achievement_resume_cancel"
+   )
+MSG_HASH(
+   MENU_ENUM_LABEL_ACHIEVEMENT_PAUSE,
+   "achievement_pause"
+   )
+MSG_HASH(
+   MENU_ENUM_LABEL_ACHIEVEMENT_RESUME,
+   "achievement_resume"
    )
 MSG_HASH(
    MENU_ENUM_LABEL_ACCOUNTS_TWITCH,

--- a/menu/cbs/menu_cbs_deferred_push.c
+++ b/menu/cbs/menu_cbs_deferred_push.c
@@ -852,7 +852,7 @@ static int menu_cbs_init_bind_deferred_push_compare_label(
 #ifdef HAVE_VIDEO_LAYOUT
       {MENU_ENUM_LABEL_VIDEO_LAYOUT_PATH, deferred_push_video_layout_path}, 
 #endif
-      {MENU_ENUM_LABEL_VALUE_ACHIEVEMENT_PAUSE_MENU, deferred_push_achievement_pause_menu},
+      {MENU_ENUM_LABEL_ACHIEVEMENT_PAUSE_MENU, deferred_push_achievement_pause_menu},
       {MENU_ENUM_LABEL_ACHIEVEMENT_LIST, deferred_push_achievement_list},
       {MENU_ENUM_LABEL_CORE_COUNTERS, deferred_push_core_counters},
       {MENU_ENUM_LABEL_FRONTEND_COUNTERS, deferred_push_frontend_counters},

--- a/menu/cbs/menu_cbs_title.c
+++ b/menu/cbs/menu_cbs_title.c
@@ -1177,7 +1177,7 @@ static int menu_cbs_init_bind_title_compare_label(menu_file_list_cbs_t *cbs,
       {MENU_ENUM_LABEL_DEFERRED_PLAYLIST_MANAGER_LIST,
          action_get_playlist_manager_list},
 #ifdef HAVE_CHEEVOS
-      {MENU_ENUM_LABEL_VALUE_ACHIEVEMENT_PAUSE_MENU,
+      {MENU_ENUM_LABEL_ACHIEVEMENT_PAUSE_MENU,
          action_get_title_achievement_pause_menu},
       {MENU_ENUM_LABEL_ACHIEVEMENT_LIST,
          action_get_title_cheevos_list},

--- a/state_manager.c
+++ b/state_manager.c
@@ -578,9 +578,18 @@ void state_manager_event_init(
       struct state_manager_rewind_state *rewind_st,
       unsigned rewind_buffer_size)
 {
-   void *state          = NULL;
+   core_info_t *core_info = NULL;
+   void *state            = NULL;
 
    if (!rewind_st || rewind_st->state)
+      return;
+
+   /* We cannot initialise the rewind buffer
+    * unless the core info struct for the current
+    * core has been initialised (i.e. without this,
+    * the savestate support level for the current
+    * core is unknown) */
+   if (!core_info_get_current_core(&core_info) || !core_info)
       return;
 
    if (!core_info_current_supports_rewind())


### PR DESCRIPTION
## Description

At present, we have a troublesome edge case. If rewind, cheevos and cheevos hardcore mode are all enabled, then launching content will inadvertently cause the rewind buffer to be initialised 'early', at a point where the info struct for the current core is not yet initialised. Normally, the rewind buffer will be disabled if the core has an insufficient savestate support level - but if the info struct is unavailable then deterministic savestate support is assumed by default. Thus, if a core has 'broken' savestate support, the rewind+cheevos+hardcore combination can result in the rewind buffer being initialised inappropriately - and if the core is sufficiently 'broken' (e.g. cdi2005), this can produce a segfault.

This PR simply modifies the rewind buffer code to prevent initialisation if the info struct for the current core is unavailable. While the cheevos code should probably be modified to prevent buffer initialisation requests in the first place, guarding the rewind buffer code is good practice in any case, and solves the immediate problem.

This PR also fixes a few trivial menu bugs (incorrect label usage) related to cheevos hardcore mode that I noticed while investigating the above issue.