### PR TITLE
(XInput) Ensure disconnection notification

### DIFF
--- a/input/drivers_joypad/xinput_hybrid_joypad.c
+++ b/input/drivers_joypad/xinput_hybrid_joypad.c
@@ -487,37 +487,6 @@ static bool xinput_joypad_query_pad(unsigned pad)
    return dinput_joypad_query_pad(pad);
 }
 
-static void xinput_joypad_destroy(void)
-{
-   unsigned i;
-
-   for (i = 0; i < 4; ++i)
-   {
-      g_xinput_states[i].xstate.dwPacketNumber        = 0;
-      g_xinput_states[i].xstate.Gamepad.wButtons      = 0;
-      g_xinput_states[i].xstate.Gamepad.bLeftTrigger  = 0;
-      g_xinput_states[i].xstate.Gamepad.bRightTrigger = 0;
-      g_xinput_states[i].xstate.Gamepad.sThumbLX      = 0;
-      g_xinput_states[i].xstate.Gamepad.sThumbLY      = 0;
-      g_xinput_states[i].xstate.Gamepad.sThumbRX      = 0;
-      g_xinput_states[i].xstate.Gamepad.sThumbRY      = 0;
-      g_xinput_states[i].connected                    = false;
-   }
-
-#if defined(HAVE_DYNAMIC) && !defined(__WINRT__)
-   dylib_close(g_xinput_dll);
-
-   g_xinput_dll        = NULL;
-#endif
-   g_XInputGetStateEx  = NULL;
-   g_XInputSetState    = NULL;
-
-   dinput_joypad_destroy();
-
-   g_xinput_block_pads = false;
-}
-
-
 static int32_t xinput_joypad_button(unsigned port, uint16_t joykey)
 {
    int xuser                  = PAD_INDEX_TO_XUSER_INDEX(port);
@@ -684,6 +653,40 @@ static bool xinput_joypad_rumble(unsigned pad,
    return (g_XInputSetState(xuser, &g_xinput_rumble_states[xuser])
       == 0);
 }
+
+static void xinput_joypad_destroy(void)
+{
+   unsigned i;
+
+   /* Run poll one last time in order to detect disconnections */
+   xinput_joypad_poll();
+
+   for (i = 0; i < 4; ++i)
+   {
+      g_xinput_states[i].xstate.dwPacketNumber        = 0;
+      g_xinput_states[i].xstate.Gamepad.wButtons      = 0;
+      g_xinput_states[i].xstate.Gamepad.bLeftTrigger  = 0;
+      g_xinput_states[i].xstate.Gamepad.bRightTrigger = 0;
+      g_xinput_states[i].xstate.Gamepad.sThumbLX      = 0;
+      g_xinput_states[i].xstate.Gamepad.sThumbLY      = 0;
+      g_xinput_states[i].xstate.Gamepad.sThumbRX      = 0;
+      g_xinput_states[i].xstate.Gamepad.sThumbRY      = 0;
+      g_xinput_states[i].connected                    = false;
+   }
+
+#if defined(HAVE_DYNAMIC) && !defined(__WINRT__)
+   dylib_close(g_xinput_dll);
+
+   g_xinput_dll        = NULL;
+#endif
+   g_XInputGetStateEx  = NULL;
+   g_XInputSetState    = NULL;
+
+   dinput_joypad_destroy();
+
+   g_xinput_block_pads = false;
+}
+
 
 input_device_driver_t xinput_joypad = {
    xinput_joypad_init,

--- a/input/drivers_joypad/xinput_joypad.c
+++ b/input/drivers_joypad/xinput_joypad.c
@@ -246,33 +246,6 @@ static bool xinput_joypad_query_pad(unsigned pad)
    return false;
 }
 
-static void xinput_joypad_destroy(void)
-{
-   unsigned i;
-
-   for (i = 0; i < 4; ++i)
-   {
-      g_xinput_states[i].xstate.dwPacketNumber        = 0;
-      g_xinput_states[i].xstate.Gamepad.wButtons      = 0;
-      g_xinput_states[i].xstate.Gamepad.bLeftTrigger  = 0;
-      g_xinput_states[i].xstate.Gamepad.bRightTrigger = 0;
-      g_xinput_states[i].xstate.Gamepad.sThumbLX      = 0;
-      g_xinput_states[i].xstate.Gamepad.sThumbLY      = 0;
-      g_xinput_states[i].xstate.Gamepad.sThumbRX      = 0;
-      g_xinput_states[i].xstate.Gamepad.sThumbRY      = 0;
-      g_xinput_states[i].connected                    = false;
-   }
-
-#if defined(HAVE_DYNAMIC) && !defined(__WINRT__)
-   dylib_close(g_xinput_dll);
-
-   g_xinput_dll        = NULL;
-#endif
-   g_XInputGetStateEx  = NULL;
-   g_XInputSetState    = NULL;
-}
-
-
 static int32_t xinput_joypad_button(unsigned port, uint16_t joykey)
 {
    int xuser                  = pad_index_to_xuser_index(port);
@@ -383,6 +356,35 @@ static bool xinput_joypad_rumble(unsigned pad,
 
    return (g_XInputSetState(xuser, &g_xinput_rumble_states[xuser])
       == 0);
+}
+
+static void xinput_joypad_destroy(void)
+{
+   unsigned i;
+
+   /* Run poll one last time in order to detect disconnections */
+   xinput_joypad_poll();
+
+   for (i = 0; i < 4; ++i)
+   {
+      g_xinput_states[i].xstate.dwPacketNumber        = 0;
+      g_xinput_states[i].xstate.Gamepad.wButtons      = 0;
+      g_xinput_states[i].xstate.Gamepad.bLeftTrigger  = 0;
+      g_xinput_states[i].xstate.Gamepad.bRightTrigger = 0;
+      g_xinput_states[i].xstate.Gamepad.sThumbLX      = 0;
+      g_xinput_states[i].xstate.Gamepad.sThumbLY      = 0;
+      g_xinput_states[i].xstate.Gamepad.sThumbRX      = 0;
+      g_xinput_states[i].xstate.Gamepad.sThumbRY      = 0;
+      g_xinput_states[i].connected                    = false;
+   }
+
+#if defined(HAVE_DYNAMIC) && !defined(__WINRT__)
+   dylib_close(g_xinput_dll);
+
+   g_xinput_dll        = NULL;
+#endif
+   g_XInputGetStateEx  = NULL;
+   g_XInputSetState    = NULL;
 }
 
 input_device_driver_t xinput_joypad = {

--- a/input/drivers_joypad/xinput_joypad_inl.h
+++ b/input/drivers_joypad/xinput_joypad_inl.h
@@ -44,7 +44,7 @@ static bool load_xinput_dll(void)
 
    if (!g_xinput_dll)
    {
-      RARCH_ERR("[XInput]: Failed to load XInput, ensure DirectX and controller drivers are up to date.\n");
+      RARCH_ERR("[XInput]: Failed to load XInput. Ensure DirectX and controller drivers are up to date.\n");
       return false;
    }
 

--- a/tasks/task_autodetect.c
+++ b/tasks/task_autodetect.c
@@ -872,6 +872,7 @@ bool input_autoconfigure_disconnect(unsigned port, const char *name)
    autoconfig_handle_t *autoconfig_handle = NULL;
    task_finder_data_t find_data;
    settings_t *settings                   = config_get_ptr();
+   input_driver_state_t *input_st         = input_state_get_ptr();
    bool notification_show_autoconfig      = settings ?
          settings->bools.notification_show_autoconfig : true;
 
@@ -896,7 +897,13 @@ bool input_autoconfigure_disconnect(unsigned port, const char *name)
    if (!notification_show_autoconfig)
       autoconfig_handle->flags |= AUTOCONF_FLAG_SUPPRESS_NOTIFICATIONS;
 
-   if (!string_is_empty(name))
+   /* Use display_name as name instead since autoconfig display_name
+    * is destroyed already, and real name does not matter at this point */
+   if (input_st && !string_is_empty(input_st->input_device_info[port].display_name))
+      strlcpy(autoconfig_handle->device_info.name,
+            input_st->input_device_info[port].display_name,
+            sizeof(autoconfig_handle->device_info.name));
+   else if (!string_is_empty(name))
       strlcpy(autoconfig_handle->device_info.name,
             name, sizeof(autoconfig_handle->device_info.name));
 


### PR DESCRIPTION
## Description

Currently autoconf disconnect notification is triggered in `xinput_joypad_poll()`, but poll isn't reliably called anymore after removing the controller battery etc, but `xinput_joypad_destroy()` is. Therefore run poll once at the start of destroy to see the notification. I moved the destroy function below poll in order to avoid adding extra declarations.

Also changed the disconnect notification to show autoconf `display_name` if available, since connect message prefers that too. Maybe there is a better way to achieve that than this.
