### PR TITLE
(RGUI) Fix and add toggle for playlist thumbnails

### DIFF
--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -10602,7 +10602,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_MENU_RGUI_INLINE_THUMBNAILS,
-   "Enable display of inline downscaled thumbnails while viewing playlists. When disabled, 'Top Thumbnail' may still be toggled fullscreen by pressing RetroPad Y."
+   "Enable display of inline downscaled thumbnails while viewing playlists. Toggleable with RetroPad Select. When disabled, thumbnails can still be toggled fullscreen with RetroPad Start."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_THUMBNAILS_RGUI,
@@ -10610,7 +10610,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_THUMBNAILS_RGUI,
-   "Type of thumbnail to display at the top right of playlists. This thumbnail may be toggled fullscreen by pressing RetroPad Y."
+   "Type of thumbnail to display at the top right of playlists. This thumbnail type can be cycled by pressing RetroPad Y."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_LEFT_THUMBNAILS_RGUI,

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -7858,9 +7858,18 @@ static enum menu_action rgui_parse_menu_entry_action(
       case MENU_ACTION_CANCEL:
          if (rgui->flags & RGUI_FLAG_SHOW_FULLSCREEN_THUMBNAIL)
          {
-            rgui_thumbnail_cycle_dupe(rgui);
-            rgui_toggle_fs_thumbnail(rgui, config_get_ptr()->bools.menu_rgui_inline_thumbnails);
+            if (     ((rgui->flags & RGUI_FLAG_IS_STATE_SLOT) || (rgui->is_quick_menu))
+                  && !string_is_empty(rgui->savestate_thumbnail_file_path))
+            {
+               rgui_toggle_fs_thumbnail(rgui, true);
+            }
+            else
+            {
+               rgui_thumbnail_cycle_dupe(rgui);
+               rgui_toggle_fs_thumbnail(rgui, config_get_ptr()->bools.menu_rgui_inline_thumbnails);
+            }
             new_action = MENU_ACTION_NOOP;
+            break;
          }
 
          if (string_is_equal(rgui->menu_title, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_MAIN_MENU)))


### PR DESCRIPTION
## Description

- Made playlist thumbnail option to behave like it says in the sublabel
  - Fullscreen viewing does not work currently because entry update depends on the option
- Corrected RetroPad buttons in sublabels
- Added visibility toggle to Select (Quick Menu shows thumbnails always)


## Related Issues

Closes #14904

