### PR TITLE
Remove unused variables

### DIFF
--- a/deps/glslang/glslang/SPIRV/GlslangToSpv.cpp
+++ b/deps/glslang/glslang/SPIRV/GlslangToSpv.cpp
@@ -5364,8 +5364,10 @@ spv::Id TGlslangToSpvTraverser::createAtomicOperation(glslang::TOperator op, spv
 // Create group invocation operations.
 spv::Id TGlslangToSpvTraverser::createInvocationsOperation(glslang::TOperator op, spv::Id typeId, std::vector<spv::Id>& operands, glslang::TBasicType typeProxy)
 {
+#ifdef AMD_EXTENSIONS
     bool isUnsigned = isTypeUnsignedInt(typeProxy);
-    bool isFloat = isTypeFloat(typeProxy);
+    bool isFloat    = isTypeFloat(typeProxy);
+#endif
 
     spv::Op opCode = spv::OpNop;
     std::vector<spv::Id> spvGroupOperands;

--- a/libretro-common/file/config_file.c
+++ b/libretro-common/file/config_file.c
@@ -721,7 +721,6 @@ bool config_file_deinitialize(config_file_t *conf)
 {
    struct config_include_list *inc_tmp = NULL;
    struct config_entry_list *tmp       = NULL;
-   struct path_linked_list *ref_tmp = NULL;
 
    if (!conf)
       return false;

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -7073,7 +7073,6 @@ static int xmb_list_push(void *data, void *userdata,
    bool menu_show_restart_ra       = settings->bools.menu_show_restart_retroarch;
 #endif
    bool menu_show_information      = settings->bools.menu_show_information;
-   bool menu_show_help             = settings->bools.menu_show_help;
    bool kiosk_mode_enable          = settings->bools.kiosk_mode_enable;
 #ifdef HAVE_QT
    bool desktop_menu_enable        = settings->bools.desktop_menu_enable;

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -8269,7 +8269,9 @@ unsigned menu_displaylist_build_list(
       case DISPLAYLIST_USER_INTERFACE_SETTINGS_LIST:
          {
             bool kiosk_mode_enable                                  = settings->bools.kiosk_mode_enable;
+#if defined(HAVE_QT) || defined(HAVE_COCOA)
             bool desktop_menu_enable                                = settings->bools.desktop_menu_enable;
+#endif
             bool menu_screensaver_supported                         = menu_driver_screensaver_supported();
 #if defined(HAVE_MATERIALUI) || defined(HAVE_XMB) || defined(HAVE_OZONE)
             enum menu_screensaver_effect menu_screensaver_animation =


### PR DESCRIPTION
Removes some unused variable warnings that popped up on Clang/macOS.