### PR TITLE
Fix crash when using multiple physical devices and HW core

### DIFF
--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -1584,6 +1584,9 @@ static bool vulkan_context_init_device(gfx_ctx_vulkan_data_t *vk)
       iface = NULL;
    }
 
+   if (!vulkan_context_init_gpu(vk))
+      return false;
+
    if (!cached_device_vk && iface && iface->create_device)
    {
       struct retro_vulkan_context context     = { 0 };
@@ -1628,9 +1631,6 @@ static bool vulkan_context_init_device(gfx_ctx_vulkan_data_t *vk)
       vk->context.destroy_device = cached_destroy_device_vk;
       cached_destroy_device_vk   = NULL;
    }
-
-   if (!vulkan_context_init_gpu(vk))
-      return false;
 
    vkGetPhysicalDeviceProperties(vk->context.gpu,
          &vk->context.gpu_properties);

--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -1605,6 +1605,9 @@ static bool vulkan_context_init_device(gfx_ctx_vulkan_data_t *vk)
       }
       else
       {
+         if (vk->context.gpu != VK_NULL_HANDLE && context.gpu != vk->context.gpu)
+            RARCH_ERR("[Vulkan]: Got unexpected VkPhysicalDevice, despite RetroArch using explicit physical device.\n");
+
          vk->context.destroy_device       = iface->destroy_device;
 
          vk->context.device               = context.device;


### PR DESCRIPTION
Fixes https://github.com/libretro/RetroArch/issues/13787.

For some reason, VkPhysicalDevices were queried after create_device() was called, which leads to a mismatch.