### PR TITLE
Stop always reseting to defaults on remap delete

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -4339,8 +4339,6 @@ bool config_load_remap(const char *directory_input_remapping,
          FILE_PATH_REMAP_EXTENSION,
          sizeof(core_path));
 
-   input_remapping_set_defaults(false);
-
    /* If a game remap file exists, load it. */
    if (has_content && (new_conf = config_file_new_from_path_to_string(game_path)))
    {
@@ -5522,10 +5520,9 @@ bool input_remapping_load_file(void *data, const char *path)
       return false;
 
    if (!string_is_empty(runloop_st->name.remapfile))
-   {
       input_remapping_deinit(false);
-      input_remapping_set_defaults(false);
-   }
+
+   input_remapping_set_defaults(false);
    runloop_st->name.remapfile = strdup(path);
 
    for (i = 0; i < MAX_USERS; i++)

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -3602,24 +3602,15 @@ static int generic_action_ok_remap_file_operation(const char *path,
          {
             case ACTION_OK_REMAP_FILE_REMOVE_CORE:
                if (flags & RUNLOOP_FLAG_REMAPS_CORE_ACTIVE)
-               {
                   input_remapping_deinit(false);
-                  input_remapping_set_defaults(false);
-               }
                break;
             case ACTION_OK_REMAP_FILE_REMOVE_GAME:
                if (flags & RUNLOOP_FLAG_REMAPS_GAME_ACTIVE)
-               {
                   input_remapping_deinit(false);
-                  input_remapping_set_defaults(false);
-               }
                break;
             case ACTION_OK_REMAP_FILE_REMOVE_CONTENT_DIR:
                if (flags & RUNLOOP_FLAG_REMAPS_CONTENT_DIR_ACTIVE)
-               {
                   input_remapping_deinit(false);
-                  input_remapping_set_defaults(false);
-               }
                break;
          }
 


### PR DESCRIPTION
## Description

Menu behavior adjustment to stop aggressively reseting inputs to defaults on every turn, and instead only before loading a new file. The same behavior stands, which is if there are multiple remaps, deleting one will try to load the next one. But if there is no next one, inputs won't reset to defaults. The "Reset Input Mapping" menu item is enough for that.

## Related Issues

Closes #15245
