### PR TITLE
Revert "(Wayland) Remove splash screen (#15178)"

### DIFF
--- a/gfx/common/wayland_common.h
+++ b/gfx/common/wayland_common.h
@@ -68,6 +68,9 @@ bool gfx_ctx_wl_init_common(
 bool gfx_ctx_wl_set_video_mode_common_size(gfx_ctx_wayland_data_t *wl,
       unsigned width, unsigned height, bool fullscreen);
 
+bool gfx_ctx_wl_set_video_mode_common_fullscreen(gfx_ctx_wayland_data_t *wl,
+      bool fullscreen);
+
 bool gfx_ctx_wl_suppress_screensaver(void *data, bool state);
 
 bool gfx_ctx_wl_set_video_mode_common(gfx_ctx_wayland_data_t *wl,

--- a/gfx/drivers_context/wayland_ctx.c
+++ b/gfx/drivers_context/wayland_ctx.c
@@ -420,6 +420,9 @@ static bool gfx_ctx_wl_set_video_mode(void *data,
    egl_set_swap_interval(&wl->egl, wl->egl.interval);
 #endif
 
+   if (!gfx_ctx_wl_set_video_mode_common_fullscreen(wl, fullscreen))
+      goto error;
+
    return true;
 
 error:

--- a/gfx/drivers_context/wayland_vk_ctx.c
+++ b/gfx/drivers_context/wayland_vk_ctx.c
@@ -210,6 +210,9 @@ static bool gfx_ctx_wl_set_video_mode(void *data,
          wl->swap_interval))
       goto error;
 
+   if (!gfx_ctx_wl_set_video_mode_common_fullscreen(wl, fullscreen))
+      goto error;
+
    return true;
 
 error:

--- a/input/common/wayland_common.h
+++ b/input/common/wayland_common.h
@@ -205,7 +205,6 @@ typedef struct gfx_ctx_wayland_data
 
    bool core_hw_context_enable;
    bool fullscreen;
-   bool pending_fullscreen;
    bool maximized;
    bool resize;
    bool configured;


### PR DESCRIPTION
This reverts commit f19def349f79a20355a2466006486222fb2ea2a1.

The splash screen allows the initial call to `gfx_ctx_wl_get_video_size_common` to return the size of the display that the window (splash screen) is currently on.

Fixes: #15333

## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

[Description of the pull request, detail any issues you are fixing or any features you are implementing]

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
