### PR TITLE
(Network) Move natt files to "network"

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -2108,8 +2108,8 @@ ifeq ($(HAVE_NETWORKING), 1)
           $(LIBRETRO_COMM_DIR)/net/net_http.o \
           $(LIBRETRO_COMM_DIR)/net/net_http_parse.o \
           $(LIBRETRO_COMM_DIR)/net/net_socket.o \
-          $(LIBRETRO_COMM_DIR)/net/net_natt.o \
           core_updater_list.o \
+          network/natt.o \
           network/net_http_special.o \
           tasks/task_http.o \
           tasks/task_netplay_lan_scan.o \

--- a/griffin/griffin.c
+++ b/griffin/griffin.c
@@ -1330,12 +1330,12 @@ THREAD
 NETPLAY
 ============================================================ */
 #ifdef HAVE_NETWORKING
+#include "../network/natt.c"
 #include "../network/netplay/netplay_frontend.c"
 #include "../network/netplay/netplay_room_parse.c"
 #include "../libretro-common/net/net_compat.c"
 #include "../libretro-common/net/net_socket.c"
 #include "../libretro-common/net/net_http.c"
-#include "../libretro-common/net/net_natt.c"
 #if !defined(HAVE_SOCKET_LEGACY)
 #include "../libretro-common/net/net_ifinfo.c"
 #endif

--- a/network/natt.c
+++ b/network/natt.c
@@ -1,23 +1,16 @@
-/* Copyright  (C) 2016-2022 The RetroArch team
+/*  RetroArch - A frontend for libretro.
+ *  Copyright (C) 2021-2022 - Roberto V. Rampim
  *
- * ---------------------------------------------------------------------------------------
- * The following license statement only applies to this file (net_natt.c).
- * ---------------------------------------------------------------------------------------
+ *  RetroArch is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
  *
- * Permission is hereby granted, free of charge,
- * to any person obtaining a copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation the rights to
- * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
- * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *  RetroArch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
  *
- * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
- * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
- * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *  You should have received a copy of the GNU General Public License along with RetroArch.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include <stdlib.h>
@@ -33,9 +26,9 @@
 #include <net/net_ifinfo.h>
 #endif
 
-#include "../../tasks/tasks_internal.h"
+#include "../tasks/tasks_internal.h"
 
-#include <net/net_natt.h>
+#include "natt.h"
 
 static bool translate_addr(struct sockaddr_in *addr,
    char *host, size_t hostlen, char *port, size_t portlen)

--- a/network/natt.h
+++ b/network/natt.h
@@ -1,34 +1,26 @@
-/* Copyright  (C) 2010-2022 The RetroArch team
+/*  RetroArch - A frontend for libretro.
+ *  Copyright (C) 2021-2022 - Roberto V. Rampim
  *
- * ---------------------------------------------------------------------------------------
- * The following license statement only applies to this file (net_natt.h).
- * ---------------------------------------------------------------------------------------
+ *  RetroArch is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
  *
- * Permission is hereby granted, free of charge,
- * to any person obtaining a copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation the rights to
- * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
- * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *  RetroArch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
  *
- * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
- * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
- * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *  You should have received a copy of the GNU General Public License along with RetroArch.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _LIBRETRO_SDK_NET_NATT_H
-#define _LIBRETRO_SDK_NET_NATT_H
+#ifndef __RARCH_NATT_H
+#define __RARCH_NATT_H
+
+#include <libretro.h>
+#include <boolean.h>
 
 #include <net/net_compat.h>
 #include <net/net_socket.h>
-
-#include <retro_common_api.h>
-
-RETRO_BEGIN_DECLS
 
 enum natt_forward_type
 {
@@ -182,6 +174,4 @@ bool natt_open_port(struct natt_device *device,
 bool natt_close_port(struct natt_device *device,
    struct natt_request *request, bool block);
 
-RETRO_END_DECLS
-
-#endif
+#endif /* __RARCH_NATT_H */

--- a/network/netplay/netplay.h
+++ b/network/netplay/netplay.h
@@ -31,10 +31,11 @@
 
 #include <net/net_compat.h>
 #include <net/net_ifinfo.h>
-#include <net/net_natt.h>
 #include <retro_miscellaneous.h>
 
 #include "../../core.h"
+
+#include "../natt.h"
 
 #include "netplay_protocol.h"
 

