### PR TITLE
Prevent MIDI startup error with old configurations

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -3593,6 +3593,16 @@ static bool config_load_file(global_t *global,
    audio_set_float(AUDIO_ACTION_MIXER_VOLUME_GAIN, settings->floats.audio_mixer_volume);
 #endif
 
+   /* MIDI fallback for old OFF-string */
+   if (string_is_equal(settings->arrays.midi_input, "Off"))
+      configuration_set_string(settings,
+            settings->arrays.midi_input,
+            DEFAULT_MIDI_INPUT);
+   if (string_is_equal(settings->arrays.midi_output, "Off"))
+      configuration_set_string(settings,
+            settings->arrays.midi_output,
+            DEFAULT_MIDI_OUTPUT);
+
    path_config = path_get(RARCH_PATH_CONFIG);
 
    if (string_is_empty(settings->paths.path_content_favorites))


### PR DESCRIPTION
## Description

Due to the recent MIDI change existing configurations with "Off" string will error, so let's force them silently to the new default "OFF" value. Kinda ugly, but is there a better way..?

## Related Pull Requests

#14686

