### PR TITLE
Disable per-game and per-content-directory shader presets when running contentless cores

### DIFF
--- a/gfx/video_shader_parse.c
+++ b/gfx/video_shader_parse.c
@@ -2331,8 +2331,9 @@ bool load_shader_preset(settings_t *settings, const char *core_name,
    const char *video_shader_directory = settings->paths.directory_video_shader;
    const char *menu_config_directory  = settings->paths.directory_menu_config;
    const char *rarch_path_basename    = path_get(RARCH_PATH_BASENAME);
+   bool has_content                   = !string_is_empty(rarch_path_basename);
 
-   const char *game_name              = path_basename(rarch_path_basename);
+   const char *game_name              = NULL;
    const char *dirs[3]                = {0};
    size_t i                           = 0;
 
@@ -2346,17 +2347,16 @@ bool load_shader_preset(settings_t *settings, const char *core_name,
    config_file_directory[0]           = '\0';
    old_presets_directory[0]           = '\0';
 
-   if (!string_is_empty(rarch_path_basename))
+   if (has_content)
+   {
       fill_pathname_parent_dir_name(content_dir_name,
             rarch_path_basename, sizeof(content_dir_name));
-
-   config_file_directory[0]           = '\0';
+      game_name = path_basename(rarch_path_basename);
+   }
 
    if (!path_is_empty(RARCH_PATH_CONFIG))
       fill_pathname_basedir(config_file_directory,
             path_get(RARCH_PATH_CONFIG), sizeof(config_file_directory));
-
-   old_presets_directory[0]           = '\0';
 
    if (!string_is_empty(video_shader_directory))
       fill_pathname_join(old_presets_directory,
@@ -2371,14 +2371,14 @@ bool load_shader_preset(settings_t *settings, const char *core_name,
       if (string_is_empty(dirs[i]))
          continue;
       /* Game-specific shader preset found? */
-      if (retroarch_load_shader_preset_internal(
+      if (has_content && retroarch_load_shader_preset_internal(
                shader_path,
                sizeof(shader_path),
                dirs[i], core_name,
                game_name))
          goto success;
       /* Folder-specific shader preset found? */
-      if (retroarch_load_shader_preset_internal(
+      if (has_content && retroarch_load_shader_preset_internal(
                shader_path,
                sizeof(shader_path),
                dirs[i], core_name,

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -5807,6 +5807,8 @@ unsigned menu_displaylist_build_list(
       case DISPLAYLIST_SHADER_PRESET_SAVE:
          {
 #if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)
+            bool has_content = !string_is_empty(path_get(RARCH_PATH_CONTENT));
+
             if (MENU_DISPLAYLIST_PARSE_SETTINGS_ENUM(list,
                      MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_SAVE_REFERENCE,
                      PARSE_ONLY_BOOL, false) == 0)
@@ -5829,13 +5831,13 @@ unsigned menu_displaylist_build_list(
                      MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_SAVE_CORE,
                      MENU_SETTING_ACTION, 0, 0))
                count++;
-            if (menu_entries_append_enum(list,
+            if (has_content && menu_entries_append_enum(list,
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_PARENT),
                      msg_hash_to_str(MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_SAVE_PARENT),
                      MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_SAVE_PARENT,
                      MENU_SETTING_ACTION, 0, 0))
                count++;
-            if (menu_entries_append_enum(list,
+            if (has_content && menu_entries_append_enum(list,
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_VIDEO_SHADER_PRESET_SAVE_GAME),
                      msg_hash_to_str(MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_SAVE_GAME),
                      MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_SAVE_GAME,

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -3882,11 +3882,18 @@ bool menu_shader_manager_operate_auto_preset(
       RARCH_SHADER_GLSL, RARCH_SHADER_SLANG, RARCH_SHADER_CG
    };
    const char *core_name            = system ? system->library_name : NULL;
+   const char *rarch_path_basename  = path_get(RARCH_PATH_BASENAME);
    const char *auto_preset_dirs[3]  = {0};
+   bool has_content                 = !string_is_empty(rarch_path_basename);
 
    old_presets_directory[0] = config_directory[0] = tmp[0] = file[0] = '\0';
 
    if (type != SHADER_PRESET_GLOBAL && string_is_empty(core_name))
+      return false;
+
+   if (!has_content &&
+       ((type == SHADER_PRESET_GAME) ||
+            (type == SHADER_PRESET_PARENT)))
       return false;
 
    if (!path_is_empty(RARCH_PATH_CONFIG))
@@ -3918,13 +3925,12 @@ bool menu_shader_manager_operate_auto_preset(
          break;
       case SHADER_PRESET_PARENT:
          fill_pathname_parent_dir_name(tmp,
-               path_get(RARCH_PATH_BASENAME), sizeof(tmp));
+               rarch_path_basename, sizeof(tmp));
          fill_pathname_join(file, core_name, tmp, sizeof(file));
          break;
       case SHADER_PRESET_GAME:
          {
-            const char *game_name =
-               path_basename(path_get(RARCH_PATH_BASENAME));
+            const char *game_name = path_basename(rarch_path_basename);
             if (string_is_empty(game_name))
                return false;
             fill_pathname_join(file, core_name, game_name, sizeof(file));


### PR DESCRIPTION
## Description

This PR prevents RetroArch from (incorrectly) attempting to auto-load per-game and per-content-directory shader preset files when running contentless cores. It additionally disables/hides the associated menu entries.
