### PR TITLE
(PSL1GHT) Code cleanup

### DIFF
--- a/Makefile.psl1ght
+++ b/Makefile.psl1ght
@@ -33,7 +33,7 @@ LIBDIRS += -L. -L$(PORTLIBS)/lib
 MACHDEP := -D__PSL1GHT__ -D__PS3__ -mcpu=cell
 CFLAGS += -Wall $(MACHDEP) $(INCLUDE)
 LDFLAGS := $(MACHDEP)
-LIBS := -lretro_psl1ght -laudio -lrsx -lgcm_sys -lnet -lio -lsysutil -lsysmodule -lm -ljpgdec -lpngdec -llv2 -lnet -lnetctl -lsysfs -lfreetype -lcamera -lgem -lspurs
+LIBS := -lretro_psl1ght -lrt -laudio -lrsx -lgcm_sys -lnet -lio -lsysutil -lsysmodule -lm -ljpgdec -lpngdec -llv2 -lnet -lnetctl -lsysfs -lfreetype -lcamera -lgem -lspurs
 
 # system platform
 system_platform = unix

--- a/frontend/drivers/platform_ps3.c
+++ b/frontend/drivers/platform_ps3.c
@@ -646,14 +646,14 @@ static void frontend_ps3_process_args(int *argc, char *argv[])
 static size_t frontend_ps3_get_mem_total(void)
 {
    sys_memory_info_t mem_info;
-   sys_memory_get_user_memory_size(&mem_info);
+   sys_memory_get_user_memory_size((u64)&mem_info);
    return mem_info.total;
 }
 
 static size_t frontend_ps3_get_mem_used(void)
 {
    sys_memory_info_t mem_info;
-   sys_memory_get_user_memory_size(&mem_info);
+   sys_memory_get_user_memory_size((u64)&mem_info);
    return mem_info.avail;
 }
 #endif

--- a/gfx/common/rsx_common.h
+++ b/gfx/common/rsx_common.h
@@ -38,6 +38,9 @@
 #define RSX_MAX_TEXTURE_VERTICES 4096 // Set > 0 for preallocated texture vertices
 #define RSX_MAX_FONT_VERTICES 8192
 
+#define RSX_SHADER_STOCK_BLEND (RSX_MAX_SHADERS - 1)
+#define RSX_SHADER_MENU        (RSX_MAX_SHADERS - 2)
+
 /* Shader objects */
 extern const u8 modern_opaque_vpo_end[];
 extern const u8 modern_opaque_vpo[];

