### PR TITLE
Fix for fullscreen GL driver in Metal OSX build

### DIFF
--- a/gfx/drivers_context/cocoa_gl_ctx.m
+++ b/gfx/drivers_context/cocoa_gl_ctx.m
@@ -420,6 +420,9 @@ static bool cocoa_gl_gfx_ctx_set_video_mode(void *data,
       if (!has_went_fullscreen)
       {
          [g_view enterFullScreenMode:(BRIDGE NSScreen *)cocoa_screen_get_chosen() withOptions:nil];
+#ifdef HAVE_COCOA_METAL
+         [apple_platform setupMainWindow];
+#endif
          cocoa_show_mouse(data, false);
       }
    }

--- a/ui/drivers/cocoa/apple_platform.h
+++ b/ui/drivers/cocoa/apple_platform.h
@@ -28,6 +28,7 @@
  * the displays should not sleep.
  */
 - (bool)setDisableDisplaySleep:(bool)disable;
+- (void)setupMainWindow;
 @end
 
 #endif

--- a/ui/drivers/ui_cocoa.m
+++ b/ui/drivers/ui_cocoa.m
@@ -565,8 +565,7 @@ static ui_application_t ui_application_cocoa = {
    waiting_argc = 0;
 
 #ifdef HAVE_COCOA_METAL
-   [self.window makeMainWindow];
-   [self.window makeKeyWindow];
+   [self setupMainWindow];
 #endif
 
    [self performSelectorOnMainThread:@selector(rarch_main) withObject:nil waitUntilDone:NO];
@@ -575,6 +574,12 @@ static ui_application_t ui_application_cocoa = {
 #pragma mark - ApplePlatform
 
 #ifdef HAVE_COCOA_METAL
+- (void)setupMainWindow
+{
+   [self.window makeMainWindow];
+   [self.window makeKeyWindow];
+}
+
 - (void)setViewType:(apple_view_type_t)vt
 {
    if (vt == _vt)


### PR DESCRIPTION
After calling enterFullScreenMode on the GL view, it becomes the "key" window, meaning it gets all of the input. This is problematic as that view doesn't forward the input on to the input driver.