### PR TITLE
Fix parport_joypad snprintf warning

### DIFF
--- a/input/drivers_joypad/parport_joypad.c
+++ b/input/drivers_joypad/parport_joypad.c
@@ -249,7 +249,7 @@ static void *parport_joypad_init(void *data)
       pad->fd    = -1;
       pad->ident = input_config_get_device_name_ptr(i);
 
-      snprintf(path + _len, sizeof(path) - _len, "%u", i);
+      snprintf(path + _len, sizeof(path) - _len, "%u", (uint32_t)i);
 
       if (parport_joypad_init_pad(path, pad))
       {


### PR DESCRIPTION
This change fixes the warning that appears in parport_joypad snprintf() call...

```
input/drivers_joypad/parport_joypad.c: In function ‘parport_joypad_init’:
input/drivers_joypad/parport_joypad.c:252:52: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 4 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
  252 |       snprintf(path + _len, sizeof(path) - _len, "%u", i);
      |                                                   ~^   ~
      |                                                    |   |
      |                                                    |   size_t {aka long unsigned int}
      |                                                    unsigned int
      |                                                   %lu
```