### PR TITLE
Thumbnail fullscreen toggle behavior correction

### DIFF
--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -7095,12 +7095,10 @@ static void ozone_set_thumbnail_content(void *data, const char *s)
 #endif
             case OZONE_SYSTEM_TAB_MUSIC:
                ozone->want_thumbnail_bar              = false;
-               ozone->fullscreen_thumbnails_available = false;
                break;
 
             default:
                ozone->want_thumbnail_bar              = true;
-               ozone->fullscreen_thumbnails_available = true;
                break;
          }
       }
@@ -7262,11 +7260,14 @@ static bool INLINE ozone_fullscreen_thumbnails_available(ozone_handle_t *ozone)
          ozone->fullscreen_thumbnails_available
       && !ozone->cursor_in_sidebar
       && ozone->show_thumbnail_bar
-      && ((ozone->thumbnails.right.status     != GFX_THUMBNAIL_STATUS_MISSING) ||
-          (ozone->thumbnails.left.status      != GFX_THUMBNAIL_STATUS_MISSING) ||
-          (ozone->thumbnails.savestate.status != GFX_THUMBNAIL_STATUS_MISSING))
       && (gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_RIGHT) ||
-          gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_LEFT));
+          gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_LEFT))
+      && (  (ozone->thumbnails.left.status == GFX_THUMBNAIL_STATUS_AVAILABLE ||
+               (ozone->thumbnails.left.status < GFX_THUMBNAIL_STATUS_AVAILABLE
+                  && ozone->thumbnails_left_status_prev <= GFX_THUMBNAIL_STATUS_AVAILABLE))
+         || (ozone->thumbnails.right.status == GFX_THUMBNAIL_STATUS_AVAILABLE ||
+               (ozone->thumbnails.right.status < GFX_THUMBNAIL_STATUS_AVAILABLE
+                  && ozone->thumbnails_right_status_prev <= GFX_THUMBNAIL_STATUS_AVAILABLE)));
 
    if (ozone->is_state_slot &&
          (ozone->thumbnails.savestate.status == GFX_THUMBNAIL_STATUS_MISSING ||
@@ -7472,7 +7473,7 @@ static enum menu_action ozone_parse_menu_entry_action(
          /* If this is a menu with thumbnails and cursor
           * is not in the sidebar, attempt to show
           * fullscreen thumbnail view */
-         if (ozone->fullscreen_thumbnails_available &&
+         if (ozone_fullscreen_thumbnails_available(ozone) &&
                !ozone->show_fullscreen_thumbnails &&
                !ozone->cursor_in_sidebar)
          {

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -7619,6 +7619,11 @@ static enum menu_action rgui_parse_menu_entry_action(
          {
             settings_t *settings = config_get_ptr();
 
+            new_action = MENU_ACTION_NOOP;
+
+            if (!rgui->entry_has_thumbnail && !rgui->entry_has_left_thumbnail)
+               break;
+
             if (!rgui->show_fs_thumbnail && rgui->gfx_thumbnails_prev < 0)
                rgui->gfx_thumbnails_prev = settings->uints.gfx_thumbnails;
 
@@ -7644,7 +7649,6 @@ static enum menu_action rgui_parse_menu_entry_action(
                rgui_thumbnail_cycle_dupe(rgui);
 
             rgui_toggle_fs_thumbnail(rgui, config_get_ptr()->bools.menu_rgui_inline_thumbnails);
-            new_action = MENU_ACTION_NOOP;
 
             if (!rgui->show_fs_thumbnail)
                rgui->gfx_thumbnails_prev = -1;

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -4228,6 +4228,23 @@ static void xmb_show_fullscreen_thumbnails(
    xmb->show_fullscreen_thumbnails     = true;
 }
 
+static bool INLINE xmb_fullscreen_thumbnails_available(xmb_handle_t *xmb)
+{
+   bool ret =
+         xmb->fullscreen_thumbnails_available
+      && (gfx_thumbnail_is_enabled(xmb->thumbnail_path_data, GFX_THUMBNAIL_RIGHT) ||
+          gfx_thumbnail_is_enabled(xmb->thumbnail_path_data, GFX_THUMBNAIL_LEFT))
+      && (xmb->thumbnails.left.status  == GFX_THUMBNAIL_STATUS_AVAILABLE ||
+          xmb->thumbnails.right.status == GFX_THUMBNAIL_STATUS_AVAILABLE);
+
+   if (xmb->is_state_slot &&
+         (xmb->thumbnails.savestate.status == GFX_THUMBNAIL_STATUS_MISSING ||
+          xmb->thumbnails.savestate.status == GFX_THUMBNAIL_STATUS_UNKNOWN))
+      ret = false;
+
+   return ret;
+}
+
 /* Common thumbnail switch requires FILE_TYPE_RPL_ENTRY,
  * which only works with playlists, therefore activate it
  * manually for Quick Menu, Explore and Database */
@@ -4282,7 +4299,7 @@ static enum menu_action xmb_parse_menu_entry_action(
 
          /* If this is a menu with thumbnails, attempt
           * to show fullscreen thumbnail view */
-         if (xmb->fullscreen_thumbnails_available &&
+         if (xmb_fullscreen_thumbnails_available(xmb) &&
                !xmb->show_fullscreen_thumbnails)
          {
             xmb_hide_fullscreen_thumbnails(xmb, false);


### PR DESCRIPTION
## Description

Consistent behavior for all menu drivers regarding thumbnail fullscreen toggling, which is allow doing so only when image is available.

## Related Issues

Closes #14493