### PR TITLE
(Wayland) Fix wayland vulkan not reacting to initial resize

### DIFF
--- a/input/common/wayland_common.h
+++ b/input/common/wayland_common.h
@@ -156,10 +156,10 @@ typedef struct gfx_ctx_wayland_data
    int num_active_touches;
    int swap_interval;
    touch_pos_t active_touch_positions[MAX_TOUCHES]; /* int32_t alignment */
-   unsigned prev_width;
-   unsigned prev_height;
    unsigned width;
    unsigned height;
+   unsigned floating_width;
+   unsigned floating_height;
    unsigned last_buffer_scale;
    unsigned buffer_scale;
 


### PR DESCRIPTION
## Description

(Wayland) Correct log stamps for GL or Vulkan
(Wayland) Fix style issues and sync formatting on identical code in GL and Vulkan

The issue of the vulkan window not resizing is fixed by adding `wl_display_roundtrip(wl->input.dpy);` after drawing the splash screen.

I synced the formatting between GL and Vulkan as I was trying to track down an issue where in tiled mode the window would resize on lost focus.
This happens in with Vulkan but not GL and seems to be fixed when using the master branch of libdecor.

If there are further formatting improvements please point them out.