### PR TITLE
Fix incorrect lines in .cht files for 'cheat10' and above

### DIFF
--- a/cheat_manager.c
+++ b/cheat_manager.c
@@ -199,7 +199,7 @@ bool cheat_manager_save(
       char desc_key[128];
       char code_key[128];
       char enable_key[128];
-      char formatted_number[8];
+      char formatted_number[12];
  
       formatted_number[0] = '\0';
       snprintf(formatted_number, sizeof(formatted_number), "cheat%u_", i);


### PR DESCRIPTION
Right now RetroArch doesn't create some lines from the .cht file properly for cheat10 and above because of the 8 characters limit, as an example you can end up with this (notice the missing `_`):

> cheat10big_endian = "false"
cheat10code = "SHRT-ST04"
cheat10desc = "Roar meter increases faster"
cheat10enable = "false"

instead of:

> cheat10_big_endian = "false"
cheat10_code = "SHRT-ST04"
cheat10_desc = "Roar meter increases faster"
cheat10_enable = "false"

Bumped the characters limit to 12, should be more than enough (up to cheat99999) :p 