### PR TITLE
Thumbnail aspect ratio fix

### DIFF
--- a/gfx/gfx_thumbnail.c
+++ b/gfx/gfx_thumbnail.c
@@ -415,6 +415,7 @@ void gfx_thumbnail_reset(gfx_thumbnail_t *thumbnail)
    thumbnail->alpha       = 0.0f;
    thumbnail->delay_timer = 0.0f;
    thumbnail->fade_active = false;
+   thumbnail->core_aspect = false;
 }
 
 /* Stream processing */
@@ -810,20 +811,26 @@ void gfx_thumbnail_get_draw_dimensions(
    {
       *draw_width  = (float)width;
       *draw_height = (float)thumbnail->height * (*draw_width / (float)thumbnail->width);
-      *draw_height = *draw_height * (thumbnail_aspect / core_aspect);
 
-      if (*draw_height > height)
+      if (thumbnail->core_aspect)
       {
-         *draw_height = (float)height;
-         *draw_width  = (float)thumbnail->width * (*draw_height / (float)thumbnail->height);
-         *draw_width  = *draw_width / (thumbnail_aspect / core_aspect);
+         *draw_height = *draw_height * (thumbnail_aspect / core_aspect);
+
+         if (*draw_height > height)
+         {
+            *draw_height = (float)height;
+            *draw_width  = (float)thumbnail->width * (*draw_height / (float)thumbnail->height);
+            *draw_width  = *draw_width / (thumbnail_aspect / core_aspect);
+         }
       }
    }
    else
    {
       *draw_height = (float)height;
       *draw_width  = (float)thumbnail->width * (*draw_height / (float)thumbnail->height);
-      *draw_width  = *draw_width / (thumbnail_aspect / core_aspect);
+
+      if (thumbnail->core_aspect)
+         *draw_width  = *draw_width / (thumbnail_aspect / core_aspect);
    }
 
    /* Account for scale factor

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -3397,8 +3397,6 @@ static void ozone_update_savestate_thumbnail_image(void *data)
    if (!((ozone->is_quick_menu || ozone->is_state_slot) && ozone->libretro_running))
       return;
 
-   ozone->thumbnails.savestate.core_aspect = true;
-
    /* If path is empty, just reset thumbnail */
    if (string_is_empty(ozone->savestate_thumbnail_file_path))
       gfx_thumbnail_reset(&ozone->thumbnails.savestate);
@@ -3416,6 +3414,8 @@ static void ozone_update_savestate_thumbnail_image(void *data)
                thumbnail_upscale_threshold);
       }
    }
+
+   ozone->thumbnails.savestate.core_aspect = true;
 }
 
 static void ozone_entries_update_thumbnail_bar(

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -1432,8 +1432,6 @@ static void xmb_update_savestate_thumbnail_image(void *data)
    if (!((xmb->is_quick_menu || xmb->is_state_slot) && xmb->libretro_running))
       return;
 
-   xmb->thumbnails.savestate.core_aspect = true;
-
    /* If path is empty, just reset thumbnail */
    if (string_is_empty(xmb->savestate_thumbnail_file_path))
       gfx_thumbnail_reset(&xmb->thumbnails.savestate);
@@ -1449,6 +1447,8 @@ static void xmb_update_savestate_thumbnail_image(void *data)
                &xmb->thumbnails.savestate,
                thumbnail_upscale_threshold);
    }
+
+   xmb->thumbnails.savestate.core_aspect = true;
 }
 
 /* Is called when the pointer position changes within a list/sub-list (vertically) */


### PR DESCRIPTION
## Description

Forgot to add the new flag to `gfx_thumbnail_reset()` which caused it to be true even when not set true.. Also made sure no extra calculations are done at all if the flag is not set, and moved the flag setting after reset.

## Related Issues

Closes #14144 


