### PR TITLE
Move SRAM init to content init

### DIFF
--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -12119,10 +12119,6 @@ MSG_HASH(
    "Auto save state to"
    )
 MSG_HASH(
-   MSG_BLOCKING_SRAM_OVERWRITE,
-   "Blocking SRAM Overwrite"
-   )
-MSG_HASH(
    MSG_BRINGING_UP_COMMAND_INTERFACE_ON_PORT,
    "Bringing up command interface on port"
    )
@@ -12815,10 +12811,6 @@ MSG_HASH(
    "Shader preset saved successfully."
    )
 MSG_HASH(
-   MSG_SKIPPING_SRAM_LOAD,
-   "Skipping SRAM load."
-   )
-MSG_HASH(
    MSG_SLOW_MOTION,
    "Slow-Motion."
    )
@@ -12831,8 +12823,16 @@ MSG_HASH(
    "Slow-motion rewind."
    )
 MSG_HASH(
+   MSG_SKIPPING_SRAM_LOAD,
+   "Skipping SRAM load."
+   )
+MSG_HASH(
    MSG_SRAM_WILL_NOT_BE_SAVED,
    "SRAM will not be saved."
+   )
+MSG_HASH(
+   MSG_BLOCKING_SRAM_OVERWRITE,
+   "Blocking SRAM Overwrite"
    )
 MSG_HASH(
    MSG_STARTING_MOVIE_PLAYBACK,

--- a/retroarch.c
+++ b/retroarch.c
@@ -5528,8 +5528,6 @@ bool retroarch_main_init(int argc, char *argv[])
    if (!string_is_empty(recording_st->path))
       command_event(CMD_EVENT_RECORD_INIT, NULL);
 
-   runloop_path_init_savefile();
-
    command_event(CMD_EVENT_SET_PER_GAME_RESOLUTION, NULL);
 
    global->error_on_init            = false;

--- a/runloop.c
+++ b/runloop.c
@@ -5200,6 +5200,8 @@ static bool event_init_content(
 
    command_event_set_savestate_auto_index(settings);
 
+   runloop_path_init_savefile();
+
    if (!event_load_save_files(runloop_st->flags &
             RUNLOOP_FLAG_IS_SRAM_LOAD_DISABLED))
       RARCH_LOG("[SRAM]: %s\n",

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -3098,13 +3098,10 @@ bool content_init(void)
    if (error_string)
    {
       if (ret)
-      {
          RARCH_LOG("[Content]: %s\n", error_string);
-      }
       else
-      {
          RARCH_ERR("[Content]: %s\n", error_string);
-      }
+
       /* Do not flush the message queue here
        * > This allows any core-generated error messages
        *   to propagate through to the frontend */


### PR DESCRIPTION
## Description

- Don't init SRAM saving without content (gets rid of the redundant logging)
- Moved SRAM related msg hashes together

