### PR TITLE
Fix broken fullscreen mode in macOS Ventura

### DIFF
--- a/ui/drivers/ui_cocoa.m
+++ b/ui/drivers/ui_cocoa.m
@@ -525,7 +525,7 @@ static ui_application_t ui_application_cocoa = {
 }
 #endif
 
-#define NS_WINDOW_COLLECTION_BEHAVIOR_FULLSCREEN_PRIMARY (1 << 17)
+#define NS_WINDOW_COLLECTION_BEHAVIOR_FULLSCREEN_PRIMARY (1 << 7)
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification
 {


### PR DESCRIPTION
Fixes broken fullscreen mode in macOS Ventura by defining `NS_WINDOW_COLLECTION_BEHAVIOR_FULLSCREEN_PRIMARY` as `1 << 7` as defined by `NSWindowCollectionBehaviorFullScreenPrimary` in `AppKit` framework (should fix #14474.)

## Reviewers

@LibretroAdmin