### PR TITLE
(Network) Don't call getsockopt on 3DS platform

### DIFF
--- a/libretro-common/net/net_socket.c
+++ b/libretro-common/net/net_socket.c
@@ -728,7 +728,10 @@ bool socket_connect_with_timeout(int fd, void *data, int timeout)
          return false;
    }
 
-#if !defined(GEKKO) && defined(SO_ERROR)
+   /* Excluded platforms do not have getsockopt implemented [GEKKO],
+    * or it's returned values are unreliable [3DS].
+    */
+#if !defined(GEKKO) && !defined(_3DS) && defined(SO_ERROR)
    {
       int       error = -1;
       socklen_t errsz = sizeof(error);


### PR DESCRIPTION
## Description

Do not call ```getsockopt``` on the 3DS platform.

## Related Issues
closes https://github.com/libretro/RetroArch/issues/14381

## Reviewers
@Cthulhu-throwaway 
