### PR TITLE
(RGUI) Savestate thumbnails

### DIFF
--- a/menu/cbs/menu_cbs_scan.c
+++ b/menu/cbs/menu_cbs_scan.c
@@ -114,8 +114,8 @@ int action_switch_thumbnail(const char *path,
    if (!settings)
       return -1;
 
-   /* RGUI is a special case where thumbnail 'switch' corresponds to
-    * toggling thumbnail view on/off.
+   /* RGUI has its own cycling for thumbnails in order to allow
+    * cycling all images in fullscreen mode.
     * GLUI is a special case where thumbnail 'switch' corresponds to
     * changing thumbnail view mode.
     * For other menu drivers, we cycle through available thumbnail


### PR DESCRIPTION
## Description

The same savestate/playlist thumbnail treatment/logic like currently with XMB & Ozone, plus:
- Title headroom for fullscreen maximum height
- Fullscreen toggle logic with missing boxart
- Separate thumbnail cycle logic for playlist fullscreen mode

## Related Issues

Closes #12026

![retroarch_2022_08_18_00_36_32_623](https://user-images.githubusercontent.com/45124675/185247988-2029e7e0-1089-4c9b-9429-ea04cd28097e.png)

![retroarch_2022_08_18_00_36_35_276](https://user-images.githubusercontent.com/45124675/185248000-2200e460-02da-4e04-b1a4-36372c13bc2d.png)

![retroarch_2022_08_18_00_39_42_271](https://user-images.githubusercontent.com/45124675/185248335-048eca22-9ab0-465f-afbb-60a9b2046e46.png)

![retroarch_2022_08_18_00_40_58_318](https://user-images.githubusercontent.com/45124675/185248452-950de3c8-0a03-488b-8540-7f4c6eb5c1ab.png)
