### PR TITLE
Silence Linux snprintf warnings

### DIFF
--- a/command.c
+++ b/command.c
@@ -1443,7 +1443,7 @@ bool command_event_save_core_config(
    if (path_is_valid(core_path))
    {
       unsigned i;
-      char tmp[PATH_MAX_LENGTH];
+      char tmp[PATH_MAX_LENGTH + 8];
       RARCH_LOG("[Config]: %s\n", msg_hash_to_str(MSG_USING_CORE_NAME_FOR_NEW_CONFIG));
 
       fill_pathname_base_noext(

--- a/configuration.c
+++ b/configuration.c
@@ -3925,7 +3925,7 @@ bool config_load_override(void *data)
       /* Create a new config file from content_path */
       if (config_file_exists(content_path))
       {
-         char temp_path[PATH_MAX_LENGTH];
+         char temp_path[PATH_MAX_LENGTH + 1];
 
          RARCH_LOG("[Overrides]: Content dir-specific overrides found at \"%s\".\n",
                content_path);
@@ -3957,7 +3957,7 @@ bool config_load_override(void *data)
       /* Create a new config file from game_path */
       if (config_file_exists(game_path))
       {
-         char temp_path[PATH_MAX_LENGTH];
+         char temp_path[PATH_MAX_LENGTH + 1];
 
          RARCH_LOG("[Overrides]: Game-specific overrides found at \"%s\".\n",
                game_path);

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -6392,9 +6392,9 @@ static void ozone_show_fullscreen_thumbnails(ozone_handle_t *ozone)
    }
    else if (string_to_unsigned(selected_entry.label) == MENU_ENUM_LABEL_STATE_SLOT)
    {
-      snprintf(tmpstr, sizeof(tmpstr), "%s %s",
+      snprintf(tmpstr, sizeof(tmpstr), "%s %d",
             msg_hash_to_str(MENU_ENUM_LABEL_VALUE_STATE_SLOT),
-            selected_entry.path);
+            string_to_unsigned(selected_entry.path));
       thumbnail_label = tmpstr;
    }
    /* > Quick Menu playlist label */

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -3975,9 +3975,9 @@ static void xmb_show_fullscreen_thumbnails(
    }
    else if (string_to_unsigned(selected_entry.label) == MENU_ENUM_LABEL_STATE_SLOT)
    {
-      snprintf(tmpstr, sizeof(tmpstr), "%s %s",
+      snprintf(tmpstr, sizeof(tmpstr), "%s %d",
             msg_hash_to_str(MENU_ENUM_LABEL_VALUE_STATE_SLOT),
-            selected_entry.path);
+            string_to_unsigned(selected_entry.path));
       thumbnail_label = tmpstr;
    }
    /* > Quick Menu playlist label */

--- a/menu/menu_contentless_cores.c
+++ b/menu/menu_contentless_cores.c
@@ -130,7 +130,7 @@ static void contentless_cores_init_info_entries(
          /* Populate licences string */
          if (core_info->licenses_list)
          {
-            char tmp_str[MENU_SUBLABEL_MAX_LENGTH];
+            char tmp_str[MENU_SUBLABEL_MAX_LENGTH - 2];
 
             tmp_str[0] = '\0';
 

--- a/tasks/task_autodetect.c
+++ b/tasks/task_autodetect.c
@@ -445,7 +445,7 @@ static void input_autoconfigure_connect_handler(retro_task_t *task)
    autoconfig_handle_t *autoconfig_handle = NULL;
    bool match_found                       = false;
    const char *device_display_name        = NULL;
-   char task_title[NAME_MAX_LENGTH];
+   char task_title[NAME_MAX_LENGTH + 16];
 
    task_title[0] = '\0';
 
@@ -782,7 +782,7 @@ static void cb_input_autoconfigure_disconnect(
 static void input_autoconfigure_disconnect_handler(retro_task_t *task)
 {
    autoconfig_handle_t *autoconfig_handle = NULL;
-   char task_title[NAME_MAX_LENGTH];
+   char task_title[NAME_MAX_LENGTH + 16];
 
    task_title[0] = '\0';
 

--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -770,7 +770,8 @@ static int database_info_list_iterate_found_match(
 
    if (!string_is_empty(db_state->serial))
    {
-      snprintf(db_crc, str_len, "%s|serial", db_state->serial);
+      if (snprintf(db_crc, str_len, "%s|serial", db_state->serial) < 0)
+         RARCH_ERR("Serial string encoding error\n");
    }
    else
    {

--- a/tasks/task_save.c
+++ b/tasks/task_save.c
@@ -1830,7 +1830,7 @@ static bool dump_to_file_desperate(const void *data,
    time_t time_;
    struct tm tm_;
    char timebuf[256];
-   char path[PATH_MAX_LENGTH];
+   char path[PATH_MAX_LENGTH + 256 + 32];
    char application_data[PATH_MAX_LENGTH];
 
    application_data[0]    = '\0';


### PR DESCRIPTION
## Description

Silence all snprintf-related warnings on Linux that did not warn on Windows.

After these only this warning remains on Linux (at least on my setup):
```
gfx/common/vulkan_common.c: In function ‘vulkan_create_swapchain’:
gfx/common/vulkan_common.c:2847:23: warning: ‘*((void *)&format+4)’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 2847 |    VkSurfaceFormatKHR format;
      |                       ^~~~~~
```
