### PR TITLE
(database) Added serial scanning for PS2

### DIFF
--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -123,7 +123,7 @@ static int task_database_iterate_start(retro_task_t *task,
       task_set_title(task, strdup(msg));
       if (db->list->size != 0)
          task_set_progress(task,
-               roundf((float)db->list_ptr / 
+               roundf((float)db->list_ptr /
                   ((float)db->list->size / 100.0f)));
 #else
       fprintf(stderr, "msg: %s\n", msg);
@@ -148,6 +148,11 @@ static int intfstream_get_serial(intfstream_t *fd, char *serial, size_t serial_l
       else if (string_is_equal(system_name, "Sony - PlayStation"))
       {
          if (detect_ps1_game(fd, serial, serial_len, filename) != 0)
+            return 1;
+      }
+      else if (string_is_equal(system_name, "Sony - PlayStation 2"))
+      {
+         if (detect_ps2_game(fd, serial, serial_len, filename) != 0)
             return 1;
       }
       else if (string_is_equal(system_name, "Nintendo - GameCube"))
@@ -817,7 +822,7 @@ static int database_info_list_iterate_found_match(
       again */
    if (db_state->list_index != 0)
    {
-      struct string_list_elem entry = 
+      struct string_list_elem entry =
          db_state->list->elems[db_state->list_index];
       memmove(&db_state->list->elems[1],
               &db_state->list->elems[0],
@@ -862,7 +867,7 @@ static int task_database_iterate_crc_lookup(
       return database_info_list_iterate_end_no_match(db, db_state, name,
             path_contains_compressed_file);
 
-   /* Archive did not contain a CRC for this entry, 
+   /* Archive did not contain a CRC for this entry,
     * or the file is empty. */
    if (!db_state->crc)
    {
@@ -974,7 +979,7 @@ static int task_database_iterate_playlist_lutro(
             path_basename(path), "", sizeof(game_title));
       path_remove_extension(game_title);
 
-      /* the push function reads our entry as const, 
+      /* the push function reads our entry as const,
        * so these casts are safe */
       entry.path                  = (char*)path;
       entry.label                 = game_title;
@@ -1227,7 +1232,7 @@ static void task_database_handler(retro_task_t *task)
       case DATABASE_STATUS_ITERATE:
          {
             bool path_contains_compressed_file = false;
-            const char *name                   = 
+            const char *name                   =
                database_info_get_current_element_name(dbinfo);
             if (!name)
                goto task_finished;

--- a/tasks/task_database_cue.c
+++ b/tasks/task_database_cue.c
@@ -59,8 +59,9 @@ static struct magic_entry MAGIC_NUMBERS[] = {
    { "Sega - Dreamcast",            "SEGA SEGAKATANA",  0x000010},
    { "Sega - Mega-CD - Sega CD",    "SEGADISCSYSTEM",   0x000010},
    { "Sega - Saturn",               "SEGA SEGASATURN",  0x000010},
-   { "Sony - PlayStation",          "PLAYSTATION",      0x008008},
-   { "Sony - PlayStation",          "PLAYSTATION",      0x009320},
+   { "Sony - PlayStation",          "Sony Computer ",   0x0024f8}, /* PS1 CD license string, PS2 CD doesnt have this string */
+   { "Sony - PlayStation 2",        "PLAYSTATION",      0x009320}, /* PS1 CD and PS2 CD */
+   { "Sony - PlayStation 2",        "PLAYSTATION",      0x008008}, /* PS2 DVD */
    { "Sony - PlayStation Portable", "PSP GAME",         0x008008},
    { NULL,                          NULL,               0}
 };
@@ -202,21 +203,22 @@ int detect_ps1_game(intfstream_t *fd, char *s, size_t len, const char *filename)
    {
       strncpy(raw_game_id, &disc_data[pos], 12);
       raw_game_id[12] = '\0';
-      if (     string_is_equal_fast(raw_game_id, "S", STRLEN_CONST("S")) 
+      if (     string_is_equal_fast(raw_game_id, "S", STRLEN_CONST("S"))
             || string_is_equal_fast(raw_game_id, "E", STRLEN_CONST("E")))
       {
-         if (
-            (   string_is_equal_fast(raw_game_id, "SCUS_", STRLEN_CONST("SCUS_")))
-            || (string_is_equal_fast(raw_game_id, "SLUS_", STRLEN_CONST("SLUS_")))
-            || (string_is_equal_fast(raw_game_id, "SLES_", STRLEN_CONST("SLES_")))
-            || (string_is_equal_fast(raw_game_id, "SCED_", STRLEN_CONST("SCED_")))
-            || (string_is_equal_fast(raw_game_id, "SLPS_", STRLEN_CONST("SLPS_")))
-            || (string_is_equal_fast(raw_game_id, "SLPM_", STRLEN_CONST("SLPM_")))
-            || (string_is_equal_fast(raw_game_id, "SCPS_", STRLEN_CONST("SCPS_")))
-            || (string_is_equal_fast(raw_game_id, "SLED_", STRLEN_CONST("SLED_")))
-            || (string_is_equal_fast(raw_game_id, "SIPS_", STRLEN_CONST("SIPS_")))
-            || (string_is_equal_fast(raw_game_id, "ESPM_", STRLEN_CONST("ESPM_")))
-            || (string_is_equal_fast(raw_game_id, "SCES_", STRLEN_CONST("SCES_")))
+         if (  string_is_equal_fast(raw_game_id, "SCUS_", STRLEN_CONST("SCUS_"))
+            || string_is_equal_fast(raw_game_id, "SLUS_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "SLES_", STRLEN_CONST("SLES_"))
+            || string_is_equal_fast(raw_game_id, "SCED_", STRLEN_CONST("SCED_"))
+            || string_is_equal_fast(raw_game_id, "SLPS_", STRLEN_CONST("SLPS_"))
+            || string_is_equal_fast(raw_game_id, "SLPM_", STRLEN_CONST("SLPM_"))
+            || string_is_equal_fast(raw_game_id, "SCPS_", STRLEN_CONST("SCPS_"))
+            || string_is_equal_fast(raw_game_id, "SLED_", STRLEN_CONST("SLED_"))
+            || string_is_equal_fast(raw_game_id, "SIPS_", STRLEN_CONST("SIPS_"))
+            || string_is_equal_fast(raw_game_id, "ESPM_", STRLEN_CONST("ESPM_"))
+            || string_is_equal_fast(raw_game_id, "SCES_", STRLEN_CONST("SCES_"))
+            || string_is_equal_fast(raw_game_id, "SLKA_", STRLEN_CONST("SLKA_"))
+            || string_is_equal_fast(raw_game_id, "SCAJ_", STRLEN_CONST("SCAJ_"))
             )
          {
             raw_game_id[4] = '-';
@@ -239,10 +241,138 @@ int detect_ps1_game(intfstream_t *fd, char *s, size_t len, const char *filename)
             cue_append_multi_disc_suffix(s, filename);
             return true;
          }
-         else if (string_is_equal_fast(&disc_data[pos], "LSP-", STRLEN_CONST("LSP-")))
+      }
+      else if (string_is_equal_fast(raw_game_id, "LSP-", STRLEN_CONST("LSP-")))
+      {
+         raw_game_id[10] = '\0';
+
+         string_remove_all_whitespace(s, raw_game_id);
+         cue_append_multi_disc_suffix(s, filename);
+         return true;
+      }
+      else if (string_is_equal_fast(raw_game_id, "PSX.EXE", STRLEN_CONST("PSX.EXE")))
+      {
+         raw_game_id[7] = '\0';
+
+         string_remove_all_whitespace(s, raw_game_id);
+         cue_append_multi_disc_suffix(s, filename);
+         return true;
+      }
+   }
+
+   s[0 ] = 'X';
+   s[1 ] = 'X';
+   s[2 ] = 'X';
+   s[3 ] = 'X';
+   s[4 ] = 'X';
+   s[5 ] = 'X';
+   s[6 ] = 'X';
+   s[7 ] = 'X';
+   s[8 ] = 'X';
+   s[9 ] = 'X';
+   s[10] = '\0';
+   cue_append_multi_disc_suffix(s, filename);
+   return false;
+}
+
+int detect_ps2_game(intfstream_t *fd, char *s, size_t len, const char *filename)
+{
+   #define DISC_DATA_SIZE_PS2 0x84000
+   int pos;
+   char raw_game_id[50];
+   char disc_data[DISC_DATA_SIZE_PS2];
+
+   /* Load data into buffer and use pointers */
+   if (intfstream_seek(fd, 0, SEEK_SET) < 0)
+      return false;
+
+   if (intfstream_read(fd, disc_data, DISC_DATA_SIZE_PS2) <= 0)
+      return false;
+
+   disc_data[DISC_DATA_SIZE_PS2 - 1] = '\0';
+
+   for (pos = 0; pos < DISC_DATA_SIZE_PS2; pos++)
+   {
+      strncpy(raw_game_id, &disc_data[pos], 12);
+      raw_game_id[12] = '\0';
+      if (     string_is_equal_fast(raw_game_id, "S", STRLEN_CONST("S"))
+            || string_is_equal_fast(raw_game_id, "P", STRLEN_CONST("P"))
+            || string_is_equal_fast(raw_game_id, "T", STRLEN_CONST("T"))
+            || string_is_equal_fast(raw_game_id, "C", STRLEN_CONST("C"))
+            || string_is_equal_fast(raw_game_id, "H", STRLEN_CONST("H"))
+            || string_is_equal_fast(raw_game_id, "A", STRLEN_CONST("A"))
+            || string_is_equal_fast(raw_game_id, "V", STRLEN_CONST("A"))
+            || string_is_equal_fast(raw_game_id, "L", STRLEN_CONST("A"))
+            || string_is_equal_fast(raw_game_id, "M", STRLEN_CONST("A"))
+            || string_is_equal_fast(raw_game_id, "N", STRLEN_CONST("A"))
+            || string_is_equal_fast(raw_game_id, "U", STRLEN_CONST("A"))
+            || string_is_equal_fast(raw_game_id, "W", STRLEN_CONST("A"))
+            || string_is_equal_fast(raw_game_id, "G", STRLEN_CONST("A"))
+            || string_is_equal_fast(raw_game_id, "K", STRLEN_CONST("A"))
+            || string_is_equal_fast(raw_game_id, "R", STRLEN_CONST("A"))
+         )
+      {
+         if (  string_is_equal_fast(raw_game_id, "SLPM_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "SLES_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "SCES_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "SLUS_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "SLPS_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "SCED_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "SCUS_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "SCPS_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "SCAJ_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "SLKA_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "SCKA_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "SLAJ_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "TCPS_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "KOEI_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "PBPX_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "PCPX_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "PAPX_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "SCCS_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "ALCH_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "TCES_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "CPCS_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "SLED_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "TLES_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "GUST_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "CF00_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "SCPN_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "SCPM_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "PSXC_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "SLPN_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "ULKS_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "LDTL_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "PKP2_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "WLFD_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "CZP2_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "HAKU_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "SRPM_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "MTP2_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "NMP2_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "ARZE_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "VUGJ_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "ARP2_", STRLEN_CONST("SLUS_"))
+            || string_is_equal_fast(raw_game_id, "ROSE_", STRLEN_CONST("SLUS_"))
+            )
          {
+            raw_game_id[4] = '-';
+            if (string_is_equal_fast(&raw_game_id[8], ".", STRLEN_CONST(".")))
+            {
+               raw_game_id[8] = raw_game_id[9];
+               raw_game_id[9] = raw_game_id[10];
+            }
+            /* A few games have their serial in the form of xx.xxx */
+            /* Tanaka Torahiko no Ultra-ryuu Shougi - Ibisha Anaguma-hen (Japan) -> SLPS_02.261 */
+            else if (string_is_equal_fast(&raw_game_id[7], ".", STRLEN_CONST(".")))
+            {
+               raw_game_id[7] = raw_game_id[8];
+               raw_game_id[8] = raw_game_id[9];
+               raw_game_id[9] = raw_game_id[10];
+            }
+            raw_game_id[10] = '\0';
+
             string_remove_all_whitespace(s, raw_game_id);
-            s[10] = '\0';
             cue_append_multi_disc_suffix(s, filename);
             return true;
          }
@@ -283,7 +413,7 @@ int detect_psp_game(intfstream_t *fd, char *s, size_t len, const char *filename)
    {
       strncpy(s, &disc_data[pos], 10);
       s[10] = '\0';
-      if (     string_is_equal_fast(s, "U", STRLEN_CONST("U")) 
+      if (     string_is_equal_fast(s, "U", STRLEN_CONST("U"))
             || string_is_equal_fast(s, "N", STRLEN_CONST("N")))
       {
          if (
@@ -455,7 +585,7 @@ int detect_gc_game(intfstream_t *fd, char *s, size_t len, const char *filename)
          s[_len+4] = '\0';
          return true;
       default:
-	 break;
+    break;
    }
 
    return false;
@@ -545,7 +675,7 @@ int detect_scd_game(intfstream_t *fd, char *s, size_t len, const char *filename)
          && pre_game_id[1] == 'K'
          && pre_game_id[2] == '-')
    {
-      if (     check_suffix_50[0] == '5' 
+      if (     check_suffix_50[0] == '5'
             && check_suffix_50[1] == '0')
       {
          strncpy(lgame_id, &pre_game_id[3], 4);
@@ -640,7 +770,7 @@ int detect_sat_game(intfstream_t *fd, char *s, size_t len, const char *filename)
       case 'E':
          strncpy(lgame_id, &raw_game_id[0], 2);
          lgame_id[2] = '\0';
-         if (     !strcmp(check_suffix_5, "-5") 
+         if (     !strcmp(check_suffix_5, "-5")
                || !strcmp(check_suffix_50, "50"))
          {
             strncpy(rgame_id, &raw_game_id[2], length - 4);
@@ -873,7 +1003,7 @@ int detect_wii_game(intfstream_t *fd, char *s, size_t len, const char *filename)
 
    if (intfstream_read(fd, raw_game_id, 6) <= 0)
       return false;
-   
+
    if (string_is_equal_fast(raw_game_id, "WBFS", STRLEN_CONST("WBFS")))
    {
       if (intfstream_seek(fd, 0x0200, SEEK_SET) < 0)
@@ -934,15 +1064,15 @@ static int detect_serial_ascii_game(intfstream_t *fd, char *s, size_t len)
          for (i = 0; i < 15; i++)
          {
             /* Is the given character ASCII? A-Z, 0-9, - */
-            if (  (s[i] == 45) || 
-                  (s[i] >= 48 && s[i] <= 57) || 
+            if (  (s[i] == 45) ||
+                  (s[i] >= 48 && s[i] <= 57) ||
                   (s[i] >= 65 && s[i] <= 90))
                number_of_ascii++;
             else
                break;
          }
 
-         /* If the length of the text is between 3 and 9 characters, 
+         /* If the length of the text is between 3 and 9 characters,
           * it could be a serial. */
          if (number_of_ascii > 3 && number_of_ascii < 9)
          {

--- a/tasks/task_database_cue.h
+++ b/tasks/task_database_cue.h
@@ -28,6 +28,8 @@ struct magic_entry
 
 int detect_ps1_game(intfstream_t *fd, char *s, size_t len,
       const char *filename);
+int detect_ps2_game(intfstream_t *fd, char *s, size_t len,
+      const char *filename);
 int detect_psp_game(intfstream_t *fd, char *s, size_t len,
       const char *filename);
 int detect_gc_game(intfstream_t *fd, char *s, size_t len,
@@ -45,11 +47,11 @@ int detect_system(intfstream_t *fd, const char **system_name,
 int cue_find_track(const char *cue_path, bool first, uint64_t *offset,
       uint64_t *size, char *track_path, uint64_t max_len);
 bool cue_next_file(intfstream_t *fd, const char *cue_path,
-       char *s, uint64_t len);
+      char *s, uint64_t len);
 int gdi_find_track(const char *gdi_path, bool first, char *track_path,
       uint64_t max_len);
 bool gdi_next_file(intfstream_t *fd, const char *gdi_path, char *path,
-       uint64_t max_len);
+      uint64_t max_len);
 
 RETRO_END_DECLS
 


### PR DESCRIPTION
reworked ps1 magic numbers
PS1 scan: fixed not scanned LSP titles, added PSX.EXE titles, extended ps1 serial variations

## Description

PS1 and PS2 titles share similar structures so it is a bit tricky to differentiate them. Currently, the database checks Primary Volume Descriptor System Identifier if it matches `PLAYSTATION`. Details on PS1 image structure here: https://psx-spx.consoledev.net/cdromdrive/#primary-volume-descriptor-sector-16-on-psx-disks The problem is that PS2 CD games share the same Primary Volume Descriptor, so this check will also detect all PS2 CD games. To differentiate between PS1 and PS2 CD games we can use the fact that PS1 games must have a license string in Sector 4 (https://psx-spx.consoledev.net/cdromdrive/#system-area-prior-to-volume-descriptors). While PS2 games must have PS2LOGO in the first 12 sectors.
So for detecting the PS1 games it is safe to check some parts of the license string in sector 4. If that check fails, we can check Primary Volume Descriptor System Identifier.
For detecting PS2 DVD games the check is the same (Primary Volume Descriptor System Identifier = `PLAYSTATION`), but DVD games have different sector sizes, so the offset will be different. Currently, this check incorrectly detects all PS2 ISO games as PS1 games, this pr will fix it.

PS1 scanning function fixed. All LSP- titles were ignored, cause they were placed in the incorrect if-else block. This PR fixes it. Also, some PS1 games don't have valid serial, but they have instead PSX.EXE, so it is safe to assume that, if we have PSX.EXE on the disk, then it is a PS1 title. Extended possible serial variations for PS1 (based on RDB for PS1).

Also, added a function for scanning PS2 serial. It is similar to the PS1 function but involves many more possible serial variations. Also, it uses a bigger ROM chunk, cause the ISO sector size is larger and the file list is placed at a higher offset.

## Related Issues

#13245, #11177 (should work now as PSX.EXE should be recognized), #7404 should already be resolved with the previous changes to the database scan

## Related Pull Requests


## Reviewers

