### PR TITLE
Small opts

### DIFF
--- a/audio/audio_driver.c
+++ b/audio/audio_driver.c
@@ -927,8 +927,7 @@ bool audio_driver_dsp_filter_init(const char *device)
    if (!frontend_driver_get_core_extension(ext_name, sizeof(ext_name)))
       return false;
 
-   plugs = dir_list_new(basedir, ext_name, false, true, false, false);
-   if (!plugs)
+   if (!(plugs = dir_list_new(basedir, ext_name, false, true, false, false)))
       return false;
 #endif
    audio_driver_dsp = retro_dsp_filter_new(

--- a/configuration.c
+++ b/configuration.c
@@ -3322,9 +3322,6 @@ static bool config_load_file(global_t *global,
        * variable. */
       char tmp_append_path[PATH_MAX_LENGTH];
       const char *extra_path = NULL;
-
-      tmp_append_path[0] = '\0';
-
       strlcpy(tmp_append_path, path_get(RARCH_PATH_CONFIG_APPEND),
             sizeof(tmp_append_path));
       extra_path = strtok_r(tmp_append_path, "|", &save);
@@ -3941,10 +3938,7 @@ bool config_load_override(void *data)
                   );
          }
          else
-         {
-            tmp_path[0]    = '\0';
             strlcpy(tmp_path, content_path, sizeof(tmp_path));
-         }
 
          path_set(RARCH_PATH_CONFIG_APPEND, tmp_path);
 
@@ -3973,10 +3967,7 @@ bool config_load_override(void *data)
                   );
          }
          else
-         {
-            tmp_path[0]    = '\0';
             strlcpy(tmp_path, game_path, sizeof(tmp_path));
-         }
 
          path_set(RARCH_PATH_CONFIG_APPEND, tmp_path);
 
@@ -5258,8 +5249,6 @@ bool input_remapping_save_file(const char *path)
    runloop_state_t *runloop_st = runloop_state_get_ptr();
    settings_t        *settings = config_st;
    unsigned          max_users = settings->uints.input_max_users;
-
-   remap_file_dir[0]           = '\0';
 
    if (string_is_empty(path))
       return false;

