### PR TITLE
Correct rotated "Core provided" aspect ratio

### DIFF
--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -1951,6 +1951,10 @@ float video_driver_get_core_aspect(void)
    else
       out_aspect = (float)geom->base_width / geom->base_height;
 
+   /* Flip rotated aspect */
+   if ((retroarch_get_rotation() + retroarch_get_core_requested_rotation()) % 2)
+      out_aspect = 1.0f / out_aspect;
+
    return out_aspect;
 }
 

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -8060,11 +8060,11 @@ static void general_write_handler(rarch_setting_t *setting)
       case MENU_ENUM_LABEL_VIDEO_ROTATION:
          {
             video_viewport_t vp;
-	    rarch_system_info_t *system          = &runloop_state_get_ptr()->system;
+            rarch_system_info_t *system          = &runloop_state_get_ptr()->system;
             struct retro_system_av_info *av_info = video_viewport_get_system_av_info();
-            video_viewport_t            *custom  = video_viewport_get_custom();
+            video_viewport_t             *custom = video_viewport_get_custom();
             struct retro_game_geometry     *geom = (struct retro_game_geometry*)
-               &av_info->geometry;
+                  &av_info->geometry;
 
             if (system)
             {
@@ -8078,6 +8078,7 @@ static void general_write_handler(rarch_setting_t *setting)
                video_driver_get_viewport_info(&vp);
                custom->x      = 0;
                custom->y      = 0;
+
                /* Round down when rotation is "horizontal", round up when rotation is "vertical"
                   to avoid expanding viewport each time user rotates */
                if (rotation % 2)
@@ -8090,8 +8091,7 @@ static void general_write_handler(rarch_setting_t *setting)
                   custom->width  = ((custom->width + geom->base_width   - 1) / geom->base_width)  * geom->base_width;
                   custom->height = ((custom->height + geom->base_height - 1) / geom->base_height) * geom->base_height;
                }
-               aspectratio_lut[ASPECT_RATIO_CUSTOM].value =
-                  (float)custom->width / custom->height;
+               aspectratio_lut[ASPECT_RATIO_CUSTOM].value = (float)custom->width / custom->height;
 
                /* Update Aspect Ratio (only useful for 1:1 PAR) */
                video_driver_set_aspect_ratio();


### PR DESCRIPTION
## Description

Take rotation into account for "Core provided" aspect ratio, so that this:
![image](https://github.com/libretro/RetroArch/assets/45124675/c942830e-8343-438a-9a9b-14771df045b6)

Becomes this:
![image](https://github.com/libretro/RetroArch/assets/45124675/03dc60e3-79d6-4b57-b55f-454f10607204)

Instead of:
![image](https://github.com/libretro/RetroArch/assets/45124675/6b23615c-ab4d-41a9-b41c-9a1a03ae4e69)


