### PR TITLE
The default pthread stack size on Apple is too small for detect_ps2_game

### DIFF
--- a/libretro-common/rthreads/rthreads.c
+++ b/libretro-common/rthreads/rthreads.c
@@ -229,6 +229,10 @@ sthread_t *sthread_create_with_priority(void (*thread_func)(void*), void *userda
 #if defined(VITA)
    pthread_attr_setstacksize(&thread_attr , 0x10000 );
    thread_attr_needed = true;
+#elif defined(__APPLE__)
+   // default stack size on apple is 512kb; for ps2 disc scanning and other reasons, we'd like 2MB.
+   pthread_attr_setstacksize(&thread_attr , 0x200000 );
+   thread_attr_needed = true;
 #endif
 
 #ifdef HAVE_THREAD_ATTR


### PR DESCRIPTION
1MB should be enough but to be safe let's ask for 2MB.