### PR TITLE
Remove () from language names in intl/progress.h

### DIFF
--- a/intl/fetch_progress.py
+++ b/intl/fetch_progress.py
@@ -18,7 +18,8 @@ with open("crowdin.yaml", 'r') as config_file:
       lang_name = res2.json()['data']['name']
    
       output += '/* ' + lang_name + ' */\n'
-      escaped_name = lang_name.replace(', ', '_').replace(' ', '_').upper()
+      replacements = lang_name.maketrans(' ', '_', ',()')
+      escaped_name = lang_name.translate(replacements).upper()
       output += '#define LANGUAGE_PROGRESS_' + escaped_name + '_TRANSLATED ' + str(lang['data']['translationProgress']) + '\n'
       output += '#define LANGUAGE_PROGRESS_' + escaped_name + '_APPROVED   ' + str(lang['data']['approvalProgress']) + '\n\n'
    with open("progress.h", 'w') as output_file:


### PR DESCRIPTION
## Description

More sanitization of language names in progress.h (unused so far), as it was emitting a warning when included.
```
#define LANGUAGE_PROGRESS_SERBIAN_(LATIN)_TRANSLATED 5
->
#define LANGUAGE_PROGRESS_SERBIAN_LATIN_TRANSLATED 5
```
No changes seen for other languages in progress.h.

## Related Issues

Translation completeness display (WIP)