### PR TITLE
(String) Do not assume char is unsigned

### DIFF
--- a/libretro-common/include/string/stdstring.h
+++ b/libretro-common/include/string/stdstring.h
@@ -268,13 +268,13 @@ extern const unsigned char lr_char_props[256];
 int string_count_occurrences_single_character(char *str, char t);
 
 /* Replaces all spaces with the given character. */
-void string_replace_whitespace_with_single_character(char *str, char t);
+void string_replace_whitespace_with_single_character(char *str, char c);
 
 /* Replaces multiple spaces with a single space in a string. */
 void string_replace_multi_space_with_single_space(char *str);
 
 /* Remove all spaces from the given string. */
-void string_remove_all_whitespace(char* str_trimmed, const char* str_untrimmed);
+void string_remove_all_whitespace(char *str_trimmed, const char *str);
 
 /* Retrieve the last occurance of the given character in a string. */
 int string_index_last_occurance(char str[], char t);

--- a/libretro-common/string/stdstring.c
+++ b/libretro-common/string/stdstring.c
@@ -545,14 +545,11 @@ int string_count_occurrences_single_character(char *str, char t)
 /**
  * Replaces all spaces with the given character.
  */
-void string_replace_whitespace_with_single_character(char *str, char t)
+void string_replace_whitespace_with_single_character(char *str, char c)
 {
-   while (*str)
-   {
-      if (isspace(*str))
-         *str = t;
-      str++;
-   }
+   for (; *str; str++)
+      if (ISSPACE(*str))
+         *str = c;
 }
 
 /**
@@ -560,33 +557,29 @@ void string_replace_whitespace_with_single_character(char *str, char t)
  */
 void string_replace_multi_space_with_single_space(char *str)
 {
-   char *dest = str;
+   char *str_trimmed  = str;
+   bool prev_is_space = false;
+   bool curr_is_space = false;
 
-   while (*str != '\0')
+   for (; *str; str++)
    {
-      while (*str == ' ' && *(str + 1) == ' ')
-         str++;
-
-      *dest++ = *str++;
+      curr_is_space  = ISSPACE(*str);
+      if (prev_is_space && curr_is_space)
+         continue;
+      *str_trimmed++ = *str;
+      prev_is_space  = curr_is_space;
    }
-
-   *dest = '\0';
+   *str_trimmed = '\0';
 }
 
 /**
  * Remove all spaces from the given string.
  */
-void string_remove_all_whitespace(char* str_trimmed, const char* str_untrimmed)
+void string_remove_all_whitespace(char *str_trimmed, const char *str)
 {
-   while (*str_untrimmed != '\0')
-   {
-      if(!isspace(*str_untrimmed))
-      {
-         *str_trimmed = *str_untrimmed;
-         str_trimmed++;
-      }
-      str_untrimmed++;
-   }
+   for (; *str; str++)
+      if (!ISSPACE(*str))
+         *str_trimmed++ = *str;
    *str_trimmed = '\0';
 }
 


### PR DESCRIPTION
## Description

ANSI C allows "char" to behave in the same way as either "unsigned char" or "signed char".

See these warnings that can lead to buffer overflows when char behaves like signed char:
```
In file included from libretro-common/string/stdstring.c:24:
libretro-common/string/stdstring.c: In function 'string_replace_whitespace_with_single_character':
libretro-common/string/stdstring.c:552:19: warning: array subscript has type 'char' [-Wchar-subscripts]
  552 |       if (isspace(*str))
      |                   ^~~~
libretro-common/string/stdstring.c: In function 'string_remove_all_whitespace':
libretro-common/string/stdstring.c:583:19: warning: array subscript has type 'char' [-Wchar-subscripts]
  583 |       if(!isspace(*str_untrimmed))
      |                   ^~~~~~~~~~~~~~
```
## Reviewers

@sonninnos I believe you wrote those functions. Could you please confirm that my refactoring suits them?