### PR TITLE
Various tvOS improvements

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -65,6 +65,10 @@
 #include "switch_performance_profiles.h"
 #endif
 
+#if TARGET_OS_TV
+#include "ui/drivers/cocoa/apple_platform.h"
+#endif
+
 enum video_driver_enum
 {
    VIDEO_GL                 = 0,
@@ -3355,6 +3359,16 @@ static bool config_load_file(global_t *global,
 
    conf = (path) ? config_file_new_from_path_to_string(path) : open_default_config_file();
 
+#if TARGET_OS_TV
+   if (!conf && path && string_is_equal(path, path_get(RARCH_PATH_CONFIG)))
+   {
+      /* Sometimes the OS decides it needs to reclaim disk space
+       * by emptying the cache, which is the only disk space we
+       * have access to, other than NSUserDefaults. */
+      conf = open_userdefaults_config_file();
+   }
+#endif
+
    if (!conf)
    {
       first_load = false;
@@ -5073,6 +5087,11 @@ bool config_save_file(const char *path)
 
    ret = config_file_write(conf, path, true);
    config_file_free(conf);
+
+#if TARGET_OS_TV
+   if (ret && string_is_equal(path, path_get(RARCH_PATH_CONFIG)))
+       write_userdefaults_config_file();
+#endif
 
    return ret;
 }

--- a/input/drivers_joypad/mfi_joypad.m
+++ b/input/drivers_joypad/mfi_joypad.m
@@ -96,7 +96,7 @@ static void apple_gamecontroller_joypad_poll_internal(GCController *controller, 
         *buttons             |= gp.leftTrigger.pressed     ? (1 << RETRO_DEVICE_ID_JOYPAD_L2)    : 0;
         *buttons             |= gp.rightTrigger.pressed    ? (1 << RETRO_DEVICE_ID_JOYPAD_R2)    : 0;
 #if OSX || __IPHONE_OS_VERSION_MAX_ALLOWED >= 120100 || __TV_OS_VERSION_MAX_ALLOWED >= 120100
-        if (@available(iOS 12.1, macOS 10.15, *))
+        if (@available(iOS 12.1, macOS 10.15, tvOS 12.1, *))
         {
             *buttons         |= gp.leftThumbstickButton.pressed ? (1 << RETRO_DEVICE_ID_JOYPAD_L3) : 0;
             *buttons         |= gp.rightThumbstickButton.pressed ? (1 << RETRO_DEVICE_ID_JOYPAD_R3) : 0;

--- a/pkg/apple/RetroArch_iOS13.xcodeproj/project.pbxproj
+++ b/pkg/apple/RetroArch_iOS13.xcodeproj/project.pbxproj
@@ -1979,7 +1979,7 @@
 				SDKROOT = appletvos;
 				SRCBASE = "$(SRCROOT)/../..";
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 12.1;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 			};
 			name = Debug;
 		};
@@ -2141,7 +2141,7 @@
 				SDKROOT = appletvos;
 				SRCBASE = "$(SRCROOT)/../..";
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 12.1;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 			};
 			name = Release;
 		};

--- a/ui/drivers/cocoa/apple_platform.h
+++ b/ui/drivers/cocoa/apple_platform.h
@@ -1,6 +1,14 @@
 #ifndef COCOA_APPLE_PLATFORM_H
 #define COCOA_APPLE_PLATFORM_H
 
+#if TARGET_OS_TV
+#include "config_file.h"
+extern config_file_t *open_userdefaults_config_file(void);
+extern void write_userdefaults_config_file(void);
+#endif
+
+#ifdef __OBJC__
+
 #ifdef HAVE_METAL
 #import <Metal/Metal.h>
 #import <MetalKit/MetalKit.h>
@@ -92,6 +100,8 @@ UINavigationControllerDelegate> {
 @property(nonatomic, retain) NSWindow IBOutlet *window;
 
 @end
+#endif
+
 #endif
 
 #endif

--- a/ui/drivers/cocoa/cocoa_common.m
+++ b/ui/drivers/cocoa/cocoa_common.m
@@ -30,6 +30,7 @@
 #endif
 
 #include "../../../configuration.h"
+#include "../../../paths.h"
 #include "../../../retroarch.h"
 #include "../../../verbosity.h"
 
@@ -836,3 +837,21 @@ bool cocoa_get_metrics(
    return true;
 }
 #endif
+
+config_file_t *open_userdefaults_config_file()
+{
+   config_file_t *conf = NULL;
+   NSString *backup = [NSUserDefaults.standardUserDefaults stringForKey:@FILE_PATH_MAIN_CONFIG];
+   if ([backup length] >= 0)
+      conf = config_file_new_from_string([backup cStringUsingEncoding:NSUTF8StringEncoding], path_get(RARCH_PATH_CONFIG));
+   return conf;
+}
+
+void write_userdefaults_config_file()
+{
+   NSString *conf = [NSString stringWithContentsOfFile:[NSString stringWithUTF8String:path_get(RARCH_PATH_CONFIG)]
+                                              encoding:NSUTF8StringEncoding
+                                                 error:nil];
+   if (conf)
+      [NSUserDefaults.standardUserDefaults setObject:conf forKey:@FILE_PATH_MAIN_CONFIG];
+}

--- a/ui/drivers/ui_cocoatouch.m
+++ b/ui/drivers/ui_cocoatouch.m
@@ -294,7 +294,7 @@ enum
 - (void)sendEvent:(UIEvent *)event
 {
    [super sendEvent:event];
-    if (@available(iOS 13.4, *)) {
+    if (@available(iOS 13.4, tvOS 13.4, *)) {
         if (event.type == UIEventTypeHover)
             return;
     }


### PR DESCRIPTION
1. Default tvOS build goes back to tvOS 11 instead of 13.
2. If the cache directory gets destroyed we can at least restore from a backed up copy of retroarch.cfg. This will be necessary at the least if there is ever support for cloud backups; the credentials for the cloud backup would still have to be stored locally somewhere.
3. Handle taps on Siri Remote for directional movement.