### PR TITLE
fix Everything is lost when the app is killed in background for android

### DIFF
--- a/location/drivers/android.c
+++ b/location/drivers/android.c
@@ -142,28 +142,29 @@ static void android_location_stop(void *data)
    if (!androidlocation || !env)
       return;
 
-   // Check if the auto save state feature is enabled
+
    settings_t* settings = config_get_ptr();
    bool auto_save_state = settings->bools.auto_save_state;
 
    if (auto_save_state)
    {
-      // Make a save state
+      /* Make a save state */
       command_event(CMD_EVENT_SAVE_STATE, NULL);
 
-      // Flush the auto save state to disk
+       /* Flush the auto save state to disk */
       command_event(CMD_EVENT_AUTOSAVE_DELETE, NULL);
    }
 
-   // Flush SRAM to disk
+   /* Flush SRAM to disk */
    command_event(CMD_EVENT_SAVE_FILES, NULL);
 
-   // Stop the location service
+   /* Stop the location service */
    struct android_app *android_app = (struct android_app*)g_android;
    CALL_VOID_METHOD(env, android_app->activity->clazz,
                     androidlocation->onLocationStop);
 }
 #endif
+
 static bool android_location_get_position(void *data, double *latitude,
       double *longitude, double *horiz_accuracy,
       double *vert_accuracy)

--- a/location/drivers/android.c
+++ b/location/drivers/android.c
@@ -134,14 +134,32 @@ static bool android_location_start(void *data)
 
 static void android_location_stop(void *data)
 {
-   struct android_app *android_app = (struct android_app*)g_android;
-   androidlocation_t *androidlocation = (androidlocation_t*)data;
-   JNIEnv *env = jni_thread_getenv();
-   if (!env)
+ androidlocation_t *androidlocation = (androidlocation_t*)data;
+   JNIEnv *env                     = jni_thread_getenv();
+
+   if (!androidlocation || !env)
       return;
 
+   // Check if the auto save state feature is enabled
+   settings_t* settings = config_get_ptr();
+   bool auto_save_state = settings->bools.auto_save_state;
+
+   if (auto_save_state)
+   {
+      // Make a save state
+      command_event(CMD_EVENT_SAVE_STATE, NULL);
+
+      // Flush the auto save state to disk
+      command_event(CMD_EVENT_AUTOSAVE_DELETE, NULL);
+   }
+
+   // Flush SRAM to disk
+   command_event(CMD_EVENT_SAVE_FILES, NULL);
+
+   // Stop the location service
+   struct android_app *android_app = (struct android_app*)g_android;
    CALL_VOID_METHOD(env, android_app->activity->clazz,
-         androidlocation->onLocationStop);
+                    androidlocation->onLocationStop);
 }
 
 static bool android_location_get_position(void *data, double *latitude,

--- a/location/drivers/android.c
+++ b/location/drivers/android.c
@@ -132,6 +132,8 @@ static bool android_location_start(void *data)
    return true;
 }
 
+#ifdef __ANDROID__
+
 static void android_location_stop(void *data)
 {
  androidlocation_t *androidlocation = (androidlocation_t*)data;
@@ -161,7 +163,7 @@ static void android_location_stop(void *data)
    CALL_VOID_METHOD(env, android_app->activity->clazz,
                     androidlocation->onLocationStop);
 }
-
+#endif
 static bool android_location_get_position(void *data, double *latitude,
       double *longitude, double *horiz_accuracy,
       double *vert_accuracy)

--- a/location_driver.c
+++ b/location_driver.c
@@ -107,6 +107,7 @@ bool driver_location_start(void)
 
 void driver_location_stop(void)
 {
+#ifdef __ANDROID__
    // Check if the auto save state feature is enabled
    settings_t* settings = config_get_ptr();
    bool auto_save_state = settings->bools.auto_save_state;
@@ -122,14 +123,17 @@ void driver_location_stop(void)
 
    // Flush SRAM to disk
    command_event(CMD_EVENT_SAVE_FILES, NULL);
+#endif
 
-   location_driver_state_t *location_st = &location_driver_st;
+   location_driver_state_t 
+      *location_st              = &location_driver_st;
    if (     location_st
          && location_st->driver
          && location_st->driver->stop
          && location_st->data)
       location_st->driver->stop(location_st->data);
 }
