### PR TITLE
Increase DEFAULT_MAX_PADS to 8 for ODROIDGO2, since that impacts the …

### DIFF
--- a/input/input_driver.h
+++ b/input/input_driver.h
@@ -77,7 +77,7 @@
 #elif defined(GEKKO) || defined(HW_RVL)
 #define DEFAULT_MAX_PADS 4
 #elif defined(HAVE_ODROIDGO2)
-#define DEFAULT_MAX_PADS 1
+#define DEFAULT_MAX_PADS 8
 #elif defined(__linux__) || (defined(BSD) && !defined(__MACH__))
 #define DEFAULT_MAX_PADS 8
 #elif defined(__QNX__)


### PR DESCRIPTION
## Description

Fixes USB gamepads on RG351[X} consoles.

Increase DEFAULT_MAX_PADS to 8 for ODROIDGO2, since that impacts the RG351[X] consoles. The RG351[X] have a USB host controller and can have an arbitrary number of USB gamepads.

## Related Issues

Resolves Issue #13281

## Reviewers

@sergimes