### PR TITLE
[Wayland/Vulkan] Don't clamp the number of requested images.

### DIFF
--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -3189,9 +3189,10 @@ bool vulkan_create_swapchain(gfx_ctx_vulkan_data_t *vk,
     * for GPU-rendered cores. */
    desired_swapchain_images    = settings->uints.video_max_swapchain_images;
 
-   /* Clamp images requested to what is supported by the implementation. */
-   if (desired_swapchain_images < surface_properties.minImageCount)
-      desired_swapchain_images = surface_properties.minImageCount;
+   /* We don't clamp the number of images requested to what is reported
+    * as supported by the implementation in surface_properties.minImageCount,
+    * because MESA always reports a minImageCount of 4, but 3 and 2 work
+    * pefectly well, even if it's out of spec. */
 
    if ((surface_properties.maxImageCount > 0)
          && (desired_swapchain_images > surface_properties.maxImageCount))


### PR DESCRIPTION
Due to an unfortunate "feature", MESA always reports 4 as the Vulkan surface's `minImageCount` in Wayland.
However, values of 2 and 3 work perfectly well, even if they are out of spec, providing way better latencies when using the Vulkan backend on Wayland.
So this removes the artificial clamping that was being done to `desired_swapchain_images`, because it's not really necessary and was causing very noticeable input lag on Wayland+Vulkan.

Fixes (well, circumvents) this issue:
https://github.com/libretro/RetroArch/issues/13812