### PR TITLE
Improve scanner console output

### DIFF
--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -804,9 +804,30 @@ static int database_info_list_iterate_found_match(
       entry.last_played_second= 0;
 
       playlist_push(playlist, &entry);
-      RARCH_LOG("[Scanner]: Add \"%s\"\n", entry_label);
+      RARCH_LOG("[Scanner]: Add \"%s\" to \"%s\"\n", entry_label, entry.db_name);
       if (retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_DATABASE_SCAN, NULL))
-         printf("Add \"%s\"\n", entry.label);
+      {
+         const char* no_color = getenv("NO_COLOR");
+         bool color           = (no_color && no_color[0] != '0') ? false : true;
+
+         /* Colorize " Add " prefix with green. */
+#ifdef _WIN32
+         HANDLE con = GetStdHandle(STD_OUTPUT_HANDLE);
+         if (color && con != INVALID_HANDLE_VALUE)
+         {
+            SetConsoleTextAttribute(con, 2);
+            WriteConsole(con, " Add ", 5, NULL, NULL);
+            SetConsoleTextAttribute(con, 7);
+         }
+#else
+         if (color)
+            fputs("\x1B[32m Add \x1B[0m", stdout);
+#endif
+         else
+            fputs(" Add ", stdout);
+
+         printf("\"%s\" to \"%s\"\n", entry.label, entry.db_name);
+      }
    }
 
    playlist_write_file(playlist);


### PR DESCRIPTION
## Description

Just a tiny bit better readability to the console output by adding the target playlist, adding a space in the beginning, and coloring `Add` green. Are there cases where these won't work or are not enough? Windows coloring works both in native command prompt and in msys2 bash, and ANSI method works only in bash.


```
# ra-dev --scan s:\emu\amiga\lha\y
Scanning content: "s:\emu\amiga\lha\y"..
1/5: YogisBigCleanUp_v1.01_2171.lha..
 Add "Yogi's Big Clean Up (Europe)" to "Commodore - Amiga.lpl"
2/5: YogisGreatEscape_v1.1_1355.lha..
 Add "Yogi's Great Escape (Europe)" to "Commodore - Amiga.lpl"
3/5: YoJoe_v1.0_0750.lha..
 Add "Yo! Joe! (Europe)" to "Commodore - Amiga.lpl"
4/5: Yolanda_v1.0a_Files.lha..
 Add "Yolanda (Europe)" to "Commodore - Amiga.lpl"
5/5: YogiBear&Friends_v1.0.lha..
 Add "Yogi Bear & Friends in the Greed Monster (Europe)" to "Commodore - Amiga.lpl"
Scanning of directory finished
```

![image](https://github.com/libretro/RetroArch/assets/45124675/f71431d6-89e7-44d4-aeeb-c456a8aa50a0)
