### PR TITLE
net_http - Temp fix for cheevos crash (#14742)

### DIFF
--- a/libretro-common/net/net_http.c
+++ b/libretro-common/net/net_http.c
@@ -440,7 +440,19 @@ static int net_http_new_socket(struct http_connection_t *conn)
          fd = -1;
          goto done;
       }
-      if (ssl_socket_connect(conn->sock_state.ssl_ctx, addr, true, true)
+
+      /* TODO: Promperly figure out what's going wrong when the newer 
+         timeout/poll code interacts with mbed and winsock
+         https://github.com/libretro/RetroArch/issues/14742 */
+
+      /* Temp fix, don't use new timeout/poll code for cheevos http requests */
+         bool timeout = true;
+#ifdef __WIN32
+      if (!strcmp(conn->domain, "retroachievements.org\0"))
+         timeout = false;
+#endif
+
+      if (ssl_socket_connect(conn->sock_state.ssl_ctx, addr, timeout, true)
             < 0)
       {
          fd = -1;

--- a/libretro-common/net/net_http.c
+++ b/libretro-common/net/net_http.c
@@ -441,7 +441,7 @@ static int net_http_new_socket(struct http_connection_t *conn)
          goto done;
       }
 
-      /* TODO: Promperly figure out what's going wrong when the newer 
+      /* TODO: Properly figure out what's going wrong when the newer 
          timeout/poll code interacts with mbed and winsock
          https://github.com/libretro/RetroArch/issues/14742 */
 


### PR DESCRIPTION
Don't use new timeout/poll code for cheevos http requests

Temporary fix isolated to __WIN32 and requests to "retroachievements.org" for now, as to try and not upset anything else going through this code.