### PR TITLE
CRT: fix aspect ratio for tate games on a horizontal screen

### DIFF
--- a/gfx/drivers_context/drm_ctx.c
+++ b/gfx/drivers_context/drm_ctx.c
@@ -122,7 +122,7 @@ static float mode_vrefresh(drmModeModeInfo *mode)
 
 static void dump_mode(drmModeModeInfo *mode, int index)
 {
-   RARCH_LOG("Mode details:  #%i %s %.2f %d %d %d %d %d %d %d %d %d\n",
+   RARCH_DBG("Mode details:  #%i %s %.2f %d %d %d %d %d %d %d %d %d\n",
       index,
       mode->name,
       mode_vrefresh(mode),

--- a/gfx/video_crt_switch.c
+++ b/gfx/video_crt_switch.c
@@ -125,7 +125,10 @@ static void crt_switch_set_aspect(
       patched_height           = height;
    }
 
-   if (srm_width >= 1920 && !srm_isstretched)
+   sr_state state;
+   sr_get_state(&state);
+
+   if (srm_width >= state.super_width && !srm_isstretched)
       RARCH_LOG("[CRT]: Super resolution detected. Fractal scaling @ X:%f Y:%f \n", srm_xscale, srm_yscale);
    else if (srm_isstretched && srm_width > 0 )
       RARCH_LOG("[CRT]: Resolution is stretched. Fractal scaling @ X:%f Y:%f \n", srm_xscale, srm_yscale);
@@ -144,6 +147,14 @@ static bool is_kms_driver_context(void)
    return (gfxctx.ident && strncmp(gfxctx.ident, "kms",3) == 0);
 }
 
+static bool is_khr_driver_context()
+{
+   gfx_ctx_ident_t gfxctx;
+   video_context_driver_get_ident(&gfxctx);
+   RARCH_LOG("[CRT] Video context is: %s\n", gfxctx.ident);
+   return (gfxctx.ident && strncmp(gfxctx.ident, "khr_display",11) == 0);
+}
+
 #if !defined(HAVE_VIDEOCORE)
 static bool crt_sr2_init(videocrt_switch_t *p_switch,
       int monitor_index, unsigned int crt_mode, unsigned int super_width)
@@ -160,6 +171,7 @@ static bool crt_sr2_init(videocrt_switch_t *p_switch,
       strlcpy(index, "0", sizeof(index));
 
    p_switch->kms_ctx = is_kms_driver_context();
+   p_switch->khr_ctx = is_khr_driver_context();
 
    if (!p_switch->sr2_active)
    {
@@ -191,8 +203,13 @@ static bool crt_sr2_init(videocrt_switch_t *p_switch,
             break;
       }
 
-      if (super_width >2)
+      if (super_width > 2)
+      {
          sr_set_user_mode(super_width, 0, 0);
+         char sw[16];
+         sprintf(sw, "%d", super_width);
+         sr_set_option(SR_OPT_SUPER_WIDTH, sw);
+      }
 
       if (p_switch->kms_ctx)
             p_switch->rtn = sr_init_disp("dummy", NULL);
@@ -234,6 +251,12 @@ static bool crt_sr2_init(videocrt_switch_t *p_switch,
    {
       p_switch->sr2_active = true;
       RARCH_LOG("[CRT]: KMS context detected, keeping SR alive\n");
+      return true;
+   }
+   else if (p_switch->rtn >= 0 && p_switch->khr_ctx)
+   {
+      p_switch->sr2_active = true;
+      RARCH_LOG("[CRT]: Vulkan context detected, keeping SR alive\n");
       return true;
    }
 
@@ -282,7 +305,6 @@ static void switch_res_crt(
    /* Check if SR2 is loaded, if not, load it */
    if (crt_sr2_init(p_switch, monitor_index, crt_mode, super_width))
    {
-      bool swap_w_h;
       const char *_core_name = (const char*)runloop_state_get_ptr()->system.info.library_name;
       /* Check for core and content changes in case we need
          to make any adjustments */
@@ -310,32 +332,33 @@ static void switch_res_crt(
       if (p_switch->rotated)
          flags |= SR_MODE_ROTATED;
 
-      swap_w_h = p_switch->rotated ^ retroarch_get_rotation();
-      ret      = sr_add_mode(swap_w_h ? h : w, swap_w_h ? w : h, rr, flags, &srm);
+      RARCH_DBG("%dx%d rotation: %d rotated: %d core rotation:%d\n", w, h, p_switch->rotated, flags & SR_MODE_ROTATED, retroarch_get_rotation());
+      ret = sr_add_mode(w, h, rr, flags, &srm);
       if (!ret)
-         RARCH_LOG("[CRT]: SR failed to add mode\n");
+         RARCH_ERR("[CRT]: SR failed to add mode\n");
       if (p_switch->kms_ctx)
       {
-         RARCH_LOG("[CRT]: KMS -> use sr_add_mode\n");
 #if 0
          settings_t *settings = config_get_ptr();
 #endif
          get_modeline_for_kms(p_switch, &srm);
-#if 0
-         /* Need trigger the context set video mode */
-         video_driver_reinit(DRIVER_VIDEO_MASK);
-#endif
          video_driver_set_video_mode(srm.width, srm.height, true);
+      }
+      else if (p_switch->khr_ctx)
+      {
+         RARCH_WARN("[CRT]: Vulkan -> Can't modeswitch for now\n");
+         /*crt_switch_driver_refresh();
+         video_driver_set_video_mode(srm.width, srm.height, true);*/
       }
       else
          ret = sr_set_mode(srm.id);
       if (!p_switch->kms_ctx && !ret)
-         RARCH_LOG("[CRT]: SR failed to switch mode\n");
+         RARCH_ERR("[CRT]: SR failed to switch mode\n");
       p_switch->sr_core_hz = (float)srm.vfreq;
 
       crt_switch_set_aspect(p_switch,
-            retroarch_get_rotation() ? h : w,
-            retroarch_get_rotation() ? w : h,
+            p_switch->rotated? h : w,
+            p_switch->rotated? w : h,
             srm.width, srm.height,
             (float)srm.x_scale, (float)srm.y_scale, srm.is_stretched);
    }

--- a/gfx/video_crt_switch.h
+++ b/gfx/video_crt_switch.h
@@ -68,6 +68,7 @@ typedef struct videocrt_switch
    bool rotated;
    bool tmp_rotated;
    bool kms_ctx;
+   bool khr_ctx;
 } videocrt_switch_t;
 
 void crt_switch_res_core(

--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -664,7 +664,7 @@ void video_monitor_set_refresh_rate(float hz)
    /* Avoid message spamming if there is no change. */
    if (settings->floats.video_refresh_rate == hz)
       return;
-   
+
    snprintf(rate, sizeof(rate), "%.3f", hz);
    snprintf(msg, sizeof(msg),
       msg_hash_to_str(MSG_VIDEO_REFRESH_RATE_CHANGED), rate);
@@ -3817,7 +3817,7 @@ void video_driver_frame(const void *data, unsigned width,
             native_width, width,
             height,
             video_st->core_hz,
-            video_st->av_info.geometry.aspect_ratio < 1.0 ? true : false,
+            retroarch_get_rotation() & 1,
             video_info.crt_switch_resolution,
             video_info.crt_switch_center_adjust,
             video_info.crt_switch_porch_adjust,


### PR DESCRIPTION
## Description

When on CRT, playing vertical games on a horizontal screen resulted in a wrong aspect ratio. This PR fixes it. A few messages also changed of log level + inform that Vulkan can't modeswitch on KMS (for now ?)

Hopefully since https://github.com/libretro/mame/pull/364 the last piece of the puzzle for core provided rotation information finally came, making this PR hackless and solely rely on the core rotation info. Too bad for people not updating the MAME core, just checking the original aspect ratio (as it was so far) can lead to other cores (like MSX) not displaying properly. 

## Related Issues

None I know of

## Related Pull Requests

none

## Reviewers
@hunterk 
