### PR TITLE
(Ozone+XMB) Savestate thumbnail aspect ratio correction

### DIFF
--- a/gfx/gfx_thumbnail.h
+++ b/gfx/gfx_thumbnail.h
@@ -74,6 +74,7 @@ typedef struct
    float delay_timer;
    enum gfx_thumbnail_status status;
    bool fade_active;
+   bool core_aspect;
 } gfx_thumbnail_t;
 
 /* Holds all configuration parameters associated

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -3397,6 +3397,8 @@ static void ozone_update_savestate_thumbnail_image(void *data)
    if (!((ozone->is_quick_menu || ozone->is_state_slot) && ozone->libretro_running))
       return;
 
+   ozone->thumbnails.savestate.core_aspect = true;
+
    /* If path is empty, just reset thumbnail */
    if (string_is_empty(ozone->savestate_thumbnail_file_path))
       gfx_thumbnail_reset(&ozone->thumbnails.savestate);

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -1432,6 +1432,8 @@ static void xmb_update_savestate_thumbnail_image(void *data)
    if (!((xmb->is_quick_menu || xmb->is_state_slot) && xmb->libretro_running))
       return;
 
+   xmb->thumbnails.savestate.core_aspect = true;
+
    /* If path is empty, just reset thumbnail */
    if (string_is_empty(xmb->savestate_thumbnail_file_path))
       gfx_thumbnail_reset(&xmb->thumbnails.savestate);


### PR DESCRIPTION
## Description

Currently with some cores and settings the savestate thumbnail will look squashed, like in PUAE single line hires mode and GenPlusGX when using Blargg filters. So let's set a flag and do aspect ratio correction accordingly.

