### PR TITLE
Playlist + database changes

### DIFF
--- a/manual_content_scan.c
+++ b/manual_content_scan.c
@@ -1394,12 +1394,12 @@ void manual_content_scan_add_content_to_playlist(
        * > The push function reads our entry as const,
        *   so these casts are safe */
       entry.path       = (char*)playlist_content_path;
-      entry.entry_slot = 0;
       entry.label      = label;
       entry.core_path  = (char*)FILE_PATH_DETECT;
       entry.core_name  = (char*)FILE_PATH_DETECT;
       entry.crc32      = (char*)"00000000|crc";
       entry.db_name    = task_config->database_name;
+      entry.entry_slot = 0;
 
       /* Add entry to playlist */
       playlist_push(playlist, &entry);

--- a/playlist.c
+++ b/playlist.c
@@ -610,26 +610,27 @@ static void playlist_free_entry(struct playlist_entry *entry)
    if (entry->path_id)
       playlist_path_id_free(entry->path_id);
 
-   entry->path      = NULL;
-   entry->label     = NULL;
-   entry->core_path = NULL;
-   entry->core_name = NULL;
-   entry->db_name   = NULL;
-   entry->crc32     = NULL;
-   entry->subsystem_ident = NULL;
-   entry->subsystem_name = NULL;
-   entry->runtime_str = NULL;
-   entry->last_played_str = NULL;
-   entry->subsystem_roms = NULL;
-   entry->path_id = NULL;
-   entry->runtime_status = PLAYLIST_RUNTIME_UNKNOWN;
-   entry->runtime_hours = 0;
-   entry->runtime_minutes = 0;
-   entry->runtime_seconds = 0;
-   entry->last_played_year = 0;
-   entry->last_played_month = 0;
-   entry->last_played_day = 0;
-   entry->last_played_hour = 0;
+   entry->path               = NULL;
+   entry->label              = NULL;
+   entry->core_path          = NULL;
+   entry->core_name          = NULL;
+   entry->db_name            = NULL;
+   entry->crc32              = NULL;
+   entry->subsystem_ident    = NULL;
+   entry->subsystem_name     = NULL;
+   entry->runtime_str        = NULL;
+   entry->last_played_str    = NULL;
+   entry->subsystem_roms     = NULL;
+   entry->path_id            = NULL;
+   entry->entry_slot         = 0;
+   entry->runtime_status     = PLAYLIST_RUNTIME_UNKNOWN;
+   entry->runtime_hours      = 0;
+   entry->runtime_minutes    = 0;
+   entry->runtime_seconds    = 0;
+   entry->last_played_year   = 0;
+   entry->last_played_month  = 0;
+   entry->last_played_day    = 0;
+   entry->last_played_hour   = 0;
    entry->last_played_minute = 0;
    entry->last_played_second = 0;
 }

--- a/playlist.h
+++ b/playlist.h
@@ -101,7 +101,6 @@ typedef struct
 struct playlist_entry
 {
    char *path;
-   unsigned entry_slot;
    char *label;
    char *core_path;
    char *core_name;
@@ -113,6 +112,7 @@ struct playlist_entry
    char *last_played_str;
    struct string_list *subsystem_roms;
    playlist_path_id_t *path_id;
+   unsigned entry_slot;
    unsigned runtime_hours;
    unsigned runtime_minutes;
    unsigned runtime_seconds;

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -1675,7 +1675,6 @@ static void task_push_to_history_list(
             /* The push function reads our entry as const, 
              * so these casts are safe */
             entry.path            = (char*)tmp;
-            entry.entry_slot      = runloop_st->entry_state_slot;
             entry.label           = (char*)label;
             entry.core_path       = (char*)core_path;
             entry.core_name       = (char*)core_name;
@@ -1684,6 +1683,7 @@ static void task_push_to_history_list(
             entry.subsystem_ident = (char*)path_get(RARCH_PATH_SUBSYSTEM);
             entry.subsystem_name  = (char*)subsystem_name;
             entry.subsystem_roms  = (struct string_list*)path_get_subsystem_list();
+            entry.entry_slot      = runloop_st->entry_state_slot;
 
             command_playlist_push_write(playlist_hist, &entry);
          }


### PR DESCRIPTION
## Description

- Stop including garbage as `entry_slot` in the playlist after scanning
- `entry_slot` cleanups
- Stop requiring exact CRC match to include any `label` in playlist
  - Fixes for example `Rockman - Mega World (Japan)` having different CRC in the database, which results in empty label, which results in no thumbnail even if the filenames match
- Add logging for non-matches during scanning

