### PR TITLE
(video_driver) fix windowed viewport with libretro rotation

### DIFF
--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -3303,14 +3303,14 @@ bool video_driver_init_internal(bool *video_is_threaded, bool verbosity_enabled)
                 {
                    /* Do rounding here to simplify integer
                     * scale correctness. */
-                   unsigned base_height = roundf(geom->base_height *
-                      (1/video_st->aspect_ratio));
-                   height = base_height * video_scale;
+                   unsigned base_width = roundf(geom->base_width *
+                      video_st->aspect_ratio);
+                   width = base_width * video_scale;
                 }
                 else
-                   height = geom->base_width * video_scale;
+                   width = geom->base_height * video_scale;
 
-                width = geom->base_height * video_scale;
+                height = geom->base_width * video_scale;
             }
             else
             {

--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -3293,20 +3293,42 @@ bool video_driver_init_internal(bool *video_is_threaded, bool verbosity_enabled)
                }
             }
 
-            /* Determine nominal window size based on
-             * core geometry */
-            if (settings->bools.video_force_aspect)
+            /* rotated games send unrotated width/height and
+             * require special handling here because of it */
+            if ((retroarch_get_rotation() % 2))
             {
-               /* Do rounding here to simplify integer
-                * scale correctness. */
-               unsigned base_width = roundf(geom->base_height *
-                  video_st->aspect_ratio);
-               width = base_width * video_scale;
+                /* Determine nominal window size based on
+                 * core geometry */
+                if (settings->bools.video_force_aspect)
+                {
+                   /* Do rounding here to simplify integer
+                    * scale correctness. */
+                   unsigned base_height = roundf(geom->base_height *
+                      (1/video_st->aspect_ratio));
+                   height = base_height * video_scale;
+                }
+                else
+                   height = geom->base_width * video_scale;
+
+                width = geom->base_height * video_scale;
             }
             else
-               width = geom->base_width * video_scale;
+            {
+                /* Determine nominal window size based on
+                 * core geometry */
+                if (settings->bools.video_force_aspect)
+                {
+                   /* Do rounding here to simplify integer
+                    * scale correctness. */
+                   unsigned base_width = roundf(geom->base_height *
+                      video_st->aspect_ratio);
+                   width = base_width * video_scale;
+                }
+                else
+                   width = geom->base_width * video_scale;
 
-            height = geom->base_height * video_scale;
+                height = geom->base_height * video_scale;
+            }
 
             /* Cap window size to maximum allowed values */
             if ((width > max_win_width) || (height > max_win_height))


### PR DESCRIPTION
I noticed the viewport seems wrong when running rotated games in windowed mode: a rotated 320x240 game with a 3x scaling will output `[INFO] [Video]: Set video size to: 540x720.` instead of `[INFO] [Video]: Set video size to: 720x960.`, the original resolution will even be downsized if you run it at 1x scaling.

This PR should fix this, i don't think it affects anything besides rotated games running in windowed mode, however i'm not familiar with that code so correct me if i'm wrong.