### PR TITLE
Savestate thumbnail aspect ratio fallback

### DIFF
--- a/gfx/gfx_thumbnail.c
+++ b/gfx/gfx_thumbnail.c
@@ -803,8 +803,9 @@ void gfx_thumbnail_get_draw_dimensions(
    display_aspect   = (float)width            / (float)height;
    thumbnail_aspect = (float)thumbnail->width / (float)thumbnail->height;
    core_aspect      = ((thumbnail->flags & GFX_THUMB_FLAG_CORE_ASPECT) 
-         && video_st)
-         ? video_st->av_info.geometry.aspect_ratio : thumbnail_aspect;
+         && video_st && video_st->av_info.geometry.aspect_ratio > 0)
+               ? video_st->av_info.geometry.aspect_ratio
+               : thumbnail_aspect;
 
    if (thumbnail_aspect > display_aspect)
    {

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -2364,8 +2364,10 @@ static bool rgui_downscale_thumbnail(
    /* Determine output dimensions */
    float display_aspect_ratio    = (float)max_width / (float)max_height;
    float         aspect_ratio    = (float)image_src->width / (float)image_src->height;
-   float core_aspect             = (thumbnail_core_aspect && video_st)
-         ? video_st->av_info.geometry.aspect_ratio : aspect_ratio;
+   float core_aspect             = (thumbnail_core_aspect
+         && video_st && video_st->av_info.geometry.aspect_ratio > 0)
+               ? video_st->av_info.geometry.aspect_ratio
+               : aspect_ratio;
 
    if (aspect_ratio > display_aspect_ratio)
    {


### PR DESCRIPTION
## Description

Thanks to at least one certain core that announces aspect ratio as 0, we have to add the same fallback in savestate thumbnails that is happening elsewhere in normal video driver use anyway.

## Related Issues

Closes #14827