### PR TITLE
Ensure that cores are deinitialised correctly following initialisation failure

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -5364,6 +5364,12 @@ bool retroarch_main_init(int argc, char *argv[])
          else
             input_remapping_restore_global_config(true);
 
+#ifdef HAVE_DYNAMIC
+         /* Ensure that currently loaded core is properly
+          * deinitialised */
+         if (runloop_st->current_core_type != CORE_TYPE_DUMMY)
+            command_event(CMD_EVENT_CORE_DEINIT, NULL);
+#endif
          /* Attempt initializing dummy core */
          runloop_st->current_core_type = CORE_TYPE_DUMMY;
          if (!command_event(CMD_EVENT_CORE_INIT, &runloop_st->current_core_type))


### PR DESCRIPTION
## Description

At present, on platforms with dynamic library support, if core initialisation fails (i.e. if `retro_load_game()` returns false) then the core library remains loaded on the system (i.e. the OS considers the library file to be in use). This leads to undefined behaviour if the user subsequently attempts any operation that would modify the file - core delete, core update via online updater/side-loading, etc.

This PR adds a `CMD_EVENT_CORE_DEINIT` call on dynamic platforms in the event of failed initialisation (before the dummy core is loaded), ensuring that the core library file is properly closed.