### PR TITLE
tvOS improvements

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -2082,6 +2082,10 @@ static struct config_bool_setting *populate_settings_bool(
    SETTING_BOOL("android_input_disconnect_workaround",   &settings->bools.android_input_disconnect_workaround, true, false, false);
 #endif
 
+#if defined(HAVE_COCOATOUCH) && defined(TARGET_OS_TV)
+   SETTING_BOOL("gcdwebserver_alert",    &settings->bools.gcdwebserver_alert, true, true, false);
+#endif
+
    *size = count;
 
    return tmp;

--- a/configuration.h
+++ b/configuration.h
@@ -976,6 +976,10 @@ typedef struct settings
 #ifdef ANDROID
       bool android_input_disconnect_workaround;
 #endif
+
+#if defined(HAVE_COCOATOUCH) && defined(TARGET_OS_TV)
+      bool gcdwebserver_alert;
+#endif
    } bools;
 
 } settings_t;

--- a/input/drivers_joypad/mfi_joypad.m
+++ b/input/drivers_joypad/mfi_joypad.m
@@ -387,14 +387,8 @@ static void mfi_joypad_autodetect_add(unsigned autoconf_pad)
 - (void)shutdown
 {
     if (@available(iOS 14, tvOS 14, macOS 11, *)) {
-        if (self.weakPlayer)
-            [self.weakPlayer cancelAndReturnError:nil];
         _weakPlayer = nil;
-        if (self.strongPlayer)
-            [self.strongPlayer cancelAndReturnError:nil];
         _strongPlayer = nil;
-        if (self.engine)
-            [self.engine stopWithCompletionHandler:nil];
         self.engine = nil;
     }
 }
@@ -454,7 +448,7 @@ static void apple_gamecontroller_joypad_connect(GCController *controller)
            for (GCController *connectedController in mfiControllers)
            {
               if (     connectedController.microGamepad    != nil
-                    || connectedController.extendedGamepad == nil )
+                    && connectedController.extendedGamepad == nil )
                  connectedNonGameControllerIndex = index;
               index++;
            }
@@ -626,7 +620,6 @@ static bool apple_gamecontroller_joypad_set_rumble(unsigned pad,
                                                initWithParameterID:CHHapticDynamicParameterIDHapticIntensityControl
                                                value:str
                                                relativeTime:0];
-            NSError *error;
             [player sendParameters:[NSArray arrayWithObject:param] atTime:0 error:&error];
             if (!error)
                 [player startAtTime:0 error:&error];

--- a/ui/drivers/cocoa/apple_platform.h
+++ b/ui/drivers/cocoa/apple_platform.h
@@ -52,6 +52,9 @@ extern id apple_platform;
 #endif
 
 #if defined(HAVE_COCOATOUCH)
+void rarch_start_draw_observer();
+void rarch_stop_draw_observer();
+
 @interface RetroArch_iOS : UINavigationController<ApplePlatform, UIApplicationDelegate,
 UINavigationControllerDelegate> {
     UIView *_renderView;

--- a/ui/drivers/ui_cocoatouch.m
+++ b/ui/drivers/ui_cocoatouch.m
@@ -75,7 +75,7 @@ static void rarch_draw_observer(CFRunLoopObserverRef observer,
       CFRunLoopWakeUp(CFRunLoopGetMain());
 }
 
-static void rarch_start_draw_observer()
+void rarch_start_draw_observer()
 {
    if (iterate_observer && CFRunLoopObserverIsValid(iterate_observer))
        return;
@@ -87,7 +87,7 @@ static void rarch_start_draw_observer()
    CFRunLoopAddObserver(CFRunLoopGetMain(), iterate_observer, kCFRunLoopCommonModes);
 }
 
-static void rarch_stop_draw_observer()
+void rarch_stop_draw_observer()
 {
     if (!iterate_observer || !CFRunLoopObserverIsValid(iterate_observer))
         return;


### PR DESCRIPTION
The initial popup screen advertising the web server did not prevent keys from passing through, so interactions with the alert would also be handled by the menu. The alert would pop up any time there was a network reconfiguration; now it only pops up once per run. Added a way to turn off the webserver advertisement alert permanently.

Also fixed a bug around filtering the Siri remote out, and turning controllers off while the app is running.