### PR TITLE
Introduce RETRO_DEPRECATED macro

### DIFF
--- a/libretro-common/include/retro_common_api.h
+++ b/libretro-common/include/retro_common_api.h
@@ -101,6 +101,26 @@ typedef int ssize_t;
 #define STRING_REP_UINT64 "%" PRIu64
 #define STRING_REP_USIZE "%" PRIuPTR
 
+/* Wrap a declaration in RETRO_DEPRECATED() to produce a compiler warning when
+it's used. This is intended for developer machines, so it won't work on ancient
+or obscure compilers */
+#if defined(_MSC_VER)
+#if _MSC_VER >= 1400 /* Visual C 2005 or later */
+#define RETRO_DEPRECATED(decl) __declspec(deprecated) decl
+#endif
+#elif defined(__GNUC__)
+#if __GNUC__ >= 3 /* GCC 3 or later */
+#define RETRO_DEPRECATED(decl) decl __attribute__((deprecated))
+#endif
+#elif defined(__clang__)
+#if __clang_major__ >= 3 /* clang 3 or later */
+#define RETRO_DEPRECATED(decl) decl __attribute__((deprecated))
+#endif
+#endif
+#ifndef RETRO_DEPRECATED /* Unsupported compilers */
+#define RETRO_DEPRECATED(decl) decl
+#endif
+
 /*
 I would like to see retro_inline.h moved in here; possibly boolean too.
 


### PR DESCRIPTION
## Description
This PR introduces a RETRO_DEPRECATED macro to retro_common_api.h to produce deprecation warnings during build on supported compilers, so that some unfortunate older APIs in libretro-common could be gradually phased out. You can see how it works with various compilers in [this godbolt](https://godbolt.org/z/G8Eaf6Wa9).