### PR TITLE
Add LOAD_STATE_SLOT N command to stdin/network protocol

### DIFF
--- a/command.c
+++ b/command.c
@@ -68,7 +68,7 @@
 
 #define CMD_BUF_SIZE           4096
 
-void command_post_state_loaded();
+void command_post_state_loaded(void);
 
 #if defined(HAVE_COMMAND)
 
@@ -670,14 +670,10 @@ bool command_load_state_slot(command_t *cmd, const char *arg)
    {
       ret = content_load_state(state_path, false, false);
       if(ret)
-      {
-          command_post_state_loaded();
-      }
+         command_post_state_loaded();
    }
    else
-   {
       ret = false;
-   }
 
    cmd->replier(cmd, reply, strlen(reply));
    return ret;
@@ -1707,7 +1703,7 @@ void command_event_remove_current_config(enum override_type type)
 }
 #endif
 
-void command_post_state_loaded()
+void command_post_state_loaded(void)
 {
 #ifdef HAVE_CHEEVOS
    if (rcheevos_hardcore_active())

--- a/command.c
+++ b/command.c
@@ -68,6 +68,8 @@
 
 #define CMD_BUF_SIZE           4096
 
+void command_post_state_loaded();
+
 #if defined(HAVE_COMMAND)
 
 /* Generic command parse utilities */
@@ -642,6 +644,45 @@ bool command_show_osd_msg(command_t *cmd, const char* arg)
           MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
     return true;
 }
+
+bool command_load_state_slot(command_t *cmd, const char *arg)
+{
+   retro_ctx_size_info_t info;
+   char reply[128]              = "";
+   runloop_state_t *runloop_st  = runloop_state_get_ptr();
+   const rarch_system_info_t
+      *system                   = &runloop_st->system;
+   unsigned int slot            = (unsigned int)strtoul(arg, NULL, 10);
+   char *reply_at               = reply + snprintf(reply, sizeof(reply) - 1, "LOAD_STATE_SLOT %d", slot);
+   bool savestates_enabled      = core_info_current_supports_savestate();
+   bool ret                     = false;
+   char state_path[16384];
+   state_path[0]                = '\0';
+   if (savestates_enabled)
+   {
+      runloop_get_current_savestate_path(state_path,
+            sizeof(state_path));
+
+      core_serialize_size(&info);
+      savestates_enabled = (info.size > 0);
+   }
+   if (savestates_enabled)
+   {
+      ret = content_load_state(state_path, false, false);
+      if(ret)
+      {
+          command_post_state_loaded();
+      }
+   }
+   else
+   {
+      ret = false;
+   }
+
+   cmd->replier(cmd, reply, strlen(reply));
+   return ret;
+}
+
 
 #if defined(HAVE_CHEEVOS)
 bool command_read_ram(command_t *cmd, const char *arg)
@@ -1666,6 +1707,29 @@ void command_event_remove_current_config(enum override_type type)
 }
 #endif
 
+void command_post_state_loaded()
+{
+#ifdef HAVE_CHEEVOS
+   if (rcheevos_hardcore_active())
+   {
+      rcheevos_pause_hardcore();
+      runloop_msg_queue_push(msg_hash_to_str(MSG_CHEEVOS_HARDCORE_MODE_DISABLED), 0, 180, true, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
+   }
+#endif
+#ifdef HAVE_NETWORKING
+   netplay_driver_ctl(RARCH_NETPLAY_CTL_LOAD_SAVESTATE, NULL);
+#endif
+   {
+     settings_t *settings        = config_get_ptr();
+     video_driver_state_t *video_st                 =
+       video_state_get_ptr();
+     bool frame_time_counter_reset_after_load_state =
+       settings->bools.frame_time_counter_reset_after_load_state;
+     if (frame_time_counter_reset_after_load_state)
+        video_st->frame_time_count = 0;
+   }
+}
+
 bool command_event_main_state(unsigned cmd)
 {
    retro_ctx_size_info_t info;
@@ -1733,25 +1797,8 @@ bool command_event_main_state(unsigned cmd)
 
                if (res)
                {
-#ifdef HAVE_CHEEVOS
-                  if (rcheevos_hardcore_active())
-                  {
-                     rcheevos_pause_hardcore();
-                     runloop_msg_queue_push(msg_hash_to_str(MSG_CHEEVOS_HARDCORE_MODE_DISABLED), 0, 180, true, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
-                  }
-#endif
+                  command_post_state_loaded();
                   ret = true;
-#ifdef HAVE_NETWORKING
-                  netplay_driver_ctl(RARCH_NETPLAY_CTL_LOAD_SAVESTATE, NULL);
-#endif
-                  {
-                     video_driver_state_t *video_st                 = 
-                        video_state_get_ptr();
-                     bool frame_time_counter_reset_after_load_state =
-                        settings->bools.frame_time_counter_reset_after_load_state;
-                     if (frame_time_counter_reset_after_load_state)
-                        video_st->frame_time_count = 0;
-                  }
                }
             }
             push_msg = false;

--- a/command.h
+++ b/command.h
@@ -396,6 +396,7 @@ bool command_version(command_t *cmd, const char* arg);
 bool command_get_status(command_t *cmd, const char* arg);
 bool command_get_config_param(command_t *cmd, const char* arg);
 bool command_show_osd_msg(command_t *cmd, const char* arg);
+bool command_load_state_slot(command_t *cmd, const char* arg);
 #ifdef HAVE_CHEEVOS
 bool command_read_ram(command_t *cmd, const char *arg);
 bool command_write_ram(command_t *cmd, const char *arg);
@@ -426,6 +427,8 @@ static const struct cmd_action_map action_map[] = {
 #endif
    { "READ_CORE_MEMORY", command_read_memory,      "<address> <number of bytes>" },
    { "WRITE_CORE_MEMORY",command_write_memory,     "<address> <byte1> <byte2> ..." },
+
+   {"LOAD_STATE_SLOT",command_load_state_slot, "<slot number>"}
 };
 
 static const struct cmd_map map[] = {

--- a/runloop.c
+++ b/runloop.c
@@ -7094,9 +7094,13 @@ void runloop_task_msg_queue_push(
 
 bool runloop_get_current_savestate_path(char *path, size_t len)
 {
-   runloop_state_t *runloop_st = &runloop_state;
    settings_t *settings        = config_get_ptr();
    int state_slot              = settings ? settings->ints.state_slot : 0;
+   return runloop_get_savestate_path(path, len, state_slot);
+}
+bool runloop_get_savestate_path(char *path, size_t len, unsigned state_slot)
+{
+   runloop_state_t *runloop_st = &runloop_state;
    const char *name_savestate  = NULL;
 
    if (!path)

--- a/runloop.h
+++ b/runloop.h
@@ -425,6 +425,8 @@ bool runloop_get_entry_state_path(char *path, size_t len, unsigned slot);
 
 bool runloop_get_current_savestate_path(char *path, size_t len);
 
+bool runloop_get_savestate_path(char *path, size_t len, unsigned slot);
+
 void runloop_state_free(runloop_state_t *runloop_st);
 
 void runloop_path_set_redirect(settings_t *settings, const char *a, const char *b);


### PR DESCRIPTION
This adds a LOAD_STATE_SLOT <slot number> command to the network and stdin protocols.  This way an external process can trigger loads of specific states.