### PR TITLE
(Ozone/XMB) Prevent unnecessary thumbnail requests when scrolling through playlists

### DIFF
--- a/gfx/gfx_thumbnail.h
+++ b/gfx/gfx_thumbnail.h
@@ -171,8 +171,7 @@ void gfx_thumbnail_request(
       gfx_thumbnail_path_data_t *path_data, enum gfx_thumbnail_id thumbnail_id,
       playlist_t *playlist, size_t idx, gfx_thumbnail_t *thumbnail,
       unsigned gfx_thumbnail_upscale_threshold,
-      bool network_on_demand_thumbnails
-      );
+      bool network_on_demand_thumbnails);
 
 /* Requests loading of a specific thumbnail image file
  * (may be used, for example, to load savestate images)
@@ -192,6 +191,66 @@ void gfx_thumbnail_reset(gfx_thumbnail_t *thumbnail);
 
 /* Stream processing */
 
+/* Requests loading of the specified thumbnail via
+ * the stream interface
+ * - Must be called on each frame for the duration
+ *   that specified thumbnail is on-screen
+ * - Actual load request is deferred by currently
+ *   set stream delay
+ * - Function becomes a no-op once load request is
+ *   made
+ * - Thumbnails loaded via this function must be
+ *   deleted manually via gfx_thumbnail_reset()
+ *   when they move off-screen
+ * NOTE 1: Must be called *after* gfx_thumbnail_set_system()
+ *         and gfx_thumbnail_set_content*()
+ * NOTE 2: 'playlist' and 'idx' are only required here for
+ *         on-demand thumbnail download support
+ *         (an annoyance...)
+ * NOTE 3: This function is intended for use in situations
+ *         where each menu entry has a *single* thumbnail.
+ *         If each entry has two thumbnails, use
+ *         gfx_thumbnail_request_streams() for improved
+ *         performance */
+void gfx_thumbnail_request_stream(
+      gfx_thumbnail_path_data_t *path_data,
+      gfx_animation_t *p_anim,
+      enum gfx_thumbnail_id thumbnail_id,
+      playlist_t *playlist, size_t idx,
+      gfx_thumbnail_t *thumbnail,
+      unsigned gfx_thumbnail_upscale_threshold,
+      bool network_on_demand_thumbnails);
+
+/* Requests loading of the specified thumbnails via
+ * the stream interface
+ * - Must be called on each frame for the duration
+ *   that specified thumbnails are on-screen
+ * - Actual load request is deferred by currently
+ *   set stream delay
+ * - Function becomes a no-op once load request is
+ *   made
+ * - Thumbnails loaded via this function must be
+ *   deleted manually via gfx_thumbnail_reset()
+ *   when they move off-screen
+ * NOTE 1: Must be called *after* gfx_thumbnail_set_system()
+ *         and gfx_thumbnail_set_content*()
+ * NOTE 2: 'playlist' and 'idx' are only required here for
+ *         on-demand thumbnail download support
+ *         (an annoyance...)
+ * NOTE 3: This function is intended for use in situations
+ *         where each menu entry has *two* thumbnails.
+ *         If each entry only has a single thumbnail, use
+ *         gfx_thumbnail_request_stream() for improved
+ *         performance */
+void gfx_thumbnail_request_streams(
+      gfx_thumbnail_path_data_t *path_data,
+      gfx_animation_t *p_anim,
+      playlist_t *playlist, size_t idx,
+      gfx_thumbnail_t *right_thumbnail,
+      gfx_thumbnail_t *left_thumbnail,
+      unsigned gfx_thumbnail_upscale_threshold,
+      bool network_on_demand_thumbnails);
+
 /* Handles streaming of the specified thumbnail as it moves
  * on/off screen
  * - Must be called each frame for every on-screen entry
@@ -208,13 +267,11 @@ void gfx_thumbnail_process_stream(
       gfx_thumbnail_path_data_t *path_data,
       gfx_animation_t *p_anim,
       enum gfx_thumbnail_id thumbnail_id,
-      playlist_t *playlist,
-      size_t idx,
+      playlist_t *playlist, size_t idx,
       gfx_thumbnail_t *thumbnail,
       bool on_screen,
       unsigned gfx_thumbnail_upscale_threshold,
-      bool network_on_demand_thumbnails
-      );
+      bool network_on_demand_thumbnails);
 
 /* Handles streaming of the specified thumbnails as they move
  * on/off screen
@@ -236,8 +293,7 @@ void gfx_thumbnail_process_streams(
       gfx_thumbnail_t *left_thumbnail,
       bool on_screen,
       unsigned gfx_thumbnail_upscale_threshold,
-      bool network_on_demand_thumbnails
-      );
+      bool network_on_demand_thumbnails);
 
 /* Thumbnail rendering */
 


### PR DESCRIPTION
## Description

Ozone and XMB have a very long standing issue: when scrolling through playlists with thumbnails enabled, thumbnails are requested every time the navigation selection changes. When scrolling through playlists at high speed, this means enormous numbers of requests can be generated every second. These all get pushed onto the task queue, creating large performance overheads (which can slow navigation to a crawl on weak devices) - and on platforms with limited RAM it is easy to exhaust the entire system memory with these requests, causing RetroArch to crash (as reported in  #10556).

This PR addresses the issue by introducing a small delay between changing the navigation selection and requesting thumbnails. Consequently, requests are no longer spammed when scrolling rapidly through playlists, greatly improving navigation performance and avoiding extreme memory usage on weak devices.

## Related Issues

This should resolve  #10556 (but we should wait for confirmation from a Vita user before closing that issue)


