### PR TITLE
(3DS) Update __system_initArgv

### DIFF
--- a/ctr/ctr_system.c
+++ b/ctr/ctr_system.c
@@ -5,7 +5,6 @@
 #include <unistd.h>
 #include <string.h>
 #include <stdlib.h>
-#include <ctype.h>
 #include "ctr_debug.h"
 
 #define CTR_APPMEMALLOC_PTR ((u32*)0x1FF80040)
@@ -232,20 +231,7 @@ void __system_initArgv(void)
       for (i = 1; i < __system_argc; i++)
          __system_argv[i] = __system_argv[i - 1] + strlen(__system_argv[i - 1]) + 1;
 
-      i             = __system_argc - 1;
-      __system_argc = 1;
-
-      while (i)
-      {
-         if(__system_argv[i] && isalnum(__system_argv[i][0])
-               && strncmp(__system_argv[i], "3dslink:/", 9))
-         {
-            __system_argv[1] = __system_argv[i];
-            __system_argc = 2;
-            break;
-         }
-         i--;
-      }
+      __system_argv[__system_argc] = NULL;
    }
    else
    {


### PR DESCRIPTION
Allow multiple argv arguments to be passed to main(), required for loading netplay or subsystems.

- __system_argc was set to 1, preventing multiple arguments to be passed to main().
- Updated to more closely match the libctru function it replaces.
