### PR TITLE
make ffmpeg core compile separately again and silence a couple of unu…

### DIFF
--- a/cores/libretro-ffmpeg/Makefile
+++ b/cores/libretro-ffmpeg/Makefile
@@ -217,7 +217,7 @@ else
    CFLAGS += -O3
 endif
 
-OBJECTS := $(SOURCES_C:.c=.o) $(SOURCES_CXX:.cpp=.o)
+OBJECTS := $(SOURCES_C:.c=.o) $(SOURCES_CXX:.cpp=.o) ../../libretro-common/features/features_cpu.o
 
 all: $(TARGET)
 

--- a/cores/libretro-ffmpeg/Makefile.common
+++ b/cores/libretro-ffmpeg/Makefile.common
@@ -8,7 +8,7 @@ GL_SOURCE          :=
 
 CPUOPTS            :=
 DEPS_DIR           := $(CORE_DIR)/deps
-LIBRETRO_COMM_DIR  := $(CORE_DIR)/libretro-common
+LIBRETRO_COMM_DIR  := $(CORE_DIR)/../../libretro-common
 BASE_DIR       	 := $(CORE_DIR)/..
 AVFORMAT_DIR   	 := $(BASE_DIR)/libavformat
 AVCODEC_DIR    	 := $(BASE_DIR)/libavcodec

--- a/cores/libretro-ffmpeg/ffmpeg_core.c
+++ b/cores/libretro-ffmpeg/ffmpeg_core.c
@@ -1060,7 +1060,6 @@ exit:
 static enum AVPixelFormat auto_hw_decoder(AVCodecContext *ctx,
                                     const enum AVPixelFormat *pix_fmts)
 {
-   int ret = 0;
    enum AVPixelFormat decoder_pix_fmt = AV_PIX_FMT_NONE;
    enum AVHWDeviceType type = AV_HWDEVICE_TYPE_NONE;
 

--- a/libretro-common/features/features_cpu.c
+++ b/libretro-common/features/features_cpu.c
@@ -694,7 +694,6 @@ uint64_t cpu_features_get(void)
    int flags[4];
    int vendor_shuffle[3];
    char vendor[13];
-   uint64_t cpu_flags  = 0;
    x86_cpuid(0, flags);
    vendor_shuffle[0] = flags[1];
    vendor_shuffle[1] = flags[3];


### PR DESCRIPTION
…sed variable warnings

## Description

The standalone ffmpeg-libretro core wouldn't build because it was looking for some things in the wrong location. I'm not sure if this is the best way to include the features_cpu.o object file, but when I just pointed to the libretro-common directory, the linker wouldn't take it.

There were also a couple of simple unused variable errors that I just deleted.

## Related Issues

I don't think there's an issue open for this, but I had talked to @HyperspaceMadness about it a few weeks ago and just got time to mess with it.

## Related Pull Requests

There are no related PRs.

## Reviewers

@LibretroAdmin 
