### PR TITLE
Fix building kmsdrm without crtswitchres

### DIFF
--- a/gfx/drivers_context/drm_ctx.c
+++ b/gfx/drivers_context/drm_ctx.c
@@ -343,6 +343,7 @@ error:
 /* Get the mode from video_state */
 bool gfx_ctx_drm_get_mode_from_video_state(drmModeModeInfoPtr modeInfo)
 {
+#ifdef HAVE_CRTSWITCHRES
    video_driver_state_t *video_st = video_state_get_ptr();
    if (video_st->crt_switch_st.vdisplay < 1)
    {
@@ -375,6 +376,9 @@ bool gfx_ctx_drm_get_mode_from_video_state(drmModeModeInfoPtr modeInfo)
    /* consider the mode read and removed */
    video_st->crt_switch_st.vdisplay = 0;
    return true;
+#else
+   return false;
+#endif
 }
 
 /* Load custom hdmi timings from config */


### PR DESCRIPTION
## Description

I build for my Raspberry Pi (which runs Linux not Lakka) with KMSDRM (`-DHAVE_KMS -DHAVE_DRM -DHAVE_PLAIN_DRM`) but without crt-switchres (no `-DHAVE_CRTSWITCHRES`).

I think since #15131 the build fails like that but I haven't noticed it because I don't update the build on the Pi that often.

This PR adds an `#ifdef HAVE_CRTSWITCHRES` guard around the crtswitchres using code in drm_ctx.c and makes RetroArch work again in my environment.

## Related Issues

## Related Pull Requests

- #15131

## Reviewers
Maybe @substring who contributed the KMS modeswitching for CRT?