--- a/core_updater_list.c
+++ b/core_updater_list.c
@@ -278,14 +278,9 @@ bool core_updater_list_get_core(
    size_t i;
    char real_core_path[PATH_MAX_LENGTH];
 
-   real_core_path[0] = '\0';
-
    if (!core_list || !entry || string_is_empty(local_core_path))
       return false;
-
-   num_entries = RBUF_LEN(core_list->entries);
-
-   if (num_entries < 1)
+   if ((num_entries = RBUF_LEN(core_list->entries)) < 1)
       return false;
 
    /* Resolve absolute pathname of local_core_path */
@@ -771,13 +766,10 @@ static void core_updater_list_qsort(core_updater_list_t *core_list)
 
    if (!core_list)
       return;
-
-   num_entries = RBUF_LEN(core_list->entries);
-
-   if (num_entries < 2)
+   if ((num_entries = RBUF_LEN(core_list->entries)) < 2)
       return;
-
-   qsort(
+   if (core_list->entries)
+      qsort(
          core_list->entries, num_entries,
          sizeof(core_updater_list_entry_t),
          (int (*)(const void *, const void *))
@@ -809,9 +801,7 @@ bool core_updater_list_parse_network_data(
 
    /* Input data string is not terminated - have
     * to copy it to a temporary buffer... */
-   data_buf = (char*)malloc((len + 1) * sizeof(char));
-
-   if (!data_buf)
+   if (!(data_buf = (char*)malloc((len + 1) * sizeof(char))))
       goto error;
 
    memcpy(data_buf, data, len * sizeof(char));

--- a/disk_index_file.c
+++ b/disk_index_file.c
@@ -222,8 +222,6 @@ bool disk_index_file_init(
    char disk_index_file_dir[PATH_MAX_LENGTH];
    char disk_index_file_path[PATH_MAX_LENGTH];
 
-   content_name[0]         = '\0';
-   disk_index_file_dir[0]  = '\0';
    disk_index_file_path[0] = '\0';
 
    /* Sanity check */

--- a/gfx/gfx_widgets.c
+++ b/gfx/gfx_widgets.c
@@ -531,7 +531,6 @@ static void gfx_widgets_msg_queue_free(
 
 static void gfx_widgets_msg_queue_kill_end(void *userdata)
 {
-   unsigned i;
    disp_widget_msg_t* msg;
    dispgfx_widget_t *p_dispwidget   = &dispwidget_st;
 
@@ -541,6 +540,7 @@ static void gfx_widgets_msg_queue_kill_end(void *userdata)
 
    if ((msg = p_dispwidget->current_msgs[p_dispwidget->msg_queue_kill]))
    {
+      int i;
       /* Remove it from the list */
       for (i = p_dispwidget->msg_queue_kill; i < p_dispwidget->current_msgs_size - 1; i++)
          p_dispwidget->current_msgs[i] = p_dispwidget->current_msgs[i + 1];
@@ -2013,7 +2013,7 @@ bool gfx_widgets_init(
       unsigned width, unsigned height, bool fullscreen,
       const char *dir_assets, char *font_path)
 {
-   unsigned i;
+   size_t i;
    unsigned color                              = 0x222222;
    dispgfx_widget_t *p_dispwidget              = &dispwidget_st;
    gfx_display_t *p_disp                       = (gfx_display_t*)data_disp;
@@ -2047,8 +2047,6 @@ bool gfx_widgets_init(
 
    if (!p_dispwidget->inited)
    {
-      size_t i;
-
       p_dispwidget->gfx_widgets_frame_count = 0;
 
       for (i = 0; i < ARRAY_SIZE(widgets); i++)
@@ -2160,33 +2158,6 @@ void gfx_widgets_ai_service_overlay_unload(void)
       p_dispwidget->ai_service_overlay_texture = 0;
       p_dispwidget->ai_service_overlay_state   = 0;
    }
-}
-#endif
-
-#ifdef HAVE_SCREENSHOTS
-void task_screenshot_callback(retro_task_t *task,
-      void *task_data,
-      void *user_data, const char *error)
-{
-   screenshot_task_state_t *state = NULL;
-
-   if (!task)
-      return;
-
-   state = (screenshot_task_state_t*)task->state;
-
-   if (!state)
-      return;
-
-   if (!state->silence && state->widgets_ready)
-      gfx_widget_screenshot_taken(&dispwidget_st,
-            state->shotname, state->filename);
-
-   free(state);
-   /* Must explicitly set task->state to NULL here,
-    * to avoid potential heap-use-after-free errors */
-   state       = NULL;
-   task->state = NULL;
 }
 #endif
 

--- a/gfx/video_shader_parse.c
+++ b/gfx/video_shader_parse.c
@@ -293,7 +293,6 @@ static bool video_shader_parse_pass(config_file_t *conf,
    snprintf(scale_name_buf, sizeof(scale_name_buf), "scale_type_y%u", i);
    config_get_array(conf, scale_name_buf, scale_type_y, sizeof(scale_type_y));
 
-
    if (*scale_type)
    {
       strlcpy(scale_type_x, scale_type, sizeof(scale_type_x));
@@ -438,8 +437,6 @@ static bool video_shader_parse_textures(config_file_t *conf,
       bool smooth         = false;
       struct config_entry_list 
          *entry           = NULL;
-
-      id_filter[0] = id_wrap[0] = id_mipmap[0] = '\0';
 
       if (!(entry = config_get_entry(conf, id)) ||
             string_is_empty(entry->value))
@@ -828,9 +825,6 @@ static bool video_shader_write_root_preset(const struct video_shader *shader,
    if (shader->luts)
    {
       char textures[4096];
-
-      textures[0] = '\0';
-
       /* Names of the textures */
       strlcpy(textures, shader->lut[0].id, sizeof(textures));
 
@@ -855,7 +849,6 @@ static bool video_shader_write_root_preset(const struct video_shader *shader,
          if (shader->lut[i].filter != RARCH_FILTER_UNSPEC)
          {
             char k[128];
-            k[0]  = '\0';
             strlcpy(k, shader->lut[i].id, sizeof(k));
             strlcat(k, "_linear", sizeof(k));
             config_set_string(conf, k, 
@@ -867,7 +860,6 @@ static bool video_shader_write_root_preset(const struct video_shader *shader,
          /* Wrap Mode */
          {
             char k[128];
-            k[0]  = '\0';
             strlcpy(k, shader->lut[i].id, sizeof(k));
             strlcat(k, "_wrap_mode", sizeof(k));
             config_set_string(conf, k,
@@ -877,7 +869,6 @@ static bool video_shader_write_root_preset(const struct video_shader *shader,
          /* Mipmap On or Off */
          {
             char k[128];
-            k[0]  = '\0';
             strlcpy(k, shader->lut[i].id, sizeof(k));
             strlcat(k, "_mipmap", sizeof(k));
             config_set_string(conf, k, shader->lut[i].mipmap
@@ -1095,7 +1086,6 @@ static bool video_shader_write_referenced_preset(
    config_dir[0]                          = '\0';
    relative_tmp_ref_path[0]               = '\0';
    abs_tmp_ref_path[0]                    = '\0';
-   path_to_ref[0]                         = '\0';
 
    path_basedir(new_preset_basedir);
 
@@ -1688,10 +1678,8 @@ static bool override_shader_values(config_file_t *override_conf,
        * for each in the override config */
       for (i = 0; i < shader->luts; i++)
       {
-         entry = config_get_entry(override_conf, shader->lut[i].id);
-
          /* If the texture is defined in the reference config */
-         if (entry)
+         if ((entry = config_get_entry(override_conf, shader->lut[i].id)))
          {
             /* Texture path from shader the config */
             config_get_path(override_conf, shader->lut[i].id,
@@ -2424,20 +2412,23 @@ bool load_shader_preset(settings_t *settings, const char *core_name,
    {
       if (string_is_empty(dirs[i]))
          continue;
-      /* Game-specific shader preset found? */
-      if (has_content && retroarch_load_shader_preset_internal(
-               shader_path,
-               sizeof(shader_path),
-               dirs[i], core_name,
-               game_name))
-         goto success;
-      /* Folder-specific shader preset found? */
-      if (has_content && retroarch_load_shader_preset_internal(
-               shader_path,
-               sizeof(shader_path),
-               dirs[i], core_name,
-               content_dir_name))
-         goto success;
+      if (has_content)
+      {
+         /* Game-specific shader preset found? */
+         if (retroarch_load_shader_preset_internal(
+                  shader_path,
+                  sizeof(shader_path),
+                  dirs[i], core_name,
+                  game_name))
+            goto success;
+         /* Folder-specific shader preset found? */
+         if (retroarch_load_shader_preset_internal(
+                  shader_path,
+                  sizeof(shader_path),
+                  dirs[i], core_name,
+                  content_dir_name))
+            goto success;
+      }
       /* Core-specific shader preset found? */
       if (retroarch_load_shader_preset_internal(
                shader_path,

--- a/input/connect/joypad_connection.c
+++ b/input/connect/joypad_connection.c
@@ -54,26 +54,16 @@ static bool joypad_is_end_of_list(joypad_connection_t *pad)
 
 int pad_connection_find_vacant_pad(joypad_connection_t *joyconn)
 {
-   unsigned i;
-
-   if (!joyconn)
-      return -1;
-
-   for (i = 0; !joypad_is_end_of_list(&joyconn[i]); i++)
+   int i;
+   if (joyconn)
    {
-      if(!joyconn[i].connected)
-         return i;
+      for (i = 0; !joypad_is_end_of_list(&joyconn[i]); i++)
+      {
+         if (!joyconn[i].connected)
+            return i;
+      }
    }
-
    return -1;
-}
-
-static void set_end_of_list(joypad_connection_t *list, unsigned end)
-{
-   joypad_connection_t *entry = (joypad_connection_t *)&list[end];
-   entry->connected           = false;
-   entry->iface               = NULL;
-   entry->data                = (void*)0xdeadbeef;
 }
 
 /**
@@ -83,19 +73,17 @@ static void set_end_of_list(joypad_connection_t *list, unsigned end)
  */
 joypad_connection_t *pad_connection_init(unsigned pads)
 {
-   unsigned i;
+   int i;
    joypad_connection_t *joyconn;
 
-   if(pads > MAX_USERS)
+   if (pads > MAX_USERS)
    {
-     RARCH_WARN("[joypad] invalid number of pads requested (%d), using default (%d)\n",
-      pads, MAX_USERS);
-     pads = MAX_USERS;
+      RARCH_WARN("[joypad] invalid number of pads requested (%d), using default (%d)\n",
+            pads, MAX_USERS);
+      pads = MAX_USERS;
    }
 
-   joyconn = (joypad_connection_t*)calloc(pads+1, sizeof(joypad_connection_t));
-
-   if (!joyconn)
+   if (!(joyconn = (joypad_connection_t*)calloc(pads+1, sizeof(joypad_connection_t))))
       return NULL;
 
    for (i = 0; i < pads; i++)
@@ -107,12 +95,18 @@ joypad_connection_t *pad_connection_init(unsigned pads)
       conn->data                = NULL;
    }
 
-   set_end_of_list(joyconn, pads);
+   /* Set end of list */
+   {
+      joypad_connection_t *entry = (joypad_connection_t *)&joyconn[pads];
+      entry->connected           = false;
+      entry->iface               = NULL;
+      entry->data                = (void*)0xdeadbeef;
+   }
 
    return joyconn;
 }
 
-void init_pad_map(void)
+static void init_pad_map(void)
 {
    pad_map[0].vid         = VID_NINTENDO;
    pad_map[0].pid         = PID_NINTENDO_PRO;
@@ -146,8 +140,9 @@ joypad_connection_entry_t *find_connection_entry(uint16_t vid, uint16_t pid, con
 {
    unsigned i;
    const bool has_name = !string_is_empty(name);
+   size_t name_len     = strlen(name);
 
-   if(pad_map[0].vid == 0)
+   if (pad_map[0].vid == 0)
       init_pad_map();
 
    for(i = 0; pad_map[i].name != NULL; i++)
@@ -156,7 +151,7 @@ joypad_connection_entry_t *find_connection_entry(uint16_t vid, uint16_t pid, con
       /* The Wii Pro Controller and WiiU Pro controller have
        * the same VID/PID, so we have to use the
        * descriptor string to differentiate them. */
-      if(      pad_map[i].vid == VID_NINTENDO
+      if (     pad_map[i].vid == VID_NINTENDO
             && pad_map[i].pid == PID_NINTENDO_PRO
             && pad_map[i].vid == vid
             && pad_map[i].pid == pid)
@@ -164,18 +159,17 @@ joypad_connection_entry_t *find_connection_entry(uint16_t vid, uint16_t pid, con
          name_match = has_name
             ? (char*)strstr(pad_map[i].name, name)
             : NULL;
-         if (has_name && strlen(name) < 19)
+         if (has_name && name_len < 19)
          {
             /* Wii U: Argument 'name' may be truncated. This is not enough for a reliable name match! */
             RARCH_ERR("find_connection_entry(0x%04x,0x%04x): device name '%s' too short: assuming controller '%s'\n",
                   SWAP_IF_BIG(vid), SWAP_IF_BIG(pid), name, pad_map[i].name);
          }
-         else
-            if(!string_is_equal(pad_map[i].name, name))
+         else if (!string_is_equal(pad_map[i].name, name))
                continue;
       }
 
-      if(name_match || (pad_map[i].vid == vid && pad_map[i].pid == pid))
+      if (name_match || (pad_map[i].vid == vid && pad_map[i].pid == pid))
          return &pad_map[i];
    }
 
@@ -187,13 +181,12 @@ static int joypad_to_slot(joypad_connection_t *haystack,
 {
    int i;
 
-   if(needle == NULL) {
+   if (!needle)
       return -1;
-   }
 
    for(i = 0; !joypad_is_end_of_list(&haystack[i]); i++)
    {
-      if(&haystack[i] == needle)
+      if (&haystack[i] == needle)
          return i;
    }
    return -1;
@@ -203,11 +196,13 @@ void release_joypad(joypad_connection_t *joypad) {
 
 }
 
-void legacy_pad_connection_pad_deregister(joypad_connection_t *pad_list, pad_connection_interface_t *iface, void *pad_data) {
+void legacy_pad_connection_pad_deregister(joypad_connection_t *pad_list, pad_connection_interface_t *iface, void *pad_data)
+{
    int i;
    for(i = 0; !joypad_is_end_of_list(&pad_list[i]); i++)
    {
-      if(pad_list[i].connection == pad_data) {
+      if (pad_list[i].connection == pad_data)
+      {
          input_autoconfigure_disconnect(i, iface ? iface->get_name(pad_data) : NULL);
          memset(&pad_list[i], 0, sizeof(joypad_connection_t));
          return;
@@ -219,9 +214,8 @@ void pad_connection_pad_deregister(joypad_connection_t *joyconn,
       pad_connection_interface_t *iface, void *pad_data)
 {
    int i; 
-   int slot;
 
-   if(!iface || !iface->multi_pad)
+   if (!iface || !iface->multi_pad)
    {
       legacy_pad_connection_pad_deregister(joyconn, iface, pad_data);
       return;
@@ -229,8 +223,8 @@ void pad_connection_pad_deregister(joypad_connection_t *joyconn,
 
    for(i = 0; i < iface->max_pad; i++)
    {
-      slot = joypad_to_slot(joyconn, iface->joypad(pad_data, i));
-      if(slot >= 0)
+      int slot = joypad_to_slot(joyconn, iface->joypad(pad_data, i));
+      if (slot >= 0)
       {
          input_autoconfigure_disconnect(slot, iface->get_name(joyconn[slot].connection));
          iface->pad_deinit(joyconn[slot].connection);
@@ -261,7 +255,6 @@ void pad_connection_pad_refresh(joypad_connection_t *joyconn,
          /* The pad slot is bound to a joypad 
             that's no longer connected */
          case PAD_CONNECT_BOUND:
-            RARCH_LOG("PAD_CONNECT_BOUND (0x%02x)\n", state);
             joypad = iface->joypad(device_data, i);
             slot   = joypad_to_slot(joyconn, joypad);
             input_autoconfigure_disconnect(slot,
@@ -273,7 +266,7 @@ void pad_connection_pad_refresh(joypad_connection_t *joyconn,
             /* The joypad is connected but has not been bound */
          case PAD_CONNECT_READY:
             slot = pad_connection_find_vacant_pad(joyconn);
-            if(slot >= 0)
+            if (slot >= 0)
             {
                joypad = &joyconn[slot];
                joypad->connection   = iface->pad_init(device_data,
@@ -286,8 +279,10 @@ void pad_connection_pad_refresh(joypad_connection_t *joyconn,
             }
             break;
          default:
-            if(state > 0x03)
+#ifndef NDEBUG
+            if (state > 0x03)
                RARCH_LOG("Unrecognized state: 0x%02x", state);
+#endif
             break;
       }
    }
@@ -298,12 +293,10 @@ void pad_connection_pad_register(joypad_connection_t *joyconn,
       void *device_data, void *handle,
       input_device_driver_t *input_driver, int slot)
 {
-   int i, status;
-   int found_slot;
+   int i;
    int max_pad;
-   void *connection;
 
-   if(      (iface->multi_pad)
+   if (     (iface->multi_pad)
          && (iface->max_pad <= 1 || !iface->status || !iface->pad_init))
    {
       RARCH_ERR("pad_connection_pad_register: multi-pad driver has incomplete implementation\n");
@@ -314,23 +307,22 @@ void pad_connection_pad_register(joypad_connection_t *joyconn,
 
    for(i = 0; i < max_pad; i++)
    {
-      status = iface->multi_pad 
+      int status = iface->multi_pad 
          ? iface->status(device_data, i) 
          : PAD_CONNECT_READY;
-      if(status == PAD_CONNECT_READY)
+      if (status == PAD_CONNECT_READY)
       {
-         found_slot = (slot == SLOT_AUTO) 
+         void *connection = NULL;
+         int found_slot   = (slot == SLOT_AUTO) 
             ? pad_connection_find_vacant_pad(joyconn) 
             : slot;
-         if(found_slot < 0)
+         if (found_slot < 0)
             continue;
-         connection = device_data;
-         if(iface->multi_pad)
-         {
-            RARCH_LOG("pad_connection_pad_register: multi-pad detected, initializing pad %d\n", i);
+         if (iface->multi_pad)
             connection = iface->pad_init(device_data, i,
                   &joyconn[found_slot]);
-         }
+         else
+            connection = device_data;
 
          joyconn[found_slot].iface        = iface;
          joyconn[found_slot].data         = handle;
@@ -338,7 +330,7 @@ void pad_connection_pad_register(joypad_connection_t *joyconn,
          joyconn[found_slot].input_driver = input_driver;
          joyconn[found_slot].connected    = true;
 
-         RARCH_LOG("connecting pad to slot %d\n", found_slot);
+         RARCH_LOG("Connecting pad to slot %d\n", found_slot);
          input_pad_connect(found_slot, input_driver);
       }
    }
@@ -383,7 +375,7 @@ int32_t pad_connection_pad_init(joypad_connection_t *joyconn,
 {
    joypad_connection_entry_t *entry = NULL;
 
-   if(pad_map[0].vid == 0)
+   if (pad_map[0].vid == 0)
       init_pad_map();
 
    entry = find_connection_entry(vid, pid, name);
@@ -399,7 +391,6 @@ void pad_connection_pad_deinit(joypad_connection_t *joyconn,
 
    if (joyconn->iface)
    {
-
       joyconn->iface->set_rumble(joyconn->connection,
             RETRO_RUMBLE_STRONG, 0);
       joyconn->iface->set_rumble(joyconn->connection,
@@ -417,16 +408,12 @@ void pad_connection_pad_deinit(joypad_connection_t *joyconn,
 void pad_connection_packet(joypad_connection_t *joyconn, uint32_t pad,
       uint8_t* data, uint32_t length)
 {
-   if (!joyconn || !joyconn->connected)
-       return;
-   if (     
-            joyconn->connection 
+   if (     joyconn
+         && joyconn->connected
+         && joyconn->connection 
          && joyconn->iface
-       && joyconn->iface->packet_handler) {
-
+         && joyconn->iface->packet_handler)
       joyconn->iface->packet_handler(joyconn->connection, data, length);
-
-       }
 }
 
 void pad_connection_get_buttons(joypad_connection_t *joyconn,
@@ -441,24 +428,22 @@ void pad_connection_get_buttons(joypad_connection_t *joyconn,
 int16_t pad_connection_get_axis(joypad_connection_t *joyconn,
    unsigned idx, unsigned i)
 {
-   if (!joyconn || !joyconn->iface)
-      return 0;
-   return joyconn->iface->get_axis(joyconn->connection, i);
+   if (joyconn && joyconn->iface)
+      return joyconn->iface->get_axis(joyconn->connection, i);
+   return 0;
 }
 
 bool pad_connection_has_interface(joypad_connection_t *joyconn,
       unsigned pad)
 {
-   if (     joyconn && pad < MAX_USERS
-         && joyconn[pad].connected
-         && joyconn[pad].iface)
-      return true;
-   return false;
+   return (     joyconn && pad < MAX_USERS
+             && joyconn[pad].connected
+             && joyconn[pad].iface);
 }
 
 void pad_connection_destroy(joypad_connection_t *joyconn)
 {
-   unsigned i;
+   int i;
 
    for (i = 0; !joypad_is_end_of_list(&joyconn[i]); i ++)
      pad_connection_pad_deinit(&joyconn[i], i);
@@ -481,7 +466,7 @@ bool pad_connection_rumble(joypad_connection_t *joyconn,
 const char* pad_connection_get_name(joypad_connection_t *joyconn,
       unsigned pad)
 {
-   if (!joyconn || !joyconn->iface || !joyconn->iface->get_name)
-      return NULL;
-   return joyconn->iface->get_name(joyconn->connection);
+   if (joyconn && joyconn->iface && joyconn->iface->get_name)
+      return joyconn->iface->get_name(joyconn->connection);
+   return NULL;
 }

--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -393,8 +393,7 @@ const char* config_get_joypad_driver_options(void)
  **/
 static const input_device_driver_t *input_joypad_init_first(void *data)
 {
-   unsigned i;
-
+   int i;
    for (i = 0; joypad_drivers[i]; i++)
    {
       if (     joypad_drivers[i]
@@ -429,7 +428,6 @@ bool input_driver_set_rumble(
 
    if (primary_joypad && primary_joypad->set_rumble)
       rumble_state = primary_joypad->set_rumble(joy_idx, effect, strength);
-   
    /* if sec_joypad exists, this set_rumble() return value will replace primary_joypad's return */
    if (sec_joypad     && sec_joypad->set_rumble)
       rumble_state = sec_joypad->set_rumble(joy_idx, effect, strength);
@@ -441,12 +439,12 @@ bool input_driver_set_rumble_gain(
          unsigned gain,
          unsigned input_max_users)
 {
-   unsigned i;
+   int i;
 
    if (  input_driver_st.primary_joypad
       && input_driver_st.primary_joypad->set_rumble_gain)
    {
-      for (i = 0; i < input_max_users; i++)
+      for (i = 0; i < (int)input_max_users; i++)
          input_driver_st.primary_joypad->set_rumble_gain(i, gain);
       return true;
    }
@@ -458,14 +456,9 @@ bool input_driver_set_sensor(
          enum retro_sensor_action action, unsigned rate)
 {
    const input_driver_t *current_driver;
-   void *current_data;
 
    if (!input_driver_st.current_data)
       return false;
-
-   current_driver = input_driver_st.current_driver;
-   current_data   = input_driver_st.current_data;
-
    /* If sensors are disabled, inhibit any enable
     * actions (but always allow disable actions) */
    if (!sensors_enable &&
@@ -473,10 +466,13 @@ bool input_driver_set_sensor(
         (action == RETRO_SENSOR_GYROSCOPE_ENABLE) ||
         (action == RETRO_SENSOR_ILLUMINANCE_ENABLE)))
       return false;
-
-   if (current_driver && current_driver->set_sensor_state)
+   if (   (current_driver = input_driver_st.current_driver)
+       &&  current_driver->set_sensor_state)
+   {
+      void *current_data = input_driver_st.current_data;
       return current_driver->set_sensor_state(current_data,
             port, action, rate);
+   }
 
    return false;
 }
@@ -486,17 +482,15 @@ bool input_driver_set_sensor(
 float input_driver_get_sensor(
          unsigned port, bool sensors_enable, unsigned id)
 {
-   const input_driver_t *current_driver;
-   void *current_data;
-
-   if (!input_driver_st.current_data)
-      return 0.0f;
-
-   current_driver = input_driver_st.current_driver;
-   current_data   = input_driver_st.current_data;
-
-   if (sensors_enable && current_driver->get_sensor_input)
-      return current_driver->get_sensor_input(current_data, port, id);
+   if (input_driver_st.current_data)
+   {
+      const input_driver_t *current_driver = input_driver_st.current_driver;
+      if (sensors_enable && current_driver->get_sensor_input)
+      {
+         void *current_data = input_driver_st.current_data;
+         return current_driver->get_sensor_input(current_data, port, id);
+      }
+   }
 
    return 0.0f;
 }
@@ -504,10 +498,9 @@ float input_driver_get_sensor(
 const input_device_driver_t *input_joypad_init_driver(
       const char *ident, void *data)
 {
-   unsigned i;
-
    if (ident && *ident)
    {
+      int i;
       for (i = 0; joypad_drivers[i]; i++)
       {
          if (string_is_equal(ident, joypad_drivers[i]->ident)
@@ -984,8 +977,8 @@ bool input_keyboard_line_append(
       struct input_keyboard_line *keyboard_line,
       const char *word)
 {
-   unsigned i                  = 0;
-   unsigned len                = (unsigned)strlen(word);
+   int i;
+   size_t len                  = strlen(word);
    char *newbuf                = (char*)realloc(
          keyboard_line->buffer,
          keyboard_line->size + len * 2);
@@ -1032,8 +1025,7 @@ static bool input_remote_init_network(input_remote_t *handle,
 {
    int fd;
    struct addrinfo *res  = NULL;
-
-   port = port + user;
+   port                  = port + user;
 
    if (!network_init())
       return false;
@@ -1041,9 +1033,7 @@ static bool input_remote_init_network(input_remote_t *handle,
    RARCH_LOG("Bringing up remote interface on port %hu.\n",
          (unsigned short)port);
 
-   fd = socket_init((void**)&res, port, NULL, SOCKET_TYPE_DATAGRAM);
-
-   if (fd < 0)
+   if ((fd = socket_init((void**)&res, port, NULL, SOCKET_TYPE_DATAGRAM)) < 0)
       goto error;
 
    handle->net_fd[user] = fd;
@@ -1068,10 +1058,9 @@ error:
 
 void input_remote_free(input_remote_t *handle, unsigned max_users)
 {
-   unsigned user;
-   for (user = 0; user < max_users; user ++)
+   int user;
+   for (user = 0; user < (int)max_users; user ++)
       socket_close(handle->net_fd[user]);
-
    free(handle);
 }
 
@@ -1079,14 +1068,14 @@ static input_remote_t *input_remote_new(
       settings_t *settings,
       uint16_t port, unsigned max_users)
 {
-   unsigned user;
+   int user;
    input_remote_t      *handle = (input_remote_t*)
       calloc(1, sizeof(*handle));
 
    if (!handle)
       return NULL;
 
-   for (user = 0; user < max_users; user ++)
+   for (user = 0; user < (int)max_users; user++)
    {
       handle->net_fd[user] = -1;
       if (settings->bools.network_remote_enable_user[user])
@@ -1138,7 +1127,7 @@ bool input_overlay_add_inputs_inner(overlay_desc_t *desc,
    {
       case OVERLAY_TYPE_BUTTONS:
          {
-            unsigned i;
+            int i;
             bool all_buttons_pressed        = false;
 
             /* Check each bank of the mask */
@@ -1181,36 +1170,31 @@ bool input_overlay_add_inputs_inner(overlay_desc_t *desc,
       case OVERLAY_TYPE_ANALOG_LEFT:
       case OVERLAY_TYPE_ANALOG_RIGHT:
          {
-            float analog_x;
-            float analog_y;
-            float dx;
-            float dy;
-
+            float dx, dy;
             if (ol_state)
             {
                unsigned index_offset = (desc->type == OVERLAY_TYPE_ANALOG_RIGHT) ? 2 : 0;
-               analog_x              = (float)ol_state->analog[index_offset];
-               analog_y              = (float)ol_state->analog[index_offset + 1];
+               float analog_x        = (float)ol_state->analog[index_offset];
+               float analog_y        = (float)ol_state->analog[index_offset + 1];
+
+               dx                    = (analog_x / (float)0x8000) * (desc->range_x / 2.0f);
+               dy                    = (analog_y / (float)0x8000) * (desc->range_y / 2.0f);
             }
             else
             {
                unsigned index        = (desc->type == OVERLAY_TYPE_ANALOG_RIGHT) ?
                   RETRO_DEVICE_INDEX_ANALOG_RIGHT : RETRO_DEVICE_INDEX_ANALOG_LEFT;
-
-               analog_x              = input_state_internal(port, RETRO_DEVICE_ANALOG,
+               float analog_x        = input_state_internal(port, RETRO_DEVICE_ANALOG,
                      index, RETRO_DEVICE_ID_ANALOG_X);
-               analog_y              = input_state_internal(port, RETRO_DEVICE_ANALOG,
+               float analog_y        = input_state_internal(port, RETRO_DEVICE_ANALOG,
                      index, RETRO_DEVICE_ID_ANALOG_Y);
-            }
 
-            dx = (analog_x / (float)0x8000) * (desc->range_x / 2.0f);
-            dy = (analog_y / (float)0x8000) * (desc->range_y / 2.0f);
+               dx                    = (analog_x / (float)0x8000) * (desc->range_x / 2.0f);
+               dy                    = (analog_y / (float)0x8000) * (desc->range_y / 2.0f);
 
-            /* Only modify overlay delta_x/delta_y values
-             * if we are monitoring input from a physical
-             * controller */
-            if (!ol_state)
-            {
+               /* Only modify overlay delta_x/delta_y values
+                * if we are monitoring input from a physical
+                * controller */
                desc->delta_x = dx;
                desc->delta_y = dy;
             }
@@ -1242,7 +1226,7 @@ bool input_overlay_add_inputs_inner(overlay_desc_t *desc,
 bool input_overlay_add_inputs(input_overlay_t *ol,
       bool show_touched, unsigned port)
 {
-   unsigned i;
+   size_t i;
    bool button_pressed             = false;
    input_overlay_state_t *ol_state = &ol->overlay_state;
 
@@ -1273,9 +1257,6 @@ bool input_overlay_add_inputs(input_overlay_t *ol,
  **/
 static bool inside_hitbox(const struct overlay_desc *desc, float x, float y)
 {
-   if (!desc)
-      return false;
-
    switch (desc->hitbox)
    {
       case OVERLAY_HITBOX_RADIAL:
@@ -1286,13 +1267,11 @@ static bool inside_hitbox(const struct overlay_desc *desc, float x, float y)
          float sq_dist = x_dist * x_dist + y_dist * y_dist;
          return (sq_dist <= 1.0f);
       }
-
       case OVERLAY_HITBOX_RECT:
          return
             (fabs(x - desc->x_shift) <= desc->range_x_mod) &&
             (fabs(y - desc->y_shift) <= desc->range_y_mod);
    }
-
    return false;
 }
 
@@ -1333,7 +1312,7 @@ void input_overlay_poll(
       unsigned int base         = 0;
       struct overlay_desc *desc = &ol->active->descs[i];
 
-      if (!inside_hitbox(desc, x, y))
+      if (!desc || !inside_hitbox(desc, x, y))
          continue;
 
       desc->updated = true;
@@ -1508,7 +1487,7 @@ void input_overlay_scale(struct overlay *ol,
       else if (desc->x > (0.5f + 0.0001f))
          x_shift_offset = layout->x_separation;
 
-      desc->x_shift = desc->x + x_shift_offset;
+      desc->x_shift     = desc->x + x_shift_offset;
 
       /* Apply 'y separation' factor */
       if (desc->y < (0.5f - 0.0001f))
@@ -1516,17 +1495,17 @@ void input_overlay_scale(struct overlay *ol,
       else if (desc->y > (0.5f + 0.0001f))
          y_shift_offset = layout->y_separation;
 
-      desc->y_shift = desc->y + y_shift_offset;
+      desc->y_shift     = desc->y + y_shift_offset;
 
-      scale_w       = ol->mod_w * desc->range_x;
-      scale_h       = ol->mod_h * desc->range_y;
-      adj_center_x  = ol->mod_x + desc->x_shift * ol->mod_w;
-      adj_center_y  = ol->mod_y + desc->y_shift * ol->mod_h;
+      scale_w           = ol->mod_w * desc->range_x;
+      scale_h           = ol->mod_h * desc->range_y;
+      adj_center_x      = ol->mod_x + desc->x_shift * ol->mod_w;
+      adj_center_y      = ol->mod_y + desc->y_shift * ol->mod_h;
 
-      desc->mod_w   = 2.0f * scale_w;
-      desc->mod_h   = 2.0f * scale_h;
-      desc->mod_x   = adj_center_x - scale_w;
-      desc->mod_y   = adj_center_y - scale_h;
+      desc->mod_w       = 2.0f * scale_w;
+      desc->mod_h       = 2.0f * scale_h;
+      desc->mod_x       = adj_center_x - scale_w;
+      desc->mod_y       = adj_center_y - scale_h;
    }
 }
 
@@ -1659,22 +1638,21 @@ void input_overlay_set_vertex_geom(input_overlay_t *ol)
 {
    size_t i;
 
+   if (!ol->iface->vertex_geom)
+      return;
+
    if (ol->active->image.pixels)
       ol->iface->vertex_geom(ol->iface_data, 0,
             ol->active->mod_x, ol->active->mod_y,
             ol->active->mod_w, ol->active->mod_h);
 
-   if (ol->iface->vertex_geom)
-      for (i = 0; i < ol->active->size; i++)
-      {
-         struct overlay_desc *desc = &ol->active->descs[i];
-
-         if (!desc->image.pixels)
-            continue;
-
+   for (i = 0; i < ol->active->size; i++)
+   {
+      struct overlay_desc *desc = &ol->active->descs[i];
+      if (desc->image.pixels)
          ol->iface->vertex_geom(ol->iface_data, desc->image_index,
                desc->mod_x, desc->mod_y, desc->mod_w, desc->mod_h);
-      }
+   }
 }
 
 
@@ -1819,10 +1797,10 @@ void input_overlay_auto_rotate_(
          active_overlay_orientation = OVERLAY_ORIENTATION_LANDSCAPE;
       else if (strstr(ol->active->name, "portrait"))
          active_overlay_orientation = OVERLAY_ORIENTATION_PORTRAIT;
+      else /* Sanity check */
+         return;
    }
-
-   /* Sanity check */
-   if (active_overlay_orientation == OVERLAY_ORIENTATION_NONE)
+   else /* Sanity check */
       return;
 
    /* If screen and overlay have the same orientation,
@@ -1871,7 +1849,7 @@ void input_poll_overlay(
       float axis_threshold)
 {
    input_overlay_state_t old_key_state;
-   unsigned i, j;
+   int i, j;
    input_overlay_t *ol                     = (input_overlay_t*)ol_data;
    uint16_t key_mod                        = 0;
    bool polled                             = false;
@@ -5339,7 +5317,7 @@ void input_remapping_set_defaults(bool clear_cache)
 void input_driver_collect_system_input(input_driver_state_t *input_st,
       settings_t *settings, input_bits_t *current_bits)
 {
-   unsigned port;
+   int port;
    rarch_joypad_info_t joypad_info;
    int block_delay                     = settings->uints.input_hotkey_block_delay;
    const input_device_driver_t *joypad = input_st->primary_joypad;
@@ -5362,9 +5340,8 @@ void input_driver_collect_system_input(input_driver_state_t *input_st,
    joypad_info.axis_threshold          = settings->floats.input_axis_threshold;
 
    /* Gather input from each (enabled) joypad */
-   for(port = 0; port < max_users; port++)
+   for (port = 0; port < (int)max_users; port++)
    {
-      unsigned i;
       input_bits_t tmp_bits;
       input_bits_t *loop_bits                = NULL;
       const struct retro_keybind *binds_norm = &input_config_binds[port][RARCH_ENABLE_HOTKEY];
@@ -5385,7 +5362,7 @@ void input_driver_collect_system_input(input_driver_state_t *input_st,
 #ifdef HAVE_MENU
       if (menu_is_alive)
       {
-         unsigned k;
+         int k;
          unsigned x_plus  = RARCH_ANALOG_LEFT_X_PLUS;
          unsigned y_plus  = RARCH_ANALOG_LEFT_Y_PLUS;
          unsigned x_minus = RARCH_ANALOG_LEFT_X_MINUS;
@@ -5434,8 +5411,7 @@ void input_driver_collect_system_input(input_driver_state_t *input_st,
 #ifdef HAVE_MENU
       if (menu_is_alive)
       {
-         unsigned j;
-
+         int j;
          /* Restores analog D-pad binds temporarily overridden. */
          for (j = RETRO_DEVICE_ID_JOYPAD_UP; j <= RETRO_DEVICE_ID_JOYPAD_RIGHT; j++)
          {
@@ -5448,6 +5424,7 @@ void input_driver_collect_system_input(input_driver_state_t *input_st,
       /* we write port 0 directly to input_bits to save one iteration of this loop */
       if (port != 0)
       {
+         int i;
          /* Update compound 'current_bits' record
           * Note: Only digital inputs are considered */
          for(i = 0; i < sizeof(current_bits->data) / sizeof(current_bits->data[0]); i++)
@@ -5455,7 +5432,6 @@ void input_driver_collect_system_input(input_driver_state_t *input_st,
       }
       else if (!all_users_control_menu)
          break;
-
    }
 
 #ifdef HAVE_MENU
@@ -5525,10 +5501,8 @@ void input_driver_collect_system_input(input_driver_state_t *input_st,
 #if defined(HAVE_ACCESSIBILITY) && defined(HAVE_TRANSLATE)
       if (settings->bools.ai_service_enable)
       {
-         unsigned i;
-
+         int i;
          input_st->gamepad_input_override = 0;
-
          for (i = 0; i < MAX_USERS; i++)
          {
             /* Set gamepad input override */

--- a/libretro-common/file/file_path.c
+++ b/libretro-common/file/file_path.c
@@ -148,7 +148,6 @@ void path_linked_list_add_path(struct path_linked_list *in_path_linked_list, cha
 const char *path_get_archive_delim(const char *path)
 {
    char buf[5];
-   const char *delim      = NULL;
    /* Find delimiter position
     * > Since filenames may contain '#' characters,
     *   must loop until we find the first '#' that

--- a/libretro-common/file/file_path.c
+++ b/libretro-common/file/file_path.c
@@ -74,7 +74,7 @@
  * Create a new linked list with one node in it
  * The path on this node will be set to NULL
 **/
-struct path_linked_list* path_linked_list_new()
+struct path_linked_list* path_linked_list_new(void)
 {
    struct path_linked_list* paths_list = (struct path_linked_list*)malloc(sizeof(*paths_list));
    paths_list->next = NULL;
@@ -83,23 +83,19 @@ struct path_linked_list* path_linked_list_new()
 }
 
 /* Free the entire linked list */
-bool path_linked_list_free(struct path_linked_list *in_path_linked_list)
+void path_linked_list_free(struct path_linked_list *in_path_linked_list)
 {
-   struct path_linked_list *node_tmp = NULL;
-
-   node_tmp = (struct path_linked_list*)in_path_linked_list;
+   struct path_linked_list *node_tmp = (struct path_linked_list*)in_path_linked_list;
    while (node_tmp)
    {
       struct path_linked_list *hold = NULL;
       if (node_tmp->path)
          free(node_tmp->path);
-      hold    = (struct path_linked_list*)node_tmp;
+      hold     = (struct path_linked_list*)node_tmp;
       node_tmp = node_tmp->next;
       if (hold)
          free(hold);
    }
-
-   return true;
 }
 
 /**
@@ -151,16 +147,13 @@ void path_linked_list_add_path(struct path_linked_list *in_path_linked_list, cha
  */
 const char *path_get_archive_delim(const char *path)
 {
-   const char *delim      = NULL;
    char buf[5];
-
-   buf[0] = '\0';
-
+   const char *delim      = NULL;
    /* Find delimiter position
     * > Since filenames may contain '#' characters,
     *   must loop until we find the first '#' that
     *   is directly *after* a compression extension */
-   delim = strchr(path, '#');
+   const char *delim      = strchr(path, '#');
 
    while (delim)
    {

--- a/libretro-common/file/file_path.c
+++ b/libretro-common/file/file_path.c
@@ -278,9 +278,6 @@ void fill_pathname(char *out_path, const char *in_path,
 {
    char tmp_path[PATH_MAX_LENGTH];
    char *tok   = NULL;
-
-   tmp_path[0] = '\0';
-
    strlcpy(tmp_path, in_path, sizeof(tmp_path));
    if ((tok = (char*)strrchr(path_basename(tmp_path), '.')))
       *tok = '\0';
@@ -502,8 +499,6 @@ void fill_str_dated_filename(char *out_filename,
    char format[NAME_MAX_LENGTH];
    struct tm tm_;
    time_t cur_time = time(NULL);
-
-   format[0]       = '\0';
 
    rtime_localtime(&cur_time, &tm_);
 
@@ -934,9 +929,6 @@ void fill_pathname_expand_special(char *out_path,
    if (in_path[0] == '~')
    {
       char *home_dir = (char*)malloc(PATH_MAX_LENGTH * sizeof(char));
-
-      home_dir[0] = '\0';
-
       fill_pathname_home_dir(home_dir,
          PATH_MAX_LENGTH * sizeof(char));
 
@@ -1009,7 +1001,6 @@ void fill_pathname_abbreviate_special(char *out_path,
    char home_dir[PATH_MAX_LENGTH];
 
    application_dir[0] = '\0';
-   home_dir[0]        = '\0';
 
    /* application_dir could be zero-string. Safeguard against this.
     *

--- a/libretro-common/file/file_path.c
+++ b/libretro-common/file/file_path.c
@@ -1087,7 +1087,7 @@ void pathname_make_slashes_portable(char *path)
 }
 
 /* Get the number of slashes in a path, returns an integer */
-int get_pathname_num_slashes(const char *in_path)
+static int get_pathname_num_slashes(const char *in_path)
 {
    int num_slashes = 0;
    int i = 0;
@@ -1320,8 +1320,7 @@ void fill_pathname_home_dir(char *s, size_t len)
 bool is_path_accessible_using_standard_io(const char *path)
 {
 #ifdef __WINRT__
-   DWORD trygetattrbs = GetFileAttributesA(path);
-   return trygetattrbs != INVALID_FILE_ATTRIBUTES;
+   return GetFileAttributesA(path) != INVALID_FILE_ATTRIBUTES;
 #else
    return true;
 #endif

--- a/libretro-common/include/file/file_path.h
+++ b/libretro-common/include/file/file_path.h
@@ -64,7 +64,7 @@ struct path_linked_list
 struct path_linked_list* path_linked_list_new(void);
 
 /* Free the entire linked list */
-bool path_linked_list_free(struct path_linked_list *in_path_linked_list);
+void path_linked_list_free(struct path_linked_list *in_path_linked_list);
 
 /**
  * Add a node to the linked list with this path

--- a/libretro-common/lists/string_list.c
+++ b/libretro-common/lists/string_list.c
@@ -258,7 +258,7 @@ void string_list_join_concat(char *buffer, size_t size,
    /* If buffer is already 'full', nothing
     * further can be added
     * > This condition will also be triggered
-    *   if buffer is not NUL-terminated,
+    *   if buffer is not NULL-terminated,
     *   in which case any attempt to increment
     *   buffer or decrement size would lead to
     *   undefined behaviour */
@@ -434,66 +434,66 @@ bool string_separate_noalloc(
 
 /**
  * string_list_find_elem:
- * @list             : pointer to string list
- * @elem             : element to find inside the string list.
+ *
+ * @param list
+ * Pointer to string list
+ * @param elem
+ * Element to find inside the string list.
  *
  * Searches for an element (@elem) inside the string list.
  *
- * Returns: true (1) if element could be found, otherwise false (0).
+ * @return number of element found, otherwise 0.
  */
 int string_list_find_elem(const struct string_list *list, const char *elem)
 {
    if (list)
    {
-      size_t i;
+      int i;
       for (i = 0; i < list->size; i++)
       {
          if (string_is_equal_noncase(list->elems[i].data, elem))
-            return (int)(i + 1);
+            return (i + 1);
       }
    }
-
-   return false;
+   return 0;
 }
 
 /**
  * string_list_find_elem_prefix:
- * @list             : pointer to string list
- * @prefix           : prefix to append to @elem
- * @elem             : element to find inside the string list.
+ *
+ * @param list
+ * Pointer to string list
+ * @param prefix
+ * Prefix to append to @elem
+ * @param elem
+ * Element to find inside the string list.
  *
  * Searches for an element (@elem) inside the string list. Will
  * also search for the same element prefixed by @prefix.
  *
- * Returns: true (1) if element could be found, otherwise false (0).
+ * @return true if element could be found, otherwise false.
  */
 bool string_list_find_elem_prefix(const struct string_list *list,
       const char *prefix, const char *elem)
 {
    size_t i;
    char prefixed[255];
-
    if (!list)
       return false;
-
-   prefixed[0] = '\0';
-
    strlcpy(prefixed, prefix, sizeof(prefixed));
    strlcat(prefixed, elem,   sizeof(prefixed));
-
    for (i = 0; i < list->size; i++)
    {
       if (     string_is_equal_noncase(list->elems[i].data, elem)
             || string_is_equal_noncase(list->elems[i].data, prefixed))
          return true;
    }
-
    return false;
 }
 
 struct string_list *string_list_clone(const struct string_list *src)
 {
-   unsigned i;
+   size_t i;
    struct string_list_elem 
       *elems              = NULL;
    struct string_list 

--- a/libretro-common/string/stdstring.c
+++ b/libretro-common/string/stdstring.c
@@ -208,9 +208,7 @@ void word_wrap(char *dst, size_t dst_size, const char *src, int line_width, int 
 
    while (*src != '\0')
    {
-      unsigned char_len;
-
-      char_len = (unsigned)(utf8skip(src, 1) - src);
+      unsigned char_len = (unsigned)(utf8skip(src, 1) - src);
       counter++;
 
       if (*src == ' ')

--- a/menu/cbs/menu_cbs_deferred_push.c
+++ b/menu/cbs/menu_cbs_deferred_push.c
@@ -313,8 +313,6 @@ static int deferred_push_cursor_manager_list_deferred(
       return -1;
    }
 
-   rdb_path[0] = '\0';
-
    settings = config_get_ptr();
    
    fill_pathname_join(rdb_path,
@@ -426,10 +424,6 @@ static int general_push(menu_displaylist_info_t *info,
          {
             char tmp_str[PATH_MAX_LENGTH];
             char tmp_str2[PATH_MAX_LENGTH];
-
-            tmp_str[0] = '\0';
-            tmp_str2[0] = '\0';
-
             fill_pathname_join(tmp_str, menu->scratch2_buf,
                   menu->scratch_buf, sizeof(tmp_str));
             fill_pathname_join(tmp_str2, menu->scratch2_buf,

--- a/menu/cbs/menu_cbs_label.c
+++ b/menu/cbs/menu_cbs_label.c
@@ -79,9 +79,6 @@ static int action_bind_label_playlist_collection_entry(
       else
       {
          char playlist_name[PATH_MAX_LENGTH];
-
-         playlist_name[0] = '\0';
-
          strlcpy(playlist_name, playlist_file, sizeof(playlist_name));
          path_remove_extension(playlist_name);
 

--- a/menu/cbs/menu_cbs_sublabel.c
+++ b/menu/cbs/menu_cbs_sublabel.c
@@ -172,14 +172,13 @@ static int menu_action_sublabel_contentless_core(file_list_t *list,
       {
          size_t n = 0;
          char tmp[64];
-
-         tmp[0] = '\0';
-
          if (display_licenses)
          {
             tmp[0  ] = '\n';
             tmp[1  ] = '\0';
          }
+         else
+            tmp[0]   = '\0';
          n           = strlcat(tmp, entry->runtime.runtime_str, sizeof(tmp));
 
          if (n < 64 - 1)

--- a/menu/cbs/menu_cbs_title.c
+++ b/menu/cbs/menu_cbs_title.c
@@ -391,9 +391,6 @@ static int action_get_title_deferred_playlist_list(const char *path, const char 
       else
       {
          char playlist_name[PATH_MAX_LENGTH];
-
-         playlist_name[0] = '\0';
-
          strlcpy(playlist_name, playlist_file, sizeof(playlist_name));
          path_remove_extension(playlist_name);
 
@@ -507,8 +504,6 @@ static int action_get_title_dropdown_input_description_common(
 {
    const char *input_label_ptr = input_name;
    char input_label[256];
-
-   input_label[0] = '\0';
 
    if (!string_is_empty(input_label_ptr))
    {
@@ -795,8 +790,6 @@ static int action_get_title_generic(char *s, size_t len,
       if (string_split_noalloc(&list_path, path, "|"))
       {
          char elem0_path[255];
-         elem0_path[0] = '\0';
-
          if (list_path.size > 0)
             strlcpy(elem0_path, list_path.elems[0].data,
                   sizeof(elem0_path));
@@ -910,9 +903,6 @@ static int action_get_title_group_settings(const char *path, const char *label,
       char elem0[255];
       char elem1[255];
       struct string_list list_label = {0};
-      
-      elem0[0] = elem1[0] = '\0';
-
       string_list_initialize(&list_label);
       string_split_noalloc(&list_label, label, "|");
 

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -3654,8 +3654,6 @@ bool menu_entries_search_push(const char *search_term)
    menu_search_terms_t *search = menu_entries_search_get_terms_internal();
    char search_term_clipped[MENU_SEARCH_FILTER_MAX_LENGTH];
 
-   search_term_clipped[0] = '\0';
-
    /* Sanity check + verify whether we have reached
     * the maximum number of allowed search terms */
    if (!search ||
@@ -3761,9 +3759,7 @@ bool menu_shader_manager_save_preset_internal(
    if (!shader || !shader->passes)
       return false;
 
-   type = menu_shader_manager_get_type(shader);
-
-   if (type == RARCH_SHADER_NONE)
+   if ((type = menu_shader_manager_get_type(shader)) == RARCH_SHADER_NONE)
       return false;
 
    if (!string_is_empty(basename))
@@ -3773,10 +3769,7 @@ bool menu_shader_manager_save_preset_internal(
        * in length. We therefore only need to extract the first
        * 7 characters from the extension of the input path
        * to correctly validate a match */
-      char ext_lower[8];
       const char *ext = NULL;
-
-      ext_lower[0]    = '\0';
 
       strlcpy(fullname, basename, sizeof(fullname));
 
@@ -3786,17 +3779,17 @@ bool menu_shader_manager_save_preset_internal(
       /* Copy and convert to lower case */
       if (ext && (*(++ext) != '\0'))
       {
+         char ext_lower[8];
          strlcpy(ext_lower, ext, sizeof(ext_lower));
          string_to_lower(ext_lower);
-      }
-
-      /* Append extension automatically as appropriate. */
-      if (     !string_is_equal(ext_lower, "cgp")
-            && !string_is_equal(ext_lower, "glslp")
-            && !string_is_equal(ext_lower, "slangp"))
-      {
-         const char *preset_ext = video_shader_get_preset_extension(type);
-         strlcat(fullname, preset_ext, sizeof(fullname));
+         /* Append extension automatically as appropriate. */
+         if (     !string_is_equal(ext_lower, "cgp")
+               && !string_is_equal(ext_lower, "glslp")
+               && !string_is_equal(ext_lower, "slangp"))
+         {
+            const char *preset_ext = video_shader_get_preset_extension(type);
+            strlcat(fullname, preset_ext, sizeof(fullname));
+         }
       }
    }
    else
@@ -3832,9 +3825,7 @@ bool menu_shader_manager_save_preset_internal(
 
          if (!path_is_directory(basedir))
          {
-            ret = path_mkdir(basedir);
-
-            if (!ret)
+            if (!(ret = path_mkdir(basedir)))
             {
                RARCH_WARN("[Shaders]: Failed to create preset directory \"%s\".\n", basedir);
                continue;
@@ -3843,11 +3834,9 @@ bool menu_shader_manager_save_preset_internal(
 
          preset_path = buffer;
 
-         ret = video_shader_write_preset(preset_path,
+         if ((ret = video_shader_write_preset(preset_path,
                dir_video_shader,
-               shader, save_reference);
-
-         if (ret)
+               shader, save_reference)))
          {
             RARCH_LOG("[Shaders]: Saved shader preset to \"%s\".\n", preset_path);
             break;
@@ -4064,10 +4053,8 @@ void menu_driver_set_last_shader_path_int(
       return;
 
    /* Get shader type */
-   *type = video_shader_parse_type(shader_path);
-
    /* If type is invalid, do nothing */
-   if (*type == RARCH_SHADER_NONE)
+   if ((*type = video_shader_parse_type(shader_path)) == RARCH_SHADER_NONE)
       return;
 
    /* Cache parent directory */
@@ -4208,13 +4195,9 @@ void menu_driver_set_pending_selection(const char *pending_selection)
 
    /* Reset existing cache */
    selection[0] = '\0';
-
-   /* If path is empty, do nothing */
-   if (string_is_empty(pending_selection))
-      return;
-
-   strlcpy(selection, pending_selection,
-         sizeof(menu_st->pending_selection));
+   if (!string_is_empty(pending_selection))
+      strlcpy(selection, pending_selection,
+            sizeof(menu_st->pending_selection));
 }
 
 void menu_input_search_cb(void *userdata, const char *str)
@@ -4329,17 +4312,13 @@ void menu_driver_set_last_start_content(const char *start_content_path)
          start_content_path, sizeof(menu->last_start_content.directory));
 
    /* Cache file name */
-   archive_delim      = path_get_archive_delim(start_content_path);
-   if (archive_delim)
+   if ((archive_delim = path_get_archive_delim(start_content_path)))
    {
       /* If path references a file inside an
        * archive, must extract the string segment
        * before the archive delimiter (i.e. path of
        * 'parent' archive file) */
-      size_t len;
-
-      archive_path[0] = '\0';
-      len             = (size_t)(1 + archive_delim - start_content_path);
+      size_t len      = (size_t)(1 + archive_delim - start_content_path);
       len             = (len < PATH_MAX_LENGTH) ? len : PATH_MAX_LENGTH;
 
       strlcpy(archive_path, start_content_path, len * sizeof(char));
@@ -4414,10 +4393,9 @@ void menu_entries_append(
       free(list_info.fullpath);
 
    file_list_free_actiondata(list, idx);
-   cbs                             = (menu_file_list_cbs_t*)
-      malloc(sizeof(menu_file_list_cbs_t));
 
-   if (!cbs)
+   if (!(cbs = (menu_file_list_cbs_t*)
+      malloc(sizeof(menu_file_list_cbs_t))))
       return;
 
    cbs->action_sublabel_cache[0]   = '\0';

--- a/playlist.c
+++ b/playlist.c
@@ -261,8 +261,6 @@ static playlist_path_id_t *playlist_path_id_init(const char *path)
    const char *archive_delim   = NULL;
    char real_path[PATH_MAX_LENGTH];
 
-   real_path[0] = '\0';
-
    if (!path_id)
       return NULL;
 
@@ -326,8 +324,6 @@ static bool playlist_path_equal(const char *real_path,
    bool real_path_is_compressed;
    bool entry_real_path_is_compressed;
    char entry_real_path[PATH_MAX_LENGTH];
-
-   entry_real_path[0] = '\0';
 
    /* Sanity check */
    if (string_is_empty(real_path)  ||
@@ -513,8 +509,6 @@ static bool playlist_path_matches_entry(playlist_path_id_t *path_id,
 static bool playlist_core_path_equal(const char *real_core_path, const char *entry_core_path, const playlist_config_t *config)
 {
    char entry_real_core_path[PATH_MAX_LENGTH];
-
-   entry_real_core_path[0] = '\0';
 
    /* Sanity check */
    if (string_is_empty(real_core_path) || string_is_empty(entry_core_path))
@@ -965,11 +959,8 @@ bool playlist_push_runtime(playlist_t *playlist,
       goto error;
    }
 
-   real_core_path[0] = '\0';
-
    /* Get path ID */
-   path_id = playlist_path_id_init(entry->path);
-   if (!path_id)
+   if (!(path_id = playlist_path_id_init(entry->path)))
       goto error;
 
    /* Get 'real' core path */
@@ -1237,8 +1228,6 @@ bool playlist_push(playlist_t *playlist,
    const char *core_name       = entry->core_name;
    bool entry_updated          = false;
 
-   real_core_path[0] = '\0';
-
    if (!playlist || !entry)
       goto error;
 
@@ -1249,8 +1238,7 @@ bool playlist_push(playlist_t *playlist,
    }
 
    /* Get path ID */
-   path_id = playlist_path_id_init(entry->path);
-   if (!path_id)
+   if (!(path_id = playlist_path_id_init(entry->path)))
       goto error;
 
    /* Get 'real' core path */
@@ -1338,13 +1326,13 @@ bool playlist_push(playlist_t *playlist,
          {
             char real_rom_path[PATH_MAX_LENGTH];
 
-            real_rom_path[0] = '\0';
-
             if (!string_is_empty(entry->subsystem_roms->elems[j].data))
             {
                strlcpy(real_rom_path, entry->subsystem_roms->elems[j].data, sizeof(real_rom_path));
                path_resolve_realpath(real_rom_path, sizeof(real_rom_path), true);
             }
+            else
+               real_rom_path[0] = '\0';
 
             if (!playlist_path_equal(real_rom_path, roms->elems[j].data,
                      &playlist->config))
@@ -3104,9 +3092,6 @@ bool playlist_entries_are_equal(
    char real_path_a[PATH_MAX_LENGTH];
    char real_core_path_a[PATH_MAX_LENGTH];
 
-   real_path_a[0]      = '\0';
-   real_core_path_a[0] = '\0';
-
    /* Sanity check */
    if (!entry_a || !entry_b || !config)
       return false;
@@ -3123,6 +3108,8 @@ bool playlist_entries_are_equal(
       strlcpy(real_path_a, entry_a->path, sizeof(real_path_a));
       path_resolve_realpath(real_path_a, sizeof(real_path_a), true);
    }
+   else
+      real_path_a[0]      = '\0';
 
    if (!playlist_path_equal(
          real_path_a, entry_b->path, config))
@@ -3137,6 +3124,8 @@ bool playlist_entries_are_equal(
          playlist_resolve_path(PLAYLIST_SAVE, true,
                real_core_path_a, sizeof(real_core_path_a));
    }
+   else
+      real_core_path_a[0] = '\0';
 
    return playlist_core_path_equal(real_core_path_a, entry_b->core_path, config);
 }
@@ -3312,8 +3301,6 @@ void playlist_set_default_core_path(playlist_t *playlist, const char *core_path)
 
    if (!playlist || string_is_empty(core_path))
       return;
-
-   real_core_path[0] = '\0';
 
    /* Get 'real' core path */
    strlcpy(real_core_path, core_path, sizeof(real_core_path));

--- a/retroarch.c
+++ b/retroarch.c
@@ -717,8 +717,6 @@ void retroarch_path_set_redirect(settings_t *settings)
    bool savestates_in_content_dir              = settings->bools.savestates_in_content_dir;
 
    content_dir_name[0]  = '\0';
-   new_savefile_dir[0]  = '\0';
-   new_savestate_dir[0] = '\0';
 
    /* Initialize current save directories
     * with the values from the config. */
@@ -925,7 +923,6 @@ void path_set_special(char **argv, unsigned num_content)
    struct string_list subsystem_paths  = {0};
    runloop_state_t         *runloop_st = runloop_state_get_ptr();
    const char *savestate_dir           = runloop_st->savestate_dir;
-
 
    /* First content file is the significant one. */
    runloop_path_set_basename(argv[0]);
@@ -1239,9 +1236,6 @@ void ram_state_to_file(void)
 enum rarch_content_type path_is_media_type(const char *path)
 {
    char ext_lower[128];
-
-   ext_lower[0] = '\0';
-
    strlcpy(ext_lower, path_get_extension(path), sizeof(ext_lower));
 
    string_to_lower(ext_lower);
@@ -4326,8 +4320,6 @@ static void retroarch_parse_input_libretro_path(const char *path)
    const char *core_path  = NULL;
    bool core_path_matched = false;
    char tmp_path[PATH_MAX_LENGTH];
-
-   tmp_path[0] = '\0';
 
    if (string_is_empty(path))
       goto end;

--- a/runloop.c
+++ b/runloop.c
@@ -5760,8 +5760,6 @@ bool runloop_path_init_subsystem(void)
             const struct retro_subsystem_memory_info *mem =
                (const struct retro_subsystem_memory_info*)
                &info->roms[i].memory[j];
-
-            path[0] = ext[0] = '\0';
             ext[0]  = '.';
             ext[1]  = '\0';
             strlcat(ext, mem->extension, sizeof(ext));

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -568,9 +568,6 @@ static bool content_file_list_set_info(
       {
          char archive_path[PATH_MAX_LENGTH];
          size_t len      = 0;
-
-         archive_path[0] = '\0';
-
          /* Extract path of parent archive */
          if ((len = (size_t)(1 + archive_delim - path))
                  >= PATH_MAX_LENGTH)
@@ -961,9 +958,9 @@ static bool content_file_load(
       const char *content_path = NULL;
       uint8_t *content_data    = NULL;
       size_t content_size      = 0;
-      const char *valid_exts   = special ?
-            special->roms[i].valid_extensions :
-                  content_ctx->valid_extensions;
+      const char *valid_exts   = special
+            ? special->roms[i].valid_extensions
+            : content_ctx->valid_extensions;
       bool content_compressed  = false;
 
       /* Get content path */
@@ -1025,7 +1022,7 @@ static bool content_file_load(
             if (!system->supports_vfs &&
                 !is_path_accessible_using_standard_io(content_path))
             {
-               /* Try copy ACL to file first. If successful, this should mean that cores using standard I/O can still access them
+               /* Try to copy ACL to file first. If successful, this should mean that cores using standard I/O can still access them
                *  It would be better to set the ACL to allow full access for all application packages. However,
                *  this is substantially easier than writing out new functions to do this
                *  Copy ACL from localstate
@@ -1042,7 +1039,6 @@ static bool content_file_load(
                   char new_path[PATH_MAX_LENGTH];
 
                   new_path[0] = '\0';
-                  new_basedir[0] = '\0';
 
                   RARCH_LOG("[Content]: Core does not support VFS"
                      " - copying to cache directory.\n");
@@ -1050,6 +1046,8 @@ static bool content_file_load(
                   if (!string_is_empty(content_ctx->directory_cache))
                      strlcpy(new_basedir, content_ctx->directory_cache,
                         sizeof(new_basedir));
+                  else
+                     new_basedir[0] = '\0';
 
                   if (string_is_empty(new_basedir) ||
                      !path_is_directory(new_basedir) ||
@@ -1559,8 +1557,6 @@ static void task_push_to_history_list(
       const char *path_content       = path_get(RARCH_PATH_CONTENT);
       struct retro_system_info *info = &runloop_state_get_ptr()->system.info;
 
-      tmp[0] = '\0';
-
       if (!string_is_empty(path_content))
       {
          strlcpy(tmp, path_content, sizeof(tmp));
@@ -1569,6 +1565,8 @@ static void task_push_to_history_list(
          if (!launched_from_menu)
             path_resolve_realpath(tmp, sizeof(tmp), true);
       }
+      else
+         tmp[0] = '\0';
 
 #ifdef HAVE_MENU
       /* Push quick menu onto menu stack */

--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -537,9 +537,6 @@ static void gdi_prune(database_info_handle_t *db, const char *name)
 static enum msg_file_type extension_to_file_type(const char *ext)
 {
    char ext_lower[6];
-
-   ext_lower[0] = '\0';
-
    /* Copy and convert to lower case */
    strlcpy(ext_lower, ext, sizeof(ext_lower));
    string_to_lower(ext_lower);
@@ -677,7 +674,6 @@ static int database_info_list_iterate_end_no_match(
                      + 1 < PATH_MAX_LENGTH)
             {
                char new_path[PATH_MAX_LENGTH];
-               new_path[0] = '\0';
                strlcpy(new_path, path, sizeof(new_path));
                new_path[path_len] = '#';
                strlcpy(new_path + path_len + 1,

--- a/tasks/task_decompress.c
+++ b/tasks/task_decompress.c
@@ -295,14 +295,10 @@ void *task_push_decompress(
    if (task_check_decompress(source_file))
       return NULL;
 
-   s              = (decompress_state_t*)calloc(1, sizeof(*s));
-
-   if (!s)
+   if (!(s = (decompress_state_t*)calloc(1, sizeof(*s))))
       return NULL;
 
-   t                   = (retro_task_t*)calloc(1, sizeof(*t));
-
-   if (!t)
+   if (!(t = (retro_task_t*)calloc(1, sizeof(*t))))
    {
       free(s);
       return NULL;

--- a/tasks/task_pl_thumbnail_download.c
+++ b/tasks/task_pl_thumbnail_download.c
@@ -183,7 +183,6 @@ void cb_http_task_download_pl_thumbnail(
    http_transfer_data_t *data  = (http_transfer_data_t*)task_data;
    file_transfer_t *transf     = (file_transfer_t*)user_data;
    pl_thumb_handle_t *pl_thumb = NULL;
-   output_dir[0]               = '\0';
 
    /* Update pl_thumb task status
     * > Do this first, to minimise the risk of hanging

--- a/tasks/task_screenshot.c
+++ b/tasks/task_screenshot.c
@@ -191,9 +191,28 @@ task_finished:
 }
 
 #if defined(HAVE_GFX_WIDGETS)
-void task_screenshot_callback(retro_task_t *task,
+static void task_screenshot_callback(retro_task_t *task,
       void *task_data,
-      void *user_data, const char *error);
+      void *user_data, const char *error)
+{
+   screenshot_task_state_t *state = NULL;
+
+   if (!task)
+      return;
+
+   if (!(state = (screenshot_task_state_t*)task->state))
+      return;
+
+   if (!state->silence && state->widgets_ready)
+      gfx_widget_screenshot_taken(dispwidget_get_ptr(),
+            state->shotname, state->filename);
+
+   free(state);
+   /* Must explicitly set task->state to NULL here,
+    * to avoid potential heap-use-after-free errors */
+   state       = NULL;
+   task->state = NULL;
+}
 #endif
 
 /* Take frame bottom-up. */
@@ -218,8 +237,6 @@ static bool screenshot_dump(
    settings_t *settings           = config_get_ptr();
    screenshot_task_state_t *state = (screenshot_task_state_t*)
          calloc(1, sizeof(*state));
-
-   state->shotname[0]             = '\0';
 
    /* If fullpath is true, name_base already contains a 
     * static path + filename to save the screenshot to. */
@@ -254,8 +271,6 @@ static bool screenshot_dump(
       else
       {
          char new_screenshot_dir[PATH_MAX_LENGTH];
-
-         new_screenshot_dir[0] = '\0';
 
          if (!string_is_empty(screenshot_dir))
          {
@@ -333,8 +348,7 @@ static bool screenshot_dump(
    }
 
 #if defined(HAVE_RPNG)
-   buf = (uint8_t*)malloc(width * height * 3);
-   if (!buf)
+   if (!(buf = (uint8_t*)malloc(width * height * 3)))
    {
       free(state);
       return false;

--- a/verbosity.c
+++ b/verbosity.c
@@ -438,7 +438,6 @@ void rarch_log_file_init(
    static char timestamped_log_file_name[64] = {0};
    bool logging_to_file                      = g_verbosity->initialized;
 
-   log_directory[0]                          = '\0';
    log_file_path[0]                          = '\0';
 
    /* If this is the first run, generate a timestamped log


### PR DESCRIPTION
In general:
* Prefer 'int' and 'size_t' as loop counter type instead of 'unsigned' - more optimized, produces
less instructions due to not having to account for infinite loops - see top answer - https://stackoverflow.com/questions/35385157/is-copying-in-a-loop-less-efficient-than-memcpy#:~:text=Yes%2C%20it's%20inefficient%2C%20not%20because,finds%20the%20terminating%20zero%20byte.
* Take advantage of fact that strlcpy already NULL-terminates, so don't do this explicitly
outside if we're just going to end up calling strlcpy/fill_pathname_join on it anyway