### PR TITLE
(Wayland) Skip splash screen if window is not ready

### DIFF
--- a/gfx/drivers_context/wayland_ctx.c
+++ b/gfx/drivers_context/wayland_ctx.c
@@ -616,7 +616,8 @@ static void *gfx_ctx_wl_init(void *video_driver)
    /* Bind SHM based wl_buffer to wl_surface until the vulkan surface is ready.
     * This shows the window which assigns us a display (wl_output)
     *  which is usefull for HiDPI and auto selecting a display for fullscreen. */
-   draw_splash_screen(wl);
+   if (!draw_splash_screen(wl))
+      RARCH_ERR("[Wayland/GL]: Failed to draw splash screen\n");
 
    wl_display_roundtrip(wl->input.dpy);
 

--- a/gfx/drivers_context/wayland_vk_ctx.c
+++ b/gfx/drivers_context/wayland_vk_ctx.c
@@ -519,7 +519,8 @@ static void *gfx_ctx_wl_init(void *video_driver)
    /* Bind SHM based wl_buffer to wl_surface until the vulkan surface is ready.
     * This shows the window which assigns us a display (wl_output)
     *  which is usefull for HiDPI and auto selecting a display for fullscreen. */
-   draw_splash_screen(wl);
+   if (!draw_splash_screen(wl))
+      RARCH_ERR("[Wayland/Vulkan]: Failed to draw splash screen\n");
 
    wl_display_roundtrip(wl->input.dpy);
 

--- a/input/common/wayland_common.c
+++ b/input/common/wayland_common.c
@@ -1027,6 +1027,9 @@ shm_buffer_t *create_shm_buffer(gfx_ctx_wayland_data_t *wl, int width,
    stride = width * 4;
    size = stride * height;
 
+   if (size <= 0)
+      return NULL;
+
    fd = create_shm_file(size);
    if (fd < 0) {
       RARCH_ERR("[Wayland] [SHM]: Creating a buffer file for %d B failed: %s\n",
@@ -1084,7 +1087,7 @@ void shm_buffer_paint_checkerboard(shm_buffer_t *buffer,
 }
 
 
-void draw_splash_screen(gfx_ctx_wayland_data_t *wl)
+bool draw_splash_screen(gfx_ctx_wayland_data_t *wl)
 {
    shm_buffer_t *buffer;
 
@@ -1092,6 +1095,10 @@ void draw_splash_screen(gfx_ctx_wayland_data_t *wl)
       wl->width * wl->buffer_scale,
       wl->height * wl->buffer_scale,
       WL_SHM_FORMAT_XRGB8888);
+
+   if (buffer == NULL)
+     return false;
+
    shm_buffer_paint_checkerboard(buffer, wl->width,
       wl->height, wl->buffer_scale,
       16, 0xffbcbcbc, 0xff8e8e8e);
@@ -1103,5 +1110,6 @@ void draw_splash_screen(gfx_ctx_wayland_data_t *wl)
          wl->width * wl->buffer_scale,
          wl->height * wl->buffer_scale);
    wl_surface_commit(wl->surface);
+   return true;
 }
 

--- a/input/common/wayland_common.h
+++ b/input/common/wayland_common.h
@@ -215,7 +215,7 @@ void shm_buffer_paint_checkerboard(shm_buffer_t *buffer,
       int width, int height, int scale,
       size_t chk, uint32_t bg, uint32_t fg);
 
-void draw_splash_screen(gfx_ctx_wayland_data_t *wl);
+bool draw_splash_screen(gfx_ctx_wayland_data_t *wl);
 
 extern const struct wl_keyboard_listener keyboard_listener;
 


### PR DESCRIPTION
## Description

The Ubuntu PPA version of RetroArch crashes after requesting a buffer for the wayland splash screen of size 0B (zero width and height).

I've been able to reproduce this on fedora 35 on GNOME by compiling with `./configure --disable-libdecor`.

This merge request skips the splash screen when the surface has not been assigned a size yet. This fixes the crash but means fullscreen windows won't necessarily appear on the display selected in the settings.

@twinaphex would it be possible to add [libdecor](https://packages.ubuntu.com/jammy/libdecor-0-0) as a dependency for the PPA? It only seems to exist on the Ubuntu jammy package list so maybe it should be added to the deps directory.

## Related Issues

#13740

## Reviewers

@twinaphex
