### PR TITLE
Use only macros from now on in config.def.h

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -375,7 +375,6 @@
  */
 #define DEFAULT_BLACK_FRAME_INSERTION 0
 
-
 /* Uses a custom swap interval for VSync.
  * Set this to effectively halve monitor refresh rate.
  */
@@ -676,8 +675,7 @@
 #define DEFAULT_MENU_HORIZONTAL_ANIMATION true
 
 #define DEFAULT_MENU_TICKER_TYPE (TICKER_TYPE_LOOP)
-static const float menu_ticker_speed        = 2.0f;
-
+#define DEFAULT_MENU_TICKER_SPEED 2.0f
 #define DEFAULT_MENU_TICKER_SMOOTH true
 
 #if defined(HAVE_THREADS)
@@ -742,18 +740,18 @@ static const float menu_ticker_speed        = 2.0f;
 #define DEFAULT_XMB_TITLE_MARGIN                   5
 #define DEFAULT_XMB_TITLE_MARGIN_HORIZONTAL_OFFSET 0
 #define MAXIMUM_XMB_TITLE_MARGIN                   12
+#define DEFAULT_XMB_ALPHA_FACTOR 75
 
-static const unsigned xmb_alpha_factor      = 75;
-static const unsigned menu_font_color_red   = 255;
-static const unsigned menu_font_color_green = 255;
-static const unsigned menu_font_color_blue  = 255;
+#define DEFAULT_MENU_FONT_COLOR_RED 255
+#define DEFAULT_MENU_FONT_COLOR_GREEN 255
+#define DEFAULT_MENU_FONT_COLOR_BLUE 255
 #ifdef HAVE_ODROIDGO2
-static const unsigned xmb_menu_layout       = 2;
+#define DEFAULT_XMB_MENU_LAYOUT 2
 #else
-static const unsigned xmb_menu_layout       = 0;
+#define DEFAULT_XMB_MENU_LAYOUT 0
 #endif
-static const unsigned xmb_icon_theme        = XMB_ICON_THEME_MONOCHROME;
-static const unsigned xmb_theme             = XMB_THEME_ELECTRIC_BLUE;
+#define DEFAULT_XMB_ICON_THEME XMB_ICON_THEME_MONOCHROME
+#define DEFAULT_XMB_THEME XMB_THEME_ELECTRIC_BLUE
 
 #if defined(HAVE_LAKKA) || defined(__arm__) || defined(__PPC64__) || defined(__ppc64__) || defined(__powerpc64__) || defined(__powerpc__) || defined(__ppc__) || defined(__POWERPC__)
 #define DEFAULT_XMB_SHADOWS_ENABLE false
@@ -762,13 +760,10 @@ static const unsigned xmb_theme             = XMB_THEME_ELECTRIC_BLUE;
 #endif
 #endif
 
-static const float menu_framebuffer_opacity = 0.900;
-
-static const float menu_wallpaper_opacity = 0.300;
-
-static const float menu_footer_opacity = 1.000;
-
-static const float menu_header_opacity = 1.000;
+#define DEFAULT_MENU_FRAMEBUFFER_OPACITY 0.900f
+#define DEFAULT_MENU_WALLPAPER_OPACITY 0.300f
+#define DEFAULT_MENU_FOOTER_OPACITY 1.000f
+#define DEFAULT_MENU_HEADER_OPACITY 1.000f
 
 #if defined(HAVE_OPENGLES2) || (defined(__MACH__)  && defined(MAC_OS_X_VERSION_MAX_ALLOWED) && (MAC_OS_X_VERSION_MAX_ALLOWED < 101200))
 #define DEFAULT_MENU_SHADER_PIPELINE 1
@@ -783,12 +778,12 @@ static const float menu_header_opacity = 1.000;
 
 #define DEFAULT_RGUI_INLINE_THUMBNAILS false
 #define DEFAULT_RGUI_SWAP_THUMBNAILS false
-static const unsigned rgui_thumbnail_downscaler = RGUI_THUMB_SCALE_POINT;
-static const unsigned rgui_thumbnail_delay = 0;
-static const unsigned rgui_internal_upscale_level = RGUI_UPSCALE_NONE;
-static const bool rgui_full_width_layout = true;
-static const unsigned rgui_aspect = RGUI_ASPECT_RATIO_4_3;
-static const unsigned rgui_aspect_lock = RGUI_ASPECT_RATIO_LOCK_NONE;
+#define DEFAULT_RGUI_THUMBNAIL_DOWNSCALER RGUI_THUMB_SCALE_POINT
+#define DEFAULT_RGUI_THUMBNAIL_DELAY 0
+#define DEFAULT_RGUI_INTERNAL_UPSCALE_LEVEL RGUI_UPSCALE_NONE
+#define DEFAULT_RGUI_FULL_WIDTH_LAYOUT true
+#define DEFAULT_RGUI_ASPECT RGUI_ASPECT_RATIO_4_3
+#define DEFAULT_RGUI_ASPECT_LOCK RGUI_ASPECT_RATIO_LOCK_NONE
 #define DEFAULT_RGUI_SHADOWS false
 #define DEFAULT_RGUI_PARTICLE_EFFECT RGUI_PARTICLE_EFFECT_NONE
 #define DEFAULT_RGUI_PARTICLE_EFFECT_SPEED 1.0f
@@ -806,22 +801,22 @@ static const unsigned rgui_aspect_lock = RGUI_ASPECT_RATIO_LOCK_NONE;
 /* TODO/FIXME - this setting is thread-unsafe right now and can corrupt the stack - default to off */
 #define DEFAULT_AUTOMATICALLY_ADD_CONTENT_TO_PLAYLIST false
 
-static const bool default_game_specific_options = true;
-static const bool default_auto_overrides_enable = true;
-static const bool default_auto_remaps_enable = true;
-static const bool default_global_core_options = false;
-static const bool default_auto_shaders_enable = true;
+#define DEFAULT_GAME_SPECIFIC_OPTIONS true
+#define DEFAULT_AUTO_OVERRIDES_ENABLE true
+#define DEFAULT_AUTO_REMAPS_ENABLE true
+#define DEFAULT_GLOBAL_CORE_OPTIONS false
+#define DEFAULT_AUTO_SHADERS_ENABLE true
 
-static const bool default_sort_savefiles_enable = false;
-static const bool default_sort_savestates_enable = false;
-static const bool default_sort_savefiles_by_content_enable = false;
-static const bool default_sort_savestates_by_content_enable = false;
-static const bool default_sort_screenshots_by_content_enable = false;
+#define DEFAULT_SORT_SAVEFILES_ENABLE false
+#define DEFAULT_SORT_SAVESTATES_ENABLE false
+#define DEFAULT_SORT_SAVEFILES_BY_CONTENT_ENABLE false
+#define DEFAULT_SORT_SAVESTATES_BY_CONTENT_ENABLE false
+#define DEFAULT_SORT_SCREENSHOTS_BY_CONTENT_ENABLE false
 
-static const bool default_savestates_in_content_dir = false;
-static const bool default_savefiles_in_content_dir = false;
-static const bool default_systemfiles_in_content_dir = false;
-static const bool default_screenshots_in_content_dir = false;
+#define DEFAULT_SAVESTATES_IN_CONTENT_DIR false
+#define DEFAULT_SAVEFILES_IN_CONTENT_DIR false
+#define DEFAULT_SYSTEMFILES_IN_CONTENT_DIR false
+#define DEFAULT_SCREENSHOTS_IN_CONTENT_DIR false
 
 #if defined(RS90) || defined(RETROFW) || defined(MIYOO)
 #define DEFAULT_MENU_TOGGLE_GAMEPAD_COMBO INPUT_COMBO_START_SELECT
@@ -842,8 +837,8 @@ static const bool default_screenshots_in_content_dir = false;
 #define DEFAULT_QUIT_GAMEPAD_COMBO INPUT_COMBO_NONE
 
 #if defined(VITA)
-static const unsigned input_backtouch_enable       = false;
-static const unsigned input_backtouch_toggle       = false;
+#define DEFAULT_INPUT_BACKTOUCH_ENABLE false
+#define DEFAULT_INPUT_BACKTOUCH_TOGGLE false
 #endif
 
 #define DEFAULT_OVERLAY_ENABLE_AUTOPREFERRED true
@@ -891,7 +886,6 @@ static const unsigned input_backtouch_toggle       = false;
 #else
 #define DEFAULT_FONT_SIZE 32
 #endif
-
 
 /* Offset for where messages will be placed on-screen.
  * Values are in range [0.0, 1.0]. */
@@ -942,9 +936,9 @@ static const unsigned input_backtouch_toggle       = false;
  * If your monitor does not run at 60Hz, or something close to it,
  * disable VSync, and leave this at its default. */
 #ifdef _3DS
-#define DEFAULT_REFRESH_RATE ((32730.0 * 8192.0) / 4481134.0)
+#define DEFAULT_REFRESH_RATE ((32730.0f * 8192.0f) / 4481134.0f)
 #elif defined(RARCH_CONSOLE)
-#define DEFAULT_REFRESH_RATE (60/1.001)
+#define DEFAULT_REFRESH_RATE (60 / 1.001f)
 #else
 #define DEFAULT_REFRESH_RATE (60)
 #endif
@@ -957,15 +951,15 @@ static const unsigned input_backtouch_toggle       = false;
 
 #ifdef _3DS
 /* Enable New3DS clock and L2 cache */
-static const bool new3ds_speedup_enable      = true;
+#define DEFAULT_NEW_3DS_SPEEDUP_ENABLE true
 /* Enable bottom LCD screen */
-static const bool video_3ds_lcd_bottom       = true;
+#define DEFAULT_VIDEO_3DS_LCD_BOTTOM true
 /* Sets video display mode (3D, 2D, etc.) */
-static const unsigned video_3ds_display_mode = CTR_VIDEO_MODE_3D;
+#define DEFAULT_VIDEO_3DS_DISPLAY_MODE CTR_VIDEO_MODE_3D
 
 #define DEFAULT_BOTTOM_FONT_ENABLE true
 #define DEFAULT_BOTTOM_FONT_COLOR 255
-#define DEFAULT_BOTTOM_FONT_SCALE 1.48
+#define DEFAULT_BOTTOM_FONT_SCALE 1.48f
 #endif
 
 #ifdef WIIU
