### PR TITLE
Wii: Rework Retrode gamepad implementation to support multi_pad interface

### DIFF
--- a/input/drivers_hid/wiiusb_hid.c
+++ b/input/drivers_hid/wiiusb_hid.c
@@ -270,28 +270,6 @@ static int wiiusb_hid_removal_cb(int result, void *usrdata)
    return 0;
 }
 
-static bool isRetrodeGamepad(usb_devdesc devdesc)
-{
-    if (devdesc.idVendor != VID_RETRODE || devdesc.idProduct != PID_RETRODE)
-        return false;
-    if (devdesc.configurations)
-        if (devdesc.configurations->interfaces)
-            if (devdesc.configurations->interfaces->endpoints)
-                return devdesc.configurations->interfaces->bInterfaceSubClass == 0;
-    return false;
-}
-
-static bool isRetrodeMouse(usb_devdesc devdesc)
-{
-    if (devdesc.idVendor != VID_RETRODE || devdesc.idProduct != PID_RETRODE)
-        return false;
-    if (devdesc.configurations)
-        if (devdesc.configurations->interfaces)
-            if (devdesc.configurations->interfaces->endpoints)
-                return devdesc.configurations->interfaces->bInterfaceSubClass == 1;
-    return false;
-}
-
 static int wiiusb_hid_add_adapter(void *data, usb_device_entry *dev)
 {
    usb_devdesc desc;
@@ -299,8 +277,6 @@ static int wiiusb_hid_add_adapter(void *data, usb_device_entry *dev)
    wiiusb_hid_t              *hid = (wiiusb_hid_t*)data;
    struct wiiusb_adapter *adapter = (struct wiiusb_adapter*)
       calloc(1, sizeof(struct wiiusb_adapter));
-   int i;
-   int32_t slot1;
 
    if (!adapter)
       return -1;
@@ -323,12 +299,6 @@ static int wiiusb_hid_add_adapter(void *data, usb_device_entry *dev)
    adapter->device_id = dev->device_id;
 
    USB_GetDescriptors(adapter->handle, &desc);
-
-   if (isRetrodeMouse(desc))
-   {
-       RARCH_LOG("Retrode SNES mouse found (currently not supported)\n");
-       goto error;
-   }
 
    wiiusb_get_description(dev, adapter, &desc);
 
@@ -376,27 +346,8 @@ static int wiiusb_hid_add_adapter(void *data, usb_device_entry *dev)
    RARCH_LOG("Device 0x%p attached (VID/PID: %04x:%04x).\n",
          adapter->device_id, desc.idVendor, desc.idProduct);
 
-   if (isRetrodeGamepad(desc))
-   {
-       /* Retrode port #1 */
-       RARCH_LOG("Interface Retrode1 gamepad slot: %d\n", adapter->slot);
-       wiiusb_hid_device_add_autodetect(adapter->slot, device_name, wiiusb_hid.ident, desc.idVendor, desc.idProduct);
-       /* Retrode port #2, #3, #4 */
-       for (i = 2; i <= 4; i++)
-       {
-           slot1 = pad_connection_pad_init(hid->connections, "hid", desc.idVendor, desc.idProduct, adapter, &wiiusb_hid);
-           if (slot1 == -1)
-               RARCH_LOG("No slot free for Retrode%d gamepad\n", i);
-           else
-           {
-               RARCH_LOG("Interface Retrode%d gamepad slot: %d\n", i, slot1);
-               wiiusb_hid_device_add_autodetect(slot1, device_name, wiiusb_hid.ident, desc.idVendor, desc.idProduct);
-           }
-       }
-   }
-   else
-       wiiusb_hid_device_add_autodetect(adapter->slot,
-             device_name, wiiusb_hid.ident, desc.idVendor, desc.idProduct);
+   wiiusb_hid_device_add_autodetect(adapter->slot,
+         device_name, wiiusb_hid.ident, desc.idVendor, desc.idProduct);
 
    USB_FreeDescriptors(&desc);
    USB_DeviceRemovalNotifyAsync(adapter->handle, wiiusb_hid_removal_cb, adapter);


### PR DESCRIPTION
- Fix: Unplugging and re-plugging now works again
- Wii/vWii: Only gamepad 1 is supported, because multi_pad is currently only relevant in the Wii U implementation
- Wii U: I implemented the multi_pad interface according to `input/connect/connect_wiiugca.c`
- Wii U currently does not work with any USB gamepad, until these issues are fixed: no test possible