### PR TITLE
Allow empty str as input result

### DIFF
--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -1017,9 +1017,9 @@ const char **input_keyboard_start_line(
       struct input_keyboard_line *keyboard_line,
       input_keyboard_line_complete_t cb)
 {
-   keyboard_line->buffer    = NULL;
+   keyboard_line->buffer    = calloc(1,1);
    keyboard_line->ptr       = 0;
-   keyboard_line->size      = 0;
+   keyboard_line->size      = 1;
    keyboard_line->cb        = cb;
    keyboard_line->userdata  = userdata;
    keyboard_line->enabled   = true;

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -480,7 +480,7 @@ static void menu_input_st_float_cb(void *userdata, const char *str)
 
 static void menu_input_st_string_cb(void *userdata, const char *str)
 {
-   if (str && *str)
+   if (str)
    {
       rarch_setting_t *setting = NULL;
       const char        *label = menu_input_dialog_get_label_setting_buffer();


### PR DESCRIPTION
I've noticed that I can't delete the password I set for netplay via menu. If user just press Enter in popup dialog with virtual kb - nothing happens. It can be workarounded by launching Qt GUI.  
This patch solves this small problem.
1. Now input result could be a pointer to a buffer with only '\0'.
2. buffer is initialized with '\0' instead of NULL.

Only first one isn't enough as user would need to type something in the editor and then delete everything and press Enter to get empty but non NULL buffer. And it would be enough if editor would be initialized by a current password value instead of empty string.