### PR TITLE
(Wayland) Fix splash screen when using xdg_toplevel

### DIFF
--- a/gfx/drivers_context/wayland_ctx.c
+++ b/gfx/drivers_context/wayland_ctx.c
@@ -90,12 +90,9 @@ static void handle_toplevel_config_common(void *data,
             break;
       }
    }
-   if (     width  > 0
-         && height > 0)
-   {
-      wl->width  = width;
-      wl->height = height;
-   }
+
+   wl->width  = width  > 0 ? width  : DEFAULT_WINDOWED_WIDTH;
+   wl->height = height > 0 ? height : DEFAULT_WINDOWED_HEIGHT;
 
 #ifdef HAVE_EGL
    if (wl->win)

--- a/gfx/drivers_context/wayland_vk_ctx.c
+++ b/gfx/drivers_context/wayland_vk_ctx.c
@@ -83,12 +83,9 @@ static void handle_toplevel_config_common(void *data,
             break;
       }
    }
-   if (     width  > 0
-         && height > 0)
-   {
-      wl->width  = width;
-      wl->height = height;
-   }
+
+   wl->width  = width  > 0 ? width  : DEFAULT_WINDOWED_WIDTH;
+   wl->height = height > 0 ? height : DEFAULT_WINDOWED_HEIGHT;
 
    wl->configured = false;
 }


### PR DESCRIPTION
## Description

When not using libdecor width and height values are not initialized meaning that retroarch tries and fails to create with a width and height of zero.

This merge request initializes width and height, allowing the splash screen to be displayed, allowing the display to be selected in fullscreen.

## Related Issues

#13666

## Related Pull Requests

#13759
