### PR TITLE
Extended character ime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ ifneq ($(findstring FPGA,$(OS)),)
 endif
 
 ifneq ($(findstring Win32,$(OS)),)
-   LDFLAGS += -static-libgcc -lwinmm
+   LDFLAGS += -static-libgcc -lwinmm -limm32
 endif
 
 include Makefile.common

--- a/gfx/gfx_thumbnail_path.c
+++ b/gfx/gfx_thumbnail_path.c
@@ -663,6 +663,32 @@ bool gfx_thumbnail_update_path(
       thumbnail_path[0] = '\0';
       fill_pathname_join_special(thumbnail_path, tmp_buf,
             path_data->content_img, PATH_MAX_LENGTH * sizeof(char));
+      
+      /* Thumbnail fallback 1 - rom_name.png */
+      if ( !path_is_valid(thumbnail_path) )						//  :\thumbnails\db_name\Named_Snaps\rom_name.png
+      {	
+         char content_name[PATH_MAX_LENGTH]; 
+         char* cp = find_last_slash(path_data->content_path);
+         if( cp ) cp++; else cp = path_data->content_path;
+         strcpy(content_name,cp);
+         cp = strchr( content_name,'.'); 
+         if(cp) 	strcpy(cp,".png");
+         fill_pathname_join(thumbnail_path, dir_thumbnails,	system_name,  PATH_MAX_LENGTH);
+         fill_pathname_join(thumbnail_path, thumbnail_path,	type,		  PATH_MAX_LENGTH);
+         fill_pathname_join(thumbnail_path, thumbnail_path,	content_name, PATH_MAX_LENGTH);
+      }
+      /* Thumbnail fallback 2 - rom_path/rom_name.png */
+      if ( !path_is_valid(thumbnail_path) )						//  :\roms\db_name\rom_name.png
+      {	
+         char*  cp;
+         char content_name[PATH_MAX_LENGTH]; 
+         strcpy(content_name,path_data->content_path);
+         cp = strstr(content_name, ".zip#");
+         if( cp ) cp[4]=0;
+         cp = strrchr( content_name,'.'); 
+         strcpy(cp,".png");
+         strcpy(thumbnail_path,content_name);
+      }      
    }
    
    /* Final error check - is cached path empty? */


### PR DESCRIPTION

-IME (win32_common.c/input_driver.c)
The playlist supports utf8, but edit control replaces the extended character with #.
The following code enables extended character input in Netplay Chatting, Search, and Rename titles.

-Thumbnail fallback (gfx_thumbnail_path.c )
If you rename title, you cannot use the thumbnail image. because the thumbnail filename and the title must be the same.
If there is no thumbnail with title, find the thumbnail image with rom-name. This has nothing to do with IME.

![image](https://user-images.githubusercontent.com/116796154/198523791-ad14af4f-eed5-46a9-8d2b-07441e80c92a.png)
