### PR TITLE
Linux input driver fix 8+ joypads

### DIFF
--- a/input/drivers_joypad/dinput_joypad_inl.h
+++ b/input/drivers_joypad/dinput_joypad_inl.h
@@ -273,7 +273,7 @@ static int16_t dinput_joypad_state(
 
    if (!pad || !pad->joypad)
       return 0;
-   if (port_idx >= DEFAULT_MAX_PADS)
+   if (port_idx >= MAX_USERS)
       return 0;
 
    for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)

--- a/input/drivers_joypad/linuxraw_joypad.c
+++ b/input/drivers_joypad/linuxraw_joypad.c
@@ -298,7 +298,7 @@ static int32_t linuxraw_joypad_button(unsigned port, uint16_t joykey)
 {
    const struct linuxraw_joypad    *pad = (const struct linuxraw_joypad*)
       &linuxraw_pads[port];
-   if (port >= DEFAULT_MAX_PADS)
+   if (port >= MAX_USERS)
       return 0;
    if (joykey < NUM_BUTTONS)
       return (BIT32_GET(pad->buttons, joykey));
@@ -356,7 +356,7 @@ static int16_t linuxraw_joypad_state(
    const struct linuxraw_joypad    *pad = (const struct linuxraw_joypad*)
       &linuxraw_pads[port_idx];
 
-   if (port_idx >= DEFAULT_MAX_PADS)
+   if (port_idx >= MAX_USERS)
       return 0;
 
    for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)

--- a/input/drivers_joypad/sdl_joypad.c
+++ b/input/drivers_joypad/sdl_joypad.c
@@ -374,7 +374,7 @@ static int32_t sdl_joypad_button(unsigned port, uint16_t joykey)
    sdl_joypad_t *pad                    = (sdl_joypad_t*)&sdl_pads[port];
    if (!pad || !pad->joypad)
       return 0;
-   if (port >= DEFAULT_MAX_PADS)
+   if (port >= MAX_USERS)
       return 0;
    return sdl_joypad_button_state(pad, port, joykey);
 }
@@ -424,7 +424,7 @@ static int16_t sdl_joypad_state(
 
    if (!pad || !pad->joypad)
       return 0;
-   if (port_idx >= DEFAULT_MAX_PADS)
+   if (port_idx >= MAX_USERS)
       return 0;
 
    for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)

--- a/input/drivers_joypad/udev_joypad.c
+++ b/input/drivers_joypad/udev_joypad.c
@@ -672,7 +672,7 @@ static int32_t udev_joypad_button(unsigned port, uint16_t joykey)
 {
    const struct udev_joypad *pad        = (const struct udev_joypad*)
       &udev_pads[port];
-   if (port >= DEFAULT_MAX_PADS)
+   if (port >= MAX_USERS)
       return 0;
    return udev_joypad_button_state(pad, port, joykey);
 }
@@ -736,7 +736,7 @@ static int16_t udev_joypad_state(
    int16_t ret                          = 0;
    uint16_t port_idx                    = joypad_info->joy_idx;
 
-   if (port_idx < DEFAULT_MAX_PADS)
+   if (port_idx < MAX_USERS)
    {
       unsigned i;
       const struct udev_joypad *pad     = (const struct udev_joypad*)

--- a/input/input_driver.h
+++ b/input/input_driver.h
@@ -80,7 +80,7 @@
 #define DEFAULT_MAX_PADS 4
 #elif defined(HAVE_ODROIDGO2)
 #define DEFAULT_MAX_PADS 8
-#elif defined(__linux__) || (defined(BSD) && !defined(__MACH__))
+#elif (defined(BSD) && !defined(__MACH__))
 #define DEFAULT_MAX_PADS 8
 #elif defined(__QNX__)
 #define DEFAULT_MAX_PADS 8


### PR DESCRIPTION
## Description

It was reported that controllers beyond 8 worked only partially (analogs yes, but not buttons), and the found fix was also confirmed.

Surely the define of 8 `DEFAULT_MAX_PADS` is too aggressive like that, and also the drivers in question (linuxraw, sdl, udev, and even dinput) used that value to limit getting button states even though the state variables have room for `MAX_USERS`, and `MAX_USERS` is used elsewhere for port limiting.