### PR TITLE
Music files should also obey builtin_mediaplayer_enable

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -390,13 +390,17 @@ static void filebrowser_parse(
          if (filebrowser_type == FILEBROWSER_SELECT_COLLECTION)
             file_type = FILE_TYPE_PLAYLIST_COLLECTION;
 
-         if (path_type == RARCH_CONTENT_MUSIC)
-            file_type = FILE_TYPE_MUSIC;
-         else if (builtin_mediaplayer_enable ||
+         if (builtin_mediaplayer_enable ||
                   builtin_imageviewer_enable)
          {
             switch (path_type)
             {
+               case RARCH_CONTENT_MUSIC:
+#if defined(HAVE_FFMPEG) || defined(HAVE_MPV)
+                  if (builtin_mediaplayer_enable)
+                     file_type = FILE_TYPE_MUSIC;
+#endif
+                  break;
                case RARCH_CONTENT_MOVIE:
 #if defined(HAVE_FFMPEG) || defined(HAVE_MPV)
                   if (builtin_mediaplayer_enable)


### PR DESCRIPTION
## Description

Disabling the built in media player should be possible for music files as well. Without this, sound files can not be opened from file browser with cores that support them.
