### PR TITLE
Bring back number of swapchain images log

### DIFF
--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -3247,10 +3247,9 @@ bool vulkan_create_swapchain(gfx_ctx_vulkan_data_t *vk,
    vkGetSwapchainImagesKHR(vk->context.device, vk->swapchain,
          &vk->context.num_swapchain_images, vk->context.swapchain_images);
 
-#ifdef VULKAN_DEBUG
-   RARCH_LOG("[Vulkan]: Got %u swapchain images.\n",
-         vk->context.num_swapchain_images);
-#endif
+   if (old_swapchain == VK_NULL_HANDLE)
+      RARCH_LOG("[Vulkan]: Got %u swapchain images.\n",
+            vk->context.num_swapchain_images);
 
    /* Force driver to reset swapchain image handles. */
    vk->context.invalid_swapchain      = true;


### PR DESCRIPTION
## Description

This brings back the log message that indicates the number of swapchain images received by the driver.
As the number of swapchain images returned depends on the driver implementation, this log message is valuable information for the end user.

## Reviewers

@sonninnos Is this as you described?
