### PR TITLE
Prevent 'global' configuration of input libretro device type

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -3422,9 +3422,6 @@ static bool config_load_file(global_t *global,
 
       snprintf(buf, sizeof(buf), "input_player%u_mouse_index", i + 1);
       CONFIG_GET_INT_BASE(conf, settings, uints.input_mouse_index[i], buf);
-
-      snprintf(buf, sizeof(buf), "input_libretro_device_p%u", i + 1);
-      CONFIG_GET_INT_BASE(conf, settings, uints.input_libretro_device[i], buf);
    }
 
    /* LED map for use by the led driver */
@@ -4704,8 +4701,6 @@ bool config_save_file(const char *path)
       config_set_int(conf, cfg, settings->uints.input_device[i]);
       snprintf(cfg, sizeof(cfg), "input_player%u_joypad_index", i + 1);
       config_set_int(conf, cfg, settings->uints.input_joypad_index[i]);
-      snprintf(cfg, sizeof(cfg), "input_libretro_device_p%u", i + 1);
-      config_set_int(conf, cfg, input_config_get_device(i));
       snprintf(cfg, sizeof(cfg), "input_player%u_analog_dpad_mode", i + 1);
       config_set_int(conf, cfg, settings->uints.input_analog_dpad_mode[i]);
       snprintf(cfg, sizeof(cfg), "input_player%u_mouse_index", i + 1);

--- a/configuration.h
+++ b/configuration.h
@@ -156,8 +156,7 @@ typedef struct settings
       unsigned input_joypad_index[MAX_USERS];
       unsigned input_device[MAX_USERS];
       unsigned input_mouse_index[MAX_USERS];
-      /* Set by autoconfiguration in joypad_autoconfig_dir.
-       * Does not override main binds. */
+
       unsigned input_libretro_device[MAX_USERS];
       unsigned input_analog_dpad_mode[MAX_USERS];
 

