### PR TITLE
Added argument to force exit RetroArch UWP using URI Scheme

### DIFF
--- a/uwp/uwp_main.cpp
+++ b/uwp/uwp_main.cpp
@@ -405,16 +405,16 @@ void App::Uninitialize()
 
 void App::OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^ args)
 {
+	int argc = NULL;
+	std::vector<char*> argv;
+	std::vector<std::string> argvTmp; //using std::string as temp buf instead of char* array to avoid manual char allocations
+	ParseProtocolArgs(args, &argc, &argv, &argvTmp);
+	
 	//start only if not already initialized. If there is a game in progress, just return
 	if (m_initialized == true)
 	{
 		return;
 	}
-
-	int argc = NULL;
-	std::vector<char*> argv;
-	std::vector<std::string> argvTmp; //using std::string as temp buf instead of char* array to avoid manual char allocations
-	ParseProtocolArgs(args, &argc, &argv, &argvTmp);
 
 	int ret = rarch_main(argc, argv.data(), NULL);
 	if (ret != 0)
@@ -705,7 +705,12 @@ void App::ParseProtocolArgs(Windows::ApplicationModel::Activation::IActivatedEve
 			IWwwFormUrlDecoderEntry^ arg = query->GetAt(i);
 
 			//parse RetroArch command line string
-			if (arg->Name == "cmd")
+			if (arg->Name == "forceExit")
+			{
+				//this allows a frotend to quit RetroArch, which in turn allows it to launch a different game.
+				CoreApplication::Exit();
+			}
+			else if (arg->Name == "cmd" && m_initalized == false)
 			{
 				std::wstring wsValue(arg->Value->ToString()->Data());
 				std::string strValue(wsValue.begin(), wsValue.end());
@@ -725,14 +730,17 @@ void App::ParseProtocolArgs(Windows::ApplicationModel::Activation::IActivatedEve
 			}
 		}
 	}
-
-	(*argc) = argvTmp->size();
-	//convert to char* array compatible with argv
-	for (int i = 0; i < argvTmp->size(); i++)
+	
+	if (m_initialized == false)
 	{
-		argv->push_back((char*)(argvTmp->at(i)).c_str());
+		(*argc) = argvTmp->size();
+		//convert to char* array compatible with argv
+		for (int i = 0; i < argvTmp->size(); i++)
+		{
+			argv->push_back((char*)(argvTmp->at(i)).c_str());
+		}
+		argv->push_back(nullptr);
 	}
-	argv->push_back(nullptr);
 }
 
 /* Implement UWP equivalents of various win32_* functions */


### PR DESCRIPTION
Added launch protocol arg 'forceExit' so a frontend can tell an already-running RetroArch UWP instance to quit.

## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

[Description of the pull request, detail any issues you are fixing or any features you are implementing]

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
