### PR TITLE
Allow On-Demand Thumbnails in Explore menu

### DIFF
--- a/gfx/gfx_thumbnail_path.c
+++ b/gfx/gfx_thumbnail_path.c
@@ -42,6 +42,7 @@ struct gfx_thumbnail_path_data
 {
    enum playlist_thumbnail_mode playlist_right_mode;
    enum playlist_thumbnail_mode playlist_left_mode;
+   size_t playlist_index;
    char system[PATH_MAX_LENGTH];
    char content_path[PATH_MAX_LENGTH];
    char content_label[PATH_MAX_LENGTH];
@@ -319,9 +320,9 @@ bool gfx_thumbnail_set_system(gfx_thumbnail_path_data_t *path_data,
    return true;
 }
 
-/* Sets current thumbnail content according to the specified label and optional database name.
+/* Sets current thumbnail content according to the specified label.
  * Returns true if content is valid */
-bool gfx_thumbnail_set_content(gfx_thumbnail_path_data_t *path_data, const char *label, const char *db_name)
+bool gfx_thumbnail_set_content(gfx_thumbnail_path_data_t *path_data, const char *label)
 {
    if (!path_data)
       return false;
@@ -341,6 +342,7 @@ bool gfx_thumbnail_set_content(gfx_thumbnail_path_data_t *path_data, const char 
    /* Must also reset playlist thumbnail display modes */
    path_data->playlist_right_mode  = PLAYLIST_THUMBNAIL_MODE_DEFAULT;
    path_data->playlist_left_mode   = PLAYLIST_THUMBNAIL_MODE_DEFAULT;
+   path_data->playlist_index       = 0;
    
    if (string_is_empty(label))
       return false;
@@ -355,10 +357,6 @@ bool gfx_thumbnail_set_content(gfx_thumbnail_path_data_t *path_data, const char 
     * Just use label value (it doesn't matter) */
    strlcpy(path_data->content_path, label, sizeof(path_data->content_path));
 
-   /* Database name required for Explore thumbnails */
-   if (!string_is_empty(db_name))
-      strlcpy(path_data->content_db_name, db_name, sizeof(path_data->content_db_name));
-   
    /* Redundant error check... */
    return !string_is_empty(path_data->content_img);
 }
@@ -389,6 +387,7 @@ bool gfx_thumbnail_set_content_image(
    /* Must also reset playlist thumbnail display modes */
    path_data->playlist_right_mode  = PLAYLIST_THUMBNAIL_MODE_DEFAULT;
    path_data->playlist_left_mode   = PLAYLIST_THUMBNAIL_MODE_DEFAULT;
+   path_data->playlist_index       = 0;
    
    if (string_is_empty(img_dir) || string_is_empty(img_name))
       return false;
@@ -462,6 +461,7 @@ bool gfx_thumbnail_set_content_playlist(
    /* Must also reset playlist thumbnail display modes */
    path_data->playlist_right_mode     = PLAYLIST_THUMBNAIL_MODE_DEFAULT;
    path_data->playlist_left_mode      = PLAYLIST_THUMBNAIL_MODE_DEFAULT;
+   path_data->playlist_index          = 0;
    
    if (!playlist)
       return false;
@@ -506,6 +506,9 @@ bool gfx_thumbnail_set_content_playlist(
    
    /* Determine content image name */
    fill_content_img(path_data);
+
+   /* Store playlist index */
+   path_data->playlist_index = idx;
    
    /* Redundant error check... */
    if (string_is_empty(path_data->content_img))
@@ -820,4 +823,11 @@ bool gfx_thumbnail_get_content_dir(
    strlcpy(content_dir, path_basename_nocompression(tmp_buf), len);
    
    return !string_is_empty(content_dir);
+}
+
+/* Fetches current playlist index. */
+size_t gfx_thumbnail_get_playlist_index(
+      gfx_thumbnail_path_data_t *path_data)
+{
+   return (path_data) ? path_data->playlist_index : 0;
 }

--- a/gfx/gfx_thumbnail_path.h
+++ b/gfx/gfx_thumbnail_path.h
@@ -85,9 +85,9 @@ bool gfx_thumbnail_is_enabled(gfx_thumbnail_path_data_t *path_data, enum gfx_thu
  *   associated database name */
 bool gfx_thumbnail_set_system(gfx_thumbnail_path_data_t *path_data, const char *system, playlist_t *playlist);
 
-/* Sets current thumbnail content according to the specified label and optional database name.
+/* Sets current thumbnail content according to the specified label.
  * Returns true if content is valid */
-bool gfx_thumbnail_set_content(gfx_thumbnail_path_data_t *path_data, const char *label, const char *db_name);
+bool gfx_thumbnail_set_content(gfx_thumbnail_path_data_t *path_data, const char *label);
 
 /* Sets current thumbnail content to the specified image.
  * Returns true if content is valid */
@@ -148,6 +148,9 @@ bool gfx_thumbnail_get_img_name(gfx_thumbnail_path_data_t *path_data, const char
 /* Fetches current content directory.
  * Returns true if content directory is valid. */
 bool gfx_thumbnail_get_content_dir(gfx_thumbnail_path_data_t *path_data, char *content_dir, size_t len);
+
+/* Fetches current playlist index. */
+size_t gfx_thumbnail_get_playlist_index(gfx_thumbnail_path_data_t *path_data);
 
 RETRO_END_DECLS
 

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -1141,6 +1141,20 @@ int menu_entries_get_title(char *s, size_t len)
    return 0;
 }
 
+/* Get current menu label */
+int menu_entries_get_label(char *s, size_t len)
+{
+   struct menu_state   *menu_st = &menu_driver_state;
+   const file_list_t *list      = MENU_LIST_GET(menu_st->entries.list, 0);
+
+   if (list && list->size)
+   {
+      strlcpy(s, list->list[list->size - 1].label, len);
+      return 1;
+   }
+   return 0;
+}
+
 /* Used to close an active message box (help or info)
  * TODO/FIXME: The way that message boxes are handled
  * is complete garbage. generic_menu_iterate() and

--- a/menu/menu_driver.h
+++ b/menu/menu_driver.h
@@ -42,7 +42,7 @@
 #include "menu_shader.h"
 #include "../gfx/gfx_animation.h"
 #include "../gfx/gfx_display.h"
-
+#include "../gfx/gfx_thumbnail_path.h"
 #include "../gfx/font_driver.h"
 #include "../performance_counters.h"
 
@@ -668,6 +668,8 @@ const char *menu_explore_get_entry_database(unsigned type);
 ssize_t menu_explore_get_entry_playlist_index(unsigned type,
       playlist_t **playlist,
       const struct playlist_entry **entry);
+ssize_t menu_explore_set_entry_playlist_index(unsigned type,
+      gfx_thumbnail_path_data_t *thumbnail_path_data);
 void menu_explore_context_init(void);
 void menu_explore_context_deinit(void);
 void menu_explore_free_state(explore_state_t *state);

--- a/menu/menu_entries.h
+++ b/menu/menu_entries.h
@@ -160,6 +160,8 @@ typedef struct menu_entry
 
 int menu_entries_get_title(char *title, size_t title_len);
 
+int menu_entries_get_label(char *label, size_t label_len);
+
 int menu_entries_get_core_title(char *title_msg, size_t title_msg_len);
 
 file_list_t *menu_entries_get_selection_buf_ptr(size_t idx);

--- a/menu/menu_explore.c
+++ b/menu/menu_explore.c
@@ -1330,11 +1330,38 @@ ssize_t menu_explore_get_entry_playlist_index(unsigned type,
          {
             *playlist_entry = entry;
             *playlist       = p;
+
+            /* Playlist needs to get cached for on-demand thumbnails */
+            playlist_set_cached_external(p);
             return j;
          }
       }
    }
 
+   return -1;
+}
+
+ssize_t menu_explore_set_entry_playlist_index(unsigned type,
+      gfx_thumbnail_path_data_t *thumbnail_path_data)
+{
+   const char *db_name;
+   ssize_t playlist_index                      = -1;
+   playlist_t *playlist                        = NULL;
+   const struct playlist_entry *playlist_entry = NULL;
+
+   db_name = menu_explore_get_entry_database(type);
+   if (!string_is_empty(db_name))
+      playlist_index = menu_explore_get_entry_playlist_index(type, &playlist, &playlist_entry);
+
+   if (playlist_index >= 0 && playlist && playlist_entry)
+   {
+      gfx_thumbnail_set_system(thumbnail_path_data, db_name, playlist);
+      gfx_thumbnail_set_content_playlist(thumbnail_path_data,
+            playlist, playlist_index);
+      return playlist_index;
+   }
+
+   gfx_thumbnail_set_content_playlist(thumbnail_path_data, NULL, 0);
    return -1;
 }
 

--- a/tasks/task_pl_thumbnail_download.c
+++ b/tasks/task_pl_thumbnail_download.c
@@ -578,6 +578,17 @@ static void cb_task_pl_entry_thumbnail_refresh_menu(
    else
 #endif
    {
+      char str[255];
+      menu_entries_get_label(str, sizeof(str));
+
+      /* Explore menu selection index does not match playlist index even in System list. */
+      if (string_is_equal(str, msg_hash_to_str(MENU_ENUM_LABEL_EXPLORE_TAB)))
+      {
+         if (!string_is_equal(pl_thumb->playlist_path,
+               playlist_get_conf_path(current_playlist)))
+         return;
+      }
+      else
       if (((pl_thumb->list_index != menu_navigation_get_selection()) &&
            (pl_thumb->list_index != menu->rpl_entry_selection_ptr)) ||
             !string_is_equal(pl_thumb->playlist_path,


### PR DESCRIPTION
## Description

This reverts a tiny addition from the previous PR and handles the required playlist matching properly via `gfx_thumbnail_set_content_playlist()` instead in Explore menu, since on-demand thumbnail downloading won't work otherwise. And with all drivers that currently show thumbnails there.

Also fixed mouse hover in Ozone Explore menu.

