### PR TITLE
Fix "Windowed Scale" dropdown menu

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -12006,6 +12006,7 @@ static bool setting_append_list(
                      general_write_handler,
                      general_read_handler);
                (*list)[list_info->index - 1].action_ok = &setting_action_ok_uint;
+               (*list)[list_info->index - 1].offset_by = 1;
                menu_settings_list_current_add_range(list, list_info, 1, 10, 1, true, true);
                SETTINGS_DATA_LIST_CURRENT_ADD_FLAGS(list, list_info, SD_FLAG_LAKKA_ADVANCED);
 


### PR DESCRIPTION
Since 84868ab21f6f0528ea80b4bf4461940c123287ea the dropdown menu for `Settings > Video > Windowed Mode > Windowed Scale` doesn't work properly: selecting "3" will set it to "2", selecting "2" will set it to "1", etc.