### PR TITLE
Frame limiting improvements

### DIFF
--- a/audio/audio_driver.c
+++ b/audio/audio_driver.c
@@ -797,10 +797,8 @@ bool audio_driver_init_internal(
 #endif
 
    /* Threaded driver is initially stopped. */
-   if (
-            (audio_driver_st.flags & AUDIO_FLAG_ACTIVE)
-         &&  audio_cb_inited
-         )
+   if (     (audio_driver_st.flags & AUDIO_FLAG_ACTIVE)
+         &&  audio_cb_inited)
       audio_driver_start(false);
 
    return true;
@@ -1444,7 +1442,8 @@ void audio_driver_load_system_sounds(void)
       task_push_audio_mixer_load(path_ok, NULL, NULL, true, AUDIO_MIXER_SLOT_SELECTION_MANUAL, AUDIO_MIXER_SYSTEM_SLOT_OK);
    if (path_cancel && audio_enable_menu_cancel)
       task_push_audio_mixer_load(path_cancel, NULL, NULL, true, AUDIO_MIXER_SLOT_SELECTION_MANUAL, AUDIO_MIXER_SYSTEM_SLOT_CANCEL);
-   if (audio_enable_menu_notice) {
+   if (audio_enable_menu_notice)
+   {
       if (path_notice)
          task_push_audio_mixer_load(path_notice, NULL, NULL, true, AUDIO_MIXER_SLOT_SELECTION_MANUAL, AUDIO_MIXER_SYSTEM_SLOT_NOTICE);
       if (path_notice_back)
@@ -1882,11 +1881,10 @@ void audio_driver_menu_sample(void)
    struct retro_system_av_info *av_info   = &video_st->av_info;
    const struct retro_system_timing *info =
       (const struct retro_system_timing*)&av_info->timing;
-   unsigned sample_count                  = (info->sample_rate / info->fps) * 2;
+   unsigned sample_count                  = floor(info->sample_rate / info->fps) * 2;
    audio_driver_state_t *audio_st         = &audio_driver_st;
    bool check_flush                       = !(
-             (runloop_flags & RUNLOOP_FLAG_PAUSED)
-         || !(audio_st->flags & AUDIO_FLAG_ACTIVE)
+            !(audio_st->flags & AUDIO_FLAG_ACTIVE)
          || !audio_st->output_samples_buf);
    if ((audio_st->flags & AUDIO_FLAG_SUSPENDED))
       check_flush                         = false;

--- a/audio/audio_driver.h
+++ b/audio/audio_driver.h
@@ -181,7 +181,7 @@ typedef struct
     * up to (but excluding) the point where it's converted to 16-bit audio
     * to give to the driver.
     */
-   float  *output_samples_buf;
+   float *output_samples_buf;
    size_t output_samples_buf_length;
 #ifdef HAVE_REWIND
    int16_t *rewind_buf;
@@ -229,8 +229,7 @@ typedef struct
    size_t buffer_size;
    size_t data_ptr;
 
-   unsigned free_samples_buf[
-      AUDIO_BUFFER_FREE_SAMPLES_COUNT];
+   unsigned free_samples_buf[AUDIO_BUFFER_FREE_SAMPLES_COUNT];
 
 #ifdef HAVE_AUDIOMIXER
    float mixer_volume_gain;
@@ -252,7 +251,7 @@ typedef struct
 #endif
 
    /* Sample the flush delta-time when fast forwarding to find the correct
-   ressample ratio. */
+   resample ratio. */
    retro_time_t last_flush_time;
    /* Exponential moving average */
    retro_time_t avg_flush_delta;

--- a/gfx/video_driver.h
+++ b/gfx/video_driver.h
@@ -776,7 +776,6 @@ typedef struct
 #endif
    struct retro_system_av_info av_info; /* double alignment */
    retro_time_t frame_time_samples[MEASURE_FRAME_TIME_SAMPLES_COUNT];
-   retro_time_t core_frame_time;
    uint64_t frame_time_count;
    uint64_t frame_count;
    uint8_t *record_gpu_buffer;
@@ -868,6 +867,7 @@ typedef struct
    uint8_t frame_delay_effective;
    bool frame_delay_pause;
 
+   bool frame_discard;
    bool threaded;
 } video_driver_state_t;
 

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -42,6 +42,7 @@
 #endif
 
 #include "../audio/audio_driver.h"
+#include "../midi_driver.h"
 
 #include "menu_driver.h"
 #include "menu_cbs.h"
@@ -5077,16 +5078,15 @@ unsigned menu_event(
    input_driver_state_t *input_st                  = input_state_get_ptr();
    input_driver_t *current_input                   = input_st->current_driver;
    const input_device_driver_t
-      *joypad                                      = input_st->primary_joypad;
+         *joypad                                   = input_st->primary_joypad;
 #ifdef HAVE_MFI
-   const input_device_driver_t *sec_joypad         =
-      input_st->secondary_joypad;
+   const input_device_driver_t *sec_joypad         = input_st->secondary_joypad;
 #else
    const input_device_driver_t *sec_joypad         = NULL;
 #endif
    gfx_display_t *p_disp                           = disp_get_ptr();
    menu_input_pointer_hw_state_t *pointer_hw_state = &menu_st->input_pointer_hw_state;
-   menu_handle_t             *menu                 = menu_st->driver_data;
+   menu_handle_t *menu                             = menu_st->driver_data;
    bool keyboard_mapping_blocked                   = input_st->flags & INP_FLAG_KB_MAPPING_BLOCKED;
    bool menu_mouse_enable                          = settings->bools.menu_mouse_enable;
    bool menu_pointer_enable                        = settings->bools.menu_pointer_enable;
@@ -5095,13 +5095,12 @@ unsigned menu_event(
    bool menu_scroll_fast                           = settings->bools.menu_scroll_fast;
    bool pointer_enabled                            = settings->bools.menu_pointer_enable;
    unsigned input_touch_scale                      = settings->uints.input_touch_scale;
-   unsigned menu_scroll_delay                      =
-      settings->uints.menu_scroll_delay;
+   unsigned menu_scroll_delay                      = settings->uints.menu_scroll_delay;
 #ifdef HAVE_OVERLAY
    bool input_overlay_enable                       = settings->bools.input_overlay_enable;
    bool overlay_active                             = input_overlay_enable 
-      && (input_st->overlay_ptr)
-      && (input_st->overlay_ptr->flags & INPUT_OVERLAY_ALIVE);
+         && (input_st->overlay_ptr)
+         && (input_st->overlay_ptr->flags & INPUT_OVERLAY_ALIVE);
 #else
    bool input_overlay_enable                       = false;
    bool overlay_active                             = false;
@@ -5269,11 +5268,11 @@ unsigned menu_event(
           * for old_input_state. */
 
          first_held                 = true;
+         delay_count                = 0;
          if (initial_held)
             delay_timer             = menu_scroll_delay;
          else
-            delay_timer             = menu_scroll_fast ? 100 : 20;
-         delay_count                = 0;
+            delay_timer             = menu_scroll_delay / 8;
       }
 
       if (delay_count >= delay_timer)
@@ -5288,25 +5287,25 @@ unsigned menu_event(
          new_scroll_accel           = menu_st->scroll.acceleration;
 
          if (menu_scroll_fast)
-            new_scroll_accel        = MIN(new_scroll_accel + 1, 64);
+            new_scroll_accel        = MIN(new_scroll_accel + 1, 20);
          else
             new_scroll_accel        = MIN(new_scroll_accel + 1, 5);
       }
 
       initial_held                  = false;
+      delay_count                  += anim_get_ptr()->delta_time;
    }
    else
    {
       set_scroll                    = true;
       first_held                    = false;
       initial_held                  = true;
+      delay_count                   = 0;
       navigation_initial            = 0;
    }
 
    if (set_scroll)
       menu_st->scroll.acceleration  = (unsigned)(new_scroll_accel);
-
-   delay_count                     += anim_get_ptr()->delta_time;
 
    if (display_kb)
    {
@@ -6101,7 +6100,6 @@ void menu_driver_toggle(
     */
    video_driver_t *current_video      = (video_driver_t*)curr_video_data;
    bool pause_libretro                = false;
-   bool audio_enable_menu             = false;
    runloop_state_t *runloop_st        = runloop_state_get_ptr();
    struct menu_state *menu_st         = &menu_driver_state;
    bool runloop_shutdown_initiated    = runloop_st->flags &
@@ -6119,9 +6117,6 @@ void menu_driver_toggle(
          netplay_driver_ctl(RARCH_NETPLAY_CTL_ALLOW_PAUSE, NULL);
 #else
       pause_libretro                  = settings->bools.menu_pause_libretro;
-#endif
-#ifdef HAVE_AUDIOMIXER
-      audio_enable_menu               = settings->bools.audio_enable_menu;
 #endif
 #ifdef HAVE_OVERLAY
       input_overlay_hide_in_menu      = settings->bools.input_overlay_hide_in_menu;
@@ -6177,27 +6172,34 @@ void menu_driver_toggle(
 
       menu_st->flags |= MENU_ST_FLAG_ENTRIES_NEED_REFRESH;
 
-      /* Menu should always run with vsync on and
-       * a video swap interval of 1 */
-      if (current_video->set_nonblock_state)
+      /* Enforce menu vsync accordingly. */
+      if (     settings->bools.menu_throttle_framerate
+            && current_video->set_nonblock_state)
          current_video->set_nonblock_state(
                video_driver_data,
                false,
-               video_driver_test_all_flags(GFX_CTX_FLAGS_ADAPTIVE_VSYNC) &&
-               video_adaptive_vsync,
-               1
-               );
+               video_driver_test_all_flags(GFX_CTX_FLAGS_ADAPTIVE_VSYNC) && video_adaptive_vsync,
+               1);
+
       /* Stop all rumbling before entering the menu. */
       command_event(CMD_EVENT_RUMBLE_STOP, NULL);
 
+      /* Always disable FF & SM when entering menu. */
+      input_state_get_ptr()->flags &= ~INP_FLAG_NONBLOCKING;
+      runloop_st->flags            &= ~RUNLOOP_FLAG_FASTMOTION;
+      runloop_st->flags            &= ~RUNLOOP_FLAG_SLOWMOTION;
+#if defined(HAVE_GFX_WIDGETS)
+      video_state_get_ptr()->flags &= ~VIDEO_FLAG_WIDGETS_FAST_FORWARD;
+      video_state_get_ptr()->flags &= ~VIDEO_FLAG_WIDGETS_REWINDING;
+#endif
+      driver_set_nonblock_state();
+
       if (pause_libretro)
-      { /* If the menu pauses the game... */
+      {
+         midi_driver_set_all_sounds_off();
 #ifdef HAVE_MICROPHONE
          command_event(CMD_EVENT_MICROPHONE_STOP, NULL);
 #endif
-
-         if (!audio_enable_menu) /* If the menu shouldn't have audio... */
-            command_event(CMD_EVENT_AUDIO_STOP, NULL);
       }
 
       /* Override keyboard callback to redirect to menu instead.
@@ -6224,15 +6226,9 @@ void menu_driver_toggle(
          driver_set_nonblock_state();
 
       if (pause_libretro)
-      { /* If the menu pauses the game... */
-
-         if (!audio_enable_menu) /* ...and the menu doesn't have audio... */
-            command_event(CMD_EVENT_AUDIO_START, NULL);
-            /* ...then re-enable the audio driver (which we shut off earlier) */
-
+      {
 #ifdef HAVE_MICROPHONE
          command_event(CMD_EVENT_MICROPHONE_START, NULL);
-         /* Start the microphone, if it was paused beforehand */
 #endif
       }
 

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -8291,6 +8291,7 @@ static void general_write_handler(rarch_setting_t *setting)
 #ifdef HAVE_AUDIOMIXER
          if (settings->bools.audio_enable_menu)
          {
+            audio_driver_load_system_sounds();
             if (settings->bools.audio_enable_menu_bgm)
                audio_driver_mixer_play_menu_sound_looped(AUDIO_MIXER_SYSTEM_SLOT_BGM);
             else
@@ -15398,6 +15399,7 @@ static bool setting_append_list(
                general_read_handler,
                SD_FLAG_ADVANCED
                );
+         MENU_SETTINGS_LIST_CURRENT_ADD_CMD(list, list_info, CMD_EVENT_REINIT);
 
          END_SUB_GROUP(list, list_info, parent_group);
          END_GROUP(list, list_info, parent_group);
@@ -16626,7 +16628,6 @@ static bool setting_append_list(
                SD_FLAG_CMD_APPLY_AUTO
                );
          MENU_SETTINGS_LIST_CURRENT_ADD_CMD(list, list_info, CMD_EVENT_MENU_PAUSE_LIBRETRO);
-            SETTINGS_DATA_LIST_CURRENT_ADD_FLAGS(list, list_info, SD_FLAG_LAKKA_ADVANCED);
 
          CONFIG_BOOL(
                list, list_info,

--- a/runloop.c
+++ b/runloop.c
@@ -2674,9 +2674,6 @@ bool runloop_environment_cb(unsigned cmd, void *data)
                   (*info)->timing.sample_rate);
 
             memcpy(av_info, *info, sizeof(*av_info));
-            video_st->core_frame_time = 1000000 /
-                  ((video_st->av_info.timing.fps > 0.0) ?
-                        video_st->av_info.timing.fps : 60.0);
 
             command_event(CMD_EVENT_REINIT, &reinit_flags);
 
@@ -4507,13 +4504,9 @@ static bool runloop_event_load_core(runloop_state_t *runloop_st,
 
    if (!core_verify_api_version(runloop_st))
       return false;
+
    core_init_libretro_cbs(runloop_st, &runloop_st->retro_ctx);
-
    runloop_st->current_core.retro_get_system_av_info(&video_st->av_info);
-   video_st->core_frame_time = 1000000 /
-         ((video_st->av_info.timing.fps > 0.0) ?
-               video_st->av_info.timing.fps : 60.0);
-
    return true;
 }
 
@@ -4692,11 +4685,11 @@ void runloop_pause_checks(void)
 #ifdef HAVE_PRESENCE
    presence_userdata_t userdata;
 #endif
+   video_driver_state_t *video_st = video_state_get_ptr();
    runloop_state_t *runloop_st    = &runloop_state;
    bool is_paused                 = runloop_st->flags & RUNLOOP_FLAG_PAUSED;
    bool is_idle                   = runloop_st->flags & RUNLOOP_FLAG_IDLE;
 #if defined(HAVE_GFX_WIDGETS)
-   video_driver_state_t *video_st = video_state_get_ptr();
    dispgfx_widget_t *p_dispwidget = dispwidget_get_ptr();
    bool widgets_active            = p_dispwidget->active;
    if (widgets_active)
@@ -4719,6 +4712,8 @@ void runloop_pause_checks(void)
 
       if (!is_idle)
          video_driver_cached_frame();
+
+      midi_driver_set_all_sounds_off();
 
 #ifdef HAVE_PRESENCE
       userdata.status = PRESENCE_GAME_PAUSED;
@@ -4747,6 +4742,9 @@ void runloop_pause_checks(void)
 
    /* Signal/reset paused rewind to take the initial step */
    runloop_st->run_frames_and_pause = -1;
+
+   /* Ignore frame delay target temporarily */
+   video_st->frame_delay_pause      = true;
 }
 
 struct string_list *path_get_subsystem_list(void)
@@ -5400,6 +5398,10 @@ static enum runloop_state_enum runloop_check_state(
    if (!aptMainLoop())
       return RUNLOOP_STATE_QUIT;
 #endif
+
+   /* When frames are generated quicker than necessary */
+   if (video_st->frame_discard)
+      return RUNLOOP_STATE_PAUSE;
 
    BIT256_CLEAR_ALL_PTR(&current_bits);
 


### PR DESCRIPTION
## Description

This PR retries a few reverted changes, and some more (quite a lot for a single PR though, but they are related):

- Corrected fast-forward frame skipping to use display frame time as target instead of core frame time
- Extended fast-forward frame skipping to also be used in paused state (which renders at unlimited speed now without vsync)
- Adjusted menu navigation timings
- Don't do double frame skipping with Vulkan on fast-forward (WIN32 + fullscreen + vsync on)
- Allow disabling menu vsync forcing with existing "Throttle Menu Framerate" option (still on by default)
- Stop fast-forward and slow-motion on menu toggle
- Don't stop/start audio on menu toggle
- Moved `midi_driver_set_all_sounds_off()` to menu and pause toggle
- Don't pause menu sounds if paused manually
- Relocated audio reinit for menu sounds to always after reinit (find out later why the same reinit is not enough)
- Ensure menu sounds are loaded on menu sound toggle
- Cleanups

The crucial part is the new frame discarding system to limit paused menu and and paused state rendering to display refresh rate without any sleep shenanigans. Even if menu is rendered uncapped without vsync, only visible frames are shown, and menu navigation delays stay the same.
