### PR TITLE
HDR Optimisation - Remove redundant copy

### DIFF
--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -1076,18 +1076,12 @@ static bool d3d11_init_swapchain(d3d11_video_t* d3d11,
          d3d11->hdr.max_cll,
          d3d11->hdr.max_fall);
 
-   DXGI_FORMAT back_buffer_format = d3d11->shader_preset && d3d11->shader_preset->passes ? glslang_format_to_dxgi(d3d11->pass[d3d11->shader_preset->passes - 1].semantics.format) : DXGI_FORMAT_R8G8B8A8_UNORM;
-   bool use_back_buffer           = back_buffer_format == d3d11->chain_formats[d3d11->chain_bit_depth];
-
-   if(use_back_buffer)
-   {
-      memset(&d3d11->back_buffer, 0, sizeof(d3d11->back_buffer));
-      d3d11->back_buffer.desc.Width              = width;
-      d3d11->back_buffer.desc.Height             = height;
-      d3d11->back_buffer.desc.Format             = back_buffer_format;
-      d3d11->back_buffer.desc.BindFlags          = D3D11_BIND_RENDER_TARGET;
-      d3d11_init_texture(d3d11->device, &d3d11->back_buffer);
-   }
+   memset(&d3d11->back_buffer, 0, sizeof(d3d11->back_buffer));
+   d3d11->back_buffer.desc.Width              = width;
+   d3d11->back_buffer.desc.Height             = height;
+   d3d11->back_buffer.desc.Format             = d3d11->shader_preset && d3d11->shader_preset->passes ? glslang_format_to_dxgi(d3d11->pass[d3d11->shader_preset->passes - 1].semantics.format) : DXGI_FORMAT_R8G8B8A8_UNORM;
+   d3d11->back_buffer.desc.BindFlags          = D3D11_BIND_RENDER_TARGET;
+   d3d11_init_texture(d3d11->device, &d3d11->back_buffer);
 #endif
 
    dxgiFactory->lpVtbl->Release(dxgiFactory);
