### PR TITLE
fix uwp debug build

### DIFF
--- a/gfx/common/d3d12_common.c
+++ b/gfx/common/d3d12_common.c
@@ -164,7 +164,10 @@ HRESULT WINAPI D3D12SerializeVersionedRootSignature(
 bool d3d12_init_base(d3d12_video_t* d3d12)
 {
    DXGIAdapter adapter = NULL;
-#ifdef DEBUG
+#ifdef __WINRT__
+   if (SUCCEEDED(D3D12GetDebugInterface_(&d3d12->debugController)))
+      d3d12->debugController->lpVtbl->EnableDebugLayer(&d3d12->debugController);
+#else
    D3D12GetDebugInterface_(&d3d12->debugController);
    D3D12EnableDebugLayer(d3d12->debugController);
 #endif

--- a/gfx/common/d3d12_common.c
+++ b/gfx/common/d3d12_common.c
@@ -164,6 +164,7 @@ HRESULT WINAPI D3D12SerializeVersionedRootSignature(
 bool d3d12_init_base(d3d12_video_t* d3d12)
 {
    DXGIAdapter adapter = NULL;
+#ifdef DEBUG
 #ifdef __WINRT__
    if (SUCCEEDED(D3D12GetDebugInterface_(&d3d12->debugController)))
       d3d12->debugController->lpVtbl->EnableDebugLayer(&d3d12->debugController);


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

Fixed UWP debug build as it previously did not compile with a missing symbol error

## Related Issues

## Related Pull Requests

## Reviewers

