### PR TITLE
(Network) Fix getaddrinfo_retro

### DIFF
--- a/command.c
+++ b/command.c
@@ -209,7 +209,7 @@ command_t* command_network_new(uint16_t port)
    command_network_t *netcmd = (command_network_t*)calloc(
                                    1, sizeof(command_network_t));
    int fd                    = socket_init(
-         (void**)&res, port, NULL, SOCKET_TYPE_DATAGRAM);
+         (void**)&res, port, NULL, SOCKET_TYPE_DATAGRAM, AF_INET);
 
    RARCH_LOG("[NetCMD]: %s %hu.\n",
          msg_hash_to_str(MSG_BRINGING_UP_COMMAND_INTERFACE_ON_PORT),

--- a/gfx/drivers/network_gfx.c
+++ b/gfx/drivers/network_gfx.c
@@ -117,7 +117,7 @@ static void *network_gfx_init(const video_info_t *video,
 
    RARCH_LOG("[Network]: Connecting to host %s:%d\n", network->address, network->port);
 try_connect:
-   fd = socket_init((void**)&addr, network->port, network->address, SOCKET_TYPE_STREAM);
+   fd = socket_init((void**)&addr, network->port, network->address, SOCKET_TYPE_STREAM, 0);
 
    next_addr = addr;
 

--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -1033,7 +1033,7 @@ static bool input_remote_init_network(input_remote_t *handle,
    RARCH_LOG("Bringing up remote interface on port %hu.\n",
          (unsigned short)port);
 
-   if ((fd = socket_init((void**)&res, port, NULL, SOCKET_TYPE_DATAGRAM)) < 0)
+   if ((fd = socket_init((void**)&res, port, NULL, SOCKET_TYPE_DATAGRAM, AF_INET)) < 0)
       goto error;
 
    handle->net_fd[user] = fd;

--- a/libretro-common/include/net/net_compat.h
+++ b/libretro-common/include/net/net_compat.h
@@ -70,6 +70,7 @@ struct hostent
    int  h_length;
    char **h_addr_list;
    char *h_addr;
+   char *h_end;
 };
 
 #elif defined(GEKKO)
@@ -172,6 +173,7 @@ struct hostent
    int  h_length;
    char **h_addr_list;
    char *h_addr;
+   char *h_end;
 };
 
 struct SceNetInAddr inet_aton(const char *ip_addr);

--- a/libretro-common/include/net/net_socket.h
+++ b/libretro-common/include/net/net_socket.h
@@ -60,7 +60,8 @@ typedef struct socket_target
    enum socket_protocol prot;
 } socket_target_t;
 
-int socket_init(void **address, uint16_t port, const char *server, enum socket_type type);
+int socket_init(void **address, uint16_t port, const char *server,
+      enum socket_type type, int family);
 
 int socket_next(void **address);
 

--- a/libretro-common/net/net_http.c
+++ b/libretro-common/net/net_http.c
@@ -417,7 +417,7 @@ static int net_http_new_socket(struct http_connection_t *conn)
 {
    struct addrinfo *addr = NULL, *next_addr = NULL;
    int fd                = socket_init(
-         (void**)&addr, conn->port, conn->domain, SOCKET_TYPE_STREAM);
+         (void**)&addr, conn->port, conn->domain, SOCKET_TYPE_STREAM, 0);
 #ifdef HAVE_SSL
    if (conn->sock_state.ssl)
    {

--- a/network/natt.c
+++ b/network/natt.c
@@ -90,7 +90,8 @@ bool natt_init(struct natt_discovery *discovery)
    if (!msearch_addr)
       goto failure;
 
-   fd = socket_init((void **) &bind_addr, 0, NULL, SOCKET_TYPE_DATAGRAM);
+   fd = socket_init((void**)&bind_addr, 0, NULL,
+      SOCKET_TYPE_DATAGRAM, AF_INET);
    if (fd < 0)
       goto failure;
    if (!bind_addr)

--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -214,7 +214,7 @@ bool init_netplay_discovery(void)
    struct addrinfo *addr      = NULL;
    net_driver_state_t *net_st = &networking_driver_st;
    int fd                     = socket_init((void**)&addr, 0, NULL,
-      SOCKET_TYPE_DATAGRAM);
+      SOCKET_TYPE_DATAGRAM, AF_INET);
    bool ret                   = fd >= 0 && addr;
 
    if (ret)
@@ -457,7 +457,7 @@ static bool init_lan_ad_server_socket(void)
    struct addrinfo *addr      = NULL;
    net_driver_state_t *net_st = &networking_driver_st;
    int fd                     = socket_init((void**)&addr, RARCH_DISCOVERY_PORT,
-      NULL, SOCKET_TYPE_DATAGRAM);
+      NULL, SOCKET_TYPE_DATAGRAM, AF_INET);
    bool ret                   = fd >= 0 && addr &&
       socket_bind(fd, addr) && socket_nonblock(fd);
 

--- a/tools/ranetplayer/ranetplayer.c
+++ b/tools/ranetplayer/ranetplayer.c
@@ -271,7 +271,7 @@ int main(int argc, char **argv)
    }
 
    /* Connect to the netplay server */
-   if ((sock = socket_init((void **) &addr, port, host, SOCKET_PROTOCOL_TCP)) < 0)
+   if ((sock = socket_init((void**)&addr, port, host, SOCKET_PROTOCOL_TCP, 0)) < 0)
    {
       perror("socket");
       return 1;


### PR DESCRIPTION
## Description

Refactor broke some functions that depend on it for platforms where both IPv4 and IPv6 are available.
Before the refactor, it was already broken, but its bad side effect was somewhat hidden.

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/14258