### PR TITLE
(Ozone/XMB/RGUI) Explore menu thumbnails

### DIFF
--- a/gfx/gfx_thumbnail_path.c
+++ b/gfx/gfx_thumbnail_path.c
@@ -319,9 +319,9 @@ bool gfx_thumbnail_set_system(gfx_thumbnail_path_data_t *path_data,
    return true;
 }
 
-/* Sets current thumbnail content according to the specified label.
+/* Sets current thumbnail content according to the specified label and optional database name.
  * Returns true if content is valid */
-bool gfx_thumbnail_set_content(gfx_thumbnail_path_data_t *path_data, const char *label)
+bool gfx_thumbnail_set_content(gfx_thumbnail_path_data_t *path_data, const char *label, const char *db_name)
 {
    if (!path_data)
       return false;
@@ -354,6 +354,10 @@ bool gfx_thumbnail_set_content(gfx_thumbnail_path_data_t *path_data, const char 
    /* Have to set content path to *something*...
     * Just use label value (it doesn't matter) */
    strlcpy(path_data->content_path, label, sizeof(path_data->content_path));
+
+   /* Database name required for Explore thumbnails */
+   if (!string_is_empty(db_name))
+      strlcpy(path_data->content_db_name, db_name, sizeof(path_data->content_db_name));
    
    /* Redundant error check... */
    return !string_is_empty(path_data->content_img);

--- a/gfx/gfx_thumbnail_path.h
+++ b/gfx/gfx_thumbnail_path.h
@@ -85,9 +85,9 @@ bool gfx_thumbnail_is_enabled(gfx_thumbnail_path_data_t *path_data, enum gfx_thu
  *   associated database name */
 bool gfx_thumbnail_set_system(gfx_thumbnail_path_data_t *path_data, const char *system, playlist_t *playlist);
 
-/* Sets current thumbnail content according to the specified label.
+/* Sets current thumbnail content according to the specified label and optional database name.
  * Returns true if content is valid */
-bool gfx_thumbnail_set_content(gfx_thumbnail_path_data_t *path_data, const char *label);
+bool gfx_thumbnail_set_content(gfx_thumbnail_path_data_t *path_data, const char *label, const char *db_name);
 
 /* Sets current thumbnail content to the specified image.
  * Returns true if content is valid */

--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -4043,9 +4043,11 @@ static void materialui_render_menu_entry_default(
          if (!entry->checked)
             icon_texture = mui->textures.list[node->icon_texture_index];
          break;
+#if defined(HAVE_LIBRETRODB)
       case MUI_ICON_TYPE_MENU_EXPLORE:
          icon_texture = menu_explore_get_entry_icon(entry_type);
          break;
+#endif
       case MUI_ICON_TYPE_MENU_CONTENTLESS_CORE:
          icon_texture = menu_contentless_cores_get_entry_icon(entry->label);
          break;

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -342,7 +342,6 @@ typedef struct xmb_handle
    size_t categories_selection_ptr_old;
    size_t selection_ptr_old;
    size_t fullscreen_thumbnail_selection;
-   size_t playlist_index;
    size_t playlist_collection_offset;
 
    /* size of the current list */
@@ -423,6 +422,7 @@ typedef struct xmb_handle
    /* Favorites, History, Images, Music, Videos, user generated */
    bool is_playlist;
    bool is_db_manager_list;
+   bool is_explore_list;
    bool is_contentless_cores;
 
    /* Load Content file browser */
@@ -1228,7 +1228,7 @@ static void xmb_update_savestate_thumbnail_path(void *data, unsigned i)
                      xmb->fullscreen_thumbnail_label,
                      sizeof(xmb->fullscreen_thumbnail_label),
                      xmb->is_quick_menu,
-                     xmb->playlist_index);
+                     NULL);
             }
          }
       }
@@ -1382,9 +1382,6 @@ static void xmb_set_thumbnail_content(void *data, const char *s)
             playlist_index = list->list[selection].entry_idx;
          }
 
-         /* Remember playlist index for Quick Menu fullscreen thumbnail title */
-         xmb->playlist_index = playlist_index;
-
          gfx_thumbnail_set_content_playlist(xmb->thumbnail_path_data,
                playlist_valid ? playlist_get_cached() : NULL, playlist_index);
          xmb->fullscreen_thumbnails_available = true;
