### PR TITLE
Clean up gfx driver interface structs

### DIFF
--- a/gfx/drivers/caca_gfx.c
+++ b/gfx/drivers/caca_gfx.c
@@ -373,27 +373,27 @@ static void caca_set_texture_frame(void *data,
 }
 
 static const video_poke_interface_t caca_poke_interface = {
-   NULL,                   /* get_flags */
-   NULL,
-   NULL,
-   NULL,
-   NULL,
-   NULL,
-   NULL,
-   NULL,
-   NULL,
-   NULL,
-   NULL,
-   NULL,
-   NULL,
+   NULL, /* get_flags */
+   NULL, /* load_texture */
+   NULL, /* unload_texture */
+   NULL, /* set_video_mode */
+   NULL, /* get_refresh_rate */
+   NULL, /* set_filtering */
+   NULL, /* get_video_output_size */
+   NULL, /* get_video_output_prev */
+   NULL, /* get_video_output_next */
+   NULL, /* get_current_framebuffer */
+   NULL, /* get_proc_address */
+   NULL, /* set_aspect_ratio */
+   NULL, /* apply_state_changes */
    caca_set_texture_frame,
-   NULL,
+   NULL, /* set_texture_enable */
    font_driver_render_msg,
-   NULL,                   /* show_mouse */
-   NULL,                   /* grab_mouse_toggle */
-   NULL,                   /* get_current_shader */
-   NULL,                   /* get_current_software_framebuffer */
-   NULL,                   /* get_hw_render_interface */
+   NULL, /* show_mouse */
+   NULL, /* grab_mouse_toggle */
+   NULL, /* get_current_shader */
+   NULL, /* get_current_software_framebuffer */
+   NULL, /* get_hw_render_interface */
    NULL, /* set_hdr_max_nits */
    NULL, /* set_hdr_paper_white_nits */
    NULL, /* set_hdr_contrast */
@@ -418,13 +418,15 @@ video_driver_t video_caca = {
    "caca",
    caca_set_viewport,
    caca_set_rotation,
-   NULL, /* viewport_info  */
-   NULL, /* read_viewport  */
+   NULL, /* viewport_info */
+   NULL, /* read_viewport */
    NULL, /* read_frame_raw */
-
 #ifdef HAVE_OVERLAY
-  NULL, /* overlay_interface */
+   NULL, /* overlay_interface */
 #endif
-  caca_get_poke_interface,
-  NULL /* wrap_type_to_enum */
+   caca_get_poke_interface,
+   NULL, /* wrap_type_to_enum */
+#ifdef HAVE_GFX_WIDGETS
+   NULL  /* gfx_widgets_enabled */
+#endif
 };

--- a/gfx/drivers/ctr_gfx.c
+++ b/gfx/drivers/ctr_gfx.c
@@ -2941,24 +2941,24 @@ static const video_poke_interface_t ctr_poke_interface = {
    ctr_get_flags,
    ctr_load_texture,
    ctr_unload_texture,
-   NULL,
-   NULL,
+   NULL, /* set_video_mode */
+   NULL, /* get_refresh_rate */
    ctr_set_filtering,
-   NULL,                                  /* get_video_output_size */
-   NULL,                                  /* get_video_output_prev */
-   NULL,                                  /* get_video_output_next */
-   NULL,                                  /* get_current_framebuffer */
-   NULL,
+   NULL, /* get_video_output_size */
+   NULL, /* get_video_output_prev */
+   NULL, /* get_video_output_next */
+   NULL, /* get_current_framebuffer */
+   NULL, /* get_proc_address */
    ctr_set_aspect_ratio,
    ctr_apply_state_changes,
    ctr_set_texture_frame,
    ctr_set_texture_enable,
-   font_driver_render_msg, /* ctr_set_osd_msg*/
-   NULL,                   /* show_mouse */
-   NULL,                   /* grab_mouse_toggle */
-   NULL,                   /* get_current_shader */
-   NULL,                   /* get_current_software_framebuffer */
-   NULL,                    /* get_hw_render_interface */
+   font_driver_render_msg,
+   NULL, /* show_mouse */
+   NULL, /* grab_mouse_toggle */
+   NULL, /* get_current_shader */
+   NULL, /* get_current_software_framebuffer */
+   NULL, /* get_hw_render_interface */
    NULL, /* set_hdr_max_nits */
    NULL, /* set_hdr_paper_white_nits */
    NULL, /* set_hdr_contrast */
@@ -2998,7 +2998,7 @@ video_driver_t video_ctr =
    ctr_overlay_interface,
 #endif
    ctr_get_poke_interface,
-   NULL,
+   NULL, /* wrap_type_to_enum */
 #ifdef HAVE_GFX_WIDGETS
    ctr_widgets_enabled
 #endif

--- a/gfx/drivers/d3d10.c
+++ b/gfx/drivers/d3d10.c
@@ -2799,17 +2799,17 @@ static const video_poke_interface_t d3d10_poke_interface = {
    d3d10_gfx_load_texture,
    d3d10_gfx_unload_texture,
    NULL, /* set_video_mode */
-#ifndef __WINRT__
-   win32_get_refresh_rate,
-#else
+#ifdef __WINRT__
    /* UWP does not expose this information easily */
-   NULL,
+   NULL, /* get_refresh_rate */
+#else
+   win32_get_refresh_rate,
 #endif
    d3d10_set_filtering,
 #ifdef __WINRT__
-   NULL,                               /* get_video_output_size */
-   NULL,                               /* get_video_output_prev */
-   NULL,                               /* get_video_output_next */
+   NULL, /* get_video_output_size */
+   NULL, /* get_video_output_prev */
+   NULL, /* get_video_output_next */
 #else
    d3d10_get_video_output_size,
    d3d10_get_video_output_prev,
@@ -2866,12 +2866,11 @@ video_driver_t video_d3d10 = {
    d3d10_gfx_viewport_info,
    NULL, /* read_viewport  */
    NULL, /* read_frame_raw */
-
 #ifdef HAVE_OVERLAY
    d3d10_get_overlay_interface,
 #endif
    d3d10_gfx_get_poke_interface,
-   NULL, /* d3d10_wrap_type_to_enum */
+   NULL, /* wrap_type_to_enum */
 #if defined(HAVE_GFX_WIDGETS)
    d3d10_gfx_widgets_enabled
 #endif

--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -3613,17 +3613,17 @@ static const video_poke_interface_t d3d11_poke_interface = {
    d3d11_gfx_load_texture,
    d3d11_gfx_unload_texture,
    NULL, /* set_video_mode */
-#ifndef __WINRT__
-   win32_get_refresh_rate,
-#else
+#ifdef __WINRT__
    /* UWP does not expose this information easily */
-   NULL,
+   NULL, /* get_refresh_rate */
+#else
+   win32_get_refresh_rate,
 #endif
    d3d11_set_filtering,
 #ifdef __WINRT__
-   NULL,                               /* get_video_output_size */
-   NULL,                               /* get_video_output_prev */
-   NULL,                               /* get_video_output_next */
+   NULL, /* get_video_output_size */
+   NULL, /* get_video_output_prev */
+   NULL, /* get_video_output_next */
 #else
    d3d11_get_video_output_size,
    d3d11_get_video_output_prev,
@@ -3680,12 +3680,11 @@ video_driver_t video_d3d11 = {
    d3d11_gfx_viewport_info,
    NULL, /* read_viewport  */
    NULL, /* read_frame_raw */
-
 #ifdef HAVE_OVERLAY
    d3d11_get_overlay_interface,
 #endif
    d3d11_gfx_get_poke_interface,
-   NULL, /* d3d11_wrap_type_to_enum */
+   NULL, /* wrap_type_to_enum */
 #if defined(HAVE_GFX_WIDGETS)
    d3d11_gfx_widgets_enabled
 #endif

--- a/gfx/drivers/d3d12.c
+++ b/gfx/drivers/d3d12.c
@@ -4150,17 +4150,17 @@ static const video_poke_interface_t d3d12_poke_interface = {
    d3d12_gfx_load_texture,
    d3d12_gfx_unload_texture,
    NULL, /* set_video_mode */
-#ifndef __WINRT__
-   win32_get_refresh_rate,
-#else
+#ifdef __WINRT__
    /* UWP does not expose this information easily */
    NULL,
+#else
+   win32_get_refresh_rate,
 #endif
    d3d12_set_filtering,
 #ifdef __WINRT__
-   NULL,                               /* get_video_output_size */
-   NULL,                               /* get_video_output_prev */
-   NULL,                               /* get_video_output_next */
+   NULL, /* get_video_output_size */
+   NULL, /* get_video_output_prev */
+   NULL, /* get_video_output_next */
 #else
    d3d12_get_video_output_size,
    d3d12_get_video_output_prev,
@@ -4216,12 +4216,11 @@ video_driver_t video_d3d12 = {
    d3d12_gfx_viewport_info,
    NULL, /* read_viewport  */
    NULL, /* read_frame_raw */
-
 #ifdef HAVE_OVERLAY
    d3d12_get_overlay_interface,
 #endif
    d3d12_gfx_get_poke_interface,
-   NULL, /* d3d12_wrap_type_to_enum */
+   NULL, /* wrap_type_to_enum */
 #ifdef HAVE_GFX_WIDGETS
    d3d12_gfx_widgets_enabled
 #endif

--- a/gfx/drivers/d3d8.c
+++ b/gfx/drivers/d3d8.c
@@ -2187,12 +2187,12 @@ static const video_poke_interface_t d3d_poke_interface = {
    d3d8_unload_texture,
    d3d8_set_video_mode,
 #if defined(_XBOX) || defined(__WINRT__)
-   NULL,
+   NULL, /* get_refresh_rate */
 #else
    /* UWP does not expose this information easily */
    win32_get_refresh_rate,
 #endif
-   NULL,
+   NULL, /* set_filtering */
    NULL, /* get_video_output_size */
    NULL, /* get_video_output_prev */
    NULL, /* get_video_output_next */
@@ -2203,16 +2203,15 @@ static const video_poke_interface_t d3d_poke_interface = {
    d3d8_set_menu_texture_frame,
    d3d8_set_menu_texture_enable,
    d3d8_set_osd_msg,
-
    win32_show_cursor,
-   NULL,                         /* grab_mouse_toggle */
-   NULL,                         /* get_current_shader */
-   NULL,                         /* get_current_software_framebuffer */
-   NULL,                         /* get_hw_render_interface */
-   NULL,                         /* set_hdr_max_nits */
-   NULL,                         /* set_hdr_paper_white_nits */
-   NULL,                         /* set_hdr_contrast */
-   NULL                          /* set_hdr_expand_gamut */
+   NULL, /* grab_mouse_toggle */
+   NULL, /* get_current_shader */
+   NULL, /* get_current_software_framebuffer */
+   NULL, /* get_hw_render_interface */
+   NULL, /* set_hdr_max_nits */
+   NULL, /* set_hdr_paper_white_nits */
+   NULL, /* set_hdr_contrast */
+   NULL  /* set_hdr_expand_gamut */
 };
 
 static void d3d8_get_poke_interface(void *data,
@@ -2232,7 +2231,7 @@ video_driver_t video_d3d8 = {
    d3d8_frame,
    d3d8_set_nonblock_state,
    d3d8_alive,
-   NULL,                      /* focus */
+   NULL, /* focus */
 #ifdef _XBOX
    d3d8_suppress_screensaver,
 #else
@@ -2245,10 +2244,14 @@ video_driver_t video_d3d8 = {
    d3d8_set_viewport,
    d3d8_set_rotation,
    d3d8_viewport_info,
-   NULL,                      /* read_viewport  */
-   NULL,                      /* read_frame_raw */
+   NULL, /* read_viewport  */
+   NULL, /* read_frame_raw */
 #ifdef HAVE_OVERLAY
    d3d8_get_overlay_interface,
 #endif
-   d3d8_get_poke_interface
+   d3d8_get_poke_interface,
+   NULL, /* wrap_type_to_enum */
+#ifdef HAVE_GFX_WIDGETS
+   NULL  /* gfx_widgets_enabled */
+#endif
 };

--- a/gfx/drivers/d3d9cg.c
+++ b/gfx/drivers/d3d9cg.c
@@ -2195,12 +2195,12 @@ static const video_poke_interface_t d3d9_cg_poke_interface = {
    d3d9_unload_texture,
    d3d9_set_video_mode,
 #if defined(__WINRT__)
-   NULL,
+   NULL, /* get_refresh_rate */
 #else
    /* UWP does not expose this information easily */
    win32_get_refresh_rate,
 #endif
-   NULL,
+   NULL, /* set_filtering */
    NULL, /* get_video_output_size */
    NULL, /* get_video_output_prev */
    NULL, /* get_video_output_next */
@@ -2211,16 +2211,15 @@ static const video_poke_interface_t d3d9_cg_poke_interface = {
    d3d9_set_menu_texture_frame,
    d3d9_set_menu_texture_enable,
    d3d9_set_osd_msg,
-
    win32_show_cursor,
-   NULL,                         /* grab_mouse_toggle */
-   NULL,                         /* get_current_shader */
-   NULL,                         /* get_current_software_framebuffer */
-   NULL,                         /* get_hw_render_interface */
-   NULL,                         /* set_hdr_max_nits */
-   NULL,                         /* set_hdr_paper_white_nits */
-   NULL,                         /* set_hdr_contrast */
-   NULL                          /* set_hdr_expand_gamut */
+   NULL, /* grab_mouse_toggle */
+   NULL, /* get_current_shader */
+   NULL, /* get_current_software_framebuffer */
+   NULL, /* get_hw_render_interface */
+   NULL, /* set_hdr_max_nits */
+   NULL, /* set_hdr_paper_white_nits */
+   NULL, /* set_hdr_contrast */
+   NULL  /* set_hdr_expand_gamut */
 };
 
 static void d3d9_cg_get_poke_interface(void *data,
@@ -2301,7 +2300,7 @@ video_driver_t video_d3d9_cg = {
    d3d9_cg_frame,
    d3d9_cg_set_nonblock_state,
    d3d9_cg_alive,
-   NULL,                      /* focus */
+   NULL, /* focus */
    win32_suppress_screensaver,
    d3d9_has_windowed,
    d3d9_cg_set_shader,
@@ -2311,7 +2310,7 @@ video_driver_t video_d3d9_cg = {
    d3d9_set_rotation,
    d3d9_viewport_info,
    d3d9_read_viewport,
-   NULL,                      /* read_frame_raw */
+   NULL, /* read_frame_raw */
 #ifdef HAVE_OVERLAY
    d3d9_get_overlay_interface,
 #endif

--- a/gfx/drivers/d3d9hlsl.c
+++ b/gfx/drivers/d3d9hlsl.c
@@ -1764,12 +1764,12 @@ static const video_poke_interface_t d3d9_hlsl_poke_interface = {
    d3d9_unload_texture,
    d3d9_set_video_mode,
 #if defined(_XBOX) || defined(__WINRT__)
-   NULL,
+   NULL, /* get_refresh_rate */
 #else
    /* UWP does not expose this information easily */
    win32_get_refresh_rate,
 #endif
-   NULL,
+   NULL, /* set_filtering */
    NULL, /* get_video_output_size */
    NULL, /* get_video_output_prev */
    NULL, /* get_video_output_next */
@@ -1780,16 +1780,15 @@ static const video_poke_interface_t d3d9_hlsl_poke_interface = {
    d3d9_set_menu_texture_frame,
    d3d9_set_menu_texture_enable,
    d3d9_set_osd_msg,
-
    win32_show_cursor,
-   NULL,                         /* grab_mouse_toggle */
-   NULL,                         /* get_current_shader */
-   NULL,                         /* get_current_software_framebuffer */
-   NULL,                         /* get_hw_render_interface */
-   NULL,                         /* set_hdr_max_nits */
-   NULL,                         /* set_hdr_paper_white_nits */
-   NULL,                         /* set_hdr_contrast */
-   NULL                          /* set_hdr_expand_gamut */
+   NULL, /* grab_mouse_toggle */
+   NULL, /* get_current_shader */
+   NULL, /* get_current_software_framebuffer */
+   NULL, /* get_hw_render_interface */
+   NULL, /* set_hdr_max_nits */
+   NULL, /* set_hdr_paper_white_nits */
+   NULL, /* set_hdr_contrast */
+   NULL  /* set_hdr_expand_gamut */
 };
 
 static void d3d9_hlsl_get_poke_interface(void *data,
@@ -1893,7 +1892,7 @@ video_driver_t video_d3d9_hlsl = {
    d3d9_hlsl_frame,
    d3d9_hlsl_set_nonblock_state,
    d3d9_hlsl_alive,
-   NULL,                      /* focus */
+   NULL, /* focus */
 #ifdef _XBOX
    d3d9_hlsl_suppress_screensaver,
 #else
@@ -1907,7 +1906,7 @@ video_driver_t video_d3d9_hlsl = {
    d3d9_set_rotation,
    d3d9_viewport_info,
    d3d9_read_viewport,
-   NULL,                      /* read_frame_raw */
+   NULL, /* read_frame_raw */
 #ifdef HAVE_OVERLAY
    d3d9_get_overlay_interface,
 #endif

--- a/gfx/drivers/dispmanx_gfx.c
+++ b/gfx/drivers/dispmanx_gfx.c
@@ -566,8 +566,8 @@ static uint32_t dispmanx_get_flags(void *data)
 
 static const video_poke_interface_t dispmanx_poke_interface = {
    dispmanx_get_flags,
-   NULL,
-   NULL,
+   NULL, /* load_texture */
+   NULL, /* unload_texture */
    NULL, /* set_video_mode */
    NULL, /* get_refresh_rate */
    NULL, /* set_filtering */
@@ -580,16 +580,16 @@ static const video_poke_interface_t dispmanx_poke_interface = {
    NULL, /* dispmanx_apply_state_changes */
    dispmanx_set_texture_frame,
    dispmanx_set_texture_enable,
-   NULL,                         /* set_osd_msg */
-   NULL,                         /* show_mouse */
-   NULL,                         /* grab_mouse_toggle */
-   NULL,                         /* get_current_shader */
-   NULL,                         /* get_current_software_framebuffer */
-   NULL,                         /* get_hw_render_interface */
-   NULL,                         /* set_hdr_max_nits */
-   NULL,                         /* set_hdr_paper_white_nits */
-   NULL,                         /* set_hdr_contrast */
-   NULL                          /* set_hdr_expand_gamut */
+   NULL, /* set_osd_msg */
+   NULL, /* show_mouse */
+   NULL, /* grab_mouse_toggle */
+   NULL, /* get_current_shader */
+   NULL, /* get_current_software_framebuffer */
+   NULL, /* get_hw_render_interface */
+   NULL, /* set_hdr_max_nits */
+   NULL, /* set_hdr_paper_white_nits */
+   NULL, /* set_hdr_contrast */
+   NULL  /* set_hdr_expand_gamut */
 };
 
 static void dispmanx_get_poke_interface(void *data,
@@ -638,9 +638,12 @@ video_driver_t video_dispmanx = {
    dispmanx_viewport_info,
    NULL, /* read_viewport */
    NULL, /* read_frame_raw */
-
 #ifdef HAVE_OVERLAY
    NULL, /* overlay_interface */
 #endif
-   dispmanx_get_poke_interface
+   dispmanx_get_poke_interface,
+   NULL, /* wrap_type_to_enum */
+#ifdef HAVE_GFX_WIDGETS
+   NULL  /* gfx_widgets_enabled */
+#endif
 };

--- a/gfx/drivers/drm_gfx.c
+++ b/gfx/drivers/drm_gfx.c
@@ -908,8 +908,8 @@ static void drm_set_aspect_ratio (void *data, unsigned aspect_ratio_idx)
 
 static const video_poke_interface_t drm_poke_interface = {
    NULL, /* get_flags */
-   NULL,
-   NULL,
+   NULL, /* load_texture */
+   NULL, /* unload_texture */
    NULL, /* set_video_mode */
    drm_get_refresh_rate,
    NULL, /* set_filtering */
@@ -922,16 +922,16 @@ static const video_poke_interface_t drm_poke_interface = {
    NULL, /* drm_apply_state_changes */
    drm_set_texture_frame,
    drm_set_texture_enable,
-   NULL,                         /* drm_set_osd_msg */
-   NULL,                         /* drm_show_mouse */
-   NULL,                         /* grab_mouse_toggle */
-   NULL,                         /* get_current_shader */
-   NULL,                         /* get_current_software_framebuffer */
-   NULL,                         /* get_hw_render_interface */
-   NULL,                         /* set_hdr_max_nits */
-   NULL,                         /* set_hdr_paper_white_nits */
-   NULL,                         /* set_hdr_contrast */
-   NULL                          /* set_hdr_expand_gamut */
+   NULL, /* drm_set_osd_msg */
+   NULL, /* drm_show_mouse */
+   NULL, /* grab_mouse_toggle */
+   NULL, /* get_current_shader */
+   NULL, /* get_current_software_framebuffer */
+   NULL, /* get_hw_render_interface */
+   NULL, /* set_hdr_max_nits */
+   NULL, /* set_hdr_paper_white_nits */
+   NULL, /* set_hdr_contrast */
+   NULL  /* set_hdr_expand_gamut */
 };
 
 static void drm_get_poke_interface(void *data,
@@ -978,9 +978,12 @@ video_driver_t video_drm = {
    drm_viewport_info,
    NULL, /* read_viewport */
    NULL, /* read_frame_raw */
-
 #ifdef HAVE_OVERLAY
-   NULL, /* overlay_interface */
+   NULL, /* get_overlay_interface */
 #endif
-   drm_get_poke_interface
+   drm_get_poke_interface,
+   NULL, /* wrap_type_to_enum */
+#ifdef HAVE_GFX_WIDGETS
+   NULL  /* gfx_widgets_enabled */
+#endif
 };

--- a/gfx/drivers/exynos_gfx.c
+++ b/gfx/drivers/exynos_gfx.c
@@ -1452,8 +1452,8 @@ static void exynos_show_mouse(void *data, bool state) { }
 
 static const video_poke_interface_t exynos_poke_interface = {
    NULL, /* get_flags */
-   NULL,
-   NULL,
+   NULL, /* load_texture */
+   NULL, /* unload_texture */
    NULL, /* set_video_mode */
    drm_get_refresh_rate,
    NULL, /* set_filtering */
@@ -1468,14 +1468,14 @@ static const video_poke_interface_t exynos_poke_interface = {
    exynos_set_texture_enable,
    exynos_set_osd_msg,
    exynos_show_mouse,
-   NULL,                         /* grab_mouse_toggle */
-   NULL,                         /* get_current_shader */
-   NULL,                         /* get_current_software_framebuffer */
-   NULL,                         /* get_hw_render_interface */
-   NULL,                         /* set_hdr_max_nits */
-   NULL,                         /* set_hdr_paper_white_nits */
-   NULL,                         /* set_hdr_contrast */
-   NULL                          /* set_hdr_expand_gamut */
+   NULL, /* grab_mouse_toggle */
+   NULL, /* get_current_shader */
+   NULL, /* get_current_software_framebuffer */
+   NULL, /* get_hw_render_interface */
+   NULL, /* set_hdr_max_nits */
+   NULL, /* set_hdr_paper_white_nits */
+   NULL, /* set_hdr_contrast */
+   NULL  /* set_hdr_expand_gamut */
 };
 
 static void exynos_get_poke_interface(void *data,
@@ -1491,24 +1491,27 @@ static bool exynos_set_shader(void *data,
 }
 
 video_driver_t video_exynos = {
-  exynos_init,
-  exynos_frame,
-  exynos_set_nonblock_state,
-  exynos_alive,
-  exynos_focus,
-  exynos_suppress_screensaver,
-  NULL, /* has_windowed */
-  exynos_set_shader,
-  exynos_free,
-  "exynos",
-  NULL, /* set_viewport */
-  exynos_set_rotation,
-  exynos_viewport_info,
-  NULL, /* read_viewport */
-  NULL, /* read_frame_raw */
-
+   exynos_init,
+   exynos_frame,
+   exynos_set_nonblock_state,
+   exynos_alive,
+   exynos_focus,
+   exynos_suppress_screensaver,
+   NULL, /* has_windowed */
+   exynos_set_shader,
+   exynos_free,
+   "exynos",
+   NULL, /* set_viewport */
+   exynos_set_rotation,
+   exynos_viewport_info,
+   NULL, /* read_viewport */
+   NULL, /* read_frame_raw */
 #ifdef HAVE_OVERLAY
-  NULL, /* overlay_interface */
+   NULL, /* get_overlay_interface */
 #endif
-  exynos_get_poke_interface
+   exynos_get_poke_interface,
+   NULL, /* wrap_type_to_enum */
+#ifdef HAVE_GFX_WIDGETS
+   NULL  /* gfx_widgets_enabled */
+#endif
 };

--- a/gfx/drivers/fpga_gfx.c
+++ b/gfx/drivers/fpga_gfx.c
@@ -351,33 +351,34 @@ static void fpga_set_video_mode(void *data, unsigned width, unsigned height,
       bool fullscreen) { }
 
 static const video_poke_interface_t fpga_poke_interface = {
-   NULL,
-   NULL,
+   NULL, /* get_flags */
+   NULL, /* load_texture */
+   NULL, /* unload_texture */
    fpga_set_video_mode,
-   NULL,
+   NULL, /* get_refresh_rate */
+   NULL, /* set_filtering */
    fpga_get_video_output_size,
    fpga_get_video_output_prev,
    fpga_get_video_output_next,
-   NULL,
-   NULL,
-   NULL,
-   NULL,
-#if defined(HAVE_MENU)
-   fpga_set_texture_frame,
-   NULL,
-   fpga_set_osd_msg,
-   NULL,
-#else
-   NULL,
-   NULL,
-   NULL,
-   NULL,
-#endif
-
-   NULL,
+   NULL, /* get_current_framebuffer */
+   NULL, /* get_proc_address */
+   NULL, /* set_aspect_ratio */
+   NULL, /* apply_state_changes */
 #ifdef HAVE_MENU
-   NULL,
+   fpga_set_texture_frame,
+   NULL, /* set_texture_enable */
+   fpga_set_osd_msg,
+   NULL, /* show_mouse */
+#else
+   NULL, /* set_texture_frame */
+   NULL, /* set_texture_enable */
+   NULL, /* set_osd_msg */
+   NULL, /* show_mouse */
 #endif
+   NULL, /* grab_mouse_toggle */
+   NULL, /* get_current_shader */
+   NULL, /* get_current_software_framebuffer */
+   NULL, /* get_hw_render_interface */
    NULL, /* set_hdr_max_nits */
    NULL, /* set_hdr_paper_white_nits */
    NULL, /* set_hdr_contrast */
@@ -408,12 +409,15 @@ video_driver_t video_fpga = {
    "fpga",
    fpga_set_viewport,
    fpga_set_rotation,
-   NULL, /* viewport_info  */
-   NULL, /* read_viewport  */
+   NULL, /* viewport_info */
+   NULL, /* read_viewport */
    NULL, /* read_frame_raw */
-
 #ifdef HAVE_OVERLAY
-  NULL, /* overlay_interface */
+   NULL, /* get_overlay_interface */
 #endif
-  fpga_get_poke_interface,
+   fpga_get_poke_interface,
+   NULL, /* wrap_type_to_enum */
+#ifdef HAVE_GFX_WIDGETS
+   NULL  /* gfx_widgets_enabled */
+#endif
 };

--- a/gfx/drivers/gdi_gfx.c
+++ b/gfx/drivers/gdi_gfx.c
@@ -993,26 +993,26 @@ static const video_poke_interface_t gdi_poke_interface = {
    gdi_unload_texture,
    gdi_set_video_mode,
    win32_get_refresh_rate,
-   NULL,
+   NULL, /* set_filtering */
    gdi_get_video_output_size,
    gdi_get_video_output_prev,
    gdi_get_video_output_next,
-   NULL,
-   NULL,
-   NULL,
-   NULL,
+   NULL, /* get_current_framebuffer */
+   NULL, /* get_proc_address */
+   NULL, /* set_aspect_ratio */
+   NULL, /* apply_state_changes */
    gdi_set_texture_frame,
    gdi_set_texture_enable,
    font_driver_render_msg,
-   NULL,
-   NULL,                         /* grab_mouse_toggle */
-   NULL,                         /* get_current_shader */
-   NULL,                         /* get_current_software_framebuffer */
-   NULL,                         /* get_hw_render_interface */
-   NULL,                         /* set_hdr_max_nits */
-   NULL,                         /* set_hdr_paper_white_nits */
-   NULL,                         /* set_hdr_contrast */
-   NULL                          /* set_hdr_expand_gamut */
+   NULL, /* show_mouse */
+   NULL, /* grab_mouse_toggle */
+   NULL, /* get_current_shader */
+   NULL, /* get_current_software_framebuffer */
+   NULL, /* get_hw_render_interface */
+   NULL, /* set_hdr_max_nits */
+   NULL, /* set_hdr_paper_white_nits */
+   NULL, /* set_hdr_contrast */
+   NULL  /* set_hdr_expand_gamut */
 };
 
 static void gdi_get_poke_interface(void *data,
@@ -1036,9 +1036,12 @@ video_driver_t video_gdi = {
    NULL, /* viewport_info */
    NULL, /* read_viewport */
    NULL, /* read_frame_raw */
-
 #ifdef HAVE_OVERLAY
-  NULL, /* overlay_interface */
+   NULL, /* get_overlay_interface */
 #endif
-  gdi_get_poke_interface,
+   gdi_get_poke_interface,
+   NULL, /* wrap_type_to_enum */
+#ifdef HAVE_GFX_WIDGETS
+   NULL  /* gfx_widgets_enabled */
+#endif
 };

--- a/gfx/drivers/gl1.c
+++ b/gfx/drivers/gl1.c
@@ -2217,26 +2217,26 @@ static const video_poke_interface_t gl1_poke_interface = {
    gl1_unload_texture,
    gl1_set_video_mode,
    gl1_get_refresh_rate,
-   NULL,
+   NULL, /* set_filtering */
    gl1_get_video_output_size,
    gl1_get_video_output_prev,
    gl1_get_video_output_next,
-   NULL,
-   NULL,
+   NULL, /* get_current_framebuffer */
+   NULL, /* get_proc_address */
    gl1_set_aspect_ratio,
-   NULL,
+   NULL, /* apply_state_changes */
    gl1_set_texture_frame,
    gl1_set_texture_enable,
    font_driver_render_msg,
-   NULL,
-   NULL,                         /* grab_mouse_toggle */
-   NULL,                         /* get_current_shader */
-   NULL,                         /* get_current_software_framebuffer */
-   NULL,                         /* get_hw_render_interface */
-   NULL,                         /* set_hdr_max_nits */
-   NULL,                         /* set_hdr_paper_white_nits */
-   NULL,                         /* set_hdr_contrast */
-   NULL                          /* set_hdr_expand_gamut */
+   NULL, /* show_mouse */
+   NULL, /* grab_mouse_toggle */
+   NULL, /* get_current_shader */
+   NULL, /* get_current_software_framebuffer */
+   NULL, /* get_hw_render_interface */
+   NULL, /* set_hdr_max_nits */
+   NULL, /* set_hdr_paper_white_nits */
+   NULL, /* set_hdr_contrast */
+   NULL  /* set_hdr_expand_gamut */
 };
 
 static void gl1_get_poke_interface(void *data,
@@ -2406,13 +2406,12 @@ video_driver_t video_gl1 = {
    gl1_viewport_info,
    gl1_read_viewport,
    NULL, /* read_frame_raw */
-
 #ifdef HAVE_OVERLAY
    gl1_get_overlay_interface,
 #endif
-  gl1_get_poke_interface,
-  gl1_wrap_type_to_enum,
+   gl1_get_poke_interface,
+   gl1_wrap_type_to_enum,
 #ifdef HAVE_GFX_WIDGETS
-  gl1_widgets_enabled
+   gl1_widgets_enabled
 #endif
 };

--- a/gfx/drivers/gl2.c
+++ b/gfx/drivers/gl2.c
@@ -5228,7 +5228,7 @@ static const video_poke_interface_t gl2_poke_interface = {
    gl2_unload_texture,
    gl2_set_video_mode,
    gl2_get_refresh_rate,
-   NULL,
+   NULL, /* set_filtering */
    gl2_get_video_output_size,
    gl2_get_video_output_prev,
    gl2_get_video_output_next,
@@ -5240,14 +5240,14 @@ static const video_poke_interface_t gl2_poke_interface = {
    gl2_set_texture_enable,
    font_driver_render_msg,
    gl2_show_mouse,
-   NULL,
+   NULL, /* grab_mouse_toggle */
    gl2_get_current_shader,
-   NULL,                      /* get_current_software_framebuffer */
-   NULL,                      /* get_hw_render_interface */
-   NULL,                      /* set_hdr_max_nits */
-   NULL,                      /* set_hdr_paper_white_nits */
-   NULL,                      /* set_hdr_contrast */
-   NULL                       /* set_hdr_expand_gamut */
+   NULL, /* get_current_software_framebuffer */
+   NULL, /* get_hw_render_interface */
+   NULL, /* set_hdr_max_nits */
+   NULL, /* set_hdr_paper_white_nits */
+   NULL, /* set_hdr_contrast */
+   NULL  /* set_hdr_expand_gamut */
 };
 
 static void gl2_get_poke_interface(void *data,
@@ -5280,24 +5280,18 @@ video_driver_t video_gl2 = {
    gl2_focus,
    gl2_suppress_screensaver,
    gl2_has_windowed,
-
    gl2_set_shader,
-
    gl2_free,
    "gl",
-
    gl2_set_viewport_wrapper,
    gl2_set_rotation,
-
    gl2_viewport_info,
-
    gl2_read_viewport,
 #if defined(READ_RAW_GL_FRAME_TEST)
    gl2_read_frame_raw,
 #else
    NULL,
 #endif
-
 #ifdef HAVE_OVERLAY
    gl2_get_overlay_interface,
 #endif

--- a/gfx/drivers/gl3.c
+++ b/gfx/drivers/gl3.c
@@ -2953,8 +2953,8 @@ static const video_poke_interface_t gl3_poke_interface = {
    gl3_load_texture,
    gl3_unload_texture,
    gl3_set_video_mode,
-   gl3_get_refresh_rate, /* get_refresh_rate */
-   NULL,
+   gl3_get_refresh_rate,
+   NULL, /* set_filtering */
    gl3_get_video_output_size,
    gl3_get_video_output_prev,
    gl3_get_video_output_next,
@@ -2966,10 +2966,10 @@ static const video_poke_interface_t gl3_poke_interface = {
    gl3_set_texture_enable,
    font_driver_render_msg,
    gl3_show_mouse,
-   NULL,                               /* grab_mouse_toggle */
+   NULL, /* grab_mouse_toggle */
    gl3_get_current_shader,
-   NULL,
-   NULL,
+   NULL, /* get_current_software_framebuffer */
+   NULL, /* get_hw_render_interface */
    NULL, /* set_hdr_max_nits */
    NULL, /* set_hdr_paper_white_nits */
    NULL, /* set_hdr_contrast */
@@ -3036,24 +3036,18 @@ video_driver_t video_gl3 = {
    gl3_focus,
    gl3_suppress_screensaver,
    gl3_has_windowed,
-
    gl3_set_shader,
-
    gl3_free,
    "glcore",
-
    gl3_set_viewport_wrapper,
    gl3_set_rotation,
-
    gl3_viewport_info,
-
    gl3_read_viewport,
 #if defined(READ_RAW_GL_FRAME_TEST)
    gl3_read_frame_raw,
 #else
-   NULL,
+   NULL, /* read_frame_raw */
 #endif
-
 #ifdef HAVE_OVERLAY
    gl3_get_overlay_interface,
 #endif

--- a/gfx/drivers/gx2_gfx.c
+++ b/gfx/drivers/gx2_gfx.c
@@ -2466,7 +2466,7 @@ video_driver_t video_wiiu =
    NULL, /* read_viewport  */
    NULL, /* read_frame_raw */
 #ifdef HAVE_OVERLAY
-   gx2_get_overlay_interface, /* overlay_interface */
+   gx2_get_overlay_interface,
 #endif
    gx2_get_poke_interface,
    NULL, /* wrap_type_to_enum */

--- a/gfx/drivers/gx_gfx.c
+++ b/gfx/drivers/gx_gfx.c
@@ -1320,30 +1320,30 @@ static uint32_t gx_get_flags(void *data)
 
 static const video_poke_interface_t gx_poke_interface = {
    gx_get_flags,
-   NULL,
-   NULL,
+   NULL, /* load_texture */
+   NULL, /* unload_texture */
    gx_set_video_mode,
    NULL, /* get_refresh_rate */
-   NULL,
+   NULL, /* set_filtering */
    gx_get_video_output_size,
    gx_get_video_output_prev,
    gx_get_video_output_next,
-   NULL,
-   NULL,
+   NULL, /* get_current_framebuffer */
+   NULL, /* get_proc_address */
    gx_set_aspect_ratio,
    gx_apply_state_changes,
    gx_set_texture_frame,
    gx_set_texture_enable,
-   NULL,                         /* set_osd_msg */
-   NULL,                         /* show_mouse */
-   NULL,                         /* grab_mouse_toggle */
-   NULL,                         /* get_current_shader */
-   NULL,                         /* get_current_software_framebuffer */
-   NULL,                         /* get_hw_render_interface */
-   NULL,                         /* set_hdr_max_nits */
-   NULL,                         /* set_hdr_paper_white_nits */
-   NULL,                         /* set_hdr_contrast */
-   NULL                          /* set_hdr_expand_gamut */
+   NULL, /* set_osd_msg */
+   NULL, /* show_mouse */
+   NULL, /* grab_mouse_toggle */
+   NULL, /* get_current_shader */
+   NULL, /* get_current_software_framebuffer */
+   NULL, /* get_hw_render_interface */
+   NULL, /* set_hdr_max_nits */
+   NULL, /* set_hdr_paper_white_nits */
+   NULL, /* set_hdr_contrast */
+   NULL  /* set_hdr_expand_gamut */
 };
 
 static void gx_get_poke_interface(void *data,
@@ -1758,4 +1758,8 @@ video_driver_t video_gx = {
    gx_get_overlay_interface,
 #endif
    gx_get_poke_interface,
+   NULL, /* wrap_type_to_enum */
+#ifdef HAVE_GFX_WIDGETS
+   NULL  /* gfx_widgets_enabled */
+#endif
 };

--- a/gfx/drivers/metal.m
+++ b/gfx/drivers/metal.m
@@ -2523,25 +2523,25 @@ static const video_poke_interface_t metal_poke_interface = {
    metal_set_video_mode,
    metal_get_refresh_rate,
    metal_set_filtering,
-   NULL,                      /* get_video_output_size */
-   NULL,                      /* get_video_output_prev */
-   NULL,                      /* get_video_output_next */
-   NULL,                      /* get_current_framebuffer */
-   NULL,                      /* get_proc_address */
+   NULL, /* get_video_output_size */
+   NULL, /* get_video_output_prev */
+   NULL, /* get_video_output_next */
+   NULL, /* get_current_framebuffer */
+   NULL, /* get_proc_address */
    metal_set_aspect_ratio,
    metal_apply_state_changes,
    metal_set_texture_frame,
    metal_set_texture_enable,
    font_driver_render_msg,
    metal_show_mouse,
-   NULL,                      /* grab_mouse_toggle */
+   NULL, /* grab_mouse_toggle */
    metal_get_current_shader,
-   NULL,                      /* get_current_software_framebuffer */
-   NULL,                      /* get_hw_render_interface */
-   NULL,                      /* set_hdr_max_nits */
-   NULL,                      /* set_hdr_paper_white_nits */
-   NULL,                      /* set_hdr_contrast */
-   NULL                       /* set_hdr_expand_gamut */
+   NULL, /* get_current_software_framebuffer */
+   NULL, /* get_hw_render_interface */
+   NULL, /* set_hdr_max_nits */
+   NULL, /* set_hdr_paper_white_nits */
+   NULL, /* set_hdr_contrast */
+   NULL  /* set_hdr_expand_gamut */
 };
 
 static void metal_get_poke_interface(void *data,
@@ -2640,7 +2640,7 @@ video_driver_t video_metal = {
    metal_get_overlay_interface,
 #endif
    metal_get_poke_interface,
-   NULL, /* metal_wrap_type_to_enum */
+   NULL, /* wrap_type_to_enum */
 #ifdef HAVE_GFX_WIDGETS
    metal_widgets_enabled
 #endif

--- a/gfx/drivers/network_gfx.c
+++ b/gfx/drivers/network_gfx.c
@@ -428,34 +428,38 @@ static void network_set_video_mode(void *data, unsigned width, unsigned height,
       bool fullscreen) { }
 
 static const video_poke_interface_t network_poke_interface = {
-   NULL,
-   NULL,
-   NULL,
+   NULL, /* get_flags */
+   NULL, /* load_texture */
+   NULL, /* unload_texture */
    network_set_video_mode,
-   NULL,
-   NULL,
+   NULL, /* get_refresh_rate */
+   NULL, /* set_filtering */
    network_get_video_output_size,
    network_get_video_output_prev,
    network_get_video_output_next,
-   NULL,
-   NULL,
-   NULL,
-   NULL,
+   NULL, /* get_current_framebuffer */
+   NULL, /* get_proc_address */
+   NULL, /* set_aspect_ratio */
+   NULL, /* apply_state_changes */
 #if defined(HAVE_MENU)
    network_set_texture_frame,
-   NULL,
+   NULL, /* set_texture_enable */
    font_driver_render_msg,
-   NULL,
+   NULL, /* show_mouse */
 #else
-   NULL,
-   NULL,
-   NULL,
-   NULL,
+   NULL, /* set_texture_frame */
+   NULL, /* set_texture_enable */
+   NULL, /* set_osd_msg */
+   NULL, /* show_mouse */
 #endif
-   NULL,
-   NULL,
-   NULL,
-   NULL,
+   NULL, /* grab_mouse_toggle */
+   NULL, /* get_current_shader */
+   NULL, /* get_current_software_framebuffer */
+   NULL, /* get_hw_render_interface */
+   NULL, /* set_hdr_max_nits */
+   NULL, /* set_hdr_paper_white_nits */
+   NULL, /* set_hdr_contrast */
+   NULL  /* set_hdr_expand_gamut */
 };
 
 static void network_gfx_get_poke_interface(void *data,
@@ -492,5 +496,8 @@ video_driver_t video_network = {
    NULL, /* overlay_interface */
 #endif
    network_gfx_get_poke_interface,
-   NULL /* wrap_type_to_enum */
+   NULL, /* wrap_type_to_enum */
+#ifdef HAVE_GFX_WIDGETS
+   NULL  /* gfx_widgets_enabled */
+#endif
 };

--- a/gfx/drivers/oga_gfx.c
+++ b/gfx/drivers/oga_gfx.c
@@ -737,27 +737,31 @@ static bool oga_get_current_software_framebuffer(void *data, struct retro_frameb
 }
 
 video_poke_interface_t oga_poke_interface = {
-   NULL,
-   NULL,
-   NULL,
-   NULL,
-   NULL,
-   NULL,
-   NULL,
-   NULL,
-   NULL,
-   NULL,
-   NULL,
-   NULL,
-   NULL,
+   NULL, /* get_flags */
+   NULL, /* load_texture */
+   NULL, /* unload_texture */
+   NULL, /* set_video_mode */
+   NULL, /* get_refresh_rate */
+   NULL, /* set_filtering */
+   NULL, /* get_video_output_size */
+   NULL, /* get_video_output_prev */
+   NULL, /* get_video_output_next */
+   NULL, /* get_current_framebuffer */
+   NULL, /* get_proc_address */
+   NULL, /* set_aspect_ratio */
+   NULL, /* apply_state_changes */
    oga_set_texture_frame,
    oga_texture_enable,
-   NULL,
-   NULL,
-   NULL,
-   NULL,
+   NULL, /* set_osd_msg */
+   NULL, /* show_mouse */
+   NULL, /* grab_mouse_toggle */
+   NULL, /* get_current_shader */
    oga_get_current_software_framebuffer,
-   NULL
+   NULL, /* get_hw_render_interface */
+   NULL, /* set_hdr_max_nits */
+   NULL, /* set_hdr_paper_white_nits */
+   NULL, /* set_hdr_contrast */
+   NULL  /* set_hdr_expand_gamut */
 };
 
 static void oga_get_poke_interface(void *data, const video_poke_interface_t **iface)
@@ -776,13 +780,17 @@ video_driver_t video_oga = {
    oga_set_shader,
    oga_free,
    "oga",
-   NULL,
+   NULL, /* set_viewport */
    oga_set_rotation,
    oga_viewport_info,
-   NULL,
-   NULL,
+   NULL, /* read_viewport */
+   NULL, /* read_frame_raw */
 #ifdef HAVE_OVERLAY
-   NULL,
+   NULL, /* get_overlay_interface */
 #endif
-   oga_get_poke_interface
+   oga_get_poke_interface,
+   NULL, /* wrap_type_to_enum */
+#ifdef HAVE_GFX_WIDGETS
+   NULL  /* gfx_widgets_enabled */
+#endif
 };

--- a/gfx/drivers/omap_gfx.c
+++ b/gfx/drivers/omap_gfx.c
@@ -1090,9 +1090,9 @@ static float omap_get_refresh_rate(void *data)
 
 static const video_poke_interface_t omap_poke_interface = {
    NULL, /* get_flags  */
-   NULL,
-   NULL,
-   NULL,
+   NULL, /* load_texture */
+   NULL, /* unload_texture */
+   NULL, /* set_video_mode */
    omap_get_refresh_rate,
    NULL, /* set_filtering */
    NULL, /* get_video_output_size */
@@ -1104,16 +1104,16 @@ static const video_poke_interface_t omap_poke_interface = {
    NULL, /* apply_state_changes */
    omap_set_texture_frame,
    omap_set_texture_enable,
-   NULL,
-   NULL,                         /* show_mouse */
-   NULL,                         /* grab_mouse_toggle */
-   NULL,                         /* get_current_shader */
-   NULL,                         /* get_current_software_framebuffer */
-   NULL,                         /* get_hw_render_interface */
-   NULL,                         /* set_hdr_max_nits */
-   NULL,                         /* set_hdr_paper_white_nits */
-   NULL,                         /* set_hdr_contrast */
-   NULL                          /* set_hdr_expand_gamut */
+   NULL, /* set_osd_msg */
+   NULL, /* show_mouse */
+   NULL, /* grab_mouse_toggle */
+   NULL, /* get_current_shader */
+   NULL, /* get_current_software_framebuffer */
+   NULL, /* get_hw_render_interface */
+   NULL, /* set_hdr_max_nits */
+   NULL, /* set_hdr_paper_white_nits */
+   NULL, /* set_hdr_contrast */
+   NULL  /* set_hdr_expand_gamut */
 };
 
 static void omap_get_poke_interface(void *data,
@@ -1138,9 +1138,12 @@ video_driver_t video_omap = {
    omap_viewport_info,
    NULL, /* read_viewport  */
    NULL, /* read_frame_raw */
-
 #ifdef HAVE_OVERLAY
-   NULL, /* overlay_interface */
+   NULL, /* get_overlay_interface */
 #endif
-   omap_get_poke_interface
+   omap_get_poke_interface,
+   NULL, /* wrap_type_to_enum */
+#ifdef HAVE_GFX_WIDGETS
+   NULL  /* gfx_widgets_enabled */
+#endif
 };

--- a/gfx/drivers/ps2_gfx.c
+++ b/gfx/drivers/ps2_gfx.c
@@ -1063,31 +1063,31 @@ static bool ps2_get_hw_render_interface(void *data,
 }
 
 static const video_poke_interface_t ps2_poke_interface = {
-    NULL, /* get_flags  */
-    NULL, /* load_texture */
-    NULL, /* unload_texture */
-    ps2_set_video_mode,
-    NULL, /* get_refresh_rate */
-    ps2_set_filtering,
-    ps2_get_video_output_size,
-    ps2_get_video_output_prev,
-    ps2_get_video_output_next,
-    NULL, /* get_current_framebuffer */
-    NULL, /* get_proc_address */
-    NULL, /* set_aspect_ratio */
-    NULL, /* apply_state_changes */
-    ps2_set_texture_frame,
-    ps2_set_texture_enable,
-    ps2_set_osd_msg,
-    NULL, /* show_mouse  */
-    NULL, /* grab_mouse_toggle */
-    NULL, /* get_current_shader */
-    NULL, /* get_current_software_framebuffer */
-    ps2_get_hw_render_interface,
-    NULL, /* set_hdr_max_nits */
-    NULL, /* set_hdr_paper_white_nits */
-    NULL, /* set_hdr_contrast */
-    NULL  /* set_hdr_expand_gamut */
+   NULL, /* get_flags  */
+   NULL, /* load_texture */
+   NULL, /* unload_texture */
+   ps2_set_video_mode,
+   NULL, /* get_refresh_rate */
+   ps2_set_filtering,
+   ps2_get_video_output_size,
+   ps2_get_video_output_prev,
+   ps2_get_video_output_next,
+   NULL, /* get_current_framebuffer */
+   NULL, /* get_proc_address */
+   NULL, /* set_aspect_ratio */
+   NULL, /* apply_state_changes */
+   ps2_set_texture_frame,
+   ps2_set_texture_enable,
+   ps2_set_osd_msg,
+   NULL, /* show_mouse  */
+   NULL, /* grab_mouse_toggle */
+   NULL, /* get_current_shader */
+   NULL, /* get_current_software_framebuffer */
+   ps2_get_hw_render_interface,
+   NULL, /* set_hdr_max_nits */
+   NULL, /* set_hdr_paper_white_nits */
+   NULL, /* set_hdr_contrast */
+   NULL  /* set_hdr_expand_gamut */
 };
 
 static void ps2_get_poke_interface(void *data,
@@ -1097,24 +1097,27 @@ static void ps2_get_poke_interface(void *data,
 }
 
 video_driver_t video_ps2 = {
-    ps2_init,
-    ps2_frame,
-    ps2_set_nonblock_state,
-    ps2_alive,
-    ps2_focus,
-    ps2_suppress_screensaver,
-    ps2_has_windowed,
-    ps2_set_shader,
-    ps2_free,
-    "ps2",
-    NULL, /* set_viewport */
-    NULL, /* set_rotation */
-    NULL, /* viewport_info */
-    NULL, /* read_viewport  */
-    NULL, /* read_frame_raw */
-
+   ps2_init,
+   ps2_frame,
+   ps2_set_nonblock_state,
+   ps2_alive,
+   ps2_focus,
+   ps2_suppress_screensaver,
+   ps2_has_windowed,
+   ps2_set_shader,
+   ps2_free,
+   "ps2",
+   NULL, /* set_viewport */
+   NULL, /* set_rotation */
+   NULL, /* viewport_info */
+   NULL, /* read_viewport  */
+   NULL, /* read_frame_raw */
 #ifdef HAVE_OVERLAY
-    NULL, /* overlay_interface */
+   NULL, /* overlay_interface */
 #endif
-    ps2_get_poke_interface,
+   ps2_get_poke_interface,
+   NULL, /* wrap_type_to_enum */
+#ifdef HAVE_GFX_WIDGETS
+   NULL  /* gfx_widgets_enabled */
+#endif
 };

--- a/gfx/drivers/psp1_gfx.c
+++ b/gfx/drivers/psp1_gfx.c
@@ -770,9 +770,9 @@ static uint32_t psp_get_flags(void *data)
 
 static const video_poke_interface_t psp_poke_interface = {
    psp_get_flags,
-   NULL,
-   NULL,
-   NULL,
+   NULL, /* load_texture */
+   NULL, /* unload_texture */
+   NULL, /* set_video_mode */
    NULL, /* get_refresh_rate */
    psp_set_filtering,
    NULL, /* get_video_output_size */
@@ -784,16 +784,16 @@ static const video_poke_interface_t psp_poke_interface = {
    psp_apply_state_changes,
    psp_set_texture_frame,
    psp_set_texture_enable,
-   NULL,                        /* set_osd_msg */
-   NULL,                        /* show_mouse  */
-   NULL,                        /* grab_mouse_toggle */
-   NULL,                        /* get_current_shader */
-   NULL,                        /* get_current_software_framebuffer */
-   NULL,                        /* get_hw_render_interface */
-   NULL,                        /* set_hdr_max_nits */
-   NULL,                        /* set_hdr_paper_white_nits */
-   NULL,                        /* set_hdr_contrast */
-   NULL                         /* set_hdr_expand_gamut */
+   NULL, /* set_osd_msg */
+   NULL, /* show_mouse  */
+   NULL, /* grab_mouse_toggle */
+   NULL, /* get_current_shader */
+   NULL, /* get_current_software_framebuffer */
+   NULL, /* get_hw_render_interface */
+   NULL, /* set_hdr_max_nits */
+   NULL, /* set_hdr_paper_white_nits */
+   NULL, /* set_hdr_contrast */
+   NULL  /* set_hdr_expand_gamut */
 };
 
 static void psp_get_poke_interface(void *data,
@@ -902,7 +902,11 @@ video_driver_t video_psp1 = {
    psp_read_viewport,
    NULL, /* read_frame_raw */
 #ifdef HAVE_OVERLAY
-   NULL,
+   NULL, /* get_overlay_interface */
 #endif
-   psp_get_poke_interface
+   psp_get_poke_interface,
+   NULL, /* wrap_type_to_enum */
+#ifdef HAVE_GFX_WIDGETS
+   NULL  /* gfx_widgets_enabled */
+#endif
 };

--- a/gfx/drivers/rsx_gfx.c
+++ b/gfx/drivers/rsx_gfx.c
@@ -2391,28 +2391,28 @@ static const video_poke_interface_t rsx_poke_interface = {
    rsx_get_flags,
    rsx_load_texture,
    rsx_unload_texture,
-   NULL,                                  /* set_video_mode   */
-   NULL,                                  /* get_refresh_rate */
+   NULL, /* set_video_mode */
+   NULL, /* get_refresh_rate */
    rsx_set_filtering,
-   NULL,                                  /* get_video_output_size */
-   NULL,                                  /* get_video_output_prev */
-   NULL,                                  /* get_video_output_next */
-   NULL,                                  /* get_current_framebuffer */
-   NULL,                                  /* get_proc_address */
+   NULL, /* get_video_output_size */
+   NULL, /* get_video_output_prev */
+   NULL, /* get_video_output_next */
+   NULL, /* get_current_framebuffer */
+   NULL, /* get_proc_address */
    rsx_set_aspect_ratio,
    rsx_apply_state_changes,
    rsx_set_texture_frame,
    rsx_set_texture_enable,
    font_driver_render_msg,
-   NULL,                                  /* show_mouse */
-   NULL,                                  /* grab_mouse_toggle */
-   NULL,                                  /* get_current_shader */
-   NULL,                                  /* get_current_software_framebuffer */
-   NULL,                                  /* get_hw_render_interface */
-   NULL,                                  /* set_hdr_max_nits */
-   NULL,                                  /* set_hdr_paper_white_nits */
-   NULL,                                  /* set_hdr_contrast */
-   NULL                                   /* set_hdr_expand_gamut */
+   NULL, /* show_mouse */
+   NULL, /* grab_mouse_toggle */
+   NULL, /* get_current_shader */
+   NULL, /* get_current_software_framebuffer */
+   NULL, /* get_hw_render_interface */
+   NULL, /* set_hdr_max_nits */
+   NULL, /* set_hdr_paper_white_nits */
+   NULL, /* set_hdr_contrast */
+   NULL  /* set_hdr_expand_gamut */
 };
 
 static void rsx_get_poke_interface(void* data,
@@ -2440,7 +2440,7 @@ video_driver_t video_gcm =
    rsx_set_viewport,
    rsx_set_rotation,
    rsx_viewport_info,
-   NULL, /* read_viewport  */
+   NULL, /* read_viewport */
    NULL, /* read_frame_raw */
 #ifdef HAVE_OVERLAY
    rsx_get_overlay_interface,

--- a/gfx/drivers/sdl2_gfx.c
+++ b/gfx/drivers/sdl2_gfx.c
@@ -678,9 +678,9 @@ static uint32_t sdl2_get_flags(void *data) { return 0; }
 
 static video_poke_interface_t sdl2_video_poke_interface = {
    sdl2_get_flags,
-   NULL,
-   NULL,
-   NULL,
+   NULL, /* load_texture */
+   NULL, /* unload_texture */
+   NULL, /* set_video_mode */
    NULL, /* get_refresh_rate */
    sdl2_poke_set_filtering,
    NULL, /* get_video_output_size */
@@ -695,9 +695,13 @@ static video_poke_interface_t sdl2_video_poke_interface = {
    sdl2_poke_set_osd_msg,
    sdl2_show_mouse,
    sdl2_grab_mouse_toggle,
-   NULL,                         /* get_current_shader */
-   NULL,                         /* get_current_software_framebuffer */
-   NULL                          /* get_hw_render_interface */
+   NULL, /* get_current_shader */
+   NULL, /* get_current_software_framebuffer */
+   NULL, /* get_hw_render_interface */
+   NULL, /* set_hdr_max_nits */
+   NULL, /* set_hdr_paper_white_nits */
+   NULL, /* set_hdr_contrast */
+   NULL, /* set_hdr_expand_gamut */
 };
 
 static void sdl2_gfx_poke_interface(void *data, const video_poke_interface_t **iface)
@@ -727,14 +731,17 @@ video_driver_t video_sdl2 = {
    sdl2_gfx_set_shader,
    sdl2_gfx_free,
    "sdl2",
-
-   NULL,
+   NULL, /* set_viewport */
    sdl2_gfx_set_rotation,
    sdl2_gfx_viewport_info,
    sdl2_gfx_read_viewport,
    NULL, /* read_frame_raw */
 #ifdef HAVE_OVERLAY
-    NULL,
+   NULL, /* get_overlay_interface */
 #endif
-    sdl2_gfx_poke_interface
+   sdl2_gfx_poke_interface,
+   NULL, /* wrap_type_to_enum */
+#ifdef HAVE_GFX_WIDGETS
+   NULL  /* gfx_widgets_enabled */
+#endif
 };

--- a/gfx/drivers/sdl_dingux_gfx.c
+++ b/gfx/drivers/sdl_dingux_gfx.c
@@ -1085,9 +1085,9 @@ static uint32_t sdl_dingux_get_flags(void *data)
 
 static const video_poke_interface_t sdl_dingux_poke_interface = {
    sdl_dingux_get_flags,
-   NULL,
-   NULL,
-   NULL,
+   NULL, /* load_texture */
+   NULL, /* unload_texture */
+   NULL, /* set_video_mode */
    sdl_dingux_get_refresh_rate,
    sdl_dingux_set_filtering,
    NULL, /* get_video_output_size */
@@ -1095,11 +1095,11 @@ static const video_poke_interface_t sdl_dingux_poke_interface = {
    NULL, /* get_video_output_next */
    NULL, /* get_current_framebuffer */
    NULL, /* get_proc_address */
-   NULL,
+   NULL, /* set_aspect_ratio */
    sdl_dingux_apply_state_changes,
    sdl_dingux_set_texture_frame,
    sdl_dingux_set_texture_enable,
-   NULL,
+   NULL, /* set_osd_msg */
    NULL, /* sdl_show_mouse */
    NULL, /* sdl_grab_mouse_toggle */
    NULL, /* get_current_shader */
@@ -1133,13 +1133,17 @@ video_driver_t video_sdl_dingux = {
    sdl_dingux_gfx_set_shader,
    sdl_dingux_gfx_free,
    "sdl_dingux",
-   NULL,
+   NULL, /* set_viewport */
    NULL, /* set_rotation */
    sdl_dingux_gfx_viewport_info,
    NULL, /* read_viewport  */
    NULL, /* read_frame_raw */
 #ifdef HAVE_OVERLAY
-   NULL,
+   NULL, /* get_overlay_interface */
 #endif
-   sdl_dingux_get_poke_interface
+   sdl_dingux_get_poke_interface,
+   NULL, /* wrap_type_to_enum */
+#ifdef HAVE_GFX_WIDGETS
+   NULL  /* gfx_widgets_enabled */
+#endif
 };

--- a/gfx/drivers/sdl_gfx.c
+++ b/gfx/drivers/sdl_gfx.c
@@ -527,9 +527,9 @@ static uint32_t sdl_get_flags(void *data)
 
 static const video_poke_interface_t sdl_poke_interface = {
    sdl_get_flags,
-   NULL,
-   NULL,
-   NULL,
+   NULL, /* load_texture */
+   NULL, /* unload_texture */
+   NULL, /* set_video_mode */
    NULL, /* get_refresh_rate */
    sdl_set_filtering,
    NULL, /* get_video_output_size */
@@ -537,20 +537,20 @@ static const video_poke_interface_t sdl_poke_interface = {
    NULL, /* get_video_output_next */
    NULL, /* get_current_framebuffer */
    NULL, /* get_proc_address */
-   NULL,
+   NULL, /* set_aspect_ratio */
    sdl_apply_state_changes,
    sdl_set_texture_frame,
    sdl_set_texture_enable,
-   NULL,
+   NULL, /* set_osd_msg */
    sdl_show_mouse,
    sdl_grab_mouse_toggle,
-   NULL,                         /* get_current_shader */
-   NULL,                         /* get_current_software_framebuffer */
-   NULL,                         /* get_hw_render_interface */
-   NULL,                         /* set_hdr_max_nits */
-   NULL,                         /* set_hdr_paper_white_nits */
-   NULL,                         /* set_hdr_contrast */
-   NULL                          /* set_hdr_expand_gamut */
+   NULL, /* get_current_shader */
+   NULL, /* get_current_software_framebuffer */
+   NULL, /* get_hw_render_interface */
+   NULL, /* set_hdr_max_nits */
+   NULL, /* set_hdr_paper_white_nits */
+   NULL, /* set_hdr_contrast */
+   NULL  /* set_hdr_expand_gamut */
 };
 
 static void sdl_get_poke_interface(void *data, const video_poke_interface_t **iface)
@@ -581,13 +581,17 @@ video_driver_t video_sdl = {
    sdl_gfx_set_shader,
    sdl_gfx_free,
    "sdl",
-   NULL,
+   NULL, /* set_viewport */
    NULL, /* set_rotation */
    sdl_gfx_viewport_info,
    NULL, /* read_viewport  */
    NULL, /* read_frame_raw */
 #ifdef HAVE_OVERLAY
-   NULL,
+   NULL, /* get_overlay_interface */
 #endif
-   sdl_get_poke_interface
+   sdl_get_poke_interface,
+   NULL, /* wrap_type_to_enum */
+#ifdef HAVE_GFX_WIDGETS
+   NULL  /* gfx_widgets_enabled */
+#endif
 };

--- a/gfx/drivers/sdl_rs90_gfx.c
+++ b/gfx/drivers/sdl_rs90_gfx.c
@@ -1387,9 +1387,9 @@ static uint32_t sdl_rs90_get_flags(void *data)
 
 static const video_poke_interface_t sdl_rs90_poke_interface = {
    sdl_rs90_get_flags,
-   NULL,
-   NULL,
-   NULL,
+   NULL, /* load_texture */
+   NULL, /* unload_texture */
+   NULL, /* set_video_mode */
    sdl_rs90_get_refresh_rate,
    sdl_rs90_set_filtering,
    NULL, /* get_video_output_size */
@@ -1397,13 +1397,13 @@ static const video_poke_interface_t sdl_rs90_poke_interface = {
    NULL, /* get_video_output_next */
    NULL, /* get_current_framebuffer */
    NULL, /* get_proc_address */
-   NULL,
+   NULL, /* set_aspect_ratio */
    sdl_rs90_apply_state_changes,
    sdl_rs90_set_texture_frame,
    sdl_rs90_set_texture_enable,
-   NULL,
-   NULL, /* sdl_show_mouse */
-   NULL, /* sdl_grab_mouse_toggle */
+   NULL, /* set_osd_msg */
+   NULL, /* show_mouse */
+   NULL, /* grab_mouse_toggle */
    NULL, /* get_current_shader */
    NULL, /* get_current_software_framebuffer */
    NULL, /* get_hw_render_interface */
@@ -1435,13 +1435,17 @@ video_driver_t video_sdl_rs90 = {
    sdl_rs90_gfx_set_shader,
    sdl_rs90_gfx_free,
    "sdl_rs90",
-   NULL,
+   NULL, /* set_viewport */
    NULL, /* set_rotation */
    sdl_rs90_gfx_viewport_info,
    NULL, /* read_viewport  */
    NULL, /* read_frame_raw */
 #ifdef HAVE_OVERLAY
-   NULL,
+   NULL, /* get_overlay_interface */
 #endif
-   sdl_rs90_get_poke_interface
+   sdl_rs90_get_poke_interface,
+   NULL, /* wrap_type_to_enum */
+#ifdef HAVE_GFX_WIDGETS
+   NULL  /* gfx_widgets_enabled */
+#endif
 };

--- a/gfx/drivers/sixel_gfx.c
+++ b/gfx/drivers/sixel_gfx.c
@@ -593,34 +593,34 @@ static void sixel_set_video_mode(void *data, unsigned width, unsigned height,
       bool fullscreen) { }
 
 static const video_poke_interface_t sixel_poke_interface = {
-   NULL,
-   NULL,
-   NULL,
+   NULL, /* get_flags */
+   NULL, /* load_texture */
+   NULL, /* unload_texture */
    sixel_set_video_mode,
-   NULL,
-   NULL,
+   NULL, /* get_refresh_rate */
+   NULL, /* set_filtering */
    sixel_get_video_output_size,
    sixel_get_video_output_prev,
    sixel_get_video_output_next,
-   NULL,
-   NULL,
-   NULL,
-   NULL,
-#if defined(HAVE_MENU)
+   NULL, /* get_current_framebuffer */
+   NULL, /* get_proc_address */
+   NULL, /* set_aspect_ratio */
+   NULL, /* apply_state_changes */
+#ifdef HAVE_MENU
    sixel_set_texture_frame,
-   NULL,
+   NULL, /* set_texture_enable */
    font_driver_render_msg,
-   NULL,
+   NULL, /* show_mouse */
 #else
-   NULL,
-   NULL,
-   NULL,
-   NULL,
+   NULL, /* set_texture_frame */
+   NULL, /* set_texture_enable */
+   NULL, /* set_osd_msg */
+   NULL, /* show_mouse */
 #endif
-   NULL,
-   NULL,
-   NULL,
-   NULL,
+   NULL, /* grab_mouse_toggle */
+   NULL, /* get_current_shader */
+   NULL, /* get_current_software_framebuffer */
+   NULL, /* get_hw_render_interface */
    NULL, /* set_hdr_max_nits */
    NULL, /* set_hdr_paper_white_nits */
    NULL, /* set_hdr_contrast */
@@ -661,8 +661,11 @@ video_driver_t video_sixel = {
    NULL, /* read_viewport */
    NULL, /* read_frame_raw */
 #ifdef HAVE_OVERLAY
-   NULL, /* overlay_interface */
+   NULL, /* get_overlay_interface */
 #endif
    sixel_gfx_get_poke_interface,
-   NULL /* wrap_type_to_enum */
+   NULL, /* wrap_type_to_enum */
+#ifdef HAVE_GFX_WIDGETS
+   NULL  /* gfx_widgets_enabled */
+#endif
 };

--- a/gfx/drivers/sunxi_gfx.c
+++ b/gfx/drivers/sunxi_gfx.c
@@ -904,8 +904,8 @@ static float sunxi_get_refresh_rate (void *data)
 
 static const video_poke_interface_t sunxi_poke_interface = {
    NULL, /* get_flags */
-   NULL,
-   NULL,
+   NULL, /* load_texture */
+   NULL, /* unload_texture */
    NULL, /* set_video_mode */
    NULL, /* get_refresh_rate */
    NULL, /* set_filtering */
@@ -918,16 +918,16 @@ static const video_poke_interface_t sunxi_poke_interface = {
    NULL, /* sunxi_apply_state_changes */
    sunxi_set_texture_frame,
    sunxi_set_texture_enable,
-   NULL,                         /* set_osd_msg */
-   NULL,                         /* show_mouse */
-   NULL,                         /* grab_mouse_toggle */
-   NULL,                         /* get_current_shader */
-   NULL,                         /* get_current_software_framebuffer */
-   NULL,                         /* get_hw_render_interface */
-   NULL,                         /* set_hdr_max_nits */
-   NULL,                         /* set_hdr_paper_white_nits */
-   NULL,                         /* set_hdr_contrast */
-   NULL                          /* set_hdr_expand_gamut */
+   NULL, /* set_osd_msg */
+   NULL, /* show_mouse */
+   NULL, /* grab_mouse_toggle */
+   NULL, /* get_current_shader */
+   NULL, /* get_current_software_framebuffer */
+   NULL, /* get_hw_render_interface */
+   NULL, /* set_hdr_max_nits */
+   NULL, /* set_hdr_paper_white_nits */
+   NULL, /* set_hdr_contrast */
+   NULL  /* set_hdr_expand_gamut */
 };
 
 static void sunxi_get_poke_interface(void *data,
@@ -937,24 +937,27 @@ static void sunxi_get_poke_interface(void *data,
 }
 
 video_driver_t video_sunxi = {
-  sunxi_init,
-  sunxi_frame,
-  sunxi_set_nonblock_state,
-  sunxi_alive,
-  sunxi_focus,
-  sunxi_suppress_screensaver,
-  NULL, /* has_windowed */
-  sunxi_set_shader,
-  sunxi_free,
-  "sunxi",
-  NULL, /* set_viewport */
-  NULL, /* set_rotation */
-  sunxi_viewport_info,
-  NULL, /* read_viewport */
-  NULL, /* read_frame_raw */
-
+   sunxi_init,
+   sunxi_frame,
+   sunxi_set_nonblock_state,
+   sunxi_alive,
+   sunxi_focus,
+   sunxi_suppress_screensaver,
+   NULL, /* has_windowed */
+   sunxi_set_shader,
+   sunxi_free,
+   "sunxi",
+   NULL, /* set_viewport */
+   NULL, /* set_rotation */
+   sunxi_viewport_info,
+   NULL, /* read_viewport */
+   NULL, /* read_frame_raw */
 #ifdef HAVE_OVERLAY
-  NULL, /* overlay_interface */
+   NULL, /* get_overlay_interface */
 #endif
-  sunxi_get_poke_interface
+   sunxi_get_poke_interface,
+   NULL, /* wrap_type_to_enum */
+#ifdef HAVE_GFX_WIDGETS
+   NULL  /* gfx_widgets_enabled */
+#endif
 };

--- a/gfx/drivers/switch_nx_gfx.c
+++ b/gfx/drivers/switch_nx_gfx.c
@@ -968,7 +968,7 @@ static const video_overlay_interface_t switch_overlay = {
     switch_overlay_set_alpha,
 };
 
-void switch_overlay_interface(void *data, const video_overlay_interface_t **iface)
+static void switch_get_overlay_interface(void *data, const video_overlay_interface_t **iface)
 {
     switch_video_t *swa = (switch_video_t *)data;
     if (!swa)
@@ -979,31 +979,31 @@ void switch_overlay_interface(void *data, const video_overlay_interface_t **ifac
 #endif
 
 static const video_poke_interface_t switch_poke_interface = {
-    NULL,                       /* get_flags */
-    NULL,                       /* load_texture */
-    NULL,                       /* unload_texture */
-    NULL,                       /* set_video_mode */
-    NULL,                       /* get_refresh_rate */
-    NULL,                       /* set_filtering */
-    NULL,                       /* get_video_output_size */
-    NULL,                       /* get_video_output_prev */
-    NULL,                       /* get_video_output_next */
-    NULL,                       /* get_current_framebuffer */
-    NULL,                       /* get_proc_address */
-    switch_set_aspect_ratio,    /* set_aspect_ratio */
-    switch_apply_state_changes, /* apply_state_changes */
-    switch_set_texture_frame,
-    switch_set_texture_enable,
-    font_driver_render_msg,
-    NULL, /* show_mouse */
-    NULL, /* grab_mouse_toggle */
-    NULL, /* get_current_shader */
-    NULL, /* get_current_software_framebuffer */
-    NULL, /* get_hw_render_interface */
-    NULL, /* set_hdr_max_nits */
-    NULL, /* set_hdr_paper_white_nits */
-    NULL, /* set_hdr_contrast */
-    NULL  /* set_hdr_expand_gamut */
+   NULL, /* get_flags */
+   NULL, /* load_texture */
+   NULL, /* unload_texture */
+   NULL, /* set_video_mode */
+   NULL, /* get_refresh_rate */
+   NULL, /* set_filtering */
+   NULL, /* get_video_output_size */
+   NULL, /* get_video_output_prev */
+   NULL, /* get_video_output_next */
+   NULL, /* get_current_framebuffer */
+   NULL, /* get_proc_address */
+   switch_set_aspect_ratio,
+   switch_apply_state_changes,
+   switch_set_texture_frame,
+   switch_set_texture_enable,
+   font_driver_render_msg,
+   NULL, /* show_mouse */
+   NULL, /* grab_mouse_toggle */
+   NULL, /* get_current_shader */
+   NULL, /* get_current_software_framebuffer */
+   NULL, /* get_hw_render_interface */
+   NULL, /* set_hdr_max_nits */
+   NULL, /* set_hdr_paper_white_nits */
+   NULL, /* set_hdr_contrast */
+   NULL  /* set_hdr_expand_gamut */
 };
 
 static void switch_get_poke_interface(void *data,
@@ -1014,25 +1014,29 @@ static void switch_get_poke_interface(void *data,
 }
 
 video_driver_t video_switch = {
-    switch_init,
-    switch_frame,
-    switch_set_nonblock_state,
-    switch_alive,
-    switch_focus,
-    switch_suppress_screensaver,
-    switch_has_windowed,
-    switch_set_shader,
-    switch_free,
-    "switch",
-    NULL, /* set_viewport */
-    switch_set_rotation,
-    switch_viewport_info,
-    NULL, /* read_viewport  */
-    NULL, /* read_frame_raw */
+   switch_init,
+   switch_frame,
+   switch_set_nonblock_state,
+   switch_alive,
+   switch_focus,
+   switch_suppress_screensaver,
+   switch_has_windowed,
+   switch_set_shader,
+   switch_free,
+   "switch",
+   NULL, /* set_viewport */
+   switch_set_rotation,
+   switch_viewport_info,
+   NULL, /* read_viewport  */
+   NULL, /* read_frame_raw */
 #ifdef HAVE_OVERLAY
-    switch_overlay_interface, /* switch_overlay_interface */
+   switch_get_overlay_interface,
 #endif
-    switch_get_poke_interface,
+   switch_get_poke_interface,
+   NULL, /* wrap_type_to_enum */
+#ifdef HAVE_GFX_WIDGETS
+   NULL  /* gfx_widgets_enabled */
+#endif
 };
 
 /* vim: set ts=3 sw=3 */

--- a/gfx/drivers/vg.c
+++ b/gfx/drivers/vg.c
@@ -516,13 +516,17 @@ video_driver_t video_vg = {
    vg_set_shader,
    vg_free,
    "vg",
-   NULL,                      /* set_viewport */
-   NULL,                      /* set_rotation */
-   NULL,                      /* viewport_info */
-   NULL,                      /* read_viewport */
-   NULL,                      /* read_frame_raw */
+   NULL, /* set_viewport */
+   NULL, /* set_rotation */
+   NULL, /* viewport_info */
+   NULL, /* read_viewport */
+   NULL, /* read_frame_raw */
 #ifdef HAVE_OVERLAY
-  NULL,                       /* overlay_interface */
+   NULL, /* get_overlay_interface */
 #endif
-  vg_get_poke_interface
+   vg_get_poke_interface,
+   NULL, /* wrap_type_to_enum */
+#ifdef HAVE_GFX_WIDGETS
+   NULL  /* gfx_widgets_enabled */
+#endif
 };

--- a/gfx/drivers/vga_gfx.c
+++ b/gfx/drivers/vga_gfx.c
@@ -441,30 +441,30 @@ static uint32_t vga_get_flags(void *data) { return 0; }
 
 static const video_poke_interface_t vga_poke_interface = {
    vga_get_flags,
-   NULL,
-   NULL,
-   NULL,
-   NULL,
-   NULL,
-   NULL,
-   NULL,
-   NULL,
-   NULL,
-   NULL,
-   NULL,
-   NULL,
+   NULL, /* load_texture */
+   NULL, /* unload_texture */
+   NULL, /* set_video_mode */
+   NULL, /* get_refresh_rate */
+   NULL, /* set_filtering */
+   NULL, /* get_video_output_size */
+   NULL, /* get_video_output_prev */
+   NULL, /* get_video_output_next */
+   NULL, /* get_current_framebuffer */
+   NULL, /* get_proc_address */
+   NULL, /* set_aspect_ratio */
+   NULL, /* apply_state_changes */
    vga_set_texture_frame,
-   NULL,
+   NULL, /* set_texture_enable */
    font_driver_render_msg,
-   NULL,                   /* show_mouse */
-   NULL,                   /* grab_mouse_toggle */
-   NULL,                   /* get_current_shader */
-   NULL,                   /* get_current_software_framebuffer */
-   NULL,                   /* get_hw_render_interface */
-   NULL,                   /* set_hdr_max_nits */
-   NULL,                   /* set_hdr_paper_white_nits */
-   NULL,                   /* set_hdr_contrast */
-   NULL                    /* set_hdr_expand_gamut */
+   NULL, /* show_mouse */
+   NULL, /* grab_mouse_toggle */
+   NULL, /* get_current_shader */
+   NULL, /* get_current_software_framebuffer */
+   NULL, /* get_hw_render_interface */
+   NULL, /* set_hdr_max_nits */
+   NULL, /* set_hdr_paper_white_nits */
+   NULL, /* set_hdr_contrast */
+   NULL  /* set_hdr_expand_gamut */
 };
 
 static void vga_gfx_get_poke_interface(void *data,
@@ -488,9 +488,12 @@ video_driver_t video_vga = {
    NULL, /* viewport_info */
    NULL, /* read_viewport */
    NULL, /* read_frame_raw */
-
 #ifdef HAVE_OVERLAY
-  NULL, /* overlay_interface */
+   NULL, /* get_overlay_interface */
 #endif
-  vga_gfx_get_poke_interface,
+   vga_gfx_get_poke_interface,
+   NULL, /* wrap_type_to_enum */
+#ifdef HAVE_GFX_WIDGETS
+   NULL  /* gfx_widgets_enabled */
+#endif
 };

--- a/gfx/drivers/vita2d_gfx.c
+++ b/gfx/drivers/vita2d_gfx.c
@@ -1247,7 +1247,7 @@ static const video_poke_interface_t vita_poke_interface = {
    vita2d_get_flags,
    vita2d_load_texture,
    vita2d_unload_texture,
-   NULL,
+   NULL, /* set_video_mode */
    NULL, /* get_refresh_rate */
    vita2d_set_filtering,
    NULL, /* get_video_output_size */
@@ -1260,11 +1260,11 @@ static const video_poke_interface_t vita_poke_interface = {
    vita2d_set_texture_frame,
    vita2d_set_texture_enable,
    font_driver_render_msg,
-   NULL,
-   NULL,
-   NULL,
+   NULL, /* show_mouse */
+   NULL, /* grab_mouse_toggle */
+   NULL, /* get_current_shader */
    vita2d_get_current_sw_framebuffer,
-   NULL,
+   NULL, /* get_hw_render_interface */
    NULL, /* set_hdr_max_nits */
    NULL, /* set_hdr_paper_white_nits */
    NULL, /* set_hdr_contrast */
@@ -1440,7 +1440,7 @@ video_driver_t video_vita2d = {
    vita2d_get_overlay_interface,
 #endif
    vita2d_get_poke_interface,
-   NULL,
+   NULL, /* wrap_type_to_enum */
 #ifdef HAVE_GFX_WIDGETS
    vita2d_widgets_enabled
 #endif

--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -5177,20 +5177,20 @@ static const video_poke_interface_t vulkan_poke_interface = {
    vulkan_load_texture,
    vulkan_unload_texture,
    vulkan_set_video_mode,
-   vulkan_get_refresh_rate,            /* get_refresh_rate */
-   NULL,                               /* set_filtering */
+   vulkan_get_refresh_rate,
+   NULL, /* set_filtering */
    vulkan_get_video_output_size,
    vulkan_get_video_output_prev,
    vulkan_get_video_output_next,
-   NULL,                               /* get_current_framebuffer */
-   NULL,                               /* get_proc_address */
+   NULL, /* get_current_framebuffer */
+   NULL, /* get_proc_address */
    vulkan_set_aspect_ratio,
    vulkan_apply_state_changes,
    vulkan_set_texture_frame,
    vulkan_set_texture_enable,
    font_driver_render_msg,
    vulkan_show_mouse,
-   NULL,                               /* grab_mouse_toggle */
+   NULL, /* grab_mouse_toggle */
    vulkan_get_current_shader,
    vulkan_get_current_sw_framebuffer,
    vulkan_get_hw_render_interface,
@@ -5621,13 +5621,12 @@ video_driver_t video_vulkan = {
    vulkan_set_rotation,
    vulkan_viewport_info,
    vulkan_read_viewport,
-   NULL,                         /* vulkan_read_frame_raw */
-
+   NULL, /* read_frame_raw */
 #ifdef HAVE_OVERLAY
    vulkan_get_overlay_interface,
 #endif
    vulkan_get_poke_interface,
-   NULL,                         /* vulkan_wrap_type_to_enum */
+   NULL, /* wrap_type_to_enum */
 #ifdef HAVE_GFX_WIDGETS
    vulkan_gfx_widgets_enabled
 #endif

--- a/gfx/drivers/xenon360_gfx.c
+++ b/gfx/drivers/xenon360_gfx.c
@@ -287,9 +287,11 @@ video_driver_t video_xenon360 = {
    NULL, /* viewport_info */
    NULL, /* read_viewport */
    NULL, /* read_frame_raw */
-
 #ifdef HAVE_OVERLAY
-   NULL, /* overlay_interface */
+   NULL, /* get_overlay_interface */
 #endif
-   xenon360_get_poke_interface
+   xenon360_get_poke_interface,
+#ifdef HAVE_GFX_WIDGETS
+   NULL  /* gfx_widgets_enabled */
+#endif
 };

--- a/gfx/drivers/xshm_gfx.c
+++ b/gfx/drivers/xshm_gfx.c
@@ -184,13 +184,13 @@ static void xshm_grab_mouse_toggle(void *data) { }
 
 static video_poke_interface_t xshm_video_poke_interface = {
    NULL, /* get_flags */
-   NULL,
-   NULL,
-   NULL,
+   NULL, /* load_texture */
+   NULL, /* unload_texture */
+   NULL, /* set_video_mode */
 #ifdef HAVE_XF86VM
    x11_get_refresh_rate,
 #else
-   NULL,
+   NULL, /* get_refresh_rate */
 #endif
    xshm_poke_set_filtering,
    NULL, /* get_video_output_size */
@@ -205,12 +205,20 @@ static video_poke_interface_t xshm_video_poke_interface = {
    xshm_poke_set_osd_msg,
    xshm_show_mouse,
    xshm_grab_mouse_toggle,
-   NULL,                   /* get_current_shader */
-   NULL,                   /* get_current_software_framebuffer */
-   NULL                    /* get_hw_render_interface */
+   NULL, /* get_current_shader */
+   NULL, /* get_current_software_framebuffer */
+   NULL, /* get_hw_render_interface */
+   NULL, /* set_hdr_max_nits */
+   NULL, /* set_hdr_paper_white_nits */
+   NULL, /* set_hdr_contrast */
+   NULL  /* set_hdr_expand_gamut */
 };
 
-static void xshm_poke_interface(void *data, const video_poke_interface_t **iface) { *iface = &xshm_video_poke_interface; }
+static void xshm_get_poke_interface(void *data,
+      const video_poke_interface_t **iface)
+{
+   *iface = &xshm_video_poke_interface;
+}
 static bool xshm_set_shader(void *data,
       enum rarch_shader_type type, const char *path) { return false; }
 
@@ -225,14 +233,17 @@ video_driver_t video_xshm = {
    xshm_set_shader,
    xshm_free,
    "x11",
-
-   NULL,
+   NULL, /* set_viewport */
    NULL, /* set_rotation */
    NULL, /* viewport_info */
    NULL, /* read_viewport */
    NULL, /* read_frame_raw */
 #ifdef HAVE_OVERLAY
-    NULL,
+   NULL, /* get_overlay_interface */
 #endif
-    xshm_poke_interface
+   xshm_get_poke_interface,
+   NULL, /* wrap_type_to_enum */
+#ifdef HAVE_GFX_WIDGETS
+   NULL  /* gfx_widgets_enabled */
+#endif
 };

--- a/gfx/drivers/xvideo.c
+++ b/gfx/drivers/xvideo.c
@@ -1152,7 +1152,11 @@ static video_poke_interface_t xv_video_poke_interface = {
    NULL, /* grab_mouse_toggle */
    NULL, /* get_current_shader */
    NULL, /* get_current_software_framebuffer */
-   NULL  /* get_hw_render_interface */
+   NULL, /* get_hw_render_interface */
+   NULL, /* set_hdr_max_nits */
+   NULL, /* set_hdr_paper_white_nits */
+   NULL, /* set_hdr_contrast */
+   NULL  /* set_hdr_expand_gamut */
 };
 
 static void xv_get_poke_interface(void *data,
@@ -1189,7 +1193,11 @@ video_driver_t video_xvideo = {
    NULL, /* read_viewport */
    NULL, /* read_frame_raw */
 #ifdef HAVE_OVERLAY
-  NULL, /* overlay_interface */
+   NULL, /* get_overlay_interface */
 #endif
-  xv_get_poke_interface
+   xv_get_poke_interface,
+   NULL, /* wrap_type_to_enum */
+#ifdef HAVE_GFX_WIDGETS
+   NULL  /* gfx_widgets_enabled */
+#endif
 };


### PR DESCRIPTION
## Description
Some cleanups on gfx driver interface structs: missing entries added, unused/unimplemented entries annotated with their preferred function names. This is pure maintenance work, users shouldn't be affected at all. The only significant change is in the fpga gfx driver: its poke struct was skewered for some reason.