### PR TITLE
(Frontend) Fix default remaps folder

### DIFF
--- a/frontend/drivers/platform_gx.c
+++ b/frontend/drivers/platform_gx.c
@@ -318,7 +318,7 @@ static void frontend_gx_get_env(int *argc, char *argv[],
       g_defaults.dirs[DEFAULT_DIR_PORT], "logs",
       sizeof(g_defaults.dirs[DEFAULT_DIR_LOGS]));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_REMAP],
-      g_defaults.dirs[DEFAULT_DIR_PORT], "remaps",
+      g_defaults.dirs[DEFAULT_DIR_MENU_CONFIG], "remaps",
       sizeof(g_defaults.dirs[DEFAULT_DIR_REMAP]));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_MENU_CONFIG],
       g_defaults.dirs[DEFAULT_DIR_PORT], "config",

--- a/frontend/drivers/platform_orbis.c
+++ b/frontend/drivers/platform_orbis.c
@@ -129,7 +129,7 @@ static void frontend_orbis_get_env(int *argc, char *argv[],
          "downloads", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE_ASSETS]));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_PLAYLIST], user_path,
          "playlists", sizeof(g_defaults.dirs[DEFAULT_DIR_PLAYLIST]));
-   fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_REMAP], user_path,
+   fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_REMAP], g_defaults.dirs[DEFAULT_DIR_MENU_CONFIG],
          "remaps", sizeof(g_defaults.dirs[DEFAULT_DIR_REMAP]));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_SRAM], user_path,
          "savefiles", sizeof(g_defaults.dirs[DEFAULT_DIR_SRAM]));

--- a/frontend/drivers/platform_ps2.c
+++ b/frontend/drivers/platform_ps2.c
@@ -95,7 +95,7 @@ static void create_path_names(void)
          "downloads", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE_ASSETS]));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_PLAYLIST], user_path,
          "playlists", sizeof(g_defaults.dirs[DEFAULT_DIR_PLAYLIST]));
-   fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_REMAP], user_path,
+   fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_REMAP], g_defaults.dirs[DEFAULT_DIR_MENU_CONFIG],
          "remaps", sizeof(g_defaults.dirs[DEFAULT_DIR_REMAP]));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_SRAM], user_path,
          "savefiles", sizeof(g_defaults.dirs[DEFAULT_DIR_SRAM]));

--- a/frontend/drivers/platform_ps3.c
+++ b/frontend/drivers/platform_ps3.c
@@ -139,6 +139,12 @@ static void fill_derived_paths(void)
 		       g_defaults.dirs[DEFAULT_DIR_CORE],
 		       "info",
 		       sizeof(g_defaults.dirs[DEFAULT_DIR_CORE_INFO]));
+    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_MENU_CONFIG],
+		       g_defaults.dirs[DEFAULT_DIR_CORE],
+		       "config", sizeof(g_defaults.dirs[DEFAULT_DIR_MENU_CONFIG]));
+    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_MENU_REMAPS],
+		       g_defaults.dirs[DEFAULT_DIR_MENU_CONFIG],
+		       "remaps", sizeof(g_defaults.dirs[DEFAULT_DIR_MENU_REMAPS]));
     fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_SAVESTATE],
 		       g_defaults.dirs[DEFAULT_DIR_CORE],
 		       "savestates", sizeof(g_defaults.dirs[DEFAULT_DIR_SAVESTATE]));
@@ -414,7 +420,7 @@ static int frontend_ps3_exec_exitspawn(const char *path,
 #else
    ret = -1;
 #endif
-   
+
    if (ret <  0)
    {
       RARCH_WARN("SELF file is not of NPDRM type, trying another approach to boot it...\n");

--- a/frontend/drivers/platform_psp.c
+++ b/frontend/drivers/platform_psp.c
@@ -119,8 +119,8 @@ static void frontend_psp_get_env_settings(int *argc, char *argv[],
       "downloads", sizeof(g_defaults.dirs[DEFAULT_DIR_CORE_ASSETS]));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_PLAYLIST], user_path,
       "playlists", sizeof(g_defaults.dirs[DEFAULT_DIR_PLAYLIST]));
-   fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_REMAP], user_path, "remaps",
-      sizeof(g_defaults.dirs[DEFAULT_DIR_REMAP]));
+   fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_REMAP], g_defaults.dirs[DEFAULT_DIR_MENU_CONFIG],
+      "remaps", sizeof(g_defaults.dirs[DEFAULT_DIR_REMAP]));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_SRAM], user_path,
       "savefiles", sizeof(g_defaults.dirs[DEFAULT_DIR_SRAM]));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_SAVESTATE], user_path,
@@ -293,7 +293,7 @@ static void frontend_psp_init(void *data)
 
 #endif
 
-#if defined(PSP) && defined(HAVE_KERNEL_PRX) 
+#if defined(PSP) && defined(HAVE_KERNEL_PRX)
    pspSdkLoadStartModule("kernel_functions.prx", PSP_MEMORY_PARTITION_KERNEL);
 #endif
 }

--- a/frontend/drivers/platform_qnx.c
+++ b/frontend/drivers/platform_qnx.c
@@ -119,7 +119,7 @@ static void frontend_qnx_get_env_settings(int *argc, char *argv[],
          "filters/audio", sizeof(g_defaults.dirs[DEFAULT_DIR_AUDIO_FILTER]));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_PLAYLIST], user_path,
          "playlists", sizeof(g_defaults.dirs[DEFAULT_DIR_PLAYLIST]));
-   fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_REMAP], user_path,
+   fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_REMAP], g_defaults.dirs[DEFAULT_DIR_MENU_CONFIG],
          "remaps", sizeof(g_defaults.dirs[DEFAULT_DIR_REMAP]));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_SRAM], user_path,
          "saves", sizeof(g_defaults.dirs[DEFAULT_DIR_SRAM]));


### PR DESCRIPTION
## Description

The default `remaps` folder should be created inside the `config` folder

## Related Issues

Fixes #6884, #14325

## Related Pull Requests



## Reviewers


