### PR TITLE
Add accelerometer and gyroscope sensors to iOS

### DIFF
--- a/griffin/griffin.c
+++ b/griffin/griffin.c
@@ -710,8 +710,6 @@ INPUT
 #elif defined(ORBIS)
 #include "../input/drivers/ps4_input.c"
 #include "../input/drivers_joypad/ps4_joypad.c"
-#elif defined(HAVE_COCOA) || defined(HAVE_COCOATOUCH) || defined(HAVE_COCOA_METAL)
-#include "../input/drivers/cocoa_input.c"
 #elif defined(_3DS)
 #include "../input/drivers/ctr_input.c"
 #include "../input/drivers_joypad/ctr_joypad.c"

--- a/griffin/griffin_objc.m
+++ b/griffin/griffin_objc.m
@@ -43,6 +43,8 @@
 #include "../ui/drivers/ui_cocoatouch.m"
 #endif
 
+#include "../input/drivers/cocoa_input.m"
+
 #endif
 
 #ifdef HAVE_MFI

--- a/pkg/apple/RetroArch_iOS13.xcodeproj/project.pbxproj
+++ b/pkg/apple/RetroArch_iOS13.xcodeproj/project.pbxproj
@@ -1601,6 +1601,7 @@
 					"-DHAVE_COCOA_METAL",
 					"-DHAVE_CONFIGFILE",
 					"-DHAVE_COREAUDIO",
+					"-DHAVE_COREMOTION",
 					"-DHAVE_DSP_FILTER",
 					"-DHAVE_DYNAMIC",
 					"-DHAVE_FILTERS_BUILTIN",
@@ -1743,6 +1744,7 @@
 					"-DHAVE_COCOA_METAL",
 					"-DHAVE_CONFIGFILE",
 					"-DHAVE_COREAUDIO",
+					"-DHAVE_COREMOTION",
 					"-DHAVE_DSP_FILTER",
 					"-DHAVE_DYNAMIC",
 					"-DHAVE_FILTERS_BUILTIN",
@@ -2197,9 +2199,9 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
-					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
+				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/iOS/modules";
 				MARKETING_VERSION = 1.15.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -2267,9 +2269,9 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
-					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
+				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/iOS/modules";
 				MARKETING_VERSION = 1.15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;

--- a/ui/drivers/cocoa/cocoa_common.m
+++ b/ui/drivers/cocoa/cocoa_common.m
@@ -135,8 +135,9 @@ void *glkitview_init(void);
         return !controllers[0].extendedGamepad;
 
     // are these presses that controllers send?
-    if (type == UIPressTypePageUp || type == UIPressTypePageDown)
-        return true;
+    if (@available(tvOS 14.3, *))
+        if (type == UIPressTypePageUp || type == UIPressTypePageDown)
+            return true;
 
     bool microPress = false;
     bool extendedPress = false;
@@ -844,16 +845,20 @@ bool cocoa_get_metrics(
 }
 #endif
 
-config_file_t *open_userdefaults_config_file()
+config_file_t *open_userdefaults_config_file(void)
 {
    config_file_t *conf = NULL;
    NSString *backup = [NSUserDefaults.standardUserDefaults stringForKey:@FILE_PATH_MAIN_CONFIG];
    if ([backup length] >= 0)
-      conf = config_file_new_from_string([backup cStringUsingEncoding:NSUTF8StringEncoding], path_get(RARCH_PATH_CONFIG));
+   {
+      char *str = strdup(backup.UTF8String);
+      conf = config_file_new_from_string(str, path_get(RARCH_PATH_CONFIG));
+      free(str);
+   }
    return conf;
 }
 
-void write_userdefaults_config_file()
+void write_userdefaults_config_file(void)
 {
    NSString *conf = [NSString stringWithContentsOfFile:[NSString stringWithUTF8String:path_get(RARCH_PATH_CONFIG)]
                                               encoding:NSUTF8StringEncoding

--- a/ui/drivers/ui_cocoatouch.m
+++ b/ui/drivers/ui_cocoatouch.m
@@ -73,7 +73,7 @@ static void rarch_draw_observer(CFRunLoopObserverRef observer,
       CFRunLoopWakeUp(CFRunLoopGetMain());
 }
 
-void rarch_start_draw_observer()
+void rarch_start_draw_observer(void)
 {
    if (iterate_observer && CFRunLoopObserverIsValid(iterate_observer))
        return;
@@ -85,7 +85,7 @@ void rarch_start_draw_observer()
    CFRunLoopAddObserver(CFRunLoopGetMain(), iterate_observer, kCFRunLoopCommonModes);
 }
 
-void rarch_stop_draw_observer()
+void rarch_stop_draw_observer(void)
 {
     if (!iterate_observer || !CFRunLoopObserverIsValid(iterate_observer))
         return;


### PR DESCRIPTION
This is a little awkward because sensors can come either from mFI controllers or from CoreMotion, so cocoa_input ends up checking both. This means that mFI controllers that support those sensors likely work "for free" on Mac and tvOS (including the Siri Remote).

Also fixed a few warnings.