### PR TITLE
Fix tvos metal driver

### DIFF
--- a/gfx/drivers/metal.m
+++ b/gfx/drivers/metal.m
@@ -174,6 +174,10 @@
 
       [apple_platform setVideoMode:mode];
 
+#ifdef HAVE_COCOATOUCH
+      [self mtkView:view drawableSizeWillChange:CGSizeMake(mode.width, mode.height)];
+#endif
+
       *input         = NULL;
       *inputData     = NULL;
       /* graphics display driver */


### PR DESCRIPTION
The drawableSizeWillChange notification was never coming, so the viewport size was never getting set properly.