### PR TITLE
(XMB) Fix menu wallpaper option + override

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -5267,7 +5267,7 @@ int8_t config_save_overrides(enum override_type type, void *data, bool remove)
             config_set_string(conf, array_overrides[i].ident,
                   array_overrides[i].ptr);
             RARCH_DBG("[Overrides]: %s = \"%s\"\n",
-                  array_overrides[i].ident, *array_overrides[i].ptr);
+                  array_overrides[i].ident, array_overrides[i].ptr);
          }
       }
 
@@ -5278,7 +5278,7 @@ int8_t config_save_overrides(enum override_type type, void *data, bool remove)
             config_set_path(conf, path_overrides[i].ident,
                   path_overrides[i].ptr);
             RARCH_DBG("[Overrides]: %s = \"%s\"\n",
-                  path_overrides[i].ident, *path_overrides[i].ptr);
+                  path_overrides[i].ident, path_overrides[i].ptr);
          }
       }
 

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -4641,7 +4641,8 @@ static enum menu_action xmb_parse_menu_entry_action(
             to prevent accidental imageviewer core launch */
          if (     xmb->libretro_running
                && xmb->is_file_list
-               && xmb_fullscreen_thumbnails_available(xmb))
+               && xmb_fullscreen_thumbnails_available(xmb)
+               && xmb_get_system_tab(xmb, (unsigned)xmb->categories_selection_ptr) == XMB_SYSTEM_TAB_MAIN)
          {
             if (xmb->show_fullscreen_thumbnails)
                xmb_hide_fullscreen_thumbnails(xmb, true);


### PR DESCRIPTION
## Description

Current hack for preventing accidental image content launches while already running a core also prevented background image selector from working. Also fixed debug level output crash when saving overrides of certain option types.
