### PR TITLE
Ignore system subdir replacement if subdir has subdirs

### DIFF
--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -2270,6 +2270,11 @@ static int default_action_ok_load_content_with_core_from_menu(const char *_path,
    content_info.argv                   = NULL;
    content_info.args                   = NULL;
    content_info.environ_get            = NULL;
+
+   /* Clear playlist cache to avoid stale data when
+    * getting SYSTEM dir on launch via 'Load Content' */
+   playlist_free_cached();
+
    if (!task_push_load_content_with_core(
             _path, &content_info,
             (enum rarch_core_type)_type, NULL, NULL))


### PR DESCRIPTION
## Description

Quick and crucial correction to the previous PR, because otherwise PPSSPP will break due to it already using a subdir named after `library_name`, therefore added a check for directories under the subdir, and ignoring the candidate in that case.

## Related Pull Requests

#14885