--- a/gfx/drivers/rsx_gfx.c
+++ b/gfx/drivers/rsx_gfx.c
@@ -536,46 +536,46 @@ static void rsx_init_shader(rsx_t *rsx)
 {
    u32 fpsize                                 = 0;
    u32 vpsize                                 = 0;
-   rsx->vp_ucode[VIDEO_SHADER_MENU]           = NULL;
-   rsx->fp_ucode[VIDEO_SHADER_MENU]           = NULL;
-   rsx->vpo[VIDEO_SHADER_MENU]                = (rsxVertexProgram *)modern_opaque_vpo;
-   rsx->fpo[VIDEO_SHADER_MENU]                = (rsxFragmentProgram *)modern_opaque_fpo;
-   rsxVertexProgramGetUCode(rsx->vpo[VIDEO_SHADER_MENU], &rsx->vp_ucode[VIDEO_SHADER_MENU], &vpsize);
-   rsxFragmentProgramGetUCode(rsx->fpo[VIDEO_SHADER_MENU], &rsx->fp_ucode[VIDEO_SHADER_MENU], &fpsize);
-   rsx->fp_buffer[VIDEO_SHADER_MENU]          = (u32 *)rsxMemalign(64, fpsize);
-   if (!rsx->fp_buffer[VIDEO_SHADER_MENU])
+   rsx->vp_ucode[RSX_SHADER_MENU]           = NULL;
+   rsx->fp_ucode[RSX_SHADER_MENU]           = NULL;
+   rsx->vpo[RSX_SHADER_MENU]                = (rsxVertexProgram *)modern_opaque_vpo;
+   rsx->fpo[RSX_SHADER_MENU]                = (rsxFragmentProgram *)modern_opaque_fpo;
+   rsxVertexProgramGetUCode(rsx->vpo[RSX_SHADER_MENU], &rsx->vp_ucode[RSX_SHADER_MENU], &vpsize);
+   rsxFragmentProgramGetUCode(rsx->fpo[RSX_SHADER_MENU], &rsx->fp_ucode[RSX_SHADER_MENU], &fpsize);
+   rsx->fp_buffer[RSX_SHADER_MENU]          = (u32 *)rsxMemalign(64, fpsize);
+   if (!rsx->fp_buffer[RSX_SHADER_MENU])
    {
       RARCH_LOG("failed to allocate fp_buffer\n");
       return;
    }
-   memcpy(rsx->fp_buffer[VIDEO_SHADER_MENU], rsx->fp_ucode[VIDEO_SHADER_MENU], fpsize);
-   rsxAddressToOffset(rsx->fp_buffer[VIDEO_SHADER_MENU], &rsx->fp_offset[VIDEO_SHADER_MENU]);
-   rsx->proj_matrix[VIDEO_SHADER_MENU]        = rsxVertexProgramGetConst(rsx->vpo[VIDEO_SHADER_MENU], "modelViewProj");
-   rsx->pos_index[VIDEO_SHADER_MENU]          = rsxVertexProgramGetAttrib(rsx->vpo[VIDEO_SHADER_MENU], "position");
-   rsx->col_index[VIDEO_SHADER_MENU]          = rsxVertexProgramGetAttrib(rsx->vpo[VIDEO_SHADER_MENU], "color");
-   rsx->uv_index[VIDEO_SHADER_MENU]           = rsxVertexProgramGetAttrib(rsx->vpo[VIDEO_SHADER_MENU], "texcoord");
-   rsx->tex_unit[VIDEO_SHADER_MENU]           = rsxFragmentProgramGetAttrib(rsx->fpo[VIDEO_SHADER_MENU], "texture");
+   memcpy(rsx->fp_buffer[RSX_SHADER_MENU], rsx->fp_ucode[RSX_SHADER_MENU], fpsize);
+   rsxAddressToOffset(rsx->fp_buffer[RSX_SHADER_MENU], &rsx->fp_offset[RSX_SHADER_MENU]);
+   rsx->proj_matrix[RSX_SHADER_MENU]        = rsxVertexProgramGetConst(rsx->vpo[RSX_SHADER_MENU], "modelViewProj");
+   rsx->pos_index[RSX_SHADER_MENU]          = rsxVertexProgramGetAttrib(rsx->vpo[RSX_SHADER_MENU], "position");
+   rsx->col_index[RSX_SHADER_MENU]          = rsxVertexProgramGetAttrib(rsx->vpo[RSX_SHADER_MENU], "color");
+   rsx->uv_index[RSX_SHADER_MENU]           = rsxVertexProgramGetAttrib(rsx->vpo[RSX_SHADER_MENU], "texcoord");
+   rsx->tex_unit[RSX_SHADER_MENU]           = rsxFragmentProgramGetAttrib(rsx->fpo[RSX_SHADER_MENU], "texture");
 
-   rsx->vp_ucode[VIDEO_SHADER_STOCK_BLEND]    = NULL;
-   rsx->fp_ucode[VIDEO_SHADER_STOCK_BLEND]    = NULL;
-   rsx->vpo[VIDEO_SHADER_STOCK_BLEND]         = (rsxVertexProgram *)modern_alpha_blend_vpo;
-   rsx->fpo[VIDEO_SHADER_STOCK_BLEND]         = (rsxFragmentProgram *)modern_alpha_blend_fpo;
-   rsxVertexProgramGetUCode(rsx->vpo[VIDEO_SHADER_STOCK_BLEND], &rsx->vp_ucode[VIDEO_SHADER_STOCK_BLEND], &vpsize);
-   rsxFragmentProgramGetUCode(rsx->fpo[VIDEO_SHADER_STOCK_BLEND], &rsx->fp_ucode[VIDEO_SHADER_STOCK_BLEND], &fpsize);
-   rsx->fp_buffer[VIDEO_SHADER_STOCK_BLEND]   = (u32 *)rsxMemalign(64, fpsize);
-   if (!rsx->fp_buffer[VIDEO_SHADER_STOCK_BLEND])
+   rsx->vp_ucode[RSX_SHADER_STOCK_BLEND]    = NULL;
+   rsx->fp_ucode[RSX_SHADER_STOCK_BLEND]    = NULL;
+   rsx->vpo[RSX_SHADER_STOCK_BLEND]         = (rsxVertexProgram *)modern_alpha_blend_vpo;
+   rsx->fpo[RSX_SHADER_STOCK_BLEND]         = (rsxFragmentProgram *)modern_alpha_blend_fpo;
+   rsxVertexProgramGetUCode(rsx->vpo[RSX_SHADER_STOCK_BLEND], &rsx->vp_ucode[RSX_SHADER_STOCK_BLEND], &vpsize);
+   rsxFragmentProgramGetUCode(rsx->fpo[RSX_SHADER_STOCK_BLEND], &rsx->fp_ucode[RSX_SHADER_STOCK_BLEND], &fpsize);
+   rsx->fp_buffer[RSX_SHADER_STOCK_BLEND]   = (u32 *)rsxMemalign(64, fpsize);
+   if (!rsx->fp_buffer[RSX_SHADER_STOCK_BLEND])
    {
       RARCH_LOG("failed to allocate fp_buffer\n");
       return;
    }
-   memcpy(rsx->fp_buffer[VIDEO_SHADER_STOCK_BLEND], rsx->fp_ucode[VIDEO_SHADER_STOCK_BLEND], fpsize);
-   rsxAddressToOffset(rsx->fp_buffer[VIDEO_SHADER_STOCK_BLEND], &rsx->fp_offset[VIDEO_SHADER_STOCK_BLEND]);
-   rsx->proj_matrix[VIDEO_SHADER_STOCK_BLEND] = rsxVertexProgramGetConst(rsx->vpo[VIDEO_SHADER_STOCK_BLEND], "modelViewProj");
-   rsx->pos_index[VIDEO_SHADER_STOCK_BLEND]   = rsxVertexProgramGetAttrib(rsx->vpo[VIDEO_SHADER_STOCK_BLEND], "position");
-   rsx->col_index[VIDEO_SHADER_STOCK_BLEND]   = rsxVertexProgramGetAttrib(rsx->vpo[VIDEO_SHADER_STOCK_BLEND], "color");
-   rsx->uv_index[VIDEO_SHADER_STOCK_BLEND]    = rsxVertexProgramGetAttrib(rsx->vpo[VIDEO_SHADER_STOCK_BLEND], "texcoord");
-   rsx->tex_unit[VIDEO_SHADER_STOCK_BLEND]    = rsxFragmentProgramGetAttrib(rsx->fpo[VIDEO_SHADER_STOCK_BLEND], "texture");
-   rsx->bgcolor[VIDEO_SHADER_STOCK_BLEND]     = rsxFragmentProgramGetConst(rsx->fpo[VIDEO_SHADER_STOCK_BLEND], "bgcolor");
+   memcpy(rsx->fp_buffer[RSX_SHADER_STOCK_BLEND], rsx->fp_ucode[RSX_SHADER_STOCK_BLEND], fpsize);
+   rsxAddressToOffset(rsx->fp_buffer[RSX_SHADER_STOCK_BLEND], &rsx->fp_offset[RSX_SHADER_STOCK_BLEND]);
+   rsx->proj_matrix[RSX_SHADER_STOCK_BLEND] = rsxVertexProgramGetConst(rsx->vpo[RSX_SHADER_STOCK_BLEND], "modelViewProj");
+   rsx->pos_index[RSX_SHADER_STOCK_BLEND]   = rsxVertexProgramGetAttrib(rsx->vpo[RSX_SHADER_STOCK_BLEND], "position");
+   rsx->col_index[RSX_SHADER_STOCK_BLEND]   = rsxVertexProgramGetAttrib(rsx->vpo[RSX_SHADER_STOCK_BLEND], "color");
+   rsx->uv_index[RSX_SHADER_STOCK_BLEND]    = rsxVertexProgramGetAttrib(rsx->vpo[RSX_SHADER_STOCK_BLEND], "texcoord");
+   rsx->tex_unit[RSX_SHADER_STOCK_BLEND]    = rsxFragmentProgramGetAttrib(rsx->fpo[RSX_SHADER_STOCK_BLEND], "texture");
+   rsx->bgcolor[RSX_SHADER_STOCK_BLEND]     = rsxFragmentProgramGetConst(rsx->fpo[RSX_SHADER_STOCK_BLEND], "bgcolor");
 }
 
 static void* rsx_init(const video_info_t* video,
@@ -919,21 +919,21 @@ static void rsx_blit_buffer(
 static void rsx_set_texture(rsx_t* rsx, rsx_texture_t *texture)
 {
    rsxInvalidateTextureCache(rsx->context, GCM_INVALIDATE_TEXTURE);
-   rsxLoadTexture(rsx->context, rsx->tex_unit[VIDEO_SHADER_MENU]->index, &texture->tex);
-   rsxTextureControl(rsx->context, rsx->tex_unit[VIDEO_SHADER_MENU]->index, GCM_TRUE, 0 << 8, 12 << 8, GCM_TEXTURE_MAX_ANISO_1);
-   rsxTextureFilter(rsx->context, rsx->tex_unit[VIDEO_SHADER_MENU]->index, 0, texture->min_filter, texture->mag_filter, GCM_TEXTURE_CONVOLUTION_QUINCUNX);
-   rsxTextureWrapMode(rsx->context, rsx->tex_unit[VIDEO_SHADER_MENU]->index, texture->wrap_s, texture->wrap_t, GCM_TEXTURE_CLAMP_TO_EDGE,
+   rsxLoadTexture(rsx->context, rsx->tex_unit[RSX_SHADER_MENU]->index, &texture->tex);
+   rsxTextureControl(rsx->context, rsx->tex_unit[RSX_SHADER_MENU]->index, GCM_TRUE, 0 << 8, 12 << 8, GCM_TEXTURE_MAX_ANISO_1);
+   rsxTextureFilter(rsx->context, rsx->tex_unit[RSX_SHADER_MENU]->index, 0, texture->min_filter, texture->mag_filter, GCM_TEXTURE_CONVOLUTION_QUINCUNX);
+   rsxTextureWrapMode(rsx->context, rsx->tex_unit[RSX_SHADER_MENU]->index, texture->wrap_s, texture->wrap_t, GCM_TEXTURE_CLAMP_TO_EDGE,
          0, GCM_TEXTURE_ZFUNC_LESS, 0);
 }
 
 static void rsx_set_menu_texture(rsx_t* rsx, rsx_texture_t *texture)
 {
    rsxInvalidateTextureCache(rsx->context, GCM_INVALIDATE_TEXTURE);
-   rsxLoadTexture(rsx->context, rsx->tex_unit[VIDEO_SHADER_STOCK_BLEND]->index, &texture->tex);
-   rsxTextureControl(rsx->context, rsx->tex_unit[VIDEO_SHADER_STOCK_BLEND]->index, GCM_TRUE, 0 << 8, 12 << 8, GCM_TEXTURE_MAX_ANISO_1);
-   rsxTextureFilter(rsx->context, rsx->tex_unit[VIDEO_SHADER_STOCK_BLEND]->index, 0, texture->min_filter,
+   rsxLoadTexture(rsx->context, rsx->tex_unit[RSX_SHADER_STOCK_BLEND]->index, &texture->tex);
+   rsxTextureControl(rsx->context, rsx->tex_unit[RSX_SHADER_STOCK_BLEND]->index, GCM_TRUE, 0 << 8, 12 << 8, GCM_TEXTURE_MAX_ANISO_1);
+   rsxTextureFilter(rsx->context, rsx->tex_unit[RSX_SHADER_STOCK_BLEND]->index, 0, texture->min_filter,
          texture->mag_filter, GCM_TEXTURE_CONVOLUTION_QUINCUNX);
-   rsxTextureWrapMode(rsx->context, rsx->tex_unit[VIDEO_SHADER_STOCK_BLEND]->index, texture->wrap_s,
+   rsxTextureWrapMode(rsx->context, rsx->tex_unit[RSX_SHADER_STOCK_BLEND]->index, texture->wrap_s,
          texture->wrap_t, GCM_TEXTURE_CLAMP_TO_EDGE, 0, GCM_TEXTURE_ZFUNC_LESS, 0);
 }
 
@@ -1014,21 +1014,21 @@ static void rsx_draw_vertices(rsx_t* rsx)
    vertices[rsx->vert_idx+3].b = 1.0f;
    vertices[rsx->vert_idx+3].a = 1.0f;
 
-   rsxAddressToOffset(&vertices[rsx->vert_idx].x, &rsx->pos_offset[VIDEO_SHADER_MENU]);
-   rsxAddressToOffset(&vertices[rsx->vert_idx].u, &rsx->uv_offset[VIDEO_SHADER_MENU]);
-   rsxAddressToOffset(&vertices[rsx->vert_idx].r, &rsx->col_offset[VIDEO_SHADER_MENU]);
+   rsxAddressToOffset(&vertices[rsx->vert_idx].x, &rsx->pos_offset[RSX_SHADER_MENU]);
+   rsxAddressToOffset(&vertices[rsx->vert_idx].u, &rsx->uv_offset[RSX_SHADER_MENU]);
+   rsxAddressToOffset(&vertices[rsx->vert_idx].r, &rsx->col_offset[RSX_SHADER_MENU]);
    rsx->vert_idx               = end_vert_idx;
 
-   rsxBindVertexArrayAttrib(rsx->context, rsx->pos_index[VIDEO_SHADER_MENU]->index, 0,
-         rsx->pos_offset[VIDEO_SHADER_MENU], sizeof(rsx_vertex_t), 2, GCM_VERTEX_DATA_TYPE_F32, GCM_LOCATION_RSX);
-   rsxBindVertexArrayAttrib(rsx->context, rsx->uv_index[VIDEO_SHADER_MENU]->index, 0,
-         rsx->uv_offset[VIDEO_SHADER_MENU], sizeof(rsx_vertex_t), 2, GCM_VERTEX_DATA_TYPE_F32, GCM_LOCATION_RSX);
-   rsxBindVertexArrayAttrib(rsx->context, rsx->col_index[VIDEO_SHADER_MENU]->index, 0,
-         rsx->col_offset[VIDEO_SHADER_MENU], sizeof(rsx_vertex_t), 4, GCM_VERTEX_DATA_TYPE_F32, GCM_LOCATION_RSX);
+   rsxBindVertexArrayAttrib(rsx->context, rsx->pos_index[RSX_SHADER_MENU]->index, 0,
+         rsx->pos_offset[RSX_SHADER_MENU], sizeof(rsx_vertex_t), 2, GCM_VERTEX_DATA_TYPE_F32, GCM_LOCATION_RSX);
+   rsxBindVertexArrayAttrib(rsx->context, rsx->uv_index[RSX_SHADER_MENU]->index, 0,
+         rsx->uv_offset[RSX_SHADER_MENU], sizeof(rsx_vertex_t), 2, GCM_VERTEX_DATA_TYPE_F32, GCM_LOCATION_RSX);
+   rsxBindVertexArrayAttrib(rsx->context, rsx->col_index[RSX_SHADER_MENU]->index, 0,
+         rsx->col_offset[RSX_SHADER_MENU], sizeof(rsx_vertex_t), 4, GCM_VERTEX_DATA_TYPE_F32, GCM_LOCATION_RSX);
 
-   rsxLoadVertexProgram(rsx->context, rsx->vpo[VIDEO_SHADER_MENU], rsx->vp_ucode[VIDEO_SHADER_MENU]);
-   rsxSetVertexProgramParameter(rsx->context, rsx->vpo[VIDEO_SHADER_MENU], rsx->proj_matrix[VIDEO_SHADER_MENU], (float *)&rsx->mvp);
-   rsxLoadFragmentProgramLocation(rsx->context, rsx->fpo[VIDEO_SHADER_MENU], rsx->fp_offset[VIDEO_SHADER_MENU], GCM_LOCATION_RSX);
+   rsxLoadVertexProgram(rsx->context, rsx->vpo[RSX_SHADER_MENU], rsx->vp_ucode[RSX_SHADER_MENU]);
+   rsxSetVertexProgramParameter(rsx->context, rsx->vpo[RSX_SHADER_MENU], rsx->proj_matrix[RSX_SHADER_MENU], (float *)&rsx->mvp);
+   rsxLoadFragmentProgramLocation(rsx->context, rsx->fpo[RSX_SHADER_MENU], rsx->fp_offset[RSX_SHADER_MENU], GCM_LOCATION_RSX);
 
    rsxClearSurface(rsx->context, GCM_CLEAR_Z);
    rsxDrawVertexArray(rsx->context, GCM_TYPE_TRIANGLE_STRIP, 0, 4);
@@ -1082,21 +1082,21 @@ static void rsx_draw_menu_vertices(rsx_t* rsx)
    vertices[rsx->vert_idx+3].b = 1.0f;
    vertices[rsx->vert_idx+3].a = rsx->menu_texture_alpha;
 
-   rsxAddressToOffset(&vertices[rsx->vert_idx].x, &rsx->pos_offset[VIDEO_SHADER_STOCK_BLEND]);
-   rsxAddressToOffset(&vertices[rsx->vert_idx].u, &rsx->uv_offset[VIDEO_SHADER_STOCK_BLEND]);
-   rsxAddressToOffset(&vertices[rsx->vert_idx].r, &rsx->col_offset[VIDEO_SHADER_STOCK_BLEND]);
+   rsxAddressToOffset(&vertices[rsx->vert_idx].x, &rsx->pos_offset[RSX_SHADER_STOCK_BLEND]);
+   rsxAddressToOffset(&vertices[rsx->vert_idx].u, &rsx->uv_offset[RSX_SHADER_STOCK_BLEND]);
+   rsxAddressToOffset(&vertices[rsx->vert_idx].r, &rsx->col_offset[RSX_SHADER_STOCK_BLEND]);
    rsx->vert_idx = end_vert_idx;
 
-   rsxBindVertexArrayAttrib(rsx->context, rsx->pos_index[VIDEO_SHADER_STOCK_BLEND]->index, 0,
-         rsx->pos_offset[VIDEO_SHADER_STOCK_BLEND], sizeof(rsx_vertex_t), 2, GCM_VERTEX_DATA_TYPE_F32, GCM_LOCATION_RSX);
-   rsxBindVertexArrayAttrib(rsx->context, rsx->uv_index[VIDEO_SHADER_STOCK_BLEND]->index, 0,
-         rsx->uv_offset[VIDEO_SHADER_STOCK_BLEND], sizeof(rsx_vertex_t), 2, GCM_VERTEX_DATA_TYPE_F32, GCM_LOCATION_RSX);
-   rsxBindVertexArrayAttrib(rsx->context, rsx->col_index[VIDEO_SHADER_STOCK_BLEND]->index, 0,
-         rsx->col_offset[VIDEO_SHADER_STOCK_BLEND], sizeof(rsx_vertex_t), 4, GCM_VERTEX_DATA_TYPE_F32, GCM_LOCATION_RSX);
+   rsxBindVertexArrayAttrib(rsx->context, rsx->pos_index[RSX_SHADER_STOCK_BLEND]->index, 0,
+         rsx->pos_offset[RSX_SHADER_STOCK_BLEND], sizeof(rsx_vertex_t), 2, GCM_VERTEX_DATA_TYPE_F32, GCM_LOCATION_RSX);
+   rsxBindVertexArrayAttrib(rsx->context, rsx->uv_index[RSX_SHADER_STOCK_BLEND]->index, 0,
+         rsx->uv_offset[RSX_SHADER_STOCK_BLEND], sizeof(rsx_vertex_t), 2, GCM_VERTEX_DATA_TYPE_F32, GCM_LOCATION_RSX);
+   rsxBindVertexArrayAttrib(rsx->context, rsx->col_index[RSX_SHADER_STOCK_BLEND]->index, 0,
+         rsx->col_offset[RSX_SHADER_STOCK_BLEND], sizeof(rsx_vertex_t), 4, GCM_VERTEX_DATA_TYPE_F32, GCM_LOCATION_RSX);
 
-   rsxLoadVertexProgram(rsx->context, rsx->vpo[VIDEO_SHADER_STOCK_BLEND], rsx->vp_ucode[VIDEO_SHADER_STOCK_BLEND]);
-   rsxSetVertexProgramParameter(rsx->context, rsx->vpo[VIDEO_SHADER_STOCK_BLEND], rsx->proj_matrix[VIDEO_SHADER_STOCK_BLEND], (float *)&rsx->mvp_no_rot);
-   rsxLoadFragmentProgramLocation(rsx->context, rsx->fpo[VIDEO_SHADER_STOCK_BLEND], rsx->fp_offset[VIDEO_SHADER_STOCK_BLEND], GCM_LOCATION_RSX);
+   rsxLoadVertexProgram(rsx->context, rsx->vpo[RSX_SHADER_STOCK_BLEND], rsx->vp_ucode[RSX_SHADER_STOCK_BLEND]);
+   rsxSetVertexProgramParameter(rsx->context, rsx->vpo[RSX_SHADER_STOCK_BLEND], rsx->proj_matrix[RSX_SHADER_STOCK_BLEND], (float *)&rsx->mvp_no_rot);
+   rsxLoadFragmentProgramLocation(rsx->context, rsx->fpo[RSX_SHADER_STOCK_BLEND], rsx->fp_offset[RSX_SHADER_STOCK_BLEND], GCM_LOCATION_RSX);
 
    rsxSetBlendEnable(rsx->context, GCM_TRUE);
    rsxSetBlendFunc(rsx->context, GCM_SRC_ALPHA, GCM_ONE_MINUS_SRC_ALPHA, GCM_SRC_ALPHA, GCM_ONE_MINUS_SRC_ALPHA);

--- a/gfx/drivers_display/gfx_display_rsx.c
+++ b/gfx/drivers_display/gfx_display_rsx.c
@@ -105,12 +105,12 @@ static void gfx_display_rsx_draw(gfx_display_ctx_draw_t *draw,
    rsxSetViewport(rsx->context, vp.x, vp.y, vp.w, vp.h, vp.min, vp.max, vp.scale, vp.offset);
 
    rsxInvalidateTextureCache(rsx->context, GCM_INVALIDATE_TEXTURE);
-   rsxLoadTexture(rsx->context, rsx->tex_unit[VIDEO_SHADER_STOCK_BLEND]->index, &texture->tex);
-   rsxTextureControl(rsx->context, rsx->tex_unit[VIDEO_SHADER_STOCK_BLEND]->index,
+   rsxLoadTexture(rsx->context, rsx->tex_unit[RSX_SHADER_STOCK_BLEND]->index, &texture->tex);
+   rsxTextureControl(rsx->context, rsx->tex_unit[RSX_SHADER_STOCK_BLEND]->index,
          GCM_TRUE, 0 << 8, 12 << 8, GCM_TEXTURE_MAX_ANISO_1);
-   rsxTextureFilter(rsx->context, rsx->tex_unit[VIDEO_SHADER_STOCK_BLEND]->index, 0,
+   rsxTextureFilter(rsx->context, rsx->tex_unit[RSX_SHADER_STOCK_BLEND]->index, 0,
          texture->min_filter, texture->mag_filter, GCM_TEXTURE_CONVOLUTION_QUINCUNX);
-   rsxTextureWrapMode(rsx->context, rsx->tex_unit[VIDEO_SHADER_STOCK_BLEND]->index, texture->wrap_s,
+   rsxTextureWrapMode(rsx->context, rsx->tex_unit[RSX_SHADER_STOCK_BLEND]->index, texture->wrap_s,
          texture->wrap_t, GCM_TEXTURE_CLAMP_TO_EDGE, 0, GCM_TEXTURE_ZFUNC_LESS, 0);
 
 #if RSX_MAX_TEXTURE_VERTICES > 0
@@ -140,30 +140,30 @@ static void gfx_display_rsx_draw(gfx_display_ctx_draw_t *draw,
       vertices[i].a         = *color++;
    }
    rsxAddressToOffset(&vertices[rsx->texture_vert_idx].x,
-         &rsx->pos_offset[VIDEO_SHADER_STOCK_BLEND]);
+         &rsx->pos_offset[RSX_SHADER_STOCK_BLEND]);
    rsxAddressToOffset(&vertices[rsx->texture_vert_idx].u,
-         &rsx->uv_offset[VIDEO_SHADER_STOCK_BLEND]);
+         &rsx->uv_offset[RSX_SHADER_STOCK_BLEND]);
    rsxAddressToOffset(&vertices[rsx->texture_vert_idx].r,
-         &rsx->col_offset[VIDEO_SHADER_STOCK_BLEND]);
+         &rsx->col_offset[RSX_SHADER_STOCK_BLEND]);
    rsx->texture_vert_idx  = end_vert_idx;
 
-   rsxBindVertexArrayAttrib(rsx->context, rsx->pos_index[VIDEO_SHADER_STOCK_BLEND]->index, 0,
-         rsx->pos_offset[VIDEO_SHADER_STOCK_BLEND], sizeof(rsx_vertex_t), 2,
+   rsxBindVertexArrayAttrib(rsx->context, rsx->pos_index[RSX_SHADER_STOCK_BLEND]->index, 0,
+         rsx->pos_offset[RSX_SHADER_STOCK_BLEND], sizeof(rsx_vertex_t), 2,
          GCM_VERTEX_DATA_TYPE_F32, GCM_LOCATION_RSX);
-   rsxBindVertexArrayAttrib(rsx->context, rsx->uv_index[VIDEO_SHADER_STOCK_BLEND]->index, 0,
-         rsx->uv_offset[VIDEO_SHADER_STOCK_BLEND], sizeof(rsx_vertex_t), 2,
+   rsxBindVertexArrayAttrib(rsx->context, rsx->uv_index[RSX_SHADER_STOCK_BLEND]->index, 0,
+         rsx->uv_offset[RSX_SHADER_STOCK_BLEND], sizeof(rsx_vertex_t), 2,
          GCM_VERTEX_DATA_TYPE_F32, GCM_LOCATION_RSX);
-   rsxBindVertexArrayAttrib(rsx->context, rsx->col_index[VIDEO_SHADER_STOCK_BLEND]->index, 0,
-         rsx->col_offset[VIDEO_SHADER_STOCK_BLEND], sizeof(rsx_vertex_t), 4,
+   rsxBindVertexArrayAttrib(rsx->context, rsx->col_index[RSX_SHADER_STOCK_BLEND]->index, 0,
+         rsx->col_offset[RSX_SHADER_STOCK_BLEND], sizeof(rsx_vertex_t), 4,
          GCM_VERTEX_DATA_TYPE_F32, GCM_LOCATION_RSX);
 
-   rsxLoadVertexProgram(rsx->context, rsx->vpo[VIDEO_SHADER_STOCK_BLEND],
-         rsx->vp_ucode[VIDEO_SHADER_STOCK_BLEND]);
+   rsxLoadVertexProgram(rsx->context, rsx->vpo[RSX_SHADER_STOCK_BLEND],
+         rsx->vp_ucode[RSX_SHADER_STOCK_BLEND]);
    rsxSetVertexProgramParameter(rsx->context,
-         rsx->vpo[VIDEO_SHADER_STOCK_BLEND], rsx->proj_matrix[VIDEO_SHADER_STOCK_BLEND],
+         rsx->vpo[RSX_SHADER_STOCK_BLEND], rsx->proj_matrix[RSX_SHADER_STOCK_BLEND],
          (float *)&rsx->mvp_no_rot);
    rsxLoadFragmentProgramLocation(rsx->context,
-         rsx->fpo[VIDEO_SHADER_STOCK_BLEND], rsx->fp_offset[VIDEO_SHADER_STOCK_BLEND],
+         rsx->fpo[RSX_SHADER_STOCK_BLEND], rsx->fp_offset[RSX_SHADER_STOCK_BLEND],
          GCM_LOCATION_RSX);
 
    rsxClearSurface(rsx->context, GCM_CLEAR_Z);

--- a/gfx/drivers_font/rsx_font.c
+++ b/gfx/drivers_font/rsx_font.c
@@ -161,17 +161,17 @@ static void *rsx_font_init(void *data,
 
    font->atlas        = font->font_driver->get_atlas(font->font_data);
 
-   font->vpo          = font->rsx->vpo[VIDEO_SHADER_STOCK_BLEND];
-   font->fpo          = font->rsx->fpo[VIDEO_SHADER_STOCK_BLEND];
-   font->fp_ucode     = font->rsx->fp_ucode[VIDEO_SHADER_STOCK_BLEND];
-   font->vp_ucode     = font->rsx->vp_ucode[VIDEO_SHADER_STOCK_BLEND];
-   font->fp_offset    = font->rsx->fp_offset[VIDEO_SHADER_STOCK_BLEND];
+   font->vpo          = font->rsx->vpo[RSX_SHADER_STOCK_BLEND];
+   font->fpo          = font->rsx->fpo[RSX_SHADER_STOCK_BLEND];
+   font->fp_ucode     = font->rsx->fp_ucode[RSX_SHADER_STOCK_BLEND];
+   font->vp_ucode     = font->rsx->vp_ucode[RSX_SHADER_STOCK_BLEND];
+   font->fp_offset    = font->rsx->fp_offset[RSX_SHADER_STOCK_BLEND];
 
-   font->proj_matrix  = font->rsx->proj_matrix[VIDEO_SHADER_STOCK_BLEND];
-   font->pos_index    = font->rsx->pos_index[VIDEO_SHADER_STOCK_BLEND];
-   font->uv_index     = font->rsx->uv_index[VIDEO_SHADER_STOCK_BLEND];
-   font->col_index    = font->rsx->col_index[VIDEO_SHADER_STOCK_BLEND];
-   font->tex_unit     = font->rsx->tex_unit[VIDEO_SHADER_STOCK_BLEND];
+   font->proj_matrix  = font->rsx->proj_matrix[RSX_SHADER_STOCK_BLEND];
+   font->pos_index    = font->rsx->pos_index[RSX_SHADER_STOCK_BLEND];
+   font->uv_index     = font->rsx->uv_index[RSX_SHADER_STOCK_BLEND];
+   font->col_index    = font->rsx->col_index[RSX_SHADER_STOCK_BLEND];
+   font->tex_unit     = font->rsx->tex_unit[RSX_SHADER_STOCK_BLEND];
 
    font->vertices     = (rsx_vertex_t *)rsxMemalign(128, sizeof(rsx_vertex_t) * RSX_MAX_FONT_VERTICES);
    font->rsx->font_vert_idx = 0;

--- a/gfx/drivers_font/rsx_font.c
+++ b/gfx/drivers_font/rsx_font.c
@@ -45,7 +45,7 @@ typedef struct
    rsx_texture_t texture;
    u32 tex_width;
    u32 tex_height;
-   rsxProgramAttrib *proj_matrix;
+   rsxProgramConst *proj_matrix;
    rsxProgramAttrib *pos_index;
    rsxProgramAttrib *uv_index;
    rsxProgramAttrib *col_index;
@@ -178,7 +178,7 @@ static void *rsx_font_init(void *data,
 
    font->tex_width    = font->atlas->width;
    font->tex_height   = font->atlas->height;
-   font->texture.data = (u8 *)rsxMemalign(128, (font->tex_height * font->tex_width));
+   font->texture.data = (u32 *)rsxMemalign(128, (font->tex_height * font->tex_width));
    rsxAddressToOffset(font->texture.data, &font->texture.offset);
 
    if (!font->texture.data)

--- a/input/drivers/psl1ght_input.c
+++ b/input/drivers/psl1ght_input.c
@@ -207,9 +207,9 @@ static int ps3_process_gem(ps3_input_t *ps3, int t)
    switch (t)
    {
       case 0:
-         return gemUpdateStart(ps3->camread.buffer, ps3->camread.timestamp);
+         return gemUpdateStart((void *)(u64)ps3->camread.buffer, ps3->camread.timestamp);
       case 1:
-         return gemConvertVideoStart(ps3->camread.buffer);
+         return gemConvertVideoStart((void *)(u64)ps3->camread.buffer);
       case 2:
          return gemUpdateFinish();
       case 3:
@@ -638,7 +638,7 @@ static int16_t ps3_lightgun_device_state(ps3_input_t *ps3,
    float pointer_y;
    videoState state;
    videoResolution res;
-   VmathVector4 ray_start, ray_dir;
+   VmathVector3 ray_start, ray_dir;
    struct video_viewport vp;
    float center_y              = 0.0f;
    float center_x              = 0.0f;
@@ -681,10 +681,8 @@ static int16_t ps3_lightgun_device_state(ps3_input_t *ps3,
    /* tracking mode 1: laser pointer mode (this is closest 
       to actual lightgun behavior) */
    ray_start.vec128            = ps3->gem_state.pos;
-   VmathVector4 ray_tmp        = {.vec128 = {0.0f,0.0f,-1.0f,0.0f}};
-   const VmathQuat *quat       = &ps3->gem_state.quat; /* TODO/FIXME - warning - VmathVector3/VmathVector4 issue again */
-   /* TODO/FIXME - note: expected 'VmathVector3 * {aka struct _VmathVector3 *}' but argument is of type 'VmathVector4 * {aka struct _VmathVector4 *}'
-    * vmathQRotate takes type VmathVector3* instead of VmathVector4* */
+   VmathVector3 ray_tmp        = {.vec128 = {0.0f,0.0f,-1.0f,0.0f}};
+   const VmathQuat *quat       = (VmathQuat *)&ps3->gem_state.quat;
    vmathQRotate(&ray_dir, quat, &ray_tmp);
    float t                     = -ray_start.vec128[2] / ray_dir.vec128[2];
    pointer_x                   = ray_start.vec128[0] + ray_dir.vec128[0]*t;


### PR DESCRIPTION
This should cleanup most of the compiler warnings as seen from this [issue](https://github.com/libretro/RetroArch/issues/15001).