### PR TITLE
more thread-awareness in task callbacks

### DIFF
--- a/gfx/gfx_widgets.c
+++ b/gfx/gfx_widgets.c
@@ -234,7 +234,6 @@ void gfx_widgets_msg_queue_push(
          msg_widget->expiration_timer_started   = false;
 
          msg_widget->task_ptr                   = task;
-         msg_widget->task_title_ptr             = NULL;
          msg_widget->task_count                 = 0;
 
          msg_widget->task_progress              = 0;
@@ -268,7 +267,6 @@ void gfx_widgets_msg_queue_push(
             msg_widget->task_finished           = task->finished;
             msg_widget->task_progress           = task->progress;
             msg_widget->task_ident              = task->ident;
-            msg_widget->task_title_ptr          = title;
             msg_widget->task_count              = 1;
 
             msg_widget->unfolded                = true;
@@ -366,7 +364,6 @@ void gfx_widgets_msg_queue_push(
                   1);
 
             msg_widget->msg_len                    = len;
-            msg_widget->task_title_ptr             = title;
             msg_widget->msg_transition_animation   = 0;
 
             if (!task->alternative_look)

--- a/gfx/gfx_widgets.c
+++ b/gfx/gfx_widgets.c
@@ -215,9 +215,6 @@ void gfx_widgets_msg_queue_push(
 
          msg_widget                             = (disp_widget_msg_t*)malloc(sizeof(*msg_widget));
 
-         if (task)
-            title                               = task->title;
-
          msg_widget->msg                        = NULL;
          msg_widget->msg_new                    = NULL;
          msg_widget->msg_transition_animation   = 0.0f;
@@ -262,7 +259,7 @@ void gfx_widgets_msg_queue_push(
 
          if (task)
          {
-            msg_widget->msg                     = strdup(title);
+            title = msg_widget->msg             = strdup(task->title);
             msg_widget->msg_new                 = strdup(title);
             msg_widget->msg_len                 = (unsigned)strlen(title);
 
@@ -271,7 +268,7 @@ void gfx_widgets_msg_queue_push(
             msg_widget->task_finished           = task->finished;
             msg_widget->task_progress           = task->progress;
             msg_widget->task_ident              = task->ident;
-            msg_widget->task_title_ptr          = task->title;
+            msg_widget->task_title_ptr          = title;
             msg_widget->task_count              = 1;
 
             msg_widget->unfolded                = true;
@@ -351,12 +348,7 @@ void gfx_widgets_msg_queue_push(
 
          if (!string_is_equal(task->title, msg_widget->msg_new))
          {
-            unsigned len         = (unsigned)strlen(task->title);
-            unsigned new_width   = font_driver_get_message_width(
-                  p_dispwidget->gfx_widget_fonts.msg_queue.font,
-                  task->title,
-                  len,
-                  1);
+            unsigned len, new_width;
 
             if (msg_widget->msg_new)
             {
@@ -364,9 +356,17 @@ void gfx_widgets_msg_queue_push(
                msg_widget->msg_new                 = NULL;
             }
 
-            msg_widget->msg_new                    = strdup(task->title);
+            title       = msg_widget->msg_new      = strdup(task->title);
+
+            len         = (unsigned)strlen(title);
+            new_width   = font_driver_get_message_width(
+                  p_dispwidget->gfx_widget_fonts.msg_queue.font,
+                  title,
+                  len,
+                  1);
+
             msg_widget->msg_len                    = len;
-            msg_widget->task_title_ptr             = task->title;
+            msg_widget->task_title_ptr             = title;
             msg_widget->msg_transition_animation   = 0;
 
             if (!task->alternative_look)

--- a/gfx/gfx_widgets.h
+++ b/gfx/gfx_widgets.h
@@ -116,7 +116,7 @@ typedef struct disp_widget_msg
    char *msg_new;
    retro_task_t *task_ptr;
    /* Used to detect title change */
-   char *task_title_ptr;
+   const char *task_title_ptr;
 
    uint32_t task_ident;
    unsigned msg_len;

--- a/gfx/gfx_widgets.h
+++ b/gfx/gfx_widgets.h
@@ -115,8 +115,6 @@ typedef struct disp_widget_msg
    char *msg;
    char *msg_new;
    retro_task_t *task_ptr;
-   /* Used to detect title change */
-   const char *task_title_ptr;
 
    uint32_t task_ident;
    unsigned msg_len;

--- a/libretro-common/queues/task_queue.c
+++ b/libretro-common/queues/task_queue.c
@@ -91,6 +91,13 @@ static void task_queue_msg_push(retro_task_t *task,
 
 static void task_queue_push_progress(retro_task_t *task)
 {
+#ifdef HAVE_THREADS
+   /* msg_push callback interacts directly with the task properties (particularly title).
+    * make sure another thread doesn't modify them while rendering
+    */
+   slock_lock(property_lock);
+#endif
+
    if (task->title && !task->mute)
    {
       if (task->finished)
@@ -113,6 +120,10 @@ static void task_queue_push_progress(retro_task_t *task)
       if (task->progress_cb)
          task->progress_cb(task);
    }
+
+#ifdef HAVE_THREADS
+   slock_unlock(property_lock);
+#endif
 }
 
 static void task_queue_put(task_queue_t *queue, retro_task_t *task)
@@ -392,7 +403,6 @@ static void retro_task_threaded_gather(void)
 {
    retro_task_t *task = NULL;
 
-   slock_lock(property_lock);
    slock_lock(running_lock);
    for (task = tasks_running.front; task; task = task->next)
       task_queue_push_progress(task);
@@ -401,7 +411,6 @@ static void retro_task_threaded_gather(void)
    slock_lock(finished_lock);
    retro_task_internal_gather();
    slock_unlock(finished_lock);
-   slock_unlock(property_lock);
 }
 
 static void retro_task_threaded_wait(retro_task_condition_fn_t cond, void* data)

--- a/tasks/task_decompress.c
+++ b/tasks/task_decompress.c
@@ -290,7 +290,7 @@ void *task_push_decompress(
    if (!(s = (decompress_state_t*)calloc(1, sizeof(*s))))
       return NULL;
 
-   if (!(t = (retro_task_t*)calloc(1, sizeof(*t))))
+   if (!(t = task_init()))
    {
       free(s);
       return NULL;


### PR DESCRIPTION
## Description

Second attempt of #14328.

Removing the `property_lock` in `retro_task_threaded_gather` introduced an issue where using the core updater would often cause RetroArch to crash, which resulted in that PR being reverted.

This was caused by two problems:
1) The widget code was directly interacting with the `task` object, in particular, the `task->title`. The core updater thread would update the `task->title` as it transitioned states. If these occurred at the same time, the widget code would be reading memory that may no longer contain the old string.
  - I have opted to keep the `property_lock` for this scenario, as the `task_get_title` function returns the same `char*` without any way to ensure it doesn't get replaced after the lock is free'd. This seems like a flaw with the `task_get_title` implementation, but there doesn't appear to be anything calling it currently. The `property_lock` has been moved so it's only locked while calling the widget code (thus fixing the deadlock originally being addressed in #14328). I also made a couple of changes so the widget code only references the `task->title` once per function call.
2) The core updater background thread was relying on the `property_lock` to delay transitioning from the "download" to the "decompress" state. When it updated the title to "Extracting ...", it would actually block while the main thread queued up the decompression task. Without the `property_lock`, the task title would be updated more quickly, and the code would immediately transition into the "decompress" state, where it would not find a decompress task and immediately transition into the done state assuming an error had occurred and the `core_updater_download_handle` would be free'd. In reality, no error occurred - the task just hadn't finished being constructed yet. So when the task did get created and started to execute, it would try to use the no-longer existant `core_updater_download_handle` and corrupt memory.
  - To address this, I've modified the logic to not treat a missing decompress task as an error, and instead wait for the task to exist, or an actual error to be captured.

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@LibretroAdmin, @Cthulhu-throwaway
