### PR TITLE
fix udev guns input when id_mouse is not id_joystick

### DIFF
--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -1253,7 +1253,7 @@ static int16_t udev_input_state(
                   const uint64_t bind_joyaxis    = input_config_binds[port][new_id].joyaxis;
                   const uint64_t autobind_joykey = input_autoconf_binds[port][new_id].joykey;
                   const uint64_t autobind_joyaxis= input_autoconf_binds[port][new_id].joyaxis;
-                  uint16_t port                  = joypad_info->joy_idx;
+                  uint16_t joyport                  = joypad_info->joy_idx;
                   float axis_threshold           = joypad_info->axis_threshold;
                   const uint64_t joykey          = (bind_joykey != NO_BTN)
                      ? bind_joykey  : autobind_joykey;
@@ -1267,10 +1267,10 @@ static int16_t udev_input_state(
                   if (binds[port][new_id].valid)
                   {
                      if ((uint16_t)joykey != NO_BTN && joypad->button(
-                              port, (uint16_t)joykey))
+                              joyport, (uint16_t)joykey))
                         return 1;
                      if (joyaxis != AXIS_NONE &&
-                           ((float)abs(joypad->axis(port, joyaxis))
+                           ((float)abs(joypad->axis(joyport, joyaxis))
                             / 0x8000) > axis_threshold)
                         return 1;
                      if (udev_mouse_button_pressed(udev, port,


### PR DESCRIPTION
the commit cfe9d60f5100d3d0a1d6119d156b91dd66ae8195 introduces an issues on guns inputs for drivers udev, dinput, winraw and x11. A local variable called "port" is redefining the function argument variable and is causing bad calls in subsequent function calls.

In short, functionnally, if you have only 1 gun and 1 pad on your system, all works. As soon as you use several pads or several guns, you may have issues, because subsequent calls use the joystick port instead of the device port as argument.

IMPORTANT NOTE : this fix was done originally for the batocera project which uses only the udev driver, this is why it is focused on udev only.
The same thing must be done and tested for dinput, winraw and x11. I've not the ability to test them.
