### PR TITLE
(Win32) Fix restart if path has spaces

### DIFF
--- a/frontend/drivers/platform_win32.c
+++ b/frontend/drivers/platform_win32.c
@@ -749,6 +749,7 @@ static void frontend_win32_respawn(char *s, size_t len, char *args)
    STARTUPINFO si;
    PROCESS_INFORMATION pi;
    char executable_path[PATH_MAX_LENGTH] = {0};
+   char executable_args[PATH_MAX_LENGTH] = {0};
 
    if (win32_fork_mode != FRONTEND_FORK_RESTART)
       return;
@@ -757,15 +758,16 @@ static void frontend_win32_respawn(char *s, size_t len, char *args)
          sizeof(executable_path));
    path_set(RARCH_PATH_CORE, executable_path);
 
+   /* Remove executable path from arguments given to CreateProcess */
+   snprintf(executable_args, sizeof(executable_args), "%s", strstr(args, ".exe") + 4);
+
    memset(&si, 0, sizeof(si));
    si.cb = sizeof(si);
    memset(&pi, 0, sizeof(pi));
 
-   if (!CreateProcess( executable_path, args,
-      NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi))
-   {
+   if (!CreateProcess(executable_path, executable_args,
+         NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi))
       RARCH_ERR("Failed to restart RetroArch\n");
-   }
 }
 
 static bool frontend_win32_set_fork(enum frontend_fork fork_mode)


### PR DESCRIPTION
## Description

`CreateProcess` does not like to have anything executable path related in the second parameter `lpCommandLine` if the path has spaces. Thus strip everything from args except the actual parameters.

## Related Issues

Closes #10351
