### PR TITLE
(Netplay) Ensure current content is reloaded before joining a host

### DIFF
--- a/network/discord.c
+++ b/network/discord.c
@@ -181,11 +181,6 @@ static void handle_discord_join_cb(retro_task_t *task, void *task_data,
    room = netplay_room_get(0);
    if (room)
    {
-      if (netplay_driver_ctl(RARCH_NETPLAY_CTL_IS_DATA_INITED, NULL))
-         deinit_netplay();
-
-      netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE_CLIENT, NULL);
-
       if (room->host_method == NETPLAY_HOST_METHOD_MITM)
          snprintf(hostname, sizeof(hostname), "%s|%d|%s",
             room->mitm_address, room->mitm_port, room->mitm_session);
@@ -193,12 +188,12 @@ static void handle_discord_join_cb(retro_task_t *task, void *task_data,
          snprintf(hostname, sizeof(hostname), "%s|%d",
             room->address, room->port);
 
-      task_push_netplay_crc_scan(room->gamecrc, room->gamename,
-         room->subsystem_name, room->corename, hostname);
-
       discord_st->connecting = true;
       if (discord_st->ready)
          discord_update(PRESENCE_NETPLAY_CLIENT);
+
+      task_push_netplay_crc_scan(room->gamecrc, room->gamename,
+         room->subsystem_name, room->corename, hostname);
    }
 
    netplay_rooms_free();

--- a/tasks/tasks_internal.h
+++ b/tasks/tasks_internal.h
@@ -91,6 +91,7 @@ bool task_push_netplay_lan_scan(void (*cb)(const void*), unsigned timeout);
 
 bool task_push_netplay_crc_scan(uint32_t crc, const char *content,
       const char *subsystem, const char *core, const char *hostname);
+bool task_push_netplay_content_reload(const char *hostname);
 
 bool task_push_netplay_nat_traversal(void *data, uint16_t port);
 bool task_push_netplay_nat_close(void *data);


### PR DESCRIPTION
## Description

This ensures that the special netplay saves directory is used and passed to cores at content initialization, which will prevent overriding local saves when you join a host AFTER loading the content.

## Related Issues

Closes https://github.com/libretro/RetroArch/issues/8571

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/14111