### PR TITLE
(alsa) Fix potentially never-ending while loops

### DIFF
--- a/audio/drivers/alsa.c
+++ b/audio/drivers/alsa.c
@@ -197,7 +197,7 @@ static ssize_t alsa_write(void *data, const void *buf_, size_t size_)
 
    if (alsa->nonblock)
    {
-      while (size)
+      while (size > 0)
       {
          snd_pcm_sframes_t frames = snd_pcm_writei(alsa->pcm, buf, size);
 
@@ -222,7 +222,7 @@ static ssize_t alsa_write(void *data, const void *buf_, size_t size_)
    {
       bool eagain_retry         = true;
 
-      while (size)
+      while (size > 0)
       {
          snd_pcm_sframes_t frames;
          int rc = snd_pcm_wait(alsa->pcm, -1);


### PR DESCRIPTION
## Description

'while(size)' will only ever be false and exit the loop if size = 0.  size is a variable of type 'snd_pcm_sframes_t' which can be positive or negative (long integer).  As far as I can tell, C sees any non-zero value as true.

size is only decremented in the loops so if it goes below zero, the evaluation will always be true and we will become trapped in the loop until the process is killed!  Tested this on an ARM9 platform which is having a random freezing issue by changing both loops to while(1), and confirmed this will freeze RetroArch, allowing no input resulting in the application process having to be killed to resume.

The freezing issue doesn't seem to occur when using the alsathread driver, and cross-checking shows that this driver doesn't have any while loops structured this way, which may explain it.

## Related Issues

Random freezing when using alsa as the audio driver.

## Related Pull Requests

None

## Reviewers

If possible it would be good if @inactive123 would look at this and confirm my thought process/fix as I'm not really familar with alsa/audio etc, just trying to fix an issue I've encountered!