### PR TITLE
Pause + hotkey + runloop related changes

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -2436,6 +2436,12 @@ bool command_event(enum event_command cmd, void *data)
 #endif
             if (!command_event_main_state(cmd))
                return false;
+            /* Run next frame to see the core output while paused */
+            else if (runloop_st->flags & RUNLOOP_FLAG_PAUSED)
+            {
+               runloop_st->flags               &= ~RUNLOOP_FLAG_PAUSED;
+               runloop_st->run_frames_and_pause = 1;
+            }
 
 #if HAVE_RUNAHEAD
             command_event(CMD_EVENT_PREEMPT_RESET_BUFFER, NULL);
@@ -2485,6 +2491,13 @@ bool command_event(enum event_command cmd, void *data)
          /* Recalibrate frame delay target */
          if (settings->bools.video_frame_delay_auto)
             video_st->frame_delay_target = 0;
+
+         /* Run a few frames to blank core output while paused */
+         if (runloop_st->flags & RUNLOOP_FLAG_PAUSED)
+         {
+            runloop_st->flags               &= ~RUNLOOP_FLAG_PAUSED;
+            runloop_st->run_frames_and_pause = 8;
+         }
 
 #if HAVE_RUNAHEAD
          command_event(CMD_EVENT_PREEMPT_RESET_BUFFER, NULL);

--- a/runloop.h
+++ b/runloop.h
@@ -81,6 +81,7 @@ enum  runloop_state_enum
    RUNLOOP_STATE_ITERATE = 0,
    RUNLOOP_STATE_POLLED_AND_SLEEP,
    RUNLOOP_STATE_MENU_ITERATE,
+   RUNLOOP_STATE_PAUSE,
    RUNLOOP_STATE_END,
    RUNLOOP_STATE_QUIT
 };
@@ -266,6 +267,7 @@ struct runloop
 #endif
 
    uint32_t flags;
+   int8_t run_frames_and_pause;
 
    char runtime_content_path_basename[8192];
    char current_library_name[NAME_MAX_LENGTH];

--- a/state_manager.c
+++ b/state_manager.c
@@ -591,9 +591,9 @@ void state_manager_event_init(
 
    rewind_st->size               = 0;
    rewind_st->flags             &= ~(
-                             STATE_MGR_REWIND_ST_FLAG_FRAME_IS_REVERSED
-                           | STATE_MGR_REWIND_ST_FLAG_HOTKEY_WAS_CHECKED
-                           | STATE_MGR_REWIND_ST_FLAG_HOTKEY_WAS_PRESSED
+                                   STATE_MGR_REWIND_ST_FLAG_FRAME_IS_REVERSED
+                                 | STATE_MGR_REWIND_ST_FLAG_HOTKEY_WAS_CHECKED
+                                 | STATE_MGR_REWIND_ST_FLAG_HOTKEY_WAS_PRESSED
                                     );
    rewind_st->flags             |= STATE_MGR_REWIND_ST_FLAG_INIT_ATTEMPTED;
 
@@ -666,10 +666,10 @@ void state_manager_event_deinit(
    rewind_st->state              = NULL;
    rewind_st->size               = 0;
    rewind_st->flags             &= ~(
-                             STATE_MGR_REWIND_ST_FLAG_FRAME_IS_REVERSED
-                           | STATE_MGR_REWIND_ST_FLAG_HOTKEY_WAS_CHECKED
-                           | STATE_MGR_REWIND_ST_FLAG_HOTKEY_WAS_PRESSED
-                           | STATE_MGR_REWIND_ST_FLAG_INIT_ATTEMPTED    
+                                   STATE_MGR_REWIND_ST_FLAG_FRAME_IS_REVERSED
+                                 | STATE_MGR_REWIND_ST_FLAG_HOTKEY_WAS_CHECKED
+                                 | STATE_MGR_REWIND_ST_FLAG_HOTKEY_WAS_PRESSED
+                                 | STATE_MGR_REWIND_ST_FLAG_INIT_ATTEMPTED
                                     );
 
    /* Restore regular (non-rewind) core audio
@@ -796,7 +796,8 @@ bool state_manager_check_rewind(
       cnt = (cnt + 1) % (rewind_granularity ?
             rewind_granularity : 1); /* Avoid possible SIGFPE. */
 
-      if ((cnt == 0) || retroarch_ctl(RARCH_CTL_BSV_MOVIE_IS_INITED, NULL))
+      if (     !is_paused
+            && ((cnt == 0) || retroarch_ctl(RARCH_CTL_BSV_MOVIE_IS_INITED, NULL)))
       {
          void *state = NULL;
 


### PR DESCRIPTION
## Description

Currently when core is paused, video output will be stopped completely too, making it impossible to animate widgets while paused, therefore:

- Added a new runloop state for pause which renders last cached frame
- Allowed rewinding while paused so that it acts like backwards frameadvance
  - Also moved rewind step taking before menu iteration so that steps won't be lost while in menu when `menu_pause` is disabled
- State load and reset while paused will forget pause for x frames in order to show proper output
- Allowed reading pause hotkey while menu is active
- Allowed reading screenshot hotkey while menu is active
- Joined 2 fullscreen hotkey checks to one (Any ideas why they were separated for paused and non-paused states, since one works fine for both..?)
- Sorted hotkeys a bit and cleaned up comments

Please test that I did not miss or break anything!
