### PR TITLE
(Network/Vita) Do not multiply negative timeout values

### DIFF
--- a/libretro-common/net/net_socket.c
+++ b/libretro-common/net/net_socket.c
@@ -423,7 +423,10 @@ int socket_poll(struct pollfd *fds, unsigned nfds, int timeout)
 #undef ALLOC_EVENTS
 
    /* Vita's epoll takes a microsecond timeout parameter. */
-   ret = sceNetEpollWait(epoll_fd, events, event_count, timeout * 1000);
+   if (timeout > 0)
+      timeout *= 1000;
+
+   ret = sceNetEpollWait(epoll_fd, events, event_count, timeout);
    if (ret <= 0)
       goto done;
 


### PR DESCRIPTION
## Description

Just in case it only accepts -1 for negative values.

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/14216