### PR TITLE
Fixed Debug build when GL_DEBUG=1 is set with C89_BUILD, and added it to the CI

### DIFF
--- a/.github/workflows/retroarch.yml
+++ b/.github/workflows/retroarch.yml
@@ -27,3 +27,7 @@ jobs:
         run: ./configure
       - name: Build
         run: make C89_BUILD=1
+      - name: Build Debug
+        run: |
+          make clean # making sure we don't have leftovers from previous build
+          make DEBUG=1 GL_DEBUG=1 C89_BUILD=1

--- a/gfx/drivers/gl2.c
+++ b/gfx/drivers/gl2.c
@@ -3332,9 +3332,10 @@ static bool gl2_resolve_extensions(gl2_t *gl, const char *context_ident, const v
    if (gl->core_context_in_use)
    {
 #ifdef GL_NUM_EXTENSIONS
+      GLint i;
       GLint exts = 0;
       glGetIntegerv(GL_NUM_EXTENSIONS, &exts);
-      for (GLint i = 0; i < exts; i++)
+      for (i = 0; i < exts; i++)
       {
          const char *ext = (const char*)glGetStringi(GL_EXTENSIONS, i);
          if (ext)


### PR DESCRIPTION

## Description

Code base has a lot of #ifdef DEBUG (and several GL_DEBUG), so Debug build can break while the Release one is perfectly fine.
With this PR, Github Action will now also build with the Debug strict settings DEBUG=1 GL_DEBUG=1 C89_BUILD=1.
Such a build was currently broken, so a build fix has been added to this PR so we can have a nice green status in CI
For reference, error was:
gfx/drivers/gl2.c:3338:7: error: ‘for’ loop initial declarations are only allowed in C99 or C11 mode
 3338 |       for (GLint i = 0; i < exts; i++)

* Fixed Debug build when GL_DEBUG and C89_BUILD are activated
* Added Debug build to the GitHub Action 'Retroarch CI' to prevent future Build Breaks in Debug mode



