### PR TITLE
Add files generated for wayland to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,6 +211,8 @@ gfx/common/wayland/pointer-constraints-unstable-v1.c
 gfx/common/wayland/pointer-constraints-unstable-v1.h
 gfx/common/wayland/relative-pointer-unstable-v1.c
 gfx/common/wayland/relative-pointer-unstable-v1.h
+gfx/common/wayland/viewporter.c
+gfx/common/wayland/viewporter.h
 
 # libretro-common samples
 libretro-common/samples/streams/rzip/rzip


### PR DESCRIPTION
## Description
#15176 introduced two new auto-generated files. This PR adds them to .gitignore so they won't get in the way.