### PR TITLE
Add Run-Ahead data to on-screen statistics

### DIFF
--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -2716,6 +2716,10 @@ void video_driver_build_info(video_frame_info_t *video_info)
    video_info->black_frame_insertion       = settings->uints.video_black_frame_insertion;
    video_info->hard_sync                   = settings->bools.video_hard_sync;
    video_info->hard_sync_frames            = settings->uints.video_hard_sync_frames;
+   video_info->runahead                    = settings->bools.run_ahead_enabled;
+   video_info->runahead_second_instance    = settings->bools.run_ahead_secondary_instance;
+   video_info->preemptive_frames           = settings->bools.preemptive_frames_enable;
+   video_info->runahead_frames             = settings->uints.run_ahead_frames;
    video_info->fps_show                    = settings->bools.video_fps_show;
    video_info->memory_show                 = settings->bools.video_memory_show;
    video_info->statistics_show             = settings->bools.video_statistics_show;
@@ -3999,6 +4003,7 @@ void video_driver_frame(const void *data, unsigned width,
    if (render_frame && video_info.statistics_show)
    {
       audio_statistics_t audio_stats;
+      char runahead_stats[128];
       double stddev                          = 0.0;
       struct retro_system_av_info *av_info   = &video_st->av_info;
       unsigned red                           = 255;
@@ -4027,18 +4032,34 @@ void video_driver_frame(const void *data, unsigned width,
 
       audio_compute_buffer_statistics(&audio_stats);
 
+      runahead_stats[0] = '\0';
+
+      if (video_info.runahead && !video_info.runahead_second_instance)
+         snprintf(runahead_stats, sizeof(runahead_stats),
+                  " -Run-Ahead Mode: Single Instance\n -Latency frames removed: %u\n",
+                  video_info.runahead_frames);
+      else if (video_info.runahead && video_info.runahead_second_instance)
+         snprintf(runahead_stats, sizeof(runahead_stats),
+                  " -Run-Ahead Mode: Second Instance\n -Latency frames removed: %u\n",
+                  video_info.runahead_frames);
+      else if (video_info.preemptive_frames)
+         snprintf(runahead_stats, sizeof(runahead_stats),
+                  " -Run-Ahead Mode: Preemptive Frames\n -Latency frames removed: %u\n",
+                  video_info.runahead_frames);
+
       snprintf(video_info.stat_text,
             sizeof(video_info.stat_text),
             "Video Statistics:\n -Frame rate: %6.2f fps\n -Frame time: %6.2f ms\n -Frame time deviation: %.3f %%\n"
-            " -Frame delay (target/effective): %u/%u ms\n -Frame count: %" PRIu64"\n -Viewport: %d x %d x %3.2f\n"
+            " -Frame count: %" PRIu64"\n -Frame delay (target/effective): %u/%u ms\n%s -Viewport: %d x %d x %3.2f\n"
             "Audio Statistics:\n -Average buffer saturation: %.2f %%\n -Standard deviation: %.2f %%\n -Time spent close to underrun: %.2f %%\n -Time spent close to blocking: %.2f %%\n -Sample count: %d\n"
             "Core Geometry:\n -Size: %u x %u\n -Max Size: %u x %u\n -Aspect: %3.2f\nCore Timing:\n -FPS: %3.2f\n -Sample Rate: %6.2f\n",
             last_fps,
             frame_time / 1000.0f,
             100.0f * stddev,
+            video_st->frame_count,
             video_st->frame_delay_target,
             video_st->frame_delay_effective,
-            video_st->frame_count,
+            runahead_stats,
             video_info.width,
             video_info.height,
             video_info.refresh_rate,

--- a/gfx/video_driver.h
+++ b/gfx/video_driver.h
@@ -402,6 +402,7 @@ typedef struct video_frame_info
    int crt_switch_porch_adjust;
 
    unsigned hard_sync_frames;
+   unsigned runahead_frames;
    unsigned aspect_ratio_idx;
    unsigned max_swapchain_images;
    unsigned monitor_index;
@@ -454,7 +455,7 @@ typedef struct video_frame_info
       bool full_screen;
    } osd_stat_params;
 
-   char stat_text[512];
+   char stat_text[1024];
 
    bool widgets_active;
    bool notifications_hidden;
@@ -466,6 +467,9 @@ typedef struct video_frame_info
    bool input_driver_nonblock_state;
    bool input_driver_grab_mouse_state;
    bool hard_sync;
+   bool runahead;
+   bool runahead_second_instance;
+   bool preemptive_frames;
    bool fps_show;
    bool memory_show;
    bool statistics_show;


### PR DESCRIPTION
## Description

This PR adds data on whichever is the currently active Run-Ahead mode (if any) and the related frame number to the on-screen statistics (Settings -> On-Screen Display -> On-Screen Notifications -> Notification Visibility -> Display Statistics).

- Whenever either the traditional Run-Ahead modes or the newly added "Preemptive Frames" mode are active, two lines of text are added to the statistics interface, showing the mode and the number of latency frames that are being shaved off.

   <img width="447" alt="image" src="https://user-images.githubusercontent.com/17614150/212116875-cf9f042c-431a-49ef-a67f-7fbe4b6e80aa.png">

- If both Run-Ahead and Preemptive Frames are disabled, the new lines will not show up at all.

   <img width="447" alt="image" src="https://user-images.githubusercontent.com/17614150/212117640-df71911a-70e8-4356-bd0d-d884b88cb31c.png">

- I also took the opportunity to move the "frame delay (target/effective)" string below "frame count", so that it sits closer to the Run-Ahead data.