### PR TITLE
Reduce snprintf

### DIFF
--- a/command.c
+++ b/command.c
@@ -375,7 +375,7 @@ bool command_get_config_param(command_t *cmd, const char* arg)
       value = path_username;
    /* TODO: query any string */
 
-   strlcpy(reply, "GET_CONFIG_PARAM ";
+   strlcpy(reply, "GET_CONFIG_PARAM ", sizeof(reply));
    _len          = strlcat(reply, arg, sizeof(reply));
    reply[_len  ] = ' ';
    reply[_len+1] = '\0';

--- a/configuration.c
+++ b/configuration.c
@@ -4702,7 +4702,7 @@ bool config_save_file(const char *path)
       char cfg[64];
       char formatted_number[4];
 
-      cfg[0] = formatted_number[0] = '\0';
+      formatted_number[0] = '\0';
 
       snprintf(formatted_number, sizeof(formatted_number), "%u", i + 1);
 
@@ -5135,13 +5135,7 @@ bool input_remapping_load_file(void *data, const char *path)
       char prefix[16];
       char s1[32], s2[32], s3[32];
       char formatted_number[4];
-
-      prefix[0]  = '\0';
-      s1[0]      = '\0';
-      s2[0]      = '\0';
-      s3[0]      = '\0';
       formatted_number[0] = '\0';
-
       snprintf(formatted_number, sizeof(formatted_number), "%u", i + 1);
       strlcpy(prefix, "input_player",   sizeof(prefix));
       strlcat(prefix, formatted_number, sizeof(prefix));
@@ -5225,8 +5219,7 @@ bool input_remapping_load_file(void *data, const char *path)
          }
       }
 
-      strlcpy(s1, "input_player",             sizeof(s1));
-      strlcat(s1, formatted_number,           sizeof(s1));
+      strlcpy(s1, prefix,                     sizeof(s1));
       strlcat(s1, "_analog_dpad_mode",        sizeof(s1));
       CONFIG_GET_INT_BASE(conf, settings, uints.input_analog_dpad_mode[i], s1);
 
@@ -5299,10 +5292,6 @@ bool input_remapping_save_file(const char *path)
       char s3[32];
 
       formatted_number[0] = '\0';
-      prefix[0] = '\0';
-      s1[0]     = '\0';
-      s2[0]     = '\0';
-      s3[0]     = '\0';
 
       /* We must include all mapped ports + all those
        * with an index less than max_users */
@@ -5417,8 +5406,7 @@ bool input_remapping_save_file(const char *path)
       strlcat(s1, formatted_number,          sizeof(s1));
       config_set_int(conf, s1, input_config_get_device(i));
 
-      strlcpy(s1, "input_player",            sizeof(s1));
-      strlcat(s1, formatted_number,          sizeof(s1));
+      strlcpy(s1, prefix,                    sizeof(s1));
       strlcat(s1, "_analog_dpad_mode",       sizeof(s1));
       config_set_int(conf, s1, settings->uints.input_analog_dpad_mode[i]);
 

