### PR TITLE
(Ozone) Sidebar multiline scrolling

### DIFF
--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -3975,7 +3975,7 @@ void menu_entries_build_scroll_indices(
       if (type == FILE_TYPE_DIRECTORY)
          is_dir = true;
 
-      if ((current_is_dir && !is_dir) || (first > current))
+      if ((current_is_dir && !is_dir) || (first != current))
       {
          /* Add scroll index */
          menu_st->scroll.index_list[menu_st->scroll.index_size]   = i;


### PR DESCRIPTION
## Description

Usability boost for long playlists by allowing both scroll buttons (10 items + alphabetic) to also work in the tab sidebar. Both scroll buttons stay inside the playlist area.

Also altered the behavior of alphabetic scroll in non-playlist menus to create indexes always when the first char changes, and not only for the next letter. This behaves much better in non-alphabetized menus.

