### PR TITLE
Reformat database titles

### DIFF
--- a/menu/cbs/menu_cbs_title.c
+++ b/menu/cbs/menu_cbs_title.c
@@ -801,9 +801,12 @@ static int action_get_title_generic(char *s, size_t len,
          string_list_deinitialize(&list_path);
 
          if (!string_is_empty(elem0_path))
-            snprintf(s, len, "%s- %s",
+         {
+            path_remove_extension(elem0_path);
+            snprintf(s, len, "%s: %s",
                   text,
                   path_basename(elem0_path));
+         }
          else
             strlcpy(s, text, len);
          return 0;


### PR DESCRIPTION
## Description

Visible header title under database manager looks a bit neater if:
- Separator is `: ` instead of `- `
- Extension is removed

Before:
![retroarch_2022_06_17_20_02_49_475](https://user-images.githubusercontent.com/45124675/174345324-48c665dd-fa6c-456d-bdac-dfd6a45177b5.png)

After:
![retroarch_2022_06_17_20_02_21_212](https://user-images.githubusercontent.com/45124675/174345332-ea4687d0-d94b-439f-acc9-ed4d3d62e016.png)


