### PR TITLE
Add wayland to input driver list.

### DIFF
--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -306,6 +306,9 @@ input_driver_t *input_drivers[] = {
 #ifdef HAVE_X11
    &input_x,
 #endif
+#ifdef HAVE_WAYLAND
+   &input_wayland,
+#endif
 #ifdef __WINRT__
    &input_uwp,
 #endif


### PR DESCRIPTION
## Description

Wayland input driver was not selectable from menu. It could still be enforced by context driver, or enabled in config file, but I saw no reason why it would be better to skip it from here.