### PR TITLE
Audio output menu item reinit fix

### DIFF
--- a/audio/audio_driver.c
+++ b/audio/audio_driver.c
@@ -609,6 +609,8 @@ bool audio_driver_init_internal(
       audio_driver_st.flags     &= ~AUDIO_FLAG_ACTIVE;
       return false;
    }
+   else
+      audio_driver_st.flags     |= AUDIO_FLAG_ACTIVE;
 
    if (!(audio_driver_find_driver(settings,
          "audio driver", verbosity_enabled)))

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -13568,6 +13568,7 @@ static bool setting_append_list(
                general_read_handler,
                SD_FLAG_NONE
                );
+         MENU_SETTINGS_LIST_CURRENT_ADD_CMD(list, list_info, CMD_EVENT_AUDIO_REINIT);
 
          CONFIG_BOOL(
                list, list_info,


### PR DESCRIPTION
## Description

Currently audio output option does not work in realtime, and if disabled and then reinit is forced for example by toggling fullscreen, audio can't be restored back by doing the same trick, which means full restart is mandatory. Therefore force audio reinit on toggle and reactivate audio flag.

In any case I think this option should be hidden under advanced flag, because using mute is the much more appropriate choice for the same end result. But that is something for later.
