### PR TITLE
[PS2] Avoid loading extra drivers when not needed

### DIFF
--- a/frontend/drivers/platform_ps2.c
+++ b/frontend/drivers/platform_ps2.c
@@ -304,7 +304,7 @@ static void frontend_ps2_get_env(int *argc, char *argv[],
 
 static void common_init_drivers(bool extra_drivers) 
 {
-   init_drivers(true);
+   init_drivers(extra_drivers);
 
    poweroffSetCallback(&poweroffHandler, NULL);
 


### PR DESCRIPTION
## Description

Fixed a bug where it wasn't using the variable `extra_drivers`, for loading the specific IRX needed drivers.
This is increasing compatibility with some specific PS2 models that sometimes fail when loading cores.

## Reviewers

