### PR TITLE
Get mkdir working on wiiu

### DIFF
--- a/libretro-common/vfs/vfs_implementation.c
+++ b/libretro-common/vfs/vfs_implementation.c
@@ -948,7 +948,7 @@ int retro_vfs_mkdir_impl(const char *dir)
    int ret = sceIoMkdir(dir, 0777);
 #elif defined(__QNX__)
    int ret = mkdir(dir, 0777);
-#elif defined(GEKKO)
+#elif defined(GEKKO) || defined(WIIU)
    /* On GEKKO platforms, mkdir() fails if
     * the path has a trailing slash. We must
     * therefore remove it. */


### PR DESCRIPTION
== DETAILS
Looks like Wii U's mkdir() implementation doesn't like trailing slashes either.

Since we already have an implementation to handle this, I just added Wii U to it.

## Related Issues

#14487 

## Reviewers

@LibretroAdmin 