### PR TITLE
UWP OnSuspending and save on quit fix

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -6163,9 +6163,10 @@ bool retroarch_main_quit(void)
    video_driver_state_t*video_st = video_state_get_ptr();
    settings_t *settings          = config_get_ptr();
    
-   //Save configs before quitting
-   //as for UWP depending on `OnSuspending` is not important as we can call it directly here
-   //specifically we need to get width,height which requires UI thread and it will not be available on exit
+   /*Save configs before quitting
+    *as for UWP depending on `OnSuspending` is not important as we can call it directly here
+    *specifically we need to get width,height which requires UI thread and it will not be available on exit
+    */
    bool config_save_on_exit = settings->bools.config_save_on_exit;
    if (config_save_on_exit)
       command_event(CMD_EVENT_MENU_SAVE_CURRENT_CONFIG, NULL);

--- a/retroarch.c
+++ b/retroarch.c
@@ -6162,6 +6162,13 @@ bool retroarch_main_quit(void)
    runloop_state_t *runloop_st   = runloop_state_get_ptr();
    video_driver_state_t*video_st = video_state_get_ptr();
    settings_t *settings          = config_get_ptr();
+   
+   //Save configs before quitting
+   //as for UWP depending on `OnSuspending` is not important as we can call it directly here
+   //specifically we need to get width,height which requires UI thread and it will not be available on exit
+   bool config_save_on_exit = settings->bools.config_save_on_exit;
+   if (config_save_on_exit)
+      command_event(CMD_EVENT_MENU_SAVE_CURRENT_CONFIG, NULL);
 
 #ifdef HAVE_PRESENCE
    {


### PR DESCRIPTION
## Description

Regarding to my previous pull request
I'm just resubmitting the same changes on `uwp_main.cpp`

I also added save config call in `retroarch_main_quit` at `retroarch.c`
this call must save the configs before the app closed
I believe there is no need to wait the app to reach `Suspending` state as we can call it here with no problems, so I don't know why it wasn't like that before.

I verified this in 3 cases:
- App in background
- App terminated
- App quit from menu

in all these cases configs were successfully saved

## Related Issues

#13491

## Related Pull Requests

#14372

## Reviewers

@LibretroAdmin 
