### PR TITLE
(Ozone) UWP Build fix.

### DIFF
--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -8261,8 +8261,6 @@ static void ozone_render(void *data,
    gfx_animation_t          *p_anim   = anim_get_ptr();
    settings_t             *settings   = config_get_ptr();
    bool ozone_collapse_sidebar        = settings->bools.ozone_collapse_sidebar;
-   float ozone_thumbnail_scale_factor =
-      settings->floats.ozone_thumbnail_scale_factor;
    if (!ozone)
       return;
 
@@ -8270,6 +8268,7 @@ static void ozone_render(void *data,
     * factor have changed */
    scale_factor = gfx_display_get_dpi_scale(p_disp, settings,
          width, height, false, false);
+   thumbnail_scale_factor = settings->floats.ozone_thumbnail_scale_factor;
 
    if ((scale_factor != ozone->last_scale_factor) ||
        (thumbnail_scale_factor != ozone->last_thumbnail_scale_factor) ||


### PR DESCRIPTION
## Description

As reported in my issue #13955, commit https://github.com/libretro/RetroArch/commit/d9948c00e170f8537f129c3e599d4e51b4ca2bfe broke UWP builds. This is my attempt to fix that. Although this did indeed fix builds for me and Ozone worked fine from some simple testing, further testing and reviews of the PR are welcomed just to make sure I did not break anything.

## Related Issues

Fixes #13955 

## Reviewers

Anyone familiar with the code is welcomed to take a look!
