### PR TITLE
Fix icons in playlist manager

### DIFF
--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -7924,11 +7924,11 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_CHEAT_ADD_NEW_AFTER,
-   "Add New Cheat after This One"
+   "Add New Cheat After This"
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_CHEAT_ADD_NEW_BEFORE,
-   "Add New Cheat before This One"
+   "Add New Cheat Before This"
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_CHEAT_COPY_AFTER,

--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -10891,9 +10891,24 @@ static void materialui_list_insert(
                /* Set defaults */
                node->icon_texture_index = MUI_TEXTURE_PLAYLIST;
                node->icon_type          = MUI_ICON_TYPE_INTERNAL;
-               if (mui->textures.playlist.size >= 1)
-                  if (!string_is_empty(path))
+               if (     mui->textures.playlist.size >= 1
+                     && !string_is_empty(path))
+               {
+                  if (string_ends_with_size(path, "_history.lpl",
+                        strlen(path), STRLEN_CONST("_history.lpl")))
+                  {
+                     node->icon_texture_index = MUI_TEXTURE_HISTORY;
+                     node->icon_type          = MUI_ICON_TYPE_INTERNAL;
+                  }
+                  else if (string_ends_with_size(path, "_favorites.lpl",
+                        strlen(path), STRLEN_CONST("_favorites.lpl")))
+                  {
+                     node->icon_texture_index = MUI_TEXTURE_ADD_TO_FAVORITES;
+                     node->icon_type          = MUI_ICON_TYPE_INTERNAL;
+                  }
+                  else
                      materialui_set_node_playlist_icon(mui, node, path);
+               }
             }
             break;
       }

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -2005,6 +2005,7 @@ static uintptr_t ozone_entries_icon_get_texture(
             return ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_STREAM];
       case MENU_ENUM_LABEL_QUICK_MENU_STOP_STREAMING:
       case MENU_ENUM_LABEL_QUICK_MENU_STOP_RECORDING:
+      case MENU_ENUM_LABEL_CHEAT_DELETE:
       case MENU_ENUM_LABEL_CHEAT_DELETE_ALL:
       case MENU_ENUM_LABEL_CORE_DELETE:
       case MENU_ENUM_LABEL_DELETE_PLAYLIST:
@@ -2106,6 +2107,8 @@ static uintptr_t ozone_entries_icon_get_texture(
 #endif
       case MENU_ENUM_LABEL_REBOOT:
       case MENU_ENUM_LABEL_RESET_TO_DEFAULT_CONFIG:
+      case MENU_ENUM_LABEL_CHEAT_COPY_AFTER:
+      case MENU_ENUM_LABEL_CHEAT_COPY_BEFORE:
       case MENU_ENUM_LABEL_CHEAT_RELOAD_CHEATS:
       case MENU_ENUM_LABEL_RESTART_RETROARCH:
       case MENU_ENUM_LABEL_FRAME_TIME_COUNTER_SETTINGS:
@@ -5725,9 +5728,20 @@ border_iterate:
                texture = ozone->tab_textures[OZONE_TAB_TEXTURE_FAVORITES];
             else if (i < ozone->horizontal_list.size)
             {
-               ozone_node_t *sidebar_node = (ozone_node_t*)
-                     file_list_get_userdata_at_offset(&ozone->horizontal_list, i + 1);
+               ozone_node_t *sidebar_node = NULL;
+               unsigned offset            = 0;
 
+               /* Ignore Explore Views */
+               for (offset = 0; offset < ozone->horizontal_list.size; offset++)
+               {
+                  char playlist_file_noext[255];
+                  strlcpy(playlist_file_noext, ozone->horizontal_list.list[offset].path, sizeof(playlist_file_noext));
+                  path_remove_extension(playlist_file_noext);
+                  if (string_is_equal(playlist_file_noext, entry.rich_label))
+                     break;
+               }
+
+               sidebar_node = (ozone_node_t*)file_list_get_userdata_at_offset(&ozone->horizontal_list, offset);
                if (sidebar_node && sidebar_node->icon)
                   texture = sidebar_node->icon;
             }

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -2535,6 +2535,7 @@ static void xmb_context_reset_horizontal_list(
       else if (string_ends_with_size(xmb->horizontal_list.list[i].label, ".lvw",
               strlen(xmb->horizontal_list.list[i].label), STRLEN_CONST(".lvw")))
       {
+         node->console_name = strdup(path + strlen(msg_hash_to_str(MENU_ENUM_LABEL_EXPLORE_VIEW)) + 2);
          node->icon = xmb->textures.list[XMB_TEXTURE_CURSOR];
       }
    }
@@ -2916,6 +2917,8 @@ static uintptr_t xmb_icon_get_id(xmb_handle_t *xmb,
       case MENU_ENUM_LABEL_QUICK_MENU_SHOW_RESTART_CONTENT:
       case MENU_ENUM_LABEL_REBOOT:
       case MENU_ENUM_LABEL_RESET_TO_DEFAULT_CONFIG:
+      case MENU_ENUM_LABEL_CHEAT_COPY_AFTER:
+      case MENU_ENUM_LABEL_CHEAT_COPY_BEFORE:
       case MENU_ENUM_LABEL_CHEAT_RELOAD_CHEATS:
       case MENU_ENUM_LABEL_RESTART_RETROARCH:
       case MENU_ENUM_LABEL_FRAME_TIME_COUNTER_SETTINGS:
@@ -3124,6 +3127,7 @@ static uintptr_t xmb_icon_get_id(xmb_handle_t *xmb,
          return xmb->textures.list[XMB_TEXTURE_STREAM];
       case MENU_ENUM_LABEL_QUICK_MENU_STOP_STREAMING:
       case MENU_ENUM_LABEL_QUICK_MENU_STOP_RECORDING:
+      case MENU_ENUM_LABEL_CHEAT_DELETE:
       case MENU_ENUM_LABEL_CHEAT_DELETE_ALL:
       case MENU_ENUM_LABEL_CORE_DELETE:
       case MENU_ENUM_LABEL_DELETE_PLAYLIST:
@@ -4032,9 +4036,20 @@ static int xmb_draw_item(
             texture = xmb->textures.list[XMB_TEXTURE_FAVORITES];
          else if (i < xmb->horizontal_list.size)
          {
-            xmb_node_t *sidebar_node = (xmb_node_t*)
-                  file_list_get_userdata_at_offset(&xmb->horizontal_list, i + 1);
+            xmb_node_t *sidebar_node = NULL;
+            unsigned offset          = 0;
 
+            /* Ignore Explore Views */
+            for (offset = 0; offset < xmb->horizontal_list.size; offset++)
+            {
+               char playlist_file_noext[255];
+               strlcpy(playlist_file_noext, xmb->horizontal_list.list[offset].path, sizeof(playlist_file_noext));
+               path_remove_extension(playlist_file_noext);
+               if (string_is_equal(playlist_file_noext, entry.rich_label))
+                  break;
+            }
+
+            sidebar_node = (xmb_node_t*)file_list_get_userdata_at_offset(&xmb->horizontal_list, offset);
             if (sidebar_node && sidebar_node->icon)
                texture = sidebar_node->icon;
          }


### PR DESCRIPTION
## Description

- (XMB/Ozone) Fixed playlist manager icons to take Explore Views into account properly
- (GLUI) Added missing Favorites+History icons in playlist manager
- Changed XMB Explore View title to match Ozone
- Added missing icons in cheats (Delete + Copy After/Before)
- Fixed label capitalization in cheats (Add New After/Before This)
