### PR TITLE
(Netplay/Vita) Change default port

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -1418,7 +1418,11 @@ static const int default_content_favorites_size = 200;
 #define DEFAULT_LIBRETRO_LOG_LEVEL 1
 
 #ifndef RARCH_DEFAULT_PORT
+#ifndef VITA
 #define RARCH_DEFAULT_PORT 55435
+#else
+#define RARCH_DEFAULT_PORT 19492
+#endif
 #endif
 
 #ifndef RARCH_STREAM_DEFAULT_PORT

--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -277,7 +277,7 @@ static bool netplay_lan_ad_client_query(void)
    bool ret                   = false;
 
    /* Get the broadcast address (IPv4 only for now) */
-   snprintf(port, sizeof(port), "%hu", (unsigned short)RARCH_DEFAULT_PORT);
+   snprintf(port, sizeof(port), "%hu", (unsigned short)RARCH_DISCOVERY_PORT);
    hints.ai_family   = AF_INET;
    hints.ai_socktype = SOCK_DGRAM;
    if (getaddrinfo_retro("255.255.255.255", port, &hints, &addr))
@@ -455,7 +455,7 @@ static bool init_lan_ad_server_socket(void)
 {
    struct addrinfo *addr      = NULL;
    net_driver_state_t *net_st = &networking_driver_st;
-   int fd                     = socket_init((void**)&addr, RARCH_DEFAULT_PORT,
+   int fd                     = socket_init((void**)&addr, RARCH_DISCOVERY_PORT,
       NULL, SOCKET_TYPE_DATAGRAM);
    bool ret                   = fd >= 0 && addr &&
       socket_bind(fd, addr) && socket_nonblock(fd);

--- a/network/netplay/netplay_private.h
+++ b/network/netplay/netplay_private.h
@@ -28,8 +28,13 @@
 
 #include "../../retroarch_types.h"
 
-#define RARCH_DEFAULT_PORT 55435
-#define RARCH_DEFAULT_NICK "Anonymous"
+#ifndef VITA
+#define RARCH_DEFAULT_PORT   55435
+#else
+#define RARCH_DEFAULT_PORT   19492
+#endif
+#define RARCH_DISCOVERY_PORT 55435
+#define RARCH_DEFAULT_NICK   "Anonymous"
 
 #define NETPLAY_PASS_LEN      128
 #define NETPLAY_PASS_HASH_LEN 64 /* length of a SHA-256 hash */


### PR DESCRIPTION
## Description

We can't bind the default (55435) port on Vita, so we change the default port to 19492 for it.

## Related Issues

https://github.com/libretro/RetroArch/issues/14193