### PR TITLE
Fix core option categories regression

### DIFF
--- a/core_option_manager.c
+++ b/core_option_manager.c
@@ -1206,7 +1206,7 @@ core_option_manager_t *core_option_manager_new(
          {
             address[0] = '\0';
             snprintf(address, sizeof(address),
-                  "%s#%s",
+                  "%s:#%s",
                   category_key, option_def->key);
          }
 


### PR DESCRIPTION
Just a quick edit to fix the oversight that was causing core option categories to be ignored at all times. Fixes https://github.com/libretro/RetroArch/issues/14331.
