### PR TITLE
(DInput/WinRaw) Ignore 'unknown/undefined' key

### DIFF
--- a/input/drivers/dinput.c
+++ b/input/drivers/dinput.c
@@ -265,8 +265,13 @@ static void dinput_poll(void *data)
          }
       }
       else
+      {
          /* Shifts only when window focused */
          dinput_keyboard_mods(di, RETROKMOD_SHIFT);
+
+         /* Ignore 'unknown/undefined' key */
+         di->state[RETROK_UNKNOWN] = 0;
+      }
 
       /* Left alt keyup when unfocused, to prevent alt-tab sticky */
       dinput_keyboard_mods(di, RETROKMOD_ALT);

--- a/input/drivers/winraw_input.c
+++ b/input/drivers/winraw_input.c
@@ -500,6 +500,7 @@ static LRESULT CALLBACK winraw_callback(
          /* Ignored scancodes */
          switch (mcode)
          {
+            case RETROK_UNKNOWN:
             case 0xE11D:
             case 0xE02A:
             case 0xE036:


### PR DESCRIPTION
## Description

Surprisingly and apparently it is possible in certain rare cases to trigger the "undefined" key, resulting in all unmapped hotkeys getting triggered at once, which is a major catastrophe.

This trivial change prevents all available Windows drivers from turning the bit on, even sdl2, which is using dinput.


## Related Issues

Closes #13648 
Closes #10890 
Closes #10855

