### PR TITLE
(Ozone) Refresh thumbnail on close content hotkey

### DIFF
--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -1506,6 +1506,7 @@ static float ozone_last_framebuffer_opacity = -1.0f;
 /* Forward declarations */
 static void ozone_cursor_animation_cb(void *userdata);
 static void ozone_selection_changed(ozone_handle_t *ozone, bool allow_animation);
+static void ozone_unload_thumbnail_textures(void *data);
 
 static INLINE uint8_t ozone_count_lines(const char *str)
 {
@@ -8529,6 +8530,7 @@ static void ozone_refresh_thumbnail_image(void *data, unsigned i)
       return;
 
    ozone->flags &= ~OZONE_FLAG_SKIP_THUMBNAIL_RESET;
+   ozone_unload_thumbnail_textures(ozone);
 
    /* Refresh metadata */
    if (!i)

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -8282,6 +8282,7 @@ int generic_menu_entry_action(
       const char *deferred_path = menu ? menu->deferred_path : NULL;
       const char *flush_target  = msg_hash_to_str(MENU_ENUM_LABEL_MAIN_MENU);
       size_t stack_offset       = 1;
+      unsigned i                = 0;
       bool reset_navigation     = true;
 
       /* Loop backwards through the menu stack to
@@ -8330,6 +8331,9 @@ int generic_menu_entry_action(
        * the menu stack. We therefore have to force a
        * RARCH_MENU_CTL_UNSET_PREVENT_POPULATE */
       menu_driver_ctl(RARCH_MENU_CTL_UNSET_PREVENT_POPULATE, NULL);
+
+      /* Ozone requires thumbnail refreshing */
+      menu_driver_ctl(RARCH_MENU_CTL_REFRESH_THUMBNAIL_IMAGE, &i);
 
       if (reset_navigation)
          menu_st->selection_ptr = 0;


### PR DESCRIPTION
## Description

Ozone shows empty space instead of playlist thumbnails after using close content hotkey, but not when using the menu item. Other menu drivers work fine. Therefore refresh the images by force.
