### PR TITLE
Fix build error in drm_ctx.c

### DIFF
--- a/gfx/drivers/drm_gfx.c
+++ b/gfx/drivers/drm_gfx.c
@@ -940,7 +940,7 @@ static void drm_get_poke_interface(void *data,
    *iface = &drm_poke_interface;
 }
 
-static void drm_free(void *data)
+static void drm_gfx_free(void *data)
 {
    struct drm_video *_drmvars = data;
 
@@ -971,7 +971,7 @@ video_driver_t video_drm = {
    drm_suppress_screensaver,
    NULL, /* has_windowed */
    drm_set_shader,
-   drm_free,
+   drm_gfx_free,
    "drm",
    NULL, /* set_viewport */
    NULL, /* set_rotation */


### PR DESCRIPTION
## Description

When building for my Raspberry Pi (which runs regular Linux not Lakka) I got this build error:

```h
gfx/drivers/drm_gfx.c:943:13: error: conflicting types for ‘drm_free’
  943 | static void drm_free(void *data)
      |             ^~~~~~~~
In file included from gfx/drivers/drm_gfx.c:40:
gfx/drivers/../common/drm_common.h:57:6: note: previous declaration of ‘drm_free’ was here
   57 | void drm_free(void);
      |      ^~~~~~~~
```

drm_ctx.c includes drm_common.h which defines this function:

```c
void drm_free(void);
```

But drm_ctx.c has its own function of the same name clearly causing the conflict:
```c
static void drm_free(void *data)
```

This PR renames the static `drm_free` in drm_ctx.c to `drm_gfx_free` to avoid the name conflict.

Problem was introduced by 4f6010b 3 weeks ago which renamed a bunch of functions causing this conflict.

## Related Issues

## Related Pull Requests

## Reviewers
