### PR TITLE
add keyboard recording support to bsv

### DIFF
--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -4791,13 +4791,14 @@ void bsv_movie_next_frame(input_driver_state_t *input_st)
    handle->frame_pos[handle->frame_ptr] = intfstream_tell(handle->file);
    if (input_st->bsv_movie_state.flags & BSV_FLAG_MOVIE_RECORDING)
    {
+      int i;
       /* write key events, frame is over */
-     intfstream_write(handle->file, &(handle->key_event_count), 1);
-     for(int i = 0; i < handle->key_event_count; i++)
-     {
-        intfstream_write(handle->file, &(handle->key_events[i]), sizeof(bsv_key_data_t));
-     }
-     bsv_movie_handle_clear_key_events(handle);
+      intfstream_write(handle->file, &(handle->key_event_count), 1);
+      for(i = 0; i < handle->key_event_count; i++)
+      {
+         intfstream_write(handle->file, &(handle->key_events[i]), sizeof(bsv_key_data_t));
+      }
+      bsv_movie_handle_clear_key_events(handle);
    }
    if (input_st->bsv_movie_state.flags & BSV_FLAG_MOVIE_PLAYBACK)
    {
@@ -4808,7 +4809,8 @@ void bsv_movie_next_frame(input_driver_state_t *input_st)
       }
       if (intfstream_read(handle->file, &(handle->key_event_count), 1) == 1)
       {
-         for(int i = 0; i < handle->key_event_count; i++)
+         int i;
+         for(i = 0; i < handle->key_event_count; i++)
          {
             if (intfstream_read(handle->file, &(handle->key_events[i]), sizeof(bsv_key_data_t)) != sizeof(bsv_key_data_t))
             {
@@ -5284,22 +5286,24 @@ void input_driver_poll(void)
 #ifdef HAVE_BSV_MOVIE
    if (BSV_MOVIE_IS_PLAYBACK_ON())
    {
-     runloop_state_t *runloop_st   = runloop_state_get_ptr();
-     retro_keyboard_event_t *key_event                 = &runloop_st->key_event;
+      runloop_state_t *runloop_st   = runloop_state_get_ptr();
+      retro_keyboard_event_t *key_event                 = &runloop_st->key_event;
 
-     if(*key_event && *key_event == runloop_st->frontend_key_event)
-     {
-       bsv_key_data_t k;
-       for(int i = 0; i < input_st->bsv_movie_state_handle->key_event_count; i++) {
+      if(*key_event && *key_event == runloop_st->frontend_key_event)
+      {
+         int i;
+         bsv_key_data_t k;
+         for(i = 0; i < input_st->bsv_movie_state_handle->key_event_count; i++)
+         {
 #ifdef HAVE_CHEEVOS
-         rcheevos_pause_hardcore();
+            rcheevos_pause_hardcore();
 #endif
-         k = input_st->bsv_movie_state_handle->key_events[i];
-         input_keyboard_event(k.down, swap_if_big32(k.code), swap_if_big32(k.character), swap_if_big16(k.mod), RETRO_DEVICE_KEYBOARD);
-       }
-       /* Have to clear here so we don't double-apply key events */
-       bsv_movie_handle_clear_key_events(input_st->bsv_movie_state_handle);
-     }
+            k = input_st->bsv_movie_state_handle->key_events[i];
+            input_keyboard_event(k.down, swap_if_big32(k.code), swap_if_big32(k.character), swap_if_big16(k.mod), RETRO_DEVICE_KEYBOARD);
+         }
+         /* Have to clear here so we don't double-apply key events */
+         bsv_movie_handle_clear_key_events(input_st->bsv_movie_state_handle);
+      }
    }
 #endif
 }

--- a/input/input_driver.h
+++ b/input/input_driver.h
@@ -128,6 +128,17 @@ struct bsv_state
    char movie_start_path[PATH_MAX_LENGTH];
 };
 
+/* These data are always little-endian. */
+struct bsv_key_data {
+  uint8_t down;
+  uint16_t mod;
+  uint8_t _padding;
+  uint32_t code;
+  uint32_t character;
+};
+
+typedef struct bsv_key_data bsv_key_data_t;
+
 struct bsv_movie
 {
    intfstream_t *file;
@@ -140,6 +151,11 @@ struct bsv_movie
    size_t min_file_pos;
    size_t state_size;
 
+   /* Staging variables for keyboard events */
+   uint8_t key_event_count;
+   bsv_key_data_t key_events[255];
+
+   /* Rewind state */
    bool playback;
    bool first_rewind;
    bool did_rewind;
@@ -989,6 +1005,8 @@ void input_overlay_init(void);
 
 #ifdef HAVE_BSV_MOVIE
 void bsv_movie_frame_rewind(void);
+void bsv_movie_next_frame(input_driver_state_t *input_st);
+void bsv_movie_finish_rewind(input_driver_state_t *input_st);
 void bsv_movie_deinit(input_driver_state_t *input_st);
 
 bool movie_start_playback(input_driver_state_t *input_st, char *path);

--- a/runloop.c
+++ b/runloop.c
@@ -6740,10 +6740,7 @@ int runloop_iterate(void)
 #endif
 
 #ifdef HAVE_BSV_MOVIE
-   /* Used for rewinding while playback/record. */
-   if (input_st->bsv_movie_state_handle)
-      input_st->bsv_movie_state_handle->frame_pos[input_st->bsv_movie_state_handle->frame_ptr]
-         = intfstream_tell(input_st->bsv_movie_state_handle->file);
+   bsv_movie_next_frame(input_st);
 #endif
 
    if (     camera_st->cb.caps
@@ -6974,15 +6971,11 @@ int runloop_iterate(void)
    }
 
 #ifdef HAVE_BSV_MOVIE
-   if (input_st->bsv_movie_state_handle)
+   bsv_movie_finish_rewind(input_st);
+   if (input_st->bsv_movie_state.flags & BSV_FLAG_MOVIE_END)
    {
-      input_st->bsv_movie_state_handle->frame_ptr    =
-         (input_st->bsv_movie_state_handle->frame_ptr + 1)
-         & input_st->bsv_movie_state_handle->frame_mask;
-
-      input_st->bsv_movie_state_handle->first_rewind =
-         !input_st->bsv_movie_state_handle->did_rewind;
-      input_st->bsv_movie_state_handle->did_rewind   = false;
+      movie_stop_playback(input_st);
+      command_event(CMD_EVENT_PAUSE, NULL);
    }
    if (input_st->bsv_movie_state.flags & BSV_FLAG_MOVIE_END)
    {


### PR DESCRIPTION
This patch includes keyboard events in the BSV recordings to better support DOSbox and other systems with keyboards.  After all the buttons, one byte is written to describe how many keyboard events there are, then 12 bytes are written for each keyboard event.

BSV movies recorded in older RA *WILL NOT* replay properly after this patch.  While looking to see if the core actually uses a keyboard device could mitigate this, it is an unavoidable consequence of using BSV, a format which carries no metadata whatsoever.

This is tested only with FCEUmm and DOSbox-pure cores.