### PR TITLE
Try to reduce fixed size char arrays from PATH_MAX_LENGTH to lower sizes

### DIFF
--- a/audio/audio_driver.c
+++ b/audio/audio_driver.c
@@ -918,7 +918,7 @@ bool audio_driver_dsp_filter_init(const char *device)
    struct string_list *plugs            = NULL;
 #if defined(HAVE_DYLIB) && !defined(HAVE_FILTERS_BUILTIN)
    char ext_name[32];
-   char basedir[255];
+   char basedir[256];
 
    basedir[0] = ext_name[0]             = '\0';
 
@@ -1350,7 +1350,7 @@ static void audio_driver_load_menu_bgm_callback(retro_task_t *task,
 
 void audio_driver_load_system_sounds(void)
 {
-   char basename_noext[255];
+   char basename_noext[256];
    char sounds_path[PATH_MAX_LENGTH];
    char sounds_fallback_path[PATH_MAX_LENGTH];
    settings_t *settings                  = config_get_ptr();

--- a/audio/audio_driver.c
+++ b/audio/audio_driver.c
@@ -917,8 +917,8 @@ bool audio_driver_dsp_filter_init(const char *device)
    retro_dsp_filter_t *audio_driver_dsp = NULL;
    struct string_list *plugs            = NULL;
 #if defined(HAVE_DYLIB) && !defined(HAVE_FILTERS_BUILTIN)
-   char basedir[PATH_MAX_LENGTH];
-   char ext_name[PATH_MAX_LENGTH];
+   char ext_name[32];
+   char basedir[255];
 
    basedir[0] = ext_name[0]             = '\0';
 
@@ -1350,9 +1350,9 @@ static void audio_driver_load_menu_bgm_callback(retro_task_t *task,
 
 void audio_driver_load_system_sounds(void)
 {
+   char basename_noext[255];
    char sounds_path[PATH_MAX_LENGTH];
    char sounds_fallback_path[PATH_MAX_LENGTH];
-   char basename_noext[PATH_MAX_LENGTH];
    settings_t *settings                  = config_get_ptr();
    const char *dir_assets                = settings->paths.directory_assets;
    const bool audio_enable_menu          = settings->bools.audio_enable_menu;

--- a/input/input_driver.h
+++ b/input/input_driver.h
@@ -151,7 +151,7 @@ typedef struct
    char name[256];
    char display_name[256];
    char config_path[PATH_MAX_LENGTH]; /* Path to the RetroArch config file */
-   char config_name[255]; /* Base name of the RetroArch config file */
+   char config_name[256]; /* Base name of the RetroArch config file */
    bool autoconfigured;
 } input_device_info_t;
 

--- a/input/input_driver.h
+++ b/input/input_driver.h
@@ -151,7 +151,7 @@ typedef struct
    char name[256];
    char display_name[256];
    char config_path[PATH_MAX_LENGTH]; /* Path to the RetroArch config file */
-   char config_name[PATH_MAX_LENGTH]; /* Base name of the RetroArch config file */
+   char config_name[255]; /* Base name of the RetroArch config file */
    bool autoconfigured;
 } input_device_info_t;
 

--- a/libretro-common/net/net_http.c
+++ b/libretro-common/net/net_http.c
@@ -383,7 +383,7 @@ void net_http_urlencode_full(char *dest,
 {
    size_t buf_pos                    = 0;
    char *tmp                         = NULL;
-   char url_domain[255]              = {0};
+   char url_domain[256]              = {0};
    char url_path[PATH_MAX_LENGTH]    = {0};
    int count                         = 0;
 

--- a/libretro-common/net/net_http.c
+++ b/libretro-common/net/net_http.c
@@ -383,7 +383,7 @@ void net_http_urlencode_full(char *dest,
 {
    size_t buf_pos                    = 0;
    char *tmp                         = NULL;
-   char url_domain[PATH_MAX_LENGTH]  = {0};
+   char url_domain[255]              = {0};
    char url_path[PATH_MAX_LENGTH]    = {0};
    int count                         = 0;
 

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -2153,7 +2153,7 @@ static int menu_displaylist_parse_playlist(menu_displaylist_info_t *info,
    }
    else if (!string_is_empty(info->path))
    {
-      char lpl_basename[PATH_MAX_LENGTH];
+      char lpl_basename[255];
       lpl_basename[0] = '\0';
 
       fill_pathname_base_noext(lpl_basename, info->path, sizeof(lpl_basename));

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -2153,7 +2153,7 @@ static int menu_displaylist_parse_playlist(menu_displaylist_info_t *info,
    }
    else if (!string_is_empty(info->path))
    {
-      char lpl_basename[255];
+      char lpl_basename[256];
       lpl_basename[0] = '\0';
 
       fill_pathname_base_noext(lpl_basename, info->path, sizeof(lpl_basename));
@@ -3282,8 +3282,8 @@ static int menu_displaylist_parse_horizontal_list(
 
    if (!string_is_empty(item->path))
    {
+      char lpl_basename[256];
       char path_playlist[PATH_MAX_LENGTH];
-      char lpl_basename[PATH_MAX_LENGTH];
       const char *dir_playlist  = settings->paths.directory_playlist;
 
       lpl_basename[0]           = '\0';


### PR DESCRIPTION
Hi there @Cthulhu-throwaway ,

I saw you reducing the size of fixed size char arrays in some of the netplay code, which inspired me to try to go for some low-hanging fruit too. I'd appreciate a review by you as well and maybe your own suggestions of where we can further trim the fat so that we use less local stack size per function.

Some of the decisions I made here:
* Extensions cannot be longer than 32 characters
* When dealing with basenames, either assume 255 or 500+ max characters instead of PATH_MAX_LENGTH.
* When dealing with domain names, assume they can be 256 characters max, so no need for PATH_MAX_LENGTH.
* command_set_shader - there was some nasty code here where we were setting a pointer to a local variable only to later pass it to a function. For this reason the local variable was made static. This has been rewritten and the TODO/FIXME note removed.
* command_event_save_core_config - inefficient code during the name generation. It was formatting two strings during each iteration which would always have the same value per iteration only to then be concatenated to later on. Reduced this to just an sprintf instead and the actual calls to fill_pathname_join and whatnot are done outside the loop.