### PR TITLE
Don't show override notification with appendconfig alone

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -3899,6 +3899,7 @@ bool config_load_override(void *data)
    char content_dir_name[PATH_MAX_LENGTH];
    char config_directory[PATH_MAX_LENGTH];
    bool should_append                     = false;
+   bool show_notification                 = true;
    rarch_system_info_t *system            = (rarch_system_info_t*)data;
    const char *core_name                  = system ?
       system->info.library_name : NULL;
@@ -3951,7 +3952,10 @@ bool config_load_override(void *data)
 
    /* Prevent "--appendconfig" from being ignored */
    if (!path_is_empty(RARCH_PATH_CONFIG_APPEND))
-      should_append = true;
+   {
+      should_append     = true;
+      show_notification = false;
+   }
 
    /* per-core overrides */
    /* Create a new config file from core_path */
@@ -3977,7 +3981,8 @@ bool config_load_override(void *data)
 
       path_set(RARCH_PATH_CONFIG_APPEND, tmp_path);
 
-      should_append = true;
+      should_append     = true;
+      show_notification = true;
    }
 
    if (has_content)
@@ -4006,7 +4011,8 @@ bool config_load_override(void *data)
 
          path_set(RARCH_PATH_CONFIG_APPEND, tmp_path);
 
-         should_append = true;
+         should_append     = true;
+         show_notification = true;
       }
 
       /* per-game overrides */
@@ -4033,7 +4039,8 @@ bool config_load_override(void *data)
 
          path_set(RARCH_PATH_CONFIG_APPEND, tmp_path);
 
-         should_append = true;
+         should_append     = true;
+         show_notification = true;
       }
    }
 
@@ -4045,13 +4052,14 @@ bool config_load_override(void *data)
 
    /* Toggle has_save_path to false so it resets */
    retroarch_override_setting_unset(RARCH_OVERRIDE_SETTING_STATE_PATH, NULL);
-   retroarch_override_setting_unset(RARCH_OVERRIDE_SETTING_SAVE_PATH,  NULL);
+   retroarch_override_setting_unset(RARCH_OVERRIDE_SETTING_SAVE_PATH, NULL);
 
    if (!config_load_file(global_get_ptr(),
             path_get(RARCH_PATH_CONFIG), settings))
       return false;
 
-   if (settings->bools.notification_show_config_override_load)
+   if (settings->bools.notification_show_config_override_load
+         && show_notification)
       runloop_msg_queue_push(msg_hash_to_str(MSG_CONFIG_OVERRIDE_LOADED),
             1, 100, false,
             NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
@@ -4079,7 +4087,7 @@ bool config_unload_override(void)
 
    /* Toggle has_save_path to false so it resets */
    retroarch_override_setting_unset(RARCH_OVERRIDE_SETTING_STATE_PATH, NULL);
-   retroarch_override_setting_unset(RARCH_OVERRIDE_SETTING_SAVE_PATH,  NULL);
+   retroarch_override_setting_unset(RARCH_OVERRIDE_SETTING_SAVE_PATH, NULL);
 
    if (!config_load_file(global_get_ptr(),
             path_get(RARCH_PATH_CONFIG), config_st))


### PR DESCRIPTION
## Description

Minor addition to `--appendconfig` handling to only show override notification with actual overrides.

## Related Issues

Closes #14620
