### PR TITLE
[Vulkan] Fix regression with RGB565 and OriginalHistory.

### DIFF
--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -456,7 +456,7 @@ struct vk_texture vulkan_create_texture(vk_t *vk,
     * Use compute shader uploads instead.
     * If we attempt to use streamed texture, force staging path.
     * If we're creating fallback dynamic texture, force RGBA8888. */
-   if (format == VK_FORMAT_R5G6B5_UNORM_PACK16)
+   if (vulkan_remap_to_texture_format(format) != format)
    {
       if (type == VULKAN_TEXTURE_STREAMED)
       {
@@ -464,7 +464,7 @@ struct vk_texture vulkan_create_texture(vk_t *vk,
       }
       else if (type == VULKAN_TEXTURE_DYNAMIC)
       {
-         format = VK_FORMAT_R8G8B8A8_UNORM;
+         format = vulkan_remap_to_texture_format(format);
          info.format = format;
          info.usage |= VK_IMAGE_USAGE_STORAGE_BIT;
       }
@@ -3360,7 +3360,8 @@ void vulkan_copy_staging_to_dynamic(vk_t *vk, VkCommandBuffer cmd,
             VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
             VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
 
-      /* staging->format is always RGB565 here. Can be expanded as needed. */
+      /* staging->format is always RGB565 here.
+       * Can be expanded as needed if more cases are added to vulkan_remap_to_texture_format. */
       retro_assert(staging->format == VK_FORMAT_R5G6B5_UNORM_PACK16);
 
       set = vulkan_descriptor_manager_alloc(

--- a/gfx/common/vulkan_common.h
+++ b/gfx/common/vulkan_common.h
@@ -745,6 +745,14 @@ void vulkan_set_uniform_buffer(
 void vulkan_debug_mark_image(VkDevice device, VkImage image);
 void vulkan_debug_mark_memory(VkDevice device, VkDeviceMemory memory);
 
+static inline VkFormat vulkan_remap_to_texture_format(VkFormat fmt)
+{
+   if (fmt == VK_FORMAT_R5G6B5_UNORM_PACK16)
+      return VK_FORMAT_R8G8B8A8_UNORM;
+   else
+      return fmt;
+}
+
 RETRO_END_DECLS
 
 #endif

--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -935,7 +935,7 @@ static bool vulkan_init_default_filter_chain(vk_t *vk)
    info.queue                 = vk->context->queue;
    info.command_pool          = vk->swapchain[vk->context->current_frame_index].cmd_pool;
    info.num_passes            = 0;
-   info.original_format       = vk->tex_fmt;
+   info.original_format       = vulkan_remap_to_texture_format(vk->tex_fmt);
    info.max_input_size.width  = vk->tex_w;
    info.max_input_size.height = vk->tex_h;
    info.swapchain.viewport    = vk->vk_vp;
@@ -1007,7 +1007,7 @@ static bool vulkan_init_filter_chain_preset(vk_t *vk, const char *shader_path)
    info.queue                 = vk->context->queue;
    info.command_pool          = vk->swapchain[vk->context->current_frame_index].cmd_pool;
    info.num_passes            = 0;
-   info.original_format       = vk->tex_fmt;
+   info.original_format       = vulkan_remap_to_texture_format(vk->tex_fmt);
    info.max_input_size.width  = vk->tex_w;
    info.max_input_size.height = vk->tex_h;
    info.swapchain.viewport    = vk->vk_vp;


### PR DESCRIPTION
Need to let filter chain know that we remapped the format. Otherwise we end up trying to copy RGBA8888 to RGB565.