@@ -980,11 +974,11 @@ static const unsigned video_3ds_display_mode = CTR_VIDEO_MODE_3D;
 #define DEFAULT_AUDIO_ENABLE true
 
 /* Enable menu audio sounds. */
-static const bool audio_enable_menu        = false;
-static const bool audio_enable_menu_ok     = false;
-static const bool audio_enable_menu_cancel = false;
-static const bool audio_enable_menu_notice = false;
-static const bool audio_enable_menu_bgm    = false;
+#define DEFAULT_AUDIO_ENABLE_MENU false
+#define DEFAULT_AUDIO_ENABLE_MENU_OK false
+#define DEFAULT_AUDIO_ENABLE_MENU_CANCEL false
+#define DEFAULT_AUDIO_ENABLE_MENU_NOTICE false
+#define DEFAULT_AUDIO_ENABLE_MENU_BGM    false
 
 #ifdef HAVE_GFX_WIDGETS
 #define DEFAULT_MENU_ENABLE_WIDGETS true
@@ -1093,17 +1087,17 @@ static const bool audio_enable_menu_bgm    = false;
 
 /* Rate control delta. Defines how much rate_control
  * is allowed to adjust input rate. */
-#define DEFAULT_RATE_CONTROL_DELTA  0.005
+#define DEFAULT_RATE_CONTROL_DELTA  0.005f
 
 /* Maximum timing skew. Defines how much adjust_system_rates
  * is allowed to adjust input rate. */
-#define DEFAULT_MAX_TIMING_SKEW  0.05
+#define DEFAULT_MAX_TIMING_SKEW  0.05f
 
 /* Default audio volume in dB. (0.0 dB == unity gain). */
-#define DEFAULT_AUDIO_VOLUME 0.0
+#define DEFAULT_AUDIO_VOLUME 0.0f
 
 /* Default audio volume of the audio mixer in dB. (0.0 dB == unity gain). */
-#define DEFAULT_AUDIO_MIXER_VOLUME 0.0
+#define DEFAULT_AUDIO_MIXER_VOLUME 0.0f
 
 #ifdef HAVE_WASAPI
 /* WASAPI defaults */
@@ -1197,44 +1191,44 @@ static const bool audio_enable_menu_bgm    = false;
 #define DEFAULT_NETPLAY_PUBLIC_ANNOUNCE true
 
 /* Start netplay in spectator mode */
-static const bool netplay_start_as_spectator = false;
+#define DEFAULT_NETPLAY_START_AS_SPECTATOR false
 
 /* Netplay chat fading toggle */
-static const bool netplay_fade_chat = true;
+#define DEFAULT_NETPLAY_FADE_CHAT true
 
 /* Netplay chat colors */
-static const unsigned netplay_chat_color_name = 0x008000;
-static const unsigned netplay_chat_color_msg  = 0xFFFFFF;
+#define DEFAULT_NETPLAY_CHAT_COLOR_NAME 0x008000
+#define DEFAULT_NETPLAY_CHAT_COLOR_MSG 0xFFFFFF
 
 /* Allow players to pause */
-static const bool netplay_allow_pausing = false;
+#define DEFAULT_NETPLAY_ALLOW_PAUSING false
 
 /* Allow connections in slave mode */
-static const bool netplay_allow_slaves = true;
+#define DEFAULT_NETPLAY_ALLOW_SLAVES true
 
 /* Require connections only in slave mode */
-static const bool netplay_require_slaves = false;
+#define DEFAULT_NETPLAY_REQUIRE_SLAVES false
 
 /* When being client over netplay, use keybinds for
  * user 1 rather than user 2. */
-static const bool netplay_client_swap_input = true;
+#define DEFAULT_NETPLAY_CLIENT_SWAP_INPUT true
 
-static const bool netplay_nat_traversal = false;
+#define DEFAULT_NETPLAY_NAT_TRAVERSAL false
 
-static const unsigned netplay_delay_frames = 16;
+#define DEFAULT_NETPLAY_DELAY_FRAMES 16
 
-static const int netplay_check_frames = 600;
+#define DEFAULT_NETPLAY_CHECK_FRAMES 600
 
-static const bool netplay_use_mitm_server = false;
+#define DEFAULT_NETPLAY_USE_MITM_SERVER false
 
 #define DEFAULT_NETPLAY_MITM_SERVER "nyc"
 
 #ifdef HAVE_NETWORKING
-static const unsigned netplay_max_connections = 3;
-static const unsigned netplay_max_ping        = 0;
+#define DEFAULT_NETPLAY_MAX_CONNECTIONS 3
+#define DEFAULT_NETPLAY_MAX_PING 0
 
-static const unsigned netplay_share_digital = RARCH_NETPLAY_SHARE_DIGITAL_NO_SHARING;
-static const unsigned netplay_share_analog  = RARCH_NETPLAY_SHARE_ANALOG_NO_SHARING;
+#define DEFAULT_NETPLAY_SHARE_DIGITAL RARCH_NETPLAY_SHARE_DIGITAL_NO_SHARING
+#define DEFAULT_NETPLAY_SHARE_ANALOG  RARCH_NETPLAY_SHARE_ANALOG_NO_SHARING
 #endif
 
 /* On save state load, block SRAM from being overwritten.
@@ -1278,11 +1272,11 @@ static const unsigned netplay_share_analog  = RARCH_NETPLAY_SHARE_ANALOG_NO_SHAR
 #endif
 
 /* Slowmotion ratio. */
-#define DEFAULT_SLOWMOTION_RATIO 3.0
+#define DEFAULT_SLOWMOTION_RATIO 3.0f
 
 /* Maximum fast forward ratio. */
-#define DEFAULT_FASTFORWARD_RATIO 0.0
-#define MAXIMUM_FASTFORWARD_RATIO 50.0
+#define DEFAULT_FASTFORWARD_RATIO 0.0f
+#define MAXIMUM_FASTFORWARD_RATIO 50.0f
 
 /* Skip frames when fast forwarding. */
 #define DEFAULT_FASTFORWARD_FRAMESKIP true
@@ -1463,11 +1457,11 @@ static const unsigned netplay_share_analog  = RARCH_NETPLAY_SHARE_ANALOG_NO_SHAR
 #define DEFAULT_INPUT_POLL_TYPE_BEHAVIOR 2
 #define DEFAULT_INPUT_HOTKEY_BLOCK_DELAY 5
 
-static const unsigned gfx_thumbnails_default = 3;
+#define DEFAULT_GFX_THUMBNAILS_DEFAULT 3
 
-static const unsigned menu_left_thumbnails_default = 0;
+#define DEFAULT_MENU_LEFT_THUMBNAILS_DEFAULT 0
 
-static const unsigned gfx_thumbnail_upscale_threshold = 0;
+#define DEFAULT_GFX_THUMBNAIL_UPSCALE_THRESHOLD 0
 
 #ifdef HAVE_MENU
 #if defined(RS90) || defined(MIYOO)
@@ -1517,11 +1511,11 @@ static const unsigned gfx_thumbnail_upscale_threshold = 0;
 #define DEFAULT_UI_MENUBAR_ENABLE true
 
 #if defined(__QNX__) || defined(_XBOX1) || defined(_XBOX360) || (defined(__MACH__) && defined(IOS)) || defined(ANDROID) || defined(WIIU) || defined(HAVE_NEON) || defined(GEKKO) || defined(__ARM_NEON__) || defined(__PS3__)
-static const enum resampler_quality audio_resampler_quality_level = RESAMPLER_QUALITY_LOWER;
+#define DEFAULT_AUDIO_RESAMPLER_QUALITY_LEVEL RESAMPLER_QUALITY_LOWER
 #elif defined(PSP) || defined(_3DS) || defined(VITA) || defined(PS2) || defined(DINGUX)
-static const enum resampler_quality audio_resampler_quality_level = RESAMPLER_QUALITY_LOWEST;
+#define DEFAULT_AUDIO_RESAMPLER_QUALITY_LEVEL RESAMPLER_QUALITY_LOWEST
 #else
-static const enum resampler_quality audio_resampler_quality_level = RESAMPLER_QUALITY_NORMAL;
+#define DEFAULT_AUDIO_RESAMPLER_QUALITY_LEVEL RESAMPLER_QUALITY_NORMAL
 #endif
 
 /* MIDI */

