### PR TITLE
Update pkg/emscripten/README.md with correct assets URL

### DIFF
--- a/pkg/emscripten/README.md
+++ b/pkg/emscripten/README.md
@@ -46,7 +46,7 @@ I you want a self hosted version you need
   https://buildbot.libretro.com/nightly/emscripten/
 - Extract the build somewhere in your web-server 
   - Grab the asset bundle:
-  https://buildbot.libretro.com/assets/frontend/bundle.zip
+  https://buildbot.libretro.com/assets/frontend/assets.zip
 - Unzip it in the same dir you extracted the rest, inside **/assets/frontend/bundle**
 - Create an **assets/cores** dir, you can put game data in that dir so it's available under **downloads**
 - chmod +x the indexer script


### PR DESCRIPTION
## Guidelines

Rebased the branch before opening this pull request.
This pull request contains a single commit, addressing the issue of an incorrect assets URL.
Squashed the change into a single commit.

## Description

This pull request updates the pkg/emscripten/README.md file by replacing the incorrect assets URL with the correct one. The change ensures that users are directed to the right location to download the necessary assets for setting up their self-hosted RetroArch web player.

## Related Issues

Issue: Incorrect assets URL in pkg/emscripten/README.md

[[Any issues this pull request may be addressing]](https://github.com/libretro/RetroArch/issues/11947)
https://github.com/libretro/RetroArch/issues/7125
https://github.com/libretro/RetroArch/issues/11252

## Related Pull Requests
None

## Reviewers
@antoinebou12
[Please add any other reviewers who should review this pull request]