### PR TITLE
(XMB) Improve background image selector

### DIFF
--- a/menu/cbs/menu_cbs_title.c
+++ b/menu/cbs/menu_cbs_title.c
@@ -869,8 +869,9 @@ static int action_get_title_default(const char *path, const char *label,
          msg_hash_to_str(MENU_ENUM_LABEL_VALUE_SELECT_FILE), len);
    if (!string_is_empty(path))
    {
-      s[_len  ] = ' ';
-      s[_len+1] = '\0';
+      s[_len  ] = ':';
+      s[_len+1] = ' ';
+      s[_len+2] = '\0';
       strlcat(s, path, len);
    }
 

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -2717,7 +2717,8 @@ static void xmb_populate_entries(void *data,
     * > Note: MENU_ENUM_LABEL_FAVORITES is always set
     *   as the 'label' when navigating directories after
     *   selecting 'load content' */
-   xmb->is_file_list = string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_FAVORITES));
+   xmb->is_file_list = string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_FAVORITES)) ||
+                       string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_MENU_WALLPAPER));
 
    /* Determine whether this is the quick menu */
    xmb->is_quick_menu = string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_RPL_ENTRY_ACTIONS)) ||
@@ -2819,13 +2820,12 @@ static void xmb_populate_entries(void *data,
       xmb_set_thumbnail_content(xmb, "");
       xmb_update_thumbnail_image(xmb);
    }
-
    /* Hack: XMB gets into complete muddle when
     * performing 'complex' directory navigation
     * via 'load content'. We have to work around
     * this by resetting thumbnails whenever a
     * file list is populated... */
-   if (xmb->is_file_list)
+   else if (xmb->is_file_list)
    {
       xmb->fullscreen_thumbnails_available = false;
       xmb->thumbnails.pending = XMB_PENDING_THUMBNAIL_NONE;
@@ -2833,6 +2833,9 @@ static void xmb_populate_entries(void *data,
       gfx_thumbnail_cancel_pending_requests();
       gfx_thumbnail_reset(&xmb->thumbnails.right);
       gfx_thumbnail_reset(&xmb->thumbnails.left);
+
+      xmb_set_thumbnail_content(xmb, "imageviewer");
+      xmb_update_thumbnail_image(xmb);
    }
 }
 

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -7096,8 +7096,8 @@ int menu_action_handle_setting(rarch_setting_t *setting,
          {
             menu_displaylist_info_t  info;
             settings_t *settings          = config_get_ptr();
-            file_list_t       *menu_stack = menu_entries_get_menu_stack_ptr(0);
-            const char      *name         = setting->name;
+            file_list_t *menu_stack       = menu_entries_get_menu_stack_ptr(0);
+            const char *name              = setting->name;
             size_t selection              = menu_navigation_get_selection();
 
             menu_displaylist_info_init(&info);
@@ -7107,6 +7107,26 @@ int menu_action_handle_setting(rarch_setting_t *setting,
             info.type                     = type;
             info.directory_ptr            = selection;
             info.list                     = menu_stack;
+
+            /* Menu background image */
+            if (string_is_equal(info.label, msg_hash_to_str(MENU_ENUM_LABEL_MENU_WALLPAPER)))
+            {
+               /* Start from current wallpaper instead if available */
+               if (!string_is_empty(settings->paths.path_menu_wallpaper))
+               {
+                  free(info.path);
+                  info.path = strdup(settings->paths.path_menu_wallpaper);
+               }
+            }
+
+            /* Browse basedir instead and set selection to file if available */
+            if (!string_is_empty(info.path) && !path_is_directory(info.path))
+            {
+               const char *selection_path = path_basename(info.path);
+               if (!string_is_empty(selection_path))
+                  menu_driver_set_pending_selection(selection_path);
+               path_basedir(info.path);
+            }
 
             if (menu_displaylist_ctl(DISPLAYLIST_GENERIC, &info, settings))
                menu_displaylist_process(&info);
@@ -15830,7 +15850,7 @@ static bool setting_append_list(
                   sizeof(settings->paths.path_menu_wallpaper),
                   MENU_ENUM_LABEL_MENU_WALLPAPER,
                   MENU_ENUM_LABEL_VALUE_MENU_WALLPAPER,
-                  "",
+                  settings->paths.directory_assets,
                   &group_info,
                   &subgroup_info,
                   parent_group,


### PR DESCRIPTION
## Description

Make background image selector usage more comfortable by:
- Starting from assets directory or current selection instead of drive letter root
- Showing image previews while browsing

Also:
- File selector globally removes file from selection path, uses path instead and sets file as selection
- File selector title corrected to have `:` separator
