### PR TITLE
Overlays: Add 'reach' and 'exclusive' for hitboxes

### DIFF
--- a/input/input_overlay.h
+++ b/input/input_overlay.h
@@ -144,8 +144,7 @@ struct overlay_desc
    enum overlay_hitbox hitbox;
    enum overlay_type type;
 
-   bool updated;
-   bool movable;
+   uint16_t updated;  /* one bit per pointer */
 
    unsigned next_index;
    unsigned image_index;
@@ -166,6 +165,21 @@ struct overlay_desc
     * will be equal to x/y */
    float x_shift;
    float y_shift;
+
+   /* These values are used only for hitbox
+    * detection. A hitbox can be stretched in
+    * any direction(s) by its 'reach' values */
+   float x_hitbox;
+   float y_hitbox;
+   float range_x_hitbox, range_y_hitbox;
+   float reach_right, reach_left, reach_up, reach_down;
+
+   /* If true, blocks input from overlapped hitboxes */
+   bool exclusive;
+   /* Similar, but only applies after range_mod takes affect */
+   bool range_mod_exclusive;
+
+   bool movable;
 
    /* This is a retro_key value for keyboards */
    unsigned retro_key_idx;
@@ -332,7 +346,7 @@ void input_overlay_auto_rotate_(
 void input_overlay_poll(
       input_overlay_t *ol,
       input_overlay_state_t *out,
-      int16_t norm_x, int16_t norm_y, float touch_scale);
+      unsigned ptr_idx, int16_t norm_x, int16_t norm_y, float touch_scale);
 
 /**
  * input_overlay_poll_clear:

--- a/tasks/task_overlay.c
+++ b/tasks/task_overlay.c
@@ -232,11 +232,12 @@ static bool task_overlay_load_desc(
       bool normalized, float alpha_mod, float range_mod)
 {
    float width_mod, height_mod;
-   char conf_key[32];
+   char conf_key[64];
    char overlay_desc_key[32];
    char overlay_desc_normalized_key[32];
    char overlay[256];
    float tmp_float                      = 0.0f;
+   int tmp_int                          = 0;
    bool tmp_bool                        = false;
    bool ret                             = true;
    bool by_pixel                        = false;
@@ -403,6 +404,46 @@ static bool task_overlay_load_desc(
    desc->range_x = (float)strtod(list.elems[4].data, NULL) * width_mod;
    desc->range_y = (float)strtod(list.elems[5].data, NULL) * height_mod;
 
+   snprintf(conf_key, sizeof(conf_key),
+         "overlay%u_desc%u_reach_right", ol_idx, desc_idx);
+   desc->reach_right = 1.0f;
+   if (config_get_float(conf, conf_key, &tmp_float))
+      desc->reach_right = tmp_float;
+
+   snprintf(conf_key, sizeof(conf_key),
+         "overlay%u_desc%u_reach_left", ol_idx, desc_idx);
+   desc->reach_left = 1.0f;
+   if (config_get_float(conf, conf_key, &tmp_float))
+      desc->reach_left = tmp_float;
+
+   snprintf(conf_key, sizeof(conf_key),
+         "overlay%u_desc%u_reach_up", ol_idx, desc_idx);
+   desc->reach_up = 1.0f;
+   if (config_get_float(conf, conf_key, &tmp_float))
+      desc->reach_up = tmp_float;
+
+   snprintf(conf_key, sizeof(conf_key),
+         "overlay%u_desc%u_reach_down", ol_idx, desc_idx);
+   desc->reach_down = 1.0f;
+   if (config_get_float(conf, conf_key, &tmp_float))
+      desc->reach_down = tmp_float;
+
+   snprintf(conf_key, sizeof(conf_key),
+         "overlay%u_desc%u_reach_x", ol_idx, desc_idx);
+   if (config_get_float(conf, conf_key, &tmp_float))
+   {
+      desc->reach_right = tmp_float;
+      desc->reach_left  = tmp_float;
+   }
+
+   snprintf(conf_key, sizeof(conf_key),
+         "overlay%u_desc%u_reach_y", ol_idx, desc_idx);
+   if (config_get_float(conf, conf_key, &tmp_float))
+   {
+      desc->reach_up   = tmp_float;
+      desc->reach_down = tmp_float;
+   }
+
    desc->mod_x   = desc->x - desc->range_x;
    desc->mod_w   = 2.0f * desc->range_x;
    desc->mod_y   = desc->y - desc->range_y;
@@ -421,6 +462,16 @@ static bool task_overlay_load_desc(
       desc->range_mod = tmp_float;
 
    snprintf(conf_key, sizeof(conf_key),
+         "overlay%u_desc%u_exclusive", ol_idx, desc_idx);
+   desc->exclusive = false;
+   config_get_bool(conf, conf_key, &desc->exclusive);
+
+   snprintf(conf_key, sizeof(conf_key),
+         "overlay%u_desc%u_range_mod_exclusive", ol_idx, desc_idx);
+   desc->range_mod_exclusive = false;
+   config_get_bool(conf, conf_key, &desc->range_mod_exclusive);
+
+   snprintf(conf_key, sizeof(conf_key),
          "overlay%u_desc%u_movable", ol_idx, desc_idx);
    desc->movable     = false;
    desc->delta_x     = 0.0f;
@@ -428,9 +479,6 @@ static bool task_overlay_load_desc(
 
    if (config_get_bool(conf, conf_key, &tmp_bool))
       desc->movable = tmp_bool;
-
-   desc->range_x_mod = desc->range_x;
-   desc->range_y_mod = desc->range_y;
 
    input_overlay->pos ++;
 


### PR DESCRIPTION
## Description

These allow stretching (or shrinking) hitboxes and handling their overlap. Does not affect image, analog range, or analog/eightway center.

### Hitbox Reach
reach_up, reach_down, reach_left, reach_right:
- Stretches hitbox in one direction:

reach_x, reach_y
- Stretches hitbox symmetrically

E.g. In the overlay cfg, this creates a D-Pad area and extends its hitbox left & right 50%, up 15%, and down 30%:

    overlay0_desc0 = "dpad_area,0.15,0.57,rect,0.166228,0.295516"
    overlay0_desc0_reach_x = 1.5
    overlay0_desc0_reach_up = 1.15
    overlay0_desc0_reach_down = 1.3

### Exclusive Hitboxes
exclusive:
- If true, blocks input from overlapped hitboxes

range_mod_exclusive:
- Similar, but only applies when this hitbox is extended by range_mod
- After range_mod takes effect, has priority over 'exclusive'

E.g.

    overlay0_desc0_exclusive = true
    overlay0_desc1_range_mod_exclusive = true

Expected use cases:
- A 'range_mod_exclusive' hitbox placed close enough to other hitboxes that its range_mod value would otherwise cause unwanted overlap.
- A smaller 'exclusive' hitbox placed inside (or partially inside) a larger one; the smaller hitbox would "carve out" space for itself.
- A combination of the two: A smaller 'exclusive' hitbox carves out space for itself, but the larger hitbox has 'range_mod_exclusive'. Whichever is hit first effectively has priority.

## Related Pull Requests

libretro/common-overlays#86

## Reviewers

@LibretroAdmin 
