### PR TITLE
fix minor scrolling sound issues

### DIFF
--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -8055,8 +8055,13 @@ static enum menu_action ozone_parse_menu_entry_action(
          if (ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR)
          {
             /* Go back to main menu tab */
-            if (ozone->categories_selection_ptr != 0)
+            if (ozone->categories_selection_ptr != 0) 
+            {
                ozone_sidebar_goto(ozone, 0);
+#ifdef HAVE_AUDIOMIXER
+               audio_driver_mixer_play_scroll_sound(true);
+#endif
+            }
 
             new_action = MENU_ACTION_ACCESSIBILITY_SPEAK_TITLE;
             break;

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -4494,11 +4494,12 @@ static enum menu_action xmb_parse_menu_entry_action(
             {
                settings_t *settings = config_get_ptr();
                size_t category      = xmb->categories_selection_ptr;
+               size_t list_size     = xmb_list_get_size(xmb, MENU_LIST_HORIZONTAL) + xmb->system_tab_end;
                /* We only want the scrolling sound to play if any of the following are true:
                   * 1. Wraparound is enabled (since the category is guaranteed to change) 
                   * 2. We're scrolling right, but we aren't on the last category
                   * 3. We're scrolling left, but we aren't on the first category */
-               bool fail_condition  = ((action == MENU_ACTION_RIGHT) ? (category == xmb->system_tab_end) 
+               bool fail_condition  = ((action == MENU_ACTION_RIGHT) ? (category == list_size) 
                   : (category == 0)) && !(settings->bools.menu_navigation_wraparound_enable);
             
                if (((current_time - xmb->last_tab_switch_time) >= XMB_TAB_SWITCH_REPEAT_DELAY || 

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -8004,7 +8004,7 @@ int generic_menu_entry_action(
                unsigned scroll_speed  = (unsigned)((MAX(scroll_accel, 2) - 2) / 4 + 10);
 #ifdef HAVE_AUDIOMIXER
                if (menu_st->selection_ptr != 0)
-                  audio_driver_mixer_play_scroll_sound(false);
+                  audio_driver_mixer_play_scroll_sound(true);
 #endif
                if (!(menu_st->selection_ptr == 0 && !wraparound_enable))
                {
@@ -8024,6 +8024,7 @@ int generic_menu_entry_action(
          }
          else /* MENU_SCROLL_START_LETTER */
          {
+            size_t selection_old = menu_st->selection_ptr;
             if (
                      menu_st->scroll.index_size
                   && menu_st->selection_ptr != 0
@@ -8043,6 +8044,10 @@ int generic_menu_entry_action(
                   menu_driver_ctx->navigation_descend_alphabet(
                         menu_userdata, &menu_st->selection_ptr);
             }
+#ifdef HAVE_AUDIOMIXER
+            if (menu_st->selection_ptr != selection_old)
+               audio_driver_mixer_play_scroll_sound(true);
+#endif
          }
          break;
       case MENU_ACTION_SCROLL_DOWN:
@@ -8077,6 +8082,7 @@ int generic_menu_entry_action(
          {
             if (menu_st->scroll.index_size)
             {
+               size_t selection_old = menu_st->selection_ptr;
                if (menu_st->selection_ptr == menu_st->scroll.index_list[menu_st->scroll.index_size - 1])
                   menu_st->selection_ptr = selection_buf_size - 1;
                else
@@ -8094,6 +8100,10 @@ int generic_menu_entry_action(
                if (menu_driver_ctx->navigation_ascend_alphabet)
                   menu_driver_ctx->navigation_ascend_alphabet(
                         menu_userdata, &menu_st->selection_ptr);
+#ifdef HAVE_AUDIOMIXER
+               if (menu_st->selection_ptr != selection_old)
+                  audio_driver_mixer_play_scroll_sound(false);
+#endif
             }
          }
          break;


### PR DESCRIPTION
## Description
Sorry, I messed a few things up with https://github.com/libretro/RetroArch/pull/14816. 
Here's what's fixed:

1. XMB will now get the horizontal list size correctly for playing the scrolling sounds
2. Pressing cancel while in the Ozone sidebar will correctly play the up scrolling sound
3. Pressing ZL or ZR will play the scrolling sounds and pressing L will play the scrolling sound in the correct direction (up).

I thoroughly tested it this time on all the menu drivers.