### PR TITLE
Block pointer input when overlay is pressed

### DIFF
--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -2052,10 +2052,14 @@ void input_poll_overlay(
          break;
    }
 
-   if (input_overlay_show_inputs != OVERLAY_SHOW_INPUT_NONE)
-      button_pressed = input_overlay_add_inputs(ol,
-            (input_overlay_show_inputs == OVERLAY_SHOW_INPUT_TOUCHED),
-            input_overlay_show_inputs_port);
+   button_pressed = input_overlay_add_inputs(ol,
+         (input_overlay_show_inputs == OVERLAY_SHOW_INPUT_TOUCHED),
+         input_overlay_show_inputs_port);
+
+   input_st->block_pointer_input = button_pressed;
+
+   if (input_overlay_show_inputs == OVERLAY_SHOW_INPUT_NONE)
+      button_pressed = false;
 
    if (button_pressed || polled)
       input_overlay_post_poll(overlay_visibility, ol,
@@ -3976,6 +3980,9 @@ int16_t input_state_device(
       case RETRO_DEVICE_MOUSE:
       case RETRO_DEVICE_LIGHTGUN:
       case RETRO_DEVICE_POINTER:
+
+         if (input_st->block_pointer_input)
+            break;
 
          if (id < RARCH_FIRST_META_KEY)
          {

--- a/input/input_driver.h
+++ b/input/input_driver.h
@@ -436,6 +436,7 @@ typedef struct
 
    bool block_hotkey;
    bool block_libretro_input;
+   bool block_pointer_input;
    bool grab_mouse_state;
    bool analog_requested[MAX_USERS];
    bool keyboard_mapping_blocked;


### PR DESCRIPTION
## Description

Currently overlay and pointer events are allowed at the same time, creating confusion if overlay elements overlap with pointer elements. We rather want only one input, and in overlapping cases overlay should take the priority.

For example this leads to such nasty cases as getting stuck in the virtual keyboard in VICE/PUAE if the keyboard toggle button is on top of the keyboard, which means pressing it again won't close the keyboard like it should, but presses the underlying key instead.

## Related Issues

Closes #9043
