### PR TITLE
(XMB+Ozone) Fix input icons

### DIFF
--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -2094,29 +2094,27 @@ static uintptr_t ozone_entries_icon_get_texture(ozone_handle_t *ozone,
          {
             input_id = MENU_SETTINGS_INPUT_BEGIN;
             if (type == input_id)
-               return ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_SETTING];
-            if (type == input_id + 1)
                return ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_ADC];
 #ifdef HAVE_LIBNX
             /* account for the additional split joycon option in Input User # Binds */
             input_id++;
 #endif
-            if (type == input_id + 2)
+            if (type == input_id + 1)
                return ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_SETTINGS];
-            if (type == input_id + 3)
+            if (type == input_id + 2)
                return ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_MOUSE];
-            if (type == input_id + 4)
+            if (type == input_id + 3)
                return ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BIND_ALL];
-            if (type == input_id + 5)
+            if (type == input_id + 4)
                return ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_RELOAD];
-            if (type == input_id + 6)
+            if (type == input_id + 5)
                return ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_SAVING];
-            if ((type > (input_id + 30)) && (type < (input_id + 42)))
+            if ((type > (input_id + 29)) && (type < (input_id + 41)))
                return ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_LGUN];
-            if (type == input_id + 42)
+            if (type == input_id + 41)
                return ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_TURBO];
             /* align to use the same code of Quickmenu controls*/
-            input_id = input_id + 7;
+            input_id = input_id + 6;
          }
          else
          {

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -3051,30 +3051,28 @@ static uintptr_t xmb_icon_get_id(xmb_handle_t *xmb,
          /* Input User # Binds only */
          {
             input_id = MENU_SETTINGS_INPUT_BEGIN;
-            if ( type == input_id)
-               return xmb->textures.list[XMB_TEXTURE_SETTING];
-            if ( type == input_id + 1)
+            if (type == input_id)
                return xmb->textures.list[XMB_TEXTURE_INPUT_ADC];
 #ifdef HAVE_LIBNX
             /* account for the additional split joycon option in Input # Binds */
             input_id++;
 #endif
-            if ( type == input_id + 2)
+            if (type == input_id + 1)
                return xmb->textures.list[XMB_TEXTURE_INPUT_SETTINGS];
-            if ( type == input_id + 3)
+            if (type == input_id + 2)
                return xmb->textures.list[XMB_TEXTURE_INPUT_MOUSE];
-            if ( type == input_id + 4)
+            if (type == input_id + 3)
                return xmb->textures.list[XMB_TEXTURE_INPUT_BIND_ALL];
-            if ( type == input_id + 5)
+            if (type == input_id + 4)
                return xmb->textures.list[XMB_TEXTURE_RELOAD];
-            if ( type == input_id + 6)
+            if (type == input_id + 5)
                return xmb->textures.list[XMB_TEXTURE_SAVING];
-            if ((type > (input_id + 30)) && (type < (input_id + 42)))
+            if ((type > (input_id + 29)) && (type < (input_id + 41)))
                return xmb->textures.list[XMB_TEXTURE_INPUT_LGUN];
-            if ( type == input_id + 42)
+            if (type == input_id + 41)
                return xmb->textures.list[XMB_TEXTURE_INPUT_TURBO];
             /* align to use the same code of Quickmenu controls */
-            input_id = input_id + 7;
+            input_id = input_id + 6;
          }
          else
          {


### PR DESCRIPTION
## Description

The removal of "Device Type" under global input settings caused the icons in XMB and Ozone to be off by that amount. Quick Menu Controls icons were fine though.

## Related Pull Requests

#13749
