### PR TITLE
miyoo: Enable ALSA audio driver and default to it

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -878,8 +878,10 @@ ifeq ($(HAVE_ALSA), 1)
       endif
    endif
 
-   ifeq ($(HAVE_THREADS), 1)
-      OBJ += audio/drivers/alsathread.o
+   ifneq ($(MIYOO), 1)
+      ifeq ($(HAVE_THREADS), 1)
+         OBJ += audio/drivers/alsathread.o
+      endif
    endif
 
    LIBS += $(ALSA_LIBS)

--- a/Makefile.miyoo
+++ b/Makefile.miyoo
@@ -45,8 +45,7 @@ HAVE_SCREENSHOTS = 0
 HAVE_REWIND = 0
 HAVE_7ZIP = 1
 HAVE_AL = 0
-# ALSA freezes when switching back from menu
-HAVE_ALSA = 0
+HAVE_ALSA = 1
 HAVE_DSP_FILTER = 1
 HAVE_VIDEO_FILTER = 1
 HAVE_STATIC_VIDEO_FILTERS = 1
@@ -123,7 +122,7 @@ DEF_FLAGS += -ffunction-sections -fdata-sections
 DEF_FLAGS += -I. -Ideps -Ideps/stb -DMIYOO=1 -DDINGUX -MMD
 DEF_FLAGS += -Wall -Wno-unused-variable -flto
 DEF_FLAGS += -std=gnu99 -D_GNU_SOURCE
-LIBS := -ldl -lz -lrt -pthread
+LIBS := -ldl -lz -lrt -pthread -lasound
 CFLAGS :=
 CXXFLAGS := -fno-exceptions -fno-rtti -std=c++11 -D__STDC_CONSTANT_MACROS
 ASFLAGS :=
@@ -133,7 +132,7 @@ LIBRARY_DIRS = -L$(GCW0_LIB_DIR)
 DEFINES := -DRARCH_INTERNAL -D_FILE_OFFSET_BITS=64 -UHAVE_STATIC_DUMMY
 DEFINES += -DHAVE_C99=1 -DHAVE_CXX=1
 DEFINES += -DHAVE_GETOPT_LONG=1 -DHAVE_STRCASESTR=1 -DHAVE_DYNAMIC=1
-DEFINES += -DHAVE_FILTERS_BUILTIN
+DEFINES += -DHAVE_FILTERS_BUILTIN -DHAVE_ALSA
 
 SDL_DINGUX_CFLAGS := $(shell $(GCW0_SDL_CONFIG) --cflags)
 SDL_DINGUX_LIBS := $(shell $(GCW0_SDL_CONFIG) --libs)

--- a/audio/audio_driver.c
+++ b/audio/audio_driver.c
@@ -83,7 +83,7 @@ audio_driver_t audio_null = {
 audio_driver_t *audio_drivers[] = {
 #ifdef HAVE_ALSA
    &audio_alsa,
-#if !defined(__QNX__) && defined(HAVE_THREADS)
+#if !defined(__QNX__) && !defined(MIYOO) && defined(HAVE_THREADS)
    &audio_alsathread,
 #endif
 #endif

--- a/config.def.h
+++ b/config.def.h
@@ -1051,9 +1051,9 @@ static const bool audio_enable_menu_bgm    = false;
 #endif
 
 /* Output samplerate. */
-#ifdef GEKKO
+#if defined(GEKKO) || defined(MIYOO)
 #define DEFAULT_OUTPUT_RATE 32000
-#elif defined(_3DS) || defined(RETROFW) || defined(MIYOO)
+#elif defined(_3DS) || defined(RETROFW)
 #define DEFAULT_OUTPUT_RATE 32730
 #else
 #define DEFAULT_OUTPUT_RATE 48000

--- a/configuration.c
+++ b/configuration.c
@@ -453,7 +453,7 @@ static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_PS3;
 static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_CTR;
 #elif defined(SWITCH)
 static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_SWITCH;
-#elif defined(DINGUX_BETA) && defined(HAVE_ALSA)
+#elif (defined(DINGUX_BETA) || defined(MIYOO)) && defined(HAVE_ALSA)
 static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_ALSA;
 #elif defined(DINGUX) && defined(HAVE_AL)
 static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_AL;


### PR DESCRIPTION
## Description

Enable ALSA to provide an audio backend for Miyoo that can report its buffer status, allowing auto frame skip to work on cores that support it.

Change the default sample rate to 32000Hz as the previous default of 32730Hz is derived from the 3DS and does not make sense on this platform.

## Related Issues

## Related Pull Requests

## Reviewers

@jdgleaver @salvacam 
