### PR TITLE
XMB: Fixes the D3D9 HLSL renderchain

### DIFF
--- a/gfx/drivers_display/gfx_display_d3d9.c
+++ b/gfx/drivers_display/gfx_display_d3d9.c
@@ -194,9 +194,8 @@ static void gfx_display_d3d9_draw(gfx_display_ctx_draw_t *draw,
          0);
    matrix_4x4_multiply(m1, mop, m2);
    matrix_4x4_multiply(m2, d3d->mvp_transposed, m1);
-   d3d_matrix_transpose(&m1, &m2);
 
-   d3d9_set_mvp(d3d->dev, &m1);
+   d3d9_set_mvp(d3d->dev, &m2);
 
    if (draw && draw->texture)
       gfx_display_d3d9_bind_texture(draw, d3d);


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

https://github.com/libretro/RetroArch/pull/13038 Fixed most of the issues with the D3D9 HLSL renderchain, this PR fixes it all the way, with acclerated menus XMB/OZONE/GLUI working.

![屏幕截图 2022-04-17 000321](https://user-images.githubusercontent.com/22699485/163682596-175cd302-e821-4d80-aa27-5de3d1edab0a.jpg)

Note: https://github.com/libretro/RetroArch/pull/13038 broke the CG renderchain, and this PR will break it even more. (I can't find out a way to fix that unfortunately...)

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
