### PR TITLE
(Win32) Increase maximum window limit

### DIFF
--- a/gfx/common/win32_common.c
+++ b/gfx/common/win32_common.c
@@ -1003,8 +1003,8 @@ static LRESULT CALLBACK wnd_proc_common(
             lpMinMaxInfo->ptMinTrackSize.x = min_width;
             lpMinMaxInfo->ptMinTrackSize.y = min_height;
 
-            lpMinMaxInfo->ptMaxTrackSize.x = min_width  * 10;
-            lpMinMaxInfo->ptMaxTrackSize.y = min_height * 10;
+            lpMinMaxInfo->ptMaxTrackSize.x = min_width  * 20;
+            lpMinMaxInfo->ptMaxTrackSize.y = min_height * 20;
          }
          break;
       case WM_COMMAND:


### PR DESCRIPTION
## Description

Since `320 * 10` is not big enough for 4K resolution `3840` width when maximizing window instead of using fullscreen properly, let's give more room for the maximum size.
