### PR TITLE
Show square sized widget on volume mute

### DIFF
--- a/gfx/widgets/gfx_widget_volume.c
+++ b/gfx/widgets/gfx_widget_volume.c
@@ -175,7 +175,9 @@ static void gfx_widget_volume_frame(void* data, void *user_data)
             video_width,
             video_height,
             0, 0,
-            state->widget_width,
+            (state->mute)
+                  ? state->widget_height
+                  : state->widget_width,
             state->widget_height,
             video_width,
             video_height,


### PR DESCRIPTION
## Description

Volume widget is currently fixed size always, and thus showing a lot of empty space when muting, therefore shorten the box to icon size only when muting.
