### PR TITLE
Shader Load Extra Parameter Reference Files

### DIFF
--- a/libretro-common/file/config_file.c
+++ b/libretro-common/file/config_file.c
@@ -408,6 +408,20 @@ static void config_file_add_sub_conf(config_file_t *conf, char *path,
          conf->path);
 }
 
+void config_file_add_reference(config_file_t *conf, char *path)
+{
+   /* It is expected that the conf has it's path already set */
+   char short_path[PATH_MAX_LENGTH];
+   
+   short_path[0] = '\0';
+   
+   if (!conf->references)
+      conf->references = path_linked_list_new();
+
+   fill_pathname_abbreviated_or_relative(short_path, conf->path, path, sizeof(short_path));
+   path_linked_list_add_path(conf->references, short_path);
+}
+
 static int config_file_load_internal(
       struct config_file *conf,
       const char *path, unsigned depth, config_file_cb_t *cb)
@@ -581,7 +595,7 @@ static bool config_file_parse_line(config_file_t *conf,
          if (!path)
             return false;
 
-         config_file_set_reference_path(conf, path);
+         config_file_add_reference(conf, path);
 
          if (!path)
             return false;
@@ -702,32 +716,13 @@ static int config_file_from_string_internal(
    return 0;
 }
 
-void config_file_set_reference_path(config_file_t *conf, char *path)
-{
-   /* It is expected that the conf has it's path already set */
-   
-   char short_path[PATH_MAX_LENGTH];
-   
-   short_path[0] = '\0';
-
-   if (!conf)
-      return;
-
-   if (conf->reference)
-   {
-      free(conf->reference);
-      conf->reference = NULL;
-   }
-
-   fill_pathname_abbreviated_or_relative(short_path, conf->path, path, sizeof(short_path));
-   
-   conf->reference = strdup(short_path);
-}
 
 bool config_file_deinitialize(config_file_t *conf)
 {
    struct config_include_list *inc_tmp = NULL;
    struct config_entry_list *tmp       = NULL;
+   struct path_linked_list *ref_tmp = NULL;
+
    if (!conf)
       return false;
 
@@ -762,8 +757,7 @@ bool config_file_deinitialize(config_file_t *conf)
          free(hold);
    }
 
-   if (conf->reference)
-      free(conf->reference);
+   path_linked_list_free(conf->references);
 
    if (conf->path)
       free(conf->path);
@@ -905,7 +899,7 @@ void config_file_initialize(struct config_file *conf)
    conf->entries                  = NULL;
    conf->tail                     = NULL;
    conf->last                     = NULL;
-   conf->reference                = NULL;
+   conf->references               = NULL;
    conf->includes                 = NULL;
    conf->include_depth            = 0;
    conf->guaranteed_no_duplicates = false;
@@ -1363,11 +1357,13 @@ void config_file_dump(config_file_t *conf, FILE *file, bool sort)
 {
    struct config_entry_list       *list = NULL;
    struct config_include_list *includes = conf->includes;
+   struct path_linked_list *ref_tmp = conf->references;
 
-   if (conf->reference)
+   while (ref_tmp)
    {
-      pathname_make_slashes_portable(conf->reference);
-      fprintf(file, "#reference \"%s\"\n", conf->reference);
+      pathname_make_slashes_portable(ref_tmp->path);
+      fprintf(file, "#reference \"%s\"\n", ref_tmp->path);
+      ref_tmp = ref_tmp->next;
    }
 
    if (sort)

--- a/libretro-common/file/file_path.c
+++ b/libretro-common/file/file_path.c
@@ -71,6 +71,76 @@
 #endif
 
 /**
+ * Create a new linked list with one node in it
+ * The path on this node will be set to NULL
+**/
+struct path_linked_list* path_linked_list_new()
+{
+   struct path_linked_list* paths_list = (struct path_linked_list*)malloc(sizeof(*paths_list));
+   paths_list->next = NULL;
+   paths_list->path = NULL;
+   return paths_list;
+}
+
+/* Free the entire linked list */
+bool path_linked_list_free(struct path_linked_list *in_path_linked_list)
+{
+   struct path_linked_list *node_tmp = NULL;
+
+   node_tmp = (struct path_linked_list*)in_path_linked_list;
+   while (node_tmp)
+   {
+      struct path_linked_list *hold = NULL;
+      if (node_tmp->path)
+         free(node_tmp->path);
+      hold    = (struct path_linked_list*)node_tmp;
+      node_tmp = node_tmp->next;
+      if (hold)
+         free(hold);
+   }
+
+   return true;
+}
+
+/**
+ * Add a node to the linked list with this path
+ * If the first node's path if it's not yet set the path
+ * on this node instead
+**/
+void path_linked_list_add_path(struct path_linked_list *in_path_linked_list, char *path)
+{
+    /* If the first item does not have a path this is
+      a list which has just been created, so we just fill 
+      the path for the first item
+   */
+   if (!in_path_linked_list->path)
+   {
+      in_path_linked_list->path = strdup(path);
+   }
+   else
+   {  
+      struct path_linked_list *head = in_path_linked_list;
+      struct path_linked_list *node = (struct path_linked_list*) malloc(sizeof(*node));
+
+      if (node)
+      {
+         node->next        = NULL;
+         node->path        = strdup(path);
+
+         if (head)
+         {
+            while (head->next)
+               head        = head->next;
+
+            head->next     = node;
+         }
+         else
+            in_path_linked_list = node;
+      }
+   }
+}
+
+/**
  * path_get_archive_delim:
  * @path               : path
  *

--- a/libretro-common/include/file/config_file.h
+++ b/libretro-common/include/file/config_file.h
@@ -54,12 +54,12 @@ RETRO_BEGIN_DECLS
 struct config_file
 {
    char *path;
-   char *reference;
    struct config_entry_list **entries_map;
    struct config_entry_list *entries;
    struct config_entry_list *tail;
    struct config_entry_list *last;
    struct config_include_list *includes;
+   struct path_linked_list *references;
    unsigned include_depth;
    bool guaranteed_no_duplicates;
    bool modified;
@@ -109,7 +109,7 @@ config_file_t *config_file_new_from_path_to_string(const char *path);
 /* Frees config file. */
 void config_file_free(config_file_t *conf);
 
-void config_file_set_reference_path(config_file_t *conf, char *path);
+void config_file_add_reference(config_file_t *conf, char *path);
 
 bool config_file_deinitialize(config_file_t *conf);
 

--- a/libretro-common/include/file/file_path.h
+++ b/libretro-common/include/file/file_path.h
@@ -51,6 +51,28 @@ enum
    RARCH_FILE_UNSUPPORTED
 };
 
+struct path_linked_list
+{
+   char *path;
+   struct path_linked_list *next;
+};
+
+/**
+ * Create a new linked list with one item in it
+ * The path on this item will be set to NULL
+**/
+struct path_linked_list* path_linked_list_new();
+
+/* Free the entire linked list */
+bool path_linked_list_free(struct path_linked_list *in_path_linked_list);
+
+/**
+ * Add a node to the linked list with this path
+ * If the first node's path if it's not yet set, 
+ * set this instead
+**/
+void path_linked_list_add_path(struct path_linked_list *in_path_linked_list, char *path);
+
 /**
  * path_is_compressed_file:
  * @path               : path


### PR DESCRIPTION
When a shader preset is loaded now when there are more than one #reference line the parameter values will be loaded from the references after the first one

## Description

This PR adds the ability to put additional #reference lines inside shader presets which will load additional settings. The first reference in the preset still needs to point at a chain of presets which ends with a shader chain, and subsequent #reference lines will load presets which only have parameter values adjustment. This allows presets to be made with a modular selection of settings. For example with the Mega Bezel one additional reference could point at a preset which contained settings for Night mode vs Day mode, and another reference could point to a preset which contained settings for how much the screen should be zoomed in.

The additional #reference lines will only load presets which only have parameter overrides, no shader chains.

If you do point to a preset which has a shader chain then the preset will not load and a warning will be printed in the log

## Related Issues

https://github.com/libretro/RetroArch/issues/13984 - Regression after first PR

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/13959 - Original PR
https://github.com/libretro/RetroArch/pull/13985 - Reverted PR

## Reviewers

@LibretroAdmin 
@GABO1423

Notes about the new PR: For this PR the Config file has been changed back to the original code for saving the includes, hopefully this fixes the UWP failure. I can run a UWP build on my windows machine and save the config successfully.
