### PR TITLE
[Wayland+GL] Add frame callback after egl_swap_buffers() to improve latency when max_swapchain<=2

### DIFF
--- a/gfx/drivers_context/wayland_ctx.c
+++ b/gfx/drivers_context/wayland_ctx.c
@@ -528,38 +528,44 @@ static void gfx_ctx_wl_swap_buffers(void *data)
 
    settings_t *settings           = config_get_ptr();
    unsigned max_swapchain_images  = settings->uints.video_max_swapchain_images;
+   struct wl_callback *cb; 
 
-   struct wl_callback *cb = wl_surface_frame(wl->surface);
-
-   if (max_swapchain_images <= 2) {
+   if (max_swapchain_images <= 2)
+   {
       /* Set Wayland frame callback. */
+      cb = wl_surface_frame(wl->surface);
       wl_callback_add_listener(cb, &wl_surface_frame_listener, wl);
    }
 
    egl_swap_buffers(&wl->egl);
 
-   if (max_swapchain_images <= 2) {
+   if (max_swapchain_images <= 2)
+   {
       /* Wait for the frame callback we set earlier. */
       struct pollfd pollfd = {.fd = wl->input.fd, .events = POLLIN};
       uint64_t deadline = cpu_features_get_time_usec() + 50000;
       wl->swap_complete = false;
 
-      while (!wl->swap_complete) {
+      while (!wl->swap_complete)
+      {
          uint64_t current_time = cpu_features_get_time_usec();
-         if (current_time >= deadline) {
+         if (current_time >= deadline)
+         {
             /* Deadline met. */
             wl_callback_destroy(cb);
             return;
          }
          uint64_t remaining_time = deadline - current_time;
          int ret = (wl_display_dispatch_pending(wl->input.dpy));
-         if (ret == 0) {
+         if (ret == 0)
+         {
             ret = wl_display_prepare_read(wl->input.dpy);
             if (ret == -1)
                continue; /* Retry dispatch_pending. */
 
             ret = poll(&pollfd, 1, remaining_time / 1000);
-            if (ret <= 0) {
+            if (ret <= 0)
+            {
                /* Timeout met, or polling error. */
                wl_display_cancel_read(wl->input.dpy);
                wl_callback_destroy(cb);

--- a/input/common/wayland_common.h
+++ b/input/common/wayland_common.h
@@ -211,6 +211,7 @@ typedef struct gfx_ctx_wayland_data
    bool configured;
    bool activated;
    bool reported_display_size;
+   bool swap_complete;
 } gfx_ctx_wayland_data_t;
 
 #ifdef HAVE_XKBCOMMON


### PR DESCRIPTION

## Description

This adds a frame callback after the egl_swap_buffers() when max_swapchain<=2, thus waiting until the new frame is effectively on screen. That way, there's a frame less of input lag.
There's a noticeable performance penalty with 3D-accelerated cores, which is expected since CPU has to wait for GPU to complete operations before emulating the next frame: that's always the case with a double-buffer scheme.

This is important for hardware that has GL support on GNU/Linux on Wayland but sadly not Vulkan support (Vulkan offers way better ways to control the buffer chain, but for GL on Wayland, this is a good latency improvement).

## Reviewers

@Themaister has greatly helped me with this (along with other very nice people on the IRC #wayland channel in irc.oftc.net), and has offered to review this.
Thanks, everyone who helped me with my sometimes annoying questions and locks!