### PR TITLE
Fixes the d3d9cg driver

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -2995,6 +2995,7 @@ static bool check_menu_driver_compatibility(settings_t *settings)
    if (string_starts_with_size(video_driver, "d3d", STRLEN_CONST("d3d")))
       if (
             string_is_equal(video_driver, "d3d9_hlsl") ||
+            string_is_equal(video_driver, "d3d9_cg")   ||
             string_is_equal(video_driver, "d3d10")     ||
             string_is_equal(video_driver, "d3d11")     ||
             string_is_equal(video_driver, "d3d12")

--- a/gfx/drivers/d3d9_renderchain.h
+++ b/gfx/drivers/d3d9_renderchain.h
@@ -74,14 +74,6 @@ struct shader_pass
 #undef VECTOR_LIST_TYPE
 #undef VECTOR_LIST_NAME
 
-struct D3D9Vertex
-{
-   float x, y, z;
-   float u, v;
-   float lut_u, lut_v;
-   float r, g, b, a;
-};
-
 typedef struct d3d9_renderchain
 {
    unsigned pixel_size;

--- a/gfx/drivers/d3d9cg.c
+++ b/gfx/drivers/d3d9cg.c
@@ -72,6 +72,7 @@
 #error "UWP does not support D3D9"
 #endif
 
+#include "d3d_shaders/opaque.cg.d3d9.h"
 #include "d3d9_renderchain.h"
 
 /* TODO/FIXME - Temporary workaround for D3D9 not being able to poll flags during init */
@@ -1326,7 +1327,7 @@ static bool d3d9_cg_init_chain(d3d9_video_t *d3d,
       current_width   = out_width;
       current_height  = out_height;
 
-      if (!d3d_cg_renderchain_add_pass(
+      if (!d3d9_cg_renderchain_add_pass(
                d3d->renderchain_data, &link_info))
       {
          RARCH_ERR("[D3D9]: Failed to add pass.\n");

--- a/gfx/drivers_display/gfx_display_d3d9cg.c
+++ b/gfx/drivers_display/gfx_display_d3d9cg.c
@@ -204,8 +204,9 @@ static void gfx_display_d3d9_cg_draw(gfx_display_ctx_draw_t *draw,
          0);
    matrix_4x4_multiply(m1, mop, m2);
    matrix_4x4_multiply(m2, d3d->mvp_transposed, m1);
-
-   d3d9_set_vertex_shader_constantf(d3d->dev, 0, (const float*)&m2, 4);
+   d3d_matrix_transpose(&m1, &m2);
+  
+   d3d9_set_vertex_shader_constantf(d3d->dev, 0, (const float*)&m1, 4);
 
    if (draw && draw->texture)
       gfx_display_d3d9_cg_bind_texture(draw, d3d);

--- a/gfx/drivers_display/gfx_display_d3d9cg.c
+++ b/gfx/drivers_display/gfx_display_d3d9cg.c
@@ -264,7 +264,7 @@ static void gfx_display_d3d9_cg_draw_pipeline(gfx_display_ctx_draw_t *draw,
    }
 }
 
-static bool gfx_display_d3d9_font_init_first(
+static bool gfx_display_d3d9_cg_font_init_first(
       void **font_handle, void *video_data,
       const char *font_path, float menu_font_size,
       bool is_threaded)
@@ -314,7 +314,7 @@ void gfx_display_d3d9_cg_scissor_end(void *data,
    IDirect3DDevice9_SetScissorRect(d3d9->dev, &rect);
 }
 
-gfx_display_ctx_driver_t gfx_display_ctx_d3d9 = {
+gfx_display_ctx_driver_t gfx_display_ctx_d3d9_cg = {
    gfx_display_d3d9_cg_draw,
    gfx_display_d3d9_cg_draw_pipeline,
    gfx_display_d3d9_cg_blend_begin,
@@ -322,7 +322,7 @@ gfx_display_ctx_driver_t gfx_display_ctx_d3d9 = {
    gfx_display_d3d9_cg_get_default_mvp,
    gfx_display_d3d9_cg_get_default_vertices,
    gfx_display_d3d9_cg_get_default_tex_coords,
-   gfx_display_d3d9_font_init_first,
+   gfx_display_d3d9_cg_font_init_first,
    GFX_VIDEO_DRIVER_DIRECT3D9_CG,
    "d3d9_cg",
    false,

--- a/gfx/drivers_display/gfx_display_d3d9hlsl.c
+++ b/gfx/drivers_display/gfx_display_d3d9hlsl.c
@@ -267,7 +267,7 @@ static void gfx_display_d3d9_hlsl_draw_pipeline(
    }
 }
 
-static bool gfx_display_d3d9_font_init_first(
+static bool gfx_display_d3d9_hlsl_font_init_first(
       void **font_handle, void *video_data,
       const char *font_path, float menu_font_size,
       bool is_threaded)
@@ -325,7 +325,7 @@ gfx_display_ctx_driver_t gfx_display_ctx_d3d9_hlsl = {
    gfx_display_d3d9_hlsl_get_default_mvp,
    gfx_display_d3d9_hlsl_get_default_vertices,
    gfx_display_d3d9_hlsl_get_default_tex_coords,
-   gfx_display_d3d9_font_init_first,
+   gfx_display_d3d9_hlsl_font_init_first,
    GFX_VIDEO_DRIVER_DIRECT3D9_HLSL,
    "d3d9_hlsl",
    false,


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description
Basically reverts what https://github.com/libretro/RetroArch/pull/13038 and https://github.com/libretro/RetroArch/pull/13855 did to CG side.

![屏幕截图(14)](https://user-images.githubusercontent.com/22699485/164499339-9a5400c2-af17-4e89-9220-f76b60b313d8.png)

[Description of the pull request, detail any issues you are fixing or any features you are implementing]

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
