### PR TITLE
Fix socket_connect_with_timeout for WIIU

### DIFF
--- a/libretro-common/net/net_socket.c
+++ b/libretro-common/net/net_socket.c
@@ -769,8 +769,8 @@ bool socket_connect_with_timeout(int fd, void *data, int timeout)
       int       error = -1;
       socklen_t errsz = sizeof(error);
 
-      getsockopt(fd, SOL_SOCKET, SO_ERROR, (char*)&error, &errsz);
-      if (error)
+      /* Only error out here if the getsockopt() call succeeds and error is still set. */
+      if(!getsockopt(fd, SOL_SOCKET, SO_ERROR, (char*)&error, &errsz) && error)
          return false;
    }
 #endif


### PR DESCRIPTION
## Description

Previous work to clean up the HTTP networking code surfaced a bug in `socket_connect_with_timeout()` that caused connections to immediately fail. Specifically, achievements stopped working because the http task code path was rewritten to use `socket_connect_with_timeout` instead of `socket_connect`.

The bug appears to come down to an unsupported socket option. The final check is to try to read `SO_ERROR` from the socket, and on WIIU the `getsockopt()` call returns -1 and sets `lastsocketerr()` (WIIU's equivalent to errno) to 16.

The fix is to change the logic to only abort the connection if that `getsockopt()` call succeeds *and* the error is set.

## Related Issues
- #14471 

## Reviewers
@LibretroAdmin
