### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/Orbis.yml
+++ b/.github/workflows/Orbis.yml
@@ -6,6 +6,9 @@ on:
   repository_dispatch:
     types: [run_build]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/PS2.yml
+++ b/.github/workflows/PS2.yml
@@ -6,6 +6,9 @@ on:
   repository_dispatch:
     types: [run_build]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/PSP.yml
+++ b/.github/workflows/PSP.yml
@@ -6,6 +6,9 @@ on:
   repository_dispatch:
     types: [run_build]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/crowdin-daily.yml
+++ b/.github/workflows/crowdin-daily.yml
@@ -6,8 +6,13 @@ on:
   schedule:
     - cron: '0 0 * * *'  # every day at midnight
 
+permissions:
+  contents: read
+
 jobs:
   sync:
+    permissions:
+      contents: write  # for Git to git push
     runs-on: ubuntu-latest
     steps:
       - name: Setup Java JDK

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -10,6 +10,9 @@ on:
       - 'intl/*_us.h'
       - 'intl/*_us.json'
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/retroarch.yml
+++ b/.github/workflows/retroarch.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   linux-c89: # Smoketest build using most restrictive compiler and default options
     runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
