### PR TITLE
(Ozone+XMB) Thumbnail fixes

### DIFF
--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -64,7 +64,7 @@
 #define ANIMATION_CURSOR_DURATION      133
 #define ANIMATION_CURSOR_PULSE         500
 
-#define OZONE_THUMBNAIL_STREAM_DELAY 166.66667f
+#define OZONE_THUMBNAIL_STREAM_DELAY   5 * 16.66667f
 
 #define FONT_SIZE_FOOTER            18
 #define FONT_SIZE_TITLE             36
@@ -76,8 +76,8 @@
 #define HEADER_HEIGHT 87
 #define FOOTER_HEIGHT 78
 
-#define ENTRY_PADDING_HORIZONTAL_HALF  60
-#define ENTRY_PADDING_HORIZONTAL_FULL  150
+#define ENTRY_PADDING_HORIZONTAL_HALF  40
+#define ENTRY_PADDING_HORIZONTAL_FULL  140
 #define ENTRY_PADDING_VERTICAL         20
 #define ENTRY_HEIGHT                   50
 #define ENTRY_SPACING                  8
@@ -577,6 +577,9 @@ struct ozone_handle
    char selection_lastplayed[255];
    char selection_entry_enumeration[255];
 
+   char thumbnails_left_status_prev;
+   char thumbnails_right_status_prev;
+
    bool cursor_in_sidebar;
    bool cursor_in_sidebar_old;
 
@@ -607,9 +610,11 @@ struct ozone_handle
    bool show_thumbnail_bar;
    bool skip_thumbnail_reset;
    bool pending_hide_thumbnail_bar;
+   bool no_thumbnail_available;
    bool fullscreen_thumbnails_available;
    bool show_fullscreen_thumbnails;
    bool selection_core_is_viewer;
+   bool selection_core_is_viewer_real;
 
    bool force_metadata_display;
 
@@ -3296,6 +3301,38 @@ static void ozone_thumbnail_bar_hide_end(void *userdata)
    ozone_handle_t *ozone             = (ozone_handle_t*) userdata;
    ozone->show_thumbnail_bar         = false;
    ozone->pending_hide_thumbnail_bar = false;
+   ozone->need_compute               = true;
+}
+
+static bool ozone_is_load_content_playlist(void *userdata)
+{
+   ozone_handle_t *ozone             = (ozone_handle_t*) userdata;
+   menu_entry_t entry;
+
+   if (ozone->depth != 4 || ozone->is_db_manager_list || ozone->is_file_list)
+      return false;
+
+   MENU_ENTRY_INIT(entry);
+   entry.path_enabled     = false;
+   entry.value_enabled    = false;
+   entry.sublabel_enabled = false;
+   menu_entry_get(&entry, 0, 0, NULL, true);
+
+   return entry.type == FILE_TYPE_RPL_ENTRY;
+}
+
+static bool ozone_is_running_quick_menu(void)
+{
+   menu_entry_t entry;
+
+   MENU_ENTRY_INIT(entry);
+   entry.path_enabled     = false;
+   entry.value_enabled    = false;
+   entry.sublabel_enabled = false;
+   menu_entry_get(&entry, 0, 0, NULL, true);
+
+   return string_is_equal(entry.label, "resume_content") ||
+          string_is_equal(entry.label, "state_slot");
 }
 
 static void ozone_update_savestate_thumbnail_path(void *data, unsigned i)
@@ -3314,11 +3351,16 @@ static void ozone_update_savestate_thumbnail_path(void *data, unsigned i)
          ozone->savestate_thumbnail_file_path,
          sizeof(ozone->prev_savestate_thumbnail_file_path));
 
+   ozone->selection_core_is_viewer         = ozone->selection_core_is_viewer_real;
+
+   if (ozone->skip_thumbnail_reset)
+      return;
+
    ozone->savestate_thumbnail_file_path[0] = '\0';
 
    /* Savestate thumbnails are only relevant
     * when viewing the running quick menu or state slots */
-   if (!((ozone->is_quick_menu || ozone->is_state_slot) && ozone->libretro_running))
+   if (!((ozone->is_quick_menu && ozone_is_running_quick_menu()) || ozone->is_state_slot))
       return;
 
    if (savestate_thumbnail_enable)
@@ -3347,7 +3389,7 @@ static void ozone_update_savestate_thumbnail_path(void *data, unsigned i)
             /* State slot dropdown */
             if (string_to_unsigned(entry.label) == MENU_ENUM_LABEL_STATE_SLOT)
             {
-               state_slot = i - 1;
+               state_slot           = i - 1;
                ozone->is_state_slot = true;
             }
 
@@ -3397,12 +3439,12 @@ static void ozone_update_savestate_thumbnail_image(void *data)
    settings_t *settings  = config_get_ptr();
    unsigned thumbnail_upscale_threshold
                          = settings->uints.gfx_thumbnail_upscale_threshold;
-   if (!ozone)
+   if (!ozone || ozone->skip_thumbnail_reset)
       return;
 
    /* Savestate thumbnails are only relevant
     * when viewing the running quick menu or state slots */
-   if (!((ozone->is_quick_menu || ozone->is_state_slot) && ozone->libretro_running))
+   if (!((ozone->is_quick_menu && ozone_is_running_quick_menu()) || ozone->is_state_slot))
       return;
 
    /* If path is empty, just reset thumbnail */
