### PR TITLE
(Ozone) Fixes, nits and cleanups

### DIFF
--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -36,7 +36,7 @@
 #include "../../config.def.h"
 #include "../../file_path_special.h"
 
-#if 0
+#ifdef HAVE_DISCORD_OWN_AVATAR
 #include "../../discord/discord.h"
 #endif
 
@@ -59,62 +59,62 @@
 #include "../../content.h"
 #include "../../core_info.h"
 
-#define ANIMATION_PUSH_ENTRY_DURATION  166
-#define ANIMATION_CURSOR_DURATION      133
-#define ANIMATION_CURSOR_PULSE         500
+#define ANIMATION_PUSH_ENTRY_DURATION 166
+#define ANIMATION_CURSOR_DURATION     133
+#define ANIMATION_CURSOR_PULSE        500
 
-#define OZONE_THUMBNAIL_STREAM_DELAY   5 * 16.66667f
+#define OZONE_THUMBNAIL_STREAM_DELAY  5 * 16.66667f
 
-#define FONT_SIZE_FOOTER            18
-#define FONT_SIZE_TITLE             36
-#define FONT_SIZE_TIME              22
-#define FONT_SIZE_ENTRIES_LABEL     24
-#define FONT_SIZE_ENTRIES_SUBLABEL  18
-#define FONT_SIZE_SIDEBAR           24
+#define FONT_SIZE_FOOTER              18
+#define FONT_SIZE_TITLE               36
+#define FONT_SIZE_TIME                22
+#define FONT_SIZE_ENTRIES_LABEL       24
+#define FONT_SIZE_ENTRIES_SUBLABEL    18
+#define FONT_SIZE_SIDEBAR             24
 
-#define HEADER_HEIGHT 87
-#define FOOTER_HEIGHT 78
+#define HEADER_HEIGHT                 87
+#define FOOTER_HEIGHT                 78
 
-#define ENTRY_PADDING_HORIZONTAL_HALF  40
-#define ENTRY_PADDING_HORIZONTAL_FULL  140
-#define ENTRY_PADDING_VERTICAL         20
-#define ENTRY_HEIGHT                   50
-#define ENTRY_SPACING                  8
-#define ENTRY_ICON_SIZE                46
-#define ENTRY_ICON_PADDING             15
+#define ENTRY_PADDING_HORIZONTAL_HALF 40
+#define ENTRY_PADDING_HORIZONTAL_FULL 140
+#define ENTRY_PADDING_VERTICAL        20
+#define ENTRY_HEIGHT                  50
+#define ENTRY_SPACING                 8
+#define ENTRY_ICON_SIZE               46
+#define ENTRY_ICON_PADDING            15
 
 /* > 'SIDEBAR_WIDTH' must be kept in sync with
  *   menu driver metrics */
-#define SIDEBAR_WIDTH               408
-#define SIDEBAR_X_PADDING           40
-#define SIDEBAR_Y_PADDING           20
-#define SIDEBAR_ENTRY_HEIGHT        50
-#define SIDEBAR_ENTRY_Y_PADDING     10
-#define SIDEBAR_ENTRY_ICON_SIZE     46
-#define SIDEBAR_ENTRY_ICON_PADDING  15
-#define SIDEBAR_GRADIENT_HEIGHT     28
+#define SIDEBAR_WIDTH                 408
+#define SIDEBAR_X_PADDING             40
+#define SIDEBAR_Y_PADDING             20
+#define SIDEBAR_ENTRY_HEIGHT          50
+#define SIDEBAR_ENTRY_Y_PADDING       10
+#define SIDEBAR_ENTRY_ICON_SIZE       46
+#define SIDEBAR_ENTRY_ICON_PADDING    15
+#define SIDEBAR_GRADIENT_HEIGHT       28
 
-#define FULLSCREEN_THUMBNAIL_PADDING 32
+#define FULLSCREEN_THUMBNAIL_PADDING  32
 
-#define CURSOR_SIZE 64
+#define CURSOR_SIZE                   64
 /* Cursor becomes active when it moves more
  * than CURSOR_ACTIVE_DELTA pixels (adjusted
  * by current scale factor) */
-#define CURSOR_ACTIVE_DELTA 3
+#define CURSOR_ACTIVE_DELTA           3
 
-#define INTERVAL_OSK_CURSOR            (0.5f * 1000000)
+#define INTERVAL_OSK_CURSOR           (0.5f * 1000000)
 
 #if defined(__APPLE__)
 /* UTF-8 support is currently broken on Apple devices... */
-#define OZONE_TICKER_SPACER "   |   "
+#define OZONE_TICKER_SPACER           "   |   "
 #else
 /* <EM SPACE><BULLET><EM SPACE>
  * UCN equivalent: "\u2003\u2022\u2003" */
-#define OZONE_TICKER_SPACER "\xE2\x80\x83\xE2\x80\xA2\xE2\x80\x83"
+#define OZONE_TICKER_SPACER           "\xE2\x80\x83\xE2\x80\xA2\xE2\x80\x83"
 #endif
 
-#define OZONE_WIGGLE_DURATION 15
-#define OZONE_TAB_MAX_LENGTH 255
+#define OZONE_WIGGLE_DURATION         15
+#define OZONE_TAB_MAX_LENGTH          255
 
 /* Returns true if specified entry is currently
  * displayed on screen */
@@ -158,7 +158,7 @@ enum OZONE_TEXTURE
 {
    OZONE_TEXTURE_RETROARCH = 0,
    OZONE_TEXTURE_CURSOR_BORDER,
-#if 0
+#ifdef HAVE_DISCORD_OWN_AVATAR
    OZONE_TEXTURE_DISCORD_OWN_AVATAR,
 #endif
    OZONE_TEXTURE_LAST
@@ -793,7 +793,7 @@ static float ozone_sidebar_gradient_bottom_solarized_light[16]        = {
 };
 
 static float ozone_sidebar_background_gray[16]                        = 
-COLOR_HEX_TO_FLOAT(0x101010, 0.0f);
+   COLOR_HEX_TO_FLOAT(0x101010, 0.0f);
 
 static float ozone_sidebar_background_light[16]                       = {
    0.94f, 0.94f, 0.94f, 1.00f,
@@ -873,7 +873,7 @@ static float ozone_sidebar_background_purple_rain[16] = {
 };
 
 static float ozone_background_libretro_running_gray[16]               = 
-COLOR_HEX_TO_FLOAT(0x101010, 1.0f);
+   COLOR_HEX_TO_FLOAT(0x101010, 1.0f);
 
 static float ozone_background_libretro_running_light[16]              = {
    0.690f, 0.690f, 0.690f, 0.75f,
@@ -1498,6 +1498,7 @@ static float ozone_last_framebuffer_opacity = -1.0f;
 
 /* Forward declarations */
 static void ozone_cursor_animation_cb(void *userdata);
+static void ozone_selection_changed(ozone_handle_t *ozone, bool allow_animation);
 
 static INLINE uint8_t ozone_count_lines(const char *str)
 {
@@ -1510,7 +1511,8 @@ static INLINE uint8_t ozone_count_lines(const char *str)
 }
 
 static void ozone_animate_cursor(ozone_handle_t *ozone,
-      float *dst, float *target)
+      float *dst,
+      float *target)
 {
    int i;
    gfx_animation_ctx_entry_t entry;
@@ -1552,8 +1554,7 @@ static void ozone_cursor_animation_cb(void *userdata)
          break;
    }
 
-   ozone->theme_dynamic_cursor_state = 
-      (ozone->theme_dynamic_cursor_state + 1) % 2;
+   ozone->theme_dynamic_cursor_state = (ozone->theme_dynamic_cursor_state + 1) % 2;
 
    ozone_animate_cursor(ozone, ozone->theme_dynamic.cursor_border, target);
 }
@@ -1573,7 +1574,9 @@ static void ozone_restart_cursor_animation(ozone_handle_t *ozone)
          ozone->theme->cursor_border_1);
 }
 
