### PR TITLE
(Vulkan) Add adaptive vsync support

### DIFF
--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -3074,15 +3074,19 @@ bool vulkan_create_swapchain(gfx_ctx_vulkan_data_t *vk,
    vk->context.swap_interval = swap_interval;
    for (i = 0; i < present_mode_count; i++)
    {
-      if (swap_interval == 0 && present_modes[i] == VK_PRESENT_MODE_IMMEDIATE_KHR)
-      {
-         swapchain_present_mode = VK_PRESENT_MODE_IMMEDIATE_KHR;
-         break;
-      }
-      else if (swap_interval > 0 && present_modes[i] == VK_PRESENT_MODE_MAILBOX_KHR
-            && desired_swapchain_images > 2)
+      /* Special fallthrough default for mailbox for rather getting it
+       * than fifo without vsync when immediate is not available */
+      if (present_modes[i] == VK_PRESENT_MODE_MAILBOX_KHR
+            && (  (swap_interval > 0 && desired_swapchain_images > 2)
+               || (swap_interval < 1 && swapchain_present_mode == VK_PRESENT_MODE_FIFO_KHR))
+            )
       {
          swapchain_present_mode = VK_PRESENT_MODE_MAILBOX_KHR;
+         continue;
+      }
+      else if (swap_interval == 0 && present_modes[i] == VK_PRESENT_MODE_IMMEDIATE_KHR)
+      {
+         swapchain_present_mode = VK_PRESENT_MODE_IMMEDIATE_KHR;
          break;
       }
       else if (swap_interval > 0 && present_modes[i] == VK_PRESENT_MODE_FIFO_KHR)

--- a/gfx/common/vulkan_common.h
+++ b/gfx/common/vulkan_common.h
@@ -134,6 +134,7 @@ typedef struct vulkan_context
    VkPhysicalDeviceProperties gpu_properties;
    VkPhysicalDeviceMemoryProperties memory_properties;
 
+   VkPresentModeKHR present_modes[16];
    VkImage swapchain_images[VULKAN_MAX_SWAPCHAIN_IMAGES];
    VkFence swapchain_fences[VULKAN_MAX_SWAPCHAIN_IMAGES];
    VkFormat swapchain_format;
@@ -156,9 +157,9 @@ typedef struct vulkan_context
 
    unsigned swapchain_width;
    unsigned swapchain_height;
-   unsigned swap_interval;
    unsigned num_recycled_acquire_semaphores;
 
+   int8_t swap_interval;
    uint8_t flags;
 
    bool swapchain_fences_signalled[VULKAN_MAX_SWAPCHAIN_IMAGES];
@@ -724,7 +725,7 @@ bool vulkan_surface_create(gfx_ctx_vulkan_data_t *vk,
       enum vulkan_wsi_type type,
       void *display, void *surface,
       unsigned width, unsigned height,
-      unsigned swap_interval);
+      int8_t swap_interval);
 
 void vulkan_present(gfx_ctx_vulkan_data_t *vk, unsigned index);
 
@@ -732,7 +733,7 @@ void vulkan_acquire_next_image(gfx_ctx_vulkan_data_t *vk);
 
 bool vulkan_create_swapchain(gfx_ctx_vulkan_data_t *vk,
       unsigned width, unsigned height,
-      unsigned swap_interval);
+      int8_t swap_interval);
 
 void vulkan_set_uniform_buffer(
       VkDevice device,

--- a/gfx/drivers_context/w_vk_ctx.c
+++ b/gfx/drivers_context/w_vk_ctx.c
@@ -330,10 +330,24 @@ static void *gfx_ctx_w_vk_get_context_data(void *data) { return &win32_vk.contex
 
 static uint32_t gfx_ctx_w_vk_get_flags(void *data)
 {
-   uint32_t flags = 0;
+   uint32_t flags             = 0;
+   uint8_t present_mode_count = 16;
+   uint8_t i                  = 0;
+
+   /* Check for FIFO_RELAXED_KHR capability */
+   for (i = 0; i < present_mode_count; i++)
+   {
+      if (win32_vk.context.present_modes[i] == VK_PRESENT_MODE_FIFO_RELAXED_KHR)
+      {
+         BIT32_SET(flags, GFX_CTX_FLAGS_ADAPTIVE_VSYNC);
+         break;
+      }
+   }
+
 #if defined(HAVE_SLANG) && defined(HAVE_SPIRV_CROSS)
    BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_SLANG);
 #endif
+
    return flags;
 }
 

--- a/gfx/drivers_context/x_vk_ctx.c
+++ b/gfx/drivers_context/x_vk_ctx.c
@@ -541,8 +541,20 @@ static void *gfx_ctx_x_vk_get_context_data(void *data)
 
 static uint32_t gfx_ctx_x_vk_get_flags(void *data)
 {
-   uint32_t         flags = 0;
-   gfx_ctx_x_vk_data_t *x = (gfx_ctx_x_vk_data_t*)data;
+   gfx_ctx_x_vk_data_t *x     = (gfx_ctx_x_vk_data_t*)data;
+   uint32_t flags             = 0;
+   uint8_t present_mode_count = 16;
+   uint8_t i                  = 0;
+
+   /* Check for FIFO_RELAXED_KHR capability */
+   for (i = 0; i < present_mode_count; i++)
+   {
+      if (x->vk.context.present_modes[i] == VK_PRESENT_MODE_FIFO_RELAXED_KHR)
+      {
+         BIT32_SET(flags, GFX_CTX_FLAGS_ADAPTIVE_VSYNC);
+         break;
+      }
+   }
 
 #if defined(HAVE_SLANG) && defined(HAVE_SPIRV_CROSS)
    BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_SLANG);


### PR DESCRIPTION
## Description

Added the ability to use `VK_PRESENT_MODE_FIFO_RELAXED_KHR` presentation mode, which is basically adaptive vsync like in gl. So when available it sets the same existing flag (only for Windows & X) which shows the same option.

Also made sure that vsync off rather uses `VK_PRESENT_MODE_IMMEDIATE_KHR` which causes similar tearing as other drivers, and not `VK_PRESENT_MODE_MAILBOX_KHR` which causes stutter.

Also enabled some useful logging to debug level without having `VULKAN_DEBUG` defined, such as which presentation modes are available and in use, and in readable text form rather than magic number.

```
[DEBUG] [Vulkan]: Swapchain supports present mode: FIFO_KHR.
[DEBUG] [Vulkan]: Swapchain supports present mode: FIFO_RELAXED_KHR.
[DEBUG] [Vulkan]: Swapchain supports present mode: MAILBOX_KHR.
[DEBUG] [Vulkan]: Swapchain supports present mode: IMMEDIATE_KHR.
[DEBUG] [Vulkan]: Creating swapchain with present mode: FIFO_KHR.
```

Unfortunately with `FIFO_RELAXED_KHR` the screen flashes when fast-forward is toggled, and `IMMEDIATE_KHR` flashes when menu is toggled, but hopefully those can be sorted later.

I was able to test it a little also under Linux VM, but the results weren't too good since `FIFO_RELAXED_KHR` was not available, and neither was `IMMEDIATE_KHR`, and the present modes were presented in reverse order compared to Windows, so we might have to insert some finer logic than the current one to decide which mode should be preferred.

I at least added the requirement of Max Swapchains set to more than 2 (even if it does not come to fruition) for allowing `MAILBOX_KHR` when it comes before `FIFO_KHR`. The above log snippet is from Windows, and the order is 2-3-1-0, and in Linux it was 1-2. So perhaps we should process them always in sorted order instead of offered order.

No idea why 16 was/is the maximum count for presentation modes even if there won't be that many..

Please test with proper Linux and debug log level enabled!