### PR TITLE
Add Leapfrog (LFx000) Target

### DIFF
--- a/Makefile.lfx000
+++ b/Makefile.lfx000
@@ -1,0 +1,250 @@
+#########################
+## Toolchain variables ##
+#########################
+
+# Default toolchain directory
+TOOLCHAIN_DIR="$(HOST_DIR)"
+
+# All toolchain-related variables may be
+# overridden via the command line
+
+ifdef GCW0_CC
+CC                    = $(GCW0_CC)
+else
+CC                    = $(TOOLCHAIN_DIR)/usr/bin/arm-linux-gcc
+endif
+
+ifdef GCW0_CXX
+CXX                   = $(GCW0_CXX)
+else
+CXX                   = $(TOOLCHAIN_DIR)/usr/bin/arm-linux-g++
+endif
+
+ifdef GCW0_STRIP
+STRIP                 = $(GCW0_STRIP)
+else
+STRIP                 = $(TOOLCHAIN_DIR)/usr/bin/arm-linux-strip
+endif
+
+GCW0_SDL_CONFIG      ?= $(TOOLCHAIN_DIR)/usr/arm-buildroot-linux-gnueabi/sysroot/usr/bin/sdl-config
+GCW0_FREETYPE_CONFIG ?= $(TOOLCHAIN_DIR)/usr/arm-buildroot-linux-gnueabi/sysroot/usr/bin/freetype-config
+
+GCW0_INC_DIR         ?= $(TOOLCHAIN_DIR)/usr/arm-buildroot-linux-gnueabi/sysroot/usr/include
+GCW0_LIB_DIR         ?= $(TOOLCHAIN_DIR)/usr/arm-buildroot-linux-gnueabi/sysroot/usr/lib
+
+#########################
+#########################
+
+PACKAGE_NAME = retroarch
+
+DEBUG ?= 0
+
+MIYOO = 1
+DINGUX = 1
+HAVE_SCREENSHOTS = 1
+HAVE_REWIND = 1
+HAVE_7ZIP = 1
+HAVE_AL = 0
+HAVE_ALSA = 1
+HAVE_DSP_FILTER = 1
+HAVE_VIDEO_FILTER = 1
+HAVE_STATIC_VIDEO_FILTERS = 1
+HAVE_STATIC_AUDIO_FILTERS = 1
+HAVE_FILTERS_BUILTIN	= 1
+HAVE_BUILTINMBEDTLS = 0
+HAVE_BUILTINZLIB = 1
+HAVE_C99 = 1
+HAVE_CC = 1
+HAVE_CC_RESAMPLER = 1
+HAVE_CHD = 1
+HAVE_COMMAND = 0
+HAVE_CXX = 1
+HAVE_DR_MP3 = 1
+HAVE_DYNAMIC = 1
+HAVE_EGL = 0
+HAVE_FREETYPE = 0
+HAVE_GDI = 1
+HAVE_GETADDRINFO = 0
+HAVE_GETOPT_LONG = 1
+HAVE_GLSL = 0
+HAVE_HID = 0
+HAVE_IBXM = 1
+HAVE_IMAGEVIEWER = 0
+HAVE_LANGEXTRA = 0
+HAVE_LIBRETRODB = 1
+HAVE_MENU = 1
+HAVE_MENU_COMMON = 1
+HAVE_GFX_WIDGETS = 0
+HAVE_MMAP = 1
+HAVE_OPENDINGUX_FBDEV = 0
+HAVE_OPENGL = 0
+HAVE_OPENGL1 = 0
+HAVE_OPENGLES = 0
+HAVE_OPENGLES3 = 0
+HAVE_OPENGL_CORE = 0
+HAVE_OPENSSL = 0
+HAVE_OVERLAY = 0
+HAVE_RBMP = 1
+HAVE_RJPEG = 1
+HAVE_RPILED = 0
+HAVE_RPNG = 1
+HAVE_RUNAHEAD = 0
+HAVE_SDL_DINGUX = 1
+HAVE_SHADERPIPELINE = 0
+HAVE_STB_FONT = 0
+HAVE_STB_IMAGE = 0
+HAVE_STB_VORBIS = 0
+HAVE_STDIN_CMD = 0
+HAVE_STRCASESTR = 1
+HAVE_THREADS = 1
+HAVE_UDEV = 0
+HAVE_RGUI = 1
+HAVE_MATERIALUI = 0
+HAVE_XMB = 0
+HAVE_OZONE = 0
+HAVE_ZLIB = 1
+HAVE_CONFIGFILE = 1
+HAVE_PATCH = 1
+HAVE_CHEATS = 1
+HAVE_CHEEVOS = 0
+HAVE_LIBSHAKE = 0
+HAVE_CORE_INFO_CACHE = 1
+#HAVE_TINYALSA = 1
+HAVE_NEAREST_RESAMPLER = 1
+
+OS = Linux
+TARGET = retroarch
+
+OBJ :=
+LINK := $(CXX)
+DEF_FLAGS := -march=armv5te -mtune=arm926ej-s -ffast-math -fomit-frame-pointer
+DEF_FLAGS += -ffunction-sections -fdata-sections
+DEF_FLAGS += -I. -Ideps -Ideps/stb -DMIYOO=1 -DDINGUX -MMD
+DEF_FLAGS += -Wall -Wno-unused-variable -flto
+DEF_FLAGS += -std=gnu99 -D_GNU_SOURCE
+LIBS := -ldl -lz -lrt -pthread -lasound
+CFLAGS :=
+CXXFLAGS := -fno-exceptions -fno-rtti -std=c++11 -D__STDC_CONSTANT_MACROS
+ASFLAGS :=
+LDFLAGS := -Wl,--gc-sections
+INCLUDE_DIRS = -I$(GCW0_INC_DIR)
+LIBRARY_DIRS = -L$(GCW0_LIB_DIR)
+DEFINES := -DRARCH_INTERNAL -D_FILE_OFFSET_BITS=64 -UHAVE_STATIC_DUMMY
+DEFINES += -DHAVE_C99=1 -DHAVE_CXX=1
+DEFINES += -DHAVE_GETOPT_LONG=1 -DHAVE_STRCASESTR=1 -DHAVE_DYNAMIC=1
+DEFINES += -DHAVE_FILTERS_BUILTIN -DHAVE_ALSA
+
+SDL_DINGUX_CFLAGS := $(shell $(GCW0_SDL_CONFIG) --cflags)
+SDL_DINGUX_LIBS := $(shell $(GCW0_SDL_CONFIG) --libs)
+FREETYPE_CFLAGS := $(shell $(GCW0_FREETYPE_CONFIG) --cflags)
+FREETYPE_LIBS := $(shell $(GCW0_FREETYPE_CONFIG) --libs)
+MMAP_LIBS = -lc
+
+OBJDIR_BASE := obj-unix
+
+ifeq ($(DEBUG), 1)
+   OBJDIR := $(OBJDIR_BASE)/debug
+   DEF_FLAGS += -O0 -g -DDEBUG -D_DEBUG
+else
+   OBJDIR := $(OBJDIR_BASE)/release
+   DEF_FLAGS += -O2 -DNDEBUG
+endif
+
+include Makefile.common
+
+DEF_FLAGS += $(INCLUDE_DIRS)
+LDFLAGS += $(CFLAGS) $(CXXFLAGS) $(DEF_FLAGS)
+CFLAGS += $(DEF_FLAGS)
+CXXFLAGS += $(DEF_FLAGS)
+
+HEADERS = $(wildcard */*/*.h) $(wildcard */*.h) $(wildcard *.h)
+
+Q := @
+
+RARCH_OBJ := $(addprefix $(OBJDIR)/,$(OBJ))
+
+all: $(TARGET)
+
+-include $(RARCH_OBJ:.o=.d)
+
+SYMBOL_MAP := -Wl,-Map=output.map
+
+$(TARGET): $(RARCH_OBJ)
+	@$(if $(Q), $(shell echo echo LD $@),)
+	$(Q)$(LINK) -o $@ $(RARCH_OBJ) $(LIBS) $(LDFLAGS) $(LIBRARY_DIRS)
+
+ifeq ($(STRIP_BIN),1)
+	$(STRIP) --strip-unneeded $(TARGET)
+endif
+
+$(OBJDIR)/%.o: %.c
+	@mkdir -p $(dir $@)
+	@$(if $(Q), $(shell echo echo CC $<),)
+	$(Q)$(CC) $(CPPFLAGS) $(CFLAGS) $(DEFINES) -c -o $@ $<
+
+$(OBJDIR)/%.o: %.cpp
+	@mkdir -p $(dir $@)
+	@$(if $(Q), $(shell echo echo CXX $<),)
+	$(Q)$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(DEFINES) -MMD -c -o $@ $<
+
+$(OBJDIR)/%.o: %.m
+	@mkdir -p $(dir $@)
+	@$(if $(Q), $(shell echo echo OBJC $<),)
+	$(Q)$(CXX) $(OBJCFLAGS) $(DEFINES) -MMD -c -o $@ $<
+
+$(OBJDIR)/%.o: %.S $(HEADERS)
+	@mkdir -p $(dir $@)
+	@$(if $(Q), $(shell echo echo AS $<),)
+	$(Q)$(CC) $(CFLAGS) $(ASFLAGS) $(DEFINES) -c -o $@ $<
+
+clean:
+	rm -rf $(OBJDIR_BASE)
+	rm -f $(TARGET)
+	rm -f *.d
+
+install: $(TARGET)
+	mkdir -p $(DESTDIR)$(BIN_DIR) 2>/dev/null || /bin/true
+	mkdir -p $(DESTDIR)$(GLOBAL_CONFIG_DIR) 2>/dev/null || /bin/true
+	mkdir -p $(DESTDIR)$(DATA_DIR)/applications 2>/dev/null || /bin/true
+	mkdir -p $(DESTDIR)$(DATA_DIR)/metainfo 2>/dev/null || /bin/true
+	mkdir -p $(DESTDIR)$(DOC_DIR) 2>/dev/null || /bin/true
+	mkdir -p $(DESTDIR)$(MAN_DIR)/man6 2>/dev/null || /bin/true
+	mkdir -p $(DESTDIR)$(DATA_DIR)/pixmaps 2>/dev/null || /bin/true
+	cp $(TARGET) $(DESTDIR)$(BIN_DIR)
+	cp tools/cg2glsl.py $(DESTDIR)$(BIN_DIR)/retroarch-cg2glsl
+	cp retroarch.cfg $(DESTDIR)$(GLOBAL_CONFIG_DIR)
+	cp com.libretro.RetroArch.appdata.xml $(DESTDIR)$(DATA_DIR)/metainfo
+	cp retroarch.desktop $(DESTDIR)$(DATA_DIR)/applications
+	cp docs/retroarch.6 $(DESTDIR)$(MAN_DIR)/man6
+	cp docs/retroarch-cg2glsl.6 $(DESTDIR)$(MAN_DIR)/man6
+	cp media/retroarch.svg $(DESTDIR)$(DATA_DIR)/pixmaps
+	cp COPYING $(DESTDIR)$(DOC_DIR)
+	cp README.md $(DESTDIR)$(DOC_DIR)
+	chmod 755 $(DESTDIR)$(BIN_DIR)/$(TARGET)
+	chmod 755 $(DESTDIR)$(BIN_DIR)/retroarch-cg2glsl
+	chmod 644 $(DESTDIR)$(GLOBAL_CONFIG_DIR)/retroarch.cfg
+	chmod 644 $(DESTDIR)$(DATA_DIR)/applications/retroarch.desktop
+	chmod 644 $(DESTDIR)$(DATA_DIR)/metainfo/com.libretro.RetroArch.appdata.xml
+	chmod 644 $(DESTDIR)$(MAN_DIR)/man6/retroarch.6
+	chmod 644 $(DESTDIR)$(MAN_DIR)/man6/retroarch-cg2glsl.6
+	chmod 644 $(DESTDIR)$(DATA_DIR)/pixmaps/retroarch.svg
+	@if test -d media/assets && test $(HAVE_ASSETS); then \
+		echo "Installing media assets..."; \
+		mkdir -p $(DESTDIR)$(ASSETS_DIR)/assets; \
+		if test $(HAVE_MATERIALUI) = 1; then \
+			cp -r media/assets/glui/ $(DESTDIR)$(ASSETS_DIR)/assets; \
+		fi; \
+		if test $(HAVE_XMB) = 1; then \
+			cp -r media/assets/xmb/ $(DESTDIR)$(ASSETS_DIR)/assets; \
+		fi; \
+		if test $(HAVE_OZONE) = 1; then \
+			cp -r media/assets/ozone/ $(DESTDIR)$(ASSETS_DIR)/assets; \
+		fi; \
+		cp media/assets/COPYING $(DESTDIR)$(DOC_DIR)/COPYING.assets; \
+		echo "Asset copying done."; \
+	fi
+
+.PHONY: all clean
+
+print-%:
+	@echo '$*=$($*)'


### PR DESCRIPTION

## Description

This is to add a separate Makefile for the Leapfrog devices (primarily Leapster Explorer and LeapsterGS Explorer), intended to be used with the Retroleap project (https://github.com/mac2612/retroleap)  The Leapster Explorer SoC is essentially the same as the Miyoo v1, and as such I've based it on the Makefile for this device, but intend making a few config changes after a bit more testing and tailoring to both LF devices.

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
