### PR TITLE
Fix offset + crash when clearing input port binds

### DIFF
--- a/menu/cbs/menu_cbs_scan.c
+++ b/menu/cbs/menu_cbs_scan.c
@@ -192,7 +192,7 @@ static int action_scan_input_desc(const char *path,
       inp_desc_user      = (unsigned)(player_no_str - 1);
       /* This hardcoded value may cause issues if any entries are added on
          top of the input binds */
-      key                = (unsigned)(idx - 7);
+      key                = (unsigned)(idx - 6);
       /* Select the reorderer bind */
       key                =
             (key < RARCH_ANALOG_BIND_LIST_END) ? input_config_bind_order[key] : key;


### PR DESCRIPTION
## Description

The removal of "Device Type" from input port controls caused another fun issue resulting in either crash when clearing Up, or clearing the wrong bind when clearing items below Up.

## Related Pull Requests

#13749
