### PR TITLE
Fix system info autoconf device list

### DIFF
--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -11399,11 +11399,11 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_PORT_DEVICE_NAME,
-   "Port %d device name: %s (#%d)"
+   "Port %d Device Name: %s (#%d)"
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_PORT_DEVICE_INFO,
-   "Device display name: %s\nDevice config name: %s\nDevice VID/PID: %d/%d"
+   "Device Display Name: %s\nDevice Config Name: %s\nDevice VID/PID: %d/%d"
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_CHEAT_SETTINGS,

--- a/menu/cbs/menu_cbs_sublabel.c
+++ b/menu/cbs/menu_cbs_sublabel.c
@@ -1239,7 +1239,7 @@ static int action_bind_sublabel_systeminfo_controller_entry(
       {
             snprintf(tmp, sizeof(tmp),
                val_port_dev_name,
-               controller,
+               controller + 1,
                input_config_get_device_name(controller),
                input_config_get_device_name_index(controller));
 

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -1788,7 +1788,7 @@ static unsigned menu_displaylist_parse_system_info(file_list_t *list)
       {
          snprintf(tmp, sizeof(tmp),
             msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PORT_DEVICE_NAME),
-            controller+1,
+            controller + 1,
             input_config_get_device_name(controller),
             input_config_get_device_name_index(controller));
 
@@ -1800,7 +1800,7 @@ static unsigned menu_displaylist_parse_system_info(file_list_t *list)
 #ifdef HAVE_RGUI
          if (string_is_equal(menu_driver, "rgui"))
          {
-            strlcpy(tmp, "- Device display name: ", sizeof(tmp));
+            strlcpy(tmp, "- Device Display Name: ", sizeof(tmp));
             strlcat(tmp,
                input_config_get_device_display_name(controller) ?
                input_config_get_device_display_name(controller) :
@@ -1810,7 +1810,7 @@ static unsigned menu_displaylist_parse_system_info(file_list_t *list)
                MENU_ENUM_LABEL_SYSTEM_INFO_CONTROLLER_ENTRY,
                MENU_SETTINGS_CORE_INFO_NONE, 0, 0, NULL))
                count++;
-            strlcpy(tmp, "- Device config name: ", sizeof(tmp));
+            strlcpy(tmp, "- Device Config Name: ", sizeof(tmp));
             strlcat(tmp,
                input_config_get_device_config_name(controller) ?
                input_config_get_device_config_name(controller)  :


### PR DESCRIPTION
## Description

The localization PR added `+1` to `controller` in `menu_displaylist_parse_system_info()`, so we also have to do the same for `action_bind_sublabel_systeminfo_controller_entry()` in order to find a match in System Information when not using RGUI.

Also capitalized the strings.

## Related Pull Requests

#14753

