### PR TITLE
[PS1 Scanning] Fix PS1 game scanning that have PSX.EXE instead of the real serial

### DIFF
--- a/tasks/task_database_cue.c
+++ b/tasks/task_database_cue.c
@@ -254,7 +254,7 @@ int detect_ps1_game(intfstream_t *fd, char *s, size_t len, const char *filename)
 
          string_remove_all_whitespace(s, raw_game_id);
          cue_append_multi_disc_suffix(s, filename);
-         return true;
+         return false;
       }
    }
 


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

Early PS1 games like Crime Crackers can't be scanned anymore since PSX.EXE detection was added.
To fix this regression, the detect_ps1_game function will now return a failure when PSX,EXE is detected  (yes it's a PS1 game, but the serial can't be extracted), and then fallback on usual CRC scanning, which usually ends up finding the right game.
Crime Crackers can now be scanned again.
Gradius V (PS2 CD game) was also tested for regression and scans properly.

## Related Issues
This is part of improving the PS1 scanning of Retroarch
https://github.com/libretro/RetroArch/issues/14192
## Related Pull Requests
This PR tries to fix a regression potentially introduced by
https://github.com/libretro/RetroArch/pull/14566

## Reviewers
@AKuHAK