--- a/configuration.c
+++ b/configuration.c
@@ -1630,12 +1630,12 @@ static struct config_bool_setting *populate_settings_bool(
    SETTING_BOOL("netplay_show_only_installed_cores", &settings->bools.netplay_show_only_installed_cores, true, DEFAULT_NETPLAY_SHOW_ONLY_INSTALLED_CORES, false);
    SETTING_BOOL("netplay_show_passworded",       &settings->bools.netplay_show_passworded, true, DEFAULT_NETPLAY_SHOW_PASSWORDED, false);
    SETTING_BOOL("netplay_public_announce",       &settings->bools.netplay_public_announce, true, DEFAULT_NETPLAY_PUBLIC_ANNOUNCE, false);
-   SETTING_BOOL("netplay_start_as_spectator",    &settings->bools.netplay_start_as_spectator, false, netplay_start_as_spectator, false);
-   SETTING_BOOL("netplay_fade_chat",             &settings->bools.netplay_fade_chat, true, netplay_fade_chat, false);
-   SETTING_BOOL("netplay_allow_pausing",         &settings->bools.netplay_allow_pausing, true, netplay_allow_pausing, false);
-   SETTING_BOOL("netplay_allow_slaves",          &settings->bools.netplay_allow_slaves, true, netplay_allow_slaves, false);
-   SETTING_BOOL("netplay_require_slaves",        &settings->bools.netplay_require_slaves, true, netplay_require_slaves, false);
-   SETTING_BOOL("netplay_use_mitm_server",       &settings->bools.netplay_use_mitm_server, true, netplay_use_mitm_server, false);
+   SETTING_BOOL("netplay_start_as_spectator",    &settings->bools.netplay_start_as_spectator, false, DEFAULT_NETPLAY_START_AS_SPECTATOR, false);
+   SETTING_BOOL("netplay_fade_chat",             &settings->bools.netplay_fade_chat, true, DEFAULT_NETPLAY_FADE_CHAT, false);
+   SETTING_BOOL("netplay_allow_pausing",         &settings->bools.netplay_allow_pausing, true, DEFAULT_NETPLAY_ALLOW_PAUSING, false);
+   SETTING_BOOL("netplay_allow_slaves",          &settings->bools.netplay_allow_slaves, true, DEFAULT_NETPLAY_ALLOW_SLAVES, false);
+   SETTING_BOOL("netplay_require_slaves",        &settings->bools.netplay_require_slaves, true, DEFAULT_NETPLAY_REQUIRE_SLAVES, false);
+   SETTING_BOOL("netplay_use_mitm_server",       &settings->bools.netplay_use_mitm_server, true, DEFAULT_NETPLAY_USE_MITM_SERVER, false);
    SETTING_BOOL("netplay_request_device_p1",     &settings->bools.netplay_request_devices[0], true, false, false);
    SETTING_BOOL("netplay_request_device_p2",     &settings->bools.netplay_request_devices[1], true, false, false);
    SETTING_BOOL("netplay_request_device_p3",     &settings->bools.netplay_request_devices[2], true, false, false);
@@ -1746,11 +1746,11 @@ static struct config_bool_setting *populate_settings_bool(
    SETTING_BOOL("notification_show_when_menu_is_alive", &settings->bools.notification_show_when_menu_is_alive, true, DEFAULT_NOTIFICATION_SHOW_WHEN_MENU_IS_ALIVE, false);
 #endif
    SETTING_BOOL("menu_widget_scale_auto",        &settings->bools.menu_widget_scale_auto, true, DEFAULT_MENU_WIDGET_SCALE_AUTO, false);
-   SETTING_BOOL("audio_enable_menu",             &settings->bools.audio_enable_menu, true, audio_enable_menu, false);
-   SETTING_BOOL("audio_enable_menu_ok",          &settings->bools.audio_enable_menu_ok, true, audio_enable_menu_ok, false);
-   SETTING_BOOL("audio_enable_menu_cancel",      &settings->bools.audio_enable_menu_cancel, true, audio_enable_menu_cancel, false);
-   SETTING_BOOL("audio_enable_menu_notice",      &settings->bools.audio_enable_menu_notice, true, audio_enable_menu_notice, false);
-   SETTING_BOOL("audio_enable_menu_bgm",         &settings->bools.audio_enable_menu_bgm, true, audio_enable_menu_bgm, false);
+   SETTING_BOOL("audio_enable_menu",             &settings->bools.audio_enable_menu, true, DEFAULT_AUDIO_ENABLE_MENU, false);
+   SETTING_BOOL("audio_enable_menu_ok",          &settings->bools.audio_enable_menu_ok, true, DEFAULT_AUDIO_ENABLE_MENU_OK, false);
+   SETTING_BOOL("audio_enable_menu_cancel",      &settings->bools.audio_enable_menu_cancel, true, DEFAULT_AUDIO_ENABLE_MENU_CANCEL, false);
+   SETTING_BOOL("audio_enable_menu_notice",      &settings->bools.audio_enable_menu_notice, true, DEFAULT_AUDIO_ENABLE_MENU_NOTICE, false);
+   SETTING_BOOL("audio_enable_menu_bgm",         &settings->bools.audio_enable_menu_bgm, true, DEFAULT_AUDIO_ENABLE_MENU_BGM, false);
    SETTING_BOOL("audio_mute_enable",             audio_get_bool_ptr(AUDIO_ACTION_MUTE_ENABLE), true, false, false);
 #ifdef HAVE_AUDIOMIXER
    SETTING_BOOL("audio_mixer_mute_enable",       audio_get_bool_ptr(AUDIO_ACTION_MIXER_MUTE_ENABLE), true, false, false);
@@ -1764,8 +1764,8 @@ static struct config_bool_setting *populate_settings_bool(
    SETTING_BOOL("camera_allow",                  &settings->bools.camera_allow, true, false, false);
    SETTING_BOOL("discord_allow",                 &settings->bools.discord_enable, true, false, false);
 #if defined(VITA)
-   SETTING_BOOL("input_backtouch_enable",        &settings->bools.input_backtouch_enable, false, false, false);
-   SETTING_BOOL("input_backtouch_toggle",        &settings->bools.input_backtouch_toggle, false, false, false);
+   SETTING_BOOL("input_backtouch_enable",        &settings->bools.input_backtouch_enable, false, DEFAULT_INPUT_BACKTOUCH_ENABLE, false);
+   SETTING_BOOL("input_backtouch_toggle",        &settings->bools.input_backtouch_toggle, false, DEFAULT_INPUT_BACKTOUCH_TOGGLE, false);
 #endif
 #if TARGET_OS_IPHONE
    SETTING_BOOL("small_keyboard_enable",         &settings->bools.input_small_keyboard_enable, true, false, false);
@@ -1925,7 +1925,7 @@ static struct config_bool_setting *populate_settings_bool(
    SETTING_BOOL("rgui_border_filler_enable",               &settings->bools.menu_rgui_border_filler_enable, true, true, false);
    SETTING_BOOL("menu_rgui_transparency",                  &settings->bools.menu_rgui_transparency, true, DEFAULT_RGUI_TRANSPARENCY, false);
    SETTING_BOOL("menu_rgui_shadows",                       &settings->bools.menu_rgui_shadows, true, DEFAULT_RGUI_SHADOWS, false);
-   SETTING_BOOL("menu_rgui_full_width_layout",             &settings->bools.menu_rgui_full_width_layout, true, rgui_full_width_layout, false);
+   SETTING_BOOL("menu_rgui_full_width_layout",             &settings->bools.menu_rgui_full_width_layout, true, DEFAULT_RGUI_FULL_WIDTH_LAYOUT, false);
    SETTING_BOOL("rgui_inline_thumbnails",
          &settings->bools.menu_rgui_inline_thumbnails, true,
          DEFAULT_RGUI_INLINE_THUMBNAILS, false);
@@ -1985,17 +1985,17 @@ static struct config_bool_setting *populate_settings_bool(
    SETTING_BOOL("savestate_file_compression",   &settings->bools.savestate_file_compression, true, DEFAULT_SAVESTATE_FILE_COMPRESSION, false);
    SETTING_BOOL("history_list_enable",          &settings->bools.history_list_enable, true, DEFAULT_HISTORY_LIST_ENABLE, false);
    SETTING_BOOL("playlist_entry_rename",        &settings->bools.playlist_entry_rename, true, DEFAULT_PLAYLIST_ENTRY_RENAME, false);
-   SETTING_BOOL("game_specific_options",        &settings->bools.game_specific_options, true, default_game_specific_options, false);
-   SETTING_BOOL("auto_overrides_enable",        &settings->bools.auto_overrides_enable, true, default_auto_overrides_enable, false);
-   SETTING_BOOL("auto_remaps_enable",           &settings->bools.auto_remaps_enable, true, default_auto_remaps_enable, false);
-   SETTING_BOOL("global_core_options",          &settings->bools.global_core_options, true, default_global_core_options, false);
-   SETTING_BOOL("auto_shaders_enable",          &settings->bools.auto_shaders_enable, true, default_auto_shaders_enable, false);
+   SETTING_BOOL("game_specific_options",        &settings->bools.game_specific_options, true, DEFAULT_GAME_SPECIFIC_OPTIONS, false);
+   SETTING_BOOL("auto_overrides_enable",        &settings->bools.auto_overrides_enable, true, DEFAULT_AUTO_OVERRIDES_ENABLE, false);
+   SETTING_BOOL("auto_remaps_enable",           &settings->bools.auto_remaps_enable, true, DEFAULT_AUTO_REMAPS_ENABLE, false);
+   SETTING_BOOL("global_core_options",          &settings->bools.global_core_options, true, DEFAULT_GLOBAL_CORE_OPTIONS, false);
+   SETTING_BOOL("auto_shaders_enable",          &settings->bools.auto_shaders_enable, true, DEFAULT_AUTO_SHADERS_ENABLE, false);
    SETTING_BOOL("scan_without_core_match",   &settings->bools.scan_without_core_match, true, DEFAULT_SCAN_WITHOUT_CORE_MATCH, false);
-   SETTING_BOOL("sort_savefiles_enable",        &settings->bools.sort_savefiles_enable, true, default_sort_savefiles_enable, false);
-   SETTING_BOOL("sort_savestates_enable",       &settings->bools.sort_savestates_enable, true, default_sort_savestates_enable, false);
-   SETTING_BOOL("sort_savefiles_by_content_enable", &settings->bools.sort_savefiles_by_content_enable, true, default_sort_savefiles_by_content_enable, false);
-   SETTING_BOOL("sort_savestates_by_content_enable", &settings->bools.sort_savestates_by_content_enable, true, default_sort_savestates_by_content_enable, false);
-   SETTING_BOOL("sort_screenshots_by_content_enable", &settings->bools.sort_screenshots_by_content_enable, true, default_sort_screenshots_by_content_enable, false);
+   SETTING_BOOL("sort_savefiles_enable",        &settings->bools.sort_savefiles_enable, true, DEFAULT_SORT_SAVEFILES_ENABLE, false);
+   SETTING_BOOL("sort_savestates_enable",       &settings->bools.sort_savestates_enable, true, DEFAULT_SORT_SAVESTATES_ENABLE, false);
+   SETTING_BOOL("sort_savefiles_by_content_enable", &settings->bools.sort_savefiles_by_content_enable, true, DEFAULT_SORT_SAVEFILES_BY_CONTENT_ENABLE, false);
+   SETTING_BOOL("sort_savestates_by_content_enable", &settings->bools.sort_savestates_by_content_enable, true, DEFAULT_SORT_SAVESTATES_BY_CONTENT_ENABLE, false);
+   SETTING_BOOL("sort_screenshots_by_content_enable", &settings->bools.sort_screenshots_by_content_enable, true, DEFAULT_SORT_SCREENSHOTS_BY_CONTENT_ENABLE, false);
    SETTING_BOOL("config_save_on_exit",          &settings->bools.config_save_on_exit, true, DEFAULT_CONFIG_SAVE_ON_EXIT, false);
    SETTING_BOOL("remap_save_on_exit",           &settings->bools.remap_save_on_exit, true, DEFAULT_REMAP_SAVE_ON_EXIT, false);
    SETTING_BOOL("show_hidden_files",            &settings->bools.show_hidden_files, true, DEFAULT_SHOW_HIDDEN_FILES, false);
@@ -2012,10 +2012,10 @@ static struct config_bool_setting *populate_settings_bool(
    SETTING_BOOL("audio_wasapi_float_format",    &settings->bools.audio_wasapi_float_format, true, DEFAULT_WASAPI_FLOAT_FORMAT, false);
 #endif
 
-   SETTING_BOOL("savestates_in_content_dir",     &settings->bools.savestates_in_content_dir, true, default_savestates_in_content_dir, false);
-   SETTING_BOOL("savefiles_in_content_dir",      &settings->bools.savefiles_in_content_dir, true, default_savefiles_in_content_dir, false);
-   SETTING_BOOL("systemfiles_in_content_dir",    &settings->bools.systemfiles_in_content_dir, true, default_systemfiles_in_content_dir, false);
-   SETTING_BOOL("screenshots_in_content_dir",    &settings->bools.screenshots_in_content_dir, true, default_screenshots_in_content_dir, false);
+   SETTING_BOOL("savestates_in_content_dir",     &settings->bools.savestates_in_content_dir, true, DEFAULT_SAVESTATES_IN_CONTENT_DIR, false);
+   SETTING_BOOL("savefiles_in_content_dir",      &settings->bools.savefiles_in_content_dir, true,   DEFAULT_SAVEFILES_IN_CONTENT_DIR, false);
+   SETTING_BOOL("systemfiles_in_content_dir",    &settings->bools.systemfiles_in_content_dir, true, DEFAULT_SYSTEMFILES_IN_CONTENT_DIR, false);
+   SETTING_BOOL("screenshots_in_content_dir",    &settings->bools.screenshots_in_content_dir, true, DEFAULT_SCREENSHOTS_IN_CONTENT_DIR, false);
 
    SETTING_BOOL("video_msg_bgcolor_enable",
 &settings->bools.video_msg_bgcolor_enable, true, DEFAULT_MESSAGE_BGCOLOR_ENABLE, false);
@@ -2026,8 +2026,8 @@ static struct config_bool_setting *populate_settings_bool(
    SETTING_BOOL("sustained_performance_mode",    &settings->bools.sustained_performance_mode, true, DEFAULT_SUSTAINED_PERFORMANCE_MODE, false);
 
 #ifdef _3DS
-   SETTING_BOOL("new3ds_speedup_enable",         &settings->bools.new3ds_speedup_enable, true, new3ds_speedup_enable,      false);
-   SETTING_BOOL("video_3ds_lcd_bottom",          &settings->bools.video_3ds_lcd_bottom,  true, video_3ds_lcd_bottom,       false);
+   SETTING_BOOL("new3ds_speedup_enable",         &settings->bools.new3ds_speedup_enable, true, DEFAULT_NEW_3DS_SPEEDUP_ENABLE,      false);
+   SETTING_BOOL("video_3ds_lcd_bottom",          &settings->bools.video_3ds_lcd_bottom,  true, DEFAULT_VIDEO_3DS_LCD_BOTTOM, false);
    SETTING_BOOL("bottom_font_enable",            &settings->bools.bottom_font_enable,    true, DEFAULT_BOTTOM_FONT_ENABLE, false);
 #endif
 
@@ -2114,11 +2114,11 @@ static struct config_float_setting *populate_settings_float(
 #if !(defined(RARCH_CONSOLE) || defined(RARCH_MOBILE))
    SETTING_FLOAT("menu_widget_scale_factor_windowed", &settings->floats.menu_widget_scale_factor_windowed, true, DEFAULT_MENU_WIDGET_SCALE_FACTOR_WINDOWED, false);
 #endif
-   SETTING_FLOAT("menu_wallpaper_opacity",   &settings->floats.menu_wallpaper_opacity, true, menu_wallpaper_opacity, false);
-   SETTING_FLOAT("menu_framebuffer_opacity", &settings->floats.menu_framebuffer_opacity, true, menu_framebuffer_opacity, false);
-   SETTING_FLOAT("menu_footer_opacity",      &settings->floats.menu_footer_opacity,    true, menu_footer_opacity, false);
-   SETTING_FLOAT("menu_header_opacity",      &settings->floats.menu_header_opacity,    true, menu_header_opacity, false);
-   SETTING_FLOAT("menu_ticker_speed",        &settings->floats.menu_ticker_speed,      true, menu_ticker_speed,   false);
+   SETTING_FLOAT("menu_wallpaper_opacity",   &settings->floats.menu_wallpaper_opacity, true, DEFAULT_MENU_WALLPAPER_OPACITY, false);
+   SETTING_FLOAT("menu_framebuffer_opacity", &settings->floats.menu_framebuffer_opacity, true, DEFAULT_MENU_FRAMEBUFFER_OPACITY, false);
+   SETTING_FLOAT("menu_footer_opacity",      &settings->floats.menu_footer_opacity,    true, DEFAULT_MENU_FOOTER_OPACITY, false);
+   SETTING_FLOAT("menu_header_opacity",      &settings->floats.menu_header_opacity,    true, DEFAULT_MENU_HEADER_OPACITY, false);
+   SETTING_FLOAT("menu_ticker_speed",        &settings->floats.menu_ticker_speed,      true, DEFAULT_MENU_TICKER_SPEED,   false);
    SETTING_FLOAT("rgui_particle_effect_speed", &settings->floats.menu_rgui_particle_effect_speed, true, DEFAULT_RGUI_PARTICLE_EFFECT_SPEED, false);
 #if defined(HAVE_MATERIALUI) || defined(HAVE_XMB) || defined(HAVE_OZONE)
    SETTING_FLOAT("menu_screensaver_animation_speed", &settings->floats.menu_screensaver_animation_speed, true, DEFAULT_MENU_SCREENSAVER_ANIMATION_SPEED, false);
@@ -2182,7 +2182,7 @@ static struct config_uint_setting *populate_settings_uint(
    SETTING_UINT("input_rumble_gain",            &settings->uints.input_rumble_gain, true, DEFAULT_RUMBLE_GAIN, false);
    SETTING_UINT("input_auto_game_focus",        &settings->uints.input_auto_game_focus, true, DEFAULT_INPUT_AUTO_GAME_FOCUS, false);
    SETTING_UINT("audio_latency",                &settings->uints.audio_latency, false, 0 /* TODO */, false);
-   SETTING_UINT("audio_resampler_quality",      &settings->uints.audio_resampler_quality, true, audio_resampler_quality_level, false);
+   SETTING_UINT("audio_resampler_quality",      &settings->uints.audio_resampler_quality, true, DEFAULT_AUDIO_RESAMPLER_QUALITY_LEVEL, false);
    SETTING_UINT("audio_block_frames",           &settings->uints.audio_block_frames, true, 0, false);
 #ifdef ANDROID
    SETTING_UINT("input_block_timeout",           &settings->uints.input_block_timeout, true, 0, false);
@@ -2221,9 +2221,9 @@ static struct config_uint_setting *populate_settings_uint(
    SETTING_UINT("video_overscan_correction_bottom", &settings->uints.video_overscan_correction_bottom, true, DEFAULT_VIDEO_OVERSCAN_CORRECTION_BOTTOM, false);
 #endif
 #ifdef HAVE_MENU
-   SETTING_UINT("menu_thumbnails",              &settings->uints.gfx_thumbnails, true, gfx_thumbnails_default, false);
-   SETTING_UINT("menu_left_thumbnails",         &settings->uints.menu_left_thumbnails, true, menu_left_thumbnails_default, false);
-   SETTING_UINT("menu_thumbnail_upscale_threshold", &settings->uints.gfx_thumbnail_upscale_threshold, true, gfx_thumbnail_upscale_threshold, false);
+   SETTING_UINT("menu_thumbnails",              &settings->uints.gfx_thumbnails, true, DEFAULT_GFX_THUMBNAILS_DEFAULT, false);
+   SETTING_UINT("menu_left_thumbnails",         &settings->uints.menu_left_thumbnails, true, DEFAULT_MENU_LEFT_THUMBNAILS_DEFAULT, false);
+   SETTING_UINT("menu_thumbnail_upscale_threshold", &settings->uints.gfx_thumbnail_upscale_threshold, true, DEFAULT_GFX_THUMBNAIL_UPSCALE_THRESHOLD, false);
    SETTING_UINT("menu_timedate_style",          &settings->uints.menu_timedate_style, true, DEFAULT_MENU_TIMEDATE_STYLE, false);
    SETTING_UINT("menu_timedate_date_separator", &settings->uints.menu_timedate_date_separator, true, DEFAULT_MENU_TIMEDATE_DATE_SEPARATOR, false);
    SETTING_UINT("menu_ticker_type",             &settings->uints.menu_ticker_type, true, DEFAULT_MENU_TICKER_TYPE, false);
@@ -2239,11 +2239,11 @@ static struct config_uint_setting *populate_settings_uint(
 #endif
 #ifdef HAVE_RGUI
    SETTING_UINT("rgui_menu_color_theme",        &settings->uints.menu_rgui_color_theme, true, DEFAULT_RGUI_COLOR_THEME, false);
-   SETTING_UINT("rgui_thumbnail_downscaler",    &settings->uints.menu_rgui_thumbnail_downscaler, true, rgui_thumbnail_downscaler, false);
-   SETTING_UINT("rgui_thumbnail_delay",         &settings->uints.menu_rgui_thumbnail_delay, true, rgui_thumbnail_delay, false);
-   SETTING_UINT("rgui_internal_upscale_level",  &settings->uints.menu_rgui_internal_upscale_level, true, rgui_internal_upscale_level, false);
-   SETTING_UINT("rgui_aspect_ratio",            &settings->uints.menu_rgui_aspect_ratio, true, rgui_aspect, false);
-   SETTING_UINT("rgui_aspect_ratio_lock",       &settings->uints.menu_rgui_aspect_ratio_lock, true, rgui_aspect_lock, false);
+   SETTING_UINT("rgui_thumbnail_downscaler",    &settings->uints.menu_rgui_thumbnail_downscaler, true, DEFAULT_RGUI_THUMBNAIL_DOWNSCALER, false);
+   SETTING_UINT("rgui_thumbnail_delay",         &settings->uints.menu_rgui_thumbnail_delay, true, DEFAULT_RGUI_THUMBNAIL_DELAY, false);
+   SETTING_UINT("rgui_internal_upscale_level",  &settings->uints.menu_rgui_internal_upscale_level, true, DEFAULT_RGUI_INTERNAL_UPSCALE_LEVEL, false);
+   SETTING_UINT("rgui_aspect_ratio",            &settings->uints.menu_rgui_aspect_ratio, true, DEFAULT_RGUI_ASPECT, false);
+   SETTING_UINT("rgui_aspect_ratio_lock",       &settings->uints.menu_rgui_aspect_ratio_lock, true, DEFAULT_RGUI_ASPECT_LOCK, false);
    SETTING_UINT("rgui_particle_effect",         &settings->uints.menu_rgui_particle_effect, true, DEFAULT_RGUI_PARTICLE_EFFECT, false);
 #endif
 #ifdef HAVE_LIBNX
@@ -2260,13 +2260,13 @@ static struct config_uint_setting *populate_settings_uint(
    SETTING_UINT("menu_xmb_animation_opening_main_menu",    &settings->uints.menu_xmb_animation_opening_main_menu, true, DEFAULT_XMB_ANIMATION, false);
    SETTING_UINT("menu_xmb_animation_horizontal_highlight", &settings->uints.menu_xmb_animation_horizontal_highlight, true, DEFAULT_XMB_ANIMATION, false);
    SETTING_UINT("menu_xmb_animation_move_up_down",         &settings->uints.menu_xmb_animation_move_up_down, true, DEFAULT_XMB_ANIMATION, false);
-   SETTING_UINT("xmb_alpha_factor",             &settings->uints.menu_xmb_alpha_factor, true, xmb_alpha_factor, false);
-   SETTING_UINT("xmb_layout",                   &settings->uints.menu_xmb_layout, true, xmb_menu_layout, false);
-   SETTING_UINT("xmb_theme",                    &settings->uints.menu_xmb_theme, true, xmb_icon_theme, false);
-   SETTING_UINT("xmb_menu_color_theme",         &settings->uints.menu_xmb_color_theme, true, xmb_theme, false);
-   SETTING_UINT("menu_font_color_red",          &settings->uints.menu_font_color_red, true, menu_font_color_red, false);
-   SETTING_UINT("menu_font_color_green",        &settings->uints.menu_font_color_green, true, menu_font_color_green, false);
-   SETTING_UINT("menu_font_color_blue",         &settings->uints.menu_font_color_blue, true, menu_font_color_blue, false);
+   SETTING_UINT("xmb_alpha_factor",             &settings->uints.menu_xmb_alpha_factor, true, DEFAULT_XMB_ALPHA_FACTOR, false);
+   SETTING_UINT("xmb_layout",                   &settings->uints.menu_xmb_layout, true, DEFAULT_XMB_MENU_LAYOUT, false);
+   SETTING_UINT("xmb_theme",                    &settings->uints.menu_xmb_theme, true, DEFAULT_XMB_ICON_THEME, false);
+   SETTING_UINT("xmb_menu_color_theme",         &settings->uints.menu_xmb_color_theme, true, DEFAULT_XMB_THEME, false);
+   SETTING_UINT("menu_font_color_red",          &settings->uints.menu_font_color_red, true, DEFAULT_MENU_FONT_COLOR_RED, false);
+   SETTING_UINT("menu_font_color_green",        &settings->uints.menu_font_color_green, true, DEFAULT_MENU_FONT_COLOR_GREEN, false);
+   SETTING_UINT("menu_font_color_blue",         &settings->uints.menu_font_color_blue, true, DEFAULT_MENU_FONT_COLOR_BLUE, false);
    SETTING_UINT("menu_xmb_thumbnail_scale_factor", &settings->uints.menu_xmb_thumbnail_scale_factor, true, DEFAULT_XMB_THUMBNAIL_SCALE_FACTOR, false);
    SETTING_UINT("menu_xmb_vertical_fade_factor",&settings->uints.menu_xmb_vertical_fade_factor, true, DEFAULT_XMB_VERTICAL_FADE_FACTOR, false);
 #endif
@@ -2302,14 +2302,14 @@ static struct config_uint_setting *populate_settings_uint(
 #ifdef HAVE_NETWORKING
    SETTING_UINT("netplay_ip_port",              &settings->uints.netplay_port,         true, RARCH_DEFAULT_PORT, false);
    SETTING_OVERRIDE(RARCH_OVERRIDE_SETTING_NETPLAY_IP_PORT);
-   SETTING_UINT("netplay_max_connections",      &settings->uints.netplay_max_connections, true, netplay_max_connections, false);
-   SETTING_UINT("netplay_max_ping",             &settings->uints.netplay_max_ping, true, netplay_max_ping, false);
-   SETTING_UINT("netplay_chat_color_name",      &settings->uints.netplay_chat_color_name, true, netplay_chat_color_name, false);
-   SETTING_UINT("netplay_chat_color_msg",       &settings->uints.netplay_chat_color_msg, true, netplay_chat_color_msg, false);
+   SETTING_UINT("netplay_max_connections",      &settings->uints.netplay_max_connections, true, DEFAULT_NETPLAY_MAX_CONNECTIONS, false);
+   SETTING_UINT("netplay_max_ping",             &settings->uints.netplay_max_ping, true, DEFAULT_NETPLAY_MAX_PING, false);
+   SETTING_UINT("netplay_chat_color_name",      &settings->uints.netplay_chat_color_name, true, DEFAULT_NETPLAY_CHAT_COLOR_NAME, false);
+   SETTING_UINT("netplay_chat_color_msg",       &settings->uints.netplay_chat_color_msg, true, DEFAULT_NETPLAY_CHAT_COLOR_MSG, false);
    SETTING_UINT("netplay_input_latency_frames_min",&settings->uints.netplay_input_latency_frames_min, true, 0, false);
    SETTING_UINT("netplay_input_latency_frames_range",&settings->uints.netplay_input_latency_frames_range, true, 0, false);
-   SETTING_UINT("netplay_share_digital",        &settings->uints.netplay_share_digital, true, netplay_share_digital, false);
-   SETTING_UINT("netplay_share_analog",         &settings->uints.netplay_share_analog,  true, netplay_share_analog, false);
+   SETTING_UINT("netplay_share_digital",        &settings->uints.netplay_share_digital, true, DEFAULT_NETPLAY_SHARE_DIGITAL, false);
+   SETTING_UINT("netplay_share_analog",         &settings->uints.netplay_share_analog,  true, DEFAULT_NETPLAY_SHARE_ANALOG, false);
 #endif
 #ifdef HAVE_LANGEXTRA
 #ifdef VITA
@@ -2356,7 +2356,7 @@ static struct config_uint_setting *populate_settings_uint(
    SETTING_UINT("libnx_overclock",  &settings->uints.libnx_overclock, true, SWITCH_DEFAULT_CPU_PROFILE, false);
 #endif
 #ifdef _3DS
-   SETTING_UINT("video_3ds_display_mode",       &settings->uints.video_3ds_display_mode, true, video_3ds_display_mode, false);
+   SETTING_UINT("video_3ds_display_mode",       &settings->uints.video_3ds_display_mode, true, DEFAULT_VIDEO_3DS_DISPLAY_MODE, false);
 #endif
 #if defined(DINGUX)
    SETTING_UINT("video_dingux_ipu_filter_type", &settings->uints.video_dingux_ipu_filter_type, true, DEFAULT_DINGUX_IPU_FILTER_TYPE, false);
@@ -2424,7 +2424,7 @@ static struct config_int_setting *populate_settings_int(
 
    SETTING_INT("state_slot",                   &settings->ints.state_slot, false, 0 /* TODO */, false);
 #ifdef HAVE_NETWORKING
-   SETTING_INT("netplay_check_frames",         &settings->ints.netplay_check_frames, true, netplay_check_frames, false);
+   SETTING_INT("netplay_check_frames",         &settings->ints.netplay_check_frames, true, DEFAULT_NETPLAY_CHECK_FRAMES, false);
    SETTING_OVERRIDE(RARCH_OVERRIDE_SETTING_NETPLAY_CHECK_FRAMES);
 #endif
 #ifdef HAVE_WASAPI

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -8777,10 +8777,8 @@ static void timezone_change_handler(rarch_setting_t *setting)
 #ifdef _3DS
 static void new3ds_speedup_change_handler(rarch_setting_t *setting)
 {
-   if (!setting)
-      return;
-
-   osSetSpeedupEnable(*setting->value.target.boolean);
+   if (setting)
+      osSetSpeedupEnable(*setting->value.target.boolean);
 }
 #endif
 
@@ -10403,31 +10401,31 @@ static bool setting_append_list(
             bool_entries[2].target         = &settings->bools.game_specific_options;
             bool_entries[2].name_enum_idx  = MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS;
             bool_entries[2].SHORT_enum_idx = MENU_ENUM_LABEL_VALUE_GAME_SPECIFIC_OPTIONS;
-            bool_entries[2].default_value  = default_game_specific_options;
+            bool_entries[2].default_value  = DEFAULT_GAME_SPECIFIC_OPTIONS;
             bool_entries[2].flags          = SD_FLAG_ADVANCED;
 
             bool_entries[3].target         = &settings->bools.auto_overrides_enable;
             bool_entries[3].name_enum_idx  = MENU_ENUM_LABEL_AUTO_OVERRIDES_ENABLE;
             bool_entries[3].SHORT_enum_idx = MENU_ENUM_LABEL_VALUE_AUTO_OVERRIDES_ENABLE;
-            bool_entries[3].default_value  = default_auto_overrides_enable;
+            bool_entries[3].default_value  = DEFAULT_AUTO_OVERRIDES_ENABLE;
             bool_entries[3].flags          = SD_FLAG_ADVANCED;
 
             bool_entries[4].target         = &settings->bools.auto_remaps_enable;
             bool_entries[4].name_enum_idx  = MENU_ENUM_LABEL_AUTO_REMAPS_ENABLE;
             bool_entries[4].SHORT_enum_idx = MENU_ENUM_LABEL_VALUE_AUTO_REMAPS_ENABLE;
-            bool_entries[4].default_value  = default_auto_remaps_enable;
+            bool_entries[4].default_value  = DEFAULT_AUTO_REMAPS_ENABLE;
             bool_entries[4].flags          = SD_FLAG_ADVANCED;
 
             bool_entries[5].target         = &settings->bools.auto_shaders_enable;
             bool_entries[5].name_enum_idx  = MENU_ENUM_LABEL_AUTO_SHADERS_ENABLE;
             bool_entries[5].SHORT_enum_idx = MENU_ENUM_LABEL_VALUE_AUTO_SHADERS_ENABLE;
-            bool_entries[5].default_value  = default_auto_shaders_enable;
+            bool_entries[5].default_value  = DEFAULT_AUTO_SHADERS_ENABLE;
             bool_entries[5].flags          = SD_FLAG_NONE;
 
             bool_entries[6].target         = &settings->bools.global_core_options;
             bool_entries[6].name_enum_idx  = MENU_ENUM_LABEL_GLOBAL_CORE_OPTIONS;
             bool_entries[6].SHORT_enum_idx = MENU_ENUM_LABEL_VALUE_GLOBAL_CORE_OPTIONS;
-            bool_entries[6].default_value  = default_global_core_options;
+            bool_entries[6].default_value  = DEFAULT_GLOBAL_CORE_OPTIONS;
             bool_entries[6].flags          = SD_FLAG_NONE;
 
             bool_entries[7].target         = &settings->bools.remap_save_on_exit;
@@ -10624,31 +10622,31 @@ static bool setting_append_list(
             bool_entries[0].target         = &settings->bools.sort_savefiles_enable;
             bool_entries[0].name_enum_idx  = MENU_ENUM_LABEL_SORT_SAVEFILES_ENABLE;
             bool_entries[0].SHORT_enum_idx = MENU_ENUM_LABEL_VALUE_SORT_SAVEFILES_ENABLE;
-            bool_entries[0].default_value  = default_sort_savefiles_enable;
+            bool_entries[0].default_value  = DEFAULT_SORT_SAVEFILES_ENABLE;
             bool_entries[0].flags          = SD_FLAG_ADVANCED;
 
             bool_entries[1].target         = &settings->bools.sort_savestates_enable;
             bool_entries[1].name_enum_idx  = MENU_ENUM_LABEL_SORT_SAVESTATES_ENABLE;
             bool_entries[1].SHORT_enum_idx = MENU_ENUM_LABEL_VALUE_SORT_SAVESTATES_ENABLE;
-            bool_entries[1].default_value  = default_sort_savestates_enable;
+            bool_entries[1].default_value  = DEFAULT_SORT_SAVESTATES_ENABLE;
             bool_entries[1].flags          = SD_FLAG_ADVANCED;
 
             bool_entries[2].target         = &settings->bools.sort_savefiles_by_content_enable;
             bool_entries[2].name_enum_idx  = MENU_ENUM_LABEL_SORT_SAVEFILES_BY_CONTENT_ENABLE;
             bool_entries[2].SHORT_enum_idx = MENU_ENUM_LABEL_VALUE_SORT_SAVEFILES_BY_CONTENT_ENABLE;
-            bool_entries[2].default_value  = default_sort_savefiles_by_content_enable;
+            bool_entries[2].default_value  = DEFAULT_SORT_SAVEFILES_BY_CONTENT_ENABLE;
             bool_entries[2].flags          = SD_FLAG_ADVANCED;
 
             bool_entries[3].target         = &settings->bools.sort_savestates_by_content_enable;
             bool_entries[3].name_enum_idx  = MENU_ENUM_LABEL_SORT_SAVESTATES_BY_CONTENT_ENABLE;
             bool_entries[3].SHORT_enum_idx = MENU_ENUM_LABEL_VALUE_SORT_SAVESTATES_BY_CONTENT_ENABLE;
-            bool_entries[3].default_value  = default_sort_savestates_by_content_enable;
+            bool_entries[3].default_value  = DEFAULT_SORT_SAVESTATES_BY_CONTENT_ENABLE;
             bool_entries[3].flags          = SD_FLAG_ADVANCED;
 
             bool_entries[4].target         = &settings->bools.sort_screenshots_by_content_enable;
             bool_entries[4].name_enum_idx  = MENU_ENUM_LABEL_SORT_SCREENSHOTS_BY_CONTENT_ENABLE;
             bool_entries[4].SHORT_enum_idx = MENU_ENUM_LABEL_VALUE_SORT_SCREENSHOTS_BY_CONTENT_ENABLE;
-            bool_entries[4].default_value  = default_sort_screenshots_by_content_enable;
+            bool_entries[4].default_value  = DEFAULT_SORT_SCREENSHOTS_BY_CONTENT_ENABLE;
             bool_entries[4].flags          = SD_FLAG_ADVANCED;
 
             bool_entries[5].target         = &settings->bools.block_sram_overwrite;
@@ -10678,25 +10676,25 @@ static bool setting_append_list(
             bool_entries[9].target         = &settings->bools.savefiles_in_content_dir;
             bool_entries[9].name_enum_idx  = MENU_ENUM_LABEL_SAVEFILES_IN_CONTENT_DIR_ENABLE;
             bool_entries[9].SHORT_enum_idx = MENU_ENUM_LABEL_VALUE_SAVEFILES_IN_CONTENT_DIR_ENABLE;
-            bool_entries[9].default_value  = default_savefiles_in_content_dir;
+            bool_entries[9].default_value  = DEFAULT_SAVEFILES_IN_CONTENT_DIR;
             bool_entries[9].flags          = SD_FLAG_ADVANCED;
 
             bool_entries[10].target         = &settings->bools.savestates_in_content_dir;
             bool_entries[10].name_enum_idx  = MENU_ENUM_LABEL_SAVESTATES_IN_CONTENT_DIR_ENABLE;
             bool_entries[10].SHORT_enum_idx = MENU_ENUM_LABEL_VALUE_SAVESTATES_IN_CONTENT_DIR_ENABLE;
-            bool_entries[10].default_value  = default_savestates_in_content_dir;
+            bool_entries[10].default_value  = DEFAULT_SAVESTATES_IN_CONTENT_DIR;
             bool_entries[10].flags          = SD_FLAG_ADVANCED;
 
             bool_entries[11].target         = &settings->bools.systemfiles_in_content_dir;
             bool_entries[11].name_enum_idx  = MENU_ENUM_LABEL_SYSTEMFILES_IN_CONTENT_DIR_ENABLE;
             bool_entries[11].SHORT_enum_idx = MENU_ENUM_LABEL_VALUE_SYSTEMFILES_IN_CONTENT_DIR_ENABLE;
-            bool_entries[11].default_value  = default_systemfiles_in_content_dir;
+            bool_entries[11].default_value  = DEFAULT_SYSTEMFILES_IN_CONTENT_DIR;
             bool_entries[11].flags          = SD_FLAG_ADVANCED;
 
             bool_entries[12].target         = &settings->bools.screenshots_in_content_dir;
             bool_entries[12].name_enum_idx  = MENU_ENUM_LABEL_SCREENSHOTS_IN_CONTENT_DIR_ENABLE;
             bool_entries[12].SHORT_enum_idx = MENU_ENUM_LABEL_VALUE_SCREENSHOTS_IN_CONTENT_DIR_ENABLE;
-            bool_entries[12].default_value  = default_screenshots_in_content_dir;
+            bool_entries[12].default_value  = DEFAULT_SCREENSHOTS_IN_CONTENT_DIR;
             bool_entries[12].flags          = SD_FLAG_ADVANCED;
 
             for (i = 0; i < ARRAY_SIZE(bool_entries); i++)
@@ -13009,7 +13007,7 @@ static bool setting_append_list(
                &settings->bools.audio_enable_menu,
                MENU_ENUM_LABEL_AUDIO_ENABLE_MENU,
                MENU_ENUM_LABEL_VALUE_AUDIO_ENABLE_MENU,
-               audio_enable_menu,
+               DEFAULT_AUDIO_ENABLE_MENU,
                MENU_ENUM_LABEL_VALUE_OFF,
                MENU_ENUM_LABEL_VALUE_ON,
                &group_info,
@@ -13025,7 +13023,7 @@ static bool setting_append_list(
                &settings->bools.audio_enable_menu_ok,
                MENU_ENUM_LABEL_MENU_SOUND_OK,
                MENU_ENUM_LABEL_VALUE_MENU_SOUND_OK,
-               audio_enable_menu_ok,
+               DEFAULT_AUDIO_ENABLE_MENU_OK,
                MENU_ENUM_LABEL_VALUE_OFF,
                MENU_ENUM_LABEL_VALUE_ON,
                &group_info,
@@ -13041,7 +13039,7 @@ static bool setting_append_list(
                &settings->bools.audio_enable_menu_cancel,
                MENU_ENUM_LABEL_MENU_SOUND_CANCEL,
                MENU_ENUM_LABEL_VALUE_MENU_SOUND_CANCEL,
-               audio_enable_menu_cancel,
+               DEFAULT_AUDIO_ENABLE_MENU_CANCEL,
                MENU_ENUM_LABEL_VALUE_OFF,
                MENU_ENUM_LABEL_VALUE_ON,
                &group_info,
@@ -13057,7 +13055,7 @@ static bool setting_append_list(
                &settings->bools.audio_enable_menu_notice,
                MENU_ENUM_LABEL_MENU_SOUND_NOTICE,
                MENU_ENUM_LABEL_VALUE_MENU_SOUND_NOTICE,
-               audio_enable_menu_notice,
+               DEFAULT_AUDIO_ENABLE_MENU_NOTICE,
                MENU_ENUM_LABEL_VALUE_OFF,
                MENU_ENUM_LABEL_VALUE_ON,
                &group_info,
@@ -13073,7 +13071,7 @@ static bool setting_append_list(
                &settings->bools.audio_enable_menu_bgm,
                MENU_ENUM_LABEL_MENU_SOUND_BGM,
                MENU_ENUM_LABEL_VALUE_MENU_SOUND_BGM,
-               audio_enable_menu_bgm,
+               DEFAULT_AUDIO_ENABLE_MENU_BGM,
                MENU_ENUM_LABEL_VALUE_OFF,
                MENU_ENUM_LABEL_VALUE_ON,
                &group_info,
@@ -13244,7 +13242,7 @@ static bool setting_append_list(
                &settings->uints.audio_resampler_quality,
                MENU_ENUM_LABEL_AUDIO_RESAMPLER_QUALITY,
                MENU_ENUM_LABEL_VALUE_AUDIO_RESAMPLER_QUALITY,
-               audio_resampler_quality_level,
+               DEFAULT_AUDIO_RESAMPLER_QUALITY_LEVEL,
                &group_info,
                &subgroup_info,
                parent_group,
@@ -13635,7 +13633,7 @@ static bool setting_append_list(
                   &settings->bools.input_backtouch_enable,
                   MENU_ENUM_LABEL_INPUT_TOUCH_ENABLE,
                   MENU_ENUM_LABEL_VALUE_INPUT_TOUCH_ENABLE,
-                  input_backtouch_enable,
+                  DEFAULT_INPUT_BACKTOUCH_ENABLE,
                   MENU_ENUM_LABEL_VALUE_OFF,
                   MENU_ENUM_LABEL_VALUE_ON,
                   &group_info,
@@ -13651,7 +13649,7 @@ static bool setting_append_list(
                   &settings->bools.input_backtouch_toggle,
                   MENU_ENUM_LABEL_INPUT_PREFER_FRONT_TOUCH,
                   MENU_ENUM_LABEL_VALUE_INPUT_PREFER_FRONT_TOUCH,
-                  input_backtouch_toggle,
+                  DEFAULT_INPUT_BACKTOUCH_TOGGLE,
                   MENU_ENUM_LABEL_VALUE_OFF,
                   MENU_ENUM_LABEL_VALUE_ON,
                   &group_info,
@@ -15845,7 +15843,7 @@ static bool setting_append_list(
                   &settings->floats.menu_wallpaper_opacity,
                   MENU_ENUM_LABEL_MENU_WALLPAPER_OPACITY,
                   MENU_ENUM_LABEL_VALUE_MENU_WALLPAPER_OPACITY,
-                  menu_wallpaper_opacity,
+                  DEFAULT_MENU_WALLPAPER_OPACITY,
                   "%.3f",
                   &group_info,
                   &subgroup_info,
@@ -15864,7 +15862,7 @@ static bool setting_append_list(
                   &settings->floats.menu_framebuffer_opacity,
                   MENU_ENUM_LABEL_MENU_FRAMEBUFFER_OPACITY,
                   MENU_ENUM_LABEL_VALUE_MENU_FRAMEBUFFER_OPACITY,
-                  menu_framebuffer_opacity,
+                  DEFAULT_MENU_FRAMEBUFFER_OPACITY,
                   "%.3f",
                   &group_info,
                   &subgroup_info,
@@ -16129,7 +16127,7 @@ static bool setting_append_list(
                   &settings->bools.menu_rgui_full_width_layout,
                   MENU_ENUM_LABEL_MENU_RGUI_FULL_WIDTH_LAYOUT,
                   MENU_ENUM_LABEL_VALUE_MENU_RGUI_FULL_WIDTH_LAYOUT,
-                  rgui_full_width_layout,
+                  DEFAULT_RGUI_FULL_WIDTH_LAYOUT,
                   MENU_ENUM_LABEL_VALUE_OFF,
                   MENU_ENUM_LABEL_VALUE_ON,
                   &group_info,
@@ -16162,7 +16160,7 @@ static bool setting_append_list(
                      &settings->uints.menu_rgui_internal_upscale_level,
                      MENU_ENUM_LABEL_MENU_RGUI_INTERNAL_UPSCALE_LEVEL,
                      MENU_ENUM_LABEL_VALUE_MENU_RGUI_INTERNAL_UPSCALE_LEVEL,
-                     rgui_internal_upscale_level,
+                     DEFAULT_RGUI_INTERNAL_UPSCALE_LEVEL,
                      &group_info,
                      &subgroup_info,
                      parent_group,
@@ -16182,7 +16180,7 @@ static bool setting_append_list(
                   &settings->uints.menu_rgui_aspect_ratio,
                   MENU_ENUM_LABEL_MENU_RGUI_ASPECT_RATIO,
                   MENU_ENUM_LABEL_VALUE_MENU_RGUI_ASPECT_RATIO,
-                  rgui_aspect,
+                  DEFAULT_RGUI_ASPECT,
                   &group_info,
                   &subgroup_info,
                   parent_group,
@@ -16198,7 +16196,7 @@ static bool setting_append_list(
                   &settings->uints.menu_rgui_aspect_ratio_lock,
                   MENU_ENUM_LABEL_MENU_RGUI_ASPECT_RATIO_LOCK,
                   MENU_ENUM_LABEL_VALUE_MENU_RGUI_ASPECT_RATIO_LOCK,
-                  rgui_aspect_lock,
+                  DEFAULT_RGUI_ASPECT_LOCK,
                   &group_info,
                   &subgroup_info,
                   parent_group,
@@ -16469,7 +16467,7 @@ static bool setting_append_list(
                &settings->floats.menu_ticker_speed,
                MENU_ENUM_LABEL_MENU_TICKER_SPEED,
                MENU_ENUM_LABEL_VALUE_MENU_TICKER_SPEED,
-               menu_ticker_speed,
+               DEFAULT_MENU_TICKER_SPEED,
                "%.1fx",
                &group_info,
                &subgroup_info,
@@ -16622,7 +16620,7 @@ static bool setting_append_list(
                   &settings->uints.menu_xmb_alpha_factor,
                   MENU_ENUM_LABEL_XMB_ALPHA_FACTOR,
                   MENU_ENUM_LABEL_VALUE_XMB_ALPHA_FACTOR,
-                  xmb_alpha_factor,
+                  DEFAULT_XMB_ALPHA_FACTOR,
                   &group_info,
                   &subgroup_info,
                   parent_group,
@@ -16716,7 +16714,7 @@ static bool setting_append_list(
                   &settings->uints.menu_font_color_red,
                   MENU_ENUM_LABEL_MENU_FONT_COLOR_RED,
                   MENU_ENUM_LABEL_VALUE_MENU_FONT_COLOR_RED,
-                  menu_font_color_red,
+                  DEFAULT_MENU_FONT_COLOR_RED,
                   &group_info,
                   &subgroup_info,
                   parent_group,
@@ -16731,7 +16729,7 @@ static bool setting_append_list(
                   &settings->uints.menu_font_color_green,
                   MENU_ENUM_LABEL_MENU_FONT_COLOR_GREEN,
                   MENU_ENUM_LABEL_VALUE_MENU_FONT_COLOR_GREEN,
-                  menu_font_color_green,
+                  DEFAULT_MENU_FONT_COLOR_GREEN,
                   &group_info,
                   &subgroup_info,
                   parent_group,
@@ -16746,7 +16744,7 @@ static bool setting_append_list(
                   &settings->uints.menu_font_color_blue,
                   MENU_ENUM_LABEL_MENU_FONT_COLOR_BLUE,
                   MENU_ENUM_LABEL_VALUE_MENU_FONT_COLOR_BLUE,
-                  menu_font_color_blue,
+                  DEFAULT_MENU_FONT_COLOR_BLUE,
                   &group_info,
                   &subgroup_info,
                   parent_group,
@@ -16761,7 +16759,7 @@ static bool setting_append_list(
                   &settings->uints.menu_xmb_layout,
                   MENU_ENUM_LABEL_XMB_LAYOUT,
                   MENU_ENUM_LABEL_VALUE_XMB_LAYOUT,
-                  xmb_menu_layout,
+                  DEFAULT_XMB_MENU_LAYOUT,
                   &group_info,
                   &subgroup_info,
                   parent_group,
@@ -16778,7 +16776,7 @@ static bool setting_append_list(
                   &settings->uints.menu_xmb_theme,
                   MENU_ENUM_LABEL_XMB_THEME,
                   MENU_ENUM_LABEL_VALUE_XMB_THEME,
-                  xmb_icon_theme,
+                  DEFAULT_XMB_ICON_THEME,
                   &group_info,
                   &subgroup_info,
                   parent_group,
@@ -16834,7 +16832,7 @@ static bool setting_append_list(
                   &settings->uints.menu_xmb_color_theme,
                   MENU_ENUM_LABEL_XMB_MENU_COLOR_THEME,
                   MENU_ENUM_LABEL_VALUE_XMB_MENU_COLOR_THEME,
-                  xmb_theme,
+                  DEFAULT_XMB_THEME,
                   &group_info,
                   &subgroup_info,
                   parent_group,
@@ -17553,7 +17551,7 @@ static bool setting_append_list(
                   &settings->floats.menu_header_opacity,
                   MENU_ENUM_LABEL_MATERIALUI_MENU_HEADER_OPACITY,
                   MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_HEADER_OPACITY,
-                  menu_header_opacity,
+                  DEFAULT_MENU_HEADER_OPACITY,
                   "%.3f",
                   &group_info,
                   &subgroup_info,
@@ -17568,7 +17566,7 @@ static bool setting_append_list(
                   &settings->floats.menu_footer_opacity,
                   MENU_ENUM_LABEL_MATERIALUI_MENU_FOOTER_OPACITY,
                   MENU_ENUM_LABEL_VALUE_MATERIALUI_MENU_FOOTER_OPACITY,
-                  menu_footer_opacity,
+                  DEFAULT_MENU_FOOTER_OPACITY,
                   "%.3f",
                   &group_info,
                   &subgroup_info,
@@ -17732,7 +17730,7 @@ static bool setting_append_list(
                   &settings->uints.gfx_thumbnails,
                   MENU_ENUM_LABEL_THUMBNAILS,
                   thumbnails_label_value,
-                  gfx_thumbnails_default,
+                  DEFAULT_GFX_THUMBNAILS_DEFAULT,
                   &group_info,
                   &subgroup_info,
                   parent_group,
@@ -17749,7 +17747,7 @@ static bool setting_append_list(
                   &settings->uints.menu_left_thumbnails,
                   MENU_ENUM_LABEL_LEFT_THUMBNAILS,
                   left_thumbnails_label_value,
-                  menu_left_thumbnails_default,
+                  DEFAULT_MENU_LEFT_THUMBNAILS_DEFAULT,
                   &group_info,
                   &subgroup_info,
                   parent_group,
@@ -17804,7 +17802,7 @@ static bool setting_append_list(
                   &settings->uints.gfx_thumbnail_upscale_threshold,
                   MENU_ENUM_LABEL_MENU_THUMBNAIL_UPSCALE_THRESHOLD,
                   MENU_ENUM_LABEL_VALUE_MENU_THUMBNAIL_UPSCALE_THRESHOLD,
-                  gfx_thumbnail_upscale_threshold,
+                  DEFAULT_GFX_THUMBNAIL_UPSCALE_THRESHOLD,
                   &group_info,
                   &subgroup_info,
                   parent_group,
@@ -17821,7 +17819,7 @@ static bool setting_append_list(
                   &settings->uints.menu_rgui_thumbnail_downscaler,
                   MENU_ENUM_LABEL_MENU_RGUI_THUMBNAIL_DOWNSCALER,
                   MENU_ENUM_LABEL_VALUE_MENU_RGUI_THUMBNAIL_DOWNSCALER,
-                  rgui_thumbnail_downscaler,
+                  DEFAULT_RGUI_THUMBNAIL_DOWNSCALER,
                   &group_info,
                   &subgroup_info,
                   parent_group,
@@ -17838,7 +17836,7 @@ static bool setting_append_list(
                   &settings->uints.menu_rgui_thumbnail_delay,
                   MENU_ENUM_LABEL_MENU_RGUI_THUMBNAIL_DELAY,
                   MENU_ENUM_LABEL_VALUE_MENU_RGUI_THUMBNAIL_DELAY,
-                  rgui_thumbnail_delay,
+                  DEFAULT_RGUI_THUMBNAIL_DELAY,
                   &group_info,
                   &subgroup_info,
                   parent_group,
@@ -18357,7 +18355,7 @@ static bool setting_append_list(
                   &settings->uints.video_3ds_display_mode,
                   MENU_ENUM_LABEL_VIDEO_3DS_DISPLAY_MODE,
                   MENU_ENUM_LABEL_VALUE_VIDEO_3DS_DISPLAY_MODE,
-                  video_3ds_display_mode,
+                  DEFAULT_VIDEO_3DS_DISPLAY_MODE,
                   &group_info,
                   &subgroup_info,
                   parent_group,
@@ -18376,7 +18374,7 @@ static bool setting_append_list(
                &settings->bools.new3ds_speedup_enable,
                MENU_ENUM_LABEL_NEW3DS_SPEEDUP_ENABLE,
                MENU_ENUM_LABEL_VALUE_NEW3DS_SPEEDUP_ENABLE,
-               new3ds_speedup_enable,
+               DEFAULT_NEW_3DS_SPEEDUP_ENABLE,
                MENU_ENUM_LABEL_VALUE_OFF,
                MENU_ENUM_LABEL_VALUE_ON,
                &group_info,
@@ -18392,7 +18390,7 @@ static bool setting_append_list(
                &settings->bools.video_3ds_lcd_bottom,
                MENU_ENUM_LABEL_VIDEO_3DS_LCD_BOTTOM,
                MENU_ENUM_LABEL_VALUE_VIDEO_3DS_LCD_BOTTOM,
-               video_3ds_lcd_bottom,
+               DEFAULT_VIDEO_3DS_LCD_BOTTOM,
                MENU_ENUM_LABEL_VALUE_OFF,
                MENU_ENUM_LABEL_VALUE_ON,
                &group_info,
@@ -20062,7 +20060,7 @@ static bool setting_append_list(
                   &settings->bools.netplay_public_announce,
                   MENU_ENUM_LABEL_NETPLAY_PUBLIC_ANNOUNCE,
                   MENU_ENUM_LABEL_VALUE_NETPLAY_PUBLIC_ANNOUNCE,
-                  true,
+                  DEFAULT_NETPLAY_PUBLIC_ANNOUNCE,
                   MENU_ENUM_LABEL_VALUE_OFF,
                   MENU_ENUM_LABEL_VALUE_ON,
                   &group_info,
@@ -20077,7 +20075,7 @@ static bool setting_append_list(
                   &settings->bools.netplay_use_mitm_server,
                   MENU_ENUM_LABEL_NETPLAY_USE_MITM_SERVER,
                   MENU_ENUM_LABEL_VALUE_NETPLAY_USE_MITM_SERVER,
-                  netplay_use_mitm_server,
+                  DEFAULT_NETPLAY_USE_MITM_SERVER,
                   MENU_ENUM_LABEL_VALUE_OFF,
                   MENU_ENUM_LABEL_VALUE_ON,
                   &group_info,
@@ -20163,7 +20161,7 @@ static bool setting_append_list(
                   &settings->uints.netplay_max_connections,
                   MENU_ENUM_LABEL_NETPLAY_MAX_CONNECTIONS,
                   MENU_ENUM_LABEL_VALUE_NETPLAY_MAX_CONNECTIONS,
-                  netplay_max_connections,
+                  DEFAULT_NETPLAY_MAX_CONNECTIONS,
                   &group_info,
                   &subgroup_info,
                   parent_group,
@@ -20179,7 +20177,7 @@ static bool setting_append_list(
                   &settings->uints.netplay_max_ping,
                   MENU_ENUM_LABEL_NETPLAY_MAX_PING,
                   MENU_ENUM_LABEL_VALUE_NETPLAY_MAX_PING,
-                  netplay_max_ping,
+                  DEFAULT_NETPLAY_MAX_PING,
                   &group_info,
                   &subgroup_info,
                   parent_group,
@@ -20225,7 +20223,7 @@ static bool setting_append_list(
                   &settings->bools.netplay_start_as_spectator,
                   MENU_ENUM_LABEL_NETPLAY_START_AS_SPECTATOR,
                   MENU_ENUM_LABEL_VALUE_NETPLAY_START_AS_SPECTATOR,
-                  false,
+                  DEFAULT_NETPLAY_START_AS_SPECTATOR,
                   MENU_ENUM_LABEL_VALUE_OFF,
                   MENU_ENUM_LABEL_VALUE_ON,
                   &group_info,
@@ -20240,7 +20238,7 @@ static bool setting_append_list(
                   &settings->bools.netplay_fade_chat,
                   MENU_ENUM_LABEL_NETPLAY_FADE_CHAT,
                   MENU_ENUM_LABEL_VALUE_NETPLAY_FADE_CHAT,
-                  netplay_fade_chat,
+                  DEFAULT_NETPLAY_FADE_CHAT,
                   MENU_ENUM_LABEL_VALUE_OFF,
                   MENU_ENUM_LABEL_VALUE_ON,
                   &group_info,
@@ -20255,7 +20253,7 @@ static bool setting_append_list(
                   &settings->uints.netplay_chat_color_name,
                   MENU_ENUM_LABEL_NETPLAY_CHAT_COLOR_NAME,
                   MENU_ENUM_LABEL_VALUE_NETPLAY_CHAT_COLOR_NAME,
-                  netplay_chat_color_name,
+                  DEFAULT_NETPLAY_CHAT_COLOR_NAME,
                   &group_info,
                   &subgroup_info,
                   parent_group,
@@ -20273,7 +20271,7 @@ static bool setting_append_list(
                   &settings->uints.netplay_chat_color_msg,
                   MENU_ENUM_LABEL_NETPLAY_CHAT_COLOR_MSG,
                   MENU_ENUM_LABEL_VALUE_NETPLAY_CHAT_COLOR_MSG,
-                  netplay_chat_color_msg,
+                  DEFAULT_NETPLAY_CHAT_COLOR_MSG,
                   &group_info,
                   &subgroup_info,
                   parent_group,
@@ -20291,7 +20289,7 @@ static bool setting_append_list(
                   &settings->bools.netplay_allow_pausing,
                   MENU_ENUM_LABEL_NETPLAY_ALLOW_PAUSING,
                   MENU_ENUM_LABEL_VALUE_NETPLAY_ALLOW_PAUSING,
-                  netplay_allow_pausing,
+                  DEFAULT_NETPLAY_ALLOW_PAUSING,
                   MENU_ENUM_LABEL_VALUE_OFF,
                   MENU_ENUM_LABEL_VALUE_ON,
                   &group_info,
@@ -20306,7 +20304,7 @@ static bool setting_append_list(
                   &settings->bools.netplay_allow_slaves,
                   MENU_ENUM_LABEL_NETPLAY_ALLOW_SLAVES,
                   MENU_ENUM_LABEL_VALUE_NETPLAY_ALLOW_SLAVES,
-                  true,
+                  DEFAULT_NETPLAY_ALLOW_SLAVES,
                   MENU_ENUM_LABEL_VALUE_OFF,
                   MENU_ENUM_LABEL_VALUE_ON,
                   &group_info,
@@ -20325,7 +20323,7 @@ static bool setting_append_list(
                   &settings->bools.netplay_require_slaves,
                   MENU_ENUM_LABEL_NETPLAY_REQUIRE_SLAVES,
                   MENU_ENUM_LABEL_VALUE_NETPLAY_REQUIRE_SLAVES,
-                  false,
+                  DEFAULT_NETPLAY_REQUIRE_SLAVES,
                   MENU_ENUM_LABEL_VALUE_OFF,
                   MENU_ENUM_LABEL_VALUE_ON,
                   &group_info,
@@ -20341,7 +20339,7 @@ static bool setting_append_list(
                   &settings->ints.netplay_check_frames,
                   MENU_ENUM_LABEL_NETPLAY_CHECK_FRAMES,
                   MENU_ENUM_LABEL_VALUE_NETPLAY_CHECK_FRAMES,
-                  netplay_check_frames,
+                  DEFAULT_NETPLAY_CHECK_FRAMES,
                   &group_info,
                   &subgroup_info,
                   parent_group,
@@ -20402,7 +20400,7 @@ static bool setting_append_list(
                   &settings->uints.netplay_share_digital,
                   MENU_ENUM_LABEL_NETPLAY_SHARE_DIGITAL,
                   MENU_ENUM_LABEL_VALUE_NETPLAY_SHARE_DIGITAL,
-                  netplay_share_digital,
+                  DEFAULT_NETPLAY_SHARE_DIGITAL,
                   &group_info,
                   &subgroup_info,
                   parent_group,
@@ -20419,7 +20417,7 @@ static bool setting_append_list(
                   &settings->uints.netplay_share_analog,
                   MENU_ENUM_LABEL_NETPLAY_SHARE_ANALOG,
                   MENU_ENUM_LABEL_VALUE_NETPLAY_SHARE_ANALOG,
-                  netplay_share_analog,
+                  DEFAULT_NETPLAY_SHARE_ANALOG,
                   &group_info,
                   &subgroup_info,
                   parent_group,


### PR DESCRIPTION
Finally we have achieved our goal of having only macro defines inside config.def.h.

Let's keep it like this, to reduce warnings of unused variables (in files where this header gets included).