### PR TITLE
Enable RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME for libretro-video-proce…

### DIFF
--- a/cores/libretro-video-processor/video_processor_v4l2.c
+++ b/cores/libretro-video-processor/video_processor_v4l2.c
@@ -283,6 +283,9 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_set_environment)(retro_environment_t 
 
    VIDEOPROC_CORE_PREFIX(environment_cb) = cb;
 
+   bool no_content = true;
+   cb(RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME, &no_content);
+
    /* Allows retroarch to seed the previous values */
    VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_SET_VARIABLES, envvars);
 


### PR DESCRIPTION
Fix #14950

 > RetroArch exits out, stating that "Libretro core requires content, but nothing was provided."
