### PR TITLE
(D3D11/12) Make low-latency optional

### DIFF
--- a/gfx/common/d3d11_common.h
+++ b/gfx/common/d3d11_common.h
@@ -197,6 +197,7 @@ typedef struct
    float                 clearcolor[4];
    unsigned              swap_interval;
    bool                  vsync;
+   bool                  wait_for_vblank;
    bool                  resize_chain;
    bool                  keep_aspect;
    bool                  resize_viewport;

--- a/gfx/common/d3d12_common.h
+++ b/gfx/common/d3d12_common.h
@@ -183,6 +183,7 @@ typedef struct
       float                       clearcolor[4];
       int                         frame_index;
       bool                        vsync;
+      bool                        wait_for_vblank;
       unsigned                    swap_interval;
 #ifdef HAVE_DXGI_HDR
       enum dxgi_swapchain_bit_depth bit_depth;

--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -1070,6 +1070,14 @@ static bool d3d11_init_swapchain(d3d11_video_t* d3d11,
       UINT max_latency     = settings->uints.video_max_frame_latency;
       UINT cur_latency     = 0;
 
+      if (max_latency == 0)
+      {
+         d3d11->wait_for_vblank = true;
+         max_latency            = 1;
+      }
+      else
+         d3d11->wait_for_vblank = false;
+
       DXGISetMaximumFrameLatency(d3d11->swapChain, max_latency);
       DXGIGetMaximumFrameLatency(d3d11->swapChain, &cur_latency);
       RARCH_LOG("[D3D11]: Requesting %u maximum frame latency, using %u.\n", max_latency, cur_latency);
@@ -1816,6 +1824,7 @@ static bool d3d11_gfx_frame(
    d3d11_video_t* d3d11           = (d3d11_video_t*)data;
    D3D11DeviceContext context     = d3d11->context;
    bool vsync                     = d3d11->vsync;
+   bool wait_for_vblank           = d3d11->wait_for_vblank;
    unsigned present_flags         = (vsync || !d3d11->has_allow_tearing) ? 0 : DXGI_PRESENT_ALLOW_TEARING;
    const char *stat_text          = video_info->stat_text;
    unsigned video_width           = video_info->width;
@@ -2375,7 +2384,7 @@ static bool d3d11_gfx_frame(
 
    DXGIPresent(d3d11->swapChain, d3d11->swap_interval, present_flags);
 
-   if (vsync)
+   if (vsync && wait_for_vblank)
    {
       IDXGIOutput *pOutput;
       DXGIGetContainingOutput(d3d11->swapChain, &pOutput);

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -12545,7 +12545,7 @@ static bool setting_append_list(
                   general_write_handler,
                   general_read_handler);
             (*list)[list_info->index - 1].action_ok = &setting_action_ok_uint;
-            (*list)[list_info->index - 1].offset_by = 1;
+            (*list)[list_info->index - 1].offset_by = 0;
             menu_settings_list_current_add_range(list, list_info, (*list)[list_info->index - 1].offset_by, 3, 1, true, true);
             SETTINGS_DATA_LIST_CURRENT_ADD_FLAGS(list, list_info, SD_FLAG_CMD_APPLY_AUTO);
             MENU_SETTINGS_LIST_CURRENT_ADD_CMD(list, list_info, CMD_EVENT_REINIT);


### PR DESCRIPTION
## Description

Turned out this latest trick is too taxing to have always, so for now it requires manually changing the latency value to 0, which is 1 + wait for vblank.

## Related Issues

#14069
