### PR TITLE
RETRO_ENVIRONMENT_SHUTDOWN Fixes

### DIFF
--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -9239,7 +9239,7 @@ static int materialui_list_push(void *data, void *userdata,
             }
             else
             {
-               if (system->load_no_content)
+               if (system && system->load_no_content)
                {
                   MENU_DISPLAYLIST_PARSE_SETTINGS_ENUM(
                         info->list,

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -7899,7 +7899,7 @@ static int ozone_list_push(void *data, void *userdata,
             }
             else
             {
-               if (system->load_no_content)
+               if (system && system->load_no_content)
                {
                   MENU_DISPLAYLIST_PARSE_SETTINGS_ENUM(
                         info->list,

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -7107,7 +7107,7 @@ static int xmb_list_push(void *data, void *userdata,
             }
             else
             {
-               if (system->load_no_content)
+               if (system && system->load_no_content)
                {
                   MENU_DISPLAYLIST_PARSE_SETTINGS_ENUM(
                         info->list,

--- a/menu/menu_driver.h
+++ b/menu/menu_driver.h
@@ -501,6 +501,12 @@ struct menu_state
    /* Storage container for current menu datetime
     * representation string */
    char datetime_cache[255];
+   /* Filled with current content path when a core calls
+    * RETRO_ENVIRONMENT_SHUTDOWN. Value is required in
+    * generic_menu_entry_action(), and must be cached
+    * since RETRO_ENVIRONMENT_SHUTDOWN will cause
+    * RARCH_PATH_CONTENT to be cleared */
+   char pending_env_shutdown_content_path[PATH_MAX_LENGTH];
 
 #ifdef HAVE_MENU
    char input_dialog_kb_label_setting[256];
@@ -520,6 +526,9 @@ struct menu_state
    bool entries_nonblocking_refresh;
    /* 'Close Content'-hotkey menu resetting */
    bool pending_close_content;
+   /* Flagged when a core calls RETRO_ENVIRONMENT_SHUTDOWN,
+    * requiring the menu to be flushed on the next iteration */
+   bool pending_env_shutdown_flush;
    /* Screensaver status
     * - Does menu driver support screensaver functionality?
     * - Is screensaver currently active? */

--- a/retroarch.c
+++ b/retroarch.c
@@ -1875,6 +1875,7 @@ bool command_event(enum event_command cmd, void *data)
          break;
       case CMD_EVENT_UNLOAD_CORE:
          {
+            bool load_dummy_core            = data ? *(bool*)data : true;
             bool contentless                = false;
             bool is_inited                  = false;
             content_ctx_info_t content_info = {0};
@@ -1936,7 +1937,7 @@ bool command_event(enum event_command cmd, void *data)
             else
                input_remapping_restore_global_config(true);
 
-            if (is_inited)
+            if (is_inited && load_dummy_core)
             {
 #ifdef HAVE_MENU
                if (  (settings->uints.quit_on_close_content == QUIT_ON_CLOSE_CONTENT_CLI && global->launched_from_cli)


### PR DESCRIPTION
## Description

The `RETRO_ENVIRONMENT_SHUTDOWN` callback is used by cores to request the frontend to perform a shutdown event - either to close the core or quit the frontend entirely. It turns out that RetroArch's particular implementation of this callback is deeply flawed:

- The core issuing the `RETRO_ENVIRONMENT_SHUTDOWN` request is not unloaded correctly, leaving the frontend in a partially undefined state
- When the core is closed, the menu is left open at the last selected location. This means it is trivial to end up on an 'illegal' menu screen - i.e. one that should never be available unless a core is running. At best this means the user has to perform unnecessary backwards navigation to get back to a 'sane' position; at worst, interacting with such an 'illegal' menu can cause undefined behaviour (and potentially crashes)

This PR fixes both issues. Now when `RETRO_ENVIRONMENT_SHUTDOWN` is called:

- The old hackish exit routines are eschewed in favour of a proper `CMD_EVENT_UNLOAD_CORE`
- The menu stack is flushed to an appropriate location, depending upon whether the core was originally launched via a playlist, the standalone cores menu, or other means

In addition, this PR tweaks the menu flushing used by the 'close content' hotkey, so cores launched via the standalone cores menu are handled gracefully.