### PR TITLE
Remove clamping swapchain when minImageCount is higher than what the user chooses

### DIFF
--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -3148,9 +3148,6 @@ bool vulkan_create_swapchain(gfx_ctx_vulkan_data_t *vk,
    desired_swapchain_images = settings->uints.video_max_swapchain_images;
 
    /* Clamp images requested to what is supported by the implementation. */
-   if (desired_swapchain_images < surface_properties.minImageCount)
-      desired_swapchain_images = surface_properties.minImageCount;
-
    if ((surface_properties.maxImageCount > 0)
          && (desired_swapchain_images > surface_properties.maxImageCount))
       desired_swapchain_images = surface_properties.maxImageCount;


### PR DESCRIPTION
## Description

This should fix https://github.com/libretro/RetroArch/issues/13812, where the problem is explained in detail.

It is unclear to me if this change will cause any problem with other setups, but I can confirm this fixes the problem on my Manjaro KDE Wayland machine. I measured latency with a 480fps camera and I can confirm removing this has reduced input lag from 77ms previously to 50ms after removing this check.

Is it really necessary to respect `minImageCount`?

The log also confirms RetroArch is now using 2 images after the fix.

EDIT: I confirmed that X is now also using 2 swapchain images, when it was using 3 previously.

## Related Issues

Discussion about this also happened on this issue I opened with MESA, where Michel Dänzer suggests RetroArch does not need to use the 4 provided images (if I'm interpreting him correctly):
https://gitlab.freedesktop.org/mesa/mesa/-/issues/6249