### PR TITLE
Overlays: Ignore hitboxes with zero area

### DIFF
--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -1408,6 +1408,8 @@ static bool inside_hitbox(const struct overlay_desc *desc, float x, float y)
          return
             (fabs(x - desc->x_hitbox) <= desc->range_x_mod) &&
             (fabs(y - desc->y_hitbox) <= desc->range_y_mod);
+      case OVERLAY_HITBOX_NONE:
+         return false;
    }
    return false;
 }

--- a/input/input_overlay.h
+++ b/input/input_overlay.h
@@ -62,7 +62,8 @@ typedef struct video_overlay_interface
 enum overlay_hitbox
 {
    OVERLAY_HITBOX_RADIAL = 0,
-   OVERLAY_HITBOX_RECT
+   OVERLAY_HITBOX_RECT,
+   OVERLAY_HITBOX_NONE
 };
 
 enum overlay_type

--- a/tasks/task_overlay.c
+++ b/tasks/task_overlay.c
@@ -237,7 +237,6 @@ static bool task_overlay_load_desc(
    char overlay_desc_normalized_key[32];
    char overlay[256];
    float tmp_float                      = 0.0f;
-   int tmp_int                          = 0;
    bool tmp_bool                        = false;
    bool ret                             = true;
    bool by_pixel                        = false;
@@ -444,6 +443,10 @@ static bool task_overlay_load_desc(
       desc->reach_down = tmp_float;
    }
 
+   if (     (desc->reach_left == 0.0f && desc->reach_right == 0.0f)
+         || (desc->reach_up   == 0.0f && desc->reach_down  == 0.0f))
+      desc->hitbox = OVERLAY_HITBOX_NONE;
+
    desc->mod_x   = desc->x - desc->range_x;
    desc->mod_w   = 2.0f * desc->range_x;
    desc->mod_y   = desc->y - desc->range_y;
@@ -464,12 +467,14 @@ static bool task_overlay_load_desc(
    snprintf(conf_key, sizeof(conf_key),
          "overlay%u_desc%u_exclusive", ol_idx, desc_idx);
    desc->exclusive = false;
-   config_get_bool(conf, conf_key, &desc->exclusive);
+   if (config_get_bool(conf, conf_key, &tmp_bool))
+      desc->exclusive = tmp_bool;
 
    snprintf(conf_key, sizeof(conf_key),
          "overlay%u_desc%u_range_mod_exclusive", ol_idx, desc_idx);
    desc->range_mod_exclusive = false;
-   config_get_bool(conf, conf_key, &desc->range_mod_exclusive);
+   if (config_get_bool(conf, conf_key, &tmp_bool))
+      desc->range_mod_exclusive = tmp_bool;
 
    snprintf(conf_key, sizeof(conf_key),
          "overlay%u_desc%u_movable", ol_idx, desc_idx);


### PR DESCRIPTION
I.e. Set 'reach_x' or 'reach_y' to zero to ensure no hitbox math is done.

This simplifies designating animation-only descriptors (e.g. for eightway areas) or obsolete descriptors.

## Related Pull Requests

libretro/common-overlays#87

## Reviewers

@LibretroAdmin
