### PR TITLE
Prevent video filter init if game is not running

### DIFF
--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -3284,7 +3284,9 @@ bool video_driver_init_internal(bool *video_is_threaded, bool verbosity_enabled)
 #ifdef HAVE_VIDEO_FILTER
    const char *path_softfilter_plugin     = settings->paths.path_softfilter_plugin;
 
-   if (!string_is_empty(path_softfilter_plugin))
+   /* Init video filter only when game is running */
+   if ((runloop_st->current_core.flags & RETRO_CORE_FLAG_GAME_LOADED) &&
+         !string_is_empty(path_softfilter_plugin))
       video_driver_init_filter(video_driver_pix_fmt, settings);
 #endif
 


### PR DESCRIPTION
## Description

Currently for some reason dll versions of Blargg filters will crash at least on my system no matter what, and if the config has a crashing `video_filter` set, there is no way to remove it without editing the config by hand, because the filter will init at startup even when there is no core running. 

This additional check at least allows the user to remove the filter via the menu. Even though the config should not even be saved when trying to apply the filter because of the crash, but somehow I managed to brick the config. Non-crashing filters don't seem to mind the check, so I guess it is safe.

More testing would be nice regardless.
