### PR TITLE
(3DS) Support latest libctru

### DIFF
--- a/Makefile.ctr
+++ b/Makefile.ctr
@@ -159,6 +159,10 @@ CFLAGS	+=	-mword-relocations \
 #CFLAGS	+= -Wall
 CFLAGS	+=	-DARM11 -D_3DS
 
+ifeq ($(strip $(USE_CTRULIB_2)),1)
+   CFLAGS	+= -D__3DS__
+endif
+
 ifeq ($(DEBUG), 1)
    CFLAGS	+= -O0 -g
 else

--- a/Makefile.ctr.salamander
+++ b/Makefile.ctr.salamander
@@ -90,6 +90,10 @@ CFLAGS	+=	-mword-relocations \
 #CFLAGS	+= -Wall
 CFLAGS	+=	-DARM11 -D_3DS
 
+ifeq ($(strip $(USE_CTRULIB_2)),1)
+   CFLAGS	+= -D__3DS__
+endif
+
 ifeq ($(DEBUG), 1)
    CFLAGS	+= -O0 -g
 else


### PR DESCRIPTION
Latest libctru requires compilation flags to be changed from ```-DARM11 -D_3DS``` to ```__3DS__```.

Since retroarch still support building legacy builds, add this flag when using libctru > v2.0.0

