### PR TITLE
Fixed items of system top menu bar on macOS.

### DIFF
--- a/pkg/apple/OSX/en.lproj/MainMenu.xib
+++ b/pkg/apple/OSX/en.lproj/MainMenu.xib
@@ -104,7 +104,7 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="Audio Options" id="661">
                                     <items>
-                                        <menuItem title="Mute Toggle" tag="11" id="663">
+                                        <menuItem title="Mute Toggle" tag="22" id="663">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
                                                 <action selector="basicEvent:" target="494" id="664"/>
@@ -185,7 +185,7 @@
                                     <action selector="basicEvent:" target="494" id="627"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Take Screenshot" tag="10" id="658">
+                            <menuItem title="Take Screenshot" tag="21" id="658">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="basicEvent:" target="494" id="659"/>

--- a/pkg/apple/OSX/en.lproj/MainMenu_Metal.xib
+++ b/pkg/apple/OSX/en.lproj/MainMenu_Metal.xib
@@ -104,7 +104,7 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="Audio Options" id="661">
                                     <items>
-                                        <menuItem title="Mute Toggle" tag="11" id="663">
+                                        <menuItem title="Mute Toggle" tag="22" id="663">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
                                                 <action selector="basicEvent:" target="494" id="664"/>
@@ -185,7 +185,7 @@
                                     <action selector="basicEvent:" target="494" id="627"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Take Screenshot" tag="10" id="658">
+                            <menuItem title="Take Screenshot" tag="21" id="658">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="basicEvent:" target="494" id="659"/>

--- a/ui/drivers/ui_cocoa.m
+++ b/ui/drivers/ui_cocoa.m
@@ -332,6 +332,33 @@ static ui_application_t ui_application_cocoa = {
    "cocoa"
 };
 
+@interface CommandPerformer : NSObject
+@end // @interface CommandPerformer
+
+@implementation CommandPerformer {
+   void *data;
+   enum event_command cmd;
+}
+
+- (id)initWithData:(void *)data command:(enum event_command)cmd
+{
+   self = [super init];
+   if (!self)
+      return self;
+
+   self->data = data;
+   self->cmd = cmd;
+
+   return self;
+}
+
+- (void)perform
+{
+   command_event(self->cmd, self->data);
+}
+
+@end // @implementation CommandPerformer
+
 #if defined(HAVE_COCOA_METAL)
 @interface RAWindow : NSWindow
 @end
@@ -877,6 +904,12 @@ static void open_document_handler(
       case 20:
          cmd = CMD_EVENT_FULLSCREEN_TOGGLE;
          break;
+      case 21:
+         cmd = CMD_EVENT_TAKE_SCREENSHOT;
+         break;
+      case 22:
+         cmd = CMD_EVENT_AUDIO_MUTE_TOGGLE;
+         break;
       default:
          break;
    }
@@ -921,7 +954,12 @@ static void ui_companion_cocoa_deinit(void *data)
 static void *ui_companion_cocoa_init(void) { return (void*)-1; }
 static void ui_companion_cocoa_notify_content_loaded(void *data) { }
 static void ui_companion_cocoa_toggle(void *data, bool force) { }
-static void ui_companion_cocoa_event_command(void *data, enum event_command cmd) { }
+static void ui_companion_cocoa_event_command(void *data, enum event_command cmd)
+{
+   id performer = [[CommandPerformer alloc] initWithData:data command:cmd];
+   [performer performSelectorOnMainThread:@selector(perform) withObject:nil waitUntilDone:NO];
+   RELEASE(performer);
+}
 static void ui_companion_cocoa_notify_list_pushed(void *data,
     file_list_t *list, file_list_t *menu_list) { }
 


### PR DESCRIPTION
Related to #14279.

> Please submit a new version of this PR that meets the requirements. It has to compile in both ARC and non-ARC mode.

I guess the `RELEASE` macro was created for such purposes, so I just replaced `[peformed release]` with `RELEASE(performer)`.

https://github.com/libretro/RetroArch/blob/ef551478d34056defd8cf10ef0e45a8ab5dc440d/ui/drivers/cocoa/cocoa_common.h#L101-L120

Sorry for the inconvenience.