### PR TITLE
Don't save switched video driver on quit

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -6873,11 +6873,13 @@ bool retroarch_main_quit(void)
    bool config_save_on_exit      = settings->bools.config_save_on_exit;
 
 #if !defined(HAVE_DYNAMIC)
+   {
       /* Salamander sets RUNLOOP_FLAG_SHUTDOWN_INITIATED prior, so we need to handle it seperately */
       /* config_save_file_salamander() must be called independent of config_save_on_exit */
       config_save_file_salamander();
       if (config_save_on_exit)
          command_event(CMD_EVENT_MENU_SAVE_CURRENT_CONFIG, NULL);
+   }
 #endif
 
 #ifdef HAVE_PRESENCE
@@ -6915,6 +6917,9 @@ bool retroarch_main_quit(void)
        * specifically we need to get width,height which requires UI thread and it will not be available on exit
        */
 #if defined(HAVE_DYNAMIC)
+      /* Restore video driver before saving */
+      video_driver_restore_cached(settings);
+
       if (config_save_on_exit)
          command_event(CMD_EVENT_MENU_SAVE_CURRENT_CONFIG, NULL);
 #endif


### PR DESCRIPTION
## Description

Make sure video driver is switched back to config value before saving config on quit.
