### PR TITLE
Keyboard event blocking corrections

### DIFF
--- a/input/input_driver.h
+++ b/input/input_driver.h
@@ -463,6 +463,7 @@ typedef struct
 
    /* primitives */
    bool analog_requested[MAX_USERS];
+   bool keyboard_menu_toggle_pressed;
    retro_bits_512_t keyboard_mapping_bits;    /* bool alignment */
    input_game_focus_state_t game_focus_state; /* bool alignment */
 } input_driver_state_t;

--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -2723,7 +2723,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_INPUT_META_ENABLE_HOTKEY,
-   "When assigned, the 'Hotkey Enable' key must be held before any other hotkeys are recognized. Allows controller buttons to be mapped to hotkey functions without affecting normal input."
+   "When assigned, the 'Hotkey Enable' key must be held before any other hotkeys are recognized. Allows controller buttons to be mapped to hotkey functions without affecting normal input. Assigning the modifier to controller only will not require it for keyboard hotkeys, but both modifiers work for both devices."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_INPUT_HOTKEY_BLOCK_DELAY,

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -5390,10 +5390,10 @@ bool menu_input_key_bind_iterate(
    /* Tick main timers */
    _binds->timer_timeout.current    = current_time;
    _binds->timer_timeout.timeout_us = _binds->timer_timeout.timeout_end -
-current_time;
+         current_time;
    _binds->timer_hold   .current    = current_time;
    _binds->timer_hold   .timeout_us = _binds->timer_hold   .timeout_end -
-current_time;
+         current_time;
 
    if (_binds->timer_timeout.timeout_us <= 0)
    {
@@ -5429,7 +5429,7 @@ current_time;
       {
          input_st->keyboard_press_cb        = NULL;
          input_st->keyboard_press_data      = NULL;
-	 input_st->flags                   &= ~INP_FLAG_KB_MAPPING_BLOCKED;
+         input_st->flags                   &= ~INP_FLAG_KB_MAPPING_BLOCKED;
       }
 
       return true;
@@ -5470,7 +5470,7 @@ current_time;
             new_binds.timer_hold.timeout_end - current_time;
 
          snprintf(bind->s, bind->len,
-               "[%s]\npress keyboard, mouse or joypad\nand hold ...",
+               "[%s]\nPress keyboard, mouse or joypad\nand hold ...",
                input_config_bind_map_get_desc(
                   _binds->begin - MENU_SETTINGS_BIND_BEGIN));
 
@@ -5501,7 +5501,7 @@ current_time;
          uint64_t current_usec             = cpu_features_get_time_usec();
          *(new_binds.output)               = new_binds.buffer;
 
-	 input_st->flags                  &= ~INP_FLAG_KB_MAPPING_BLOCKED;
+         input_st->flags                  &= ~INP_FLAG_KB_MAPPING_BLOCKED;
 
          /* Avoid new binds triggering things right away. */
          /* Inhibits input for 2 frames
@@ -5515,7 +5515,7 @@ current_time;
          {
             input_st->keyboard_press_cb        = NULL;
             input_st->keyboard_press_data      = NULL;
-	    input_st->flags                   &= ~INP_FLAG_KB_MAPPING_BLOCKED;
+            input_st->flags                   &= ~INP_FLAG_KB_MAPPING_BLOCKED;
             return true;
          }
 


### PR DESCRIPTION
## Description

Made key event blocking a little less aggressive by:
- Allowing keyboard hotkeys to work without hotkey modifier if modifier is only mapped to RetroPad
- Allowing keyboard hotkey keys for typing if hotkey modifier is set to keyboard but not pressed
- Allowing keyboard RetroPad keys for typing if emulated device type is "None"

Plus some related nits.

Testing is most appreciated!

## Related Issues

Closes #14690 

