### PR TITLE
Change network port menu options to 'allow_input' mode

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -21069,7 +21069,8 @@ static bool setting_append_list(
                   NULL);
             (*list)[list_info->index - 1].action_ok = &setting_action_ok_uint;
             (*list)[list_info->index - 1].offset_by = 1;
-            menu_settings_list_current_add_range(list, list_info, 1, 99999, 1, true, true);
+            menu_settings_list_current_add_range(list, list_info, 0, 65535, 1, true, true);
+            SETTINGS_DATA_LIST_CURRENT_ADD_FLAGS(list, list_info, SD_FLAG_ALLOW_INPUT);
             SETTINGS_DATA_LIST_CURRENT_ADD_FLAGS(list, list_info, SD_FLAG_ADVANCED);
 
             CONFIG_BOOL(
@@ -21103,7 +21104,8 @@ static bool setting_append_list(
                   NULL);
             (*list)[list_info->index - 1].action_ok = &setting_action_ok_uint;
             (*list)[list_info->index - 1].offset_by = 1;
-            menu_settings_list_current_add_range(list, list_info, 1, 99999, 1, true, true);
+            menu_settings_list_current_add_range(list, list_info, 0, 65535, 1, true, true);
+            SETTINGS_DATA_LIST_CURRENT_ADD_FLAGS(list, list_info, SD_FLAG_ALLOW_INPUT);
             SETTINGS_DATA_LIST_CURRENT_ADD_FLAGS(list, list_info, SD_FLAG_ADVANCED);
 
             /* TODO/FIXME - add enum_idx */


### PR DESCRIPTION
## Description

Change both "Network Command Port" and "Network RetroPad Base Port" menu options to free-type input mode instead of clunky and slow dropdown selector, just like "Netplay TCP Port". Opening the dropdown takes a while even with a beefy system. Maximum value of `99999` for them was overkill regardless.

## Related Issues

Closes #15212