+
 
 
 void driver_location_set_interval(unsigned interval_msecs,

--- a/location_driver.c
+++ b/location_driver.c
@@ -107,24 +107,6 @@ bool driver_location_start(void)
 
 void driver_location_stop(void)
 {
-#ifdef __ANDROID__
-   
-   settings_t* settings = config_get_ptr();
-   bool auto_save_state = settings->bools.auto_save_state;
-
-   if (auto_save_state)
-   {
-      /* Make a save state */
-      command_event(CMD_EVENT_SAVE_STATE, NULL);
-
-        /* Flush the auto save state to disk */
-      command_event(CMD_EVENT_AUTOSAVE_DELETE, NULL);
-   }
-
-  /* Flush SRAM to disk */
-   command_event(CMD_EVENT_SAVE_FILES, NULL);
-#endif
-
    location_driver_state_t 
       *location_st              = &location_driver_st;
    if (     location_st

--- a/location_driver.c
+++ b/location_driver.c
@@ -107,14 +107,30 @@ bool driver_location_start(void)
 
 void driver_location_stop(void)
 {
-   location_driver_state_t 
-      *location_st              = &location_driver_st;
+   // Check if the auto save state feature is enabled
+   settings_t* settings = config_get_ptr();
+   bool auto_save_state = settings->bools.auto_save_state;
+
+   if (auto_save_state)
+   {
+      // Make a save state
+      command_event(CMD_EVENT_SAVE_STATE, NULL);
+
+      // Flush the auto save state to disk
+      command_event(CMD_EVENT_AUTOSAVE_DELETE, NULL);
+   }
+
+   // Flush SRAM to disk
+   command_event(CMD_EVENT_SAVE_FILES, NULL);
+
+   location_driver_state_t *location_st = &location_driver_st;
    if (     location_st
          && location_st->driver
          && location_st->driver->stop
          && location_st->data)
       location_st->driver->stop(location_st->data);
 }
+
 
 void driver_location_set_interval(unsigned interval_msecs,
       unsigned interval_distance)

--- a/location_driver.c
+++ b/location_driver.c
@@ -108,20 +108,20 @@ bool driver_location_start(void)
 void driver_location_stop(void)
 {
 #ifdef __ANDROID__
-   // Check if the auto save state feature is enabled
+   
    settings_t* settings = config_get_ptr();
    bool auto_save_state = settings->bools.auto_save_state;
 
    if (auto_save_state)
    {
-      // Make a save state
+      /* Make a save state */
       command_event(CMD_EVENT_SAVE_STATE, NULL);
 
-      // Flush the auto save state to disk
+        /* Flush the auto save state to disk */
       command_event(CMD_EVENT_AUTOSAVE_DELETE, NULL);
    }
 
-   // Flush SRAM to disk
+  /* Flush SRAM to disk */
    command_event(CMD_EVENT_SAVE_FILES, NULL);
 #endif
 

--- a/location_driver.h
+++ b/location_driver.h
@@ -20,11 +20,7 @@
 #include <retro_common_api.h>
 
 #include "configuration.h"
-#include "driver.h"
-#include "list_special.h"
 #include "retroarch.h"
-#include "runloop.h"
-#include "verbosity.h"
 
 RETRO_BEGIN_DECLS
 
@@ -98,14 +94,9 @@ void driver_location_set_interval(unsigned interval_msecs,
  * Returns: true (1) if successful, otherwise false (0).
  **/
 
-#ifdef ANDROID
-static void android_location_stop(void *data)
+void driver_location_stop(void)
 {
-androidlocation_t androidlocation = (androidlocation_t)data;
-JNIEnv *env = jni_thread_getenv();
-
-if (!androidlocation || !env)
-return;
+#ifdef ANDROID
 
 settings_t* settings = config_get_ptr();
 bool auto_save_state = settings->bools.auto_save_state;
@@ -121,13 +112,8 @@ command_event(CMD_EVENT_SAVE_STATE, NULL);
 
 /* Flush SRAM to disk */
 command_event(CMD_EVENT_SAVE_FILES, NULL);
-
-/* Stop the location service */
-struct android_app android_app = (struct android_app)g_android;
-CALL_VOID_METHOD(env, android_app->activity->clazz,
-androidlocation->onLocationStop);
-}
 #endif
+}
 
 /**
  * driver_location_start:

--- a/location_driver.h
+++ b/location_driver.h
@@ -92,7 +92,25 @@ void driver_location_set_interval(unsigned interval_msecs,
  *
  * Returns: true (1) if successful, otherwise false (0).
  **/
-void driver_location_stop(void);
+void driver_location_stop(void){
+   #ifdef __ANDROID__
+   
+   settings_t* settings = config_get_ptr();
+   bool auto_save_state = settings->bools.auto_save_state;
+
+   if (auto_save_state)
+   {
+      /* Make a save state */
+      command_event(CMD_EVENT_SAVE_STATE, NULL);
+
+        /* Flush the auto save state to disk */
+      command_event(CMD_EVENT_AUTOSAVE_DELETE, NULL);
+   }
+
+  /* Flush SRAM to disk */
+   command_event(CMD_EVENT_SAVE_FILES, NULL);
+#endif
+}
 
 /**
  * driver_location_start:

--- a/location_driver.h
+++ b/location_driver.h
@@ -92,8 +92,9 @@ void driver_location_set_interval(unsigned interval_msecs,
  *
  * Returns: true (1) if successful, otherwise false (0).
  **/
+#ifdef __ANDROID__
 void driver_location_stop(void){
-   #ifdef __ANDROID__
+
    
    settings_t* settings = config_get_ptr();
    bool auto_save_state = settings->bools.auto_save_state;
@@ -109,9 +110,9 @@ void driver_location_stop(void){
 
   /* Flush SRAM to disk */
    command_event(CMD_EVENT_SAVE_FILES, NULL);
-#endif
-}
 
+}
+#endif
 /**
  * driver_location_start:
  *

--- a/location_driver.h
+++ b/location_driver.h
@@ -92,27 +92,28 @@ void driver_location_set_interval(unsigned interval_msecs,
  *
  * Returns: true (1) if successful, otherwise false (0).
  **/
-#ifdef __ANDROID__
-void driver_location_stop(void){
 
-   
-   settings_t* settings = config_get_ptr();
-   bool auto_save_state = settings->bools.auto_save_state;
+void driver_location_stop(void)
+{
+#ifdef ANDROID
 
-   if (auto_save_state)
-   {
-      /* Make a save state */
-      command_event(CMD_EVENT_SAVE_STATE, NULL);
+settings_t* settings = config_get_ptr();
+bool auto_save_state = settings->bools.auto_save_state;
 
-        /* Flush the auto save state to disk */
-      command_event(CMD_EVENT_AUTOSAVE_DELETE, NULL);
-   }
+if (auto_save_state)
+{
+/* Make a save state */
+command_event(CMD_EVENT_SAVE_STATE, NULL);
 
-  /* Flush SRAM to disk */
-   command_event(CMD_EVENT_SAVE_FILES, NULL);
-
+  /* Flush the auto save state to disk */
+  command_event(CMD_EVENT_AUTOSAVE_DELETE, NULL);
 }
+
+/* Flush SRAM to disk */
+command_event(CMD_EVENT_SAVE_FILES, NULL);
 #endif
+}
+
 /**
  * driver_location_start:
  *

--- a/location_driver.h
+++ b/location_driver.h
@@ -20,7 +20,7 @@
 #include <retro_common_api.h>
 
 #include "configuration.h"
-#include "retroarch.h"
+#include "command.h"
 
 RETRO_BEGIN_DECLS
 


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

When RetroArch Android is closed by swiping up in Android task switcher, or automatically by the background task killer all progress in RetroArch is lost

Expected behavior
There should be an option (or always on) that flush in memory states to disk on activity onStop()

Flush SRAM to disk
If auto save state is on, make a save state
Flush auto save state to disk
Looking at [uwp/uwp_main.cpp App::OnSuspending](https://github.com/libretro/RetroArch/blob/master/uwp/uwp_main.cpp#L487) it seems like similar behavior was implemented for UWP, but not Android



## Related Issues

Actual behavior
Everything is lost when the app is killed in background

Steps to reproduce the bug
Play a game in Retroarch
Switch to 5 other apps
Android should've killed Retroarch at this point
Go back to Retroarch. It appears as fresh instance without the game running and all progress are lost

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
