### PR TITLE
(cheevos) disallow manual frame delay setting in hardcore

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -957,9 +957,20 @@ void rcheevos_validate_config_settings(void)
    core_option_manager_t* coreopts  = NULL;
    struct retro_system_info *system = 
       &runloop_state_get_ptr()->system.info;
+   const settings_t* settings = config_get_ptr();
 
    if (!system->library_name || !rcheevos_locals.hardcore_active)
       return;
+
+   if (!settings->bools.video_frame_delay_auto && settings->uints.video_frame_delay != 0) {
+      const char* error = "Hardcore paused. Manual video frame delay setting not allowed.";
+      CHEEVOS_LOG(RCHEEVOS_TAG "%s\n", error);
+      rcheevos_pause_hardcore();
+
+      runloop_msg_queue_push(error, 0, 4 * 60, false, NULL,
+         MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_WARNING);
+      return;
+   }
 
    if (!(disallowed_settings 
             = rc_libretro_get_disallowed_settings(system->library_name)))

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -7823,6 +7823,12 @@ static void general_write_handler(rarch_setting_t *setting)
                   *setting->value.target.fraction);
          }
          break;
+#ifdef HAVE_CHEEVOS
+      case MENU_ENUM_LABEL_VIDEO_FRAME_DELAY:
+      case MENU_ENUM_LABEL_VIDEO_FRAME_DELAY_AUTO:
+         rcheevos_validate_config_settings();
+         break;
+#endif
       case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE_AUTO:
          driver_ctl(RARCH_DRIVER_CTL_SET_REFRESH_RATE, setting->value.target.fraction);
 


### PR DESCRIPTION
## Description

The frame delay option introduces a sleep at the start of each frame so the processing is executed as close to the render as possible. This helps reduce input lag. However, if the value causes the processing to exceed the allowed time for a single frame to render, then the emulator cannot generate frames at the expected rate and the game seems to run in slow motion. 

For example, a 60Hz machine is expected to output one frame approximately every 16ms. If the frame delay setting is put at the maximum (19), then it will sleep for 19ms before even trying to generate the frame. Assuming the frame takes 2ms to generate, that means one frame is output every 21ms, and the game runs at 47Hz, which is nearly 25% slower than the target framerate. This provides a slight advantage to the user and we have decided to block the functionality when earning achievements with hardcore enabled.

As there is some benefit to allowing a bit of frame delay to account for the difference between the time it takes to emulate a frame vs the time it takes to run a frame on the original hardware, we have decided that fully blocking the functionality may not be an appropriate choice, but it was difficult to determine the correct threshold to allow. With the addition of Automatic Frame Delay in 1.9.13, we've decided to simply block the manual setting and allow the automatic one.

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@Sanaki
