### PR TITLE
[SDL Gfx] Fix no on-screen notifications

### DIFF
--- a/gfx/drivers/sdl_gfx.c
+++ b/gfx/drivers/sdl_gfx.c
@@ -403,6 +403,12 @@ static bool sdl_gfx_frame(void *data, const void *frame, unsigned width,
 
       if (SDL_MUSTLOCK(vid->screen))
          SDL_UnlockSurface(vid->screen);
+      
+      if (msg)
+         sdl_render_msg(vid, vid->screen,
+         msg, vid->screen->w, vid->screen->h, vid->screen->format,
+         video_info->font_msg_pos_x,
+         video_info->font_msg_pos_y);
    }
 
    if (title[0])


### PR DESCRIPTION
This was broken in commit 083b14b85cb7894f34c66a815e07ba0e2446354a - my bad, as I forgot to re-add the call to sdl_render_msg when reorganising sdl_gfx_frame!
