### PR TITLE
(Wayland) Set correct app ID

### DIFF
--- a/gfx/common/wayland_common.c
+++ b/gfx/common/wayland_common.c
@@ -29,6 +29,9 @@
 
 #define SPLASH_SHM_NAME "retroarch-wayland-vk-splash"
 
+#define APP_ID "org.libretro.RetroArch"
+#define WINDOW_TITLE "RetroArch"
+
 #ifdef HAVE_LIBDECOR_H
 #include <libdecor.h>
 #endif
@@ -544,8 +547,8 @@ bool gfx_ctx_wl_init_common(
             goto error;
          }
 
-         wl->libdecor_frame_set_app_id(wl->libdecor_frame, "retroarch");
-         wl->libdecor_frame_set_title(wl->libdecor_frame, "RetroArch");
+         wl->libdecor_frame_set_app_id(wl->libdecor_frame, APP_ID);
+         wl->libdecor_frame_set_title(wl->libdecor_frame, WINDOW_TITLE);
          wl->libdecor_frame_map(wl->libdecor_frame);
       }
 
@@ -571,8 +574,8 @@ bool gfx_ctx_wl_init_common(
       wl->xdg_toplevel = xdg_surface_get_toplevel(wl->xdg_surface);
       xdg_toplevel_add_listener(wl->xdg_toplevel, &toplevel_listener->xdg_toplevel_listener, wl);
 
-      xdg_toplevel_set_app_id(wl->xdg_toplevel, "retroarch");
-      xdg_toplevel_set_title(wl->xdg_toplevel, "RetroArch");
+      xdg_toplevel_set_app_id(wl->xdg_toplevel, APP_ID);
+      xdg_toplevel_set_title(wl->xdg_toplevel, WINDOW_TITLE);
 
       if (wl->deco_manager)
          wl->deco = zxdg_decoration_manager_v1_get_toplevel_decoration(


### PR DESCRIPTION
## Description

On KDE RetroArch has a wayland icon in the title bar.
The icon is set based on the app id which for retroarch should be "org.libretro.RetroArch".

| master branch | this branch |
| --- | --- |
| ![Screenshot from 2022-10-16 18-04-37](https://user-images.githubusercontent.com/334272/196048622-431a3839-8d53-4560-823d-b66bb10e882c.png) | ![Screenshot from 2022-10-16 18-05-01](https://user-images.githubusercontent.com/334272/196048626-29bf1eca-4907-4656-8c4e-fdc186d6e994.png) |

## Related Issues

## Related Pull Requests

## Reviewers

@LibretroAdmin 