### PR TITLE
(cheevos) re-enforce hardcore limitations once achievements are loaded

### DIFF
--- a/runloop.c
+++ b/runloop.c
@@ -6261,7 +6261,7 @@ static enum runloop_state_enum runloop_check_state(
    bool widgets_active                 = dispwidget_get_ptr()->active;
 #endif
 #ifdef HAVE_CHEEVOS
-   bool cheevos_hardcore_active        = rcheevos_hardcore_active();
+   bool cheevos_hardcore_active        = false;
 #endif
 
 #if defined(HAVE_TRANSLATE) && defined(HAVE_GFX_WIDGETS)
@@ -6961,6 +6961,10 @@ static enum runloop_state_enum runloop_check_state(
       bool trig_frameadvance        = false;
       bool pause_pressed            = BIT256_GET(current_bits, RARCH_PAUSE_TOGGLE);
 #ifdef HAVE_CHEEVOS
+      /* make sure not to evaluate this before calling menu_driver_iterate
+       * as that may change its value */
+      cheevos_hardcore_active = rcheevos_hardcore_active();
+
       if (cheevos_hardcore_active)
       {
          static int unpaused_frames = 0;


### PR DESCRIPTION
## Description

Addresses an issue where `cheevos_hardcore_active` can change during `runloop_check_state`.

`cheevos_hardcore_active` is evaluated at the top of `runloop_check_state` (line 6264), but may be modified when loading a game through the menu (`menu_driver_iterate`, line 6716), so the checks on lines 6964 and 7189 could be using a stale value. This leads to a situation where a user can activate functionality meant to be blocked in hardcore by holding down the associated button while loading a game.

This PR makes two changes:
1) evaluation of `cheevos_hardcore_enabled` has been moved closer to where it's used (after processing the menu).
2) hardcore disallowed functionality is re-evaluated after the achievements for a game have been loaded.

## Related Issues

Reported via retroarchievements discord

## Related Pull Requests

n/a

## Reviewers

@Sanaki 
