### PR TITLE
(.gitlab-ci.yml) Temporarily disable build-retroarch-osx-ppc target while macosx-legacy runner is offline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -376,6 +376,8 @@ build-retroarch-osx-ppc:
     XCCONFIG: OpenGL_GitLabCI.xcconfig
   tags:
    - macosx-legacy
+  rules:
+    - if: '"1" != "1"' # Temporary disable rule while runner is offline
   script:
     - xcodebuild -target RetroArch -configuration Release -project pkg/apple/RetroArch_PPC.xcodeproj ONLY_ACTIVE_ARCH=NO
     - pushd pkg/apple/build/Release/


### PR DESCRIPTION
## Description

This PR temporarily disables the gitlab `build-retroarch-osx-ppc` build target; the `macosx-legacy` runner is offline until further notice, so the build currently fails - and it's choking the buildbot.