### PR TITLE
allow audio playback capture on android

### DIFF
--- a/pkg/android/phoenix-legacy/AndroidManifest.xml
+++ b/pkg/android/phoenix-legacy/AndroidManifest.xml
@@ -17,6 +17,7 @@
     <uses-permission android:name="android.permission.VIBRATE" />
 
     <application
+        android:allowAudioPlaybackCapture="true"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="RetroArch"

--- a/pkg/android/phoenix/AndroidManifest.xml
+++ b/pkg/android/phoenix/AndroidManifest.xml
@@ -16,6 +16,7 @@
 
     <application
         android:name="com.retroarch.playcore.RetroArchApplication"
+        android:allowAudioPlaybackCapture="true"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"


### PR DESCRIPTION
## Description

Someone on discord mentioned that when they capture RetroArch with other programs, they lack audio and this is apparently because [this functionality is not enabled by default on programs that target API version <29](https://cdn.discordapp.com/attachments/469974542299955210/963239701446262804/IMG_20220412_034912.jpg).

I just added the line in question to the manifest.

## Related Issues

I don't think this has been put into an issue.

## Related Pull Requests

This should not need any other PRs merged.

## Reviewers

@twinaphex @farmerbb 
