### PR TITLE
Support screen refresh rate in Vulkan KHR_Display context

### DIFF
--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -2078,6 +2078,7 @@ static bool vulkan_update_display_mode(
 {
    unsigned visible_width  = mode->parameters.visibleRegion.width;
    unsigned visible_height = mode->parameters.visibleRegion.height;
+   unsigned visible_rate   = mode->parameters.refreshRate;
 
    if (!info->width || !info->height)
    {
@@ -2095,13 +2096,14 @@ static bool vulkan_update_display_mode(
       /* For particular resolutions, find the closest. */
       int delta_x     = (int)info->width - (int)visible_width;
       int delta_y     = (int)info->height - (int)visible_height;
+      int delta_rate  = abs(info->refresh_rate_x1000 - visible_rate);
       int old_delta_x = (int)info->width - (int)*width;
       int old_delta_y = (int)info->height - (int)*height;
 
       int dist        = delta_x * delta_x + delta_y * delta_y;
       int old_dist    = old_delta_x * old_delta_x + old_delta_y * old_delta_y;
 
-      if (dist < old_dist)
+      if (dist < old_dist && delta_rate < 1000)
       {
          *width       = visible_width;
          *height      = visible_height;

--- a/gfx/common/vulkan_common.h
+++ b/gfx/common/vulkan_common.h
@@ -216,6 +216,7 @@ struct vulkan_display_surface_info
    unsigned width;
    unsigned height;
    unsigned monitor_index;
+   unsigned refresh_rate_x1000;
 };
 
 struct vk_color

--- a/gfx/drivers_context/khr_display_ctx.c
+++ b/gfx/drivers_context/khr_display_ctx.c
@@ -32,6 +32,7 @@ typedef struct
    int swap_interval;
    unsigned width;
    unsigned height;
+   unsigned refresh_rate_x1000;
 } khr_display_ctx_data_t;
 
 static void gfx_ctx_khr_display_destroy(void *data)
@@ -55,6 +56,20 @@ static void gfx_ctx_khr_display_get_video_size(void *data,
    *width                      = khr->width;
    *height                     = khr->height;
 }
+
+static float gfx_ctx_khr_display_get_refresh_rate(void *data)
+{
+   float refresh_rate = 0.0f;
+   khr_display_ctx_data_t *khr = (khr_display_ctx_data_t*)data;
+
+   if (khr)
+   {
+      refresh_rate = khr->refresh_rate_x1000 / 1000.0f;
+   }
+
+   return refresh_rate;
+}
+
 
 static void *gfx_ctx_khr_display_init(void *video_driver)
 {
@@ -126,6 +141,7 @@ static bool gfx_ctx_khr_display_set_video_mode(void *data,
    khr_display_ctx_data_t *khr    = (khr_display_ctx_data_t*)data;
    settings_t *settings           = config_get_ptr();
    unsigned video_monitor_index   = settings->uints.video_monitor_index;
+   unsigned refresh_rate_x1000    = settings->floats.video_refresh_rate * 1000;
 
    if (!fullscreen)
    {
@@ -136,6 +152,7 @@ static bool gfx_ctx_khr_display_set_video_mode(void *data,
    info.width                     = width;
    info.height                    = height;
    info.monitor_index             = video_monitor_index;
+   info.refresh_rate_x1000        = refresh_rate_x1000;
 
    if (!vulkan_surface_create(&khr->vk, VULKAN_WSI_DISPLAY, &info, NULL,
             0, 0, khr->swap_interval))
@@ -147,6 +164,7 @@ static bool gfx_ctx_khr_display_set_video_mode(void *data,
 
    khr->width                     = khr->vk.context.swapchain_width;
    khr->height                    = khr->vk.context.swapchain_height;
+   khr->refresh_rate_x1000        = info.refresh_rate_x1000;
 
    return true;
 }
@@ -262,7 +280,7 @@ const gfx_ctx_driver_t gfx_ctx_khr_display = {
    gfx_ctx_khr_display_set_swap_interval,
    gfx_ctx_khr_display_set_video_mode,
    gfx_ctx_khr_display_get_video_size,
-   NULL,                                        /* get_refresh_rate */
+   gfx_ctx_khr_display_get_refresh_rate,
    NULL,                                        /* get_video_output_size */
    NULL,                                        /* get_video_output_prev */
    NULL,                                        /* get_video_output_next */


### PR DESCRIPTION
## Description

The Vulkan khr_display context driver (the one used in Linux without windowing environment, like KMS mode for GL drivers) did not consider refresh rate so far. This PR adds minimal capabilities: refresh rate shown in Video/Output menu, and if refresh rate is set in retroarch.cfg to a specific value, mode selection will follow.

Tested on RPi 4 with Ubuntu Server (to get newer Mesa with the updated VC4 driver that is not present in RPi OS yet).

## Related Issues

Final goal would be to implement a display server adding resolution selection / automatic refresh rate switch, which sort of works already, but it exhibits some validation errors when switching modes, fixing those may be a longer task.
