### PR TITLE
Fixed gfx scissoring on D3D drivers

### DIFF
--- a/gfx/drivers_display/gfx_display_d3d10.c
+++ b/gfx/drivers_display/gfx_display_d3d10.c
@@ -249,7 +249,7 @@ void gfx_display_d3d10_scissor_begin(void *data,
    D3D10_RECT rect;
    d3d10_video_t *d3d10 = (d3d10_video_t*)data;
 
-   if (!d3d10 || !width || !height)
+   if (!d3d10)
       return;
 
    rect.left            = x;

--- a/gfx/drivers_display/gfx_display_d3d11.c
+++ b/gfx/drivers_display/gfx_display_d3d11.c
@@ -279,7 +279,7 @@ void gfx_display_d3d11_scissor_begin(void *data,
    D3D11_RECT rect;
    d3d11_video_t *d3d11 = (d3d11_video_t*)data;
 
-   if (!d3d11 || !width || !height)
+   if (!d3d11)
       return;
 
    rect.left            = x;

--- a/gfx/drivers_display/gfx_display_d3d12.c
+++ b/gfx/drivers_display/gfx_display_d3d12.c
@@ -254,7 +254,7 @@ void gfx_display_d3d12_scissor_begin(void *data,
    D3D12_RECT rect;
    d3d12_video_t *d3d12 = (d3d12_video_t*)data;
 
-   if (!d3d12 || !width || !height)
+   if (!d3d12)
       return;
 
    rect.left            = x;

--- a/gfx/drivers_display/gfx_display_d3d9cg.c
+++ b/gfx/drivers_display/gfx_display_d3d9cg.c
@@ -272,7 +272,7 @@ void gfx_display_d3d9_cg_scissor_begin(
    RECT rect;
    d3d9_video_t *d3d9 = (d3d9_video_t*)data;
 
-   if (!d3d9 || !width || !height)
+   if (!d3d9)
       return;
 
    rect.left          = x;

--- a/gfx/drivers_display/gfx_display_d3d9hlsl.c
+++ b/gfx/drivers_display/gfx_display_d3d9hlsl.c
@@ -279,7 +279,7 @@ void gfx_display_d3d9_hlsl_scissor_begin(
    RECT rect;
    d3d9_video_t *d3d9 = (d3d9_video_t*)data;
 
-   if (!d3d9 || !width || !height)
+   if (!d3d9)
       return;
 
    rect.left          = x;


### PR DESCRIPTION
Zero width/height is valid, just means that it won't draw anything between those begin/end calls

Fix for https://github.com/libretro/RetroArch/issues/14786