### PR TITLE
Improve widget appearance with missing assets

### DIFF
--- a/gfx/gfx_widgets.c
+++ b/gfx/gfx_widgets.c
@@ -860,7 +860,7 @@ static void gfx_widgets_layout(
    }
    else
    {
-      p_dispwidget->msg_queue_icon_size_x         = 0;
+      p_dispwidget->msg_queue_icon_size_x         = p_dispwidget->simple_widget_padding * 1.5f;
       p_dispwidget->msg_queue_icon_size_y         = 0;
    }
 
@@ -1400,7 +1400,7 @@ static void gfx_widgets_draw_regular_msg(
 
    /* Background */
    bar_width  = p_dispwidget->simple_widget_padding + msg->width + p_dispwidget->msg_queue_icon_size_x;
-   bar_margin = p_dispwidget->msg_queue_icon_size_x * 0.04f;
+   bar_margin = p_dispwidget->simple_widget_padding * 0.15f;
 
    gfx_display_draw_quad(
          p_disp,


### PR DESCRIPTION
## Description

Tiny tweaks for more graceful operation when info icon asset is missing.

Before:
![retroarch_2022_11_04_00_32_39_739](https://user-images.githubusercontent.com/45124675/199849839-fa9071c9-756d-410c-a2d7-3f2e9e6fa96f.png)

After:
![retroarch_2022_11_04_00_43_14_682](https://user-images.githubusercontent.com/45124675/199849852-4ad69432-2624-47e1-a04f-41e9e2e1bd3d.png)

Asset available:
![retroarch_2022_11_04_00_40_44_326](https://user-images.githubusercontent.com/45124675/199849797-006e6259-44c9-42da-9b44-1242cae598cd.png)

