### PR TITLE
Wii: Fix find_connection_entry(): needs unsigned int

### DIFF
--- a/input/connect/joypad_connection.c
+++ b/input/connect/joypad_connection.c
@@ -142,7 +142,7 @@ void init_pad_map(void)
    pad_map[12].pid        = PID_HORI_MINI_WIRED_PS4;
 }
 
-joypad_connection_entry_t *find_connection_entry(int16_t vid, int16_t pid, const char *name)
+joypad_connection_entry_t *find_connection_entry(uint16_t vid, uint16_t pid, const char *name)
 {
    unsigned i;
    const bool has_name = !string_is_empty(name);

--- a/input/connect/joypad_connection.h
+++ b/input/connect/joypad_connection.h
@@ -145,7 +145,7 @@ bool pad_connection_rumble(joypad_connection_t *s,
 const char* pad_connection_get_name(joypad_connection_t *joyconn,
    unsigned idx);
 
-joypad_connection_entry_t *find_connection_entry(int16_t vid, int16_t pid, const char *name);
+joypad_connection_entry_t *find_connection_entry(uint16_t vid, uint16_t pid, const char *name);
 int32_t pad_connection_pad_init_entry(joypad_connection_t *joyconn, joypad_connection_entry_t *entry, void *data, hid_driver_t *driver);
 void pad_connection_pad_register(joypad_connection_t *joyconn, pad_connection_interface_t *iface, void *pad_data, void *handle, input_device_driver_t *input_driver, int slot);
 void pad_connection_pad_deregister(joypad_connection_t *joyconn, pad_connection_interface_t *iface, void *pad_data);


### PR DESCRIPTION
Otherwise the USB gamepad cannot be found, if VID/PID has leading zero.
For example: Retrode gamepad adapter:
             vid=1027 (0x403) pid=38849      (0x97c1) becomes
             vid=1027 (0x403) pid=-26687 (0xffff97c1)