### PR TITLE
(Bug fix) Fix the weird 'empty translations' & correct backslash escaping in translation strings

### DIFF
--- a/.github/workflows/crowdin-daily.yml
+++ b/.github/workflows/crowdin-daily.yml
@@ -16,13 +16,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Java JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          java-version: 18
+          distribution: zulu
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Crowdin Sync
         shell: bash
         env:

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -18,13 +18,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Java JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          java-version: 18
+          distribution: zulu
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Crowdin Sync
         shell: bash
         env:

--- a/intl/json2h.py
+++ b/intl/json2h.py
@@ -88,8 +88,10 @@ def update(messages, template, source_messages):
         if tp_msg['key'] in messages and messages[tp_msg['key']] != source_messages[tp_msg['key']]:
             tp_msg_val = tp_msg['val']
             tl_msg_val = messages[tp_msg['key']]
-            # escape: reduce \\ -> \ (prevents 'over-expansion': \\ -> \\\\), then expand all \ -> \\
-            tl_msg_val = tl_msg_val.replace('\\\\', '\\').replace('\\', '\\\\')
+            # escape all \
+            tl_msg_val = tl_msg_val.replace('\\', r'\\')
+            # remove "double-dipping" on escape sequences
+            tl_msg_val = re.sub(r'\\\\(?=[nrt])', r'\\', tl_msg_val)
             # escape other symbols
             tl_msg_val = tl_msg_val.replace('"', '\\\"').replace('\n', '')
             if tp_msg['key'].find('_QT_') < 0:


### PR DESCRIPTION
## Description

Something weird (presumably some error in Crowdin?) caused the loss of a large number of translated texts, rendering RA basically unusable in the affected languages. By re-running the sync scripts (and utilising Crowdins 'pre-translation' feature) this issue is largely fixed, even if not perfectly.

Also, to my great shame, my attempt at escaping backslashes creates duplicate backslashes wherever an escape sequence is used (e.g. \n -> \\\\n). But this time, after thorough testing, I can say for sure that this issue is now fixed. Should have used regex from the start, honestly.

## Reviewers
@IlDucci, @guoyunhe 
I don't know what on earth happened to make Crowdin crap itself like that, but we've fixed as much as we could, I guess.
