### PR TITLE
(3DS) Only enable internal counter with CONSOLE_LOG defined

### DIFF
--- a/gfx/drivers/ctr_gfx.c
+++ b/gfx/drivers/ctr_gfx.c
@@ -1399,6 +1399,7 @@ static bool ctr_frame(void* data, const void* frame,
 
    ctr->vsync_event_pending = true;
 
+#ifdef CONSOLE_LOG
    /* Internal counters/statistics
     * > This is only required if the bottom screen is enabled */
    if (ctr_bottom_screen_enabled)
@@ -1464,6 +1465,7 @@ static bool ctr_frame(void* data, const void* frame,
 #endif
       fflush(stdout);
    }
+#endif
 
    if (ctr->should_resize)
       ctr_update_viewport(ctr, settings,


### PR DESCRIPTION
## Description

The 3DS used to show an fps counter on the bottom screen in previous retroarch builds.
The internal counter is still running on current builds.

This pr disables this counter, if not build with ```CONSOLE_LOG``` defined.