### PR TITLE
BSV ergonomics improvements

### DIFF
--- a/input/input_defines.h
+++ b/input/input_defines.h
@@ -234,8 +234,8 @@ enum input_turbo_default_button
 #define GET_HAT(x)         (x & (~HAT_MASK))
 
 #ifdef HAVE_BSV_MOVIE
-#define BSV_MOVIE_IS_PLAYBACK_ON() (input_st->bsv_movie_state_handle && (input_st->bsv_movie_state.flags & BSV_FLAG_MOVIE_PLAYBACK))
-#define BSV_MOVIE_IS_PLAYBACK_OFF() (input_st->bsv_movie_state_handle && (!(input_st->bsv_movie_state.flags & BSV_FLAG_MOVIE_PLAYBACK)))
+#define BSV_MOVIE_IS_PLAYBACK_ON() (input_st->bsv_movie_state_handle && (input_st->bsv_movie_state.flags & BSV_FLAG_MOVIE_PLAYBACK) && !(input_st->bsv_movie_state.flags & BSV_FLAG_MOVIE_END))
+#define BSV_MOVIE_IS_RECORDING() (input_st->bsv_movie_state_handle && (input_st->bsv_movie_state.flags & BSV_FLAG_MOVIE_RECORDING))
 
 #endif
 

--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -5447,7 +5447,7 @@ int16_t input_driver_state_wrapper(unsigned port, unsigned device,
 
 #ifdef HAVE_BSV_MOVIE
    /* Save input to BSV record, if enabled */
-   if (BSV_MOVIE_IS_PLAYBACK_OFF())
+   if (BSV_MOVIE_IS_RECORDING())
    {
       result = swap_if_big16(result);
       intfstream_write(input_st->bsv_movie_state_handle->file, &result, 2);

--- a/input/input_driver.h
+++ b/input/input_driver.h
@@ -114,15 +114,16 @@ enum bsv_flags
    BSV_FLAG_MOVIE_START_RECORDING    = (1 << 0),
    BSV_FLAG_MOVIE_START_PLAYBACK     = (1 << 1),
    BSV_FLAG_MOVIE_PLAYBACK           = (1 << 2),
-   BSV_FLAG_MOVIE_EOF_EXIT           = (1 << 3),
-   BSV_FLAG_MOVIE_END                = (1 << 4)
+   BSV_FLAG_MOVIE_RECORDING          = (1 << 3),
+   BSV_FLAG_MOVIE_END                = (1 << 4),
+   BSV_FLAG_MOVIE_EOF_EXIT           = (1 << 5),
 };
 
 struct bsv_state
 {
    uint8_t flags;
    /* Movie playback/recording support. */
-   char movie_path[PATH_MAX_LENGTH];
+   char movie_auto_path[PATH_MAX_LENGTH];
    /* Immediate playback/recording. */
    char movie_start_path[PATH_MAX_LENGTH];
 };

--- a/input/input_driver.h
+++ b/input/input_driver.h
@@ -116,7 +116,7 @@ enum bsv_flags
    BSV_FLAG_MOVIE_PLAYBACK           = (1 << 2),
    BSV_FLAG_MOVIE_RECORDING          = (1 << 3),
    BSV_FLAG_MOVIE_END                = (1 << 4),
-   BSV_FLAG_MOVIE_EOF_EXIT           = (1 << 5),
+   BSV_FLAG_MOVIE_EOF_EXIT           = (1 << 5)
 };
 
 struct bsv_state

--- a/runloop.c
+++ b/runloop.c
@@ -4681,9 +4681,9 @@ void runloop_path_fill_names(void)
    runloop_path_init_savefile_internal(runloop_st);
 
 #ifdef HAVE_BSV_MOVIE
-   strlcpy(input_st->bsv_movie_state.movie_path,
+   strlcpy(input_st->bsv_movie_state.movie_auto_path,
          runloop_st->name.savefile,
-         sizeof(input_st->bsv_movie_state.movie_path));
+         sizeof(input_st->bsv_movie_state.movie_auto_path));
 #endif
 
    if (string_is_empty(runloop_st->runtime_content_path_basename))
@@ -6970,6 +6970,11 @@ int runloop_iterate(void)
       input_st->bsv_movie_state_handle->first_rewind =
          !input_st->bsv_movie_state_handle->did_rewind;
       input_st->bsv_movie_state_handle->did_rewind   = false;
+   }
+   if (input_st->bsv_movie_state.flags & BSV_FLAG_MOVIE_END)
+   {
+      movie_stop_playback(input_st);
+      command_event(CMD_EVENT_PAUSE, NULL);
    }
 #endif
 


### PR DESCRIPTION
- Date stamp toggled recordings instead of overwriting or using save slot number
- Properly stop movie on playback EOF; also pause emulation
- Add recording flag to match playback flag in bsv state enum
- Rename bsv "movie path" to "movie auto path" to clarify role
- Allow stopping movie playback before EOF using record toggle hotkey