### PR TITLE
Microphone menu correction

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -7228,7 +7228,7 @@ unsigned menu_displaylist_build_list(
             count++;
          if (MENU_DISPLAYLIST_PARSE_SETTINGS_ENUM(list,
                   MENU_ENUM_LABEL_MICROPHONE_WASAPI_SH_BUFFER_LENGTH,
-                  PARSE_ONLY_INT, false) == 0)
+                  PARSE_ONLY_UINT, false) == 0)
             count++;
          break;
 #endif


### PR DESCRIPTION
## Description

Accidentally set this to wrong type, since output variant is of that type, causing the item to not show.
