### PR TITLE
Fix NULL related crash on CRT Switchres code

### DIFF
--- a/gfx/video_crt_switch.c
+++ b/gfx/video_crt_switch.c
@@ -144,7 +144,7 @@ static bool is_kms_driver_context()
    gfx_ctx_ident_t gfxctx;
    video_context_driver_get_ident(&gfxctx);
    RARCH_LOG("[CRT] Video context is: %s\n", gfxctx.ident);
-   if (strncmp(gfxctx.ident, "kms",3) == 0)
+   if (gfxctx.ident !=NULL && strncmp(gfxctx.ident, "kms",3) == 0)
       return true;
    return false;
 }


### PR DESCRIPTION
## Description

The variable for Video Context `gfxctx.ident` returns `NULL` on Windows but there's no check for this when comparing its value


## Related Issues

#15298 possibly

## Related Pull Requests

#15131 

## Reviewers

[If possible @mention all the people that should review your pull request]
