### PR TITLE
Don't make libretrodb dependent on errno anymore

### DIFF
--- a/libretro-db/bintree.c
+++ b/libretro-db/bintree.c
@@ -22,7 +22,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <errno.h>
 
 #include <retro_inline.h>
 

--- a/libretro-db/libretrodb.c
+++ b/libretro-db/libretrodb.c
@@ -27,7 +27,6 @@
 #include <unistd.h>
 #endif
 #include <string.h>
-#include <errno.h>
 #include <sys/stat.h>
 #include <stdlib.h>
 
@@ -214,13 +213,12 @@ int libretrodb_open(const char *path, libretrodb_t *db)
 {
    libretrodb_header_t header;
    libretrodb_metadata_t md;
-   int rv    = 0;
    RFILE *fd = filestream_open(path,
          RETRO_VFS_FILE_ACCESS_READ,
          RETRO_VFS_FILE_ACCESS_HINT_NONE);
 
    if (!fd)
-      return -errno;
+      return -1;
 
    if (!string_is_empty(db->path))
       free(db->path);
@@ -229,26 +227,17 @@ int libretrodb_open(const char *path, libretrodb_t *db)
    db->root  = filestream_tell(fd);
 
    if ((int)filestream_read(fd, &header, sizeof(header)) == -1)
-   {
-      rv = -errno;
       goto error;
-   }
 
    if (strncmp(header.magic_number, MAGIC_NUMBER, sizeof(MAGIC_NUMBER)) != 0)
-   {
-      rv = -EINVAL;
       goto error;
-   }
 
    header.metadata_offset = swap_if_little64(header.metadata_offset);
    filestream_seek(fd, (ssize_t)header.metadata_offset,
          RETRO_VFS_SEEK_POSITION_START);
 
    if (libretrodb_read_metadata(fd, &md) < 0)
-   {
-      rv = -EINVAL;
       goto error;
-   }
 
    db->count              = md.count;
    db->first_index_offset = filestream_tell(fd);
@@ -258,7 +247,7 @@ int libretrodb_open(const char *path, libretrodb_t *db)
 error:
    if (fd)
       filestream_close(fd);
-   return rv;
+   return -1;
 }
 
 static int libretrodb_find_index(libretrodb_t *db, const char *index_name,
@@ -322,10 +311,9 @@ int libretrodb_find_entry(libretrodb_t *db, const char *index_name,
       return -1;
 
    bufflen = idx.next;
-   buff    = malloc(bufflen);
 
-   if (!buff)
-      return -ENOMEM;
+   if (!(buff = malloc(bufflen)))
+      return -1;
 
    while (nread < bufflen)
    {
@@ -335,7 +323,7 @@ int libretrodb_find_entry(libretrodb_t *db, const char *index_name,
       if (rv <= 0)
       {
          free(buff);
-         return -errno;
+         return -1;
       }
       nread += rv;
    }
@@ -437,14 +425,12 @@ int libretrodb_cursor_open(libretrodb_t *db,
 {
    RFILE *fd = NULL;
    if (!db || string_is_empty(db->path))
-      return -errno;
+      return -1;
 
-   fd = filestream_open(db->path,
+   if (!(fd = filestream_open(db->path,
          RETRO_VFS_FILE_ACCESS_READ,
-         RETRO_VFS_FILE_ACCESS_HINT_NONE);
-
-   if (!fd)
-      return -errno;
+         RETRO_VFS_FILE_ACCESS_HINT_NONE)))
+      return -1;
 
    cursor->fd       = fd;
    cursor->db       = db;

--- a/libretro-db/libretrodb_tool.c
+++ b/libretro-db/libretrodb_tool.c
@@ -62,14 +62,14 @@ int main(int argc, char ** argv)
 
    if ((rv = libretrodb_open(path, db)) != 0)
    {
-      printf("Could not open db file '%s': %s\n", path, strerror(-rv));
+      printf("Could not open db file '%s'\n", path);
       goto error;
    }
    else if (memcmp(command, "list", 4) == 0)
    {
       if ((rv = libretrodb_cursor_open(db, cur, NULL)) != 0)
       {
-         printf("Could not open cursor: %s\n", strerror(-rv));
+         printf("Could not open cursor\n");
          goto error;
       }
 
@@ -106,7 +106,7 @@ int main(int argc, char ** argv)
 
       if ((rv = libretrodb_cursor_open(db, cur, q)) != 0)
       {
-         printf("Could not open cursor: %s\n", strerror(-rv));
+         printf("Could not open cursor\n");
          goto error;
       }
 
@@ -137,7 +137,7 @@ int main(int argc, char ** argv)
 
       if ((rv = libretrodb_cursor_open(db, cur, q)) != 0)
       {
-         printf("Could not open cursor: %s\n", strerror(-rv));
+         printf("Could not open cursor\n");
          goto error;
       }
 

--- a/libretro-db/rmsgpack.c
+++ b/libretro-db/rmsgpack.c
@@ -26,7 +26,6 @@
 #else
 #include <unistd.h>
 #endif
-#include <errno.h>
 #include <stdint.h>
 #include <string.h>
 
@@ -107,31 +106,28 @@ int rmsgpack_write_array_header(RFILE *fd, uint32_t size)
    {
       size = (size | MPF_FIXARRAY);
       if (filestream_write(fd, &size, sizeof(int8_t)) == -1)
-         goto error;
+         return -1;
       return sizeof(int8_t);
    }
    else if (size == (uint16_t)size)
    {
       if (filestream_write(fd, &MPF_ARRAY16, sizeof(MPF_ARRAY16)) == -1)
-         goto error;
+         return -1;
       tmp_i16 = swap_if_little16(size);
       if (filestream_write(fd, (void *)(&tmp_i16), sizeof(uint16_t)) == -1)
-         goto error;
+         return -1;
       return sizeof(int8_t) + sizeof(uint16_t);
    }
 
    if (filestream_write(fd, &MPF_ARRAY32, sizeof(MPF_ARRAY32)) == -1)
-      goto error;
+      return -1;
 
    tmp_i32 = swap_if_little32(size);
 
    if (filestream_write(fd, (void *)(&tmp_i32), sizeof(uint32_t)) == -1)
-      goto error;
+      return -1;
 
    return sizeof(int8_t) + sizeof(uint32_t);
-
-error:
-   return -errno;
 }
 
 int rmsgpack_write_map_header(RFILE *fd, uint32_t size)
@@ -143,29 +139,26 @@ int rmsgpack_write_map_header(RFILE *fd, uint32_t size)
    {
       size = (size | MPF_FIXMAP);
       if (filestream_write(fd, &size, sizeof(int8_t)) == -1)
-         goto error;
+         return -1;
       return sizeof(int8_t);
    }
    else if (size == (uint16_t)size)
    {
       if (filestream_write(fd, &MPF_MAP16, sizeof(MPF_MAP16)) == -1)
-         goto error;
+         return -1;
       tmp_i16 = swap_if_little16(size);
       if (filestream_write(fd, (void *)(&tmp_i16), sizeof(uint16_t)) == -1)
-         goto error;
+         return -1;
       return sizeof(uint8_t) + sizeof(uint16_t);
    }
 
    tmp_i32 = swap_if_little32(size);
    if (filestream_write(fd, &MPF_MAP32, sizeof(MPF_MAP32)) == -1)
-      goto error;
+      return -1;
    if (filestream_write(fd, (void *)(&tmp_i32), sizeof(uint32_t)) == -1)
-      goto error;
+      return -1;
 
    return sizeof(int8_t) + sizeof(uint32_t);
-
-error:
-   return -errno;
 }
 
 int rmsgpack_write_string(RFILE *fd, const char *s, uint32_t len)
@@ -179,45 +172,42 @@ int rmsgpack_write_string(RFILE *fd, const char *s, uint32_t len)
    {
       tmp_i8 = len | MPF_FIXSTR;
       if (filestream_write(fd, &tmp_i8, sizeof(uint8_t)) == -1)
-         goto error;
+         return -1;
    }
    else if (len == (uint8_t)len)
    {
       if (filestream_write(fd, &MPF_STR8, sizeof(MPF_STR8)) == -1)
-         goto error;
+         return -1;
       tmp_i8 = (uint8_t)len;
       if (filestream_write(fd, &tmp_i8, sizeof(uint8_t)) == -1)
-         goto error;
+         return -1;
       written += sizeof(uint8_t);
    }
    else if (len == (uint16_t)len)
    {
       if (filestream_write(fd, &MPF_STR16, sizeof(MPF_STR16)) == -1)
-         goto error;
+         return -1;
       tmp_i16 = swap_if_little16(len);
       if (filestream_write(fd, &tmp_i16, sizeof(uint16_t)) == -1)
-         goto error;
+         return -1;
       written += sizeof(uint16_t);
    }
    else
    {
       if (filestream_write(fd, &MPF_STR32, sizeof(MPF_STR32)) == -1)
-         goto error;
+         return -1;
       tmp_i32 = swap_if_little32(len);
       if (filestream_write(fd, &tmp_i32, sizeof(uint32_t)) == -1)
-         goto error;
+         return -1;
       written += sizeof(uint32_t);
    }
 
    if (filestream_write(fd, s, len) == -1)
-      goto error;
+      return -1;
 
    written += len;
 
    return written;
-
-error:
-   return -errno;
 }
 
 int rmsgpack_write_bin(RFILE *fd, const void *s, uint32_t len)
@@ -229,41 +219,36 @@ int rmsgpack_write_bin(RFILE *fd, const void *s, uint32_t len)
    if (len == (uint8_t)len)
    {
       if (filestream_write(fd, &MPF_BIN8, sizeof(MPF_BIN8)) == -1)
-         goto error;
+         return -1;
       tmp_i8 = (uint8_t)len;
       if (filestream_write(fd, &tmp_i8, sizeof(uint8_t)) == -1)
-         goto error;
+         return -1;
    }
    else if (len == (uint16_t)len)
    {
       if (filestream_write(fd, &MPF_BIN16, sizeof(MPF_BIN16)) == -1)
-         goto error;
+         return -1;
       tmp_i16 = swap_if_little16(len);
       if (filestream_write(fd, &tmp_i16, sizeof(uint16_t)) == -1)
-         goto error;
+         return -1;
    }
    else
    {
       if (filestream_write(fd, &MPF_BIN32, sizeof(MPF_BIN32)) == -1)
-         goto error;
+         return -1;
       tmp_i32 = swap_if_little32(len);
       if (filestream_write(fd, &tmp_i32, sizeof(uint32_t)) == -1)
-         goto error;
+         return -1;
    }
-
    if (filestream_write(fd, s, len) == -1)
-      goto error;
-
+      return -1;
    return 0;
-
-error:
-   return -errno;
 }
 
 int rmsgpack_write_nil(RFILE *fd)
 {
    if (filestream_write(fd, &MPF_NIL, sizeof(MPF_NIL)) == -1)
-      return -errno;
+      return -1;
    return sizeof(uint8_t);
 }
 
@@ -272,16 +257,13 @@ int rmsgpack_write_bool(RFILE *fd, int value)
    if (value)
    {
       if (filestream_write(fd, &MPF_TRUE, sizeof(MPF_TRUE)) == -1)
-         goto error;
+         return -1;
    }
 
    if (filestream_write(fd, &MPF_FALSE, sizeof(MPF_FALSE)) == -1)
-      goto error;
+      return -1;
 
    return sizeof(uint8_t);
-
-error:
-   return -errno;
 }
 
 int rmsgpack_write_int(RFILE *fd, int64_t value)
@@ -296,59 +278,56 @@ int rmsgpack_write_int(RFILE *fd, int64_t value)
    {
       tmpval = (uint8_t)value;
       if (filestream_write(fd, &tmpval, sizeof(uint8_t)) == -1)
-         goto error;
+         return -1;
    }
    else if (value >= -32 && value < 0)
    {
       tmpval = (uint8_t)(value + 256); /* -32..-1 => 0xE0 .. 0xFF */
       if (filestream_write(fd, &tmpval, sizeof(uint8_t)) == -1)
-         goto error;
+         return -1;
    }
    else if (value == (int8_t)value)
    {
       if (filestream_write(fd, &MPF_INT8, sizeof(MPF_INT8)) == -1)
-         goto error;
+         return -1;
 
       tmp_i8 = (int8_t)value;
       if (filestream_write(fd, &tmp_i8, sizeof(int8_t)) == -1)
-         goto error;
+         return -1;
       written += sizeof(int8_t);
    }
    else if (value == (int16_t)value)
    {
       if (filestream_write(fd, &MPF_INT16, sizeof(MPF_INT16)) == -1)
-         goto error;
+         return -1;
 
       tmp_i16 = swap_if_little16((uint16_t)value);
       if (filestream_write(fd, &tmp_i16, sizeof(int16_t)) == -1)
-         goto error;
+         return -1;
       written += sizeof(int16_t);
    }
    else if (value == (int32_t)value)
    {
       if (filestream_write(fd, &MPF_INT32, sizeof(MPF_INT32)) == -1)
-         goto error;
+         return -1;
 
       tmp_i32 = swap_if_little32((uint32_t)value);
       if (filestream_write(fd, &tmp_i32, sizeof(int32_t)) == -1)
-         goto error;
+         return -1;
       written += sizeof(int32_t);
    }
    else
    {
       if (filestream_write(fd, &MPF_INT64, sizeof(MPF_INT64)) == -1)
-         goto error;
+         return -1;
 
       value = swap_if_little64(value);
       if (filestream_write(fd, &value, sizeof(int64_t)) == -1)
-         goto error;
+         return -1;
       written += sizeof(int64_t);
    }
 
    return written;
-
-error:
-   return -errno;
 }
 
 int rmsgpack_write_uint(RFILE *fd, uint64_t value)
