### PR TITLE
Fix base path when compiling with unix cwd

### DIFF
--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -1799,7 +1799,7 @@ static void frontend_unix_get_env(int *argc,
    char base_path[PATH_MAX] = {0};
 #if defined(RARCH_UNIX_CWD_ENV)
    /* The entire path is zero initialized. */
-   base_path[0] = '.';
+   getcwd(base_path, sizeof(base_path));
 #elif defined(DINGUX)
    dingux_get_base_path(base_path, sizeof(base_path));
 #else


### PR DESCRIPTION
## Description

RetroArch did not tackle getting . as base path provided by the unix platform breaking some cores, using getcwd seems to fix it.

## Related Issues

https://steamcommunity.com/app/1118310/discussions/3/3194737075872645555/

## Reviewers

@twinaphex @jdgleaver 
