### PR TITLE
(D3D11/12) Cleanups

### DIFF
--- a/gfx/drivers/d3d12.c
+++ b/gfx/drivers/d3d12.c
@@ -93,7 +93,6 @@ static D3D12_RENDER_TARGET_BLEND_DESC d3d12_blend_disable_desc = {
 
 /* Temporary workaround for d3d12 not being able to poll flags during init */
 static gfx_ctx_driver_t d3d12_fake_context;
-static uint32_t d3d12_get_flags(void *data);
 
 static void d3d12_gfx_sync(d3d12_video_t* d3d12)
 {
@@ -104,6 +103,20 @@ static void d3d12_gfx_sync(d3d12_video_t* d3d12)
             d3d12->queue.fence, d3d12->queue.fenceValue, d3d12->queue.fenceEvent);
       WaitForSingleObject(d3d12->queue.fenceEvent, INFINITE);
    }
+}
+
+static uint32_t d3d12_get_flags(void *data)
+{
+   uint32_t flags = 0;
+
+   BIT32_SET(flags, GFX_CTX_FLAGS_CUSTOMIZABLE_FRAME_LATENCY);
+   BIT32_SET(flags, GFX_CTX_FLAGS_MENU_FRAME_FILTERING);
+   BIT32_SET(flags, GFX_CTX_FLAGS_OVERLAY_BEHIND_MENU_SUPPORTED);
+#if defined(HAVE_SLANG) && defined(HAVE_SPIRV_CROSS)
+   BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_SLANG);
+#endif
+
+   return flags;
 }
 
 #ifdef HAVE_OVERLAY
@@ -490,15 +503,10 @@ static void d3d12_update_viewport(d3d12_video_t *d3d12, bool force_full)
    d3d12->frame.viewport.MaxDepth = 0.0f;
    d3d12->frame.viewport.MaxDepth = 1.0f;
 
-   /* having to add vp.x and vp.y here doesn't make any sense */
-   d3d12->frame.scissorRect.top    = d3d12->vp.y;
-   d3d12->frame.scissorRect.left   = d3d12->vp.x;
-   d3d12->frame.scissorRect.right  = d3d12->vp.x + d3d12->vp.width;
-   d3d12->frame.scissorRect.bottom = d3d12->vp.y + d3d12->vp.height;
-
-   if (d3d12->shader_preset && (d3d12->frame.output_size.x != d3d12->vp.width ||
-                                d3d12->frame.output_size.y != d3d12->vp.height))
-      d3d12->flags |= D3D12_ST_FLAG_RESIZE_RTS;
+   if (d3d12->shader_preset
+         && (  d3d12->frame.output_size.x != d3d12->vp.width
+            || d3d12->frame.output_size.y != d3d12->vp.height))
+      d3d12->flags           |= D3D12_ST_FLAG_RESIZE_RTS;
 
    d3d12->frame.output_size.x = d3d12->vp.width;
    d3d12->frame.output_size.y = d3d12->vp.height;
