### PR TITLE
Remove 'Advanced Settings' flag from 'Settings > Core' menu

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -9527,7 +9527,6 @@ static bool setting_append_list(
                &group_info,
                &subgroup_info,
                parent_group);
-         SETTINGS_DATA_LIST_CURRENT_ADD_FLAGS(list, list_info, SD_FLAG_ADVANCED);
 
          CONFIG_ACTION(
                list, list_info,
@@ -10040,8 +10039,6 @@ static bool setting_append_list(
                   msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CORE_SETTINGS), parent_group);
             MENU_SETTINGS_LIST_CURRENT_ADD_ENUM_IDX_PTR(list, list_info, MENU_ENUM_LABEL_CORE_SETTINGS);
 
-            SETTINGS_DATA_LIST_CURRENT_ADD_FLAGS(list, list_info, SD_FLAG_ADVANCED);
-
             parent_group = msg_hash_to_str(MENU_ENUM_LABEL_SETTINGS);
 
             START_SUB_GROUP(list, list_info, "State", &group_info, &subgroup_info,
@@ -10100,7 +10097,7 @@ static bool setting_append_list(
             bool_entries[listing].name_enum_idx  = MENU_ENUM_LABEL_CORE_INFO_CACHE_ENABLE;
             bool_entries[listing].SHORT_enum_idx = MENU_ENUM_LABEL_VALUE_CORE_INFO_CACHE_ENABLE;
             bool_entries[listing].default_value  = DEFAULT_CORE_INFO_CACHE_ENABLE;
-            bool_entries[listing].flags          = SD_FLAG_NONE;
+            bool_entries[listing].flags          = SD_FLAG_ADVANCED;
             listing++;
 
 #ifndef HAVE_DYNAMIC


### PR DESCRIPTION
## Description

At present, the `Settings > Core` menu is hidden unless the `Settings > User Interface > Show Advanced Settings` option is enabled. This means it is hidden by default, which provides a poor user experience; without the `Core` menu there is no access to the core manager, which means users cannot easily:

- View core information
- Configure which cores appear on the `Standalone Cores` Menu
- Delete cores
- Back up or restore cores

None of this functionality is 'advanced', and so it should be available to all users by default.

This PR removes the 'advanced' flag from the `Settings > Core` menu, so new users can access the following by default:

![Screenshot_2022-03-21_12-34-56](https://user-images.githubusercontent.com/38211560/159264409-8051ed69-c859-4ecd-b8d5-b9c92a11a220.png)

