### PR TITLE
(Netplay) More removal of older unused code

### DIFF
--- a/network/netplay/netplay_private.h
+++ b/network/netplay/netplay_private.h
@@ -258,10 +258,7 @@ enum rarch_netplay_stall_reason
    NETPLAY_STALL_INPUT_LATENCY,
 
    /* The server asked us to stall */
-   NETPLAY_STALL_SERVER_REQUESTED,
-
-   /* We have no connection and must have one to proceed */
-   NETPLAY_STALL_NO_CONNECTION
+   NETPLAY_STALL_SERVER_REQUESTED
 };
 
 /* Input state for a particular client-device pair */


### PR DESCRIPTION
## Description

NETPLAY_STALL_NO_CONNECTION and its related code was only used by stateless, which in turn was not being used at all.
Now that the old stateless code is removed, remove the code related to this enum aswell.