### PR TITLE
Fix #14870

### DIFF
--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -5735,16 +5735,6 @@ int16_t input_state_internal(unsigned port, unsigned device,
          result |= port_result;
    }
 
-#ifdef HAVE_BSV_MOVIE
-   /* Save input to BSV record, if enabled */
-   if (BSV_MOVIE_IS_PLAYBACK_OFF())
-   {
-      result = swap_if_big16(result);
-      intfstream_write(
-            input_st->bsv_movie_state_handle->file, &result, 2);
-   }
-#endif
-
    return result;
 }
 

--- a/retroarch.c
+++ b/retroarch.c
@@ -2153,10 +2153,6 @@ bool command_event(enum event_command cmd, void *data)
          {
 #ifdef HAVE_BSV_MOVIE
             input_driver_state_t *input_st = input_state_get_ptr();
-            if (!recording_st->enable)
-               command_event(CMD_EVENT_RECORD_INIT, NULL);
-            else
-               command_event(CMD_EVENT_RECORD_DEINIT, NULL);
             bsv_movie_check(input_st, settings);
 #endif
          }


### PR DESCRIPTION
## Description

This seems to fix two key issues for #14870 , namely that input recording seems to double-record inputs (or records an input and then an empty input) and that video recording should not always be toggled to the same state as BSV recording. 

## Issues

There are two main problems I want feedback on before this PR is ready to merge.

1. Save-state autoloading should not happen if BSV replay is happening.  I have code that I think should do this, but it doesn't seem to work and I need to explore it more deeply.
2. I'm not sure that my solution to avoid double-recording inputs is correct. I don't really understand the `input_state_device` or analog input paths, so I think this might only function properly for inputs coming through `input_driver_state_wrapper`.  So I'd love to have the perspective of that code's owner.