### PR TITLE
Ensure history list will contain crc32

### DIFF
--- a/ui/drivers/ui_qt.h
+++ b/ui/drivers/ui_qt.h
@@ -398,6 +398,8 @@ public:
    QModelIndex getCurrentContentIndex();
    QHash<QString, QString> getCurrentContentHash();
    QHash<QString, QString> getFileContentHash(const QModelIndex &index);
+   QHash<QString, QString> getFileContentHashWithCRC32(const QModelIndex &index);
+   QString getFileCRC32(const QString &path);
    static double lerp(double x, double y, double a, double b, double d);
    QString getSpecialPlaylistPath(SpecialPlaylist playlist);
    QVector<QPair<QString, QString> > getPlaylists();


### PR DESCRIPTION
A [task_push_to_history_list()](https://github.com/libretro/RetroArch/blob/master/tasks/task_content.c#L1653) expects that if `launched_from_companion_ui` is true then 
```
 /* Database name + checksum are supplied
                   * by the companion UI itself */
```
But this is incorrect at least for Qt UI, as it's not filling a contentHash with "crc32" value in `getFileContentHash()`.  
This patch adds such functionality. As `getFileContentHash` is called not only when the content is loaded but also in `onCurrentFileChanged` (to update displayed pixmaps etc.) I've decided to wrap `getFileContentHash` in `getFileContentHashWithCRC32` and calculate crc32 (which require reading a whole file) only when it leads to a history list update.