### PR TITLE
Don't send mouse click events when pressing overlay buttons

### DIFF
--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -742,7 +742,12 @@ static INLINE void android_input_poll_event_type_motion(
          /* If touchscreen was pressed for less than 200ms
           * then register time stamp of a quick tap */
          if ((AMotionEvent_getEventTime(event)-AMotionEvent_getDownTime(event))/1000000 < 200)
-            android->quick_tap_time = AMotionEvent_getEventTime(event);
+         {
+            /* Prevent the quick tap if a button on the overlay is down */
+            input_driver_state_t *input_st = input_state_get_ptr();
+            if (!(input_st->flags & INP_FLAG_BLOCK_POINTER_INPUT))
+               android->quick_tap_time = AMotionEvent_getEventTime(event);
+         }
          android->mouse_l = 0;
       }
 


### PR DESCRIPTION
## Description
In general RetroArch does not send mouse click events to the core while pressing a button on the on-screen overlay. During the press `INP_FLAG_BLOCK_POINTER_INPUT` is set and then in `input_state_device` all events for `RETRO_DEVICE_MOUSE`, `RETRO_DEVICE_LIGHTGUN` and `RETRO_DEVICE_POINTER` are not forwarded to the core.

There is one exception on Android which has a function for a so called "quick tap". As far as I can tell this is exclusive to the android input driver. It works by detecting a touch screen tap that lasts for less than 200 ms, then 200 ms after releasing the finger from the touch screen it generates a left mouse click event.

Because that fake mouse click event is generated after the finger has already been released the aforementioned `INP_FLAG_BLOCK_POINTER_INPUT` is now also not active anymore and thus a fake click event is forwarded to the core even if the user just pressed on an overlay button.

This PR prevents the android quick tap mouse click emulation while pressing a button on the on-screen overlay.

With this DOSBox Pure works much better because its startup menu is able to handle both mouse and retropad inputs. Up until this PR on Android the menu was basically unusable because pressing on the on-screen overlay pad caused mouse clicks to select items in the menu.

## Related Pull Requests
- #4640

## Reviewers
It looks like the function was added in #4640 by @diablodiab not sure if they're still around though :-)