@@ -511,6 +519,7 @@ static void d3d12_update_viewport(d3d12_video_t *d3d12, bool force_full)
 static void d3d12_free_shader_preset(d3d12_video_t* d3d12)
 {
    size_t i;
+
    if (!d3d12->shader_preset)
       return;
 
@@ -555,7 +564,8 @@ static void d3d12_free_shader_preset(d3d12_video_t* d3d12)
    free(d3d12->shader_preset);
    d3d12->shader_preset         = NULL;
    d3d12->flags                &= ~(D3D12_ST_FLAG_INIT_HISTORY
-                                  | D3D12_ST_FLAG_RESIZE_RTS);
+                                  | D3D12_ST_FLAG_RESIZE_RTS
+                                   );
 }
 
 static void d3d12_init_pipeline(
@@ -813,8 +823,8 @@ static bool d3d12_gfx_set_shader(void* data, enum rarch_shader_type type, const 
       image_texture_free(&image);
    }
 
-   d3d12->flags                |=  (D3D12_ST_FLAG_INIT_HISTORY
-                                  | D3D12_ST_FLAG_RESIZE_RTS);
+   d3d12->flags |= D3D12_ST_FLAG_INIT_HISTORY | D3D12_ST_FLAG_RESIZE_RTS;
+
    return true;
 
 error:
@@ -1125,13 +1135,16 @@ static void d3d12_gfx_free(void* data)
 
    d3d12_gfx_sync(d3d12);
 
+   if (d3d12->flags & D3D12_ST_FLAG_WAITABLE_SWAPCHAINS)
+      CloseHandle(d3d12->chain.frameLatencyWaitableObject);
+
+   font_driver_free_osd();
+
 #ifdef HAVE_OVERLAY
    d3d12_free_overlays(d3d12);
 #endif
 
    d3d12_free_shader_preset(d3d12);
-
-   font_driver_free_osd();
 
    Release(d3d12->sprites.vbo);
    Release(d3d12->menu_pipeline_vbo);
@@ -1174,13 +1187,17 @@ static void d3d12_gfx_free(void* data)
    Release(d3d12->sprites.pipe_font);
 
    Release(d3d12->queue.fence);
-   Release(d3d12->chain.renderTargets[0]);
-   Release(d3d12->chain.renderTargets[1]);
-   Release(d3d12->chain.handle);
-
    Release(d3d12->queue.cmd);
    Release(d3d12->queue.allocator);
    Release(d3d12->queue.handle);
+
+   Release(d3d12->chain.renderTargets[0]);
+   Release(d3d12->chain.renderTargets[1]);
+
+#if 0
+   /* Releasing this will crash eventually (?!) */
+   Release(d3d12->chain.handle);
+#endif
 
    Release(d3d12->factory);
    Release(d3d12->device);
@@ -1309,7 +1326,6 @@ static bool d3d12_init_swapchain(d3d12_video_t* d3d12,
       RARCH_LOG("[D3D12]: Requesting %u maximum frame latency, using %u.\n", max_latency, cur_latency);
    }
 
-
 #ifdef HAVE_WINDOW
    DXGIMakeWindowAssociation(d3d12->factory, hwnd, DXGI_MWA_NO_ALT_ENTER);
 #endif
@@ -1366,6 +1382,7 @@ static bool d3d12_init_swapchain(d3d12_video_t* d3d12,
 
    d3d12->chain.viewport.Width                     = width;
    d3d12->chain.viewport.Height                    = height;
+
    d3d12->chain.scissorRect.left                   = d3d12->vp.x;
    d3d12->chain.scissorRect.top                    = d3d12->vp.y;
    d3d12->chain.scissorRect.right                  = d3d12->vp.x + width;
@@ -1920,16 +1937,22 @@ static void *d3d12_gfx_init(const video_info_t* video,
    video_driver_set_size(d3d12->vp.full_width, d3d12->vp.full_height);
    d3d12->chain.viewport.Width  = d3d12->vp.full_width;
    d3d12->chain.viewport.Height = d3d12->vp.full_height;
+
    d3d12->flags                |=  D3D12_ST_FLAG_RESIZE_VIEWPORT;
+
    if (video->force_aspect)
       d3d12->flags             |=  D3D12_ST_FLAG_KEEP_ASPECT;
    else
       d3d12->flags             &= ~D3D12_ST_FLAG_KEEP_ASPECT;
+
    if (video->vsync)
       d3d12->flags             |=  D3D12_ST_FLAG_VSYNC;
    else
       d3d12->flags             &= ~D3D12_ST_FLAG_VSYNC;
-   d3d12->format                = (video->rgb32) ? DXGI_FORMAT_B8G8R8X8_UNORM : DXGI_FORMAT_B5G6R5_UNORM;
+
+   d3d12->format                = (video->rgb32)
+         ? DXGI_FORMAT_B8G8R8X8_UNORM : DXGI_FORMAT_B5G6R5_UNORM;
+
    d3d12->frame.texture[0].desc.Format = d3d12->format;
    d3d12->frame.texture[0].desc.Width  = 4;
    d3d12->frame.texture[0].desc.Height = 4;
@@ -1983,13 +2006,13 @@ static void d3d12_init_history(d3d12_video_t* d3d12, unsigned width, unsigned he
 static void d3d12_init_render_targets(d3d12_video_t* d3d12, unsigned width, unsigned height)
 {
    size_t i;
+
    for (i = 0; i < d3d12->shader_preset->passes; i++)
    {
       struct video_shader_pass* pass = &d3d12->shader_preset->pass[i];
 
       if (pass->fbo.flags & FBO_SCALE_FLAG_VALID)
       {
-
          switch (pass->fbo.type_x)
          {
             case RARCH_SCALE_INPUT:
@@ -2067,8 +2090,9 @@ static void d3d12_init_render_targets(d3d12_video_t* d3d12, unsigned width, unsi
          d3d12->pass[i].scissorRect.bottom   = height;
       }
 
-      if ((i != (d3d12->shader_preset->passes - 1)) || (width != d3d12->vp.width) ||
-          (height != d3d12->vp.height))
+      if (     (i != (d3d12->shader_preset->passes - 1))
+            || (width  != d3d12->vp.width)
+            || (height != d3d12->vp.height))
       {
          d3d12->pass[i].rt.desc.Width      = width;
          d3d12->pass[i].rt.desc.Height     = height;
@@ -2114,12 +2138,11 @@ static bool d3d12_gfx_frame(
       const char*         msg,
       video_frame_info_t* video_info)
 {
-   unsigned         i;
+   unsigned i;
    d3d12_texture_t* texture       = NULL;
    d3d12_video_t*   d3d12         = (d3d12_video_t*)data;
    bool vsync                     = d3d12->flags & D3D12_ST_FLAG_VSYNC;
    bool wait_for_vblank           = d3d12->flags & D3D12_ST_FLAG_WAIT_FOR_VBLANK;
-   unsigned sync_interval         = (vsync) ? d3d12->chain.swap_interval : 0;
    unsigned present_flags         = (vsync) ? 0 : DXGI_PRESENT_ALLOW_TEARING;
    const char *stat_text          = video_info->stat_text;
    bool statistics_show           = video_info->statistics_show;
@@ -2139,15 +2162,27 @@ static bool d3d12_gfx_frame(
    bool use_back_buffer           = back_buffer_format != d3d12->chain.formats[d3d12->chain.bit_depth];
 #endif
 
+   if (d3d12->flags & D3D12_ST_FLAG_WAITABLE_SWAPCHAINS)
+      WaitForSingleObjectEx(
+            d3d12->chain.frameLatencyWaitableObject,
+            1000,
+            true);
+
    d3d12_gfx_sync(d3d12);
 
 #ifdef HAVE_DXGI_HDR
    d3d12_hdr_enable               = d3d12->flags & D3D12_ST_FLAG_HDR_ENABLE;
-   if ((d3d12->flags & D3D12_ST_FLAG_RESIZE_CHAIN) || (d3d12_hdr_enable != video_hdr_enable))
+   if (     (d3d12->flags & D3D12_ST_FLAG_RESIZE_CHAIN)
+         || (d3d12_hdr_enable != video_hdr_enable))
 #else
    if (d3d12->flags & D3D12_ST_FLAG_RESIZE_CHAIN)
 #endif
    {
+      UINT swapchain_flags        = DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;
+
+      if (d3d12->flags & D3D12_ST_FLAG_WAITABLE_SWAPCHAINS)
+         swapchain_flags         |= DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT;
+
 #ifdef HAVE_DXGI_HDR
       if (video_hdr_enable)
          d3d12->flags |=  D3D12_ST_FLAG_HDR_ENABLE;
@@ -2164,19 +2199,20 @@ static bool d3d12_gfx_frame(
          d3d12_release_texture(&d3d12->chain.back_buffer);
          d3d12->chain.back_buffer.handle = NULL;
       }
+
       DXGIResizeBuffers(d3d12->chain.handle,
             countof(d3d12->chain.renderTargets),
             video_width,
             video_height,
             d3d12->chain.formats[d3d12->chain.bit_depth],
-            DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING);
+            swapchain_flags);
 #else
       DXGIResizeBuffers(d3d12->chain.handle,
             0,
             0,
             0,
             DXGI_FORMAT_UNKNOWN,
-            DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING);
+            swapchain_flags);
 #endif
 
       for (i = 0; i < countof(d3d12->chain.renderTargets); i++)
@@ -2190,15 +2226,17 @@ static bool d3d12_gfx_frame(
 
       d3d12->chain.viewport.Width         = video_width;
       d3d12->chain.viewport.Height        = video_height;
-      d3d12->chain.scissorRect.left       = d3d12->vp.x;
-      d3d12->chain.scissorRect.top        = d3d12->vp.y;
-      d3d12->chain.scissorRect.right      = d3d12->vp.x + video_width;
-      d3d12->chain.scissorRect.bottom     = d3d12->vp.y + video_height;
-      d3d12->flags                       &= ~D3D12_ST_FLAG_RESIZE_CHAIN;
-      d3d12->flags                       |=  D3D12_ST_FLAG_RESIZE_VIEWPORT;
+
+      d3d12->chain.scissorRect.left       = 0;
+      d3d12->chain.scissorRect.top        = 0;
+      d3d12->chain.scissorRect.right      = d3d12->vp.full_width;
+      d3d12->chain.scissorRect.bottom     = d3d12->vp.full_height;
 
       d3d12->ubo_values.OutputSize.width  = d3d12->chain.viewport.Width;
       d3d12->ubo_values.OutputSize.height = d3d12->chain.viewport.Height;
+
+      d3d12->flags                       &= ~D3D12_ST_FLAG_RESIZE_CHAIN;
+      d3d12->flags                       |=  D3D12_ST_FLAG_RESIZE_VIEWPORT;
 
       video_driver_set_size(video_width, video_height);
 
@@ -2262,13 +2300,6 @@ static bool d3d12_gfx_frame(
             d3d12->hdr.max_fall);
 #endif
    }
-   else if (d3d12->flags & D3D12_ST_FLAG_WAITABLE_SWAPCHAINS)
-   {
-      WaitForSingleObjectEx(
-            d3d12->chain.frameLatencyWaitableObject,
-            1000,
-            true);
-   }
 
    D3D12ResetCommandAllocator(d3d12->queue.allocator);
 
@@ -2284,11 +2315,10 @@ static bool d3d12_gfx_frame(
    }
 
 #if 0
-   /* Custom viewport doesn't call apply_state_changes,
-      so we can't rely on this for now */
+   /* Custom viewport doesn't call apply_state_changes, so we can't rely on this for now */
    if (d3d12->resize_viewport)
 #endif
-   d3d12_update_viewport(d3d12, false);
+      d3d12_update_viewport(d3d12, false);
 
    D3D12IASetPrimitiveTopology(d3d12->queue.cmd,
          D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
@@ -2302,14 +2332,13 @@ static bool d3d12_gfx_frame(
                d3d12_upload_texture(d3d12->queue.cmd, &d3d12->luts[i],
                     d3d12);
 
-         if (   (d3d12->frame.texture[0].desc.Width  != width)
-             || (d3d12->frame.texture[0].desc.Height != height))
-             d3d12->flags |= D3D12_ST_FLAG_RESIZE_RTS;
+         if (     (d3d12->frame.texture[0].desc.Width  != width)
+               || (d3d12->frame.texture[0].desc.Height != height))
+            d3d12->flags |= D3D12_ST_FLAG_RESIZE_RTS;
 
          if (d3d12->flags & D3D12_ST_FLAG_RESIZE_RTS)
          {
-            /* Release all render targets first 
-               to avoid memory fragmentation */
+            /* Release all Render Targets (RT) first to avoid memory fragmentation */
             for (i = 0; i < d3d12->shader_preset->passes; i++)
             {
                d3d12_release_texture(&d3d12->pass[i].rt);
@@ -2337,10 +2366,9 @@ static bool d3d12_gfx_frame(
          }
       }
 
-      /* Either no history, or we moved a texture 
-         of a different size in the front slot */
-      if (d3d12->frame.texture[0].desc.Width  != width ||
-          d3d12->frame.texture[0].desc.Height != height)
+      /* Either no history, or we moved a texture of a different size in the front slot */
+      if (     d3d12->frame.texture[0].desc.Width  != width
+            || d3d12->frame.texture[0].desc.Height != height)
       {
          d3d12->frame.texture[0].desc.Width  = width;
          d3d12->frame.texture[0].desc.Height = height;
@@ -2514,7 +2542,7 @@ static bool d3d12_gfx_frame(
          {
             D3D12_RESOURCE_TRANSITION(
                   d3d12->queue.cmd,
-		  d3d12->pass[i].rt.handle,
+                  d3d12->pass[i].rt.handle,
                   D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
                   D3D12_RESOURCE_STATE_RENDER_TARGET);
 
@@ -2537,7 +2565,7 @@ static bool d3d12_gfx_frame(
 
             D3D12_RESOURCE_TRANSITION(
                   d3d12->queue.cmd,
-		  d3d12->pass[i].rt.handle,
+                  d3d12->pass[i].rt.handle,
                   D3D12_RESOURCE_STATE_RENDER_TARGET,
                   D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
             texture = &d3d12->pass[i].rt;
@@ -2557,12 +2585,11 @@ static bool d3d12_gfx_frame(
       D3D12SetGraphicsRootSignature(d3d12->queue.cmd,
             d3d12->desc.rootSignature);
       D3D12SetGraphicsRootDescriptorTable(d3d12->queue.cmd,
-		      ROOT_ID_TEXTURE_T,
-		      d3d12->frame.texture[0].gpu_descriptor[0]);
+            ROOT_ID_TEXTURE_T,
+            d3d12->frame.texture[0].gpu_descriptor[0]);
       D3D12SetGraphicsRootDescriptorTable(d3d12->queue.cmd,
-		      ROOT_ID_SAMPLER_T,
-		      d3d12->samplers[
-		      RARCH_FILTER_UNSPEC][RARCH_WRAP_DEFAULT]);
+            ROOT_ID_SAMPLER_T,
+            d3d12->samplers[RARCH_FILTER_UNSPEC][RARCH_WRAP_DEFAULT]);
       D3D12SetGraphicsRootConstantBufferView(
             d3d12->queue.cmd, ROOT_ID_UBO,
             d3d12->frame.ubo_view.BufferLocation);
@@ -2576,13 +2603,14 @@ static bool d3d12_gfx_frame(
    {
       D3D12_RESOURCE_TRANSITION(
             d3d12->queue.cmd,
-	    d3d12->chain.back_buffer.handle,
+            d3d12->chain.back_buffer.handle,
             D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
             D3D12_RESOURCE_STATE_RENDER_TARGET);
 
       D3D12OMSetRenderTargets(
             d3d12->queue.cmd, 1,
-            &d3d12->chain.back_buffer.rt_view, FALSE, NULL);
+            &d3d12->chain.back_buffer.rt_view,
+            FALSE, NULL);
       /* TODO/FIXME - fix this warning that shows up with Debug logging 
        * EXECUTIONWARNING #820: CLEARRENDERTARGETVIEW_MISMATCHINGCLEARVALUE
        * We need to set clear value during resource creation to NULL for
@@ -2590,8 +2618,10 @@ static bool d3d12_gfx_frame(
        * warning
        */
       D3D12ClearRenderTargetView(
-            d3d12->queue.cmd, d3d12->chain.back_buffer.rt_view,
-            d3d12->chain.clearcolor, 0, NULL);
+            d3d12->queue.cmd,
+            d3d12->chain.back_buffer.rt_view,
+            d3d12->chain.clearcolor,
+            0, NULL);
    }
    else
 #endif
@@ -2609,7 +2639,8 @@ static bool d3d12_gfx_frame(
       D3D12ClearRenderTargetView(
             d3d12->queue.cmd,
             d3d12->chain.desc_handles[d3d12->chain.frame_index],
-            d3d12->chain.clearcolor, 0, NULL);
+            d3d12->chain.clearcolor,
+            0, NULL);
    }
 
    D3D12RSSetViewports(d3d12->queue.cmd, 1, &d3d12->frame.viewport);
@@ -2638,11 +2669,11 @@ static bool d3d12_gfx_frame(
       }
 
       D3D12SetGraphicsRootDescriptorTable(d3d12->queue.cmd,
-		      ROOT_ID_TEXTURE_T,
-		      d3d12->menu.texture.gpu_descriptor[0]);
+            ROOT_ID_TEXTURE_T,
+            d3d12->menu.texture.gpu_descriptor[0]);
       D3D12SetGraphicsRootDescriptorTable(d3d12->queue.cmd,
-		      ROOT_ID_SAMPLER_T,
-		      d3d12->menu.texture.sampler);
+            ROOT_ID_SAMPLER_T,
+            d3d12->menu.texture.sampler);
       D3D12IASetVertexBuffers(d3d12->queue.cmd, 0, 1, &d3d12->menu.vbo_view);
       D3D12DrawInstanced(d3d12->queue.cmd, 4, 1, 0, 0);
    }
@@ -2719,45 +2750,48 @@ static bool d3d12_gfx_frame(
    }
    d3d12->flags &= ~D3D12_ST_FLAG_SPRITES_ENABLE;
 
+#if defined(_WIN32) && !defined(__WINRT__)
+   win32_update_title();
+#endif
+
 #ifdef HAVE_DXGI_HDR
    /* Copy over back buffer to swap chain render targets */
    if ((d3d12->flags & D3D12_ST_FLAG_HDR_ENABLE) && use_back_buffer)
    {
       D3D12_RESOURCE_TRANSITION(
-         d3d12->queue.cmd,
-         d3d12->chain.renderTargets[d3d12->chain.frame_index],
-         D3D12_RESOURCE_STATE_PRESENT,
-         D3D12_RESOURCE_STATE_RENDER_TARGET);
+            d3d12->queue.cmd,
+            d3d12->chain.renderTargets[d3d12->chain.frame_index],
+            D3D12_RESOURCE_STATE_PRESENT,
+            D3D12_RESOURCE_STATE_RENDER_TARGET);
 
       D3D12_RESOURCE_TRANSITION(
-         d3d12->queue.cmd,
-	 d3d12->chain.back_buffer.handle,
-         D3D12_RESOURCE_STATE_RENDER_TARGET,
-         D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+            d3d12->queue.cmd,
+            d3d12->chain.back_buffer.handle,
+            D3D12_RESOURCE_STATE_RENDER_TARGET,
+            D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
       D3D12SetPipelineState(d3d12->queue.cmd,
             d3d12->pipes[VIDEO_SHADER_STOCK_HDR]);
 
       D3D12OMSetRenderTargets(
-         d3d12->queue.cmd, 1,
-         &d3d12->chain.desc_handles[d3d12->chain.frame_index],
-         FALSE, NULL);
+            d3d12->queue.cmd, 1,
+            &d3d12->chain.desc_handles[d3d12->chain.frame_index],
+            FALSE, NULL);
       D3D12ClearRenderTargetView(
-         d3d12->queue.cmd,
-         d3d12->chain.desc_handles[d3d12->chain.frame_index],
-         d3d12->chain.clearcolor, 0, NULL);         
+            d3d12->queue.cmd,
+            d3d12->chain.desc_handles[d3d12->chain.frame_index],
+            d3d12->chain.clearcolor, 0, NULL);
 
       D3D12SetGraphicsRootSignature(d3d12->queue.cmd,
             d3d12->desc.rootSignature);
       D3D12SetGraphicsRootDescriptorTable(d3d12->queue.cmd,
-		      ROOT_ID_TEXTURE_T,
-		      d3d12->chain.back_buffer.gpu_descriptor[0]);
+            ROOT_ID_TEXTURE_T,
+            d3d12->chain.back_buffer.gpu_descriptor[0]);
       D3D12SetGraphicsRootDescriptorTable(d3d12->queue.cmd,
-		      ROOT_ID_SAMPLER_T,
-		      d3d12->samplers[
-		      RARCH_FILTER_UNSPEC][RARCH_WRAP_DEFAULT]);
+            ROOT_ID_SAMPLER_T,
+            d3d12->samplers[RARCH_FILTER_UNSPEC][RARCH_WRAP_DEFAULT]);
       D3D12SetGraphicsRootConstantBufferView(
-         d3d12->queue.cmd, ROOT_ID_UBO,
-         d3d12->hdr.ubo_view.BufferLocation);
+            d3d12->queue.cmd, ROOT_ID_UBO,
+            d3d12->hdr.ubo_view.BufferLocation);
       D3D12IASetVertexBuffers(d3d12->queue.cmd, 0, 1,
             &d3d12->frame.vbo_view);      
 
@@ -2784,36 +2818,40 @@ static bool d3d12_gfx_frame(
    D3D12ExecuteGraphicsCommandLists(d3d12->queue.handle, 1,
          &d3d12->queue.cmd);
    
-#if defined(_WIN32) && !defined(__WINRT__)
-   win32_update_title();
-#endif
-   DXGIPresent(d3d12->chain.handle, sync_interval, present_flags);
+   DXGIPresent(d3d12->chain.handle, d3d12->chain.swap_interval, present_flags);
 
    if (vsync && wait_for_vblank)
    {
       IDXGIOutput *pOutput;
       DXGIGetContainingOutput(d3d12->chain.handle, &pOutput);
       DXGIWaitForVBlank(pOutput);
+      Release(pOutput);
    }
 
    return true;
 }
 
-static void d3d12_gfx_set_nonblock_state(void* data, bool toggle,
+static void d3d12_gfx_set_nonblock_state(void* data,
+      bool toggle,
       bool adaptive_vsync_enabled,
       unsigned swap_interval)
 {
    d3d12_video_t* d3d12       = (d3d12_video_t*)data;
+
+   if (!d3d12)
+      return;
+
    if (toggle)
       d3d12->flags           &= ~D3D12_ST_FLAG_VSYNC;
    else
       d3d12->flags           |=  D3D12_ST_FLAG_VSYNC;
-   d3d12->chain.swap_interval = swap_interval;
+
+   d3d12->chain.swap_interval = (!toggle) ? swap_interval : 0;
 }
 
 static bool d3d12_gfx_alive(void* data)
 {
-   bool           quit;
+   bool quit;
    bool resize_chain    = false;
    d3d12_video_t* d3d12 = (d3d12_video_t*)data;
 
@@ -2906,7 +2944,7 @@ static void d3d12_set_menu_texture_frame(
 static void d3d12_set_menu_texture_enable(void* data,
       bool state, bool fullscreen)
 {
-   d3d12_video_t* d3d12   = (d3d12_video_t*)data;
+   d3d12_video_t* d3d12 = (d3d12_video_t*)data;
 
    if (!d3d12)
       return;
@@ -2925,6 +2963,7 @@ static void d3d12_gfx_set_aspect_ratio(
       void* data, unsigned aspect_ratio_idx)
 {
    d3d12_video_t* d3d12 = (d3d12_video_t*)data;
+
    if (d3d12)
       d3d12->flags |= D3D12_ST_FLAG_KEEP_ASPECT | D3D12_ST_FLAG_RESIZE_VIEWPORT;
 }
@@ -2943,8 +2982,10 @@ static void d3d12_gfx_set_osd_msg(
       void* font)
 {
    d3d12_video_t* d3d12 = (d3d12_video_t*)data;
+
    if (d3d12 && (d3d12->flags & D3D12_ST_FLAG_SPRITES_ENABLE))
-      font_driver_render_msg(d3d12, msg,
+      font_driver_render_msg(d3d12,
+            msg,
             (const struct font_params*)params, font);
 }
 
@@ -2994,6 +3035,7 @@ static uintptr_t d3d12_gfx_load_texture(
 
    return (uintptr_t)texture;
 }
+
 static void d3d12_gfx_unload_texture(void* data, 
       bool threaded, uintptr_t handle)
 {
@@ -3005,20 +3047,6 @@ static void d3d12_gfx_unload_texture(void* data,
    d3d12_gfx_sync((d3d12_video_t*)data);
    d3d12_release_texture(texture);
    free(texture);
-}
-
-static uint32_t d3d12_get_flags(void *data)
-{
-   uint32_t flags = 0;
-
-   BIT32_SET(flags, GFX_CTX_FLAGS_CUSTOMIZABLE_FRAME_LATENCY);
-   BIT32_SET(flags, GFX_CTX_FLAGS_MENU_FRAME_FILTERING);
-   BIT32_SET(flags, GFX_CTX_FLAGS_OVERLAY_BEHIND_MENU_SUPPORTED);
-#if defined(HAVE_SLANG) && defined(HAVE_SPIRV_CROSS)
-   BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_SLANG);
-#endif
-
-   return flags;
 }
 
 #ifndef __WINRT__
@@ -3080,7 +3108,7 @@ static const video_poke_interface_t d3d12_poke_interface = {
    d3d12_set_hdr_max_nits,
    d3d12_set_hdr_paper_white_nits,
    d3d12_set_hdr_contrast,
-   d3d12_set_hdr_expand_gamut,
+   d3d12_set_hdr_expand_gamut
 #else
    NULL, /* set_hdr_max_nits */
    NULL, /* set_hdr_paper_white_nits */


### PR DESCRIPTION
## Description

D3D11:
- Fixed build when `HAVE_DXGI_HDR` is not defined

D3D12:
- Fixed window scaling issue, which was caused by swapchain resize function not using the same flags (waitable swapchain) as swapchain creation
- Fixed swapchain scissoring issue (visual + crash) after manually resizing window to smaller size
- Fixed eventual crashing issue on video reinit when swapchain is being freed

And:
- Moved waitable swapchain waiting to happen always even when resizing swapchain
- Unifications and readabilities
- Removed tabs

## Related Issues

Closes #14473

