### PR TITLE
menu_st missing for WIFI option fails to build

### DIFF
--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -6007,6 +6007,8 @@ static void wifi_menu_refresh_callback(retro_task_t *task,
       void *task_data,
       void *user_data, const char *error)
 {
+   struct menu_state *menu_st       = menu_state_get_ptr();
+
    menu_st->flags                  |= MENU_ST_FLAG_ENTRIES_NEED_REFRESH
                                     | MENU_ST_FLAG_PREVENT_POPULATE;
 }


### PR DESCRIPTION
## Description

Trivial fix, problem introduced in https://github.com/libretro/RetroArch/commit/91ea92e50bd4f442b1eeceeea7c0e80bc7ee9d0f#diff-04dc75103003c9b5168602965b9499bb5806ce3e8d0e5739aa0e2c71f409b335

## Related Issues

https://github.com/libretro/RetroArch/issues/15281

