### PR TITLE
Add delay to savestate notifications

### DIFF
--- a/gfx/gfx_widgets.c
+++ b/gfx/gfx_widgets.c
@@ -1500,6 +1500,7 @@ void gfx_widgets_frame(void *data)
    gfx_display_t            *p_disp = (gfx_display_t*)video_info->disp_userdata;
    gfx_display_ctx_driver_t *dispctx= p_disp->dispctx;
    dispgfx_widget_t *p_dispwidget   = (dispgfx_widget_t*)video_info->widgets_userdata;
+   bool fps_show                    = video_info->fps_show;
    bool framecount_show             = video_info->framecount_show;
    bool memory_show                 = video_info->memory_show;
    bool core_status_msg_show        = video_info->core_status_msg_show;
@@ -1507,12 +1508,12 @@ void gfx_widgets_frame(void *data)
    unsigned video_width             = video_info->width;
    unsigned video_height            = video_info->height;
    bool widgets_is_paused           = video_info->widgets_is_paused;
-   bool fps_show                    = video_info->fps_show;
    bool widgets_is_fastforwarding   = video_info->widgets_is_fast_forwarding;
    bool widgets_is_rewinding        = video_info->widgets_is_rewinding;
    bool runloop_is_slowmotion       = video_info->runloop_is_slowmotion;
    bool menu_screensaver_active     = video_info->menu_screensaver_active;
-   bool notifications_hidden        = video_info->notifications_hidden;
+   bool notifications_hidden        = video_info->notifications_hidden ||
+         video_info->msg_queue_delay;
    int top_right_x_advance          = video_width;
 
    p_dispwidget->gfx_widgets_frame_count++;

--- a/gfx/video_driver.h
+++ b/gfx/video_driver.h
@@ -471,6 +471,7 @@ typedef struct video_frame_info
    unsigned black_frame_insertion;
    unsigned fps_update_interval;
    unsigned memory_update_interval;
+   unsigned msg_queue_delay;
 
    float menu_wallpaper_opacity;
    float menu_framebuffer_opacity;

--- a/runloop.h
+++ b/runloop.h
@@ -246,6 +246,7 @@ struct runloop
 
    runloop_core_status_msg_t core_status_msg;
 
+   unsigned msg_queue_delay;
    unsigned pending_windowed_scale;
    unsigned max_frames;
    unsigned audio_latency;

--- a/tasks/task_save.c
+++ b/tasks/task_save.c
@@ -1324,7 +1324,13 @@ static void task_push_save_state(const char *path, void *data, size_t size, bool
       state->flags              |= (SAVE_TASK_FLAG_AUTOSAVE |
                                     SAVE_TASK_FLAG_MUTE);
    if (settings->bools.savestate_thumbnail_enable)
-      state->flags              |= SAVE_TASK_FLAG_THUMBNAIL_ENABLE;
+   {
+      /* Delay OSD messages and widgets for a few frames
+       * to prevent GPU screenshots from having notifications */
+      runloop_state_t *runloop_st = runloop_state_get_ptr();
+      runloop_st->msg_queue_delay = 10;
+      state->flags               |= SAVE_TASK_FLAG_THUMBNAIL_ENABLE;
+   }
    state->state_slot             = settings->ints.state_slot;
    if (video_driver_cached_frame_has_valid_framebuffer())
       state->flags              |= SAVE_TASK_FLAG_HAS_VALID_FB;


### PR DESCRIPTION
## Description

Just a trivial delay for OSD messages and widgets so that GPU savestate screenshots stay untouched.
This really ought to be redesigned at some point to get rid of the arbitrary delay by either taking the screenshot before the state, or knowing the exact frame when the shot will be taken.

And some bonus nits and indentations.
