### PR TITLE
Fix a crash in for BT HID devices.

### DIFF
--- a/input/drivers_hid/btstack_hid.c
+++ b/input/drivers_hid/btstack_hid.c
@@ -1455,7 +1455,6 @@ static void btstack_hid_free(const void *data)
    btpad_set_inquiry_state(true);
    btstack_set_poweron(false);
 
-   free(slots);
    if (hid)
       free(hid);
 }


### PR DESCRIPTION
pad_connection_destroy() frees slots, no need to free it again.