### PR TITLE
Prevent log spam when using rewind hotkey with cores that don't support rewind if rewind functionality itself is disabled

### DIFF
--- a/core.h
+++ b/core.h
@@ -27,10 +27,6 @@
 
 RETRO_BEGIN_DECLS
 
-#ifdef HAVE_REWIND
-bool core_set_rewind_callbacks(void);
-#endif
-
 #ifdef HAVE_NETWORKING
 bool core_set_netplay_callbacks(void);
 

--- a/retroarch.c
+++ b/retroarch.c
@@ -2017,7 +2017,8 @@ bool command_event(enum event_command cmd, void *data)
             if (core_type_is_dummy)
                return false;
 
-            state_manager_event_deinit(&runloop_st->rewind_st);
+            state_manager_event_deinit(&runloop_st->rewind_st,
+                  &runloop_st->current_core);
          }
 #endif
          break;
@@ -2779,7 +2780,8 @@ bool command_event(enum event_command cmd, void *data)
             /* Disable rewind & SRAM autosave if it was enabled
              * TODO/FIXME: Add a setting for these tweaks */
 #ifdef HAVE_REWIND
-            state_manager_event_deinit(&runloop_st->rewind_st);
+            state_manager_event_deinit(&runloop_st->rewind_st,
+                  &runloop_st->current_core);
 #endif
 #ifdef HAVE_THREADS
             autosave_deinit();
@@ -2815,7 +2817,8 @@ bool command_event(enum event_command cmd, void *data)
             /* Disable rewind if it was enabled
                TODO/FIXME: Add a setting for these tweaks */
 #ifdef HAVE_REWIND
-            state_manager_event_deinit(&runloop_st->rewind_st);
+            state_manager_event_deinit(&runloop_st->rewind_st,
+                  &runloop_st->current_core);
 #endif
 #ifdef HAVE_THREADS
             autosave_deinit();
@@ -2851,7 +2854,8 @@ bool command_event(enum event_command cmd, void *data)
             /* Disable rewind if it was enabled
              * TODO/FIXME: Add a setting for these tweaks */
 #ifdef HAVE_REWIND
-            state_manager_event_deinit(&runloop_st->rewind_st);
+            state_manager_event_deinit(&runloop_st->rewind_st,
+                  &runloop_st->current_core);
 #endif
 #ifdef HAVE_THREADS
             autosave_deinit();

--- a/runloop.c
+++ b/runloop.c
@@ -7187,6 +7187,7 @@ static enum runloop_state_enum runloop_check_state(
 
          rewinding      = state_manager_check_rewind(
                &runloop_st->rewind_st,
+               &runloop_st->current_core,
                BIT256_GET(current_bits, RARCH_REWIND),
                settings->uints.rewind_granularity,
                runloop_st->paused,
@@ -7970,33 +7971,6 @@ bool core_set_default_callbacks(void *data)
 
    return true;
 }
-
-#ifdef HAVE_REWIND
-/**
- * core_set_rewind_callbacks:
- *
- * Sets the audio sampling callbacks based on whether or not
- * rewinding is currently activated.
- **/
-bool core_set_rewind_callbacks(void)
-{
-   runloop_state_t *runloop_st  = &runloop_state;
-   struct state_manager_rewind_state
-      *rewind_st                = &runloop_st->rewind_st;
-
-   if (rewind_st->frame_is_reversed)
-   {
-      runloop_st->current_core.retro_set_audio_sample(audio_driver_sample_rewind);
-      runloop_st->current_core.retro_set_audio_sample_batch(audio_driver_sample_batch_rewind);
-   }
-   else
-   {
-      runloop_st->current_core.retro_set_audio_sample(audio_driver_sample);
-      runloop_st->current_core.retro_set_audio_sample_batch(audio_driver_sample_batch);
-   }
-   return true;
-}
-#endif
 
 #ifdef HAVE_NETWORKING
 /**

--- a/state_manager.h
+++ b/state_manager.h
@@ -24,6 +24,8 @@
 #include <boolean.h>
 #include <retro_common_api.h>
 
+#include "dynamic.h"
+
 RETRO_BEGIN_DECLS
 
 struct state_manager
@@ -61,12 +63,16 @@ struct state_manager_rewind_state
    state_manager_t *state;
    size_t size;
    bool frame_is_reversed;
+   bool init_attempted;
+   bool hotkey_was_checked;
+   bool hotkey_was_pressed;
 };
 
 bool state_manager_frame_is_reversed(void);
 
 void state_manager_event_deinit(
-      struct state_manager_rewind_state *rewind_st);
+      struct state_manager_rewind_state *rewind_st,
+      struct retro_core_t *current_core);
 
 void state_manager_event_init(struct state_manager_rewind_state *rewind_st,
       unsigned rewind_buffer_size);
@@ -79,6 +85,7 @@ void state_manager_event_init(struct state_manager_rewind_state *rewind_st,
  **/
 bool state_manager_check_rewind(
       struct state_manager_rewind_state *rewind_st,
+      struct retro_core_t *current_core,
       bool pressed,
       unsigned rewind_granularity, bool is_paused,
       char *s, size_t len, unsigned *time);


### PR DESCRIPTION
## Description

If the rewind hotkey is used with a core that does not support rewind (due to an insufficient save state compatibility level), RetroArch will display an appropriate OSD notification: `Rewind Unavailable because this core lacks serialized save state support`

However, as reported in #13729, this notification will also be displayed if rewind is itself disabled, leading to log spam if the user disables rewind and maps the hotkey button to another function for a particular core. This PR fixes this issue - the hotkey is now properly ignored when rewind is disabled.

In addition, the PR cleans up some of the rewind state handling code - including the removal of local static variables and the addition of error checking when assigning core audio callbacks.

## Related Issues

Closes #13729
