### PR TITLE
Add Catalan language option

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -475,7 +475,8 @@ ifeq ($(HAVE_LANGEXTRA), 1)
           intl/msg_hash_sv.o \
           intl/msg_hash_uk.o \
           intl/msg_hash_cs.o \
-          intl/msg_hash_val.o 
+          intl/msg_hash_val.o \
+          intl/msg_hash_ca.o
 endif
 
 ifneq ($(HAVE_GETOPT_LONG), 1)

--- a/griffin/griffin.c
+++ b/griffin/griffin.c
@@ -1271,6 +1271,7 @@ RETROARCH
 #include "../intl/msg_hash_uk.c"
 #include "../intl/msg_hash_cs.c"
 #include "../intl/msg_hash_val.c"
+#include "../intl/msg_hash_ca.c"
 #endif
 
 #include "../intl/msg_hash_us.c"

--- a/intl/msg_hash_ca.c
+++ b/intl/msg_hash_ca.c
@@ -1,0 +1,97 @@
+/*  RetroArch - A frontend for libretro.
+ *  Copyright (C) 2011-2017 - Daniel De Matteis
+ *  Copyright (C) 2016-2019 - Brad Parker
+ *
+ *  RetroArch is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  RetroArch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with RetroArch.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+
+#include <compat/strl.h>
+#include <string/stdstring.h>
+
+#include "../msg_hash.h"
+#include "../verbosity.h"
+
+#ifdef RARCH_INTERNAL
+#include "../configuration.h"
+#include "../config.def.h"
+
+int msg_hash_get_help_ca_enum(enum msg_hash_enums msg, char *s, size_t len)
+{
+   int ret = 0;
+
+   switch (msg)
+   {
+      case MSG_UNKNOWN:
+      default:
+         ret = -1;
+         break;
+   }
+
+   return ret;
+}
+
+#endif
+
+#ifdef HAVE_MENU
+static const char *menu_hash_to_str_ca_label_enum(enum msg_hash_enums msg)
+{
+   if (msg <= MENU_ENUM_LABEL_INPUT_HOTKEY_BIND_END &&
+         msg >= MENU_ENUM_LABEL_INPUT_HOTKEY_BIND_BEGIN)
+   {
+      static char hotkey_lbl[128] = {0};
+      unsigned idx = msg - MENU_ENUM_LABEL_INPUT_HOTKEY_BIND_BEGIN;
+      snprintf(hotkey_lbl, sizeof(hotkey_lbl), "input_hotkey_binds_%d", idx);
+      return hotkey_lbl;
+   }
+
+   switch (msg)
+   {
+#include "msg_hash_lbl.h"
+      default:
+#if 0
+         RARCH_LOG("Unimplemented: [%d]\n", msg);
+#endif
+         break;
+   }
+
+   return "null";
+}
+#endif
+
+const char *msg_hash_to_str_ca(enum msg_hash_enums msg)
+{
+#ifdef HAVE_MENU
+    const char *ret = menu_hash_to_str_ca_label_enum(msg);
+
+    if (ret && !string_is_equal(ret, "null"))
+       return ret;
+#endif
+
+    switch (msg)
+    {
+#include "msg_hash_ca.h"
+        default:
+#if 0
+            RARCH_LOG("Unimplemented: [%d]\n", msg);
+            {
+               RARCH_LOG("[%d] : %s\n", msg - 1, msg_hash_to_str(((enum msg_hash_enums)(msg - 1))));
+            }
+#endif
+            break;
+    }
+
+    return "null";
+}

--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -288,6 +288,7 @@ enum retro_language
    RETRO_LANGUAGE_UKRAINIAN           = 26,
    RETRO_LANGUAGE_CZECH               = 27,
    RETRO_LANGUAGE_CATALAN_VALENCIA    = 28,
+   RETRO_LANGUAGE_CATALAN             = 29,
    RETRO_LANGUAGE_LAST,
 
    /* Ensure sizeof(enum) == sizeof(int) */

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -1697,6 +1697,7 @@ static bool rgui_fonts_init(rgui_t *rgui)
       case RETRO_LANGUAGE_INDONESIAN:
       case RETRO_LANGUAGE_SWEDISH:
       case RETRO_LANGUAGE_CATALAN_VALENCIA:
