### PR TITLE
call ssl_socket_close for ssl sockets

### DIFF
--- a/libretro-common/net/net_http.c
+++ b/libretro-common/net/net_http.c
@@ -1199,14 +1199,16 @@ void net_http_delete(struct http_t *state)
 
    if (state->sock_state.fd >= 0)
    {
-      socket_close(state->sock_state.fd);
 #ifdef HAVE_SSL
       if (state->sock_state.ssl && state->sock_state.ssl_ctx)
       {
+         ssl_socket_close(state->sock_state.ssl_ctx);
          ssl_socket_free(state->sock_state.ssl_ctx);
          state->sock_state.ssl_ctx = NULL;
       }
+      else
 #endif
+      socket_close(state->sock_state.fd);
    }
    free(state);
 }


### PR DESCRIPTION
## Description

Found while debugging #14742, but it doesn't actually fix the issue.

`net_http_delete` was calling `socket_close` for SSL sockets, instead of `ssl_socket_close`, which does some cleanup in addition to calling `socket_close`. This mimics code present in the error handler for `net_http_new`:

https://github.com/libretro/RetroArch/blob/afe3bf72bb0cebd0ab51373f3914d1e45a282457/libretro-common/net/net_http.c#L876-L885

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

[If possible @mention all the people that should review your pull request]
