### PR TITLE
rzipstream_gets: Fix missing eol

### DIFF
--- a/libretro-common/streams/rzip_stream.c
+++ b/libretro-common/streams/rzip_stream.c
@@ -620,11 +620,15 @@ char* rzipstream_gets(rzipstream_t *stream, char *s, size_t len)
       c = rzipstream_getc(stream);
 
       /* Check for newline and EOF */
-      if ((c == '\n') || (c == EOF))
+      if (c == EOF)
          break;
 
       /* Copy character to string buffer */
       *str_ptr++ = c;
+
+      /* Check for newline and EOF */
+      if (c == '\n')
+          break;
    }
 
    /* Add NUL termination */


### PR DESCRIPTION
The eol was always stripped from the data, leading to behavior
differences with filestream_gets and general read line implementations.