### PR TITLE
Fix label sanitization

### DIFF
--- a/libretro-common/playlists/label_sanitization.c
+++ b/libretro-common/playlists/label_sanitization.c
@@ -81,13 +81,23 @@ void label_sanitize(char *label, bool (*left)(char*), bool (*right)(char*))
          if ((*left)(&label[lindex]))
             copy                = false;
          else
-            new_label[rindex++] = label[lindex];
+         {
+            const bool whitespace = label[lindex] == ' ' && (rindex == 0 || new_label[rindex - 1] == ' ');
+
+            /* Simplify consecutive whitespaces */
+            if (!whitespace)
+               new_label[rindex++] = label[lindex];
+         }
       }
       else if ((*right)(&label[lindex]))
          copy = true;
    }
 
-   new_label[rindex] = '\0';
+   /* Trim trailing whitespace */
+   if (rindex > 0 && new_label[rindex - 1] == ' ')
+      new_label[rindex - 1] = '\0';
+   else
+      new_label[rindex] = '\0';
 
    strlcpy(label, new_label, PATH_MAX_LENGTH);
 }


### PR DESCRIPTION
This simplify and trim whitespaces left.
ie, starting, trailing and multiple consecutive whitespaces are now removed.

As information, here are some unit tests this changes fix:

> ********* Start testing of PlaylistSanitizeTest *********
> Config: Using QtTest library 5.15.6, Qt 5.15.6 (x86_64-little_endian-lp64 shared (dynamic) release build; by GCC 11.3.0), kaos unknown
> PASS   : PlaylistSanitizeTest::initTestCase()
> PASS   : PlaylistSanitizeTest::testLabelSanitize(Default >> "   My title [!] (France) [Bad] (Disc #1)   ")
> FAIL!  : PlaylistSanitizeTest::testLabelSanitize(RemoveParentheses >> "   My title [!] (France) [Bad] (Disc #1)   ") Compared values are not the same
>    Actual   (Model::label(title, mode)): "   My title [!]  [Bad]    "
>    Expected (expected)                 : "My title [!] [Bad]"
>    Loc: [/home/pasnox/Projects/libretro-playlist-builder/test/PlaylistSanitize_test.cpp(39)]
> FAIL!  : PlaylistSanitizeTest::testLabelSanitize(RemoveBrackets >> "   My title [!] (France) [Bad] (Disc #1)   ") Compared values are not the same
>    Actual   (Model::label(title, mode)): "   My title  (France)  (Disc #1)   "
>    Expected (expected)                 : "My title (France) (Disc #1)"
>    Loc: [/home/pasnox/Projects/libretro-playlist-builder/test/PlaylistSanitize_test.cpp(39)]
> FAIL!  : PlaylistSanitizeTest::testLabelSanitize(RemoveParenthesesAndBrackets >> "   My title [!] (France) [Bad] (Disc #1)   ") Compared values are not the same
>    Actual   (Model::label(title, mode)): "   My title       "
>    Expected (expected)                 : "My title"
>    Loc: [/home/pasnox/Projects/libretro-playlist-builder/test/PlaylistSanitize_test.cpp(39)]
> FAIL!  : PlaylistSanitizeTest::testLabelSanitize(KeepRegion >> "   My title [!] (France) [Bad] (Disc #1)   ") Compared values are not the same
>    Actual   (Model::label(title, mode)): "   My title  (France)     "
>    Expected (expected)                 : "My title (France)"
>    Loc: [/home/pasnox/Projects/libretro-playlist-builder/test/PlaylistSanitize_test.cpp(39)]
> FAIL!  : PlaylistSanitizeTest::testLabelSanitize(KeepDiscIndex >> "   My title [!] (France) [Bad] (Disc #1)   ") Compared values are not the same
>    Actual   (Model::label(title, mode)): "   My title    (Disc #1)   "
>    Expected (expected)                 : "My title (Disc #1)"
>    Loc: [/home/pasnox/Projects/libretro-playlist-builder/test/PlaylistSanitize_test.cpp(39)]
> FAIL!  : PlaylistSanitizeTest::testLabelSanitize(KeepRegionAndDiscIndex >> "   My title [!] (France) [Bad] (Disc #1)   ") Compared values are not the same
>    Actual   (Model::label(title, mode)): "   My title  (France)  (Disc #1)   "
>    Expected (expected)                 : "My title (France) (Disc #1)"
>    Loc: [/home/pasnox/Projects/libretro-playlist-builder/test/PlaylistSanitize_test.cpp(39)]
> PASS   : PlaylistSanitizeTest::cleanupTestCase()
> Totals: 3 passed, 6 failed, 0 skipped, 0 blacklisted, 1ms
> ********* Finished testing of PlaylistSanitizeTest *********
