### PR TITLE
Update selected save slot when start with cli --entryslot

### DIFF
--- a/command.c
+++ b/command.c
@@ -1206,7 +1206,7 @@ void command_event_init_cheats(
 }
 #endif
 
-bool command_event_load_entry_state(void)
+bool command_event_load_entry_state(settings_t *settings)
 {
    char entry_state_path[PATH_MAX_LENGTH];
    int entry_path_stats;
@@ -1247,6 +1247,9 @@ bool command_event_load_entry_state(void)
          msg_hash_to_str(MSG_LOADING_ENTRY_STATE_FROM),
          entry_state_path, ret ? "succeeded" : "failed"
          );
+
+   if (ret)
+   configuration_set_int(settings, settings->ints.state_slot, runloop_st->entry_state_slot);
 
    return ret;
 }

--- a/command.h
+++ b/command.h
@@ -391,7 +391,7 @@ void command_event_set_volume(
 void command_event_init_controllers(rarch_system_info_t *info,
       settings_t *settings, unsigned num_active_users);
 
-bool command_event_load_entry_state(void);
+bool command_event_load_entry_state(settings_t *settings);
 
 void command_event_load_auto_state(void);
 

--- a/runloop.c
+++ b/runloop.c
@@ -5359,7 +5359,7 @@ static bool event_init_content(
    if (!cheevos_enable || !cheevos_hardcore_mode_enable)
 #endif
    {
-      if (runloop_st->entry_state_slot && !command_event_load_entry_state())
+      if (runloop_st->entry_state_slot && !command_event_load_entry_state(settings))
          runloop_st->entry_state_slot = 0;
       if (!runloop_st->entry_state_slot && settings->bools.savestate_auto_load)
          command_event_load_auto_state();


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

Update selected save slot when start game with --entryslot number options, This is for not overriding state 0 at the next save

## Related Issues
[
[[[Any issues this pull request may be addressing]](https://github.com/libretro/RetroArch/issues/14780)](https://github.com/libretro/RetroArch/issues/14780)](https://github.com/libretro/RetroArch/issues/14780)


## Reviewers

@asciibeats @jdgleaver 
