### PR TITLE
Check for 'enable_hotkey' also from autoconf binds

### DIFF
--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -4056,8 +4056,10 @@ static void input_keys_pressed(
    input_driver_state_t *input_st = &input_driver_st;
    bool block_hotkey[RARCH_BIND_LIST_END];
    bool libretro_hotkey_set       =
-            binds[port][RARCH_ENABLE_HOTKEY].joykey  != NO_BTN
-         || binds[port][RARCH_ENABLE_HOTKEY].joyaxis != AXIS_NONE;
+            binds[port][RARCH_ENABLE_HOTKEY].joykey                 != NO_BTN
+         || binds[port][RARCH_ENABLE_HOTKEY].joyaxis                != AXIS_NONE
+         || input_autoconf_binds[port][RARCH_ENABLE_HOTKEY].joykey  != NO_BTN
+         || input_autoconf_binds[port][RARCH_ENABLE_HOTKEY].joyaxis != AXIS_NONE;
    bool keyboard_hotkey_set       =
          binds[port][RARCH_ENABLE_HOTKEY].key != RETROK_UNKNOWN;
 


### PR DESCRIPTION
## Description

Tiny and crucial addition to checking if joypad 'enable_hotkey' is set. Currently it only works if the bind is in config or override, but not autoconf.

## Related Pull Requests

#14831

## Reviewers

@cmitu 
