### PR TITLE
(mmap) Handle disconnect bits on both sides of len

### DIFF
--- a/retroarch_types.h
+++ b/retroarch_types.h
@@ -172,7 +172,7 @@ enum runloop_action
 typedef struct rarch_memory_descriptor
 {
    struct retro_memory_descriptor core;        /* uint64_t alignment */
-   size_t disconnect_mask;
+   // retroarch can have additional context here
 } rarch_memory_descriptor_t;
 
 typedef struct rarch_memory_map


### PR DESCRIPTION
## Description

### Issue: Network access fails for SRAM data of SNES games of large ROM size

Reproduction steps:
1. Enable network commands on the default port (55355)
2. Load `generated-testExHiRom.sfc` from the attached zip file 
[exhirom.zip](https://github.com/libretro/RetroArch/files/8356499/exhirom.zip)
, with bsnes-mercury core (the only SNES core that supports SET_MEMORY_MAPS). I wrote this 'game', source in zip, and it's very simple--it won't display anything but it is 6 MiB unzipped and will enable reading and distinguishing of the relevant memory.
3. Use UDP commands:
`echo -ne "READ_CORE_MEMORY a06000 32" | nc -u 127.0.0.1 55355`
`echo -ne "READ_CORE_MEMORY a16000 32" | nc -u 127.0.0.1 55355`

Expected: Different data, set by the game, is shown in $a0:6000 vs. $a1:6000.
Actual: Second command fails with error "no data for descriptor"

### What the core is requesting

bsnes-mercury sends the following descriptor to RetroArch in SET_MEMORY_MAPS. It is common to all ROMs using ExHiROM memory mapping - the typical mapping for large ROMs >4MB. 
```
flags  offset   start    select   disconn  len      addrspace
M1A1bc 00000000 00A06000 00E0E000 0000E000 00008000
```
This is a correct mapping of SRAM (save game RAM aka static RAM) per https://archive.org/18/items/SNESDevManual/book1.pdf, page 2-21-5, Figure 2-21-4: Super NES Memory MAP (Mode 25, ROM Size Greater than 32 MBits only).

It means:
0x8000 bytes of SRAM (can vary between games - always a power of 2). Note: this length, called `len`, is an internal buffer length in the emulator core and is the true size of unique data storage in the cartridge SRAM.
First 0x2000 bytes at $a0:6000 - $a0:7fff
Next 0x2000 bytes at $a1:6000 - $a1:7ffff
Next 0x2000 bytes at $a2:6000 - $a2:7ffff
Last 0x2000 bytes at $a3:6000 - $a3:7ffff

Followed by 7 mirrors to fill the space (fewer mirrors for larger SRAM size):
First 0x2000 bytes repeated at $a4:6000 - $a4:7fff
...
Last 0x2000 bytes repeated at $a7:6000 - $a7:7fff
First 0x2000 bytes repeated at $a8:6000 - $a8:7fff
...
First 0x2000 bytes repeated at $ac:6000 - $ac:7fff
...
First 0x2000 bytes repeated at $b0:6000 - $b0:7fff
...
First 0x2000 bytes repeated at $b4:6000 - $b4:7fff
...
...
Last 0x2000 bytes repeated at $bf:6000 - $bf:7fff

### Current RA behavior

The core calls into RetroArch with SET_MEMORY_MAPS with the above descriptor.

RetroArch handles this request. Within the handling, in [mmap_preprocess_descriptors()](https://github.com/libretro/RetroArch/blob/v1.10.2/runloop.c#L954):

1) RA creates some mirroring for bits that were not specified as disconnected nor as selected by the core, but are too high to be used to access the given buffer.
```c
 992:      while (mmap_reduce(top_addr & ~desc->core.select, desc->core.disconnect) >> 1 > desc->core.len - 1)
 993:         desc->core.disconnect |= mmap_highest_bit(top_addr & ~desc->core.select & ~desc->core.disconnect);
```

2) RA converts "disconnect" behavior to a simpler "masking out" behavior for high disconnect bits. The affected bits will be: any disconnect bits above the top bit of (buflen-1), as well as any disconnect bits contiguous with a 1 bit (if any) in disconnect at the top bit position of (buflen-1).
```c
 995:      desc->disconnect_mask = mmap_add_bits_down(desc->core.len - 1);
 996:      desc->core.disconnect &= desc->disconnect_mask;
 997:
 998:      while ((~desc->disconnect_mask) >> 1 & desc->core.disconnect)
 999:      {
1000:         desc->disconnect_mask >>= 1;
1001:         desc->core.disconnect &= desc->disconnect_mask;
1002:       }
```

The low-level meaning of this code is explained at a link shared when it was [first committed to RA in 2016](https://github.com/libretro/RetroArch/commit/44ab560dd696b0cea86d3561c11b084570f1ff71) (link in commit message). However, the final link doesn't explain the end intent behind modifying disconnect. Perhaps @Alcaro could comment on this.

### Root cause

There are 2 issues with code step 2. immediately above:
- `len` is a real local buffer length, so disconnect bits higher than `len - 1` perform meaningful translation from a unique SNES address to a unique buffer address. The bits above `len - 1` cannot simply be zeroed out in a requested address.
- `disconnect_mask` is never actually used. Alcaro's guidance, "in any future reference to 'disconnect', use 'disconnect_mask' too", was used but dropped at some point, probably when disconnect translation was accidentally removed (see Related Issues below).

There is a smaller issue with code step 1. above:
- the first mirror above the original data, starting at $b4:6000, is not created because the $04:0000 bit is not OR'ed into disconnect nor AND'ed (as a 0) into disconnect_mask.

### Implementation

Simpler/shorter rewrite with comments, accomplishing the Expected behavior and the intent of Current behavior, solving the issues listed in Root cause. `disconnect_mask` is removed rather than being reintroduced into the code locations that use disconnect, since disconnecting the highest bits is the same as masking them out and the disconnect (aka mmap_reduce) operation is needed anyway when accessing core data via descriptors.

## Related Issues

This is reminiscent of the previous solved issue at #13664. For clients it presents in a very similar way. The differences:
- This current issue is a bug in the preprocessing of descriptors (rather than in searching through descriptors at command-time), and
- 1.9.0 and earlier behavior is only slightly different than current. The issue here is not a regression.

## Related Pull Requests

None

## Reviewers

@Jamiras if you are interested
