### PR TITLE
Fixed sending of report id to HID device on macOS.

### DIFF
--- a/input/drivers_hid/iohidmanager_hid.c
+++ b/input/drivers_hid/iohidmanager_hid.c
@@ -1105,7 +1105,7 @@ static int32_t iohidmanager_set_report(void *handle, uint8_t report_type, uint8_
       (struct iohidmanager_hid_adapter*)handle;
 
    if (adapter)
-      return IOHIDDeviceSetReport(adapter->handle, translate_hid_report_type(report_type), report_type, data_buf, size);
+      return IOHIDDeviceSetReport(adapter->handle, translate_hid_report_type(report_type), report_id, data_buf, size);
 
    return -1;
 }


### PR DESCRIPTION
Hi.
Yesterday I apparently noticed that a PlayStation 3 controller (with a wired connection) wasn't responding in RetroArch on macOS, however another applications that can handle it are working fine.
After some researches I had noticed that a IOHIDManager in RetroArch sends reports with an incorrect id.

Here is an invocation of the macOS system function `IOHIDDeviceSetReport`.
https://github.com/libretro/RetroArch/blob/568d788d541703f59037f2889c4caec7a9142726/input/drivers_hid/iohidmanager_hid.c#L1108


https://github.com/apple-open-source/macos/blob/8ecaeeea2e342177fc8d87238569f3634efb26ad/IOKitUser/hid.subproj/IOHIDDevice.c#L1888-L1894

Here you can see a signature of this function `IOHIDDeviceSetReport` that expects a `reportID` as the third argument, not a `report_type`.
In my opinion this is obviously a typo, and honestly I don't understand how it has worked for anyone for the last year (since 2f4cfe2a02f6bf2722607ceb446d493d6f2b3c0e).

Anyway, after replacing `report_type` with `report_id`, I found that the PS3 controller works great (tested on macOS 10.15 Catalina and macOS 12 Monterey (thanks to cdd39a63644e1a772c19c9aa6fdb0af21ddc00c5)).
