### PR TITLE
Use sublabel as help text if there is no suitable definition.

### DIFF
--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -7554,6 +7554,18 @@ static int generic_menu_iterate(
                   default:
                      ret = msg_hash_get_help_enum(cbs->enum_idx,
                            menu->menu_state_msg, sizeof(menu->menu_state_msg));
+                     if (string_is_equal(menu->menu_state_msg,
+                              msg_hash_to_str(
+                                 MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE)))
+                        {
+                        get_current_menu_sublabel(
+                              menu_st,
+                              menu->menu_state_msg, sizeof(menu->menu_state_msg));
+                        if (string_is_equal(menu->menu_state_msg, ""))
+                           strlcpy(menu->menu_state_msg,
+                                 msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE),
+                                 sizeof(menu->menu_state_msg));
+                     }
                      break;
                }
 


### PR DESCRIPTION
## Description

Help text can be shown for the menu items in RetroArch menu by pressing Select. This relies on individual help text definitions in msg_hash_us.c (or in the localized versions). If there is no such text, "No information available" is displayed. This change will display the menu item sublabel instead of "No information available" if it exists. Actual code is lifted from a few lines below, in the accessibility part.

This is a small change, but beneficial for some reasons:

- if menu sublabels are turned off, its contents can still be seen by pressing Select
- it may be more convenient to read messagebox instead of ticker text if sublabel is long
- it gives an opportunity to remove much of the content in msg_hash_us.c (and translations), as in several cases the "help text" is the duplicate of the sublabel

Checked on Linux desktop with xmb/ozone/rgui/glui menus, no problem seen. Word wrap (which is usually hardcoded for help texts in msg_hash_us.c) was handled correctly.

## Related Issues

[Translation guide](https://docs.libretro.com/development/retroarch/new-translations/) mentions an overhaul of msg_hash_xx.c in progress, I guess it could be related but I found no issue for that.