@@ -361,47 +340,44 @@ int rmsgpack_write_uint(RFILE *fd, uint64_t value)
    if (value == (uint8_t)value)
    {
       if (filestream_write(fd, &MPF_UINT8, sizeof(MPF_UINT8)) == -1)
-         goto error;
+         return -1;
 
       tmp_i8 = (uint8_t)value;
       if (filestream_write(fd, &tmp_i8, sizeof(uint8_t)) == -1)
-         goto error;
+         return -1;
       written += sizeof(uint8_t);
    }
    else if (value == (uint16_t)value)
    {
       if (filestream_write(fd, &MPF_UINT16, sizeof(MPF_UINT16)) == -1)
-         goto error;
+         return -1;
 
       tmp_i16 = swap_if_little16((uint16_t)value);
       if (filestream_write(fd, &tmp_i16, sizeof(uint16_t)) == -1)
-         goto error;
+         return -1;
       written += sizeof(uint16_t);
    }
    else if (value == (uint32_t)value)
    {
       if (filestream_write(fd, &MPF_UINT32, sizeof(MPF_UINT32)) == -1)
-         goto error;
+         return -1;
 
       tmp_i32 = swap_if_little32((uint32_t)value);
       if (filestream_write(fd, &tmp_i32, sizeof(uint32_t)) == -1)
-         goto error;
+         return -1;
       written += sizeof(uint32_t);
    }
    else
    {
       if (filestream_write(fd, &MPF_UINT64, sizeof(MPF_UINT64)) == -1)
-         goto error;
+         return -1;
 
       value = swap_if_little64(value);
       if (filestream_write(fd, &value, sizeof(uint64_t)) == -1)
-         goto error;
+         return -1;
       written += sizeof(uint64_t);
    }
    return written;
