### PR TITLE
(cheevos) collapse leaderboard trackers with same value definition

### DIFF
--- a/cheevos/cheevos_locals.h
+++ b/cheevos/cheevos_locals.h
@@ -93,6 +93,13 @@ typedef struct rcheevos_ralboard_t
   const char* mem;
   unsigned id;
   unsigned format;
+
+#ifdef HAVE_GFX_WIDGETS
+  int value;
+  unsigned value_hash;
+  uint8_t active_tracker_id;
+#endif
+
 } rcheevos_ralboard_t;
 
 
@@ -179,11 +186,18 @@ typedef struct rcheevos_locals_t
    unsigned menuitem_count;           /* current number of items in the menuitems array */
 #endif
 
+#ifdef HAVE_GFX_WIDGETS
+   unsigned active_lboard_trackers;   /* bit mask of active leaderboard tracker ids */
+#endif
+
    rcheevos_load_info_t load_info;    /* load info */
 
    bool hardcore_active;              /* hardcore functionality is active */
    bool loaded;                       /* load task has completed */
    bool core_supports;                /* false if core explicitly disables achievements */
+#ifdef HAVE_GFX_WIDGETS
+   bool assign_new_trackers;          /* a new leaderboard was started and needs a tracker assigned */
+#endif
    bool leaderboards_enabled;         /* leaderboards are enabled */
    bool leaderboard_notifications;    /* leaderboard notifications are enabled */
    bool leaderboard_trackers;         /* leaderboard trackers are enabled */


### PR DESCRIPTION
## Description

Only shows one tracker when multiple trackers have the same value/definition.

Was recently implemented in the toolkit via https://github.com/RetroAchievements/RAIntegration/pull/976

Current:
![image](https://user-images.githubusercontent.com/32680403/230450657-dcc0b2de-0a5c-4ce9-8f38-8878c1038dde.png)

New:
![image](https://user-images.githubusercontent.com/32680403/230450734-2187ba15-982e-4d7d-968d-186ff2a165b3.png)

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@Sanaki
