### PR TITLE
Fix menu switch icon correction crash

### DIFF
--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -469,7 +469,8 @@ void menu_entry_get(menu_entry_t *entry, size_t stack_idx,
 
    /* Inspect core options and set entries with only 2 options as
     * boolean for accurate graphical switch icons */
-   if (entry->type >= MENU_SETTINGS_CORE_OPTION_START)
+   if (     entry->type >= MENU_SETTINGS_CORE_OPTION_START
+         && entry->type < MENU_SETTINGS_CHEEVOS_START)
    {
       struct core_option *option      = NULL;
       core_option_manager_t *coreopts = NULL;


### PR DESCRIPTION
## Description

Stupid me didn't take into account that after core option types there will be achievements and netplay settings, so we have to limit core option inspection to core options only..

## Related Issues

Closes #14772

## Related Pull Requests

#14766