@@ -1407,11 +1404,43 @@ static void xmb_set_thumbnail_content(void *data, const char *s)
 
          if (!string_is_empty(entry.path))
          {
-            gfx_thumbnail_set_content(xmb->thumbnail_path_data, entry.path);
+            gfx_thumbnail_set_content(xmb->thumbnail_path_data, entry.path, NULL);
             xmb->fullscreen_thumbnails_available = true;
          }
       }
    }
+#if defined(HAVE_LIBRETRODB)
+   else if (xmb->is_explore_list)
+   {
+      /* Explore list */
+      if (string_is_empty(s))
+      {
+         menu_entry_t entry;
+         const char *db_name;
+         size_t selection         = menu_navigation_get_selection();
+
+         MENU_ENTRY_INIT(entry);
+         entry.label_enabled      = false;
+         entry.rich_label_enabled = false;
+         entry.value_enabled      = false;
+         entry.sublabel_enabled   = false;
+         menu_entry_get(&entry, 0, selection, NULL, true);
+
+         if (!entry.type)
+            return;
+
+         db_name = menu_explore_get_entry_database(entry.type);
+
+         if (!string_is_empty(entry.path) && !string_is_empty(db_name))
+            gfx_thumbnail_set_content(xmb->thumbnail_path_data,
+                  entry.path,
+                  db_name);
+
+         xmb->fullscreen_thumbnails_available =
+               (!string_is_empty(db_name) && menu_explore_get_entry_icon(entry.type));
+      }
+   }
+#endif
    else if (string_is_equal(s, "imageviewer"))
    {
       /* Filebrowser image updates */
@@ -1445,7 +1474,7 @@ static void xmb_set_thumbnail_content(void *data, const char *s)
        * the sublevels of database manager lists.
        * Showing thumbnails on database entries is a
        * pointless nuisance and a waste of CPU cycles, IMHO... */
-      gfx_thumbnail_set_content(xmb->thumbnail_path_data, s);
+      gfx_thumbnail_set_content(xmb->thumbnail_path_data, s, NULL);
       xmb->fullscreen_thumbnails_available = true;
    }
 }
@@ -1549,9 +1578,9 @@ static void xmb_selection_pointer_changed(
                xmb_set_thumbnail_content(xmb, NULL);
                update_thumbnails = true;
             }
-            /* Database list updates
-             * (pointless nuisance...) */
-            else if (xmb->is_db_manager_list && depth <= 4)
+            /* Database + Explore list updates */
+            else if ((xmb->is_db_manager_list && depth <= 4) ||
+                  xmb->is_explore_list)
             {
                xmb_set_thumbnail_content(xmb, NULL);
                update_thumbnails         = true;
@@ -1590,7 +1619,7 @@ static void xmb_selection_pointer_changed(
                    * persist, and be shown on the wrong entry) */
                   xmb->fullscreen_thumbnails_available = false;
                   xmb->thumbnails.pending = XMB_PENDING_THUMBNAIL_NONE;
-                  gfx_thumbnail_set_content(xmb->thumbnail_path_data, NULL);
+                  gfx_thumbnail_set_content(xmb->thumbnail_path_data, NULL, NULL);
                   gfx_thumbnail_cancel_pending_requests();
                   gfx_thumbnail_reset(&xmb->thumbnails.right);
                   gfx_thumbnail_reset(&xmb->thumbnails.left);
@@ -1797,21 +1826,18 @@ static void xmb_list_open_new(xmb_handle_t *xmb,
    xmb_system_tab = xmb_get_system_tab(xmb,
          (unsigned)xmb->categories_selection_ptr);
 
-   if (xmb_system_tab <= XMB_SYSTEM_TAB_SETTINGS)
+   if (xmb_system_tab <= XMB_SYSTEM_TAB_SETTINGS && xmb->depth > xmb->old_depth)
    {
       if (  gfx_thumbnail_is_enabled(xmb->thumbnail_path_data, GFX_THUMBNAIL_RIGHT) ||
             gfx_thumbnail_is_enabled(xmb->thumbnail_path_data, GFX_THUMBNAIL_LEFT))
       {
          if (xmb->is_playlist || xmb->is_db_manager_list)
          {
-            if (xmb->is_db_manager_list && xmb->depth < 5)
+            if (!(xmb->is_db_manager_list && xmb->depth > 4))
                xmb_unload_thumbnail_textures(xmb);
 
-            if (!(xmb->is_playlist && xmb->depth == 4 && xmb->old_depth == 5))
-            {
-               xmb_set_thumbnail_content(xmb, NULL);
-               xmb_update_thumbnail_image(xmb);
-            }
+            xmb_set_thumbnail_content(xmb, NULL);
+            xmb_update_thumbnail_image(xmb);
          }
       }
    }
@@ -2576,6 +2602,20 @@ static void xmb_populate_entries(void *data,
                         string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_SAVESTATE_LIST));
    xmb->is_state_slot = string_to_unsigned(path) == MENU_ENUM_LABEL_STATE_SLOT;
 
+   /* Explore list */
+   xmb->is_explore_list = string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_EXPLORE_LIST)) ||
+                          string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_EXPLORE_TAB));
+
+   /* Quick Menu under Explore list must also be Quick Menu */
+   if (xmb->is_explore_list)
+   {
+      xmb->is_quick_menu |= menu_is_nonrunning_quick_menu() || menu_is_running_quick_menu();
+      if (xmb->is_quick_menu)
+         xmb->is_explore_list = false;
+      else
+         xmb->skip_thumbnail_reset = true;
+   }
+
    /* Determine the first playlist item under "Load Content > Playlists" */
    xmb->playlist_collection_offset = 0;
    if (settings->uints.menu_content_show_add_entry)
