### PR TITLE
(cheevos) replace real file system function with virtual wrapper call

### DIFF
--- a/deps/rcheevos/src/rhash/cdreader.c
+++ b/deps/rcheevos/src/rhash/cdreader.c
@@ -134,7 +134,7 @@ static void* cdreader_open_bin_track(const char* path, uint32_t track)
     size_t size;
 
     rc_file_seek(cdrom->file_handle, 0, SEEK_END);
-    size = ftell(cdrom->file_handle);
+    size = rc_file_tell(cdrom->file_handle);
 
     if ((size % 2352) == 0)
     {


### PR DESCRIPTION
## Description

Fixes an exception that was being thrown when the achievements code tries to identify some `.iso`s.

The achievement code uses the RetroArch virtual file system through the `intfstream` interface. This updates a direct call to `ftell` with a virtualized call.

## Related Issues

https://discord.com/channels/184109094070779904/469974542299955210/950780637395157012

## Related Pull Requests

n/a

## Reviewers

@Sanaki 
