### PR TITLE
Add unified back action to all menu drivers

### DIFF
--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -9353,6 +9353,18 @@ static enum menu_action materialui_parse_menu_entry_action(
                materialui_switch_tabs(mui, main_menu_tab, MENU_ACTION_NOOP);
                new_action = MENU_ACTION_NOOP;
             }
+            else if (main_menu_tab_index == mui->nav_bar.active_menu_tab_index)
+            {
+               /* Jump to first item on Main Menu */
+               menu_navigation_set_selection(0);
+               materialui_navigation_set(mui, true);
+            }
+         }
+         else if (materialui_list_get_size(mui, MENU_LIST_PLAIN) == 1)
+         {
+            /* Jump to first item on current menu */
+            menu_navigation_set_selection(0);
+            materialui_navigation_set(mui, true);
          }
          break;
       default:

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -8062,6 +8062,12 @@ static enum menu_action ozone_parse_menu_entry_action(
                audio_driver_mixer_play_scroll_sound(true);
 #endif
             }
+            else
+            {
+               /* Jump to first item on Main Menu */
+               ozone->tab_selection[ozone->categories_selection_ptr] = 0;
+               menu_navigation_set_selection(0);
+            }
 
             new_action = MENU_ACTION_ACCESSIBILITY_SPEAK_TITLE;
             break;

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -7873,6 +7873,13 @@ static enum menu_action rgui_parse_menu_entry_action(
             rgui_toggle_fs_thumbnail(rgui, config_get_ptr()->bools.menu_rgui_inline_thumbnails);
             new_action = MENU_ACTION_NOOP;
          }
+
+         if (string_is_equal(rgui->menu_title, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_MAIN_MENU)))
+         {
+            /* Jump to first item on Main Menu */
+            menu_navigation_set_selection(0);
+            new_action = MENU_ACTION_NOOP;
+         }
          break;
       case MENU_ACTION_START:
          /* Playlist thumbnail fullscreen toggle */


### PR DESCRIPTION
## Description

Usability boost for all menu drivers resulting in similar behavior as with Ozone currently, which is pressing back/cancel enough the selection jumps first to Main Menu and when pressed again jumps to the first item, so that when a core is running, Quick Menu is very quickly accessible from anywhere. And when core is not running, the first item would be Load Core.

In Ozone it will ultimately forget the tab selection when backing while in the sidebar Main Menu item, and other menus don't have to. Materialui will jump to the first item in all navigation tabs if navigation bar is enabled.

