### PR TITLE
Draft: Ozone footer enhancements

### DIFF
--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -490,7 +490,9 @@ struct ozone_handle
       ozone_footer_label_t cycle;
       ozone_footer_label_t search;
       ozone_footer_label_t fullscreen_thumbs;
+      ozone_footer_label_t reset_to_default;
       ozone_footer_label_t metadata_toggle;
+      ozone_footer_label_t help;
    } footer_labels;
 
    struct
@@ -8628,6 +8630,10 @@ static void ozone_cache_footer_labels(ozone_handle_t *ozone)
          MENU_ENUM_LABEL_VALUE_SEARCH);
 
    ozone_cache_footer_label(ozone,
+         &ozone->footer_labels.reset_to_default,
+         MENU_ENUM_LABEL_VALUE_RESET_TO_DEFAULT_CONFIG);
+
+   ozone_cache_footer_label(ozone,
          &ozone->footer_labels.cycle,
          MENU_ENUM_LABEL_VALUE_CYCLE_THUMBNAILS);
 
@@ -8638,6 +8644,10 @@ static void ozone_cache_footer_labels(ozone_handle_t *ozone)
    ozone_cache_footer_label(ozone,
          &ozone->footer_labels.metadata_toggle,
          MSG_TOGGLE_CONTENT_METADATA);
+
+   ozone_cache_footer_label(ozone,
+         &ozone->footer_labels.help,
+         MENU_ENUM_LABEL_VALUE_HELP);
 
    /* Record current language setting */
    ozone->footer_labels_language = *msg_hash_get_uint(MSG_HASH_USER_LANGUAGE);
@@ -10171,6 +10181,11 @@ static void ozone_draw_footer(
          fullscreen_thumbnails_available &&
          !((ozone->is_quick_menu && menu_is_running_quick_menu()) 
                || (ozone->flags & OZONE_FLAG_IS_STATE_SLOT));
+   bool reset_to_default_available        =
+         !fullscreen_thumbnails_available &&
+         ozone_is_current_entry_settings(menu_navigation_get_selection());
+   bool help_available                    = !metadata_override_available;
+
 
    /* Determine x origin positions of each
     * button
@@ -10179,7 +10194,9 @@ static void ozone_draw_footer(
     *   - back
     *   - search
     *   - toggle fullscreen thumbs (playlists only)
-    *   - toggle metadata (playlists only) */
+    *   - reset to default (non-playlist only)
+    *   - toggle metadata (playlists only)
+    *   - help (non-playlist only) */
    float ok_x                             = (float)video_width
          - footer_margin - ozone->footer_labels.ok.width - icon_size - icon_padding;
    float back_x                           = ok_x
@@ -10190,6 +10207,11 @@ static void ozone_draw_footer(
    float cycle_x                          = (thumbnail_cycle_enabled)
          ? search_x - ozone->footer_labels.cycle.width - icon_size - (2.0f * icon_padding)
          : search_x;
+   float reset_to_default_x               = (reset_to_default_available)
+         ? search_x - ozone->footer_labels.reset_to_default.width - icon_size - (2.0f * icon_padding)
+         : search_x;
+   float help_x                           = reset_to_default_x
+         - ozone->footer_labels.help.width - icon_size - (2.0f * icon_padding);
    float fullscreen_thumbs_x              = cycle_x
          - ozone->footer_labels.fullscreen_thumbs.width - icon_size - (2.0f * icon_padding);
    float metadata_toggle_x                = fullscreen_thumbs_x
@@ -10341,6 +10363,44 @@ static void ozone_draw_footer(
                   1.0f,
                   col,
                   mymat);
+
+         /* > Reset to default */
+         if (reset_to_default_available)
+            ozone_draw_icon(
+                  p_disp,
+                  userdata,
+                  video_width,
+                  video_height,
+                  icon_size,
+                  icon_size,
+                  ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_START],
+                  reset_to_default_x,
+                  icon_y,
+                  video_width,
+                  video_height,
+                  0.0f,
+                  1.0f,
+                  col,
+                  mymat);
+
+         /* > Help */
+         if (help_available)
+            ozone_draw_icon(
+                  p_disp,
+                  userdata,
+                  video_width,
+                  video_height,
+                  icon_size,
+                  icon_size,
+                  ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_INPUT_SELECT],
+                  help_x,
+                  icon_y,
+                  video_width,
+                  video_height,
+                  0.0f,
+                  1.0f,
+                  col,
+                  mymat);
       }
 
       if (dispctx->blend_end)
@@ -10433,6 +10493,38 @@ static void ozone_draw_footer(
             ozone->fonts.footer.font,
             ozone->footer_labels.metadata_toggle.str,
             metadata_toggle_x + icon_size + icon_padding,
+            footer_text_y,
+            video_width,
+            video_height,
+            ozone->theme->text_rgba,
+            TEXT_ALIGN_LEFT,
+            1.0f,
+            false,
+            1.0f,
+            false);
+
+   /* > Reset to default */
+   if (reset_to_default_available)
+      gfx_display_draw_text(
+            ozone->fonts.footer.font,
+            ozone->footer_labels.reset_to_default.str,
+            reset_to_default_x + icon_size + icon_padding,
+            footer_text_y,
+            video_width,
+            video_height,
+            ozone->theme->text_rgba,
+            TEXT_ALIGN_LEFT,
+            1.0f,
+            false,
+            1.0f,
+            false);
+
+   /* > Help */
+   if (help_available)
+      gfx_display_draw_text(
+            ozone->fonts.footer.font,
+            ozone->footer_labels.help.str,
+            help_x + icon_size + icon_padding,
             footer_text_y,
             video_width,
             video_height,


### PR DESCRIPTION
Add Help button (Select) and Reset to Default (Start) to footer where applicable.

## Description

Ozone footer has a very handy quick guide for some buttons. It is already extended in case of playlist navigation:
![Screenshot from 2023-01-29 19-07-41](https://user-images.githubusercontent.com/101990835/215347026-682a1c50-ff42-44fb-a9a4-e7af97560829.png)
Help and Reset to default functions can be added rather easily (showing Reset to default only at setting type of entries):
![Screenshot from 2023-01-29 19-07-56](https://user-images.githubusercontent.com/101990835/215347368-9dfbff52-da9d-4b13-8521-3bd4353ad538.png)
![Screenshot from 2023-01-29 19-08-09](https://user-images.githubusercontent.com/101990835/215347372-871f66cd-7f1a-4130-be0e-3cd949a0c902.png)

One more item would be the deletion of the setting (button Y in case of hotkey binds at least), and maybe making the Help button context sensitive, i.e. only show it when there is actual help text. I plan to add those eventually, but I wanted to have some room for comments, hence marking it as draft for now. There may be other "hidden" button assignments somewhere that could be shown.

## Reviewers

@sonninnos 
