### PR TITLE
Fix runtime error in FFmpeg core when build with FFmpeg n5.1.2 and OpenGL ES

### DIFF
--- a/cores/libretro-ffmpeg/ffmpeg_core.c
+++ b/cores/libretro-ffmpeg/ffmpeg_core.c
@@ -856,7 +856,7 @@ void CORE_PREFIX(retro_run)(void)
                glBindTexture(GL_TEXTURE_2D, frames[1].tex);
 #if defined(HAVE_OPENGLES)
                glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA,
-                     media.width, media.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
+                     media.width, media.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, video_frame_temp_buffer);
 #else
                glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA,
                      media.width, media.height, 0, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, NULL);

--- a/cores/libretro-ffmpeg/video_buffer.h
+++ b/cores/libretro-ffmpeg/video_buffer.h
@@ -20,6 +20,7 @@
 extern "C" {
 #endif
 
+#include <libavcodec/version.h>
 #include <libavutil/frame.h>
 #include <libswscale/swscale.h>
 


### PR DESCRIPTION
## Description

Fix runtime error in FFmpeg core when build with FFmpeg n5.1.2 and OpenGL ES.

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
