### PR TITLE
Various memory access fixes to prevent crashes (#14459)

### DIFF
--- a/input/drivers_hid/iohidmanager_hid.c
+++ b/input/drivers_hid/iohidmanager_hid.c
@@ -544,6 +544,7 @@ static void iohidmanager_hid_device_remove(IOHIDDeviceRef device, iohidmanager_h
           free(tmp);
       }
       free(adapter);
+      adapter = NULL;
    }
    RARCH_LOG("Device removed from port %d\n", slot);
 }
@@ -702,6 +703,10 @@ static void iohidmanager_hid_device_add(IOHIDDeviceRef device, iohidmanager_hid_
 
    /* scan for buttons, axis, hats */
    elements_raw = IOHIDDeviceCopyMatchingElements(device, NULL, kIOHIDOptionsTypeNone);
+
+   if (!elements_raw)
+      goto error;
+
    count        = (int)CFArrayGetCount(elements_raw);
    elements     = CFArrayCreateMutableCopy(
          kCFAllocatorDefault,(CFIndex)count,elements_raw);
@@ -940,6 +945,7 @@ error:
          free(tmp);
       }
       free(adapter);
+      adapter = NULL;
    }
 }
 

--- a/tasks/task_autodetect.c
+++ b/tasks/task_autodetect.c
@@ -63,6 +63,9 @@ typedef struct
 
 static void free_autoconfig_handle(autoconfig_handle_t *autoconfig_handle)
 {
+   if (!autoconfig_handle)
+      return;
+
    if (autoconfig_handle->dir_autoconfig)
    {
       free(autoconfig_handle->dir_autoconfig);
@@ -743,9 +746,7 @@ error:
       task = NULL;
    }
 
-   if (autoconfig_handle)
-      free_autoconfig_handle(autoconfig_handle);
-   autoconfig_handle = NULL;
+   free_autoconfig_handle(autoconfig_handle);
    return false;
 }
 
@@ -928,7 +929,6 @@ error:
    }
 
    free_autoconfig_handle(autoconfig_handle);
-   autoconfig_handle = NULL;
 
    return false;
 }


### PR DESCRIPTION
Prevent double free and null dereference when the controller is quickly reconnected.
Handle error when controller device query returns null instead of crashing.
