### PR TITLE
Savestate thumbnails

### DIFF
--- a/menu/cbs/menu_cbs_start.c
+++ b/menu/cbs/menu_cbs_start.c
@@ -454,6 +454,20 @@ static int action_start_playlist_left_thumbnail_mode(
    return 0;
 }
 
+static int action_start_state_slot(
+      const char *path, const char *label,
+      unsigned type, size_t idx, size_t entry_idx)
+{
+   settings_t *settings      = config_get_ptr();
+
+   settings->ints.state_slot = 0;
+
+   menu_driver_ctl(RARCH_MENU_CTL_UPDATE_SAVESTATE_THUMBNAIL_PATH, NULL);
+   menu_driver_ctl(RARCH_MENU_CTL_UPDATE_SAVESTATE_THUMBNAIL_IMAGE, NULL);
+
+   return 0;
+}
+
 static int action_start_playlist_sort_mode(
       const char *path, const char *label,
       unsigned type, size_t idx, size_t entry_idx)
@@ -798,6 +812,9 @@ static int menu_cbs_init_bind_start_compare_label(menu_file_list_cbs_t *cbs)
             BIND_ACTION_START(cbs, action_start_bluetooth);
             break;
 #endif
+         case MENU_ENUM_LABEL_STATE_SLOT:
+            BIND_ACTION_START(cbs, action_start_state_slot);
+            break;
          default:
             return -1;
       }
@@ -866,6 +883,10 @@ static int menu_cbs_init_bind_start_compare_type(menu_file_list_cbs_t *cbs,
             break;
          case MENU_SETTING_ACTION_CORE_SET_STANDALONE_EXEMPT:
             BIND_ACTION_START(cbs, action_start_core_set_standalone_exempt);
+            break;
+         case MENU_SETTING_ACTION_SAVESTATE:
+         case MENU_SETTING_ACTION_LOADSTATE:
+            BIND_ACTION_START(cbs, action_start_state_slot);
             break;
          default:
             return -1;

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -3348,12 +3348,14 @@ static void ozone_update_savestate_thumbnail_path(void *data, unsigned i)
             strlcat(path, FILE_PATH_PNG_EXTENSION, sizeof(path));
 
             if (path_is_valid(path))
+            {
                strlcpy(
                      ozone->savestate_thumbnail_file_path, path,
                      sizeof(ozone->savestate_thumbnail_file_path));
 
-            ozone->thumbnails.show_savestate = true;
-            ozone->selection_core_is_viewer  = true;
+               ozone->thumbnails.show_savestate = true;
+               ozone->selection_core_is_viewer  = true;
+            }
          }
 
          /* Reset other images, otherwise they will flash
@@ -4131,7 +4133,8 @@ static void ozone_refresh_sidebars(
    }
 
    /* Set thumbnail bar position */
-   if (is_playlist && !ozone->cursor_in_sidebar && ozone->depth == 1)
+   if ((is_playlist && !ozone->cursor_in_sidebar && ozone->depth == 1) ||
+         (ozone->is_quick_menu && ozone->thumbnails.show_savestate && ozone->depth >= 2))
    {
       ozone->animations.thumbnail_bar_position = ozone->dimensions.thumbnail_bar_width;
       ozone->show_thumbnail_bar                = true;
@@ -5427,7 +5430,7 @@ static void ozone_draw_thumbnail_bar(
          thumbnail_x_position = x_position - (ozone->dimensions.sidebar_entry_icon_padding * 2);
       }
       else
-         show_right_thumbnail = false;
+         return;
    }
 
    /* If this entry is associated with the image viewer


### PR DESCRIPTION
## Description

Yet more polish to savestate thumbnails:
- Start resets slot to 0 in save/load too
- Ozone shows thumbnail bar only when image is available
- Ozone refreshes thumbnail bar on fullscreen toggle

## Related Issues

Closes #14085

