### PR TITLE
Wii U: Fix USB gamepad support

### DIFF
--- a/input/connect/connect_retrode.c
+++ b/input/connect/connect_retrode.c
@@ -50,9 +50,6 @@ struct hidpad_retrode_data
    uint8_t data[64];
 };
 
-const char *RETRODE_PAD         = "Retrode pad";
-const char *RETRODE_DEVICE_NAME = "Retrode adapter";
-
 static void* hidpad_retrode_init(void *data, uint32_t slot, hid_driver_t *driver)
 {
    int i;
@@ -203,12 +200,9 @@ static void hidpad_retrode_set_rumble(void *data,
 
 const char * hidpad_retrode_get_name(void *pad_data)
 {
-   /* this could be improved by marking it as pad/mouse */
-   retrode_pad_data_t *pad = (retrode_pad_data_t *)pad_data;
-   if(!pad || pad->datatype != RETRODE_TYPE_PAD)
-      return RETRODE_DEVICE_NAME;
-
-   return RETRODE_PAD;
+   (void)pad_data;
+   /* For now we return a single static name */
+   return "Retrode";
 }
 
 static int32_t hidpad_retrode_button(void *pad_data, uint16_t joykey)

--- a/input/connect/joypad_connection.c
+++ b/input/connect/joypad_connection.c
@@ -152,18 +152,29 @@ joypad_connection_entry_t *find_connection_entry(uint16_t vid, uint16_t pid, con
 
    for(i = 0; pad_map[i].name != NULL; i++)
    {
-      const char *name_match = has_name 
-         ? strstr(pad_map[i].name, name) 
-         : NULL;
-      /* The Wii Pro Controller and WiiU Pro controller have 
+      char *name_match = NULL;
+      /* The Wii Pro Controller and WiiU Pro controller have
        * the same VID/PID, so we have to use the
        * descriptor string to differentiate them. */
-      if(      pad_map[i].vid == VID_NINTENDO 
-            && pad_map[i].pid == PID_NINTENDO_PRO)
+      if(      pad_map[i].vid == VID_NINTENDO
+            && pad_map[i].pid == PID_NINTENDO_PRO
+            && pad_map[i].vid == vid
+            && pad_map[i].pid == pid)
       {
-         if(!string_is_equal(pad_map[i].name, name))
-            continue;
-      }      
+         name_match = has_name
+            ? strstr(pad_map[i].name, name)
+            : NULL;
+         if (has_name && strlen(name) == 3)
+         {
+            /* Wii U: Argument 'name' is only the prefix of the device name!?
+             * This is not enough for a reliable name match! */
+            RARCH_ERR("find_connection_entry(0x%04x,0x%04x): device name '%s' too short: assuming controller '%s'\n",
+                  SWAP_IF_BIG(vid), SWAP_IF_BIG(pid), name, pad_map[i].name);
+         }
+         else
+            if(!string_is_equal(pad_map[i].name, name))
+               continue;
+      }
 
       if(name_match || (pad_map[i].vid == vid && pad_map[i].pid == pid))
          return &pad_map[i];

--- a/input/drivers_hid/wiiu_hid.c
+++ b/input/drivers_hid/wiiu_hid.c
@@ -14,6 +14,7 @@
  *  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <retro_endianness.h>
 #include "../include/wiiu/hid.h"
 #include <wiiu/os/atomic.h>
 #include <string/stdstring.h>
@@ -83,7 +84,21 @@ static int16_t wiiu_hid_joypad_axis(void *data, unsigned slot, uint32_t joyaxis)
    if (!pad)
       return 0;
 
-   return pad->iface->get_axis(pad->connection, joyaxis);
+   if (AXIS_NEG_GET(joyaxis) < 4)
+   {
+      int16_t val = pad->iface->get_axis(pad->connection, AXIS_NEG_GET(joyaxis));
+
+      if (val < 0)
+         return val;
+   }
+   else if (AXIS_POS_GET(joyaxis) < 4)
+   {
+      int16_t val = pad->iface->get_axis(pad->connection, AXIS_POS_GET(joyaxis));
+
+      if (val > 0)
+         return val;
+   }
+   return 0;
 }
 
 static int16_t wiiu_hid_joypad_state(
@@ -385,8 +400,8 @@ static void log_device(HIDDevice *device)
 
    RARCH_LOG("                handle: %d\n", device->handle);
    RARCH_LOG("  physical_device_inst: %d\n", device->physical_device_inst);
-   RARCH_LOG("                   vid: 0x%x\n", device->vid);
-   RARCH_LOG("                   pid: 0x%x\n", device->pid);
+   RARCH_LOG("                   vid: 0x%04x\n", SWAP_IF_BIG(device->vid));
+   RARCH_LOG("                   pid: 0x%04x\n", SWAP_IF_BIG(device->pid));
    RARCH_LOG("       interface_index: %d\n", device->interface_index);
    RARCH_LOG("             sub_class: %d\n", device->sub_class);
    RARCH_LOG("              protocol: %d\n", device->protocol);
@@ -411,9 +426,11 @@ static uint8_t try_init_driver(wiiu_adapter_t *adapter)
 
    entry = find_connection_entry(adapter->vendor_id, adapter->product_id, adapter->device_name);
    if(!entry) {
-      RARCH_LOG("Failed to find entry for vid: 0x%x, pid: 0x%x, name: %s\n", adapter->vendor_id, adapter->product_id, adapter->device_name);
+      RARCH_LOG("Failed to find entry for vid: 0x%04x, pid: 0x%04x, name: %s\n", SWAP_IF_BIG(adapter->vendor_id), SWAP_IF_BIG(adapter->product_id), adapter->device_name);
       return ADAPTER_STATE_DONE;
    }
+   else
+      RARCH_LOG("Found entry for: vid: 0x%04x, pid: 0x%04x, name: %s\n", SWAP_IF_BIG(adapter->vendor_id), SWAP_IF_BIG(adapter->product_id), adapter->device_name);
 
    adapter->pad_driver = entry->iface;
    
@@ -607,7 +624,10 @@ static void wiiu_hid_read_loop_callback(uint32_t handle, int32_t error,
 
       if (error == 0)
       {
-         adapter->pad_driver->packet_handler(adapter->pad_driver_data, buffer, buffer_size);
+         /* NOTE: packet_handler() expects that packet[1] is the first byte, so added -1.
+          * The Wii version puts the slot number in packet[0], which is not possible here:
+          * packet[0] is undefined! */
+         adapter->pad_driver->packet_handler(adapter->pad_driver_data, buffer-1, buffer_size+1);
       }
    }
 }


### PR DESCRIPTION
Wii U USB gamepad support was broken. See #13309.

As @gblues suspected the VID/PID/name match [algorithm](https://github.com/libretro/RetroArch/issues/13309#issuecomment-985972130) wasn't perfect, but this was only a minor problem.

wiiu_hid.c needed to shift the USB package and fix the axis.

IMHO this closes the issue.
