### PR TITLE
Menu paging navigation adjustments

### DIFF
--- a/menu/cbs/menu_cbs_left.c
+++ b/menu/cbs/menu_cbs_left.c
@@ -235,7 +235,7 @@ static int action_left_scroll(unsigned type, const char *label,
       return false;
 
    scroll_speed          = (unsigned)((MAX(scroll_accel, 2) - 2) / 4 + 1);
-   fast_scroll_speed     = 4 + 4 * scroll_speed;
+   fast_scroll_speed     = 10 * scroll_speed;
 
    if (selection > fast_scroll_speed)
    {

--- a/menu/cbs/menu_cbs_right.c
+++ b/menu/cbs/menu_cbs_right.c
@@ -246,8 +246,8 @@ static int action_right_scroll(unsigned type, const char *label,
    if (!menu_driver_ctl(MENU_NAVIGATION_CTL_GET_SCROLL_ACCEL, &scroll_accel))
       return false;
 
-   scroll_speed      = (unsigned)((MAX(scroll_accel, 2) - 2) / 4 + 1);
-   fast_scroll_speed = 4 + 4 * scroll_speed;
+   scroll_speed          = (unsigned)((MAX(scroll_accel, 2) - 2) / 4 + 1);
+   fast_scroll_speed     = 10 * scroll_speed;
 
    if (selection  + fast_scroll_speed < (menu_entries_get_size()))
    {

--- a/menu/menu_driver.h
+++ b/menu/menu_driver.h
@@ -488,6 +488,7 @@ struct menu_state
       size_t   index_list[SCROLL_INDEX_SIZE];
       unsigned index_size;
       unsigned acceleration;
+      bool     mode;
    } scroll;
 
    /* unsigned alignment */


### PR DESCRIPTION
## Description

Global changes not related to any menu driver:
- Change current L1/R1 first letter paging to L2/R2
- Assign paging per 10 items to L1/R1
- Adjust current Left+Right paging where applicable to also 10 instead of 8 items

## Related Issues

Closes #14134
