### PR TITLE
RetroArch for Android Java changes to allow for sideloading cores, accepting permissions, and running content all in a single launch

### DIFF
--- a/pkg/android/phoenix/src/com/retroarch/browser/mainmenu/MainMenuActivity.java
+++ b/pkg/android/phoenix/src/com/retroarch/browser/mainmenu/MainMenuActivity.java
@@ -122,11 +122,11 @@ public final class MainMenuActivity extends PreferenceActivity
 
 		startRetroActivity(
 				retro,
-				null,
-				prefs.getString("libretro_path", getApplicationInfo().dataDir + "/cores/"),
-				UserPreferences.getDefaultConfigPath(this),
-				Settings.Secure.getString(getContentResolver(), Settings.Secure.DEFAULT_INPUT_METHOD),
-				getApplicationInfo().dataDir,
+				getIntent().getStringExtra("ROM"),
+				getIntent().getStringExtra("LIBRETRO") != null ? getIntent().getStringExtra("LIBRETRO") : prefs.getString("libretro_path", getApplicationInfo().dataDir + "/cores/"),
+				getIntent().getStringExtra("CONFIGFILE") != null ? getIntent().getStringExtra("CONFIGFILE") : UserPreferences.getDefaultConfigPath(this),
+				getIntent().getStringExtra("IME") != null ? getIntent().getStringExtra("IME") : Settings.Secure.getString(getContentResolver(), Settings.Secure.DEFAULT_INPUT_METHOD),
+				getIntent().getStringExtra("DATADIR") != null ? getIntent().getStringExtra("DATADIR") : getApplicationInfo().dataDir,
 				getApplicationInfo().sourceDir);
 		startActivity(retro);
 		finish();

--- a/pkg/android/phoenix/src/com/retroarch/browser/retroactivity/RetroActivityFuture.java
+++ b/pkg/android/phoenix/src/com/retroarch/browser/retroactivity/RetroActivityFuture.java
@@ -98,7 +98,7 @@ public final class RetroActivityFuture extends RetroActivityCamera {
 
     File destination = new File(coresFolder, providedCoreFile.getName());
 
-    if (destination.getAbsolutePath() == providedCoreFile.getAbsolutePath()){
+    if (destination.getAbsolutePath().equals(providedCoreFile.getAbsolutePath())){
       // Nothing needs to be done if the provided core path is already in the correct folder
       return;
     }

--- a/pkg/android/phoenix/src/com/retroarch/browser/retroactivity/RetroActivityFuture.java
+++ b/pkg/android/phoenix/src/com/retroarch/browser/retroactivity/RetroActivityFuture.java
@@ -93,7 +93,7 @@ public final class RetroActivityFuture extends RetroActivityCamera {
     if (!coresFolder.exists())
       coresFolder.mkdirs();
 
-    if (!providedCoreFile.exists())
+    if (!providedCoreFile.exists() || providedCoreFile.isDirectory())
         return;
 
     File destination = new File(coresFolder, providedCoreFile.getName());

--- a/pkg/android/phoenix/src/com/retroarch/browser/retroactivity/RetroActivityFuture.java
+++ b/pkg/android/phoenix/src/com/retroarch/browser/retroactivity/RetroActivityFuture.java
@@ -5,7 +5,9 @@ import android.view.View;
 import android.view.WindowManager;
 import android.content.Intent;
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.hardware.input.InputManager;
+import android.Manifest;
 import android.os.Build;
 import android.os.Bundle;
 import com.retroarch.browser.preferences.util.ConfigFile;
@@ -19,14 +21,61 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.List;
+import java.util.ArrayList;
 
 public final class RetroActivityFuture extends RetroActivityCamera {
 
   // If set to true then Retroarch will completely exit when it loses focus
   private boolean quitfocus = false;
 
+  private boolean addPermission(List<String> permissionsList, String permission)
+  {
+     if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M)
+     {
+        if (checkSelfPermission(permission) != PackageManager.PERMISSION_GRANTED)
+        {
+           permissionsList.add(permission);
+
+           // Check for Rationale Option
+           if (!shouldShowRequestPermissionRationale(permission))
+              return false;
+        }
+     }
+
+     return true;
+  }
+
   @Override
   public void onCreate(Bundle savedInstanceState) {
+
+   if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M)
+   {
+      // Android 6.0+ needs runtime permission checks
+      List<String> permissionsNeeded = new ArrayList<String>();
+      final List<String> permissionsList = new ArrayList<String>();
+
+      if (!addPermission(permissionsList, Manifest.permission.READ_EXTERNAL_STORAGE))
+         permissionsNeeded.add("Read External Storage");
+      if (!addPermission(permissionsList, Manifest.permission.WRITE_EXTERNAL_STORAGE))
+         permissionsNeeded.add("Write External Storage");
+
+      if (permissionsList.size() > 0)
+      {
+         // We have permissions that have not yet been approved, so we need to close this activity and switch to MainMenuActivity instead
+         Intent intent = new Intent(this, com.retroarch.browser.mainmenu.MainMenuActivity.class);
+         intent.putExtra("ROM", getIntent().getStringExtra("ROM"));
+         intent.putExtra("LIBRETRO", getIntent().getStringExtra("LIBRETRO"));
+         intent.putExtra("CONFIGFILE", getIntent().getStringExtra("CONFIGFILE"));
+         intent.putExtra("QUITFOCUS", getIntent().getStringExtra("QUITFOCUS"));
+         intent.putExtra("IME", getIntent().getStringExtra("IME"));
+         intent.putExtra("DATADIR", getIntent().getStringExtra("DATADIR"));
+         startActivity(intent);
+         finish();
+         return;
+      }
+   }
+
     super.onCreate(savedInstanceState);
 
     Intent retro = getIntent();


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

These changes allow for launchers/frontends (on Android only) to download a core from libretro's buildbot directly and have it be sideloaded (copied into the RetroArch cores folder) at runtime. This was implemented in order to allow for LaunchBox on Android to auto-install the sideloaded version of RetroArch and provide any necessary cores from libretro directly, greatly simplifying the process of setting up a platform for users.

These changes also allow for accepting permissions and launching a game/content all in the same launch. Previously, RetroArch for Android had to be started up at least once without content in order to be successfully launched into a game from a frontend.

## Related Issues

None

## Related Pull Requests

None

## Reviewers

Been working with @hunterk over Discord. Many thanks for his assistance and pushes in the right direction.

Also, FYI. If needed in the future, I can provide assistance with Java code on Android since I'm in it already at this point. :)
