### PR TITLE
Add CI Android build github action

### DIFF
--- a/.github/workflows/Android.yml
+++ b/.github/workflows/Android.yml
@@ -1,0 +1,34 @@
+name: CI Android
+
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [run_build]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Compile RA
+      run: |
+        cd pkg/android/phoenix
+        ./gradlew assembleDebug
+        find . -iname "*.apk" -exec ls -l "{}" \;
+
+    - name: Get short SHA
+      id: slug
+      run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
+    
+    - uses: actions/upload-artifact@v3
+      with:
+        name: retroarch-android-${{ steps.slug.outputs.sha8 }}
+        path: |
+          pkg/android/phoenix/build/outputs/apk/normal/debug/phoenix-normal-debug.apk
+          pkg/android/phoenix/build/outputs/apk/aarch64/debug/phoenix-aarch64-debug.apk


### PR DESCRIPTION
## Description

This PR adds a CI Android build github action.

It builds with `gradlew assembleDebug` which produces the following APKs:
- pkg/android/phoenix/build/outputs/apk/normal/debug/phoenix-normal-debug.apk (now 31 MB)
- pkg/android/phoenix/build/outputs/apk/aarch64/debug/phoenix-aarch64-debug.apk (now 15 MB)
- pkg/android/phoenix/build/outputs/apk/ra32/debug/phoenix-ra32-debug.apk (now 15 MB)
- pkg/android/phoenix/build/outputs/apk/playStoreNormal/debug/phoenix-playStoreNormal-debug.apk (now 31 MB)
- pkg/android/phoenix/build/outputs/apk/playStorePlus/debug/phoenix-playStorePlus-debug.apk (now 31 MB)

It then uploads artifacts of `phoenix-normal-debug.apk` and `phoenix-aarch64-debug.apk` (not the rest).

To make the build faster it would be nice if it would only build the `normal` (and maybe the `aarch64` or `ra32`) variant but I couldn't figure out how to do that.

On my repo the build took 11.5 minutes which is longer than any of the other CI builds (libnx took 10 min, others between 3 and 8 min). But maybe the build times vary.