+      case RETRO_LANGUAGE_CATALAN:
          /* We have at least partial support for
           * these languages, but extended ASCII
           * is required */

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -6747,6 +6747,7 @@ static void setting_get_string_representation_uint_user_language(
    modes[RETRO_LANGUAGE_UKRAINIAN]              = msg_hash_to_str(MENU_ENUM_LABEL_VALUE_LANG_UKRAINIAN);
    modes[RETRO_LANGUAGE_CZECH]                  = msg_hash_to_str(MENU_ENUM_LABEL_VALUE_LANG_CZECH);
    modes[RETRO_LANGUAGE_CATALAN_VALENCIA]       = msg_hash_to_str(MENU_ENUM_LABEL_VALUE_LANG_CATALAN_VALENCIA);
+   modes[RETRO_LANGUAGE_CATALAN]                = msg_hash_to_str(MENU_ENUM_LABEL_VALUE_LANG_CATALAN);
    strlcpy(s, modes[*msg_hash_get_uint(MSG_HASH_USER_LANGUAGE)], len);
 }
 #endif

--- a/msg_hash.c
+++ b/msg_hash.c
@@ -118,6 +118,9 @@ int msg_hash_get_help_enum(enum msg_hash_enums msg, char *s, size_t len)
       case RETRO_LANGUAGE_CATALAN_VALENCIA:
          ret = msg_hash_get_help_val_enum(msg, s, len);
          break;
+      case RETRO_LANGUAGE_CATALAN:
+         ret = msg_hash_get_help_ca_enum(msg, s, len);
+         break;
       default:
          break;
    }
@@ -197,6 +200,8 @@ const char *get_user_language_iso639_1(bool limit)
          return "cs";
       case RETRO_LANGUAGE_CATALAN_VALENCIA:
          return "val";
+      case RETRO_LANGUAGE_CATALAN:
+         return "ca";
    }
    return "en";
 }
@@ -291,6 +296,9 @@ const char *msg_hash_to_str(enum msg_hash_enums msg)
          break;
       case RETRO_LANGUAGE_CATALAN_VALENCIA:
          ret = msg_hash_to_str_val(msg);
+         break;
+      case RETRO_LANGUAGE_CATALAN:
+         ret = msg_hash_to_str_ca(msg);
          break;
       default:
          break;

--- a/msg_hash.h
+++ b/msg_hash.h
@@ -3523,6 +3523,9 @@ int msg_hash_get_help_cs_enum(enum msg_hash_enums msg, char *s, size_t len);
 const char *msg_hash_to_str_val(enum msg_hash_enums msg);
 int msg_hash_get_help_val_enum(enum msg_hash_enums msg, char *s, size_t len);
 
+const char *msg_hash_to_str_ca(enum msg_hash_enums msg);
+int msg_hash_get_help_ca_enum(enum msg_hash_enums msg, char *s, size_t len);
+
 int msg_hash_get_help_enum(enum msg_hash_enums msg, char *s, size_t len);
 
 enum msg_file_type msg_hash_to_file_type(uint32_t hash);

--- a/retroarch.c
+++ b/retroarch.c
@@ -6126,6 +6126,7 @@ enum retro_language rarch_get_language_from_iso(const char *iso639)
       {"uk", RETRO_LANGUAGE_UKRAINIAN},
       {"cs", RETRO_LANGUAGE_CZECH},
       {"val", RETRO_LANGUAGE_CATALAN_VALENCIA},
+      {"ca", RETRO_LANGUAGE_CATALAN},
    };
 
    if (string_is_empty(iso639))


### PR DESCRIPTION
## Description

Another language has reached the 15% milestone, qualifying it to be added to RetroArch: Catalan!
Since Catalan is encompassed in extended ASCII, it was also enabled in RGUI.

Changes were tested with Ozone and RGUI menu drivers.
