### PR TITLE
On Metal OSX build, with GL cores, fix fullscreening redisplay

### DIFF
--- a/gfx/drivers_context/cocoa_gl_ctx.m
+++ b/gfx/drivers_context/cocoa_gl_ctx.m
@@ -414,15 +414,21 @@ static bool cocoa_gl_gfx_ctx_set_video_mode(void *data,
    [EAGLContext setCurrentContext:g_ctx];
 #endif
 
+#ifdef HAVE_COCOA_METAL
+   gfx_ctx_mode_t mode = {
+      .width = width,
+      .height = height,
+      .fullscreen = fullscreen,
+   };
+   [apple_platform setVideoMode:mode];
+   cocoa_show_mouse(data, !fullscreen);
+#else
    /* TODO/FIXME: Screen mode support. */
    if (fullscreen)
    {
       if (!has_went_fullscreen)
       {
          [g_view enterFullScreenMode:(BRIDGE NSScreen *)cocoa_screen_get_chosen() withOptions:nil];
-#ifdef HAVE_COCOA_METAL
-         [apple_platform setupMainWindow];
-#endif
          cocoa_show_mouse(data, false);
       }
    }
@@ -437,6 +443,7 @@ static bool cocoa_gl_gfx_ctx_set_video_mode(void *data,
 
       [[g_view window] setContentSize:NSMakeSize(width, height)];
    }
+#endif
 
    has_went_fullscreen = fullscreen;
 

--- a/pkg/apple/RetroArch_Metal.xcodeproj/project.pbxproj
+++ b/pkg/apple/RetroArch_Metal.xcodeproj/project.pbxproj
@@ -1729,6 +1729,7 @@
 					"$(inherited)",
 					"-DHAVE_MAIN",
 					"-DHAVE_COCOA_METAL",
+					"-DHAVE_OPENGL_CORE",
 				);
 				OTHER_CODE_SIGN_FLAGS = "--deep --timestamp";
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
@@ -1758,6 +1759,7 @@
 					"$(inherited)",
 					"-DHAVE_MAIN",
 					"-DHAVE_COCOA_METAL",
+					"-DHAVE_OPENGL_CORE",
 				);
 				OTHER_CODE_SIGN_FLAGS = "--deep --timestamp";
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";


### PR DESCRIPTION
The Metal window wants to manage fullscreen mode itself directly. This also avoids the issue of the GL view trying to steal keyboard focus when it becomes full screened.

Also turn on HAVE_OPENGL_CORE for Metal builds.