### PR TITLE
Add Valencian language option

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -474,7 +474,8 @@ ifeq ($(HAVE_LANGEXTRA), 1)
           intl/msg_hash_id.o \
           intl/msg_hash_sv.o \
           intl/msg_hash_uk.o \
-          intl/msg_hash_cs.o 
+          intl/msg_hash_cs.o \
+          intl/msg_hash_val.o 
 endif
 
 ifneq ($(HAVE_GETOPT_LONG), 1)

--- a/griffin/griffin.c
+++ b/griffin/griffin.c
@@ -1270,6 +1270,7 @@ RETROARCH
 #include "../intl/msg_hash_sv.c"
 #include "../intl/msg_hash_uk.c"
 #include "../intl/msg_hash_cs.c"
+#include "../intl/msg_hash_val.c"
 #endif
 
 #include "../intl/msg_hash_us.c"

--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -8165,6 +8165,10 @@ MSG_HASH(
    "Urdu - اُردُو (Restart Required)"
    )
 MSG_HASH(
+   MENU_ENUM_LABEL_VALUE_LANG_VALENCIAN,
+   "Valencian - Valencià"
+   )
+MSG_HASH(
    MENU_ENUM_LABEL_VALUE_LANG_VIETNAMESE,
    "Vietnamese - Tiếng Việt"
    )

--- a/intl/msg_hash_val.c
+++ b/intl/msg_hash_val.c
@@ -1,0 +1,97 @@
+/*  RetroArch - A frontend for libretro.
+ *  Copyright (C) 2011-2017 - Daniel De Matteis
+ *  Copyright (C) 2016-2019 - Brad Parker
+ *
+ *  RetroArch is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  RetroArch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with RetroArch.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+
+#include <compat/strl.h>
+#include <string/stdstring.h>
+
+#include "../msg_hash.h"
+#include "../verbosity.h"
+
+#ifdef RARCH_INTERNAL
+#include "../configuration.h"
+#include "../config.def.h"
+
+int msg_hash_get_help_val_enum(enum msg_hash_enums msg, char *s, size_t len)
+{
+   int ret = 0;
+
+   switch (msg)
+   {
+      case MSG_UNKNOWN:
+      default:
+         ret = -1;
+         break;
+   }
+
+   return ret;
+}
+
+#endif
+
+#ifdef HAVE_MENU
+static const char *menu_hash_to_str_val_label_enum(enum msg_hash_enums msg)
+{
+   if (msg <= MENU_ENUM_LABEL_INPUT_HOTKEY_BIND_END &&
+         msg >= MENU_ENUM_LABEL_INPUT_HOTKEY_BIND_BEGIN)
+   {
+      static char hotkey_lbl[128] = {0};
+      unsigned idx = msg - MENU_ENUM_LABEL_INPUT_HOTKEY_BIND_BEGIN;
+      snprintf(hotkey_lbl, sizeof(hotkey_lbl), "input_hotkey_binds_%d", idx);
+      return hotkey_lbl;
+   }
+
+   switch (msg)
+   {
+#include "msg_hash_lbl.h"
+      default:
+#if 0
+         RARCH_LOG("Unimplemented: [%d]\n", msg);
+#endif
+         break;
+   }
+
+   return "null";
+}
+#endif
+
+const char *msg_hash_to_str_val(enum msg_hash_enums msg)
+{
+#ifdef HAVE_MENU
+    const char *ret = menu_hash_to_str_val_label_enum(msg);
+
+    if (ret && !string_is_equal(ret, "null"))
+       return ret;
+#endif
+
+    switch (msg)
+    {
+#include "msg_hash_val.h"
+        default:
+#if 0
+            RARCH_LOG("Unimplemented: [%d]\n", msg);
+            {
+               RARCH_LOG("[%d] : %s\n", msg - 1, msg_hash_to_str(((enum msg_hash_enums)(msg - 1))));
+            }
+#endif
+            break;
+    }
+
+    return "null";
+}

--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -287,6 +287,7 @@ enum retro_language
    RETRO_LANGUAGE_SWEDISH             = 25,
    RETRO_LANGUAGE_UKRAINIAN           = 26,
    RETRO_LANGUAGE_CZECH               = 27,
+   RETRO_LANGUAGE_VALENCIAN           = 28,
    RETRO_LANGUAGE_LAST,
 
    /* Ensure sizeof(enum) == sizeof(int) */

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -1696,6 +1696,7 @@ static bool rgui_fonts_init(rgui_t *rgui)
       case RETRO_LANGUAGE_FINNISH:
       case RETRO_LANGUAGE_INDONESIAN:
       case RETRO_LANGUAGE_SWEDISH:
