### PR TITLE
Preemptive Frames: Relax savestate requirement to 'serialized'

### DIFF
--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -3846,7 +3846,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_PREEMPT_UNSUPPORTED,
-   "Current core is incompatible with preemptive frames due to lack of deterministic save state support."
+   "Current core is incompatible with preemptive frames due to lack of serialized save state support."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_PREEMPT_ENABLE,
@@ -14140,7 +14140,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MSG_PREEMPT_CORE_DOES_NOT_SUPPORT_PREEMPT,
-   "Preemptive Frames unavailable because this core lacks deterministic save state support."
+   "Preemptive Frames unavailable because this core lacks serialized save state support."
    )
 MSG_HASH(
    MSG_PREEMPT_FAILED_TO_ALLOCATE,

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -8764,9 +8764,10 @@ static void preempt_change_handler(rarch_setting_t *setting)
          {
             /* Disable runahead and inform user */
             settings->bools.run_ahead_enabled = false;
-            runloop_msg_queue_push(
-                  msg_hash_to_str(MSG_RUNAHEAD_DISABLED), 1, 100, false,
-                  NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
+            if (core_info_current_supports_runahead())
+               runloop_msg_queue_push(
+                     msg_hash_to_str(MSG_RUNAHEAD_DISABLED), 1, 100, false,
+                     NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
          }
 
          if ((preempt_enabled != !!preempt) && !netplay_enabled)

--- a/runahead.c
+++ b/runahead.c
@@ -1440,8 +1440,8 @@ bool preempt_init(void *data)
          || !(runloop_st->current_core.flags & RETRO_CORE_FLAG_GAME_LOADED))
       return false;
 
-   /* Check if supported - same requirements as runahead */
-   if (!core_info_current_supports_runahead())
+   /* Check if supported - same requirements as rewind */
+   if (!core_info_current_supports_rewind())
    {
       failed_str = msg_hash_to_str(MSG_PREEMPT_CORE_DOES_NOT_SUPPORT_PREEMPT);
       goto error;


### PR DESCRIPTION
## Description
Draft PR for testing Preemptive Frames with its savestate requirement relaxed from 'deterministic' to 'serialized'. This makes it available to cores which likely have never been tested before with RunAhead (or Preemptive Frames).

Cores especially worth testing for speed are Beetle PSX HW, Parallel N64, Mupen, and Beetle Saturn.


## Reviewers

@LibretroAdmin
