### PR TITLE
avoid using _PACK16 pixel formats on platforms without them

### DIFF
--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -3030,6 +3030,10 @@ bool vulkan_create_swapchain(gfx_ctx_vulkan_data_t *vk,
             format = formats[i];
             video_driver_set_hdr_support();
          }
+         if (formats[i].format == VK_FORMAT_R5G6B5_UNORM_PACK16)
+         {
+             vk->context.flags |= VK_CTX_FLAG_HAS_PACK16_FMTS;
+         }
       }
 
       if (     (!(vk->context.flags & VK_CTX_FLAG_HDR_ENABLE))

--- a/gfx/common/vulkan_common.h
+++ b/gfx/common/vulkan_common.h
@@ -118,7 +118,8 @@ enum vulkan_context_flags
    /* Used by screenshot to get blits with correct colorspace. */
    VK_CTX_FLAG_SWAPCHAIN_IS_SRGB            = (1 << 2),
    VK_CTX_FLAG_SWAP_INTERVAL_EMULATION_LOCK = (1 << 3),
-   VK_CTX_FLAG_HAS_ACQUIRED_SWAPCHAIN       = (1 << 4)
+   VK_CTX_FLAG_HAS_ACQUIRED_SWAPCHAIN       = (1 << 4),
+   VK_CTX_FLAG_HAS_PACK16_FMTS              = (1 << 5)
 };
 
 typedef struct vulkan_context

--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -1476,8 +1476,12 @@ static void *vulkan_init(const video_info_t *video,
       vk->flags         &= ~VK_FLAG_FULLSCREEN;
    vk->tex_w             = RARCH_SCALE_BASE * video->input_scale;
    vk->tex_h             = RARCH_SCALE_BASE * video->input_scale;
-   vk->tex_fmt           = video->rgb32
-      ? VK_FORMAT_B8G8R8A8_UNORM : VK_FORMAT_R5G6B5_UNORM_PACK16;
+   if (vk->context->flags & VK_CTX_FLAG_HAS_PACK16_FMTS) {
+       vk->tex_fmt           = video->rgb32
+          ? VK_FORMAT_B8G8R8A8_UNORM : VK_FORMAT_R5G6B5_UNORM_PACK16;
+   } else {
+       vk->tex_fmt       = VK_FORMAT_B8G8R8A8_UNORM;
+   }
    if (video->force_aspect)
       vk->flags         |=  VK_FLAG_KEEP_ASPECT;
    else


### PR DESCRIPTION
On some x86 Macs the _PACK16 pixel formats are not supported, and this leads to a crash