### PR TITLE
Enable runtime logging for contentless cores

### DIFF
--- a/menu/cbs/menu_cbs_cancel.c
+++ b/menu/cbs/menu_cbs_cancel.c
@@ -96,6 +96,7 @@ static int action_cancel_contentless_core(const char *path,
       const char *label, unsigned type, size_t idx)
 {
    menu_state_get_ptr()->contentless_core_ptr = 0;
+   menu_contentless_cores_flush_runtime();
    return action_cancel_pop_default(path, label, type, idx) ;
 }
 

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -1309,6 +1309,7 @@ void menu_list_flush_stack(
    file_list_t *menu_list      = MENU_LIST_GET(list, (unsigned)idx);
 
    menu_entries_ctl(MENU_ENTRIES_CTL_SET_REFRESH, &refresh);
+   menu_contentless_cores_flush_runtime();
 
    if (menu_list && menu_list->size)
       file_list_get_at_offset(menu_list, menu_list->size - 1, &path, &label, &type, &entry_idx);
@@ -4162,6 +4163,8 @@ int menu_driver_deferred_push_content_list(file_list_t *list)
    menu_st->selection_ptr         = 0;
    menu_st->contentless_core_ptr  = 0;
 
+   menu_contentless_cores_flush_runtime();
+
    if (!menu_driver_displaylist_push(
             menu_st,
             settings,
@@ -5269,9 +5272,8 @@ bool menu_driver_init(bool video_is_threaded)
 const char *menu_driver_ident(void)
 {
    struct menu_state    *menu_st  = &menu_driver_state;
-   if (menu_st->alive)
-      if (menu_st->driver_ctx && menu_st->driver_ctx->ident)
-         return menu_st->driver_ctx->ident;
+   if (menu_st->driver_ctx && menu_st->driver_ctx->ident)
+      return menu_st->driver_ctx->ident;
    return NULL;
 }
 
@@ -7030,6 +7032,8 @@ bool menu_driver_ctl(enum rarch_menu_ctl_state state, void *data)
             menu_st->selection_ptr        = 0;
             menu_st->contentless_core_ptr = 0;
             menu_st->scroll.index_size    = 0;
+
+            menu_contentless_cores_flush_runtime();
 
             for (i = 0; i < SCROLL_INDEX_SIZE; i++)
                menu_st->scroll.index_list[i] = 0;

--- a/menu/menu_driver.h
+++ b/menu/menu_driver.h
@@ -639,10 +639,37 @@ void menu_explore_free(void);
 void menu_explore_set_state(explore_state_t *state);
 #endif
 
+/* Contentless cores START */
+enum contentless_core_runtime_status
+{
+   CONTENTLESS_CORE_RUNTIME_UNKNOWN = 0,
+   CONTENTLESS_CORE_RUNTIME_MISSING,
+   CONTENTLESS_CORE_RUNTIME_VALID
+};
+
+typedef struct
+{
+   char *runtime_str;
+   char *last_played_str;
+   enum contentless_core_runtime_status status;
+} contentless_core_runtime_info_t;
+
+typedef struct
+{
+   char *licenses_str;
+   contentless_core_runtime_info_t runtime;
+} contentless_core_info_entry_t;
+
 uintptr_t menu_contentless_cores_get_entry_icon(const char *core_id);
 void menu_contentless_cores_context_init(void);
 void menu_contentless_cores_context_deinit(void);
 void menu_contentless_cores_free(void);
+void menu_contentless_cores_set_runtime(const char *core_id,
+      const contentless_core_runtime_info_t *runtime_info);
+void menu_contentless_cores_get_info(const char *core_id,
+      const contentless_core_info_entry_t **info);
+void menu_contentless_cores_flush_runtime(void);
+/* Contentless cores END */
 
 /* Returns true if search filter is enabled
  * for the specified menu list */

--- a/runtime_file.h
+++ b/runtime_file.h
@@ -110,7 +110,9 @@ typedef struct
 
 /* Initialise runtime log, loading current parameters
  * if log file exists. Returned object must be free()'d.
- * Returns NULL if content_path and/or core_path are invalid */
+ * Returns NULL if core_path is invalid, or content_path
+ * is invalid and core does not support contentless
+ * operation */
 runtime_log_t *runtime_log_init(
       const char *content_path,
       const char *core_path,
@@ -204,6 +206,20 @@ void runtime_update_playlist(
       bool log_per_core,
       enum playlist_sublabel_last_played_style_type timedate_style,
       enum playlist_sublabel_last_played_date_separator_type date_separator);
+
+#if defined(HAVE_MENU)
+/* Contentless cores manipulation */
+
+/* Updates specified contentless core runtime values with
+ * contents of associated log file */
+void runtime_update_contentless_core(
+      const char *core_path,
+      const char *dir_runtime_log,
+      const char *dir_playlist,
+      bool log_per_core,
+      enum playlist_sublabel_last_played_style_type timedate_style,
+      enum playlist_sublabel_last_played_date_separator_type date_separator);
+#endif
 
 RETRO_END_DECLS
 


### PR DESCRIPTION
## Description

This PR enables runtime logging for contentless cores. Runtime information is displayed in the `Standalone Cores` menu when using all menu drivers apart from Ozone. These sublabels are configured in the same manner as with regular playlists.

![Screenshot_2022-02-25_14-32-37](https://user-images.githubusercontent.com/38211560/155737254-28f43309-2dcc-410b-a776-4ede9c43132e.png)

![Screenshot_2022-02-25_14-33-17](https://user-images.githubusercontent.com/38211560/155737278-839cb69c-24b8-41f6-93a3-0f0241aa538b.png)

![Screenshot_2022-02-25_14-33-49](https://user-images.githubusercontent.com/38211560/155737289-fac0e9c3-8c1a-482b-ad55-810c188891d1.png)

- Ozone omits runtime information for consistency with the rest of the menu. This cannot be included until thumbnail support is added for 'standalone' cores (since it requires the thumbnail side bar). In the meantime, runtime info can be viewed by selecting `Quick Menu > Information` while the contentless core is running.

- When using GLUI, the licence text is omitted from `Standalone Cores` menu entries when runtime info is enabled. This is because having three lines of sublabel text here makes the menu look ugly. We will review this after thumbnail support is added.

In addition, this PR fixes the `Quick Menu > Information` display when running contentless cores (previously, this would become 'confused' if the user navigated to a playlist and then back again; it is also unnecessary to show content label/path info when running a contentless core)
