### PR TITLE
Allow RETRO_ENVIRONMENT_SET_MEMORY_MAPS also after core startup

### DIFF
--- a/cheat_manager.c
+++ b/cheat_manager.c
@@ -933,12 +933,12 @@ int cheat_manager_initialize_memory(rarch_setting_t *setting, size_t idx, bool w
          offset += cheat_st->memory_size_list[i];
       }
 
+      runloop_msg_queue_push(msg_hash_to_str(MSG_CHEAT_INIT_SUCCESS), 1, 180, true, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
+
       cheat_st->memory_search_initialized = true;
    }
 
    cheat_st->memory_initialized = true;
-
-   runloop_msg_queue_push(msg_hash_to_str(MSG_CHEAT_INIT_SUCCESS), 1, 180, true, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
 
 #ifdef HAVE_MENU
    if (!wraparound)
@@ -1028,7 +1028,7 @@ static int cheat_manager_search(enum cheat_search_type search_type)
    struct menu_state *menu_st  = menu_state_get_ptr();
 #endif
 
-   if (cheat_st->num_memory_buffers == 0)
+   if (cheat_st->num_memory_buffers == 0 || prev == NULL || cheat_st->matches == NULL)
    {
       runloop_msg_queue_push(msg_hash_to_str(MSG_CHEAT_SEARCH_NOT_INITIALIZED), 1, 180, true, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
       return 0;

--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -746,7 +746,8 @@ void rcheevos_reset_game(bool widgets_ready)
 
 void rcheevos_refresh_memory()
 {
-   rcheevos_init_memory(&rcheevos_locals);
+   if (rcheevos_locals.memory.total_size > 0)
+      rcheevos_init_memory(&rcheevos_locals);
 }
 
 bool rcheevos_hardcore_active(void)

--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -744,6 +744,11 @@ void rcheevos_reset_game(bool widgets_ready)
       rcheevos_init_memory(&rcheevos_locals);
 }
 
+void rcheevos_refresh_memory()
+{
+   rcheevos_init_memory(&rcheevos_locals);
+}
+
 bool rcheevos_hardcore_active(void)
 {
    return rcheevos_locals.hardcore_active;

--- a/cheevos/cheevos.h
+++ b/cheevos/cheevos.h
@@ -37,6 +37,7 @@ bool rcheevos_unload(void);
 void rcheevos_test(void);
 
 void rcheevos_reset_game(bool widgets_ready);
+void rcheevos_refresh_memory();
 
 void rcheevos_pause_hardcore(void);
 void rcheevos_hardcore_enabled_changed(void);

--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -928,8 +928,6 @@ enum retro_mod
                                             * anything else.
                                             * It is recommended to expose all relevant pointers through
                                             * retro_get_memory_* as well.
-                                            *
-                                            * Can be called from retro_init and retro_load_game.
                                             */
 #define RETRO_ENVIRONMENT_SET_GEOMETRY 37
                                            /* const struct retro_game_geometry * --

--- a/runloop.c
+++ b/runloop.c
@@ -2832,6 +2832,17 @@ bool runloop_environment_cb(unsigned cmd, void *data)
 
             mmap_preprocess_descriptors(descriptors, mmaps->num_descriptors);
 
+#ifdef HAVE_CHEEVOS
+            rcheevos_refresh_memory();
+#endif
+#ifdef HAVE_CHEATS
+            if (cheat_manager_state.memory_initialized)
+            {
+               cheat_manager_initialize_memory(NULL, 0, true);
+               cheat_manager_apply_retro_cheats();
+            }
+#endif
+
             if (log_level != RETRO_LOG_DEBUG)
                break;
 


### PR DESCRIPTION
## Description
As of now RetroArch parses the passed data from `RETRO_ENVIRONMENT_SET_MEMORY_MAPS` after starting up the core (after `retro_init` and `retro_load_game`) and then if the core were to call that same environment call again during `retro_run` it would ignore the passed data.

This fits libretro.h which includes this comment:
```
Can be called from retro_init and retro_load_game.
```

This PR removes that comment and changes RetroArch so it can receive changes in the memory maps at any time when the core is running. 

While this PR modifies libretro.h, this is NOT an API/ABI change. All that is being changed is a comment.

If this PR is merged, my DOS emulator core can be improved to provide more stable memory addresses to RetroArch's cheat manager by placing the memory of a running DOS game at a fixed memory address. It also avoids a possible crash when using the cheat system with dosbox-pure because rebooting the emulated DOS computer causes the emulated RAM to be reallocated. With this fix RetroArch will use the new pointers instead of keeping the old ones that have been freed.

Another libretro frontend "RALibretro" already supports calling `RETRO_ENVIRONMENT_SET_MEMORY_MAPS` at any time so this will make RetroArch match that.

Change the comment in libretro.h about the removed limit and handle the environment call during core runtime in RetroArch.

## Related Pull Requests
- #2986
- #734

## Reviewers
It seems like in the past @Jamiras and @leiradel have been involved with handling the core's memory maps in RetroArch so I'd greatly appreciate their review or them voicing any feedback or concerns. Thanks.