### PR TITLE
Show playlist entry as 'Quick Menu' header title

### DIFF
--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -10485,11 +10485,15 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
 
 static void ozone_set_header(ozone_handle_t *ozone)
 {
-   if (ozone->categories_selection_ptr <= ozone->system_tab_end)
+   if (ozone->categories_selection_ptr <= ozone->system_tab_end ||
+         (ozone->is_quick_menu && !menu_is_running_quick_menu()) ||
+         ozone->depth > 1)
       menu_entries_get_title(ozone->title, sizeof(ozone->title));
    else
    {
-      ozone_node_t *node = (ozone_node_t*)file_list_get_userdata_at_offset(&ozone->horizontal_list, ozone->categories_selection_ptr - ozone->system_tab_end-1);
+      ozone_node_t *node = (ozone_node_t*)file_list_get_userdata_at_offset(
+            &ozone->horizontal_list,
+            ozone->categories_selection_ptr - ozone->system_tab_end-1);
 
       if (node && node->console_name)
       {
@@ -10602,8 +10606,6 @@ static void ozone_populate_entries(void *data,
    settings                    = config_get_ptr();
    ozone_collapse_sidebar      = settings->bools.ozone_collapse_sidebar;
 
-   ozone_set_header(ozone);
-
    if (menu_driver_ctl(RARCH_MENU_CTL_IS_PREVENT_POPULATE, NULL))
    {
       menu_driver_ctl(RARCH_MENU_CTL_UNSET_PREVENT_POPULATE, NULL);
@@ -10680,6 +10682,8 @@ static void ozone_populate_entries(void *data,
                                  string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_CONTENTLESS_CORES_LIST));
    ozone->is_state_slot        = string_to_unsigned(path) == MENU_ENUM_LABEL_STATE_SLOT;
    ozone->is_playlist          = ozone_is_playlist(ozone, true);
+
+   ozone_set_header(ozone);
 
    if (was_db_manager_list)
    {

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -1101,7 +1101,8 @@ static char* xmb_path_dynamic_wallpaper(xmb_handle_t *xmb)
    unsigned depth                     = (unsigned)xmb_list_get_size(xmb, MENU_LIST_PLAIN);
 
    /* Do not update wallpaper in "Load Content" playlists */
-   if (xmb->categories_selection_ptr == 0 && depth > 4)
+   if ((xmb->categories_selection_ptr == 0 && depth > 4) ||
+         (xmb->categories_selection_ptr > xmb->system_tab_end && depth > 1))
       return strdup(xmb->bg_file_path);
 
    if (tmp)
@@ -1963,7 +1964,9 @@ static void xmb_list_switch_new(xmb_handle_t *xmb,
 
 static void xmb_set_title(xmb_handle_t *xmb)
 {
-   if (xmb->categories_selection_ptr <= xmb->system_tab_end)
+   if (xmb->categories_selection_ptr <= xmb->system_tab_end ||
+         (xmb->is_quick_menu && !menu_is_running_quick_menu()) ||
+         xmb->depth > 1)
       menu_entries_get_title(xmb->title_name, sizeof(xmb->title_name));
    else
    {
@@ -2592,10 +2595,6 @@ static void xmb_populate_entries(void *data,
    if (settings->bools.menu_content_show_video)
       xmb->playlist_collection_offset++;
 
-   xmb_set_title(xmb);
-   if (menu_dynamic_wallpaper_enable)
-      xmb_update_dynamic_wallpaper(xmb);
-
    if (menu_driver_ctl(RARCH_MENU_CTL_IS_PREVENT_POPULATE, NULL))
    {
       xmb_selection_pointer_changed(xmb, false);
@@ -2607,6 +2606,10 @@ static void xmb_populate_entries(void *data,
       xmb_list_switch(xmb);
    else
       xmb_list_open(xmb);
+
+   xmb_set_title(xmb);
+   if (menu_dynamic_wallpaper_enable)
+      xmb_update_dynamic_wallpaper(xmb);
 
    /* Determine whether to show entry index */
    /* Update list size & entry index texts */
@@ -6810,7 +6813,7 @@ static void xmb_context_reset_internal(xmb_handle_t *xmb,
          APPLICATION_SPECIAL_DIRECTORY_ASSETS_XMB_BG);
 
    /* Do not reset wallpaper in "Load Content" playlists. */
-   if (!string_is_empty(bg_file_path) && xmb->depth < 4)
+   if (!string_is_empty(bg_file_path) && xmb->depth < 2)
    {
       if (!string_is_empty(xmb->bg_file_path))
          free(xmb->bg_file_path);


### PR DESCRIPTION
## Description

All menus adjusted in similar fashion, as in more useful information as header title instead of "Quick Menu".

Ozone and XMB required a bit more care for the same functionality (and for not breaking dynamic wallpapers), but it was luckily mainly simply doing certain things at a later moment.

![retroarch_2022_08_25_04_33_33_397](https://user-images.githubusercontent.com/45124675/186554218-07ccd9d9-19ce-44b1-88e5-047291c31e77.png)


## Related Issues

Closes #4754

