### PR TITLE
Fix initial blurriness on Metal

### DIFF
--- a/gfx/drivers/metal.m
+++ b/gfx/drivers/metal.m
@@ -174,7 +174,9 @@
 
       [apple_platform setVideoMode:mode];
 
+#ifdef HAVE_COCOATOUCH
       [self mtkView:view drawableSizeWillChange:CGSizeMake(mode.width, mode.height)];
+#endif
 
       *input         = NULL;
       *inputData     = NULL;

--- a/ui/drivers/ui_cocoa.m
+++ b/ui/drivers/ui_cocoa.m
@@ -701,6 +701,10 @@ static ui_application_t ui_application_cocoa = {
       [self updateWindowedMode];
    }
 
+   /* HACK(sgc): ensure MTKView posts a drawable resize event */
+   if (mode.width > 0)
+       [self.window setContentSize:NSMakeSize(mode.width-1, mode.height)];
+   [self.window setContentSize:NSMakeSize(mode.width, mode.height)];
    [self.window displayIfNeeded];
 }
 


### PR DESCRIPTION
This reverts #14963 and part of #14942. Instead of forcing a size change on mac the way we do on tvos, bring back the old way of making two setContentSize calls.