### PR TITLE
(UWP) Build Fix

### DIFF
--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -994,10 +994,10 @@ static bool d3d11_init_swapchain(d3d11_video_t* d3d11,
     * flip model cannot be used here */
    desc.SwapEffect                         = DXGI_SWAP_EFFECT_DISCARD;
 #else
-   d3d11->has_flip_model                   = true;
-   d3d11->has_allow_tearing                = true;
+   d3d11->flags |= D3D11_ST_FLAG_HAS_FLIP_MODEL
+      | D3D11_ST_FLAG_HAS_ALLOW_TEARING;
    desc.Flags                              = DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;
-   if (d3d11->waitable_swapchains)
+   if (d3d11->flags & D3D11_ST_FLAG_WAITABLE_SWAPCHAINS)
       desc.Flags                          |= DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT;
    desc.SwapEffect                         = DXGI_SWAP_EFFECT_FLIP_DISCARD;
 #endif


### PR DESCRIPTION
## Description

Commit https://github.com/libretro/RetroArch/commit/951b98fe1b64a1c32d28401d60f13b9de82fa062 broke UWP builds. This fixes it. Everything is still working as expected of course. But more testing never hurts.
