### PR TITLE
(D3D11/12) Reduce lag with WaitForVBlank

### DIFF
--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -2374,6 +2374,14 @@ static bool d3d11_gfx_frame(
 #endif
 
    DXGIPresent(d3d11->swapChain, d3d11->swap_interval, present_flags);
+
+   if (vsync)
+   {
+      IDXGIOutput *pOutput;
+      DXGIGetContainingOutput(d3d11->swapChain, &pOutput);
+      DXGIWaitForVBlank(pOutput);
+   }
+
    Release(rtv);
 
    return true;

--- a/gfx/drivers/d3d12.c
+++ b/gfx/drivers/d3d12.c
@@ -2660,6 +2660,13 @@ static bool d3d12_gfx_frame(
 #endif
    DXGIPresent(d3d12->chain.handle, sync_interval, present_flags);
 
+   if (vsync)
+   {
+      IDXGIOutput *pOutput;
+      DXGIGetContainingOutput(d3d12->chain.handle, &pOutput);
+      DXGIWaitForVBlank(pOutput);
+   }
+
    return true;
 }
 


### PR DESCRIPTION
## Description

This rather simple addition seems to make d3d11/12 very very close to vulkan/glcore regarding input lag.

Please test with high and variable refresh rate displays to see if it needs more conditions, and hopefully not a separate option.

Before:
https://user-images.githubusercontent.com/45124675/173602816-b0d1f457-6e41-4b24-9a88-3a3167d6c7e1.mp4

After:
https://user-images.githubusercontent.com/45124675/173602856-179c4229-e085-44be-8e0c-ec26687bf9f7.mp4


