### PR TITLE
Improve CPU architecture and model name identification for Miyoo

### DIFF
--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -1274,12 +1274,7 @@ static enum frontend_architecture frontend_unix_get_arch(void)
          string_is_equal(val, "armv7b")
       )
       return FRONTEND_ARCH_ARMV7;
-   else if (
-         string_is_equal(val, "armv6l") ||
-         string_is_equal(val, "armv6b") ||
-         string_is_equal(val, "armv5tel") ||
-         string_is_equal(val, "arm")
-      )
+   else if (string_starts_with(val, "arm"))
       return FRONTEND_ARCH_ARM;
    else if (string_is_equal(val, "x86_64"))
       return FRONTEND_ARCH_X86_64;


### PR DESCRIPTION
## Description

For the Miyoo platform which runs on dingux-arm32, CPU architecture and model name are currently blank.
This identifies the architecture as ARM and returns a model name of "ARM926EJ-S rev 5 (v5l)". The model name fix also applies to any non-x86 Linux platform.

## Related Issues

None

## Related Pull Requests

None

## Reviewers

[If possible @mention all the people that should review your pull request]
