### PR TITLE
Have sdl2 gfx driver use "nearest" scaling in menus

### DIFF
--- a/gfx/drivers/sdl2_gfx.c
+++ b/gfx/drivers/sdl2_gfx.c
@@ -301,7 +301,7 @@ static void sdl_refresh_input_size(sdl2_video_t *vid, bool menu, bool rgb32,
          format = rgb32 ? SDL_PIXELFORMAT_ARGB8888 : SDL_PIXELFORMAT_RGB565;
 
       SDL_SetHintWithPriority(SDL_HINT_RENDER_SCALE_QUALITY,
-                              (vid->video.smooth || menu) ? "linear" : "nearest",
+                              (menu ? "nearest" : (vid->video.smooth ? "linear" : "nearest")),
                               SDL_HINT_OVERRIDE);
 
       target->tex = SDL_CreateTexture(vid->renderer, format,


### PR DESCRIPTION
## Description
The rgui menu is blurry when using the sdl2 gfx driver: this is because the sdl2 driver uses bilinear texture filtering while others use nearest neighbor. This PR reverts it to nearest neighbor filtering, making the menu crisp. The content is unaffected and is still controlled by the Bilinear Filtering setting in the Video menu.