### PR TITLE
Fix Redump bin/cue scan for some DC games + add RVZ/WIA scan support for GC/Wii

### DIFF
--- a/msg_hash.h
+++ b/msg_hash.h
@@ -140,6 +140,8 @@ enum msg_file_type
    FILE_TYPE_LUTRO,
    FILE_TYPE_CHD,
    FILE_TYPE_WBFS,
+   FILE_TYPE_RVZ,
+   FILE_TYPE_WIA,
 
    FILE_TYPE_DIRECT_LOAD,
 

--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -505,6 +505,14 @@ static enum msg_file_type extension_to_file_type(const char *ext)
       )
       return FILE_TYPE_WBFS;
    if (
+         string_is_equal(ext_lower, "rvz")
+      )
+      return FILE_TYPE_RVZ;
+   if (
+         string_is_equal(ext_lower, "wia")
+      )
+      return FILE_TYPE_WIA;
+   if (
          string_is_equal(ext_lower, "lutro")
       )
       return FILE_TYPE_LUTRO;
@@ -550,12 +558,10 @@ static int task_database_iterate_playlist(
             return task_database_gdi_get_crc(name, &db_state->crc);
          }
          break;
-      /* Consider Wii WBFS files similar to ISO files. */
+      /* Consider WBFS, RVZ and WIA files similar to ISO files. */
       case FILE_TYPE_WBFS:
-         db_state->serial[0] = '\0';
-         intfstream_file_get_serial(name, 0, SIZE_MAX, db_state->serial, sizeof(db_state->serial));
-         db->type            =  DATABASE_TYPE_SERIAL_LOOKUP;
-         break;
+      case FILE_TYPE_RVZ:
+      case FILE_TYPE_WIA:
       case FILE_TYPE_ISO:
          db_state->serial[0] = '\0';
          intfstream_file_get_serial(name, 0, SIZE_MAX, db_state->serial, sizeof(db_state->serial));


### PR DESCRIPTION
## Description

Currently when scanning Redump bin/cue DC games the serial found doesn't always match with Redump database, example with Crazy Taxi: http://redump.org/disc/18037/ if you check the "HEADER" part, you'll see that on the 5th line it shows "MK-51035", however in their database the game serial is just "51035".

So for every 8 chars serial in "MK-xxxxx" format we remove "MK-", there in one exception tho, Sega GT: http://redump.org/disc/2819/ which appears in the database with the serial "MK-51053", so I've added an exception for it.

Also added support for RVZ and WIA for GameCube and Wii. Note for potential testers: WIA is not currently included as a supported extension in the Dolphin info file so they won't scan atm unless you add it manually (then disable or delete the core info cache file or RA may not register the change). I'll make a PR to add "wia" as supported extensions for Dolphin ;) 

## Related Issues

Closes #10693

## Reviewers

@LibretroAdmin @RobLoach 
