### PR TITLE
(3DS) Set bottom_asset directory default

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -3644,6 +3644,12 @@ static bool config_load_file(global_t *global,
       *settings->paths.directory_core_assets = '\0';
    if (string_is_equal(settings->paths.directory_assets, "default"))
       *settings->paths.directory_assets = '\0';
+#ifdef _3DS
+   if (string_is_equal(settings->paths.directory_bottom_assets, "default"))
+         configuration_set_string(settings,
+               settings->paths.directory_bottom_assets,
+               g_defaults.dirs[DEFAULT_DIR_BOTTOM_ASSETS]);
+#endif
    if (string_is_equal(settings->paths.directory_dynamic_wallpapers, "default"))
       *settings->paths.directory_dynamic_wallpapers = '\0';
    if (string_is_equal(settings->paths.directory_thumbnails, "default"))

--- a/gfx/drivers/ctr_gfx.c
+++ b/gfx/drivers/ctr_gfx.c
@@ -503,8 +503,7 @@ static void bottom_menu_control(void* data, bool lcd_bottom)
       return;
 #endif
 
-      if (    !lcd_bottom
-            || ctr->bottom_menu == CTR_BOTTOM_MENU_NOT_AVAILABLE)
+      if (!lcd_bottom)
       {
          BIT64_SET(lifecycle_state, RARCH_MENU_TOGGLE);
          return;
@@ -522,6 +521,13 @@ static void bottom_menu_control(void* data, bool lcd_bottom)
          ctr->bottom_check_idle = false;
          ctr->bottom_is_fading  = false;
          fadeCount              = 256;
+      }
+
+      if (ctr->bottom_menu == CTR_BOTTOM_MENU_NOT_AVAILABLE)
+      {
+         BIT64_SET(lifecycle_state, RARCH_MENU_TOGGLE);
+         ctr->refresh_bottom_menu = true;
+         return;
       }
 
       switch (ctr->bottom_menu)
@@ -700,14 +706,26 @@ static void ctr_render_bottom_screen(void *data)
    switch (ctr->bottom_menu)
    {
       case CTR_BOTTOM_MENU_NOT_AVAILABLE:
-         params.color = COLOR_ABGR(255, 255, 255, 255);
-         params.scale = 1.6f;
-         params.x     = 0.0f;
-         params.y     = 0.5f;
+         {
+            char str_path[PATH_MAX_LENGTH];
+            const char *dir_assets = settings->paths.directory_bottom_assets;
 
-         font_driver_render_msg_bottom(ctr,
-               msg_hash_to_str(MSG_3DS_BOTTOM_MENU_ASSET_NOT_FOUND),
+            params.color = COLOR_ABGR(255, 255, 255, 255);
+            params.scale = 1.6f;
+            params.x     = 0.0f;
+            params.y     = 0.5f;
+
+            font_driver_render_msg_bottom(ctr,
+                  msg_hash_to_str(MSG_3DS_BOTTOM_MENU_ASSET_NOT_FOUND),
+                  &params);
+
+            sprintf(str_path, "%s\n/bottom_menu.png", dir_assets);
+
+            params.scale = 1.10f;
+            params.y    -= 0.10f;
+            font_driver_render_msg_bottom(ctr, str_path,
                &params);
+            }
          break;
       case CTR_BOTTOM_MENU_DEFAULT:
          params.color = COLOR_ABGR(255, 255, 255, 255);

--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -13861,7 +13861,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MSG_3DS_BOTTOM_MENU_ASSET_NOT_FOUND,
-   "bottom_menu.png not found\nin the assets/ctr folder"
+   "Asset(s) not found"
    )
 MSG_HASH(
    MSG_3DS_BOTTOM_MENU_NO_STATE_DATA,


### PR DESCRIPTION
## Description
- Fix the bottom_asset default directory:
The default value ```default```, was not being updated to the actual path value.
This is only done when generating a new ```retroarch.cfg``` configuration file.

- Update 'Asset not found' error message:
This pr changes the static error message to a dynamic one, displaying the actual path retroarch looks for ```bottom_menu.png```.

@LibretroAdmin 
This changes a ```MSG_HASH``` entry included with ```/intl/msg_hash_us.h```.
Will this cause issues with crowdin translations? If so, what would be the best approach here?

## Related issues
* #14375