@@ -2611,12 +2651,13 @@ static void xmb_populate_entries(void *data,
 
    /* Determine whether to show entry index */
    /* Update list size & entry index texts */
-   if ((xmb->entry_idx_enabled = show_entry_idx && xmb->is_playlist))
+   if ((xmb->entry_idx_enabled = show_entry_idx &&
+         (xmb->is_playlist || (xmb->is_explore_list && xmb->depth > 1))))
    {
       xmb->list_size = menu_entries_get_size();
       snprintf(xmb->entry_index_str, sizeof(xmb->entry_index_str),
-      "%lu/%lu", (unsigned long)menu_navigation_get_selection() + 1,
-                 (unsigned long)xmb->list_size);
+            "%lu/%lu", (unsigned long)menu_navigation_get_selection() + 1,
+                       (unsigned long)xmb->list_size);
    }
 
    /* By default, fullscreen thumbnails are only
@@ -2634,18 +2675,14 @@ static void xmb_populate_entries(void *data,
    {
       xmb->fullscreen_thumbnails_available = true;
    }
-   else if (xmb->is_quick_menu && xmb->depth < 6)
+   else if (xmb->is_quick_menu)
    {
-      const char *thumbnail_content_path = NULL;
-      runloop_state_t *runloop_st        = runloop_state_get_ptr();
-      gfx_thumbnail_get_content_path(xmb->thumbnail_path_data, &thumbnail_content_path);
-
-      if (xmb->libretro_running)
-         xmb->fullscreen_thumbnails_available = false;
-
-      if (!string_is_empty(thumbnail_content_path) &&
-            !string_is_equal(thumbnail_content_path, runloop_st->runtime_content_path))
-         xmb->fullscreen_thumbnails_available = true;
+      xmb->fullscreen_thumbnails_available = !menu_is_running_quick_menu();
+   }
+   else if (xmb->is_explore_list)
+   {
+      xmb_set_thumbnail_content(xmb, "");
+      xmb_update_thumbnail_image(xmb);
    }
 
    /* Hack: XMB gets into complete muddle when
@@ -2657,7 +2694,7 @@ static void xmb_populate_entries(void *data,
    {
       xmb->fullscreen_thumbnails_available = false;
       xmb->thumbnails.pending = XMB_PENDING_THUMBNAIL_NONE;
-      gfx_thumbnail_set_content(xmb->thumbnail_path_data, NULL);
+      gfx_thumbnail_set_content(xmb->thumbnail_path_data, NULL, NULL);
       gfx_thumbnail_cancel_pending_requests();
       gfx_thumbnail_reset(&xmb->thumbnails.right);
       gfx_thumbnail_reset(&xmb->thumbnails.left);
@@ -4127,7 +4164,7 @@ static void xmb_show_fullscreen_thumbnails(
          xmb->fullscreen_thumbnail_label,
          sizeof(xmb->fullscreen_thumbnail_label),
          xmb->is_quick_menu,
-         xmb->playlist_index) == 0)
+         xmb->title_name) == 0)
       xmb->fullscreen_thumbnail_label[0] = '\0';
 
    /* Configure fade in animation */
