### PR TITLE
(macOS) Fixed cocoa keyboard not allowing to map Analog stick

### DIFF
--- a/input/drivers/cocoa_input.c
+++ b/input/drivers/cocoa_input.c
@@ -431,7 +431,36 @@ static int16_t cocoa_input_state(
          }
          break;
       case RETRO_DEVICE_ANALOG:
+         {
+            int16_t ret           = 0;
+            int id_minus_key      = 0;
+            int id_plus_key       = 0;
+            unsigned id_minus     = 0;
+            unsigned id_plus      = 0;
+            bool id_plus_valid    = false;
+            bool id_minus_valid   = false;
+
+            input_conv_analog_id_to_bind_id(idx, id, id_minus, id_plus);
+
+            id_minus_valid        = binds[port][id_minus].valid;
+            id_plus_valid         = binds[port][id_plus].valid;
+            id_minus_key          = binds[port][id_minus].key;
+            id_plus_key           = binds[port][id_plus].key;
+
+            if (id_plus_valid && id_plus_key < RETROK_LAST)
+            {
+               if (apple_key_state[rarch_keysym_lut[(enum retro_key)id_plus_key]])
+                  ret = 0x7fff;
+            }
+            if (id_minus_valid && id_minus_key < RETROK_LAST)
+            {
+               if (apple_key_state[rarch_keysym_lut[(enum retro_key)id_minus_key]])
+                  ret += -0x7fff;
+            }
+            return ret;
+         }
          break;
+
       case RETRO_DEVICE_KEYBOARD:
          return (id < RETROK_LAST) && apple_key_state[rarch_keysym_lut[(enum retro_key)id]];
       case RETRO_DEVICE_MOUSE:


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

Cocoa keyboard input driver while advertising `RETRO_DEVICE_ANALOG` did not implement returning the values. This PR adapted implementation for `RETRO_DEVICE_ANALOG` from `winraw` driver.

## Related Issues
[analog stick RetroPad keyboard mappings not working](https://github.com/libretro/RetroArch/issues/3954) looks similar to what this PR is fixing

## Related Pull Requests

None

## Reviewers

Unknown