### PR TITLE
(Vulkan) Fix screenshot widget crash when ticker animating

### DIFF
--- a/gfx/widgets/gfx_widget_screenshot.c
+++ b/gfx/widgets/gfx_widget_screenshot.c
@@ -262,6 +262,7 @@ static void gfx_widget_screenshot_frame(void* data, void *user_data)
       ticker.s          = shotname;
       ticker.selected   = true;
       ticker.str        = state->shotname;
+      ticker.spacer     = NULL;
 
       gfx_animation_ticker(&ticker);
 


### PR DESCRIPTION
## Description

Ensure ticker spacer is NULL, otherwise Vulkan (only, why?!) crashes when screenshot widget size is not big enough for the title. 