@@ -4146,6 +4183,12 @@ static void xmb_show_fullscreen_thumbnails(
    xmb->fullscreen_thumbnail_selection = selection;
    xmb->show_fullscreen_thumbnails     = true;
 }
+
+/* Common thumbnail switch requires FILE_TYPE_RPL_ENTRY,
+ * which only works with playlists, therefore activate it
+ * manually for Quick Menu, Explore and Database */
+extern int action_switch_thumbnail(const char *path,
+      const char *label, unsigned type, size_t idx);
 
 static enum menu_action xmb_parse_menu_entry_action(
       xmb_handle_t *xmb, enum menu_action action)
@@ -4190,8 +4233,7 @@ static enum menu_action xmb_parse_menu_entry_action(
          break;
       case MENU_ACTION_START:
          if (xmb->is_state_slot ||
-               (xmb->is_quick_menu &&
-                  (!string_is_empty(xmb->savestate_thumbnail_file_path) || xmb->depth > 2)))
+               (xmb->is_quick_menu && menu_is_running_quick_menu()))
             break;
 
          /* If this is a menu with thumbnails, attempt
@@ -4221,10 +4263,16 @@ static enum menu_action xmb_parse_menu_entry_action(
             xmb->want_fullscreen_thumbnails = true;
             new_action = MENU_ACTION_NOOP;
          }
-         else if (xmb->show_fullscreen_thumbnails && !xmb->is_playlist)
+         else if (xmb->show_fullscreen_thumbnails &&
+               (xmb->is_state_slot || (xmb->is_quick_menu && menu_is_running_quick_menu())))
          {
             xmb_hide_fullscreen_thumbnails(xmb, true);
             xmb->want_fullscreen_thumbnails = false;
+            new_action = MENU_ACTION_NOOP;
+         }
+         else if (xmb->is_explore_list || xmb->is_quick_menu || xmb->is_db_manager_list)
+         {
+            action_switch_thumbnail(NULL, NULL, 0, 0);
             new_action = MENU_ACTION_NOOP;
          }
          break;
@@ -4246,7 +4294,7 @@ static enum menu_action xmb_parse_menu_entry_action(
          {
             xmb_hide_fullscreen_thumbnails(xmb, true);
             xmb->want_fullscreen_thumbnails = false;
-            if (!xmb->is_state_slot && !xmb->is_playlist)
+            if (!xmb->is_state_slot && !xmb->is_playlist && !xmb->is_explore_list)
                return MENU_ACTION_NOOP;
          }
          break;
@@ -6902,6 +6950,7 @@ static void xmb_context_reset_internal(xmb_handle_t *xmb,
              (xmb_system_tab < XMB_SYSTEM_TAB_SETTINGS && depth == 4)) &&
               xmb->is_playlist))
             || xmb->is_db_manager_list
+            || xmb->is_explore_list
             || xmb->is_file_list
             || xmb->is_quick_menu)
          xmb_update_thumbnail_image(xmb);

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -8158,7 +8158,7 @@ bool menu_input_dialog_start(menu_input_ctx_line_t *line)
 
 size_t menu_update_fullscreen_thumbnail_label(
       char *s, size_t len,
-      bool is_quick_menu, size_t playlist_index)
+      bool is_quick_menu, const char *title)
 {
    menu_entry_t selected_entry;
    const char *thumbnail_label     = NULL;
@@ -8196,13 +8196,8 @@ size_t menu_update_fullscreen_thumbnail_label(
       thumbnail_label = tmpstr;
    }
    /* > Quick Menu playlist label */
-   else if (is_quick_menu)
-   {
-      const struct playlist_entry *entry = NULL;
-      playlist_get_index(playlist_get_cached(), playlist_index, &entry);
-      if (entry)
-         thumbnail_label = entry->label;
-   }
+   else if (is_quick_menu && title)
+      thumbnail_label = title;
    else
       thumbnail_label = selected_entry.path;
 
@@ -8224,4 +8219,17 @@ bool menu_is_running_quick_menu(void)
 
    return string_is_equal(entry.label, "resume_content") ||
           string_is_equal(entry.label, "state_slot");