--- a/pkg/apple/RetroArch_iOS11_Metal.xcodeproj/project.pbxproj
+++ b/pkg/apple/RetroArch_iOS11_Metal.xcodeproj/project.pbxproj
@@ -142,7 +142,6 @@
 		92B9EB7A24E0518700E6CFB2 /* net_ifinfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = net_ifinfo.h; sourceTree = "<group>"; };
 		92B9EB7B24E0518700E6CFB2 /* net_compat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = net_compat.h; sourceTree = "<group>"; };
 		92B9EB7C24E0518700E6CFB2 /* net_socket.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = net_socket.h; sourceTree = "<group>"; };
-		92B9EB7D24E0518700E6CFB2 /* net_natt.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = net_natt.h; sourceTree = "<group>"; };
 		92B9EB7E24E0518700E6CFB2 /* net_socket_ssl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = net_socket_ssl.h; sourceTree = "<group>"; };
 		92B9EB7F24E0518700E6CFB2 /* net_http.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = net_http.h; sourceTree = "<group>"; };
 		92B9EB8024E0518700E6CFB2 /* net_http_parse.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = net_http_parse.h; sourceTree = "<group>"; };
@@ -571,7 +570,6 @@
 				92B9EB7A24E0518700E6CFB2 /* net_ifinfo.h */,
 				92B9EB7B24E0518700E6CFB2 /* net_compat.h */,
 				92B9EB7C24E0518700E6CFB2 /* net_socket.h */,
-				92B9EB7D24E0518700E6CFB2 /* net_natt.h */,
 				92B9EB7E24E0518700E6CFB2 /* net_socket_ssl.h */,
 				92B9EB7F24E0518700E6CFB2 /* net_http.h */,
 				92B9EB8024E0518700E6CFB2 /* net_http_parse.h */,

--- a/pkg/apple/RetroArch_iOS13.xcodeproj/project.pbxproj
+++ b/pkg/apple/RetroArch_iOS13.xcodeproj/project.pbxproj
@@ -170,7 +170,6 @@
 		92B9EB7A24E0518700E6CFB2 /* net_ifinfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = net_ifinfo.h; sourceTree = "<group>"; };
 		92B9EB7B24E0518700E6CFB2 /* net_compat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = net_compat.h; sourceTree = "<group>"; };
 		92B9EB7C24E0518700E6CFB2 /* net_socket.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = net_socket.h; sourceTree = "<group>"; };
-		92B9EB7D24E0518700E6CFB2 /* net_natt.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = net_natt.h; sourceTree = "<group>"; };
 		92B9EB7E24E0518700E6CFB2 /* net_socket_ssl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = net_socket_ssl.h; sourceTree = "<group>"; };
 		92B9EB7F24E0518700E6CFB2 /* net_http.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = net_http.h; sourceTree = "<group>"; };
 		92B9EB8024E0518700E6CFB2 /* net_http_parse.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = net_http_parse.h; sourceTree = "<group>"; };
@@ -637,7 +636,6 @@
 				92B9EB7A24E0518700E6CFB2 /* net_ifinfo.h */,
 				92B9EB7B24E0518700E6CFB2 /* net_compat.h */,
 				92B9EB7C24E0518700E6CFB2 /* net_socket.h */,
-				92B9EB7D24E0518700E6CFB2 /* net_natt.h */,
 				92B9EB7E24E0518700E6CFB2 /* net_socket_ssl.h */,
 				92B9EB7F24E0518700E6CFB2 /* net_http.h */,
 				92B9EB8024E0518700E6CFB2 /* net_http_parse.h */,

--- a/tasks/task_netplay_nat_traversal.c
+++ b/tasks/task_netplay_nat_traversal.c
@@ -30,7 +30,7 @@
 #include <net/net_ifinfo.h>
 #endif
 
-#include <net/net_natt.h>
+#include "../network/natt.h"
 #include "../network/netplay/netplay.h"
 
 /* Find the most suitable address within the device's network. */


### PR DESCRIPTION
## Description

We cannot keep natt files at libretro-common due to its reliance on the RetroArch's task system (task_http).
Reworking the code to avoid the http task requires too much work and will prevent us from fetching/sending HTTP data asynchronous through the task system.

Only RetroArch should make use of this code, so move it from libretro-common to network.