### PR TITLE
Fix trivial signedness warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ else
    DEF_FLAGS += -ffast-math
 endif
 
-DEF_FLAGS += -Wall
+DEF_FLAGS += -Wall -Wsign-compare
 
 ifneq ($(findstring BSD,$(OS)),)
    DEF_FLAGS += -DBSD

--- a/cheevos/cheevos_client.c
+++ b/cheevos/cheevos_client.c
@@ -1753,7 +1753,7 @@ static void rcheevos_async_award_achievement_callback(
    if (rcheevos_async_succeeded(result, &api_response.response,
             buffer, buffer_size))
    {
-      if (api_response.awarded_achievement_id != request->id)
+      if ((int)api_response.awarded_achievement_id != request->id)
          snprintf(buffer, buffer_size, "Achievement %u awarded instead",
                api_response.awarded_achievement_id);
       else if (api_response.response.error_message)

--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -2685,7 +2685,7 @@ static bool frontend_unix_check_for_path_changes(path_change_data_t *change_data
    {
       i = 0;
 
-      while (i < length && i < sizeof(buffer))
+      while (i < length && i < (int)sizeof(buffer))
       {
          struct inotify_event *event = (struct inotify_event *)&buffer[i];
 
@@ -2702,7 +2702,7 @@ static bool frontend_unix_check_for_path_changes(path_change_data_t *change_data
              * to disk, to make sure that the new data is
              * immediately available when the file is re-read.
              */
-            for (j = 0; j < inotify_data->wd_list->count; j++)
+            for (j = 0; j < (int)inotify_data->wd_list->count; j++)
             {
                if (inotify_data->wd_list->data[j] == event->wd)
                {

--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -961,7 +961,7 @@ static bool vulkan_update_display_mode(
       /* For particular resolutions, find the closest. */
       int delta_x     = (int)info->width - (int)visible_width;
       int delta_y     = (int)info->height - (int)visible_height;
-      int delta_rate  = abs(info->refresh_rate_x1000 - visible_rate);
+      int delta_rate  = abs((int)info->refresh_rate_x1000 - (int)visible_rate);
       int old_delta_x = (int)info->width - (int)*width;
       int old_delta_y = (int)info->height - (int)*height;
 
@@ -2096,7 +2096,7 @@ bool vulkan_create_swapchain(gfx_ctx_vulkan_data_t *vk,
          format = formats[0];
    }
 
-   if (surface_properties.currentExtent.width == -1)
+   if (surface_properties.currentExtent.width == UINT32_MAX)
    {
       swapchain_size.width     = width;
       swapchain_size.height    = height;

--- a/gfx/common/wayland_common.c
+++ b/gfx/common/wayland_common.c
@@ -850,7 +850,7 @@ bool gfx_ctx_wl_set_video_mode_common_fullscreen(gfx_ctx_wayland_data_t *wl,
       {
          wl_list_for_each(od, &wl->all_outputs, link)
          {
-            if (++output_i == video_monitor_index)
+            if (++output_i == (int)video_monitor_index)
             {
                oi = od->output;
                output = oi->output;

--- a/gfx/common/x11_common.c
+++ b/gfx/common/x11_common.c
@@ -857,7 +857,7 @@ static bool x11_check_atom_supported(Display *dpy, Atom atom)
    if (!prop || type != XA_ATOM)
       return false;
 
-   for (i = 0; i < nitems; i++)
+   for (i = 0; i < (int)nitems; i++)
    {
       if (prop[i] == atom)
       {

--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -2327,7 +2327,7 @@ static void vulkan_init_pipelines(vk_t *vk)
    vkDestroyShaderModule(vk->context->device, shader_stages[0].module, NULL);
 
    /* Other menu pipelines. */
-   for (i = 0; i < ARRAY_SIZE(vk->display.pipelines) - 6; i++)
+   for (i = 0; i < (int)ARRAY_SIZE(vk->display.pipelines) - 6; i++)
    {
       switch (i >> 1)
       {
@@ -2612,7 +2612,7 @@ static void vulkan_deinit_pipelines(vk_t *vk)
          vk->pipelines.hdr, NULL);
 #endif /* VULKAN_HDR_SWAPCHAIN */
 
-   for (i = 0; i < ARRAY_SIZE(vk->display.pipelines); i++)
+   for (i = 0; i < (int)ARRAY_SIZE(vk->display.pipelines); i++)
       vkDestroyPipeline(vk->context->device,
             vk->display.pipelines[i], NULL);
 }

--- a/gfx/drivers_context/x_ctx.c
+++ b/gfx/drivers_context/x_ctx.c
@@ -814,7 +814,7 @@ static bool gfx_ctx_x_set_video_mode(void *data,
 
                         break;
                      }
-                     else if (versions[i][0] == g_major && versions[i][1] == g_minor)
+                     else if (versions[i][0] == (int)g_major && versions[i][1] == (int)g_minor)
                      {
                         /* The requested version was tried and is not supported, go ahead and fail since everything else will be lower than that. */
                         break;

--- a/gfx/drivers_shader/shader_gl3.cpp
+++ b/gfx/drivers_shader/shader_gl3.cpp
@@ -2136,7 +2136,7 @@ bool gl3_filter_chain::init_alias()
    common.texture_semantic_map.clear();
    common.texture_semantic_uniform_map.clear();
 
-   for (i = 0; i < passes.size(); i++)
+   for (i = 0; i < (int)passes.size(); i++)
    {
       unsigned j;
       const std::string name = passes[i]->get_name();
@@ -2165,7 +2165,7 @@ bool gl3_filter_chain::init_alias()
          return false;
    }
 
-   for (i = 0; i < common.luts.size(); i++)
+   for (i = 0; i < (int)common.luts.size(); i++)
    {
       unsigned j = (unsigned)(&common.luts[i] - common.luts.data());
       if (!slang_set_unique_map(common.texture_semantic_map,

--- a/gfx/drivers_shader/shader_vulkan.cpp
+++ b/gfx/drivers_shader/shader_vulkan.cpp
@@ -1442,7 +1442,7 @@ bool vulkan_filter_chain::init_alias()
    common.texture_semantic_map.clear();
    common.texture_semantic_uniform_map.clear();
 
-   for (i = 0; i < passes.size(); i++)
+   for (i = 0; i < (int)passes.size(); i++)
    {
       unsigned j;
       const std::string name = passes[i]->get_name();
@@ -1472,7 +1472,7 @@ bool vulkan_filter_chain::init_alias()
          return false;
    }
 
-   for (i = 0; i < common.luts.size(); i++)
+   for (i = 0; i < (int)common.luts.size(); i++)
    {
       unsigned j = (unsigned)(&common.luts[i] - common.luts.data());
       if (!slang_set_unique_map(

--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -543,7 +543,7 @@ void video_driver_set_gpu_api_devices(
 {
    int i;
 
-   for (i = 0; i < ARRAY_SIZE(gpu_map); i++)
+   for (i = 0; i < (int)ARRAY_SIZE(gpu_map); i++)
    {
       if (api == gpu_map[i].api)
       {
@@ -557,7 +557,7 @@ struct string_list* video_driver_get_gpu_api_devices(enum gfx_ctx_api api)
 {
    int i;
 
-   for (i = 0; i < ARRAY_SIZE(gpu_map); i++)
+   for (i = 0; i < (int)ARRAY_SIZE(gpu_map); i++)
    {
       if (api == gpu_map[i].api)
          return gpu_map[i].list;

--- a/gfx/video_shader_parse.c
+++ b/gfx/video_shader_parse.c
@@ -2782,7 +2782,7 @@ static bool video_shader_load_shader_preset_internal(
       RARCH_SHADER_GLSL, RARCH_SHADER_SLANG, RARCH_SHADER_CG, RARCH_SHADER_HLSL
    };
 
-   for (i = 0; i < ARRAY_SIZE(types); i++)
+   for (i = 0; i < (int)ARRAY_SIZE(types); i++)
    {
       if (!video_shader_is_supported(types[i]))
          continue;

--- a/gfx/widgets/gfx_widget_leaderboard_display.c
+++ b/gfx/widgets/gfx_widget_leaderboard_display.c
@@ -379,7 +379,7 @@ void gfx_widgets_set_leaderboard_display(unsigned id, const char* value)
          {
             char buffer[2] = "0";
             int j = 0;
-            for (j = 0; j < ARRAY_SIZE(state->char_width); ++j)
+            for (j = 0; j < (int)ARRAY_SIZE(state->char_width); ++j)
             {
                buffer[0] = (char)(j + CHEEVO_LBOARD_FIRST_FIXED_CHAR);
                state->char_width[j] = (uint16_t)font_driver_get_message_width(

--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -712,7 +712,7 @@ static void udev_mouse_set_x(udev_input_mouse_t *mouse, int32_t x, bool abs)
 
          if (mouse->x_abs < vp.x)
             mouse->x_abs = vp.x;
-         else if (mouse->x_abs >= vp.x + vp.full_width)
+         else if (mouse->x_abs >= (vp.x + (int)vp.full_width))
             mouse->x_abs = vp.x + vp.full_width - 1;
       }
    }
@@ -755,7 +755,7 @@ static void udev_mouse_set_y(udev_input_mouse_t *mouse, int32_t y, bool abs)
 
          if (mouse->y_abs < vp.y)
             mouse->y_abs = vp.y;
-         else if (mouse->y_abs >= vp.y + vp.full_height)
+         else if (mouse->y_abs >= (vp.y + (int)vp.full_height))
             mouse->y_abs = vp.y + vp.full_height - 1;
       }
    }
@@ -3435,7 +3435,7 @@ static void udev_input_handle_hotplug(udev_input_t *udev)
    }
  
    /* Add what devices we have now */
-   for (i = 0; i < udev->num_devices; ++i)
+   for (i = 0; i < (int)udev->num_devices; i++)
    {
       if (udev->devices[i]->type != UDEV_INPUT_KEYBOARD)
       { /* Pointers */
@@ -3532,7 +3532,7 @@ static void udev_input_poll(void *data)
    udev_input_get_pointer_position(&udev->pointer_x, &udev->pointer_y);
 #endif
 
-   for (i = 0; i < udev->num_devices; ++i)
+   for (i = 0; i < (int)udev->num_devices; i++)
    {
       if (udev->devices[i]->type == UDEV_INPUT_KEYBOARD)
          continue;
@@ -3603,9 +3603,9 @@ static bool udev_pointer_is_off_window(const udev_input_t *udev)
 
    if (r)
       r = udev->pointer_x < 0 ||
-          udev->pointer_x >= view.full_width ||
+          udev->pointer_x >= (int)view.full_width ||
           udev->pointer_y < 0 ||
-          udev->pointer_y >= view.full_height;
+          udev->pointer_y >= (int)view.full_height;
    return r;
 #else
    return false;
@@ -4163,7 +4163,7 @@ static void *udev_input_init(const char *joypad_driver)
       udev->keyboards[i] = -1;
    }
 
-   for (i = 0; i < udev->num_devices; ++i)
+   for (i = 0; i < (int)udev->num_devices; ++i)
    {
       if (udev->devices[i]->type != UDEV_INPUT_KEYBOARD)
       {

--- a/input/drivers/wayland_input.c
+++ b/input/drivers/wayland_input.c
@@ -83,14 +83,14 @@ static void input_wl_poll(void *data)
       /* Clamp X */
       if (wl->mouse.x < 0)
          wl->mouse.x = 0;
-      if (wl->mouse.x >= wl->gfx->buffer_width)
-         wl->mouse.x = (wl->gfx->buffer_width - 1);
+      if (wl->mouse.x >= (int)wl->gfx->buffer_width)
+         wl->mouse.x = ((int)wl->gfx->buffer_width - 1);
 
       /* Clamp Y */
       if (wl->mouse.y < 0)
          wl->mouse.y = 0;
-      if (wl->mouse.y >= wl->gfx->buffer_height)
-         wl->mouse.y = (wl->gfx->buffer_height - 1);
+      if (wl->mouse.y >= (int)wl->gfx->buffer_height)
+         wl->mouse.y = ((int)wl->gfx->buffer_height - 1);
    }
 
    for (id = 0; id < MAX_TOUCHES; id++)

--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -2212,7 +2212,7 @@ static void input_poll_overlay(
                polled_data.buttons.data,
                ARRAY_SIZE(polled_data.buttons.data));
 
-         for (j = 0; j < ARRAY_SIZE(ol_state->keys); j++)
+         for (j = 0; j < (int)ARRAY_SIZE(ol_state->keys); j++)
             ol_state->keys[j] |= polled_data.keys[j];
 
          /* Fingers pressed later take priority and matched up
@@ -2242,7 +2242,7 @@ static void input_poll_overlay(
       key_mod |= RETROKMOD_META;
 
    /* CAPSLOCK SCROLLOCK NUMLOCK */
-   for (i = 0; i < ARRAY_SIZE(ol_state->keys); i++)
+   for (i = 0; i < (int)ARRAY_SIZE(ol_state->keys); i++)
    {
       if (ol_state->keys[i] != old_ol_state.keys[i])
       {
@@ -3756,7 +3756,7 @@ void input_driver_init_command(input_driver_state_t *input_st,
 void input_driver_deinit_command(input_driver_state_t *input_st)
 {
    int i;
-   for (i = 0; i < ARRAY_SIZE(input_st->command); i++)
+   for (i = 0; i < (int)ARRAY_SIZE(input_st->command); i++)
    {
       if (input_st->command[i])
          input_st->command[i]->destroy(
@@ -4030,7 +4030,7 @@ static bool input_keys_pressed_other_sources(
 {
 #ifdef HAVE_COMMAND
    int j;
-   for (j = 0; j < ARRAY_SIZE(input_st->command); j++)
+   for (j = 0; j < (int)ARRAY_SIZE(input_st->command); j++)
       if ((i < RARCH_BIND_LIST_END) && input_st->command[j]
          && input_st->command[j]->state[i])
          return true;
@@ -4914,7 +4914,7 @@ void bsv_movie_next_frame(input_driver_state_t *input_st)
 
            size = swap_if_big64(size);
            st   = (uint8_t*)malloc(size);
-           if (intfstream_read(handle->file, st, size) != size)
+           if (intfstream_read(handle->file, st, size) != (int64_t)size)
            {
               RARCH_ERR("[Replay] Replay checkpoint truncated\n");
               input_st->bsv_movie_state.flags |= BSV_FLAG_MOVIE_END;
@@ -6142,7 +6142,7 @@ void input_driver_collect_system_input(input_driver_state_t *input_st,
          int i;
          /* Update compound 'current_bits' record
           * Note: Only digital inputs are considered */
-         for (i = 0; i < sizeof(current_bits->data) / sizeof(current_bits->data[0]); i++)
+         for (i = 0; i < (int)ARRAY_SIZE(current_bits->data); i++)
             current_bits->data[i] |= loop_bits->data[i];
       }
       else if (!all_users_control_menu)

--- a/libretro-common/cdrom/cdrom.c
+++ b/libretro-common/cdrom/cdrom.c
@@ -1404,7 +1404,7 @@ struct string_list* cdrom_get_available_drives(void)
          
          if (string_split_noalloc(&mods, buf, "\n"))
          {
-            for (i = 0; i < mods.size; i++)
+            for (i = 0; i < (int)mods.size; i++)
             {
                if (strcasestr(mods.elems[i].data, "sg "))
                {

--- a/libretro-common/features/features_cpu.c
+++ b/libretro-common/features/features_cpu.c
@@ -837,7 +837,7 @@ void cpu_features_get_model_name(char *name, int len)
       unsigned char s[16];
    } flags;
    int i, j;
-   size_t pos = 0;
+   int pos = 0;
    bool start = false;
 
    if (!name)
@@ -853,7 +853,7 @@ void cpu_features_get_model_name(char *name, int len)
       memset(flags.i, 0, sizeof(flags.i));
       x86_cpuid(0x80000002 + i, flags.i);
 
-      for (j = 0; j < sizeof(flags.s); j++)
+      for (j = 0; j < (int)sizeof(flags.s); j++)
       {
          if (!start && flags.s[j] == ' ')
             continue;
@@ -872,7 +872,7 @@ void cpu_features_get_model_name(char *name, int len)
    }
 end:
    /* terminate our string */
-   if (pos < (size_t)len)
+   if (pos < len)
       name[pos] = '\0';
 #elif defined(__MACH__)
    if (!name)

--- a/libretro-common/file/archive_file_zlib.c
+++ b/libretro-common/file/archive_file_zlib.c
@@ -404,7 +404,7 @@ static int zip_parse_file_init(file_archive_transfer_t *state,
    uint8_t footer_buf[1024];
    uint8_t *footer = footer_buf;
    int64_t read_pos = state->archive_size;
-   int64_t read_block = MIN(read_pos, sizeof(footer_buf));
+   int64_t read_block = MIN(read_pos, (ssize_t)sizeof(footer_buf));
    int64_t directory_size, directory_offset;
    zip_context_t *zip_context = NULL;
 

--- a/libretro-common/formats/cdfs/cdfs.c
+++ b/libretro-common/formats/cdfs/cdfs.c
@@ -28,7 +28,7 @@ static void cdfs_determine_sector_size(cdfs_track_t* track)
 
    /* The boot record or primary volume descriptor is always at sector 16 and will contain a "CD001" marker */
    intfstream_seek(track->stream, toc_sector * 2352 + track->first_sector_offset, SEEK_SET);
-   if (intfstream_read(track->stream, buffer, sizeof(buffer)) < sizeof(buffer))
+   if (intfstream_read(track->stream, &buffer, sizeof(buffer)) != (int64_t)sizeof(buffer))
       return;
 
    /* if this is a CDROM-XA data source, the "CD001" tag will be 25 bytes into the sector */
@@ -99,13 +99,13 @@ void cdfs_seek_sector(cdfs_file_t* file, unsigned int sector)
    /* only allowed if open_file was called with a NULL path */
    if (file->first_sector == 0)
    {
-      if (sector != file->current_sector)
+      if (file->current_sector != (int)sector)
       {
-         file->current_sector      = sector;
+         file->current_sector      = (int)sector;
          file->sector_buffer_valid = 0;
       }
 
-      file->pos                    = file->current_sector * 2048;
+      file->pos                    = sector * 2048;
       file->current_sector_offset  = 0;
    }
 }

--- a/libretro-common/formats/libchdr/libchdr_chd.c
+++ b/libretro-common/formats/libchdr/libchdr_chd.c
@@ -637,7 +637,7 @@ static chd_error decompress_v5_map(chd_file* chd, chd_header* header)
 		return CHDERR_DECOMPRESSION_ERROR;
 	}
 
-	for (hunknum = 0; hunknum < header->hunkcount; hunknum++)
+	for (hunknum = 0; hunknum < (int)header->hunkcount; hunknum++)
 	{
 		uint8_t *rawmap = header->rawmap + (hunknum * 12);
 		if (repcount > 0)
@@ -666,7 +666,7 @@ static chd_error decompress_v5_map(chd_file* chd, chd_header* header)
 
 	/* then iterate through the hunks and extract the needed data */
 	curoffset = firstoffs;
-	for (hunknum = 0; hunknum < header->hunkcount; hunknum++)
+	for (hunknum = 0; hunknum < (int)header->hunkcount; hunknum++)
 	{
 		uint8_t *rawmap = header->rawmap + (hunknum * 12);
 		uint64_t offset = curoffset;
@@ -856,7 +856,7 @@ chd_error chd_open_file(RFILE *file, int mode, chd_file *parent, chd_file **chd)
 	/* find the codec interface */
 	if (newchd->header.version < 5)
 	{
-		for (intfnum = 0; intfnum < ARRAY_SIZE(codec_interfaces); intfnum++)
+		for (intfnum = 0; intfnum < (int)ARRAY_SIZE(codec_interfaces); intfnum++)
 			if (codec_interfaces[intfnum].compression == newchd->header.compression[0])
 			{
 				newchd->codecintf[0] = &codec_interfaces[intfnum];
@@ -878,9 +878,9 @@ chd_error chd_open_file(RFILE *file, int mode, chd_file *parent, chd_file **chd)
 	{
 		int i, decompnum;
 		/* verify the compression types and initialize the codecs */
-		for (decompnum = 0; decompnum < ARRAY_SIZE(newchd->header.compression); decompnum++)
+		for (decompnum = 0; decompnum < (int)ARRAY_SIZE(newchd->header.compression); decompnum++)
 		{
-			for (i = 0 ; i < ARRAY_SIZE(codec_interfaces) ; i++)
+			for (i = 0 ; i < (int)ARRAY_SIZE(codec_interfaces); i++)
 			{
 				if (codec_interfaces[i].compression == newchd->header.compression[decompnum])
 				{
@@ -1331,7 +1331,7 @@ static chd_error header_validate(const chd_header *header)
 			return CHDERR_INVALID_PARAMETER;
 
 		/* require a supported compression mechanism */
-		for (intfnum = 0; intfnum < ARRAY_SIZE(codec_interfaces); intfnum++)
+		for (intfnum = 0; intfnum < (int)ARRAY_SIZE(codec_interfaces); intfnum++)
 			if (codec_interfaces[intfnum].compression == header->compression[0])
 				break;
 
@@ -1571,7 +1571,7 @@ static UINT8* hunk_read_compressed(chd_file *chd, UINT64 offset, size_t size)
       return chd->file_cache + offset;
    filestream_seek(chd->file, offset, SEEK_SET);
    bytes = filestream_read(chd->file, chd->compressed, size);
-   if (bytes != size)
+   if (bytes != (int64_t)size)
       return NULL;
    return chd->compressed;
 }
@@ -1591,7 +1591,7 @@ static chd_error hunk_read_uncompressed(chd_file *chd, UINT64 offset, size_t siz
    }
    filestream_seek(chd->file, offset, SEEK_SET);
    bytes = filestream_read(chd->file, dest, size);
-   if (bytes != size)
+   if (bytes != (int64_t)size)
       return CHDERR_READ_ERROR;
    return CHDERR_NONE;
 }
@@ -1825,7 +1825,7 @@ static chd_error map_read(chd_file *chd)
 
 	/* read the map entries in in chunks and extract to the map list */
 	fileoffset = chd->header.length;
-	for (i = 0; i < chd->header.totalhunks; i += MAP_STACK_ENTRIES)
+	for (i = 0; i < (int)chd->header.totalhunks; i += MAP_STACK_ENTRIES)
 	{
 		/* compute how many entries this time */
 		int entries = chd->header.totalhunks - i, j;

--- a/libretro-common/formats/libchdr/libchdr_flac.c
+++ b/libretro-common/formats/libchdr/libchdr_flac.c
@@ -292,7 +292,7 @@ FLAC__StreamDecoderWriteStatus flac_decoder_write_callback(void *client_data, co
 	{
 		int16_t *dest = decoder->uncompressed_start[0] + decoder->uncompressed_offset * frame->header.channels;
 		for (sampnum = 0; sampnum < blocksize && decoder->uncompressed_offset < decoder->uncompressed_length; sampnum++, decoder->uncompressed_offset++)
-			for (chan = 0; chan < frame->header.channels; chan++)
+			for (chan = 0; chan < (int)frame->header.channels; chan++)
 				*dest++ = (int16_t)((((uint16_t)buffer[chan][sampnum]) << shift) | (((uint16_t)buffer[chan][sampnum]) >> shift));
 	}
 
@@ -300,7 +300,7 @@ FLAC__StreamDecoderWriteStatus flac_decoder_write_callback(void *client_data, co
 	else
 	{
 		for (sampnum = 0; sampnum < blocksize && decoder->uncompressed_offset < decoder->uncompressed_length; sampnum++, decoder->uncompressed_offset++)
-			for (chan = 0; chan < frame->header.channels; chan++)
+			for (chan = 0; chan < (int)frame->header.channels; chan++)
 				if (decoder->uncompressed_start[chan] != NULL)
 					decoder->uncompressed_start[chan][decoder->uncompressed_offset] = (int16_t) ( (((uint16_t)(buffer[chan][sampnum])) << shift) | ( ((uint16_t)(buffer[chan][sampnum])) >> shift) );
 	}

--- a/libretro-common/formats/libchdr/libchdr_huffman.c
+++ b/libretro-common/formats/libchdr/libchdr_huffman.c
@@ -191,7 +191,7 @@ enum huffman_error huffman_import_tree_rle(struct huffman_decoder* decoder, stru
 		numbits = 3;
 
 	/* loop until we read all the nodes */
-	for (curnode = 0; curnode < decoder->numcodes; )
+	for (curnode = 0; curnode < (int)decoder->numcodes; /* blank */)
 	{
 		/* a non-one value is just raw */
 		int nodebits = bitstream_read(bitbuf, numbits);
@@ -217,7 +217,7 @@ enum huffman_error huffman_import_tree_rle(struct huffman_decoder* decoder, stru
 	}
 
 	/* make sure we ended up with the right number */
-	if (curnode != decoder->numcodes)
+	if (curnode != (int)decoder->numcodes)
 		return HUFFERR_INVALID_DATA;
 
 	/* assign canonical codes for all nodes based on their code lengths */
@@ -279,7 +279,7 @@ enum huffman_error huffman_import_tree_huffman(struct huffman_decoder* decoder, 
     }
 
 	/* now process the rest of the data */
-	for (curcode = 0; curcode < decoder->numcodes; )
+	for (curcode = 0; curcode < (int)decoder->numcodes; /* blank */)
 	{
 		int value = huffman_decode_one(smallhuff, bitbuf);
 		if (value != 0)
@@ -289,13 +289,13 @@ enum huffman_error huffman_import_tree_huffman(struct huffman_decoder* decoder, 
 			int count = bitstream_read(bitbuf, 3) + 2;
 			if (count == 7+2)
 				count += bitstream_read(bitbuf, rlefullbits);
-			for ( ; count != 0 && curcode < decoder->numcodes; count--)
+			for (/* blank */; count != 0 && curcode < (int)decoder->numcodes; count--)
 				decoder->huffnode[curcode++].numbits = last;
 		}
 	}
 
 	/* make sure we ended up with the right number */
-	if (curcode != decoder->numcodes)
+	if (curcode != (int)decoder->numcodes)
    {
       delete_huffman_decoder(smallhuff);
 		return HUFFERR_INVALID_DATA;
@@ -330,7 +330,7 @@ enum huffman_error huffman_compute_tree_from_histo(struct huffman_decoder* decod
    uint32_t upperweight;
 	uint32_t lowerweight = 0;
 	uint32_t sdatacount = 0;
-	for (i = 0; i < decoder->numcodes; i++)
+	for (i = 0; i < (int)decoder->numcodes; i++)
 		sdatacount += decoder->datahisto[i];
 
 	/* binary search to achieve the optimum encoding */
@@ -399,7 +399,7 @@ int huffman_build_tree(struct huffman_decoder* decoder, uint32_t totaldata, uint
 	memset(decoder->huffnode, 0,
          decoder->numcodes * sizeof(decoder->huffnode[0]));
 
-	for (curcode = 0; curcode < decoder->numcodes; curcode++)
+	for (curcode = 0; curcode < (int)decoder->numcodes; curcode++)
 		if (decoder->datahisto[curcode] != 0)
 		{
 			list[listitems++] = &decoder->huffnode[curcode];
@@ -466,7 +466,7 @@ int huffman_build_tree(struct huffman_decoder* decoder, uint32_t totaldata, uint
 
 	/* compute the number of bits in each code,
     * and fill in another histogram */
-	for (curcode = 0; curcode < decoder->numcodes; curcode++)
+	for (curcode = 0; curcode < (int)decoder->numcodes; curcode++)
 	{
 		struct node_t *curnode;
 		struct node_t* node = &decoder->huffnode[curcode];
@@ -504,7 +504,7 @@ enum huffman_error huffman_assign_canonical_codes(struct huffman_decoder* decode
 	/* build up a histogram of bit lengths */
 	int curcode, codelen;
 	uint32_t bithisto[33] = { 0 };
-	for (curcode = 0; curcode < decoder->numcodes; curcode++)
+	for (curcode = 0; curcode < (int)decoder->numcodes; curcode++)
 	{
 		struct node_t* node = &decoder->huffnode[curcode];
 		if (node->numbits > decoder->maxbits)
@@ -524,7 +524,7 @@ enum huffman_error huffman_assign_canonical_codes(struct huffman_decoder* decode
 	}
 
 	/* now assign canonical codes */
-	for (curcode = 0; curcode < decoder->numcodes; curcode++)
+	for (curcode = 0; curcode < (int)decoder->numcodes; curcode++)
 	{
 		struct node_t* node = &decoder->huffnode[curcode];
 		if (node->numbits > 0)
@@ -543,7 +543,7 @@ void huffman_build_lookup_table(struct huffman_decoder* decoder)
 {
 	/* iterate over all codes */
 	int curcode;
-	for (curcode = 0; curcode < decoder->numcodes; curcode++)
+	for (curcode = 0; curcode < (int)decoder->numcodes; curcode++)
 	{
 		/* process all nodes which have non-zero bits */
 		struct node_t* node = &decoder->huffnode[curcode];

--- a/libretro-common/formats/xml/rxml.c
+++ b/libretro-common/formats/xml/rxml.c
@@ -105,7 +105,7 @@ rxml_document_t *rxml_load_document(const char *path)
       goto error;
 
    memory_buffer[len]      = '\0';
-   if (filestream_read(file, memory_buffer, len) != (size_t)len)
+   if (filestream_read(file, memory_buffer, len) != len)
       goto error;
 
    filestream_close(file);
@@ -129,7 +129,7 @@ rxml_document_t *rxml_load_document_string(const char *str)
    rxml_document_t *doc          = NULL;
    size_t stack_i                = 0;
    size_t level                  = 0;
-   int c                         = 0;
+   int i                         = 0;
    char *valptr                  = NULL;
    rxml_node_t *node             = NULL;
    struct rxml_attrib_node *attr = NULL;
@@ -238,9 +238,9 @@ rxml_document_t *rxml_load_document_string(const char *str)
             break;
 
          case YXML_CONTENT:
-            for (c = 0; c < sizeof(x.data) && x.data[c]; ++c)
+            for (i = 0; i < (int)sizeof(x.data) && x.data[i]; i++)
             {
-               *valptr = x.data[c];
+               *valptr = x.data[i];
                ++valptr;
             }
             break;
@@ -260,9 +260,9 @@ rxml_document_t *rxml_load_document_string(const char *str)
             break;
 
          case YXML_ATTRVAL:
-            for (c = 0; c < sizeof(x.data) && x.data[c]; ++c)
+            for (i = 0; i < (int)sizeof(x.data) && x.data[i]; i++)
             {
-               *valptr = x.data[c];
+               *valptr = x.data[i];
                ++valptr;
             }
             break;

--- a/libretro-common/streams/chd_stream.c
+++ b/libretro-common/streams/chd_stream.c
@@ -142,7 +142,7 @@ chdstream_find_track_number(chd_file *fd, int32_t track, metadata_t *meta)
       if (!chdstream_get_meta(fd, i, meta))
          return false;
 
-      if (track == meta->track)
+      if (track == (int)meta->track)
       {
          meta->frame_offset = frame_offset;
          return true;
@@ -294,7 +294,7 @@ chdstream_load_hunk(chdstream_t *stream, uint32_t hunknum)
 {
    uint16_t *array;
 
-   if (hunknum == stream->hunknum)
+   if ((int)hunknum == stream->hunknum)
       return true;
 
    if (chd_read(stream->chd, hunknum, stream->hunkmem) != CHDERR_NONE)
@@ -416,7 +416,7 @@ int64_t chdstream_seek(chdstream_t *stream, int64_t offset, int whence)
    if (new_offset < 0)
       return -1;
 
-   if (new_offset > stream->track_end)
+   if ((size_t)new_offset > stream->track_end)
       new_offset = stream->track_end;
 
    stream->offset = new_offset;

--- a/libretro-db/query.c
+++ b/libretro-db/query.c
@@ -277,7 +277,7 @@ static void query_raise_unknown_function(
          (uint64_t)where
          );
 
-   if (len < (_len - n - 3))
+   if (len < ((ssize_t)_len - n - 3))
       strncpy(s + n, name, len);
 
    strcpy_literal(s + n + len, "'");

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -1287,7 +1287,7 @@ int generic_action_ok_displaylist_push(const char *path,
                strlcpy(tmp, path_get(RARCH_PATH_CONTENT), sizeof(tmp));
             path_basedir(tmp);
 
-            if (content_get_subsystem() != type - MENU_SETTINGS_SUBSYSTEM_ADD)
+            if (content_get_subsystem() != (int)type - MENU_SETTINGS_SUBSYSTEM_ADD)
                content_clear_subsystem();
             content_set_subsystem(type - MENU_SETTINGS_SUBSYSTEM_ADD);
             filebrowser_set_type(FILEBROWSER_SELECT_FILE_SUBSYSTEM);

--- a/menu/cbs/menu_cbs_sublabel.c
+++ b/menu/cbs/menu_cbs_sublabel.c
@@ -1404,7 +1404,7 @@ static int action_bind_sublabel_subsystem_add(
       if (content_get_subsystem_rom_id() < subsystem->num_roms)
          snprintf(s, len,
                msg_hash_to_str(MENU_ENUM_LABEL_VALUE_SUBSYSTEM_CONTENT_INFO),
-               (content_get_subsystem() == type - MENU_SETTINGS_SUBSYSTEM_ADD)
+               (content_get_subsystem() == (int)type - MENU_SETTINGS_SUBSYSTEM_ADD)
              ? subsystem->roms[content_get_subsystem_rom_id()].desc
              : subsystem->roms[0].desc);
    }
@@ -1718,7 +1718,7 @@ static int action_bind_sublabel_netplay_kick_client(file_list_t *list,
          msg_hash_to_str(MSG_NETPLAY_CLIENT_DEVICES));
 
       /* Ensure that at least one device can be written. */
-      if (written > 0 && written < (sizeof(buf) - STRLEN_CONST(" 16\n")))
+      if (written > 0 && written < (int)sizeof(buf) - (int)STRLEN_CONST(" 16\n"))
       {
          uint32_t device;
          char *buf_written = buf + written;
@@ -1738,7 +1738,7 @@ static int action_bind_sublabel_netplay_kick_client(file_list_t *list,
                }
 
                written += tmp_written;
-               if (written >= (sizeof(buf) - 1))
+               if (written >= (int)sizeof(buf) - 1)
                   break;
 
                buf_written += tmp_written;

--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -2668,7 +2668,7 @@ static void materialui_render_messagebox(
     * are too large to fit on screen */
 
    /* Find the longest line width */
-   for (i = 0; i < list.size; i++)
+   for (i = 0; i < (int)list.size; i++)
    {
       const char *line = list.elems[i].data;
 
@@ -2700,7 +2700,7 @@ static void materialui_render_messagebox(
          NULL);
 
    /* Print each line of the message */
-   for (i = 0; i < list.size; i++)
+   for (i = 0; i < (int)list.size; i++)
    {
       const char *line = list.elems[i].data;
 
@@ -3806,10 +3806,10 @@ static void materialui_render(void *data,
          /* Check if pointer is within the 'list' region of
           * the window (i.e. exclude header, navigation bar,
           * landscape borders) */
-         if ((pointer_x >  mui->landscape_optimization.border_width) &&
-             (pointer_x <  width - mui->landscape_optimization.border_width - mui->nav_bar_layout_width) &&
-             (pointer_y >= header_height) &&
-             (pointer_y <= height - mui->nav_bar_layout_height - mui->status_bar.height))
+         if (((unsigned)pointer_x >  mui->landscape_optimization.border_width) &&
+             ((unsigned)pointer_x <  width - mui->landscape_optimization.border_width - mui->nav_bar_layout_width) &&
+             ((unsigned)pointer_y >= header_height) &&
+             ((unsigned)pointer_y <= height - mui->nav_bar_layout_height - mui->status_bar.height))
          {
             /* Check if pointer is within the bounds of the
              * current entry */
@@ -5583,11 +5583,12 @@ static void materialui_render_entry_touch_feedback(
     * or pointer may no longer be held above the entry
     * currently selected for feedback animations */
    if (pointer_active)
-      pointer_active =    (mui->touch_feedback_selection == menu_input->ptr)
-                       && (mui->pointer.x >  mui->landscape_optimization.border_width)
-                       && (mui->pointer.x <  video_width - mui->landscape_optimization.border_width - mui->nav_bar_layout_width)
-                       && (mui->pointer.y >= header_height)
-                       && (mui->pointer.y <= video_height - mui->nav_bar_layout_height - mui->status_bar.height);
+      pointer_active =
+         (mui->touch_feedback_selection == menu_input->ptr)
+         && ((unsigned)mui->pointer.x >  mui->landscape_optimization.border_width)
+         && ((unsigned)mui->pointer.x <  video_width - mui->landscape_optimization.border_width - mui->nav_bar_layout_width)
+         && ((unsigned)mui->pointer.y >= header_height)
+         && ((unsigned)mui->pointer.y <= video_height - mui->nav_bar_layout_height - mui->status_bar.height);
 
    /* Touch feedback highlight fades in when pointer
     * is held stationary on a menu entry */
@@ -6079,8 +6080,8 @@ static void materialui_render_header(
             /* Even more trickery required for proper centring
              * if both search and switch view icons are shown... */
             if (show_search_icon && show_switch_view_icon)
-               if (str_width < usable_title_bar_width - mui->icon_size)
-                  title_x += (int)(mui->icon_size >> 1);
+               if (str_width < (int)usable_title_bar_width - (int)mui->icon_size)
+                  title_x += (int)(mui->icon_size / 2);
          }
       }
    }
@@ -8299,7 +8300,7 @@ static void materialui_reset_thumbnails(void)
       return;
 
    /* Free node thumbnails */
-   for (i = 0; i < list->size; i++)
+   for (i = 0; i < (int)list->size; i++)
    {
       materialui_node_t *node = (materialui_node_t*)list->list[i].userdata;
 
@@ -9019,7 +9020,7 @@ static int materialui_switch_tabs(
             {
                target_tab_index = (int)mui->nav_bar.active_menu_tab_index + 1;
 
-               if (target_tab_index >= mui->nav_bar.num_menu_tabs)
+               if (target_tab_index >= (int)mui->nav_bar.num_menu_tabs)
                {
                   target_tab_index = 0;
                   mui->nav_bar.menu_navigation_wrapped = true;
@@ -10158,10 +10159,10 @@ static int materialui_pointer_up(void *userdata,
 
                /* Check if pointer location is within the
                 * bounds of the pointer item */
-               if (   (x < entry_x)
-                   || (x > (entry_x + node->entry_width))
-                   || (y < entry_y)
-                   || (y > (entry_y + node->entry_height)))
+               if (   ((int)x < entry_x)
+                   || ((int)x > (entry_x + node->entry_width))
+                   || ((int)y < entry_y)
+                   || ((int)y > (entry_y + node->entry_height)))
                   break;
 
                /* Pointer input is valid - perform action */

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -12360,7 +12360,7 @@ static int ozone_pointer_up(void *userdata,
       menu_entry_t *entry,
       unsigned action)
 {
-   int width, height;
+   unsigned int width, height;
    ozone_handle_t *ozone             = (ozone_handle_t*)userdata;
    struct menu_state *menu_st        = menu_state_get_ptr();
    menu_input_t *menu_input          = &menu_st->input_state;
@@ -12398,12 +12398,12 @@ static int ozone_pointer_up(void *userdata,
       case MENU_INPUT_GESTURE_SHORT_PRESS:
          /* Tap/press header or footer: Menu back/cancel */
          if (((int)y < ozone->dimensions.header_height) ||
-             ((int)y > height - ozone->dimensions.footer_height))
+             ((int)y > (int)height - ozone->dimensions.footer_height))
             return ozone_menu_entry_action(ozone, entry, selection, MENU_ACTION_CANCEL);
          /* Tap/press entries: Activate and/or select item */
          else if ((ptr < entries_end)
-               && (x > ozone->dimensions_sidebar_width + ozone->sidebar_offset)
-               && (x < width - ozone->animations.thumbnail_bar_position))
+               && ((int)x > (int)(ozone->dimensions_sidebar_width + ozone->sidebar_offset))
+               && ((int)x < (int)((float)width - ozone->animations.thumbnail_bar_position)))
          {
             if (gesture == MENU_INPUT_GESTURE_TAP)
             {

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -2397,7 +2397,7 @@ static uintptr_t ozone_entries_icon_get_texture(
                int input_num  = type - input_id;
                for (index = 0; index < ARRAY_SIZE(input_config_bind_order); index++)
                {
-                  if (input_config_bind_order[index] == input_num)
+                  if ((int)input_config_bind_order[index] == input_num)
                   {
                      type = input_id + index;
                      break;
@@ -8133,7 +8133,7 @@ static enum menu_action ozone_parse_menu_entry_action(
             ozone->flags      &= ~OZONE_FLAG_CURSOR_MODE;
 
 #ifdef HAVE_AUDIOMIXER
-            if (new_selection != selection)
+            if (new_selection != (int)selection)
                audio_driver_mixer_play_scroll_sound(false);
 #endif
             break;
@@ -8170,7 +8170,7 @@ static enum menu_action ozone_parse_menu_entry_action(
             ozone->flags      &= ~OZONE_FLAG_CURSOR_MODE;
 
 #ifdef HAVE_AUDIOMIXER
-            if (new_selection != selection)
+            if (new_selection != (int)selection)
                audio_driver_mixer_play_scroll_sound(true);
 #endif
             break;
@@ -8387,18 +8387,18 @@ static enum menu_action ozone_parse_menu_entry_action(
 
             if (tab_selection < ozone->system_tab_end + 1)
                new_selection           = 0;
-            else if (tab_selection > ozone->system_tab_end - new_selection
+            else if ((int)tab_selection > (int)ozone->system_tab_end - new_selection
                   || new_selection < 0)
                new_selection           = (int)(ozone->system_tab_end + 1);
 
-            if (new_selection != tab_selection)
+            if (new_selection != (int)tab_selection)
                ozone_sidebar_goto(ozone, new_selection);
 
             new_action         = MENU_ACTION_NOOP;
             ozone->flags      &= ~OZONE_FLAG_CURSOR_MODE;
 
 #ifdef HAVE_AUDIOMIXER
-            if (new_selection != selection)
+            if (new_selection != (int)selection)
                audio_driver_mixer_play_scroll_sound(true);
 #endif
             break;
@@ -8454,14 +8454,14 @@ static enum menu_action ozone_parse_menu_entry_action(
             if (new_selection > (int)(ozone->system_tab_end + horizontal_list_size))
                new_selection           = (int)(ozone->system_tab_end + horizontal_list_size);
 
-            if (new_selection != tab_selection)
+            if (new_selection != (int)tab_selection)
                ozone_sidebar_goto(ozone, new_selection);
 
             new_action         = MENU_ACTION_NOOP;
             ozone->flags      &= ~OZONE_FLAG_CURSOR_MODE;
 
 #ifdef HAVE_AUDIOMIXER
-            if (new_selection != selection)
+            if (new_selection != (int)selection)
                audio_driver_mixer_play_scroll_sound(false);
 #endif
             break;
@@ -8493,14 +8493,14 @@ static enum menu_action ozone_parse_menu_entry_action(
             if (tab_selection > ozone->system_tab_end)
                new_selection           = (int)(ozone->system_tab_end + 1);
 
-            if (new_selection != tab_selection)
+            if (new_selection != (int)tab_selection)
                ozone_sidebar_goto(ozone, new_selection);
 
             new_action         = MENU_ACTION_NOOP;
             ozone->flags      &= ~OZONE_FLAG_CURSOR_MODE;
 
 #ifdef HAVE_AUDIOMIXER
-            if (new_selection != selection)
+            if (new_selection != (int)selection)
                audio_driver_mixer_play_scroll_sound(true);
 #endif
             break;
@@ -8517,14 +8517,14 @@ static enum menu_action ozone_parse_menu_entry_action(
 
             new_selection              = ozone->system_tab_end + horizontal_list_size;
 
-            if (new_selection != tab_selection)
+            if (new_selection != (int)tab_selection)
                ozone_sidebar_goto(ozone, new_selection);
 
             new_action         = MENU_ACTION_NOOP;
             ozone->flags      &= ~OZONE_FLAG_CURSOR_MODE;
 
 #ifdef HAVE_AUDIOMIXER
-            if (new_selection != selection)
+            if (new_selection != (int)selection)
                audio_driver_mixer_play_scroll_sound(false);
 #endif
             break;
@@ -12360,7 +12360,7 @@ static int ozone_pointer_up(void *userdata,
       menu_entry_t *entry,
       unsigned action)
 {
-   unsigned width, height;
+   int width, height;
    ozone_handle_t *ozone             = (ozone_handle_t*)userdata;
    struct menu_state *menu_st        = menu_state_get_ptr();
    menu_input_t *menu_input          = &menu_st->input_state;
@@ -12397,8 +12397,8 @@ static int ozone_pointer_up(void *userdata,
       case MENU_INPUT_GESTURE_TAP:
       case MENU_INPUT_GESTURE_SHORT_PRESS:
          /* Tap/press header or footer: Menu back/cancel */
-         if ((y < ozone->dimensions.header_height) ||
-             (y > height - ozone->dimensions.footer_height))
+         if (((int)y < ozone->dimensions.header_height) ||
+             ((int)y > height - ozone->dimensions.footer_height))
             return ozone_menu_entry_action(ozone, entry, selection, MENU_ACTION_CANCEL);
          /* Tap/press entries: Activate and/or select item */
          else if ((ptr < entries_end)
@@ -12492,12 +12492,12 @@ static int ozone_pointer_up(void *userdata,
          break;
       case MENU_INPUT_GESTURE_LONG_PRESS:
          /* 'Reset to default' action */
-         if (     (y > ozone->dimensions.header_height)
-               && (y < height - ozone->dimensions.footer_height)
+         if (     ((int)y > ozone->dimensions.header_height)
+               && ((int)y < height - ozone->dimensions.footer_height)
                && (ptr < entries_end)
                && (ptr == selection)
-               && (x > ozone->dimensions_sidebar_width + ozone->sidebar_offset)
-               && (x < width - ozone->animations.thumbnail_bar_position))
+               && ((int)x > ozone->dimensions_sidebar_width + ozone->sidebar_offset)
+               && ((int)x < width - ozone->animations.thumbnail_bar_position))
             return ozone_menu_entry_action(ozone,
                   entry, selection, MENU_ACTION_START);
          break;

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -4588,8 +4588,8 @@ static int rgui_osk_ptr_at_pos(
          unsigned osk_ptr_x       = osk_x + keyboard_offset_x + ptr_offset_x + (key_column * key_width);
          unsigned osk_ptr_y       = osk_y + keyboard_offset_y + ptr_offset_y + (key_row    * key_height);
 
-         if (  x > osk_ptr_x && x < osk_ptr_x + ptr_width &&
-               y > osk_ptr_y && y < osk_ptr_y + ptr_height)
+         if ((unsigned)x > osk_ptr_x && (unsigned)x < osk_ptr_x + ptr_width &&
+             (unsigned)y > osk_ptr_y && (unsigned)y < osk_ptr_y + ptr_height)
             return (int)key_index;
       }
    }
@@ -4606,7 +4606,7 @@ static void rgui_render_osk(
       unsigned fb_width,
       unsigned fb_height)
 {
-   size_t key_index;
+   int key_index;
    
    unsigned input_label_max_length;
    unsigned input_str_max_length;
@@ -5099,7 +5099,7 @@ static void rgui_render(
        rgui->pointer.active && !show_fs_thumbnail)
    {
       /* Update currently 'highlighted' item */
-      if (rgui->pointer.y > rgui->term_layout.start_y)
+      if (rgui->pointer.y > (int)rgui->term_layout.start_y)
       {
          old_start       = menu_st->entries.begin;
          /* NOTE: It's okay for this to go out of range

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -3542,7 +3542,7 @@ static uintptr_t xmb_icon_get_id(xmb_handle_t *xmb,
                   index < ARRAY_SIZE(input_config_bind_order);
                   index++)
             {
-               if (input_config_bind_order[index] == input_num)
+               if (input_num == (int)input_config_bind_order[index])
                {
                   type = input_id + index;
                   break;
@@ -8232,14 +8232,14 @@ static int xmb_pointer_up(void *userdata,
           * - A touch in the right margin triggers a 'select' action
           *   for the current item
           * - Between the left/right margins input is handled normally */
-         if (x < margin_left)
+         if ((int)x < margin_left)
          {
-            if (y >= margin_top)
+            if ((int)y >= margin_top)
                return xmb_menu_entry_action(xmb,
                      entry, selection, MENU_ACTION_CANCEL);
             return menu_input_dialog_start_search() ? 0 : -1;
          }
-         else if (x > margin_right)
+         else if ((int)x > margin_right)
             return xmb_menu_entry_action(xmb,
                   entry, selection, MENU_ACTION_SELECT);
          else if (ptr <= (end - 1))
@@ -8265,7 +8265,7 @@ static int xmb_pointer_up(void *userdata,
           * Note: At the top level, navigating left
           * means switching to the 'next' horizontal list,
           * which is actually a movement to the *right* */
-         if (y > margin_top)
+         if ((int)y > margin_top)
             xmb_menu_entry_action(xmb,
                   entry, selection,
                   (xmb->depth == 1) ? MENU_ACTION_RIGHT : MENU_ACTION_LEFT);
@@ -8275,17 +8275,17 @@ static int xmb_pointer_up(void *userdata,
           * Note: At the top level, navigating right
           * means switching to the 'previous' horizontal list,
           * which is actually a movement to the *left* */
-         if (y > margin_top)
+         if ((int)y > margin_top)
             xmb_menu_entry_action(xmb,
                   entry, selection,
                   (xmb->depth == 1) ? MENU_ACTION_LEFT : MENU_ACTION_RIGHT);
          break;
       case MENU_INPUT_GESTURE_SWIPE_UP:
          /* Swipe up in left margin: ascend alphabet */
-         if (x < margin_left)
+         if ((int)x < margin_left)
             xmb_menu_entry_action(xmb,
                   entry, selection, MENU_ACTION_SCROLL_DOWN);
-         else if (x < margin_right)
+         else if ((int)x < margin_right)
          {
             /* Swipe up between left and right margins:
              * move selection pointer down by 1 'page' */
@@ -8315,10 +8315,10 @@ static int xmb_pointer_up(void *userdata,
          break;
       case MENU_INPUT_GESTURE_SWIPE_DOWN:
          /* Swipe down in left margin: descend alphabet */
-         if (x < margin_left)
+         if ((int)x < margin_left)
             xmb_menu_entry_action(xmb,
                   entry, selection, MENU_ACTION_SCROLL_UP);
-         else if (x < margin_right)
+         else if ((int)x < margin_right)
          {
             /* Swipe down between left and right margins:
              * move selection pointer up by 1 'page' */

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -1195,7 +1195,7 @@ static unsigned menu_displaylist_parse_core_option_dropdown_list(
    val_off_str  = msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF);
 
    /* Loop over all option values */
-   for (j = 0; j < option->vals->size; j++)
+   for (j = 0; j < (int)option->vals->size; j++)
    {
       const char *val_str       = option->vals->elems[j].data;
       const char *val_label_str = option->val_labels->elems[j].data;
@@ -5115,7 +5115,7 @@ static int menu_displaylist_parse_audio_device_list(
       }
    }
 
-   for (i = 0; i < ptr->size; i++)
+   for (i = 0; i < (int)ptr->size; i++)
    {
       bool add = false;
 
@@ -5205,7 +5205,7 @@ static int menu_displaylist_parse_microphone_device_list(
       }
    }
 
-   for (i = 0; i < ptr->size; i++)
+   for (i = 0; i < (int)ptr->size; i++)
    {
       bool add = false;
 
@@ -6173,7 +6173,7 @@ static unsigned menu_displaylist_populate_subsystem(
     * UCN equivalent: "\u2605" */
    static const char utf8_star_char[] = "\xE2\x98\x85";
 #endif
-   unsigned   i = 0;
+   int  i       = 0;
    bool is_rgui = string_is_equal(menu_driver, "rgui");
 
    /* Select appropriate 'star' marker for subsystem menu entries
@@ -6191,7 +6191,7 @@ static unsigned menu_displaylist_populate_subsystem(
    {
       runloop_state_t *runloop_st = runloop_state_get_ptr();
 
-      for (i = 0; i < runloop_st->subsystem_current_count; i++, subsystem++)
+      for (i = 0; i < (int)runloop_st->subsystem_current_count; i++, subsystem++)
       {
          char s[PATH_MAX_LENGTH];
          if (content_get_subsystem() == i)
@@ -14942,7 +14942,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                                              setting_type, val, 0, NULL))
                                        count++;
 
-                                    if (!checked_found && val == orig_value)
+                                    if (!checked_found && val == (int)orig_value)
                                     {
                                        checked       = entry_index;
                                        checked_found = true;
@@ -14967,7 +14967,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                                              setting_type, val, 0, NULL))
                                        count++;
 
-                                    if (!checked_found && val == orig_value)
+                                    if (!checked_found && val == (int)orig_value)
                                     {
                                        checked       = entry_index;
                                        checked_found = true;
@@ -15278,7 +15278,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                                           setting_type, val, 0, NULL))
                                     count++;
 
-                                 if (!checked_found && val == orig_value)
+                                 if (!checked_found && val == (int)orig_value)
                                  {
                                     checked       = entry_index;
                                     checked_found = true;
@@ -15303,7 +15303,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                                           setting_type, val, 0, NULL))
                                     count++;
 
-                                 if (!checked_found && val == orig_value)
+                                 if (!checked_found && val == (int)orig_value)
                                  {
                                     checked       = entry_index;
                                     checked_found = true;

--- a/menu/menu_explore.c
+++ b/menu/menu_explore.c
@@ -1658,7 +1658,7 @@ SKIP_ENTRY:;
       strlcpy(state->title,
             pl_entry->label, sizeof(state->title));
 
-      for (pl_idx = 0; pl_idx != RBUF_LEN(state->playlists); pl_idx++)
+      for (pl_idx = 0; pl_idx != (int)RBUF_LEN(state->playlists); pl_idx++)
       {
          menu_displaylist_info_t          info;
          const struct playlist_entry* pl_first = NULL;
@@ -1726,7 +1726,7 @@ ssize_t menu_explore_get_entry_playlist_index(unsigned type,
          || !entry->playlist_entry)
       return -1;
 
-   for (pl_idx = 0; pl_idx != RBUF_LEN(explore_state->playlists); pl_idx++)
+   for (pl_idx = 0; pl_idx != (int)RBUF_LEN(explore_state->playlists); pl_idx++)
    {
       const struct playlist_entry* pl_first = NULL;
       playlist_t *pl  = explore_state->playlists[pl_idx];

--- a/midi_driver.c
+++ b/midi_driver.c
@@ -95,7 +95,7 @@ static midi_driver_t *midi_driver_find_driver(const char *ident)
 
 const void *midi_driver_find_handle(int index)
 {
-   if (index < 0 || index >= ARRAY_SIZE(midi_drivers))
+   if (index < 0 || index >= (int)ARRAY_SIZE(midi_drivers))
       return NULL;
 
    return midi_drivers[index];
@@ -425,7 +425,7 @@ bool midi_driver_output_enabled(void)
 
 bool midi_driver_read(uint8_t *byte)
 {
-   static int i;
+   static int i = 0;
 
    if (!rarch_midi_drv_data || !rarch_midi_drv_input_enabled || !byte)
    {
@@ -440,7 +440,7 @@ bool midi_driver_read(uint8_t *byte)
       return false;
    }
 
-   if (i == rarch_midi_drv_input_event.data_size)
+   if (i == (int)rarch_midi_drv_input_event.data_size)
    {
       rarch_midi_drv_input_event.data_size = MIDI_DRIVER_BUF_SIZE;
       if (!midi_drv->read(rarch_midi_drv_data, &rarch_midi_drv_input_event))
@@ -558,7 +558,7 @@ bool midi_driver_write(uint8_t byte, uint32_t delta_time)
       return false;
    }
 
-   if (rarch_midi_drv_output_event.data_size == event_size)
+   if (event_size == (int)rarch_midi_drv_output_event.data_size)
    {
       if (!midi_drv->write(rarch_midi_drv_data, &rarch_midi_drv_output_event))
          return false;

--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -3443,7 +3443,7 @@ static int handle_mitm_connection(netplay_t *netplay, netplay_address_t *addr,
             netplay->mitm_handler->id_recvd = 0;
 
             if (socket_send_all_nonblocking(netplay->listen_fd,
-                  ping, len, true) != len)
+                  ping, len, true) != (ssize_t)len)
             {
                /* We couldn't send our ping reply in one call. Assume error. */
                RARCH_ERR("[Netplay] Tunnel ping reply failed.\n");

--- a/tasks/task_translation.c
+++ b/tasks/task_translation.c
@@ -218,7 +218,7 @@ static void handle_translation_cb(
          int i;
          json_current_key = -1;
 
-         for (i = 0; i < ARRAY_SIZE(keys); i++)
+         for (i = 0; i < (int)ARRAY_SIZE(keys); i++)
          {
             if (string_is_equal(str, keys[i]))
             {
@@ -517,12 +517,12 @@ static void handle_translation_cb(
    if (key_string)
    {
       char key[8];
-      size_t length = strlen(key_string);
+      int length = (int)strlen(key_string);
       int i         = 0;
       int start     = 0;
       char t        = ' ';
 
-      for (i = 1; i < (int)length; i++)
+      for (i = 1; i < length; i++)
       {
          t = key_string[i];
          if (i == length-1 || t == ' ' || t == ',')
@@ -1001,7 +1001,7 @@ bool run_translation_service(settings_t *settings, bool paused)
    {
       static const char* state_labels[] = { "b", "y", "select", "start", "up", "down", "left", "right", "a", "x", "l", "r", "l2", "r2", "l3", "r3" };
       int i;
-      for (i = 0; i < ARRAY_SIZE(state_labels); i++)
+      for (i = 0; i < (int)ARRAY_SIZE(state_labels); i++)
       {
          rjsonwriter_raw(jsonwriter, ",", 1);
          rjsonwriter_raw(jsonwriter, " ", 1);


### PR DESCRIPTION
## Description
This PR cleans up almost all signed to unsigned integer comparison warnings, mostly by doing type casts, and enables `-Wsign-compare` by default. I've only done this for the most trivial cases: there are a few places where it isn't immediately clear how to proceed. I hope to clean up other warning classes too, so that they actually help catching bugs.