### PR TITLE
LED driver for Linux /sys/class/leds

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -2416,7 +2416,8 @@ ifeq ($(HAVE_STATIC_AUDIO_FILTERS), 1)
 endif
 
 ifeq ($(HAVE_RPILED), 1)
-   OBJ += led/drivers/led_rpi.o
+   OBJ += led/drivers/led_rpi.o \
+          led/drivers/led_sys_linux.o
 endif
 
 ifneq ($(findstring Win32,$(OS)),)

--- a/griffin/griffin.c
+++ b/griffin/griffin.c
@@ -904,6 +904,7 @@ LEDS
 
 #if defined(HAVE_RPILED)
 #include "../led/drivers/led_rpi.c"
+#include "../led/drivers/led_sys_linux.c"
 #endif
 
 #if defined(_WIN32) && !defined(_XBOX) && !defined(__WINRT__)

--- a/led/drivers/led_sys_linux.c
+++ b/led/drivers/led_sys_linux.c
@@ -1,0 +1,114 @@
+/*  RetroArch - A frontend for libretro.
+ *
+ *  RetroArch is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  RetroArch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with RetroArch.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+#include <compat/strl.h>
+
+#include "../led_driver.h"
+#include "../led_defines.h"
+
+#include "../../configuration.h"
+
+typedef struct
+{
+   int setup[MAX_LEDS];
+   int map[MAX_LEDS];
+} sysled_t;
+
+/* TODO/FIXME - static globals */
+static sysled_t sys_curins;
+static sysled_t *sys_cur = &sys_curins;
+
+static void sys_led_init(void)
+{
+   int i;
+   settings_t *settings = config_get_ptr();
+
+   if (!settings)
+      return;
+
+   for (i = 0; i < MAX_LEDS; i++)
+   {
+      sys_cur->setup[i] = 0;
+      sys_cur->map[i]   = settings->uints.led_map[i];
+   }
+}
+
+static void sys_led_free(void)
+{
+   int i;
+
+   for (i = 0; i < MAX_LEDS; i++)
+   {
+      sys_cur->setup[i] = 0;
+      sys_cur->map[i]   = 0;
+   }
+}
+
+static int set_sysled(int sysled, int value)
+{
+   FILE *fp;
+   char buf[256];
+   snprintf(buf, sizeof(buf), "/sys/class/leds/led%d/brightness", sysled);
+
+   /* Failed to set LED? */
+   if (!(fp = fopen(buf, "w")))
+      return -1;
+
+   /* Simplified: max_brightness could be taken into account */
+   /* Pi Zero may have reversed brightness? */
+   fprintf(fp, "%d\n", value ? 1 : 0);
+   fclose(fp);
+   return 1;
+}
+
+static int setup_sysled(int sysled)
+{
+   FILE *fp;
+   char buf[256];
+   snprintf(buf, sizeof(buf), "/sys/class/leds/led%d/trigger", sysled);
+   
+   if (!(fp = fopen(buf, "w")))
+      return -1;
+
+   /* TODO: read actual trigger in [] and restore on exit */
+   fprintf(fp, "none");
+   fclose(fp);
+   return 1;
+}
+
+static void sys_led_set(int led, int state)
+{
+   int sysled = 0;
+
+   /* Invalid LED? */
+   if((led < 0) || (led >= MAX_LEDS))
+      return;
+
+   sysled = sys_cur->map[led];
+   if(sysled < 0)
+      return;
+
+   if(sys_cur->setup[led] == 0)
+      sys_cur->setup[led] = setup_sysled(sysled);
+   if(sys_cur->setup[led] > 0)
+      set_sysled(sysled, state);
+}
+
+const led_driver_t sys_led_driver = {
+   sys_led_init,
+   sys_led_free,
+   sys_led_set,
+   "sysled"
+};

--- a/led/led_driver.c
+++ b/led/led_driver.c
@@ -47,12 +47,15 @@ void led_driver_init(const char *led_driver)
 #ifdef HAVE_RPILED
    if (string_is_equal("rpi", drivername))
       current_led_driver  = &rpi_led_driver;
+   if (string_is_equal("sysled", drivername))
+      current_led_driver  = &sys_led_driver;
 #endif
 
 #if (defined(_WIN32) && !defined(_XBOX) && !defined(__WINRT__)) || defined(HAVE_X11)
    if (string_is_equal("keyboard", drivername))
       current_led_driver  = &keyboard_led_driver;
 #endif
+
 
    if (current_led_driver)
       (*current_led_driver->init)();

--- a/led/led_driver.h
+++ b/led/led_driver.h
@@ -44,6 +44,7 @@ void led_driver_set_led(int led, int value);
 extern const led_driver_t overlay_led_driver;
 extern const led_driver_t rpi_led_driver;
 extern const led_driver_t keyboard_led_driver;
+extern const led_driver_t sys_led_driver;
 
 RETRO_END_DECLS
 


### PR DESCRIPTION
## Description

New driver for controlling system LEDs offered via /sys/class/leds. Currently it handles led0, led1 etc. type of entries, which are present on e.g. Raspberry Pi's. The [full LED naming scheme](https://docs.kernel.org/leds/leds-class.html) is complex, supporting it would require more effort while providing little benefit.

Code is based on existing gpio driver ("rpiled"). Same compiling option is used, as it is enabled on Linux platforms.

Tested on Pi 1/2/3 with ep128emu-core. It requires write access to /sys/class/leds/led?/trigger and brightness files, it can be chmod'ed to allow write by user. (Lakka should be able to use it without more hacks.)