### PR TITLE
Prevent playlist thumbnail cycle from showing duplicate images

### DIFF
--- a/menu/cbs/menu_cbs_scan.c
+++ b/menu/cbs/menu_cbs_scan.c
@@ -119,7 +119,7 @@ int action_switch_thumbnail(const char *path,
     * GLUI is a special case where thumbnail 'switch' corresponds to
     * changing thumbnail view mode.
     * For other menu drivers, we cycle through available thumbnail
-    * types. */
+    * types and skip if already visible. */
    if (!switch_enabled)
       return 0;
 
@@ -129,9 +129,19 @@ int action_switch_thumbnail(const char *path,
             settings->uints.menu_left_thumbnails,
             settings->uints.menu_left_thumbnails + 1);
 
+      if (settings->uints.gfx_thumbnails == settings->uints.menu_left_thumbnails)
+         configuration_set_uint(settings,
+               settings->uints.menu_left_thumbnails,
+               settings->uints.menu_left_thumbnails + 1);
+
       if (settings->uints.menu_left_thumbnails > 3)
          configuration_set_uint(settings,
                settings->uints.menu_left_thumbnails, 1);
+
+      if (settings->uints.gfx_thumbnails == settings->uints.menu_left_thumbnails)
+         configuration_set_uint(settings,
+               settings->uints.menu_left_thumbnails,
+               settings->uints.menu_left_thumbnails + 1);
    }
    else
    {
@@ -139,9 +149,19 @@ int action_switch_thumbnail(const char *path,
             settings->uints.gfx_thumbnails,
             settings->uints.gfx_thumbnails + 1);
 
+      if (settings->uints.gfx_thumbnails == settings->uints.menu_left_thumbnails)
+         configuration_set_uint(settings,
+               settings->uints.gfx_thumbnails,
+               settings->uints.gfx_thumbnails + 1);
+
       if (settings->uints.gfx_thumbnails > 3)
          configuration_set_uint(settings,
                settings->uints.gfx_thumbnails, 1);
+
+      if (settings->uints.gfx_thumbnails == settings->uints.menu_left_thumbnails)
+         configuration_set_uint(settings,
+               settings->uints.gfx_thumbnails,
+               settings->uints.gfx_thumbnails + 1);
    }
 
    menu_driver_ctl(RARCH_MENU_CTL_UPDATE_THUMBNAIL_PATH, NULL);


### PR DESCRIPTION
## Description

Cycling the thumbnail with Y is indeed better when it does not show the same image twice.

## Related Issues

Closes #14236
