### PR TITLE
Allow coreaudio3 driver to work with audio devices that have 2 or more output channels

### DIFF
--- a/audio/drivers/coreaudio3.m
+++ b/audio/drivers/coreaudio3.m
@@ -204,7 +204,7 @@ static bool g_interrupted;
          return nil;
 
       format = au.outputBusses[0].format;
-      if (format.channelCount != 2)
+      if (format.channelCount < 2)
          return nil;
 
       renderFormat = [[AVAudioFormat alloc] initStandardFormatWithSampleRate:rate channels:2];


### PR DESCRIPTION
The coreaudio3 driver failed to initialize if the audio device had more than 2 output channels. Changed the logic so it allows audio devices with at least 2 output channels.

## Reviewers

@LibretroAdmin
