### PR TITLE
[cheevos] release achievement badge textures when video driver is deinitialized

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -53,6 +53,7 @@
 
 #include "cheevos.h"
 #include "cheevos_client.h"
+#include "cheevos_menu.h"
 #include "cheevos_locals.h"
 
 #include "../network/netplay/netplay.h"

--- a/cheevos/cheevos_locals.h
+++ b/cheevos/cheevos_locals.h
@@ -147,8 +147,6 @@ typedef struct rcheevos_menuitem_t
    enum msg_hash_enums state_label_idx;
 } rcheevos_menuitem_t;
 
-void rcheevos_menu_reset_badges(void);
-
 #endif
 
 typedef struct rcheevos_locals_t

--- a/cheevos/cheevos_menu.h
+++ b/cheevos/cheevos_menu.h
@@ -33,6 +33,7 @@ void rcheevos_menu_populate_hardcore_pause_submenu(void* data);
 bool rcheevos_menu_get_state(unsigned menu_offset, char* buffer, size_t buffer_size);
 bool rcheevos_menu_get_sublabel(unsigned menu_offset, char* buffer, size_t buffer_size);
 uintptr_t rcheevos_menu_get_badge_texture(unsigned menu_offset);
+void rcheevos_menu_reset_badges(void);
 
 RETRO_END_DECLS
 

--- a/driver.c
+++ b/driver.c
@@ -49,6 +49,9 @@
 
 #ifdef HAVE_MENU
 #include "menu/menu_driver.h"
+#ifdef HAVE_CHEEVOS
+#include "cheevos/cheevos_menu.h"
+#endif
 #endif
 
 static void retro_frame_null(const void *data, unsigned width,
@@ -719,6 +722,10 @@ void driver_uninit(int flags)
       menu_explore_context_deinit();
 #endif
       menu_contentless_cores_context_deinit();
+
+#ifdef HAVE_CHEEVOS
+      rcheevos_menu_reset_badges();
+#endif
 
       menu_driver_ctl(RARCH_MENU_CTL_DEINIT, NULL);
    }


### PR DESCRIPTION
## Description

Fixes corrupted badges showing in achievements menu after toggling fullscreen. Could also potentially fix a memory leak or a crash depending on how the video driver manages its texture memory.

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

[If possible @mention all the people that should review your pull request]
