### PR TITLE
config.libs: dont fail if OSDependent/OGLCompiler libraries are not p…

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -638,8 +638,6 @@ if [ "$HAVE_GLSLANG" != no ]; then
    check_lib cxx GLSLANG_SPIRV_TOOLS -lSPIRV-Tools
 
    if [ "$HAVE_GLSLANG" = no ] ||
-      [ "$HAVE_GLSLANG_OSDEPENDENT" = no ] ||
-      [ "$HAVE_GLSLANG_OGLCOMPILER" = no ] ||
       [ "$HAVE_GLSLANG_HLSL" = no ] ||
       [ "$HAVE_GLSLANG_SPIRV" = no ] ||
       [ "$HAVE_GLSLANG_SPIRV_TOOLS_OPT" = no ] ||


### PR DESCRIPTION
…resent

glslang no longer installs them separately, and all needed functionality has been merged into glslang shared library itself.

This wasn't a problem previously as they were still provided as static libraries but in latest glslang they no longer are: https://github.com/KhronosGroup/glslang/commit/7cd519511c32d7e86d901c7ed231cb84c652d18

Signed-off-by: Markus Volk <f_l_k@t-online.de>

## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

[Description of the pull request, detail any issues you are fixing or any features you are implementing]

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
