### PR TITLE
C89 Buildfix

### DIFF
--- a/gfx/drivers_shader/slang_reflection.cpp
+++ b/gfx/drivers_shader/slang_reflection.cpp
@@ -336,7 +336,7 @@ static bool add_active_buffer_ranges(
       }
       else
       {
-         // TODO - Try to print name
+         /* TODO - Try to print name */
          RARCH_ERR("[slang]: Unknown semantic found.\n");
          return false;
       }

--- a/gfx/video_shader_parse.c
+++ b/gfx/video_shader_parse.c
@@ -1906,12 +1906,12 @@ bool video_shader_write_preset(const char *path,
    /* We need to clean up paths to be able to properly process them
     * path and shader->loaded_preset_path can use '/' on 
     * Windows due to Qt being Qt */
-   // char preset_dir[PATH_MAX_LENGTH];
+   /* char preset_dir[PATH_MAX_LENGTH]; */
 
    if (!shader || string_is_empty(path))
       return false;
 
-   // fill_pathname_join(preset_dir, shader_dir, "presets", sizeof(preset_dir));
+   /* fill_pathname_join(preset_dir, shader_dir, "presets", sizeof(preset_dir)); */
 
    /* If we should still save a referenced preset do it now */
    if (reference)

--- a/gfx/video_shader_parse.h
+++ b/gfx/video_shader_parse.h
@@ -262,10 +262,12 @@ void video_shader_dir_free_shader(
       struct rarch_dir_shader_list *dir_list,
       bool shader_remember_last_dir);
 
-// void video_shader_dir_init_shader(
-//       void *menu_driver_data_,
-//       settings_t *settings,
-//       struct rarch_dir_shader_list *dir_list);
+/**
+ * void video_shader_dir_init_shader(
+ *        void *menu_driver_data_,
+ *        settings_t *settings,
+ *        struct rarch_dir_shader_list *dir_list);
+ **/
 
 /**
  * video_shader_dir_check_shader:

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -7406,11 +7406,11 @@ bool menu_shader_manager_append_preset(struct video_shader *shader,
    bool ret = false;
    settings_t* settings = config_get_ptr();
    const char *dir_video_shader  = settings->paths.directory_video_shader;
-   //struct video_shader* shader = menu_shader_get();
+   /*struct video_shader* shader = menu_shader_get();*/
    enum rarch_shader_type type = menu_shader_manager_get_type(shader);
 
-   //if (!video_shader_apply_shader(settings, type, preset_path, true))
-   //   goto clear;
+   /*if (!video_shader_apply_shader(settings, type, preset_path, true))
+      goto clear;*/
 
    if (string_is_empty(preset_path))
    {


### PR DESCRIPTION
## Description

PR #14757 Broke the C89 builds since it used the C++ method of commenting lines in some files, which is incompatible with the C89 standard. This PR changes those lines to the method that is accepted by the standard.
