### PR TITLE
(Network) Get rid of the timeout_enable parameter for socket_connect

### DIFF
--- a/libretro-common/include/net/net_socket.h
+++ b/libretro-common/include/net/net_socket.h
@@ -101,7 +101,7 @@ ssize_t socket_receive_all_nonblocking(int fd, bool *error,
 
 bool socket_bind(int fd, void *data);
 
-int socket_connect(int fd, void *data, bool timeout_enable);
+int socket_connect(int fd, void *data);
 
 bool socket_connect_with_timeout(int fd, void *data, int timeout);
 

--- a/libretro-common/net/net_socket.c
+++ b/libretro-common/net/net_socket.c
@@ -660,20 +660,9 @@ bool socket_bind(int fd, void *data)
    return !bind(fd, addr->ai_addr, addr->ai_addrlen);
 }
 
-int socket_connect(int fd, void *data, bool timeout_enable)
+int socket_connect(int fd, void *data)
 {
    struct addrinfo *addr = (struct addrinfo*)data;
-
-#if !defined(_WIN32) && !defined(VITA) && !defined(WIIU) && !defined(_3DS)
-   if (timeout_enable)
-   {
-      struct timeval timeout;
-      timeout.tv_sec  = 4;
-      timeout.tv_usec = 0;
-
-      setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, (char*)&timeout, sizeof(timeout));
-   }
-#endif
 
 #ifdef WIIU
    {

--- a/libretro-common/net/net_socket_ssl_bear.c
+++ b/libretro-common/net/net_socket_ssl_bear.c
@@ -222,8 +222,19 @@ int ssl_socket_connect(void *state_data,
    struct ssl_state *state = (struct ssl_state*)state_data;
    unsigned bearstate;
 
-   if (socket_connect(state->fd, data, timeout_enable))
-      return -1;
+   if (timeout_enable)
+   {
+      if (!socket_connect_with_timeout(state->fd, data, 5000))
+         return -1;
+      /* socket_connect_with_timeout makes the socket non-blocking. */
+      if (!socket_set_block(state->fd, true))
+         return -1;
+   }
+   else
+   {
+      if (socket_connect(state->fd, data))
+         return -1;
+   }
 
    for (;;)
    {

--- a/libretro-common/net/net_socket_ssl_mbed.c
+++ b/libretro-common/net/net_socket_ssl_mbed.c
@@ -115,8 +115,19 @@ int ssl_socket_connect(void *state_data,
    int ret, flags;
    struct ssl_state *state = (struct ssl_state*)state_data;
 
-   if (socket_connect(state->net_ctx.fd, data, timeout_enable))
-      return -1;
+   if (timeout_enable)
+   {
+      if (!socket_connect_with_timeout(state->net_ctx.fd, data, 5000))
+         return -1;
+      /* socket_connect_with_timeout makes the socket non-blocking. */
+      if (!socket_set_block(state->net_ctx.fd, true))
+         return -1;
+   }
+   else
+   {
+      if (socket_connect(state->net_ctx.fd, data))
+         return -1;
+   }
 
    if (mbedtls_ssl_config_defaults(&state->conf,
                MBEDTLS_SSL_IS_CLIENT,

--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -3207,7 +3207,7 @@ static bool netplay_tunnel_connect(int fd, const struct addrinfo *addr)
    SET_TCP_NODELAY(fd)
    SET_FD_CLOEXEC(fd)
 
-   result = socket_connect(fd, (void*)addr, false);
+   result = socket_connect(fd, (void*)addr);
    if (result && !isinprogress(result) && !isagain(result))
       return false;
 

--- a/tools/ranetplayer/ranetplayer.c
+++ b/tools/ranetplayer/ranetplayer.c
@@ -277,7 +277,7 @@ int main(int argc, char **argv)
       return 1;
    }
 
-   if (socket_connect(sock, addr, false) < 0)
+   if (socket_connect(sock, addr) < 0)
    {
       perror("connect");
       return 1;


### PR DESCRIPTION
## Description

socket_connect_with_timeout already provides this functionality in a portable and customizable way.

NOTE: This PR solves two memory leaks related to HTTPS; Someone should probably go through net_http.c as there are probably more leaks and/or bugs in there (code is pretty bad imo).