### PR TITLE
(Vulkan) Ignore Fast-Forward Frameskip option

### DIFF
--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -2816,7 +2816,8 @@ void video_driver_build_info(video_frame_info_t *video_info)
    video_info->msg_queue_delay             = runloop_st->msg_queue_delay;
    video_info->runloop_is_paused           = runloop_st->flags & RUNLOOP_FLAG_PAUSED;
    video_info->runloop_is_slowmotion       = runloop_st->flags & RUNLOOP_FLAG_SLOWMOTION;
-   video_info->fastforward_frameskip       = settings->bools.fastforward_frameskip;
+   video_info->fastforward_frameskip       = settings->bools.fastforward_frameskip
+         && !string_is_equal(video_driver_get_ident(), "vulkan");
 
    video_info->input_driver_nonblock_state = input_st
          ? (input_st->flags & INP_FLAG_NONBLOCKING) : false;

--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -4378,7 +4378,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_FASTFORWARD_FRAMESKIP,
-   "Skip frames according to fast-forward rate. This conserves power and allows the use of 3rd party frame limiting."
+   "Skip frames according to fast-forward rate. This conserves power and allows the use of 3rd party frame limiting. Ignored with Vulkan to prevent double frame skipping."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_SLOWMOTION_RATIO,


### PR DESCRIPTION
## Description

Because Vulkan is already doing similar stuff internally by force, let's ignore this option with Vulkan in order to avoid jerky double skipping.
