### PR TITLE
Unload screenshot widget texture early

### DIFF
--- a/gfx/widgets/gfx_widget_screenshot.c
+++ b/gfx/widgets/gfx_widget_screenshot.c
@@ -193,6 +193,11 @@ static void gfx_widget_screenshot_free(void)
    gfx_widget_screenshot_dispose(NULL);
 }
 
+static void gfx_widget_screenshot_context_destroy(void)
+{
+   gfx_widget_screenshot_dispose(NULL);
+}
+
 static void gfx_widget_screenshot_frame(void* data, void *user_data)
 {
    static float pure_white[16]          = {
@@ -379,7 +384,7 @@ const gfx_widget_t gfx_widget_screenshot = {
    gfx_widget_screenshot_init,
    gfx_widget_screenshot_free,
    NULL, /* context_reset*/
-   NULL, /* context_destroy */
+   gfx_widget_screenshot_context_destroy,
    NULL, /* layout */
    gfx_widget_screenshot_iterate,
    gfx_widget_screenshot_frame


### PR DESCRIPTION
## Description

Allow `context_destroy` to unload screenshot texture. This makes sure that the widget will not be seen in broken state at all after closing content when widget is visible. Otherwise the result is either random garbage as the screenshot preview texture and/or crash after it vanishes.

## Related Issues

Closes #14359