### PR TITLE
(SDL) Fix rumble on PS4/PS5 controllers connected via bluetooth

### DIFF
--- a/input/drivers_joypad/sdl_joypad.c
+++ b/input/drivers_joypad/sdl_joypad.c
@@ -2,6 +2,7 @@
  *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
  *  Copyright (C) 2011-2017 - Daniel De Matteis
  *  Copyright (C) 2014-2017 - Higor Euripedes
+ *  Copyright (C)      2023 - Carlo Refice
  *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-
@@ -32,7 +33,7 @@ typedef struct _sdl_joypad
 #ifdef HAVE_SDL2
    SDL_GameController *controller;
    SDL_Haptic *haptic;
-   int rumble_effect; /* -1 = not initialized, -2 = error/unsupported */
+   int rumble_effect; /* -1 = not initialized, -2 = error/unsupported, -3 = use SDL_JoystickRumble instead of haptic */
 #endif
    unsigned num_axes;
    unsigned num_buttons;
@@ -212,9 +213,15 @@ static void sdl_pad_connect(unsigned id)
       if (SDL_HapticEffectSupported(pad->haptic, &efx) == SDL_FALSE)
       {
          pad->rumble_effect = -2;
-         RARCH_WARN("[SDL]: Device #%u does not support rumble.\n", id);
+         RARCH_WARN("[SDL]: Device #%u does not support leftright haptic effect.\n", id);
       }
    }
+#if SDL_VERSION_ATLEAST(2, 0, 9)
+   if (!pad->haptic || pad->rumble_effect == -2) {
+      pad->rumble_effect = -3;
+      RARCH_LOG("[SDL]: Falling back to joystick rumble\n");
+   }
+#endif
 #else
    pad->num_axes    = SDL_JoystickNumAxes(pad->joypad);
    pad->num_buttons = SDL_JoystickNumButtons(pad->joypad);
@@ -289,6 +296,11 @@ static void *sdl_joypad_init(void *data)
    }
    else
       g_has_haptic = true;
+      
+#if SDL_VERSION_ATLEAST(2, 0, 9)
+   /* enable extended hid reports to support ps4/ps5 rumble over bluetooth */
+   SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS4_RUMBLE, "1");
+#endif
 #endif
 
    memset(sdl_pads, 0, sizeof(sdl_pads));
@@ -471,7 +483,7 @@ static bool sdl_joypad_set_rumble(unsigned pad, enum retro_rumble_effect effect,
 
    memset(&efx, 0, sizeof(efx));
 
-   if (!joypad->joypad || !joypad->haptic)
+   if (!joypad->joypad)
       return false;
 
    efx.type             = SDL_HAPTIC_LEFTRIGHT;
@@ -490,9 +502,25 @@ static bool sdl_joypad_set_rumble(unsigned pad, enum retro_rumble_effect effect,
          return false;
    }
 
+#if SDL_VERSION_ATLEAST(2, 0, 9)
+   if (joypad->rumble_effect == -3)
+   {
+      if (SDL_JoystickRumble(joypad->joypad, efx.leftright.large_magnitude, efx.leftright.small_magnitude, efx.leftright.length) == -1)
+      {
+         RARCH_WARN("[SDL]: Failed to rumble joypad %u: %s\n",
+                    pad, SDL_GetError());
+         joypad->rumble_effect = -2;
+         return false;
+      }
+   }
+#endif
+
+   if (!joypad->haptic)
+      return false;
+
    if (joypad->rumble_effect == -1)
    {
-      joypad->rumble_effect = SDL_HapticNewEffect(sdl_pads[pad].haptic, &efx);
+      joypad->rumble_effect = SDL_HapticNewEffect(joypad->haptic, &efx);
       if (joypad->rumble_effect < 0)
       {
          RARCH_WARN("[SDL]: Failed to create rumble effect for joypad %u: %s\n",


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

I don't like using remapping software on Windows to support DualShock controllers connected via Bluetooth, since SDL usually supports them well enough. I noticed that Retroarch's SDL support for vibration of these controllers was broken. This PR adds vibration support for PS4/PS5 (and potentially other) controllers in the SDL joystick driver.

This is done with two major changes:
1. Enabling extended HID reports by setting `SDL_HINT_JOYSTICK_HIDAPI_PS4_RUMBLE`.
2. Falling back to using `SDL_JoystickRumble` if `SDL_Haptic` is not supported for a controller (as is the case with the PS4 controller)