### PR TITLE
[Wayland] Add mouse grab/lock functionality.

### DIFF
--- a/input/common/wayland_common.c
+++ b/input/common/wayland_common.c
@@ -421,6 +421,18 @@ static void wl_touch_handle_motion(void *data,
    }
 }
 
+static void handle_relative_motion(void *data,
+   struct zwp_relative_pointer_v1 *zwp_relative_pointer_v1,
+   uint32_t utime_hi, uint32_t utime_lo,
+   wl_fixed_t dx, wl_fixed_t dy,
+   wl_fixed_t dx_unaccel, wl_fixed_t dy_unaccel)
+{
+    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
+
+    wl->input.mouse.delta_x = wl_fixed_to_int(dx);
+    wl->input.mouse.delta_y = wl_fixed_to_int(dy);
+}
+
 static void wl_touch_handle_frame(void *data, struct wl_touch *wl_touch) { }
 
 static void wl_touch_handle_cancel(void *data, struct wl_touch *wl_touch)
@@ -460,6 +472,11 @@ static void wl_seat_handle_capabilities(void *data,
    {
       wl->wl_pointer = wl_seat_get_pointer(seat);
       wl_pointer_add_listener(wl->wl_pointer, &pointer_listener, wl);
+      wl->wl_relative_pointer =
+         zwp_relative_pointer_manager_v1_get_relative_pointer(
+	    wl->relative_pointer_manager, wl->wl_pointer);
+      zwp_relative_pointer_v1_add_listener(wl->wl_relative_pointer,
+         &relative_pointer_listener, wl);
    }
    else if (!(caps & WL_SEAT_CAPABILITY_POINTER) && wl->wl_pointer)
    {
@@ -626,6 +643,14 @@ static void wl_registry_handle_global(void *data, struct wl_registry *reg,
             interface, zxdg_decoration_manager_v1_interface.name))
       wl->deco_manager = (struct zxdg_decoration_manager_v1*)wl_registry_bind(
             reg, id, &zxdg_decoration_manager_v1_interface, MIN(version, 1));
+   else if (string_is_equal(interface, zwp_pointer_constraints_v1_interface.name))
+      wl->pointer_constraints = (struct zwp_pointer_constraints_v1*)
+         wl_registry_bind(
+            reg, id, &zwp_pointer_constraints_v1_interface, MIN(version, 1));
+   else if (string_is_equal(interface, zwp_relative_pointer_manager_v1_interface.name))
+      wl->relative_pointer_manager = (struct zwp_relative_pointer_manager_v1*)
+         wl_registry_bind(
+            reg, id, &zwp_relative_pointer_manager_v1_interface, MIN(version, 1));
 }
 
 static void wl_registry_handle_global_remove(void *data,
@@ -949,6 +974,10 @@ const struct wl_data_offer_listener data_offer_listener = {
    wl_data_offer_handle_offer,
    wl_data_offer_handle_source_actions,
    wl_data_offer_handle_action
+};
+
+const struct zwp_relative_pointer_v1_listener relative_pointer_listener = {
+   .relative_motion = handle_relative_motion,
 };
 
 void flush_wayland_fd(void *data)

--- a/input/common/wayland_common.h
+++ b/input/common/wayland_common.h
@@ -41,6 +41,12 @@
 /* Generated from xdg-decoration-unstable-v1.h */
 #include "../../gfx/common/wayland/xdg-decoration-unstable-v1.h"
 
+/* Generated from pointer-constraints-unstable-v1.h */
+#include "../../gfx/common/wayland/pointer-constraints-unstable-v1.h"
+
+/* Generated from relative-pointer-unstable-v1.h */
+#include "../../gfx/common/wayland/relative-pointer-unstable-v1.h"
+
 #define UDEV_KEY_MAX			     0x2ff
 #define UDEV_MAX_KEYS           (UDEV_KEY_MAX + 7) / 8
 
@@ -138,6 +144,7 @@ typedef struct gfx_ctx_wayland_data
    struct xdg_toplevel *xdg_toplevel;
    struct wl_keyboard *wl_keyboard;
    struct wl_pointer  *wl_pointer;
+   struct zwp_relative_pointer_v1 *wl_relative_pointer;
    struct wl_touch *wl_touch;
    struct wl_seat *seat;
    struct wl_shm *shm;
@@ -157,6 +164,8 @@ typedef struct gfx_ctx_wayland_data
    struct zxdg_toplevel_decoration_v1 *deco;
    struct zwp_idle_inhibit_manager_v1 *idle_inhibit_manager;
    struct zwp_idle_inhibitor_v1 *idle_inhibitor;
+   struct zwp_pointer_constraints_v1 *pointer_constraints;
+   struct zwp_relative_pointer_manager_v1 *relative_pointer_manager;
    output_info_t *current_output;
 #ifdef HAVE_VULKAN
    gfx_ctx_vulkan_data_t vk;
@@ -210,6 +219,8 @@ void flush_wayland_fd(void *data);
 extern const struct wl_keyboard_listener keyboard_listener;
 
 extern const struct wl_pointer_listener pointer_listener;
+
+extern const struct zwp_relative_pointer_v1_listener relative_pointer_listener;
 
 extern const struct wl_touch_listener touch_listener;
 

--- a/input/drivers/wayland_input.c
+++ b/input/drivers/wayland_input.c
@@ -73,8 +73,6 @@ static void input_wl_poll(void *data)
 
    flush_wayland_fd(wl);
 
-   wl->mouse.delta_x            = wl->mouse.x - wl->mouse.last_x;
-   wl->mouse.delta_y            = wl->mouse.y - wl->mouse.last_y;
    wl->mouse.last_x             = wl->mouse.x;
    wl->mouse.last_y             = wl->mouse.y;
 
@@ -406,10 +404,11 @@ static uint64_t input_wl_get_capabilities(void *data)
 
 static void input_wl_grab_mouse(void *data, bool state)
 {
-   /* This function does nothing but registering it is necessary for allowing
-    * mouse-grab toggling. */
-   (void)data;
-   (void)state;
+   gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
+
+   if (state && wl->pointer_constraints)
+      zwp_pointer_constraints_v1_lock_pointer(wl->pointer_constraints, wl->surface,
+         wl->wl_pointer, NULL, ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_PERSISTENT);
 }
 
 input_driver_t input_wayland = {


### PR DESCRIPTION
## Description

This implements mouse grab/lock in Wayland, needed for some cores like Dosbox-core to work correctly with mouse-driven games.

## Related Issues

This long-standing issue is now fixed:
https://github.com/realnc/dosbox-core/issues/48
Mouse was misbehaving in Wayland because of the missing feature this PR adds: mouse grab/lock.