### PR TITLE
Fix lightgun scaling on Y axis

### DIFF
--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -450,9 +450,9 @@ static int16_t udev_mouse_get_pointer_y(const udev_input_mouse_t *mouse, bool sc
          src_min = vp.y;
          src_height = vp.height;
       }
+      y = -32767.0 + 65535.0 / src_height * (mouse->y_abs - src_min);
    }
 
-   y = -32767.0 + 65535.0 / src_height * (mouse->y_abs - src_min);
    y += (y < 0 ? -0.5 : 0.5);
 
    if (y < -0x7fff)


### PR DESCRIPTION
## Description

Pull request #13258 has a minor error that makes the Y axis of lightgun devices track inaccurately when a letterbox image is displayed on the user's monitor. This change puts that line of code in the correct spot. With this change, the structure of the code for the Y axis matches that of the already-working X axis. The result is that the Y axis tracks correctly regardless of aspect ratio.

## Related Pull Requests

#13258
