### PR TITLE
comment out forced core update for netplay

### DIFF
--- a/runloop.c
+++ b/runloop.c
@@ -4541,7 +4541,8 @@ bool runloop_event_init_core(
 #ifdef HAVE_NETWORKING
    if (netplay_driver_ctl(RARCH_NETPLAY_CTL_IS_ENABLED, NULL))
    {
-#ifdef HAVE_UPDATE_CORES
+#if 0
+//#ifdef HAVE_UPDATE_CORES
       /* If netplay is enabled, update the core before initializing. */
       const char *path_core = path_get(RARCH_PATH_CORE);
 


### PR DESCRIPTION
## Description

This PR just comments out the forced updating of cores during netplay. I looked into reverting the entire commit (ef022ffe9017bef06d5f82d479e472362a7b8ba7) but it ended up getting pretty hairy in retroarch.c with some functions that no longer exist and some new ifdefs that could lead to iffy codepaths if I tried to put everything back to how it was.

Also, most of the rest of the original commit is related to the 'update single core' function, which could be useful for other things in the future.

Also, just commenting it makes it easy to wrap in an option later, to replace with log calls and/or widget warnings, etc. in the future.

## Related Issues

I don't know of any open issues, but @LibretroAdmin mentioned that this affected some console ports negatively.

## Related Pull Requests

I don't know of any currently open PRs, but it may affect @schellingb 's upcoming PR.

## Reviewers

schellingb and libretroadmin have both been tagged already.
