### PR TITLE
Improved success rate of Serial scanning on PS1 by adding support for the xx.xxx format

### DIFF
--- a/tasks/task_database_cue.c
+++ b/tasks/task_database_cue.c
@@ -261,6 +261,14 @@ int detect_ps1_game(intfstream_t *fd, char *game_id, const char *filename)
                raw_game_id[8] = raw_game_id[9];
                raw_game_id[9] = raw_game_id[10];
             }
+            /* A few games have their serial in the form of xx.xxx */
+            /* Tanaka Torahiko no Ultra-ryuu Shougi - Ibisha Anaguma-hen (Japan) -> SLPS_02.261 */
+            else if (string_is_equal_fast(&raw_game_id[7], ".", 1))
+            {
+               raw_game_id[7] = raw_game_id[8];
+               raw_game_id[8] = raw_game_id[9];
+               raw_game_id[9] = raw_game_id[10];
+            }
             raw_game_id[10] = '\0';
 
             string_remove_all_whitespace(game_id, raw_game_id);


### PR DESCRIPTION
## Description

PS1 Serial Scanner is failing to detect a few games because in Serial number in the data tracker used the xx.xxx format instead of xxx.xx
Current scanner is interpreting the serial found in the data track incorrectly and leaves a 'dot' in the Serial, making the DB lookup fail. Since a Serial was found, no crc fallback is being used.
With the fix, games like 'Tanaka Torahiko no Ultra-ryuu Shougi - Ibisha Anaguma-hen (Japan)' are now scanned properly.



