### PR TITLE
ui/drivers/cocoa: fix -fno-common build

### DIFF
--- a/ui/drivers/cocoa/apple_platform.h
+++ b/ui/drivers/cocoa/apple_platform.h
@@ -34,10 +34,8 @@
 
 #if defined(HAVE_COCOA_METAL) || defined(HAVE_COCOATOUCH)
 extern id<ApplePlatform> apple_platform;
-
-id<ApplePlatform> apple_platform;
 #else
-id apple_platform;
+extern id apple_platform;
 #endif
 
 #if defined(HAVE_COCOATOUCH)

--- a/ui/drivers/cocoa/cocoa_common.m
+++ b/ui/drivers/cocoa/cocoa_common.m
@@ -38,6 +38,11 @@
 #include "../../input/drivers/cocoa_input.h"
 #include "../../input/drivers_keyboard/keyboard_event_apple.h"
 
+#if defined(HAVE_COCOA_METAL) || defined(HAVE_COCOATOUCH)
+id<ApplePlatform> apple_platform;
+#else
+id apple_platform;
+#endif
 
 static CocoaView* g_instance;
 


### PR DESCRIPTION
`llvm-11` changed the default from `-fcommon` to `-fno-common`:
  https://reviews.llvm.org/D75056

As a result build fails as:

    LD retroarch
    duplicate symbol '_apple_platform' in:
        obj-unix/release/ui/drivers/ui_cocoa.o
        obj-unix/release/ui/drivers/cocoa/cocoa_common.o
    duplicate symbol '_apple_platform' in:
        obj-unix/release/ui/drivers/ui_cocoa.o
        obj-unix/release/gfx/drivers_context/cocoa_gl_ctx.o
    ld: 2 duplicate symbols for architecture x86_64

The change moves `apple_platform` definition from `apple_platform.h`
to `cocoa_common.m` leaving only declaration in `apple_platform.h`.

## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

[Description of the pull request, detail any issues you are fixing or any features you are implementing]

## Related Issues

https://github.com/libretro/RetroArch/issues/14025

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
