### PR TITLE
(Bug fix) Escape backslashes in translation strings

### DIFF
--- a/intl/json2h.py
+++ b/intl/json2h.py
@@ -88,7 +88,10 @@ def update(messages, template, source_messages):
         if tp_msg['key'] in messages and messages[tp_msg['key']] != source_messages[tp_msg['key']]:
             tp_msg_val = tp_msg['val']
             tl_msg_val = messages[tp_msg['key']]
-            tl_msg_val = tl_msg_val.replace('"', '\\\"').replace('\n', '')  # escape
+            # escape: reduce \\ -> \ (prevents 'over-expansion': \\ -> \\\\), then expand all \ -> \\
+            tl_msg_val = tl_msg_val.replace('\\\\', '\\').replace('\\', '\\\\')
+            # escape other symbols
+            tl_msg_val = tl_msg_val.replace('"', '\\\"').replace('\n', '')
             if tp_msg['key'].find('_QT_') < 0:
                 tl_msg_val = c89_cut(tl_msg_val)
             # Replace last match, in case the key contains the value string

--- a/intl/msg_hash_cht.h
+++ b/intl/msg_hash_cht.h
@@ -3025,7 +3025,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_CONTENT_RUNTIME_LOG,
-   "記錄每個項目的執行時間，儲存在核心名稱資料夾中(..\列表資料夾\logs\核心名稱)。"
+   "記錄每個項目的執行時間，儲存在核心名稱資料夾中(..\\列表資料夾\\logs\\核心名稱)。"
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_CONTENT_RUNTIME_LOG_AGGREGATE,
@@ -3033,7 +3033,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_CONTENT_RUNTIME_LOG_AGGREGATE,
-   "記錄每個項目的執行時間，儲存在共用資料夾中(..\列表資料夾\logs)。"
+   "記錄每個項目的執行時間，儲存在共用資料夾中(..\\列表資料夾\\logs)。"
    )
 
 /* Settings > Logging */


### PR DESCRIPTION
## Description

Crowdin seems to not properly escape all backslashes in translation strings.
So I modified the sync script to handle it:

- First, any already escaped backslashes are reduced to avoid 'double dipping': \\\\ -> \ 
- Then, all backslashes are escaped: \ -> \\\\
- Lastly, all other escape operations occur (e.g. " -> \\")

According to my (admittedly limited) testing, this seems to work out fine, but please feel free to try it out yourselves.

## Reviewers
@guoyunhe 
@sonninnos 
@LibretroAdmin 