+      case RETRO_LANGUAGE_VALENCIAN:
          /* We have at least partial support for
           * these languages, but extended ASCII
           * is required */

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -6743,6 +6743,7 @@ static void setting_get_string_representation_uint_user_language(
    modes[RETRO_LANGUAGE_SWEDISH]                = msg_hash_to_str(MENU_ENUM_LABEL_VALUE_LANG_SWEDISH);
    modes[RETRO_LANGUAGE_UKRAINIAN]              = msg_hash_to_str(MENU_ENUM_LABEL_VALUE_LANG_UKRAINIAN);
    modes[RETRO_LANGUAGE_CZECH]                  = msg_hash_to_str(MENU_ENUM_LABEL_VALUE_LANG_CZECH);
+   modes[RETRO_LANGUAGE_VALENCIAN]              = msg_hash_to_str(MENU_ENUM_LABEL_VALUE_LANG_VALENCIAN);
    strlcpy(s, modes[*msg_hash_get_uint(MSG_HASH_USER_LANGUAGE)], len);
 }
 #endif

--- a/msg_hash.c
+++ b/msg_hash.c
@@ -115,6 +115,9 @@ int msg_hash_get_help_enum(enum msg_hash_enums msg, char *s, size_t len)
       case RETRO_LANGUAGE_CZECH:
          ret = msg_hash_get_help_cs_enum(msg, s, len);
          break;
+      case RETRO_LANGUAGE_VALENCIAN:
+         ret = msg_hash_get_help_val_enum(msg, s, len);
+         break;
       default:
          break;
    }
@@ -192,6 +195,8 @@ const char *get_user_language_iso639_1(bool limit)
          return "uk";
       case RETRO_LANGUAGE_CZECH:
          return "cs";
+      case RETRO_LANGUAGE_VALENCIAN:
+         return "val";
    }
    return "en";
 }
@@ -283,6 +288,9 @@ const char *msg_hash_to_str(enum msg_hash_enums msg)
          break;
       case RETRO_LANGUAGE_CZECH:
          ret = msg_hash_to_str_cs(msg);
+         break;
+      case RETRO_LANGUAGE_VALENCIAN:
+         ret = msg_hash_to_str_val(msg);
          break;
       default:
          break;

--- a/msg_hash.h
+++ b/msg_hash.h
@@ -2863,6 +2863,7 @@ enum msg_hash_enums
    MENU_ENUM_LABEL_VALUE_LANG_THAI,
    MENU_ENUM_LABEL_VALUE_LANG_UKRAINIAN,
    MENU_ENUM_LABEL_VALUE_LANG_URDU,
+   MENU_ENUM_LABEL_VALUE_LANG_VALENCIAN,
    MENU_ENUM_LABEL_VALUE_LANG_WELSH,
    MENU_ENUM_LABEL_VALUE_LANG_YIDDISH,
    MENU_ENUM_LABEL_VALUE_AI_SERVICE_IMAGE_MODE,
@@ -3503,6 +3504,9 @@ int msg_hash_get_help_uk_enum(enum msg_hash_enums msg, char *s, size_t len);
 
 const char *msg_hash_to_str_cs(enum msg_hash_enums msg);
 int msg_hash_get_help_cs_enum(enum msg_hash_enums msg, char *s, size_t len);
+
+const char *msg_hash_to_str_val(enum msg_hash_enums msg);
+int msg_hash_get_help_val_enum(enum msg_hash_enums msg, char *s, size_t len);
 
 int msg_hash_get_help_enum(enum msg_hash_enums msg, char *s, size_t len);
 

--- a/retroarch.c
+++ b/retroarch.c
@@ -6127,6 +6127,7 @@ enum retro_language rarch_get_language_from_iso(const char *iso639)
       {"sv", RETRO_LANGUAGE_SWEDISH},
       {"uk", RETRO_LANGUAGE_UKRAINIAN},
       {"cs", RETRO_LANGUAGE_CZECH},
+      {"val", RETRO_LANGUAGE_VALENCIAN},
    };
 
    if (string_is_empty(iso639))


### PR DESCRIPTION
## Description

Another language has reached the 15% milestone, qualifying it to be added to RetroArch: Valencian!
Since Valencian is encompassed in extended ASCII, it was also enabled in RGUI.

Changes were tested with Ozone and RGUI menu drivers.

PS: there are many white-space changes in `rgui.c` - I don't really know where they come from, but it's just white-space, so, no big deal?

## Reviewers

@IlDucci 
@guoyunhe 
@jdgleaver 