### PR TITLE
Fix nvda switching to powershell on speak.

### DIFF
--- a/frontend/drivers/platform_win32.c
+++ b/frontend/drivers/platform_win32.c
@@ -466,8 +466,13 @@ static void init_nvda(void)
       }
    }
 #endif
-   g_plat_win32_flags &= ~PLAT_WIN32_FLAG_USE_NVDA;
-   g_plat_win32_flags |=  PLAT_WIN32_FLAG_USE_POWERSHELL;
+   /* The above code is executed on each accessibility speak event, so
+    * we should only revert to powershell if nvda_lib wasn't loaded previously,
+    * and we weren't able to load it on this call, or we don't HAVE_DYLIB */
+   if ((g_plat_win32_flags & PLAT_WIN32_FLAG_USE_NVDA) && !nvda_lib) {
+      g_plat_win32_flags &= ~PLAT_WIN32_FLAG_USE_NVDA;
+      g_plat_win32_flags |=  PLAT_WIN32_FLAG_USE_POWERSHELL;
+   }
 }
 #endif
 


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

Fix for nvda reverting to powershell on speak call.

## Related Issues

Is a fix for https://github.com/libretro/RetroArch/issues/14396 

## Related Pull Requests

None

## Reviewers