--- a/configuration.c
+++ b/configuration.c
@@ -4204,7 +4204,6 @@ static void save_keybind_hat(config_file_t *conf, const char *key,
 {
    char config[16];
    unsigned hat     = (unsigned)GET_HAT(bind->joykey);
-   const char *dir  = NULL;
 
    config[0]        = 'h';
    config[1]        = '\0';

--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -669,9 +669,17 @@ void video_monitor_set_refresh_rate(float hz)
 {
    char msg[128];
    settings_t        *settings = config_get_ptr();
-
-   snprintf(msg, sizeof(msg),
-         "Setting refresh rate to: %.3f Hz.", hz);
+   /* TODO/FIXME - localize */
+   size_t _len = strlcpy(msg, "Setting refresh rate to", sizeof(msg));
+   msg[_len  ] = ':';
+   msg[++_len] = ' ';
+   msg[++_len] = '\0';
+   _len       += snprintf(msg + _len, sizeof(msg) - _len, "%.3f", hz);
+   msg[_len  ] = ' ';
+   msg[_len+1] = 'H';
+   msg[_len+2] = 'z';
+   msg[_len+3] = '.';
+   msg[_len+4] = '\0';
    if (settings->bools.notification_show_refresh_rate)
       runloop_msg_queue_push(msg, 1, 180, false, NULL,
             MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);

--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -4663,6 +4663,7 @@ error:
 static bool runloop_check_movie_init(input_driver_state_t *input_st,
       settings_t *settings)
 {
+   size_t _len;
    char msg[16384], path[8192];
    bsv_movie_t *state          = NULL;
    int state_slot              = settings->ints.state_slot;
@@ -4670,15 +4671,10 @@ static bool runloop_check_movie_init(input_driver_state_t *input_st,
 
    configuration_set_uint(settings, settings->uints.rewind_granularity, 1);
 
-   strlcpy(path,
+   _len = strlcpy(path,
          input_st->bsv_movie_state.movie_path, sizeof(path));
    if (state_slot > 0)
-   {
-      char formatted_number[16];
-      formatted_number[0] = '\0';
-      snprintf(formatted_number, sizeof(formatted_number), "%d", state_slot);
-      strlcat(path, formatted_number, sizeof(path));
-   }
+      snprintf(path + _len, sizeof(path) - _len, "%d", state_slot);
    strlcat(path, ".bsv", sizeof(path));
 
    snprintf(msg, sizeof(msg), "%s \"%s\".",

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -3443,8 +3443,6 @@ static void ozone_update_savestate_thumbnail_path(void *data, unsigned i)
             char path[8204];
             runloop_state_t *runloop_st = runloop_state_get_ptr();
 
-            path[0] = '\0';
-
             /* State slot dropdown */
             if (string_to_unsigned(entry.label) == MENU_ENUM_LABEL_STATE_SLOT)
             {
@@ -3452,14 +3450,20 @@ static void ozone_update_savestate_thumbnail_path(void *data, unsigned i)
                ozone->is_state_slot = true;
             }
 
-            if (state_slot > 0)
-               snprintf(path, sizeof(path), "%s%d",
-                     runloop_st->name.savestate, state_slot);
-            else if (state_slot < 0)
+            if (state_slot < 0)
+            {
+               path[0] = '\0';
                fill_pathname_join_delim(path,
                      runloop_st->name.savestate, "auto", '.', sizeof(path));
+            }
             else
-               strlcpy(path, runloop_st->name.savestate, sizeof(path));
+            {
+               size_t _len = strlcpy(path,
+                     runloop_st->name.savestate, sizeof(path));
+               if (state_slot > 0)
+                  snprintf(path + _len, sizeof(path) - _len, "%d",
+                        state_slot);
+            }
 
             strlcat(path, FILE_PATH_PNG_EXTENSION, sizeof(path));
 
@@ -3864,14 +3868,14 @@ static void ozone_update_content_metadata(ozone_handle_t *ozone)
       /* Fill entry enumeration */
       if (show_entry_idx)
       {
+         unsigned long _entry = (unsigned long)(playlist_index + 1);
          if (ozone->is_explore_list)
-            snprintf(ozone->selection_entry_enumeration, sizeof(ozone->selection_entry_enumeration),
-                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CONTENT_INFO_ENTRY_IDX),
-                  (unsigned long)(selection), (unsigned long)list_size);
-         else
-            snprintf(ozone->selection_entry_enumeration, sizeof(ozone->selection_entry_enumeration),
-                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CONTENT_INFO_ENTRY_IDX),
-                  (unsigned long)(playlist_index + 1), (unsigned long)list_size);
+            _entry            = (unsigned long)(selection);
+
+         snprintf(ozone->selection_entry_enumeration,
+               sizeof(ozone->selection_entry_enumeration),
+               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CONTENT_INFO_ENTRY_IDX),
+               _entry, (unsigned long)list_size);
 
          if (!scroll_content_metadata)
             linebreak_after_colon(&ozone->selection_entry_enumeration);

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -5025,7 +5025,7 @@ static void rgui_render(void *data,
             if (rgui->is_quick_menu)
             {
                snprintf(thumbnail_title_buf      + _len,
-                     sizeof(thumbnail_title_buf) + _len,
+                     sizeof(thumbnail_title_buf) - _len,
                      " %d",
                      config_get_ptr()->ints.state_slot);
                thumbnail_title = thumbnail_title_buf;

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -5019,17 +5019,22 @@ static void rgui_render(void *data,
          /* State slot title */
          if (is_state_slot)
          {
+            size_t _len = strlcpy(thumbnail_title_buf,
+                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_STATE_SLOT),
+                  sizeof(thumbnail_title_buf));
             if (rgui->is_quick_menu)
             {
-               snprintf(thumbnail_title_buf, sizeof(thumbnail_title_buf), "%s %d",
-                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_STATE_SLOT),
+               snprintf(thumbnail_title_buf      + _len,
+                     sizeof(thumbnail_title_buf) + _len,
+                     " %d",
                      config_get_ptr()->ints.state_slot);
                thumbnail_title = thumbnail_title_buf;
             }
             else if (rgui->is_state_slot)
             {
-               snprintf(thumbnail_title_buf, sizeof(thumbnail_title_buf), "%s %d",
-                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_STATE_SLOT),
+               snprintf(thumbnail_title_buf      + _len,
+                     sizeof(thumbnail_title_buf) - _len,
+                     " %d",
                      (int)menu_navigation_get_selection() - 1);
                thumbnail_title = thumbnail_title_buf;
             }
@@ -6572,8 +6577,6 @@ static void rgui_update_savestate_thumbnail_path(void *data, unsigned i)
             char path[8204];
             runloop_state_t *runloop_st = runloop_state_get_ptr();
 
-            path[0] = '\0';
-
             /* State slot dropdown */
             if (string_to_unsigned(entry.label) == MENU_ENUM_LABEL_STATE_SLOT)
             {
@@ -6581,14 +6584,20 @@ static void rgui_update_savestate_thumbnail_path(void *data, unsigned i)
                rgui->is_state_slot = true;
             }
 
-            if (state_slot > 0)
-               snprintf(path, sizeof(path), "%s%d",
-                     runloop_st->name.savestate, state_slot);
-            else if (state_slot < 0)
+            if (state_slot < 0)
+            {
+               path[0] = '\0';
                fill_pathname_join_delim(path,
                      runloop_st->name.savestate, "auto", '.', sizeof(path));
+            }
             else
-               strlcpy(path, runloop_st->name.savestate, sizeof(path));
+            {
+               size_t _len = strlcpy(path,
+                     runloop_st->name.savestate, sizeof(path));
+               if (state_slot > 0)
+                  snprintf(path + _len, sizeof(path) - _len, "%d",
+                        state_slot);
+            }
 
             strlcat(path, FILE_PATH_PNG_EXTENSION, sizeof(path));
 

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -1197,8 +1197,6 @@ static void xmb_update_savestate_thumbnail_path(void *data, unsigned i)
             char path[8204];
             runloop_state_t *runloop_st = runloop_state_get_ptr();
 
-            path[0] = '\0';
-
             /* State slot dropdown */
             if (string_to_unsigned(entry.label) == MENU_ENUM_LABEL_STATE_SLOT)
             {
@@ -1206,14 +1204,20 @@ static void xmb_update_savestate_thumbnail_path(void *data, unsigned i)
                xmb->is_state_slot = true;
             }
 
-            if (state_slot > 0)
-               snprintf(path, sizeof(path), "%s%d",
-                     runloop_st->name.savestate, state_slot);
-            else if (state_slot < 0)
+            if (state_slot < 0)
+            {
+               path[0] = '\0';
                fill_pathname_join_delim(path,
                      runloop_st->name.savestate, "auto", '.', sizeof(path));
+            }
             else
-               strlcpy(path, runloop_st->name.savestate, sizeof(path));
+            {
+               size_t _len = strlcpy(path,
+                     runloop_st->name.savestate, sizeof(path));
+               if (state_slot > 0)
+                  snprintf(path + _len, sizeof(path) - _len, "%d",
+                        state_slot);
+            }
 
             strlcat(path, FILE_PATH_PNG_EXTENSION, sizeof(path));
 

--- a/menu/menu_contentless_cores.c
+++ b/menu/menu_contentless_cores.c
@@ -121,11 +121,15 @@ static void contentless_cores_init_info_entries(
       if (core_info &&
           core_info->supports_no_game)
       {
+         char licenses_str[MENU_SUBLABEL_MAX_LENGTH];
          contentless_core_info_entry_t *entry =
                (contentless_core_info_entry_t*)malloc(sizeof(*entry));
-         char licenses_str[MENU_SUBLABEL_MAX_LENGTH];
-
-         licenses_str[0] = '\0';
+         size_t _len          = strlcpy(licenses_str,
+               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CORE_INFO_LICENSES),
+               sizeof(licenses_str));
+         licenses_str[_len  ] = ':';
+         licenses_str[_len+1] = ' ';
+         licenses_str[_len+2] = '\0';
 
          /* Populate licences string */
          if (core_info->licenses_list)
@@ -134,17 +138,15 @@ static void contentless_cores_init_info_entries(
             tmp_str[0] = '\0';
             string_list_join_concat(tmp_str, sizeof(tmp_str),
                   core_info->licenses_list, ", ");
-            snprintf(licenses_str, sizeof(licenses_str), "%s: %s",
-                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CORE_INFO_LICENSES),
-                  tmp_str);
+            strlcat(licenses_str, tmp_str, sizeof(licenses_str));
          }
          /* No license found - set to N/A */
          else
-            snprintf(licenses_str, sizeof(licenses_str), "%s: %s",
-                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CORE_INFO_LICENSES),
-                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE));
+            strlcat(licenses_str,
+                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE),
+                  sizeof(licenses_str));
 
-         entry->licenses_str = strdup(licenses_str);
+         entry->licenses_str            = strdup(licenses_str);
 
          /* Initialise runtime info */
          entry->runtime.runtime_str     = NULL;

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -1810,6 +1810,7 @@ static unsigned menu_displaylist_parse_system_info(file_list_t *list)
                MENU_ENUM_LABEL_SYSTEM_INFO_CONTROLLER_ENTRY,
                MENU_SETTINGS_CORE_INFO_NONE, 0, 0, NULL))
                count++;
+            /* TODO/FIXME - Localize */
             snprintf(tmp, sizeof(tmp), " Device VID/PID: %d/%d",
                input_config_get_device_vid(controller),
                input_config_get_device_pid(controller));
@@ -2425,7 +2426,7 @@ static int create_string_list_rdb_entry_int(
    str_len                         += strlen(label) + 1;
    string_list_append(&str_list, label, attr);
 
-   _len = snprintf(str, sizeof(str), "%d", actual_int);
+   _len                             = snprintf(str, sizeof(str), "%d", actual_int);
    str_len                         += _len + 1;
    string_list_append(&str_list, str, attr);
 
@@ -5125,7 +5126,6 @@ static int menu_displaylist_parse_input_device_index_list(
 {
    char device_id[10];
    char device_label[128];
-   const char *device_name      = NULL;
    const char *val_port         = NULL;
    const char *val_na           = NULL;
    const char *val_disabled     = NULL;
@@ -5162,11 +5162,10 @@ static int menu_displaylist_parse_input_device_index_list(
       snprintf(device_id, sizeof(device_id), "%d", i);
 
       device_label[0] = '\0';
-      device_name     = NULL;
 
       if (i < max_devices)
       {
-         device_name = input_config_get_device_display_name(i) ?
+         const char *device_name = input_config_get_device_display_name(i) ?
                input_config_get_device_display_name(i) : input_config_get_device_name(i);
 
          if (!string_is_empty(device_name))
@@ -5486,7 +5485,7 @@ static int menu_displaylist_parse_input_description_kbd_list(
       }
       else
       {
-         /* TODO/FIXME: Localise 'Keyboard' */
+         /* TODO/FIXME: Localize 'Keyboard' */
          strlcpy(input_description, "Keyboard ", sizeof(input_description));
          strlcat(input_description, key_label, sizeof(input_description));
       }
@@ -5909,19 +5908,20 @@ static int menu_displaylist_parse_disc_info(file_list_t *info_list,
       unsigned type)
 {
    unsigned i;
-   unsigned           count = 0;
-   struct string_list *list = cdrom_get_available_drives();
+   unsigned           count     = 0;
+   struct string_list *list     = cdrom_get_available_drives();
+   const char *msg_drive_number = msg_hash_to_str(MSG_DRIVE_NUMBER);
 
    for (i = 0; list && i < list->size; i++)
    {
+      char drive[2];
       char drive_string[256] = {0};
-      char drive[2]          = {0};
-      size_t pos             = 0;
+      size_t pos             = snprintf(drive_string, sizeof(drive_string),
+            msg_drive_number, i + 1);
+      pos += snprintf(drive_string + pos, sizeof(drive_string) - pos, ": %s", list->elems[i].data);
 
       drive[0]               = list->elems[i].attr.i;
-
-      pos += snprintf(drive_string + pos, sizeof(drive_string) - pos, msg_hash_to_str(MSG_DRIVE_NUMBER), i + 1);
-      pos += snprintf(drive_string + pos, sizeof(drive_string) - pos, ": %s", list->elems[i].data);
+      drive[1]               = '\0';
 
       if (menu_entries_append(info_list,
                drive_string,
@@ -5984,7 +5984,7 @@ static unsigned menu_displaylist_populate_subsystem(
          {
             if (content_get_subsystem_rom_id() < subsystem->num_roms)
             {
-               /* TODO/FIXME - localize string */
+               /* TODO/FIXME - Localize string */
                size_t _len = strlcpy(s, "Load", sizeof(s));
                s[_len  ]   = ' ';
                s[_len+1]   = '\0';
@@ -5998,7 +5998,7 @@ static unsigned menu_displaylist_populate_subsystem(
                if (is_rgui && !menu_show_sublabels)
                {
                   strlcat(s, " [", sizeof(s));
-                  /* TODO/FIXME - localize */
+                  /* TODO/FIXME - Localize */
                   _len        = strlcat(s, "Current Content:", sizeof(s));
                   s[_len  ]   = ' ';
                   s[_len+1]   = '\0';
@@ -6018,7 +6018,7 @@ static unsigned menu_displaylist_populate_subsystem(
             }
             else
             {
-               /* TODO/FIXME - localize string */
+               /* TODO/FIXME - Localize string */
                size_t _len = strlcpy(s, "Start", sizeof(s));
                s[_len  ]   = ' ';
                s[_len+1]   = '\0';
@@ -6062,7 +6062,7 @@ static unsigned menu_displaylist_populate_subsystem(
          }
          else
          {
-            /* TODO/FIXME - localize */
+            /* TODO/FIXME - Localize */
             size_t _len = strlcpy(s, "Load", sizeof(s));
             s[_len  ]   = ' ';
             s[_len+1]   = '\0';
@@ -6078,7 +6078,7 @@ static unsigned menu_displaylist_populate_subsystem(
                if (subsystem->num_roms > 0)
                {
                   strlcat(s, " [", sizeof(s));
-                  /* TODO/FIXME - localize */
+                  /* TODO/FIXME - Localize */
                   strlcat(s, "Current Content:", sizeof(s));
                   strlcat(s, " ",  sizeof(s));
                   strlcat(s, subsystem->roms[0].desc, sizeof(s));
@@ -10513,7 +10513,7 @@ unsigned menu_displaylist_netplay_refresh_rooms(file_list_t *list)
    char passworded[64];
    char country[8];
    const char *room_type;
-   struct netplay_room *room;
+   const char *cnc_netplay_room   = NULL;
    const char *msg_int_nc         = NULL;
    const char *msg_int_relay      = NULL;
    const char *msg_int            = NULL;
@@ -10589,15 +10589,16 @@ unsigned menu_displaylist_netplay_refresh_rooms(file_list_t *list)
 
    core_info_get_list(&coreinfos);
 
-   msg_int_nc    = msg_hash_to_str(MSG_INTERNET_NOT_CONNECTABLE);
-   msg_int_relay = msg_hash_to_str(MSG_INTERNET_RELAY);
-   msg_int       = msg_hash_to_str(MSG_INTERNET);
-   msg_local     = msg_hash_to_str(MSG_LOCAL);
-   msg_room_pwd  = msg_hash_to_str(MSG_ROOM_PASSWORDED);
+   msg_int_nc       = msg_hash_to_str(MSG_INTERNET_NOT_CONNECTABLE);
+   msg_int_relay    = msg_hash_to_str(MSG_INTERNET_RELAY);
+   msg_int          = msg_hash_to_str(MSG_INTERNET);
+   msg_local        = msg_hash_to_str(MSG_LOCAL);
+   msg_room_pwd     = msg_hash_to_str(MSG_ROOM_PASSWORDED);
+   cnc_netplay_room = msg_hash_to_str(MENU_ENUM_LABEL_CONNECT_NETPLAY_ROOM);
 
    for (i = 0; i < net_st->room_count; i++)
    {
-      room = &net_st->room_list[i];
+      struct netplay_room *room = &net_st->room_list[i];
 
       /* Get rid of any room that is not running RetroArch. */
       if (!room->is_retroarch)
@@ -10657,7 +10658,7 @@ unsigned menu_displaylist_netplay_refresh_rooms(file_list_t *list)
          passworded, room_type, room->nickname, country);
 
       if (menu_entries_append(list, buf,
-            msg_hash_to_str(MENU_ENUM_LABEL_CONNECT_NETPLAY_ROOM),
+            cnc_netplay_room,
             MENU_ENUM_LABEL_CONNECT_NETPLAY_ROOM,
             (unsigned)MENU_SETTINGS_NETPLAY_ROOMS_START + i, 0, 0, NULL))
          count++;
@@ -10892,30 +10893,30 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
 
 		    menu_entries_ctl(MENU_ENTRIES_CTL_CLEAR, list);
 
-            if (netplay_driver_ctl(RARCH_NETPLAY_CTL_IS_ENABLED, NULL))
-            {
-               if (netplay_driver_ctl(RARCH_NETPLAY_CTL_IS_SERVER, NULL))
-               {
-                  menu_entries_append(list,
-                     msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NETPLAY_DISABLE_HOST),
-                     msg_hash_to_str(MENU_ENUM_LABEL_NETPLAY_DISCONNECT),
-                     MENU_ENUM_LABEL_NETPLAY_DISCONNECT,
-                     MENU_SETTING_ACTION, 0, 0, NULL);
-                  if (netplay_driver_ctl(RARCH_NETPLAY_CTL_IS_DATA_INITED, NULL))
-                  {
-                     menu_entries_append(list,
-                        msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NETPLAY_KICK),
-                        msg_hash_to_str(MENU_ENUM_LABEL_NETPLAY_KICK),
-                        MENU_ENUM_LABEL_NETPLAY_KICK,
-                        MENU_SETTING_ACTION, 0, 0, NULL);
-                     menu_entries_append(list,
-                        msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NETPLAY_BAN),
-                        msg_hash_to_str(MENU_ENUM_LABEL_NETPLAY_BAN),
-                        MENU_ENUM_LABEL_NETPLAY_BAN,
-                        MENU_SETTING_ACTION, 0, 0, NULL);
-                  }
-               }
-            }
+          if (netplay_driver_ctl(RARCH_NETPLAY_CTL_IS_ENABLED, NULL))
+          {
+             if (netplay_driver_ctl(RARCH_NETPLAY_CTL_IS_SERVER, NULL))
+             {
+                menu_entries_append(list,
+                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NETPLAY_DISABLE_HOST),
+                      msg_hash_to_str(MENU_ENUM_LABEL_NETPLAY_DISCONNECT),
+                      MENU_ENUM_LABEL_NETPLAY_DISCONNECT,
+                      MENU_SETTING_ACTION, 0, 0, NULL);
+                if (netplay_driver_ctl(RARCH_NETPLAY_CTL_IS_DATA_INITED, NULL))
+                {
+                   menu_entries_append(list,
+                         msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NETPLAY_KICK),
+                         msg_hash_to_str(MENU_ENUM_LABEL_NETPLAY_KICK),
+                         MENU_ENUM_LABEL_NETPLAY_KICK,
+                         MENU_SETTING_ACTION, 0, 0, NULL);
+                   menu_entries_append(list,
+                         msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NETPLAY_BAN),
+                         msg_hash_to_str(MENU_ENUM_LABEL_NETPLAY_BAN),
+                         MENU_ENUM_LABEL_NETPLAY_BAN,
+                         MENU_SETTING_ACTION, 0, 0, NULL);
+                }
+             }
+          }
             else
             {
                menu_entries_append(list,
@@ -11153,9 +11154,8 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
             cdrom_device_fillpath(file_path, sizeof(file_path), drive, 0, true);
 
             /* opening the cue triggers storing of TOC info internally */
-            file = filestream_open(file_path, RETRO_VFS_FILE_ACCESS_READ, 0);
-
-            if (file)
+            if ((file = filestream_open(file_path, RETRO_VFS_FILE_ACCESS_READ,
+                        0)))
             {
                const cdrom_toc_t *toc = retro_vfs_file_get_cdrom_toc();
                unsigned first_data_track = 1;
@@ -11199,6 +11199,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                   if (!string_is_empty(cd_info.system))
                   {
                      char system[256];
+                     /* TODO/FIXME - Localize */
                      strlcpy(system, "System: ", sizeof(system));
                      strlcat(system, cd_info.system, sizeof(system));
 
@@ -11230,6 +11231,8 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                   if (!string_is_empty(cd_info.version))
                   {
                      char version[256];
+                     /* TODO/FIXME - why are we using a Qt core version string
+                      * message here? */
                      snprintf(version, sizeof(version),
                            "%s: %s", msg_hash_to_str(MENU_ENUM_LABEL_VALUE_QT_CORE_VERSION), cd_info.version);
 
@@ -11244,6 +11247,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                   if (!string_is_empty(cd_info.release_date))
                   {
                      char release_date[256];
+                     /* TODO/FIXME - Localize */
                      snprintf(release_date, sizeof(release_date),
                            "Release Date: %s", cd_info.release_date);
 
@@ -11257,6 +11261,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
 
                   if (atip)
                   {
+                     /* TODO/FIXME - Localize */
                      const char *atip_string = "Genuine Disc: No";
                      if (menu_entries_append(info->list,
                               atip_string,
@@ -11267,6 +11272,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                   }
                   else
                   {
+                     /* TODO/FIXME - Localize */
                      const char *atip_string = "Genuine Disc: Yes";
                      if (menu_entries_append(info->list,
                               atip_string,
@@ -11277,6 +11283,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                   }
 
                   {
+                     /* TODO/FIXME - Localize */
                      char tracks_string[32] = {"Number of tracks: "};
 
                      snprintf(tracks_string + strlen(tracks_string), sizeof(tracks_string) - strlen(tracks_string), "%d", toc->num_tracks);
@@ -11549,6 +11556,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
             char title[PATH_MAX_LENGTH];
             char* profile               = SWITCH_CPU_PROFILES[i];
             char* speed                 = SWITCH_CPU_SPEEDS[i];
+            title[0] = '\0';
 
             snprintf(title, sizeof(title), "%s (%s)", profile, speed);
 
@@ -11575,7 +11583,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
          FILE               *profile = NULL;
          const size_t profiles_count = sizeof(SWITCH_GPU_PROFILES)/sizeof(SWITCH_GPU_PROFILES[1]);
 
-         runloop_msg_queue_push("Warning : extented overclocking can damage the Switch", 1, 90, true, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
+         runloop_msg_queue_push("Warning : extended overclocking can damage the Switch", 1, 90, true, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
 
          profile = popen("gpu-profile get", "r");
          fgets(current_profile, PATH_MAX_LENGTH, profile);
@@ -11583,6 +11591,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
 
          menu_entries_ctl(MENU_ENTRIES_CTL_CLEAR, info->list);
 
+         /* TODO/FIXME - Localize */
          snprintf(text, sizeof(text),
                "Current profile : %s", current_profile);
 
@@ -11880,6 +11889,8 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
 
             if (video_shader_enable)
             {
+               char buf_tmp[64];
+               size_t _len;
                const char *val_shdr =
                   msg_hash_to_str(MENU_ENUM_LABEL_VALUE_SHADER);
                const char *shdr_pass =
@@ -11952,33 +11963,31 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                         0, 0, 0, NULL))
                   count++;
 
+               _len = strlcpy(buf_tmp, val_shdr, sizeof(buf_tmp));
+
                for (i = 0; i < pass_count; i++)
                {
-                  size_t _len;
-                  char buf_tmp[64];
+                  size_t _len2;
                   char buf[128];
-
-                  buf_tmp[0] = '\0';
-
-                  snprintf(buf_tmp, sizeof(buf_tmp),"%s #%u", val_shdr, i);
+                  snprintf(buf_tmp + _len, sizeof(buf_tmp) - _len," #%u", i);
 
                   if (menu_entries_append(info->list, buf_tmp, shdr_pass,
                            MENU_ENUM_LABEL_VIDEO_SHADER_PASS,
                            MENU_SETTINGS_SHADER_PASS_0 + i, 0, 0, NULL))
                      count++;
 
-                  _len        = strlcpy(buf, buf_tmp, sizeof(buf));
-                  buf[_len  ] = ' ';
-                  buf[_len+1] = '\0';
+                  _len2        = strlcpy(buf, buf_tmp, sizeof(buf));
+                  buf[_len2  ] = ' ';
+                  buf[_len2+1] = '\0';
                   strlcat(buf, val_filter, sizeof(buf));
                   if (menu_entries_append(info->list, buf, shdr_filter_pass,
                            MENU_ENUM_LABEL_VIDEO_SHADER_FILTER_PASS,
                            MENU_SETTINGS_SHADER_PASS_FILTER_0 + i, 0, 0, NULL))
                      count++;
 
-                  _len        = strlcpy(buf, buf_tmp, sizeof(buf));
-                  buf[_len  ] = ' ';
-                  buf[_len+1] = '\0';
+                  _len2        = strlcpy(buf, buf_tmp, sizeof(buf));
+                  buf[_len2  ] = ' ';
+                  buf[_len2+1] = '\0';
                   strlcat(buf, val_scale, sizeof(buf));
                   if (menu_entries_append(info->list, buf, shdr_scale_pass,
                            MENU_ENUM_LABEL_VIDEO_SHADER_SCALE_PASS,
@@ -12726,11 +12735,8 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
 
                if (retroarch_ctl(RARCH_CTL_CORE_OPTIONS_LIST_GET, &coreopts))
                {
-                  nested_list_item_t *category_item = NULL;
-                  nested_list_t *option_list        = NULL;
-                  nested_list_item_t *option_item   = NULL;
-                  const struct core_option *option  = NULL;
                   size_t i;
+                  nested_list_t *option_list        = NULL;
 
                   /* Empty 'category' string signifies top
                    * level core options menu */
@@ -12738,7 +12744,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                      option_list = coreopts->option_map;
                   else
                   {
-                     category_item  = nested_list_get_item(coreopts->option_map,
+                     nested_list_item_t *category_item  = nested_list_get_item(coreopts->option_map,
                            category, NULL);
                      if (category_item)
                         option_list = nested_list_item_get_children(category_item);
@@ -12749,8 +12755,8 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                      /* Loop over child options */
                      for (i = 0; i < nested_list_get_size(option_list); i++)
                      {
-                        option_item = nested_list_get_item_idx(option_list, i);
-                        option      = (const struct core_option *)
+                        nested_list_item_t *option_item  = nested_list_get_item_idx(option_list, i);
+                        const struct core_option *option = (const struct core_option *)
                               nested_list_item_get_value(option_item);
 
                         /* Check whether this is an option or a
@@ -12771,9 +12777,9 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                         else if (option_item)
                         {
                            /* This is a subcategory */
-                           const char *catgory_id = nested_list_item_get_id(option_item);
-                           bool category_visible  = core_option_manager_get_category_visible(
-                                 coreopts, catgory_id);
+                           const char *category_id = nested_list_item_get_id(option_item);
+                           bool category_visible   = core_option_manager_get_category_visible(
+                                 coreopts, category_id);
 
                            /* Note: We use nested_list_item_get_id() because we
                             * guarantee that the list can only be two levels
@@ -12781,10 +12787,10 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                             * have to use nested_list_item_get_address() here */
 
                            if (category_visible &&
-                               !string_is_empty(catgory_id))
+                               !string_is_empty(category_id))
                            {
                               if (menu_entries_append(info->list,
-                                    catgory_id,
+                                    category_id,
                                     msg_hash_to_str(MENU_ENUM_LABEL_CORE_OPTIONS),
                                     MENU_ENUM_LABEL_CORE_OPTIONS,
                                     MENU_SETTING_ACTION_CORE_OPTIONS, 0, 0, NULL))
@@ -14243,13 +14249,14 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                            }
                            else
                            {
+                              char val_d[16];
+                              snprintf(val_d, sizeof(val_d), "%d", setting->enum_idx);
+
                               for (i = min; i <= max; i += step)
                               {
-                                 char val_s[16], val_d[16];
+                                 char val_s[16];
                                  int val = (int)i;
-
                                  snprintf(val_s, sizeof(val_s), "%d", val);
-                                 snprintf(val_d, sizeof(val_d), "%d", setting->enum_idx);
 
                                  if (menu_entries_append(info->list,
                                        val_s,
@@ -14292,15 +14299,15 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
 
                            if (setting->get_string_representation)
                            {
+                              char val_d[16];
+                              snprintf(val_d, sizeof(val_d), "%d", setting->enum_idx);
+
                               for (i = min; i <= max; i += step)
                               {
-                                 char val_s[256], val_d[16];
-
+                                 char val_s[256];
                                  *setting->value.target.fraction = i;
-
                                  setting->get_string_representation(setting,
                                        val_s, sizeof(val_s));
-                                 snprintf(val_d, sizeof(val_d), "%d", setting->enum_idx);
                                  if (menu_entries_append(info->list,
                                        val_s,
                                        val_d,
@@ -14327,7 +14334,6 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                               for (i = min; i <= max; i += step)
                               {
                                  char val_s[16];
-
                                  snprintf(val_s, sizeof(val_s), "%.2f", i);
 
                                  if (menu_entries_append(info->list,
@@ -14370,16 +14376,15 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
 
                            if (setting->get_string_representation)
                            {
+                              char val_d[16];
+                              snprintf(val_d, sizeof(val_d), "%d", setting->enum_idx);
                               for (i = min; i <= max; i += step)
                               {
-                                 char val_s[256], val_d[16];
+                                 char val_s[256];
                                  int val = (int)i;
-
                                  *setting->value.target.unsigned_integer = val;
-
                                  setting->get_string_representation(setting,
                                        val_s, sizeof(val_s));
-                                 snprintf(val_d, sizeof(val_d), "%d", setting->enum_idx);
                                  if (menu_entries_append(info->list,
                                           val_s,
                                           val_d,
@@ -14406,9 +14411,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                               {
                                  char val_s[16];
                                  int val = (int)i;
-
                                  snprintf(val_s, sizeof(val_s), "%d", val);
-
                                  if (menu_entries_append(info->list,
                                        val_s,
                                        val_d,
@@ -14556,16 +14559,16 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
 
                         if (setting->get_string_representation)
                         {
+                           char val_d[16];
+                           snprintf(val_d, sizeof(val_d), "%d", setting->enum_idx);
+
                            for (i = min; i <= max; i += step)
                            {
-                              char val_s[256], val_d[16];
+                              char val_s[256];
                               int val = (int)i;
-
                               *setting->value.target.integer = val;
-
                               setting->get_string_representation(setting,
                                     val_s, sizeof(val_s));
-                              snprintf(val_d, sizeof(val_d), "%d", setting->enum_idx);
                               if (menu_entries_append(info->list,
                                     val_s,
                                     val_d,
@@ -14593,7 +14596,6 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                               char val_s[16];
                               int val = (int)i;
                               snprintf(val_s, sizeof(val_s), "%d", val);
-
                               if (menu_entries_append(info->list,
                                     val_s,
                                     val_d,
@@ -14635,15 +14637,14 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
 
                         if (setting->get_string_representation)
                         {
+                           char val_d[16];
+                           snprintf(val_d, sizeof(val_d), "%d", setting->enum_idx);
                            for (i = min; i <= max; i += step)
                            {
-                              char val_s[256], val_d[16];
-
+                              char val_s[256];
                               *setting->value.target.fraction = i;
-
                               setting->get_string_representation(setting,
                                     val_s, sizeof(val_s));
-                              snprintf(val_d, sizeof(val_d), "%d", setting->enum_idx);
                               if (menu_entries_append(info->list,
                                     val_s,
                                     val_d,
@@ -14670,7 +14671,6 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                            {
                               char val_s[16];
                               snprintf(val_s, sizeof(val_s), "%.2f", i);
-
                               if (menu_entries_append(info->list,
                                     val_s,
                                     val_d,
@@ -14711,16 +14711,15 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
 
                         if (setting->get_string_representation)
                         {
+                           char val_d[16];
+                           snprintf(val_d, sizeof(val_d), "%d", setting->enum_idx);
                            for (i = min; i <= max; i += step)
                            {
-                              char val_s[256], val_d[16];
+                              char val_s[256];
                               int val = (int)i;
-
                               *setting->value.target.unsigned_integer = val;
-
                               setting->get_string_representation(setting,
                                     val_s, sizeof(val_s));
-                              snprintf(val_d, sizeof(val_d), "%d", setting->enum_idx);
                               if (menu_entries_append(info->list,
                                     val_s,
                                     val_d,
@@ -14748,7 +14747,6 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                               char val_s[16];
                               int val = (int)i;
                               snprintf(val_s, sizeof(val_s), "%d", val);
-
                               if (menu_entries_append(info->list,
                                     val_s,
                                     val_d,

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -1760,10 +1760,12 @@ static unsigned menu_displaylist_parse_system_info(file_list_t *list)
    {
       char cpu_str[64];
       unsigned amount_cores = cpu_features_get_core_amount();
-      cpu_str[0]            = '\0';
-      snprintf(cpu_str, sizeof(cpu_str),
-            "%s %d\n",
-            msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CPU_CORES), amount_cores);
+      size_t _len           = strlcpy(cpu_str,
+            msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CPU_CORES),
+            sizeof(cpu_str));
+      snprintf(cpu_str      + _len,
+            sizeof(cpu_str) - _len,
+            " %d\n", amount_cores);
       if (menu_entries_append(list, cpu_str,
             msg_hash_to_str(MENU_ENUM_LABEL_CPU_CORES),
             MENU_ENUM_LABEL_CPU_CORES, MENU_SETTINGS_CORE_INFO_NONE, 0, 0, NULL))
@@ -2029,10 +2031,13 @@ static unsigned menu_displaylist_parse_system_info(file_list_t *list)
 
       if (video_context_driver_get_metrics(&metrics))
       {
-         snprintf(tmp, sizeof(tmp), "%s: %.2f",
+         size_t _len = strlcpy(tmp,
                msg_hash_to_str(
                   MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_DISPLAY_METRIC_MM_WIDTH),
-               val);
+               sizeof(tmp));
+         snprintf(tmp      + _len,
+               sizeof(tmp) - _len,
+               ": %.2f", val);
          if (menu_entries_append(list, tmp, "",
                MENU_ENUM_LABEL_SYSTEM_INFO_ENTRY,
                MENU_SETTINGS_CORE_INFO_NONE, 0, 0, NULL))

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -1150,18 +1150,21 @@ static unsigned menu_displaylist_parse_core_option_dropdown_list(
    retroarch_ctl(RARCH_CTL_CORE_OPTIONS_LIST_GET, &coreopts);
 
    if (!coreopts)
-      goto end;
+      return 0;
 
    /* Path string has the format core_option_<opt_idx>
     * > Extract option index */
    if (string_is_empty(info->path))
-      goto end;
+      return 0;
 
    string_list_initialize(&tmp_str_list);
    string_split_noalloc(&tmp_str_list, info->path, "_");
 
    if (tmp_str_list.size < 1)
-      goto end;
+   {
+      string_list_deinitialize(&tmp_str_list);
+      return 0;
+   }
 
    option_index = string_to_unsigned(
          tmp_str_list.elems[tmp_str_list.size - 1].data);
@@ -1174,7 +1177,10 @@ static unsigned menu_displaylist_parse_core_option_dropdown_list(
 
    if (!option ||
        string_is_empty(val))
-      goto end;
+   {
+      string_list_deinitialize(&tmp_str_list);
+      return 0;
+   }
 
    lbl_enabled  = msg_hash_to_str(MENU_ENUM_LABEL_ENABLED);
    lbl_disabled = msg_hash_to_str(MENU_ENUM_LABEL_DISABLED);
@@ -1209,6 +1215,8 @@ static unsigned menu_displaylist_parse_core_option_dropdown_list(
       }
    }
 
+   string_list_deinitialize(&tmp_str_list);
+
    if (checked_found)
    {
       menu_file_list_cbs_t *cbs = (menu_file_list_cbs_t*)
@@ -1220,8 +1228,6 @@ static unsigned menu_displaylist_parse_core_option_dropdown_list(
       menu_navigation_set_selection(checked);
    }
 
-end:
-   string_list_deinitialize(&tmp_str_list);
    return count;
 }
 
@@ -14149,14 +14155,13 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                            if (tmp_str_list.size > 0)
                            {
                               unsigned i;
+                              char val_s[256], val_d[16];
                               unsigned size        = (unsigned)
                                  tmp_str_list.size;
                               bool checked_found   = false;
                               unsigned checked     = 0;
-
-                              char* orig_val = setting->get_string_representation ?
+                              char* orig_val       = setting->get_string_representation ?
                                  strdup(setting->value.target.string) : setting->value.target.string;
-                              char val_s[256], val_d[16];
                               snprintf(val_d, sizeof(val_d), "%d", setting->enum_idx);
 
                               for (i = 0; i < size; i++)
@@ -14208,6 +14213,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                      case ST_INT:
                         {
                            float i;
+                           char val_d[16];
                            int32_t orig_value     = *setting->value.target.integer;
                            unsigned setting_type  = MENU_SETTING_DROPDOWN_SETTING_INT_ITEM;
                            float step             = setting->step;
@@ -14217,18 +14223,17 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                            unsigned checked       = 0;
                            unsigned entry_index   = 0;
 
+                           snprintf(val_d, sizeof(val_d), "%d", setting->enum_idx);
+
                            if (setting->get_string_representation)
                            {
                               for (i = min; i <= max; i += step)
                               {
-                                 char val_s[256], val_d[16];
+                                 char val_s[256];
                                  int val = (int)i;
-
                                  *setting->value.target.integer = val;
-
                                  setting->get_string_representation(setting,
                                        val_s, sizeof(val_s));
-                                 snprintf(val_d, sizeof(val_d), "%d", setting->enum_idx);
                                  if (menu_entries_append(info->list,
                                        val_s,
                                        val_d,
@@ -14249,9 +14254,6 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                            }
                            else
                            {
-                              char val_d[16];
-                              snprintf(val_d, sizeof(val_d), "%d", setting->enum_idx);
-
                               for (i = min; i <= max; i += step)
                               {
                                  char val_s[16];
@@ -14287,6 +14289,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                      case ST_FLOAT:
                         {
                            float i;
+                           char val_d[16];
                            float orig_value       = *setting->value.target.fraction;
                            unsigned setting_type  = MENU_SETTING_DROPDOWN_SETTING_FLOAT_ITEM;
                            float step             = setting->step;
@@ -14297,11 +14300,10 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                            unsigned checked       = 0;
                            unsigned entry_index   = 0;
 
+                           snprintf(val_d, sizeof(val_d), "%d", setting->enum_idx);
+
                            if (setting->get_string_representation)
                            {
-                              char val_d[16];
-                              snprintf(val_d, sizeof(val_d), "%d", setting->enum_idx);
-
                               for (i = min; i <= max; i += step)
                               {
                                  char val_s[256];
@@ -14328,9 +14330,6 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                            }
                            else
                            {
-                              char val_d[16];
-                              snprintf(val_d, sizeof(val_d), "%d", setting->enum_idx);
-
                               for (i = min; i <= max; i += step)
                               {
                                  char val_s[16];
@@ -14365,6 +14364,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                      case ST_UINT:
                         {
                            float i;
+                           char val_d[16];
                            unsigned orig_value    = *setting->value.target.unsigned_integer;
                            unsigned setting_type  = MENU_SETTING_DROPDOWN_SETTING_UINT_ITEM;
                            float step             = setting->step;
@@ -14374,10 +14374,10 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                            unsigned checked       = 0;
                            unsigned entry_index   = 0;
 
+                           snprintf(val_d, sizeof(val_d), "%d", setting->enum_idx);
+
                            if (setting->get_string_representation)
                            {
-                              char val_d[16];
-                              snprintf(val_d, sizeof(val_d), "%d", setting->enum_idx);
                               for (i = min; i <= max; i += step)
                               {
                                  char val_s[256];
@@ -14405,8 +14405,6 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                            }
                            else
                            {
-                              char val_d[16];
-                              snprintf(val_d, sizeof(val_d), "%d", setting->enum_idx);
                               for (i = min; i <= max; i += step)
                               {
                                  char val_s[16];
@@ -14548,6 +14546,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                   case ST_INT:
                      {
                         float i;
+                        char val_d[16];
                         int32_t orig_value     = *setting->value.target.integer;
                         unsigned setting_type  = MENU_SETTING_DROPDOWN_SETTING_INT_ITEM_SPECIAL;
                         float step             = setting->step;
@@ -14557,11 +14556,10 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                         unsigned checked       = 0;
                         unsigned entry_index   = 0;
 
+                        snprintf(val_d, sizeof(val_d), "%d", setting->enum_idx);
+
                         if (setting->get_string_representation)
                         {
-                           char val_d[16];
-                           snprintf(val_d, sizeof(val_d), "%d", setting->enum_idx);
-
                            for (i = min; i <= max; i += step)
                            {
                               char val_s[256];
@@ -14589,8 +14587,6 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                         }
                         else
                         {
-                           char val_d[16];
-                           snprintf(val_d, sizeof(val_d), "%d", setting->enum_idx);
                            for (i = min; i <= max; i += step)
                            {
                               char val_s[16];
@@ -14625,6 +14621,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                   case ST_FLOAT:
                      {
                         float i;
+                        char val_d[16];
                         float orig_value       = *setting->value.target.fraction;
                         unsigned setting_type  = MENU_SETTING_DROPDOWN_SETTING_FLOAT_ITEM_SPECIAL;
                         float step             = setting->step;
@@ -14635,10 +14632,10 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                         unsigned checked       = 0;
                         unsigned entry_index   = 0;
 
+                        snprintf(val_d, sizeof(val_d), "%d", setting->enum_idx);
+
                         if (setting->get_string_representation)
                         {
-                           char val_d[16];
-                           snprintf(val_d, sizeof(val_d), "%d", setting->enum_idx);
                            for (i = min; i <= max; i += step)
                            {
                               char val_s[256];
@@ -14665,8 +14662,6 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                         }
                         else
                         {
-                           char val_d[16];
-                           snprintf(val_d, sizeof(val_d), "%d", setting->enum_idx);
                            for (i = min; i <= max; i += step)
                            {
                               char val_s[16];
@@ -14700,6 +14695,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                   case ST_UINT:
                      {
                         float i;
+                        char val_d[16];
                         unsigned orig_value    = *setting->value.target.unsigned_integer;
                         unsigned setting_type  = MENU_SETTING_DROPDOWN_SETTING_UINT_ITEM_SPECIAL;
                         float step             = setting->step;
@@ -14709,10 +14705,10 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                         unsigned checked       = 0;
                         unsigned entry_index   = 0;
 
+                        snprintf(val_d, sizeof(val_d), "%d", setting->enum_idx);
+
                         if (setting->get_string_representation)
                         {
-                           char val_d[16];
-                           snprintf(val_d, sizeof(val_d), "%d", setting->enum_idx);
                            for (i = min; i <= max; i += step)
                            {
                               char val_s[256];
@@ -14740,8 +14736,6 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                         }
                         else
                         {
-                           char val_d[16];
-                           snprintf(val_d, sizeof(val_d), "%d", setting->enum_idx);
                            for (i = min; i <= max; i += step)
                            {
                               char val_s[16];

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -5167,15 +5167,13 @@ static int menu_displaylist_parse_input_device_index_list(
          if (!string_is_empty(device_name))
          {
             unsigned idx = input_config_get_device_name_index(i);
+            size_t _len  = strlcpy(device_label, device_name,
+                  sizeof(device_label));
 
             /*if idx is non-zero, it's part of a set*/
             if (idx > 0)
-               snprintf(device_label, sizeof(device_label),
-                     "%s (#%u)",
-                     device_name,
-                     idx);
-            else
-               strlcpy(device_label, device_name, sizeof(device_label));
+               snprintf(device_label         + _len,
+                        sizeof(device_label) - _len, " (#%u)", idx);
          }
          else
             snprintf(device_label, sizeof(device_label), "%s (%s %u)", val_na,
@@ -5297,8 +5295,8 @@ static int menu_displaylist_parse_input_description_list(
           * > Above RARCH_FIRST_CUSTOM_BIND, inputs
           *   are analog axes - have to add +/-
           *   indicators */
-	 size_t _len = strlcpy(input_description, input_desc_btn,
-			 sizeof(input_description));
+         size_t _len = strlcpy(input_description, input_desc_btn,
+               sizeof(input_description));
          if (i >= RARCH_FIRST_CUSTOM_BIND)
          {
             input_description   [_len  ] = ' ';
@@ -5306,7 +5304,7 @@ static int menu_displaylist_parse_input_description_list(
                input_description[_len+1] = '+';
             else
                input_description[_len+1] = '-';
-	    input_description   [_len+2] = '\0';
+            input_description   [_len+2] = '\0';
          }
 
          if (string_is_empty(input_description))
@@ -7094,18 +7092,18 @@ unsigned menu_displaylist_build_list(
 #ifdef HAVE_LIBNX
          {
             unsigned user;
+            char key_split_joycon[PATH_MAX_LENGTH];
+            const char *split_joycon_str =
+               msg_hash_to_str(MENU_ENUM_LABEL_INPUT_SPLIT_JOYCON);
+            size_t _len                  = strlcpy(key_split_joycon, split_joycon_str, 
+                  sizeof(key_split_joycon));
 
             for (user = 0; user < 8; user++)
             {
-               char key_split_joycon[PATH_MAX_LENGTH];
                unsigned val = user + 1;
-
-               key_split_joycon[0] = '\0';
-
-               snprintf(key_split_joycon, sizeof(key_split_joycon),
-                     "%s_%u",
-                     msg_hash_to_str(MENU_ENUM_LABEL_INPUT_SPLIT_JOYCON), val);
-
+               snprintf(key_split_joycon         + _len,
+                        sizeof(key_split_joycon) - _len,
+                        "_%u", val);
                if (MENU_DISPLAYLIST_PARSE_SETTINGS(list,
                         key_split_joycon, PARSE_ONLY_UINT, true, 0) != -1)
                   count++;
@@ -7235,12 +7233,12 @@ unsigned menu_displaylist_build_list(
                size_t i;
                char buf[768];
                const char *msg_intf = msg_hash_to_str(MSG_INTERFACE);
+               size_t _len          = strlcpy(buf, msg_intf, sizeof(buf));
 
                for (i = 0; i < interfaces.size; i++)
                {
                   struct net_ifinfo_entry *entry = &interfaces.entries[i];
-
-                  snprintf(buf, sizeof(buf), "%s (%s) : %s\n", msg_intf,
+                  snprintf(buf + _len, sizeof(buf) - _len, " (%s) : %s\n",
                      entry->name, entry->host);
                   if (menu_entries_append(list, buf, entry->name,
                         MENU_ENUM_LABEL_NETWORK_INFO_ENTRY,

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -7926,20 +7926,31 @@ int generic_menu_entry_action(
 
       if (!string_is_empty(title_name))
       {
+	      size_t _len             = strlcpy(speak_string,
+               title_name, sizeof(speak_string));
+         speak_string[_len  ]    = ' ';
+         speak_string[_len+1]    = '\0';
+         _len                    = strlcat(speak_string,
+               current_label, sizeof(speak_string));
          if (!string_is_equal(current_value, "..."))
-            snprintf(speak_string, sizeof(speak_string),
-                  "%s %s %s", title_name, current_label, current_value);
-         else
-            snprintf(speak_string, sizeof(speak_string),
-                  "%s %s", title_name, current_label);
+         {
+            speak_string[_len  ] = ' ';
+            speak_string[_len+1] = '\0';
+            strlcat(speak_string, current_value,
+                  sizeof(speak_string));
+         }
       }
       else
       {
+         size_t _len = strlcpy(speak_string,
+               current_label, sizeof(speak_string));
          if (!string_is_equal(current_value, "..."))
-            snprintf(speak_string, sizeof(speak_string),
-                  "%s %s", current_label, current_value);
-         else
-            strlcpy(speak_string, current_label, sizeof(speak_string));
+         {
+            speak_string[_len  ] = ' ';
+            speak_string[_len+1] = '\0';
+            strlcat(speak_string, current_value,
+                  sizeof(speak_string));
+         }
       }
 
       if (!string_is_empty(speak_string))

--- a/menu/menu_explore.c
+++ b/menu/menu_explore.c
@@ -1017,10 +1017,8 @@ unsigned menu_displaylist_explore(file_list_t *list,
          if (is_top && tmplen < sizeof(tmp) - 5)
          {
             if (explore_by_info[cat].is_numeric)
-            {
                snprintf(tmp + tmplen, sizeof(tmp) - tmplen, " (%s - %s)",
                      entries[0]->str, entries[RBUF_LEN(entries) - 1]->str);
-            }
             else
             {
                strlcat(tmp, " (", sizeof(tmp));

--- a/retroarch.c
+++ b/retroarch.c
@@ -1693,14 +1693,15 @@ bool command_event(enum event_command cmd, void *data)
 
             if (video_driver_get_video_output_size(&width, &height, desc, sizeof(desc)))
             {
-               char msg[128] = {0};
+               char msg[128];
 
                video_driver_set_video_mode(width, height, true);
 
                if (width == 0 || height == 0)
-                  snprintf(msg, sizeof(msg), msg_hash_to_str(MSG_SCREEN_RESOLUTION_DEFAULT));
+                  strlcpy(msg, msg_hash_to_str(MSG_SCREEN_RESOLUTION_DEFAULT), sizeof(msg));
                else
                {
+                  msg[0] = '\0';
                   if (!string_is_empty(desc))
                      snprintf(msg, sizeof(msg),
                         msg_hash_to_str(MSG_SCREEN_RESOLUTION_DESC),

--- a/runloop.c
+++ b/runloop.c
@@ -7336,15 +7336,17 @@ static enum runloop_state_enum runloop_check_state(
        * for this frame. */
       if (check2)
       {
+         size_t _len;
          char msg[128];
          int cur_state_slot                = state_slot;
          if (check1)
             configuration_set_int(settings, settings->ints.state_slot,
                   cur_state_slot + addition);
-         msg[0] = '\0';
-         snprintf(msg, sizeof(msg), "%s: %d",
-               msg_hash_to_str(MSG_STATE_SLOT),
-               settings->ints.state_slot);
+         _len = strlcpy(msg, msg_hash_to_str(MSG_STATE_SLOT), sizeof(msg));
+         snprintf(msg         + _len,
+                  sizeof(msg) - _len,
+                  ": %d",
+                  settings->ints.state_slot);
          runloop_msg_queue_push(msg, 2, 180, true, NULL,
                MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
          RARCH_LOG("[State]: %s\n", msg);
@@ -8130,6 +8132,7 @@ bool retroarch_get_current_savestate_path(char *path, size_t len)
 
 bool retroarch_get_entry_state_path(char *path, size_t len, unsigned slot)
 {
+   size_t _len;
    runloop_state_t *runloop_st = &runloop_state;
    const char *name_savestate  = NULL;
 
@@ -8140,8 +8143,8 @@ bool retroarch_get_entry_state_path(char *path, size_t len, unsigned slot)
    if (string_is_empty(name_savestate))
       return false;
 
-   snprintf(path, len, "%s%d", name_savestate, slot);
-   strlcat(path, ".entry", len);
+   _len = strlcpy(path, name_savestate, len);
+   snprintf(path + _len, len - _len, "%d.entry", slot);
 
    return true;
 }

--- a/tasks/task_core_updater.c
+++ b/tasks/task_core_updater.c
@@ -1370,8 +1370,9 @@ static void task_update_installed_cores_handler(retro_task_t *task)
             if (update_installed_handle->list_size > 0)
             {
                char task_title[PATH_MAX_LENGTH];
-
-               task_title[0] = '\0';
+               size_t _len = strlcpy(task_title,
+                     msg_hash_to_str(MSG_ALL_CORES_UPDATED),
+                     sizeof(task_title));
 
                /* > Generate final status message based on number
                 *   of cores that were updated/locked */
@@ -1379,28 +1380,28 @@ static void task_update_installed_cores_handler(retro_task_t *task)
                {
                   if (update_installed_handle->num_locked > 0)
                      snprintf(
-                           task_title, sizeof(task_title), "%s [%s%u, %s%u]",
-                           msg_hash_to_str(MSG_ALL_CORES_UPDATED),
+                           task_title         + _len,
+                           sizeof(task_title) - _len,
+                           " [%s%u, %s%u]",
                            msg_hash_to_str(MSG_NUM_CORES_UPDATED),
                            update_installed_handle->num_updated,
                            msg_hash_to_str(MSG_NUM_CORES_LOCKED),
                            update_installed_handle->num_locked);
                   else
                      snprintf(
-                           task_title, sizeof(task_title), "%s [%s%u]",
-                           msg_hash_to_str(MSG_ALL_CORES_UPDATED),
+                           task_title         + _len,
+                           sizeof(task_title) - _len,
+                           " [%s%u]",
                            msg_hash_to_str(MSG_NUM_CORES_UPDATED),
                            update_installed_handle->num_updated);
                }
                else if (update_installed_handle->num_locked > 0)
                   snprintf(
-                        task_title, sizeof(task_title), "%s [%s%u]",
-                        msg_hash_to_str(MSG_ALL_CORES_UPDATED),
+                        task_title         + _len,
+                        sizeof(task_title) - _len,
+                        " [%s%u]",
                         msg_hash_to_str(MSG_NUM_CORES_LOCKED),
                         update_installed_handle->num_locked);
-               else
-                  strlcpy(task_title, msg_hash_to_str(MSG_ALL_CORES_UPDATED),
-                        sizeof(task_title));
 
                task_set_title(task, strdup(task_title));
             }


### PR DESCRIPTION
*  Don't do snprintf calls in loops that can be done once outside
* Try to prevent some msg_hash_to_str calls in loops
* Add FIXME/TODO localize notes to hardcoded strings
* Reduce some snprintf calls by moving them out of if/else blocks
* Simplify early return path for one function