@@ -1780,7 +1774,7 @@ static bool d3d11_gfx_frame(
 #ifdef HAVE_DXGI_HDR
    bool video_hdr_enable          = video_info->hdr_enable;
    DXGI_FORMAT back_buffer_format = d3d11->shader_preset && d3d11->shader_preset->passes ? glslang_format_to_dxgi(d3d11->pass[d3d11->shader_preset->passes - 1].semantics.format) : DXGI_FORMAT_R8G8B8A8_UNORM;
-   bool use_back_buffer           = back_buffer_format == d3d11->chain_formats[d3d11->chain_bit_depth];
+   bool use_back_buffer           = back_buffer_format != d3d11->chain_formats[d3d11->chain_bit_depth];
 
    if (   d3d11->resize_chain || 
          (d3d11->hdr.enable != video_hdr_enable))
@@ -1829,15 +1823,12 @@ static bool d3d11_gfx_frame(
 
       if(d3d11->hdr.enable)
       {
-         if(use_back_buffer)
-         {
-            memset(&d3d11->back_buffer, 0, sizeof(d3d11->back_buffer));
-            d3d11->back_buffer.desc.Width              = video_width;
-            d3d11->back_buffer.desc.Height             = video_height;
-            d3d11->back_buffer.desc.Format             = back_buffer_format;
-            d3d11->back_buffer.desc.BindFlags          = D3D11_BIND_RENDER_TARGET;
-            d3d11_init_texture(d3d11->device, &d3d11->back_buffer);
-         }
+         memset(&d3d11->back_buffer, 0, sizeof(d3d11->back_buffer));
+         d3d11->back_buffer.desc.Width              = video_width;
+         d3d11->back_buffer.desc.Height             = video_height;
+         d3d11->back_buffer.desc.Format             = back_buffer_format;
+         d3d11->back_buffer.desc.BindFlags          = D3D11_BIND_RENDER_TARGET;
+         d3d11_init_texture(d3d11->device, &d3d11->back_buffer);
 
          dxgi_swapchain_color_space(
                d3d11->swapChain,

--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -1076,12 +1076,18 @@ static bool d3d11_init_swapchain(d3d11_video_t* d3d11,
          d3d11->hdr.max_cll,
          d3d11->hdr.max_fall);
 
-   memset(&d3d11->back_buffer, 0, sizeof(d3d11->back_buffer));
-   d3d11->back_buffer.desc.Width              = width;
-   d3d11->back_buffer.desc.Height             = height;
-   d3d11->back_buffer.desc.Format             = d3d11->shader_preset && d3d11->shader_preset->passes ? glslang_format_to_dxgi(d3d11->pass[d3d11->shader_preset->passes - 1].semantics.format) : DXGI_FORMAT_R8G8B8A8_UNORM;
-   d3d11->back_buffer.desc.BindFlags          = D3D11_BIND_RENDER_TARGET;
-   d3d11_init_texture(d3d11->device, &d3d11->back_buffer);            
+   DXGI_FORMAT back_buffer_format = d3d11->shader_preset && d3d11->shader_preset->passes ? glslang_format_to_dxgi(d3d11->pass[d3d11->shader_preset->passes - 1].semantics.format) : DXGI_FORMAT_R8G8B8A8_UNORM;
+   bool use_back_buffer           = back_buffer_format == d3d11->chain_formats[d3d11->chain_bit_depth];
+
+   if(use_back_buffer)
+   {
+      memset(&d3d11->back_buffer, 0, sizeof(d3d11->back_buffer));
+      d3d11->back_buffer.desc.Width              = width;
+      d3d11->back_buffer.desc.Height             = height;
+      d3d11->back_buffer.desc.Format             = back_buffer_format;
+      d3d11->back_buffer.desc.BindFlags          = D3D11_BIND_RENDER_TARGET;
+      d3d11_init_texture(d3d11->device, &d3d11->back_buffer);
+   }
 #endif
 
    dxgiFactory->lpVtbl->Release(dxgiFactory);
@@ -1773,6 +1779,8 @@ static bool d3d11_gfx_frame(
 #endif
 #ifdef HAVE_DXGI_HDR
    bool video_hdr_enable          = video_info->hdr_enable;
+   DXGI_FORMAT back_buffer_format = d3d11->shader_preset && d3d11->shader_preset->passes ? glslang_format_to_dxgi(d3d11->pass[d3d11->shader_preset->passes - 1].semantics.format) : DXGI_FORMAT_R8G8B8A8_UNORM;
+   bool use_back_buffer           = back_buffer_format == d3d11->chain_formats[d3d11->chain_bit_depth];
 
    if (   d3d11->resize_chain || 
          (d3d11->hdr.enable != video_hdr_enable))
@@ -1821,12 +1829,15 @@ static bool d3d11_gfx_frame(
 
       if(d3d11->hdr.enable)
       {
-         memset(&d3d11->back_buffer, 0, sizeof(d3d11->back_buffer));
-         d3d11->back_buffer.desc.Width              = video_width;
-         d3d11->back_buffer.desc.Height             = video_height;
-         d3d11->back_buffer.desc.Format             = d3d11->shader_preset && d3d11->shader_preset->passes ? glslang_format_to_dxgi(d3d11->pass[d3d11->shader_preset->passes - 1].semantics.format) : DXGI_FORMAT_R8G8B8A8_UNORM;
-         d3d11->back_buffer.desc.BindFlags          = D3D11_BIND_RENDER_TARGET;
-         d3d11_init_texture(d3d11->device, &d3d11->back_buffer);
+         if(use_back_buffer)
+         {
+            memset(&d3d11->back_buffer, 0, sizeof(d3d11->back_buffer));
+            d3d11->back_buffer.desc.Width              = video_width;
+            d3d11->back_buffer.desc.Height             = video_height;
+            d3d11->back_buffer.desc.Format             = back_buffer_format;
+            d3d11->back_buffer.desc.BindFlags          = D3D11_BIND_RENDER_TARGET;
+            d3d11_init_texture(d3d11->device, &d3d11->back_buffer);
+         }
 
          dxgi_swapchain_color_space(
                d3d11->swapChain,
@@ -2054,7 +2065,7 @@ static bool d3d11_gfx_frame(
 
 
 #ifdef HAVE_DXGI_HDR
-   if(d3d11->hdr.enable)
+   if(d3d11->hdr.enable && use_back_buffer)
    {
       D3D11SetRenderTargets(context, 1, &d3d11->back_buffer.rt_view, NULL);
       D3D11ClearRenderTargetView(context, d3d11->back_buffer.rt_view, d3d11->clearcolor);
@@ -2165,7 +2176,7 @@ static bool d3d11_gfx_frame(
 
 #ifdef HAVE_DXGI_HDR
    /* Copy over back buffer to swap chain render targets */
-   if(d3d11->hdr.enable)
+   if(d3d11->hdr.enable && use_back_buffer)
    {
       ID3D11ShaderResourceView* nullSRV[1] = {NULL};
       D3D11SetRenderTargets(context, 1, &rtv, NULL);

--- a/gfx/drivers/d3d12.c
+++ b/gfx/drivers/d3d12.c
@@ -1528,22 +1528,19 @@ static bool d3d12_gfx_frame(
 
       if(d3d12->hdr.enable)
       {
-         if(use_back_buffer)
-         {
-            memset(&d3d12->chain.back_buffer,
-                  0, sizeof(d3d12->chain.back_buffer));
-            d3d12->chain.back_buffer.desc.Width  = video_width;
-            d3d12->chain.back_buffer.desc.Height = video_height;
-            d3d12->chain.back_buffer.desc.Format = back_buffer_format;
-            d3d12->chain.back_buffer.desc.Flags  = 
+         memset(&d3d12->chain.back_buffer,
+               0, sizeof(d3d12->chain.back_buffer));
+         d3d12->chain.back_buffer.desc.Width  = video_width;
+         d3d12->chain.back_buffer.desc.Height = video_height;
+         d3d12->chain.back_buffer.desc.Format = back_buffer_format;
+         d3d12->chain.back_buffer.desc.Flags  = 
                D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
-            d3d12->chain.back_buffer.srv_heap    = &d3d12->desc.srv_heap;
-            d3d12->chain.back_buffer.rt_view.ptr = 
+         d3d12->chain.back_buffer.srv_heap    = &d3d12->desc.srv_heap;
+         d3d12->chain.back_buffer.rt_view.ptr = 
                d3d12->desc.rtv_heap.cpu.ptr 
                + countof(d3d12->chain.renderTargets) 
                * d3d12->desc.rtv_heap.stride;
-            d3d12_init_texture(d3d12->device, &d3d12->chain.back_buffer);
-         }
+         d3d12_init_texture(d3d12->device, &d3d12->chain.back_buffer);
 
          dxgi_swapchain_color_space(d3d12->chain.handle,
                &d3d12->chain.color_space,

--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -2669,7 +2669,7 @@ static bool vulkan_frame(void *data, const void *frame,
       if (!(vk->hdr.support = vk->context->swapchain_colour_space == VK_COLOR_SPACE_HDR10_ST2084_EXT))
          vk->context->hdr_enable                = false;
 
-      if(vk->context->hdr_enable && use_main_buffer)
+      if(vk->context->hdr_enable)
       {
          memset(&vk->main_buffer, 0, sizeof(vk->main_buffer));
 

--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -1,1017 +1,3208 @@
-## Skeleton config file for RetroArch
-
-# If set to a directory, the content history playlist will be saved
-# to this directory.
-# content_history_dir =
-
-# Automatically saves a savestate at the end of RetroArch's lifetime.
-# The path is $SRAM_PATH.auto.
-# RetroArch will automatically load any savestate with this path on startup if savestate_auto_load is set.
-# savestate_auto_save = false
-# savestate_auto_load = true
-
-# Load libretro from a dynamic location for dynamically built RetroArch.
-# This option is mandatory.
-
-# Path to a libretro implementation.
-# libretro_path = "/path/to/libretro.so"
-
-# Sets log level for libretro cores (GET_LOG_INTERFACE).
-# If a log level issued by a libretro core is below libretro_log_level, it is ignored.
-# DEBUG logs are always ignored unless verbose mode is activated (--verbose).
-# DEBUG = 0, INFO = 1, WARN = 2, ERROR = 3.
-# libretro_log_level = 0
-
-# Enable or disable verbosity level of frontend.
-# log_verbosity = false
-
-# If this option is enabled, every content file loaded in RetroArch will be
-# automatically added to a history list.
-# history_list_enable = true
-
-# Enable performance counters
-# perfcnt_enable = false
-
-# Path to core options config file.
-# This config file is used to expose core-specific options.
-# It will be written to by RetroArch.
-# A default path will be assigned if not set.
-# core_options_path =
-
-# Path to content history file.
-# RetroArch keeps track of all content loaded in the menu and from CLI directly for convenient quick loading.
-# A default path will be assigned if not set.
-# content_history_path =
-
-# Path to music content history file (optional).
-# RetroArch keeps track of all music content loaded in the menu and from CLI directly for convenient quick loading.
-# A default path will be assigned if not set.
-# content_music_history_path =
-
-# Path to image content history file (optional).
-# RetroArch keeps track of all image content loaded in the menu and from CLI directly for convenient quick loading.
-# A default path will be assigned if not set.
-# content_image_history_path =
-
-# Path to video content history file (optional).
-# RetroArch keeps track of all video content loaded in the menu and from CLI directly for convenient quick loading.
-# A default path will be assigned if not set.
-# content_video_history_path =
-
-# Number of entries that will be kept in content history file.
-# content_history_size = 200
-
-# Content directory. Interacts with RETRO_ENVIRONMENT_GET_CONTENT_DIRECTORY.
-# Usually set by developers who bundle libretro/RetroArch apps to point to assets.
-# content_directory =
-
-# Sets start directory for menu config browser.
-# rgui_config_directory =
-
-# Show startup screen in menu.
-# Is automatically set to false when seen for the first time.
-# This is only updated in config if config_save_on_exit is set to true, however.
-# rgui_show_start_screen = true
-
-# Flushes config to disk on exit. Useful for menu as settings can be modified.
-# Overwrites the config. #include's and comments are not preserved.
-# config_save_on_exit = true
-
-# Shows hidden files and folders in directory listings.
-# show_hidden_files = false
-
-#### Driver
-
-# Input driver. Depending on video driver, it might force a different input driver.
-# input_driver = sdl
-
-# Joypad driver. ("udev", "linuxraw", "paraport", "sdl2", "hid", "dinput")
-# input_joypad_driver =
-
-# Video driver to use. "gl", "xvideo", "sdl", "d3d"
-# video_driver = "gl"
-
-# Which context implementation to use.
-# Possible ones for desktop are: glx, x-egl, kms-egl, sdl-gl, wgl.
-# By default, tries to use first suitable driver.
-# video_context_driver =
-
-# Audio driver backend. Depending on configuration possible candidates are: alsa, pulse, oss, jack, rsound, roar, openal, sdl, xaudio.
-# audio_driver =
-
-# Audio resampler driver backend. Which audio resampler to use.
-# Default will use "sinc".
-# audio_resampler =
-
-# Camera driver.
-# camera_driver =
-
-# Location driver.
-# location_driver =
-
-# Menu driver to use. ("rgui", "xmb", "glui")
-# menu_driver = "rgui"
-
-# Record driver. Used when recording video.
-# record_driver =
-
-#### Video
-
-# Suspends the screensaver if set to true. Is a hint that does not necessarily have to be honored
-# by video driver.
-# suspend_screensaver_enable  = true
-
-# Display framerate.
-# fps_show = false
-
-# Display memory.
-# memory_show = false
-
-# Display total number of frames rendered. (only displays if fps_show is enabled)
-# framecount_show =
-
-# Which monitor to prefer. 0 (default) means no particular monitor is preferred, 1 and up (1 being first monitor),
-# suggests RetroArch to use that particular monitor.
-# video_monitor_index = 0
-
-# Start in fullscreen. Can be changed at runtime.
-# video_fullscreen = false
-
-# If fullscreen, prefer using a windowed fullscreen mode.
-# video_windowed_fullscreen = true
-
-# Fullscreen resolution. Resolution of 0 uses the resolution of the desktop.
-# video_fullscreen_x = 0
-# video_fullscreen_y = 0
-
-# Video refresh rate of your CRT monitor.
-# Used to calculate a suitable audio input rate.
-# crt_video_refresh_rate = 59.94
-
-# Video refresh rate of your monitor.
-# Used to calculate a suitable audio input rate.
-# video_refresh_rate = 59.94
-
-# Forcibly disable sRGB FBO support. Some Intel OpenGL drivers on Windows
-# have video problems with sRGB FBO support enabled.
-# video_force_srgb_disable = false
-
-# If this is true and video_aspect_ratio is not set,
-# aspect ratio is decided by libretro implementation.
-# If this is false, 1:1 PAR will always be assumed if video_aspect_ratio is not set.
-# video_aspect_ratio_auto = false
-
-# A floating point value for video aspect ratio (width / height).
-# If this is not set, aspect ratio is assumed to be automatic.
-# Behavior then is defined by video_aspect_ratio_auto.
-# video_aspect_ratio =
-
-# Windowed x resolution scale and y resolution scale
-# (Real x res: base_size * xscale * aspect_ratio, real y res: base_size * yscale)
-# video_scale = 3.0
-
-# Percentage of opacity to use for the window (100 is completely opaque).
-# video_window_opacity = 100
-
-# Whether to enable the default window decorations like border, titlebar etc.
-# video_window_show_decorations = true
-
-# Forcibly disable composition. Only works in Windows Vista/7 for now.
-# video_disable_composition = false
-
-# Video vsync.
-# video_vsync = true
-
-# Interval at which a Vsync swap is performed.
-# 1 is normal, 2 is doubled frames, 3 is tripled frames, etc.
-# video_swap_interval = 1
-
-# Max amount of swapchain images.
-# Single buffering = 1, Double buffering = 2, 3 = Triple buffering
-# video_max_swapchain_images = 3
-
-# Attempts to hard-synchronize CPU and GPU. Can reduce latency at cost of performance.
-# video_hard_sync = false
-
-# Sets how many frames CPU can run ahead of GPU when using video_hard_sync.
-# Maximum is 3.
-# video_hard_sync_frames = 0
-
-# Sets how many milliseconds to delay after VSync before running the core.
-# Can reduce latency at cost of higher risk of stuttering.
-# Maximum is 15.
-# video_frame_delay = 0
-
-# Inserts a black frame inbetween frames.
-# Useful for 120 Hz monitors who want to play 60 Hz material with eliminated ghosting.
-# video_refresh_rate should still be configured as if it is a 60 Hz monitor (divide refresh rate by 2).
-# video_black_frame_insertion = false
-
-# Use threaded video driver. Using this might improve performance at possible cost of latency and more video stuttering.
-# video_threaded = false
-
-# Use a shared context for HW rendered libretro cores.
-# Avoids having to assume HW state changes inbetween frames.
-# video_shared_context = false
-
-# Smoothens picture with bilinear filtering. Should be disabled if using pixel shaders.
-# video_smooth = true
-
-# Forces rendering area to stay equal to content aspect ratio or as defined in video_aspect_ratio.
-# video_force_aspect = true
-
-# Only scales video in integer steps.
-# The base size depends on system-reported geometry and aspect ratio.
-# If video_force_aspect is not set, X/Y will be integer scaled independently.
-# video_scale_integer = false
-
-# Index of the aspect ratio selection in the menu.
-# 20 = Config, 21 = 1:1 PAR, 22 = Core Provided, 23 = Custom Aspect Ratio
-# aspect_ratio_index = 20
-
-# Forces cropping of overscanned frames.
-# Exact behavior of this option is implementation specific.
-# video_crop_overscan = true
-
-# Path to shader. Shader can be either Cg, CGP (Cg preset) or GLSL, GLSLP (GLSL preset)
-# video_shader = "/path/to/shader.{cg,cgp,glsl,glslp}"
-
-# Load video_shader on startup.
-# Other shaders can still be loaded later in runtime.
-# video_shader_enable = false
-
-# CPU-based video filter. Path to a dynamic library.
-# video_filter =
-
-# Path to a font used for rendering messages. This path must be defined to enable fonts.
-# Do note that the _full_ path of the font is necessary!
-# video_font_path =
-
-# Size of the font rendered in points.
-# video_font_size = 32
-
-# Enable usage of OSD messages.
-# video_font_enable = true
-
-# Offset for where messages will be placed on screen. Values are in range 0.0 to 1.0 for both x and y values.
-# [0.0, 0.0] maps to the lower left corner of the screen.
-# video_message_pos_x = 0.05
-# video_message_pos_y = 0.05
-
-# Color for message. The value is treated as a hexadecimal value.
-# It is a regular RGB hex number, i.e. red is "ff0000".
-# video_message_color = ffffff
-
-# Background color for OSD messages. Red/Green/Blue values are from 0 to 255 and opacity is 0.0 to 1.0.
-# video_message_bgcolor_enable = false
-# video_message_bgcolor_red = 0
-# video_message_bgcolor_green = 0
-# video_message_bgcolor_blue = 0
-# video_message_bgcolor_opacity = 1.0
-
-# Allows libretro cores to set rotation modes.
-# Setting this to false will honor, but ignore this request.
-# This is useful for vertically oriented content where one manually rotates the monitor.
-# video_allow_rotate = true
-
-# Forces a certain rotation of the video.
-# The rotation is added to rotations which the libretro core sets (see video_allow_rotate).
-# The angle is <value> * 90 degrees counter-clockwise.
-# video_rotation = 0
-
-# Forces a certain orientation of the screen from the operating system.
-# The angle is <value> * 90 degrees counter-clockwise.
-# screen_orientation = 0
-
-# HDR settings
-# video_hdr_enable            = false
-# video_hdr_max_nits          = 1000.0f
-# video_hdr_paper_white_nits  = 200.0f
-# video_hdr_contrast          = 1.0f
-# video_hdr_expand_gamut      = true
-
-#### Audio
-
-# Enable audio.
-# audio_enable = true
-
-# Enable menu audio sounds.
-# audio_enable_menu = false
-# audio_enable_menu_ok = false
-# audio_enable_menu_cancel = false
-# audio_enable_menu_notice = false
-# audio_enable_menu_bgm = false
-
-# Mutes audio.
-# audio_mute_enable = false
-
-# Mutes audio mixer volume globally.
-# audio_mixer_mute_enable = false
-
-# Audio output samplerate.
-# audio_out_rate = 48000
-
-# Override the default audio device the audio_driver uses. This is driver dependant. E.g. ALSA wants a PCM device, OSS wants a path (e.g. /dev/dsp), Jack wants portnames (e.g. system:playback1,system:playback_2), and so on ...
-# audio_device =
-
-# Audio DSP plugin that processes audio before it's sent to the driver. Path to a dynamic library.
-# audio_dsp_plugin =
-
-# Will sync (block) on audio. Recommended.
-# audio_sync = true
-
-# Desired audio latency in milliseconds. Might not be honored if driver can't provide given latency.
-# audio_latency = 64
-
-# Enable audio rate control.
-# audio_rate_control = true
-
-# Controls audio rate control delta. Defines how much input rate can be adjusted dynamically.
-# Input rate = in_rate * (1.0 +/- audio_rate_control_delta)
-# audio_rate_control_delta = 0.005
-
-# Controls maximum audio timing skew. Defines the maximum change in input rate.
-# Input rate = in_rate * (1.0 +/- max_timing_skew)
-# audio_max_timing_skew = 0.05
-
-# Audio volume. Volume is expressed in dB.
-# 0 dB is normal volume. No gain will be applied.
-# Gain can be controlled in runtime with input_volume_up/input_volume_down.
-# audio_volume = 0.0
-
-# Audio mixer volume. Volume is expressed in dB.
-# 0 dB is normal volume. No gain will be applied.
-# audio_mixer_volume = 0.0
-
-#### Overlay
-
-# Enable the overlay.
-# input_overlay_enable = true
-
-# Show the overlay behind the menu instead of in front.
-# input_overlay_behind_menu = "false"
-
-# Hide the current overlay from appearing inside the menu.
-# input_overlay_hide_in_menu = true
-
-# Path to input overlay.
-# input_overlay =
-
-# Opacity of all the UI elements of the overlay.
-# input_overlay_opacity = 1.0
-
-# Scale of all UI elements of the overlay.
-# input_overlay_scale = 1.0
-
-# Center of all UI elements of the overlay.
-# input_overlay_center_x = 0.5
-# input_overlay_center_y = 0.5
-
-#### Input
-
-# Path to input remapping file.
-# input_remapping_path =
-
-# Input bind timer timeout.
-# Amount of seconds to wait until proceeding to the next bind. Default: 5, minimum: 1
-# input_bind_timeout = 1
-
-# If enabled, overrides the input binds with the remapped binds set for the current core.
-# input_remap_binds_enable = true
-
-# Maximum amount of users supported by RetroArch.
-# input_max_users = 16
-
-# Keyboard layout for input driver if applicable (udev/evdev for now).
-# Syntax is either just layout (e.g. "no"), or a layout and variant separated with colon ("no:nodeadkeys").
-# input_keyboard_layout =
-
-# Defines axis threshold. Possible values are [0.0, 1.0]
-# input_axis_threshold = 0.5
-
-# input_analog_deadzone = 0.0
-
-# input_analog_sensitivity = 1.0
-
-# Enable input auto-detection. Will attempt to autoconfigure
-# joypads, Plug-and-Play style.
-# input_autodetect_enable = true
-
-# Show the input descriptors set by the core instead of the
-# default ones.
-# input_descriptor_label_show = true
-
-# Hide input descriptors that were not set by the core.
-# input_descriptor_hide_unbound = false
-
-# Influence how input polling is done inside RetroArch.
-# 0 : Early  - Input polling is performed before call to retro_run.
-# 1 : Normal - Input polling is performed when retro_input_poll is
-#     requested.
-# 2 : Late   - Input polling is performed on first call to retro_input_state
-#     per frame
-#
-# Setting it to 0 or 2 can result in less latency depending on
-# your configuration.
-#
-# When netplay is enabled, the default polling behavior (1) will
-# be used regardless of the value set here.
-# input_poll_type_behavior = 1
-
-# Sets which libretro device is used for a user.
-# Devices are indentified with a number.
-# This is normally saved by the menu.
-# Device IDs are found in libretro.h.
-# These settings are overridden by explicit command-line arguments which refer to input devices.
-# None: 0
-# Joypad (RetroPad): 1
-# Mouse: 2
-# Keyboard: 3
-# Generic Lightgun: 4
-# Joypad w/ Analog (RetroPad + Analog sticks): 5
-# Multitap (SNES specific): 257
-# Super Scope (SNES specific): 260
-# Justifier (SNES specific): 516
-# Justifiers (SNES specific): 772
-
-# input_libretro_device_p1 =
-# input_libretro_device_p2 =
-# input_libretro_device_p3 =
-# input_libretro_device_p4 =
-# input_libretro_device_p5 =
-# input_libretro_device_p6 =
-# input_libretro_device_p7 =
-# input_libretro_device_p8 =
-
-# Keyboard input. Will recognize letters ("a" to "z") and the following special keys (where "kp_"
-# is for keypad keys):
-#
-#   left, right, up, down, enter, kp_enter, tab, insert, del, end, home,
-#   rshift, shift, ctrl, alt, space, escape, add, subtract, kp_plus, kp_minus,
-#   f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12,
-#   num0, num1, num2, num3, num4, num5, num6, num7, num8, num9, pageup, pagedown,
-#   keypad0, keypad1, keypad2, keypad3, keypad4, keypad5, keypad6, keypad7, keypad8, keypad9,
-#   period, capslock, numlock, backspace, multiply, divide, print_screen, scroll_lock,
-#   tilde, backquote, pause, quote, comma, minus, slash, semicolon, equals, leftbracket,
-#   backslash, rightbracket, kp_period, kp_equals, rctrl, ralt
-#
-# Keyboard input, Joypad and Joyaxis will all obey the "nul" bind, which disables the bind completely,
-# rather than relying on a default.
-# input_player1_a = "x"
-# input_player1_b = "z"
-# input_player1_y = "a"
-# input_player1_x = "s"
-# input_player1_start = "enter"
-# input_player1_select = "rshift"
-# input_player1_l = "q"
-# input_player1_r = "w"
-# input_player1_left = "left"
-# input_player1_right = "right"
-# input_player1_up = "up"
-# input_player1_down = "down"
-# input_player1_l2 =
-# input_player1_r2 =
-# input_player1_l3 =
-# input_player1_r3 =
-
-# Two analog sticks (DualShock-esque).
-# Bound as usual, however, if a real analog axis is bound,
-# it can be read as a true analog.
-# Positive X axis is right, Positive Y axis is down.
-# input_player1_l_x_plus =
-# input_player1_l_x_minus =
-# input_player1_l_y_plus =
-# input_player1_l_y_minus =
-# input_player1_r_x_plus =
-# input_player1_r_x_minus =
-# input_player1_r_y_plus =
-# input_player1_r_y_minus =
-
-# If desired, it is possible to override which joypads are being used for user 1 through 8.
-# First joypad available is 0.
-# input_player1_joypad_index = 0
-# input_player2_joypad_index = 1
-# input_player3_joypad_index = 2
-# input_player4_joypad_index = 3
-# input_player5_joypad_index = 4
-# input_player6_joypad_index = 5
-# input_player7_joypad_index = 6
-# input_player8_joypad_index = 7
-
-# Input device buttons.
-# Figure these out by using RetroArch-Phoenix or retroarch-joyconfig.
-# You can use joypad hats with hnxx, where n is the hat, and xx is a string representing direction.
-# E.g. "h0up"
-# input_player1_a_btn =
-# input_player1_b_btn =
-# input_player1_y_btn =
-# input_player1_x_btn =
-# input_player1_start_btn =
-# input_player1_select_btn =
-# input_player1_l_btn =
-# input_player1_r_btn =
-# input_player1_left_btn =
-# input_player1_right_btn =
-# input_player1_up_btn =
-# input_player1_down_btn =
-# input_player1_l2_btn =
-# input_player1_r2_btn =
-# input_player1_l3_btn =
-# input_player1_r3_btn =
-
-# Menu buttons.
-# menu_search_btn      =
-# menu_info_btn        =
-# menu_default_btn     =
-# menu_scroll_down_btn =
-# menu_scroll_up_btn   =
-
-# Swap buttons for OK/Cancel
-# menu_swap_ok_cancel_buttons = false
-
-# Axis for RetroArch D-Pad.
-# Needs to be either '+' or '-' in the first character signaling either positive or negative direction of the axis, then the axis number.
-# Do note that every other input option has the corresponding _btn and _axis binds as well; they are omitted here for clarity.
-# input_player1_left_axis =
-# input_player1_right_axis =
-# input_player1_up_axis =
-# input_player1_down_axis =
-
-# Holding the turbo while pressing another button will let the button enter a turbo mode
-# where the button state is modulated with a periodic signal.
-# The modulation stops when the button itself (not turbo button) is released.
-# input_player1_turbo =
-
-# Describes the period and how long of that period a turbo-enabled button should behave.
-# Numbers are described in frames.
-# input_turbo_period = 6
-# input_turbo_duty_cycle = 3
-
-# This goes all the way to user 8 (*_player2_*, *_player3_*, etc), but omitted for clarity.
-# All input binds have corresponding binds for keyboard (none), joykeys (_btn) and joyaxes (_axis) as well.
-
-# Toggles fullscreen.
-# input_toggle_fullscreen = f
-
-# Saves state.
-# input_save_state = f2
-# Loads state.
-# input_load_state = f4
-
-# State slots. With slot set to 0, save state name is *.state (or whatever defined on commandline).
-# When slot is != 0, path will be $path%d, where %d is slot number.
-# input_state_slot_increase = f7
-# input_state_slot_decrease = f6
-
-# Toggles between fast-forwarding and normal speed.
-# input_toggle_fast_forward = space
-
-# Hold for fast-forward. Releasing button disables fast-forward.
-# input_hold_fast_forward = l
-
-# Key to exit RetroArch cleanly.
-# Killing it in any hard way (SIGKILL, etc) will terminate RetroArch without saving RAM, etc.
-# On Unix-likes, SIGINT/SIGTERM allows a clean deinitialization.
-# input_exit_emulator = escape
-
-# Applies next and previous shader in directory.
-# input_shader_next = m
-# input_shader_prev = n
-
-# Hold button down to rewind. Rewinding must be enabled.
-# input_rewind = r
-
-# Toggle between recording and not.
-# input_movie_record_toggle = o
-
-# Toggle between paused and non-paused state
-# input_pause_toggle = p
-
-# Frame advance when content is paused
-# input_frame_advance = k
-
-# Reset the content.
-# input_reset = h
-
-# Cheats.
-# input_cheat_index_plus = y
-# input_cheat_index_minus = t
-# input_cheat_toggle = u
-
-# Mute/unmute audio
-# input_audio_mute = f9
-
-# Take screenshot
-# input_screenshot = f8
-
-# Netplay flip users.
-# input_netplay_flip_players = i
-
-# Hold for slowmotion.
-# input_slowmotion = e
-
-# Toggles sync to exact content framerate.
-# input_toggle_vrr_runloop =
-
-# Enable other hotkeys.
-# If this hotkey is bound to either keyboard, joybutton or joyaxis,
-# all other hotkeys will be disabled unless this hotkey is also held at the same time.
-# This is useful for RETRO_KEYBOARD centric implementations
-# which query a large area of the keyboard, where it is not desirable
-# that hotkeys get in the way.
-
-# Alternatively, all hotkeys for keyboard could be disabled by the user.
-# input_enable_hotkey_btn =
-
-# Adds a delay in frames before the assigned hotkey blocks input.  Useful if the the
-# hotkey input is mapped to another action.
-# input_hotkey_block_delay = "5"
-
-# Increases audio volume.
-# input_volume_up = kp_plus
-# Decreases audio volume.
-# input_volume_down = kp_minus
-
-# Toggles to next overlay. Wraps around.
-# input_overlay_next =
-
-# Toggles eject for disks. Used for multiple-disk content.
-# input_disk_eject_toggle =
-
-# Cycles through disk images. Use after ejecting.
-# Complete by toggling eject again.
-# input_disk_next =
-
-# Toggles menu.
-# input_menu_toggle = f1
-
-# Toggles display of on-screen technical statistics.
-# input_toggle_statistics =
-
-# RetroPad button combination to toggle menu
-# 0: None
-# 1: Down + Y + L1 + R1
-# 2: L3 + R3
-# 3: L1 + R1 + Start + Select
-# 4: Start + Select
-# 5: L3 + R1
-# 6: L1 + R1
-# 7: Hold Start (2 seconds)
-# 8: Hold Select (2 seconds)
-# 9: Down + Select
-# 10: L2 + R2
-# input_menu_toggle_gamepad_combo = 0
-
-# RetroPad button combination to quit
-# 0: None
-# 1: Down + Y + L1 + R1
-# 2: L3 + R3
-# 3: L1 + R1 + Start + Select
-# 4: Start + Select
-# 5: L3 + R1
-# 6: L1 + R1
-# 7: Hold Start (2 seconds)
-# 8: Hold Select (2 seconds)
-# 9: Down + Select
-# 10: L2 + R2
-# input_quit_gamepad_combo = 0
-
-# allow any RetroPad to control the menu
-# all_users_control_menu = false
-
-# Toggles mouse grab. When mouse is grabbed, RetroArch hides the mouse,
-# and keeps the mouse pointer inside the window to allow relative mouse input
-# to work better.
-# input_grab_mouse_toggle = f11
-
-#### Menu
-
-# If disabled, will hide 'Online Updater' inside the menu.
-# menu_show_online_updater = true
-
-# If disabled, will hide the ability to update cores (and core info files) inside the menu.
-# menu_show_core_updater = true
-
-# If disabled, the libretro core will keep running in the background when we
-# are in the menu.
-# menu_pause_libretro = false
-
-# If disabled, we use separate controls for menu operation.
-# menu_unified_controls = false
-
-# Enable mouse controls inside the menu.
-# menu_mouse_enable = false
-
-# Enable touch controls inside the menu.
-# menu_pointer_enable = false
-
-# Shows current date and/or time inside menu.
-# menu_timedate_enable = true
-
-# Shows current battery level inside menu.
-# menu_battery_level_enable = true
-
-# Shows current core inside menu.
-# menu_core_enable = true
-
-# Path to an image to set as menu wallpaper.
-# menu_wallpaper =
-
-# Dynamically load a new wallpaper depending on context.
-# menu_dynamic_wallpaper_enable = false
-
-# Type of thumbnail to display. 0 = none, 1 = snaps, 2 = titles, 3 = boxarts
-# menu_thumbnails = 0
-# menu_left_thumbnails = 0
-
-# Wrap-around to beginning and/or end if boundary of list is reached horizontally or vertically.
-# menu_navigation_wraparound_enable = false
-
-# Filter files being shown in filebrowser by supported extensions.
-# menu_navigation_browser_filter_supported_extensions_enable = true
-
-# Collapse subgroup settings into main group to create one big listing of settings
-# per category.
-# menu_collapse_subgroups_enable = false
-
-#### Core
-#
-# Prevent libretro cores from closing RetroArch on exit by loading a dummy core.
-# load_dummy_on_core_shutdown = "true"
-
-# Check for firmware requirement(s) before loading a content.
-# check_firmware_before_loading = "false"
-
-#### User Interface
-
-# Start UI companion driver's interface on boot (if available).
-# ui_companion_start_on_boot  = true
-
-# Toggle companion UI on startup (currently only used to show the WIMP UI)
-# ui_companion_toggle = false
-
-# Only init the WIMP UI for this session if this is enabled
-# desktop_menu_enable = true
-
-#### Camera
-
-# Override the default camera device the camera driver uses. This is driver dependant.
-# camera_device =
-
-# Override the default privacy permission for cores that want to access camera services. Is "false" by default.
-# camera_allow = false
-
-#### Location
-
-# Override the default privacy permission for cores that want to access location services. Is "false" by default.
-# location_allow = false
-
-#### Core Updater
-
-# URL to core update directory on buildbot.
-# core_updater_buildbot_url = "http://buildbot.libretro.com"
-
-# URL to assets update directory on buildbot.
-# core_updater_buildbot_assets_url = "http://buildbot.libretro.com/assets/"
-
-# After downloading, automatically extract archives that the downloads are contained inside.
-# core_updater_auto_extract_archive = true
-
-#### Network
-
-# When being client over netplay, use keybinds for user 1.
-# netplay_client_swap_input = false
-
-# The username of the person running RetroArch. This will be used for playing online, for instance.
-# netplay_nickname =
-
-# The amount of delay frames to use for netplay. Increasing this value will increase
-# performance, but introduce more latency.
-# netplay_delay_frames = 0
-
-# Netplay mode for the current user.
-# false is Server, true is Client.
-# netplay_mode = false
-
-# Enable or disable spectator mode for the user during netplay.
-# netplay_spectator_mode_enable = false
-
-# The IP Address of the host to connect to.
-# netplay_ip_address =
-
-# The port of the host IP Address. Can be either a TCP or UDP port.
-# netplay_ip_port = 55435
-
-# Force game hosting to go through a man-in-the-middle server to get around firewalls and NAT/UPnP problems.
-# netplay_use_mitm_server = false
-
-# The requested MITM server to use.
-# netplay_mitm_server = "nyc"
-
-#### Directory
-
-# Sets the System/BIOS directory.
-# Implementations can query for this directory to load BIOSes, system-specific configs, etc.
-# system_directory =
-
-# Save all downloaded files to this directory.
-# core_assets_directory =
-
-# Assets directory. This location is queried by default when menu interfaces try to look for
-# loadable assets, etc.
-# assets_directory =
-
-# Dynamic wallpapers directory. The place to store the wallpapers dynamically
-# loaded by the menu depending on context.
-# dynamic_wallpapers_directory =
-
-# Thumbnails directory. To store thumbnail files.
-# thumbnails_directory =
-
-# File browser directory. Sets start directory for menu file browser.
-# rgui_browser_directory =
-
-# Core directory for libretro core implementations.
-# libretro_directory =
-
-# Core info directory for libretro core information.
-# libretro_info_path =
-
-# Path to content database directory.
-# content_database_path =
-
-# Saved queries are stored to this directory.
-# cursor_directory =
-
-# Path to cheat database directory.
-# cheat_database_path =
-
-# Defines a directory where CPU-based video filters are kept.
-# video_filter_dir =
-
-# Directory where DSP plugins are kept.
-# audio_filter_dir =
-
-# Defines a directory where shaders (Cg, CGP, GLSL) are kept for easy access.
-# video_shader_dir =
-
-# Recording output directory. Where recordings are saved.
-# recording_output_directory =
-
-# Recording config directory. Where recording settings are kept.
-# recording_config_directory =
-
-# Overlay directory. Where overlays are kept for easy access.
-# overlay_directory =
-
-# Directory to dump screenshots to.
-# screenshot_directory =
-
-# Directory for joypad autoconfigs.
-# If a joypad is plugged in, that joypad will be autoconfigured if a config file
-# corresponding to that joypad is present in joypad_autoconfig_dir.
-# Input binds which are made explicit (input_playerN_*_btn/axis) will take priority over autoconfigs.
-# Autoconfigs can be created with retroarch-joyconfig, manually, or with a frontend.
-# Requires input_autodetect_enable to be enabled.
-# joypad_autoconfig_dir =
-
-# Save all remapped controls to this directory.
-# input_remapping_directory =
-
-# Save all playlists/collections to this directory.
-# playlist_directory =
-
-# Save all save files (*.srm) to this directory. This includes related files like .bsv, .rtc, .psrm, etc ...
-# This will be overridden by explicit command line options.
-# savefile_directory =
-
-# Save all save states (*.state) to this directory.
-# This will be overridden by explicit command line options.
-# savestate_directory =
-
-# If set to a directory, content which is temporarily extracted
-# will be extracted to this directory.
-# cache_directory =
-
-#### RetroAchievements
-
-# Enable the RetroAchievements feature.
-# cheevos_enable = false
-
-# RetroAchievements.org credentials.
-# cheevos_username =
-# cheevos_password =
-
-# The hardcore mode disables savestates and cheating features, but it
-# makes the achievements points double.
-# cheevos_hardcore_mode_enable = false
-
-# Play the 'unlock' audio sound when an achievement is unlocked.
-# cheevos_unlock_sound_enable = false
-
-# Show RetroAchievements related messages right after loading a game, such as
-# successfull login and the number of cheevos you have unlocked for the game.
-# cheevos_verbose_enable = false
-
-# Show achievements' badges in Quick Menu > Achievements List.
-# (note: has no effect if menu_driver = rgui).
-# cheevos_badges_enable = false
-
-# Take a screenshot when an achievement is triggered.
-# cheevos_auto_screenshot = false
-
-# Besides achievements, some games also have leaderboards, where you can
-# compete for high-scores, speedruns, etc.
-# cheevos_leaderboards_enable = false
-
-# Show an on-screen indicator when attempting challenging achievements
-# to provide feedback when the attempt has failed (for achievements that
-# support it)
-# cheevos_challenge_indicators = true
-
-# Send some messages to the RetroAchievements.org saying, for example,
-# where you are in the game, how many lives you have, your score, etc.
-# cheevos_richpresence_enable = true
-
-# Even after unlocking achievements in previous sessions, you may still want
-# to see them triggering in the current session.
-# cheevos_start_active = false
-
-# Unnoficial achievements are used only for achievement creators and testers.
-# cheevos_test_unofficial = false
-
-#### Misc
-
-# Enable rewinding. This will take a performance hit when playing, so it is disabled by default.
-# rewind_enable = false
-
-# Rewinding buffer size in megabytes. Bigger rewinding buffer means you can rewind longer.
-# The buffer should be approx. 20MB per minute of buffer time.
-# rewind_buffer_size = 20
-
-# Rewind granularity. When rewinding defined number of frames, you can rewind several frames at a time, increasing the rewinding speed.
-# rewind_granularity = 1
-
-# Pause gameplay when window focus is lost.
-# pause_nonactive = true
-
-# Autosaves the non-volatile SRAM at a regular interval. This is disabled by default unless set otherwise.
-# The interval is measured in seconds. A value of 0 disables autosave.
-# autosave_interval =
-
-# Records video after CPU video filter.
-# video_post_filter_record = false
-
-# Records output of GPU shaded material if available.
-# video_gpu_record = false
-
-# Screenshots output of GPU shaded material if available.
-# video_gpu_screenshot = true
-
-# Watch content shader files for changes and auto-apply as necessary.
-# video_shader_watch_files = false
-
-# Block SRAM from being overwritten when loading save states.
-# Might potentially lead to buggy games.
-# block_sram_overwrite = false
-
-# When saving a savestate, save state index is automatically increased before
-# it is saved.
-# Also, when loading content, the index will be set to the highest existing index.
-# There is no upper bound on the index.
-# savestate_auto_index = false
-
-# Slowmotion ratio. When slowmotion, content will slow down by factor.
-# slowmotion_ratio = 3.0
-
-# The maximum rate at which content will be run when using fast forward. (E.g. 5.0 for 60 fps content => 300 fps cap).
-# RetroArch will go to sleep to ensure that the maximum rate will not be exceeded.
-# Do not rely on this cap to be perfectly accurate.
-# If this is set at 0, then fastforward ratio is unlimited (no FPS cap)
-# fastforward_ratio = 0.0
-
-# Enable stdin/network command interface.
-# network_cmd_enable = false
-# network_cmd_port = 55355
-# stdin_cmd_enable = false
-
-# Enable Sustained Performance Mode in Android 7.0+
-# sustained_performance_mode = true
-
-# File format to use when writing playlists to disk
-# playlist_use_old_format = false
-
-# Keep track of how long each core+content has been running for over time
-# content_runtime_log = false
-
-# vibrate_on_keypress = false
-
-# Enable device vibration for supported cores
-# enable_device_vibration = false
-
-# Enable game mode on supported platforms.
-# Depending on the system, it can result in more stable frame times, less audio
-# crackling, better performance and lower latency. On Linux, Feral GameMode
-# needs to be installed (https://github.com/FeralInteractive/gamemode).
-#
-# gamemode_enable = true
+accessibility_enable = "false"
+accessibility_narrator_speech_speed = "5"
+ai_service_enable = "true"
+ai_service_mode = "1"
+ai_service_pause = "false"
+ai_service_source_lang = "0"
+ai_service_target_lang = "0"
+ai_service_url = "http://localhost:4404/"
+all_users_control_menu = "false"
+apply_cheats_after_load = "false"
+apply_cheats_after_toggle = "false"
+aspect_ratio_index = "22"
+assets_directory = ":\assets"
+audio_block_frames = "0"
+audio_device = ""
+audio_driver = "xaudio"
+audio_dsp_plugin = ""
+audio_enable = "true"
+audio_enable_menu = "false"
+audio_enable_menu_bgm = "false"
+audio_enable_menu_cancel = "false"
+audio_enable_menu_notice = "false"
+audio_enable_menu_ok = "false"
+audio_fastforward_mute = "false"
+audio_filter_dir = ":\filters\audio"
+audio_latency = "64"
+audio_max_timing_skew = "0.050000"
+audio_mixer_mute_enable = "false"
+audio_mixer_volume = "0.000000"
+audio_mute_enable = "false"
+audio_out_rate = "48000"
+audio_rate_control = "true"
+audio_rate_control_delta = "0.005000"
+audio_resampler = "sinc"
+audio_resampler_quality = "3"
+audio_sync = "true"
+audio_volume = "0.000000"
+audio_wasapi_exclusive_mode = "true"
+audio_wasapi_float_format = "false"
+audio_wasapi_sh_buffer_length = "-16"
+auto_overrides_enable = "true"
+auto_remaps_enable = "true"
+auto_screenshot_filename = "true"
+auto_shaders_enable = "true"
+autosave_interval = "10"
+block_sram_overwrite = "false"
+bluetooth_driver = "null"
+builtin_imageviewer_enable = "true"
+builtin_mediaplayer_enable = "true"
+bundle_assets_dst_path = ""
+bundle_assets_dst_path_subdir = ""
+bundle_assets_extract_enable = "false"
+bundle_assets_extract_last_version = "0"
+bundle_assets_extract_version_current = "0"
+bundle_assets_src_path = ""
+cache_directory = "C:\Users\billy\AppData\Local\Temp"
+camera_allow = "false"
+camera_device = ""
+camera_driver = "null"
+cheat_database_path = ":\cheats"
+check_firmware_before_loading = "false"
+cheevos_auto_screenshot = "false"
+cheevos_badges_enable = "false"
+cheevos_challenge_indicators = "true"
+cheevos_custom_host = ""
+cheevos_enable = "false"
+cheevos_hardcore_mode_enable = "true"
+cheevos_leaderboards_enable = "true"
+cheevos_password = ""
+cheevos_richpresence_enable = "true"
+cheevos_start_active = "false"
+cheevos_test_unofficial = "false"
+cheevos_token = ""
+cheevos_unlock_sound_enable = "false"
+cheevos_username = ""
+cheevos_verbose_enable = "true"
+config_save_on_exit = "true"
+content_database_path = ":\database\rdb"
+content_favorites_directory = "default"
+content_favorites_path = ":\content_favorites.lpl"
+content_favorites_size = "200"
+content_history_directory = "default"
+content_history_path = ":\content_history.lpl"
+content_history_size = "200"
+content_image_history_directory = "default"
+content_image_history_path = ":\content_image_history.lpl"
+content_music_history_directory = "default"
+content_music_history_path = ":\content_music_history.lpl"
+content_runtime_log = "true"
+content_runtime_log_aggregate = "false"
+content_show_add = "true"
+content_show_add_entry = "2"
+content_show_contentless_cores = "2"
+content_show_explore = "true"
+content_show_favorites = "true"
+content_show_history = "true"
+content_show_images = "true"
+content_show_music = "true"
+content_show_netplay = "true"
+content_show_playlists = "true"
+content_show_settings = "true"
+content_show_settings_password = ""
+content_show_video = "true"
+content_video_directory = "default"
+content_video_history_path = ":\content_video_history.lpl"
+core_assets_directory = ":\downloads"
+core_info_cache_enable = "true"
+core_option_category_enable = "true"
+core_options_path = ""
+core_set_supports_no_game_enable = "true"
+core_updater_auto_backup = "true"
+core_updater_auto_backup_history_size = "1"
+core_updater_auto_extract_archive = "true"
+core_updater_buildbot_assets_url = "http://buildbot.libretro.com/assets/"
+core_updater_buildbot_cores_url = "http://buildbot.libretro.com/nightly/windows/x86_64/latest/"
+core_updater_show_experimental_cores = "false"
+crt_switch_center_adjust = "0"
+crt_switch_hires_menu = "false"
+crt_switch_porch_adjust = "0"
+crt_switch_resolution = "0"
+crt_switch_resolution_super = "2560"
+crt_switch_resolution_use_custom_refresh_rate = "false"
+crt_switch_timings = ""
+crt_video_refresh_rate = "60.000000"
+current_resolution_id = "0"
+cursor_directory = ":\database\cursors"
+custom_viewport_height = "720"
+custom_viewport_width = "960"
+custom_viewport_x = "0"
+custom_viewport_y = "0"
+d3d10_gpu_index = "0"
+d3d11_gpu_index = "0"
+d3d12_gpu_index = "0"
+desktop_menu_enable = "true"
+discord_allow = "false"
+discord_app_id = "475456035851599874"
+driver_switch_enable = "true"
+dynamic_wallpapers_directory = ":\assets\wallpapers"
+enable_device_vibration = "false"
+facebook_stream_key = ""
+fastforward_frameskip = "true"
+fastforward_ratio = "0.000000"
+filter_by_current_core = "false"
+flicker_filter_enable = "false"
+flicker_filter_index = "0"
+fps_show = "false"
+fps_update_interval = "256"
+frame_time_counter_reset_after_fastforwarding = "false"
+frame_time_counter_reset_after_load_state = "false"
+frame_time_counter_reset_after_save_state = "false"
+framecount_show = "false"
+frontend_log_level = "1"
+game_specific_options = "true"
+gamemode_enable = "true"
+gamma_correction = "0"
+global_core_options = "false"
+history_list_enable = "true"
+input_ai_service = "nul"
+input_ai_service_axis = "nul"
+input_ai_service_btn = "nul"
+input_ai_service_mbtn = "nul"
+input_analog_deadzone = "0.000000"
+input_analog_sensitivity = "1.000000"
+input_audio_mute = "f9"
+input_audio_mute_axis = "nul"
+input_audio_mute_btn = "nul"
+input_audio_mute_mbtn = "nul"
+input_auto_game_focus = "0"
+input_auto_mouse_grab = "false"
+input_autodetect_enable = "true"
+input_axis_threshold = "0.500000"
+input_bind_hold = "2"
+input_bind_timeout = "5"
+input_cheat_index_minus = "t"
+input_cheat_index_minus_axis = "nul"
+input_cheat_index_minus_btn = "nul"
+input_cheat_index_minus_mbtn = "nul"
+input_cheat_index_plus = "y"
+input_cheat_index_plus_axis = "nul"
+input_cheat_index_plus_btn = "nul"
+input_cheat_index_plus_mbtn = "nul"
+input_cheat_toggle = "u"
+input_cheat_toggle_axis = "nul"
+input_cheat_toggle_btn = "nul"
+input_cheat_toggle_mbtn = "nul"
+input_close_content = "nul"
+input_close_content_axis = "nul"
+input_close_content_btn = "nul"
+input_close_content_mbtn = "nul"
+input_descriptor_hide_unbound = "false"
+input_descriptor_label_show = "true"
+input_desktop_menu_toggle = "f5"
+input_desktop_menu_toggle_axis = "nul"
+input_desktop_menu_toggle_btn = "nul"
+input_desktop_menu_toggle_mbtn = "nul"
+input_device_p1 = "0"
+input_device_p10 = "0"
+input_device_p11 = "0"
+input_device_p12 = "0"
+input_device_p13 = "0"
+input_device_p14 = "0"
+input_device_p15 = "0"
+input_device_p16 = "0"
+input_device_p2 = "0"
+input_device_p3 = "0"
+input_device_p4 = "0"
+input_device_p5 = "0"
+input_device_p6 = "0"
+input_device_p7 = "0"
+input_device_p8 = "0"
+input_device_p9 = "0"
+input_disk_eject_toggle = "nul"
+input_disk_eject_toggle_axis = "nul"
+input_disk_eject_toggle_btn = "nul"
+input_disk_eject_toggle_mbtn = "nul"
+input_disk_next = "nul"
+input_disk_next_axis = "nul"
+input_disk_next_btn = "nul"
+input_disk_next_mbtn = "nul"
+input_disk_prev = "nul"
+input_disk_prev_axis = "nul"
+input_disk_prev_btn = "nul"
+input_disk_prev_mbtn = "nul"
+input_driver = "dinput"
+input_duty_cycle = "3"
+input_enable_hotkey = "nul"
+input_enable_hotkey_axis = "nul"
+input_enable_hotkey_btn = "nul"
+input_enable_hotkey_mbtn = "nul"
+input_exit_emulator = "escape"
+input_exit_emulator_axis = "nul"
+input_exit_emulator_btn = "nul"
+input_exit_emulator_mbtn = "nul"
+input_fps_toggle = "f3"
+input_fps_toggle_axis = "nul"
+input_fps_toggle_btn = "nul"
+input_fps_toggle_mbtn = "nul"
+input_frame_advance = "k"
+input_frame_advance_axis = "nul"
+input_frame_advance_btn = "nul"
+input_frame_advance_mbtn = "nul"
+input_game_focus_toggle = "scroll_lock"
+input_game_focus_toggle_axis = "nul"
+input_game_focus_toggle_btn = "nul"
+input_game_focus_toggle_mbtn = "nul"
+input_grab_mouse_toggle = "f11"
+input_grab_mouse_toggle_axis = "nul"
+input_grab_mouse_toggle_btn = "nul"
+input_grab_mouse_toggle_mbtn = "nul"
+input_hold_fast_forward = "l"
+input_hold_fast_forward_axis = "nul"
+input_hold_fast_forward_btn = "nul"
+input_hold_fast_forward_mbtn = "nul"
+input_hold_slowmotion = "e"
+input_hold_slowmotion_axis = "nul"
+input_hold_slowmotion_btn = "nul"
+input_hold_slowmotion_mbtn = "nul"
+input_hotkey_block_delay = "5"
+input_joypad_driver = "xinput"
+input_keyboard_layout = ""
+input_libretro_device_p1 = "1"
+input_libretro_device_p10 = "1"
+input_libretro_device_p11 = "1"
+input_libretro_device_p12 = "1"
+input_libretro_device_p13 = "1"
+input_libretro_device_p14 = "1"
+input_libretro_device_p15 = "1"
+input_libretro_device_p16 = "1"
+input_libretro_device_p2 = "1"
+input_libretro_device_p3 = "1"
+input_libretro_device_p4 = "1"
+input_libretro_device_p5 = "1"
+input_libretro_device_p6 = "1"
+input_libretro_device_p7 = "1"
+input_libretro_device_p8 = "1"
+input_libretro_device_p9 = "1"
+input_load_state = "f4"
+input_load_state_axis = "nul"
+input_load_state_btn = "nul"
+input_load_state_mbtn = "nul"
+input_max_users = "5"
+input_menu_toggle = "f1"
+input_menu_toggle_axis = "nul"
+input_menu_toggle_btn = "nul"
+input_menu_toggle_gamepad_combo = "0"
+input_menu_toggle_mbtn = "nul"
+input_movie_record_toggle = "o"
+input_movie_record_toggle_axis = "nul"
+input_movie_record_toggle_btn = "nul"
+input_movie_record_toggle_mbtn = "nul"
+input_netplay_fade_chat_toggle = "nul"
+input_netplay_fade_chat_toggle_axis = "nul"
+input_netplay_fade_chat_toggle_btn = "nul"
+input_netplay_fade_chat_toggle_mbtn = "nul"
+input_netplay_game_watch = "i"
+input_netplay_game_watch_axis = "nul"
+input_netplay_game_watch_btn = "nul"
+input_netplay_game_watch_mbtn = "nul"
+input_netplay_host_toggle = "nul"
+input_netplay_host_toggle_axis = "nul"
+input_netplay_host_toggle_btn = "nul"
+input_netplay_host_toggle_mbtn = "nul"
+input_netplay_ping_toggle = "nul"
+input_netplay_ping_toggle_axis = "nul"
+input_netplay_ping_toggle_btn = "nul"
+input_netplay_ping_toggle_mbtn = "nul"
+input_netplay_player_chat = "tilde"
+input_netplay_player_chat_axis = "nul"
+input_netplay_player_chat_btn = "nul"
+input_netplay_player_chat_mbtn = "nul"
+input_nowinkey_enable = "false"
+input_osk_toggle = "f12"
+input_osk_toggle_axis = "nul"
+input_osk_toggle_btn = "nul"
+input_osk_toggle_mbtn = "nul"
+input_overlay = ""
+input_overlay_aspect_adjust_landscape = "0.000000"
+input_overlay_aspect_adjust_portrait = "0.000000"
+input_overlay_auto_rotate = "false"
+input_overlay_auto_scale = "false"
+input_overlay_behind_menu = "false"
+input_overlay_enable = "true"
+input_overlay_enable_autopreferred = "true"
+input_overlay_hide_in_menu = "true"
+input_overlay_hide_when_gamepad_connected = "false"
+input_overlay_next = "nul"
+input_overlay_next_axis = "nul"
+input_overlay_next_btn = "nul"
+input_overlay_next_mbtn = "nul"
+input_overlay_opacity = "0.700000"
+input_overlay_scale_landscape = "1.000000"
+input_overlay_scale_portrait = "1.000000"
+input_overlay_show_inputs = "2"
+input_overlay_show_inputs_port = "0"
+input_overlay_show_mouse_cursor = "true"
+input_overlay_x_offset_landscape = "0.000000"
+input_overlay_x_offset_portrait = "0.000000"
+input_overlay_x_separation_landscape = "0.000000"
+input_overlay_x_separation_portrait = "0.000000"
+input_overlay_y_offset_landscape = "0.000000"
+input_overlay_y_offset_portrait = "0.000000"
+input_overlay_y_separation_landscape = "0.000000"
+input_overlay_y_separation_portrait = "0.000000"
+input_pause_toggle = "p"
+input_pause_toggle_axis = "nul"
+input_pause_toggle_btn = "nul"
+input_pause_toggle_mbtn = "nul"
+input_player10_a = "nul"
+input_player10_a_axis = "nul"
+input_player10_a_btn = "nul"
+input_player10_a_mbtn = "nul"
+input_player10_analog_dpad_mode = "0"
+input_player10_b = "nul"
+input_player10_b_axis = "nul"
+input_player10_b_btn = "nul"
+input_player10_b_mbtn = "nul"
+input_player10_down = "nul"
+input_player10_down_axis = "nul"
+input_player10_down_btn = "nul"
+input_player10_down_mbtn = "nul"
+input_player10_gun_aux_a = "nul"
+input_player10_gun_aux_a_axis = "nul"
+input_player10_gun_aux_a_btn = "nul"
+input_player10_gun_aux_a_mbtn = "nul"
+input_player10_gun_aux_b = "nul"
+input_player10_gun_aux_b_axis = "nul"
+input_player10_gun_aux_b_btn = "nul"
+input_player10_gun_aux_b_mbtn = "nul"
+input_player10_gun_aux_c = "nul"
+input_player10_gun_aux_c_axis = "nul"
+input_player10_gun_aux_c_btn = "nul"
+input_player10_gun_aux_c_mbtn = "nul"
+input_player10_gun_dpad_down = "nul"
+input_player10_gun_dpad_down_axis = "nul"
+input_player10_gun_dpad_down_btn = "nul"
+input_player10_gun_dpad_down_mbtn = "nul"
+input_player10_gun_dpad_left = "nul"
+input_player10_gun_dpad_left_axis = "nul"
+input_player10_gun_dpad_left_btn = "nul"
+input_player10_gun_dpad_left_mbtn = "nul"
+input_player10_gun_dpad_right = "nul"
+input_player10_gun_dpad_right_axis = "nul"
+input_player10_gun_dpad_right_btn = "nul"
+input_player10_gun_dpad_right_mbtn = "nul"
+input_player10_gun_dpad_up = "nul"
+input_player10_gun_dpad_up_axis = "nul"
+input_player10_gun_dpad_up_btn = "nul"
+input_player10_gun_dpad_up_mbtn = "nul"
+input_player10_gun_offscreen_shot = "nul"
+input_player10_gun_offscreen_shot_axis = "nul"
+input_player10_gun_offscreen_shot_btn = "nul"
+input_player10_gun_offscreen_shot_mbtn = "nul"
+input_player10_gun_select = "nul"
+input_player10_gun_select_axis = "nul"
+input_player10_gun_select_btn = "nul"
+input_player10_gun_select_mbtn = "nul"
+input_player10_gun_start = "nul"
+input_player10_gun_start_axis = "nul"
+input_player10_gun_start_btn = "nul"
+input_player10_gun_start_mbtn = "nul"
+input_player10_gun_trigger = "nul"
+input_player10_gun_trigger_axis = "nul"
+input_player10_gun_trigger_btn = "nul"
+input_player10_gun_trigger_mbtn = "1"
+input_player10_joypad_index = "9"
+input_player10_l = "nul"
+input_player10_l2 = "nul"
+input_player10_l2_axis = "nul"
+input_player10_l2_btn = "nul"
+input_player10_l2_mbtn = "nul"
+input_player10_l3 = "nul"
+input_player10_l3_axis = "nul"
+input_player10_l3_btn = "nul"
+input_player10_l3_mbtn = "nul"
+input_player10_l_axis = "nul"
+input_player10_l_btn = "nul"
+input_player10_l_mbtn = "nul"
+input_player10_l_x_minus = "nul"
+input_player10_l_x_minus_axis = "nul"
+input_player10_l_x_minus_btn = "nul"
+input_player10_l_x_minus_mbtn = "nul"
+input_player10_l_x_plus = "nul"
+input_player10_l_x_plus_axis = "nul"
+input_player10_l_x_plus_btn = "nul"
+input_player10_l_x_plus_mbtn = "nul"
+input_player10_l_y_minus = "nul"
+input_player10_l_y_minus_axis = "nul"
+input_player10_l_y_minus_btn = "nul"
+input_player10_l_y_minus_mbtn = "nul"
+input_player10_l_y_plus = "nul"
+input_player10_l_y_plus_axis = "nul"
+input_player10_l_y_plus_btn = "nul"
+input_player10_l_y_plus_mbtn = "nul"
+input_player10_left = "nul"
+input_player10_left_axis = "nul"
+input_player10_left_btn = "nul"
+input_player10_left_mbtn = "nul"
+input_player10_mouse_index = "9"
+input_player10_r = "nul"
+input_player10_r2 = "nul"
+input_player10_r2_axis = "nul"
+input_player10_r2_btn = "nul"
+input_player10_r2_mbtn = "nul"
+input_player10_r3 = "nul"
+input_player10_r3_axis = "nul"
+input_player10_r3_btn = "nul"
+input_player10_r3_mbtn = "nul"
+input_player10_r_axis = "nul"
+input_player10_r_btn = "nul"
+input_player10_r_mbtn = "nul"
+input_player10_r_x_minus = "nul"
+input_player10_r_x_minus_axis = "nul"
+input_player10_r_x_minus_btn = "nul"
+input_player10_r_x_minus_mbtn = "nul"
+input_player10_r_x_plus = "nul"
+input_player10_r_x_plus_axis = "nul"
+input_player10_r_x_plus_btn = "nul"
+input_player10_r_x_plus_mbtn = "nul"
+input_player10_r_y_minus = "nul"
+input_player10_r_y_minus_axis = "nul"
+input_player10_r_y_minus_btn = "nul"
+input_player10_r_y_minus_mbtn = "nul"
+input_player10_r_y_plus = "nul"
+input_player10_r_y_plus_axis = "nul"
+input_player10_r_y_plus_btn = "nul"
+input_player10_r_y_plus_mbtn = "nul"
+input_player10_right = "nul"
+input_player10_right_axis = "nul"
+input_player10_right_btn = "nul"
+input_player10_right_mbtn = "nul"
+input_player10_select = "nul"
+input_player10_select_axis = "nul"
+input_player10_select_btn = "nul"
+input_player10_select_mbtn = "nul"
+input_player10_start = "nul"
+input_player10_start_axis = "nul"
+input_player10_start_btn = "nul"
+input_player10_start_mbtn = "nul"
+input_player10_turbo = "nul"
+input_player10_turbo_axis = "nul"
+input_player10_turbo_btn = "nul"
+input_player10_turbo_mbtn = "nul"
+input_player10_up = "nul"
+input_player10_up_axis = "nul"
+input_player10_up_btn = "nul"
+input_player10_up_mbtn = "nul"
+input_player10_x = "nul"
+input_player10_x_axis = "nul"
+input_player10_x_btn = "nul"
+input_player10_x_mbtn = "nul"
+input_player10_y = "nul"
+input_player10_y_axis = "nul"
+input_player10_y_btn = "nul"
+input_player10_y_mbtn = "nul"
+input_player11_a = "nul"
+input_player11_a_axis = "nul"
+input_player11_a_btn = "nul"
+input_player11_a_mbtn = "nul"
+input_player11_analog_dpad_mode = "0"
+input_player11_b = "nul"
+input_player11_b_axis = "nul"
+input_player11_b_btn = "nul"
+input_player11_b_mbtn = "nul"
+input_player11_down = "nul"
+input_player11_down_axis = "nul"
+input_player11_down_btn = "nul"
+input_player11_down_mbtn = "nul"
+input_player11_gun_aux_a = "nul"
+input_player11_gun_aux_a_axis = "nul"
+input_player11_gun_aux_a_btn = "nul"
+input_player11_gun_aux_a_mbtn = "nul"
+input_player11_gun_aux_b = "nul"
+input_player11_gun_aux_b_axis = "nul"
+input_player11_gun_aux_b_btn = "nul"
+input_player11_gun_aux_b_mbtn = "nul"
+input_player11_gun_aux_c = "nul"
+input_player11_gun_aux_c_axis = "nul"
+input_player11_gun_aux_c_btn = "nul"
+input_player11_gun_aux_c_mbtn = "nul"
+input_player11_gun_dpad_down = "nul"
+input_player11_gun_dpad_down_axis = "nul"
+input_player11_gun_dpad_down_btn = "nul"
+input_player11_gun_dpad_down_mbtn = "nul"
+input_player11_gun_dpad_left = "nul"
+input_player11_gun_dpad_left_axis = "nul"
+input_player11_gun_dpad_left_btn = "nul"
+input_player11_gun_dpad_left_mbtn = "nul"
+input_player11_gun_dpad_right = "nul"
+input_player11_gun_dpad_right_axis = "nul"
+input_player11_gun_dpad_right_btn = "nul"
+input_player11_gun_dpad_right_mbtn = "nul"
+input_player11_gun_dpad_up = "nul"
+input_player11_gun_dpad_up_axis = "nul"
+input_player11_gun_dpad_up_btn = "nul"
+input_player11_gun_dpad_up_mbtn = "nul"
+input_player11_gun_offscreen_shot = "nul"
+input_player11_gun_offscreen_shot_axis = "nul"
+input_player11_gun_offscreen_shot_btn = "nul"
+input_player11_gun_offscreen_shot_mbtn = "nul"
+input_player11_gun_select = "nul"
+input_player11_gun_select_axis = "nul"
+input_player11_gun_select_btn = "nul"
+input_player11_gun_select_mbtn = "nul"
+input_player11_gun_start = "nul"
+input_player11_gun_start_axis = "nul"
+input_player11_gun_start_btn = "nul"
+input_player11_gun_start_mbtn = "nul"
+input_player11_gun_trigger = "nul"
+input_player11_gun_trigger_axis = "nul"
+input_player11_gun_trigger_btn = "nul"
+input_player11_gun_trigger_mbtn = "1"
+input_player11_joypad_index = "10"
+input_player11_l = "nul"
+input_player11_l2 = "nul"
+input_player11_l2_axis = "nul"
+input_player11_l2_btn = "nul"
+input_player11_l2_mbtn = "nul"
+input_player11_l3 = "nul"
+input_player11_l3_axis = "nul"
+input_player11_l3_btn = "nul"
+input_player11_l3_mbtn = "nul"
+input_player11_l_axis = "nul"
+input_player11_l_btn = "nul"
+input_player11_l_mbtn = "nul"
+input_player11_l_x_minus = "nul"
+input_player11_l_x_minus_axis = "nul"
+input_player11_l_x_minus_btn = "nul"
+input_player11_l_x_minus_mbtn = "nul"
+input_player11_l_x_plus = "nul"
+input_player11_l_x_plus_axis = "nul"
+input_player11_l_x_plus_btn = "nul"
+input_player11_l_x_plus_mbtn = "nul"
+input_player11_l_y_minus = "nul"
+input_player11_l_y_minus_axis = "nul"
+input_player11_l_y_minus_btn = "nul"
+input_player11_l_y_minus_mbtn = "nul"
+input_player11_l_y_plus = "nul"
+input_player11_l_y_plus_axis = "nul"
+input_player11_l_y_plus_btn = "nul"
+input_player11_l_y_plus_mbtn = "nul"
+input_player11_left = "nul"
+input_player11_left_axis = "nul"
+input_player11_left_btn = "nul"
+input_player11_left_mbtn = "nul"
+input_player11_mouse_index = "10"
+input_player11_r = "nul"
+input_player11_r2 = "nul"
+input_player11_r2_axis = "nul"
+input_player11_r2_btn = "nul"
+input_player11_r2_mbtn = "nul"
+input_player11_r3 = "nul"
+input_player11_r3_axis = "nul"
+input_player11_r3_btn = "nul"
+input_player11_r3_mbtn = "nul"
+input_player11_r_axis = "nul"
+input_player11_r_btn = "nul"
+input_player11_r_mbtn = "nul"
+input_player11_r_x_minus = "nul"
+input_player11_r_x_minus_axis = "nul"
+input_player11_r_x_minus_btn = "nul"
+input_player11_r_x_minus_mbtn = "nul"
+input_player11_r_x_plus = "nul"
+input_player11_r_x_plus_axis = "nul"
+input_player11_r_x_plus_btn = "nul"
+input_player11_r_x_plus_mbtn = "nul"
+input_player11_r_y_minus = "nul"
+input_player11_r_y_minus_axis = "nul"
+input_player11_r_y_minus_btn = "nul"
+input_player11_r_y_minus_mbtn = "nul"
+input_player11_r_y_plus = "nul"
+input_player11_r_y_plus_axis = "nul"
+input_player11_r_y_plus_btn = "nul"
+input_player11_r_y_plus_mbtn = "nul"
+input_player11_right = "nul"
+input_player11_right_axis = "nul"
+input_player11_right_btn = "nul"
+input_player11_right_mbtn = "nul"
+input_player11_select = "nul"
+input_player11_select_axis = "nul"
+input_player11_select_btn = "nul"
+input_player11_select_mbtn = "nul"
+input_player11_start = "nul"
+input_player11_start_axis = "nul"
+input_player11_start_btn = "nul"
+input_player11_start_mbtn = "nul"
+input_player11_turbo = "nul"
+input_player11_turbo_axis = "nul"
+input_player11_turbo_btn = "nul"
+input_player11_turbo_mbtn = "nul"
+input_player11_up = "nul"
+input_player11_up_axis = "nul"
+input_player11_up_btn = "nul"
+input_player11_up_mbtn = "nul"
+input_player11_x = "nul"
+input_player11_x_axis = "nul"
+input_player11_x_btn = "nul"
+input_player11_x_mbtn = "nul"
+input_player11_y = "nul"
+input_player11_y_axis = "nul"
+input_player11_y_btn = "nul"
+input_player11_y_mbtn = "nul"
+input_player12_a = "nul"
+input_player12_a_axis = "nul"
+input_player12_a_btn = "nul"
+input_player12_a_mbtn = "nul"
+input_player12_analog_dpad_mode = "0"
+input_player12_b = "nul"
+input_player12_b_axis = "nul"
+input_player12_b_btn = "nul"
+input_player12_b_mbtn = "nul"
+input_player12_down = "nul"
+input_player12_down_axis = "nul"
+input_player12_down_btn = "nul"
+input_player12_down_mbtn = "nul"
+input_player12_gun_aux_a = "nul"
+input_player12_gun_aux_a_axis = "nul"
+input_player12_gun_aux_a_btn = "nul"
+input_player12_gun_aux_a_mbtn = "nul"
+input_player12_gun_aux_b = "nul"
+input_player12_gun_aux_b_axis = "nul"
+input_player12_gun_aux_b_btn = "nul"
+input_player12_gun_aux_b_mbtn = "nul"
+input_player12_gun_aux_c = "nul"
+input_player12_gun_aux_c_axis = "nul"
+input_player12_gun_aux_c_btn = "nul"
+input_player12_gun_aux_c_mbtn = "nul"
+input_player12_gun_dpad_down = "nul"
+input_player12_gun_dpad_down_axis = "nul"
+input_player12_gun_dpad_down_btn = "nul"
+input_player12_gun_dpad_down_mbtn = "nul"
+input_player12_gun_dpad_left = "nul"
+input_player12_gun_dpad_left_axis = "nul"
+input_player12_gun_dpad_left_btn = "nul"
+input_player12_gun_dpad_left_mbtn = "nul"
+input_player12_gun_dpad_right = "nul"
+input_player12_gun_dpad_right_axis = "nul"
+input_player12_gun_dpad_right_btn = "nul"
+input_player12_gun_dpad_right_mbtn = "nul"
+input_player12_gun_dpad_up = "nul"
+input_player12_gun_dpad_up_axis = "nul"
+input_player12_gun_dpad_up_btn = "nul"
+input_player12_gun_dpad_up_mbtn = "nul"
+input_player12_gun_offscreen_shot = "nul"
+input_player12_gun_offscreen_shot_axis = "nul"
+input_player12_gun_offscreen_shot_btn = "nul"
+input_player12_gun_offscreen_shot_mbtn = "nul"
+input_player12_gun_select = "nul"
+input_player12_gun_select_axis = "nul"
+input_player12_gun_select_btn = "nul"
+input_player12_gun_select_mbtn = "nul"
+input_player12_gun_start = "nul"
+input_player12_gun_start_axis = "nul"
+input_player12_gun_start_btn = "nul"
+input_player12_gun_start_mbtn = "nul"
+input_player12_gun_trigger = "nul"
+input_player12_gun_trigger_axis = "nul"
+input_player12_gun_trigger_btn = "nul"
+input_player12_gun_trigger_mbtn = "1"
+input_player12_joypad_index = "11"
+input_player12_l = "nul"
+input_player12_l2 = "nul"
+input_player12_l2_axis = "nul"
+input_player12_l2_btn = "nul"
+input_player12_l2_mbtn = "nul"
+input_player12_l3 = "nul"
+input_player12_l3_axis = "nul"
+input_player12_l3_btn = "nul"
+input_player12_l3_mbtn = "nul"
+input_player12_l_axis = "nul"
+input_player12_l_btn = "nul"
+input_player12_l_mbtn = "nul"
+input_player12_l_x_minus = "nul"
+input_player12_l_x_minus_axis = "nul"
+input_player12_l_x_minus_btn = "nul"
+input_player12_l_x_minus_mbtn = "nul"
+input_player12_l_x_plus = "nul"
+input_player12_l_x_plus_axis = "nul"
+input_player12_l_x_plus_btn = "nul"
+input_player12_l_x_plus_mbtn = "nul"
+input_player12_l_y_minus = "nul"
+input_player12_l_y_minus_axis = "nul"
+input_player12_l_y_minus_btn = "nul"
+input_player12_l_y_minus_mbtn = "nul"
+input_player12_l_y_plus = "nul"
+input_player12_l_y_plus_axis = "nul"
+input_player12_l_y_plus_btn = "nul"
+input_player12_l_y_plus_mbtn = "nul"
+input_player12_left = "nul"
+input_player12_left_axis = "nul"
+input_player12_left_btn = "nul"
+input_player12_left_mbtn = "nul"
+input_player12_mouse_index = "11"
+input_player12_r = "nul"
+input_player12_r2 = "nul"
+input_player12_r2_axis = "nul"
+input_player12_r2_btn = "nul"
+input_player12_r2_mbtn = "nul"
+input_player12_r3 = "nul"
+input_player12_r3_axis = "nul"
+input_player12_r3_btn = "nul"
+input_player12_r3_mbtn = "nul"
+input_player12_r_axis = "nul"
+input_player12_r_btn = "nul"
+input_player12_r_mbtn = "nul"
+input_player12_r_x_minus = "nul"
+input_player12_r_x_minus_axis = "nul"
+input_player12_r_x_minus_btn = "nul"
+input_player12_r_x_minus_mbtn = "nul"
+input_player12_r_x_plus = "nul"
+input_player12_r_x_plus_axis = "nul"
+input_player12_r_x_plus_btn = "nul"
+input_player12_r_x_plus_mbtn = "nul"
+input_player12_r_y_minus = "nul"
+input_player12_r_y_minus_axis = "nul"
+input_player12_r_y_minus_btn = "nul"
+input_player12_r_y_minus_mbtn = "nul"
+input_player12_r_y_plus = "nul"
+input_player12_r_y_plus_axis = "nul"
+input_player12_r_y_plus_btn = "nul"
+input_player12_r_y_plus_mbtn = "nul"
+input_player12_right = "nul"
+input_player12_right_axis = "nul"
+input_player12_right_btn = "nul"
+input_player12_right_mbtn = "nul"
+input_player12_select = "nul"
+input_player12_select_axis = "nul"
+input_player12_select_btn = "nul"
+input_player12_select_mbtn = "nul"
+input_player12_start = "nul"
+input_player12_start_axis = "nul"
+input_player12_start_btn = "nul"
+input_player12_start_mbtn = "nul"
+input_player12_turbo = "nul"
+input_player12_turbo_axis = "nul"
+input_player12_turbo_btn = "nul"
+input_player12_turbo_mbtn = "nul"
+input_player12_up = "nul"
+input_player12_up_axis = "nul"
+input_player12_up_btn = "nul"
+input_player12_up_mbtn = "nul"
+input_player12_x = "nul"
+input_player12_x_axis = "nul"
+input_player12_x_btn = "nul"
+input_player12_x_mbtn = "nul"
+input_player12_y = "nul"
+input_player12_y_axis = "nul"
+input_player12_y_btn = "nul"
+input_player12_y_mbtn = "nul"
+input_player13_a = "nul"
+input_player13_a_axis = "nul"
+input_player13_a_btn = "nul"
+input_player13_a_mbtn = "nul"
+input_player13_analog_dpad_mode = "0"
+input_player13_b = "nul"
+input_player13_b_axis = "nul"
+input_player13_b_btn = "nul"
+input_player13_b_mbtn = "nul"
+input_player13_down = "nul"
+input_player13_down_axis = "nul"
+input_player13_down_btn = "nul"
+input_player13_down_mbtn = "nul"
+input_player13_gun_aux_a = "nul"
+input_player13_gun_aux_a_axis = "nul"
+input_player13_gun_aux_a_btn = "nul"
+input_player13_gun_aux_a_mbtn = "nul"
+input_player13_gun_aux_b = "nul"
+input_player13_gun_aux_b_axis = "nul"
+input_player13_gun_aux_b_btn = "nul"
+input_player13_gun_aux_b_mbtn = "nul"
+input_player13_gun_aux_c = "nul"
+input_player13_gun_aux_c_axis = "nul"
+input_player13_gun_aux_c_btn = "nul"
+input_player13_gun_aux_c_mbtn = "nul"
+input_player13_gun_dpad_down = "nul"
+input_player13_gun_dpad_down_axis = "nul"
+input_player13_gun_dpad_down_btn = "nul"
+input_player13_gun_dpad_down_mbtn = "nul"
+input_player13_gun_dpad_left = "nul"
+input_player13_gun_dpad_left_axis = "nul"
+input_player13_gun_dpad_left_btn = "nul"
+input_player13_gun_dpad_left_mbtn = "nul"
+input_player13_gun_dpad_right = "nul"
+input_player13_gun_dpad_right_axis = "nul"
+input_player13_gun_dpad_right_btn = "nul"
+input_player13_gun_dpad_right_mbtn = "nul"
+input_player13_gun_dpad_up = "nul"
+input_player13_gun_dpad_up_axis = "nul"
+input_player13_gun_dpad_up_btn = "nul"
+input_player13_gun_dpad_up_mbtn = "nul"
+input_player13_gun_offscreen_shot = "nul"
+input_player13_gun_offscreen_shot_axis = "nul"
+input_player13_gun_offscreen_shot_btn = "nul"
+input_player13_gun_offscreen_shot_mbtn = "nul"
+input_player13_gun_select = "nul"
+input_player13_gun_select_axis = "nul"
+input_player13_gun_select_btn = "nul"
+input_player13_gun_select_mbtn = "nul"
+input_player13_gun_start = "nul"
+input_player13_gun_start_axis = "nul"
+input_player13_gun_start_btn = "nul"
+input_player13_gun_start_mbtn = "nul"
+input_player13_gun_trigger = "nul"
+input_player13_gun_trigger_axis = "nul"
+input_player13_gun_trigger_btn = "nul"
+input_player13_gun_trigger_mbtn = "1"
+input_player13_joypad_index = "12"
+input_player13_l = "nul"
+input_player13_l2 = "nul"
+input_player13_l2_axis = "nul"
+input_player13_l2_btn = "nul"
+input_player13_l2_mbtn = "nul"
+input_player13_l3 = "nul"
+input_player13_l3_axis = "nul"
+input_player13_l3_btn = "nul"
+input_player13_l3_mbtn = "nul"
+input_player13_l_axis = "nul"
+input_player13_l_btn = "nul"
+input_player13_l_mbtn = "nul"
+input_player13_l_x_minus = "nul"
+input_player13_l_x_minus_axis = "nul"
+input_player13_l_x_minus_btn = "nul"
+input_player13_l_x_minus_mbtn = "nul"
+input_player13_l_x_plus = "nul"
+input_player13_l_x_plus_axis = "nul"
+input_player13_l_x_plus_btn = "nul"
+input_player13_l_x_plus_mbtn = "nul"
+input_player13_l_y_minus = "nul"
+input_player13_l_y_minus_axis = "nul"
+input_player13_l_y_minus_btn = "nul"
+input_player13_l_y_minus_mbtn = "nul"
+input_player13_l_y_plus = "nul"
+input_player13_l_y_plus_axis = "nul"
+input_player13_l_y_plus_btn = "nul"
+input_player13_l_y_plus_mbtn = "nul"
+input_player13_left = "nul"
+input_player13_left_axis = "nul"
+input_player13_left_btn = "nul"
+input_player13_left_mbtn = "nul"
+input_player13_mouse_index = "12"
+input_player13_r = "nul"
+input_player13_r2 = "nul"
+input_player13_r2_axis = "nul"
+input_player13_r2_btn = "nul"
+input_player13_r2_mbtn = "nul"
+input_player13_r3 = "nul"
+input_player13_r3_axis = "nul"
+input_player13_r3_btn = "nul"
+input_player13_r3_mbtn = "nul"
+input_player13_r_axis = "nul"
+input_player13_r_btn = "nul"
+input_player13_r_mbtn = "nul"
+input_player13_r_x_minus = "nul"
+input_player13_r_x_minus_axis = "nul"
+input_player13_r_x_minus_btn = "nul"
+input_player13_r_x_minus_mbtn = "nul"
+input_player13_r_x_plus = "nul"
+input_player13_r_x_plus_axis = "nul"
+input_player13_r_x_plus_btn = "nul"
+input_player13_r_x_plus_mbtn = "nul"
+input_player13_r_y_minus = "nul"
+input_player13_r_y_minus_axis = "nul"
+input_player13_r_y_minus_btn = "nul"
+input_player13_r_y_minus_mbtn = "nul"
+input_player13_r_y_plus = "nul"
+input_player13_r_y_plus_axis = "nul"
+input_player13_r_y_plus_btn = "nul"
+input_player13_r_y_plus_mbtn = "nul"
+input_player13_right = "nul"
+input_player13_right_axis = "nul"
+input_player13_right_btn = "nul"
+input_player13_right_mbtn = "nul"
+input_player13_select = "nul"
+input_player13_select_axis = "nul"
+input_player13_select_btn = "nul"
+input_player13_select_mbtn = "nul"
+input_player13_start = "nul"
+input_player13_start_axis = "nul"
+input_player13_start_btn = "nul"
+input_player13_start_mbtn = "nul"
+input_player13_turbo = "nul"
+input_player13_turbo_axis = "nul"
+input_player13_turbo_btn = "nul"
+input_player13_turbo_mbtn = "nul"
+input_player13_up = "nul"
+input_player13_up_axis = "nul"
+input_player13_up_btn = "nul"
+input_player13_up_mbtn = "nul"
+input_player13_x = "nul"
+input_player13_x_axis = "nul"
+input_player13_x_btn = "nul"
+input_player13_x_mbtn = "nul"
+input_player13_y = "nul"
+input_player13_y_axis = "nul"
+input_player13_y_btn = "nul"
+input_player13_y_mbtn = "nul"
+input_player14_a = "nul"
+input_player14_a_axis = "nul"
+input_player14_a_btn = "nul"
+input_player14_a_mbtn = "nul"
+input_player14_analog_dpad_mode = "0"
+input_player14_b = "nul"
+input_player14_b_axis = "nul"
+input_player14_b_btn = "nul"
+input_player14_b_mbtn = "nul"
+input_player14_down = "nul"
+input_player14_down_axis = "nul"
+input_player14_down_btn = "nul"
+input_player14_down_mbtn = "nul"
+input_player14_gun_aux_a = "nul"
+input_player14_gun_aux_a_axis = "nul"
+input_player14_gun_aux_a_btn = "nul"
+input_player14_gun_aux_a_mbtn = "nul"
+input_player14_gun_aux_b = "nul"
+input_player14_gun_aux_b_axis = "nul"
+input_player14_gun_aux_b_btn = "nul"
+input_player14_gun_aux_b_mbtn = "nul"
+input_player14_gun_aux_c = "nul"
+input_player14_gun_aux_c_axis = "nul"
+input_player14_gun_aux_c_btn = "nul"
+input_player14_gun_aux_c_mbtn = "nul"
+input_player14_gun_dpad_down = "nul"
+input_player14_gun_dpad_down_axis = "nul"
+input_player14_gun_dpad_down_btn = "nul"
+input_player14_gun_dpad_down_mbtn = "nul"
+input_player14_gun_dpad_left = "nul"
+input_player14_gun_dpad_left_axis = "nul"
+input_player14_gun_dpad_left_btn = "nul"
+input_player14_gun_dpad_left_mbtn = "nul"
+input_player14_gun_dpad_right = "nul"
+input_player14_gun_dpad_right_axis = "nul"
+input_player14_gun_dpad_right_btn = "nul"
+input_player14_gun_dpad_right_mbtn = "nul"
+input_player14_gun_dpad_up = "nul"
+input_player14_gun_dpad_up_axis = "nul"
+input_player14_gun_dpad_up_btn = "nul"
+input_player14_gun_dpad_up_mbtn = "nul"
+input_player14_gun_offscreen_shot = "nul"
+input_player14_gun_offscreen_shot_axis = "nul"
+input_player14_gun_offscreen_shot_btn = "nul"
+input_player14_gun_offscreen_shot_mbtn = "nul"
+input_player14_gun_select = "nul"
+input_player14_gun_select_axis = "nul"
+input_player14_gun_select_btn = "nul"
+input_player14_gun_select_mbtn = "nul"
+input_player14_gun_start = "nul"
+input_player14_gun_start_axis = "nul"
+input_player14_gun_start_btn = "nul"
+input_player14_gun_start_mbtn = "nul"
+input_player14_gun_trigger = "nul"
+input_player14_gun_trigger_axis = "nul"
+input_player14_gun_trigger_btn = "nul"
+input_player14_gun_trigger_mbtn = "1"
+input_player14_joypad_index = "13"
+input_player14_l = "nul"
+input_player14_l2 = "nul"
+input_player14_l2_axis = "nul"
+input_player14_l2_btn = "nul"
+input_player14_l2_mbtn = "nul"
+input_player14_l3 = "nul"
+input_player14_l3_axis = "nul"
+input_player14_l3_btn = "nul"
+input_player14_l3_mbtn = "nul"
+input_player14_l_axis = "nul"
+input_player14_l_btn = "nul"
+input_player14_l_mbtn = "nul"
+input_player14_l_x_minus = "nul"
+input_player14_l_x_minus_axis = "nul"
+input_player14_l_x_minus_btn = "nul"
+input_player14_l_x_minus_mbtn = "nul"
+input_player14_l_x_plus = "nul"
+input_player14_l_x_plus_axis = "nul"
+input_player14_l_x_plus_btn = "nul"
+input_player14_l_x_plus_mbtn = "nul"
+input_player14_l_y_minus = "nul"
+input_player14_l_y_minus_axis = "nul"
+input_player14_l_y_minus_btn = "nul"
+input_player14_l_y_minus_mbtn = "nul"
+input_player14_l_y_plus = "nul"
+input_player14_l_y_plus_axis = "nul"
+input_player14_l_y_plus_btn = "nul"
+input_player14_l_y_plus_mbtn = "nul"
+input_player14_left = "nul"
+input_player14_left_axis = "nul"
+input_player14_left_btn = "nul"
+input_player14_left_mbtn = "nul"
+input_player14_mouse_index = "13"
+input_player14_r = "nul"
+input_player14_r2 = "nul"
+input_player14_r2_axis = "nul"
+input_player14_r2_btn = "nul"
+input_player14_r2_mbtn = "nul"
+input_player14_r3 = "nul"
+input_player14_r3_axis = "nul"
+input_player14_r3_btn = "nul"
+input_player14_r3_mbtn = "nul"
+input_player14_r_axis = "nul"
+input_player14_r_btn = "nul"
+input_player14_r_mbtn = "nul"
+input_player14_r_x_minus = "nul"
+input_player14_r_x_minus_axis = "nul"
+input_player14_r_x_minus_btn = "nul"
+input_player14_r_x_minus_mbtn = "nul"
+input_player14_r_x_plus = "nul"
+input_player14_r_x_plus_axis = "nul"
+input_player14_r_x_plus_btn = "nul"
+input_player14_r_x_plus_mbtn = "nul"
+input_player14_r_y_minus = "nul"
+input_player14_r_y_minus_axis = "nul"
+input_player14_r_y_minus_btn = "nul"
+input_player14_r_y_minus_mbtn = "nul"
+input_player14_r_y_plus = "nul"
+input_player14_r_y_plus_axis = "nul"
+input_player14_r_y_plus_btn = "nul"
+input_player14_r_y_plus_mbtn = "nul"
+input_player14_right = "nul"
+input_player14_right_axis = "nul"
+input_player14_right_btn = "nul"
+input_player14_right_mbtn = "nul"
+input_player14_select = "nul"
+input_player14_select_axis = "nul"
+input_player14_select_btn = "nul"
+input_player14_select_mbtn = "nul"
+input_player14_start = "nul"
+input_player14_start_axis = "nul"
+input_player14_start_btn = "nul"
+input_player14_start_mbtn = "nul"
+input_player14_turbo = "nul"
+input_player14_turbo_axis = "nul"
+input_player14_turbo_btn = "nul"
+input_player14_turbo_mbtn = "nul"
+input_player14_up = "nul"
+input_player14_up_axis = "nul"
+input_player14_up_btn = "nul"
+input_player14_up_mbtn = "nul"
+input_player14_x = "nul"
+input_player14_x_axis = "nul"
+input_player14_x_btn = "nul"
+input_player14_x_mbtn = "nul"
+input_player14_y = "nul"
+input_player14_y_axis = "nul"
+input_player14_y_btn = "nul"
+input_player14_y_mbtn = "nul"
+input_player15_a = "nul"
+input_player15_a_axis = "nul"
+input_player15_a_btn = "nul"
+input_player15_a_mbtn = "nul"
+input_player15_analog_dpad_mode = "0"
+input_player15_b = "nul"
+input_player15_b_axis = "nul"
+input_player15_b_btn = "nul"
+input_player15_b_mbtn = "nul"
+input_player15_down = "nul"
+input_player15_down_axis = "nul"
+input_player15_down_btn = "nul"
+input_player15_down_mbtn = "nul"
+input_player15_gun_aux_a = "nul"
+input_player15_gun_aux_a_axis = "nul"
+input_player15_gun_aux_a_btn = "nul"
+input_player15_gun_aux_a_mbtn = "nul"
+input_player15_gun_aux_b = "nul"
+input_player15_gun_aux_b_axis = "nul"
+input_player15_gun_aux_b_btn = "nul"
+input_player15_gun_aux_b_mbtn = "nul"
+input_player15_gun_aux_c = "nul"
+input_player15_gun_aux_c_axis = "nul"
+input_player15_gun_aux_c_btn = "nul"
+input_player15_gun_aux_c_mbtn = "nul"
+input_player15_gun_dpad_down = "nul"
+input_player15_gun_dpad_down_axis = "nul"
+input_player15_gun_dpad_down_btn = "nul"
+input_player15_gun_dpad_down_mbtn = "nul"
+input_player15_gun_dpad_left = "nul"
+input_player15_gun_dpad_left_axis = "nul"
+input_player15_gun_dpad_left_btn = "nul"
+input_player15_gun_dpad_left_mbtn = "nul"
+input_player15_gun_dpad_right = "nul"
+input_player15_gun_dpad_right_axis = "nul"
+input_player15_gun_dpad_right_btn = "nul"
+input_player15_gun_dpad_right_mbtn = "nul"
+input_player15_gun_dpad_up = "nul"
+input_player15_gun_dpad_up_axis = "nul"
+input_player15_gun_dpad_up_btn = "nul"
+input_player15_gun_dpad_up_mbtn = "nul"
+input_player15_gun_offscreen_shot = "nul"
+input_player15_gun_offscreen_shot_axis = "nul"
+input_player15_gun_offscreen_shot_btn = "nul"
+input_player15_gun_offscreen_shot_mbtn = "nul"
+input_player15_gun_select = "nul"
+input_player15_gun_select_axis = "nul"
+input_player15_gun_select_btn = "nul"
+input_player15_gun_select_mbtn = "nul"
+input_player15_gun_start = "nul"
+input_player15_gun_start_axis = "nul"
+input_player15_gun_start_btn = "nul"
+input_player15_gun_start_mbtn = "nul"
+input_player15_gun_trigger = "nul"
+input_player15_gun_trigger_axis = "nul"
+input_player15_gun_trigger_btn = "nul"
+input_player15_gun_trigger_mbtn = "1"
+input_player15_joypad_index = "14"
+input_player15_l = "nul"
+input_player15_l2 = "nul"
+input_player15_l2_axis = "nul"
+input_player15_l2_btn = "nul"
+input_player15_l2_mbtn = "nul"
+input_player15_l3 = "nul"
+input_player15_l3_axis = "nul"
+input_player15_l3_btn = "nul"
+input_player15_l3_mbtn = "nul"
+input_player15_l_axis = "nul"
+input_player15_l_btn = "nul"
+input_player15_l_mbtn = "nul"
+input_player15_l_x_minus = "nul"
+input_player15_l_x_minus_axis = "nul"
+input_player15_l_x_minus_btn = "nul"
+input_player15_l_x_minus_mbtn = "nul"
+input_player15_l_x_plus = "nul"
+input_player15_l_x_plus_axis = "nul"
+input_player15_l_x_plus_btn = "nul"
+input_player15_l_x_plus_mbtn = "nul"
+input_player15_l_y_minus = "nul"
+input_player15_l_y_minus_axis = "nul"
+input_player15_l_y_minus_btn = "nul"
+input_player15_l_y_minus_mbtn = "nul"
+input_player15_l_y_plus = "nul"
+input_player15_l_y_plus_axis = "nul"
+input_player15_l_y_plus_btn = "nul"
+input_player15_l_y_plus_mbtn = "nul"
+input_player15_left = "nul"
+input_player15_left_axis = "nul"
+input_player15_left_btn = "nul"
+input_player15_left_mbtn = "nul"
+input_player15_mouse_index = "14"
+input_player15_r = "nul"
+input_player15_r2 = "nul"
+input_player15_r2_axis = "nul"
+input_player15_r2_btn = "nul"
+input_player15_r2_mbtn = "nul"
+input_player15_r3 = "nul"
+input_player15_r3_axis = "nul"
+input_player15_r3_btn = "nul"
+input_player15_r3_mbtn = "nul"
+input_player15_r_axis = "nul"
+input_player15_r_btn = "nul"
+input_player15_r_mbtn = "nul"
+input_player15_r_x_minus = "nul"
+input_player15_r_x_minus_axis = "nul"
+input_player15_r_x_minus_btn = "nul"
+input_player15_r_x_minus_mbtn = "nul"
+input_player15_r_x_plus = "nul"
+input_player15_r_x_plus_axis = "nul"
+input_player15_r_x_plus_btn = "nul"
+input_player15_r_x_plus_mbtn = "nul"
+input_player15_r_y_minus = "nul"
+input_player15_r_y_minus_axis = "nul"
+input_player15_r_y_minus_btn = "nul"
+input_player15_r_y_minus_mbtn = "nul"
+input_player15_r_y_plus = "nul"
+input_player15_r_y_plus_axis = "nul"
+input_player15_r_y_plus_btn = "nul"
+input_player15_r_y_plus_mbtn = "nul"
+input_player15_right = "nul"
+input_player15_right_axis = "nul"
+input_player15_right_btn = "nul"
+input_player15_right_mbtn = "nul"
+input_player15_select = "nul"
+input_player15_select_axis = "nul"
+input_player15_select_btn = "nul"
+input_player15_select_mbtn = "nul"
+input_player15_start = "nul"
+input_player15_start_axis = "nul"
+input_player15_start_btn = "nul"
+input_player15_start_mbtn = "nul"
+input_player15_turbo = "nul"
+input_player15_turbo_axis = "nul"
+input_player15_turbo_btn = "nul"
+input_player15_turbo_mbtn = "nul"
+input_player15_up = "nul"
+input_player15_up_axis = "nul"
+input_player15_up_btn = "nul"
+input_player15_up_mbtn = "nul"
+input_player15_x = "nul"
+input_player15_x_axis = "nul"
+input_player15_x_btn = "nul"
+input_player15_x_mbtn = "nul"
+input_player15_y = "nul"
+input_player15_y_axis = "nul"
+input_player15_y_btn = "nul"
+input_player15_y_mbtn = "nul"
+input_player16_a = "nul"
+input_player16_a_axis = "nul"
+input_player16_a_btn = "nul"
+input_player16_a_mbtn = "nul"
+input_player16_analog_dpad_mode = "0"
+input_player16_b = "nul"
+input_player16_b_axis = "nul"
+input_player16_b_btn = "nul"
+input_player16_b_mbtn = "nul"
+input_player16_down = "nul"
+input_player16_down_axis = "nul"
+input_player16_down_btn = "nul"
+input_player16_down_mbtn = "nul"
+input_player16_gun_aux_a = "nul"
+input_player16_gun_aux_a_axis = "nul"
+input_player16_gun_aux_a_btn = "nul"
+input_player16_gun_aux_a_mbtn = "nul"
+input_player16_gun_aux_b = "nul"
+input_player16_gun_aux_b_axis = "nul"
+input_player16_gun_aux_b_btn = "nul"
+input_player16_gun_aux_b_mbtn = "nul"
+input_player16_gun_aux_c = "nul"
+input_player16_gun_aux_c_axis = "nul"
+input_player16_gun_aux_c_btn = "nul"
+input_player16_gun_aux_c_mbtn = "nul"
+input_player16_gun_dpad_down = "nul"
+input_player16_gun_dpad_down_axis = "nul"
+input_player16_gun_dpad_down_btn = "nul"
+input_player16_gun_dpad_down_mbtn = "nul"
+input_player16_gun_dpad_left = "nul"
+input_player16_gun_dpad_left_axis = "nul"
+input_player16_gun_dpad_left_btn = "nul"
+input_player16_gun_dpad_left_mbtn = "nul"
+input_player16_gun_dpad_right = "nul"
+input_player16_gun_dpad_right_axis = "nul"
+input_player16_gun_dpad_right_btn = "nul"
+input_player16_gun_dpad_right_mbtn = "nul"
+input_player16_gun_dpad_up = "nul"
+input_player16_gun_dpad_up_axis = "nul"
+input_player16_gun_dpad_up_btn = "nul"
+input_player16_gun_dpad_up_mbtn = "nul"
+input_player16_gun_offscreen_shot = "nul"
+input_player16_gun_offscreen_shot_axis = "nul"
+input_player16_gun_offscreen_shot_btn = "nul"
+input_player16_gun_offscreen_shot_mbtn = "nul"
+input_player16_gun_select = "nul"
+input_player16_gun_select_axis = "nul"
+input_player16_gun_select_btn = "nul"
+input_player16_gun_select_mbtn = "nul"
+input_player16_gun_start = "nul"
+input_player16_gun_start_axis = "nul"
+input_player16_gun_start_btn = "nul"
+input_player16_gun_start_mbtn = "nul"
+input_player16_gun_trigger = "nul"
+input_player16_gun_trigger_axis = "nul"
+input_player16_gun_trigger_btn = "nul"
+input_player16_gun_trigger_mbtn = "1"
+input_player16_joypad_index = "15"
+input_player16_l = "nul"
+input_player16_l2 = "nul"
+input_player16_l2_axis = "nul"
+input_player16_l2_btn = "nul"
+input_player16_l2_mbtn = "nul"
+input_player16_l3 = "nul"
+input_player16_l3_axis = "nul"
+input_player16_l3_btn = "nul"
+input_player16_l3_mbtn = "nul"
+input_player16_l_axis = "nul"
+input_player16_l_btn = "nul"
+input_player16_l_mbtn = "nul"
+input_player16_l_x_minus = "nul"
+input_player16_l_x_minus_axis = "nul"
+input_player16_l_x_minus_btn = "nul"
+input_player16_l_x_minus_mbtn = "nul"
+input_player16_l_x_plus = "nul"
+input_player16_l_x_plus_axis = "nul"
+input_player16_l_x_plus_btn = "nul"
+input_player16_l_x_plus_mbtn = "nul"
+input_player16_l_y_minus = "nul"
+input_player16_l_y_minus_axis = "nul"
+input_player16_l_y_minus_btn = "nul"
+input_player16_l_y_minus_mbtn = "nul"
+input_player16_l_y_plus = "nul"
+input_player16_l_y_plus_axis = "nul"
+input_player16_l_y_plus_btn = "nul"
+input_player16_l_y_plus_mbtn = "nul"
+input_player16_left = "nul"
+input_player16_left_axis = "nul"
+input_player16_left_btn = "nul"
+input_player16_left_mbtn = "nul"
+input_player16_mouse_index = "15"
+input_player16_r = "nul"
+input_player16_r2 = "nul"
+input_player16_r2_axis = "nul"
+input_player16_r2_btn = "nul"
+input_player16_r2_mbtn = "nul"
+input_player16_r3 = "nul"
+input_player16_r3_axis = "nul"
+input_player16_r3_btn = "nul"
+input_player16_r3_mbtn = "nul"
+input_player16_r_axis = "nul"
+input_player16_r_btn = "nul"
+input_player16_r_mbtn = "nul"
+input_player16_r_x_minus = "nul"
+input_player16_r_x_minus_axis = "nul"
+input_player16_r_x_minus_btn = "nul"
+input_player16_r_x_minus_mbtn = "nul"
+input_player16_r_x_plus = "nul"
+input_player16_r_x_plus_axis = "nul"
+input_player16_r_x_plus_btn = "nul"
+input_player16_r_x_plus_mbtn = "nul"
+input_player16_r_y_minus = "nul"
+input_player16_r_y_minus_axis = "nul"
+input_player16_r_y_minus_btn = "nul"
+input_player16_r_y_minus_mbtn = "nul"
+input_player16_r_y_plus = "nul"
+input_player16_r_y_plus_axis = "nul"
+input_player16_r_y_plus_btn = "nul"
+input_player16_r_y_plus_mbtn = "nul"
+input_player16_right = "nul"
+input_player16_right_axis = "nul"
+input_player16_right_btn = "nul"
+input_player16_right_mbtn = "nul"
+input_player16_select = "nul"
+input_player16_select_axis = "nul"
+input_player16_select_btn = "nul"
+input_player16_select_mbtn = "nul"
+input_player16_start = "nul"
+input_player16_start_axis = "nul"
+input_player16_start_btn = "nul"
+input_player16_start_mbtn = "nul"
+input_player16_turbo = "nul"
+input_player16_turbo_axis = "nul"
+input_player16_turbo_btn = "nul"
+input_player16_turbo_mbtn = "nul"
+input_player16_up = "nul"
+input_player16_up_axis = "nul"
+input_player16_up_btn = "nul"
+input_player16_up_mbtn = "nul"
+input_player16_x = "nul"
+input_player16_x_axis = "nul"
+input_player16_x_btn = "nul"
+input_player16_x_mbtn = "nul"
+input_player16_y = "nul"
+input_player16_y_axis = "nul"
+input_player16_y_btn = "nul"
+input_player16_y_mbtn = "nul"
+input_player1_a = "x"
+input_player1_a_axis = "nul"
+input_player1_a_btn = "nul"
+input_player1_a_mbtn = "nul"
+input_player1_analog_dpad_mode = "0"
+input_player1_b = "z"
+input_player1_b_axis = "nul"
+input_player1_b_btn = "nul"
+input_player1_b_mbtn = "nul"
+input_player1_down = "down"
+input_player1_down_axis = "nul"
+input_player1_down_btn = "nul"
+input_player1_down_mbtn = "nul"
+input_player1_gun_aux_a = "nul"
+input_player1_gun_aux_a_axis = "nul"
+input_player1_gun_aux_a_btn = "nul"
+input_player1_gun_aux_a_mbtn = "nul"
+input_player1_gun_aux_b = "nul"
+input_player1_gun_aux_b_axis = "nul"
+input_player1_gun_aux_b_btn = "nul"
+input_player1_gun_aux_b_mbtn = "nul"
+input_player1_gun_aux_c = "nul"
+input_player1_gun_aux_c_axis = "nul"
+input_player1_gun_aux_c_btn = "nul"
+input_player1_gun_aux_c_mbtn = "nul"
+input_player1_gun_dpad_down = "nul"
+input_player1_gun_dpad_down_axis = "nul"
+input_player1_gun_dpad_down_btn = "nul"
+input_player1_gun_dpad_down_mbtn = "nul"
+input_player1_gun_dpad_left = "nul"
+input_player1_gun_dpad_left_axis = "nul"
+input_player1_gun_dpad_left_btn = "nul"
+input_player1_gun_dpad_left_mbtn = "nul"
+input_player1_gun_dpad_right = "nul"
+input_player1_gun_dpad_right_axis = "nul"
+input_player1_gun_dpad_right_btn = "nul"
+input_player1_gun_dpad_right_mbtn = "nul"
+input_player1_gun_dpad_up = "nul"
+input_player1_gun_dpad_up_axis = "nul"
+input_player1_gun_dpad_up_btn = "nul"
+input_player1_gun_dpad_up_mbtn = "nul"
+input_player1_gun_offscreen_shot = "nul"
+input_player1_gun_offscreen_shot_axis = "nul"
+input_player1_gun_offscreen_shot_btn = "nul"
+input_player1_gun_offscreen_shot_mbtn = "nul"
+input_player1_gun_select = "nul"
+input_player1_gun_select_axis = "nul"
+input_player1_gun_select_btn = "nul"
+input_player1_gun_select_mbtn = "nul"
+input_player1_gun_start = "nul"
+input_player1_gun_start_axis = "nul"
+input_player1_gun_start_btn = "nul"
+input_player1_gun_start_mbtn = "nul"
+input_player1_gun_trigger = "nul"
+input_player1_gun_trigger_axis = "nul"
+input_player1_gun_trigger_btn = "nul"
+input_player1_gun_trigger_mbtn = "1"
+input_player1_joypad_index = "0"
+input_player1_l = "q"
+input_player1_l2 = "nul"
+input_player1_l2_axis = "nul"
+input_player1_l2_btn = "nul"
+input_player1_l2_mbtn = "nul"
+input_player1_l3 = "nul"
+input_player1_l3_axis = "nul"
+input_player1_l3_btn = "nul"
+input_player1_l3_mbtn = "nul"
+input_player1_l_axis = "nul"
+input_player1_l_btn = "nul"
+input_player1_l_mbtn = "nul"
+input_player1_l_x_minus = "nul"
+input_player1_l_x_minus_axis = "nul"
+input_player1_l_x_minus_btn = "nul"
+input_player1_l_x_minus_mbtn = "nul"
+input_player1_l_x_plus = "nul"
+input_player1_l_x_plus_axis = "nul"
+input_player1_l_x_plus_btn = "nul"
+input_player1_l_x_plus_mbtn = "nul"
+input_player1_l_y_minus = "nul"
+input_player1_l_y_minus_axis = "nul"
+input_player1_l_y_minus_btn = "nul"
+input_player1_l_y_minus_mbtn = "nul"
+input_player1_l_y_plus = "nul"
+input_player1_l_y_plus_axis = "nul"
+input_player1_l_y_plus_btn = "nul"
+input_player1_l_y_plus_mbtn = "nul"
+input_player1_left = "left"
+input_player1_left_axis = "nul"
+input_player1_left_btn = "nul"
+input_player1_left_mbtn = "nul"
+input_player1_mouse_index = "0"
+input_player1_r = "w"
+input_player1_r2 = "nul"
+input_player1_r2_axis = "nul"
+input_player1_r2_btn = "nul"
+input_player1_r2_mbtn = "nul"
+input_player1_r3 = "nul"
+input_player1_r3_axis = "nul"
+input_player1_r3_btn = "nul"
+input_player1_r3_mbtn = "nul"
+input_player1_r_axis = "nul"
+input_player1_r_btn = "nul"
+input_player1_r_mbtn = "nul"
+input_player1_r_x_minus = "nul"
+input_player1_r_x_minus_axis = "nul"
+input_player1_r_x_minus_btn = "nul"
+input_player1_r_x_minus_mbtn = "nul"
+input_player1_r_x_plus = "nul"
+input_player1_r_x_plus_axis = "nul"
+input_player1_r_x_plus_btn = "nul"
+input_player1_r_x_plus_mbtn = "nul"
+input_player1_r_y_minus = "nul"
+input_player1_r_y_minus_axis = "nul"
+input_player1_r_y_minus_btn = "nul"
+input_player1_r_y_minus_mbtn = "nul"
+input_player1_r_y_plus = "nul"
+input_player1_r_y_plus_axis = "nul"
+input_player1_r_y_plus_btn = "nul"
+input_player1_r_y_plus_mbtn = "nul"
+input_player1_right = "right"
+input_player1_right_axis = "nul"
+input_player1_right_btn = "nul"
+input_player1_right_mbtn = "nul"
+input_player1_select = "rshift"
+input_player1_select_axis = "nul"
+input_player1_select_btn = "nul"
+input_player1_select_mbtn = "nul"
+input_player1_start = "enter"
+input_player1_start_axis = "nul"
+input_player1_start_btn = "nul"
+input_player1_start_mbtn = "nul"
+input_player1_turbo = "nul"
+input_player1_turbo_axis = "nul"
+input_player1_turbo_btn = "nul"
+input_player1_turbo_mbtn = "nul"
+input_player1_up = "up"
+input_player1_up_axis = "nul"
+input_player1_up_btn = "nul"
+input_player1_up_mbtn = "nul"
+input_player1_x = "s"
+input_player1_x_axis = "nul"
+input_player1_x_btn = "nul"
+input_player1_x_mbtn = "nul"
+input_player1_y = "a"
+input_player1_y_axis = "nul"
+input_player1_y_btn = "nul"
+input_player1_y_mbtn = "nul"
+input_player2_a = "nul"
+input_player2_a_axis = "nul"
+input_player2_a_btn = "nul"
+input_player2_a_mbtn = "nul"
+input_player2_analog_dpad_mode = "0"
+input_player2_b = "nul"
+input_player2_b_axis = "nul"
+input_player2_b_btn = "nul"
+input_player2_b_mbtn = "nul"
+input_player2_down = "nul"
+input_player2_down_axis = "nul"
+input_player2_down_btn = "nul"
+input_player2_down_mbtn = "nul"
+input_player2_gun_aux_a = "nul"
+input_player2_gun_aux_a_axis = "nul"
+input_player2_gun_aux_a_btn = "nul"
+input_player2_gun_aux_a_mbtn = "nul"
+input_player2_gun_aux_b = "nul"
+input_player2_gun_aux_b_axis = "nul"
+input_player2_gun_aux_b_btn = "nul"
+input_player2_gun_aux_b_mbtn = "nul"
+input_player2_gun_aux_c = "nul"
+input_player2_gun_aux_c_axis = "nul"
+input_player2_gun_aux_c_btn = "nul"
+input_player2_gun_aux_c_mbtn = "nul"
+input_player2_gun_dpad_down = "nul"
+input_player2_gun_dpad_down_axis = "nul"
+input_player2_gun_dpad_down_btn = "nul"
+input_player2_gun_dpad_down_mbtn = "nul"
+input_player2_gun_dpad_left = "nul"
+input_player2_gun_dpad_left_axis = "nul"
+input_player2_gun_dpad_left_btn = "nul"
+input_player2_gun_dpad_left_mbtn = "nul"
+input_player2_gun_dpad_right = "nul"
+input_player2_gun_dpad_right_axis = "nul"
+input_player2_gun_dpad_right_btn = "nul"
+input_player2_gun_dpad_right_mbtn = "nul"
+input_player2_gun_dpad_up = "nul"
+input_player2_gun_dpad_up_axis = "nul"
+input_player2_gun_dpad_up_btn = "nul"
+input_player2_gun_dpad_up_mbtn = "nul"
+input_player2_gun_offscreen_shot = "nul"
+input_player2_gun_offscreen_shot_axis = "nul"
+input_player2_gun_offscreen_shot_btn = "nul"
+input_player2_gun_offscreen_shot_mbtn = "nul"
+input_player2_gun_select = "nul"
+input_player2_gun_select_axis = "nul"
+input_player2_gun_select_btn = "nul"
+input_player2_gun_select_mbtn = "nul"
+input_player2_gun_start = "nul"
+input_player2_gun_start_axis = "nul"
+input_player2_gun_start_btn = "nul"
+input_player2_gun_start_mbtn = "nul"
+input_player2_gun_trigger = "nul"
+input_player2_gun_trigger_axis = "nul"
+input_player2_gun_trigger_btn = "nul"
+input_player2_gun_trigger_mbtn = "1"
+input_player2_joypad_index = "1"
+input_player2_l = "nul"
+input_player2_l2 = "nul"
+input_player2_l2_axis = "nul"
+input_player2_l2_btn = "nul"
+input_player2_l2_mbtn = "nul"
+input_player2_l3 = "nul"
+input_player2_l3_axis = "nul"
+input_player2_l3_btn = "nul"
+input_player2_l3_mbtn = "nul"
+input_player2_l_axis = "nul"
+input_player2_l_btn = "nul"
+input_player2_l_mbtn = "nul"
+input_player2_l_x_minus = "nul"
+input_player2_l_x_minus_axis = "nul"
+input_player2_l_x_minus_btn = "nul"
+input_player2_l_x_minus_mbtn = "nul"
+input_player2_l_x_plus = "nul"
+input_player2_l_x_plus_axis = "nul"
+input_player2_l_x_plus_btn = "nul"
+input_player2_l_x_plus_mbtn = "nul"
+input_player2_l_y_minus = "nul"
+input_player2_l_y_minus_axis = "nul"
+input_player2_l_y_minus_btn = "nul"
+input_player2_l_y_minus_mbtn = "nul"
+input_player2_l_y_plus = "nul"
+input_player2_l_y_plus_axis = "nul"
+input_player2_l_y_plus_btn = "nul"
+input_player2_l_y_plus_mbtn = "nul"
+input_player2_left = "nul"
+input_player2_left_axis = "nul"
+input_player2_left_btn = "nul"
+input_player2_left_mbtn = "nul"
+input_player2_mouse_index = "1"
+input_player2_r = "nul"
+input_player2_r2 = "nul"
+input_player2_r2_axis = "nul"
+input_player2_r2_btn = "nul"
+input_player2_r2_mbtn = "nul"
+input_player2_r3 = "nul"
+input_player2_r3_axis = "nul"
+input_player2_r3_btn = "nul"
+input_player2_r3_mbtn = "nul"
+input_player2_r_axis = "nul"
+input_player2_r_btn = "nul"
+input_player2_r_mbtn = "nul"
+input_player2_r_x_minus = "nul"
+input_player2_r_x_minus_axis = "nul"
+input_player2_r_x_minus_btn = "nul"
+input_player2_r_x_minus_mbtn = "nul"
+input_player2_r_x_plus = "nul"
+input_player2_r_x_plus_axis = "nul"
+input_player2_r_x_plus_btn = "nul"
+input_player2_r_x_plus_mbtn = "nul"
+input_player2_r_y_minus = "nul"
+input_player2_r_y_minus_axis = "nul"
+input_player2_r_y_minus_btn = "nul"
+input_player2_r_y_minus_mbtn = "nul"
+input_player2_r_y_plus = "nul"
+input_player2_r_y_plus_axis = "nul"
+input_player2_r_y_plus_btn = "nul"
+input_player2_r_y_plus_mbtn = "nul"
+input_player2_right = "nul"
+input_player2_right_axis = "nul"
+input_player2_right_btn = "nul"
+input_player2_right_mbtn = "nul"
+input_player2_select = "nul"
+input_player2_select_axis = "nul"
+input_player2_select_btn = "nul"
+input_player2_select_mbtn = "nul"
+input_player2_start = "nul"
+input_player2_start_axis = "nul"
+input_player2_start_btn = "nul"
+input_player2_start_mbtn = "nul"
+input_player2_turbo = "nul"
+input_player2_turbo_axis = "nul"
+input_player2_turbo_btn = "nul"
+input_player2_turbo_mbtn = "nul"
+input_player2_up = "nul"
+input_player2_up_axis = "nul"
+input_player2_up_btn = "nul"
+input_player2_up_mbtn = "nul"
+input_player2_x = "nul"
+input_player2_x_axis = "nul"
+input_player2_x_btn = "nul"
+input_player2_x_mbtn = "nul"
+input_player2_y = "nul"
+input_player2_y_axis = "nul"
+input_player2_y_btn = "nul"
+input_player2_y_mbtn = "nul"
+input_player3_a = "nul"
+input_player3_a_axis = "nul"
+input_player3_a_btn = "nul"
+input_player3_a_mbtn = "nul"
+input_player3_analog_dpad_mode = "0"
+input_player3_b = "nul"
+input_player3_b_axis = "nul"
+input_player3_b_btn = "nul"
+input_player3_b_mbtn = "nul"
+input_player3_down = "nul"
+input_player3_down_axis = "nul"
+input_player3_down_btn = "nul"
+input_player3_down_mbtn = "nul"
+input_player3_gun_aux_a = "nul"
+input_player3_gun_aux_a_axis = "nul"
+input_player3_gun_aux_a_btn = "nul"
+input_player3_gun_aux_a_mbtn = "nul"
+input_player3_gun_aux_b = "nul"
+input_player3_gun_aux_b_axis = "nul"
+input_player3_gun_aux_b_btn = "nul"
+input_player3_gun_aux_b_mbtn = "nul"
+input_player3_gun_aux_c = "nul"
+input_player3_gun_aux_c_axis = "nul"
+input_player3_gun_aux_c_btn = "nul"
+input_player3_gun_aux_c_mbtn = "nul"
+input_player3_gun_dpad_down = "nul"
+input_player3_gun_dpad_down_axis = "nul"
+input_player3_gun_dpad_down_btn = "nul"
+input_player3_gun_dpad_down_mbtn = "nul"
+input_player3_gun_dpad_left = "nul"
+input_player3_gun_dpad_left_axis = "nul"
+input_player3_gun_dpad_left_btn = "nul"
+input_player3_gun_dpad_left_mbtn = "nul"
+input_player3_gun_dpad_right = "nul"
+input_player3_gun_dpad_right_axis = "nul"
+input_player3_gun_dpad_right_btn = "nul"
+input_player3_gun_dpad_right_mbtn = "nul"
+input_player3_gun_dpad_up = "nul"
+input_player3_gun_dpad_up_axis = "nul"
+input_player3_gun_dpad_up_btn = "nul"
+input_player3_gun_dpad_up_mbtn = "nul"
+input_player3_gun_offscreen_shot = "nul"
+input_player3_gun_offscreen_shot_axis = "nul"
+input_player3_gun_offscreen_shot_btn = "nul"
+input_player3_gun_offscreen_shot_mbtn = "nul"
+input_player3_gun_select = "nul"
+input_player3_gun_select_axis = "nul"
+input_player3_gun_select_btn = "nul"
+input_player3_gun_select_mbtn = "nul"
+input_player3_gun_start = "nul"
+input_player3_gun_start_axis = "nul"
+input_player3_gun_start_btn = "nul"
+input_player3_gun_start_mbtn = "nul"
+input_player3_gun_trigger = "nul"
+input_player3_gun_trigger_axis = "nul"
+input_player3_gun_trigger_btn = "nul"
+input_player3_gun_trigger_mbtn = "1"
+input_player3_joypad_index = "2"
+input_player3_l = "nul"
+input_player3_l2 = "nul"
+input_player3_l2_axis = "nul"
+input_player3_l2_btn = "nul"
+input_player3_l2_mbtn = "nul"
+input_player3_l3 = "nul"
+input_player3_l3_axis = "nul"
+input_player3_l3_btn = "nul"
+input_player3_l3_mbtn = "nul"
+input_player3_l_axis = "nul"
+input_player3_l_btn = "nul"
+input_player3_l_mbtn = "nul"
+input_player3_l_x_minus = "nul"
+input_player3_l_x_minus_axis = "nul"
+input_player3_l_x_minus_btn = "nul"
+input_player3_l_x_minus_mbtn = "nul"
+input_player3_l_x_plus = "nul"
+input_player3_l_x_plus_axis = "nul"
+input_player3_l_x_plus_btn = "nul"
+input_player3_l_x_plus_mbtn = "nul"
+input_player3_l_y_minus = "nul"
+input_player3_l_y_minus_axis = "nul"
+input_player3_l_y_minus_btn = "nul"
+input_player3_l_y_minus_mbtn = "nul"
+input_player3_l_y_plus = "nul"
+input_player3_l_y_plus_axis = "nul"
+input_player3_l_y_plus_btn = "nul"
+input_player3_l_y_plus_mbtn = "nul"
+input_player3_left = "nul"
+input_player3_left_axis = "nul"
+input_player3_left_btn = "nul"
+input_player3_left_mbtn = "nul"
+input_player3_mouse_index = "2"
+input_player3_r = "nul"
+input_player3_r2 = "nul"
+input_player3_r2_axis = "nul"
+input_player3_r2_btn = "nul"
+input_player3_r2_mbtn = "nul"
+input_player3_r3 = "nul"
+input_player3_r3_axis = "nul"
+input_player3_r3_btn = "nul"
+input_player3_r3_mbtn = "nul"
+input_player3_r_axis = "nul"
+input_player3_r_btn = "nul"
+input_player3_r_mbtn = "nul"
+input_player3_r_x_minus = "nul"
+input_player3_r_x_minus_axis = "nul"
+input_player3_r_x_minus_btn = "nul"
+input_player3_r_x_minus_mbtn = "nul"
+input_player3_r_x_plus = "nul"
+input_player3_r_x_plus_axis = "nul"
+input_player3_r_x_plus_btn = "nul"
+input_player3_r_x_plus_mbtn = "nul"
+input_player3_r_y_minus = "nul"
+input_player3_r_y_minus_axis = "nul"
+input_player3_r_y_minus_btn = "nul"
+input_player3_r_y_minus_mbtn = "nul"
+input_player3_r_y_plus = "nul"
+input_player3_r_y_plus_axis = "nul"
+input_player3_r_y_plus_btn = "nul"
+input_player3_r_y_plus_mbtn = "nul"
+input_player3_right = "nul"
+input_player3_right_axis = "nul"
+input_player3_right_btn = "nul"
+input_player3_right_mbtn = "nul"
+input_player3_select = "nul"
+input_player3_select_axis = "nul"
+input_player3_select_btn = "nul"
+input_player3_select_mbtn = "nul"
+input_player3_start = "nul"
+input_player3_start_axis = "nul"
+input_player3_start_btn = "nul"
+input_player3_start_mbtn = "nul"
+input_player3_turbo = "nul"
+input_player3_turbo_axis = "nul"
+input_player3_turbo_btn = "nul"
+input_player3_turbo_mbtn = "nul"
+input_player3_up = "nul"
+input_player3_up_axis = "nul"
+input_player3_up_btn = "nul"
+input_player3_up_mbtn = "nul"
+input_player3_x = "nul"
+input_player3_x_axis = "nul"
+input_player3_x_btn = "nul"
+input_player3_x_mbtn = "nul"
+input_player3_y = "nul"
+input_player3_y_axis = "nul"
+input_player3_y_btn = "nul"
+input_player3_y_mbtn = "nul"
+input_player4_a = "nul"
+input_player4_a_axis = "nul"
+input_player4_a_btn = "nul"
+input_player4_a_mbtn = "nul"
+input_player4_analog_dpad_mode = "0"
+input_player4_b = "nul"
+input_player4_b_axis = "nul"
+input_player4_b_btn = "nul"
+input_player4_b_mbtn = "nul"
+input_player4_down = "nul"
+input_player4_down_axis = "nul"
+input_player4_down_btn = "nul"
+input_player4_down_mbtn = "nul"
+input_player4_gun_aux_a = "nul"
+input_player4_gun_aux_a_axis = "nul"
+input_player4_gun_aux_a_btn = "nul"
+input_player4_gun_aux_a_mbtn = "nul"
+input_player4_gun_aux_b = "nul"
+input_player4_gun_aux_b_axis = "nul"
+input_player4_gun_aux_b_btn = "nul"
+input_player4_gun_aux_b_mbtn = "nul"
+input_player4_gun_aux_c = "nul"
+input_player4_gun_aux_c_axis = "nul"
+input_player4_gun_aux_c_btn = "nul"
+input_player4_gun_aux_c_mbtn = "nul"
+input_player4_gun_dpad_down = "nul"
+input_player4_gun_dpad_down_axis = "nul"
+input_player4_gun_dpad_down_btn = "nul"
+input_player4_gun_dpad_down_mbtn = "nul"
+input_player4_gun_dpad_left = "nul"
+input_player4_gun_dpad_left_axis = "nul"
+input_player4_gun_dpad_left_btn = "nul"
+input_player4_gun_dpad_left_mbtn = "nul"
+input_player4_gun_dpad_right = "nul"
+input_player4_gun_dpad_right_axis = "nul"
+input_player4_gun_dpad_right_btn = "nul"
+input_player4_gun_dpad_right_mbtn = "nul"
+input_player4_gun_dpad_up = "nul"
+input_player4_gun_dpad_up_axis = "nul"
+input_player4_gun_dpad_up_btn = "nul"
+input_player4_gun_dpad_up_mbtn = "nul"
+input_player4_gun_offscreen_shot = "nul"
+input_player4_gun_offscreen_shot_axis = "nul"
+input_player4_gun_offscreen_shot_btn = "nul"
+input_player4_gun_offscreen_shot_mbtn = "nul"
+input_player4_gun_select = "nul"
+input_player4_gun_select_axis = "nul"
+input_player4_gun_select_btn = "nul"
+input_player4_gun_select_mbtn = "nul"
+input_player4_gun_start = "nul"
+input_player4_gun_start_axis = "nul"
+input_player4_gun_start_btn = "nul"
+input_player4_gun_start_mbtn = "nul"
+input_player4_gun_trigger = "nul"
+input_player4_gun_trigger_axis = "nul"
+input_player4_gun_trigger_btn = "nul"
+input_player4_gun_trigger_mbtn = "1"
+input_player4_joypad_index = "3"
+input_player4_l = "nul"
+input_player4_l2 = "nul"
+input_player4_l2_axis = "nul"
+input_player4_l2_btn = "nul"
+input_player4_l2_mbtn = "nul"
+input_player4_l3 = "nul"
+input_player4_l3_axis = "nul"
+input_player4_l3_btn = "nul"
+input_player4_l3_mbtn = "nul"
+input_player4_l_axis = "nul"
+input_player4_l_btn = "nul"
+input_player4_l_mbtn = "nul"
+input_player4_l_x_minus = "nul"
+input_player4_l_x_minus_axis = "nul"
+input_player4_l_x_minus_btn = "nul"
+input_player4_l_x_minus_mbtn = "nul"
+input_player4_l_x_plus = "nul"
+input_player4_l_x_plus_axis = "nul"
+input_player4_l_x_plus_btn = "nul"
+input_player4_l_x_plus_mbtn = "nul"
+input_player4_l_y_minus = "nul"
+input_player4_l_y_minus_axis = "nul"
+input_player4_l_y_minus_btn = "nul"
+input_player4_l_y_minus_mbtn = "nul"
+input_player4_l_y_plus = "nul"
+input_player4_l_y_plus_axis = "nul"
+input_player4_l_y_plus_btn = "nul"
+input_player4_l_y_plus_mbtn = "nul"
+input_player4_left = "nul"
+input_player4_left_axis = "nul"
+input_player4_left_btn = "nul"
+input_player4_left_mbtn = "nul"
+input_player4_mouse_index = "3"
+input_player4_r = "nul"
+input_player4_r2 = "nul"
+input_player4_r2_axis = "nul"
+input_player4_r2_btn = "nul"
+input_player4_r2_mbtn = "nul"
+input_player4_r3 = "nul"
+input_player4_r3_axis = "nul"
+input_player4_r3_btn = "nul"
+input_player4_r3_mbtn = "nul"
+input_player4_r_axis = "nul"
+input_player4_r_btn = "nul"
+input_player4_r_mbtn = "nul"
+input_player4_r_x_minus = "nul"
+input_player4_r_x_minus_axis = "nul"
+input_player4_r_x_minus_btn = "nul"
+input_player4_r_x_minus_mbtn = "nul"
+input_player4_r_x_plus = "nul"
+input_player4_r_x_plus_axis = "nul"
+input_player4_r_x_plus_btn = "nul"
+input_player4_r_x_plus_mbtn = "nul"
+input_player4_r_y_minus = "nul"
+input_player4_r_y_minus_axis = "nul"
+input_player4_r_y_minus_btn = "nul"
+input_player4_r_y_minus_mbtn = "nul"
+input_player4_r_y_plus = "nul"
+input_player4_r_y_plus_axis = "nul"
+input_player4_r_y_plus_btn = "nul"
+input_player4_r_y_plus_mbtn = "nul"
+input_player4_right = "nul"
+input_player4_right_axis = "nul"
+input_player4_right_btn = "nul"
+input_player4_right_mbtn = "nul"
+input_player4_select = "nul"
+input_player4_select_axis = "nul"
+input_player4_select_btn = "nul"
+input_player4_select_mbtn = "nul"
+input_player4_start = "nul"
+input_player4_start_axis = "nul"
+input_player4_start_btn = "nul"
+input_player4_start_mbtn = "nul"
+input_player4_turbo = "nul"
+input_player4_turbo_axis = "nul"
+input_player4_turbo_btn = "nul"
+input_player4_turbo_mbtn = "nul"
+input_player4_up = "nul"
+input_player4_up_axis = "nul"
+input_player4_up_btn = "nul"
+input_player4_up_mbtn = "nul"
+input_player4_x = "nul"
+input_player4_x_axis = "nul"
+input_player4_x_btn = "nul"
+input_player4_x_mbtn = "nul"
+input_player4_y = "nul"
+input_player4_y_axis = "nul"
+input_player4_y_btn = "nul"
+input_player4_y_mbtn = "nul"
+input_player5_a = "nul"
+input_player5_a_axis = "nul"
+input_player5_a_btn = "nul"
+input_player5_a_mbtn = "nul"
+input_player5_analog_dpad_mode = "0"
+input_player5_b = "nul"
+input_player5_b_axis = "nul"
+input_player5_b_btn = "nul"
+input_player5_b_mbtn = "nul"
+input_player5_down = "nul"
+input_player5_down_axis = "nul"
+input_player5_down_btn = "nul"
+input_player5_down_mbtn = "nul"
+input_player5_gun_aux_a = "nul"
+input_player5_gun_aux_a_axis = "nul"
+input_player5_gun_aux_a_btn = "nul"
+input_player5_gun_aux_a_mbtn = "nul"
+input_player5_gun_aux_b = "nul"
+input_player5_gun_aux_b_axis = "nul"
+input_player5_gun_aux_b_btn = "nul"
+input_player5_gun_aux_b_mbtn = "nul"
+input_player5_gun_aux_c = "nul"
+input_player5_gun_aux_c_axis = "nul"
+input_player5_gun_aux_c_btn = "nul"
+input_player5_gun_aux_c_mbtn = "nul"
+input_player5_gun_dpad_down = "nul"
+input_player5_gun_dpad_down_axis = "nul"
+input_player5_gun_dpad_down_btn = "nul"
+input_player5_gun_dpad_down_mbtn = "nul"
+input_player5_gun_dpad_left = "nul"
+input_player5_gun_dpad_left_axis = "nul"
+input_player5_gun_dpad_left_btn = "nul"
+input_player5_gun_dpad_left_mbtn = "nul"
+input_player5_gun_dpad_right = "nul"
+input_player5_gun_dpad_right_axis = "nul"
+input_player5_gun_dpad_right_btn = "nul"
+input_player5_gun_dpad_right_mbtn = "nul"
+input_player5_gun_dpad_up = "nul"
+input_player5_gun_dpad_up_axis = "nul"
+input_player5_gun_dpad_up_btn = "nul"
+input_player5_gun_dpad_up_mbtn = "nul"
+input_player5_gun_offscreen_shot = "nul"
+input_player5_gun_offscreen_shot_axis = "nul"
+input_player5_gun_offscreen_shot_btn = "nul"
+input_player5_gun_offscreen_shot_mbtn = "nul"
+input_player5_gun_select = "nul"
+input_player5_gun_select_axis = "nul"
+input_player5_gun_select_btn = "nul"
+input_player5_gun_select_mbtn = "nul"
+input_player5_gun_start = "nul"
+input_player5_gun_start_axis = "nul"
+input_player5_gun_start_btn = "nul"
+input_player5_gun_start_mbtn = "nul"
+input_player5_gun_trigger = "nul"
+input_player5_gun_trigger_axis = "nul"
+input_player5_gun_trigger_btn = "nul"
+input_player5_gun_trigger_mbtn = "1"
+input_player5_joypad_index = "4"
+input_player5_l = "nul"
+input_player5_l2 = "nul"
+input_player5_l2_axis = "nul"
+input_player5_l2_btn = "nul"
+input_player5_l2_mbtn = "nul"
+input_player5_l3 = "nul"
+input_player5_l3_axis = "nul"
+input_player5_l3_btn = "nul"
+input_player5_l3_mbtn = "nul"
+input_player5_l_axis = "nul"
+input_player5_l_btn = "nul"
+input_player5_l_mbtn = "nul"
+input_player5_l_x_minus = "nul"
+input_player5_l_x_minus_axis = "nul"
+input_player5_l_x_minus_btn = "nul"
+input_player5_l_x_minus_mbtn = "nul"
+input_player5_l_x_plus = "nul"
+input_player5_l_x_plus_axis = "nul"
+input_player5_l_x_plus_btn = "nul"
+input_player5_l_x_plus_mbtn = "nul"
+input_player5_l_y_minus = "nul"
+input_player5_l_y_minus_axis = "nul"
+input_player5_l_y_minus_btn = "nul"
+input_player5_l_y_minus_mbtn = "nul"
+input_player5_l_y_plus = "nul"
+input_player5_l_y_plus_axis = "nul"
+input_player5_l_y_plus_btn = "nul"
+input_player5_l_y_plus_mbtn = "nul"
+input_player5_left = "nul"
+input_player5_left_axis = "nul"
+input_player5_left_btn = "nul"
+input_player5_left_mbtn = "nul"
+input_player5_mouse_index = "4"
+input_player5_r = "nul"
+input_player5_r2 = "nul"
+input_player5_r2_axis = "nul"
+input_player5_r2_btn = "nul"
+input_player5_r2_mbtn = "nul"
+input_player5_r3 = "nul"
+input_player5_r3_axis = "nul"
+input_player5_r3_btn = "nul"
+input_player5_r3_mbtn = "nul"
+input_player5_r_axis = "nul"
+input_player5_r_btn = "nul"
+input_player5_r_mbtn = "nul"
+input_player5_r_x_minus = "nul"
+input_player5_r_x_minus_axis = "nul"
+input_player5_r_x_minus_btn = "nul"
+input_player5_r_x_minus_mbtn = "nul"
+input_player5_r_x_plus = "nul"
+input_player5_r_x_plus_axis = "nul"
+input_player5_r_x_plus_btn = "nul"
+input_player5_r_x_plus_mbtn = "nul"
+input_player5_r_y_minus = "nul"
+input_player5_r_y_minus_axis = "nul"
+input_player5_r_y_minus_btn = "nul"
+input_player5_r_y_minus_mbtn = "nul"
+input_player5_r_y_plus = "nul"
+input_player5_r_y_plus_axis = "nul"
+input_player5_r_y_plus_btn = "nul"
+input_player5_r_y_plus_mbtn = "nul"
+input_player5_right = "nul"
+input_player5_right_axis = "nul"
+input_player5_right_btn = "nul"
+input_player5_right_mbtn = "nul"
+input_player5_select = "nul"
+input_player5_select_axis = "nul"
+input_player5_select_btn = "nul"
+input_player5_select_mbtn = "nul"
+input_player5_start = "nul"
+input_player5_start_axis = "nul"
+input_player5_start_btn = "nul"
+input_player5_start_mbtn = "nul"
+input_player5_turbo = "nul"
+input_player5_turbo_axis = "nul"
+input_player5_turbo_btn = "nul"
+input_player5_turbo_mbtn = "nul"
+input_player5_up = "nul"
+input_player5_up_axis = "nul"
+input_player5_up_btn = "nul"
+input_player5_up_mbtn = "nul"
+input_player5_x = "nul"
+input_player5_x_axis = "nul"
+input_player5_x_btn = "nul"
+input_player5_x_mbtn = "nul"
+input_player5_y = "nul"
+input_player5_y_axis = "nul"
+input_player5_y_btn = "nul"
+input_player5_y_mbtn = "nul"
+input_player6_a = "nul"
+input_player6_a_axis = "nul"
+input_player6_a_btn = "nul"
+input_player6_a_mbtn = "nul"
+input_player6_analog_dpad_mode = "0"
+input_player6_b = "nul"
+input_player6_b_axis = "nul"
+input_player6_b_btn = "nul"
+input_player6_b_mbtn = "nul"
+input_player6_down = "nul"
+input_player6_down_axis = "nul"
+input_player6_down_btn = "nul"
+input_player6_down_mbtn = "nul"
+input_player6_gun_aux_a = "nul"
+input_player6_gun_aux_a_axis = "nul"
+input_player6_gun_aux_a_btn = "nul"
+input_player6_gun_aux_a_mbtn = "nul"
+input_player6_gun_aux_b = "nul"
+input_player6_gun_aux_b_axis = "nul"
+input_player6_gun_aux_b_btn = "nul"
+input_player6_gun_aux_b_mbtn = "nul"
+input_player6_gun_aux_c = "nul"
+input_player6_gun_aux_c_axis = "nul"
+input_player6_gun_aux_c_btn = "nul"
+input_player6_gun_aux_c_mbtn = "nul"
+input_player6_gun_dpad_down = "nul"
+input_player6_gun_dpad_down_axis = "nul"
+input_player6_gun_dpad_down_btn = "nul"
+input_player6_gun_dpad_down_mbtn = "nul"
+input_player6_gun_dpad_left = "nul"
+input_player6_gun_dpad_left_axis = "nul"
+input_player6_gun_dpad_left_btn = "nul"
+input_player6_gun_dpad_left_mbtn = "nul"
+input_player6_gun_dpad_right = "nul"
+input_player6_gun_dpad_right_axis = "nul"
+input_player6_gun_dpad_right_btn = "nul"
+input_player6_gun_dpad_right_mbtn = "nul"
+input_player6_gun_dpad_up = "nul"
+input_player6_gun_dpad_up_axis = "nul"
+input_player6_gun_dpad_up_btn = "nul"
+input_player6_gun_dpad_up_mbtn = "nul"
+input_player6_gun_offscreen_shot = "nul"
+input_player6_gun_offscreen_shot_axis = "nul"
+input_player6_gun_offscreen_shot_btn = "nul"
+input_player6_gun_offscreen_shot_mbtn = "nul"
+input_player6_gun_select = "nul"
+input_player6_gun_select_axis = "nul"
+input_player6_gun_select_btn = "nul"
+input_player6_gun_select_mbtn = "nul"
+input_player6_gun_start = "nul"
+input_player6_gun_start_axis = "nul"
+input_player6_gun_start_btn = "nul"
+input_player6_gun_start_mbtn = "nul"
+input_player6_gun_trigger = "nul"
+input_player6_gun_trigger_axis = "nul"
+input_player6_gun_trigger_btn = "nul"
+input_player6_gun_trigger_mbtn = "1"
+input_player6_joypad_index = "5"
+input_player6_l = "nul"
+input_player6_l2 = "nul"
+input_player6_l2_axis = "nul"
+input_player6_l2_btn = "nul"
+input_player6_l2_mbtn = "nul"
+input_player6_l3 = "nul"
+input_player6_l3_axis = "nul"
+input_player6_l3_btn = "nul"
+input_player6_l3_mbtn = "nul"
+input_player6_l_axis = "nul"
+input_player6_l_btn = "nul"
+input_player6_l_mbtn = "nul"
+input_player6_l_x_minus = "nul"
+input_player6_l_x_minus_axis = "nul"
+input_player6_l_x_minus_btn = "nul"
+input_player6_l_x_minus_mbtn = "nul"
+input_player6_l_x_plus = "nul"
+input_player6_l_x_plus_axis = "nul"
+input_player6_l_x_plus_btn = "nul"
+input_player6_l_x_plus_mbtn = "nul"
+input_player6_l_y_minus = "nul"
+input_player6_l_y_minus_axis = "nul"
+input_player6_l_y_minus_btn = "nul"
+input_player6_l_y_minus_mbtn = "nul"
+input_player6_l_y_plus = "nul"
+input_player6_l_y_plus_axis = "nul"
+input_player6_l_y_plus_btn = "nul"
+input_player6_l_y_plus_mbtn = "nul"
+input_player6_left = "nul"
+input_player6_left_axis = "nul"
+input_player6_left_btn = "nul"
+input_player6_left_mbtn = "nul"
+input_player6_mouse_index = "5"
+input_player6_r = "nul"
+input_player6_r2 = "nul"
+input_player6_r2_axis = "nul"
+input_player6_r2_btn = "nul"
+input_player6_r2_mbtn = "nul"
+input_player6_r3 = "nul"
+input_player6_r3_axis = "nul"
+input_player6_r3_btn = "nul"
+input_player6_r3_mbtn = "nul"
+input_player6_r_axis = "nul"
+input_player6_r_btn = "nul"
+input_player6_r_mbtn = "nul"
+input_player6_r_x_minus = "nul"
+input_player6_r_x_minus_axis = "nul"
+input_player6_r_x_minus_btn = "nul"
+input_player6_r_x_minus_mbtn = "nul"
+input_player6_r_x_plus = "nul"
+input_player6_r_x_plus_axis = "nul"
+input_player6_r_x_plus_btn = "nul"
+input_player6_r_x_plus_mbtn = "nul"
+input_player6_r_y_minus = "nul"
+input_player6_r_y_minus_axis = "nul"
+input_player6_r_y_minus_btn = "nul"
+input_player6_r_y_minus_mbtn = "nul"
+input_player6_r_y_plus = "nul"
+input_player6_r_y_plus_axis = "nul"
+input_player6_r_y_plus_btn = "nul"
+input_player6_r_y_plus_mbtn = "nul"
+input_player6_right = "nul"
+input_player6_right_axis = "nul"
+input_player6_right_btn = "nul"
+input_player6_right_mbtn = "nul"
+input_player6_select = "nul"
+input_player6_select_axis = "nul"
+input_player6_select_btn = "nul"
+input_player6_select_mbtn = "nul"
+input_player6_start = "nul"
+input_player6_start_axis = "nul"
+input_player6_start_btn = "nul"
+input_player6_start_mbtn = "nul"
+input_player6_turbo = "nul"
+input_player6_turbo_axis = "nul"
+input_player6_turbo_btn = "nul"
+input_player6_turbo_mbtn = "nul"
+input_player6_up = "nul"
+input_player6_up_axis = "nul"
+input_player6_up_btn = "nul"
+input_player6_up_mbtn = "nul"
+input_player6_x = "nul"
+input_player6_x_axis = "nul"
+input_player6_x_btn = "nul"
+input_player6_x_mbtn = "nul"
+input_player6_y = "nul"
+input_player6_y_axis = "nul"
+input_player6_y_btn = "nul"
+input_player6_y_mbtn = "nul"
+input_player7_a = "nul"
+input_player7_a_axis = "nul"
+input_player7_a_btn = "nul"
+input_player7_a_mbtn = "nul"
+input_player7_analog_dpad_mode = "0"
+input_player7_b = "nul"
+input_player7_b_axis = "nul"
+input_player7_b_btn = "nul"
+input_player7_b_mbtn = "nul"
+input_player7_down = "nul"
+input_player7_down_axis = "nul"
+input_player7_down_btn = "nul"
+input_player7_down_mbtn = "nul"
+input_player7_gun_aux_a = "nul"
+input_player7_gun_aux_a_axis = "nul"
+input_player7_gun_aux_a_btn = "nul"
+input_player7_gun_aux_a_mbtn = "nul"
+input_player7_gun_aux_b = "nul"
+input_player7_gun_aux_b_axis = "nul"
+input_player7_gun_aux_b_btn = "nul"
+input_player7_gun_aux_b_mbtn = "nul"
+input_player7_gun_aux_c = "nul"
+input_player7_gun_aux_c_axis = "nul"
+input_player7_gun_aux_c_btn = "nul"
+input_player7_gun_aux_c_mbtn = "nul"
+input_player7_gun_dpad_down = "nul"
+input_player7_gun_dpad_down_axis = "nul"
+input_player7_gun_dpad_down_btn = "nul"
+input_player7_gun_dpad_down_mbtn = "nul"
+input_player7_gun_dpad_left = "nul"
+input_player7_gun_dpad_left_axis = "nul"
+input_player7_gun_dpad_left_btn = "nul"
+input_player7_gun_dpad_left_mbtn = "nul"
+input_player7_gun_dpad_right = "nul"
+input_player7_gun_dpad_right_axis = "nul"
+input_player7_gun_dpad_right_btn = "nul"
+input_player7_gun_dpad_right_mbtn = "nul"
+input_player7_gun_dpad_up = "nul"
+input_player7_gun_dpad_up_axis = "nul"
+input_player7_gun_dpad_up_btn = "nul"
+input_player7_gun_dpad_up_mbtn = "nul"
+input_player7_gun_offscreen_shot = "nul"
+input_player7_gun_offscreen_shot_axis = "nul"
+input_player7_gun_offscreen_shot_btn = "nul"
+input_player7_gun_offscreen_shot_mbtn = "nul"
+input_player7_gun_select = "nul"
+input_player7_gun_select_axis = "nul"
+input_player7_gun_select_btn = "nul"
+input_player7_gun_select_mbtn = "nul"
+input_player7_gun_start = "nul"
+input_player7_gun_start_axis = "nul"
+input_player7_gun_start_btn = "nul"
+input_player7_gun_start_mbtn = "nul"
+input_player7_gun_trigger = "nul"
+input_player7_gun_trigger_axis = "nul"
+input_player7_gun_trigger_btn = "nul"
+input_player7_gun_trigger_mbtn = "1"
+input_player7_joypad_index = "6"
+input_player7_l = "nul"
+input_player7_l2 = "nul"
+input_player7_l2_axis = "nul"
+input_player7_l2_btn = "nul"
+input_player7_l2_mbtn = "nul"
+input_player7_l3 = "nul"
+input_player7_l3_axis = "nul"
+input_player7_l3_btn = "nul"
+input_player7_l3_mbtn = "nul"
+input_player7_l_axis = "nul"
+input_player7_l_btn = "nul"
+input_player7_l_mbtn = "nul"
+input_player7_l_x_minus = "nul"
+input_player7_l_x_minus_axis = "nul"
+input_player7_l_x_minus_btn = "nul"
+input_player7_l_x_minus_mbtn = "nul"
+input_player7_l_x_plus = "nul"
+input_player7_l_x_plus_axis = "nul"
+input_player7_l_x_plus_btn = "nul"
+input_player7_l_x_plus_mbtn = "nul"
+input_player7_l_y_minus = "nul"
+input_player7_l_y_minus_axis = "nul"
+input_player7_l_y_minus_btn = "nul"
+input_player7_l_y_minus_mbtn = "nul"
+input_player7_l_y_plus = "nul"
+input_player7_l_y_plus_axis = "nul"
+input_player7_l_y_plus_btn = "nul"
+input_player7_l_y_plus_mbtn = "nul"
+input_player7_left = "nul"
+input_player7_left_axis = "nul"
+input_player7_left_btn = "nul"
+input_player7_left_mbtn = "nul"
+input_player7_mouse_index = "6"
+input_player7_r = "nul"
+input_player7_r2 = "nul"
+input_player7_r2_axis = "nul"
+input_player7_r2_btn = "nul"
+input_player7_r2_mbtn = "nul"
+input_player7_r3 = "nul"
+input_player7_r3_axis = "nul"
+input_player7_r3_btn = "nul"
+input_player7_r3_mbtn = "nul"
+input_player7_r_axis = "nul"
+input_player7_r_btn = "nul"
+input_player7_r_mbtn = "nul"
+input_player7_r_x_minus = "nul"
+input_player7_r_x_minus_axis = "nul"
+input_player7_r_x_minus_btn = "nul"
+input_player7_r_x_minus_mbtn = "nul"
+input_player7_r_x_plus = "nul"
+input_player7_r_x_plus_axis = "nul"
+input_player7_r_x_plus_btn = "nul"
+input_player7_r_x_plus_mbtn = "nul"
+input_player7_r_y_minus = "nul"
+input_player7_r_y_minus_axis = "nul"
+input_player7_r_y_minus_btn = "nul"
+input_player7_r_y_minus_mbtn = "nul"
+input_player7_r_y_plus = "nul"
+input_player7_r_y_plus_axis = "nul"
+input_player7_r_y_plus_btn = "nul"
+input_player7_r_y_plus_mbtn = "nul"
+input_player7_right = "nul"
+input_player7_right_axis = "nul"
+input_player7_right_btn = "nul"
+input_player7_right_mbtn = "nul"
+input_player7_select = "nul"
+input_player7_select_axis = "nul"
+input_player7_select_btn = "nul"
+input_player7_select_mbtn = "nul"
+input_player7_start = "nul"
+input_player7_start_axis = "nul"
+input_player7_start_btn = "nul"
+input_player7_start_mbtn = "nul"
+input_player7_turbo = "nul"
+input_player7_turbo_axis = "nul"
+input_player7_turbo_btn = "nul"
+input_player7_turbo_mbtn = "nul"
+input_player7_up = "nul"
+input_player7_up_axis = "nul"
+input_player7_up_btn = "nul"
+input_player7_up_mbtn = "nul"
+input_player7_x = "nul"
+input_player7_x_axis = "nul"
+input_player7_x_btn = "nul"
+input_player7_x_mbtn = "nul"
+input_player7_y = "nul"
+input_player7_y_axis = "nul"
+input_player7_y_btn = "nul"
+input_player7_y_mbtn = "nul"
+input_player8_a = "nul"
+input_player8_a_axis = "nul"
+input_player8_a_btn = "nul"
+input_player8_a_mbtn = "nul"
+input_player8_analog_dpad_mode = "0"
+input_player8_b = "nul"
+input_player8_b_axis = "nul"
+input_player8_b_btn = "nul"
+input_player8_b_mbtn = "nul"
+input_player8_down = "nul"
+input_player8_down_axis = "nul"
+input_player8_down_btn = "nul"
+input_player8_down_mbtn = "nul"
+input_player8_gun_aux_a = "nul"
+input_player8_gun_aux_a_axis = "nul"
+input_player8_gun_aux_a_btn = "nul"
+input_player8_gun_aux_a_mbtn = "nul"
+input_player8_gun_aux_b = "nul"
+input_player8_gun_aux_b_axis = "nul"
+input_player8_gun_aux_b_btn = "nul"
+input_player8_gun_aux_b_mbtn = "nul"
+input_player8_gun_aux_c = "nul"
+input_player8_gun_aux_c_axis = "nul"
+input_player8_gun_aux_c_btn = "nul"
+input_player8_gun_aux_c_mbtn = "nul"
+input_player8_gun_dpad_down = "nul"
+input_player8_gun_dpad_down_axis = "nul"
+input_player8_gun_dpad_down_btn = "nul"
+input_player8_gun_dpad_down_mbtn = "nul"
+input_player8_gun_dpad_left = "nul"
+input_player8_gun_dpad_left_axis = "nul"
+input_player8_gun_dpad_left_btn = "nul"
+input_player8_gun_dpad_left_mbtn = "nul"
+input_player8_gun_dpad_right = "nul"
+input_player8_gun_dpad_right_axis = "nul"
+input_player8_gun_dpad_right_btn = "nul"
+input_player8_gun_dpad_right_mbtn = "nul"
+input_player8_gun_dpad_up = "nul"
+input_player8_gun_dpad_up_axis = "nul"
+input_player8_gun_dpad_up_btn = "nul"
+input_player8_gun_dpad_up_mbtn = "nul"
+input_player8_gun_offscreen_shot = "nul"
+input_player8_gun_offscreen_shot_axis = "nul"
+input_player8_gun_offscreen_shot_btn = "nul"
+input_player8_gun_offscreen_shot_mbtn = "nul"
+input_player8_gun_select = "nul"
+input_player8_gun_select_axis = "nul"
+input_player8_gun_select_btn = "nul"
+input_player8_gun_select_mbtn = "nul"
+input_player8_gun_start = "nul"
+input_player8_gun_start_axis = "nul"
+input_player8_gun_start_btn = "nul"
+input_player8_gun_start_mbtn = "nul"
+input_player8_gun_trigger = "nul"
+input_player8_gun_trigger_axis = "nul"
+input_player8_gun_trigger_btn = "nul"
+input_player8_gun_trigger_mbtn = "1"
+input_player8_joypad_index = "7"
+input_player8_l = "nul"
+input_player8_l2 = "nul"
+input_player8_l2_axis = "nul"
+input_player8_l2_btn = "nul"
+input_player8_l2_mbtn = "nul"
+input_player8_l3 = "nul"
+input_player8_l3_axis = "nul"
+input_player8_l3_btn = "nul"
+input_player8_l3_mbtn = "nul"
+input_player8_l_axis = "nul"
+input_player8_l_btn = "nul"
+input_player8_l_mbtn = "nul"
+input_player8_l_x_minus = "nul"
+input_player8_l_x_minus_axis = "nul"
+input_player8_l_x_minus_btn = "nul"
+input_player8_l_x_minus_mbtn = "nul"
+input_player8_l_x_plus = "nul"
+input_player8_l_x_plus_axis = "nul"
+input_player8_l_x_plus_btn = "nul"
+input_player8_l_x_plus_mbtn = "nul"
+input_player8_l_y_minus = "nul"
+input_player8_l_y_minus_axis = "nul"
+input_player8_l_y_minus_btn = "nul"
+input_player8_l_y_minus_mbtn = "nul"
+input_player8_l_y_plus = "nul"
+input_player8_l_y_plus_axis = "nul"
+input_player8_l_y_plus_btn = "nul"
+input_player8_l_y_plus_mbtn = "nul"
+input_player8_left = "nul"
+input_player8_left_axis = "nul"
+input_player8_left_btn = "nul"
+input_player8_left_mbtn = "nul"
+input_player8_mouse_index = "7"
+input_player8_r = "nul"
+input_player8_r2 = "nul"
+input_player8_r2_axis = "nul"
+input_player8_r2_btn = "nul"
+input_player8_r2_mbtn = "nul"
+input_player8_r3 = "nul"
+input_player8_r3_axis = "nul"
+input_player8_r3_btn = "nul"
+input_player8_r3_mbtn = "nul"
+input_player8_r_axis = "nul"
+input_player8_r_btn = "nul"
+input_player8_r_mbtn = "nul"
+input_player8_r_x_minus = "nul"
+input_player8_r_x_minus_axis = "nul"
+input_player8_r_x_minus_btn = "nul"
+input_player8_r_x_minus_mbtn = "nul"
+input_player8_r_x_plus = "nul"
+input_player8_r_x_plus_axis = "nul"
+input_player8_r_x_plus_btn = "nul"
+input_player8_r_x_plus_mbtn = "nul"
+input_player8_r_y_minus = "nul"
+input_player8_r_y_minus_axis = "nul"
+input_player8_r_y_minus_btn = "nul"
+input_player8_r_y_minus_mbtn = "nul"
+input_player8_r_y_plus = "nul"
+input_player8_r_y_plus_axis = "nul"
+input_player8_r_y_plus_btn = "nul"
+input_player8_r_y_plus_mbtn = "nul"
+input_player8_right = "nul"
+input_player8_right_axis = "nul"
+input_player8_right_btn = "nul"
+input_player8_right_mbtn = "nul"
+input_player8_select = "nul"
+input_player8_select_axis = "nul"
+input_player8_select_btn = "nul"
+input_player8_select_mbtn = "nul"
+input_player8_start = "nul"
+input_player8_start_axis = "nul"
+input_player8_start_btn = "nul"
+input_player8_start_mbtn = "nul"
+input_player8_turbo = "nul"
+input_player8_turbo_axis = "nul"
+input_player8_turbo_btn = "nul"
+input_player8_turbo_mbtn = "nul"
+input_player8_up = "nul"
+input_player8_up_axis = "nul"
+input_player8_up_btn = "nul"
+input_player8_up_mbtn = "nul"
+input_player8_x = "nul"
+input_player8_x_axis = "nul"
+input_player8_x_btn = "nul"
+input_player8_x_mbtn = "nul"
+input_player8_y = "nul"
+input_player8_y_axis = "nul"
+input_player8_y_btn = "nul"
+input_player8_y_mbtn = "nul"
+input_player9_a = "nul"
+input_player9_a_axis = "nul"
+input_player9_a_btn = "nul"
+input_player9_a_mbtn = "nul"
+input_player9_analog_dpad_mode = "0"
+input_player9_b = "nul"
+input_player9_b_axis = "nul"
+input_player9_b_btn = "nul"
+input_player9_b_mbtn = "nul"
+input_player9_down = "nul"
+input_player9_down_axis = "nul"
+input_player9_down_btn = "nul"
+input_player9_down_mbtn = "nul"
+input_player9_gun_aux_a = "nul"
+input_player9_gun_aux_a_axis = "nul"
+input_player9_gun_aux_a_btn = "nul"
+input_player9_gun_aux_a_mbtn = "nul"
+input_player9_gun_aux_b = "nul"
+input_player9_gun_aux_b_axis = "nul"
+input_player9_gun_aux_b_btn = "nul"
+input_player9_gun_aux_b_mbtn = "nul"
+input_player9_gun_aux_c = "nul"
+input_player9_gun_aux_c_axis = "nul"
+input_player9_gun_aux_c_btn = "nul"
+input_player9_gun_aux_c_mbtn = "nul"
+input_player9_gun_dpad_down = "nul"
+input_player9_gun_dpad_down_axis = "nul"
+input_player9_gun_dpad_down_btn = "nul"
+input_player9_gun_dpad_down_mbtn = "nul"
+input_player9_gun_dpad_left = "nul"
+input_player9_gun_dpad_left_axis = "nul"
+input_player9_gun_dpad_left_btn = "nul"
+input_player9_gun_dpad_left_mbtn = "nul"
+input_player9_gun_dpad_right = "nul"
+input_player9_gun_dpad_right_axis = "nul"
+input_player9_gun_dpad_right_btn = "nul"
+input_player9_gun_dpad_right_mbtn = "nul"
+input_player9_gun_dpad_up = "nul"
+input_player9_gun_dpad_up_axis = "nul"
+input_player9_gun_dpad_up_btn = "nul"
+input_player9_gun_dpad_up_mbtn = "nul"
+input_player9_gun_offscreen_shot = "nul"
+input_player9_gun_offscreen_shot_axis = "nul"
+input_player9_gun_offscreen_shot_btn = "nul"
+input_player9_gun_offscreen_shot_mbtn = "nul"
+input_player9_gun_select = "nul"
+input_player9_gun_select_axis = "nul"
+input_player9_gun_select_btn = "nul"
+input_player9_gun_select_mbtn = "nul"
+input_player9_gun_start = "nul"
+input_player9_gun_start_axis = "nul"
+input_player9_gun_start_btn = "nul"
+input_player9_gun_start_mbtn = "nul"
+input_player9_gun_trigger = "nul"
+input_player9_gun_trigger_axis = "nul"
+input_player9_gun_trigger_btn = "nul"
+input_player9_gun_trigger_mbtn = "1"
+input_player9_joypad_index = "8"
+input_player9_l = "nul"
+input_player9_l2 = "nul"
+input_player9_l2_axis = "nul"
+input_player9_l2_btn = "nul"
+input_player9_l2_mbtn = "nul"
+input_player9_l3 = "nul"
+input_player9_l3_axis = "nul"
+input_player9_l3_btn = "nul"
+input_player9_l3_mbtn = "nul"
+input_player9_l_axis = "nul"
+input_player9_l_btn = "nul"
+input_player9_l_mbtn = "nul"
+input_player9_l_x_minus = "nul"
+input_player9_l_x_minus_axis = "nul"
+input_player9_l_x_minus_btn = "nul"
+input_player9_l_x_minus_mbtn = "nul"
+input_player9_l_x_plus = "nul"
+input_player9_l_x_plus_axis = "nul"
+input_player9_l_x_plus_btn = "nul"
+input_player9_l_x_plus_mbtn = "nul"
+input_player9_l_y_minus = "nul"
+input_player9_l_y_minus_axis = "nul"
+input_player9_l_y_minus_btn = "nul"
+input_player9_l_y_minus_mbtn = "nul"
+input_player9_l_y_plus = "nul"
+input_player9_l_y_plus_axis = "nul"
+input_player9_l_y_plus_btn = "nul"
+input_player9_l_y_plus_mbtn = "nul"
+input_player9_left = "nul"
+input_player9_left_axis = "nul"
+input_player9_left_btn = "nul"
+input_player9_left_mbtn = "nul"
+input_player9_mouse_index = "8"
+input_player9_r = "nul"
+input_player9_r2 = "nul"
+input_player9_r2_axis = "nul"
+input_player9_r2_btn = "nul"
+input_player9_r2_mbtn = "nul"
+input_player9_r3 = "nul"
+input_player9_r3_axis = "nul"
+input_player9_r3_btn = "nul"
+input_player9_r3_mbtn = "nul"
+input_player9_r_axis = "nul"
+input_player9_r_btn = "nul"
+input_player9_r_mbtn = "nul"
+input_player9_r_x_minus = "nul"
+input_player9_r_x_minus_axis = "nul"
+input_player9_r_x_minus_btn = "nul"
+input_player9_r_x_minus_mbtn = "nul"
+input_player9_r_x_plus = "nul"
+input_player9_r_x_plus_axis = "nul"
+input_player9_r_x_plus_btn = "nul"
+input_player9_r_x_plus_mbtn = "nul"
+input_player9_r_y_minus = "nul"
+input_player9_r_y_minus_axis = "nul"
+input_player9_r_y_minus_btn = "nul"
+input_player9_r_y_minus_mbtn = "nul"
+input_player9_r_y_plus = "nul"
+input_player9_r_y_plus_axis = "nul"
+input_player9_r_y_plus_btn = "nul"
+input_player9_r_y_plus_mbtn = "nul"
+input_player9_right = "nul"
+input_player9_right_axis = "nul"
+input_player9_right_btn = "nul"
+input_player9_right_mbtn = "nul"
+input_player9_select = "nul"
+input_player9_select_axis = "nul"
+input_player9_select_btn = "nul"
+input_player9_select_mbtn = "nul"
+input_player9_start = "nul"
+input_player9_start_axis = "nul"
+input_player9_start_btn = "nul"
+input_player9_start_mbtn = "nul"
+input_player9_turbo = "nul"
+input_player9_turbo_axis = "nul"
+input_player9_turbo_btn = "nul"
+input_player9_turbo_mbtn = "nul"
+input_player9_up = "nul"
+input_player9_up_axis = "nul"
+input_player9_up_btn = "nul"
+input_player9_up_mbtn = "nul"
+input_player9_x = "nul"
+input_player9_x_axis = "nul"
+input_player9_x_btn = "nul"
+input_player9_x_mbtn = "nul"
+input_player9_y = "nul"
+input_player9_y_axis = "nul"
+input_player9_y_btn = "nul"
+input_player9_y_mbtn = "nul"
+input_poll_type_behavior = "2"
+input_quit_gamepad_combo = "0"
+input_recording_toggle = "nul"
+input_recording_toggle_axis = "nul"
+input_recording_toggle_btn = "nul"
+input_recording_toggle_mbtn = "nul"
+input_remap_binds_enable = "true"
+input_remapping_directory = ":\config\remaps"
+input_reset = "h"
+input_reset_axis = "nul"
+input_reset_btn = "nul"
+input_reset_mbtn = "nul"
+input_rewind = "r"
+input_rewind_axis = "nul"
+input_rewind_btn = "nul"
+input_rewind_mbtn = "nul"
+input_rumble_gain = "100"
+input_runahead_toggle = "nul"
+input_runahead_toggle_axis = "nul"
+input_runahead_toggle_btn = "nul"
+input_runahead_toggle_mbtn = "nul"
+input_save_state = "f2"
+input_save_state_axis = "nul"
+input_save_state_btn = "nul"
+input_save_state_mbtn = "nul"
+input_screenshot = "f8"
+input_screenshot_axis = "nul"
+input_screenshot_btn = "nul"
+input_screenshot_mbtn = "nul"
+input_send_debug_info = "f10"
+input_send_debug_info_axis = "nul"
+input_send_debug_info_btn = "nul"
+input_send_debug_info_mbtn = "nul"
+input_sensors_enable = "true"
+input_shader_next = "m"
+input_shader_next_axis = "nul"
+input_shader_next_btn = "nul"
+input_shader_next_mbtn = "nul"
+input_shader_prev = "n"
+input_shader_prev_axis = "nul"
+input_shader_prev_btn = "nul"
+input_shader_prev_mbtn = "nul"
+input_state_slot_decrease = "f6"
+input_state_slot_decrease_axis = "nul"
+input_state_slot_decrease_btn = "nul"
+input_state_slot_decrease_mbtn = "nul"
+input_state_slot_increase = "f7"
+input_state_slot_increase_axis = "nul"
+input_state_slot_increase_btn = "nul"
+input_state_slot_increase_mbtn = "nul"
+input_streaming_toggle = "nul"
+input_streaming_toggle_axis = "nul"
+input_streaming_toggle_btn = "nul"
+input_streaming_toggle_mbtn = "nul"
+input_toggle_fast_forward = "space"
+input_toggle_fast_forward_axis = "nul"
+input_toggle_fast_forward_btn = "nul"
+input_toggle_fast_forward_mbtn = "nul"
+input_toggle_fullscreen = "f"
+input_toggle_fullscreen_axis = "nul"
+input_toggle_fullscreen_btn = "nul"
+input_toggle_fullscreen_mbtn = "nul"
+input_toggle_slowmotion = "nul"
+input_toggle_slowmotion_axis = "nul"
+input_toggle_slowmotion_btn = "nul"
+input_toggle_slowmotion_mbtn = "nul"
+input_toggle_statistics = "nul"
+input_toggle_statistics_axis = "nul"
+input_toggle_statistics_btn = "nul"
+input_toggle_statistics_mbtn = "nul"
+input_toggle_vrr_runloop = "nul"
+input_toggle_vrr_runloop_axis = "nul"
+input_toggle_vrr_runloop_btn = "nul"
+input_toggle_vrr_runloop_mbtn = "nul"
+input_touch_scale = "1"
+input_turbo_default_button = "0"
+input_turbo_mode = "0"
+input_turbo_period = "6"
+input_volume_down = "subtract"
+input_volume_down_axis = "nul"
+input_volume_down_btn = "nul"
+input_volume_down_mbtn = "nul"
+input_volume_up = "add"
+input_volume_up_axis = "nul"
+input_volume_up_btn = "nul"
+input_volume_up_mbtn = "nul"
+joypad_autoconfig_dir = ":\autoconfig"
+keyboard_gamepad_enable = "true"
+keyboard_gamepad_mapping_type = "1"
+kiosk_mode_enable = "false"
+kiosk_mode_password = ""
+led_driver = "null"
+libretro_directory = ":\cores"
+libretro_info_path = ":\info"
+libretro_log_level = "1"
+load_dummy_on_core_shutdown = "true"
+location_allow = "false"
+location_driver = "null"
+log_dir = ":\logs"
+log_to_file = "false"
+log_to_file_timestamp = "false"
+log_verbosity = "true"
+materialui_auto_rotate_nav_bar = "true"
+materialui_dual_thumbnail_list_view_enable = "true"
+materialui_icons_enable = "true"
+materialui_landscape_layout_optimization = "1"
+materialui_menu_color_theme = "9"
+materialui_menu_transition_animation = "0"
+materialui_playlist_icons_enable = "true"
+materialui_show_nav_bar = "true"
+materialui_thumbnail_background_enable = "true"
+materialui_thumbnail_view_landscape = "2"
+materialui_thumbnail_view_portrait = "1"
+memory_show = "false"
+memory_update_interval = "256"
+menu_battery_level_enable = "true"
+menu_core_enable = "true"
+menu_driver = "ozone"
+menu_dynamic_wallpaper_enable = "true"
+menu_enable_widgets = "true"
+menu_font_color_blue = "255"
+menu_font_color_green = "255"
+menu_font_color_red = "255"
+menu_footer_opacity = "1.000000"
+menu_framebuffer_opacity = "0.900000"
+menu_header_opacity = "1.000000"
+menu_horizontal_animation = "true"
+menu_insert_disk_resume = "true"
+menu_left_thumbnails = "0"
+menu_linear_filter = "false"
+menu_mouse_enable = "true"
+menu_navigation_browser_filter_supported_extensions_enable = "true"
+menu_navigation_wraparound_enable = "true"
+menu_pause_libretro = "true"
+menu_pointer_enable = "false"
+menu_rgui_full_width_layout = "true"
+menu_rgui_shadows = "false"
+menu_rgui_transparency = "true"
+menu_savestate_resume = "true"
+menu_scale_factor = "1.000000"
+menu_screensaver_animation = "0"
+menu_screensaver_animation_speed = "1.000000"
+menu_screensaver_timeout = "0"
+menu_scroll_delay = "256"
+menu_scroll_fast = "false"
+menu_shader_pipeline = "2"
+menu_show_advanced_settings = "false"
+menu_show_configurations = "true"
+menu_show_core_updater = "true"
+menu_show_dump_disc = "true"
+menu_show_help = "true"
+menu_show_information = "true"
+menu_show_latency = "true"
+menu_show_legacy_thumbnail_updater = "false"
+menu_show_load_content = "true"
+menu_show_load_content_animation = "true"
+menu_show_load_core = "true"
+menu_show_load_disc = "true"
+menu_show_online_updater = "true"
+menu_show_overlays = "true"
+menu_show_quit_retroarch = "true"
+menu_show_reboot = "true"
+menu_show_restart_retroarch = "true"
+menu_show_rewind = "true"
+menu_show_shutdown = "true"
+menu_show_sublabels = "true"
+menu_show_video_layout = "true"
+menu_swap_ok_cancel_buttons = "true"
+menu_throttle_framerate = "true"
+menu_thumbnail_upscale_threshold = "0"
+menu_thumbnails = "3"
+menu_ticker_smooth = "true"
+menu_ticker_speed = "2.000000"
+menu_ticker_type = "1"
+menu_timedate_date_separator = "0"
+menu_timedate_enable = "true"
+menu_timedate_style = "11"
+menu_unified_controls = "false"
+menu_use_preferred_system_color_theme = "false"
+menu_wallpaper = ""
+menu_wallpaper_opacity = "0.300000"
+menu_widget_scale_auto = "true"
+menu_widget_scale_factor = "1.000000"
+menu_widget_scale_factor_windowed = "1.000000"
+menu_xmb_animation_horizontal_highlight = "0"
+menu_xmb_animation_move_up_down = "0"
+menu_xmb_animation_opening_main_menu = "0"
+menu_xmb_thumbnail_scale_factor = "100"
+menu_xmb_vertical_fade_factor = "100"
+midi_driver = "winmm"
+midi_input = "Off"
+midi_output = "Off"
+midi_volume = "100"
+netplay_allow_pausing = "false"
+netplay_allow_slaves = "true"
+netplay_check_frames = "600"
+netplay_custom_mitm_server = ""
+netplay_fade_chat = "true"
+netplay_input_latency_frames_min = "0"
+netplay_input_latency_frames_range = "0"
+netplay_ip_address = ""
+netplay_ip_port = "55435"
+netplay_max_connections = "3"
+netplay_max_ping = "0"
+netplay_mitm_server = "nyc"
+netplay_nat_traversal = "true"
+netplay_nickname = ""
+netplay_password = ""
+netplay_ping_show = "false"
+netplay_public_announce = "true"
+netplay_request_device_p1 = "false"
+netplay_request_device_p10 = "false"
+netplay_request_device_p11 = "false"
+netplay_request_device_p12 = "false"
+netplay_request_device_p13 = "false"
+netplay_request_device_p14 = "false"
+netplay_request_device_p15 = "false"
+netplay_request_device_p16 = "false"
+netplay_request_device_p2 = "false"
+netplay_request_device_p3 = "false"
+netplay_request_device_p4 = "false"
+netplay_request_device_p5 = "false"
+netplay_request_device_p6 = "false"
+netplay_request_device_p7 = "false"
+netplay_request_device_p8 = "false"
+netplay_request_device_p9 = "false"
+netplay_require_slaves = "false"
+netplay_share_analog = "1"
+netplay_share_digital = "1"
+netplay_show_only_connectable = "true"
+netplay_spectate_password = ""
+netplay_start_as_spectator = "false"
+netplay_stateless_mode = "false"
+netplay_use_mitm_server = "false"
+network_cmd_enable = "false"
+network_cmd_port = "55355"
+network_on_demand_thumbnails = "false"
+network_remote_base_port = "55400"
+network_remote_enable = "false"
+network_remote_enable_user_p1 = "false"
+network_remote_enable_user_p10 = "false"
+network_remote_enable_user_p11 = "false"
+network_remote_enable_user_p12 = "false"
+network_remote_enable_user_p13 = "false"
+network_remote_enable_user_p14 = "false"
+network_remote_enable_user_p15 = "false"
+network_remote_enable_user_p16 = "false"
+network_remote_enable_user_p2 = "false"
+network_remote_enable_user_p3 = "false"
+network_remote_enable_user_p4 = "false"
+network_remote_enable_user_p5 = "false"
+network_remote_enable_user_p6 = "false"
+network_remote_enable_user_p7 = "false"
+network_remote_enable_user_p8 = "false"
+network_remote_enable_user_p9 = "false"
+notification_show_autoconfig = "true"
+notification_show_cheats_applied = "true"
+notification_show_config_override_load = "true"
+notification_show_fast_forward = "true"
+notification_show_netplay_extra = "false"
+notification_show_patch_applied = "true"
+notification_show_refresh_rate = "true"
+notification_show_remap_load = "true"
+notification_show_screenshot = "true"
+notification_show_screenshot_duration = "0"
+notification_show_screenshot_flash = "0"
+notification_show_set_initial_disk = "true"
+notification_show_when_menu_is_alive = "false"
+overlay_directory = ":\overlays"
+ozone_collapse_sidebar = "false"
+ozone_menu_color_theme = "1"
+ozone_scroll_content_metadata = "false"
+ozone_sort_after_truncate_playlist_name = "true"
+ozone_thumbnail_scale_factor = "1.000000"
+ozone_truncate_playlist_name = "true"
+pause_nonactive = "true"
+perfcnt_enable = "false"
+playlist_compression = "false"
+playlist_directory = ":\playlists"
+playlist_entry_remove_enable = "1"
+playlist_entry_rename = "true"
+playlist_fuzzy_archive_match = "false"
+playlist_portable_paths = "false"
+playlist_show_entry_idx = "true"
+playlist_show_history_icons = "0"
+playlist_show_inline_core_name = "0"
+playlist_show_sublabels = "true"
+playlist_sort_alphabetical = "true"
+playlist_sublabel_last_played_style = "0"
+playlist_sublabel_runtime_type = "0"
+playlist_use_old_format = "false"
+quick_menu_show_add_to_favorites = "true"
+quick_menu_show_cheats = "true"
+quick_menu_show_close_content = "true"
+quick_menu_show_controls = "true"
+quick_menu_show_core_options_flush = "false"
+quick_menu_show_download_thumbnails = "true"
+quick_menu_show_information = "true"
+quick_menu_show_options = "true"
+quick_menu_show_recording = "true"
+quick_menu_show_reset_core_association = "true"
+quick_menu_show_restart_content = "true"
+quick_menu_show_resume_content = "true"
+quick_menu_show_save_content_dir_overrides = "true"
+quick_menu_show_save_core_overrides = "true"
+quick_menu_show_save_game_overrides = "true"
+quick_menu_show_save_load_state = "true"
+quick_menu_show_set_core_association = "true"
+quick_menu_show_shaders = "true"
+quick_menu_show_start_recording = "true"
+quick_menu_show_start_streaming = "true"
+quick_menu_show_streaming = "true"
+quick_menu_show_take_screenshot = "true"
+quick_menu_show_undo_save_load_state = "true"
+quit_on_close_content = "0"
+quit_press_twice = "true"
+record_driver = "ffmpeg"
+recording_config_directory = ":\config\record"
+recording_output_directory = ":\recordings"
+resampler_directory = ""
+rewind_buffer_size = "20971520"
+rewind_buffer_size_step = "10"
+rewind_enable = "false"
+rewind_granularity = "1"
+rgui_aspect_ratio = "0"
+rgui_aspect_ratio_lock = "0"
+rgui_background_filler_thickness_enable = "true"
+rgui_border_filler_enable = "true"
+rgui_border_filler_thickness_enable = "true"
+rgui_browser_directory = "default"
+rgui_config_directory = ":\config"
+rgui_extended_ascii = "false"
+rgui_inline_thumbnails = "false"
+rgui_internal_upscale_level = "0"
+rgui_menu_color_theme = "4"
+rgui_menu_theme_preset = ""
+rgui_particle_effect = "0"
+rgui_particle_effect_screensaver = "true"
+rgui_particle_effect_speed = "1.000000"
+rgui_show_start_screen = "false"
+rgui_swap_thumbnails = "false"
+rgui_switch_icons = "true"
+rgui_thumbnail_delay = "0"
+rgui_thumbnail_downscaler = "0"
+run_ahead_enabled = "false"
+run_ahead_frames = "1"
+run_ahead_hide_warnings = "false"
+run_ahead_secondary_instance = "true"
+runtime_log_directory = "default"
+save_file_compression = "false"
+savefile_directory = ":\saves"
+savefiles_in_content_dir = "false"
+savestate_auto_index = "false"
+savestate_auto_load = "false"
+savestate_auto_save = "false"
+savestate_directory = ":\states"
+savestate_file_compression = "true"
+savestate_max_keep = "0"
+savestate_thumbnail_enable = "false"
+savestates_in_content_dir = "false"
+scan_without_core_match = "false"
+screen_brightness = "100"
+screen_orientation = "0"
+screenshot_directory = ":\screenshots"
+screenshots_in_content_dir = "false"
+settings_show_accessibility = "true"
+settings_show_achievements = "true"
+settings_show_ai_service = "true"
+settings_show_audio = "true"
+settings_show_configuration = "true"
+settings_show_core = "true"
+settings_show_directory = "true"
+settings_show_drivers = "true"
+settings_show_file_browser = "true"
+settings_show_frame_throttle = "true"
+settings_show_input = "true"
+settings_show_latency = "true"
+settings_show_logging = "true"
+settings_show_network = "true"
+settings_show_onscreen_display = "true"
+settings_show_playlists = "true"
+settings_show_power_management = "true"
+settings_show_recording = "true"
+settings_show_saving = "true"
+settings_show_user = "true"
+settings_show_user_interface = "true"
+settings_show_video = "true"
+show_hidden_files = "false"
+slowmotion_ratio = "3.000000"
+soft_filter_enable = "false"
+soft_filter_index = "0"
+sort_savefiles_by_content_enable = "false"
+sort_savefiles_enable = "false"
+sort_savestates_by_content_enable = "false"
+sort_savestates_enable = "false"
+sort_screenshots_by_content_enable = "false"
+state_slot = "0"
+statistics_show = "false"
+stdin_cmd_enable = "false"
+streaming_mode = "0"
+suspend_screensaver_enable = "true"
+sustained_performance_mode = "false"
+system_directory = ":\system"
+systemfiles_in_content_dir = "false"
+threaded_data_runloop_enable = "true"
+thumbnails_directory = ":\thumbnails"
+twitch_stream_key = ""
+ui_companion_enable = "false"
+ui_companion_start_on_boot = "true"
+ui_companion_toggle = "false"
+ui_menubar_enable = "true"
+use_last_start_directory = "false"
+user_language = "0"
+vibrate_on_keypress = "false"
+video_adaptive_vsync = "false"
+video_allow_rotate = "true"
+video_aspect_ratio = "1.333300"
+video_aspect_ratio_auto = "false"
+video_black_frame_insertion = "0"
+video_context_driver = ""
+video_crop_overscan = "true"
+video_ctx_scaling = "false"
+video_disable_composition = "false"
+video_driver = "d3d11"
+video_filter = ""
+video_filter_dir = ":\filters\video"
+video_font_enable = "true"
+video_font_path = ""
+video_font_size = "32.000000"
+video_force_aspect = "true"
+video_force_srgb_disable = "false"
+video_frame_delay = "0"
+video_frame_delay_auto = "false"
+video_fullscreen = "true"
+video_fullscreen_x = "0"
+video_fullscreen_y = "0"
+video_gpu_record = "false"
+video_gpu_screenshot = "true"
+video_hard_sync = "false"
+video_hard_sync_frames = "0"
+video_hdr_display_contrast = "5.000000"
+video_hdr_enable = "false"
+video_hdr_expand_gamut = "true"
+video_hdr_max_nits = "1000.000000"
+video_hdr_paper_white_nits = "200.000000"
+video_layout_directory = ":\layouts"
+video_layout_enable = "true"
+video_layout_path = ""
+video_layout_selected_view = "0"
+video_max_swapchain_images = "3"
+video_message_color = "ffff00"
+video_message_pos_x = "0.050000"
+video_message_pos_y = "0.050000"
+video_monitor_index = "0"
+video_msg_bgcolor_blue = "0"
+video_msg_bgcolor_enable = "false"
+video_msg_bgcolor_green = "0"
+video_msg_bgcolor_opacity = "1.000000"
+video_msg_bgcolor_red = "0"
+video_notch_write_over_enable = "false"
+video_post_filter_record = "false"
+video_record_config = ""
+video_record_quality = "2"
+video_record_scale_factor = "1"
+video_record_threads = "2"
+video_refresh_rate = "60.000000"
+video_rotation = "0"
+video_scale = "3.000000"
+video_scale_integer = "false"
+video_scale_integer_overscale = "false"
+video_shader_delay = "0"
+video_shader_dir = ":\shaders"
+video_shader_enable = "false"
+video_shader_preset_save_reference_enable = "true"
+video_shader_remember_last_dir = "false"
+video_shader_watch_files = "false"
+video_shared_context = "false"
+video_smooth = "false"
+video_stream_config = ""
+video_stream_port = "56400"
+video_stream_quality = "11"
+video_stream_scale_factor = "1"
+video_stream_url = ""
+video_swap_interval = "1"
+video_threaded = "false"
+video_vsync = "true"
+video_window_auto_height_max = "1080"
+video_window_auto_width_max = "1920"
+video_window_custom_size_enable = "false"
+video_window_opacity = "100"
+video_window_save_positions = "false"
+video_window_show_decorations = "true"
+video_windowed_fullscreen = "true"
+video_windowed_position_height = "720"
+video_windowed_position_width = "1280"
+video_windowed_position_x = "0"
+video_windowed_position_y = "0"
+vrr_runloop_enable = "false"
+vulkan_gpu_index = "0"
+wifi_driver = "null"
+wifi_enabled = "true"
+xmb_alpha_factor = "75"
+xmb_font = ""
+xmb_layout = "0"
+xmb_menu_color_theme = "4"
+xmb_shadows_enable = "true"
+xmb_theme = "0"
+xmb_vertical_thumbnails = "false"
+youtube_stream_key = ""


### PR DESCRIPTION
## Description

Removed redundant GPU copy when using a HDR shader that uses the same render target format as the back buffer format in HDR's case R10G10B10A2.  This has been done for all three drivers that support HDR - D3D11, D3D12, Vulkan

## Related Issues

N/A

## Related Pull Requests

N/A

## Reviewers

@twinaphex hope you're well