-
-error:
-   return -errno;
 }
 
 static int read_uint(RFILE *fd, uint64_t *out, size_t size)
@@ -409,7 +385,7 @@ static int read_uint(RFILE *fd, uint64_t *out, size_t size)
    union { uint64_t u64; uint32_t u32; uint16_t u16; uint8_t u8; } tmp;
 
    if (filestream_read(fd, &tmp, size) == -1)
-      goto error;
+      return -1;
 
    switch (size)
    {
@@ -427,9 +403,6 @@ static int read_uint(RFILE *fd, uint64_t *out, size_t size)
          break;
    }
    return 0;
-
-error:
-   return -errno;
 }
 
 static int read_int(RFILE *fd, int64_t *out, size_t size)
@@ -437,7 +410,7 @@ static int read_int(RFILE *fd, int64_t *out, size_t size)
    union { uint64_t u64; uint32_t u32; uint16_t u16; uint8_t u8; } tmp;
 
    if (filestream_read(fd, &tmp, size) == -1)
-      goto error;
+      return -1;
 
    switch (size)
    {
@@ -455,9 +428,6 @@ static int read_int(RFILE *fd, int64_t *out, size_t size)
          break;
    }
    return 0;
-
-error:
-   return -errno;
 }
 
 static int read_buff(RFILE *fd, size_t size, char **pbuff, uint64_t *len)
