### PR TITLE
Reduce snprintfs + assorted cleanups

### DIFF
--- a/command.c
+++ b/command.c
@@ -375,7 +375,7 @@ bool command_get_config_param(command_t *cmd, const char* arg)
       value = path_username;
    /* TODO: query any string */
 
-   strlcpy(reply, "GET_CONFIG_PARAM ";
+   strlcpy(reply, "GET_CONFIG_PARAM ", sizeof(reply));
    _len          = strlcat(reply, arg, sizeof(reply));
    reply[_len  ] = ' ';
    reply[_len+1] = '\0';

--- a/configuration.c
+++ b/configuration.c
@@ -4702,7 +4702,7 @@ bool config_save_file(const char *path)
       char cfg[64];
       char formatted_number[4];
 
-      cfg[0] = formatted_number[0] = '\0';
+      formatted_number[0] = '\0';
 
       snprintf(formatted_number, sizeof(formatted_number), "%u", i + 1);
 
@@ -5135,13 +5135,7 @@ bool input_remapping_load_file(void *data, const char *path)
       char prefix[16];
       char s1[32], s2[32], s3[32];
       char formatted_number[4];
-
-      prefix[0]  = '\0';
-      s1[0]      = '\0';
-      s2[0]      = '\0';
-      s3[0]      = '\0';
       formatted_number[0] = '\0';
-
       snprintf(formatted_number, sizeof(formatted_number), "%u", i + 1);
       strlcpy(prefix, "input_player",   sizeof(prefix));
       strlcat(prefix, formatted_number, sizeof(prefix));
@@ -5225,8 +5219,7 @@ bool input_remapping_load_file(void *data, const char *path)
          }
       }
 
-      strlcpy(s1, "input_player",             sizeof(s1));
-      strlcat(s1, formatted_number,           sizeof(s1));
+      strlcpy(s1, prefix,                     sizeof(s1));
       strlcat(s1, "_analog_dpad_mode",        sizeof(s1));
       CONFIG_GET_INT_BASE(conf, settings, uints.input_analog_dpad_mode[i], s1);
 
@@ -5299,10 +5292,6 @@ bool input_remapping_save_file(const char *path)
       char s3[32];
 
       formatted_number[0] = '\0';
-      prefix[0] = '\0';
-      s1[0]     = '\0';
-      s2[0]     = '\0';
-      s3[0]     = '\0';
 
       /* We must include all mapped ports + all those
        * with an index less than max_users */
@@ -5417,8 +5406,7 @@ bool input_remapping_save_file(const char *path)
       strlcat(s1, formatted_number,          sizeof(s1));
       config_set_int(conf, s1, input_config_get_device(i));
 
-      strlcpy(s1, "input_player",            sizeof(s1));
-      strlcat(s1, formatted_number,          sizeof(s1));
+      strlcpy(s1, prefix,                    sizeof(s1));
       strlcat(s1, "_analog_dpad_mode",       sizeof(s1));
       config_set_int(conf, s1, settings->uints.input_analog_dpad_mode[i]);
 

