### PR TITLE
Report error when core download failed

### DIFF
--- a/tasks/task_core_updater.c
+++ b/tasks/task_core_updater.c
@@ -77,6 +77,7 @@ enum core_updater_download_status
    CORE_UPDATER_DOWNLOAD_START_TRANSFER,
    CORE_UPDATER_DOWNLOAD_WAIT_TRANSFER,
    CORE_UPDATER_DOWNLOAD_WAIT_DECOMPRESS,
+   CORE_UPDATER_DOWNLOAD_ERROR,
    CORE_UPDATER_DOWNLOAD_END
 };
 
@@ -633,9 +634,11 @@ void cb_http_task_core_updater_download(
 finish:
    /* Log any error messages */
    if (!string_is_empty(err))
+   {
       RARCH_ERR("[core updater] Download of '%s' failed: %s\n",
             (transf ? transf->path: "unknown"), err);
-
+      download_handle->status = CORE_UPDATER_DOWNLOAD_ERROR;
+   }
    if (transf)
       free(transf);
 
@@ -921,6 +924,21 @@ static void task_core_updater_download_handler(retro_task_t *task)
              * callback to trigger */
             if (download_handle->decompress_task_complete)
                download_handle->status = CORE_UPDATER_DOWNLOAD_END;
+         }
+         break;
+      case CORE_UPDATER_DOWNLOAD_ERROR:
+         {
+            char task_title[PATH_MAX_LENGTH];
+
+            /* Set final task title */
+            task_free_title(task);
+
+            strlcpy(task_title, msg_hash_to_str(MSG_CORE_INSTALL_FAILED), sizeof(task_title));
+            strlcat(task_title, download_handle->display_name, sizeof(task_title));
+
+            task_set_title(task, strdup(task_title));
+            task_set_progress(task, 100);
+            goto task_finished;
          }
          break;
       case CORE_UPDATER_DOWNLOAD_END:


### PR DESCRIPTION
Fix curly bracket opening

## Description

Report error when core download failed when the core directory is not writeable.

![image](https://user-images.githubusercontent.com/7869503/211209481-0fe8563a-120b-4873-b150-3251d5a12507.png)


## Related Issues

Fix #14808

