### PR TITLE
bluetoothctl: add / modify pairing steps

### DIFF
--- a/bluetooth/drivers/bluetoothctl.c
+++ b/bluetooth/drivers/bluetoothctl.c
@@ -170,13 +170,18 @@ static bool bluetoothctl_connect_device(void *data, unsigned idx)
    string_list_free(list);
 
    snprintf(btctl->command, sizeof(btctl->command), "\
-         bluetoothctl -- trust %s",
-         device);
+         bluetoothctl -- pairable on");
 
    pclose(popen(btctl->command, "r"));
 
    snprintf(btctl->command, sizeof(btctl->command), "\
          bluetoothctl -- pair %s",
+         device);
+
+   pclose(popen(btctl->command, "r"));
+
+   snprintf(btctl->command, sizeof(btctl->command), "\
+         bluetoothctl -- trust %s",
          device);
 
    pclose(popen(btctl->command, "r"));


### PR DESCRIPTION
due to some changes in bluez / bluetoothctl, `pairable on` is required
in order to create a `[LinkKey]` section in the configuration file for
the connected device. if this section is missing, the device / gamepad
will not pair after being disconnect and has to be repaired again.
