### PR TITLE
Notification font + statistics adjustments

### DIFF
--- a/gfx/video_driver.h
+++ b/gfx/video_driver.h
@@ -424,13 +424,13 @@ typedef struct video_frame_info
    float menu_header_opacity;
    float menu_footer_opacity;
    float refresh_rate;
+   float font_size;
    float font_msg_pos_x;
    float font_msg_pos_y;
    float font_msg_color_r;
    float font_msg_color_g;
    float font_msg_color_b;
    float xmb_alpha_factor;
-
 
    struct
    {

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -971,7 +971,7 @@ int generic_action_ok_displaylist_push(const char *path,
 
          action_ok_get_file_browser_start_path(
                settings->paths.path_font,
-               NULL,
+               settings->paths.directory_assets,
                parent_dir, sizeof(parent_dir), true);
 
          info_path          = parent_dir;

--- a/menu/cbs/menu_cbs_scan.c
+++ b/menu/cbs/menu_cbs_scan.c
@@ -232,6 +232,17 @@ static int action_scan_input_desc(const char *path,
    return 0;
 }
 
+static int action_scan_video_font_path(const char *path,
+      const char *label, unsigned type, size_t idx)
+{
+   settings_t *settings       = config_get_ptr();
+
+   strlcpy(settings->paths.path_font, "null", sizeof(settings->paths.path_font));
+   command_event(CMD_EVENT_REINIT, NULL);
+
+   return 0;
+}
+
 static int menu_cbs_init_bind_scan_compare_type(menu_file_list_cbs_t *cbs,
       unsigned type)
 {
@@ -279,10 +290,21 @@ int menu_cbs_init_bind_scan(menu_file_list_cbs_t *cbs,
 
    if (cbs->setting)
    {
-      if (cbs->setting->type == ST_BIND)
+      switch (cbs->setting->type)
       {
-         BIND_ACTION_SCAN(cbs, action_scan_input_desc);
-         return 0;
+         case ST_BIND:
+            BIND_ACTION_SCAN(cbs, action_scan_input_desc);
+            return 0;
+         case ST_PATH:
+            if (string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_VIDEO_FONT_PATH)))
+            {
+               BIND_ACTION_SCAN(cbs, action_scan_video_font_path);
+               return 0;
+            }
+            break;
+         default:
+         case ST_NONE:
+            break;
       }
    }
 

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -14760,10 +14760,8 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                            unsigned setting_type  = MENU_SETTING_DROPDOWN_SETTING_FLOAT_ITEM;
                            float step             = setting->step;
                            float half_step        = step * 0.5f;
-                           float min              = (setting->flags & SD_FLAG_ENFORCE_MINRANGE) ?
-setting->min : 0.00f;
-                           float max              = (setting->flags & SD_FLAG_ENFORCE_MAXRANGE) ?
-setting->max : 9999.00f;
+                           float min              = (setting->flags & SD_FLAG_ENFORCE_MINRANGE) ? setting->min : 0.00f;
+                           float max              = (setting->flags & SD_FLAG_ENFORCE_MAXRANGE) ? setting->max : 9999.00f;
                            bool checked_found     = false;
                            unsigned checked       = 0;
                            unsigned entry_index   = 0;
@@ -14836,10 +14834,8 @@ setting->max : 9999.00f;
                            unsigned orig_value    = *setting->value.target.unsigned_integer;
                            unsigned setting_type  = MENU_SETTING_DROPDOWN_SETTING_UINT_ITEM;
                            float step             = setting->step;
-                           float min              = (setting->flags & SD_FLAG_ENFORCE_MINRANGE) ?
-                              setting->min : 0.00f;
-                           float max              = (setting->flags & SD_FLAG_ENFORCE_MAXRANGE) ?
-                              setting->max : 9999.00f;
+                           float min              = (setting->flags & SD_FLAG_ENFORCE_MINRANGE) ? setting->min : 0.00f;
+                           float max              = (setting->flags & SD_FLAG_ENFORCE_MAXRANGE) ? setting->max : 9999.00f;
                            bool checked_found     = false;
                            unsigned checked       = 0;
                            unsigned entry_index   = 0;

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -3121,6 +3121,19 @@ static void setting_get_string_representation_video_filter(rarch_setting_t *sett
             "", len);
 }
 
+static void setting_get_string_representation_video_font_path(rarch_setting_t *setting,
+      char *s, size_t len)
+{
+   if (!setting)
+      return;
+
+   if (string_is_empty(setting->value.target.string))
+      strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_DONT_CARE), len);
+   else
+      fill_pathname(s, path_basename(setting->value.target.string),
+            "", len);
+}
+
 static void setting_get_string_representation_state_slot(rarch_setting_t *setting,
       char *s, size_t len)
 {
@@ -15280,6 +15293,7 @@ static bool setting_append_list(
          MENU_SETTINGS_LIST_CURRENT_ADD_VALUES(list, list_info, "ttf");
          MENU_SETTINGS_LIST_CURRENT_ADD_CMD(list, list_info, CMD_EVENT_REINIT);
          (*list)[list_info->index - 1].ui_type   = ST_UI_TYPE_FONT_SELECTOR;
+         (*list)[list_info->index - 1].get_string_representation = &setting_get_string_representation_video_font_path;
 
          CONFIG_FLOAT(
                list, list_info,


### PR DESCRIPTION
## Description

Font option:
- Allow reseting notification font with RetroPad Y to "null", which uses the fallback pixel font
- Show "Default" instead of empty with default font
- Start browsing font from `assets` instead of root

Statistics:
- Finetuned statistics layout to be more compact and aligned
- Group Run-Ahead and Frame Delay as "Latency"
- Try to scale font as small as possible/readable if stats won't fit

![retroarch_2023_03_12_22_47_21_816](https://user-images.githubusercontent.com/45124675/224577880-38d0bc65-56d3-46f2-bd34-e935e4ec5685.png)

![retroarch_2023_03_12_22_47_09_852](https://user-images.githubusercontent.com/45124675/224577884-caf1c744-18a7-4836-9bcf-3399b8eb1b02.png)
