### PR TITLE
(cheevos) fix construction of badge path

### DIFF
--- a/cheevos/cheevos_client.c
+++ b/cheevos/cheevos_client.c
@@ -1509,7 +1509,7 @@ static bool rcheevos_client_fetch_badge(
    strlcpy(badge_fullpath,
          state->badge_directory, sizeof(badge_fullpath));
    fill_pathname_slash(badge_fullpath, sizeof(badge_fullpath));
-   badge_fullname      = badge_fullpath + strlen(state->badge_directory);
+   badge_fullname      = badge_fullpath + strlen(badge_fullpath);
    badge_fullname_size = sizeof(badge_fullpath) - 
       (badge_fullname - badge_fullpath);
 


### PR DESCRIPTION
## Description

Changes in #14275 [removed the trailing slash](https://github.com/libretro/RetroArch/pull/14275/files#diff-7ebbc8c195bef76b3750f1a3148d92c9fc4f8da81c5869990cc1da9a47f514b0L371) from `APPLICATION_SPECIAL_DIRECTORY_THUMBNAILS_CHEEVOS_BADGES`, revealing an issue in the construction of the path to the locally downloaded badges. As a result, the achievement badges were being downloaded every time a game was opened, even if they were already in the thumbnails/cheevos/badges directory.

## Related Issues

https://retroachievements.org/viewtopic.php?t=18364

## Related Pull Requests

n/a

## Reviewers

@Sanaki