--- a/configuration.c
+++ b/configuration.c
@@ -4204,7 +4204,6 @@ static void save_keybind_hat(config_file_t *conf, const char *key,
 {
    char config[16];
    unsigned hat     = (unsigned)GET_HAT(bind->joykey);
-   const char *dir  = NULL;
 
    config[0]        = 'h';
    config[1]        = '\0';

--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -669,9 +669,17 @@ void video_monitor_set_refresh_rate(float hz)
 {
    char msg[128];
    settings_t        *settings = config_get_ptr();
-
-   snprintf(msg, sizeof(msg),
-         "Setting refresh rate to: %.3f Hz.", hz);
+   /* TODO/FIXME - localize */
+   size_t _len = strlcpy(msg, "Setting refresh rate to", sizeof(msg));
+   msg[_len  ] = ':';
+   msg[++_len] = ' ';
+   msg[++_len] = '\0';
+   _len       += snprintf(msg + _len, sizeof(msg) - _len, "%.3f", hz);
+   msg[_len  ] = ' ';
+   msg[_len+1] = 'H';
+   msg[_len+2] = 'z';
+   msg[_len+3] = '.';
+   msg[_len+4] = '\0';
    if (settings->bools.notification_show_refresh_rate)
       runloop_msg_queue_push(msg, 1, 180, false, NULL,
             MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);

--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -4663,6 +4663,7 @@ error:
 static bool runloop_check_movie_init(input_driver_state_t *input_st,
       settings_t *settings)
 {
+   size_t _len;
    char msg[16384], path[8192];
    bsv_movie_t *state          = NULL;
    int state_slot              = settings->ints.state_slot;
@@ -4670,15 +4671,10 @@ static bool runloop_check_movie_init(input_driver_state_t *input_st,
 
    configuration_set_uint(settings, settings->uints.rewind_granularity, 1);
 
-   strlcpy(path,
+   _len = strlcpy(path,
          input_st->bsv_movie_state.movie_path, sizeof(path));
    if (state_slot > 0)
-   {
-      char formatted_number[16];
-      formatted_number[0] = '\0';
-      snprintf(formatted_number, sizeof(formatted_number), "%d", state_slot);
-      strlcat(path, formatted_number, sizeof(path));
-   }
+      snprintf(path + _len, sizeof(path) - _len, "%d", state_slot);
    strlcat(path, ".bsv", sizeof(path));
 
    snprintf(msg, sizeof(msg), "%s \"%s\".",

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -3443,8 +3443,6 @@ static void ozone_update_savestate_thumbnail_path(void *data, unsigned i)
             char path[8204];
             runloop_state_t *runloop_st = runloop_state_get_ptr();
 
-            path[0] = '\0';
-
             /* State slot dropdown */
             if (string_to_unsigned(entry.label) == MENU_ENUM_LABEL_STATE_SLOT)
             {
@@ -3452,14 +3450,20 @@ static void ozone_update_savestate_thumbnail_path(void *data, unsigned i)
                ozone->is_state_slot = true;
             }
 
-            if (state_slot > 0)
-               snprintf(path, sizeof(path), "%s%d",
-                     runloop_st->name.savestate, state_slot);
-            else if (state_slot < 0)
+            if (state_slot < 0)
+            {
+               path[0] = '\0';
                fill_pathname_join_delim(path,
                      runloop_st->name.savestate, "auto", '.', sizeof(path));
+            }
             else
-               strlcpy(path, runloop_st->name.savestate, sizeof(path));
+            {
+               size_t _len = strlcpy(path,
+                     runloop_st->name.savestate, sizeof(path));
+               if (state_slot > 0)
+                  snprintf(path + _len, sizeof(path) - _len, "%d",
+                        state_slot);
+            }
 
             strlcat(path, FILE_PATH_PNG_EXTENSION, sizeof(path));
 
@@ -3864,14 +3868,14 @@ static void ozone_update_content_metadata(ozone_handle_t *ozone)
       /* Fill entry enumeration */
       if (show_entry_idx)
       {
+         unsigned long _entry = (unsigned long)(playlist_index + 1);
          if (ozone->is_explore_list)
-            snprintf(ozone->selection_entry_enumeration, sizeof(ozone->selection_entry_enumeration),
-                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CONTENT_INFO_ENTRY_IDX),
-                  (unsigned long)(selection), (unsigned long)list_size);
-         else
-            snprintf(ozone->selection_entry_enumeration, sizeof(ozone->selection_entry_enumeration),
-                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CONTENT_INFO_ENTRY_IDX),
-                  (unsigned long)(playlist_index + 1), (unsigned long)list_size);
+            _entry            = (unsigned long)(selection);
+
+         snprintf(ozone->selection_entry_enumeration,
+               sizeof(ozone->selection_entry_enumeration),
+               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CONTENT_INFO_ENTRY_IDX),
+               _entry, (unsigned long)list_size);
 
          if (!scroll_content_metadata)
             linebreak_after_colon(&ozone->selection_entry_enumeration);

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -5025,7 +5025,7 @@ static void rgui_render(void *data,
             if (rgui->is_quick_menu)
             {
                snprintf(thumbnail_title_buf      + _len,
-                     sizeof(thumbnail_title_buf) + _len,
+                     sizeof(thumbnail_title_buf) - _len,
                      " %d",
                      config_get_ptr()->ints.state_slot);
                thumbnail_title = thumbnail_title_buf;

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -5019,17 +5019,22 @@ static void rgui_render(void *data,
          /* State slot title */
          if (is_state_slot)
          {
+            size_t _len = strlcpy(thumbnail_title_buf,
+                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_STATE_SLOT),
+                  sizeof(thumbnail_title_buf));
             if (rgui->is_quick_menu)
             {
-               snprintf(thumbnail_title_buf, sizeof(thumbnail_title_buf), "%s %d",
-                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_STATE_SLOT),
+               snprintf(thumbnail_title_buf      + _len,
+                     sizeof(thumbnail_title_buf) + _len,
+                     " %d",
                      config_get_ptr()->ints.state_slot);
                thumbnail_title = thumbnail_title_buf;
             }
             else if (rgui->is_state_slot)
             {
-               snprintf(thumbnail_title_buf, sizeof(thumbnail_title_buf), "%s %d",
-                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_STATE_SLOT),
+               snprintf(thumbnail_title_buf      + _len,
+                     sizeof(thumbnail_title_buf) - _len,
+                     " %d",
                      (int)menu_navigation_get_selection() - 1);
                thumbnail_title = thumbnail_title_buf;
             }
@@ -6572,8 +6577,6 @@ static void rgui_update_savestate_thumbnail_path(void *data, unsigned i)
             char path[8204];
             runloop_state_t *runloop_st = runloop_state_get_ptr();
 
-            path[0] = '\0';
-
             /* State slot dropdown */
             if (string_to_unsigned(entry.label) == MENU_ENUM_LABEL_STATE_SLOT)
             {
@@ -6581,14 +6584,20 @@ static void rgui_update_savestate_thumbnail_path(void *data, unsigned i)
                rgui->is_state_slot = true;
             }
 
-            if (state_slot > 0)
-               snprintf(path, sizeof(path), "%s%d",
-                     runloop_st->name.savestate, state_slot);
-            else if (state_slot < 0)
+            if (state_slot < 0)
+            {
+               path[0] = '\0';
                fill_pathname_join_delim(path,
                      runloop_st->name.savestate, "auto", '.', sizeof(path));
+            }
             else
-               strlcpy(path, runloop_st->name.savestate, sizeof(path));
+            {
+               size_t _len = strlcpy(path,
+                     runloop_st->name.savestate, sizeof(path));
+               if (state_slot > 0)
+                  snprintf(path + _len, sizeof(path) - _len, "%d",
+                        state_slot);
+            }
 
             strlcat(path, FILE_PATH_PNG_EXTENSION, sizeof(path));
 

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -1197,8 +1197,6 @@ static void xmb_update_savestate_thumbnail_path(void *data, unsigned i)
             char path[8204];
             runloop_state_t *runloop_st = runloop_state_get_ptr();
 
-            path[0] = '\0';
-
             /* State slot dropdown */
             if (string_to_unsigned(entry.label) == MENU_ENUM_LABEL_STATE_SLOT)
             {
@@ -1206,14 +1204,20 @@ static void xmb_update_savestate_thumbnail_path(void *data, unsigned i)
                xmb->is_state_slot = true;
             }
 
-            if (state_slot > 0)
-               snprintf(path, sizeof(path), "%s%d",
-                     runloop_st->name.savestate, state_slot);
-            else if (state_slot < 0)
+            if (state_slot < 0)
+            {
+               path[0] = '\0';
                fill_pathname_join_delim(path,
                      runloop_st->name.savestate, "auto", '.', sizeof(path));
+            }
             else
-               strlcpy(path, runloop_st->name.savestate, sizeof(path));
+            {
+               size_t _len = strlcpy(path,
+                     runloop_st->name.savestate, sizeof(path));
+               if (state_slot > 0)
+                  snprintf(path + _len, sizeof(path) - _len, "%d",
+                        state_slot);
+            }
 
             strlcat(path, FILE_PATH_PNG_EXTENSION, sizeof(path));
 

--- a/menu/menu_contentless_cores.c
+++ b/menu/menu_contentless_cores.c
@@ -121,11 +121,15 @@ static void contentless_cores_init_info_entries(
       if (core_info &&
           core_info->supports_no_game)
       {
+         char licenses_str[MENU_SUBLABEL_MAX_LENGTH];
          contentless_core_info_entry_t *entry =
                (contentless_core_info_entry_t*)malloc(sizeof(*entry));
-         char licenses_str[MENU_SUBLABEL_MAX_LENGTH];
-
-         licenses_str[0] = '\0';
+         size_t _len          = strlcpy(licenses_str,
+               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CORE_INFO_LICENSES),
+               sizeof(licenses_str));
+         licenses_str[_len  ] = ':';
+         licenses_str[_len+1] = ' ';
+         licenses_str[_len+2] = '\0';
 
          /* Populate licences string */
          if (core_info->licenses_list)
@@ -134,17 +138,15 @@ static void contentless_cores_init_info_entries(
             tmp_str[0] = '\0';
             string_list_join_concat(tmp_str, sizeof(tmp_str),
                   core_info->licenses_list, ", ");
-            snprintf(licenses_str, sizeof(licenses_str), "%s: %s",
-                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CORE_INFO_LICENSES),
-                  tmp_str);
+            strlcat(licenses_str, tmp_str, sizeof(licenses_str));
          }
          /* No license found - set to N/A */
          else
-            snprintf(licenses_str, sizeof(licenses_str), "%s: %s",
-                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CORE_INFO_LICENSES),
-                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE));
+            strlcat(licenses_str,
+                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE),
+                  sizeof(licenses_str));
 
-         entry->licenses_str = strdup(licenses_str);
+         entry->licenses_str            = strdup(licenses_str);
 
          /* Initialise runtime info */
          entry->runtime.runtime_str     = NULL;

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -1760,10 +1760,12 @@ static unsigned menu_displaylist_parse_system_info(file_list_t *list)
    {
       char cpu_str[64];
       unsigned amount_cores = cpu_features_get_core_amount();
-      cpu_str[0]            = '\0';
-      snprintf(cpu_str, sizeof(cpu_str),
-            "%s %d\n",
-            msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CPU_CORES), amount_cores);
+      size_t _len           = strlcpy(cpu_str,
+            msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CPU_CORES),
+            sizeof(cpu_str));
+      snprintf(cpu_str      + _len,
+            sizeof(cpu_str) - _len,
+            " %d\n", amount_cores);
       if (menu_entries_append(list, cpu_str,
             msg_hash_to_str(MENU_ENUM_LABEL_CPU_CORES),
             MENU_ENUM_LABEL_CPU_CORES, MENU_SETTINGS_CORE_INFO_NONE, 0, 0, NULL))
@@ -2029,10 +2031,13 @@ static unsigned menu_displaylist_parse_system_info(file_list_t *list)
 
       if (video_context_driver_get_metrics(&metrics))
       {
-         snprintf(tmp, sizeof(tmp), "%s: %.2f",
+         size_t _len = strlcpy(tmp,
                msg_hash_to_str(
                   MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_WIDTH),
-               val);
+               sizeof(tmp));
+         snprintf(tmp      + _len,
+               sizeof(tmp) - _len,
+               ": %.2f", val);
          if (menu_entries_append(list, tmp, "",
                MENU_ENUM_LABEL_SYSTEM_INFO_ENTRY,
                MENU_SETTINGS_CORE_INFO_NONE, 0, 0, NULL))

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -5167,15 +5167,13 @@ static int menu_displaylist_parse_input_device_index_list(
          if (!string_is_empty(device_name))
          {
             unsigned idx = input_config_get_device_name_index(i);
+            size_t _len  = strlcpy(device_label, device_name,
+                  sizeof(device_label));
 
             /*if idx is non-zero, it's part of a set*/
             if (idx > 0)
-               snprintf(device_label, sizeof(device_label),
-                     "%s (#%u)",
-                     device_name,
-                     idx);
-            else
-               strlcpy(device_label, device_name, sizeof(device_label));
+               snprintf(device_label         + _len,
+                        sizeof(device_label) - _len, " (#%u)", idx);
          }
          else
             snprintf(device_label, sizeof(device_label), "%s (%s %u)", val_na,
@@ -5297,8 +5295,8 @@ static int menu_displaylist_parse_input_description_list(
           * > Above RARCH_FIRST_CUSTOM_BIND, inputs
           *   are analog axes - have to add +/-
           *   indicators */
-	 size_t _len = strlcpy(input_description, input_desc_btn,
-			 sizeof(input_description));
+         size_t _len = strlcpy(input_description, input_desc_btn,
+               sizeof(input_description));
          if (i >= RARCH_FIRST_CUSTOM_BIND)
          {
             input_description   [_len  ] = ' ';
@@ -5306,7 +5304,7 @@ static int menu_displaylist_parse_input_description_list(
                input_description[_len+1] = '+';
             else
                input_description[_len+1] = '-';
-	    input_description   [_len+2] = '\0';
+            input_description   [_len+2] = '\0';
          }
 
          if (string_is_empty(input_description))
@@ -7094,18 +7092,18 @@ unsigned menu_displaylist_build_list(
 #ifdef HAVE_LIBNX
          {
             unsigned user;
+            char key_split_joycon[PATH_MAX_LENGTH];
+            const char *split_joycon_str =
+               msg_hash_to_str(MENU_ENUM_LABEL_INPUT_SPLIT_JOYCON);
+            size_t _len                  = strlcpy(key_split_joycon, split_joycon_str, 
+                  sizeof(key_split_joycon));
 
             for (user = 0; user < 8; user++)
             {
-               char key_split_joycon[PATH_MAX_LENGTH];
                unsigned val = user + 1;
-
-               key_split_joycon[0] = '\0';
-
-               snprintf(key_split_joycon, sizeof(key_split_joycon),
-                     "%s_%u",
-                     msg_hash_to_str(MENU_ENUM_LABEL_INPUT_SPLIT_JOYCON), val);
-
+               snprintf(key_split_joycon         + _len,
+                        sizeof(key_split_joycon) - _len,
+                        "_%u", val);
                if (MENU_DISPLAYLIST_PARSE_SETTINGS(list,
                         key_split_joycon, PARSE_ONLY_UINT, true, 0) != -1)
                   count++;
@@ -7235,12 +7233,12 @@ unsigned menu_displaylist_build_list(
                size_t i;
                char buf[768];
                const char *msg_intf = msg_hash_to_str(MSG_INTERFACE);
+               size_t _len          = strlcpy(buf, msg_intf, sizeof(buf));
 
                for (i = 0; i < interfaces.size; i++)
                {
                   struct net_ifinfo_entry *entry = &interfaces.entries[i];
-
-                  snprintf(buf, sizeof(buf), "%s (%s) : %s\n", msg_intf,
+                  snprintf(buf + _len, sizeof(buf) - _len, " (%s) : %s\n",
                      entry->name, entry->host);
                   if (menu_entries_append(list, buf, entry->name,
                         MENU_ENUM_LABEL_NETWORK_INFO_ENTRY,

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -7926,20 +7926,31 @@ int generic_menu_entry_action(
 
       if (!string_is_empty(title_name))
       {
+	      size_t _len             = strlcpy(speak_string,
+               title_name, sizeof(speak_string));
+         speak_string[_len  ]    = ' ';
+         speak_string[_len+1]    = '\0';
+         _len                    = strlcat(speak_string,
+               current_label, sizeof(speak_string));
          if (!string_is_equal(current_value, "..."))
-            snprintf(speak_string, sizeof(speak_string),
-                  "%s %s %s", title_name, current_label, current_value);
-         else
-            snprintf(speak_string, sizeof(speak_string),
-                  "%s %s", title_name, current_label);
+         {
+            speak_string[_len  ] = ' ';
+            speak_string[_len+1] = '\0';
+            strlcat(speak_string, current_value,
+                  sizeof(speak_string));
+         }
       }
       else
       {
+         size_t _len = strlcpy(speak_string,
+               current_label, sizeof(speak_string));
          if (!string_is_equal(current_value, "..."))
-            snprintf(speak_string, sizeof(speak_string),
-                  "%s %s", current_label, current_value);
-         else
-            strlcpy(speak_string, current_label, sizeof(speak_string));
+         {
+            speak_string[_len  ] = ' ';
+            speak_string[_len+1] = '\0';
+            strlcat(speak_string, current_value,
+                  sizeof(speak_string));
+         }
       }
 
       if (!string_is_empty(speak_string))

--- a/menu/menu_explore.c
+++ b/menu/menu_explore.c
@@ -1017,10 +1017,8 @@ unsigned menu_displaylist_explore(file_list_t *list,
          if (is_top && tmplen < sizeof(tmp) - 5)
          {
             if (explore_by_info[cat].is_numeric)
-            {
                snprintf(tmp + tmplen, sizeof(tmp) - tmplen, " (%s - %s)",
                      entries[0]->str, entries[RBUF_LEN(entries) - 1]->str);
-            }
             else
             {
                strlcat(tmp, " (", sizeof(tmp));

--- a/retroarch.c
+++ b/retroarch.c
@@ -1693,14 +1693,15 @@ bool command_event(enum event_command cmd, void *data)
 
             if (video_driver_get_video_output_size(&width, &height, desc, sizeof(desc)))
             {
-               char msg[128] = {0};
+               char msg[128];
 
                video_driver_set_video_mode(width, height, true);
 
                if (width == 0 || height == 0)
-                  snprintf(msg, sizeof(msg), msg_hash_to_str(MSG_SCREEN_RESOLUTION_DEFAULT));
+                  strlcpy(msg, msg_hash_to_str(MSG_SCREEN_RESOLUTION_DEFAULT), sizeof(msg));
                else
                {
+                  msg[0] = '\0';
                   if (!string_is_empty(desc))
                      snprintf(msg, sizeof(msg),
                         msg_hash_to_str(MSG_SCREEN_RESOLUTION_DESC),

--- a/runloop.c
+++ b/runloop.c
@@ -7336,15 +7336,17 @@ static enum runloop_state_enum runloop_check_state(
        * for this frame. */
       if (check2)
       {
+         size_t _len;
          char msg[128];
          int cur_state_slot                = state_slot;
          if (check1)
             configuration_set_int(settings, settings->ints.state_slot,
                   cur_state_slot + addition);
-         msg[0] = '\0';
-         snprintf(msg, sizeof(msg), "%s: %d",
-               msg_hash_to_str(MSG_STATE_SLOT),
-               settings->ints.state_slot);
+         _len = strlcpy(msg, msg_hash_to_str(MSG_STATE_SLOT), sizeof(msg));
+         snprintf(msg         + _len,
+                  sizeof(msg) - _len,
+                  ": %d",
+                  settings->ints.state_slot);
          runloop_msg_queue_push(msg, 2, 180, true, NULL,
                MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
          RARCH_LOG("[State]: %s\n", msg);
@@ -8130,6 +8132,7 @@ bool retroarch_get_current_savestate_path(char *path, size_t len)
 
 bool retroarch_get_entry_state_path(char *path, size_t len, unsigned slot)
 {
+   size_t _len;
    runloop_state_t *runloop_st = &runloop_state;
    const char *name_savestate  = NULL;
 
@@ -8140,8 +8143,8 @@ bool retroarch_get_entry_state_path(char *path, size_t len, unsigned slot)
    if (string_is_empty(name_savestate))
       return false;
 
-   snprintf(path, len, "%s%d", name_savestate, slot);
-   strlcat(path, ".entry", len);
+   _len = strlcpy(path, name_savestate, len);
+   snprintf(path + _len, len - _len, "%d.entry", slot);
 
    return true;
 }

--- a/tasks/task_core_updater.c
+++ b/tasks/task_core_updater.c
@@ -1370,8 +1370,9 @@ static void task_update_installed_cores_handler(retro_task_t *task)
             if (update_installed_handle->list_size > 0)
             {
                char task_title[PATH_MAX_LENGTH];
-
-               task_title[0] = '\0';
+               size_t _len = strlcpy(task_title,
+                     msg_hash_to_str(MSG_ALL_CORES_UPDATED),
+                     sizeof(task_title));
 
                /* > Generate final status message based on number
                 *   of cores that were updated/locked */
@@ -1379,28 +1380,28 @@ static void task_update_installed_cores_handler(retro_task_t *task)
                {
                   if (update_installed_handle->num_locked > 0)
                      snprintf(
-                           task_title, sizeof(task_title), "%s [%s%u, %s%u]",
-                           msg_hash_to_str(MSG_ALL_CORES_UPDATED),
+                           task_title         + _len,
+                           sizeof(task_title) - _len,
+                           " [%s%u, %s%u]",
                            msg_hash_to_str(MSG_NUM_CORES_UPDATED),
                            update_installed_handle->num_updated,
                            msg_hash_to_str(MSG_NUM_CORES_LOCKED),
                            update_installed_handle->num_locked);
                   else
                      snprintf(
-                           task_title, sizeof(task_title), "%s [%s%u]",
-                           msg_hash_to_str(MSG_ALL_CORES_UPDATED),
+                           task_title         + _len,
+                           sizeof(task_title) - _len,
+                           " [%s%u]",
                            msg_hash_to_str(MSG_NUM_CORES_UPDATED),
                            update_installed_handle->num_updated);
                }
                else if (update_installed_handle->num_locked > 0)
                   snprintf(
-                        task_title, sizeof(task_title), "%s [%s%u]",
-                        msg_hash_to_str(MSG_ALL_CORES_UPDATED),
+                        task_title         + _len,
+                        sizeof(task_title) - _len,
+                        " [%s%u]",
                         msg_hash_to_str(MSG_NUM_CORES_LOCKED),
                         update_installed_handle->num_locked);
-               else
-                  strlcpy(task_title, msg_hash_to_str(MSG_ALL_CORES_UPDATED),
-                        sizeof(task_title));
 
                task_set_title(task, strdup(task_title));
             }


### PR DESCRIPTION
Aims of this PR:
* Reduce the amount of snprintf calls in general
* Replace snprintf with strlcpy call when possible
* Use snprintf for string concatenation when snprintf formatting is absolutely necessary
* Do away with certain intermediary string copying