### PR TITLE
Don't autoload states if a BSV file is being played back or recorded

### DIFF
--- a/runloop.c
+++ b/runloop.c
@@ -4053,6 +4053,16 @@ static bool event_init_content(
       RARCH_LOG("[SRAM]: %s\n",
             msg_hash_to_str(MSG_SKIPPING_SRAM_LOAD));
 
+#ifdef HAVE_BSV_MOVIE
+   bsv_movie_deinit(input_st);
+   if (bsv_movie_init(input_st))
+   {
+      /* Set granularity upon success */
+      configuration_set_uint(settings,
+            settings->uints.rewind_granularity, 1);
+   }
+#endif
+
 /*
    Since the operations are asynchronous we can't
    guarantee users will not use auto_load_state to cheat on
@@ -4063,6 +4073,9 @@ static bool event_init_content(
 #ifdef HAVE_CHEEVOS
    if (!cheevos_enable || !cheevos_hardcore_mode_enable)
 #endif
+#ifdef HAVE_BSV_MOVIE
+     if (!input_st->bsv_movie_state_handle)
+#endif
    {
       if (runloop_st->entry_state_slot && !command_event_load_entry_state(settings))
          runloop_st->entry_state_slot = 0;
@@ -4070,15 +4083,6 @@ static bool event_init_content(
          command_event_load_auto_state();
    }
 
-#ifdef HAVE_BSV_MOVIE
-   bsv_movie_deinit(input_st);
-   if (bsv_movie_init(input_st))
-   {
-      /* Set granularity upon success */
-      configuration_set_uint(settings,
-            settings->uints.rewind_granularity, 1);
-   }
-#endif
    command_event(CMD_EVENT_NETPLAY_INIT, NULL);
 
    return true;


### PR DESCRIPTION
There was a problem with the command-line where replaying a BSV file would first load an autosave state.  Technically, the autoload task was scheduled, then the BSV state was deserialized, and then the autoload task completed.  This PR resolves that bad temporal ordering by ignoring autoload and entry states if BSV recording or playback is happening.  This took two steps:

1. Moved BSV initialization before autoload code
2. Don't trigger autoload code if there is bsv movie state

Open questions: 
- What's the difference between entry state and autoload state? 
- Should BSV recording use the entry state even if playback does not?