### PR TITLE
(Netplay) Force a core update when starting netplay

### DIFF
--- a/runloop.c
+++ b/runloop.c
@@ -5448,6 +5448,26 @@ bool runloop_event_init_core(
    float fastforward_ratio         = 0.0f;
    rarch_system_info_t *sys_info   = &runloop_st->system;
 
+#if defined(HAVE_NETWORKING) && defined(HAVE_UPDATE_CORES)
+   /* If netplay is enabled, update the core before initializing. */
+   if (netplay_driver_ctl(RARCH_NETPLAY_CTL_IS_ENABLED, NULL))
+   {
+      const char *path_core = path_get(RARCH_PATH_CORE);
+
+      if (!string_is_empty(path_core) &&
+            !string_is_equal(path_core, "builtin"))
+      {
+         task_push_update_single_core(path_core,
+            settings->bools.core_updater_auto_backup,
+            settings->uints.core_updater_auto_backup_history_size,
+            settings->paths.directory_libretro,
+            settings->paths.directory_core_assets);
+         /* We must wait for the update to finish before starting the core. */
+         task_update_installed_cores_wait();
+      }
+   }
+#endif
+
    if (!init_libretro_symbols(runloop_st,
             type, &runloop_st->current_core))
       return false;

--- a/tasks/task_netplay_find_content.c
+++ b/tasks/task_netplay_find_content.c
@@ -468,9 +468,17 @@ static void task_netplay_crc_scan_callback(retro_task_t *task,
                data->core, content_path);
 
             command_event(CMD_EVENT_NETPLAY_DEINIT, NULL);
-            netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE_CLIENT, NULL);
-            command_event(CMD_EVENT_NETPLAY_INIT_DIRECT_DEFERRED,
-               data->hostname);
+
+            if (string_is_empty(data->hostname))
+            {
+               netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE_SERVER, NULL);
+            }
+            else
+            {
+               netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE_CLIENT, NULL);
+               command_event(CMD_EVENT_NETPLAY_INIT_DIRECT_DEFERRED,
+                  data->hostname);
+            }
 
             task_push_load_new_core(data->core,
                NULL, NULL, CORE_TYPE_PLAIN, NULL, NULL);
@@ -502,7 +510,11 @@ static void task_netplay_crc_scan_callback(retro_task_t *task,
                data->core, subsystem);
 
             command_event(CMD_EVENT_NETPLAY_DEINIT, NULL);
-            netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE_CLIENT, NULL);
+
+            if (string_is_empty(data->hostname))
+               netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE_SERVER, NULL);
+            else
+               netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE_CLIENT, NULL);
 
             task_push_load_new_core(data->core,
                NULL, NULL, CORE_TYPE_PLAIN, NULL, NULL);
@@ -517,8 +529,9 @@ static void task_netplay_crc_scan_callback(retro_task_t *task,
                for (i = 0; i < subsystem_content->size; i++)
                   content_add_subsystem(subsystem_content->elems[i].data);
 
-               command_event(CMD_EVENT_NETPLAY_INIT_DIRECT_DEFERRED,
-                  data->hostname);
+               if (!string_is_empty(data->hostname))
+                  command_event(CMD_EVENT_NETPLAY_INIT_DIRECT_DEFERRED,
+                     data->hostname);
 
                task_push_load_subsystem_with_core(NULL,
                   &content_info, CORE_TYPE_PLAIN, NULL, NULL);
@@ -545,9 +558,17 @@ static void task_netplay_crc_scan_callback(retro_task_t *task,
             RARCH_LOG("[Lobby] Loading contentless core '%s'.\n", data->core);
 
             command_event(CMD_EVENT_NETPLAY_DEINIT, NULL);
-            netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE_CLIENT, NULL);
-            command_event(CMD_EVENT_NETPLAY_INIT_DIRECT_DEFERRED,
-               data->hostname);
+
+            if (string_is_empty(data->hostname))
+            {
+               netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE_SERVER, NULL);
+            }
+            else
+            {
+               netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE_CLIENT, NULL);
+               command_event(CMD_EVENT_NETPLAY_INIT_DIRECT_DEFERRED,
+                  data->hostname);
+            }
 
             task_push_load_new_core(data->core,
                NULL, NULL, CORE_TYPE_PLAIN, NULL, NULL);
@@ -562,9 +583,17 @@ static void task_netplay_crc_scan_callback(retro_task_t *task,
                command_event(CMD_EVENT_UNLOAD_CORE, NULL);
 
                command_event(CMD_EVENT_NETPLAY_DEINIT, NULL);
-               netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE_CLIENT, NULL);
-               command_event(CMD_EVENT_NETPLAY_INIT_DIRECT_DEFERRED,
-                  data->hostname);
+
+               if (string_is_empty(data->hostname))
+               {
+                  netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE_SERVER, NULL);
+               }
+               else
+               {
+                  netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE_CLIENT, NULL);
+                  command_event(CMD_EVENT_NETPLAY_INIT_DIRECT_DEFERRED,
+                     data->hostname);
+               }
 
                task_push_load_new_core(data->core,
                   NULL, NULL, CORE_TYPE_PLAIN, NULL, NULL);
@@ -754,7 +783,10 @@ bool task_push_netplay_content_reload(const char *hostname)
    scan_state.state = STATE_RELOAD;
 
    strlcpy(data->core, pcore, sizeof(data->core));
-   strlcpy(data->hostname, hostname, sizeof(data->hostname));
+
+   /* Hostname being NULL indicates this is a host. */
+   if (hostname)
+      strlcpy(data->hostname, hostname, sizeof(data->hostname));
 
    content_get_status(&contentless, &is_inited);
    if (contentless)

--- a/tasks/tasks_internal.h
+++ b/tasks/tasks_internal.h
@@ -112,6 +112,10 @@ void task_push_update_installed_cores(
       bool auto_backup, size_t auto_backup_history_size,
       const char *path_dir_libretro,
       const char *path_dir_core_assets);
+void task_push_update_single_core(
+      const char *path_core, bool auto_backup, size_t auto_backup_history_size,
+      const char *path_dir_libretro, const char *path_dir_core_assets);
+void task_update_installed_cores_wait(void);
 #if defined(ANDROID)
 void *task_push_play_feature_delivery_core_install(
       core_updater_list_t* core_list,


### PR DESCRIPTION
## Description

The update is silent and not visible to the user, including network errors (this should prevent displaying error notifications for LAN netplay).
Locked cores and latest cores WILL NOT be updated.

NOTE: Big cores like fbneo take a while to download. RetroArch will hang until the download is completed.

## Related Issues

https://github.com/libretro/RetroArch/issues/14149