### PR TITLE
(cheevos) disable slowdown when toggling cheevos_enable

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -863,6 +863,9 @@ static void rcheevos_toggle_hardcore_active(rcheevos_locals_t* locals)
          runloop_msg_queue_push(msg, 0, 3 * 60, true, NULL,
             MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
 
+         /* disable slowdown */
+         runloop_state_get_ptr()->slowmotion = false;
+
          /* Reactivate leaderboards */
          if (locals->leaderboards_enabled)
             rcheevos_activate_leaderboards();
@@ -924,7 +927,7 @@ static void rcheevos_toggle_hardcore_active(rcheevos_locals_t* locals)
 void rcheevos_toggle_hardcore_paused(void)
 {
    settings_t* settings = config_get_ptr();
-   /* if hardcore mode is not enabled, we can't toggle it */
+   /* if hardcore mode is not enabled, we can't toggle whether its active */
    if (settings->bools.cheevos_hardcore_mode_enable)
       rcheevos_toggle_hardcore_active(&rcheevos_locals);
 }

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -19027,7 +19027,7 @@ static bool setting_append_list(
                &group_info,
                &subgroup_info,
                parent_group,
-               achievement_hardcore_mode_write_handler,
+               achievement_hardcore_mode_write_handler, /* re-evaluate whether hardcore is enabled */
                general_read_handler,
                SD_FLAG_NONE
                );

--- a/retroarch.c
+++ b/retroarch.c
@@ -1994,9 +1994,6 @@ bool command_event(enum event_command cmd, void *data)
       case CMD_EVENT_CHEEVOS_HARDCORE_MODE_TOGGLE:
 #ifdef HAVE_CHEEVOS
          rcheevos_toggle_hardcore_paused();
-
-         if (rcheevos_hardcore_active())
-            runloop_st->slowmotion = false;
 #endif
          break;
       case CMD_EVENT_REINIT_FROM_TOGGLE:


### PR DESCRIPTION
## Description

Expands on #12958, which disabled slowdown when hardcore was re-enabled via the menu. This moves that change such that slowdown will also be disabled when hardcore is re-enabled via enabling achievements.

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@Sanaki
