### PR TITLE
[PS1 Serial Scanning]

### DIFF
--- a/tasks/task_database_cue.c
+++ b/tasks/task_database_cue.c
@@ -280,7 +280,7 @@ int detect_ps1_game(intfstream_t *fd, char *game_id, const char *filename)
    strcpy(game_id, "XXXXXXXXXX");
    game_id[10] = '\0';
    cue_append_multi_disc_suffix(game_id, filename);
-   return true;
+   return false;
 }
 
 int detect_psp_game(intfstream_t *fd, char *game_id, const char *filename)


### PR DESCRIPTION
[PS1 Serial Scanning] enhancement
Changed return value of detect_ps1_game function to actually return a failure when the Serial can't be extracted.
Scanner will then fallback on crc check, and usually ends up finding the games in the database.

## Description

Several PS1 games that don't have the serial in the data track and completely missed by the Scanner.  (Ridge Racer (Japan) for example)
Serial Extraction currently returns a success even when it fails extracting the serial, and returns a fake 'XXXXXXXXXX' serial, that's can't be looked up in the database.
This PR changes this return value to actually return a failure when Serial Extraction can't find a serial, letting Retroarch fallback on CRC scan, usually finding the game.
Out of a sample of 4000 Disks, this changed allowed scanning an extra 100 that were originally missed.