--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -2718,15 +2718,19 @@ void input_config_set_device(unsigned port, unsigned id)
 {
    settings_t        *settings = config_get_ptr();
 
-   if (settings)
+   if (settings && (port < MAX_USERS))
       configuration_set_uint(settings,
-      settings->uints.input_libretro_device[port], id);
+            settings->uints.input_libretro_device[port], id);
 }
 
 unsigned input_config_get_device(unsigned port)
 {
    settings_t             *settings = config_get_ptr();
-   return settings->uints.input_libretro_device[port];
+
+   if (settings && (port < MAX_USERS))
+      return settings->uints.input_libretro_device[port];
+
+   return RETRO_DEVICE_NONE;
 }
 
 const struct retro_keybind *input_config_get_bind_auto(
@@ -2743,7 +2747,11 @@ const struct retro_keybind *input_config_get_bind_auto(
 unsigned *input_config_get_device_ptr(unsigned port)
 {
    settings_t             *settings = config_get_ptr();
-   return &settings->uints.input_libretro_device[port];
+
+   if (settings && (port < MAX_USERS))
+      return &settings->uints.input_libretro_device[port];
+
+   return NULL;
 }
 
 unsigned input_config_get_device_count(void)
@@ -5142,8 +5150,18 @@ void input_remapping_cache_global_config(void)
 
    for (i = 0; i < MAX_USERS; i++)
    {
+      /* Libretro device type is always set to
+       * RETRO_DEVICE_JOYPAD globally *unless*
+       * an override has been set via the command
+       * line interface */
+      unsigned device = RETRO_DEVICE_JOYPAD;
+
+      if (retroarch_override_setting_is_set(
+            RARCH_OVERRIDE_SETTING_LIBRETRO_DEVICE, &i))
+         device = settings->uints.input_libretro_device[i];
+
       input_st->old_analog_dpad_mode[i] = settings->uints.input_analog_dpad_mode[i];
-      input_st->old_libretro_device[i]  = settings->uints.input_libretro_device[i];
+      input_st->old_libretro_device[i]  = device;
    }
 
    input_st->old_analog_dpad_mode_set = true;
@@ -5187,7 +5205,7 @@ end:
    {
       input_st->old_analog_dpad_mode_set = false;
       input_st->old_libretro_device_set  = false;
-      input_st->remapping_cache_active     = false;
+      input_st->remapping_cache_active   = false;
    }
 }
 

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -8618,7 +8618,6 @@ static bool setting_append_list_input_player_options(
        */
       /* FIXME/TODO - really need to clean up this mess in some way. */
       static char key[MAX_USERS][64];
-      static char key_type[MAX_USERS][64];
       static char key_analog[MAX_USERS][64];
       static char key_bind_all[MAX_USERS][64];
       static char key_bind_all_save_autoconfig[MAX_USERS][64];
@@ -8628,7 +8627,6 @@ static bool setting_append_list_input_player_options(
       static char mouse_index[MAX_USERS][64];
 
       static char label[MAX_USERS][64];
-      static char label_type[MAX_USERS][64];
       static char label_analog[MAX_USERS][64];
       static char label_bind_all[MAX_USERS][64];
       static char label_bind_all_save_autoconfig[MAX_USERS][64];
@@ -8641,9 +8639,6 @@ static bool setting_append_list_input_player_options(
 
       fill_pathname_join_delim(key[user], tmp_string, "joypad_index", '_',
             sizeof(key[user]));
-      snprintf(key_type[user], sizeof(key_type[user]),
-               msg_hash_to_str(MENU_ENUM_LABEL_INPUT_LIBRETRO_DEVICE),
-               user + 1);
       snprintf(key_analog[user], sizeof(key_analog[user]),
                msg_hash_to_str(MENU_ENUM_LABEL_INPUT_PLAYER_ANALOG_DPAD_MODE),
                user + 1);
@@ -8668,9 +8663,6 @@ static bool setting_append_list_input_player_options(
       snprintf(label[user], sizeof(label[user]),
                "%s",
                msg_hash_to_str(MENU_ENUM_LABEL_VALUE_INPUT_DEVICE_INDEX));
-      snprintf(label_type[user], sizeof(label_type[user]),
-               "%s",
-               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_INPUT_DEVICE_TYPE));
       snprintf(label_analog[user], sizeof(label_analog[user]),
                "%s",
                msg_hash_to_str(MENU_ENUM_LABEL_VALUE_INPUT_ADC_TYPE));
@@ -8686,29 +8678,6 @@ static bool setting_append_list_input_player_options(
       snprintf(label_mouse_index[user], sizeof(label_mouse_index[user]),
                "%s",
                msg_hash_to_str(MENU_ENUM_LABEL_VALUE_INPUT_MOUSE_INDEX));
-
-      CONFIG_UINT_ALT(
-            list, list_info,
-            input_config_get_device_ptr(user),
-            key_type[user],
-            label_type[user],
-            user,
-            &group_info,
-            &subgroup_info,
-            parent_group,
-            general_write_handler,
-            general_read_handler);
-      (*list)[list_info->index - 1].index         = user + 1;
-      (*list)[list_info->index - 1].index_offset  = user;
-      (*list)[list_info->index - 1].action_left   = &setting_action_left_libretro_device_type;
-      (*list)[list_info->index - 1].action_right  = &setting_action_right_libretro_device_type;
-      (*list)[list_info->index - 1].action_select = &setting_action_right_libretro_device_type;
-      (*list)[list_info->index - 1].action_start  = &setting_action_start_libretro_device_type;
-      (*list)[list_info->index - 1].action_ok     = &setting_action_ok_libretro_device_type;
-      (*list)[list_info->index - 1].get_string_representation =
-         &setting_get_string_representation_uint_libretro_device;
-      MENU_SETTINGS_LIST_CURRENT_ADD_ENUM_IDX_PTR(list, list_info,
-            (enum msg_hash_enums)(MENU_ENUM_LABEL_INPUT_LIBRETRO_DEVICE + user));
 
       CONFIG_UINT_ALT(
             list, list_info,
@@ -8895,6 +8864,72 @@ static bool setting_append_list_input_player_options(
             &subgroup_info,
             parent_group);
       (*list)[list_info->index - 1].bind_type = i + MENU_SETTINGS_BIND_BEGIN;
+   }
+
+   END_SUB_GROUP(list, list_info, parent_group);
+   END_GROUP(list, list_info, parent_group);
+
+   return true;
+}
+
+static bool setting_append_list_input_libretro_device_options(
+      rarch_setting_t **list,
+      rarch_setting_info_t *list_info,
+      const char *parent_group)
+{
+   settings_t *settings = config_get_ptr();
+   rarch_setting_group_info_t group_info;
+   rarch_setting_group_info_t subgroup_info;
+   static char key_device_type[MAX_USERS][64];
+   static char label_device_type[MAX_USERS][64];
+   unsigned user;
+
+   group_info.name    = NULL;
+   subgroup_info.name = NULL;
+
+   START_GROUP(list, list_info, &group_info,
+         "Libretro Device Type", parent_group);
+
+   parent_group = msg_hash_to_str(MENU_ENUM_LABEL_SETTINGS);
+
+   START_SUB_GROUP(list, list_info, "State", &group_info,
+         &subgroup_info, parent_group);
+
+   for (user = 0; user < MAX_USERS; user++)
+   {
+      key_device_type[user][0]   = '\0';
+      label_device_type[user][0] = '\0';
+
+      snprintf(key_device_type[user], sizeof(key_device_type[user]),
+            msg_hash_to_str(MENU_ENUM_LABEL_INPUT_LIBRETRO_DEVICE),
+            user + 1);
+
+      snprintf(label_device_type[user], sizeof(label_device_type[user]),
+            "%s",
+            msg_hash_to_str(MENU_ENUM_LABEL_VALUE_INPUT_DEVICE_TYPE));
+
+      CONFIG_UINT_ALT(
+            list, list_info,
+            input_config_get_device_ptr(user),
+            key_device_type[user],
+            label_device_type[user],
+            user,
+            &group_info,
+            &subgroup_info,
+            parent_group,
+            general_write_handler,
+            general_read_handler);
+      (*list)[list_info->index - 1].index         = user + 1;
+      (*list)[list_info->index - 1].index_offset  = user;
+      (*list)[list_info->index - 1].action_left   = &setting_action_left_libretro_device_type;
+      (*list)[list_info->index - 1].action_right  = &setting_action_right_libretro_device_type;
+      (*list)[list_info->index - 1].action_select = &setting_action_right_libretro_device_type;
+      (*list)[list_info->index - 1].action_start  = &setting_action_start_libretro_device_type;
+      (*list)[list_info->index - 1].action_ok     = &setting_action_ok_libretro_device_type;
+      (*list)[list_info->index - 1].get_string_representation =
+            &setting_get_string_representation_uint_libretro_device;
+      MENU_SETTINGS_LIST_CURRENT_ADD_ENUM_IDX_PTR(list, list_info,
+            (enum msg_hash_enums)(MENU_ENUM_LABEL_INPUT_LIBRETRO_DEVICE + user));
    }
 
    END_SUB_GROUP(list, list_info, parent_group);
@@ -9837,6 +9872,7 @@ static bool setting_append_list(
          for (user = 0; user < MAX_USERS; user++)
             setting_append_list_input_player_options(list, list_info, parent_group, user);
 
+         setting_append_list_input_libretro_device_options(list, list_info, parent_group);
          setting_append_list_input_remap_port_options(list, list_info, parent_group);
 
          END_SUB_GROUP(list, list_info, parent_group);

--- a/retroarch.c
+++ b/retroarch.c
@@ -3448,7 +3448,7 @@ void retroarch_override_setting_set(
             if (val)
             {
                unsigned                bit = *val;
-	       runloop_state_t *runloop_st = runloop_state_get_ptr();
+               runloop_state_t *runloop_st = runloop_state_get_ptr();
                BIT256_SET(runloop_st->has_set_libretro_device, bit);
             }
          }
@@ -3525,7 +3525,7 @@ void retroarch_override_setting_unset(
             if (val)
             {
                unsigned                bit = *val;
-	       runloop_state_t *runloop_st = runloop_state_get_ptr();
+               runloop_state_t *runloop_st = runloop_state_get_ptr();
                BIT256_CLEAR(runloop_st->has_set_libretro_device, bit);
             }
          }
@@ -3596,7 +3596,7 @@ static void retroarch_override_setting_free_state(void)
          unsigned j;
          for (j = 0; j < MAX_USERS; j++)
             retroarch_override_setting_unset(
-                  (enum rarch_override_setting)(i), &j);
+                  RARCH_OVERRIDE_SETTING_LIBRETRO_DEVICE, &j);
       }
       else
          retroarch_override_setting_unset(
@@ -3832,7 +3832,7 @@ int rarch_main(int argc, char *argv[], void *data)
    audio_state_get_ptr()->active = true;
 
    {
-      uint8_t i;
+      unsigned i;
       for (i = 0; i < MAX_USERS; i++)
          input_config_set_device(i, RETRO_DEVICE_JOYPAD);
    }
@@ -4760,7 +4760,7 @@ static bool retroarch_parse_input_and_config(
                      retroarch_print_help(argv[0]);
                      retroarch_fail(1, "retroarch_parse_input()");
                   }
-                  new_port = port -1;
+                  new_port = port - 1;
 
                   input_config_set_device(new_port, id);
 
@@ -4805,7 +4805,7 @@ static bool retroarch_parse_input_and_config(
                      retroarch_fail(1, "retroarch_parse_input()");
                   }
                   new_port = port - 1;
-                  input_config_set_device(port - 1, RETRO_DEVICE_NONE);
+                  input_config_set_device(new_port, RETRO_DEVICE_NONE);
                   retroarch_override_setting_set(
                         RARCH_OVERRIDE_SETTING_LIBRETRO_DEVICE, &new_port);
                }
@@ -5853,7 +5853,7 @@ bool retroarch_override_setting_is_set(
             if (val)
             {
                unsigned                bit = *val;
-	       runloop_state_t *runloop_st = runloop_state_get_ptr();
+               runloop_state_t *runloop_st = runloop_state_get_ptr();
                return BIT256_GET(runloop_st->has_set_libretro_device, bit);
             }
          }


### PR DESCRIPTION
## Description

At present, RetroArch allows the input 'libretro device type' to be set globally per-user. As pointed out in #13083, this is nonsensical:

- Input device type has no meaning unless a core is actually running, so the option to set it globally does nothing but confuse users
- A global device type may be set that is incompatible with cores, leading to disabled input in-game. e.g. setting the global type to 'RetroPad with Analog' breaks Beetle PSX, since that is not a valid device type recognised by the core

This PR fixes the issue by:

- Removing the global option `Settings > Input > Port N Controls > Device Type` (device type can now only be set while a core is running, via `Quick Menu > Controls > Port N Controls`)
- Ensuring that the 'global' device type is reset to the default `RETRO_DEVICE_JOYPAD` on startup and when closing cores (unless a device type override is set via the existing command line interface)

Note that device type is no longer stored in the main RetroArch config file, only in remap files.

## Related Issues

Closes #13083