@@ -3460,11 +3502,7 @@ static void ozone_entries_update_thumbnail_bar(
     *   to track mid-animation state changes... */
    if (  !ozone->cursor_in_sidebar &&
          (!ozone->show_thumbnail_bar || ozone->pending_hide_thumbnail_bar) &&
-         (
-            (is_playlist && ozone->depth == 1) ||
-            (ozone->want_thumbnail_bar) ||
-            (ozone->is_state_slot)
-         )
+         (ozone->want_thumbnail_bar || ozone->is_state_slot)
       )
    {
       if (allow_animation)
@@ -3522,6 +3560,8 @@ static bool ozone_is_playlist(ozone_handle_t *ozone, bool depth)
       switch (ozone->tabs[ozone->categories_selection_ptr])
       {
          case OZONE_SYSTEM_TAB_MAIN:
+            if (ozone_is_load_content_playlist(ozone))
+               return true;
          case OZONE_SYSTEM_TAB_SETTINGS:
          case OZONE_SYSTEM_TAB_ADD:
 #ifdef HAVE_NETWORKING
@@ -3571,6 +3611,10 @@ static void ozone_sidebar_update_collapse(
    entry.duration            = ANIMATION_CURSOR_DURATION;
 
    gfx_animation_kill_by_tag(&tag);
+
+   /* Playlists under 'Load Content' don't need sidebar animations */
+   if (is_playlist && ozone->depth > 3)
+      goto end;
 
    /* Collapse it */
    if (ozone_collapse_sidebar || (is_playlist && !ozone->cursor_in_sidebar))
@@ -3628,6 +3672,7 @@ static void ozone_sidebar_update_collapse(
       }
    }
 
+end:
    ozone_entries_update_thumbnail_bar(ozone, is_playlist, allow_animation);
 }
 
@@ -3695,7 +3740,10 @@ static void ozone_update_content_metadata(ozone_handle_t *ozone)
    else
       ozone->selection_core_is_viewer    = false;
 
-   if (ozone->is_playlist && playlist)
+   ozone->selection_core_is_viewer_real  = ozone->selection_core_is_viewer;
+
+   if ((ozone->is_playlist && playlist) ||
+         (ozone->is_db_manager_list && ozone->depth == 4))
    {
       const char *core_label             = NULL;
       const struct playlist_entry *entry = NULL;
@@ -3838,6 +3886,7 @@ static void ozone_leave_sidebar(ozone_handle_t *ozone,
    entry.userdata                   = NULL;
 
    gfx_animation_push(&entry);
+
    ozone_sidebar_update_collapse(ozone, ozone_collapse_sidebar, true);
 }
 
@@ -4155,10 +4204,7 @@ static void ozone_refresh_sidebars(
 
    /* Set thumbnail bar position */
    if (  !ozone->cursor_in_sidebar &&
-         (  (is_playlist && ozone->depth == 1) ||
-            (ozone->want_thumbnail_bar) ||
-            (ozone->is_state_slot)
-         )
+         (ozone->want_thumbnail_bar || ozone->is_state_slot)
       )
    {
       ozone->animations.thumbnail_bar_position = ozone->dimensions.thumbnail_bar_width;
@@ -4623,6 +4669,8 @@ static void ozone_draw_no_thumbnail_available(
    gfx_display_ctx_driver_t *dispctx = p_disp->dispctx;
    float                        *col = ozone->theme->entries_icon;
 
+   ozone->no_thumbnail_available     = true;
+
    if (dispctx)
    {
       if (dispctx->blend_begin)
@@ -4651,9 +4699,9 @@ static void ozone_draw_no_thumbnail_available(
    gfx_display_draw_text(
          ozone->fonts.footer.font,
          msg_hash_to_str(MSG_NO_THUMBNAIL_AVAILABLE),
-         x_position + sidebar_width   / 2,
-           video_height / 2 + icon_size / 2 
-         + ozone->fonts.footer.line_ascender - y_offset,
+         x_position + sidebar_width / 2,
+         video_height / 2 + icon_size / 2
+            + ozone->fonts.footer.line_ascender - y_offset,
          video_width,
          video_height,
          ozone->theme->text_rgba,
@@ -4846,8 +4894,8 @@ static void ozone_compute_entries_position(
 
             if (ozone->depth == 1)
                sublabel_max_width -= (unsigned) ozone->dimensions_sidebar_width;
-            if (ozone->show_thumbnail_bar && ozone->depth < 3)
-               sublabel_max_width += -(ozone->dimensions.thumbnail_bar_width / 2) + ozone->dimensions.sidebar_entry_icon_padding;
+            if (ozone->show_thumbnail_bar)
+               sublabel_max_width -= ozone->dimensions.thumbnail_bar_width - entry_padding * 2;
 
             (ozone->word_wrap)(wrapped_sublabel_str, sizeof(wrapped_sublabel_str), entry.sublabel,
                   sublabel_max_width / 
@@ -4924,13 +4972,24 @@ static void ozone_draw_entries(
 
    /* Increase entry width, or rather decrease padding between
     * entries and thumbnails when thumbnail bar is visible */
-   if (ozone->show_thumbnail_bar)
+   if (ozone->show_thumbnail_bar && ozone->depth > 1)
    {
-      entry_width += (entry_padding / 2);
+      unsigned entry_padding_old = entry_padding;
+
+      if (ozone->is_playlist && !ozone->is_quick_menu)
+      {
+         entry_width   += entry_padding / 1.25f;
+         entry_padding /= 1.25f;
+      }
+      else
+         entry_width   += entry_padding / 1.5f;
 
       /* Limit entry width to prevent animation bouncing */
       if (entry_width > entry_width_max)
-         entry_width = entry_width_max;
+      {
+         entry_padding = entry_padding_old;
+         entry_width   = entry_width_max;
+      }
    }
 
    if (old_list)
@@ -5175,8 +5234,13 @@ border_iterate:
 
             if (ozone->depth == 1)
                sublabel_max_width -= (unsigned) ozone->dimensions_sidebar_width;
-            if (ozone->show_thumbnail_bar && ozone->depth < 3)
-               sublabel_max_width += -(ozone->dimensions.thumbnail_bar_width / 2) + ozone->dimensions.sidebar_entry_icon_padding;
+            if (ozone->show_thumbnail_bar)
+            {
+               if (ozone->is_quick_menu && ozone_is_running_quick_menu())
+                  sublabel_max_width -= ozone->dimensions.thumbnail_bar_width - entry_padding * 2;
+               else
+                  sublabel_max_width -= ozone->dimensions.thumbnail_bar_width - entry_padding;
+            }
 
             wrapped_sublabel_str[0] = '\0';
             (ozone->word_wrap)(wrapped_sublabel_str, sizeof(wrapped_sublabel_str),
@@ -5458,9 +5522,6 @@ static void ozone_draw_thumbnail_bar(
          gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_LEFT) &&
          !ozone->selection_core_is_viewer;
 
-   if (ozone->is_quick_menu && !ozone->libretro_running)
-      ozone->selection_core_is_viewer = false;
-
    /* Special "viewer" mode for savestate thumbnails */
    if ((ozone->want_thumbnail_bar && !string_is_empty(ozone->savestate_thumbnail_file_path)) ||
          ozone->is_state_slot)
@@ -5485,9 +5546,14 @@ static void ozone_draw_thumbnail_bar(
       }
    }
    else if (!ozone->want_thumbnail_bar)
-   {
-      ozone->selection_core_is_viewer = false;
       return;
+   else if (ozone->no_thumbnail_available)
+   {
+      /* Remove useless re-blinking of "No thumbnail available" */
+      if (show_right_thumbnail && ozone->thumbnails.right.status == GFX_THUMBNAIL_STATUS_UNKNOWN)
+         show_right_thumbnail = false;
+      if (show_left_thumbnail && ozone->thumbnails.left.status == GFX_THUMBNAIL_STATUS_UNKNOWN)
+         show_left_thumbnail  = false;
    }
 
    /* If this entry is associated with the image viewer
@@ -5536,6 +5602,7 @@ static void ozone_draw_thumbnail_bar(
 
    /* > If we have a right thumbnail, show it */
    if (show_right_thumbnail)
+   {
       gfx_thumbnail_draw(
             userdata,
             video_width,
@@ -5550,6 +5617,8 @@ static void ozone_draw_thumbnail_bar(
             thumbnail_height,
             right_thumbnail_alignment,
             1.0f, 1.0f, NULL);
+      ozone->no_thumbnail_available = false;
+   }
    /* > If we have neither a right thumbnail nor
     *   a left thumbnail to show in its place,
     *   display 'no thumbnail available' message */
@@ -5626,6 +5695,7 @@ static void ozone_draw_thumbnail_bar(
             left_thumbnail_alignment,
             left_thumbnail_alpha,
             1.0f, NULL);
+      ozone->no_thumbnail_available = false;
    }
 
    /* > Display content metadata in the bottom
@@ -6802,6 +6872,22 @@ static void ozone_set_thumbnail_content(void *data, const char *s)
          else
             gfx_thumbnail_set_content_playlist(ozone->thumbnail_path_data,
                   NULL, selection);
+
+         switch (ozone->tabs[ozone->categories_selection_ptr])
+         {
+#if defined(HAVE_FFMPEG) || defined(HAVE_MPV)
+            case OZONE_SYSTEM_TAB_VIDEO:
+#endif
+            case OZONE_SYSTEM_TAB_MUSIC:
+               ozone->want_thumbnail_bar              = false;
+               ozone->fullscreen_thumbnails_available = false;
+               break;
+
+            default:
+               ozone->want_thumbnail_bar              = true;
+               ozone->fullscreen_thumbnails_available = true;
+               break;
+         }
       }
    }
    else if (ozone->is_db_manager_list)
@@ -6839,6 +6925,7 @@ static void ozone_set_thumbnail_content(void *data, const char *s)
          entry.value_enabled      = false;
          entry.sublabel_enabled   = false;
          menu_entry_get(&entry, 0, selection, NULL, true);
+
          if (!string_is_empty(entry.path) && !string_is_empty(node->fullpath))
             gfx_thumbnail_set_content_image(ozone->thumbnail_path_data, node->fullpath, entry.path);
       }
@@ -6924,14 +7011,34 @@ static bool INLINE ozone_metadata_override_available(ozone_handle_t *ozone)
     * only 'ozone->is_playlist' will be evaluated,
     * so this isn't too much of a performance hog... */
    return ozone->is_playlist
-      &&  ozone->show_thumbnail_bar 
-      && !ozone->selection_core_is_viewer 
-      && (ozone->thumbnails.left.status != GFX_THUMBNAIL_STATUS_MISSING)
-      && gfx_thumbnail_is_enabled(ozone->thumbnail_path_data,
-            GFX_THUMBNAIL_LEFT)
-      && (ozone->thumbnails.right.status != GFX_THUMBNAIL_STATUS_MISSING) 
-      && gfx_thumbnail_is_enabled(ozone->thumbnail_path_data,
-            GFX_THUMBNAIL_RIGHT);
+      &&  ozone->show_thumbnail_bar
+      && !ozone->selection_core_is_viewer
+      && (ozone->thumbnails.left.status == GFX_THUMBNAIL_STATUS_AVAILABLE ||
+            (ozone->thumbnails.left.status < GFX_THUMBNAIL_STATUS_AVAILABLE
+               && ozone->thumbnails_left_status_prev <= GFX_THUMBNAIL_STATUS_AVAILABLE))
+      && (ozone->thumbnails.right.status == GFX_THUMBNAIL_STATUS_AVAILABLE ||
+            (ozone->thumbnails.right.status < GFX_THUMBNAIL_STATUS_AVAILABLE
+               && ozone->thumbnails_right_status_prev <= GFX_THUMBNAIL_STATUS_AVAILABLE));
+}
+
+static bool INLINE ozone_fullscreen_thumbnails_available(ozone_handle_t *ozone)
+{
+   bool ret =
+         ozone->fullscreen_thumbnails_available
+      && !ozone->cursor_in_sidebar
+      && ozone->show_thumbnail_bar
+      && ((ozone->thumbnails.right.status     != GFX_THUMBNAIL_STATUS_MISSING) ||
+          (ozone->thumbnails.left.status      != GFX_THUMBNAIL_STATUS_MISSING) ||
+          (ozone->thumbnails.savestate.status != GFX_THUMBNAIL_STATUS_MISSING))
+      && (gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_RIGHT) ||
+          gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_LEFT));
+
+   if (ozone->is_state_slot &&
+         (ozone->thumbnails.savestate.status == GFX_THUMBNAIL_STATUS_MISSING ||
+          ozone->thumbnails.savestate.status == GFX_THUMBNAIL_STATUS_UNKNOWN))
+      ret = false;
+
+   return ret;
 }
 
 static bool ozone_is_current_entry_settings(size_t current_selection)
@@ -7289,6 +7396,19 @@ static enum menu_action ozone_parse_menu_entry_action(
       case MENU_ACTION_OK:
          ozone->cursor_mode = false;
 
+         if (ozone->is_state_slot)
+            ozone->skip_thumbnail_reset = true;
+
+         /* Open fullscreen thumbnail with Ok when core is running
+            to prevent accidental imageviewer core launch */
+         if (ozone->libretro_running && ozone->is_file_list &&
+               ozone->show_thumbnail_bar && ozone->fullscreen_thumbnails_available)
+         {
+            ozone_show_fullscreen_thumbnails(ozone);
+            new_action = MENU_ACTION_NOOP;
+            break;
+         }
+
          if (ozone->cursor_in_sidebar)
          {
             if (!ozone->empty_playlist)
@@ -7299,6 +7419,9 @@ static enum menu_action ozone_parse_menu_entry_action(
          break;
       case MENU_ACTION_CANCEL:
          ozone->cursor_mode = false;
+
+         if (ozone->is_state_slot)
+            ozone->skip_thumbnail_reset = true;
 
          /* If this is a playlist, handle 'backing out'
           * of a search, if required */
@@ -7496,6 +7619,7 @@ static void *ozone_init(void **userdata, bool video_is_threaded)
 
    ozone->animations.thumbnail_bar_position     = 0.0f;
    ozone->show_thumbnail_bar                    = false;
+   ozone->want_thumbnail_bar                    = false;
    ozone->pending_hide_thumbnail_bar            = false;
    ozone->dimensions_sidebar_width              = 0.0f;
 
@@ -7514,6 +7638,7 @@ static void *ozone_init(void **userdata, bool video_is_threaded)
 
    ozone->fullscreen_thumbnails_available       = false;
    ozone->show_fullscreen_thumbnails            = false;
+   ozone->skip_thumbnail_reset                  = false;
    ozone->animations.fullscreen_thumbnail_alpha = 0.0f;
    ozone->fullscreen_thumbnail_selection        = 0;
    ozone->fullscreen_thumbnail_label[0]         = '\0';
@@ -7706,11 +7831,13 @@ static void ozone_free(void *data)
 static void ozone_update_thumbnail_image(void *data)
 {
    ozone_handle_t *ozone      = (ozone_handle_t*)data;
-   const char *thumbnail_path = NULL;
-   bool has_thumbnail         = false;
 
    if (!ozone)
       return;
+
+   /* Cache previous status to remove footer metadata indicator blinking */
+   ozone->thumbnails_left_status_prev  = ozone->thumbnails.left.status;
+   ozone->thumbnails_right_status_prev = ozone->thumbnails.right.status;
 
    ozone->thumbnails.pending = OZONE_PENDING_THUMBNAIL_NONE;
    gfx_thumbnail_cancel_pending_requests();
@@ -7734,10 +7861,6 @@ static void ozone_update_thumbnail_image(void *data)
       ozone->thumbnails.pending =
             (ozone->thumbnails.pending == OZONE_PENDING_THUMBNAIL_RIGHT) ?
                   OZONE_PENDING_THUMBNAIL_BOTH : OZONE_PENDING_THUMBNAIL_LEFT;
-
-   has_thumbnail = gfx_thumbnail_get_path(ozone->thumbnail_path_data, 0, &thumbnail_path);
-   if (has_thumbnail && !ozone->libretro_running)
-      ozone->want_thumbnail_bar = true;
 
    if (ozone->show_thumbnail_bar != ozone->want_thumbnail_bar)
       ozone->need_compute = true;
@@ -7900,8 +8023,8 @@ static void ozone_set_layout(
           ozone->dimensions.sidebar_entry_icon_padding) *
          ozone->last_thumbnail_scale_factor;
    /* Prevent the thumbnail sidebar from growing too much and make the UI unusable. */
-   if (ozone->dimensions.thumbnail_bar_width > ozone->last_width / 2.0f)
-      ozone->dimensions.thumbnail_bar_width         = ozone->last_width / 2.0f;
+   if (ozone->dimensions.thumbnail_bar_width > ozone->last_width / 3.0f)
+      ozone->dimensions.thumbnail_bar_width         = ozone->last_width / 3.0f;
 
    ozone->dimensions.cursor_size                    = CURSOR_SIZE * scale_factor;
 
@@ -8859,7 +8982,7 @@ static void ozone_render(void *data,
                      menu_navigation_set_selection(i);
 
                      /* If this is a playlist, must update thumbnails */
-                     if (ozone->is_playlist && (ozone->depth == 1))
+                     if (ozone->is_playlist && (ozone->depth == 1 || ozone->depth == 4))
                      {
                         ozone_set_thumbnail_content(ozone, "");
                         ozone_update_thumbnail_image(ozone);
@@ -8892,7 +9015,7 @@ static void ozone_render(void *data,
                         ozone_leave_sidebar(ozone, ozone_collapse_sidebar, animation_tag);
                   }
                   /* If this is a playlist, must update thumbnails */
-                  else if (ozone->is_playlist && (ozone->depth == 1))
+                  else if (ozone->is_playlist && (ozone->depth == 1 || ozone->depth == 4))
                   {
                      ozone_set_thumbnail_content(ozone, "");
                      ozone_update_thumbnail_image(ozone);
@@ -9012,6 +9135,11 @@ static void ozone_render(void *data,
          default:
             break;
       }
+
+      if (ozone->thumbnails.left.status != GFX_THUMBNAIL_STATUS_UNKNOWN)
+         ozone->thumbnails_left_status_prev  = ozone->thumbnails.left.status;
+      if (ozone->thumbnails.right.status != GFX_THUMBNAIL_STATUS_UNKNOWN)
+         ozone->thumbnails_right_status_prev = ozone->thumbnails.right.status;
    }
 
    menu_entries_ctl(MENU_ENTRIES_CTL_START_GET, &i);
@@ -9316,14 +9444,7 @@ static void ozone_draw_footer(
     *   here to prevent 'gaps' in the button list in
     *   the event of unknown errors */
    bool fullscreen_thumbnails_available =
-         ozone->fullscreen_thumbnails_available &&
-         !ozone->cursor_in_sidebar &&
-         ozone->show_thumbnail_bar &&
-         ((ozone->thumbnails.right.status     != GFX_THUMBNAIL_STATUS_MISSING) ||
-          (ozone->thumbnails.left.status      != GFX_THUMBNAIL_STATUS_MISSING) ||
-          (ozone->thumbnails.savestate.status != GFX_THUMBNAIL_STATUS_MISSING)) &&
-         (gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_RIGHT) ||
-          gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_LEFT));
+         ozone_fullscreen_thumbnails_available(ozone);
    bool metadata_override_available     =
          fullscreen_thumbnails_available &&
          ozone_metadata_override_available(ozone);
@@ -9729,7 +9850,7 @@ static void ozone_selection_changed(ozone_handle_t *ozone, bool allow_animation)
          bool update_thumbnails = false;
 
          /* Playlist updates */
-         if (ozone->is_playlist && ozone->depth == 1)
+         if (ozone->is_playlist && (ozone->depth == 1 || ozone->depth == 4))
          {
             ozone_set_thumbnail_content(ozone, "");
             update_thumbnails           = true;
@@ -9737,10 +9858,12 @@ static void ozone_selection_changed(ozone_handle_t *ozone, bool allow_animation)
          }
          /* Database list updates
           * (pointless nuisance...) */
-         else if (ozone->depth == 4 && ozone->is_db_manager_list)
+         else if (ozone->is_db_manager_list && ozone->depth == 4)
          {
             ozone_set_thumbnail_content(ozone, "");
-            update_thumbnails = true;
+            update_thumbnails           = true;
+            ozone->want_thumbnail_bar   = true;
+            ozone->skip_thumbnail_reset = false;
          }
          /* Filebrowser image updates */
          else if (ozone->is_file_list)
@@ -10225,7 +10348,7 @@ static void ozone_animation_end(void *userdata)
    ozone->animations.cursor_alpha   = 1.0f;
 }
 
-static void ozone_list_open(ozone_handle_t *ozone, bool ozone_collapse_sidebar)
+static void ozone_list_open(ozone_handle_t *ozone, bool ozone_collapse_sidebar, bool animate)
 {
    struct gfx_animation_ctx_entry entry;
    uintptr_t sidebar_tag        = (uintptr_t)&ozone->sidebar_offset;
@@ -10233,20 +10356,25 @@ static void ozone_list_open(ozone_handle_t *ozone, bool ozone_collapse_sidebar)
    ozone->draw_old_list         = true;
 
    /* Left/right animation */
-   ozone->animations.list_alpha = 0.0f;
+   if (animate)
+   {
+      ozone->animations.list_alpha = 0.0f;
 
-   entry.cb                     = ozone_animation_end;
-   entry.duration               = ANIMATION_PUSH_ENTRY_DURATION;
-   entry.easing_enum            = EASING_OUT_QUAD;
-   entry.subject                = &ozone->animations.list_alpha;
-   entry.tag                    = (uintptr_t)NULL;
-   entry.target_value           = 1.0f;
-   entry.userdata               = ozone;
+      entry.cb                     = ozone_animation_end;
+      entry.duration               = ANIMATION_PUSH_ENTRY_DURATION;
+      entry.easing_enum            = EASING_OUT_QUAD;
+      entry.subject                = &ozone->animations.list_alpha;
+      entry.tag                    = (uintptr_t)NULL;
+      entry.target_value           = 1.0f;
+      entry.userdata               = ozone;
 
-   gfx_animation_push(&entry);
+      gfx_animation_push(&entry);
+   }
+   else
+      ozone->animations.list_alpha = 1.0f;
 
    /* Sidebar animation */
-   ozone_sidebar_update_collapse(ozone, ozone_collapse_sidebar, true);
+   ozone_sidebar_update_collapse(ozone, ozone_collapse_sidebar, animate);
 
    /* Kill any existing sidebar slide-in/out animations
     * before pushing a new one
@@ -10261,29 +10389,39 @@ static void ozone_list_open(ozone_handle_t *ozone, bool ozone_collapse_sidebar)
    {
       ozone->draw_sidebar = true;
 
-      entry.cb            = NULL;
-      entry.duration      = ANIMATION_PUSH_ENTRY_DURATION;
-      entry.easing_enum   = EASING_OUT_QUAD;
-      entry.subject       = &ozone->sidebar_offset;
-      entry.tag           = sidebar_tag;
-      entry.target_value  = 0.0f;
-      entry.userdata      = NULL;
+      if (animate)
+      {
+         entry.cb            = NULL;
+         entry.duration      = ANIMATION_PUSH_ENTRY_DURATION;
+         entry.easing_enum   = EASING_OUT_QUAD;
+         entry.subject       = &ozone->sidebar_offset;
+         entry.tag           = sidebar_tag;
+         entry.target_value  = 0.0f;
+         entry.userdata      = NULL;
 
-      gfx_animation_push(&entry);
+         gfx_animation_push(&entry);
+      }
+      else
+         ozone->sidebar_offset = 0.0f;
    }
    else if (ozone->depth > 1)
    {
-      struct gfx_animation_ctx_entry entry;
+      if (animate)
+      {
+         struct gfx_animation_ctx_entry entry;
 
-      entry.cb           = ozone_collapse_end;
-      entry.duration     = ANIMATION_PUSH_ENTRY_DURATION;
-      entry.easing_enum  = EASING_OUT_QUAD;
-      entry.subject      = &ozone->sidebar_offset;
-      entry.tag          = sidebar_tag;
-      entry.target_value = -ozone->dimensions_sidebar_width;
-      entry.userdata     = (void*)ozone;
+         entry.cb           = ozone_collapse_end;
+         entry.duration     = ANIMATION_PUSH_ENTRY_DURATION;
+         entry.easing_enum  = EASING_OUT_QUAD;
+         entry.subject      = &ozone->sidebar_offset;
+         entry.tag          = sidebar_tag;
+         entry.target_value = -ozone->dimensions_sidebar_width;
+         entry.userdata     = (void*)ozone;
 
-      gfx_animation_push(&entry);
+         gfx_animation_push(&entry);
+      }
+      else
+         ozone->sidebar_offset = -ozone->dimensions_sidebar_width;
    }
 }
 
@@ -10295,6 +10433,7 @@ static void ozone_populate_entries(void *data,
    settings_t *settings        = NULL;
    ozone_handle_t *ozone       = (ozone_handle_t*) data;
    bool ozone_collapse_sidebar = false;
+   bool was_db_manager_list    = false;
 
    if (!ozone)
       return;
@@ -10366,11 +10505,11 @@ static void ozone_populate_entries(void *data,
    ozone->last_onscreen_entry  = 0;
 
    new_depth                   = (int)ozone_list_get_size(ozone, MENU_LIST_PLAIN);
+   was_db_manager_list         = ozone->is_db_manager_list && new_depth > ozone->depth;
 
    animate                     = new_depth != ozone->depth;
    ozone->fade_direction       = new_depth <= ozone->depth;
    ozone->depth                = new_depth;
-   ozone->is_playlist          = ozone_is_playlist(ozone, true);
    ozone->is_db_manager_list   = string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_DATABASE_MANAGER_LIST));
    ozone->is_file_list         = string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_FAVORITES));
    ozone->is_quick_menu        = string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_RPL_ENTRY_ACTIONS)) ||
@@ -10379,22 +10518,39 @@ static void ozone_populate_entries(void *data,
    ozone->is_contentless_cores = string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_CONTENTLESS_CORES_TAB)) ||
                                  string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_CONTENTLESS_CORES_LIST));
    ozone->is_state_slot        = string_to_unsigned(path) == MENU_ENUM_LABEL_STATE_SLOT;
+   ozone->is_playlist          = ozone_is_playlist(ozone, true);
+
+   if (was_db_manager_list)
+   {
+      ozone->is_db_manager_list   = true;
+      ozone->skip_thumbnail_reset = true;
+   }
 
    if (animate)
       if (ozone->categories_selection_ptr == ozone->categories_active_idx_old)
-         ozone_list_open(ozone, ozone_collapse_sidebar);
+         ozone_list_open(ozone, ozone_collapse_sidebar, !ozone->first_frame);
 
    /* Thumbnails
     * > Note: Leave current thumbnails loaded when
     *   opening the quick menu - allows proper fade
     *   out of the fullscreen thumbnail viewer
     * > Do not reset thumbnail when returning from quick menu */
-   if (!ozone->is_quick_menu && ozone->was_quick_menu)
+   if (!ozone->is_quick_menu && ozone->was_quick_menu && !ozone->is_state_slot &&
+         (gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_RIGHT) ||
+          gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_LEFT)) &&
+         (ozone->thumbnails.left.status  == GFX_THUMBNAIL_STATUS_AVAILABLE ||
+          ozone->thumbnails.right.status == GFX_THUMBNAIL_STATUS_AVAILABLE ||
+          ozone->thumbnails.left.status  == GFX_THUMBNAIL_STATUS_MISSING ||
+          ozone->thumbnails.right.status == GFX_THUMBNAIL_STATUS_MISSING))
       ozone->skip_thumbnail_reset = true;
 
    if (!ozone->is_quick_menu && !ozone->is_state_slot && !ozone->skip_thumbnail_reset)
    {
-      ozone_unload_thumbnail_textures(ozone);
+      if (ozone->is_db_manager_list && ozone->depth == 4)
+         ozone->skip_thumbnail_reset = true;
+
+      if (!ozone->skip_thumbnail_reset)
+         ozone_unload_thumbnail_textures(ozone);
 
       if (gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_RIGHT) ||
           gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_LEFT))
@@ -10405,7 +10561,7 @@ static void ozone_populate_entries(void *data,
           *   since the first selected item on such a list
           *   can never have a thumbnail */
          if (ozone->is_playlist ||
-             (ozone->depth == 4 && ozone->is_db_manager_list))
+             (ozone->is_db_manager_list && ozone->depth >= 4))
          {
             ozone_set_thumbnail_content(ozone, "");
             ozone_update_thumbnail_image(ozone);
@@ -10414,42 +10570,49 @@ static void ozone_populate_entries(void *data,
             ozone->want_thumbnail_bar = false;
       }
    }
-   else if (ozone->is_quick_menu && !ozone->libretro_running)
+   else if (ozone->is_quick_menu)
    {
-      ozone->want_thumbnail_bar   = true;
-      ozone->skip_thumbnail_reset = true;
-      ozone_update_thumbnail_image(ozone);
-   }
-   else if (ozone->is_quick_menu && ozone->libretro_running)
-   {
-      const char *thumbnail_content_path = NULL;
-      runloop_state_t *runloop_st        = runloop_state_get_ptr();
-      gfx_thumbnail_get_content_path(ozone->thumbnail_path_data, &thumbnail_content_path);
-
-      if (!string_is_empty(thumbnail_content_path) &&
-            !string_is_equal(thumbnail_content_path, runloop_st->runtime_content_path))
+      if (ozone_is_running_quick_menu())
+      {
+         ozone->want_thumbnail_bar   = false;
+         ozone->skip_thumbnail_reset = false;
+         ozone_update_savestate_thumbnail_path(ozone, menu_navigation_get_selection());
+         ozone_update_savestate_thumbnail_image(ozone);
+      }
+      else if (gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_RIGHT) ||
+               gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_LEFT))
       {
          ozone->want_thumbnail_bar   = true;
          ozone->skip_thumbnail_reset = true;
          ozone_update_thumbnail_image(ozone);
       }
-      else
-      {
-         ozone->want_thumbnail_bar   = false;
-         ozone_update_savestate_thumbnail_path(ozone, menu_navigation_get_selection());
-         ozone_update_savestate_thumbnail_image(ozone);
-      }
+   }
+
+   if (ozone->skip_thumbnail_reset &&
+         (gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_RIGHT) ||
+          gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_LEFT)))
+      ozone->want_thumbnail_bar = true;
+
+   switch (ozone->tabs[ozone->categories_selection_ptr])
+   {
+#if defined(HAVE_FFMPEG) || defined(HAVE_MPV)
+      case OZONE_SYSTEM_TAB_VIDEO:
+#endif
+      case OZONE_SYSTEM_TAB_MUSIC:
+         ozone->want_thumbnail_bar              = false;
+         ozone->fullscreen_thumbnails_available = false;
+         break;
    }
 
    /* Fullscreen thumbnails are only enabled on
     * playlists, database manager lists, file lists
     * and savestate slots */
    ozone->fullscreen_thumbnails_available =
-         (ozone->is_playlist        && ozone->depth == 1) ||
-         (ozone->is_db_manager_list && ozone->depth == 4) ||
+         (ozone->is_playlist        && ozone->want_thumbnail_bar && (ozone->depth == 1 || ozone->depth == 4)) ||
+         (ozone->is_db_manager_list && ozone->want_thumbnail_bar && ozone->depth >= 4) ||
          (ozone->is_quick_menu      && ozone->want_thumbnail_bar) ||
          (ozone->is_file_list       && ozone->want_thumbnail_bar) ||
-          ozone->is_state_slot;
+         (ozone->is_state_slot);
 
    if (ozone->fullscreen_thumbnails_available != ozone->want_thumbnail_bar)
       ozone->want_thumbnail_bar = ozone->fullscreen_thumbnails_available;
@@ -10470,6 +10633,7 @@ static void ozone_toggle(void *userdata, bool menu_on)
     * 'save state' option */
    if (ozone->is_quick_menu)
    {
+      ozone->want_thumbnail_bar   = false;
       ozone->skip_thumbnail_reset = false;
       gfx_thumbnail_reset(&ozone->thumbnails.savestate);
       ozone_update_savestate_thumbnail_path(ozone, menu_navigation_get_selection());

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -72,7 +72,7 @@
 #define XMB_DELAY 166.66667f
 #endif
 
-#define XMB_THUMBNAIL_STREAM_DELAY 166.66667f
+#define XMB_THUMBNAIL_STREAM_DELAY 5 * 16.66667f
 
 /* Specifies minimum period (in usec) between
  * tab switch events when input repeat is
@@ -409,6 +409,7 @@ typedef struct xmb_handle
 
    bool fullscreen_thumbnails_available;
    bool show_fullscreen_thumbnails;
+   bool skip_thumbnail_reset;
    bool show_mouse;
    bool show_screensaver;
    bool use_ps3_layout;
@@ -1131,6 +1132,20 @@ static void xmb_update_dynamic_wallpaper(xmb_handle_t *xmb)
    path = NULL;
 }
 
+static bool xmb_is_running_quick_menu(void)
+{
+   menu_entry_t entry;
+
+   MENU_ENTRY_INIT(entry);
+   entry.path_enabled     = false;
+   entry.value_enabled    = false;
+   entry.sublabel_enabled = false;
+   menu_entry_get(&entry, 0, 0, NULL, true);
+
+   return string_is_equal(entry.label, "resume_content") ||
+          string_is_equal(entry.label, "state_slot");
+}
+
 static void xmb_update_savestate_thumbnail_path(void *data, unsigned i)
 {
    settings_t *settings = config_get_ptr();
@@ -1147,11 +1162,14 @@ static void xmb_update_savestate_thumbnail_path(void *data, unsigned i)
          xmb->savestate_thumbnail_file_path,
          sizeof(xmb->prev_savestate_thumbnail_file_path));
 
+   if (xmb->skip_thumbnail_reset)
+      return;
+
    xmb->savestate_thumbnail_file_path[0] = '\0';
 
    /* Savestate thumbnails are only relevant
     * when viewing the running quick menu or state slots */
-   if (!((xmb->is_quick_menu || xmb->is_state_slot) && xmb->libretro_running))
+   if (!((xmb->is_quick_menu && xmb_is_running_quick_menu()) || xmb->is_state_slot))
       return;
 
    xmb->fullscreen_thumbnails_available = false;
@@ -1182,7 +1200,7 @@ static void xmb_update_savestate_thumbnail_path(void *data, unsigned i)
             /* State slot dropdown */
             if (string_to_unsigned(entry.label) == MENU_ENUM_LABEL_STATE_SLOT)
             {
-               state_slot = menu_navigation_get_selection() - 1;
+               state_slot         = i - 1;
                xmb->is_state_slot = true;
             }
 
@@ -1220,8 +1238,12 @@ static void xmb_update_thumbnail_image(void *data)
 
    xmb->thumbnails.pending = XMB_PENDING_THUMBNAIL_NONE;
    gfx_thumbnail_cancel_pending_requests();
-   gfx_thumbnail_reset(&xmb->thumbnails.right);
-   gfx_thumbnail_reset(&xmb->thumbnails.left);
+
+   if (!xmb->skip_thumbnail_reset)
+   {
+      gfx_thumbnail_reset(&xmb->thumbnails.right);
+      gfx_thumbnail_reset(&xmb->thumbnails.left);
+   }
 
    /* imageviewer content requires special treatment... */
    gfx_thumbnail_get_core_name(xmb->thumbnail_path_data, &core_name);
@@ -1427,12 +1449,12 @@ static void xmb_update_savestate_thumbnail_image(void *data)
    settings_t *settings = config_get_ptr();
    unsigned thumbnail_upscale_threshold
                         = settings->uints.gfx_thumbnail_upscale_threshold;
-   if (!xmb)
+   if (!xmb || xmb->skip_thumbnail_reset)
       return;
 
    /* Savestate thumbnails are only relevant
     * when viewing the running quick menu or state slots */
-   if (!((xmb->is_quick_menu || xmb->is_state_slot) && xmb->libretro_running))
+   if (!((xmb->is_quick_menu && xmb_is_running_quick_menu()) || xmb->is_state_slot))
       return;
 
    /* If path is empty, just reset thumbnail */
@@ -1524,10 +1546,15 @@ static void xmb_selection_pointer_changed(
             }
             /* Database list updates
              * (pointless nuisance...) */
-            else if (depth == 4 && xmb->is_db_manager_list)
+            else if (xmb->is_db_manager_list && depth <= 4)
             {
                xmb_set_thumbnail_content(xmb, NULL);
-               update_thumbnails = true;
+               update_thumbnails         = true;
+               xmb->skip_thumbnail_reset = false;
+            }
+            else if (xmb->is_db_manager_list && depth == 5)
+            {
+               xmb->skip_thumbnail_reset = true;
             }
             /* Filebrowser image updates */
             else if (xmb->is_file_list)
@@ -1556,6 +1583,7 @@ static void xmb_selection_pointer_changed(
                    * content + right/left thumbnails
                    * (otherwise last loaded thumbnail will
                    * persist, and be shown on the wrong entry) */
+                  xmb->fullscreen_thumbnails_available = false;
                   xmb->thumbnails.pending = XMB_PENDING_THUMBNAIL_NONE;
                   gfx_thumbnail_set_content(xmb->thumbnail_path_data, NULL);
                   gfx_thumbnail_cancel_pending_requests();
@@ -1759,7 +1787,6 @@ static void xmb_list_open_new(xmb_handle_t *xmb,
       }
    }
 
-   xmb->old_depth = xmb->depth;
    menu_entries_ctl(MENU_ENTRIES_CTL_SET_START, &skip);
 
    xmb_system_tab = xmb_get_system_tab(xmb,
@@ -1770,17 +1797,16 @@ static void xmb_list_open_new(xmb_handle_t *xmb,
       if (  gfx_thumbnail_is_enabled(xmb->thumbnail_path_data, GFX_THUMBNAIL_RIGHT) ||
             gfx_thumbnail_is_enabled(xmb->thumbnail_path_data, GFX_THUMBNAIL_LEFT))
       {
-         /* This code is horrible, full of hacks...
-          * This hack ensures that thumbnails are not cleared
-          * when selecting an entry from a collection via
-          * 'load content'... */
-         if (xmb->depth != 5)
-            xmb_unload_thumbnail_textures(xmb);
-
          if (xmb->is_playlist || xmb->is_db_manager_list)
          {
-            xmb_set_thumbnail_content(xmb, NULL);
-            xmb_update_thumbnail_image(xmb);
+            if (xmb->is_db_manager_list && xmb->depth < 5)
+               xmb_unload_thumbnail_textures(xmb);
+
+            if (!(xmb->is_playlist && xmb->depth == 4 && xmb->old_depth == 5))
+            {
+               xmb_set_thumbnail_content(xmb, NULL);
+               xmb_update_thumbnail_image(xmb);
+            }
          }
       }
    }
@@ -1791,9 +1817,11 @@ static void xmb_list_open_new(xmb_handle_t *xmb,
    {
       /* This shows savestate thumbnail after
        * opening savestate submenu */
-      xmb_update_savestate_thumbnail_path(xmb, menu_navigation_get_selection());
+      xmb_update_savestate_thumbnail_path(xmb, current);
       xmb_update_savestate_thumbnail_image(xmb);
    }
+
+   xmb->old_depth = xmb->depth;
 }
 
 static xmb_node_t *xmb_node_allocate_userdata(
@@ -2462,6 +2490,7 @@ static void xmb_populate_entries(void *data,
    bool menu_dynamic_wallpaper_enable =
       settings ? settings->bools.menu_dynamic_wallpaper_enable : false;
    bool show_entry_idx  = settings ? settings->bools.playlist_show_entry_idx : false;
+   bool was_db_manager_list    = false;
    unsigned    depth    = (unsigned)xmb_list_get_size(xmb, MENU_LIST_PLAIN);
    if (!xmb)
       return;
@@ -2488,7 +2517,15 @@ static void xmb_populate_entries(void *data,
    xmb->is_playlist = xmb->is_playlist && !string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_RDB_ENTRY_DETAIL));
 
    /* Determine whether this is a database manager list */
+   was_db_manager_list     = xmb->is_db_manager_list && depth >= 4;
    xmb->is_db_manager_list = string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_DATABASE_MANAGER_LIST));
+
+   xmb->skip_thumbnail_reset    = false;
+   if (was_db_manager_list)
+   {
+      xmb->is_db_manager_list   = true;
+      xmb->skip_thumbnail_reset = true;
+   }
 
    /* Determine whether this is the contentless cores menu */
    xmb->is_contentless_cores = string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_CONTENTLESS_CORES_TAB)) ||
@@ -2544,11 +2581,12 @@ static void xmb_populate_entries(void *data,
          (xmb->is_playlist || xmb->is_db_manager_list || xmb->is_file_list) &&
          !((xmb_system_tab > XMB_SYSTEM_TAB_SETTINGS) && (xmb->depth > 2));
 
-   if (xmb->is_state_slot || (xmb->is_quick_menu &&
-         !string_is_empty(xmb->savestate_thumbnail_file_path)))
+   if ((xmb->is_quick_menu || xmb->is_state_slot) &&
+         !string_is_empty(xmb->savestate_thumbnail_file_path))
+   {
       xmb->fullscreen_thumbnails_available = true;
-
-   if (xmb->is_quick_menu && xmb->depth < 3)
+   }
+   else if (xmb->is_quick_menu && xmb->depth < 6)
    {
       const char *thumbnail_content_path = NULL;
       runloop_state_t *runloop_st        = runloop_state_get_ptr();
@@ -2569,6 +2607,7 @@ static void xmb_populate_entries(void *data,
     * file list is populated... */
    if (xmb->is_file_list)
    {
+      xmb->fullscreen_thumbnails_available = false;
       xmb->thumbnails.pending = XMB_PENDING_THUMBNAIL_NONE;
       gfx_thumbnail_set_content(xmb->thumbnail_path_data, NULL);
       gfx_thumbnail_cancel_pending_requests();
@@ -4151,6 +4190,24 @@ static enum menu_action xmb_parse_menu_entry_action(
             new_action = MENU_ACTION_NOOP;
          }
          break;
+      case MENU_ACTION_OK:
+         if (xmb->is_state_slot)
+            xmb->skip_thumbnail_reset = true;
+
+         /* Open fullscreen thumbnail with Ok when core is running
+            to prevent accidental imageviewer core launch */
+         if (xmb->libretro_running && xmb->is_file_list &&
+               xmb->fullscreen_thumbnails_available)
+         {
+            xmb_hide_fullscreen_thumbnails(xmb, false);
+            xmb_show_fullscreen_thumbnails(xmb, menu_navigation_get_selection());
+            new_action = MENU_ACTION_NOOP;
+         }
+         break;
+      case MENU_ACTION_CANCEL:
+         if (xmb->is_state_slot)
+            xmb->skip_thumbnail_reset = true;
+         break;
       default:
          /* In all other cases, pass through input
           * menu action without intervention */
@@ -4936,7 +4993,7 @@ static void xmb_draw_fullscreen_thumbnails(
                   xmb->font,
                   title_buf,
                   title_x,
-                  xmb->font_size,
+                  xmb->font_size * 1.33f,
                   (unsigned)view_width,
                   (unsigned)view_height,
                   title_color,
@@ -4955,7 +5012,7 @@ static void xmb_draw_fullscreen_thumbnails(
                   xmb->font,
                   xmb->fullscreen_thumbnail_label,
                   view_width >> 1,
-                  xmb->font_size,
+                  xmb->font_size * 1.33f,
                   (unsigned)view_width,
                   (unsigned)view_height,
                   title_color,
@@ -5231,7 +5288,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
    /* Draw thumbnails: START */
    /**************************/
 
-   /* Reset thumbnail bar when starting/closing content */
+   /* Reset thumbnails when starting/closing content */
    if (xmb->libretro_running != libretro_running)
    {
       xmb->libretro_running = libretro_running;
@@ -6148,6 +6205,7 @@ static void *xmb_init(void **userdata, bool video_is_threaded)
 
    xmb->fullscreen_thumbnails_available       = false;
    xmb->show_fullscreen_thumbnails            = false;
+   xmb->skip_thumbnail_reset                  = false;
    xmb->fullscreen_thumbnail_alpha            = 0.0f;
    xmb->fullscreen_thumbnail_selection        = 0;
    xmb->fullscreen_thumbnail_label[0]         = '\0';


### PR DESCRIPTION
## Description

Yet another batch of Ozone adjustments:
- Thumbnail bar maximum size reduced a bit
- Thumbnail bar size+padding to work better with thumbnail scaling option and different screen sizes
- Fixed issue with thumbnail bar getting hidden due to animation race condition
- More unnecessary image blinking reduced
- Entry paddings reduced for more usable screen estate
- Sublabel width improved

Both menus also get a reduced image stream delay, and also a fool proof mechanism for "Load Content" browsing when core is already running, to prevent accidental launching of images as a core, as in rather open fullscreen image with Ok.

Edit:
Added extra changes:
- Prevented footer "Toggle metadata" from blinking
- Prevented "No thumbnail available" from blinking
- Fixed thumbnails under database manager
- Fixed thumbnails under "Load Content" playlists
- Removed ability to go to parent directory in database/cursor managers, which does not even work
- Adjusted XMB fullscreen thumbnail title position

## Related Issues

Closes #14206 

## Reviewers

@Ryunam 
