### PR TITLE
don't hold property_lock while gathering tasks

### DIFF
--- a/libretro-common/queues/task_queue.c
+++ b/libretro-common/queues/task_queue.c
@@ -392,17 +392,14 @@ static void retro_task_threaded_gather(void)
 {
    retro_task_t *task = NULL;
 
-   slock_lock(property_lock);
    slock_lock(running_lock);
    for (task = tasks_running.front; task; task = task->next)
       task_queue_push_progress(task);
-
    slock_unlock(running_lock);
 
    slock_lock(finished_lock);
    retro_task_internal_gather();
    slock_unlock(finished_lock);
-   slock_unlock(property_lock);
 }
 
 static void retro_task_threaded_wait(retro_task_condition_fn_t cond, void* data)


### PR DESCRIPTION
## Description

Fixes a deadlock on Windows when initializing the netplay host with achievements enabled

1. Open a game with achievements
2. Open the menu
3. Select the Netplay submenu
4. Select Host

At this point, the main loop attempts to process the task queue by calling `task_queue_check`. The netplay load task is in the queue and gets invoked. That calls into `CMD_EVENT_UNLOAD_CORE` via the changes in https://github.com/libretro/RetroArch/pull/14117/files#diff-6800918de82a2c6e290d04443a9c9c39251494fb29ad21d0d6367b1370c0b3ebR465. That calls back into the task code to kill the background tasks via `sthread_join`, which waits indefinitely for the background threads to terminate.

However, the background thread that is attempting to initialize the achievement subsystem is trying to update its `task` object, and is waiting for the `property_lock` to be released, which was grabbed by `retro_task_threaded_gather` as called by `task_queue_check`. This results in a deadlock where the main thread is waiting for the background thread to finish and is holding a lock that prevents the background thread from being able to finish.

Main thread callstack:
```
 sthread_join(sthread * thread) Line 293  <<< waiting for background thread to terminate
 retro_task_threaded_deinit() Line 573
 task_queue_deinit() Line 609
 task_push_start_dummy_core(content_ctx_info * content_info) Line 1962
 command_event(event_command cmd, void * data) Line 1951
 task_netplay_crc_scan_callback(retro_task * task, void * task_data, void * user_data, const char * error) Line 556
 retro_task_internal_gather() Line 176
 retro_task_threaded_gather() Line 404  <<< lock is being held here
 task_queue_check() Line 669
 rarch_main(int argc, char * * argv, void * data) Line 3870
 main(int argc, char * * argv) Line 3944
```
Background thread:
```
 slock_lock(slock * lock) Line 378  <<< waiting for lock
 task_set_progress(retro_task * task, char progress) Line 802
 task_http_iterate_transfer(retro_task * task) Line 131
 task_http_transfer_handler(retro_task * task) Line 160
 threaded_worker(void * userdata) Line 509
 thread_wrap(void * data_) Line 144
```

The lock being held is the `property_lock`, which seems to only be used in the `task_get_` and `task_set_` functions. It's unclear why it's being grabbed in `task_threaded_gather`, or why it's being held for the duration of the function. 

Holding a lock around callbacks is generally dangerous because it's unclear to the callback that the lock is being held, and there's no way to prevent the callback from calling something else that will try to grab the lock. That's more-or-less what's happening here.

I believe `property_lock` is being used incorrectly in this scenario, so I've removed the lock on it. This allows the background thread to terminate properly and the netplay code to deinit the core in the task callback.

## Related Issues

Possibly #14327? It's describing the same behavior, but on Android. I don't have an Android debugger/build to test with. I could not reproduce on Linux.

## Related Pull Requests

n/a

## Reviewers

@LibretroAdmin @Cthulhu-throwaway
