### PR TITLE
fix building against ffmpeg 5.0

### DIFF
--- a/cores/libretro-ffmpeg/video_buffer.c
+++ b/cores/libretro-ffmpeg/video_buffer.c
@@ -2,6 +2,7 @@
 extern "C" {
 #endif
 #include <libavformat/avformat.h>
+#include <libavutil/imgutils.h>
 #ifdef __cplusplus
 }
 #endif
@@ -69,17 +70,18 @@ video_buffer_t *video_buffer_create(
       b->buffer[i].pts       = 0;
       b->buffer[i].sws       = sws_alloc_context();
       b->buffer[i].source    = av_frame_alloc();
-#if LIBAVUTIL_VERSION_MAJOR > 55
+#if ENABLE_HW_ACCEL
       b->buffer[i].hw_source = av_frame_alloc();
 #endif
       b->buffer[i].target    = av_frame_alloc();
 
-      avpicture_alloc((AVPicture*)b->buffer[i].target,
-            PIX_FMT_RGB32, width, height);
+      AVFrame* frame = b->buffer[i].target;
+      av_image_alloc(frame->data, frame->linesize,
+            width, height, AV_PIX_FMT_RGB32, 1);
 
       if (!b->buffer[i].sws       ||
           !b->buffer[i].source    ||
-#if LIBAVUTIL_VERSION_MAJOR > 55
+#if ENABLE_HW_ACCEL
           !b->buffer[i].hw_source ||
 #endif
           !b->buffer[i].target)
@@ -106,11 +108,11 @@ void video_buffer_destroy(video_buffer_t *video_buffer)
    {
       for (i = 0; i < video_buffer->capacity; i++)
       {
-#if LIBAVUTIL_VERSION_MAJOR > 55
+#if ENABLE_HW_ACCEL
          av_frame_free(&video_buffer->buffer[i].hw_source);
 #endif
          av_frame_free(&video_buffer->buffer[i].source);
-         avpicture_free((AVPicture*)video_buffer->buffer[i].target);
+         av_freep((AVFrame*)video_buffer->buffer[i].target);
          av_frame_free(&video_buffer->buffer[i].target);
          sws_freeContext(video_buffer->buffer[i].sws);
       }

--- a/cores/libretro-ffmpeg/video_buffer.h
+++ b/cores/libretro-ffmpeg/video_buffer.h
@@ -31,22 +31,24 @@ extern "C" {
 
 RETRO_BEGIN_DECLS
 
-#ifndef PIX_FMT_RGB32
-#define PIX_FMT_RGB32 AV_PIX_FMT_RGB32
-#endif
+/* If libavutil is at least version 55,
+ * and if libavcodec is at least version 57.80.100,
+ * enable hardware acceleration */
+#define ENABLE_HW_ACCEL ((LIBAVUTIL_VERSION_MAJOR >= 55) && \
+      (LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 80, 100)))
 
 /**
  * video_decoder_context
- * 
+ *
  * Context object for the sws worker threads.
- * 
+ *
  */
 struct video_decoder_context
 {
    int64_t pts;
    struct SwsContext *sws;
    AVFrame *source;
-#if LIBAVUTIL_VERSION_MAJOR > 55
+#if ENABLE_HW_ACCEL
    AVFrame *hw_source;
 #endif
    AVFrame *target;
@@ -60,15 +62,15 @@ typedef struct video_decoder_context video_decoder_context_t;
 
 /**
  * video_buffer
- * 
- * The video buffer is a ring buffer, that can be used as a 
+ *
+ * The video buffer is a ring buffer, that can be used as a
  * buffer for many workers while keeping the order.
- * 
+ *
  * It is thread safe in a sensem that it is designed to work
  * with one work coordinator, that allocates work slots for
  * workers threads to work on and later collect the work
  * product in the same order, as the slots were allocated.
- * 
+ *
  */
 struct video_buffer;
 typedef struct video_buffer video_buffer_t;
@@ -81,38 +83,38 @@ typedef struct video_buffer video_buffer_t;
  * @height        : Height of the target frame.
  *
  * Create a video buffer.
- * 
+ *
  * Returns: A video buffer.
  */
 video_buffer_t *video_buffer_create(size_t capacity, int frame_size, int width, int height);
 
-/** 
+/**
  * video_buffer_destroy:
  * @video_buffer      : video buffer.
- * 
+ *
  * Destroys a video buffer.
- * 
+ *
  * Does also free the buffer allocated with video_buffer_create().
  * User has to shut down any external worker threads that may have
  * a reference to this video buffer.
- * 
+ *
  **/
 void video_buffer_destroy(video_buffer_t *video_buffer);
 
-/** 
+/**
  * video_buffer_clear:
  * @video_buffer      : video buffer.
- * 
+ *
  * Clears a video buffer.
- * 
+ *
  **/
 void video_buffer_clear(video_buffer_t *video_buffer);
 
-/** 
+/**
  * video_buffer_get_open_slot:
  * @video_buffer     : video buffer.
  * @context          : sws context.
- * 
+ *
  * Returns the next open context inside the ring buffer
  * and it's index. The status of the slot will be marked as
  * 'in progress' until slot is marked as finished with
@@ -121,21 +123,21 @@ void video_buffer_clear(video_buffer_t *video_buffer);
  **/
 void video_buffer_get_open_slot(video_buffer_t *video_buffer, video_decoder_context_t **context);
 
-/** 
+/**
  * video_buffer_return_open_slot:
  * @video_buffer     : video buffer.
  * @context          : sws context.
- * 
+ *
  * Marks the given sws context that is "in progress" as "open" again.
  *
  **/
 void video_buffer_return_open_slot(video_buffer_t *video_buffer, video_decoder_context_t *context);
 
-/** 
+/**
  * video_buffer_open_slot:
  * @video_buffer     : video buffer.
  * @context          : sws context.
- * 
+ *
  * Sets the status of the given context from "finished" to "open".
  * The slot is then available for producers to claim again with video_buffer_get_open_slot().
  **/
@@ -145,7 +147,7 @@ void video_buffer_open_slot(video_buffer_t *video_buffer, video_decoder_context_
  * video_buffer_get_finished_slot:
  * @video_buffer     : video buffer.
  * @context          : sws context.
- * 
+ *
  * Returns a reference for the next context inside
  * the ring buffer. User needs to use video_buffer_open_slot()
  * to open the slot in the ringbuffer for the next
@@ -158,7 +160,7 @@ void video_buffer_get_finished_slot(video_buffer_t *video_buffer, video_decoder_
  * video_buffer_finish_slot:
  * @video_buffer     : video buffer.
  * @context          : sws context.
- * 
+ *
  * Sets the status of the given context from "in progress" to "finished".
  * This is normally done by a producer. User can then retrieve the finished work
  * context by calling video_buffer_get_finished_slot().
@@ -168,9 +170,9 @@ void video_buffer_finish_slot(video_buffer_t *video_buffer, video_decoder_contex
 /**
  * video_buffer_wait_for_open_slot:
  * @video_buffer      : video buffer.
- * 
+ *
  * Blocks until open slot is available.
- * 
+ *
  * Returns true if the buffer has a open slot available.
  */
 bool video_buffer_wait_for_open_slot(video_buffer_t *video_buffer);
@@ -180,7 +182,7 @@ bool video_buffer_wait_for_open_slot(video_buffer_t *video_buffer);
  * @video_buffer      : video buffer.
  *
  * Blocks until finished slot is available.
- * 
+ *
  * Returns true if the buffers next slot is finished and a
  * context available.
  */
@@ -190,7 +192,7 @@ bool video_buffer_wait_for_finished_slot(video_buffer_t *video_buffer);
  * bool video_buffer_has_open_slot(video_buffer_t *video_buffer)
 :
  * @video_buffer      : video buffer.
- * 
+ *
  * Returns true if the buffer has a open slot available.
  */
 bool video_buffer_has_open_slot(video_buffer_t *video_buffer);

--- a/gfx/include/userland/interface/mmal/components/avcodec_audio_decoder.c
+++ b/gfx/include/userland/interface/mmal/components/avcodec_audio_decoder.c
@@ -32,25 +32,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "libavcodec/avcodec.h"
 #include "libavutil/mathematics.h"
-#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT( 52, 23, 0 )
-# include "libavformat/avformat.h"
- static AVPacket null_packet = {AV_NOPTS_VALUE, AV_NOPTS_VALUE};
-# define av_init_packet(a) *(a) = null_packet
-#endif
-
-#if LIBAVCODEC_VERSION_MAJOR < 53
-# define avcodec_decode_audio3(a,b,c,d) avcodec_decode_audio2(a,b,c,(d)->data,(d)->size)
-#endif
-
-#if LIBAVCODEC_VERSION_MAJOR < 54
-#define AVSampleFormat      SampleFormat
-#define AV_SAMPLE_FMT_NONE  SAMPLE_FMT_NONE
-#define AV_SAMPLE_FMT_U8    SAMPLE_FMT_U8
-#define AV_SAMPLE_FMT_S16   SAMPLE_FMT_S16
-#define AV_SAMPLE_FMT_S32   SAMPLE_FMT_S32
-#define AV_SAMPLE_FMT_FLT   SAMPLE_FMT_FLT
-#define AV_SAMPLE_FMT_DBL   SAMPLE_FMT_DBL
-#endif
 
 /* Buffering requirements */
 #define INPUT_MIN_BUFFER_SIZE (4*1024)


### PR DESCRIPTION
## Description

This is a continuation of @alucryd's excellent work in PR #13542.  I've fixed the segfault and various other issues.  It works perfectly with FFmpeg 4, but there's no audio with FFmpeg 5; I have no idea why, as it seems that everything is working properly, but for some reason, none of the audio data is actually being written to the file (the video works fine and the FFmpeg API calls used for both the audio and the video seem to be mostly the same, so I don't know why one works and one doesn't; I must have overlooked something somewhere).

## Related Issues

As with alucryd's original PR, this fixes #13530.
