### PR TITLE
Fix rwebaudio bug

### DIFF
--- a/emscripten/library_rwebaudio.js
+++ b/emscripten/library_rwebaudio.js
@@ -74,7 +74,7 @@ var LibraryRWebAudio = {
       block: function() {
          do {
             RA.process();
-         } while (RA.bufIndex === RA.numBuffers);
+         } while (RA.bufIndex === RA.numBuffers-1);
       }
    },
 
@@ -87,6 +87,8 @@ var LibraryRWebAudio = {
 
       RA.numBuffers = ((latency * RA.context.sampleRate) / (1000 * RA.BUFFER_SIZE))|0;
       if (RA.numBuffers < 2) RA.numBuffers = 2;
+      
+      RA.numBuffers++;
 
       for (var i = 0; i < RA.numBuffers; i++) {
          RA.buffers[i] = RA.context.createBuffer(2, RA.BUFFER_SIZE, RA.context.sampleRate);
@@ -112,7 +114,7 @@ var LibraryRWebAudio = {
       var count = 0;
 
       while (samples) {
-         if (RA.bufIndex === RA.numBuffers) {
+         if (RA.bufIndex === RA.numBuffers-1) {
             if (RA.nonblock) break;
             else RA.block();
          }

--- a/emscripten/library_rwebaudio.js
+++ b/emscripten/library_rwebaudio.js
@@ -74,7 +74,7 @@ var LibraryRWebAudio = {
       block: function() {
          do {
             RA.process();
-         } while (RA.bufIndex === RA.numBuffers-1);
+         } while (RA.bufIndex === RA.numBuffers-2);
       }
    },
 
@@ -114,7 +114,7 @@ var LibraryRWebAudio = {
       var count = 0;
 
       while (samples) {
-         if (RA.bufIndex === RA.numBuffers-1) {
+         if (RA.bufIndex === RA.numBuffers-2) {
             if (RA.nonblock) break;
             else RA.block();
          }


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

Fixes a known bug in the rwebaudio (emscripten) driver.

Upon page load, the audio driver, especially on lower end devices, would freeze the page. The console and page would be entirely unresponsive. This fix adds a padding that fixes that issue while preserving audio quality. I dont fully understand why it fixes it, all I can say is that it does

note, you can technically just decrease the blocking check by 1 (`RA.bufIndex === RA.numBuffers-1`) and not increase the overall amount of buffers, but this causes major audio glitches. I dont understand why decreasing it by 2 and increasing the overall amount of buffers fixes this freezing bug, but it does.

## Related Issues

See https://github.com/EmulatorJS/EmulatorJS/issues/416
