### PR TITLE
menu - Increase shader scale max value

### DIFF
--- a/menu/cbs/menu_cbs_left.c
+++ b/menu/cbs/menu_cbs_left.c
@@ -306,9 +306,10 @@ static int action_left_shader_scale_pass(unsigned type, const char *label,
    if (!shader_pass)
       return menu_cbs_exit();
 
+   /* A 20x scale is used to support scaling handheld border shaders up to 8K resolutions */
    current_scale            = shader_pass->fbo.scale_x;
-   delta                    = 5;
-   current_scale            = (current_scale + delta) % 6;
+   delta                    = 20;
+   current_scale            = (current_scale + delta) % 21;
 
    shader_pass->fbo.valid   = current_scale;
    shader_pass->fbo.scale_x = current_scale;

--- a/menu/cbs/menu_cbs_right.c
+++ b/menu/cbs/menu_cbs_right.c
@@ -348,9 +348,10 @@ static int action_right_shader_scale_pass(unsigned type, const char *label,
    if (!shader_pass)
       return menu_cbs_exit();
 
+   /* A 20x scale is used to support scaling handheld border shaders up to 8K resolutions */
    current_scale            = shader_pass->fbo.scale_x;
    delta                    = 1;
-   current_scale            = (current_scale + delta) % 6;
+   current_scale            = (current_scale + delta) % 21;
 
    shader_pass->fbo.valid   = current_scale;
    shader_pass->fbo.scale_x = shader_pass->fbo.scale_y = current_scale;


### PR DESCRIPTION
## Description

As the major cleanup of the handheld border shaders on this [PR](https://github.com/libretro/slang-shaders/pull/249) is about to be merged, the user is expected to change a single value to scale the image to the desired size instead of keeping a huge number of presets that would get out of hand to cover 4K and 8K resolutions.
Currently, RetroArch only allows for the scaling of a shader pass to a maximum value of 5x, which is not enough to scale these shaders for high resolutions, such as 4K and 8K.

This increases that max value to 20x.

I am not familiar with the internals of RetroArch, so please check if I'm not breaking anything.

## Related Pull Requests

https://github.com/libretro/slang-shaders/pull/249
