### PR TITLE
macOS Cocoa: fix mouse grab in windowed mode

### DIFF
--- a/input/drivers/cocoa_input.h
+++ b/input/drivers/cocoa_input.h
@@ -52,6 +52,7 @@ typedef struct
    int16_t mouse_wd;
    int16_t mouse_wl;
    int16_t mouse_wr;
+   bool mouse_grabbed;
 } cocoa_input_data_t;
 
 #endif

--- a/input/drivers/cocoa_input.m
+++ b/input/drivers/cocoa_input.m
@@ -745,6 +745,23 @@ static void cocoa_input_keypress_vibrate()
 }
 #endif
 
+static void cocoa_input_grab_mouse(void *data, bool state)
+{
+   cocoa_input_data_t *apple = (cocoa_input_data_t*)data;
+
+   if (state) {
+      NSWindow *window = (BRIDGE NSWindow*)ui_companion_cocoa.get_main_window(nil);
+      CGPoint window_pos = window.frame.origin;
+      CGSize window_size = window.frame.size;
+      CGPoint window_center = CGPointMake(window_pos.x + window_size.width / 2.0f, window_pos.y + window_size.height / 2.0f);
+      CGWarpMouseCursorPosition(window_center);
+   }
+
+   CGAssociateMouseAndMouseCursorPosition(!state);
+   cocoa_show_mouse(nil, !state);
+   apple->mouse_grabbed = state;
+}
+
 input_driver_t input_cocoa = {
    cocoa_input_init,
    cocoa_input_poll,
@@ -754,7 +771,7 @@ input_driver_t input_cocoa = {
    cocoa_input_get_sensor_input,
    cocoa_input_get_capabilities,
    "cocoa",
-   NULL,                         /* grab_mouse */
+   cocoa_input_grab_mouse,
    NULL,                         /* grab_stdin */
 #if TARGET_OS_IOS
    cocoa_input_keypress_vibrate

--- a/pkg/apple/RetroArch_Metal.xcodeproj/project.pbxproj
+++ b/pkg/apple/RetroArch_Metal.xcodeproj/project.pbxproj
@@ -454,7 +454,6 @@
 		05C5D53320E3DD0900654EE4 /* input_types.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = input_types.h; sourceTree = "<group>"; };
 		05C5D53820E3DD0900654EE4 /* cocoa_input.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = cocoa_input.h; sourceTree = "<group>"; };
 		05C5D54120E3DD0900654EE4 /* sdl_input.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = sdl_input.c; sourceTree = "<group>"; };
-		05C5D54220E3DD0900654EE4 /* cocoa_input.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = cocoa_input.c; sourceTree = "<group>"; };
 		05C5D54C20E3DD0900654EE4 /* input_keymaps.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = input_keymaps.h; sourceTree = "<group>"; };
 		05C5D54E20E3DD0900654EE4 /* blissbox.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = blissbox.h; sourceTree = "<group>"; };
 		05C5D55420E3DD0900654EE4 /* GCExtendedGamepadSnapshot.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GCExtendedGamepadSnapshot.h; sourceTree = "<group>"; };
@@ -554,6 +553,7 @@
 		A9020FA64527ED74C836B41D /* cocoa_gl_ctx_metal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = cocoa_gl_ctx_metal.m; sourceTree = "<group>"; };
 		D27C50872228360000113BC0 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		D27C50892228360D00113BC0 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
+		E8EE1E942A2C6A26003C73F6 /* cocoa_input.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = cocoa_input.m; sourceTree = "<group>"; };
 		F0B1238F270D73A90006E60F /* connect */ = {isa = PBXFileReference; lastKnownFileType = folder; path = connect; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -838,7 +838,6 @@
 			isa = PBXGroup;
 			children = (
 				05A8C55E20DB72F000FF7857 /* menu_osk_utf8_pages.h */,
-				05A8C55F20DB72F000FF7857 /* menu_osk.h */,
 			);
 			path = widgets;
 			sourceTree = "<group>";
@@ -1240,7 +1239,7 @@
 		05C5D53520E3DD0900654EE4 /* drivers */ = {
 			isa = PBXGroup;
 			children = (
-				05C5D54220E3DD0900654EE4 /* cocoa_input.c */,
+				E8EE1E942A2C6A26003C73F6 /* cocoa_input.m */,
 				05C5D53820E3DD0900654EE4 /* cocoa_input.h */,
 				05C5D54120E3DD0900654EE4 /* sdl_input.c */,
 			);

--- a/ui/drivers/ui_cocoa.m
+++ b/ui/drivers/ui_cocoa.m
@@ -467,8 +467,14 @@ static ui_application_t ui_application_cocoa = {
             /* Absolute */
             apple->touches[0].screen_x  = (int16_t)pos.x;
             apple->touches[0].screen_y  = (int16_t)pos.y;
-            apple->window_pos_x         = (int16_t)pos.x;
-            apple->window_pos_y         = (int16_t)pos.y;
+
+            if (apple->mouse_grabbed) {
+               apple->window_pos_x      += (int16_t)delta_x;
+               apple->window_pos_y      += (int16_t)delta_y;
+            } else {
+               apple->window_pos_x       = (int16_t)pos.x;
+               apple->window_pos_y       = (int16_t)pos.y;
+            }
          }
          break;
 #if defined(HAVE_COCOA_METAL)


### PR DESCRIPTION
macOS Cocoa: fix mouse grab in windowed mode. Tested on Quake II.