### PR TITLE
(WinRaw) Fix mouse position when using input overlay with mouse cursor

### DIFF
--- a/input/drivers/winraw_input.c
+++ b/input/drivers/winraw_input.c
@@ -413,9 +413,20 @@ static void winraw_update_mouse_state(winraw_input_t *wr,
       if (menu_state_get_ptr()->flags & MENU_ST_FLAG_ALIVE)
          getcursorpos = true;
 #endif
+      /* Input overlay with mouse cursor must also use GetCursorPos() */
+      if (!getcursorpos)
+      {
+         settings_t *settings = config_get_ptr();
+         if (     settings->bools.input_overlay_enable
+               && settings->bools.input_overlay_show_mouse_cursor)
+            getcursorpos = true;
+      }
 
       if (getcursorpos)
       {
+         InterlockedExchangeAdd(&mouse->dlt_x, state->lLastX);
+         InterlockedExchangeAdd(&mouse->dlt_y, state->lLastY);
+
          if (!GetCursorPos(&crs_pos))
             RARCH_DBG("[WinRaw]: GetCursorPos failed with error %lu.\n", GetLastError());
          else if (!ScreenToClient((HWND)video_driver_window_get(), &crs_pos))


### PR DESCRIPTION
## Description

Corrections to WinRaw driver regarding mouse:
- Fixed mouse position to use the same method required for menu items and pointer when simulating input overlays with mouse, since it won't work with multi mouse method
- Fixed passing mouse position to core also when using aforementioned method
