### PR TITLE
Rename 'Standalone Cores' to 'Contentless Cores'

### DIFF
--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -46,7 +46,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_CONTENTLESS_CORES_TAB,
-   "Standalone Cores"
+   "Contentless Cores"
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_ADD_TAB,
@@ -292,7 +292,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_GOTO_CONTENTLESS_CORES,
-   "Standalone Cores"
+   "Contentless Cores"
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_GOTO_CONTENTLESS_CORES,
@@ -537,11 +537,11 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_CORE_SET_STANDALONE_EXEMPT,
-   "Exclude From 'Standalone Cores' Menu"
+   "Exclude From 'Contentless Cores' Menu"
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_CORE_SET_STANDALONE_EXEMPT,
-   "Prevent this core from being displayed in the 'Standalone Cores' tab/menu. Only applies when display mode is set to 'Custom'."
+   "Prevent this core from being displayed in the 'Contentless Cores' tab/menu. Only applies when display mode is set to 'Custom'."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_CORE_DELETE,
@@ -4974,11 +4974,11 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_CONTENT_SHOW_CONTENTLESS_CORES,
-   "Show 'Standalone Cores'"
+   "Show 'Contentless Cores'"
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_CONTENT_SHOW_CONTENTLESS_CORES,
-   "Specify the type of core (if any) to show in the 'Standalone Cores' menu. When set to 'Custom', individual core visibility may be toggled via the 'Manage Cores' menu. (Restart Required on Ozone/XMB)"
+   "Specify the type of core (if any) to show in the 'Contentless Cores' menu. When set to 'Custom', individual core visibility may be toggled via the 'Manage Cores' menu. (Restart Required on Ozone/XMB)"
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_SHOW_CONTENTLESS_CORES_ALL,
@@ -13396,11 +13396,11 @@ MSG_HASH(
    )
 MSG_HASH(
    MSG_CORE_SET_STANDALONE_EXEMPT_FAILED,
-   "Failed to remove core from 'Standalone Cores' list: "
+   "Failed to remove core from 'Contentless Cores' list: "
    )
 MSG_HASH(
    MSG_CORE_UNSET_STANDALONE_EXEMPT_FAILED,
-   "Failed to add core to 'Standalone Cores' list: "
+   "Failed to add core to 'Contentless Cores' list: "
    )
 MSG_HASH(
    MSG_CORE_DELETE_DISABLED,

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -4729,7 +4729,7 @@ static unsigned menu_displaylist_parse_content_information(
     * > Can only assume a valid playlist if the origin
     *   was an actual playlist - i.e. cached playlist is
     *   dubious if information was selected from
-    *   'Main Menu > Quick Menu' or 'Standalone Cores >
+    *   'Main Menu > Quick Menu' or 'Contentless Cores >
     *   Quick Menu' */
    if (menu_st->entries.list)
       list  = MENU_LIST_GET(menu_st->entries.list, 0);

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -8133,8 +8133,8 @@ int generic_menu_entry_action(
             flush_target = msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_RPL_ENTRY_ACTIONS);
             break;
          }
-         /* If core was launched via standalone cores menu,
-          * flush to standalone cores menu */
+         /* If core was launched via 'Contentless Cores' menu,
+          * flush to 'Contentless Cores' menu */
          else if (string_is_equal(parent_label,
                         msg_hash_to_str(MENU_ENUM_LABEL_CONTENTLESS_CORES_TAB)) ||
                   string_is_equal(parent_label,


### PR DESCRIPTION
## Description

Let's rename all visible mentions of "Standalone Cores" to "Contentless Cores". `SET_STANDALONE_EXEMPT` enums etc are too late to change I guess..
