### PR TITLE
Refactor file path special

### DIFF
--- a/file_path_special.c
+++ b/file_path_special.c
@@ -168,13 +168,12 @@ void fill_pathname_application_special(char *s,
 #ifdef HAVE_XMB
          {
             char s1[PATH_MAX_LENGTH];
-            char s2[PATH_MAX_LENGTH];
-            s1[0]    = '\0';
-            fill_pathname_application_special(s1, sizeof(s1),
-                  APPLICATION_SPECIAL_DIRECTORY_ASSETS_XMB);
-            fill_pathname_join(s2, s1, "png", sizeof(s2));
-            fill_pathname_slash(s2, sizeof(s2));
-            strlcpy(s, s2, len);
+            char s8[PATH_MAX_LENGTH];
+            settings_t *settings     = config_get_ptr();
+            const char *dir_assets   = settings->paths.directory_assets;
+            fill_pathname_join(s8, dir_assets, "xmb", sizeof(s8));
+            fill_pathname_join(s1, s8, xmb_theme_ident(), sizeof(s1));
+            fill_pathname_join(s, s1, "png", len);
          }
 #endif
          break;
@@ -188,12 +187,14 @@ void fill_pathname_application_special(char *s,
                strlcpy(s, path_menu_wallpaper, len);
             else
             {
+               char s1[PATH_MAX_LENGTH];
+               char s8[PATH_MAX_LENGTH];
                char s3[PATH_MAX_LENGTH];
-
-               s3[0] = '\0';
-
-               fill_pathname_application_special(s3, sizeof(s3),
-                     APPLICATION_SPECIAL_DIRECTORY_ASSETS_XMB_ICONS);
+               settings_t *settings     = config_get_ptr();
+               const char *dir_assets   = settings->paths.directory_assets;
+               fill_pathname_join(s8, dir_assets, "xmb", sizeof(s8));
+               fill_pathname_join(s1, s8, xmb_theme_ident(), sizeof(s1));
+               fill_pathname_join(s3, s1, "png", sizeof(s3));
                fill_pathname_join(s, s3, FILE_PATH_BACKGROUND_IMAGE, len);
             }
          }
@@ -207,13 +208,13 @@ void fill_pathname_application_special(char *s,
             const char *menu_ident = settings->arrays.menu_driver;
             const char *dir_assets = settings->paths.directory_assets;
 
-            s4[0]                  = '\0';
-
             if (string_is_equal(menu_ident, "xmb"))
             {
-               fill_pathname_application_special(s4, sizeof(s4),
-                     APPLICATION_SPECIAL_DIRECTORY_ASSETS_XMB);
-
+               char s8[PATH_MAX_LENGTH];
+               settings_t *settings     = config_get_ptr();
+               const char *dir_assets   = settings->paths.directory_assets;
+               fill_pathname_join(s8, dir_assets, "xmb", sizeof(s8));
+               fill_pathname_join(s4, s8, xmb_theme_ident(), sizeof(s4));
                if (!string_is_empty(s4))
                   strlcat(s4, "/sounds", sizeof(s4));
             }
@@ -234,6 +235,8 @@ void fill_pathname_application_special(char *s,
                if (!string_is_empty(s4))
                   strlcat(s4, "/sounds", sizeof(s4));
             }
+            else
+               s4[0] = '\0';
 
             if (string_is_empty(s4))
                fill_pathname_join(
@@ -251,10 +254,34 @@ void fill_pathname_application_special(char *s,
             const char *menu_ident = settings->arrays.menu_driver;
 
             if      (string_is_equal(menu_ident, "xmb"))
-               fill_pathname_application_special(s, len, APPLICATION_SPECIAL_DIRECTORY_ASSETS_XMB_ICONS);
+            {
+               char s1[PATH_MAX_LENGTH];
+               char s8[PATH_MAX_LENGTH];
+               settings_t *settings     = config_get_ptr();
+               const char *dir_assets   = settings->paths.directory_assets;
+               fill_pathname_join(s8, dir_assets, "xmb", sizeof(s8));
+               fill_pathname_join(s1, s8, xmb_theme_ident(), sizeof(s1));
+               fill_pathname_join(s, s1, "png", len);
+            }
             else if (    string_is_equal(menu_ident, "ozone")
                       || string_is_equal(menu_ident, "glui"))
-               fill_pathname_application_special(s, len, APPLICATION_SPECIAL_DIRECTORY_ASSETS_OZONE_ICONS);
+            {
+               char s5[PATH_MAX_LENGTH];
+               char s6[PATH_MAX_LENGTH];
+               settings_t *settings     = config_get_ptr();
+               const char *dir_assets   = settings->paths.directory_assets;
+
+#if defined(WIIU) || defined(VITA)
+               /* Smaller 46x46 icons look better on low-DPI devices */
+               fill_pathname_join(s5, dir_assets, "ozone", sizeof(s5));
+               fill_pathname_join(s6, "png", "icons", sizeof(s6));
+#else
+               /* Otherwise, use large 256x256 icons */
+               fill_pathname_join(s5, dir_assets, "xmb", sizeof(s5));
+               fill_pathname_join(s6, "monochrome", "png", sizeof(s6));
+#endif
+               fill_pathname_join(s, s5, s6, len);
+            }
             else if (len)
                s[0] = '\0';
 #endif
@@ -339,9 +366,15 @@ void fill_pathname_application_special(char *s,
                      fill_pathname_join(s, s9, "korean-fallback-font.ttf", len);
                      break;
                   default:
-                     fill_pathname_application_special(s9, sizeof(s9),
-                           APPLICATION_SPECIAL_DIRECTORY_ASSETS_XMB);
-                     fill_pathname_join(s, s9, FILE_PATH_TTF_FONT, len);
+                     {
+                        char s8[PATH_MAX_LENGTH];
+                        settings_t *settings     = config_get_ptr();
+                        const char *dir_assets   = settings->paths.directory_assets;
+                        fill_pathname_join(s8, dir_assets, "xmb", sizeof(s8));
+                        fill_pathname_join(s9, s8, xmb_theme_ident(), sizeof(s9));
+                        fill_pathname_join(s, s9, FILE_PATH_TTF_FONT, len);
+                     }
+                     break;
                }
             }
          }
@@ -350,13 +383,10 @@ void fill_pathname_application_special(char *s,
       case APPLICATION_SPECIAL_DIRECTORY_THUMBNAILS_DISCORD_AVATARS:
       {
         char s10[PATH_MAX_LENGTH];
-        char s11[PATH_MAX_LENGTH];
         settings_t *settings       = config_get_ptr();
         const char *dir_thumbnails = settings->paths.directory_thumbnails;
         fill_pathname_join(s10, dir_thumbnails, "discord", sizeof(s10));
-        fill_pathname_join(s11, s10, "avatars", sizeof(s11));
-        fill_pathname_slash(s11, sizeof(s11));
-        strlcpy(s, s11, len);
+        fill_pathname_join(s, s10, "avatars", len);
       }
       break;
 
@@ -367,9 +397,7 @@ void fill_pathname_application_special(char *s,
         settings_t *settings       = config_get_ptr();
         const char *dir_thumbnails = settings->paths.directory_thumbnails;
         fill_pathname_join(s12, dir_thumbnails, "cheevos", len);
-        fill_pathname_join(s13, s12, "badges", sizeof(s13));
-        fill_pathname_slash(s13, sizeof(s13));
-        strlcpy(s, s13, len);
+        fill_pathname_join(s, s12, "badges", len);
       }
       break;
 

--- a/file_path_special.c
+++ b/file_path_special.c
@@ -260,6 +260,7 @@ void fill_pathname_application_special(char *s,
             settings_t *settings   = config_get_ptr();
             const char *menu_ident = settings->arrays.menu_driver;
 
+#ifdef HAVE_XMB
             if      (string_is_equal(menu_ident, "xmb"))
             {
                char s1[PATH_MAX_LENGTH];
@@ -270,7 +271,9 @@ void fill_pathname_application_special(char *s,
                fill_pathname_join(s1, s8, xmb_theme_ident(), sizeof(s1));
                fill_pathname_join(s, s1, "png", len);
             }
-            else if (    string_is_equal(menu_ident, "ozone")
+            else
+#endif
+		    if (    string_is_equal(menu_ident, "ozone")
                       || string_is_equal(menu_ident, "glui"))
             {
                char s5[PATH_MAX_LENGTH];

--- a/file_path_special.c
+++ b/file_path_special.c
@@ -354,7 +354,6 @@ void fill_pathname_application_special(char *s,
             else
             {
                char s9[PATH_MAX_LENGTH];
-               s9[0] = '\0';
 
                switch (*msg_hash_get_uint(MSG_HASH_USER_LANGUAGE))
                {
@@ -403,7 +402,6 @@ void fill_pathname_application_special(char *s,
       case APPLICATION_SPECIAL_DIRECTORY_THUMBNAILS_CHEEVOS_BADGES:
       {
         char s12[PATH_MAX_LENGTH];
-        char s13[PATH_MAX_LENGTH];
         settings_t *settings       = config_get_ptr();
         const char *dir_thumbnails = settings->paths.directory_thumbnails;
         fill_pathname_join(s12, dir_thumbnails, "cheevos", len);

--- a/file_path_special.c
+++ b/file_path_special.c
@@ -208,6 +208,7 @@ void fill_pathname_application_special(char *s,
             const char *menu_ident = settings->arrays.menu_driver;
             const char *dir_assets = settings->paths.directory_assets;
 
+#ifdef HAVE_XMB
             if (string_is_equal(menu_ident, "xmb"))
             {
                char s8[PATH_MAX_LENGTH];
@@ -218,7 +219,10 @@ void fill_pathname_application_special(char *s,
                if (!string_is_empty(s4))
                   strlcat(s4, "/sounds", sizeof(s4));
             }
-            else if (string_is_equal(menu_ident, "glui"))
+            else
+#endif
+#ifdef HAVE_MATERIALUI
+               if (string_is_equal(menu_ident, "glui"))
             {
                const char *dir_assets = settings->paths.directory_assets;
                fill_pathname_join(s4, dir_assets, "glui", sizeof(s4));
@@ -226,6 +230,8 @@ void fill_pathname_application_special(char *s,
                if (!string_is_empty(s4))
                   strlcat(s4, "/sounds", sizeof(s4));
             }
+#endif
+#ifdef HAVE_OZONE
             else if (string_is_equal(menu_ident, "ozone"))
             {
                const char *dir_assets   = settings->paths.directory_assets;
@@ -236,6 +242,7 @@ void fill_pathname_application_special(char *s,
                   strlcat(s4, "/sounds", sizeof(s4));
             }
             else
+#endif
                s4[0] = '\0';
 
             if (string_is_empty(s4))

--- a/file_path_special.c
+++ b/file_path_special.c
@@ -188,13 +188,13 @@ void fill_pathname_application_special(char *s,
                strlcpy(s, path_menu_wallpaper, len);
             else
             {
-               char s1[PATH_MAX_LENGTH];
+               char s3[PATH_MAX_LENGTH];
 
-               s1[0] = '\0';
+               s3[0] = '\0';
 
-               fill_pathname_application_special(s1, sizeof(s1),
+               fill_pathname_application_special(s3, sizeof(s3),
                      APPLICATION_SPECIAL_DIRECTORY_ASSETS_XMB_ICONS);
-               fill_pathname_join(s, s1, FILE_PATH_BACKGROUND_IMAGE, len);
+               fill_pathname_join(s, s3, FILE_PATH_BACKGROUND_IMAGE, len);
             }
          }
 #endif
@@ -202,44 +202,44 @@ void fill_pathname_application_special(char *s,
       case APPLICATION_SPECIAL_DIRECTORY_ASSETS_SOUNDS:
          {
 #ifdef HAVE_MENU
-            char s1[PATH_MAX_LENGTH];
+            char s4[PATH_MAX_LENGTH];
             settings_t *settings   = config_get_ptr();
             const char *menu_ident = settings->arrays.menu_driver;
             const char *dir_assets = settings->paths.directory_assets;
 
-            s1[0]                  = '\0';
+            s4[0]                  = '\0';
 
             if (string_is_equal(menu_ident, "xmb"))
             {
-               fill_pathname_application_special(s1, sizeof(s1),
+               fill_pathname_application_special(s4, sizeof(s4),
                      APPLICATION_SPECIAL_DIRECTORY_ASSETS_XMB);
 
-               if (!string_is_empty(s1))
-                  strlcat(s1, "/sounds", sizeof(s1));
+               if (!string_is_empty(s4))
+                  strlcat(s4, "/sounds", sizeof(s4));
             }
             else if (string_is_equal(menu_ident, "glui"))
             {
                const char *dir_assets = settings->paths.directory_assets;
-               fill_pathname_join(s1, dir_assets, "glui", sizeof(s1));
+               fill_pathname_join(s4, dir_assets, "glui", sizeof(s4));
 
-               if (!string_is_empty(s1))
-                  strlcat(s1, "/sounds", sizeof(s1));
+               if (!string_is_empty(s4))
+                  strlcat(s4, "/sounds", sizeof(s4));
             }
             else if (string_is_equal(menu_ident, "ozone"))
             {
                const char *dir_assets   = settings->paths.directory_assets;
-               fill_pathname_join(s1, dir_assets, "ozone",
-                     sizeof(s1));
+               fill_pathname_join(s4, dir_assets, "ozone",
+                     sizeof(s4));
 
-               if (!string_is_empty(s1))
-                  strlcat(s1, "/sounds", sizeof(s1));
+               if (!string_is_empty(s4))
+                  strlcat(s4, "/sounds", sizeof(s4));
             }
 
-            if (string_is_empty(s1))
+            if (string_is_empty(s4))
                fill_pathname_join(
-                     s1, dir_assets, "sounds", sizeof(s1));
+                     s4, dir_assets, "sounds", sizeof(s4));
 
-            strlcpy(s, s1, len);
+            strlcpy(s, s4, len);
 #endif
          }
 
@@ -264,21 +264,21 @@ void fill_pathname_application_special(char *s,
       case APPLICATION_SPECIAL_DIRECTORY_ASSETS_OZONE_ICONS:
 #ifdef HAVE_OZONE
          {
-            char tmp[PATH_MAX_LENGTH];
-            char tmp2[PATH_MAX_LENGTH];
+            char s5[PATH_MAX_LENGTH];
+            char s6[PATH_MAX_LENGTH];
             settings_t *settings     = config_get_ptr();
             const char *dir_assets   = settings->paths.directory_assets;
 
 #if defined(WIIU) || defined(VITA)
             /* Smaller 46x46 icons look better on low-DPI devices */
-            fill_pathname_join(tmp, dir_assets, "ozone", sizeof(tmp));
-            fill_pathname_join(tmp2, "png", "icons", sizeof(tmp2));
+            fill_pathname_join(s5, dir_assets, "ozone", sizeof(s5));
+            fill_pathname_join(s6, "png", "icons", sizeof(s6));
 #else
             /* Otherwise, use large 256x256 icons */
-            fill_pathname_join(tmp, dir_assets, "xmb", sizeof(tmp));
-            fill_pathname_join(tmp2, "monochrome", "png", sizeof(tmp2));
+            fill_pathname_join(s5, dir_assets, "xmb", sizeof(s5));
+            fill_pathname_join(s6, "monochrome", "png", sizeof(s6));
 #endif
-            fill_pathname_join(s, tmp, tmp2, len);
+            fill_pathname_join(s, s5, s6, len);
          }
 #endif
          break;
@@ -286,11 +286,11 @@ void fill_pathname_application_special(char *s,
       case APPLICATION_SPECIAL_DIRECTORY_ASSETS_RGUI_FONT:
 #ifdef HAVE_RGUI
          {
-            char rgui_dir[PATH_MAX_LENGTH];
+            char s7[PATH_MAX_LENGTH];
             settings_t *settings     = config_get_ptr();
             const char *dir_assets   = settings->paths.directory_assets;
-            fill_pathname_join(rgui_dir, dir_assets, "rgui", sizeof(rgui_dir));
-            fill_pathname_join(s, rgui_dir, "font", len);
+            fill_pathname_join(s7, dir_assets, "rgui", sizeof(s7));
+            fill_pathname_join(s, s7, "font", len);
          }
 #endif
          break;
@@ -298,11 +298,11 @@ void fill_pathname_application_special(char *s,
       case APPLICATION_SPECIAL_DIRECTORY_ASSETS_XMB:
 #ifdef HAVE_XMB
          {
-            char s1[PATH_MAX_LENGTH];
+            char s8[PATH_MAX_LENGTH];
             settings_t *settings     = config_get_ptr();
             const char *dir_assets   = settings->paths.directory_assets;
-            fill_pathname_join(s1, dir_assets, "xmb", sizeof(s1));
-            fill_pathname_join(s, s1, xmb_theme_ident(), len);
+            fill_pathname_join(s8, dir_assets, "xmb", sizeof(s8));
+            fill_pathname_join(s, s8, xmb_theme_ident(), len);
          }
 #endif
          break;
@@ -316,32 +316,32 @@ void fill_pathname_application_special(char *s,
                strlcpy(s, path_menu_xmb_font, len);
             else
             {
-               char s1[PATH_MAX_LENGTH];
-               s1[0] = '\0';
+               char s9[PATH_MAX_LENGTH];
+               s9[0] = '\0';
 
                switch (*msg_hash_get_uint(MSG_HASH_USER_LANGUAGE))
                {
                   case RETRO_LANGUAGE_ARABIC:
                   case RETRO_LANGUAGE_PERSIAN:
-                     fill_pathname_join(s1,
-                           settings->paths.directory_assets, "pkg", sizeof(s1));
-                     fill_pathname_join(s, s1, "fallback-font.ttf", len);
+                     fill_pathname_join(s9,
+                           settings->paths.directory_assets, "pkg", sizeof(s9));
+                     fill_pathname_join(s, s9, "fallback-font.ttf", len);
                      break;
                   case RETRO_LANGUAGE_CHINESE_SIMPLIFIED:
                   case RETRO_LANGUAGE_CHINESE_TRADITIONAL:
-                     fill_pathname_join(s1,
-                           settings->paths.directory_assets, "pkg", sizeof(s1));
-                     fill_pathname_join(s, s1, "chinese-fallback-font.ttf", len);
+                     fill_pathname_join(s9,
+                           settings->paths.directory_assets, "pkg", sizeof(s9));
+                     fill_pathname_join(s, s9, "chinese-fallback-font.ttf", len);
                      break;
                   case RETRO_LANGUAGE_KOREAN:
-                     fill_pathname_join(s1,
-                           settings->paths.directory_assets, "pkg", sizeof(s1));
-                     fill_pathname_join(s, s1, "korean-fallback-font.ttf", len);
+                     fill_pathname_join(s9,
+                           settings->paths.directory_assets, "pkg", sizeof(s9));
+                     fill_pathname_join(s, s9, "korean-fallback-font.ttf", len);
                      break;
                   default:
-                     fill_pathname_application_special(s1, sizeof(s1),
+                     fill_pathname_application_special(s9, sizeof(s9),
                            APPLICATION_SPECIAL_DIRECTORY_ASSETS_XMB);
-                     fill_pathname_join(s, s1, FILE_PATH_TTF_FONT, len);
+                     fill_pathname_join(s, s9, FILE_PATH_TTF_FONT, len);
                }
             }
          }
@@ -349,27 +349,27 @@ void fill_pathname_application_special(char *s,
          break;
       case APPLICATION_SPECIAL_DIRECTORY_THUMBNAILS_DISCORD_AVATARS:
       {
-        char s1[PATH_MAX_LENGTH];
-        char s2[PATH_MAX_LENGTH];
+        char s10[PATH_MAX_LENGTH];
+        char s11[PATH_MAX_LENGTH];
         settings_t *settings       = config_get_ptr();
         const char *dir_thumbnails = settings->paths.directory_thumbnails;
-        fill_pathname_join(s1, dir_thumbnails, "discord", sizeof(s1));
-        fill_pathname_join(s2, s1, "avatars", sizeof(s2));
-        fill_pathname_slash(s2, sizeof(s2));
-        strlcpy(s, s2, len);
+        fill_pathname_join(s10, dir_thumbnails, "discord", sizeof(s10));
+        fill_pathname_join(s11, s10, "avatars", sizeof(s11));
+        fill_pathname_slash(s11, sizeof(s11));
+        strlcpy(s, s11, len);
       }
       break;
 
       case APPLICATION_SPECIAL_DIRECTORY_THUMBNAILS_CHEEVOS_BADGES:
       {
-        char s1[PATH_MAX_LENGTH];
-        char s2[PATH_MAX_LENGTH];
+        char s12[PATH_MAX_LENGTH];
+        char s13[PATH_MAX_LENGTH];
         settings_t *settings       = config_get_ptr();
         const char *dir_thumbnails = settings->paths.directory_thumbnails;
-        fill_pathname_join(s1, dir_thumbnails, "cheevos", len);
-        fill_pathname_join(s2, s1, "badges", sizeof(s2));
-        fill_pathname_slash(s2, sizeof(s2));
-        strlcpy(s, s2, len);
+        fill_pathname_join(s12, dir_thumbnails, "cheevos", len);
+        fill_pathname_join(s13, s12, "badges", sizeof(s13));
+        fill_pathname_slash(s13, sizeof(s13));
+        strlcpy(s, s13, len);
       }
       break;
 

--- a/file_path_special.c
+++ b/file_path_special.c
@@ -190,7 +190,6 @@ void fill_pathname_application_special(char *s,
                char s1[PATH_MAX_LENGTH];
                char s8[PATH_MAX_LENGTH];
                char s3[PATH_MAX_LENGTH];
-               settings_t *settings     = config_get_ptr();
                const char *dir_assets   = settings->paths.directory_assets;
                fill_pathname_join(s8, dir_assets, "xmb", sizeof(s8));
                fill_pathname_join(s1, s8, xmb_theme_ident(), sizeof(s1));
@@ -203,7 +202,6 @@ void fill_pathname_application_special(char *s,
       case APPLICATION_SPECIAL_DIRECTORY_ASSETS_SOUNDS:
          {
 #ifdef HAVE_MENU
-            char s4[PATH_MAX_LENGTH];
             settings_t *settings   = config_get_ptr();
             const char *menu_ident = settings->arrays.menu_driver;
             const char *dir_assets = settings->paths.directory_assets;
@@ -212,44 +210,35 @@ void fill_pathname_application_special(char *s,
             if (string_is_equal(menu_ident, "xmb"))
             {
                char s8[PATH_MAX_LENGTH];
-               settings_t *settings     = config_get_ptr();
-               const char *dir_assets   = settings->paths.directory_assets;
+               char s4[PATH_MAX_LENGTH];
                fill_pathname_join(s8, dir_assets, "xmb", sizeof(s8));
                fill_pathname_join(s4, s8, xmb_theme_ident(), sizeof(s4));
-               if (!string_is_empty(s4))
-                  strlcat(s4, "/sounds", sizeof(s4));
+               fill_pathname_join(s, s4, "sounds", len);
             }
             else
 #endif
 #ifdef HAVE_MATERIALUI
                if (string_is_equal(menu_ident, "glui"))
             {
-               const char *dir_assets = settings->paths.directory_assets;
+               char s4[PATH_MAX_LENGTH];
                fill_pathname_join(s4, dir_assets, "glui", sizeof(s4));
-
-               if (!string_is_empty(s4))
-                  strlcat(s4, "/sounds", sizeof(s4));
+               fill_pathname_join(s, s4, "sounds", len);
             }
 #endif
 #ifdef HAVE_OZONE
             else if (string_is_equal(menu_ident, "ozone"))
             {
-               const char *dir_assets   = settings->paths.directory_assets;
+               char s4[PATH_MAX_LENGTH];
                fill_pathname_join(s4, dir_assets, "ozone",
                      sizeof(s4));
-
-               if (!string_is_empty(s4))
-                  strlcat(s4, "/sounds", sizeof(s4));
+               fill_pathname_join(s, s4, "sounds", len);
             }
             else
 #endif
-               s4[0] = '\0';
-
-            if (string_is_empty(s4))
+            {
                fill_pathname_join(
-                     s4, dir_assets, "sounds", sizeof(s4));
-
-            strlcpy(s, s4, len);
+                     s, dir_assets, "sounds", len);
+            }
 #endif
          }
 
@@ -261,11 +250,10 @@ void fill_pathname_application_special(char *s,
             const char *menu_ident = settings->arrays.menu_driver;
 
 #ifdef HAVE_XMB
-            if      (string_is_equal(menu_ident, "xmb"))
+            if (string_is_equal(menu_ident, "xmb"))
             {
                char s1[PATH_MAX_LENGTH];
                char s8[PATH_MAX_LENGTH];
-               settings_t *settings     = config_get_ptr();
                const char *dir_assets   = settings->paths.directory_assets;
                fill_pathname_join(s8, dir_assets, "xmb", sizeof(s8));
                fill_pathname_join(s1, s8, xmb_theme_ident(), sizeof(s1));
@@ -274,11 +262,10 @@ void fill_pathname_application_special(char *s,
             else
 #endif
 		    if (    string_is_equal(menu_ident, "ozone")
-                      || string_is_equal(menu_ident, "glui"))
+               || string_is_equal(menu_ident, "glui"))
             {
                char s5[PATH_MAX_LENGTH];
                char s6[PATH_MAX_LENGTH];
-               settings_t *settings     = config_get_ptr();
                const char *dir_assets   = settings->paths.directory_assets;
 
 #if defined(WIIU) || defined(VITA)


### PR DESCRIPTION
file_path_special. c optimizations/cleanups:
- Unique variable names
- fill_pathname_application_special() is no longer a recursive function, other optimizations
- Try to use fill_pathname_join as much as possible for concatenating to avoid slash mistakes, avoid straight strlcpy/strlcat