### PR TITLE
Fix crc32 comparision

### DIFF
--- a/tasks/task_netplay_find_content.c
+++ b/tasks/task_netplay_find_content.c
@@ -288,7 +288,7 @@ static void task_netplay_crc_scan_handler(retro_task_t *task)
             playlist_path = playlist_entry->path;
             playlist_crc32 = playlist_entry->crc32;
 
-            if (have_crc && string_is_equal(playlist_crc32, state->content_crc))
+            if (have_crc && string_starts_with(state->content_crc, playlist_crc32))
             {
                RARCH_LOG("[Lobby]: CRC match %s\n", playlist_crc32);
                strlcpy(state->content_path, playlist_path, sizeof(state->content_path));


### PR DESCRIPTION
A `if (have_crc && string_is_equal(playlist_crc32, state->content_crc))` is always false because `playlist_crc32` is a 8-digit hex number and `state->content_crc` is a 8-digit hex number with "|crc32" at the end. For ex. that's how `state->content_crc` is checked for null value few lines of code above:
```
have_crc = !string_is_equal(state->content_crc, "00000000|crc");
```

This patch replaces exact match of crc32 with `string_starts_with` where crc32 is prefix. That fixes a search for compatible content for netplay.