### PR TITLE
Restore framelimit on fastforward toggle

### DIFF
--- a/runloop.c
+++ b/runloop.c
@@ -7331,6 +7331,7 @@ static enum runloop_state_enum runloop_check_state(
          {
             input_st->flags                     |=  INP_FLAG_NONBLOCKING;
             runloop_st->flags                   |=  RUNLOOP_FLAG_FASTMOTION;
+            command_event(CMD_EVENT_SET_FRAME_LIMIT, NULL);
          }
 
          driver_set_nonblock_state();


### PR DESCRIPTION
## Description

Fast-forward will currently be broken after toggling `vrr_runloop` off, since it will force frame limit to 1.0 (even on every frame, yikes) and never restores it. So let's make sure the wanted ratio is applied when toggling FF.

I think FF ratio should be completely separate from normal running frame limit anyway, and `vrr_runloop` for sure does not have to keep setting the frame limit on every frame, so those should be inspected later.

