### PR TITLE
Fixed macOS keyboard bindings in game focus mode.

### DIFF
--- a/input/drivers/cocoa_input.c
+++ b/input/drivers/cocoa_input.c
@@ -424,8 +424,10 @@ static int16_t cocoa_input_state(
          if (binds[port][id].valid)
          {
             if (id < RARCH_BIND_LIST_END)
-               if (apple_key_state[rarch_keysym_lut[binds[port][id].key]])
-                  return 1;
+               if (!keyboard_mapping_blocked || (id == RARCH_GAME_FOCUS_TOGGLE))
+                  if (apple_key_state[rarch_keysym_lut[binds[port][id].key]])
+                     return 1;
+
          }
          break;
       case RETRO_DEVICE_ANALOG:


### PR DESCRIPTION
In the game focus mode the keyboard should not be remapped with the exception that when a key is used for toggling the game focus mode it should still be remapped.
