### PR TITLE
Cleanup of msg_hash_xx.c files after msg_hash_us.c cleanup.

### DIFF
--- a/intl/msg_hash_ar.c
+++ b/intl/msg_hash_ar.c
@@ -44,133 +44,6 @@ int msg_hash_get_help_ar_enum(enum msg_hash_enums msg, char *s, size_t len)
 
        switch (idx)
        {
-          case RARCH_FAST_FORWARD_KEY:
-             snprintf(s, len,
-                   "Toggles between fast-forwarding and \n"
-                   "normal speed."
-                   );
-             break;
-          case RARCH_FAST_FORWARD_HOLD_KEY:
-             snprintf(s, len,
-                   "Hold for fast-forward. \n"
-                   " \n"
-                   "Releasing button disables fast-forward."
-                   );
-             break;
-          case RARCH_SLOWMOTION_KEY:
-             snprintf(s, len,
-                   "Toggles slowmotion.");
-             break;
-          case RARCH_SLOWMOTION_HOLD_KEY:
-             snprintf(s, len,
-                   "Hold for slowmotion.");
-             break;
-          case RARCH_PAUSE_TOGGLE:
-             snprintf(s, len,
-                   "Toggle between paused and non-paused state.");
-             break;
-          case RARCH_FRAMEADVANCE:
-             snprintf(s, len,
-                   "Frame advance when content is paused.");
-             break;
-          case RARCH_SHADER_NEXT:
-             snprintf(s, len,
-                   "Applies next shader in directory.");
-             break;
-          case RARCH_SHADER_PREV:
-             snprintf(s, len,
-                   "Applies previous shader in directory.");
-             break;
-          case RARCH_CHEAT_INDEX_PLUS:
-          case RARCH_CHEAT_INDEX_MINUS:
-          case RARCH_CHEAT_TOGGLE:
-             snprintf(s, len,
-                   "Cheats.");
-             break;
-          case RARCH_RESET:
-             snprintf(s, len,
-                   "Reset the content.");
-             break;
-          case RARCH_SCREENSHOT:
-             snprintf(s, len,
-                   "Take screenshot.");
-             break;
-          case RARCH_MUTE:
-             snprintf(s, len,
-                   "Mute/unmute audio.");
-             break;
-          case RARCH_OSK:
-             snprintf(s, len,
-                   "Toggles onscreen keyboard.");
-             break;
-          case RARCH_NETPLAY_GAME_WATCH:
-             snprintf(s, len,
-                   "Netplay toggle play/spectate mode.");
-             break;
-          case RARCH_ENABLE_HOTKEY:
-             snprintf(s, len,
-                   "Enable other hotkeys. \n"
-                   " \n"
-                   "If this hotkey is bound to either\n"
-                   "a keyboard, joybutton or joyaxis, \n"
-                   "all other hotkeys will be enabled only \n"
-                   "if this one is held at the same time. \n"
-                   " \n"
-                   "Alternatively, all hotkeys for keyboard \n"
-                   "could be disabled by the user.");
-             break;
-          case RARCH_VOLUME_UP:
-             snprintf(s, len,
-                   "Increases audio volume.");
-             break;
-          case RARCH_VOLUME_DOWN:
-             snprintf(s, len,
-                   "Decreases audio volume.");
-             break;
-          case RARCH_OVERLAY_NEXT:
-             snprintf(s, len,
-                   "Switches to next overlay. Wraps around.");
-             break;
-          case RARCH_DISK_EJECT_TOGGLE:
-             snprintf(s, len,
-                   "Toggles eject for disks. \n"
-                   " \n"
-                   "Used for multiple-disk content. ");
-             break;
-          case RARCH_DISK_NEXT:
-          case RARCH_DISK_PREV:
-             snprintf(s, len,
-                   "Cycles through disk images. Use after ejecting. \n"
-                   " \n"
-                   "Complete by toggling eject again.");
-             break;
-          case RARCH_GRAB_MOUSE_TOGGLE:
-             snprintf(s, len,
-                   "Toggles mouse grab. \n"
-                   " \n"
-                   "When mouse is grabbed, RetroArch hides the \n"
-                   "mouse, and keeps the mouse pointer inside \n"
-                   "the window to allow relative mouse input to \n"
-                   "work better.");
-             break;
-          case RARCH_GAME_FOCUS_TOGGLE:
-             snprintf(s, len,
-                   "Toggles game focus.\n"
-                   " \n"
-                   "When a game has focus, RetroArch will both disable \n"
-                   "hotkeys and keep/warp the mouse pointer inside the window.");
-             break;
-          case RARCH_MENU_TOGGLE:
-             snprintf(s, len, "Toggles menu.");
-             break;
-          case RARCH_LOAD_STATE_KEY:
-             snprintf(s, len,
-                   "Loads state.");
-             break;
-          case RARCH_FULLSCREEN_TOGGLE_KEY:
-             snprintf(s, len,
-                   "Toggles fullscreen.");
-             break;
           case RARCH_QUIT_KEY:
              snprintf(s, len,
                    "Key to exit RetroArch cleanly. \n"
@@ -194,20 +67,6 @@ int msg_hash_get_help_ar_enum(enum msg_hash_enums msg, char *s, size_t len)
                    "When slot is not 0, path will be <path><d>, \n"
                    "where <d> is slot number.");
              break;
-          case RARCH_SAVE_STATE_KEY:
-             snprintf(s, len,
-                   "Saves state.");
-             break;
-          case RARCH_REWIND:
-             snprintf(s, len,
-                   "Hold button down to rewind. \n"
-                   " \n"
-                   "Rewinding must be enabled.");
-             break;
-          case RARCH_BSV_RECORD_TOGGLE:
-             snprintf(s, len,
-                   "Toggle between recording and not.");
-             break;
           default:
              if (string_is_empty(s))
                 strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE), len);
@@ -230,12 +89,6 @@ int msg_hash_get_help_ar_enum(enum msg_hash_enums msg, char *s, size_t len)
                     "to input the username and password into \n"
                     "RetroArch.");
             break;
-        case MENU_ENUM_LABEL_CHEEVOS_USERNAME:
-            snprintf(s, len, "Username for your Retro Achievements account.");
-            break;
-        case MENU_ENUM_LABEL_CHEEVOS_PASSWORD:
-            snprintf(s, len, "Password for your Retro Achievements account.");
-            break;
         case MENU_ENUM_LABEL_USER_LANGUAGE:
             snprintf(s, len, "Localizes the menu and all onscreen messages \n"
                     "according to the language you have selected \n"
@@ -249,62 +102,6 @@ int msg_hash_get_help_ar_enum(enum msg_hash_enums msg, char *s, size_t len)
                     " \n"
                     "In case a language is not implemented, \n"
                     "we fallback to English.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FONT_PATH:
-            snprintf(s, len, "Change the font that is used \n"
-                    "for the Onscreen Display text.");
-            break;
-        case MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS:
-            snprintf(s, len, "Automatically load content-specific core options.");
-            break;
-        case MENU_ENUM_LABEL_AUTO_OVERRIDES_ENABLE:
-            snprintf(s, len, "Automatically load override configurations.");
-            break;
-        case MENU_ENUM_LABEL_AUTO_REMAPS_ENABLE:
-            snprintf(s, len, "Automatically load input remapping files.");
-            break;
-        case MENU_ENUM_LABEL_SORT_SAVESTATES_ENABLE:
-            snprintf(s, len, "Sort save states in folders \n"
-                    "named after the libretro core used.");
-            break;
-        case MENU_ENUM_LABEL_SORT_SAVEFILES_ENABLE:
-            snprintf(s, len, "Sort save files in folders \n"
-                    "named after the libretro core used.");
-            break;
-        case MENU_ENUM_LABEL_RESUME_CONTENT:
-            snprintf(s, len, "Exits from the menu and returns back \n"
-                    "to the content.");
-            break;
-        case MENU_ENUM_LABEL_RESTART_CONTENT:
-            snprintf(s, len, "Restarts the content from the beginning.");
-            break;
-        case MENU_ENUM_LABEL_CLOSE_CONTENT:
-            snprintf(s, len, "Closes the content and unloads it from \n"
-                    "memory.");
-            break;
-        case MENU_ENUM_LABEL_UNDO_LOAD_STATE:
-            snprintf(s, len, "If a state was loaded, content will \n"
-                    "go back to the state prior to loading.");
-            break;
-        case MENU_ENUM_LABEL_UNDO_SAVE_STATE:
-            snprintf(s, len, "If a state was overwritten, it will \n"
-                    "roll back to the previous save state.");
-            break;
-        case MENU_ENUM_LABEL_TAKE_SCREENSHOT:
-            snprintf(s, len, "Create a screenshot. \n"
-                    " \n"
-                    "The screenshot will be stored inside the \n"
-                    "Screenshot Directory.");
-            break;
-        case MENU_ENUM_LABEL_ADD_TO_FAVORITES:
-            snprintf(s, len, "Add the entry to your Favorites.");
-            break;
-        case MENU_ENUM_LABEL_RUN:
-            snprintf(s, len, "Start the content.");
-            break;
-        case MENU_ENUM_LABEL_INFORMATION:
-            snprintf(s, len, "Show additional metadata information \n"
-                    "about the content.");
             break;
         case MENU_ENUM_LABEL_FILE_BROWSER_CONFIG:
             snprintf(s, len, "Configuration file.");
@@ -329,33 +126,6 @@ int msg_hash_get_help_ar_enum(enum msg_hash_enums msg, char *s, size_t len)
         case MENU_ENUM_LABEL_USE_THIS_DIRECTORY:
             snprintf(s, len,
                      "Select this to set this as the directory.");
-            break;
-        case MENU_ENUM_LABEL_CONTENT_DATABASE_DIRECTORY:
-            snprintf(s, len,
-                     "Content Database Directory. \n"
-                             " \n"
-                             "Path to content database \n"
-                             "directory.");
-            break;
-        case MENU_ENUM_LABEL_THUMBNAILS_DIRECTORY:
-            snprintf(s, len,
-                     "Thumbnails Directory. \n"
-                             " \n"
-                             "To store thumbnail files.");
-            break;
-        case MENU_ENUM_LABEL_LIBRETRO_INFO_PATH:
-            snprintf(s, len,
-                     "Core Info Directory. \n"
-                             " \n"
-                             "A directory for where to search \n"
-                             "for libretro core information.");
-            break;
-        case MENU_ENUM_LABEL_PLAYLIST_DIRECTORY:
-            snprintf(s, len,
-                     "Playlist Directory. \n"
-                             " \n"
-                             "Save all playlist files to this \n"
-                             "directory.");
             break;
         case MENU_ENUM_LABEL_DUMMY_ON_CORE_SHUTDOWN:
             snprintf(s, len,
@@ -468,18 +238,6 @@ int msg_hash_get_help_ar_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Content decompressed by RetroArch will be \n"
                              "temporarily extracted to this directory.");
             break;
-        case MENU_ENUM_LABEL_HISTORY_LIST_ENABLE:
-            snprintf(s, len,
-                     "If enabled, every content loaded \n"
-                             "in RetroArch will be automatically \n"
-                             "added to the recent history list.");
-            break;
-        case MENU_ENUM_LABEL_RGUI_BROWSER_DIRECTORY:
-            snprintf(s, len,
-                     "File Browser Directory. \n"
-                             " \n"
-                             "Sets start directory for menu file browser.");
-            break;
         case MENU_ENUM_LABEL_INPUT_POLL_TYPE_BEHAVIOR:
             snprintf(s, len,
                      "Influence how input polling is done inside \n"
@@ -498,137 +256,11 @@ int msg_hash_get_help_ar_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Will be ignored when using netplay."
             );
             break;
-        case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_HIDE_UNBOUND:
-            snprintf(s, len,
-                     "Hide input descriptors that were not set \n"
-                             "by the core.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE:
-            snprintf(s, len,
-                     "Video refresh rate of your monitor. \n"
-                             "Used to calculate a suitable audio input rate.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FORCE_SRGB_DISABLE:
-            snprintf(s, len,
-                     "Forcibly disable sRGB FBO support. Some Intel \n"
-                             "OpenGL drivers on Windows have video problems \n"
-                             "with sRGB FBO support enabled.");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_ENABLE:
-            snprintf(s, len,
-                     "Enable audio output.");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_SYNC:
-            snprintf(s, len,
-                     "Synchronize audio (recommended).");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_LATENCY:
-            snprintf(s, len,
-                     "Desired audio latency in milliseconds. \n"
-                             "Might not be honored if the audio driver \n"
-                             "can't provide given latency.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_ALLOW_ROTATE:
-            snprintf(s, len,
-                     "Allow cores to set rotation. If false, \n"
-                             "rotation requests are honored, but ignored.\n\n"
-                             "Used for setups where one manually rotates \n"
-                             "the monitor.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_LABEL_SHOW:
-            snprintf(s, len,
-                     "Show the input descriptors set by the core \n"
-                             "instead of the default ones.");
-            break;
-        case MENU_ENUM_LABEL_CONTENT_HISTORY_SIZE:
-            snprintf(s, len,
-                     "Number of entries that will be kept in \n"
-                             "content history playlist.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_WINDOWED_FULLSCREEN:
-            snprintf(s, len,
-                     "To use windowed mode or not when going \n"
-                             "fullscreen.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FONT_SIZE:
-            snprintf(s, len,
-                     "Font size for on-screen messages.");
-            break;
-        case MENU_ENUM_LABEL_SAVESTATE_AUTO_INDEX:
-            snprintf(s, len,
-                     "Automatically increment slot index on each save, \n"
-                             "generating multiple savestate files. \n"
-                             "When the content is loaded, state slot will be \n"
-                             "set to the highest existing value (last savestate).");
-            break;
-        case MENU_ENUM_LABEL_FPS_SHOW:
-            snprintf(s, len,
-                     "Enables displaying the current frames \n"
-                             "per second.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FONT_ENABLE:
-            snprintf(s, len,
-                     "Show and/or hide onscreen messages.");
-            break;
         case MENU_ENUM_LABEL_VIDEO_MESSAGE_POS_X:
         case MENU_ENUM_LABEL_VIDEO_MESSAGE_POS_Y:
             snprintf(s, len,
                      "Offset for where messages will be placed \n"
                              "onscreen. Values are in range [0.0, 1.0].");
-            break;
-        case MENU_ENUM_LABEL_INPUT_OVERLAY_ENABLE:
-            snprintf(s, len,
-                     "Enable or disable the current overlay.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_OVERLAY_HIDE_IN_MENU:
-            snprintf(s, len,
-                     "Hide the current overlay from appearing \n"
-                             "inside the menu.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_OVERLAY_SHOW_PHYSICAL_INPUTS:
-            snprintf(s, len,
-                      "Show keyboard/controller button presses on \n"
-                            "the onscreen overlay.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_OVERLAY_SHOW_PHYSICAL_INPUTS_PORT:
-            snprintf(s, len,
-                      "Select the port to listen for controller input \n"
-                            "to display on the onscreen overlay.");
-            break;
-        case MENU_ENUM_LABEL_OVERLAY_PRESET:
-            snprintf(s, len,
-                     "Path to input overlay.");
-            break;
-        case MENU_ENUM_LABEL_OVERLAY_OPACITY:
-            snprintf(s, len,
-                     "Overlay opacity.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_BIND_TIMEOUT:
-            snprintf(s, len,
-                     "Input bind timer timeout (in seconds). \n"
-                             "Amount of seconds to wait until proceeding \n"
-                             "to the next bind.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_BIND_HOLD:
-            snprintf(s, len,
-               "Input bind hold time (in seconds). \n"
-               "Amount of seconds to hold an input to bind it.");
-            break;
-        case MENU_ENUM_LABEL_OVERLAY_SCALE:
-            snprintf(s, len,
-                     "Overlay scale.");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_OUTPUT_RATE:
-            snprintf(s, len,
-                     "Audio output samplerate.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SHARED_CONTEXT:
-            snprintf(s, len,
-                     "Set to true if hardware-rendered cores \n"
-                             "should get their private context. \n"
-                             "Avoids having to assume hardware state changes \n"
-                             "inbetween frames."
-            );
             break;
         case MENU_ENUM_LABEL_CORE_LIST:
             snprintf(s, len,
@@ -873,13 +505,6 @@ int msg_hash_get_help_ar_enum(enum msg_hash_enums msg, char *s, size_t len)
                }
             }
             break;
-        case MENU_ENUM_LABEL_AUDIO_DSP_PLUGIN:
-            snprintf(s, len,
-                     "Audio DSP plugin.\n"
-                             " Processes audio before it's sent to \n"
-                             "the driver."
-            );
-            break;
         case MENU_ENUM_LABEL_AUDIO_RESAMPLER_DRIVER:
             {
                const char *lbl = settings ? settings->arrays.audio_resampler : NULL;
@@ -941,20 +566,6 @@ int msg_hash_get_help_ar_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "The Default Filter option will affect the \n"
                              "stretching filter.");
             break;
-        case MENU_ENUM_LABEL_VIDEO_SHADER_PARAMETERS:
-            snprintf(s, len,
-                     "Shader Parameters. \n"
-                             " \n"
-                             "Modifies current shader directly. Will not be \n"
-                             "saved to CGP/GLSLP preset file.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_PARAMETERS:
-            snprintf(s, len,
-                     "Shader Preset Parameters. \n"
-                             " \n"
-                             "Modifies shader preset currently in menu."
-            );
-            break;
         case MENU_ENUM_LABEL_VIDEO_SHADER_PASS:
             snprintf(s, len,
                      "Path to shader. \n"
@@ -993,13 +604,6 @@ int msg_hash_get_help_ar_enum(enum msg_hash_enums msg, char *s, size_t len)
             "manually isn't really an option."
 #endif
             );
-            break;
-        case MENU_ENUM_LABEL_CONFIRM_ON_EXIT:
-            snprintf(s, len, "Are you sure you want to quit?");
-            break;
-        case MENU_ENUM_LABEL_SHOW_HIDDEN_FILES:
-            snprintf(s, len, "Show hidden files\n"
-                    "and folders.");
             break;
         case MENU_ENUM_LABEL_VIDEO_SHADER_FILTER_PASS:
             snprintf(s, len,
@@ -1083,26 +687,6 @@ int msg_hash_get_help_ar_enum(enum msg_hash_enums msg, char *s, size_t len)
                      "and applied to the running content."
             );
             break;
-        case MENU_ENUM_LABEL_MENU_TOGGLE:
-            snprintf(s, len,
-                     "Toggles menu.");
-            break;
-        case MENU_ENUM_LABEL_GRAB_MOUSE_TOGGLE:
-            snprintf(s, len,
-                     "Toggles mouse grab.\n"
-                             " \n"
-                             "When mouse is grabbed, RetroArch hides the \n"
-                             "mouse, and keeps the mouse pointer inside \n"
-                             "the window to allow relative mouse input to \n"
-                             "work better.");
-            break;
-        case MENU_ENUM_LABEL_GAME_FOCUS_TOGGLE:
-            snprintf(s, len,
-                     "Toggles game focus.\n"
-                             " \n"
-                             "When a game has focus, RetroArch will both disable \n"
-                             "hotkeys and keep/warp the mouse pointer inside the window.");
-            break;
         case MENU_ENUM_LABEL_DISK_NEXT:
             snprintf(s, len,
                      "Cycles through disk images. Use after \n"
@@ -1146,12 +730,6 @@ int msg_hash_get_help_ar_enum(enum msg_hash_enums msg, char *s, size_t len)
 #endif
             );
             break;
-        case MENU_ENUM_LABEL_DISK_EJECT_TOGGLE:
-            snprintf(s, len,
-                     "Toggles eject for disks.\n"
-                             " \n"
-                             "Used for multiple-disk content.");
-            break;
         case MENU_ENUM_LABEL_ENABLE_HOTKEY:
             snprintf(s, len,
                      "Enable other hotkeys.\n"
@@ -1165,20 +743,6 @@ int msg_hash_get_help_ar_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "implementations which query a large area of \n"
                              "the keyboard, where it is not desirable that \n"
                              "hotkeys get in the way.");
-            break;
-        case MENU_ENUM_LABEL_REWIND_ENABLE:
-            snprintf(s, len,
-                     "Enable rewinding.\n"
-                             " \n"
-                             "This will take a performance hit, \n"
-                             "so it is disabled by default.");
-            break;
-        case MENU_ENUM_LABEL_LIBRETRO_DIR_PATH:
-            snprintf(s, len,
-                     "Core Directory. \n"
-                             " \n"
-                             "A directory for where to search for \n"
-                             "libretro core implementations.");
             break;
         case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE_AUTO:
             snprintf(s, len,
@@ -1199,22 +763,6 @@ int msg_hash_get_help_ar_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "large pitch changes. If your monitor does \n"
                              "not run at 60Hz, or something close to it, \n"
                              "disable VSync, and leave this at its default.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_ROTATION:
-            snprintf(s, len,
-                     "Forces a certain rotation \n"
-                             "of the screen.\n"
-                             " \n"
-                             "The rotation is added to rotations which\n"
-                             "the libretro core sets (see Video Allow\n"
-                             "Rotate).");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SCALE:
-            snprintf(s, len,
-                     "Fullscreen resolution.\n"
-                             " \n"
-                             "Resolution of 0 uses the \n"
-                             "resolution of the environment.\n");
             break;
         case MENU_ENUM_LABEL_FASTFORWARD_RATIO:
             snprintf(s, len,
@@ -1239,25 +787,6 @@ int msg_hash_get_help_ar_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "is preferred, 1 and up (1 being first \n"
                              "monitor), suggests RetroArch to use that \n"
                              "particular monitor.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_CROP_OVERSCAN:
-            snprintf(s, len,
-                     "Forces cropping of overscanned \n"
-                             "frames.\n"
-                             " \n"
-                             "Exact behavior of this option is \n"
-                             "core-implementation specific.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SCALE_INTEGER:
-            snprintf(s, len,
-                     "Only scales video in integer \n"
-                             "steps.\n"
-                             " \n"
-                             "The base size depends on system-reported \n"
-                             "geometry and aspect ratio.\n"
-                             " \n"
-                             "If Force Aspect is not set, X/Y will be \n"
-                             "integer scaled independently.");
             break;
         case MENU_ENUM_LABEL_AUDIO_VOLUME:
             snprintf(s, len,
@@ -1294,53 +823,10 @@ int msg_hash_get_help_ar_enum(enum msg_hash_enums msg, char *s, size_t len)
                              " Input rate is defined as: \n"
                              " input rate * (1.0 +/- (max timing skew))");
             break;
-        case MENU_ENUM_LABEL_OVERLAY_NEXT:
-            snprintf(s, len,
-                     "Toggles to next overlay.\n"
-                             " \n"
-                             "Wraps around.");
-            break;
-        case MENU_ENUM_LABEL_LOG_VERBOSITY:
-            snprintf(s, len,
-                     "Enable or disable verbosity level \n"
-                             "of frontend.");
-            break;
-        case MENU_ENUM_LABEL_VOLUME_UP:
-            snprintf(s, len,
-                     "Increases audio volume.");
-            break;
-        case MENU_ENUM_LABEL_VOLUME_DOWN:
-            snprintf(s, len,
-                     "Decreases audio volume.");
-            break;
         case MENU_ENUM_LABEL_VIDEO_DISABLE_COMPOSITION:
             snprintf(s, len,
                      "Forcibly disable composition.\n"
                              "Only valid on Windows Vista/7 for now.");
-            break;
-        case MENU_ENUM_LABEL_PERFCNT_ENABLE:
-            snprintf(s, len,
-                     "Enable or disable frontend \n"
-                             "performance counters.");
-            break;
-        case MENU_ENUM_LABEL_SYSTEM_DIRECTORY:
-            snprintf(s, len,
-                     "System Directory. \n"
-                             " \n"
-                             "Sets the 'system' directory.\n"
-                             "Cores can query for this\n"
-                             "directory to load BIOSes, \n"
-                             "system-specific configs, etc.");
-            break;
-        case MENU_ENUM_LABEL_SAVESTATE_AUTO_SAVE:
-        case MENU_ENUM_LABEL_SAVESTATE_AUTO_LOAD:
-            snprintf(s, len,
-                     "Automatically saves a savestate at the \n"
-                             "end of RetroArch's lifetime.\n"
-                             " \n"
-                             "RetroArch will automatically load any savestate\n"
-                             "with this path on startup if 'Auto Load State\n"
-                             "is enabled.");
             break;
         case MENU_ENUM_LABEL_VIDEO_THREADED:
             snprintf(s, len,
@@ -1349,31 +835,6 @@ int msg_hash_get_help_ar_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Using this might improve performance at the \n"
                              "possible cost of latency and more video \n"
                              "stuttering.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_VSYNC:
-            snprintf(s, len,
-                     "Video V-Sync.\n");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_HARD_SYNC:
-            snprintf(s, len,
-                     "Attempts to hard-synchronize \n"
-                             "CPU and GPU.\n"
-                             " \n"
-                             "Can reduce latency at the cost of \n"
-                             "performance.");
-            break;
-        case MENU_ENUM_LABEL_REWIND_GRANULARITY:
-            snprintf(s, len,
-                     "Rewind granularity.\n"
-                             " \n"
-                             " When rewinding defined number of \n"
-                             "frames, you can rewind several frames \n"
-                             "at a time, increasing the rewinding \n"
-                             "speed.");
-            break;
-        case MENU_ENUM_LABEL_SCREENSHOT:
-            snprintf(s, len,
-                     "Take screenshot.");
             break;
         case MENU_ENUM_LABEL_VIDEO_FRAME_DELAY:
             snprintf(s, len,
@@ -1410,49 +871,6 @@ int msg_hash_get_help_ar_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "configured as if it is a 60 Hz monitor \n"
                              "(divide refresh rate by 2).");
             break;
-        case MENU_ENUM_LABEL_RGUI_SHOW_START_SCREEN:
-            snprintf(s, len,
-                     "Show startup screen in menu.\n"
-                             "Is automatically set to false when seen\n"
-                             "for the first time.\n"
-                             " \n"
-                             "This is only updated in config if\n"
-                             "'Save Configuration on Exit' is enabled.\n");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FULLSCREEN:
-            snprintf(s, len, "Toggles fullscreen.");
-            break;
-        case MENU_ENUM_LABEL_BLOCK_SRAM_OVERWRITE:
-            snprintf(s, len,
-                     "Block SRAM from being overwritten \n"
-                             "when loading save states.\n"
-                             " \n"
-                             "Might potentially lead to buggy games.");
-            break;
-        case MENU_ENUM_LABEL_PAUSE_NONACTIVE:
-            snprintf(s, len,
-                     "Pause gameplay when window focus \n"
-                             "is lost.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_GPU_SCREENSHOT:
-            snprintf(s, len,
-                     "Screenshots output of GPU shaded \n"
-                             "material if available.");
-            break;
-        case MENU_ENUM_LABEL_SCREENSHOT_DIRECTORY:
-            snprintf(s, len,
-                     "Screenshot Directory. \n"
-                             " \n"
-                             "Directory to dump screenshots to."
-            );
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SWAP_INTERVAL:
-            snprintf(s, len,
-                     "VSync Swap Interval.\n"
-                             " \n"
-                             "Uses a custom swap interval for VSync. Set this \n"
-                             "to effectively halve monitor refresh rate.");
-            break;
         case MENU_ENUM_LABEL_SAVEFILE_DIRECTORY:
             snprintf(s, len,
                      "Savefile Directory. \n"
@@ -1460,16 +878,6 @@ int msg_hash_get_help_ar_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Save all save files (*.srm) to this \n"
                              "directory. This includes related files like \n"
                              ".bsv, .rt, .psrm, etc...\n"
-                             " \n"
-                             "This will be overridden by explicit command line\n"
-                             "options.");
-            break;
-        case MENU_ENUM_LABEL_SAVESTATE_DIRECTORY:
-            snprintf(s, len,
-                     "Savestate Directory. \n"
-                             " \n"
-                             "Save all save states (*.state) to this \n"
-                             "directory.\n"
                              " \n"
                              "This will be overridden by explicit command line\n"
                              "options.");
@@ -1490,59 +898,8 @@ int msg_hash_get_help_ar_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "be loaded dynamically by the menu depending \n"
                              "on context.");
             break;
-        case MENU_ENUM_LABEL_SLOWMOTION_RATIO:
-            snprintf(s, len,
-                     "Slowmotion ratio."
-                             " \n"
-                             "When slowmotion, content will slow\n"
-                             "down by factor.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_TURBO_PERIOD:
-            snprintf(s, len,
-                     "Turbo period.\n"
-                             " \n"
-                             "Describes the period of which turbo-enabled\n"
-                             "buttons toggle.\n"
-                             " \n"
-                             "Numbers are described in frames."
-            );
-            break;
-        case MENU_ENUM_LABEL_INPUT_DUTY_CYCLE:
-            snprintf(s, len,
-                     "Duty cycle.\n"
-                             " \n"
-                             "Describes how long the period of a turbo-enabled\n"
-                             "should be.\n"
-                             " \n"
-                             "Numbers are described in frames."
-            );
-            break;
-        case MENU_ENUM_LABEL_INPUT_TOUCH_ENABLE:
-            snprintf(s, len, "Enable touch support.");
-            break;
         case MENU_ENUM_LABEL_INPUT_PREFER_FRONT_TOUCH:
             snprintf(s, len, "Use front instead of back touch.");
-            break;
-        case MENU_ENUM_LABEL_MOUSE_ENABLE:
-            snprintf(s, len, "Enable mouse input inside the menu.");
-            break;
-        case MENU_ENUM_LABEL_POINTER_ENABLE:
-            snprintf(s, len, "Enable touch input inside the menu.");
-            break;
-        case MENU_ENUM_LABEL_MENU_WALLPAPER:
-            snprintf(s, len, "Path to an image to set as the background.");
-            break;
-        case MENU_ENUM_LABEL_NAVIGATION_WRAPAROUND:
-            snprintf(s, len,
-                     "Wrap-around to beginning and/or end \n"
-                             "if boundary of list is reached \n"
-                             "horizontally and/or vertically.");
-            break;
-        case MENU_ENUM_LABEL_PAUSE_LIBRETRO:
-            snprintf(s, len,
-                     "If disabled, the game will keep \n"
-                             "running in the background when we are in the \n"
-                             "menu.");
             break;
         case MENU_ENUM_LABEL_SUSPEND_SCREENSAVER_ENABLE:
             snprintf(s, len,
@@ -1562,13 +919,6 @@ int msg_hash_get_help_ar_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Increasing this value will increase \n"
                              "performance, but introduce more latency.");
             break;
-        case MENU_ENUM_LABEL_NETPLAY_PUBLIC_ANNOUNCE:
-            snprintf(s, len,
-                     "Whether to announce netplay games publicly. \n"
-                             " \n"
-                             "If set to false, clients must manually connect \n"
-                             "rather than using the public lobby.");
-            break;
         case MENU_ENUM_LABEL_NETPLAY_START_AS_SPECTATOR:
             snprintf(s, len,
                      "Whether to start netplay in spectator mode. \n"
@@ -1576,21 +926,6 @@ int msg_hash_get_help_ar_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "If set to true, netplay will be in spectator mode \n"
                              "on start. It's always possible to change mode \n"
                              "later.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_ALLOW_SLAVES:
-            snprintf(s, len,
-                     "Whether to allow connections in slave mode. \n"
-                             " \n"
-                             "Slave-mode clients require very little processing \n"
-                             "power on either side, but will suffer \n"
-                             "significantly from network latency.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_REQUIRE_SLAVES:
-            snprintf(s, len,
-                     "Whether to disallow connections not in slave mode. \n"
-                             " \n"
-                             "Not recommended except for very fast networks \n"
-                             "with very weak machines. \n");
             break;
         case MENU_ENUM_LABEL_NETPLAY_CHECK_FRAMES:
             snprintf(s, len,
@@ -1633,24 +968,6 @@ int msg_hash_get_help_ar_enum(enum msg_hash_enums msg, char *s, size_t len)
                      "makes netplay less CPU-intensive, but at \n"
                      "the price of unpredictable input lag. \n");
             break;
-        case MENU_ENUM_LABEL_NETPLAY_NAT_TRAVERSAL:
-            snprintf(s, len,
-                     "When hosting, attempt to listen for\n"
-                             "connections from the public internet, using\n"
-                             "UPnP or similar technologies to escape LANs. \n");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_USE_MITM_SERVER:
-            snprintf(s, len,
-                     "When hosting a netplay session, relay connection through a \n"
-                             "man-in-the-middle server \n"
-                             "to get around firewalls or NAT/UPnP issues. \n");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_MITM_SERVER:
-            snprintf(s, len,
-                     "Specifies the man-in-the-middle server \n"
-                             "to use for netplay. A server that is \n"
-                             "located closer to you may have less latency. \n");
-            break;
         case MENU_ENUM_LABEL_VIDEO_MAX_SWAPCHAIN_IMAGES:
             snprintf(s, len,
                      "Maximum amount of swapchain images. This \n"
@@ -1678,181 +995,19 @@ int msg_hash_get_help_ar_enum(enum msg_hash_enums msg, char *s, size_t len)
 #endif
          );
          break;
-        case MENU_ENUM_LABEL_TIMEDATE_ENABLE:
-            snprintf(s, len,
-                     "Shows current date and/or time inside menu.");
-            break;
-        case MENU_ENUM_LABEL_BATTERY_LEVEL_ENABLE:
-            snprintf(s, len,
-                     "Shows current battery level inside menu.");
-            break;
-        case MENU_ENUM_LABEL_CORE_ENABLE:
-            snprintf(s, len,
-                     "Shows current core inside menu.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_ENABLE_HOST:
-            snprintf(s, len,
-                     "Enables Netplay in host (server) mode.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_ENABLE_CLIENT:
-            snprintf(s, len,
-                     "Enables Netplay in client mode.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_DISCONNECT:
-            snprintf(s, len,
-                     "Disconnects an active Netplay connection.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_LAN_SCAN_SETTINGS:
-            snprintf(s, len,
-                     "Search for and connect to netplay hosts on the local network.");
-            break;
         case MENU_ENUM_LABEL_NETPLAY_SETTINGS:
             snprintf(s, len,
                      "Setting related to Netplay.");
-            break;
-        case MENU_ENUM_LABEL_DYNAMIC_WALLPAPER:
-            snprintf(s, len,
-                     "Dynamically load a new background \n"
-                             "depending on context.");
-            break;
-        case MENU_ENUM_LABEL_CORE_UPDATER_BUILDBOT_URL:
-            snprintf(s, len,
-                     "URL to core updater directory on the \n"
-                             "Libretro buildbot.");
-            break;
-        case MENU_ENUM_LABEL_BUILDBOT_ASSETS_URL:
-            snprintf(s, len,
-                     "URL to assets updater directory on the \n"
-                             "Libretro buildbot.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_REMAP_BINDS_ENABLE:
-            snprintf(s, len,
-                     "if enabled, overrides the input binds \n"
-                             "with the remapped binds set for the \n"
-                             "current core.");
-            break;
-        case MENU_ENUM_LABEL_OVERLAY_DIRECTORY:
-            snprintf(s, len,
-                     "Overlay Directory. \n"
-                             " \n"
-                             "Defines a directory where overlays are \n"
-                             "kept for easy access.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_MAX_USERS:
-            snprintf(s, len,
-                     "Maximum amount of users supported by \n"
-                             "RetroArch.");
-            break;
-        case MENU_ENUM_LABEL_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
-            snprintf(s, len,
-                     "After downloading, automatically extract \n"
-                             "archives that the downloads are contained \n"
-                             "inside.");
-            break;
-        case MENU_ENUM_LABEL_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
-            snprintf(s, len,
-                     "Filter files being shown by \n"
-                             "supported extensions.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_NICKNAME:
-            snprintf(s, len,
-                     "The username of the person running RetroArch. \n"
-                             "This will be used for playing online games.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_TCP_UDP_PORT:
-            snprintf(s, len,
-                     "The port of the host IP address. \n"
-                             "Can be either a TCP or UDP port.");
             break;
         case MENU_ENUM_LABEL_NETPLAY_SPECTATOR_MODE_ENABLE:
             snprintf(s, len,
                      "Enable or disable spectator mode for \n"
                              "the user during netplay.");
             break;
-        case MENU_ENUM_LABEL_NETPLAY_IP_ADDRESS:
-            snprintf(s, len,
-                     "The address of the host to connect to.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_PASSWORD:
-            snprintf(s, len,
-                     "The password for connecting to the netplay \n"
-                             "host. Used only in host mode.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_SPECTATE_PASSWORD:
-            snprintf(s, len,
-                     "The password for connecting to the netplay \n"
-                             "host with only spectator privileges. Used \n"
-                             "only in host mode.");
-            break;
-        case MENU_ENUM_LABEL_STDIN_CMD_ENABLE:
-            snprintf(s, len,
-                     "Enable stdin command interface.");
-            break;
         case MENU_ENUM_LABEL_UI_COMPANION_START_ON_BOOT:
             snprintf(s, len,
                      "Start User Interface companion driver \n"
                              "on boot (if available).");
-            break;
-        case MENU_ENUM_LABEL_MENU_DRIVER:
-            snprintf(s, len, "Menu driver to use.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
-            snprintf(s, len,
-                     "Gamepad button combination to toggle menu. \n"
-                             " \n"
-                             "0 - None \n"
-                             "1 - Press L + R + Y + D-Pad Down \n"
-                             "simultaneously. \n"
-                             "2 - Press L3 + R3 simultaneously. \n"
-                             "3 - Press Start + Select simultaneously.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_ALL_USERS_CONTROL_MENU:
-            snprintf(s, len, "Allows any user to control the menu. \n"
-                    " \n"
-                    "When disabled, only user 1 can control the menu.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_AUTODETECT_ENABLE:
-            snprintf(s, len,
-                     "Enable input auto-detection.\n"
-                             " \n"
-                             "Will attempt to auto-configure \n"
-                             "joypads, Plug-and-Play style.");
-            break;
-        case MENU_ENUM_LABEL_CAMERA_ALLOW:
-            snprintf(s, len,
-                     "Allow or disallow camera access by \n"
-                             "cores.");
-            break;
-        case MENU_ENUM_LABEL_LOCATION_ALLOW:
-            snprintf(s, len,
-                     "Allow or disallow location services \n"
-                             "access by cores.");
-            break;
-        case MENU_ENUM_LABEL_TURBO:
-            snprintf(s, len,
-                     "Turbo enable.\n"
-                             " \n"
-                             "Holding the turbo while pressing another \n"
-                             "button will let the button enter a turbo \n"
-                             "mode where the button state is modulated \n"
-                             "with a periodic signal. \n"
-                             " \n"
-                             "The modulation stops when the button \n"
-                             "itself (not turbo button) is released.");
-            break;
-        case MENU_ENUM_LABEL_OSK_ENABLE:
-            snprintf(s, len,
-                     "Enable/disable on-screen keyboard.");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_MUTE:
-            snprintf(s, len,
-                     "Mute/unmute audio.");
-            break;
-        case MENU_ENUM_LABEL_REWIND:
-            snprintf(s, len,
-                     "Hold button down to rewind.\n"
-                             " \n"
-                             "Rewind must be enabled.");
             break;
         case MENU_ENUM_LABEL_EXIT_EMULATOR:
             snprintf(s, len,
@@ -1865,80 +1020,6 @@ int msg_hash_get_help_ar_enum(enum msg_hash_enums msg, char *s, size_t len)
                             "a clean deinitialization."
 #endif
             );
-            break;
-        case MENU_ENUM_LABEL_LOAD_STATE:
-            snprintf(s, len,
-                     "Loads state.");
-            break;
-        case MENU_ENUM_LABEL_SAVE_STATE:
-            snprintf(s, len,
-                     "Saves state.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_GAME_WATCH:
-            snprintf(s, len,
-                     "Netplay toggle play/spectate mode.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_INDEX_PLUS:
-            snprintf(s, len,
-                     "Increment cheat index.\n");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_INDEX_MINUS:
-            snprintf(s, len,
-                     "Decrement cheat index.\n");
-            break;
-        case MENU_ENUM_LABEL_SHADER_PREV:
-            snprintf(s, len,
-                     "Applies previous shader in directory.");
-            break;
-        case MENU_ENUM_LABEL_SHADER_NEXT:
-            snprintf(s, len,
-                     "Applies next shader in directory.");
-            break;
-        case MENU_ENUM_LABEL_RESET:
-            snprintf(s, len,
-                     "Reset the content.\n");
-            break;
-        case MENU_ENUM_LABEL_PAUSE_TOGGLE:
-            snprintf(s, len,
-                     "Toggle between paused and non-paused state.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_TOGGLE:
-            snprintf(s, len,
-                     "Toggle cheat index.\n");
-            break;
-        case MENU_ENUM_LABEL_HOLD_FAST_FORWARD:
-            snprintf(s, len,
-                     "Hold for fast-forward. Releasing button \n"
-                             "disables fast-forward.");
-            break;
-        case MENU_ENUM_LABEL_SLOWMOTION_HOLD:
-            snprintf(s, len,
-                     "Hold for slowmotion.");
-            break;
-        case MENU_ENUM_LABEL_FRAME_ADVANCE:
-            snprintf(s, len,
-                     "Frame advance when content is paused.");
-            break;
-        case MENU_ENUM_LABEL_BSV_RECORD_TOGGLE:
-            snprintf(s, len,
-                     "Toggle between recording and not.");
-            break;
-        case MENU_ENUM_LABEL_L_X_PLUS:
-        case MENU_ENUM_LABEL_L_X_MINUS:
-        case MENU_ENUM_LABEL_L_Y_PLUS:
-        case MENU_ENUM_LABEL_L_Y_MINUS:
-        case MENU_ENUM_LABEL_R_X_PLUS:
-        case MENU_ENUM_LABEL_R_X_MINUS:
-        case MENU_ENUM_LABEL_R_Y_PLUS:
-        case MENU_ENUM_LABEL_R_Y_MINUS:
-            snprintf(s, len,
-                     "Axis for analog stick (DualShock-esque).\n"
-                             " \n"
-                             "Bound as usual, however, if a real analog \n"
-                             "axis is bound, it can be read as a true analog.\n"
-                             " \n"
-                             "Positive X axis is right. \n"
-                             "Positive Y axis is down.");
             break;
         case MENU_ENUM_LABEL_VALUE_WHAT_IS_A_CORE_DESC:
             snprintf(s, len,
@@ -1987,35 +1068,35 @@ int msg_hash_get_help_ar_enum(enum msg_hash_enums msg, char *s, size_t len)
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_HIDE_IN_MENU)
             );
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_ENABLE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_ENABLE:
             snprintf(s, len,
                      "Enables a background color for the OSD.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_RED:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_RED:
             snprintf(s, len,
                      "Sets the red value of the OSD background color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_GREEN:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_GREEN:
             snprintf(s, len,
                      "Sets the green value of the OSD background color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_BLUE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_BLUE:
             snprintf(s, len,
                      "Sets the blue value of the OSD background color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_OPACITY:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_OPACITY:
             snprintf(s, len,
                      "Sets the opacity of the OSD background color. Valid values are between 0.0 and 1.0.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_RED:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_RED:
             snprintf(s, len,
                      "Sets the red value of the OSD text color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_GREEN:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_GREEN:
             snprintf(s, len,
                      "Sets the green value of the OSD text color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_BLUE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_BLUE:
             snprintf(s, len,
                      "Sets the blue value of the OSD text color. Valid values are between 0 and 255.");
             break;

--- a/intl/msg_hash_cs.c
+++ b/intl/msg_hash_cs.c
@@ -47,153 +47,6 @@ int msg_hash_get_help_cs_enum(enum msg_hash_enums msg, char *s, size_t len)
 
        switch (idx)
        {
-          case RARCH_FAST_FORWARD_KEY:
-             snprintf(s, len,
-                   "Toggles between fast-forwarding and \n"
-                   "normal speed."
-                   );
-             break;
-          case RARCH_FAST_FORWARD_HOLD_KEY:
-             snprintf(s, len,
-                   "Hold for fast-forward. \n"
-                   " \n"
-                   "Releasing button disables fast-forward."
-                   );
-             break;
-          case RARCH_SLOWMOTION_KEY:
-             snprintf(s, len,
-                   "Toggles slowmotion.");
-             break;
-          case RARCH_SLOWMOTION_HOLD_KEY:
-             snprintf(s, len,
-                   "Hold for slowmotion.");
-             break;
-          case RARCH_PAUSE_TOGGLE:
-             snprintf(s, len,
-                   "Toggle between paused and non-paused state.");
-             break;
-          case RARCH_FRAMEADVANCE:
-             snprintf(s, len,
-                   "Frame advance when content is paused.");
-             break;
-          case RARCH_SHADER_NEXT:
-             snprintf(s, len,
-                   "Applies next shader in directory.");
-             break;
-          case RARCH_SHADER_PREV:
-             snprintf(s, len,
-                   "Applies previous shader in directory.");
-             break;
-          case RARCH_CHEAT_INDEX_PLUS:
-          case RARCH_CHEAT_INDEX_MINUS:
-          case RARCH_CHEAT_TOGGLE:
-             snprintf(s, len,
-                   "Cheats.");
-             break;
-          case RARCH_RESET:
-             snprintf(s, len,
-                   "Reset the content.");
-             break;
-          case RARCH_SCREENSHOT:
-             snprintf(s, len,
-                   "Take screenshot.");
-             break;
-          case RARCH_MUTE:
-             snprintf(s, len,
-                   "Mute/unmute audio.");
-             break;
-          case RARCH_OSK:
-             snprintf(s, len,
-                   "Toggles onscreen keyboard.");
-             break;
-          case RARCH_FPS_TOGGLE:
-             snprintf(s, len,
-                   "Toggles frames per second counter.");
-             break;
-          case RARCH_STATISTICS_TOGGLE:
-             snprintf(s, len,
-                   "Toggles display of technical statistics.");
-             break;
-          case RARCH_SEND_DEBUG_INFO:
-             snprintf(s, len,
-                   "Sends diagnostic info about your device and RetroArch configuration to our servers for analysis.");
-             break;
-          case RARCH_NETPLAY_HOST_TOGGLE:
-             snprintf(s, len,
-                   "Toggles netplay hosting on/off.");
-             break;
-          case RARCH_NETPLAY_GAME_WATCH:
-             snprintf(s, len,
-                   "Netplay toggle play/spectate mode.");
-             break;
-          case RARCH_ENABLE_HOTKEY:
-             snprintf(s, len,
-                   "Enable other hotkeys. \n"
-                   " \n"
-                   "If this hotkey is bound to either\n"
-                   "a keyboard, joybutton or joyaxis, \n"
-                   "all other hotkeys will be enabled only \n"
-                   "if this one is held at the same time. \n"
-                   " \n"
-                   "Alternatively, all hotkeys for keyboard \n"
-                   "could be disabled by the user.");
-             break;
-          case RARCH_VOLUME_UP:
-             snprintf(s, len,
-                   "Increases audio volume.");
-             break;
-          case RARCH_VOLUME_DOWN:
-             snprintf(s, len,
-                   "Decreases audio volume.");
-             break;
-          case RARCH_OVERLAY_NEXT:
-             snprintf(s, len,
-                   "Switches to next overlay. Wraps around.");
-             break;
-          case RARCH_DISK_EJECT_TOGGLE:
-             snprintf(s, len,
-                   "Toggles eject for disks. \n"
-                   " \n"
-                   "Used for multiple-disk content.");
-             break;
-          case RARCH_DISK_NEXT:
-          case RARCH_DISK_PREV:
-             snprintf(s, len,
-                   "Cycles through disk images. Use after ejecting. \n"
-                   " \n"
-                   "Complete by toggling eject again.");
-             break;
-          case RARCH_GRAB_MOUSE_TOGGLE:
-             snprintf(s, len,
-                   "Toggles mouse grab. \n"
-                   " \n"
-                   "When mouse is grabbed, RetroArch hides the \n"
-                   "mouse, and keeps the mouse pointer inside \n"
-                   "the window to allow relative mouse input to \n"
-                   "work better.");
-             break;
-          case RARCH_GAME_FOCUS_TOGGLE:
-             snprintf(s, len,
-                   "Toggles game focus.\n"
-                   " \n"
-                   "When a game has focus, RetroArch will both disable \n"
-                   "hotkeys and keep/wrap the mouse pointer inside the window.");
-             break;
-          case RARCH_MENU_TOGGLE:
-             snprintf(s, len, "Toggles menu.");
-             break;
-          case RARCH_LOAD_STATE_KEY:
-             snprintf(s, len,
-                   "Loads state.");
-             break;
-          case RARCH_FULLSCREEN_TOGGLE_KEY:
-             snprintf(s, len,
-                   "Toggles fullscreen.");
-             break;
-          case RARCH_CLOSE_CONTENT_KEY:
-             snprintf(s, len,
-                   "Closes content.");
-             break;
           case RARCH_QUIT_KEY:
              snprintf(s, len,
                    "Key to exit RetroArch cleanly. \n"
@@ -217,24 +70,6 @@ int msg_hash_get_help_cs_enum(enum msg_hash_enums msg, char *s, size_t len)
                    "When slot is not 0, path will be <path><d>, \n"
                    "where <d> is slot number.");
              break;
-          case RARCH_SAVE_STATE_KEY:
-             snprintf(s, len,
-                   "Saves state.");
-             break;
-          case RARCH_REWIND:
-             snprintf(s, len,
-                   "Hold button down to rewind. \n"
-                   " \n"
-                   "Rewinding must be enabled.");
-             break;
-          case RARCH_BSV_RECORD_TOGGLE:
-             snprintf(s, len,
-                   "Toggle between recording and not.");
-             break;
-          case RARCH_RUNAHEAD_TOGGLE:
-             snprintf(s, len,
-                   "Toggles Run-Ahead mode on/off.");
-             break;
           default:
              if (string_is_empty(s))
                 strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE), len);
@@ -257,12 +92,6 @@ int msg_hash_get_help_cs_enum(enum msg_hash_enums msg, char *s, size_t len)
                     "to input the username and password into \n"
                     "RetroArch.");
             break;
-        case MENU_ENUM_LABEL_CHEEVOS_USERNAME:
-            snprintf(s, len, "Username for your Retro Achievements account.");
-            break;
-        case MENU_ENUM_LABEL_CHEEVOS_PASSWORD:
-            snprintf(s, len, "Password for your Retro Achievements account.");
-            break;
         case MENU_ENUM_LABEL_USER_LANGUAGE:
             snprintf(s, len, "Localizes the menu and all onscreen messages \n"
                     "according to the language you have selected \n"
@@ -276,74 +105,6 @@ int msg_hash_get_help_cs_enum(enum msg_hash_enums msg, char *s, size_t len)
                     " \n"
                     "In case a language is not implemented, \n"
                     "we fallback to English.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FONT_PATH:
-            snprintf(s, len, "Change the font that is used \n"
-                    "for the Onscreen Display text.");
-            break;
-        case MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS:
-            snprintf(s, len, "Automatically load content-specific core options.");
-            break;
-        case MENU_ENUM_LABEL_AUTO_OVERRIDES_ENABLE:
-            snprintf(s, len, "Automatically load override configurations.");
-            break;
-        case MENU_ENUM_LABEL_AUTO_REMAPS_ENABLE:
-            snprintf(s, len, "Automatically load input remapping files.");
-            break;
-        case MENU_ENUM_LABEL_SORT_SAVESTATES_ENABLE:
-            snprintf(s, len, "Sort save states in folders \n"
-                    "named after the libretro core used.");
-            break;
-        case MENU_ENUM_LABEL_SORT_SAVEFILES_ENABLE:
-            snprintf(s, len, "Sort save files in folders \n"
-                    "named after the libretro core used.");
-            break;
-        case MENU_ENUM_LABEL_SORT_SAVESTATES_BY_CONTENT_ENABLE:
-            snprintf(s, len, "Sort save states in folders named \n"
-                   "after the folder in which the content lives.");
-            break;
-        case MENU_ENUM_LABEL_SORT_SAVEFILES_BY_CONTENT_ENABLE:
-            snprintf(s, len, "Sort save files in folders named \n"
-                  "after the folder in which the content lives.");
-            break;
-        case MENU_ENUM_LABEL_SORT_SCREENSHOTS_BY_CONTENT_ENABLE:
-            snprintf(s, len, "Sort screenshots in folders named \n"
-                  "after the folder in which the content lives.");
-            break;
-        case MENU_ENUM_LABEL_RESUME_CONTENT:
-            snprintf(s, len, "Exits from the menu and returns back \n"
-                    "to the content.");
-            break;
-        case MENU_ENUM_LABEL_RESTART_CONTENT:
-            snprintf(s, len, "Restarts the content from the beginning.");
-            break;
-        case MENU_ENUM_LABEL_CLOSE_CONTENT:
-            snprintf(s, len, "Closes the content and unloads it from \n"
-                    "memory.");
-            break;
-        case MENU_ENUM_LABEL_UNDO_LOAD_STATE:
-            snprintf(s, len, "If a state was loaded, content will \n"
-                    "go back to the state prior to loading.");
-            break;
-        case MENU_ENUM_LABEL_UNDO_SAVE_STATE:
-            snprintf(s, len, "If a state was overwritten, it will \n"
-                    "roll back to the previous save state.");
-            break;
-        case MENU_ENUM_LABEL_TAKE_SCREENSHOT:
-            snprintf(s, len, "Create a screenshot. \n"
-                    " \n"
-                    "The screenshot will be stored inside the \n"
-                    "Screenshot Directory.");
-            break;
-        case MENU_ENUM_LABEL_ADD_TO_FAVORITES:
-            snprintf(s, len, "Add the entry to your Favorites.");
-            break;
-        case MENU_ENUM_LABEL_RUN:
-            snprintf(s, len, "Start the content.");
-            break;
-        case MENU_ENUM_LABEL_INFORMATION:
-            snprintf(s, len, "Show additional metadata information \n"
-                    "about the content.");
             break;
         case MENU_ENUM_LABEL_FILE_BROWSER_CONFIG:
             snprintf(s, len, "Configuration file.");
@@ -368,68 +129,6 @@ int msg_hash_get_help_cs_enum(enum msg_hash_enums msg, char *s, size_t len)
         case MENU_ENUM_LABEL_USE_THIS_DIRECTORY:
             snprintf(s, len,
                      "Select this to set this as the directory.");
-            break;
-        case MENU_ENUM_LABEL_CONTENT_DATABASE_DIRECTORY:
-            snprintf(s, len,
-                     "Content Database Directory. \n"
-                             " \n"
-                             "Path to content database \n"
-                             "directory.");
-            break;
-        case MENU_ENUM_LABEL_THUMBNAILS_DIRECTORY:
-            snprintf(s, len,
-                     "Thumbnails Directory. \n"
-                             " \n"
-                             "To store thumbnail files.");
-            break;
-        case MENU_ENUM_LABEL_LIBRETRO_INFO_PATH:
-            snprintf(s, len,
-                     "Core Info Directory. \n"
-                             " \n"
-                             "A directory for where to search \n"
-                             "for libretro core information.");
-            break;
-        case MENU_ENUM_LABEL_PLAYLIST_DIRECTORY:
-            snprintf(s, len,
-                     "Playlist Directory. \n"
-                             " \n"
-                             "Save all playlist files to this \n"
-                             "directory.");
-            break;
-        case MENU_ENUM_LABEL_CONTENT_FAVORITES_DIRECTORY:
-            snprintf(s, len,
-                     "Favorites Playlist Directory. \n"
-                             " \n"
-                             "Save the favorites playlist to this \n"
-                             "directory.");
-            break;
-        case MENU_ENUM_LABEL_CONTENT_HISTORY_DIRECTORY:
-            snprintf(s, len,
-                     "History Playlist Directory. \n"
-                             " \n"
-                             "Save the history playlist to this \n"
-                             "directory.");
-            break;
-        case MENU_ENUM_LABEL_CONTENT_IMAGE_HISTORY_DIRECTORY:
-            snprintf(s, len,
-                     "Images Playlist Directory. \n"
-                             " \n"
-                             "Save the images playlist to this \n"
-                             "directory.");
-            break;
-        case MENU_ENUM_LABEL_CONTENT_MUSIC_HISTORY_DIRECTORY:
-            snprintf(s, len,
-                     "Music Playlist Directory. \n"
-                             " \n"
-                             "Save the music playlist to this \n"
-                             "directory.");
-            break;
-        case MENU_ENUM_LABEL_CONTENT_VIDEO_HISTORY_DIRECTORY:
-            snprintf(s, len,
-                     "Videos Playlist Directory. \n"
-                             " \n"
-                             "Save the videos playlist to this \n"
-                             "directory.");
             break;
         case MENU_ENUM_LABEL_DUMMY_ON_CORE_SHUTDOWN:
             snprintf(s, len,
@@ -464,11 +163,6 @@ int msg_hash_get_help_cs_enum(enum msg_hash_enums msg, char *s, size_t len)
                      "Open Windows permission settings to enable \n"
                      "the broadFileSystemAccess capability.");
             break;
-        case MENU_ENUM_LABEL_FILE_BROWSER_OPEN_PICKER:
-           snprintf(s, len,
-                     "Open the system file picker to access \n"
-                     "additional directories.");
-           break;
         case MENU_ENUM_LABEL_FILE_BROWSER_SHADER_PRESET:
             snprintf(s, len,
                      "Shader preset file.");
@@ -552,18 +246,6 @@ int msg_hash_get_help_cs_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Content decompressed by RetroArch will be \n"
                              "temporarily extracted to this directory.");
             break;
-        case MENU_ENUM_LABEL_HISTORY_LIST_ENABLE:
-            snprintf(s, len,
-                     "If enabled, every content loaded \n"
-                             "in RetroArch will be automatically \n"
-                             "added to the recent history list.");
-            break;
-        case MENU_ENUM_LABEL_RGUI_BROWSER_DIRECTORY:
-            snprintf(s, len,
-                     "File Browser Directory. \n"
-                             " \n"
-                             "Sets start directory for menu file browser.");
-            break;
         case MENU_ENUM_LABEL_INPUT_POLL_TYPE_BEHAVIOR:
             snprintf(s, len,
                      "Influence how input polling is done inside \n"
@@ -581,150 +263,11 @@ int msg_hash_get_help_cs_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "depending on your configuration.\n\n"
                              "Will be ignored when using netplay.");
             break;
-        case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_HIDE_UNBOUND:
-            snprintf(s, len,
-                     "Hide input descriptors that were not set \n"
-                             "by the core.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE:
-            snprintf(s, len,
-                     "Video refresh rate of your monitor. \n"
-                             "Used to calculate a suitable audio input rate.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FORCE_SRGB_DISABLE:
-            snprintf(s, len,
-                     "Forcibly disable sRGB FBO support. Some Intel \n"
-                             "OpenGL drivers on Windows have video problems \n"
-                             "with sRGB FBO support enabled.");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_ENABLE:
-            snprintf(s, len,
-                     "Enable audio output.");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_SYNC:
-            snprintf(s, len,
-                     "Synchronize audio (recommended).");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_LATENCY:
-            snprintf(s, len,
-                     "Desired audio latency in milliseconds. \n"
-                             "Might not be honored if the audio driver \n"
-                             "can't provide given latency.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_ALLOW_ROTATE:
-            snprintf(s, len,
-                     "Allow cores to set rotation. If false, \n"
-                             "rotation requests are honored, but ignored.\n\n"
-                             "Used for setups where one manually rotates \n"
-                             "the monitor.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_LABEL_SHOW:
-            snprintf(s, len,
-                     "Show the input descriptors set by the core \n"
-                             "instead of the default ones.");
-            break;
-        case MENU_ENUM_LABEL_CONTENT_HISTORY_SIZE:
-            snprintf(s, len,
-                     "Number of entries that will be kept in \n"
-                             "content history playlist.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_WINDOWED_FULLSCREEN:
-            snprintf(s, len,
-                     "To use windowed mode or not when going \n"
-                             "fullscreen.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FONT_SIZE:
-            snprintf(s, len,
-                     "Font size for on-screen messages.");
-            break;
-        case MENU_ENUM_LABEL_SAVESTATE_AUTO_INDEX:
-            snprintf(s, len,
-                     "Automatically increment slot index on each save, \n"
-                             "generating multiple savestate files. \n"
-                             "When the content is loaded, state slot will be \n"
-                             "set to the highest existing value (last savestate).");
-            break;
-        case MENU_ENUM_LABEL_FPS_SHOW:
-            snprintf(s, len,
-                     "Enables displaying the current frames \n"
-                             "per second.");
-            break;
-        case MENU_ENUM_LABEL_MEMORY_SHOW:
-            snprintf(s, len,
-                     "Includes displaying the current memory \n"
-                             "usage/total with FPS/Frames.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FONT_ENABLE:
-            snprintf(s, len,
-                     "Show and/or hide onscreen messages.");
-            break;
         case MENU_ENUM_LABEL_VIDEO_MESSAGE_POS_X:
         case MENU_ENUM_LABEL_VIDEO_MESSAGE_POS_Y:
             snprintf(s, len,
                      "Offset for where messages will be placed \n"
                              "onscreen. Values are in range [0.0, 1.0].");
-            break;
-        case MENU_ENUM_LABEL_INPUT_OVERLAY_ENABLE:
-            snprintf(s, len,
-                     "Enable or disable the current overlay.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_OVERLAY_HIDE_IN_MENU:
-            snprintf(s, len,
-                     "Hide the current overlay from appearing \n"
-                             "inside the menu.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_OVERLAY_SHOW_PHYSICAL_INPUTS:
-            snprintf(s, len,
-                      "Show keyboard/controller button presses on \n"
-                            "the onscreen overlay.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_OVERLAY_SHOW_PHYSICAL_INPUTS_PORT:
-            snprintf(s, len,
-                      "Select the port to listen for controller input \n"
-                            "to display on the onscreen overlay.");
-            break;
-        case MENU_ENUM_LABEL_OVERLAY_PRESET:
-            snprintf(s, len,
-                     "Path to input overlay.");
-            break;
-        case MENU_ENUM_LABEL_OVERLAY_OPACITY:
-            snprintf(s, len,
-                     "Overlay opacity.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_LAYOUT_ENABLE:
-            snprintf(s, len,
-                     "Enable or disable the current video layout.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_LAYOUT_PATH:
-            snprintf(s, len,
-                     "Path to video layout.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_LAYOUT_SELECTED_VIEW:
-            snprintf(s, len,
-                     "Layouts can contain multiple views. \n"
-                     "Select a view.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_BIND_TIMEOUT:
-            snprintf(s, len,
-                     "Input bind timer timeout (in seconds). \n"
-                             "Amount of seconds to wait until proceeding \n"
-                             "to the next bind.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_BIND_HOLD:
-            snprintf(s, len,
-               "Input bind hold time (in seconds). \n"
-               "Amount of seconds to hold an input to bind it.");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_OUTPUT_RATE:
-            snprintf(s, len,
-                     "Audio output samplerate.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SHARED_CONTEXT:
-            snprintf(s, len,
-                     "Set to true if hardware-rendered cores \n"
-                             "should get their private context. \n"
-                             "Avoids having to assume hardware state changes \n"
-                             "inbetween frames.");
             break;
         case MENU_ENUM_LABEL_CORE_LIST:
             snprintf(s, len,
@@ -965,12 +508,6 @@ int msg_hash_get_help_cs_enum(enum msg_hash_enums msg, char *s, size_t len)
                }
             }
             break;
-        case MENU_ENUM_LABEL_AUDIO_DSP_PLUGIN:
-            snprintf(s, len,
-                     "Audio DSP plugin.\n"
-                             " Processes audio before it's sent to \n"
-                             "the driver.");
-            break;
         case MENU_ENUM_LABEL_AUDIO_RESAMPLER_DRIVER:
             {
                const char *lbl = settings ? settings->arrays.audio_resampler : NULL;
@@ -987,12 +524,6 @@ int msg_hash_get_help_cs_enum(enum msg_hash_enums msg, char *s, size_t len)
                   strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE), len);
             }
             break;
-
-		case MENU_ENUM_LABEL_CRT_SWITCH_RESOLUTION: snprintf(s, len, "SET CRT");
-			break;
-
-		case MENU_ENUM_LABEL_CRT_SWITCH_RESOLUTION_SUPER: snprintf(s, len, "SET CRT SUPER");
-			break;
 
         case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET:
             snprintf(s, len,
@@ -1039,19 +570,6 @@ int msg_hash_get_help_cs_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "The Default Filter option will affect the \n"
                              "stretching filter.");
             break;
-        case MENU_ENUM_LABEL_VIDEO_SHADER_PARAMETERS:
-            snprintf(s, len,
-                     "Shader Parameters. \n"
-                             " \n"
-                             "Modifies current shader directly. Will not be \n"
-                             "saved to CGP/GLSLP preset file.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_PARAMETERS:
-            snprintf(s, len,
-                     "Shader Preset Parameters. \n"
-                             " \n"
-                             "Modifies shader preset currently in menu.");
-            break;
         case MENU_ENUM_LABEL_VIDEO_SHADER_PASS:
             snprintf(s, len,
                      "Path to shader. \n"
@@ -1089,13 +607,6 @@ int msg_hash_get_help_cs_enum(enum msg_hash_enums msg, char *s, size_t len)
             "manually isn't really an option."
 #endif
             );
-            break;
-        case MENU_ENUM_LABEL_CONFIRM_ON_EXIT:
-            snprintf(s, len, "Are you sure you want to quit?");
-            break;
-        case MENU_ENUM_LABEL_SHOW_HIDDEN_FILES:
-            snprintf(s, len, "Show hidden files\n"
-                    "and folders.");
             break;
         case MENU_ENUM_LABEL_VIDEO_SHADER_FILTER_PASS:
             snprintf(s, len,
@@ -1174,26 +685,6 @@ int msg_hash_get_help_cs_enum(enum msg_hash_enums msg, char *s, size_t len)
                      "it will automatically be recompiled \n"
                      "and applied to the running content.");
             break;
-        case MENU_ENUM_LABEL_MENU_TOGGLE:
-            snprintf(s, len,
-                     "Toggles menu.");
-            break;
-        case MENU_ENUM_LABEL_GRAB_MOUSE_TOGGLE:
-            snprintf(s, len,
-                     "Toggles mouse grab.\n"
-                             " \n"
-                             "When mouse is grabbed, RetroArch hides the \n"
-                             "mouse, and keeps the mouse pointer inside \n"
-                             "the window to allow relative mouse input to \n"
-                             "work better.");
-            break;
-        case MENU_ENUM_LABEL_GAME_FOCUS_TOGGLE:
-            snprintf(s, len,
-                     "Toggles game focus.\n"
-                             " \n"
-                             "When a game has focus, RetroArch will both disable \n"
-                             "hotkeys and keep/wrap the mouse pointer inside the window.");
-            break;
         case MENU_ENUM_LABEL_DISK_NEXT:
             snprintf(s, len,
                      "Cycles through disk images. Use after \n"
@@ -1237,12 +728,6 @@ int msg_hash_get_help_cs_enum(enum msg_hash_enums msg, char *s, size_t len)
 #endif
             );
             break;
-        case MENU_ENUM_LABEL_DISK_EJECT_TOGGLE:
-            snprintf(s, len,
-                     "Toggles eject for disks.\n"
-                             " \n"
-                             "Used for multiple-disk content.");
-            break;
         case MENU_ENUM_LABEL_ENABLE_HOTKEY:
             snprintf(s, len,
                      "Enable other hotkeys.\n"
@@ -1256,28 +741,6 @@ int msg_hash_get_help_cs_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "implementations which query a large area of \n"
                              "the keyboard, where it is not desirable that \n"
                              "hotkeys get in the way.");
-            break;
-        case MENU_ENUM_LABEL_REWIND_ENABLE:
-            snprintf(s, len,
-                     "Enable rewinding.\n"
-                             " \n"
-                             "This will take a performance hit, \n"
-                             "so it is disabled by default.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_APPLY_AFTER_TOGGLE:
-            snprintf(s, len,
-                     "Apply cheat immediately after toggling.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_APPLY_AFTER_LOAD:
-            snprintf(s, len,
-                     "Auto-apply cheats when game loads.");
-            break;
-        case MENU_ENUM_LABEL_LIBRETRO_DIR_PATH:
-            snprintf(s, len,
-                     "Core Directory. \n"
-                             " \n"
-                             "A directory for where to search for \n"
-                             "libretro core implementations.");
             break;
         case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE_AUTO:
             snprintf(s, len,
@@ -1298,59 +761,6 @@ int msg_hash_get_help_cs_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "large pitch changes. If your monitor does \n"
                              "not run at 60Hz, or something close to it, \n"
                              "disable VSync, and leave this at its default.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE_POLLED:
-            snprintf(s, len,
-                     "Set Polled Refresh Rate\n"
-                             " \n"
-                            "Sets the refresh rate to the actual value\n"
-                            "polled from the display driver.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_ROTATION:
-            snprintf(s, len,
-                     "Forces a certain rotation \n"
-                             "of the screen.\n"
-                             " \n"
-                             "The rotation is added to rotations which\n"
-                             "the libretro core sets (see Video Allow\n"
-                             "Rotate).");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SCALE:
-            snprintf(s, len,
-                     "Fullscreen resolution.\n"
-                             " \n"
-                             "Resolution of 0 uses the \n"
-                             "resolution of the environment.\n");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_HDR_ENABLE:
-            snprintf(s, len,
-                     "Enable HDR.\n"
-                             " \n"
-                             "If supported this enables hdr \n");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_HDR_MAX_NITS:
-            snprintf(s, len,
-                     "Peak Luminance\n"
-                             " \n"
-                             "Set the peak luminance (in cd/m2) your display can reproduce - see RTings for your models peak luminance\n");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_HDR_PAPER_WHITE_NITS:
-            snprintf(s, len,
-                     "Paper White Luminance\n"
-                             " \n"
-                             "Set the luminance at which paper white should be ie readable text or luminance at the top of the SDR range\n");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_HDR_CONTRAST:
-            snprintf(s, len,
-                     "Contrast\n"
-                             " \n"
-                             "The constrast setting for HDR\n");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_HDR_EXPAND_GAMUT:
-            snprintf(s, len,
-                     "Expand Gamut\n"
-                             " \n"
-                             "Once converted to linear space should we use an expanded colour gamut to get to HDR10\n");
             break;
         case MENU_ENUM_LABEL_FASTFORWARD_RATIO:
             snprintf(s, len,
@@ -1384,30 +794,6 @@ int msg_hash_get_help_cs_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "is preferred, 1 and up (1 being first \n"
                              "monitor), suggests RetroArch to use that \n"
                              "particular monitor.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_CROP_OVERSCAN:
-            snprintf(s, len,
-                     "Forces cropping of overscanned \n"
-                             "frames.\n"
-                             " \n"
-                             "Exact behavior of this option is \n"
-                             "core-implementation specific.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SCALE_INTEGER:
-            snprintf(s, len,
-                     "Only scales video in integer \n"
-                             "steps.\n"
-                             " \n"
-                             "The base size depends on system-reported \n"
-                             "geometry and aspect ratio.\n"
-                             " \n"
-                             "If 'Force Aspect Ratio' is not set, X/Y will be \n"
-                             "integer scaled independently.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SCALE_INTEGER_OVERSCALE:
-            snprintf(s, len,
-                     "Force integer scaling to round up \n"
-                             " to the next larger integer instead of rounding down.");
             break;
         case MENU_ENUM_LABEL_AUDIO_VOLUME:
             snprintf(s, len,
@@ -1444,53 +830,10 @@ int msg_hash_get_help_cs_enum(enum msg_hash_enums msg, char *s, size_t len)
                              " Input rate is defined as: \n"
                              " input rate * (1.0 +/- (max timing skew))");
             break;
-        case MENU_ENUM_LABEL_OVERLAY_NEXT:
-            snprintf(s, len,
-                     "Toggles to next overlay.\n"
-                             " \n"
-                             "Wraps around.");
-            break;
-        case MENU_ENUM_LABEL_LOG_VERBOSITY:
-            snprintf(s, len,
-                     "Enable or disable verbosity level \n"
-                             "of frontend.");
-            break;
-        case MENU_ENUM_LABEL_VOLUME_UP:
-            snprintf(s, len,
-                     "Increases audio volume.");
-            break;
-        case MENU_ENUM_LABEL_VOLUME_DOWN:
-            snprintf(s, len,
-                     "Decreases audio volume.");
-            break;
         case MENU_ENUM_LABEL_VIDEO_DISABLE_COMPOSITION:
             snprintf(s, len,
                      "Forcibly disable composition.\n"
                              "Only valid on Windows Vista/7 for now.");
-            break;
-        case MENU_ENUM_LABEL_PERFCNT_ENABLE:
-            snprintf(s, len,
-                     "Enable or disable frontend \n"
-                             "performance counters.");
-            break;
-        case MENU_ENUM_LABEL_SYSTEM_DIRECTORY:
-            snprintf(s, len,
-                     "System Directory. \n"
-                             " \n"
-                             "Sets the 'system' directory.\n"
-                             "Cores can query for this\n"
-                             "directory to load BIOSes, \n"
-                             "system-specific configs, etc.");
-            break;
-        case MENU_ENUM_LABEL_SAVESTATE_AUTO_SAVE:
-        case MENU_ENUM_LABEL_SAVESTATE_AUTO_LOAD:
-            snprintf(s, len,
-                     "Automatically saves a savestate at the \n"
-                             "end of RetroArch's lifetime.\n"
-                             " \n"
-                             "RetroArch will automatically load any savestate\n"
-                             "with this path on startup if 'Auto Load State\n"
-                             "is enabled.");
             break;
         case MENU_ENUM_LABEL_VIDEO_THREADED:
             snprintf(s, len,
@@ -1499,47 +842,6 @@ int msg_hash_get_help_cs_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Using this might improve performance at the \n"
                              "possible cost of latency and more video \n"
                              "stuttering.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_VSYNC:
-            snprintf(s, len,
-                     "Video V-Sync.\n");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_HARD_SYNC:
-            snprintf(s, len,
-                     "Attempts to hard-synchronize \n"
-                             "CPU and GPU.\n"
-                             " \n"
-                             "Can reduce latency at the cost of \n"
-                             "performance.");
-            break;
-        case MENU_ENUM_LABEL_REWIND_GRANULARITY:
-            snprintf(s, len,
-                     "Rewind granularity.\n"
-                             " \n"
-                             " When rewinding defined number of \n"
-                             "frames, you can rewind several frames \n"
-                             "at a time, increasing the rewinding \n"
-                             "speed.");
-            break;
-        case MENU_ENUM_LABEL_REWIND_BUFFER_SIZE:
-            snprintf(s, len,
-                     "Rewind buffer size (MB).\n"
-                             " \n"
-                             " The amount of memory in MB to reserve \n"
-                             "for rewinding.  Increasing this value \n"
-                             "increases the rewind history length.\n");
-            break;
-        case MENU_ENUM_LABEL_REWIND_BUFFER_SIZE_STEP:
-            snprintf(s, len,
-                     "Rewind buffer size step (MB).\n"
-                             " \n"
-                             " Each time you increase or decrease \n"
-                             "the rewind buffer size value via this \n"
-                             "UI it will change by this amount.\n");
-            break;
-        case MENU_ENUM_LABEL_SCREENSHOT:
-            snprintf(s, len,
-                     "Take screenshot.");
             break;
         case MENU_ENUM_LABEL_VIDEO_FRAME_DELAY:
             snprintf(s, len,
@@ -1560,14 +862,6 @@ int msg_hash_get_help_cs_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "'Frame Delay' is 0.\n"
                              " \n"
                              "E.g. 8 for NTSC and 10 for PAL.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SHADER_DELAY:
-            snprintf(s, len,
-                     "Sets by how many milliseconds auto-loading shaders\n"
-                             "are delayed.\n"
-                             "\n"
-                             "Can work around graphical glitches due to using\n"
-                             "'screen grabbing' software like streaming software.");
             break;
         case MENU_ENUM_LABEL_VIDEO_HARD_SYNC_FRAMES:
             snprintf(s, len,
@@ -1594,48 +888,6 @@ int msg_hash_get_help_cs_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "configured as if it is a 60 Hz monitor \n"
                              "(divide refresh rate by 2).");
             break;
-        case MENU_ENUM_LABEL_RGUI_SHOW_START_SCREEN:
-            snprintf(s, len,
-                     "Show startup screen in menu.\n"
-                             "Is automatically set to false when seen\n"
-                             "for the first time.\n"
-                             " \n"
-                             "This is only updated in config if\n"
-                             "'Save Configuration on Exit' is enabled.\n");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FULLSCREEN:
-            snprintf(s, len, "Toggles fullscreen.");
-            break;
-        case MENU_ENUM_LABEL_BLOCK_SRAM_OVERWRITE:
-            snprintf(s, len,
-                     "Block SRAM from being overwritten \n"
-                             "when loading save states.\n"
-                             " \n"
-                             "Might potentially lead to buggy games.");
-            break;
-        case MENU_ENUM_LABEL_PAUSE_NONACTIVE:
-            snprintf(s, len,
-                     "Pause gameplay when window focus \n"
-                             "is lost.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_GPU_SCREENSHOT:
-            snprintf(s, len,
-                     "Screenshots output of GPU shaded \n"
-                             "material if available.");
-            break;
-        case MENU_ENUM_LABEL_SCREENSHOT_DIRECTORY:
-            snprintf(s, len,
-                     "Screenshot Directory. \n"
-                             " \n"
-                             "Directory to dump screenshots to.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SWAP_INTERVAL:
-            snprintf(s, len,
-                     "VSync Swap Interval.\n"
-                             " \n"
-                             "Uses a custom swap interval for VSync. Set this \n"
-                             "to effectively halve monitor refresh rate.");
-            break;
         case MENU_ENUM_LABEL_SAVEFILE_DIRECTORY:
             snprintf(s, len,
                      "Savefile Directory. \n"
@@ -1643,16 +895,6 @@ int msg_hash_get_help_cs_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Save all save files (*.srm) to this \n"
                              "directory. This includes related files like \n"
                              ".bsv, .rt, .psrm, etc...\n"
-                             " \n"
-                             "This will be overridden by explicit command line\n"
-                             "options.");
-            break;
-        case MENU_ENUM_LABEL_SAVESTATE_DIRECTORY:
-            snprintf(s, len,
-                     "Savestate Directory. \n"
-                             " \n"
-                             "Save all save states (*.state) to this \n"
-                             "directory.\n"
                              " \n"
                              "This will be overridden by explicit command line\n"
                              "options.");
@@ -1673,77 +915,8 @@ int msg_hash_get_help_cs_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "be loaded dynamically by the menu depending \n"
                              "on context.");
             break;
-        case MENU_ENUM_LABEL_SLOWMOTION_RATIO:
-            snprintf(s, len,
-                     "Slowmotion ratio."
-                             " \n"
-                             "When slowmotion, content will slow\n"
-                             "down by factor.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_BUTTON_AXIS_THRESHOLD:
-            snprintf(s, len,
-                     "Defines the axis threshold.\n"
-                             " \n"
-                             "How far an axis must be tilted to result\n"
-                             "in a button press.\n"
-                             " Possible values are [0.0, 1.0].");
-            break;
-        case MENU_ENUM_LABEL_INPUT_TURBO_PERIOD:
-            snprintf(s, len,
-                     "Turbo period.\n"
-                             " \n"
-                             "Describes the period of which turbo-enabled\n"
-                             "buttons toggle.\n"
-                             " \n"
-                             "Numbers are described in frames.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_TURBO_MODE:
-            snprintf(s, len,
-                  "Turbo Mode.\n"
-                  " \n"
-                  "Selects the general behavior of turbo mode.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_TURBO_DEFAULT_BUTTON:
-            snprintf(s, len,
-                  "Turbo Default Button.\n"
-                  " \n"
-                  "Default active button for Turbo Mode 'Single Button'.\n");
-            break;
-        case MENU_ENUM_LABEL_INPUT_DUTY_CYCLE:
-            snprintf(s, len,
-                     "Duty cycle.\n"
-                             " \n"
-                             "Describes how long the period of a turbo-enabled\n"
-                             "should be.\n"
-                             " \n"
-                             "Numbers are described in frames.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_TOUCH_ENABLE:
-            snprintf(s, len, "Enable touch support.");
-            break;
         case MENU_ENUM_LABEL_INPUT_PREFER_FRONT_TOUCH:
             snprintf(s, len, "Use front instead of back touch.");
-            break;
-        case MENU_ENUM_LABEL_MOUSE_ENABLE:
-            snprintf(s, len, "Enable mouse input inside the menu.");
-            break;
-        case MENU_ENUM_LABEL_POINTER_ENABLE:
-            snprintf(s, len, "Enable touch input inside the menu.");
-            break;
-        case MENU_ENUM_LABEL_MENU_WALLPAPER:
-            snprintf(s, len, "Path to an image to set as the background.");
-            break;
-        case MENU_ENUM_LABEL_NAVIGATION_WRAPAROUND:
-            snprintf(s, len,
-                     "Wrap-around to beginning and/or end \n"
-                             "if boundary of list is reached \n"
-                             "horizontally and/or vertically.");
-            break;
-        case MENU_ENUM_LABEL_PAUSE_LIBRETRO:
-            snprintf(s, len,
-                     "If disabled, the game will keep \n"
-                             "running in the background when we are in the \n"
-                             "menu.");
             break;
         case MENU_ENUM_LABEL_SUSPEND_SCREENSAVER_ENABLE:
             snprintf(s, len,
@@ -1763,13 +936,6 @@ int msg_hash_get_help_cs_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Increasing this value will increase \n"
                              "performance, but introduce more latency.");
             break;
-        case MENU_ENUM_LABEL_NETPLAY_PUBLIC_ANNOUNCE:
-            snprintf(s, len,
-                     "Whether to announce netplay games publicly. \n"
-                             " \n"
-                             "If set to false, clients must manually connect \n"
-                             "rather than using the public lobby.");
-            break;
         case MENU_ENUM_LABEL_NETPLAY_START_AS_SPECTATOR:
             snprintf(s, len,
                      "Whether to start netplay in spectator mode. \n"
@@ -1777,21 +943,6 @@ int msg_hash_get_help_cs_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "If set to true, netplay will be in spectator mode \n"
                              "on start. It's always possible to change mode \n"
                              "later.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_ALLOW_SLAVES:
-            snprintf(s, len,
-                     "Whether to allow connections in slave mode. \n"
-                             " \n"
-                             "Slave-mode clients require very little processing \n"
-                             "power on either side, but will suffer \n"
-                             "significantly from network latency.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_REQUIRE_SLAVES:
-            snprintf(s, len,
-                     "Whether to disallow connections not in slave mode. \n"
-                             " \n"
-                             "Not recommended except for very fast networks \n"
-                             "with very weak machines.");
             break;
         case MENU_ENUM_LABEL_NETPLAY_CHECK_FRAMES:
             snprintf(s, len,
@@ -1834,24 +985,6 @@ int msg_hash_get_help_cs_enum(enum msg_hash_enums msg, char *s, size_t len)
                      "makes netplay less CPU-intensive, but at \n"
                      "the price of unpredictable input lag. \n");
             break;
-        case MENU_ENUM_LABEL_NETPLAY_NAT_TRAVERSAL:
-            snprintf(s, len,
-                     "When hosting, attempt to listen for\n"
-                             "connections from the public internet, using\n"
-                             "UPnP or similar technologies to escape LANs. \n");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_USE_MITM_SERVER:
-            snprintf(s, len,
-                     "When hosting a netplay session, relay connection through a \n"
-                             "man-in-the-middle server \n"
-                             "to get around firewalls or NAT/UPnP issues. \n");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_MITM_SERVER:
-            snprintf(s, len,
-                     "Specifies the man-in-the-middle server \n"
-                             "to use for netplay. A server that is \n"
-                             "located closer to you may have less latency. \n");
-            break;
         case MENU_ENUM_LABEL_VIDEO_MAX_SWAPCHAIN_IMAGES:
             snprintf(s, len,
                      "Maximum amount of swapchain images. This \n"
@@ -1879,202 +1012,19 @@ int msg_hash_get_help_cs_enum(enum msg_hash_enums msg, char *s, size_t len)
 #endif
          );
          break;
-        case MENU_ENUM_LABEL_TIMEDATE_ENABLE:
-            snprintf(s, len,
-                     "Shows current date and/or time inside menu.");
-            break;
-        case MENU_ENUM_LABEL_TIMEDATE_STYLE:
-           snprintf(s, len,
-              "Style to show the current date and/or time in.");
-           break;
-        case MENU_ENUM_LABEL_BATTERY_LEVEL_ENABLE:
-            snprintf(s, len,
-                     "Shows current battery level inside menu.");
-            break;
-        case MENU_ENUM_LABEL_CORE_ENABLE:
-            snprintf(s, len,
-                     "Shows current core inside menu.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_ENABLE_HOST:
-            snprintf(s, len,
-                     "Enables Netplay in host (server) mode.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_ENABLE_CLIENT:
-            snprintf(s, len,
-                     "Enables Netplay in client mode.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_DISCONNECT:
-            snprintf(s, len,
-                     "Disconnects an active Netplay connection.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_LAN_SCAN_SETTINGS:
-            snprintf(s, len,
-                     "Search for and connect to netplay hosts on the local network.");
-            break;
         case MENU_ENUM_LABEL_NETPLAY_SETTINGS:
             snprintf(s, len,
                      "Setting related to Netplay.");
-            break;
-        case MENU_ENUM_LABEL_DYNAMIC_WALLPAPER:
-            snprintf(s, len,
-                     "Dynamically load a new background \n"
-                             "depending on context.");
-            break;
-        case MENU_ENUM_LABEL_CORE_UPDATER_BUILDBOT_URL:
-            snprintf(s, len,
-                     "URL to core updater directory on the \n"
-                             "Libretro buildbot.");
-            break;
-        case MENU_ENUM_LABEL_BUILDBOT_ASSETS_URL:
-            snprintf(s, len,
-                     "URL to assets updater directory on the \n"
-                             "Libretro buildbot.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_REMAP_BINDS_ENABLE:
-            snprintf(s, len,
-                     "if enabled, overrides the input binds \n"
-                             "with the remapped binds set for the \n"
-                             "current core.");
-            break;
-        case MENU_ENUM_LABEL_OVERLAY_DIRECTORY:
-            snprintf(s, len,
-                     "Overlay Directory. \n"
-                             " \n"
-                             "Defines a directory where overlays are \n"
-                             "kept for easy access.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_LAYOUT_DIRECTORY:
-            snprintf(s, len,
-                     "Video Layout Directory. \n"
-                             " \n"
-                             "Defines a directory where video layouts are \n"
-                             "kept for easy access.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_MAX_USERS:
-            snprintf(s, len,
-                     "Maximum amount of users supported by \n"
-                             "RetroArch.");
-            break;
-        case MENU_ENUM_LABEL_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
-            snprintf(s, len,
-                     "After downloading, automatically extract \n"
-                             "archives that the downloads are contained \n"
-                             "inside.");
-            break;
-        case MENU_ENUM_LABEL_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
-            snprintf(s, len,
-                     "Filter files being shown by \n"
-                             "supported extensions.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_NICKNAME:
-            snprintf(s, len,
-                     "The username of the person running RetroArch. \n"
-                             "This will be used for playing online games.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_TCP_UDP_PORT:
-            snprintf(s, len,
-                     "The port of the host IP address. \n"
-                             "Can be either a TCP or UDP port.");
             break;
         case MENU_ENUM_LABEL_NETPLAY_SPECTATOR_MODE_ENABLE:
             snprintf(s, len,
                      "Enable or disable spectator mode for \n"
                              "the user during netplay.");
             break;
-        case MENU_ENUM_LABEL_NETPLAY_IP_ADDRESS:
-            snprintf(s, len,
-                     "The address of the host to connect to.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_PASSWORD:
-            snprintf(s, len,
-                     "The password for connecting to the netplay \n"
-                             "host. Used only in host mode.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_SPECTATE_PASSWORD:
-            snprintf(s, len,
-                     "The password for connecting to the netplay \n"
-                             "host with only spectator privileges. Used \n"
-                             "only in host mode.");
-            break;
-        case MENU_ENUM_LABEL_STDIN_CMD_ENABLE:
-            snprintf(s, len,
-                     "Enable stdin command interface.");
-            break;
         case MENU_ENUM_LABEL_UI_COMPANION_START_ON_BOOT:
             snprintf(s, len,
                      "Start User Interface companion driver \n"
                              "on boot (if available).");
-            break;
-        case MENU_ENUM_LABEL_MENU_DRIVER:
-            snprintf(s, len, "Menu driver to use.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
-            snprintf(s, len,
-                     "Gamepad button combination to toggle menu. \n"
-                             " \n"
-                             "0 - None \n"
-                             "1 - Press L + R + Y + D-Pad Down \n"
-                             "simultaneously. \n"
-                             "2 - Press L3 + R3 simultaneously. \n"
-                             "3 - Press Start + Select simultaneously.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_QUIT_GAMEPAD_COMBO:
-            snprintf(s, len,
-                     "Gamepad button combination to quit. \n"
-                             " \n"
-                             "0 - None \n"
-                             "1 - Press L + R + Y + D-Pad Down \n"
-                             "simultaneously. \n"
-                             "2 - Press L3 + R3 simultaneously. \n"
-                             "3 - Press Start + Select simultaneously.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_ALL_USERS_CONTROL_MENU:
-            snprintf(s, len, "Allows any user to control the menu. \n"
-                    " \n"
-                    "When disabled, only user 1 can control the menu.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_AUTODETECT_ENABLE:
-            snprintf(s, len,
-                     "Enable input auto-detection.\n"
-                             " \n"
-                             "Will attempt to auto-configure \n"
-                             "joypads, Plug-and-Play style.");
-            break;
-        case MENU_ENUM_LABEL_CAMERA_ALLOW:
-            snprintf(s, len,
-                     "Allow or disallow camera access by \n"
-                             "cores.");
-            break;
-        case MENU_ENUM_LABEL_LOCATION_ALLOW:
-            snprintf(s, len,
-                     "Allow or disallow location services \n"
-                             "access by cores.");
-            break;
-        case MENU_ENUM_LABEL_TURBO:
-            snprintf(s, len,
-                     "Turbo enable.\n"
-                             " \n"
-                             "Holding the turbo while pressing another \n"
-                             "button will let the button enter a turbo \n"
-                             "mode where the button state is modulated \n"
-                             "with a periodic signal. \n"
-                             " \n"
-                             "The modulation stops when the button \n"
-                             "itself (not turbo button) is released.");
-            break;
-        case MENU_ENUM_LABEL_OSK_ENABLE:
-            snprintf(s, len,
-                     "Enable/disable on-screen keyboard.");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_MUTE:
-            snprintf(s, len,
-                     "Mute/unmute audio.");
-            break;
-        case MENU_ENUM_LABEL_REWIND:
-            snprintf(s, len,
-                     "Hold button down to rewind.\n"
-                             " \n"
-                             "Rewind must be enabled.");
             break;
         case MENU_ENUM_LABEL_EXIT_EMULATOR:
             snprintf(s, len,
@@ -2088,176 +1038,9 @@ int msg_hash_get_help_cs_enum(enum msg_hash_enums msg, char *s, size_t len)
 #endif
             );
             break;
-        case MENU_ENUM_LABEL_LOAD_STATE:
-            snprintf(s, len,
-                     "Loads state.");
-            break;
-        case MENU_ENUM_LABEL_SAVE_STATE:
-            snprintf(s, len,
-                     "Saves state.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_GAME_WATCH:
-            snprintf(s, len,
-                     "Netplay toggle play/spectate mode.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_INDEX_PLUS:
-            snprintf(s, len,
-                     "Increase cheat index.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_INDEX_MINUS:
-            snprintf(s, len,
-                     "Decrease cheat index.");
-            break;
-        case MENU_ENUM_LABEL_SHADER_PREV:
-            snprintf(s, len,
-                     "Applies previous shader in directory.");
-            break;
-        case MENU_ENUM_LABEL_SHADER_NEXT:
-            snprintf(s, len,
-                     "Applies next shader in directory.");
-            break;
-        case MENU_ENUM_LABEL_RESET:
-            snprintf(s, len,
-                     "Reset the content.");
-            break;
-        case MENU_ENUM_LABEL_PAUSE_TOGGLE:
-            snprintf(s, len,
-                     "Toggle between paused and non-paused state.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_TOGGLE:
-            snprintf(s, len,
-                     "Toggle cheat index.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_IDX:
-            snprintf(s, len,
-                     "Index position in list.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_ADDRESS_BIT_POSITION:
-            snprintf(s, len,
-                     "Address bitmask when Memory Search Size < 8-bit.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_REPEAT_COUNT:
-            snprintf(s, len,
-                     "The number of times the cheat will be applied.\nUse with the other two Iteration options to affect large areas of memory.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_REPEAT_ADD_TO_ADDRESS:
-            snprintf(s, len,
-                     "After each 'Number of Iterations' the Memory Address will be increased by this number times the 'Memory Search Size'.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_REPEAT_ADD_TO_VALUE:
-            snprintf(s, len,
-                     "After each 'Number of Iterations' the Value will be increased by this amount.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_MATCH_IDX:
-            snprintf(s, len,
-                     "Select the match to view.");
-            break;
         case MENU_ENUM_LABEL_CHEAT_START_OR_CONT:
             snprintf(s, len,
                      "Scan memory to create new cheats.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_START_OR_RESTART:
-            snprintf(s, len,
-                     "Left/Right to change bit-size.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_EXACT:
-            snprintf(s, len,
-                     "Left/Right to change value.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_LT:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_GT:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_EQ:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_NEQ:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_EQPLUS:
-            snprintf(s, len,
-                     "Left/Right to change value.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_EQMINUS:
-            snprintf(s, len,
-                     "Left/Right to change value.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_ADD_MATCHES:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_VIEW_MATCHES:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_CREATE_OPTION:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_DELETE_OPTION:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_ADD_NEW_TOP:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_RELOAD_CHEATS:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_ADD_NEW_BOTTOM:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_DELETE_ALL:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_BIG_ENDIAN:
-            snprintf(s, len,
-                     "Big endian    : 258 = 0x0102\n"
-                     "Little endian : 258 = 0x0201");
-            break;
-        case MENU_ENUM_LABEL_HOLD_FAST_FORWARD:
-            snprintf(s, len,
-                     "Hold for fast-forward. Releasing button \n"
-                             "disables fast-forward.");
-            break;
-        case MENU_ENUM_LABEL_SLOWMOTION_HOLD:
-            snprintf(s, len,
-                     "Hold for slowmotion.");
-            break;
-        case MENU_ENUM_LABEL_FRAME_ADVANCE:
-            snprintf(s, len,
-                     "Frame advance when content is paused.");
-            break;
-        case MENU_ENUM_LABEL_BSV_RECORD_TOGGLE:
-            snprintf(s, len,
-                     "Toggle between recording and not.");
-            break;
-        case MENU_ENUM_LABEL_L_X_PLUS:
-        case MENU_ENUM_LABEL_L_X_MINUS:
-        case MENU_ENUM_LABEL_L_Y_PLUS:
-        case MENU_ENUM_LABEL_L_Y_MINUS:
-        case MENU_ENUM_LABEL_R_X_PLUS:
-        case MENU_ENUM_LABEL_R_X_MINUS:
-        case MENU_ENUM_LABEL_R_Y_PLUS:
-        case MENU_ENUM_LABEL_R_Y_MINUS:
-            snprintf(s, len,
-                     "Axis for analog stick (DualShock-esque).\n"
-                             " \n"
-                             "Bound as usual, however, if a real analog \n"
-                             "axis is bound, it can be read as a true analog.\n"
-                             " \n"
-                             "Positive X axis is right. \n"
-                             "Positive Y axis is down.");
             break;
         case MENU_ENUM_LABEL_VALUE_WHAT_IS_A_CORE_DESC:
             snprintf(s, len,
@@ -2305,41 +1088,37 @@ int msg_hash_get_help_cs_enum(enum msg_hash_enums msg, char *s, size_t len)
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OVERLAY_SETTINGS),
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_HIDE_IN_MENU));
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_ENABLE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_ENABLE:
             snprintf(s, len,
                      "Enables a background color for the OSD.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_RED:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_RED:
             snprintf(s, len,
                      "Sets the red value of the OSD background color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_GREEN:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_GREEN:
             snprintf(s, len,
                      "Sets the green value of the OSD background color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_BLUE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_BLUE:
             snprintf(s, len,
                      "Sets the blue value of the OSD background color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_OPACITY:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_OPACITY:
             snprintf(s, len,
                      "Sets the opacity of the OSD background color. Valid values are between 0.0 and 1.0.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_RED:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_RED:
             snprintf(s, len,
                      "Sets the red value of the OSD text color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_GREEN:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_GREEN:
             snprintf(s, len,
                      "Sets the green value of the OSD text color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_BLUE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_BLUE:
             snprintf(s, len,
                      "Sets the blue value of the OSD text color. Valid values are between 0 and 255.");
-            break;
-        case MENU_ENUM_LABEL_MIDI_DRIVER:
-            snprintf(s, len,
-                     "MIDI driver to use.");
             break;
 #ifdef HAVE_LAKKA
         case MENU_ENUM_LABEL_TIMEZONE:
@@ -2365,10 +1144,6 @@ int msg_hash_get_help_cs_enum(enum msg_hash_enums msg, char *s, size_t len)
                      "When MIDI output is enabled and core and game/app support MIDI output,\n"
                      "some or all sounds (depends on game/app) will be generated by MIDI device.\n"
                      "In case of \"null\" MIDI driver this means that those sounds won't be audible.");
-            break;
-        case MENU_ENUM_LABEL_MIDI_VOLUME:
-            snprintf(s, len,
-                     "Sets the master volume of the output device.");
             break;
 #ifdef __linux__
         case MENU_ENUM_LABEL_GAMEMODE_ENABLE:

--- a/intl/msg_hash_de.c
+++ b/intl/msg_hash_de.c
@@ -1989,35 +1989,35 @@ int msg_hash_get_help_de_enum(enum msg_hash_enums msg, char *s, size_t len)
                msg_hash_to_str(MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_HIDE_IN_MENU)
                );
          break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_ENABLE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_ENABLE:
             snprintf(s, len,
                      "Verwendet eine Hintergrundfarbe für das OSD.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_RED:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_RED:
             snprintf(s, len,
                      "Legt den Rot-Anteil der OSD-Hintergrundfarbe fest. Gültige Werte liegen zwischen 0 und 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_GREEN:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_GREEN:
             snprintf(s, len,
                      "Legt den Grün-Anteil der OSD-Hintergrundfarbe fest. Gültige Werte liegen zwischen 0 und 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_BLUE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_BLUE:
             snprintf(s, len,
                      "Legt den Blau-Anteil der OSD-Hintergrundfarbe fest. Gültige Werte liegen zwischen 0 und 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_OPACITY:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_OPACITY:
             snprintf(s, len,
                      "Legt die Transparenz der OSD-Hintergrundfarbe fest. Gültige Werte liegen zwischen 0.0 und 1.0.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_RED:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_RED:
             snprintf(s, len,
                      "Legt den Rot-Anteil der OSD-Textfarbe fest. Gültige Werte liegen zwischen 0 und 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_GREEN:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_GREEN:
             snprintf(s, len,
                      "Legt den Grün-Anteil der OSD-Textfarbe fest. Gültige Werte liegen zwischen 0 und 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_BLUE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_BLUE:
             snprintf(s, len,
                      "Legt den Blau-Anteil der OSD-Textfarbe fest. Gültige Werte liegen zwischen 0 und 255.");
             break;

--- a/intl/msg_hash_el.c
+++ b/intl/msg_hash_el.c
@@ -483,18 +483,6 @@ int msg_hash_get_help_el_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Content decompressed by RetroArch will be \n"
                              "temporarily extracted to this directory.");
             break;
-        case MENU_ENUM_LABEL_HISTORY_LIST_ENABLE:
-            snprintf(s, len,
-                     "If enabled, every content loaded \n"
-                             "in RetroArch will be automatically \n"
-                             "added to the recent history list.");
-            break;
-        case MENU_ENUM_LABEL_RGUI_BROWSER_DIRECTORY:
-            snprintf(s, len,
-                     "File Browser Directory. \n"
-                             " \n"
-                             "Sets start directory for menu file browser.");
-            break;
         case MENU_ENUM_LABEL_INPUT_POLL_TYPE_BEHAVIOR:
             snprintf(s, len,
                      "Influence how input polling is done inside \n"
@@ -513,137 +501,11 @@ int msg_hash_get_help_el_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Will be ignored when using netplay."
             );
             break;
-        case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_HIDE_UNBOUND:
-            snprintf(s, len,
-                     "Hide input descriptors that were not set \n"
-                             "by the core.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE:
-            snprintf(s, len,
-                     "Video refresh rate of your monitor. \n"
-                             "Used to calculate a suitable audio input rate.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FORCE_SRGB_DISABLE:
-            snprintf(s, len,
-                     "Forcibly disable sRGB FBO support. Some Intel \n"
-                             "OpenGL drivers on Windows have video problems \n"
-                             "with sRGB FBO support enabled.");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_ENABLE:
-            snprintf(s, len,
-                     "Enable audio output.");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_SYNC:
-            snprintf(s, len,
-                     "Synchronize audio (recommended).");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_LATENCY:
-            snprintf(s, len,
-                     "Desired audio latency in milliseconds. \n"
-                             "Might not be honored if the audio driver \n"
-                             "can't provide given latency.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_ALLOW_ROTATE:
-            snprintf(s, len,
-                     "Allow cores to set rotation. If false, \n"
-                             "rotation requests are honored, but ignored.\n\n"
-                             "Used for setups where one manually rotates \n"
-                             "the monitor.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_LABEL_SHOW:
-            snprintf(s, len,
-                     "Show the input descriptors set by the core \n"
-                             "instead of the default ones.");
-            break;
-        case MENU_ENUM_LABEL_CONTENT_HISTORY_SIZE:
-            snprintf(s, len,
-                     "Number of entries that will be kept in \n"
-                             "content history playlist.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_WINDOWED_FULLSCREEN:
-            snprintf(s, len,
-                     "To use windowed mode or not when going \n"
-                             "fullscreen.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FONT_SIZE:
-            snprintf(s, len,
-                     "Font size for on-screen messages.");
-            break;
-        case MENU_ENUM_LABEL_SAVESTATE_AUTO_INDEX:
-            snprintf(s, len,
-                     "Automatically increment slot index on each save, \n"
-                             "generating multiple savestate files. \n"
-                             "When the content is loaded, state slot will be \n"
-                             "set to the highest existing value (last savestate).");
-            break;
-        case MENU_ENUM_LABEL_FPS_SHOW:
-            snprintf(s, len,
-                     "Enables displaying the current frames \n"
-                             "per second.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FONT_ENABLE:
-            snprintf(s, len,
-                     "Show and/or hide onscreen messages.");
-            break;
         case MENU_ENUM_LABEL_VIDEO_MESSAGE_POS_X:
         case MENU_ENUM_LABEL_VIDEO_MESSAGE_POS_Y:
             snprintf(s, len,
                      "Offset for where messages will be placed \n"
                              "onscreen. Values are in range [0.0, 1.0].");
-            break;
-        case MENU_ENUM_LABEL_INPUT_OVERLAY_ENABLE:
-            snprintf(s, len,
-                     "Enable or disable the current overlay.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_OVERLAY_HIDE_IN_MENU:
-            snprintf(s, len,
-                     "Hide the current overlay from appearing \n"
-                             "inside the menu.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_OVERLAY_SHOW_PHYSICAL_INPUTS:
-            snprintf(s, len,
-                      "Show keyboard/controller button presses on \n"
-                            "the onscreen overlay.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_OVERLAY_SHOW_PHYSICAL_INPUTS_PORT:
-            snprintf(s, len,
-                      "Select the port to listen for controller input \n"
-                            "to display on the onscreen overlay.");
-            break;
-        case MENU_ENUM_LABEL_OVERLAY_PRESET:
-            snprintf(s, len,
-                     "Path to input overlay.");
-            break;
-        case MENU_ENUM_LABEL_OVERLAY_OPACITY:
-            snprintf(s, len,
-                     "Overlay opacity.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_BIND_TIMEOUT:
-            snprintf(s, len,
-                     "Input bind timer timeout (in seconds). \n"
-                             "Amount of seconds to wait until proceeding \n"
-                             "to the next bind.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_BIND_HOLD:
-            snprintf(s, len,
-               "Input bind hold time (in seconds). \n"
-               "Amount of seconds to hold an input to bind it.");
-            break;
-        case MENU_ENUM_LABEL_OVERLAY_SCALE:
-            snprintf(s, len,
-                     "Overlay scale.");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_OUTPUT_RATE:
-            snprintf(s, len,
-                     "Audio output samplerate.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SHARED_CONTEXT:
-            snprintf(s, len,
-                     "Set to true if hardware-rendered cores \n"
-                             "should get their private context. \n"
-                             "Avoids having to assume hardware state changes \n"
-                             "inbetween frames."
-            );
             break;
         case MENU_ENUM_LABEL_CORE_LIST:
             snprintf(s, len,
@@ -891,13 +753,6 @@ int msg_hash_get_help_el_enum(enum msg_hash_enums msg, char *s, size_t len)
                }
             }
             break;
-        case MENU_ENUM_LABEL_AUDIO_DSP_PLUGIN:
-            snprintf(s, len,
-                     "Audio DSP plugin.\n"
-                             " Processes audio before it's sent to \n"
-                             "the driver."
-            );
-            break;
         case MENU_ENUM_LABEL_AUDIO_RESAMPLER_DRIVER:
             {
                const char *lbl = settings ? settings->arrays.audio_resampler : NULL;
@@ -914,12 +769,6 @@ int msg_hash_get_help_el_enum(enum msg_hash_enums msg, char *s, size_t len)
                   strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE), len);
             }
             break;
-
-		case MENU_ENUM_LABEL_CRT_SWITCH_RESOLUTION: snprintf(s, len, "SET CRT");
-			break;
-
-		case MENU_ENUM_LABEL_CRT_SWITCH_RESOLUTION_SUPER: snprintf(s, len, "SET CRT SUPER");
-			break;
 
         case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET:
             snprintf(s, len,
@@ -968,20 +817,6 @@ int msg_hash_get_help_el_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "The Default Filter option will affect the \n"
                              "stretching filter.");
             break;
-        case MENU_ENUM_LABEL_VIDEO_SHADER_PARAMETERS:
-            snprintf(s, len,
-                     "Shader Parameters. \n"
-                             " \n"
-                             "Modifies current shader directly. Will not be \n"
-                             "saved to CGP/GLSLP preset file.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_PARAMETERS:
-            snprintf(s, len,
-                     "Shader Preset Parameters. \n"
-                             " \n"
-                             "Modifies shader preset currently in menu."
-            );
-            break;
         case MENU_ENUM_LABEL_VIDEO_SHADER_PASS:
             snprintf(s, len,
                      "Path to shader. \n"
@@ -1020,13 +855,6 @@ int msg_hash_get_help_el_enum(enum msg_hash_enums msg, char *s, size_t len)
             "manually isn't really an option."
 #endif
             );
-            break;
-        case MENU_ENUM_LABEL_CONFIRM_ON_EXIT:
-            snprintf(s, len, "Are you sure you want to quit?");
-            break;
-        case MENU_ENUM_LABEL_SHOW_HIDDEN_FILES:
-            snprintf(s, len, "Show hidden files\n"
-                    "and folders.");
             break;
         case MENU_ENUM_LABEL_VIDEO_SHADER_FILTER_PASS:
             snprintf(s, len,
@@ -1110,26 +938,6 @@ int msg_hash_get_help_el_enum(enum msg_hash_enums msg, char *s, size_t len)
                      "and applied to the running content."
             );
             break;
-        case MENU_ENUM_LABEL_MENU_TOGGLE:
-            snprintf(s, len,
-                     "Toggles menu.");
-            break;
-        case MENU_ENUM_LABEL_GRAB_MOUSE_TOGGLE:
-            snprintf(s, len,
-                     "Toggles mouse grab.\n"
-                             " \n"
-                             "When mouse is grabbed, RetroArch hides the \n"
-                             "mouse, and keeps the mouse pointer inside \n"
-                             "the window to allow relative mouse input to \n"
-                             "work better.");
-            break;
-        case MENU_ENUM_LABEL_GAME_FOCUS_TOGGLE:
-            snprintf(s, len,
-                     "Toggles game focus.\n"
-                             " \n"
-                             "When a game has focus, RetroArch will both disable \n"
-                             "hotkeys and keep/warp the mouse pointer inside the window.");
-            break;
         case MENU_ENUM_LABEL_DISK_NEXT:
             snprintf(s, len,
                      "Cycles through disk images. Use after \n"
@@ -1173,12 +981,6 @@ int msg_hash_get_help_el_enum(enum msg_hash_enums msg, char *s, size_t len)
 #endif
             );
             break;
-        case MENU_ENUM_LABEL_DISK_EJECT_TOGGLE:
-            snprintf(s, len,
-                     "Toggles eject for disks.\n"
-                             " \n"
-                             "Used for multiple-disk content.");
-            break;
         case MENU_ENUM_LABEL_ENABLE_HOTKEY:
             snprintf(s, len,
                      "Enable other hotkeys.\n"
@@ -1192,28 +994,6 @@ int msg_hash_get_help_el_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "implementations which query a large area of \n"
                              "the keyboard, where it is not desirable that \n"
                              "hotkeys get in the way.");
-            break;
-        case MENU_ENUM_LABEL_REWIND_ENABLE:
-            snprintf(s, len,
-                     "Enable rewinding.\n"
-                             " \n"
-                             "This will take a performance hit, \n"
-                             "so it is disabled by default.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_APPLY_AFTER_TOGGLE:
-            snprintf(s, len,
-                     "Apply cheat immediately after toggling.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_APPLY_AFTER_LOAD:
-            snprintf(s, len,
-                     "Auto-apply cheats when game loads.");
-            break;
-        case MENU_ENUM_LABEL_LIBRETRO_DIR_PATH:
-            snprintf(s, len,
-                     "Core Directory. \n"
-                             " \n"
-                             "A directory for where to search for \n"
-                             "libretro core implementations.");
             break;
         case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE_AUTO:
             snprintf(s, len,
@@ -1234,29 +1014,6 @@ int msg_hash_get_help_el_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "large pitch changes. If your monitor does \n"
                              "not run at 60Hz, or something close to it, \n"
                              "disable VSync, and leave this at its default.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE_POLLED:
-            snprintf(s, len,
-                     "Set Polled Refresh Rate\n"
-                             " \n"
-                            "Sets the refresh rate to the actual value\n"
-                            "polled from the display driver.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_ROTATION:
-            snprintf(s, len,
-                     "Forces a certain rotation \n"
-                             "of the screen.\n"
-                             " \n"
-                             "The rotation is added to rotations which\n"
-                             "the libretro core sets (see Video Allow\n"
-                             "Rotate).");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SCALE:
-            snprintf(s, len,
-                     "Fullscreen resolution.\n"
-                             " \n"
-                             "Resolution of 0 uses the \n"
-                             "resolution of the environment.\n");
             break;
         case MENU_ENUM_LABEL_FASTFORWARD_RATIO:
             snprintf(s, len,
@@ -1290,25 +1047,6 @@ int msg_hash_get_help_el_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "is preferred, 1 and up (1 being first \n"
                              "monitor), suggests RetroArch to use that \n"
                              "particular monitor.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_CROP_OVERSCAN:
-            snprintf(s, len,
-                     "Forces cropping of overscanned \n"
-                             "frames.\n"
-                             " \n"
-                             "Exact behavior of this option is \n"
-                             "core-implementation specific.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SCALE_INTEGER:
-            snprintf(s, len,
-                     "Only scales video in integer \n"
-                             "steps.\n"
-                             " \n"
-                             "The base size depends on system-reported \n"
-                             "geometry and aspect ratio.\n"
-                             " \n"
-                             "If Force Aspect is not set, X/Y will be \n"
-                             "integer scaled independently.");
             break;
         case MENU_ENUM_LABEL_AUDIO_VOLUME:
             snprintf(s, len,
@@ -1345,53 +1083,10 @@ int msg_hash_get_help_el_enum(enum msg_hash_enums msg, char *s, size_t len)
                              " Input rate is defined as: \n"
                              " input rate * (1.0 +/- (max timing skew))");
             break;
-        case MENU_ENUM_LABEL_OVERLAY_NEXT:
-            snprintf(s, len,
-                     "Toggles to next overlay.\n"
-                             " \n"
-                             "Wraps around.");
-            break;
-        case MENU_ENUM_LABEL_LOG_VERBOSITY:
-            snprintf(s, len,
-                     "Enable or disable verbosity level \n"
-                             "of frontend.");
-            break;
-        case MENU_ENUM_LABEL_VOLUME_UP:
-            snprintf(s, len,
-                     "Increases audio volume.");
-            break;
-        case MENU_ENUM_LABEL_VOLUME_DOWN:
-            snprintf(s, len,
-                     "Decreases audio volume.");
-            break;
         case MENU_ENUM_LABEL_VIDEO_DISABLE_COMPOSITION:
             snprintf(s, len,
                      "Forcibly disable composition.\n"
                              "Only valid on Windows Vista/7 for now.");
-            break;
-        case MENU_ENUM_LABEL_PERFCNT_ENABLE:
-            snprintf(s, len,
-                     "Enable or disable frontend \n"
-                             "performance counters.");
-            break;
-        case MENU_ENUM_LABEL_SYSTEM_DIRECTORY:
-            snprintf(s, len,
-                     "System Directory. \n"
-                             " \n"
-                             "Sets the 'system' directory.\n"
-                             "Cores can query for this\n"
-                             "directory to load BIOSes, \n"
-                             "system-specific configs, etc.");
-            break;
-        case MENU_ENUM_LABEL_SAVESTATE_AUTO_SAVE:
-        case MENU_ENUM_LABEL_SAVESTATE_AUTO_LOAD:
-            snprintf(s, len,
-                     "Automatically saves a savestate at the \n"
-                             "end of RetroArch's lifetime.\n"
-                             " \n"
-                             "RetroArch will automatically load any savestate\n"
-                             "with this path on startup if 'Auto Load State\n"
-                             "is enabled.");
             break;
         case MENU_ENUM_LABEL_VIDEO_THREADED:
             snprintf(s, len,
@@ -1400,47 +1095,6 @@ int msg_hash_get_help_el_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Using this might improve performance at the \n"
                              "possible cost of latency and more video \n"
                              "stuttering.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_VSYNC:
-            snprintf(s, len,
-                     "Video V-Sync.\n");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_HARD_SYNC:
-            snprintf(s, len,
-                     "Attempts to hard-synchronize \n"
-                             "CPU and GPU.\n"
-                             " \n"
-                             "Can reduce latency at the cost of \n"
-                             "performance.");
-            break;
-        case MENU_ENUM_LABEL_REWIND_GRANULARITY:
-            snprintf(s, len,
-                     "Rewind granularity.\n"
-                             " \n"
-                             " When rewinding defined number of \n"
-                             "frames, you can rewind several frames \n"
-                             "at a time, increasing the rewinding \n"
-                             "speed.");
-            break;
-        case MENU_ENUM_LABEL_REWIND_BUFFER_SIZE:
-            snprintf(s, len,
-                     "Rewind buffer size (MB).\n"
-                             " \n"
-                             " The amount of memory in MB to reserve \n"
-                             "for rewinding.  Increasing this value \n"
-                             "increases the rewind history length.\n");
-            break;
-        case MENU_ENUM_LABEL_REWIND_BUFFER_SIZE_STEP:
-            snprintf(s, len,
-                     "Rewind buffer size step (MB).\n"
-                             " \n"
-                             " Each time you increase or decrease \n"
-                             "the rewind buffer size value via this \n"
-                             "UI it will change by this amount.\n");
-            break;
-        case MENU_ENUM_LABEL_SCREENSHOT:
-            snprintf(s, len,
-                     "Take screenshot.");
             break;
         case MENU_ENUM_LABEL_VIDEO_FRAME_DELAY:
             snprintf(s, len,
@@ -1477,49 +1131,6 @@ int msg_hash_get_help_el_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "configured as if it is a 60 Hz monitor \n"
                              "(divide refresh rate by 2).");
             break;
-        case MENU_ENUM_LABEL_RGUI_SHOW_START_SCREEN:
-            snprintf(s, len,
-                     "Show startup screen in menu.\n"
-                             "Is automatically set to false when seen\n"
-                             "for the first time.\n"
-                             " \n"
-                             "This is only updated in config if\n"
-                             "'Save Configuration on Exit' is enabled.\n");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FULLSCREEN:
-            snprintf(s, len, "Toggles fullscreen.");
-            break;
-        case MENU_ENUM_LABEL_BLOCK_SRAM_OVERWRITE:
-            snprintf(s, len,
-                     "Block SRAM from being overwritten \n"
-                             "when loading save states.\n"
-                             " \n"
-                             "Might potentially lead to buggy games.");
-            break;
-        case MENU_ENUM_LABEL_PAUSE_NONACTIVE:
-            snprintf(s, len,
-                     "Pause gameplay when window focus \n"
-                             "is lost.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_GPU_SCREENSHOT:
-            snprintf(s, len,
-                     "Screenshots output of GPU shaded \n"
-                             "material if available.");
-            break;
-        case MENU_ENUM_LABEL_SCREENSHOT_DIRECTORY:
-            snprintf(s, len,
-                     "Screenshot Directory. \n"
-                             " \n"
-                             "Directory to dump screenshots to."
-            );
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SWAP_INTERVAL:
-            snprintf(s, len,
-                     "VSync Swap Interval.\n"
-                             " \n"
-                             "Uses a custom swap interval for VSync. Set this \n"
-                             "to effectively halve monitor refresh rate.");
-            break;
         case MENU_ENUM_LABEL_SAVEFILE_DIRECTORY:
             snprintf(s, len,
                      "Savefile Directory. \n"
@@ -1527,16 +1138,6 @@ int msg_hash_get_help_el_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Save all save files (*.srm) to this \n"
                              "directory. This includes related files like \n"
                              ".bsv, .rt, .psrm, etc...\n"
-                             " \n"
-                             "This will be overridden by explicit command line\n"
-                             "options.");
-            break;
-        case MENU_ENUM_LABEL_SAVESTATE_DIRECTORY:
-            snprintf(s, len,
-                     "Savestate Directory. \n"
-                             " \n"
-                             "Save all save states (*.state) to this \n"
-                             "directory.\n"
                              " \n"
                              "This will be overridden by explicit command line\n"
                              "options.");
@@ -1557,59 +1158,8 @@ int msg_hash_get_help_el_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "be loaded dynamically by the menu depending \n"
                              "on context.");
             break;
-        case MENU_ENUM_LABEL_SLOWMOTION_RATIO:
-            snprintf(s, len,
-                     "Slowmotion ratio."
-                             " \n"
-                             "When slowmotion, content will slow\n"
-                             "down by factor.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_TURBO_PERIOD:
-            snprintf(s, len,
-                     "Turbo period.\n"
-                             " \n"
-                             "Describes the period of which turbo-enabled\n"
-                             "buttons toggle.\n"
-                             " \n"
-                             "Numbers are described in frames."
-            );
-            break;
-        case MENU_ENUM_LABEL_INPUT_DUTY_CYCLE:
-            snprintf(s, len,
-                     "Duty cycle.\n"
-                             " \n"
-                             "Describes how long the period of a turbo-enabled\n"
-                             "should be.\n"
-                             " \n"
-                             "Numbers are described in frames."
-            );
-            break;
-        case MENU_ENUM_LABEL_INPUT_TOUCH_ENABLE:
-            snprintf(s, len, "Enable touch support.");
-            break;
         case MENU_ENUM_LABEL_INPUT_PREFER_FRONT_TOUCH:
             snprintf(s, len, "Use front instead of back touch.");
-            break;
-        case MENU_ENUM_LABEL_MOUSE_ENABLE:
-            snprintf(s, len, "Enable mouse input inside the menu.");
-            break;
-        case MENU_ENUM_LABEL_POINTER_ENABLE:
-            snprintf(s, len, "Enable touch input inside the menu.");
-            break;
-        case MENU_ENUM_LABEL_MENU_WALLPAPER:
-            snprintf(s, len, "Path to an image to set as the background.");
-            break;
-        case MENU_ENUM_LABEL_NAVIGATION_WRAPAROUND:
-            snprintf(s, len,
-                     "Wrap-around to beginning and/or end \n"
-                             "if boundary of list is reached \n"
-                             "horizontally and/or vertically.");
-            break;
-        case MENU_ENUM_LABEL_PAUSE_LIBRETRO:
-            snprintf(s, len,
-                     "If disabled, the game will keep \n"
-                             "running in the background when we are in the \n"
-                             "menu.");
             break;
         case MENU_ENUM_LABEL_SUSPEND_SCREENSAVER_ENABLE:
             snprintf(s, len,
@@ -1629,13 +1179,6 @@ int msg_hash_get_help_el_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Increasing this value will increase \n"
                              "performance, but introduce more latency.");
             break;
-        case MENU_ENUM_LABEL_NETPLAY_PUBLIC_ANNOUNCE:
-            snprintf(s, len,
-                     "Whether to announce netplay games publicly. \n"
-                             " \n"
-                             "If set to false, clients must manually connect \n"
-                             "rather than using the public lobby.");
-            break;
         case MENU_ENUM_LABEL_NETPLAY_START_AS_SPECTATOR:
             snprintf(s, len,
                      "Whether to start netplay in spectator mode. \n"
@@ -1643,21 +1186,6 @@ int msg_hash_get_help_el_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "If set to true, netplay will be in spectator mode \n"
                              "on start. It's always possible to change mode \n"
                              "later.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_ALLOW_SLAVES:
-            snprintf(s, len,
-                     "Whether to allow connections in slave mode. \n"
-                             " \n"
-                             "Slave-mode clients require very little processing \n"
-                             "power on either side, but will suffer \n"
-                             "significantly from network latency.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_REQUIRE_SLAVES:
-            snprintf(s, len,
-                     "Whether to disallow connections not in slave mode. \n"
-                             " \n"
-                             "Not recommended except for very fast networks \n"
-                             "with very weak machines. \n");
             break;
         case MENU_ENUM_LABEL_NETPLAY_CHECK_FRAMES:
             snprintf(s, len,
@@ -1700,24 +1228,6 @@ int msg_hash_get_help_el_enum(enum msg_hash_enums msg, char *s, size_t len)
                      "makes netplay less CPU-intensive, but at \n"
                      "the price of unpredictable input lag. \n");
             break;
-        case MENU_ENUM_LABEL_NETPLAY_NAT_TRAVERSAL:
-            snprintf(s, len,
-                     "When hosting, attempt to listen for\n"
-                             "connections from the public internet, using\n"
-                             "UPnP or similar technologies to escape LANs. \n");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_USE_MITM_SERVER:
-            snprintf(s, len,
-                     "When hosting a netplay session, relay connection through a \n"
-                             "man-in-the-middle server \n"
-                             "to get around firewalls or NAT/UPnP issues. \n");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_MITM_SERVER:
-            snprintf(s, len,
-                     "Specifies the man-in-the-middle server \n"
-                             "to use for netplay. A server that is \n"
-                             "located closer to you may have less latency. \n");
-            break;
         case MENU_ENUM_LABEL_VIDEO_MAX_SWAPCHAIN_IMAGES:
             snprintf(s, len,
                      "Maximum amount of swapchain images. This \n"
@@ -1745,181 +1255,19 @@ int msg_hash_get_help_el_enum(enum msg_hash_enums msg, char *s, size_t len)
 #endif
          );
          break;
-        case MENU_ENUM_LABEL_TIMEDATE_ENABLE:
-            snprintf(s, len,
-                     "Shows current date and/or time inside menu.");
-            break;
-        case MENU_ENUM_LABEL_BATTERY_LEVEL_ENABLE:
-            snprintf(s, len,
-                     "Shows current battery level inside menu.");
-            break;
-        case MENU_ENUM_LABEL_CORE_ENABLE:
-            snprintf(s, len,
-                     "Shows current core inside menu.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_ENABLE_HOST:
-            snprintf(s, len,
-                     "Enables Netplay in host (server) mode.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_ENABLE_CLIENT:
-            snprintf(s, len,
-                     "Enables Netplay in client mode.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_DISCONNECT:
-            snprintf(s, len,
-                     "Disconnects an active Netplay connection.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_LAN_SCAN_SETTINGS:
-            snprintf(s, len,
-                     "Search for and connect to netplay hosts on the local network.");
-            break;
         case MENU_ENUM_LABEL_NETPLAY_SETTINGS:
             snprintf(s, len,
                      "Setting related to Netplay.");
-            break;
-        case MENU_ENUM_LABEL_DYNAMIC_WALLPAPER:
-            snprintf(s, len,
-                     "Dynamically load a new background \n"
-                             "depending on context.");
-            break;
-        case MENU_ENUM_LABEL_CORE_UPDATER_BUILDBOT_URL:
-            snprintf(s, len,
-                     "URL to core updater directory on the \n"
-                             "Libretro buildbot.");
-            break;
-        case MENU_ENUM_LABEL_BUILDBOT_ASSETS_URL:
-            snprintf(s, len,
-                     "URL to assets updater directory on the \n"
-                             "Libretro buildbot.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_REMAP_BINDS_ENABLE:
-            snprintf(s, len,
-                     "if enabled, overrides the input binds \n"
-                             "with the remapped binds set for the \n"
-                             "current core.");
-            break;
-        case MENU_ENUM_LABEL_OVERLAY_DIRECTORY:
-            snprintf(s, len,
-                     "Overlay Directory. \n"
-                             " \n"
-                             "Defines a directory where overlays are \n"
-                             "kept for easy access.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_MAX_USERS:
-            snprintf(s, len,
-                     "Maximum amount of users supported by \n"
-                             "RetroArch.");
-            break;
-        case MENU_ENUM_LABEL_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
-            snprintf(s, len,
-                     "After downloading, automatically extract \n"
-                             "archives that the downloads are contained \n"
-                             "inside.");
-            break;
-        case MENU_ENUM_LABEL_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
-            snprintf(s, len,
-                     "Filter files being shown by \n"
-                             "supported extensions.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_NICKNAME:
-            snprintf(s, len,
-                     "The username of the person running RetroArch. \n"
-                             "This will be used for playing online games.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_TCP_UDP_PORT:
-            snprintf(s, len,
-                     "The port of the host IP address. \n"
-                             "Can be either a TCP or UDP port.");
             break;
         case MENU_ENUM_LABEL_NETPLAY_SPECTATOR_MODE_ENABLE:
             snprintf(s, len,
                      "Enable or disable spectator mode for \n"
                              "the user during netplay.");
             break;
-        case MENU_ENUM_LABEL_NETPLAY_IP_ADDRESS:
-            snprintf(s, len,
-                     "The address of the host to connect to.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_PASSWORD:
-            snprintf(s, len,
-                     "The password for connecting to the netplay \n"
-                             "host. Used only in host mode.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_SPECTATE_PASSWORD:
-            snprintf(s, len,
-                     "The password for connecting to the netplay \n"
-                             "host with only spectator privileges. Used \n"
-                             "only in host mode.");
-            break;
-        case MENU_ENUM_LABEL_STDIN_CMD_ENABLE:
-            snprintf(s, len,
-                     "Enable stdin command interface.");
-            break;
         case MENU_ENUM_LABEL_UI_COMPANION_START_ON_BOOT:
             snprintf(s, len,
                      "Start User Interface companion driver \n"
                              "on boot (if available).");
-            break;
-        case MENU_ENUM_LABEL_MENU_DRIVER:
-            snprintf(s, len, "Menu driver to use.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
-            snprintf(s, len,
-                     "Gamepad button combination to toggle menu. \n"
-                             " \n"
-                             "0 - None \n"
-                             "1 - Press L + R + Y + D-Pad Down \n"
-                             "simultaneously. \n"
-                             "2 - Press L3 + R3 simultaneously. \n"
-                             "3 - Press Start + Select simultaneously.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_ALL_USERS_CONTROL_MENU:
-            snprintf(s, len, "Allows any user to control the menu. \n"
-                    " \n"
-                    "When disabled, only user 1 can control the menu.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_AUTODETECT_ENABLE:
-            snprintf(s, len,
-                     "Enable input auto-detection.\n"
-                             " \n"
-                             "Will attempt to auto-configure \n"
-                             "joypads, Plug-and-Play style.");
-            break;
-        case MENU_ENUM_LABEL_CAMERA_ALLOW:
-            snprintf(s, len,
-                     "Allow or disallow camera access by \n"
-                             "cores.");
-            break;
-        case MENU_ENUM_LABEL_LOCATION_ALLOW:
-            snprintf(s, len,
-                     "Allow or disallow location services \n"
-                             "access by cores.");
-            break;
-        case MENU_ENUM_LABEL_TURBO:
-            snprintf(s, len,
-                     "Turbo enable.\n"
-                             " \n"
-                             "Holding the turbo while pressing another \n"
-                             "button will let the button enter a turbo \n"
-                             "mode where the button state is modulated \n"
-                             "with a periodic signal. \n"
-                             " \n"
-                             "The modulation stops when the button \n"
-                             "itself (not turbo button) is released.");
-            break;
-        case MENU_ENUM_LABEL_OSK_ENABLE:
-            snprintf(s, len,
-                     "Enable/disable on-screen keyboard.");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_MUTE:
-            snprintf(s, len,
-                     "Mute/unmute audio.");
-            break;
-        case MENU_ENUM_LABEL_REWIND:
-            snprintf(s, len,
-                     "Hold button down to rewind.\n"
-                             " \n"
-                             "Rewind must be enabled.");
             break;
         case MENU_ENUM_LABEL_EXIT_EMULATOR:
             snprintf(s, len,
@@ -1933,176 +1281,9 @@ int msg_hash_get_help_el_enum(enum msg_hash_enums msg, char *s, size_t len)
 #endif
             );
             break;
-        case MENU_ENUM_LABEL_LOAD_STATE:
-            snprintf(s, len,
-                     "Loads state.");
-            break;
-        case MENU_ENUM_LABEL_SAVE_STATE:
-            snprintf(s, len,
-                     "Saves state.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_GAME_WATCH:
-            snprintf(s, len,
-                     "Netplay toggle play/spectate mode.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_INDEX_PLUS:
-            snprintf(s, len,
-                     "Increment cheat index.\n");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_INDEX_MINUS:
-            snprintf(s, len,
-                     "Decrement cheat index.\n");
-            break;
-        case MENU_ENUM_LABEL_SHADER_PREV:
-            snprintf(s, len,
-                     "Applies previous shader in directory.");
-            break;
-        case MENU_ENUM_LABEL_SHADER_NEXT:
-            snprintf(s, len,
-                     "Applies next shader in directory.");
-            break;
-        case MENU_ENUM_LABEL_RESET:
-            snprintf(s, len,
-                     "Reset the content.\n");
-            break;
-        case MENU_ENUM_LABEL_PAUSE_TOGGLE:
-            snprintf(s, len,
-                     "Toggle between paused and non-paused state.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_TOGGLE:
-            snprintf(s, len,
-                     "Toggle cheat index.\n");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_IDX:
-            snprintf(s, len,
-                     "Index position in list.\n");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_ADDRESS_BIT_POSITION:
-            snprintf(s, len,
-                     "Address bitmask when Memory Search Size < 8-bit.\n");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_REPEAT_COUNT:
-            snprintf(s, len,
-                     "The number of times the cheat will be applied.\nUse with the other two Iteration options to affect large areas of memory.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_REPEAT_ADD_TO_ADDRESS:
-            snprintf(s, len,
-                     "After each 'Number of Iterations' the Memory Address will be increased by this number times the 'Memory Search Size'.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_REPEAT_ADD_TO_VALUE:
-            snprintf(s, len,
-                     "After each 'Number of Iterations' the Value will be increased by this amount.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_MATCH_IDX:
-            snprintf(s, len,
-                     "Select the match to view.");
-            break;
         case MENU_ENUM_LABEL_CHEAT_START_OR_CONT:
             snprintf(s, len,
                      "Scan memory to create new cheats");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_START_OR_RESTART:
-            snprintf(s, len,
-                     "Left/Right to change bit-size\n");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_EXACT:
-            snprintf(s, len,
-                     "Left/Right to change value\n");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_LT:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_GT:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_EQ:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_NEQ:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_EQPLUS:
-            snprintf(s, len,
-                     "Left/Right to change value\n");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_EQMINUS:
-            snprintf(s, len,
-                     "Left/Right to change value\n");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_ADD_MATCHES:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_VIEW_MATCHES:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_CREATE_OPTION:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_DELETE_OPTION:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_ADD_NEW_TOP:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_RELOAD_CHEATS:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_ADD_NEW_BOTTOM:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_DELETE_ALL:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_BIG_ENDIAN:
-            snprintf(s, len,
-                     "Big endian    : 258 = 0x0102\n"
-                     "Little endian : 258 = 0x0201");
-            break;
-        case MENU_ENUM_LABEL_HOLD_FAST_FORWARD:
-            snprintf(s, len,
-                     "Hold for fast-forward. Releasing button \n"
-                             "disables fast-forward.");
-            break;
-        case MENU_ENUM_LABEL_SLOWMOTION_HOLD:
-            snprintf(s, len,
-                     "Hold for slowmotion.");
-            break;
-        case MENU_ENUM_LABEL_FRAME_ADVANCE:
-            snprintf(s, len,
-                     "Frame advance when content is paused.");
-            break;
-        case MENU_ENUM_LABEL_BSV_RECORD_TOGGLE:
-            snprintf(s, len,
-                     "Toggle between recording and not.");
-            break;
-        case MENU_ENUM_LABEL_L_X_PLUS:
-        case MENU_ENUM_LABEL_L_X_MINUS:
-        case MENU_ENUM_LABEL_L_Y_PLUS:
-        case MENU_ENUM_LABEL_L_Y_MINUS:
-        case MENU_ENUM_LABEL_R_X_PLUS:
-        case MENU_ENUM_LABEL_R_X_MINUS:
-        case MENU_ENUM_LABEL_R_Y_PLUS:
-        case MENU_ENUM_LABEL_R_Y_MINUS:
-            snprintf(s, len,
-                     "Axis for analog stick (DualShock-esque).\n"
-                             " \n"
-                             "Bound as usual, however, if a real analog \n"
-                             "axis is bound, it can be read as a true analog.\n"
-                             " \n"
-                             "Positive X axis is right. \n"
-                             "Positive Y axis is down.");
             break;
         case MENU_ENUM_LABEL_VALUE_WHAT_IS_A_CORE_DESC:
             snprintf(s, len,
@@ -2151,41 +1332,37 @@ int msg_hash_get_help_el_enum(enum msg_hash_enums msg, char *s, size_t len)
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_HIDE_IN_MENU)
             );
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_ENABLE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_ENABLE:
             snprintf(s, len,
                      "Enables a background color for the OSD.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_RED:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_RED:
             snprintf(s, len,
                      "Sets the red value of the OSD background color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_GREEN:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_GREEN:
             snprintf(s, len,
                      "Sets the green value of the OSD background color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_BLUE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_BLUE:
             snprintf(s, len,
                      "Sets the blue value of the OSD background color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_OPACITY:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_OPACITY:
             snprintf(s, len,
                      "Sets the opacity of the OSD background color. Valid values are between 0.0 and 1.0.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_RED:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_RED:
             snprintf(s, len,
                      "Sets the red value of the OSD text color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_GREEN:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_GREEN:
             snprintf(s, len,
                      "Sets the green value of the OSD text color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_BLUE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_BLUE:
             snprintf(s, len,
                      "Sets the blue value of the OSD text color. Valid values are between 0 and 255.");
-            break;
-        case MENU_ENUM_LABEL_MIDI_DRIVER:
-            snprintf(s, len,
-                     "MIDI driver to use.");
             break;
         case MENU_ENUM_LABEL_MIDI_INPUT:
             snprintf(s, len,
@@ -2202,10 +1379,6 @@ int msg_hash_get_help_el_enum(enum msg_hash_enums msg, char *s, size_t len)
                      "When MIDI output is enabled and core and game/app support MIDI output,\n"
                      "some or all sounds (depends on game/app) will be generated by MIDI device.\n"
                      "In case of \"null\" MIDI driver this means that those sounds won't be audible.");
-            break;
-        case MENU_ENUM_LABEL_MIDI_VOLUME:
-            snprintf(s, len,
-                     "Sets the master volume of the output device.");
             break;
         default:
             if (string_is_empty(s))

--- a/intl/msg_hash_es.c
+++ b/intl/msg_hash_es.c
@@ -2386,48 +2386,48 @@ int msg_hash_get_help_es_enum(enum msg_hash_enums msg, char *s, size_t len)
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_HIDE_IN_MENU)
             );
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_ENABLE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_ENABLE:
             snprintf(s, len,
                      "Elige un color para el fondo\n"
                      "de los mensajes en pantalla.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_RED:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_RED:
             snprintf(s, len,
                      "Ajusta el componente rojo del color\n"
                      "de fondo de los mensajes en pantalla.\n"
                      "Los valores válidos son de 0 a 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_GREEN:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_GREEN:
             snprintf(s, len,
                      "Ajusta el componente verde del color\n"
                      "de fondo de los mensajes en pantalla.\n"
                      "Los valores válidos son de 0 a 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_BLUE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_BLUE:
             snprintf(s, len,
                      "Ajusta el componente azul del color\n"
                      "de fondo de los mensajes en pantalla.\n"
                      "Los valores válidos son de 0 a 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_OPACITY:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_OPACITY:
             snprintf(s, len,
                      "Ajusta la opacidad del color de fondo\n"
                      "de los mensajes en pantalla.\n"
                      "Los valores válidos son de 0.0 a 1.0.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_RED:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_RED:
             snprintf(s, len,
                      "Ajusta el componente rojo del color\n"
                      "de los textos de los mensajes en pantalla.\n"
                      "Los valores válidos son de 0 a 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_GREEN:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_GREEN:
             snprintf(s, len,
                      "Ajusta el componente verde del color\n"
                      "de los textos de los mensajes en pantalla.\n"
                      "Los valores válidos son de 0 a 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_BLUE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_BLUE:
             snprintf(s, len,
                      "Ajusta el componente azul del color\n"
                      "de los textos de los mensajes en pantalla.\n"

--- a/intl/msg_hash_fi.c
+++ b/intl/msg_hash_fi.c
@@ -38,149 +38,6 @@ int msg_hash_get_help_fi_enum(enum msg_hash_enums msg, char *s, size_t len)
 
        switch (idx)
        {
-          case RARCH_FAST_FORWARD_KEY:
-             snprintf(s, len,
-                   "Toggles between fast-forwarding and \n"
-                   "normal speed."
-                   );
-             break;
-          case RARCH_FAST_FORWARD_HOLD_KEY:
-             snprintf(s, len,
-                   "Hold for fast-forward. \n"
-                   " \n"
-                   "Releasing button disables fast-forward."
-                   );
-             break;
-          case RARCH_SLOWMOTION_KEY:
-             snprintf(s, len,
-                   "Toggles slowmotion.");
-             break;
-          case RARCH_SLOWMOTION_HOLD_KEY:
-             snprintf(s, len,
-                   "Hold for slowmotion.");
-             break;
-          case RARCH_PAUSE_TOGGLE:
-             snprintf(s, len,
-                   "Toggle between paused and non-paused state.");
-             break;
-          case RARCH_FRAMEADVANCE:
-             snprintf(s, len,
-                   "Frame advance when content is paused.");
-             break;
-          case RARCH_SHADER_NEXT:
-             snprintf(s, len,
-                   "Applies next shader in directory.");
-             break;
-          case RARCH_SHADER_PREV:
-             snprintf(s, len,
-                   "Applies previous shader in directory.");
-             break;
-          case RARCH_CHEAT_INDEX_PLUS:
-          case RARCH_CHEAT_INDEX_MINUS:
-          case RARCH_CHEAT_TOGGLE:
-             snprintf(s, len,
-                   "Cheats.");
-             break;
-          case RARCH_RESET:
-             snprintf(s, len,
-                   "Reset the content.");
-             break;
-          case RARCH_SCREENSHOT:
-             snprintf(s, len,
-                   "Take screenshot.");
-             break;
-          case RARCH_MUTE:
-             snprintf(s, len,
-                   "Mute/unmute audio.");
-             break;
-          case RARCH_OSK:
-             snprintf(s, len,
-                   "Toggles onscreen keyboard.");
-             break;
-          case RARCH_FPS_TOGGLE:
-             snprintf(s, len,
-                   "Toggles frames per second counter.");
-             break;
-          case RARCH_SEND_DEBUG_INFO:
-             snprintf(s, len,
-                   "Sends diagnostic info about your device and RetroArch configuration to our servers for analysis.");
-             break;
-          case RARCH_NETPLAY_HOST_TOGGLE:
-             snprintf(s, len,
-                   "Toggles netplay hosting on/off.");
-             break;
-          case RARCH_NETPLAY_GAME_WATCH:
-             snprintf(s, len,
-                   "Netplay toggle play/spectate mode.");
-             break;
-          case RARCH_ENABLE_HOTKEY:
-             snprintf(s, len,
-                   "Enable other hotkeys. \n"
-                   " \n"
-                   "If this hotkey is bound to either\n"
-                   "a keyboard, joybutton or joyaxis, \n"
-                   "all other hotkeys will be enabled only \n"
-                   "if this one is held at the same time. \n"
-                   " \n"
-                   "Alternatively, all hotkeys for keyboard \n"
-                   "could be disabled by the user.");
-             break;
-          case RARCH_VOLUME_UP:
-             snprintf(s, len,
-                   "Increases audio volume.");
-             break;
-          case RARCH_VOLUME_DOWN:
-             snprintf(s, len,
-                   "Decreases audio volume.");
-             break;
-          case RARCH_OVERLAY_NEXT:
-             snprintf(s, len,
-                   "Switches to next overlay. Wraps around.");
-             break;
-          case RARCH_DISK_EJECT_TOGGLE:
-             snprintf(s, len,
-                   "Toggles eject for disks. \n"
-                   " \n"
-                   "Used for multiple-disk content.");
-             break;
-          case RARCH_DISK_NEXT:
-          case RARCH_DISK_PREV:
-             snprintf(s, len,
-                   "Cycles through disk images. Use after ejecting. \n"
-                   " \n"
-                   "Complete by toggling eject again.");
-             break;
-          case RARCH_GRAB_MOUSE_TOGGLE:
-             snprintf(s, len,
-                   "Toggles mouse grab. \n"
-                   " \n"
-                   "When mouse is grabbed, RetroArch hides the \n"
-                   "mouse, and keeps the mouse pointer inside \n"
-                   "the window to allow relative mouse input to \n"
-                   "work better.");
-             break;
-          case RARCH_GAME_FOCUS_TOGGLE:
-             snprintf(s, len,
-                   "Toggles game focus.\n"
-                   " \n"
-                   "When a game has focus, RetroArch will both disable \n"
-                   "hotkeys and keep/wrap the mouse pointer inside the window.");
-             break;
-          case RARCH_MENU_TOGGLE:
-             snprintf(s, len, "Toggles menu.");
-             break;
-          case RARCH_LOAD_STATE_KEY:
-             snprintf(s, len,
-                   "Loads state.");
-             break;
-          case RARCH_FULLSCREEN_TOGGLE_KEY:
-             snprintf(s, len,
-                   "Toggles fullscreen.");
-             break;
-          case RARCH_CLOSE_CONTENT_KEY:
-             snprintf(s, len,
-                   "Closes content.");
-             break;
           case RARCH_QUIT_KEY:
              snprintf(s, len,
                    "Key to exit RetroArch cleanly. \n"
@@ -204,24 +61,6 @@ int msg_hash_get_help_fi_enum(enum msg_hash_enums msg, char *s, size_t len)
                    "When slot is not 0, path will be <path><d>, \n"
                    "where <d> is slot number.");
              break;
-          case RARCH_SAVE_STATE_KEY:
-             snprintf(s, len,
-                   "Saves state.");
-             break;
-          case RARCH_REWIND:
-             snprintf(s, len,
-                   "Hold button down to rewind. \n"
-                   " \n"
-                   "Rewinding must be enabled.");
-             break;
-          case RARCH_BSV_RECORD_TOGGLE:
-             snprintf(s, len,
-                   "Toggle between recording and not.");
-             break;
-          case RARCH_RUNAHEAD_TOGGLE:
-             snprintf(s, len,
-                   "Toggles Run-Ahead mode on/off.");
-             break;
           default:
              if (string_is_empty(s))
                 strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE), len);
@@ -244,12 +83,6 @@ int msg_hash_get_help_fi_enum(enum msg_hash_enums msg, char *s, size_t len)
                     "to input the username and password into \n"
                     "RetroArch.");
             break;
-        case MENU_ENUM_LABEL_CHEEVOS_USERNAME:
-            snprintf(s, len, "Username for your Retro Achievements account.");
-            break;
-        case MENU_ENUM_LABEL_CHEEVOS_PASSWORD:
-            snprintf(s, len, "Password for your Retro Achievements account.");
-            break;
         case MENU_ENUM_LABEL_USER_LANGUAGE:
             snprintf(s, len, "Localizes the menu and all onscreen messages \n"
                     "according to the language you have selected \n"
@@ -263,74 +96,6 @@ int msg_hash_get_help_fi_enum(enum msg_hash_enums msg, char *s, size_t len)
                     " \n"
                     "In case a language is not implemented, \n"
                     "we fallback to English.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FONT_PATH:
-            snprintf(s, len, "Change the font that is used \n"
-                    "for the Onscreen Display text.");
-            break;
-        case MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS:
-            snprintf(s, len, "Automatically load content-specific core options.");
-            break;
-        case MENU_ENUM_LABEL_AUTO_OVERRIDES_ENABLE:
-            snprintf(s, len, "Automatically load override configurations.");
-            break;
-        case MENU_ENUM_LABEL_AUTO_REMAPS_ENABLE:
-            snprintf(s, len, "Automatically load input remapping files.");
-            break;
-        case MENU_ENUM_LABEL_SORT_SAVESTATES_ENABLE:
-            snprintf(s, len, "Sort save states in folders \n"
-                    "named after the libretro core used.");
-            break;
-        case MENU_ENUM_LABEL_SORT_SAVEFILES_ENABLE:
-            snprintf(s, len, "Sort save files in folders \n"
-                    "named after the libretro core used.");
-            break;
-        case MENU_ENUM_LABEL_SORT_SAVESTATES_BY_CONTENT_ENABLE:
-            snprintf(s, len, "Sort save states in folders named \n"
-                   "after the folder in which the content lives.");
-            break;
-        case MENU_ENUM_LABEL_SORT_SAVEFILES_BY_CONTENT_ENABLE:
-            snprintf(s, len, "Sort save files in folders named \n"
-                  "after the folder in which the content lives.");
-            break;
-        case MENU_ENUM_LABEL_SORT_SCREENSHOTS_BY_CONTENT_ENABLE:
-            snprintf(s, len, "Sort screenshots in folders named \n"
-                  "after the folder in which the content lives.");
-            break;
-        case MENU_ENUM_LABEL_RESUME_CONTENT:
-            snprintf(s, len, "Exits from the menu and returns back \n"
-                    "to the content.");
-            break;
-        case MENU_ENUM_LABEL_RESTART_CONTENT:
-            snprintf(s, len, "Restarts the content from the beginning.");
-            break;
-        case MENU_ENUM_LABEL_CLOSE_CONTENT:
-            snprintf(s, len, "Closes the content and unloads it from \n"
-                    "memory.");
-            break;
-        case MENU_ENUM_LABEL_UNDO_LOAD_STATE:
-            snprintf(s, len, "If a state was loaded, content will \n"
-                    "go back to the state prior to loading.");
-            break;
-        case MENU_ENUM_LABEL_UNDO_SAVE_STATE:
-            snprintf(s, len, "If a state was overwritten, it will \n"
-                    "roll back to the previous save state.");
-            break;
-        case MENU_ENUM_LABEL_TAKE_SCREENSHOT:
-            snprintf(s, len, "Create a screenshot. \n"
-                    " \n"
-                    "The screenshot will be stored inside the \n"
-                    "Screenshot Directory.");
-            break;
-        case MENU_ENUM_LABEL_ADD_TO_FAVORITES:
-            snprintf(s, len, "Add the entry to your Favorites.");
-            break;
-        case MENU_ENUM_LABEL_RUN:
-            snprintf(s, len, "Start the content.");
-            break;
-        case MENU_ENUM_LABEL_INFORMATION:
-            snprintf(s, len, "Show additional metadata information \n"
-                    "about the content.");
             break;
         case MENU_ENUM_LABEL_FILE_BROWSER_CONFIG:
             snprintf(s, len, "Configuration file.");
@@ -355,33 +120,6 @@ int msg_hash_get_help_fi_enum(enum msg_hash_enums msg, char *s, size_t len)
         case MENU_ENUM_LABEL_USE_THIS_DIRECTORY:
             snprintf(s, len,
                      "Select this to set this as the directory.");
-            break;
-        case MENU_ENUM_LABEL_CONTENT_DATABASE_DIRECTORY:
-            snprintf(s, len,
-                     "Content Database Directory. \n"
-                             " \n"
-                             "Path to content database \n"
-                             "directory.");
-            break;
-        case MENU_ENUM_LABEL_THUMBNAILS_DIRECTORY:
-            snprintf(s, len,
-                     "Thumbnails Directory. \n"
-                             " \n"
-                             "To store thumbnail files.");
-            break;
-        case MENU_ENUM_LABEL_LIBRETRO_INFO_PATH:
-            snprintf(s, len,
-                     "Core Info Directory. \n"
-                             " \n"
-                             "A directory for where to search \n"
-                             "for libretro core information.");
-            break;
-        case MENU_ENUM_LABEL_PLAYLIST_DIRECTORY:
-            snprintf(s, len,
-                     "Playlist Directory. \n"
-                             " \n"
-                             "Save all playlist files to this \n"
-                             "directory.");
             break;
         case MENU_ENUM_LABEL_DUMMY_ON_CORE_SHUTDOWN:
             snprintf(s, len,
@@ -416,11 +154,6 @@ int msg_hash_get_help_fi_enum(enum msg_hash_enums msg, char *s, size_t len)
                      "Open Windows permission settings to enable \n"
                      "the broadFileSystemAccess capability.");
             break;
-        case MENU_ENUM_LABEL_FILE_BROWSER_OPEN_PICKER:
-           snprintf(s, len,
-                     "Open the system file picker to access \n"
-                     "additional directories.");
-           break;
         case MENU_ENUM_LABEL_FILE_BROWSER_SHADER_PRESET:
             snprintf(s, len,
                      "Shader preset file.");
@@ -504,18 +237,6 @@ int msg_hash_get_help_fi_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Content decompressed by RetroArch will be \n"
                              "temporarily extracted to this directory.");
             break;
-        case MENU_ENUM_LABEL_HISTORY_LIST_ENABLE:
-            snprintf(s, len,
-                     "If enabled, every content loaded \n"
-                             "in RetroArch will be automatically \n"
-                             "added to the recent history list.");
-            break;
-        case MENU_ENUM_LABEL_RGUI_BROWSER_DIRECTORY:
-            snprintf(s, len,
-                     "File Browser Directory. \n"
-                             " \n"
-                             "Sets start directory for menu file browser.");
-            break;
         case MENU_ENUM_LABEL_INPUT_POLL_TYPE_BEHAVIOR:
             snprintf(s, len,
                      "Influence how input polling is done inside \n"
@@ -533,150 +254,11 @@ int msg_hash_get_help_fi_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "depending on your configuration.\n\n"
                              "Will be ignored when using netplay.");
             break;
-        case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_HIDE_UNBOUND:
-            snprintf(s, len,
-                     "Hide input descriptors that were not set \n"
-                             "by the core.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE:
-            snprintf(s, len,
-                     "Video refresh rate of your monitor. \n"
-                             "Used to calculate a suitable audio input rate.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FORCE_SRGB_DISABLE:
-            snprintf(s, len,
-                     "Forcibly disable sRGB FBO support. Some Intel \n"
-                             "OpenGL drivers on Windows have video problems \n"
-                             "with sRGB FBO support enabled.");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_ENABLE:
-            snprintf(s, len,
-                     "Enable audio output.");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_SYNC:
-            snprintf(s, len,
-                     "Synchronize audio (recommended).");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_LATENCY:
-            snprintf(s, len,
-                     "Desired audio latency in milliseconds. \n"
-                             "Might not be honored if the audio driver \n"
-                             "can't provide given latency.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_ALLOW_ROTATE:
-            snprintf(s, len,
-                     "Allow cores to set rotation. If false, \n"
-                             "rotation requests are honored, but ignored.\n\n"
-                             "Used for setups where one manually rotates \n"
-                             "the monitor.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_LABEL_SHOW:
-            snprintf(s, len,
-                     "Show the input descriptors set by the core \n"
-                             "instead of the default ones.");
-            break;
-        case MENU_ENUM_LABEL_CONTENT_HISTORY_SIZE:
-            snprintf(s, len,
-                     "Number of entries that will be kept in \n"
-                             "content history playlist.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_WINDOWED_FULLSCREEN:
-            snprintf(s, len,
-                     "To use windowed mode or not when going \n"
-                             "fullscreen.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FONT_SIZE:
-            snprintf(s, len,
-                     "Font size for on-screen messages.");
-            break;
-        case MENU_ENUM_LABEL_SAVESTATE_AUTO_INDEX:
-            snprintf(s, len,
-                     "Automatically increment slot index on each save, \n"
-                             "generating multiple savestate files. \n"
-                             "When the content is loaded, state slot will be \n"
-                             "set to the highest existing value (last savestate).");
-            break;
-        case MENU_ENUM_LABEL_FPS_SHOW:
-            snprintf(s, len,
-                     "Enables displaying the current frames \n"
-                             "per second.");
-            break;
-        case MENU_ENUM_LABEL_MEMORY_SHOW:
-            snprintf(s, len,
-                     "Includes displaying the current memory \n"
-                             "usage/total with FPS/Frames.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FONT_ENABLE:
-            snprintf(s, len,
-                     "Show and/or hide onscreen messages.");
-            break;
         case MENU_ENUM_LABEL_VIDEO_MESSAGE_POS_X:
         case MENU_ENUM_LABEL_VIDEO_MESSAGE_POS_Y:
             snprintf(s, len,
                      "Offset for where messages will be placed \n"
                              "onscreen. Values are in range [0.0, 1.0].");
-            break;
-        case MENU_ENUM_LABEL_INPUT_OVERLAY_ENABLE:
-            snprintf(s, len,
-                     "Enable or disable the current overlay.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_OVERLAY_HIDE_IN_MENU:
-            snprintf(s, len,
-                     "Hide the current overlay from appearing \n"
-                             "inside the menu.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_OVERLAY_SHOW_PHYSICAL_INPUTS:
-            snprintf(s, len,
-                      "Show keyboard/controller button presses on \n"
-                            "the onscreen overlay.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_OVERLAY_SHOW_PHYSICAL_INPUTS_PORT:
-            snprintf(s, len,
-                      "Select the port to listen for controller input \n"
-                            "to display on the onscreen overlay.");
-            break;
-        case MENU_ENUM_LABEL_OVERLAY_PRESET:
-            snprintf(s, len,
-                     "Path to input overlay.");
-            break;
-        case MENU_ENUM_LABEL_OVERLAY_OPACITY:
-            snprintf(s, len,
-                     "Overlay opacity.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_LAYOUT_ENABLE:
-            snprintf(s, len,
-                     "Enable or disable the current video layout.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_LAYOUT_PATH:
-            snprintf(s, len,
-                     "Path to video layout.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_LAYOUT_SELECTED_VIEW:
-            snprintf(s, len,
-                     "Layouts can contain multiple views. \n"
-                     "Select a view.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_BIND_TIMEOUT:
-            snprintf(s, len,
-                     "Input bind timer timeout (in seconds). \n"
-                             "Amount of seconds to wait until proceeding \n"
-                             "to the next bind.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_BIND_HOLD:
-            snprintf(s, len,
-               "Input bind hold time (in seconds). \n"
-               "Amount of seconds to hold an input to bind it.");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_OUTPUT_RATE:
-            snprintf(s, len,
-                     "Audio output samplerate.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SHARED_CONTEXT:
-            snprintf(s, len,
-                     "Set to true if hardware-rendered cores \n"
-                             "should get their private context. \n"
-                             "Avoids having to assume hardware state changes \n"
-                             "inbetween frames.");
             break;
         case MENU_ENUM_LABEL_CORE_LIST:
             snprintf(s, len,
@@ -917,12 +499,6 @@ int msg_hash_get_help_fi_enum(enum msg_hash_enums msg, char *s, size_t len)
                }
             }
             break;
-        case MENU_ENUM_LABEL_AUDIO_DSP_PLUGIN:
-            snprintf(s, len,
-                     "Audio DSP plugin.\n"
-                             " Processes audio before it's sent to \n"
-                             "the driver.");
-            break;
         case MENU_ENUM_LABEL_AUDIO_RESAMPLER_DRIVER:
             {
                const char *lbl = settings ? settings->arrays.audio_resampler : NULL;
@@ -939,12 +515,6 @@ int msg_hash_get_help_fi_enum(enum msg_hash_enums msg, char *s, size_t len)
                   strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE), len);
             }
             break;
-
-		case MENU_ENUM_LABEL_CRT_SWITCH_RESOLUTION: snprintf(s, len, "SET CRT");
-			break;
-
-		case MENU_ENUM_LABEL_CRT_SWITCH_RESOLUTION_SUPER: snprintf(s, len, "SET CRT SUPER");
-			break;
 
         case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET:
             snprintf(s, len,
@@ -991,19 +561,6 @@ int msg_hash_get_help_fi_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "The Default Filter option will affect the \n"
                              "stretching filter.");
             break;
-        case MENU_ENUM_LABEL_VIDEO_SHADER_PARAMETERS:
-            snprintf(s, len,
-                     "Shader Parameters. \n"
-                             " \n"
-                             "Modifies current shader directly. Will not be \n"
-                             "saved to CGP/GLSLP preset file.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_PARAMETERS:
-            snprintf(s, len,
-                     "Shader Preset Parameters. \n"
-                             " \n"
-                             "Modifies shader preset currently in menu.");
-            break;
         case MENU_ENUM_LABEL_VIDEO_SHADER_PASS:
             snprintf(s, len,
                      "Path to shader. \n"
@@ -1041,13 +598,6 @@ int msg_hash_get_help_fi_enum(enum msg_hash_enums msg, char *s, size_t len)
             "manually isn't really an option."
 #endif
             );
-            break;
-        case MENU_ENUM_LABEL_CONFIRM_ON_EXIT:
-            snprintf(s, len, "Are you sure you want to quit?");
-            break;
-        case MENU_ENUM_LABEL_SHOW_HIDDEN_FILES:
-            snprintf(s, len, "Show hidden files\n"
-                    "and folders.");
             break;
         case MENU_ENUM_LABEL_VIDEO_SHADER_FILTER_PASS:
             snprintf(s, len,
@@ -1126,26 +676,6 @@ int msg_hash_get_help_fi_enum(enum msg_hash_enums msg, char *s, size_t len)
                      "it will automatically be recompiled \n"
                      "and applied to the running content.");
             break;
-        case MENU_ENUM_LABEL_MENU_TOGGLE:
-            snprintf(s, len,
-                     "Toggles menu.");
-            break;
-        case MENU_ENUM_LABEL_GRAB_MOUSE_TOGGLE:
-            snprintf(s, len,
-                     "Toggles mouse grab.\n"
-                             " \n"
-                             "When mouse is grabbed, RetroArch hides the \n"
-                             "mouse, and keeps the mouse pointer inside \n"
-                             "the window to allow relative mouse input to \n"
-                             "work better.");
-            break;
-        case MENU_ENUM_LABEL_GAME_FOCUS_TOGGLE:
-            snprintf(s, len,
-                     "Toggles game focus.\n"
-                             " \n"
-                             "When a game has focus, RetroArch will both disable \n"
-                             "hotkeys and keep/wrap the mouse pointer inside the window.");
-            break;
         case MENU_ENUM_LABEL_DISK_NEXT:
             snprintf(s, len,
                      "Cycles through disk images. Use after \n"
@@ -1189,12 +719,6 @@ int msg_hash_get_help_fi_enum(enum msg_hash_enums msg, char *s, size_t len)
 #endif
             );
             break;
-        case MENU_ENUM_LABEL_DISK_EJECT_TOGGLE:
-            snprintf(s, len,
-                     "Toggles eject for disks.\n"
-                             " \n"
-                             "Used for multiple-disk content.");
-            break;
         case MENU_ENUM_LABEL_ENABLE_HOTKEY:
             snprintf(s, len,
                      "Enable other hotkeys.\n"
@@ -1208,28 +732,6 @@ int msg_hash_get_help_fi_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "implementations which query a large area of \n"
                              "the keyboard, where it is not desirable that \n"
                              "hotkeys get in the way.");
-            break;
-        case MENU_ENUM_LABEL_REWIND_ENABLE:
-            snprintf(s, len,
-                     "Enable rewinding.\n"
-                             " \n"
-                             "This will take a performance hit, \n"
-                             "so it is disabled by default.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_APPLY_AFTER_TOGGLE:
-            snprintf(s, len,
-                     "Apply cheat immediately after toggling.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_APPLY_AFTER_LOAD:
-            snprintf(s, len,
-                     "Auto-apply cheats when game loads.");
-            break;
-        case MENU_ENUM_LABEL_LIBRETRO_DIR_PATH:
-            snprintf(s, len,
-                     "Core Directory. \n"
-                             " \n"
-                             "A directory for where to search for \n"
-                             "libretro core implementations.");
             break;
         case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE_AUTO:
             snprintf(s, len,
@@ -1250,29 +752,6 @@ int msg_hash_get_help_fi_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "large pitch changes. If your monitor does \n"
                              "not run at 60Hz, or something close to it, \n"
                              "disable VSync, and leave this at its default.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE_POLLED:
-            snprintf(s, len,
-                     "Set Polled Refresh Rate\n"
-                             " \n"
-                            "Sets the refresh rate to the actual value\n"
-                            "polled from the display driver.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_ROTATION:
-            snprintf(s, len,
-                     "Forces a certain rotation \n"
-                             "of the screen.\n"
-                             " \n"
-                             "The rotation is added to rotations which\n"
-                             "the libretro core sets (see Video Allow\n"
-                             "Rotate).");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SCALE:
-            snprintf(s, len,
-                     "Fullscreen resolution.\n"
-                             " \n"
-                             "Resolution of 0 uses the \n"
-                             "resolution of the environment.\n");
             break;
         case MENU_ENUM_LABEL_FASTFORWARD_RATIO:
             snprintf(s, len,
@@ -1306,25 +785,6 @@ int msg_hash_get_help_fi_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "is preferred, 1 and up (1 being first \n"
                              "monitor), suggests RetroArch to use that \n"
                              "particular monitor.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_CROP_OVERSCAN:
-            snprintf(s, len,
-                     "Forces cropping of overscanned \n"
-                             "frames.\n"
-                             " \n"
-                             "Exact behavior of this option is \n"
-                             "core-implementation specific.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SCALE_INTEGER:
-            snprintf(s, len,
-                     "Only scales video in integer \n"
-                             "steps.\n"
-                             " \n"
-                             "The base size depends on system-reported \n"
-                             "geometry and aspect ratio.\n"
-                             " \n"
-                             "If Force Aspect is not set, X/Y will be \n"
-                             "integer scaled independently.");
             break;
         case MENU_ENUM_LABEL_AUDIO_VOLUME:
             snprintf(s, len,
@@ -1361,53 +821,10 @@ int msg_hash_get_help_fi_enum(enum msg_hash_enums msg, char *s, size_t len)
                              " Input rate is defined as: \n"
                              " input rate * (1.0 +/- (max timing skew))");
             break;
-        case MENU_ENUM_LABEL_OVERLAY_NEXT:
-            snprintf(s, len,
-                     "Toggles to next overlay.\n"
-                             " \n"
-                             "Wraps around.");
-            break;
-        case MENU_ENUM_LABEL_LOG_VERBOSITY:
-            snprintf(s, len,
-                     "Enable or disable verbosity level \n"
-                             "of frontend.");
-            break;
-        case MENU_ENUM_LABEL_VOLUME_UP:
-            snprintf(s, len,
-                     "Increases audio volume.");
-            break;
-        case MENU_ENUM_LABEL_VOLUME_DOWN:
-            snprintf(s, len,
-                     "Decreases audio volume.");
-            break;
         case MENU_ENUM_LABEL_VIDEO_DISABLE_COMPOSITION:
             snprintf(s, len,
                      "Forcibly disable composition.\n"
                              "Only valid on Windows Vista/7 for now.");
-            break;
-        case MENU_ENUM_LABEL_PERFCNT_ENABLE:
-            snprintf(s, len,
-                     "Enable or disable frontend \n"
-                             "performance counters.");
-            break;
-        case MENU_ENUM_LABEL_SYSTEM_DIRECTORY:
-            snprintf(s, len,
-                     "System Directory. \n"
-                             " \n"
-                             "Sets the 'system' directory.\n"
-                             "Cores can query for this\n"
-                             "directory to load BIOSes, \n"
-                             "system-specific configs, etc.");
-            break;
-        case MENU_ENUM_LABEL_SAVESTATE_AUTO_SAVE:
-        case MENU_ENUM_LABEL_SAVESTATE_AUTO_LOAD:
-            snprintf(s, len,
-                     "Automatically saves a savestate at the \n"
-                             "end of RetroArch's lifetime.\n"
-                             " \n"
-                             "RetroArch will automatically load any savestate\n"
-                             "with this path on startup if 'Auto Load State\n"
-                             "is enabled.");
             break;
         case MENU_ENUM_LABEL_VIDEO_THREADED:
             snprintf(s, len,
@@ -1416,47 +833,6 @@ int msg_hash_get_help_fi_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Using this might improve performance at the \n"
                              "possible cost of latency and more video \n"
                              "stuttering.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_VSYNC:
-            snprintf(s, len,
-                     "Video V-Sync.\n");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_HARD_SYNC:
-            snprintf(s, len,
-                     "Attempts to hard-synchronize \n"
-                             "CPU and GPU.\n"
-                             " \n"
-                             "Can reduce latency at the cost of \n"
-                             "performance.");
-            break;
-        case MENU_ENUM_LABEL_REWIND_GRANULARITY:
-            snprintf(s, len,
-                     "Rewind granularity.\n"
-                             " \n"
-                             " When rewinding defined number of \n"
-                             "frames, you can rewind several frames \n"
-                             "at a time, increasing the rewinding \n"
-                             "speed.");
-            break;
-        case MENU_ENUM_LABEL_REWIND_BUFFER_SIZE:
-            snprintf(s, len,
-                     "Rewind buffer size (MB).\n"
-                             " \n"
-                             " The amount of memory in MB to reserve \n"
-                             "for rewinding.  Increasing this value \n"
-                             "increases the rewind history length.\n");
-            break;
-        case MENU_ENUM_LABEL_REWIND_BUFFER_SIZE_STEP:
-            snprintf(s, len,
-                     "Rewind buffer size step (MB).\n"
-                             " \n"
-                             " Each time you increase or decrease \n"
-                             "the rewind buffer size value via this \n"
-                             "UI it will change by this amount.\n");
-            break;
-        case MENU_ENUM_LABEL_SCREENSHOT:
-            snprintf(s, len,
-                     "Take screenshot.");
             break;
         case MENU_ENUM_LABEL_VIDEO_FRAME_DELAY:
             snprintf(s, len,
@@ -1467,14 +843,6 @@ int msg_hash_get_help_fi_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "higher risk of stuttering.\n"
                              " \n"
                              "Maximum is 15.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SHADER_DELAY:
-            snprintf(s, len,
-                     "Sets by how many milliseconds auto-loading shaders\n"
-                             "are delayed.\n"
-                             "\n"
-                             "Can work around graphical glitches due to using\n"
-                             "'screen grabbing' software like streaming software.");
             break;
         case MENU_ENUM_LABEL_VIDEO_HARD_SYNC_FRAMES:
             snprintf(s, len,
@@ -1501,48 +869,6 @@ int msg_hash_get_help_fi_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "configured as if it is a 60 Hz monitor \n"
                              "(divide refresh rate by 2).");
             break;
-        case MENU_ENUM_LABEL_RGUI_SHOW_START_SCREEN:
-            snprintf(s, len,
-                     "Show startup screen in menu.\n"
-                             "Is automatically set to false when seen\n"
-                             "for the first time.\n"
-                             " \n"
-                             "This is only updated in config if\n"
-                             "'Save Configuration on Exit' is enabled.\n");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FULLSCREEN:
-            snprintf(s, len, "Toggles fullscreen.");
-            break;
-        case MENU_ENUM_LABEL_BLOCK_SRAM_OVERWRITE:
-            snprintf(s, len,
-                     "Block SRAM from being overwritten \n"
-                             "when loading save states.\n"
-                             " \n"
-                             "Might potentially lead to buggy games.");
-            break;
-        case MENU_ENUM_LABEL_PAUSE_NONACTIVE:
-            snprintf(s, len,
-                     "Pause gameplay when window focus \n"
-                             "is lost.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_GPU_SCREENSHOT:
-            snprintf(s, len,
-                     "Screenshots output of GPU shaded \n"
-                             "material if available.");
-            break;
-        case MENU_ENUM_LABEL_SCREENSHOT_DIRECTORY:
-            snprintf(s, len,
-                     "Screenshot Directory. \n"
-                             " \n"
-                             "Directory to dump screenshots to.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SWAP_INTERVAL:
-            snprintf(s, len,
-                     "VSync Swap Interval.\n"
-                             " \n"
-                             "Uses a custom swap interval for VSync. Set this \n"
-                             "to effectively halve monitor refresh rate.");
-            break;
         case MENU_ENUM_LABEL_SAVEFILE_DIRECTORY:
             snprintf(s, len,
                      "Savefile Directory. \n"
@@ -1550,16 +876,6 @@ int msg_hash_get_help_fi_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Save all save files (*.srm) to this \n"
                              "directory. This includes related files like \n"
                              ".bsv, .rt, .psrm, etc...\n"
-                             " \n"
-                             "This will be overridden by explicit command line\n"
-                             "options.");
-            break;
-        case MENU_ENUM_LABEL_SAVESTATE_DIRECTORY:
-            snprintf(s, len,
-                     "Savestate Directory. \n"
-                             " \n"
-                             "Save all save states (*.state) to this \n"
-                             "directory.\n"
                              " \n"
                              "This will be overridden by explicit command line\n"
                              "options.");
@@ -1580,77 +896,8 @@ int msg_hash_get_help_fi_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "be loaded dynamically by the menu depending \n"
                              "on context.");
             break;
-        case MENU_ENUM_LABEL_SLOWMOTION_RATIO:
-            snprintf(s, len,
-                     "Slowmotion ratio."
-                             " \n"
-                             "When slowmotion, content will slow\n"
-                             "down by factor.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_BUTTON_AXIS_THRESHOLD:
-            snprintf(s, len,
-                     "Defines the axis threshold.\n"
-                             " \n"
-                             "How far an axis must be tilted to result\n"
-                             "in a button press.\n"
-                             " Possible values are [0.0, 1.0].");
-            break;
-        case MENU_ENUM_LABEL_INPUT_TURBO_PERIOD:
-            snprintf(s, len,
-                     "Turbo period.\n"
-                             " \n"
-                             "Describes the period of which turbo-enabled\n"
-                             "buttons toggle.\n"
-                             " \n"
-                             "Numbers are described in frames.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_TURBO_MODE:
-            snprintf(s, len,
-                  "Turbo Mode.\n"
-                  " \n"
-                  "Selects the general behavior of turbo mode.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_TURBO_DEFAULT_BUTTON:
-            snprintf(s, len,
-                  "Turbo Default Button.\n"
-                  " \n"
-                  "Default active button for Turbo Mode 'Single Button'.\n");
-            break;
-        case MENU_ENUM_LABEL_INPUT_DUTY_CYCLE:
-            snprintf(s, len,
-                     "Duty cycle.\n"
-                             " \n"
-                             "Describes how long the period of a turbo-enabled\n"
-                             "should be.\n"
-                             " \n"
-                             "Numbers are described in frames.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_TOUCH_ENABLE:
-            snprintf(s, len, "Enable touch support.");
-            break;
         case MENU_ENUM_LABEL_INPUT_PREFER_FRONT_TOUCH:
             snprintf(s, len, "Use front instead of back touch.");
-            break;
-        case MENU_ENUM_LABEL_MOUSE_ENABLE:
-            snprintf(s, len, "Enable mouse input inside the menu.");
-            break;
-        case MENU_ENUM_LABEL_POINTER_ENABLE:
-            snprintf(s, len, "Enable touch input inside the menu.");
-            break;
-        case MENU_ENUM_LABEL_MENU_WALLPAPER:
-            snprintf(s, len, "Path to an image to set as the background.");
-            break;
-        case MENU_ENUM_LABEL_NAVIGATION_WRAPAROUND:
-            snprintf(s, len,
-                     "Wrap-around to beginning and/or end \n"
-                             "if boundary of list is reached \n"
-                             "horizontally and/or vertically.");
-            break;
-        case MENU_ENUM_LABEL_PAUSE_LIBRETRO:
-            snprintf(s, len,
-                     "If disabled, the game will keep \n"
-                             "running in the background when we are in the \n"
-                             "menu.");
             break;
         case MENU_ENUM_LABEL_SUSPEND_SCREENSAVER_ENABLE:
             snprintf(s, len,
@@ -1670,13 +917,6 @@ int msg_hash_get_help_fi_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Increasing this value will increase \n"
                              "performance, but introduce more latency.");
             break;
-        case MENU_ENUM_LABEL_NETPLAY_PUBLIC_ANNOUNCE:
-            snprintf(s, len,
-                     "Whether to announce netplay games publicly. \n"
-                             " \n"
-                             "If set to false, clients must manually connect \n"
-                             "rather than using the public lobby.");
-            break;
         case MENU_ENUM_LABEL_NETPLAY_START_AS_SPECTATOR:
             snprintf(s, len,
                      "Whether to start netplay in spectator mode. \n"
@@ -1684,21 +924,6 @@ int msg_hash_get_help_fi_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "If set to true, netplay will be in spectator mode \n"
                              "on start. It's always possible to change mode \n"
                              "later.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_ALLOW_SLAVES:
-            snprintf(s, len,
-                     "Whether to allow connections in slave mode. \n"
-                             " \n"
-                             "Slave-mode clients require very little processing \n"
-                             "power on either side, but will suffer \n"
-                             "significantly from network latency.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_REQUIRE_SLAVES:
-            snprintf(s, len,
-                     "Whether to disallow connections not in slave mode. \n"
-                             " \n"
-                             "Not recommended except for very fast networks \n"
-                             "with very weak machines.");
             break;
         case MENU_ENUM_LABEL_NETPLAY_CHECK_FRAMES:
             snprintf(s, len,
@@ -1741,24 +966,6 @@ int msg_hash_get_help_fi_enum(enum msg_hash_enums msg, char *s, size_t len)
                      "makes netplay less CPU-intensive, but at \n"
                      "the price of unpredictable input lag. \n");
             break;
-        case MENU_ENUM_LABEL_NETPLAY_NAT_TRAVERSAL:
-            snprintf(s, len,
-                     "When hosting, attempt to listen for\n"
-                             "connections from the public internet, using\n"
-                             "UPnP or similar technologies to escape LANs. \n");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_USE_MITM_SERVER:
-            snprintf(s, len,
-                     "When hosting a netplay session, relay connection through a \n"
-                             "man-in-the-middle server \n"
-                             "to get around firewalls or NAT/UPnP issues. \n");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_MITM_SERVER:
-            snprintf(s, len,
-                     "Specifies the man-in-the-middle server \n"
-                             "to use for netplay. A server that is \n"
-                             "located closer to you may have less latency. \n");
-            break;
         case MENU_ENUM_LABEL_VIDEO_MAX_SWAPCHAIN_IMAGES:
             snprintf(s, len,
                      "Maximum amount of swapchain images. This \n"
@@ -1786,192 +993,19 @@ int msg_hash_get_help_fi_enum(enum msg_hash_enums msg, char *s, size_t len)
 #endif
          );
          break;
-        case MENU_ENUM_LABEL_TIMEDATE_ENABLE:
-            snprintf(s, len,
-                     "Shows current date and/or time inside menu.");
-            break;
-        case MENU_ENUM_LABEL_TIMEDATE_STYLE:
-           snprintf(s, len,
-              "Style to show the current date and/or time in.");
-           break;
-        case MENU_ENUM_LABEL_BATTERY_LEVEL_ENABLE:
-            snprintf(s, len,
-                     "Shows current battery level inside menu.");
-            break;
-        case MENU_ENUM_LABEL_CORE_ENABLE:
-            snprintf(s, len,
-                     "Shows current core inside menu.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_ENABLE_HOST:
-            snprintf(s, len,
-                     "Enables Netplay in host (server) mode.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_ENABLE_CLIENT:
-            snprintf(s, len,
-                     "Enables Netplay in client mode.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_DISCONNECT:
-            snprintf(s, len,
-                     "Disconnects an active Netplay connection.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_LAN_SCAN_SETTINGS:
-            snprintf(s, len,
-                     "Search for and connect to netplay hosts on the local network.");
-            break;
         case MENU_ENUM_LABEL_NETPLAY_SETTINGS:
             snprintf(s, len,
                      "Setting related to Netplay.");
-            break;
-        case MENU_ENUM_LABEL_DYNAMIC_WALLPAPER:
-            snprintf(s, len,
-                     "Dynamically load a new background \n"
-                             "depending on context.");
-            break;
-        case MENU_ENUM_LABEL_CORE_UPDATER_BUILDBOT_URL:
-            snprintf(s, len,
-                     "URL to core updater directory on the \n"
-                             "Libretro buildbot.");
-            break;
-        case MENU_ENUM_LABEL_BUILDBOT_ASSETS_URL:
-            snprintf(s, len,
-                     "URL to assets updater directory on the \n"
-                             "Libretro buildbot.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_REMAP_BINDS_ENABLE:
-            snprintf(s, len,
-                     "if enabled, overrides the input binds \n"
-                             "with the remapped binds set for the \n"
-                             "current core.");
-            break;
-        case MENU_ENUM_LABEL_OVERLAY_DIRECTORY:
-            snprintf(s, len,
-                     "Overlay Directory. \n"
-                             " \n"
-                             "Defines a directory where overlays are \n"
-                             "kept for easy access.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_LAYOUT_DIRECTORY:
-            snprintf(s, len,
-                     "Video Layout Directory. \n"
-                             " \n"
-                             "Defines a directory where video layouts are \n"
-                             "kept for easy access.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_MAX_USERS:
-            snprintf(s, len,
-                     "Maximum amount of users supported by \n"
-                             "RetroArch.");
-            break;
-        case MENU_ENUM_LABEL_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
-            snprintf(s, len,
-                     "After downloading, automatically extract \n"
-                             "archives that the downloads are contained \n"
-                             "inside.");
-            break;
-        case MENU_ENUM_LABEL_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
-            snprintf(s, len,
-                     "Filter files being shown by \n"
-                             "supported extensions.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_NICKNAME:
-            snprintf(s, len,
-                     "The username of the person running RetroArch. \n"
-                             "This will be used for playing online games.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_TCP_UDP_PORT:
-            snprintf(s, len,
-                     "The port of the host IP address. \n"
-                             "Can be either a TCP or UDP port.");
             break;
         case MENU_ENUM_LABEL_NETPLAY_SPECTATOR_MODE_ENABLE:
             snprintf(s, len,
                      "Enable or disable spectator mode for \n"
                              "the user during netplay.");
             break;
-        case MENU_ENUM_LABEL_NETPLAY_IP_ADDRESS:
-            snprintf(s, len,
-                     "The address of the host to connect to.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_PASSWORD:
-            snprintf(s, len,
-                     "The password for connecting to the netplay \n"
-                             "host. Used only in host mode.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_SPECTATE_PASSWORD:
-            snprintf(s, len,
-                     "The password for connecting to the netplay \n"
-                             "host with only spectator privileges. Used \n"
-                             "only in host mode.");
-            break;
-        case MENU_ENUM_LABEL_STDIN_CMD_ENABLE:
-            snprintf(s, len,
-                     "Enable stdin command interface.");
-            break;
         case MENU_ENUM_LABEL_UI_COMPANION_START_ON_BOOT:
             snprintf(s, len,
                      "Start User Interface companion driver \n"
                              "on boot (if available).");
-            break;
-        case MENU_ENUM_LABEL_MENU_DRIVER:
-            snprintf(s, len, "Menu driver to use.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
-            snprintf(s, len,
-                     "Gamepad button combination to toggle menu. \n"
-                             " \n"
-                             "0 - None \n"
-                             "1 - Press L + R + Y + D-Pad Down \n"
-                             "simultaneously. \n"
-                             "2 - Press L3 + R3 simultaneously. \n"
-                             "3 - Press Start + Select simultaneously.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_ALL_USERS_CONTROL_MENU:
-            snprintf(s, len, "Allows any user to control the menu. \n"
-                    " \n"
-                    "When disabled, only user 1 can control the menu.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_AUTODETECT_ENABLE:
-            snprintf(s, len,
-                     "Enable input auto-detection.\n"
-                             " \n"
-                             "Will attempt to auto-configure \n"
-                             "joypads, Plug-and-Play style.");
-            break;
-        case MENU_ENUM_LABEL_CAMERA_ALLOW:
-            snprintf(s, len,
-                     "Allow or disallow camera access by \n"
-                             "cores.");
-            break;
-        case MENU_ENUM_LABEL_LOCATION_ALLOW:
-            snprintf(s, len,
-                     "Allow or disallow location services \n"
-                             "access by cores.");
-            break;
-        case MENU_ENUM_LABEL_TURBO:
-            snprintf(s, len,
-                     "Turbo enable.\n"
-                             " \n"
-                             "Holding the turbo while pressing another \n"
-                             "button will let the button enter a turbo \n"
-                             "mode where the button state is modulated \n"
-                             "with a periodic signal. \n"
-                             " \n"
-                             "The modulation stops when the button \n"
-                             "itself (not turbo button) is released.");
-            break;
-        case MENU_ENUM_LABEL_OSK_ENABLE:
-            snprintf(s, len,
-                     "Enable/disable on-screen keyboard.");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_MUTE:
-            snprintf(s, len,
-                     "Mute/unmute audio.");
-            break;
-        case MENU_ENUM_LABEL_REWIND:
-            snprintf(s, len,
-                     "Hold button down to rewind.\n"
-                             " \n"
-                             "Rewind must be enabled.");
             break;
         case MENU_ENUM_LABEL_EXIT_EMULATOR:
             snprintf(s, len,
@@ -1985,176 +1019,9 @@ int msg_hash_get_help_fi_enum(enum msg_hash_enums msg, char *s, size_t len)
 #endif
             );
             break;
-        case MENU_ENUM_LABEL_LOAD_STATE:
-            snprintf(s, len,
-                     "Loads state.");
-            break;
-        case MENU_ENUM_LABEL_SAVE_STATE:
-            snprintf(s, len,
-                     "Saves state.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_GAME_WATCH:
-            snprintf(s, len,
-                     "Netplay toggle play/spectate mode.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_INDEX_PLUS:
-            snprintf(s, len,
-                     "Increase cheat index.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_INDEX_MINUS:
-            snprintf(s, len,
-                     "Decrease cheat index.");
-            break;
-        case MENU_ENUM_LABEL_SHADER_PREV:
-            snprintf(s, len,
-                     "Applies previous shader in directory.");
-            break;
-        case MENU_ENUM_LABEL_SHADER_NEXT:
-            snprintf(s, len,
-                     "Applies next shader in directory.");
-            break;
-        case MENU_ENUM_LABEL_RESET:
-            snprintf(s, len,
-                     "Reset the content.");
-            break;
-        case MENU_ENUM_LABEL_PAUSE_TOGGLE:
-            snprintf(s, len,
-                     "Toggle between paused and non-paused state.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_TOGGLE:
-            snprintf(s, len,
-                     "Toggle cheat index.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_IDX:
-            snprintf(s, len,
-                     "Index position in list.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_ADDRESS_BIT_POSITION:
-            snprintf(s, len,
-                     "Address bitmask when Memory Search Size < 8-bit.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_REPEAT_COUNT:
-            snprintf(s, len,
-                     "The number of times the cheat will be applied.\nUse with the other two Iteration options to affect large areas of memory.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_REPEAT_ADD_TO_ADDRESS:
-            snprintf(s, len,
-                     "After each 'Number of Iterations' the Memory Address will be increased by this number times the 'Memory Search Size'.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_REPEAT_ADD_TO_VALUE:
-            snprintf(s, len,
-                     "After each 'Number of Iterations' the Value will be increased by this amount.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_MATCH_IDX:
-            snprintf(s, len,
-                     "Select the match to view.");
-            break;
         case MENU_ENUM_LABEL_CHEAT_START_OR_CONT:
             snprintf(s, len,
                      "Scan memory to create new cheats.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_START_OR_RESTART:
-            snprintf(s, len,
-                     "Left/Right to change bit-size.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_EXACT:
-            snprintf(s, len,
-                     "Left/Right to change value.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_LT:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_GT:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_EQ:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_NEQ:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_EQPLUS:
-            snprintf(s, len,
-                     "Left/Right to change value.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_EQMINUS:
-            snprintf(s, len,
-                     "Left/Right to change value.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_ADD_MATCHES:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_VIEW_MATCHES:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_CREATE_OPTION:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_DELETE_OPTION:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_ADD_NEW_TOP:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_RELOAD_CHEATS:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_ADD_NEW_BOTTOM:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_DELETE_ALL:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_BIG_ENDIAN:
-            snprintf(s, len,
-                     "Big endian    : 258 = 0x0102\n"
-                     "Little endian : 258 = 0x0201");
-            break;
-        case MENU_ENUM_LABEL_HOLD_FAST_FORWARD:
-            snprintf(s, len,
-                     "Hold for fast-forward. Releasing button \n"
-                             "disables fast-forward.");
-            break;
-        case MENU_ENUM_LABEL_SLOWMOTION_HOLD:
-            snprintf(s, len,
-                     "Hold for slowmotion.");
-            break;
-        case MENU_ENUM_LABEL_FRAME_ADVANCE:
-            snprintf(s, len,
-                     "Frame advance when content is paused.");
-            break;
-        case MENU_ENUM_LABEL_BSV_RECORD_TOGGLE:
-            snprintf(s, len,
-                     "Toggle between recording and not.");
-            break;
-        case MENU_ENUM_LABEL_L_X_PLUS:
-        case MENU_ENUM_LABEL_L_X_MINUS:
-        case MENU_ENUM_LABEL_L_Y_PLUS:
-        case MENU_ENUM_LABEL_L_Y_MINUS:
-        case MENU_ENUM_LABEL_R_X_PLUS:
-        case MENU_ENUM_LABEL_R_X_MINUS:
-        case MENU_ENUM_LABEL_R_Y_PLUS:
-        case MENU_ENUM_LABEL_R_Y_MINUS:
-            snprintf(s, len,
-                     "Axis for analog stick (DualShock-esque).\n"
-                             " \n"
-                             "Bound as usual, however, if a real analog \n"
-                             "axis is bound, it can be read as a true analog.\n"
-                             " \n"
-                             "Positive X axis is right. \n"
-                             "Positive Y axis is down.");
             break;
         case MENU_ENUM_LABEL_VALUE_WHAT_IS_A_CORE_DESC:
             snprintf(s, len,
@@ -2202,41 +1069,37 @@ int msg_hash_get_help_fi_enum(enum msg_hash_enums msg, char *s, size_t len)
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OVERLAY_SETTINGS),
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_HIDE_IN_MENU));
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_ENABLE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_ENABLE:
             snprintf(s, len,
                      "Enables a background color for the OSD.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_RED:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_RED:
             snprintf(s, len,
                      "Sets the red value of the OSD background color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_GREEN:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_GREEN:
             snprintf(s, len,
                      "Sets the green value of the OSD background color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_BLUE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_BLUE:
             snprintf(s, len,
                      "Sets the blue value of the OSD background color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_OPACITY:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_OPACITY:
             snprintf(s, len,
                      "Sets the opacity of the OSD background color. Valid values are between 0.0 and 1.0.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_RED:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_RED:
             snprintf(s, len,
                      "Sets the red value of the OSD text color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_GREEN:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_GREEN:
             snprintf(s, len,
                      "Sets the green value of the OSD text color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_BLUE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_BLUE:
             snprintf(s, len,
                      "Sets the blue value of the OSD text color. Valid values are between 0 and 255.");
-            break;
-        case MENU_ENUM_LABEL_MIDI_DRIVER:
-            snprintf(s, len,
-                     "MIDI driver to use.");
             break;
         case MENU_ENUM_LABEL_MIDI_INPUT:
             snprintf(s, len,
@@ -2253,10 +1116,6 @@ int msg_hash_get_help_fi_enum(enum msg_hash_enums msg, char *s, size_t len)
                      "When MIDI output is enabled and core and game/app support MIDI output,\n"
                      "some or all sounds (depends on game/app) will be generated by MIDI device.\n"
                      "In case of \"null\" MIDI driver this means that those sounds won't be audible.");
-            break;
-        case MENU_ENUM_LABEL_MIDI_VOLUME:
-            snprintf(s, len,
-                     "Sets the master volume of the output device.");
             break;
         default:
             if (string_is_empty(s))

--- a/intl/msg_hash_fr.c
+++ b/intl/msg_hash_fr.c
@@ -2215,35 +2215,35 @@ int msg_hash_get_help_fr_enum(enum msg_hash_enums msg, char *s, size_t len)
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_HIDE_IN_MENU)
             );
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_ENABLE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_ENABLE:
             snprintf(s, len,
                      "Active l'utilisation d'une couleur de fond pour le texte d'affichage à l'écran (OSD).");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_RED:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_RED:
             snprintf(s, len,
                      "Définit la valeur de rouge de la couleur d'arrière-plan du texte d'affichage à l'écran (OSD). Les valeurs valides sont comprises entre 0 et 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_GREEN:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_GREEN:
             snprintf(s, len,
                      "Définit la valeur de vert de la couleur d'arrière-plan du texte d'affichage à l'écran (OSD). Les valeurs valides sont comprises entre 0 et 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_BLUE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_BLUE:
             snprintf(s, len,
                      "Définit la valeur de bleu de la couleur d'arrière-plan du texte d'affichage à l'écran (OSD). Les valeurs valides sont comprises entre 0 et 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_OPACITY:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_OPACITY:
             snprintf(s, len,
                      "Définit l'opacité de la couleur d'arrière-plan du texte d'affichage à l'écran (OSD). Les valeurs valides sont comprises entre 0.0 et 1.0.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_RED:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_RED:
             snprintf(s, len,
                      "Définit la valeur de rouge de la couleur du texte d'affichage à l'écran (OSD). Les valeurs valides sont comprises entre 0 et 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_GREEN:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_GREEN:
             snprintf(s, len,
                      "Définit la valeur de vert de la couleur du texte d'affichage à l'écran (OSD). Les valeurs valides sont comprises entre 0 et 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_BLUE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_BLUE:
             snprintf(s, len,
                      "Définit la valeur de bleu de la couleur du texte d'affichage à l'écran (OSD). Les valeurs valides sont comprises entre 0 et 255.");
             break;

--- a/intl/msg_hash_it.c
+++ b/intl/msg_hash_it.c
@@ -541,12 +541,6 @@ int msg_hash_get_help_it_enum(enum msg_hash_enums msg, char *s, size_t len)
 #endif
                );
          break;
-      case MENU_ENUM_LABEL_DISK_EJECT_TOGGLE:
-         snprintf(s, len,
-               "Toggles eject for disks.\n"
-               " \n"
-               "Used for multiple-disk content.");
-         break;
       case MENU_ENUM_LABEL_ENABLE_HOTKEY:
          snprintf(s, len,
                "Enable other hotkeys.\n"
@@ -560,20 +554,6 @@ int msg_hash_get_help_it_enum(enum msg_hash_enums msg, char *s, size_t len)
                "implementations which query a large area of \n"
                "the keyboard, where it is not desirable that \n"
                "hotkeys get in the way.");
-         break;
-      case MENU_ENUM_LABEL_REWIND_ENABLE:
-         snprintf(s, len,
-               "Enable rewinding.\n"
-               " \n"
-               "This will take a performance hit, \n"
-               "so it is disabled by default.");
-         break;
-      case MENU_ENUM_LABEL_LIBRETRO_DIR_PATH:
-         snprintf(s, len,
-               "Core Directory. \n"
-               " \n"
-               "A directory for where to search for \n"
-               "libretro core implementations.");
          break;
       case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE_AUTO:
          snprintf(s, len,
@@ -594,22 +574,6 @@ int msg_hash_get_help_it_enum(enum msg_hash_enums msg, char *s, size_t len)
                "large pitch changes. If your monitor does \n"
                "not run at 60Hz, or something close to it, \n"
                "disable VSync, and leave this at its default.");
-         break;
-      case MENU_ENUM_LABEL_VIDEO_ROTATION:
-         snprintf(s, len,
-               "Forces a certain rotation \n"
-               "of the screen.\n"
-               " \n"
-               "The rotation is added to rotations which\n"
-               "the libretro core sets (see Video Allow\n"
-               "Rotate).");
-         break;
-      case MENU_ENUM_LABEL_VIDEO_SCALE:
-         snprintf(s, len,
-               "Fullscreen resolution.\n"
-               " \n"
-               "Resolution of 0 uses the \n"
-               "resolution of the environment.\n");
          break;
       case MENU_ENUM_LABEL_FASTFORWARD_RATIO:
          snprintf(s, len,
@@ -634,25 +598,6 @@ int msg_hash_get_help_it_enum(enum msg_hash_enums msg, char *s, size_t len)
                "is preferred, 1 and up (1 being first \n"
                "monitor), suggests RetroArch to use that \n"
                "particular monitor.");
-         break;
-      case MENU_ENUM_LABEL_VIDEO_CROP_OVERSCAN:
-         snprintf(s, len,
-               "Forces cropping of overscanned \n"
-               "frames.\n"
-               " \n"
-               "Exact behavior of this option is \n"
-               "core-implementation specific.");
-         break;
-      case MENU_ENUM_LABEL_VIDEO_SCALE_INTEGER:
-         snprintf(s, len,
-               "Only scales video in integer \n"
-               "steps.\n"
-               " \n"
-               "The base size depends on system-reported \n"
-               "geometry and aspect ratio.\n"
-               " \n"
-               "If Force Aspect is not set, X/Y will be \n"
-               "integer scaled independently.");
          break;
       case MENU_ENUM_LABEL_AUDIO_VOLUME:
          snprintf(s, len,
@@ -689,52 +634,10 @@ int msg_hash_get_help_it_enum(enum msg_hash_enums msg, char *s, size_t len)
                " Input rate is defined as: \n"
                " input rate * (1.0 +/- (max timing skew))");
          break;
-      case MENU_ENUM_LABEL_OVERLAY_NEXT:
-         snprintf(s, len,
-               "Toggles to next overlay.\n"
-               " \n"
-               "Wraps around.");
-         break;
-      case MENU_ENUM_LABEL_LOG_VERBOSITY:
-         snprintf(s, len,
-               "Enable or disable verbosity level \n"
-               "of frontend.");
-         break;
-      case MENU_ENUM_LABEL_VOLUME_UP:
-         snprintf(s, len,
-               "Increases audio volume.");
-         break;
-      case MENU_ENUM_LABEL_VOLUME_DOWN:
-         snprintf(s, len,
-               "Decreases audio volume.");
-         break;
       case MENU_ENUM_LABEL_VIDEO_DISABLE_COMPOSITION:
          snprintf(s, len,
                "Forcibly disable composition.\n"
                "Only valid on Windows Vista/7 for now.");
-         break;
-      case MENU_ENUM_LABEL_PERFCNT_ENABLE:
-         snprintf(s, len,
-               "Enable or disable frontend \n"
-               "performance counters.");
-         break;
-      case MENU_ENUM_LABEL_SYSTEM_DIRECTORY:
-         snprintf(s, len,
-               "System Directory. \n"
-               " \n"
-               "Sets the 'system' directory.\n"
-               "Cores can query for this\n"
-               "directory to load BIOSes, \n"
-               "system-specific configs, etc.");
-         break;
-      case MENU_ENUM_LABEL_SAVESTATE_AUTO_SAVE:
-         snprintf(s, len,
-               "Automatically saves a savestate at the \n"
-               "end of RetroArch's lifetime.\n"
-               " \n"
-               "RetroArch will automatically load any savestate\n"
-               "with this path on startup if 'Auto Load State\n"
-               "is enabled.");
          break;
       case MENU_ENUM_LABEL_VIDEO_THREADED:
          snprintf(s, len,
@@ -743,31 +646,6 @@ int msg_hash_get_help_it_enum(enum msg_hash_enums msg, char *s, size_t len)
                "Using this might improve performance at \n"
                "possible cost of latency and more video \n"
                "stuttering.");
-         break;
-      case MENU_ENUM_LABEL_VIDEO_VSYNC:
-         snprintf(s, len,
-               "Video V-Sync.\n");
-         break;
-      case MENU_ENUM_LABEL_VIDEO_HARD_SYNC:
-         snprintf(s, len,
-               "Attempts to hard-synchronize \n"
-               "CPU and GPU.\n"
-               " \n"
-               "Can reduce latency at cost of \n"
-               "performance.");
-         break;
-      case MENU_ENUM_LABEL_REWIND_GRANULARITY:
-         snprintf(s, len,
-               "Rewind granularity.\n"
-               " \n"
-               " When rewinding defined number of \n"
-               "frames, you can rewind several frames \n"
-               "at a time, increasing the rewinding \n"
-               "speed.");
-         break;
-      case MENU_ENUM_LABEL_SCREENSHOT:
-         snprintf(s, len,
-               "Take screenshot.");
          break;
       case MENU_ENUM_LABEL_VIDEO_FRAME_DELAY:
          snprintf(s, len,
@@ -804,70 +682,6 @@ int msg_hash_get_help_it_enum(enum msg_hash_enums msg, char *s, size_t len)
                "configured as if it is a 60 Hz monitor \n"
                "(divide refresh rate by 2).");
          break;
-      case MENU_ENUM_LABEL_RGUI_SHOW_START_SCREEN:
-         snprintf(s, len,
-               "Show startup screen in menu.\n"
-               "Is automatically set to false when seen\n"
-               "for the first time.\n"
-               " \n"
-               "This is only updated in config if\n"
-               "'Save Configuration on Exit' is enabled.\n");
-         break;
-      case MENU_ENUM_LABEL_VIDEO_FULLSCREEN:
-         snprintf(s, len, "Toggles fullscreen.");
-         break;
-      case MENU_ENUM_LABEL_BLOCK_SRAM_OVERWRITE:
-         snprintf(s, len,
-               "Block SRAM from being overwritten \n"
-               "when loading save states.\n"
-               " \n"
-               "Might potentially lead to buggy games.");
-         break;
-      case MENU_ENUM_LABEL_PAUSE_NONACTIVE:
-         snprintf(s, len,
-               "Pause gameplay when window focus \n"
-               "is lost.");
-         break;
-      case MENU_ENUM_LABEL_VIDEO_GPU_SCREENSHOT:
-         snprintf(s, len,
-               "Screenshots output of GPU shaded \n"
-               "material if available.");
-         break;
-      case MENU_ENUM_LABEL_SCREENSHOT_DIRECTORY:
-         snprintf(s, len,
-               "Screenshot Directory. \n"
-               " \n"
-               "Directory to dump screenshots to."
-               );
-         break;
-      case MENU_ENUM_LABEL_VIDEO_SWAP_INTERVAL:
-         snprintf(s, len,
-               "VSync Swap Interval.\n"
-               " \n"
-               "Uses a custom swap interval for VSync. Set this \n"
-               "to effectively halve monitor refresh rate.");
-         break;
-      case MENU_ENUM_LABEL_SAVEFILE_DIRECTORY:
-         snprintf(s, len,
-               "Savefile Directory. \n"
-               " \n"
-               "Save all save files (*.srm) to this \n"
-               "directory. This includes related files like \n"
-               ".bsv, .rt, .psrm, etc...\n"
-               " \n"
-               "This will be overridden by explicit command line\n"
-               "options.");
-         break;
-      case MENU_ENUM_LABEL_SAVESTATE_DIRECTORY:
-         snprintf(s, len,
-               "Savestate Directory. \n"
-               " \n"
-               "Save all save states (*.state) to this \n"
-               "directory.\n"
-               " \n"
-               "This will be overridden by explicit command line\n"
-               "options.");
-         break;
       case MENU_ENUM_LABEL_ASSETS_DIRECTORY:
          snprintf(s, len,
                "Assets Directory. \n"
@@ -884,64 +698,6 @@ int msg_hash_get_help_it_enum(enum msg_hash_enums msg, char *s, size_t len)
                "be loaded dynamically by the menu depending \n"
                "on context.");
          break;
-      case MENU_ENUM_LABEL_SLOWMOTION_RATIO:
-         snprintf(s, len,
-               "Slowmotion ratio."
-               " \n"
-               "When slowmotion, content will slow\n"
-               "down by factor.");
-         break;
-      case MENU_ENUM_LABEL_INPUT_TURBO_PERIOD:
-         snprintf(s, len,
-               "Turbo period.\n"
-               " \n"
-               "Describes speed of which turbo-enabled\n"
-               "buttons toggle."
-               );
-         break;
-      case MENU_ENUM_LABEL_INPUT_AUTODETECT_ENABLE:
-         snprintf(s, len,
-               "Enable input auto-detection.\n"
-               " \n"
-               "Will attempt to auto-configure \n"
-               "joypads, Plug-and-Play style.");
-         break;
-      case MENU_ENUM_LABEL_CAMERA_ALLOW:
-         snprintf(s, len,
-               "Allow or disallow camera access by \n"
-               "cores.");
-         break;
-      case MENU_ENUM_LABEL_LOCATION_ALLOW:
-         snprintf(s, len,
-               "Allow or disallow location services \n"
-               "access by cores.");
-         break;
-      case MENU_ENUM_LABEL_TURBO:
-         snprintf(s, len,
-               "Turbo enable.\n"
-               " \n"
-               "Holding the turbo while pressing another \n"
-               "button will let the button enter a turbo \n"
-               "mode where the button state is modulated \n"
-               "with a periodic signal. \n"
-               " \n"
-               "The modulation stops when the button \n"
-               "itself (not turbo button) is released.");
-         break;
-      case MENU_ENUM_LABEL_OSK_ENABLE:
-         snprintf(s, len,
-               "Enable/disable on-screen keyboard.");
-         break;
-      case MENU_ENUM_LABEL_AUDIO_MUTE:
-         snprintf(s, len,
-               "Mute/unmute audio.");
-         break;
-      case MENU_ENUM_LABEL_REWIND:
-         snprintf(s, len,
-               "Hold button down to rewind.\n"
-               " \n"
-               "Rewind must be enabled.");
-         break;
       case MENU_ENUM_LABEL_EXIT_EMULATOR:
          snprintf(s, len,
                "Key to exit RetroArch cleanly."
@@ -953,72 +709,6 @@ int msg_hash_get_help_it_enum(enum msg_hash_enums msg, char *s, size_t len)
                "a clean deinitialization."
 #endif
                );
-         break;
-      case MENU_ENUM_LABEL_LOAD_STATE:
-         snprintf(s, len,
-               "Loads state.");
-         break;
-      case MENU_ENUM_LABEL_SAVE_STATE:
-         snprintf(s, len,
-               "Saves state.");
-         break;
-      case MENU_ENUM_LABEL_CHEAT_INDEX_MINUS:
-         snprintf(s, len,
-               "Decrement cheat index.\n");
-         break;
-      case MENU_ENUM_LABEL_SHADER_PREV:
-         snprintf(s, len,
-               "Applies previous shader in directory.");
-         break;
-      case MENU_ENUM_LABEL_SHADER_NEXT:
-         snprintf(s, len,
-               "Applies next shader in directory.");
-         break;
-      case MENU_ENUM_LABEL_RESET:
-         snprintf(s, len,
-               "Reset the content.\n");
-         break;
-      case MENU_ENUM_LABEL_PAUSE_TOGGLE:
-         snprintf(s, len,
-               "Toggle between paused and non-paused state.");
-         break;
-      case MENU_ENUM_LABEL_CHEAT_TOGGLE:
-         snprintf(s, len,
-               "Toggle cheat index.\n");
-         break;
-      case MENU_ENUM_LABEL_HOLD_FAST_FORWARD:
-         snprintf(s, len,
-               "Hold for fast-forward. Releasing button \n"
-               "disables fast-forward.");
-         break;
-      case MENU_ENUM_LABEL_SLOWMOTION_HOLD:
-         snprintf(s, len,
-               "Hold for slowmotion.");
-         break;
-      case MENU_ENUM_LABEL_FRAME_ADVANCE:
-         snprintf(s, len,
-               "Frame advance when content is paused.");
-         break;
-      case MENU_ENUM_LABEL_BSV_RECORD_TOGGLE:
-         snprintf(s, len,
-               "Toggle between recording and not.");
-         break;
-      case MENU_ENUM_LABEL_L_X_PLUS:
-      case MENU_ENUM_LABEL_L_X_MINUS:
-      case MENU_ENUM_LABEL_L_Y_PLUS:
-      case MENU_ENUM_LABEL_L_Y_MINUS:
-      case MENU_ENUM_LABEL_R_X_PLUS:
-      case MENU_ENUM_LABEL_R_X_MINUS:
-      case MENU_ENUM_LABEL_R_Y_PLUS:
-      case MENU_ENUM_LABEL_R_Y_MINUS:
-         snprintf(s, len,
-               "Axis for analog stick (DualShock-esque).\n"
-               " \n"
-               "Bound as usual, however, if a real analog \n"
-               "axis is bound, it can be read as a true analog.\n"
-               " \n"
-               "Positive X axis is right. \n"
-               "Positive Y axis is down.");
          break;
       case MENU_ENUM_LABEL_VALUE_WHAT_IS_A_CORE_DESC:
          snprintf(s, len,

--- a/intl/msg_hash_ko.c
+++ b/intl/msg_hash_ko.c
@@ -209,20 +209,6 @@ int msg_hash_get_help_ko_enum(enum msg_hash_enums msg, char *s, size_t len)
                    "When slot is not 0, path will be <path><d>, \n"
                    "where <d> is slot number.");
              break;
-          case RARCH_SAVE_STATE_KEY:
-             snprintf(s, len,
-                   "Saves state.");
-             break;
-          case RARCH_REWIND:
-             snprintf(s, len,
-                   "Hold button down to rewind. \n"
-                   " \n"
-                   "Rewinding must be enabled.");
-             break;
-          case RARCH_BSV_RECORD_TOGGLE:
-             snprintf(s, len,
-                   "Toggle between recording and not.");
-             break;
           default:
              if (string_is_empty(s))
                 strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE), len);
@@ -245,12 +231,6 @@ int msg_hash_get_help_ko_enum(enum msg_hash_enums msg, char *s, size_t len)
                     "to input the username and password into \n"
                     "RetroArch.");
             break;
-        case MENU_ENUM_LABEL_CHEEVOS_USERNAME:
-            snprintf(s, len, "Username for your Retro Achievements account.");
-            break;
-        case MENU_ENUM_LABEL_CHEEVOS_PASSWORD:
-            snprintf(s, len, "Password for your Retro Achievements account.");
-            break;
         case MENU_ENUM_LABEL_USER_LANGUAGE:
             snprintf(s, len, "Localizes the menu and all onscreen messages \n"
                     "according to the language you have selected \n"
@@ -264,62 +244,6 @@ int msg_hash_get_help_ko_enum(enum msg_hash_enums msg, char *s, size_t len)
                     " \n"
                     "In case a language is not implemented, \n"
                     "we fallback to English.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FONT_PATH:
-            snprintf(s, len, "Change the font that is used \n"
-                    "for the Onscreen Display text.");
-            break;
-        case MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS:
-            snprintf(s, len, "Automatically load content-specific core options.");
-            break;
-        case MENU_ENUM_LABEL_AUTO_OVERRIDES_ENABLE:
-            snprintf(s, len, "Automatically load override configurations.");
-            break;
-        case MENU_ENUM_LABEL_AUTO_REMAPS_ENABLE:
-            snprintf(s, len, "Automatically load input remapping files.");
-            break;
-        case MENU_ENUM_LABEL_SORT_SAVESTATES_ENABLE:
-            snprintf(s, len, "Sort save states in folders \n"
-                    "named after the libretro core used.");
-            break;
-        case MENU_ENUM_LABEL_SORT_SAVEFILES_ENABLE:
-            snprintf(s, len, "Sort save files in folders \n"
-                    "named after the libretro core used.");
-            break;
-        case MENU_ENUM_LABEL_RESUME_CONTENT:
-            snprintf(s, len, "Exits from the menu and returns back \n"
-                    "to the content.");
-            break;
-        case MENU_ENUM_LABEL_RESTART_CONTENT:
-            snprintf(s, len, "Restarts the content from the beginning.");
-            break;
-        case MENU_ENUM_LABEL_CLOSE_CONTENT:
-            snprintf(s, len, "Closes the content and unloads it from \n"
-                    "memory.");
-            break;
-        case MENU_ENUM_LABEL_UNDO_LOAD_STATE:
-            snprintf(s, len, "If a state was loaded, content will \n"
-                    "go back to the state prior to loading.");
-            break;
-        case MENU_ENUM_LABEL_UNDO_SAVE_STATE:
-            snprintf(s, len, "If a state was overwritten, it will \n"
-                    "roll back to the previous save state.");
-            break;
-        case MENU_ENUM_LABEL_TAKE_SCREENSHOT:
-            snprintf(s, len, "Create a screenshot. \n"
-                    " \n"
-                    "The screenshot will be stored inside the \n"
-                    "Screenshot Directory.");
-            break;
-        case MENU_ENUM_LABEL_ADD_TO_FAVORITES:
-            snprintf(s, len, "Add the entry to your Favorites.");
-            break;
-        case MENU_ENUM_LABEL_RUN:
-            snprintf(s, len, "Start the content.");
-            break;
-        case MENU_ENUM_LABEL_INFORMATION:
-            snprintf(s, len, "Show additional metadata information \n"
-                    "about the content.");
             break;
         case MENU_ENUM_LABEL_FILE_BROWSER_CONFIG:
             snprintf(s, len, "Configuration file.");
@@ -344,33 +268,6 @@ int msg_hash_get_help_ko_enum(enum msg_hash_enums msg, char *s, size_t len)
         case MENU_ENUM_LABEL_USE_THIS_DIRECTORY:
             snprintf(s, len,
                      "Select this to set this as the directory.");
-            break;
-        case MENU_ENUM_LABEL_CONTENT_DATABASE_DIRECTORY:
-            snprintf(s, len,
-                     "Content Database Directory. \n"
-                             " \n"
-                             "Path to content database \n"
-                             "directory.");
-            break;
-        case MENU_ENUM_LABEL_THUMBNAILS_DIRECTORY:
-            snprintf(s, len,
-                     "Thumbnails Directory. \n"
-                             " \n"
-                             "To store thumbnail files.");
-            break;
-        case MENU_ENUM_LABEL_LIBRETRO_INFO_PATH:
-            snprintf(s, len,
-                     "Core Info Directory. \n"
-                             " \n"
-                             "A directory for where to search \n"
-                             "for libretro core information.");
-            break;
-        case MENU_ENUM_LABEL_PLAYLIST_DIRECTORY:
-            snprintf(s, len,
-                     "Playlist Directory. \n"
-                             " \n"
-                             "Save all playlist files to this \n"
-                             "directory.");
             break;
         case MENU_ENUM_LABEL_DUMMY_ON_CORE_SHUTDOWN:
             snprintf(s, len,
@@ -405,11 +302,6 @@ int msg_hash_get_help_ko_enum(enum msg_hash_enums msg, char *s, size_t len)
                      "Open Windows permission settings to enable \n"
                      "the broadFileSystemAccess capability.");
             break;
-        case MENU_ENUM_LABEL_FILE_BROWSER_OPEN_PICKER:
-           snprintf(s, len,
-                     "Open the system file picker to access \n"
-                     "additional directories.");
-           break;
         case MENU_ENUM_LABEL_FILE_BROWSER_SHADER_PRESET:
             snprintf(s, len,
                      "Shader preset file.");
@@ -493,18 +385,6 @@ int msg_hash_get_help_ko_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Content decompressed by RetroArch will be \n"
                              "temporarily extracted to this directory.");
             break;
-        case MENU_ENUM_LABEL_HISTORY_LIST_ENABLE:
-            snprintf(s, len,
-                     "If enabled, every content loaded \n"
-                             "in RetroArch will be automatically \n"
-                             "added to the recent history list.");
-            break;
-        case MENU_ENUM_LABEL_RGUI_BROWSER_DIRECTORY:
-            snprintf(s, len,
-                     "File Browser Directory. \n"
-                             " \n"
-                             "Sets start directory for menu file browser.");
-            break;
         case MENU_ENUM_LABEL_INPUT_POLL_TYPE_BEHAVIOR:
             snprintf(s, len,
                      "Influence how input polling is done inside \n"
@@ -523,155 +403,11 @@ int msg_hash_get_help_ko_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Will be ignored when using netplay."
             );
             break;
-        case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_HIDE_UNBOUND:
-            snprintf(s, len,
-                     "Hide input descriptors that were not set \n"
-                             "by the core.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE:
-            snprintf(s, len,
-                     "Video refresh rate of your monitor. \n"
-                             "Used to calculate a suitable audio input rate.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FORCE_SRGB_DISABLE:
-            snprintf(s, len,
-                     "Forcibly disable sRGB FBO support. Some Intel \n"
-                             "OpenGL drivers on Windows have video problems \n"
-                             "with sRGB FBO support enabled.");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_ENABLE:
-            snprintf(s, len,
-                     "Enable audio output.");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_SYNC:
-            snprintf(s, len,
-                     "Synchronize audio (recommended).");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_LATENCY:
-            snprintf(s, len,
-                     "Desired audio latency in milliseconds. \n"
-                             "Might not be honored if the audio driver \n"
-                             "can't provide given latency.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_ALLOW_ROTATE:
-            snprintf(s, len,
-                     "Allow cores to set rotation. If false, \n"
-                             "rotation requests are honored, but ignored.\n\n"
-                             "Used for setups where one manually rotates \n"
-                             "the monitor.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_LABEL_SHOW:
-            snprintf(s, len,
-                     "Show the input descriptors set by the core \n"
-                             "instead of the default ones.");
-            break;
-        case MENU_ENUM_LABEL_CONTENT_HISTORY_SIZE:
-            snprintf(s, len,
-                     "Number of entries that will be kept in \n"
-                             "content history playlist.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_WINDOWED_FULLSCREEN:
-            snprintf(s, len,
-                     "To use windowed mode or not when going \n"
-                             "fullscreen.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FONT_SIZE:
-            snprintf(s, len,
-                     "Font size for on-screen messages.");
-            break;
-        case MENU_ENUM_LABEL_SAVESTATE_AUTO_INDEX:
-            snprintf(s, len,
-                     "Automatically increment slot index on each save, \n"
-                             "generating multiple savestate files. \n"
-                             "When the content is loaded, state slot will be \n"
-                             "set to the highest existing value (last savestate).");
-            break;
-        case MENU_ENUM_LABEL_FPS_SHOW:
-            snprintf(s, len,
-                     "Enables displaying the current frames \n"
-                             "per second.");
-            break;
-        case MENU_ENUM_LABEL_MEMORY_SHOW:
-            snprintf(s, len,
-                     "Includes displaying the current memory \n"
-                             "usage/total with FPS/Frames.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FONT_ENABLE:
-            snprintf(s, len,
-                     "Show and/or hide onscreen messages.");
-            break;
         case MENU_ENUM_LABEL_VIDEO_MESSAGE_POS_X:
         case MENU_ENUM_LABEL_VIDEO_MESSAGE_POS_Y:
             snprintf(s, len,
                      "Offset for where messages will be placed \n"
                              "onscreen. Values are in range [0.0, 1.0].");
-            break;
-        case MENU_ENUM_LABEL_INPUT_OVERLAY_ENABLE:
-            snprintf(s, len,
-                     "Enable or disable the current overlay.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_OVERLAY_HIDE_IN_MENU:
-            snprintf(s, len,
-                     "Hide the current overlay from appearing \n"
-                             "inside the menu.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_OVERLAY_SHOW_PHYSICAL_INPUTS:
-            snprintf(s, len,
-                      "Show keyboard/controller button presses on \n"
-                            "the onscreen overlay.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_OVERLAY_SHOW_PHYSICAL_INPUTS_PORT:
-            snprintf(s, len,
-                      "Select the port to listen for controller input \n"
-                            "to display on the onscreen overlay.");
-            break;
-        case MENU_ENUM_LABEL_OVERLAY_PRESET:
-            snprintf(s, len,
-                     "Path to input overlay.");
-            break;
-        case MENU_ENUM_LABEL_OVERLAY_OPACITY:
-            snprintf(s, len,
-                     "Overlay opacity.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_LAYOUT_ENABLE:
-            snprintf(s, len,
-                     "Enable or disable the current video layout.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_LAYOUT_PATH:
-            snprintf(s, len,
-                     "Path to video layout.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_LAYOUT_SELECTED_VIEW:
-            snprintf(s, len,
-                     "Layouts can contain multiple views. \n"
-                     "Select a view.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_BIND_TIMEOUT:
-            snprintf(s, len,
-                     "Input bind timer timeout (in seconds). \n"
-                             "Amount of seconds to wait until proceeding \n"
-                             "to the next bind.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_BIND_HOLD:
-            snprintf(s, len,
-               "Input bind hold time (in seconds). \n"
-               "Amount of seconds to hold an input to bind it.");
-            break;
-        case MENU_ENUM_LABEL_OVERLAY_SCALE:
-            snprintf(s, len,
-                     "Overlay scale.");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_OUTPUT_RATE:
-            snprintf(s, len,
-                     "Audio output samplerate.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SHARED_CONTEXT:
-            snprintf(s, len,
-                     "Set to true if hardware-rendered cores \n"
-                             "should get their private context. \n"
-                             "Avoids having to assume hardware state changes \n"
-                             "inbetween frames."
-            );
             break;
         case MENU_ENUM_LABEL_CORE_LIST:
             snprintf(s, len,
@@ -918,13 +654,6 @@ int msg_hash_get_help_ko_enum(enum msg_hash_enums msg, char *s, size_t len)
                }
             }
             break;
-        case MENU_ENUM_LABEL_AUDIO_DSP_PLUGIN:
-            snprintf(s, len,
-                     "Audio DSP plugin.\n"
-                             " Processes audio before it's sent to \n"
-                             "the driver."
-            );
-            break;
         case MENU_ENUM_LABEL_AUDIO_RESAMPLER_DRIVER:
             {
                const char *lbl = settings ? settings->arrays.audio_resampler : NULL;
@@ -941,12 +670,6 @@ int msg_hash_get_help_ko_enum(enum msg_hash_enums msg, char *s, size_t len)
                   strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE), len);
             }
             break;
-
-		case MENU_ENUM_LABEL_CRT_SWITCH_RESOLUTION: snprintf(s, len, "SET CRT");
-			break;
-
-		case MENU_ENUM_LABEL_CRT_SWITCH_RESOLUTION_SUPER: snprintf(s, len, "SET CRT SUPER");
-			break;
 
         case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET:
             snprintf(s, len,
@@ -995,20 +718,6 @@ int msg_hash_get_help_ko_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "The Default Filter option will affect the \n"
                              "stretching filter.");
             break;
-        case MENU_ENUM_LABEL_VIDEO_SHADER_PARAMETERS:
-            snprintf(s, len,
-                     "Shader Parameters. \n"
-                             " \n"
-                             "Modifies current shader directly. Will not be \n"
-                             "saved to CGP/GLSLP preset file.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_PARAMETERS:
-            snprintf(s, len,
-                     "Shader Preset Parameters. \n"
-                             " \n"
-                             "Modifies shader preset currently in menu."
-            );
-            break;
         case MENU_ENUM_LABEL_VIDEO_SHADER_PASS:
             snprintf(s, len,
                      "Path to shader. \n"
@@ -1047,13 +756,6 @@ int msg_hash_get_help_ko_enum(enum msg_hash_enums msg, char *s, size_t len)
             "manually isn't really an option."
 #endif
             );
-            break;
-        case MENU_ENUM_LABEL_CONFIRM_ON_EXIT:
-            snprintf(s, len, "Are you sure you want to quit?");
-            break;
-        case MENU_ENUM_LABEL_SHOW_HIDDEN_FILES:
-            snprintf(s, len, "Show hidden files\n"
-                    "and folders.");
             break;
         case MENU_ENUM_LABEL_VIDEO_SHADER_FILTER_PASS:
             snprintf(s, len,
@@ -1137,26 +839,6 @@ int msg_hash_get_help_ko_enum(enum msg_hash_enums msg, char *s, size_t len)
                      "and applied to the running content."
             );
             break;
-        case MENU_ENUM_LABEL_MENU_TOGGLE:
-            snprintf(s, len,
-                     "Toggles menu.");
-            break;
-        case MENU_ENUM_LABEL_GRAB_MOUSE_TOGGLE:
-            snprintf(s, len,
-                     "Toggles mouse grab.\n"
-                             " \n"
-                             "When mouse is grabbed, RetroArch hides the \n"
-                             "mouse, and keeps the mouse pointer inside \n"
-                             "the window to allow relative mouse input to \n"
-                             "work better.");
-            break;
-        case MENU_ENUM_LABEL_GAME_FOCUS_TOGGLE:
-            snprintf(s, len,
-                     "Toggles game focus.\n"
-                             " \n"
-                             "When a game has focus, RetroArch will both disable \n"
-                             "hotkeys and keep/warp the mouse pointer inside the window.");
-            break;
         case MENU_ENUM_LABEL_DISK_NEXT:
             snprintf(s, len,
                      "Cycles through disk images. Use after \n"
@@ -1200,12 +882,6 @@ int msg_hash_get_help_ko_enum(enum msg_hash_enums msg, char *s, size_t len)
 #endif
             );
             break;
-        case MENU_ENUM_LABEL_DISK_EJECT_TOGGLE:
-            snprintf(s, len,
-                     "Toggles eject for disks.\n"
-                             " \n"
-                             "Used for multiple-disk content.");
-            break;
         case MENU_ENUM_LABEL_ENABLE_HOTKEY:
             snprintf(s, len,
                      "Enable other hotkeys.\n"
@@ -1219,28 +895,6 @@ int msg_hash_get_help_ko_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "implementations which query a large area of \n"
                              "the keyboard, where it is not desirable that \n"
                              "hotkeys get in the way.");
-            break;
-        case MENU_ENUM_LABEL_REWIND_ENABLE:
-            snprintf(s, len,
-                     "Enable rewinding.\n"
-                             " \n"
-                             "This will take a performance hit, \n"
-                             "so it is disabled by default.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_APPLY_AFTER_TOGGLE:
-            snprintf(s, len,
-                     "Apply cheat immediately after toggling.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_APPLY_AFTER_LOAD:
-            snprintf(s, len,
-                     "Auto-apply cheats when game loads.");
-            break;
-        case MENU_ENUM_LABEL_LIBRETRO_DIR_PATH:
-            snprintf(s, len,
-                     "Core Directory. \n"
-                             " \n"
-                             "A directory for where to search for \n"
-                             "libretro core implementations.");
             break;
         case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE_AUTO:
             snprintf(s, len,
@@ -1261,29 +915,6 @@ int msg_hash_get_help_ko_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "large pitch changes. If your monitor does \n"
                              "not run at 60Hz, or something close to it, \n"
                              "disable VSync, and leave this at its default.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE_POLLED:
-            snprintf(s, len,
-                     "Set Polled Refresh Rate\n"
-                             " \n"
-                            "Sets the refresh rate to the actual value\n"
-                            "polled from the display driver.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_ROTATION:
-            snprintf(s, len,
-                     "Forces a certain rotation \n"
-                             "of the screen.\n"
-                             " \n"
-                             "The rotation is added to rotations which\n"
-                             "the libretro core sets (see Video Allow\n"
-                             "Rotate).");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SCALE:
-            snprintf(s, len,
-                     "Fullscreen resolution.\n"
-                             " \n"
-                             "Resolution of 0 uses the \n"
-                             "resolution of the environment.\n");
             break;
         case MENU_ENUM_LABEL_FASTFORWARD_RATIO:
             snprintf(s, len,
@@ -1317,25 +948,6 @@ int msg_hash_get_help_ko_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "is preferred, 1 and up (1 being first \n"
                              "monitor), suggests RetroArch to use that \n"
                              "particular monitor.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_CROP_OVERSCAN:
-            snprintf(s, len,
-                     "Forces cropping of overscanned \n"
-                             "frames.\n"
-                             " \n"
-                             "Exact behavior of this option is \n"
-                             "core-implementation specific.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SCALE_INTEGER:
-            snprintf(s, len,
-                     "Only scales video in integer \n"
-                             "steps.\n"
-                             " \n"
-                             "The base size depends on system-reported \n"
-                             "geometry and aspect ratio.\n"
-                             " \n"
-                             "If Force Aspect is not set, X/Y will be \n"
-                             "integer scaled independently.");
             break;
         case MENU_ENUM_LABEL_AUDIO_VOLUME:
             snprintf(s, len,
@@ -1372,53 +984,10 @@ int msg_hash_get_help_ko_enum(enum msg_hash_enums msg, char *s, size_t len)
                              " Input rate is defined as: \n"
                              " input rate * (1.0 +/- (max timing skew))");
             break;
-        case MENU_ENUM_LABEL_OVERLAY_NEXT:
-            snprintf(s, len,
-                     "Toggles to next overlay.\n"
-                             " \n"
-                             "Wraps around.");
-            break;
-        case MENU_ENUM_LABEL_LOG_VERBOSITY:
-            snprintf(s, len,
-                     "Enable or disable verbosity level \n"
-                             "of frontend.");
-            break;
-        case MENU_ENUM_LABEL_VOLUME_UP:
-            snprintf(s, len,
-                     "Increases audio volume.");
-            break;
-        case MENU_ENUM_LABEL_VOLUME_DOWN:
-            snprintf(s, len,
-                     "Decreases audio volume.");
-            break;
         case MENU_ENUM_LABEL_VIDEO_DISABLE_COMPOSITION:
             snprintf(s, len,
                      "Forcibly disable composition.\n"
                              "Only valid on Windows Vista/7 for now.");
-            break;
-        case MENU_ENUM_LABEL_PERFCNT_ENABLE:
-            snprintf(s, len,
-                     "Enable or disable frontend \n"
-                             "performance counters.");
-            break;
-        case MENU_ENUM_LABEL_SYSTEM_DIRECTORY:
-            snprintf(s, len,
-                     "System Directory. \n"
-                             " \n"
-                             "Sets the 'system' directory.\n"
-                             "Cores can query for this\n"
-                             "directory to load BIOSes, \n"
-                             "system-specific configs, etc.");
-            break;
-        case MENU_ENUM_LABEL_SAVESTATE_AUTO_SAVE:
-        case MENU_ENUM_LABEL_SAVESTATE_AUTO_LOAD:
-            snprintf(s, len,
-                     "Automatically saves a savestate at the \n"
-                             "end of RetroArch's lifetime.\n"
-                             " \n"
-                             "RetroArch will automatically load any savestate\n"
-                             "with this path on startup if 'Auto Load State\n"
-                             "is enabled.");
             break;
         case MENU_ENUM_LABEL_VIDEO_THREADED:
             snprintf(s, len,
@@ -1427,47 +996,6 @@ int msg_hash_get_help_ko_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Using this might improve performance at the \n"
                              "possible cost of latency and more video \n"
                              "stuttering.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_VSYNC:
-            snprintf(s, len,
-                     "Video V-Sync.\n");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_HARD_SYNC:
-            snprintf(s, len,
-                     "Attempts to hard-synchronize \n"
-                             "CPU and GPU.\n"
-                             " \n"
-                             "Can reduce latency at the cost of \n"
-                             "performance.");
-            break;
-        case MENU_ENUM_LABEL_REWIND_GRANULARITY:
-            snprintf(s, len,
-                     "Rewind granularity.\n"
-                             " \n"
-                             " When rewinding defined number of \n"
-                             "frames, you can rewind several frames \n"
-                             "at a time, increasing the rewinding \n"
-                             "speed.");
-            break;
-        case MENU_ENUM_LABEL_REWIND_BUFFER_SIZE:
-            snprintf(s, len,
-                     "Rewind buffer size (MB).\n"
-                             " \n"
-                             " The amount of memory in MB to reserve \n"
-                             "for rewinding.  Increasing this value \n"
-                             "increases the rewind history length.\n");
-            break;
-        case MENU_ENUM_LABEL_REWIND_BUFFER_SIZE_STEP:
-            snprintf(s, len,
-                     "Rewind buffer size step (MB).\n"
-                             " \n"
-                             " Each time you increase or decrease \n"
-                             "the rewind buffer size value via this \n"
-                             "UI it will change by this amount.\n");
-            break;
-        case MENU_ENUM_LABEL_SCREENSHOT:
-            snprintf(s, len,
-                     "Take screenshot.");
             break;
         case MENU_ENUM_LABEL_VIDEO_FRAME_DELAY:
             snprintf(s, len,
@@ -1504,49 +1032,6 @@ int msg_hash_get_help_ko_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "configured as if it is a 60 Hz monitor \n"
                              "(divide refresh rate by 2).");
             break;
-        case MENU_ENUM_LABEL_RGUI_SHOW_START_SCREEN:
-            snprintf(s, len,
-                     "Show startup screen in menu.\n"
-                             "Is automatically set to false when seen\n"
-                             "for the first time.\n"
-                             " \n"
-                             "This is only updated in config if\n"
-                             "'Save Configuration on Exit' is enabled.\n");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FULLSCREEN:
-            snprintf(s, len, "Toggles fullscreen.");
-            break;
-        case MENU_ENUM_LABEL_BLOCK_SRAM_OVERWRITE:
-            snprintf(s, len,
-                     "Block SRAM from being overwritten \n"
-                             "when loading save states.\n"
-                             " \n"
-                             "Might potentially lead to buggy games.");
-            break;
-        case MENU_ENUM_LABEL_PAUSE_NONACTIVE:
-            snprintf(s, len,
-                     "Pause gameplay when window focus \n"
-                             "is lost.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_GPU_SCREENSHOT:
-            snprintf(s, len,
-                     "Screenshots output of GPU shaded \n"
-                             "material if available.");
-            break;
-        case MENU_ENUM_LABEL_SCREENSHOT_DIRECTORY:
-            snprintf(s, len,
-                     "Screenshot Directory. \n"
-                             " \n"
-                             "Directory to dump screenshots to."
-            );
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SWAP_INTERVAL:
-            snprintf(s, len,
-                     "VSync Swap Interval.\n"
-                             " \n"
-                             "Uses a custom swap interval for VSync. Set this \n"
-                             "to effectively halve monitor refresh rate.");
-            break;
         case MENU_ENUM_LABEL_SAVEFILE_DIRECTORY:
             snprintf(s, len,
                      "Savefile Directory. \n"
@@ -1554,16 +1039,6 @@ int msg_hash_get_help_ko_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Save all save files (*.srm) to this \n"
                              "directory. This includes related files like \n"
                              ".bsv, .rt, .psrm, etc...\n"
-                             " \n"
-                             "This will be overridden by explicit command line\n"
-                             "options.");
-            break;
-        case MENU_ENUM_LABEL_SAVESTATE_DIRECTORY:
-            snprintf(s, len,
-                     "Savestate Directory. \n"
-                             " \n"
-                             "Save all save states (*.state) to this \n"
-                             "directory.\n"
                              " \n"
                              "This will be overridden by explicit command line\n"
                              "options.");
@@ -1584,67 +1059,8 @@ int msg_hash_get_help_ko_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "be loaded dynamically by the menu depending \n"
                              "on context.");
             break;
-        case MENU_ENUM_LABEL_SLOWMOTION_RATIO:
-            snprintf(s, len,
-                     "Slowmotion ratio."
-                             " \n"
-                             "When slowmotion, content will slow\n"
-                             "down by factor.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_BUTTON_AXIS_THRESHOLD:
-            snprintf(s, len,
-                     "Defines the axis threshold.\n"
-                             " \n"
-                             "How far an axis must be tilted to result\n"
-                             "in a button press.\n"
-                             " Possible values are [0.0, 1.0].");
-            break;
-        case MENU_ENUM_LABEL_INPUT_TURBO_PERIOD:
-            snprintf(s, len,
-                     "Turbo period.\n"
-                             " \n"
-                             "Describes the period of which turbo-enabled\n"
-                             "buttons toggle.\n"
-                             " \n"
-                             "Numbers are described in frames."
-            );
-            break;
-        case MENU_ENUM_LABEL_INPUT_DUTY_CYCLE:
-            snprintf(s, len,
-                     "Duty cycle.\n"
-                             " \n"
-                             "Describes how long the period of a turbo-enabled\n"
-                             "should be.\n"
-                             " \n"
-                             "Numbers are described in frames."
-            );
-            break;
-        case MENU_ENUM_LABEL_INPUT_TOUCH_ENABLE:
-            snprintf(s, len, "Enable touch support.");
-            break;
         case MENU_ENUM_LABEL_INPUT_PREFER_FRONT_TOUCH:
             snprintf(s, len, "Use front instead of back touch.");
-            break;
-        case MENU_ENUM_LABEL_MOUSE_ENABLE:
-            snprintf(s, len, "Enable mouse input inside the menu.");
-            break;
-        case MENU_ENUM_LABEL_POINTER_ENABLE:
-            snprintf(s, len, "Enable touch input inside the menu.");
-            break;
-        case MENU_ENUM_LABEL_MENU_WALLPAPER:
-            snprintf(s, len, "Path to an image to set as the background.");
-            break;
-        case MENU_ENUM_LABEL_NAVIGATION_WRAPAROUND:
-            snprintf(s, len,
-                     "Wrap-around to beginning and/or end \n"
-                             "if boundary of list is reached \n"
-                             "horizontally and/or vertically.");
-            break;
-        case MENU_ENUM_LABEL_PAUSE_LIBRETRO:
-            snprintf(s, len,
-                     "If disabled, the game will keep \n"
-                             "running in the background when we are in the \n"
-                             "menu.");
             break;
         case MENU_ENUM_LABEL_SUSPEND_SCREENSAVER_ENABLE:
             snprintf(s, len,
@@ -1664,13 +1080,6 @@ int msg_hash_get_help_ko_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Increasing this value will increase \n"
                              "performance, but introduce more latency.");
             break;
-        case MENU_ENUM_LABEL_NETPLAY_PUBLIC_ANNOUNCE:
-            snprintf(s, len,
-                     "Whether to announce netplay games publicly. \n"
-                             " \n"
-                             "If set to false, clients must manually connect \n"
-                             "rather than using the public lobby.");
-            break;
         case MENU_ENUM_LABEL_NETPLAY_START_AS_SPECTATOR:
             snprintf(s, len,
                      "Whether to start netplay in spectator mode. \n"
@@ -1678,21 +1087,6 @@ int msg_hash_get_help_ko_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "If set to true, netplay will be in spectator mode \n"
                              "on start. It's always possible to change mode \n"
                              "later.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_ALLOW_SLAVES:
-            snprintf(s, len,
-                     "Whether to allow connections in slave mode. \n"
-                             " \n"
-                             "Slave-mode clients require very little processing \n"
-                             "power on either side, but will suffer \n"
-                             "significantly from network latency.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_REQUIRE_SLAVES:
-            snprintf(s, len,
-                     "Whether to disallow connections not in slave mode. \n"
-                             " \n"
-                             "Not recommended except for very fast networks \n"
-                             "with very weak machines. \n");
             break;
         case MENU_ENUM_LABEL_NETPLAY_CHECK_FRAMES:
             snprintf(s, len,
@@ -1735,24 +1129,6 @@ int msg_hash_get_help_ko_enum(enum msg_hash_enums msg, char *s, size_t len)
                      "makes netplay less CPU-intensive, but at \n"
                      "the price of unpredictable input lag. \n");
             break;
-        case MENU_ENUM_LABEL_NETPLAY_NAT_TRAVERSAL:
-            snprintf(s, len,
-                     "When hosting, attempt to listen for\n"
-                             "connections from the public internet, using\n"
-                             "UPnP or similar technologies to escape LANs. \n");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_USE_MITM_SERVER:
-            snprintf(s, len,
-                     "When hosting a netplay session, relay connection through a \n"
-                             "man-in-the-middle server \n"
-                             "to get around firewalls or NAT/UPnP issues. \n");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_MITM_SERVER:
-            snprintf(s, len,
-                     "Specifies the man-in-the-middle server \n"
-                             "to use for netplay. A server that is \n"
-                             "located closer to you may have less latency. \n");
-            break;
         case MENU_ENUM_LABEL_VIDEO_MAX_SWAPCHAIN_IMAGES:
             snprintf(s, len,
                      "Maximum amount of swapchain images. This \n"
@@ -1780,192 +1156,19 @@ int msg_hash_get_help_ko_enum(enum msg_hash_enums msg, char *s, size_t len)
 #endif
          );
          break;
-        case MENU_ENUM_LABEL_TIMEDATE_ENABLE:
-            snprintf(s, len,
-                     "Shows current date and/or time inside menu.");
-            break;
-        case MENU_ENUM_LABEL_TIMEDATE_STYLE:
-           snprintf(s, len,
-              "Style to show the current date and/or time in.");
-           break;
-        case MENU_ENUM_LABEL_BATTERY_LEVEL_ENABLE:
-            snprintf(s, len,
-                     "Shows current battery level inside menu.");
-            break;
-        case MENU_ENUM_LABEL_CORE_ENABLE:
-            snprintf(s, len,
-                     "Shows current core inside menu.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_ENABLE_HOST:
-            snprintf(s, len,
-                     "Enables Netplay in host (server) mode.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_ENABLE_CLIENT:
-            snprintf(s, len,
-                     "Enables Netplay in client mode.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_DISCONNECT:
-            snprintf(s, len,
-                     "Disconnects an active Netplay connection.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_LAN_SCAN_SETTINGS:
-            snprintf(s, len,
-                     "Search for and connect to netplay hosts on the local network.");
-            break;
         case MENU_ENUM_LABEL_NETPLAY_SETTINGS:
             snprintf(s, len,
                      "Setting related to Netplay.");
-            break;
-        case MENU_ENUM_LABEL_DYNAMIC_WALLPAPER:
-            snprintf(s, len,
-                     "Dynamically load a new background \n"
-                             "depending on context.");
-            break;
-        case MENU_ENUM_LABEL_CORE_UPDATER_BUILDBOT_URL:
-            snprintf(s, len,
-                     "URL to core updater directory on the \n"
-                             "Libretro buildbot.");
-            break;
-        case MENU_ENUM_LABEL_BUILDBOT_ASSETS_URL:
-            snprintf(s, len,
-                     "URL to assets updater directory on the \n"
-                             "Libretro buildbot.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_REMAP_BINDS_ENABLE:
-            snprintf(s, len,
-                     "if enabled, overrides the input binds \n"
-                             "with the remapped binds set for the \n"
-                             "current core.");
-            break;
-        case MENU_ENUM_LABEL_OVERLAY_DIRECTORY:
-            snprintf(s, len,
-                     "Overlay Directory. \n"
-                             " \n"
-                             "Defines a directory where overlays are \n"
-                             "kept for easy access.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_LAYOUT_DIRECTORY:
-            snprintf(s, len,
-                     "Video Layout Directory. \n"
-                             " \n"
-                             "Defines a directory where video layouts are \n"
-                             "kept for easy access.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_MAX_USERS:
-            snprintf(s, len,
-                     "Maximum amount of users supported by \n"
-                             "RetroArch.");
-            break;
-        case MENU_ENUM_LABEL_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
-            snprintf(s, len,
-                     "After downloading, automatically extract \n"
-                             "archives that the downloads are contained \n"
-                             "inside.");
-            break;
-        case MENU_ENUM_LABEL_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
-            snprintf(s, len,
-                     "Filter files being shown by \n"
-                             "supported extensions.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_NICKNAME:
-            snprintf(s, len,
-                     "The username of the person running RetroArch. \n"
-                             "This will be used for playing online games.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_TCP_UDP_PORT:
-            snprintf(s, len,
-                     "The port of the host IP address. \n"
-                             "Can be either a TCP or UDP port.");
             break;
         case MENU_ENUM_LABEL_NETPLAY_SPECTATOR_MODE_ENABLE:
             snprintf(s, len,
                      "Enable or disable spectator mode for \n"
                              "the user during netplay.");
             break;
-        case MENU_ENUM_LABEL_NETPLAY_IP_ADDRESS:
-            snprintf(s, len,
-                     "The address of the host to connect to.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_PASSWORD:
-            snprintf(s, len,
-                     "The password for connecting to the netplay \n"
-                             "host. Used only in host mode.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_SPECTATE_PASSWORD:
-            snprintf(s, len,
-                     "The password for connecting to the netplay \n"
-                             "host with only spectator privileges. Used \n"
-                             "only in host mode.");
-            break;
-        case MENU_ENUM_LABEL_STDIN_CMD_ENABLE:
-            snprintf(s, len,
-                     "Enable stdin command interface.");
-            break;
         case MENU_ENUM_LABEL_UI_COMPANION_START_ON_BOOT:
             snprintf(s, len,
                      "Start User Interface companion driver \n"
                              "on boot (if available).");
-            break;
-        case MENU_ENUM_LABEL_MENU_DRIVER:
-            snprintf(s, len, "Menu driver to use.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
-            snprintf(s, len,
-                     "Gamepad button combination to toggle menu. \n"
-                             " \n"
-                             "0 - None \n"
-                             "1 - Press L + R + Y + D-Pad Down \n"
-                             "simultaneously. \n"
-                             "2 - Press L3 + R3 simultaneously. \n"
-                             "3 - Press Start + Select simultaneously.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_ALL_USERS_CONTROL_MENU:
-            snprintf(s, len, "Allows any user to control the menu. \n"
-                    " \n"
-                    "When disabled, only user 1 can control the menu.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_AUTODETECT_ENABLE:
-            snprintf(s, len,
-                     "Enable input auto-detection.\n"
-                             " \n"
-                             "Will attempt to auto-configure \n"
-                             "joypads, Plug-and-Play style.");
-            break;
-        case MENU_ENUM_LABEL_CAMERA_ALLOW:
-            snprintf(s, len,
-                     "Allow or disallow camera access by \n"
-                             "cores.");
-            break;
-        case MENU_ENUM_LABEL_LOCATION_ALLOW:
-            snprintf(s, len,
-                     "Allow or disallow location services \n"
-                             "access by cores.");
-            break;
-        case MENU_ENUM_LABEL_TURBO:
-            snprintf(s, len,
-                     "Turbo enable.\n"
-                             " \n"
-                             "Holding the turbo while pressing another \n"
-                             "button will let the button enter a turbo \n"
-                             "mode where the button state is modulated \n"
-                             "with a periodic signal. \n"
-                             " \n"
-                             "The modulation stops when the button \n"
-                             "itself (not turbo button) is released.");
-            break;
-        case MENU_ENUM_LABEL_OSK_ENABLE:
-            snprintf(s, len,
-                     "Enable/disable on-screen keyboard.");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_MUTE:
-            snprintf(s, len,
-                     "Mute/unmute audio.");
-            break;
-        case MENU_ENUM_LABEL_REWIND:
-            snprintf(s, len,
-                     "Hold button down to rewind.\n"
-                             " \n"
-                             "Rewind must be enabled.");
             break;
         case MENU_ENUM_LABEL_EXIT_EMULATOR:
             snprintf(s, len,
@@ -1979,176 +1182,9 @@ int msg_hash_get_help_ko_enum(enum msg_hash_enums msg, char *s, size_t len)
 #endif
             );
             break;
-        case MENU_ENUM_LABEL_LOAD_STATE:
-            snprintf(s, len,
-                     "Loads state.");
-            break;
-        case MENU_ENUM_LABEL_SAVE_STATE:
-            snprintf(s, len,
-                     "Saves state.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_GAME_WATCH:
-            snprintf(s, len,
-                     "Netplay toggle play/spectate mode.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_INDEX_PLUS:
-            snprintf(s, len,
-                     "Increment cheat index.\n");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_INDEX_MINUS:
-            snprintf(s, len,
-                     "Decrement cheat index.\n");
-            break;
-        case MENU_ENUM_LABEL_SHADER_PREV:
-            snprintf(s, len,
-                     "Applies previous shader in directory.");
-            break;
-        case MENU_ENUM_LABEL_SHADER_NEXT:
-            snprintf(s, len,
-                     "Applies next shader in directory.");
-            break;
-        case MENU_ENUM_LABEL_RESET:
-            snprintf(s, len,
-                     "Reset the content.\n");
-            break;
-        case MENU_ENUM_LABEL_PAUSE_TOGGLE:
-            snprintf(s, len,
-                     "Toggle between paused and non-paused state.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_TOGGLE:
-            snprintf(s, len,
-                     "Toggle cheat index.\n");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_IDX:
-            snprintf(s, len,
-                     "Index position in list.\n");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_ADDRESS_BIT_POSITION:
-            snprintf(s, len,
-                     "Address bitmask when Memory Search Size < 8-bit.\n");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_REPEAT_COUNT:
-            snprintf(s, len,
-                     "The number of times the cheat will be applied.\nUse with the other two Iteration options to affect large areas of memory.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_REPEAT_ADD_TO_ADDRESS:
-            snprintf(s, len,
-                     "After each 'Number of Iterations' the Memory Address will be increased by this number times the 'Memory Search Size'.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_REPEAT_ADD_TO_VALUE:
-            snprintf(s, len,
-                     "After each 'Number of Iterations' the Value will be increased by this amount.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_MATCH_IDX:
-            snprintf(s, len,
-                     "Select the match to view.");
-            break;
         case MENU_ENUM_LABEL_CHEAT_START_OR_CONT:
             snprintf(s, len,
                      "Scan memory to create new cheats");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_START_OR_RESTART:
-            snprintf(s, len,
-                     "Left/Right to change bit-size\n");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_EXACT:
-            snprintf(s, len,
-                     "Left/Right to change value\n");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_LT:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_GT:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_EQ:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_NEQ:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_EQPLUS:
-            snprintf(s, len,
-                     "Left/Right to change value\n");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_EQMINUS:
-            snprintf(s, len,
-                     "Left/Right to change value\n");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_ADD_MATCHES:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_VIEW_MATCHES:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_CREATE_OPTION:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_DELETE_OPTION:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_ADD_NEW_TOP:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_RELOAD_CHEATS:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_ADD_NEW_BOTTOM:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_DELETE_ALL:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_BIG_ENDIAN:
-            snprintf(s, len,
-                     "Big endian    : 258 = 0x0102\n"
-                     "Little endian : 258 = 0x0201");
-            break;
-        case MENU_ENUM_LABEL_HOLD_FAST_FORWARD:
-            snprintf(s, len,
-                     "Hold for fast-forward. Releasing button \n"
-                             "disables fast-forward.");
-            break;
-        case MENU_ENUM_LABEL_SLOWMOTION_HOLD:
-            snprintf(s, len,
-                     "Hold for slowmotion.");
-            break;
-        case MENU_ENUM_LABEL_FRAME_ADVANCE:
-            snprintf(s, len,
-                     "Frame advance when content is paused.");
-            break;
-        case MENU_ENUM_LABEL_BSV_RECORD_TOGGLE:
-            snprintf(s, len,
-                     "Toggle between recording and not.");
-            break;
-        case MENU_ENUM_LABEL_L_X_PLUS:
-        case MENU_ENUM_LABEL_L_X_MINUS:
-        case MENU_ENUM_LABEL_L_Y_PLUS:
-        case MENU_ENUM_LABEL_L_Y_MINUS:
-        case MENU_ENUM_LABEL_R_X_PLUS:
-        case MENU_ENUM_LABEL_R_X_MINUS:
-        case MENU_ENUM_LABEL_R_Y_PLUS:
-        case MENU_ENUM_LABEL_R_Y_MINUS:
-            snprintf(s, len,
-                     "Axis for analog stick (DualShock-esque).\n"
-                             " \n"
-                             "Bound as usual, however, if a real analog \n"
-                             "axis is bound, it can be read as a true analog.\n"
-                             " \n"
-                             "Positive X axis is right. \n"
-                             "Positive Y axis is down.");
             break;
         case MENU_ENUM_LABEL_VALUE_WHAT_IS_A_CORE_DESC:
             snprintf(s, len,
@@ -2197,41 +1233,37 @@ int msg_hash_get_help_ko_enum(enum msg_hash_enums msg, char *s, size_t len)
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_HIDE_IN_MENU)
             );
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_ENABLE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_ENABLE:
             snprintf(s, len,
                      "Enables a background color for the OSD.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_RED:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_RED:
             snprintf(s, len,
                      "Sets the red value of the OSD background color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_GREEN:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_GREEN:
             snprintf(s, len,
                      "Sets the green value of the OSD background color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_BLUE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_BLUE:
             snprintf(s, len,
                      "Sets the blue value of the OSD background color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_OPACITY:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_OPACITY:
             snprintf(s, len,
                      "Sets the opacity of the OSD background color. Valid values are between 0.0 and 1.0.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_RED:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_RED:
             snprintf(s, len,
                      "Sets the red value of the OSD text color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_GREEN:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_GREEN:
             snprintf(s, len,
                      "Sets the green value of the OSD text color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_BLUE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_BLUE:
             snprintf(s, len,
                      "Sets the blue value of the OSD text color. Valid values are between 0 and 255.");
-            break;
-        case MENU_ENUM_LABEL_MIDI_DRIVER:
-            snprintf(s, len,
-                     "MIDI driver to use.");
             break;
         case MENU_ENUM_LABEL_MIDI_INPUT:
             snprintf(s, len,
@@ -2248,10 +1280,6 @@ int msg_hash_get_help_ko_enum(enum msg_hash_enums msg, char *s, size_t len)
                      "When MIDI output is enabled and core and game/app support MIDI output,\n"
                      "some or all sounds (depends on game/app) will be generated by MIDI device.\n"
                      "In case of \"null\" MIDI driver this means that those sounds won't be audible.");
-            break;
-        case MENU_ENUM_LABEL_MIDI_VOLUME:
-            snprintf(s, len,
-                     "Sets the master volume of the output device.");
             break;
         default:
             if (string_is_empty(s))

--- a/intl/msg_hash_sv.c
+++ b/intl/msg_hash_sv.c
@@ -47,153 +47,6 @@ int msg_hash_get_help_sv_enum(enum msg_hash_enums msg, char *s, size_t len)
 
        switch (idx)
        {
-          case RARCH_FAST_FORWARD_KEY:
-             snprintf(s, len,
-                   "Toggles between fast-forwarding and \n"
-                   "normal speed."
-                   );
-             break;
-          case RARCH_FAST_FORWARD_HOLD_KEY:
-             snprintf(s, len,
-                   "Hold for fast-forward. \n"
-                   " \n"
-                   "Releasing button disables fast-forward."
-                   );
-             break;
-          case RARCH_SLOWMOTION_KEY:
-             snprintf(s, len,
-                   "Toggles slowmotion.");
-             break;
-          case RARCH_SLOWMOTION_HOLD_KEY:
-             snprintf(s, len,
-                   "Hold for slowmotion.");
-             break;
-          case RARCH_PAUSE_TOGGLE:
-             snprintf(s, len,
-                   "Toggle between paused and non-paused state.");
-             break;
-          case RARCH_FRAMEADVANCE:
-             snprintf(s, len,
-                   "Frame advance when content is paused.");
-             break;
-          case RARCH_SHADER_NEXT:
-             snprintf(s, len,
-                   "Applies next shader in directory.");
-             break;
-          case RARCH_SHADER_PREV:
-             snprintf(s, len,
-                   "Applies previous shader in directory.");
-             break;
-          case RARCH_CHEAT_INDEX_PLUS:
-          case RARCH_CHEAT_INDEX_MINUS:
-          case RARCH_CHEAT_TOGGLE:
-             snprintf(s, len,
-                   "Cheats.");
-             break;
-          case RARCH_RESET:
-             snprintf(s, len,
-                   "Reset the content.");
-             break;
-          case RARCH_SCREENSHOT:
-             snprintf(s, len,
-                   "Take screenshot.");
-             break;
-          case RARCH_MUTE:
-             snprintf(s, len,
-                   "Mute/unmute audio.");
-             break;
-          case RARCH_OSK:
-             snprintf(s, len,
-                   "Toggles onscreen keyboard.");
-             break;
-          case RARCH_FPS_TOGGLE:
-             snprintf(s, len,
-                   "Toggles frames per second counter.");
-             break;
-          case RARCH_STATISTICS_TOGGLE:
-             snprintf(s, len,
-                   "Toggles display of technical statistics.");
-             break;
-          case RARCH_SEND_DEBUG_INFO:
-             snprintf(s, len,
-                   "Sends diagnostic info about your device and RetroArch configuration to our servers for analysis.");
-             break;
-          case RARCH_NETPLAY_HOST_TOGGLE:
-             snprintf(s, len,
-                   "Toggles netplay hosting on/off.");
-             break;
-          case RARCH_NETPLAY_GAME_WATCH:
-             snprintf(s, len,
-                   "Netplay toggle play/spectate mode.");
-             break;
-          case RARCH_ENABLE_HOTKEY:
-             snprintf(s, len,
-                   "Enable other hotkeys. \n"
-                   " \n"
-                   "If this hotkey is bound to either\n"
-                   "a keyboard, joybutton or joyaxis, \n"
-                   "all other hotkeys will be enabled only \n"
-                   "if this one is held at the same time. \n"
-                   " \n"
-                   "Alternatively, all hotkeys for keyboard \n"
-                   "could be disabled by the user.");
-             break;
-          case RARCH_VOLUME_UP:
-             snprintf(s, len,
-                   "Increases audio volume.");
-             break;
-          case RARCH_VOLUME_DOWN:
-             snprintf(s, len,
-                   "Decreases audio volume.");
-             break;
-          case RARCH_OVERLAY_NEXT:
-             snprintf(s, len,
-                   "Switches to next overlay. Wraps around.");
-             break;
-          case RARCH_DISK_EJECT_TOGGLE:
-             snprintf(s, len,
-                   "Toggles eject for disks. \n"
-                   " \n"
-                   "Used for multiple-disk content.");
-             break;
-          case RARCH_DISK_NEXT:
-          case RARCH_DISK_PREV:
-             snprintf(s, len,
-                   "Cycles through disk images. Use after ejecting. \n"
-                   " \n"
-                   "Complete by toggling eject again.");
-             break;
-          case RARCH_GRAB_MOUSE_TOGGLE:
-             snprintf(s, len,
-                   "Toggles mouse grab. \n"
-                   " \n"
-                   "When mouse is grabbed, RetroArch hides the \n"
-                   "mouse, and keeps the mouse pointer inside \n"
-                   "the window to allow relative mouse input to \n"
-                   "work better.");
-             break;
-          case RARCH_GAME_FOCUS_TOGGLE:
-             snprintf(s, len,
-                   "Toggles game focus.\n"
-                   " \n"
-                   "When a game has focus, RetroArch will both disable \n"
-                   "hotkeys and keep/wrap the mouse pointer inside the window.");
-             break;
-          case RARCH_MENU_TOGGLE:
-             snprintf(s, len, "Toggles menu.");
-             break;
-          case RARCH_LOAD_STATE_KEY:
-             snprintf(s, len,
-                   "Loads state.");
-             break;
-          case RARCH_FULLSCREEN_TOGGLE_KEY:
-             snprintf(s, len,
-                   "Toggles fullscreen.");
-             break;
-          case RARCH_CLOSE_CONTENT_KEY:
-             snprintf(s, len,
-                   "Closes content.");
-             break;
           case RARCH_QUIT_KEY:
              snprintf(s, len,
                    "Key to exit RetroArch cleanly. \n"
@@ -217,24 +70,6 @@ int msg_hash_get_help_sv_enum(enum msg_hash_enums msg, char *s, size_t len)
                    "When slot is not 0, path will be <path><d>, \n"
                    "where <d> is slot number.");
              break;
-          case RARCH_SAVE_STATE_KEY:
-             snprintf(s, len,
-                   "Saves state.");
-             break;
-          case RARCH_REWIND:
-             snprintf(s, len,
-                   "Hold button down to rewind. \n"
-                   " \n"
-                   "Rewinding must be enabled.");
-             break;
-          case RARCH_BSV_RECORD_TOGGLE:
-             snprintf(s, len,
-                   "Toggle between recording and not.");
-             break;
-          case RARCH_RUNAHEAD_TOGGLE:
-             snprintf(s, len,
-                   "Toggles Run-Ahead mode on/off.");
-             break;
           default:
              if (string_is_empty(s))
                 strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE), len);
@@ -257,12 +92,6 @@ int msg_hash_get_help_sv_enum(enum msg_hash_enums msg, char *s, size_t len)
                     "to input the username and password into \n"
                     "RetroArch.");
             break;
-        case MENU_ENUM_LABEL_CHEEVOS_USERNAME:
-            snprintf(s, len, "Username for your Retro Achievements account.");
-            break;
-        case MENU_ENUM_LABEL_CHEEVOS_PASSWORD:
-            snprintf(s, len, "Password for your Retro Achievements account.");
-            break;
         case MENU_ENUM_LABEL_USER_LANGUAGE:
             snprintf(s, len, "Localizes the menu and all onscreen messages \n"
                     "according to the language you have selected \n"
@@ -276,74 +105,6 @@ int msg_hash_get_help_sv_enum(enum msg_hash_enums msg, char *s, size_t len)
                     " \n"
                     "In case a language is not implemented, \n"
                     "we fallback to English.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FONT_PATH:
-            snprintf(s, len, "Change the font that is used \n"
-                    "for the Onscreen Display text.");
-            break;
-        case MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS:
-            snprintf(s, len, "Automatically load content-specific core options.");
-            break;
-        case MENU_ENUM_LABEL_AUTO_OVERRIDES_ENABLE:
-            snprintf(s, len, "Automatically load override configurations.");
-            break;
-        case MENU_ENUM_LABEL_AUTO_REMAPS_ENABLE:
-            snprintf(s, len, "Automatically load input remapping files.");
-            break;
-        case MENU_ENUM_LABEL_SORT_SAVESTATES_ENABLE:
-            snprintf(s, len, "Sort save states in folders \n"
-                    "named after the libretro core used.");
-            break;
-        case MENU_ENUM_LABEL_SORT_SAVEFILES_ENABLE:
-            snprintf(s, len, "Sort save files in folders \n"
-                    "named after the libretro core used.");
-            break;
-        case MENU_ENUM_LABEL_SORT_SAVESTATES_BY_CONTENT_ENABLE:
-            snprintf(s, len, "Sort save states in folders named \n"
-                   "after the folder in which the content lives.");
-            break;
-        case MENU_ENUM_LABEL_SORT_SAVEFILES_BY_CONTENT_ENABLE:
-            snprintf(s, len, "Sort save files in folders named \n"
-                  "after the folder in which the content lives.");
-            break;
-        case MENU_ENUM_LABEL_SORT_SCREENSHOTS_BY_CONTENT_ENABLE:
-            snprintf(s, len, "Sort screenshots in folders named \n"
-                  "after the folder in which the content lives.");
-            break;
-        case MENU_ENUM_LABEL_RESUME_CONTENT:
-            snprintf(s, len, "Exits from the menu and returns back \n"
-                    "to the content.");
-            break;
-        case MENU_ENUM_LABEL_RESTART_CONTENT:
-            snprintf(s, len, "Restarts the content from the beginning.");
-            break;
-        case MENU_ENUM_LABEL_CLOSE_CONTENT:
-            snprintf(s, len, "Closes the content and unloads it from \n"
-                    "memory.");
-            break;
-        case MENU_ENUM_LABEL_UNDO_LOAD_STATE:
-            snprintf(s, len, "If a state was loaded, content will \n"
-                    "go back to the state prior to loading.");
-            break;
-        case MENU_ENUM_LABEL_UNDO_SAVE_STATE:
-            snprintf(s, len, "If a state was overwritten, it will \n"
-                    "roll back to the previous save state.");
-            break;
-        case MENU_ENUM_LABEL_TAKE_SCREENSHOT:
-            snprintf(s, len, "Create a screenshot. \n"
-                    " \n"
-                    "The screenshot will be stored inside the \n"
-                    "Screenshot Directory.");
-            break;
-        case MENU_ENUM_LABEL_ADD_TO_FAVORITES:
-            snprintf(s, len, "Add the entry to your Favorites.");
-            break;
-        case MENU_ENUM_LABEL_RUN:
-            snprintf(s, len, "Start the content.");
-            break;
-        case MENU_ENUM_LABEL_INFORMATION:
-            snprintf(s, len, "Show additional metadata information \n"
-                    "about the content.");
             break;
         case MENU_ENUM_LABEL_FILE_BROWSER_CONFIG:
             snprintf(s, len, "Configuration file.");
@@ -368,68 +129,6 @@ int msg_hash_get_help_sv_enum(enum msg_hash_enums msg, char *s, size_t len)
         case MENU_ENUM_LABEL_USE_THIS_DIRECTORY:
             snprintf(s, len,
                      "Select this to set this as the directory.");
-            break;
-        case MENU_ENUM_LABEL_CONTENT_DATABASE_DIRECTORY:
-            snprintf(s, len,
-                     "Content Database Directory. \n"
-                             " \n"
-                             "Path to content database \n"
-                             "directory.");
-            break;
-        case MENU_ENUM_LABEL_THUMBNAILS_DIRECTORY:
-            snprintf(s, len,
-                     "Thumbnails Directory. \n"
-                             " \n"
-                             "To store thumbnail files.");
-            break;
-        case MENU_ENUM_LABEL_LIBRETRO_INFO_PATH:
-            snprintf(s, len,
-                     "Core Info Directory. \n"
-                             " \n"
-                             "A directory for where to search \n"
-                             "for libretro core information.");
-            break;
-        case MENU_ENUM_LABEL_PLAYLIST_DIRECTORY:
-            snprintf(s, len,
-                     "Playlist Directory. \n"
-                             " \n"
-                             "Save all playlist files to this \n"
-                             "directory.");
-            break;
-        case MENU_ENUM_LABEL_CONTENT_FAVORITES_DIRECTORY:
-            snprintf(s, len,
-                     "Favorites Playlist Directory. \n"
-                             " \n"
-                             "Save the favorites playlist to this \n"
-                             "directory.");
-            break;
-        case MENU_ENUM_LABEL_CONTENT_HISTORY_DIRECTORY:
-            snprintf(s, len,
-                     "History Playlist Directory. \n"
-                             " \n"
-                             "Save the history playlist to this \n"
-                             "directory.");
-            break;
-        case MENU_ENUM_LABEL_CONTENT_IMAGE_HISTORY_DIRECTORY:
-            snprintf(s, len,
-                     "Images Playlist Directory. \n"
-                             " \n"
-                             "Save the images playlist to this \n"
-                             "directory.");
-            break;
-        case MENU_ENUM_LABEL_CONTENT_MUSIC_HISTORY_DIRECTORY:
-            snprintf(s, len,
-                     "Music Playlist Directory. \n"
-                             " \n"
-                             "Save the music playlist to this \n"
-                             "directory.");
-            break;
-        case MENU_ENUM_LABEL_CONTENT_VIDEO_HISTORY_DIRECTORY:
-            snprintf(s, len,
-                     "Videos Playlist Directory. \n"
-                             " \n"
-                             "Save the videos playlist to this \n"
-                             "directory.");
             break;
         case MENU_ENUM_LABEL_DUMMY_ON_CORE_SHUTDOWN:
             snprintf(s, len,
@@ -464,11 +163,6 @@ int msg_hash_get_help_sv_enum(enum msg_hash_enums msg, char *s, size_t len)
                      "Open Windows permission settings to enable \n"
                      "the broadFileSystemAccess capability.");
             break;
-        case MENU_ENUM_LABEL_FILE_BROWSER_OPEN_PICKER:
-           snprintf(s, len,
-                     "Open the system file picker to access \n"
-                     "additional directories.");
-           break;
         case MENU_ENUM_LABEL_FILE_BROWSER_SHADER_PRESET:
             snprintf(s, len,
                      "Shader preset file.");
@@ -552,18 +246,6 @@ int msg_hash_get_help_sv_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Content decompressed by RetroArch will be \n"
                              "temporarily extracted to this directory.");
             break;
-        case MENU_ENUM_LABEL_HISTORY_LIST_ENABLE:
-            snprintf(s, len,
-                     "If enabled, every content loaded \n"
-                             "in RetroArch will be automatically \n"
-                             "added to the recent history list.");
-            break;
-        case MENU_ENUM_LABEL_RGUI_BROWSER_DIRECTORY:
-            snprintf(s, len,
-                     "File Browser Directory. \n"
-                             " \n"
-                             "Sets start directory for menu file browser.");
-            break;
         case MENU_ENUM_LABEL_INPUT_POLL_TYPE_BEHAVIOR:
             snprintf(s, len,
                      "Influence how input polling is done inside \n"
@@ -581,150 +263,11 @@ int msg_hash_get_help_sv_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "depending on your configuration.\n\n"
                              "Will be ignored when using netplay.");
             break;
-        case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_HIDE_UNBOUND:
-            snprintf(s, len,
-                     "Hide input descriptors that were not set \n"
-                             "by the core.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE:
-            snprintf(s, len,
-                     "Video refresh rate of your monitor. \n"
-                             "Used to calculate a suitable audio input rate.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FORCE_SRGB_DISABLE:
-            snprintf(s, len,
-                     "Forcibly disable sRGB FBO support. Some Intel \n"
-                             "OpenGL drivers on Windows have video problems \n"
-                             "with sRGB FBO support enabled.");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_ENABLE:
-            snprintf(s, len,
-                     "Enable audio output.");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_SYNC:
-            snprintf(s, len,
-                     "Synchronize audio (recommended).");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_LATENCY:
-            snprintf(s, len,
-                     "Desired audio latency in milliseconds. \n"
-                             "Might not be honored if the audio driver \n"
-                             "can't provide given latency.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_ALLOW_ROTATE:
-            snprintf(s, len,
-                     "Allow cores to set rotation. If false, \n"
-                             "rotation requests are honored, but ignored.\n\n"
-                             "Used for setups where one manually rotates \n"
-                             "the monitor.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_LABEL_SHOW:
-            snprintf(s, len,
-                     "Show the input descriptors set by the core \n"
-                             "instead of the default ones.");
-            break;
-        case MENU_ENUM_LABEL_CONTENT_HISTORY_SIZE:
-            snprintf(s, len,
-                     "Number of entries that will be kept in \n"
-                             "content history playlist.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_WINDOWED_FULLSCREEN:
-            snprintf(s, len,
-                     "To use windowed mode or not when going \n"
-                             "fullscreen.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FONT_SIZE:
-            snprintf(s, len,
-                     "Font size for on-screen messages.");
-            break;
-        case MENU_ENUM_LABEL_SAVESTATE_AUTO_INDEX:
-            snprintf(s, len,
-                     "Automatically increment slot index on each save, \n"
-                             "generating multiple savestate files. \n"
-                             "When the content is loaded, state slot will be \n"
-                             "set to the highest existing value (last savestate).");
-            break;
-        case MENU_ENUM_LABEL_FPS_SHOW:
-            snprintf(s, len,
-                     "Enables displaying the current frames \n"
-                             "per second.");
-            break;
-        case MENU_ENUM_LABEL_MEMORY_SHOW:
-            snprintf(s, len,
-                     "Includes displaying the current memory \n"
-                             "usage/total with FPS/Frames.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FONT_ENABLE:
-            snprintf(s, len,
-                     "Show and/or hide onscreen messages.");
-            break;
         case MENU_ENUM_LABEL_VIDEO_MESSAGE_POS_X:
         case MENU_ENUM_LABEL_VIDEO_MESSAGE_POS_Y:
             snprintf(s, len,
                      "Offset for where messages will be placed \n"
                              "onscreen. Values are in range [0.0, 1.0].");
-            break;
-        case MENU_ENUM_LABEL_INPUT_OVERLAY_ENABLE:
-            snprintf(s, len,
-                     "Enable or disable the current overlay.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_OVERLAY_HIDE_IN_MENU:
-            snprintf(s, len,
-                     "Hide the current overlay from appearing \n"
-                             "inside the menu.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_OVERLAY_SHOW_PHYSICAL_INPUTS:
-            snprintf(s, len,
-                      "Show keyboard/controller button presses on \n"
-                            "the onscreen overlay.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_OVERLAY_SHOW_PHYSICAL_INPUTS_PORT:
-            snprintf(s, len,
-                      "Select the port to listen for controller input \n"
-                            "to display on the onscreen overlay.");
-            break;
-        case MENU_ENUM_LABEL_OVERLAY_PRESET:
-            snprintf(s, len,
-                     "Path to input overlay.");
-            break;
-        case MENU_ENUM_LABEL_OVERLAY_OPACITY:
-            snprintf(s, len,
-                     "Overlay opacity.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_LAYOUT_ENABLE:
-            snprintf(s, len,
-                     "Enable or disable the current video layout.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_LAYOUT_PATH:
-            snprintf(s, len,
-                     "Path to video layout.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_LAYOUT_SELECTED_VIEW:
-            snprintf(s, len,
-                     "Layouts can contain multiple views. \n"
-                     "Select a view.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_BIND_TIMEOUT:
-            snprintf(s, len,
-                     "Input bind timer timeout (in seconds). \n"
-                             "Amount of seconds to wait until proceeding \n"
-                             "to the next bind.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_BIND_HOLD:
-            snprintf(s, len,
-               "Input bind hold time (in seconds). \n"
-               "Amount of seconds to hold an input to bind it.");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_OUTPUT_RATE:
-            snprintf(s, len,
-                     "Audio output samplerate.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SHARED_CONTEXT:
-            snprintf(s, len,
-                     "Set to true if hardware-rendered cores \n"
-                             "should get their private context. \n"
-                             "Avoids having to assume hardware state changes \n"
-                             "inbetween frames.");
             break;
         case MENU_ENUM_LABEL_CORE_LIST:
             snprintf(s, len,
@@ -965,12 +508,6 @@ int msg_hash_get_help_sv_enum(enum msg_hash_enums msg, char *s, size_t len)
                }
             }
             break;
-        case MENU_ENUM_LABEL_AUDIO_DSP_PLUGIN:
-            snprintf(s, len,
-                     "Audio DSP plugin.\n"
-                             " Processes audio before it's sent to \n"
-                             "the driver.");
-            break;
         case MENU_ENUM_LABEL_AUDIO_RESAMPLER_DRIVER:
             {
                const char *lbl = settings ? settings->arrays.audio_resampler : NULL;
@@ -987,12 +524,6 @@ int msg_hash_get_help_sv_enum(enum msg_hash_enums msg, char *s, size_t len)
                   strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE), len);
             }
             break;
-
-		case MENU_ENUM_LABEL_CRT_SWITCH_RESOLUTION: snprintf(s, len, "SET CRT");
-			break;
-
-		case MENU_ENUM_LABEL_CRT_SWITCH_RESOLUTION_SUPER: snprintf(s, len, "SET CRT SUPER");
-			break;
 
         case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET:
             snprintf(s, len,
@@ -1039,19 +570,6 @@ int msg_hash_get_help_sv_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "The Default Filter option will affect the \n"
                              "stretching filter.");
             break;
-        case MENU_ENUM_LABEL_VIDEO_SHADER_PARAMETERS:
-            snprintf(s, len,
-                     "Shader Parameters. \n"
-                             " \n"
-                             "Modifies current shader directly. Will not be \n"
-                             "saved to CGP/GLSLP preset file.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_PARAMETERS:
-            snprintf(s, len,
-                     "Shader Preset Parameters. \n"
-                             " \n"
-                             "Modifies shader preset currently in menu.");
-            break;
         case MENU_ENUM_LABEL_VIDEO_SHADER_PASS:
             snprintf(s, len,
                      "Path to shader. \n"
@@ -1089,13 +607,6 @@ int msg_hash_get_help_sv_enum(enum msg_hash_enums msg, char *s, size_t len)
             "manually isn't really an option."
 #endif
             );
-            break;
-        case MENU_ENUM_LABEL_CONFIRM_ON_EXIT:
-            snprintf(s, len, "Are you sure you want to quit?");
-            break;
-        case MENU_ENUM_LABEL_SHOW_HIDDEN_FILES:
-            snprintf(s, len, "Show hidden files\n"
-                    "and folders.");
             break;
         case MENU_ENUM_LABEL_VIDEO_SHADER_FILTER_PASS:
             snprintf(s, len,
@@ -1174,26 +685,6 @@ int msg_hash_get_help_sv_enum(enum msg_hash_enums msg, char *s, size_t len)
                      "it will automatically be recompiled \n"
                      "and applied to the running content.");
             break;
-        case MENU_ENUM_LABEL_MENU_TOGGLE:
-            snprintf(s, len,
-                     "Toggles menu.");
-            break;
-        case MENU_ENUM_LABEL_GRAB_MOUSE_TOGGLE:
-            snprintf(s, len,
-                     "Toggles mouse grab.\n"
-                             " \n"
-                             "When mouse is grabbed, RetroArch hides the \n"
-                             "mouse, and keeps the mouse pointer inside \n"
-                             "the window to allow relative mouse input to \n"
-                             "work better.");
-            break;
-        case MENU_ENUM_LABEL_GAME_FOCUS_TOGGLE:
-            snprintf(s, len,
-                     "Toggles game focus.\n"
-                             " \n"
-                             "When a game has focus, RetroArch will both disable \n"
-                             "hotkeys and keep/wrap the mouse pointer inside the window.");
-            break;
         case MENU_ENUM_LABEL_DISK_NEXT:
             snprintf(s, len,
                      "Cycles through disk images. Use after \n"
@@ -1237,12 +728,6 @@ int msg_hash_get_help_sv_enum(enum msg_hash_enums msg, char *s, size_t len)
 #endif
             );
             break;
-        case MENU_ENUM_LABEL_DISK_EJECT_TOGGLE:
-            snprintf(s, len,
-                     "Toggles eject for disks.\n"
-                             " \n"
-                             "Used for multiple-disk content.");
-            break;
         case MENU_ENUM_LABEL_ENABLE_HOTKEY:
             snprintf(s, len,
                      "Enable other hotkeys.\n"
@@ -1256,28 +741,6 @@ int msg_hash_get_help_sv_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "implementations which query a large area of \n"
                              "the keyboard, where it is not desirable that \n"
                              "hotkeys get in the way.");
-            break;
-        case MENU_ENUM_LABEL_REWIND_ENABLE:
-            snprintf(s, len,
-                     "Enable rewinding.\n"
-                             " \n"
-                             "This will take a performance hit, \n"
-                             "so it is disabled by default.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_APPLY_AFTER_TOGGLE:
-            snprintf(s, len,
-                     "Apply cheat immediately after toggling.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_APPLY_AFTER_LOAD:
-            snprintf(s, len,
-                     "Auto-apply cheats when game loads.");
-            break;
-        case MENU_ENUM_LABEL_LIBRETRO_DIR_PATH:
-            snprintf(s, len,
-                     "Core Directory. \n"
-                             " \n"
-                             "A directory for where to search for \n"
-                             "libretro core implementations.");
             break;
         case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE_AUTO:
             snprintf(s, len,
@@ -1298,59 +761,6 @@ int msg_hash_get_help_sv_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "large pitch changes. If your monitor does \n"
                              "not run at 60Hz, or something close to it, \n"
                              "disable VSync, and leave this at its default.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE_POLLED:
-            snprintf(s, len,
-                     "Set Polled Refresh Rate\n"
-                             " \n"
-                            "Sets the refresh rate to the actual value\n"
-                            "polled from the display driver.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_ROTATION:
-            snprintf(s, len,
-                     "Forces a certain rotation \n"
-                             "of the screen.\n"
-                             " \n"
-                             "The rotation is added to rotations which\n"
-                             "the libretro core sets (see Video Allow\n"
-                             "Rotate).");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SCALE:
-            snprintf(s, len,
-                     "Fullscreen resolution.\n"
-                             " \n"
-                             "Resolution of 0 uses the \n"
-                             "resolution of the environment.\n");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_HDR_ENABLE:
-            snprintf(s, len,
-                     "Enable HDR.\n"
-                             " \n"
-                             "If supported this enables hdr \n");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_HDR_MAX_NITS:
-            snprintf(s, len,
-                     "Peak Luminance\n"
-                             " \n"
-                             "Set the peak luminance (in cd/m2) your display can reproduce - see RTings for your models peak luminance\n");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_HDR_PAPER_WHITE_NITS:
-            snprintf(s, len,
-                     "Paper White Luminance\n"
-                             " \n"
-                             "Set the luminance at which paper white should be ie readable text or luminance at the top of the SDR range\n");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_HDR_CONTRAST:
-            snprintf(s, len,
-                     "Contrast\n"
-                             " \n"
-                             "The constrast setting for HDR\n");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_HDR_EXPAND_GAMUT:
-            snprintf(s, len,
-                     "Expand Gamut\n"
-                             " \n"
-                             "Once converted to linear space should we use an expanded colour gamut to get to HDR10\n");
             break;
         case MENU_ENUM_LABEL_FASTFORWARD_RATIO:
             snprintf(s, len,
@@ -1384,30 +794,6 @@ int msg_hash_get_help_sv_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "is preferred, 1 and up (1 being first \n"
                              "monitor), suggests RetroArch to use that \n"
                              "particular monitor.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_CROP_OVERSCAN:
-            snprintf(s, len,
-                     "Forces cropping of overscanned \n"
-                             "frames.\n"
-                             " \n"
-                             "Exact behavior of this option is \n"
-                             "core-implementation specific.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SCALE_INTEGER:
-            snprintf(s, len,
-                     "Only scales video in integer \n"
-                             "steps.\n"
-                             " \n"
-                             "The base size depends on system-reported \n"
-                             "geometry and aspect ratio.\n"
-                             " \n"
-                             "If 'Force Aspect Ratio' is not set, X/Y will be \n"
-                             "integer scaled independently.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SCALE_INTEGER_OVERSCALE:
-            snprintf(s, len,
-                     "Force integer scaling to round up \n"
-                             " to the next larger integer instead of rounding down.");
             break;
         case MENU_ENUM_LABEL_AUDIO_VOLUME:
             snprintf(s, len,
@@ -1444,53 +830,10 @@ int msg_hash_get_help_sv_enum(enum msg_hash_enums msg, char *s, size_t len)
                              " Input rate is defined as: \n"
                              " input rate * (1.0 +/- (max timing skew))");
             break;
-        case MENU_ENUM_LABEL_OVERLAY_NEXT:
-            snprintf(s, len,
-                     "Toggles to next overlay.\n"
-                             " \n"
-                             "Wraps around.");
-            break;
-        case MENU_ENUM_LABEL_LOG_VERBOSITY:
-            snprintf(s, len,
-                     "Enable or disable verbosity level \n"
-                             "of frontend.");
-            break;
-        case MENU_ENUM_LABEL_VOLUME_UP:
-            snprintf(s, len,
-                     "Increases audio volume.");
-            break;
-        case MENU_ENUM_LABEL_VOLUME_DOWN:
-            snprintf(s, len,
-                     "Decreases audio volume.");
-            break;
         case MENU_ENUM_LABEL_VIDEO_DISABLE_COMPOSITION:
             snprintf(s, len,
                      "Forcibly disable composition.\n"
                              "Only valid on Windows Vista/7 for now.");
-            break;
-        case MENU_ENUM_LABEL_PERFCNT_ENABLE:
-            snprintf(s, len,
-                     "Enable or disable frontend \n"
-                             "performance counters.");
-            break;
-        case MENU_ENUM_LABEL_SYSTEM_DIRECTORY:
-            snprintf(s, len,
-                     "System Directory. \n"
-                             " \n"
-                             "Sets the 'system' directory.\n"
-                             "Cores can query for this\n"
-                             "directory to load BIOSes, \n"
-                             "system-specific configs, etc.");
-            break;
-        case MENU_ENUM_LABEL_SAVESTATE_AUTO_SAVE:
-        case MENU_ENUM_LABEL_SAVESTATE_AUTO_LOAD:
-            snprintf(s, len,
-                     "Automatically saves a savestate at the \n"
-                             "end of RetroArch's lifetime.\n"
-                             " \n"
-                             "RetroArch will automatically load any savestate\n"
-                             "with this path on startup if 'Auto Load State\n"
-                             "is enabled.");
             break;
         case MENU_ENUM_LABEL_VIDEO_THREADED:
             snprintf(s, len,
@@ -1499,47 +842,6 @@ int msg_hash_get_help_sv_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Using this might improve performance at the \n"
                              "possible cost of latency and more video \n"
                              "stuttering.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_VSYNC:
-            snprintf(s, len,
-                     "Video V-Sync.\n");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_HARD_SYNC:
-            snprintf(s, len,
-                     "Attempts to hard-synchronize \n"
-                             "CPU and GPU.\n"
-                             " \n"
-                             "Can reduce latency at the cost of \n"
-                             "performance.");
-            break;
-        case MENU_ENUM_LABEL_REWIND_GRANULARITY:
-            snprintf(s, len,
-                     "Rewind granularity.\n"
-                             " \n"
-                             " When rewinding defined number of \n"
-                             "frames, you can rewind several frames \n"
-                             "at a time, increasing the rewinding \n"
-                             "speed.");
-            break;
-        case MENU_ENUM_LABEL_REWIND_BUFFER_SIZE:
-            snprintf(s, len,
-                     "Rewind buffer size (MB).\n"
-                             " \n"
-                             " The amount of memory in MB to reserve \n"
-                             "for rewinding.  Increasing this value \n"
-                             "increases the rewind history length.\n");
-            break;
-        case MENU_ENUM_LABEL_REWIND_BUFFER_SIZE_STEP:
-            snprintf(s, len,
-                     "Rewind buffer size step (MB).\n"
-                             " \n"
-                             " Each time you increase or decrease \n"
-                             "the rewind buffer size value via this \n"
-                             "UI it will change by this amount.\n");
-            break;
-        case MENU_ENUM_LABEL_SCREENSHOT:
-            snprintf(s, len,
-                     "Take screenshot.");
             break;
         case MENU_ENUM_LABEL_VIDEO_FRAME_DELAY:
             snprintf(s, len,
@@ -1560,14 +862,6 @@ int msg_hash_get_help_sv_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "'Frame Delay' is 0.\n"
                              " \n"
                              "E.g. 8 for NTSC and 10 for PAL.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SHADER_DELAY:
-            snprintf(s, len,
-                     "Sets by how many milliseconds auto-loading shaders\n"
-                             "are delayed.\n"
-                             "\n"
-                             "Can work around graphical glitches due to using\n"
-                             "'screen grabbing' software like streaming software.");
             break;
         case MENU_ENUM_LABEL_VIDEO_HARD_SYNC_FRAMES:
             snprintf(s, len,
@@ -1594,48 +888,6 @@ int msg_hash_get_help_sv_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "configured as if it is a 60 Hz monitor \n"
                              "(divide refresh rate by 2).");
             break;
-        case MENU_ENUM_LABEL_RGUI_SHOW_START_SCREEN:
-            snprintf(s, len,
-                     "Show startup screen in menu.\n"
-                             "Is automatically set to false when seen\n"
-                             "for the first time.\n"
-                             " \n"
-                             "This is only updated in config if\n"
-                             "'Save Configuration on Exit' is enabled.\n");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FULLSCREEN:
-            snprintf(s, len, "Toggles fullscreen.");
-            break;
-        case MENU_ENUM_LABEL_BLOCK_SRAM_OVERWRITE:
-            snprintf(s, len,
-                     "Block SRAM from being overwritten \n"
-                             "when loading save states.\n"
-                             " \n"
-                             "Might potentially lead to buggy games.");
-            break;
-        case MENU_ENUM_LABEL_PAUSE_NONACTIVE:
-            snprintf(s, len,
-                     "Pause gameplay when window focus \n"
-                             "is lost.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_GPU_SCREENSHOT:
-            snprintf(s, len,
-                     "Screenshots output of GPU shaded \n"
-                             "material if available.");
-            break;
-        case MENU_ENUM_LABEL_SCREENSHOT_DIRECTORY:
-            snprintf(s, len,
-                     "Screenshot Directory. \n"
-                             " \n"
-                             "Directory to dump screenshots to.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SWAP_INTERVAL:
-            snprintf(s, len,
-                     "VSync Swap Interval.\n"
-                             " \n"
-                             "Uses a custom swap interval for VSync. Set this \n"
-                             "to effectively halve monitor refresh rate.");
-            break;
         case MENU_ENUM_LABEL_SAVEFILE_DIRECTORY:
             snprintf(s, len,
                      "Savefile Directory. \n"
@@ -1643,16 +895,6 @@ int msg_hash_get_help_sv_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Save all save files (*.srm) to this \n"
                              "directory. This includes related files like \n"
                              ".bsv, .rt, .psrm, etc...\n"
-                             " \n"
-                             "This will be overridden by explicit command line\n"
-                             "options.");
-            break;
-        case MENU_ENUM_LABEL_SAVESTATE_DIRECTORY:
-            snprintf(s, len,
-                     "Savestate Directory. \n"
-                             " \n"
-                             "Save all save states (*.state) to this \n"
-                             "directory.\n"
                              " \n"
                              "This will be overridden by explicit command line\n"
                              "options.");
@@ -1673,77 +915,8 @@ int msg_hash_get_help_sv_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "be loaded dynamically by the menu depending \n"
                              "on context.");
             break;
-        case MENU_ENUM_LABEL_SLOWMOTION_RATIO:
-            snprintf(s, len,
-                     "Slowmotion ratio."
-                             " \n"
-                             "When slowmotion, content will slow\n"
-                             "down by factor.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_BUTTON_AXIS_THRESHOLD:
-            snprintf(s, len,
-                     "Defines the axis threshold.\n"
-                             " \n"
-                             "How far an axis must be tilted to result\n"
-                             "in a button press.\n"
-                             " Possible values are [0.0, 1.0].");
-            break;
-        case MENU_ENUM_LABEL_INPUT_TURBO_PERIOD:
-            snprintf(s, len,
-                     "Turbo period.\n"
-                             " \n"
-                             "Describes the period of which turbo-enabled\n"
-                             "buttons toggle.\n"
-                             " \n"
-                             "Numbers are described in frames.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_TURBO_MODE:
-            snprintf(s, len,
-                  "Turbo Mode.\n"
-                  " \n"
-                  "Selects the general behavior of turbo mode.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_TURBO_DEFAULT_BUTTON:
-            snprintf(s, len,
-                  "Turbo Default Button.\n"
-                  " \n"
-                  "Default active button for Turbo Mode 'Single Button'.\n");
-            break;
-        case MENU_ENUM_LABEL_INPUT_DUTY_CYCLE:
-            snprintf(s, len,
-                     "Duty cycle.\n"
-                             " \n"
-                             "Describes how long the period of a turbo-enabled\n"
-                             "should be.\n"
-                             " \n"
-                             "Numbers are described in frames.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_TOUCH_ENABLE:
-            snprintf(s, len, "Enable touch support.");
-            break;
         case MENU_ENUM_LABEL_INPUT_PREFER_FRONT_TOUCH:
             snprintf(s, len, "Use front instead of back touch.");
-            break;
-        case MENU_ENUM_LABEL_MOUSE_ENABLE:
-            snprintf(s, len, "Enable mouse input inside the menu.");
-            break;
-        case MENU_ENUM_LABEL_POINTER_ENABLE:
-            snprintf(s, len, "Enable touch input inside the menu.");
-            break;
-        case MENU_ENUM_LABEL_MENU_WALLPAPER:
-            snprintf(s, len, "Path to an image to set as the background.");
-            break;
-        case MENU_ENUM_LABEL_NAVIGATION_WRAPAROUND:
-            snprintf(s, len,
-                     "Wrap-around to beginning and/or end \n"
-                             "if boundary of list is reached \n"
-                             "horizontally and/or vertically.");
-            break;
-        case MENU_ENUM_LABEL_PAUSE_LIBRETRO:
-            snprintf(s, len,
-                     "If disabled, the game will keep \n"
-                             "running in the background when we are in the \n"
-                             "menu.");
             break;
         case MENU_ENUM_LABEL_SUSPEND_SCREENSAVER_ENABLE:
             snprintf(s, len,
@@ -1763,13 +936,6 @@ int msg_hash_get_help_sv_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Increasing this value will increase \n"
                              "performance, but introduce more latency.");
             break;
-        case MENU_ENUM_LABEL_NETPLAY_PUBLIC_ANNOUNCE:
-            snprintf(s, len,
-                     "Whether to announce netplay games publicly. \n"
-                             " \n"
-                             "If set to false, clients must manually connect \n"
-                             "rather than using the public lobby.");
-            break;
         case MENU_ENUM_LABEL_NETPLAY_START_AS_SPECTATOR:
             snprintf(s, len,
                      "Whether to start netplay in spectator mode. \n"
@@ -1777,21 +943,6 @@ int msg_hash_get_help_sv_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "If set to true, netplay will be in spectator mode \n"
                              "on start. It's always possible to change mode \n"
                              "later.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_ALLOW_SLAVES:
-            snprintf(s, len,
-                     "Whether to allow connections in slave mode. \n"
-                             " \n"
-                             "Slave-mode clients require very little processing \n"
-                             "power on either side, but will suffer \n"
-                             "significantly from network latency.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_REQUIRE_SLAVES:
-            snprintf(s, len,
-                     "Whether to disallow connections not in slave mode. \n"
-                             " \n"
-                             "Not recommended except for very fast networks \n"
-                             "with very weak machines.");
             break;
         case MENU_ENUM_LABEL_NETPLAY_CHECK_FRAMES:
             snprintf(s, len,
@@ -1834,24 +985,6 @@ int msg_hash_get_help_sv_enum(enum msg_hash_enums msg, char *s, size_t len)
                      "makes netplay less CPU-intensive, but at \n"
                      "the price of unpredictable input lag. \n");
             break;
-        case MENU_ENUM_LABEL_NETPLAY_NAT_TRAVERSAL:
-            snprintf(s, len,
-                     "When hosting, attempt to listen for\n"
-                             "connections from the public internet, using\n"
-                             "UPnP or similar technologies to escape LANs. \n");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_USE_MITM_SERVER:
-            snprintf(s, len,
-                     "When hosting a netplay session, relay connection through a \n"
-                             "man-in-the-middle server \n"
-                             "to get around firewalls or NAT/UPnP issues. \n");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_MITM_SERVER:
-            snprintf(s, len,
-                     "Specifies the man-in-the-middle server \n"
-                             "to use for netplay. A server that is \n"
-                             "located closer to you may have less latency. \n");
-            break;
         case MENU_ENUM_LABEL_VIDEO_MAX_SWAPCHAIN_IMAGES:
             snprintf(s, len,
                      "Maximum amount of swapchain images. This \n"
@@ -1879,202 +1012,19 @@ int msg_hash_get_help_sv_enum(enum msg_hash_enums msg, char *s, size_t len)
 #endif
          );
          break;
-        case MENU_ENUM_LABEL_TIMEDATE_ENABLE:
-            snprintf(s, len,
-                     "Shows current date and/or time inside menu.");
-            break;
-        case MENU_ENUM_LABEL_TIMEDATE_STYLE:
-           snprintf(s, len,
-              "Style to show the current date and/or time in.");
-           break;
-        case MENU_ENUM_LABEL_BATTERY_LEVEL_ENABLE:
-            snprintf(s, len,
-                     "Shows current battery level inside menu.");
-            break;
-        case MENU_ENUM_LABEL_CORE_ENABLE:
-            snprintf(s, len,
-                     "Shows current core inside menu.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_ENABLE_HOST:
-            snprintf(s, len,
-                     "Enables Netplay in host (server) mode.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_ENABLE_CLIENT:
-            snprintf(s, len,
-                     "Enables Netplay in client mode.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_DISCONNECT:
-            snprintf(s, len,
-                     "Disconnects an active Netplay connection.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_LAN_SCAN_SETTINGS:
-            snprintf(s, len,
-                     "Search for and connect to netplay hosts on the local network.");
-            break;
         case MENU_ENUM_LABEL_NETPLAY_SETTINGS:
             snprintf(s, len,
                      "Setting related to Netplay.");
-            break;
-        case MENU_ENUM_LABEL_DYNAMIC_WALLPAPER:
-            snprintf(s, len,
-                     "Dynamically load a new background \n"
-                             "depending on context.");
-            break;
-        case MENU_ENUM_LABEL_CORE_UPDATER_BUILDBOT_URL:
-            snprintf(s, len,
-                     "URL to core updater directory on the \n"
-                             "Libretro buildbot.");
-            break;
-        case MENU_ENUM_LABEL_BUILDBOT_ASSETS_URL:
-            snprintf(s, len,
-                     "URL to assets updater directory on the \n"
-                             "Libretro buildbot.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_REMAP_BINDS_ENABLE:
-            snprintf(s, len,
-                     "if enabled, overrides the input binds \n"
-                             "with the remapped binds set for the \n"
-                             "current core.");
-            break;
-        case MENU_ENUM_LABEL_OVERLAY_DIRECTORY:
-            snprintf(s, len,
-                     "Overlay Directory. \n"
-                             " \n"
-                             "Defines a directory where overlays are \n"
-                             "kept for easy access.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_LAYOUT_DIRECTORY:
-            snprintf(s, len,
-                     "Video Layout Directory. \n"
-                             " \n"
-                             "Defines a directory where video layouts are \n"
-                             "kept for easy access.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_MAX_USERS:
-            snprintf(s, len,
-                     "Maximum amount of users supported by \n"
-                             "RetroArch.");
-            break;
-        case MENU_ENUM_LABEL_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
-            snprintf(s, len,
-                     "After downloading, automatically extract \n"
-                             "archives that the downloads are contained \n"
-                             "inside.");
-            break;
-        case MENU_ENUM_LABEL_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
-            snprintf(s, len,
-                     "Filter files being shown by \n"
-                             "supported extensions.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_NICKNAME:
-            snprintf(s, len,
-                     "The username of the person running RetroArch. \n"
-                             "This will be used for playing online games.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_TCP_UDP_PORT:
-            snprintf(s, len,
-                     "The port of the host IP address. \n"
-                             "Can be either a TCP or UDP port.");
             break;
         case MENU_ENUM_LABEL_NETPLAY_SPECTATOR_MODE_ENABLE:
             snprintf(s, len,
                      "Enable or disable spectator mode for \n"
                              "the user during netplay.");
             break;
-        case MENU_ENUM_LABEL_NETPLAY_IP_ADDRESS:
-            snprintf(s, len,
-                     "The address of the host to connect to.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_PASSWORD:
-            snprintf(s, len,
-                     "The password for connecting to the netplay \n"
-                             "host. Used only in host mode.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_SPECTATE_PASSWORD:
-            snprintf(s, len,
-                     "The password for connecting to the netplay \n"
-                             "host with only spectator privileges. Used \n"
-                             "only in host mode.");
-            break;
-        case MENU_ENUM_LABEL_STDIN_CMD_ENABLE:
-            snprintf(s, len,
-                     "Enable stdin command interface.");
-            break;
         case MENU_ENUM_LABEL_UI_COMPANION_START_ON_BOOT:
             snprintf(s, len,
                      "Start User Interface companion driver \n"
                              "on boot (if available).");
-            break;
-        case MENU_ENUM_LABEL_MENU_DRIVER:
-            snprintf(s, len, "Menu driver to use.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
-            snprintf(s, len,
-                     "Gamepad button combination to toggle menu. \n"
-                             " \n"
-                             "0 - None \n"
-                             "1 - Press L + R + Y + D-Pad Down \n"
-                             "simultaneously. \n"
-                             "2 - Press L3 + R3 simultaneously. \n"
-                             "3 - Press Start + Select simultaneously.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_QUIT_GAMEPAD_COMBO:
-            snprintf(s, len,
-                     "Gamepad button combination to quit. \n"
-                             " \n"
-                             "0 - None \n"
-                             "1 - Press L + R + Y + D-Pad Down \n"
-                             "simultaneously. \n"
-                             "2 - Press L3 + R3 simultaneously. \n"
-                             "3 - Press Start + Select simultaneously.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_ALL_USERS_CONTROL_MENU:
-            snprintf(s, len, "Allows any user to control the menu. \n"
-                    " \n"
-                    "When disabled, only user 1 can control the menu.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_AUTODETECT_ENABLE:
-            snprintf(s, len,
-                     "Enable input auto-detection.\n"
-                             " \n"
-                             "Will attempt to auto-configure \n"
-                             "joypads, Plug-and-Play style.");
-            break;
-        case MENU_ENUM_LABEL_CAMERA_ALLOW:
-            snprintf(s, len,
-                     "Allow or disallow camera access by \n"
-                             "cores.");
-            break;
-        case MENU_ENUM_LABEL_LOCATION_ALLOW:
-            snprintf(s, len,
-                     "Allow or disallow location services \n"
-                             "access by cores.");
-            break;
-        case MENU_ENUM_LABEL_TURBO:
-            snprintf(s, len,
-                     "Turbo enable.\n"
-                             " \n"
-                             "Holding the turbo while pressing another \n"
-                             "button will let the button enter a turbo \n"
-                             "mode where the button state is modulated \n"
-                             "with a periodic signal. \n"
-                             " \n"
-                             "The modulation stops when the button \n"
-                             "itself (not turbo button) is released.");
-            break;
-        case MENU_ENUM_LABEL_OSK_ENABLE:
-            snprintf(s, len,
-                     "Enable/disable on-screen keyboard.");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_MUTE:
-            snprintf(s, len,
-                     "Mute/unmute audio.");
-            break;
-        case MENU_ENUM_LABEL_REWIND:
-            snprintf(s, len,
-                     "Hold button down to rewind.\n"
-                             " \n"
-                             "Rewind must be enabled.");
             break;
         case MENU_ENUM_LABEL_EXIT_EMULATOR:
             snprintf(s, len,
@@ -2088,176 +1038,9 @@ int msg_hash_get_help_sv_enum(enum msg_hash_enums msg, char *s, size_t len)
 #endif
             );
             break;
-        case MENU_ENUM_LABEL_LOAD_STATE:
-            snprintf(s, len,
-                     "Loads state.");
-            break;
-        case MENU_ENUM_LABEL_SAVE_STATE:
-            snprintf(s, len,
-                     "Saves state.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_GAME_WATCH:
-            snprintf(s, len,
-                     "Netplay toggle play/spectate mode.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_INDEX_PLUS:
-            snprintf(s, len,
-                     "Increase cheat index.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_INDEX_MINUS:
-            snprintf(s, len,
-                     "Decrease cheat index.");
-            break;
-        case MENU_ENUM_LABEL_SHADER_PREV:
-            snprintf(s, len,
-                     "Applies previous shader in directory.");
-            break;
-        case MENU_ENUM_LABEL_SHADER_NEXT:
-            snprintf(s, len,
-                     "Applies next shader in directory.");
-            break;
-        case MENU_ENUM_LABEL_RESET:
-            snprintf(s, len,
-                     "Reset the content.");
-            break;
-        case MENU_ENUM_LABEL_PAUSE_TOGGLE:
-            snprintf(s, len,
-                     "Toggle between paused and non-paused state.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_TOGGLE:
-            snprintf(s, len,
-                     "Toggle cheat index.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_IDX:
-            snprintf(s, len,
-                     "Index position in list.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_ADDRESS_BIT_POSITION:
-            snprintf(s, len,
-                     "Address bitmask when Memory Search Size < 8-bit.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_REPEAT_COUNT:
-            snprintf(s, len,
-                     "The number of times the cheat will be applied.\nUse with the other two Iteration options to affect large areas of memory.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_REPEAT_ADD_TO_ADDRESS:
-            snprintf(s, len,
-                     "After each 'Number of Iterations' the Memory Address will be increased by this number times the 'Memory Search Size'.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_REPEAT_ADD_TO_VALUE:
-            snprintf(s, len,
-                     "After each 'Number of Iterations' the Value will be increased by this amount.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_MATCH_IDX:
-            snprintf(s, len,
-                     "Select the match to view.");
-            break;
         case MENU_ENUM_LABEL_CHEAT_START_OR_CONT:
             snprintf(s, len,
                      "Scan memory to create new cheats.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_START_OR_RESTART:
-            snprintf(s, len,
-                     "Left/Right to change bit-size.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_EXACT:
-            snprintf(s, len,
-                     "Left/Right to change value.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_LT:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_GT:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_EQ:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_NEQ:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_EQPLUS:
-            snprintf(s, len,
-                     "Left/Right to change value.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_EQMINUS:
-            snprintf(s, len,
-                     "Left/Right to change value.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_ADD_MATCHES:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_VIEW_MATCHES:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_CREATE_OPTION:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_DELETE_OPTION:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_ADD_NEW_TOP:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_RELOAD_CHEATS:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_ADD_NEW_BOTTOM:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_DELETE_ALL:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_BIG_ENDIAN:
-            snprintf(s, len,
-                     "Big endian    : 258 = 0x0102\n"
-                     "Little endian : 258 = 0x0201");
-            break;
-        case MENU_ENUM_LABEL_HOLD_FAST_FORWARD:
-            snprintf(s, len,
-                     "Hold for fast-forward. Releasing button \n"
-                             "disables fast-forward.");
-            break;
-        case MENU_ENUM_LABEL_SLOWMOTION_HOLD:
-            snprintf(s, len,
-                     "Hold for slowmotion.");
-            break;
-        case MENU_ENUM_LABEL_FRAME_ADVANCE:
-            snprintf(s, len,
-                     "Frame advance when content is paused.");
-            break;
-        case MENU_ENUM_LABEL_BSV_RECORD_TOGGLE:
-            snprintf(s, len,
-                     "Toggle between recording and not.");
-            break;
-        case MENU_ENUM_LABEL_L_X_PLUS:
-        case MENU_ENUM_LABEL_L_X_MINUS:
-        case MENU_ENUM_LABEL_L_Y_PLUS:
-        case MENU_ENUM_LABEL_L_Y_MINUS:
-        case MENU_ENUM_LABEL_R_X_PLUS:
-        case MENU_ENUM_LABEL_R_X_MINUS:
-        case MENU_ENUM_LABEL_R_Y_PLUS:
-        case MENU_ENUM_LABEL_R_Y_MINUS:
-            snprintf(s, len,
-                     "Axis for analog stick (DualShock-esque).\n"
-                             " \n"
-                             "Bound as usual, however, if a real analog \n"
-                             "axis is bound, it can be read as a true analog.\n"
-                             " \n"
-                             "Positive X axis is right. \n"
-                             "Positive Y axis is down.");
             break;
         case MENU_ENUM_LABEL_VALUE_WHAT_IS_A_CORE_DESC:
             snprintf(s, len,
@@ -2305,41 +1088,37 @@ int msg_hash_get_help_sv_enum(enum msg_hash_enums msg, char *s, size_t len)
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OVERLAY_SETTINGS),
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_HIDE_IN_MENU));
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_ENABLE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_ENABLE:
             snprintf(s, len,
                      "Enables a background color for the OSD.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_RED:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_RED:
             snprintf(s, len,
                      "Sets the red value of the OSD background color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_GREEN:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_GREEN:
             snprintf(s, len,
                      "Sets the green value of the OSD background color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_BLUE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_BLUE:
             snprintf(s, len,
                      "Sets the blue value of the OSD background color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_OPACITY:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_OPACITY:
             snprintf(s, len,
                      "Sets the opacity of the OSD background color. Valid values are between 0.0 and 1.0.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_RED:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_RED:
             snprintf(s, len,
                      "Sets the red value of the OSD text color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_GREEN:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_GREEN:
             snprintf(s, len,
                      "Sets the green value of the OSD text color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_BLUE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_BLUE:
             snprintf(s, len,
                      "Sets the blue value of the OSD text color. Valid values are between 0 and 255.");
-            break;
-        case MENU_ENUM_LABEL_MIDI_DRIVER:
-            snprintf(s, len,
-                     "MIDI driver to use.");
             break;
 #ifdef HAVE_LAKKA
         case MENU_ENUM_LABEL_TIMEZONE:
@@ -2365,10 +1144,6 @@ int msg_hash_get_help_sv_enum(enum msg_hash_enums msg, char *s, size_t len)
                      "When MIDI output is enabled and core and game/app support MIDI output,\n"
                      "some or all sounds (depends on game/app) will be generated by MIDI device.\n"
                      "In case of \"null\" MIDI driver this means that those sounds won't be audible.");
-            break;
-        case MENU_ENUM_LABEL_MIDI_VOLUME:
-            snprintf(s, len,
-                     "Sets the master volume of the output device.");
             break;
 #ifdef __linux__
         case MENU_ENUM_LABEL_GAMEMODE_ENABLE:

--- a/intl/msg_hash_tr.c
+++ b/intl/msg_hash_tr.c
@@ -2148,35 +2148,35 @@ int msg_hash_get_help_tr_enum(enum msg_hash_enums msg, char *s, size_t len)
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_HIDE_IN_MENU)
             );
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_ENABLE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_ENABLE:
             snprintf(s, len,
                      "OSD için arka plan rengini etkinleştirir.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_RED:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_RED:
             snprintf(s, len,
                      "OSD arka plan renginin kırmızı değerini ayarlar. Geçerli değerler 0 ile 255 arasındadır.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_GREEN:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_GREEN:
             snprintf(s, len,
                      "OSD arka plan renginin yeşil değerini ayarlar. Geçerli değerler 0 ile 255 arasındadır.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_BLUE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_BLUE:
             snprintf(s, len,
                      "OSD arka plan renginin mavi değerini ayarlar. Geçerli değerler 0 ile 255 arasındadır.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_OPACITY:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_OPACITY:
             snprintf(s, len,
                      "OSD arka plan renginin opaklığını ayarlar. Geçerli değerler 0,0 ile 1,0 arasındadır.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_RED:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_RED:
             snprintf(s, len,
                      "OSD metin renginin kırmızı değerini ayarlar. Geçerli değerler 0 ile 255 arasındadır.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_GREEN:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_GREEN:
             snprintf(s, len,
                      "OSD metin renginin yeşil değerini ayarlar. Geçerli değerler 0 ile 255 arasındadır.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_BLUE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_BLUE:
             snprintf(s, len,
                      "OSD metin renginin mavi değerini ayarlar. Geçerli değerler 0 ile 255 arasındadır.");
             break;

--- a/intl/msg_hash_uk.c
+++ b/intl/msg_hash_uk.c
@@ -47,153 +47,6 @@ int msg_hash_get_help_uk_enum(enum msg_hash_enums msg, char *s, size_t len)
 
        switch (idx)
        {
-          case RARCH_FAST_FORWARD_KEY:
-             snprintf(s, len,
-                   "Toggles between fast-forwarding and \n"
-                   "normal speed."
-                   );
-             break;
-          case RARCH_FAST_FORWARD_HOLD_KEY:
-             snprintf(s, len,
-                   "Hold for fast-forward. \n"
-                   " \n"
-                   "Releasing button disables fast-forward."
-                   );
-             break;
-          case RARCH_SLOWMOTION_KEY:
-             snprintf(s, len,
-                   "Toggles slowmotion.");
-             break;
-          case RARCH_SLOWMOTION_HOLD_KEY:
-             snprintf(s, len,
-                   "Hold for slowmotion.");
-             break;
-          case RARCH_PAUSE_TOGGLE:
-             snprintf(s, len,
-                   "Toggle between paused and non-paused state.");
-             break;
-          case RARCH_FRAMEADVANCE:
-             snprintf(s, len,
-                   "Frame advance when content is paused.");
-             break;
-          case RARCH_SHADER_NEXT:
-             snprintf(s, len,
-                   "Applies next shader in directory.");
-             break;
-          case RARCH_SHADER_PREV:
-             snprintf(s, len,
-                   "Applies previous shader in directory.");
-             break;
-          case RARCH_CHEAT_INDEX_PLUS:
-          case RARCH_CHEAT_INDEX_MINUS:
-          case RARCH_CHEAT_TOGGLE:
-             snprintf(s, len,
-                   "Cheats.");
-             break;
-          case RARCH_RESET:
-             snprintf(s, len,
-                   "Reset the content.");
-             break;
-          case RARCH_SCREENSHOT:
-             snprintf(s, len,
-                   "Take screenshot.");
-             break;
-          case RARCH_MUTE:
-             snprintf(s, len,
-                   "Mute/unmute audio.");
-             break;
-          case RARCH_OSK:
-             snprintf(s, len,
-                   "Toggles onscreen keyboard.");
-             break;
-          case RARCH_FPS_TOGGLE:
-             snprintf(s, len,
-                   "Toggles frames per second counter.");
-             break;
-          case RARCH_STATISTICS_TOGGLE:
-             snprintf(s, len,
-                   "Toggles display of technical statistics.");
-             break;
-          case RARCH_SEND_DEBUG_INFO:
-             snprintf(s, len,
-                   "Sends diagnostic info about your device and RetroArch configuration to our servers for analysis.");
-             break;
-          case RARCH_NETPLAY_HOST_TOGGLE:
-             snprintf(s, len,
-                   "Toggles netplay hosting on/off.");
-             break;
-          case RARCH_NETPLAY_GAME_WATCH:
-             snprintf(s, len,
-                   "Netplay toggle play/spectate mode.");
-             break;
-          case RARCH_ENABLE_HOTKEY:
-             snprintf(s, len,
-                   "Enable other hotkeys. \n"
-                   " \n"
-                   "If this hotkey is bound to either\n"
-                   "a keyboard, joybutton or joyaxis, \n"
-                   "all other hotkeys will be enabled only \n"
-                   "if this one is held at the same time. \n"
-                   " \n"
-                   "Alternatively, all hotkeys for keyboard \n"
-                   "could be disabled by the user.");
-             break;
-          case RARCH_VOLUME_UP:
-             snprintf(s, len,
-                   "Increases audio volume.");
-             break;
-          case RARCH_VOLUME_DOWN:
-             snprintf(s, len,
-                   "Decreases audio volume.");
-             break;
-          case RARCH_OVERLAY_NEXT:
-             snprintf(s, len,
-                   "Switches to next overlay. Wraps around.");
-             break;
-          case RARCH_DISK_EJECT_TOGGLE:
-             snprintf(s, len,
-                   "Toggles eject for disks. \n"
-                   " \n"
-                   "Used for multiple-disk content.");
-             break;
-          case RARCH_DISK_NEXT:
-          case RARCH_DISK_PREV:
-             snprintf(s, len,
-                   "Cycles through disk images. Use after ejecting. \n"
-                   " \n"
-                   "Complete by toggling eject again.");
-             break;
-          case RARCH_GRAB_MOUSE_TOGGLE:
-             snprintf(s, len,
-                   "Toggles mouse grab. \n"
-                   " \n"
-                   "When mouse is grabbed, RetroArch hides the \n"
-                   "mouse, and keeps the mouse pointer inside \n"
-                   "the window to allow relative mouse input to \n"
-                   "work better.");
-             break;
-          case RARCH_GAME_FOCUS_TOGGLE:
-             snprintf(s, len,
-                   "Toggles game focus.\n"
-                   " \n"
-                   "When a game has focus, RetroArch will both disable \n"
-                   "hotkeys and keep/wrap the mouse pointer inside the window.");
-             break;
-          case RARCH_MENU_TOGGLE:
-             snprintf(s, len, "Toggles menu.");
-             break;
-          case RARCH_LOAD_STATE_KEY:
-             snprintf(s, len,
-                   "Loads state.");
-             break;
-          case RARCH_FULLSCREEN_TOGGLE_KEY:
-             snprintf(s, len,
-                   "Toggles fullscreen.");
-             break;
-          case RARCH_CLOSE_CONTENT_KEY:
-             snprintf(s, len,
-                   "Closes content.");
-             break;
           case RARCH_QUIT_KEY:
              snprintf(s, len,
                    "Key to exit RetroArch cleanly. \n"
@@ -217,24 +70,6 @@ int msg_hash_get_help_uk_enum(enum msg_hash_enums msg, char *s, size_t len)
                    "When slot is not 0, path will be <path><d>, \n"
                    "where <d> is slot number.");
              break;
-          case RARCH_SAVE_STATE_KEY:
-             snprintf(s, len,
-                   "Saves state.");
-             break;
-          case RARCH_REWIND:
-             snprintf(s, len,
-                   "Hold button down to rewind. \n"
-                   " \n"
-                   "Rewinding must be enabled.");
-             break;
-          case RARCH_BSV_RECORD_TOGGLE:
-             snprintf(s, len,
-                   "Toggle between recording and not.");
-             break;
-          case RARCH_RUNAHEAD_TOGGLE:
-             snprintf(s, len,
-                   "Toggles Run-Ahead mode on/off.");
-             break;
           default:
              if (string_is_empty(s))
                 strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE), len);
@@ -257,12 +92,6 @@ int msg_hash_get_help_uk_enum(enum msg_hash_enums msg, char *s, size_t len)
                     "to input the username and password into \n"
                     "RetroArch.");
             break;
-        case MENU_ENUM_LABEL_CHEEVOS_USERNAME:
-            snprintf(s, len, "Username for your Retro Achievements account.");
-            break;
-        case MENU_ENUM_LABEL_CHEEVOS_PASSWORD:
-            snprintf(s, len, "Password for your Retro Achievements account.");
-            break;
         case MENU_ENUM_LABEL_USER_LANGUAGE:
             snprintf(s, len, "Localizes the menu and all onscreen messages \n"
                     "according to the language you have selected \n"
@@ -276,74 +105,6 @@ int msg_hash_get_help_uk_enum(enum msg_hash_enums msg, char *s, size_t len)
                     " \n"
                     "In case a language is not implemented, \n"
                     "we fallback to English.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FONT_PATH:
-            snprintf(s, len, "Change the font that is used \n"
-                    "for the Onscreen Display text.");
-            break;
-        case MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS:
-            snprintf(s, len, "Automatically load content-specific core options.");
-            break;
-        case MENU_ENUM_LABEL_AUTO_OVERRIDES_ENABLE:
-            snprintf(s, len, "Automatically load override configurations.");
-            break;
-        case MENU_ENUM_LABEL_AUTO_REMAPS_ENABLE:
-            snprintf(s, len, "Automatically load input remapping files.");
-            break;
-        case MENU_ENUM_LABEL_SORT_SAVESTATES_ENABLE:
-            snprintf(s, len, "Sort save states in folders \n"
-                    "named after the libretro core used.");
-            break;
-        case MENU_ENUM_LABEL_SORT_SAVEFILES_ENABLE:
-            snprintf(s, len, "Sort save files in folders \n"
-                    "named after the libretro core used.");
-            break;
-        case MENU_ENUM_LABEL_SORT_SAVESTATES_BY_CONTENT_ENABLE:
-            snprintf(s, len, "Sort save states in folders named \n"
-                   "after the folder in which the content lives.");
-            break;
-        case MENU_ENUM_LABEL_SORT_SAVEFILES_BY_CONTENT_ENABLE:
-            snprintf(s, len, "Sort save files in folders named \n"
-                  "after the folder in which the content lives.");
-            break;
-        case MENU_ENUM_LABEL_SORT_SCREENSHOTS_BY_CONTENT_ENABLE:
-            snprintf(s, len, "Sort screenshots in folders named \n"
-                  "after the folder in which the content lives.");
-            break;
-        case MENU_ENUM_LABEL_RESUME_CONTENT:
-            snprintf(s, len, "Exits from the menu and returns back \n"
-                    "to the content.");
-            break;
-        case MENU_ENUM_LABEL_RESTART_CONTENT:
-            snprintf(s, len, "Restarts the content from the beginning.");
-            break;
-        case MENU_ENUM_LABEL_CLOSE_CONTENT:
-            snprintf(s, len, "Closes the content and unloads it from \n"
-                    "memory.");
-            break;
-        case MENU_ENUM_LABEL_UNDO_LOAD_STATE:
-            snprintf(s, len, "If a state was loaded, content will \n"
-                    "go back to the state prior to loading.");
-            break;
-        case MENU_ENUM_LABEL_UNDO_SAVE_STATE:
-            snprintf(s, len, "If a state was overwritten, it will \n"
-                    "roll back to the previous save state.");
-            break;
-        case MENU_ENUM_LABEL_TAKE_SCREENSHOT:
-            snprintf(s, len, "Create a screenshot. \n"
-                    " \n"
-                    "The screenshot will be stored inside the \n"
-                    "Screenshot Directory.");
-            break;
-        case MENU_ENUM_LABEL_ADD_TO_FAVORITES:
-            snprintf(s, len, "Add the entry to your Favorites.");
-            break;
-        case MENU_ENUM_LABEL_RUN:
-            snprintf(s, len, "Start the content.");
-            break;
-        case MENU_ENUM_LABEL_INFORMATION:
-            snprintf(s, len, "Show additional metadata information \n"
-                    "about the content.");
             break;
         case MENU_ENUM_LABEL_FILE_BROWSER_CONFIG:
             snprintf(s, len, "Configuration file.");
@@ -368,68 +129,6 @@ int msg_hash_get_help_uk_enum(enum msg_hash_enums msg, char *s, size_t len)
         case MENU_ENUM_LABEL_USE_THIS_DIRECTORY:
             snprintf(s, len,
                      "Select this to set this as the directory.");
-            break;
-        case MENU_ENUM_LABEL_CONTENT_DATABASE_DIRECTORY:
-            snprintf(s, len,
-                     "Content Database Directory. \n"
-                             " \n"
-                             "Path to content database \n"
-                             "directory.");
-            break;
-        case MENU_ENUM_LABEL_THUMBNAILS_DIRECTORY:
-            snprintf(s, len,
-                     "Thumbnails Directory. \n"
-                             " \n"
-                             "To store thumbnail files.");
-            break;
-        case MENU_ENUM_LABEL_LIBRETRO_INFO_PATH:
-            snprintf(s, len,
-                     "Core Info Directory. \n"
-                             " \n"
-                             "A directory for where to search \n"
-                             "for libretro core information.");
-            break;
-        case MENU_ENUM_LABEL_PLAYLIST_DIRECTORY:
-            snprintf(s, len,
-                     "Playlist Directory. \n"
-                             " \n"
-                             "Save all playlist files to this \n"
-                             "directory.");
-            break;
-        case MENU_ENUM_LABEL_CONTENT_FAVORITES_DIRECTORY:
-            snprintf(s, len,
-                     "Favorites Playlist Directory. \n"
-                             " \n"
-                             "Save the favorites playlist to this \n"
-                             "directory.");
-            break;
-        case MENU_ENUM_LABEL_CONTENT_HISTORY_DIRECTORY:
-            snprintf(s, len,
-                     "History Playlist Directory. \n"
-                             " \n"
-                             "Save the history playlist to this \n"
-                             "directory.");
-            break;
-        case MENU_ENUM_LABEL_CONTENT_IMAGE_HISTORY_DIRECTORY:
-            snprintf(s, len,
-                     "Images Playlist Directory. \n"
-                             " \n"
-                             "Save the images playlist to this \n"
-                             "directory.");
-            break;
-        case MENU_ENUM_LABEL_CONTENT_MUSIC_HISTORY_DIRECTORY:
-            snprintf(s, len,
-                     "Music Playlist Directory. \n"
-                             " \n"
-                             "Save the music playlist to this \n"
-                             "directory.");
-            break;
-        case MENU_ENUM_LABEL_CONTENT_VIDEO_HISTORY_DIRECTORY:
-            snprintf(s, len,
-                     "Videos Playlist Directory. \n"
-                             " \n"
-                             "Save the videos playlist to this \n"
-                             "directory.");
             break;
         case MENU_ENUM_LABEL_DUMMY_ON_CORE_SHUTDOWN:
             snprintf(s, len,
@@ -464,11 +163,6 @@ int msg_hash_get_help_uk_enum(enum msg_hash_enums msg, char *s, size_t len)
                      "Open Windows permission settings to enable \n"
                      "the broadFileSystemAccess capability.");
             break;
-        case MENU_ENUM_LABEL_FILE_BROWSER_OPEN_PICKER:
-           snprintf(s, len,
-                     "Open the system file picker to access \n"
-                     "additional directories.");
-           break;
         case MENU_ENUM_LABEL_FILE_BROWSER_SHADER_PRESET:
             snprintf(s, len,
                      "Shader preset file.");
@@ -552,18 +246,6 @@ int msg_hash_get_help_uk_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Content decompressed by RetroArch will be \n"
                              "temporarily extracted to this directory.");
             break;
-        case MENU_ENUM_LABEL_HISTORY_LIST_ENABLE:
-            snprintf(s, len,
-                     "If enabled, every content loaded \n"
-                             "in RetroArch will be automatically \n"
-                             "added to the recent history list.");
-            break;
-        case MENU_ENUM_LABEL_RGUI_BROWSER_DIRECTORY:
-            snprintf(s, len,
-                     "File Browser Directory. \n"
-                             " \n"
-                             "Sets start directory for menu file browser.");
-            break;
         case MENU_ENUM_LABEL_INPUT_POLL_TYPE_BEHAVIOR:
             snprintf(s, len,
                      "Influence how input polling is done inside \n"
@@ -581,150 +263,11 @@ int msg_hash_get_help_uk_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "depending on your configuration.\n\n"
                              "Will be ignored when using netplay.");
             break;
-        case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_HIDE_UNBOUND:
-            snprintf(s, len,
-                     "Hide input descriptors that were not set \n"
-                             "by the core.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE:
-            snprintf(s, len,
-                     "Video refresh rate of your monitor. \n"
-                             "Used to calculate a suitable audio input rate.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FORCE_SRGB_DISABLE:
-            snprintf(s, len,
-                     "Forcibly disable sRGB FBO support. Some Intel \n"
-                             "OpenGL drivers on Windows have video problems \n"
-                             "with sRGB FBO support enabled.");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_ENABLE:
-            snprintf(s, len,
-                     "Enable audio output.");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_SYNC:
-            snprintf(s, len,
-                     "Synchronize audio (recommended).");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_LATENCY:
-            snprintf(s, len,
-                     "Desired audio latency in milliseconds. \n"
-                             "Might not be honored if the audio driver \n"
-                             "can't provide given latency.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_ALLOW_ROTATE:
-            snprintf(s, len,
-                     "Allow cores to set rotation. If false, \n"
-                             "rotation requests are honored, but ignored.\n\n"
-                             "Used for setups where one manually rotates \n"
-                             "the monitor.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_LABEL_SHOW:
-            snprintf(s, len,
-                     "Show the input descriptors set by the core \n"
-                             "instead of the default ones.");
-            break;
-        case MENU_ENUM_LABEL_CONTENT_HISTORY_SIZE:
-            snprintf(s, len,
-                     "Number of entries that will be kept in \n"
-                             "content history playlist.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_WINDOWED_FULLSCREEN:
-            snprintf(s, len,
-                     "To use windowed mode or not when going \n"
-                             "fullscreen.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FONT_SIZE:
-            snprintf(s, len,
-                     "Font size for on-screen messages.");
-            break;
-        case MENU_ENUM_LABEL_SAVESTATE_AUTO_INDEX:
-            snprintf(s, len,
-                     "Automatically increment slot index on each save, \n"
-                             "generating multiple savestate files. \n"
-                             "When the content is loaded, state slot will be \n"
-                             "set to the highest existing value (last savestate).");
-            break;
-        case MENU_ENUM_LABEL_FPS_SHOW:
-            snprintf(s, len,
-                     "Enables displaying the current frames \n"
-                             "per second.");
-            break;
-        case MENU_ENUM_LABEL_MEMORY_SHOW:
-            snprintf(s, len,
-                     "Includes displaying the current memory \n"
-                             "usage/total with FPS/Frames.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FONT_ENABLE:
-            snprintf(s, len,
-                     "Show and/or hide onscreen messages.");
-            break;
         case MENU_ENUM_LABEL_VIDEO_MESSAGE_POS_X:
         case MENU_ENUM_LABEL_VIDEO_MESSAGE_POS_Y:
             snprintf(s, len,
                      "Offset for where messages will be placed \n"
                              "onscreen. Values are in range [0.0, 1.0].");
-            break;
-        case MENU_ENUM_LABEL_INPUT_OVERLAY_ENABLE:
-            snprintf(s, len,
-                     "Enable or disable the current overlay.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_OVERLAY_HIDE_IN_MENU:
-            snprintf(s, len,
-                     "Hide the current overlay from appearing \n"
-                             "inside the menu.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_OVERLAY_SHOW_PHYSICAL_INPUTS:
-            snprintf(s, len,
-                      "Show keyboard/controller button presses on \n"
-                            "the onscreen overlay.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_OVERLAY_SHOW_PHYSICAL_INPUTS_PORT:
-            snprintf(s, len,
-                      "Select the port to listen for controller input \n"
-                            "to display on the onscreen overlay.");
-            break;
-        case MENU_ENUM_LABEL_OVERLAY_PRESET:
-            snprintf(s, len,
-                     "Path to input overlay.");
-            break;
-        case MENU_ENUM_LABEL_OVERLAY_OPACITY:
-            snprintf(s, len,
-                     "Overlay opacity.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_LAYOUT_ENABLE:
-            snprintf(s, len,
-                     "Enable or disable the current video layout.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_LAYOUT_PATH:
-            snprintf(s, len,
-                     "Path to video layout.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_LAYOUT_SELECTED_VIEW:
-            snprintf(s, len,
-                     "Layouts can contain multiple views. \n"
-                     "Select a view.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_BIND_TIMEOUT:
-            snprintf(s, len,
-                     "Input bind timer timeout (in seconds). \n"
-                             "Amount of seconds to wait until proceeding \n"
-                             "to the next bind.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_BIND_HOLD:
-            snprintf(s, len,
-               "Input bind hold time (in seconds). \n"
-               "Amount of seconds to hold an input to bind it.");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_OUTPUT_RATE:
-            snprintf(s, len,
-                     "Audio output samplerate.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SHARED_CONTEXT:
-            snprintf(s, len,
-                     "Set to true if hardware-rendered cores \n"
-                             "should get their private context. \n"
-                             "Avoids having to assume hardware state changes \n"
-                             "inbetween frames.");
             break;
         case MENU_ENUM_LABEL_CORE_LIST:
             snprintf(s, len,
@@ -965,12 +508,6 @@ int msg_hash_get_help_uk_enum(enum msg_hash_enums msg, char *s, size_t len)
                }
             }
             break;
-        case MENU_ENUM_LABEL_AUDIO_DSP_PLUGIN:
-            snprintf(s, len,
-                     "Audio DSP plugin.\n"
-                             " Processes audio before it's sent to \n"
-                             "the driver.");
-            break;
         case MENU_ENUM_LABEL_AUDIO_RESAMPLER_DRIVER:
             {
                const char *lbl = settings ? settings->arrays.audio_resampler : NULL;
@@ -987,12 +524,6 @@ int msg_hash_get_help_uk_enum(enum msg_hash_enums msg, char *s, size_t len)
                   strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NO_INFORMATION_AVAILABLE), len);
             }
             break;
-
-		case MENU_ENUM_LABEL_CRT_SWITCH_RESOLUTION: snprintf(s, len, "SET CRT");
-			break;
-
-		case MENU_ENUM_LABEL_CRT_SWITCH_RESOLUTION_SUPER: snprintf(s, len, "SET CRT SUPER");
-			break;
 
         case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET:
             snprintf(s, len,
@@ -1039,19 +570,6 @@ int msg_hash_get_help_uk_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "The Default Filter option will affect the \n"
                              "stretching filter.");
             break;
-        case MENU_ENUM_LABEL_VIDEO_SHADER_PARAMETERS:
-            snprintf(s, len,
-                     "Shader Parameters. \n"
-                             " \n"
-                             "Modifies current shader directly. Will not be \n"
-                             "saved to CGP/GLSLP preset file.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_PARAMETERS:
-            snprintf(s, len,
-                     "Shader Preset Parameters. \n"
-                             " \n"
-                             "Modifies shader preset currently in menu.");
-            break;
         case MENU_ENUM_LABEL_VIDEO_SHADER_PASS:
             snprintf(s, len,
                      "Path to shader. \n"
@@ -1089,13 +607,6 @@ int msg_hash_get_help_uk_enum(enum msg_hash_enums msg, char *s, size_t len)
             "manually isn't really an option."
 #endif
             );
-            break;
-        case MENU_ENUM_LABEL_CONFIRM_ON_EXIT:
-            snprintf(s, len, "Are you sure you want to quit?");
-            break;
-        case MENU_ENUM_LABEL_SHOW_HIDDEN_FILES:
-            snprintf(s, len, "Show hidden files\n"
-                    "and folders.");
             break;
         case MENU_ENUM_LABEL_VIDEO_SHADER_FILTER_PASS:
             snprintf(s, len,
@@ -1174,26 +685,6 @@ int msg_hash_get_help_uk_enum(enum msg_hash_enums msg, char *s, size_t len)
                      "it will automatically be recompiled \n"
                      "and applied to the running content.");
             break;
-        case MENU_ENUM_LABEL_MENU_TOGGLE:
-            snprintf(s, len,
-                     "Toggles menu.");
-            break;
-        case MENU_ENUM_LABEL_GRAB_MOUSE_TOGGLE:
-            snprintf(s, len,
-                     "Toggles mouse grab.\n"
-                             " \n"
-                             "When mouse is grabbed, RetroArch hides the \n"
-                             "mouse, and keeps the mouse pointer inside \n"
-                             "the window to allow relative mouse input to \n"
-                             "work better.");
-            break;
-        case MENU_ENUM_LABEL_GAME_FOCUS_TOGGLE:
-            snprintf(s, len,
-                     "Toggles game focus.\n"
-                             " \n"
-                             "When a game has focus, RetroArch will both disable \n"
-                             "hotkeys and keep/wrap the mouse pointer inside the window.");
-            break;
         case MENU_ENUM_LABEL_DISK_NEXT:
             snprintf(s, len,
                      "Cycles through disk images. Use after \n"
@@ -1237,12 +728,6 @@ int msg_hash_get_help_uk_enum(enum msg_hash_enums msg, char *s, size_t len)
 #endif
             );
             break;
-        case MENU_ENUM_LABEL_DISK_EJECT_TOGGLE:
-            snprintf(s, len,
-                     "Toggles eject for disks.\n"
-                             " \n"
-                             "Used for multiple-disk content.");
-            break;
         case MENU_ENUM_LABEL_ENABLE_HOTKEY:
             snprintf(s, len,
                      "Enable other hotkeys.\n"
@@ -1256,28 +741,6 @@ int msg_hash_get_help_uk_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "implementations which query a large area of \n"
                              "the keyboard, where it is not desirable that \n"
                              "hotkeys get in the way.");
-            break;
-        case MENU_ENUM_LABEL_REWIND_ENABLE:
-            snprintf(s, len,
-                     "Enable rewinding.\n"
-                             " \n"
-                             "This will take a performance hit, \n"
-                             "so it is disabled by default.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_APPLY_AFTER_TOGGLE:
-            snprintf(s, len,
-                     "Apply cheat immediately after toggling.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_APPLY_AFTER_LOAD:
-            snprintf(s, len,
-                     "Auto-apply cheats when game loads.");
-            break;
-        case MENU_ENUM_LABEL_LIBRETRO_DIR_PATH:
-            snprintf(s, len,
-                     "Core Directory. \n"
-                             " \n"
-                             "A directory for where to search for \n"
-                             "libretro core implementations.");
             break;
         case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE_AUTO:
             snprintf(s, len,
@@ -1298,59 +761,6 @@ int msg_hash_get_help_uk_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "large pitch changes. If your monitor does \n"
                              "not run at 60Hz, or something close to it, \n"
                              "disable VSync, and leave this at its default.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE_POLLED:
-            snprintf(s, len,
-                     "Set Polled Refresh Rate\n"
-                             " \n"
-                            "Sets the refresh rate to the actual value\n"
-                            "polled from the display driver.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_ROTATION:
-            snprintf(s, len,
-                     "Forces a certain rotation \n"
-                             "of the screen.\n"
-                             " \n"
-                             "The rotation is added to rotations which\n"
-                             "the libretro core sets (see Video Allow\n"
-                             "Rotate).");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SCALE:
-            snprintf(s, len,
-                     "Fullscreen resolution.\n"
-                             " \n"
-                             "Resolution of 0 uses the \n"
-                             "resolution of the environment.\n");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_HDR_ENABLE:
-            snprintf(s, len,
-                     "Enable HDR.\n"
-                             " \n"
-                             "If supported this enables hdr \n");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_HDR_MAX_NITS:
-            snprintf(s, len,
-                     "Peak Luminance\n"
-                             " \n"
-                             "Set the peak luminance (in cd/m2) your display can reproduce - see RTings for your models peak luminance\n");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_HDR_PAPER_WHITE_NITS:
-            snprintf(s, len,
-                     "Paper White Luminance\n"
-                             " \n"
-                             "Set the luminance at which paper white should be ie readable text or luminance at the top of the SDR range\n");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_HDR_CONTRAST:
-            snprintf(s, len,
-                     "Contrast\n"
-                             " \n"
-                             "The constrast setting for HDR\n");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_HDR_EXPAND_GAMUT:
-            snprintf(s, len,
-                     "Expand Gamut\n"
-                             " \n"
-                             "Once converted to linear space should we use an expanded colour gamut to get to HDR10\n");
             break;
         case MENU_ENUM_LABEL_FASTFORWARD_RATIO:
             snprintf(s, len,
@@ -1384,30 +794,6 @@ int msg_hash_get_help_uk_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "is preferred, 1 and up (1 being first \n"
                              "monitor), suggests RetroArch to use that \n"
                              "particular monitor.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_CROP_OVERSCAN:
-            snprintf(s, len,
-                     "Forces cropping of overscanned \n"
-                             "frames.\n"
-                             " \n"
-                             "Exact behavior of this option is \n"
-                             "core-implementation specific.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SCALE_INTEGER:
-            snprintf(s, len,
-                     "Only scales video in integer \n"
-                             "steps.\n"
-                             " \n"
-                             "The base size depends on system-reported \n"
-                             "geometry and aspect ratio.\n"
-                             " \n"
-                             "If 'Force Aspect Ratio' is not set, X/Y will be \n"
-                             "integer scaled independently.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SCALE_INTEGER_OVERSCALE:
-            snprintf(s, len,
-                     "Force integer scaling to round up \n"
-                             " to the next larger integer instead of rounding down.");
             break;
         case MENU_ENUM_LABEL_AUDIO_VOLUME:
             snprintf(s, len,
@@ -1444,53 +830,10 @@ int msg_hash_get_help_uk_enum(enum msg_hash_enums msg, char *s, size_t len)
                              " Input rate is defined as: \n"
                              " input rate * (1.0 +/- (max timing skew))");
             break;
-        case MENU_ENUM_LABEL_OVERLAY_NEXT:
-            snprintf(s, len,
-                     "Toggles to next overlay.\n"
-                             " \n"
-                             "Wraps around.");
-            break;
-        case MENU_ENUM_LABEL_LOG_VERBOSITY:
-            snprintf(s, len,
-                     "Enable or disable verbosity level \n"
-                             "of frontend.");
-            break;
-        case MENU_ENUM_LABEL_VOLUME_UP:
-            snprintf(s, len,
-                     "Increases audio volume.");
-            break;
-        case MENU_ENUM_LABEL_VOLUME_DOWN:
-            snprintf(s, len,
-                     "Decreases audio volume.");
-            break;
         case MENU_ENUM_LABEL_VIDEO_DISABLE_COMPOSITION:
             snprintf(s, len,
                      "Forcibly disable composition.\n"
                              "Only valid on Windows Vista/7 for now.");
-            break;
-        case MENU_ENUM_LABEL_PERFCNT_ENABLE:
-            snprintf(s, len,
-                     "Enable or disable frontend \n"
-                             "performance counters.");
-            break;
-        case MENU_ENUM_LABEL_SYSTEM_DIRECTORY:
-            snprintf(s, len,
-                     "System Directory. \n"
-                             " \n"
-                             "Sets the 'system' directory.\n"
-                             "Cores can query for this\n"
-                             "directory to load BIOSes, \n"
-                             "system-specific configs, etc.");
-            break;
-        case MENU_ENUM_LABEL_SAVESTATE_AUTO_SAVE:
-        case MENU_ENUM_LABEL_SAVESTATE_AUTO_LOAD:
-            snprintf(s, len,
-                     "Automatically saves a savestate at the \n"
-                             "end of RetroArch's lifetime.\n"
-                             " \n"
-                             "RetroArch will automatically load any savestate\n"
-                             "with this path on startup if 'Auto Load State\n"
-                             "is enabled.");
             break;
         case MENU_ENUM_LABEL_VIDEO_THREADED:
             snprintf(s, len,
@@ -1499,47 +842,6 @@ int msg_hash_get_help_uk_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Using this might improve performance at the \n"
                              "possible cost of latency and more video \n"
                              "stuttering.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_VSYNC:
-            snprintf(s, len,
-                     "Video V-Sync.\n");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_HARD_SYNC:
-            snprintf(s, len,
-                     "Attempts to hard-synchronize \n"
-                             "CPU and GPU.\n"
-                             " \n"
-                             "Can reduce latency at the cost of \n"
-                             "performance.");
-            break;
-        case MENU_ENUM_LABEL_REWIND_GRANULARITY:
-            snprintf(s, len,
-                     "Rewind granularity.\n"
-                             " \n"
-                             " When rewinding defined number of \n"
-                             "frames, you can rewind several frames \n"
-                             "at a time, increasing the rewinding \n"
-                             "speed.");
-            break;
-        case MENU_ENUM_LABEL_REWIND_BUFFER_SIZE:
-            snprintf(s, len,
-                     "Rewind buffer size (MB).\n"
-                             " \n"
-                             " The amount of memory in MB to reserve \n"
-                             "for rewinding.  Increasing this value \n"
-                             "increases the rewind history length.\n");
-            break;
-        case MENU_ENUM_LABEL_REWIND_BUFFER_SIZE_STEP:
-            snprintf(s, len,
-                     "Rewind buffer size step (MB).\n"
-                             " \n"
-                             " Each time you increase or decrease \n"
-                             "the rewind buffer size value via this \n"
-                             "UI it will change by this amount.\n");
-            break;
-        case MENU_ENUM_LABEL_SCREENSHOT:
-            snprintf(s, len,
-                     "Take screenshot.");
             break;
         case MENU_ENUM_LABEL_VIDEO_FRAME_DELAY:
             snprintf(s, len,
@@ -1560,14 +862,6 @@ int msg_hash_get_help_uk_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "'Frame Delay' is 0.\n"
                              " \n"
                              "E.g. 8 for NTSC and 10 for PAL.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SHADER_DELAY:
-            snprintf(s, len,
-                     "Sets by how many milliseconds auto-loading shaders\n"
-                             "are delayed.\n"
-                             "\n"
-                             "Can work around graphical glitches due to using\n"
-                             "'screen grabbing' software like streaming software.");
             break;
         case MENU_ENUM_LABEL_VIDEO_HARD_SYNC_FRAMES:
             snprintf(s, len,
@@ -1594,48 +888,6 @@ int msg_hash_get_help_uk_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "configured as if it is a 60 Hz monitor \n"
                              "(divide refresh rate by 2).");
             break;
-        case MENU_ENUM_LABEL_RGUI_SHOW_START_SCREEN:
-            snprintf(s, len,
-                     "Show startup screen in menu.\n"
-                             "Is automatically set to false when seen\n"
-                             "for the first time.\n"
-                             " \n"
-                             "This is only updated in config if\n"
-                             "'Save Configuration on Exit' is enabled.\n");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_FULLSCREEN:
-            snprintf(s, len, "Toggles fullscreen.");
-            break;
-        case MENU_ENUM_LABEL_BLOCK_SRAM_OVERWRITE:
-            snprintf(s, len,
-                     "Block SRAM from being overwritten \n"
-                             "when loading save states.\n"
-                             " \n"
-                             "Might potentially lead to buggy games.");
-            break;
-        case MENU_ENUM_LABEL_PAUSE_NONACTIVE:
-            snprintf(s, len,
-                     "Pause gameplay when window focus \n"
-                             "is lost.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_GPU_SCREENSHOT:
-            snprintf(s, len,
-                     "Screenshots output of GPU shaded \n"
-                             "material if available.");
-            break;
-        case MENU_ENUM_LABEL_SCREENSHOT_DIRECTORY:
-            snprintf(s, len,
-                     "Screenshot Directory. \n"
-                             " \n"
-                             "Directory to dump screenshots to.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_SWAP_INTERVAL:
-            snprintf(s, len,
-                     "VSync Swap Interval.\n"
-                             " \n"
-                             "Uses a custom swap interval for VSync. Set this \n"
-                             "to effectively halve monitor refresh rate.");
-            break;
         case MENU_ENUM_LABEL_SAVEFILE_DIRECTORY:
             snprintf(s, len,
                      "Savefile Directory. \n"
@@ -1643,16 +895,6 @@ int msg_hash_get_help_uk_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Save all save files (*.srm) to this \n"
                              "directory. This includes related files like \n"
                              ".bsv, .rt, .psrm, etc...\n"
-                             " \n"
-                             "This will be overridden by explicit command line\n"
-                             "options.");
-            break;
-        case MENU_ENUM_LABEL_SAVESTATE_DIRECTORY:
-            snprintf(s, len,
-                     "Savestate Directory. \n"
-                             " \n"
-                             "Save all save states (*.state) to this \n"
-                             "directory.\n"
                              " \n"
                              "This will be overridden by explicit command line\n"
                              "options.");
@@ -1673,77 +915,8 @@ int msg_hash_get_help_uk_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "be loaded dynamically by the menu depending \n"
                              "on context.");
             break;
-        case MENU_ENUM_LABEL_SLOWMOTION_RATIO:
-            snprintf(s, len,
-                     "Slowmotion ratio."
-                             " \n"
-                             "When slowmotion, content will slow\n"
-                             "down by factor.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_BUTTON_AXIS_THRESHOLD:
-            snprintf(s, len,
-                     "Defines the axis threshold.\n"
-                             " \n"
-                             "How far an axis must be tilted to result\n"
-                             "in a button press.\n"
-                             " Possible values are [0.0, 1.0].");
-            break;
-        case MENU_ENUM_LABEL_INPUT_TURBO_PERIOD:
-            snprintf(s, len,
-                     "Turbo period.\n"
-                             " \n"
-                             "Describes the period of which turbo-enabled\n"
-                             "buttons toggle.\n"
-                             " \n"
-                             "Numbers are described in frames.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_TURBO_MODE:
-            snprintf(s, len,
-                  "Turbo Mode.\n"
-                  " \n"
-                  "Selects the general behavior of turbo mode.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_TURBO_DEFAULT_BUTTON:
-            snprintf(s, len,
-                  "Turbo Default Button.\n"
-                  " \n"
-                  "Default active button for Turbo Mode 'Single Button'.\n");
-            break;
-        case MENU_ENUM_LABEL_INPUT_DUTY_CYCLE:
-            snprintf(s, len,
-                     "Duty cycle.\n"
-                             " \n"
-                             "Describes how long the period of a turbo-enabled\n"
-                             "should be.\n"
-                             " \n"
-                             "Numbers are described in frames.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_TOUCH_ENABLE:
-            snprintf(s, len, "Enable touch support.");
-            break;
         case MENU_ENUM_LABEL_INPUT_PREFER_FRONT_TOUCH:
             snprintf(s, len, "Use front instead of back touch.");
-            break;
-        case MENU_ENUM_LABEL_MOUSE_ENABLE:
-            snprintf(s, len, "Enable mouse input inside the menu.");
-            break;
-        case MENU_ENUM_LABEL_POINTER_ENABLE:
-            snprintf(s, len, "Enable touch input inside the menu.");
-            break;
-        case MENU_ENUM_LABEL_MENU_WALLPAPER:
-            snprintf(s, len, "Path to an image to set as the background.");
-            break;
-        case MENU_ENUM_LABEL_NAVIGATION_WRAPAROUND:
-            snprintf(s, len,
-                     "Wrap-around to beginning and/or end \n"
-                             "if boundary of list is reached \n"
-                             "horizontally and/or vertically.");
-            break;
-        case MENU_ENUM_LABEL_PAUSE_LIBRETRO:
-            snprintf(s, len,
-                     "If disabled, the game will keep \n"
-                             "running in the background when we are in the \n"
-                             "menu.");
             break;
         case MENU_ENUM_LABEL_SUSPEND_SCREENSAVER_ENABLE:
             snprintf(s, len,
@@ -1763,13 +936,6 @@ int msg_hash_get_help_uk_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "Increasing this value will increase \n"
                              "performance, but introduce more latency.");
             break;
-        case MENU_ENUM_LABEL_NETPLAY_PUBLIC_ANNOUNCE:
-            snprintf(s, len,
-                     "Whether to announce netplay games publicly. \n"
-                             " \n"
-                             "If set to false, clients must manually connect \n"
-                             "rather than using the public lobby.");
-            break;
         case MENU_ENUM_LABEL_NETPLAY_START_AS_SPECTATOR:
             snprintf(s, len,
                      "Whether to start netplay in spectator mode. \n"
@@ -1777,21 +943,6 @@ int msg_hash_get_help_uk_enum(enum msg_hash_enums msg, char *s, size_t len)
                              "If set to true, netplay will be in spectator mode \n"
                              "on start. It's always possible to change mode \n"
                              "later.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_ALLOW_SLAVES:
-            snprintf(s, len,
-                     "Whether to allow connections in slave mode. \n"
-                             " \n"
-                             "Slave-mode clients require very little processing \n"
-                             "power on either side, but will suffer \n"
-                             "significantly from network latency.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_REQUIRE_SLAVES:
-            snprintf(s, len,
-                     "Whether to disallow connections not in slave mode. \n"
-                             " \n"
-                             "Not recommended except for very fast networks \n"
-                             "with very weak machines.");
             break;
         case MENU_ENUM_LABEL_NETPLAY_CHECK_FRAMES:
             snprintf(s, len,
@@ -1834,24 +985,6 @@ int msg_hash_get_help_uk_enum(enum msg_hash_enums msg, char *s, size_t len)
                      "makes netplay less CPU-intensive, but at \n"
                      "the price of unpredictable input lag. \n");
             break;
-        case MENU_ENUM_LABEL_NETPLAY_NAT_TRAVERSAL:
-            snprintf(s, len,
-                     "When hosting, attempt to listen for\n"
-                             "connections from the public internet, using\n"
-                             "UPnP or similar technologies to escape LANs. \n");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_USE_MITM_SERVER:
-            snprintf(s, len,
-                     "When hosting a netplay session, relay connection through a \n"
-                             "man-in-the-middle server \n"
-                             "to get around firewalls or NAT/UPnP issues. \n");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_MITM_SERVER:
-            snprintf(s, len,
-                     "Specifies the man-in-the-middle server \n"
-                             "to use for netplay. A server that is \n"
-                             "located closer to you may have less latency. \n");
-            break;
         case MENU_ENUM_LABEL_VIDEO_MAX_SWAPCHAIN_IMAGES:
             snprintf(s, len,
                      "Maximum amount of swapchain images. This \n"
@@ -1879,202 +1012,19 @@ int msg_hash_get_help_uk_enum(enum msg_hash_enums msg, char *s, size_t len)
 #endif
          );
          break;
-        case MENU_ENUM_LABEL_TIMEDATE_ENABLE:
-            snprintf(s, len,
-                     "Shows current date and/or time inside menu.");
-            break;
-        case MENU_ENUM_LABEL_TIMEDATE_STYLE:
-           snprintf(s, len,
-              "Style to show the current date and/or time in.");
-           break;
-        case MENU_ENUM_LABEL_BATTERY_LEVEL_ENABLE:
-            snprintf(s, len,
-                     "Shows current battery level inside menu.");
-            break;
-        case MENU_ENUM_LABEL_CORE_ENABLE:
-            snprintf(s, len,
-                     "Shows current core inside menu.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_ENABLE_HOST:
-            snprintf(s, len,
-                     "Enables Netplay in host (server) mode.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_ENABLE_CLIENT:
-            snprintf(s, len,
-                     "Enables Netplay in client mode.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_DISCONNECT:
-            snprintf(s, len,
-                     "Disconnects an active Netplay connection.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_LAN_SCAN_SETTINGS:
-            snprintf(s, len,
-                     "Search for and connect to netplay hosts on the local network.");
-            break;
         case MENU_ENUM_LABEL_NETPLAY_SETTINGS:
             snprintf(s, len,
                      "Setting related to Netplay.");
-            break;
-        case MENU_ENUM_LABEL_DYNAMIC_WALLPAPER:
-            snprintf(s, len,
-                     "Dynamically load a new background \n"
-                             "depending on context.");
-            break;
-        case MENU_ENUM_LABEL_CORE_UPDATER_BUILDBOT_URL:
-            snprintf(s, len,
-                     "URL to core updater directory on the \n"
-                             "Libretro buildbot.");
-            break;
-        case MENU_ENUM_LABEL_BUILDBOT_ASSETS_URL:
-            snprintf(s, len,
-                     "URL to assets updater directory on the \n"
-                             "Libretro buildbot.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_REMAP_BINDS_ENABLE:
-            snprintf(s, len,
-                     "if enabled, overrides the input binds \n"
-                             "with the remapped binds set for the \n"
-                             "current core.");
-            break;
-        case MENU_ENUM_LABEL_OVERLAY_DIRECTORY:
-            snprintf(s, len,
-                     "Overlay Directory. \n"
-                             " \n"
-                             "Defines a directory where overlays are \n"
-                             "kept for easy access.");
-            break;
-        case MENU_ENUM_LABEL_VIDEO_LAYOUT_DIRECTORY:
-            snprintf(s, len,
-                     "Video Layout Directory. \n"
-                             " \n"
-                             "Defines a directory where video layouts are \n"
-                             "kept for easy access.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_MAX_USERS:
-            snprintf(s, len,
-                     "Maximum amount of users supported by \n"
-                             "RetroArch.");
-            break;
-        case MENU_ENUM_LABEL_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
-            snprintf(s, len,
-                     "After downloading, automatically extract \n"
-                             "archives that the downloads are contained \n"
-                             "inside.");
-            break;
-        case MENU_ENUM_LABEL_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
-            snprintf(s, len,
-                     "Filter files being shown by \n"
-                             "supported extensions.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_NICKNAME:
-            snprintf(s, len,
-                     "The username of the person running RetroArch. \n"
-                             "This will be used for playing online games.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_TCP_UDP_PORT:
-            snprintf(s, len,
-                     "The port of the host IP address. \n"
-                             "Can be either a TCP or UDP port.");
             break;
         case MENU_ENUM_LABEL_NETPLAY_SPECTATOR_MODE_ENABLE:
             snprintf(s, len,
                      "Enable or disable spectator mode for \n"
                              "the user during netplay.");
             break;
-        case MENU_ENUM_LABEL_NETPLAY_IP_ADDRESS:
-            snprintf(s, len,
-                     "The address of the host to connect to.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_PASSWORD:
-            snprintf(s, len,
-                     "The password for connecting to the netplay \n"
-                             "host. Used only in host mode.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_SPECTATE_PASSWORD:
-            snprintf(s, len,
-                     "The password for connecting to the netplay \n"
-                             "host with only spectator privileges. Used \n"
-                             "only in host mode.");
-            break;
-        case MENU_ENUM_LABEL_STDIN_CMD_ENABLE:
-            snprintf(s, len,
-                     "Enable stdin command interface.");
-            break;
         case MENU_ENUM_LABEL_UI_COMPANION_START_ON_BOOT:
             snprintf(s, len,
                      "Start User Interface companion driver \n"
                              "on boot (if available).");
-            break;
-        case MENU_ENUM_LABEL_MENU_DRIVER:
-            snprintf(s, len, "Menu driver to use.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
-            snprintf(s, len,
-                     "Gamepad button combination to toggle menu. \n"
-                             " \n"
-                             "0 - None \n"
-                             "1 - Press L + R + Y + D-Pad Down \n"
-                             "simultaneously. \n"
-                             "2 - Press L3 + R3 simultaneously. \n"
-                             "3 - Press Start + Select simultaneously.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_QUIT_GAMEPAD_COMBO:
-            snprintf(s, len,
-                     "Gamepad button combination to quit. \n"
-                             " \n"
-                             "0 - None \n"
-                             "1 - Press L + R + Y + D-Pad Down \n"
-                             "simultaneously. \n"
-                             "2 - Press L3 + R3 simultaneously. \n"
-                             "3 - Press Start + Select simultaneously.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_ALL_USERS_CONTROL_MENU:
-            snprintf(s, len, "Allows any user to control the menu. \n"
-                    " \n"
-                    "When disabled, only user 1 can control the menu.");
-            break;
-        case MENU_ENUM_LABEL_INPUT_AUTODETECT_ENABLE:
-            snprintf(s, len,
-                     "Enable input auto-detection.\n"
-                             " \n"
-                             "Will attempt to auto-configure \n"
-                             "joypads, Plug-and-Play style.");
-            break;
-        case MENU_ENUM_LABEL_CAMERA_ALLOW:
-            snprintf(s, len,
-                     "Allow or disallow camera access by \n"
-                             "cores.");
-            break;
-        case MENU_ENUM_LABEL_LOCATION_ALLOW:
-            snprintf(s, len,
-                     "Allow or disallow location services \n"
-                             "access by cores.");
-            break;
-        case MENU_ENUM_LABEL_TURBO:
-            snprintf(s, len,
-                     "Turbo enable.\n"
-                             " \n"
-                             "Holding the turbo while pressing another \n"
-                             "button will let the button enter a turbo \n"
-                             "mode where the button state is modulated \n"
-                             "with a periodic signal. \n"
-                             " \n"
-                             "The modulation stops when the button \n"
-                             "itself (not turbo button) is released.");
-            break;
-        case MENU_ENUM_LABEL_OSK_ENABLE:
-            snprintf(s, len,
-                     "Enable/disable on-screen keyboard.");
-            break;
-        case MENU_ENUM_LABEL_AUDIO_MUTE:
-            snprintf(s, len,
-                     "Mute/unmute audio.");
-            break;
-        case MENU_ENUM_LABEL_REWIND:
-            snprintf(s, len,
-                     "Hold button down to rewind.\n"
-                             " \n"
-                             "Rewind must be enabled.");
             break;
         case MENU_ENUM_LABEL_EXIT_EMULATOR:
             snprintf(s, len,
@@ -2088,176 +1038,9 @@ int msg_hash_get_help_uk_enum(enum msg_hash_enums msg, char *s, size_t len)
 #endif
             );
             break;
-        case MENU_ENUM_LABEL_LOAD_STATE:
-            snprintf(s, len,
-                     "Loads state.");
-            break;
-        case MENU_ENUM_LABEL_SAVE_STATE:
-            snprintf(s, len,
-                     "Saves state.");
-            break;
-        case MENU_ENUM_LABEL_NETPLAY_GAME_WATCH:
-            snprintf(s, len,
-                     "Netplay toggle play/spectate mode.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_INDEX_PLUS:
-            snprintf(s, len,
-                     "Increase cheat index.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_INDEX_MINUS:
-            snprintf(s, len,
-                     "Decrease cheat index.");
-            break;
-        case MENU_ENUM_LABEL_SHADER_PREV:
-            snprintf(s, len,
-                     "Applies previous shader in directory.");
-            break;
-        case MENU_ENUM_LABEL_SHADER_NEXT:
-            snprintf(s, len,
-                     "Applies next shader in directory.");
-            break;
-        case MENU_ENUM_LABEL_RESET:
-            snprintf(s, len,
-                     "Reset the content.");
-            break;
-        case MENU_ENUM_LABEL_PAUSE_TOGGLE:
-            snprintf(s, len,
-                     "Toggle between paused and non-paused state.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_TOGGLE:
-            snprintf(s, len,
-                     "Toggle cheat index.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_IDX:
-            snprintf(s, len,
-                     "Index position in list.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_ADDRESS_BIT_POSITION:
-            snprintf(s, len,
-                     "Address bitmask when Memory Search Size < 8-bit.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_REPEAT_COUNT:
-            snprintf(s, len,
-                     "The number of times the cheat will be applied.\nUse with the other two Iteration options to affect large areas of memory.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_REPEAT_ADD_TO_ADDRESS:
-            snprintf(s, len,
-                     "After each 'Number of Iterations' the Memory Address will be increased by this number times the 'Memory Search Size'.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_REPEAT_ADD_TO_VALUE:
-            snprintf(s, len,
-                     "After each 'Number of Iterations' the Value will be increased by this amount.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_MATCH_IDX:
-            snprintf(s, len,
-                     "Select the match to view.");
-            break;
         case MENU_ENUM_LABEL_CHEAT_START_OR_CONT:
             snprintf(s, len,
                      "Scan memory to create new cheats.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_START_OR_RESTART:
-            snprintf(s, len,
-                     "Left/Right to change bit-size.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_EXACT:
-            snprintf(s, len,
-                     "Left/Right to change value.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_LT:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_GT:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_EQ:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_NEQ:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_EQPLUS:
-            snprintf(s, len,
-                     "Left/Right to change value.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_SEARCH_EQMINUS:
-            snprintf(s, len,
-                     "Left/Right to change value.");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_ADD_MATCHES:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_VIEW_MATCHES:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_CREATE_OPTION:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_DELETE_OPTION:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_ADD_NEW_TOP:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_RELOAD_CHEATS:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_ADD_NEW_BOTTOM:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_DELETE_ALL:
-            snprintf(s, len,
-                     " ");
-            break;
-        case MENU_ENUM_LABEL_CHEAT_BIG_ENDIAN:
-            snprintf(s, len,
-                     "Big endian    : 258 = 0x0102\n"
-                     "Little endian : 258 = 0x0201");
-            break;
-        case MENU_ENUM_LABEL_HOLD_FAST_FORWARD:
-            snprintf(s, len,
-                     "Hold for fast-forward. Releasing button \n"
-                             "disables fast-forward.");
-            break;
-        case MENU_ENUM_LABEL_SLOWMOTION_HOLD:
-            snprintf(s, len,
-                     "Hold for slowmotion.");
-            break;
-        case MENU_ENUM_LABEL_FRAME_ADVANCE:
-            snprintf(s, len,
-                     "Frame advance when content is paused.");
-            break;
-        case MENU_ENUM_LABEL_BSV_RECORD_TOGGLE:
-            snprintf(s, len,
-                     "Toggle between recording and not.");
-            break;
-        case MENU_ENUM_LABEL_L_X_PLUS:
-        case MENU_ENUM_LABEL_L_X_MINUS:
-        case MENU_ENUM_LABEL_L_Y_PLUS:
-        case MENU_ENUM_LABEL_L_Y_MINUS:
-        case MENU_ENUM_LABEL_R_X_PLUS:
-        case MENU_ENUM_LABEL_R_X_MINUS:
-        case MENU_ENUM_LABEL_R_Y_PLUS:
-        case MENU_ENUM_LABEL_R_Y_MINUS:
-            snprintf(s, len,
-                     "Axis for analog stick (DualShock-esque).\n"
-                             " \n"
-                             "Bound as usual, however, if a real analog \n"
-                             "axis is bound, it can be read as a true analog.\n"
-                             " \n"
-                             "Positive X axis is right. \n"
-                             "Positive Y axis is down.");
             break;
         case MENU_ENUM_LABEL_VALUE_WHAT_IS_A_CORE_DESC:
             snprintf(s, len,
@@ -2305,41 +1088,37 @@ int msg_hash_get_help_uk_enum(enum msg_hash_enums msg, char *s, size_t len)
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OVERLAY_SETTINGS),
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_INPUT_OVERLAY_HIDE_IN_MENU));
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_ENABLE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_ENABLE:
             snprintf(s, len,
                      "Enables a background color for the OSD.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_RED:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_RED:
             snprintf(s, len,
                      "Sets the red value of the OSD background color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_GREEN:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_GREEN:
             snprintf(s, len,
                      "Sets the green value of the OSD background color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_BLUE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_BLUE:
             snprintf(s, len,
                      "Sets the blue value of the OSD background color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_BGCOLOR_OPACITY:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_BGCOLOR_OPACITY:
             snprintf(s, len,
                      "Sets the opacity of the OSD background color. Valid values are between 0.0 and 1.0.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_RED:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_RED:
             snprintf(s, len,
                      "Sets the red value of the OSD text color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_GREEN:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_GREEN:
             snprintf(s, len,
                      "Sets the green value of the OSD text color. Valid values are between 0 and 255.");
             break;
-        case MENU_ENUM_LABEL_VALUE_VIDEO_MESSAGE_COLOR_BLUE:
+        case MENU_ENUM_LABEL_VIDEO_MESSAGE_COLOR_BLUE:
             snprintf(s, len,
                      "Sets the blue value of the OSD text color. Valid values are between 0 and 255.");
-            break;
-        case MENU_ENUM_LABEL_MIDI_DRIVER:
-            snprintf(s, len,
-                     "MIDI driver to use.");
             break;
 #ifdef HAVE_LAKKA
         case MENU_ENUM_LABEL_TIMEZONE:
@@ -2365,10 +1144,6 @@ int msg_hash_get_help_uk_enum(enum msg_hash_enums msg, char *s, size_t len)
                      "When MIDI output is enabled and core and game/app support MIDI output,\n"
                      "some or all sounds (depends on game/app) will be generated by MIDI device.\n"
                      "In case of \"null\" MIDI driver this means that those sounds won't be audible.");
-            break;
-        case MENU_ENUM_LABEL_MIDI_VOLUME:
-            snprintf(s, len,
-                     "Sets the master volume of the output device.");
             break;
 #ifdef __linux__
         case MENU_ENUM_LABEL_GAMEMODE_ENABLE:

--- a/intl/msg_hash_vn.c
+++ b/intl/msg_hash_vn.c
@@ -240,59 +240,6 @@ int msg_hash_get_help_vn_enum(enum msg_hash_enums msg, char *s, size_t len)
                "In case a language is not implemented, \n"
                "we fallback to English.");
          break;
-      case MENU_ENUM_LABEL_VIDEO_FONT_PATH:
-         snprintf(s, len, "Change the font that is used \n"
-               "for the Onscreen Display text.");
-         break;
-      case MENU_ENUM_LABEL_GAME_SPECIFIC_OPTIONS:
-         snprintf(s, len, "Automatically tải content-specific core options.");
-         break;
-      case MENU_ENUM_LABEL_AUTO_OVERRIDES_ENABLE:
-         snprintf(s, len, "Automatically tải override configurations.");
-         break;
-      case MENU_ENUM_LABEL_AUTO_REMAPS_ENABLE:
-         snprintf(s, len, "Automatically tải input remapping files.");
-         break;
-      case MENU_ENUM_LABEL_SORT_SAVESTATES_ENABLE:
-         snprintf(s, len, "Sort save states in folders \n"
-               "named after the libretro core used.");
-         break;
-      case MENU_ENUM_LABEL_SORT_SAVEFILES_ENABLE:
-         snprintf(s, len, "Sort save files in folders \n"
-               "named after the libretro core used.");
-         break;
-      case MENU_ENUM_LABEL_RESUME_CONTENT:
-         snprintf(s, len, "Exits from the menu and returns back \n"
-               "to the content.");
-         break;
-      case MENU_ENUM_LABEL_RESTART_CONTENT:
-         snprintf(s, len, "Restarts the content from the beginning.");
-         break;
-      case MENU_ENUM_LABEL_CLOSE_CONTENT:
-         snprintf(s, len, "Closes the content and unloads it from \n"
-               "memory.");
-         break;
-      case MENU_ENUM_LABEL_UNDO_LOAD_STATE:
-         snprintf(s, len, "If a state was loaded, content will \n"
-               "go back to the state prior to loading.");
-         break;
-      case MENU_ENUM_LABEL_UNDO_SAVE_STATE:
-         snprintf(s, len, "If a state was overwritten, it will \n"
-               "roll back to the previous save state.");
-         break;
-      case MENU_ENUM_LABEL_TAKE_SCREENSHOT:
-         snprintf(s, len, "Create a screenshot. \n"
-               " \n"
-               "The screenshot will be stored inside the \n"
-               "Screenshot Thư mục.");
-         break;
-      case MENU_ENUM_LABEL_RUN:
-         snprintf(s, len, "Start the content.");
-         break;
-      case MENU_ENUM_LABEL_INFORMATION:
-         snprintf(s, len, "Show additional metadata information \n"
-               "about the content.");
-         break;
       case MENU_ENUM_LABEL_FILE_BROWSER_CONFIG:
          snprintf(s, len, "Configuration file.");
          break;
@@ -316,33 +263,6 @@ int msg_hash_get_help_vn_enum(enum msg_hash_enums msg, char *s, size_t len)
       case MENU_ENUM_LABEL_USE_THIS_DIRECTORY:
          snprintf(s, len,
                "Select this to set this as the thư mục.");
-         break;
-      case MENU_ENUM_LABEL_CONTENT_DATABASE_DIRECTORY:
-         snprintf(s, len,
-               "Content Database thư mục. \n"
-               " \n"
-               "Path to content database \n"
-               "thư mục.");
-         break;
-      case MENU_ENUM_LABEL_THUMBNAILS_DIRECTORY:
-         snprintf(s, len,
-               "Thumbnails thư mục. \n"
-               " \n"
-               "To store thumbnail files.");
-         break;
-      case MENU_ENUM_LABEL_LIBRETRO_INFO_PATH:
-         snprintf(s, len,
-               "Core Info thư mục. \n"
-               " \n"
-               "A thư mục for where to search \n"
-               "for libretro core information.");
-         break;
-      case MENU_ENUM_LABEL_PLAYLIST_DIRECTORY:
-         snprintf(s, len,
-               "Playlist thư mục. \n"
-               " \n"
-               "Save all playlist files to this \n"
-               "thư mục.");
          break;
       case MENU_ENUM_LABEL_DUMMY_ON_CORE_SHUTDOWN:
          snprintf(s, len,
@@ -456,18 +376,6 @@ int msg_hash_get_help_vn_enum(enum msg_hash_enums msg, char *s, size_t len)
                "Content decompressed by RetroArch will be \n"
                "temporarily extracted to this thư mục.");
          break;
-      case MENU_ENUM_LABEL_HISTORY_LIST_ENABLE:
-         snprintf(s, len,
-               "If enabled, every content loaded \n"
-               "in RetroArch will be automatically \n"
-               "added to the recent history list.");
-         break;
-      case MENU_ENUM_LABEL_RGUI_BROWSER_DIRECTORY:
-         snprintf(s, len,
-               "File Browser thư mục. \n"
-               " \n"
-               "Sets start thư mục for menu file browser.");
-         break;
       case MENU_ENUM_LABEL_INPUT_POLL_TYPE_BEHAVIOR:
          snprintf(s, len,
                "Influence how input polling is done inside \n"
@@ -488,127 +396,11 @@ int msg_hash_get_help_vn_enum(enum msg_hash_enums msg, char *s, size_t len)
                "regardless of the value set here."
                );
          break;
-      case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_HIDE_UNBOUND:
-         snprintf(s, len,
-               "Hide input descriptors that were not set \n"
-               "by the core.");
-         break;
-      case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE:
-         snprintf(s, len,
-               "Video refresh rate of your monitor. \n"
-               "Used to calculate a suitable audio input rate.");
-         break;
-      case MENU_ENUM_LABEL_VIDEO_FORCE_SRGB_DISABLE:
-         snprintf(s, len,
-               "Forcibly disable sRGB FBO support. Some Intel \n"
-               "OpenGL drivers on Windows have video problems \n"
-               "with sRGB FBO support enabled.");
-         break;
-      case MENU_ENUM_LABEL_AUDIO_ENABLE:
-         snprintf(s, len,
-               "Enable audio output.");
-         break;
-      case MENU_ENUM_LABEL_AUDIO_SYNC:
-         snprintf(s, len,
-               "Synchronize audio (recommended).");
-         break;
-      case MENU_ENUM_LABEL_AUDIO_LATENCY:
-         snprintf(s, len,
-               "Desired audio latency in milliseconds. \n"
-               "Might not be honored if the audio driver \n"
-               "can't provide given latency.");
-         break;
-      case MENU_ENUM_LABEL_VIDEO_ALLOW_ROTATE:
-         snprintf(s, len,
-               "Allow cores to set rotation. If false, \n"
-               "rotation requests are honored, but ignored.\n\n"
-               "Used for setups where one manually rotates \n"
-               "the monitor.");
-         break;
-      case MENU_ENUM_LABEL_INPUT_DESCRIPTOR_LABEL_SHOW:
-         snprintf(s, len,
-               "Show the input descriptors set by the core \n"
-               "instead of the default ones.");
-         break;
-      case MENU_ENUM_LABEL_CONTENT_HISTORY_SIZE:
-         snprintf(s, len,
-               "Number of entries that will be kept in \n"
-               "content history playlist.");
-         break;
-      case MENU_ENUM_LABEL_VIDEO_WINDOWED_FULLSCREEN:
-         snprintf(s, len,
-               "To use windowed mode or not when going \n"
-               "fullscreen.");
-         break;
-      case MENU_ENUM_LABEL_VIDEO_FONT_SIZE:
-         snprintf(s, len,
-               "Font size for on-screen messages.");
-         break;
-      case MENU_ENUM_LABEL_SAVESTATE_AUTO_INDEX:
-         snprintf(s, len,
-               "Automatically increment slot index on each save, \n"
-               "generating multiple savestate files. \n"
-               "When the content is loaded, state slot will be \n"
-               "set to the highest existing value (last savestate).");
-         break;
-      case MENU_ENUM_LABEL_FPS_SHOW:
-         snprintf(s, len,
-               "Enables displaying the current frames \n"
-               "per second.");
-         break;
-      case MENU_ENUM_LABEL_VIDEO_FONT_ENABLE:
-         snprintf(s, len,
-               "Show and/or hide onscreen messages.");
-         break;
       case MENU_ENUM_LABEL_VIDEO_MESSAGE_POS_X:
       case MENU_ENUM_LABEL_VIDEO_MESSAGE_POS_Y:
          snprintf(s, len,
                "Offset for where messages will be placed \n"
                "onscreen. Values are in range [0.0, 1.0].");
-         break;
-      case MENU_ENUM_LABEL_INPUT_OVERLAY_ENABLE:
-         snprintf(s, len,
-               "Enable or disable the current overlay.");
-         break;
-      case MENU_ENUM_LABEL_INPUT_OVERLAY_HIDE_IN_MENU:
-         snprintf(s, len,
-               "Hide the current overlay from appearing \n"
-               "inside the menu.");
-         break;
-      case MENU_ENUM_LABEL_OVERLAY_PRESET:
-         snprintf(s, len,
-               "Path to input overlay.");
-         break;
-      case MENU_ENUM_LABEL_OVERLAY_OPACITY:
-         snprintf(s, len,
-               "Overlay opacity.");
-         break;
-      case MENU_ENUM_LABEL_INPUT_BIND_TIMEOUT:
-         snprintf(s, len,
-               "Input bind timer timeout (in seconds). \n"
-               "Amount of seconds to wait until proceeding \n"
-               "to the next bind.");
-         break;
-      case MENU_ENUM_LABEL_INPUT_BIND_HOLD:
-         snprintf(s, len,
-               "Input bind hold time (in seconds). \n"
-               "Amount of seconds to hold an input to bind it.");
-         break;
-      case MENU_ENUM_LABEL_OVERLAY_SCALE:
-         snprintf(s, len,
-               "Overlay scale.");
-         break;
-      case MENU_ENUM_LABEL_AUDIO_OUTPUT_RATE:
-         snprintf(s, len,
-               "Audio output samplerate.");
-         break;
-      case MENU_ENUM_LABEL_VIDEO_SHARED_CONTEXT:
-         snprintf(s, len,
-               "Set to true if hardware-rendered cores \n"
-               "should get their private context. \n"
-               "Avoids having to assume hardware state changes \n"
-               "inbetween frames."
-               );
          break;
       case MENU_ENUM_LABEL_CORE_LIST:
          snprintf(s, len,
@@ -858,13 +650,6 @@ int msg_hash_get_help_vn_enum(enum msg_hash_enums msg, char *s, size_t len)
             }
          }
          break;
-      case MENU_ENUM_LABEL_AUDIO_DSP_PLUGIN:
-         snprintf(s, len,
-               "Audio DSP plugin.\n"
-               " Processes audio before it's sent to \n"
-               "the driver."
-               );
-         break;
       case MENU_ENUM_LABEL_AUDIO_RESAMPLER_DRIVER:
          {
             const char *lbl = settings ? settings->arrays.audio_resampler : NULL;
@@ -942,20 +727,6 @@ int msg_hash_get_help_vn_enum(enum msg_hash_enums msg, char *s, size_t len)
                "The Default Filter option will affect the \n"
                "stretching filter.");
          break;
-      case MENU_ENUM_LABEL_VIDEO_SHADER_PARAMETERS:
-         snprintf(s, len,
-               "Shader Parameters. \n"
-               " \n"
-               "Modifies current shader directly. Will not be \n"
-               "saved to CGP/GLSLP preset file.");
-         break;
-      case MENU_ENUM_LABEL_VIDEO_SHADER_PRESET_PARAMETERS:
-         snprintf(s, len,
-               "Shader Preset Parameters. \n"
-               " \n"
-               "Modifies shader preset currently in menu."
-               );
-         break;
       case MENU_ENUM_LABEL_VIDEO_SHADER_PASS:
          snprintf(s, len,
                "Path to shader. \n"
@@ -994,13 +765,6 @@ int msg_hash_get_help_vn_enum(enum msg_hash_enums msg, char *s, size_t len)
                "manually isn't really an option."
 #endif
                );
-         break;
-      case MENU_ENUM_LABEL_CONFIRM_ON_EXIT:
-         snprintf(s, len, "Are you sure you want to quit?");
-         break;
-      case MENU_ENUM_LABEL_SHOW_HIDDEN_FILES:
-         snprintf(s, len, "Show hidden files\n"
-               "and folders.");
          break;
       case MENU_ENUM_LABEL_VIDEO_SHADER_FILTER_PASS:
          snprintf(s, len,
@@ -1131,12 +895,6 @@ int msg_hash_get_help_vn_enum(enum msg_hash_enums msg, char *s, size_t len)
 #endif
                );
          break;
-      case MENU_ENUM_LABEL_DISK_EJECT_TOGGLE:
-         snprintf(s, len,
-               "Bật/tắt eject for disks.\n"
-               " \n"
-               "Used for multiple-disk content.");
-         break;
       case MENU_ENUM_LABEL_ENABLE_HOTKEY:
          snprintf(s, len,
                "Enable other hotkeys.\n"
@@ -1150,20 +908,6 @@ int msg_hash_get_help_vn_enum(enum msg_hash_enums msg, char *s, size_t len)
                "implementations which query a large area of \n"
                "the keyboard, where it is not desirable that \n"
                "hotkeys get in the way.");
-         break;
-      case MENU_ENUM_LABEL_REWIND_ENABLE:
-         snprintf(s, len,
-               "Enable rewinding.\n"
-               " \n"
-               "This will take a performance hit, \n"
-               "so it is disabled by default.");
-         break;
-      case MENU_ENUM_LABEL_LIBRETRO_DIR_PATH:
-         snprintf(s, len,
-               "Core thư mục. \n"
-               " \n"
-               "A thư mục for where to search for \n"
-               "libretro core implementations.");
          break;
       case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE_AUTO:
          snprintf(s, len,
@@ -1184,22 +928,6 @@ int msg_hash_get_help_vn_enum(enum msg_hash_enums msg, char *s, size_t len)
                "large pitch changes. If your monitor does \n"
                "not run at 60Hz, or something close to it, \n"
                "disable VSync, and leave this at its default.");
-         break;
-      case MENU_ENUM_LABEL_VIDEO_ROTATION:
-         snprintf(s, len,
-               "Forces a certain rotation \n"
-               "of the screen.\n"
-               " \n"
-               "The rotation is added to rotations which\n"
-               "the libretro core sets (see Video Allow\n"
-               "Rotate).");
-         break;
-      case MENU_ENUM_LABEL_VIDEO_SCALE:
-         snprintf(s, len,
-               "Fullscreen resolution.\n"
-               " \n"
-               "Resolution of 0 uses the \n"
-               "resolution of the environment.\n");
          break;
       case MENU_ENUM_LABEL_FASTFORWARD_RATIO:
          snprintf(s, len,
@@ -1224,25 +952,6 @@ int msg_hash_get_help_vn_enum(enum msg_hash_enums msg, char *s, size_t len)
                "is preferred, 1 and up (1 being first \n"
                "monitor), suggests RetroArch to use that \n"
                "particular monitor.");
-         break;
-      case MENU_ENUM_LABEL_VIDEO_CROP_OVERSCAN:
-         snprintf(s, len,
-               "Forces cropping of overscanned \n"
-               "frames.\n"
-               " \n"
-               "Exact behavior of this option is \n"
-               "core-implementation specific.");
-         break;
-      case MENU_ENUM_LABEL_VIDEO_SCALE_INTEGER:
-         snprintf(s, len,
-               "Only scales video in integer \n"
-               "steps.\n"
-               " \n"
-               "The base size depends on system-reported \n"
-               "geometry and aspect ratio.\n"
-               " \n"
-               "If Force Aspect is not set, X/Y will be \n"
-               "integer scaled independently.");
          break;
       case MENU_ENUM_LABEL_AUDIO_VOLUME:
          snprintf(s, len,
@@ -1285,11 +994,6 @@ int msg_hash_get_help_vn_enum(enum msg_hash_enums msg, char *s, size_t len)
                " \n"
                "Wraps around.");
          break;
-      case MENU_ENUM_LABEL_LOG_VERBOSITY:
-         snprintf(s, len,
-               "Enable or disable verbosity level \n"
-               "of frontend.");
-         break;
       case MENU_ENUM_LABEL_VOLUME_UP:
          snprintf(s, len,
                "Tăng âm lượng.");
@@ -1302,11 +1006,6 @@ int msg_hash_get_help_vn_enum(enum msg_hash_enums msg, char *s, size_t len)
          snprintf(s, len,
                "Forcibly disable composition.\n"
                "Only valid on Windows Vista/7 for now.");
-         break;
-      case MENU_ENUM_LABEL_PERFCNT_ENABLE:
-         snprintf(s, len,
-               "Enable or disable frontend \n"
-               "performance counters.");
          break;
       case MENU_ENUM_LABEL_SYSTEM_DIRECTORY:
          snprintf(s, len,
@@ -1334,27 +1033,6 @@ int msg_hash_get_help_vn_enum(enum msg_hash_enums msg, char *s, size_t len)
                "Using this might improve performance at the \n"
                "possible cost of latency and more video \n"
                "stuttering.");
-         break;
-      case MENU_ENUM_LABEL_VIDEO_VSYNC:
-         snprintf(s, len,
-               "Video V-Sync.\n");
-         break;
-      case MENU_ENUM_LABEL_VIDEO_HARD_SYNC:
-         snprintf(s, len,
-               "Attempts to hard-synchronize \n"
-               "CPU and GPU.\n"
-               " \n"
-               "Can reduce latency at the cost of \n"
-               "performance.");
-         break;
-      case MENU_ENUM_LABEL_REWIND_GRANULARITY:
-         snprintf(s, len,
-               "Rewind granularity.\n"
-               " \n"
-               " When rewinding defined number of \n"
-               "frames, you can rewind several frames \n"
-               "at a time, increasing the rewinding \n"
-               "speed.");
          break;
       case MENU_ENUM_LABEL_SCREENSHOT:
          snprintf(s, len,
@@ -1395,48 +1073,8 @@ int msg_hash_get_help_vn_enum(enum msg_hash_enums msg, char *s, size_t len)
                "configured as if it is a 60 Hz monitor \n"
                "(divide refresh rate by 2).");
          break;
-      case MENU_ENUM_LABEL_RGUI_SHOW_START_SCREEN:
-         snprintf(s, len,
-               "Show startup screen in menu.\n"
-               "Is automatically set to false when seen\n"
-               "for the first time.\n"
-               " \n"
-               "This is only updated in config if\n"
-               "'Save Configuration on Exit' is enabled.\n");
-         break;
       case MENU_ENUM_LABEL_VIDEO_FULLSCREEN:
          snprintf(s, len, "Bật/tắt chế độ toàn màn hình.");
-         break;
-      case MENU_ENUM_LABEL_BLOCK_SRAM_OVERWRITE:
-         snprintf(s, len,
-               "Block SRAM from being overwritten \n"
-               "when loading save states.\n"
-               " \n"
-               "Might potentially lead to buggy games.");
-         break;
-      case MENU_ENUM_LABEL_PAUSE_NONACTIVE:
-         snprintf(s, len,
-               "Pause gameplay when window focus \n"
-               "is lost.");
-         break;
-      case MENU_ENUM_LABEL_VIDEO_GPU_SCREENSHOT:
-         snprintf(s, len,
-               "Screenshots output of GPU shaded \n"
-               "material if available.");
-         break;
-      case MENU_ENUM_LABEL_SCREENSHOT_DIRECTORY:
-         snprintf(s, len,
-               "Screenshot thư mục. \n"
-               " \n"
-               "thư mục to dump screenshots to."
-               );
-         break;
-      case MENU_ENUM_LABEL_VIDEO_SWAP_INTERVAL:
-         snprintf(s, len,
-               "VSync Swap Interval.\n"
-               " \n"
-               "Uses a custom swap interval for VSync. Set this \n"
-               "to effectively halve monitor refresh rate.");
          break;
       case MENU_ENUM_LABEL_SAVEFILE_DIRECTORY:
          snprintf(s, len,
@@ -1475,59 +1113,8 @@ int msg_hash_get_help_vn_enum(enum msg_hash_enums msg, char *s, size_t len)
                "be loaded dynamically by the menu depending \n"
                "on context.");
          break;
-      case MENU_ENUM_LABEL_SLOWMOTION_RATIO:
-         snprintf(s, len,
-               "Slowmotion ratio."
-               " \n"
-               "When slowmotion, content will slow\n"
-               "down by factor.");
-         break;
-      case MENU_ENUM_LABEL_INPUT_TURBO_PERIOD:
-         snprintf(s, len,
-               "Turbo period.\n"
-               " \n"
-               "Describes the period of which turbo-enabled\n"
-               "buttons toggle.\n"
-               " \n"
-               "Numbers are described in frames."
-               );
-         break;
-      case MENU_ENUM_LABEL_INPUT_DUTY_CYCLE:
-         snprintf(s, len,
-               "Duty cycle.\n"
-               " \n"
-               "Describes how long the period of a turbo-enabled\n"
-               "should be.\n"
-               " \n"
-               "Numbers are described in frames."
-               );
-         break;
-      case MENU_ENUM_LABEL_INPUT_TOUCH_ENABLE:
-         snprintf(s, len, "Enable touch support.");
-         break;
       case MENU_ENUM_LABEL_INPUT_PREFER_FRONT_TOUCH:
          snprintf(s, len, "Use front instead of back touch.");
-         break;
-      case MENU_ENUM_LABEL_MOUSE_ENABLE:
-         snprintf(s, len, "Enable mouse input inside the menu.");
-         break;
-      case MENU_ENUM_LABEL_POINTER_ENABLE:
-         snprintf(s, len, "Enable touch input inside the menu.");
-         break;
-      case MENU_ENUM_LABEL_MENU_WALLPAPER:
-         snprintf(s, len, "Path to an image to set as the background.");
-         break;
-      case MENU_ENUM_LABEL_NAVIGATION_WRAPAROUND:
-         snprintf(s, len,
-               "Wrap-around to beginning and/or end \n"
-               "if boundary of list is reached \n"
-               "horizontally and/or vertically.");
-         break;
-      case MENU_ENUM_LABEL_PAUSE_LIBRETRO:
-         snprintf(s, len,
-               "If disabled, the libretro core will keep \n"
-               "running in the background when we are in the \n"
-               "menu.");
          break;
       case MENU_ENUM_LABEL_SUSPEND_SCREENSAVER_ENABLE:
          snprintf(s, len,
@@ -1590,164 +1177,19 @@ int msg_hash_get_help_vn_enum(enum msg_hash_enums msg, char *s, size_t len)
 #endif
          );
          break;
-      case MENU_ENUM_LABEL_TIMEDATE_ENABLE:
-         snprintf(s, len,
-               "Shows current date and/or time inside menu.");
-         break;
-      case MENU_ENUM_LABEL_CORE_ENABLE:
-         snprintf(s, len,
-               "Shows current core inside menu.");
-         break;
-      case MENU_ENUM_LABEL_NETPLAY_ENABLE_HOST:
-         snprintf(s, len,
-               "Enables Netplay in host (server) mode.");
-         break;
-      case MENU_ENUM_LABEL_NETPLAY_ENABLE_CLIENT:
-         snprintf(s, len,
-               "Enables Netplay in client mode.");
-         break;
-      case MENU_ENUM_LABEL_NETPLAY_DISCONNECT:
-         snprintf(s, len,
-               "Disconnects an active Netplay connection.");
-         break;
       case MENU_ENUM_LABEL_NETPLAY_SETTINGS:
          snprintf(s, len,
                "Setting related to Netplay.");
-         break;
-      case MENU_ENUM_LABEL_NETPLAY_LAN_SCAN_SETTINGS:
-         snprintf(s, len,
-               "Search for and connect to netplay hosts on the local network.");
-         break;
-      case MENU_ENUM_LABEL_DYNAMIC_WALLPAPER:
-         snprintf(s, len,
-               "Dynamically tải a new wallpaper \n"
-               "depending on context.");
-         break;
-      case MENU_ENUM_LABEL_CORE_UPDATER_BUILDBOT_URL:
-         snprintf(s, len,
-               "URL to core updater thư mục on the \n"
-               "Libretro buildbot.");
-         break;
-      case MENU_ENUM_LABEL_BUILDBOT_ASSETS_URL:
-         snprintf(s, len,
-               "URL to assets updater thư mục on the \n"
-               "Libretro buildbot.");
-         break;
-      case MENU_ENUM_LABEL_INPUT_REMAP_BINDS_ENABLE:
-         snprintf(s, len,
-               "if enabled, overrides the input binds \n"
-               "with the remapped binds set for the \n"
-               "current core.");
-         break;
-      case MENU_ENUM_LABEL_OVERLAY_DIRECTORY:
-         snprintf(s, len,
-               "Overlay thư mục. \n"
-               " \n"
-               "Defines a thư mục where overlays are \n"
-               "kept for easy access.");
-         break;
-      case MENU_ENUM_LABEL_INPUT_MAX_USERS:
-         snprintf(s, len,
-               "Maximum amount of users supported by \n"
-               "RetroArch.");
-         break;
-      case MENU_ENUM_LABEL_CORE_UPDATER_AUTO_EXTRACT_ARCHIVE:
-         snprintf(s, len,
-               "After downloading, automatically extract \n"
-               "archives that the downloads are contained \n"
-               "inside.");
-         break;
-      case MENU_ENUM_LABEL_NAVIGATION_BROWSER_FILTER_SUPPORTED_EXTENSIONS_ENABLE:
-         snprintf(s, len,
-               "Filter files being shown by \n"
-               "supported extensions.");
-         break;
-      case MENU_ENUM_LABEL_NETPLAY_NICKNAME:
-         snprintf(s, len,
-               "The username of the person running RetroArch. \n"
-               "This will be used for playing online games.");
-         break;
-      case MENU_ENUM_LABEL_NETPLAY_TCP_UDP_PORT:
-         snprintf(s, len,
-               "The port of the host IP address. \n"
-               "Can be either a TCP or UDP port.");
          break;
       case MENU_ENUM_LABEL_NETPLAY_SPECTATOR_MODE_ENABLE:
          snprintf(s, len,
                "Enable or disable spectator mode for \n"
                "the user during netplay.");
          break;
-      case MENU_ENUM_LABEL_NETPLAY_IP_ADDRESS:
-         snprintf(s, len,
-               "The address of the host to connect to.");
-         break;
-      case MENU_ENUM_LABEL_STDIN_CMD_ENABLE:
-         snprintf(s, len,
-               "Enable stdin command interface.");
-         break;
       case MENU_ENUM_LABEL_UI_COMPANION_START_ON_BOOT:
          snprintf(s, len,
                "Start User Interface companion driver \n"
                "on boot (if available).");
-         break;
-      case MENU_ENUM_LABEL_MENU_DRIVER:
-         snprintf(s, len, "Menu driver to use.");
-         break;
-      case MENU_ENUM_LABEL_INPUT_MENU_ENUM_TOGGLE_GAMEPAD_COMBO:
-         snprintf(s, len,
-               "Gamepad button combination to toggle menu. \n"
-               " \n"
-               "0 - None \n"
-               "1 - Press L + R + Y + D-Pad Down \n"
-               "simultaneously. \n"
-               "2 - Press L3 + R3 simultaneously. \n"
-               "3 - Press Start + Select simultaneously.");
-         break;
-      case MENU_ENUM_LABEL_INPUT_ALL_USERS_CONTROL_MENU:
-         snprintf(s, len, "Allow any RetroPad to control the menu.");
-         break;
-      case MENU_ENUM_LABEL_INPUT_AUTODETECT_ENABLE:
-         snprintf(s, len,
-               "Enable input auto-detection.\n"
-               " \n"
-               "Will attempt to auto-configure \n"
-               "joypads, Plug-and-Play style.");
-         break;
-      case MENU_ENUM_LABEL_CAMERA_ALLOW:
-         snprintf(s, len,
-               "Allow or disallow camera access by \n"
-               "cores.");
-         break;
-      case MENU_ENUM_LABEL_LOCATION_ALLOW:
-         snprintf(s, len,
-               "Allow or disallow location services \n"
-               "access by cores.");
-         break;
-      case MENU_ENUM_LABEL_TURBO:
-         snprintf(s, len,
-               "Turbo enable.\n"
-               " \n"
-               "Holding the turbo while pressing another \n"
-               "button will let the button enter a turbo \n"
-               "mode where the button state is modulated \n"
-               "with a periodic signal. \n"
-               " \n"
-               "The modulation stops when the button \n"
-               "itself (not turbo button) is released.");
-         break;
-      case MENU_ENUM_LABEL_OSK_ENABLE:
-         snprintf(s, len,
-               "Enable/disable on-screen keyboard.");
-         break;
-      case MENU_ENUM_LABEL_AUDIO_MUTE:
-         snprintf(s, len,
-               "Tắt/Bật âm thanh.");
-         break;
-      case MENU_ENUM_LABEL_REWIND:
-         snprintf(s, len,
-               "Hold button down to rewind.\n"
-               " \n"
-               "Rewind must be enabled.");
          break;
       case MENU_ENUM_LABEL_EXIT_EMULATOR:
          snprintf(s, len,
@@ -1765,18 +1207,6 @@ int msg_hash_get_help_vn_enum(enum msg_hash_enums msg, char *s, size_t len)
          snprintf(s, len,
                "Tải state.");
          break;
-      case MENU_ENUM_LABEL_SAVE_STATE:
-         snprintf(s, len,
-               "Saves state.");
-         break;
-      case MENU_ENUM_LABEL_CHEAT_INDEX_PLUS:
-         snprintf(s, len,
-               "Increment cheat index.\n");
-         break;
-      case MENU_ENUM_LABEL_CHEAT_INDEX_MINUS:
-         snprintf(s, len,
-               "Decrement cheat index.\n");
-         break;
       case MENU_ENUM_LABEL_SHADER_PREV:
          snprintf(s, len,
                "Áp dụng previous shader in thư mục.");
@@ -1784,52 +1214,6 @@ int msg_hash_get_help_vn_enum(enum msg_hash_enums msg, char *s, size_t len)
       case MENU_ENUM_LABEL_SHADER_NEXT:
          snprintf(s, len,
                "Áp dụng next shader in thư mục.");
-         break;
-      case MENU_ENUM_LABEL_RESET:
-         snprintf(s, len,
-               "Reset the content.\n");
-         break;
-      case MENU_ENUM_LABEL_PAUSE_TOGGLE:
-         snprintf(s, len,
-               "Toggle between paused and non-paused state.");
-         break;
-      case MENU_ENUM_LABEL_CHEAT_TOGGLE:
-         snprintf(s, len,
-               "Toggle cheat index.\n");
-         break;
-      case MENU_ENUM_LABEL_HOLD_FAST_FORWARD:
-         snprintf(s, len,
-               "Hold for fast-forward. Releasing button \n"
-               "disables fast-forward.");
-         break;
-      case MENU_ENUM_LABEL_SLOWMOTION_HOLD:
-         snprintf(s, len,
-               "Hold for slowmotion.");
-         break;
-      case MENU_ENUM_LABEL_FRAME_ADVANCE:
-         snprintf(s, len,
-               "Frame advance when content is paused.");
-         break;
-      case MENU_ENUM_LABEL_BSV_RECORD_TOGGLE:
-         snprintf(s, len,
-               "Toggle between recording and not.");
-         break;
-      case MENU_ENUM_LABEL_L_X_PLUS:
-      case MENU_ENUM_LABEL_L_X_MINUS:
-      case MENU_ENUM_LABEL_L_Y_PLUS:
-      case MENU_ENUM_LABEL_L_Y_MINUS:
-      case MENU_ENUM_LABEL_R_X_PLUS:
-      case MENU_ENUM_LABEL_R_X_MINUS:
-      case MENU_ENUM_LABEL_R_Y_PLUS:
-      case MENU_ENUM_LABEL_R_Y_MINUS:
-         snprintf(s, len,
-               "Axis for analog stick (DualShock-esque).\n"
-               " \n"
-               "Bound as usual, however, if a real analog \n"
-               "axis is bound, it can be read as a true analog.\n"
-               " \n"
-               "Positive X axis is right. \n"
-               "Positive Y axis is down.");
          break;
       case MENU_ENUM_LABEL_VALUE_WHAT_IS_A_CORE_DESC:
          snprintf(s, len,


### PR DESCRIPTION
## Description

After PR14723, several help texts are not present in msg_hash_us.c file any more. Same removals were done for translated variants where the text was actually still English (or, in case of Vietnamese, only partially translated).

Label corrections also applied.

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/14723

