### PR TITLE
revert offending function

### DIFF
--- a/gfx/video_thread_wrapper.c
+++ b/gfx/video_thread_wrapper.c
@@ -1384,28 +1384,15 @@ bool video_init_thread(const video_driver_t **out_driver, void **out_data,
       const video_driver_t *drv, const video_info_t info)
 {
    thread_video_t *thr = (thread_video_t*)calloc(1, sizeof(*thr));
-
    if (!thr)
-      goto error;
+      return false;
 
    video_thread_set_callbacks(thr, drv);
 
-   if (!video_thread_init(thr, info, input, input_data))
-   {
-      thr->video_thread.free(thr);
-      goto error;
-   }
-
+   thr->driver = drv;
    *out_driver = &thr->video_thread;
    *out_data   = thr;
-
-   return true;
-
-error:
-   *out_driver = NULL;
-   *out_data   = NULL;
-
-   return false;
+   return video_thread_init(thr, info, input, input_data);
 }
 
 bool video_thread_font_init(const void **font_driver, void **font_handle,


### PR DESCRIPTION
fixes https://github.com/libretro/RetroArch/issues/14528

## Description

This reverts the one offending function from 9e39abcd0026fe3ffca674e6b27b10a949f63621 that was preventing glcore+threaded video from loading core presets. I had to manually bisect it function by function, which was a drag, but this seems to be the one.

## Related Issues

none that I know of. There's a previous issue with similar behavior (https://github.com/libretro/RetroArch/issues/9376) but it ended up being a different cause.

## Related Pull Requests

none

## Reviewers

@LibretroAdmin
