### PR TITLE
(Wayland) Fix resize check

### DIFF
--- a/gfx/common/wayland_common.c
+++ b/gfx/common/wayland_common.c
@@ -436,7 +436,7 @@ static void shm_buffer_paint_checkerboard(
 static bool wl_draw_splash_screen(gfx_ctx_wayland_data_t *wl)
 {
    shm_buffer_t *buffer = create_shm_buffer(wl,
-      wl->width * wl->buffer_scale,
+      wl->width  * wl->buffer_scale,
       wl->height * wl->buffer_scale,
       WL_SHM_FORMAT_XRGB8888);
 
@@ -451,7 +451,7 @@ static bool wl_draw_splash_screen(gfx_ctx_wayland_data_t *wl)
    wl_surface_set_buffer_scale(wl->surface, wl->buffer_scale);
    if (wl_surface_get_version(wl->surface) >= WL_SURFACE_DAMAGE_BUFFER_SINCE_VERSION)
       wl_surface_damage_buffer(wl->surface, 0, 0,
-         wl->width * wl->buffer_scale,
+         wl->width  * wl->buffer_scale,
          wl->height * wl->buffer_scale);
    wl_surface_commit(wl->surface);
    return true;

--- a/gfx/common/wayland_common.c
+++ b/gfx/common/wayland_common.c
@@ -751,13 +751,10 @@ void gfx_ctx_wl_check_window_common(gfx_ctx_wayland_data_t *wl,
 
    flush_wayland_fd(&wl->input);
 
-   new_width  = *width  * wl->last_buffer_scale;
-   new_height = *height * wl->last_buffer_scale;
-
    get_video_size(wl, &new_width, &new_height);
 
-   if (     new_width  != *width  * wl->last_buffer_scale
-         || new_height != *height * wl->last_buffer_scale)
+   if (     new_width  != *width
+         || new_height != *height)
    {
       *width  = new_width;
       *height = new_height;

--- a/gfx/common/wayland_common.h
+++ b/gfx/common/wayland_common.h
@@ -66,7 +66,7 @@ bool gfx_ctx_wl_init_common(
       gfx_ctx_wayland_data_t **wl);
 
 bool gfx_ctx_wl_set_video_mode_common_size(gfx_ctx_wayland_data_t *wl,
-      unsigned width, unsigned height);
+      unsigned width, unsigned height, bool fullscreen);
 
 bool gfx_ctx_wl_set_video_mode_common_fullscreen(gfx_ctx_wayland_data_t *wl,
       bool fullscreen);

--- a/gfx/drivers_context/wayland_ctx.c
+++ b/gfx/drivers_context/wayland_ctx.c
@@ -66,13 +66,13 @@ static void xdg_toplevel_handle_configure(void *data,
 #ifdef HAVE_EGL
    if (wl->win)
       wl_egl_window_resize(wl->win,
-            wl->width  * wl->buffer_scale,
-            wl->height * wl->buffer_scale,
+            wl->buffer_width,
+            wl->buffer_height,
             0, 0);
    else
       wl->win = wl_egl_window_create(wl->surface,
-            wl->width  * wl->buffer_scale,
-            wl->height * wl->buffer_scale);
+            wl->buffer_width,
+            wl->buffer_height);
 #endif
 
    wl->configured = false;
@@ -148,14 +148,14 @@ libdecor_frame_handle_configure(struct libdecor_frame *frame,
 #ifdef HAVE_EGL
    if (wl->win)
       wl_egl_window_resize(wl->win,
-            wl->width  * wl->buffer_scale,
-            wl->height * wl->buffer_scale,
+            wl->buffer_width,
+            wl->buffer_height,
             0, 0);
    else
       wl->win         = wl_egl_window_create(
             wl->surface,
-            wl->width  * wl->buffer_scale,
-            wl->height * wl->buffer_scale);
+            wl->buffer_width,
+            wl->buffer_height);
 #endif
 
    wl->configured = false;
@@ -393,7 +393,7 @@ static bool gfx_ctx_wl_set_video_mode(void *data,
 {
    gfx_ctx_wayland_data_t *wl   = (gfx_ctx_wayland_data_t*)data;
 
-   if (!gfx_ctx_wl_set_video_mode_common_size(wl, width, height))
+   if (!gfx_ctx_wl_set_video_mode_common_size(wl, width, height, fullscreen))
       goto error;
 
 #ifdef HAVE_EGL
@@ -402,8 +402,8 @@ static bool gfx_ctx_wl_set_video_mode(void *data,
          (gfx_ctx_wayland_data_t*)data, egl_attribs);
 
    wl->win = wl_egl_window_create(wl->surface,
-      wl->width  * wl->buffer_scale,
-      wl->height * wl->buffer_scale);
+      wl->buffer_width,
+      wl->buffer_height);
 
    if (!egl_create_context(&wl->egl, (attr != egl_attribs)
             ? egl_attribs : NULL))

--- a/gfx/drivers_context/wayland_ctx.c
+++ b/gfx/drivers_context/wayland_ctx.c
@@ -65,10 +65,13 @@ static void xdg_toplevel_handle_configure(void *data,
    xdg_toplevel_handle_configure_common(wl, toplevel, width, height, states);
 #ifdef HAVE_EGL
    if (wl->win)
-      wl_egl_window_resize(wl->win, wl->width, wl->height, 0, 0);
+      wl_egl_window_resize(wl->win,
+            wl->width  * wl->buffer_scale,
+            wl->height * wl->buffer_scale,
+            0, 0);
    else
       wl->win = wl_egl_window_create(wl->surface,
-            wl->width * wl->buffer_scale,
+            wl->width  * wl->buffer_scale,
             wl->height * wl->buffer_scale);
 #endif
 
@@ -144,7 +147,10 @@ libdecor_frame_handle_configure(struct libdecor_frame *frame,
 
 #ifdef HAVE_EGL
    if (wl->win)
-      wl_egl_window_resize(wl->win, wl->width, wl->height, 0, 0);
+      wl_egl_window_resize(wl->win,
+            wl->width  * wl->buffer_scale,
+            wl->height * wl->buffer_scale,
+            0, 0);
    else
       wl->win         = wl_egl_window_create(
             wl->surface,

--- a/gfx/drivers_context/wayland_vk_ctx.c
+++ b/gfx/drivers_context/wayland_vk_ctx.c
@@ -199,13 +199,13 @@ static bool gfx_ctx_wl_set_video_mode(void *data,
 {
    gfx_ctx_wayland_data_t *wl   = (gfx_ctx_wayland_data_t*)data;
 
-   if (!gfx_ctx_wl_set_video_mode_common_size(wl, width, height))
+   if (!gfx_ctx_wl_set_video_mode_common_size(wl, width, height, fullscreen))
       goto error;
 
    if (!vulkan_surface_create(&wl->vk, VULKAN_WSI_WAYLAND,
          wl->input.dpy, wl->surface,
-         wl->width  * wl->buffer_scale,
-         wl->height * wl->buffer_scale,
+         wl->buffer_width,
+         wl->buffer_height,
          wl->swap_interval))
       goto error;
 

--- a/input/common/wayland_common.h
+++ b/input/common/wayland_common.h
@@ -178,6 +178,8 @@ typedef struct gfx_ctx_wayland_data
    touch_pos_t active_touch_positions[MAX_TOUCHES]; /* int32_t alignment */
    unsigned width;
    unsigned height;
+   unsigned buffer_width;
+   unsigned buffer_height;
    unsigned floating_width;
    unsigned floating_height;
    unsigned last_buffer_scale;


### PR DESCRIPTION
## Description

This solves MR two issues:

* On scaled desktops the wayland backend deciding to resize based on values multiplied by the scale factor twice. Resulting in continuous attempts to rebuild the swapchain when in fullscreen.

* GL is sometimes not rescaling property (Super + Left).

![Screenshot from 2023-03-06 18-57-08](https://user-images.githubusercontent.com/334272/223206212-17d7386b-7516-4872-808a-483f9c49b98b.png)

Also on 

## Related Issues

#15062

## Reviewers

@nfp0 