### PR TITLE
Analog button mapping fixes

### DIFF
--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -3919,6 +3919,7 @@ int16_t input_state_device(
                         if (input_st->overlay_ptr &&
                             input_st->overlay_ptr->alive &&
                             (port == 0) &&
+                            (idx != RETRO_DEVICE_INDEX_ANALOG_BUTTON) &&
                             !(((input_analog_dpad_mode == ANALOG_DPAD_LSTICK) &&
                                  (idx == RETRO_DEVICE_INDEX_ANALOG_LEFT)) ||
                              ((input_analog_dpad_mode == ANALOG_DPAD_RSTICK) &&
@@ -4939,7 +4940,14 @@ int16_t input_state_internal(unsigned port, unsigned device,
             {
                if (id < RARCH_FIRST_CUSTOM_BIND)
                {
-                  bool valid_bind = (*input_st->libretro_input_binds[mapped_port])[id].valid;
+                  /* TODO/FIXME: Analog buttons can only be read as analog
+                   * when the default mapping is applied. If the user
+                   * remaps any analog buttons, they will become 'digital'
+                   * due to the way that mapping is handled elsewhere. We
+                   * cannot fix this without rewriting the entire mess that
+                   * is the input remapping system... */
+                  bool valid_bind = (*input_st->libretro_input_binds[mapped_port])[id].valid &&
+                        (id == settings->uints.input_remap_ids[mapped_port][id]);
 
                   if (valid_bind)
                   {


### PR DESCRIPTION
## Description

At present, RetroArch suffers from two significant issues involving analog button mapping:

- If an overlay with analog (stick) input is used with any core that reads analog buttons (e.g. left/right triggers in flycast), moving the virtual analog stick will erroneously trigger these analog buttons. (c.f. https://github.com/libretro/flycast/issues/1023)

- If a core reads buttons as analog (e.g. left/right triggers in flycast), those buttons cannot be unbound or remapped correctly. Whatever the corresponding physical gamepad buttons are mapped to, they will still trigger the original analog inputs, (c.f. https://github.com/libretro/RetroArch/issues/12596)

This PR fixes both issues. There is a caveat, however: analog buttons can only be read as analog when the default mapping is applied. If the user remaps an analog button, then it will be read as digital (e.g. if the user swaps the left and right analog triggers, they will both produce digital input). There is no way to fix this without rewriting the whole input remapping system...

## Related Issues

Closes #12596