-static void ozone_set_color_theme(ozone_handle_t *ozone, unsigned color_theme)
+static void ozone_set_color_theme(
+      ozone_handle_t *ozone,
+      unsigned color_theme)
 {
    ozone_theme_t *theme = ozone_default_theme;
 
@@ -1624,13 +1627,27 @@ static void ozone_set_color_theme(ozone_handle_t *ozone, unsigned color_theme)
 
    ozone->theme = theme;
 
-   memcpy(ozone->theme_dynamic.selection_border, ozone->theme->selection_border, sizeof(ozone->theme_dynamic.selection_border));
-   memcpy(ozone->theme_dynamic.selection, ozone->theme->selection, sizeof(ozone->theme_dynamic.selection));
-   memcpy(ozone->theme_dynamic.entries_border, ozone->theme->entries_border, sizeof(ozone->theme_dynamic.entries_border));
-   memcpy(ozone->theme_dynamic.entries_icon, ozone->theme->entries_icon, sizeof(ozone->theme_dynamic.entries_icon));
-   memcpy(ozone->theme_dynamic.entries_checkmark, ozone->pure_white, sizeof(ozone->theme_dynamic.entries_checkmark));
-   memcpy(ozone->theme_dynamic.cursor_alpha, ozone->pure_white, sizeof(ozone->theme_dynamic.cursor_alpha));
-   memcpy(ozone->theme_dynamic.message_background, ozone->theme->message_background, sizeof(ozone->theme_dynamic.message_background));
+   memcpy(ozone->theme_dynamic.selection_border,
+         ozone->theme->selection_border,
+         sizeof(ozone->theme_dynamic.selection_border));
+   memcpy(ozone->theme_dynamic.selection,
+         ozone->theme->selection,
+         sizeof(ozone->theme_dynamic.selection));
+   memcpy(ozone->theme_dynamic.entries_border,
+         ozone->theme->entries_border,
+         sizeof(ozone->theme_dynamic.entries_border));
+   memcpy(ozone->theme_dynamic.entries_icon,
+         ozone->theme->entries_icon,
+         sizeof(ozone->theme_dynamic.entries_icon));
+   memcpy(ozone->theme_dynamic.entries_checkmark,
+         ozone->pure_white,
+         sizeof(ozone->theme_dynamic.entries_checkmark));
+   memcpy(ozone->theme_dynamic.cursor_alpha,
+         ozone->pure_white,
+         sizeof(ozone->theme_dynamic.cursor_alpha));
+   memcpy(ozone->theme_dynamic.message_background,
+         ozone->theme->message_background,
+         sizeof(ozone->theme_dynamic.message_background));
 
    if (ozone->flags & OZONE_FLAG_HAS_ALL_ASSETS)
       ozone_restart_cursor_animation(ozone);
@@ -1658,12 +1675,13 @@ static unsigned ozone_get_system_theme(void)
 }
 
 static void ozone_set_background_running_opacity(
-      ozone_handle_t *ozone, float framebuffer_opacity)
+      ozone_handle_t *ozone,
+      float framebuffer_opacity)
 {
    static float background_running_alpha_top    = 1.0f;
    static float background_running_alpha_bottom = 0.75f;
    float *background                            = 
-      ozone->theme->background_libretro_running;
+         ozone->theme->background_libretro_running;
 
    /* When content is running, background is a
     * gradient that from top to bottom transitions
@@ -1673,18 +1691,18 @@ static void ozone_set_background_running_opacity(
     *   - Background top has an alpha of 1.0
     *   - Background bottom has an alpha of 0.75 */
    background_running_alpha_top                 = framebuffer_opacity / 0.9f;
-   background_running_alpha_top                 = (background_running_alpha_top > 1.0f) 
-      ?  1.0f
-      : (background_running_alpha_top < 0.0f) 
-      ?  0.0f
-      : background_running_alpha_top;
+   background_running_alpha_top                 = (background_running_alpha_top > 1.0f)
+         ?  1.0f
+         : (background_running_alpha_top < 0.0f)
+               ?  0.0f
+               : background_running_alpha_top;
 
    background_running_alpha_bottom              = (2.5f * framebuffer_opacity) - 1.5f;
-   background_running_alpha_bottom              = (background_running_alpha_bottom > 1.0f) 
-      ?  1.0f
-      : (background_running_alpha_bottom < 0.0f)
-      ?  0.0f 
-      : background_running_alpha_bottom;
+   background_running_alpha_bottom              = (background_running_alpha_bottom > 1.0f)
+         ?  1.0f
+         : (background_running_alpha_bottom < 0.0f)
+               ?  0.0f
+               : background_running_alpha_bottom;
 
    background[11]                               = background_running_alpha_top;
    background[15]                               = background_running_alpha_top;
@@ -1694,9 +1712,13 @@ static void ozone_set_background_running_opacity(
    ozone_last_framebuffer_opacity               = framebuffer_opacity;
 }
 
-static uintptr_t ozone_entries_icon_get_texture(ozone_handle_t *ozone,
-      enum msg_hash_enums enum_idx, const char *enum_path,
-      const char *enum_label, unsigned type, bool active)
+static uintptr_t ozone_entries_icon_get_texture(
+      ozone_handle_t *ozone,
+      enum msg_hash_enums enum_idx,
+      const char *enum_path,
+      const char *enum_label,
+      unsigned type,
+      bool active)
 {
    switch (enum_idx)
    {
@@ -2047,18 +2069,20 @@ static uintptr_t ozone_entries_icon_get_texture(ozone_handle_t *ozone,
       case MENU_ENUM_LABEL_EXPLORE_ITEM:
       {
          uintptr_t icon = menu_explore_get_entry_icon(type);
-         if (icon) return icon;
+         if (icon)
+            return icon;
          break;
       }
 #endif
       case MENU_ENUM_LABEL_CONTENTLESS_CORE:
       {
          uintptr_t icon = menu_contentless_cores_get_entry_icon(enum_label);
-         if (icon) return icon;
+         if (icon)
+            return icon;
          break;
       }
       default:
-            break;
+         break;
    }
 
    switch(type)
@@ -2320,7 +2344,7 @@ static uintptr_t ozone_entries_icon_get_texture(ozone_handle_t *ozone,
 
 static const char *ozone_entries_icon_texture_path(unsigned id)
 {
-switch (id)
+   switch (id)
    {
       case OZONE_ENTRIES_ICONS_TEXTURE_MAIN_MENU:
 #if defined(HAVE_LAKKA)
@@ -2603,15 +2627,21 @@ static bool ozone_reset_theme_textures(ozone_handle_t *ozone)
          continue;
 
       fill_pathname_join_special(
-         theme_path,
-         ozone->png_path,
-         theme->name,
-         sizeof(theme_path)
+            theme_path,
+            ozone->png_path,
+            theme->name,
+            sizeof(theme_path)
       );
 
       for (i = 0; i < OZONE_THEME_TEXTURE_LAST; i++)
       {
-         if (!gfx_display_reset_textures_list(OZONE_THEME_TEXTURES_FILES[i], theme_path, &theme->textures[i], TEXTURE_FILTER_MIPMAP_LINEAR, NULL, NULL))
+         if (!gfx_display_reset_textures_list(
+               OZONE_THEME_TEXTURES_FILES[i],
+               theme_path,
+               &theme->textures[i],
+               TEXTURE_FILTER_MIPMAP_LINEAR,
+               NULL,
+               NULL))
             result = false;
       }
    }
@@ -2628,35 +2658,39 @@ static void ozone_sidebar_collapse_end(void *userdata)
 
 static unsigned ozone_get_sidebar_height(ozone_handle_t *ozone)
 {
-   int entries = (int)(ozone->system_tab_end + 1 + (ozone->horizontal_list.size ));
-   return entries * ozone->dimensions.sidebar_entry_height + (entries - 1) * ozone->dimensions.sidebar_entry_padding_vertical + ozone->dimensions.sidebar_padding_vertical +
-      (ozone->horizontal_list.size > 0 ? ozone->dimensions.sidebar_entry_padding_vertical + ozone->dimensions.spacer_1px : 0);
+   int entries = (int)(ozone->system_tab_end + 1 + (ozone->horizontal_list.size));
+   return entries * ozone->dimensions.sidebar_entry_height
+         + (entries - 1) * ozone->dimensions.sidebar_entry_padding_vertical
+         + ozone->dimensions.sidebar_padding_vertical
+         + (ozone->horizontal_list.size > 0
+               ? ozone->dimensions.sidebar_entry_padding_vertical + ozone->dimensions.spacer_1px
+               : 0);
 }
 
 static unsigned ozone_get_selected_sidebar_y_position(ozone_handle_t *ozone)
 {
-   return ozone->categories_selection_ptr * ozone->dimensions.sidebar_entry_height +
-         (ozone->categories_selection_ptr - 1) * ozone->dimensions.sidebar_entry_padding_vertical + ozone->dimensions.sidebar_padding_vertical +
-         (ozone->categories_selection_ptr > ozone->system_tab_end ? ozone->dimensions.sidebar_entry_padding_vertical + ozone->dimensions.spacer_1px : 0);
+   return ozone->categories_selection_ptr * ozone->dimensions.sidebar_entry_height
+         + (ozone->categories_selection_ptr - 1) * ozone->dimensions.sidebar_entry_padding_vertical
+         + ozone->dimensions.sidebar_padding_vertical
+         + (ozone->categories_selection_ptr > ozone->system_tab_end
+               ? ozone->dimensions.sidebar_entry_padding_vertical + ozone->dimensions.spacer_1px
+               : 0);
 }
 
 static float ozone_sidebar_get_scroll_y(
-      ozone_handle_t *ozone, unsigned video_height)
+      ozone_handle_t *ozone,
+      unsigned video_height)
 {
-   float scroll_y                          =
-      ozone->animations.scroll_y_sidebar;
-   float selected_position_y               =
-      ozone_get_selected_sidebar_y_position(ozone);
-   float current_selection_middle_onscreen =
-        ozone->dimensions.header_height
-      + ozone->dimensions.spacer_1px
-      + ozone->animations.scroll_y_sidebar
-      + selected_position_y
-      + ozone->dimensions.sidebar_entry_height / 2.0f;
-   float bottom_boundary                   =
-      (float)video_height
-      - (ozone->dimensions.header_height + ozone->dimensions.spacer_1px)
-      - ozone->dimensions.footer_height;
+   float scroll_y                          = ozone->animations.scroll_y_sidebar;
+   float selected_position_y               = ozone_get_selected_sidebar_y_position(ozone);
+   float current_selection_middle_onscreen = ozone->dimensions.header_height
+         + ozone->dimensions.spacer_1px
+         + ozone->animations.scroll_y_sidebar
+         + selected_position_y
+         + ozone->dimensions.sidebar_entry_height / 2.0f;
+   float bottom_boundary                   = (float)video_height
+         - (ozone->dimensions.header_height + ozone->dimensions.spacer_1px)
+         - ozone->dimensions.footer_height;
    float entries_middle                    = (float)video_height / 2.0f;
    float entries_height                    = ozone_get_sidebar_height(ozone);
 
@@ -2671,10 +2705,10 @@ static float ozone_sidebar_get_scroll_y(
    return scroll_y;
 }
 
-/* Flushing is slow - only do it if font
- * has actually been used */
+/* Flushing is slow - only do it if font has actually been used */
 static void ozone_font_flush(
-      unsigned video_width, unsigned video_height,
+      unsigned video_width,
+      unsigned video_height,
       ozone_font_data_t *font_data)
 {
    if (font_data->raster_block.carr.coords.vertices == 0)
@@ -2699,9 +2733,8 @@ static void ozone_draw_icon(
 {
    gfx_display_ctx_draw_t draw;
    struct video_coords coords;
-   gfx_display_ctx_driver_t 
-      *dispctx              = p_disp->dispctx;
-
+   gfx_display_ctx_driver_t
+         *dispctx       = p_disp->dispctx;
 
    coords.vertices      = 4;
    coords.vertex        = NULL;
@@ -2734,10 +2767,8 @@ static int ozone_wiggle(ozone_handle_t* ozone, float t)
    return roundf(a * exp(-(c * t)) * sin(w * t));
 }
 
-/**
- * Changes x and y to the current offset of the cursor wiggle animation
- */
-static void ozone_apply_cursor_wiggle_offset(ozone_handle_t* ozone, int* x, size_t* y)
+/* Changes x and y to the current offset of the cursor wiggle animation */
+static void ozone_apply_cursor_wiggle_offset(ozone_handle_t *ozone, int *x, size_t *y)
 {
    retro_time_t cur_time, t;
 
@@ -2782,19 +2813,23 @@ static void ozone_draw_cursor_slice(
       unsigned video_width,
       unsigned video_height,
       int x_offset,
-      unsigned width, unsigned height,
-      size_t y, float alpha,
+      unsigned width,
+      unsigned height,
+      size_t y,
+      float alpha,
       math_matrix_4x4 *mymat)
 {
-   float scale_factor    = ozone->last_scale_factor;
-   int slice_x           = x_offset - 12 * scale_factor;
-   int slice_y           = (int)y + 8 * scale_factor;
-   unsigned slice_new_w  = width + (24 + 1) * scale_factor;
-   unsigned slice_new_h  = height + 20 * scale_factor;
    gfx_display_ctx_driver_t 
-      *dispctx           = p_disp->dispctx;
-   static float 
-      last_alpha         = 0.0f;
+         *dispctx                  = p_disp->dispctx;
+   static float last_alpha         = 0.0f;
+   float scale_factor              = ozone->last_scale_factor;
+   int slice_x                     = x_offset - 12 * scale_factor;
+   int slice_y                     = (int)y + 8 * scale_factor;
+   unsigned slice_new_w            = width + (24 + 1) * scale_factor;
+   unsigned slice_new_h            = height + 20 * scale_factor;
+   unsigned slice_w                = 80;
+   unsigned slice_h                = 80;
+   unsigned offset                 = 20;
 
    if (alpha != last_alpha)
    {
@@ -2814,12 +2849,15 @@ static void ozone_draw_cursor_slice(
          video_height,
          slice_x,
          slice_y,
-         80, 80,
+         slice_w,
+         slice_h,
          slice_new_w,
          slice_new_h,
-         video_width, video_height,
+         video_width,
+         video_height,
          ozone->theme_dynamic.cursor_alpha,
-         20, scale_factor,
+         offset,
+         scale_factor,
          ozone->theme->textures[OZONE_THEME_TEXTURE_CURSOR_NO_BORDER],
          mymat
          );
@@ -2832,12 +2870,15 @@ static void ozone_draw_cursor_slice(
          video_height,
          slice_x,
          slice_y,
-         80, 80,
+         slice_w,
+         slice_h,
          slice_new_w,
          slice_new_h,
-         video_width, video_height,
+         video_width,
+         video_height,
          ozone->theme_dynamic.cursor_border,
-         20, scale_factor,
+         offset,
+         scale_factor,
          ozone->textures[OZONE_TEXTURE_CURSOR_BORDER],
          mymat
          );
@@ -2853,10 +2894,12 @@ static void ozone_draw_cursor_fallback(
       unsigned video_width,
       unsigned video_height,
       int x_offset,
-      unsigned width, unsigned height,
-      size_t y, float alpha)
+      unsigned width,
+      unsigned height,
+      size_t y,
+      float alpha)
 {
-   static float last_alpha           = 0.0f;
+   static float last_alpha         = 0.0f;
 
    if (alpha != last_alpha)
    {
@@ -2943,7 +2986,6 @@ static void ozone_draw_cursor_fallback(
          NULL);
 }
 
-
 static void ozone_draw_cursor(
       ozone_handle_t *ozone,
       gfx_display_t *p_disp,
@@ -2951,8 +2993,10 @@ static void ozone_draw_cursor(
       unsigned video_width,
       unsigned video_height,
       int x_offset,
-      unsigned width, unsigned height,
-      size_t y, float alpha,
+      unsigned width,
+      unsigned height,
+      size_t y,
+      float alpha,
       math_matrix_4x4 *mymat)
 {
    int new_x    = x_offset;
@@ -2968,8 +3012,13 @@ static void ozone_draw_cursor(
       ozone_draw_cursor_slice(ozone, 
             p_disp,
             userdata,
-            video_width, video_height,
-            new_x, width, height, new_y, alpha,
+            video_width,
+            video_height,
+            new_x,
+            width,
+            height,
+            new_y,
+            alpha,
             mymat);
    else
       ozone_draw_cursor_fallback(ozone,
@@ -2977,9 +3026,12 @@ static void ozone_draw_cursor(
             userdata,
             video_width,
             video_height,
-            new_x, width, height, new_y, alpha);
+            new_x,
+            width,
+            height,
+            new_y,
+            alpha);
 }
-
 
 static void ozone_draw_sidebar(
       ozone_handle_t *ozone,
@@ -2991,8 +3043,7 @@ static void ozone_draw_sidebar(
       unsigned video_height,
       bool libretro_running,
       float menu_framebuffer_opacity,
-      math_matrix_4x4 *mymat
-      )
+      math_matrix_4x4 *mymat)
 {
    static const enum msg_hash_enums ozone_system_tabs_value[OZONE_SYSTEM_TAB_LAST] = {
       MENU_ENUM_LABEL_VALUE_MAIN_MENU,
@@ -3043,15 +3094,14 @@ static void ozone_draw_sidebar(
    gfx_animation_ctx_ticker_t ticker;
    gfx_animation_ctx_ticker_smooth_t ticker_smooth;
    static const char* const
-      ticker_spacer                  = OZONE_TICKER_SPACER;
+         ticker_spacer               = OZONE_TICKER_SPACER;
    unsigned ticker_x_offset          = 0;
-   uint32_t text_alpha               = ozone->animations.sidebar_text_alpha 
-      * 255.0f;
+   uint32_t text_alpha               = ozone->animations.sidebar_text_alpha * 255.0f;
    bool use_smooth_ticker            = settings->bools.menu_ticker_smooth;
    float scale_factor                = ozone->last_scale_factor;
    enum gfx_animation_ticker_type
-      menu_ticker_type               = (enum gfx_animation_ticker_type)
-      settings->uints.menu_ticker_type;
+         menu_ticker_type            =
+         (enum gfx_animation_ticker_type)settings->uints.menu_ticker_type;
    unsigned selection_y              = 0;
    unsigned selection_old_y          = 0;
    unsigned horizontal_list_size     = 0;
@@ -3084,11 +3134,17 @@ static void ozone_draw_sidebar(
             video_width, video_height,
             0,
             ozone->dimensions.header_height + ozone->dimensions.spacer_1px,
-            (unsigned) ozone->dimensions_sidebar_width,
-            video_height - ozone->dimensions.header_height - ozone->dimensions.footer_height - ozone->dimensions.spacer_1px);
+            (unsigned)ozone->dimensions_sidebar_width,
+            video_height
+                  - ozone->dimensions.header_height
+                  - ozone->dimensions.footer_height
+                  - ozone->dimensions.spacer_1px);
 
    /* Background */
-   sidebar_height = video_height - ozone->dimensions.header_height - ozone->dimensions.sidebar_gradient_height * 2 - ozone->dimensions.footer_height;
+   sidebar_height = video_height
+         - ozone->dimensions.header_height
+         - ozone->dimensions.sidebar_gradient_height * 2
+         - ozone->dimensions.footer_height;
 
    if (!libretro_running || (menu_framebuffer_opacity >= 1.0f))
    {
@@ -3111,7 +3167,8 @@ static void ozone_draw_sidebar(
             video_width,
             video_height,
             ozone->sidebar_offset,
-            ozone->dimensions.header_height + ozone->dimensions.spacer_1px + ozone->dimensions.sidebar_gradient_height,
+            ozone->dimensions.header_height + ozone->dimensions.spacer_1px
+                  + ozone->dimensions.sidebar_gradient_height,
             (unsigned)ozone->dimensions_sidebar_width,
             sidebar_height,
             video_width,
@@ -3124,13 +3181,13 @@ static void ozone_draw_sidebar(
             video_width,
             video_height,
             ozone->sidebar_offset,
-              video_height 
-            - ozone->dimensions.footer_height 
-            - ozone->dimensions.sidebar_gradient_height 
-            - ozone->dimensions.spacer_1px,
+            video_height
+                  - ozone->dimensions.footer_height
+                  - ozone->dimensions.sidebar_gradient_height
+                  - ozone->dimensions.spacer_1px,
             (unsigned)ozone->dimensions_sidebar_width,
-              ozone->dimensions.sidebar_gradient_height 
-            + ozone->dimensions.spacer_1px,
+            ozone->dimensions.sidebar_gradient_height
+                  + ozone->dimensions.spacer_1px,
             video_width,
             video_height,
             ozone->theme->sidebar_bottom_gradient,
@@ -3159,7 +3216,7 @@ static void ozone_draw_sidebar(
       y += ozone->dimensions.sidebar_entry_height + ozone->dimensions.sidebar_entry_padding_vertical;
    }
 
-   entry_width = (unsigned) ozone->dimensions_sidebar_width - ozone->dimensions.sidebar_padding_horizontal * 2;
+   entry_width = (unsigned)ozone->dimensions_sidebar_width - ozone->dimensions.sidebar_padding_horizontal * 2;
 
    /* Cursor */
    if (ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR)
@@ -3187,7 +3244,7 @@ static void ozone_draw_sidebar(
             entry_width - ozone->dimensions.spacer_5px,
             ozone->dimensions.sidebar_entry_height + ozone->dimensions.spacer_1px,
             selection_old_y + ozone->animations.scroll_y_sidebar,
-            1-ozone->animations.cursor_alpha,
+            1 - ozone->animations.cursor_alpha,
             mymat);
 
    /* Menu tabs */
@@ -3195,16 +3252,14 @@ static void ozone_draw_sidebar(
    if (dispctx && dispctx->blend_begin)
       dispctx->blend_begin(userdata);
 
-   for (i = 0; i < (unsigned)(ozone->system_tab_end+1); i++)
+   for (i = 0; i < (unsigned)(ozone->system_tab_end + 1); i++)
    {
       float *col                     = NULL;
       bool     selected              = (ozone->categories_selection_ptr == i);
       unsigned     icon              = ozone_system_tabs_icons[ozone->tabs[i]];
 
-      if (!(col = selected
-         ? ozone->theme->text_selected
-         : ozone->theme->entries_icon))
-         col               = ozone->pure_white;
+      if (!(col = selected ? ozone->theme->text_selected : ozone->theme->entries_icon))
+         col = ozone->pure_white;
 
       /* Icon */
       ozone_draw_icon(
@@ -3215,8 +3270,13 @@ static void ozone_draw_sidebar(
             ozone->dimensions.sidebar_entry_icon_size,
             ozone->dimensions.sidebar_entry_icon_size,
             ozone->tab_textures[icon],
-            ozone->sidebar_offset + ozone->dimensions.sidebar_padding_horizontal + ozone->dimensions.sidebar_entry_icon_padding,
-            y + ozone->dimensions.sidebar_entry_height / 2 - ozone->dimensions.sidebar_entry_icon_size / 2 + ozone->animations.scroll_y_sidebar,
+            ozone->sidebar_offset
+                  + ozone->dimensions.sidebar_padding_horizontal
+                  + ozone->dimensions.sidebar_entry_icon_padding,
+            y
+                  + ozone->dimensions.sidebar_entry_height / 2
+                  - ozone->dimensions.sidebar_entry_icon_size / 2
+                  + ozone->animations.scroll_y_sidebar,
             video_width,
             video_height,
             0.0f,
@@ -3230,18 +3290,19 @@ static void ozone_draw_sidebar(
          enum msg_hash_enums value_idx  = ozone_system_tabs_value[ozone->tabs[i]];
          const char *title              = msg_hash_to_str(value_idx);
          uint32_t text_color            = selected
-            ? COLOR_TEXT_ALPHA(ozone->theme->text_selected_rgba, text_alpha)
-            : COLOR_TEXT_ALPHA(ozone->theme->text_sidebar_rgba, text_alpha);
+               ? COLOR_TEXT_ALPHA(ozone->theme->text_selected_rgba, text_alpha)
+               : COLOR_TEXT_ALPHA(ozone->theme->text_sidebar_rgba, text_alpha);
          gfx_display_draw_text(
                ozone->fonts.sidebar.font,
                title,
-               ozone->sidebar_offset 
-               + ozone->dimensions.sidebar_padding_horizontal 
-               + ozone->dimensions.sidebar_entry_icon_padding * 2 
-               + ozone->dimensions.sidebar_entry_icon_size,
-               y + ozone->dimensions.sidebar_entry_height / 2.0f 
-               + ozone->fonts.sidebar.line_centre_offset 
-               + ozone->animations.scroll_y_sidebar,
+               ozone->sidebar_offset
+                     + ozone->dimensions.sidebar_padding_horizontal
+                     + ozone->dimensions.sidebar_entry_icon_padding * 2
+                     + ozone->dimensions.sidebar_entry_icon_size,
+               y
+                     + ozone->dimensions.sidebar_entry_height / 2.0f
+                     + ozone->fonts.sidebar.line_centre_offset
+                     + ozone->animations.scroll_y_sidebar,
                video_width,
                video_height,
                text_color,
@@ -3282,19 +3343,18 @@ static void ozone_draw_sidebar(
 
       for (i = 0; i < horizontal_list_size; i++)
       {
+         ozone_node_t *node   = (ozone_node_t*)ozone->horizontal_list.list[i].userdata;
          float *col           = NULL;
          bool selected        = (ozone->categories_selection_ptr == ozone->system_tab_end + 1 + i);
-
-         uint32_t text_color  = COLOR_TEXT_ALPHA((selected ? ozone->theme->text_selected_rgba : ozone->theme->text_sidebar_rgba), text_alpha);
-
-         ozone_node_t *node   = (ozone_node_t*)ozone->horizontal_list.list[i].userdata;
+         uint32_t text_color  = COLOR_TEXT_ALPHA((selected
+               ? ozone->theme->text_selected_rgba
+               : ozone->theme->text_sidebar_rgba), text_alpha);
 
          if (!node)
             goto console_iterate;
 
-         if (!(col = (selected ? ozone->theme->text_selected :
-                     ozone->theme->entries_icon)))
-            col               = ozone->pure_white;
+         if (!(col = (selected ? ozone->theme->text_selected : ozone->theme->entries_icon)))
+            col = ozone->pure_white;
 
          /* Icon */
          ozone_draw_icon(
@@ -3305,8 +3365,13 @@ static void ozone_draw_sidebar(
                ozone->dimensions.sidebar_entry_icon_size,
                ozone->dimensions.sidebar_entry_icon_size,
                node->icon,
-               ozone->sidebar_offset + ozone->dimensions.sidebar_padding_horizontal + ozone->dimensions.sidebar_entry_icon_padding,
-               y + ozone->dimensions.sidebar_entry_height / 2 - ozone->dimensions.sidebar_entry_icon_size / 2 + ozone->animations.scroll_y_sidebar,
+               ozone->sidebar_offset
+                     + ozone->dimensions.sidebar_padding_horizontal
+                     + ozone->dimensions.sidebar_entry_icon_padding,
+               y
+                     + ozone->dimensions.sidebar_entry_height / 2
+                     - ozone->dimensions.sidebar_entry_icon_size / 2
+                     + ozone->animations.scroll_y_sidebar,
                video_width,
                video_height,
                0.0f,
@@ -3325,7 +3390,9 @@ static void ozone_draw_sidebar(
              *-12.549 is outside the range of representable values
              of type 'unsigned int'
              * */
-            ticker_smooth.field_width = (entry_width - ozone->dimensions.sidebar_entry_icon_size - 40 * scale_factor);
+            ticker_smooth.field_width = (entry_width
+                  - ozone->dimensions.sidebar_entry_icon_size
+                  - 40 * scale_factor);
             ticker_smooth.src_str     = node->console_name;
             ticker_smooth.dst_str     = console_title;
             ticker_smooth.dst_str_len = sizeof(console_title);
@@ -3334,7 +3401,10 @@ static void ozone_draw_sidebar(
          }
          else
          {
-            ticker.len      = (entry_width - ozone->dimensions.sidebar_entry_icon_size - 40 * scale_factor) / ozone->fonts.sidebar.glyph_width;
+            ticker.len      = (entry_width
+                  - ozone->dimensions.sidebar_entry_icon_size
+                  - 40 * scale_factor)
+                  / ozone->fonts.sidebar.glyph_width;
             ticker.s        = console_title;
             ticker.selected = selected;
             ticker.str      = node->console_name;
@@ -3345,13 +3415,15 @@ static void ozone_draw_sidebar(
          gfx_display_draw_text(
                ozone->fonts.sidebar.font,
                console_title,
-               ticker_x_offset + ozone->sidebar_offset 
-               + ozone->dimensions.sidebar_padding_horizontal 
-               + ozone->dimensions.sidebar_entry_icon_padding * 2 
-               + ozone->dimensions.sidebar_entry_icon_size,
-               y + ozone->dimensions.sidebar_entry_height / 2 
-               + ozone->fonts.sidebar.line_centre_offset 
-               + ozone->animations.scroll_y_sidebar,
+               ticker_x_offset
+                     + ozone->sidebar_offset
+                     + ozone->dimensions.sidebar_padding_horizontal
+                     + ozone->dimensions.sidebar_entry_icon_padding * 2
+                     + ozone->dimensions.sidebar_entry_icon_size,
+               y
+                     + ozone->dimensions.sidebar_entry_height / 2
+                     + ozone->fonts.sidebar.line_centre_offset
+                     + ozone->animations.scroll_y_sidebar,
                video_width,
                video_height,
                text_color,
@@ -3372,24 +3444,22 @@ console_iterate:
    ozone_font_flush(video_width, video_height, &ozone->fonts.sidebar);
 
    if (dispctx && dispctx->scissor_end)
-      dispctx->scissor_end(userdata,
-            video_width, video_height);
+      dispctx->scissor_end(userdata, video_width, video_height);
 }
 
 static void ozone_thumbnail_bar_hide_end(void *userdata)
 {
-   ozone_handle_t *ozone             = (ozone_handle_t*) userdata;
-   ozone->show_thumbnail_bar         = false;
-   ozone->flags                     &= ~(
-                                         OZONE_FLAG_PENDING_HIDE_THUMBNAIL_BAR);
+   ozone_handle_t *ozone      = (ozone_handle_t*) userdata;
+   ozone->show_thumbnail_bar  = false;
+   ozone->flags              &= ~(OZONE_FLAG_PENDING_HIDE_THUMBNAIL_BAR);
 
    if (!(ozone->is_quick_menu && menu_is_running_quick_menu()))
-      ozone->flags                  |= OZONE_FLAG_NEED_COMPUTE;
+      ozone->flags           |= OZONE_FLAG_NEED_COMPUTE;
 }
 
 static bool ozone_is_load_content_playlist(void *userdata)
 {
-   ozone_handle_t *ozone             = (ozone_handle_t*) userdata;
+   ozone_handle_t *ozone      = (ozone_handle_t*) userdata;
    menu_entry_t entry;
 
    if (     (ozone->depth != 4)
@@ -3407,11 +3477,11 @@ static bool ozone_is_load_content_playlist(void *userdata)
 
 static void ozone_update_savestate_thumbnail_path(void *data, unsigned i)
 {
-   settings_t *settings  = config_get_ptr();
-   ozone_handle_t *ozone = (ozone_handle_t*)data;
-   int state_slot        = settings->ints.state_slot;
-   bool savestate_thumbnail_enable
-                         = settings->bools.savestate_thumbnail_enable;
+   settings_t *settings     = config_get_ptr();
+   ozone_handle_t *ozone    = (ozone_handle_t*)data;
+   int state_slot           = settings->ints.state_slot;
+   bool savestate_thumbnail = settings->bools.savestate_thumbnail_enable;
+
    if (!ozone)
       return;
 
@@ -3437,7 +3507,7 @@ static void ozone_update_savestate_thumbnail_path(void *data, unsigned i)
             || (ozone->flags & OZONE_FLAG_IS_STATE_SLOT)))
       return;
 
-   if (savestate_thumbnail_enable)
+   if (savestate_thumbnail)
    {
       menu_entry_t entry;
 
@@ -3470,11 +3540,9 @@ static void ozone_update_savestate_thumbnail_path(void *data, unsigned i)
             }
             else
             {
-               size_t _len = strlcpy(path,
-                     runloop_st->name.savestate, sizeof(path));
+               size_t _len = strlcpy(path, runloop_st->name.savestate, sizeof(path));
                if (state_slot > 0)
-                  snprintf(path + _len, sizeof(path) - _len, "%d",
-                        state_slot);
+                  snprintf(path + _len, sizeof(path) - _len, "%d", state_slot);
             }
 
             strlcat(path, FILE_PATH_PNG_EXTENSION, sizeof(path));
@@ -3495,17 +3563,15 @@ static void ozone_update_savestate_thumbnail_path(void *data, unsigned i)
             }
             else if (!(ozone->flags & OZONE_FLAG_IS_STATE_SLOT))
                ozone->flags &= ~(OZONE_FLAG_WANT_THUMBNAIL_BAR
-                               | OZONE_FLAG_FULLSCREEN_THUMBNAILS_AVAILABLE
-                                );
+                               | OZONE_FLAG_FULLSCREEN_THUMBNAILS_AVAILABLE);
             else
                ozone->flags &= ~OZONE_FLAG_FULLSCREEN_THUMBNAILS_AVAILABLE;
          }
          else if (!(ozone->flags & OZONE_FLAG_SKIP_THUMBNAIL_RESET))
             ozone->flags &= ~(OZONE_FLAG_WANT_THUMBNAIL_BAR
-                            | OZONE_FLAG_FULLSCREEN_THUMBNAILS_AVAILABLE
-                             );
+                            | OZONE_FLAG_FULLSCREEN_THUMBNAILS_AVAILABLE);
 
-         if (     ((ozone->show_thumbnail_bar) 
+         if (     ((ozone->show_thumbnail_bar)
                != ((ozone->flags & OZONE_FLAG_WANT_THUMBNAIL_BAR) > 0)
                && (!(ozone->flags & OZONE_FLAG_PENDING_HIDE_THUMBNAIL_BAR))))
             ozone->flags |= OZONE_FLAG_NEED_COMPUTE;
@@ -3519,14 +3585,13 @@ static void ozone_update_savestate_thumbnail_image(void *data)
    settings_t *settings  = config_get_ptr();
    unsigned thumbnail_upscale_threshold
                          = settings->uints.gfx_thumbnail_upscale_threshold;
-   if (   (!ozone)
-       || (ozone->flags & OZONE_FLAG_SKIP_THUMBNAIL_RESET))
+   if ((!ozone) || (ozone->flags & OZONE_FLAG_SKIP_THUMBNAIL_RESET))
       return;
 
    /* Savestate thumbnails are only relevant
     * when viewing the running quick menu or state slots */
    if (!((ozone->is_quick_menu && menu_is_running_quick_menu()) 
-            || (ozone->flags & OZONE_FLAG_IS_STATE_SLOT)))
+         || (ozone->flags & OZONE_FLAG_IS_STATE_SLOT)))
       return;
 
    /* If path is empty, just reset thumbnail */
@@ -3551,15 +3616,16 @@ static void ozone_update_savestate_thumbnail_image(void *data)
 }
 
 static void ozone_entries_update_thumbnail_bar(
-      ozone_handle_t *ozone, bool is_playlist, bool allow_animation)
+      ozone_handle_t *ozone,
+      bool is_playlist,
+      bool allow_animation)
 {
    struct gfx_animation_ctx_entry entry;
-   uintptr_t tag         = (uintptr_t)&ozone->show_thumbnail_bar;
-   settings_t *settings  = config_get_ptr();
-   bool savestate_thumbnail_enable
-                         = settings ? settings->bools.savestate_thumbnail_enable : false;
+   uintptr_t tag            = (uintptr_t)&ozone->show_thumbnail_bar;
+   settings_t *settings     = config_get_ptr();
+   bool savestate_thumbnail = settings ? settings->bools.savestate_thumbnail_enable : false;
 
-   if (!savestate_thumbnail_enable)
+   if (!savestate_thumbnail)
       ozone->flags &= ~OZONE_FLAG_IS_STATE_SLOT;
 
    entry.duration    = ANIMATION_CURSOR_DURATION;
@@ -3582,11 +3648,11 @@ static void ozone_entries_update_thumbnail_bar(
     *   be a false positive. We therefore require an
     *   additional OZONE_FLAG_PENDING_HIDE_THUMBNAIL_BAR parameter
     *   to track mid-animation state changes... */
-   if (       (!(ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR))
-          &&( (!(ozone->show_thumbnail_bar))
-          ||  (ozone->flags & OZONE_FLAG_PENDING_HIDE_THUMBNAIL_BAR))
-          && ((ozone->flags & OZONE_FLAG_WANT_THUMBNAIL_BAR)
-          ||  (ozone->flags & OZONE_FLAG_IS_STATE_SLOT))
+   if ( (!(ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR))
+         && ( (!(ozone->show_thumbnail_bar))
+            ||  (ozone->flags & OZONE_FLAG_PENDING_HIDE_THUMBNAIL_BAR))
+         && (   (ozone->flags & OZONE_FLAG_WANT_THUMBNAIL_BAR)
+            ||  (ozone->flags & OZONE_FLAG_IS_STATE_SLOT))
       )
    {
       if (allow_animation)
@@ -3601,11 +3667,12 @@ static void ozone_entries_update_thumbnail_bar(
       }
       else
       {
-         ozone->animations.thumbnail_bar_position = ozone->dimensions.thumbnail_bar_width;
-         ozone->show_thumbnail_bar   = true;
+         ozone->animations.thumbnail_bar_position
+                                   = ozone->dimensions.thumbnail_bar_width;
+         ozone->show_thumbnail_bar = true;
       }
 
-      ozone->flags                  &= ~OZONE_FLAG_PENDING_HIDE_THUMBNAIL_BAR;
+      ozone->flags                &= ~OZONE_FLAG_PENDING_HIDE_THUMBNAIL_BAR;
 
       /* Want thumbnails to load instantly when thumbnail
        * sidebar first opens */
@@ -3613,10 +3680,10 @@ static void ozone_entries_update_thumbnail_bar(
       gfx_thumbnail_set_stream_delay(ozone->thumbnails.stream_delay);
    }
    /* Hide it */
-   else if   ((ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR)
-          || ((ozone->show_thumbnail_bar)
-          && (!(ozone->flags & OZONE_FLAG_WANT_THUMBNAIL_BAR))
-          && (!(ozone->flags & OZONE_FLAG_IS_STATE_SLOT))))
+   else if ((ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR)
+         || ((ozone->show_thumbnail_bar)
+            && (!(ozone->flags & OZONE_FLAG_WANT_THUMBNAIL_BAR))
+            && (!(ozone->flags & OZONE_FLAG_IS_STATE_SLOT))))
    {
       if (allow_animation)
       {
@@ -3693,6 +3760,13 @@ static bool ozone_is_playlist(ozone_handle_t *ozone, bool depth)
    return is_playlist;
 }
 
+static bool ozone_want_collapse(ozone_handle_t *ozone,
+      bool ozone_collapse_sidebar,
+      bool is_playlist)
+{
+   return (ozone_collapse_sidebar)
+         || (is_playlist && (!(ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR)));
+}
 
 static void ozone_sidebar_update_collapse(
       ozone_handle_t *ozone,
@@ -3702,6 +3776,7 @@ static void ozone_sidebar_update_collapse(
    /* Collapse sidebar if needed */
    struct gfx_animation_ctx_entry entry;
    bool is_playlist          = ozone_is_playlist(ozone, false);
+   bool collapse             = false;
    uintptr_t tag             = (uintptr_t)&ozone->sidebar_collapsed;
 
    entry.easing_enum         = EASING_OUT_QUAD;
@@ -3711,14 +3786,24 @@ static void ozone_sidebar_update_collapse(
 
    gfx_animation_kill_by_tag(&tag);
 
+   /* Treat Explore lists as playlists */
+   if (ozone_get_horizontal_selection_type(ozone) == MENU_EXPLORE_TAB)
+      is_playlist = true;
+
    /* Playlists under 'Load Content' don't need sidebar animations */
    if (is_playlist && ozone->depth > 3)
       goto end;
 
+   /* To collapse or not to collapse */
+   collapse = ozone_want_collapse(ozone, ozone_collapse_sidebar, is_playlist);
+
+   /* Skip if already at wanted state */
+   if ( (collapse  && ozone->sidebar_collapsed) ||
+        (!collapse && !ozone->sidebar_collapsed))
+      goto end;
+
    /* Collapse it */
-   if (        ozone_collapse_sidebar 
-         || (!(ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR) && (is_playlist ||
-               ozone_get_horizontal_selection_type(ozone) == MENU_EXPLORE_TAB)))
+   if (collapse)
    {
       if (allow_animation)
       {
@@ -3739,14 +3824,12 @@ static void ozone_sidebar_update_collapse(
       else
       {
          ozone->animations.sidebar_text_alpha = 0.0f;
-         ozone->dimensions_sidebar_width      = 
-            ozone->dimensions.sidebar_width_collapsed;
+         ozone->dimensions_sidebar_width      = ozone->dimensions.sidebar_width_collapsed;
          ozone->sidebar_collapsed             = true;
       }
    }
    /* Show it */
-   else if ((ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR)
-         || (!is_playlist && !ozone_collapse_sidebar))
+   else
    {
       if (allow_animation)
       {
@@ -3778,8 +3861,8 @@ end:
    ozone_entries_update_thumbnail_bar(ozone, is_playlist, allow_animation);
 }
 
-
-static void ozone_go_to_sidebar(ozone_handle_t *ozone,
+static void ozone_go_to_sidebar(
+      ozone_handle_t *ozone,
       bool ozone_collapse_sidebar,
       uintptr_t tag)
 {
@@ -3858,13 +3941,11 @@ static void ozone_update_content_metadata(ozone_handle_t *ozone)
    else
       ozone->flags2 &= ~OZONE_FLAG2_SELECTION_CORE_IS_VIEWER_REAL;
 
-   if ((playlist && (
-                    (ozone->flags & OZONE_FLAG_IS_PLAYLIST)
-               ||   (ozone->flags & OZONE_FLAG_IS_EXPLORE_LIST)
-               ||   (ozone->is_quick_menu && !menu_is_running_quick_menu())))
-               || ( (ozone->flags & OZONE_FLAG_IS_DB_MANAGER_LIST) 
-                  && ozone->depth == 4))
-         
+   if ( (playlist
+         && (   (ozone->flags & OZONE_FLAG_IS_PLAYLIST)
+            ||  (ozone->flags & OZONE_FLAG_IS_EXPLORE_LIST)
+            ||  (ozone->is_quick_menu && !menu_is_running_quick_menu())))
+         || (   (ozone->flags & OZONE_FLAG_IS_DB_MANAGER_LIST) && ozone->depth == 4))
    {
       size_t _len;
       const char *core_label             = NULL;
@@ -3885,8 +3966,8 @@ static void ozone_update_content_metadata(ozone_handle_t *ozone)
             playlist_get_index(playlist, playlist_index, &entry);
       }
 #if defined(HAVE_LIBRETRODB)
-      else if (list &&
-               (selection < list_size)
+      else if (list
+            && (selection < list_size)
             && (ozone->flags & OZONE_FLAG_IS_EXPLORE_LIST))
       {
          playlist_index = menu_explore_get_entry_playlist_index(list->list[selection].type, &playlist, &entry, list, &selection, &list_size);
@@ -3901,9 +3982,9 @@ static void ozone_update_content_metadata(ozone_handle_t *ozone)
 #endif
       /* Get playlist index corresponding
        * to the selected entry */
-      else if (list &&
-          (selection < list_size) &&
-          (list->list[selection].type == FILE_TYPE_RPL_ENTRY))
+      else if (list
+            && (selection < list_size)
+            && (list->list[selection].type == FILE_TYPE_RPL_ENTRY))
       {
          playlist_index        = list->list[selection].entry_idx;
 
@@ -3954,8 +4035,7 @@ static void ozone_update_content_metadata(ozone_handle_t *ozone)
             sizeof(ozone->selection_core_name));
       ozone->selection_core_name[_len  ] = ' ';
       ozone->selection_core_name[_len+1] = '\0';
-      strlcat(ozone->selection_core_name, core_label,
-            sizeof(ozone->selection_core_name));
+      strlcat(ozone->selection_core_name, core_label, sizeof(ozone->selection_core_name));
 
       if (!scroll_content_metadata)
          linebreak_after_colon(&ozone->selection_core_name);
@@ -3965,8 +4045,9 @@ static void ozone_update_content_metadata(ozone_handle_t *ozone)
       {
          char tmpstr[256];
          unsigned metadata_len =
-               (ozone->dimensions.thumbnail_bar_width - ((ozone->dimensions.sidebar_entry_icon_padding * 2) * 2)) /
-                     ozone->fonts.footer.glyph_width;
+               (ozone->dimensions.thumbnail_bar_width
+                     - ((ozone->dimensions.sidebar_entry_icon_padding * 2) * 2))
+                     / ozone->fonts.footer.glyph_width;
 
          strlcpy(tmpstr, ozone->selection_core_name, sizeof(tmpstr));
          (ozone->word_wrap)(ozone->selection_core_name,
@@ -3997,27 +4078,22 @@ static void ozone_update_content_metadata(ozone_handle_t *ozone)
       }
       else
       {
-         const char *disabled_str =
-            msg_hash_to_str(MENU_ENUM_LABEL_VALUE_DISABLED);
+         const char *disabled_str = msg_hash_to_str(MENU_ENUM_LABEL_VALUE_DISABLED);
          size_t _len                       = 
             strlcpy(ozone->selection_playtime,
-               msg_hash_to_str(
-                  MENU_ENUM_LABEL_VALUE_PLAYLIST_SUBLABEL_RUNTIME),
+               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLIST_SUBLABEL_RUNTIME),
                sizeof(ozone->selection_playtime));
          ozone->selection_playtime[_len  ] = ' ';
          ozone->selection_playtime[_len+1] = '\0';
-         strlcat(ozone->selection_playtime, disabled_str,
-               sizeof(ozone->selection_playtime));
+         strlcat(ozone->selection_playtime, disabled_str, sizeof(ozone->selection_playtime));
 
          _len                                = 
             strlcpy(ozone->selection_lastplayed,
-               msg_hash_to_str(
-                  MENU_ENUM_LABEL_VALUE_PLAYLIST_SUBLABEL_LAST_PLAYED),
+               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLIST_SUBLABEL_LAST_PLAYED),
                sizeof(ozone->selection_lastplayed));
          ozone->selection_lastplayed[_len  ] = ' ';
          ozone->selection_lastplayed[_len+1] = '\0';
-         strlcat(ozone->selection_lastplayed, disabled_str,
-               sizeof(ozone->selection_lastplayed));
+         strlcat(ozone->selection_lastplayed, disabled_str, sizeof(ozone->selection_lastplayed));
       }
 
       if (!scroll_content_metadata)
@@ -4046,8 +4122,6 @@ static void ozone_update_content_metadata(ozone_handle_t *ozone)
    }
 }
 
-static void ozone_navigation_pointer_changed(void *data);
-
 static void ozone_tab_set_selection(void *data)
 {
    ozone_handle_t *ozone = (ozone_handle_t*)data;
@@ -4058,12 +4132,13 @@ static void ozone_tab_set_selection(void *data)
       if (tab_selection)
       {
          menu_navigation_set_selection(tab_selection);
-         ozone_navigation_pointer_changed(ozone);
+         ozone_selection_changed(ozone, false);
       }
    }
 }
 
-static void ozone_leave_sidebar(ozone_handle_t *ozone,
+static void ozone_leave_sidebar(
+      ozone_handle_t *ozone,
       bool ozone_collapse_sidebar,
       uintptr_t tag)
 {
@@ -4072,6 +4147,7 @@ static void ozone_leave_sidebar(ozone_handle_t *ozone,
    ozone_update_content_metadata(ozone);
 
    ozone->categories_active_idx_old = ozone->categories_selection_ptr;
+
    if (ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR)
       ozone->flags               |=  OZONE_FLAG_CURSOR_IN_SIDEBAR_OLD;
    else
@@ -4115,7 +4191,6 @@ static void ozone_free_node(ozone_node_t *node)
    free(node);
 }
 
-
 static void ozone_free_list_nodes(file_list_t *list, bool actiondata)
 {
    unsigned i, size = list ? (unsigned)list->size : 0;
@@ -4136,16 +4211,18 @@ static ozone_node_t *ozone_copy_node(const ozone_node_t *old_node)
    ozone_node_t *new_node = (ozone_node_t*)malloc(sizeof(*new_node));
 
    *new_node              = *old_node;
-   new_node->fullpath     = old_node->fullpath 
-      ? strdup(old_node->fullpath) 
-      : NULL;
+   new_node->fullpath     = old_node->fullpath
+         ? strdup(old_node->fullpath) 
+         : NULL;
 
    return new_node;
 }
 
 static void ozone_list_deep_copy(
-      const file_list_t *src, file_list_t *dst,
-      size_t first, size_t last)
+      const file_list_t *src,
+      file_list_t *dst,
+      size_t first,
+      size_t last)
 {
    size_t i, j   = 0;
    uintptr_t tag = (uintptr_t)dst;
@@ -4185,9 +4262,10 @@ static void ozone_list_deep_copy(
    dst->size = j;
 }
 
-
-static void ozone_list_cache(void *data,
-      enum menu_list_type type, unsigned action)
+static void ozone_list_cache(
+      void *data,
+      enum menu_list_type type,
+      unsigned action)
 {
    size_t y, entries_end;
    unsigned i;
@@ -4249,7 +4327,8 @@ text_iterate:
          &ozone->selection_buf_old, first, last);
 }
 
-static void ozone_change_tab(ozone_handle_t *ozone,
+static void ozone_change_tab(
+      ozone_handle_t *ozone,
       enum msg_hash_enums tab,
       enum menu_settings_type type)
 {
@@ -4261,18 +4340,17 @@ static void ozone_change_tab(ozone_handle_t *ozone,
       free(menu_stack->list[stack_size - 1].label);
    menu_stack->list[stack_size - 1].label = NULL;
 
-   menu_stack->list[stack_size - 1].label =
-      strdup(msg_hash_to_str(tab));
-   menu_stack->list[stack_size - 1].type =
-      type;
+   menu_stack->list[stack_size - 1].label = strdup(msg_hash_to_str(tab));
+   menu_stack->list[stack_size - 1].type  = type;
 
-   ozone_list_cache(ozone, MENU_LIST_HORIZONTAL,
-         MENU_ACTION_LEFT);
+   ozone_list_cache(ozone, MENU_LIST_HORIZONTAL, MENU_ACTION_LEFT);
 
    menu_driver_deferred_push_content_list(selection_buf);
 }
 
-static void ozone_sidebar_goto(ozone_handle_t *ozone, unsigned new_selection)
+static void ozone_sidebar_goto(
+      ozone_handle_t *ozone,
+      unsigned new_selection)
 {
    static const enum msg_hash_enums ozone_system_tabs_idx[OZONE_SYSTEM_TAB_LAST]      = {
       MENU_ENUM_LABEL_MAIN_MENU,
@@ -4381,6 +4459,7 @@ static void ozone_refresh_sidebars(
    uintptr_t thumbnail_tag              = (uintptr_t)&ozone->show_thumbnail_bar;
    uintptr_t scroll_tag                 = (uintptr_t)ozone;
    bool is_playlist                     = ozone_is_playlist(ozone, false);
+   bool collapse                        = false;
 
    /* Kill any existing animations */
    gfx_animation_kill_by_tag(&collapsed_tag);
@@ -4389,17 +4468,21 @@ static void ozone_refresh_sidebars(
    if (ozone->depth == 1)
       gfx_animation_kill_by_tag(&scroll_tag);
 
+   /* Treat Explore lists as playlists */
+   if (ozone_get_horizontal_selection_type(ozone) == MENU_EXPLORE_TAB)
+      is_playlist = true;
+
+   /* To collapse or not to collapse */
+   collapse = ozone_want_collapse(ozone, ozone_collapse_sidebar, is_playlist);
+
    /* Set sidebar width */
-   if (     (ozone_collapse_sidebar)
-         || (   (is_playlist)
-             && (!(ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR))))
+   if (collapse)
    {
       ozone->animations.sidebar_text_alpha = 0.0f;
       ozone->dimensions_sidebar_width      = ozone->dimensions.sidebar_width_collapsed;
       ozone->sidebar_collapsed             = true;
    }
-   else if ((ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR)
-         || (!is_playlist && !ozone_collapse_sidebar))
+   else
    {
       ozone->animations.sidebar_text_alpha = 1.0f;
       ozone->dimensions_sidebar_width      = ozone->dimensions.sidebar_width_normal;
@@ -4419,9 +4502,9 @@ static void ozone_refresh_sidebars(
    }
 
    /* Set thumbnail bar position */
-   if (      (!(ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR))
-          && (!(ozone->flags & OZONE_FLAG_WANT_THUMBNAIL_BAR)
-          || (ozone->flags & OZONE_FLAG_IS_STATE_SLOT))
+   if (     ( !(ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR))
+         && ( !(ozone->flags & OZONE_FLAG_WANT_THUMBNAIL_BAR)
+            || (ozone->flags & OZONE_FLAG_IS_STATE_SLOT))
       )
    {
       ozone->animations.thumbnail_bar_position = ozone->dimensions.thumbnail_bar_width;
@@ -4467,8 +4550,8 @@ static size_t ozone_list_get_size(void *data, enum menu_list_type type)
    return 0;
 }
 
-
-static void ozone_init_horizontal_list(ozone_handle_t *ozone,
+static void ozone_init_horizontal_list(
+      ozone_handle_t *ozone,
       settings_t *settings)
 {
    menu_displaylist_info_t info;
@@ -4483,16 +4566,14 @@ static void ozone_init_horizontal_list(ozone_handle_t *ozone,
 
    info.list                    = &ozone->horizontal_list;
    info.path                    = strdup(dir_playlist);
-   info.label                   = strdup(
-         msg_hash_to_str(MENU_ENUM_LABEL_PLAYLISTS_TAB));
+   info.label                   = strdup(msg_hash_to_str(MENU_ENUM_LABEL_PLAYLISTS_TAB));
    info.exts                    = strldup("lpl", sizeof("lpl"));
    info.type_default            = FILE_TYPE_PLAIN;
    info.enum_idx                = MENU_ENUM_LABEL_PLAYLISTS_TAB;
 
    if (menu_content_show_playlists && !string_is_empty(info.path))
    {
-      if (menu_displaylist_ctl(DISPLAYLIST_DATABASE_PLAYLISTS_HORIZONTAL,
-               &info, settings))
+      if (menu_displaylist_ctl(DISPLAYLIST_DATABASE_PLAYLISTS_HORIZONTAL, &info, settings))
          menu_displaylist_process(&info);
    }
 
@@ -4554,9 +4635,9 @@ static void ozone_init_horizontal_list(ozone_handle_t *ozone,
 
    /* If playlist names were truncated and option is
     * enabled, re-sort list by console name */
-   if (ozone_truncate_playlist_name &&
-       ozone_sort_after_truncate &&
-       (list_size > 0))
+   if (     ozone_truncate_playlist_name
+         && ozone_sort_after_truncate
+         && (list_size > 0))
       file_list_sort_on_alt(&ozone->horizontal_list);
 }
 
@@ -4567,7 +4648,7 @@ static void ozone_context_destroy_horizontal_list(ozone_handle_t *ozone)
 
    for (i = 0; i < list_size; i++)
    {
-      const char *path = NULL;
+      const char *path   = NULL;
       ozone_node_t *node = (ozone_node_t*)ozone->horizontal_list.list[i].userdata;
 
       if (!node)
@@ -4575,8 +4656,8 @@ static void ozone_context_destroy_horizontal_list(ozone_handle_t *ozone)
 
       if (!(path = ozone->horizontal_list.list[i].path))
          continue;
-      if (string_ends_with_size(path, ".lpl",
-               strlen(path), STRLEN_CONST(".lpl")))
+
+      if (string_ends_with_size(path, ".lpl", strlen(path), STRLEN_CONST(".lpl")))
       {
          video_driver_texture_unload(&node->icon);
          video_driver_texture_unload(&node->content_icon);
@@ -4600,7 +4681,6 @@ static ozone_node_t *ozone_alloc_node(void)
    return node;
 }
 
-
 static void ozone_context_reset_horizontal_list(ozone_handle_t *ozone)
 {
    unsigned i;
@@ -4621,8 +4701,7 @@ static void ozone_context_reset_horizontal_list(ozone_handle_t *ozone)
       if (!(path = ozone->horizontal_list.list[i].path))
          continue;
 
-      if (string_ends_with_size(path, ".lpl",
-               strlen(path), STRLEN_CONST(".lpl")))
+      if (string_ends_with_size(path, ".lpl", strlen(path), STRLEN_CONST(".lpl")))
       {
          size_t len, _len;
          struct texture_image ti;
@@ -4718,8 +4797,8 @@ static void ozone_context_reset_horizontal_list(ozone_handle_t *ozone)
 
          /* Console name */
          console_name = ozone->horizontal_list.list[i].alt
-            ? ozone->horizontal_list.list[i].alt
-            : ozone->horizontal_list.list[i].path;
+               ? ozone->horizontal_list.list[i].alt
+               : ozone->horizontal_list.list[i].path;
 
          if (node->console_name)
             free(node->console_name);
@@ -4733,7 +4812,7 @@ static void ozone_context_reset_horizontal_list(ozone_handle_t *ozone)
             node->console_name = strdup(path);
       }
       else if (string_ends_with_size(ozone->horizontal_list.list[i].label, ".lvw",
-              strlen(ozone->horizontal_list.list[i].label), STRLEN_CONST(".lvw")))
+            strlen(ozone->horizontal_list.list[i].label), STRLEN_CONST(".lvw")))
       {
          /* For now use a default icon for views */
          node->console_name = strdup(path + strlen(msg_hash_to_str(MENU_ENUM_LABEL_EXPLORE_VIEW)) + 2);
@@ -4742,7 +4821,8 @@ static void ozone_context_reset_horizontal_list(ozone_handle_t *ozone)
    }
 }
 
-static void ozone_refresh_horizontal_list(ozone_handle_t *ozone,
+static void ozone_refresh_horizontal_list(
+      ozone_handle_t *ozone,
       settings_t *settings)
 {
    ozone_context_destroy_horizontal_list(ozone);
@@ -4792,7 +4872,7 @@ static void ozone_draw_entry_value(
    float scale_factor                = ozone->last_scale_factor;
    gfx_display_ctx_driver_t *dispctx = p_disp->dispctx;
 
-   /* check icon */
+   /* Check icon */
    if (entry->flags & MENU_ENTRY_FLAG_CHECKED)
    {
       float *col = ozone->theme_dynamic.entries_checkmark;
@@ -4822,9 +4902,8 @@ static void ozone_draw_entry_value(
    }
    else if (string_is_empty(value))
       return;
-      
 
-   /* text value */
+   /* Text value */
    if (string_is_equal(value, msg_hash_to_str(MENU_ENUM_LABEL_DISABLED)) ||
          (string_is_equal(value, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF))))
       switch_is_on = false;
@@ -4836,9 +4915,8 @@ static void ozone_draw_entry_value(
       {
          if (string_is_equal(entry->value, "..."))
             return;
-         if (string_starts_with_size(entry->value, "(", STRLEN_CONST("(")) &&
-               string_ends_with  (entry->value, ")")
-            )
+         if (string_starts_with_size(entry->value, "(", STRLEN_CONST("("))
+               && string_ends_with  (entry->value, ")"))
          {
             if (
                   string_is_equal(entry->value, "(PRESET)")  ||
@@ -4880,12 +4958,16 @@ static void ozone_draw_entry_value(
    else
       gfx_display_draw_text(
             ozone->fonts.entries_label.font,
-            (switch_is_on ? msg_hash_to_str(MENU_ENUM_LABEL_VALUE_ON) : msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF)),
+            (switch_is_on
+                  ? msg_hash_to_str(MENU_ENUM_LABEL_VALUE_ON)
+                  : msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF)),
             x,
             y,
             video_width,
             video_height,
-            COLOR_TEXT_ALPHA((switch_is_on ? ozone->theme->text_selected_rgba : ozone->theme->text_sublabel_rgba), alpha_uint32),
+            COLOR_TEXT_ALPHA((switch_is_on
+                  ? ozone->theme->text_selected_rgba
+                  : ozone->theme->text_sublabel_rgba), alpha_uint32),
             TEXT_ALIGN_RIGHT,
             1.0f,
             false,
@@ -4925,8 +5007,8 @@ static void ozone_draw_no_thumbnail_available(
                icon_size,
                icon_size,
                ozone->icons_textures[icon],
-               x_position + sidebar_width/2 - icon_size/2,
-               video_height/2 - icon_size/2 - y_offset,
+               x_position + sidebar_width / 2 - icon_size / 2,
+               video_height / 2 - icon_size / 2 - y_offset,
                video_width,
                video_height,
                0.0f,
@@ -4941,8 +5023,7 @@ static void ozone_draw_no_thumbnail_available(
          ozone->fonts.footer.font,
          msg_hash_to_str(MSG_NO_THUMBNAIL_AVAILABLE),
          x_position + sidebar_width / 2,
-         video_height / 2 + icon_size / 2
-            + ozone->fonts.footer.line_ascender - y_offset,
+         video_height / 2 + icon_size / 2 + ozone->fonts.footer.line_ascender - y_offset,
          video_width,
          video_height,
          ozone->theme->text_rgba,
@@ -4978,7 +5059,8 @@ static void ozone_content_metadata_line(
          true);
 
    if (lines_count > 0)
-      *y += (unsigned)(ozone->fonts.footer.line_height * (lines_count - 1)) + (unsigned)((float)ozone->fonts.footer.line_height * 1.5f);
+      *y += (unsigned)(ozone->fonts.footer.line_height * (lines_count - 1))
+            + (unsigned)((float)ozone->fonts.footer.line_height * 1.5f);
 }
 
 
@@ -4987,8 +5069,10 @@ static void ozone_content_metadata_line(
  * And if we can scroll so that it's in the middle
  * Then scroll
  */
-static void ozone_update_scroll(ozone_handle_t *ozone,
-      bool allow_animation, ozone_node_t *node)
+static void ozone_update_scroll(
+      ozone_handle_t *ozone,
+      bool allow_animation,
+      ozone_node_t *node)
 {
    unsigned video_info_height;
    gfx_animation_ctx_entry_t entry;
@@ -5002,15 +5086,17 @@ static void ozone_update_scroll(ozone_handle_t *ozone,
    if (!node)
       return;
 
-   current_selection_middle_onscreen    =
-      ozone->dimensions.header_height +
-      ozone->dimensions.entry_padding_vertical +
-      ozone->animations.scroll_y +
-      node->position_y +
-      node->height / 2;
+   current_selection_middle_onscreen    = ozone->dimensions.header_height
+         + ozone->dimensions.entry_padding_vertical
+         + ozone->animations.scroll_y
+         + node->position_y
+         + node->height / 2;
 
-   bottom_boundary                      = video_info_height - ozone->dimensions.header_height - ozone->dimensions.spacer_1px - ozone->dimensions.footer_height;
-   entries_middle                       = video_info_height/2;
+   bottom_boundary                      = video_info_height
+         - ozone->dimensions.header_height
+         - ozone->dimensions.spacer_1px
+         - ozone->dimensions.footer_height;
+   entries_middle                       = video_info_height / 2;
 
    new_scroll = ozone->animations.scroll_y - (current_selection_middle_onscreen - entries_middle);
 
@@ -5056,7 +5142,7 @@ static void ozone_update_scroll(ozone_handle_t *ozone,
    }
    else
    {
-      ozone->selection_old = ozone->selection;
+      ozone->selection_old       = ozone->selection;
       ozone->animations.scroll_y = new_scroll;
    }
 }
@@ -5078,7 +5164,7 @@ static void ozone_compute_entries_position(
 
    if (show_thumbnail_bar != want_thumbnail_bar)
    {
-      if (!(      (ozone->flags & OZONE_FLAG_PENDING_HIDE_THUMBNAIL_BAR) 
+      if (!(      (ozone->flags & OZONE_FLAG_PENDING_HIDE_THUMBNAIL_BAR)
                && (ozone->is_quick_menu)))
          ozone_entries_update_thumbnail_bar(ozone, false, true);
    }
@@ -5092,7 +5178,7 @@ static void ozone_compute_entries_position(
 
    video_driver_get_size(&video_info_width, &video_info_height);
 
-   ozone->entries_height = 0;
+   ozone->entries_height         = 0;
 
    for (i = 0; i < entries_end; i++)
    {
@@ -5112,8 +5198,7 @@ static void ozone_compute_entries_position(
       {
          uintptr_t         tex = ozone_entries_icon_get_texture(ozone,
                entry.enum_idx, entry.path, entry.label, entry.type, false);
-         if (tex ==
-               ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_CORE_INFO])
+         if (tex == ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_CORE_INFO])
             ozone->flags      |=  OZONE_FLAG_EMPTY_PLAYLIST;
          else
             ozone->flags      &= ~OZONE_FLAG_EMPTY_PLAYLIST;
@@ -5137,10 +5222,11 @@ static void ozone_compute_entries_position(
             char wrapped_sublabel_str[MENU_SUBLABEL_MAX_LENGTH];
             wrapped_sublabel_str[0] = '\0';
 
-            node->height += ozone->dimensions.entry_spacing + 40 * scale_factor;
+            node->height        += ozone->dimensions.entry_spacing + 40 * scale_factor;
 
-            sublabel_max_width = video_info_width -
-               entry_padding * 2 - ozone->dimensions.entry_icon_padding * 2;
+            sublabel_max_width   = video_info_width
+                  - entry_padding * 2
+                  - ozone->dimensions.entry_icon_padding * 2;
 
             if (ozone->depth == 1)
                sublabel_max_width -= (unsigned) ozone->dimensions_sidebar_width;
@@ -5151,9 +5237,9 @@ static void ozone_compute_entries_position(
                   sizeof(wrapped_sublabel_str),
                   entry.sublabel,
                   strlen(entry.sublabel),
-                  sublabel_max_width / 
-                  ozone->fonts.entries_sublabel.glyph_width,
-                  ozone->fonts.entries_sublabel.wideglyph_width, 0);
+                  sublabel_max_width / ozone->fonts.entries_sublabel.glyph_width,
+                  ozone->fonts.entries_sublabel.wideglyph_width,
+                  0);
 
             node->sublabel_lines = ozone_count_lines(wrapped_sublabel_str);
 
@@ -5165,8 +5251,7 @@ static void ozone_compute_entries_position(
          }
       }
 
-      node->position_y = ozone->entries_height;
-
+      node->position_y       = ozone->entries_height;
       ozone->entries_height += node->height;
    }
 
@@ -5199,30 +5284,37 @@ static void ozone_draw_entries(
    bool use_smooth_ticker            = settings->bools.menu_ticker_smooth;
    unsigned show_history_icons       = settings->uints.playlist_show_history_icons;
    enum gfx_animation_ticker_type 
-      menu_ticker_type               = (enum gfx_animation_ticker_type)
-      settings->uints.menu_ticker_type;
+         menu_ticker_type            =
+         (enum gfx_animation_ticker_type)settings->uints.menu_ticker_type;
    bool old_list                     = selection_buf == &ozone->selection_buf_old;
    int x_offset                      = 0;
    size_t selection_y                = 0; /* 0 means no selection (we assume that no entry has y = 0) */
    size_t old_selection_y            = 0;
    int entry_padding                 = old_list 
-      ? ozone_get_entries_padding_old_list(ozone)
-      : ozone_get_entries_padding(ozone);
+         ? ozone_get_entries_padding_old_list(ozone)
+         : ozone_get_entries_padding(ozone);
    float scale_factor                = ozone->last_scale_factor;
    gfx_display_ctx_driver_t *dispctx = p_disp->dispctx;
    size_t entries_end                = selection_buf ? selection_buf->size : 0;
-   size_t y                          = ozone->dimensions.header_height + ozone->dimensions.spacer_1px + ozone->dimensions.entry_padding_vertical;
+   size_t y                          = ozone->dimensions.header_height
+         + ozone->dimensions.spacer_1px
+         + ozone->dimensions.entry_padding_vertical;
    float sidebar_offset              = ozone->sidebar_offset;
-   unsigned entry_width              = video_width - (unsigned) ozone->dimensions_sidebar_width - ozone->sidebar_offset - entry_padding * 2 - ozone->animations.thumbnail_bar_position;
+   unsigned entry_width              = video_width
+         - (unsigned)ozone->dimensions_sidebar_width
+         - ozone->sidebar_offset
+         - entry_padding * 2
+         - ozone->animations.thumbnail_bar_position;
    unsigned entry_width_max          = entry_width + ozone->animations.thumbnail_bar_position;
    unsigned button_height            = ozone->dimensions.entry_height; /* height of the button (entry minus sublabel) */
-   float invert                      = (ozone->flags &
-         OZONE_FLAG_FADE_DIRECTION) ? -1 : 1;
+   float invert                      = (ozone->flags & OZONE_FLAG_FADE_DIRECTION) ? -1 : 1;
    float alpha_anim                  = old_list ? alpha : 1.0f - alpha;
 
    video_driver_get_size(&video_info_width, &video_info_height);
 
-   bottom_boundary                   = video_info_height - ozone->dimensions.header_height - ozone->dimensions.footer_height;
+   bottom_boundary                   = video_info_height
+         - ozone->dimensions.header_height
+         - ozone->dimensions.footer_height;
 
    /* Increase entry width, or rather decrease padding between
     * entries and thumbnails when thumbnail bar is visible */
@@ -5288,8 +5380,7 @@ static void ozone_draw_entries(
       else if (y + scroll_y - node->height - 20 * scale_factor > bottom_boundary)
          goto border_iterate;
 
-      border_start_x = (unsigned) ozone->dimensions_sidebar_width 
-         + x_offset + entry_padding;
+      border_start_x = (unsigned)ozone->dimensions_sidebar_width + x_offset + entry_padding;
       border_start_y = y + scroll_y;
 
       gfx_display_set_alpha(ozone->theme_dynamic.entries_border, alpha);
@@ -5336,8 +5427,7 @@ border_iterate:
             userdata,
             video_width,
             video_height,
-            ozone->dimensions_sidebar_width 
-            + x_offset + entry_padding + ozone->dimensions.spacer_3px,
+            ozone->dimensions_sidebar_width + x_offset + entry_padding + ozone->dimensions.spacer_3px,
             entry_width - ozone->dimensions.spacer_5px,
             button_height + ozone->dimensions.spacer_1px,
             selection_y + scroll_y,
@@ -5352,8 +5442,7 @@ border_iterate:
             userdata,
             video_width,
             video_height,
-            (unsigned)ozone->dimensions_sidebar_width 
-            + x_offset + entry_padding + ozone->dimensions.spacer_3px,
+            (unsigned)ozone->dimensions_sidebar_width + x_offset + entry_padding + ozone->dimensions.spacer_3px,
             /* TODO/FIXME - undefined behavior reported by ASAN -
              *-35.2358 is outside the range of representable values
              of type 'unsigned int'
@@ -5361,7 +5450,7 @@ border_iterate:
             entry_width - ozone->dimensions.spacer_5px,
             button_height + ozone->dimensions.spacer_1px,
             old_selection_y + scroll_y,
-            (1-ozone->animations.cursor_alpha) * alpha,
+            (1 - ozone->animations.cursor_alpha) * alpha,
             mymat);
 
    /* Icons + text */
@@ -5383,7 +5472,7 @@ border_iterate:
       unsigned ticker_str_width    = 0;
       int value_x_offset           = 0;
       static const char* const 
-         ticker_spacer             = OZONE_TICKER_SPACER;
+            ticker_spacer          = OZONE_TICKER_SPACER;
       const char *sublabel_str     = NULL;
       ozone_node_t *node           = NULL;
       const char *entry_rich_label = NULL;
@@ -5415,15 +5504,12 @@ border_iterate:
       if (!node)
          continue;
 
-      if (y + scroll_y + node->height + 20 * scale_factor 
-            < ozone->dimensions.header_height 
-            + ozone->dimensions.entry_padding_vertical)
+      if (y + scroll_y + node->height + 20 * scale_factor < ozone->dimensions.header_height + ozone->dimensions.entry_padding_vertical)
       {
          y += node->height;
          continue;
       }
-      else if (y + scroll_y - node->height - 20 * scale_factor 
-            > bottom_boundary)
+      else if (y + scroll_y - node->height - 20 * scale_factor > bottom_boundary)
       {
          y += node->height;
          continue;
@@ -5452,9 +5538,7 @@ border_iterate:
 
       if (use_smooth_ticker)
       {
-         ticker_smooth.selected    = entry_selected 
-                                     && (!(ozone->flags &
-                                              OZONE_FLAG_CURSOR_IN_SIDEBAR));
+         ticker_smooth.selected    = entry_selected && (!(ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR));
          ticker_smooth.field_width = entry_width - entry_padding - (10 * scale_factor) - ozone->dimensions.entry_icon_padding;
          ticker_smooth.src_str     = entry_rich_label;
          ticker_smooth.dst_str     = rich_label;
@@ -5466,8 +5550,7 @@ border_iterate:
       {
          ticker.s        = rich_label;
          ticker.str      = entry_rich_label;
-         ticker.selected = entry_selected 
-                           && (!(ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR));
+         ticker.selected = entry_selected && (!(ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR));
          ticker.len      = (entry_width - entry_padding - (10 * scale_factor) - ozone->dimensions.entry_icon_padding) / ozone->fonts.entries_label.glyph_width;
 
          gfx_animation_ticker(&ticker);
@@ -5478,10 +5561,8 @@ border_iterate:
          /* Note: This entry can never be selected, so ticker_x_offset
           * is irrelevant here (i.e. this text will never scroll) */
          unsigned text_width = font_driver_get_message_width(ozone->fonts.entries_label.font, rich_label, strlen(rich_label), 1.0f);
-         x_offset = (video_info_width - (unsigned)
-               ozone->dimensions_sidebar_width - entry_padding * 2) 
-            / 2 - text_width / 2 - 60 * scale_factor;
-         y = video_info_height / 2 - 60 * scale_factor;
+         x_offset            = (video_info_width - (unsigned)ozone->dimensions_sidebar_width - entry_padding * 2) / 2 - (text_width / 2) - (60 * scale_factor);
+         y                   = (video_info_height / 2) - (60 * scale_factor);
       }
 
       sublabel_str = entry.sublabel;
@@ -5490,11 +5571,10 @@ border_iterate:
       {
          if (node->wrap && !string_is_empty(sublabel_str))
          {
-            int sublabel_max_width = video_info_width -
-               entry_padding * 2 - ozone->dimensions.entry_icon_padding * 2;
+            int sublabel_max_width = video_info_width - entry_padding * 2 - ozone->dimensions.entry_icon_padding * 2;
 
             if (ozone->depth == 1)
-               sublabel_max_width -= (unsigned) ozone->dimensions_sidebar_width;
+               sublabel_max_width -= (unsigned)ozone->dimensions_sidebar_width;
             if (ozone->show_thumbnail_bar)
             {
                if (ozone->is_quick_menu && menu_is_running_quick_menu())
@@ -5508,9 +5588,9 @@ border_iterate:
                   sizeof(wrapped_sublabel_str),
                   sublabel_str,
                   strlen(sublabel_str),
-                  sublabel_max_width 
-                  / ozone->fonts.entries_sublabel.glyph_width,
-                  ozone->fonts.entries_sublabel.wideglyph_width, 0);
+                  sublabel_max_width / ozone->fonts.entries_sublabel.glyph_width,
+                  ozone->fonts.entries_sublabel.wideglyph_width,
+                  0);
             sublabel_str = wrapped_sublabel_str;
          }
       }
@@ -5525,7 +5605,9 @@ border_iterate:
          if (     entry.type == FILE_TYPE_RPL_ENTRY 
                && ozone->categories_selection_ptr > ozone->system_tab_end)
          {
-            ozone_node_t *sidebar_node = (ozone_node_t*) file_list_get_userdata_at_offset(&ozone->horizontal_list, ozone->categories_selection_ptr - ozone->system_tab_end-1);
+            ozone_node_t *sidebar_node = (ozone_node_t*)
+                  file_list_get_userdata_at_offset(&ozone->horizontal_list,
+                        ozone->categories_selection_ptr - ozone->system_tab_end - 1);
 
             if (sidebar_node && sidebar_node->content_icon)
                texture = sidebar_node->content_icon;
@@ -5541,14 +5623,17 @@ border_iterate:
                playlist_get_index(playlist_get_cached(),
                      entry.entry_idx, &pl_entry);
 
-               if (pl_entry &&
-                     !string_is_empty(pl_entry->db_name) &&
-                     (db_node = RHMAP_GET_STR(ozone->playlist_db_node_map, pl_entry->db_name)))
+               if (pl_entry
+                     && !string_is_empty(pl_entry->db_name)
+                     && (db_node = RHMAP_GET_STR(ozone->playlist_db_node_map, pl_entry->db_name)))
                   texture = db_node->content_icon;
             }
             else if (ozone->depth == 3 && entry.type == FILE_TYPE_PLAYLIST_COLLECTION)
             {
-               ozone_node_t *sidebar_node = (ozone_node_t*) file_list_get_userdata_at_offset(&ozone->horizontal_list, selection_buf->list[i].entry_idx);
+               ozone_node_t *sidebar_node = (ozone_node_t*)
+                     file_list_get_userdata_at_offset(&ozone->horizontal_list,
+                           selection_buf->list[i].entry_idx);
+
                if (sidebar_node && sidebar_node->icon)
                   texture = sidebar_node->icon;
             }
@@ -5568,9 +5653,9 @@ border_iterate:
                      playlist_get_index(playlist_get_cached(),
                            entry.entry_idx, &pl_entry);
 
-                     if (pl_entry &&
-                         !string_is_empty(pl_entry->db_name) &&
-                         (db_node = RHMAP_GET_STR(ozone->playlist_db_node_map, pl_entry->db_name)))
+                     if (pl_entry
+                           && !string_is_empty(pl_entry->db_name)
+                           && (db_node = RHMAP_GET_STR(ozone->playlist_db_node_map, pl_entry->db_name)))
                      {
                         switch (show_history_icons)
                         {
@@ -5592,10 +5677,7 @@ border_iterate:
          }
 
          /* Cheevos badges should not be recolored */
-         if (!(
-            (entry.type >= MENU_SETTINGS_CHEEVOS_START) &&
-            (entry.type < MENU_SETTINGS_NETPLAY_ROOMS_START)
-         ))
+         if (!((entry.type >= MENU_SETTINGS_CHEEVOS_START) && (entry.type < MENU_SETTINGS_NETPLAY_ROOMS_START)))
             icon_color = ozone->theme_dynamic.entries_icon;
          else
             icon_color = ozone->pure_white;
@@ -5615,11 +5697,14 @@ border_iterate:
                      ozone->dimensions.entry_icon_size,
                      ozone->dimensions.entry_icon_size,
                      texture,
-                     ozone->dimensions_sidebar_width 
-                     + x_offset + entry_padding 
-                     + ozone->dimensions.entry_icon_padding,
-                     y + scroll_y + ozone->dimensions.entry_height 
-                     / 2 - ozone->dimensions.entry_icon_size / 2,
+                     ozone->dimensions_sidebar_width
+                           + x_offset
+                           + entry_padding
+                           + ozone->dimensions.entry_icon_padding,
+                     y
+                           + scroll_y
+                           + ozone->dimensions.entry_height / 2
+                           - ozone->dimensions.entry_icon_size / 2,
                      video_width,
                      video_height,
                      0.0f,
@@ -5640,13 +5725,17 @@ border_iterate:
       gfx_display_draw_text(
             ozone->fonts.entries_label.font,
             rich_label,
-            ticker_x_offset + text_offset + (unsigned)
-            ozone->dimensions_sidebar_width + x_offset        + 
-            entry_padding + ozone->dimensions.entry_icon_size + 
-            ozone->dimensions.entry_icon_padding * 2,
-            y + ozone->dimensions.entry_height / 2.0f         + 
-            ozone->fonts.entries_label.line_centre_offset     + 
-            scroll_y,
+            ticker_x_offset
+                  + text_offset
+                  + (unsigned)ozone->dimensions_sidebar_width
+                  + x_offset
+                  + entry_padding
+                  + ozone->dimensions.entry_icon_size
+                  + ozone->dimensions.entry_icon_padding * 2,
+            y
+                  + ozone->dimensions.entry_height / 2.0f
+                  + ozone->fonts.entries_label.line_centre_offset
+                  + scroll_y,
             video_width,
             video_height,
             COLOR_TEXT_ALPHA(ozone->theme->text_rgba, alpha_uint32),
@@ -5662,13 +5751,21 @@ border_iterate:
             gfx_display_draw_text(
                   ozone->fonts.entries_sublabel.font,
                   sublabel_str,
-                  (unsigned) ozone->dimensions_sidebar_width + 
-                  x_offset + entry_padding                   + 
-                  ozone->dimensions.entry_icon_padding,
-                  y + ozone->dimensions.entry_height - ozone->dimensions.spacer_1px + (node->height - ozone->dimensions.entry_height - (node->sublabel_lines * ozone->fonts.entries_sublabel.line_height))/2.0f + ozone->fonts.entries_sublabel.line_ascender + scroll_y,
+                  (unsigned)ozone->dimensions_sidebar_width
+                        + x_offset
+                        + entry_padding
+                        + ozone->dimensions.entry_icon_padding,
+                  y
+                        + ozone->dimensions.entry_height
+                        - ozone->dimensions.spacer_1px
+                        + (node->height
+                              - ozone->dimensions.entry_height
+                              - (node->sublabel_lines * ozone->fonts.entries_sublabel.line_height)) / 2.0f
+                        + ozone->fonts.entries_sublabel.line_ascender
+                        + scroll_y,
                   video_width,
                   video_height,
-                  COLOR_TEXT_ALPHA(ozone->theme->text_sublabel_rgba,alpha_uint32),
+                  COLOR_TEXT_ALPHA(ozone->theme->text_sublabel_rgba, alpha_uint32),
                   TEXT_ALIGN_LEFT,
                   1.0f,
                   false,
@@ -5679,11 +5776,11 @@ border_iterate:
       /* Value */
       if (use_smooth_ticker)
       {
-         ticker_smooth.selected    = entry_selected 
-                                     && (!(ozone->flags &
-                                              OZONE_FLAG_CURSOR_IN_SIDEBAR));
-         ticker_smooth.field_width = (entry_width - ozone->dimensions.entry_icon_size - ozone->dimensions.entry_icon_padding * 2 -
-               ((unsigned)utf8len(entry_rich_label) * ozone->fonts.entries_label.glyph_width));
+         ticker_smooth.selected    = entry_selected && (!(ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR));
+         ticker_smooth.field_width = (entry_width
+               - ozone->dimensions.entry_icon_size
+               - ozone->dimensions.entry_icon_padding * 2
+               - ((unsigned)utf8len(entry_rich_label) * ozone->fonts.entries_label.glyph_width));
          ticker_smooth.src_str     = entry_value;
          ticker_smooth.dst_str     = entry_value_ticker;
          ticker_smooth.dst_str_len = sizeof(entry_value_ticker);
@@ -5697,10 +5794,11 @@ border_iterate:
       {
          ticker.s        = entry_value_ticker;
          ticker.str      = entry_value;
-         ticker.selected = entry_selected 
-                           && (!(ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR));
-         ticker.len      = (entry_width - ozone->dimensions.entry_icon_size - ozone->dimensions.entry_icon_padding * 2 -
-               ((unsigned)utf8len(entry_rich_label) * ozone->fonts.entries_label.glyph_width)) / ozone->fonts.entries_label.glyph_width;
+         ticker.selected = entry_selected && (!(ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR));
+         ticker.len      = (entry_width
+               - ozone->dimensions.entry_icon_size
+               - ozone->dimensions.entry_icon_padding * 2
+               - ((unsigned)utf8len(entry_rich_label) * ozone->fonts.entries_label.glyph_width)) / ozone->fonts.entries_label.glyph_width;
 
          gfx_animation_ticker(&ticker);
       }
@@ -5711,10 +5809,16 @@ border_iterate:
             video_width,
             video_height,
             entry_value_ticker,
-            value_x_offset + (unsigned) ozone->dimensions_sidebar_width 
-            + entry_padding + x_offset 
-            + entry_width - ozone->dimensions.entry_icon_padding,
-            y + ozone->dimensions.entry_height / 2 + ozone->fonts.entries_label.line_centre_offset + scroll_y,
+            value_x_offset
+                  + (unsigned)ozone->dimensions_sidebar_width
+                  + entry_padding
+                  + x_offset
+                  + entry_width
+                  - ozone->dimensions.entry_icon_padding,
+            y
+                  + ozone->dimensions.entry_height / 2
+                  + ozone->fonts.entries_label.line_centre_offset
+                  + scroll_y,
             alpha_uint32,
             &entry,
             mymat);
@@ -5750,10 +5854,20 @@ static void ozone_draw_thumbnail_bar(
    int bottom_row_y_position         = 0;
    bool show_right_thumbnail         = false;
    bool show_left_thumbnail          = false;
-   unsigned sidebar_height           = video_height - ozone->dimensions.header_height - ozone->dimensions.sidebar_gradient_height * 2 - ozone->dimensions.footer_height;
-   unsigned x_position               = video_width - (unsigned) ozone->animations.thumbnail_bar_position - ozone->dimensions.sidebar_entry_icon_padding;
-   int thumbnail_x_position          = x_position + ozone->dimensions.sidebar_entry_icon_padding + ozone->dimensions.sidebar_entry_icon_padding;
-   unsigned thumbnail_height         = (video_height - ozone->dimensions.header_height - ozone->dimensions.spacer_2px - ozone->dimensions.footer_height - (ozone->dimensions.sidebar_entry_icon_padding * 3)) / 2;
+   unsigned sidebar_height           = video_height
+         - ozone->dimensions.header_height
+         - ozone->dimensions.sidebar_gradient_height * 2
+         - ozone->dimensions.footer_height;
+   unsigned x_position               = video_width
+         - (unsigned)ozone->animations.thumbnail_bar_position
+         - ozone->dimensions.sidebar_entry_icon_padding;
+   int thumbnail_x_position          = x_position
+         + ozone->dimensions.sidebar_entry_icon_padding * 2;
+   unsigned thumbnail_height         = (video_height
+         - ozone->dimensions.header_height
+         - ozone->dimensions.spacer_2px
+         - ozone->dimensions.footer_height
+         - (ozone->dimensions.sidebar_entry_icon_padding * 3)) / 2;
    float scale_factor                = ozone->last_scale_factor;
    gfx_display_ctx_driver_t *dispctx = p_disp->dispctx;
 
@@ -5793,7 +5907,7 @@ static void ozone_draw_thumbnail_bar(
             video_height,
             x_position,
             video_height - ozone->dimensions.footer_height - ozone->dimensions.sidebar_gradient_height - ozone->dimensions.spacer_1px,
-            (unsigned) ozone->animations.thumbnail_bar_position + ozone->dimensions.sidebar_entry_icon_padding,
+            (unsigned)ozone->animations.thumbnail_bar_position + ozone->dimensions.sidebar_entry_icon_padding,
             ozone->dimensions.sidebar_gradient_height + ozone->dimensions.spacer_1px,
             video_width,
             video_height,
@@ -5803,16 +5917,15 @@ static void ozone_draw_thumbnail_bar(
 
    /* Thumbnails */
    show_right_thumbnail =
-         (ozone->thumbnails.right.status != GFX_THUMBNAIL_STATUS_MISSING) &&
-         gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_RIGHT);
+         (ozone->thumbnails.right.status != GFX_THUMBNAIL_STATUS_MISSING)
+         && gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_RIGHT);
    show_left_thumbnail  =
-         (ozone->thumbnails.left.status != GFX_THUMBNAIL_STATUS_MISSING) &&
-         gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_LEFT) &&
-         (!(ozone->flags2 & OZONE_FLAG2_SELECTION_CORE_IS_VIEWER));
+         (ozone->thumbnails.left.status != GFX_THUMBNAIL_STATUS_MISSING)
+         && gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_LEFT)
+         && (!(ozone->flags2 & OZONE_FLAG2_SELECTION_CORE_IS_VIEWER));
 
    /* Special "viewer" mode for savestate thumbnails */
-   if (     ((ozone->flags & OZONE_FLAG_WANT_THUMBNAIL_BAR)
-         && !string_is_empty(ozone->savestate_thumbnail_file_path))
+   if (     ((ozone->flags & OZONE_FLAG_WANT_THUMBNAIL_BAR) && !string_is_empty(ozone->savestate_thumbnail_file_path))
          || (ozone->flags & OZONE_FLAG_IS_STATE_SLOT))
    {
       ozone->flags2                  |= OZONE_FLAG2_SELECTION_CORE_IS_VIEWER;
@@ -5857,7 +5970,9 @@ static void ozone_draw_thumbnail_bar(
             userdata,
             video_width,
             video_height,
-            x_position, sidebar_width, 0,
+            x_position,
+            sidebar_width,
+            0,
             mymat);
       return;
    }
@@ -5874,20 +5989,19 @@ static void ozone_draw_thumbnail_bar(
     *   content metadata -> centre image vertically */
    if (ozone->flags2 & OZONE_FLAG2_SELECTION_CORE_IS_VIEWER)
    {
-      right_thumbnail_y_position =
-            ozone->dimensions.header_height +
-            ((thumbnail_height / 2) +
-            (int)(1.5f * (float)ozone->dimensions.sidebar_entry_icon_padding));
+      right_thumbnail_y_position = ozone->dimensions.header_height
+            + (thumbnail_height / 2)
+            + (int)(1.5f * (float)ozone->dimensions.sidebar_entry_icon_padding);
 
-      right_thumbnail_alignment = GFX_THUMBNAIL_ALIGN_CENTRE;
+      right_thumbnail_alignment  = GFX_THUMBNAIL_ALIGN_CENTRE;
    }
    else
    {
-      right_thumbnail_y_position =
-            ozone->dimensions.header_height + ozone->dimensions.spacer_1px +
-            ozone->dimensions.sidebar_entry_icon_padding;
+      right_thumbnail_y_position = ozone->dimensions.header_height
+            + ozone->dimensions.spacer_1px
+            + ozone->dimensions.sidebar_entry_icon_padding;
 
-      right_thumbnail_alignment = GFX_THUMBNAIL_ALIGN_BOTTOM;
+      right_thumbnail_alignment  = GFX_THUMBNAIL_ALIGN_BOTTOM;
    }
 
    /* > If we have a right thumbnail, show it */
@@ -5906,7 +6020,9 @@ static void ozone_draw_thumbnail_bar(
             thumbnail_width,
             thumbnail_height,
             right_thumbnail_alignment,
-            1.0f, 1.0f, NULL);
+            1.0f,
+            1.0f,
+            NULL);
       ozone->flags &= ~OZONE_FLAG_NO_THUMBNAIL_AVAILABLE;
    }
    /* > If we have neither a right thumbnail nor
@@ -5935,9 +6051,10 @@ static void ozone_draw_thumbnail_bar(
     *   2) Content metadata */
 
    /* > Get baseline 'start' position of bottom row */
-   bottom_row_y_position = ozone->dimensions.header_height + ozone->dimensions.spacer_1px +
-         thumbnail_height +
-         (ozone->dimensions.sidebar_entry_icon_padding * 2);
+   bottom_row_y_position = ozone->dimensions.header_height
+         + ozone->dimensions.spacer_1px
+         + thumbnail_height
+         + (ozone->dimensions.sidebar_entry_icon_padding * 2);
 
    /* > If we have a left thumbnail, show it */
    if (show_left_thumbnail)
@@ -5984,7 +6101,8 @@ static void ozone_draw_thumbnail_bar(
             thumbnail_height,
             left_thumbnail_alignment,
             left_thumbnail_alpha,
-            1.0f, NULL);
+            1.0f,
+            NULL);
       ozone->flags &= ~OZONE_FLAG_NO_THUMBNAIL_AVAILABLE;
    }
 
@@ -6001,8 +6119,7 @@ static void ozone_draw_thumbnail_bar(
     *     (i.e. fade in, fade out, or fully
     *     active) */
    if (   (!(ozone->flags2 & OZONE_FLAG2_SELECTION_CORE_IS_VIEWER))
-       && (!show_left_thumbnail || !show_right_thumbnail
-       || (ozone->animations.left_thumbnail_alpha < 1.0f)))
+       && (!show_left_thumbnail || !show_right_thumbnail || (ozone->animations.left_thumbnail_alpha < 1.0f)))
    {
       char ticker_buf[255];
       gfx_animation_ctx_ticker_t ticker;
@@ -6012,23 +6129,19 @@ static void ozone_draw_thumbnail_bar(
       bool scroll_content_metadata           = settings->bools.ozone_scroll_content_metadata;
       bool use_smooth_ticker                 = settings->bools.menu_ticker_smooth;
       enum gfx_animation_ticker_type 
-         menu_ticker_type                    = (enum gfx_animation_ticker_type)
-               settings->uints.menu_ticker_type;
+            menu_ticker_type                 = (enum gfx_animation_ticker_type)settings->uints.menu_ticker_type;
       bool show_entry_idx                    = settings->bools.playlist_show_entry_idx;
-      bool show_entry_core                   = (!(ozone->flags &
-               OZONE_FLAG_IS_DB_MANAGER_LIST));
-      bool show_entry_playtime               = (!(ozone->flags &
-               OZONE_FLAG_IS_DB_MANAGER_LIST));
-      bool show_entry_last_played            = (!(ozone->flags &
-               OZONE_FLAG_IS_DB_MANAGER_LIST));
+      bool show_entry_core                   = (!(ozone->flags & OZONE_FLAG_IS_DB_MANAGER_LIST));
+      bool show_entry_playtime               = (!(ozone->flags & OZONE_FLAG_IS_DB_MANAGER_LIST));
+      bool show_entry_last_played            = (!(ozone->flags & OZONE_FLAG_IS_DB_MANAGER_LIST));
       unsigned y                             = (unsigned)bottom_row_y_position;
-      unsigned separator_padding             = ozone->dimensions.sidebar_entry_icon_padding*2;
+      unsigned separator_padding             = ozone->dimensions.sidebar_entry_icon_padding * 2;
       unsigned column_x                      = x_position + separator_padding;
-      bool metadata_override_enabled         = show_left_thumbnail &&
-                                               show_right_thumbnail &&
-                                               (ozone->animations.left_thumbnail_alpha < 1.0f);
-      float metadata_alpha                   = metadata_override_enabled ?
-            (1.0f - ozone->animations.left_thumbnail_alpha) : 1.0f;
+      bool metadata_override_enabled         =
+            show_left_thumbnail && show_right_thumbnail && (ozone->animations.left_thumbnail_alpha < 1.0f);
+      float metadata_alpha                   = metadata_override_enabled
+            ? (1.0f - ozone->animations.left_thumbnail_alpha)
+            : 1.0f;
       uint32_t text_color                    = COLOR_TEXT_ALPHA(
             ozone->theme->text_rgba, (uint32_t)(metadata_alpha * 255.0f));
 
@@ -6074,7 +6187,7 @@ static void ozone_draw_thumbnail_bar(
             video_height,
             x_position + separator_padding,
             y,
-            sidebar_width - separator_padding*2,
+            sidebar_width - separator_padding * 2,
             ozone->dimensions.spacer_1px,
             video_width,
             video_height,
@@ -6304,7 +6417,7 @@ static void ozone_draw_backdrop(
       0.00, 0.00, 0.00, 0.75,
       0.00, 0.00, 0.00, 0.75,
    };
-   static float last_alpha           = 0.0f;
+   static float last_alpha         = 0.0f;
 
    /* TODO: Replace this backdrop by a blur shader 
     * on the whole screen if available */
@@ -6329,7 +6442,8 @@ static void ozone_draw_backdrop(
          NULL);
 }
 
-static void ozone_draw_osk(ozone_handle_t *ozone,
+static void ozone_draw_osk(
+      ozone_handle_t *ozone,
       void *userdata,
       void *disp_userdata,
       unsigned video_width,
@@ -6375,7 +6489,7 @@ static void ozone_draw_osk(ozone_handle_t *ozone,
          video_height,
          margin,
          margin,
-         video_width - margin*2,
+         video_width - (margin * 2),
          ozone->dimensions.spacer_1px,
          video_width,
          video_height,
@@ -6390,7 +6504,7 @@ static void ozone_draw_osk(ozone_handle_t *ozone,
          video_height,
          margin,
          bottom_end - margin,
-         video_width - margin*2,
+         video_width - (margin * 2),
          ozone->dimensions.spacer_1px,
          video_width,
          video_height,
@@ -6406,7 +6520,7 @@ static void ozone_draw_osk(ozone_handle_t *ozone,
          margin,
          margin,
          ozone->dimensions.spacer_1px,
-         bottom_end - margin*2,
+         bottom_end - (margin * 2),
          video_width,
          video_height,
          ozone->theme->entries_border,
@@ -6421,7 +6535,7 @@ static void ozone_draw_osk(ozone_handle_t *ozone,
          video_width - margin,
          margin,
          ozone->dimensions.spacer_1px,
-         bottom_end - margin*2,
+         bottom_end - (margin * 2),
          video_width,
          video_height,
          ozone->theme->entries_border,
@@ -6436,8 +6550,8 @@ static void ozone_draw_osk(ozone_handle_t *ozone,
          video_height,
          margin + ozone->dimensions.spacer_1px,
          margin + ozone->dimensions.spacer_1px,
-         video_width - margin*2 - ozone->dimensions.spacer_2px,
-         bottom_end - margin*2 - ozone->dimensions.spacer_2px,
+         video_width - (margin * 2) - ozone->dimensions.spacer_2px,
+         bottom_end - (margin * 2) - ozone->dimensions.spacer_2px,
          video_width,
          video_height,
          ozone_osk_backdrop,
@@ -6450,10 +6564,13 @@ static void ozone_draw_osk(ozone_handle_t *ozone,
       text_color  = ozone_theme_light.text_sublabel_rgba;
    }
 
-   (ozone->word_wrap)(message, sizeof(message), text, strlen(text),
-         (video_width - margin*2 - padding*2) / 
-         ozone->fonts.entries_label.glyph_width,
-         ozone->fonts.entries_label.wideglyph_width, 0);
+   (ozone->word_wrap)(message,
+         sizeof(message),
+         text,
+         strlen(text),
+         (video_width - (margin * 2) - (padding * 2)) / ozone->fonts.entries_label.glyph_width,
+         ozone->fonts.entries_label.wideglyph_width,
+         0);
 
    string_list_initialize(&list);
    string_split_noalloc(&list, message, "\n");
@@ -6465,11 +6582,10 @@ static void ozone_draw_osk(ozone_handle_t *ozone,
       gfx_display_draw_text(
             ozone->fonts.entries_label.font,
             msg,
-            margin + padding * 2,       /* x */
-            margin + padding + 
-            ozone->fonts.entries_label.line_height 
-            + y_offset,                /* y */
-            video_width, video_height,
+            margin + (padding * 2),
+            margin + padding + ozone->fonts.entries_label.line_height + y_offset,
+            video_width,
+            video_height,
             text_color,
             TEXT_ALIGN_LEFT,
             1.0f,
@@ -6482,25 +6598,23 @@ static void ozone_draw_osk(ozone_handle_t *ozone,
       {
          if (ozone->flags & OZONE_FLAG_OSK_CURSOR)
          {
-            unsigned cursor_x = draw_placeholder 
-               ? 0 
-               : font_driver_get_message_width(
-                     ozone->fonts.entries_label.font, msg,
-                     strlen(msg), 1.0f);
+            unsigned cursor_x = draw_placeholder
+                  ? 0
+                  : font_driver_get_message_width(ozone->fonts.entries_label.font, msg, strlen(msg), 1.0f);
             gfx_display_draw_quad(
                   p_disp,
                   userdata,
                   video_width,
                   video_height,
-                    margin 
-                  + padding * 2 
-                  + cursor_x,
-                    margin 
-                  + padding 
-                  + y_offset 
-                  + ozone->fonts.entries_label.line_height 
-                  - ozone->fonts.entries_label.line_ascender 
-                  + ozone->dimensions.spacer_3px,
+                  margin
+                        + (padding * 2)
+                        + cursor_x,
+                  margin
+                        + padding
+                        + y_offset
+                        + ozone->fonts.entries_label.line_height
+                        - ozone->fonts.entries_label.line_ascender
+                        + ozone->dimensions.spacer_3px,
                   ozone->dimensions.spacer_1px,
                   ozone->fonts.entries_label.line_ascender,
                   video_width,
@@ -6543,40 +6657,42 @@ static void ozone_draw_messagebox(
       math_matrix_4x4 *mymat)
 {
    size_t x, y;
-   unsigned i, y_position;
    char wrapped_message[MENU_SUBLABEL_MAX_LENGTH];
    int longest_width        = 0;
    int usable_width         = 0;
    struct string_list list  = {0};
    float scale_factor       = 0.0f;
+   unsigned i               = 0;
+   unsigned y_position      = 0;
    unsigned width           = video_width;
    unsigned height          = video_height;
    gfx_display_ctx_driver_t 
-      *dispctx              = p_disp->dispctx;
+         *dispctx           = p_disp->dispctx;
 
    wrapped_message[0]       = '\0';
 
    /* Sanity check */
-   if (string_is_empty(message) ||
-       !ozone->fonts.footer.font)
+   if (string_is_empty(message) || !ozone->fonts.footer.font)
       return;
 
-   scale_factor = ozone->last_scale_factor;
-   usable_width = (int)width - (48 * 8 * scale_factor);
+   scale_factor             = ozone->last_scale_factor;
+   usable_width             = (int)width - (48 * 8 * scale_factor);
 
    if (usable_width < 1)
       return;
 
    /* Split message into lines */
    (ozone->word_wrap)(
-         wrapped_message, sizeof(wrapped_message),
-         message, strlen(message),
+         wrapped_message,
+         sizeof(wrapped_message),
+         message,
+         strlen(message),
          usable_width / (int)ozone->fonts.footer.glyph_width,
-         ozone->fonts.footer.wideglyph_width, 0);
+         ozone->fonts.footer.wideglyph_width,
+         0);
 
    string_list_initialize(&list);
-   if (
-            !string_split_noalloc(&list, wrapped_message, "\n")
+   if (     !string_split_noalloc(&list, wrapped_message, "\n")
          || list.elems == 0)
    {
       string_list_deinitialize(&list);
@@ -6588,18 +6704,16 @@ static void ozone_draw_messagebox(
       y_position    = height / 4;
 
    x                = width  / 2;
-   y                = y_position - (list.size 
-         * ozone->fonts.footer.line_height) / 2;
+   y                = y_position - (list.size * ozone->fonts.footer.line_height) / 2;
 
    /* find the longest line width */
    for (i = 0; i < list.size; i++)
    {
-      const char *msg  = list.elems[i].data;
+      const char *msg = list.elems[i].data;
 
       if (!string_is_empty(msg))
       {
-         int width = font_driver_get_message_width(
-               ozone->fonts.footer.font, msg, strlen(msg), 1.0f);
+         int width = font_driver_get_message_width(ozone->fonts.footer.font, msg, strlen(msg), 1.0f);
 
          if (width > longest_width)
             longest_width = width;
@@ -6621,11 +6735,12 @@ static void ozone_draw_messagebox(
        *   size, draw size and scale factor... */
       size_t slice_new_w   = longest_width + 48 * 2 * scale_factor;
       size_t slice_new_h   = ozone->fonts.footer.line_height * (list.size + 2);
+      unsigned slice_w     = 256;
       int slice_x          = x - longest_width / 2 - 48 * scale_factor;
-      int slice_y          = y - ozone->fonts.footer.line_height +
-            ((slice_new_h >= 256) 
-             ? (16.0f * scale_factor) 
-             : (16.0f * ((float)slice_new_h / 256.0f)));
+      int slice_y          = y - ozone->fonts.footer.line_height
+            + ((slice_new_h >= slice_w)
+                  ? (16.0f * scale_factor)
+                  : (16.0f * ((float)slice_new_h / (float)slice_w)));
 
       gfx_display_draw_texture_slice(
             p_disp,
@@ -6634,12 +6749,15 @@ static void ozone_draw_messagebox(
             video_height,
             slice_x,
             slice_y,
-            256, 256,
+            slice_w,
+            slice_w,
             (unsigned)slice_new_w,
             (unsigned)slice_new_h,
-            width, height,
+            width,
+            height,
             ozone->theme_dynamic.message_background,
-            16, scale_factor,
+            16,
+            scale_factor,
             ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_DIALOG_SLICE],
             mymat
             );
@@ -6653,9 +6771,8 @@ static void ozone_draw_messagebox(
          gfx_display_draw_text(
                ozone->fonts.footer.font,
                msg,
-               x - longest_width/2.0,
-               y + (i * ozone->fonts.footer.line_height) + 
-               ozone->fonts.footer.line_ascender,
+               x - (longest_width / 2),
+               y + (i * ozone->fonts.footer.line_height) + ozone->fonts.footer.line_ascender,
                width,
                height,
                COLOR_TEXT_ALPHA(ozone->theme->text_rgba, (uint32_t)(ozone->animations.messagebox_alpha*255.0f)),
@@ -6672,7 +6789,7 @@ static void ozone_draw_messagebox(
 static void ozone_hide_fullscreen_thumbnails(ozone_handle_t *ozone, bool animate)
 {
    uintptr_t alpha_tag                = (uintptr_t)
-      &ozone->animations.fullscreen_thumbnail_alpha;
+         &ozone->animations.fullscreen_thumbnail_alpha;
 
    /* Kill any existing fade in/out animations */
    gfx_animation_kill_by_tag(&alpha_tag);
@@ -6734,22 +6851,20 @@ static void ozone_show_fullscreen_thumbnails(ozone_handle_t *ozone)
    }
    else
    {
-      bool left_thumbnail_enabled = gfx_thumbnail_is_enabled(
-            ozone->thumbnail_path_data, GFX_THUMBNAIL_LEFT);
+      bool left_thumbnail_enabled = gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_LEFT);
 
-      if (!left_thumbnail_enabled &&
-          !gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_RIGHT))
+      if (!left_thumbnail_enabled && !gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_RIGHT))
          return;
 
       if ((ozone->thumbnails.right.status == GFX_THUMBNAIL_STATUS_AVAILABLE) &&
-          (left_thumbnail_enabled &&
-               ((ozone->thumbnails.left.status != GFX_THUMBNAIL_STATUS_MISSING) &&
-                (ozone->thumbnails.left.status != GFX_THUMBNAIL_STATUS_AVAILABLE))))
+            (left_thumbnail_enabled &&
+                  ((ozone->thumbnails.left.status != GFX_THUMBNAIL_STATUS_MISSING) &&
+                   (ozone->thumbnails.left.status != GFX_THUMBNAIL_STATUS_AVAILABLE))))
          return;
 
       if ((ozone->thumbnails.right.status == GFX_THUMBNAIL_STATUS_MISSING) &&
-          (!left_thumbnail_enabled ||
-               (ozone->thumbnails.left.status != GFX_THUMBNAIL_STATUS_AVAILABLE)))
+            (!(ozone->flags & OZONE_FLAG_IS_STATE_SLOT)) &&
+            (!left_thumbnail_enabled || (ozone->thumbnails.left.status != GFX_THUMBNAIL_STATUS_AVAILABLE)))
          return;
    }
 
@@ -6787,8 +6902,6 @@ static void ozone_show_fullscreen_thumbnails(ozone_handle_t *ozone)
    ozone->flags2 |=  OZONE_FLAG2_SHOW_FULLSCREEN_THUMBNAILS;
 }
 
-
-
 static void ozone_draw_fullscreen_thumbnails(
       ozone_handle_t *ozone,
       void *userdata,
@@ -6807,7 +6920,10 @@ static void ozone_draw_fullscreen_thumbnails(
       int view_width                    = (int)width;
       gfx_display_t *p_disp             = (gfx_display_t*)disp_userdata;
 
-      int view_height                   = (int)height - ozone->dimensions.header_height - ozone->dimensions.footer_height - ozone->dimensions.spacer_1px;
+      int view_height                   = (int)height
+            - ozone->dimensions.header_height
+            - ozone->dimensions.footer_height
+            - ozone->dimensions.spacer_1px;
       int thumbnail_margin              = ozone->dimensions.fullscreen_thumbnail_padding;
       bool show_right_thumbnail         = false;
       bool show_left_thumbnail          = false;
@@ -6835,8 +6951,8 @@ static void ozone_draw_fullscreen_thumbnails(
       /* Sanity check: Return immediately if this is
        * a menu without thumbnails and we are not currently
        * 'fading out' the fullscreen thumbnail view */
-      if ( (!(ozone->flags & OZONE_FLAG_FULLSCREEN_THUMBNAILS_AVAILABLE))
-          && (ozone->flags2 & OZONE_FLAG2_SHOW_FULLSCREEN_THUMBNAILS))
+      if (   (!(ozone->flags  & OZONE_FLAG_FULLSCREEN_THUMBNAILS_AVAILABLE))
+            && (ozone->flags2 & OZONE_FLAG2_SHOW_FULLSCREEN_THUMBNAILS))
          goto error;
 
       /* Safety check: ensure that current
@@ -6850,8 +6966,7 @@ static void ozone_draw_fullscreen_thumbnails(
        *   quick menu while fullscreen thumbnails are
        *   being displayed */
       if (((size_t)ozone->selection != ozone->fullscreen_thumbnail_selection) &&
-          (   (!(ozone->is_quick_menu))
-           ||   (ozone->flags2 & OZONE_FLAG2_SHOW_FULLSCREEN_THUMBNAILS)))
+            ((!(ozone->is_quick_menu)) || (ozone->flags2 & OZONE_FLAG2_SHOW_FULLSCREEN_THUMBNAILS)))
          goto error;
 
       /* Sanity check: Return immediately if the view
@@ -6864,7 +6979,7 @@ static void ozone_draw_fullscreen_thumbnails(
       show_left_thumbnail  = (left_thumbnail->status  == GFX_THUMBNAIL_STATUS_AVAILABLE);
 
       if ((ozone->is_quick_menu && !string_is_empty(ozone->savestate_thumbnail_file_path))
-           || (ozone->flags & OZONE_FLAG_IS_STATE_SLOT))
+            || (ozone->flags & OZONE_FLAG_IS_STATE_SLOT))
       {
          left_thumbnail       = &ozone->thumbnails.savestate;
          show_left_thumbnail  = (left_thumbnail->status == GFX_THUMBNAIL_STATUS_AVAILABLE);
@@ -6934,7 +7049,7 @@ static void ozone_draw_fullscreen_thumbnails(
       }
 
       /* Sanity check */
-      if ((thumbnail_box_width < 1) ||
+      if ((thumbnail_box_width  < 1) ||
           (thumbnail_box_height < 1))
          goto error;
 
@@ -6949,11 +7064,14 @@ static void ozone_draw_fullscreen_thumbnails(
       {
          gfx_thumbnail_get_draw_dimensions(
                right_thumbnail,
-               thumbnail_box_width, thumbnail_box_height, 1.0f,
-               &right_thumbnail_draw_width, &right_thumbnail_draw_height);
+               thumbnail_box_width,
+               thumbnail_box_height,
+               1.0f,
+               &right_thumbnail_draw_width,
+               &right_thumbnail_draw_height);
 
          /* Sanity check */
-         if ((right_thumbnail_draw_width <= 0.0f) ||
+         if ((right_thumbnail_draw_width  <= 0.0f) ||
              (right_thumbnail_draw_height <= 0.0f))
             goto error;
       }
@@ -6962,11 +7080,14 @@ static void ozone_draw_fullscreen_thumbnails(
       {
          gfx_thumbnail_get_draw_dimensions(
                left_thumbnail,
-               thumbnail_box_width, thumbnail_box_height, 1.0f,
-               &left_thumbnail_draw_width, &left_thumbnail_draw_height);
+               thumbnail_box_width,
+               thumbnail_box_height,
+               1.0f,
+               &left_thumbnail_draw_width,
+               &left_thumbnail_draw_height);
 
          /* Sanity check */
-         if ((left_thumbnail_draw_width <= 0.0f) ||
+         if ((left_thumbnail_draw_width  <= 0.0f) ||
              (left_thumbnail_draw_height <= 0.0f))
             goto error;
       }
@@ -6996,12 +7117,14 @@ static void ozone_draw_fullscreen_thumbnails(
       /* > Separators */
       memcpy(separator_color, ozone->theme->header_footer_separator, sizeof(separator_color));
       gfx_display_set_alpha(
-            separator_color, ozone->animations.fullscreen_thumbnail_alpha);
+            separator_color,
+            ozone->animations.fullscreen_thumbnail_alpha);
 
       /* > Thumbnail frame */
       memcpy(frame_color, ozone->theme->sidebar_background, sizeof(frame_color));
       gfx_display_set_alpha(
-            frame_color, ozone->animations.fullscreen_thumbnail_alpha);
+            frame_color,
+            ozone->animations.fullscreen_thumbnail_alpha);
 
       /* Darken background */
       gfx_display_draw_quad(
@@ -7058,11 +7181,13 @@ static void ozone_draw_fullscreen_thumbnails(
                userdata,
                video_width,
                video_height,
-               right_thumbnail_x - frame_width +
-                     ((thumbnail_box_width - (int)right_thumbnail_draw_width) >> 1),
-               thumbnail_y - frame_width +
-                     ((thumbnail_box_height - (int)right_thumbnail_draw_height) >> 1),
-               (unsigned)right_thumbnail_draw_width + (frame_width << 1),
+               right_thumbnail_x
+                     - frame_width
+                     + ((thumbnail_box_width  - (int)right_thumbnail_draw_width)  >> 1),
+               thumbnail_y
+                     - frame_width
+                     + ((thumbnail_box_height - (int)right_thumbnail_draw_height) >> 1),
+               (unsigned)right_thumbnail_draw_width  + (frame_width << 1),
                (unsigned)right_thumbnail_draw_height + (frame_width << 1),
                width,
                height,
@@ -7094,11 +7219,13 @@ static void ozone_draw_fullscreen_thumbnails(
                userdata,
                video_width,
                video_height,
-               left_thumbnail_x - frame_width +
-                     ((thumbnail_box_width - (int)left_thumbnail_draw_width) >> 1),
-               thumbnail_y - frame_width +
-                     ((thumbnail_box_height - (int)left_thumbnail_draw_height) >> 1),
-               (unsigned)left_thumbnail_draw_width + (frame_width << 1),
+               left_thumbnail_x
+                     - frame_width
+                     + ((thumbnail_box_width  - (int)left_thumbnail_draw_width)  >> 1),
+               thumbnail_y
+                     - frame_width
+                     + ((thumbnail_box_height - (int)left_thumbnail_draw_height) >> 1),
+               (unsigned)left_thumbnail_draw_width  + (frame_width << 1),
                (unsigned)left_thumbnail_draw_height + (frame_width << 1),
                width,
                height,
@@ -7149,9 +7276,9 @@ static void ozone_set_thumbnail_content(void *data, const char *s)
 
          /* Get playlist index corresponding
           * to the selected entry */
-         if (list &&
-             (selection < list_size) &&
-             (list->list[selection].type == FILE_TYPE_RPL_ENTRY))
+         if (list
+               && (selection < list_size)
+               && (list->list[selection].type == FILE_TYPE_RPL_ENTRY))
          {
             size_t playlist_index = list->list[selection].entry_idx;
             gfx_thumbnail_set_content_playlist(ozone->thumbnail_path_data,
@@ -7182,11 +7309,10 @@ static void ozone_set_thumbnail_content(void *data, const char *s)
       if (string_is_empty(s))
       {
          menu_entry_t entry;
-         size_t selection         = menu_navigation_get_selection();
 
          MENU_ENTRY_INITIALIZE(entry);
          entry.flags |= MENU_ENTRY_FLAG_PATH_ENABLED;
-         menu_entry_get(&entry, 0, selection, NULL, true);
+         menu_entry_get(&entry, 0, menu_navigation_get_selection(), NULL, true);
 
          if (!string_is_empty(entry.path))
             gfx_thumbnail_set_content(ozone->thumbnail_path_data, entry.path);
@@ -7200,11 +7326,12 @@ static void ozone_set_thumbnail_content(void *data, const char *s)
       {
          /* Selected entry */
          menu_entry_t entry;
+
          MENU_ENTRY_INITIALIZE(entry);
          entry.flags |= MENU_ENTRY_FLAG_PATH_ENABLED;
          menu_entry_get(&entry, 0, menu_navigation_get_selection(), NULL, true);
-         if (menu_explore_set_playlist_thumbnail(entry.type,
-             ozone->thumbnail_path_data) >= 0)
+
+         if (menu_explore_set_playlist_thumbnail(entry.type, ozone->thumbnail_path_data) >= 0)
             ozone->flags |=  OZONE_FLAG_FULLSCREEN_THUMBNAILS_AVAILABLE;
          else
             ozone->flags &= ~OZONE_FLAG_FULLSCREEN_THUMBNAILS_AVAILABLE;
@@ -7219,13 +7346,14 @@ static void ozone_set_thumbnail_content(void *data, const char *s)
    else if (string_is_equal(s, "imageviewer"))
    {
       /* Filebrowser image updates */
-      menu_entry_t entry;
       size_t selection           = menu_navigation_get_selection();
       file_list_t *selection_buf = menu_entries_get_selection_buf_ptr(0);
       ozone_node_t *node         = (ozone_node_t*)selection_buf->list[selection].userdata;
 
       if (node)
       {
+         menu_entry_t entry;
+
          MENU_ENTRY_INITIALIZE(entry);
          entry.flags |= MENU_ENTRY_FLAG_PATH_ENABLED;
          menu_entry_get(&entry, 0, selection, NULL, true);
@@ -7251,7 +7379,8 @@ static void ozone_set_thumbnail_content(void *data, const char *s)
 /* Returns true if specified category is currently
  * displayed on screen */
 static bool INLINE ozone_category_onscreen(
-      ozone_handle_t *ozone, size_t idx)
+      ozone_handle_t *ozone,
+      size_t idx)
 {
    return (idx >= ozone->first_onscreen_category) &&
           (idx <= ozone->last_onscreen_category);
@@ -7268,8 +7397,7 @@ static size_t ozone_get_onscreen_category_selection(
       return ozone->categories_selection_ptr;
 
    /* Return index of centremost category */
-   return (ozone->first_onscreen_category >> 1) +
-         (ozone->last_onscreen_category >> 1);
+   return (ozone->first_onscreen_category >> 1) + (ozone->last_onscreen_category >> 1);
 }
 
 /* If currently selected entry is off screen,
@@ -7293,8 +7421,7 @@ static void ozone_auto_select_onscreen_entry(
          break;
       case OZONE_ONSCREEN_ENTRY_CENTRE:
       default:
-         selection = (ozone->first_onscreen_entry >> 1) +
-               (ozone->last_onscreen_entry >> 1);
+         selection = (ozone->first_onscreen_entry >> 1) + (ozone->last_onscreen_entry >> 1);
          break;
    }
 
@@ -7314,17 +7441,18 @@ static bool INLINE ozone_metadata_override_available(ozone_handle_t *ozone)
     * Short circuiting means that in most cases
     * only OZONE_FLAG_IS_PLAYLIST will be evaluated,
     * so this isn't too much of a performance hog... */
-   return (   (ozone->flags   & OZONE_FLAG_IS_PLAYLIST)
-      ||      (ozone->flags   & OZONE_FLAG_IS_EXPLORE_LIST))
-      &&    (ozone->show_thumbnail_bar)
-      &&    (!(ozone->flags2  & OZONE_FLAG2_SELECTION_CORE_IS_VIEWER))
-      &&    (ozone->thumbnails.left.status == GFX_THUMBNAIL_STATUS_AVAILABLE
-      ||    (ozone->thumbnails.left.status  < GFX_THUMBNAIL_STATUS_AVAILABLE
-      &&    (ozone->thumbnails_left_status_prev <=
-         GFX_THUMBNAIL_STATUS_AVAILABLE)))
-      && (ozone->thumbnails.right.status == GFX_THUMBNAIL_STATUS_AVAILABLE
-      || (ozone->thumbnails.right.status  < GFX_THUMBNAIL_STATUS_AVAILABLE
-      && (ozone->thumbnails_right_status_prev <= GFX_THUMBNAIL_STATUS_AVAILABLE)));
+   return (
+            (ozone->flags   & OZONE_FLAG_IS_PLAYLIST) ||
+            (ozone->flags   & OZONE_FLAG_IS_EXPLORE_LIST)
+         )
+         && (ozone->show_thumbnail_bar)
+         && (!(ozone->flags2 & OZONE_FLAG2_SELECTION_CORE_IS_VIEWER))
+         && (   ozone->thumbnails.left.status == GFX_THUMBNAIL_STATUS_AVAILABLE ||
+               (ozone->thumbnails.left.status       < GFX_THUMBNAIL_STATUS_AVAILABLE &&
+               (ozone->thumbnails_left_status_prev <= GFX_THUMBNAIL_STATUS_AVAILABLE)))
+         && (   ozone->thumbnails.right.status == GFX_THUMBNAIL_STATUS_AVAILABLE ||
+               (ozone->thumbnails.right.status       < GFX_THUMBNAIL_STATUS_AVAILABLE &&
+               (ozone->thumbnails_right_status_prev <= GFX_THUMBNAIL_STATUS_AVAILABLE)));
 }
 
 static bool INLINE ozone_fullscreen_thumbnails_available(ozone_handle_t *ozone)
@@ -7336,11 +7464,11 @@ static bool INLINE ozone_fullscreen_thumbnails_available(ozone_handle_t *ozone)
       && (gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_RIGHT) ||
           gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_LEFT))
       && (  (ozone->thumbnails.left.status == GFX_THUMBNAIL_STATUS_AVAILABLE ||
-               (ozone->thumbnails.left.status < GFX_THUMBNAIL_STATUS_AVAILABLE
-                  && ozone->thumbnails_left_status_prev <= GFX_THUMBNAIL_STATUS_AVAILABLE))
+               (ozone->thumbnails.left.status       < GFX_THUMBNAIL_STATUS_AVAILABLE &&
+                ozone->thumbnails_left_status_prev <= GFX_THUMBNAIL_STATUS_AVAILABLE))
          || (ozone->thumbnails.right.status == GFX_THUMBNAIL_STATUS_AVAILABLE ||
-               (ozone->thumbnails.right.status < GFX_THUMBNAIL_STATUS_AVAILABLE
-                  && ozone->thumbnails_right_status_prev <= GFX_THUMBNAIL_STATUS_AVAILABLE)));
+               (ozone->thumbnails.right.status       < GFX_THUMBNAIL_STATUS_AVAILABLE &&
+                ozone->thumbnails_right_status_prev <= GFX_THUMBNAIL_STATUS_AVAILABLE)));
 
    if (!string_is_empty(ozone->savestate_thumbnail_file_path) &&
          ozone->thumbnails.savestate.status == GFX_THUMBNAIL_STATUS_AVAILABLE)
@@ -7423,8 +7551,7 @@ static bool ozone_is_current_entry_settings(size_t current_selection)
 static void ozone_toggle_metadata_override(ozone_handle_t *ozone)
 {
    gfx_animation_ctx_entry_t animation_entry;
-   uintptr_t alpha_tag                = (uintptr_t)
-      &ozone->animations.left_thumbnail_alpha;
+   uintptr_t alpha_tag         = (uintptr_t)&ozone->animations.left_thumbnail_alpha;
 
    /* Kill any existing fade in/out animations */
    gfx_animation_kill_by_tag(&alpha_tag);
@@ -7462,7 +7589,8 @@ static void ozone_toggle_metadata_override(ozone_handle_t *ozone)
  * once it has started
  */
 static void ozone_start_cursor_wiggle(
-      ozone_handle_t* ozone, enum menu_action direction)
+      ozone_handle_t* ozone,
+      enum menu_action direction)
 {
    /* Don't start another wiggle animation on top of another */
    if (!ozone || (ozone->flags2 & OZONE_FLAG2_CURSOR_WIGGLING))
@@ -7487,8 +7615,11 @@ static void ozone_start_cursor_wiggle(
 /* Common thumbnail switch requires FILE_TYPE_RPL_ENTRY,
  * which only works with playlists, therefore activate it
  * manually for Quick Menu, Explore and Database */
-extern int action_switch_thumbnail(const char *path,
-      const char *label, unsigned type, size_t idx);
+extern int action_switch_thumbnail(
+      const char *path,
+      const char *label,
+      unsigned type,
+      size_t idx);
 
 static enum menu_action ozone_parse_menu_entry_action(
       ozone_handle_t *ozone,
@@ -7562,30 +7693,28 @@ static enum menu_action ozone_parse_menu_entry_action(
          break;
       case MENU_ACTION_SCAN:
          ozone->flags      &= ~(OZONE_FLAG_SKIP_THUMBNAIL_RESET
-                              | OZONE_FLAG_CURSOR_MODE
-                               );
+                              | OZONE_FLAG_CURSOR_MODE);
 
-         if (          (ozone->flags &
-                        OZONE_FLAG_FULLSCREEN_THUMBNAILS_AVAILABLE)
-               &&    (!(ozone->flags2 & OZONE_FLAG2_SHOW_FULLSCREEN_THUMBNAILS))
-               &&     ((ozone->flags  & OZONE_FLAG_IS_STATE_SLOT)
-               ||      (ozone->is_quick_menu && !string_is_empty(ozone->savestate_thumbnail_file_path))))
+         if (       (ozone->flags  & OZONE_FLAG_FULLSCREEN_THUMBNAILS_AVAILABLE)
+               && (!(ozone->flags2 & OZONE_FLAG2_SHOW_FULLSCREEN_THUMBNAILS))
+               && ( (ozone->flags  & OZONE_FLAG_IS_STATE_SLOT) ||
+                    (ozone->is_quick_menu && !string_is_empty(ozone->savestate_thumbnail_file_path))))
          {
             ozone_show_fullscreen_thumbnails(ozone);
             ozone->flags2 |= OZONE_FLAG2_WANT_FULLSCREEN_THUMBNAILS;
             new_action     = MENU_ACTION_NOOP;
          }
-         else if    (ozone->flags2 & OZONE_FLAG2_SHOW_FULLSCREEN_THUMBNAILS
-                && ((ozone->flags  & OZONE_FLAG_IS_STATE_SLOT) 
-                ||  (ozone->is_quick_menu && menu_is_running_quick_menu())))
+         else if (  (ozone->flags2 & OZONE_FLAG2_SHOW_FULLSCREEN_THUMBNAILS)
+               && ( (ozone->flags  & OZONE_FLAG_IS_STATE_SLOT) ||
+                    (ozone->is_quick_menu && menu_is_running_quick_menu())))
          {
             ozone_hide_fullscreen_thumbnails(ozone, true);
             ozone->flags2 &= ~OZONE_FLAG2_WANT_FULLSCREEN_THUMBNAILS;
             new_action     = MENU_ACTION_NOOP;
          }
-         else if ((ozone->flags & OZONE_FLAG_IS_EXPLORE_LIST)
-               || (ozone->is_quick_menu)
-               || (ozone->flags & OZONE_FLAG_IS_DB_MANAGER_LIST))
+         else if (  (ozone->flags & OZONE_FLAG_IS_EXPLORE_LIST)
+               ||   (ozone->flags & OZONE_FLAG_IS_DB_MANAGER_LIST)
+               ||   (ozone->is_quick_menu))
          {
             action_switch_thumbnail(NULL, NULL, 0, 0);
             new_action = MENU_ACTION_NOOP;
@@ -7596,14 +7725,13 @@ static enum menu_action ozone_parse_menu_entry_action(
          {
             /* If cursor is active, ensure we target
              * an on screen category */
-            size_t selection = (ozone->flags & OZONE_FLAG_CURSOR_MODE)
-               ? ozone_get_onscreen_category_selection(ozone)
-               : ozone->categories_selection_ptr;
+            size_t selection   = (ozone->flags & OZONE_FLAG_CURSOR_MODE)
+                  ? ozone_get_onscreen_category_selection(ozone)
+                  : ozone->categories_selection_ptr;
 
-            new_selection    = (int)(selection + 1);
+            new_selection      = (int)(selection + 1);
 
-            if (new_selection >= (int)(ozone->system_tab_end
-                     + horizontal_list_size + 1))
+            if (new_selection >= (int)(ozone->system_tab_end + horizontal_list_size + 1))
                new_selection = 0;
 
             ozone_sidebar_goto(ozone, new_selection);
@@ -7633,8 +7761,8 @@ static enum menu_action ozone_parse_menu_entry_action(
             /* If cursor is active, ensure we target
              * an on screen category */
             size_t selection   = (ozone->flags & OZONE_FLAG_CURSOR_MODE)
-               ? ozone_get_onscreen_category_selection(ozone)
-               : ozone->categories_selection_ptr;
+                  ? ozone_get_onscreen_category_selection(ozone)
+                  : ozone->categories_selection_ptr;
             if ((new_selection = (int)selection - 1) < 0)
                new_selection   = horizontal_list_size + ozone->system_tab_end;
 
@@ -7655,8 +7783,7 @@ static enum menu_action ozone_parse_menu_entry_action(
           * is off screen, auto select *centre* item */
          if (ozone->flags & OZONE_FLAG_CURSOR_MODE)
             if (!OZONE_ENTRY_ONSCREEN(ozone, selection))
-               ozone_auto_select_onscreen_entry(ozone,
-                     OZONE_ONSCREEN_ENTRY_CENTRE);
+               ozone_auto_select_onscreen_entry(ozone, OZONE_ONSCREEN_ENTRY_CENTRE);
          ozone->flags &= ~OZONE_FLAG_CURSOR_MODE;
          break;
       case MENU_ACTION_LEFT:
@@ -7705,12 +7832,14 @@ static enum menu_action ozone_parse_menu_entry_action(
             /* Pressing right goes down but faster, so
                wiggle down to say that there is nothing more downwards
                even though the user pressed the right button */
-            else if (!menu_navigation_wraparound_enable && selection == selection_total - 1 && !is_current_entry_settings)
+            else if (!menu_navigation_wraparound_enable
+                  && selection == (selection_total - 1)
+                  && !is_current_entry_settings)
                ozone_start_cursor_wiggle(ozone, MENU_ACTION_DOWN);
 
-            if (      (ozone->flags2 & OZONE_FLAG2_SHOW_FULLSCREEN_THUMBNAILS)
-                   &&((ozone->flags  & OZONE_FLAG_IS_PLAYLIST)
-                   || (ozone->is_quick_menu && !menu_is_running_quick_menu())))
+            if (     (ozone->flags2 & OZONE_FLAG2_SHOW_FULLSCREEN_THUMBNAILS)
+                  && (  (ozone->flags & OZONE_FLAG_IS_PLAYLIST) ||
+                        (ozone->is_quick_menu && !menu_is_running_quick_menu())))
                return MENU_ACTION_NOOP;
 
             break;
@@ -7722,7 +7851,7 @@ static enum menu_action ozone_parse_menu_entry_action(
          new_action    = MENU_ACTION_ACCESSIBILITY_SPEAK_LABEL;
          break;
       case MENU_ACTION_OK:
-         ozone->flags    &= ~OZONE_FLAG_CURSOR_MODE;
+         ozone->flags &= ~OZONE_FLAG_CURSOR_MODE;
 
          if (ozone->flags & OZONE_FLAG_IS_STATE_SLOT)
             ozone->flags |= OZONE_FLAG_SKIP_THUMBNAIL_RESET;
@@ -7731,11 +7860,11 @@ static enum menu_action ozone_parse_menu_entry_action(
             to prevent accidental imageviewer core launch */
          if (     (ozone->flags & OZONE_FLAG_LIBRETRO_RUNNING)
                && (ozone->flags & OZONE_FLAG_IS_FILE_LIST)
-               && (ozone->show_thumbnail_bar)
-               && (ozone->flags & OZONE_FLAG_FULLSCREEN_THUMBNAILS_AVAILABLE))
+               && (ozone->flags & OZONE_FLAG_FULLSCREEN_THUMBNAILS_AVAILABLE)
+               && (ozone->show_thumbnail_bar))
          {
             ozone_show_fullscreen_thumbnails(ozone);
-            ozone->flags2 |=  OZONE_FLAG2_WANT_FULLSCREEN_THUMBNAILS;
+            ozone->flags2 |= OZONE_FLAG2_WANT_FULLSCREEN_THUMBNAILS;
             new_action     = MENU_ACTION_NOOP;
             break;
          }
@@ -7762,7 +7891,7 @@ static enum menu_action ozone_parse_menu_entry_action(
          }
          break;
       case MENU_ACTION_CANCEL:
-         ozone->flags    &= ~OZONE_FLAG_CURSOR_MODE;
+         ozone->flags &= ~OZONE_FLAG_CURSOR_MODE;
 
          if (ozone->flags & OZONE_FLAG_IS_STATE_SLOT)
             ozone->flags |= OZONE_FLAG_SKIP_THUMBNAIL_RESET;
@@ -7787,6 +7916,7 @@ static enum menu_action ozone_parse_menu_entry_action(
                || (ozone->flags2 & OZONE_FLAG2_WANT_FULLSCREEN_THUMBNAILS))
          {
             ozone_hide_fullscreen_thumbnails(ozone, true);
+            ozone->flags  &= ~OZONE_FLAG_SKIP_THUMBNAIL_RESET;
             ozone->flags2 &= ~OZONE_FLAG2_WANT_FULLSCREEN_THUMBNAILS;
             new_action     = MENU_ACTION_NOOP;
             break;
@@ -7800,7 +7930,7 @@ static enum menu_action ozone_parse_menu_entry_action(
          break;
 
       case MENU_ACTION_SCROLL_UP:
-         /* Descend alphabet (Z towards A) */
+         /* Descend 10 items or to previous alphabet (Z towards A) */
 
          /* Ignore if cursor is in sidebar */
          if (ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR)
@@ -7817,12 +7947,11 @@ static enum menu_action ozone_parse_menu_entry_action(
           * is off screen, auto select *last* item */
          if (ozone->flags & OZONE_FLAG_CURSOR_MODE)
             if (!OZONE_ENTRY_ONSCREEN(ozone, selection))
-               ozone_auto_select_onscreen_entry(ozone,
-                     OZONE_ONSCREEN_ENTRY_LAST);
-         ozone->flags      &= ~OZONE_FLAG_CURSOR_MODE;
+               ozone_auto_select_onscreen_entry(ozone, OZONE_ONSCREEN_ENTRY_LAST);
+         ozone->flags &= ~OZONE_FLAG_CURSOR_MODE;
          break;
       case MENU_ACTION_SCROLL_DOWN:
-         /* Ascend alphabet (A towards Z) */
+         /* Ascend 10 items or to next alphabet (A towards Z) */
 
          /* > Ignore if cursor is in sidebar */
          if (ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR)
@@ -7839,8 +7968,7 @@ static enum menu_action ozone_parse_menu_entry_action(
           * is off screen, auto select *first* item */
          if (ozone->flags & OZONE_FLAG_CURSOR_MODE)
             if (!OZONE_ENTRY_ONSCREEN(ozone, selection))
-               ozone_auto_select_onscreen_entry(ozone,
-                     OZONE_ONSCREEN_ENTRY_FIRST);
+               ozone_auto_select_onscreen_entry(ozone, OZONE_ONSCREEN_ENTRY_FIRST);
          ozone->flags &= ~OZONE_FLAG_CURSOR_MODE;
          break;
 
@@ -7864,7 +7992,7 @@ static enum menu_action ozone_parse_menu_entry_action(
           *   trigger this message when you just want to
           *   toggle metadata... */
          else if ((ozone->flags & OZONE_FLAG_IS_PLAYLIST)
-               && ozone->show_thumbnail_bar)
+               && (ozone->show_thumbnail_bar))
             new_action = MENU_ACTION_NOOP;
 
          ozone->flags &= ~OZONE_FLAG_CURSOR_MODE;
@@ -7880,8 +8008,10 @@ static enum menu_action ozone_parse_menu_entry_action(
 
 /* Menu entry action callback */
 static int ozone_menu_entry_action(
-      void *userdata, menu_entry_t *entry,
-      size_t i, enum menu_action action)
+      void *userdata,
+      menu_entry_t *entry,
+      size_t i,
+      enum menu_action action)
 {
    menu_entry_t new_entry;
    ozone_handle_t *ozone       = (ozone_handle_t*)userdata;
@@ -7903,17 +8033,20 @@ static int ozone_menu_entry_action(
        * entry pointer */
       MENU_ENTRY_INITIALIZE(new_entry);
       menu_entry_get(&new_entry, 0, new_selection, NULL, true);
-      entry_ptr                    = &new_entry;
+      entry_ptr                = &new_entry;
    }
 
    /* Call standard generic_menu_entry_action() function */
-   return generic_menu_entry_action(userdata, entry_ptr,
-         new_selection, new_action);
+   return generic_menu_entry_action(userdata,
+         entry_ptr,
+         new_selection,
+         new_action);
 }
 
 static void ozone_menu_animation_update_time(
       float *ticker_pixel_increment,
-      unsigned video_width, unsigned video_height)
+      unsigned video_width,
+      unsigned video_height)
 {
    gfx_display_t *p_disp      = disp_get_ptr();
    settings_t *settings       = config_get_ptr();
@@ -7947,15 +8080,15 @@ static void *ozone_init(void **userdata, bool video_is_threaded)
    *userdata = ozone;
 
    for (i = 0; i < 15; i++)
-      ozone->pure_white[i]  = 1.00f;
+      ozone->pure_white[i]                      = 1.00f;
 
    video_driver_get_size(&width, &height);
 
-   ozone->last_width        = width;
-   ozone->last_height       = height;
-   ozone->last_scale_factor = gfx_display_get_dpi_scale(p_disp,
+   ozone->last_width                            = width;
+   ozone->last_height                           = height;
+   ozone->last_scale_factor                     = gfx_display_get_dpi_scale(p_disp,
          settings, width, height, false, false);
-   ozone->last_thumbnail_scale_factor = settings->floats.ozone_thumbnail_scale_factor;
+   ozone->last_thumbnail_scale_factor           = settings->floats.ozone_thumbnail_scale_factor;
 
    ozone->selection_buf_old.list                = NULL;
    ozone->selection_buf_old.capacity            = 0;
@@ -7967,10 +8100,9 @@ static void *ozone_init(void **userdata, bool video_is_threaded)
    ozone->categories_selection_ptr              = 0;
    ozone->pending_message                       = NULL;
 
-   ozone->flags                                |=  OZONE_FLAG_FIRST_FRAME;
+   ozone->flags                                |= OZONE_FLAG_FIRST_FRAME;
 
    ozone->animations.sidebar_text_alpha         = 1.0f;
-
    ozone->animations.thumbnail_bar_position     = 0.0f;
    ozone->dimensions_sidebar_width              = 0.0f;
 
@@ -7993,8 +8125,8 @@ static void *ozone_init(void **userdata, bool video_is_threaded)
 
    ozone->animations.left_thumbnail_alpha       = 1.0f;
 
-   ozone->thumbnails.pending      = OZONE_PENDING_THUMBNAIL_NONE;
-   ozone->thumbnails.stream_delay = OZONE_THUMBNAIL_STREAM_DELAY;
+   ozone->thumbnails.pending                    = OZONE_PENDING_THUMBNAIL_NONE;
+   ozone->thumbnails.stream_delay               = OZONE_THUMBNAIL_STREAM_DELAY;
    gfx_thumbnail_set_stream_delay(ozone->thumbnails.stream_delay);
    gfx_thumbnail_set_fade_duration(-1.0f);
    gfx_thumbnail_set_fade_missing(false);
@@ -8050,9 +8182,9 @@ static void *ozone_init(void **userdata, bool video_is_threaded)
 
    gfx_display_init_white_texture();
 
-   ozone->horizontal_list.list     = NULL;
-   ozone->horizontal_list.capacity = 0;
-   ozone->horizontal_list.size     = 0;
+   ozone->horizontal_list.list                  = NULL;
+   ozone->horizontal_list.capacity              = 0;
+   ozone->horizontal_list.size                  = 0;
 
    ozone_init_horizontal_list(ozone, settings);
 
@@ -8074,65 +8206,67 @@ static void *ozone_init(void **userdata, bool video_is_threaded)
       }
       else
 #endif
-         fallback_color_theme = true;
+         fallback_color_theme                   = true;
    }
    else
-      fallback_color_theme    = true;
+      fallback_color_theme                      = true;
 
    if (fallback_color_theme)
    {
-      color_theme = settings->uints.menu_ozone_color_theme;
+      color_theme                               = settings->uints.menu_ozone_color_theme;
       ozone_set_color_theme(ozone, color_theme);
    }
 
-   ozone->flags                       &= ~OZONE_FLAG_NEED_COMPUTE;
-   ozone->animations.scroll_y          = 0.0f;
-   ozone->animations.scroll_y_sidebar  = 0.0f;
+   ozone->flags                                &= ~OZONE_FLAG_NEED_COMPUTE;
+   ozone->animations.scroll_y                   = 0.0f;
+   ozone->animations.scroll_y_sidebar           = 0.0f;
 
-   ozone->first_onscreen_entry         = 0;
-   ozone->last_onscreen_entry          = 0;
-   ozone->first_onscreen_category      = 0;
-   ozone->last_onscreen_category       = 0;
+   ozone->first_onscreen_entry                  = 0;
+   ozone->last_onscreen_entry                   = 0;
+   ozone->first_onscreen_category               = 0;
+   ozone->last_onscreen_category                = 0;
 
    /* Assets path */
    fill_pathname_join_special(
-      ozone->assets_path,
-      directory_assets,
-      "ozone",
-      sizeof(ozone->assets_path)
-   );
+         ozone->assets_path,
+         directory_assets,
+         "ozone",
+         sizeof(ozone->assets_path));
 
    /* PNG path */
    fill_pathname_join_special(
-      ozone->png_path,
-      ozone->assets_path,
-      "png",
-      sizeof(ozone->png_path)
-   );
+         ozone->png_path,
+         ozone->assets_path,
+         "png",
+         sizeof(ozone->png_path));
 
    /* Sidebar path */
    fill_pathname_join_special(
-      ozone->tab_path,
-      ozone->png_path,
-      "sidebar",
-      sizeof(ozone->tab_path)
-   );
+         ozone->tab_path,
+         ozone->png_path,
+         "sidebar",
+         sizeof(ozone->tab_path));
 
    /* Icons path */
    fill_pathname_application_special(ozone->icons_path,
-       sizeof(ozone->icons_path),
-       APPLICATION_SPECIAL_DIRECTORY_ASSETS_OZONE_ICONS);
-   fill_pathname_join_special(ozone->icons_path_default, ozone->icons_path,
-		   "default", sizeof(ozone->icons_path_default));
+         sizeof(ozone->icons_path),
+         APPLICATION_SPECIAL_DIRECTORY_ASSETS_OZONE_ICONS);
+   fill_pathname_join_special(ozone->icons_path_default,
+         ozone->icons_path,
+         "default",
+         sizeof(ozone->icons_path_default));
 
    if (settings->bools.menu_use_preferred_system_color_theme)
       ozone->flags2 |=  OZONE_FLAG2_LAST_USE_PREFERRED_SYSTEM_COLOR_THEME;
    else
       ozone->flags2 &= ~OZONE_FLAG2_LAST_USE_PREFERRED_SYSTEM_COLOR_THEME;
-   p_anim->updatetime_cb                       = ozone_menu_animation_update_time;
+
+   p_anim->updatetime_cb                        = ozone_menu_animation_update_time;
 
    /* set word_wrap function pointer */
-   ozone->word_wrap = msg_hash_get_wideglyph_str() ? word_wrap_wideglyph : word_wrap;
+   ozone->word_wrap                             = msg_hash_get_wideglyph_str()
+         ? word_wrap_wideglyph
+         : word_wrap;
 
    return menu;
 
@@ -8206,18 +8340,16 @@ static void ozone_update_thumbnail_image(void *data)
    }
 
    /* Right thumbnail */
-   if (gfx_thumbnail_is_enabled(ozone->thumbnail_path_data,
-         GFX_THUMBNAIL_RIGHT))
+   if (gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_RIGHT))
       ozone->thumbnails.pending = OZONE_PENDING_THUMBNAIL_RIGHT;
 
    /* Left thumbnail
     * > Disabled for image (and video/music) content */
    if (  (!(ozone->flags2 & OZONE_FLAG2_SELECTION_CORE_IS_VIEWER))
-       &&  (gfx_thumbnail_is_enabled(ozone->thumbnail_path_data,
-         GFX_THUMBNAIL_LEFT)))
-      ozone->thumbnails.pending =
-            (ozone->thumbnails.pending == OZONE_PENDING_THUMBNAIL_RIGHT) ?
-                  OZONE_PENDING_THUMBNAIL_BOTH : OZONE_PENDING_THUMBNAIL_LEFT;
+       &&  (gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_LEFT)))
+      ozone->thumbnails.pending = (ozone->thumbnails.pending == OZONE_PENDING_THUMBNAIL_RIGHT)
+            ? OZONE_PENDING_THUMBNAIL_BOTH
+            : OZONE_PENDING_THUMBNAIL_LEFT;
 
    show_thumbnail_bar = ozone->show_thumbnail_bar;
    want_thumbnail_bar = ozone->flags & OZONE_FLAG_WANT_THUMBNAIL_BAR;
@@ -8239,54 +8371,50 @@ static void ozone_refresh_thumbnail_image(void *data, unsigned i)
       ozone_update_content_metadata(ozone);
 
    /* Only refresh thumbnails if thumbnails are enabled */
-   if (
-            (gfx_thumbnail_is_enabled(ozone->thumbnail_path_data,
-                                      GFX_THUMBNAIL_RIGHT) 
-         || (gfx_thumbnail_is_enabled(ozone->thumbnail_path_data,
-               GFX_THUMBNAIL_LEFT))
-           )
-         &&  (ozone->flags & OZONE_FLAG_WANT_THUMBNAIL_BAR)
-         && ((ozone->is_quick_menu)
-         ||  (ozone->flags & OZONE_FLAG_IS_PLAYLIST)
-         ||  (ozone->flags & OZONE_FLAG_IS_EXPLORE_LIST)))
+   if (     (  gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_RIGHT) ||
+               gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_LEFT))
+         && (ozone->flags & OZONE_FLAG_WANT_THUMBNAIL_BAR)
+         && (  (ozone->is_quick_menu) ||
+               (ozone->flags & OZONE_FLAG_IS_PLAYLIST) ||
+               (ozone->flags & OZONE_FLAG_IS_EXPLORE_LIST)))
       ozone_update_thumbnail_image(ozone);
 }
 
 static bool ozone_init_font(
       ozone_font_data_t *font_data,
-      bool is_threaded, char *font_path, float font_size)
+      bool is_threaded,
+      char *font_path,
+      float font_size)
 {
-   int glyph_width       = 0;
-   gfx_display_t *p_disp = disp_get_ptr();
-   const char *wideglyph_str = msg_hash_get_wideglyph_str();
+   int glyph_width               = 0;
+   gfx_display_t *p_disp         = disp_get_ptr();
+   const char *wideglyph_str     = msg_hash_get_wideglyph_str();
 
    /* Free existing */
    if (font_data->font)
    {
       gfx_display_font_free(font_data->font);
-      font_data->font = NULL;
+      font_data->font            = NULL;
    }
 
    /* Cache approximate dimensions */
-   font_data->line_height = (int)(font_size + 0.5f);
-   font_data->glyph_width = (int)((font_size * (3.0f / 4.0f)) + 0.5f);
+   font_data->line_height        = (int)(font_size + 0.5f);
+   font_data->glyph_width        = (int)((font_size * (3.0f / 4.0f)) + 0.5f);
 
    /* Create font */
-   if (!(font_data->font = gfx_display_font_file(p_disp, 
-         font_path, font_size, is_threaded)))
+   if (!(font_data->font = gfx_display_font_file(p_disp, font_path, font_size, is_threaded)))
       return false;
 
    /* Get font metadata */
-   if ((glyph_width = font_driver_get_message_width(font_data->font, "a", 1,
-               1.0f)) > 0)
+   if ((glyph_width = font_driver_get_message_width(font_data->font, "a", 1, 1.0f)) > 0)
       font_data->glyph_width     = glyph_width;
 
    font_data->wideglyph_width    = 100;
 
    if (wideglyph_str)
    {
-      int wideglyph_width =
-         font_driver_get_message_width(font_data->font, wideglyph_str, strlen(wideglyph_str), 1.0f);
+      int wideglyph_width        =
+            font_driver_get_message_width(font_data->font, wideglyph_str, strlen(wideglyph_str), 1.0f);
       
       if (wideglyph_width > 0 && glyph_width > 0) 
          font_data->wideglyph_width = wideglyph_width * 100 / glyph_width;
@@ -8299,8 +8427,10 @@ static bool ozone_init_font(
    return true;
 }
 
-static void ozone_cache_footer_label(ozone_handle_t *ozone,
-      ozone_footer_label_t *label, enum msg_hash_enums enum_idx)
+static void ozone_cache_footer_label(
+      ozone_handle_t *ozone,
+      ozone_footer_label_t *label,
+      enum msg_hash_enums enum_idx)
 {
    const char *str = msg_hash_to_str(enum_idx);
    /* Determine pixel width */
@@ -8308,9 +8438,7 @@ static void ozone_cache_footer_label(ozone_handle_t *ozone,
 
    /* Assign string */
    label->str      = str;
-   label->width    = font_driver_get_message_width(
-         ozone->fonts.footer.font,
-         label->str, length, 1.0f);
+   label->width    = font_driver_get_message_width(ozone->fonts.footer.font, label->str, length, 1.0f);
    /* If font_driver_get_message_width() fails,
     * use predetermined glyph_width as a fallback */
    if (label->width < 0)
@@ -8321,28 +8449,28 @@ static void ozone_cache_footer_label(ozone_handle_t *ozone,
  * menu language) and calculates pixel widths */
 static void ozone_cache_footer_labels(ozone_handle_t *ozone)
 {
-   ozone_cache_footer_label(
-         ozone, &ozone->footer_labels.ok,
+   ozone_cache_footer_label(ozone,
+         &ozone->footer_labels.ok,
          MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_OK);
 
-   ozone_cache_footer_label(
-         ozone, &ozone->footer_labels.back,
+   ozone_cache_footer_label(ozone,
+         &ozone->footer_labels.back,
          MENU_ENUM_LABEL_VALUE_BASIC_MENU_CONTROLS_BACK);
 
-   ozone_cache_footer_label(
-         ozone, &ozone->footer_labels.search,
+   ozone_cache_footer_label(ozone,
+         &ozone->footer_labels.search,
          MENU_ENUM_LABEL_VALUE_SEARCH);
 
-   ozone_cache_footer_label(
-         ozone, &ozone->footer_labels.cycle,
+   ozone_cache_footer_label(ozone,
+         &ozone->footer_labels.cycle,
          MENU_ENUM_LABEL_VALUE_CYCLE_THUMBNAILS);
 
-   ozone_cache_footer_label(
-         ozone, &ozone->footer_labels.fullscreen_thumbs,
+   ozone_cache_footer_label(ozone,
+         &ozone->footer_labels.fullscreen_thumbs,
          MSG_TOGGLE_FULLSCREEN_THUMBNAILS);
 
-   ozone_cache_footer_label(
-         ozone, &ozone->footer_labels.metadata_toggle,
+   ozone_cache_footer_label(ozone,
+         &ozone->footer_labels.metadata_toggle,
          MSG_TOGGLE_CONTENT_METADATA);
 
    /* Record current language setting */
@@ -8357,21 +8485,21 @@ static void ozone_set_layout(
 {
    char s1[PATH_MAX_LENGTH];
    char font_path[PATH_MAX_LENGTH];
-   settings_t *settings  = config_get_ptr();
-   bool font_inited      = false;
-   float scale_factor    = ozone->last_scale_factor;
+   settings_t *settings                             = config_get_ptr();
+   bool font_inited                                 = false;
+   float scale_factor                               = ozone->last_scale_factor;
 
    /* Calculate dimensions */
-   ozone->dimensions.header_height                 = HEADER_HEIGHT * scale_factor;
-   ozone->dimensions.footer_height                 = FOOTER_HEIGHT * scale_factor;
+   ozone->dimensions.header_height                  = HEADER_HEIGHT * scale_factor;
+   ozone->dimensions.footer_height                  = FOOTER_HEIGHT * scale_factor;
 
-   ozone->dimensions.entry_padding_horizontal_half = ENTRY_PADDING_HORIZONTAL_HALF * scale_factor;
-   ozone->dimensions.entry_padding_horizontal_full = ENTRY_PADDING_HORIZONTAL_FULL * scale_factor;
-   ozone->dimensions.entry_padding_vertical        = ENTRY_PADDING_VERTICAL * scale_factor;
-   ozone->dimensions.entry_height                  = ENTRY_HEIGHT * scale_factor;
-   ozone->dimensions.entry_spacing                 = ENTRY_SPACING * scale_factor;
-   ozone->dimensions.entry_icon_size               = ENTRY_ICON_SIZE * scale_factor;
-   ozone->dimensions.entry_icon_padding            = ENTRY_ICON_PADDING * scale_factor;
+   ozone->dimensions.entry_padding_horizontal_half  = ENTRY_PADDING_HORIZONTAL_HALF * scale_factor;
+   ozone->dimensions.entry_padding_horizontal_full  = ENTRY_PADDING_HORIZONTAL_FULL * scale_factor;
+   ozone->dimensions.entry_padding_vertical         = ENTRY_PADDING_VERTICAL * scale_factor;
+   ozone->dimensions.entry_height                   = ENTRY_HEIGHT * scale_factor;
+   ozone->dimensions.entry_spacing                  = ENTRY_SPACING * scale_factor;
+   ozone->dimensions.entry_icon_size                = ENTRY_ICON_SIZE * scale_factor;
+   ozone->dimensions.entry_icon_padding             = ENTRY_ICON_PADDING * scale_factor;
 
    ozone->dimensions.sidebar_entry_height           = SIDEBAR_ENTRY_HEIGHT * scale_factor;
    ozone->dimensions.sidebar_padding_horizontal     = SIDEBAR_X_PADDING * scale_factor;
@@ -8382,20 +8510,19 @@ static void ozone_set_layout(
    ozone->dimensions.sidebar_gradient_height        = SIDEBAR_GRADIENT_HEIGHT * scale_factor;
 
    ozone->dimensions.sidebar_width_normal           = SIDEBAR_WIDTH * scale_factor;
-   ozone->dimensions.sidebar_width_collapsed        =
-         ozone->dimensions.sidebar_entry_icon_size +
-         ozone->dimensions.sidebar_entry_icon_padding * 2 +
-         ozone->dimensions.sidebar_padding_horizontal * 2;
+   ozone->dimensions.sidebar_width_collapsed        = ozone->dimensions.sidebar_entry_icon_size
+         + ozone->dimensions.sidebar_entry_icon_padding * 2
+         + ozone->dimensions.sidebar_padding_horizontal * 2;
 
    if (ozone->dimensions_sidebar_width == 0)
       ozone->dimensions_sidebar_width               = (float)ozone->dimensions.sidebar_width_normal;
 
-   ozone->dimensions.thumbnail_bar_width            =
+   ozone->dimensions.thumbnail_bar_width            = ozone->last_thumbnail_scale_factor *
          (ozone->dimensions.sidebar_width_normal -
           ozone->dimensions.sidebar_entry_icon_size +
-          ozone->dimensions.sidebar_entry_icon_padding) *
-         ozone->last_thumbnail_scale_factor;
-   /* Prevent the thumbnail sidebar from growing too much and make the UI unusable. */
+          ozone->dimensions.sidebar_entry_icon_padding);
+
+   /* Prevent thumbnail sidebar from growing too much and making the UI unusable. */
    if (ozone->dimensions.thumbnail_bar_width > ozone->last_width / 3.0f)
       ozone->dimensions.thumbnail_bar_width         = ozone->last_width / 3.0f;
 
@@ -8403,6 +8530,7 @@ static void ozone_set_layout(
 
    ozone->dimensions.fullscreen_thumbnail_padding   = FULLSCREEN_THUMBNAIL_PADDING * scale_factor;
 
+   /* Common spacers */
    ozone->dimensions.spacer_1px = (scale_factor > 1.0f) ? (unsigned)(scale_factor + 0.5f) : 1;
    ozone->dimensions.spacer_2px = ozone->dimensions.spacer_1px * 2;
    ozone->dimensions.spacer_3px = (unsigned)((scale_factor * 3.0f) + 0.5f);
@@ -8418,23 +8546,21 @@ static void ozone_set_layout(
    {
       case RETRO_LANGUAGE_ARABIC:
       case RETRO_LANGUAGE_PERSIAN:
-         fill_pathname_join_special(s1,
-               settings->paths.directory_assets, "pkg", sizeof(s1));
+         fill_pathname_join_special(s1, settings->paths.directory_assets, "pkg", sizeof(s1));
          fill_pathname_join_special(font_path, s1, "fallback-font.ttf", sizeof(font_path));
          break;
       case RETRO_LANGUAGE_CHINESE_SIMPLIFIED:
       case RETRO_LANGUAGE_CHINESE_TRADITIONAL:
-         fill_pathname_join_special(s1,
-               settings->paths.directory_assets, "pkg", sizeof(s1));
+         fill_pathname_join_special(s1, settings->paths.directory_assets, "pkg", sizeof(s1));
          fill_pathname_join_special(font_path, s1, "chinese-fallback-font.ttf", sizeof(font_path));
          break;
       case RETRO_LANGUAGE_KOREAN:
-         fill_pathname_join_special(s1,
-               settings->paths.directory_assets, "pkg", sizeof(s1));
+         fill_pathname_join_special(s1, settings->paths.directory_assets, "pkg", sizeof(s1));
          fill_pathname_join_special(font_path, s1, "korean-fallback-font.ttf", sizeof(font_path));
          break;
       default:
          fill_pathname_join_special(font_path, ozone->assets_path, "bold.ttf", sizeof(font_path));
+         break;
    }
 
    font_inited = ozone_init_font(&ozone->fonts.title,
@@ -8446,23 +8572,21 @@ static void ozone_set_layout(
    {
       case RETRO_LANGUAGE_ARABIC:
       case RETRO_LANGUAGE_PERSIAN:
-         fill_pathname_join_special(s1,
-               settings->paths.directory_assets, "pkg", sizeof(s1));
+         fill_pathname_join_special(s1, settings->paths.directory_assets, "pkg", sizeof(s1));
          fill_pathname_join_special(font_path, s1, "fallback-font.ttf", sizeof(font_path));
          break;
       case RETRO_LANGUAGE_CHINESE_SIMPLIFIED:
       case RETRO_LANGUAGE_CHINESE_TRADITIONAL:
-         fill_pathname_join_special(s1,
-               settings->paths.directory_assets, "pkg", sizeof(s1));
+         fill_pathname_join_special(s1, settings->paths.directory_assets, "pkg", sizeof(s1));
          fill_pathname_join_special(font_path, s1, "chinese-fallback-font.ttf", sizeof(font_path));
          break;
       case RETRO_LANGUAGE_KOREAN:
-         fill_pathname_join_special(s1,
-               settings->paths.directory_assets, "pkg", sizeof(s1));
+         fill_pathname_join_special(s1, settings->paths.directory_assets, "pkg", sizeof(s1));
          fill_pathname_join_special(font_path, s1, "korean-fallback-font.ttf", sizeof(font_path));
          break;
       default:
          fill_pathname_join_special(font_path, ozone->assets_path, "regular.ttf", sizeof(font_path));
+         break;
    }
 
    font_inited = ozone_init_font(&ozone->fonts.footer,
@@ -8538,7 +8662,7 @@ static void ozone_context_reset(void *data, bool is_threaded)
       for (i = 0; i < OZONE_TEXTURE_LAST; i++)
       {
          char filename[64];
-#if 0
+#ifdef HAVE_DISCORD_OWN_AVATAR
          if (i == OZONE_TEXTURE_DISCORD_OWN_AVATAR && discord_avatar_is_ready())
          {
             strlcpy(filename, discord_get_own_avatar(), sizeof(filename));
@@ -8550,29 +8674,30 @@ static void ozone_context_reset(void *data, bool is_threaded)
             strlcpy(filename, OZONE_TEXTURES_FILES[i], sizeof(filename));
          }
 
-#if 0
+#ifdef HAVE_DISCORD_OWN_AVATAR
          if (i == OZONE_TEXTURE_DISCORD_OWN_AVATAR && discord_avatar_is_ready())
          {
             char buf[PATH_MAX_LENGTH];
             fill_pathname_application_special(buf,
                sizeof(buf),
                APPLICATION_SPECIAL_DIRECTORY_THUMBNAILS_DISCORD_AVATARS);
-            gfx_display_reset_textures_list(filename, buf, &ozone->textures[i], TEXTURE_FILTER_MIPMAP_LINEAR, NULL, NULL);
+            gfx_display_reset_textures_list(filename,
+                  buf, &ozone->textures[i], TEXTURE_FILTER_MIPMAP_LINEAR, NULL, NULL);
          }
          else
+#endif
          {
-#endif
-            if (!gfx_display_reset_textures_list(filename, ozone->png_path, &ozone->textures[i], TEXTURE_FILTER_MIPMAP_LINEAR, NULL, NULL))
+            if (!gfx_display_reset_textures_list(filename,
+                  ozone->png_path, &ozone->textures[i], TEXTURE_FILTER_MIPMAP_LINEAR, NULL, NULL))
                ozone->flags &= ~OZONE_FLAG_HAS_ALL_ASSETS;
-#if 0
          }
-#endif
       }
 
       /* Sidebar textures */
       for (i = 0; i < OZONE_TAB_TEXTURE_LAST; i++)
       {
-         if (!gfx_display_reset_textures_list(OZONE_TAB_TEXTURES_FILES[i], ozone->tab_path, &ozone->tab_textures[i], TEXTURE_FILTER_MIPMAP_LINEAR, NULL, NULL))
+         if (!gfx_display_reset_textures_list(OZONE_TAB_TEXTURES_FILES[i],
+               ozone->tab_path, &ozone->tab_textures[i], TEXTURE_FILTER_MIPMAP_LINEAR, NULL, NULL))
             ozone->flags &= ~OZONE_FLAG_HAS_ALL_ASSETS;
       }
 
@@ -8583,7 +8708,8 @@ static void ozone_context_reset(void *data, bool is_threaded)
       /* Icons textures init */
       for (i = 0; i < OZONE_ENTRIES_ICONS_TEXTURE_LAST; i++)
       {
-         if (!gfx_display_reset_textures_list(ozone_entries_icon_texture_path(i), ozone->icons_path, &ozone->icons_textures[i], TEXTURE_FILTER_MIPMAP_LINEAR, NULL, NULL))
+         if (!gfx_display_reset_textures_list(ozone_entries_icon_texture_path(i),
+               ozone->icons_path, &ozone->icons_textures[i], TEXTURE_FILTER_MIPMAP_LINEAR, NULL, NULL))
             ozone->flags &= ~OZONE_FLAG_HAS_ALL_ASSETS;
       }
 
@@ -8605,9 +8731,9 @@ static void ozone_context_reset(void *data, bool is_threaded)
       ozone->flags2                      &= ~OZONE_FLAG2_CURSOR_WIGGLING;
 
       /* Animations */
-      ozone->animations.cursor_alpha   = 1.0f;
-      ozone->animations.scroll_y       = 0.0f;
-      ozone->animations.list_alpha     = 1.0f;
+      ozone->animations.cursor_alpha      = 1.0f;
+      ozone->animations.scroll_y          = 0.0f;
+      ozone->animations.list_alpha        = 1.0f;
 
       /* Thumbnails */
       ozone_update_thumbnail_image(ozone);
@@ -8619,6 +8745,7 @@ static void ozone_context_reset(void *data, bool is_threaded)
       /* Screensaver */
       menu_screensaver_context_destroy(ozone->screensaver);
    }
+
    video_driver_monitor_reset();
 }
 
@@ -9031,7 +9158,8 @@ static void ozone_list_free(file_list_t *list, size_t a, size_t b)
 }
 
 static void ozone_render(void *data,
-      unsigned width, unsigned height,
+      unsigned width,
+      unsigned height,
       bool is_idle)
 {
    size_t i;
@@ -9163,23 +9291,26 @@ static void ozone_render(void *data,
    if (pointer_enabled)
    {
       bool pointer_in_sidebar, last_pointer_in_sidebar;
-      file_list_t *selection_buf  = menu_entries_get_selection_buf_ptr(0);
-      uintptr_t     animation_tag = (uintptr_t)selection_buf;
+      file_list_t *selection_buf    = menu_entries_get_selection_buf_ptr(0);
+      uintptr_t     animation_tag   = (uintptr_t)selection_buf;
 
-      int entry_padding           = (ozone->depth == 1) ?
-            ozone->dimensions.entry_padding_horizontal_half :
-                  ozone->dimensions.entry_padding_horizontal_full;
-      float entry_x               = ozone->dimensions_sidebar_width +
-            ozone->sidebar_offset + entry_padding;
-      float entry_width           = width - ozone->dimensions_sidebar_width -
-            ozone->sidebar_offset - entry_padding * 2 -
-            ozone->animations.thumbnail_bar_position;
-      bool first_entry_found      = false;
-      bool last_entry_found       = false;
+      int entry_padding             = (ozone->depth == 1)
+            ? ozone->dimensions.entry_padding_horizontal_half
+            : ozone->dimensions.entry_padding_horizontal_full;
+      float entry_x                 = ozone->dimensions_sidebar_width
+            + ozone->sidebar_offset
+            + entry_padding;
+      float entry_width             = width
+            - ozone->dimensions_sidebar_width
+            - ozone->sidebar_offset
+            - entry_padding * 2
+            - ozone->animations.thumbnail_bar_position;
+      bool first_entry_found        = false;
+      bool last_entry_found         = false;
 
       unsigned horizontal_list_size = (unsigned)ozone->horizontal_list.size;
-      float category_height         = ozone->dimensions.sidebar_entry_height +
-            ozone->dimensions.sidebar_entry_padding_vertical;
+      float category_height         = ozone->dimensions.sidebar_entry_height
+            + ozone->dimensions.sidebar_entry_padding_vertical;
       bool first_category_found     = false;
       bool last_category_found      = false;
 
@@ -9207,8 +9338,7 @@ static void ozone_render(void *data,
            ozone->pointer.pressed)
       {
          if ((ozone->flags & OZONE_FLAG_DRAW_SIDEBAR)
-               && (ozone->pointer.x < ozone->dimensions_sidebar_width 
-                + ozone->sidebar_offset))
+               && (ozone->pointer.x < ozone->dimensions_sidebar_width + ozone->sidebar_offset))
             ozone->flags2 |=  OZONE_FLAG2_POINTER_IN_SIDEBAR;
          else
             ozone->flags2 &= ~OZONE_FLAG2_POINTER_IN_SIDEBAR;
@@ -9231,16 +9361,14 @@ static void ozone_render(void *data,
        * mouse focus from entries to sidebar (and vice versa) */
       if (ozone->pointer.type == MENU_POINTER_MOUSE)
       {
-         pointer_in_sidebar      = ozone->flags2 &
-            OZONE_FLAG2_POINTER_IN_SIDEBAR;
-         last_pointer_in_sidebar = ozone->flags2 &
-            OZONE_FLAG2_LAST_POINTER_IN_SIDEBAR;
+         pointer_in_sidebar      = ozone->flags2 & OZONE_FLAG2_POINTER_IN_SIDEBAR;
+         last_pointer_in_sidebar = ozone->flags2 & OZONE_FLAG2_LAST_POINTER_IN_SIDEBAR;
 
-         if (      pointer_in_sidebar
-             && (!(last_pointer_in_sidebar))
-             && (!(ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR)))
+         if (       (pointer_in_sidebar)
+               && (!(last_pointer_in_sidebar))
+               && (!(ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR)))
             ozone_go_to_sidebar(ozone, ozone_collapse_sidebar, animation_tag);
-         else if (  (!pointer_in_sidebar)
+         else if (   (!pointer_in_sidebar)
                   && (last_pointer_in_sidebar)
                   && (ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR))
             if (!(ozone->flags & OZONE_FLAG_EMPTY_PLAYLIST))
@@ -9252,9 +9380,11 @@ static void ozone_render(void *data,
        * > Entries */
       if (!(ozone->flags2 & OZONE_FLAG2_POINTER_IN_SIDEBAR))
       {
-         float entry_bottom_boundary = height - ozone->dimensions.header_height -
-               ozone->dimensions.spacer_1px - ozone->dimensions.footer_height -
-               ozone->dimensions.entry_padding_vertical * 2;
+         float entry_bottom_boundary = height
+               - ozone->dimensions.header_height
+               - ozone->dimensions.spacer_1px
+               - ozone->dimensions.footer_height
+               - ozone->dimensions.entry_padding_vertical * 2;
 
          ozone->animations.scroll_y += ozone->pointer.y_accel;
 
@@ -9307,9 +9437,11 @@ static void ozone_render(void *data,
             break;
 
          /* Get current entry y position */
-         entry_y = ozone->dimensions.header_height + ozone->dimensions.spacer_1px +
-               ozone->dimensions.entry_padding_vertical + ozone->animations.scroll_y +
-               node->position_y;
+         entry_y = ozone->dimensions.header_height
+               + ozone->dimensions.spacer_1px
+               + ozone->dimensions.entry_padding_vertical
+               + ozone->animations.scroll_y
+               + node->position_y;
 
          /* Check whether this is the first on screen entry */
          if (!first_entry_found)
@@ -9336,16 +9468,16 @@ static void ozone_render(void *data,
          }
 
          /* Track pointer input, if required */
-         if ((!(ozone->flags2 & OZONE_FLAG2_POINTER_IN_SIDEBAR))
-             && first_entry_found
-             && !last_entry_found)
+         if (     (!(ozone->flags2 & OZONE_FLAG2_POINTER_IN_SIDEBAR))
+               && first_entry_found
+               && !last_entry_found)
          {
             /* Check whether pointer is within the bounds
              * of the current entry */
-            if ((ozone->pointer.x > entry_x) &&
-                (ozone->pointer.x < entry_x + entry_width) &&
-                (ozone->pointer.y > entry_y) &&
-                (ozone->pointer.y < entry_y + node->height))
+            if (     (ozone->pointer.x > entry_x)
+                  && (ozone->pointer.x < entry_x + entry_width)
+                  && (ozone->pointer.y > entry_y)
+                  && (ozone->pointer.y < entry_y + node->height))
             {
                /* Pointer selection is always updated */
                menu_input_set_pointer_selection((unsigned)i);
@@ -9358,17 +9490,16 @@ static void ozone_render(void *data,
                    * items while drag-scrolling the entry list,
                    * so have to wait until pointer acceleration
                    * drops below a 'sensible' level... */
-                  if (   (!(ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR))
-                      && (i != ozone->selection)
-                      && (ozone->pointer.y_accel < ozone->last_scale_factor)
-                      && (ozone->pointer.y_accel > -ozone->last_scale_factor))
+                  if (     (!(ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR))
+                        && (i != ozone->selection)
+                        && (ozone->pointer.y_accel < ozone->last_scale_factor)
+                        && (ozone->pointer.y_accel > -ozone->last_scale_factor))
                   {
                      menu_navigation_set_selection(i);
 
                      /* If this is a playlist, must update thumbnails */
-                     if ((       (ozone->flags & OZONE_FLAG_IS_PLAYLIST)
-                              && (ozone->depth == 1 || ozone->depth == 4))
-                              || (ozone->flags & OZONE_FLAG_IS_EXPLORE_LIST))
+                     if (    ((ozone->flags & OZONE_FLAG_IS_PLAYLIST) && (ozone->depth == 1 || ozone->depth == 4))
+                           || (ozone->flags & OZONE_FLAG_IS_EXPLORE_LIST))
                      {
                         ozone->flags &= ~OZONE_FLAG_SKIP_THUMBNAIL_RESET;
                         ozone_set_thumbnail_content(ozone, "");
@@ -9388,10 +9519,10 @@ static void ozone_render(void *data,
                 * if pointer has been held for at least
                 * MENU_INPUT_PRESS_TIME_SHORT ms, automatically
                 * select current entry */
-               if (ozone->pointer.pressed &&
-                   !ozone->pointer.dragged &&
-                   (ozone->pointer.press_duration >= MENU_INPUT_PRESS_TIME_SHORT) &&
-                   (i != ozone->selection))
+               if (      ozone->pointer.pressed
+                     && !ozone->pointer.dragged
+                     && (ozone->pointer.press_duration >= MENU_INPUT_PRESS_TIME_SHORT)
+                     && (i != ozone->selection))
                {
                   menu_navigation_set_selection(i);
 
@@ -9423,11 +9554,14 @@ static void ozone_render(void *data,
       for (i = 0; i < ozone->system_tab_end + horizontal_list_size + 1; i++)
       {
          /* Get current category y position */
-         float category_y = ozone->dimensions.header_height + ozone->dimensions.spacer_1px +
-               ozone->dimensions.sidebar_padding_vertical + (category_height * i) +
-               ((i > ozone->system_tab_end) ?
-                     (ozone->dimensions.sidebar_entry_padding_vertical + ozone->dimensions.spacer_1px) : 0) +
-               ozone->animations.scroll_y_sidebar;
+         float category_y = ozone->dimensions.header_height
+               + ozone->dimensions.spacer_1px
+               + ozone->dimensions.sidebar_padding_vertical
+               + (category_height * i)
+               + ((i > ozone->system_tab_end)
+                     ? (ozone->dimensions.sidebar_entry_padding_vertical + ozone->dimensions.spacer_1px)
+                     : 0)
+               + ozone->animations.scroll_y_sidebar;
 
          /* Check whether this is the first on screen category */
          if (!first_category_found)
@@ -9454,16 +9588,16 @@ static void ozone_render(void *data,
          }
 
          /* Track pointer input, if required */
-         if (   (ozone->flags2 & OZONE_FLAG2_POINTER_IN_SIDEBAR)
-             && (ozone->flags  & OZONE_FLAG_CURSOR_IN_SIDEBAR)
-             && first_category_found
-             && !last_category_found)
+         if (     (ozone->flags2 & OZONE_FLAG2_POINTER_IN_SIDEBAR)
+               && (ozone->flags  & OZONE_FLAG_CURSOR_IN_SIDEBAR)
+               && first_category_found
+               && !last_category_found)
          {
             /* If pointer is within the bounds of the
              * current category, cache category index
              * (for use in next 'pointer up' event) */
-            if ((ozone->pointer.y > category_y) &&
-                (ozone->pointer.y < category_y + category_height))
+            if (     (ozone->pointer.y > category_y)
+                  && (ozone->pointer.y < category_y + category_height))
                ozone->pointer_categories_selection = i;
          }
 
@@ -9473,8 +9607,7 @@ static void ozone_render(void *data,
    }
 
    /* Handle any pending thumbnail load requests */
-   if (ozone->show_thumbnail_bar &&
-       (ozone->thumbnails.pending != OZONE_PENDING_THUMBNAIL_NONE))
+   if (ozone->show_thumbnail_bar && (ozone->thumbnails.pending != OZONE_PENDING_THUMBNAIL_NONE))
    {
       size_t selection                         = menu_navigation_get_selection();
       playlist_t *playlist                     = playlist_get_cached();
@@ -9491,13 +9624,14 @@ static void ozone_render(void *data,
             gfx_thumbnail_request_streams(
                   ozone->thumbnail_path_data,
                   p_anim,
-                  playlist, selection,
+                  playlist,
+                  selection,
                   &ozone->thumbnails.right,
                   &ozone->thumbnails.left,
                   gfx_thumbnail_upscale_threshold,
                   network_on_demand_thumbnails);
-            if ((ozone->thumbnails.right.status != GFX_THUMBNAIL_STATUS_UNKNOWN) &&
-                (ozone->thumbnails.left.status  != GFX_THUMBNAIL_STATUS_UNKNOWN))
+            if (     (ozone->thumbnails.right.status != GFX_THUMBNAIL_STATUS_UNKNOWN)
+                  && (ozone->thumbnails.left.status  != GFX_THUMBNAIL_STATUS_UNKNOWN))
                ozone->thumbnails.pending = OZONE_PENDING_THUMBNAIL_NONE;
             break;
          case OZONE_PENDING_THUMBNAIL_RIGHT:
@@ -9505,7 +9639,8 @@ static void ozone_render(void *data,
                   ozone->thumbnail_path_data,
                   p_anim,
                   GFX_THUMBNAIL_RIGHT,
-                  playlist, selection,
+                  playlist,
+                  selection,
                   &ozone->thumbnails.right,
                   gfx_thumbnail_upscale_threshold,
                   network_on_demand_thumbnails);
@@ -9517,7 +9652,8 @@ static void ozone_render(void *data,
                   ozone->thumbnail_path_data,
                   p_anim,
                   GFX_THUMBNAIL_LEFT,
-                  playlist, selection,
+                  playlist,
+                  selection,
                   &ozone->thumbnails.left,
                   gfx_thumbnail_upscale_threshold,
                   network_on_demand_thumbnails);
@@ -9528,7 +9664,7 @@ static void ozone_render(void *data,
             break;
       }
 
-      if (ozone->thumbnails.left.status != GFX_THUMBNAIL_STATUS_UNKNOWN)
+      if (ozone->thumbnails.left.status  != GFX_THUMBNAIL_STATUS_UNKNOWN)
          ozone->thumbnails_left_status_prev  = ozone->thumbnails.left.status;
       if (ozone->thumbnails.right.status != GFX_THUMBNAIL_STATUS_UNKNOWN)
          ozone->thumbnails_right_status_prev = ozone->thumbnails.right.status;
@@ -9558,21 +9694,21 @@ static void ozone_draw_header(
       math_matrix_4x4 *mymat)
 {
    char title[255];
+   static const char* const ticker_spacer   = OZONE_TICKER_SPACER;
    gfx_animation_ctx_ticker_t ticker;
    gfx_animation_ctx_ticker_smooth_t ticker_smooth;
-   static const char* const ticker_spacer = OZONE_TICKER_SPACER;
-   unsigned ticker_x_offset  = 0;
-   unsigned timedate_offset  = 0;
-   bool use_smooth_ticker    = settings->bools.menu_ticker_smooth;
-   float scale_factor        = ozone->last_scale_factor;
-   unsigned logo_icon_size   = 60 * scale_factor;
-   unsigned status_icon_size = 92 * scale_factor;
-   unsigned status_row_size  = 160 * scale_factor;
-   unsigned seperator_margin = 30 * scale_factor;
+   unsigned ticker_x_offset                 = 0;
+   unsigned timedate_offset                 = 0;
+   bool use_smooth_ticker                   = settings->bools.menu_ticker_smooth;
+   float scale_factor                       = ozone->last_scale_factor;
+   float *col                               = ozone->theme->entries_icon;
+   unsigned logo_icon_size                  = 60 * scale_factor;
+   unsigned status_icon_size                = 92 * scale_factor;
+   unsigned status_row_size                 = 160 * scale_factor;
+   unsigned seperator_margin                = 30 * scale_factor;
    enum gfx_animation_ticker_type
-      menu_ticker_type       = (enum gfx_animation_ticker_type)settings->uints.menu_ticker_type;
-   gfx_display_ctx_driver_t *dispctx = p_disp->dispctx;
-   float *col                        = ozone->theme->entries_icon;
+         menu_ticker_type                   = (enum gfx_animation_ticker_type)settings->uints.menu_ticker_type;
+   gfx_display_ctx_driver_t *dispctx        = p_disp->dispctx;
 
    /* Initial ticker configuration */
    if (use_smooth_ticker)
@@ -9613,7 +9749,7 @@ static void ozone_draw_header(
          dispctx->blend_begin(userdata);
       if (dispctx->draw)
       {
-#if 0
+#ifdef HAVE_DISCORD_OWN_AVATAR
          if (discord_avatar_is_ready())
             ozone_draw_icon(
                   p_disp,
@@ -9676,8 +9812,7 @@ static void ozone_draw_header(
                ozone->fonts.time.font,
                msg,
                video_width - 55 * scale_factor,
-                 ozone->dimensions.header_height / 2 
-               + ozone->fonts.time.line_centre_offset,
+               ozone->dimensions.header_height / 2 + ozone->fonts.time.line_centre_offset,
                video_width,
                video_height,
                ozone->theme->text_rgba,
@@ -9699,7 +9834,8 @@ static void ozone_draw_header(
                      video_height,
                      status_icon_size,
                      status_icon_size,
-                     ozone->icons_textures[powerstate.charging ? OZONE_ENTRIES_ICONS_TEXTURE_BATTERY_CHARGING
+                     ozone->icons_textures[powerstate.charging
+                           ? OZONE_ENTRIES_ICONS_TEXTURE_BATTERY_CHARGING
                            : (powerstate.percent > 80) ? OZONE_ENTRIES_ICONS_TEXTURE_BATTERY_FULL
                            : (powerstate.percent > 60) ? OZONE_ENTRIES_ICONS_TEXTURE_BATTERY_80
                            : (powerstate.percent > 40) ? OZONE_ENTRIES_ICONS_TEXTURE_BATTERY_60
@@ -9738,8 +9874,7 @@ static void ozone_draw_header(
             ozone->fonts.time.font,
             timedate,
             video_width - (64 * scale_factor) - timedate_offset,
-              ozone->dimensions.header_height / 2
-            + ozone->fonts.time.line_centre_offset,
+            ozone->dimensions.header_height / 2 + ozone->fonts.time.line_centre_offset,
             video_width,
             video_height,
             ozone->theme->text_rgba,
@@ -9783,10 +9918,9 @@ static void ozone_draw_header(
       ticker_smooth.font        = ozone->fonts.title.font;
       ticker_smooth.selected    = true;
       ticker_smooth.field_width = video_width - status_row_size;
-      ticker_smooth.src_str     = (ozone->flags2 &
-            OZONE_FLAG2_SHOW_FULLSCREEN_THUMBNAILS) 
-         ? ozone->fullscreen_thumbnail_label 
-         : ozone->title;
+      ticker_smooth.src_str     = (ozone->flags2 & OZONE_FLAG2_SHOW_FULLSCREEN_THUMBNAILS)
+            ? ozone->fullscreen_thumbnail_label
+            : ozone->title;
       ticker_smooth.dst_str     = title;
       ticker_smooth.dst_str_len = sizeof(title);
 
@@ -9796,10 +9930,9 @@ static void ozone_draw_header(
    {
       ticker.s        = title;
       ticker.len      = video_width - status_row_size / ozone->fonts.title.glyph_width;
-      ticker.str      = 
-          (ozone->flags2 & OZONE_FLAG2_SHOW_FULLSCREEN_THUMBNAILS) 
-         ? ozone->fullscreen_thumbnail_label 
-         : ozone->title;
+      ticker.str      = (ozone->flags2 & OZONE_FLAG2_SHOW_FULLSCREEN_THUMBNAILS)
+            ? ozone->fullscreen_thumbnail_label
+            : ozone->title;
       ticker.selected = true;
 
       gfx_animation_ticker(&ticker);
@@ -9809,8 +9942,7 @@ static void ozone_draw_header(
          ozone->fonts.title.font,
          title,
          ticker_x_offset + 128 * scale_factor,
-           ozone->dimensions.header_height / 2
-         + ozone->fonts.title.line_centre_offset,
+         ozone->dimensions.header_height / 2 + ozone->fonts.title.line_centre_offset,
          video_width,
          video_height,
          ozone->theme->text_rgba,
@@ -9837,27 +9969,27 @@ static void ozone_draw_footer(
    float scale_factor                     = ozone->last_scale_factor;
    unsigned seperator_margin              = 30 * scale_factor;
    float footer_margin                    = 42 * scale_factor;
-   float footer_text_y                    = (float)video_height -
-         (ozone->dimensions.footer_height / 2.0f) +
-         ozone->fonts.footer.line_centre_offset;
+   float footer_text_y                    = (float)video_height
+         - (ozone->dimensions.footer_height / 2.0f)
+         + ozone->fonts.footer.line_centre_offset;
    float icon_size                        = 35 * scale_factor;
    float icon_padding                     = 15 * scale_factor;
    float icon_padding_half                = icon_padding / 2;
-   float icon_y                           = (float)video_height -
-         (ozone->dimensions.footer_height / 2.0f) -
-         (icon_size / 2.0f);
+   float icon_y                           = (float)video_height
+         - (ozone->dimensions.footer_height / 2.0f)
+         - (icon_size / 2.0f);
    /* Button enable states
     * > Note: Only show 'metadata_toggle' if
     *   'fullscreen_thumbs' is shown. This condition
     *   should be guaranteed anyway, but enforce it
     *   here to prevent 'gaps' in the button list in
     *   the event of unknown errors */
-   bool fullscreen_thumbnails_available =
+   bool fullscreen_thumbnails_available   =
          ozone_fullscreen_thumbnails_available(ozone);
-   bool metadata_override_available     =
+   bool metadata_override_available       =
          fullscreen_thumbnails_available &&
          ozone_metadata_override_available(ozone);
-   bool thumbnail_cycle_enabled         =
+   bool thumbnail_cycle_enabled           =
          fullscreen_thumbnails_available &&
          !((ozone->is_quick_menu && menu_is_running_quick_menu()) 
                || (ozone->flags & OZONE_FLAG_IS_STATE_SLOT));
@@ -9870,22 +10002,22 @@ static void ozone_draw_footer(
     *   - search
     *   - toggle fullscreen thumbs (playlists only)
     *   - toggle metadata (playlists only) */
-   float ok_x                = (float)video_width - footer_margin -
-         ozone->footer_labels.ok.width - icon_size - icon_padding;
-   float back_x              = ok_x -
-         ozone->footer_labels.back.width - icon_size - (2.0f * icon_padding);
-   float search_x            = (search_enabled)
+   float ok_x                             = (float)video_width
+         - footer_margin - ozone->footer_labels.ok.width - icon_size - icon_padding;
+   float back_x                           = ok_x
+         - ozone->footer_labels.back.width - icon_size - (2.0f * icon_padding);
+   float search_x                         = (search_enabled)
          ? back_x - ozone->footer_labels.search.width - icon_size - (2.0f * icon_padding)
          : back_x;
-   float cycle_x             = (thumbnail_cycle_enabled)
+   float cycle_x                          = (thumbnail_cycle_enabled)
          ? search_x - ozone->footer_labels.cycle.width - icon_size - (2.0f * icon_padding)
          : search_x;
-   float fullscreen_thumbs_x = cycle_x -
-         ozone->footer_labels.fullscreen_thumbs.width - icon_size - (2.0f * icon_padding);
-   float metadata_toggle_x   = fullscreen_thumbs_x -
-         ozone->footer_labels.metadata_toggle.width - icon_size - (2.0f * icon_padding);
-   gfx_display_ctx_driver_t *dispctx = p_disp->dispctx;
-   float *col                        = ozone->theme_dynamic.entries_icon;
+   float fullscreen_thumbs_x              = cycle_x
+         - ozone->footer_labels.fullscreen_thumbs.width - icon_size - (2.0f * icon_padding);
+   float metadata_toggle_x                = fullscreen_thumbs_x
+         - ozone->footer_labels.metadata_toggle.width - icon_size - (2.0f * icon_padding);
+   gfx_display_ctx_driver_t *dispctx      = p_disp->dispctx;
+   float *col                             = ozone->theme_dynamic.entries_icon;
 
    /* Separator */
    gfx_display_draw_quad(
@@ -9913,7 +10045,7 @@ static void ozone_draw_footer(
 
       if (dispctx->draw)
       {
-         /* > ok */
+         /* > Ok */
          ozone_draw_icon(
                p_disp,
                userdata,
@@ -9921,9 +10053,9 @@ static void ozone_draw_footer(
                video_height,
                icon_size,
                icon_size,
-               input_menu_swap_ok_cancel_buttons ?
-               ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_D] :
-               ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_R],
+               input_menu_swap_ok_cancel_buttons
+                     ? ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_D]
+                     : ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_R],
                ok_x,
                icon_y,
                video_width,
@@ -9933,7 +10065,7 @@ static void ozone_draw_footer(
                col,
                mymat);
 
-         /* > back */
+         /* > Back */
          ozone_draw_icon(
                p_disp,
                userdata,
@@ -9941,18 +10073,19 @@ static void ozone_draw_footer(
                video_height,
                icon_size,
                icon_size,
-               input_menu_swap_ok_cancel_buttons ?
-               ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_R] :
-               ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_D],
+               input_menu_swap_ok_cancel_buttons
+                     ? ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_R]
+                     : ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_D],
                back_x,
                icon_y,
-               video_width,video_height,
+               video_width,
+               video_height,
                0.0f,
                1.0f,
                col,
                mymat);
 
-         /* > search */
+         /* > Search */
          if (search_enabled)
             ozone_draw_icon(
                   p_disp,
@@ -9964,13 +10097,14 @@ static void ozone_draw_footer(
                   ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_U],
                   search_x,
                   icon_y,
-                  video_width,video_height,
+                  video_width,
+                  video_height,
                   0.0f,
                   1.0f,
                   col,
                   mymat);
 
-         /* > thumbnail cycle */
+         /* > Thumbnail cycle */
          if (thumbnail_cycle_enabled)
             ozone_draw_icon(
                   p_disp,
@@ -9982,13 +10116,14 @@ static void ozone_draw_footer(
                   ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_BTN_L],
                   cycle_x,
                   icon_y,
-                  video_width,video_height,
+                  video_width,
+                  video_height,
                   0.0f,
                   1.0f,
                   col,
                   mymat);
 
-         /* > fullscreen_thumbs */
+         /* > Fullscreen thumbnais */
          if (fullscreen_thumbnails_available)
             ozone_draw_icon(
                   p_disp,
@@ -10003,13 +10138,14 @@ static void ozone_draw_footer(
                         : ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_START],
                   fullscreen_thumbs_x,
                   icon_y,
-                  video_width,video_height,
+                  video_width,
+                  video_height,
                   0.0f,
                   1.0f,
                   col,
                   mymat);
 
-         /* > metadata_toggle */
+         /* > Metadata toggle */
          if (metadata_override_available)
             ozone_draw_icon(
                   p_disp,
@@ -10021,7 +10157,8 @@ static void ozone_draw_footer(
                   ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_SELECT],
                   metadata_toggle_x,
                   icon_y,
-                  video_width,video_height,
+                  video_width,
+                  video_height,
                   0.0f,
                   1.0f,
                   col,
@@ -10034,7 +10171,7 @@ static void ozone_draw_footer(
 
    /* Draw labels */
 
-   /* > ok */
+   /* > Ok */
    gfx_display_draw_text(
          ozone->fonts.footer.font,
          ozone->footer_labels.ok.str,
@@ -10049,7 +10186,7 @@ static void ozone_draw_footer(
          1.0f,
          false);
 
-   /* > back */
+   /* > Back */
    gfx_display_draw_text(
          ozone->fonts.footer.font,
          ozone->footer_labels.back.str,
@@ -10064,7 +10201,7 @@ static void ozone_draw_footer(
          1.0f,
          false);
 
-   /* > search */
+   /* > Search */
    if (search_enabled)
       gfx_display_draw_text(
             ozone->fonts.footer.font,
@@ -10080,7 +10217,7 @@ static void ozone_draw_footer(
             1.0f,
             false);
 
-   /* > thumbnail cycle */
+   /* > Thumbnail cycle */
    if (thumbnail_cycle_enabled)
       gfx_display_draw_text(
             ozone->fonts.footer.font,
@@ -10096,7 +10233,7 @@ static void ozone_draw_footer(
             1.0f,
             false);
 
-   /* > fullscreen_thumbs */
+   /* > Fullscreen thumbnails */
    if (fullscreen_thumbnails_available)
       gfx_display_draw_text(
             ozone->fonts.footer.font,
@@ -10112,7 +10249,7 @@ static void ozone_draw_footer(
             1.0f,
             false);
 
-   /* > metadata_toggle */
+   /* > Metadata toggle */
    if (metadata_override_available)
       gfx_display_draw_text(
             ozone->fonts.footer.font,
@@ -10135,24 +10272,24 @@ static void ozone_draw_footer(
       gfx_animation_ctx_ticker_smooth_t ticker_smooth;
       char core_title[255];
       char core_title_buf[255];
+      static const char* const ticker_spacer          = OZONE_TICKER_SPACER;
       int usable_width;
+      unsigned ticker_x_offset                        = 0;
       bool use_smooth_ticker                          =
             settings->bools.menu_ticker_smooth;
       enum gfx_animation_ticker_type menu_ticker_type =
             (enum gfx_animation_ticker_type)settings->uints.menu_ticker_type;
-            static const char* const ticker_spacer    = OZONE_TICKER_SPACER;
-      unsigned ticker_x_offset                        = 0;
 
       core_title[0]     = '\0';
       core_title_buf[0] = '\0';
 
       /* Determine available width for core
        * title string */
-      usable_width = metadata_override_available ?
-            metadata_toggle_x :
-                  fullscreen_thumbnails_available ?
-                        fullscreen_thumbs_x :
-                        search_x;
+      usable_width = metadata_override_available
+            ? metadata_toggle_x
+            : fullscreen_thumbnails_available
+                  ? fullscreen_thumbs_x
+                  : search_x;
       usable_width -= footer_margin + (icon_padding * 3);
 
       if (usable_width > 0)
@@ -10240,7 +10377,7 @@ static void ozone_draw_footer(
 #endif
 }
 
-static void ozone_set_thumbnail_system(void *data, char*s, size_t len)
+static void ozone_set_thumbnail_system(void *data, char *s, size_t len)
 {
    ozone_handle_t *ozone = (ozone_handle_t*)data;
    if (!ozone)
@@ -10250,7 +10387,7 @@ static void ozone_set_thumbnail_system(void *data, char*s, size_t len)
          ozone->thumbnail_path_data, s, playlist_get_cached());
 }
 
-static void ozone_get_thumbnail_system(void *data, char*s, size_t len)
+static void ozone_get_thumbnail_system(void *data, char *s, size_t len)
 {
    ozone_handle_t *ozone = (ozone_handle_t*)data;
    const char *system    = NULL;
@@ -10294,10 +10431,8 @@ static void ozone_selection_changed(ozone_handle_t *ozone, bool allow_animation)
       ozone_update_scroll(ozone, allow_animation, node);
 
       /* Update thumbnail */
-      if (gfx_thumbnail_is_enabled(
-            ozone->thumbnail_path_data, GFX_THUMBNAIL_RIGHT) ||
-          gfx_thumbnail_is_enabled(
-            ozone->thumbnail_path_data, GFX_THUMBNAIL_LEFT))
+      if (gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_RIGHT) ||
+          gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_LEFT))
       {
          bool update_thumbnails = false;
 
@@ -10310,8 +10445,7 @@ static void ozone_selection_changed(ozone_handle_t *ozone, bool allow_animation)
             ozone->flags               &= ~OZONE_FLAG_SKIP_THUMBNAIL_RESET;
          }
          /* Database + Explore list updates */
-         else if ((  (ozone->flags & OZONE_FLAG_IS_DB_MANAGER_LIST) 
-                  && (ozone->depth == 4))
+         else if (  ((ozone->flags & OZONE_FLAG_IS_DB_MANAGER_LIST) && (ozone->depth == 4))
                ||    (ozone->flags & OZONE_FLAG_IS_EXPLORE_LIST))
          {
             ozone_set_thumbnail_content(ozone, "");
@@ -10425,7 +10559,7 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
    gfx_animation_t *p_anim                = anim_get_ptr();
    gfx_display_ctx_driver_t *dispctx      = p_disp->dispctx;
 
-#if 0
+#ifdef HAVE_DISCORD_OWN_AVATAR
    static bool reset                      = false;
 
    if (discord_avatar_is_ready() && !reset)
@@ -10451,17 +10585,14 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
       {
          if (libretro_running)
             ozone->flags       &= ~(OZONE_FLAG_WANT_THUMBNAIL_BAR
-                               |    OZONE_FLAG_FULLSCREEN_THUMBNAILS_AVAILABLE
-                                   );
+                               |    OZONE_FLAG_FULLSCREEN_THUMBNAILS_AVAILABLE);
          else
             ozone->flags       |=  (OZONE_FLAG_WANT_THUMBNAIL_BAR
-                               |    OZONE_FLAG_FULLSCREEN_THUMBNAILS_AVAILABLE
-                                   );
+                               |    OZONE_FLAG_FULLSCREEN_THUMBNAILS_AVAILABLE);
       }
    }
 
-   if (     ((ozone->flags  & OZONE_FLAG_IS_PLAYLIST)
-         ||  (ozone->flags  & OZONE_FLAG_IS_STATE_SLOT))
+   if (     ((ozone->flags  & OZONE_FLAG_IS_PLAYLIST) || (ozone->flags & OZONE_FLAG_IS_STATE_SLOT))
          &&  (ozone->flags2 & OZONE_FLAG2_SHOW_FULLSCREEN_THUMBNAILS)
          &&  (size_t)ozone->selection != ozone->fullscreen_thumbnail_selection)
    {
@@ -10492,22 +10623,21 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
       {
          ozone->flags                       &= ~(OZONE_FLAG_SHOULD_DRAW_MSGBOX
                                                | OZONE_FLAG_MSGBOX_STATE
-                                               | OZONE_FLAG_MSGBOX_STATE_OLD
-                                                );
+                                               | OZONE_FLAG_MSGBOX_STATE_OLD);
          ozone->animations.messagebox_alpha  = 0.0f;
       }
    }
 
    /* Change theme on the fly */
-   ozone_last_use_preferred_system_color_theme = ozone->flags2 &
-      OZONE_FLAG2_LAST_USE_PREFERRED_SYSTEM_COLOR_THEME;
+   ozone_last_use_preferred_system_color_theme =
+         ozone->flags2 & OZONE_FLAG2_LAST_USE_PREFERRED_SYSTEM_COLOR_THEME;
+
    if (   (color_theme != ozone_last_color_theme)
-       || (ozone_last_use_preferred_system_color_theme 
-       != use_preferred_system_color_theme))
+       || (ozone_last_use_preferred_system_color_theme != use_preferred_system_color_theme))
    {
       if (use_preferred_system_color_theme)
       {
-         color_theme                            = ozone_get_system_theme();
+         color_theme                           = ozone_get_system_theme();
          configuration_set_uint(settings,
                settings->uints.menu_ozone_color_theme, color_theme);
       }
@@ -10542,8 +10672,7 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
    ozone_font_bind(&ozone->fonts.sidebar);
 
    /* Background */
-   if (libretro_running &&
-       (menu_framebuffer_opacity < 1.0f))
+   if (libretro_running && (menu_framebuffer_opacity < 1.0f))
    {
       if (menu_framebuffer_opacity != ozone_last_framebuffer_opacity)
          if (ozone->theme->background_libretro_running)
@@ -10554,13 +10683,16 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
    else
       background_color = ozone->theme->background;
 
-   gfx_display_draw_quad(
-         p_disp,
+   gfx_display_draw_quad(p_disp,
          userdata,
          video_width,
          video_height,
-         0, 0, video_width, video_height,
-         video_width, video_height,
+         0,
+         0,
+         video_width,
+         video_height,
+         video_width,
+         video_height,
          background_color,
          NULL);
 
@@ -10572,8 +10704,7 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
    }
 
    /* Header, footer */
-   ozone_draw_header(
-         ozone,
+   ozone_draw_header(ozone,
          p_disp,
          p_anim,
          settings,
@@ -10583,18 +10714,20 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
          battery_level_enable,
          timedate_enable,
          &mymat);
+
    ozone_draw_footer(ozone,
-         p_disp, p_anim,
+         p_disp,
+         p_anim,
          userdata,
          video_width,
          video_height,
          input_menu_swap_ok_cancel_buttons,
-         settings, &mymat);
+         settings,
+         &mymat);
 
    /* Sidebar */
    if (ozone->flags & OZONE_FLAG_DRAW_SIDEBAR)
-      ozone_draw_sidebar(
-            ozone,
+      ozone_draw_sidebar(ozone,
             p_disp,
             p_anim,
             settings,
@@ -10611,21 +10744,16 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
             userdata,
             video_width,
             video_height,
-              ozone->sidebar_offset 
-            + (unsigned)ozone->dimensions_sidebar_width,
-              ozone->dimensions.header_height 
-            + ozone->dimensions.spacer_1px,
-            video_width 
-            - (unsigned) ozone->dimensions_sidebar_width 
-            + (-ozone->sidebar_offset),
-              video_height 
-            - ozone->dimensions.header_height 
-            - ozone->dimensions.footer_height 
-            - ozone->dimensions.spacer_1px);
+            ozone->sidebar_offset + (unsigned)ozone->dimensions_sidebar_width,
+            ozone->dimensions.header_height + ozone->dimensions.spacer_1px,
+            video_width - (unsigned)ozone->dimensions_sidebar_width + (-ozone->sidebar_offset),
+            video_height
+                  - ozone->dimensions.header_height
+                  - ozone->dimensions.footer_height
+                  - ozone->dimensions.spacer_1px);
 
    /* Current list */
-   ozone_draw_entries(
-         ozone,
+   ozone_draw_entries(ozone,
          p_disp,
          p_anim,
          settings,
@@ -10643,8 +10771,7 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
 
    /* Old list */
    if (ozone->flags & OZONE_FLAG_DRAW_OLD_LIST)
-      ozone_draw_entries(
-            ozone,
+      ozone_draw_entries(ozone,
             p_disp,
             p_anim,
             settings,
@@ -10674,8 +10801,7 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
             &mymat);
 
    if (dispctx && dispctx->scissor_end)
-      dispctx->scissor_end(userdata,
-            video_width, video_height);
+      dispctx->scissor_end(userdata, video_width, video_height);
 
    /* Flush first layer of text */
    ozone_font_flush(video_width, video_height, &ozone->fonts.footer);
@@ -10697,14 +10823,13 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
          || draw_osk)
    {
       /* Fade in animation */
-      if (     (((ozone->flags & OZONE_FLAG_MSGBOX_STATE_OLD) > 0)
-            != ((ozone->flags & OZONE_FLAG_MSGBOX_STATE) > 0))
+      if (     (((ozone->flags & OZONE_FLAG_MSGBOX_STATE_OLD) > 0) != ((ozone->flags & OZONE_FLAG_MSGBOX_STATE) > 0))
             && (((ozone->flags & OZONE_FLAG_MSGBOX_STATE) > 0)))
       {
          if (ozone->flags & OZONE_FLAG_MSGBOX_STATE)
-            ozone->flags |=  OZONE_FLAG_MSGBOX_STATE_OLD;
+            ozone->flags                   |=  OZONE_FLAG_MSGBOX_STATE_OLD;
          else
-            ozone->flags &= ~OZONE_FLAG_MSGBOX_STATE_OLD;
+            ozone->flags                   &= ~OZONE_FLAG_MSGBOX_STATE_OLD;
 
          gfx_animation_kill_by_tag(&messagebox_tag);
          ozone->animations.messagebox_alpha = 0.0f;
@@ -10720,8 +10845,7 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
          gfx_animation_push(&entry);
       }
       /* Fade out animation */
-      else if   (((ozone->flags & OZONE_FLAG_MSGBOX_STATE_OLD) > 0)
-            !=   ((ozone->flags & OZONE_FLAG_MSGBOX_STATE)     > 0) 
+      else if   (((ozone->flags & OZONE_FLAG_MSGBOX_STATE_OLD) > 0) != ((ozone->flags & OZONE_FLAG_MSGBOX_STATE) > 0)
             &&  (!(ozone->flags & OZONE_FLAG_MSGBOX_STATE)))
       {
          if (ozone->flags & OZONE_FLAG_MSGBOX_STATE)
@@ -10744,8 +10868,7 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
          gfx_animation_push(&entry);
       }
 
-      ozone_draw_backdrop(
-            userdata,
+      ozone_draw_backdrop(userdata,
             video_info->disp_userdata,
             video_width,
             video_height,
@@ -10761,11 +10884,11 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
                video_info->disp_userdata,
                video_width,
                video_height,
-               label, str);
+               label,
+               str);
       }
       else
-         ozone_draw_messagebox(
-               ozone,
+         ozone_draw_messagebox(ozone,
                p_disp,
                userdata,
                video_width,
@@ -10782,13 +10905,11 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
    if (     (ozone->flags & OZONE_FLAG_SHOW_CURSOR)
          && (ozone->pointer.type != MENU_POINTER_DISABLED))
    {
-      bool cursor_visible = (video_fullscreen || mouse_grabbed) &&
-            menu_mouse_enable;
+      bool cursor_visible = (video_fullscreen || mouse_grabbed) && menu_mouse_enable;
 
       gfx_display_set_alpha(ozone->pure_white, 1.0f);
       if (cursor_visible)
-         gfx_display_draw_cursor(
-               p_disp,
+         gfx_display_draw_cursor(p_disp,
                userdata,
                video_width,
                video_height,
@@ -10799,8 +10920,7 @@ static void ozone_frame(void *data, video_frame_info_t *video_info)
                ozone->pointer.x,
                ozone->pointer.y,
                video_width,
-               video_height
-               );
+               video_height);
    }
 
    /* Unbind fonts */
@@ -10824,15 +10944,14 @@ static void ozone_set_header(ozone_handle_t *ozone)
    {
       ozone_node_t *node = (ozone_node_t*)file_list_get_userdata_at_offset(
             &ozone->horizontal_list,
-            ozone->categories_selection_ptr - ozone->system_tab_end-1);
+            ozone->categories_selection_ptr - ozone->system_tab_end - 1);
 
       if (node && node->console_name)
       {
          strlcpy(ozone->title, node->console_name, sizeof(ozone->title));
 
          /* Add current search terms */
-         menu_entries_search_append_terms_string(
-               ozone->title, sizeof(ozone->title));
+         menu_entries_search_append_terms_string(ozone->title, sizeof(ozone->title));
       }
    }
 }
@@ -10844,12 +10963,15 @@ static void ozone_animation_end(void *userdata)
    ozone->animations.cursor_alpha   = 1.0f;
 }
 
-static void ozone_list_open(ozone_handle_t *ozone, bool ozone_collapse_sidebar, bool animate)
+static void ozone_list_open(
+      ozone_handle_t *ozone,
+      bool ozone_collapse_sidebar,
+      bool animate)
 {
    struct gfx_animation_ctx_entry entry;
-   uintptr_t sidebar_tag        = (uintptr_t)&ozone->sidebar_offset;
+   uintptr_t sidebar_tag           = (uintptr_t)&ozone->sidebar_offset;
 
-   ozone->flags                |= (OZONE_FLAG_DRAW_OLD_LIST);
+   ozone->flags                   |= (OZONE_FLAG_DRAW_OLD_LIST);
 
    /* Left/right animation */
    if (animate)
@@ -10883,17 +11005,17 @@ static void ozone_list_open(ozone_handle_t *ozone, bool ozone_collapse_sidebar, 
 
    if (ozone->depth == 1)
    {
-      ozone->flags          |= OZONE_FLAG_DRAW_SIDEBAR;
+      ozone->flags            |= OZONE_FLAG_DRAW_SIDEBAR;
 
       if (animate)
       {
-         entry.cb            = NULL;
-         entry.duration      = ANIMATION_PUSH_ENTRY_DURATION;
-         entry.easing_enum   = EASING_OUT_QUAD;
-         entry.subject       = &ozone->sidebar_offset;
-         entry.tag           = sidebar_tag;
-         entry.target_value  = 0.0f;
-         entry.userdata      = NULL;
+         entry.cb              = NULL;
+         entry.duration        = ANIMATION_PUSH_ENTRY_DURATION;
+         entry.easing_enum     = EASING_OUT_QUAD;
+         entry.subject         = &ozone->sidebar_offset;
+         entry.tag             = sidebar_tag;
+         entry.target_value    = 0.0f;
+         entry.userdata        = NULL;
 
          gfx_animation_push(&entry);
       }
@@ -10906,13 +11028,13 @@ static void ozone_list_open(ozone_handle_t *ozone, bool ozone_collapse_sidebar, 
       {
          struct gfx_animation_ctx_entry entry;
 
-         entry.cb           = ozone_collapse_end;
-         entry.duration     = ANIMATION_PUSH_ENTRY_DURATION;
-         entry.easing_enum  = EASING_OUT_QUAD;
-         entry.subject      = &ozone->sidebar_offset;
-         entry.tag          = sidebar_tag;
-         entry.target_value = -ozone->dimensions_sidebar_width;
-         entry.userdata     = (void*)ozone;
+         entry.cb              = ozone_collapse_end;
+         entry.duration        = ANIMATION_PUSH_ENTRY_DURATION;
+         entry.easing_enum     = EASING_OUT_QUAD;
+         entry.subject         = &ozone->sidebar_offset;
+         entry.tag             = sidebar_tag;
+         entry.target_value    = -ozone->dimensions_sidebar_width;
+         entry.userdata        = (void*)ozone;
 
          gfx_animation_push(&entry);
       }
@@ -10921,22 +11043,26 @@ static void ozone_list_open(ozone_handle_t *ozone, bool ozone_collapse_sidebar, 
    }
 }
 
-static void ozone_populate_entries(void *data,
-      const char *path, const char *label, unsigned k)
+static void ozone_populate_entries(
+      void *data,
+      const char *path,
+      const char *label,
+      unsigned k)
 {
-   bool want_thumbnail_bar, fullscreen_thumbnails_available;
-   int new_depth               = 0;
-   bool animate                = false;
-   settings_t *settings        = NULL;
-   ozone_handle_t *ozone       = (ozone_handle_t*) data;
-   bool ozone_collapse_sidebar = false;
-   bool was_db_manager_list    = false;
+   int new_depth                        = 0;
+   bool ozone_collapse_sidebar          = false;
+   bool was_db_manager_list             = false;
+   bool want_thumbnail_bar              = false;
+   bool fullscreen_thumbnails_available = false;
+   bool animate                         = false;
+   settings_t *settings                 = NULL;
+   ozone_handle_t *ozone                = (ozone_handle_t*) data;
 
    if (!ozone)
       return;
 
-   settings                    = config_get_ptr();
-   ozone_collapse_sidebar      = settings->bools.ozone_collapse_sidebar;
+   settings                             = config_get_ptr();
+   ozone_collapse_sidebar               = settings->bools.ozone_collapse_sidebar;
 
    if (menu_driver_ctl(RARCH_MENU_CTL_IS_PREVENT_POPULATE, NULL))
    {
@@ -10947,10 +11073,10 @@ static void ozone_populate_entries(void *data,
        * (Ozone is a fickle beast...) */
       if (ozone->flags & OZONE_FLAG_IS_PLAYLIST)
       {
-         menu_search_terms_t *menu_search_terms =
-               menu_entries_search_get_terms();
-         size_t num_search_terms                =
-               menu_search_terms ? menu_search_terms->size : 0;
+         menu_search_terms_t *menu_search_terms = menu_entries_search_get_terms();
+         size_t num_search_terms                = menu_search_terms
+               ? menu_search_terms->size
+               : 0;
 
          if (ozone->num_search_terms_old != num_search_terms)
          {
@@ -11011,21 +11137,21 @@ static void ozone_populate_entries(void *data,
    was_db_manager_list         = (ozone->flags & OZONE_FLAG_IS_DB_MANAGER_LIST) && new_depth > ozone->depth;
 
    animate                     = new_depth != ozone->depth;
+
    if (new_depth <= ozone->depth)
       ozone->flags            |=  OZONE_FLAG_FADE_DIRECTION;
    else
       ozone->flags            &= ~OZONE_FLAG_FADE_DIRECTION;
    ozone->depth                = new_depth;
-   if (string_is_equal(label,
-            msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_DATABASE_MANAGER_LIST)))
+
+   if (string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_DATABASE_MANAGER_LIST)))
       ozone->flags            |=  OZONE_FLAG_IS_DB_MANAGER_LIST;
    else
       ozone->flags            &= ~OZONE_FLAG_IS_DB_MANAGER_LIST;
 
-   if (string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_EXPLORE_LIST)) ||
-                                 string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_EXPLORE_TAB)) ||
-                                 ozone_get_horizontal_selection_type(ozone) ==
-MENU_EXPLORE_TAB)
+   if (  string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_EXPLORE_LIST)) ||
+         string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_EXPLORE_TAB)) ||
+         ozone_get_horizontal_selection_type(ozone) == MENU_EXPLORE_TAB)
       ozone->flags |=  OZONE_FLAG_IS_EXPLORE_LIST;
    else
       ozone->flags &= ~OZONE_FLAG_IS_EXPLORE_LIST;
@@ -11038,9 +11164,8 @@ MENU_EXPLORE_TAB)
                                  string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_CONTENT_SETTINGS)) ||
                                  string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_SAVESTATE_LIST));
 
-   if (string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_CONTENTLESS_CORES_TAB)) ||
-                                 string_is_equal(label,
-msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_CONTENTLESS_CORES_LIST)))
+   if (  string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_CONTENTLESS_CORES_TAB)) ||
+         string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_CONTENTLESS_CORES_LIST)))
       ozone->flags |=  OZONE_FLAG_IS_CONTENTLESS_CORES;
    else
       ozone->flags &= ~OZONE_FLAG_IS_CONTENTLESS_CORES;
@@ -11049,6 +11174,7 @@ msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_CONTENTLESS_CORES_LIST)))
       ozone->flags |=  OZONE_FLAG_IS_STATE_SLOT;
    else
       ozone->flags &= ~OZONE_FLAG_IS_STATE_SLOT;
+
    if (ozone_is_playlist(ozone, true))
       ozone->flags |=  OZONE_FLAG_IS_PLAYLIST;
    else
@@ -11072,8 +11198,7 @@ msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_CONTENTLESS_CORES_LIST)))
 
    if (animate)
       if (ozone->categories_selection_ptr == ozone->categories_active_idx_old)
-         ozone_list_open(ozone, ozone_collapse_sidebar, (!(ozone->flags &
-OZONE_FLAG_FIRST_FRAME)));
+         ozone_list_open(ozone, ozone_collapse_sidebar, (!(ozone->flags & OZONE_FLAG_FIRST_FRAME)));
 
    /* Thumbnails
     * > Note: Leave current thumbnails loaded when
@@ -11083,12 +11208,12 @@ OZONE_FLAG_FIRST_FRAME)));
    if (     (!(ozone->is_quick_menu))
          &&   (ozone->flags & OZONE_FLAG_WAS_QUICK_MENU)
          && (!(ozone->flags & OZONE_FLAG_IS_STATE_SLOT))
-         && (gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_RIGHT) ||
-          gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_LEFT)) &&
-         (ozone->thumbnails.left.status  == GFX_THUMBNAIL_STATUS_AVAILABLE ||
-          ozone->thumbnails.right.status == GFX_THUMBNAIL_STATUS_AVAILABLE ||
-          ozone->thumbnails.left.status  == GFX_THUMBNAIL_STATUS_MISSING ||
-          ozone->thumbnails.right.status == GFX_THUMBNAIL_STATUS_MISSING))
+         && (  gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_RIGHT) ||
+               gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_LEFT))
+         && (  ozone->thumbnails.left.status  == GFX_THUMBNAIL_STATUS_AVAILABLE ||
+               ozone->thumbnails.right.status == GFX_THUMBNAIL_STATUS_AVAILABLE ||
+               ozone->thumbnails.left.status  == GFX_THUMBNAIL_STATUS_MISSING ||
+               ozone->thumbnails.right.status == GFX_THUMBNAIL_STATUS_MISSING))
       ozone->flags |= OZONE_FLAG_SKIP_THUMBNAIL_RESET;
 
    if (ozone->is_quick_menu)
@@ -11108,6 +11233,10 @@ OZONE_FLAG_FIRST_FRAME)));
          ozone_update_thumbnail_image(ozone);
       }
    }
+   else if (ozone->flags & OZONE_FLAG_IS_STATE_SLOT)
+   {
+      ozone->flags |= OZONE_FLAG_WANT_THUMBNAIL_BAR;
+   }
    else if (ozone->flags & OZONE_FLAG_IS_EXPLORE_LIST)
    {
       ozone->flags &= ~OZONE_FLAG_WANT_THUMBNAIL_BAR;
@@ -11117,8 +11246,7 @@ OZONE_FLAG_FIRST_FRAME)));
    else if ((!(ozone->flags & OZONE_FLAG_IS_STATE_SLOT))
          && (!(ozone->flags & OZONE_FLAG_SKIP_THUMBNAIL_RESET)))
    {
-      if (     (ozone->flags & OZONE_FLAG_IS_DB_MANAGER_LIST)
-            && (ozone->depth == 4))
+      if ((ozone->flags & OZONE_FLAG_IS_DB_MANAGER_LIST) && (ozone->depth == 4))
          ozone->flags |= OZONE_FLAG_SKIP_THUMBNAIL_RESET;
 
       if (!(ozone->flags & OZONE_FLAG_SKIP_THUMBNAIL_RESET))
@@ -11132,9 +11260,8 @@ OZONE_FLAG_FIRST_FRAME)));
           * > Note that we can ignore file browser lists,
           *   since the first selected item on such a list
           *   can never have a thumbnail */
-         if (       (ozone->flags & OZONE_FLAG_IS_PLAYLIST)
-             || (   (ozone->flags & OZONE_FLAG_IS_DB_MANAGER_LIST)
-                 && (ozone->depth >= 4)))
+         if (    (ozone->flags & OZONE_FLAG_IS_PLAYLIST)
+             || ((ozone->flags & OZONE_FLAG_IS_DB_MANAGER_LIST) && (ozone->depth >= 4)))
          {
             ozone_set_thumbnail_content(ozone, "");
             ozone_update_thumbnail_image(ozone);
@@ -11145,11 +11272,8 @@ OZONE_FLAG_FIRST_FRAME)));
    }
 
    if (     (ozone->flags & OZONE_FLAG_SKIP_THUMBNAIL_RESET)
-         && (gfx_thumbnail_is_enabled(ozone->thumbnail_path_data,
-               GFX_THUMBNAIL_RIGHT)   
-         || (gfx_thumbnail_is_enabled(ozone->thumbnail_path_data,
-               GFX_THUMBNAIL_LEFT))
-          ))
+         && (  gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_RIGHT) ||
+               gfx_thumbnail_is_enabled(ozone->thumbnail_path_data, GFX_THUMBNAIL_LEFT)))
       ozone->flags |= OZONE_FLAG_WANT_THUMBNAIL_BAR;
 
    switch (ozone->tabs[ozone->categories_selection_ptr])
@@ -11159,34 +11283,29 @@ OZONE_FLAG_FIRST_FRAME)));
 #endif
       case OZONE_SYSTEM_TAB_MUSIC:
          ozone->flags &= ~(OZONE_FLAG_WANT_THUMBNAIL_BAR
-                         | OZONE_FLAG_FULLSCREEN_THUMBNAILS_AVAILABLE
-                          );
+                         | OZONE_FLAG_FULLSCREEN_THUMBNAILS_AVAILABLE);
          break;
    }
 
-   /* Fullscreen thumbnails are only enabled on
+   /* Fullscreen thumbnails are only available on
     * playlists, database manager lists, file lists
     * and savestate slots */
-   if ((((ozone->flags & OZONE_FLAG_IS_PLAYLIST)
-         &&  (ozone->flags & OZONE_FLAG_WANT_THUMBNAIL_BAR)
-         &&  (ozone->depth == 1 || ozone->depth == 4))
-         || ((ozone->flags & OZONE_FLAG_IS_DB_MANAGER_LIST)
-         &&  (ozone->flags & OZONE_FLAG_WANT_THUMBNAIL_BAR) 
-         &&  (ozone->depth >= 4))
-         ||  (ozone->is_quick_menu      
-         &&  (ozone->flags & OZONE_FLAG_WANT_THUMBNAIL_BAR))
-         || ((ozone->flags & OZONE_FLAG_IS_FILE_LIST)
-         &&  (ozone->flags & OZONE_FLAG_WANT_THUMBNAIL_BAR))
-         ||( (ozone->flags & OZONE_FLAG_IS_EXPLORE_LIST)
-         &&  (ozone->flags & OZONE_FLAG_WANT_THUMBNAIL_BAR))
-         ||  (ozone->flags & OZONE_FLAG_IS_STATE_SLOT)))
+   if (
+            ((ozone->flags & OZONE_FLAG_WANT_THUMBNAIL_BAR))
+         && (  ((ozone->flags & OZONE_FLAG_IS_PLAYLIST) && (ozone->depth == 1 || ozone->depth == 4))
+            || ((ozone->flags & OZONE_FLAG_IS_DB_MANAGER_LIST) && (ozone->depth >= 4))
+            || (ozone->flags & OZONE_FLAG_IS_EXPLORE_LIST)
+            || (ozone->flags & OZONE_FLAG_IS_FILE_LIST)
+            || (ozone->flags & OZONE_FLAG_IS_STATE_SLOT)
+            || (ozone->is_quick_menu)
+            )
+      )
       ozone->flags |=  OZONE_FLAG_FULLSCREEN_THUMBNAILS_AVAILABLE;
    else
       ozone->flags &= ~OZONE_FLAG_FULLSCREEN_THUMBNAILS_AVAILABLE;
 
-   fullscreen_thumbnails_available = ozone->flags &
-      OZONE_FLAG_FULLSCREEN_THUMBNAILS_AVAILABLE;
-   want_thumbnail_bar = ozone->flags & OZONE_FLAG_WANT_THUMBNAIL_BAR;
+   fullscreen_thumbnails_available = ozone->flags & OZONE_FLAG_FULLSCREEN_THUMBNAILS_AVAILABLE;
+   want_thumbnail_bar              = ozone->flags & OZONE_FLAG_WANT_THUMBNAIL_BAR;
 
    if (fullscreen_thumbnails_available != want_thumbnail_bar)
    {
@@ -11195,6 +11314,10 @@ OZONE_FLAG_FIRST_FRAME)));
       else
          ozone->flags &= ~OZONE_FLAG_WANT_THUMBNAIL_BAR;
    }
+
+   /* State slots must not allow fullscreen thumbnails when slot has no image */
+   if ((ozone->flags & OZONE_FLAG_IS_STATE_SLOT) && string_is_empty(ozone->savestate_thumbnail_file_path))
+      ozone->flags &= ~OZONE_FLAG_FULLSCREEN_THUMBNAILS_AVAILABLE;
 }
 
 /* TODO: Fancy toggle animation */
@@ -11244,16 +11367,19 @@ static bool ozone_menu_init_list(void *data)
 
    menu_displaylist_info_init(&info);
 
-   info.label                   = strdup(
-         msg_hash_to_str(MENU_ENUM_LABEL_MAIN_MENU));
+   info.label                   = strdup(msg_hash_to_str(MENU_ENUM_LABEL_MAIN_MENU));
    info.exts                    = strldup("lpl", sizeof("lpl"));
    info.type_default            = FILE_TYPE_PLAIN;
    info.enum_idx                = MENU_ENUM_LABEL_MAIN_MENU;
 
-   menu_entries_append(menu_stack, info.path,
+   menu_entries_append(menu_stack,
+         info.path,
          info.label,
          MENU_ENUM_LABEL_MAIN_MENU,
-         info.type, info.flags, 0, NULL);
+         info.type,
+         info.flags,
+         0,
+         NULL);
 
    info.list                    = selection_buf;
 
@@ -11361,8 +11487,7 @@ static void ozone_messagebox(void *data, const char *message)
 static int ozone_deferred_push_content_actions(menu_displaylist_info_t *info)
 {
    settings_t *settings         = config_get_ptr();
-   if (!menu_displaylist_ctl(
-            DISPLAYLIST_HORIZONTAL_CONTENT_ACTIONS, info, settings))
+   if (!menu_displaylist_ctl(DISPLAYLIST_HORIZONTAL_CONTENT_ACTIONS, info, settings))
       return -1;
    menu_displaylist_process(info);
    menu_displaylist_info_free(info);
@@ -11387,7 +11512,10 @@ static int ozone_list_bind_init_compare_label(menu_file_list_cbs_t *cbs)
 }
 
 static int ozone_list_bind_init(menu_file_list_cbs_t *cbs,
-      const char *path, const char *label, unsigned type, size_t idx)
+      const char *path,
+      const char *label,
+      unsigned type,
+      size_t idx)
 {
    if (ozone_list_bind_init_compare_label(cbs) == 0)
       return 0;
@@ -11396,10 +11524,13 @@ static int ozone_list_bind_init(menu_file_list_cbs_t *cbs,
 }
 
 static int ozone_pointer_up(void *userdata,
-      unsigned x, unsigned y, unsigned ptr,
+      unsigned x,
+      unsigned y,
+      unsigned ptr,
       enum menu_input_pointer_gesture gesture,
       menu_file_list_cbs_t *cbs,
-      menu_entry_t *entry, unsigned action)
+      menu_entry_t *entry,
+      unsigned action)
 {
    unsigned width, height;
    ozone_handle_t *ozone             = (ozone_handle_t*)userdata;
@@ -11439,10 +11570,9 @@ static int ozone_pointer_up(void *userdata,
              (y > height - ozone->dimensions.footer_height))
             return ozone_menu_entry_action(ozone, entry, selection, MENU_ACTION_CANCEL);
          /* Tap/press entries: Activate and/or select item */
-         else if ((ptr < entries_end) &&
-                  (x > ozone->dimensions_sidebar_width 
-                   + ozone->sidebar_offset) &&
-                  (x < width - ozone->animations.thumbnail_bar_position))
+         else if ((ptr < entries_end)
+               && (x > ozone->dimensions_sidebar_width + ozone->sidebar_offset)
+               && (x < width - ozone->animations.thumbnail_bar_position))
          {
             if (gesture == MENU_INPUT_GESTURE_TAP)
             {
@@ -11531,12 +11661,12 @@ static int ozone_pointer_up(void *userdata,
          break;
       case MENU_INPUT_GESTURE_LONG_PRESS:
          /* 'Reset to default' action */
-         if ((y > ozone->dimensions.header_height) &&
-             (y < height - ozone->dimensions.footer_height) &&
-             (ptr < entries_end) &&
-             (ptr == selection) &&
-             (x > ozone->dimensions_sidebar_width + ozone->sidebar_offset) &&
-             (x < width - ozone->animations.thumbnail_bar_position))
+         if (     (y > ozone->dimensions.header_height)
+               && (y < height - ozone->dimensions.footer_height)
+               && (ptr < entries_end)
+               && (ptr == selection)
+               && (x > ozone->dimensions_sidebar_width + ozone->sidebar_offset)
+               && (x < width - ozone->animations.thumbnail_bar_position))
             return ozone_menu_entry_action(ozone,
                   entry, selection, MENU_ACTION_START);
          break;
@@ -11545,9 +11675,9 @@ static int ozone_pointer_up(void *userdata,
           * > Note: Can only do this if we are not using
           *   a mouse, since it conflicts with auto selection
           *   of entry under cursor */
-         if (   (ozone->pointer.type != MENU_POINTER_MOUSE)
-             && (ozone->flags & OZONE_FLAG_IS_PLAYLIST)
-             && (ozone->depth == 1))
+         if (     (ozone->pointer.type != MENU_POINTER_MOUSE)
+               && (ozone->flags & OZONE_FLAG_IS_PLAYLIST)
+               && (ozone->depth == 1))
             return ozone_menu_entry_action(ozone, entry, (size_t)ptr, MENU_ACTION_SCROLL_UP);
          break;
       case MENU_INPUT_GESTURE_SWIPE_RIGHT:
@@ -11555,9 +11685,9 @@ static int ozone_pointer_up(void *userdata,
           * > Note: Can only do this if we are not using
           *   a mouse, since it conflicts with auto selection
           *   of entry under cursor */
-         if (   (ozone->pointer.type != MENU_POINTER_MOUSE)
-             && (ozone->flags & OZONE_FLAG_IS_PLAYLIST)
-             && (ozone->depth == 1))
+         if (     (ozone->pointer.type != MENU_POINTER_MOUSE)
+               && (ozone->flags & OZONE_FLAG_IS_PLAYLIST)
+               && (ozone->depth == 1))
             return ozone_menu_entry_action(ozone, entry, (size_t)ptr, MENU_ACTION_SCROLL_DOWN);
          break;
       default:


### PR DESCRIPTION
## Description

Massive and scary commit, but I find it worth it for readability. Please let me know if something looks worse or illogical. Especially conditionals with both ORs and ANDs were hard to read and understand. 

Main reason was fixing a few issues, but fixing them was easier after unifying things somewhat. Changes are mostly only whitespace and indents. All tabs are also removed. Long line wrappings have a bit more leeway in order to keep it simpler.

Fixes:
- Launching anything from a View no longer throws Quick Menu off the screen
- Save state thumbnails in slot dropdown obeys fullscreen toggle properly when content launched via CLI
- Save state thumbnail dropdown won't allow fullscreen toggle when it shouldn't
- Selection position remembering in non-playlists won't flash the first entry

Testing is most welcome!