### PR TITLE
(UWP) Remove expandedResources

### DIFF
--- a/pkg/msvc-uwp/RetroArch-msvc2017-UWP/Package.appxmanifest
+++ b/pkg/msvc-uwp/RetroArch-msvc2017-UWP/Package.appxmanifest
@@ -34,6 +34,5 @@
     <Capability Name="internetClientServer" />
     <rescap:Capability Name="runFullTrust"/>
     <rescap:Capability Name="broadFileSystemAccess" />
-    <rescap:Capability Name="expandedResources" />
   </Capabilities>
 </Package>

--- a/pkg/msvc-uwp/RetroArch-msvc2019-UWP/Package.appxmanifest
+++ b/pkg/msvc-uwp/RetroArch-msvc2019-UWP/Package.appxmanifest
@@ -34,6 +34,5 @@
     <Capability Name="internetClientServer" />
     <rescap:Capability Name="runFullTrust"/>
     <rescap:Capability Name="broadFileSystemAccess" />
-    <rescap:Capability Name="expandedResources" />
   </Capabilities>
 </Package>


### PR DESCRIPTION
## Description

This flag is only needed for when RetroArch is set as an App. When using it as a Game it's pretty useless. Not to mention it causes some buggy behavior, where controller inputs are still recognized when you have the Xbox Guide opened. This means you could accidentally open a game or inadvertently screw up your settings while checking your friends list for example.
