### PR TITLE
String cleanups

### DIFF
--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -910,10 +910,7 @@ static void check_proc_acpi_sysfs_ac_adapter(const char * node, bool *have_ac)
    int64_t length   = 0;
    char     *buf    = NULL;
    const char *base = proc_acpi_sysfs_ac_adapter_path;
-
-   path[0]          = '\0';
-
-   snprintf(path, sizeof(path), "%s/%s", base, "online");
+   fill_pathname_join_special(path, base, "online", sizeof(path));
    if (!filestream_exists(path))
       return;
 
@@ -1788,7 +1785,7 @@ static void frontend_unix_get_env(int *argc,
       strlcat(base_path, "/.config/retroarch", sizeof(base_path));
    }
    else
-      strcpy_literal(base_path, "retroarch");
+      strlcpy(base_path, "retroarch", sizeof(base_path));
 #endif
 
    if (!string_is_empty(libretro_directory))
@@ -2804,10 +2801,14 @@ static bool accessibility_speak_unix(int speed,
    else if (speed > 10)
       speed = 10;
 
-   strcpy_literal(voice_out, "-v");
+   voice_out[0] = '-';
+   voice_out[1] = 'v';
+   voice_out[2] = '\0';
    strlcat(voice_out, language, 5);
 
-   strcpy_literal(speed_out, "-s");
+   speed_out[0] = '-';
+   speed_out[1] = 's';
+   speed_out[2] = '\0';
    strlcat(speed_out, speeds[speed-1], 6);
 
    if (priority < 10 && speak_pid > 0)

--- a/gfx/drivers/d3d10.c
+++ b/gfx/drivers/d3d10.c
@@ -466,18 +466,16 @@ static bool d3d10_gfx_set_shader(void* data, enum rarch_shader_type type, const 
             { "TEXCOORD", 1, DXGI_FORMAT_R32G32_FLOAT, 0, offsetof(d3d10_vertex_t, texcoord),
                D3D10_INPUT_PER_VERTEX_DATA, 0 },
          };
-         static const char vs_ext[] = ".vs.hlsl";
-         static const char ps_ext[] = ".ps.hlsl";
-         char              vs_path[PATH_MAX_LENGTH] = {0};
-         char              ps_path[PATH_MAX_LENGTH] = {0};
-         const char*       slang_path = d3d10->shader_preset->pass[i].source.path;
-         const char*       vs_src     = d3d10->shader_preset->pass[i].source.string.vertex;
-         const char*       ps_src     = d3d10->shader_preset->pass[i].source.string.fragment;
+         char vs_path[PATH_MAX_LENGTH];
+         char ps_path[PATH_MAX_LENGTH];
+         const char *slang_path = d3d10->shader_preset->pass[i].source.path;
+         const char *vs_src     = d3d10->shader_preset->pass[i].source.string.vertex;
+         const char *ps_src     = d3d10->shader_preset->pass[i].source.string.fragment;
 
          strlcpy(vs_path, slang_path, sizeof(vs_path));
          strlcpy(ps_path, slang_path, sizeof(ps_path));
-         strlcat(vs_path, vs_ext, sizeof(vs_path));
-         strlcat(ps_path, ps_ext, sizeof(ps_path));
+         strlcat(vs_path, ".vs.hlsl", sizeof(vs_path));
+         strlcat(ps_path, ".ps.hlsl", sizeof(ps_path));
 
          if (!d3d10_init_shader(
                   d3d10->device, vs_src, 0, vs_path, "main", NULL, NULL, desc, countof(desc),

--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -640,18 +640,16 @@ static bool d3d11_gfx_set_shader(void* data, enum rarch_shader_type type, const 
             { "TEXCOORD", 1, DXGI_FORMAT_R32G32_FLOAT, 0, offsetof(d3d11_vertex_t, texcoord),
                D3D11_INPUT_PER_VERTEX_DATA, 0 },
          };
-         static const char vs_ext[] = ".vs.hlsl";
-         static const char ps_ext[] = ".ps.hlsl";
-         char              vs_path[PATH_MAX_LENGTH] = {0};
-         char              ps_path[PATH_MAX_LENGTH] = {0};
-         const char*       slang_path = d3d11->shader_preset->pass[i].source.path;
-         const char*       vs_src     = d3d11->shader_preset->pass[i].source.string.vertex;
-         const char*       ps_src     = d3d11->shader_preset->pass[i].source.string.fragment;
+         char vs_path[PATH_MAX_LENGTH];
+         char ps_path[PATH_MAX_LENGTH];
+         const char *slang_path = d3d11->shader_preset->pass[i].source.path;
+         const char *vs_src     = d3d11->shader_preset->pass[i].source.string.vertex;
+         const char *ps_src     = d3d11->shader_preset->pass[i].source.string.fragment;
 
          strlcpy(vs_path, slang_path, sizeof(vs_path));
          strlcpy(ps_path, slang_path, sizeof(ps_path));
-         strlcat(vs_path, vs_ext, sizeof(vs_path));
-         strlcat(ps_path, ps_ext, sizeof(ps_path));
+         strlcat(vs_path, ".vs.hlsl", sizeof(vs_path));
+         strlcat(ps_path, ".ps.hlsl", sizeof(ps_path));
 
          if (!d3d11_init_shader(
                   d3d11->device, vs_src, 0, vs_path, "main", NULL, NULL, desc, countof(desc),

--- a/gfx/drivers/d3d12.c
+++ b/gfx/drivers/d3d12.c
@@ -687,21 +687,18 @@ static bool d3d12_gfx_set_shader(void* data, enum rarch_shader_type type, const 
             { "TEXCOORD", 1, DXGI_FORMAT_R32G32_FLOAT, 0, offsetof(d3d12_vertex_t, texcoord),
               D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
          };
-         static const char vs_ext[] = ".vs.hlsl";
-         static const char ps_ext[] = ".ps.hlsl";
-         char              vs_path[PATH_MAX_LENGTH] = {0};
-         char              ps_path[PATH_MAX_LENGTH] = {0};
-         const char*       slang_path = d3d12->shader_preset->pass[i].source.path;
-         const char*       vs_src     = d3d12->shader_preset->pass[i].source.string.vertex;
-         const char*       ps_src     = d3d12->shader_preset->pass[i].source.string.fragment;
-
+         char vs_path[PATH_MAX_LENGTH];
+         char ps_path[PATH_MAX_LENGTH];
+         const char *slang_path = d3d12->shader_preset->pass[i].source.path;
+         const char *vs_src     = d3d12->shader_preset->pass[i].source.string.vertex;
+         const char *ps_src     = d3d12->shader_preset->pass[i].source.string.fragment;
          strlcpy(vs_path, slang_path, sizeof(vs_path));
          strlcpy(ps_path, slang_path, sizeof(ps_path));
-         strlcat(vs_path, vs_ext, sizeof(vs_path));
-         strlcat(ps_path, ps_ext, sizeof(ps_path));
+         strlcat(vs_path, ".vs.hlsl", sizeof(vs_path));
+         strlcat(ps_path, ".ps.hlsl", sizeof(ps_path));
 
-         if (!d3d_compile(vs_src, 0, vs_path,"main","vs_5_0", &vs_code)){ }
-         if (!d3d_compile(ps_src, 0, ps_path,"main","ps_5_0", &ps_code)){ }
+         if (!d3d_compile(vs_src, 0, vs_path, "main", "vs_5_0", &vs_code)){ }
+         if (!d3d_compile(ps_src, 0, ps_path, "main", "ps_5_0", &ps_code)){ }
 
          desc.BlendState.RenderTarget[0].RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
          if (i == d3d12->shader_preset->passes - 1)

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -5259,22 +5259,23 @@ static int menu_displaylist_parse_input_description_list(
       if (!string_is_empty(input_desc_btn))
       {
          char input_description[256];
-
-         input_description[0] = '\0';
-
          /* > Up to RARCH_FIRST_CUSTOM_BIND, inputs
           *   are buttons - description can be used
           *   directly
           * > Above RARCH_FIRST_CUSTOM_BIND, inputs
           *   are analog axes - have to add +/-
           *   indicators */
-         if (i < RARCH_FIRST_CUSTOM_BIND)
-            strlcpy(input_description, input_desc_btn,
-                  sizeof(input_description));
-         else
-            snprintf(input_description, sizeof(input_description),
-                     "%s %c", input_desc_btn,
-                     ((i % 2) == 0) ? '+' : '-');
+	 size_t _len = strlcpy(input_description, input_desc_btn,
+			 sizeof(input_description));
+         if (i >= RARCH_FIRST_CUSTOM_BIND)
+         {
+            input_description   [_len  ] = ' ';
+            if ((i % 2) == 0)
+               input_description[_len+1] = '+';
+            else
+               input_description[_len+1] = '-';
+	    input_description   [_len+2] = '\0';
+         }
 
          if (string_is_empty(input_description))
             continue;
@@ -7266,11 +7267,16 @@ unsigned menu_displaylist_build_list(
             {
                /* On/off key strings may be required,
                 * so populate them... */
-               snprintf(on_string, sizeof(on_string), ".%s",
-                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_ON));
-
-               snprintf(off_string, sizeof(off_string), ".%s",
-                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF));
+               on_string [0] = '.';
+               on_string [1] = '\0';
+               off_string[0] = '.';
+               off_string[1] = '\0';
+               strlcat(on_string,
+                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_ON),
+		     sizeof(on_string));
+               strlcat(off_string,
+                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF),
+		     sizeof(off_string));
             }
             else
             {

--- a/retroarch.c
+++ b/retroarch.c
@@ -4095,7 +4095,7 @@ static void retroarch_print_version(void)
 #else
    printf("\n");
 #endif
-   retroarch_get_capabilities(RARCH_CAPABILITIES_COMPILER, str, sizeof(str));
+   retroarch_get_capabilities(RARCH_CAPABILITIES_COMPILER, str, sizeof(str), 0);
    strlcat(str, " Built: " __DATE__, sizeof(str));
    fprintf(stdout, "%s\n", str);
 }
@@ -5265,9 +5265,7 @@ bool retroarch_main_init(int argc, char *argv[])
       {
          char str_output[256];
          char str[128];
-         str[0]        = '\0';
-
-         retroarch_get_capabilities(RARCH_CAPABILITIES_CPU, str, sizeof(str));
+         retroarch_get_capabilities(RARCH_CAPABILITIES_CPU, str, sizeof(str), 0);
 
 #ifdef HAVE_GIT_VERSION
          snprintf(str_output, sizeof(str_output),
@@ -5906,52 +5904,179 @@ bool retroarch_override_setting_is_set(
 }
 
 int retroarch_get_capabilities(enum rarch_capabilities type,
-      char *s, size_t len)
+      char *s, size_t len, size_t _len)
 {
    switch (type)
    {
       case RARCH_CAPABILITIES_CPU:
          {
-            uint64_t cpu     = cpu_features_get();
+            uint64_t cpu = cpu_features_get();
 
             if (cpu & RETRO_SIMD_MMX)
-               strlcat(s, " MMX", len);
+            {
+               s[_len++] = ' ';
+               s[_len++] = 'M';
+               s[_len++] = 'M';
+               s[_len++] = 'X';
+               s[_len+1] = '\0';
+            }
             if (cpu & RETRO_SIMD_MMXEXT)
-               strlcat(s, " MMXEXT", len);
+            {
+               s[_len++] = ' ';
+               s[_len++] = 'M';
+               s[_len++] = 'M';
+               s[_len++] = 'X';
+               s[_len++] = 'E';
+               s[_len++] = 'X';
+               s[_len++] = 'T';
+               s[_len+1] = '\0';
+            }
             if (cpu & RETRO_SIMD_SSE)
-               strlcat(s, " SSE", len);
+            {
+               s[_len++] = ' ';
+               s[_len++] = 'S';
+               s[_len++] = 'S';
+               s[_len++] = 'E';
+               s[_len+1] = '\0';
+            }
             if (cpu & RETRO_SIMD_SSE2)
-               strlcat(s, " SSE2", len);
+            {
+               s[_len++] = ' ';
+               s[_len++] = 'S';
+               s[_len++] = 'S';
+               s[_len++] = 'E';
+               s[_len++] = '2';
+               s[_len+1] = '\0';
+            }
             if (cpu & RETRO_SIMD_SSE3)
-               strlcat(s, " SSE3", len);
-            if (cpu & RETRO_SIMD_SSSE3)
-               strlcat(s, " SSSE3", len);
+            {
+               s[_len++] = ' ';
+               s[_len++] = 'S';
+               s[_len++] = 'S';
+               s[_len++] = 'E';
+               s[_len++] = '3';
+               s[_len+1] = '\0';
+            }
             if (cpu & RETRO_SIMD_SSE4)
-               strlcat(s, " SSE4", len);
+            {
+               s[_len++] = ' ';
+               s[_len++] = 'S';
+               s[_len++] = 'S';
+               s[_len++] = 'E';
+               s[_len++] = '4';
+               s[_len+1] = '\0';
+            }
             if (cpu & RETRO_SIMD_SSE42)
-               strlcat(s, " SSE4.2", len);
+            {
+               s[_len++] = ' ';
+               s[_len++] = 'S';
+               s[_len++] = 'S';
+               s[_len++] = 'E';
+               s[_len++] = '4';
+               s[_len++] = '.';
+               s[_len++] = '2';
+               s[_len+1] = '\0';
+            }
             if (cpu & RETRO_SIMD_AES)
-               strlcat(s, " AES", len);
+            {
+               s[_len++] = ' ';
+               s[_len++] = 'A';
+               s[_len++] = 'E';
+               s[_len++] = 'S';
+               s[_len+1] = '\0';
+            }
             if (cpu & RETRO_SIMD_AVX)
-               strlcat(s, " AVX", len);
+            {
+               s[_len++] = ' ';
+               s[_len++] = 'A';
+               s[_len++] = 'V';
+               s[_len++] = 'X';
+               s[_len+1] = '\0';
+            }
             if (cpu & RETRO_SIMD_AVX2)
-               strlcat(s, " AVX2", len);
+            {
+               s[_len++] = ' ';
+               s[_len++] = 'A';
+               s[_len++] = 'V';
+               s[_len++] = 'X';
+               s[_len++] = '2';
+               s[_len+1] = '\0';
+            }
             if (cpu & RETRO_SIMD_NEON)
-               strlcat(s, " NEON", len);
+            {
+               s[_len++] = ' ';
+               s[_len++] = 'N';
+               s[_len++] = 'E';
+               s[_len++] = 'O';
+               s[_len++] = 'N';
+               s[_len+1] = '\0';
+            }
             if (cpu & RETRO_SIMD_VFPV3)
-               strlcat(s, " VFPv3", len);
+            {
+               s[_len++] = ' ';
+               s[_len++] = 'V';
+               s[_len++] = 'F';
+               s[_len++] = 'P';
+               s[_len++] = 'v';
+               s[_len++] = '3';
+               s[_len+1] = '\0';
+            }
             if (cpu & RETRO_SIMD_VFPV4)
-               strlcat(s, " VFPv4", len);
+            {
+               s[_len++] = ' ';
+               s[_len++] = 'V';
+               s[_len++] = 'F';
+               s[_len++] = 'P';
+               s[_len++] = 'v';
+               s[_len++] = '4';
+               s[_len+1] = '\0';
+            }
             if (cpu & RETRO_SIMD_VMX)
-               strlcat(s, " VMX", len);
+            {
+               s[_len++] = ' ';
+               s[_len++] = 'V';
+               s[_len++] = 'M';
+               s[_len++] = 'X';
+               s[_len+1] = '\0';
+            }
             if (cpu & RETRO_SIMD_VMX128)
-               strlcat(s, " VMX128", len);
+            {
+               s[_len++] = ' ';
+               s[_len++] = 'V';
+               s[_len++] = 'M';
+               s[_len++] = 'X';
+               s[_len++] = '1';
+               s[_len++] = '2';
+               s[_len++] = '8';
+               s[_len+1] = '\0';
+            }
             if (cpu & RETRO_SIMD_VFPU)
-               strlcat(s, " VFPU", len);
+            {
+               s[_len++] = ' ';
+               s[_len++] = 'V';
+               s[_len++] = 'F';
+               s[_len++] = 'P';
+               s[_len++] = 'U';
+               s[_len+1] = '\0';
+            }
             if (cpu & RETRO_SIMD_PS)
-               strlcat(s, " PS", len);
+            {
+               s[_len++] = ' ';
+               s[_len++] = 'P';
+               s[_len++] = 'S';
+               s[_len+1] = '\0';
+            }
             if (cpu & RETRO_SIMD_ASIMD)
-               strlcat(s, " ASIMD", len);
+            {
+               s[_len++] = ' ';
+               s[_len++] = 'A';
+               s[_len++] = 'S';
+               s[_len++] = 'I';
+               s[_len++] = 'M';
+               s[_len++] = 'D';
+               s[_len+1] = '\0';
+            }
+            s[_len++] = '\0';
          }
          break;
       case RARCH_CAPABILITIES_COMPILER:

--- a/retroarch.h
+++ b/retroarch.h
@@ -88,7 +88,7 @@ RETRO_BEGIN_DECLS
 bool retroarch_ctl(enum rarch_ctl_state state, void *data);
 
 int retroarch_get_capabilities(enum rarch_capabilities type,
-      char *s, size_t len);
+      char *s, size_t len, size_t _len);
 
 void retroarch_override_setting_set(enum rarch_override_setting enum_idx, void *data);
 


### PR DESCRIPTION
(retroarch.c) retroarch_get_capabilities - get rid of strlcat
 party in RARCH_CAPABILITIES_CPU, do simple manual assignment for
 concatenation instead and NULL terminate at the end
(menu_displaylist.c) Do something about some of the unnecessarily huge
 local strings of PATH_MAX_LENGTH size (can be as large as 8192)
(menu_displaylist.c) Replace some trivial strlcats / snprintfs
(D3D10/D3D11/D3D12) Strings don't need to be initialized -
strlcpy already null-terminates - get rid of some constants