### PR TITLE
Fix lan rooms on android

### DIFF
--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -333,13 +333,17 @@ static bool netplay_lan_ad_client_response(void)
 
          /* And that we know how to handle it */
 #ifdef HAVE_INET6
+#ifndef ANDROID
          if (their_addr.ss_family != AF_INET)
             continue;
 #endif
-
-         if (!netplay_is_lan_address(
-               (struct sockaddr_in *) &their_addr))
-            continue;
+#endif
+         if (their_addr.ss_family != AF_INET)
+         {
+            if (!netplay_is_lan_address(
+                  (struct sockaddr_in *) &their_addr))
+               continue;
+         }
 
 #ifndef HAVE_SOCKET_LEGACY
          if (getnameinfo((struct sockaddr *)


### PR DESCRIPTION
This simple change makes lan discovery work on android again
Explanation, the address on android is an IPv4 address that is seen as: ::ffff:192.168.1.241