### PR TITLE
[Netplay] Disable savestates on stateless mode

### DIFF
--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -6762,6 +6762,9 @@ netplay_t *netplay_new(const char *server, const char *mitm, uint16_t port,
                                 NETPLAY_CONNECTION_SPECTATING :
                                 NETPLAY_CONNECTION_NONE;
 
+   if (netplay->stateless_mode)
+      netplay->quirks |= NETPLAY_QUIRK_NO_SAVESTATES;
+
    if (netplay->is_server)
    {
       netplay->connections       = NULL;


### PR DESCRIPTION
## Description

Stateless mode is currently not working correctly and still using savestates.

## Reviewers

@twinaphex 