@@ -466,24 +436,22 @@ static int read_buff(RFILE *fd, size_t size, char **pbuff, uint64_t *len)
    ssize_t read_len = 0;
 
    if (read_uint(fd, &tmp_len, size) == -1)
-      return -errno;
+      return -1;
 
    *pbuff = (char *)malloc((size_t)(tmp_len + 1) * sizeof(char));
 
    if ((read_len = filestream_read(fd, *pbuff, (size_t)tmp_len)) == -1)
-      goto error;
+   {
+      free(*pbuff);
+      *pbuff = NULL;
+      return -1;
+   }
 
    *len = read_len;
    (*pbuff)[read_len] = 0;
 
    /* Throw warning on read_len != tmp_len ? */
-
    return 0;
-
-error:
-   free(*pbuff);
-   *pbuff = NULL;
-   return -errno;
 }
 
 static int read_map(RFILE *fd, uint32_t len,
@@ -537,7 +505,7 @@ int rmsgpack_read(RFILE *fd,
    char *buff        = NULL;
 
    if (filestream_read(fd, &type, sizeof(uint8_t)) == -1)
-      goto error;
+      return -1;
 
    if (type < MPF_FIXMAP)
    {
@@ -565,7 +533,7 @@ int rmsgpack_read(RFILE *fd,
       if ((read_len = filestream_read(fd, buff, (ssize_t)tmp_len)) == -1)
       {
          free(buff);
-         goto error;
+         return -1;
       }
       buff[read_len] = '\0';
       if (!callbacks->read_string)
@@ -613,7 +581,7 @@ int rmsgpack_read(RFILE *fd,
          tmp_len  = UINT64_C(1) << (type - _MPF_UINT8);
          tmp_uint = 0;
          if (read_uint(fd, &tmp_uint, (size_t)tmp_len) == -1)
-            goto error;
+            return -1;
 
          if (callbacks->read_uint)
             return callbacks->read_uint(tmp_uint, data);
@@ -625,7 +593,7 @@ int rmsgpack_read(RFILE *fd,
          tmp_len = UINT64_C(1) << (type - _MPF_INT8);
          tmp_int = 0;
          if (read_int(fd, &tmp_int, (size_t)tmp_len) == -1)
-            goto error;
+            return -1;
 
          if (callbacks->read_int)
             return callbacks->read_int(tmp_int, data);
@@ -642,19 +610,16 @@ int rmsgpack_read(RFILE *fd,
       case _MPF_ARRAY16:
       case _MPF_ARRAY32:
          if (read_uint(fd, &tmp_len, 2<<(type - _MPF_ARRAY16)) == -1)
-            goto error;
+            return -1;
          return read_array(fd, (uint32_t)tmp_len, callbacks, data);
       case _MPF_MAP16:
       case _MPF_MAP32:
          if (read_uint(fd, &tmp_len, 2<<(type - _MPF_MAP16)) == -1)
-            goto error;
+            return -1;
          return read_map(fd, (uint32_t)tmp_len, callbacks, data);
    }
 
    if (buff)
       free(buff);
    return 0;
-
-error:
-   return -errno;
 }

--- a/libretro-db/rmsgpack_dom.c
+++ b/libretro-db/rmsgpack_dom.c
@@ -24,7 +24,6 @@
 
 #include <stdint.h>
 #include <stdio.h>
-#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -23,7 +23,6 @@
 #include <sys/types.h>
 #include <string.h>
 #include <time.h>
-#include <errno.h>
 
 #ifdef _WIN32
 #ifdef _XBOX

--- a/tasks/task_database_cue.c
+++ b/tasks/task_database_cue.c
@@ -1050,8 +1050,7 @@ int cue_find_track(const char *cue_path, bool first,
             RETRO_VFS_FILE_ACCESS_READ, RETRO_VFS_FILE_ACCESS_HINT_NONE))
    {
 #ifdef DEBUG
-      RARCH_LOG("Could not open CUE file '%s': %s\n", cue_path,
-            strerror(errno));
+      RARCH_LOG("Could not open CUE file '%s'\n", cue_path);
 #endif
       goto error;
    }
@@ -1208,8 +1207,7 @@ int gdi_find_track(const char *gdi_path, bool first,
             RETRO_VFS_FILE_ACCESS_READ, RETRO_VFS_FILE_ACCESS_HINT_NONE))
    {
 #ifdef DEBUG
-      RARCH_LOG("Could not open GDI file '%s': %s\n", gdi_path,
-            strerror(errno));
+      RARCH_LOG("Could not open GDI file '%s'\n", gdi_path);
 #endif
       goto error;
    }


### PR DESCRIPTION
For @Psyraven to review - see comment here

> So in https://github.com/libretro/RetroArch/blob/master/libretro-db/libretrodb.c there are a bunch of places that return errno even though errno might not be set. Sometimes it's called after a VFS function where fopen or fread might have set errno. But on some VFS implementation errno is never set. This is what causes crashes on UWP platforms when interacting with RDB databases like the Explore menu.

Because some functions that call libretrodb_open or libretrodb_cursor_open pass the return value into strerror so we can't just return generic -1 or the errors logged there would lose some information.
We could simply replace all return -errno; with return (errno ? -errno : EIO); or more complex modify vfs_implementation_uwp.cpp so all error cases would set errno to something that makes sense there.

Besides libretrodb.c there's also a bunch of places in rmsgpack.c and task_database_cue.c that return errno which should also be fixed otherwise it might lead to further problems on UWP there.