### PR TITLE
(Network) poll support

### DIFF
--- a/libretro-common/include/net/net_socket.h
+++ b/libretro-common/include/net/net_socket.h
@@ -23,9 +23,9 @@
 #ifndef _LIBRETRO_SDK_NET_SOCKET_H
 #define _LIBRETRO_SDK_NET_SOCKET_H
 
+#include <stddef.h>
 #include <stdint.h>
 #include <boolean.h>
-#include <string.h>
 
 #include <net/net_compat.h>
 
@@ -71,8 +71,14 @@ bool socket_set_block(int fd, bool block);
 /* TODO: all callers should be converted to socket_set_block() */
 bool socket_nonblock(int fd);
 
-int socket_select(int nfds, fd_set *readfs, fd_set *writefds,
+int socket_select(int nfds, fd_set *readfds, fd_set *writefds,
       fd_set *errorfds, struct timeval *timeout);
+
+#ifdef NETWORK_HAVE_POLL
+int socket_poll(struct pollfd *fds, unsigned nfds, int timeout);
+#endif
+
+bool socket_wait(int fd, bool *rd, bool *wr, int timeout);
 
 bool socket_send_all_blocking(int fd, const void *data_, size_t size, bool no_signal);
 


### PR DESCRIPTION
## Description

This PR adds poll support for platforms that support it through two functions.

#### socket_poll

Low level platform specific function. Same parameters and return values as POSIX's poll.
Only available to platforms defining NETWORK_HAVE_POLL.

#### socket_wait

High level function that only works with a single descriptor. If poll is available, socket_wait will use it, otherwise it falls back to select.
Parameters "rd" and "wr" define which state(s) the function will query/wait. On return, these parameters are set to true/false depending on the state's readiness.
Returns true on success.

Example:
```
bool check_read  = true;
bool check_write = false;
int  timeout     = 5000; /* 5 seconds */

if (socket_wait(fd, &check_read, &check_write, timeout))
{
   if (check_read)
      RARCH_LOG("FD ready to read\n");
   else
      RARCH_LOG("FD not ready to read\n");
}
else
   RARCH_ERR("socket_wait failed")
```

### TODO

Replace socket_select calls with socket_wait and socket_poll calls where appropriate.

### Considerations

There were many problems (non C89 compliant, memory leaks, bugs, etc) within platform-specific code in net_compat.c. This PR includes multiple fixes in there that I cannot test myself.

Also, socket_select was completely broken for PS Vita; socket_select is required by several netplay features.
I've refactored it with what I could research (no docs for Vita's epoll, only function/parameter names and struct/member names); again, I cannot test this myself.

~~And finally, while Vita supports epoll, socket_poll is unavailable due to the lack of documentation (thanks Sony). My refactoring of socket_select also only works with a single descriptor. Maybe someone with more experience developing for this platform can try to solve these limitations (I might try solving them myself eventually).~~

### Broken Builds

I've tried to cover only platforms which have obvious poll support, but I can't guarantee that all of them will build just fine (tested on Windows and Linux only).
It's a very simple matter to blacklist a platform from compiling with poll support, so just notify me if a build happens to fail.