### PR TITLE
State slot hotkey adjustments

### DIFF
--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -13536,7 +13536,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MSG_LOADED_STATE_FROM_SLOT_AUTO,
-   "Loaded state from slot #-1 (auto)."
+   "Loaded state from slot #-1 (Auto)."
    )
 MSG_HASH(
    MSG_LOADING,
@@ -13720,7 +13720,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MSG_SAVED_STATE_TO_SLOT_AUTO,
-   "Saved state to slot #-1 (auto)."
+   "Saved state to slot #-1 (Auto)."
    )
 MSG_HASH(
    MSG_SAVED_SUCCESSFULLY_TO,


### PR DESCRIPTION
## Description

- Allow selecting -1 Auto slot with hotkeys
- Allow wrap-around from -1 to 999 and backwards
- Show failure message when trying to load a state that does not exist instead of plain "Loading state"
- Shorten the duration of slot change notification
- Change the widget type to the same type as shader toggle for better back and forth action
  Closes #8887

