### PR TITLE
(Wayland) Fallback to shm_open when memfd_create fails

### DIFF
--- a/input/common/wayland_common.h
+++ b/input/common/wayland_common.h
@@ -206,7 +206,7 @@ void handle_toplevel_close(void *data,
 
 void flush_wayland_fd(void *data);
 
-int create_anonymous_file(off_t size);
+int create_shm_file(off_t size);
 
 shm_buffer_t *create_shm_buffer(gfx_ctx_wayland_data_t *wl,
    int width, int height, uint32_t format);


### PR DESCRIPTION
## Description

Currently `shm_open` is used when retroarch is compiled with a version of glibc that doesn't support `memfd_create`.
This merge request allows the wayland splash screen to fallback to `shm_open` when `memfd_create` is supported but throws an error.

## Related Issues

Fixes #13666

## Related Pull Requests

## Reviewers
