### PR TITLE
change default for cheevos_richpresence_enable back to true

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -1899,7 +1899,7 @@ static struct config_bool_setting *populate_settings_bool(
    SETTING_BOOL("cheevos_test_unofficial",      &settings->bools.cheevos_test_unofficial, true, false, false);
    SETTING_BOOL("cheevos_hardcore_mode_enable", &settings->bools.cheevos_hardcore_mode_enable, true, true, false);
    SETTING_BOOL("cheevos_challenge_indicators", &settings->bools.cheevos_challenge_indicators, true, true, false);
-   SETTING_BOOL("cheevos_richpresence_enable",  &settings->bools.cheevos_richpresence_enable, true, false, false);
+   SETTING_BOOL("cheevos_richpresence_enable",  &settings->bools.cheevos_richpresence_enable, true, true, false);
    SETTING_BOOL("cheevos_unlock_sound_enable",  &settings->bools.cheevos_unlock_sound_enable, true, false, false);
    SETTING_BOOL("cheevos_verbose_enable",       &settings->bools.cheevos_verbose_enable, true, true, false);
    SETTING_BOOL("cheevos_auto_screenshot",      &settings->bools.cheevos_auto_screenshot, true, false, false);


### PR DESCRIPTION
## Description

#13486 changed the default for `cheevos_richpresence_enable` to false for 3DS. Apparently, the change was pushed through for all systems by https://github.com/libretro/RetroArch/commit/4fa1443c71dbf55905453e3db0c3c76b970a0ca5, without any input from the RetroAchievements team. This PR changes the default back to `true`.

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@Sanaki
