### PR TITLE
Avoid 'video_gpu_screenshot' with savestates

### DIFF
--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -2030,12 +2030,6 @@ bool video_driver_supports_viewport_read(void)
 bool video_driver_prefer_viewport_read(void)
 {
    video_driver_state_t *video_st = &video_driver_st;
-   settings_t *settings           = config_get_ptr();
-#ifdef HAVE_SCREENSHOTS
-   bool video_gpu_screenshot      = settings->bools.video_gpu_screenshot;
-   if (video_gpu_screenshot)
-      return true;
-#endif
    return (video_driver_is_hw_context() &&
        !video_st->current_video->read_frame_raw);
 }


### PR DESCRIPTION
## Description

Allow GPU screenshots with savestates only when there is no other way of getting a screenshot.

Also renamed `silence` variable to `savestate` since in this context it is called like that and used for that everywhere else.
