### PR TITLE
Fixed RETROK_LMETA not working on macOS port.

### DIFF
--- a/input/input_keymaps.c
+++ b/input/input_keymaps.c
@@ -1595,7 +1595,7 @@ const struct rarch_key_map rarch_key_map_apple_hid[] = {
    { KEY_RightAlt, RETROK_RALT },
    { KEY_LeftAlt, RETROK_LALT },
    { KEY_RightGUI, RETROK_RMETA },
-   { KEY_LeftGUI, RETROK_RMETA },
+   { KEY_LeftGUI, RETROK_LMETA },
    /* { ?, RETROK_LSUPER }, */
    /* { ?, RETROK_RSUPER }, */
    /* { ?, RETROK_MODE }, */


### PR DESCRIPTION
The RETROK_LMETA key was not defined in the rarch_key_map_apple_hid[]. The definition should be there like other platforms.
