### PR TITLE
feat(iOS13): Menu UI - Enable Touch Support upon enabling Mouse Support

### DIFF
--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -5729,6 +5729,12 @@ unsigned menu_event(
       menu_input_pointer_hw_state_t touchscreen_hw_state = {0};
 
       /* Read mouse */
+#ifdef HAVE_IOS_TOUCHMOUSE
+       if (menu_mouse_enable) {
+         settings->bools.menu_pointer_enable=true;
+         menu_pointer_enable=true;
+       }
+#else
       if (menu_mouse_enable)
          menu_input_get_mouse_hw_state(
                p_disp,
@@ -5742,7 +5748,7 @@ unsigned menu_event(
                input_overlay_enable,
                overlay_active,
                &mouse_hw_state);
-
+#endif
       /* Read touchscreen
        * Note: Could forgo this if mouse is currently active,
        * but this is 'cleaner' code... (if performance is a


### PR DESCRIPTION
## Description

Enable Touch Mouse Support upon enabling mouse support in menu UI, as trackpad support is achieved through touch mouse feature in iOS, use Touch Mouse to drive Mouse in the menu

## Related Issues

[[https://github.com/libretro/RetroArch/pull/14639]](https://github.com/libretro/RetroArch/pull/14639)
