### PR TITLE
Fix analog stick not working with 'Unified Menu Controls'

### DIFF
--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -5328,7 +5328,8 @@ void input_driver_collect_system_input(input_driver_state_t *input_st,
 #endif
 #ifdef HAVE_MENU
    bool display_kb                     = menu_input_dialog_get_display_kb();
-   bool menu_input_active              = menu_state_get_ptr()->alive &&
+   bool menu_is_alive                  = menu_state_get_ptr()->alive;
+   bool menu_input_active              = menu_is_alive &&
          !(settings->bools.menu_unified_controls && !display_kb);
 #endif
    input_driver_t *current_input       = input_st->current_driver;
@@ -5358,7 +5359,7 @@ void input_driver_collect_system_input(input_driver_state_t *input_st,
       }
 
 #ifdef HAVE_MENU
-      if (menu_input_active)
+      if (menu_is_alive)
       {
          unsigned k;
          unsigned x_plus  = RARCH_ANALOG_LEFT_X_PLUS;
@@ -5407,7 +5408,7 @@ void input_driver_collect_system_input(input_driver_state_t *input_st,
             &joypad_info);
 
 #ifdef HAVE_MENU
-      if (menu_input_active)
+      if (menu_is_alive)
       {
          unsigned j;
 


### PR DESCRIPTION
## Description

Currently 'Unified Menu Controls' breaks analog stick menu navigation even when it should only apply to keyboard input.
