### PR TITLE
(XMB) Layout corrections

### DIFF
--- a/gfx/gfx_display.h
+++ b/gfx/gfx_display.h
@@ -41,7 +41,7 @@ enum gfx_display_flags
    GFX_DISP_FLAG_FB_DIRTY         = (1 << 2)
 };
 
-#define GFX_SHADOW_ALPHA 0.50f
+#define GFX_SHADOW_ALPHA 0.75f
 
 /* Number of pixels corner-to-corner on a 1080p
  * display:

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -3136,7 +3136,7 @@ static void setting_get_string_representation_state_slot(rarch_setting_t *settin
 
    snprintf(s, len, "%d", *setting->value.target.integer);
    if (*setting->value.target.integer == -1)
-      strlcat(s, " (Auto)", len);
+      strlcpy(s, "Auto", len);
 }
 
 static void setting_get_string_representation_percentage(rarch_setting_t *setting,


### PR DESCRIPTION
## Description

Currently many menu entries are shortened without a valid reason, as in when the item is not a setting and/or does not have a value, or playlist item does not have a thumbnail. For example "Load Core",  "Core Downloader" and database entries. Therefore the goal is to not waste screen estate and force tickers when not necessary.

- More room for longer item labels and values
  - "Core Downloader" has extra space for item and "installed" indicator
- Fixed "Menu Scale Factor" to not require restarting to get the actual end result
- Adjusted scale factor to behave better with both layouts
- Fixed savestate thumbnails and adjusted vertical fade factor in "Handheld" layout
- Changed thumbnail shadow to outline and tightened fullscreen thumbnail margins
- Adjusted global shadow opacity

For example this value in 1.00x scale no longer goes to ticker mode:
![retroarch_2023_02_16_07_04_25_026](https://user-images.githubusercontent.com/45124675/219357491-b009d087-ed73-464e-b7b1-5e38b4f160d5.png)

And even the longest core names fit due to the extra space:
![retroarch_2023_02_16_13_55_12_850](https://user-images.githubusercontent.com/45124675/219358504-314a8e26-4732-40d0-9f50-d18ceaa3a62d.png)

Let me know if something became worse.

## Related Issues

Closes #6396

