### PR TITLE
Fixed Z/X keys not working on the macOS port.

### DIFF
--- a/input/drivers/cocoa_input.c
+++ b/input/drivers/cocoa_input.c
@@ -421,7 +421,7 @@ static int16_t cocoa_input_state(
             return ret;
          }
 
-         if (binds[port][id].valid)
+         if (!keyboard_mapping_blocked && binds[port][id].valid)
          {
             if (id < RARCH_BIND_LIST_END)
                if (apple_key_state[rarch_keysym_lut[binds[port][id].key]])


### PR DESCRIPTION
On the macOS platform, the Z/X keys are still re-mapped when GAME FOCUS is enabled. This is fixed by checking keyboard_mapping_blocked before using apple_key_state[] like what's been done in the dinput.c.