+}
+
+bool menu_is_nonrunning_quick_menu(void)
+{
+   menu_entry_t entry;
+
+   MENU_ENTRY_INIT(entry);
+   entry.path_enabled     = false;
+   entry.value_enabled    = false;
+   entry.sublabel_enabled = false;
+   menu_entry_get(&entry, 0, 0, NULL, true);
+
+   return string_is_equal(entry.label, "collection");
 }

--- a/menu/menu_driver.h
+++ b/menu/menu_driver.h
@@ -663,6 +663,10 @@ typedef struct explore_state explore_state_t;
 explore_state_t *menu_explore_build_list(const char *directory_playlist,
       const char *directory_database);
 uintptr_t menu_explore_get_entry_icon(unsigned type);
+const char *menu_explore_get_entry_database(unsigned type);
+ssize_t menu_explore_get_entry_playlist_index(unsigned type,
+      playlist_t **playlist,
+      const struct playlist_entry **entry);
 void menu_explore_context_init(void);
 void menu_explore_context_deinit(void);
 void menu_explore_free_state(explore_state_t *state);
@@ -1006,9 +1010,10 @@ bool menu_driver_iterate(
 
 size_t menu_update_fullscreen_thumbnail_label(
       char *s, size_t len,
-      bool is_quick_menu, size_t playlist_index);
+      bool is_quick_menu, const char *title);
 
 bool menu_is_running_quick_menu(void);
+bool menu_is_nonrunning_quick_menu(void);
 
 extern const menu_ctx_driver_t *menu_ctx_drivers[];
 

--- a/menu/menu_explore.c
+++ b/menu/menu_explore.c
@@ -1279,6 +1279,67 @@ uintptr_t menu_explore_get_entry_icon(unsigned type)
    return 0;
 }
 
+const char *menu_explore_get_entry_database(unsigned type)
+{
+   explore_entry_t* e = NULL;
+   unsigned i;
+
+   if (!explore_state || type < EXPLORE_TYPE_FIRSTITEM)
+      return 0;
+
+   i = (type - EXPLORE_TYPE_FIRSTITEM);
+   e = &explore_state->entries[i];
+
+   if (e < RBUF_END(explore_state->entries))
+      return e->by[EXPLORE_BY_SYSTEM]->str;
+
+   return NULL;
+}
+
+ssize_t menu_explore_get_entry_playlist_index(unsigned type,
+      playlist_t **playlist,
+      const struct playlist_entry **playlist_entry)
+{
+   explore_entry_t* e = NULL;
+   playlist_t*      p = NULL;
+   unsigned i;
+
+   if (!explore_state || type < EXPLORE_TYPE_FIRSTITEM)
+      return 0;
+
+   i = (type - EXPLORE_TYPE_FIRSTITEM);
+   e = &explore_state->entries[i];
+   p = explore_state->playlists[0];
+
+   if (e < RBUF_END(explore_state->entries))
+   {
+      const struct playlist_entry *entry = NULL;
+      size_t pi = 0;
+      size_t j  = 0;
+
+      playlist_get_index(p, 0, &entry);
+      while (!string_is_equal(e->playlist_entry->db_name, entry->db_name))
+      {
+         p = explore_state->playlists[pi];
+         playlist_get_index(p, 0, &entry);
+         pi++;
+      }
+
+      for (j = 0; j < playlist_size(p); j++)
+      {
+         playlist_get_index(p, j, &entry);
+         if (string_is_equal(entry->label, e->playlist_entry->label))
+         {
+            *playlist_entry = entry;
+            *playlist       = p;
+            return j;
+         }
+      }
+   }
+
+   return -1;
+}
+
 void menu_explore_context_init(void)
 {
    if (!explore_state)


### PR DESCRIPTION
## Description

Again all menus are aimed to act the same regarding thumbnails. Being able to cycle and toggle FS always when thumbnails are visible regardless of the menu type, etc.

Also changed FS thumbnail order in Ozone to match XMB order. GLUI is still untouched except fixed build fail when libretrodb is disabled.

If anyone has a better method of getting the actual playlist index for getting proper metadata (runtime + last played) for Ozone instead of this current `menu_explore_get_entry_playlist_index()`, I'm all ears. The same metadata is supposed to be in sublabels in XMB, and that is saved for later also.

## Related Issues

Closes #13610
