### PR TITLE
Fix gamecrc parsing

### DIFF
--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -7825,7 +7825,7 @@ static void netplay_announce_cb(retro_task_t *task,
             else if (string_is_equal(key, "game_name"))
                strlcpy(host_room->gamename, value, sizeof(host_room->gamename));
             else if (string_is_equal(key, "game_crc"))
-               sscanf(value, "%08d", &host_room->gamecrc);
+               sscanf(value, "%08lX", &host_room->gamecrc);
             else if (string_is_equal(key, "host_method"))
                sscanf(value, "%i", &host_room->host_method);
             else if (string_is_equal(key, "has_password"))


### PR DESCRIPTION
Current gamecrc parsing expects a string of digits, not a hex value. While hex is sent to the server and returned back:
```
   snprintf(buf, sizeof(buf),
      "username=%s&"
      "core_name=%s&"
      "core_version=%s&"
      "game_name=%s&"
      "game_crc=%08lX&"
      "port=%hu&"
...
```

 It will cut a hex value if it starts from digits up to the first non digit value or even return an empty string if hex starts from A-F (ex. "C93B5664"). This patch fixes that.