### PR TITLE
Fix some command line segfaults

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -4064,7 +4064,7 @@ static void retroarch_print_version(void)
    frontend_driver_attach_console();
    str[0] = '\0';
 
-   fprintf(stderr, "%s: %s -- v%s",
+   fprintf(stdout, "%s: %s -- v%s",
          msg_hash_to_str(MSG_PROGRAM),
          msg_hash_to_str(MSG_LIBRETRO_FRONTEND),
          PACKAGE_VERSION);
@@ -4095,7 +4095,7 @@ static void retroarch_print_help(const char *arg0)
    puts("===================================================================");
    fputs("\n", stdout);
 
-   printf("Usage: %s [OPTIONS]... [FILE]\n\n", arg0);
+   fprintf(stdout, "Usage: %s [OPTIONS]... [FILE]\n\n", arg0);
 
    strlcat(buf, "  -h, --help                     "
          "Show this help message.\n", sizeof(buf));
@@ -4655,8 +4655,12 @@ static bool retroarch_parse_input_and_config(
 
             /* Must handle '?' otherwise you get an infinite loop */
             case '?':
-               retroarch_print_help(argv[0]);
-               retroarch_fail(1, "retroarch_parse_input()");
+               frontend_driver_attach_console();
+#ifdef _WIN32
+               fprintf(stderr, "\n%s: unrecognized option '%s'\n", argv[0], argv[optind]);
+#endif
+               fprintf(stderr, "Try '%s --help' for more information\n", argv[0]);
+               exit(EXIT_FAILURE);
                break;
             /* All other arguments are handled in the second pass */
          }


### PR DESCRIPTION
## Description

I discovered a few weird inconsistencies regarding command line parsing between Windows and Linux. For example Linux shows these clear `getopt` error messages, but Windows outputs nothing:
```
unrecognized option '--configx'
```

```
option '--config' requires an argument
```

Both however crash in those cases after the usual help output. Windows also crashes when trying to use the long format with `=` for any option, as described in the help, for example:
```
--config=test
```
But with space there is no crash:
```
--config test
```



These changes seem to do the job for both platforms, but perhaps there is a better way to achieve those `getopt` shenanigans?

I decided to fake the `unrecognized option` for Windows to have at least some useful and somewhat similar output. And I replaced the forced help output with `Try 'retroarch --help' for more information` to be more inline with other programs and to be more user friendly (no need to scroll up to see what is wrong). And harnessed `stdout` and `stderr` a bit more where suitable.

Please test if I missed/goofed something.
