### PR TITLE
Fix for #15097

### DIFF
--- a/msg_hash.c
+++ b/msg_hash.c
@@ -171,7 +171,7 @@ const char *get_user_language_iso639_1(bool limit)
       case RETRO_LANGUAGE_CATALAN_VALENCIA:
          if (limit)
             return "ca";
-         return "ca_valencia";
+         return "ca_ES@valencia";
       case RETRO_LANGUAGE_CATALAN:
          return "ca";
       case RETRO_LANGUAGE_BRITISH_ENGLISH:

--- a/retroarch.c
+++ b/retroarch.c
@@ -7058,7 +7058,6 @@ enum retro_language retroarch_get_language_from_iso(const char *iso639)
 
    const struct lang_pair pairs[] =
    {
-      {"en", RETRO_LANGUAGE_ENGLISH},
       {"ja", RETRO_LANGUAGE_JAPANESE},
       {"fr", RETRO_LANGUAGE_FRENCH},
       {"es", RETRO_LANGUAGE_SPANISH},
@@ -7090,9 +7089,10 @@ enum retro_language retroarch_get_language_from_iso(const char *iso639)
       {"sv", RETRO_LANGUAGE_SWEDISH},
       {"uk", RETRO_LANGUAGE_UKRAINIAN},
       {"cs", RETRO_LANGUAGE_CZECH},
-      {"ca_valencia", RETRO_LANGUAGE_CATALAN_VALENCIA},
+      {"ca_ES@valencia", RETRO_LANGUAGE_CATALAN_VALENCIA},
       {"ca", RETRO_LANGUAGE_CATALAN},
       {"en_GB", RETRO_LANGUAGE_BRITISH_ENGLISH},
+      {"en", RETRO_LANGUAGE_ENGLISH},
       {"hu", RETRO_LANGUAGE_HUNGARIAN},
    };
 


### PR DESCRIPTION
## Description

Fix for #15097 (happens only with fontconfig enabled builds)
And a small fix for en_GB as it was not autodetected correctly.

## Related Issues

It seems that language autodetection (in configuration.c) is only enabled for Vita builds ever since https://github.com/libretro/RetroArch/pull/9541. Based on the current code, I do not see why it could not be extended, even if frontend driver does not support it, fallback will happen to English. But that will be a separate PR.