### PR TITLE
Count amount of characters for window title

### DIFF
--- a/gfx/common/x11_common.c
+++ b/gfx/common/x11_common.c
@@ -216,11 +216,11 @@ static void xdg_screensaver_inhibit(Window wnd)
        * xdg-screensaver will fail and report to stderr, framing RA for its bug.
        * A single space character is used so that the title bar stays visibly
        * the same, as if there's no title at all. */
-      video_driver_get_window_title(title, sizeof(title));
-      if (strlen(title) == 0)
-         snprintf(title, sizeof(title), " ");
+      size_t title_len = video_driver_get_window_title(title, sizeof(title));
+      if (title_len == 0)
+         title_len = strlcpy(title, " ", sizeof(title));
       XChangeProperty(g_x11_dpy, g_x11_win, XA_WM_NAME, XA_STRING,
-            8, PropModeReplace, (const unsigned char*) title, strlen(title));
+            8, PropModeReplace, (const unsigned char*) title, title_len);
    }
 
    snprintf(cmd, sizeof(cmd), "xdg-screensaver suspend 0x%x", (int)wnd);

--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -2684,7 +2684,7 @@ bool video_driver_has_focus(void)
    return VIDEO_HAS_FOCUS(video_st);
 }
 
-void video_driver_get_window_title(char *buf, unsigned len)
+size_t video_driver_get_window_title(char *buf, unsigned len)
 {
    video_driver_state_t *video_st = &video_driver_st;
    if (buf && video_st->window_title_update)
@@ -2692,6 +2692,7 @@ void video_driver_get_window_title(char *buf, unsigned len)
       strlcpy(buf, video_st->window_title, len);
       video_st->window_title_update = false;
    }
+   return video_st->window_title_len;
 }
 
 void video_driver_build_info(video_frame_info_t *video_info)
@@ -3783,15 +3784,15 @@ void video_driver_frame(const void *data, unsigned width,
          last_fps = TIME_TO_FPS(curr_time, new_time,
                fps_update_interval);
 
-         strlcpy(video_st->window_title,
+         video_st->window_title_len = strlcpy(video_st->window_title,
                video_st->title_buf,
                sizeof(video_st->window_title));
 
          if (!string_is_empty(status_text))
          {
-            strlcat(video_st->window_title,
+            video_st->window_title_len += strlcat(video_st->window_title,
                   " || ", sizeof(video_st->window_title));
-            strlcat(video_st->window_title,
+            video_st->window_title_len += strlcat(video_st->window_title,
                   status_text, sizeof(video_st->window_title));
          }
 
@@ -3803,7 +3804,8 @@ void video_driver_frame(const void *data, unsigned width,
    {
       curr_time = fps_time = new_time;
 
-      strlcpy(video_st->window_title,
+      video_st->window_title_len = strlcpy(
+            video_st->window_title,
             video_st->title_buf,
             sizeof(video_st->window_title));
 

--- a/gfx/video_driver.h
+++ b/gfx/video_driver.h
@@ -868,6 +868,7 @@ typedef struct
    uintptr_t window;
 
    size_t frame_cache_pitch;
+   size_t window_title_len;
 
 #ifdef HAVE_VIDEO_FILTER
    unsigned state_scale;
@@ -1234,7 +1235,7 @@ void video_driver_build_info(video_frame_info_t *video_info);
 
 void video_driver_reinit(int flags);
 
-void video_driver_get_window_title(char *buf, unsigned len);
+size_t video_driver_get_window_title(char *buf, unsigned len);
 
 bool *video_driver_get_threaded(void);
 


### PR DESCRIPTION
[Count amount of characters window title has so that we can
return the value when calling video_driver_get_window_title -
this is so we can prevent strlen calls in x11_common.c