### PR TITLE
(Network) Adapt POLL for 3DS platform

### DIFF
--- a/libretro-common/net/net_socket.c
+++ b/libretro-common/net/net_socket.c
@@ -469,6 +469,33 @@ done:
    sceNetEpollDestroy(epoll_fd);
 
    return ret;
+#elif defined(_3DS)
+   int i;
+   int timeout_quotient;
+   int timeout_remainder;
+   int ret = -1;
+
+#define TIMEOUT_DIVISOR 100
+   if (timeout <= TIMEOUT_DIVISOR)
+      return poll(fds, nfds, timeout);
+
+   timeout_quotient = timeout / TIMEOUT_DIVISOR;
+   for (i = 0; i < timeout_quotient; i++)
+   {
+      ret = poll(fds, nfds, TIMEOUT_DIVISOR);
+
+      /* Success or error. */
+      if (ret)
+         return ret;
+   }
+
+   timeout_remainder = timeout % TIMEOUT_DIVISOR;
+   if (timeout_remainder)
+      ret = poll(fds, nfds, timeout_remainder);
+
+   return ret;
+#undef TIMEOUT_DIVISOR
+
 #elif defined(GEKKO)
    return net_poll(fds, nfds, timeout);
 #else


### PR DESCRIPTION
## Description

Adapt ```socket_poll``` to the libctru ```poll``` behaviour on 3DS platform.
This addresses the issue utilizing ```poll``` would wait for the full timeout.

Authored by @Cthulhu-throwaway 

## Related Issues
- https://github.com/libretro/RetroArch/issues/14381#issuecomment-1250375912

## Reviewers
@Cthulhu-throwaway 
