### PR TITLE
WASAPI Frame Delay fix + cleanups

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -1115,9 +1115,9 @@
 
 #ifdef HAVE_WASAPI
 /* WASAPI defaults */
-#define DEFAULT_WASAPI_EXCLUSIVE_MODE true
+#define DEFAULT_WASAPI_EXCLUSIVE_MODE false
 #define DEFAULT_WASAPI_FLOAT_FORMAT false
-/* auto */
+/* Automatic shared mode buffer */
 #define DEFAULT_WASAPI_SH_BUFFER_LENGTH -16
 #endif
 
@@ -1554,8 +1554,12 @@
 #endif
 
 /* MIDI */
-#define DEFAULT_MIDI_INPUT  "OFF"
+#if defined(_WIN32) && !defined(_XBOX) && !defined(__WINRT__)
+#define DEFAULT_MIDI_OUTPUT "Microsoft GS Wavetable Synth"
+#else
 #define DEFAULT_MIDI_OUTPUT "OFF"
+#endif
+#define DEFAULT_MIDI_INPUT  "OFF"
 #define DEFAULT_MIDI_VOLUME 100
 
 #ifdef HAVE_MIST

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -5119,8 +5119,7 @@ static void setting_get_string_representation_int_audio_wasapi_sh_buffer_length(
       return;
 
    if (*setting->value.target.integer > 0)
-      snprintf(s, len, "%d",
-            *setting->value.target.integer);
+      snprintf(s, len, "%d", *setting->value.target.integer);
    else if (*setting->value.target.integer == 0)
       strlcpy(s, "0 (Off)", len);
    else

--- a/midi_driver.c
+++ b/midi_driver.c
@@ -22,6 +22,11 @@
 #include "midi_driver.h"
 #include "verbosity.h"
 
+#ifdef HAVE_WASAPI
+#include "audio/audio_driver.h"
+#include "gfx/video_driver.h"
+#endif
+
 #define MIDI_DRIVER_BUF_SIZE 4096
 #define MIDI_DRIVER_OFF "OFF"
 
@@ -115,6 +120,19 @@ bool midi_driver_set_all_sounds_off(void)
 
    if (!rarch_midi_drv_data || !rarch_midi_drv_output_enabled)
       return false;
+
+#ifdef HAVE_WASAPI
+   /* FIXME: Due to some mysterious reason Frame Delay does not
+    * work with WASAPI unless MIDI output is active, even when
+    * MIDI is not used. Frame Delay also breaks if MIDI sounds
+    * are "set off", which happens on menu toggle, therefore
+    * skip this if WASAPI is used and Frame Delay is effective.. */
+   if (string_is_equal(audio_state_get_ptr()->current_audio->ident, "wasapi"))
+   {
+      if (video_state_get_ptr()->frame_delay_effective > 0)
+         return false;
+   }
+#endif
 
    event.data       = data;
    event.data_size  = sizeof(data);

--- a/retroarch.c
+++ b/retroarch.c
@@ -956,7 +956,7 @@ void drivers_init(
    if (flags & DRIVER_LED_MASK)
       led_driver_init(settings->arrays.led_driver);
 
-   /* Initialize MIDI  driver */
+   /* Initialize MIDI driver */
    if (flags & DRIVER_MIDI_MASK)
       midi_driver_init(settings);
 


### PR DESCRIPTION
## Description

Currently WASAPI and Frame Delay do not work properly together, but I found a band-aid method. For some reason it requires MIDI output driver to be active, even when the core is not using it. Therefore added the following changes:

- Set default MIDI output driver to `Microsoft GS Wavetable Synth` since it always exists, and there does not seem to be any harm having it enabled, and no benefit having it off
- Ignore setting all MIDI sounds off when menu is toggled when WASAPI and Frame Delay are active

Also:
- Changed default WASAPI mode to shared, because exclusive will kill all other audio output, which is not a friendly starting point
- Changed WASAPI shared mode buffer to use client buffer instead of device period in order to get solid frame times out of the box. Shared mode will ignore the global audio latency option anyway.
- Removed `AUDCLNT_STREAMFLAGS_NOPERSIST` flag from shared mode so that application volume mixer will not reset on restart
- Readability and logging cleanups

Would be very nice if someone could try to help hunting down the reason why MIDI driver is required for Frame Delay.
